### PR TITLE
fix(convexity): rank-1 certificate path for x^2/y on wide boxes (closes #42)

### DIFF
--- a/python/discopt/_jax/convexity/certificate.py
+++ b/python/discopt/_jax/convexity/certificate.py
@@ -35,7 +35,7 @@ import numpy as np
 
 from discopt.modeling.core import Constraint, Expression, Model
 
-from .eigenvalue import gershgorin_lambda_max, gershgorin_lambda_min
+from .eigenvalue import gershgorin_lambda_max, gershgorin_lambda_min, psd_2x2_sufficient
 from .interval import Interval
 from .interval_ad import interval_hessian
 from .lattice import Curvature
@@ -80,6 +80,21 @@ def certify_convex(
     hess = ad.hess
     if not (np.all(np.isfinite(hess.lo)) and np.all(np.isfinite(hess.hi))):
         return None
+
+    # Structural rank-1 PSD fast path. When the AD walker has attached
+    # a ``Rank1Factor`` with nonneg coefficient, the Hessian equals
+    # ``c · v vᵀ`` pointwise (sound by construction) and is therefore
+    # PSD on the entire box even when the entry-wise interval matrix
+    # is too loose for Gershgorin to certify.
+    rank1 = ad.rank1_factor
+    if rank1 is not None and np.all(np.isfinite(rank1.c.lo)) and np.all(rank1.c.lo >= -_PSD_TOL):
+        return Curvature.CONVEX
+
+    # 2×2 sufficient PSD test (Sylvester) — useful when the interval
+    # Hessian is tight enough that Gershgorin's row-sum loosening
+    # would cross zero but the determinant proof still holds.
+    if hess.lo.shape == (2, 2) and psd_2x2_sufficient(hess):
+        return Curvature.CONVEX
 
     lam_min = gershgorin_lambda_min(hess)
     if lam_min >= -_PSD_TOL:

--- a/python/discopt/_jax/convexity/eigenvalue.py
+++ b/python/discopt/_jax/convexity/eigenvalue.py
@@ -110,4 +110,39 @@ def gershgorin_lambda_max(H: Interval) -> float:
     return float(bounds.max())
 
 
-__all__ = ["gershgorin_lambda_min", "gershgorin_lambda_max"]
+def psd_2x2_sufficient(H: Interval) -> bool:
+    """Sufficient PSD test for a 2×2 interval Hessian.
+
+    Returns ``True`` only when every concrete symmetric matrix in
+    ``H`` is provably PSD via Sylvester's criterion: both diagonal
+    entries are nonneg, and the worst-case 2×2 determinant is nonneg
+    (``H[0,0].lo · H[1,1].lo ≥ max(|H[0,1].lo|, |H[0,1].hi|)²``). This
+    is *sufficient* — when it returns ``False`` the matrix may still
+    be PSD; the caller should fall through to Gershgorin.
+
+    The off-diagonal magnitude squared is computed with an upward
+    round, and the diagonal product with a downward round, so
+    floating-point roundoff cannot push a borderline determinant
+    incorrectly into the nonneg bucket.
+    """
+    lo = np.asarray(H.lo, dtype=np.float64)
+    hi = np.asarray(H.hi, dtype=np.float64)
+    if lo.shape != (2, 2):
+        return False
+    if not (np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))):
+        return False
+    if lo[0, 0] < 0.0 or lo[1, 1] < 0.0:
+        return False
+    off = max(abs(lo[0, 1]), abs(hi[0, 1]), abs(lo[1, 0]), abs(hi[1, 0]))
+    prod = float(lo[0, 0]) * float(lo[1, 1])
+    sq = float(off) * float(off)
+    # Outward rounding is a no-op when the float product is exactly
+    # zero (no roundoff to absorb); skipping it there prevents the
+    # nextafter shift from manufacturing a spurious negative
+    # determinant on the all-zero / rank-deficient corner.
+    prod_lo = prod if prod == 0.0 else float(_round_down(np.float64(prod)))
+    sq_hi = sq if sq == 0.0 else float(_round_up(np.float64(sq)))
+    return bool(prod_lo >= sq_hi)
+
+
+__all__ = ["gershgorin_lambda_min", "gershgorin_lambda_max", "psd_2x2_sufficient"]

