### PR TITLE
fix(presolve): tolerance-aware FBBT/probing infeasibility — fix unsound GDP optimality certificate (#27a)

### DIFF
--- a/crates/discopt-core/src/presolve/fbbt.rs
+++ b/crates/discopt-core/src/presolve/fbbt.rs
@@ -8,6 +8,16 @@ use crate::expr::{
 };
 use std::f64::consts::PI;
 
+/// Feasibility tolerance for declaring a constraint infeasible during FBBT.
+///
+/// A forward-propagated constraint body that misses its required output bound
+/// by less than this is treated as feasible (numerical noise), not as proof of
+/// infeasibility. Matches the solver's absolute feasibility tolerance (1e-6)
+/// and is deliberately larger than the FBBT convergence tolerance (~1e-8) so
+/// that eps-scale residuals from approximate reformulations (e.g. GDP hull
+/// perspective forms) cannot fabricate an unsound infeasibility certificate.
+pub const FEAS_TOL: f64 = 1e-6;
+
 // ─────────────────────────────────────────────────────────────
 // Interval type
 // ─────────────────────────────────────────────────────────────
@@ -58,6 +68,21 @@ impl Interval {
     /// Whether the interval is empty (lo > hi).
     pub fn is_empty(&self) -> bool {
         self.lo > self.hi
+    }
+
+    /// Whether the interval is empty by more than a feasibility tolerance,
+    /// i.e. `lo - hi > tol`.
+    ///
+    /// Use this (not [`is_empty`]) when deciding that a *constraint* is
+    /// genuinely infeasible. Approximate reformulations — notably the GDP
+    /// hull perspective form `y * f(v / y)` with a clamp `y + eps` — leave
+    /// eps-scale (~1e-8) residuals at integer faces. A strict `lo > hi`
+    /// check mistakes that numerical noise for infeasibility and can fix a
+    /// disjunction's selector incorrectly, producing an unsound bound. A
+    /// tolerance-aware check declares infeasibility only when the violation
+    /// exceeds the feasibility tolerance.
+    pub fn is_empty_beyond(&self, tol: f64) -> bool {
+        self.lo - self.hi > tol
     }
 
     /// Whether `x` is contained in the interval.
@@ -711,7 +736,7 @@ pub fn fbbt_with_cutoff(
             };
 
             let body_bound = node_bounds[constr.body.0];
-            if body_bound.intersect(&output_bound).is_empty() {
+            if body_bound.intersect(&output_bound).is_empty_beyond(FEAS_TOL) {
                 for b in &mut var_bounds {
                     *b = Interval::empty();
                 }
@@ -731,7 +756,7 @@ pub fn fbbt_with_cutoff(
         if let Some((obj_expr, ref cutoff_bound)) = obj_cutoff {
             let node_bounds = forward_propagate(&model.arena, obj_expr, &var_bounds);
             let obj_bound = node_bounds[obj_expr.0];
-            if obj_bound.intersect(cutoff_bound).is_empty() {
+            if obj_bound.intersect(cutoff_bound).is_empty_beyond(FEAS_TOL) {
                 for b in &mut var_bounds {
                     *b = Interval::empty();
                 }
@@ -794,7 +819,7 @@ pub fn fbbt(model: &ModelRepr, max_iter: usize, tol: f64) -> Vec<Interval> {
             // Check feasibility: if the forward bound is incompatible
             // with the constraint, the problem is infeasible.
             let body_bound = node_bounds[constr.body.0];
-            if body_bound.intersect(&output_bound).is_empty() {
+            if body_bound.intersect(&output_bound).is_empty_beyond(FEAS_TOL) {
                 // Infeasible — mark all bounds as empty.
                 for b in &mut var_bounds {
                     *b = Interval::empty();
@@ -1593,5 +1618,86 @@ mod tests {
         let bounds = fbbt_with_cutoff(&model, 10, 1e-8, Some(cutoff));
         assert!((bounds[0].lo - (-10.0)).abs() < 1e-8);
         assert!((bounds[0].hi - 2.0).abs() < 1e-8);
+    }
+
+    // -- feasibility-tolerance regression tests (issue #27a) --
+
+    #[test]
+    fn test_is_empty_beyond_tolerance() {
+        // An eps-scale inverted interval is empty in the strict sense but
+        // feasible within tolerance — it must not be treated as infeasible.
+        let eps = Interval::new(1.0, 1.0 - 1e-9);
+        assert!(eps.is_empty());
+        assert!(!eps.is_empty_beyond(FEAS_TOL));
+
+        // A genuinely inverted interval is empty beyond tolerance.
+        let real = Interval::new(1.0, 0.9);
+        assert!(real.is_empty());
+        assert!(real.is_empty_beyond(FEAS_TOL));
+
+        // The canonical empty interval is empty beyond any finite tolerance.
+        assert!(Interval::empty().is_empty_beyond(FEAS_TOL));
+    }
+
+    /// Build a one-variable model `x` fixed to `[0, 0]` with a single `x >= rhs`
+    /// constraint. With `rhs` a small positive number the constraint is violated
+    /// by exactly `rhs` — the shape of a GDP hull perspective residual at an
+    /// integer face.
+    fn make_eps_violated_model(rhs: f64) -> ModelRepr {
+        let mut arena = ExprArena::new();
+        let x = arena.add(ExprNode::Variable {
+            name: "x".into(),
+            index: 0,
+            size: 1,
+            shape: vec![],
+        });
+        ModelRepr {
+            arena,
+            objective: x,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body: x,
+                sense: ConstraintSense::Ge,
+                rhs,
+                name: Some("c1".into()),
+            }],
+            variables: vec![VarInfo {
+                name: "x".into(),
+                var_type: VarType::Continuous,
+                offset: 0,
+                size: 1,
+                shape: vec![],
+                lb: vec![0.0],
+                ub: vec![0.0],
+            }],
+            n_vars: 1,
+        }
+    }
+
+    #[test]
+    fn test_fbbt_eps_violation_not_infeasible() {
+        // x = 0, constraint x >= 1e-9. The body misses the bound by 1e-9, well
+        // within the feasibility tolerance: FBBT must NOT collapse all bounds to
+        // empty (which would fabricate an unsound infeasibility certificate).
+        let model = make_eps_violated_model(1e-9);
+        let bounds = fbbt(&model, 5, 1e-8);
+        assert!(
+            bounds[0].lo.is_finite() && bounds[0].hi.is_finite(),
+            "eps-scale violation must not be treated as infeasible"
+        );
+        // The variable stays pinned near its fixed value, not blown up to empty.
+        assert!(bounds[0].lo <= 1e-6 && bounds[0].hi >= -1e-6);
+    }
+
+    #[test]
+    fn test_fbbt_real_violation_is_infeasible() {
+        // x = 0, constraint x >= 0.5. The violation (0.5) exceeds the feasibility
+        // tolerance, so FBBT must still detect infeasibility and empty the bounds.
+        let model = make_eps_violated_model(0.5);
+        let bounds = fbbt(&model, 5, 1e-8);
+        assert!(
+            bounds.iter().all(|b| b.is_empty()),
+            "a violation beyond the feasibility tolerance must be infeasible"
+        );
     }
 }

--- a/crates/discopt-core/src/presolve/probing.rs
+++ b/crates/discopt-core/src/presolve/probing.rs
@@ -3,7 +3,7 @@
 //! For each binary variable, temporarily fix it to 0 and 1, run FBBT,
 //! and use the results to detect fixings, tightened bounds, and implications.
 
-use super::fbbt::{fbbt, Interval};
+use super::fbbt::{fbbt, Interval, FEAS_TOL};
 use crate::expr::{ModelRepr, VarType};
 
 /// Result of probing all binary variables.
@@ -55,14 +55,19 @@ pub fn probe_binary_vars(model: &ModelRepr, var_bounds: &[Interval]) -> ProbingR
         bounds_zero[i] = Interval::new(0.0, 0.0);
         let model_zero = make_probing_model(model, &bounds_zero);
         let result_zero = fbbt(&model_zero, max_fbbt_iter, fbbt_tol);
-        let infeasible_zero = result_zero.iter().any(|b| b.is_empty());
+        // Declare a fixing infeasible only when a bound is empty beyond the
+        // feasibility tolerance. An eps-scale inverted interval (e.g. from a
+        // GDP hull perspective residual) is numerical noise, not proof that
+        // the selector cannot take this value — treating it as such would fix
+        // the disjunction wrongly and yield an unsound bound.
+        let infeasible_zero = result_zero.iter().any(|b| b.is_empty_beyond(FEAS_TOL));
 
         // Probe y=1.
         let mut bounds_one = var_bounds.to_vec();
         bounds_one[i] = Interval::new(1.0, 1.0);
         let model_one = make_probing_model(model, &bounds_one);
         let result_one = fbbt(&model_one, max_fbbt_iter, fbbt_tol);
-        let infeasible_one = result_one.iter().any(|b| b.is_empty());
+        let infeasible_one = result_one.iter().any(|b| b.is_empty_beyond(FEAS_TOL));
 
         if infeasible_zero && infeasible_one {
             // Both infeasible — model is infeasible. Mark bounds as empty.
@@ -437,5 +442,149 @@ mod tests {
 
         // x should be tightened.
         assert!(result.tightened_bounds[0].hi <= 8.0 + 1e-8);
+    }
+
+    #[test]
+    fn test_probing_ignores_eps_residual() {
+        // x + 1e-9*y <= 0, with x fixed to [0, 0], y binary.
+        // Fixing y=1 makes the body 1e-9 — an eps-scale violation of the bound,
+        // exactly the shape of a GDP hull perspective residual at an integer
+        // face. This is feasible within tolerance and MUST NOT fix y=0; doing so
+        // would wrongly eliminate a disjunct and yield an unsound bound (#27a).
+        let mut arena = ExprArena::new();
+        let x = arena.add(ExprNode::Variable {
+            name: "x".into(),
+            index: 0,
+            size: 1,
+            shape: vec![],
+        });
+        let y = arena.add(ExprNode::Variable {
+            name: "y".into(),
+            index: 1,
+            size: 1,
+            shape: vec![],
+        });
+        let eps = arena.add(ExprNode::Constant(1e-9));
+        let prod = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Mul,
+            left: eps,
+            right: y,
+        });
+        let sum = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Add,
+            left: x,
+            right: prod,
+        });
+        let model = ModelRepr {
+            arena,
+            objective: x,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body: sum,
+                sense: ConstraintSense::Le,
+                rhs: 0.0,
+                name: Some("c1".into()),
+            }],
+            variables: vec![
+                VarInfo {
+                    name: "x".into(),
+                    var_type: VarType::Continuous,
+                    offset: 0,
+                    size: 1,
+                    shape: vec![],
+                    lb: vec![0.0],
+                    ub: vec![0.0],
+                },
+                VarInfo {
+                    name: "y".into(),
+                    var_type: VarType::Binary,
+                    offset: 1,
+                    size: 1,
+                    shape: vec![],
+                    lb: vec![0.0],
+                    ub: vec![1.0],
+                },
+            ],
+            n_vars: 2,
+        };
+
+        let var_bounds = vec![Interval::new(0.0, 0.0), Interval::new(0.0, 1.0)];
+        let result = probe_binary_vars(&model, &var_bounds);
+
+        // y must remain free: the eps-scale residual is not a real infeasibility.
+        assert!(
+            result.fixed_vars.is_empty(),
+            "eps-scale residual must not fix the binary selector"
+        );
+    }
+
+    #[test]
+    fn test_probing_fixes_on_real_violation() {
+        // x + 1.0*y <= 0, with x fixed to [0, 0], y binary.
+        // Fixing y=1 makes the body 1.0 — a violation well beyond the
+        // feasibility tolerance — so y must genuinely be fixed to 0.
+        let mut arena = ExprArena::new();
+        let x = arena.add(ExprNode::Variable {
+            name: "x".into(),
+            index: 0,
+            size: 1,
+            shape: vec![],
+        });
+        let y = arena.add(ExprNode::Variable {
+            name: "y".into(),
+            index: 1,
+            size: 1,
+            shape: vec![],
+        });
+        let one = arena.add(ExprNode::Constant(1.0));
+        let prod = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Mul,
+            left: one,
+            right: y,
+        });
+        let sum = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Add,
+            left: x,
+            right: prod,
+        });
+        let model = ModelRepr {
+            arena,
+            objective: x,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body: sum,
+                sense: ConstraintSense::Le,
+                rhs: 0.0,
+                name: Some("c1".into()),
+            }],
+            variables: vec![
+                VarInfo {
+                    name: "x".into(),
+                    var_type: VarType::Continuous,
+                    offset: 0,
+                    size: 1,
+                    shape: vec![],
+                    lb: vec![0.0],
+                    ub: vec![0.0],
+                },
+                VarInfo {
+                    name: "y".into(),
+                    var_type: VarType::Binary,
+                    offset: 1,
+                    size: 1,
+                    shape: vec![],
+                    lb: vec![0.0],
+                    ub: vec![1.0],
+                },
+            ],
+            n_vars: 2,
+        };
+
+        let var_bounds = vec![Interval::new(0.0, 0.0), Interval::new(0.0, 1.0)];
+        let result = probe_binary_vars(&model, &var_bounds);
+
+        assert_eq!(result.fixed_vars.len(), 1);
+        assert_eq!(result.fixed_vars[0].0, 1);
+        assert!((result.fixed_vars[0].1 - 0.0).abs() < 1e-15);
     }
 }

