### PR TITLE
feat(presolve): wire M4+M5, M10, M9 of #51 into root presolve pipeline

### DIFF
--- a/python/discopt/_jax/presolve_pipeline.py
+++ b/python/discopt/_jax/presolve_pipeline.py
@@ -1,0 +1,210 @@
+"""Root-stage presolve orchestrator (wires M4+M5 and M10 of issue #51).
+
+The Rust-side passes ``eliminate_variables`` and ``reformulate_polynomial``
+are pure ``ModelRepr -> ModelRepr`` transforms and are exposed individually
+through PyO3. This module sequences them at root, together with the
+existing FBBT pass, and returns a tightened ``PyModelRepr`` plus an
+aggregate stats dict suitable for logging / regression assertions.
+
+Sequencing rationale (cheapest-and-most-shrinking first):
+
+1. ``eliminate_variables`` (M10) — pins continuous scalar variables that
+   are uniquely determined by a singleton equality and drops the
+   determining equality. Pure tightening, monotone, idempotent. Cheap.
+2. ``reformulate_polynomial`` (M4 + M5) — rewrites high-degree monomials
+   to nested bilinear products with auxiliary variables; derives
+   McCormick-style bounds for the new aux vars from interval AD. This
+   *changes the model topology* (adds aux vars and constraints), so it
+   is opt-in by default.
+3. ``fbbt`` — forward/backward bound propagation. Runs last so it sees
+   the tightened bounds and (when enabled) the new aux variables.
+
+All passes produce a *new* ``ModelRepr``; nothing in-place. The caller is
+responsible for swapping in the returned object as the active repr.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def run_root_presolve(
+    model_repr,
+    *,
+    eliminate: bool = True,
+    polynomial: bool = False,
+    fbbt: bool = True,
+    fbbt_max_iter: int = 20,
+    fbbt_tol: float = 1e-8,
+) -> tuple[Any, dict]:
+    """Run the root-stage presolve sequence on ``model_repr``.
+
+    Args:
+        model_repr: a ``PyModelRepr`` produced by ``model_to_repr``.
+        eliminate: run ``eliminate_variables`` (M10). Safe by default.
+        polynomial: run ``reformulate_polynomial`` (M4 + M5). Off by
+            default because it adds auxiliary variables and changes the
+            shape of the variable index space; downstream code that
+            assumes a fixed n_vars must opt in.
+        fbbt: run FBBT after the structural rewrites.
+        fbbt_max_iter, fbbt_tol: forwarded to ``fbbt`` / ``fbbt_with_cutoff``.
+
+    Returns:
+        ``(new_model_repr, stats)`` where ``stats`` is a dict with keys
+        ``elimination`` (or absent when skipped), ``polynomial`` (ditto),
+        and ``fbbt`` containing per-block ``lb``/``ub`` arrays. Empty
+        dict means no pass actually ran.
+    """
+    stats: dict = {}
+    repr_ = model_repr
+
+    if eliminate:
+        repr_, elim_stats = repr_.eliminate_variables()
+        stats["elimination"] = dict(elim_stats)
+
+    if polynomial:
+        repr_, poly_stats = repr_.reformulate_polynomial()
+        stats["polynomial"] = dict(poly_stats)
+
+    if fbbt:
+        lbs, ubs = repr_.fbbt_with_cutoff(
+            max_iter=fbbt_max_iter, tol=fbbt_tol, incumbent_bound=None
+        )
+        stats["fbbt"] = {"lb": lbs, "ub": ubs}
+
+    return repr_, stats
+
+
+def propagate_bounds_to_model(model, model_repr) -> int:
+    """Push tightened per-element bounds from ``model_repr`` back into ``model``.
+
+    This is the bridge that lets the Rust-side presolve outcome influence
+    the Python-side relaxation compiler / branch-and-bound initialisation.
+    Only blocks whose count and flat element count are unchanged from the
+    original model are touched. Aux variables introduced by
+    ``reformulate_polynomial`` have no Python-side counterpart and are
+    silently skipped.
+
+    Returns the number of *scalar elements* whose ``lb`` or ``ub`` was
+    strictly tightened. Equal-or-looser updates are ignored.
+    """
+    import numpy as np
+
+    n_tightened = 0
+    py_blocks = list(model._variables)
+    n_blocks = min(len(py_blocks), model_repr.n_var_blocks)
+    for bi in range(n_blocks):
+        block = py_blocks[bi]
+        py_lb = np.asarray(block.lb, dtype=np.float64)
+        py_ub = np.asarray(block.ub, dtype=np.float64)
+        rust_lb = np.asarray(model_repr.var_lb(bi), dtype=np.float64)
+        rust_ub = np.asarray(model_repr.var_ub(bi), dtype=np.float64)
+        if rust_lb.size != py_lb.size or rust_ub.size != py_ub.size:
+            continue
+        flat_py_lb = py_lb.reshape(-1).copy()
+        flat_py_ub = py_ub.reshape(-1).copy()
+        changed = False
+        for k in range(flat_py_lb.size):
+            new_lo = max(flat_py_lb[k], rust_lb[k])
+            new_hi = min(flat_py_ub[k], rust_ub[k])
+            if new_lo > flat_py_lb[k] + 1e-12:
+                flat_py_lb[k] = new_lo
+                n_tightened += 1
+                changed = True
+            if new_hi < flat_py_ub[k] - 1e-12:
+                flat_py_ub[k] = new_hi
+                n_tightened += 1
+                changed = True
+        if changed:
+            block.lb = flat_py_lb.reshape(py_lb.shape)
+            block.ub = flat_py_ub.reshape(py_ub.shape)
+    return n_tightened
+
+
+def run_reverse_ad_tightening(
+    model,
+    *,
+    max_iter: int = 25,
+    tol: float = 1e-9,
+) -> int:
+    """Tighten ``model`` variable bounds via reverse-mode interval AD (M9).
+
+    Walks every constraint as ``(body, target_interval)`` where ``target``
+    is derived from the constraint sense and rhs, then iterates the
+    Gauss-Seidel reverse-AD propagation in ``interval_ad_reverse.tighten_box``
+    to a fixed point. The returned tightened intervals are intersected
+    with the current Python-side ``lb``/``ub`` and written back, so that
+    the relaxation compiler and B&B initialisation see the tighter box.
+
+    Returns the number of variable blocks whose bounds were strictly
+    tightened. Skips quietly when no constraints have polynomial /
+    differentiable bodies.
+    """
+    import numpy as np
+
+    from discopt._jax.convexity.interval import Interval
+    from discopt._jax.convexity.interval_ad_reverse import tighten_box
+
+    constraints: list = []
+    for c in model._constraints:
+        sense = getattr(c, "sense", None)
+        rhs = float(getattr(c, "rhs", 0.0))
+        body = getattr(c, "body", None)
+        if body is None or sense is None:
+            continue
+        if sense == "<=":
+            target = Interval(
+                np.asarray(-np.inf, dtype=np.float64),
+                np.asarray(rhs, dtype=np.float64),
+            )
+        elif sense == ">=":
+            target = Interval(
+                np.asarray(rhs, dtype=np.float64),
+                np.asarray(np.inf, dtype=np.float64),
+            )
+        elif sense == "==":
+            target = Interval(
+                np.asarray(rhs, dtype=np.float64),
+                np.asarray(rhs, dtype=np.float64),
+            )
+        else:
+            continue
+        constraints.append((body, target))
+    if not constraints:
+        return 0
+
+    try:
+        new_box = tighten_box(constraints, model, max_iter=max_iter, tol=tol)
+    except Exception:
+        return 0
+
+    n_tightened = 0
+    for v, iv in new_box.items():
+        lo_arr = np.asarray(iv.lo, dtype=np.float64).ravel()
+        hi_arr = np.asarray(iv.hi, dtype=np.float64).ravel()
+        if lo_arr.size != 1 or hi_arr.size != 1:
+            # Vector / matrix interval bounds aren't supported by this
+            # propagation path yet.
+            continue
+        new_lo = float(lo_arr[0])
+        new_hi = float(hi_arr[0])
+        if not (np.isfinite(new_lo) and np.isfinite(new_hi)):
+            continue
+        py_lb = np.asarray(v.lb, dtype=np.float64).ravel()
+        py_ub = np.asarray(v.ub, dtype=np.float64).ravel()
+        if py_lb.size != 1 or py_ub.size != 1:
+            continue
+        cur_lo = float(py_lb[0])
+        cur_hi = float(py_ub[0])
+        if new_lo > cur_lo + 1e-12 or new_hi < cur_hi - 1e-12:
+            v.lb = np.broadcast_to(np.asarray(max(cur_lo, new_lo)), v.shape)
+            v.ub = np.broadcast_to(np.asarray(min(cur_hi, new_hi)), v.shape)
+            n_tightened += 1
+    return n_tightened
+
+
+__all__ = [
+    "run_root_presolve",
+    "propagate_bounds_to_model",
+    "run_reverse_ad_tightening",
+]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1235,6 +1235,9 @@ def solve_model(
     node_callback=None,
     solver: Optional[str] = None,
     use_highs_milp: bool = True,
+    presolve: bool = True,
+    presolve_polynomial: bool = False,
+    presolve_reverse_ad: bool = False,
     **kwargs,
 ) -> SolveResult:
     """
