### PR TITLE
Silence expected interval overflow warnings

### DIFF
--- a/python/discopt/_jax/convexity/interval.py
+++ b/python/discopt/_jax/convexity/interval.py
@@ -210,12 +210,21 @@ class Interval:
 
 def _monotonic_nondec(x: Interval, f) -> Interval:
     """Image of ``x`` under a nondecreasing function ``f``, outward-rounded."""
-    return Interval(_round_down(f(x.lo)), _round_up(f(x.hi)))
+    # Wide boxes can intentionally overflow to unbounded enclosures. The
+    # certificate code treats non-finite endpoints as an abstention signal, so
+    # keep the interval sound without emitting benchmark-visible warnings.
+    with np.errstate(over="ignore", invalid="ignore"):
+        lo = f(x.lo)
+        hi = f(x.hi)
+    return Interval(_round_down(lo), _round_up(hi))
 
 
 def _monotonic_nonincr(x: Interval, f) -> Interval:
     """Image of ``x`` under a nonincreasing function ``f``, outward-rounded."""
-    return Interval(_round_down(f(x.hi)), _round_up(f(x.lo)))
+    with np.errstate(over="ignore", invalid="ignore"):
+        lo = f(x.hi)
+        hi = f(x.lo)
+    return Interval(_round_down(lo), _round_up(hi))
 
 
 def exp(x: Interval) -> Interval:
@@ -234,17 +243,23 @@ def log(x: Interval) -> Interval:
     if np.any(lo <= 0):
         # Replace nonpositive parts with -inf to keep the enclosure
         # sound without poisoning well-defined entries.
-        safe_lo = np.where(lo > 0, np.log(np.where(lo > 0, lo, 1.0)), -np.inf)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            safe_lo = np.where(lo > 0, np.log(np.where(lo > 0, lo, 1.0)), -np.inf)
     else:
-        safe_lo = np.log(lo)
-    return Interval(_round_down(safe_lo), _round_up(np.log(x.hi)))
+        with np.errstate(divide="ignore", invalid="ignore"):
+            safe_lo = np.log(lo)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        hi = np.log(x.hi)
+    return Interval(_round_down(safe_lo), _round_up(hi))
 
 
 def sqrt(x: Interval) -> Interval:
     """Sound enclosure of ``sqrt([lo, hi])`` on the nonneg domain."""
     lo = x.lo
-    safe_lo = np.where(lo >= 0, np.sqrt(np.where(lo >= 0, lo, 0.0)), -np.inf)
-    return Interval(_round_down(safe_lo), _round_up(np.sqrt(x.hi)))
+    with np.errstate(invalid="ignore"):
+        safe_lo = np.where(lo >= 0, np.sqrt(np.where(lo >= 0, lo, 0.0)), -np.inf)
+        hi = np.sqrt(x.hi)
+    return Interval(_round_down(safe_lo), _round_up(hi))
 
 
 def absolute(x: Interval) -> Interval:

--- a/python/discopt/_jax/convexity/interval_ad.py
+++ b/python/discopt/_jax/convexity/interval_ad.py
@@ -136,7 +136,7 @@ def _outer(a: Interval, b: Interval) -> Interval:
     a_hi = a.hi[:, None]
     b_lo = b.lo[None, :]
     b_hi = b.hi[None, :]
-    with np.errstate(invalid="ignore"):
+    with np.errstate(over="ignore", invalid="ignore"):
         p1 = a_lo * b_lo
         p2 = a_lo * b_hi
         p3 = a_hi * b_lo
@@ -165,10 +165,11 @@ def _scalar_times_array(s: Interval, arr: Interval) -> Interval:
 def _broadcast_product(s: Interval, arr: Interval) -> Interval:
     s_lo = np.asarray(s.lo)
     s_hi = np.asarray(s.hi)
