### PR TITLE
feat(relax): ellipsoidal arithmetic bound provider (#81 M7)

### DIFF
--- a/discopt_benchmarks/tests/test_ellipsoidal_regression.py
+++ b/discopt_benchmarks/tests/test_ellipsoidal_regression.py
@@ -1,0 +1,137 @@
+"""M7 regression: ellipsoidal arithmetic is a sound, correlation-aware bound
+provider that integrates through the polyhedral-OA wrapper and the full solver.
+
+Issue #81 (M7) asks for *ellipsoidal arithmetic* — propagating ellipsoidal
+enclosures ``{x : (x-c)^T P^{-1} (x-c) <= 1}`` through the DAG so that affine
+correlations interval arithmetic discards are retained. Acceptance criteria
+exercised here as a benchmark-suite regression:
+
+1. **Soundness (rigorous-bound invariant).** Every cut the ellipsoidal provider
+   emits through :func:`polyhedral_oa.outer_approximation` encloses the true
+   graph ``y = f(x)`` on > 10^4 samples — no cut shaves a feasible point.
+2. **Correlation win.** On a correlated-affine combination the ellipsoidal
+   (2-norm) enclosure is strictly tighter than the interval/affine-arithmetic
+   (1-norm) enclosure, the property a forward interval bound cannot reproduce.
+3. **End-to-end correctness.** A full spatial-B&B solve with
+   ``relaxation_arithmetic="ellipsoidal"`` returns the same correct global
+   optimum as plain McCormick, and never reports a bound above the achieved
+   objective (``incorrect_count == 0``).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt import Model
+from discopt import modeling as dm
+from discopt._jax import ellipsoidal_arith as ea
+from discopt._jax.polyhedral_oa import outer_approximation
+
+jax.config.update("jax_enable_x64", True)
+
+N_REGRESSION_SAMPLES = 12_000
+
+# Smooth-unary coupling instance:  y = exp(x),  minimize y - 2 x  over a box.
+# Unconstrained interior optimum of exp(x) - 2x is at x = ln 2.
+X_BOX = (-1.0, 2.0)
+Y_BOX = (0.0, 10.0)
+
+
+def _true_optimum() -> float:
+    xs = np.linspace(X_BOX[0], X_BOX[1], 2_000_001)
+    ys = np.exp(xs)
+    feasible = (ys >= Y_BOX[0]) & (ys <= Y_BOX[1])
+    return float((ys - 2.0 * xs)[feasible].min())
+
+
+def _build_model() -> Model:
+    m = Model()
+    x = m.continuous("x", lb=X_BOX[0], ub=X_BOX[1])
+    y = m.continuous("y", lb=Y_BOX[0], ub=Y_BOX[1])
+    m.subject_to(dm.exp(x) - y <= 0.0)
+    m.minimize(y - 2.0 * x)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# 1. Soundness — every ellipsoidal-provider cut globally encloses the graph
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.regression
+def test_ellipsoidal_oa_cuts_are_globally_valid():
+    oa = outer_approximation(jnp.exp, X_BOX, "ellipsoidal", degree=10, n_slopes=16)
+
+    rng = np.random.default_rng(0)
+    xs = rng.uniform(X_BOX[0], X_BOX[1], size=N_REGRESSION_SAMPLES)
+    ys = np.exp(xs)  # the true graph y = f(x)
+    for k, cut in enumerate(oa.cuts):
+        sx, sy = float(cut.coeffs[0]), float(cut.coeffs[1])
+        lhs = sx * xs + sy * ys
+        if cut.sense == ">=":
+            assert (lhs >= cut.rhs - 1e-9).all(), f"cut[{k}] (>=) shaves the graph"
+        else:
+            assert (lhs <= cut.rhs + 1e-9).all(), f"cut[{k}] (<=) shaves the graph"
+
+    # The cut family sandwiches the graph: lower envelope <= f <= upper envelope.
+    grid = np.linspace(X_BOX[0], X_BOX[1], 4001)
+    lo = oa.evaluate_lower(grid)
+    hi = oa.evaluate_upper(grid)
+    fg = np.exp(grid)
+    assert (lo <= fg + 1e-9).all()
+    assert (hi >= fg - 1e-9).all()
+
+
+# ---------------------------------------------------------------------------
+# 2. Correlation win — ellipsoidal strictly beats interval AA on a correlated
+#    combination (2-norm vs 1-norm radius), the property M7 exists to capture.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_ellipsoidal_strictly_tighter_than_interval_on_correlated_affine():
+    rng = np.random.default_rng(5)
+    trials = 200
+    strictly_tighter = 0
+    for _ in range(trials):
+        k = 3
+        cin = rng.standard_normal(k)
+        gk = rng.standard_normal((k, k)) * 0.4
+        forms = ea.forms_from_ellipsoid(ea.Ellipsoid(cin, gk @ gk.T))
+        weights = rng.standard_normal(k)
+        comb = ea.EllipsoidalForm(0.0, np.zeros(k))
+        for w, f in zip(weights, forms, strict=True):
+            comb = comb + f.scaled(float(w))
+        elo, ehi = comb.bounds()
+        ilo, ihi = comb.interval_bounds()
+        # Sound: ellipsoidal never looser than interval.
+        assert (ehi - elo) <= (ihi - ilo) + 1e-12
+        if (ehi - elo) < (ihi - ilo) - 1e-9:
+            strictly_tighter += 1
+    assert strictly_tighter / trials >= 0.5
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end solve correctness — relaxation_arithmetic="ellipsoidal" reaches
+#    the same global optimum and never reports an invalid bound.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("arithmetic", ["mccormick", "ellipsoidal"])
+def test_full_solve_reaches_correct_optimum(arithmetic):
+    model = _build_model()
+    res = model.solve(
+        mccormick_bounds="lp",
+        relaxation_arithmetic=arithmetic,
+        time_limit=60,
+        skip_convex_check=True,
+    )
+    assert res.status == "optimal"
+    true_opt = _true_optimum()
+    assert res.objective == pytest.approx(true_opt, abs=1e-4, rel=1e-4)
+    # Rigorous-bound invariant: the reported bound never exceeds the optimum.
+    assert res.bound <= res.objective + 1e-4

--- a/python/discopt/_jax/ellipsoidal_arith.py
+++ b/python/discopt/_jax/ellipsoidal_arith.py
@@ -1,0 +1,393 @@
+"""Ellipsoidal arithmetic for rigorous range enclosure (M7 of issue #81).
+
+Axis-aligned interval arithmetic loses the *affine correlations* between
+intermediate quantities: after ``a = x + y`` and ``b = x - y`` it forgets that
+``a + b = 2x``, so ``a + b`` re-inflates to the sum of the two intervals.
+Ellipsoidal arithmetic keeps those correlations by enclosing a vector of
+quantities in an ellipsoid
+
+    E(c, Q) = { c + Q^{1/2} u : ||u||_2 <= 1 }
+            = { x : (x - c)^T Q^{-1} (x - c) <= 1 }   (Q positive definite),
+
+whose shape matrix ``Q`` carries the off-diagonal correlation terms an interval
+box cannot represent.
+
+The implementation follows the **affine-form** (noise-symbol) view of
+ellipsoidal calculus used by Houska, Villanueva and Chachuat: every scalar
+quantity is tracked as
+
+    v = center + gens . xi + [-rem, +rem],     ||xi||_2 <= 1,
+
+where ``xi`` is a *shared* vector of input noise symbols constrained to the unit
+2-ball (so affine combinations across quantities reuse the same ``xi`` and stay
+correlated), ``gens`` are the linear generator coefficients, and ``rem`` is an
+independent interval remainder radius accumulating the rigorously-bounded
+nonlinear defects. The enclosure of a single scalar is therefore the interval
+
+    [ center - (||gens||_2 + rem),  center + (||gens||_2 + rem) ],
+
+and the support of a linear functional ``s`` over a vector of forms sharing the
+same ``xi`` is
+
+    s . c  +/-  ( sqrt(s^T A A^T s)  +  |s| . rem ) ,
+
+i.e. the ellipsoidal support ``s^T c + sqrt(s^T Q s)`` (with ``Q = A A^T``) plus
+the box contribution of the remainders. The ``sqrt`` (2-norm) of the generator
+contribution is what beats interval arithmetic's 1-norm whenever two or more
+noise symbols combine with cancellation.
+
+* **Affine operators** (``+``, ``-``, scalar ``*``/``+``) act in closed form on
+  ``(center, gens, rem)`` and are *exact* on the generator part — no correlation
+  is lost.
+* **Bilinear products** and **unary nonlinear** operators (``exp``, ``log``,
+  ``sqrt``, ``sin``, ...) linearise around the centre and fold the rigorous
+  second-order-and-higher defect into ``rem``. The unary defect is bounded with
+  the Chebyshev-model kernel (:mod:`chebyshev_model`, M2 of #51), reusing the
+  same Taylor-remainder machinery as the polynomial relaxations.
+
+All interval/remainder/support results are *outward rounded* by a small relative
+factor so floating-point error can only loosen an enclosure, never invalidate
+it. This preserves discopt's rigorous-bound invariant (a computed lower bound
+never exceeds the true global minimum).
+
+References:
+- Villanueva, Rajyaguru, Houska, Chachuat, *Comput. Aided Chem. Eng.* 37,
+  767-772, 2015.
+- Villanueva, *Set-theoretic methods for analysis and control of dynamic
+  systems*, PhD thesis, Imperial College London, 2016.
+- Houska, Villanueva, Chachuat, *A validated integration algorithm for
+  nonlinear ODEs using Taylor models and ellipsoidal calculus*, CDC 2013.
+
+See issue #81 (M7) and #51 for the convexification roadmap context.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from discopt._jax import chebyshev_model as cm
+
+# Outward-rounding factor: every enclosure radius / support value is inflated by
+# this relative amount (plus an absolute floor) so rounding error only loosens.
+_ROUND_SAFETY = 1e-12
+_ROUND_FLOOR = 1e-15
+
+# Eigenvalue floor used when regularising a shape matrix back to PSD.
+_PSD_FLOOR = 0.0
+
+
+def _outward(radius: float) -> float:
+    """Inflate a non-negative radius outward so rounding error cannot shave it."""
+    r = float(radius)
+    return r + _ROUND_SAFETY * abs(r) + _ROUND_FLOOR
+
+
+# ---------------------------------------------------------------------------
+# Ellipsoid (c, Q) — the geometric object and its closed-form calculus
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Ellipsoid:
+    """An ellipsoid ``E(c, Q) = {c + Q^{1/2} u : ||u|| <= 1}`` in ``R^n``.
+
+    ``Q`` is symmetric positive *semi*-definite (a degenerate ellipsoid — a
+    lower-dimensional slab or segment — is allowed and represented by a rank
+    deficient ``Q``).
+    """
+
+    center: np.ndarray
+    shape: np.ndarray
+
+    def __post_init__(self) -> None:
+        c = np.asarray(self.center, dtype=np.float64).reshape(-1)
+        q = np.asarray(self.shape, dtype=np.float64)
+        if q.shape != (c.size, c.size):
+            raise ValueError(f"shape must be {(c.size, c.size)}, got {q.shape}")
+        object.__setattr__(self, "center", c)
+        object.__setattr__(self, "shape", 0.5 * (q + q.T))  # symmetrise
+
+    @property
+    def dim(self) -> int:
+        return self.center.size
+
+    def support(self, s: np.ndarray) -> tuple[float, float]:
+        """Range ``[min, max]`` of the linear functional ``s . x`` over ``E``.
+
+        Exactly ``s^T c +/- sqrt(s^T Q s)`` (outward rounded). This is the
+        closed-form support function that drops into the polyhedral cut path.
+        """
+        s = np.asarray(s, dtype=np.float64).reshape(-1)
+        mid = float(s @ self.center)
+        quad = float(s @ self.shape @ s)
+        rad = _outward(np.sqrt(max(quad, 0.0)))
+        return (mid - rad, mid + rad)
+
+    def coordinate_box(self) -> tuple[np.ndarray, np.ndarray]:
+        """Tightest axis-aligned box ``[lb, ub]`` containing ``E``."""
+        rad = np.sqrt(np.maximum(np.diag(self.shape), 0.0))
+        rad = np.array([_outward(r) for r in rad])
+        return self.center - rad, self.center + rad
+
+    def affine_image(self, a: np.ndarray, b: np.ndarray | None = None) -> "Ellipsoid":
+        """The exact image ``A . E + b = E(A c + b, A Q A^T)``."""
+        a = np.asarray(a, dtype=np.float64)
+        if a.ndim != 2:
+            raise ValueError("A must be a 2-D matrix")
+        c = a @ self.center
+        if b is not None:
+            c = c + np.asarray(b, dtype=np.float64).reshape(-1)
+        q = a @ self.shape @ a.T
+        return Ellipsoid(c, q)
+
+    def minkowski_sum(self, other: "Ellipsoid") -> "Ellipsoid":
+        """Trace-minimising ellipsoidal outer approximation of ``E1 ⊕ E2``.
+
+        The Minkowski sum of two ellipsoids is not an ellipsoid; the family
+
+            E(c1 + c2, (1 + 1/k) Q1 + (1 + k) Q2),   k > 0,
+
+        outer-bounds it for every ``k``, and ``k = sqrt(tr Q2 / tr Q1)``
+        minimises the trace (sum of squared semi-axes) of the result.
+        """
+        if other.dim != self.dim:
+            raise ValueError("dimension mismatch in Minkowski sum")
+        t1 = float(np.trace(self.shape))
+        t2 = float(np.trace(other.shape))
+        if t1 <= 0.0:
+            return Ellipsoid(self.center + other.center, other.shape)
+        if t2 <= 0.0:
+            return Ellipsoid(self.center + other.center, self.shape)
+        k = np.sqrt(t2 / t1)
+        q = (1.0 + 1.0 / k) * self.shape + (1.0 + k) * other.shape
+        return Ellipsoid(self.center + other.center, q)
+
+    def contains(self, x: np.ndarray, tol: float = 1e-9) -> bool:
+        """True if point ``x`` lies in ``E`` (within ``tol``)."""
+        x = np.asarray(x, dtype=np.float64).reshape(-1)
+        d = x - self.center
+        # Use a pseudo-inverse so degenerate ellipsoids are handled: a point off
+        # the supporting subspace is reported outside.
+        q_pinv = np.linalg.pinv(self.shape, rcond=1e-12)
+        proj = self.shape @ q_pinv @ d
+        if np.linalg.norm(proj - d) > tol * (1.0 + np.linalg.norm(d)):
+            return False
+        return float(d @ q_pinv @ d) <= 1.0 + tol
+
+    def regularize(self, floor: float = _PSD_FLOOR) -> "Ellipsoid":
+        """Project the shape matrix back to PSD (clamp eigenvalues at ``floor``)."""
+        w, v = np.linalg.eigh(self.shape)
+        w = np.maximum(w, floor)
+        return Ellipsoid(self.center, (v * w) @ v.T)
+
+
+def bounding_ellipsoid_of_box(lb: np.ndarray, ub: np.ndarray) -> Ellipsoid:
+    """Smallest-volume ellipsoid enclosing the axis-aligned box ``[lb, ub]``.
+
+    For a box of half-widths ``r`` in ``R^n`` the Loewner-John enclosing
+    ellipsoid is ``E(midpoint, n * diag(r^2))`` (its boundary passes through the
+    box corners). Note the dimension-``n`` inflation: ellipsoidal arithmetic
+    only pays off when the inputs carry genuine affine correlation, not for an
+    axis-aligned box of independent ranges.
+    """
+    lb = np.asarray(lb, dtype=np.float64).reshape(-1)
+    ub = np.asarray(ub, dtype=np.float64).reshape(-1)
+    c = 0.5 * (lb + ub)
+    r = 0.5 * (ub - lb)
+    n = c.size
+    return Ellipsoid(c, float(n) * np.diag(r * r))
+
+
+# ---------------------------------------------------------------------------
+# EllipsoidalForm — scalar affine-form arithmetic over a shared input ball
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EllipsoidalForm:
+    """A scalar quantity ``center + gens . xi + [-rem, rem]``, ``||xi||_2 <= 1``.
+
+    ``gens`` are coefficients on a *shared* input noise vector, so two forms
+    built from the same inputs stay correlated under affine combination. ``rem``
+    is an independent, outward-rounded interval radius collecting nonlinear
+    defects.
+    """
+
+    center: float
+    gens: np.ndarray
+    rem: float = 0.0
+
+    def __post_init__(self) -> None:
+        self.center = float(self.center)
+        self.gens = np.asarray(self.gens, dtype=np.float64).reshape(-1)
+        self.rem = float(self.rem)
+
+    # -- enclosures ---------------------------------------------------------
+    def ellipsoidal_radius(self) -> float:
+        """Half-width of the rigorous interval enclosure (2-norm of generators)."""
+        return _outward(float(np.linalg.norm(self.gens)) + self.rem)
+
+    def interval_radius(self) -> float:
+        """Half-width an interval/affine-arithmetic enclosure would give (1-norm)."""
+        return _outward(float(np.sum(np.abs(self.gens))) + self.rem)
+
+    def bounds(self) -> tuple[float, float]:
+        """Rigorous ``[lo, hi]`` enclosure of the quantity."""
+        r = self.ellipsoidal_radius()
+        return (self.center - r, self.center + r)
+
+    def interval_bounds(self) -> tuple[float, float]:
+        """The looser interval-arithmetic enclosure (for comparison/tests)."""
+        r = self.interval_radius()
+        return (self.center - r, self.center + r)
+
+    # -- affine operators (exact on the generator part) ---------------------
+    def __add__(self, other: "EllipsoidalForm | float") -> "EllipsoidalForm":
+        if isinstance(other, EllipsoidalForm):
+            return EllipsoidalForm(
+                self.center + other.center, self.gens + other.gens, self.rem + other.rem
+            )
+        return EllipsoidalForm(self.center + float(other), self.gens, self.rem)
+
+    __radd__ = __add__
+
+    def __neg__(self) -> "EllipsoidalForm":
+        return EllipsoidalForm(-self.center, -self.gens, self.rem)
+
+    def __sub__(self, other: "EllipsoidalForm | float") -> "EllipsoidalForm":
+        if isinstance(other, EllipsoidalForm):
+            return EllipsoidalForm(
+                self.center - other.center, self.gens - other.gens, self.rem + other.rem
+            )
+        return EllipsoidalForm(self.center - float(other), self.gens, self.rem)
+
+    def __rsub__(self, other: float) -> "EllipsoidalForm":
+        return EllipsoidalForm(float(other) - self.center, -self.gens, self.rem)
+
+    def scaled(self, a: float) -> "EllipsoidalForm":
+        a = float(a)
+        return EllipsoidalForm(a * self.center, a * self.gens, abs(a) * self.rem)
+
+    # -- nonlinear operators ------------------------------------------------
+    def __mul__(self, other: "EllipsoidalForm | float") -> "EllipsoidalForm":
+        if not isinstance(other, EllipsoidalForm):
+            return self.scaled(other)
+        cu, au, ru = self.center, self.gens, self.rem
+        cv, av, rv = other.center, other.gens, other.rem
+        nau = float(np.linalg.norm(au))
+        nav = float(np.linalg.norm(av))
+        center = cu * cv
+        gens = cu * av + cv * au
+        # All second-order-and-cross terms folded into the remainder, bounded by
+        # Cauchy-Schwarz over the unit 2-ball: |(au.xi)(av.xi)| <= ||au|| ||av||.
+        rem = nau * nav + abs(cu) * rv + abs(cv) * ru + nau * rv + nav * ru + ru * rv
+        return EllipsoidalForm(center, gens, _outward(rem))
+
+    __rmul__ = __mul__
+
+    def apply_unary(self, f: Callable, degree: int = 8) -> "EllipsoidalForm":
+        """Return ``f(self)`` as an ellipsoidal form with rigorous remainder.
+
+        Linearises ``f`` around the centre; the rigorous bound on the
+        linearisation defect over the form's interval enclosure comes from the
+        Chebyshev-model kernel and is folded into ``rem``.
+        """
+        cu = self.center
+        radius = self.ellipsoidal_radius()
+        if radius < 1e-15:
+            return EllipsoidalForm(float(f(jnp.asarray(cu))), np.zeros_like(self.gens), 0.0)
+        box = (cu - radius, cu + radius)
+        fc = float(f(jnp.asarray(cu, dtype=jnp.float64)))
+        fpc = float(jax.grad(lambda t: f(t))(jnp.asarray(cu, dtype=jnp.float64)))
+
+        x = cm.from_variable(box, degree)
+        fm = cm.compose_unary(f, x)
+        lin = cm.scalar_add(fc, cm.scalar_mul(fpc, cm.scalar_add(-cu, x)))
+        defect_lo, defect_hi = cm.sub(fm, lin).bounds()
+
+        center = fc + 0.5 * (defect_lo + defect_hi)
+        gens = fpc * self.gens
+        rem = abs(fpc) * self.rem + 0.5 * (defect_hi - defect_lo)
+        return EllipsoidalForm(center, gens, _outward(rem))
+
+
+# ---------------------------------------------------------------------------
+# Seeding forms from an input ellipsoid / box, and re-assembling enclosures
+# ---------------------------------------------------------------------------
+
+
+def forms_from_ellipsoid(ellipsoid: Ellipsoid) -> list[EllipsoidalForm]:
+    """One :class:`EllipsoidalForm` per coordinate of an input ``E(c, Q)``.
+
+    Factoring ``Q = G G^T`` gives ``x_i = c_i + (G xi)_i`` with ``||xi|| <= 1``,
+    so the generator row of coordinate ``i`` is ``G[i]`` and the forms share the
+    common noise vector ``xi`` — exactly the correlation an input ellipsoid
+    encodes.
+    """
+    c = ellipsoid.center
+    g = _psd_sqrt(ellipsoid.shape)
+    return [EllipsoidalForm(float(c[i]), g[i].copy(), 0.0) for i in range(ellipsoid.dim)]
+
+
+def forms_from_box(lb: np.ndarray, ub: np.ndarray) -> list[EllipsoidalForm]:
+    """Independent-coordinate input forms for an axis-aligned box ``[lb, ub]``.
+
+    Each coordinate gets its own noise symbol (diagonal generator matrix), so a
+    single coordinate's enclosure is exact and there is no spurious correlation.
+    """
+    lb = np.asarray(lb, dtype=np.float64).reshape(-1)
+    ub = np.asarray(ub, dtype=np.float64).reshape(-1)
+    n = lb.size
+    c = 0.5 * (lb + ub)
+    r = 0.5 * (ub - lb)
+    forms = []
+    for i in range(n):
+        row = np.zeros(n)
+        row[i] = r[i]
+        forms.append(EllipsoidalForm(float(c[i]), row, 0.0))
+    return forms
+
+
+def joint_ellipsoid(forms: list[EllipsoidalForm]) -> Ellipsoid:
+    """Assemble the joint ellipsoidal enclosure ``E(c, A A^T) ⊕ box(rem)``.
+
+    The generator rows of the forms (padded to a common width) form ``A``; the
+    independent remainders contribute an axis-aligned box that is Minkowski-
+    summed in as its Loewner-John enclosing ellipsoid.
+    """
+    if not forms:
+        raise ValueError("need at least one form")
+    width = max(f.gens.size for f in forms)
+    a = np.zeros((len(forms), width))
+    c = np.zeros(len(forms))
+    rem = np.zeros(len(forms))
+    for i, f in enumerate(forms):
+        a[i, : f.gens.size] = f.gens
+        c[i] = f.center
+        rem[i] = f.rem
+    ell = Ellipsoid(c, a @ a.T)
+    if np.any(rem > 0.0):
+        ell = ell.minkowski_sum(bounding_ellipsoid_of_box(-rem, rem))
+    return ell
+
+
+def _psd_sqrt(q: np.ndarray) -> np.ndarray:
+    """A real symmetric square root ``G`` with ``G G^T = Q`` for PSD ``Q``."""
+    w, v = np.linalg.eigh(0.5 * (q + q.T))
+    w = np.maximum(w, 0.0)
+    return np.asarray((v * np.sqrt(w)) @ v.T, dtype=np.float64)
+
+
+__all__ = [
+    "Ellipsoid",
+    "EllipsoidalForm",
+    "bounding_ellipsoid_of_box",
+    "forms_from_box",
+    "forms_from_ellipsoid",
+    "joint_ellipsoid",
+]

--- a/python/discopt/_jax/oa_relax.py
+++ b/python/discopt/_jax/oa_relax.py
@@ -73,7 +73,8 @@ def make_oa_relax(
         name: univariate operator name (must be a key of ``_NAME_TO_JAX_FN``).
         ref_box: ``(a, b)`` reference box used to fit the OA. Must satisfy
             ``a < b`` and be inside the natural domain of ``f``.
-        arithmetic: one of ``"chebyshev"``, ``"taylor"``, ``"mccormick"``.
+        arithmetic: one of ``"chebyshev"``, ``"taylor"``, ``"mccormick"``,
+            ``"ellipsoidal"``.
         degree: polynomial degree for the bound provider.
         n_slopes: number of candidate slopes (yields up to ``2 * n_slopes``
             cuts after deduplication).

--- a/python/discopt/_jax/polyhedral_oa.py
+++ b/python/discopt/_jax/polyhedral_oa.py
@@ -34,7 +34,11 @@ Provider dispatch:
   univariate-OA face of the McCormick path; the native multivariate
   McCormick envelopes already implemented in ``mccormick.py`` continue
   to be the path used by ``relaxation_compiler.py``.)
-* ``arithmetic="ellipsoidal"``: not yet implemented (M7).
+* ``arithmetic="ellipsoidal"``: build a first-order ellipsoidal-arithmetic
+  enclosure of the joint ``(x, f(x))`` (:mod:`ellipsoidal_arith`, M7) and use
+  its rigorous interval support to bound ``f - s*x``. The generator part is
+  exact on the affine ``-s*x`` term, so the ellipsoidal provider captures the
+  ``x``/``f(x)`` correlation an interval bound would drop.
 
 Acceptance criteria from issue #51 met by this module:
 
@@ -54,6 +58,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Union
 
+import jax.numpy as jnp
 import numpy as np
 
 from discopt._jax import chebyshev_model as cm
@@ -132,18 +137,16 @@ def outer_approximation(
         raise ValueError(f"domain must have a < b, got {(a, b)}")
     if arithmetic not in ARITHMETICS:
         raise ValueError(f"arithmetic must be one of {ARITHMETICS}, got {arithmetic!r}")
-    if arithmetic == "ellipsoidal":
-        raise NotImplementedError(
-            "ellipsoidal outer approximation is not yet implemented (M7 of #51)"
-        )
     if n_slopes < 2:
         raise ValueError(f"n_slopes must be >= 2, got {n_slopes}")
 
-    provider: Union["_ChebyshevProvider", "_TaylorProvider"]
+    provider: Union["_ChebyshevProvider", "_TaylorProvider", "_EllipsoidalProvider"]
     if arithmetic == "chebyshev":
         provider = _ChebyshevProvider(f_callable, (a, b), degree)
     elif arithmetic == "taylor":
         provider = _TaylorProvider(f_callable, (a, b), degree)
+    elif arithmetic == "ellipsoidal":
+        provider = _EllipsoidalProvider(f_callable, (a, b), degree)
     elif arithmetic == "mccormick":
         # Use the Chebyshev kernel as a rigorous univariate bound provider
         # for the standalone OA wrapper. The multivariate McCormick path
@@ -188,6 +191,35 @@ class _TaylorProvider:
 
     def sample_polynomial(self, xs: np.ndarray) -> np.ndarray:
         return np.asarray(self._f.evaluate_polynomial(xs), dtype=np.float64)
+
+
+class _EllipsoidalProvider:
+    """Ellipsoidal-arithmetic bound provider (M7).
+
+    Tracks the joint ``(x, f(x))`` as ellipsoidal forms over a single shared
+    input noise symbol: ``x = c_x + r_x * xi`` and ``y = f(x)`` via a first-order
+    linearisation with a rigorous Chebyshev-bounded remainder. Because ``y`` and
+    ``x`` share ``xi``, ``f(x) - s*x`` keeps their correlation exactly on the
+    generator part, and its rigorous range is read off the form's bounds.
+    """
+
+    def __init__(self, f, domain, degree):
+        from discopt._jax import ellipsoidal_arith as ea
+
+        a, b = domain
+        self._f = f
+        self._degree = degree
+        (self._x_form,) = ea.forms_from_box(np.array([a]), np.array([b]))
+        self._y_form = self._x_form.apply_unary(f, degree=degree)
+
+    def range_minus_slope(self, s: float) -> tuple[float, float]:
+        h = self._y_form - self._x_form.scaled(float(s))
+        lo, hi = h.bounds()
+        return float(lo), float(hi)
+
+    def sample_polynomial(self, xs: np.ndarray) -> np.ndarray:
+        # No polynomial part; evaluate f directly to obtain true secant slopes.
+        return np.asarray(self._f(jnp.asarray(xs, dtype=jnp.float64)), dtype=np.float64)
 
 
 # ---------------------------------------------------------------------------

--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -729,12 +729,12 @@ def _compile_relax_node(
         if name in _univariate_relax:
             a_fn = arg_fns[0]
 
-            # Chebyshev / Taylor dispatch (M2 / M3 of issue #51): build a
-            # pre-compiled outer-approximation shim if (a) the operator
-            # is supported, (b) we can infer a finite static box for the
-            # inner expression. Otherwise fall through to the existing
-            # McCormick path so the choice is non-blocking.
-            if arithmetic in ("chebyshev", "taylor"):
+            # Chebyshev / Taylor / ellipsoidal dispatch (M2 / M3 of issue
+            # #51; M7 of issue #81): build a pre-compiled outer-approximation
+            # shim if (a) the operator is supported, (b) we can infer a finite
+            # static box for the inner expression. Otherwise fall through to
+            # the existing McCormick path so the choice is non-blocking.
+            if arithmetic in ("chebyshev", "taylor", "ellipsoidal"):
                 from discopt._jax import oa_relax
 
                 if oa_relax.is_supported(name):

--- a/python/tests/test_ellipsoidal_arith.py
+++ b/python/tests/test_ellipsoidal_arith.py
@@ -1,0 +1,236 @@
+"""Tests for ellipsoidal arithmetic (M7 of issue #81).
+
+Covers :mod:`discopt._jax.ellipsoidal_arith`:
+
+* **Geometry** — the closed-form ellipsoid calculus: support function, exact
+  affine image, and trace-minimising Minkowski-sum outer approximation.
+* **Soundness (rigorous-bound invariant)** — every propagated enclosure
+  contains the true range of its node on > 10^4 random samples, so a relaxation
+  built on it can never exclude a feasible point.
+* **Correlation win** — on correlated-affine expressions the ellipsoidal
+  enclosure is at least as tight as (and usually strictly tighter than) the
+  interval/affine-arithmetic enclosure, on well over 50% of nodes.
+* **Villanueva-style reproduction** — for an affine parametric map the
+  ellipsoidal enclosure equals the analytic image ellipsoid to ~machine
+  precision (the defining exactness property of ellipsoidal calculus), and for
+  a nonlinear parametric map it rigorously contains the true reachable set.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt._jax.ellipsoidal_arith import (
+    Ellipsoid,
+    EllipsoidalForm,
+    bounding_ellipsoid_of_box,
+    forms_from_box,
+    forms_from_ellipsoid,
+    joint_ellipsoid,
+)
+
+jax.config.update("jax_enable_x64", True)
+
+N_SAMPLES = 12_000
+
+
+def _ball_samples(rng, k, n=N_SAMPLES):
+    """Uniform samples in the unit 2-ball of dimension ``k``."""
+    z = rng.standard_normal((n, k))
+    z /= np.linalg.norm(z, axis=1, keepdims=True)
+    radius = rng.uniform(0.0, 1.0, size=(n, 1)) ** (1.0 / k)
+    return z * radius
+
+
+# ---------------------------------------------------------------------------
+# Geometry of the Ellipsoid object
+# ---------------------------------------------------------------------------
+
+
+def test_support_function_encloses_projections():
+    rng = np.random.default_rng(0)
+    c = np.array([0.3, -0.7, 1.1])
+    a = rng.standard_normal((3, 3))
+    ell = Ellipsoid(c, a @ a.T)
+    pts = c[None] + _ball_samples(rng, 3) @ np.linalg.cholesky(ell.shape).T
+    for _ in range(25):
+        s = rng.standard_normal(3)
+        lo, hi = ell.support(s)
+        proj = pts @ s
+        assert proj.min() >= lo - 1e-9
+        assert proj.max() <= hi + 1e-9
+
+
+def test_affine_image_is_exact():
+    """``A E + b`` has support exactly ``A``-transformed: tight, not just sound."""
+    rng = np.random.default_rng(1)
+    c = np.array([1.0, -2.0, 0.5])
+    a = rng.standard_normal((3, 3))
+    ell = Ellipsoid(c, a @ a.T)
+    m = rng.standard_normal((2, 3))
+    b = np.array([0.5, -1.0])
+    img = ell.affine_image(m, b)
+    for _ in range(10):
+        s = rng.standard_normal(2)
+        lo, hi = img.support(s)
+        # support of A E + b along s == support of E along A^T s, plus s.b
+        lo0, hi0 = ell.support(m.T @ s)
+        shift = float(s @ b)
+        assert lo == pytest.approx(lo0 + shift, rel=1e-9, abs=1e-9)
+        assert hi == pytest.approx(hi0 + shift, rel=1e-9, abs=1e-9)
+
+
+def test_minkowski_sum_is_sound_and_trace_optimal():
+    rng = np.random.default_rng(2)
+    e1 = Ellipsoid(np.array([0.0, 0.0]), np.diag([1.0, 0.25]))
+    e2 = Ellipsoid(np.array([0.5, -0.5]), np.diag([0.25, 1.0]))
+    summed = e1.minkowski_sum(e2)
+    g1 = np.linalg.cholesky(e1.shape)
+    g2 = np.linalg.cholesky(e2.shape)
+    xa = e1.center[None] + _ball_samples(rng, 2, 4000) @ g1.T
+    xb = e2.center[None] + _ball_samples(rng, 2, 4000) @ g2.T
+    for p in xa + xb:
+        assert summed.contains(p, tol=1e-7)
+    # Trace optimality: the chosen kappa minimises trace over a sweep.
+    best = min(
+        np.trace((1 + 1 / k) * e1.shape + (1 + k) * e2.shape) for k in np.linspace(0.05, 20.0, 4000)
+    )
+    assert np.trace(summed.shape) <= best + 1e-6
+
+
+def test_bounding_ellipsoid_of_box_contains_corners():
+    lb = np.array([-1.0, -0.5, 2.0])
+    ub = np.array([1.0, 1.5, 3.0])
+    ell = bounding_ellipsoid_of_box(lb, ub)
+    # All 2^3 corners lie inside (boundary) within tolerance.
+    from itertools import product
+
+    for combo in product(*zip(lb, ub)):
+        assert ell.contains(np.array(combo), tol=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# Soundness of propagated enclosures — the rigorous-bound invariant
+# ---------------------------------------------------------------------------
+
+
+def _nodes_for(x1, x2, X):
+    return {
+        "x1 - x2": (x1 - x2, X[:, 0] - X[:, 1]),
+        "3*x1 + x2": (x1 * 3.0 + x2, 3 * X[:, 0] + X[:, 1]),
+        "x1 * x2": (x1 * x2, X[:, 0] * X[:, 1]),
+        "exp(x1)": (x1.apply_unary(jnp.exp), np.exp(X[:, 0])),
+        "exp(x1) * x2": (x1.apply_unary(jnp.exp) * x2, np.exp(X[:, 0]) * X[:, 1]),
+        "log(2 + x1^2)": ((x1 * x1 + 2.0).apply_unary(jnp.log), np.log(2 + X[:, 0] ** 2)),
+        "sin(x1 + x2)": ((x1 + x2).apply_unary(jnp.sin), np.sin(X[:, 0] + X[:, 1])),
+        "(x1 - x2)^2": ((x1 - x2) * (x1 - x2), (X[:, 0] - X[:, 1]) ** 2),
+    }
+
+
+def test_propagated_enclosures_are_sound_on_dense_samples():
+    rng = np.random.default_rng(3)
+    c0 = np.array([1.0, -0.5])
+    g = np.array([[0.6, 0.2], [0.1, 0.5]])
+    ell_in = Ellipsoid(c0, g @ g.T)
+    x1, x2 = forms_from_ellipsoid(ell_in)
+    samples = c0[None] + _ball_samples(rng, 2) @ np.linalg.cholesky(ell_in.shape).T
+    for name, (form, truth) in _nodes_for(x1, x2, samples).items():
+        lo, hi = form.bounds()
+        assert (truth >= lo - 1e-9).all(), f"{name}: underestimator shaves the node"
+        assert (truth <= hi + 1e-9).all(), f"{name}: overestimator below the node"
+
+
+def test_ellipsoidal_at_least_as_tight_as_interval_on_every_node():
+    rng = np.random.default_rng(4)
+    c0 = np.array([1.0, -0.5])
+    g = np.array([[0.6, 0.2], [0.1, 0.5]])
+    ell_in = Ellipsoid(c0, g @ g.T)
+    x1, x2 = forms_from_ellipsoid(ell_in)
+    samples = c0[None] + _ball_samples(rng, 2, 2000) @ np.linalg.cholesky(ell_in.shape).T
+    for name, (form, _truth) in _nodes_for(x1, x2, samples).items():
+        lo, hi = form.bounds()
+        ilo, ihi = form.interval_bounds()
+        assert (hi - lo) <= (ihi - ilo) + 1e-12, f"{name}: ellipsoidal looser than interval"
+
+
+def test_correlated_affine_strictly_tighter_than_interval_majority():
+    """Acceptance: tighter than forward interval AA on >= 50% of nodes."""
+    rng = np.random.default_rng(5)
+    trials = 200
+    strictly_tighter = 0
+    for _ in range(trials):
+        k = 3
+        cin = rng.standard_normal(k)
+        gk = rng.standard_normal((k, k)) * 0.4
+        forms = forms_from_ellipsoid(Ellipsoid(cin, gk @ gk.T))
+        weights = rng.standard_normal(k)
+        comb = EllipsoidalForm(0.0, np.zeros(k))
+        for w, f in zip(weights, forms):
+            comb = comb + f.scaled(float(w))
+        elo, ehi = comb.bounds()
+        ilo, ihi = comb.interval_bounds()
+        if (ehi - elo) < (ihi - ilo) - 1e-9:
+            strictly_tighter += 1
+    assert strictly_tighter / trials >= 0.5
+
+
+def test_independent_box_inputs_have_no_spurious_correlation():
+    """A single box coordinate's enclosure is exact (no inflation)."""
+    x1, x2 = forms_from_box(np.array([-1.0, 2.0]), np.array([3.0, 5.0]))
+    assert x1.bounds() == pytest.approx((-1.0, 3.0), abs=1e-9)
+    assert x2.bounds() == pytest.approx((2.0, 5.0), abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Villanueva-style parametric reproduction
+# ---------------------------------------------------------------------------
+
+
+def test_affine_parametric_map_matches_analytic_ellipsoid():
+    """For an affine map of an ellipsoidal parameter set, the propagated joint
+    enclosure equals the analytic image ellipsoid ``E(A c + b, A Q A^T)`` to
+    ~machine precision — the exactness property ellipsoidal calculus is built
+    on (the 1e-6 reproduction criterion in its strongest form)."""
+    rng = np.random.default_rng(6)
+    c0 = np.array([0.5, -1.0])
+    g0 = np.array([[0.7, 0.1], [0.2, 0.5]])
+    q0 = g0 @ g0.T
+    ell_in = Ellipsoid(c0, q0)
+    p1, p2 = forms_from_ellipsoid(ell_in)
+
+    # Affine outputs y1 = 2 p1 - p2 + 1, y2 = p1 + 3 p2 - 2.
+    y1 = p1 * 2.0 - p2 + 1.0
+    y2 = p1 + p2 * 3.0 - 2.0
+    joint = joint_ellipsoid([y1, y2])
+
+    a = np.array([[2.0, -1.0], [1.0, 3.0]])
+    b = np.array([1.0, -2.0])
+    analytic = ell_in.affine_image(a, b)
+
+    assert joint.center == pytest.approx(analytic.center, abs=1e-6)
+    assert joint.shape == pytest.approx(analytic.shape, abs=1e-6)
+    # And both describe the same support in every direction.
+    for _ in range(10):
+        s = rng.standard_normal(2)
+        assert joint.support(s) == pytest.approx(analytic.support(s), abs=1e-6)
+
+
+def test_nonlinear_parametric_map_rigorously_contains_reachable_set():
+    """A nonlinear parametric map's ellipsoidal enclosure contains the true
+    reachable set on > 10^4 samples (rigorous, if no longer exact)."""
+    rng = np.random.default_rng(7)
+    c0 = np.array([0.2, 0.1])
+    g0 = np.array([[0.4, 0.05], [0.05, 0.3]])
+    ell_in = Ellipsoid(c0, g0 @ g0.T)
+    p1, p2 = forms_from_ellipsoid(ell_in)
+    # y1 = exp(p1) + p2,  y2 = p1 * p2.
+    y1 = p1.apply_unary(jnp.exp) + p2
+    y2 = p1 * p2
+    joint = joint_ellipsoid([y1, y2])
+
+    samples = c0[None] + _ball_samples(rng, 2) @ np.linalg.cholesky(ell_in.shape).T
+    out = np.column_stack([np.exp(samples[:, 0]) + samples[:, 1], samples[:, 0] * samples[:, 1]])
+    inside = np.array([joint.contains(p, tol=1e-6) for p in out])
+    assert inside.all(), f"{(~inside).sum()} reachable points fell outside the enclosure"

--- a/python/tests/test_polyhedral_oa.py
+++ b/python/tests/test_polyhedral_oa.py
@@ -41,9 +41,21 @@ def test_unknown_arithmetic_raises():
         oa.outer_approximation(jnp.exp, (-1.0, 1.0), "bogus")
 
 
-def test_ellipsoidal_not_implemented():
-    with pytest.raises(NotImplementedError):
-        oa.outer_approximation(jnp.exp, (-1.0, 1.0), "ellipsoidal")
+def test_ellipsoidal_is_implemented_and_sound():
+    """M7 (issue #81): the ellipsoidal provider now produces a valid OA."""
+    approx = oa.outer_approximation(jnp.exp, (-1.0, 1.0), "ellipsoidal")
+    assert approx.arithmetic == "ellipsoidal"
+    assert approx.cuts
+    rng = np.random.default_rng(0)
+    xs = rng.uniform(-1.0, 1.0, size=N_SAMPLES)
+    ys = np.exp(xs)
+    for cut in approx.cuts:
+        sx, sy = float(cut.coeffs[0]), float(cut.coeffs[1])
+        lhs = sx * xs + sy * ys
+        if cut.sense == ">=":
+            assert (lhs >= cut.rhs - TOL).all()
+        else:
+            assert (lhs <= cut.rhs + TOL).all()
 
 
 def test_invalid_domain_raises():
@@ -85,7 +97,7 @@ SOUNDNESS_CASES = [
 ]
 
 
-@pytest.mark.parametrize("arithmetic", ["mccormick", "chebyshev", "taylor"])
+@pytest.mark.parametrize("arithmetic", ["mccormick", "chebyshev", "taylor", "ellipsoidal"])
 @pytest.mark.parametrize("name, f, domain, degree", SOUNDNESS_CASES)
 def test_oa_is_sound(arithmetic, name, f, domain, degree):
     rng = np.random.default_rng(0)
@@ -98,7 +110,7 @@ def test_oa_is_sound(arithmetic, name, f, domain, degree):
     assert (true <= hi + TOL).all(), f"{arithmetic}/{name}: upper violated"
 
 
-@pytest.mark.parametrize("arithmetic", ["mccormick", "chebyshev", "taylor"])
+@pytest.mark.parametrize("arithmetic", ["mccormick", "chebyshev", "taylor", "ellipsoidal"])
 def test_oa_each_cut_is_globally_valid(arithmetic):
     """Stronger than the OA-as-tube test: every individual cut must hold
     for every sampled point. This guards against future refactors that
@@ -125,7 +137,7 @@ def test_oa_each_cut_is_globally_valid(arithmetic):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("arithmetic", ["mccormick", "chebyshev", "taylor"])
+@pytest.mark.parametrize("arithmetic", ["mccormick", "chebyshev", "taylor", "ellipsoidal"])
 def test_endpoint_secant_present(arithmetic):
     domain = (-1.0, 2.0)
     a, b = domain
@@ -162,7 +174,7 @@ def test_uniform_api_across_arithmetics():
     domain = (-0.5, 0.5)
     results = {
         kind: oa.outer_approximation(jnp.exp, domain, kind, degree=6, n_slopes=8)
-        for kind in ("mccormick", "chebyshev", "taylor")
+        for kind in ("mccormick", "chebyshev", "taylor", "ellipsoidal")
     }
     for kind, r in results.items():
         assert r.arithmetic == kind

--- a/python/tests/test_relaxation_arithmetic.py
+++ b/python/tests/test_relaxation_arithmetic.py
@@ -36,7 +36,7 @@ def _eval_at(fn, x_val, n_vars):
     return float(cv), float(cc)
 
 
-@pytest.mark.parametrize("arithmetic", ["chebyshev", "taylor"])
+@pytest.mark.parametrize("arithmetic", ["chebyshev", "taylor", "ellipsoidal"])
 def test_oa_relax_soundness_exp(arithmetic):
     """cv ≤ exp(x) ≤ cc on a Monte Carlo sample inside the box."""
     m = discopt.Model("exp_test")
@@ -54,7 +54,7 @@ def test_oa_relax_soundness_exp(arithmetic):
         assert cc >= true - 1e-6, f"cc={cc} < exp({xv})={true} at arithmetic={arithmetic}"
 
 
-@pytest.mark.parametrize("arithmetic", ["chebyshev", "taylor"])
+@pytest.mark.parametrize("arithmetic", ["chebyshev", "taylor", "ellipsoidal"])
 def test_oa_relax_soundness_log(arithmetic):
     """cv ≤ log(x) ≤ cc on a Monte Carlo sample inside the box."""
     m = discopt.Model("log_test")
@@ -114,3 +114,23 @@ def test_solve_with_chebyshev_preserves_optimum():
     assert res_base.status in ("optimal", "feasible")
     assert res_cheb.status in ("optimal", "feasible")
     assert res_cheb.objective == pytest.approx(res_base.objective, abs=1e-3, rel=1e-3)
+
+
+def test_solve_with_ellipsoidal_preserves_optimum():
+    """End-to-end: compile-time ellipsoidal path (M7) keeps the global optimum."""
+
+    def _build(name):
+        m = discopt.Model(name)
+        x = m.continuous("x", lb=-1.0, ub=1.0)
+        y = m.continuous("y", lb=-1.0, ub=1.0)
+        m.minimize(discopt.exp(x) + discopt.log(y + 2.0) + (x - y) ** 2)
+        m.subject_to(x + y >= 0.0)
+        return m
+
+    base = _build("base")
+    res_base = base.solve(time_limit=30.0, relaxation_arithmetic="mccormick")
+    ell = _build("ell")
+    res_ell = ell.solve(time_limit=30.0, relaxation_arithmetic="ellipsoidal")
+    assert res_base.status in ("optimal", "feasible")
+    assert res_ell.status in ("optimal", "feasible")
+    assert res_ell.objective == pytest.approx(res_base.objective, abs=1e-3, rel=1e-3)


### PR DESCRIPTION
## Summary

Implements **M7 "ellipsoidal arithmetic"** of issue #81 — the last remaining milestone (M8 superposition landed earlier). Propagates ellipsoidal enclosures `{x : (x-c)^T P^-1 (x-c) <= 1}` through the expression DAG, capturing affine correlations that forward interval/affine arithmetic discards.

## What's new

- **`python/discopt/_jax/ellipsoidal_arith.py`** — the core module:
  - `Ellipsoid(center, shape)`: closed-form calculus — support function `s^T c ± sqrt(s^T Q s)`, **exact** affine image `A·E+b = E(Ac+b, AQA^T)`, trace-minimizing Minkowski-sum outer approximation.
  - `EllipsoidalForm(center, gens, rem)`: noise-symbol affine forms over a shared input ball. Radius is `‖gens‖₂ + rem` (2-norm) vs interval-AA's `‖gens‖₁ + rem` (1-norm) — that's where the correlation tightening comes from. Nonlinear unary/bilinear ops fold a **rigorous** Chebyshev-bounded linearization defect into `rem`; all rounding is outward so floating-point error can only loosen an enclosure (never violate the rigorous-bound invariant).
- **Integration** — selectable end-to-end via `relaxation_arithmetic="ellipsoidal"`:
  - `_EllipsoidalProvider` in `polyhedral_oa.py` (the documented bound-provider integration point).
  - Added to the `relaxation_compiler.py` / `oa_relax.py` OA dispatch alongside chebyshev/taylor, so the full solver actually uses it.

## Acceptance criteria (issue #81 M7) — all verified

- **Soundness / rigorous-bound invariant**: every propagated enclosure and every emitted OA cut contains the true node range on >10⁴ samples per node.
- **Villanueva-style reproduction**: an affine parametric map reproduces the analytic image ellipsoid to ~1e-6; a nonlinear parametric map rigorously contains the true reachable set.
- **Correlation win**: strictly tighter than forward interval AA on ≥50% of correlated-affine nodes (≈100% on the random battery).
- **Regression instance + suite**: new `discopt_benchmarks/tests/test_ellipsoidal_regression.py`; smoke suite reports `incorrect_count == 0` (default path untouched).

## Tests

- New: `python/tests/test_ellipsoidal_arith.py` (10), `discopt_benchmarks/tests/test_ellipsoidal_regression.py` (4).
- Extended parametrized coverage in `test_polyhedral_oa.py` and `test_relaxation_arithmetic.py` to include `ellipsoidal`; replaced the obsolete `test_ellipsoidal_not_implemented` with a positive soundness test.
- ruff / ruff format / mypy clean on all touched modules.

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
