### PR TITLE
fix(solver): enforce time_limit in MILP B&B and per-node budgets

### DIFF
--- a/crates/discopt-core/examples/par_bench.rs
+++ b/crates/discopt-core/examples/par_bench.rs
@@ -108,6 +108,7 @@ fn opts(inst: &Instance) -> MilpOptions {
         n_struct: inst.n_struct,
         integer_cols: inst.integer_cols.clone(),
         max_nodes: 2_000_000,
+        time_limit_s: None,
         gap_tol: 1e-6,
         root_cuts: 16,
         cut_rounds: 2,

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -67,6 +67,12 @@ pub struct MilpOptions {
     pub integer_cols: Vec<usize>,
     /// Node-creation cap.
     pub max_nodes: usize,
+    /// Optional wall-time cap in seconds. `None` = unlimited. Checked at each
+    /// batch boundary of the B&B search; on expiry the search stops and returns
+    /// the incumbent with a valid (uncertified) dual bound — never a false
+    /// "optimal". Keeps a single atomic MILP solve from overrunning a caller's
+    /// `time_limit` (the McCormick LP relaxer node solve was the worst offender).
+    pub time_limit_s: Option<f64>,
     /// Relative gap tolerance for proving optimality.
     pub gap_tol: f64,
     /// Max Gomory mixed-integer cuts to add at the root (0 disables), summed
@@ -245,6 +251,7 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
     let mut slack_l = l_w[ns..].to_vec();
     let mut slack_u = u_w[ns..].to_vec();
 
+    let t_start = std::time::Instant::now();
     'search: loop {
         if tm.is_finished() || tm.gap() <= opts.gap_tol {
             break;
@@ -252,6 +259,12 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
         if tm.stats().total_nodes >= opts.max_nodes {
             gap_certified = false;
             break;
+        }
+        if let Some(tl) = opts.time_limit_s {
+            if t_start.elapsed().as_secs_f64() >= tl {
+                gap_certified = false;
+                break;
+            }
         }
         let batch = tm.export_batch(64);
         if batch.node_ids.is_empty() {
@@ -884,6 +897,7 @@ mod tests {
             n_struct: ns,
             integer_cols: int_cols,
             max_nodes: 100_000,
+            time_limit_s: None,
             gap_tol: 1e-9,
             root_cuts: 16,
             cut_rounds: 3,

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -260,7 +260,8 @@ pub fn solve_lp_py<'py>(
 #[pyo3(signature = (c, a, b, lb, ub, integer_cols, n_struct, obj_const=0.0,
                     max_nodes=1_000_000, gap_tol=1e-6, tol=1e-9, root_cuts=16,
                     cut_rounds=1, node_cuts=false, max_pool_cuts=128, heuristics=true,
-                    presolve=true, strong_branch=true, sb_max_cands=8, sb_node_budget=1024))]
+                    presolve=true, strong_branch=true, sb_max_cands=8, sb_node_budget=1024,
+                    time_limit_s=0.0))]
 pub fn solve_milp_py<'py>(
     py: Python<'py>,
     c: PyReadonlyArray1<'py, f64>,
@@ -283,6 +284,7 @@ pub fn solve_milp_py<'py>(
     strong_branch: bool,
     sb_max_cands: usize,
     sb_node_budget: usize,
+    time_limit_s: f64,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let dims = a.shape();
     let (m, n) = (dims[0], dims[1]);
@@ -309,6 +311,11 @@ pub fn solve_milp_py<'py>(
         n_struct,
         integer_cols: int_cols,
         max_nodes,
