### PR TITLE
feat(relaxation): wire M2/M3 arithmetics + M6 eigenvalue bound (#51)

### DIFF
--- a/python/discopt/_jax/oa_relax.py
+++ b/python/discopt/_jax/oa_relax.py
@@ -1,0 +1,190 @@
+"""JAX-traceable (cv, cc) shim for polyhedral outer approximations.
+
+The standalone ``polyhedral_oa.outer_approximation`` (M11 of issue #51)
+returns a list of affine cuts that sandwich a univariate function ``f``
+on a static reference box. The relaxation compiler, by contrast, needs a
+``(mid, cv_a, cc_a) -> (cv, cc)`` pair that is jit/vmap compatible and
+plays the same role as the existing McCormick ``relax_*`` functions.
+
+This module performs the conversion at *compile time*: cuts are
+materialised once into two stacks of ``(slope, intercept)`` pairs (one
+for lower-bound cuts, one for upper-bound cuts). At runtime the cv and
+cc are recovered as the elementwise max / min of all affine cuts
+evaluated at the linearisation point ``mid``. The result is sound by
+construction because each cut globally encloses ``f`` on the reference
+box (see ``polyhedral_oa.py`` docstring).
+
+Reference-box choice
+--------------------
+
+The reference box used to build the OA is the *static* interval
+enclosure of the inner expression, computed via
+``evaluate_interval`` from ``discopt._jax.convexity``. Using the static
+declared bounds means the OA is built once at compile time and stays
+fixed across B&B nodes. As nodes shrink, the OA may become looser than
+the McCormick envelope evaluated on the node-local interval — but it is
+always sound. Future work: rebuild OAs per node when the gain warrants
+the recompile cost.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import jax.numpy as jnp
+import numpy as np
+
+from discopt._jax import polyhedral_oa
+
+_NAME_TO_JAX_FN: dict[str, Callable] = {
+    "exp": jnp.exp,
+    "log": jnp.log,
+    "log2": jnp.log2,
+    "log10": jnp.log10,
+    "sqrt": jnp.sqrt,
+    "sin": jnp.sin,
+    "cos": jnp.cos,
+    "tan": jnp.tan,
+    "atan": jnp.arctan,
+    "asin": jnp.arcsin,
+    "acos": jnp.arccos,
+    "sinh": jnp.sinh,
+    "cosh": jnp.cosh,
+    "tanh": jnp.tanh,
+}
+
+
+def is_supported(name: str) -> bool:
+    """Whether ``polyhedral_oa`` can build an OA for the given op."""
+    return name in _NAME_TO_JAX_FN
+
+
+def make_oa_relax(
+    name: str,
+    ref_box: tuple[float, float],
+    arithmetic: str,
+    *,
+    degree: int = 8,
+    n_slopes: int = 16,
+) -> Callable:
+    """Build a ``(mid, cv_a, cc_a) -> (cv, cc)`` JAX function.
+
+    Args:
+        name: univariate operator name (must be a key of ``_NAME_TO_JAX_FN``).
+        ref_box: ``(a, b)`` reference box used to fit the OA. Must satisfy
+            ``a < b`` and be inside the natural domain of ``f``.
+        arithmetic: one of ``"chebyshev"``, ``"taylor"``, ``"mccormick"``.
+        degree: polynomial degree for the bound provider.
+        n_slopes: number of candidate slopes (yields up to ``2 * n_slopes``
+            cuts after deduplication).
+
+    Returns:
+        A jit/vmap-friendly function with the same signature as the
+        McCormick ``relax_*`` shims used by ``relaxation_compiler.py``.
+
+    Raises:
+        ValueError: when ``name`` is not in ``_NAME_TO_JAX_FN`` or
+            ``ref_box`` is degenerate / outside the operator's domain.
+    """
+    if name not in _NAME_TO_JAX_FN:
+        raise ValueError(f"OA shim does not support operator {name!r}")
+    a, b = float(ref_box[0]), float(ref_box[1])
+    if not (a < b):
+        raise ValueError(f"ref_box must have a < b, got {(a, b)}")
+    f = _NAME_TO_JAX_FN[name]
+    oa = polyhedral_oa.outer_approximation(f, (a, b), arithmetic, degree=degree, n_slopes=n_slopes)
+
+    lower_slopes: list[float] = []
+    lower_intercepts: list[float] = []
+    upper_slopes: list[float] = []
+    upper_intercepts: list[float] = []
+    for cut in oa.cuts:
+        sx = float(cut.coeffs[0])  # = -s
+        sy = float(cut.coeffs[1])  # = +1
+        if sy <= 0.0:
+            continue
+        slope = -sx / sy
+        intercept = float(cut.rhs) / sy
+        if cut.sense == ">=":
+            lower_slopes.append(slope)
+            lower_intercepts.append(intercept)
+        elif cut.sense == "<=":
+            upper_slopes.append(slope)
+            upper_intercepts.append(intercept)
+    if not lower_slopes or not upper_slopes:
+        # OA degenerate; fall back to a trivial function that defers to
+        # the natural-domain image. We materialise constant arrays so the
+        # caller's downstream jit path stays unbroken.
+        lo_arr_lb = jnp.asarray([float("-inf")], dtype=jnp.float64)
+        lo_arr_int = jnp.asarray([0.0], dtype=jnp.float64)
+        hi_arr_lb = jnp.asarray([0.0], dtype=jnp.float64)
+        hi_arr_int = jnp.asarray([float("inf")], dtype=jnp.float64)
+    else:
+        lo_arr_lb = jnp.asarray(lower_slopes, dtype=jnp.float64)
+        lo_arr_int = jnp.asarray(lower_intercepts, dtype=jnp.float64)
+        hi_arr_lb = jnp.asarray(upper_slopes, dtype=jnp.float64)
+        hi_arr_int = jnp.asarray(upper_intercepts, dtype=jnp.float64)
+
+    def relax_fn(
+        mid,
+        cv_a,
+        cc_a,
+        _lo_s=lo_arr_lb,
+        _lo_i=lo_arr_int,
+        _hi_s=hi_arr_lb,
+        _hi_i=hi_arr_int,
+    ):
+        cv_vals = _lo_s * mid + _lo_i
+        cc_vals = _hi_s * mid + _hi_i
+        return jnp.max(cv_vals), jnp.min(cc_vals)
+
+    return relax_fn
+
+
+def _safe_box_for_op(name: str, lo: float, hi: float) -> tuple[float, float]:
+    """Clip ``[lo, hi]`` to the natural domain of the named operator.
+
+    Returns a strictly nondegenerate box; if the natural-domain
+    intersection is empty or degenerate, returns ``(lo, hi)`` unchanged
+    (the caller will surface the eventual error).
+    """
+    eps = 1e-9
+    if name in {"log", "log2", "log10"}:
+        lo = max(lo, eps)
+        hi = max(hi, lo + eps)
+    elif name == "sqrt":
+        lo = max(lo, 0.0)
+        hi = max(hi, lo + eps)
+    elif name in {"asin", "acos"}:
+        lo = max(lo, -1.0 + eps)
+        hi = min(hi, 1.0 - eps)
+        if hi <= lo:
+            hi = lo + eps
+    return float(lo), float(hi)
+
+
+def static_box_for_arg(arg, model) -> tuple[float, float] | None:
+    """Compute a static interval bound for an inner expression.
+
+    Returns ``(lo, hi)`` or ``None`` if the bound cannot be inferred
+    (e.g. the expression contains an unsupported operator).
+    """
+    try:
+        from discopt._jax.convexity.interval_eval import evaluate_interval
+    except Exception:
+        return None
+    try:
+        iv = evaluate_interval(arg, model)
+    except Exception:
+        return None
+    try:
+        lo = float(np.asarray(iv.lo).reshape(()))
+        hi = float(np.asarray(iv.hi).reshape(()))
+    except Exception:
+        return None
+    if not (np.isfinite(lo) and np.isfinite(hi)) or hi <= lo:
+        return None
+    return lo, hi
+
+
+__all__ = ["is_supported", "make_oa_relax", "static_box_for_arg", "_safe_box_for_op"]

--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -212,6 +212,7 @@ def _compile_relax_node(
     partitions: int = 0,
     mode: str = "standard",
     learned_registry: Optional["LearnedRelaxationRegistry"] = None,
+    arithmetic: str = "mccormick",
 ) -> Callable:
     """
     Recursively compile an Expression node into a relaxation function.
@@ -230,6 +231,12 @@ def _compile_relax_node(
             (ICNN-based learned relaxations with McCormick fallback).
         learned_registry: Registry of trained learned relaxations.
             Required when ``mode="learned"``.
+        arithmetic: Univariate-envelope provider — ``"mccormick"``
+            (default; existing analytic envelopes), ``"chebyshev"``, or
+            ``"taylor"``. The latter two route supported univariate ops
+            through ``oa_relax.make_oa_relax`` (M2 / M3 of issue #51).
+            Falls back to McCormick for unsupported operators or when the
+            inner expression's static box cannot be inferred.
     """
 
     if isinstance(expr, Constant):
@@ -269,8 +276,12 @@ def _compile_relax_node(
         return fn
 
     if isinstance(expr, BinaryOp):
-        left_fn = _compile_relax_node(expr.left, model, partitions, mode, learned_registry)
-        right_fn = _compile_relax_node(expr.right, model, partitions, mode, learned_registry)
+        left_fn = _compile_relax_node(
+            expr.left, model, partitions, mode, learned_registry, arithmetic
+        )
+        right_fn = _compile_relax_node(
+            expr.right, model, partitions, mode, learned_registry, arithmetic
+        )
         op = expr.op
 
         if op == "+":
@@ -589,7 +600,9 @@ def _compile_relax_node(
         raise ValueError(f"Unknown binary operator: {op!r}")
 
     if isinstance(expr, UnaryOp):
-        operand_fn = _compile_relax_node(expr.operand, model, partitions, mode, learned_registry)
+        operand_fn = _compile_relax_node(
+            expr.operand, model, partitions, mode, learned_registry, arithmetic
+        )
         op = expr.op
 
         if op == "neg":
@@ -613,7 +626,8 @@ def _compile_relax_node(
 
     if isinstance(expr, FunctionCall):
         arg_fns = [
-            _compile_relax_node(a, model, partitions, mode, learned_registry) for a in expr.args
+            _compile_relax_node(a, model, partitions, mode, learned_registry, arithmetic)
+            for a in expr.args
         ]
         name = expr.func_name
 
@@ -713,12 +727,38 @@ def _compile_relax_node(
             return fn
 
         if name in _univariate_relax:
+            a_fn = arg_fns[0]
+
+            # Chebyshev / Taylor dispatch (M2 / M3 of issue #51): build a
+            # pre-compiled outer-approximation shim if (a) the operator
+            # is supported, (b) we can infer a finite static box for the
+            # inner expression. Otherwise fall through to the existing
+            # McCormick path so the choice is non-blocking.
+            if arithmetic in ("chebyshev", "taylor"):
+                from discopt._jax import oa_relax
+
+                if oa_relax.is_supported(name):
+                    box = oa_relax.static_box_for_arg(expr.args[0], model)
+                    if box is not None:
+                        try:
+                            safe_box = oa_relax._safe_box_for_op(name, box[0], box[1])
+                            oa_fn = oa_relax.make_oa_relax(name, safe_box, arithmetic)
+
+                            def fn(x_cv, x_cc, lb, ub, _oa_fn=oa_fn, _a_fn=a_fn):
+                                cv_a, cc_a = _a_fn(x_cv, x_cc, lb, ub)
+                                mid = 0.5 * (cv_a + cc_a)
+                                return _oa_fn(mid, cv_a, cc_a)
+
+                            return fn
+                        except Exception:
+                            # Fall through to McCormick on any OA failure.
+                            pass
+
             # Prefer the TM2014 (multivariate McCormick) composition rule when
             # available — it is sound at non-degenerate inner intervals, where
             # the legacy midpoint composition can violate the bounds. See
             # python/discopt/_jax/multivariate_mccormick.py and issue #51 (M1).
             tm_rule = get_composition_rule(name)
-            a_fn = arg_fns[0]
             if tm_rule is not None:
 
                 def fn(x_cv, x_cc, lb, ub, _tm=tm_rule, _a_fn=a_fn):
@@ -851,7 +891,9 @@ def _compile_relax_node(
         raise ValueError(f"Unknown function: {name!r}")
 
     if isinstance(expr, IndexExpression):
-        base_fn = _compile_relax_node(expr.base, model, partitions, mode, learned_registry)
+        base_fn = _compile_relax_node(
+            expr.base, model, partitions, mode, learned_registry, arithmetic
+        )
         idx = expr.index
 
         def fn(x_cv, x_cc, lb, ub, _idx=idx):
@@ -861,7 +903,9 @@ def _compile_relax_node(
         return fn
 
     if isinstance(expr, SumExpression):
-        operand_fn = _compile_relax_node(expr.operand, model, partitions, mode, learned_registry)
+        operand_fn = _compile_relax_node(
+            expr.operand, model, partitions, mode, learned_registry, arithmetic
+        )
         axis = expr.axis
 
         def fn(x_cv, x_cc, lb, ub, _axis=axis):
@@ -872,7 +916,8 @@ def _compile_relax_node(
 
     if isinstance(expr, SumOverExpression):
         term_fns = [
-            _compile_relax_node(t, model, partitions, mode, learned_registry) for t in expr.terms
+            _compile_relax_node(t, model, partitions, mode, learned_registry, arithmetic)
+            for t in expr.terms
         ]
 
         def fn(x_cv, x_cc, lb, ub):
@@ -894,6 +939,7 @@ def compile_relaxation(
     partitions: int = 0,
     mode: str = "standard",
     learned_registry: Optional["LearnedRelaxationRegistry"] = None,
+    arithmetic: str = "mccormick",
 ) -> Callable:
     """
     Compile an Expression into a McCormick relaxation function.
@@ -920,7 +966,7 @@ def compile_relaxation(
 
         The function is compatible with jax.jit and jax.vmap.
     """
-    return _compile_relax_node(expr, model, partitions, mode, learned_registry)
+    return _compile_relax_node(expr, model, partitions, mode, learned_registry, arithmetic)
 
 
 def compile_objective_relaxation(
@@ -928,12 +974,18 @@ def compile_objective_relaxation(
     partitions: int = 0,
     mode: str = "standard",
     learned_registry: Optional["LearnedRelaxationRegistry"] = None,
+    arithmetic: str = "mccormick",
 ) -> Callable:
     """Compile relaxation of the model's objective."""
     if model._objective is None:
         raise ValueError("Model has no objective set.")
     return compile_relaxation(
-        model._objective.expression, model, partitions, mode, learned_registry
+        model._objective.expression,
+        model,
+        partitions,
+        mode,
+        learned_registry,
+        arithmetic,
     )
 
 
@@ -943,6 +995,9 @@ def compile_constraint_relaxation(
     partitions: int = 0,
     mode: str = "standard",
     learned_registry: Optional["LearnedRelaxationRegistry"] = None,
+    arithmetic: str = "mccormick",
 ) -> Callable:
     """Compile relaxation of a constraint body."""
-    return compile_relaxation(constraint.body, model, partitions, mode, learned_registry)
+    return compile_relaxation(
+        constraint.body, model, partitions, mode, learned_registry, arithmetic
+    )

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1238,6 +1238,8 @@ def solve_model(
     presolve: bool = True,
     presolve_polynomial: bool = False,
     presolve_reverse_ad: bool = False,
+    eigenvalue_root_bound: bool = False,
+    relaxation_arithmetic: str = "mccormick",
     **kwargs,
 ) -> SolveResult:
     """
@@ -1498,6 +1500,40 @@ def solve_model(
                 logger.info("Reverse-AD presolve tightened %d variable bounds", n_rad)
         except Exception as e:
             logger.debug("Reverse-AD tightening failed: %s", e)
+
+    # --- Eigenvalue root bound on quadratic objectives (M6 of #51, opt-in) ---
+    # For models with a quadratic objective, compute a sound root-node
+    # bound via spectral decomposition. Used only as an informational
+    # diagnostic at the root; does not affect the B&B tree directly.
+    if eigenvalue_root_bound:
+        try:
+            from discopt._jax.convexity.eigenvalue_arith import (
+                QuadraticForm,
+                quadratic_form_bound,
+            )
+            from discopt._jax.problem_classifier import (
+                ProblemClass,
+                classify_problem,
+                extract_qp_data,
+            )
+
+            pcls = classify_problem(model)
+            if pcls in (ProblemClass.QP, ProblemClass.MIQP):
+                qp = extract_qp_data(model)
+                Q_qf = 0.5 * np.asarray(qp.Q, dtype=np.float64)
+                b_qf = np.asarray(qp.c, dtype=np.float64)
+                qf = QuadraticForm(Q=Q_qf, b=b_qf, c=float(qp.obj_const))
+                x_lo = np.asarray(qp.x_l, dtype=np.float64)
+                x_hi = np.asarray(qp.x_u, dtype=np.float64)
+                if np.all(np.isfinite(x_lo)) and np.all(np.isfinite(x_hi)):
+                    eig_bound = quadratic_form_bound(qf, x_lo, x_hi)
+                    logger.info(
+                        "Eigenvalue root bound on quadratic objective: [%g, %g]",
+                        float(eig_bound.lo),
+                        float(eig_bound.hi),
+                    )
+        except Exception as e:
+            logger.debug("Eigenvalue root bound failed: %s", e)
 
     # --- Learned relaxation registry (opt-in) ---
     import warnings
@@ -1832,6 +1868,7 @@ def solve_model(
                 partitions=partitions,
                 mode=_relax_mode,
                 learned_registry=_learned_registry,
+                arithmetic=relaxation_arithmetic,
             )
             _mc_obj_eval = BatchRelaxationEvaluator(_mc_obj_relax_fn, n_vars)
             _mc_negate = model._objective.sense == ObjectiveSense.MAXIMIZE
@@ -1848,6 +1885,7 @@ def solve_model(
                                 partitions=partitions,
                                 mode=_relax_mode,
                                 learned_registry=_learned_registry,
+                                arithmetic=relaxation_arithmetic,
                             )
                         )
                         _mc_con_senses.append(c.sense)

--- a/python/tests/test_relaxation_arithmetic.py
+++ b/python/tests/test_relaxation_arithmetic.py
@@ -1,0 +1,116 @@
+"""Tests for the ``arithmetic`` kwarg of ``compile_relaxation``.
+
+Wires M2 (Chebyshev) and M3 (Taylor) of issue #51 into the LP
+relaxation compiler. Verifies:
+
+1. The default ``"mccormick"`` path is unchanged (covered by the existing
+   ``test_relaxation_compiler.py`` suite, not duplicated here).
+2. ``"chebyshev"`` and ``"taylor"`` produce sound (cv ≤ f ≤ cc)
+   underestimator / overestimator pairs on a sample of inner points.
+3. Falls back gracefully to McCormick for unsupported ops.
+4. End-to-end ``Model.solve(relaxation_arithmetic=...)`` preserves the
+   global optimum.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import discopt
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt._jax.relaxation_compiler import compile_objective_relaxation
+
+
+def _eval_at(fn, x_val, n_vars):
+    """Evaluate (cv, cc) at a single scalar point."""
+    x = jnp.asarray([x_val] * n_vars, dtype=jnp.float64)
+    cv, cc = fn(x, x, jnp.full(n_vars, -1e6), jnp.full(n_vars, 1e6))
+    return float(cv), float(cc)
+
+
+@pytest.mark.parametrize("arithmetic", ["chebyshev", "taylor"])
+def test_oa_relax_soundness_exp(arithmetic):
+    """cv ≤ exp(x) ≤ cc on a Monte Carlo sample inside the box."""
+    m = discopt.Model("exp_test")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    m.minimize(discopt.exp(x))
+    m.subject_to(x >= -1.0)
+
+    fn = compile_objective_relaxation(m, arithmetic=arithmetic)
+    rng = np.random.default_rng(0)
+    xs = rng.uniform(-1.0, 1.0, size=200)
+    for xv in xs:
+        cv, cc = _eval_at(fn, float(xv), n_vars=1)
+        true = np.exp(xv)
+        assert cv <= true + 1e-6, f"cv={cv} > exp({xv})={true} at arithmetic={arithmetic}"
+        assert cc >= true - 1e-6, f"cc={cc} < exp({xv})={true} at arithmetic={arithmetic}"
+
+
+@pytest.mark.parametrize("arithmetic", ["chebyshev", "taylor"])
+def test_oa_relax_soundness_log(arithmetic):
+    """cv ≤ log(x) ≤ cc on a Monte Carlo sample inside the box."""
+    m = discopt.Model("log_test")
+    x = m.continuous("x", lb=0.5, ub=3.0)
+    m.minimize(discopt.log(x))
+    m.subject_to(x >= 0.5)
+
+    fn = compile_objective_relaxation(m, arithmetic=arithmetic)
+    rng = np.random.default_rng(1)
+    xs = rng.uniform(0.5, 3.0, size=200)
+    for xv in xs:
+        cv, cc = _eval_at(fn, float(xv), n_vars=1)
+        true = np.log(xv)
+        assert cv <= true + 1e-6
+        assert cc >= true - 1e-6
+
+
+def test_solve_with_eigenvalue_root_bound_preserves_optimum(caplog):
+    """Opt-in eigenvalue root bound on a QP must not change the optimum."""
+    import logging
+
+    m = discopt.Model("eig_qp")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    # Mixed-sign Hessian: x^2 - y^2 + x - y (saddle on the box)
+    m.minimize(x * x - y * y + x - y)
+    m.subject_to(x + y >= -1.0)
+
+    base = m.solve(time_limit=30.0)
+    m2 = discopt.Model("eig_qp2")
+    x2 = m2.continuous("x", lb=-2.0, ub=2.0)
+    y2 = m2.continuous("y", lb=-2.0, ub=2.0)
+    m2.minimize(x2 * x2 - y2 * y2 + x2 - y2)
+    m2.subject_to(x2 + y2 >= -1.0)
+    with caplog.at_level(logging.INFO, logger="discopt.solver"):
+        eig = m2.solve(time_limit=30.0, eigenvalue_root_bound=True)
+    assert base.status in ("optimal", "feasible")
+    assert eig.status in ("optimal", "feasible")
+    assert eig.objective == pytest.approx(base.objective, abs=1e-3, rel=1e-3)
+
+
+def test_solve_with_chebyshev_preserves_optimum():
+    """End-to-end: compile-time chebyshev path keeps the global optimum."""
+
+    def _build(name):
+        m = discopt.Model(name)
+        x = m.continuous("x", lb=-1.0, ub=1.0)
+        y = m.continuous("y", lb=-1.0, ub=1.0)
+        m.minimize(discopt.exp(x) + discopt.log(y + 2.0) + (x - y) ** 2)
+        m.subject_to(x + y >= 0.0)
+        return m
+
+    base = _build("base")
+    res_base = base.solve(time_limit=30.0, relaxation_arithmetic="mccormick")
+    cheb = _build("cheb")
+    res_cheb = cheb.solve(time_limit=30.0, relaxation_arithmetic="chebyshev")
+    assert res_base.status in ("optimal", "feasible")
+    assert res_cheb.status in ("optimal", "feasible")
+    assert res_cheb.objective == pytest.approx(res_base.objective, abs=1e-3, rel=1e-3)


### PR DESCRIPTION
## Summary

Follow-up to PR #77 (presolve wiring). Wires three more bound providers from PR #75 into the default solver path:

- **M2 (Chebyshev)** and **M3 (Taylor)** — exposed via a new `relaxation_arithmetic="chebyshev"|"taylor"|"mccormick"` kwarg on `Model.solve()`. The compiler dispatches univariate ops (exp, log, sqrt, trig, hyperbolic) through a new polyhedral OA shim (`oa_relax.py`) that materialises cuts as static jnp arrays at compile time and recovers `(cv, cc)` as `max/min` over affine cuts at the linearisation midpoint. Falls back to McCormick for unsupported ops or degenerate ref boxes.
- **M6 (eigenvalue)** — opt-in `eigenvalue_root_bound=True` flag computes a sound spectral bound on quadratic objectives at the root via `quadratic_form_bound`. Diagnostic-only for now (logged at INFO); does not yet affect B&B pruning.

The `arithmetic` kwarg is plumbed through every `_compile_relax_node` recursion and surfaces on `compile_relaxation`, `compile_objective_relaxation`, and `compile_constraint_relaxation`.

## Stacking

Base = `feat/wire-presolve-pipeline` (PR #77). Once #77 merges, this branch's base will retarget to `main`.

## Test plan

- [x] `pytest python/tests/test_relaxation_arithmetic.py -v` — 6 new tests pass (Chebyshev/Taylor soundness for exp + log, end-to-end optimum preservation for both Chebyshev and the eigenvalue root bound).
- [x] `pytest python/tests/test_correctness.py python/tests/test_presolve_pipeline.py` — full existing suite remains green (95 tests).
- [x] `mypy python/discopt/_jax/oa_relax.py python/discopt/_jax/relaxation_compiler.py python/discopt/solver.py` — clean.
- [x] `ruff check python/` and `ruff format --check python/` — clean.
- [ ] CI on this PR.

## Notes for review

- Default `relaxation_arithmetic="mccormick"` keeps existing behaviour byte-identical.
- `_safe_box_for_op` in `oa_relax.py` clips to natural domain (log → positive, sqrt → nonneg, asin/acos → `[-1, 1]`) before invoking `polyhedral_oa.outer_approximation`, so the OA build never sees an invalid ref box.
- The OA is built once at compile time using the static interval enclosure of the inner expression. As B&B nodes shrink, the OA may become looser than the McCormick envelope evaluated on the node-local interval — but it is always sound. Per-node OA rebuild is left as future work.
- M6 is intentionally diagnostic-only in this PR; using it as a B&B fathoming bound requires more careful integration with the relaxation LP and the dual-bound bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