--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -478,17 +478,29 @@ def _tighten_univariate_quadratic_interval(
     lb: float,
     ub: float,
 ) -> Optional[tuple[float, float]]:
-    """Intersect [lb, ub] with the feasible set of a*x^2 + b*x <= rhs for a >= 0."""
+    """Intersect [lb, ub] with the feasible set of a*x^2 + b*x <= rhs for a >= 0.
+
+    Infeasibility is declared (``None``) only when the constraint is violated by
+    more than the feasibility tolerance. A sub-tolerance violation — e.g. the
+    O(eps) residual of an approximate GDP hull perspective — must not manufacture
+    a hard infeasibility here, because the ``None`` return is pruned upstream
+    without any tolerance check. The threshold is translated into each branch's
+    native units: a constant constraint compares ``rhs`` directly, while the
+    quadratic branch compares the discriminant, since the constraint violation of
+    ``a*x^2 + b*x <= rhs`` at its vertex equals ``-discriminant / (4a)`` (issue
+    #27a). Such residuals are deferred to the node NLP for exact validation.
+    """
     if abs(a) <= 1e-12:
         if abs(b) <= 1e-12:
-            return (lb, ub) if rhs >= -1e-12 else None
+            return (lb, ub) if rhs >= -_EMPTY_INTERVAL_FEAS_TOL else None
         bound = rhs / b
         if b > 0.0:
             return (lb, min(ub, bound))
         return (max(lb, bound), ub)
 
     discriminant = b * b + 4.0 * a * rhs