--- a/python/discopt/_jax/convexity/interval_ad.py
+++ b/python/discopt/_jax/convexity/interval_ad.py
@@ -63,6 +63,30 @@ from .interval import Interval, _round_down, _round_up
 
 
 @dataclass(frozen=True)
+class Rank1Factor:
+    """Sound metadata: this node's Hessian is ``c · v vᵀ``.
+
+    A node carries this when its Hessian is provably rank-1 PSD (or
+    NSD, with a sign-bracketed ``c``). The certificate consults it
+    for a structural sufficient PSD test that does not depend on the
+    entry-wise tightness of the interval matrix — useful on wide
+    boxes where the off-diagonal interval blows up but the underlying
+    rank-1 structure is intact.
+
+    The ``affine_base_*`` fields are populated when the node arose
+    from squaring an expression whose Hessian is identically zero
+    (i.e. the base is affine in the variables); a downstream
+    division by an affine positive denominator combines them via the
+    perspective rule into a tighter rank-1 form.
+    """
+
+    c: Interval
+    v: Interval
+    affine_base_value: Optional[Interval] = None
+    affine_base_grad: Optional[Interval] = None
+
+
+@dataclass(frozen=True)
 class IntervalAD:
     """A scalar expression's value, gradient, and Hessian as intervals.
 
@@ -71,11 +95,19 @@ class IntervalAD:
     * ``hess``  — shape-``(n, n)`` symmetric interval enclosing
       ``∇²f(x)``. Symmetry is only enforced downstream by the
       consumer (``hess`` + ``hess.T`` / 2 if needed).
+    * ``rank1_factor`` — optional rank-1 metadata; see
+      :class:`Rank1Factor`. ``None`` for nodes without a known
+      rank-1 structure. Soundness is independent of this field —
+      it is metadata that lets the certificate dispatch a tighter
+      sufficient PSD test. Any op that does not explicitly preserve
+      the factorisation drops the field, so a stale value cannot
+      mislead.
     """
 
     value: Interval
     grad: Interval
     hess: Interval
+    rank1_factor: Optional[Rank1Factor] = None
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -373,7 +405,23 @@ def _binary(expr: BinaryOp, model: Model, box: dict, cache: dict, n: int) -> Int
             + _outer(left.grad, right.grad)
             + _outer(right.grad, left.grad)
         )
-        return IntervalAD(value=fg, grad=grad, hess=hess_terms)
+        # Rank-1 metadata for ``g * g`` (BinaryOp form of squaring)
+        # when ``g`` is affine. The cache makes ``left is right`` for
+        # any expression node that appears twice as the same instance,
+        # so this catches ``x * x`` and any ``e * e`` where the user
+        # bound ``e`` to a single Python variable. The Hessian
+        # already collapses to ``2 ∇g ∇gᵀ`` exactly here (the two
+        # ``_outer`` calls fire self-product tightening), so the
+        # metadata claim is sound.
+        rank1: Optional[Rank1Factor] = None
+        if expr.left is expr.right and _hess_is_exactly_zero(left.hess):
+            rank1 = Rank1Factor(
+                c=Interval.point(2.0),
+                v=left.grad,
+                affine_base_value=left.value,
+                affine_base_grad=left.grad,
+            )
+        return IntervalAD(value=fg, grad=grad, hess=hess_terms, rank1_factor=rank1)
 
     if expr.op == "/":
         return _division(expr, left, right, n)
@@ -393,6 +441,21 @@ def _division(expr: BinaryOp, left: IntervalAD, right: IntervalAD, n: int) -> In
     g = right.value
     if g.contains_zero().any():
         return _unbounded_triple(n)
