### PR TITLE
feat(modeling): dm.custom opaque AD-only user functions (#27b)

### DIFF
--- a/python/discopt/_jax/dag_compiler.py
+++ b/python/discopt/_jax/dag_compiler.py
@@ -29,6 +29,7 @@ from discopt.modeling.core import (
     BinaryOp,
     Constant,
     Constraint,
+    CustomCall,
     Expression,
     FunctionCall,
     IndexExpression,
@@ -206,6 +207,19 @@ def _compile_node(expr: Expression, model: Model, param_index: dict) -> Callable
             return fn
 
         raise ValueError(f"Unknown function: {name!r}")
+
+    if isinstance(expr, CustomCall):
+        # Opaque AD-only user function: trace the stored callable through JAX so
+        # value + autodiff gradients/Hessians come for free on the local NLP
+        # path. No relaxation rule exists (see relaxation_compiler / solver
+        # guards), so this branch is only reached on the continuous NLP path.
+        custom_arg_fns = tuple(_compile_node(a, model, param_index) for a in expr.args)
+        user_fn = expr.fn
+
+        def fn(x_flat, params, _user_fn=user_fn, _arg_fns=custom_arg_fns):
+            return _user_fn(*[a(x_flat, params) for a in _arg_fns])
+
+        return fn
 
     if isinstance(expr, IndexExpression):
         base_fn = _compile_node(expr.base, model, param_index)

--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -59,6 +59,7 @@ from discopt.modeling.core import (
     BinaryOp,
     Constant,
     Constraint,
+    CustomCall,
     Expression,
     FunctionCall,
     IndexExpression,
@@ -929,6 +930,16 @@ def _compile_relax_node(
             return cv_acc, cc_acc
 
         return fn
+
+    if isinstance(expr, CustomCall):
+        raise NotImplementedError(
+            f"Cannot build a McCormick relaxation for the opaque AD-only user "
+            f"function {expr.name!r} (dm.custom). Global / spatial branch-and-bound "
+            f"needs rigorous convex/concave relaxations, which an opaque callable "
+            f"cannot provide. Solve on the local NLP path (pure-continuous models "
+            f"route there automatically), or rebuild the function from dm.* "
+            f"primitives and use dm.udf."
+        )
 
     raise TypeError(f"Unhandled expression type: {type(expr).__name__}")
 

--- a/python/discopt/_jax/sparsity.py
+++ b/python/discopt/_jax/sparsity.py
@@ -23,6 +23,7 @@ from discopt.modeling.core import (
     BinaryOp,
     Constant,
     Constraint,
+    CustomCall,
     Expression,
     FunctionCall,
     IndexExpression,
@@ -106,7 +107,11 @@ def _collect_variable_indices(expr: Expression, model: Model) -> set[int]:
         return left | right
     if isinstance(expr, UnaryOp):
         return _collect_variable_indices(expr.operand, model)
-    if isinstance(expr, FunctionCall):
+    if isinstance(expr, (FunctionCall, CustomCall)):
+        # CustomCall is an opaque AD-only callable: we cannot see inside it, so
+        # conservatively treat every variable reaching its arguments as a
+        # structural dependency (over-approximation is always sound for
+        # sparsity — it can only declare extra nonzeros, never miss one).
         result: set[int] = set()
         for arg in expr.args:
             result |= _collect_variable_indices(arg, model)
@@ -159,7 +164,10 @@ def _collect_nonlinear_pairs(expr: Expression, model: Model) -> set[tuple[int, i
             pairs.add((i, i))
         pairs |= _collect_nonlinear_pairs(expr.operand, model)
 
-    elif isinstance(expr, FunctionCall):
+    elif isinstance(expr, (FunctionCall, CustomCall)):
+        # Opaque/nonlinear: assume every pair of argument variables interacts
+        # nonlinearly (dense Hessian block over the touched variables). This is
+        # a sound over-approximation of the true Hessian sparsity.
         all_vars: set[int] = set()
         for arg in expr.args:
             all_vars |= _collect_variable_indices(arg, model)

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -33,6 +33,7 @@ import numpy as np
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
+    CustomCall,
     Expression,
     FunctionCall,
     IndexExpression,
@@ -801,6 +802,13 @@ class _NLWriter:
             raise ValueError(
                 "MatMul expressions must be expanded before .nl export. "
                 "Use explicit indexing instead of @."
+            )
+
+        if isinstance(expr, CustomCall):
+            raise ValueError(
+                f"Cannot export the opaque AD-only user function {expr.name!r} "
+                f"(dm.custom) to .nl: it has no AMPL opcode. Rebuild the function "
+                f"from dm.* primitives and use dm.udf to make it exportable."
             )
 
         raise ValueError(f"Cannot write expression type to .nl: {type(expr).__name__}")

--- a/python/discopt/modeling/__init__.py
+++ b/python/discopt/modeling/__init__.py
@@ -21,6 +21,8 @@ from discopt.modeling.core import (
     BooleanVar,
     BooleanVarArray,
     Constraint,
+    # Opaque AD-only user function node (for isinstance checks)
+    CustomCall,
     Disjunct,
     # Expressions (for isinstance checks, rarely needed)
     Expression,
@@ -41,6 +43,7 @@ from discopt.modeling.core import (
     atleast,
     atmost,
     cos,
+    custom,
     erf,
     exactly,
     # Mathematical functions
@@ -106,6 +109,8 @@ __all__ = [
     "maximum",
     "if_else",
     "udf",
+    "custom",
+    "CustomCall",
     "sum",
     "prod",
     "norm",

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -282,6 +282,39 @@ class FunctionCall(Expression):
         return f"{self.func_name}({arg_str})"
 
 
+class CustomCall(Expression):
+    """Opaque, AD-only user function wrapping a JAX-traceable callable.
+
+    Unlike :class:`FunctionCall` -- whose ``func_name`` is dispatched to a known
+    value / relaxation / interval / ``.nl`` rule -- a ``CustomCall`` carries an
+    arbitrary Python callable that discopt evaluates by *tracing it through JAX*.
+    discopt can therefore autodifferentiate it for the local NLP path, but it
+    CANNOT build the rigorous convex/concave relaxations and interval rules that
+    global spatial branch-and-bound, the Rust presolve, and ``.nl`` export
+    require.
+
+    Consequences (enforced by the solver and the export/relaxation layers):
+
+    - A model containing a ``CustomCall`` is solved on the **local NLP path
+      only** -- the result carries **no global optimality certificate**
+      (``gap_certified`` is ``False``).
+    - The solver **raises** if integer/binary variables are present, because
+      global B&B has no valid node relaxation for an opaque callable.
+    - Relaxation compilation and ``.nl`` export **raise** a clear error.
+
+    Built via :func:`custom`; do not instantiate directly in user code.
+    """
+
+    def __init__(self, fn: Callable, *args: Expression, name: Optional[str] = None):
+        self.fn = fn
+        self.args = tuple(args)
+        self.name = name or getattr(fn, "__name__", "custom")
+
+    def __repr__(self):
+        arg_str = ", ".join(str(a) for a in self.args)
+        return f"custom:{self.name}({arg_str})"
+
+
 class MatMulExpression(Expression):
     """Matrix multiplication: A @ x."""
 
@@ -708,6 +741,57 @@ def udf(fn: Callable) -> Callable:
     if not callable(fn):
         raise TypeError(f"udf() expects a callable, got {type(fn).__name__}")
     return fn
+
+
+def custom(fn: Callable, *, name: Optional[str] = None) -> Callable:
+    """Wrap an opaque, JAX-traceable callable as an AD-only user function.
+
+    Use this **only** when a function genuinely cannot be expressed with
+    ``dm.*`` primitives. If you can write the body symbolically (with
+    ``dm.exp``, ``dm.maximum``, ``dm.if_else``, arithmetic on variables, ...),
+    use :func:`udf` instead -- that keeps full global-solver support, whereas a
+    ``custom`` function is restricted to the local NLP path.
+
+    *fn* must be differentiable by JAX: write it with ``jax.numpy`` operations
+    on its array arguments so discopt can autodiff it for gradients/Hessians.
+    The returned wrapper builds a :class:`CustomCall` node when called with
+    expression arguments::
+
+        import jax.numpy as jnp
+        import discopt.modeling as dm
+
+        weird = dm.custom(lambda x: jnp.sum(jnp.sinc(x) ** 2))
+        m.minimize(weird(x) + dm.sum(x))
+
+    Because the body is opaque to the relaxation machinery, a model that uses a
+    ``dm.custom`` function is solved on the **local NLP path only** -- there is
+    no global optimality certificate -- and the solver raises if integer/binary
+    variables are present (global branch-and-bound cannot bound an opaque
+    callable). See :class:`CustomCall`.
+
+    Parameters
+    ----------
+    fn : callable
+        A JAX-traceable function of one or more array arguments returning a
+        scalar (objective term) or array (constraint body).
+    name : str, optional
+        Display name used in reprs and error messages. Defaults to
+        ``fn.__name__``.
+
+    Returns
+    -------
+    callable
+        A builder; call it with expression arguments to produce a
+        :class:`CustomCall` DAG node.
+    """
+    if not callable(fn):
+        raise TypeError(f"custom() expects a callable, got {type(fn).__name__}")
+
+    def _build(*args) -> Expression:
+        return CustomCall(fn, *[_wrap(a) for a in args], name=name)
+
+    _build.__name__ = name or str(getattr(fn, "__name__", "custom"))
+    return _build
 
 
 # ─────────────────────────────────────────────────────────────

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -26,6 +26,7 @@ from discopt.constants import SENTINEL_THRESHOLD as _SENTINEL_THRESHOLD
 from discopt.constants import STARTING_POINT_CLIP as _SPC
 from discopt.modeling.core import (
     Constraint,
+    CustomCall,
     Model,
     SolveResult,
     VarType,
@@ -1404,6 +1405,52 @@ def _is_pure_continuous(model: Model) -> bool:
     return all(v.var_type == VarType.CONTINUOUS for v in model._variables)
 
 
+def _model_contains_custom_call(model: Model) -> bool:
+    """True if any objective/constraint body contains a ``CustomCall`` node.
+
+    A ``CustomCall`` wraps an opaque AD-only user function (``dm.custom``) that
+    the relaxation compiler, Rust presolve, and ``.nl`` export cannot reason
+    about. The solver uses this to force the local NLP path and to refuse global
+    branch-and-bound (see ``solve_model``). See issue #27b.
+    """
+
+    def _walk(expr) -> bool:
+        if isinstance(expr, CustomCall):
+            return True
+        # Generic child traversal mirroring the DAG node fields used elsewhere
+        # (e.g. discopt._jax.cutting_planes): BinaryOp/MatMul -> left/right,
+        # UnaryOp/SumExpression -> operand, FunctionCall/CustomCall -> args,
+        # SumOverExpression -> terms, IndexExpression -> base.
+        left = getattr(expr, "left", None)
+        if left is not None and _walk(left):
+            return True
+        right = getattr(expr, "right", None)
+        if right is not None and _walk(right):
+            return True
+        operand = getattr(expr, "operand", None)
+        if operand is not None and _walk(operand):
+            return True
+        base = getattr(expr, "base", None)
+        if base is not None and _walk(base):
+            return True
+        for a in getattr(expr, "args", ()) or ():
+            if _walk(a):
+                return True
+        for t in getattr(expr, "terms", ()) or ():
+            if _walk(t):
+                return True
+        return False
+
+    obj = getattr(model, "_objective", None)
+    if obj is not None and getattr(obj, "expression", None) is not None and _walk(obj.expression):
+        return True
+    for c in model._constraints:
+        body = getattr(c, "body", None)
+        if body is not None and _walk(body):
+            return True
+    return False
+
+
 def _classify_model_convexity(
     model: Model,
     *,
@@ -1885,6 +1932,38 @@ def solve_model(
     t_start = time.perf_counter()
     rust_time = 0.0
     jax_time = 0.0
+
+    # --- AD-only user functions (dm.custom): force the local NLP path ---
+    # A CustomCall wraps an opaque JAX-traceable callable. discopt can autodiff
+    # it (so the local NLP path works), but the relaxation compiler, Rust
+    # presolve, .nl export, and nonlinear bound tightening cannot reason about
+    # it — global branch-and-bound would have no valid node relaxation. So we
+    # solve locally only (no global optimality certificate) and refuse when
+    # integer/binary variables force B&B. Placed before the DAG-walking
+    # presolve/infeasibility checks so they never see a CustomCall. See #27b.
+    if _model_contains_custom_call(model):
+        if not _is_pure_continuous(model):
+            raise ValueError(
+                "Model contains a dm.custom(...) AD-only user function together "
+                "with integer/binary variables. Global branch-and-bound needs a "
+                "valid relaxation at each node, which an opaque callable cannot "
+                "provide. Rebuild the function from dm.* primitives (see dm.udf), "
+                "or remove the integer/binary variables."
+            )
+        logger.info(
+            "Model contains a dm.custom(...) AD-only user function — solving on "
+            "the local NLP path only (no global optimality certificate)."
+        )
+        result = _solve_continuous(
+            model,
+            time_limit,
+            ipopt_options,
+            t_start,
+            nlp_solver,
+            initial_point=initial_point,
+        )
+        result.gap_certified = False
+        return result
 
     if nlp_solver == "pounce":
         logger.info("Using POUNCE (pure-Rust Ipopt port)")

--- a/python/tests/test_custom_udf.py
+++ b/python/tests/test_custom_udf.py
@@ -1,0 +1,204 @@
+"""Tests for ``dm.custom`` / :class:`CustomCall` — opaque AD-only user functions.
+
+A ``dm.custom`` function wraps an arbitrary JAX-traceable callable. discopt can
+autodifferentiate it (so the local NLP path works), but it cannot build the
+rigorous relaxations / interval rules / ``.nl`` export that global spatial
+branch-and-bound needs. These tests pin down both halves of that contract:
+
+* the value/autodiff path works through the DAG compiler and the local solver,
+  and the result carries no global certificate (``gap_certified is False``);
+* every machinery that would need a relaxation refuses loudly — integer/binary
+  variables (solver ``ValueError``), ``.nl`` export (``ValueError``), and
+  relaxation compilation (``NotImplementedError``); and ``custom`` itself
+  rejects a non-callable argument (``TypeError``).
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt.modeling import Model
+from discopt.modeling.core import CustomCall
+
+# ─────────────────────────────────────────────────────────────
+# Node construction / repr
+# ─────────────────────────────────────────────────────────────
+
+
+class TestCustomCallNode:
+    def test_custom_returns_builder(self):
+        builder = dm.custom(lambda x: jnp.sum(x**2))
+        assert callable(builder)
+
+    def test_builder_produces_customcall(self):
+        m = Model("c")
+        x = m.continuous("x", lb=-5, ub=5)
+        node = dm.custom(lambda x: jnp.sum(x**2))(x)
+        assert isinstance(node, CustomCall)
+        assert node.fn is not None
+        assert len(node.args) == 1
+
+    def test_name_defaults_to_fn_name(self):
+        def weird(x):
+            return jnp.sum(x)
+
+        node = dm.custom(weird)(Model("c").continuous("x"))
+        assert node.name == "weird"
+
+    def test_explicit_name_overrides(self):
+        m = Model("c")
+        x = m.continuous("x")
+        node = dm.custom(lambda x: x, name="my_fn")(x)
+        assert node.name == "my_fn"
+        assert "my_fn" in repr(node)
+        assert repr(node).startswith("custom:")
+
+    def test_lambda_default_name(self):
+        # An unnamed lambda has __name__ == "<lambda>"; just ensure no crash.
+        node = dm.custom(lambda x: x)(Model("c").continuous("x"))
+        assert isinstance(node.name, str)
+
+    def test_custom_rejects_non_callable(self):
+        with pytest.raises(TypeError):
+            dm.custom(42)
+        with pytest.raises(TypeError):
+            dm.custom("not a function")
+
+
+# ─────────────────────────────────────────────────────────────
+# Local NLP path: value + autodiff correctness, no certificate
+# ─────────────────────────────────────────────────────────────
+
+
+class TestLocalSolve:
+    def test_scalar_custom_solves_and_uncertified(self):
+        # minimize (x - 3)^2 written through an opaque callable.
+        m = Model("scalar")
+        x = m.continuous("x", lb=-10, ub=10)
+        sq = dm.custom(lambda x: (x - 3.0) ** 2)
+        m.minimize(sq(x))
+
+        result = m.solve()
+        assert result.status == "optimal"
+        assert result.x["x"] == pytest.approx(3.0, abs=1e-4)
+        # Opaque callable ⇒ no global optimality certificate.
+        assert result.gap_certified is False
+
+    def test_vector_custom_solves(self):
+        # minimize sum((x - target)^2) over a vector variable.
+        target = jnp.array([1.0, -2.0, 0.5])
+        m = Model("vector")
+        x = m.continuous("x", shape=(3,), lb=-10, ub=10)
+        f = dm.custom(lambda x: jnp.sum((x - target) ** 2))
+        m.minimize(f(x))
+
+        result = m.solve()
+        assert result.status == "optimal"
+        np.testing.assert_allclose(result.x["x"], np.asarray(target), atol=1e-4)
+        assert result.gap_certified is False
+
+    def test_custom_in_constraint(self):
+        # minimize x s.t. custom(x) <= 4  where custom(x) = x^2  ⇒  x >= -2.
+        m = Model("constr")
+        x = m.continuous("x", lb=-10, ub=10)
+        m.minimize(x)
+        sq = dm.custom(lambda x: x**2)
+        m.subject_to(sq(x) <= 4.0)
+
+        result = m.solve()
+        assert result.status == "optimal"
+        assert result.x["x"] == pytest.approx(-2.0, abs=1e-4)
+        assert result.gap_certified is False
+
+    def test_custom_mixed_with_primitives(self):
+        # Objective mixes an opaque term with ordinary dm.* primitives.
+        m = Model("mixed")
+        x = m.continuous("x", lb=-5, ub=5)
+        opaque = dm.custom(lambda x: jnp.sin(x) ** 2)
+        m.minimize(opaque(x) + (x - 1.0) ** 2)
+
+        result = m.solve()
+        assert result.status == "optimal"
+        # Verify the reported point is a stationary point of the true objective:
+        # d/dx [sin^2(x) + (x-1)^2] = sin(2x) + 2(x-1) = 0.
+        xv = float(result.x["x"])
+        assert abs(np.sin(2 * xv) + 2 * (xv - 1.0)) < 1e-4
+        assert result.gap_certified is False
+
+
+# ─────────────────────────────────────────────────────────────
+# DAG compiler: value + gradient match the underlying callable
+# ─────────────────────────────────────────────────────────────
+
+
+class TestDagCompile:
+    def test_compiled_value_and_gradient(self):
+        from discopt._jax.dag_compiler import compile_expression
+
+        m = Model("grad")
+        x = m.continuous("x", shape=(2,), lb=-5, ub=5)
+
+        def raw(v):
+            return jnp.sum(v**3) + jnp.prod(v)
+
+        node = dm.custom(raw)(x)
+        fn = compile_expression(node, m)
+
+        xv = jnp.array([1.5, -0.7])
+        assert float(fn(xv)) == pytest.approx(float(raw(xv)))
+
+        g_compiled = jax.grad(lambda v: fn(v))(xv)
+        g_raw = jax.grad(raw)(xv)
+        np.testing.assert_allclose(np.asarray(g_compiled), np.asarray(g_raw), atol=1e-6)
+
+
+# ─────────────────────────────────────────────────────────────
+# Refusal guards: integer vars, .nl export, relaxation compilation
+# ─────────────────────────────────────────────────────────────
+
+
+class TestRefusals:
+    def test_integer_variable_raises(self):
+        m = Model("int")
+        x = m.continuous("x", lb=-10, ub=10)
+        m.integer("k", lb=0, ub=5)
+        f = dm.custom(lambda x: (x - 3.0) ** 2)
+        m.minimize(f(x))
+
+        with pytest.raises(ValueError, match="custom"):
+            m.solve()
+
+    def test_binary_variable_raises(self):
+        m = Model("bin")
+        x = m.continuous("x", lb=-10, ub=10)
+        m.binary("b")
+        f = dm.custom(lambda x: (x - 3.0) ** 2)
+        m.minimize(f(x))
+
+        with pytest.raises(ValueError, match="custom"):
+            m.solve()
+
+    def test_nl_export_raises(self):
+        from discopt.export.nl import to_nl
+
+        m = Model("nl")
+        x = m.continuous("x", lb=-10, ub=10)
+        f = dm.custom(lambda x: (x - 3.0) ** 2)
+        m.minimize(f(x))
+
+        with pytest.raises(ValueError, match="custom|opaque|AD-only"):
+            to_nl(m)
+
+    def test_relaxation_compile_raises(self):
+        from discopt._jax.relaxation_compiler import compile_objective_relaxation
+
+        m = Model("relax")
+        x = m.continuous("x", lb=-10, ub=10)
+        f = dm.custom(lambda x: (x - 3.0) ** 2)
+        m.minimize(f(x))
+
+        with pytest.raises(NotImplementedError, match="custom|opaque|relaxation"):
+            compile_objective_relaxation(m)


### PR DESCRIPTION
## Summary

Implements the pure-JAX path of #27b: a `dm.custom(fn)` escape hatch for wrapping an arbitrary JAX-traceable callable as an expression, plus the `CustomCall` DAG node it produces.

`dm.custom` complements the existing `dm.udf`:

| | `dm.udf` | `dm.custom` (new) |
|---|---|---|
| Body | must be symbolic (`dm.*` primitives) | opaque Python/JAX callable |
| How discopt sees it | full DAG | traced through JAX |
| Global solver support | yes (relaxations, `.nl`, B&B) | **no** — local NLP path only |
| Certificate | yes | `gap_certified=False` |

Use `dm.custom` only when a function genuinely cannot be expressed with `dm.*` primitives. Because the callable is opaque to the relaxation machinery, discopt evaluates it (value + autodiff gradients/Hessians) on the **local NLP path only** and refuses everywhere a valid relaxation is required.

## What changed

- **`modeling/core.py`** — `CustomCall(Expression)` node + `custom(fn, *, name=None)` factory (rejects non-callables with `TypeError`).
- **`modeling/__init__.py`** — export `custom` and `CustomCall`.
- **`_jax/dag_compiler.py`** — compile a `CustomCall` by tracing the stored callable through JAX (value + autodiff).
- **`solver.py`** — route any model containing a `CustomCall` to the continuous NLP path, mark `gap_certified=False`, and raise a clear `ValueError` if integer/binary variables are present.
- **`_jax/relaxation_compiler.py`** — raise `NotImplementedError` (no McCormick rule for an opaque callable).
- **`export/nl.py`** — raise `ValueError` (cannot serialize an opaque callable to `.nl`).
- **`_jax/sparsity.py`** — treat a `CustomCall` like a `FunctionCall` in Jacobian/Hessian sparsity detection: union all argument variables as structural dependencies (a sound over-approximation). Without this, a `CustomCall` in a *constraint* body was detected as depending on no variables, producing an empty Jacobian pattern that crashed cyipopt problem creation.

## Refusal contract (enforced + tested)

| Path | Behavior |
|---|---|
| Continuous local solve | works; `gap_certified=False` |
| Integer/binary variables | `ValueError` |
| `.nl` export | `ValueError` |
| Relaxation compilation | `NotImplementedError` |
| `custom(non_callable)` | `TypeError` |

## Tests

New `python/tests/test_custom_udf.py` (15 tests): node construction/repr, scalar/vector/constraint/mixed continuous solves with `gap_certified=False`, compiled value+gradient parity against the raw callable, and all four refusal guards.

Regression: `test_dag_compiler`, `test_nl_writer`, `test_export`, `test_sparsity`, `test_sparse_*`, `test_convex_fast_path` all pass; full `-m smoke` suite passes (201 passed). `ruff check`/`format` and `mypy` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
