### PR TITLE
fix(gdp): deterministic root binary-seed enumeration for disjunct cover

### DIFF
--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -468,11 +468,11 @@ def enumerate_binary_seeds_subnlp(
                 evaluator=evaluator,
                 integer_tol=integer_tol,
             )
-            logger.warning(
-                "GDPENUM combo=%s start=%s -> %s",
-                combo,
-                "zero" if base is zero_start else "relax",
-                "None" if found is None else f"obj={found[1]:.6g}",
+            print(
+                f"GDPENUM combo={combo} "
+                f"start={'zero' if base is zero_start else 'relax'} -> "
+                f"{'None' if found is None else f'obj={found[1]:.6g}'}",
+                flush=True,
             )
             if found is not None:
                 results.append(found)

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -9,7 +9,6 @@ and re-solves the resulting NLP.
 from __future__ import annotations
 
 import itertools
-import logging
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
@@ -18,8 +17,6 @@ import numpy as np
 from discopt._jax.nlp_evaluator import NLPEvaluator
 from discopt.modeling.core import Model, VarType
 from discopt.solvers import NLPResult, SolveStatus
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -467,12 +464,6 @@ def enumerate_binary_seeds_subnlp(
                 nlp_options=nlp_options,
                 evaluator=evaluator,
                 integer_tol=integer_tol,
-            )
-            print(
-                f"GDPENUM combo={combo} "
-                f"start={'zero' if base is zero_start else 'relax'} -> "
-                f"{'None' if found is None else f'obj={found[1]:.6g}'}",
-                flush=True,
             )
             if found is not None:
                 results.append(found)

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -9,7 +9,6 @@ and re-solves the resulting NLP.
 from __future__ import annotations
 
 import itertools
-import logging
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
@@ -18,8 +17,6 @@ import numpy as np
 from discopt._jax.nlp_evaluator import NLPEvaluator
 from discopt.modeling.core import Model, VarType
 from discopt.solvers import NLPResult, SolveStatus
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -399,9 +396,15 @@ def enumerate_binary_seeds_subnlp(
     regardless of which branch the relaxation happened to lock onto. Seeds whose
     fixing is infeasible simply yield no sub-NLP solution and are dropped.
 
-    The cost is bounded to ``2 ** max_binaries`` sub-NLP solves; when the model
-    has more than ``max_binaries`` binaries the enumeration is skipped (an empty
-    list is returned) to avoid combinatorial blow-up, leaving the regular
+    Each disjunct is attempted from two continuous starts — the relaxation point
+    and a neutral bound midpoint. The disaggregated perspective variables in the
+    relaxation point carry the *settled* disjunct's values, a poor (and
+    platform-sensitively convergent) start for the others; the second start
+    makes escaping to the right disjunct robust across platforms.
+
+    The cost is bounded to ``2 ** (max_binaries + 1)`` sub-NLP solves; when the
+    model has more than ``max_binaries`` binaries the enumeration is skipped (an
+    empty list is returned) to avoid combinatorial blow-up, leaving the regular
     rounding/pump heuristics in charge. Intended for a single root invocation.
 
     Args:
@@ -459,12 +462,6 @@ def enumerate_binary_seeds_subnlp(
                 nlp_options=nlp_options,
                 evaluator=evaluator,
                 integer_tol=integer_tol,
-            )
-            logger.warning(
-                "GDPENUM combo=%s start=%s -> %s",
-                combo,
-                "relax" if base is x_relax else "mid",
-                "None" if found is None else f"obj={found[1]:.6g}",
             )
             if found is not None:
                 results.append(found)

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -8,6 +8,7 @@ and re-solves the resulting NLP.
 
 from __future__ import annotations
 
+import itertools
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
@@ -365,3 +366,78 @@ def subnlp(
     # Recompute objective at the snapped point to keep it consistent.
     obj = float(evaluator.evaluate_objective(x_out))
     return x_out, obj
+
+
+def enumerate_binary_seeds_subnlp(
+    model: Model,
+    x_relax: np.ndarray,
+    backend: Optional[Callable] = None,
+    nlp_options: Optional[dict] = None,
+    evaluator: Optional[NLPEvaluator] = None,
+    max_binaries: int = 4,
+    integer_tol: float = 1e-5,
+) -> list[tuple[np.ndarray, float]]:
+    """Root primal heuristic: enumerate roundings of the fractional binaries.
+
+    A single nearest-rounding :func:`subnlp` seed lands in whichever disjunct
+    the relaxation's fractional selector happens to round toward. For a
+    nonconvex disjunctive (GDP) model that choice is decided by tiny,
+    platform-dependent floating-point differences in the relaxation solution —
+    so the global optimum is found on one platform and missed on another, an
+    unwanted nondeterminism.
+
+    This heuristic removes that dependence at the root: it takes the (capped)
+    set of binary variables that are fractional in ``x_relax`` and enumerates
+    *all* 0/1 assignments over them, solving a fixed-integer sub-NLP from each.
+    For a single disjunction the enumeration covers every disjunct, so the
+    optimal one is always tried regardless of which way the relaxation leaned.
+
+    The cost is bounded to ``2 ** max_binaries`` sub-NLP solves; when more than
+    ``max_binaries`` binaries are fractional the enumeration is skipped (an
+    empty list is returned) to avoid combinatorial blow-up, leaving the regular
+    rounding/pump heuristics in charge.
+
+    Args:
+        model: The optimization model.
+        x_relax: Relaxation point at the root node.
+        backend: ``solve_nlp(evaluator, x0, options=...)`` callable; resolved to
+            ``get_nlp_solver("auto")`` if None.
+        nlp_options: Options forwarded to the NLP backend.
+        evaluator: Pre-built evaluator; one is constructed if omitted.
+        max_binaries: Maximum number of fractional binaries to enumerate over.
+        integer_tol: Tolerance for deciding a binary is fractional.
+
+    Returns:
+        Every feasible ``(x, obj)`` found across the enumerated seeds (possibly
+        empty). The caller injects each as an incumbent candidate and lets the
+        B&B tree keep the best, so this is agnostic to the objective sense.
+    """
+    int_mask = _get_integer_mask(model)
+    if not np.any(int_mask):
+        return []
+
+    lb, ub = _get_variable_bounds(model)
+    x_relax = np.asarray(x_relax, dtype=np.float64)
+
+    # Binary variables: integer-typed with [0, 1] bounds.
+    binary = int_mask & (lb >= -1e-9) & (ub <= 1.0 + 1e-9)
+    frac = [i for i in np.nonzero(binary)[0] if integer_tol < x_relax[i] < 1.0 - integer_tol]
+    if not frac or len(frac) > max_binaries:
+        return []
+
+    results: list[tuple[np.ndarray, float]] = []
+    for combo in itertools.product((0.0, 1.0), repeat=len(frac)):
+        seed = x_relax.copy()
+        for idx, value in zip(frac, combo):
+            seed[idx] = value
+        found = subnlp(
+            model,
+            seed,
+            backend=backend,
+            nlp_options=nlp_options,
+            evaluator=evaluator,
+            integer_tol=integer_tol,
+        )
+        if found is not None:
+            results.append(found)
+    return results

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -9,6 +9,7 @@ and re-solves the resulting NLP.
 from __future__ import annotations
 
 import itertools
+import logging
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
@@ -17,6 +18,8 @@ import numpy as np
 from discopt._jax.nlp_evaluator import NLPEvaluator
 from discopt.modeling.core import Model, VarType
 from discopt.solvers import NLPResult, SolveStatus
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -438,16 +441,18 @@ def enumerate_binary_seeds_subnlp(
         return []
 
     # Continuous (non-binary) base seeds. The relaxation point is a good start
-    # for whichever disjunct it settled in, but a *bad* one for the others —
-    # the disaggregated perspective variables carry the wrong disjunct's values,
-    # which on some platforms traps the NLP at the relaxation's local optimum.
-    # Add a neutral bound-midpoint start so escaping to the right disjunct does
-    # not depend on platform-sensitive convergence from the stale start.
+    # for whichever disjunct it settled in, but a *bad* one for the others: the
+    # disaggregated perspective variables carry the settled disjunct's (nonzero)
+    # values, so for the other disjuncts the NLP must restore them toward 0 —
+    # an ill-conditioned step (the hull perspective divides by y_k + eps) where
+    # the solver can stall nondeterministically under load. A zero-continuous
+    # start sidesteps that: the inactive disaggregated variables begin at their
+    # feasible 0, leaving only the active (convex) disjunct to solve, which
+    # converges robustly regardless of platform or CPU contention.
     cont_mask = ~np.isin(np.arange(len(x_relax)), binary_idx)
-    _spc = 1e6
-    midpoint = x_relax.copy()
-    midpoint[cont_mask] = 0.5 * (np.clip(lb, -_spc, _spc) + np.clip(ub, -_spc, _spc))[cont_mask]
-    base_seeds = [x_relax, midpoint]
+    zero_start = x_relax.copy()
+    zero_start[cont_mask] = np.clip(0.0, lb, ub)[cont_mask]
+    base_seeds = [zero_start, x_relax]
 
     results: list[tuple[np.ndarray, float]] = []
     for combo in itertools.product((0.0, 1.0), repeat=len(binary_idx)):
@@ -462,6 +467,12 @@ def enumerate_binary_seeds_subnlp(
                 nlp_options=nlp_options,
                 evaluator=evaluator,
                 integer_tol=integer_tol,
+            )
+            logger.warning(
+                "GDPENUM combo=%s start=%s -> %s",
+                combo,
+                "zero" if base is zero_start else "relax",
+                "None" if found is None else f"obj={found[1]:.6g}",
             )
             if found is not None:
                 results.append(found)

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -9,6 +9,7 @@ and re-solves the resulting NLP.
 from __future__ import annotations
 
 import itertools
+import logging
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
@@ -17,6 +18,8 @@ import numpy as np
 from discopt._jax.nlp_evaluator import NLPEvaluator
 from discopt.modeling.core import Model, VarType
 from discopt.solvers import NLPResult, SolveStatus
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -431,19 +434,38 @@ def enumerate_binary_seeds_subnlp(
     if not binary_idx or len(binary_idx) > max_binaries:
         return []
 
+    # Continuous (non-binary) base seeds. The relaxation point is a good start
+    # for whichever disjunct it settled in, but a *bad* one for the others —
+    # the disaggregated perspective variables carry the wrong disjunct's values,
+    # which on some platforms traps the NLP at the relaxation's local optimum.
+    # Add a neutral bound-midpoint start so escaping to the right disjunct does
+    # not depend on platform-sensitive convergence from the stale start.
+    cont_mask = ~np.isin(np.arange(len(x_relax)), binary_idx)
+    _spc = 1e6
+    midpoint = x_relax.copy()
+    midpoint[cont_mask] = 0.5 * (np.clip(lb, -_spc, _spc) + np.clip(ub, -_spc, _spc))[cont_mask]
+    base_seeds = [x_relax, midpoint]
+
     results: list[tuple[np.ndarray, float]] = []
     for combo in itertools.product((0.0, 1.0), repeat=len(binary_idx)):
-        seed = x_relax.copy()
-        for idx, value in zip(binary_idx, combo):
-            seed[idx] = value
-        found = subnlp(
-            model,
-            seed,
-            backend=backend,
-            nlp_options=nlp_options,
-            evaluator=evaluator,
-            integer_tol=integer_tol,
-        )
-        if found is not None:
-            results.append(found)
+        for base in base_seeds:
+            seed = base.copy()
+            for idx, value in zip(binary_idx, combo):
+                seed[idx] = value
+            found = subnlp(
+                model,
+                seed,
+                backend=backend,
+                nlp_options=nlp_options,
+                evaluator=evaluator,
+                integer_tol=integer_tol,
+            )
+            logger.warning(
+                "GDPENUM combo=%s start=%s -> %s",
+                combo,
+                "relax" if base is x_relax else "mid",
+                "None" if found is None else f"obj={found[1]:.6g}",
+            )
+            if found is not None:
+                results.append(found)
     return results

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -377,35 +377,40 @@ def enumerate_binary_seeds_subnlp(
     max_binaries: int = 4,
     integer_tol: float = 1e-5,
 ) -> list[tuple[np.ndarray, float]]:
-    """Root primal heuristic: enumerate roundings of the fractional binaries.
+    """Root primal heuristic: enumerate every 0/1 assignment of the binaries.
 
     A single nearest-rounding :func:`subnlp` seed lands in whichever disjunct
-    the relaxation's fractional selector happens to round toward. For a
-    nonconvex disjunctive (GDP) model that choice is decided by tiny,
-    platform-dependent floating-point differences in the relaxation solution —
-    so the global optimum is found on one platform and missed on another, an
-    unwanted nondeterminism.
+    the relaxation's selector points at — and for a nonconvex disjunctive (GDP)
+    model the relaxation can return an *integer-feasible but only locally
+    optimal* selector (e.g. the wrong branch of an ``if_else``). Which branch it
+    settles on is decided by tiny, platform-dependent floating-point differences
+    in the relaxation solution, so the global optimum is found on one platform
+    and missed on another — unwanted nondeterminism. Critically the offending
+    selector is usually *not* fractional: the relaxation reports it at a clean
+    0/1, so rounding heuristics never reconsider it.
 
-    This heuristic removes that dependence at the root: it takes the (capped)
-    set of binary variables that are fractional in ``x_relax`` and enumerates
-    *all* 0/1 assignments over them, solving a fixed-integer sub-NLP from each.
-    For a single disjunction the enumeration covers every disjunct, so the
-    optimal one is always tried regardless of which way the relaxation leaned.
+    This heuristic removes that dependence at the root: it enumerates *all* 0/1
+    assignments over the (capped) set of binary variables — fractional or not —
+    and solves a fixed-integer sub-NLP from each. For a single disjunction the
+    enumeration covers every disjunct, so the optimal one is always tried
+    regardless of which branch the relaxation happened to lock onto. Seeds whose
+    fixing is infeasible simply yield no sub-NLP solution and are dropped.
 
-    The cost is bounded to ``2 ** max_binaries`` sub-NLP solves; when more than
-    ``max_binaries`` binaries are fractional the enumeration is skipped (an
-    empty list is returned) to avoid combinatorial blow-up, leaving the regular
-    rounding/pump heuristics in charge.
+    The cost is bounded to ``2 ** max_binaries`` sub-NLP solves; when the model
+    has more than ``max_binaries`` binaries the enumeration is skipped (an empty
+    list is returned) to avoid combinatorial blow-up, leaving the regular
+    rounding/pump heuristics in charge. Intended for a single root invocation.
 
     Args:
         model: The optimization model.
-        x_relax: Relaxation point at the root node.
+        x_relax: Relaxation point at the root node (used as the continuous seed).
         backend: ``solve_nlp(evaluator, x0, options=...)`` callable; resolved to
             ``get_nlp_solver("auto")`` if None.
         nlp_options: Options forwarded to the NLP backend.
         evaluator: Pre-built evaluator; one is constructed if omitted.
-        max_binaries: Maximum number of fractional binaries to enumerate over.
-        integer_tol: Tolerance for deciding a binary is fractional.
+        max_binaries: Maximum number of binaries to enumerate over; above this
+            the enumeration is skipped entirely.
+        integer_tol: Integrality tolerance forwarded to :func:`subnlp`.
 
     Returns:
         Every feasible ``(x, obj)`` found across the enumerated seeds (possibly
@@ -419,16 +424,17 @@ def enumerate_binary_seeds_subnlp(
     lb, ub = _get_variable_bounds(model)
     x_relax = np.asarray(x_relax, dtype=np.float64)
 
-    # Binary variables: integer-typed with [0, 1] bounds.
-    binary = int_mask & (lb >= -1e-9) & (ub <= 1.0 + 1e-9)
-    frac = [i for i in np.nonzero(binary)[0] if integer_tol < x_relax[i] < 1.0 - integer_tol]
-    if not frac or len(frac) > max_binaries:
+    # Binary variables: integer-typed with [0, 1] bounds. Enumerate over *all*
+    # of them, not just the fractional ones — the selector that traps the
+    # relaxation in the wrong disjunct is typically reported at a clean 0/1.
+    binary_idx = [i for i in np.nonzero(int_mask)[0] if lb[i] >= -1e-9 and ub[i] <= 1.0 + 1e-9]
+    if not binary_idx or len(binary_idx) > max_binaries:
         return []
 
     results: list[tuple[np.ndarray, float]] = []
-    for combo in itertools.product((0.0, 1.0), repeat=len(frac)):
+    for combo in itertools.product((0.0, 1.0), repeat=len(binary_idx)):
         seed = x_relax.copy()
-        for idx, value in zip(frac, combo):
+        for idx, value in zip(binary_idx, combo):
             seed[idx] = value
         found = subnlp(
             model,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3110,11 +3110,6 @@ def solve_model(
             except Exception as _e:
                 logger.debug("enumerate_binary_seeds_subnlp raised: %s", _e)
                 _enum_results = []
-            print(  # TEMP-GDPENUM: remove after Linux determinism confirmed
-                f"GDPENUM-GUARD n_cands={len(_enum_cands)} "
-                f"results={[round(o, 6) for _, o in _enum_results]}",
-                flush=True,
-            )
             _subnlp_calls += len(_enum_results)
             for _x_en, _obj_en in _enum_results:
                 _subnlp_feasible += 1

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3074,12 +3074,6 @@ def solve_model(
         # (capped) set of fractional binaries and solve a fixed-integer subnlp
         # from each, so the optimal disjunct is always tried regardless of
         # platform FP. Bounded to 2**max_binaries solves; skipped above the cap.
-        if iteration == 0:
-            print(
-                f"GDPENUM-GUARD iter0 backend={_subnlp_backend_fn is not None} "
-                f"convex={_model_is_convex} calls={_subnlp_calls}/{subnlp_max_calls}",
-                flush=True,
-            )
         if (
             iteration == 0
             and _subnlp_backend_fn is not None
@@ -3088,36 +3082,46 @@ def solve_model(
         ):
             from discopt._jax.primal_heuristics import enumerate_binary_seeds_subnlp
 
+            # Seed the enumeration from the best root relaxation point when one
+            # produced a usable bound; otherwise fall back to the bound midpoint.
+            # The enumeration sets the binaries explicitly and starts each
+            # disjunct's continuous NLP from zero, so it does not actually need a
+            # good relaxation point — and on some platforms the root relaxation
+            # returns only sentinel bounds (no usable candidate), which must not
+            # silently disable this heuristic.
             _enum_cands = [
                 (i, float(result_lbs[i]))
                 for i in range(n_batch)
                 if result_lbs[i] < _SENTINEL_THRESHOLD and np.isfinite(result_lbs[i])
             ]
             _enum_cands.sort(key=lambda t: t[1])
-            print(f"GDPENUM-GUARD n_cands={len(_enum_cands)}", flush=True)
             if _enum_cands:
                 _enum_seed = result_sols[_enum_cands[0][0]]
-                try:
-                    _enum_results = enumerate_binary_seeds_subnlp(
-                        model,
-                        _enum_seed,
-                        backend=_subnlp_backend_fn,
-                        nlp_options=subnlp_options,
-                        evaluator=evaluator,
-                    )
-                except Exception as _e:
-                    print(f"GDPENUM-GUARD raised: {_e!r}", flush=True)
-                    logger.debug("enumerate_binary_seeds_subnlp raised: %s", _e)
-                    _enum_results = []
-                _enum_objs = [round(o, 6) for _, o in _enum_results]
-                print(f"GDPENUM-GUARD results={_enum_objs}", flush=True)
-                _subnlp_calls += len(_enum_results)
-                for _x_en, _obj_en in _enum_results:
-                    _subnlp_feasible += 1
-                    if np.isfinite(_obj_en) and _obj_en < _SENTINEL_THRESHOLD:
-                        tree.inject_incumbent(_x_en.copy(), float(_obj_en))
-                        _subnlp_incumbent_updates += 1
-                        logger.info("SubNLP enum incumbent: obj=%.6g", _obj_en)
+            else:
+                _enum_seed = 0.5 * (np.clip(lb, -_SPC, _SPC) + np.clip(ub, -_SPC, _SPC))
+            try:
+                _enum_results = enumerate_binary_seeds_subnlp(
+                    model,
+                    _enum_seed,
+                    backend=_subnlp_backend_fn,
+                    nlp_options=subnlp_options,
+                    evaluator=evaluator,
+                )
+            except Exception as _e:
+                logger.debug("enumerate_binary_seeds_subnlp raised: %s", _e)
+                _enum_results = []
+            print(  # TEMP-GDPENUM: remove after Linux determinism confirmed
+                f"GDPENUM-GUARD n_cands={len(_enum_cands)} "
+                f"results={[round(o, 6) for _, o in _enum_results]}",
+                flush=True,
+            )
+            _subnlp_calls += len(_enum_results)
+            for _x_en, _obj_en in _enum_results:
+                _subnlp_feasible += 1
+                if np.isfinite(_obj_en) and _obj_en < _SENTINEL_THRESHOLD:
+                    tree.inject_incumbent(_x_en.copy(), float(_obj_en))
+                    _subnlp_incumbent_updates += 1
+                    logger.info("SubNLP enum incumbent: obj=%.6g", _obj_en)
 
         # --- User callbacks: lazy constraints and incumbent filtering ---
         if lazy_constraints is not None or incumbent_callback is not None:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3074,6 +3074,12 @@ def solve_model(
         # (capped) set of fractional binaries and solve a fixed-integer subnlp
         # from each, so the optimal disjunct is always tried regardless of
         # platform FP. Bounded to 2**max_binaries solves; skipped above the cap.
+        if iteration == 0:
+            print(
+                f"GDPENUM-GUARD iter0 backend={_subnlp_backend_fn is not None} "
+                f"convex={_model_is_convex} calls={_subnlp_calls}/{subnlp_max_calls}",
+                flush=True,
+            )
         if (
             iteration == 0
             and _subnlp_backend_fn is not None
@@ -3088,6 +3094,7 @@ def solve_model(
                 if result_lbs[i] < _SENTINEL_THRESHOLD and np.isfinite(result_lbs[i])
             ]
             _enum_cands.sort(key=lambda t: t[1])
+            print(f"GDPENUM-GUARD n_cands={len(_enum_cands)}", flush=True)
             if _enum_cands:
                 _enum_seed = result_sols[_enum_cands[0][0]]
                 try:
@@ -3099,8 +3106,11 @@ def solve_model(
                         evaluator=evaluator,
                     )
                 except Exception as _e:
+                    print(f"GDPENUM-GUARD raised: {_e!r}", flush=True)
                     logger.debug("enumerate_binary_seeds_subnlp raised: %s", _e)
                     _enum_results = []
+                _enum_objs = [round(o, 6) for _, o in _enum_results]
+                print(f"GDPENUM-GUARD results={_enum_objs}", flush=True)
                 _subnlp_calls += len(_enum_results)
                 for _x_en, _obj_en in _enum_results:
                     _subnlp_feasible += 1

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3066,6 +3066,49 @@ def solve_model(
                         _subnlp_incumbent_updates += 1
                         logger.info("SubNLP incumbent: obj=%.6g (iter=%d)", _obj_sn, iteration)
 
+        # --- Root binary-seed enumeration (deterministic disjunct cover) ---
+        # A single nearest-rounding subnlp lands in whichever disjunct the
+        # relaxation's fractional selector happens to round toward, a choice
+        # decided by platform-dependent floating point for nonconvex GDP
+        # models. At the root only, enumerate every 0/1 assignment over the
+        # (capped) set of fractional binaries and solve a fixed-integer subnlp
+        # from each, so the optimal disjunct is always tried regardless of
+        # platform FP. Bounded to 2**max_binaries solves; skipped above the cap.
+        if (
+            iteration == 0
+            and _subnlp_backend_fn is not None
+            and not _model_is_convex
+            and _subnlp_calls < subnlp_max_calls
+        ):
+            from discopt._jax.primal_heuristics import enumerate_binary_seeds_subnlp
+
+            _enum_cands = [
+                (i, float(result_lbs[i]))
+                for i in range(n_batch)
+                if result_lbs[i] < _SENTINEL_THRESHOLD and np.isfinite(result_lbs[i])
+            ]
+            _enum_cands.sort(key=lambda t: t[1])
+            if _enum_cands:
+                _enum_seed = result_sols[_enum_cands[0][0]]
+                try:
+                    _enum_results = enumerate_binary_seeds_subnlp(
+                        model,
+                        _enum_seed,
+                        backend=_subnlp_backend_fn,
+                        nlp_options=subnlp_options,
+                        evaluator=evaluator,
+                    )
+                except Exception as _e:
+                    logger.debug("enumerate_binary_seeds_subnlp raised: %s", _e)
+                    _enum_results = []
+                _subnlp_calls += len(_enum_results)
+                for _x_en, _obj_en in _enum_results:
+                    _subnlp_feasible += 1
+                    if np.isfinite(_obj_en) and _obj_en < _SENTINEL_THRESHOLD:
+                        tree.inject_incumbent(_x_en.copy(), float(_obj_en))
+                        _subnlp_incumbent_updates += 1
+                        logger.info("SubNLP enum incumbent: obj=%.6g", _obj_en)
+
         # --- User callbacks: lazy constraints and incumbent filtering ---
         if lazy_constraints is not None or incumbent_callback is not None:
             _invoke_pre_import_callbacks(

--- a/python/tests/test_primal_heuristics.py
+++ b/python/tests/test_primal_heuristics.py
@@ -18,6 +18,7 @@ from discopt._jax.primal_heuristics import (  # noqa: E402
     _generate_starts,
     _get_integer_mask,
     _is_integer_feasible,
+    enumerate_binary_seeds_subnlp,
     feasibility_pump,
 )
 from discopt.modeling.core import Model  # noqa: E402
@@ -408,3 +409,60 @@ class TestIntegerMask:
         """Empty integer mask is always feasible."""
         mask = np.array([False, False])
         assert _is_integer_feasible(np.array([1.5, 2.5]), mask)
+
+
+# ─────────────────────────────────────────────────────────────
+# TestEnumerateBinarySeeds
+# ─────────────────────────────────────────────────────────────
+
+
+def _make_disjunctive_minlp() -> Model:
+    """min z*((x-1)^2+1) + (1-z)*((x+1)^2+2), x in [-3,3], z in {0,1}.
+
+    Two local optima: z=0 -> obj 2 at x=-1; z=1 -> obj 1 at x=1.
+    Global optimum is obj 1 at z=1. Nearest-rounding a fractional z<0.5
+    seed lands in the worse z=0 disjunct; enumeration must still find z=1.
+    """
+    m = Model("disjunctive")
+    x = m.continuous("x", lb=-3, ub=3)
+    z = m.binary("z")
+    m.minimize(z * ((x - 1) ** 2 + 1) + (1 - z) * ((x + 1) ** 2 + 2))
+    return m
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+class TestEnumerateBinarySeeds:
+    def test_finds_global_disjunct_regardless_of_seed(self):
+        """Both disjuncts are tried, so the global optimum is found whichever
+        way the fractional binary leans in the seed."""
+        m = _make_disjunctive_minlp()
+        # Flat order is [x, z]. Seed x at 0; vary the fractional selector so
+        # nearest rounding would pick the worse disjunct in one case.
+        for z_frac in (0.2, 0.8):
+            seed = np.array([0.0, z_frac])
+            results = enumerate_binary_seeds_subnlp(m, seed)
+            assert results, f"no feasible points for z_frac={z_frac}"
+            best = min(obj for _, obj in results)
+            assert best == pytest.approx(1.0, abs=1e-3)
+
+    def test_skips_when_binary_already_integral(self):
+        """No fractional binary -> nothing to enumerate -> empty list."""
+        m = _make_disjunctive_minlp()
+        seed = np.array([0.0, 0.0])
+        assert enumerate_binary_seeds_subnlp(m, seed) == []
+
+    def test_skips_above_cap(self):
+        """More fractional binaries than max_binaries -> skipped (empty list)."""
+        m = Model("many_binaries")
+        x = m.continuous("x", lb=-3, ub=3)
+        zs = [m.binary(f"z{i}") for i in range(5)]
+        m.minimize(x**2 + sum(zs))
+        seed = np.array([0.0, 0.5, 0.5, 0.5, 0.5, 0.5])
+        assert enumerate_binary_seeds_subnlp(m, seed, max_binaries=4) == []
+
+    def test_no_integers_returns_empty(self):
+        """Continuous-only model has no binaries to enumerate."""
+        m = _make_quadratic_nlp()
+        seed = np.array([0.0, 0.0])
+        assert enumerate_binary_seeds_subnlp(m, seed) == []

--- a/python/tests/test_primal_heuristics.py
+++ b/python/tests/test_primal_heuristics.py
@@ -435,22 +435,27 @@ def _make_disjunctive_minlp() -> Model:
 class TestEnumerateBinarySeeds:
     def test_finds_global_disjunct_regardless_of_seed(self):
         """Both disjuncts are tried, so the global optimum is found whichever
-        way the fractional binary leans in the seed."""
+        way the selector leans in the seed -- fractional or integral."""
         m = _make_disjunctive_minlp()
-        # Flat order is [x, z]. Seed x at 0; vary the fractional selector so
-        # nearest rounding would pick the worse disjunct in one case.
-        for z_frac in (0.2, 0.8):
-            seed = np.array([0.0, z_frac])
+        # Flat order is [x, z]. Vary the selector across fractional values and
+        # both clean integers; every case must still surface the z=1 optimum.
+        for z_val in (0.2, 0.8, 0.0, 1.0):
+            seed = np.array([0.0, z_val])
             results = enumerate_binary_seeds_subnlp(m, seed)
-            assert results, f"no feasible points for z_frac={z_frac}"
+            assert results, f"no feasible points for z={z_val}"
             best = min(obj for _, obj in results)
             assert best == pytest.approx(1.0, abs=1e-3)
 
-    def test_skips_when_binary_already_integral(self):
-        """No fractional binary -> nothing to enumerate -> empty list."""
+    def test_finds_global_from_wrong_integral_seed(self):
+        """The key robustness property: a clean-integral seed pinned to the
+        *worse* disjunct (z=0, obj 2) must still recover the z=1 global (obj 1).
+        This is the platform-FP case the heuristic exists to fix."""
         m = _make_disjunctive_minlp()
-        seed = np.array([0.0, 0.0])
-        assert enumerate_binary_seeds_subnlp(m, seed) == []
+        seed = np.array([-1.0, 0.0])  # integral selector at the wrong branch
+        results = enumerate_binary_seeds_subnlp(m, seed)
+        objs = sorted(obj for _, obj in results)
+        assert objs, "enumeration returned no feasible points"
+        assert objs[0] == pytest.approx(1.0, abs=1e-3)
 
     def test_skips_above_cap(self):
         """More fractional binaries than max_binaries -> skipped (empty list)."""


### PR DESCRIPTION
## Summary

Makes the GDP root primal heuristic **deterministic** so the global optimum of a
disjunctive (GDP) model is found regardless of platform floating point.

Follow-up to #108 (which fixed the unsound FBBT/probing infeasibility certificate).
With #108 the bound is always sound, but `test_solve_piecewise_reaches_global_optimum`
remained **flaky under parallel CI load**: the nearest-rounding subnlp seed lands in
whichever disjunct the relaxation's selector happens to round toward, decided by tiny
platform-dependent FP differences in the root relaxation. When it rounds to the wrong
disjunct the solver returns an integer-feasible local optimum (obj=2.0) and must then
race B&B to the true leaf within the time limit — a race it loses under load.

## Change

New root-only heuristic `enumerate_binary_seeds_subnlp` (in `_jax/primal_heuristics.py`):
at the root, enumerate **every** 0/1 assignment over the (capped) set of binaries and
solve a fixed-integer sub-NLP from each, starting each disjunct's continuous NLP from a
well-conditioned zero start as well as the relaxation point. For a single disjunction this
covers every disjunct, so the optimal one is always tried — no dependence on which way the
relaxation leaned.

- Bounded to `2 ** (max_binaries + 1)` solves (`max_binaries=4`); skipped above the cap so
  the regular rounding/pump heuristics stay in charge for larger integer problems.
- Wired into `solve_model` at `iteration == 0`, non-convex models only, guarded by the
  existing `subnlp_max_calls` budget. Each feasible `(x, obj)` is injected via
  `tree.inject_incumbent`, which keeps the best (sense-agnostic).
- **Critical Linux fix**: the enumeration seeds from the best root-relaxation point when one
  produced a usable bound, but on some platforms the root relaxation returns only sentinel
  bounds (no usable candidate). Previously that silently disabled the heuristic on Linux
  (diagnosed via `n_cands=0` — byte-identical Linux failures proved the code never ran).
  It now falls back to the bound midpoint so the enumeration **always** runs.
- Pure-Python; no Rust or ABI changes.

## Validation

- `test_solve_piecewise_reaches_global_optimum` now returns obj=1.0 deterministically
  (verified locally and on the previously-flaky "Python fast" Linux CI job, twice).
- New unit tests `TestEnumerateBinarySeeds` prove the global disjunct is found even when
  the seed leans toward the worse disjunct, plus the cap / no-binary skip paths.
- Benchmark smoke suite: `incorrect_count == 0` (correctness gate holds).
- `ruff check` / `ruff format` / `mypy` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
