### PR TITLE
feat(solver): sound per-node interval bound for nonconvex spatial B&B

### DIFF
--- a/crates/discopt-core/src/bnb/branching.rs
+++ b/crates/discopt-core/src/bnb/branching.rs
@@ -421,8 +421,14 @@ pub fn select_spatial_branch_variable(
         if relative_width < SPATIAL_MIN_WIDTH {
             continue; // Domain already very tight.
         }
-        if width > best_width {
-            best_width = width;
+        // Select on the same relative width used for the threshold so the
+        // branch falls on the dimension that has shrunk least relative to its
+        // root domain (longest-edge in normalized coordinates). Selecting on
+        // the absolute width instead just tracks whichever variable happens to
+        // have the largest raw range. Strict `>` with the ascending scan keeps
+        // tie-breaking deterministic (lowest index wins).
+        if relative_width > best_width {
+            best_width = relative_width;
             best_idx = Some(idx);
         }
     }

--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -430,7 +430,16 @@ impl TreeManager {
         if min_lb == f64::INFINITY {
             self.global_lower_bound = self.incumbent_value;
         } else {
-            self.global_lower_bound = min_lb;
+            // The global lower bound can never exceed the best known incumbent:
+            // the optimum is <= any feasible solution, so a valid lower bound is
+            // <= the incumbent too. When every open node's bound is already >=
+            // the incumbent (which happens transiently after the incumbent
+            // improves but before those nodes are re-pruned), the incumbent is
+            // proven optimal and the bound equals it. Without this cap,
+            // global_lower_bound could exceed the incumbent, producing a
+            // negative gap (masked by the clamp in `gap()`) and an unsound
+            // "bound > objective" at a certified-optimal exit.
+            self.global_lower_bound = min_lb.min(self.incumbent_value);
         }
     }
 
@@ -699,6 +708,43 @@ mod tests {
         tm.incumbent_value = 10.0;
         tm.global_lower_bound = 5.0;
         assert!((tm.gap() - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_global_lower_bound_capped_at_incumbent() {
+        // Regression: when the incumbent improves below an already-open node's
+        // bound (before that node is re-pruned), the global lower bound must be
+        // capped at the incumbent — never exceed it. An uncapped bound yields a
+        // negative gap (masked by the clamp in `gap()`) and an unsound
+        // "bound > objective" at a certified-optimal exit.
+        let mut tm = TreeManager::new(
+            1,
+            vec![0.0],
+            vec![1.0],
+            vec![VarBranchInfo {
+                offset: 0,
+                size: 1,
+                is_integer: true,
+            }],
+            SelectionStrategy::BestFirst,
+        );
+        tm.initialize();
+        // One open node whose bound sits above the (later, better) incumbent.
+        let node = tm.pool.get_mut(NodeId(0));
+        node.local_lower_bound = 2.48;
+        node.status = NodeStatus::Evaluated;
+        tm.incumbent_value = 1.92;
+
+        tm.update_global_lower_bound();
+
+        assert!(
+            tm.global_lower_bound <= tm.incumbent_value + 1e-12,
+            "global_lower_bound {} must not exceed incumbent {}",
+            tm.global_lower_bound,
+            tm.incumbent_value
+        );
+        assert!((tm.global_lower_bound - 1.92).abs() < 1e-12);
+        assert!(tm.gap() >= 0.0);
     }
 
     #[test]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -6451,6 +6451,25 @@ def _solve_milp_bb(
     except Exception as _cc_exc:
         logger.debug("root cuts skipped: %s", _cc_exc)
 
+    # Seed a rigorous root lower bound from the (cut-augmented) LP relaxation,
+    # solved once via the fast convex engine (~0.03 s). This is always a valid
+    # dual bound and is surfaced even on an uncertified / time-limited exit, so
+    # a solve that cannot finish the tree — e.g. AMP's short per-iteration MILP
+    # budget, which otherwise returns bound=-inf and leaves AMP's LB stuck at
+    # -inf — still yields a finite lower bound. Tightens across AMP iterations
+    # as the relaxation gains partitions/cuts. POUNCE-only (the convex engine);
+    # left at -inf otherwise so behavior is unchanged on the JAX-IPM path.
+    _root_lp_bound = -np.inf
+    if prefer_pounce:
+        try:
+            _root_out = _solve_node_lp_pounce(
+                lp_data, lb, ub, n_vars, n_orig, t_start, time_limit
+            )
+            if _root_out is not None and _root_out[2] == "optimal" and np.isfinite(_root_out[0]):
+                _root_lp_bound = float(_root_out[0])
+        except Exception as _rlb_exc:
+            logger.debug("root LP bound seeding skipped: %s", _rlb_exc)
+
     t_rust_start = time.perf_counter()
     tree = PyTreeManager(n_vars, lb.tolist(), ub.tolist(), int_offsets, int_sizes, strategy)
     tree.initialize()
@@ -6774,14 +6793,23 @@ def _solve_milp_bb(
     # Negate bound back for maximization
     bound_val = stats["global_lower_bound"]
     assert model._objective is not None
-    if bound_val is not None and model._objective.sense == ObjectiveSense.MAXIMIZE:
+    _maximize = model._objective.sense == ObjectiveSense.MAXIMIZE
+    if bound_val is not None and _maximize:
         bound_val = -bound_val
 
-    # An uncertified gap is not a rigorous dual bound; do not present one.
     gap_val = stats["gap"]
     if not _gap_certified:
+        # Tree bound/gap are not rigorous on an uncertified exit (a node may
+        # have been pruned without proof); drop them.
         bound_val = None
         gap_val = None
+    # The root LP relaxation bound is always a valid dual bound. Surface it
+    # whenever the tree did not yield a usable finite bound — an uncertified
+    # exit (dropped above) or a certified-but-time-limited solve that never
+    # closed a node (global_lower_bound still -inf). This lets AMP's short
+    # per-iteration MILP budget return a finite lower bound instead of None.
+    if (bound_val is None or not np.isfinite(bound_val)) and np.isfinite(_root_lp_bound):
+        bound_val = -_root_lp_bound if _maximize else _root_lp_bound
 
     return SolveResult(
         status=status,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5539,17 +5539,35 @@ def _solve_node_lp_pounce(lp_data, node_lb, node_ub, n_vars, n_orig, t_start, ti
         return None
     if not POUNCE_AVAILABLE:
         return None
-    xl = np.asarray(lp_data.x_l, dtype=np.float64)
-    xu = np.asarray(lp_data.x_u, dtype=np.float64)
-    full_lb = np.concatenate([np.asarray(node_lb, dtype=np.float64), xl[n_orig:]])
-    full_ub = np.concatenate([np.asarray(node_ub, dtype=np.float64), xu[n_orig:]])
     time_left = max(0.5, time_limit - (time.perf_counter() - t_start))
+    # POUNCE's interior-point LP is far faster on the native *inequality* form
+    # than on the slack-expanded standard form: ``lp_data`` carries one explicit
+    # slack column per inequality, which quadruples the variable count (e.g.
+    # 92 -> 400) and stalls the IPM (it times out without a bound). Decompose
+    # the standard form back to inequalities over the structural columns and
+    # hand POUNCE ``A_ub``/``A_eq`` directly with only the structural bounds.
+    n_slack = int(lp_data.A_eq.shape[1]) - n_orig
     try:
+        A_ub_m, b_ub_m, A_eq_m, b_eq_m = _decompose_eq_slack_form(
+            np.asarray(lp_data.A_eq, dtype=np.float64),
+            np.asarray(lp_data.b_eq, dtype=np.float64),
+            n_orig,
+            n_slack,
+        )
+        # _decompose_eq_slack_form already returns None for empty A_ub/A_eq,
+        # which solve_lp accepts; pass through directly.
         res = _pounce_solve(
-            c=np.asarray(lp_data.c, dtype=np.float64),
-            A_eq=np.asarray(lp_data.A_eq, dtype=np.float64),
-            b_eq=np.asarray(lp_data.b_eq, dtype=np.float64),
-            bounds=list(zip(full_lb.tolist(), full_ub.tolist())),
+            c=np.asarray(lp_data.c[:n_orig], dtype=np.float64),
+            A_ub=A_ub_m,
+            b_ub=b_ub_m,
+            A_eq=A_eq_m,
+            b_eq=b_eq_m,
+            bounds=list(
+                zip(
+                    np.asarray(node_lb, dtype=np.float64).tolist(),
+                    np.asarray(node_ub, dtype=np.float64).tolist(),
+                )
+            ),
             time_limit=min(30.0, time_left),
         )
     except Exception as e:
@@ -6205,7 +6223,7 @@ def _root_cover_cut_loop(
     return lp_data, total
 
 
-def _root_dive(lp_data, n_orig, int_idx, t_start, time_limit, max_steps=None):
+def _root_dive(lp_data, n_orig, int_idx, t_start, time_limit, max_steps=None, prefer_pounce=False):
     """Fractional diving from the root LP to find an early incumbent (Phase 3).
 
     Repeatedly solve the LP relaxation, fix the most-fractional unfixed integer
@@ -6213,9 +6231,26 @@ def _root_dive(lp_data, n_orig, int_idx, t_start, time_limit, max_steps=None):
     integral (an incumbent) or a fix makes the LP non-optimal (dive abandoned).
     Returns ``(objective, x_orig)`` in minimization sense, or ``None``. An early
     incumbent front-loads pruning and reduced-cost fixing.
+
+    In POUNCE-only mode (``prefer_pounce``) the dive LPs are solved with POUNCE
+    on the native inequality form instead of the pure-JAX IPM (Phase 8: no JAX
+    IPM on the POUNCE LP/MILP path; the JAX IPM stalls on the slack-expanded
+    standard form anyway).
     """
     if not int_idx:
         return None
+
+    steps = max_steps if max_steps is not None else len(int_idx) + 1
+
+    if prefer_pounce:
+        # POUNCE-only mode (Phase 8: no pure-JAX IPM on this path). The dive is
+        # an optional early-incumbent heuristic; a faithful POUNCE port would
+        # need one LP solve per fixed integer (dozens of sequential solves),
+        # which can starve the main B&B budget on larger relaxations. Skipping
+        # it is sound — node solves and small-integer recovery still find
+        # incumbents — and removes the last JAX-IPM call from the POUNCE path.
+        return None
+
     import jax.numpy as jnp
 
     from discopt._jax.lp_ipm import lp_ipm_solve
@@ -6414,7 +6449,9 @@ def _solve_milp_bb(
     # and reduced-cost fixing. The tree keeps the best of any injected points.
     try:
         _int_idx = [j for off, sz in zip(int_offsets, int_sizes) for j in range(off, off + int(sz))]
-        _dive = _root_dive(lp_data, n_orig, _int_idx, t_start, time_limit)
+        _dive = _root_dive(
+            lp_data, n_orig, _int_idx, t_start, time_limit, prefer_pounce=prefer_pounce
+        )
         if _dive is not None:
             _dz, _dx = _dive
             tree.inject_incumbent(np.asarray(_dx[:n_vars], dtype=np.float64).copy(), float(_dz))

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5584,9 +5584,7 @@ def _solve_node_lp_pounce(lp_data, node_lb, node_ub, n_vars, n_orig, t_start, ti
         if A_ub_m is not None and A_ub_m.shape[0]:
             feasible = bool(np.all(A_ub_m @ x_sol <= b_ub_m + tol * (1.0 + np.abs(b_ub_m))))
         if feasible and A_eq_m is not None and A_eq_m.shape[0]:
-            feasible = bool(
-                np.all(np.abs(A_eq_m @ x_sol - b_eq_m) <= tol * (1.0 + np.abs(b_eq_m)))
-            )
+            feasible = bool(np.all(np.abs(A_eq_m @ x_sol - b_eq_m) <= tol * (1.0 + np.abs(b_eq_m))))
         if not feasible:
             logger.debug("POUNCE convex node solution violates its rows; rejecting")
             return None
@@ -6462,9 +6460,7 @@ def _solve_milp_bb(
     _root_lp_bound = -np.inf
     if prefer_pounce:
         try:
-            _root_out = _solve_node_lp_pounce(
-                lp_data, lb, ub, n_vars, n_orig, t_start, time_limit
-            )
+            _root_out = _solve_node_lp_pounce(lp_data, lb, ub, n_vars, n_orig, t_start, time_limit)
             if _root_out is not None and _root_out[2] == "optimal" and np.isfinite(_root_out[0]):
                 _root_lp_bound = float(_root_out[0])
         except Exception as _rlb_exc:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -310,6 +310,46 @@ def _compute_alphabb_bound(evaluator, node_lb, node_ub, alpha):
     return best_val if np.isfinite(best_val) else -np.inf
 
 
+def _compute_interval_bound(model, node_lb, node_ub, negate):
+    """Sound interval-arithmetic lower bound on the objective over a node box.
+
+    Builds a ``{Variable: Interval}`` box from the flat node bounds and
+    evaluates the objective expression with outward-rounded interval
+    arithmetic. The lower endpoint of the resulting enclosure is always a
+    valid (if loose) lower bound on ``f`` over the box; for a maximization
+    model the internal minimization objective is ``-f``, so its valid lower
+    bound is ``-hi``.
+
+    Unlike the McCormick-NLP bound this is cheap and unconditional, so it lets
+    every open nonconvex node carry a finite valid bound on every iteration
+    (instead of ``-inf`` on iterations where the periodic McCormick-NLP solve
+    is skipped). Returns ``-inf`` when the enclosure is not finite or
+    evaluation fails — never an invalid (too-high) bound.
+    """
+    if model._objective is None:
+        return -np.inf
+    try:
+        from discopt._jax.convexity.interval import Interval
+        from discopt._jax.convexity.interval_eval import evaluate_interval
+
+        box = {}
+        offset = 0
+        for v in model._variables:
+            sz = v.size
+            lo = np.asarray(node_lb[offset : offset + sz], dtype=np.float64).reshape(v.shape)
+            hi = np.asarray(node_ub[offset : offset + sz], dtype=np.float64).reshape(v.shape)
+            box[v] = Interval(lo, hi)
+            offset += sz
+        iv = evaluate_interval(model._objective.expression, model, box)
+        lo = float(np.min(np.asarray(iv.lo)))
+        hi = float(np.max(np.asarray(iv.hi)))
+    except (ValueError, ArithmeticError, RuntimeError, TypeError, KeyError, IndexError) as e:
+        logger.debug("interval objective bound failed: %s", e)
+        return -np.inf
+    bound = -hi if negate else lo
+    return bound if np.isfinite(bound) else -np.inf
+
+
 def _extract_variable_info(model: Model):
     """Extract flat variable bounds and integer variable group info from a model.
 
@@ -2067,6 +2107,16 @@ def solve_model(
         tree.set_nonconvex(True)
     _gap_certified = True
 
+    # Sense-derived negation flag for the internal (minimization) B&B. Unlike
+    # ``_mc_negate`` below — which is only assigned correctly inside the
+    # McCormick "nlp"/"midpoint" setup — this is valid in every relaxation
+    # mode, so the interval bound stays sound for maximization models too.
+    from discopt.modeling.core import ObjectiveSense as _ObjectiveSense
+
+    _obj_negate = (
+        model._objective is not None and model._objective.sense == _ObjectiveSense.MAXIMIZE
+    )
+
     # --- Default Ipopt options ---
     opts = dict(ipopt_options) if ipopt_options else {}
     opts.setdefault("print_level", 0)
@@ -2437,6 +2487,20 @@ def solve_model(
                             result_lbs[i] = max(result_lbs[i], relax_lb)
                         except (ValueError, ArithmeticError, RuntimeError) as e:
                             logger.debug("alphaBB bound failed at node %d: %s", i, e)
+            # Cheap, always-valid interval-arithmetic bound. Runs every
+            # iteration so nonconvex nodes never sit at -inf between the
+            # periodic McCormick-NLP solves (which only fire every
+            # _mc_nlp_period iterations). max() of valid bounds stays valid,
+            # so this only ever tightens the global lower bound — enabling
+            # certified "optimal" status without weakening soundness.
+            if not _model_is_convex and model._objective is not None:
+                for i in range(n_batch):
+                    if result_lbs[i] < _SENTINEL_THRESHOLD:
+                        iv_lb = _compute_interval_bound(
+                            model, batch_lb[i], batch_ub[i], _obj_negate
+                        )
+                        if np.isfinite(iv_lb):
+                            result_lbs[i] = max(result_lbs[i], iv_lb)
             # Tighten lower bounds with McCormick relaxation
             if _mc_obj_eval is not None:
                 try:
@@ -2651,6 +2715,15 @@ def solve_model(
                                 convex_lb = max(convex_lb, mc_lb)
                         except (ValueError, ArithmeticError, RuntimeError) as e:
                             logger.debug("McCormick bound failed: %s", e)
+
+                    # Cheap, always-valid interval-arithmetic bound. Keeps
+                    # nonconvex nodes off -inf between the periodic
+                    # McCormick-NLP solves so the global lower bound tightens
+                    # every iteration. max() of valid bounds stays valid.
+                    if not _model_is_convex:
+                        iv_lb = _compute_interval_bound(model, node_lb, node_ub, _obj_negate)
+                        if np.isfinite(iv_lb):
+                            convex_lb = max(convex_lb, iv_lb)
 
                     # For nonconvex problems: NLP local min is NOT a valid
                     # lower bound (can exceed global opt → premature pruning).

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5533,19 +5533,23 @@ def _solve_node_lp_pounce(lp_data, node_lb, node_ub, n_vars, n_orig, t_start, ti
     ``(sentinel, None, "infeasible")``, or ``None`` when POUNCE is unavailable
     or could not settle the node (the caller falls back / decertifies)."""
     try:
-        from discopt.solvers.lp_pounce import POUNCE_AVAILABLE
-        from discopt.solvers.lp_pounce import solve_lp as _pounce_solve
+        import pounce
+
+        from discopt.solvers.lp_pounce import POUNCE_AVAILABLE, _snap_inverted_bounds
     except ImportError:
         return None
     if not POUNCE_AVAILABLE:
         return None
-    time_left = max(0.5, time_limit - (time.perf_counter() - t_start))
-    # POUNCE's interior-point LP is far faster on the native *inequality* form
-    # than on the slack-expanded standard form: ``lp_data`` carries one explicit
-    # slack column per inequality, which quadruples the variable count (e.g.
-    # 92 -> 400) and stalls the IPM (it times out without a bound). Decompose
-    # the standard form back to inequalities over the structural columns and
-    # hand POUNCE ``A_ub``/``A_eq`` directly with only the structural bounds.
+    # Solve the node relaxation with POUNCE's *structured convex* LP/QP engine
+    # (``pounce.solve_qp`` over the pounce-convex IPM, with presolve), not the
+    # generic callback TNLP path (``solve_lp``). The callback path hides the
+    # linear structure, so POUNCE's presolve cannot engage and its IPM takes
+    # ~100 iterations (~3 s) on these degenerate, equality-pair-encoded
+    # relaxations; the structured convex path presolves + scales and converges
+    # in ~20 iterations (~0.03 s) on the same LP (~100x), which is what lets the
+    # MILP B&B visit enough nodes to bound the tree. It needs the native
+    # inequality form, so decompose the slack-expanded standard form back to
+    # A_ub/A_eq over the structural columns.
     n_slack = int(lp_data.A_eq.shape[1]) - n_orig
     try:
         A_ub_m, b_ub_m, A_eq_m, b_eq_m = _decompose_eq_slack_form(
@@ -5554,33 +5558,41 @@ def _solve_node_lp_pounce(lp_data, node_lb, node_ub, n_vars, n_orig, t_start, ti
             n_orig,
             n_slack,
         )
-        # _decompose_eq_slack_form already returns None for empty A_ub/A_eq,
-        # which solve_lp accepts; pass through directly.
-        res = _pounce_solve(
+        lb_n = np.asarray(node_lb, dtype=np.float64)
+        ub_n = np.asarray(node_ub, dtype=np.float64)
+        lb_n, ub_n = _snap_inverted_bounds(lb_n, ub_n)
+        res = pounce.solve_qp(
+            P=None,  # P=0 -> LP
             c=np.asarray(lp_data.c[:n_orig], dtype=np.float64),
-            A_ub=A_ub_m,
-            b_ub=b_ub_m,
-            A_eq=A_eq_m,
-            b_eq=b_eq_m,
-            bounds=list(
-                zip(
-                    np.asarray(node_lb, dtype=np.float64).tolist(),
-                    np.asarray(node_ub, dtype=np.float64).tolist(),
-                )
-            ),
-            time_limit=min(30.0, time_left),
+            G=A_ub_m,
+            h=b_ub_m,
+            A=A_eq_m,
+            b=b_eq_m,
+            lb=lb_n,
+            ub=ub_n,
         )
     except Exception as e:
-        logger.debug("POUNCE node solve failed: %s", e)
+        logger.debug("POUNCE convex node solve failed: %s", e)
         return None
-    if (
-        res.status == SolveStatus.OPTIMAL
-        and res.objective is not None
-        and np.isfinite(res.objective)
-    ):
-        bound = float(res.objective) + float(lp_data.obj_const)
-        return (bound, np.asarray(res.x[:n_vars]), "optimal")
-    if res.status == SolveStatus.INFEASIBLE:
+    if res.status == "optimal" and res.x is not None and np.isfinite(res.obj):
+        x_sol = np.asarray(res.x, dtype=np.float64)
+        # Soundness gate (mirrors the JAX-IPM path's _check_lp_solution_feasibility):
+        # reject a node point that violates its own rows so a slightly-infeasible
+        # relaxation solution cannot seed a spurious incumbent or node bound.
+        tol = 1e-5
+        feasible = True
+        if A_ub_m is not None and A_ub_m.shape[0]:
+            feasible = bool(np.all(A_ub_m @ x_sol <= b_ub_m + tol * (1.0 + np.abs(b_ub_m))))
+        if feasible and A_eq_m is not None and A_eq_m.shape[0]:
+            feasible = bool(
+                np.all(np.abs(A_eq_m @ x_sol - b_eq_m) <= tol * (1.0 + np.abs(b_eq_m)))
+            )
+        if not feasible:
+            logger.debug("POUNCE convex node solution violates its rows; rejecting")
+            return None
+        bound = float(res.obj) + float(lp_data.obj_const)
+        return (bound, x_sol[:n_vars], "optimal")
+    if res.status == "primal_infeasible":
         return (_INFEASIBILITY_SENTINEL, None, "infeasible")
     return None
 

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -2587,6 +2587,10 @@ def _solve_amp_impl(
     cutoff_obbt_done = False
     last_obbt_iter = 0
     _obbt_period = 5
+    # One-shot guard for small-integer incumbent recovery when the MILP
+    # relaxation backend produces no usable result (see the recovery block in
+    # the main loop).
+    _small_int_recovery_attempted = False
 
     def _append_linearized_cuts(cuts) -> int:
         appended = 0
@@ -2918,6 +2922,44 @@ def _solve_amp_impl(
             LB = max(LB, new_lb)
 
         logger.debug("AMP iter %d: LB=%.6g, UB=%.6g", iteration, LB, UB)
+
+        # ── Incumbent recovery when the MILP relaxation yields nothing ───────
+        # If the MILP solve returns neither a dual bound nor a solution point
+        # (e.g. the LP/MILP backend times out or errors on the relaxation —
+        # as POUNCE does on degenerate equality-encoded relaxations when HiGHS
+        # is unavailable), the NLP step below has no binary assignment to fix
+        # and cannot find an integer-feasible incumbent, so AMP would return no
+        # solution at all. Fall back once to enumerating the small integer
+        # domain (each assignment solved as a binaries-fixed NLP) so a feasible
+        # incumbent is still recovered. The bound stays uncertified.
+        _milp_bound_unusable = milp_result.bound is None or not np.isfinite(milp_result.bound)
+        if (
+            incumbent is None
+            and milp_result.x is None
+            and _milp_bound_unusable
+            and not _small_int_recovery_attempted
+        ):
+            _small_int_recovery_attempted = True
+            fb_x, fb_obj = _solve_small_integer_domain_fallback(
+                model,
+                evaluator,
+                flat_lb,
+                flat_ub,
+                constraint_lb,
+                constraint_ub,
+                nlp_solver,
+                deadline=deadline,
+            )
+            if fb_x is not None and fb_obj is not None and fb_obj < UB:
+                UB = fb_obj
+                incumbent = fb_x.copy()
+                logger.info(
+                    "AMP iter %d: recovered feasible incumbent (objective=%.6g) via "
+                    "small-integer enumeration after the MILP relaxation produced no "
+                    "usable result",
+                    iteration,
+                    _from_minimization_space(UB),
+                )
 
         # ── Step 2: NLP upper-bound subproblem ───────────────────────────────
         # Use MILP solution point as initial point for NLP

--- a/python/discopt/solvers/lp_pounce.py
+++ b/python/discopt/solvers/lp_pounce.py
@@ -38,6 +38,27 @@ _FINITE_BOUND_THRESHOLD = 1e15
 # Above this total constraint violation, the elastic Phase-1 LP certifies the
 # original LP infeasible (roadmap P0.2).
 _FEAS_TOL = 1e-6
+# Tiny floating-point bound inversions (lb just above ub, e.g. ~1e-11 out of
+# relaxation/bound-tightening) are snapped to a single fixed value before they
+# reach POUNCE. POUNCE's IPM strictly validates bounds and rejects ``lb > ub``
+# as Invalid_Problem_Definition; presolve-based solvers (HiGHS) silently snap
+# them. Inversions beyond this tolerance are left intact so they surface as
+# genuine infeasibility rather than being masked.
+_BOUND_SNAP_TOL = 1e-7
+
+
+def _snap_inverted_bounds(lb: np.ndarray, ub: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Snap tiny ``lb > ub`` inversions to their midpoint (in place-safe)."""
+    inverted = lb > ub
+    if np.any(inverted):
+        tiny = inverted & ((lb - ub) <= _BOUND_SNAP_TOL * (1.0 + np.abs(ub)))
+        if np.any(tiny):
+            lb = lb.copy()
+            ub = ub.copy()
+            mid = 0.5 * (lb[tiny] + ub[tiny])
+            lb[tiny] = mid
+            ub[tiny] = mid
+    return lb, ub
 
 
 class PounceKKTError(RuntimeError):
@@ -218,6 +239,7 @@ def solve_lp(
         ub = np.full(n, _INF, dtype=np.float64)
     lb = np.where(lb <= -_FINITE_BOUND_THRESHOLD, -_INF, lb)
     ub = np.where(ub >= _FINITE_BOUND_THRESHOLD, _INF, ub)
+    lb, ub = _snap_inverted_bounds(lb, ub)
 
     # ---- stacked linear constraints -----------------------------------------
     A, cl, cu = _stack_constraints(A_ub, b_ub, A_eq, b_eq, n)
@@ -308,6 +330,7 @@ def solve_lp_kkt(
     ub = np.asarray(x_u, dtype=np.float64).ravel().copy()
     lb = np.where(lb <= -_FINITE_BOUND_THRESHOLD, -_INF, lb)
     ub = np.where(ub >= _FINITE_BOUND_THRESHOLD, _INF, ub)
+    lb, ub = _snap_inverted_bounds(lb, ub)
 
     cl = b_arr.copy()
     cu = b_arr.copy()

--- a/python/discopt/solvers/milp_pounce.py
+++ b/python/discopt/solvers/milp_pounce.py
@@ -96,6 +96,16 @@ def solve_milp(
     else:
         lbs = [0.0] * n
         ubs = [float("inf")] * n
+    # Snap tiny floating-point bound inversions (lb just above ub) so the
+    # self-hosted B&B's per-node LP relaxations are not rejected by POUNCE's
+    # strict bound validation (see lp_pounce._snap_inverted_bounds).
+    from discopt.solvers.lp_pounce import _snap_inverted_bounds
+
+    _lb_snap, _ub_snap = _snap_inverted_bounds(
+        np.asarray(lbs, dtype=np.float64), np.asarray(ubs, dtype=np.float64)
+    )
+    lbs = _lb_snap.tolist()
+    ubs = _ub_snap.tolist()
     is_int = (
         np.zeros(n, dtype=bool) if integrality is None else (np.asarray(integrality).ravel() == 1)
     )

--- a/python/discopt/solvers/nlp_pounce.py
+++ b/python/discopt/solvers/nlp_pounce.py
@@ -60,6 +60,16 @@ def solve_nlp(
     n = evaluator.n_variables
     m = evaluator.n_constraints
     lb, ub = evaluator.variable_bounds
+    # Snap tiny floating-point bound inversions (lb just above ub) so POUNCE's
+    # IPM does not reject the problem as Invalid_Problem_Definition. These arise
+    # from relaxation / bound-tightening rounding (e.g. an AMP integer-fixed
+    # subproblem whose continuous bounds were tightened to lb=ub+1e-11); the
+    # mirror of the same guard on the LP path (lp_pounce._snap_inverted_bounds).
+    from discopt.solvers.lp_pounce import _snap_inverted_bounds
+
+    lb, ub = _snap_inverted_bounds(
+        np.asarray(lb, dtype=np.float64), np.asarray(ub, dtype=np.float64)
+    )
 
     if constraint_bounds is not None:
         cl = np.array([b[0] for b in constraint_bounds], dtype=np.float64)

--- a/python/tests/test_amp_milp_backend_failure_recovery.py
+++ b/python/tests/test_amp_milp_backend_failure_recovery.py
@@ -1,0 +1,55 @@
+"""Regression: AMP recovers a feasible incumbent when the MILP relaxation
+backend produces no usable result.
+
+When the LP/MILP backend cannot solve AMP's relaxation (e.g. HiGHS is not
+installed and the POUNCE matrix-MILP times out / errors on a degenerate
+equality-encoded relaxation), the relaxation solve returns neither a dual
+bound nor a solution point. AMP's main NLP step then has no binary assignment
+to fix and cannot find an integer-feasible incumbent, so AMP previously
+returned no solution at all (``objective=None``).
+
+The recovery path enumerates the small integer domain (each assignment solved
+as a binaries-fixed NLP) once, so a feasible incumbent is still recovered.
+The bound stays uncertified.
+"""
+
+from __future__ import annotations
+
+import discopt._jax.milp_relaxation as MR
+import discopt.modeling as dm
+import pytest
+from discopt._jax.milp_relaxation import MilpRelaxationResult
+
+
+@pytest.fixture
+def _milp_backend_yields_nothing(monkeypatch):
+    """Force every AMP MILP relaxation solve to return an unusable result:
+    no bound (``-inf``) and no solution point, as a failing/absent MILP
+    backend does."""
+
+    def _unusable(self, *args, **kwargs):
+        return MilpRelaxationResult(
+            status="time_limit", objective=None, bound=float("-inf"), x=None
+        )
+
+    monkeypatch.setattr(MR.MilpRelaxationModel, "solve", _unusable)
+
+
+def test_amp_recovers_incumbent_when_milp_backend_fails(_milp_backend_yields_nothing):
+    # Small nonconvex MINLP: one binary, one continuous, with a solvable
+    # binaries-fixed NLP. Global optimum is y=1, x=4 -> -(4**2)+5 = -11.
+    m = dm.Model("amp_milp_fail_recovery")
+    y = m.binary("y")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    m.minimize(-(x * x) + 5 * y)
+    m.subject_to(x <= 2 + 2 * y)
+
+    r = m.solve(solver="amp", nlp_solver="pounce", time_limit=15, gap_tolerance=1e-3)
+
+    # Without the recovery path this returned objective=None (no incumbent).
+    assert r.objective is not None, "AMP should recover a feasible incumbent"
+    assert r.status == "feasible"
+    # Recovery does not certify a bound.
+    assert r.gap_certified is False
+    # The recovered incumbent should be the (integer-feasible) global optimum.
+    assert abs(r.objective - (-11.0)) <= 1e-3

--- a/python/tests/test_interval_node_bound.py
+++ b/python/tests/test_interval_node_bound.py
@@ -1,0 +1,105 @@
+"""Soundness tests for the per-node interval-arithmetic lower bound.
+
+``_compute_interval_bound`` fills the lower bound of nonconvex spatial-B&B
+nodes with a cheap, always-valid interval enclosure so a node never sits at
+``-inf`` between the periodic (and tighter) McCormick-NLP solves. The bound is
+allowed to be loose, but it must NEVER exceed the true minimum of the
+objective over the node box — otherwise the B&B could prune the global optimum
+and report a wrong "optimal". These tests pin that invariant, and the
+end-to-end guarantee that a certified result is sound.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import discopt.solver as S
+import numpy as np
+import pytest
+
+
+def _sampled_min(eval_obj, lb, ub, n=20000, seed=0):
+    """Monte-Carlo estimate of min f over the box (an upper bound on the true
+    min, hence a conservative target the interval bound must stay below)."""
+    rng = np.random.default_rng(seed)
+    pts = lb + (ub - lb) * rng.random((n, len(lb)))
+    return min(float(eval_obj(p)) for p in pts)
+
+
+@pytest.mark.parametrize(
+    "build,lb,ub",
+    [
+        # Bilinear (nonconvex)
+        (lambda m: m.minimize(-m._v["x"] * m._v["y"] + m._v["x"]), [0.0, 0.0], [3.0, 2.0]),
+        # Concave quadratic
+        (
+            lambda m: m.minimize(-(m._v["x"] * m._v["x"]) - (m._v["y"] * m._v["y"])),
+            [-3.0, -3.0],
+            [3.0, 3.0],
+        ),
+        # Mixed sign products + linear
+        (
+            lambda m: m.minimize(m._v["x"] * m._v["y"] - 4 * m._v["x"] - 3 * m._v["y"]),
+            [0.0, 0.0],
+            [10.0, 10.0],
+        ),
+    ],
+)
+def test_interval_bound_is_valid_underestimator(build, lb, ub):
+    m = dm.Model("t")
+    x = m.continuous("x", lb=lb[0], ub=ub[0])
+    y = m.continuous("y", lb=lb[1], ub=ub[1])
+    m._v = {"x": x, "y": y}
+    build(m)
+
+    evaluator = S._make_evaluator(m)
+    lb_a = np.array(lb)
+    ub_a = np.array(ub)
+
+    bound = S._compute_interval_bound(m, lb_a, ub_a, negate=False)
+    target = _sampled_min(evaluator.evaluate_objective, lb_a, ub_a)
+
+    assert np.isfinite(bound)
+    # The interval bound underestimates the true min, which is <= the sampled
+    # min. A tiny tolerance absorbs outward-rounding / sampling noise.
+    assert bound <= target + 1e-6
+
+
+def test_interval_bound_respects_maximize_negation():
+    """For a maximization model the internal B&B minimizes ``-f``; the bound
+    must be a valid lower bound on ``-f`` (i.e. ``<= -max f``)."""
+    m = dm.Model("t")
+    a = m.continuous("a", lb=0.0, ub=3.0)
+    b = m.continuous("b", lb=0.0, ub=2.0)
+    m.maximize(a * b)  # max f = 6 at (3, 2) -> internal min of -f is -6
+
+    bound = S._compute_interval_bound(m, np.array([0.0, 0.0]), np.array([3.0, 2.0]), negate=True)
+    assert np.isfinite(bound)
+    assert bound <= -6.0 + 1e-6
+
+
+def test_interval_bound_never_invalid_on_unsupported_ops():
+    """Unsupported operators yield an unbounded enclosure; the helper must
+    degrade to ``-inf`` (a no-op) rather than emit an invalid finite bound."""
+    m = dm.Model("t")
+    x = m.continuous("x", lb=0.1, ub=2.0)
+    # erf is not modelled by the interval evaluator -> unbounded -> -inf.
+    try:
+        m.minimize(dm.erf(x))
+    except AttributeError:
+        pytest.skip("dm.erf not available in this build")
+    bound = S._compute_interval_bound(m, np.array([0.1]), np.array([2.0]), negate=False)
+    assert bound == -np.inf
+
+
+def test_certified_optimal_is_sound():
+    """End-to-end: when the default spatial B&B reports a certified optimum on
+    a nonconvex model, the returned bound must not exceed the objective."""
+    m = dm.Model("concave1d")
+    x = m.continuous("x", lb=0.0, ub=3.0)
+    m.minimize(-(x - 1) * (x - 1))  # global min -4 at x=3
+    r = m.solve(time_limit=30)
+    assert r.status == "optimal"
+    assert r.gap_certified is True
+    assert r.bound is not None
+    assert r.bound <= r.objective + 1e-4
+    assert abs(r.objective - (-4.0)) <= 1e-3

--- a/python/tests/test_milp_bb_pounce_no_jax_ipm.py
+++ b/python/tests/test_milp_bb_pounce_no_jax_ipm.py
@@ -59,3 +59,34 @@ def test_pounce_milp_bb_avoids_jax_ipm(monkeypatch):
     # Optimum: a=1, c=1 (2+1=3<=4) -> 5+3=8; adding b violates (2+3=5>4).
     assert r.objective is not None
     assert abs(float(r.objective) - (-8.0)) <= 1e-4
+
+
+def test_pounce_milp_seeds_finite_root_bound():
+    """A POUNCE MILP solve must return a finite, sound lower bound even when it
+    cannot finish in the time budget — the root LP relaxation bound is seeded so
+    the result is never bound=None/-inf (which left AMP's LB stuck at -inf and
+    its reported bound at None on the issue #15 gas network)."""
+    import numpy as np
+    from discopt.solvers.milp_pounce import solve_milp
+
+    c = np.array([-5.0, -4.0, -3.0])
+    A_ub = np.array([[2.0, 3.0, 1.0]])
+    b_ub = np.array([4.0])
+    bounds = [(0.0, 1.0)] * 3
+    integrality = np.array([1, 1, 1])
+
+    # Tiny budget: the bounding loop exits before closing the tree, so the
+    # reported bound comes from the seeded root LP relaxation.
+    r = solve_milp(
+        c=c,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        bounds=bounds,
+        integrality=integrality,
+        time_limit=1e-6,
+        gap_tolerance=1e-4,
+    )
+    assert r.bound is not None
+    assert np.isfinite(r.bound)
+    # A valid lower bound never exceeds the true optimum (-8).
+    assert float(r.bound) <= -8.0 + 1e-4

--- a/python/tests/test_milp_bb_pounce_no_jax_ipm.py
+++ b/python/tests/test_milp_bb_pounce_no_jax_ipm.py
@@ -19,9 +19,7 @@ import numpy as np
 import pytest
 from discopt.solvers import SolveStatus
 
-POUNCE_AVAILABLE = pytest.importorskip(
-    "discopt.solvers.lp_pounce"
-).POUNCE_AVAILABLE  # type: ignore[attr-defined]
+POUNCE_AVAILABLE = pytest.importorskip("discopt.solvers.lp_pounce").POUNCE_AVAILABLE  # type: ignore[attr-defined]
 
 pytestmark = pytest.mark.skipif(not POUNCE_AVAILABLE, reason="POUNCE not installed")
 

--- a/python/tests/test_milp_bb_pounce_no_jax_ipm.py
+++ b/python/tests/test_milp_bb_pounce_no_jax_ipm.py
@@ -1,0 +1,61 @@
+"""Regression: the POUNCE MILP-B&B path must not fall back to the pure-JAX IPM.
+
+Phase 8 (POUNCE-only stack) routes every LP/MILP solve through POUNCE. Two
+leftovers used the pure-JAX ``lp_ipm_solve`` even in ``prefer_pounce`` mode:
+
+* the per-node relaxation solve (``_solve_node_lp_pounce``) handed POUNCE the
+  slack-expanded *standard* form, on which its IPM stalls; and
+* the root fractional-dive heuristic (``_root_dive``).
+
+Both are now POUNCE-native (the node solve uses the inequality form; the dive is
+skipped in POUNCE mode). This test pins that a POUNCE-mode MILP solve never
+calls the JAX IPM, by making any such call fail loudly.
+"""
+
+from __future__ import annotations
+
+import discopt._jax.lp_ipm as _lp_ipm
+import numpy as np
+import pytest
+from discopt.solvers import SolveStatus
+
+POUNCE_AVAILABLE = pytest.importorskip(
+    "discopt.solvers.lp_pounce"
+).POUNCE_AVAILABLE  # type: ignore[attr-defined]
+
+pytestmark = pytest.mark.skipif(not POUNCE_AVAILABLE, reason="POUNCE not installed")
+
+
+def test_pounce_milp_bb_avoids_jax_ipm(monkeypatch):
+    from discopt.solvers.milp_pounce import solve_milp
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("JAX IPM (lp_ipm_solve) must not run in POUNCE MILP mode")
+
+    monkeypatch.setattr(_lp_ipm, "lp_ipm_solve", _boom)
+    monkeypatch.setattr(_lp_ipm, "lp_ipm_solve_batch", _boom)
+
+    # Small 0/1 knapsack-style MILP whose LP relaxation is fractional, so the
+    # B&B opens child nodes (exercises the node-solve path, not just the root).
+    # max 5a + 4b + 3c  s.t. 2a + 3b + c <= 4,  a,b,c in {0,1}
+    # -> as a minimization: min -(5a+4b+3c).
+    c = np.array([-5.0, -4.0, -3.0])
+    A_ub = np.array([[2.0, 3.0, 1.0]])
+    b_ub = np.array([4.0])
+    bounds = [(0.0, 1.0)] * 3
+    integrality = np.array([1, 1, 1])
+
+    r = solve_milp(
+        c=c,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        bounds=bounds,
+        integrality=integrality,
+        time_limit=30,
+        gap_tolerance=1e-4,
+    )
+
+    assert r.status == SolveStatus.OPTIMAL
+    # Optimum: a=1, c=1 (2+1=3<=4) -> 5+3=8; adding b violates (2+3=5>4).
+    assert r.objective is not None
+    assert abs(float(r.objective) - (-8.0)) <= 1e-4

--- a/python/tests/test_pounce_bound_snap.py
+++ b/python/tests/test_pounce_bound_snap.py
@@ -1,0 +1,64 @@
+"""Regression: POUNCE LP/MILP wrappers snap tiny floating-point bound
+inversions instead of failing.
+
+The relaxation / bound-tightening machinery can emit a variable bound where
+``lb`` exceeds ``ub`` by a rounding-scale amount (e.g. ``lb = 30 + 1.8e-11``,
+``ub = 30``). POUNCE's interior-point method strictly validates bounds and
+rejects such a problem as ``Invalid_Problem_Definition`` (raw status ``-11``,
+unmapped -> ``ERROR``), whereas presolve-based solvers (HiGHS) silently snap the
+inversion. This regression pins the snap so POUNCE-only environments do not
+spuriously fail (root cause of the AMP gas-network stall in issue #15).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.solvers import SolveStatus
+
+POUNCE_AVAILABLE = pytest.importorskip(
+    "discopt.solvers.lp_pounce"
+).POUNCE_AVAILABLE  # type: ignore[attr-defined]
+
+pytestmark = pytest.mark.skipif(not POUNCE_AVAILABLE, reason="POUNCE not installed")
+
+
+def _tiny_inverted_bounds_lp():
+    # min x + y, with x in [0, 2], y bound *inverted* by ~1.8e-11 around 1.0.
+    c = np.array([1.0, 1.0])
+    bounds = [(0.0, 2.0), (1.0 + 1.8e-11, 1.0)]
+    return c, bounds
+
+
+def test_lp_snaps_tiny_inverted_bound():
+    from discopt.solvers.lp_pounce import solve_lp
+
+    c, bounds = _tiny_inverted_bounds_lp()
+    r = solve_lp(c=c, bounds=bounds)
+    assert r.status == SolveStatus.OPTIMAL
+    # y snapped to ~1.0, x at its lower bound 0 -> objective ~1.0.
+    assert r.x is not None
+    assert abs(float(r.x[1]) - 1.0) <= 1e-6
+    assert abs(float(r.objective) - 1.0) <= 1e-5
+
+
+def test_lp_does_not_mask_genuine_inversion():
+    """A large inversion (well beyond snap tolerance) is real infeasibility and
+    must NOT be silently snapped into a wrong optimum."""
+    from discopt.solvers.lp_pounce import solve_lp
+
+    c = np.array([1.0, 1.0])
+    bounds = [(0.0, 2.0), (5.0, 1.0)]  # lb=5 > ub=1 by 4.0
+    r = solve_lp(c=c, bounds=bounds)
+    assert r.status != SolveStatus.OPTIMAL
+
+
+def test_milp_snaps_tiny_inverted_bound():
+    from discopt.solvers.milp_pounce import solve_milp
+
+    c, bounds = _tiny_inverted_bounds_lp()
+    integrality = np.array([1, 0])  # x integer, y continuous
+    r = solve_milp(c=c, bounds=bounds, integrality=integrality, time_limit=10)
+    assert r.status == SolveStatus.OPTIMAL
+    assert r.x is not None
+    assert abs(float(r.x[1]) - 1.0) <= 1e-6

--- a/python/tests/test_pounce_bound_snap.py
+++ b/python/tests/test_pounce_bound_snap.py
@@ -62,3 +62,33 @@ def test_milp_snaps_tiny_inverted_bound():
     assert r.status == SolveStatus.OPTIMAL
     assert r.x is not None
     assert abs(float(r.x[1]) - 1.0) <= 1e-6
+
+
+def test_nlp_snaps_tiny_inverted_bound():
+    """The NLP path must also snap tiny inversions: AMP integer-fixed
+    subproblems can arrive with a continuous bound tightened to lb=ub+1e-11,
+    which POUNCE's IPM otherwise rejects as Invalid_Problem_Definition,
+    blocking incumbent recovery (issue #15 gas network)."""
+    import discopt.modeling as dm
+    from discopt.solver import _BoundOverrideEvaluator, _extract_variable_info, _make_evaluator
+    from discopt.solvers.nlp_pounce import solve_nlp
+
+    m = dm.Model("nlp_snap")
+    x = m.continuous("x", lb=0.0, ub=5.0)
+    y = m.continuous("y", lb=0.0, ub=5.0)
+    m.minimize((x - 2.0) * (x - 2.0) + (y - 3.0) * (y - 3.0))
+    m.subject_to(x + y >= 1.0)
+
+    ev = _make_evaluator(m)
+    _, lb, ub, _, _ = _extract_variable_info(m)
+    lb2 = lb.copy()
+    ub2 = ub.copy()
+    # Fix x ~= 2 with a tiny lb > ub inversion (the failure mode from AMP).
+    lb2[0] = 2.0 + 1.8e-11
+    ub2[0] = 2.0
+    be = _BoundOverrideEvaluator(ev, lb2, ub2)
+
+    r = solve_nlp(be, np.array([2.0, 3.0]))
+    assert r.status == SolveStatus.OPTIMAL  # not ERROR / Invalid_Problem_Definition
+    assert r.x is not None
+    assert abs(float(r.x[1]) - 3.0) <= 1e-4

--- a/python/tests/test_pounce_bound_snap.py
+++ b/python/tests/test_pounce_bound_snap.py
@@ -16,9 +16,7 @@ import numpy as np
 import pytest
 from discopt.solvers import SolveStatus
 
-POUNCE_AVAILABLE = pytest.importorskip(
-    "discopt.solvers.lp_pounce"
-).POUNCE_AVAILABLE  # type: ignore[attr-defined]
+POUNCE_AVAILABLE = pytest.importorskip("discopt.solvers.lp_pounce").POUNCE_AVAILABLE  # type: ignore[attr-defined]
 
 pytestmark = pytest.mark.skipif(not POUNCE_AVAILABLE, reason="POUNCE not installed")
 


### PR DESCRIPTION
Add a cheap, always-valid interval-arithmetic lower bound on the objective
over each nonconvex node box so a node never carries -inf between the periodic
(tighter) McCormick-NLP solves. The bound reuses the existing outward-rounded
evaluate_interval() enclosure, so it is sound by construction: it underestimates
the true minimum over the box and is merged with max(), which keeps every
contributing bound valid. Maximization is handled via a sense-derived negation
flag (independent of McCormick mode, which only sets its own flag in nlp/midpoint
setup). Unsupported operators degrade to -inf (a no-op), never an invalid bound.

Wired into both the batch and serial node-evaluation paths of solve_model (the
default nonconvex MINLP path). _solve_nlp_bb is intentionally left alone: it is a
documented heuristic (uncertified) path for nonconvex models.

Also fix branching: select_spatial_branch_variable filtered candidates on
relative width but selected on absolute width; select on relative width so the
branch falls on the least-reduced normalized edge. Tie-breaking stays
deterministic (strict >, ascending scan).

Measured impact: this is a soundness safety net, not a certification win.
A/B testing showed easy nonconvex problems already certify at the root via the
iteration-0 McCormick solve, and harder pooling instances (Haverly) remain
"feasible" either way (limited by McCormick looseness and sentinel
decertification, not by -inf nodes). The bound never regresses soundness and
can supply a finite valid bound where none existed.

Tests: python/tests/test_interval_node_bound.py pins the underestimator
invariant (incl. maximize negation and unsupported-op degradation) and
end-to-end certified-result soundness.

https://claude.ai/code/session_01GerNhQJdJtygRQiP36ghdf