### PR TITLE
feat(relax): engage spatial LP relaxer on monomial/fractional-power nonconvex models (#120)

### DIFF
--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -72,6 +72,24 @@ class MccormickLPRelaxer:
         """True if the model has any bilinear / trilinear / multilinear product."""
         return bool(self._terms.bilinear or self._terms.trilinear or self._terms.multilinear)
 
+    @property
+    def has_relaxable_nonlinearity(self) -> bool:
+        """True if the model has any nonlinear term the LP relaxer can bound.
+
+        :func:`build_milp_relaxation` emits valid outer-approximation cuts not
+        only for products (bilinear/trilinear/multilinear) but also for
+        ``monomial`` (x^n, n≥2) and ``fractional_power`` (x^p) terms. Gating the
+        spatial LP relaxer on :attr:`has_bilinear` alone routes purely
+        univariate-power nonconvex models to the McCormick "nlp" bound, which is
+        not a valid dual bound for nonconvex models (issue #120). The LP
+        relaxation is a rigorous polyhedral outer approximation for every term
+        type here, so engaging it on these models yields a valid lower bound
+        (and any per-node term it cannot relax safely errors out to "no bound"
+        rather than an unsound one).
+        """
+        t = self._terms
+        return bool(t.bilinear or t.trilinear or t.multilinear or t.monomial or t.fractional_power)
+
     def solve_at_node(
         self,
         node_lb: np.ndarray,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2210,11 +2210,39 @@ def solve_model(
                 _mc_lp_relaxer = None
                 _mc_mode = "none"
             else:
-                if not _mc_lp_relaxer.has_bilinear:
-                    # No nonlinear products → standard LP relaxation = the
-                    # model itself for linear parts. Drop back to NLP.
+                if not _mc_lp_relaxer.has_relaxable_nonlinearity:
+                    # No nonlinear term the LP relaxer can bound (products,
+                    # monomials, or fractional powers) → standard LP relaxation
+                    # = the model itself for linear parts. Drop back to NLP.
+                    # NB: monomial/fractional-power-only nonconvex models DO get
+                    # a valid LP dual bound here (issue #120 fix); gating on
+                    # has_bilinear alone wrongly routed them to the unsound "nlp"
+                    # bound.
                     _mc_lp_relaxer = None
                     _mc_mode = "nlp"
+                else:
+                    # Root probe: keep the LP relaxer only if it actually yields
+                    # a valid objective bound (or a rigorous infeasibility proof)
+                    # at the root box. When the objective is not LP-linearizable
+                    # the relaxer falls back to a feasibility objective and
+                    # returns no bound; engaging it would then SKIP the root NLP
+                    # multistart and suppress the alphaBB/interval floor, losing
+                    # a bound that path would otherwise produce. Falling back to
+                    # "none" here preserves the rigorous alphaBB underestimator
+                    # for those models while keeping the LP bound for the ones it
+                    # can actually relax.
+                    try:
+                        _probe_lb, _probe_ub = flat_variable_bounds(model)
+                        _probe = _mc_lp_relaxer.solve_at_node(_probe_lb, _probe_ub)
+                    except Exception as e:  # pragma: no cover - defensive
+                        logger.debug("McCormick LP root probe failed: %s", e)
+                        _probe = None
+                    _probe_useful = _probe is not None and (
+                        _probe.status == "infeasible" or _probe.lower_bound is not None
+                    )
+                    if not _probe_useful:
+                        _mc_lp_relaxer = None
+                        _mc_mode = "none"
 
     # Soundness guard (issue #120): the McCormick "nlp" objective bound is a
     # valid dual bound only for convex models. The bound solver evaluates the

--- a/python/tests/test_monomial_lp_bound.py
+++ b/python/tests/test_monomial_lp_bound.py
@@ -1,0 +1,70 @@
+"""Regression test for the issue #120 follow-up: monomial / fractional-power
+nonconvex models must get a *valid* LP spatial dual bound, not the unsound
+"nlp"/alphaBB fallback.
+
+The spatial LP relaxer (:class:`MccormickLPRelaxer`) was engaged only when the
+model had a bilinear/trilinear/multilinear product (its ``has_bilinear`` gate).
+Nonconvex models whose only nonlinearity is a univariate power — ``x**n``
+(monomial) or ``x**p`` (fractional power) — were therefore routed to the
+McCormick ``"nlp"`` objective bound, which is not a valid dual bound for
+nonconvex models, and fell back to alphaBB with *no* certifying bound.
+
+:func:`build_milp_relaxation` emits valid outer-approximation cuts for those
+term types too, so the LP optimum is a rigorous lower bound. The gate now keys
+on :attr:`MccormickLPRelaxer.has_relaxable_nonlinearity`, so these models
+certify optimality with a sound bound.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+# (instance, global optimum) for monomial/fractional-power-only models that
+# previously produced no dual bound and now certify. Optima are the proven
+# values (gap closed: bound == objective) and agree with MINLPLib references.
+_CERTIFY_CASES = [
+    ("prob06", 1.177124),
+    ("st_e13", 2.000000),
+    ("ex1221", 7.667180),
+    ("ex1222", 1.076543),
+    ("ex1225", 31.000000),
+    ("st_e15", 7.667180),
+]
+
+
+@pytest.mark.correctness
+def test_relaxer_gate_includes_monomial_and_fractional_power():
+    """The LP relaxer must engage for purely univariate-power nonconvexity."""
+    from discopt._jax.mccormick_lp import MccormickLPRelaxer
+
+    # st_e13: a monomial-only nonconvex model (no product term at all).
+    m = dm.from_nl(str(_DATA / "st_e13.nl"))
+    relaxer = MccormickLPRelaxer(m)
+    assert not relaxer.has_bilinear, "st_e13 has no product term (precondition)"
+    assert relaxer.has_relaxable_nonlinearity, (
+        "monomial/fractional-power models must engage the LP relaxer"
+    )
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("instance, optimum", _CERTIFY_CASES)
+def test_monomial_model_certifies_with_valid_bound(instance, optimum):
+    """Each model reaches its optimum and certifies with a sound dual bound."""
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    r = dm.from_nl(str(nl)).solve(time_limit=30, gap_tolerance=1e-4)
+
+    assert r.objective is not None
+    assert abs(r.objective - optimum) <= 1e-3, f"[{instance}] obj={r.objective} != {optimum}"
+    # A valid dual bound must exist and never exceed the optimum (soundness).
+    assert r.bound is not None, f"[{instance}] no dual bound produced (issue #120 follow-up)"
+    assert r.bound <= optimum + 1e-3, f"[{instance}] invalid dual bound {r.bound} > {optimum}"
+    assert r.gap_certified, f"[{instance}] expected certified optimality"


### PR DESCRIPTION
## Summary

Closes a concrete piece of the MINLPLib **certification gap**: nonconvex
continuous models whose only nonlinearity is a **monomial** (`x^n`, n≥2) or
**fractional power** (`x^p`) were being routed to the McCormick `"nlp"`
objective bound, which is **not a valid dual bound** for nonconvex models
(issue #120). They were discarded by the LP-relaxer gate, which engaged only
on product terms (`has_bilinear`).

`build_milp_relaxation` already emits valid polyhedral outer-approximation
cuts for monomial and fractional-power terms, so engaging the LP relaxer on
these models produces a **rigorous valid lower bound** and lets them certify.

## Changes

- **`mccormick_lp.py`** — new `has_relaxable_nonlinearity` property covering
  bilinear / trilinear / multilinear / monomial / fractional_power terms.
- **`solver.py`** — gate on `has_relaxable_nonlinearity`, plus a **root probe**:
  keep the LP relaxer only when it yields a valid bound or a rigorous
  infeasibility proof at the root box. When the objective is not
  LP-linearizable the relaxer falls back to a feasibility objective and
  returns no bound; engaging it then would skip root NLP multistart and
  suppress the alphaBB/interval floor. The probe falls back to `"none"`
  (rigorous alphaBB underestimator) for those models — this prevents the
  prob10 regression.
- **`test_monomial_lp_bound.py`** — regression test: monomial/fractional-power
  nonconvex MINLPLib instances certify with a valid bound ≤ optimum; the gate
  includes these term types.

## Validation

Rigorous before/after on the 17-instance affected set:

- **7 newly certified optimal**: `ex1221`, `ex1222`, `ex1225`, `fuel`,
  `prob06`, `st_e13`, `st_e15`
- **2 new valid dual bounds**: `ex1226`, `nvs08`
- **0 regressions**, **0 unsoundness** — every reported bound ≤ objective;
  `nvs16` soundness (issue #120 regression test) preserved.

## Soundness

The LP-form McCormick relaxation is a polyhedral **outer** approximation of
the nonconvex feasible set, so its LP optimum is a rigorous lower bound and an
infeasible relaxation is a rigorous fathom. Any per-node term it cannot relax
safely errors out to "no bound" rather than an unsound one. The root probe
ensures a model only keeps the LP relaxer when that path actually produces a
valid bound; otherwise it falls back to the always-valid alphaBB underestimator.

## Tests

`test_monomial_lp_bound.py`, `test_nvs16_soundness.py`,
`test_mccormick_bounds.py`, `test_interval_node_bound.py` — 34 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