+
+    # Rank-1 fast path: when the numerator is the square of an affine
+    # expression and the denominator is itself affine and strictly
+    # positive, the quotient's Hessian collapses to a perspective-form
+    # rank-1 matrix that the certificate can prove PSD structurally
+    # — even on wide boxes where the entry-wise interval enclosure is
+    # too loose for Gershgorin.
+    if (
+        left.rank1_factor is not None
+        and left.rank1_factor.affine_base_value is not None
+        and left.rank1_factor.affine_base_grad is not None
+        and bool(np.all(np.asarray(g.lo) > 0.0))
+        and _hess_is_exactly_zero(right.hess)
+    ):
+        return _rank1_quotient(left, right, n)
 
     # Reciprocal derivatives:
     #   (1/g)'  = -g' / g^2
@@ -420,6 +483,58 @@ def _division(expr: BinaryOp, left: IntervalAD, right: IntervalAD, n: int) -> In
         + _outer(recip_grad, left.grad)
     )
     return IntervalAD(value=fg_val, grad=fg_grad, hess=fg_hess)
+
+
+def _rank1_quotient(left: IntervalAD, right: IntervalAD, n: int) -> IntervalAD:
+    """Specialised ``g² / h`` Hessian when ``g`` and ``h`` are affine.
+
+    For affine ``g`` with gradient ``v_g`` (so ``H_g = 0``) and affine
+    ``h`` with gradient ``v_h`` (so ``H_h = 0``) and ``h > 0`` on the
+    box, the quotient ``g²/h`` has the exact pointwise Hessian
+
+        ``H = (2/h) · v vᵀ``     where  ``v = v_g − (g/h) · v_h``.
+
+    This is the perspective form: a rank-1 PSD matrix on every point
+    of the box. We emit the Hessian via ``_outer(v, v)`` with a
+    single :class:`Interval` instance so the self-product tightening
+    forces the diagonal to be nonneg, and we attach a
+    :class:`Rank1Factor` so the certificate's structural PSD test
+    fires regardless of off-diagonal interval blowup.
+    """
+    assert left.rank1_factor is not None
+    assert left.rank1_factor.affine_base_value is not None
+    assert left.rank1_factor.affine_base_grad is not None
+
+    g_val = left.rank1_factor.affine_base_value
+    v_g = left.rank1_factor.affine_base_grad
+    h = right.value
+    v_h = right.grad
+
+    # Combined rank-1 vector and coefficient. Each operand is a fresh
+    # Interval; the final combined Interval is the single instance we
+    # pass to _outer to trigger self-product tightening.
+    g_over_h = g_val / h
+    v_combined = v_g - _broadcast_product(g_over_h, v_h)
+    c_combined = Interval.point(2.0) / h
+
+    outer_vv = _outer(v_combined, v_combined)
+    hess = _broadcast_product(c_combined, outer_vv)
+
+    # Value and gradient via the standard reciprocal-product rule —
+    # tightness on those is not required for the convexity verdict
+    # but they remain sound and consistent with the generic path.
+    inv_h = Interval.point(1.0) / h
+    inv_h2 = Interval.point(1.0) / (h * h)
+    recip_grad = _broadcast_product(-inv_h2, v_h)
+    fg_val = left.value * inv_h
+    fg_grad = _broadcast_product(inv_h, left.grad) + _broadcast_product(left.value, recip_grad)
+
+    return IntervalAD(
+        value=fg_val,
+        grad=fg_grad,
+        hess=hess,
+        rank1_factor=Rank1Factor(c=c_combined, v=v_combined),
+    )
 
 
 def _power(expr: BinaryOp, base: IntervalAD, n_vars: int) -> IntervalAD:
@@ -460,6 +575,31 @@ def _power(expr: BinaryOp, base: IntervalAD, n_vars: int) -> IntervalAD:
     return _apply_exp(scaled, n_vars)
 
 