-    if discriminant < -1e-12:
+    # Vertex violation = -discriminant / (4a); infeasible only beyond tolerance.
+    if discriminant < -4.0 * a * _EMPTY_INTERVAL_FEAS_TOL:
         return None
     discriminant = max(discriminant, 0.0)
     sqrt_disc = float(np.sqrt(discriminant))
@@ -552,7 +564,11 @@ class SumOfSquaresUpperBoundRule(NonlinearBoundTighteningRule):
                 continue
 
             rhs = -constant_term
-            if rhs < -1e-12:
+            # A negative upper bound on a nonnegative sum of squares is genuine
+            # infeasibility only beyond the feasibility tolerance; a sub-tolerance
+            # excess (e.g. an eps-scale hull-perspective residual) is feasible
+            # within tolerance and must not be pruned (issue #27a).
+            if rhs < -_EMPTY_INTERVAL_FEAS_TOL:
                 _prove_infeasible(
                     self.name,
                     constraint,
@@ -700,7 +716,9 @@ class SqrtSumOfSquaresUpperBoundRule(NonlinearBoundTighteningRule):
                 continue
 
             rhs = -constant_term / sqrt_coeff
-            if rhs < -1e-12:
+            # Infeasible only beyond the feasibility tolerance (see issue #27a);
+            # a sub-tolerance excess is feasible within tolerance and deferred.
+            if rhs < -_EMPTY_INTERVAL_FEAS_TOL:
                 _prove_infeasible(
                     self.name,
                     constraint,
@@ -1290,7 +1308,10 @@ class QuadraticEqualityBoundsRule(NonlinearBoundTighteningRule):
         square_lb: float,
         square_ub: float,
     ) -> Optional[tuple[float, float]]:
-        if square_ub < -1e-12:
+        # A negative upper bound on x**2 is infeasible only beyond the
+        # feasibility tolerance; a sub-tolerance residual (e.g. eps-scale hull
+        # perspective) is feasible within tolerance and deferred (issue #27a).
+        if square_ub < -_EMPTY_INTERVAL_FEAS_TOL:
             return None
         square_lb = max(0.0, square_lb)
         square_ub = max(0.0, square_ub)
@@ -1535,7 +1556,9 @@ class SquareDifferenceLowerBoundRule(NonlinearBoundTighteningRule):
                 rhs_lb += coeff * sq_lb
                 rhs_ub += coeff * sq_ub
 
-            if rhs_ub < -1e-12:
+            # Infeasible only beyond the feasibility tolerance (issue #27a); a
+            # sub-tolerance residual is feasible within tolerance and deferred.
+            if rhs_ub < -_EMPTY_INTERVAL_FEAS_TOL:
                 _prove_infeasible(
                     self.name,
                     constraint,
@@ -1544,7 +1567,7 @@ class SquareDifferenceLowerBoundRule(NonlinearBoundTighteningRule):
 
             feasible_square_lb = max(0.0, rhs_lb / target_scale)
             feasible_square_ub = max(0.0, rhs_ub / target_scale)
-            if feasible_square_lb > feasible_square_ub + 1e-12:
+            if feasible_square_lb > feasible_square_ub + _EMPTY_INTERVAL_FEAS_TOL:
                 _prove_infeasible(
                     self.name,
                     constraint,

--- a/python/tests/test_nonlinear_bound_tightening_tol.py
+++ b/python/tests/test_nonlinear_bound_tightening_tol.py
@@ -1,0 +1,58 @@
+"""Feasibility-tolerance behavior of nonlinear bound-tightening infeasibility guards.
+
+Regression for issue #27a (Linux-only manifestation). The GDP hull perspective
+reformulation is an O(eps) approximation at the integer faces, so constraint
+bodies carry an eps-scale residual. Several bound-tightening rules previously
+declared *hard* infeasibility from a residual as small as 1e-12 (a numeric-noise
+floor), which on some platforms tipped a feasible problem into a spurious prune
+and certified a wrong optimum. The guards now declare infeasibility only when the
+constraint is violated by more than the feasibility tolerance; sub-tolerance
+violations are deferred to the node NLP.
+
+These tests exercise the guard math directly, so they are deterministic across
+platforms (unlike the end-to-end solve, which only tripped on Linux numerics).
+"""
+
+from __future__ import annotations
+
+from discopt._jax.nonlinear_bound_tightening import (
+    _EMPTY_INTERVAL_FEAS_TOL,
+    _tighten_univariate_quadratic_interval,
+)
+
+TOL = _EMPTY_INTERVAL_FEAS_TOL
+
+
+class TestQuadraticIntervalTolerance:
+    def test_subtolerance_vertex_violation_is_not_infeasible(self):
+        # x**2 <= -r with 0 < r < TOL: the true min (0) exceeds rhs by r, a
+        # sub-tolerance violation. Must NOT prune; returns the degenerate vertex.
+        r = 0.5 * TOL
+        interval = _tighten_univariate_quadratic_interval(1.0, 0.0, -r, -3.0, 3.0)
+        assert interval is not None
+        lo, hi = interval
+        # Vertex is x = 0; clamped discriminant gives a (near-)degenerate box there.
+        assert abs(lo) <= 1e-6
+        assert abs(hi) <= 1e-6
+
+    def test_supertolerance_vertex_violation_is_infeasible(self):
+        # Violation well beyond tolerance is still a genuine infeasibility.
+        interval = _tighten_univariate_quadratic_interval(1.0, 0.0, -1e-3, -3.0, 3.0)
+        assert interval is None
+
+    def test_feasible_quadratic_unchanged(self):
+        # x**2 <= 4 over [-3, 3] tightens to [-2, 2].
+        interval = _tighten_univariate_quadratic_interval(1.0, 0.0, 4.0, -3.0, 3.0)
+        assert interval is not None
+        lo, hi = interval
+        assert lo == -2.0
+        assert hi == 2.0
+
+    def test_constant_constraint_subtolerance_is_feasible(self):
+        # Degenerate "0 <= rhs" with rhs a hair negative (within tol): not pruned.
+        interval = _tighten_univariate_quadratic_interval(0.0, 0.0, -0.5 * TOL, -3.0, 3.0)
+        assert interval == (-3.0, 3.0)
+
+    def test_constant_constraint_supertolerance_is_infeasible(self):
+        interval = _tighten_univariate_quadratic_interval(0.0, 0.0, -1e-3, -3.0, 3.0)
+        assert interval is None


### PR DESCRIPTION
## Summary

Fixes an **unsound optimality certificate** on GDP hull-reformulated models: the
solver could return `status=optimal` with a valid lower bound that *exceeds* the
true optimum.

On the piecewise regression `f(x) = (x>=0) ? (x-1)²+1 : (x+1)²+2` (global min
**1.0** at x=1, else-branch min 2.0), the solver certified obj=2.0 / bound=2.0 /
gap=0 — a valid lower bound of 2.0 on a problem whose true optimum is 1.0. This
surfaced on Linux CI but not macOS.

## Root cause

The GDP hull perspective reformulation `y · f(v / y)` is clamped as `y + eps`
(eps=1e-8), leaving **eps-scale residuals at integer faces**. FBBT
(`fbbt`, `fbbt_with_cutoff`) and the binary **probing** presolve pass declared a
constraint infeasible whenever a forward-propagated interval intersection was
empty in the *strict* sense (`lo > hi`), with **no tolerance**. The eps residual
tripped that check, so probing fixed the then-branch selector `y0 = 0` at the
root — eliminating the branch containing the global optimum **before the B&B tree
was built** — and the remaining else-branch was certified optimal.

Whether the eps residual crossed the strict threshold depended on platform
floating-point rounding, which is why the false certificate appeared on Linux but
not macOS (where the feasibility pump happened to also find obj=1.0 and masked it).

## Fix

- Add `Interval::is_empty_beyond(tol)` and `FEAS_TOL = 1e-6` (matching the
  solver's absolute feasibility tolerance, and deliberately larger than the
  ~1e-8 FBBT convergence tolerance).
- Use it at **every** point where FBBT or probing concludes infeasibility, so a
  sub-tolerance residual is feasible and only a genuine violation prunes.

The then-branch now survives presolve on both platforms and the global optimum of
1.0 is reached.

Also retains the Python-layer hardening for the same class of issue
(`SeparableQuadraticUpperBoundRule` and friends declare infeasibility at the
feasibility tolerance and snap degenerate boxes instead of pruning).

## Tests

- Rust: `test_is_empty_beyond_tolerance`, `test_fbbt_eps_violation_not_infeasible`,
  `test_fbbt_real_violation_is_infeasible`, `test_probing_ignores_eps_residual`,
  `test_probing_fixes_on_real_violation` (eps-residual vs. real-violation at both
  the FBBT and probing layers). 160 presolve unit tests pass; clippy clean.
- Python: `test_gdp.py::TestIfElse::test_solve_piecewise_reaches_global_optimum`
  plus the full suite (2981 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
