### PR TITLE
test(convexity): three-axis SUSPECT head-to-head + monotonicity API

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -40,6 +40,7 @@ parts:
       - file: notebooks/warm_start
       - file: notebooks/convex_fast_path
       - file: notebooks/convexity_detection
+      - file: notebooks/suspect_head_to_head
       - file: notebooks/nlp_bb
       - file: notebooks/export_formats
       - file: notebooks/callbacks

--- a/docs/notebooks/suspect_head_to_head.ipynb
+++ b/docs/notebooks/suspect_head_to_head.ipynb
@@ -1,0 +1,396 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e5cb11fc",
+   "metadata": {},
+   "source": [
+    "# Head-to-head: `discopt` vs. SUSPECT\n",
+    "\n",
+    "`discopt` ships a sound structure detector — it labels expressions `CONVEX` /\n",
+    "`CONCAVE` / `AFFINE`, classifies monotonicity, and computes interval bounds, each\n",
+    "verdict backed by a *proof* (an interval Hessian, interval gradient, or interval\n",
+    "value enclosure). The natural question is how it stacks up against the reference\n",
+    "implementation in the field: **SUSPECT** {cite:t}`Ceccon2020`, the MINLP\n",
+    "special-structure detector from Misener's group, referenced directly in the\n",
+    "project's convexity roadmap ([issue #38](https://github.com/jkitchin/discopt/issues/38)).\n",
+    "\n",
+    "This notebook documents a **direct, agree/disagree head-to-head** of the two\n",
+    "detectors over a single shared corpus of 40 curated instances (43 compared\n",
+    "items), on the three verdict axes SUSPECT reports.\n",
+    "\n",
+    "| Axis | `discopt` API | What a positive verdict means |\n",
+    "|------|---------------|-------------------------------|\n",
+    "| **Convexity** | `convexity.classify_expr` | A *proof* of curvature via the interval-Hessian αBB test {cite:p}`Adjiman1998a` |\n",
+    "| **Monotonicity** | `monotonicity.classify_monotonicity` | A *proof*: the interval gradient lies in the nonneg/nonpos orthant on the box |\n",
+    "| **Interval bounds** | `convexity.interval_eval.evaluate_interval` | A sound forward natural-range enclosure |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2b6dc32",
+   "metadata": {},
+   "source": [
+    "## Methodology: one corpus, identical mathematics\n",
+    "\n",
+    "Both tools are driven from the **same neutral expression AST** (`scripts/suspect_oracle/corpus.py`),\n",
+    "rendered into a `discopt` model and a Pyomo model by two thin renderers. So the\n",
+    "comparison is genuinely on identical math, not two independently hand-written\n",
+    "models that might silently differ.\n",
+    "\n",
+    "SUSPECT itself cannot run in `discopt`'s environment — `cog-suspect` 2.1.3 is\n",
+    "unmaintained and imports `np.float` (removed in NumPy ≥ 1.24) and Pyomo's\n",
+    "`ReciprocalExpression` (removed in Pyomo ≥ 6.2), neither compatible with\n",
+    "`discopt`'s NumPy 2.x / Pyomo 6.10. Its verdicts are therefore recorded **once**,\n",
+    "out of process in a pinned environment, into the committed golden file\n",
+    "`suspect_verdicts.json`. This notebook (like the live parity tests) imports only\n",
+    "the neutral corpus and the `discopt` renderer — never SUSPECT — and compares\n",
+    "`discopt`'s live verdicts against that golden file.\n",
+    "\n",
+    "**A soundness asymmetry shapes what we assert.** `discopt`'s verdicts are\n",
+    "rigorous: convexity rests on a sound interval Hessian {cite:p}`Moore1966,Neumaier1990`\n",
+    "built by forward-mode interval AD {cite:p}`GriewankWalther2008` whose minimum\n",
+    "eigenvalue is lower-bounded by an interval Gershgorin theorem {cite:p}`Gershgorin1931`,\n",
+    "giving a second-order proof of convexity {cite:p}`Boyd2004`. SUSPECT's *convexity*\n",
+    "axis is likewise sound, so there we assert **mutual no-contradiction**. But\n",
+    "SUSPECT's *monotonicity* and *bounds* are heuristic and occasionally unsound (its\n",
+    "interval cosine ignores interior critical points, so it declares `sin` monotone\n",
+    "— and mis-bounds it — on `[-3, 3]`, where it is neither). So on those axes the\n",
+    "tests rest on `discopt`'s own sampling-validated soundness plus\n",
+    "no-contradiction, rather than treating SUSPECT as ground truth."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "524735d7",
+   "metadata": {},
+   "source": [
+    "## The convexity head-to-head, computed live\n",
+    "\n",
+    "The cell below loads the shared corpus and the committed SUSPECT golden verdicts,\n",
+    "runs `discopt`'s `classify_expr` over every item, normalises both sides to\n",
+    "`≤`-form, and buckets each comparison into *agree* / *discopt-stronger* /\n",
+    "*suspect-stronger* / *contradiction* — the exact logic the CI parity test\n",
+    "enforces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3ff3c758",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T11:47:06.054865Z",
+     "iopub.status.busy": "2026-06-12T11:47:06.054697Z",
+     "iopub.status.idle": "2026-06-12T11:47:06.061132Z",
+     "shell.execute_reply": "2026-06-12T11:47:06.060485Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SUSPECT golden file: {'n_errors': 0, 'n_instances': 40, 'pyomo': '6.1.2', 'tool': 'cog-suspect', 'tool_version': '2.1.3'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import sys\n",
+    "import warnings\n",
+    "from collections import Counter\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Locate the shared oracle directory (search upward from the working dir).\n",
+    "def _find_oracle() -> Path:\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / \"scripts\" / \"suspect_oracle\"\n",
+    "        if (cand / \"corpus.py\").exists():\n",
+    "            return cand\n",
+    "    raise FileNotFoundError(\"scripts/suspect_oracle not found\")\n",
+    "\n",
+    "oracle = _find_oracle()\n",
+    "sys.path.insert(0, str(oracle))\n",
+    "golden = json.loads((oracle / \"suspect_verdicts.json\").read_text())\n",
+    "print(\"SUSPECT golden file:\", golden[\"_meta\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3f66afd2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T11:47:06.063251Z",
+     "iopub.status.busy": "2026-06-12T11:47:06.063098Z",
+     "iopub.status.idle": "2026-06-12T11:47:06.345442Z",
+     "shell.execute_reply": "2026-06-12T11:47:06.345024Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "compared 43 items across 40 instances\n",
+      "\n",
+      "  agree              33\n",
+      "  discopt_stronger   5\n",
+      "  suspect_stronger   5\n",
+      "  contradiction      0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from corpus import INSTANCES\n",
+    "from discopt._jax.convexity import Curvature, classify_expr\n",
+    "from discopt.modeling.core import ObjectiveSense\n",
+    "from render_discopt import build_discopt\n",
+    "\n",
+    "_NEG = {\n",
+    "    Curvature.CONVEX: Curvature.CONCAVE,\n",
+    "    Curvature.CONCAVE: Curvature.CONVEX,\n",
+    "    Curvature.AFFINE: Curvature.AFFINE,\n",
+    "    Curvature.UNKNOWN: Curvature.UNKNOWN,\n",
+    "}\n",
+    "_TOK = {\n",
+    "    Curvature.CONVEX: \"convex\",\n",
+    "    Curvature.CONCAVE: \"concave\",\n",
+    "    Curvature.AFFINE: \"affine\",\n",
+    "    Curvature.UNKNOWN: \"unknown\",\n",
+    "}\n",
+    "\n",
+    "def _norm(t):           # SUSPECT calls affine \"linear\"\n",
+    "    return \"affine\" if t == \"linear\" else t\n",
+    "\n",
+    "def _compatible(a, b):  # affine is both convex and concave\n",
+    "    return a == b or (\"affine\" in (a, b) and \"unknown\" not in (a, b))\n",
+    "\n",
+    "def _category(d, s):\n",
+    "    if _compatible(d, s):\n",
+    "        return \"agree\"\n",
+    "    if d != \"unknown\" and s == \"unknown\":\n",
+    "        return \"discopt_stronger\"\n",
+    "    if s != \"unknown\" and d == \"unknown\":\n",
+    "        return \"suspect_stronger\"\n",
+    "    return \"contradiction\"\n",
+    "\n",
+    "verdicts = golden[\"verdicts\"]\n",
+    "counts = Counter()\n",
+    "disagreements = []\n",
+    "\n",
+    "with warnings.catch_warnings():\n",
+    "    warnings.simplefilter(\"ignore\")  # wide-box interval overflow is an abstention signal\n",
+    "    for inst in INSTANCES:\n",
+    "        name = inst[\"name\"]\n",
+    "        model, cnames = build_discopt(inst)\n",
+    "        g = verdicts[name]\n",
+    "        items = []\n",
+    "        if model._objective is not None and g.get(\"objective\") is not None:\n",
+    "            curv = classify_expr(model._objective.expression, model)\n",
+    "            if model._objective.sense == ObjectiveSense.MAXIMIZE:\n",
+    "                curv = _NEG[curv]  # normalise \"max f\" to \"min -f\"\n",
+    "            items.append((f\"{name}::objective\", _TOK[curv], _norm(g[\"objective\"][\"convexity\"])))\n",
+    "        for con, cn in zip(model._constraints, cnames):\n",
+    "            curv = classify_expr(con.body, model)\n",
+    "            if con.sense == \">=\":\n",
+    "                curv = _NEG[curv]  # normalise to <=, as SUSPECT does\n",
+    "            items.append((f\"{name}::{cn}\", _TOK[curv], _norm(g[\"constraints\"][cn][\"convexity\"])))\n",
+    "        for key, d, s in items:\n",
+    "            cat = _category(d, s)\n",
+    "            counts[cat] += 1\n",
+    "            if cat != \"agree\":\n",
+    "                disagreements.append((key, d, s, cat))\n",
+    "\n",
+    "total = sum(counts.values())\n",
+    "print(f\"compared {total} items across {len(INSTANCES)} instances\\n\")\n",
+    "for cat in (\"agree\", \"discopt_stronger\", \"suspect_stronger\", \"contradiction\"):\n",
+    "    print(f\"  {cat:18s} {counts[cat]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79d6c256",
+   "metadata": {},
+   "source": [
+    "`agree` dominates, and — the soundness-critical line — there are **zero**\n",
+    "contradictions: the two sound detectors never call the same body convex on one\n",
+    "side and concave on the other. The disagreements are all one tool proving\n",
+    "curvature the other abstains on:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a807bbc9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-12T11:47:06.346772Z",
+     "iopub.status.busy": "2026-06-12T11:47:06.346677Z",
+     "iopub.status.idle": "2026-06-12T11:47:06.348601Z",
+     "shell.execute_reply": "2026-06-12T11:47:06.348285Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Where the two detectors differ:\n",
+      "\n",
+      "  discopt-stronger  euclidean_norm::objective               discopt=convex   suspect=unknown\n",
+      "  discopt-stronger  quad_over_affine::objective             discopt=convex   suspect=unknown\n",
+      "  discopt-stronger  exp_perspective::objective              discopt=convex   suspect=unknown\n",
+      "  discopt-stronger  quad_over_affine_epigraph::qoa          discopt=convex   suspect=unknown\n",
+      "  discopt-stronger  norm_le::soc                            discopt=convex   suspect=unknown\n",
+      "\n",
+      "  suspect-stronger  sin_convex_branch::objective            discopt=unknown  suspect=convex\n",
+      "  suspect-stronger  cos_concave_branch::objective           discopt=unknown  suspect=convex\n",
+      "  suspect-stronger  asin_convex_branch::objective           discopt=unknown  suspect=convex\n",
+      "  suspect-stronger  acos_concave_branch::objective          discopt=unknown  suspect=convex\n",
+      "  suspect-stronger  atan_concave_branch::objective          discopt=unknown  suspect=convex\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Where the two detectors differ:\\n\")\n",
+    "for key, d, s in [(k, d, s) for k, d, s, c in disagreements if c == \"discopt_stronger\"]:\n",
+    "    print(f\"  discopt-stronger  {key:38s}  discopt={d:8s} suspect={s}\")\n",
+    "print()\n",
+    "for key, d, s in [(k, d, s) for k, d, s, c in disagreements if c == \"suspect_stronger\"]:\n",
+    "    print(f\"  suspect-stronger  {key:38s}  discopt={d:8s} suspect={s}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb27e8e7",
+   "metadata": {},
+   "source": [
+    "### Reading the disagreements\n",
+    "\n",
+    "**The 5 `discopt`-stronger items are cone primitives SUSPECT 2.1.3 does not\n",
+    "recognise**, proven by `discopt`'s special-pattern recognizers:\n",
+    "\n",
+    "- `euclidean_norm` — `sqrt` of a PSD quadratic (the 2-norm),\n",
+    "- `quad_over_affine` — `x²/y` with `y > 0`,\n",
+    "- `exp_perspective` — `y·exp(x/y)`, the perspective of `exp`,\n",
+    "- `quad_over_affine_epigraph` — an `nlp_cvx_108`-style fractional epigraph,\n",
+    "- `norm_le` — a second-order-cone constraint.\n",
+    "\n",
+    "**The 5 SUSPECT-stronger items are SUSPECT's bound-aware trig / inverse-trig\n",
+    "rules** — on a sign-restricted branch it proves `sin` convex on `[π, 2π]`, `cos`\n",
+    "concave on `[-π/2, π/2]`, and `asin`/`acos`/`atan` curvature on `(0,1)` / `x>0`,\n",
+    "which `discopt`'s detector currently leaves `UNKNOWN`. These are **tracked\n",
+    "detector gaps**: the parity test pins them in `KNOWN_SUSPECT_STRONGER`, so a newly\n",
+    "appearing gap fails loudly rather than being silently tolerated, and closing one\n",
+    "(adding the bound-aware trig curvature rule) is a clean follow-up."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "188cbb66",
+   "metadata": {},
+   "source": [
+    "## Monotonicity and interval bounds\n",
+    "\n",
+    "The other two axes are compared the same way (see\n",
+    "`python/tests/test_monotonicity_suspect_parity.py` and\n",
+    "`test_fbbt_bounds_suspect_parity.py`), but because SUSPECT is heuristic there,\n",
+    "every `discopt` verdict is *also* validated against a dense numeric sampling of\n",
+    "the real body — the comparison rests on `discopt`'s own soundness, not on\n",
+    "trusting SUSPECT.\n",
+    "\n",
+    "| Axis | agree | discopt-stronger | suspect-stronger | contradiction |\n",
+    "|------|------:|-----------------:|-----------------:|--------------:|\n",
+    "| Convexity | 33 | 5 | 5 | **0** |\n",
+    "| Monotonicity | 40 | 0 | 3 | **0** |\n",
+    "| Bounds | — sound on all 43 items, **0 disjoint enclosures** — | | | |\n",
+    "\n",
+    "On monotonicity the 3 SUSPECT-stronger items are instructive: `sqrt_concave` and\n",
+    "`cubic` are sound `discopt` conservatism (a domain-edge / sub-ULP abstention),\n",
+    "while `sine` is a case where SUSPECT claims monotonicity that is **false** — and\n",
+    "`discopt` correctly abstains. For bounds, `discopt`'s forward enclosure is tighter\n",
+    "on quadratics / powers / `tan` (which SUSPECT leaves unbounded) and looser on\n",
+    "constraint bodies (where SUSPECT folds in the RHS via full FBBT); the two\n",
+    "enclosures always overlap."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e908aff",
+   "metadata": {},
+   "source": [
+    "## Performance: the sparse interval-Hessian\n",
+    "\n",
+    "The convexity certificate's cost is dominated by the interval Hessian. A naive\n",
+    "implementation materialises a dense `n×n` interval matrix at **every** node of the\n",
+    "expression DAG — `O(N·n²)` for an `N`-term separable expression, even though such\n",
+    "a Hessian has only `O(N)` nonzeros. `discopt` instead carries the gradient and\n",
+    "Hessian as **sparse maps of scalar intervals** (a missing key is an exact\n",
+    "structural zero) and materialises the single `n×n` matrix once, at the root, only\n",
+    "when the Gershgorin eigenvalue bound {cite:p}`Gershgorin1931` needs it. This turns\n",
+    "`certify_convex` from `O(N·n²)` to `O(N)` while preserving the proof (outward\n",
+    "rounding everywhere, the αBB interval-Hessian foundation of {cite:p}`Adjiman1998a`\n",
+    "intact).\n",
+    "\n",
+    "On a separable convex sum over `N` variables, per-node cost goes from climbing\n",
+    "with `n` (the `O(N·n²)` signature) to flat:\n",
+    "\n",
+    "| N nodes | dense µs/node | sparse µs/node | total speedup |\n",
+    "|--------:|--------------:|---------------:|--------------:|\n",
+    "| 13  | 26.6  | 14.2 | 1.9× |\n",
+    "| 193 | 65.2  | 13.2 | 4.9× |\n",
+    "| 385 | 176.9 | 13.7 | 12.9× |\n",
+    "| 769 | 625.0 | 14.0 | **44.5×** |\n",
+    "\n",
+    "The harness that produced these numbers is `scripts/detector_timing.py`. The\n",
+    "upshot for the roadmap: the cost that looked like the case *for* a Rust port was a\n",
+    "representation choice fixable in Python, so the port is not warranted on current\n",
+    "evidence."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6607671d",
+   "metadata": {},
+   "source": [
+    "## Takeaways\n",
+    "\n",
+    "- On a shared corpus, `discopt` and SUSPECT **agree wherever both are sound, with\n",
+    "  zero contradictions** — independent corroboration that `discopt`'s detector is\n",
+    "  correct in the wild.\n",
+    "- `discopt` is **stronger on cone primitives** (norms, quadratic-over-affine,\n",
+    "  perspectives, SOC) that SUSPECT 2.1.3 misses.\n",
+    "- SUSPECT is **stronger on bound-aware trig curvature** — five tracked, pinned\n",
+    "  detector gaps that are clean follow-ups.\n",
+    "- Where SUSPECT's heuristics are **unsound** (monotonicity/bounds of trig),\n",
+    "  `discopt` correctly abstains; its verdicts are validated by numeric sampling.\n",
+    "\n",
+    "The comparison is enforced in CI by the three `*_suspect_parity.py` suites, with\n",
+    "the full write-up in `scripts/suspect_oracle/README.md`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/_jax/convexity/eigenvalue.py
+++ b/python/discopt/_jax/convexity/eigenvalue.py
@@ -36,6 +36,43 @@ import numpy as np
 
 from .interval import Interval, _round_down, _round_up
 
+# Unit roundoff for IEEE-754 binary64 round-to-nearest (2**-53).
+_UNIT_ROUNDOFF = 2.0**-53
+
+
+def _row_offdiag_abs_sum_upper(abs_sup: np.ndarray) -> np.ndarray:
+    """Sound per-row upper bound on the off-diagonal absolute sums.
+
+    ``abs_sup`` is the entry-wise ``max(|H_lo|, |H_hi|)`` matrix with its
+    diagonal already zeroed, so row ``i`` summed gives ``Σ_{j≠i} |H_ij|``.
+
+    The previous implementation accumulated each row in a Python double loop,
+    pushing every partial one ULP toward ``+∞`` — O(n²) scalar ``np.nextafter``
+    calls and the dominant cost of the whole certificate. This computes the
+    row sums with a single vectorised ``np.sum`` and then inflates each by the
+    standard Higham recursive-summation error factor
+
+        ``S ≤ Ŝ / (1 − γ_m)``,   ``γ_m = m·u / (1 − m·u)``,   ``m = n − 1``,
+
+    valid because all summands are nonnegative (so ``Σ|x_i| = S``). numpy's
+    pairwise summation has an even smaller error than the recursive bound, so
+    ``γ_{n−1}`` is a safe over-estimate. A final outward round absorbs the
+    division's own roundoff. The result is therefore a rigorous upper bound,
+    matching the loop's guarantee at O(n²) vectorised cost instead of O(n²)
+    interpreted scalar ops.
+    """
+    raw = np.asarray(np.sum(abs_sup, axis=1), dtype=np.float64)
+    m = abs_sup.shape[1] - 1  # off-diagonal terms per row (diagonal is zeroed)
+    if m <= 0:
+        return raw
+    mu = m * _UNIT_ROUNDOFF
+    # mu < 1 for any n < 2**53; guard defensively so the bound stays sound
+    # (and finite) even in the absurd-size limit.
+    if mu >= 0.5:
+        return _round_up(np.full_like(raw, np.inf))
+    gamma = mu / (1.0 - mu)
+    return _round_up(raw / (1.0 - gamma))
+
 
 def gershgorin_lambda_min(H: Interval) -> float:
     """Sound lower bound on ``λ_min`` over the interval Hessian ``H``.
@@ -64,20 +101,13 @@ def gershgorin_lambda_min(H: Interval) -> float:
     if not (np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))):
         return float(-np.inf)
 
-    n = lo.shape[0]
     # |A_ij| supremum over the interval: max(|lo|, |hi|).
     abs_sup = np.maximum(np.abs(lo), np.abs(hi))
-    # Remove diagonal contribution so row_sums holds Σ_{j ≠ i} |A_ij|.
-    abs_sup[np.arange(n), np.arange(n)] = 0.0
+    # Remove diagonal contribution so row sums hold Σ_{j ≠ i} |A_ij|.
+    np.fill_diagonal(abs_sup, 0.0)
 
-    # Sum with outward rounding. ``np.sum`` is not directed-rounded,
-    # so we accumulate pair-wise and push each partial toward +∞.
-    row_sum = np.zeros(n, dtype=np.float64)
-    for i in range(n):
-        s = 0.0
-        for j in range(n):
-            s = _round_up(np.float64(s + abs_sup[i, j]))
-        row_sum[i] = s
+    # Sound per-row upper bound on the off-diagonal sums (vectorised).
+    row_sum = _row_offdiag_abs_sum_upper(abs_sup)
 
     # Diagonal lower bound minus sum — round down.
     diag_lo = np.diag(lo)
@@ -94,16 +124,10 @@ def gershgorin_lambda_max(H: Interval) -> float:
     if not (np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))):
         return float(np.inf)
 
-    n = lo.shape[0]
     abs_sup = np.maximum(np.abs(lo), np.abs(hi))
-    abs_sup[np.arange(n), np.arange(n)] = 0.0
+    np.fill_diagonal(abs_sup, 0.0)
 
-    row_sum = np.zeros(n, dtype=np.float64)
-    for i in range(n):
-        s = 0.0
-        for j in range(n):
-            s = _round_up(np.float64(s + abs_sup[i, j]))
-        row_sum[i] = s
+    row_sum = _row_offdiag_abs_sum_upper(abs_sup)
 
     diag_hi = np.diag(hi)
     bounds = _round_up(diag_hi + row_sum)

--- a/python/discopt/_jax/convexity/interval.py
+++ b/python/discopt/_jax/convexity/interval.py
@@ -80,15 +80,36 @@ class Interval:
 
     def __post_init__(self) -> None:
         # Frozen dataclass: use object.__setattr__ to normalize inputs.
-        lo = np.asarray(self.lo, dtype=np.float64)
-        hi = np.asarray(self.hi, dtype=np.float64)
-        # Broadcast to a common shape once so downstream ops can assume
-        # shape agreement without re-broadcasting every time.
-        lo, hi = np.broadcast_arrays(lo, hi)
-        if np.any(lo > hi):
+        #
+        # This constructor is extremely hot — the interval AD / monotonicity
+        # walkers build millions of tiny (mostly 0-d) intervals. The general
+        # ``np.broadcast_arrays`` + ``np.ascontiguousarray`` + ``np.any`` path
+        # dominates those walks, so the common case (both endpoints already
+        # ``float64`` ndarrays of identical shape, which every internal
+        # arithmetic result satisfies) takes a fast path that skips the
+        # broadcasting machinery entirely. Soundness is unchanged: the
+        # ``lo <= hi`` invariant is still validated.
+        lo = self.lo
+        hi = self.hi
+        if type(lo) is not np.ndarray or lo.dtype != np.float64:
+            lo = np.asarray(lo, dtype=np.float64)
+        if type(hi) is not np.ndarray or hi.dtype != np.float64:
+            hi = np.asarray(hi, dtype=np.float64)
+        if lo.shape != hi.shape:
+            # Differing shapes: broadcast to a common shape once and force
+            # contiguity so downstream ops can assume shape agreement.
+            lo, hi = np.broadcast_arrays(lo, hi)
+            lo = np.ascontiguousarray(lo)
+            hi = np.ascontiguousarray(hi)
+        if lo.ndim == 0:
+            # Scalar fast path: a direct comparison avoids the ``np.any``
+            # ufunc-reduction wrapper that otherwise shows up by the million.
+            if lo > hi:
+                raise ValueError(f"Interval lo > hi: lo={lo}, hi={hi}")
+        elif np.any(lo > hi):
             raise ValueError(f"Interval lo > hi: lo={lo}, hi={hi}")
-        object.__setattr__(self, "lo", np.ascontiguousarray(lo))
-        object.__setattr__(self, "hi", np.ascontiguousarray(hi))
+        object.__setattr__(self, "lo", lo)
+        object.__setattr__(self, "hi", hi)
 
     # ------------------------------------------------------------------
     # Construction

--- a/python/discopt/_jax/convexity/interval_ad.py
+++ b/python/discopt/_jax/convexity/interval_ad.py
@@ -14,8 +14,30 @@ is ≥ 0, the expression is convex on the box.
 
 The implementation is pure numpy; no JAX. JAX's autodiff does not
 carry interval types, and the per-constraint cost is small enough
-that a Python walker is adequate — the big-O concern is the ``n × n``
-Hessian matrix, not the arithmetic of traversing the DAG.
+that a Python walker is adequate.
+
+Sparse representation
+---------------------
+Internally the walker does **not** materialise a dense ``n × n``
+interval Hessian at every node. A separable expression — a sum of ``N``
+terms each touching only one or two variables — has a Hessian whose
+non-zero footprint is ``O(N)``, yet a dense per-node representation
+forces ``O(n²)`` work (allocation + arithmetic) at every one of the
+``N`` nodes, i.e. ``O(N · n²)`` overall. Instead each node carries
+
+* ``grad`` as ``dict[int, Interval]`` — only the non-zero partials,
+* ``hess`` as ``dict[(int, int), Interval]`` — only the non-zero
+  entries of the *upper triangle* (the Hessian is symmetric), keyed by
+  ``(i, j)`` with ``i ≤ j``.
+
+The chain-rule arithmetic then touches only the live entries, so the
+walk is ``O(N + nnz)``. The single ``n × n`` allocation happens once,
+at the very top, when :func:`interval_hessian` densifies the root node
+into the public :class:`IntervalAD` the certificate consumes. Soundness
+is identical to the dense path: a missing key denotes a *structural*
+zero (the partial is identically zero — no computation, hence no
+roundoff to enclose), and every present entry is produced by the same
+outward-rounded :class:`Interval` arithmetic.
 
 Limitations
 -----------
@@ -35,7 +57,7 @@ automatic differentiation).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 import numpy as np
@@ -55,10 +77,20 @@ from discopt.modeling.core import (
 )
 
 from . import interval as iv
-from .interval import Interval, _round_down, _round_up
+from .interval import Interval
+
+# Reused scalar-interval constants (degenerate points) — building these
+# once avoids re-allocating tiny 0-d arrays in every chain-rule step.
+_ONE = Interval.point(1.0)
+_TWO = Interval.point(2.0)
+
+# Type aliases for the sparse carriers (documentation only).
+GradMap = "dict[int, Interval]"
+HessMap = "dict[tuple[int, int], Interval]"
+
 
 # ──────────────────────────────────────────────────────────────────────
-# Data type
+# Public data types (dense — the certificate / tests consume these)
 # ──────────────────────────────────────────────────────────────────────
 
 
@@ -93,8 +125,7 @@ class IntervalAD:
     * ``value`` — scalar interval enclosing ``f(x)`` for ``x`` in the box.
     * ``grad``  — shape-``(n,)`` interval enclosing ``∇f(x)``.
     * ``hess``  — shape-``(n, n)`` symmetric interval enclosing
-      ``∇²f(x)``. Symmetry is only enforced downstream by the
-      consumer (``hess`` + ``hess.T`` / 2 if needed).
+      ``∇²f(x)``.
     * ``rank1_factor`` — optional rank-1 metadata; see
       :class:`Rank1Factor`. ``None`` for nodes without a known
       rank-1 structure. Soundness is independent of this field —
@@ -111,15 +142,78 @@ class IntervalAD:
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Internal sparse carriers
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass(slots=True)
+class _SparseRank1:
+    """Sparse counterpart of :class:`Rank1Factor` used during the walk.
+
+    ``v`` and ``affine_base_grad`` are sparse gradient maps; they are
+    densified to dense :class:`Interval` vectors only when the root
+    node is converted to the public :class:`IntervalAD`.
+    """
+
+    c: Interval
+    v: "dict[int, Interval]"
+    affine_base_value: Optional[Interval] = None
+    affine_base_grad: Optional["dict[int, Interval]"] = None
+
+
+@dataclass(slots=True)
+class _SparseAD:
+    """A node's value, gradient, and Hessian in sparse form.
+
+    * ``value`` — scalar :class:`Interval`.
+    * ``grad`` — ``{flat_index: Interval}``; absent key ⇒ exact-zero
+      partial.
+    * ``hess`` — ``{(i, j): Interval}`` for ``i ≤ j`` (upper triangle of
+      the symmetric Hessian); absent key ⇒ exact-zero entry.
+    * ``n`` — flat variable count (for densification).
+    * ``unbounded`` — ``True`` when an unsupported / non-smooth atom
+      forced an abstention; densifies to a ``±inf`` Hessian so the
+      certificate refuses to certify.
+    * ``rank1`` — optional sparse rank-1 metadata.
+    """
+
+    value: Interval
+    grad: "dict[int, Interval]"
+    hess: "dict[tuple[int, int], Interval]"
+    n: int
+    unbounded: bool = False
+    rank1: Optional[_SparseRank1] = field(default=None)
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Flat-variable index map
 # ──────────────────────────────────────────────────────────────────────
 
 
+def _offset_map(model: Model) -> list[int]:
+    """Prefix-sum flat offsets for ``model``'s variables, cached on the model.
+
+    ``_var_offset`` is called once per variable leaf of every node visited, so
+    the naive ``sum(v.size for v in variables[:index])`` made leaf handling
+    O(n) and the whole walk O(n²). The prefix sums are a pure function of the
+    variable list (which only ever grows by append), so cache them keyed on the
+    list identity and length; a length change invalidates the cache.
+    """
+    variables = model._variables
+    cached = model.__dict__.get("_iad_offset_cache")
+    if cached is not None and cached[0] is variables and cached[1] == len(variables):
+        return cached[2]  # type: ignore[no-any-return]
+    offsets: list[int] = []
+    acc = 0
+    for v in variables:
+        offsets.append(acc)
+        acc += v.size
+    model.__dict__["_iad_offset_cache"] = (variables, len(variables), offsets)
+    return offsets
+
+
 def _var_offset(var: Variable, model: Model) -> int:
-    offset = 0
-    for v in model._variables[: var._index]:
-        offset += v.size
-    return offset
+    return _offset_map(model)[var._index]
 
 
 def _flat_size(model: Model) -> int:
@@ -127,93 +221,201 @@ def _flat_size(model: Model) -> int:
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Helpers: zeros, outer product, scalar lift
+# Sparse arithmetic helpers
+# ──────────────────────────────────────────────────────────────────────
+#
+# All multiplications below feed scalar :class:`Interval` operators,
+# which outward-round (toward ∓inf) on every op — so the maps these
+# helpers build are sound enclosures, entry by entry. The whole walk
+# runs under a single ``np.errstate`` (see :func:`interval_hessian`) so
+# that intentional overflow / ``0 * inf`` on wide boxes — which produce
+# the ``±inf`` sentinels the certificate reads as "abstain" — do not
+# emit benchmark-visible warnings.
+
+
+def _dadd(a: dict, b: dict) -> dict:
+    """Entry-wise sum of two sparse maps (grad or hess)."""
+    if not a:
+        return dict(b)
+    if not b:
+        return dict(a)
+    out = dict(a)
+    for k, v in b.items():
+        cur = out.get(k)
+        out[k] = v if cur is None else cur + v
+    return out
+
+
+def _dsub(a: dict, b: dict) -> dict:
+    """Entry-wise difference ``a - b`` of two sparse maps."""
+    if not b:
+        return dict(a)
+    out = dict(a)
+    for k, v in b.items():
+        cur = out.get(k)
+        out[k] = -v if cur is None else cur - v
+    return out
+
+
+def _dneg(a: dict) -> dict:
+    """Entry-wise negation (exact — sign flip carries no roundoff)."""
+    return {k: -v for k, v in a.items()}
+
+
+def _dscale(s: Interval, a: dict) -> dict:
+    """Scale every entry of a sparse map by the scalar interval ``s``."""
+    if not a:
+        return {}
+    return {k: s * v for k, v in a.items()}
+
+
+def _self_outer(g: dict) -> dict:
+    """Upper-triangle of ``g gᵀ`` with dependency-aware tightening.
+
+    The diagonal uses the squaring rule (``gᵢ²`` is nonneg and bracketed
+    by ``[0, max(|loᵢ|, |hiᵢ|)²]``), matching the dense self-outer
+    specialisation — essential for Hessian enclosures tight enough for
+    Gershgorin to certify compositions like ``exp(x²)``. Off-diagonal
+    entries are the general corner products ``gᵢ · gⱼ``.
+    """
+    items = list(g.items())
+    out: dict = {}
+    for a in range(len(items)):
+        i, gi = items[a]
+        out[(i, i)] = gi**2  # nonneg squaring special-case in Interval.__pow__
+        for b in range(a + 1, len(items)):
+            j, gj = items[b]
+            out[(i, j) if i < j else (j, i)] = gi * gj
+    return out
+
+
+def _sym_cross(a: dict, b: dict) -> dict:
+    """Upper-triangle of the symmetric matrix ``a bᵀ + b aᵀ``.
+
+    Mirrors the dense ``_outer(a, b) + _outer(b, a)`` term: entry
+    ``(i, j)`` is ``aᵢ bⱼ + aⱼ bᵢ`` (absent keys count as exact zero).
+    When ``a is b`` the result is ``2 · a aᵀ`` and is routed through
+    :func:`_self_outer` so the diagonal keeps the squaring tightening.
+    """
+    if a is b:
+        return _dscale(_TWO, _self_outer(a))
+    if not a or not b:
+        return {}
+    keys = sorted(set(a) | set(b))
+    out: dict = {}
+    for ix in range(len(keys)):
+        i = keys[ix]
+        ai = a.get(i)
+        bi = b.get(i)
+        for jx in range(ix, len(keys)):
+            j = keys[jx]
+            aj = a.get(j)
+            bj = b.get(j)
+            term: Optional[Interval] = None
+            if ai is not None and bj is not None:
+                term = ai * bj
+            if aj is not None and bi is not None:
+                t2 = aj * bi
+                term = t2 if term is None else term + t2
+            if term is not None:
+                out[(i, j)] = term
+    return out
+
+
+_AFFINE_HESS_TOL = 1e-300
+
+
+def _hess_is_exactly_zero(hess: dict) -> bool:
+    """``True`` iff the sparse Hessian has no curvature above ``_AFFINE_HESS_TOL``.
+
+    An empty map is the common affine case (no second-order entry was
+    ever produced). A non-empty map can still be "affine" when every
+    entry encloses ``0`` within a few ULPs (subnormals from
+    outward-rounded cancellations). The tolerance ``1e-300`` sits ~270
+    orders of magnitude below any plausible real curvature term, so it
+    cannot misclassify genuine curvature as affine.
+
+    Sufficient-only: a false ``False`` merely skips the rank-1 fast path
+    and falls through to Gershgorin.
+    """
+    tol = _AFFINE_HESS_TOL
+    for entry in hess.values():
+        if abs(float(entry.lo)) > tol or abs(float(entry.hi)) > tol:
+            return False
+    return True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Sentinels / densification
 # ──────────────────────────────────────────────────────────────────────
 
 
-def _zero_grad(n: int) -> Interval:
-    z = np.zeros(n, dtype=np.float64)
-    return Interval(z, z)
+def _unbounded(n: int) -> _SparseAD:
+    """Abstention sentinel: densifies to a ``±inf`` Hessian."""
+    inf = np.float64(np.inf)
+    return _SparseAD(
+        value=Interval(-inf, inf),
+        grad={},
+        hess={},
+        n=n,
+        unbounded=True,
+    )
 
 
-def _zero_hess(n: int) -> Interval:
-    z = np.zeros((n, n), dtype=np.float64)
-    return Interval(z, z)
-
-
-def _unit_grad(n: int, slot: int) -> Interval:
-    z = np.zeros(n, dtype=np.float64)
-    z[slot] = 1.0
-    return Interval(z, z)
-
-
-def _outer(a: Interval, b: Interval) -> Interval:
-    """Interval outer product ``a ⊗ b`` with outward rounding.
-
-    When an operand contains unbounded entries (flowing from an
-    unsupported-atom abstention), the corner products can hit
-    ``0 * inf = NaN``. NaN is sound here: downstream Gershgorin
-    already refuses to certify when Hessian entries are non-finite.
-    The ``errstate`` below merely suppresses the runtime warning.
-
-    When ``a is b`` the result is ``a aᵀ``, which is symmetric PSD for
-    every concrete ``a`` — a property the generic corner-product
-    enclosure does not preserve. The self-outer-product specialisation
-    tightens the diagonal via the squaring rule (``aᵢ²`` is nonneg and
-    bounded between ``0`` and ``max(|loᵢ|, |hiᵢ|)²``) which is
-    essential for Hessian enclosures tight enough for Gershgorin to
-    certify convexity of compositions like ``exp(x²)``.
-    """
-    a_lo = a.lo[:, None]
-    a_hi = a.hi[:, None]
-    b_lo = b.lo[None, :]
-    b_hi = b.hi[None, :]
-    with np.errstate(over="ignore", invalid="ignore"):
-        p1 = a_lo * b_lo
-        p2 = a_lo * b_hi
-        p3 = a_hi * b_lo
-        p4 = a_hi * b_hi
-    lo = np.minimum(np.minimum(p1, p2), np.minimum(p3, p4))
-    hi = np.maximum(np.maximum(p1, p2), np.maximum(p3, p4))
-    if a is b:
-        # Dependency-aware tightening of the diagonal: use the
-        # squaring rule to force ``aᵢ² ≥ 0``. Off-diagonal entries
-        # stay as general corner products.
-        n = a.lo.shape[0]
-        zero_in = (a.lo <= 0) & (a.hi >= 0)
-        sq_lo = np.where(zero_in, 0.0, np.minimum(a.lo * a.lo, a.hi * a.hi))
-        sq_hi = np.maximum(a.lo * a.lo, a.hi * a.hi)
-        diag_idx = np.arange(n)
-        lo[diag_idx, diag_idx] = sq_lo
-        hi[diag_idx, diag_idx] = sq_hi
-    return Interval(_round_down(lo), _round_up(hi))
-
-
-def _scalar_times_array(s: Interval, arr: Interval) -> Interval:
-    """``s * arr`` where ``s`` is scalar and ``arr`` has array endpoints."""
-    return Interval.point(0.0) if False else _broadcast_product(s, arr)
-
-
-def _broadcast_product(s: Interval, arr: Interval) -> Interval:
-    s_lo = np.asarray(s.lo)
-    s_hi = np.asarray(s.hi)
-    with np.errstate(over="ignore", invalid="ignore"):
-        p1 = s_lo * arr.lo
-        p2 = s_lo * arr.hi
-        p3 = s_hi * arr.lo
-        p4 = s_hi * arr.hi
-    lo = np.minimum(np.minimum(p1, p2), np.minimum(p3, p4))
-    hi = np.maximum(np.maximum(p1, p2), np.maximum(p3, p4))
-    return Interval(_round_down(lo), _round_up(hi))
-
-
-def _unbounded_triple(n: int) -> IntervalAD:
+def _dense_unbounded(n: int) -> IntervalAD:
     inf = np.float64(np.inf)
     return IntervalAD(
-        value=Interval(np.float64(-inf), np.float64(inf)),
+        value=Interval(-inf, inf),
         grad=Interval(np.full(n, -inf), np.full(n, inf)),
         hess=Interval(np.full((n, n), -inf), np.full((n, n), inf)),
     )
+
+
+def _dense_vec(d: dict, n: int) -> Interval:
+    lo = np.zeros(n, dtype=np.float64)
+    hi = np.zeros(n, dtype=np.float64)
+    for i, entry in d.items():
+        lo[i] = entry.lo
+        hi[i] = entry.hi
+    return Interval(lo, hi)
+
+
+def _densify(sad: _SparseAD, n: int) -> IntervalAD:
+    """Materialise a sparse node into the public dense :class:`IntervalAD`.
+
+    The only ``O(n²)`` allocation in the whole certificate; the
+    scatter loop costs ``O(nnz)``. Absent grad/hess keys denote exact
+    structural zeros and are left as ``0.0``.
+    """
+    if sad.unbounded:
+        return _dense_unbounded(n)
+
+    grad = _dense_vec(sad.grad, n)
+
+    hlo = np.zeros((n, n), dtype=np.float64)
+    hhi = np.zeros((n, n), dtype=np.float64)
+    for (i, j), entry in sad.hess.items():
+        lo = entry.lo
+        hi = entry.hi
+        hlo[i, j] = lo
+        hhi[i, j] = hi
+        if i != j:
+            hlo[j, i] = lo
+            hhi[j, i] = hi
+    hess = Interval(hlo, hhi)
+
+    rank1: Optional[Rank1Factor] = None
+    if sad.rank1 is not None:
+        r = sad.rank1
+        abg = _dense_vec(r.affine_base_grad, n) if r.affine_base_grad is not None else None
+        rank1 = Rank1Factor(
+            c=r.c,
+            v=_dense_vec(r.v, n),
+            affine_base_value=r.affine_base_value,
+            affine_base_grad=abg,
+        )
+
+    return IntervalAD(value=sad.value, grad=grad, hess=hess, rank1_factor=rank1)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -247,7 +449,13 @@ def interval_hessian(
         raise ValueError("Model has no variables; cannot produce Hessian.")
     box = box or {}
     cache: dict = {}
-    return _walk(expr, model, box, cache, n)
+    # Wide boxes intentionally overflow to ``±inf`` / ``0 * inf`` (the
+    # abstention sentinels the certificate reads as UNKNOWN). Those are
+    # sound interval results, not numerical bugs — suppress the warnings
+    # for the whole walk, mirroring the dense path's per-op errstate.
+    with np.errstate(over="ignore", invalid="ignore"):
+        sad = _walk(expr, model, box, cache, n)
+        return _densify(sad, n)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -255,19 +463,30 @@ def interval_hessian(
 # ──────────────────────────────────────────────────────────────────────
 
 
-def _walk(expr: Expression, model: Model, box: dict, cache: dict, n: int) -> IntervalAD:
+def _walk(expr: Expression, model: Model, box: dict, cache: dict, n: int) -> _SparseAD:
     eid = id(expr)
-    if eid in cache:
-        return cache[eid]
+    hit = cache.get(eid)
+    if hit is not None:
+        return hit
     out = _impl(expr, model, box, cache, n)
     cache[eid] = out
     return out
 
 
 def _variable_scalar_value(v: Variable, box: dict) -> Interval:
-    """Interval enclosure of a *scalar* variable's value."""
+    """Interval enclosure of a *scalar* variable's value.
+
+    The result is always a 0-d (scalar) :class:`Interval`: the sparse
+    walker stores one scalar per grad/hess entry, so a box override
+    supplied as a shape-``(1,)`` interval (the layout
+    :func:`refresh_convex_mask` builds) must be raveled to a scalar
+    here rather than flowing as a length-1 vector.
+    """
     if v in box:
-        return box[v]
+        bi = box[v]
+        lo = float(np.asarray(bi.lo).ravel()[0])
+        hi = float(np.asarray(bi.hi).ravel()[0])
+        return Interval(np.float64(lo), np.float64(hi))
     lb = float(np.asarray(v.lb).ravel()[0])
     ub = float(np.asarray(v.ub).ravel()[0])
     return Interval(np.float64(lb), np.float64(ub))
@@ -292,30 +511,22 @@ def _indexed_scalar_value(expr: IndexExpression, box: dict) -> Interval:
     return Interval(np.float64(lb[idx]), np.float64(ub[idx]))
 
 
-def _impl(expr: Expression, model: Model, box: dict, cache: dict, n: int) -> IntervalAD:
+def _impl(expr: Expression, model: Model, box: dict, cache: dict, n: int) -> _SparseAD:
     # --- Leaves -----------------------------------------------------
     if isinstance(expr, Constant):
         v = float(np.asarray(expr.value))
-        return IntervalAD(
-            value=Interval(np.float64(v), np.float64(v)),
-            grad=_zero_grad(n),
-            hess=_zero_hess(n),
-        )
+        return _SparseAD(value=Interval(np.float64(v), np.float64(v)), grad={}, hess={}, n=n)
 
     if isinstance(expr, Parameter):
         v = float(np.asarray(expr.value))
-        return IntervalAD(
-            value=Interval(np.float64(v), np.float64(v)),
-            grad=_zero_grad(n),
-            hess=_zero_hess(n),
-        )
+        return _SparseAD(value=Interval(np.float64(v), np.float64(v)), grad={}, hess={}, n=n)
 
     if isinstance(expr, Variable):
         if expr.size != 1:
             raise ValueError(f"Interval Hessian requires scalar variables; got shape {expr.shape}")
         slot = _var_offset(expr, model)
         val = _variable_scalar_value(expr, box)
-        return IntervalAD(value=val, grad=_unit_grad(n, slot), hess=_zero_hess(n))
+        return _SparseAD(value=val, grad={slot: _ONE}, hess={}, n=n)
 
     if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
         v = expr.base
@@ -328,19 +539,22 @@ def _impl(expr: Expression, model: Model, box: dict, cache: dict, n: int) -> Int
             flat_idx = int(raw_idx)
         slot = _var_offset(v, model) + flat_idx
         val = _indexed_scalar_value(expr, box)
-        return IntervalAD(value=val, grad=_unit_grad(n, slot), hess=_zero_hess(n))
+        return _SparseAD(value=val, grad={slot: _ONE}, hess={}, n=n)
 
     # --- Unary ops --------------------------------------------------
     if isinstance(expr, UnaryOp):
         child = _walk(expr.operand, model, box, cache, n)
+        if child.unbounded:
+            return _unbounded(n)
         if expr.op == "neg":
-            return IntervalAD(
+            return _SparseAD(
                 value=-child.value,
-                grad=-child.grad,
-                hess=-child.hess,
+                grad=_dneg(child.grad),
+                hess=_dneg(child.hess),
+                n=n,
             )
         # |x| is non-smooth at 0 — no sound Hessian.
-        return _unbounded_triple(n)
+        return _unbounded(n)
 
     # --- Binary ops -------------------------------------------------
     if isinstance(expr, BinaryOp):
@@ -355,18 +569,23 @@ def _impl(expr: Expression, model: Model, box: dict, cache: dict, n: int) -> Int
 
     if isinstance(expr, SumOverExpression):
         if not expr.terms:
-            return IntervalAD(Interval.point(0.0), _zero_grad(n), _zero_hess(n))
+            return _SparseAD(value=Interval.point(0.0), grad={}, hess={}, n=n)
         result = _walk(expr.terms[0], model, box, cache, n)
+        if result.unbounded:
+            return _unbounded(n)
+        value = result.value
+        grad = dict(result.grad)
+        hess = dict(result.hess)
         for t in expr.terms[1:]:
             other = _walk(t, model, box, cache, n)
-            result = IntervalAD(
-                value=result.value + other.value,
-                grad=result.grad + other.grad,
-                hess=result.hess + other.hess,
-            )
-        return result
+            if other.unbounded:
+                return _unbounded(n)
+            value = value + other.value
+            grad = _dadd(grad, other.grad)
+            hess = _dadd(hess, other.hess)
+        return _SparseAD(value=value, grad=grad, hess=hess, n=n)
 
-    return _unbounded_triple(n)
+    return _unbounded(n)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -374,54 +593,53 @@ def _impl(expr: Expression, model: Model, box: dict, cache: dict, n: int) -> Int
 # ──────────────────────────────────────────────────────────────────────
 
 
-def _binary(expr: BinaryOp, model: Model, box: dict, cache: dict, n: int) -> IntervalAD:
+def _binary(expr: BinaryOp, model: Model, box: dict, cache: dict, n: int) -> _SparseAD:
     left = _walk(expr.left, model, box, cache, n)
     right = _walk(expr.right, model, box, cache, n)
 
+    if left.unbounded or right.unbounded:
+        return _unbounded(n)
+
     if expr.op == "+":
-        return IntervalAD(
+        return _SparseAD(
             value=left.value + right.value,
-            grad=left.grad + right.grad,
-            hess=left.hess + right.hess,
+            grad=_dadd(left.grad, right.grad),
+            hess=_dadd(left.hess, right.hess),
+            n=n,
         )
 
     if expr.op == "-":
-        return IntervalAD(
+        return _SparseAD(
             value=left.value - right.value,
-            grad=left.grad - right.grad,
-            hess=left.hess - right.hess,
+            grad=_dsub(left.grad, right.grad),
+            hess=_dsub(left.hess, right.hess),
+            n=n,
         )
 
     if expr.op == "*":
         # (f g)'  = g f' + f g'
-        # (f g)'' = g f'' + f g'' + f' g'^T + g' f'^T
+        # (f g)'' = g f'' + f g'' + f' g'ᵀ + g' f'ᵀ
         fg = left.value * right.value
-        grad = _broadcast_product(right.value, left.grad) + _broadcast_product(
-            left.value, right.grad
+        grad = _dadd(_dscale(right.value, left.grad), _dscale(left.value, right.grad))
+        hess = _dadd(
+            _dadd(_dscale(right.value, left.hess), _dscale(left.value, right.hess)),
+            _sym_cross(left.grad, right.grad),
         )
-        hess_terms = (
-            _broadcast_product(right.value, left.hess)
-            + _broadcast_product(left.value, right.hess)
-            + _outer(left.grad, right.grad)
-            + _outer(right.grad, left.grad)
-        )
-        # Rank-1 metadata for ``g * g`` (BinaryOp form of squaring)
-        # when ``g`` is affine. The cache makes ``left is right`` for
-        # any expression node that appears twice as the same instance,
-        # so this catches ``x * x`` and any ``e * e`` where the user
-        # bound ``e`` to a single Python variable. The Hessian
-        # already collapses to ``2 ∇g ∇gᵀ`` exactly here (the two
-        # ``_outer`` calls fire self-product tightening), so the
-        # metadata claim is sound.
-        rank1: Optional[Rank1Factor] = None
+        # Rank-1 metadata for ``g * g`` (BinaryOp form of squaring) when
+        # ``g`` is affine. The DAG cache makes ``left is right`` for any
+        # node that appears twice as the same instance, so this catches
+        # ``x * x`` and any ``e * e`` bound to one Python variable. The
+        # Hessian already collapsed to ``2 ∇g ∇gᵀ`` here, so the claim is
+        # sound.
+        rank1: Optional[_SparseRank1] = None
         if expr.left is expr.right and _hess_is_exactly_zero(left.hess):
-            rank1 = Rank1Factor(
-                c=Interval.point(2.0),
+            rank1 = _SparseRank1(
+                c=_TWO,
                 v=left.grad,
                 affine_base_value=left.value,
                 affine_base_grad=left.grad,
             )
-        return IntervalAD(value=fg, grad=grad, hess=hess_terms, rank1_factor=rank1)
+        return _SparseAD(value=fg, grad=grad, hess=hess, n=n, rank1=rank1)
 
     if expr.op == "/":
         return _division(expr, left, right, n)
@@ -429,10 +647,10 @@ def _binary(expr: BinaryOp, model: Model, box: dict, cache: dict, n: int) -> Int
     if expr.op == "**":
         return _power(expr, left, n)
 
-    return _unbounded_triple(n)
+    return _unbounded(n)
 
 
-def _division(expr: BinaryOp, left: IntervalAD, right: IntervalAD, n: int) -> IntervalAD:
+def _division(expr: BinaryOp, left: _SparseAD, right: _SparseAD, n: int) -> _SparseAD:
     """Implement ``f / g`` via the reciprocal chain rule.
 
     Defined only when ``g`` is strictly sign-determined. Otherwise the
@@ -440,18 +658,18 @@ def _division(expr: BinaryOp, left: IntervalAD, right: IntervalAD, n: int) -> In
     """
     g = right.value
     if g.contains_zero().any():
-        return _unbounded_triple(n)
+        return _unbounded(n)
 
     # Rank-1 fast path: when the numerator is the square of an affine
     # expression and the denominator is itself affine and strictly
     # positive, the quotient's Hessian collapses to a perspective-form
-    # rank-1 matrix that the certificate can prove PSD structurally
-    # — even on wide boxes where the entry-wise interval enclosure is
-    # too loose for Gershgorin.
+    # rank-1 matrix that the certificate can prove PSD structurally —
+    # even on wide boxes where the entry-wise enclosure is too loose for
+    # Gershgorin.
     if (
-        left.rank1_factor is not None
-        and left.rank1_factor.affine_base_value is not None
-        and left.rank1_factor.affine_base_grad is not None
+        left.rank1 is not None
+        and left.rank1.affine_base_value is not None
+        and left.rank1.affine_base_grad is not None
         and bool(np.all(np.asarray(g.lo) > 0.0))
         and _hess_is_exactly_zero(right.hess)
     ):
@@ -459,33 +677,30 @@ def _division(expr: BinaryOp, left: IntervalAD, right: IntervalAD, n: int) -> In
 
     # Reciprocal derivatives:
     #   (1/g)'  = -g' / g^2
-    #   (1/g)'' = 2 g' g'^T / g^3 - g'' / g^2
+    #   (1/g)'' = 2 g' g'ᵀ / g^3 - g'' / g^2
     g2 = g * g
     g3 = g2 * g
-    inv_g = Interval.point(1.0) / g
-    inv_g2 = Interval.point(1.0) / g2
-    inv_g3 = Interval.point(1.0) / g3
+    inv_g = _ONE / g
+    inv_g2 = _ONE / g2
+    inv_g3 = _ONE / g3
     recip_value = inv_g
-    recip_grad = _broadcast_product(-inv_g2, right.grad)
-    recip_hess = _broadcast_product(
-        Interval.point(2.0) * inv_g3, _outer(right.grad, right.grad)
-    ) - _broadcast_product(inv_g2, right.hess)
+    recip_grad = _dscale(-inv_g2, right.grad)
+    recip_hess = _dsub(
+        _dscale(_TWO * inv_g3, _self_outer(right.grad)),
+        _dscale(inv_g2, right.hess),
+    )
 
     # f / g = f * (1/g) — apply product rule.
     fg_val = left.value * recip_value
-    fg_grad = _broadcast_product(recip_value, left.grad) + _broadcast_product(
-        left.value, recip_grad
+    fg_grad = _dadd(_dscale(recip_value, left.grad), _dscale(left.value, recip_grad))
+    fg_hess = _dadd(
+        _dadd(_dscale(recip_value, left.hess), _dscale(left.value, recip_hess)),
+        _sym_cross(left.grad, recip_grad),
     )
-    fg_hess = (
-        _broadcast_product(recip_value, left.hess)
-        + _broadcast_product(left.value, recip_hess)
-        + _outer(left.grad, recip_grad)
-        + _outer(recip_grad, left.grad)
-    )
-    return IntervalAD(value=fg_val, grad=fg_grad, hess=fg_hess)
+    return _SparseAD(value=fg_val, grad=fg_grad, hess=fg_hess, n=n)
 
 
-def _rank1_quotient(left: IntervalAD, right: IntervalAD, n: int) -> IntervalAD:
+def _rank1_quotient(left: _SparseAD, right: _SparseAD, n: int) -> _SparseAD:
     """Specialised ``g² / h`` Hessian when ``g`` and ``h`` are affine.
 
     For affine ``g`` with gradient ``v_g`` (so ``H_g = 0``) and affine
@@ -494,64 +709,61 @@ def _rank1_quotient(left: IntervalAD, right: IntervalAD, n: int) -> IntervalAD:
 
         ``H = (2/h) · v vᵀ``     where  ``v = v_g − (g/h) · v_h``.
 
-    This is the perspective form: a rank-1 PSD matrix on every point
-    of the box. We emit the Hessian via ``_outer(v, v)`` with a
-    single :class:`Interval` instance so the self-product tightening
-    forces the diagonal to be nonneg, and we attach a
-    :class:`Rank1Factor` so the certificate's structural PSD test
-    fires regardless of off-diagonal interval blowup.
+    This is the perspective form: a rank-1 PSD matrix on every point of
+    the box. We emit the Hessian via :func:`_self_outer` so the diagonal
+    is forced nonneg, and attach a :class:`_SparseRank1` so the
+    certificate's structural PSD test fires regardless of off-diagonal
+    interval blowup.
     """
-    assert left.rank1_factor is not None
-    assert left.rank1_factor.affine_base_value is not None
-    assert left.rank1_factor.affine_base_grad is not None
+    assert left.rank1 is not None
+    assert left.rank1.affine_base_value is not None
+    assert left.rank1.affine_base_grad is not None
 
-    g_val = left.rank1_factor.affine_base_value
-    v_g = left.rank1_factor.affine_base_grad
+    g_val = left.rank1.affine_base_value
+    v_g = left.rank1.affine_base_grad
     h = right.value
     v_h = right.grad
 
-    # Combined rank-1 vector and coefficient. Each operand is a fresh
-    # Interval; the final combined Interval is the single instance we
-    # pass to _outer to trigger self-product tightening.
+    # Combined rank-1 vector and coefficient.
     g_over_h = g_val / h
-    v_combined = v_g - _broadcast_product(g_over_h, v_h)
-    c_combined = Interval.point(2.0) / h
+    v_combined = _dsub(v_g, _dscale(g_over_h, v_h))
+    c_combined = _TWO / h
 
-    outer_vv = _outer(v_combined, v_combined)
-    hess = _broadcast_product(c_combined, outer_vv)
+    hess = _dscale(c_combined, _self_outer(v_combined))
 
     # Value and gradient via the standard reciprocal-product rule —
-    # tightness on those is not required for the convexity verdict
-    # but they remain sound and consistent with the generic path.
-    inv_h = Interval.point(1.0) / h
-    inv_h2 = Interval.point(1.0) / (h * h)
-    recip_grad = _broadcast_product(-inv_h2, v_h)
+    # tightness on those is not required for the convexity verdict but
+    # they remain sound and consistent with the generic path.
+    inv_h = _ONE / h
+    inv_h2 = _ONE / (h * h)
+    recip_grad = _dscale(-inv_h2, v_h)
     fg_val = left.value * inv_h
-    fg_grad = _broadcast_product(inv_h, left.grad) + _broadcast_product(left.value, recip_grad)
+    fg_grad = _dadd(_dscale(inv_h, left.grad), _dscale(left.value, recip_grad))
 
-    return IntervalAD(
+    return _SparseAD(
         value=fg_val,
         grad=fg_grad,
         hess=hess,
-        rank1_factor=Rank1Factor(c=c_combined, v=v_combined),
+        n=n,
+        rank1=_SparseRank1(c=c_combined, v=v_combined),
     )
 
 
-def _power(expr: BinaryOp, base: IntervalAD, n_vars: int) -> IntervalAD:
+def _power(expr: BinaryOp, base: _SparseAD, n_vars: int) -> _SparseAD:
     """``g^p`` for a literal exponent ``p``.
 
     Supports integer ``p`` on any domain and fractional ``p`` on a
     strictly positive base (through ``exp(p log g)`` composition).
     """
     if not isinstance(expr.right, (Constant, Parameter)):
-        return _unbounded_triple(n_vars)
+        return _unbounded(n_vars)
     raw = np.asarray(expr.right.value)
     if raw.ndim != 0:
-        return _unbounded_triple(n_vars)
+        return _unbounded(n_vars)
     p = float(raw)
 
     if np.isclose(p, 0.0):
-        return IntervalAD(Interval.point(1.0), _zero_grad(n_vars), _zero_hess(n_vars))
+        return _SparseAD(value=_ONE, grad={}, hess={}, n=n_vars)
     if np.isclose(p, 1.0):
         return base
 
@@ -562,45 +774,21 @@ def _power(expr: BinaryOp, base: IntervalAD, n_vars: int) -> IntervalAD:
 
     # Fractional: require strictly positive base; use exp(p log g).
     if np.any(base.value.lo <= 0):
-        return _unbounded_triple(n_vars)
-    # Build exp(p * log(g)) through the AD machinery by applying log
-    # and exp rules to ``base`` directly — equivalent to the general
-    # power rule.
+        return _unbounded(n_vars)
     log_g = _apply_log(base, n_vars)
-    scaled = IntervalAD(
-        value=Interval.point(p) * log_g.value,
-        grad=_broadcast_product(Interval.point(p), log_g.grad),
-        hess=_broadcast_product(Interval.point(p), log_g.hess),
+    if log_g.unbounded:
+        return _unbounded(n_vars)
+    pt = Interval.point(p)
+    scaled = _SparseAD(
+        value=pt * log_g.value,
+        grad=_dscale(pt, log_g.grad),
+        hess=_dscale(pt, log_g.hess),
+        n=n_vars,
     )
     return _apply_exp(scaled, n_vars)
 
 
-_AFFINE_HESS_TOL = 1e-300
-
-
-def _hess_is_exactly_zero(hess: Interval) -> bool:
-    """``True`` iff every entry of the interval Hessian encloses ``0``
-    with a magnitude well below any meaningful scale.
-
-    Used to detect "affine in the variables" nodes: when the
-    algebraic ``H_g`` is identically zero, the AD walker produces
-    an interval Hessian whose entries are within a few ULPs of
-    ``0`` (subnormals from outward-rounded additions of exact
-    zeros). The tolerance ``1e-300`` is six orders of magnitude
-    above the smallest subnormal and still ~270 orders of magnitude
-    below any plausible nonzero Hessian entry, so it cannot
-    misclassify a real (even tiny) curvature term as affine.
-
-    The check is sufficient-only: a false ``False`` just causes the
-    rank-1 fast path to be skipped, falling through to the existing
-    Gershgorin path.
-    """
-    return bool(
-        np.all(np.abs(hess.lo) <= _AFFINE_HESS_TOL) and np.all(np.abs(hess.hi) <= _AFFINE_HESS_TOL)
-    )
-
-
-def _integer_power(base: IntervalAD, p: int, n: int) -> IntervalAD:
+def _integer_power(base: _SparseAD, p: int, n: int) -> _SparseAD:
     """Direct chain rule for ``g^p`` with integer ``p``.
 
     * value   : ``g^p``
@@ -619,41 +807,38 @@ def _integer_power(base: IntervalAD, p: int, n: int) -> IntervalAD:
     coeff1 = Interval.point(float(p)) * g_pm1
     coeff2 = Interval.point(float(p * (p - 1))) * g_pm2
     value = g**p
-    grad = _broadcast_product(coeff1, base.grad)
-    hess = _broadcast_product(coeff1, base.hess) + _broadcast_product(
-        coeff2, _outer(base.grad, base.grad)
-    )
+    grad = _dscale(coeff1, base.grad)
+    hess = _dadd(_dscale(coeff1, base.hess), _dscale(coeff2, _self_outer(base.grad)))
     # Rank-1 metadata: when p == 2 and H_g is identically zero (g is
-    # affine), the second-order term ``p g^{p-1} H_g`` vanishes and
-    # the Hessian collapses exactly to ``2 · ∇g ∇gᵀ``. Soundness is
-    # independent of this field; it is consumed only as a tighter
-    # sufficient test by the certificate.
-    rank1: Optional[Rank1Factor] = None
+    # affine), the second-order term ``p g^{p-1} H_g`` vanishes and the
+    # Hessian collapses exactly to ``2 · ∇g ∇gᵀ``. Soundness is
+    # independent of this field.
+    rank1: Optional[_SparseRank1] = None
     if p == 2 and _hess_is_exactly_zero(base.hess):
-        rank1 = Rank1Factor(
-            c=Interval.point(2.0),
+        rank1 = _SparseRank1(
+            c=_TWO,
             v=base.grad,
             affine_base_value=base.value,
             affine_base_grad=base.grad,
         )
-    return IntervalAD(value=value, grad=grad, hess=hess, rank1_factor=rank1)
+    return _SparseAD(value=value, grad=grad, hess=hess, n=n, rank1=rank1)
 
 
-def _reciprocal_power(base: IntervalAD, k: int, n: int) -> IntervalAD:
+def _reciprocal_power(base: _SparseAD, k: int, n: int) -> _SparseAD:
     """``g^(-k) = 1 / g^k`` via the reciprocal rule."""
     if base.value.contains_zero().any():
-        return _unbounded_triple(n)
+        return _unbounded(n)
     gk = _integer_power(base, k, n)
-    # Reciprocal of gk.
     g = gk.value
     g2 = g * g
     g3 = g2 * g
-    value = Interval.point(1.0) / g
-    grad = _broadcast_product(-(Interval.point(1.0) / g2), gk.grad)
-    hess = _broadcast_product(
-        Interval.point(2.0) / g3, _outer(gk.grad, gk.grad)
-    ) - _broadcast_product(Interval.point(1.0) / g2, gk.hess)
-    return IntervalAD(value=value, grad=grad, hess=hess)
+    value = _ONE / g
+    grad = _dscale(-(_ONE / g2), gk.grad)
+    hess = _dsub(
+        _dscale(_TWO / g3, _self_outer(gk.grad)),
+        _dscale(_ONE / g2, gk.hess),
+    )
+    return _SparseAD(value=value, grad=grad, hess=hess, n=n)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -661,73 +846,68 @@ def _reciprocal_power(base: IntervalAD, k: int, n: int) -> IntervalAD:
 # ──────────────────────────────────────────────────────────────────────
 
 
-def _function_call(expr: FunctionCall, model: Model, box: dict, cache: dict, n: int) -> IntervalAD:
+def _function_call(expr: FunctionCall, model: Model, box: dict, cache: dict, n: int) -> _SparseAD:
     if len(expr.args) != 1:
-        return _unbounded_triple(n)
+        return _unbounded(n)
     arg = _walk(expr.args[0], model, box, cache, n)
+    if arg.unbounded:
+        return _unbounded(n)
     name = expr.func_name
     if name == "exp":
         return _apply_exp(arg, n)
     if name == "log":
         return _apply_log(arg, n)
     if name == "sqrt":
-        # sqrt = x^0.5 on the positive domain; reuse the fractional path.
+        # sqrt = x^0.5 on the positive domain.
         if np.any(arg.value.lo < 0):
-            return _unbounded_triple(n)
-        half = IntervalAD(
-            value=iv.sqrt(arg.value),
-            grad=arg.grad,  # will be overwritten; dummy
-            hess=arg.hess,
-        )
-        # Apply g^0.5 chain rule directly: f = g^0.5, f' = 0.5 g^-0.5 g',
-        # f'' = 0.5 g^-0.5 H_g - 0.25 g^-1.5 (∇g ∇g^T).
+            return _unbounded(n)
+        # f = g^0.5, f' = 0.5 g^-0.5 g', f'' = 0.5 g^-0.5 H_g - 0.25 g^-1.5 (∇g ∇gᵀ).
         sqrt_g = iv.sqrt(arg.value)
-        inv_sqrt_g = Interval.point(1.0) / sqrt_g
+        inv_sqrt_g = _ONE / sqrt_g
         inv_sqrt_g3 = inv_sqrt_g * inv_sqrt_g * inv_sqrt_g
         coeff1 = Interval.point(0.5) * inv_sqrt_g
         coeff2 = Interval.point(-0.25) * inv_sqrt_g3
-        grad = _broadcast_product(coeff1, arg.grad)
-        hess = _broadcast_product(coeff1, arg.hess) + _broadcast_product(
-            coeff2, _outer(arg.grad, arg.grad)
-        )
-        _ = half  # kept to make the intent above explicit
-        return IntervalAD(value=sqrt_g, grad=grad, hess=hess)
+        grad = _dscale(coeff1, arg.grad)
+        hess = _dadd(_dscale(coeff1, arg.hess), _dscale(coeff2, _self_outer(arg.grad)))
+        return _SparseAD(value=sqrt_g, grad=grad, hess=hess, n=n)
     # Other atoms (trig, abs, cosh, ...) are unsupported by the v1
     # certificate; return unbounded to force abstention.
-    return _unbounded_triple(n)
+    return _unbounded(n)
 
 
-def _apply_exp(arg: IntervalAD, n: int) -> IntervalAD:
+def _apply_exp(arg: _SparseAD, n: int) -> _SparseAD:
     """Chain rule through ``exp``.
 
     * value    : ``exp(g)``
     * gradient : ``exp(g) ∇g``
-    * hessian  : ``exp(g) (H_g + ∇g ∇g^T)``
+    * hessian  : ``exp(g) (H_g + ∇g ∇gᵀ)``
     """
+    if arg.unbounded:
+        return _unbounded(n)
     e = iv.exp(arg.value)
-    grad = _broadcast_product(e, arg.grad)
-    hess = _broadcast_product(e, arg.hess + _outer(arg.grad, arg.grad))
-    return IntervalAD(value=e, grad=grad, hess=hess)
+    grad = _dscale(e, arg.grad)
+    hess = _dscale(e, _dadd(arg.hess, _self_outer(arg.grad)))
+    return _SparseAD(value=e, grad=grad, hess=hess, n=n)
 
 
-def _apply_log(arg: IntervalAD, n: int) -> IntervalAD:
+def _apply_log(arg: _SparseAD, n: int) -> _SparseAD:
     """Chain rule through ``log``.
 
     * value    : ``log(g)``
     * gradient : ``(1/g) ∇g``
-    * hessian  : ``(1/g) H_g - (1/g²) (∇g ∇g^T)``
+    * hessian  : ``(1/g) H_g - (1/g²) (∇g ∇gᵀ)``
     """
+    if arg.unbounded:
+        return _unbounded(n)
     if np.any(arg.value.lo <= 0):
-        return _unbounded_triple(n)
+        return _unbounded(n)
     g = arg.value
-    inv_g = Interval.point(1.0) / g
+    inv_g = _ONE / g
     inv_g2 = inv_g * inv_g
     value = iv.log(g)
-    grad = _broadcast_product(inv_g, arg.grad)
-    hess = _broadcast_product(inv_g, arg.hess) - _broadcast_product(
-        inv_g2, _outer(arg.grad, arg.grad)
-    )
-    return IntervalAD(value=value, grad=grad, hess=hess)
+    grad = _dscale(inv_g, arg.grad)
+    hess = _dsub(_dscale(inv_g, arg.hess), _dscale(inv_g2, _self_outer(arg.grad)))
+    return _SparseAD(value=value, grad=grad, hess=hess, n=n)
 
 
 __all__ = ["IntervalAD", "Rank1Factor", "interval_hessian"]

--- a/python/discopt/_jax/convexity/rules.py
+++ b/python/discopt/_jax/convexity/rules.py
@@ -351,6 +351,15 @@ def _classify_product(
         s = 0 if val == 0 else (1 if val > 0 else -1)
         return ExprInfo(scale(left.curvature, s), prod_sign)
 
+    # Square of an affine expression: ``e * e`` with ``e`` affine is convex
+    # and nonnegative. Recognising it here (the two operands are the *same*
+    # node, so ``expr.left is expr.right``) is both sound and a large speed
+    # win: it keeps ``x * x`` out of the whole-expression quadratic fallback,
+    # which would otherwise build a dense n×n form and run an O(n³)
+    # eigendecomposition on every such product node.
+    if expr.left is expr.right and left.curvature == Curvature.AFFINE:
+        return ExprInfo(Curvature.CONVEX, Sign.NONNEG)
+
     # Special product patterns: perspective of exp and weighted
     # geometric mean. See :mod:`patterns` for the preconditions.
     if model is not None:

--- a/python/discopt/_jax/monotonicity.py
+++ b/python/discopt/_jax/monotonicity.py
@@ -1,0 +1,371 @@
+"""Per-expression monotonicity detection for expression DAGs.
+
+Classifies a scalar expression by how it responds to *jointly* increasing the
+decision variables over the model's box:
+
+* ``NONDECREASING`` -- ``∂f/∂xᵢ ≥ 0`` for every variable ``xᵢ`` over the box.
+* ``NONINCREASING`` -- ``∂f/∂xᵢ ≤ 0`` for every variable over the box.
+* ``CONSTANT``      -- the expression does not depend on any variable.
+* ``UNKNOWN``       -- neither could be proven (mixed signs, an unsupported
+  atom, or a domain issue forcing a sound abstention).
+
+This mirrors SUSPECT's ``Monotonicity`` verdict (Ceccon, Siirola, Misener,
+2020) and is the monotonicity counterpart to :mod:`discopt._jax.convexity`.
+
+Soundness invariant
+-------------------
+A ``NONDECREASING`` / ``NONINCREASING`` verdict is a *proof*. It is obtained
+from an interval enclosure of the gradient via forward-mode interval automatic
+differentiation: if the interval enclosing ``∇f`` over the whole box lies in
+the nonnegative (resp. nonpositive) orthant, then the true gradient has that
+sign everywhere, so the monotonicity holds. Anything that cannot be proven --
+an atom without a derivative rule here, a non-finite enclosure (e.g. ``tan``
+across an asymptote), a ``log`` of a possibly-nonpositive argument -- abstains
+to ``UNKNOWN`` rather than guessing.
+
+Scope
+-----
+Scalar (size-1) variables only; array-valued variables and constructs the
+evaluator does not recognise abstain to ``UNKNOWN``. The public surface is
+intentionally small::
+
+    classify_monotonicity(expr, model=None, box=None) -> Monotonicity
+    Monotonicity  (enum)
+"""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+from typing import Optional, cast
+
+import numpy as np
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Expression,
+    FunctionCall,
+    UnaryOp,
+    Variable,
+)
+
+from .convexity import interval as iv
+from .convexity.interval import Interval
+
+
+class Monotonicity(Enum):
+    """Monotonicity of a scalar expression over the model box."""
+
+    NONDECREASING = "nondecreasing"
+    NONINCREASING = "nonincreasing"
+    CONSTANT = "constant"
+    UNKNOWN = "unknown"
+
+
+# A node's forward-mode payload: an interval enclosing its value, and a sparse
+# gradient mapping each variable it depends on to an interval enclosing the
+# corresponding partial derivative over the box. Absent keys are exact zeros.
+class _Abstain(Exception):
+    """Raised internally to force a sound UNKNOWN verdict."""
+
+
+_LN2 = math.log(2.0)
+_LN10 = math.log(10.0)
+
+
+def classify_monotonicity(
+    expr: Expression,
+    model: Optional[object] = None,
+    box: Optional[dict] = None,
+) -> Monotonicity:
+    """Classify the monotonicity of a scalar expression over its box.
+
+    Args:
+        expr: A scalar expression from :mod:`discopt.modeling.core`.
+        model: Unused; accepted for signature symmetry with
+            :func:`discopt._jax.convexity.classify_expr`. Bounds are read from
+            the variables themselves (or ``box``).
+        box: Optional ``{Variable: Interval}`` overriding declared bounds.
+
+    Returns:
+        A :class:`Monotonicity` verdict. ``NONDECREASING`` / ``NONINCREASING``
+        are proofs; ``UNKNOWN`` is a sound abstention.
+    """
+    box = box or {}
+    try:
+        _value, grad = _walk(expr, box, {})
+    except _Abstain:
+        return Monotonicity.UNKNOWN
+
+    if not grad:
+        return Monotonicity.CONSTANT
+
+    partials = list(grad.values())
+    if all(_is_zero(p) for p in partials):
+        return Monotonicity.CONSTANT
+    if all(_finite(p) and bool(np.all(np.asarray(p.lo) >= 0.0)) for p in partials):
+        return Monotonicity.NONDECREASING
+    if all(_finite(p) and bool(np.all(np.asarray(p.hi) <= 0.0)) for p in partials):
+        return Monotonicity.NONINCREASING
+    return Monotonicity.UNKNOWN
+
+
+def _is_zero(p: Interval) -> bool:
+    return bool(np.all(np.asarray(p.lo) == 0.0)) and bool(np.all(np.asarray(p.hi) == 0.0))
+
+
+def _finite(p: Interval) -> bool:
+    return bool(np.all(np.isfinite(np.asarray(p.lo)))) and bool(
+        np.all(np.isfinite(np.asarray(p.hi)))
+    )
+
+
+def _scalar(x) -> float:
+    """First element of a (possibly shape-``(1,)``) interval endpoint as a float."""
+    return float(np.asarray(x).ravel()[0])
+
+
+def _scalar_box(v: Variable, box: dict) -> Interval:
+    if v in box:
+        return cast(Interval, box[v])
+    if v.size != 1:
+        raise _Abstain  # array-valued variables are out of scope
+    lb = float(np.asarray(v.lb).ravel()[0])
+    ub = float(np.asarray(v.ub).ravel()[0])
+    return Interval.from_bounds(lb, ub)
+
+
+def _walk(node: Expression, box: dict, cache: dict) -> tuple[Interval, dict]:
+    """Return ``(value_interval, {Variable: partial_interval})`` for ``node``."""
+    key = id(node)
+    if key in cache:
+        return cast("tuple[Interval, dict]", cache[key])
+    out = _impl(node, box, cache)
+    cache[key] = out
+    return out
+
+
+def _impl(node: Expression, box: dict, cache: dict) -> tuple[Interval, dict]:
+    if isinstance(node, (int, float)):
+        return Interval.point(float(node)), {}
+    if isinstance(node, Constant):
+        val = np.asarray(node.value, dtype=np.float64)
+        if val.ndim != 0:
+            raise _Abstain
+        return Interval.point(float(val)), {}
+    if isinstance(node, Variable):
+        return _scalar_box(node, box), {node: Interval.point(1.0)}
+    if isinstance(node, BinaryOp):
+        return _binary(node, box, cache)
+    if isinstance(node, UnaryOp):
+        return _unary(node, box, cache)
+    if isinstance(node, FunctionCall):
+        return _function(node, box, cache)
+    raise _Abstain  # IndexExpression, MatMul, SumOver, CustomCall, ... -> abstain
+
+
+# ----------------------------------------------------------------------
+# Gradient combinators (interval product / quotient rules)
+# ----------------------------------------------------------------------
+
+
+def _vars(*grads: dict) -> set:
+    out: set = set()
+    for g in grads:
+        out.update(g.keys())
+    return out
+
+
+def _get(g: dict, v) -> Interval:
+    return cast(Interval, g.get(v, Interval.point(0.0)))
+
+
+def _binary(node: BinaryOp, box: dict, cache: dict) -> tuple[Interval, dict]:
+    lo_val, lo_g = _walk(node.left, box, cache)
+    ro_val, ro_g = _walk(node.right, box, cache)
+    op = node.op
+
+    if op == "+":
+        return lo_val + ro_val, {v: _get(lo_g, v) + _get(ro_g, v) for v in _vars(lo_g, ro_g)}
+    if op == "-":
+        return lo_val - ro_val, {v: _get(lo_g, v) - _get(ro_g, v) for v in _vars(lo_g, ro_g)}
+    if op == "*":
+        # (uv)' = u' v + u v'
+        grad = {v: _get(lo_g, v) * ro_val + lo_val * _get(ro_g, v) for v in _vars(lo_g, ro_g)}
+        return lo_val * ro_val, grad
+    if op == "/":
+        if bool(np.asarray(ro_val.contains_zero())):
+            raise _Abstain
+        # (u/v)' = (u' v - u v') / v^2
+        denom = ro_val * ro_val
+        grad = {
+            v: (_get(lo_g, v) * ro_val - lo_val * _get(ro_g, v)) / denom for v in _vars(lo_g, ro_g)
+        }
+        return lo_val / ro_val, grad
+    if op == "**":
+        return _power(lo_val, lo_g, node.right)
+    raise _Abstain
+
+
+def _power(base_val: Interval, base_g: dict, exponent: Expression) -> tuple[Interval, dict]:
+    p = _as_constant(exponent)
+    if p is None:
+        raise _Abstain  # variable exponent -> abstain
+    value = _pow_value(base_val, p)
+    if not base_g:
+        return value, {}
+    # f = u^p ;  f' = p * u^(p-1) * u'
+    deriv_factor = Interval.point(float(p)) * _pow_value(base_val, p - 1.0)
+    grad = {v: deriv_factor * g for v, g in base_g.items()}
+    return value, grad
+
+
+def _pow_value(u: Interval, q: float) -> Interval:
+    """Interval enclosure of ``u**q`` for a constant exponent ``q``."""
+    if float(q).is_integer():
+        return u ** int(q)
+    # Fractional power needs a positive base; use exp(q log u).
+    if bool(np.any(np.asarray(u.lo) <= 0.0)):
+        raise _Abstain
+    return iv.exp(Interval.point(float(q)) * iv.log(u))
+
+
+def _as_constant(node: Expression) -> Optional[float]:
+    if isinstance(node, (int, float)):
+        return float(node)
+    if isinstance(node, Constant):
+        val = np.asarray(node.value)
+        if val.ndim == 0:
+            return float(val)
+    return None
+
+
+# ----------------------------------------------------------------------
+# Unary ops and named functions: value + derivative-factor per atom
+# ----------------------------------------------------------------------
+
+
+def _unary(node: UnaryOp, box: dict, cache: dict) -> tuple[Interval, dict]:
+    val, g = _walk(node.operand, box, cache)
+    if node.op == "neg":
+        return -val, {v: -gi for v, gi in g.items()}
+    if node.op == "abs":
+        factor = _abs_deriv(val)
+        return iv.absolute(val), {v: factor * gi for v, gi in g.items()}
+    raise _Abstain
+
+
+def _abs_deriv(u: Interval) -> Interval:
+    lo = _scalar(u.lo)
+    hi = _scalar(u.hi)
+    if lo >= 0.0:
+        return Interval.point(1.0)
+    if hi <= 0.0:
+        return Interval.point(-1.0)
+    return Interval.from_bounds(-1.0, 1.0)
+
+
+def _function(node: FunctionCall, box: dict, cache: dict) -> tuple[Interval, dict]:
+    if len(node.args) != 1:
+        raise _Abstain
+    u_val, u_g = _walk(node.args[0], box, cache)
+    name = node.func_name
+    value = _func_value(name, u_val)
+    factor = _func_deriv(name, u_val)
+    if not _finite(factor):
+        raise _Abstain
+    return value, {v: factor * gi for v, gi in u_g.items()}
+
+
+def _func_value(name: str, u: Interval) -> Interval:
+    if name == "exp":
+        return iv.exp(u)
+    if name == "log":
+        return _log_or_abstain(u)
+    if name == "log2":
+        return _log_or_abstain(u) * Interval.point(1.0 / _LN2)
+    if name == "log10":
+        return _log_or_abstain(u) * Interval.point(1.0 / _LN10)
+    if name == "sqrt":
+        if bool(np.any(np.asarray(u.lo) < 0.0)):
+            raise _Abstain
+        return iv.sqrt(u)
+    if name == "sin":
+        return iv.sin(u)
+    if name == "cos":
+        return iv.cos(u)
+    if name == "tan":
+        return iv.tan(u)
+    if name == "tanh":
+        return iv.tanh(u)
+    if name == "sinh":
+        return iv.sinh(u)
+    if name == "cosh":
+        return iv.cosh(u)
+    if name in ("asin", "acos", "atan"):
+        return _inverse_trig_value(name, u)
+    raise _Abstain
+
+
+def _log_or_abstain(u: Interval) -> Interval:
+    if bool(np.any(np.asarray(u.lo) <= 0.0)):
+        raise _Abstain
+    return iv.log(u)
+
+
+def _inverse_trig_value(name: str, u: Interval) -> Interval:
+    """Value enclosure for asin/acos/atan (all monotone on their domains)."""
+    lo = _scalar(u.lo)
+    hi = _scalar(u.hi)
+    if name in ("asin", "acos") and (lo < -1.0 or hi > 1.0):
+        raise _Abstain
+    if name == "asin":  # increasing
+        return Interval.from_bounds(float(np.arcsin(lo)), float(np.arcsin(hi)))
+    if name == "acos":  # decreasing
+        return Interval.from_bounds(float(np.arccos(hi)), float(np.arccos(lo)))
+    return Interval.from_bounds(float(np.arctan(lo)), float(np.arctan(hi)))  # atan, increasing
+
+
+def _func_deriv(name: str, u: Interval) -> Interval:
+    """Interval enclosure of ``g'(u)`` for a named unary atom ``g``."""
+    one = Interval.point(1.0)
+    if name == "exp":
+        return iv.exp(u)
+    if name == "log":
+        return one / _positive(u)
+    if name == "log2":
+        return Interval.point(1.0 / _LN2) / _positive(u)
+    if name == "log10":
+        return Interval.point(1.0 / _LN10) / _positive(u)
+    if name == "sqrt":
+        return Interval.point(0.5) / iv.sqrt(_positive(u))
+    if name == "sin":
+        return iv.cos(u)
+    if name == "cos":
+        return -iv.sin(u)
+    if name == "tan":
+        # sec^2 = 1 + tan^2; non-finite (asymptote crossing) -> abstain upstream
+        return one + iv.tan(u) ** 2
+    if name == "tanh":
+        return one - iv.tanh(u) ** 2
+    if name == "sinh":
+        return iv.cosh(u)
+    if name == "cosh":
+        return iv.sinh(u)
+    if name in ("asin", "acos"):
+        # d/du asin = 1/sqrt(1-u^2) ; acos is its negation
+        radicand = one - u**2
+        if bool(np.any(np.asarray(radicand.lo) <= 0.0)):
+            raise _Abstain
+        d = one / iv.sqrt(radicand)
+        return d if name == "asin" else -d
+    if name == "atan":
+        return one / (one + u**2)
+    raise _Abstain
+
+
+def _positive(u: Interval) -> Interval:
+    if bool(np.any(np.asarray(u.lo) <= 0.0)):
+        raise _Abstain
+    return u

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -222,10 +222,15 @@ class Variable(Expression):
         self.ub = np.broadcast_to(np.asarray(ub, dtype=np.float64), shape)
         self.model = model
         self._index = len(model._variables)  # Position in flat variable vector
+        # ``size`` is a hot property on the convexity / AD walkers (called
+        # once per leaf, per node visited). ``shape`` is immutable after
+        # construction, so cache the product once instead of recomputing
+        # ``int(np.prod(shape))`` on every access.
+        self._size = int(np.prod(shape)) if shape else 1
 
     @property
     def size(self) -> int:
-        return int(np.prod(self.shape))
+        return self._size
 
     def __hash__(self):
         return id(self)

--- a/python/tests/test_convexity_suspect_parity.py
+++ b/python/tests/test_convexity_suspect_parity.py
@@ -1,0 +1,211 @@
+"""Head-to-head parity: discopt's convexity detector vs. SUSPECT.
+
+SUSPECT (``cog-suspect``) is the reference MINLP special-structure detector
+from Misener's group and is referenced directly in the project's convexity
+roadmap (issue #38). This suite runs both detectors over a *single shared
+corpus* of curated instances and asserts the two soundness-critical invariants:
+
+1. **No contradictions.** Both detectors are sound (a CONVEX / CONCAVE verdict
+   is a proof). On the same ``<=``-normalised body they must never disagree
+   convex-vs-concave. A contradiction would mean one of the two tools is
+   unsound -- a hard failure.
+
+2. **No undetected SUSPECT-stronger cases.** Every instance where SUSPECT
+   proves curvature that discopt leaves UNKNOWN is a detector gap. The set of
+   such gaps is pinned (currently empty); a newly-appearing gap fails the test
+   so the regression is caught and triaged rather than silently accepted.
+
+It also guards discopt's special-pattern recognizers from regressing: the
+instances where discopt is *stronger* than SUSPECT (cone primitives SUSPECT
+cannot prove) are pinned and must remain discopt-stronger.
+
+Mechanics
+---------
+SUSPECT is unmaintained and incompatible with discopt's own numpy / pyomo, so
+it cannot run in this environment. Its verdicts are recorded once, out of
+process, into ``scripts/suspect_oracle/suspect_verdicts.json`` (see that
+directory's README for the exact, pinned environment recipe and regeneration
+command). This test imports only the *neutral corpus* and the discopt renderer
+-- never SUSPECT -- and compares discopt's live verdicts against that golden
+file. The corpus is rendered into discopt and pyomo models from the same
+neutral AST, so the comparison is genuinely on identical mathematics.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ORACLE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "suspect_oracle"
+_GOLDEN = _ORACLE_DIR / "suspect_verdicts.json"
+
+if str(_ORACLE_DIR) not in sys.path:
+    sys.path.insert(0, str(_ORACLE_DIR))
+
+pytestmark = pytest.mark.skipif(
+    not _GOLDEN.exists(),
+    reason=(
+        "SUSPECT golden verdicts not found; regenerate via "
+        "scripts/suspect_oracle/run_suspect.py (see its README)."
+    ),
+)
+
+# Instances where discopt's special-pattern recognizers prove curvature that
+# SUSPECT 2.1.3 leaves UNKNOWN. These must remain discopt-stronger -- losing
+# any of them means a recognizer regressed. (item key = "<instance>::<item>")
+EXPECTED_DISCOPT_STRONGER = frozenset(
+    {
+        "euclidean_norm::objective",  # sqrt of PSD quadratic (2-norm)
+        "quad_over_affine::objective",  # x^2 / y, y > 0
+        "exp_perspective::objective",  # y*exp(x/y), perspective of exp
+        "quad_over_affine_epigraph::qoa",  # nlp_cvx_108-style fractional epigraph
+        "norm_le::soc",  # second-order cone constraint
+    }
+)
+
+# Instances where SUSPECT proves curvature discopt misses. Pinned so a newly
+# discovered gap fails loudly instead of being silently tolerated. These are
+# SUSPECT's bound-aware trig rules: on a sign-restricted branch it proves the
+# curvature of sin / cos, which discopt's detector leaves UNKNOWN.
+KNOWN_SUSPECT_STRONGER: frozenset[str] = frozenset(
+    {
+        "sin_convex_branch::objective",  # sin convex on [pi, 2pi]
+        "cos_concave_branch::objective",  # cos concave on [-pi/2, pi/2]
+        "asin_convex_branch::objective",  # asin convex on (0, 1)
+        "acos_concave_branch::objective",  # acos concave on (0, 1)
+        "atan_concave_branch::objective",  # atan concave on x > 0
+    }
+)
+
+
+def _classify_all() -> dict[str, dict]:
+    """Run discopt's detector over the corpus and compare to the golden file.
+
+    Returns ``{item_key: {"discopt", "suspect", "category"}}`` where category is
+    one of ``agree`` / ``discopt_stronger`` / ``suspect_stronger`` /
+    ``contradiction``.
+    """
+    from corpus import INSTANCES  # local import: path set above
+    from discopt._jax.convexity import Curvature, classify_expr
+    from discopt.modeling.core import ObjectiveSense
+    from render_discopt import build_discopt
+
+    negate = {
+        Curvature.CONVEX: Curvature.CONCAVE,
+        Curvature.CONCAVE: Curvature.CONVEX,
+        Curvature.AFFINE: Curvature.AFFINE,
+        Curvature.UNKNOWN: Curvature.UNKNOWN,
+    }
+    token = {
+        Curvature.CONVEX: "convex",
+        Curvature.CONCAVE: "concave",
+        Curvature.AFFINE: "affine",
+        Curvature.UNKNOWN: "unknown",
+    }
+
+    golden = json.loads(_GOLDEN.read_text())["verdicts"]
+    results: dict[str, dict] = {}
+
+    for inst in INSTANCES:
+        name = inst["name"]
+        model, constraint_names = build_discopt(inst)
+        g = golden[name]
+
+        if model._objective is not None and g.get("objective") is not None:
+            curv = classify_expr(model._objective.expression, model)
+            if model._objective.sense == ObjectiveSense.MAXIMIZE:
+                curv = negate[curv]  # normalise max f -> min -f
+            results[f"{name}::objective"] = _compare(
+                token[curv], _norm(g["objective"]["convexity"])
+            )
+
+        for con, cname in zip(model._constraints, constraint_names):
+            curv = classify_expr(con.body, model)
+            if con.sense == ">=":
+                curv = negate[curv]  # normalise to <= form, as SUSPECT does
+            results[f"{name}::{cname}"] = _compare(
+                token[curv], _norm(g["constraints"][cname]["convexity"])
+            )
+
+    return results
+
+
+def _norm(suspect_token: str) -> str:
+    """Map SUSPECT's 'linear' to 'affine'; pass others through."""
+    return "affine" if suspect_token == "linear" else suspect_token
+
+
+def _compatible(a: str, b: str) -> bool:
+    """Affine is both convex and concave, so it never conflicts with either."""
+    if a == b:
+        return True
+    return "affine" in (a, b) and a != "unknown" and b != "unknown"
+
+
+def _compare(discopt_token: str, suspect_token: str) -> dict:
+    if _compatible(discopt_token, suspect_token):
+        category = "agree"
+    elif discopt_token != "unknown" and suspect_token == "unknown":
+        category = "discopt_stronger"
+    elif suspect_token != "unknown" and discopt_token == "unknown":
+        category = "suspect_stronger"
+    else:
+        # Both non-unknown and not compatible -> one says convex, other concave.
+        category = "contradiction"
+    return {"discopt": discopt_token, "suspect": suspect_token, "category": category}
+
+
+@pytest.fixture(scope="module")
+def parity() -> dict[str, dict]:
+    return _classify_all()
+
+
+def test_no_contradictions(parity: dict[str, dict]) -> None:
+    """Soundness: the two sound detectors never disagree convex-vs-concave."""
+    contradictions = {k: v for k, v in parity.items() if v["category"] == "contradiction"}
+    assert not contradictions, (
+        "discopt and SUSPECT give contradictory (convex vs concave) verdicts on "
+        f"identical bodies -- one detector is unsound: {contradictions}"
+    )
+
+
+def test_no_new_suspect_stronger_gaps(parity: dict[str, dict]) -> None:
+    """No instance where SUSPECT proves curvature discopt misses, beyond known gaps."""
+    suspect_stronger = {k for k, v in parity.items() if v["category"] == "suspect_stronger"}
+    new_gaps = suspect_stronger - KNOWN_SUSPECT_STRONGER
+    assert not new_gaps, (
+        "SUSPECT proves curvature discopt leaves UNKNOWN on new instances "
+        f"(detector gap to triage): {sorted(new_gaps)}"
+    )
+    stale = KNOWN_SUSPECT_STRONGER - suspect_stronger
+    assert not stale, (
+        "These instances are no longer SUSPECT-stronger; drop them from "
+        f"KNOWN_SUSPECT_STRONGER: {sorted(stale)}"
+    )
+
+
+def test_discopt_recognizers_remain_stronger(parity: dict[str, dict]) -> None:
+    """discopt's cone-primitive recognizers must keep beating SUSPECT here."""
+    discopt_stronger = {k for k, v in parity.items() if v["category"] == "discopt_stronger"}
+    regressed = EXPECTED_DISCOPT_STRONGER - discopt_stronger
+    assert not regressed, (
+        "discopt no longer proves these convex shapes that SUSPECT cannot -- "
+        f"a special-pattern recognizer regressed: {sorted(regressed)}"
+    )
+
+
+def test_corpus_fully_compared(parity: dict[str, dict]) -> None:
+    """Every golden item is exercised (guards against silent corpus drift)."""
+    golden = json.loads(_GOLDEN.read_text())["verdicts"]
+    expected_items = 0
+    for name, g in golden.items():
+        if g.get("objective") is not None:
+            expected_items += 1
+        expected_items += len(g.get("constraints", {}))
+    assert len(parity) == expected_items, (
+        f"compared {len(parity)} items but golden has {expected_items}; "
+        "corpus and golden file are out of sync -- regenerate the golden."
+    )

--- a/python/tests/test_fbbt_bounds_suspect_parity.py
+++ b/python/tests/test_fbbt_bounds_suspect_parity.py
@@ -1,0 +1,206 @@
+"""Head-to-head cross-check: discopt's interval bounds vs. SUSPECT's FBBT.
+
+SUSPECT propagates interval bounds for every expression; discopt has its own
+interval evaluator (:func:`discopt._jax.convexity.interval_eval.evaluate_interval`).
+This suite cross-checks the two enclosures of the *same raw body* over one
+shared corpus.
+
+What the two actually compute differs, and that difference is the point of the
+cross-check rather than a flaw in it:
+
+* **discopt** -- a sound *forward* natural-range enclosure: propagate the
+  variable box through the expression. It does not use a constraint's RHS.
+* **SUSPECT** -- the result of full FBBT: forward propagation *intersected with
+  backward propagation from the constraint RHS*. So on a constraint body
+  SUSPECT is typically tighter (it knows ``x^2 + y^2 <= 1``), while on
+  quadratics / powers / ``tan`` discopt is tighter (SUSPECT often leaves those
+  unbounded above).
+
+Established facts this suite encodes:
+
+* discopt's forward enclosure is **sound on every item** -- it contains the
+  body's dense numeric sampling. This is asserted directly and is the shippable
+  guarantee for the bounds API.
+* The two enclosures are **never disjoint**. Two enclosures of the same body
+  must overlap; a disjoint pair would prove one tool unsound. (SUSPECT's
+  interval trig *is* occasionally unsound -- it under-encloses ``sin`` on a wide
+  box -- but always to a *subset* of discopt's correct enclosure, so overlap
+  still holds.)
+* discopt abstains to an unbounded endpoint on a small, pinned set (the
+  sqrt-of-sum-of-squares bodies, whose inner square outward-rounds its exact 0
+  minimum just below 0 and poisons the sqrt domain, and the inverse-trig atoms
+  the interval evaluator does not model).
+
+Mechanics mirror the convexity / monotonicity suites: SUSPECT's bounds are
+recorded once into ``scripts/suspect_oracle/suspect_verdicts.json`` (see that
+directory's README); this test imports only the neutral corpus and the discopt
+renderer.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from itertools import product
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_ORACLE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "suspect_oracle"
+_GOLDEN = _ORACLE_DIR / "suspect_verdicts.json"
+
+if str(_ORACLE_DIR) not in sys.path:
+    sys.path.insert(0, str(_ORACLE_DIR))
+
+pytestmark = pytest.mark.skipif(
+    not _GOLDEN.exists(),
+    reason=(
+        "SUSPECT golden verdicts not found; regenerate via "
+        "scripts/suspect_oracle/run_suspect.py (see its README)."
+    ),
+)
+
+# Items where discopt's forward interval has an unbounded endpoint and so cannot
+# be compared for tightness. Pinned so the set cannot silently grow.
+#   - euclidean_norm / norm_le : sqrt(x^2 + y^2); the inner square's exact 0
+#     minimum outward-rounds just below 0, poisoning sqrt's domain to a -inf
+#     lower endpoint (sound, but loose).
+#   - asin / acos / atan       : the interval evaluator has no enclosure for the
+#     inverse-trig atoms and soundly returns (-inf, +inf).
+DISCOPT_UNBOUNDED: frozenset[str] = frozenset(
+    {
+        "euclidean_norm::objective",
+        "norm_le::soc",
+        "asin_convex_branch::objective",
+        "acos_concave_branch::objective",
+        "atan_concave_branch::objective",
+    }
+)
+
+_TOL = 1e-6
+
+
+def _lo(x) -> float:
+    return -math.inf if x is None else float(x)
+
+
+def _hi(x) -> float:
+    return math.inf if x is None else float(x)
+
+
+def _discopt_interval(body, model) -> tuple[float, float]:
+    from discopt._jax.convexity.interval_eval import evaluate_interval
+
+    iv = evaluate_interval(body, model)
+    return float(np.asarray(iv.lo).ravel()[0]), float(np.asarray(iv.hi).ravel()[0])
+
+
+def _sampled_range(ast, vbounds: dict, n: int = 11) -> tuple[float, float]:
+    """Min / max of the raw body sampled on a dense grid over its box."""
+    from corpus import eval_ast
+
+    names = list(vbounds)
+    grids = [np.linspace(lb, ub, n) for lb, ub in (vbounds[nm] for nm in names)]
+    mn, mx = math.inf, -math.inf
+    for combo in product(*grids):
+        env = {nm: float(t) for nm, t in zip(names, combo)}
+        y = eval_ast(ast, env)
+        mn = min(mn, y)
+        mx = max(mx, y)
+    return mn, mx
+
+
+def _iter_items():
+    """Yield ``(item_key, body, ast, vbounds, suspect_bounds)`` for every item."""
+    from corpus import INSTANCES, item_asts
+    from render_discopt import build_discopt_items
+
+    golden = json.loads(_GOLDEN.read_text())["verdicts"]
+    for inst in INSTANCES:
+        name = inst["name"]
+        asts = item_asts(inst)
+        model, items = build_discopt_items(inst)
+        g = golden[name]
+        for item in items:
+            key = item["key"]
+            gd = g["objective"] if key == "objective" else g["constraints"][key]
+            if gd is None:
+                continue
+            yield (
+                f"{name}::{key}",
+                item["body"],
+                model,
+                asts[key],
+                inst["vars"],
+                gd["bounds"],
+            )
+
+
+def test_discopt_bounds_are_sound() -> None:
+    """discopt's forward enclosure contains the body's dense numeric sampling."""
+    violations = []
+    for ikey, body, model, ast, vbounds, _sb in _iter_items():
+        dlo, dhi = _discopt_interval(body, model)
+        smn, smx = _sampled_range(ast, vbounds)
+        if dlo > smn + _TOL or dhi < smx - _TOL:
+            violations.append(
+                f"{ikey}: discopt enclosure [{dlo:.6g}, {dhi:.6g}] does not "
+                f"contain sampled range [{smn:.6g}, {smx:.6g}]"
+            )
+    assert not violations, "discopt produced an UNSOUND interval enclosure:\n" + "\n".join(
+        violations
+    )
+
+
+def test_no_disjoint_enclosures() -> None:
+    """discopt's and SUSPECT's enclosures of the same body always overlap.
+
+    Two enclosures of one quantity can never be disjoint; a disjoint pair would
+    prove one tool unsound.
+    """
+    disjoint = []
+    for ikey, body, model, _ast, _vbounds, sb in _iter_items():
+        dlo, dhi = _discopt_interval(body, model)
+        slo, shi = _lo(sb["lower"]), _hi(sb["upper"])
+        if shi < dlo - _TOL or slo > dhi + _TOL:
+            disjoint.append(
+                f"{ikey}: discopt [{dlo:.6g}, {dhi:.6g}] disjoint from "
+                f"SUSPECT [{slo:.6g}, {shi:.6g}]"
+            )
+    assert not disjoint, "discopt and SUSPECT give disjoint enclosures:\n" + "\n".join(disjoint)
+
+
+def test_discopt_unbounded_set_pinned() -> None:
+    """Exactly the pinned items have an unbounded discopt endpoint."""
+    unbounded = set()
+    for ikey, body, model, _ast, _vbounds, _sb in _iter_items():
+        dlo, dhi = _discopt_interval(body, model)
+        if math.isinf(dlo) or math.isinf(dhi):
+            unbounded.add(ikey)
+    new = unbounded - DISCOPT_UNBOUNDED
+    assert not new, (
+        "discopt's interval evaluator newly abstains to an unbounded endpoint "
+        f"on: {sorted(new)} -- tighten or add to DISCOPT_UNBOUNDED with reason."
+    )
+    stale = DISCOPT_UNBOUNDED - unbounded
+    assert not stale, (
+        "These items are no longer unbounded in discopt; drop them from "
+        f"DISCOPT_UNBOUNDED: {sorted(stale)}"
+    )
+
+
+def test_corpus_fully_compared() -> None:
+    """Every golden item is exercised (guards against silent corpus drift)."""
+    golden = json.loads(_GOLDEN.read_text())["verdicts"]
+    expected_items = 0
+    for _name, g in golden.items():
+        if g.get("objective") is not None:
+            expected_items += 1
+        expected_items += len(g.get("constraints", {}))
+    compared = sum(1 for _ in _iter_items())
+    assert compared == expected_items, (
+        f"compared {compared} items but golden has {expected_items}; "
+        "corpus and golden file are out of sync -- regenerate the golden."
+    )

--- a/python/tests/test_monotonicity.py
+++ b/python/tests/test_monotonicity.py
@@ -1,0 +1,183 @@
+"""Unit tests for per-expression monotonicity detection.
+
+Exercises :func:`discopt._jax.monotonicity.classify_monotonicity` directly (the
+SUSPECT head-to-head lives in ``test_monotonicity_suspect_parity.py``). The
+contract under test:
+
+* ``NONDECREASING`` / ``NONINCREASING`` are *proofs* obtained from an interval
+  enclosure of the gradient over the variable box.
+* ``CONSTANT`` means the expression does not vary with any decision variable.
+* ``UNKNOWN`` is a sound abstention -- mixed gradient signs, an unsupported
+  atom, a non-finite enclosure, or a domain issue.
+"""
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.convexity.interval import Interval
+from discopt._jax.monotonicity import Monotonicity, classify_monotonicity
+from discopt.modeling.core import Constant, FunctionCall, Model, _wrap
+
+ND = Monotonicity.NONDECREASING
+NI = Monotonicity.NONINCREASING
+C = Monotonicity.CONSTANT
+U = Monotonicity.UNKNOWN
+
+
+def _model_with(name="x", lb=0.0, ub=1.0):
+    m = Model("t")
+    x = m.continuous(name, lb=lb, ub=ub)
+    return m, x
+
+
+class TestLeaves:
+    def test_constant_is_constant(self):
+        assert classify_monotonicity(Constant(3.0)) == C
+
+    def test_bare_variable_is_nondecreasing(self):
+        _m, x = _model_with(lb=-2.0, ub=5.0)
+        assert classify_monotonicity(x) == ND
+
+
+class TestLinear:
+    def test_positive_coefficient_nondecreasing(self):
+        _m, x = _model_with(lb=-5.0, ub=5.0)
+        assert classify_monotonicity(3.0 * x + 1.0) == ND
+
+    def test_negative_coefficient_nonincreasing(self):
+        _m, x = _model_with(lb=-5.0, ub=5.0)
+        assert classify_monotonicity(-2.0 * x + 7.0) == NI
+
+    def test_mixed_signs_two_vars_is_unknown(self):
+        m = Model("t")
+        x = m.continuous("x", lb=-5.0, ub=5.0)
+        y = m.continuous("y", lb=-5.0, ub=5.0)
+        # +x - y : nondecreasing in x, nonincreasing in y -> not jointly either
+        assert classify_monotonicity(x - y) == U
+
+    def test_both_positive_two_vars_nondecreasing(self):
+        m = Model("t")
+        x = m.continuous("x", lb=-5.0, ub=5.0)
+        y = m.continuous("y", lb=-5.0, ub=5.0)
+        assert classify_monotonicity(x + 2.0 * y) == ND
+
+    def test_self_cancellation_is_not_falsely_directional(self):
+        """``x - x`` has zero slope, but interval subtraction cannot prove the
+        exact cancellation (it yields a sub-ULP enclosure around 0). The sound
+        result is therefore UNKNOWN -- never a (wrong) proven direction."""
+        _m, x = _model_with(lb=-5.0, ub=5.0)
+        assert classify_monotonicity(x - x) in (C, U)
+
+
+class TestMonotoneAtoms:
+    def test_exp_nondecreasing(self):
+        _m, x = _model_with(lb=-3.0, ub=3.0)
+        assert classify_monotonicity(dm.exp(x)) == ND
+
+    def test_log_nondecreasing(self):
+        _m, x = _model_with(lb=0.05, ub=10.0)
+        assert classify_monotonicity(dm.log(x)) == ND
+
+    def test_reciprocal_nonincreasing_on_positive(self):
+        _m, x = _model_with(lb=0.05, ub=10.0)
+        assert classify_monotonicity(1.0 / x) == NI
+
+    def test_sqrt_nondecreasing_strictly_positive(self):
+        _m, x = _model_with(lb=0.1, ub=10.0)
+        assert classify_monotonicity(dm.sqrt(x)) == ND
+
+    def test_tanh_nondecreasing(self):
+        _m, x = _model_with(lb=-3.0, ub=3.0)
+        assert classify_monotonicity(dm.tanh(x)) == ND
+
+
+class TestPowers:
+    def test_even_power_straddling_zero_unknown(self):
+        _m, x = _model_with(lb=-3.0, ub=3.0)
+        assert classify_monotonicity(x**2) == U
+
+    def test_even_power_positive_branch_nondecreasing(self):
+        _m, x = _model_with(lb=0.5, ub=3.0)
+        assert classify_monotonicity(x**2) == ND
+
+    def test_negative_even_power_nonincreasing_on_positive(self):
+        _m, x = _model_with(lb=0.1, ub=5.0)
+        # x^-2 is decreasing on x > 0
+        assert classify_monotonicity(x**-2) == NI
+
+
+class TestInverseTrig:
+    def test_asin_nondecreasing(self):
+        _m, x = _model_with(lb=0.1, ub=0.9)
+        expr = FunctionCall("asin", _wrap(x))
+        assert classify_monotonicity(expr) == ND
+
+    def test_acos_nonincreasing(self):
+        _m, x = _model_with(lb=0.1, ub=0.9)
+        expr = FunctionCall("acos", _wrap(x))
+        assert classify_monotonicity(expr) == NI
+
+    def test_atan_nondecreasing(self):
+        _m, x = _model_with(lb=-3.0, ub=3.0)
+        expr = FunctionCall("atan", _wrap(x))
+        assert classify_monotonicity(expr) == ND
+
+
+class TestSoundAbstentions:
+    def test_abs_straddling_zero_unknown(self):
+        _m, x = _model_with(lb=-5.0, ub=5.0)
+        assert classify_monotonicity(abs(x)) == U
+
+    def test_sine_wide_box_unknown(self):
+        _m, x = _model_with(lb=-3.0, ub=3.0)
+        assert classify_monotonicity(dm.sin(x)) == U
+
+    def test_unsupported_atom_unknown(self):
+        _m, x = _model_with(lb=0.1, ub=0.9)
+        assert classify_monotonicity(FunctionCall("erf", _wrap(x))) == U
+
+    def test_bilinear_unknown(self):
+        m = Model("t")
+        x = m.continuous("x", lb=-5.0, ub=5.0)
+        y = m.continuous("y", lb=-5.0, ub=5.0)
+        assert classify_monotonicity(x * y) == U
+
+
+class TestBoxOverride:
+    def test_box_override_changes_verdict(self):
+        """Restricting abs to a positive branch via ``box`` proves the direction."""
+        _m, x = _model_with(lb=-5.0, ub=5.0)
+        # On the declared box [-5, 5], |x| is UNKNOWN ...
+        assert classify_monotonicity(abs(x)) == U
+        # ... but restricted to a strictly positive box it is nondecreasing.
+        box = {x: Interval(np.float64(1.0), np.float64(5.0))}
+        assert classify_monotonicity(abs(x), box=box) == ND
+
+
+class TestSoundnessAgainstSampling:
+    """A proven direction must match a dense numeric sampling of the body.
+
+    Each case pairs the symbolic builder (fed to ``classify_monotonicity``) with
+    the matching closed form (sampled with numpy), so the proof is checked
+    against the real function, not just a label.
+    """
+
+    @pytest.mark.parametrize(
+        "build, closed_form, lb, ub, expected",
+        [
+            (lambda x: dm.exp(x), np.exp, -2.0, 2.0, ND),
+            (lambda x: 1.0 / x, lambda t: 1.0 / t, 0.1, 4.0, NI),
+            (lambda x: dm.log(x), np.log, 0.2, 9.0, ND),
+            (lambda x: -3.0 * x, lambda t: -3.0 * t, -4.0, 4.0, NI),
+            (lambda x: dm.sqrt(x), np.sqrt, 0.1, 9.0, ND),
+        ],
+    )
+    def test_direction_matches_samples(self, build, closed_form, lb, ub, expected):
+        _m, x = _model_with(lb=lb, ub=ub)
+        assert classify_monotonicity(build(x)) == expected
+
+        ys = closed_form(np.linspace(lb, ub, 101))
+        if expected is ND:
+            assert np.all(np.diff(ys) >= -1e-9)
+        else:
+            assert np.all(np.diff(ys) <= 1e-9)

--- a/python/tests/test_monotonicity_suspect_parity.py
+++ b/python/tests/test_monotonicity_suspect_parity.py
@@ -1,0 +1,268 @@
+"""Head-to-head parity: discopt's monotonicity detector vs. SUSPECT.
+
+This is the monotonicity counterpart to ``test_convexity_suspect_parity.py``.
+SUSPECT (``cog-suspect``) reports a per-expression ``Monotonicity`` verdict
+(Ceccon, Siirola, Misener, 2020) on the *raw* body -- increasing / decreasing /
+constant / unknown. discopt now exposes a comparable verdict via
+:func:`discopt._jax.monotonicity.classify_monotonicity`. Both run over a single
+shared corpus and are compared item-by-item.
+
+A key asymmetry, established when this suite was built, shapes what is asserted:
+
+* **discopt's monotonicity is rigorous.** A ``NONDECREASING`` / ``NONINCREASING``
+  verdict is an interval-gradient *proof* (``∇f`` enclosed in the nonneg / nonpos
+  orthant over the whole box). Every such verdict is validated here directly
+  against a dense numeric sampling of the real body -- independent of SUSPECT.
+
+* **SUSPECT's monotonicity is heuristic and occasionally unsound.** Its interval
+  cosine ignores interior critical points, so e.g. it declares ``sin`` monotone
+  on ``[-3, 3]`` where it is not. discopt correctly abstains there. So a
+  *disagreement* is not evidence against discopt; discopt's verdicts stand on
+  their own validated soundness, and SUSPECT is the side that errs.
+
+Assertions
+----------
+1. **discopt monotonicity is sound** -- every discopt monotone verdict matches a
+   coordinate-wise numeric sampling of the body (the shippable guarantee).
+2. **No proven-direction contradictions** -- discopt and SUSPECT never prove
+   opposite directions (nondecreasing vs nonincreasing) on the same body.
+   Because discopt's side is independently validated sound, any such conflict
+   would be a SUSPECT defect; the set is pinned empty.
+3. **Detector-gap sets are pinned** -- instances where one side proves a
+   direction the other leaves UNKNOWN are pinned so a regression (or a newly
+   closed gap) is caught and triaged rather than silently drifting.
+
+Mechanics mirror the convexity suite: SUSPECT cannot run in this environment,
+so its verdicts are recorded once into
+``scripts/suspect_oracle/suspect_verdicts.json`` (see that directory's README).
+This test imports only the neutral corpus and the discopt renderer.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from itertools import product
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_ORACLE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "suspect_oracle"
+_GOLDEN = _ORACLE_DIR / "suspect_verdicts.json"
+
+if str(_ORACLE_DIR) not in sys.path:
+    sys.path.insert(0, str(_ORACLE_DIR))
+
+pytestmark = pytest.mark.skipif(
+    not _GOLDEN.exists(),
+    reason=(
+        "SUSPECT golden verdicts not found; regenerate via "
+        "scripts/suspect_oracle/run_suspect.py (see its README)."
+    ),
+)
+
+# Instances where SUSPECT proves a monotone direction discopt leaves UNKNOWN.
+# Pinned so a newly discovered gap fails loudly. These are sound *for SUSPECT to
+# report* only in the first two cases; the third is a SUSPECT defect that
+# discopt rightly avoids:
+#   - sqrt_concave : sqrt is nondecreasing, but its derivative is unbounded at
+#     x=0 (the box touches 0), so discopt's interval-gradient enclosure abstains.
+#   - cubic        : x^3 is nondecreasing (3x^2 >= 0), but squaring outward-rounds
+#     the exact 0 minimum to a sub-ULP negative, so the gradient enclosure admits
+#     a negative sliver and discopt abstains. A sound (if conservative) miss.
+#   - sine         : SUSPECT declares sin(x) on [-3, 3] *nonincreasing* via its
+#     unsound interval cosine; sin is NOT monotone there. discopt correctly
+#     abstains. This entry documents a SUSPECT unsoundness, not a discopt gap.
+KNOWN_SUSPECT_STRONGER: frozenset[str] = frozenset(
+    {
+        "sqrt_concave::objective",
+        "cubic::objective",
+        "sine::objective",
+    }
+)
+
+# Instances where discopt proves a direction SUSPECT leaves UNKNOWN. Pinned so a
+# recognizer regression is caught. Currently none.
+EXPECTED_DISCOPT_STRONGER: frozenset[str] = frozenset()
+
+_DIRECTIONS = {
+    "nondecreasing": "nondecreasing",
+    "nonincreasing": "nonincreasing",
+    "constant": "constant",
+    "unknown": "unknown",
+}
+
+
+def _token(verdict) -> str:
+    """discopt ``Monotonicity`` enum -> short lowercase token."""
+    return verdict.value
+
+
+def _compatible(a: str, b: str) -> bool:
+    """``constant`` is both nondecreasing and nonincreasing, so it never
+    conflicts with a proven direction (mirrors affine ⊆ convex∩concave)."""
+    if a == b:
+        return True
+    return "constant" in (a, b) and a != "unknown" and b != "unknown"
+
+
+def _compare(discopt_token: str, suspect_token: str) -> dict:
+    if _compatible(discopt_token, suspect_token):
+        category = "agree"
+    elif discopt_token != "unknown" and suspect_token == "unknown":
+        category = "discopt_stronger"
+    elif suspect_token != "unknown" and discopt_token == "unknown":
+        category = "suspect_stronger"
+    else:
+        # Both proven and incompatible -> one says nondecreasing, other
+        # nonincreasing on the same raw body.
+        category = "contradiction"
+    return {"discopt": discopt_token, "suspect": suspect_token, "category": category}
+
+
+def _classify_all() -> dict[str, dict]:
+    """discopt vs golden monotonicity verdicts, keyed ``<instance>::<item>``."""
+    from corpus import INSTANCES
+    from discopt._jax.monotonicity import classify_monotonicity
+    from render_discopt import build_discopt_items
+
+    golden = json.loads(_GOLDEN.read_text())["verdicts"]
+    results: dict[str, dict] = {}
+
+    for inst in INSTANCES:
+        name = inst["name"]
+        model, items = build_discopt_items(inst)
+        g = golden[name]
+        for item in items:
+            key = item["key"]
+            gd = g["objective"] if key == "objective" else g["constraints"][key]
+            if gd is None:
+                continue
+            discopt_token = _token(classify_monotonicity(item["body"], model))
+            suspect_token = _DIRECTIONS.get(gd["monotonicity"], "unknown")
+            results[f"{name}::{key}"] = _compare(discopt_token, suspect_token)
+
+    return results
+
+
+# --- Independent numeric validation of discopt's verdicts --------------------
+
+
+def _sampled_directions(ast, vbounds: dict, n: int = 9) -> dict:
+    """Coordinate-wise monotonicity of ``ast`` sampled over its box.
+
+    Returns ``{"nondecreasing": bool, "nonincreasing": bool, "constant": bool}``
+    where each flag is whether the *sampled* body is consistent with that
+    property: holding every other variable fixed on a grid, sweep one variable
+    and check the value never decreases / never increases / never changes.
+    """
+    from corpus import eval_ast
+
+    names = list(vbounds)
+    grids = {nm: np.linspace(lb, ub, n) for nm, (lb, ub) in vbounds.items()}
+    nondec = noninc = const = True
+    for vi in names:
+        others = [o for o in names if o != vi]
+        other_combos = product(*[grids[o] for o in others]) if others else [()]
+        for combo in other_combos:
+            base = dict(zip(others, combo))
+            seq = [eval_ast(ast, {**base, vi: float(t)}) for t in grids[vi]]
+            for a, b in zip(seq, seq[1:]):
+                tol = 1e-7 * (1.0 + max(abs(a), abs(b)))
+                if b < a - tol:
+                    nondec = False
+                if b > a + tol:
+                    noninc = False
+                if abs(b - a) > tol:
+                    const = False
+    return {"nondecreasing": nondec, "nonincreasing": noninc, "constant": const}
+
+
+@pytest.fixture(scope="module")
+def parity() -> dict[str, dict]:
+    return _classify_all()
+
+
+def test_discopt_monotonicity_is_sound() -> None:
+    """Every discopt monotone/constant verdict matches a dense numeric sampling.
+
+    This validates discopt's detector directly against the real body, with no
+    reference to SUSPECT -- the core soundness guarantee for the new API.
+    """
+    from corpus import INSTANCES, item_asts
+    from discopt._jax.monotonicity import classify_monotonicity
+    from render_discopt import build_discopt_items
+
+    violations = []
+    for inst in INSTANCES:
+        asts = item_asts(inst)
+        model, items = build_discopt_items(inst)
+        for item in items:
+            key = item["key"]
+            token = _token(classify_monotonicity(item["body"], model))
+            if token == "unknown":
+                continue  # abstentions need no witness
+            sampled = _sampled_directions(asts[key], inst["vars"])
+            if not sampled[token]:
+                violations.append(
+                    f"{inst['name']}::{key} discopt says {token} but sampling "
+                    f"contradicts it (sampled={sampled})"
+                )
+    assert not violations, "discopt produced an UNSOUND monotonicity verdict:\n" + "\n".join(
+        violations
+    )
+
+
+def test_no_monotonicity_contradictions(parity: dict[str, dict]) -> None:
+    """discopt and SUSPECT never prove opposite directions on the same body.
+
+    discopt's verdicts are independently validated sound (see the sampling
+    test), so a contradiction here would be a SUSPECT defect. The set is empty.
+    """
+    contradictions = {k: v for k, v in parity.items() if v["category"] == "contradiction"}
+    assert not contradictions, (
+        "discopt and SUSPECT give opposite monotone directions on identical raw "
+        f"bodies: {contradictions}"
+    )
+
+
+def test_monotonicity_gaps_pinned(parity: dict[str, dict]) -> None:
+    """Detector-gap sets (either side stronger) must match the pinned sets."""
+    suspect_stronger = {k for k, v in parity.items() if v["category"] == "suspect_stronger"}
+    new_gaps = suspect_stronger - KNOWN_SUSPECT_STRONGER
+    assert not new_gaps, (
+        "SUSPECT proves a monotone direction discopt leaves UNKNOWN on new "
+        f"instances (gap to triage): {sorted(new_gaps)}"
+    )
+    stale = KNOWN_SUSPECT_STRONGER - suspect_stronger
+    assert not stale, (
+        "These instances are no longer SUSPECT-stronger; drop them from "
+        f"KNOWN_SUSPECT_STRONGER: {sorted(stale)}"
+    )
+
+    discopt_stronger = {k for k, v in parity.items() if v["category"] == "discopt_stronger"}
+    regressed = EXPECTED_DISCOPT_STRONGER - discopt_stronger
+    assert not regressed, (
+        "discopt no longer proves these monotone directions SUSPECT misses -- "
+        f"a regression: {sorted(regressed)}"
+    )
+    unexpected = discopt_stronger - EXPECTED_DISCOPT_STRONGER
+    assert not unexpected, (
+        "discopt newly proves a direction SUSPECT misses; if intended, add to "
+        f"EXPECTED_DISCOPT_STRONGER: {sorted(unexpected)}"
+    )
+
+
+def test_corpus_fully_compared(parity: dict[str, dict]) -> None:
+    """Every golden item is exercised (guards against silent corpus drift)."""
+    golden = json.loads(_GOLDEN.read_text())["verdicts"]
+    expected_items = 0
+    for _name, g in golden.items():
+        if g.get("objective") is not None:
+            expected_items += 1
+        expected_items += len(g.get("constraints", {}))
+    assert len(parity) == expected_items, (
+        f"compared {len(parity)} items but golden has {expected_items}; "
+        "corpus and golden file are out of sync -- regenerate the golden."
+    )

--- a/scripts/detector_timing.py
+++ b/scripts/detector_timing.py
@@ -1,0 +1,205 @@
+"""Detector-timing benchmark — baseline the Rust-port discussion for issue #38.
+
+discopt's structure detectors in ``python/discopt/_jax/convexity/`` and the new
+``python/discopt/_jax/monotonicity.py`` are pure Python today. A Rust port only
+pays off if (a) detection is a measurable share of work and (b) the hot path is
+*interpreter-bound* DAG walking rather than already-vectorised numpy/JAX kernels.
+This script measures both, on two workloads, and prints a cProfile breakdown so
+the bottleneck is visible rather than assumed.
+
+Paths timed (the public detector entry points):
+  * ``classify_expr``         — lattice curvature walk (DCP composition rules)
+  * ``certify_convex``        — interval-AD Hessian + eigenvalue lower bound
+  * ``classify_monotonicity`` — forward interval-gradient orthant test
+  * ``evaluate_interval``     — forward natural-range interval enclosure
+
+Workloads:
+  1. Corpus      — the 40-instance suspect_oracle corpus (realistic, mixed atoms).
+  2. Scaling     — synthetic convex expressions of growing node count N, to expose
+                   per-node interpreter cost and how each detector scales in N.
+
+Usage::
+
+    python scripts/detector_timing.py            # full run + cProfile
+    python scripts/detector_timing.py --quick     # fewer repeats / smaller sweep
+    python scripts/detector_timing.py --no-profile
+"""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import io
+import pstats
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+import discopt.modeling as dm
+from discopt import Model
+from discopt._jax.convexity import certify_convex, classify_expr
+from discopt._jax.convexity.interval_eval import evaluate_interval
+from discopt._jax.monotonicity import classify_monotonicity
+
+_ORACLE_DIR = Path(__file__).resolve().parent / "suspect_oracle"
+if str(_ORACLE_DIR) not in sys.path:
+    sys.path.insert(0, str(_ORACLE_DIR))
+
+
+# --------------------------------------------------------------------------- #
+# Timing helpers
+# --------------------------------------------------------------------------- #
+def _time(fn: Callable[[], object], repeat: int) -> float:
+    """Best-of-``repeat`` median wall time (seconds) for a zero-arg call."""
+    samples = []
+    for _ in range(repeat):
+        t0 = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - t0)
+    samples.sort()
+    return samples[len(samples) // 2]
+
+
+def _count_nodes(expr: object, seen: set | None = None) -> int:
+    """Count distinct Expression nodes reachable from ``expr`` (DAG-aware)."""
+    from discopt.modeling.core import Expression
+
+    if seen is None:
+        seen = set()
+    if id(expr) in seen:
+        return 0
+    seen.add(id(expr))
+    n = 1
+    for v in vars(expr).values():
+        if isinstance(v, Expression):
+            n += _count_nodes(v, seen)
+        elif isinstance(v, (list, tuple)):
+            for it in v:
+                if isinstance(it, Expression):
+                    n += _count_nodes(it, seen)
+    return n
+
+
+# --------------------------------------------------------------------------- #
+# The four detector paths, each as a () -> value thunk over (expr, model)
+# --------------------------------------------------------------------------- #
+DETECTORS: dict[str, Callable[[object, Model], Callable[[], object]]] = {
+    "classify_expr": lambda e, m: (lambda: classify_expr(e, m)),
+    "certify_convex": lambda e, m: (lambda: certify_convex(e, m)),
+    "classify_monotonicity": lambda e, m: (lambda: classify_monotonicity(e, m)),
+    "evaluate_interval": lambda e, m: (lambda: evaluate_interval(e, m)),
+}
+
+
+# --------------------------------------------------------------------------- #
+# Workload 1: the suspect_oracle corpus
+# --------------------------------------------------------------------------- #
+def _corpus_items() -> list[tuple[str, object, Model, int]]:
+    """`(key, raw_body, model, node_count)` for every corpus item."""
+    from corpus import INSTANCES  # noqa: PLC0415
+    from render_discopt import build_discopt_items  # noqa: PLC0415
+
+    out = []
+    for inst in INSTANCES:
+        model, items = build_discopt_items(inst)
+        for item in items:
+            body = item["body"]
+            out.append(
+                (f"{inst['name']}::{item['key']}", body, model, _count_nodes(body))
+            )
+    return out
+
+
+def run_corpus(repeat: int) -> None:
+    items = _corpus_items()
+    total_nodes = sum(n for _, _, _, n in items)
+    print(f"\n=== Workload 1: suspect_oracle corpus "
+          f"({len(items)} items, {total_nodes} total nodes) ===")
+    print(f"{'detector':<24}{'total ms':>12}{'µs / item':>14}{'µs / node':>14}")
+    for name, make in DETECTORS.items():
+        total = 0.0
+        for _key, body, model, _n in items:
+            try:
+                total += _time(make(body, model), repeat)
+            except Exception:  # a detector may not support every atom; skip
+                pass
+        per_item = total / len(items) * 1e6
+        per_node = total / total_nodes * 1e6
+        print(f"{name:<24}{total * 1e3:>12.3f}{per_item:>14.2f}{per_node:>14.3f}")
+
+
+# --------------------------------------------------------------------------- #
+# Workload 2: synthetic scaling sweep
+# --------------------------------------------------------------------------- #
+def _build_chain(n_terms: int) -> tuple[object, Model]:
+    """A convex expression with ~``n_terms`` atom terms: sum of squares, exp,
+    softplus-ish logs, over distinct variables — every term a real atom so the
+    detectors do genuine per-node work (not a trivially-foldable constant)."""
+    m = Model(f"scale{n_terms}")
+    xs = [m.continuous(f"x{i}", lb=0.1, ub=2.0) for i in range(n_terms)]
+    expr: object = dm.exp(xs[0])
+    for i, x in enumerate(xs):
+        if i % 3 == 0:
+            expr = expr + x * x
+        elif i % 3 == 1:
+            expr = expr + dm.exp(x)
+        else:
+            expr = expr - dm.log(x)  # -log is convex
+    return expr, m
+
+
+def run_scaling(sizes: list[int], repeat: int) -> None:
+    print("\n=== Workload 2: synthetic scaling sweep (convex sum) ===")
+    header = f"{'N nodes':>10}" + "".join(f"{d:>22}" for d in DETECTORS)
+    print(header)
+    print(f"{'':>10}" + "".join(f"{'ms (µs/node)':>22}" for _ in DETECTORS))
+    for n_terms in sizes:
+        expr, model = _build_chain(n_terms)
+        nodes = _count_nodes(expr)
+        row = f"{nodes:>10}"
+        for _name, make in DETECTORS.items():
+            try:
+                t = _time(make(expr, model), repeat)
+                row += f"{t * 1e3:>11.2f}({t / nodes * 1e6:>6.2f})"
+            except Exception:
+                row += f"{'err':>22}"
+        print(row)
+
+
+# --------------------------------------------------------------------------- #
+# cProfile breakdown — the Rust-port signal
+# --------------------------------------------------------------------------- #
+def run_profile(n_terms: int, repeat: int) -> None:
+    expr, model = _build_chain(n_terms)
+    nodes = _count_nodes(expr)
+    print(f"\n=== cProfile: certify_convex on N={nodes}-node expr "
+          f"(×{repeat}) — the likely hot path ===")
+    pr = cProfile.Profile()
+    pr.enable()
+    for _ in range(repeat):
+        certify_convex(expr, model)
+    pr.disable()
+    s = io.StringIO()
+    pstats.Stats(pr, stream=s).sort_stats("cumulative").print_stats(20)
+    print(s.getvalue())
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--quick", action="store_true", help="fewer repeats / smaller sweep")
+    ap.add_argument("--no-profile", action="store_true", help="skip the cProfile breakdown")
+    args = ap.parse_args(argv)
+
+    repeat = 3 if args.quick else 7
+    sizes = [4, 16, 64] if args.quick else [4, 16, 64, 128, 256]
+
+    run_corpus(repeat=repeat)
+    run_scaling(sizes=sizes, repeat=repeat)
+    if not args.no_profile:
+        run_profile(n_terms=sizes[-1], repeat=20 if args.quick else 50)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/suspect_oracle/README.md
+++ b/scripts/suspect_oracle/README.md
@@ -1,0 +1,198 @@
+# discopt ⟷ SUSPECT head-to-head
+
+A direct, agree/disagree comparison of discopt's structure detectors against
+[SUSPECT](https://github.com/cog-imperial/suspect) (`cog-suspect`), the MINLP
+special-structure detector from Misener's group referenced in issue #38.
+
+Both tools run over **one shared corpus** of curated instances, compared on the
+three axes SUSPECT reports:
+
+| Axis | discopt API | Live test |
+|------|-------------|-----------|
+| **Convexity** | `discopt._jax.convexity.classify_expr` | [`test_convexity_suspect_parity.py`](../../python/tests/test_convexity_suspect_parity.py) |
+| **Monotonicity** | `discopt._jax.monotonicity.classify_monotonicity` | [`test_monotonicity_suspect_parity.py`](../../python/tests/test_monotonicity_suspect_parity.py) |
+| **Interval bounds (FBBT)** | `discopt._jax.convexity.interval_eval.evaluate_interval` | [`test_fbbt_bounds_suspect_parity.py`](../../python/tests/test_fbbt_bounds_suspect_parity.py) |
+
+A key asymmetry, established when the monotonicity / bounds axes were added,
+shapes what each test asserts:
+
+* **discopt's verdicts are rigorous.** A convex/concave, nondecreasing/
+  nonincreasing, or interval-bound verdict is a *proof* (interval Hessian /
+  gradient / value enclosure). Each monotonicity and bounds verdict is validated
+  directly against a dense numeric sampling of the real body — independent of
+  SUSPECT.
+* **SUSPECT's monotonicity and bounds are heuristic and occasionally unsound.**
+  Its interval cosine ignores interior critical points, so it e.g. declares
+  `sin` monotone — and mis-bounds it — on `[-3, 3]`, where it is neither. discopt
+  correctly abstains / encloses there. (Its *convexity* axis, by contrast, is
+  sound, so that test asserts mutual no-contradiction symmetrically.)
+
+### Convexity invariants
+
+1. **No contradictions** — neither tool ever proves *convex* where the other
+   proves *concave* on the same `≤`-normalised body. Both are sound here, so a
+   contradiction would mean one is buggy.
+2. **No undetected SUSPECT-stronger cases** — every instance where SUSPECT
+   proves curvature discopt misses is a tracked detector gap (currently five:
+   SUSPECT's bound-aware trig and inverse-trig rules on a sign-restricted
+   branch, see below).
+
+### Monotonicity invariants
+
+1. **discopt monotonicity is sound** — every discopt nondecreasing /
+   nonincreasing / constant verdict matches a coordinate-wise numeric sampling.
+2. **No proven-direction contradictions** — the two never prove opposite
+   directions on the same raw body (pinned empty; discopt's independently
+   validated soundness means any conflict would be a SUSPECT defect).
+3. **Detector-gap sets pinned** — three SUSPECT-stronger items
+   (`sqrt_concave`, `cubic`, `sine`) are tracked; the first two are sound
+   discopt conservatism (domain-edge / sub-ULP), the third a SUSPECT unsoundness
+   discopt rightly avoids.
+
+### FBBT interval-bounds invariants
+
+discopt's `evaluate_interval` is a *forward* natural-range enclosure (it does
+not use a constraint's RHS); SUSPECT's `bounds.get(...)` is full FBBT (forward ∩
+backward-from-RHS), so on constraint bodies SUSPECT is typically tighter, while
+on quadratics / powers / `tan` discopt is tighter (SUSPECT leaves those
+unbounded). The test asserts:
+
+1. **discopt bounds are sound** — the forward enclosure contains the body's
+   dense numeric sampling on every item.
+2. **No disjoint enclosures** — discopt's and SUSPECT's enclosures of the same
+   body always overlap (a disjoint pair would prove one tool unsound).
+3. **Unbounded-abstention set pinned** — the five items where discopt's forward
+   pass abstains to an unbounded endpoint (sqrt-of-sum-of-squares, inverse trig)
+   are tracked so the set cannot silently grow.
+
+## Why SUSPECT runs out of process
+
+`cog-suspect` 2.1.3 is unmaintained and incompatible with discopt's runtime:
+it imports `np.float` (removed in numpy ≥ 1.24) and Pyomo's
+`ReciprocalExpression` (removed in Pyomo ≥ 6.2), neither of which can coexist
+with discopt's numpy 2.x / Pyomo 6.10. So SUSPECT cannot be a live dependency.
+
+Instead its verdicts are recorded **once**, in an isolated environment, into
+the committed golden file [`suspect_verdicts.json`](suspect_verdicts.json). The
+parity test imports only the neutral corpus and the discopt renderer — never
+SUSPECT — and compares discopt's live verdicts against that golden file.
+
+## Files
+
+| File | Environment | Purpose |
+|------|-------------|---------|
+| `corpus.py` | none (stdlib only) | Single source of truth: a neutral expression AST + 40 curated instances, plus a numeric `eval_ast` used to validate verdicts against the real body. Imported by *both* sides. |
+| `render_pyomo.py` | SUSPECT env | Renders the neutral AST into Pyomo models. |
+| `run_suspect.py` | SUSPECT env | Runs SUSPECT over the corpus (convexity + monotonicity + FBBT bounds), writes `suspect_verdicts.json`. |
+| `render_discopt.py` | discopt env | Renders the *same* AST into discopt models; `build_discopt_items` also exposes each item's *raw* (pre-canonicalisation) body for the monotonicity / bounds cross-checks. |
+| `suspect_verdicts.json` | — | Committed golden verdicts (all three axes per item). |
+
+Because both renderers walk the same neutral AST, the comparison is a genuine
+head-to-head on identical mathematics, not two independently hand-written
+models that might silently differ.
+
+## Regenerating the golden file
+
+Only needed when the corpus changes. Build the pinned, isolated SUSPECT
+environment and run the oracle:
+
+```bash
+# 1. Create an isolated env (SUSPECT needs an old, narrow dependency window).
+uv venv /tmp/suspect_oracle_env -p 3.10
+source /tmp/suspect_oracle_env/bin/activate
+
+# 2. Pin the exact compatible versions:
+#    - pyomo 6.0–6.1 is the only window with BOTH ScalarExpression (≥6.0) and
+#      ReciprocalExpression (removed in 6.2);
+#    - numpy 1.23.x still provides the np.float alias SUSPECT imports;
+#    - setuptools<81 still ships pkg_resources.
+uv pip install "cog-suspect==2.1.3" "pyomo==6.1.2" "numpy==1.23.5" "setuptools<81"
+
+# 3. Generate (writes suspect_verdicts.json next to run_suspect.py):
+cd scripts/suspect_oracle
+python run_suspect.py            # or: python run_suspect.py --check  (print only)
+```
+
+`run_suspect.py` installs small `np.float`/`np.int`/… shims at import time and
+isolates each instance in its own `try/except` (SUSPECT's interval FBBT can
+raise `EmptyIntervalError` on degenerate boxes), so one failing instance never
+sinks the whole run. The instance count and any SUSPECT errors are recorded in
+the file's `_meta` block.
+
+After regenerating, re-run the parity test and update the pinned
+`EXPECTED_DISCOPT_STRONGER` / `KNOWN_SUSPECT_STRONGER` sets in the test if the
+agreement profile changed:
+
+```bash
+pytest python/tests/test_convexity_suspect_parity.py \
+       python/tests/test_monotonicity_suspect_parity.py \
+       python/tests/test_fbbt_bounds_suspect_parity.py -v
+```
+
+## Current result (40 instances, 43 compared items)
+
+### Convexity
+
+| Category | Count | Meaning |
+|----------|------:|---------|
+| agree | 33 | identical verdicts (modulo affine ⊆ convex∩concave) |
+| discopt-stronger | 5 | discopt proves curvature where SUSPECT abstains |
+| SUSPECT-stronger | 5 | SUSPECT proves curvature discopt leaves UNKNOWN |
+| contradiction | 0 | — |
+
+The five **discopt-stronger** items are exactly the cone primitives SUSPECT
+2.1.3 does not recognise: the Euclidean norm (`sqrt` of a PSD quadratic),
+quadratic-over-affine (`x²/y`), the perspective of `exp` (`y·exp(x/y)`), the
+`nlp_cvx_108`-style fractional epigraph, and a second-order-cone constraint.
+
+The five **SUSPECT-stronger** items are SUSPECT's bound-aware trig / inverse-trig
+rules: on a sign-restricted branch it proves `sin` convex (`[π, 2π]`), `cos`
+concave (`[−π/2, π/2]`), `asin` convex (`(0,1)`), `acos` concave (`(0,1)`), and
+`atan` concave (`x > 0`) — curvature discopt's detector currently leaves
+UNKNOWN. They are pinned in `KNOWN_SUSPECT_STRONGER` as tracked detector gaps.
+
+### Monotonicity
+
+| Category | Count | Meaning |
+|----------|------:|---------|
+| agree | 40 | identical direction (modulo constant ⊆ nondec∩noninc) |
+| discopt-stronger | 0 | — |
+| SUSPECT-stronger | 3 | `sqrt_concave`, `cubic`, `sine` (see invariants above) |
+| contradiction | 0 | — |
+
+Every discopt nondecreasing / nonincreasing / constant verdict is also checked
+against a coordinate-wise numeric sampling of the body, so the comparison rests
+on discopt's own validated soundness rather than on trusting SUSPECT.
+
+### FBBT interval bounds
+
+discopt's forward enclosure is **sound on all 43 items** (contains the sampled
+range), and the two enclosures are **never disjoint**. The enclosures rarely
+coincide exactly because they compute different things (forward natural range vs
+full FBBT) — for constraints SUSPECT is tighter (it uses the RHS); for
+quadratics / powers / `tan` discopt is tighter (SUSPECT leaves them unbounded).
+discopt abstains to an unbounded endpoint on five items (`euclidean_norm`,
+`norm_le`, and the three inverse-trig objectives), pinned in
+`DISCOPT_UNBOUNDED`.
+
+## Atom-coverage gaps
+
+The corpus walks SUSPECT's *buildable* atom × regime matrix (abs, tan, log2,
+the full power-exponent set, bound-restricted convex trig, and inverse trig).
+discopt's expression layer is a generic `FunctionCall` node whose JAX backend
+already maps every atom SUSPECT has a rule for (`asin → jnp.arcsin`, etc.), so
+**discopt can represent everything SUSPECT can** — `asin`/`acos`/`atan` simply
+lack a `discopt.modeling` convenience wrapper and are built directly via
+`FunctionCall` in `render_discopt.py`. Hence `UNBUILDABLE_SUSPECT_ATOMS` is
+**empty**.
+
+The only one-directional gap is the reverse: atoms discopt expresses but
+SUSPECT 2.1.3 cannot, recorded as a named constant in `corpus.py`:
+
+| Constant | Atoms | Reason |
+|----------|-------|--------|
+| `UNBUILDABLE_SUSPECT_ATOMS` | *(none)* | discopt's `FunctionCall` backend represents every SUSPECT atom. |
+| `SUSPECT_UNSUPPORTED_ATOMS` | `tanh`, `sinh`, `cosh`, `log10` | discopt expresses them, but SUSPECT 2.1.3 raises `ValueError: Unknown function type` (no rule in its registry). |
+
+(`log2` *is* buildable: it is rendered as a positively-scaled native `log`, so
+SUSPECT sees an ordinary concave `log` rather than a dedicated atom.)

--- a/scripts/suspect_oracle/corpus.py
+++ b/scripts/suspect_oracle/corpus.py
@@ -1,0 +1,617 @@
+"""Neutral instance corpus for the discopt vs. SUSPECT convexity head-to-head.
+
+This module is the **single source of truth** for the shared instance set. It
+is deliberately dependency-free (standard library only) so it can be imported
+*both* by the discopt-side parity test (modern numpy / pyomo-free environment)
+*and* by the SUSPECT oracle runner (isolated py3.10 + pyomo 6.1.2 environment).
+Neither tool's model objects appear here; each side renders the same neutral
+AST into its own representation, which is what makes the comparison a genuine
+head-to-head on identical mathematics rather than two hand-written models that
+might silently differ.
+
+Expression AST
+--------------
+An expression is one of:
+
+* ``int`` / ``float``                      -- a numeric constant
+* ``("var", name)``                        -- a decision variable
+* ``("+", a, b, ...)``                      -- n-ary sum
+* ``("-", a, b)``                           -- binary difference
+* ``("*", a, b, ...)``                      -- n-ary product
+* ``("/", a, b)``                           -- division
+* ``("neg", a)``                            -- unary negation
+* ``("pow", a, p)``                         -- ``a ** p`` (``p`` numeric constant)
+* ``("exp", a)`` / ``("log", a)`` / ``("log2", a)`` / ``("sqrt", a)``
+* ``("sin", a)`` / ``("cos", a)`` / ``("tan", a)`` / ``("abs", a)``
+* ``("asin", a)`` / ``("acos", a)`` / ``("atan", a)``
+
+Instance schema
+---------------
+Each instance is a dict::
+
+    {
+        "name": str,
+        "vars": {name: (lb, ub), ...},           # finite bounds (SUSPECT FBBT needs them)
+        "objective": {"sense": "min"|"max", "expr": AST} | None,
+        "constraints": [{"name": str, "expr": AST, "op": "<="|">="|"==", "rhs": float}, ...],
+        "note": str,                              # human description of the intended structure
+    }
+
+Every comparable *item* (the objective, each constraint) is reduced on both
+sides to the curvature of its ``<=``-normalised body, so the verdicts line up
+directly with SUSPECT's per-constraint / per-objective ``Convexity`` enum.
+
+Bounds are chosen finite and domain-safe (strictly positive where ``log`` /
+``sqrt`` / division by a variable appear) so SUSPECT's interval FBBT does not
+raise ``EmptyIntervalError`` on degenerate boxes.
+"""
+
+from __future__ import annotations
+
+import math
+
+# --- AST constructor helpers (readability only; the AST is plain tuples) -----
+
+
+def var(name: str):
+    return ("var", name)
+
+
+def add(*args):
+    return ("+", *args)
+
+
+def sub(a, b):
+    return ("-", a, b)
+
+
+def mul(*args):
+    return ("*", *args)
+
+
+def div(a, b):
+    return ("/", a, b)
+
+
+def neg(a):
+    return ("neg", a)
+
+
+def power(a, p):
+    return ("pow", a, p)
+
+
+def exp(a):
+    return ("exp", a)
+
+
+def log(a):
+    return ("log", a)
+
+
+def sqrt(a):
+    return ("sqrt", a)
+
+
+def sin(a):
+    return ("sin", a)
+
+
+def cos(a):
+    return ("cos", a)
+
+
+def tan(a):
+    return ("tan", a)
+
+
+def asin(a):
+    return ("asin", a)
+
+
+def acos(a):
+    return ("acos", a)
+
+
+def atan(a):
+    return ("atan", a)
+
+
+def log2(a):
+    return ("log2", a)
+
+
+def absval(a):
+    return ("abs", a)
+
+
+# Atoms SUSPECT has a convexity rule for but that NO shared instance can reach.
+# Empty by construction: discopt's expression layer is a generic FunctionCall
+# node whose JAX backend already maps every SUSPECT atom (asin->jnp.arcsin,
+# etc.), so discopt can represent anything SUSPECT can. (asin/acos/atan have no
+# convenience wrapper in discopt.modeling, but build fine via FunctionCall and
+# are exercised below -- they are detector gaps, not expressivity gaps.)
+UNBUILDABLE_SUSPECT_ATOMS: tuple[str, ...] = ()
+
+# The reverse gap: atoms discopt expresses but SUSPECT 2.1.3 cannot -- it raises
+# "ValueError: Unknown function type" for these (no rule in its registry), so no
+# shared instance can be built. (``log2`` IS buildable: it is rendered as a
+# positively-scaled native ``log``, so SUSPECT sees an ordinary concave ``log``
+# rather than a dedicated atom.)
+SUSPECT_UNSUPPORTED_ATOMS = ("tanh", "sinh", "cosh", "log10")
+
+
+# --- Curated instances -------------------------------------------------------
+#
+# "expected" records the ground-truth curvature of the item's <=-normalised
+# body: "convex", "concave", "affine", or "indefinite" (provably neither).
+# It is documentation / sanity-check fodder, not used to score either tool
+# against the other.
+
+INSTANCES: list[dict] = [
+    # ----- Convex objectives: cone primitives discopt recognises -----
+    {
+        "name": "psd_quadratic",
+        "note": "PSD quadratic form x^2 + y^2 (convex).",
+        "vars": {"x": (-5.0, 5.0), "y": (-5.0, 5.0)},
+        "objective": {"sense": "min", "expr": add(power(var("x"), 2), power(var("y"), 2))},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "shifted_sum_of_squares",
+        "note": "(x-1)^2 + (2y+3)^2 -- convex, affine inner.",
+        "vars": {"x": (-5.0, 5.0), "y": (-5.0, 5.0)},
+        "objective": {
+            "sense": "min",
+            "expr": add(power(sub(var("x"), 1), 2), power(add(mul(2, var("y")), 3), 2)),
+        },
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "euclidean_norm",
+        "note": "sqrt(x^2 + y^2) -- 2-norm, convex via sqrt-of-PSD-quadratic.",
+        "vars": {"x": (-5.0, 5.0), "y": (-5.0, 5.0)},
+        "objective": {
+            "sense": "min",
+            "expr": sqrt(add(power(var("x"), 2), power(var("y"), 2))),
+        },
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "exp_univariate",
+        "note": "exp(x) -- convex.",
+        "vars": {"x": (-3.0, 3.0)},
+        "objective": {"sense": "min", "expr": exp(var("x"))},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "sum_exp",
+        "note": "exp(x) + exp(2y) -- sum of convex exponentials.",
+        "vars": {"x": (-3.0, 3.0), "y": (-3.0, 3.0)},
+        "objective": {
+            "sense": "min",
+            "expr": add(exp(var("x")), exp(mul(2, var("y")))),
+        },
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "neg_entropy",
+        "note": "x*log(x) -- convex on x>0 (negative entropy).",
+        "vars": {"x": (0.05, 10.0)},
+        "objective": {"sense": "min", "expr": mul(var("x"), log(var("x")))},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "reciprocal",
+        "note": "1/x -- convex on x>0.",
+        "vars": {"x": (0.05, 10.0)},
+        "objective": {"sense": "min", "expr": div(1.0, var("x"))},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "quad_over_affine",
+        "note": "x^2 / y -- convex on y>0 (quadratic-over-affine).",
+        "vars": {"x": (-5.0, 5.0), "y": (0.1, 10.0)},
+        "objective": {"sense": "min", "expr": div(power(var("x"), 2), var("y"))},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "exp_perspective",
+        "note": "y*exp(x/y) -- perspective of exp, convex on y>0.",
+        "vars": {"x": (-3.0, 3.0), "y": (0.1, 5.0)},
+        "objective": {
+            "sense": "min",
+            "expr": mul(var("y"), exp(div(var("x"), var("y")))),
+        },
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "softplus",
+        "note": "log(exp(x) + exp(y)) -- log-sum-exp, convex.",
+        "vars": {"x": (-3.0, 3.0), "y": (-3.0, 3.0)},
+        "objective": {
+            "sense": "min",
+            "expr": log(add(exp(var("x")), exp(var("y")))),
+        },
+        "constraints": [],
+        "expected": "convex",
+    },
+    # ----- Concave objectives (convex problems under max) -----
+    {
+        "name": "log_concave",
+        "note": "max log(x) -- concave body, convex problem.",
+        "vars": {"x": (0.05, 10.0)},
+        "objective": {"sense": "max", "expr": log(var("x"))},
+        "constraints": [],
+        "expected": "concave",
+    },
+    {
+        "name": "sqrt_concave",
+        "note": "max sqrt(x) -- concave body.",
+        "vars": {"x": (0.0, 10.0)},
+        "objective": {"sense": "max", "expr": sqrt(var("x"))},
+        "constraints": [],
+        "expected": "concave",
+    },
+    {
+        "name": "geo_mean_2d",
+        "note": "max sqrt(x*y) -- weighted geometric mean, concave on the positive orthant.",
+        "vars": {"x": (0.05, 10.0), "y": (0.05, 10.0)},
+        "objective": {"sense": "max", "expr": sqrt(mul(var("x"), var("y")))},
+        "constraints": [],
+        "expected": "concave",
+    },
+    # ----- Affine -----
+    {
+        "name": "affine_objective",
+        "note": "3x - 2y + 1 -- affine.",
+        "vars": {"x": (-5.0, 5.0), "y": (-5.0, 5.0)},
+        "objective": {
+            "sense": "min",
+            "expr": add(mul(3, var("x")), mul(-2, var("y")), 1),
+        },
+        "constraints": [],
+        "expected": "affine",
+    },
+    # ----- Nonconvex / indefinite objectives (foils) -----
+    {
+        "name": "bilinear",
+        "note": "x*y -- indefinite (saddle), neither convex nor concave.",
+        "vars": {"x": (-5.0, 5.0), "y": (-5.0, 5.0)},
+        "objective": {"sense": "min", "expr": mul(var("x"), var("y"))},
+        "constraints": [],
+        "expected": "indefinite",
+    },
+    {
+        "name": "indefinite_quadratic",
+        "note": "x^2 - y^2 -- indefinite quadratic.",
+        "vars": {"x": (-5.0, 5.0), "y": (-5.0, 5.0)},
+        "objective": {"sense": "min", "expr": sub(power(var("x"), 2), power(var("y"), 2))},
+        "constraints": [],
+        "expected": "indefinite",
+    },
+    {
+        "name": "sine",
+        "note": "sin(x) -- nonconvex (oscillatory) on a wide box.",
+        "vars": {"x": (-3.0, 3.0)},
+        "objective": {"sense": "min", "expr": sin(var("x"))},
+        "constraints": [],
+        "expected": "indefinite",
+    },
+    {
+        "name": "cubic",
+        "note": "x^3 -- neither convex nor concave on a box straddling 0.",
+        "vars": {"x": (-3.0, 3.0)},
+        "objective": {"sense": "min", "expr": power(var("x"), 3)},
+        "constraints": [],
+        "expected": "indefinite",
+    },
+    # ----- Constraint sense-normalisation (convex feasible sets) -----
+    {
+        "name": "ball_le",
+        "note": "x^2 + y^2 <= 1 -- convex feasible set (convex body, <=).",
+        "vars": {"x": (-2.0, 2.0), "y": (-2.0, 2.0)},
+        "objective": None,
+        "constraints": [
+            {
+                "name": "ball",
+                "expr": add(power(var("x"), 2), power(var("y"), 2)),
+                "op": "<=",
+                "rhs": 1.0,
+            }
+        ],
+        "expected": "convex",
+    },
+    {
+        "name": "log_lower_bound",
+        "note": "log(x) >= 0 -- concave body with >=, convex feasible set.",
+        "vars": {"x": (0.05, 10.0)},
+        "objective": None,
+        "constraints": [{"name": "logc", "expr": log(var("x")), "op": ">=", "rhs": 0.0}],
+        "expected": "concave",  # <=-normalised body (-log x) is convex; raw body concave
+    },
+    {
+        "name": "quad_over_affine_epigraph",
+        "note": "x^2/y <= t style: x^2 - y*t <= 0 is hard; use x^2/y <= 5 (nlp_cvx_108 shape).",
+        "vars": {"x": (-5.0, 5.0), "y": (0.1, 10.0)},
+        "objective": None,
+        "constraints": [
+            {"name": "qoa", "expr": div(power(var("x"), 2), var("y")), "op": "<=", "rhs": 5.0}
+        ],
+        "expected": "convex",
+    },
+    {
+        "name": "norm_le",
+        "note": "sqrt(x^2+y^2) <= 3 -- second-order cone, convex set.",
+        "vars": {"x": (-5.0, 5.0), "y": (-5.0, 5.0)},
+        "objective": None,
+        "constraints": [
+            {
+                "name": "soc",
+                "expr": sqrt(add(power(var("x"), 2), power(var("y"), 2))),
+                "op": "<=",
+                "rhs": 3.0,
+            }
+        ],
+        "expected": "convex",
+    },
+    # ----- Nonconvex feasible sets (foils, sense matters) -----
+    {
+        "name": "ball_complement_ge",
+        "note": "x^2 + y^2 >= 1 -- convex body with >=, NONconvex feasible set.",
+        "vars": {"x": (-2.0, 2.0), "y": (-2.0, 2.0)},
+        "objective": None,
+        "constraints": [
+            {
+                "name": "shell",
+                "expr": add(power(var("x"), 2), power(var("y"), 2)),
+                "op": ">=",
+                "rhs": 1.0,
+            }
+        ],
+        "expected": "convex",  # raw body convex; the >= makes the SET nonconvex (SUSPECT: Concave)
+    },
+    {
+        "name": "log_upper_bound",
+        "note": "log(x) <= 1 -- concave body with <=, NONconvex feasible set.",
+        "vars": {"x": (0.05, 10.0)},
+        "objective": None,
+        "constraints": [{"name": "logu", "expr": log(var("x")), "op": "<=", "rhs": 1.0}],
+        "expected": "concave",
+    },
+    {
+        "name": "bilinear_constraint",
+        "note": "x*y <= 1 -- indefinite body, nonconvex.",
+        "vars": {"x": (0.1, 5.0), "y": (0.1, 5.0)},
+        "objective": None,
+        "constraints": [{"name": "bil", "expr": mul(var("x"), var("y")), "op": "<=", "rhs": 1.0}],
+        "expected": "indefinite",
+    },
+    # ----- Mixed objective + constraints (whole-model convex) -----
+    {
+        "name": "convex_qp_model",
+        "note": "min x^2+y^2 s.t. affine + a convex ball constraint -- fully convex model.",
+        "vars": {"x": (-5.0, 5.0), "y": (-5.0, 5.0)},
+        "objective": {"sense": "min", "expr": add(power(var("x"), 2), power(var("y"), 2))},
+        "constraints": [
+            {"name": "aff", "expr": add(var("x"), var("y")), "op": "<=", "rhs": 4.0},
+            {
+                "name": "ball",
+                "expr": add(power(sub(var("x"), 1), 2), power(var("y"), 2)),
+                "op": "<=",
+                "rhs": 9.0,
+            },
+        ],
+        "expected": "convex",
+    },
+    {
+        "name": "nonconvex_mixed_model",
+        "note": "convex objective but a bilinear equality -- whole model nonconvex.",
+        "vars": {"x": (0.1, 5.0), "y": (0.1, 5.0)},
+        "objective": {"sense": "min", "expr": add(power(var("x"), 2), power(var("y"), 2))},
+        "constraints": [
+            {"name": "bil_eq", "expr": mul(var("x"), var("y")), "op": "==", "rhs": 1.0},
+        ],
+        "expected": "indefinite",
+    },
+    # ----- Atom coverage: SUSPECT convexity-rule atoms not in the core set -----
+    {
+        "name": "abs_value",
+        "note": "|x| -- convex (SUSPECT AbsRule).",
+        "vars": {"x": (-5.0, 5.0)},
+        "objective": {"sense": "min", "expr": absval(var("x"))},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "tan_convex_branch",
+        "note": "tan(x) on (0, pi/2) -- convex & increasing (bound-dependent, SUSPECT TanRule).",
+        "vars": {"x": (0.1, 1.4)},
+        "objective": {"sense": "min", "expr": tan(var("x"))},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "log2_concave",
+        "note": "max log2(x) -- concave (base-2 log).",
+        "vars": {"x": (0.05, 10.0)},
+        "objective": {"sense": "max", "expr": log2(var("x"))},
+        "constraints": [],
+        "expected": "concave",
+    },
+    # ----- Power-exponent matrix (SUSPECT PowerRule: sign/parity/bound-aware) -----
+    {
+        "name": "quartic_even_power",
+        "note": "x^4 -- convex (even integer power) on a box straddling 0.",
+        "vars": {"x": (-3.0, 3.0)},
+        "objective": {"sense": "min", "expr": power(var("x"), 4)},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "inverse_square_power",
+        "note": "x^-2 -- convex on x>0 (negative even power).",
+        "vars": {"x": (0.1, 5.0)},
+        "objective": {"sense": "min", "expr": power(var("x"), -2)},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "pow_three_halves",
+        "note": "x^1.5 -- convex on x>=0 (fractional power > 1).",
+        "vars": {"x": (0.05, 5.0)},
+        "objective": {"sense": "min", "expr": power(var("x"), 1.5)},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "pow_half_concave",
+        "note": "max x^0.5 -- concave on x>=0 (fractional power in (0,1); sqrt as a power atom).",
+        "vars": {"x": (0.05, 10.0)},
+        "objective": {"sense": "max", "expr": power(var("x"), 0.5)},
+        "constraints": [],
+        "expected": "concave",
+    },
+    {
+        "name": "cubic_positive_branch",
+        "note": "x^3 on x>=0 -- convex (bound-restricted odd power; bound-aware PowerRule).",
+        "vars": {"x": (0.1, 3.0)},
+        "objective": {"sense": "min", "expr": power(var("x"), 3)},
+        "constraints": [],
+        "expected": "convex",
+    },
+    # ----- Bound-restricted trig convexity -----
+    {
+        "name": "sin_convex_branch",
+        "note": "sin(x) on [pi, 2pi] -- convex (sin'' = -sin >= 0 there; bound-aware SinRule).",
+        "vars": {"x": (3.3, 6.0)},
+        "objective": {"sense": "min", "expr": sin(var("x"))},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "cos_concave_branch",
+        "note": "max cos(x) on [-pi/2, pi/2] -- cos concave there (bound-aware CosRule).",
+        "vars": {"x": (-1.4, 1.4)},
+        "objective": {"sense": "max", "expr": cos(var("x"))},
+        "constraints": [],
+        "expected": "concave",
+    },
+    # ----- Inverse trig (SUSPECT Asin/Acos/AtanRule; discopt backend supports
+    #       them via FunctionCall but has no curvature rule -> detector gaps) -----
+    {
+        "name": "asin_convex_branch",
+        "note": "asin(x) on (0,1) -- convex & increasing there (bound-aware AsinRule).",
+        "vars": {"x": (0.1, 0.9)},
+        "objective": {"sense": "min", "expr": asin(var("x"))},
+        "constraints": [],
+        "expected": "convex",
+    },
+    {
+        "name": "acos_concave_branch",
+        "note": "max acos(x) on (0,1) -- acos concave there (bound-aware AcosRule).",
+        "vars": {"x": (0.1, 0.9)},
+        "objective": {"sense": "max", "expr": acos(var("x"))},
+        "constraints": [],
+        "expected": "concave",
+    },
+    {
+        "name": "atan_concave_branch",
+        "note": "max atan(x) on x>0 -- atan concave on the positive axis (bound-aware AtanRule).",
+        "vars": {"x": (0.1, 3.0)},
+        "objective": {"sense": "max", "expr": atan(var("x"))},
+        "constraints": [],
+        "expected": "concave",
+    },
+]
+
+
+def instance_by_name(name: str) -> dict:
+    for inst in INSTANCES:
+        if inst["name"] == name:
+            return inst
+    raise KeyError(name)
+
+
+# --- Numeric evaluation of the neutral AST ----------------------------------
+#
+# Evaluates an expression AST at a concrete point ``env`` (``{var_name: float}``)
+# using only the standard library. This is the ground truth both detector-side
+# verdicts are validated against: the monotonicity and FBBT-bounds parity tests
+# *sample* the real body over its box with this evaluator and check that
+# discopt's symbolic verdict (monotone direction / interval enclosure) is
+# consistent with the sampled values. It deliberately shares no code with
+# either renderer, so a bug in a renderer cannot mask a wrong verdict.
+
+
+def eval_ast(node, env: dict) -> float:
+    """Evaluate a neutral AST ``node`` at the point ``env`` (``{name: float}``)."""
+    if isinstance(node, (int, float)):
+        return float(node)
+    head = node[0]
+    if head == "var":
+        return float(env[node[1]])
+    args = [eval_ast(a, env) for a in node[1:]]
+    if head == "+":
+        return math.fsum(args)
+    if head == "-":
+        return args[0] - args[1]
+    if head == "*":
+        acc = 1.0
+        for a in args:
+            acc *= a
+        return acc
+    if head == "/":
+        return args[0] / args[1]
+    if head == "neg":
+        return -args[0]
+    if head == "pow":
+        return float(args[0]) ** node[2]
+    if head == "exp":
+        return math.exp(args[0])
+    if head == "log":
+        return math.log(args[0])
+    if head == "sqrt":
+        return math.sqrt(args[0])
+    if head == "sin":
+        return math.sin(args[0])
+    if head == "cos":
+        return math.cos(args[0])
+    if head == "tan":
+        return math.tan(args[0])
+    if head == "asin":
+        return math.asin(args[0])
+    if head == "acos":
+        return math.acos(args[0])
+    if head == "atan":
+        return math.atan(args[0])
+    if head == "log2":
+        return math.log2(args[0])
+    if head == "abs":
+        return abs(args[0])
+    raise ValueError(f"unknown AST head: {head!r}")
+
+
+def item_asts(instance: dict) -> dict:
+    """Map each comparable item key to its raw body AST.
+
+    Keys are ``"objective"`` (when present) and each constraint name -- the
+    same keys the discopt renderer and the SUSPECT golden use, so a test can
+    line up a verdict with the AST it should be validated against.
+    """
+    out: dict = {}
+    obj = instance.get("objective")
+    if obj is not None:
+        out["objective"] = obj["expr"]
+    for con in instance["constraints"]:
+        out[con["name"]] = con["expr"]
+    return out

--- a/scripts/suspect_oracle/render_discopt.py
+++ b/scripts/suspect_oracle/render_discopt.py
@@ -1,0 +1,129 @@
+"""Render the neutral corpus AST (``corpus.py``) into discopt models.
+
+Runs in the main discopt environment (the parity test imports this). It must
+not import pyomo or SUSPECT. Mirror image of ``render_pyomo.py`` -- the two
+renderers walk the *same* neutral AST, which is what makes the comparison a
+head-to-head on identical mathematics.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+from discopt.modeling.core import FunctionCall, _wrap
+
+# Inverse-trig atoms discopt's backend supports (FunctionCall -> jnp.arcsin etc.)
+# but for which discopt.modeling ships no convenience wrapper. Built directly via
+# FunctionCall so the head-to-head can still exercise them.
+_FUNCTIONCALL_ATOMS = ("asin", "acos", "atan")
+
+
+def _eval(node, vars_):
+    """Recursively turn a neutral AST node into a discopt Expression."""
+    if isinstance(node, (int, float)):
+        return float(node)
+    head = node[0]
+    if head == "var":
+        return vars_[node[1]]
+    args = [_eval(a, vars_) for a in node[1:]]
+    if head == "+":
+        acc = args[0]
+        for a in args[1:]:
+            acc = acc + a
+        return acc
+    if head == "-":
+        return args[0] - args[1]
+    if head == "*":
+        acc = args[0]
+        for a in args[1:]:
+            acc = acc * a
+        return acc
+    if head == "/":
+        return args[0] / args[1]
+    if head == "neg":
+        return -args[0]
+    if head == "pow":
+        return args[0] ** node[2]
+    if head == "exp":
+        return dm.exp(args[0])
+    if head == "log":
+        return dm.log(args[0])
+    if head == "sqrt":
+        return dm.sqrt(args[0])
+    if head == "sin":
+        return dm.sin(args[0])
+    if head == "cos":
+        return dm.cos(args[0])
+    if head == "tan":
+        return dm.tan(args[0])
+    if head == "log2":
+        return dm.log2(args[0])
+    if head == "abs":
+        return abs(args[0])
+    if head in _FUNCTIONCALL_ATOMS:
+        return FunctionCall(head, _wrap(args[0]))
+    raise ValueError(f"unknown AST head: {head!r}")
+
+
+def _build_model_and_vars(instance: dict):
+    """Build the discopt ``Model`` and return it with its variable map and
+    constraint-name order. Shared by :func:`build_discopt` and
+    :func:`build_discopt_items`."""
+    m = dm.Model(instance["name"])
+    vars_ = {name: m.continuous(name, lb=lb, ub=ub) for name, (lb, ub) in instance["vars"].items()}
+
+    obj = instance.get("objective")
+    if obj is not None:
+        expr = _eval(obj["expr"], vars_)
+        if obj["sense"] == "min":
+            m.minimize(expr)
+        else:
+            m.maximize(expr)
+
+    constraint_names: list[str] = []
+    for con in instance["constraints"]:
+        body = _eval(con["expr"], vars_)
+        rhs = con["rhs"]
+        if con["op"] == "<=":
+            m.subject_to(body <= rhs, name=con["name"])
+        elif con["op"] == ">=":
+            m.subject_to(body >= rhs, name=con["name"])
+        else:
+            m.subject_to(body == rhs, name=con["name"])
+        constraint_names.append(con["name"])
+
+    return m, vars_, constraint_names
+
+
+def build_discopt(instance: dict):
+    """Build a discopt ``Model`` from a neutral corpus instance.
+
+    Returns ``(model, constraint_names)`` where ``constraint_names`` lists the
+    corpus constraint names in the same order they were added, so the parity
+    test can align ``model._constraints`` with SUSPECT's named verdicts.
+    """
+    m, _vars, constraint_names = _build_model_and_vars(instance)
+    return m, constraint_names
+
+
+def build_discopt_items(instance: dict):
+    """Build the model and the *raw* (pre-canonicalisation) body of every
+    comparable item.
+
+    Returns ``(model, items)`` where each item is
+    ``{"key": str, "body": Expression}`` and ``body`` is the corpus AST
+    rendered directly into a discopt :class:`Expression`, untouched by the
+    model's ``<=``-canonicalisation of constraints. This is exactly the body
+    SUSPECT reports monotonicity / interval bounds on (its ``obj.expr`` /
+    ``con.body``), so the monotonicity and FBBT cross-checks compare identical
+    raw mathematics on both sides with **zero** normalisation. The bodies share
+    the model's :class:`Variable` objects, so ``classify_monotonicity`` and
+    ``evaluate_interval`` read their declared bounds.
+    """
+    m, vars_, _cnames = _build_model_and_vars(instance)
+    items: list[dict] = []
+    obj = instance.get("objective")
+    if obj is not None:
+        items.append({"key": "objective", "body": _eval(obj["expr"], vars_)})
+    for con in instance["constraints"]:
+        items.append({"key": con["name"], "body": _eval(con["expr"], vars_)})
+    return m, items

--- a/scripts/suspect_oracle/render_pyomo.py
+++ b/scripts/suspect_oracle/render_pyomo.py
@@ -1,0 +1,89 @@
+"""Render the neutral corpus AST (``corpus.py``) into Pyomo models for SUSPECT.
+
+Runs only inside the isolated SUSPECT environment (py3.10 + pyomo 6.1.2). It
+must not import discopt or modern numpy. See ``README.md`` for the env recipe.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pyomo.environ as pe
+
+
+def _eval(node, m):
+    """Recursively turn a neutral AST node into a Pyomo expression."""
+    if isinstance(node, (int, float)):
+        return float(node)
+    head = node[0]
+    if head == "var":
+        return getattr(m, node[1])
+    args = [_eval(a, m) for a in node[1:]]
+    if head == "+":
+        acc = args[0]
+        for a in args[1:]:
+            acc = acc + a
+        return acc
+    if head == "-":
+        return args[0] - args[1]
+    if head == "*":
+        acc = args[0]
+        for a in args[1:]:
+            acc = acc * a
+        return acc
+    if head == "/":
+        return args[0] / args[1]
+    if head == "neg":
+        return -args[0]
+    if head == "pow":
+        return args[0] ** node[2]
+    if head == "exp":
+        return pe.exp(args[0])
+    if head == "log":
+        return pe.log(args[0])
+    if head == "sqrt":
+        return pe.sqrt(args[0])
+    if head == "sin":
+        return pe.sin(args[0])
+    if head == "cos":
+        return pe.cos(args[0])
+    if head == "tan":
+        return pe.tan(args[0])
+    if head == "asin":
+        return pe.asin(args[0])
+    if head == "acos":
+        return pe.acos(args[0])
+    if head == "atan":
+        return pe.atan(args[0])
+    if head == "log2":
+        # Pyomo has no native log2; SUSPECT sees a positively-scaled log,
+        # whose curvature matches log (concave on x>0).
+        return pe.log(args[0]) / math.log(2.0)
+    if head == "abs":
+        return abs(args[0])
+    raise ValueError(f"unknown AST head: {head!r}")
+
+
+_OP = {
+    "<=": lambda body, rhs: body <= rhs,
+    ">=": lambda body, rhs: body >= rhs,
+    "==": lambda body, rhs: body == rhs,
+}
+
+
+def build_pyomo(instance: dict):
+    """Build a Pyomo ``ConcreteModel`` from a neutral corpus instance."""
+    m = pe.ConcreteModel(name=instance["name"])
+    for vname, (lb, ub) in instance["vars"].items():
+        setattr(m, vname, pe.Var(bounds=(lb, ub)))
+
+    obj = instance.get("objective")
+    if obj is not None:
+        sense = pe.minimize if obj["sense"] == "min" else pe.maximize
+        m.objective = pe.Objective(expr=_eval(obj["expr"], m), sense=sense)
+
+    for con in instance["constraints"]:
+        body = _eval(con["expr"], m)
+        setattr(m, con["name"], pe.Constraint(expr=_OP[con["op"]](body, con["rhs"])))
+
+    return m

--- a/scripts/suspect_oracle/run_suspect.py
+++ b/scripts/suspect_oracle/run_suspect.py
@@ -1,0 +1,197 @@
+"""Record SUSPECT's verdicts over the shared corpus into a golden JSON.
+
+Runs only inside the isolated SUSPECT environment. SUSPECT (cog-suspect 2.1.3)
+is unmaintained and incompatible with discopt's own numpy / pyomo, so its
+verdicts are captured once, here, and committed as ``suspect_verdicts.json``.
+The in-repo parity tests (``python/tests/test_convexity_suspect_parity.py``,
+``test_monotonicity_suspect_parity.py``, ``test_fbbt_bounds_suspect_parity.py``)
+compare discopt against that recorded file and never import SUSPECT.
+
+Three verdict axes are recorded per objective / constraint:
+
+* ``convexity``    -- the sense-/``<=``-normalised body curvature, from the
+  high-level ``detect_special_structure``. For ``x^2 <= 4`` it returns
+  ``Convex``; for ``x^2 >= 4``, ``Concave``. Persisted with the constraint
+  sense so the discopt side can normalise identically.
+* ``monotonicity`` -- the *raw-body* increasing / decreasing / constant verdict.
+* ``bounds``       -- the *raw-body* FBBT interval enclosure (``lower``/``upper``,
+  ``null`` for an unbounded endpoint).
+
+The latter two come from SUSPECT's lower-level ``perform_fbbt`` +
+``propagate_special_structure`` pass, which keys by the raw ``obj.expr`` /
+``con.body`` (no sense normalisation), so the discopt side classifies the
+identical raw body.
+
+Usage (see README.md for the exact environment recipe)::
+
+    python run_suspect.py            # writes suspect_verdicts.json next to this file
+    python run_suspect.py --check    # print verdicts, do not write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import warnings
+from pathlib import Path
+
+# --- Legacy shims: cog-suspect 2.1.3 predates numpy 1.24 alias removals. ------
+# These must run *before* `import suspect`, so the SUSPECT / corpus / pyomo
+# imports below are deliberately placed after the shim (hence the noqa: E402).
+import numpy as _np
+
+for _name, _ty in (
+    ("float", float),
+    ("int", int),
+    ("bool", bool),
+    ("object", object),
+    ("complex", complex),
+):
+    if not hasattr(_np, _name):
+        setattr(_np, _name, _ty)
+
+warnings.filterwarnings("ignore")
+
+import pyomo.environ as pe  # noqa: E402
+from corpus import INSTANCES  # noqa: E402,I001
+from render_pyomo import build_pyomo  # noqa: E402
+from suspect import detect_special_structure  # noqa: E402
+from suspect.fbbt import perform_fbbt  # noqa: E402
+from suspect.propagation import propagate_special_structure  # noqa: E402
+
+_HERE = Path(__file__).resolve().parent
+_OUT = _HERE / "suspect_verdicts.json"
+
+
+def _convexity_str(value) -> str:
+    """Normalise a SUSPECT ``Convexity`` enum to a short lowercase token."""
+    name = str(value).split(".")[-1].lower()  # "Convexity.Convex" -> "convex"
+    if name in ("convex", "concave", "linear", "unknown"):
+        return name
+    return "unknown"
+
+
+def _monotonicity_str(value) -> str:
+    """Normalise a SUSPECT ``Monotonicity`` enum to a short lowercase token."""
+    name = str(value).split(".")[-1].lower()  # "Monotonicity.Nondecreasing" -> ...
+    if name in ("nondecreasing", "nonincreasing", "constant", "unknown"):
+        return name
+    return "unknown"
+
+
+def _bound(value):
+    """A SUSPECT interval endpoint as a JSON-safe float, or ``None`` for an
+    unbounded (``±inf``) endpoint. SUSPECT already uses ``None`` for unbounded
+    endpoints; finite floats pass straight through."""
+    if value is None:
+        return None
+    fval = float(value)
+    return None if fval != fval or abs(fval) == float("inf") else fval
+
+
+def _raw_mono_bounds(instance: dict) -> dict:
+    """SUSPECT's *raw-body* monotonicity + FBBT interval bounds per item.
+
+    Returns ``{item_key: {"monotonicity": token, "bounds": {"lower", "upper"}}}``
+    keyed by ``"objective"`` and each constraint name. Uses SUSPECT's
+    lower-level ``perform_fbbt`` + ``propagate_special_structure`` (which key by
+    the raw ``obj.expr`` / ``con.body``), so the values are *not* sense- or
+    ``<=``-normalised -- the discopt side classifies the same raw body.
+    """
+    pm = build_pyomo(instance)
+    bounds = perform_fbbt(pm)
+    mono, _cvx = propagate_special_structure(pm, bounds)
+
+    out: dict = {}
+    for obj in pm.component_data_objects(pe.Objective, active=True):
+        b = bounds.get(obj.expr)
+        out["objective"] = {
+            "monotonicity": _monotonicity_str(mono[obj.expr]),
+            "bounds": {"lower": _bound(b.lower_bound), "upper": _bound(b.upper_bound)},
+        }
+    for con in pm.component_data_objects(pe.Constraint, active=True):
+        b = bounds.get(con.body)
+        out[con.name] = {
+            "monotonicity": _monotonicity_str(mono[con.body]),
+            "bounds": {"lower": _bound(b.lower_bound), "upper": _bound(b.upper_bound)},
+        }
+    return out
+
+
+def run_instance(instance: dict) -> dict:
+    """Return SUSPECT's verdicts for one instance, or an error marker.
+
+    Captures, per objective / constraint:
+    * ``convexity`` -- the sense-/``<=``-normalised body curvature (from the
+      high-level ``detect_special_structure``); and
+    * ``monotonicity`` + ``bounds`` -- the *raw-body* monotonicity verdict and
+      FBBT interval enclosure (from the lower-level FBBT + propagation pass).
+    """
+    try:
+        model = build_pyomo(instance)
+        info = detect_special_structure(model)
+        raw = _raw_mono_bounds(instance)
+    except Exception as exc:  # SUSPECT FBBT can raise (e.g. EmptyIntervalError)
+        return {"error": f"{type(exc).__name__}: {exc}"}
+
+    out: dict = {"objective": None, "constraints": {}}
+
+    if info.objectives:
+        # Single objective named "objective" in our renderer.
+        for _oname, odata in info.objectives.items():
+            ro = raw.get("objective", {})
+            out["objective"] = {
+                "sense": odata.get("sense"),
+                "convexity": _convexity_str(odata["convexity"]),
+                "monotonicity": ro.get("monotonicity", "unknown"),
+                "bounds": ro.get("bounds", {"lower": None, "upper": None}),
+            }
+            break
+
+    sense_by_name = {c["name"]: c["op"] for c in instance["constraints"]}
+    for cname, cdata in info.constraints.items():
+        rc = raw.get(cname, {})
+        out["constraints"][cname] = {
+            "op": sense_by_name.get(cname),
+            "convexity": _convexity_str(cdata["convexity"]),
+            "monotonicity": rc.get("monotonicity", "unknown"),
+            "bounds": rc.get("bounds", {"lower": None, "upper": None}),
+        }
+    return out
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check", action="store_true", help="print verdicts without writing the JSON file"
+    )
+    args = parser.parse_args(argv)
+
+    verdicts = {inst["name"]: run_instance(inst) for inst in INSTANCES}
+
+    errors = {k: v["error"] for k, v in verdicts.items() if "error" in v}
+    payload = {
+        "_meta": {
+            "tool": "cog-suspect",
+            "tool_version": "2.1.3",
+            "pyomo": "6.1.2",
+            "n_instances": len(verdicts),
+            "n_errors": len(errors),
+        },
+        "verdicts": verdicts,
+    }
+
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if args.check:
+        print(text)
+    else:
+        _OUT.write_text(text + "\n")
+        print(f"wrote {_OUT} ({len(verdicts)} instances, {len(errors)} SUSPECT errors)")
+    if errors:
+        print("SUSPECT errored on:", ", ".join(sorted(errors)), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/suspect_oracle/suspect_verdicts.json
+++ b/scripts/suspect_oracle/suspect_verdicts.json
@@ -1,0 +1,534 @@
+{
+  "_meta": {
+    "n_errors": 0,
+    "n_instances": 40,
+    "pyomo": "6.1.2",
+    "tool": "cog-suspect",
+    "tool_version": "2.1.3"
+  },
+  "verdicts": {
+    "abs_value": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.0,
+          "upper": 5.0
+        },
+        "convexity": "convex",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "acos_concave_branch": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.45102681179626236,
+          "upper": 1.4706289056333368
+        },
+        "convexity": "convex",
+        "monotonicity": "nonincreasing",
+        "sense": "max"
+      }
+    },
+    "affine_objective": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": -24.0,
+          "upper": 26.0
+        },
+        "convexity": "linear",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "asin_convex_branch": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.1001674211615598,
+          "upper": 1.1197695149986342
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "min"
+      }
+    },
+    "atan_concave_branch": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.09966865249116204,
+          "upper": 1.2490457723982544
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "max"
+      }
+    },
+    "ball_complement_ge": {
+      "constraints": {
+        "shell": {
+          "bounds": {
+            "lower": 1.0,
+            "upper": null
+          },
+          "convexity": "concave",
+          "monotonicity": "unknown",
+          "op": ">="
+        }
+      },
+      "objective": null
+    },
+    "ball_le": {
+      "constraints": {
+        "ball": {
+          "bounds": {
+            "lower": 0.0,
+            "upper": 1.0
+          },
+          "convexity": "convex",
+          "monotonicity": "unknown",
+          "op": "<="
+        }
+      },
+      "objective": null
+    },
+    "bilinear": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": -25.0,
+          "upper": 25.0
+        },
+        "convexity": "unknown",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "bilinear_constraint": {
+      "constraints": {
+        "bil": {
+          "bounds": {
+            "lower": 0.010000000000000002,
+            "upper": 1.0
+          },
+          "convexity": "unknown",
+          "monotonicity": "nondecreasing",
+          "op": "<="
+        }
+      },
+      "objective": null
+    },
+    "convex_qp_model": {
+      "constraints": {
+        "aff": {
+          "bounds": {
+            "lower": -10.0,
+            "upper": 4.0
+          },
+          "convexity": "linear",
+          "monotonicity": "nondecreasing",
+          "op": "<="
+        },
+        "ball": {
+          "bounds": {
+            "lower": 0.0,
+            "upper": 9.0
+          },
+          "convexity": "convex",
+          "monotonicity": "unknown",
+          "op": "<="
+        }
+      },
+      "objective": {
+        "bounds": {
+          "lower": 0.0,
+          "upper": null
+        },
+        "convexity": "convex",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "cos_concave_branch": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.16996714290024095,
+          "upper": 1.0
+        },
+        "convexity": "convex",
+        "monotonicity": "unknown",
+        "sense": "max"
+      }
+    },
+    "cubic": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": null,
+          "upper": null
+        },
+        "convexity": "unknown",
+        "monotonicity": "nondecreasing",
+        "sense": "min"
+      }
+    },
+    "cubic_positive_branch": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": null,
+          "upper": null
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "min"
+      }
+    },
+    "euclidean_norm": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.0,
+          "upper": null
+        },
+        "convexity": "unknown",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "exp_perspective": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 9.357622968840175e-15,
+          "upper": 53432372907622.31
+        },
+        "convexity": "unknown",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "exp_univariate": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.049787068367863944,
+          "upper": 20.085536923187668
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "min"
+      }
+    },
+    "geo_mean_2d": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.05,
+          "upper": 10.0
+        },
+        "convexity": "unknown",
+        "monotonicity": "nondecreasing",
+        "sense": "max"
+      }
+    },
+    "indefinite_quadratic": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": null,
+          "upper": null
+        },
+        "convexity": "unknown",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "inverse_square_power": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": null,
+          "upper": null
+        },
+        "convexity": "convex",
+        "monotonicity": "nonincreasing",
+        "sense": "min"
+      }
+    },
+    "log2_concave": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": -4.321928094887362,
+          "upper": 3.3219280948873626
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "max"
+      }
+    },
+    "log_concave": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": -2.995732273553991,
+          "upper": 2.302585092994046
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "max"
+      }
+    },
+    "log_lower_bound": {
+      "constraints": {
+        "logc": {
+          "bounds": {
+            "lower": 0.0,
+            "upper": 2.302585092994046
+          },
+          "convexity": "convex",
+          "monotonicity": "nondecreasing",
+          "op": ">="
+        }
+      },
+      "objective": null
+    },
+    "log_upper_bound": {
+      "constraints": {
+        "logu": {
+          "bounds": {
+            "lower": -2.995732273553991,
+            "upper": 1.0
+          },
+          "convexity": "concave",
+          "monotonicity": "nondecreasing",
+          "op": "<="
+        }
+      },
+      "objective": null
+    },
+    "neg_entropy": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": -29.957322735539908,
+          "upper": 23.02585092994046
+        },
+        "convexity": "unknown",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "nonconvex_mixed_model": {
+      "constraints": {
+        "bil_eq": {
+          "bounds": {
+            "lower": 1.0,
+            "upper": 1.0
+          },
+          "convexity": "unknown",
+          "monotonicity": "nondecreasing",
+          "op": "=="
+        }
+      },
+      "objective": {
+        "bounds": {
+          "lower": 0.0,
+          "upper": null
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "min"
+      }
+    },
+    "norm_le": {
+      "constraints": {
+        "soc": {
+          "bounds": {
+            "lower": 0.0,
+            "upper": 3.0
+          },
+          "convexity": "unknown",
+          "monotonicity": "unknown",
+          "op": "<="
+        }
+      },
+      "objective": null
+    },
+    "pow_half_concave": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": null,
+          "upper": null
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "max"
+      }
+    },
+    "pow_three_halves": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": null,
+          "upper": null
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "min"
+      }
+    },
+    "psd_quadratic": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.0,
+          "upper": null
+        },
+        "convexity": "convex",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "quad_over_affine": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.0,
+          "upper": null
+        },
+        "convexity": "unknown",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "quad_over_affine_epigraph": {
+      "constraints": {
+        "qoa": {
+          "bounds": {
+            "lower": 0.0,
+            "upper": 5.0
+          },
+          "convexity": "unknown",
+          "monotonicity": "unknown",
+          "op": "<="
+        }
+      },
+      "objective": null
+    },
+    "quartic_even_power": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.0,
+          "upper": null
+        },
+        "convexity": "convex",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "reciprocal": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.1,
+          "upper": 20.0
+        },
+        "convexity": "convex",
+        "monotonicity": "nonincreasing",
+        "sense": "min"
+      }
+    },
+    "shifted_sum_of_squares": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.0,
+          "upper": null
+        },
+        "convexity": "convex",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "sin_convex_branch": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": -1.0,
+          "upper": -0.1577456941432482
+        },
+        "convexity": "convex",
+        "monotonicity": "unknown",
+        "sense": "min"
+      }
+    },
+    "sine": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": -1.0,
+          "upper": 0.14112000805986746
+        },
+        "convexity": "unknown",
+        "monotonicity": "nonincreasing",
+        "sense": "min"
+      }
+    },
+    "softplus": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": -2.3068528194400546,
+          "upper": 3.6931471805599454
+        },
+        "convexity": "unknown",
+        "monotonicity": "nondecreasing",
+        "sense": "min"
+      }
+    },
+    "sqrt_concave": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.0,
+          "upper": 3.1622776601683795
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "max"
+      }
+    },
+    "sum_exp": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": 0.0522658205445303,
+          "upper": 423.51433041592276
+        },
+        "convexity": "convex",
+        "monotonicity": "nondecreasing",
+        "sense": "min"
+      }
+    },
+    "tan_convex_branch": {
+      "constraints": {},
+      "objective": {
+        "bounds": {
+          "lower": null,
+          "upper": null
+        },
+        "convexity": "unknown",
+        "monotonicity": "nondecreasing",
+        "sense": "min"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Delivers the **"head-to-head SUSPECT comparison on a shared instance set"** open item from #38 — and broadens it beyond convexity to the **three verdict axes** SUSPECT reports: convexity, monotonicity, and FBBT interval bounds. Both tools run over one shared 40-instance corpus (rendered into discopt and Pyomo from the same neutral AST), with live in-CI parity assertions.

## New public API

`discopt._jax.monotonicity.classify_monotonicity(expr, model=None, box=None) -> Monotonicity`

A per-expression monotonicity classifier — the counterpart to `convexity.classify_expr`. It is a forward-mode **interval-gradient** evaluator: a `NONDECREASING`/`NONINCREASING` verdict is a *proof* (the interval enclosure of ∇f over the whole box lies in the nonneg/nonpos orthant). It covers `+ - * / **`, `neg`/`abs`, and `exp/log/log2/log10/sqrt/sin/cos/tan/tanh/sinh/cosh/asin/acos/atan`, and abstains soundly (`UNKNOWN`) on unsupported atoms, non-finite enclosures, and domain issues.

The FBBT cross-check reuses the existing `convexity.interval_eval.evaluate_interval` as discopt's interval-bounds surface.

## Oracle changes (`scripts/suspect_oracle/`)

- `run_suspect.py` now records all three axes per item — convexity (as before) plus raw-body **monotonicity** and **FBBT bounds** via SUSPECT's lower-level `perform_fbbt` + `propagate_special_structure`.
- `render_discopt.build_discopt_items` exposes each item's **raw** (pre-canonicalisation) body, so both sides classify identical mathematics with zero normalisation.
- `corpus.eval_ast` — a stdlib numeric evaluator used to validate verdicts directly against the real body.

## Live parity tests

- `test_convexity_suspect_parity.py` — no contradictions; pinned detector-gap sets.
- `test_monotonicity_suspect_parity.py` — every discopt verdict validated against dense sampling; no proven-direction contradictions; pinned gaps.
- `test_fbbt_bounds_suspect_parity.py` — discopt forward bounds sound on all 43 items; no disjoint enclosures; pinned unbounded-abstention set.
- `test_monotonicity.py` — unit tests for the new classifier.

## Design note

SUSPECT's monotonicity and bounds axes are **heuristic and occasionally unsound** — its interval cosine ignores interior critical points, so it declares `sin` monotone *and* mis-bounds it on `[-3, 3]`, where it is neither. discopt's verdicts are rigorous and are validated directly against numeric sampling. So the tests rest on **discopt's own sampling-validated soundness** plus **mutual no-contradiction / no-disjoint-enclosure**, rather than treating SUSPECT as ground truth. (SUSPECT's *convexity* axis is sound, so that test asserts no-contradiction symmetrically.)

## Results

- **Convexity:** 33 agree, 5 discopt-stronger (cone primitives), 5 SUSPECT-stronger (bound-aware trig/inverse-trig), 0 contradictions.
- **Monotonicity:** 40 agree, 0 contradictions, 3 pinned SUSPECT-stronger (`sqrt_concave`/`cubic` = sound discopt conservatism, `sine` = a documented SUSPECT defect discopt avoids).
- **Bounds:** discopt sound on all 43 items, 0 disjoint enclosures, 5 pinned unbounded abstentions.

## Verification

- `pytest python/tests/ -k "monoton or convexity or interval or fbbt_bounds"` → 426 passed, 2 xfailed.
- `ruff check`, `ruff format --check`, and `mypy python/discopt/_jax/monotonicity.py` all clean.

Relates to #38 (closes the SUSPECT head-to-head open item; leaves the Rust port and timing/MINLPLib follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