+_AFFINE_HESS_TOL = 1e-300
+
+
+def _hess_is_exactly_zero(hess: Interval) -> bool:
+    """``True`` iff every entry of the interval Hessian encloses ``0``
+    with a magnitude well below any meaningful scale.
+
+    Used to detect "affine in the variables" nodes: when the
+    algebraic ``H_g`` is identically zero, the AD walker produces
+    an interval Hessian whose entries are within a few ULPs of
+    ``0`` (subnormals from outward-rounded additions of exact
+    zeros). The tolerance ``1e-300`` is six orders of magnitude
+    above the smallest subnormal and still ~270 orders of magnitude
+    below any plausible nonzero Hessian entry, so it cannot
+    misclassify a real (even tiny) curvature term as affine.
+
+    The check is sufficient-only: a false ``False`` just causes the
+    rank-1 fast path to be skipped, falling through to the existing
+    Gershgorin path.
+    """
+    return bool(
+        np.all(np.abs(hess.lo) <= _AFFINE_HESS_TOL) and np.all(np.abs(hess.hi) <= _AFFINE_HESS_TOL)
+    )
+
+
 def _integer_power(base: IntervalAD, p: int, n: int) -> IntervalAD:
     """Direct chain rule for ``g^p`` with integer ``p``.
 
@@ -483,7 +623,20 @@ def _integer_power(base: IntervalAD, p: int, n: int) -> IntervalAD:
     hess = _broadcast_product(coeff1, base.hess) + _broadcast_product(
         coeff2, _outer(base.grad, base.grad)
     )
-    return IntervalAD(value=value, grad=grad, hess=hess)
+    # Rank-1 metadata: when p == 2 and H_g is identically zero (g is
+    # affine), the second-order term ``p g^{p-1} H_g`` vanishes and
+    # the Hessian collapses exactly to ``2 · ∇g ∇gᵀ``. Soundness is
+    # independent of this field; it is consumed only as a tighter
+    # sufficient test by the certificate.
+    rank1: Optional[Rank1Factor] = None
+    if p == 2 and _hess_is_exactly_zero(base.hess):
+        rank1 = Rank1Factor(
+            c=Interval.point(2.0),
+            v=base.grad,
+            affine_base_value=base.value,
+            affine_base_grad=base.grad,
+        )
+    return IntervalAD(value=value, grad=grad, hess=hess, rank1_factor=rank1)
 
 
 def _reciprocal_power(base: IntervalAD, k: int, n: int) -> IntervalAD:
@@ -577,4 +730,4 @@ def _apply_log(arg: IntervalAD, n: int) -> IntervalAD:
     return IntervalAD(value=value, grad=grad, hess=hess)
 
 
-__all__ = ["IntervalAD", "interval_hessian"]
+__all__ = ["IntervalAD", "Rank1Factor", "interval_hessian"]

--- a/python/tests/test_convexity_certificate.py
+++ b/python/tests/test_convexity_certificate.py
@@ -185,6 +185,48 @@ class TestCrossConsistencyWithSyntactic:
             assert cert == syntactic, f"Certificate {cert} disagrees with syntactic {syntactic}"
 
 
+class TestRank1QuotientPath:
+    """The interval-AD walker's rank-1 PSD fast path certifies the
+    perspective form ``g²/h`` (affine ``g``, affine strictly-positive
+    ``h``) on boxes where Gershgorin would otherwise abstain.
+    """
+
+    def test_quadratic_over_linear_wide_box(self):
+        m = Model("qol_wide")
+        x = m.continuous("x", lb=-1.0e8, ub=1.0e8)
+        y = m.continuous("y", lb=1.0e-3, ub=1.0e8)
+        assert certify_convex((x * x) / y, m) == Curvature.CONVEX
+
+    def test_quadratic_via_pow_over_linear_wide_box(self):
+        m = Model("qol_pow_wide")
+        x = m.continuous("x", lb=-1.0e8, ub=1.0e8)
+        y = m.continuous("y", lb=1.0e-3, ub=1.0e8)
+        assert certify_convex((x**2) / y, m) == Curvature.CONVEX
+
+    def test_shifted_square_over_linear_wide_box(self):
+        m = Model("shifted_qol_wide")
+        x = m.continuous("x", lb=-1.0e8, ub=1.0e8)
+        y = m.continuous("y", lb=1.0e-3, ub=1.0e8)
+        assert certify_convex(((x + 1.0) ** 2) / y, m) == Curvature.CONVEX
+
+    def test_quadratic_over_scaled_linear_wide_box(self):
+        m = Model("qol_scaled_wide")
+        x = m.continuous("x", lb=-1.0e8, ub=1.0e8)
+        y = m.continuous("y", lb=1.0e-3, ub=1.0e8)
+        assert certify_convex((x * x) / (2.0 * y + 1.0), m) == Curvature.CONVEX
+
+    def test_jensen_consistency_on_rank1_quotient(self):
+        """Independent Jensen audit: x²/y is convex on the box, and
+        the rank-1 path's CONVEX verdict must hold up against random
+        convex-combination probes (no false positives)."""
+        m = Model("qol_jensen")
+        x = m.continuous("x", lb=-2.0, ub=2.0)
+        y = m.continuous("y", lb=0.5, ub=3.0)
+        expr = (x * x) / y
+        assert certify_convex(expr, m) == Curvature.CONVEX
+        _jensen_consistent(expr, m, convex=True)
+
+
 @pytest.mark.slow
 class TestJensenAuditOnCertificate:
     """Every CONVEX/CONCAVE verdict from the certificate is cross-

