### PR TITLE
chore: bump to 0.4.1.dev0 (post-v0.4.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "discopt"
-version = "0.4.0"
+version = "0.4.1.dev0"
 description = "Hybrid MINLP solver combining Rust and JAX"
 requires-python = ">=3.10"
 authors = [{name = "John Kitchin"}]

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -25,7 +25,7 @@ solvers
     NLP solver backends: ripopt (Rust IPM), pure-JAX IPM (vmap batch), cyipopt (Ipopt).
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1.dev0"
 
 # Enable JAX 64-bit mode before any downstream discopt import triggers a
 # jax import. IPOPT tolerances (default tol=1e-6, bound_relax_factor=1e-8)


### PR DESCRIPTION
Routine post-release dev bump per RELEASE.md §12. v0.4.0 published on PyPI: https://pypi.org/project/discopt/0.4.0/