### PR TITLE
Add AMP global MINLP solver

### DIFF
--- a/python/discopt/_jax/convexity.py
+++ b/python/discopt/_jax/convexity.py
@@ -22,6 +22,7 @@ Key composition rules implemented:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
@@ -51,6 +52,14 @@ class Curvature(Enum):
     CONVEX = "convex"
     CONCAVE = "concave"
     UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class OACutConvexity:
+    """Convexity information relevant to globally valid OA cuts."""
+
+    objective_is_convex: bool
+    constraint_mask: list[bool]
 
 
 def _combine_sum(a: Curvature, b: Curvature) -> Curvature:
@@ -363,17 +372,10 @@ def classify_constraint(
     return False
 
 
-def classify_model(model: Model) -> tuple[bool, list[bool]]:
-    """Classify a model's convexity.
-
-    Returns:
-        (is_convex, constraint_convexity_mask)
-        - is_convex: True if objective is convex and all constraints are convex
-        - constraint_convexity_mask: per-constraint convexity flags
-    """
+def classify_oa_cut_convexity(model: Model) -> OACutConvexity:
+    """Return the convexity information needed to generate sound OA cuts."""
     cache: dict = {}
 
-    # Check objective
     obj_convex = True
     if model._objective is not None:
         from discopt.modeling.core import ObjectiveSense
@@ -385,17 +387,28 @@ def classify_model(model: Model) -> tuple[bool, list[bool]]:
             # Maximize f  ≡ Minimize -f; convex if f is concave
             obj_convex = obj_curv in (Curvature.CONCAVE, Curvature.AFFINE)
 
-    # Check constraints
     constraint_mask = []
-    all_convex = obj_convex
     for c in model._constraints:
         if isinstance(c, Constraint):
-            is_cvx = classify_constraint(c, model, cache)
-            constraint_mask.append(is_cvx)
-            if not is_cvx:
-                all_convex = False
+            constraint_mask.append(classify_constraint(c, model, cache))
         else:
             constraint_mask.append(False)
-            all_convex = False
 
-    return all_convex, constraint_mask
+    return OACutConvexity(
+        objective_is_convex=obj_convex,
+        constraint_mask=constraint_mask,
+    )
+
+
+def classify_model(model: Model) -> tuple[bool, list[bool]]:
+    """Classify a model's convexity.
+
+    Returns:
+        (is_convex, constraint_convexity_mask)
+        - is_convex: True if objective is convex and all constraints are convex
+        - constraint_convexity_mask: per-constraint convexity flags
+    """
+    oa_convexity = classify_oa_cut_convexity(model)
+    all_convex = oa_convexity.objective_is_convex and all(oa_convexity.constraint_mask)
+
+    return all_convex, oa_convexity.constraint_mask

--- a/python/discopt/_jax/cutting_planes.py
+++ b/python/discopt/_jax/cutting_planes.py
@@ -245,6 +245,7 @@ def generate_oa_cuts_from_evaluator(
     evaluator,
     x_sol: np.ndarray,
     constraint_senses: Optional[list[str]] = None,
+    convex_mask: Optional[list[bool]] = None,
 ) -> list[LinearCut]:
     """Generate OA cuts for all constraints using an NLPEvaluator.
 
@@ -257,6 +258,8 @@ def generate_oa_cuts_from_evaluator(
         x_sol: solution point at which to linearize, shape (n,).
         constraint_senses: list of senses for each constraint. If None,
             all constraints are assumed to be "<=".
+        convex_mask: Per-constraint boolean list. If provided, only constraints
+            where ``convex_mask[k]`` is True are linearized.
 
     Returns:
         List of LinearCut objects, one per constraint.
@@ -273,6 +276,8 @@ def generate_oa_cuts_from_evaluator(
 
     cuts = []
     for k in range(m):
+        if convex_mask is not None and not convex_mask[k]:
+            continue
         grad_k = jac[k, :]
         g_k = float(cons_vals[k])
         sense = constraint_senses[k]

--- a/python/discopt/_jax/discretization.py
+++ b/python/discopt/_jax/discretization.py
@@ -54,6 +54,8 @@ def initialize_partitions(
     lb: list[float],
     ub: list[float],
     n_init: int = 2,
+    scaling_factor: float = 10.0,
+    abs_width_tol: float = 1e-3,
 ) -> DiscretizationState:
     """Create n_init uniform intervals for each partition variable.
 
@@ -68,6 +70,10 @@ def initialize_partitions(
     n_init : int, default 2
         Number of initial intervals per variable.  n_init=2 gives 3 breakpoints:
         [lb, midpoint, ub].
+    scaling_factor : float, default 10.0
+        Refinement ratio stored on the returned state.
+    abs_width_tol : float, default 1e-3
+        Convergence tolerance stored on the returned state.
 
     Returns
     -------
@@ -77,7 +83,11 @@ def initialize_partitions(
     partitions: dict[int, np.ndarray] = {}
     for k, v_idx in enumerate(var_indices):
         partitions[v_idx] = np.linspace(float(lb[k]), float(ub[k]), n_init + 1)
-    return DiscretizationState(partitions=partitions)
+    return DiscretizationState(
+        partitions=partitions,
+        scaling_factor=float(scaling_factor),
+        abs_width_tol=float(abs_width_tol),
+    )
 
 
 def add_adaptive_partition(
@@ -158,6 +168,41 @@ def add_adaptive_partition(
         if candidates:
             merged = np.sort(np.unique(np.concatenate([pts, candidates])))
             new_partitions[v_idx] = merged
+
+    return DiscretizationState(
+        partitions=new_partitions,
+        scaling_factor=state.scaling_factor,
+        abs_width_tol=state.abs_width_tol,
+    )
+
+
+def add_uniform_partition(
+    state: DiscretizationState,
+    solution: dict[int, float],
+    var_indices: list[int],
+    lb: list[float],
+    ub: list[float],
+) -> DiscretizationState:
+    """Uniformly refine every current interval for the selected variables.
+
+    Unlike adaptive refinement, this does not use the current solution value.
+    Each interval is split at its midpoint, preserving all existing breakpoints.
+    """
+    del solution  # uniform refinement is solution-agnostic
+
+    new_partitions = {k: v.copy() for k, v in state.partitions.items()}
+
+    for k, v_idx in enumerate(var_indices):
+        if v_idx not in new_partitions:
+            new_partitions[v_idx] = np.linspace(float(lb[k]), float(ub[k]), 3)
+
+        pts = new_partitions[v_idx]
+        if len(pts) < 2:
+            continue
+
+        mids = 0.5 * (pts[:-1] + pts[1:])
+        merged = np.sort(np.unique(np.concatenate([pts, mids])))
+        new_partitions[v_idx] = merged
 
     return DiscretizationState(
         partitions=new_partitions,

--- a/python/discopt/_jax/discretization.py
+++ b/python/discopt/_jax/discretization.py
@@ -1,0 +1,191 @@
+"""
+Discretization State Management for AMP (Adaptive Multivariate Partitioning).
+
+Manages the partition breakpoints for each selected variable.  The core insight
+from CP 2016 is that adding breakpoints near the current MILP solution concentrates
+refinement where the relaxation gap is largest, converging faster than uniform
+refinement.
+
+Key properties guaranteed by this module:
+- Partitions are monotonically finer: once a breakpoint is added, it is never removed.
+- Bounds are always preserved: partitions[v][0] == lb[v], partitions[v][-1] == ub[v].
+- Convergence check: all partition widths < abs_width_tol.
+
+Theory references:
+  - Nagarajan et al., CP 2016: http://harshangrjn.github.io/pdf/CP_2016.pdf
+  - Alpine.jl add_adaptive_partition() in bounding_model.jl
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+@dataclass
+class DiscretizationState:
+    """Breakpoint dictionaries for AMP domain partitioning.
+
+    Attributes
+    ----------
+    partitions : dict[int, np.ndarray]
+        Maps flat variable index → sorted 1-D array of breakpoints.
+        For a variable with n_init=2 initial intervals:
+            partitions[v] = [lb, midpoint, ub]  (3 elements)
+        Finer partitions have more elements.
+    scaling_factor : float
+        Controls the width of new partitions added during adaptive refinement.
+        New breakpoints are placed at x* ± (partition_width / scaling_factor).
+        Default 10.0 (Alpine's default).
+    abs_width_tol : float
+        Convergence threshold.  When all partition widths are below this value,
+        check_partition_convergence() returns True.
+        Default 1e-3.
+    """
+
+    partitions: dict[int, np.ndarray] = field(default_factory=dict)
+    scaling_factor: float = 10.0
+    abs_width_tol: float = 1e-3
+
+
+def initialize_partitions(
+    var_indices: list[int],
+    lb: list[float],
+    ub: list[float],
+    n_init: int = 2,
+) -> DiscretizationState:
+    """Create n_init uniform intervals for each partition variable.
+
+    Parameters
+    ----------
+    var_indices : list[int]
+        Flat variable indices to partition.
+    lb : list[float]
+        Lower bound for each variable (same order as var_indices).
+    ub : list[float]
+        Upper bound for each variable (same order as var_indices).
+    n_init : int, default 2
+        Number of initial intervals per variable.  n_init=2 gives 3 breakpoints:
+        [lb, midpoint, ub].
+
+    Returns
+    -------
+    DiscretizationState
+        Initial discretization with uniform breakpoints.
+    """
+    partitions: dict[int, np.ndarray] = {}
+    for k, v_idx in enumerate(var_indices):
+        partitions[v_idx] = np.linspace(float(lb[k]), float(ub[k]), n_init + 1)
+    return DiscretizationState(partitions=partitions)
+
+
+def add_adaptive_partition(
+    state: DiscretizationState,
+    solution: dict[int, float],
+    var_indices: list[int],
+    lb: list[float],
+    ub: list[float],
+) -> DiscretizationState:
+    """Add breakpoints near solution[v] for each partition variable v.
+
+    For each variable v in var_indices:
+    1. Identify the active partition [p_lo, p_hi] containing solution[v].
+    2. Compute width = p_hi - p_lo.
+    3. Add new breakpoints at:
+         p_lo + width / scaling_factor
+         p_hi - width / scaling_factor
+    4. Merge with existing breakpoints, sort, deduplicate.
+
+    This mirrors Alpine.jl's add_adaptive_partition() in bounding_model.jl.
+
+    Parameters
+    ----------
+    state : DiscretizationState
+        Current partition state.
+    solution : dict[int, float]
+        Current MILP solution values, keyed by flat variable index.
+    var_indices : list[int]
+        Variables to refine.
+    lb : list[float]
+        Lower bounds (same order as var_indices).
+    ub : list[float]
+        Upper bounds (same order as var_indices).
+
+    Returns
+    -------
+    DiscretizationState
+        New state with refined partitions (old breakpoints preserved).
+    """
+    new_partitions = {k: v.copy() for k, v in state.partitions.items()}
+
+    for k, v_idx in enumerate(var_indices):
+        if v_idx not in new_partitions:
+            # Variable not yet partitioned — initialize with 2 intervals
+            new_partitions[v_idx] = np.linspace(float(lb[k]), float(ub[k]), 3)
+
+        pts = new_partitions[v_idx]
+        x_star = float(solution.get(v_idx, 0.5 * (pts[0] + pts[-1])))
+
+        # Clip x_star to [lb, ub]
+        x_star = float(np.clip(x_star, pts[0], pts[-1]))
+
+        # Find active partition interval
+        p_lo_idx = np.searchsorted(pts, x_star, side="right") - 1
+        p_lo_idx = int(np.clip(p_lo_idx, 0, len(pts) - 2))
+        p_lo = float(pts[p_lo_idx])
+        p_hi = float(pts[p_lo_idx + 1])
+        width = p_hi - p_lo
+
+        if width <= 0:
+            continue  # degenerate partition — skip
+
+        delta = width / state.scaling_factor
+
+        # New breakpoints: two new points around the solution value
+        # (mirrors Alpine.jl add_adaptive_partition)
+        new1 = x_star - delta
+        new2 = x_star + delta
+
+        # Only add if they create a meaningful improvement and lie strictly inside
+        eps = 1e-12
+        candidates = []
+        if new1 > p_lo + eps and new1 < p_hi - eps:
+            candidates.append(new1)
+        if new2 > p_lo + eps and new2 < p_hi - eps and abs(new2 - new1) > eps:
+            candidates.append(new2)
+
+        if candidates:
+            merged = np.sort(np.unique(np.concatenate([pts, candidates])))
+            new_partitions[v_idx] = merged
+
+    return DiscretizationState(
+        partitions=new_partitions,
+        scaling_factor=state.scaling_factor,
+        abs_width_tol=state.abs_width_tol,
+    )
+
+
+def check_partition_convergence(state: DiscretizationState) -> bool:
+    """Return True if every partition width is below state.abs_width_tol.
+
+    When this returns True, further partitioning will not significantly improve
+    the relaxation bound.
+
+    Parameters
+    ----------
+    state : DiscretizationState
+        Current partition state.
+
+    Returns
+    -------
+    bool
+        True if all partition widths < abs_width_tol.
+    """
+    for pts in state.partitions.values():
+        if len(pts) < 2:
+            continue
+        widths = np.diff(pts)
+        if np.any(widths >= state.abs_width_tol):
+            return False
+    return True

--- a/python/discopt/_jax/discretization.py
+++ b/python/discopt/_jax/discretization.py
@@ -164,6 +164,10 @@ def add_adaptive_partition(
             candidates.append(new1)
         if new2 > p_lo + eps and new2 < p_hi - eps and abs(new2 - new1) > eps:
             candidates.append(new2)
+        if not candidates:
+            midpoint = 0.5 * (p_lo + p_hi)
+            if midpoint > p_lo + eps and midpoint < p_hi - eps:
+                candidates.append(midpoint)
 
         if candidates:
             merged = np.sort(np.unique(np.concatenate([pts, candidates])))

--- a/python/discopt/_jax/discretization.py
+++ b/python/discopt/_jax/discretization.py
@@ -178,7 +178,7 @@ def add_adaptive_partition(
 
 def add_uniform_partition(
     state: DiscretizationState,
-    solution: dict[int, float],
+    _solution: dict[int, float],
     var_indices: list[int],
     lb: list[float],
     ub: list[float],
@@ -188,8 +188,6 @@ def add_uniform_partition(
     Unlike adaptive refinement, this does not use the current solution value.
     Each interval is split at its midpoint, preserving all existing breakpoints.
     """
-    del solution  # uniform refinement is solution-agnostic
-
     new_partitions = {k: v.copy() for k, v in state.partitions.items()}
 
     for k, v_idx in enumerate(var_indices):

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -168,9 +168,7 @@ def _normalize_convhull_formulation(formulation: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _decompose_product(
-    expr: Expression, model: Model
-) -> tuple[float, list[int]] | None:
+def _decompose_product(expr: Expression, model: Model) -> tuple[float, list[int]] | None:
     """Decompose a product expression into (scalar, [flat_var_idx, ...]).
 
     Returns None if expr contains non-constant, non-variable leaves.
@@ -301,9 +299,7 @@ def _linearize_expr(
                         raise ValueError(f"Monomial {key} not in map")
                 elif len(unique) == 2:
                     if len(unique) != len(indices):
-                        raise ValueError(
-                            "Mixed repeated-factor products are not supported"
-                        )
+                        raise ValueError("Mixed repeated-factor products are not supported")
                     i_idx, j_idx = unique[0], unique[1]
                     key = (min(i_idx, j_idx), max(i_idx, j_idx))
                     if key in bilinear_var_map:
@@ -311,9 +307,7 @@ def _linearize_expr(
                     else:
                         raise ValueError(f"Bilinear {key} not in map")
                 else:
-                    raise ValueError(
-                        f"Higher-order product ({len(unique)} vars) not supported"
-                    )
+                    raise ValueError(f"Higher-order product ({len(unique)} vars) not supported")
 
             else:
                 raise ValueError(f"Cannot linearize BinaryOp: {e.op}")
@@ -404,9 +398,7 @@ def build_milp_relaxation(
     monomial_var_map: dict[tuple[int, int], int] = {}
 
     col_idx = n_orig
-    all_bounds: list[tuple[float, float]] = list(
-        zip(flat_lb.tolist(), flat_ub.tolist())
-    )
+    all_bounds: list[tuple[float, float]] = list(zip(flat_lb.tolist(), flat_ub.tolist()))
     integrality_flags: list[int] = []
     for v in model._variables:
         flag = 1 if v.var_type in (VarType.BINARY, VarType.INTEGER) else 0
@@ -678,7 +670,7 @@ def build_milp_relaxation(
             row_recon[part_var] = 1.0
             for _, xbar_col, _, _, _ in intervals:
                 row_recon[xbar_col] = -1.0
-            _add_row(row_recon, 0.0)   # x_part - Σ x̄_k ≤ 0
+            _add_row(row_recon, 0.0)  # x_part - Σ x̄_k ≤ 0
             _add_row(-row_recon, 0.0)  # -(x_part - Σ x̄_k) ≤ 0
 
             # Constraint: w = Σ w̄_k
@@ -733,7 +725,7 @@ def build_milp_relaxation(
                 row[wbar_col] = -1.0
                 row[other_var] += a_k
                 row[xbar_col] += yj_lb
-                row[delta_col] = M_k   # +M_k so constraint loosens when δ_k=0
+                row[delta_col] = M_k  # +M_k so constraint loosens when δ_k=0
                 _add_row(row, a_k * yj_lb + M_k)
 
                 # cv2: w̄_k ≥ b_k*y + x̄_k*y_ub - b_k*y_ub - M*(1-δ_k)
@@ -751,7 +743,7 @@ def build_milp_relaxation(
                 row[wbar_col] = 1.0
                 row[other_var] -= b_k
                 row[xbar_col] -= yj_lb
-                row[delta_col] = M_k   # +M_k so constraint loosens when δ_k=0
+                row[delta_col] = M_k  # +M_k so constraint loosens when δ_k=0
                 _add_row(row, M_k - b_k * yj_lb)
 
                 # cc2: w̄_k ≤ a_k*y + x̄_k*y_ub - a_k*y_ub + M*(1-δ_k)
@@ -853,9 +845,7 @@ def build_milp_relaxation(
         body = constraint.body  # normalized: body <= 0  (sense is always "<=")
         sense = constraint.sense
         try:
-            c, const = _linearize_expr(
-                body, model, bilinear_var_map, monomial_var_map, n_total
-            )
+            c, const = _linearize_expr(body, model, bilinear_var_map, monomial_var_map, n_total)
             # body ≤ 0  →  c @ z + const ≤ 0  →  c @ z ≤ -const
             if sense == "<=":
                 _add_row(c, -const)
@@ -875,10 +865,11 @@ def build_milp_relaxation(
     if oa_cuts:
         for coeff, rhs in oa_cuts:
             row = np.zeros(n_total)
-            row[:len(coeff)] = coeff[:n_total if len(coeff) > n_total else len(coeff)]
+            row[: len(coeff)] = coeff[: n_total if len(coeff) > n_total else len(coeff)]
             _add_row(row, rhs)
 
     # ── Objective ────────────────────────────────────────────────────────────
+    assert model._objective is not None
     obj_expr = model._objective.expression
     try:
         c_obj, const_obj = _linearize_expr(

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -21,7 +21,7 @@ Theory: Nagarajan et al., JOGO 2018, Section 4 (piecewise McCormick relaxation).
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, Union
 
 import numpy as np
@@ -31,7 +31,6 @@ from discopt._jax.discretization import DiscretizationState
 from discopt._jax.model_utils import flat_variable_bounds
 from discopt._jax.term_classifier import (
     NonlinearTerms,
-    _collect_product_factors,
     _compute_var_offset,
     _get_flat_index,
 )
@@ -45,8 +44,8 @@ from discopt.modeling.core import (
     SumExpression,
     SumOverExpression,
     UnaryOp,
-    VarType,
     Variable,
+    VarType,
 )
 
 logger = logging.getLogger(__name__)
@@ -144,6 +143,24 @@ def _compute_piecewise_big_m(corners: list[float]) -> float:
     """Scale Big-M with the interval magnitude instead of adding a flat constant."""
     max_corner = max(abs(float(c)) for c in corners)
     return max_corner * (1.0 + 1e-4) + max(1e-6, 1e-4 * max_corner)
+
+
+def _normalize_convhull_formulation(formulation: str) -> str:
+    """Normalize accepted bilinear convex-hull mode names."""
+    aliases = {
+        "disaggregated": "disaggregated",
+        "piecewise": "disaggregated",
+        "sos2": "sos2",
+        "facet": "facet",
+        "lambda": "sos2",
+    }
+    try:
+        return aliases[formulation]
+    except KeyError as err:
+        raise ValueError(
+            f"Unsupported convhull_formulation: {formulation!r}. "
+            "Choose from 'disaggregated', 'sos2', 'facet', or 'lambda'."
+        ) from err
 
 
 # ---------------------------------------------------------------------------
@@ -338,6 +355,7 @@ def build_milp_relaxation(
     disc_state: DiscretizationState,
     incumbent: Optional[np.ndarray] = None,
     oa_cuts: Optional[list] = None,
+    convhull_formulation: str = "disaggregated",
 ) -> tuple["MilpRelaxationModel", dict]:
     """Build a MILP relaxation with piecewise McCormick for bilinear/monomial terms.
 
@@ -364,6 +382,10 @@ def build_milp_relaxation(
     incumbent : np.ndarray, optional
         Current best NLP solution (flat).  Used to add OA tangent cuts for
         general nonlinear terms; currently unused (reserved for future use).
+    convhull_formulation : str, default "disaggregated"
+        Piecewise bilinear formulation. ``"disaggregated"`` keeps the existing
+        xbar/wbar construction; ``"sos2"`` and ``"facet"`` use a λ-based
+        convex-hull reformulation similar to Alpine.jl.
 
     Returns
     -------
@@ -373,6 +395,7 @@ def build_milp_relaxation(
     """
     flat_lb, flat_ub = flat_variable_bounds(model)
     n_orig = len(flat_lb)
+    convhull_mode = _normalize_convhull_formulation(convhull_formulation)
 
     # ── Assign MILP column indices ──────────────────────────────────────────
     # Layout: [original vars 0..n_orig-1] [bilinear aux w_ij] [monomial aux s_i^n]
@@ -418,6 +441,7 @@ def build_milp_relaxation(
     #     w̄_k  ∈ [wi_lo, wi_hi] — bilinear product within interval k (0 outside)
     # bilinear_pw_map[(i,j)] = [(delta_col, xbar_col, wbar_col, a_k, b_k), ...]
     bilinear_pw_map: dict[tuple[int, int], list] = {}
+    bilinear_lambda_map: dict[tuple[int, int], dict] = {}
 
     for i, j in terms.bilinear:
         # Choose which variable to partition: prefer the one in disc_state
@@ -432,40 +456,76 @@ def build_milp_relaxation(
         xj_lb_g = float(flat_lb[other_var])
         xj_ub_g = float(flat_ub[other_var])
 
-        intervals = []
-        for k in range(len(pts) - 1):
-            a_k = float(pts[k])
-            b_k = float(pts[k + 1])
+        if convhull_mode == "disaggregated":
+            intervals = []
+            for k in range(len(pts) - 1):
+                a_k = float(pts[k])
+                b_k = float(pts[k + 1])
 
-            # Big-M for bilinear product within this interval
-            _, wk_lo, wk_hi = _piecewise_product_bounds(
-                a_k,
-                b_k,
-                xj_lb_g,
-                xj_ub_g,
-            )
+                # Big-M for bilinear product within this interval
+                _, wk_lo, wk_hi = _piecewise_product_bounds(
+                    a_k,
+                    b_k,
+                    xj_lb_g,
+                    xj_ub_g,
+                )
 
-            # δ_k ∈ {0,1}
-            delta_col = col_idx
-            all_bounds.append((0.0, 1.0))
-            integrality_flags.append(1)
-            col_idx += 1
+                # δ_k ∈ {0,1}
+                delta_col = col_idx
+                all_bounds.append((0.0, 1.0))
+                integrality_flags.append(1)
+                col_idx += 1
 
-            # x̄_k ∈ [0, max(|a_k|, |b_k|)]  (0 when δ_k=0)
-            xbar_col = col_idx
-            all_bounds.append((min(a_k, 0.0), max(abs(a_k), abs(b_k))))
-            integrality_flags.append(0)
-            col_idx += 1
+                # x̄_k ∈ [0, max(|a_k|, |b_k|)]  (0 when δ_k=0)
+                xbar_col = col_idx
+                all_bounds.append((min(a_k, 0.0), max(abs(a_k), abs(b_k))))
+                integrality_flags.append(0)
+                col_idx += 1
 
-            # w̄_k ∈ [wk_lo, wk_hi]  (0 when δ_k=0)
-            wbar_col = col_idx
-            all_bounds.append((min(wk_lo, 0.0), max(wk_hi, 0.0)))
-            integrality_flags.append(0)
-            col_idx += 1
+                # w̄_k ∈ [wk_lo, wk_hi]  (0 when δ_k=0)
+                wbar_col = col_idx
+                all_bounds.append((min(wk_lo, 0.0), max(wk_hi, 0.0)))
+                integrality_flags.append(0)
+                col_idx += 1
 
-            intervals.append((delta_col, xbar_col, wbar_col, a_k, b_k))
+                intervals.append((delta_col, xbar_col, wbar_col, a_k, b_k))
 
-        bilinear_pw_map[(i, j)] = intervals
+            bilinear_pw_map[(i, j)] = intervals
+        else:
+            breakpoints = [float(p) for p in pts]
+            lambda_cols: list[int] = []
+            alpha_cols: list[int] = []
+            theta_cols: list[int] = []
+            theta_lb = min(0.0, xj_lb_g, xj_ub_g)
+            theta_ub = max(0.0, xj_lb_g, xj_ub_g)
+
+            for _ in breakpoints:
+                lambda_cols.append(col_idx)
+                all_bounds.append((0.0, 1.0))
+                integrality_flags.append(0)
+                col_idx += 1
+
+            for _ in range(len(breakpoints) - 1):
+                alpha_cols.append(col_idx)
+                all_bounds.append((0.0, 1.0))
+                integrality_flags.append(1)
+                col_idx += 1
+
+            for _ in breakpoints:
+                theta_cols.append(col_idx)
+                all_bounds.append((theta_lb, theta_ub))
+                integrality_flags.append(0)
+                col_idx += 1
+
+            bilinear_lambda_map[(i, j)] = {
+                "part_var": part_var,
+                "other_var": other_var,
+                "breakpoints": breakpoints,
+                "lambda_cols": lambda_cols,
+                "alpha_cols": alpha_cols,
+                "theta_cols": theta_cols,
+                "mode": convhull_mode,
+            }
 
     # Also store in a form keyed by (part_var, other_var) for reference
     # (not needed separately; we use bilinear_pw_map[(i,j)] directly)
@@ -496,7 +556,103 @@ def build_milp_relaxation(
         xj_ub_g = float(flat_ub[j])
         w_col = bilinear_var_map[(i, j)]
 
-        if (i, j) in bilinear_pw_map and bilinear_pw_map[(i, j)]:
+        if (i, j) in bilinear_lambda_map:
+            lambda_info = bilinear_lambda_map[(i, j)]
+            part_var = int(lambda_info["part_var"])
+            other_var = int(lambda_info["other_var"])
+            breakpoints = list(lambda_info["breakpoints"])
+            lambda_cols = list(lambda_info["lambda_cols"])
+            alpha_cols = list(lambda_info["alpha_cols"])
+            theta_cols = list(lambda_info["theta_cols"])
+            mode = str(lambda_info["mode"])
+            yj_lb = float(flat_lb[other_var])
+            yj_ub = float(flat_ub[other_var])
+
+            row_sum_lambda = np.zeros(n_total)
+            for lambda_col in lambda_cols:
+                row_sum_lambda[lambda_col] = -1.0
+            _add_row(row_sum_lambda, -1.0)
+            _add_row(-row_sum_lambda, 1.0)
+
+            row_sum_alpha = np.zeros(n_total)
+            for alpha_col in alpha_cols:
+                row_sum_alpha[alpha_col] = -1.0
+            _add_row(row_sum_alpha, -1.0)
+            _add_row(-row_sum_alpha, 1.0)
+
+            row_x = np.zeros(n_total)
+            row_x[part_var] = 1.0
+            for p_j, lambda_col in zip(breakpoints, lambda_cols):
+                row_x[lambda_col] -= float(p_j)
+            _add_row(row_x, 0.0)
+            _add_row(-row_x, 0.0)
+
+            row_y = np.zeros(n_total)
+            row_y[other_var] = 1.0
+            for theta_col in theta_cols:
+                row_y[theta_col] -= 1.0
+            _add_row(row_y, 0.0)
+            _add_row(-row_y, 0.0)
+
+            row_w = np.zeros(n_total)
+            row_w[w_col] = 1.0
+            for p_j, theta_col in zip(breakpoints, theta_cols):
+                row_w[theta_col] -= float(p_j)
+            _add_row(row_w, 0.0)
+            _add_row(-row_w, 0.0)
+
+            if mode == "sos2":
+                for idx, lambda_col in enumerate(lambda_cols):
+                    row = np.zeros(n_total)
+                    row[lambda_col] = 1.0
+                    if idx == 0:
+                        row[alpha_cols[0]] = -1.0
+                    elif idx == len(lambda_cols) - 1:
+                        row[alpha_cols[-1]] = -1.0
+                    else:
+                        row[alpha_cols[idx - 1]] = -1.0
+                        row[alpha_cols[idx]] = -1.0
+                    _add_row(row, 0.0)
+            else:
+                for idx in range(len(alpha_cols) - 1):
+                    row = np.zeros(n_total)
+                    for alpha_col in alpha_cols[: idx + 1]:
+                        row[alpha_col] -= 1.0
+                    for lambda_col in lambda_cols[: idx + 1]:
+                        row[lambda_col] += 1.0
+                    _add_row(row, 0.0)
+
+                    row = np.zeros(n_total)
+                    for alpha_col in alpha_cols[: idx + 1]:
+                        row[alpha_col] += 1.0
+                    for lambda_col in lambda_cols[: idx + 2]:
+                        row[lambda_col] -= 1.0
+                    _add_row(row, 0.0)
+
+            for lambda_col, theta_col in zip(lambda_cols, theta_cols):
+                row = np.zeros(n_total)
+                row[theta_col] = -1.0
+                row[lambda_col] = yj_lb
+                _add_row(row, 0.0)
+
+                row = np.zeros(n_total)
+                row[theta_col] = -1.0
+                row[other_var] = 1.0
+                row[lambda_col] = yj_ub
+                _add_row(row, yj_ub)
+
+                row = np.zeros(n_total)
+                row[theta_col] = 1.0
+                row[other_var] = -1.0
+                row[lambda_col] = -yj_lb
+                _add_row(row, -yj_lb)
+
+                row = np.zeros(n_total)
+                row[theta_col] = 1.0
+                row[lambda_col] = -yj_ub
+                _add_row(row, 0.0)
+
+        elif (i, j) in bilinear_pw_map and bilinear_pw_map[(i, j)]:
             # ── Piecewise McCormick with binary partition selection ──────────
             intervals = bilinear_pw_map[(i, j)]
             # Determine partition var vs other var
@@ -766,6 +922,8 @@ def build_milp_relaxation(
         "bilinear": bilinear_var_map,
         "monomial": monomial_var_map,
         "bilinear_pw": bilinear_pw_map,
+        "bilinear_lambda": bilinear_lambda_map,
+        "convhull_formulation": convhull_mode,
     }
 
     return milp_model, varmap

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -143,7 +143,7 @@ def _piecewise_product_bounds(
 def _compute_piecewise_big_m(corners: list[float]) -> float:
     """Scale Big-M with the interval magnitude instead of adding a flat constant."""
     max_corner = max(abs(float(c)) for c in corners)
-    return max_corner * (1.0 + 1e-4) + 1e-2
+    return max_corner * (1.0 + 1e-4) + max(1e-6, 1e-4 * max_corner)
 
 
 # ---------------------------------------------------------------------------

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -20,12 +20,15 @@ Theory: Nagarajan et al., JOGO 2018, Section 4 (piecewise McCormick relaxation).
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
+import scipy.sparse as sp
 
 from discopt._jax.discretization import DiscretizationState
+from discopt._jax.model_utils import flat_variable_bounds
 from discopt._jax.term_classifier import (
     NonlinearTerms,
     _collect_product_factors,
@@ -42,8 +45,11 @@ from discopt.modeling.core import (
     SumExpression,
     SumOverExpression,
     UnaryOp,
+    VarType,
     Variable,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -69,7 +75,7 @@ class MilpRelaxationModel:
     def __init__(
         self,
         c: np.ndarray,
-        A_ub: Optional[np.ndarray],
+        A_ub: Optional[Union[np.ndarray, sp.spmatrix]],
         b_ub: Optional[np.ndarray],
         bounds: list[tuple[float, float]],
         obj_offset: float = 0.0,
@@ -123,14 +129,21 @@ class MilpRelaxationModel:
 # ---------------------------------------------------------------------------
 
 
-def _flat_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
-    """Return (lb, ub) as flat 1-D arrays for all model variables."""
-    lbs: list[float] = []
-    ubs: list[float] = []
-    for v in model._variables:
-        lbs.extend(np.asarray(v.lb, dtype=np.float64).ravel().tolist())
-        ubs.extend(np.asarray(v.ub, dtype=np.float64).ravel().tolist())
-    return np.array(lbs, dtype=np.float64), np.array(ubs, dtype=np.float64)
+def _piecewise_product_bounds(
+    a_k: float,
+    b_k: float,
+    y_lb: float,
+    y_ub: float,
+) -> tuple[list[float], float, float]:
+    """Return interval corner products and their min/max values."""
+    corners = [a_k * y_lb, a_k * y_ub, b_k * y_lb, b_k * y_ub]
+    return corners, min(corners), max(corners)
+
+
+def _compute_piecewise_big_m(corners: list[float]) -> float:
+    """Scale Big-M with the interval magnitude instead of adding a flat constant."""
+    max_corner = max(abs(float(c)) for c in corners)
+    return max_corner * (1.0 + 1e-4) + 1e-2
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +283,10 @@ def _linearize_expr(
                     else:
                         raise ValueError(f"Monomial {key} not in map")
                 elif len(unique) == 2:
+                    if len(unique) != len(indices):
+                        raise ValueError(
+                            "Mixed repeated-factor products are not supported"
+                        )
                     i_idx, j_idx = unique[0], unique[1]
                     key = (min(i_idx, j_idx), max(i_idx, j_idx))
                     if key in bilinear_var_map:
@@ -354,7 +371,7 @@ def build_milp_relaxation(
         MilpRelaxationModel has a .solve() method returning MilpRelaxationResult.
         varmap maps auxiliary variable keys to MILP column indices.
     """
-    flat_lb, flat_ub = _flat_bounds(model)
+    flat_lb, flat_ub = flat_variable_bounds(model)
     n_orig = len(flat_lb)
 
     # ── Assign MILP column indices ──────────────────────────────────────────
@@ -367,7 +384,10 @@ def build_milp_relaxation(
     all_bounds: list[tuple[float, float]] = list(
         zip(flat_lb.tolist(), flat_ub.tolist())
     )
-    integrality_flags: list[int] = [0] * n_orig
+    integrality_flags: list[int] = []
+    for v in model._variables:
+        flag = 1 if v.var_type in (VarType.BINARY, VarType.INTEGER) else 0
+        integrality_flags.extend([flag] * v.size)
 
     # Pre-compute bilinear auxiliary variable slots
     for i, j in terms.bilinear:
@@ -418,8 +438,12 @@ def build_milp_relaxation(
             b_k = float(pts[k + 1])
 
             # Big-M for bilinear product within this interval
-            corners = [a_k * xj_lb_g, a_k * xj_ub_g, b_k * xj_lb_g, b_k * xj_ub_g]
-            wk_lo, wk_hi = min(corners), max(corners)
+            _, wk_lo, wk_hi = _piecewise_product_bounds(
+                a_k,
+                b_k,
+                xj_lb_g,
+                xj_ub_g,
+            )
 
             # δ_k ∈ {0,1}
             delta_col = col_idx
@@ -429,7 +453,7 @@ def build_milp_relaxation(
 
             # x̄_k ∈ [0, max(|a_k|, |b_k|)]  (0 when δ_k=0)
             xbar_col = col_idx
-            all_bounds.append((min(a_k, 0.0) if a_k < 0 else 0.0, max(abs(a_k), abs(b_k))))
+            all_bounds.append((min(a_k, 0.0), max(abs(a_k), abs(b_k))))
             integrality_flags.append(0)
             col_idx += 1
 
@@ -449,11 +473,19 @@ def build_milp_relaxation(
     n_total = col_idx
 
     # ── Constraint rows (A_ub @ z ≤ b_ub) ───────────────────────────────────
-    A_rows: list[np.ndarray] = []
+    A_data: list[float] = []
+    A_row_indices: list[int] = []
+    A_col_indices: list[int] = []
     b_rows: list[float] = []
 
     def _add_row(coeff: np.ndarray, rhs: float) -> None:
-        A_rows.append(coeff.copy())
+        coeff_arr = np.asarray(coeff, dtype=np.float64).ravel()
+        row_idx = len(b_rows)
+        nz = np.flatnonzero(coeff_arr)
+        if nz.size:
+            A_row_indices.extend([row_idx] * int(nz.size))
+            A_col_indices.extend(nz.tolist())
+            A_data.extend(coeff_arr[nz].tolist())
         b_rows.append(float(rhs))
 
     # McCormick constraints for each bilinear term
@@ -500,8 +532,13 @@ def build_milp_relaxation(
             _add_row(-row_wsum, 0.0)
 
             for delta_col, xbar_col, wbar_col, a_k, b_k in intervals:
-                corners = [a_k * yj_lb, a_k * yj_ub, b_k * yj_lb, b_k * yj_ub]
-                M_k = max(abs(c) for c in corners) + 1.0
+                corners, wk_lo, wk_hi = _piecewise_product_bounds(
+                    a_k,
+                    b_k,
+                    yj_lb,
+                    yj_ub,
+                )
+                M_k = _compute_piecewise_big_m(corners)
 
                 # x̄_k ≥ a_k * δ_k  (x̄_k is in [a_k, b_k] when δ_k=1)
                 row = np.zeros(n_total)
@@ -668,10 +705,10 @@ def build_milp_relaxation(
                 _add_row(c, -const)
                 _add_row(-c, const)
             # (">=" is normalized to "<=" by the Expression operators)
-        except ValueError:
+        except ValueError as err:
             # Constraint contains terms we can't linearize (e.g. general nonlinear).
             # Omitting it makes the LP feasible region larger → still a valid lower bound.
-            pass
+            logger.debug("AMP: omitting constraint (cannot linearize): %s", err)
 
     # ── OA tangent cuts from NLP incumbent ──────────────────────────────────
     # These are outer-approximation linearizations of the original nonlinear
@@ -700,8 +737,12 @@ def build_milp_relaxation(
         const_obj = -const_obj
 
     # ── Assemble and return ──────────────────────────────────────────────────
-    if A_rows:
-        A_ub_arr = np.array(A_rows, dtype=np.float64)
+    if b_rows:
+        A_ub_arr = sp.csr_matrix(
+            (A_data, (A_row_indices, A_col_indices)),
+            shape=(len(b_rows), n_total),
+            dtype=np.float64,
+        )
         b_ub_arr = np.array(b_rows, dtype=np.float64)
     else:
         A_ub_arr = None

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -496,6 +496,8 @@ def build_milp_relaxation(
             lambda_cols: list[int] = []
             alpha_cols: list[int] = []
             theta_cols: list[int] = []
+            # theta = lambda * y can be zero whenever lambda = 0, so 0 must lie in
+            # the explicit theta bounds even if y does not cross zero.
             theta_lb = min(0.0, xj_lb_g, xj_ub_g)
             theta_ub = max(0.0, xj_lb_g, xj_ub_g)
 

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -1,0 +1,730 @@
+"""
+MILP Relaxation Builder for AMP (Adaptive Multivariate Partitioning).
+
+Builds a linear programming relaxation of the original MINLP by:
+  1. Replacing bilinear terms x_i*x_j with auxiliary variables w_ij and
+     adding standard McCormick envelope constraints.
+  2. Replacing monomial terms x_i^n with auxiliary variables s_i and adding
+     piecewise tangent-cut underestimators (using disc_state partition intervals)
+     and a global secant overestimator.
+  3. Linearizing the original objective and constraints.
+
+The LP relaxation gives a valid lower bound:
+  LP_opt ≤ global NLP_opt
+
+As the partition becomes finer (more intervals in disc_state), more tangent cuts
+are added for monomials in the objective, tightening the lower bound.
+
+Theory: Nagarajan et al., JOGO 2018, Section 4 (piecewise McCormick relaxation).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+
+from discopt._jax.discretization import DiscretizationState
+from discopt._jax.term_classifier import (
+    NonlinearTerms,
+    _collect_product_factors,
+    _compute_var_offset,
+    _get_flat_index,
+)
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Expression,
+    IndexExpression,
+    Model,
+    ObjectiveSense,
+    SumExpression,
+    SumOverExpression,
+    UnaryOp,
+    Variable,
+)
+
+
+# ---------------------------------------------------------------------------
+# Result and model wrappers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MilpRelaxationResult:
+    """Result of solving a MILP relaxation."""
+
+    status: str  # "optimal", "infeasible", "error", "time_limit"
+    objective: Optional[float] = None
+    x: Optional[np.ndarray] = None
+
+
+class MilpRelaxationModel:
+    """Wrapper around a MILP that exposes a .solve() method.
+
+    Stores the LP data and delegates solving to solve_milp (HiGHS).
+    """
+
+    def __init__(
+        self,
+        c: np.ndarray,
+        A_ub: Optional[np.ndarray],
+        b_ub: Optional[np.ndarray],
+        bounds: list[tuple[float, float]],
+        obj_offset: float = 0.0,
+        integrality: Optional[np.ndarray] = None,
+    ):
+        self._c = c
+        self._A_ub = A_ub
+        self._b_ub = b_ub
+        self._bounds = bounds
+        self._obj_offset = obj_offset
+        self._integrality = integrality
+
+    def solve(
+        self,
+        time_limit: Optional[float] = None,
+        gap_tolerance: float = 1e-4,
+    ) -> MilpRelaxationResult:
+        from discopt.solvers import SolveStatus
+        from discopt.solvers.milp_highs import solve_milp
+
+        result = solve_milp(
+            c=self._c,
+            A_ub=self._A_ub,
+            b_ub=self._b_ub,
+            bounds=self._bounds,
+            integrality=self._integrality,
+            time_limit=time_limit,
+            gap_tolerance=gap_tolerance,
+        )
+
+        # Map SolveStatus enum to string
+        status_map = {
+            SolveStatus.OPTIMAL: "optimal",
+            SolveStatus.INFEASIBLE: "infeasible",
+            SolveStatus.UNBOUNDED: "unbounded",
+            SolveStatus.TIME_LIMIT: "time_limit",
+            SolveStatus.ITERATION_LIMIT: "iteration_limit",
+            SolveStatus.ERROR: "error",
+        }
+        status_str = status_map.get(result.status, str(result.status))
+
+        obj = None
+        if result.objective is not None:
+            obj = float(result.objective) + self._obj_offset
+
+        return MilpRelaxationResult(status=status_str, objective=obj, x=result.x)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: variable bounds
+# ---------------------------------------------------------------------------
+
+
+def _flat_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
+    """Return (lb, ub) as flat 1-D arrays for all model variables."""
+    lbs: list[float] = []
+    ubs: list[float] = []
+    for v in model._variables:
+        lbs.extend(np.asarray(v.lb, dtype=np.float64).ravel().tolist())
+        ubs.extend(np.asarray(v.ub, dtype=np.float64).ravel().tolist())
+    return np.array(lbs, dtype=np.float64), np.array(ubs, dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: expression decomposition
+# ---------------------------------------------------------------------------
+
+
+def _decompose_product(
+    expr: Expression, model: Model
+) -> tuple[float, list[int]] | None:
+    """Decompose a product expression into (scalar, [flat_var_idx, ...]).
+
+    Returns None if expr contains non-constant, non-variable leaves.
+    Constants are accumulated into the scalar; variable references are
+    appended to the index list.
+    """
+    scalar: list[float] = [1.0]
+    var_indices: list[int] = []
+
+    def visit(e: Expression) -> bool:
+        if isinstance(e, BinaryOp) and e.op == "*":
+            return visit(e.left) and visit(e.right)
+        if isinstance(e, Constant):
+            scalar[0] *= float(e.value)
+            return True
+        flat = _get_flat_index(e, model)
+        if flat is not None:
+            var_indices.append(flat)
+            return True
+        return False
+
+    if visit(expr):
+        return scalar[0], var_indices
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers: expression linearizer
+# ---------------------------------------------------------------------------
+
+
+def _linearize_expr(
+    expr: Expression,
+    model: Model,
+    bilinear_var_map: dict[tuple[int, int], int],
+    monomial_var_map: dict[tuple[int, int], int],
+    n_total_vars: int,
+) -> tuple[np.ndarray, float]:
+    """Walk expression tree and return (coeff, constant) for linearized form.
+
+    coeff[j] = coefficient of MILP variable j in the linear approximation.
+    constant = scalar constant term.
+
+    Nonlinear terms must have a corresponding auxiliary variable in the maps;
+    raises ValueError if an unregistered nonlinear term is encountered.
+    """
+    coeff = np.zeros(n_total_vars, dtype=np.float64)
+    const_acc: list[float] = [0.0]
+
+    def visit(e: Expression, scale: float) -> None:  # noqa: C901
+        if isinstance(e, Constant):
+            const_acc[0] += scale * float(e.value)
+
+        elif isinstance(e, Variable):
+            offset = _compute_var_offset(e, model)
+            if e.size == 1:
+                coeff[offset] += scale
+            else:
+                # Multi-element variable (unusual in scalar expression)
+                for k in range(e.size):
+                    coeff[offset + k] += scale
+
+        elif isinstance(e, IndexExpression):
+            flat = _get_flat_index(e, model)
+            if flat is not None:
+                coeff[flat] += scale
+            else:
+                raise ValueError(f"Cannot linearize IndexExpression: {e}")
+
+        elif isinstance(e, BinaryOp):
+            if e.op == "+":
+                visit(e.left, scale)
+                visit(e.right, scale)
+
+            elif e.op == "-":
+                visit(e.left, scale)
+                visit(e.right, -scale)
+
+            elif e.op == "/":
+                if isinstance(e.right, Constant):
+                    visit(e.left, scale / float(e.right.value))
+                else:
+                    raise ValueError(f"Cannot linearize non-constant division: {e}")
+
+            elif e.op == "**":
+                flat = _get_flat_index(e.left, model)
+                if flat is not None and isinstance(e.right, Constant):
+                    n = int(float(e.right.value))
+                    if n == 1:
+                        coeff[flat] += scale
+                        return
+                    if n == 0:
+                        const_acc[0] += scale
+                        return
+                    key = (flat, n)
+                    if key in monomial_var_map:
+                        coeff[monomial_var_map[key]] += scale
+                    else:
+                        raise ValueError(f"Monomial {key} not in monomial_var_map")
+                else:
+                    raise ValueError(f"Cannot linearize power expression: {e}")
+
+            elif e.op == "*":
+                # Constant scaling?
+                if isinstance(e.left, Constant):
+                    visit(e.right, scale * float(e.left.value))
+                    return
+                if isinstance(e.right, Constant):
+                    visit(e.left, scale * float(e.right.value))
+                    return
+                # Full product decomposition
+                decomp = _decompose_product(e, model)
+                if decomp is None:
+                    raise ValueError(f"Cannot decompose product: {e}")
+                c, indices = decomp
+                unique = list(dict.fromkeys(indices))
+                if len(indices) == 0:
+                    const_acc[0] += scale * c
+                elif len(unique) == 1 and len(indices) == 1:
+                    coeff[unique[0]] += scale * c
+                elif len(unique) == 1:
+                    # x^n monomial
+                    n = len(indices)
+                    key = (unique[0], n)
+                    if key in monomial_var_map:
+                        coeff[monomial_var_map[key]] += scale * c
+                    else:
+                        raise ValueError(f"Monomial {key} not in map")
+                elif len(unique) == 2:
+                    i_idx, j_idx = unique[0], unique[1]
+                    key = (min(i_idx, j_idx), max(i_idx, j_idx))
+                    if key in bilinear_var_map:
+                        coeff[bilinear_var_map[key]] += scale * c
+                    else:
+                        raise ValueError(f"Bilinear {key} not in map")
+                else:
+                    raise ValueError(
+                        f"Higher-order product ({len(unique)} vars) not supported"
+                    )
+
+            else:
+                raise ValueError(f"Cannot linearize BinaryOp: {e.op}")
+
+        elif isinstance(e, UnaryOp):
+            if e.op == "neg":
+                visit(e.operand, -scale)
+            else:
+                raise ValueError(f"Cannot linearize UnaryOp: {e.op}")
+
+        elif isinstance(e, SumExpression):
+            op = e.operand
+            if isinstance(op, Variable):
+                offset = _compute_var_offset(op, model)
+                for k in range(op.size):
+                    coeff[offset + k] += scale
+            else:
+                visit(op, scale)
+
+        elif isinstance(e, SumOverExpression):
+            for term in e.terms:
+                visit(term, scale)
+
+        else:
+            raise ValueError(f"Cannot linearize {type(e).__name__}: {e}")
+
+    visit(expr, 1.0)
+    return coeff, const_acc[0]
+
+
+# ---------------------------------------------------------------------------
+# Main builder
+# ---------------------------------------------------------------------------
+
+
+def build_milp_relaxation(
+    model: Model,
+    terms: NonlinearTerms,
+    disc_state: DiscretizationState,
+    incumbent: Optional[np.ndarray] = None,
+    oa_cuts: Optional[list] = None,
+) -> tuple["MilpRelaxationModel", dict]:
+    """Build a MILP relaxation with piecewise McCormick for bilinear/monomial terms.
+
+    For each bilinear term x_i*x_j: adds standard McCormick envelope constraints
+    (4 linear inequalities).  These give the convex hull of the bilinear set on the
+    bounding box and are independent of the partition (piecewise refinement via binary
+    variables is left for future enhancement).
+
+    For each monomial x_i^n (currently n=2 handled precisely):
+    - Piecewise tangent underestimators (one per partition interval midpoint) — gets
+      tighter as disc_state gains more intervals.
+    - Global secant overestimator — bounds s from above.
+
+    The LP objective and constraints are obtained by substituting auxiliary vars for
+    all nonlinear terms.
+
+    Parameters
+    ----------
+    model : Model
+    terms : NonlinearTerms
+        Output of classify_nonlinear_terms(model).
+    disc_state : DiscretizationState
+        Current partition; provides intervals for tangent cut placement.
+    incumbent : np.ndarray, optional
+        Current best NLP solution (flat).  Used to add OA tangent cuts for
+        general nonlinear terms; currently unused (reserved for future use).
+
+    Returns
+    -------
+    (MilpRelaxationModel, varmap)
+        MilpRelaxationModel has a .solve() method returning MilpRelaxationResult.
+        varmap maps auxiliary variable keys to MILP column indices.
+    """
+    flat_lb, flat_ub = _flat_bounds(model)
+    n_orig = len(flat_lb)
+
+    # ── Assign MILP column indices ──────────────────────────────────────────
+    # Layout: [original vars 0..n_orig-1] [bilinear aux w_ij] [monomial aux s_i^n]
+    # For partitioned bilinear terms: also [δ_k, x̄_k, w̄_k per partition k]
+    bilinear_var_map: dict[tuple[int, int], int] = {}
+    monomial_var_map: dict[tuple[int, int], int] = {}
+
+    col_idx = n_orig
+    all_bounds: list[tuple[float, float]] = list(
+        zip(flat_lb.tolist(), flat_ub.tolist())
+    )
+    integrality_flags: list[int] = [0] * n_orig
+
+    # Pre-compute bilinear auxiliary variable slots
+    for i, j in terms.bilinear:
+        xi_lb, xi_ub = float(flat_lb[i]), float(flat_ub[i])
+        xj_lb, xj_ub = float(flat_lb[j]), float(flat_ub[j])
+        corners = [xi_lb * xj_lb, xi_lb * xj_ub, xi_ub * xj_lb, xi_ub * xj_ub]
+        bilinear_var_map[(i, j)] = col_idx
+        all_bounds.append((min(corners), max(corners)))
+        integrality_flags.append(0)
+        col_idx += 1
+
+    for var_idx, n in terms.monomial:
+        lb_i = float(flat_lb[var_idx])
+        ub_i = float(flat_ub[var_idx])
+        vals = [lb_i**n, ub_i**n]
+        if n % 2 == 0 and lb_i < 0 < ub_i:
+            vals.append(0.0)
+        monomial_var_map[(var_idx, n)] = col_idx
+        all_bounds.append((min(vals), max(vals)))
+        integrality_flags.append(0)
+        col_idx += 1
+
+    # Piecewise McCormick: per-partition auxiliary variables for bilinear terms.
+    # For each bilinear (i,j) where i ∈ disc_state.partitions:
+    #   For each partition interval k:
+    #     δ_k  ∈ {0,1}       — binary selector (col)
+    #     x̄_k  ∈ [a_k, b_k]  — x_i value within interval k (0 outside)
+    #     w̄_k  ∈ [wi_lo, wi_hi] — bilinear product within interval k (0 outside)
+    # bilinear_pw_map[(i,j)] = [(delta_col, xbar_col, wbar_col, a_k, b_k), ...]
+    bilinear_pw_map: dict[tuple[int, int], list] = {}
+
+    for i, j in terms.bilinear:
+        # Choose which variable to partition: prefer the one in disc_state
+        if i in disc_state.partitions:
+            part_var, other_var = i, j
+        elif j in disc_state.partitions:
+            part_var, other_var = j, i
+        else:
+            continue  # no partitioning for this term
+
+        pts = disc_state.partitions[part_var]
+        xj_lb_g = float(flat_lb[other_var])
+        xj_ub_g = float(flat_ub[other_var])
+
+        intervals = []
+        for k in range(len(pts) - 1):
+            a_k = float(pts[k])
+            b_k = float(pts[k + 1])
+
+            # Big-M for bilinear product within this interval
+            corners = [a_k * xj_lb_g, a_k * xj_ub_g, b_k * xj_lb_g, b_k * xj_ub_g]
+            wk_lo, wk_hi = min(corners), max(corners)
+
+            # δ_k ∈ {0,1}
+            delta_col = col_idx
+            all_bounds.append((0.0, 1.0))
+            integrality_flags.append(1)
+            col_idx += 1
+
+            # x̄_k ∈ [0, max(|a_k|, |b_k|)]  (0 when δ_k=0)
+            xbar_col = col_idx
+            all_bounds.append((min(a_k, 0.0) if a_k < 0 else 0.0, max(abs(a_k), abs(b_k))))
+            integrality_flags.append(0)
+            col_idx += 1
+
+            # w̄_k ∈ [wk_lo, wk_hi]  (0 when δ_k=0)
+            wbar_col = col_idx
+            all_bounds.append((min(wk_lo, 0.0), max(wk_hi, 0.0)))
+            integrality_flags.append(0)
+            col_idx += 1
+
+            intervals.append((delta_col, xbar_col, wbar_col, a_k, b_k))
+
+        bilinear_pw_map[(i, j)] = intervals
+
+    # Also store in a form keyed by (part_var, other_var) for reference
+    # (not needed separately; we use bilinear_pw_map[(i,j)] directly)
+
+    n_total = col_idx
+
+    # ── Constraint rows (A_ub @ z ≤ b_ub) ───────────────────────────────────
+    A_rows: list[np.ndarray] = []
+    b_rows: list[float] = []
+
+    def _add_row(coeff: np.ndarray, rhs: float) -> None:
+        A_rows.append(coeff.copy())
+        b_rows.append(float(rhs))
+
+    # McCormick constraints for each bilinear term
+    for i, j in terms.bilinear:
+        xi_lb_g = float(flat_lb[i])
+        xi_ub_g = float(flat_ub[i])
+        xj_lb_g = float(flat_lb[j])
+        xj_ub_g = float(flat_ub[j])
+        w_col = bilinear_var_map[(i, j)]
+
+        if (i, j) in bilinear_pw_map and bilinear_pw_map[(i, j)]:
+            # ── Piecewise McCormick with binary partition selection ──────────
+            intervals = bilinear_pw_map[(i, j)]
+            # Determine partition var vs other var
+            if i in disc_state.partitions:
+                part_var, other_var = i, j
+            else:
+                part_var, other_var = j, i
+
+            yj_lb = float(flat_lb[other_var])
+            yj_ub = float(flat_ub[other_var])
+
+            # Constraint: Σ δ_k = 1 (select exactly one partition)
+            row_sum = np.zeros(n_total)
+            for delta_col, _, _, _, _ in intervals:
+                row_sum[delta_col] = -1.0
+            _add_row(row_sum, -1.0)  # -Σδ_k ≤ -1
+            _add_row(-row_sum, 1.0)  # Σδ_k ≤ 1
+
+            # Constraint: x_part = Σ x̄_k (reconstruct partition variable)
+            row_recon = np.zeros(n_total)
+            row_recon[part_var] = 1.0
+            for _, xbar_col, _, _, _ in intervals:
+                row_recon[xbar_col] = -1.0
+            _add_row(row_recon, 0.0)   # x_part - Σ x̄_k ≤ 0
+            _add_row(-row_recon, 0.0)  # -(x_part - Σ x̄_k) ≤ 0
+
+            # Constraint: w = Σ w̄_k
+            row_wsum = np.zeros(n_total)
+            row_wsum[w_col] = 1.0
+            for _, _, wbar_col, _, _ in intervals:
+                row_wsum[wbar_col] = -1.0
+            _add_row(row_wsum, 0.0)
+            _add_row(-row_wsum, 0.0)
+
+            for delta_col, xbar_col, wbar_col, a_k, b_k in intervals:
+                corners = [a_k * yj_lb, a_k * yj_ub, b_k * yj_lb, b_k * yj_ub]
+                M_k = max(abs(c) for c in corners) + 1.0
+
+                # x̄_k ≥ a_k * δ_k  (x̄_k is in [a_k, b_k] when δ_k=1)
+                row = np.zeros(n_total)
+                row[xbar_col] = -1.0
+                row[delta_col] = a_k
+                _add_row(row, 0.0)  # -x̄_k + a_k*δ_k ≤ 0  → x̄_k ≥ a_k*δ_k
+
+                # x̄_k ≤ b_k * δ_k
+                row = np.zeros(n_total)
+                row[xbar_col] = 1.0
+                row[delta_col] = -b_k
+                _add_row(row, 0.0)
+
+                # w̄_k ≤ wk_hi * δ_k  → w̄_k=0 when δ_k=0
+                # This forces the bilinear product to 0 when interval k is inactive.
+                row = np.zeros(n_total)
+                row[wbar_col] = 1.0
+                row[delta_col] = -wk_hi
+                _add_row(row, 0.0)
+
+                # w̄_k ≥ wk_lo * δ_k  → w̄_k=0 when δ_k=0 (for wk_lo ≥ 0 case)
+                if wk_lo > 0:
+                    row = np.zeros(n_total)
+                    row[wbar_col] = -1.0
+                    row[delta_col] = wk_lo
+                    _add_row(row, 0.0)
+
+                # Per-interval McCormick with big-M relaxation.
+                # The big-M term LOOSENS the constraint when δ_k=0 (interval inactive).
+                #
+                # cv1: w̄_k ≥ a_k*y + x̄_k*y_lb - a_k*y_lb - M*(1-δ_k)
+                #   → -w̄_k + a_k*y + x̄_k*y_lb + M*δ_k ≤ a_k*y_lb + M
+                row = np.zeros(n_total)
+                row[wbar_col] = -1.0
+                row[other_var] += a_k
+                row[xbar_col] += yj_lb
+                row[delta_col] = M_k   # +M_k so constraint loosens when δ_k=0
+                _add_row(row, a_k * yj_lb + M_k)
+
+                # cv2: w̄_k ≥ b_k*y + x̄_k*y_ub - b_k*y_ub - M*(1-δ_k)
+                #   → -w̄_k + b_k*y + x̄_k*y_ub + M*δ_k ≤ b_k*y_ub + M
+                row = np.zeros(n_total)
+                row[wbar_col] = -1.0
+                row[other_var] += b_k
+                row[xbar_col] += yj_ub
+                row[delta_col] = M_k
+                _add_row(row, b_k * yj_ub + M_k)
+
+                # cc1: w̄_k ≤ b_k*y + x̄_k*y_lb - b_k*y_lb + M*(1-δ_k)
+                #   → w̄_k - b_k*y - x̄_k*y_lb + M*δ_k ≤ M - b_k*y_lb
+                row = np.zeros(n_total)
+                row[wbar_col] = 1.0
+                row[other_var] -= b_k
+                row[xbar_col] -= yj_lb
+                row[delta_col] = M_k   # +M_k so constraint loosens when δ_k=0
+                _add_row(row, M_k - b_k * yj_lb)
+
+                # cc2: w̄_k ≤ a_k*y + x̄_k*y_ub - a_k*y_ub + M*(1-δ_k)
+                #   → w̄_k - a_k*y - x̄_k*y_ub + M*δ_k ≤ M - a_k*y_ub
+                row = np.zeros(n_total)
+                row[wbar_col] = 1.0
+                row[other_var] -= a_k
+                row[xbar_col] -= yj_ub
+                row[delta_col] = M_k
+                _add_row(row, M_k - a_k * yj_ub)
+
+        else:
+            # ── Standard (global) McCormick ──────────────────────────────────
+            # cv1: w ≥ xi_lb*xj + xi*xj_lb - xi_lb*xj_lb
+            #   →  -w + xj_lb*xi + xi_lb*xj ≤ xi_lb*xj_lb
+            row = np.zeros(n_total)
+            row[w_col] = -1.0
+            row[i] += xj_lb_g
+            row[j] += xi_lb_g
+            _add_row(row, xi_lb_g * xj_lb_g)
+
+            # cv2: w ≥ xi_ub*xj + xi*xj_ub - xi_ub*xj_ub
+            row = np.zeros(n_total)
+            row[w_col] = -1.0
+            row[i] += xj_ub_g
+            row[j] += xi_ub_g
+            _add_row(row, xi_ub_g * xj_ub_g)
+
+            # cc1: w ≤ xi_ub*xj + xi*xj_lb - xi_ub*xj_lb
+            row = np.zeros(n_total)
+            row[w_col] = 1.0
+            row[i] -= xj_lb_g
+            row[j] -= xi_ub_g
+            _add_row(row, -xi_ub_g * xj_lb_g)
+
+            # cc2: w ≤ xi_lb*xj + xi*xj_ub - xi_lb*xj_ub
+            row = np.zeros(n_total)
+            row[w_col] = 1.0
+            row[i] -= xj_ub_g
+            row[j] -= xi_lb_g
+            _add_row(row, -xi_lb_g * xj_ub_g)
+
+    # Monomial constraints
+    for var_idx, n in terms.monomial:
+        lb_i = float(flat_lb[var_idx])
+        ub_i = float(flat_ub[var_idx])
+        s_col = monomial_var_map[(var_idx, n)]
+
+        if n == 2:
+            # Piecewise tangent underestimators: s ≥ 2*t*x - t^2  for tangent point t.
+            # → -s + 2*t*x ≤ t^2
+            #
+            # KEY monotonicity requirement: as partitions get finer, the set of tangent
+            # points must grow (never shrink).  Using ALL BREAKPOINTS achieves this:
+            # linspace(lb,ub,k+1) breakpoints are a superset of linspace(lb,ub,k) for
+            # the test sequence n_init=1,2,4,8 (each is a refinement of the previous).
+            # Using midpoints would fail because n_init=1's midpoint (2.5) gives a
+            # tighter cut than n_init=2's midpoints (1.75, 3.25) at the LP optimum.
+            if var_idx in disc_state.partitions and len(disc_state.partitions[var_idx]) >= 2:
+                pts = disc_state.partitions[var_idx]
+                tangent_pts = [float(p) for p in pts]  # breakpoints as tangent points
+            else:
+                tangent_pts = [lb_i, ub_i]
+
+            for t in tangent_pts:
+                row = np.zeros(n_total)
+                row[s_col] = -1.0
+                row[var_idx] = 2.0 * t
+                _add_row(row, t * t)
+
+            # Global secant overestimator: s ≤ (lb+ub)*x - lb*ub
+            # → s - (lb+ub)*x ≤ -lb*ub
+            row = np.zeros(n_total)
+            row[s_col] = 1.0
+            row[var_idx] = -(lb_i + ub_i)
+            _add_row(row, -lb_i * ub_i)
+
+        else:
+            # General n: secant overestimator
+            if abs(ub_i - lb_i) > 1e-12:
+                slope = (ub_i**n - lb_i**n) / (ub_i - lb_i)
+                intercept = lb_i**n - slope * lb_i
+                row = np.zeros(n_total)
+                row[s_col] = 1.0
+                row[var_idx] = -slope
+                _add_row(row, intercept)
+
+            # Tangent at midpoint
+            mid = 0.5 * (lb_i + ub_i)
+            t_slope = n * (mid ** (n - 1))
+            t_intercept = -(n - 1) * (mid**n)
+            row = np.zeros(n_total)
+            row[s_col] = -1.0
+            row[var_idx] = t_slope
+            _add_row(row, -t_intercept)
+
+    # Model constraints
+    for constraint in model._constraints:
+        body = constraint.body  # normalized: body <= 0  (sense is always "<=")
+        sense = constraint.sense
+        try:
+            c, const = _linearize_expr(
+                body, model, bilinear_var_map, monomial_var_map, n_total
+            )
+            # body ≤ 0  →  c @ z + const ≤ 0  →  c @ z ≤ -const
+            if sense == "<=":
+                _add_row(c, -const)
+            elif sense == "==":
+                _add_row(c, -const)
+                _add_row(-c, const)
+            # (">=" is normalized to "<=" by the Expression operators)
+        except ValueError:
+            # Constraint contains terms we can't linearize (e.g. general nonlinear).
+            # Omitting it makes the LP feasible region larger → still a valid lower bound.
+            pass
+
+    # ── OA tangent cuts from NLP incumbent ──────────────────────────────────
+    # These are outer-approximation linearizations of the original nonlinear
+    # constraints at the incumbent point.  They are in terms of ORIGINAL
+    # variables (columns 0..n_orig-1) and tighten the LP relaxation.
+    if oa_cuts:
+        for coeff, rhs in oa_cuts:
+            row = np.zeros(n_total)
+            row[:len(coeff)] = coeff[:n_total if len(coeff) > n_total else len(coeff)]
+            _add_row(row, rhs)
+
+    # ── Objective ────────────────────────────────────────────────────────────
+    obj_expr = model._objective.expression
+    try:
+        c_obj, const_obj = _linearize_expr(
+            obj_expr, model, bilinear_var_map, monomial_var_map, n_total
+        )
+    except ValueError:
+        # Fallback: trivial objective (LP gives ‑∞ lower bound — acceptable for soundness)
+        c_obj = np.zeros(n_total)
+        const_obj = 0.0
+
+    # Negate for maximization
+    if model._objective.sense == ObjectiveSense.MAXIMIZE:
+        c_obj = -c_obj
+        const_obj = -const_obj
+
+    # ── Assemble and return ──────────────────────────────────────────────────
+    if A_rows:
+        A_ub_arr = np.array(A_rows, dtype=np.float64)
+        b_ub_arr = np.array(b_rows, dtype=np.float64)
+    else:
+        A_ub_arr = None
+        b_ub_arr = None
+
+    # Build integrality array (1 = integer, 0 = continuous)
+    integrality_arr = np.array(integrality_flags, dtype=np.int32)
+    has_integers = bool(np.any(integrality_arr > 0))
+
+    milp_model = MilpRelaxationModel(
+        c=c_obj,
+        A_ub=A_ub_arr,
+        b_ub=b_ub_arr,
+        bounds=all_bounds,
+        obj_offset=const_obj,
+        integrality=integrality_arr if has_integers else None,
+    )
+
+    varmap: dict = {
+        "original": {k: k for k in range(n_orig)},
+        "bilinear": bilinear_var_map,
+        "monomial": monomial_var_map,
+        "bilinear_pw": bilinear_pw_map,
+    }
+
+    return milp_model, varmap

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -79,6 +79,7 @@ class MilpRelaxationModel:
         bounds: list[tuple[float, float]],
         obj_offset: float = 0.0,
         integrality: Optional[np.ndarray] = None,
+        objective_bound_valid: bool = True,
     ):
         self._c = c
         self._A_ub = A_ub
@@ -86,6 +87,7 @@ class MilpRelaxationModel:
         self._bounds = bounds
         self._obj_offset = obj_offset
         self._integrality = integrality
+        self._objective_bound_valid = objective_bound_valid
 
     def solve(
         self,
@@ -117,7 +119,7 @@ class MilpRelaxationModel:
         status_str = status_map.get(result.status, str(result.status))
 
         obj = None
-        if result.objective is not None:
+        if result.objective is not None and self._objective_bound_valid:
             obj = float(result.objective) + self._obj_offset
 
         return MilpRelaxationResult(status=status_str, objective=obj, x=result.x)
@@ -163,6 +165,28 @@ def _normalize_convhull_formulation(formulation: str) -> str:
         ) from err
 
 
+def _choose_trilinear_pair(
+    term: tuple[int, int, int],
+    partitioned_vars: set[int],
+) -> tuple[tuple[int, int], int]:
+    """Choose a deterministic trilinear decomposition pair.
+
+    Prefer a pair that already uses partitioned original variables so the
+    existing piecewise bilinear machinery can tighten one stage of the lifted
+    relaxation.
+    """
+    i, j, k = tuple(sorted(term))
+    candidates = [((i, j), k), ((i, k), j), ((j, k), i)]
+    candidates.sort()
+    return max(
+        candidates,
+        key=lambda item: (
+            sum(v in partitioned_vars for v in item[0]),
+            item[0][0] in partitioned_vars or item[0][1] in partitioned_vars,
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers: expression decomposition
 # ---------------------------------------------------------------------------
@@ -204,6 +228,7 @@ def _linearize_expr(
     expr: Expression,
     model: Model,
     bilinear_var_map: dict[tuple[int, int], int],
+    trilinear_var_map: dict[tuple[int, int, int], int],
     monomial_var_map: dict[tuple[int, int], int],
     n_total_vars: int,
 ) -> tuple[np.ndarray, float]:
@@ -306,6 +331,15 @@ def _linearize_expr(
                         coeff[bilinear_var_map[key]] += scale * c
                     else:
                         raise ValueError(f"Bilinear {key} not in map")
+                elif len(unique) == 3:
+                    if len(unique) != len(indices):
+                        raise ValueError("Mixed repeated-factor products are not supported")
+                    ordered = sorted(unique)
+                    tri_key = (ordered[0], ordered[1], ordered[2])
+                    if tri_key in trilinear_var_map:
+                        coeff[trilinear_var_map[tri_key]] += scale * c
+                    else:
+                        raise ValueError(f"Trilinear {tri_key} not in map")
                 else:
                     raise ValueError(f"Higher-order product ({len(unique)} vars) not supported")
 
@@ -392,9 +426,9 @@ def build_milp_relaxation(
     convhull_mode = _normalize_convhull_formulation(convhull_formulation)
 
     # ── Assign MILP column indices ──────────────────────────────────────────
-    # Layout: [original vars 0..n_orig-1] [bilinear aux w_ij] [monomial aux s_i^n]
-    # For partitioned bilinear terms: also [δ_k, x̄_k, w̄_k per partition k]
     bilinear_var_map: dict[tuple[int, int], int] = {}
+    trilinear_var_map: dict[tuple[int, int, int], int] = {}
+    trilinear_stage_map: dict[tuple[int, int, int], dict[str, object]] = {}
     monomial_var_map: dict[tuple[int, int], int] = {}
 
     col_idx = n_orig
@@ -404,15 +438,50 @@ def build_milp_relaxation(
         flag = 1 if v.var_type in (VarType.BINARY, VarType.INTEGER) else 0
         integrality_flags.extend([flag] * v.size)
 
-    # Pre-compute bilinear auxiliary variable slots
-    for i, j in terms.bilinear:
-        xi_lb, xi_ub = float(flat_lb[i]), float(flat_ub[i])
-        xj_lb, xj_ub = float(flat_lb[j]), float(flat_ub[j])
-        corners = [xi_lb * xj_lb, xi_lb * xj_ub, xi_ub * xj_lb, xi_ub * xj_ub]
-        bilinear_var_map[(i, j)] = col_idx
+    bilinear_relation_map: dict[tuple[int, int], int] = {}
+
+    def _ensure_bilinear_aux(lhs_col: int, rhs_col: int) -> int:
+        nonlocal col_idx
+        key = (min(lhs_col, rhs_col), max(lhs_col, rhs_col))
+        if key in bilinear_relation_map:
+            return bilinear_relation_map[key]
+
+        lhs_lb, lhs_ub = all_bounds[key[0]]
+        rhs_lb, rhs_ub = all_bounds[key[1]]
+        corners = [
+            lhs_lb * rhs_lb,
+            lhs_lb * rhs_ub,
+            lhs_ub * rhs_lb,
+            lhs_ub * rhs_ub,
+        ]
+        bilinear_relation_map[key] = col_idx
         all_bounds.append((min(corners), max(corners)))
         integrality_flags.append(0)
         col_idx += 1
+        return bilinear_relation_map[key]
+
+    original_bilinear_keys = sorted({(min(i, j), max(i, j)) for i, j in terms.bilinear})
+    for key in original_bilinear_keys:
+        bilinear_var_map[key] = _ensure_bilinear_aux(*key)
+
+    partitioned_vars = set(disc_state.partitions)
+    trilinear_terms: list[tuple[int, int, int]] = []
+    for term in terms.trilinear:
+        ordered = tuple(sorted(term))
+        if ordered not in trilinear_terms:
+            trilinear_terms.append(ordered)
+
+    for term in sorted(trilinear_terms):
+        pair, remaining = _choose_trilinear_pair(term, partitioned_vars)
+        pair_col = _ensure_bilinear_aux(*pair)
+        final_col = _ensure_bilinear_aux(pair_col, remaining)
+        trilinear_var_map[term] = final_col
+        trilinear_stage_map[term] = {
+            "pair": pair,
+            "pair_col": pair_col,
+            "remaining_var": remaining,
+            "product_col": final_col,
+        }
 
     for var_idx, n in terms.monomial:
         lb_i = float(flat_lb[var_idx])
@@ -425,56 +494,45 @@ def build_milp_relaxation(
         integrality_flags.append(0)
         col_idx += 1
 
-    # Piecewise McCormick: per-partition auxiliary variables for bilinear terms.
-    # For each bilinear (i,j) where i ∈ disc_state.partitions:
-    #   For each partition interval k:
-    #     δ_k  ∈ {0,1}       — binary selector (col)
-    #     x̄_k  ∈ [a_k, b_k]  — x_i value within interval k (0 outside)
-    #     w̄_k  ∈ [wi_lo, wi_hi] — bilinear product within interval k (0 outside)
-    # bilinear_pw_map[(i,j)] = [(delta_col, xbar_col, wbar_col, a_k, b_k), ...]
     bilinear_pw_map: dict[tuple[int, int], list] = {}
     bilinear_lambda_map: dict[tuple[int, int], dict] = {}
 
-    for i, j in terms.bilinear:
-        # Choose which variable to partition: prefer the one in disc_state
-        if i in disc_state.partitions:
-            part_var, other_var = i, j
-        elif j in disc_state.partitions:
-            part_var, other_var = j, i
+    for (lhs_col, rhs_col), _w_col in bilinear_relation_map.items():
+        part_var: Optional[int] = None
+        if lhs_col < n_orig and lhs_col in disc_state.partitions:
+            part_var = lhs_col
+            other_var = rhs_col
+        elif rhs_col < n_orig and rhs_col in disc_state.partitions:
+            part_var = rhs_col
+            other_var = lhs_col
         else:
-            continue  # no partitioning for this term
+            continue
 
         pts = disc_state.partitions[part_var]
-        xj_lb_g = float(flat_lb[other_var])
-        xj_ub_g = float(flat_ub[other_var])
+        other_lb, other_ub = all_bounds[other_var]
 
         if convhull_mode == "disaggregated":
             intervals = []
             for k in range(len(pts) - 1):
                 a_k = float(pts[k])
                 b_k = float(pts[k + 1])
-
-                # Big-M for bilinear product within this interval
                 _, wk_lo, wk_hi = _piecewise_product_bounds(
                     a_k,
                     b_k,
-                    xj_lb_g,
-                    xj_ub_g,
+                    float(other_lb),
+                    float(other_ub),
                 )
 
-                # δ_k ∈ {0,1}
                 delta_col = col_idx
                 all_bounds.append((0.0, 1.0))
                 integrality_flags.append(1)
                 col_idx += 1
 
-                # x̄_k ∈ [0, max(|a_k|, |b_k|)]  (0 when δ_k=0)
                 xbar_col = col_idx
                 all_bounds.append((min(a_k, 0.0), max(abs(a_k), abs(b_k))))
                 integrality_flags.append(0)
                 col_idx += 1
 
-                # w̄_k ∈ [wk_lo, wk_hi]  (0 when δ_k=0)
                 wbar_col = col_idx
                 all_bounds.append((min(wk_lo, 0.0), max(wk_hi, 0.0)))
                 integrality_flags.append(0)
@@ -482,16 +540,14 @@ def build_milp_relaxation(
 
                 intervals.append((delta_col, xbar_col, wbar_col, a_k, b_k))
 
-            bilinear_pw_map[(i, j)] = intervals
+            bilinear_pw_map[(lhs_col, rhs_col)] = intervals
         else:
             breakpoints = [float(p) for p in pts]
             lambda_cols: list[int] = []
             alpha_cols: list[int] = []
             theta_cols: list[int] = []
-            # theta = lambda * y can be zero whenever lambda = 0, so 0 must lie in
-            # the explicit theta bounds even if y does not cross zero.
-            theta_lb = min(0.0, xj_lb_g, xj_ub_g)
-            theta_ub = max(0.0, xj_lb_g, xj_ub_g)
+            theta_lb = min(0.0, float(other_lb), float(other_ub))
+            theta_ub = max(0.0, float(other_lb), float(other_ub))
 
             for _ in breakpoints:
                 lambda_cols.append(col_idx)
@@ -511,7 +567,7 @@ def build_milp_relaxation(
                 integrality_flags.append(0)
                 col_idx += 1
 
-            bilinear_lambda_map[(i, j)] = {
+            bilinear_lambda_map[(lhs_col, rhs_col)] = {
                 "part_var": part_var,
                 "other_var": other_var,
                 "breakpoints": breakpoints,
@@ -520,9 +576,6 @@ def build_milp_relaxation(
                 "theta_cols": theta_cols,
                 "mode": convhull_mode,
             }
-
-    # Also store in a form keyed by (part_var, other_var) for reference
-    # (not needed separately; we use bilinear_pw_map[(i,j)] directly)
 
     n_total = col_idx
 
@@ -542,13 +595,10 @@ def build_milp_relaxation(
             A_data.extend(coeff_arr[nz].tolist())
         b_rows.append(float(rhs))
 
-    # McCormick constraints for each bilinear term
-    for i, j in terms.bilinear:
-        xi_lb_g = float(flat_lb[i])
-        xi_ub_g = float(flat_ub[i])
-        xj_lb_g = float(flat_lb[j])
-        xj_ub_g = float(flat_ub[j])
-        w_col = bilinear_var_map[(i, j)]
+    # McCormick constraints for each lifted bilinear relation
+    for (i, j), w_col in bilinear_relation_map.items():
+        xi_lb_g, xi_ub_g = [float(v) for v in all_bounds[i]]
+        xj_lb_g, xj_ub_g = [float(v) for v in all_bounds[j]]
 
         if (i, j) in bilinear_lambda_map:
             lambda_info = bilinear_lambda_map[(i, j)]
@@ -559,8 +609,7 @@ def build_milp_relaxation(
             alpha_cols = list(lambda_info["alpha_cols"])
             theta_cols = list(lambda_info["theta_cols"])
             mode = str(lambda_info["mode"])
-            yj_lb = float(flat_lb[other_var])
-            yj_ub = float(flat_ub[other_var])
+            yj_lb, yj_ub = [float(v) for v in all_bounds[other_var]]
 
             row_sum_lambda = np.zeros(n_total)
             for lambda_col in lambda_cols:
@@ -650,13 +699,12 @@ def build_milp_relaxation(
             # ── Piecewise McCormick with binary partition selection ──────────
             intervals = bilinear_pw_map[(i, j)]
             # Determine partition var vs other var
-            if i in disc_state.partitions:
+            if i < n_orig and i in disc_state.partitions:
                 part_var, other_var = i, j
             else:
                 part_var, other_var = j, i
 
-            yj_lb = float(flat_lb[other_var])
-            yj_ub = float(flat_ub[other_var])
+            yj_lb, yj_ub = [float(v) for v in all_bounds[other_var]]
 
             # Constraint: Σ δ_k = 1 (select exactly one partition)
             row_sum = np.zeros(n_total)
@@ -709,12 +757,11 @@ def build_milp_relaxation(
                 row[delta_col] = -wk_hi
                 _add_row(row, 0.0)
 
-                # w̄_k ≥ wk_lo * δ_k  → w̄_k=0 when δ_k=0 (for wk_lo ≥ 0 case)
-                if wk_lo > 0:
-                    row = np.zeros(n_total)
-                    row[wbar_col] = -1.0
-                    row[delta_col] = wk_lo
-                    _add_row(row, 0.0)
+                # w̄_k ≥ wk_lo * δ_k  → w̄_k=0 when δ_k=0
+                row = np.zeros(n_total)
+                row[wbar_col] = -1.0
+                row[delta_col] = wk_lo
+                _add_row(row, 0.0)
 
                 # Per-interval McCormick with big-M relaxation.
                 # The big-M term LOOSENS the constraint when δ_k=0 (interval inactive).
@@ -845,7 +892,14 @@ def build_milp_relaxation(
         body = constraint.body  # normalized: body <= 0  (sense is always "<=")
         sense = constraint.sense
         try:
-            c, const = _linearize_expr(body, model, bilinear_var_map, monomial_var_map, n_total)
+            c, const = _linearize_expr(
+                body,
+                model,
+                bilinear_var_map,
+                trilinear_var_map,
+                monomial_var_map,
+                n_total,
+            )
             # body ≤ 0  →  c @ z + const ≤ 0  →  c @ z ≤ -const
             if sense == "<=":
                 _add_row(c, -const)
@@ -856,7 +910,12 @@ def build_milp_relaxation(
         except ValueError as err:
             # Constraint contains terms we can't linearize (e.g. general nonlinear).
             # Omitting it makes the LP feasible region larger → still a valid lower bound.
-            logger.debug("AMP: omitting constraint (cannot linearize): %s", err)
+            logger.warning(
+                "AMP: omitting constraint %s from the MILP relaxation because it cannot "
+                "be linearized safely: %s",
+                constraint.name or "<unnamed>",
+                err,
+            )
 
     # ── OA tangent cuts from NLP incumbent ──────────────────────────────────
     # These are outer-approximation linearizations of the original nonlinear
@@ -873,12 +932,20 @@ def build_milp_relaxation(
     obj_expr = model._objective.expression
     try:
         c_obj, const_obj = _linearize_expr(
-            obj_expr, model, bilinear_var_map, monomial_var_map, n_total
+            obj_expr,
+            model,
+            bilinear_var_map,
+            trilinear_var_map,
+            monomial_var_map,
+            n_total,
         )
+        objective_bound_valid = True
     except ValueError:
-        # Fallback: trivial objective (LP gives ‑∞ lower bound — acceptable for soundness)
+        # Keep a feasibility objective so the relaxation can still produce a point,
+        # but do not treat the LP value as a sound global bound.
         c_obj = np.zeros(n_total)
         const_obj = 0.0
+        objective_bound_valid = False
 
     # Negate for maximization
     if model._objective.sense == ObjectiveSense.MAXIMIZE:
@@ -908,11 +975,14 @@ def build_milp_relaxation(
         bounds=all_bounds,
         obj_offset=const_obj,
         integrality=integrality_arr if has_integers else None,
+        objective_bound_valid=objective_bound_valid,
     )
 
     varmap: dict = {
         "original": {k: k for k in range(n_orig)},
         "bilinear": bilinear_var_map,
+        "trilinear": trilinear_var_map,
+        "trilinear_stages": trilinear_stage_map,
         "monomial": monomial_var_map,
         "bilinear_pw": bilinear_pw_map,
         "bilinear_lambda": bilinear_lambda_map,

--- a/python/discopt/_jax/model_utils.py
+++ b/python/discopt/_jax/model_utils.py
@@ -1,0 +1,17 @@
+"""Small helpers shared across JAX-backed solver modules."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from discopt.modeling.core import Model
+
+
+def flat_variable_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
+    """Return flattened lower and upper bounds for all model variables."""
+    lbs: list[float] = []
+    ubs: list[float] = []
+    for v in model._variables:
+        lbs.extend(np.asarray(v.lb, dtype=np.float64).ravel().tolist())
+        ubs.extend(np.asarray(v.ub, dtype=np.float64).ravel().tolist())
+    return np.array(lbs, dtype=np.float64), np.array(ubs, dtype=np.float64)

--- a/python/discopt/_jax/partition_selection.py
+++ b/python/discopt/_jax/partition_selection.py
@@ -129,11 +129,7 @@ def _solve_vertex_cover_milp(
         heavy = 1.0 if not positive else 1.0 / min(positive)
         c = np.array(
             [
-                (
-                    heavy
-                    if abs(float(weights.get(v, 0.0))) <= 1e-6
-                    else 1.0 / abs(float(weights[v]))
-                )
+                (heavy if abs(float(weights.get(v, 0.0))) <= 1e-6 else 1.0 / abs(float(weights[v])))
                 for v in candidates
             ],
             dtype=np.float64,
@@ -158,9 +154,7 @@ def _solve_vertex_cover_milp(
             nonzero_cols = np.array(
                 [i for i in range(n) if A_le[row_idx, i] != 0.0], dtype=np.int32
             )
-            vals = np.array(
-                [A_le[row_idx, i] for i in nonzero_cols], dtype=np.float64
-            )
+            vals = np.array([A_le[row_idx, i] for i in nonzero_cols], dtype=np.float64)
             h.addRow(-np.inf, float(b_le[row_idx]), len(nonzero_cols), nonzero_cols, vals)
 
         h.run()

--- a/python/discopt/_jax/partition_selection.py
+++ b/python/discopt/_jax/partition_selection.py
@@ -118,6 +118,7 @@ def _solve_vertex_cover_milp(
                 A[row_idx, var_to_col[v]] = 1.0
 
     # Objective: minimize sum(y) or a weighted cover objective.
+    c: np.ndarray
     if weights is None:
         c = np.ones(n, dtype=np.float64)
     else:
@@ -144,6 +145,7 @@ def _solve_vertex_cover_milp(
 
         h = highspy.Highs()
         h.silent()
+        h.setOptionValue("time_limit", 30.0)
 
         # Add binary variables (y_v ∈ {0,1} for each candidate)
         for i in range(n):
@@ -158,15 +160,21 @@ def _solve_vertex_cover_milp(
             h.addRow(-np.inf, float(b_le[row_idx]), len(nonzero_cols), nonzero_cols, vals)
 
         h.run()
+        model_status = h.getModelStatus()
+        if model_status != highspy.HighsModelStatus.kOptimal:
+            greedy = _greedy_vertex_cover(candidates, valid_terms, weights=weights)
+            return greedy if greedy else list(dict.fromkeys(candidates))
 
         sol = h.getSolution()
         y = np.array(sol.col_value[:n])
         selected = [candidates[i] for i in range(n) if y[i] > 0.5]
+        selected_set = set(selected)
 
         # Verify coverage (fallback to max_cover if something went wrong)
         for term in valid_terms:
-            if not any(v in set(selected) for v in term):
-                return list(dict.fromkeys(candidates))  # max_cover fallback
+            if not any(v in selected_set for v in term):
+                greedy = _greedy_vertex_cover(candidates, valid_terms, weights=weights)
+                return greedy if greedy else list(dict.fromkeys(candidates))
 
         return selected
 

--- a/python/discopt/_jax/partition_selection.py
+++ b/python/discopt/_jax/partition_selection.py
@@ -210,8 +210,8 @@ def _greedy_vertex_cover(
                 score = float(count)
             else:
                 dist = abs(float(weights.get(v, 0.0)))
-                penalty = 1.0 / max(dist, 1e-6)
-                score = float(count) / penalty
+                weight = max(dist, 1e-6)
+                score = float(count) * weight
 
             if score > best_score:
                 best_score = score

--- a/python/discopt/_jax/partition_selection.py
+++ b/python/discopt/_jax/partition_selection.py
@@ -63,13 +63,34 @@ def _min_vertex_cover(terms: NonlinearTerms) -> list[int]:
     try:
         return _solve_vertex_cover_milp(candidates, all_t)
     except Exception:
-        # Fallback: use max_cover if MILP fails
+        greedy = _greedy_vertex_cover(candidates, all_t)
+        return greedy if greedy else candidates
+
+
+def _weighted_min_vertex_cover(
+    terms: NonlinearTerms,
+    distance: dict[int, float],
+) -> list[int]:
+    """Weighted minimum vertex cover using Alpine-style incumbent distance scores."""
+    all_t = _all_terms(terms)
+    candidates = list(terms.partition_candidates)
+
+    if not candidates or not all_t:
+        return []
+    if len(candidates) <= 2:
         return candidates
+
+    try:
+        return _solve_vertex_cover_milp(candidates, all_t, weights=distance)
+    except Exception:
+        greedy = _greedy_vertex_cover(candidates, all_t, weights=distance)
+        return greedy if greedy else candidates
 
 
 def _solve_vertex_cover_milp(
     candidates: list[int],
     terms: list[tuple[int, ...]],
+    weights: dict[int, float] | None = None,
 ) -> list[int]:
     """Solve the minimum vertex cover as a MILP using HiGHS.
 
@@ -96,12 +117,27 @@ def _solve_vertex_cover_milp(
             if v in var_to_col:
                 A[row_idx, var_to_col[v]] = 1.0
 
-    # Objective: minimize sum(y)
-    c = np.ones(n, dtype=np.float64)
-
-    # Bounds: y ∈ [0, 1]
-    lb = np.zeros(n, dtype=np.float64)
-    ub = np.ones(n, dtype=np.float64)
+    # Objective: minimize sum(y) or a weighted cover objective.
+    if weights is None:
+        c = np.ones(n, dtype=np.float64)
+    else:
+        positive = [
+            abs(float(weights.get(v, 0.0)))
+            for v in candidates
+            if abs(float(weights.get(v, 0.0))) > 0.0
+        ]
+        heavy = 1.0 if not positive else 1.0 / min(positive)
+        c = np.array(
+            [
+                (
+                    heavy
+                    if abs(float(weights.get(v, 0.0))) <= 1e-6
+                    else 1.0 / abs(float(weights[v]))
+                )
+                for v in candidates
+            ],
+            dtype=np.float64,
+        )
 
     # Convert A >= 1 to standard form: -A @ y <= -1
     A_le = -A
@@ -141,16 +177,19 @@ def _solve_vertex_cover_milp(
         return selected
 
     except ImportError:
-        # HiGHS not available; use greedy max-cover
-        return list(dict.fromkeys(candidates))
+        greedy = _greedy_vertex_cover(candidates, valid_terms, weights=weights)
+        return greedy if greedy else list(dict.fromkeys(candidates))
 
 
-def _greedy_vertex_cover(candidates: list[int], terms: list[tuple[int, ...]]) -> list[int]:
+def _greedy_vertex_cover(
+    candidates: list[int],
+    terms: list[tuple[int, ...]],
+    weights: dict[int, float] | None = None,
+) -> list[int]:
     """Greedy vertex cover: repeatedly pick the variable covering the most uncovered terms.
 
     O(n * m) but good approximation for small instances.
     """
-    covered = set()
     selected = []
     term_set = [set(t) for t in terms]
     n_terms = len(term_set)
@@ -159,15 +198,25 @@ def _greedy_vertex_cover(candidates: list[int], terms: list[tuple[int, ...]]) ->
     while uncovered:
         # Find variable with most coverage
         best_var = None
-        best_count = -1
+        best_score = -1.0
         for v in candidates:
             if v in selected:
                 continue
             count = sum(1 for idx in uncovered if v in term_set[idx])
-            if count > best_count:
-                best_count = count
+            if count <= 0:
+                continue
+
+            if weights is None:
+                score = float(count)
+            else:
+                dist = abs(float(weights.get(v, 0.0)))
+                penalty = 1.0 / max(dist, 1e-6)
+                score = float(count) / penalty
+
+            if score > best_score:
+                best_score = score
                 best_var = v
-        if best_var is None or best_count == 0:
+        if best_var is None or best_score <= 0.0:
             break
         selected.append(best_var)
         newly_covered = {idx for idx in uncovered if best_var in term_set[idx]}
@@ -176,7 +225,11 @@ def _greedy_vertex_cover(candidates: list[int], terms: list[tuple[int, ...]]) ->
     return selected
 
 
-def pick_partition_vars(terms: NonlinearTerms, method: str = "auto") -> list[int]:
+def pick_partition_vars(
+    terms: NonlinearTerms,
+    method: str = "auto",
+    distance: dict[int, float] | None = None,
+) -> list[int]:
     """Select variables to partition for the AMP relaxation.
 
     Parameters
@@ -188,6 +241,8 @@ def pick_partition_vars(terms: NonlinearTerms, method: str = "auto") -> list[int
         - ``"max_cover"``: all variables appearing in any nonlinear term.
         - ``"min_vertex_cover"``: minimum set covering all terms (MILP-based).
         - ``"auto"``: max_cover if ≤15 candidates, else min_vertex_cover.
+        - ``"adaptive_vertex_cover"``: Alpine-style weighted cover using incumbent
+          distances when available, else falls back to ``"auto"``.
 
     Returns
     -------
@@ -207,8 +262,13 @@ def pick_partition_vars(terms: NonlinearTerms, method: str = "auto") -> list[int
             return _max_cover(terms)
         else:
             return _min_vertex_cover(terms)
+    elif method == "adaptive_vertex_cover":
+        if len(terms.partition_candidates) <= 15 or not distance:
+            return _max_cover(terms)
+        return _weighted_min_vertex_cover(terms, distance)
     else:
         raise ValueError(
             f"Unknown variable selection method: {method!r}. "
-            "Choose from 'max_cover', 'min_vertex_cover', 'auto'."
+            "Choose from 'max_cover', 'min_vertex_cover', 'auto', "
+            "'adaptive_vertex_cover'."
         )

--- a/python/discopt/_jax/partition_selection.py
+++ b/python/discopt/_jax/partition_selection.py
@@ -1,0 +1,214 @@
+"""
+Variable Selection for AMP (Adaptive Multivariate Partitioning).
+
+Implements two strategies from JOGO 2018 for choosing which variables to partition:
+
+1. max_cover: Partition ALL variables appearing in any nonlinear term.
+   Gives the tightest relaxation but introduces more binary variables in the MILP.
+
+2. min_vertex_cover: Find the MINIMUM set of variables such that every nonlinear
+   term contains at least one selected variable.  Solved as a small MILP.
+   Reduces the number of binary variables introduced, keeping the relaxation MILP
+   tractable for large problems.
+
+3. auto: Use max_cover when ≤15 candidates, otherwise min_vertex_cover.
+
+Theory:
+  Nagarajan et al., JOGO 2018 (Section 3.2):
+  "We use a greedy max-cover heuristic or a minimum vertex cover on the interaction
+   graph to decide which variables to discretize."
+"""
+
+from __future__ import annotations
+
+from discopt._jax.term_classifier import NonlinearTerms
+
+
+def _all_terms(terms: NonlinearTerms) -> list[tuple[int, ...]]:
+    """Flatten all nonlinear terms (bilinear + trilinear) into a single list."""
+    all_t: list[tuple[int, ...]] = []
+    all_t.extend(terms.bilinear)
+    all_t.extend(terms.trilinear)
+    return all_t
+
+
+def _max_cover(terms: NonlinearTerms) -> list[int]:
+    """Return all partition candidates (max-cover strategy)."""
+    return list(terms.partition_candidates)
+
+
+def _min_vertex_cover(terms: NonlinearTerms) -> list[int]:
+    """Minimum vertex cover of the term-variable interaction graph.
+
+    Formulation (integer program):
+        min  sum(y_v for v in candidates)
+        s.t. sum(y_v for v in term) >= 1   for each nonlinear term
+             y_v in {0, 1}
+
+    Solved using HiGHS (via highspy or discopt's MILP wrapper).
+    Falls back to max_cover if HiGHS is not available.
+    """
+    all_t = _all_terms(terms)
+    candidates = list(terms.partition_candidates)
+
+    # Trivial cases
+    if not candidates:
+        return []
+    if not all_t:
+        return []
+    if len(candidates) <= 2:
+        # With ≤2 variables, max_cover and min_vertex_cover are the same
+        return candidates
+
+    try:
+        return _solve_vertex_cover_milp(candidates, all_t)
+    except Exception:
+        # Fallback: use max_cover if MILP fails
+        return candidates
+
+
+def _solve_vertex_cover_milp(
+    candidates: list[int],
+    terms: list[tuple[int, ...]],
+) -> list[int]:
+    """Solve the minimum vertex cover as a MILP using HiGHS.
+
+    Variables: y_v ∈ {0,1} for each candidate v
+    Objective: min sum(y_v)
+    Constraints: for each term t: sum(y_v for v in t ∩ candidates) >= 1
+    """
+    import numpy as np
+
+    n = len(candidates)
+    var_to_col = {v: i for i, v in enumerate(candidates)}
+
+    # Build constraint matrix: one row per term
+    valid_terms = [t for t in terms if any(v in var_to_col for v in t)]
+    m_rows = len(valid_terms)
+
+    if m_rows == 0:
+        return []
+
+    # Coefficients for the covering constraints: A @ y >= 1
+    A = np.zeros((m_rows, n), dtype=np.float64)
+    for row_idx, term in enumerate(valid_terms):
+        for v in term:
+            if v in var_to_col:
+                A[row_idx, var_to_col[v]] = 1.0
+
+    # Objective: minimize sum(y)
+    c = np.ones(n, dtype=np.float64)
+
+    # Bounds: y ∈ [0, 1]
+    lb = np.zeros(n, dtype=np.float64)
+    ub = np.ones(n, dtype=np.float64)
+
+    # Convert A >= 1 to standard form: -A @ y <= -1
+    A_le = -A
+    b_le = -np.ones(m_rows, dtype=np.float64)
+
+    try:
+        import highspy
+
+        h = highspy.Highs()
+        h.silent()
+
+        # Add binary variables (y_v ∈ {0,1} for each candidate)
+        for i in range(n):
+            h.addBinary(obj=c[i])  # binary + set objective coefficient
+
+        # Add covering constraints: -A @ y <= -1  (i.e., A @ y >= 1)
+        for row_idx in range(m_rows):
+            nonzero_cols = np.array(
+                [i for i in range(n) if A_le[row_idx, i] != 0.0], dtype=np.int32
+            )
+            vals = np.array(
+                [A_le[row_idx, i] for i in nonzero_cols], dtype=np.float64
+            )
+            h.addRow(-np.inf, float(b_le[row_idx]), len(nonzero_cols), nonzero_cols, vals)
+
+        h.run()
+
+        sol = h.getSolution()
+        y = np.array(sol.col_value[:n])
+        selected = [candidates[i] for i in range(n) if y[i] > 0.5]
+
+        # Verify coverage (fallback to max_cover if something went wrong)
+        for term in valid_terms:
+            if not any(v in set(selected) for v in term):
+                return list(dict.fromkeys(candidates))  # max_cover fallback
+
+        return selected
+
+    except ImportError:
+        # HiGHS not available; use greedy max-cover
+        return list(dict.fromkeys(candidates))
+
+
+def _greedy_vertex_cover(candidates: list[int], terms: list[tuple[int, ...]]) -> list[int]:
+    """Greedy vertex cover: repeatedly pick the variable covering the most uncovered terms.
+
+    O(n * m) but good approximation for small instances.
+    """
+    covered = set()
+    selected = []
+    term_set = [set(t) for t in terms]
+    n_terms = len(term_set)
+    uncovered = set(range(n_terms))
+
+    while uncovered:
+        # Find variable with most coverage
+        best_var = None
+        best_count = -1
+        for v in candidates:
+            if v in selected:
+                continue
+            count = sum(1 for idx in uncovered if v in term_set[idx])
+            if count > best_count:
+                best_count = count
+                best_var = v
+        if best_var is None or best_count == 0:
+            break
+        selected.append(best_var)
+        newly_covered = {idx for idx in uncovered if best_var in term_set[idx]}
+        uncovered -= newly_covered
+
+    return selected
+
+
+def pick_partition_vars(terms: NonlinearTerms, method: str = "auto") -> list[int]:
+    """Select variables to partition for the AMP relaxation.
+
+    Parameters
+    ----------
+    terms : NonlinearTerms
+        Output of classify_nonlinear_terms(model).
+    method : str, default "auto"
+        Variable selection strategy:
+        - ``"max_cover"``: all variables appearing in any nonlinear term.
+        - ``"min_vertex_cover"``: minimum set covering all terms (MILP-based).
+        - ``"auto"``: max_cover if ≤15 candidates, else min_vertex_cover.
+
+    Returns
+    -------
+    list[int]
+        Flat variable indices selected for partitioning. Guaranteed to cover
+        every bilinear and trilinear term (i.e., each term has ≥1 selected var).
+    """
+    if not terms.partition_candidates:
+        return []
+
+    if method == "max_cover":
+        return _max_cover(terms)
+    elif method == "min_vertex_cover":
+        return _min_vertex_cover(terms)
+    elif method == "auto":
+        if len(terms.partition_candidates) <= 15:
+            return _max_cover(terms)
+        else:
+            return _min_vertex_cover(terms)
+    else:
+        raise ValueError(
+            f"Unknown variable selection method: {method!r}. "
+            "Choose from 'max_cover', 'min_vertex_cover', 'auto'."
+        )

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -184,11 +184,12 @@ def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
                 result.term_incidence.setdefault(v, set()).add(term_idx)
 
     def _record_trilinear(i: int, j: int, k: int) -> None:
-        key = tuple(sorted([i, j, k]))
+        a, b, c = sorted((i, j, k))
+        key = (a, b, c)
         if key not in seen_trilinear:
             seen_trilinear.add(key)
             term_idx = len(result.bilinear) + len(result.trilinear)
-            result.trilinear.append(key)  # type: ignore[arg-type]
+            result.trilinear.append(key)
             for v in key:
                 result.term_incidence.setdefault(v, set()).add(term_idx)
 

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -1,0 +1,345 @@
+"""
+Nonlinear Term Classifier for AMP (Adaptive Multivariate Partitioning).
+
+Walks the expression DAG of a Model and catalogs nonlinear term structure:
+  - bilinear terms:   x_i * x_j  (two distinct continuous variables)
+  - trilinear terms:  x_i * x_j * x_k  (three distinct continuous variables)
+  - monomial terms:   x_i^n  (single variable raised to integer power n ≥ 2)
+  - general_nl:       all other nonlinearities (sin, cos, exp, log, etc.)
+
+This catalog drives:
+  1. Variable selection for partitioning (which variables appear in nonlinear terms)
+  2. MILP relaxation construction (which terms get McCormick / lambda constraints)
+  3. Interaction graph for min-vertex-cover variable selection
+
+Theory references:
+  - Nagarajan et al., CP 2016: http://harshangrjn.github.io/pdf/CP_2016.pdf
+  - Nagarajan et al., JOGO 2018: http://harshangrjn.github.io/pdf/JOGO_2018.pdf
+  - Alpine.jl operators.jl / nlexpr.jl
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Expression,
+    FunctionCall,
+    IndexExpression,
+    MatMulExpression,
+    Model,
+    SumExpression,
+    SumOverExpression,
+    UnaryOp,
+    Variable,
+)
+
+# ---------------------------------------------------------------------------
+# Data structure
+# ---------------------------------------------------------------------------
+
+# Flat variable index type alias for clarity
+_VarIdx = int
+
+
+@dataclass
+class NonlinearTerms:
+    """Catalog of nonlinear term structure for AMP.
+
+    Attributes
+    ----------
+    bilinear : list of (int, int)
+        Each entry is a pair of flat variable indices (i, j) for a term x_i * x_j.
+        The pair is always sorted (i <= j) to avoid duplicates.
+    trilinear : list of (int, int, int)
+        Each entry is a sorted triple of flat variable indices for x_i * x_j * x_k.
+    monomial : list of (int, int)
+        Each entry is (var_idx, exponent) for x_i^n, n integer ≥ 2.
+    general_nl : list of Expression
+        Nonlinear expression nodes that are neither bilinear, trilinear, nor monomial
+        (e.g., sin, cos, exp, log, sqrt, tan, abs).
+    term_incidence : dict[int, set[int]]
+        Maps flat variable index → set of term indices (into the combined bilinear +
+        trilinear list) that the variable appears in.  Used for vertex-cover computation.
+    partition_candidates : list[int]
+        Sorted list of flat variable indices appearing in any bilinear or trilinear term.
+        These are the candidates for domain partitioning in AMP.
+        (Monomials are convex/treated separately; general_nl may also be candidates
+        but are currently excluded from partitioning as AMP focuses on polynomial terms.)
+    """
+
+    bilinear: list[tuple[_VarIdx, _VarIdx]] = field(default_factory=list)
+    trilinear: list[tuple[_VarIdx, _VarIdx, _VarIdx]] = field(default_factory=list)
+    monomial: list[tuple[_VarIdx, int]] = field(default_factory=list)
+    general_nl: list[Expression] = field(default_factory=list)
+    term_incidence: dict[_VarIdx, set[int]] = field(default_factory=dict)
+    partition_candidates: list[_VarIdx] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: flat index extraction
+# ---------------------------------------------------------------------------
+
+
+def _compute_var_offset(var: Variable, model: Model) -> int:
+    """Compute the starting flat index of a variable in the stacked x vector."""
+    offset = 0
+    for v in model._variables[: var._index]:
+        offset += v.size
+    return offset
+
+
+def _get_flat_index(expr: Expression, model: Model) -> int | None:
+    """Return the flat variable index for a scalar Variable or IndexExpression.
+
+    Returns None if the expression is not a scalar variable reference.
+    """
+    if isinstance(expr, Variable):
+        if expr.size == 1:
+            return _compute_var_offset(expr, model)
+        return None  # multi-element variable without index — can't reduce to scalar
+    if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
+        base_off = _compute_var_offset(expr.base, model)
+        idx = expr.index
+        if isinstance(idx, int):
+            return base_off + idx
+        if isinstance(idx, tuple) and len(idx) == 1 and isinstance(idx[0], int):
+            return base_off + idx[0]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers: product-tree decomposition
+# ---------------------------------------------------------------------------
+
+
+def _collect_product_factors(expr: Expression, model: Model) -> list[int] | None:
+    """Try to decompose a pure product tree into a list of flat variable indices.
+
+    Handles: Variable * Variable, (Var * Var) * Var, Var[i] * Var[j], etc.
+    Returns None if the expression contains non-variable leaves (e.g., constants,
+    general functions).  Constant scale factors are NOT handled here — they belong
+    in the coefficient extraction, not term classification.
+    """
+    indices: list[int] = []
+
+    def _visit(e: Expression) -> bool:
+        if isinstance(e, BinaryOp) and e.op == "*":
+            return _visit(e.left) and _visit(e.right)
+        flat = _get_flat_index(e, model)
+        if flat is not None:
+            indices.append(flat)
+            return True
+        # Constant multiplier: skip it (treat as scaling, not a new variable)
+        if isinstance(e, Constant):
+            return True
+        return False
+
+    if _visit(expr):
+        # Filter out duplicates introduced by constants (empty index list)
+        var_indices = indices  # may have duplicates if e.g. x*x
+        if len(var_indices) >= 2:
+            return var_indices
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main classifier
+# ---------------------------------------------------------------------------
+
+
+def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
+    """Walk the model's expression DAG and catalog nonlinear term structure.
+
+    Scans all constraints and the objective.  Each unique bilinear/trilinear/monomial
+    pattern is recorded at most once (deduplicated by sorted variable index tuple).
+
+    Parameters
+    ----------
+    model : Model
+        A discopt Model with objective and constraints set.
+
+    Returns
+    -------
+    NonlinearTerms
+        Catalog of nonlinear terms ready for AMP partitioning.
+    """
+    result = NonlinearTerms()
+
+    # Track seen terms to avoid duplicates
+    seen_bilinear: set[tuple[int, int]] = set()
+    seen_trilinear: set[tuple[int, int, int]] = set()
+    seen_monomial: set[tuple[int, int]] = set()
+
+    def _record_bilinear(i: int, j: int) -> None:
+        key = (min(i, j), max(i, j))
+        if key not in seen_bilinear:
+            seen_bilinear.add(key)
+            term_idx = len(result.bilinear) + len(result.trilinear)
+            result.bilinear.append(key)
+            # Update term incidence
+            for v in key:
+                result.term_incidence.setdefault(v, set()).add(term_idx)
+
+    def _record_trilinear(i: int, j: int, k: int) -> None:
+        key = tuple(sorted([i, j, k]))
+        if key not in seen_trilinear:
+            seen_trilinear.add(key)
+            term_idx = len(result.bilinear) + len(result.trilinear)
+            result.trilinear.append(key)  # type: ignore[arg-type]
+            for v in key:
+                result.term_incidence.setdefault(v, set()).add(term_idx)
+
+    def _record_monomial(var_idx: int, exp: int) -> None:
+        key = (var_idx, exp)
+        if key not in seen_monomial:
+            seen_monomial.add(key)
+            result.monomial.append(key)
+
+    def _classify_node(expr: Expression) -> None:
+        """Recursively classify all nonlinear nodes in the expression tree."""
+        if isinstance(expr, Constant):
+            return
+
+        if isinstance(expr, Variable):
+            return  # bare variable — linear
+
+        if isinstance(expr, IndexExpression):
+            # x[i] — linear leaf; recurse into base only if it's something unusual
+            if not isinstance(expr.base, Variable):
+                _classify_node(expr.base)
+            return
+
+        if isinstance(expr, BinaryOp):
+            # ── Power: x**n ──
+            if expr.op == "**":
+                flat = _get_flat_index(expr.left, model)
+                if flat is not None and isinstance(expr.right, Constant):
+                    exp_val = float(expr.right.value)
+                    if exp_val == int(exp_val) and int(exp_val) >= 2:
+                        _record_monomial(flat, int(exp_val))
+                        return
+                    elif exp_val != 1.0:
+                        # Non-integer or non-trivial exponent → general nonlinear
+                        result.general_nl.append(expr)
+                        return
+                # Recurse for complex bases
+                _classify_node(expr.left)
+                _classify_node(expr.right)
+                return
+
+            # ── Multiplication: try product-tree decomposition ──
+            if expr.op == "*":
+                factors = _collect_product_factors(expr, model)
+                if factors is not None:
+                    unique_vars = list(dict.fromkeys(factors))  # preserve order, remove dups
+                    n_unique = len(unique_vars)
+                    if n_unique == 1:
+                        # x * x = x^2 → monomial
+                        _record_monomial(unique_vars[0], factors.count(unique_vars[0]))
+                        return
+                    elif n_unique == 2:
+                        # Check if any var appears twice → monomial
+                        counts = {v: factors.count(v) for v in unique_vars}
+                        if any(c >= 2 for c in counts.values()):
+                            for v, c in counts.items():
+                                if c >= 2:
+                                    _record_monomial(v, c)
+                            # The other var is a separate multiplier — treat whole as bilinear-like
+                            # e.g. x^2 * y: still bilinear between (x_squared, y)
+                            # For simplicity, record as bilinear
+                            _record_bilinear(unique_vars[0], unique_vars[1])
+                        else:
+                            _record_bilinear(unique_vars[0], unique_vars[1])
+                        return
+                    elif n_unique == 3:
+                        _record_trilinear(unique_vars[0], unique_vars[1], unique_vars[2])
+                        return
+                    else:
+                        # Higher-order multilinear — decompose into bilinear pairs
+                        # (AMP handles multilinear via repeated bilinear decomposition)
+                        for ii in range(len(unique_vars)):
+                            for jj in range(ii + 1, len(unique_vars)):
+                                _record_bilinear(unique_vars[ii], unique_vars[jj])
+                        return
+                # If product decomposition failed, recurse on children
+                _classify_node(expr.left)
+                _classify_node(expr.right)
+                return
+
+            # ── Other binary ops: +, -, / ──
+            if expr.op in ("+", "-"):
+                _classify_node(expr.left)
+                _classify_node(expr.right)
+                return
+
+            if expr.op == "/":
+                # x / c where c is constant → linear scaling
+                if isinstance(expr.right, Constant):
+                    _classify_node(expr.left)
+                    return
+                # c / x or x / y → general nonlinear
+                result.general_nl.append(expr)
+                return
+
+            # Fallthrough: recurse
+            _classify_node(expr.left)
+            _classify_node(expr.right)
+            return
+
+        if isinstance(expr, UnaryOp):
+            if expr.op == "neg":
+                _classify_node(expr.operand)
+                return
+            # abs → nonlinear
+            result.general_nl.append(expr)
+            return
+
+        if isinstance(expr, FunctionCall):
+            # All named functions are considered nonlinear (transcendental)
+            # sin, cos, exp, log, sqrt, tan, etc.
+            result.general_nl.append(expr)
+            # Recurse into arguments (they might contain bilinear sub-expressions)
+            for arg in expr.args:
+                _classify_node(arg)
+            return
+
+        if isinstance(expr, SumExpression):
+            _classify_node(expr.operand)
+            return
+
+        if isinstance(expr, SumOverExpression):
+            for term in expr.terms:
+                _classify_node(term)
+            return
+
+        if isinstance(expr, MatMulExpression):
+            # A @ x is linear if A is constant — recurse for safety
+            _classify_node(expr.left)
+            _classify_node(expr.right)
+            return
+
+    # ── Scan objective ──
+    if model._objective is not None:
+        _classify_node(model._objective.expression)
+
+    # ── Scan constraints ──
+    for constraint in model._constraints:
+        _classify_node(constraint.body)
+
+    # ── Build partition_candidates ──
+    # Variables that appear in bilinear or trilinear terms (not just monomials,
+    # since x^2 is convex and handled by alphaBB/direct secant).
+    candidates: set[int] = set()
+    for i, j in result.bilinear:
+        candidates.add(i)
+        candidates.add(j)
+    for i, j, k in result.trilinear:
+        candidates.add(i)
+        candidates.add(j)
+        candidates.add(k)
+    result.partition_candidates = sorted(candidates)
+
+    return result

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -237,23 +237,23 @@ def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
                 if factors is not None:
                     unique_vars = list(dict.fromkeys(factors))  # preserve order, remove dups
                     n_unique = len(unique_vars)
+                    counts = {v: factors.count(v) for v in unique_vars}
                     if n_unique == 1:
                         # x * x = x^2 → monomial
-                        _record_monomial(unique_vars[0], factors.count(unique_vars[0]))
+                        _record_monomial(unique_vars[0], counts[unique_vars[0]])
                         return
-                    elif n_unique == 2:
-                        # Check if any var appears twice → monomial
-                        counts = {v: factors.count(v) for v in unique_vars}
-                        if any(c >= 2 for c in counts.values()):
-                            for v, c in counts.items():
-                                if c >= 2:
-                                    _record_monomial(v, c)
-                            # The other var is a separate multiplier — treat whole as bilinear-like
-                            # e.g. x^2 * y: still bilinear between (x_squared, y)
-                            # For simplicity, record as bilinear
-                            _record_bilinear(unique_vars[0], unique_vars[1])
-                        else:
-                            _record_bilinear(unique_vars[0], unique_vars[1])
+                    if any(c >= 2 for c in counts.values()):
+                        # Mixed repeated-factor products such as x*x*y are not
+                        # represented correctly by the current bilinear/trilinear
+                        # relaxation pipeline. Keep the whole product in general_nl
+                        # and recurse so nested pure monomials like x*x are still
+                        # discovered on their own subexpressions.
+                        result.general_nl.append(expr)
+                        _classify_node(expr.left)
+                        _classify_node(expr.right)
+                        return
+                    if n_unique == 2:
+                        _record_bilinear(unique_vars[0], unique_vars[1])
                         return
                     elif n_unique == 3:
                         _record_trilinear(unique_vars[0], unique_vars[1], unique_vars[2])

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -818,8 +818,9 @@ class SolveResult:
     Attributes
     ----------
     status : str
-        Termination status. One of ``"optimal"``, ``"feasible"``,
-        ``"infeasible"``, ``"time_limit"``, ``"node_limit"``.
+        Termination status. Typical values are ``"optimal"``, ``"feasible"``,
+        ``"infeasible"``, ``"time_limit"``, ``"node_limit"``,
+        ``"iteration_limit"``, and ``"error"``.
     objective : float or None
         Best objective value found (None if infeasible).
     bound : float or None

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1791,6 +1791,7 @@ class Model:
         lazy_constraints: Optional[Callable] = None,
         incumbent_callback: Optional[Callable] = None,
         node_callback: Optional[Callable] = None,
+        solver: Optional[str] = None,
         **kwargs,
     ) -> Union[SolveResult, Iterator["SolveUpdate"]]:
         r"""
@@ -1894,6 +1895,9 @@ class Model:
             )
 
         from discopt.solver import solve_model
+
+        if solver is not None:
+            kwargs["solver"] = solver
 
         result = solve_model(
             self,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1231,6 +1231,35 @@ def solve_model(
             stacklevel=2,
         )
 
+    # --- AMP (Adaptive Multivariate Partitioning) global solver ---
+    _solver = kwargs.pop("solver", None)
+    if _solver == "amp":
+        from discopt.solvers.amp import solve_amp
+
+        amp_kwargs = {}
+        for key in (
+            "rel_gap",
+            "max_iter",
+            "n_init_partitions",
+            "partition_method",
+            "iteration_callback",
+            "milp_time_limit",
+            "milp_gap_tolerance",
+        ):
+            if key in kwargs:
+                amp_kwargs[key] = kwargs.pop(key)
+
+        # rel_gap defaults to gap_tolerance if not separately provided
+        if "rel_gap" not in amp_kwargs:
+            amp_kwargs["rel_gap"] = gap_tolerance
+
+        return solve_amp(
+            model,
+            time_limit=time_limit,
+            nlp_solver=nlp_solver,
+            **amp_kwargs,
+        )
+
     # --- OA decomposition: general-purpose Outer Approximation ---
     if gdp_method == "oa":
         from discopt.solvers.oa import solve_oa

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1239,12 +1239,19 @@ def solve_model(
         amp_kwargs = {}
         for key in (
             "rel_gap",
+            "abs_tol",
             "max_iter",
             "n_init_partitions",
             "partition_method",
             "iteration_callback",
             "milp_time_limit",
             "milp_gap_tolerance",
+            "apply_partitioning",
+            "disc_var_pick",
+            "partition_scaling_factor",
+            "disc_add_partition_method",
+            "disc_abs_width_tol",
+            "convhull_formulation",
         ):
             if key in kwargs:
                 amp_kwargs[key] = kwargs.pop(key)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1143,6 +1143,7 @@ def solve_model(
     lazy_constraints=None,
     incumbent_callback=None,
     node_callback=None,
+    solver: Optional[str] = None,
     use_highs_milp: bool = True,
     **kwargs,
 ) -> SolveResult:
@@ -1208,6 +1209,9 @@ def solve_model(
     gdp_method : str, default "big-m"
         Reformulation method for disjunctive constraints:
         ``"big-m"`` (default) or ``"hull"`` (convex hull).
+    solver : str or None, default None
+        Optional global-solver selector. Use ``"amp"`` to dispatch to
+        Adaptive Multivariate Partitioning instead of branch-and-bound.
 
     Returns
     -------
@@ -1232,7 +1236,7 @@ def solve_model(
         )
 
     # --- AMP (Adaptive Multivariate Partitioning) global solver ---
-    _solver = kwargs.pop("solver", None)
+    _solver = solver if solver is not None else kwargs.pop("solver", None)
     if _solver == "amp":
         from discopt.solvers.amp import solve_amp
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1238,10 +1238,12 @@ def solve_model(
     # --- AMP (Adaptive Multivariate Partitioning) global solver ---
     _solver = solver if solver is not None else kwargs.pop("solver", None)
     if _solver == "amp":
+        import warnings
+
         from discopt.solvers.amp import solve_amp
 
         amp_kwargs = {}
-        for key in (
+        amp_option_keys = (
             "rel_gap",
             "abs_tol",
             "max_iter",
@@ -1256,9 +1258,45 @@ def solve_model(
             "disc_add_partition_method",
             "disc_abs_width_tol",
             "convhull_formulation",
-        ):
+        )
+        for key in amp_option_keys:
             if key in kwargs:
                 amp_kwargs[key] = kwargs.pop(key)
+
+        ignored_amp_options = []
+
+        def _note_ignored(name: str, should_warn: bool) -> None:
+            if should_warn:
+                ignored_amp_options.append(name)
+
+        _note_ignored("threads", threads != 1)
+        _note_ignored("deterministic", deterministic is not True)
+        _note_ignored("batch_size", batch_size != 16)
+        _note_ignored("strategy", strategy != "best_first")
+        _note_ignored("max_nodes", max_nodes != 100_000)
+        _note_ignored("ipopt_options", ipopt_options is not None)
+        _note_ignored("sparse", sparse is not None)
+        _note_ignored("cutting_planes", cutting_planes is not False)
+        _note_ignored("partitions", partitions != 0)
+        _note_ignored("branching_policy", branching_policy != "fractional")
+        _note_ignored("use_learned_relaxations", use_learned_relaxations is not False)
+        _note_ignored("mccormick_bounds", mccormick_bounds != "auto")
+        _note_ignored("gdp_method", gdp_method != "big-m")
+        _note_ignored("initial_point", initial_point is not None)
+        _note_ignored("skip_convex_check", skip_convex_check is not False)
+        _note_ignored("nlp_bb", nlp_bb is not None)
+        _note_ignored("lazy_constraints", lazy_constraints is not None)
+        _note_ignored("incumbent_callback", incumbent_callback is not None)
+        _note_ignored("node_callback", node_callback is not None)
+        _note_ignored("use_highs_milp", use_highs_milp is not True)
+        if kwargs:
+            ignored_amp_options.extend(sorted(kwargs))
+        if ignored_amp_options:
+            warnings.warn(
+                "AMP ignores solve_model options: "
+                + ", ".join(sorted(dict.fromkeys(ignored_amp_options))),
+                stacklevel=2,
+            )
 
         # rel_gap defaults to gap_tolerance if not separately provided
         if "rel_gap" not in amp_kwargs:

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -241,6 +241,8 @@ def _solve_best_nlp_candidate(
         )
         if cand_x is None or cand_obj is None:
             continue
+        if not _check_integer_feasible(cand_x, model):
+            continue
         if not _check_constraints_with_evaluator(
             evaluator,
             cand_x,
@@ -270,7 +272,11 @@ def _solve_milp_with_oa_recovery(
     from discopt._jax.milp_relaxation import build_milp_relaxation
 
     active_oa_cuts = list(oa_cuts or [])
-    while True:
+    max_retries = max(1, len(active_oa_cuts).bit_length() + 1)
+    milp_result = None
+    varmap = None
+
+    for _retry in range(max_retries):
         milp_model, varmap = build_milp_relaxation(
             model,
             terms,
@@ -292,6 +298,10 @@ def _solve_milp_with_oa_recovery(
             drop_count,
         )
         active_oa_cuts = active_oa_cuts[drop_count:]
+
+    assert milp_result is not None
+    assert varmap is not None
+    return milp_result, varmap, active_oa_cuts
 
 
 def _check_constraints(x: np.ndarray, model: Model, tol: float = 1e-4) -> bool:

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -267,6 +267,7 @@ def _solve_milp_with_oa_recovery(
     oa_cuts: Optional[list],
     time_limit: Optional[float],
     gap_tolerance: float,
+    convhull_formulation: str,
 ):
     """Retry MILP solves after dropping the oldest half of OA cuts on infeasibility."""
     from discopt._jax.milp_relaxation import build_milp_relaxation
@@ -283,6 +284,7 @@ def _solve_milp_with_oa_recovery(
             disc_state,
             incumbent,
             oa_cuts=active_oa_cuts,
+            convhull_formulation=convhull_formulation,
         )
         milp_result = milp_model.solve(
             time_limit=time_limit,
@@ -351,6 +353,64 @@ def _default_milp_time_limit(
     return min(iter_budget * 3, remaining * 0.8, 60.0)
 
 
+def _normalize_partition_method(
+    partition_method: str,
+    disc_var_pick: int | str | None,
+) -> str:
+    """Resolve public AMP aliases to the internal partition-selection strategy."""
+    if disc_var_pick is None:
+        return partition_method
+
+    if isinstance(disc_var_pick, str):
+        aliases = {
+            "all": "max_cover",
+            "max_cover": "max_cover",
+            "min_vertex_cover": "min_vertex_cover",
+            "auto": "auto",
+            "adaptive": "adaptive_vertex_cover",
+            "adaptive_vertex_cover": "adaptive_vertex_cover",
+        }
+        if disc_var_pick not in aliases:
+            raise ValueError(
+                f"Unsupported disc_var_pick string: {disc_var_pick!r}. "
+                "Choose from 'all', 'max_cover', 'min_vertex_cover', "
+                "'auto', or 'adaptive_vertex_cover'."
+            )
+        return aliases[disc_var_pick]
+
+    if disc_var_pick == 0:
+        return "max_cover"
+    if disc_var_pick == 1:
+        return "min_vertex_cover"
+    if disc_var_pick == 2:
+        return "auto"
+    if disc_var_pick == 3:
+        return "adaptive_vertex_cover"
+
+    raise ValueError(
+        f"Unsupported disc_var_pick integer: {disc_var_pick!r}. "
+        "Choose from 0, 1, 2, or 3."
+    )
+
+
+def _normalize_convhull_formulation(formulation: str) -> str:
+    """Normalize bilinear convex-hull mode names accepted by the AMP interface."""
+    aliases = {
+        "disaggregated": "disaggregated",
+        "piecewise": "disaggregated",
+        "sos2": "sos2",
+        "facet": "facet",
+        "lambda": "sos2",
+    }
+    try:
+        return aliases[formulation]
+    except KeyError as err:
+        raise ValueError(
+            f"Unsupported convhull_formulation: {formulation!r}. "
+            "Choose from 'disaggregated', 'sos2', 'facet', or 'lambda'."
+        ) from err
+
+
 def _compute_relative_gap(
     abs_gap: Optional[float],
     upper_bound: float,
@@ -385,6 +445,12 @@ def solve_amp(
     iteration_callback: Optional[Callable] = None,
     milp_time_limit: Optional[float] = None,
     milp_gap_tolerance: Optional[float] = None,
+    apply_partitioning: bool = True,
+    disc_var_pick: int | str | None = None,
+    partition_scaling_factor: float = 10.0,
+    disc_add_partition_method: str = "adaptive",
+    disc_abs_width_tol: float = 1e-3,
+    convhull_formulation: str = "disaggregated",
 ) -> SolveResult:
     """Solve MINLP globally using Adaptive Multivariate Partitioning (AMP).
 
@@ -412,6 +478,21 @@ def solve_amp(
         Per-MILP-call time limit (defaults to remaining time).
     milp_gap_tolerance : float
         MILP solver gap tolerance (default 1e-4).
+    apply_partitioning : bool
+        If False, solve a single relaxation/NLP pass without adaptive refinement.
+    disc_var_pick : int | str, optional
+        Alpine-style alias for partition selection:
+        0/``"all"`` → max_cover, 1 → min_vertex_cover, 2 → auto,
+        3 → adaptive weighted cover.
+    partition_scaling_factor : float
+        Width scaling used by adaptive partition refinement.
+    disc_add_partition_method : str
+        Refinement update rule: ``"adaptive"`` or ``"uniform"``.
+    disc_abs_width_tol : float
+        Absolute partition-width convergence tolerance.
+    convhull_formulation : str
+        Piecewise bilinear formulation: ``"disaggregated"``, ``"sos2"``,
+        ``"facet"``, or ``"lambda"`` (alias for ``"sos2"``).
 
     Returns
     -------
@@ -422,6 +503,7 @@ def solve_amp(
 
     from discopt._jax.discretization import (
         add_adaptive_partition,
+        add_uniform_partition,
         check_partition_convergence,
         initialize_partitions,
     )
@@ -432,6 +514,18 @@ def solve_amp(
 
     assert model._objective is not None
     maximize = model._objective.sense == ObjectiveSense.MAXIMIZE
+    part_lbs: list[float] = []
+    part_ubs: list[float] = []
+
+    if partition_scaling_factor <= 1.0:
+        raise ValueError("partition_scaling_factor must be > 1.0")
+    if disc_add_partition_method not in {"adaptive", "uniform"}:
+        raise ValueError(
+            "disc_add_partition_method must be 'adaptive' or 'uniform'"
+        )
+
+    partition_mode = _normalize_partition_method(partition_method, disc_var_pick)
+    convhull_mode = _normalize_convhull_formulation(convhull_formulation)
 
     def _to_minimization_space(value: float) -> float:
         return -float(value) if maximize else float(value)
@@ -455,27 +549,40 @@ def solve_amp(
     )
 
     # ── Select partition variables ───────────────────────────────────────────
-    part_vars = pick_partition_vars(terms, method=partition_method)
+    if apply_partitioning:
+        part_vars = pick_partition_vars(terms, method=partition_mode)
+    else:
+        part_vars = []
 
     # If no bilinear/multilinear terms, still partition monomial variables
     # to add tangent cuts at more points and tighten the lower bound.
-    if not part_vars and terms.monomial:
+    if apply_partitioning and not part_vars and terms.monomial:
         part_vars = sorted(set(var_idx for var_idx, _ in terms.monomial))
         logger.info("AMP: no bilinear terms; partitioning %d monomial vars", len(part_vars))
+    elif not apply_partitioning:
+        logger.info("AMP: partitioning disabled; running a single fixed relaxation pass")
     else:
-        logger.info("AMP: partitioning %d variables via %s", len(part_vars), partition_method)
+        logger.info("AMP: partitioning %d variables via %s", len(part_vars), partition_mode)
 
     # ── Initialize partitions ────────────────────────────────────────────────
     if part_vars:
         part_lbs = [float(flat_lb[i]) for i in part_vars]
         part_ubs = [float(flat_ub[i]) for i in part_vars]
         disc_state = initialize_partitions(
-            part_vars, lb=part_lbs, ub=part_ubs, n_init=n_init_partitions
+            part_vars,
+            lb=part_lbs,
+            ub=part_ubs,
+            n_init=n_init_partitions,
+            scaling_factor=partition_scaling_factor,
+            abs_width_tol=disc_abs_width_tol,
         )
     else:
         from discopt._jax.discretization import DiscretizationState
 
-        disc_state = DiscretizationState()
+        disc_state = DiscretizationState(
+            scaling_factor=partition_scaling_factor,
+            abs_width_tol=disc_abs_width_tol,
+        )
 
     LB = -np.inf
     UB = np.inf
@@ -498,7 +605,10 @@ def solve_amp(
 
         # ── Step 1: Solve MILP relaxation → lower bound ──────────────────────
         # MILP gap tolerance: no tighter than needed for overall convergence.
-        _milp_gap_tol = milp_gap_tolerance if milp_gap_tolerance is not None else min(rel_gap / 2, 1e-3)
+        if milp_gap_tolerance is not None:
+            _milp_gap_tol = milp_gap_tolerance
+        else:
+            _milp_gap_tol = min(rel_gap / 2, 1e-3)
 
         try:
             milp_result, varmap, active_oa_cuts = _solve_milp_with_oa_recovery(
@@ -509,6 +619,7 @@ def solve_amp(
                 oa_cuts=oa_cuts,
                 time_limit=milp_tl,
                 gap_tolerance=_milp_gap_tol,
+                convhull_formulation=convhull_mode,
             )
             oa_cuts = active_oa_cuts
         except Exception as e:
@@ -516,11 +627,18 @@ def solve_amp(
             break
 
         if milp_result.status in ("infeasible", "error"):
-            logger.info("AMP: MILP infeasible/error at iteration %d, status=%s", iteration, milp_result.status)
+            logger.info(
+                "AMP: MILP infeasible/error at iteration %d, status=%s",
+                iteration,
+                milp_result.status,
+            )
             if LB == -np.inf:
                 # Problem may be infeasible
                 if iteration == 1:
-                    return SolveResult(status="infeasible", wall_time=time.perf_counter() - t_start)
+                    return SolveResult(
+                        status="infeasible",
+                        wall_time=time.perf_counter() - t_start,
+                    )
             break
 
         if milp_result.objective is not None:
@@ -657,6 +775,43 @@ def solve_amp(
                 gap_certified = False  # no lower bound from partitioning
             break
 
+        if (
+            partition_mode == "adaptive_vertex_cover"
+            and incumbent is not None
+            and milp_result.x is not None
+        ):
+            distances = {
+                i: abs(float(incumbent[i]) - float(x0[i]))
+                for i in terms.partition_candidates
+            }
+            adaptive_vars = pick_partition_vars(
+                terms,
+                method="adaptive_vertex_cover",
+                distance=distances,
+            )
+            if adaptive_vars and set(adaptive_vars) != set(part_vars):
+                logger.info(
+                    "AMP: updating adaptive partition set from %d to %d variables",
+                    len(part_vars),
+                    len(adaptive_vars),
+                )
+                new_vars = [i for i in adaptive_vars if i not in disc_state.partitions]
+                if new_vars:
+                    new_lbs = [float(flat_lb[i]) for i in new_vars]
+                    new_ubs = [float(flat_ub[i]) for i in new_vars]
+                    init_state = initialize_partitions(
+                        new_vars,
+                        lb=new_lbs,
+                        ub=new_ubs,
+                        n_init=n_init_partitions,
+                        scaling_factor=partition_scaling_factor,
+                        abs_width_tol=disc_abs_width_tol,
+                    )
+                    disc_state.partitions.update(init_state.partitions)
+                part_vars = adaptive_vars
+                part_lbs = [float(flat_lb[i]) for i in part_vars]
+                part_ubs = [float(flat_ub[i]) for i in part_vars]
+
         # Use MILP solution (original vars) as the refinement point
         refine_solution: dict[int, float] = {}
         if milp_result.x is not None:
@@ -664,9 +819,22 @@ def solve_amp(
             for i in part_vars:
                 refine_solution[i] = float(x_orig[i])
 
-        disc_state = add_adaptive_partition(
-            disc_state, refine_solution, part_vars, part_lbs, part_ubs
-        )
+        if disc_add_partition_method == "uniform":
+            disc_state = add_uniform_partition(
+                disc_state,
+                refine_solution,
+                part_vars,
+                part_lbs,
+                part_ubs,
+            )
+        else:
+            disc_state = add_adaptive_partition(
+                disc_state,
+                refine_solution,
+                part_vars,
+                part_lbs,
+                part_ubs,
+            )
 
         # Check partition convergence
         if check_partition_convergence(disc_state):

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -648,11 +648,13 @@ def solve_amp(
     incumbent = None
     gap_certified = False
     oa_cuts: list = []  # accumulated OA linearizations from NLP incumbents
+    termination_reason = "iteration_limit"
 
     for iteration in range(1, max_iter + 1):
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
             logger.info("AMP: time limit reached at iteration %d", iteration)
+            termination_reason = "time_limit"
             break
 
         remaining = time_limit - elapsed
@@ -683,21 +685,20 @@ def solve_amp(
             oa_cuts = active_oa_cuts
         except Exception as e:
             logger.warning("AMP: MILP build/solve failed at iteration %d: %s", iteration, e)
+            termination_reason = "error"
             break
 
-        if milp_result.status in ("infeasible", "error"):
+        if milp_result.status == "error":
+            logger.info("AMP: MILP error at iteration %d", iteration)
+            termination_reason = "error"
+            break
+
+        if milp_result.status == "infeasible":
             logger.info(
-                "AMP: MILP infeasible/error at iteration %d, status=%s",
+                "AMP: MILP infeasible at iteration %d",
                 iteration,
-                milp_result.status,
             )
-            if LB == -np.inf:
-                # Problem may be infeasible
-                if iteration == 1:
-                    return SolveResult(
-                        status="infeasible",
-                        wall_time=time.perf_counter() - t_start,
-                    )
+            termination_reason = "infeasible"
             break
 
         if milp_result.objective is not None:
@@ -904,9 +905,18 @@ def solve_amp(
     elapsed = time.perf_counter() - t_start
 
     if UB >= np.inf and LB == -np.inf:
+        if termination_reason == "infeasible":
+            status = "infeasible"
+        elif termination_reason == "time_limit":
+            status = "time_limit"
+        elif termination_reason == "error":
+            status = "error"
+        else:
+            status = "iteration_limit"
         return SolveResult(
-            status="infeasible",
+            status=status,
             wall_time=elapsed,
+            gap_certified=False,
         )
 
     if incumbent is not None:
@@ -931,10 +941,14 @@ def solve_amp(
         )
 
     # No feasible solution found
-    if elapsed >= time_limit:
-        status = "time_limit"
-    else:
+    if termination_reason == "infeasible":
         status = "infeasible"
+    elif termination_reason == "time_limit" or elapsed >= time_limit:
+        status = "time_limit"
+    elif termination_reason == "error":
+        status = "error"
+    else:
+        status = "iteration_limit"
 
     return SolveResult(
         status=status,

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -21,30 +21,23 @@ Soundness guarantee: LB_k ≤ global_opt ≤ UB_k at every iteration k.
 
 from __future__ import annotations
 
+import itertools
 import logging
 import time
 from typing import Callable, Optional
 
 import numpy as np
 
-from discopt.modeling.core import Model, SolveResult, VarType
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt.modeling.core import Model, ObjectiveSense, SolveResult, VarType
 
 logger = logging.getLogger(__name__)
+_DEFAULT_MAX_OA_CUTS = 128
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _flat_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
-    """Return (lb_flat, ub_flat) arrays for all model variables."""
-    lbs: list[float] = []
-    ubs: list[float] = []
-    for v in model._variables:
-        lbs.extend(np.asarray(v.lb, dtype=np.float64).ravel().tolist())
-        ubs.extend(np.asarray(v.ub, dtype=np.float64).ravel().tolist())
-    return np.array(lbs, dtype=np.float64), np.array(ubs, dtype=np.float64)
 
 
 def _build_x_dict(x_flat: np.ndarray, model: Model) -> dict:
@@ -63,7 +56,7 @@ def _extract_orig_solution(x_milp: np.ndarray, n_orig: int) -> np.ndarray:
 
 
 def _solve_nlp_subproblem(
-    model: Model,
+    evaluator,
     x0: np.ndarray,
     lb: np.ndarray,
     ub: np.ndarray,
@@ -74,9 +67,6 @@ def _solve_nlp_subproblem(
     Returns (x_opt, obj_val) or (None, None) on failure.
     """
     try:
-        from discopt._jax.nlp_evaluator import NLPEvaluator
-
-        evaluator = NLPEvaluator(model)
         lb_clip = np.clip(lb, -1e8, 1e8)
         ub_clip = np.clip(ub, -1e8, 1e8)
         x0_clipped = np.clip(x0, lb_clip, ub_clip)
@@ -119,32 +109,210 @@ def _check_integer_feasible(
     return True
 
 
-def _round_integers(x: np.ndarray, model: Model) -> np.ndarray:
-    """Round integer/binary variables to nearest integer in-place (copy)."""
-    x = x.copy()
+def _integer_rounding_candidates(
+    x: np.ndarray,
+    model: Model,
+    max_candidates: int = 64,
+) -> list[np.ndarray]:
+    """Generate nearest-first integer rounding candidates within variable bounds."""
+    base = np.asarray(x, dtype=np.float64).copy()
+    integer_entries: list[tuple[int, list[int]]] = []
+
     offset = 0
     for v in model._variables:
         if v.var_type in (VarType.BINARY, VarType.INTEGER):
+            v_lb = np.asarray(v.lb, dtype=np.float64).ravel()
+            v_ub = np.asarray(v.ub, dtype=np.float64).ravel()
             for i in range(v.size):
-                x[offset + i] = round(float(x[offset + i]))
+                idx = offset + i
+                lb_i = float(v_lb[i])
+                ub_i = float(v_ub[i])
+                clipped = float(np.clip(base[idx], lb_i, ub_i))
+                lo_i = int(np.ceil(lb_i - 1e-9))
+                hi_i = int(np.floor(ub_i + 1e-9))
+
+                options: list[int] = []
+                for raw in (
+                    int(round(clipped)),
+                    int(np.floor(clipped)),
+                    int(np.ceil(clipped)),
+                ):
+                    if lo_i <= hi_i:
+                        cand = min(max(raw, lo_i), hi_i)
+                    else:
+                        cand = int(round(clipped))
+                    if cand not in options:
+                        options.append(cand)
+
+                integer_entries.append((idx, options))
         offset += v.size
-    return x
+
+    if not integer_entries:
+        return [base]
+
+    total_candidates = 1
+    for _, options in integer_entries:
+        total_candidates *= max(1, len(options))
+
+    candidates: list[np.ndarray] = []
+    if total_candidates <= max_candidates:
+        option_lists = [options for _, options in integer_entries]
+        for values in itertools.product(*option_lists):
+            cand = base.copy()
+            for (idx, _), value in zip(integer_entries, values):
+                cand[idx] = float(value)
+            candidates.append(cand)
+    else:
+        nearest = base.copy()
+        for idx, options in integer_entries:
+            nearest[idx] = float(options[0])
+        candidates.append(nearest)
+        for idx, options in integer_entries:
+            for value in options[1:]:
+                cand = nearest.copy()
+                cand[idx] = float(value)
+                candidates.append(cand)
+
+    deduped: list[np.ndarray] = []
+    seen: set[tuple[float, ...]] = set()
+    for cand in candidates:
+        key = tuple(float(v) for v in cand)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(cand)
+    return deduped
+
+
+def _round_integers(x: np.ndarray, model: Model) -> np.ndarray:
+    """Round integer/binary variables to the nearest candidate."""
+    return _integer_rounding_candidates(x, model)[0]
+
+
+def _build_fixed_integer_bounds(
+    x: np.ndarray,
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fix integer and binary variables to the provided candidate values."""
+    nlp_lb = flat_lb.copy()
+    nlp_ub = flat_ub.copy()
+
+    offset = 0
+    for v in model._variables:
+        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+            v_lb = np.asarray(v.lb, dtype=np.float64).ravel()
+            v_ub = np.asarray(v.ub, dtype=np.float64).ravel()
+            for k in range(v.size):
+                idx = offset + k
+                val = float(np.clip(x[idx], v_lb[k], v_ub[k]))
+                rounded = round(val)
+                nlp_lb[idx] = rounded
+                nlp_ub[idx] = rounded
+        offset += v.size
+
+    return nlp_lb, nlp_ub
+
+
+def _solve_milp_with_oa_recovery(
+    model: Model,
+    terms,
+    disc_state,
+    incumbent: Optional[np.ndarray],
+    oa_cuts: Optional[list],
+    time_limit: Optional[float],
+    gap_tolerance: float,
+):
+    """Retry MILP solves after dropping the oldest half of OA cuts on infeasibility."""
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+
+    active_oa_cuts = list(oa_cuts or [])
+    while True:
+        milp_model, varmap = build_milp_relaxation(
+            model,
+            terms,
+            disc_state,
+            incumbent,
+            oa_cuts=active_oa_cuts,
+        )
+        milp_result = milp_model.solve(
+            time_limit=time_limit,
+            gap_tolerance=gap_tolerance,
+        )
+        if milp_result.status != "infeasible" or not active_oa_cuts:
+            return milp_result, varmap, active_oa_cuts
+
+        drop_count = max(1, len(active_oa_cuts) // 2)
+        logger.info(
+            "AMP: MILP infeasible with %d OA cuts; dropping %d oldest cuts and retrying",
+            len(active_oa_cuts),
+            drop_count,
+        )
+        active_oa_cuts = active_oa_cuts[drop_count:]
 
 
 def _check_constraints(x: np.ndarray, model: Model, tol: float = 1e-4) -> bool:
     """Return True if all constraints are satisfied at x."""
     try:
         from discopt._jax.nlp_evaluator import NLPEvaluator
+        from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
 
         evaluator = NLPEvaluator(model)
         if evaluator.n_constraints == 0:
             return True
         g = np.array(evaluator.evaluate_constraints(x))
-        lb_g = np.array(evaluator.constraint_bounds[0])
-        ub_g = np.array(evaluator.constraint_bounds[1])
+        lb_g, ub_g = _infer_constraint_bounds(model)
+        lb_g = np.asarray(lb_g, dtype=np.float64)
+        ub_g = np.asarray(ub_g, dtype=np.float64)
         return bool(np.all(g >= lb_g - tol) and np.all(g <= ub_g + tol))
-    except Exception:
-        return True  # conservative: assume feasible if evaluation fails
+    except Exception as err:
+        logger.warning("AMP: constraint evaluation failed; rejecting point: %s", err)
+        return False
+
+
+def _check_constraints_with_evaluator(
+    evaluator,
+    x: np.ndarray,
+    lb_g: np.ndarray,
+    ub_g: np.ndarray,
+    tol: float = 1e-4,
+) -> bool:
+    """Return True if all constraints are satisfied at x."""
+    try:
+        if evaluator.n_constraints == 0:
+            return True
+        g = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64)
+        return bool(np.all(g >= lb_g - tol) and np.all(g <= ub_g + tol))
+    except Exception as err:
+        logger.warning("AMP: constraint evaluation failed; rejecting point: %s", err)
+        return False
+
+
+def _default_milp_time_limit(
+    remaining: float,
+    iteration: int,
+    max_iter: int,
+) -> float:
+    """Allocate a bounded MILP budget from the remaining AMP wall time."""
+    iter_budget = remaining / max(1, max_iter - iteration + 1)
+    return min(iter_budget * 3, remaining * 0.8, 60.0)
+
+
+def _compute_relative_gap(
+    abs_gap: Optional[float],
+    upper_bound: float,
+) -> Optional[float]:
+    """Return a relative gap, or None when the upper bound is numerically zero."""
+    if abs_gap is None or not np.isfinite(upper_bound) or abs(upper_bound) <= 1e-10:
+        return None
+    return abs(abs_gap) / abs(upper_bound)
+
+
+def _prune_oa_cuts(oa_cuts: list, max_cuts: int = _DEFAULT_MAX_OA_CUTS) -> None:
+    """Keep only the most recent OA cuts to cap MILP growth."""
+    overflow = len(oa_cuts) - max_cuts
+    if overflow > 0:
+        del oa_cuts[:overflow]
 
 
 # ---------------------------------------------------------------------------
@@ -204,12 +372,24 @@ def solve_amp(
         check_partition_convergence,
         initialize_partitions,
     )
-    from discopt._jax.milp_relaxation import build_milp_relaxation
+    from discopt._jax.nlp_evaluator import NLPEvaluator
     from discopt._jax.partition_selection import pick_partition_vars
     from discopt._jax.term_classifier import classify_nonlinear_terms
+    from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+    assert model._objective is not None
+    maximize = model._objective.sense == ObjectiveSense.MAXIMIZE
+
+    def _to_minimization_space(value: float) -> float:
+        return -float(value) if maximize else float(value)
+
+    def _from_minimization_space(value: float) -> float:
+        return -float(value) if maximize else float(value)
 
     n_orig = sum(v.size for v in model._variables)
-    flat_lb, flat_ub = _flat_bounds(model)
+    flat_lb, flat_ub = flat_variable_bounds(model)
+    evaluator = NLPEvaluator(model)
+    constraint_lb, constraint_ub = _infer_constraint_bounds(model)
 
     # ── Classify nonlinear terms ─────────────────────────────────────────────
     terms = classify_nonlinear_terms(model)
@@ -257,21 +437,27 @@ def solve_amp(
             break
 
         remaining = time_limit - elapsed
-        # Budget time evenly across remaining iterations, capped at 60s per MILP.
-        iter_budget = remaining / max(1, max_iter - iteration + 1)
-        milp_tl = milp_time_limit if milp_time_limit is not None else min(iter_budget * 3, min(remaining * 0.8, 60.0))
+        milp_tl = (
+            milp_time_limit
+            if milp_time_limit is not None
+            else _default_milp_time_limit(remaining, iteration, max_iter)
+        )
 
         # ── Step 1: Solve MILP relaxation → lower bound ──────────────────────
         # MILP gap tolerance: no tighter than needed for overall convergence.
         _milp_gap_tol = milp_gap_tolerance if milp_gap_tolerance is not None else min(rel_gap / 2, 1e-3)
 
         try:
-            milp_model, varmap = build_milp_relaxation(
-                model, terms, disc_state, incumbent, oa_cuts=oa_cuts
+            milp_result, varmap, active_oa_cuts = _solve_milp_with_oa_recovery(
+                model=model,
+                terms=terms,
+                disc_state=disc_state,
+                incumbent=incumbent,
+                oa_cuts=oa_cuts,
+                time_limit=milp_tl,
+                gap_tolerance=_milp_gap_tol,
             )
-            milp_result = milp_model.solve(
-                time_limit=milp_tl, gap_tolerance=_milp_gap_tol
-            )
+            oa_cuts = active_oa_cuts
         except Exception as e:
             logger.warning("AMP: MILP build/solve failed at iteration %d: %s", iteration, e)
             break
@@ -299,32 +485,44 @@ def solve_amp(
         else:
             x0 = 0.5 * (flat_lb + flat_ub)
 
-        # Round integer/binary vars to nearest integer for NLP subproblem
-        x0_nlp = _round_integers(x0, model)
+        x_nlp = None
+        obj_nlp = None
+        obj_nlp_min = None
+        for x0_nlp in _integer_rounding_candidates(x0, model):
+            nlp_lb, nlp_ub = _build_fixed_integer_bounds(
+                x0_nlp, model, flat_lb, flat_ub
+            )
+            cand_x, cand_obj = _solve_nlp_subproblem(
+                evaluator,
+                x0_nlp,
+                nlp_lb,
+                nlp_ub,
+                nlp_solver,
+            )
+            if cand_x is None or cand_obj is None:
+                continue
+            if not _check_constraints_with_evaluator(
+                evaluator,
+                cand_x,
+                constraint_lb,
+                constraint_ub,
+            ):
+                continue
+            x_nlp = cand_x
+            obj_nlp = cand_obj
+            obj_nlp_min = float(cand_obj)
+            break
 
-        # Build fixed-integer bounds for NLP
-        nlp_lb = flat_lb.copy()
-        nlp_ub = flat_ub.copy()
-        offset = 0
-        for v in model._variables:
-            if v.var_type in (VarType.BINARY, VarType.INTEGER):
-                for k in range(v.size):
-                    val = float(x0_nlp[offset + k])
-                    val = np.clip(val, float(flat_lb[offset + k]), float(flat_ub[offset + k]))
-                    rounded = round(val)
-                    nlp_lb[offset + k] = rounded
-                    nlp_ub[offset + k] = rounded
-            offset += v.size
-
-        x_nlp, obj_nlp = _solve_nlp_subproblem(model, x0_nlp, nlp_lb, nlp_ub, nlp_solver)
-
-        if x_nlp is not None and obj_nlp is not None:
-            # Verify feasibility and update UB
-            feasible = _check_constraints(x_nlp, model)
-            if feasible and obj_nlp < UB:
-                UB = obj_nlp
+        if x_nlp is not None and obj_nlp is not None and obj_nlp_min is not None:
+            # Verify feasibility and update UB in the canonical minimization space.
+            if obj_nlp_min < UB:
+                UB = obj_nlp_min
                 incumbent = x_nlp.copy()
-                logger.debug("AMP iter %d: new UB=%.6g", iteration, UB)
+                logger.debug(
+                    "AMP iter %d: new incumbent objective=%.6g",
+                    iteration,
+                    _from_minimization_space(UB),
+                )
 
                 # Accumulate OA tangent cuts at this NLP solution to tighten
                 # the next MILP relaxation.  Uses existing OA infrastructure
@@ -333,19 +531,17 @@ def solve_amp(
                     from discopt._jax.cutting_planes import (
                         generate_oa_cuts_from_evaluator,
                     )
-                    from discopt._jax.nlp_evaluator import NLPEvaluator
                     from discopt.modeling.core import Constraint
 
-                    _eval = NLPEvaluator(model)
                     _x_orig = x_nlp[:n_orig]
-                    if _eval.n_constraints > 0:
+                    if evaluator.n_constraints > 0:
                         _senses = [
                             c.sense
                             for c in model._constraints
                             if isinstance(c, Constraint)
                         ]
                         cuts = generate_oa_cuts_from_evaluator(
-                            _eval, _x_orig, constraint_senses=_senses
+                            evaluator, _x_orig, constraint_senses=_senses
                         )
                         for cut in cuts:
                             if np.linalg.norm(cut.coeffs) < 1e-12:
@@ -358,31 +554,64 @@ def solve_amp(
                                 oa_cuts.append((-cut.coeffs, -cut.rhs))
                             else:
                                 oa_cuts.append((cut.coeffs, cut.rhs))
+                        _prune_oa_cuts(oa_cuts)
                 except Exception as _oa_err:
                     logger.debug("AMP: OA cut computation failed: %s", _oa_err)
 
         # ── Step 3: Gap check ────────────────────────────────────────────────
         if iteration_callback is not None:
+            if maximize:
+                callback_lb = _from_minimization_space(UB) if UB < np.inf else -np.inf
+                callback_ub = _from_minimization_space(LB) if LB > -np.inf else np.inf
+            else:
+                callback_lb = LB
+                callback_ub = UB
             iteration_callback(
-                {"iteration": iteration, "lower_bound": LB, "upper_bound": UB}
+                {
+                    "iteration": iteration,
+                    "lower_bound": callback_lb,
+                    "upper_bound": callback_ub,
+                }
             )
 
         if UB < np.inf and LB > -np.inf:
             abs_gap = UB - LB
-            if abs(UB) > 1e-10:
-                rel_g = abs_gap / abs(UB)
+            rel_g = _compute_relative_gap(abs_gap, UB)
+            if maximize:
+                display_lb = _from_minimization_space(UB)
+                display_ub = _from_minimization_space(LB)
             else:
-                rel_g = abs_gap
-            logger.info(
-                "AMP iter %d: LB=%.6g, UB=%.6g, gap=%.4g%%",
-                iteration,
-                LB,
-                UB,
-                100 * rel_g,
-            )
-            if abs_gap <= abs_tol or rel_g <= rel_gap:
+                display_lb = LB
+                display_ub = UB
+            if rel_g is None:
+                logger.info(
+                    "AMP iter %d: LB=%.6g, UB=%.6g, abs_gap=%.6g (relative gap undefined)",
+                    iteration,
+                    display_lb,
+                    display_ub,
+                    abs_gap,
+                )
+            else:
+                logger.info(
+                    "AMP iter %d: LB=%.6g, UB=%.6g, gap=%.4g%%",
+                    iteration,
+                    display_lb,
+                    display_ub,
+                    100 * rel_g,
+                )
+            if abs_gap <= abs_tol or (rel_g is not None and rel_g <= rel_gap):
                 gap_certified = True
-                logger.info("AMP: gap certified at iteration %d (gap=%.4g%%)", iteration, 100 * rel_g)
+                if rel_g is None:
+                    logger.info(
+                        "AMP: gap certified at iteration %d by absolute tolerance",
+                        iteration,
+                    )
+                else:
+                    logger.info(
+                        "AMP: gap certified at iteration %d (gap=%.4g%%)",
+                        iteration,
+                        100 * rel_g,
+                    )
                 break
 
         # ── Step 4: Adaptive partition refinement ────────────────────────────
@@ -411,7 +640,6 @@ def solve_amp(
 
     # ── Build final result ───────────────────────────────────────────────────
     elapsed = time.perf_counter() - t_start
-    total_iterations = min(iteration, max_iter)
 
     if UB >= np.inf and LB == -np.inf:
         return SolveResult(
@@ -421,10 +649,7 @@ def solve_amp(
 
     if incumbent is not None:
         abs_gap_final = UB - LB if LB > -np.inf else None
-        rel_gap_final = (
-            abs(abs_gap_final) / abs(UB) if abs_gap_final is not None and abs(UB) > 1e-10
-            else abs_gap_final
-        )
+        rel_gap_final = _compute_relative_gap(abs_gap_final, UB)
 
         if elapsed >= time_limit:
             status = "time_limit" if not gap_certified else "optimal"
@@ -433,8 +658,8 @@ def solve_amp(
 
         return SolveResult(
             status=status,
-            objective=float(UB),
-            bound=float(LB) if LB > -np.inf else None,
+            objective=_from_minimization_space(UB),
+            bound=_from_minimization_space(LB) if LB > -np.inf else None,
             gap=float(rel_gap_final) if rel_gap_final is not None else None,
             x=_build_x_dict(incumbent, model),
             wall_time=elapsed,
@@ -450,7 +675,7 @@ def solve_amp(
     return SolveResult(
         status=status,
         objective=None,
-        bound=float(LB) if LB > -np.inf else None,
+        bound=_from_minimization_space(LB) if LB > -np.inf else None,
         gap=None,
         x=None,
         wall_time=elapsed,

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -28,6 +28,7 @@ from typing import Callable, Optional
 
 import numpy as np
 
+from discopt._jax.milp_relaxation import _normalize_convhull_formulation
 from discopt._jax.model_utils import flat_variable_bounds
 from discopt.modeling.core import Model, ObjectiveSense, SolveResult, VarType
 
@@ -393,24 +394,6 @@ def _normalize_partition_method(
     )
 
 
-def _normalize_convhull_formulation(formulation: str) -> str:
-    """Normalize bilinear convex-hull mode names accepted by the AMP interface."""
-    aliases = {
-        "disaggregated": "disaggregated",
-        "piecewise": "disaggregated",
-        "sos2": "sos2",
-        "facet": "facet",
-        "lambda": "sos2",
-    }
-    try:
-        return aliases[formulation]
-    except KeyError as err:
-        raise ValueError(
-            f"Unsupported convhull_formulation: {formulation!r}. "
-            "Choose from 'disaggregated', 'sos2', 'facet', or 'lambda'."
-        ) from err
-
-
 def _compute_relative_gap(
     abs_gap: Optional[float],
     upper_bound: float,
@@ -483,7 +466,9 @@ def solve_amp(
     disc_var_pick : int | str, optional
         Alpine-style alias for partition selection:
         0/``"all"`` → max_cover, 1 → min_vertex_cover, 2 → auto,
-        3 → adaptive weighted cover.
+        3 → adaptive weighted cover. This intentionally collapses Alpine's
+        separate `disc_var_pick_algo` and `disc_var_pick` options into one
+        user-facing control.
     partition_scaling_factor : float
         Width scaling used by adaptive partition refinement.
     disc_add_partition_method : str

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -1,0 +1,458 @@
+"""
+Adaptive Multivariate Partitioning (AMP) global MINLP solver.
+
+Implements the algorithm from:
+  - CP 2016: "Tightening McCormick Relaxations via Dynamic Multivariate
+    Partitioning", Nagarajan et al.
+  - JOGO 2018: "An Adaptive, Multivariate Partitioning Algorithm for Global
+    Optimization", Nagarajan et al.
+
+Algorithm loop (per iteration k):
+  1. Solve MILP relaxation → lower bound LB_k
+  2. Fix continuous variables' interval assignments from MILP solution,
+     solve NLP subproblem → upper bound UB_k
+  3. Check gap: if (UB_k - LB_k) / |UB_k| ≤ rel_gap → CERTIFIED OPTIMAL
+  4. Refine partitions adaptively around the MILP solution point
+  5. Repeat until gap closed, max_iter reached, or time_limit exceeded
+
+The MILP relaxation is built by build_milp_relaxation() in milp_relaxation.py.
+Soundness guarantee: LB_k ≤ global_opt ≤ UB_k at every iteration k.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Callable, Optional
+
+import numpy as np
+
+from discopt.modeling.core import Model, SolveResult, VarType
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _flat_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
+    """Return (lb_flat, ub_flat) arrays for all model variables."""
+    lbs: list[float] = []
+    ubs: list[float] = []
+    for v in model._variables:
+        lbs.extend(np.asarray(v.lb, dtype=np.float64).ravel().tolist())
+        ubs.extend(np.asarray(v.ub, dtype=np.float64).ravel().tolist())
+    return np.array(lbs, dtype=np.float64), np.array(ubs, dtype=np.float64)
+
+
+def _build_x_dict(x_flat: np.ndarray, model: Model) -> dict:
+    """Convert flat solution vector to {var_name: array} dict."""
+    result = {}
+    offset = 0
+    for v in model._variables:
+        result[v.name] = x_flat[offset : offset + v.size].reshape(v.shape)
+        offset += v.size
+    return result
+
+
+def _extract_orig_solution(x_milp: np.ndarray, n_orig: int) -> np.ndarray:
+    """Extract original variable values from MILP solution (drop aux vars)."""
+    return x_milp[:n_orig]
+
+
+def _solve_nlp_subproblem(
+    model: Model,
+    x0: np.ndarray,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    nlp_solver: str = "ipm",
+) -> tuple[Optional[np.ndarray], Optional[float]]:
+    """Solve the NLP relaxation with given bounds.
+
+    Returns (x_opt, obj_val) or (None, None) on failure.
+    """
+    try:
+        from discopt._jax.nlp_evaluator import NLPEvaluator
+
+        evaluator = NLPEvaluator(model)
+        lb_clip = np.clip(lb, -1e8, 1e8)
+        ub_clip = np.clip(ub, -1e8, 1e8)
+        x0_clipped = np.clip(x0, lb_clip, ub_clip)
+
+        if nlp_solver == "ipm" and hasattr(evaluator, "_obj_fn"):
+            from discopt._jax.ipm import solve_nlp_ipm
+
+            result = solve_nlp_ipm(
+                evaluator, x0_clipped, options={"print_level": 0, "max_iter": 300}
+            )
+        else:
+            from discopt.solvers.nlp_ipopt import solve_nlp
+
+            result = solve_nlp(
+                evaluator, x0_clipped, options={"print_level": 0, "max_iter": 300}
+            )
+
+        from discopt.solvers import SolveStatus
+
+        if result.status == SolveStatus.OPTIMAL:
+            obj = float(evaluator.evaluate_objective(result.x))
+            return result.x, obj
+    except Exception as e:
+        logger.debug("AMP NLP subproblem failed: %s", e)
+    return None, None
+
+
+def _check_integer_feasible(
+    x: np.ndarray, model: Model, int_tol: float = 1e-5
+) -> bool:
+    """Return True if all integer/binary variables satisfy integrality."""
+    offset = 0
+    for v in model._variables:
+        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+            for i in range(v.size):
+                val = float(x[offset + i])
+                if abs(val - round(val)) > int_tol:
+                    return False
+        offset += v.size
+    return True
+
+
+def _round_integers(x: np.ndarray, model: Model) -> np.ndarray:
+    """Round integer/binary variables to nearest integer in-place (copy)."""
+    x = x.copy()
+    offset = 0
+    for v in model._variables:
+        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+            for i in range(v.size):
+                x[offset + i] = round(float(x[offset + i]))
+        offset += v.size
+    return x
+
+
+def _check_constraints(x: np.ndarray, model: Model, tol: float = 1e-4) -> bool:
+    """Return True if all constraints are satisfied at x."""
+    try:
+        from discopt._jax.nlp_evaluator import NLPEvaluator
+
+        evaluator = NLPEvaluator(model)
+        if evaluator.n_constraints == 0:
+            return True
+        g = np.array(evaluator.evaluate_constraints(x))
+        lb_g = np.array(evaluator.constraint_bounds[0])
+        ub_g = np.array(evaluator.constraint_bounds[1])
+        return bool(np.all(g >= lb_g - tol) and np.all(g <= ub_g + tol))
+    except Exception:
+        return True  # conservative: assume feasible if evaluation fails
+
+
+# ---------------------------------------------------------------------------
+# Main solver
+# ---------------------------------------------------------------------------
+
+
+def solve_amp(
+    model: Model,
+    rel_gap: float = 1e-3,
+    abs_tol: float = 1e-6,
+    time_limit: float = 3600.0,
+    max_iter: int = 50,
+    n_init_partitions: int = 2,
+    partition_method: str = "auto",
+    nlp_solver: str = "ipm",
+    iteration_callback: Optional[Callable] = None,
+    milp_time_limit: Optional[float] = None,
+    milp_gap_tolerance: Optional[float] = None,
+) -> SolveResult:
+    """Solve MINLP globally using Adaptive Multivariate Partitioning (AMP).
+
+    Parameters
+    ----------
+    model : Model
+        A validated discopt Model.
+    rel_gap : float
+        Relative gap tolerance: terminate when (UB-LB)/|UB| ≤ rel_gap.
+    abs_tol : float
+        Absolute gap tolerance: terminate when UB-LB ≤ abs_tol.
+    time_limit : float
+        Wall-clock limit in seconds.
+    max_iter : int
+        Maximum number of AMP iterations.
+    n_init_partitions : int
+        Number of initial uniform intervals per partition variable.
+    partition_method : str
+        Variable selection: ``"auto"``, ``"max_cover"``, or ``"min_vertex_cover"``.
+    nlp_solver : str
+        NLP backend for upper-bound subproblems: ``"ipm"`` or ``"ipopt"``.
+    iteration_callback : callable, optional
+        Called each iteration with dict: {"iteration", "lower_bound", "upper_bound"}.
+    milp_time_limit : float, optional
+        Per-MILP-call time limit (defaults to remaining time).
+    milp_gap_tolerance : float
+        MILP solver gap tolerance (default 1e-4).
+
+    Returns
+    -------
+    SolveResult
+        With gap_certified=True if termination is by gap criterion.
+    """
+    t_start = time.perf_counter()
+
+    from discopt._jax.discretization import (
+        add_adaptive_partition,
+        check_partition_convergence,
+        initialize_partitions,
+    )
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+    from discopt._jax.partition_selection import pick_partition_vars
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    n_orig = sum(v.size for v in model._variables)
+    flat_lb, flat_ub = _flat_bounds(model)
+
+    # ── Classify nonlinear terms ─────────────────────────────────────────────
+    terms = classify_nonlinear_terms(model)
+    logger.info(
+        "AMP: %d bilinear, %d trilinear, %d monomial, %d general_nl terms",
+        len(terms.bilinear),
+        len(terms.trilinear),
+        len(terms.monomial),
+        len(terms.general_nl),
+    )
+
+    # ── Select partition variables ───────────────────────────────────────────
+    part_vars = pick_partition_vars(terms, method=partition_method)
+
+    # If no bilinear/multilinear terms, still partition monomial variables
+    # to add tangent cuts at more points and tighten the lower bound.
+    if not part_vars and terms.monomial:
+        part_vars = sorted(set(var_idx for var_idx, _ in terms.monomial))
+        logger.info("AMP: no bilinear terms; partitioning %d monomial vars", len(part_vars))
+    else:
+        logger.info("AMP: partitioning %d variables via %s", len(part_vars), partition_method)
+
+    # ── Initialize partitions ────────────────────────────────────────────────
+    if part_vars:
+        part_lbs = [float(flat_lb[i]) for i in part_vars]
+        part_ubs = [float(flat_ub[i]) for i in part_vars]
+        disc_state = initialize_partitions(
+            part_vars, lb=part_lbs, ub=part_ubs, n_init=n_init_partitions
+        )
+    else:
+        from discopt._jax.discretization import DiscretizationState
+
+        disc_state = DiscretizationState()
+
+    LB = -np.inf
+    UB = np.inf
+    incumbent = None
+    gap_certified = False
+    oa_cuts: list = []  # accumulated OA linearizations from NLP incumbents
+
+    for iteration in range(1, max_iter + 1):
+        elapsed = time.perf_counter() - t_start
+        if elapsed >= time_limit:
+            logger.info("AMP: time limit reached at iteration %d", iteration)
+            break
+
+        remaining = time_limit - elapsed
+        # Budget time evenly across remaining iterations, capped at 60s per MILP.
+        iter_budget = remaining / max(1, max_iter - iteration + 1)
+        milp_tl = milp_time_limit if milp_time_limit is not None else min(iter_budget * 3, min(remaining * 0.8, 60.0))
+
+        # ── Step 1: Solve MILP relaxation → lower bound ──────────────────────
+        # MILP gap tolerance: no tighter than needed for overall convergence.
+        _milp_gap_tol = milp_gap_tolerance if milp_gap_tolerance is not None else min(rel_gap / 2, 1e-3)
+
+        try:
+            milp_model, varmap = build_milp_relaxation(
+                model, terms, disc_state, incumbent, oa_cuts=oa_cuts
+            )
+            milp_result = milp_model.solve(
+                time_limit=milp_tl, gap_tolerance=_milp_gap_tol
+            )
+        except Exception as e:
+            logger.warning("AMP: MILP build/solve failed at iteration %d: %s", iteration, e)
+            break
+
+        if milp_result.status in ("infeasible", "error"):
+            logger.info("AMP: MILP infeasible/error at iteration %d, status=%s", iteration, milp_result.status)
+            if LB == -np.inf:
+                # Problem may be infeasible
+                if iteration == 1:
+                    return SolveResult(status="infeasible", wall_time=time.perf_counter() - t_start)
+            break
+
+        if milp_result.objective is not None:
+            new_lb = float(milp_result.objective)
+            # Soundness: LB must be non-decreasing
+            LB = max(LB, new_lb)
+
+        logger.debug("AMP iter %d: LB=%.6g, UB=%.6g", iteration, LB, UB)
+
+        # ── Step 2: NLP upper-bound subproblem ───────────────────────────────
+        # Use MILP solution point as initial point for NLP
+        if milp_result.x is not None:
+            x0 = _extract_orig_solution(milp_result.x, n_orig)
+            x0 = np.clip(x0, flat_lb, flat_ub)
+        else:
+            x0 = 0.5 * (flat_lb + flat_ub)
+
+        # Round integer/binary vars to nearest integer for NLP subproblem
+        x0_nlp = _round_integers(x0, model)
+
+        # Build fixed-integer bounds for NLP
+        nlp_lb = flat_lb.copy()
+        nlp_ub = flat_ub.copy()
+        offset = 0
+        for v in model._variables:
+            if v.var_type in (VarType.BINARY, VarType.INTEGER):
+                for k in range(v.size):
+                    val = float(x0_nlp[offset + k])
+                    val = np.clip(val, float(flat_lb[offset + k]), float(flat_ub[offset + k]))
+                    rounded = round(val)
+                    nlp_lb[offset + k] = rounded
+                    nlp_ub[offset + k] = rounded
+            offset += v.size
+
+        x_nlp, obj_nlp = _solve_nlp_subproblem(model, x0_nlp, nlp_lb, nlp_ub, nlp_solver)
+
+        if x_nlp is not None and obj_nlp is not None:
+            # Verify feasibility and update UB
+            feasible = _check_constraints(x_nlp, model)
+            if feasible and obj_nlp < UB:
+                UB = obj_nlp
+                incumbent = x_nlp.copy()
+                logger.debug("AMP iter %d: new UB=%.6g", iteration, UB)
+
+                # Accumulate OA tangent cuts at this NLP solution to tighten
+                # the next MILP relaxation.  Uses existing OA infrastructure
+                # from cutting_planes.py which handles all constraint senses.
+                try:
+                    from discopt._jax.cutting_planes import (
+                        generate_oa_cuts_from_evaluator,
+                    )
+                    from discopt._jax.nlp_evaluator import NLPEvaluator
+                    from discopt.modeling.core import Constraint
+
+                    _eval = NLPEvaluator(model)
+                    _x_orig = x_nlp[:n_orig]
+                    if _eval.n_constraints > 0:
+                        _senses = [
+                            c.sense
+                            for c in model._constraints
+                            if isinstance(c, Constraint)
+                        ]
+                        cuts = generate_oa_cuts_from_evaluator(
+                            _eval, _x_orig, constraint_senses=_senses
+                        )
+                        for cut in cuts:
+                            if np.linalg.norm(cut.coeffs) < 1e-12:
+                                continue
+                            if cut.sense == ">=":
+                                # Convert to <= form for milp_relaxation.py
+                                oa_cuts.append((-cut.coeffs, -cut.rhs))
+                            elif cut.sense == "==":
+                                oa_cuts.append((cut.coeffs, cut.rhs))
+                                oa_cuts.append((-cut.coeffs, -cut.rhs))
+                            else:
+                                oa_cuts.append((cut.coeffs, cut.rhs))
+                except Exception as _oa_err:
+                    logger.debug("AMP: OA cut computation failed: %s", _oa_err)
+
+        # ── Step 3: Gap check ────────────────────────────────────────────────
+        if iteration_callback is not None:
+            iteration_callback(
+                {"iteration": iteration, "lower_bound": LB, "upper_bound": UB}
+            )
+
+        if UB < np.inf and LB > -np.inf:
+            abs_gap = UB - LB
+            if abs(UB) > 1e-10:
+                rel_g = abs_gap / abs(UB)
+            else:
+                rel_g = abs_gap
+            logger.info(
+                "AMP iter %d: LB=%.6g, UB=%.6g, gap=%.4g%%",
+                iteration,
+                LB,
+                UB,
+                100 * rel_g,
+            )
+            if abs_gap <= abs_tol or rel_g <= rel_gap:
+                gap_certified = True
+                logger.info("AMP: gap certified at iteration %d (gap=%.4g%%)", iteration, 100 * rel_g)
+                break
+
+        # ── Step 4: Adaptive partition refinement ────────────────────────────
+        if not part_vars:
+            # No partition variables → single iteration
+            if UB < np.inf:
+                gap_certified = False  # no lower bound from partitioning
+            break
+
+        # Use MILP solution (original vars) as the refinement point
+        refine_solution: dict[int, float] = {}
+        if milp_result.x is not None:
+            x_orig = milp_result.x[:n_orig]
+            for i in part_vars:
+                refine_solution[i] = float(x_orig[i])
+
+        disc_state = add_adaptive_partition(
+            disc_state, refine_solution, part_vars, part_lbs, part_ubs
+        )
+
+        # Check partition convergence
+        if check_partition_convergence(disc_state):
+            logger.info("AMP: partition convergence at iteration %d", iteration)
+            gap_certified = UB < np.inf and LB > -np.inf
+            break
+
+    # ── Build final result ───────────────────────────────────────────────────
+    elapsed = time.perf_counter() - t_start
+    total_iterations = min(iteration, max_iter)
+
+    if UB >= np.inf and LB == -np.inf:
+        return SolveResult(
+            status="infeasible",
+            wall_time=elapsed,
+        )
+
+    if incumbent is not None:
+        abs_gap_final = UB - LB if LB > -np.inf else None
+        rel_gap_final = (
+            abs(abs_gap_final) / abs(UB) if abs_gap_final is not None and abs(UB) > 1e-10
+            else abs_gap_final
+        )
+
+        if elapsed >= time_limit:
+            status = "time_limit" if not gap_certified else "optimal"
+        else:
+            status = "optimal"
+
+        return SolveResult(
+            status=status,
+            objective=float(UB),
+            bound=float(LB) if LB > -np.inf else None,
+            gap=float(rel_gap_final) if rel_gap_final is not None else None,
+            x=_build_x_dict(incumbent, model),
+            wall_time=elapsed,
+            gap_certified=gap_certified,
+        )
+
+    # No feasible solution found
+    if elapsed >= time_limit:
+        status = "time_limit"
+    else:
+        status = "infeasible"
+
+    return SolveResult(
+        status=status,
+        objective=None,
+        bound=float(LB) if LB > -np.inf else None,
+        gap=None,
+        x=None,
+        wall_time=elapsed,
+        gap_certified=False,
+    )

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -89,7 +89,7 @@ def _solve_nlp_subproblem(
         lb_clip = np.clip(lb, -1e8, 1e8)
         ub_clip = np.clip(ub, -1e8, 1e8)
         x0_clipped = np.clip(x0, lb_clip, ub_clip)
-        solver_options = {"print_level": 0, "max_iter": 300}
+        solver_options: dict[str, float | int] = {"print_level": 0, "max_iter": 300}
         if time_limit is not None:
             solver_options["max_wall_time"] = max(time_limit, 0.05)
 

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -559,6 +559,7 @@ def solve_amp(
         check_partition_convergence,
         initialize_partitions,
     )
+    from discopt._jax.convexity import classify_oa_cut_convexity
     from discopt._jax.nlp_evaluator import NLPEvaluator
     from discopt._jax.partition_selection import pick_partition_vars
     from discopt._jax.term_classifier import classify_nonlinear_terms
@@ -588,6 +589,13 @@ def solve_amp(
     evaluator = NLPEvaluator(model)
     constraint_lb, constraint_ub = _infer_constraint_bounds(model)
     deadline = t_start + time_limit
+    oa_convexity = classify_oa_cut_convexity(model)
+    if evaluator.n_constraints > 0 and not all(oa_convexity.constraint_mask):
+        logger.warning(
+            "AMP: generating OA cuts only for %d of %d constraints classified convex",
+            sum(1 for is_convex in oa_convexity.constraint_mask if is_convex),
+            len(oa_convexity.constraint_mask),
+        )
 
     # ── Classify nonlinear terms ─────────────────────────────────────────────
     terms = classify_nonlinear_terms(model)
@@ -743,7 +751,10 @@ def solve_amp(
                     if evaluator.n_constraints > 0:
                         _senses = [c.sense for c in model._constraints if isinstance(c, Constraint)]
                         cuts = generate_oa_cuts_from_evaluator(
-                            evaluator, _x_orig, constraint_senses=_senses
+                            evaluator,
+                            _x_orig,
+                            constraint_senses=_senses,
+                            convex_mask=oa_convexity.constraint_mask,
                         )
                         for cut in cuts:
                             if np.linalg.norm(cut.coeffs) < 1e-12:

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -81,9 +81,7 @@ def _solve_nlp_subproblem(
         else:
             from discopt.solvers.nlp_ipopt import solve_nlp
 
-            result = solve_nlp(
-                evaluator, x0_clipped, options={"print_level": 0, "max_iter": 300}
-            )
+            result = solve_nlp(evaluator, x0_clipped, options={"print_level": 0, "max_iter": 300})
 
         from discopt.solvers import SolveStatus
 
@@ -95,9 +93,7 @@ def _solve_nlp_subproblem(
     return None, None
 
 
-def _check_integer_feasible(
-    x: np.ndarray, model: Model, int_tol: float = 1e-5
-) -> bool:
+def _check_integer_feasible(x: np.ndarray, model: Model, int_tol: float = 1e-5) -> bool:
     """Return True if all integer/binary variables satisfy integrality."""
     offset = 0
     for v in model._variables:
@@ -139,11 +135,11 @@ def _integer_rounding_candidates(
                     int(np.ceil(clipped)),
                 ):
                     if lo_i <= hi_i:
-                        cand = min(max(raw, lo_i), hi_i)
+                        cand_int = min(max(raw, lo_i), hi_i)
                     else:
-                        cand = int(round(clipped))
-                    if cand not in options:
-                        options.append(cand)
+                        cand_int = int(round(clipped))
+                    if cand_int not in options:
+                        options.append(cand_int)
 
                 integer_entries.append((idx, options))
         offset += v.size
@@ -230,9 +226,7 @@ def _solve_best_nlp_candidate(
     best_obj: Optional[float] = None
 
     for x0_nlp in _integer_rounding_candidates(x0, model):
-        nlp_lb, nlp_ub = _build_fixed_integer_bounds(
-            x0_nlp, model, flat_lb, flat_ub
-        )
+        nlp_lb, nlp_ub = _build_fixed_integer_bounds(x0_nlp, model, flat_lb, flat_ub)
         cand_x, cand_obj = _solve_nlp_subproblem(
             evaluator,
             x0_nlp,
@@ -389,8 +383,7 @@ def _normalize_partition_method(
         return "adaptive_vertex_cover"
 
     raise ValueError(
-        f"Unsupported disc_var_pick integer: {disc_var_pick!r}. "
-        "Choose from 0, 1, 2, or 3."
+        f"Unsupported disc_var_pick integer: {disc_var_pick!r}. Choose from 0, 1, 2, or 3."
     )
 
 
@@ -505,9 +498,7 @@ def solve_amp(
     if partition_scaling_factor <= 1.0:
         raise ValueError("partition_scaling_factor must be > 1.0")
     if disc_add_partition_method not in {"adaptive", "uniform"}:
-        raise ValueError(
-            "disc_add_partition_method must be 'adaptive' or 'uniform'"
-        )
+        raise ValueError("disc_add_partition_method must be 'adaptive' or 'uniform'")
 
     partition_mode = _normalize_partition_method(partition_method, disc_var_pick)
     convhull_mode = _normalize_convhull_formulation(convhull_formulation)
@@ -674,11 +665,7 @@ def solve_amp(
 
                     _x_orig = x_nlp[:n_orig]
                     if evaluator.n_constraints > 0:
-                        _senses = [
-                            c.sense
-                            for c in model._constraints
-                            if isinstance(c, Constraint)
-                        ]
+                        _senses = [c.sense for c in model._constraints if isinstance(c, Constraint)]
                         cuts = generate_oa_cuts_from_evaluator(
                             evaluator, _x_orig, constraint_senses=_senses
                         )
@@ -766,8 +753,7 @@ def solve_amp(
             and milp_result.x is not None
         ):
             distances = {
-                i: abs(float(incumbent[i]) - float(x0[i]))
-                for i in terms.partition_candidates
+                i: abs(float(incumbent[i]) - float(x0[i])) for i in terms.partition_candidates
             }
             adaptive_vars = pick_partition_vars(
                 terms,

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import itertools
 import logging
 import time
+from functools import lru_cache
+from importlib.util import find_spec
 from typing import Callable, Optional
 
 import numpy as np
@@ -41,6 +43,12 @@ _DEFAULT_MAX_OA_CUTS = 128
 # ---------------------------------------------------------------------------
 
 
+@lru_cache(maxsize=1)
+def _has_cyipopt() -> bool:
+    """Return True when cyipopt is importable in the active environment."""
+    return find_spec("cyipopt") is not None
+
+
 def _build_x_dict(x_flat: np.ndarray, model: Model) -> dict:
     """Convert flat solution vector to {var_name: array} dict."""
     result = {}
@@ -56,32 +64,47 @@ def _extract_orig_solution(x_milp: np.ndarray, n_orig: int) -> np.ndarray:
     return x_milp[:n_orig]
 
 
+def _remaining_wall_time(deadline: Optional[float]) -> Optional[float]:
+    """Return seconds remaining until a deadline, or None when uncapped."""
+    if deadline is None:
+        return None
+    return max(0.0, deadline - time.perf_counter())
+
+
 def _solve_nlp_subproblem(
     evaluator,
     x0: np.ndarray,
     lb: np.ndarray,
     ub: np.ndarray,
     nlp_solver: str = "ipm",
+    time_limit: Optional[float] = None,
 ) -> tuple[Optional[np.ndarray], Optional[float]]:
     """Solve the NLP relaxation with given bounds.
 
     Returns (x_opt, obj_val) or (None, None) on failure.
     """
+    if time_limit is not None and time_limit <= 0.0:
+        return None, None
     try:
         lb_clip = np.clip(lb, -1e8, 1e8)
         ub_clip = np.clip(ub, -1e8, 1e8)
         x0_clipped = np.clip(x0, lb_clip, ub_clip)
+        solver_options = {"print_level": 0, "max_iter": 300}
+        if time_limit is not None:
+            solver_options["max_wall_time"] = max(time_limit, 0.05)
 
-        if nlp_solver == "ipm" and hasattr(evaluator, "_obj_fn"):
+        prefer_ipopt = nlp_solver == "ipm" and time_limit is not None and _has_cyipopt()
+
+        if nlp_solver == "ipm" and hasattr(evaluator, "_obj_fn") and not prefer_ipopt:
             from discopt._jax.ipm import solve_nlp_ipm
 
-            result = solve_nlp_ipm(
-                evaluator, x0_clipped, options={"print_level": 0, "max_iter": 300}
-            )
+            result = solve_nlp_ipm(evaluator, x0_clipped, options=solver_options)
         else:
             from discopt.solvers.nlp_ipopt import solve_nlp
 
-            result = solve_nlp(evaluator, x0_clipped, options={"print_level": 0, "max_iter": 300})
+            if time_limit is not None:
+                solver_options["max_cpu_time"] = max(time_limit, 0.05)
+            result = solve_nlp(evaluator, x0_clipped, options=solver_options)
 
         from discopt.solvers import SolveStatus
 
@@ -220,20 +243,34 @@ def _solve_best_nlp_candidate(
     constraint_lb: np.ndarray,
     constraint_ub: np.ndarray,
     nlp_solver: str,
+    deadline: Optional[float] = None,
 ) -> tuple[Optional[np.ndarray], Optional[float]]:
     """Return the best feasible NLP candidate across the integer-rounding set."""
     best_x: Optional[np.ndarray] = None
     best_obj: Optional[float] = None
 
     for x0_nlp in _integer_rounding_candidates(x0, model):
+        remaining = _remaining_wall_time(deadline)
+        if remaining is not None and remaining <= 0.0:
+            break
         nlp_lb, nlp_ub = _build_fixed_integer_bounds(x0_nlp, model, flat_lb, flat_ub)
-        cand_x, cand_obj = _solve_nlp_subproblem(
-            evaluator,
-            x0_nlp,
-            nlp_lb,
-            nlp_ub,
-            nlp_solver,
-        )
+        if remaining is None:
+            cand_x, cand_obj = _solve_nlp_subproblem(
+                evaluator,
+                x0_nlp,
+                nlp_lb,
+                nlp_ub,
+                nlp_solver,
+            )
+        else:
+            cand_x, cand_obj = _solve_nlp_subproblem(
+                evaluator,
+                x0_nlp,
+                nlp_lb,
+                nlp_ub,
+                nlp_solver,
+                time_limit=remaining,
+            )
         if cand_x is None or cand_obj is None:
             continue
         if not _check_integer_feasible(cand_x, model):
@@ -513,6 +550,7 @@ def solve_amp(
     flat_lb, flat_ub = flat_variable_bounds(model)
     evaluator = NLPEvaluator(model)
     constraint_lb, constraint_ub = _infer_constraint_bounds(model)
+    deadline = t_start + time_limit
 
     # ── Classify nonlinear terms ─────────────────────────────────────────────
     terms = classify_nonlinear_terms(model)
@@ -641,6 +679,7 @@ def solve_amp(
             constraint_lb,
             constraint_ub,
             nlp_solver,
+            deadline=deadline,
         )
 
         if x_nlp is not None and obj_nlp_min is not None:

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -214,6 +214,49 @@ def _build_fixed_integer_bounds(
     return nlp_lb, nlp_ub
 
 
+def _solve_best_nlp_candidate(
+    x0: np.ndarray,
+    model: Model,
+    evaluator,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+    constraint_lb: np.ndarray,
+    constraint_ub: np.ndarray,
+    nlp_solver: str,
+) -> tuple[Optional[np.ndarray], Optional[float]]:
+    """Return the best feasible NLP candidate across the integer-rounding set."""
+    best_x: Optional[np.ndarray] = None
+    best_obj: Optional[float] = None
+
+    for x0_nlp in _integer_rounding_candidates(x0, model):
+        nlp_lb, nlp_ub = _build_fixed_integer_bounds(
+            x0_nlp, model, flat_lb, flat_ub
+        )
+        cand_x, cand_obj = _solve_nlp_subproblem(
+            evaluator,
+            x0_nlp,
+            nlp_lb,
+            nlp_ub,
+            nlp_solver,
+        )
+        if cand_x is None or cand_obj is None:
+            continue
+        if not _check_constraints_with_evaluator(
+            evaluator,
+            cand_x,
+            constraint_lb,
+            constraint_ub,
+        ):
+            continue
+
+        cand_obj_min = float(cand_obj)
+        if best_obj is None or cand_obj_min < best_obj:
+            best_x = cand_x
+            best_obj = cand_obj_min
+
+    return best_x, best_obj
+
+
 def _solve_milp_with_oa_recovery(
     model: Model,
     terms,
@@ -485,35 +528,18 @@ def solve_amp(
         else:
             x0 = 0.5 * (flat_lb + flat_ub)
 
-        x_nlp = None
-        obj_nlp = None
-        obj_nlp_min = None
-        for x0_nlp in _integer_rounding_candidates(x0, model):
-            nlp_lb, nlp_ub = _build_fixed_integer_bounds(
-                x0_nlp, model, flat_lb, flat_ub
-            )
-            cand_x, cand_obj = _solve_nlp_subproblem(
-                evaluator,
-                x0_nlp,
-                nlp_lb,
-                nlp_ub,
-                nlp_solver,
-            )
-            if cand_x is None or cand_obj is None:
-                continue
-            if not _check_constraints_with_evaluator(
-                evaluator,
-                cand_x,
-                constraint_lb,
-                constraint_ub,
-            ):
-                continue
-            x_nlp = cand_x
-            obj_nlp = cand_obj
-            obj_nlp_min = float(cand_obj)
-            break
+        x_nlp, obj_nlp_min = _solve_best_nlp_candidate(
+            x0,
+            model,
+            evaluator,
+            flat_lb,
+            flat_ub,
+            constraint_lb,
+            constraint_ub,
+            nlp_solver,
+        )
 
-        if x_nlp is not None and obj_nlp is not None and obj_nlp_min is not None:
+        if x_nlp is not None and obj_nlp_min is not None:
             # Verify feasibility and update UB in the canonical minimization space.
             if obj_nlp_min < UB:
                 UB = obj_nlp_min
@@ -635,7 +661,7 @@ def solve_amp(
         # Check partition convergence
         if check_partition_convergence(disc_state):
             logger.info("AMP: partition convergence at iteration %d", iteration)
-            gap_certified = UB < np.inf and LB > -np.inf
+            gap_certified = False
             break
 
     # ── Build final result ───────────────────────────────────────────────────
@@ -651,10 +677,12 @@ def solve_amp(
         abs_gap_final = UB - LB if LB > -np.inf else None
         rel_gap_final = _compute_relative_gap(abs_gap_final, UB)
 
-        if elapsed >= time_limit:
-            status = "time_limit" if not gap_certified else "optimal"
-        else:
+        if gap_certified:
             status = "optimal"
+        elif elapsed >= time_limit:
+            status = "time_limit"
+        else:
+            status = "feasible"
 
         return SolveResult(
             status=status,

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -26,7 +26,7 @@ import logging
 import time
 from functools import lru_cache
 from importlib.util import find_spec
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import numpy as np
 
@@ -64,6 +64,37 @@ def _extract_orig_solution(x_milp: np.ndarray, n_orig: int) -> np.ndarray:
     return x_milp[:n_orig]
 
 
+def _snapshot_variable_bounds(model: Model) -> list[tuple[Any, np.ndarray, np.ndarray]]:
+    """Capture model variable bounds so temporary overrides can be restored."""
+    saved_bounds: list[tuple[Any, np.ndarray, np.ndarray]] = []
+    for var in model._variables:
+        saved_bounds.append(
+            (
+                var,
+                np.array(var.lb, dtype=np.float64, copy=True),
+                np.array(var.ub, dtype=np.float64, copy=True),
+            )
+        )
+    return saved_bounds
+
+
+def _restore_variable_bounds(saved_bounds: list[tuple[Any, np.ndarray, np.ndarray]]) -> None:
+    """Restore variable bounds previously returned by _snapshot_variable_bounds()."""
+    for var, orig_lb, orig_ub in saved_bounds:
+        var.lb = orig_lb
+        var.ub = orig_ub
+
+
+def _apply_flat_bounds_to_model(model: Model, lb: np.ndarray, ub: np.ndarray) -> None:
+    """Apply flat bound arrays to model variables in-place."""
+    offset = 0
+    for var in model._variables:
+        size = var.size
+        var.lb = np.asarray(lb[offset : offset + size], dtype=np.float64).reshape(var.shape).copy()
+        var.ub = np.asarray(ub[offset : offset + size], dtype=np.float64).reshape(var.shape).copy()
+        offset += size
+
+
 def _remaining_wall_time(deadline: Optional[float]) -> Optional[float]:
     """Return seconds remaining until a deadline, or None when uncapped."""
     if deadline is None:
@@ -94,17 +125,23 @@ def _solve_nlp_subproblem(
             solver_options["max_wall_time"] = max(time_limit, 0.05)
 
         prefer_ipopt = nlp_solver == "ipm" and time_limit is not None and _has_cyipopt()
+        model = evaluator._model
+        saved_bounds = _snapshot_variable_bounds(model)
+        _apply_flat_bounds_to_model(model, lb, ub)
 
-        if nlp_solver == "ipm" and hasattr(evaluator, "_obj_fn") and not prefer_ipopt:
-            from discopt._jax.ipm import solve_nlp_ipm
+        try:
+            if nlp_solver == "ipm" and hasattr(evaluator, "_obj_fn") and not prefer_ipopt:
+                from discopt._jax.ipm import solve_nlp_ipm
 
-            result = solve_nlp_ipm(evaluator, x0_clipped, options=solver_options)
-        else:
-            from discopt.solvers.nlp_ipopt import solve_nlp
+                result = solve_nlp_ipm(evaluator, x0_clipped, options=solver_options)
+            else:
+                from discopt.solvers.nlp_ipopt import solve_nlp
 
-            if time_limit is not None:
-                solver_options["max_cpu_time"] = max(time_limit, 0.05)
-            result = solve_nlp(evaluator, x0_clipped, options=solver_options)
+                if time_limit is not None:
+                    solver_options["max_cpu_time"] = max(time_limit, 0.05)
+                result = solve_nlp(evaluator, x0_clipped, options=solver_options)
+        finally:
+            _restore_variable_bounds(saved_bounds)
 
         from discopt.solvers import SolveStatus
 

--- a/python/discopt/solvers/gdpopt_loa.py
+++ b/python/discopt/solvers/gdpopt_loa.py
@@ -57,12 +57,16 @@ def solve_gdpopt_loa(
     reformulated = reformulate_gdp(model, method="big-m")
 
     # 2. Build NLP evaluator for the reformulated model
+    from discopt._jax.convexity import classify_oa_cut_convexity
     from discopt._jax.nlp_evaluator import NLPEvaluator
 
     evaluator = NLPEvaluator(reformulated)
+    oa_convexity = classify_oa_cut_convexity(reformulated)
     n_vars = evaluator.n_variables
     n_cons = evaluator.n_constraints
     lb, ub = evaluator.variable_bounds
+    obj_is_linear = False
+    master_bound_valid = False
 
     # 3. Identify integer/binary variable indices
     int_indices = []
@@ -108,6 +112,19 @@ def solve_gdpopt_loa(
         else None
     )
     obj_is_linear = obj_coeffs is not None
+    master_bound_valid = obj_is_linear or oa_convexity.objective_is_convex
+
+    if n_cons > 0 and not all(oa_convexity.constraint_mask):
+        logger.warning(
+            "LOA: generating OA cuts only for %d of %d constraints classified convex",
+            sum(1 for is_convex in oa_convexity.constraint_mask if is_convex),
+            len(oa_convexity.constraint_mask),
+        )
+    if not obj_is_linear and not oa_convexity.objective_is_convex:
+        logger.warning(
+            "LOA: nonlinear objective is not convex in the optimization sense; "
+            "disabling master lower-bound updates and skipping objective OA cuts"
+        )
 
     # 6. Solve initial NLP relaxation (continuous)
     x_relax = _solve_nlp_relaxation(evaluator, lb, ub, nlp_solver)
@@ -117,7 +134,17 @@ def solve_gdpopt_loa(
     oa_b_rows: list[float] = []
 
     if x_relax is not None:
-        _add_oa_cuts(evaluator, x_relax, n_vars, n_cons, oa_A_rows, oa_b_rows, obj_is_linear)
+        _add_oa_cuts(
+            evaluator,
+            x_relax,
+            n_vars,
+            n_cons,
+            oa_A_rows,
+            oa_b_rows,
+            obj_is_linear,
+            oa_convexity.constraint_mask,
+            oa_convexity.objective_is_convex,
+        )
 
     # 8. Main LOA loop
     LB = -1e20
@@ -143,6 +170,7 @@ def solve_gdpopt_loa(
             ub,
             obj_coeffs,
             obj_is_linear,
+            master_bound_valid,
             time_limit=time_limit - elapsed,
             gap_tolerance=gap_tolerance,
         )
@@ -153,7 +181,8 @@ def solve_gdpopt_loa(
             break
 
         x_master = master_result.x[:n_vars]
-        LB = max(LB, master_result.objective if master_result.objective is not None else -1e20)
+        if master_bound_valid and master_result.objective is not None:
+            LB = max(LB, master_result.objective)
 
         # b. Fix integers to master values, solve NLP subproblem
         sub_lb = lb.copy()
@@ -173,12 +202,32 @@ def solve_gdpopt_loa(
                 incumbent_obj = obj_nlp
 
             # c. Generate OA cuts at NLP solution
-            _add_oa_cuts(evaluator, x_nlp, n_vars, n_cons, oa_A_rows, oa_b_rows, obj_is_linear)
+            _add_oa_cuts(
+                evaluator,
+                x_nlp,
+                n_vars,
+                n_cons,
+                oa_A_rows,
+                oa_b_rows,
+                obj_is_linear,
+                oa_convexity.constraint_mask,
+                oa_convexity.objective_is_convex,
+            )
         else:
             # NLP infeasible → add no-good cut
             _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars)
             # Also try OA cuts at master point
-            _add_oa_cuts(evaluator, x_master, n_vars, n_cons, oa_A_rows, oa_b_rows, obj_is_linear)
+            _add_oa_cuts(
+                evaluator,
+                x_master,
+                n_vars,
+                n_cons,
+                oa_A_rows,
+                oa_b_rows,
+                obj_is_linear,
+                oa_convexity.constraint_mask,
+                oa_convexity.objective_is_convex,
+            )
 
         # d. Check convergence
         gap = _compute_gap(LB, UB)
@@ -197,6 +246,8 @@ def solve_gdpopt_loa(
     # 9. Build result
     wall_time = time.perf_counter() - t_start
     gap = _compute_gap(LB, UB)
+    bound = LB if master_bound_valid and LB > -1e19 else None
+    reported_gap = gap if bound is not None and UB < 1e19 else None
 
     if incumbent is not None:
         status = "optimal" if gap <= gap_tolerance else "feasible"
@@ -204,8 +255,8 @@ def solve_gdpopt_loa(
         return SolveResult(
             status=status,
             objective=incumbent_obj,
-            bound=LB,
-            gap=gap,
+            bound=bound,
+            gap=reported_gap,
             x=x_dict,
             wall_time=wall_time,
         )
@@ -213,7 +264,7 @@ def solve_gdpopt_loa(
     return SolveResult(
         status="infeasible",
         objective=None,
-        bound=LB,
+        bound=bound,
         gap=None,
         x={},
         wall_time=wall_time,
@@ -364,7 +415,17 @@ class _BoundsProxy:
         return self._eval.evaluate_lagrangian_hessian(x, obj_factor, lam)
 
 
-def _add_oa_cuts(evaluator, x_star, n_vars, n_cons, oa_A_rows, oa_b_rows, obj_is_linear):
+def _add_oa_cuts(
+    evaluator,
+    x_star,
+    n_vars,
+    n_cons,
+    oa_A_rows,
+    oa_b_rows,
+    obj_is_linear,
+    constraint_convex_mask,
+    objective_is_convex,
+):
     """Generate OA cuts at x_star and append to cut lists."""
     from discopt._jax.cutting_planes import (
         generate_oa_cuts_from_evaluator,
@@ -373,7 +434,11 @@ def _add_oa_cuts(evaluator, x_star, n_vars, n_cons, oa_A_rows, oa_b_rows, obj_is
 
     # Constraint OA cuts
     if n_cons > 0:
-        cuts = generate_oa_cuts_from_evaluator(evaluator, x_star)
+        cuts = generate_oa_cuts_from_evaluator(
+            evaluator,
+            x_star,
+            convex_mask=constraint_convex_mask,
+        )
         for cut in cuts:
             if cut.sense == "<=":
                 oa_A_rows.append(cut.coeffs.copy())
@@ -383,8 +448,8 @@ def _add_oa_cuts(evaluator, x_star, n_vars, n_cons, oa_A_rows, oa_b_rows, obj_is
                 oa_b_rows.append(-cut.rhs)
 
     # Objective OA cut (only if nonlinear)
-    if not obj_is_linear:
-        obj_cut = generate_objective_oa_cut(evaluator, x_star, n_vars)
+    if not obj_is_linear and objective_is_convex:
+        obj_cut = generate_objective_oa_cut(evaluator, x_star, n_vars + 1, z_index=n_vars)
         # This cut is: coeffs @ x <= rhs (underestimates the objective)
         oa_A_rows.append(obj_cut.coeffs.copy())
         oa_b_rows.append(obj_cut.rhs)
@@ -420,6 +485,7 @@ def _solve_master_milp(
     ub,
     obj_coeffs,
     obj_is_linear,
+    objective_bound_valid,
     time_limit,
     gap_tolerance,
 ):
@@ -432,8 +498,9 @@ def _solve_master_milp(
         ) from e
 
     # Determine master problem dimensions
+    use_objective_epigraph = (not obj_is_linear) and objective_bound_valid
     n_master = n_vars
-    if not obj_is_linear:
+    if use_objective_epigraph:
         n_master += 1  # epigraph variable eta
 
     # Build A_ub, b_ub from linear <= constraints + OA cuts
@@ -443,7 +510,7 @@ def _solve_master_milp(
     for i, sense in enumerate(linear_senses):
         row = linear_A_rows[i]
         rhs = linear_b_rows[i]
-        if not obj_is_linear:
+        if use_objective_epigraph:
             row = np.append(row, 0.0)
         if sense == "<=":
             A_ub_rows.append(row)
@@ -455,7 +522,7 @@ def _solve_master_milp(
     # OA cuts (all <= form)
     for i in range(len(oa_A_rows)):
         row = oa_A_rows[i]
-        if not obj_is_linear:
+        if use_objective_epigraph and len(row) == n_vars:
             row = np.append(row, 0.0)
         A_ub_rows.append(row)
         b_ub_vals.append(oa_b_rows[i])
@@ -466,7 +533,7 @@ def _solve_master_milp(
     for i, sense in enumerate(linear_senses):
         if sense == "==":
             row = linear_A_rows[i]
-            if not obj_is_linear:
+            if use_objective_epigraph:
                 row = np.append(row, 0.0)
             A_eq_rows.append(row)
             b_eq_vals.append(linear_b_rows[i])
@@ -481,14 +548,16 @@ def _solve_master_milp(
     if obj_is_linear:
         c_vec, off = obj_coeffs
         c = c_vec.copy()
-    else:
+    elif use_objective_epigraph:
         # min eta, with OA cuts: eta >= f(x*) + grad(x*) . (x - x*)
         c = np.zeros(n_master)
         c[-1] = 1.0  # minimize eta
+    else:
+        c = np.zeros(n_master)
 
     # Bounds
     bounds_list = list(zip(lb.tolist(), ub.tolist()))
-    if not obj_is_linear:
+    if use_objective_epigraph:
         bounds_list.append((-1e20, 1e20))  # eta unbounded
 
     # Integrality

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -69,15 +69,20 @@ class _DecomposedProblem:
     constraint_senses: list[str]
     obj_coeffs: Optional[tuple] = None
     obj_is_linear: bool = False
+    oa_objective_is_convex: bool = True
+    oa_constraint_mask: Optional[list[bool]] = None
+    master_bound_valid: bool = True
     model: Optional[Model] = None
 
 
 def _decompose_model(model: Model) -> _DecomposedProblem:
     """Separate model into linear/nonlinear constraints, identify integers."""
+    from discopt._jax.convexity import classify_oa_cut_convexity
     from discopt._jax.gdp_reformulate import _extract_body_coeffs, _is_linear
     from discopt._jax.nlp_evaluator import NLPEvaluator
 
     evaluator = NLPEvaluator(model)
+    oa_convexity = classify_oa_cut_convexity(model)
     n_vars = evaluator.n_variables
     n_cons = evaluator.n_constraints
     lb, ub = evaluator.variable_bounds
@@ -144,6 +149,9 @@ def _decompose_model(model: Model) -> _DecomposedProblem:
         constraint_senses=all_constraint_senses,
         obj_coeffs=obj_coeffs,
         obj_is_linear=obj_is_linear,
+        oa_objective_is_convex=oa_convexity.objective_is_convex,
+        oa_constraint_mask=oa_convexity.constraint_mask,
+        master_bound_valid=(obj_is_linear or oa_convexity.objective_is_convex),
         model=model,
     )
 
@@ -292,6 +300,8 @@ def _add_oa_cuts(
     oa_A_rows,
     oa_b_rows,
     obj_is_linear,
+    constraint_convex_mask,
+    objective_is_convex,
     equality_relaxation=False,
 ):
     """Generate OA cuts at x_star and append to cut lists.
@@ -307,7 +317,10 @@ def _add_oa_cuts(
 
     if n_cons > 0:
         cuts = generate_oa_cuts_from_evaluator(
-            evaluator, x_star, constraint_senses=constraint_senses
+            evaluator,
+            x_star,
+            constraint_senses=constraint_senses,
+            convex_mask=constraint_convex_mask,
         )
         for cut in cuts:
             coeffs = cut.coeffs.copy()
@@ -333,7 +346,7 @@ def _add_oa_cuts(
                 oa_b_rows.append(-cut.rhs)
 
     # Objective OA cut (only if nonlinear): grad^T x - eta <= rhs
-    if not obj_is_linear:
+    if not obj_is_linear and objective_is_convex:
         n_master = n_vars + 1
         obj_cut = generate_objective_oa_cut(evaluator, x_star, n_master, z_index=n_vars)
         oa_A_rows.append(obj_cut.coeffs.copy())
@@ -348,6 +361,8 @@ def _add_ecp_cuts(
     oa_A_rows,
     oa_b_rows,
     obj_is_linear,
+    constraint_convex_mask,
+    objective_is_convex,
     equality_relaxation=False,
 ):
     """Generate ECP cuts: OA cuts only for violated constraints at x_master."""
@@ -358,7 +373,12 @@ def _add_ecp_cuts(
 
     n_added = 0
     if evaluator.n_constraints > 0:
-        cuts = separate_oa_cuts(evaluator, x_master, constraint_senses=constraint_senses)
+        cuts = separate_oa_cuts(
+            evaluator,
+            x_master,
+            constraint_senses=constraint_senses,
+            convex_mask=constraint_convex_mask,
+        )
         for cut in cuts:
             coeffs = cut.coeffs.copy()
             if np.linalg.norm(coeffs) < 1e-12:
@@ -383,7 +403,7 @@ def _add_ecp_cuts(
                 oa_b_rows.append(-cut.rhs)
                 n_added += 2
 
-    if not obj_is_linear:
+    if not obj_is_linear and objective_is_convex:
         n_master = n_vars + 1
         obj_cut = generate_objective_oa_cut(evaluator, x_master, n_master, z_index=n_vars)
         oa_A_rows.append(obj_cut.coeffs.copy())
@@ -413,7 +433,15 @@ def _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars):
     oa_b_rows.append(float(count_ones - 1))
 
 
-def _add_feasibility_cuts(evaluator, x_feas, n_vars, constraint_senses, oa_A_rows, oa_b_rows):
+def _add_feasibility_cuts(
+    evaluator,
+    x_feas,
+    n_vars,
+    constraint_senses,
+    oa_A_rows,
+    oa_b_rows,
+    constraint_convex_mask,
+):
     """Add gradient-based feasibility cuts (Fletcher-Leyffer 1994).
 
     For each violated constraint g_k(x) <= 0 at x_feas:
@@ -424,7 +452,12 @@ def _add_feasibility_cuts(evaluator, x_feas, n_vars, constraint_senses, oa_A_row
     if evaluator.n_constraints == 0:
         return
 
-    cuts = separate_oa_cuts(evaluator, x_feas, constraint_senses=constraint_senses)
+    cuts = separate_oa_cuts(
+        evaluator,
+        x_feas,
+        constraint_senses=constraint_senses,
+        convex_mask=constraint_convex_mask,
+    )
     for cut in cuts:
         coeffs = cut.coeffs.copy()
         if np.linalg.norm(coeffs) < 1e-12:
@@ -452,6 +485,7 @@ def _solve_master_milp(
     ub,
     obj_coeffs,
     obj_is_linear,
+    objective_bound_valid,
     time_limit,
     gap_tolerance,
 ):
@@ -463,8 +497,9 @@ def _solve_master_milp(
             "OA solver requires highspy for the MILP master. Install with: pip install highspy"
         ) from e
 
+    use_objective_epigraph = (not obj_is_linear) and objective_bound_valid
     n_master = n_vars
-    if not obj_is_linear:
+    if use_objective_epigraph:
         n_master += 1  # epigraph variable eta
 
     # Build A_ub, b_ub from linear <= constraints + OA cuts
@@ -473,7 +508,7 @@ def _solve_master_milp(
 
     for i, sense in enumerate(linear_senses):
         row = linear_A_rows[i]
-        if not obj_is_linear:
+        if use_objective_epigraph:
             row = np.append(row, 0.0)
         if sense == "<=":
             A_ub_rows.append(row)
@@ -486,7 +521,7 @@ def _solve_master_milp(
     # Constraint cuts have length n_vars; objective cuts have length n_master
     for i in range(len(oa_A_rows)):
         row = oa_A_rows[i]
-        if not obj_is_linear and len(row) == n_vars:
+        if use_objective_epigraph and len(row) == n_vars:
             row = np.append(row, 0.0)  # extend constraint cuts with 0 for eta
         A_ub_rows.append(row)
         b_ub_vals.append(oa_b_rows[i])
@@ -497,7 +532,7 @@ def _solve_master_milp(
     for i, sense in enumerate(linear_senses):
         if sense == "==":
             row = linear_A_rows[i]
-            if not obj_is_linear:
+            if use_objective_epigraph:
                 row = np.append(row, 0.0)
             A_eq_rows.append(row)
             b_eq_vals.append(linear_b_rows[i])
@@ -511,15 +546,15 @@ def _solve_master_milp(
     if obj_is_linear:
         c_vec, _off = obj_coeffs
         c = c_vec.copy()
-        if not obj_is_linear:
-            c = np.append(c, 0.0)
-    else:
+    elif use_objective_epigraph:
         c = np.zeros(n_master)
         c[-1] = 1.0  # minimize eta
+    else:
+        c = np.zeros(n_master)
 
     # Bounds
     bounds_list = list(zip(lb.tolist(), ub.tolist()))
-    if not obj_is_linear:
+    if use_objective_epigraph:
         bounds_list.append((-1e20, 1e20))  # eta unbounded
 
     # Integrality
@@ -614,6 +649,17 @@ def solve_oa(
     evaluator = decomp.evaluator
     n_vars = decomp.n_vars
     n_cons = decomp.n_cons
+    if decomp.oa_constraint_mask is not None and not all(decomp.oa_constraint_mask):
+        logger.warning(
+            "OA: generating OA cuts only for %d of %d constraints classified convex",
+            sum(1 for is_convex in decomp.oa_constraint_mask if is_convex),
+            len(decomp.oa_constraint_mask),
+        )
+    if not decomp.obj_is_linear and not decomp.oa_objective_is_convex:
+        logger.warning(
+            "OA: nonlinear objective is not convex in the optimization sense; "
+            "disabling master lower-bound updates and skipping objective OA cuts"
+        )
 
     # If no integer variables, just solve the NLP directly
     if len(decomp.int_indices) == 0:
@@ -658,6 +704,8 @@ def solve_oa(
             oa_A_rows,
             oa_b_rows,
             decomp.obj_is_linear,
+            decomp.oa_constraint_mask,
+            decomp.oa_objective_is_convex,
             equality_relaxation=equality_relaxation,
         )
         # Check if relaxation solution is already integer-feasible
@@ -682,6 +730,8 @@ def solve_oa(
             oa_A_rows,
             oa_b_rows,
             decomp.obj_is_linear,
+            decomp.oa_constraint_mask,
+            decomp.oa_objective_is_convex,
             equality_relaxation=equality_relaxation,
         )
 
@@ -705,6 +755,7 @@ def solve_oa(
             decomp.ub,
             decomp.obj_coeffs,
             decomp.obj_is_linear,
+            decomp.master_bound_valid,
             time_limit=time_limit - elapsed,
             gap_tolerance=gap_tolerance,
         )
@@ -734,12 +785,15 @@ def solve_oa(
                 oa_A_rows,
                 oa_b_rows,
                 decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
                 equality_relaxation=equality_relaxation,
             )
             continue
 
         x_master = master_result.x[:n_vars]
-        LB = max(LB, master_result.objective or -1e20)
+        if decomp.master_bound_valid and master_result.objective is not None:
+            LB = max(LB, master_result.objective)
 
         # b. ECP mode: add cuts at master point, skip NLP
         if ecp_mode:
@@ -751,6 +805,8 @@ def solve_oa(
                 oa_A_rows,
                 oa_b_rows,
                 decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
                 equality_relaxation=equality_relaxation,
             )
             # In ECP, use master objective as heuristic UB
@@ -803,6 +859,8 @@ def solve_oa(
                 oa_A_rows,
                 oa_b_rows,
                 decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
                 equality_relaxation=equality_relaxation,
             )
         else:
@@ -824,6 +882,7 @@ def solve_oa(
                         decomp.constraint_senses,
                         oa_A_rows,
                         oa_b_rows,
+                        decomp.oa_constraint_mask,
                     )
 
             # Always add no-good cut as fallback to avoid cycling
@@ -839,6 +898,8 @@ def solve_oa(
                 oa_A_rows,
                 oa_b_rows,
                 decomp.obj_is_linear,
+                decomp.oa_constraint_mask,
+                decomp.oa_objective_is_convex,
                 equality_relaxation=equality_relaxation,
             )
 
@@ -859,14 +920,16 @@ def solve_oa(
     # 4. Build result
     wall_time = time.perf_counter() - t_start
     gap = _compute_gap(LB, UB)
+    bound = LB if decomp.master_bound_valid and LB > -1e19 else None
+    reported_gap = gap if bound is not None and UB < 1e19 else None
 
     if incumbent is not None:
         status = "optimal" if gap <= gap_tolerance else "feasible"
         return SolveResult(
             status=status,
             objective=incumbent_obj,
-            bound=LB,
-            gap=gap,
+            bound=bound,
+            gap=reported_gap,
             x=_build_x_dict(incumbent, model),
             wall_time=wall_time,
         )
@@ -874,7 +937,7 @@ def solve_oa(
     return SolveResult(
         status="infeasible",
         objective=None,
-        bound=LB,
+        bound=bound,
         gap=None,
         x={},
         wall_time=wall_time,

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1,0 +1,1007 @@
+"""
+Tests for the Adaptive Multivariate Partitioning (AMP) global MINLP solver.
+
+Theory references:
+  - CP 2016: "Tightening McCormick Relaxations via Dynamic Multivariate
+    Partitioning", Nagarajan et al.
+  - JOGO 2018: "An Adaptive, Multivariate Partitioning Algorithm for Global
+    Optimization of Nonconvex Programs", Nagarajan et al.
+
+Test strategy (TDD):
+  All tests are written BEFORE implementation.  Running this suite against
+  the current codebase reveals which modules are missing and which existing
+  functions have gaps or bugs.  Each section maps to a new module that must
+  be created to make the tests pass.
+
+Sections:
+  1. Term Classifier            (term_classifier.py)
+  2. Variable Selection         (partition_selection.py)
+  3. Discretization State       (discretization.py)
+  4. Piecewise McCormick validity (existing mccormick.py / piecewise_mccormick.py)
+  5. MILP Relaxation lower bounds (milp_relaxation.py)
+  6. End-to-end AMP             (solvers/amp.py + solver.py routing)
+  7. Convergence properties     (AMP loop invariants)
+  8. Weakness probes            (expose bugs/gaps in current code)
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import numpy as np
+import pytest
+
+import discopt.modeling as dm
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    FunctionCall,
+    IndexExpression,
+    Model,
+    SolveResult,
+    Variable,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers / problem builders
+# ---------------------------------------------------------------------------
+
+
+def _make_nlp1() -> Model:
+    """Alpine nlp1: min 6x₀²+4x₁²-2.5x₀x₁  s.t. x₀x₁≥8, x∈[1,4]²
+
+    Known global optimum ≈ 58.38368 (verified in Alpine.jl test suite).
+    """
+    m = Model("nlp1")
+    x = m.continuous("x", lb=1, ub=4, shape=(2,))
+    m.subject_to(x[0] * x[1] >= 8)
+    m.minimize(6 * x[0] ** 2 + 4 * x[1] ** 2 - 2.5 * x[0] * x[1])
+    return m
+
+
+def _make_circle() -> Model:
+    """Alpine circle: min x₀+x₁  s.t. x₀²+x₁²≥2, x∈[0,2]²
+
+    Known global optimum = √2 ≈ 1.41421356.
+    """
+    m = Model("circle")
+    x = m.continuous("x", lb=0, ub=2, shape=(2,))
+    m.subject_to(x[0] ** 2 + x[1] ** 2 >= 2)
+    m.minimize(x[0] + x[1])
+    return m
+
+
+def _build_nlp3() -> Model:
+    """Alpine nlp3: 8-variable multilinear industrial process.
+
+    Ported from Alpine.jl examples/MINLPs/nlp.jl (nlp3 function).
+    Known global optimum ≈ 7049.247898 (Alpine test suite).
+
+    Alpine formulation (1-indexed → 0-indexed Python):
+      min  x[1]+x[2]+x[3]  →  x[0]+x[1]+x[2]
+      s.t. 0.0025*(x[4]+x[6]) <= 1          (linear)
+           0.0025*(x[5]-x[4]+x[7]) <= 1     (linear)
+           0.01*(x[8]-x[5]) <= 1             (linear)
+           100*x[1] - x[1]*x[6] + 833.33252*x[4] <= 83333.333  (bilinear)
+           x[2]*x[4] - x[2]*x[7] - 1250*x[4] + 1250*x[5] <= 0  (bilinear)
+           x[3]*x[5] - x[3]*x[8] - 2500*x[5] + 1250000 <= 0     (bilinear)
+    """
+    m = Model("nlp3")
+    LB = [100.0, 1000.0, 1000.0, 10.0, 10.0, 10.0, 10.0, 10.0]
+    UB = [10000.0, 10000.0, 10000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0]
+    x = [m.continuous(f"x{i}", lb=LB[i], ub=UB[i]) for i in range(8)]
+    m.minimize(x[0] + x[1] + x[2])
+    # Linear constraints
+    m.subject_to(0.0025 * (x[3] + x[5]) <= 1)
+    m.subject_to(0.0025 * (x[4] - x[3] + x[6]) <= 1)
+    m.subject_to(0.01 * (x[7] - x[4]) <= 1)
+    # Nonlinear (bilinear) constraints — in >= form (multiply Alpine's <= by -1)
+    m.subject_to(83333.333 - 100.0 * x[0] + x[0] * x[5] - 833.33252 * x[3] >= 0)
+    m.subject_to(x[1] * x[6] - x[1] * x[3] - 1250.0 * x[4] + 1250.0 * x[3] >= 0)
+    m.subject_to(x[2] * x[7] - x[2] * x[4] + 2500.0 * x[4] - 1250000.0 >= 0)
+    return m
+
+
+# ===========================================================================
+# Section 1: Nonlinear Term Classifier
+#
+# Module to be created: python/discopt/_jax/term_classifier.py
+# Function: classify_nonlinear_terms(model: Model) -> NonlinearTerms
+# ===========================================================================
+
+
+class TestTermClassifier:
+    """Tests for classify_nonlinear_terms().
+
+    These will all fail with ImportError until term_classifier.py is created.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        """Import the to-be-created module (expected to fail initially)."""
+        from discopt._jax.term_classifier import (  # noqa: F401
+            NonlinearTerms,
+            classify_nonlinear_terms,
+        )
+        self.classify = classify_nonlinear_terms
+        self.NonlinearTerms = NonlinearTerms
+
+    def test_detect_bilinear_objective(self):
+        """x[0]*x[1] in objective → one bilinear term (0,1)."""
+        m = Model("t")
+        x = m.continuous("x", lb=0, ub=10, shape=(2,))
+        m.minimize(x[0] * x[1])
+        terms = self.classify(m)
+        assert len(terms.bilinear) == 1
+        assert set(terms.bilinear[0]) == {0, 1}
+
+    def test_detect_bilinear_constraint(self):
+        """x[0]*x[1] in constraint → detected as bilinear."""
+        m = Model("t")
+        x = m.continuous("x", lb=1, ub=4, shape=(2,))
+        m.subject_to(x[0] * x[1] >= 8)
+        m.minimize(x[0] + x[1])
+        terms = self.classify(m)
+        assert len(terms.bilinear) >= 1
+        found = any(set(b) == {0, 1} for b in terms.bilinear)
+        assert found, f"Expected bilinear (0,1), got {terms.bilinear}"
+
+    def test_detect_monomial_squared(self):
+        """x[0]**2 → monomial with exponent 2."""
+        m = Model("t")
+        x = m.continuous("x", lb=0, ub=10, shape=(2,))
+        m.minimize(x[0] ** 2 + x[1] ** 2)
+        terms = self.classify(m)
+        assert len(terms.monomial) >= 2
+        exponents = [exp for _, exp in terms.monomial]
+        assert all(e == 2 for e in exponents), f"Expected exponent 2, got {exponents}"
+
+    def test_detect_trilinear(self):
+        """x[0]*x[1]*x[2] → one trilinear term."""
+        m = Model("t")
+        x = m.continuous("x", lb=0, ub=10, shape=(3,))
+        m.minimize(x[0] * x[1] * x[2])
+        terms = self.classify(m)
+        assert len(terms.trilinear) >= 1
+        found = any(set(t) == {0, 1, 2} for t in terms.trilinear)
+        assert found, f"Expected trilinear (0,1,2), got {terms.trilinear}"
+
+    def test_mixed_bilinear_and_monomial(self):
+        """nlp1: bilinear in constraint, monomial in objective."""
+        m = _make_nlp1()
+        terms = self.classify(m)
+        assert len(terms.bilinear) >= 1
+        assert len(terms.monomial) >= 2  # x[0]**2 and x[1]**2
+
+    def test_partition_candidates_excludes_linear_vars(self):
+        """Variable not in any nonlinear term must NOT be a partition candidate."""
+        m = Model("t")
+        x = m.continuous("x", lb=0, ub=10, shape=(3,))
+        # Only x[0]*x[1] — x[2] is only in linear expressions
+        m.minimize(x[0] * x[1] + 2.0 * x[2])
+        terms = self.classify(m)
+        # x[0] and x[1] appear in bilinear term
+        assert 0 in terms.partition_candidates
+        assert 1 in terms.partition_candidates
+        # x[2] is only in a linear term — must NOT be a candidate
+        assert 2 not in terms.partition_candidates, (
+            "x[2] is linear-only and must not be a partition candidate"
+        )
+
+    def test_transcendental_classified_as_general_nl(self):
+        """sin(x), exp(x), log(x) → classified as general_nl (not bilinear)."""
+        m = Model("t")
+        x = m.continuous("x", lb=0.1, ub=3.14)
+        m.minimize(dm.sin(x) + dm.exp(x))
+        terms = self.classify(m)
+        assert len(terms.general_nl) >= 1, "sin/exp should be classified as general_nl"
+        assert len(terms.bilinear) == 0, "sin/exp must not be misclassified as bilinear"
+
+    def test_empty_model_has_no_terms(self):
+        """Model with only linear expressions → no nonlinear terms."""
+        m = Model("linear")
+        x = m.continuous("x", lb=0, ub=1, shape=(3,))
+        m.minimize(x[0] + 2 * x[1] - x[2])
+        terms = self.classify(m)
+        assert len(terms.bilinear) == 0
+        assert len(terms.monomial) == 0
+        assert len(terms.trilinear) == 0
+        assert len(terms.partition_candidates) == 0
+
+    def test_term_incidence_correct(self):
+        """term_incidence maps var_idx → set of term indices it appears in."""
+        m = Model("t")
+        x = m.continuous("x", lb=0, ub=10, shape=(3,))
+        # Two bilinear terms: x[0]*x[1] and x[0]*x[2]
+        m.minimize(x[0] * x[1] + x[0] * x[2])
+        terms = self.classify(m)
+        # x[0] should appear in 2 terms; x[1] and x[2] each in 1
+        assert len(terms.term_incidence[0]) == 2, "x[0] appears in 2 bilinear terms"
+        assert len(terms.term_incidence[1]) == 1
+        assert len(terms.term_incidence[2]) == 1
+
+
+# ===========================================================================
+# Section 2: Variable Selection for AMP Partitioning
+#
+# Module to be created: python/discopt/_jax/partition_selection.py
+# Function: pick_partition_vars(terms, method="auto") -> list[int]
+# ===========================================================================
+
+
+class TestPartitionSelection:
+    """Tests for pick_partition_vars().
+
+    These will all fail with ImportError until partition_selection.py is created.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from discopt._jax.partition_selection import pick_partition_vars  # noqa: F401
+        from discopt._jax.term_classifier import NonlinearTerms  # noqa: F401
+
+        self.pick = pick_partition_vars
+        self.NonlinearTerms = NonlinearTerms
+
+    def _make_terms(self, bilinear=None, trilinear=None, monomial=None):
+        """Helper to build a NonlinearTerms stub."""
+        bilinear = bilinear or []
+        trilinear = trilinear or []
+        monomial = monomial or []
+        candidates = list({v for t in bilinear + trilinear for v in t}
+                         | {v for v, _ in monomial})
+        incidence: dict[int, set[int]] = {}
+        for idx, t in enumerate(bilinear + trilinear):
+            for v in t:
+                incidence.setdefault(v, set()).add(idx)
+        return self.NonlinearTerms(
+            bilinear=bilinear,
+            trilinear=trilinear,
+            monomial=monomial,
+            general_nl=[],
+            term_incidence=incidence,
+            partition_candidates=candidates,
+        )
+
+    def test_max_cover_returns_all_candidates(self):
+        """max_cover selects every variable appearing in any nonlinear term."""
+        terms = self._make_terms(bilinear=[(0, 1), (1, 2)])
+        selected = self.pick(terms, method="max_cover")
+        assert set(selected) == {0, 1, 2}
+
+    def test_min_vertex_cover_covers_all_terms(self):
+        """min_vertex_cover: every bilinear term must have ≥1 selected variable."""
+        # Star: (0,1),(0,2),(0,3),(0,4) — selecting just {0} covers all
+        terms = self._make_terms(bilinear=[(0, 1), (0, 2), (0, 3), (0, 4)])
+        selected = self.pick(terms, method="min_vertex_cover")
+        for t in terms.bilinear:
+            assert any(v in selected for v in t), f"term {t} not covered"
+
+    def test_min_vertex_cover_smaller_than_max_cover(self):
+        """min_vertex_cover should use ≤ variables than max_cover for star graphs."""
+        terms = self._make_terms(bilinear=[(0, 1), (0, 2), (0, 3), (0, 4)])
+        mvc = self.pick(terms, method="min_vertex_cover")
+        maxc = self.pick(terms, method="max_cover")
+        assert len(mvc) <= len(maxc)
+        assert 0 in mvc, "hub variable 0 should be selected"
+
+    def test_min_vertex_cover_path_graph(self):
+        """Path graph: (0,1),(1,2),(2,3) — vertex 1 and 2 cover all edges."""
+        terms = self._make_terms(bilinear=[(0, 1), (1, 2), (2, 3)])
+        selected = self.pick(terms, method="min_vertex_cover")
+        for t in terms.bilinear:
+            assert any(v in selected for v in t), f"term {t} not covered by {selected}"
+
+    def test_auto_uses_max_cover_for_small(self):
+        """auto strategy uses max_cover when ≤15 partition candidates."""
+        terms = self._make_terms(bilinear=[(0, 1), (2, 3)])
+        auto = self.pick(terms, method="auto")
+        maxc = self.pick(terms, method="max_cover")
+        assert set(auto) == set(maxc)
+
+    def test_auto_uses_min_vertex_cover_for_large(self):
+        """auto strategy uses min_vertex_cover when >15 partition candidates."""
+        # 20 variables in a star — hub is var 0
+        terms = self._make_terms(bilinear=[(0, i) for i in range(1, 20)])
+        auto = self.pick(terms, method="auto")
+        mvc = self.pick(terms, method="min_vertex_cover")
+        # Both should cover all terms
+        for t in terms.bilinear:
+            assert any(v in auto for v in t), f"term {t} not covered"
+        # auto should be no larger than max_cover
+        maxc = self.pick(terms, method="max_cover")
+        assert len(auto) <= len(maxc)
+
+    def test_trilinear_terms_covered(self):
+        """Trilinear terms (x*y*z) must also be covered."""
+        terms = self._make_terms(trilinear=[(0, 1, 2)])
+        selected = self.pick(terms, method="min_vertex_cover")
+        t = (0, 1, 2)
+        assert any(v in selected for v in t), "trilinear term not covered"
+
+    def test_empty_terms_returns_empty(self):
+        """No nonlinear terms → empty partition variable list."""
+        terms = self._make_terms()
+        assert self.pick(terms, method="max_cover") == []
+        assert self.pick(terms, method="min_vertex_cover") == []
+
+
+# ===========================================================================
+# Section 3: Discretization State Management
+#
+# Module to be created: python/discopt/_jax/discretization.py
+# Classes/functions:
+#   DiscretizationState
+#   initialize_partitions(var_indices, lb, ub, n_init=2) -> DiscretizationState
+#   add_adaptive_partition(state, solution, var_indices, lb, ub) -> DiscretizationState
+#   check_partition_convergence(state) -> bool
+# ===========================================================================
+
+
+class TestDiscretizationState:
+    """Tests for discretization state management.
+
+    Will fail with ImportError until discretization.py is created.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from discopt._jax.discretization import (  # noqa: F401
+            DiscretizationState,
+            add_adaptive_partition,
+            check_partition_convergence,
+            initialize_partitions,
+        )
+
+        self.DiscretizationState = DiscretizationState
+        self.initialize_partitions = initialize_partitions
+        self.add_adaptive_partition = add_adaptive_partition
+        self.check_partition_convergence = check_partition_convergence
+
+    def test_initialize_correct_breakpoints(self):
+        """2 initial intervals → 3 breakpoints spanning [lb, ub]."""
+        state = self.initialize_partitions([0, 1], lb=[0.0, 2.0], ub=[10.0, 8.0], n_init=2)
+        assert 0 in state.partitions
+        assert 1 in state.partitions
+        pts0 = state.partitions[0]
+        assert pts0[0] == pytest.approx(0.0)
+        assert pts0[-1] == pytest.approx(10.0)
+        assert len(pts0) == 3  # n_init=2 intervals → 3 edges
+
+    def test_initialize_uniform_spacing(self):
+        """Breakpoints should be uniformly spaced with n_init intervals."""
+        state = self.initialize_partitions([0], lb=[0.0], ub=[6.0], n_init=3)
+        pts = state.partitions[0]
+        assert len(pts) == 4
+        diffs = np.diff(pts)
+        assert np.allclose(diffs, diffs[0], atol=1e-12), "Should be uniform spacing"
+
+    def test_adaptive_adds_breakpoints_near_solution(self):
+        """After refinement, new breakpoints should appear near the solution value."""
+        state = self.initialize_partitions([0], lb=[0.0], ub=[10.0], n_init=2)
+        sol = {0: 3.0}
+        state2 = self.add_adaptive_partition(state, sol, [0], lb=[0.0], ub=[10.0])
+        pts = state2.partitions[0]
+        assert len(pts) > len(state.partitions[0]), "Should have more breakpoints"
+        # At least one new breakpoint within 1.5 of the solution (3.0)
+        assert any(1.5 <= p <= 4.5 for p in pts if p not in (0.0, 5.0, 10.0)), (
+            f"Expected breakpoint near 3.0, got {pts}"
+        )
+
+    def test_refinement_reduces_active_partition_width(self):
+        """The partition containing the solution must be split after refinement.
+
+        Note: the GLOBAL max width may not decrease if the solution falls in a
+        non-maximal interval.  Start from a single interval to ensure the active
+        partition IS the widest, so global max must decrease.
+        """
+        # Use n_init=1 → [0.0, 10.0]: single interval of width 10
+        state = self.initialize_partitions([0], lb=[0.0], ub=[10.0], n_init=1)
+        assert len(state.partitions[0]) == 2
+
+        solution = {0: 3.0}
+        state2 = self.add_adaptive_partition(state, solution, [0], lb=[0.0], ub=[10.0])
+        w1 = float(np.max(np.diff(state.partitions[0])))
+        w2 = float(np.max(np.diff(state2.partitions[0])))
+        assert w2 < w1, f"Max width should decrease from single interval: {w1} → {w2}"
+
+    def test_partitions_are_monotonically_refined(self):
+        """After multiple refinements, partitions only become finer (never coarser)."""
+        state = self.initialize_partitions([0], lb=[0.0], ub=[1.0])
+        all_seen: set[float] = set(state.partitions[0].tolist())
+        for sol_val in [0.3, 0.7, 0.15, 0.55]:
+            state = self.add_adaptive_partition(state, {0: sol_val}, [0], [0.0], [1.0])
+            new_pts = set(state.partitions[0].tolist())
+            missing = all_seen - new_pts
+            assert not missing, f"Breakpoints removed during refinement: {missing}"
+            all_seen = new_pts
+        # Endpoints must be preserved
+        pts = state.partitions[0]
+        assert pts[0] == pytest.approx(0.0)
+        assert pts[-1] == pytest.approx(1.0)
+        # Strictly sorted
+        assert all(pts[i] < pts[i + 1] for i in range(len(pts) - 1))
+
+    def test_convergence_check_fine_partitions(self):
+        """check_partition_convergence returns True when all widths < abs_width_tol."""
+        bpts = np.linspace(0, 1, 3000)  # width ≈ 3.3e-4 < 1e-3
+        state = self.DiscretizationState(
+            partitions={0: bpts},
+            scaling_factor=10.0,
+            abs_width_tol=1e-3,
+        )
+        assert self.check_partition_convergence(state) is True
+
+    def test_convergence_check_coarse_partitions(self):
+        """check_partition_convergence returns False when widths > abs_width_tol."""
+        bpts = np.array([0.0, 5.0, 10.0])  # width = 5.0 >> 1e-3
+        state = self.DiscretizationState(
+            partitions={0: bpts},
+            scaling_factor=10.0,
+            abs_width_tol=1e-3,
+        )
+        assert self.check_partition_convergence(state) is False
+
+    def test_bounds_preserved(self):
+        """Lower and upper bounds of partitions must equal provided lb/ub."""
+        state = self.initialize_partitions([0, 1], lb=[-2.0, 0.5], ub=[3.0, 4.5], n_init=4)
+        assert state.partitions[0][0] == pytest.approx(-2.0)
+        assert state.partitions[0][-1] == pytest.approx(3.0)
+        assert state.partitions[1][0] == pytest.approx(0.5)
+        assert state.partitions[1][-1] == pytest.approx(4.5)
+
+
+# ===========================================================================
+# Section 4: Piecewise McCormick Relaxation Validity
+#
+# Tests against EXISTING code in mccormick.py and piecewise_mccormick.py.
+# Some of these should PASS already; failures reveal existing bugs.
+# Key theoretical claim (CP 2016): piecewise gap < standard gap.
+# ===========================================================================
+
+
+class TestMcCormickSoundness:
+    """Soundness tests for McCormick relaxation primitives.
+
+    Theoretical requirement (CP 2016): relaxation must be a valid lower bound.
+    cv ≤ f(x) ≤ cc at every feasible point.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _rng(self):
+        self.rng = np.random.default_rng(42)
+
+    def test_standard_mccormick_bilinear_valid(self):
+        """cv ≤ x*y ≤ cc at 500 random points — core soundness test."""
+        import jax.numpy as jnp
+
+        from discopt._jax.mccormick import relax_bilinear
+
+        x_lb, x_ub, y_lb, y_ub = 1.0, 4.0, 1.0, 4.0
+        for _ in range(500):
+            x = float(self.rng.uniform(x_lb, x_ub))
+            y = float(self.rng.uniform(y_lb, y_ub))
+            cv, cc = relax_bilinear(
+                jnp.float64(x),
+                jnp.float64(y),
+                jnp.float64(x_lb),
+                jnp.float64(x_ub),
+                jnp.float64(y_lb),
+                jnp.float64(y_ub),
+            )
+            w_true = x * y
+            assert float(cv) <= w_true + 1e-9, f"cv={cv} > w={w_true}"
+            assert float(cc) >= w_true - 1e-9, f"cc={cc} < w={w_true}"
+
+    def test_piecewise_mccormick_bilinear_valid(self):
+        """Piecewise McCormick is still a valid relaxation (cv ≤ x*y ≤ cc)."""
+        import jax.numpy as jnp
+
+        from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear
+
+        x_lb, x_ub, y_lb, y_ub = 0.0, 10.0, 0.0, 10.0
+        for _ in range(300):
+            x = float(self.rng.uniform(x_lb, x_ub))
+            y = float(self.rng.uniform(y_lb, y_ub))
+            cv, cc = piecewise_mccormick_bilinear(
+                jnp.float64(x),
+                jnp.float64(y),
+                jnp.float64(x_lb),
+                jnp.float64(x_ub),
+                jnp.float64(y_lb),
+                jnp.float64(y_ub),
+                k=4,
+            )
+            w_true = x * y
+            assert float(cv) <= w_true + 1e-9, f"cv={cv} > w={w_true} at x={x}, y={y}"
+            assert float(cc) >= w_true - 1e-9, f"cc={cc} < w={w_true} at x={x}, y={y}"
+
+    def test_piecewise_strictly_tighter_than_standard(self):
+        """Piecewise gap < standard gap at the midpoint (key claim from CP 2016).
+
+        At the center of the domain, standard McCormick has its maximum gap.
+        Piecewise must be strictly tighter.
+        """
+        import jax.numpy as jnp
+
+        from discopt._jax.mccormick import relax_bilinear
+        from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear
+
+        x_lb, x_ub, y_lb, y_ub = 0.0, 10.0, 0.0, 10.0
+        x, y = 5.0, 5.0  # exact midpoint — maximum standard McCormick gap
+
+        cv_std, cc_std = relax_bilinear(
+            jnp.float64(x),
+            jnp.float64(y),
+            jnp.float64(x_lb),
+            jnp.float64(x_ub),
+            jnp.float64(y_lb),
+            jnp.float64(y_ub),
+        )
+        cv_pw, cc_pw = piecewise_mccormick_bilinear(
+            jnp.float64(x),
+            jnp.float64(y),
+            jnp.float64(x_lb),
+            jnp.float64(x_ub),
+            jnp.float64(y_lb),
+            jnp.float64(y_ub),
+            k=4,
+        )
+        gap_std = float(cc_std - cv_std)
+        gap_pw = float(cc_pw - cv_pw)
+
+        assert gap_pw < gap_std, (
+            f"Piecewise gap {gap_pw:.4f} must be < standard gap {gap_std:.4f}"
+        )
+        # Also verify piecewise is still sound
+        w_true = x * y
+        assert float(cv_pw) <= w_true + 1e-9
+        assert float(cc_pw) >= w_true - 1e-9
+
+    def test_piecewise_gap_decreases_with_k(self):
+        """Gap must decrease as k increases (convergence property from CP 2016).
+
+        Theoretical bound: max gap ≤ (domain_width / k)².
+        """
+        import jax.numpy as jnp
+
+        from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear
+
+        x_lb, x_ub, y_lb, y_ub = 0.0, 10.0, 0.0, 10.0
+        x, y = 3.0, 7.0
+        prev_gap = float("inf")
+        for k in [2, 4, 8, 16]:
+            cv, cc = piecewise_mccormick_bilinear(
+                jnp.float64(x),
+                jnp.float64(y),
+                jnp.float64(x_lb),
+                jnp.float64(x_ub),
+                jnp.float64(y_lb),
+                jnp.float64(y_ub),
+                k=k,
+            )
+            gap = float(cc - cv)
+            assert gap < prev_gap, f"Gap should decrease as k increases (k={k})"
+            prev_gap = gap
+
+    def test_piecewise_is_solution_agnostic(self):
+        """Document: current piecewise_mccormick is curvature-based, NOT solution-adaptive.
+
+        This test SHOULD PASS — it documents existing behavior as a baseline.
+        The AMP implementation will add solution-adaptive refinement separately.
+        """
+        from discopt._jax.piecewise_mccormick import _partition_bounds
+
+        # Same call twice → identical result (no solution context)
+        import jax.numpy as jnp
+
+        lbs1, ubs1 = _partition_bounds(jnp.float64(0.0), jnp.float64(10.0), 4)
+        lbs2, ubs2 = _partition_bounds(jnp.float64(0.0), jnp.float64(10.0), 4)
+        np.testing.assert_array_equal(
+            np.array(lbs1),
+            np.array(lbs2),
+            err_msg="Curvature-based partition is deterministic (good baseline)",
+        )
+
+
+# ===========================================================================
+# Section 5: MILP Relaxation Lower Bound Validity
+#
+# Module to be created: python/discopt/_jax/milp_relaxation.py
+# Function: build_milp_relaxation(model, terms, disc_state, incumbent) -> (model_obj, varmap)
+#
+# These tests will fail with ImportError until milp_relaxation.py exists.
+# Key invariant: MILP LB ≤ global optimum (soundness).
+# ===========================================================================
+
+
+class TestMilpRelaxation:
+    """Tests for build_milp_relaxation().
+
+    Will fail with ImportError until milp_relaxation.py is created.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from discopt._jax.discretization import initialize_partitions
+        from discopt._jax.milp_relaxation import build_milp_relaxation
+        from discopt._jax.term_classifier import classify_nonlinear_terms
+
+        self.classify = classify_nonlinear_terms
+        self.init_partitions = initialize_partitions
+        self.build_milp = build_milp_relaxation
+
+    def _build_and_solve(self, model, n_init=2):
+        terms = self.classify(model)
+        lb_arr = []
+        ub_arr = []
+        for v in model._variables:
+            lb_arr.extend(v.lb.tolist() if hasattr(v.lb, "tolist") else [float(v.lb)])
+            ub_arr.extend(v.ub.tolist() if hasattr(v.ub, "tolist") else [float(v.ub)])
+        state = self.init_partitions(
+            terms.partition_candidates,
+            lb=[lb_arr[i] for i in terms.partition_candidates],
+            ub=[ub_arr[i] for i in terms.partition_candidates],
+            n_init=n_init,
+        )
+        milp_model, varmap = self.build_milp(model, terms, state, incumbent=None)
+        result = milp_model.solve()
+        return result
+
+    def test_milp_lb_valid_nlp1(self):
+        """MILP LB must be ≤ known global optimum 58.38368 for nlp1."""
+        result = self._build_and_solve(_make_nlp1())
+        assert result.status not in ("infeasible", "error"), (
+            f"MILP relaxation of nlp1 should be feasible, got {result.status}"
+        )
+        if result.objective is not None:
+            assert result.objective <= 58.4 + 1e-4, (
+                f"MILP LB {result.objective:.6f} exceeds known global optimum 58.38368"
+            )
+
+    def test_milp_lb_valid_circle(self):
+        """MILP LB must be ≤ √2 ≈ 1.41421 for circle problem."""
+        result = self._build_and_solve(_make_circle())
+        assert result.status not in ("infeasible", "error")
+        if result.objective is not None:
+            assert result.objective <= 1.41422 + 1e-4, (
+                f"MILP LB {result.objective:.6f} exceeds known global optimum √2"
+            )
+
+    def test_milp_lb_tightens_with_finer_partitions(self):
+        """LB must be non-decreasing as partition count increases (key paper claim)."""
+        m = _make_nlp1()
+        lbs = []
+        for n_init in [1, 2, 4, 8]:
+            result = self._build_and_solve(m, n_init=n_init)
+            if result.objective is not None:
+                lbs.append(result.objective)
+            else:
+                lbs.append(-np.inf)
+        # Lower bounds must be non-decreasing with finer partitions
+        for i in range(len(lbs) - 1):
+            assert lbs[i] <= lbs[i + 1] + 1e-6, (
+                f"LBs must be non-decreasing: lbs[{i}]={lbs[i]:.4f} > lbs[{i+1}]={lbs[i+1]:.4f}"
+            )
+
+    def test_milp_relaxation_feasible_when_problem_feasible(self):
+        """Relaxation must be feasible when original problem is feasible."""
+        for m in [_make_nlp1(), _make_circle()]:
+            result = self._build_and_solve(m)
+            assert result.status != "infeasible", (
+                f"MILP relaxation infeasible for a feasible problem: {m._name}"
+            )
+
+
+# ===========================================================================
+# Section 6: End-to-End AMP Solver (Alpine canonical problems)
+#
+# Requires:
+#   - python/discopt/solvers/amp.py (solve_amp function)
+#   - python/discopt/solver.py routing for solver="amp"
+#
+# Known optima from Alpine.jl test suite.
+# ===========================================================================
+
+# Known global optima (from Alpine.jl test suite + standard references)
+NLP1_OPTIMUM = 58.38368   # Alpine nlp1
+CIRCLE_OPTIMUM = 1.41421356  # √2
+NLP3_OPTIMUM = 7049.247898   # Alpine nlp3
+
+
+class TestAmpEndToEnd:
+    """End-to-end AMP solver tests on Alpine canonical problems.
+
+    Will fail until solvers/amp.py exists and solver.py routes solver="amp".
+    """
+
+    @pytest.mark.smoke
+    def test_nlp1_bilinear_global_optimum(self):
+        """nlp1: bilinear MINLP solved to global optimum ≈ 58.38368."""
+        from discopt.modeling.core import SolveResult
+
+        m = _make_nlp1()
+        result = m.solve(solver="amp", rel_gap=1e-3, time_limit=60)
+        assert result.status == "optimal", f"Expected optimal, got {result.status}"
+        assert result.gap_certified is True, "Gap must be certified for AMP"
+        assert result.objective is not None
+        assert abs(result.objective - NLP1_OPTIMUM) <= 0.15, (
+            f"Objective {result.objective:.5f} too far from {NLP1_OPTIMUM}"
+        )
+
+    @pytest.mark.smoke
+    def test_circle_bilinear_global_optimum(self):
+        """circle: x₀²+x₁²≥2 minimized to global optimum √2."""
+        m = _make_circle()
+        result = m.solve(solver="amp", rel_gap=1e-4, time_limit=60)
+        assert result.status == "optimal"
+        assert result.gap_certified is True
+        assert result.objective is not None
+        assert abs(result.objective - CIRCLE_OPTIMUM) <= 1e-3, (
+            f"Objective {result.objective:.6f} too far from √2={CIRCLE_OPTIMUM}"
+        )
+
+    @pytest.mark.slow
+    def test_nlp3_multilinear_global_optimum(self):
+        """nlp3: 8-variable multilinear industrial problem."""
+        m = _build_nlp3()
+        result = m.solve(solver="amp", rel_gap=1e-3, time_limit=300)
+        assert result.status in ("optimal", "feasible")
+        assert result.objective is not None
+        assert abs(result.objective - NLP3_OPTIMUM) <= 2.0, (
+            f"Objective {result.objective:.3f} too far from {NLP3_OPTIMUM}"
+        )
+
+    @pytest.mark.smoke
+    def test_bilinear_minlp_global(self):
+        """MINLP with bilinear product + integer variable."""
+        m = Model("bi_minlp")
+        x = m.continuous("x", lb=0, ub=5, shape=(2,))
+        y = m.integer("y", lb=0, ub=3)
+        m.subject_to(x[0] * x[1] + y >= 4)
+        m.minimize(x[0] ** 2 + x[1] ** 2 + y)
+        result = m.solve(solver="amp", rel_gap=1e-3, time_limit=60)
+        assert result.status in ("optimal", "feasible")
+        assert result.objective is not None
+        # x[0]*x[1]≥4-y: optimal at x[0]=x[1]=2, y=0 → obj=8 or similar
+        assert result.objective >= 0
+
+    @pytest.mark.smoke
+    def test_pure_quadratic_convex(self):
+        """min x²  s.t. x ≥ 1: AMP should certify global optimum = 1."""
+        m = Model("quad")
+        x = m.continuous("x", lb=1, ub=10)
+        m.minimize(x ** 2)
+        result = m.solve(solver="amp", rel_gap=1e-4, time_limit=30)
+        assert result.status == "optimal"
+        assert result.objective is not None
+        assert abs(result.objective - 1.0) <= 1e-3
+
+
+# ===========================================================================
+# Section 7: Convergence Property Tests
+#
+# Verify key theoretical invariants from JOGO 2018:
+#   (a) LB sequence is monotonically non-decreasing
+#   (b) UB sequence is monotonically non-increasing
+#   (c) gap_certified=True iff termination by gap criterion
+#   (d) early termination when gap closes
+#   (e) time_limit respected
+# ===========================================================================
+
+
+class TestAmpConvergenceProperties:
+    """Test AMP's theoretical convergence properties.
+
+    Will fail until solvers/amp.py supports iteration_callback.
+    """
+
+    @pytest.mark.smoke
+    def test_lower_bound_monotone(self):
+        """LB sequence must be non-decreasing across AMP iterations (JOGO 2018)."""
+        m = _make_nlp1()
+        lbs = []
+
+        def cb(info):
+            lbs.append(info["lower_bound"])
+
+        m.solve(solver="amp", rel_gap=1e-6, max_iter=6, iteration_callback=cb, time_limit=60)
+        assert len(lbs) >= 2, "Should have at least 2 iterations"
+        for i in range(len(lbs) - 1):
+            assert lbs[i] <= lbs[i + 1] + 1e-8, (
+                f"LB decreased at iteration {i}: {lbs[i]:.6f} > {lbs[i+1]:.6f}"
+            )
+
+    @pytest.mark.smoke
+    def test_upper_bound_monotone(self):
+        """UB sequence must be non-increasing (best feasible improves or stays same)."""
+        m = _make_nlp1()
+        ubs = []
+
+        def cb(info):
+            ubs.append(info["upper_bound"])
+
+        m.solve(solver="amp", rel_gap=1e-6, max_iter=6, iteration_callback=cb, time_limit=60)
+        # Filter out inf (no feasible found yet)
+        finite_ubs = [(i, u) for i, u in enumerate(ubs) if u < 1e18]
+        for j in range(len(finite_ubs) - 1):
+            i1, u1 = finite_ubs[j]
+            i2, u2 = finite_ubs[j + 1]
+            assert u2 <= u1 + 1e-8, (
+                f"UB increased at iteration {i2}: {u1:.6f} → {u2:.6f}"
+            )
+
+    @pytest.mark.smoke
+    def test_gap_certified_after_convergence(self):
+        """gap_certified must be True after AMP converges by gap criterion."""
+        m = _make_circle()
+        result = m.solve(solver="amp", rel_gap=0.05, time_limit=30)
+        # If we converged by gap criterion, gap_certified must be True
+        if result.status == "optimal":
+            assert result.gap_certified is True
+
+    @pytest.mark.smoke
+    def test_early_termination_when_gap_closes(self):
+        """AMP should terminate before max_iter when gap closes."""
+        m = _make_circle()
+        iters = []
+
+        def cb(info):
+            iters.append(info["iteration"])
+
+        result = m.solve(
+            solver="amp", rel_gap=0.5, max_iter=100, iteration_callback=cb, time_limit=30
+        )
+        if result.status == "optimal":
+            # If gap-terminated, should be well before max_iter
+            assert len(iters) < 100, (
+                "Should terminate before max_iter=100 when gap closes"
+            )
+
+    @pytest.mark.smoke
+    def test_time_limit_respected(self):
+        """AMP must respect the time_limit parameter."""
+        import time
+
+        m = _build_nlp3()
+        t0 = time.perf_counter()
+        result = m.solve(solver="amp", time_limit=3.0)
+        elapsed = time.perf_counter() - t0
+        # Allow 5s buffer for cleanup
+        assert elapsed <= 8.0, f"Time limit 3s violated: ran {elapsed:.1f}s"
+        assert result.status in ("optimal", "feasible", "time_limit", "infeasible")
+
+    @pytest.mark.smoke
+    def test_max_iter_respected(self):
+        """AMP must terminate at max_iter if gap not closed."""
+        m = _build_nlp3()
+        iters = []
+
+        def cb(info):
+            iters.append(info["iteration"])
+
+        m.solve(solver="amp", max_iter=3, time_limit=300)
+        assert len(iters) <= 3, f"max_iter=3 violated: {len(iters)} iterations"
+
+
+# ===========================================================================
+# Section 8: Weakness Probes (Tests Designed to Expose Current Gaps)
+#
+# These tests probe the *current* implementation for known limitations.
+# Some may pass (confirming good existing behavior) or fail (revealing gaps).
+# ===========================================================================
+
+
+class TestCurrentCodeWeaknesses:
+    """Probe existing code for gaps relevant to AMP implementation.
+
+    These are diagnostic tests — failures here guide implementation priorities.
+    """
+
+    def test_spatial_bnb_bilinear_global_correctness(self):
+        """Existing spatial B&B should solve nlp1 to global optimum.
+
+        If this fails: existing spatial B&B cannot certify global optimality
+        on bilinear problems (needs AMP's MILP-based lower bound).
+        """
+        m = _make_nlp1()
+        result = m.solve(time_limit=60, gap_tolerance=1e-3)
+        assert result.objective is not None, "Spatial B&B failed to find any solution"
+        assert abs(result.objective - NLP1_OPTIMUM) <= 0.5, (
+            f"Spatial B&B found {result.objective:.4f}, expected near {NLP1_OPTIMUM} "
+            f"(gap={abs(result.objective - NLP1_OPTIMUM):.4f})"
+        )
+
+    def test_circle_monomial_global_correctness(self):
+        """Existing solver should handle x²+y²≥2 correctly (monomials)."""
+        m = _make_circle()
+        result = m.solve(time_limit=30, gap_tolerance=1e-3)
+        assert result.objective is not None
+        # Global optimum is √2 ≈ 1.41421
+        assert abs(result.objective - CIRCLE_OPTIMUM) <= 0.1, (
+            f"Existing solver found {result.objective:.5f}, expected near {CIRCLE_OPTIMUM}"
+        )
+
+    def test_monomial_square_is_convex(self):
+        """x² is convex — should solve to x=0 globally even without AMP."""
+        m = Model("quad_convex")
+        x = m.continuous("x", lb=-3, ub=3)
+        m.minimize(x ** 2)
+        result = m.solve()
+        assert result.objective is not None
+        assert abs(result.objective) < 1e-4, (
+            f"x² on [-3,3] has global min 0 at x=0, got {result.objective}"
+        )
+
+    def test_existing_piecewise_mccormick_bilinear_function_exists(self):
+        """piecewise_mccormick_bilinear must exist in piecewise_mccormick.py.
+
+        If this fails: the function was removed or renamed.
+        """
+        from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear  # noqa: F401
+
+        assert callable(piecewise_mccormick_bilinear)
+
+    def test_obbt_runs_on_bilinear_model(self):
+        """OBBT should run without errors on a model with bilinear constraints.
+
+        If this fails: OBBT cannot handle nonlinear constraints.
+        """
+        try:
+            from discopt._jax.obbt import run_obbt
+
+            m = _make_nlp1()
+            # Just check it doesn't crash — bound tightening quality tested separately
+            run_obbt(m)
+        except (ImportError, NotImplementedError):
+            pytest.skip("OBBT module not available")
+        except Exception as e:
+            pytest.fail(f"OBBT crashed on bilinear model: {e}")
+
+    def test_existing_milp_solver_available(self):
+        """HiGHS MILP solver must be available for AMP to use."""
+        try:
+            from discopt.solvers.milp_highs import solve_milp  # noqa: F401
+
+            assert callable(solve_milp)
+        except ImportError:
+            # Try alternative import path
+            try:
+                import highspy  # noqa: F401
+            except ImportError:
+                pytest.skip("HiGHS not available")
+
+    def test_relaxation_compiler_handles_bilinear(self):
+        """Relaxation compiler must handle BinaryOp('*', Variable, Variable)."""
+        try:
+            from discopt._jax.relaxation_compiler import compile_relaxation
+
+            m = _make_nlp1()
+            # compile_relaxation(expr, model, partitions, mode)
+            assert m._objective is not None
+            compile_relaxation(m._objective.expression, m, partitions=0, mode="standard")
+        except (ImportError, AttributeError):
+            pytest.skip("relaxation_compiler not available in expected form")
+        except Exception as e:
+            pytest.fail(f"Relaxation compiler failed on bilinear model: {e}")
+
+    @pytest.mark.smoke
+    def test_solve_result_has_gap_certified(self):
+        """SolveResult must have gap_certified attribute."""
+        m = Model("t")
+        x = m.continuous("x", lb=0, ub=1)
+        m.minimize(x)
+        result = m.solve()
+        assert hasattr(result, "gap_certified"), "SolveResult missing gap_certified field"
+
+    @pytest.mark.smoke
+    def test_solve_result_has_bound(self):
+        """SolveResult must have bound attribute (dual lower bound)."""
+        m = Model("t")
+        x = m.continuous("x", lb=0, ub=1)
+        m.minimize(x)
+        result = m.solve()
+        assert hasattr(result, "bound"), "SolveResult missing bound field"

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -355,6 +355,25 @@ class TestPartitionSelection:
 
         assert set(selected) == {0}
 
+    def test_adaptive_vertex_cover_uses_distance_weights(self):
+        """Adaptive cover should favor high-distance variables on large graphs."""
+        terms = self._make_terms(bilinear=[(i, i + 1) for i in range(16)])
+        distance = {
+            i: (10.0 if i % 2 == 0 else 1e-3)
+            for i in terms.partition_candidates
+        }
+
+        selected = self.pick(
+            terms,
+            method="adaptive_vertex_cover",
+            distance=distance,
+        )
+
+        assert selected
+        assert all(v % 2 == 0 for v in selected)
+        for t in terms.bilinear:
+            assert any(v in selected for v in t), f"term {t} not covered"
+
 
 # ===========================================================================
 # Section 3: Discretization State Management
@@ -379,6 +398,7 @@ class TestDiscretizationState:
         from discopt._jax.discretization import (  # noqa: F401
             DiscretizationState,
             add_adaptive_partition,
+            add_uniform_partition,
             check_partition_convergence,
             initialize_partitions,
         )
@@ -386,6 +406,7 @@ class TestDiscretizationState:
         self.DiscretizationState = DiscretizationState
         self.initialize_partitions = initialize_partitions
         self.add_adaptive_partition = add_adaptive_partition
+        self.add_uniform_partition = add_uniform_partition
         self.check_partition_convergence = check_partition_convergence
 
     def test_initialize_correct_breakpoints(self):
@@ -451,6 +472,15 @@ class TestDiscretizationState:
         assert pts[-1] == pytest.approx(1.0)
         # Strictly sorted
         assert all(pts[i] < pts[i + 1] for i in range(len(pts) - 1))
+
+    def test_uniform_refinement_splits_every_interval(self):
+        """Uniform refinement should bisect each current interval."""
+        state = self.initialize_partitions([0], lb=[0.0], ub=[4.0], n_init=2)
+        state2 = self.add_uniform_partition(state, {}, [0], [0.0], [4.0])
+        np.testing.assert_allclose(
+            state2.partitions[0],
+            np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
+        )
 
     def test_convergence_check_fine_partitions(self):
         """check_partition_convergence returns True when all widths < abs_width_tol."""
@@ -776,6 +806,77 @@ class TestMilpRelaxation:
         assert result.x is not None
         assert abs(float(result.x[1]) - round(float(result.x[1]))) <= 1e-8
 
+    def test_lambda_convhull_builds_expected_auxiliaries(self):
+        """The λ-convex-hull formulation should expose lambda, alpha, and theta blocks."""
+        m = _make_nlp1()
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[1.0], ub=[4.0], n_init=2)
+
+        _, varmap = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="sos2",
+        )
+
+        info = varmap["bilinear_lambda"][(0, 1)]
+        assert varmap["convhull_formulation"] == "sos2"
+        assert info["breakpoints"] == [1.0, 2.5, 4.0]
+        assert len(info["lambda_cols"]) == 3
+        assert len(info["alpha_cols"]) == 2
+        assert len(info["theta_cols"]) == 3
+
+    def test_sos2_and_facet_convhull_match_on_simple_bilinear_relaxation(self):
+        """SOS2 and facet λ-linking should give the same bound on a simple problem."""
+        m = Model("lambda_compare")
+        x = m.continuous("x", lb=0, ub=2, shape=(2,))
+        m.subject_to(x[0] * x[1] >= 1.0)
+        m.minimize(x[0] + x[1])
+
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[0.0], ub=[2.0], n_init=2)
+
+        sos2_model, _ = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="sos2",
+        )
+        facet_model, _ = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="facet",
+        )
+
+        sos2_result = sos2_model.solve()
+        facet_result = facet_model.solve()
+
+        assert sos2_result.status == "optimal"
+        assert facet_result.status == "optimal"
+        assert sos2_result.objective is not None
+        assert facet_result.objective is not None
+        assert sos2_result.objective == pytest.approx(facet_result.objective, abs=1e-6)
+        assert sos2_result.objective <= 2.0 + 1e-6
+
+    def test_invalid_convhull_formulation_raises(self):
+        """Unsupported convex-hull mode names should fail fast."""
+        m = _make_nlp1()
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[1.0], ub=[4.0], n_init=2)
+
+        with pytest.raises(ValueError, match="Unsupported convhull_formulation"):
+            self.build_milp(
+                m,
+                terms,
+                state,
+                incumbent=None,
+                convhull_formulation="bogus",
+            )
+
 
 class TestAmpPhase1Helpers:
     """Fast regression tests for Phase 1 helper behavior."""
@@ -1072,6 +1173,45 @@ class TestCurrentCodeWeaknesses:
 
         assert "solver" in inspect.signature(solve_model).parameters
 
+    def test_solve_model_forwards_alpine_amp_aliases(self, monkeypatch):
+        """solve_model should pass Alpine-style AMP aliases through to solve_amp."""
+        from discopt.modeling.core import SolveResult
+        from discopt.solver import solve_model
+        from discopt.solvers import amp as amp_mod
+
+        captured = {}
+
+        def fake_solve_amp(model, **kwargs):
+            del model
+            captured.update(kwargs)
+            return SolveResult(status="infeasible", wall_time=0.0)
+
+        monkeypatch.setattr(amp_mod, "solve_amp", fake_solve_amp)
+
+        m = Model("alias_forwarding")
+        x = m.continuous("x", lb=0, ub=1)
+        m.minimize(x)
+
+        solve_model(
+            m,
+            solver="amp",
+            gap_tolerance=1e-3,
+            apply_partitioning=False,
+            disc_var_pick=1,
+            partition_scaling_factor=7.0,
+            disc_add_partition_method="uniform",
+            disc_abs_width_tol=1e-2,
+            convhull_formulation="sos2",
+        )
+
+        assert captured["rel_gap"] == pytest.approx(1e-3)
+        assert captured["apply_partitioning"] is False
+        assert captured["disc_var_pick"] == 1
+        assert captured["partition_scaling_factor"] == pytest.approx(7.0)
+        assert captured["disc_add_partition_method"] == "uniform"
+        assert captured["disc_abs_width_tol"] == pytest.approx(1e-2)
+        assert captured["convhull_formulation"] == "sos2"
+
     def test_integer_rounding_candidates_include_floor_and_ceil(self):
         """Nearest-integer rounding fallback must try floor and ceil alternatives."""
         from discopt.solvers import amp as amp_mod
@@ -1198,7 +1338,15 @@ class TestCurrentCodeWeaknesses:
                     x=np.zeros(1, dtype=np.float64),
                 )
 
-        def fake_build(model, terms, disc_state, incumbent, oa_cuts=None):
+        def fake_build(
+            model,
+            terms,
+            disc_state,
+            incumbent,
+            oa_cuts=None,
+            convhull_formulation="disaggregated",
+        ):
+            assert convhull_formulation == "disaggregated"
             size = len(oa_cuts or [])
             call_sizes.append(size)
             status = "infeasible" if size >= 4 else "optimal"
@@ -1217,6 +1365,7 @@ class TestCurrentCodeWeaknesses:
             oa_cuts=[("c1", 1), ("c2", 2), ("c3", 3), ("c4", 4)],
             time_limit=1.0,
             gap_tolerance=1e-4,
+            convhull_formulation="disaggregated",
         )
 
         assert call_sizes == [4, 2]

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -176,6 +176,18 @@ class TestTermClassifier:
         assert len(terms.bilinear) >= 1
         assert len(terms.monomial) >= 2  # x[0]**2 and x[1]**2
 
+    def test_repeated_factor_product_is_general_nl(self):
+        """Mixed repeated-factor products like x*x*y must not be misclassified as bilinear."""
+        m = Model("repeat_factor")
+        x = m.continuous("x", lb=0, ub=10, shape=(2,))
+        m.minimize((x[0] * x[0]) * x[1])
+
+        terms = self.classify(m)
+
+        assert len(terms.bilinear) == 0
+        assert len(terms.general_nl) >= 1
+        assert (0, 2) in terms.monomial
+
     def test_partition_candidates_excludes_linear_vars(self):
         """Variable not in any nonlinear term must NOT be a partition candidate."""
         m = Model("t")
@@ -327,6 +339,21 @@ class TestPartitionSelection:
         terms = self._make_terms()
         assert self.pick(terms, method="max_cover") == []
         assert self.pick(terms, method="min_vertex_cover") == []
+
+    def test_min_vertex_cover_falls_back_to_greedy_cover(self, monkeypatch):
+        """When the MILP cover solve fails, the greedy fallback should still cover all terms."""
+        import discopt._jax.partition_selection as part_sel
+
+        terms = self._make_terms(bilinear=[(0, 1), (0, 2), (0, 3), (0, 4)])
+        monkeypatch.setattr(
+            part_sel,
+            "_solve_vertex_cover_milp",
+            lambda candidates, all_t: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+
+        selected = self.pick(terms, method="min_vertex_cover")
+
+        assert set(selected) == {0}
 
 
 # ===========================================================================
@@ -639,8 +666,8 @@ class TestMilpRelaxation:
         lb_arr = []
         ub_arr = []
         for v in model._variables:
-            lb_arr.extend(v.lb.tolist() if hasattr(v.lb, "tolist") else [float(v.lb)])
-            ub_arr.extend(v.ub.tolist() if hasattr(v.ub, "tolist") else [float(v.ub)])
+            lb_arr.extend(np.asarray(v.lb, dtype=np.float64).ravel().tolist())
+            ub_arr.extend(np.asarray(v.ub, dtype=np.float64).ravel().tolist())
         state = self.init_partitions(
             terms.partition_candidates,
             lb=[lb_arr[i] for i in terms.partition_candidates],
@@ -695,6 +722,75 @@ class TestMilpRelaxation:
                 f"MILP relaxation infeasible for a feasible problem: {m._name}"
             )
 
+    def test_piecewise_interval_rows_use_interval_specific_bounds(self):
+        """Piecewise product rows must use the current interval's wk_hi, not a stale value."""
+        import scipy.sparse as sp
+
+        from discopt._jax.discretization import DiscretizationState
+        from discopt._jax.term_classifier import classify_nonlinear_terms
+
+        m = Model("piecewise_bounds")
+        x = m.continuous("x", lb=1, ub=5)
+        y = m.continuous("y", lb=10, ub=20)
+        m.minimize(x * y)
+
+        terms = classify_nonlinear_terms(m)
+        state = DiscretizationState(partitions={0: np.array([1.0, 2.5, 4.0, 5.0])})
+        milp_model, varmap = self.build_milp(m, terms, state, incumbent=None)
+
+        assert sp.issparse(milp_model._A_ub)
+        A_csr = milp_model._A_ub.tocsr()
+        b_ub = np.asarray(milp_model._b_ub, dtype=np.float64)
+
+        for delta_col, _, wbar_col, a_k, b_k in varmap["bilinear_pw"][(0, 1)]:
+            expected_hi = max(
+                a_k * 10.0,
+                a_k * 20.0,
+                b_k * 10.0,
+                b_k * 20.0,
+            )
+            matched = False
+            for row_idx in range(A_csr.shape[0]):
+                row = A_csr.getrow(row_idx)
+                if row.nnz != 2 or abs(b_ub[row_idx]) > 1e-12:
+                    continue
+                coeffs = dict(zip(row.indices.tolist(), row.data.tolist()))
+                if coeffs.get(wbar_col) == 1.0 and coeffs.get(delta_col) == -expected_hi:
+                    matched = True
+                    break
+            assert matched, f"missing interval-specific upper row for [{a_k}, {b_k}]"
+
+    def test_milp_respects_original_variable_integrality(self):
+        """Original integer variables must stay integral in the MILP relaxation."""
+        m = Model("orig_integrality")
+        x = m.continuous("x", lb=0, ub=1)
+        y = m.integer("y", lb=0, ub=3)
+        m.subject_to(x * y >= 1.8)
+        m.minimize(y)
+
+        result = self._build_and_solve(m)
+
+        assert result.status == "optimal"
+        assert result.objective is not None
+        assert result.objective >= 2.0 - 1e-8
+        assert result.x is not None
+        assert abs(float(result.x[1]) - round(float(result.x[1]))) <= 1e-8
+
+
+class TestAmpPhase1Helpers:
+    """Fast regression tests for Phase 1 helper behavior."""
+
+    def test_piecewise_big_m_scales_with_large_coefficients(self):
+        """Big-M must scale with coefficient magnitude instead of adding a flat 1.0."""
+        from discopt._jax.milp_relaxation import _compute_piecewise_big_m
+
+        corners = [-25000.0, 10000.0, 5000.0, 30000.0]
+        big_m = _compute_piecewise_big_m(corners)
+        expected = 30000.0 * (1.0 + 1e-4) + 1e-2
+
+        assert big_m == pytest.approx(expected)
+        assert big_m > 30000.0
+
 
 # ===========================================================================
 # Section 6: End-to-End AMP Solver (Alpine canonical problems)
@@ -745,6 +841,11 @@ class TestAmpEndToEnd:
         )
 
     @pytest.mark.slow
+    @pytest.mark.timeout(300)
+    @pytest.mark.xfail(
+        reason="nlp3 MILP exceeds test budget; tracked in #24",
+        strict=False,
+    )
     def test_nlp3_multilinear_global_optimum(self):
         """nlp3: 8-variable multilinear industrial problem."""
         m = _build_nlp3()
@@ -779,6 +880,36 @@ class TestAmpEndToEnd:
         assert result.status == "optimal"
         assert result.objective is not None
         assert abs(result.objective - 1.0) <= 1e-3
+
+    @pytest.mark.smoke
+    def test_zero_upper_bound_reports_no_relative_gap(self):
+        """Relative gap should be left undefined when the incumbent objective is numerically zero."""
+        m = Model("zero_gap")
+        x = m.continuous("x", lb=-1, ub=1)
+        m.minimize(x ** 2)
+
+        result = m.solve(solver="amp", rel_gap=1e-4, time_limit=30)
+
+        assert result.status == "optimal"
+        assert result.objective is not None
+        assert abs(result.objective) <= 1e-6
+        assert result.gap is None
+
+    def test_bilinear_maximize_global_optimum(self):
+        """AMP must handle maximize objectives with certified bounds."""
+        m = Model("max_bilinear")
+        x = m.continuous("x", lb=0, ub=2, shape=(2,))
+        m.subject_to(x[0] + x[1] <= 2)
+        m.maximize(x[0] * x[1])
+
+        result = m.solve(solver="amp", rel_gap=1e-3, time_limit=60)
+
+        assert result.status == "optimal"
+        assert result.gap_certified is True
+        assert result.objective is not None
+        assert abs(result.objective - 1.0) <= 1e-3
+        assert result.bound is not None
+        assert result.bound >= result.objective - 1e-6
 
 
 # ===========================================================================
@@ -901,6 +1032,94 @@ class TestCurrentCodeWeaknesses:
     These are diagnostic tests — failures here guide implementation priorities.
     """
 
+    def test_constraint_check_rejects_eval_failure(self, monkeypatch):
+        """Constraint evaluation errors must reject the candidate point."""
+        import discopt._jax.nlp_evaluator as nlp_eval
+        from discopt.solvers import amp as amp_mod
+
+        class BrokenEvaluator:
+            def __init__(self, model):
+                self.n_constraints = 1
+                self.constraint_bounds = (np.array([0.0]), np.array([1.0]))
+
+            def evaluate_constraints(self, x):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(nlp_eval, "NLPEvaluator", BrokenEvaluator)
+
+        m = Model("broken_eval")
+        x = m.continuous("x", lb=0, ub=1)
+        m.subject_to(x >= 0)
+        m.minimize(x)
+
+        assert amp_mod._check_constraints(np.array([0.5]), m) is False
+
+    def test_solve_model_signature_exposes_solver_parameter(self):
+        """solve_model should expose the backend selector in its signature."""
+        import inspect
+
+        from discopt.solver import solve_model
+
+        assert "solver" in inspect.signature(solve_model).parameters
+
+    def test_integer_rounding_candidates_include_floor_and_ceil(self):
+        """Nearest-integer rounding fallback must try floor and ceil alternatives."""
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("rounding")
+        y = m.integer("y", lb=0, ub=3, shape=(2,))
+        x0 = np.array([1.49, 1.51], dtype=np.float64)
+
+        candidates = amp_mod._integer_rounding_candidates(x0, m)
+        rounded = {tuple(float(v) for v in cand) for cand in candidates}
+
+        assert (1.0, 2.0) in rounded  # nearest
+        assert (1.0, 1.0) in rounded  # floor on the second variable
+        assert (2.0, 2.0) in rounded  # ceil on the first variable
+
+    def test_oa_cut_recovery_drops_oldest_half(self, monkeypatch):
+        """OA recovery should retry with the oldest half of cuts removed."""
+        from discopt._jax.milp_relaxation import MilpRelaxationResult
+        from discopt.solvers import amp as amp_mod
+
+        call_sizes = []
+
+        class FakeMilpModel:
+            def __init__(self, status):
+                self.status = status
+
+            def solve(self, time_limit=None, gap_tolerance=None):
+                return MilpRelaxationResult(
+                    status=self.status,
+                    objective=0.0,
+                    x=np.zeros(1, dtype=np.float64),
+                )
+
+        def fake_build(model, terms, disc_state, incumbent, oa_cuts=None):
+            size = len(oa_cuts or [])
+            call_sizes.append(size)
+            status = "infeasible" if size >= 4 else "optimal"
+            return FakeMilpModel(status), {"dummy": True}
+
+        monkeypatch.setattr(
+            "discopt._jax.milp_relaxation.build_milp_relaxation",
+            fake_build,
+        )
+
+        result, _, kept_cuts = amp_mod._solve_milp_with_oa_recovery(
+            model=None,
+            terms=None,
+            disc_state=None,
+            incumbent=None,
+            oa_cuts=[("c1", 1), ("c2", 2), ("c3", 3), ("c4", 4)],
+            time_limit=1.0,
+            gap_tolerance=1e-4,
+        )
+
+        assert call_sizes == [4, 2]
+        assert kept_cuts == [("c3", 3), ("c4", 4)]
+        assert result.status == "optimal"
+
     def test_spatial_bnb_bilinear_global_correctness(self):
         """Existing spatial B&B should solve nlp1 to global optimum.
 
@@ -915,8 +1134,12 @@ class TestCurrentCodeWeaknesses:
             f"(gap={abs(result.objective - NLP1_OPTIMUM):.4f})"
         )
 
+    @pytest.mark.xfail(
+        reason="Documents a known weakness of the legacy spatial B&B on quadratic constraints",
+        strict=False,
+    )
     def test_circle_monomial_global_correctness(self):
-        """Existing solver should handle x²+y²≥2 correctly (monomials)."""
+        """Existing solver weakness: x²+y²≥2 is not yet solved globally by spatial B&B."""
         m = _make_circle()
         result = m.solve(time_limit=30, gap_tolerance=1e-3)
         assert result.objective is not None

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -31,18 +31,12 @@ import os
 os.environ["JAX_PLATFORMS"] = "cpu"
 os.environ["JAX_ENABLE_X64"] = "1"
 
+import discopt.modeling as dm
 import numpy as np
 import pytest
-
-import discopt.modeling as dm
 from discopt.modeling.core import (
-    BinaryOp,
-    Constant,
-    FunctionCall,
-    IndexExpression,
     Model,
     SolveResult,
-    Variable,
 )
 
 # ---------------------------------------------------------------------------
@@ -126,6 +120,7 @@ class TestTermClassifier:
             NonlinearTerms,
             classify_nonlinear_terms,
         )
+
         self.classify = classify_nonlinear_terms
         self.NonlinearTerms = NonlinearTerms
 
@@ -263,8 +258,7 @@ class TestPartitionSelection:
         bilinear = bilinear or []
         trilinear = trilinear or []
         monomial = monomial or []
-        candidates = list({v for t in bilinear + trilinear for v in t}
-                         | {v for v, _ in monomial})
+        candidates = list({v for t in bilinear + trilinear for v in t} | {v for v, _ in monomial})
         incidence: dict[int, set[int]] = {}
         for idx, t in enumerate(bilinear + trilinear):
             for v in t:
@@ -319,7 +313,6 @@ class TestPartitionSelection:
         # 20 variables in a star — hub is var 0
         terms = self._make_terms(bilinear=[(0, i) for i in range(1, 20)])
         auto = self.pick(terms, method="auto")
-        mvc = self.pick(terms, method="min_vertex_cover")
         # Both should cover all terms
         for t in terms.bilinear:
             assert any(v in auto for v in t), f"term {t} not covered"
@@ -358,10 +351,7 @@ class TestPartitionSelection:
     def test_adaptive_vertex_cover_uses_distance_weights(self):
         """Adaptive cover should favor high-distance variables on large graphs."""
         terms = self._make_terms(bilinear=[(i, i + 1) for i in range(16)])
-        distance = {
-            i: (10.0 if i % 2 == 0 else 1e-3)
-            for i in terms.partition_candidates
-        }
+        distance = {i: (10.0 if i % 2 == 0 else 1e-3) for i in terms.partition_candidates}
 
         selected = self.pick(
             terms,
@@ -534,7 +524,6 @@ class TestMcCormickSoundness:
     def test_standard_mccormick_bilinear_valid(self):
         """cv ≤ x*y ≤ cc at 500 random points — core soundness test."""
         import jax.numpy as jnp
-
         from discopt._jax.mccormick import relax_bilinear
 
         x_lb, x_ub, y_lb, y_ub = 1.0, 4.0, 1.0, 4.0
@@ -556,7 +545,6 @@ class TestMcCormickSoundness:
     def test_piecewise_mccormick_bilinear_valid(self):
         """Piecewise McCormick is still a valid relaxation (cv ≤ x*y ≤ cc)."""
         import jax.numpy as jnp
-
         from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear
 
         x_lb, x_ub, y_lb, y_ub = 0.0, 10.0, 0.0, 10.0
@@ -583,7 +571,6 @@ class TestMcCormickSoundness:
         Piecewise must be strictly tighter.
         """
         import jax.numpy as jnp
-
         from discopt._jax.mccormick import relax_bilinear
         from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear
 
@@ -610,9 +597,7 @@ class TestMcCormickSoundness:
         gap_std = float(cc_std - cv_std)
         gap_pw = float(cc_pw - cv_pw)
 
-        assert gap_pw < gap_std, (
-            f"Piecewise gap {gap_pw:.4f} must be < standard gap {gap_std:.4f}"
-        )
+        assert gap_pw < gap_std, f"Piecewise gap {gap_pw:.4f} must be < standard gap {gap_std:.4f}"
         # Also verify piecewise is still sound
         w_true = x * y
         assert float(cv_pw) <= w_true + 1e-9
@@ -624,7 +609,6 @@ class TestMcCormickSoundness:
         Theoretical bound: max gap ≤ (domain_width / k)².
         """
         import jax.numpy as jnp
-
         from discopt._jax.piecewise_mccormick import piecewise_mccormick_bilinear
 
         x_lb, x_ub, y_lb, y_ub = 0.0, 10.0, 0.0, 10.0
@@ -650,10 +634,9 @@ class TestMcCormickSoundness:
         This test SHOULD PASS — it documents existing behavior as a baseline.
         The AMP implementation will add solution-adaptive refinement separately.
         """
-        from discopt._jax.piecewise_mccormick import _partition_bounds
-
         # Same call twice → identical result (no solution context)
         import jax.numpy as jnp
+        from discopt._jax.piecewise_mccormick import _partition_bounds
 
         lbs1, ubs1 = _partition_bounds(jnp.float64(0.0), jnp.float64(10.0), 4)
         lbs2, ubs2 = _partition_bounds(jnp.float64(0.0), jnp.float64(10.0), 4)
@@ -741,7 +724,7 @@ class TestMilpRelaxation:
         # Lower bounds must be non-decreasing with finer partitions
         for i in range(len(lbs) - 1):
             assert lbs[i] <= lbs[i + 1] + 1e-6, (
-                f"LBs must be non-decreasing: lbs[{i}]={lbs[i]:.4f} > lbs[{i+1}]={lbs[i+1]:.4f}"
+                f"LBs must be non-decreasing: lbs[{i}]={lbs[i]:.4f} > lbs[{i + 1}]={lbs[i + 1]:.4f}"
             )
 
     def test_milp_relaxation_feasible_when_problem_feasible(self):
@@ -755,7 +738,6 @@ class TestMilpRelaxation:
     def test_piecewise_interval_rows_use_interval_specific_bounds(self):
         """Piecewise product rows must use the current interval's wk_hi, not a stale value."""
         import scipy.sparse as sp
-
         from discopt._jax.discretization import DiscretizationState
         from discopt._jax.term_classifier import classify_nonlinear_terms
 
@@ -927,9 +909,9 @@ class TestAmpPhase1Helpers:
 # ===========================================================================
 
 # Known global optima (from Alpine.jl test suite + standard references)
-NLP1_OPTIMUM = 58.38368   # Alpine nlp1
+NLP1_OPTIMUM = 58.38368  # Alpine nlp1
 CIRCLE_OPTIMUM = 1.41421356  # √2
-NLP3_OPTIMUM = 7049.247898   # Alpine nlp3
+NLP3_OPTIMUM = 7049.247898  # Alpine nlp3
 
 
 class TestAmpEndToEnd:
@@ -941,7 +923,6 @@ class TestAmpEndToEnd:
     @pytest.mark.smoke
     def test_nlp1_bilinear_global_optimum(self):
         """nlp1: bilinear MINLP solved to global optimum ≈ 58.38368."""
-        from discopt.modeling.core import SolveResult
 
         m = _make_nlp1()
         result = m.solve(solver="amp", rel_gap=1e-3, time_limit=60)
@@ -999,7 +980,7 @@ class TestAmpEndToEnd:
         """min x²  s.t. x ≥ 1: AMP should certify global optimum = 1."""
         m = Model("quad")
         x = m.continuous("x", lb=1, ub=10)
-        m.minimize(x ** 2)
+        m.minimize(x**2)
         result = m.solve(solver="amp", rel_gap=1e-4, time_limit=30)
         assert result.status == "optimal"
         assert result.objective is not None
@@ -1007,10 +988,10 @@ class TestAmpEndToEnd:
 
     @pytest.mark.smoke
     def test_zero_upper_bound_reports_no_relative_gap(self):
-        """Relative gap should be left undefined when the incumbent objective is numerically zero."""
+        """Relative gap should stay undefined when the incumbent objective is near zero."""
         m = Model("zero_gap")
         x = m.continuous("x", lb=-1, ub=1)
-        m.minimize(x ** 2)
+        m.minimize(x**2)
 
         result = m.solve(solver="amp", rel_gap=1e-4, time_limit=30)
 
@@ -1084,7 +1065,7 @@ class TestAmpConvergenceProperties:
         assert len(lbs) >= 2, "Should have at least 2 iterations"
         for i in range(len(lbs) - 1):
             assert lbs[i] <= lbs[i + 1] + 1e-8, (
-                f"LB decreased at iteration {i}: {lbs[i]:.6f} > {lbs[i+1]:.6f}"
+                f"LB decreased at iteration {i}: {lbs[i]:.6f} > {lbs[i + 1]:.6f}"
             )
 
     @pytest.mark.smoke
@@ -1102,9 +1083,7 @@ class TestAmpConvergenceProperties:
         for j in range(len(finite_ubs) - 1):
             i1, u1 = finite_ubs[j]
             i2, u2 = finite_ubs[j + 1]
-            assert u2 <= u1 + 1e-8, (
-                f"UB increased at iteration {i2}: {u1:.6f} → {u2:.6f}"
-            )
+            assert u2 <= u1 + 1e-8, f"UB increased at iteration {i2}: {u1:.6f} → {u2:.6f}"
 
     @pytest.mark.smoke
     def test_gap_certified_after_convergence(self):
@@ -1129,9 +1108,7 @@ class TestAmpConvergenceProperties:
         )
         if result.status == "optimal":
             # If gap-terminated, should be well before max_iter
-            assert len(iters) < 100, (
-                "Should terminate before max_iter=100 when gap closes"
-            )
+            assert len(iters) < 100, "Should terminate before max_iter=100 when gap closes"
 
     @pytest.mark.smoke
     def test_time_limit_respected(self):
@@ -1205,7 +1182,6 @@ class TestCurrentCodeWeaknesses:
 
     def test_solve_model_forwards_alpine_amp_aliases(self, monkeypatch):
         """solve_model should pass Alpine-style AMP aliases through to solve_amp."""
-        from discopt.modeling.core import SolveResult
         from discopt.solver import solve_model
         from discopt.solvers import amp as amp_mod
 
@@ -1247,7 +1223,7 @@ class TestCurrentCodeWeaknesses:
         from discopt.solvers import amp as amp_mod
 
         m = Model("rounding")
-        y = m.integer("y", lb=0, ub=3, shape=(2,))
+        m.integer("y", lb=0, ub=3, shape=(2,))
         x0 = np.array([1.49, 1.51], dtype=np.float64)
 
         candidates = amp_mod._integer_rounding_candidates(x0, m)
@@ -1524,7 +1500,7 @@ class TestCurrentCodeWeaknesses:
         """x² is convex — should solve to x=0 globally even without AMP."""
         m = Model("quad_convex")
         x = m.continuous("x", lb=-3, ub=3)
-        m.minimize(x ** 2)
+        m.minimize(x**2)
         result = m.solve()
         assert result.objective is not None
         assert abs(result.objective) < 1e-4, (

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1286,6 +1286,56 @@ class TestCurrentCodeWeaknesses:
         assert float(best_x[0]) == pytest.approx(1.0)
         assert best_obj == pytest.approx(1.5)
 
+    def test_nlp_subproblem_applies_and_restores_fixed_bounds(self, monkeypatch):
+        """AMP must solve the NLP at the fixed candidate bounds, then restore them."""
+        import discopt._jax.ipm as ipm_mod
+        from discopt.solvers import NLPResult, SolveStatus
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("fixed_nlp_bounds")
+        x = m.continuous("x", lb=0.0, ub=2.0)
+        y = m.binary("y")
+        m.subject_to(x >= y)
+        m.minimize(x + y)
+
+        class FakeEvaluator:
+            def __init__(self, model):
+                self._model = model
+                self._obj_fn = object()
+
+            def evaluate_objective(self, x_flat):
+                return float(np.sum(x_flat))
+
+        def fake_solve_nlp_ipm(evaluator, x0, options):
+            del x0, options
+            x_var, y_var = evaluator._model._variables
+            assert np.asarray(x_var.lb).item() == pytest.approx(0.25)
+            assert np.asarray(x_var.ub).item() == pytest.approx(0.75)
+            assert np.asarray(y_var.lb).item() == pytest.approx(1.0)
+            assert np.asarray(y_var.ub).item() == pytest.approx(1.0)
+            return NLPResult(
+                status=SolveStatus.OPTIMAL,
+                x=np.array([0.5, 1.0], dtype=np.float64),
+            )
+
+        monkeypatch.setattr(ipm_mod, "solve_nlp_ipm", fake_solve_nlp_ipm)
+
+        x_opt, obj = amp_mod._solve_nlp_subproblem(
+            FakeEvaluator(m),
+            x0=np.array([1.2, 0.2], dtype=np.float64),
+            lb=np.array([0.25, 1.0], dtype=np.float64),
+            ub=np.array([0.75, 1.0], dtype=np.float64),
+            nlp_solver="ipm",
+        )
+
+        assert x_opt is not None
+        assert np.allclose(x_opt, np.array([0.5, 1.0], dtype=np.float64))
+        assert obj == pytest.approx(1.5)
+        assert np.asarray(x.lb).item() == pytest.approx(0.0)
+        assert np.asarray(x.ub).item() == pytest.approx(2.0)
+        assert np.asarray(y.lb).item() == pytest.approx(0.0)
+        assert np.asarray(y.ub).item() == pytest.approx(1.0)
+
     def test_best_nlp_candidate_rejects_noninteger_nlp_return(self, monkeypatch):
         """NLP candidates that violate integrality should be discarded."""
         from discopt.solvers import amp as amp_mod

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -68,6 +68,15 @@ def _make_circle() -> Model:
     return m
 
 
+def _make_trilinear_cover() -> Model:
+    """Simple trilinear problem with a known AM-GM optimum of 3."""
+    m = Model("trilinear_cover")
+    x = m.continuous("x", lb=0, ub=2, shape=(3,))
+    m.subject_to(x[0] * x[1] * x[2] >= 1.0)
+    m.minimize(x[0] + x[1] + x[2])
+    return m
+
+
 def _build_nlp3() -> Model:
     """Alpine nlp3: 8-variable multilinear industrial process.
 
@@ -348,6 +357,42 @@ class TestPartitionSelection:
 
         assert set(selected) == {0}
 
+    def test_min_vertex_cover_falls_back_when_highs_status_is_not_optimal(self, monkeypatch):
+        """A non-optimal HiGHS status should fall back to the greedy cover."""
+        import highspy
+
+        terms = self._make_terms(bilinear=[(0, 1), (0, 2), (0, 3), (0, 4)])
+        options = {}
+
+        class FakeHighs:
+            def silent(self):
+                return None
+
+            def setOptionValue(self, name, value):
+                options[name] = value
+
+            def addBinary(self, obj):
+                return obj
+
+            def addRow(self, *args):
+                return args
+
+            def run(self):
+                return None
+
+            def getModelStatus(self):
+                return highspy.HighsModelStatus.kTimeLimit
+
+            def getSolution(self):
+                raise AssertionError("solution should not be read after a non-optimal status")
+
+        monkeypatch.setattr(highspy, "Highs", FakeHighs)
+
+        selected = self.pick(terms, method="min_vertex_cover")
+
+        assert set(selected) == {0}
+        assert options["time_limit"] == pytest.approx(30.0)
+
     def test_adaptive_vertex_cover_uses_distance_weights(self):
         """Adaptive cover should favor high-distance variables on large graphs."""
         terms = self._make_terms(bilinear=[(i, i + 1) for i in range(16)])
@@ -462,6 +507,22 @@ class TestDiscretizationState:
         assert pts[-1] == pytest.approx(1.0)
         # Strictly sorted
         assert all(pts[i] < pts[i + 1] for i in range(len(pts) - 1))
+
+    def test_adaptive_refinement_bisects_when_centered_candidates_hit_interval_edges(self):
+        """If centered refinement would add only edge points, fall back to the midpoint."""
+        state = self.initialize_partitions(
+            [0],
+            lb=[0.0],
+            ub=[1.0],
+            n_init=1,
+            scaling_factor=2.0,
+        )
+
+        state2 = self.add_adaptive_partition(state, {0: 0.5}, [0], [0.0], [1.0])
+
+        pts = state2.partitions[0]
+        assert len(pts) == 3
+        np.testing.assert_allclose(pts, np.array([0.0, 0.5, 1.0]))
 
     def test_uniform_refinement_splits_every_interval(self):
         """Uniform refinement should bisect each current interval."""
@@ -872,6 +933,72 @@ class TestMilpRelaxation:
                 convhull_formulation="bogus",
             )
 
+    def test_trilinear_milp_builds_nested_auxiliaries(self):
+        """Trilinear terms should be modeled through explicit lifted auxiliaries."""
+        m = _make_trilinear_cover()
+        terms = self.classify(m)
+        state = self.init_partitions([0, 1, 2], lb=[0.0, 0.0, 0.0], ub=[2.0, 2.0, 2.0], n_init=2)
+
+        milp_model, varmap = self.build_milp(m, terms, state, incumbent=None)
+        result = milp_model.solve()
+
+        assert (0, 1, 2) in varmap["trilinear"]
+        stage = varmap["trilinear_stages"][(0, 1, 2)]
+        assert stage["product_col"] == varmap["trilinear"][(0, 1, 2)]
+        assert result.status == "optimal"
+        assert result.objective is not None
+        assert 0.0 < result.objective <= 3.0 + 1e-6
+
+    def test_unsupported_objective_returns_no_relaxation_bound(self):
+        """Unsupported nonlinear objectives should not be reported as valid lower bounds."""
+        m = Model("unsupported_objective")
+        x = m.continuous("x", lb=0, ub=2, shape=(2,))
+        m.subject_to(x[0] + x[1] >= 1.0)
+        m.minimize((x[0] * x[0]) * x[1])
+
+        terms = self.classify(m)
+        state = self.init_partitions([0], lb=[0.0], ub=[2.0], n_init=2)
+
+        milp_model, _ = self.build_milp(m, terms, state, incumbent=None)
+        result = milp_model.solve()
+
+        assert result.status == "optimal"
+        assert result.objective is None
+        assert result.x is not None
+
+    def test_piecewise_interval_rows_force_inactive_wbar_to_zero_with_negative_bounds(self):
+        """Disaggregated intervals must include the lower δ-forcing row even when wk_lo < 0."""
+        import scipy.sparse as sp
+        from discopt._jax.discretization import DiscretizationState
+        from discopt._jax.term_classifier import classify_nonlinear_terms
+
+        m = Model("piecewise_sign_straddle")
+        x = m.continuous("x", lb=0, ub=2)
+        y = m.continuous("y", lb=-1, ub=1)
+        m.minimize(x * y)
+
+        terms = classify_nonlinear_terms(m)
+        state = DiscretizationState(partitions={0: np.array([0.0, 1.0, 2.0])})
+        milp_model, varmap = self.build_milp(m, terms, state, incumbent=None)
+
+        assert sp.issparse(milp_model._A_ub)
+        A_csr = milp_model._A_ub.tocsr()
+        b_ub = np.asarray(milp_model._b_ub, dtype=np.float64)
+
+        for delta_col, _, wbar_col, a_k, b_k in varmap["bilinear_pw"][(0, 1)]:
+            wk_lo = min(a_k * -1.0, a_k * 1.0, b_k * -1.0, b_k * 1.0)
+            assert wk_lo < 0.0
+            matched = False
+            for row_idx in range(A_csr.shape[0]):
+                row = A_csr.getrow(row_idx)
+                if row.nnz != 2 or abs(b_ub[row_idx]) > 1e-12:
+                    continue
+                coeffs = dict(zip(row.indices.tolist(), row.data.tolist()))
+                if coeffs.get(wbar_col) == -1.0 and coeffs.get(delta_col) == wk_lo:
+                    matched = True
+                    break
+            assert matched, f"missing inactive-interval lower row for [{a_k}, {b_k}]"
+
 
 class TestAmpPhase1Helpers:
     """Fast regression tests for Phase 1 helper behavior."""
@@ -929,27 +1056,30 @@ class TestAmpEndToEnd:
         assert result.status == "optimal", f"Expected optimal, got {result.status}"
         assert result.gap_certified is True, "Gap must be certified for AMP"
         assert result.objective is not None
-        assert abs(result.objective - NLP1_OPTIMUM) <= 0.15, (
+        assert abs(result.objective - NLP1_OPTIMUM) <= 0.06, (
             f"Objective {result.objective:.5f} too far from {NLP1_OPTIMUM}"
         )
 
     @pytest.mark.smoke
     def test_circle_bilinear_global_optimum(self):
-        """circle: x₀²+x₁²≥2 minimized to global optimum √2."""
+        """circle: recover the best known objective without a false certificate."""
         m = _make_circle()
         result = m.solve(solver="amp", rel_gap=1e-4, time_limit=60)
-        assert result.status == "optimal"
-        assert result.gap_certified is True
+        assert result.status in ("optimal", "feasible", "time_limit")
         assert result.objective is not None
         assert abs(result.objective - CIRCLE_OPTIMUM) <= 1e-3, (
             f"Objective {result.objective:.6f} too far from √2={CIRCLE_OPTIMUM}"
         )
+        if result.status == "optimal":
+            assert result.gap_certified is True
+        else:
+            assert result.gap_certified is False
 
     @pytest.mark.slow
     @pytest.mark.timeout(300)
     @pytest.mark.xfail(
         reason="nlp3 MILP exceeds test budget; tracked in #24",
-        strict=False,
+        strict=True,
     )
     def test_nlp3_multilinear_global_optimum(self):
         """nlp3: 8-variable multilinear industrial problem."""
@@ -974,6 +1104,69 @@ class TestAmpEndToEnd:
         assert result.objective is not None
         # x[0]*x[1]≥4-y: optimal at x[0]=x[1]=2, y=0 → obj=8 or similar
         assert result.objective >= 0
+
+    @pytest.mark.smoke
+    def test_trilinear_global_optimum(self):
+        """AMP should solve a simple trilinear cover problem after lifting."""
+        m = _make_trilinear_cover()
+        result = m.solve(solver="amp", rel_gap=2e-2, time_limit=20)
+
+        assert result.status in ("optimal", "feasible", "time_limit")
+        assert result.objective is not None
+        assert abs(result.objective - 3.0) <= 0.1
+
+    def test_nonconvex_constraint_oa_cuts_respect_convexity_mask(self, monkeypatch):
+        """Nonconvex constraint rows must be excluded from evaluator OA cuts."""
+        from discopt._jax import cutting_planes
+
+        recorded_masks = []
+        real_generate = cutting_planes.generate_oa_cuts_from_evaluator
+
+        def wrapped_generate(*args, **kwargs):
+            convex_mask = kwargs.get("convex_mask")
+            if convex_mask is not None:
+                recorded_masks.append(list(convex_mask))
+            return real_generate(*args, **kwargs)
+
+        monkeypatch.setattr(cutting_planes, "generate_oa_cuts_from_evaluator", wrapped_generate)
+
+        m = Model("amp_nonconvex_constraint_mask")
+        x = m.continuous("x", lb=0, ub=2)
+        y = m.binary("y")
+        m.subject_to(x**2 - 4 * y - 1 <= 0)
+        m.subject_to(x**2 - x + y >= 0)
+        m.minimize(x + y)
+
+        result = m.solve(solver="amp", max_iter=1, rel_gap=1e-3, time_limit=30)
+
+        assert result.status in ("optimal", "feasible", "time_limit")
+        assert recorded_masks
+        assert all(mask == [True, False] for mask in recorded_masks)
+
+    def test_unsupported_objective_disables_certified_bound(self, monkeypatch):
+        """AMP must not report a certified lower bound when the objective is not linearizable."""
+        from discopt.solvers import amp as amp_solver
+
+        m = Model("amp_unsupported_objective")
+        x = m.continuous("x", lb=0, ub=2, shape=(2,))
+        y = m.binary("y")
+        m.subject_to(x[0] >= 1 - y)
+        m.minimize((x[0] * x[0]) * x[1] + y)
+
+        feasible_x = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+        monkeypatch.setattr(
+            amp_solver,
+            "_solve_best_nlp_candidate",
+            lambda *args, **kwargs: (feasible_x.copy(), 0.0),
+        )
+
+        result = m.solve(solver="amp", rel_gap=1e-3, max_iter=2, time_limit=10)
+
+        assert result.status == "feasible"
+        assert result.objective == pytest.approx(0.0)
+        assert result.bound is None
+        assert result.gap is None
+        assert result.gap_certified is False
 
     @pytest.mark.smoke
     def test_pure_quadratic_convex(self):
@@ -1032,6 +1225,30 @@ class TestAmpEndToEnd:
         assert abs(result.objective - 2.0) <= 1e-3
         assert result.bound is not None
         assert result.bound >= result.objective - 1e-6
+
+    def test_amp_solver_warns_on_ignored_options(self):
+        """Routing through solve_model should warn when AMP ignores B&B-only options."""
+        m = Model("amp_warning")
+        x = m.continuous("x", lb=-1, ub=1)
+        m.minimize(x**2)
+
+        with pytest.warns(
+            UserWarning,
+            match=(
+                "AMP ignores solve_model options: "
+                ".*cutting_planes.*incumbent_callback.*mccormick_bounds.*node_callback"
+            ),
+        ):
+            result = m.solve(
+                solver="amp",
+                time_limit=10,
+                cutting_planes=True,
+                mccormick_bounds="tight",
+                incumbent_callback=lambda *_: True,
+                node_callback=lambda *_: None,
+            )
+
+        assert result.objective is not None
 
 
 # ===========================================================================

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -786,10 +786,20 @@ class TestAmpPhase1Helpers:
 
         corners = [-25000.0, 10000.0, 5000.0, 30000.0]
         big_m = _compute_piecewise_big_m(corners)
-        expected = 30000.0 * (1.0 + 1e-4) + 1e-2
+        expected = 30000.0 * (1.0 + 1e-4) + 3.0
 
         assert big_m == pytest.approx(expected)
         assert big_m > 30000.0
+
+    def test_piecewise_big_m_keeps_small_intervals_tight(self):
+        """The Big-M floor should not dominate near-zero product intervals."""
+        from discopt._jax.milp_relaxation import _compute_piecewise_big_m
+
+        corners = [0.0, 0.0, 0.01, 0.01]
+        big_m = _compute_piecewise_big_m(corners)
+
+        assert big_m == pytest.approx(0.010002)
+        assert big_m < 0.011
 
 
 # ===========================================================================
@@ -1129,6 +1139,46 @@ class TestCurrentCodeWeaknesses:
         assert best_x is not None
         assert float(best_x[0]) == pytest.approx(1.0)
         assert best_obj == pytest.approx(1.5)
+
+    def test_best_nlp_candidate_rejects_noninteger_nlp_return(self, monkeypatch):
+        """NLP candidates that violate integrality should be discarded."""
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("noninteger_candidate")
+        m.integer("y", lb=0, ub=2)
+
+        monkeypatch.setattr(
+            amp_mod,
+            "_integer_rounding_candidates",
+            lambda x0, model: [np.array([1.0], dtype=np.float64)],
+        )
+        monkeypatch.setattr(
+            amp_mod,
+            "_build_fixed_integer_bounds",
+            lambda x0, model, flat_lb, flat_ub: (flat_lb.copy(), flat_ub.copy()),
+        )
+        monkeypatch.setattr(
+            amp_mod,
+            "_solve_nlp_subproblem",
+            lambda evaluator, x0, lb, ub, nlp_solver: (
+                np.array([1.5], dtype=np.float64),
+                1.0,
+            ),
+        )
+
+        best_x, best_obj = amp_mod._solve_best_nlp_candidate(
+            np.array([1.0], dtype=np.float64),
+            m,
+            evaluator=object(),
+            flat_lb=np.array([0.0], dtype=np.float64),
+            flat_ub=np.array([2.0], dtype=np.float64),
+            constraint_lb=np.array([], dtype=np.float64),
+            constraint_ub=np.array([], dtype=np.float64),
+            nlp_solver="ipm",
+        )
+
+        assert best_x is None
+        assert best_obj is None
 
     def test_oa_cut_recovery_drops_oldest_half(self, monkeypatch):
         """OA recovery should retry with the oldest half of cuts removed."""

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -77,6 +77,14 @@ def _make_trilinear_cover() -> Model:
     return m
 
 
+def _make_convex_quadratic() -> Model:
+    """Small convex model that AMP should certify globally."""
+    m = Model("convex_quadratic")
+    x = m.continuous("x", lb=1, ub=10)
+    m.minimize(x**2)
+    return m
+
+
 def _build_nlp3() -> Model:
     """Alpine nlp3: 8-variable multilinear industrial process.
 
@@ -1065,15 +1073,14 @@ class TestAmpEndToEnd:
         """circle: recover the best known objective without a false certificate."""
         m = _make_circle()
         result = m.solve(solver="amp", rel_gap=1e-4, time_limit=60)
-        assert result.status in ("optimal", "feasible", "time_limit")
+        assert result.status == "feasible"
         assert result.objective is not None
         assert abs(result.objective - CIRCLE_OPTIMUM) <= 1e-3, (
             f"Objective {result.objective:.6f} too far from √2={CIRCLE_OPTIMUM}"
         )
-        if result.status == "optimal":
-            assert result.gap_certified is True
-        else:
-            assert result.gap_certified is False
+        # The circle constraint is a nonconvex superlevel set, so evaluator OA
+        # cuts must be skipped and AMP should not certify the relaxation gap.
+        assert result.gap_certified is False
 
     @pytest.mark.slow
     @pytest.mark.timeout(300)
@@ -1171,9 +1178,7 @@ class TestAmpEndToEnd:
     @pytest.mark.smoke
     def test_pure_quadratic_convex(self):
         """min x²  s.t. x ≥ 1: AMP should certify global optimum = 1."""
-        m = Model("quad")
-        x = m.continuous("x", lb=1, ub=10)
-        m.minimize(x**2)
+        m = _make_convex_quadratic()
         result = m.solve(solver="amp", rel_gap=1e-4, time_limit=30)
         assert result.status == "optimal"
         assert result.objective is not None
@@ -1305,16 +1310,15 @@ class TestAmpConvergenceProperties:
     @pytest.mark.smoke
     def test_gap_certified_after_convergence(self):
         """gap_certified must be True after AMP converges by gap criterion."""
-        m = _make_circle()
+        m = _make_convex_quadratic()
         result = m.solve(solver="amp", rel_gap=0.05, time_limit=30)
-        # If we converged by gap criterion, gap_certified must be True
-        if result.status == "optimal":
-            assert result.gap_certified is True
+        assert result.status == "optimal"
+        assert result.gap_certified is True
 
     @pytest.mark.smoke
     def test_early_termination_when_gap_closes(self):
         """AMP should terminate before max_iter when gap closes."""
-        m = _make_circle()
+        m = _make_convex_quadratic()
         iters = []
 
         def cb(info):
@@ -1323,9 +1327,9 @@ class TestAmpConvergenceProperties:
         result = m.solve(
             solver="amp", rel_gap=0.5, max_iter=100, iteration_callback=cb, time_limit=30
         )
-        if result.status == "optimal":
-            # If gap-terminated, should be well before max_iter
-            assert len(iters) < 100, "Should terminate before max_iter=100 when gap closes"
+        assert result.status == "optimal"
+        assert result.gap_certified is True
+        assert len(iters) < 100, "Should terminate before max_iter=100 when gap closes"
 
     @pytest.mark.smoke
     def test_time_limit_respected(self):

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1077,6 +1077,59 @@ class TestCurrentCodeWeaknesses:
         assert (1.0, 1.0) in rounded  # floor on the second variable
         assert (2.0, 2.0) in rounded  # ceil on the first variable
 
+    def test_best_nlp_candidate_chooses_lowest_feasible_objective(self, monkeypatch):
+        """Integer rounding fallback should keep the best feasible NLP candidate."""
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("best_candidate")
+        m.integer("y", lb=0, ub=2)
+
+        candidates = [
+            np.array([0.0], dtype=np.float64),
+            np.array([1.0], dtype=np.float64),
+            np.array([2.0], dtype=np.float64),
+        ]
+        objectives = {0.0: 4.0, 1.0: 1.5, 2.0: 3.0}
+
+        monkeypatch.setattr(
+            amp_mod,
+            "_integer_rounding_candidates",
+            lambda x0, model: [cand.copy() for cand in candidates],
+        )
+        monkeypatch.setattr(
+            amp_mod,
+            "_build_fixed_integer_bounds",
+            lambda x0, model, flat_lb, flat_ub: (flat_lb.copy(), flat_ub.copy()),
+        )
+        monkeypatch.setattr(
+            amp_mod,
+            "_solve_nlp_subproblem",
+            lambda evaluator, x0, lb, ub, nlp_solver: (
+                x0.copy(),
+                objectives[float(x0[0])],
+            ),
+        )
+        monkeypatch.setattr(
+            amp_mod,
+            "_check_constraints_with_evaluator",
+            lambda evaluator, x, lb_g, ub_g: True,
+        )
+
+        best_x, best_obj = amp_mod._solve_best_nlp_candidate(
+            np.array([0.3], dtype=np.float64),
+            m,
+            evaluator=object(),
+            flat_lb=np.array([0.0], dtype=np.float64),
+            flat_ub=np.array([2.0], dtype=np.float64),
+            constraint_lb=np.array([], dtype=np.float64),
+            constraint_ub=np.array([], dtype=np.float64),
+            nlp_solver="ipm",
+        )
+
+        assert best_x is not None
+        assert float(best_x[0]) == pytest.approx(1.0)
+        assert best_obj == pytest.approx(1.5)
+
     def test_oa_cut_recovery_drops_oldest_half(self, monkeypatch):
         """OA recovery should retry with the oldest half of cuts removed."""
         from discopt._jax.milp_relaxation import MilpRelaxationResult
@@ -1119,6 +1172,31 @@ class TestCurrentCodeWeaknesses:
         assert call_sizes == [4, 2]
         assert kept_cuts == [("c3", 3), ("c4", 4)]
         assert result.status == "optimal"
+
+    def test_amp_max_iter_without_gap_certificate_returns_feasible(self):
+        """An incumbent without a certified gap should not be labeled optimal."""
+        m = _make_nlp1()
+
+        result = m.solve(solver="amp", max_iter=1, time_limit=30)
+
+        assert result.status == "feasible"
+        assert result.gap_certified is False
+        assert result.objective is not None
+        assert result.gap is not None
+        assert result.gap > 1e-3
+
+    def test_partition_convergence_without_gap_is_not_certified(self, monkeypatch):
+        """Forced partition convergence should still return a non-certified incumbent."""
+        import discopt._jax.discretization as disc_mod
+
+        monkeypatch.setattr(disc_mod, "check_partition_convergence", lambda state: True)
+
+        m = _make_nlp1()
+        result = m.solve(solver="amp", rel_gap=1e-6, time_limit=30)
+
+        assert result.status == "feasible"
+        assert result.gap_certified is False
+        assert result.objective is not None
 
     def test_spatial_bnb_bilinear_global_correctness(self):
         """Existing spatial B&B should solve nlp1 to global optimum.

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -828,14 +828,22 @@ class TestMilpRelaxation:
         assert len(info["theta_cols"]) == 3
 
     def test_sos2_and_facet_convhull_match_on_simple_bilinear_relaxation(self):
-        """SOS2 and facet λ-linking should give the same bound on a simple problem."""
+        """SOS2 and facet λ-linking should dominate the disaggregated relaxation."""
         m = Model("lambda_compare")
         x = m.continuous("x", lb=0, ub=2, shape=(2,))
         m.subject_to(x[0] * x[1] >= 1.0)
         m.minimize(x[0] + x[1])
 
         terms = self.classify(m)
-        state = self.init_partitions([0], lb=[0.0], ub=[2.0], n_init=2)
+        state = self.init_partitions([0], lb=[0.0], ub=[2.0], n_init=4)
+
+        disagg_model, _ = self.build_milp(
+            m,
+            terms,
+            state,
+            incumbent=None,
+            convhull_formulation="disaggregated",
+        )
 
         sos2_model, _ = self.build_milp(
             m,
@@ -852,14 +860,19 @@ class TestMilpRelaxation:
             convhull_formulation="facet",
         )
 
+        disagg_result = disagg_model.solve()
         sos2_result = sos2_model.solve()
         facet_result = facet_model.solve()
 
+        assert disagg_result.status == "optimal"
         assert sos2_result.status == "optimal"
         assert facet_result.status == "optimal"
+        assert disagg_result.objective is not None
         assert sos2_result.objective is not None
         assert facet_result.objective is not None
         assert sos2_result.objective == pytest.approx(facet_result.objective, abs=1e-6)
+        assert sos2_result.objective >= disagg_result.objective - 1e-6
+        assert facet_result.objective >= disagg_result.objective - 1e-6
         assert sos2_result.objective <= 2.0 + 1e-6
 
     def test_invalid_convhull_formulation_raises(self):
@@ -1019,6 +1032,23 @@ class TestAmpEndToEnd:
         assert result.gap_certified is True
         assert result.objective is not None
         assert abs(result.objective - 1.0) <= 1e-3
+        assert result.bound is not None
+        assert result.bound >= result.objective - 1e-6
+
+    def test_maximize_with_integer_variables(self):
+        """Maximize should work when integer rounding and fixed NLP bounds interact."""
+        m = Model("max_bin")
+        x = m.continuous("x", lb=0, ub=2)
+        y = m.binary("y")
+        m.subject_to(x <= 2 * y)
+        m.maximize(x * y)
+
+        result = m.solve(solver="amp", rel_gap=1e-3, time_limit=60)
+
+        assert result.status == "optimal"
+        assert result.gap_certified is True
+        assert result.objective is not None
+        assert abs(result.objective - 2.0) <= 1e-3
         assert result.bound is not None
         assert result.bound >= result.objective - 1e-6
 
@@ -1396,6 +1426,71 @@ class TestCurrentCodeWeaknesses:
         assert result.status == "feasible"
         assert result.gap_certified is False
         assert result.objective is not None
+
+    def test_adaptive_partition_selection_path_runs_inside_amp(self, monkeypatch):
+        """AMP should re-pick partition variables when adaptive selection is enabled."""
+        import discopt._jax.discretization as disc_mod
+        import discopt._jax.partition_selection as part_mod
+
+        adaptive_distances = []
+        refined_var_sets = []
+        orig_pick = part_mod.pick_partition_vars
+
+        def fake_pick(terms, method="auto", distance=None):
+            if method == "adaptive_vertex_cover" and distance is None:
+                return [0]
+            if method == "adaptive_vertex_cover":
+                adaptive_distances.append(dict(distance or {}))
+                return [1]
+            return orig_pick(terms, method=method, distance=distance)
+
+        def fake_add_adaptive_partition(state, solution, var_indices, lb, ub):
+            del solution, lb, ub
+            refined_var_sets.append(list(var_indices))
+            return state
+
+        monkeypatch.setattr(part_mod, "pick_partition_vars", fake_pick)
+        monkeypatch.setattr(disc_mod, "add_adaptive_partition", fake_add_adaptive_partition)
+        monkeypatch.setattr(disc_mod, "check_partition_convergence", lambda state: True)
+
+        m = _make_nlp1()
+        result = m.solve(
+            solver="amp",
+            disc_var_pick="adaptive",
+            rel_gap=1e-6,
+            time_limit=30,
+        )
+
+        assert adaptive_distances
+        assert refined_var_sets == [[1]]
+        assert result.status == "feasible"
+        assert result.gap_certified is False
+
+    def test_uniform_partition_refinement_path_runs_inside_amp(self, monkeypatch):
+        """AMP should call the uniform refinement branch when requested."""
+        import discopt._jax.discretization as disc_mod
+
+        uniform_calls = []
+
+        def fake_add_uniform_partition(state, _solution, var_indices, lb, ub):
+            del _solution, lb, ub
+            uniform_calls.append(list(var_indices))
+            return state
+
+        monkeypatch.setattr(disc_mod, "add_uniform_partition", fake_add_uniform_partition)
+        monkeypatch.setattr(disc_mod, "check_partition_convergence", lambda state: True)
+
+        m = _make_nlp1()
+        result = m.solve(
+            solver="amp",
+            disc_add_partition_method="uniform",
+            rel_gap=1e-6,
+            time_limit=30,
+        )
+
+        assert uniform_calls
+        assert result.status == "feasible"
+        assert result.gap_certified is False
 
     def test_spatial_bnb_bilinear_global_correctness(self):
         """Existing spatial B&B should solve nlp1 to global optimum.

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1670,6 +1670,67 @@ class TestCurrentCodeWeaknesses:
         assert result.gap_certified is False
         assert result.objective is not None
 
+    def test_no_incumbent_after_search_returns_iteration_limit(self, monkeypatch):
+        """Exhausting AMP without an incumbent is not a proof of infeasibility."""
+        from discopt._jax.milp_relaxation import MilpRelaxationResult
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("amp_no_incumbent")
+        x = m.continuous("x", lb=0, ub=1)
+        m.minimize(x)
+
+        monkeypatch.setattr(
+            amp_mod,
+            "_solve_milp_with_oa_recovery",
+            lambda **kwargs: (
+                MilpRelaxationResult(
+                    status="optimal",
+                    objective=0.0,
+                    x=np.array([0.0], dtype=np.float64),
+                ),
+                {},
+                [],
+            ),
+        )
+        monkeypatch.setattr(
+            amp_mod,
+            "_solve_best_nlp_candidate",
+            lambda *args, **kwargs: (None, None),
+        )
+
+        result = m.solve(solver="amp", max_iter=1, time_limit=30)
+
+        assert result.status == "iteration_limit"
+        assert result.objective is None
+        assert result.bound == pytest.approx(0.0)
+        assert result.gap_certified is False
+
+    def test_first_iteration_milp_error_is_not_reported_as_infeasible(self, monkeypatch):
+        """MILP solve errors should surface as errors, not mathematical infeasibility."""
+        from discopt._jax.milp_relaxation import MilpRelaxationResult
+        from discopt.solvers import amp as amp_mod
+
+        m = Model("amp_milp_error")
+        x = m.continuous("x", lb=0, ub=1)
+        m.minimize(x)
+
+        monkeypatch.setattr(
+            amp_mod,
+            "_solve_milp_with_oa_recovery",
+            lambda **kwargs: (
+                MilpRelaxationResult(status="error", objective=None, x=None),
+                {},
+                [],
+            ),
+        )
+
+        result = m.solve(solver="amp", max_iter=1, time_limit=30)
+
+        assert result.status == "error"
+        assert result.objective is None
+        assert result.bound is None
+        assert result.gap_certified is False
+
     def test_adaptive_partition_selection_path_runs_inside_amp(self, monkeypatch):
         """AMP should re-pick partition variables when adaptive selection is enabled."""
         import discopt._jax.discretization as disc_mod
@@ -1741,6 +1802,7 @@ class TestCurrentCodeWeaknesses:
         If this fails: existing spatial B&B cannot certify global optimality
         on bilinear problems (needs AMP's MILP-based lower bound).
         """
+        pytest.importorskip("cyipopt")
         m = _make_nlp1()
         result = m.solve(time_limit=60, gap_tolerance=1e-3)
         assert result.objective is not None, "Spatial B&B failed to find any solution"

--- a/python/tests/test_cutting_planes.py
+++ b/python/tests/test_cutting_planes.py
@@ -309,6 +309,29 @@ class TestOACutsFromEvaluator:
         np.testing.assert_allclose(cut.coeffs, [2.0, 4.0, -1.0], atol=1e-6)
         assert abs(cut.rhs - 5.0) < 1e-6
 
+    def test_convex_mask_filters_nonconvex_constraints(self):
+        """The convex mask should suppress OA cuts for nonconvex constraint rows."""
+        from discopt._jax.nlp_evaluator import NLPEvaluator
+        from discopt.modeling.core import Model
+
+        m = Model("test_oa_mask")
+        x = m.continuous("x", shape=(2,), lb=-2.0, ub=2.0)
+        m.minimize(x[0] + x[1])
+        m.subject_to(x[0] + x[1] <= 1.0, name="linear")
+        m.subject_to(x[0] * x[1] <= 0.25, name="bilinear")
+        evaluator = NLPEvaluator(m)
+
+        cuts = generate_oa_cuts_from_evaluator(
+            evaluator,
+            np.array([0.5, 0.5]),
+            constraint_senses=["<=", "<="],
+            convex_mask=[True, False],
+        )
+
+        assert len(cuts) == 1
+        np.testing.assert_allclose(cuts[0].coeffs, [1.0, 1.0], atol=1e-6)
+        assert cuts[0].sense == "<="
+
 
 class TestOASeparation:
     """Test that OA separation returns only violated cuts."""
@@ -335,6 +358,29 @@ class TestOASeparation:
         x_sol = np.array([1.0, 1.0])  # x0^2+x1^2 = 2 > 1, violated
         cuts = separate_oa_cuts(evaluator, x_sol, constraint_senses=["<="])
         assert len(cuts) == 1
+        assert cuts[0].sense == "<="
+
+    def test_convex_mask_skips_nonconvex_violations(self):
+        """Separation should ignore violated rows that are marked nonconvex."""
+        from discopt._jax.nlp_evaluator import NLPEvaluator
+        from discopt.modeling.core import Model
+
+        m = Model("test_sep_mask")
+        x = m.continuous("x", shape=(2,), lb=-2.0, ub=2.0)
+        m.minimize(x[0] + x[1])
+        m.subject_to(x[0] ** 2 + x[1] ** 2 <= 1.0, name="circle")
+        m.subject_to(x[0] * x[1] <= 0.25, name="bilinear")
+        evaluator = NLPEvaluator(m)
+
+        cuts = separate_oa_cuts(
+            evaluator,
+            np.array([1.0, 1.0]),
+            constraint_senses=["<=", "<="],
+            convex_mask=[True, False],
+        )
+
+        assert len(cuts) == 1
+        np.testing.assert_allclose(cuts[0].coeffs, [2.0, 2.0], atol=1e-6)
         assert cuts[0].sense == "<="
 
 

--- a/python/tests/test_gdpopt_loa.py
+++ b/python/tests/test_gdpopt_loa.py
@@ -112,6 +112,31 @@ class TestGDPoptLOA:
         assert result.status in ("optimal", "feasible")
         assert result.objective == pytest.approx(0.0, abs=1e-2)
 
+    def test_nonconvex_objective_skips_objective_oa_cuts(self, monkeypatch):
+        """LOA must not generate objective OA cuts for a nonconvex objective."""
+        import discopt.modeling as dm
+        from discopt._jax import cutting_planes
+
+        calls = []
+        real_generate = cutting_planes.generate_objective_oa_cut
+
+        def wrapped_generate(*args, **kwargs):
+            calls.append((args, kwargs))
+            return real_generate(*args, **kwargs)
+
+        monkeypatch.setattr(cutting_planes, "generate_objective_oa_cut", wrapped_generate)
+
+        m = dm.Model("loa_nonconvex_objective")
+        x = m.continuous("x", lb=0, ub=2)
+        m.either_or([[x <= 1], [x >= 2]], name="choice")
+        m.minimize(-(x**2))
+
+        result = m.solve(time_limit=60, gdp_method="loa", max_nodes=6)
+
+        assert calls == []
+        assert result.bound is None
+        assert result.gap is None
+
 
 class TestMILPHiGHS:
     def test_simple_milp(self):

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -140,6 +140,33 @@ class TestOANonConvex:
         assert result.status in ("optimal", "feasible")
         assert result.objective is not None
 
+    def test_nonconvex_objective_skips_objective_oa_cuts(self, monkeypatch):
+        """A nonconvex objective must not produce OA objective cuts or certified bounds."""
+        from discopt._jax import cutting_planes
+
+        calls = []
+        real_generate = cutting_planes.generate_objective_oa_cut
+
+        def wrapped_generate(*args, **kwargs):
+            calls.append((args, kwargs))
+            return real_generate(*args, **kwargs)
+
+        monkeypatch.setattr(cutting_planes, "generate_objective_oa_cut", wrapped_generate)
+
+        m = dm.Model("oa_nonconvex_objective")
+        x = m.continuous("x", lb=0, ub=2)
+        y = m.binary("y")
+        m.subject_to(x <= 1 + y)
+        m.minimize(-(x * y))
+
+        result = _solve_oa(m, max_nodes=6)
+
+        assert calls == []
+        assert result.status == "feasible"
+        assert result.objective is not None
+        assert result.bound is None
+        assert result.gap is None
+
 
 # ── Edge Cases ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adaptive Multivariate Partitioning (AMP) is a global MINLP algorithm for nonconvex mixed-integer nonlinear problems. At each iteration it builds a MILP relaxation over a partitioned variable domain to obtain a lower bound, solves a local NLP with the relaxed solution as a starting point to obtain an upper bound or incumbent, and then refines the partitions around the most relevant nonlinear variables. Repeating that loop gives a convergent lower/upper-bound process rather than a single-shot local heuristic.

This draft PR reconstructs that AMP implementation from the fork onto a clean branch off `main`, without the fork-local benchmark tooling, archived benchmark artifacts, or planning files.

Included here:

- solver routing for `solver="amp"`
- nonlinear term classification
- partition-variable selection
- discretization state management
- MILP bounding-model construction
- the AMP main loop and option surface through the current phase-2 work
- focused `python/tests/test_amp.py` coverage for the reconstructed implementation
- the shared flat-bound helper in `python/discopt/_jax/model_utils.py`

This PR intentionally does not include the convexity-detector port. That work is split into a separate draft PR against `feat/convexity-detector`.

## Current status

This is a draft because the core AMP branch is ready for upstream review, but the fork still has a second layer of benchmark-driven follow-up work that is better tracked explicitly than folded into one large PR.

The most important resolved fork tracker is:

- [bernalde/discopt#19](https://github.com/bernalde/discopt/issues/19) `CLOSED` — the false-`infeasible` translated MINLPTests class was eliminated on the fork's follow-up branch; there are no remaining false-`infeasible` cases there, only four residual timeout cases

The remaining fork AMP follow-up issues are:

- [bernalde/discopt#2](https://github.com/bernalde/discopt/issues/2) `OPEN` — older umbrella backlog for AMP improvements; useful as historical context, but now partly superseded by the narrower issues below
- [bernalde/discopt#15](https://github.com/bernalde/discopt/issues/15) `OPEN` — Alpine-style incumbent local solve and warm-start policy; good candidate to move upstream after the core AMP PR lands
- [bernalde/discopt#16](https://github.com/bernalde/discopt/issues/16) `OPEN` — Alpine-style presolve OBBT variants around feasible incumbents; good candidate to move upstream after core AMP support is merged
- [bernalde/discopt#17](https://github.com/bernalde/discopt/issues/17) `OPEN` — shared nonlinear bound tightening extensions; likely upstream-worthy, but broader than AMP alone
- [bernalde/discopt#18](https://github.com/bernalde/discopt/issues/18) `OPEN` — partition-selection and refinement hooks; upstream-worthy as an AMP extension after the core PR
- [bernalde/discopt#20](https://github.com/bernalde/discopt/issues/20) `OPEN` — Rust performance follow-up; should probably stay local until upstream AMP behavior is settled and profiled there
- [bernalde/discopt#21](https://github.com/bernalde/discopt/issues/21) `OPEN` — operator-specific AMP relaxations for `sqrt`, `log`, `exp`, `abs`, etc.; strong candidate to move upstream after the core AMP PR
- [bernalde/discopt#22](https://github.com/bernalde/discopt/issues/22) `OPEN` — stronger benchmark-side solution validation; likely fork-local unless upstream adopts the same MINLPTests harness semantics

I would treat `#15`, `#16`, `#17`, `#18`, and `#21` as the natural follow-up issue set to migrate or re-open upstream once the base AMP implementation is under review.

## Validation

- `PYTHONPATH=python /home/bernalde/repos/discopt/.venv/bin/pytest python/tests/test_amp.py -q -k 'solve_model_forwards_alpine_amp_aliases or lambda_convhull_builds_expected_auxiliaries or bilinear_maximize_global_optimum'`
- `/home/bernalde/repos/discopt/.venv/bin/ruff check python/discopt/_jax/discretization.py python/discopt/_jax/milp_relaxation.py python/discopt/_jax/model_utils.py python/discopt/_jax/partition_selection.py python/discopt/_jax/term_classifier.py python/discopt/solver.py python/discopt/solvers/amp.py python/tests/test_amp.py`
- `python -m py_compile python/discopt/_jax/discretization.py python/discopt/_jax/milp_relaxation.py python/discopt/_jax/model_utils.py python/discopt/_jax/partition_selection.py python/discopt/_jax/term_classifier.py python/discopt/solver.py python/discopt/solvers/amp.py python/tests/test_amp.py`

## Scope exclusions

This PR does not include:

- fork-local benchmark scripts or archived benchmark outputs
- the convexity-detector redesign work
- the later benchmark-driven AMP follow-up fixes from the fork's PR #23

Those are intentionally left to the separate convexity PR and to narrower follow-up AMP issues.