--- a/python/tests/test_convexity_eigenvalue.py
+++ b/python/tests/test_convexity_eigenvalue.py
@@ -17,6 +17,7 @@ import pytest
 from discopt._jax.convexity.eigenvalue import (
     gershgorin_lambda_max,
     gershgorin_lambda_min,
+    psd_2x2_sufficient,
 )
 from discopt._jax.convexity.interval import Interval
 
@@ -147,3 +148,70 @@ class TestRandomSoundness:
         radius = 0.5 * (radius + radius.T)
         H = Interval(lo=centre - radius, hi=centre + radius)
         _assert_bounds_enclose_spectrum(H, n_samples=24, seed=seed + 100)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 2×2 sufficient PSD test
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPsd2x2Sufficient:
+    """``psd_2x2_sufficient`` returns ``True`` only when every concrete
+    symmetric matrix in ``H`` is provably PSD by Sylvester's criterion."""
+
+    def test_pure_diagonal_psd(self):
+        H = Interval(
+            lo=np.array([[1.0, 0.0], [0.0, 2.0]]),
+            hi=np.array([[3.0, 0.0], [0.0, 5.0]]),
+        )
+        assert psd_2x2_sufficient(H) is True
+
+    def test_zero_matrix_is_psd(self):
+        H = Interval(lo=np.zeros((2, 2)), hi=np.zeros((2, 2)))
+        assert psd_2x2_sufficient(H) is True
+
+    def test_negative_diagonal_lower_bound_rejected(self):
+        H = Interval(
+            lo=np.array([[-0.1, 0.0], [0.0, 1.0]]),
+            hi=np.array([[1.0, 0.0], [0.0, 2.0]]),
+        )
+        assert psd_2x2_sufficient(H) is False
+
+    def test_indefinite_via_off_diagonal(self):
+        # Diagonals are 1, off-diagonal radius is 2 — clearly indefinite.
+        H = Interval(
+            lo=np.array([[1.0, -2.0], [-2.0, 1.0]]),
+            hi=np.array([[1.0, 2.0], [2.0, 1.0]]),
+        )
+        assert psd_2x2_sufficient(H) is False
+
+    def test_borderline_psd_passes(self):
+        # Det = 1 * 1 - 0.5^2 = 0.75 > 0, both diagonals nonneg.
+        H = Interval(
+            lo=np.array([[1.0, -0.5], [-0.5, 1.0]]),
+            hi=np.array([[1.5, 0.5], [0.5, 1.5]]),
+        )
+        assert psd_2x2_sufficient(H) is True
+
+    def test_unbounded_rejected(self):
+        H = Interval(
+            lo=np.array([[1.0, -np.inf], [-np.inf, 1.0]]),
+            hi=np.array([[2.0, np.inf], [np.inf, 2.0]]),
+        )
+        assert psd_2x2_sufficient(H) is False
+
+    def test_non_2x2_rejected(self):
+        H = Interval(lo=np.eye(3), hi=np.eye(3))
+        assert psd_2x2_sufficient(H) is False
+
+    def test_strictly_positive_definite_passes(self):
+        # H = v vᵀ + ε I with ε > 0 — strictly PD; the outward-rounded
+        # determinant test certifies it. (The exactly rank-1 case
+        # ``v vᵀ`` has det = 0 and is certified through the structural
+        # ``Rank1Factor`` path in the certificate, not through this
+        # sufficient 2×2 numerical test.)
+        v = np.array([1.0, 2.0])
+        eps = 1.0
+        H_mat = np.outer(v, v) + eps * np.eye(2)
+        H = Interval(lo=H_mat, hi=H_mat)
+        assert psd_2x2_sufficient(H) is True

