### PR TITLE
feat(dae): time-accurate measurement fitting via collocation interpolation

### DIFF
--- a/python/discopt/dae/collocation.py
+++ b/python/discopt/dae/collocation.py
@@ -678,18 +678,74 @@ class DAEBuilder:
 
         return np.array(t_list), np.array(x_list)
 
+    def state_at(
+        self,
+        state_name: str,
+        t: float,
+        component: int | None = None,
+    ) -> Any:
+        """Return an expression for a state evaluated at an arbitrary time ``t``.
+
+        The state is reconstructed by evaluating the collocation polynomial of
+        the finite element that contains ``t``:
+
+            ``x(t) = sum_k  L_k(t) * var[elem, k]``
+
+        where ``L_k`` are the Lagrange basis polynomials through the element's
+        node times. This is exact to the collocation order (no node-spacing
+        error), making it the right primitive for observation operators, event
+        constraints, path outputs, and time-accurate measurement fitting.
+
+        Must be called after :meth:`discretize`.
+
+        Parameters
+        ----------
+        state_name : str
+            Name of the state variable.
+        t : float
+            Time at which to evaluate the state. Values outside the domain are
+            clamped to the nearest element (the polynomial then extrapolates).
+        component : int, optional
+            For vector-valued states, which component to evaluate.
+
+        Returns
+        -------
+        Expression
+            A discopt expression for the interpolated state value.
+        """
+        if not self._discretized:
+            raise RuntimeError("Call discretize() before state_at()")
+        if state_name not in self._vars:
+            raise KeyError(f"Unknown state {state_name!r}")
+
+        from discopt.dae.polynomials import lagrange_basis
+
+        t = float(t)
+        var = self._vars[state_name]
+        tp = self._element_points()  # (nfe, ncp+1)
+        elem = self._locate_element(t)
+        nodes = tp[elem]  # (ncp+1,) node times of the containing element
+
+        expr = None
+        for k in range(self._cs.ncp + 1):
+            coeff = float(lagrange_basis(nodes, t, k))
+            x_kc = var[elem, k, component] if component is not None else var[elem, k]
+            term = coeff * x_kc
+            expr = term if expr is None else expr + term
+        return expr
+
     def least_squares(
         self,
         state_name: str,
         t_data: np.ndarray,
         y_data: np.ndarray,
         component: int | None = None,
+        interpolate: bool = True,
     ) -> object:
         """Build a sum-of-squared-residuals expression for parameter estimation.
 
-        Maps each measurement time to the nearest collocation node and returns
-        ``sum((x[nearest] - y_data[i])^2)`` as a discopt expression suitable
-        for ``m.minimize()``.
+        Returns ``sum((x(t_data[i]) - y_data[i])^2)`` as a discopt expression
+        suitable for ``m.minimize()``.
 
         Must be called after :meth:`discretize`.
 
@@ -703,6 +759,14 @@ class DAEBuilder:
             Observed values, shape ``(n_obs,)``.
         component : int, optional
             For vector-valued states, which component to fit.
+        interpolate : bool, default True
+            If ``True`` (default), evaluate the model at the exact measurement
+            time by interpolating the element's collocation polynomial (see
+            :meth:`state_at`). This is exact to the collocation order and
+            removes the time-misalignment bias that arises when measurements do
+            not coincide with collocation nodes. If ``False``, fall back to the
+            legacy behavior of snapping each measurement to the nearest
+            collocation node (kept for backwards compatibility).
 
         Returns
         -------
@@ -717,19 +781,24 @@ class DAEBuilder:
         y_data = np.asarray(y_data, dtype=np.float64)
 
         var = self._vars[state_name]
-        tp = self._element_points()  # (nfe, ncp+1)
-        tp_flat = tp.ravel()
 
         terms = []
-        for i in range(len(t_data)):
-            idx = int(np.argmin(np.abs(tp_flat - t_data[i])))
-            elem = idx // (self._cs.ncp + 1)
-            node = idx % (self._cs.ncp + 1)
-            if component is not None:
-                x_expr = var[elem, node, component]
-            else:
-                x_expr = var[elem, node]
-            terms.append((x_expr - float(y_data[i])) ** 2)
+        if interpolate:
+            for i in range(len(t_data)):
+                x_expr = self.state_at(state_name, float(t_data[i]), component)
+                terms.append((x_expr - float(y_data[i])) ** 2)
+        else:
+            tp = self._element_points()  # (nfe, ncp+1)
+            tp_flat = tp.ravel()
+            for i in range(len(t_data)):
+                idx = int(np.argmin(np.abs(tp_flat - t_data[i])))
+                elem = idx // (self._cs.ncp + 1)
+                node = idx % (self._cs.ncp + 1)
+                if component is not None:
+                    x_expr = var[elem, node, component]
+                else:
+                    x_expr = var[elem, node]
+                terms.append((x_expr - float(y_data[i])) ** 2)
 
         result = terms[0]
         for t in terms[1:]:
@@ -737,6 +806,23 @@ class DAEBuilder:
         return result
 
     # ── Internal helpers ──
+
+    def _element_boundaries(self) -> np.ndarray:
+        """Return element boundary times, shape (nfe + 1,)."""
+        cs = self._cs
+        if cs.element_boundaries is not None:
+            return np.asarray(cs.element_boundaries, dtype=np.float64)
+        return np.linspace(cs.bounds[0], cs.bounds[1], cs.nfe + 1)
+
+    def _locate_element(self, t: float) -> int:
+        """Return the index of the finite element that contains time ``t``.
+
+        Times outside the domain clamp to the first/last element. Times on an
+        interior boundary resolve to the element to their right.
+        """
+        eb = self._element_boundaries()
+        idx = int(np.searchsorted(eb, float(t), side="right") - 1)
+        return max(0, min(idx, self._cs.nfe - 1))
 
     def _element_points(self) -> np.ndarray:
         """Return time values at all nodes, shape (nfe, ncp+1)."""
@@ -750,10 +836,7 @@ class DAEBuilder:
 
             cp = legendre_roots(cs.ncp)
 
-        if cs.element_boundaries is not None:
-            eb = cs.element_boundaries
-        else:
-            eb = np.linspace(cs.bounds[0], cs.bounds[1], cs.nfe + 1)
+        eb = self._element_boundaries()
 
         tp = np.zeros((cs.nfe, cs.ncp + 1))
         for i in range(cs.nfe):

--- a/python/tests/test_dae.py
+++ b/python/tests/test_dae.py
@@ -1087,6 +1087,206 @@ class TestLeastSquares:
         np.testing.assert_allclose(k_est, k_true, atol=0.1)
 
 
+class TestLeastSquaresInterpolation:
+    """Deterministic checks of the interpolating least_squares objective.
+
+    These pin the collocation node variables and evaluate the compiled
+    objective directly, so they need no solver and run in the fast suite.
+    """
+
+    def test_interpolation_reduces_offnode_residual(self):
+        """Interpolating at exact measurement times removes node-snapping bias.
+
+        Pin the node variables to an exact smooth signal and compare the
+        sum-of-squares objective built by each mode against measurements taken
+        at off-node times. The interpolated residual is ~0 (exact to
+        collocation order); the snapped residual is not, because it compares the
+        signal at a node against data taken between nodes (issue #94).
+        """
+        import discopt.modeling as dm
+        from discopt._jax.dag_compiler import compile_expression
+        from discopt.dae import ContinuousSet, DAEBuilder
+
+        k_true = 2.0
+        # Measurement times deliberately off the (uniform, nfe=5) node grid.
+        t_obs = np.array([0.07, 0.23, 0.41, 0.58, 0.74, 0.91])
+        g = lambda t: np.exp(-k_true * t)  # noqa: E731  smooth A -> B decay
+        y_obs = g(t_obs)
+
+        m = dm.Model("offnode")
+        cs = ContinuousSet("t", bounds=(0, 1), nfe=5, ncp=3)
+        dae = DAEBuilder(m, cs)
+        dae.add_state("x", initial=1.0, bounds=(-5, 5))
+        dae.set_ode(lambda t, s, a, c: {"x": -k_true * s["x"]})
+        dae.discretize()
+
+        # Pin node values to the exact signal; evaluate each objective there.
+        x_flat = g(dae._element_points()).ravel()
+        obj_interp = compile_expression(dae.least_squares("x", t_obs, y_obs, interpolate=True), m)
+        obj_snap = compile_expression(dae.least_squares("x", t_obs, y_obs, interpolate=False), m)
+        r_interp = float(obj_interp(x_flat))
+        r_snap = float(obj_snap(x_flat))
+
+        # Interpolation reconstructs the signal at the exact measurement times.
+        assert r_interp < 1e-6
+        # Nearest-node snapping carries a real time-misalignment residual.
+        assert r_snap > 1e-3
+        assert r_interp < r_snap
+
+    def test_interpolate_matches_snapping_on_nodes(self):
+        """When measurements land exactly on nodes, both modes must agree.
+
+        ``state_at`` reduces to the node variable at a node (Lagrange delta
+        property), so the two objective constructions are identical there.
+        """
+        import discopt.modeling as dm
+        from discopt._jax.dag_compiler import compile_expression
+        from discopt.dae import ContinuousSet, DAEBuilder
+
+        m = dm.Model("onnode")
+        cs = ContinuousSet("t", bounds=(0, 2), nfe=8, ncp=3)
+        dae = DAEBuilder(m, cs)
+        dae.add_state("x", initial=1.0, bounds=(-5, 5))
+        dae.set_ode(lambda t, s, a, c: {"x": -s["x"]})
+        dae.discretize()
+
+        # Measurements sampled directly at collocation node times.
+        t_obs = dae.time_points()[1::5]
+        y_obs = np.exp(-1.3 * t_obs)
+        x_flat = np.exp(-0.9 * dae._element_points()).ravel()  # arbitrary node state
+
+        obj_interp = compile_expression(dae.least_squares("x", t_obs, y_obs, interpolate=True), m)
+        obj_snap = compile_expression(dae.least_squares("x", t_obs, y_obs, interpolate=False), m)
+        np.testing.assert_allclose(float(obj_interp(x_flat)), float(obj_snap(x_flat)), rtol=1e-9)
+
+
+class TestStateAt:
+    def test_before_discretize_raises(self):
+        import discopt.modeling as dm
+        from discopt.dae import ContinuousSet, DAEBuilder
+
+        m = dm.Model("sa_pre")
+        cs = ContinuousSet("t", bounds=(0, 1), nfe=4, ncp=3)
+        dae = DAEBuilder(m, cs)
+        dae.add_state("x", initial=1.0)
+        dae.set_ode(lambda t, s, a, c: {"x": -s["x"]})
+
+        with pytest.raises(RuntimeError):
+            dae.state_at("x", 0.5)
+
+    def test_unknown_state_raises(self):
+        import discopt.modeling as dm
+        from discopt.dae import ContinuousSet, DAEBuilder
+
+        m = dm.Model("sa_unknown")
+        cs = ContinuousSet("t", bounds=(0, 1), nfe=4, ncp=3)
+        dae = DAEBuilder(m, cs)
+        dae.add_state("x", initial=1.0)
+        dae.set_ode(lambda t, s, a, c: {"x": -s["x"]})
+        dae.discretize()
+
+        with pytest.raises(KeyError):
+            dae.state_at("nope", 0.5)
+
+    def test_locate_element(self):
+        """_locate_element maps times to the containing element and clamps."""
+        import discopt.modeling as dm
+        from discopt.dae import ContinuousSet, DAEBuilder
+
+        m = dm.Model("sa_locate")
+        cs = ContinuousSet("t", bounds=(0, 1), nfe=5, ncp=3)  # boundaries every 0.2
+        dae = DAEBuilder(m, cs)
+        dae.add_state("x", initial=1.0)
+        dae.set_ode(lambda t, s, a, c: {"x": -s["x"]})
+        dae.discretize()
+
+        assert dae._locate_element(0.0) == 0
+        assert dae._locate_element(0.1) == 0
+        assert dae._locate_element(0.25) == 1
+        assert dae._locate_element(0.99) == 4
+        assert dae._locate_element(1.0) == 4
+        # Out-of-domain clamps to the nearest element.
+        assert dae._locate_element(-1.0) == 0
+        assert dae._locate_element(5.0) == 4
+
+    def test_exact_for_polynomial(self):
+        """state_at reproduces a degree<=ncp polynomial exactly at any time.
+
+        With ncp=3 each element has 4 nodes, so the collocation polynomial
+        interpolates cubics exactly. Evaluated against pinned node values via
+        the compiled expression (no solver needed).
+        """
+        import discopt.modeling as dm
+        from discopt._jax.dag_compiler import compile_expression
+        from discopt.dae import ContinuousSet, DAEBuilder
+
+        m = dm.Model("sa_poly")
+        cs = ContinuousSet("t", bounds=(0, 1), nfe=5, ncp=3)
+        dae = DAEBuilder(m, cs)
+        dae.add_state("x", initial=1.0, bounds=(-50, 50))
+        dae.set_ode(lambda t, s, a, c: {"x": -s["x"]})
+        dae.discretize()
+
+        p = lambda t: 1.0 + 2.0 * t - 0.5 * t**2 + 0.3 * t**3  # noqa: E731
+        x_flat = p(dae._element_points()).ravel()
+
+        for t_q in [0.0, 0.13, 0.37, 0.5, 0.62, 0.88, 1.0]:
+            fn = compile_expression(dae.state_at("x", t_q), m)
+            np.testing.assert_allclose(float(fn(x_flat)), p(t_q), atol=1e-10)
+
+    def test_reduces_to_node_value_at_node(self):
+        """At a collocation node, state_at returns exactly that node's value."""
+        import discopt.modeling as dm
+        from discopt._jax.dag_compiler import compile_expression
+        from discopt.dae import ContinuousSet, DAEBuilder
+
+        m = dm.Model("sa_node")
+        cs = ContinuousSet("t", bounds=(0, 2), nfe=4, ncp=3)
+        dae = DAEBuilder(m, cs)
+        dae.add_state("x", initial=1.0, bounds=(-50, 50))
+        dae.set_ode(lambda t, s, a, c: {"x": -s["x"]})
+        dae.discretize()
+
+        tp = dae._element_points()
+        # Node values from an injective function of time: a wrong element/node
+        # index would return the value for a different time and fail. Boundary
+        # nodes shared by two elements have the same time, hence same value, so
+        # state_at resolving a boundary to the right element stays consistent.
+        h = lambda t: 3.0 * t + 0.7  # noqa: E731  injective in t
+        node_vals = h(tp)
+        x_flat = node_vals.ravel()
+
+        for elem in range(cs.nfe):
+            for k in range(cs.ncp + 1):
+                fn = compile_expression(dae.state_at("x", float(tp[elem, k])), m)
+                np.testing.assert_allclose(float(fn(x_flat)), h(tp[elem, k]), atol=1e-9)
+
+    def test_vector_state_component(self):
+        """state_at selects the requested component of a vector state."""
+        import discopt.modeling as dm
+        from discopt._jax.dag_compiler import compile_expression
+        from discopt.dae import ContinuousSet, DAEBuilder
+
+        m = dm.Model("sa_vec")
+        cs = ContinuousSet("t", bounds=(0, 1), nfe=3, ncp=3)
+        dae = DAEBuilder(m, cs)
+        dae.add_state("x", n_components=2, initial=np.array([1.0, 0.0]), bounds=(-50, 50))
+        dae.set_ode(lambda t, s, a, c: {"x": [-s["x"][0], s["x"][0]]})
+        dae.discretize()
+
+        tp = dae._element_points()  # (nfe, ncp+1)
+        f0 = lambda t: 1.0 + t  # noqa: E731  component 0
+        f1 = lambda t: 2.0 - 0.5 * t  # noqa: E731  component 1
+        vals = np.stack([f0(tp), f1(tp)], axis=-1)  # (nfe, ncp+1, 2)
+        x_flat = vals.ravel()
+
+        t_q = 0.41
+        fn0 = compile_expression(dae.state_at("x", t_q, component=0), m)
+        fn1 = compile_expression(dae.state_at("x", t_q, component=1), m)
+        np.testing.assert_allclose(float(fn0(x_flat)), f0(t_q), atol=1e-9)
+        np.testing.assert_allclose(float(fn1(x_flat)), f1(t_q), atol=1e-9)
+
+
 # ─────────────────────────────────────────────────────────────
 # Phase 8: scipy cross-validation
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #94. `DAEBuilder.least_squares()` previously snapped each measurement time to the nearest collocation node, introducing a time-misalignment bias when data are sampled between nodes.

## Changes

- Add `DAEBuilder.state_at(state_name, t, component=None)` — evaluates a discretized state at an arbitrary time `t` via the Lagrange interpolating polynomial over the containing element's collocation nodes.
- Add `interpolate: bool = True` to `least_squares()`. When `True` (default), residuals are built at the exact measurement times via `state_at`; `interpolate=False` preserves the legacy nearest-node behavior.
- Factor out `_element_boundaries()` and add `_locate_element(t)` for element lookup.

## Tests

- `TestLeastSquaresInterpolation` and `TestStateAt` — solver-free, deterministic checks (pin node variables, evaluate the compiled objective directly): polynomial exactness, Lagrange delta at nodes, vector components, element location, and error guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
