### PR TITLE
feat(benchmarks): wire external solvers (SCIP/Couenne/HiGHS) into the harness

### DIFF
--- a/discopt_benchmarks/SOLVERS.md
+++ b/discopt_benchmarks/SOLVERS.md
@@ -1,0 +1,61 @@
+# External Solver Setup (local benchmarking)
+
+discopt benchmarks compare against external MINLP/MILP solvers via their AMPL
+`.nl` interface. The harness shells out, captures stdout, and parses status /
+objective / bound / nodes (`benchmarks/runner.py:_build_command`,
+`_parse_external_output`). This note records the working local setup on macOS
+(osx-arm64) so the comparison suite is reproducible.
+
+## Which build to use (the `.nl` gotcha)
+
+A solver binary only works here if it can **read `.nl` files**. Several distributed
+builds cannot, so the binary that matters is not always the obvious one:
+
+| Solver  | Use this binary                                                        | Version  | Reads `.nl`? |
+|---------|-----------------------------------------------------------------------|----------|--------------|
+| SCIP    | `…/miniforge/base/envs/discopt-bench/bin/scip` (conda-forge)          | 10.0.2   | ✅ (AMPL/MP reader) |
+| Couenne | `/Applications/AMPL/couenne` (COIN-OR ASL build)                       | 0.5.8    | ✅ |
+| HiGHS   | `/Applications/AMPL/highs` (ASL build)                                 | 1.11.0   | ✅ |
+
+**Do not** use conda-forge HiGHS (1.14.0) for `.nl` work — its CLI errors with
+"Model file not supported" and only reads `.mps`/`.lp`. Couenne is **not**
+available on conda-forge osx-arm64 at all; the AMPL-bundled COIN-OR build is the
+source. The AMPL-bundled open-source COIN-OR solvers (couenne, bonmin, the ASL
+highs) need **no AMPL license**.
+
+Paths are configured in `config/benchmarks.toml` under `[solvers]`.
+
+## Conda environment
+
+```bash
+conda create -n discopt-bench -c conda-forge scip=10.0.2 highs bonmin
+```
+
+(SCIP is the one solver consumed from conda-forge. HiGHS/Couenne are taken from
+`/Applications/AMPL/` per the table above.)
+
+## Invocation details
+
+- **SCIP** uses the batch `-c` interface with an explicit time limit:
+  `scip -c "set limits time T" -c "read f.nl" -c "optimize" -c "display solution"
+  -c "display statistics" -c "quit"`. Parsed from `SCIP Status`, `Primal Bound`,
+  `Dual Bound`, `Solving Nodes`.
+- **HiGHS / Couenne** take the `.nl` path as a positional argument.
+
+## Objective-sense convention (important)
+
+Couenne (and COIN AMPL solvers) report `Lower bound:` / `Upper bound:` in their
+**internal minimization** sense: for a maximization model they solve `min g = -f`.
+The harness reads the objective-sense marker from the `.nl` header
+(`O<k> 1` = maximize) via `_nl_is_maximize` and **un-negates** for max problems:
+`objective = -upper_internal`, `bound = -lower_internal`. SCIP and the ASL HiGHS
+already report in the model's original sense, so no flip is applied there.
+
+## Smoke check
+
+```python
+from benchmarks.runner import BenchmarkRunner, BenchmarkConfig
+r = BenchmarkRunner(BenchmarkConfig(suite_name="adhoc"))
+# /tmp/milp.nl is a small max-objective MILP with optimum 6.
+# scip / couenne / highs should all report status=optimal, objective=6.0.
+```

--- a/discopt_benchmarks/benchmarks/runner.py
+++ b/discopt_benchmarks/benchmarks/runner.py
@@ -7,6 +7,7 @@ collects results, computes metrics, and generates reports.
 
 from __future__ import annotations
 
+import re
 import subprocess
 import time
 from dataclasses import dataclass
@@ -96,9 +97,7 @@ class BenchmarkRunner:
         if "max_instances" in f:
             # Handled externally by truncating list
             pass
