### PR TITLE
feat(relax): pinned-variable fold + monomial*variable lift (certifies st_e11, st_e38, ex1226)

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -622,6 +622,7 @@ def _decompose_product(
     model: Model,
     fractional_power_var_map: Optional[dict[tuple[int, float], int]] = None,
     univariate_var_map: Optional[dict[object, int]] = None,
+    monomial_var_map: Optional[dict[tuple[int, int], int]] = None,
 ) -> tuple[float, list[int]] | None:
     """Decompose a product expression into (scalar, [flat_or_aux_idx, ...]).
 
@@ -629,6 +630,13 @@ def _decompose_product(
     Constants are accumulated into the scalar; variable references and
     registered lifted sub-expressions are appended to the index list (using
     their MILP column indices).
+
+    When ``monomial_var_map`` is supplied, a *mixed repeated-factor* product
+    such as ``x*x*y`` is collapsed: the repeated original-variable group ``x*x``
+    is replaced by its monomial aux column (``x**2``), leaving ``[col(x**2), y]``
+    — a lifted bilinear pair. This lets the standard McCormick pipeline relax
+    ``x**2 * y`` (one monomial envelope + one bilinear envelope) instead of
+    rejecting it as an unsupported repeated-factor term.
     """
     scalar: list[float] = [1.0]
     var_indices: list[int] = []