+        time_limit_s: if time_limit_s > 0.0 {
+            Some(time_limit_s)
+        } else {
+            None
+        },
         gap_tol,
         root_cuts,
         cut_rounds,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2573,9 +2573,7 @@ def solve_model(
                         mc_res = _mc_lp_relaxer.solve_at_node(
                             np.asarray(batch_lb[i]),
                             np.asarray(batch_ub[i]),
-                            time_limit=max(
-                                _deadline - time.perf_counter(), _DEADLINE_NODE_FLOOR_S
-                            ),
+                            time_limit=max(_deadline - time.perf_counter(), _DEADLINE_NODE_FLOOR_S),
                         )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", i, e)
@@ -2808,9 +2806,7 @@ def solve_model(
                         mc_lp_res = _mc_lp_relaxer.solve_at_node(
                             node_lb,
                             node_ub,
-                            time_limit=max(
-                                _deadline - time.perf_counter(), _DEADLINE_NODE_FLOOR_S
-                            ),
+                            time_limit=max(_deadline - time.perf_counter(), _DEADLINE_NODE_FLOOR_S),
                         )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", int(batch_ids[i]), e)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -46,6 +46,12 @@ logger = logging.getLogger(__name__)
 # variables we stay on the serial per-node path. (The real fix is a native-Rust
 # node evaluator — Phase B — which removes the GIL bottleneck entirely.)
 _POUNCE_BATCH_MIN_VARS = 50
+# Floor on the per-node NLP wall-time budget. The B&B loop re-derives each
+# node's budget from the live remaining time to the global deadline; this floor
+# keeps a node that straddles the deadline from being handed a zero/negative
+# budget. Nodes that start fully past the deadline are skipped (see the serial
+# loop), so at most one node per batch can overrun by this floor.
+_DEADLINE_NODE_FLOOR_S = 0.1
 # Multistart runs 3 starts per nonconvex node (warm/midpoint/random) and keeps
 # the best — better incumbents on nonconvex models, but ~3x the node-solve cost.
 # Off by default; flip to opt in (or pass multistart=True to _solve_batch_pounce).
@@ -2363,6 +2369,7 @@ def solve_model(
     # and use cheap midpoint bounds in between. Period=1 means every iteration.
     _mc_nlp_period = 5  # run McCormick NLP every 5th iteration
     iteration = 0
+    _deadline = t_start + time_limit
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -2370,7 +2377,7 @@ def solve_model(
 
         # Update per-iteration time budget for NLP subproblem solves (issue #5).
         remaining = time_limit - elapsed
-        opts["max_wall_time"] = max(remaining, 0.1)
+        opts["max_wall_time"] = max(remaining, _DEADLINE_NODE_FLOOR_S)
 
         # Export batch from Rust tree
         t_rust_start = time.perf_counter()
@@ -2566,6 +2573,9 @@ def solve_model(
                         mc_res = _mc_lp_relaxer.solve_at_node(
                             np.asarray(batch_lb[i]),
                             np.asarray(batch_ub[i]),
+                            time_limit=max(
+                                _deadline - time.perf_counter(), _DEADLINE_NODE_FLOOR_S
+                            ),
                         )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", i, e)
@@ -2615,6 +2625,27 @@ def solve_model(
             for i in range(n_batch):
                 node_lb = np.array(batch_lb[i])
                 node_ub = np.array(batch_ub[i])
+
+                # Deadline enforcement (time_limit overrun fix). The budget set
+                # at the batch top is the WHOLE remaining time; reusing it for
+                # every node lets a batch of N nodes run ~N x over the cap. Re-
+                # derive the live remaining budget before each node so the cap
+                # is honored. Once past the deadline, skip the solve and record a
+                # trivial (-inf) lower bound: -inf leaves the node unpruned (it
+                # is the default node bound) and decertifies the gap below, so we
+                # stop early without ever fabricating a false "optimal".
+                _node_remaining = _deadline - time.perf_counter()
+                if _node_remaining <= 0.0:
+                    result_ids[i] = int(batch_ids[i])
+                    result_lbs[i] = -np.inf
+                    lb_clipped = np.clip(node_lb, -_SPC, _SPC)
+                    ub_clipped = np.clip(node_ub, -_SPC, _SPC)
+                    result_sols[i] = 0.5 * (lb_clipped + ub_clipped)
+                    result_feas[i] = False
+                    if not _model_is_convex:
+                        _gap_certified = False
+                    continue
+                opts["max_wall_time"] = max(_node_remaining, _DEADLINE_NODE_FLOOR_S)
 
                 nlp_result = None
                 if iteration == 0 and _mc_lp_relaxer is None:
@@ -2774,7 +2805,13 @@ def solve_model(
                 # iteration_limit (any node).
                 if _mc_lp_relaxer is not None:
                     try:
-                        mc_lp_res = _mc_lp_relaxer.solve_at_node(node_lb, node_ub)
+                        mc_lp_res = _mc_lp_relaxer.solve_at_node(
+                            node_lb,
+                            node_ub,
+                            time_limit=max(
+                                _deadline - time.perf_counter(), _DEADLINE_NODE_FLOOR_S
+                            ),
+                        )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", int(batch_ids[i]), e)
                         mc_lp_res = None

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -121,6 +121,7 @@ def solve_milp(
         0.0,  # obj_const: caller (MilpRelaxationModel) applies its own offset
         int(max_nodes),
         float(gap_tolerance),
+        time_limit_s=0.0 if time_limit is None else max(0.0, float(time_limit)),
     )
 
     if status == "infeasible":


### PR DESCRIPTION
## Problem

discopt could overrun a stated `time_limit` by up to ~2.5x (e.g. `st_e36` ran
50s on a 20s cap; `st_e31` ran 21.4s on a 10s cap). The user flagged this as a
bug — the cap should be honored.

## Root causes (two)

1. **Per-node budget reuse in the serial B&B loop.** The loop set
   `opts["max_wall_time"]` once per *batch* to the whole remaining time, then
   reused it for *every* node in the batch. A batch of N nodes could run up to
   N x over the cap.

2. **No wall-time cap in the Rust MILP core.** `solve_milp` (`MilpOptions`) was
   bounded only by a 1e6 node cap — no deadline. A single McCormick
   LP-relaxation node solve (`mccormick_lp.solve_at_node` -> `solve_milp_py`)
   could run unbounded; profiling showed one such call consuming 11.3s on a 10s
   budget. This was the dominant overrun on `st_e31`.

## Fix

- **Serial loop:** re-derive each node's NLP budget from the live remaining time
  to the global deadline. Past the deadline, skip the node solve and record a
  trivial `-inf` lower bound — which leaves the node unpruned (it is the default
  node bound) and decertifies the gap. Sound by construction: we never fabricate
  a false "optimal".
- **Rust MILP core:** added an optional `time_limit_s` to `MilpOptions`, checked
  at each batch boundary of the `'search` loop. On expiry the search stops and
  returns the incumbent with a valid (uncertified) dual bound (`Feasible`).
- Threaded the budget end-to-end: `solve_milp_py` (new kwarg, `0.0` = unlimited)
  -> `milp_simplex.solve_milp` -> both `mccormick_lp.solve_at_node` call sites.

Default is unlimited (`None` / `0.0`), so existing node-capped solves and the
parallel-equivalence benchmark are bit-for-bit unchanged.

## Validation

- `st_e31` 21.4s -> 11.1s, `ex1221` 10.7s -> 10.1s on a 10s cap.
- 0/12 overruns across a representative MINLPLib slice (was 2/12).
- Objectives and the certified count unchanged (`ex1223a` still certifies
  `optimal`).
- `cargo test -p discopt-core` MILP driver tests pass; `pytest python/tests`
  solver/MILP subset: 414 passed.

## Known follow-up (out of scope)

`st_e36` still overruns, but for an unrelated reason: a combinatorial blowup in
`term_classifier.distribute_products` during relaxation *building* (preprocessing,
not B&B). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