-        if "problem_class" in f and inst.problem_class != f["problem_class"]:
-            return False
-        return True
+        return not ("problem_class" in f and inst.problem_class != f["problem_class"])
 
     def run_all(self, parallel: bool = False, max_workers: int = 4):
         """Run all solvers on all instances."""
@@ -398,11 +397,78 @@ class BenchmarkRunner:
             )
 
     def _build_command(self, solver: SolverConfig, instance: str) -> list[str]:
-        """Build solver command line."""
+        """Build a solver command line for the .nl-interface external solvers.
+
+        SCIP is driven through its batch (``-c``) interface so we can set the
+        time limit and dump the solution/statistics; the AMPL-ASL solvers
+        (Couenne, BARON, Bonmin, HiGHS-ASL) read the ``.nl`` directly and report
+        on stdout. The subprocess wrapper in :meth:`_run_external` enforces a
+        hard wall-clock timeout regardless, so an internal limit is best-effort.
+        """
+        nl = self._find_nl_file(instance) or instance
         cmd = [solver.command]
-        # Solver-specific flags would be added here
-        cmd.append(instance)
+        name = solver.name.lower()
+        time_limit = int(self.config.time_limit)
+
+        if name.startswith("scip"):
+            cmd += [
+                "-c",
+                f"set limits time {time_limit}",
+                "-c",
+                f"read {nl}",
+                "-c",
+                "optimize",
+                "-c",
+                "display solution",
+                "-c",
+                "display statistics",
+                "-c",
+                "quit",
+            ]
+        else:
+            # Couenne / BARON / Bonmin / HiGHS-ASL: solve the .nl directly.
+            cmd.append(nl)
         return cmd
+
+    @staticmethod
+    def _nl_is_maximize(nl_path: str) -> bool:
+        """Read the .nl objective sense from the ``O`` segment.
+
+        ``O<k> 0`` is minimize, ``O<k> 1`` is maximize. Couenne reports its
+        Lower/Upper bounds in internal-minimization sense, so we need this to
+        recover the original-sense objective.
+        """
+        try:
+            with open(nl_path) as fh:
+                for line in fh:
+                    if line.startswith("O"):
+                        parts = line.split()
+                        return len(parts) >= 2 and parts[1].strip() == "1"
+        except OSError:
+            pass
+        return False
+
+    @staticmethod
+    def _first_float(pattern: str, text: str) -> float | None:
+        m = re.search(pattern, text, re.IGNORECASE | re.MULTILINE)
+        if not m:
+            return None
+        try:
+            val = float(m.group(1))
+        except ValueError:
+            return None
+        # AMPL/solvers use ~1e20/1e50 as +/-infinity sentinels for "no bound".
+        return None if abs(val) >= 1e19 else val
+
+    @staticmethod
+    def _first_int(pattern: str, text: str) -> int:
+        m = re.search(pattern, text, re.IGNORECASE | re.MULTILINE)
+        if not m:
+            return 0
+        try:
+            return int(m.group(1))
+        except ValueError:
+            return 0
 
     def _parse_external_output(
         self,
@@ -412,14 +478,112 @@ class BenchmarkRunner:
         stderr: str,
         elapsed: float,
     ) -> SolveResult:
