### PR TITLE
feat(gp): auto-route geometric programs + log-convex verdict (#111)

### DIFF
--- a/python/discopt/gp/__init__.py
+++ b/python/discopt/gp/__init__.py
@@ -175,6 +175,33 @@ def _all_variables_positive_continuous(model: Model) -> bool:
     return True
 
 
+def is_log_convex(model: Model) -> bool:
+    """Return ``True`` iff ``model`` is a geometric program.
+
+    A GP is convex under the change of variables ``y = log x`` (every
+    monomial becomes ``exp`` of an affine form, a posynomial a convex
+    sum-of-exponentials). This is a verdict in **log-space**, kept
+    deliberately separate from
+    :func:`discopt._jax.convexity.classify_model`, which reports
+    convexity in the **original** ``x``-space.
+
+    The distinction matters: a genuine GP is generally *not* convex in
+    ``x`` (a posynomial Hessian is indefinite on the positive orthant),
+    so for such a model ``classify_model(model, use_certificate=True)``
+    returns ``(False, ...)`` while ``is_log_convex(model)`` returns
+    ``True``. Folding log-convexity into the ``x``-space verdict would
+    mis-gate the ``x``-space convex fast path — a soundness break — so the
+    two are exposed as independent predicates.
+
+    This is whole-model recognition (the model is a GP in standard form);
+    per-expression log-curvature lattice propagation is a future
+    extension. A ``True`` result is a proof: it is exactly the precondition
+    under which :func:`as_geometric_program` builds an equivalent convex
+    NLP in ``y``.
+    """
+    return classify_gp(model) is not None
+
+
 def classify_gp(model: Model) -> Optional[GPStructure]:
     """Return the :class:`GPStructure` of ``model`` if it is a GP, else ``None``.
 
@@ -397,6 +424,22 @@ def solve_gp(model: Model, **solve_kwargs) -> Optional[SolveResult]:
         y_values = np.asarray(log_result.x["y"], dtype=np.float64).reshape(-1)
         result.x = gp.recover_x(y_values)
         result.objective = gp.objective_value(y_values)
+
+    # The log-space program is convex and equivalent to the original GP, so an
+    # ``optimal`` log-space solution is the *global* optimum of the GP. Its
+    # objective is therefore simultaneously the best incumbent and a valid lower
+    # bound (a zero-gap, single-NLP solve). Only assert this when the convex
+    # solve actually converged — on a limit/infeasible status we must not
+    # fabricate a bound (correctness invariant). Guarded on a finite objective
+    # so a NaN/inf recovery never poses as a certified optimum.
+    if (
+        log_result.status == "optimal"
+        and result.objective is not None
+        and math.isfinite(result.objective)
+    ):
+        result.bound = result.objective
+        result.gap = 0.0
+        result.convex_fast_path = True
     return result
 
 
@@ -406,5 +449,6 @@ __all__ = [
     "GeometricProgram",
     "as_geometric_program",
     "classify_gp",
+    "is_log_convex",
     "solve_gp",
 ]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1592,6 +1592,13 @@ def solve_model(
         variables) and, if it qualifies, solved exactly via the log-space
         convex reformulation (``y = log x``). Raises ``ValueError`` if the
         model is not a geometric program. See :mod:`discopt.gp`.
+        When ``solver`` is left ``None``, a recognised GP is **automatically**
+        routed through this same exact log-space convex solve (a single NLP,
+        global optimum) instead of branch-and-bound; pass ``"bb"`` to opt out
+        and force the classic branch-and-bound path. The automatic route is
+        skipped when branch-and-bound streaming callbacks (``incumbent_callback``,
+        ``node_callback``, ``iteration_callback``) are attached, or when
+        ``skip_convex_check=True``.
     solver="amp" options
         The AMP backend also accepts ``rel_gap``, ``abs_tol``, ``max_iter``,
         ``n_init_partitions``, ``partition_method``, ``milp_time_limit``,
@@ -1635,6 +1642,13 @@ def solve_model(
 
     # --- AMP (Adaptive Multivariate Partitioning) global solver ---
     _solver = solver if solver is not None else kwargs.pop("solver", None)
+    # Recognised global-solver selectors: ``None`` (default branch-and-bound,
+    # with the automatic GP fast path below), ``"amp"``, ``"gp"`` (force the GP
+    # log-space path), and ``"bb"`` (force classic branch-and-bound, opting out
+    # of the automatic GP fast path). Reject anything else rather than silently
+    # falling through to B&B.
+    if _solver not in (None, "amp", "gp", "bb"):
+        raise ValueError(f"Unknown solver={_solver!r}. Choose one of None, 'amp', 'gp', 'bb'.")
     if _solver == "amp":
         import warnings
 
@@ -1775,6 +1789,34 @@ def solve_model(
         if result is None:  # pragma: no cover - guarded by classify_gp above
             raise RuntimeError("GP reformulation failed unexpectedly.")
         return result
+
+    # --- Auto GP fast path: a recognised geometric program solves exactly via
+    # its log-space convex reformulation (y = log x), which is strictly better
+    # than branch-and-bound (a single convex NLP gives the global optimum). This
+    # fires only when no global solver was explicitly requested and the user did
+    # not attach branch-and-bound streaming callbacks (which the GP path cannot
+    # honour — falling through to B&B keeps them firing). ``solver="bb"`` is an
+    # explicit opt-out that forces the classic path. ``classify_gp`` bails on the
+    # first integer variable / non-positive lower bound, so the probe is cheap on
+    # the common (non-GP) path.
+    _has_bb_callbacks = (
+        incumbent_callback is not None
+        or node_callback is not None
+        or kwargs.get("iteration_callback") is not None
+    )
+    if _solver is None and not _has_bb_callbacks and not skip_convex_check:
+        from discopt.gp import classify_gp, solve_gp
+
+        if classify_gp(model) is not None:
+            gp_result = solve_gp(
+                model,
+                time_limit=time_limit,
+                gap_tolerance=gap_tolerance,
+                nlp_solver=nlp_solver,
+                ipopt_options=ipopt_options,
+            )
+            if gp_result is not None:
+                return gp_result
 
     # --- OA decomposition: general-purpose Outer Approximation ---
     if gdp_method == "oa":

--- a/python/tests/test_convexity_wide_box.py
+++ b/python/tests/test_convexity_wide_box.py
@@ -375,18 +375,38 @@ class TestWideBoxSolverIntegration:
         assert result.convex_fast_path is True
         assert abs(result.objective - (2.0 * (2.0**0.5) - 2.0)) <= 1.0e-4
 
-    def test_bilinear_feasibility_does_not_take_convex_fast_path(self):
-        """Negative control: a genuinely nonconvex bilinear constraint
-        must NOT be promoted to the convex fast path by any wide-box
-        code path. Ensures the structural recognisers haven't
-        accidentally widened to over-accept.
+    def test_bilinear_feasibility_x_space_recognisers_do_not_over_accept(self):
+        """Negative control: the *x-space* structural recognisers must NOT
+        promote a genuinely nonconvex bilinear constraint to convex.
+
+        ``min u+v  s.t.  u*v >= 5`` is nonconvex in x-space, so
+        ``classify_model`` (with the certificate, the exact gate for the
+        x-space convex fast path) must keep returning ``is_convex == False`` —
+        the over-acceptance guard this control exists for.
+
+        Note this model is, however, a *geometric program* (the objective is a
+        posynomial and ``u*v >= 5`` is ``5*u^-1*v^-1 <= 1``, a monomial), so a
+        plain ``solve`` legitimately auto-routes through the exact log-space
+        convex reformulation (``discopt.gp``) and reports
+        ``convex_fast_path is True`` for that single-NLP global solve. To
+        exercise the classic branch-and-bound path here we opt out with
+        ``solver="bb"``.
         """
         m = Model("bilinear_solver_nonconvex")
         u = m.continuous("u", lb=0.1, ub=10.0)
         v = m.continuous("v", lb=0.1, ub=10.0)
         m.minimize(u + v)
-        m.subject_to(u * v >= 5.0)  # nonconvex feasible region
-        result = m.solve(time_limit=60.0)
+        m.subject_to(u * v >= 5.0)  # nonconvex in x-space (a GP in log-space)
+
+        # The genuine guard: the x-space detector must abstain.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            is_convex, _mask = classify_model(m, use_certificate=True)
+        assert is_convex is False
+
+        # Classic branch-and-bound (opting out of the GP fast path): no x-space
+        # convex shortcut is taken, and the global optimum is still found.
+        result = m.solve(time_limit=60.0, solver="bb")
         assert result.status == "optimal"
         assert result.convex_fast_path is False
         # Analytic optimum: u = v = sqrt(5), objective 2*sqrt(5) ≈ 4.472.

--- a/python/tests/test_gp_corpus.py
+++ b/python/tests/test_gp_corpus.py
@@ -1,0 +1,231 @@
+"""Regression corpus for the geometric-programming / log-convexity subsystem (#111).
+
+These tests characterise the GP subsystem end to end:
+
+* :func:`discopt.gp.is_log_convex` — the **log-space** convexity verdict, kept
+  separate from :func:`discopt._jax.convexity.classify_model` (the **x-space**
+  verdict). A genuine GP is convex only under ``y = log x``, so the two
+  disagree: ``is_log_convex`` is ``True`` while x-space ``classify_model`` is
+  ``False``. This separation is a soundness requirement — folding log-convexity
+  into the x-space verdict would mis-gate the x-space convex fast path.
+* **Automatic routing** — a plain ``model.solve()`` (no ``solver=`` argument) on
+  a recognised GP is dispatched through the exact log-space convex solve, so the
+  result carries ``convex_fast_path is True``, a valid ``bound`` equal to the
+  objective, and a certified zero ``gap``. ``solver="bb"`` opts out.
+* **Negative controls** — signomials (mixed-sign coefficients) and integer-
+  variable models are not GPs: ``is_log_convex`` is ``False`` and they are not
+  auto-routed.
+
+Why no MINLPLib ``.nl`` corpus
+------------------------------
+MINLPLib does not ship raw-posynomial geometric programs. A scan of the cached
+instance set found ``classify_gp`` recognises none of them: the ``cvxnonsep_*``
+convex family are either sums of individually-convex monomials (already convex in
+x-space, handled by the #40 signomial-monomial recogniser) or carry integer
+variables, and the ``*_r`` reformulated variants are stored already-convexified
+(they contain ``log``). The genuine log-only-convex structure therefore lives in
+programmatically-built classic GPs, which is what this corpus uses — each with a
+closed-form optimum (Boyd & Vandenberghe Ch. 4.5).
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from typing import Callable
+
+import pytest
+from discopt._jax.convexity import classify_model
+from discopt.gp import classify_gp, is_log_convex, solve_gp
+from discopt.modeling.core import Model
+
+# Strictly-positive box shared by the continuous GP variables.
+POS = dict(lb=1e-3, ub=1e3)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Corpus: classic GPs with closed-form optima
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class GPCase:
+    """A GP model factory plus its analytic optimum."""
+
+    name: str
+    build: Callable[[], Model]
+    optimum: float
+
+
+def _monomial_balance() -> Model:
+    # minimize x/y + y/x over x, y > 0. Optimum 2 at x == y (AM-GM).
+    m = Model("balance")
+    x = m.continuous("x", **POS)
+    y = m.continuous("y", **POS)
+    m.minimize(x / y + y / x)
+    return m
+
+
+def _posynomial_objective() -> Model:
+    # minimize x + 1/(x*y) + y. Stationarity gives x == y == 1, value 3.
+    m = Model("posyobj")
+    x = m.continuous("x", **POS)
+    y = m.continuous("y", **POS)
+    m.minimize(x + 1.0 / (x * y) + y)
+    return m
+
+
+def _constrained_posynomial() -> Model:
+    # minimize x + y s.t. 1/(x*y) <= 1 (i.e. x*y >= 1). AM-GM: min 2 at x==y==1.
+    # A posynomial <= monomial inequality binding at the optimum.
+    m = Model("cobb")
+    x = m.continuous("x", **POS)
+    y = m.continuous("y", **POS)
+    m.minimize(x + y)
+    m.subject_to(1.0 / (x * y) <= 1.0)
+    return m
+
+
+def _box_volume() -> Model:
+    # maximize x*y (monomial) s.t. x*y <= 6, x/y <= 3, y/x <= 3.
+    # The volume bound is tight => optimum 6.
+    m = Model("boxvol")
+    x = m.continuous("x", **POS)
+    y = m.continuous("y", **POS)
+    m.maximize(x * y)
+    m.subject_to(x * y <= 6.0)
+    m.subject_to(x / y <= 3.0)
+    m.subject_to(y / x <= 3.0)
+    return m
+
+
+CORPUS = (
+    GPCase("monomial_balance", _monomial_balance, 2.0),
+    GPCase("posynomial_objective", _posynomial_objective, 3.0),
+    GPCase("constrained_posynomial", _constrained_posynomial, 2.0),
+    GPCase("box_volume", _box_volume, 6.0),
+)
+
+
+def _ids(cases: tuple[GPCase, ...]) -> list[str]:
+    return [c.name for c in cases]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Log-convex verdict, distinct from the x-space verdict
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("case", CORPUS, ids=_ids(CORPUS))
+def test_corpus_is_log_convex(case: GPCase) -> None:
+    """Every corpus GP is recognised as log-convex (a GP in standard form)."""
+    model = case.build()
+    assert is_log_convex(model) is True
+    assert classify_gp(model) is not None
+
+
+@pytest.mark.parametrize("case", CORPUS, ids=_ids(CORPUS))
+def test_corpus_is_not_x_space_convex(case: GPCase) -> None:
+    """SOUNDNESS SEPARATION: a GP is log-convex but NOT x-space convex.
+
+    ``classify_model`` (with the certificate, the exact setting that gates the
+    x-space convex fast path) must keep returning ``is_convex == False`` for
+    these genuinely log-only-convex models — otherwise the x-space fast path
+    would be taken on a problem that is not convex in x.
+    """
+    model = case.build()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        is_convex, _mask = classify_model(model, use_certificate=True)
+    assert is_convex is False, (
+        f"{case.name}: classify_model promoted a log-only-convex GP to x-space "
+        f"convex — this would mis-gate the x-space convex fast path."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Automatic routing through the log-space convex solve
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("case", CORPUS, ids=_ids(CORPUS))
+def test_corpus_auto_routes_to_gp_fast_path(case: GPCase) -> None:
+    """A plain ``model.solve()`` auto-routes a GP through the exact log solve.
+
+    The result reaches the closed-form optimum with ``convex_fast_path`` set, a
+    valid ``bound`` equal to the objective, and a certified zero gap.
+    """
+    model = case.build()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = model.solve()
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(case.optimum, abs=1e-4)
+    assert result.convex_fast_path is True
+    assert result.bound == pytest.approx(result.objective, abs=1e-9)
+    assert result.gap == pytest.approx(0.0, abs=1e-12)
+
+
+@pytest.mark.parametrize("case", CORPUS, ids=_ids(CORPUS))
+def test_corpus_auto_route_matches_solve_gp(case: GPCase) -> None:
+    """Auto-route and the explicit ``solve_gp`` entry point agree."""
+    auto = case.build()
+    direct = case.build()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        auto_result = auto.solve()
+        direct_result = solve_gp(direct)
+    assert direct_result is not None
+    assert auto_result.objective == pytest.approx(direct_result.objective, abs=1e-6)
+
+
+def test_bb_opt_out_skips_gp_fast_path() -> None:
+    """``solver="bb"`` forces classic branch-and-bound, not the GP fast path."""
+    model = _monomial_balance()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = model.solve(solver="bb")
+    assert result.status in ("optimal", "feasible")
+    assert result.objective == pytest.approx(2.0, abs=1e-4)
+    # The classic path does not set the convex single-NLP fast-path flag.
+    assert result.convex_fast_path is False
+
+
+def test_unknown_solver_is_rejected() -> None:
+    """An unrecognised ``solver=`` value raises rather than silently routing."""
+    model = _monomial_balance()
+    with pytest.raises(ValueError, match="Unknown solver"):
+        model.solve(solver="xyz")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Negative controls: not GPs, must not be log-convex or auto-routed
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_signomial_is_not_log_convex() -> None:
+    """A mixed-sign signomial objective is not a GP."""
+    m = Model("signomial")
+    x = m.continuous("x", **POS)
+    y = m.continuous("y", **POS)
+    m.minimize(x * y - x)  # negative-coefficient term => signomial, not posynomial
+    assert is_log_convex(m) is False
+    assert solve_gp(m) is None
+
+
+def test_integer_variable_is_not_log_convex() -> None:
+    """An integer variable disqualifies the (continuous) GP fast path."""
+    m = Model("intvar")
+    x = m.integer("x", lb=1, ub=10)
+    y = m.continuous("y", **POS)
+    m.minimize(x / y + y / x)
+    assert is_log_convex(m) is False
+    assert solve_gp(m) is None
+
+
+def test_nonpositive_variable_is_not_log_convex() -> None:
+    """A variable whose lower bound is not strictly positive is not a GP."""
+    m = Model("nonpos")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    m.minimize(x * x)
+    assert is_log_convex(m) is False


### PR DESCRIPTION
## Summary

Advances #111 (geometric-programming / log-convexity subsystem) by making the GP
machinery from #105 **reachable and complete**. PR #105 shipped the posynomial
recogniser, the `y = log x` reformulation, `solve_gp`, and an opt-in `solver="gp"`
path. This PR wires it into the default solve path, adds the log-space convexity
verdict, completes the bound/gap mapping, and lands a regression corpus.

## What changed

- **Auto-routing.** A plain `model.solve()` now detects a geometric program
  (`classify_gp`) and routes it through the exact log-space convex reformulation —
  a single convex NLP that returns the global optimum, strictly better than B&B.
  It fires only when no global solver was explicitly requested and no branch-and-
  bound streaming callbacks are attached. `solver="bb"` is an explicit opt-out;
  unknown `solver=` values now raise instead of silently falling through to B&B.
- **`discopt.gp.is_log_convex(model)`** — a **log-space** convexity verdict, kept
  strictly separate from the x-space `classify_model`. A genuine GP is not convex
  in x, so `classify_model(..., use_certificate=True)` stays `(False, ...)` while
  `is_log_convex` is `True`. Folding log-convexity into the x-space verdict would
  mis-gate the x-space convex fast path — a soundness break — so they are
  independent predicates.
- **`solve_gp` solution mapping** — at an optimal log-space solve it now sets
  `bound = objective`, `gap = 0`, and `convex_fast_path = True` (the convex global
  optimum is a valid lower bound). Guarded on optimal status and a finite
  objective, so no bound is ever fabricated on a limit/infeasible solve.

## Tests

- **`test_gp_corpus.py`** (new) — classic GPs with closed-form optima (monomial
  balance, posynomial objective, constrained posynomial, box volume). Each asserts
  the characterising trio: `is_log_convex` True, x-space `classify_model` False
  (proving it is log-only-convex), and an exact **auto-routed** solve with
  `bound == objective`, `gap == 0`, `convex_fast_path True`. Plus signomial and
  integer-variable negative controls.
- **Wide-box bilinear control updated** — `min u+v s.t. u*v>=5` is in fact a GP, so
  it now auto-routes and reports `convex_fast_path True`. The test's real guard
  (the *x-space* recognisers must not over-accept) is preserved by asserting
  `classify_model` stays `False`; the classic B&B path is exercised via
  `solver="bb"`.

### Why no MINLPLib `.nl` corpus

The plan originally scoped a MINLPLib log-space corpus. An empirical scan found
`classify_gp` recognises **0 of 122** cached instances as standard-form GPs:
MINLPLib stores convex problems already-convexified (the `cvxnonsep_psig*` family
are sums of individually-convex monomials and/or carry integer variables; the
`*_r` variants literally contain `log`). The corpus therefore uses
programmatically-built classic GPs with analytic optima.

## Soundness

- x-space `classify_model` is **untouched**; the #40 suspect corpus and all
  convexity regressions pass unchanged.
- Auto-routing only fires when `classify_gp` succeeds — which is exactly the proof
  that the log reformulation is exact — so a routed solve is the global optimum.
- `bound`/`gap` are set only on a converged, finite-objective optimal solve.

## Verification

- `pytest python/tests/test_gp_corpus.py python/tests/test_gp.py python/tests/test_posynomial.py python/tests/test_convexity_wide_box.py -v`
- Full PR-fast suite (`-m "not slow"`, 120 s timeout) green locally.
- `ruff check python/`, `ruff format --check`, `mypy python/discopt/gp/ python/discopt/solver.py` clean.

## Out of scope (still tracked on #111)

- **Signomial (mixed-sign) programs** (component 5) — a separate iterative global
  solver (SGO / relaxation + y-space B&B), not an extension of the exact GP path.
  Safely gated out: signomials get `is_log_convex False` and are never auto-routed.
- **Per-expression log-curvature lattice** (component 2's *richer* form). The sound
  v1 — a whole-model `is_log_convex` verdict — **is** delivered here; what remains
  is propagating log-affine/log-convex/log-concave through the DAG so partially
  log-convex models compose. Additive, no correctness dependency on it.
- Branching / bound-tightening in y-space for GP-structured MINLPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