@@ -663,9 +671,40 @@ def _decompose_product(
                     return True
         return False
 
-    if visit(expr):
-        return scalar[0], var_indices
-    return None
+    if not visit(expr):
+        return None
+
+    # Collapse mixed repeated-factor groups (x*x*y) into monomial aux columns
+    # so the product reduces to distinct lifted factors the McCormick pipeline
+    # can relax. Pure monomials (x*x with a single unique base) are left intact
+    # for the dedicated monomial branch in the linearizer.
+    if monomial_var_map:
+        n_orig = sum(v.size for v in model._variables)
+        counts: dict[int, int] = {}
+        for i in var_indices:
+            if i < n_orig:
+                counts[i] = counts.get(i, 0) + 1
+        repeated = {i for i, c in counts.items() if c >= 2}
+        if repeated and len(set(var_indices)) >= 2:
+            collapsed: list[int] = []
+            seen: set[int] = set()
+            ok = True
+            for i in var_indices:
+                if i in repeated:
+                    if i in seen:
+                        continue
+                    col = monomial_var_map.get((i, counts[i]))
+                    if col is None:
+                        ok = False
+                        break
+                    collapsed.append(col)
+                    seen.add(i)
+                else:
+                    collapsed.append(i)
+            if ok:
+                var_indices = collapsed
+
+    return scalar[0], var_indices
 
 
 def _collect_lifted_bilinear_products(
@@ -673,6 +712,7 @@ def _collect_lifted_bilinear_products(
     fractional_power_var_map: dict[tuple[int, float], int],
     univariate_var_map: dict[object, int],
     n_orig: int,
+    monomial_var_map: Optional[dict[tuple[int, int], int]] = None,
 ) -> list[tuple[int, int]]:
     """Return products between original variables and lifted auxiliary columns."""
     keys: set[tuple[int, int]] = set()
@@ -685,6 +725,7 @@ def _collect_lifted_bilinear_products(
                     model,
                     fractional_power_var_map=fractional_power_var_map,
                     univariate_var_map=univariate_var_map,
+                    monomial_var_map=monomial_var_map,
                 )
                 if decomp is not None:
                     _scalar, indices = decomp
@@ -2120,6 +2161,7 @@ def _linearize_expr(
                     model,
                     fractional_power_var_map=fractional_power_var_map,
                     univariate_var_map=univariate_var_map,
+                    monomial_var_map=monomial_var_map,
                 )
                 if decomp is None:
                     raise ValueError(f"Cannot decompose product: {e}")
@@ -2692,6 +2734,7 @@ def build_milp_relaxation(
         fractional_power_var_map,
         univariate_var_map,
         n_orig,
+        monomial_var_map=monomial_var_map,
     )
     for key in lifted_bilinear_keys:
         bilinear_var_map[key] = _ensure_bilinear_aux(*key)

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -1981,6 +1981,8 @@ def _linearize_expr(
     n_total_vars: int,
     fractional_power_var_map: Optional[dict[tuple[int, float], int]] = None,
     univariate_square_var_map: Optional[dict[tuple[int, int], int]] = None,
+    flat_lb: Optional[np.ndarray] = None,
+    flat_ub: Optional[np.ndarray] = None,
 ) -> tuple[np.ndarray, float]:
     """Walk expression tree and return (coeff, constant) for linearized form.
 
@@ -1989,10 +1991,30 @@ def _linearize_expr(
 
     Nonlinear terms must have a corresponding auxiliary variable in the maps;
     raises ValueError if an unregistered nonlinear term is encountered.
+
+    When ``flat_lb``/``flat_ub`` are supplied, any nonlinear term whose base
+    variable is *pinned* at this node (``ub - lb`` within tolerance — produced
+    by spatial branching driving a domain to a point) is folded to its exact
+    constant value instead of requiring an auxiliary column. The aux-column
+    builders intentionally skip degenerate (zero-width) domains, so without
+    this fold a pinned monomial/fractional-power term would fail to linearize
+    and silently sink the node's objective bound to "feasibility only".
     """
     coeff = np.zeros(n_total_vars, dtype=np.float64)
     const_acc: list[float] = [0.0]
     n_orig = sum(var.size for var in model._variables)
+
+    _PIN_TOL = 1e-9
+
+    def _pinned_value(idx: int) -> Optional[float]:
+        """Exact value of variable ``idx`` if pinned at this node, else None."""
+        if flat_lb is None or flat_ub is None or idx >= len(flat_lb):
+            return None
+        lo = float(flat_lb[idx])
+        hi = float(flat_ub[idx])
+        if hi - lo <= _PIN_TOL:
+            return 0.5 * (lo + hi)
+        return None
 
     def visit(e: Expression, scale: float) -> None:  # noqa: C901
         if isinstance(e, Constant):
@@ -2068,10 +2090,18 @@ def _linearize_expr(
                             if key in monomial_var_map:
                                 coeff[monomial_var_map[key]] += scale
                                 return
+                            pinned = _pinned_value(flat)
+                            if pinned is not None:
+                                const_acc[0] += scale * (pinned**n_int)
+                                return
                             raise ValueError(f"Monomial {key} not in monomial_var_map")
                     fp_key = (flat, exp_val)
                     if fractional_power_var_map and fp_key in fractional_power_var_map:
                         coeff[fractional_power_var_map[fp_key]] += scale
+                        return
+                    pinned = _pinned_value(flat)
+                    if pinned is not None and pinned >= 0.0:
+                        const_acc[0] += scale * (pinned**exp_val)
                         return
                     raise ValueError(f"Fractional power {fp_key} has no aux column")
                 raise ValueError(f"Cannot linearize power expression: {e}")
@@ -2094,6 +2124,20 @@ def _linearize_expr(
                 if decomp is None:
                     raise ValueError(f"Cannot decompose product: {e}")
                 c, indices = decomp
+                # Fold pinned factors (lb==ub at this node) into the constant
+                # coefficient — their value is exact, lowering the product's
+                # arity so a partially-pinned bilinear/trilinear collapses to a
+                # lower-order term (or a constant) instead of demanding an aux
+                # column the builder skipped for the degenerate domain.
+                if (flat_lb is not None or flat_ub is not None) and indices:
+                    kept_indices: list[int] = []
+                    for idx in indices:
+                        pinned = _pinned_value(idx)
+                        if pinned is not None:
+                            c *= pinned
+                        else:
+                            kept_indices.append(idx)
+                    indices = kept_indices
                 unique = list(dict.fromkeys(indices))
                 if len(indices) == 0:
                     const_acc[0] += scale * c
@@ -3778,6 +3822,8 @@ def build_milp_relaxation(
                     n_total,
                     fractional_power_var_map=fractional_power_var_map,
                     univariate_square_var_map=univariate_square_var_map,
+                    flat_lb=flat_lb,
+                    flat_ub=flat_ub,
                 )
             except ValueError as err:
                 logger.debug(
@@ -3821,6 +3867,8 @@ def build_milp_relaxation(
                 n_total,
                 fractional_power_var_map=fractional_power_var_map,
                 univariate_square_var_map=univariate_square_var_map,
+                flat_lb=flat_lb,
+                flat_ub=flat_ub,
             )
             # body ≤ 0  →  c @ z + const ≤ 0  →  c @ z ≤ -const
             if sense == "<=":
@@ -3886,6 +3934,8 @@ def build_milp_relaxation(
                 n_total,
                 fractional_power_var_map=fractional_power_var_map,
                 univariate_square_var_map=univariate_square_var_map,
+                flat_lb=flat_lb,
+                flat_ub=flat_ub,
             )
         objective_bound_valid = True
     except ValueError as err:

--- a/python/tests/test_monomial_var_product.py
+++ b/python/tests/test_monomial_var_product.py
@@ -1,0 +1,89 @@
+"""Regression test for *mixed repeated-factor* product support (x**2 * y).
+
+The term classifier dumps a product like ``x*x*y`` into ``general_nl`` and the
+MILP linearizer raised ``"Mixed repeated-factor products are not supported"``,
+so any model with a ``monomial * variable`` term fell back to a feasibility
+objective and produced no dual bound (e.g. ``st_e38`` finished ``feasible`` with
+``bound=None``).
+
+:func:`_decompose_product` now collapses the repeated original-variable group
+into its monomial aux column, leaving a lifted bilinear pair
+``[col(x**2), y]``. The standard McCormick pipeline relaxes that with one
+monomial envelope plus one bilinear envelope — a rigorous outer approximation —
+so the term lifts cleanly and the model certifies.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+# (instance, optimum) — models with monomial*variable terms that previously
+# produced no certifying bound and now certify. Optima agree with MINLPLib.
+_CERTIFY_CASES = [
+    ("st_e38", 7197.727),
+    ("ex1226", -17.0),
+]
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("instance, optimum", _CERTIFY_CASES)
+def test_monomial_var_product_certifies(instance, optimum):
+    """Each monomial*variable model reaches its optimum with a sound bound."""
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    r = dm.from_nl(str(nl)).solve(time_limit=60, gap_tolerance=1e-4, max_nodes=200_000)
+
+    assert r.objective is not None
+    assert abs(r.objective - optimum) <= 1e-2, f"[{instance}] obj={r.objective} != {optimum}"
+    assert r.bound is not None, f"[{instance}] no dual bound produced"
+    # Soundness: a valid lower bound never exceeds the incumbent.
+    assert r.bound <= r.objective + 1e-3, f"[{instance}] unsound bound {r.bound} > {r.objective}"
+    assert r.gap_certified, f"[{instance}] expected certified optimality"
+
+
+@pytest.mark.correctness
+def test_decompose_collapses_repeated_factor_to_monomial_col():
+    """x*x*y decomposes to [monomial_aux(x**2), y], not a raw [x, x, y]."""
+    from discopt._jax.discretization import DiscretizationState
+    from discopt._jax.milp_relaxation import _decompose_product
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    m = dm.Model("xxy")
+    x = m.continuous("x", lb=1.0, ub=3.0)
+    y = m.continuous("y", lb=1.0, ub=2.0)
+    m.minimize(x * x * y)
+
+    # Build the monomial aux map the relaxation would construct for x**2.
+    classify_nonlinear_terms(m)
+    DiscretizationState(partitions={})
+    monomial_var_map = {(0, 2): 2}  # col 2 stands in for x**2 (cols 0,1 are x,y)
+    expr = m._objective.expression
+    decomp = _decompose_product(expr, m, monomial_var_map=monomial_var_map)
+    assert decomp is not None
+    _scalar, indices = decomp
+    # x*x folds to the monomial column (2); y (index 1) stays. No bare repeat.
+    assert sorted(indices) == [1, 2], f"expected [1, 2], got {indices}"
+
+
+@pytest.mark.correctness
+def test_monomial_var_relaxation_is_a_valid_lower_bound():
+    """The lifted x**2*y relaxation never overestimates the true minimum."""
+    # min x**2 * y over a positive box has minimum at the lower corner.
+    m = dm.Model("xxy_bound")
+    x = m.continuous("x", lb=1.0, ub=4.0)
+    y = m.continuous("y", lb=2.0, ub=5.0)
+    m.minimize(x * x * y)
+    r = m.solve(time_limit=30, gap_tolerance=1e-4)
+    assert r.objective is not None
+    true_min = 1.0 * 1.0 * 2.0  # x=1, y=2
+    assert r.objective == pytest.approx(true_min, abs=1e-3)
+    if r.bound is not None:
+        assert r.bound <= true_min + 1e-6, f"unsound bound {r.bound} > {true_min}"

--- a/python/tests/test_pinned_var_lift.py
+++ b/python/tests/test_pinned_var_lift.py
@@ -1,0 +1,85 @@
+"""Regression test for the spatial-relaxation *pinned-variable* fold.
+
+The fractional-power / monomial aux-column builders intentionally skip a
+variable whose domain is degenerate (``ub - lb`` within tolerance). Spatial
+branching routinely drives a domain to a point, so at those nodes a term like
+``x**0.6`` or ``x**2`` has no aux column. Previously the linearizer raised
+``"Fractional power (i, p) has no aux column"`` / ``"Monomial ... not in map"``
+there, which sank the node's *objective* to a feasibility-only relaxation and
+silently dropped its dual bound — so the global lower bound stalled and the
+model never certified (e.g. ``st_e11`` finished ``feasible`` with ``bound=None``
+despite the root LP producing a perfectly valid bound).
+
+A pinned variable has an exact value, so ``x**p`` is the constant ``v**p`` and a
+partially-pinned product collapses to a lower-order term. Folding pinned factors
+into constants is rigorous (no relaxation involved) and restores the node bound.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+from discopt._jax.discretization import DiscretizationState
+from discopt._jax.milp_relaxation import build_milp_relaxation
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.term_classifier import classify_nonlinear_terms
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+
+@pytest.mark.correctness
+def test_pinned_fractional_power_keeps_objective_bound():
+    """Pinning a fractional-power base must not collapse the objective bound."""
+    m = dm.from_nl(str(_DATA / "st_e11.nl"))
+    terms = classify_nonlinear_terms(m)
+    disc = DiscretizationState(partitions={})
+    lb, ub = flat_variable_bounds(m)
+
+    # Root box: objective linearizes (baseline).
+    milp_root, _ = build_milp_relaxation(m, terms, disc, bound_override=(lb.copy(), ub.copy()))
+    assert milp_root._objective_bound_valid
+
+    # Pin each fractional-power base in turn (lb == ub) and confirm the
+    # objective still linearizes (its term folds to an exact constant) rather
+    # than degrading to the feasibility fallback.
+    for var_idx, _p in terms.fractional_power:
+        ub_pin = ub.copy()
+        ub_pin[var_idx] = lb[var_idx]
+        milp, _ = build_milp_relaxation(m, terms, disc, bound_override=(lb.copy(), ub_pin))
+        assert milp._objective_bound_valid, f"pinning x{var_idx} dropped the objective bound"
+
+
+@pytest.mark.correctness
+def test_st_e11_certifies_with_sound_bound():
+    """st_e11 must reach its optimum and certify with a valid dual bound."""
+    r = dm.from_nl(str(_DATA / "st_e11.nl")).solve(time_limit=60, gap_tolerance=1e-4)
+
+    assert r.objective is not None
+    assert r.bound is not None, "no dual bound produced (pinned-variable fold)"
+    # Soundness: a valid lower bound never exceeds the incumbent.
+    assert r.bound <= r.objective + 1e-3, f"unsound bound {r.bound} > obj {r.objective}"
+    assert r.gap_certified, "expected certified optimality"
+    # Known MINLPLib optimum.
+    assert abs(r.objective - 189.31157) <= 1e-2, f"obj={r.objective}"
+
+
+@pytest.mark.correctness
+def test_pinned_value_is_exact_not_relaxed():
+    """A fully pinned univariate-power objective term equals the exact value."""
+    # min x**0.6 with x pinned to 16 → exactly 16**0.6, no relaxation slack.
+    m = dm.Model("pinned")
+    x = m.continuous("x", lb=16.0, ub=16.0)
+    m.minimize(x**0.6)
+    terms = classify_nonlinear_terms(m)
+    disc = DiscretizationState(partitions={})
+    lb, ub = flat_variable_bounds(m)
+    milp, _ = build_milp_relaxation(m, terms, disc, bound_override=(lb, ub))
+    assert milp._objective_bound_valid
+    res = milp.solve()
+    assert res.objective is not None
+    assert res.objective == pytest.approx(16.0**0.6, abs=1e-6)


### PR DESCRIPTION
## Summary

Two spatial-relaxation coverage fixes that turn three MINLPLib instances from
`feasible` (no dual bound) into **certified optimal**, continuing the
certification-gap work from #128. Both fixes are rigorous outer
approximations — they only ever produce valid lower bounds.

| Instance | Before | After | Fix |
|---|---|---|---|
| `st_e11` | feasible, bound=None | **optimal**, bound=189.31 | pinned-variable fold |
| `st_e38` | feasible, bound=None | **optimal**, bound=7197.44 | monomial×var lift |
| `ex1226` | feasible, bound=−20.99 | **optimal**, bound=−17.0 | monomial×var lift (bonus) |

## Fix 1 — fold pinned variables (commit 1)

The fractional-power / monomial aux-column builders intentionally skip a
variable whose domain is degenerate (`ub − lb` within tolerance). Spatial
branching routinely drives a domain to a point, so at those nodes a term like
`x**0.6` or `x**2` had no aux column and the linearizer raised
*"Fractional power (i, p) has no aux column"*. That collapsed the node's
objective to a feasibility-only relaxation and silently dropped its dual bound.
`st_e11` finished `feasible`/`bound=None` even though the root LP produced a
valid bound and the per-node LP bounds climbed 161 → 187 toward the optimum.

A pinned variable has an *exact* value, so `x**p` is the constant `v**p` and a
partially-pinned product collapses to a lower-order term. Folding pinned
factors into constants/coefficients is rigorous (no relaxation slack) and
restores the node bound. `_linearize_expr` now takes the node `flat_lb/flat_ub`
and folds pinned monomial/fractional-power bases and product factors.

## Fix 2 — lift monomial×variable products `x**2 * y` (commit 2)

A product mixing a repeated factor with a distinct one (`x*x*y`) was classified
into `general_nl` and the linearizer raised *"Mixed repeated-factor products
are not supported"* → feasibility fallback, no bound. `_decompose_product` now
collapses the repeated original-variable group into its monomial aux column,
reducing `x*x*y` to the lifted bilinear pair `[col(x**2), y]`. The existing
McCormick pipeline relaxes that with one monomial envelope plus one bilinear
envelope. `_collect_lifted_bilinear_products` is threaded the monomial map so
the `(monomial_col, var)` bilinear aux is actually built.

This also tightened `ex1226` enough to close its gap (bonus certification).

## Soundness & regressions

- Every reported bound ≤ incumbent objective; both mechanisms are rigorous
  polyhedral outer approximations (exact for the pinned case).
- 17-instance affected-set census (from #128): all prior wins intact, prob10
  bound preserved, only `ex1226` *improves* (feasible→optimal). **0 regressions.**
- `nvs16` soundness regression test (#120) still passes.
- ~390 relaxation / McCormick / alphaBB / NLP-BB / MILP-BB / convexity-soundness
  tests pass, plus the two new regression tests
  (`test_pinned_var_lift.py`, `test_monomial_var_product.py`).

## Honest scope: the two remaining gaps are deeper than their labels

- **`st_e04`** — labelled "`(affine)**1.2` objective", but the binding
  constraint is the *omitted* equality `x3 = exp(11.86 − 3950/(460+x2))`
  (exp-of-rational). Linearizing the affine-base power alone drives x3→14.7
  (term→0) and the bound stays ≈1000 vs optimum 5339 — it would not certify.
  The real blocker is the exp-of-rational constraint relaxation.
- **`nvs01`** — labelled "sqrt·var", but the objective is
  `sqrt(x0**2 + 900) · x1` (a product of `sqrt(quadratic)` and a variable) and
  a constraint carries a non-constant division `(18505.5·x1²+…)/(x0²+7200)`.
  This needs sqrt-of-convex envelopes plus bilinear-division relaxation.

Both are tracked as follow-up work; neither is a one-line linearizer gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