--- a/python/tests/test_convexity_wide_box.py
+++ b/python/tests/test_convexity_wide_box.py
@@ -183,16 +183,20 @@ class TestWideBoxCertificateAbstainsAsDocumented:
     """The pure interval-Hessian certificate may abstain on wide boxes.
 
     These tests lock in the current behaviour of :func:`certify_convex`
-    for shapes whose Hessian contains exp/pow/div atoms: on a wide box
-    the interval enclosure overflows or loses enough precision for
-    Gershgorin to fail, and the certificate returns ``None``. This is
-    exactly the failure mode David flagged on ``nlp_cvx_205_010``, and
-    it is *expected* under the current certificate — the structural
-    recognizers are the reason those MINLPTests cases still pass.
+    for shapes whose Hessian contains exp/pow/div atoms. The
+    quadratic-over-linear shape ``x²/y`` is now certified via a
+    structural rank-1 PSD path through the interval-AD walker
+    (see :mod:`discopt._jax.convexity.interval_ad`), so it appears in
+    the *positive* :class:`TestWideBoxCertificateProvesConvex` group.
+    The remaining abstention pinned here is the exp-perspective
+    shape: ``y * exp(x/y)`` overflows ``exp`` on a wide box regardless
+    of how the interval Hessian is encoded, and recovering it requires
+    structural pattern recognition (out of scope for the certificate).
 
     If a future certificate tightening (e.g. αBB-style Hessian bounds,
-    affine arithmetic) turns any of these into successful proofs, the
-    test will surface that change rather than let it slip through.
+    affine arithmetic) turns the remaining case into a successful
+    proof, the test will surface that change rather than let it slip
+    through.
     """
 
     def test_exp_perspective_certificate_abstains_on_wide_box(self):
@@ -205,21 +209,6 @@ class TestWideBoxCertificateAbstainsAsDocumented:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             verdict = certify_convex(y * dm.exp(x / y), m)
-        assert verdict is None
-
-    def test_quadratic_over_linear_certificate_abstains_on_wide_box(self):
-        # Hessian of x^2/y is
-        #   [[2/y,        -2x/y^2],
-        #    [-2x/y^2,     2x^2/y^3]]
-        # On x in [-WIDE, WIDE], y in [1e-3, WIDE] the off-diagonal and
-        # H[1,1] entries span many orders of magnitude; Gershgorin's
-        # lambda_min goes sharply negative and the certificate abstains.
-        m = Model("qol_cert_wide")
-        x = m.continuous("x", lb=-WIDE, ub=WIDE)
-        y = m.continuous("y", lb=1.0e-3, ub=WIDE)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
-            verdict = certify_convex((x * x) / y, m)
         assert verdict is None
 
     def test_structural_layer_strictly_stronger_than_certificate_on_perspective(self):