-        """Parse external solver output into SolveResult."""
-        # This would have solver-specific parsers for BARON, Couenne, SCIP, etc.
-        # Stub implementation
+        """Parse external-solver stdout into a :class:`SolveResult`."""
+        name = solver_name.lower()
+        if name.startswith("scip"):
+            return self._parse_scip(instance, solver_name, stdout, elapsed)
+        if name.startswith("highs"):
+            return self._parse_highs(instance, solver_name, stdout, elapsed)
+        # Couenne / BARON / Bonmin and other AMPL-ASL solvers.
+        return self._parse_ampl_solver(instance, solver_name, stdout, elapsed)
+
+    def _parse_scip(
+        self, instance: str, solver_name: str, stdout: str, elapsed: float
+    ) -> SolveResult:
+        status = SolveStatus.UNKNOWN
+        m = re.search(r"SCIP Status\s*:\s*(.+)", stdout)
+        line = m.group(1).lower() if m else ""
+        if "optimal solution found" in line:
+            status = SolveStatus.OPTIMAL
+        elif "infeasible" in line and "unbounded" not in line:
+            status = SolveStatus.INFEASIBLE
+        elif "unbounded" in line:
+            status = SolveStatus.UNBOUNDED
+        elif "time limit" in line:
+            status = SolveStatus.TIME_LIMIT
+        elif "memory limit" in line:
+            status = SolveStatus.MEMORY_LIMIT
+
+        primal = self._first_float(r"Primal Bound\s*:\s*([+\-0-9.eE]+)", stdout)
+        dual = self._first_float(r"Dual Bound\s*:\s*([+\-0-9.eE]+)", stdout)
+        nodes = self._first_int(r"Solving Nodes\s*:\s*([0-9]+)", stdout)
         return SolveResult(
             instance=instance,
             solver=solver_name,
-            status=SolveStatus.UNKNOWN,
+            status=status,
+            objective=primal,
+            bound=dual,
             wall_time=elapsed,
+            node_count=nodes,
+        )
+
+    def _parse_highs(
+        self, instance: str, solver_name: str, stdout: str, elapsed: float
+    ) -> SolveResult:
+        # ASL build prints e.g. "HiGHS 1.11.0: optimal solution; objective 6"
+        status = SolveStatus.UNKNOWN
+        low = stdout.lower()
+        if "optimal" in low:
+            status = SolveStatus.OPTIMAL
+        elif "infeasible" in low:
+            status = SolveStatus.INFEASIBLE
+        elif "unbounded" in low:
+            status = SolveStatus.UNBOUNDED
+        elif "time limit" in low or "time_limit" in low:
+            status = SolveStatus.TIME_LIMIT
+        objective = self._first_float(r"objective\s+([+\-0-9.eE]+)", stdout)
+        return SolveResult(
+            instance=instance,
+            solver=solver_name,
+            status=status,
+            objective=objective,
+            wall_time=elapsed,
+        )
+
+    def _parse_ampl_solver(
+        self, instance: str, solver_name: str, stdout: str, elapsed: float
+    ) -> SolveResult:
+        """Parse Couenne (and similar COIN AMPL solvers) stdout.
+
+        Couenne prints a ``<solver>: <Status>`` summary plus ``Lower bound:`` /
+        ``Upper bound:`` lines in *internal-minimization* sense; we un-negate
+        them for maximization models so the reported objective is original-sense.
+        """
+        status = SolveStatus.UNKNOWN
+        low = stdout.lower()
+        m = re.search(
+            r"^\s*\w+:\s*(optimal|infeasible|unbounded|\w+)",
+            stdout,
+            re.MULTILINE | re.IGNORECASE,
+        )
+        verdict = m.group(1).lower() if m else ""
+        if verdict == "optimal" or "optimal" in low:
+            status = SolveStatus.OPTIMAL
+        elif "infeasible" in low:
+            status = SolveStatus.INFEASIBLE
+        elif "unbounded" in low:
+            status = SolveStatus.UNBOUNDED
+        elif verdict in {"stopped", "limit"} or "time limit" in low:
+            status = SolveStatus.TIME_LIMIT
+
+        upper = self._first_float(r"Upper bound:\s*([+\-0-9.eE]+)", stdout)
+        lower = self._first_float(r"Lower bound:\s*([+\-0-9.eE]+)", stdout)
+        nodes = self._first_int(r"Branch-and-bound nodes:\s*([0-9]+)", stdout)
+
+        objective, bound = upper, lower
+        nl = self._find_nl_file(instance)
+        if nl and self._nl_is_maximize(nl):
+            # internal min g = -f: f_best = -upper_internal, bound = -lower_internal
+            objective = None if upper is None else -upper
+            bound = None if lower is None else -lower
+        return SolveResult(
+            instance=instance,
+            solver=solver_name,
+            status=status,
+            objective=objective,
+            bound=bound,
+            wall_time=elapsed,
+            node_count=nodes,
         )
 
     def save_results(self, path: Path | None = None):

