### PR TITLE
chore(test): align make test with CI parallel xdist (closes #68)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,11 @@ lint:
 # Common flags for the PR-fast tier (kept in sync with .github/workflows/ci.yml).
 # `not slow` excludes the heavy backend matrix; the curated PR correctness
 # subset (test_pr_correctness.py) is *not* slow-marked so it still runs.
+# `-n auto --dist loadgroup` parallelizes across CPUs while keeping
+# class-shared fixtures pinned to one worker (matches CI).
 PYTEST_FAST_FLAGS := --timeout=120 -m "not slow" \
-    --ignore=python/tests/test_correctness.py
+    --ignore=python/tests/test_correctness.py \
+    -n auto --dist loadgroup
 
 # File groups for slice targets. A test file may appear in more than one group.
 TEST_MODELING := \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ xgboost = ["xgboost>=1.7"]
 lightgbm = ["lightgbm>=4.0"]
 gnn = ["equinox>=0.13.8", "optax>=0.1"]
 learned = ["equinox>=0.13.8", "optax>=0.1"]
-dev = ["pytest", "pytest-timeout", "pytest-cov", "ruff", "mypy", "highspy"]
+dev = ["pytest", "pytest-timeout", "pytest-cov", "pytest-xdist", "ruff", "mypy", "highspy"]
 all = ["discopt[ipopt,highs,cutest,llm,gnn,nn,ml]"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- The CI fast job uses `pytest -n auto --dist loadgroup` and explicitly installs `pytest-xdist`, but the local `Makefile` ran serially and `pytest-xdist` was missing from the `dev` extras. Result: `make test` could take ~20 min for what CI finishes in ~4 min.
- This PR adds `-n auto --dist loadgroup` to `PYTEST_FAST_FLAGS` and lists `pytest-xdist` in the `dev` extras. All slice targets (`test`, `test-modeling`, `test-solvers`, `test-amp`, `test-nn`, `test-convexity`, `test-jax`) inherit the speedup.

Closes #68.

## Test plan
- [x] `make test-amp` locally: 349 tests across 14 workers in ~12 s.
- [ ] CI green on this branch (will verify after push).

Generated with [Claude Code](https://claude.com/claude-code)