@@ -235,6 +224,66 @@ class TestWideBoxCertificateAbstainsAsDocumented:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             assert certify_convex(expr, m) is None
+
+
+class TestWideBoxCertificateProvesConvex:
+    """Wide-box shapes the interval-AD certificate now certifies CONVEX.
+
+    Issue #42: the perspective form ``g²/h`` for affine ``g`` and
+    affine strictly-positive ``h`` has an exact rank-1 PSD Hessian
+    (see :func:`_rank1_quotient` in
+    :mod:`discopt._jax.convexity.interval_ad`). The certificate
+    propagates a :class:`Rank1Factor` through the AD walker and
+    consults it as a structural sufficient PSD test, certifying the
+    quotient on boxes where Gershgorin's row-sum bound would be too
+    loose.
+    """
+
+    def test_quadratic_over_linear_certificate_proves_convex_on_wide_box(self):
+        # Hessian of x^2/y is
+        #   [[2/y,        -2x/y^2],
+        #    [-2x/y^2,     2x^2/y^3]]
+        # = (2/y) · v vᵀ with v = [1, -x/y] — a rank-1 PSD form on
+        # any box with y > 0. The certificate's structural rank-1
+        # path certifies it via Rank1Factor metadata regardless of
+        # how wide the off-diagonal interval becomes.
+        m = Model("qol_cert_wide")
+        x = m.continuous("x", lb=-WIDE, ub=WIDE)
+        y = m.continuous("y", lb=1.0e-3, ub=WIDE)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            verdict = certify_convex((x * x) / y, m)
+        assert verdict == Curvature.CONVEX
+
+    def test_x_squared_via_pow_over_y_proves_convex_on_wide_box(self):
+        """``x**2 / y`` exercises the same path through ``_integer_power``."""
+        m = Model("qol_pow_cert_wide")
+        x = m.continuous("x", lb=-WIDE, ub=WIDE)
+        y = m.continuous("y", lb=1.0e-3, ub=WIDE)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            verdict = certify_convex((x**2) / y, m)
+        assert verdict == Curvature.CONVEX
+
+    def test_shifted_square_over_linear_proves_convex_on_wide_box(self):
+        """``(x+1)² / y`` — affine numerator squared, affine denominator."""
+        m = Model("shifted_qol_cert_wide")
+        x = m.continuous("x", lb=-WIDE, ub=WIDE)
+        y = m.continuous("y", lb=1.0e-3, ub=WIDE)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            verdict = certify_convex(((x + 1.0) ** 2) / y, m)
+        assert verdict == Curvature.CONVEX
+
+    def test_quadratic_over_scaled_linear_proves_convex_on_wide_box(self):
+        """``x² / (2y + 1)`` — denominator is affine and strictly positive."""
+        m = Model("qol_scaled_cert_wide")
+        x = m.continuous("x", lb=-WIDE, ub=WIDE)
+        y = m.continuous("y", lb=1.0e-3, ub=WIDE)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            verdict = certify_convex((x * x) / (2.0 * y + 1.0), m)
+        assert verdict == Curvature.CONVEX
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #42. Hardens the box-local convexity certificate against wide-box abstention on quadratic-over-linear shapes.

- Carry an optional `Rank1Factor` on `IntervalAD` declaring "my Hessian is `c · v vᵀ`". Populated in `_integer_power(p=2)` and `BinaryOp("*")` (`g*g` cache identity) when the base is affine.
- New `_rank1_quotient` path in `_division` combines the numerator's rank-1 form with an affine strictly-positive denominator into the perspective-form Hessian `(2/h) · v vᵀ` via `_outer(v, v)` self-product tightening.
- `certify_convex` consults `rank1_factor` (structural rank-1 PSD test) and `psd_2x2_sufficient` (Sylvester) ahead of Gershgorin.
- `x²/y` on `x ∈ [-1e8, 1e8], y ∈ [1e-3, 1e8]` flips from `None` to `Curvature.CONVEX`. The exp-perspective shape `y * exp(x/y)` remains the documented abstention (`patterns.py` already covers it structurally; duplicating in the certificate is redundant — see PR discussion).

## Test plan

- [x] `pytest python/tests/test_convexity_wide_box.py` — 25/25, including the new `TestWideBoxCertificateProvesConvex` class
- [x] `pytest python/tests/test_convexity_certificate.py` — 28/28, including `TestRank1QuotientPath` and Jensen consistency on `x²/y`
- [x] `pytest python/tests/test_convexity_eigenvalue.py` — 23/23, including `TestPsd2x2Sufficient` (8 cases)
- [x] `pytest python/tests/test_convexity_interval_ad.py test_convexity_node_refresh.py` — 26/26
- [x] `pytest python/tests/test_convexity_soundness.py` — 24/24 (Jensen fuzz)
- [x] `pytest python/tests/ -k convex` — 428 passed, 2 xfailed (pre-existing)
- [x] `ruff check python/`, `ruff format --check`, `mypy python/discopt/_jax/convexity/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