--- a/discopt_benchmarks/config/benchmarks.toml
+++ b/discopt_benchmarks/config/benchmarks.toml
@@ -330,28 +330,29 @@ nl_interface = true
 options = { threads = 1, epsa = 1e-6, epsr = 1e-4 }
 
 [solvers.couenne]
-command = "couenne"
+command = "/Applications/AMPL/couenne"
 type = "external"
 nl_interface = true
 options = { threads = 1 }
-note = "Not available on conda-forge for osx-arm64; build from source via coinbrew."
+note = "COIN-OR Couenne 0.5.8 (AMPL-ASL build). Not on conda-forge for osx-arm64; the AMPL bundle ships an open-source ASL-linked binary that reads .nl directly (no AMPL license needed)."
 
 [solvers.bonmin]
 command = "/opt/homebrew/Caskroom/miniforge/base/envs/discopt-bench/bin/bonmin"
 type = "external"
 nl_interface = true
 options = { threads = 1 }
-note = "Installed via `mamba create -n discopt-bench -c conda-forge coin-or-bonmin`."
+note = "conda-forge coin-or-bonmin in the discopt-bench env."
 
 [solvers.scip]
-command = "scip"
+command = "/opt/homebrew/Caskroom/miniforge/base/envs/discopt-bench/bin/scip"
 type = "external"
 nl_interface = true
 options = { threads = 1 }
-note = "Installed via `brew install scip`."
+note = "conda-forge scip 10.0.2 (SoPlex 8.0.2) in the discopt-bench env; has the AMPL/MP .nl reader. Driven via the SCIP batch -c interface."
 
 [solvers.highs]
-command = "highs"
+command = "/Applications/AMPL/highs"
 type = "external"
+nl_interface = true
 options = { threads = 1 }
-note = "LP/MILP only — used for LP subsolver comparison"
+note = "HiGHS 1.11.0 (AMPL-ASL build) — reads .nl. NOTE: the conda-forge `highs` CLI is mps/lp-only and does NOT read .nl, so the .nl benchmark path must use the ASL build. LP/MILP only."


### PR DESCRIPTION
## Summary

Wires external solvers (SCIP / Couenne / HiGHS) into the comparison benchmark harness. The harness previously had stubbed `_build_command` / `_parse_external_output`, so external-solver suites produced no results — this implements both, adds per-solver stdout parsers, and documents the reproducible local solver setup.

## Changes

- **`benchmarks/runner.py`**
  - `_build_command` resolves the `.nl` and uses SCIP's batch `-c` interface (with a time limit) or a positional `.nl` arg for Couenne/HiGHS.
  - `_parse_external_output` dispatches to `_parse_scip` / `_parse_highs` / `_parse_ampl_solver`, mapping status + objective + dual bound + node count.
  - **Objective-sense handling:** AMPL/COIN solvers report Lower/Upper bound in the internal *minimization* sense. `_nl_is_maximize` reads the `.nl` `O<k>` marker and un-negates for maximization models so the reported objective is original-sense. SCIP / ASL HiGHS already report original sense.
- **`config/benchmarks.toml`** — `[solvers]` now points at the builds that actually read `.nl`: conda-forge SCIP 10.0.2, AMPL-bundled Couenne 0.5.8 and HiGHS 1.11.0 (the conda-forge HiGHS CLI cannot read `.nl`), with corrected notes.
- **`SOLVERS.md`** (new) — documents which build per solver, versions, the `.nl` gotcha, the conda env, and the Couenne sign convention.

## Verification

End-to-end on a max-objective MILP (optimum 6): SCIP, Couenne, and HiGHS all parse to `status=optimal`, `objective=6.0` (Couenne sign correctly un-negated). `ruff check` / `ruff format --check` clean; runner/parse tests and the `-m smoke` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