-    p1 = s_lo * arr.lo
-    p2 = s_lo * arr.hi
-    p3 = s_hi * arr.lo
-    p4 = s_hi * arr.hi
+    with np.errstate(over="ignore", invalid="ignore"):
+        p1 = s_lo * arr.lo
+        p2 = s_lo * arr.hi
+        p3 = s_hi * arr.lo
+        p4 = s_hi * arr.hi
     lo = np.minimum(np.minimum(p1, p2), np.minimum(p3, p4))
     hi = np.maximum(np.maximum(p1, p2), np.maximum(p3, p4))
     return Interval(_round_down(lo), _round_up(hi))

--- a/python/tests/test_convexity_interval.py
+++ b/python/tests/test_convexity_interval.py
@@ -13,6 +13,8 @@ Neumaier (1990), *Interval Methods for Systems of Equations*.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 from discopt._jax.convexity import interval as iv
@@ -140,6 +142,16 @@ class TestElementaryFunctions:
         out = iv.exp(a)
         xs = _sample_in(a, SAMPLES, seed=seed)
         _assert_encloses(out, np.exp(xs))
+
+    def test_exp_wide_interval_overflow_is_quiet(self):
+        """Overflow to an unbounded enclosure is an expected abstention path."""
+        a = Interval.from_bounds(-1000.0, 1000.0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            out = iv.exp(a)
+
+        assert np.isfinite(out.lo)
+        assert np.isposinf(out.hi)
 
     @pytest.mark.parametrize("seed", [0, 1, 2])
     def test_log_encloses(self, seed):

--- a/python/tests/test_convexity_interval_ad.py
+++ b/python/tests/test_convexity_interval_ad.py
@@ -13,6 +13,8 @@ Griewank, Walther (2008), *Evaluating Derivatives*, §3.
 
 from __future__ import annotations
 
+import warnings
+
 import discopt.modeling as dm
 import jax
 import jax.numpy as jnp
@@ -167,6 +169,20 @@ class TestMultiVariableHessians:
         x = m.continuous("x", lb=-0.5, ub=1.0)
         y = m.continuous("y", lb=-0.5, ub=1.0)
         _assert_hess_contains_pointwise(dm.exp(x * y), m)
+
+    def test_wide_exp_bilinear_abstention_is_quiet(self):
+        """Non-finite interval Hessian entries should not emit RuntimeWarning."""
+        m = Model("t")
+        x = m.continuous("x", lb=-1000.0, ub=1000.0)
+        y = m.continuous("y", lb=-1000.0, ub=1000.0)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            ad = interval_hessian(dm.exp(x * y), m)
+
+        assert np.any(~np.isfinite(np.asarray(ad.hess.lo))) or np.any(
+            ~np.isfinite(np.asarray(ad.hess.hi))
+        )
 
     def test_quadratic_form(self):
         """``x^2 + 4 x y + 3 y^2`` — classic indefinite quadratic."""


### PR DESCRIPTION
## Summary

This keeps the convexity interval helpers from emitting NumPy `RuntimeWarning`s for expected overflow and invalid arithmetic in interval operations. Those cases are already represented by conservative infinite or NaN-aware interval bounds, so the warnings add noise during benchmark and test runs without changing the abstention behavior.

The PR also adds regression coverage for the overflow/invalid-multiply cases in both scalar interval arithmetic and interval AD.

## Verification

- `PYTHONPATH=python /home/bernalde/repos/discopt/.venv/bin/python -m pytest -q python/tests/test_convexity_interval.py python/tests/test_convexity_interval_ad.py`
- `/home/bernalde/.local/bin/uvx ruff==0.14.6 check python/discopt/_jax/convexity/interval.py python/discopt/_jax/convexity/interval_ad.py python/tests/test_convexity_interval.py python/tests/test_convexity_interval_ad.py`
- `/home/bernalde/.local/bin/uvx ruff==0.14.6 format --check python/discopt/_jax/convexity/interval.py python/discopt/_jax/convexity/interval_ad.py python/tests/test_convexity_interval.py python/tests/test_convexity_interval_ad.py`
- `/home/bernalde/repos/discopt/.venv/bin/python -m mypy python/discopt/_jax/convexity/interval.py python/discopt/_jax/convexity/interval_ad.py`