@@ -1447,6 +1450,54 @@ def solve_model(
         _model_repr = model_to_repr(model, _builder)
     except Exception:
         pass  # FBBT bindings unavailable; skip
+
+    # --- Root presolve: M10 variable elimination + (opt-in) M4+M5
+    # polynomial reformulation, then FBBT for bound propagation.
+    # Tightened bounds are pushed back into the Python `model` so that
+    # the relaxation compiler / B&B initialisation see them. See
+    # discopt._jax.presolve_pipeline for the sequencing rationale.
+    if _model_repr is not None and presolve:
+        try:
+            from discopt._jax.presolve_pipeline import (
+                propagate_bounds_to_model,
+                run_root_presolve,
+            )
+
+            _model_repr, _presolve_stats = run_root_presolve(
+                _model_repr,
+                eliminate=True,
+                polynomial=presolve_polynomial,
+                fbbt=True,
+            )
+            n_tightened = propagate_bounds_to_model(model, _model_repr)
+            elim = _presolve_stats.get("elimination", {})
+            poly = _presolve_stats.get("polynomial", {})
+            if elim.get("variables_fixed", 0) > 0 or n_tightened > 0:
+                logger.info(
+                    "Presolve: fixed %d vars, removed %d eqs, tightened %d "
+                    "bounds (poly aux vars: %d)",
+                    elim.get("variables_fixed", 0),
+                    elim.get("constraints_removed", 0),
+                    n_tightened,
+                    poly.get("aux_variables_introduced", 0),
+                )
+        except Exception as e:
+            logger.debug("Root presolve failed: %s", e)
+
+    # --- Reverse-AD interval tightening (M9 of #51, opt-in) ---
+    # Iterates Gauss-Seidel reverse-mode interval AD over every
+    # constraint to a fixed point and writes back tighter scalar bounds.
+    # Disabled by default because it walks the Python expression DAG and
+    # can be slow on very large models.
+    if presolve and presolve_reverse_ad:
+        try:
+            from discopt._jax.presolve_pipeline import run_reverse_ad_tightening
+
+            n_rad = run_reverse_ad_tightening(model)
+            if n_rad > 0:
+                logger.info("Reverse-AD presolve tightened %d variable bounds", n_rad)
+        except Exception as e:
+            logger.debug("Reverse-AD tightening failed: %s", e)
 
     # --- Learned relaxation registry (opt-in) ---
     import warnings

--- a/python/tests/test_presolve_pipeline.py
+++ b/python/tests/test_presolve_pipeline.py
@@ -1,0 +1,181 @@
+"""Integration tests for the root presolve orchestrator.
+
+Verifies that the Rust-side passes ``eliminate_variables`` (M10) and
+``reformulate_polynomial`` (M4 + M5) of issue #51 are correctly
+sequenced by ``discopt._jax.presolve_pipeline.run_root_presolve`` and
+that tightened bounds are propagated back into the Python ``Model``
+object so that ``Model.solve()`` can use them.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import discopt
+import numpy as np
+import pytest
+from discopt._jax.presolve_pipeline import (
+    propagate_bounds_to_model,
+    run_reverse_ad_tightening,
+    run_root_presolve,
+)
+
+
+def _model_repr(model):
+    from discopt._rust import model_to_repr
+
+    return model_to_repr(model, getattr(model, "_builder", None))
+
+
+def test_eliminate_pins_singleton_equality():
+    """A continuous var fully determined by a singleton equality is pinned."""
+    m = discopt.Model("singleton_eq")
+    x = m.continuous("x", lb=-10.0, ub=10.0)
+    y = m.continuous("y", lb=-10.0, ub=10.0)
+    m.subject_to(2.0 * x == 6.0, name="fix_x")
+    m.minimize((x - y) ** 2)
+
+    repr_in = _model_repr(m)
+    repr_out, stats = run_root_presolve(repr_in, eliminate=True, polynomial=False, fbbt=False)
+
+    assert stats["elimination"]["variables_fixed"] >= 1
+    assert stats["elimination"]["constraints_removed"] >= 1
+    # x's bounds should be pinned to 3.0 in the new repr.
+    lb = repr_out.var_lb(0)
+    ub = repr_out.var_ub(0)
+    assert lb[0] == pytest.approx(3.0)
+    assert ub[0] == pytest.approx(3.0)
+
+
+def test_propagate_bounds_to_python_model():
+    """Pinned bounds in the new ``ModelRepr`` flow back into ``Model``."""
+    m = discopt.Model("propagate")
+    x = m.continuous("x", lb=-100.0, ub=100.0)
+    y = m.continuous("y", lb=-100.0, ub=100.0)
+    m.subject_to(x == 7.5, name="fix_x")
+    m.subject_to(y >= -1.0)
+    m.minimize(x * y)
+
+    repr_in = _model_repr(m)
+    repr_out, _ = run_root_presolve(repr_in, eliminate=True, polynomial=False, fbbt=False)
+    n_tightened = propagate_bounds_to_model(m, repr_out)
+
+    assert n_tightened >= 2  # both lb and ub of x get tightened
+    assert float(np.asarray(x.lb)) == pytest.approx(7.5)
+    assert float(np.asarray(x.ub)) == pytest.approx(7.5)
+
+
+def test_polynomial_reformulation_runs():
+    """Opt-in polynomial reformulation completes and returns stats."""
+    m = discopt.Model("poly")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    # Cubic monomial that should trigger M4 reformulation.
+    m.minimize(x**3 + y**3)
+    m.subject_to(x + y >= 0.5)
+
+    repr_in = _model_repr(m)
+    repr_out, stats = run_root_presolve(repr_in, eliminate=False, polynomial=True, fbbt=False)
+    assert "polynomial" in stats
+    # Either the rewriter rewrote some cubic terms (and added aux vars)
+    # or it conservatively skipped them; both outcomes are sound. We
+    # assert the stats schema is intact and aux counts are consistent.
+    poly = stats["polynomial"]
+    assert poly["aux_variables_introduced"] >= 0
+    assert poly["aux_constraints_introduced"] >= 0
+    # If aux vars were introduced, the new repr must report them.
+    if poly["aux_variables_introduced"] > 0:
+        assert repr_out.n_var_blocks > repr_in.n_var_blocks
+
+
+def test_reverse_ad_tightening_shrinks_box():
+    """Reverse-mode interval AD over a square constraint shrinks the box."""
+    m = discopt.Model("rad")
+    x = m.continuous("x", lb=-100.0, ub=100.0)
+    y = m.continuous("y", lb=-100.0, ub=100.0)
+    # x**2 + y**2 <= 4 forces |x|, |y| <= 2. Use Pow nodes (x**2) rather
+    # than Mul (x*x) because the reverse-AD module's power inverse fires
+    # only on Pow.
+    m.subject_to(x**2 + y**2 <= 4.0)
+    m.minimize(x + y)
+
+    n_tight = run_reverse_ad_tightening(m)
+    assert n_tight >= 1
+    assert float(np.asarray(x.ub)) <= 2.0 + 1e-6
+    assert float(np.asarray(x.lb)) >= -2.0 - 1e-6
+    assert float(np.asarray(y.ub)) <= 2.0 + 1e-6
+    assert float(np.asarray(y.lb)) >= -2.0 - 1e-6
+
+
+def test_solve_with_presolve_does_not_change_optimum():
+    """End-to-end: enabling root presolve does not change the optimum."""
+    m = discopt.Model("e2e")
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    y = m.continuous("y", lb=-5.0, ub=5.0)
+    z = m.continuous("z", lb=-5.0, ub=5.0)
+    m.subject_to(2.0 * z == 1.0, name="pin_z")  # M10 should pin z := 0.5
+    m.subject_to(x + y >= 1.0)
+    m.minimize((x - 1.0) ** 2 + (y - 1.0) ** 2 + z)
+
+    res_no = m.solve(time_limit=30.0, presolve=False)
+    # Re-build a fresh model since solve() may mutate state.
+    m2 = discopt.Model("e2e2")
+    x2 = m2.continuous("x", lb=-5.0, ub=5.0)
+    y2 = m2.continuous("y", lb=-5.0, ub=5.0)
+    z2 = m2.continuous("z", lb=-5.0, ub=5.0)
+    m2.subject_to(2.0 * z2 == 1.0, name="pin_z")
+    m2.subject_to(x2 + y2 >= 1.0)
+    m2.minimize((x2 - 1.0) ** 2 + (y2 - 1.0) ** 2 + z2)
+    res_yes = m2.solve(time_limit=30.0, presolve=True)
+
+    assert res_no.status in ("optimal", "feasible")
+    assert res_yes.status in ("optimal", "feasible")
+    assert res_yes.objective == pytest.approx(res_no.objective, abs=1e-4, rel=1e-4)
+
+
+def _build_full_pipeline_model(name: str):
+    """Model exercising elimination, polynomial reformulation, and
+    reverse-AD tightening simultaneously.
+
+    - z is uniquely determined by ``2*z == 1.0``  → M10 fires.
+    - Objective contains ``x**3 + y**3`` cubic monomials → M4 + M5 fires
+      when ``presolve_polynomial=True``.
+    - Constraint ``x**2 + y**2 <= 4`` shrinks the [-5, 5] box on x, y to
+      [-2, 2] via reverse-AD when ``presolve_reverse_ad=True`` → M9.
+    """
+    m = discopt.Model(name)
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    y = m.continuous("y", lb=-5.0, ub=5.0)
+    z = m.continuous("z", lb=-5.0, ub=5.0)
+    m.subject_to(2.0 * z == 1.0, name="pin_z")
+    m.subject_to(x**2 + y**2 <= 4.0, name="disk")
+    m.subject_to(x + y >= 0.5)
+    m.minimize(x**3 + y**3 + 0.1 * z + (x - 0.5) ** 2 + (y - 0.5) ** 2)
+    return m
+
+
+def test_full_pipeline_preserves_global_optimum():
+    """Enabling all three new presolve passes does not change the optimum."""
+    base = _build_full_pipeline_model("baseline")
+    res_base = base.solve(
+        time_limit=60.0,
+        presolve=False,
+        presolve_polynomial=False,
+        presolve_reverse_ad=False,
+    )
+    full = _build_full_pipeline_model("full")
+    res_full = full.solve(
+        time_limit=60.0,
+        presolve=True,
+        presolve_polynomial=True,
+        presolve_reverse_ad=True,
+    )
+    assert res_base.status in ("optimal", "feasible")
+    assert res_full.status in ("optimal", "feasible")
+    assert res_full.objective == pytest.approx(res_base.objective, abs=1e-3, rel=1e-3)


### PR DESCRIPTION
## Summary

Wires three of the standalone bound-tightening modules from PR #75 into the default solver path:

- **M10** `eliminate_variables` — runs by default (`presolve=True`).
- **M4 + M5** `reformulate_polynomial` — opt-in (`presolve_polynomial=True`).
- **M9** reverse-mode interval AD — opt-in (`presolve_reverse_ad=True`).

A new orchestrator `python/discopt/_jax/presolve_pipeline.py` sequences the Rust passes, propagates tightened bounds back to the Python `Model` (with shape and aux-var-introduction guards), and exposes the reverse-AD bridge.

`solver.py` calls the orchestrator immediately after `model_to_repr(...)` so the JAX relaxation compiler and B&B initialisation see the tighter bounds.

## Deferred (intentionally) from this PR

**M2 (Chebyshev), M3 (Taylor), M6 (eigenvalue)** are landed as standalone bound providers in PR #75 but are not yet wired into `relaxation_compiler.py`. The compiler currently dispatches univariate operators directly to `mccormick.relax_*`; introducing an `arithmetic=` kwarg requires plumbing the choice through every `_compile_relax_node` recursion plus a (cv, cc) shim that converts polyhedral-OA cuts back into JAX-traceable underestimator/overestimator functions. That is a focused follow-up where each operator's tightness vs. McCormick can be benchmarked.

## Test plan

- [x] `pytest python/tests/test_presolve_pipeline.py -v` — 6 new tests pass (eliminate, propagate, polynomial, reverse-AD, end-to-end with elimination, full pipeline with all three passes).
- [x] `pytest python/tests/test_correctness.py python/tests/test_alphabb.py python/tests/test_callbacks.py` — 144 existing tests pass.
- [x] `mypy python/discopt/` — full project clean ("Success: no issues found in 158 source files").
- [x] `ruff check python/` and `ruff format --check python/` — clean.
- [ ] CI on this PR.

## Notes for review

- PR #75 has merged into main; this PR sits directly on `main` as a single commit.
- All three new flags default to OFF except `presolve` (which controls M10). The change is therefore backward-compatible: existing solver invocations get only the safe M10 elimination automatically.
- The `propagate_bounds_to_model` helper deliberately compares element-by-element rather than by block, so vector/matrix variable bounds tighten correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
