### PR TITLE
feat(relax): certify st_e04 and nvs01 via composite-univariate + factorable reformulation (#130)

### DIFF
--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -1,0 +1,362 @@
+"""Factorable reformulation: rewrite nonlinear terms the relaxation pipeline
+cannot handle natively into terms it CAN relax.
+
+Two sound, value-preserving rewrites are applied (see issue #130):
+
+1. **Sign-definite denominator clearing.** A constraint term ``N / D`` with a
+   non-constant denominator ``D`` that is provably bounded away from zero over
+   the variable box (``D > 0`` or ``D < 0`` by interval arithmetic) is cleared
+   by multiplying the whole constraint through by ``D``.  The inequality sense
+   is preserved when ``D > 0`` and flipped when ``D < 0``; equalities are
+   unaffected.  This is exact: over the box ``D`` never vanishes, so the
+   multiplied constraint has the identical solution set.
+
+2. **Mixed repeated-factor product lifting.** A *pure polynomial* product such
+   as ``x*x*y`` (= ``x**2 * y``) is not representable by the bilinear /
+   trilinear / monomial relaxation pipeline (see
+   ``term_classifier.classify_nonlinear_terms``: such terms fall into
+   ``general_nl`` and are dropped from the MILP relaxation).  Each repeated
+   power ``x**k`` (k >= 2) inside such a product is lifted to a fresh auxiliary
+   variable ``w`` with the defining equality ``w == x**k`` (a monomial the
+   pipeline *does* relax) and the product is rebuilt as ``w * y`` — a bilinear
+   term the pipeline handles.  ``w == x**k`` reproduces the term value exactly,
+   so the lifted model is equivalent to the original.
+
+Both rewrites preserve the feasible set and the objective exactly; the only
+effect on the *relaxation* is to expose a valid outer approximation where there
+previously was none.  When neither rewrite applies the input model is returned
+unchanged (zero overhead, zero behavioural change).  Anything the pass is not
+certain it can rewrite soundly is left untouched, so it never regresses a model
+that already solved.
+
+**Convexity caveat.** Although value-preserving, both rewrites can turn a
+*convex* model nonconvex — clearing ``x**2 / z`` (convex for ``z > 0``) yields
+the bilinear ``x**2 - y*z``, and distributing a product breaks the structure
+the convex fast path recognises.  The caller is therefore expected to gate this
+pass to provably-nonconvex models (see ``has_factorable_work`` and the
+convexity check in ``discopt.solver.solve_model``); the rewrite itself is
+unconditional once invoked.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Constraint,
+    Expression,
+    IndexExpression,
+    Model,
+    UnaryOp,
+    Variable,
+    VarType,
+)
+
+from .gdp_reformulate import _bound_expression
+from .term_classifier import _get_flat_index, distribute_products
+
+# A denominator counts as sign-definite only when its interval is bounded away
+# from zero by at least this margin — guards against a denominator that merely
+# grazes zero (where the multiply-through would not be value-preserving).
+_ZERO_MARGIN = 1e-9
+# Reject an aux lift whose induced bound magnitude is effectively infinite: an
+# unbounded monomial aux would make the relaxation/NLP unbounded.
+_INF_THRESH = 1e15
+
+
+def _leaf_index_and_exp(expr: Expression, model: Model):
+    """If *expr* is a variable leaf or an integer power of one, return
+    ``(leaf_expr, flat_index, exponent)``; otherwise ``None``."""
+    if isinstance(expr, (Variable, IndexExpression)):
+        idx = _get_flat_index(expr, model)
+        return (expr, idx, 1) if idx is not None else None
+    if isinstance(expr, BinaryOp) and expr.op == "**" and isinstance(expr.right, Constant):
+        p = float(expr.right.value)
+        if p == int(p) and int(p) >= 1:
+            idx = _get_flat_index(expr.left, model)
+            if idx is not None:
+                return (expr.left, idx, int(p))
+    return None
+
+
+def _decompose_poly_product(expr: Expression, model: Model):
+    """Walk a ``*``-tree and split it into ``(coeff, powers, extra)``.
+
+    ``powers`` maps ``flat_index -> [leaf_expr, total_exponent]`` for variable
+    factors; ``extra`` collects any non-polynomial factor (transcendental,
+    division, ...).  Returns ``None`` if the node is not a multiplication tree
+    (e.g. it contains a ``+``/``-``), so the caller recurses instead.
+    """
+    coeff = 1.0
+    powers: dict[int, list] = {}
+    extra: list[Expression] = []
+
+    def visit(e: Expression) -> bool:
+        nonlocal coeff
+        if isinstance(e, BinaryOp) and e.op == "*":
+            return visit(e.left) and visit(e.right)
+        if isinstance(e, Constant) and e.value.ndim == 0:
+            coeff *= float(e.value)
+            return True
+        leaf = _leaf_index_and_exp(e, model)
+        if leaf is not None:
+            leaf_expr, idx, exp = leaf
+            if idx in powers:
+                powers[idx][1] += exp
+            else:
+                powers[idx] = [leaf_expr, exp]
+            return True
+        # Any other factor (sqrt(...), exp(...), a/b, ...) is non-polynomial.
+        extra.append(e)
+        return True
+
+    if not (isinstance(expr, BinaryOp) and expr.op == "*"):
+        return None
+    visit(expr)
+    return coeff, powers, extra
+
+
+def _needs_lift(powers: dict[int, list]) -> bool:
+    """A pure polynomial product needs lifting iff it is a *mixed* product with
+    a repeated factor — at least two distinct variables and some exponent >= 2
+    (e.g. ``x*x*y``).  Single-variable monomials (``x**k``) and products of
+    distinct variables (bilinear/trilinear/multilinear) are handled natively."""
+    if len(powers) < 2:
+        return False
+    return any(exp >= 2 for _leaf, exp in powers.values())
+
+
+class _Lifter:
+    """Allocates monomial auxiliary variables ``w == leaf**k`` on *model*,
+    deduplicating by (flat_index, exponent)."""
+
+    def __init__(self, model: Model):
+        self.model = model
+        self._cache: dict[tuple[int, int], Variable] = {}
+        self.aux_constraints: list[Constraint] = []
+        self._counter = 0
+
+    def monomial(self, leaf: Expression, flat_index: int, exp: int):
+        """Return an aux variable equal to ``leaf**exp`` (creating it on first
+        use), or ``None`` if a finite bound for it cannot be established."""
+        key = (flat_index, exp)
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+        pow_expr = BinaryOp("**", leaf, Constant(float(exp)))
+        lo, hi = _bound_expression(pow_expr, self.model)
+        if not (np.isfinite(lo) and np.isfinite(hi)) or max(abs(lo), abs(hi)) >= _INF_THRESH:
+            return None
+        name = f"_fr_aux_{self._counter}"
+        self._counter += 1
+        w = Variable(name, VarType.CONTINUOUS, (), lo, hi, self.model)
+        self.model._variables.append(w)
+        self._cache[key] = w
+        # Normalised form ``body == 0`` with body = w - leaf**exp.
+        self.aux_constraints.append(Constraint(BinaryOp("-", w, pow_expr), "==", 0.0))
+        return w
+
+
+def _rebuild_product(coeff: float, atoms: list[Expression]) -> Expression:
+    """Reconstruct ``coeff * atoms[0] * atoms[1] * ...`` as a left-folded tree."""
+    expr: Expression | None = None
+    if coeff != 1.0 or not atoms:
+        expr = Constant(coeff)
+    for a in atoms:
+        expr = a if expr is None else BinaryOp("*", expr, a)
+    return expr if expr is not None else Constant(coeff)
+
+
+def _lift_expr(expr: Expression, model: Model, lifter: _Lifter) -> Expression:
+    """Return *expr* with every mixed repeated-factor polynomial product lifted
+    to bilinear form via monomial aux variables.  Identity-preserving: returns
+    the same object when nothing changed, so untouched subtrees are unaffected.
+    """
+    if isinstance(expr, BinaryOp):
+        if expr.op == "*":
+            decomp = _decompose_poly_product(expr, model)
+            if decomp is not None:
+                coeff, powers, extra = decomp
+                # Only a pure polynomial product (no transcendental/division
+                # factor) is liftable into supported bilinear terms.
+                if not extra and _needs_lift(powers):
+                    atoms: list[Expression] = []
+                    ok = True
+                    for _idx, (leaf, exp) in powers.items():
+                        if exp >= 2:
+                            w = lifter.monomial(leaf, _idx, exp)
+                            if w is None:
+                                ok = False
+                                break
+                            atoms.append(w)
+                        else:
+                            atoms.append(leaf)
+                    if ok:
+                        return _rebuild_product(coeff, atoms)
+            # Not a liftable product — recurse into factors.
+        left = _lift_expr(expr.left, model, lifter)
+        right = _lift_expr(expr.right, model, lifter)
+        if left is expr.left and right is expr.right:
+            return expr
+        return BinaryOp(expr.op, left, right)
+    if isinstance(expr, UnaryOp):
+        operand = _lift_expr(expr.operand, model, lifter)
+        if operand is expr.operand:
+            return expr
+        return UnaryOp(expr.op, operand)
+    # Do not descend into FunctionCall args: lifting inside a transcendental
+    # does not help the relaxation (the call is general_nl regardless) and must
+    # not disturb composite/univariate handling of e.g. sqrt(x**2 + c).
+    return expr
+
+
+def _find_clearable_denominator(expr: Expression, model: Model):
+    """Return the denominator ``D`` of the first division term ``N/D`` in
+    *expr*'s additive structure whose ``D`` is non-constant and sign-definite
+    over the variable box, together with its sign (+1 or -1).  ``None`` if no
+    such division exists."""
+    if isinstance(expr, BinaryOp):
+        if expr.op in ("+", "-"):
+            found = _find_clearable_denominator(expr.left, model)
+            if found is not None:
+                return found
+            return _find_clearable_denominator(expr.right, model)
+        if expr.op == "/":
+            d = expr.right
+            if not isinstance(d, Constant):
+                lo, hi = _bound_expression(d, model)
+                if lo > _ZERO_MARGIN:
+                    return d, 1
+                if hi < -_ZERO_MARGIN:
+                    return d, -1
+            # Search the numerator for a nested division.
+            return _find_clearable_denominator(expr.left, model)
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _find_clearable_denominator(expr.operand, model)
+    return None
+
+
+def _multiply_through(expr: Expression, denom: Expression) -> Expression:
+    """Return ``expr * denom`` with any division by *denom* (same object)
+    cancelled, distributing the multiply over the additive structure."""
+    if isinstance(expr, BinaryOp):
+        if expr.op in ("+", "-"):
+            return BinaryOp(
+                expr.op,
+                _multiply_through(expr.left, denom),
+                _multiply_through(expr.right, denom),
+            )
+        if expr.op == "/" and expr.right is denom:
+            return expr.left  # (N / D) * D -> N
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return UnaryOp("neg", _multiply_through(expr.operand, denom))
+    # ``0 * D`` is just 0 — keep the rewritten body free of dead zero terms.
+    if isinstance(expr, Constant) and expr.value.ndim == 0 and float(expr.value) == 0.0:
+        return expr
+    return BinaryOp("*", expr, denom)
+
+
+_FLIP = {"<=": ">=", ">=": "<=", "==": "=="}
+
+
+def _clear_divisions(body: Expression, sense: str, model: Model):
+    """Clear every sign-definite denominator from a constraint ``body sense 0``.
+    Returns ``(new_body, new_sense)``."""
+    for _ in range(8):  # bounded: each pass clears one denominator family
+        found = _find_clearable_denominator(body, model)
+        if found is None:
+            break
+        denom, sign = found
+        body = _multiply_through(body, denom)
+        if sign < 0:
+            sense = _FLIP[sense]
+    return body, sense
+
+
+def has_factorable_work(model: Model) -> bool:
+    """True if any constraint/objective has a clearable division or a mixed
+    repeated-factor product — i.e. the pass would change the model.
+
+    Exposed so the solver can run this cheap structural scan *before* the more
+    expensive convexity classification used to gate the (convexity-destroying)
+    rewrite: only nonconvex models that actually have liftable terms pay for
+    convexity detection.
+    """
+
+    def scan(expr: Expression) -> bool:
+        if _find_clearable_denominator(expr, model) is not None:
+            return True
+        dist = distribute_products(expr)
+        return _scan_for_mixed_product(dist, model)
+
+    if model._objective is not None and scan(model._objective.expression):
+        return True
+    return any(isinstance(c, Constraint) and scan(c.body) for c in model._constraints)
+
+
+def _scan_for_mixed_product(expr: Expression, model: Model) -> bool:
+    if isinstance(expr, BinaryOp):
+        if expr.op == "*":
+            decomp = _decompose_poly_product(expr, model)
+            if decomp is not None:
+                _coeff, powers, extra = decomp
+                if not extra and _needs_lift(powers):
+                    return True
+        return _scan_for_mixed_product(expr.left, model) or _scan_for_mixed_product(
+            expr.right, model
+        )
+    if isinstance(expr, UnaryOp):
+        return _scan_for_mixed_product(expr.operand, model)
+    return False
+
+
+def factorable_reformulate(model: Model) -> Model:
+    """Return a model equivalent to *model* with sign-definite denominators
+    cleared and mixed repeated-factor products lifted to bilinear form.
+
+    If neither rewrite applies, *model* is returned unchanged.  On any
+    unexpected error the original model is returned, so the pass can never make
+    a previously-solvable model unsolvable.
+    """
+    try:
+        if not has_factorable_work(model):
+            return model
+
+        new_model = Model(model.name)
+        new_model._variables = list(model._variables)
+        new_model._parameters = list(model._parameters)
+        new_model._objective = model._objective
+
+        lifter = _Lifter(new_model)
+
+        rebuilt: list[Constraint] = []
+        for c in model._constraints:
+            if not isinstance(c, Constraint):
+                rebuilt.append(c)  # pass through anything exotic untouched
+                continue
+            body, sense = _clear_divisions(c.body, c.sense, new_model)
+            body = distribute_products(body)
+            body = _lift_expr(body, new_model, lifter)
+            if body is c.body and sense == c.sense:
+                rebuilt.append(c)
+            else:
+                rebuilt.append(Constraint(body, sense, c.rhs, c.name))
+
+        # Lift the objective too (it may contain a mixed product); division
+        # clearing is meaningless for an objective so only the lift applies.
+        if new_model._objective is not None:
+            obj_expr = distribute_products(new_model._objective.expression)
+            lifted_obj = _lift_expr(obj_expr, new_model, lifter)
+            if lifted_obj is not new_model._objective.expression:
+                from discopt.modeling.core import Objective
+
+                new_model._objective = Objective(lifted_obj, new_model._objective.sense)
+
+        # Defining equalities for the aux variables come first so downstream
+        # bound propagation sees them early.
+        new_model._constraints = lifter.aux_constraints + rebuilt
+        return new_model
+    except Exception:  # pragma: no cover - defensive: never break a solve
+        return model

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -623,6 +623,7 @@ def _decompose_product(
     fractional_power_var_map: Optional[dict[tuple[int, float], int]] = None,
     univariate_var_map: Optional[dict[object, int]] = None,
     monomial_var_map: Optional[dict[tuple[int, int], int]] = None,
+    composite_var_map: Optional[dict[int, int]] = None,
 ) -> tuple[float, list[int]] | None:
     """Decompose a product expression into (scalar, [flat_or_aux_idx, ...]).
 
@@ -653,6 +654,11 @@ def _decompose_product(
             return True
         if univariate_var_map:
             aux_col = univariate_var_map.get(id(e))
+            if aux_col is not None:
+                var_indices.append(aux_col)
+                return True
+        if composite_var_map:
+            aux_col = composite_var_map.get(id(e))
             if aux_col is not None:
                 var_indices.append(aux_col)
                 return True
@@ -713,6 +719,7 @@ def _collect_lifted_bilinear_products(
     univariate_var_map: dict[object, int],
     n_orig: int,
     monomial_var_map: Optional[dict[tuple[int, int], int]] = None,
+    composite_var_map: Optional[dict[int, int]] = None,
 ) -> list[tuple[int, int]]:
     """Return products between original variables and lifted auxiliary columns."""
     keys: set[tuple[int, int]] = set()
@@ -726,6 +733,7 @@ def _collect_lifted_bilinear_products(
                     fractional_power_var_map=fractional_power_var_map,
                     univariate_var_map=univariate_var_map,
                     monomial_var_map=monomial_var_map,
+                    composite_var_map=composite_var_map,
                 )
                 if decomp is not None:
                     _scalar, indices = decomp
@@ -1839,6 +1847,417 @@ def _separable_objective_lower_bound(
     return float(total)
 
 
+@dataclass
+class CompositeUnivariateRelaxation:
+    """Outer relaxation for a single-variable nonlinear node of certified curvature.
+
+    Unlike :class:`UnivariateRelaxation` (a named operator of an *affine*
+    argument), this handles a composite node ``f(x_i)`` that depends on a single
+    original variable but whose internal structure is non-affine — e.g.
+    ``sqrt(x**2 + c)``, ``(a*x + b)**p``, or ``exp(c - k/(d + x))``. Curvature is
+    proven sound on the node box (analytic power rule, or a subdivided
+    interval-Hessian certificate), so the tangent/secant envelope below is a
+    rigorous outer approximation. The aux column ``z`` satisfies
+    ``lower_lines ≤ z ≤ upper_lines`` (convex: tangents below, secant above;
+    concave: secant below, tangents above).
+    """
+
+    expr_id: int
+    aux_col: int
+    var_idx: int
+    curvature: str
+    arg_lb: float
+    arg_ub: float
+    lower_lines: tuple[tuple[float, float], ...]
+    upper_lines: tuple[tuple[float, float], ...]
+    pin_value: Optional[float]
+
+
+_COMPOSITE_CURV_TOL = 1e-9
+_COMPOSITE_MAX_SUBDIV = 256
+
+
+def _build_convexity_box(model: Model, flat_lb: np.ndarray, flat_ub: np.ndarray) -> dict:
+    """Build the ``{Variable: Interval}`` box the convexity certificate expects."""
+    from discopt._jax.convexity.interval import Interval
+
+    box: dict = {}
+    offset = 0
+    for v in model._variables:
+        size = v.size
+        shape = v.shape if v.shape else (1,)
+        lo = np.asarray(flat_lb[offset : offset + size], dtype=np.float64).reshape(shape)
+        hi = np.asarray(flat_ub[offset : offset + size], dtype=np.float64).reshape(shape)
+        box[v] = Interval(lo, hi)
+        offset += size
+    return box
+
+
+def _composite_referenced_var(expr: Expression, model: Model) -> Optional[tuple[Variable, int]]:
+    """Return ``(var, flat_idx)`` if ``expr`` depends on exactly one scalar variable."""
+    found: dict[int, Variable] = {}
+
+    def visit(e: Expression) -> None:
+        if isinstance(e, Variable):
+            found[id(e)] = e
+            return
+        if isinstance(e, IndexExpression):
+            if isinstance(e.base, Variable):
+                found[id(e.base)] = e.base
+            else:
+                visit(e.base)
+            return
+        if isinstance(e, BinaryOp):
+            visit(e.left)
+            visit(e.right)
+        elif isinstance(e, UnaryOp):
+            visit(e.operand)
+        elif isinstance(e, FunctionCall):
+            for a in e.args:
+                visit(a)
+        elif isinstance(e, SumExpression):
+            visit(e.operand)
+        elif isinstance(e, SumOverExpression):
+            for t in e.terms:
+                visit(t)
+
+    visit(expr)
+    if len(found) != 1:
+        return None
+    var = next(iter(found.values()))
+    if var.size != 1:
+        return None
+    return var, _compute_var_offset(var, model)
+
+
+def _should_claim_composite(expr: Expression, model: Model, n_orig: int) -> bool:
+    """True when ``expr`` is a nonlinear node the *existing* machinery cannot lift.
+
+    The bilinear/monomial/fractional-power/univariate-of-affine builders already
+    cover their cases; claiming those here would create duplicate aux columns.
+    So claim only:
+
+    * a named univariate call whose argument is *non-affine* (the affine case is
+      handled by :func:`_collect_univariate_relaxations`), or
+    * ``(base)**p`` with a *non-integer* constant exponent ``p`` and a *non-bare*
+      base (a bare variable base is a monomial / fractional power; integer powers
+      of a non-bare base are squares/monomials handled by the dedicated square and
+      ``distribute_products`` machinery, so claiming them duplicates aux columns).
+    """
+    if isinstance(expr, FunctionCall) and len(expr.args) == 1:
+        op_info = _univariate_arg(expr)
+        if op_info is None:
+            return False
+        _name, arg = op_info
+        try:
+            _linearize_affine_expr(arg, model, n_orig)
+        except ValueError:
+            return True  # non-affine argument → existing univariate path can't lift it
+        return False
+    if isinstance(expr, BinaryOp) and expr.op == "**" and isinstance(expr.right, Constant):
+        p = float(expr.right.value)
+        if p == int(p):
+            return False  # integer powers → monomial / square / distribute machinery
+        # Bare variable / indexed base is a fractional power already.
+        if _get_flat_index(expr.left, model) is not None:
+            return False
+        return True
+    return False
+
+
+def _affine_base_power_curvature(expr: Expression, model: Model, box: dict) -> Optional[str]:
+    """Analytic curvature of ``(affine_base)**p`` from ``p`` and the base sign.
+
+    ``x**p`` is convex for ``p ≥ 1`` or ``p ≤ 0`` and concave for ``0 ≤ p ≤ 1``
+    on ``x > 0``; composition with an affine map preserves curvature. The base
+    sign is checked with a sound interval enclosure (Boyd & Vandenberghe §3.1.5).
+    """
+    if not (isinstance(expr, BinaryOp) and expr.op == "**" and isinstance(expr.right, Constant)):
+        return None
+    p = float(expr.right.value)
+    if p in (0.0, 1.0):
+        return None
+    from discopt._jax.convexity.interval_eval import evaluate_interval
+
+    try:
+        base_iv = evaluate_interval(expr.left, model, box=box)
+    except Exception:
+        return None
+    base_lo = float(np.asarray(base_iv.lo).ravel()[0])
+    if not np.isfinite(base_lo):
+        return None
+    # Outward interval rounding can render a true 0 as a tiny negative; a small
+    # tolerance keeps the nonnegativity test from spuriously abstaining.
+    tol = 1e-9
+    if p < 0.0:
+        return "convex" if base_lo > tol else None
+    if base_lo < -tol:
+        return None  # non-integer / odd powers need a nonnegative base for a clean verdict
+    if p > 1.0:
+        return "convex"
+    return "concave"  # 0 < p < 1
+
+
+def _subdivision_curvature(
+    expr: Expression,
+    model: Model,
+    var: Variable,
+    flat_idx: int,
+    lo: float,
+    hi: float,
+    box: dict,
+) -> Optional[str]:
+    """Sound curvature via a subdivided interval Hessian.
+
+    ``f`` is C² and depends on one variable, so its Hessian is the scalar
+    ``f''`` in entry ``(flat_idx, flat_idx)``. Covering ``[lo, hi]`` with
+    sub-intervals and enclosing ``f''`` on each tightens the dependency-induced
+    looseness of a single whole-box enclosure: if every piece has ``f'' ≥ 0``
+    the function is convex on the union ``[lo, hi]`` (symmetrically for concave).
+    """
+    from discopt._jax.convexity.interval import Interval
+    from discopt._jax.convexity.interval_ad import interval_hessian
+
+    if hi - lo <= _COMPOSITE_CURV_TOL:
+        return None  # pinned — handled by the exact pin value, not an envelope
+    shape = var.shape if var.shape else (1,)
+    n_sub = 4
+    while n_sub <= _COMPOSITE_MAX_SUBDIV:
+        edges = np.linspace(lo, hi, n_sub + 1)
+        all_convex = True
+        all_concave = True
+        finite = True
+        for k in range(n_sub):
+            box[var] = Interval(
+                np.full(shape, edges[k], dtype=np.float64),
+                np.full(shape, edges[k + 1], dtype=np.float64),
+            )
+            try:
+                ad = interval_hessian(expr, model, box=box)
+            except Exception:
+                finite = False
+                break
+            h = ad.hess
+            h_lo = float(h.lo[flat_idx, flat_idx])
+            h_hi = float(h.hi[flat_idx, flat_idx])
+            if not (np.isfinite(h_lo) and np.isfinite(h_hi)):
+                finite = False
+                break
+            if h_lo < -_COMPOSITE_CURV_TOL:
+                all_convex = False
+            if h_hi > _COMPOSITE_CURV_TOL:
+                all_concave = False
+            if not all_convex and not all_concave:
+                break
+        box[var] = Interval(
+            np.full(shape, lo, dtype=np.float64), np.full(shape, hi, dtype=np.float64)
+        )
+        if not finite:
+            return None
+        if all_convex:
+            return "convex"
+        if all_concave:
+            return "concave"
+        n_sub *= 4
+    return None
+
+
+def _composite_curvature(
+    expr: Expression,
+    model: Model,
+    var: Variable,
+    flat_idx: int,
+    lo: float,
+    hi: float,
+    box: dict,
+) -> Optional[str]:
+    """Certified curvature of a single-variable composite, or ``None`` to abstain."""
+    analytic = _affine_base_power_curvature(expr, model, box)
+    if analytic is not None:
+        return analytic
+    return _subdivision_curvature(expr, model, var, flat_idx, lo, hi, box)
+
+
+def _composite_envelope(
+    curvature: str,
+    lo: float,
+    hi: float,
+    value_fn,
+    grad_fn,
+) -> Optional[tuple[tuple, tuple, Optional[float], tuple[float, float]]]:
+    """Build (lower_lines, upper_lines, pin_value, col_bounds) for a composite.
+
+    Lines are ``(slope, intercept)`` in the single variable. For a convex
+    function tangents underestimate and the endpoint secant overestimates; the
+    roles swap for concave. Slopes/values come from exact autodiff, so for a
+    truly-convex (resp. concave) ``f`` each tangent is a supporting line and the
+    secant a chord — a rigorous outer band.
+
+    ``col_bounds`` is a rigorous box on the aux column derived from the same
+    certified curvature: a convex ``f`` attains its maximum at an endpoint, and
+    its underestimating tangents bound it from below (symmetrically for concave).
+    This avoids the interval evaluator, which abstains (``±inf``) on a
+    non-integer power whose base interval grazes zero.
+    """
+    if hi - lo <= _COMPOSITE_CURV_TOL:
+        v = value_fn(0.5 * (lo + hi))
+        if not np.isfinite(v):
+            return None
+        return (), (), float(v), (float(v), float(v))
+
+    pts: list[float] = []
+    for t in (lo, 0.5 * (lo + hi), hi):
+        if all(abs(t - s) > 1e-12 for s in pts):
+            pts.append(float(t))
+
+    f_lo = value_fn(lo)
+    f_hi = value_fn(hi)
+    if not (np.isfinite(f_lo) and np.isfinite(f_hi)):
+        return None
+    secant_slope = (f_hi - f_lo) / (hi - lo)
+    secant_intercept = f_lo - secant_slope * lo
+    if not (np.isfinite(secant_slope) and np.isfinite(secant_intercept)):
+        return None
+
+    tangents: list[tuple[float, float]] = []
+    for t in pts:
+        slope = grad_fn(t)
+        val = value_fn(t)
+        if not (np.isfinite(slope) and np.isfinite(val)):
+            return None
+        tangents.append((float(slope), float(val - slope * t)))
+
+    def _line_span(slope: float, intercept: float) -> tuple[float, float]:
+        a = slope * lo + intercept
+        b = slope * hi + intercept
+        return min(a, b), max(a, b)
+
+    secant = (float(secant_slope), float(secant_intercept))
+    if curvature == "convex":
+        # Max at an endpoint; tangents (underestimators) bound below.
+        col_hi = max(f_lo, f_hi)
+        col_lo = min(_line_span(s, b)[0] for s, b in tangents)
+        return tuple(tangents), (secant,), None, (float(col_lo), float(col_hi))
+    # Concave: min at an endpoint; tangents (overestimators) bound above.
+    col_lo = min(f_lo, f_hi)
+    col_hi = max(_line_span(s, b)[1] for s, b in tangents)
+    return (secant,), tuple(tangents), None, (float(col_lo), float(col_hi))
+
+
+def _collect_composite_univariate_relaxations(
+    model: Model,
+    n_orig: int,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+    start_col: int,
+    claimed_ids: set[int],
+) -> tuple[list[CompositeUnivariateRelaxation], dict[int, int], list[tuple[float, float]]]:
+    """Collect single-variable composite nodes with certified curvature.
+
+    Returns ``(relaxations, var_map, bounds)`` where ``var_map`` maps the node's
+    ``id(expr)`` to its aux column. Abstains silently (no entry) whenever
+    curvature can't be proven, the value range isn't finite, or autodiff fails —
+    abstention drops to the existing warn-and-omit path and never to an unsound
+    cut.
+    """
+    relaxations: list[CompositeUnivariateRelaxation] = []
+    var_map: dict[int, int] = {}
+    bounds: list[tuple[float, float]] = []
+    seen: set[int] = set()
+    col_idx = start_col
+
+    try:
+        import jax
+        import jax.numpy as jnp
+
+        from discopt._jax.dag_compiler import compile_expression
+    except Exception:
+        return relaxations, var_map, bounds
+
+    box = _build_convexity_box(model, flat_lb, flat_ub)
+    base_x = np.zeros(n_orig, dtype=np.float64)
+
+    def maybe_add(expr: Expression) -> None:
+        nonlocal col_idx
+        eid = id(expr)
+        if eid in seen or eid in claimed_ids:
+            return
+        if not _should_claim_composite(expr, model, n_orig):
+            return
+        ref = _composite_referenced_var(expr, model)
+        if ref is None:
+            return
+        var, flat_idx = ref
+        lo = float(flat_lb[flat_idx])
+        hi = float(flat_ub[flat_idx])
+        if not (np.isfinite(lo) and np.isfinite(hi)) or hi < lo:
+            return
+        curvature = _composite_curvature(expr, model, var, flat_idx, lo, hi, box)
+        if curvature is None:
+            return
+        try:
+            f = compile_expression(expr, model)
+            grad_f = jax.grad(lambda xv: jnp.reshape(f(xv), ()))
+        except Exception:
+            return
+
+        def value_fn(t: float) -> float:
+            x = jnp.asarray(base_x).at[flat_idx].set(t)
+            return float(jnp.reshape(f(x), ()))
+
+        def grad_fn(t: float) -> float:
+            x = jnp.asarray(base_x).at[flat_idx].set(t)
+            return float(np.asarray(grad_f(x)).ravel()[flat_idx])
+
+        env = _composite_envelope(curvature, lo, hi, value_fn, grad_fn)
+        if env is None:
+            return
+        lower_lines, upper_lines, pin_value, col_bounds = env
+        seen.add(eid)
+        var_map[eid] = col_idx
+        relaxations.append(
+            CompositeUnivariateRelaxation(
+                expr_id=eid,
+                aux_col=col_idx,
+                var_idx=flat_idx,
+                curvature=curvature,
+                arg_lb=lo,
+                arg_ub=hi,
+                lower_lines=lower_lines,
+                upper_lines=upper_lines,
+                pin_value=pin_value,
+            )
+        )
+        bounds.append(col_bounds)
+        col_idx += 1
+
+    def visit(expr: Expression) -> None:
+        maybe_add(expr)
+        if isinstance(expr, BinaryOp):
+            visit(expr.left)
+            visit(expr.right)
+        elif isinstance(expr, UnaryOp):
+            visit(expr.operand)
+        elif isinstance(expr, FunctionCall):
+            for arg in expr.args:
+                visit(arg)
+        elif isinstance(expr, IndexExpression):
+            if not isinstance(expr.base, Variable):
+                visit(expr.base)
+        elif isinstance(expr, SumExpression):
+            visit(expr.operand)
+        elif isinstance(expr, SumOverExpression):
+            for term in expr.terms:
+                visit(term)
+
+    if model._objective is not None:
+        visit(model._objective.expression)
+    for constraint in model._constraints:
+        visit(constraint.body)
+
+    return relaxations, var_map, bounds
+
+
 def _collect_univariate_relaxations(
     model: Model,
     n_orig: int,
@@ -2024,6 +2443,7 @@ def _linearize_expr(
     univariate_square_var_map: Optional[dict[tuple[int, int], int]] = None,
     flat_lb: Optional[np.ndarray] = None,
     flat_ub: Optional[np.ndarray] = None,
+    composite_var_map: Optional[dict[int, int]] = None,
 ) -> tuple[np.ndarray, float]:
     """Walk expression tree and return (coeff, constant) for linearized form.
 
@@ -2058,6 +2478,12 @@ def _linearize_expr(
         return None
 
     def visit(e: Expression, scale: float) -> None:  # noqa: C901
+        if composite_var_map is not None:
+            aux_col = composite_var_map.get(id(e))
+            if aux_col is not None:
+                coeff[aux_col] += scale
+                return
+
         if isinstance(e, Constant):
             const_acc[0] += scale * float(e.value)
 
@@ -2162,6 +2588,7 @@ def _linearize_expr(
                     fractional_power_var_map=fractional_power_var_map,
                     univariate_var_map=univariate_var_map,
                     monomial_var_map=monomial_var_map,
+                    composite_var_map=composite_var_map,
                 )
                 if decomp is None:
                     raise ValueError(f"Cannot decompose product: {e}")
@@ -2554,6 +2981,24 @@ def build_milp_relaxation(
         integrality_flags.append(0)
         col_idx += 1
 
+    # Single-variable composite nodes (sqrt-of-quadratic, affine-base power,
+    # exp-of-rational, …) whose curvature is certified sound on the node box.
+    _univariate_claimed_ids = {k for k in univariate_var_map if isinstance(k, int)}
+    composite_relaxations, composite_var_map, composite_bounds = (
+        _collect_composite_univariate_relaxations(
+            model,
+            n_orig,
+            flat_lb,
+            flat_ub,
+            col_idx,
+            _univariate_claimed_ids,
+        )
+    )
+    for val_bounds in composite_bounds:
+        all_bounds.append(val_bounds)
+        integrality_flags.append(0)
+        col_idx += 1
+
     univariate_square_relaxations, univariate_square_var_map, univariate_square_bounds = (
         _collect_univariate_square_relaxations(
             model,
@@ -2735,6 +3180,7 @@ def build_milp_relaxation(
         univariate_var_map,
         n_orig,
         monomial_var_map=monomial_var_map,
+        composite_var_map=composite_var_map,
     )
     for key in lifted_bilinear_keys:
         bilinear_var_map[key] = _ensure_bilinear_aux(*key)
@@ -3571,6 +4017,28 @@ def build_milp_relaxation(
                 intercept = _univariate_value(relax.func_name, pt) - slope * pt
                 _add_upper_line(relax, slope, intercept)
 
+    # ── Single-variable composite relaxations (certified curvature) ─────────
+    # z is the aux column for f(x_i); each (slope, intercept) line is in x_i.
+    # lower_lines give ``z ≥ slope·x_i + intercept`` and upper_lines give
+    # ``z ≤ slope·x_i + intercept``. A pinned variable yields an exact equality.
+    for crelax in composite_relaxations:
+        if crelax.pin_value is not None:
+            row = np.zeros(n_total)
+            row[crelax.aux_col] = 1.0
+            _add_row(row, crelax.pin_value)
+            _add_row(-row, -crelax.pin_value)
+            continue
+        for slope, intercept in crelax.lower_lines:
+            row = np.zeros(n_total)
+            row[crelax.var_idx] += slope
+            row[crelax.aux_col] = -1.0
+            _add_row(row, -intercept)
+        for slope, intercept in crelax.upper_lines:
+            row = np.zeros(n_total)
+            row[crelax.var_idx] += -slope
+            row[crelax.aux_col] = 1.0
+            _add_row(row, intercept)
+
     for table in finite_domain_trig_square_tables:
         base_col = table.square.base_col
         square_col = table.square.aux_col
@@ -3867,6 +4335,7 @@ def build_milp_relaxation(
                     univariate_square_var_map=univariate_square_var_map,
                     flat_lb=flat_lb,
                     flat_ub=flat_ub,
+                    composite_var_map=composite_var_map,
                 )
             except ValueError as err:
                 logger.debug(
@@ -3912,6 +4381,7 @@ def build_milp_relaxation(
                 univariate_square_var_map=univariate_square_var_map,
                 flat_lb=flat_lb,
                 flat_ub=flat_ub,
+                composite_var_map=composite_var_map,
             )
             # body ≤ 0  →  c @ z + const ≤ 0  →  c @ z ≤ -const
             if sense == "<=":
@@ -3979,6 +4449,7 @@ def build_milp_relaxation(
                 univariate_square_var_map=univariate_square_var_map,
                 flat_lb=flat_lb,
                 flat_ub=flat_ub,
+                composite_var_map=composite_var_map,
             )
         objective_bound_valid = True
     except ValueError as err:
@@ -4054,6 +4525,7 @@ def build_milp_relaxation(
             k: v for k, v in univariate_var_map.items() if not isinstance(k, int)
         },
         "univariate_relaxations": univariate_relaxations,
+        "composite_relaxations": composite_relaxations,
         "univariate_piecewise_relaxations": piecewise_univariate_relaxations,
         "univariate_square": univariate_square_var_map,
         "univariate_square_relaxations": univariate_square_relaxations,

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -272,9 +272,16 @@ def distribute_products(expr: Expression) -> Expression:
         right = distribute_products(expr.right)
         if expr.op == "*":
             return _distribute_mul(left, right)
+        # Preserve node identity when nothing distributed, so id()-keyed maps
+        # (e.g. composite/univariate aux columns) still match the rebuilt tree.
+        if left is expr.left and right is expr.right:
+            return expr
         return BinaryOp(expr.op, left, right)
     if isinstance(expr, UnaryOp):
-        return UnaryOp(expr.op, distribute_products(expr.operand))
+        operand = distribute_products(expr.operand)
+        if operand is expr.operand:
+            return expr
+        return UnaryOp(expr.op, operand)
     return expr
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1633,6 +1633,25 @@ def solve_model(
 
     model = reformulate_gdp(model, method=gdp_method)
 
+    # --- Factorable reformulation: clear sign-definite denominators and lift
+    # mixed repeated-factor products (e.g. x*x*y) into bilinear form via
+    # monomial aux variables, so terms the relaxation pipeline would otherwise
+    # drop to general_nl get a valid outer approximation (issue #130). The pass
+    # is value-preserving, but clearing a denominator (e.g. x**2/z, convex for
+    # z>0) or distributing a product can *destroy* convexity — so it is gated to
+    # provably-nonconvex models only, preserving the convex fast path for the
+    # rest. The cheap structural scan runs first so only models that actually
+    # have liftable terms pay for convexity detection.
+    from discopt._jax.factorable_reform import (
+        factorable_reformulate,
+        has_factorable_work,
+    )
+
+    if has_factorable_work(model):
+        _fr_ok, _fr_convex, _ = _classify_model_convexity(model)
+        if _fr_ok and not _fr_convex:
+            model = factorable_reformulate(model)
+
     # --- Build Rust model representation for FBBT ---
     _model_repr = None
     try:

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1383,8 +1383,15 @@ def test_negative_unbounded_x_exp_objective_keeps_no_bound(caplog):
     assert "falling back to a feasibility objective" in caplog.text
 
 
-def test_nested_univariate_objective_still_returns_no_relaxation_bound():
-    """Unsupported nested operator arguments should keep the safe no-bound behavior."""
+def test_nested_univariate_objective_gets_sound_composite_bound():
+    """A single-variable composite (sqrt of a quadratic) is now soundly relaxed.
+
+    ``sqrt(x**2 + 1)`` depends on one original variable but has non-affine internal
+    structure, so the named-function univariate path abstains. The composite
+    primitive certifies its convexity on the box and emits an outer envelope, so
+    the relaxation now produces a sound lower bound instead of no bound at all. The
+    true minimum is 1.0 (at x = 0); the bound must not exceed it.
+    """
     m = Model("nested_sqrt")
     x = m.continuous("x", lb=-2.0, ub=2.0)
     m.minimize(dm.sqrt(x**2 + 1.0))
@@ -1397,9 +1404,17 @@ def test_nested_univariate_objective_still_returns_no_relaxation_bound():
     )
     result = milp_model.solve()
 
+    # Not a named-function univariate relaxation; handled by the composite path.
     assert varmap["univariate_relaxations"] == []
+    composite = varmap["composite_relaxations"]
+    assert len(composite) == 1
+    assert composite[0].curvature == "convex"
+
     assert result.status == "optimal"
-    assert result.objective is None
+    assert result.objective is not None
+    # Sound lower bound: never above the true optimum of 1.0.
+    assert result.bound is not None
+    assert result.bound <= 1.0 + 1e-6
     assert result.x is not None
 
 

--- a/python/tests/test_factorable_reform.py
+++ b/python/tests/test_factorable_reform.py
@@ -1,0 +1,174 @@
+"""Tests for the factorable reformulation pass (issue #130).
+
+The pass rewrites two families of terms the relaxation pipeline cannot relax
+natively into terms it can:
+
+* sign-definite denominators ``N / D`` (``D`` bounded away from zero) are
+  cleared by multiplying the constraint through by ``D``;
+* mixed repeated-factor products such as ``x*x*y`` are lifted to bilinear form
+  via a monomial aux variable ``w == x**2``.
+
+Both rewrites are value-preserving, so the headline guard is that the raw
+``nvs01`` instance — exp/quadratic objective, a trilinear equality, and a
+division constraint — now certifies to its MINLPLib optimum with a *sound* dual
+bound where before the constraint was silently dropped from the relaxation.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+from discopt._jax.factorable_reform import factorable_reformulate
+from discopt._jax.term_classifier import classify_nonlinear_terms
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+
+def _aux_names(model):
+    return [v.name for v in model._variables if v.name.startswith("_fr_aux")]
+
+
+def test_noop_when_nothing_applies():
+    """A model with only bilinear/monomial terms is returned unchanged."""
+    m = dm.Model("plain")
+    x = m.continuous("x", lb=0, ub=10)
+    y = m.continuous("y", lb=0, ub=10)
+    m.minimize(x * y + x**2)
+    m.subject_to(x + y <= 5)
+    out = factorable_reformulate(m)
+    assert out is m  # same object, no rewrite performed
+
+
+def test_mixed_repeated_product_is_lifted_to_bilinear():
+    """``x*x*y`` is unrepresentable natively; the pass lifts ``x**2`` to an aux
+    so the product becomes a bilinear term the classifier accepts."""
+    m = dm.Model("mixed")
+    x = m.continuous("x", lb=0, ub=4)
+    y = m.continuous("y", lb=0, ub=4)
+    m.minimize(y)
+    m.subject_to(x * x * y >= 8)
+
+    # Before: the mixed product lands in general_nl (dropped by the relaxer).
+    pre = classify_nonlinear_terms(m)
+    assert pre.general_nl, "expected x*x*y to be unhandled before reformulation"
+
+    out = factorable_reformulate(m)
+    assert out is not m
+    assert len(_aux_names(out)) == 1
+
+    post = classify_nonlinear_terms(out)
+    # The lifted product is now a genuine bilinear term, and the aux defining
+    # equality contributes the x**2 monomial — nothing left in general_nl.
+    assert post.bilinear, "lifted product should be classified as bilinear"
+    assert (0, 2) in post.monomial  # w == x**2
+    assert not post.general_nl
+
+
+def _inequality_sense(model):
+    """The (single) non-equality constraint sense, as stored after discopt's
+    internal canonicalisation."""
+    senses = [c.sense for c in model._constraints if c.sense != "=="]
+    assert len(senses) == 1
+    return senses[0]
+
+
+def test_positive_denominator_cleared_sense_preserved():
+    """``N / (x**2 + c)`` with a strictly positive denominator is cleared and the
+    constraint sense is preserved (relative to discopt's stored form)."""
+    m = dm.Model("posdiv")
+    x = m.continuous("x", lb=0, ub=5)
+    y = m.continuous("y", lb=0, ub=5)
+    m.minimize(y)
+    m.subject_to((y + 1) / (x**2 + 1) - 2 >= 0)
+    orig_sense = _inequality_sense(m)
+
+    out = factorable_reformulate(m)
+    assert out is not m
+    # The division by a variable expression is gone; only the aux-defining
+    # equality and a polynomial body remain.
+    bodies = [repr(c.body) for c in out._constraints]
+    assert all("/ (" not in b and "/(" not in b for b in bodies)
+    # Positive denominator → sense unchanged from the stored original.
+    assert _inequality_sense(out) == orig_sense
+
+
+def test_negative_denominator_flips_sense():
+    """A strictly negative denominator flips the inequality sense on clearing."""
+    m = dm.Model("negdiv")
+    x = m.continuous("x", lb=1, ub=5)  # so -(x**2)-1 < 0 strictly
+    y = m.continuous("y", lb=0, ub=5)
+    m.minimize(y)
+    # denominator -(x**2) - 1 is in [-26, -2] < 0 over the box
+    m.subject_to((y + 1) / (-(x**2) - 1) <= 3)
+    orig_sense = _inequality_sense(m)
+
+    out = factorable_reformulate(m)
+    assert out is not m
+    flip = {"<=": ">=", ">=": "<="}
+    assert _inequality_sense(out) == flip[orig_sense]
+
+
+def test_grazing_denominator_not_cleared():
+    """A denominator whose interval includes zero is NOT sign-definite and must
+    be left untouched (no unsound multiply-through)."""
+    m = dm.Model("graze")
+    x = m.continuous("x", lb=-2, ub=2)  # x**2 - 1 spans [-1, 3], crosses zero
+    y = m.continuous("y", lb=0, ub=5)
+    m.minimize(y)
+    m.subject_to((y + 1) / (x**2 - 1) >= 1)
+    out = factorable_reformulate(m)
+    # No clearable denominator and no mixed product → unchanged.
+    assert out is m
+
+
+def test_transcendental_product_not_lifted():
+    """``sqrt(x) * y`` is not a pure polynomial product and must be left for the
+    native composite/general handling, not lifted."""
+    m = dm.Model("trans")
+    x = m.continuous("x", lb=1, ub=4)
+    y = m.continuous("y", lb=0, ub=4)
+    m.minimize(dm.sqrt(x) * y)
+    m.subject_to(x + y >= 3)
+    out = factorable_reformulate(m)
+    assert out is m
+
+
+@pytest.mark.correctness
+def test_lifted_model_preserves_optimum():
+    """The reformulated model is equivalent: solving it reaches the same
+    optimum as the hand-checked value of the original."""
+    m = dm.Model("equiv")
+    x = m.integer("x", lb=1, ub=5)
+    y = m.integer("y", lb=1, ub=5)
+    m.minimize(y)
+    # x*x*y >= 20 with x,y integer in [1,5]: minimum y is 1 (x=5 -> 25>=20).
+    m.subject_to(x * x * y >= 20)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r = m.solve(time_limit=60, gap_tolerance=1e-4)
+    assert r.status == "optimal"
+    assert r.objective == pytest.approx(1.0, abs=1e-4)
+    if r.bound is not None:
+        assert r.bound <= r.objective + 1e-4
+
+
+@pytest.mark.correctness
+@pytest.mark.slow
+def test_nvs01_certifies_with_sound_bound():
+    """Raw nvs01 (division + trilinear + composite objective) certifies to the
+    MINLPLib optimum 12.4697 with a valid dual bound (bound <= objective)."""
+    nl = _DATA / "nvs01.nl"
+    if not nl.exists():
+        pytest.skip("nvs01.nl not vendored")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r = dm.from_nl(str(nl)).solve(
+            time_limit=120, gap_tolerance=1e-4, max_nodes=2_000_000, subnlp_frequency=1
+        )
+    assert r.status == "optimal"
+    assert r.objective == pytest.approx(12.4697, abs=1e-2)
+    assert r.bound is not None
+    assert r.bound <= r.objective + 1e-4  # sound dual bound


### PR DESCRIPTION
## Summary

Closes #130 — the two affected-set instances that needed genuinely new
relaxation machinery (not one-line linearizer gaps) now both certify to their
MINLPLib optima with sound dual bounds.

| instance | gap | result |
|----------|-----|--------|
| `st_e04` | exp-of-rational equality + `(affine)**p` objective term | `status=optimal`, sound `bound <= objective` |
| `nvs01`  | non-constant division + mixed repeated-factor product (`x*x*y`) | `status=optimal`, `objective≈12.4697`, `bound <= objective`, 27 nodes |

## Gap A — `st_e04` (commit `bb17e63`)

Single-variable composite univariate relaxation: the binding equality
`x3 = exp(11.86 - 3950/(460+x2))` was omitted from every node relaxation,
letting the bound collapse to ≈1000. Adding a valid composite univariate
outer approximation lets the constraint participate, so the bound converges
to the reference optimum.

## Gap B — `nvs01` (commit `b10c1dd`)

A value-preserving **factorable reformulation** pass that rewrites two
families of terms the relaxation pipeline could not relax natively (and was
silently dropping to `general_nl`) into terms it can outer-approximate:

* **sign-definite denominators** `N/D` (with `D` provably bounded away from
  zero) are cleared by multiplying the constraint through by `D`, flipping the
  sense when `D` is strictly negative;
* **mixed repeated-factor products** such as `x*x*y` are lifted to bilinear
  form via monomial aux variables (`w == x**2`), so the product becomes `x*w`.

Both rewrites preserve the optimum but can **destroy convexity** (e.g.
`x**2/z` is convex for `z>0` but `x**2 - y*z` is not), so the pass is gated in
the solver to **provably-nonconvex models only**, behind a cheap structural
scan that runs before convexity detection. This preserves the convex fast
path for everything else.

## Acceptance (from #130)

- [x] `st_e04` reaches `status=optimal` with a sound dual bound.
- [x] `nvs01` reaches `status=optimal`, `objective≈12.4697`, `bound <= objective`.
- [x] No regression on the affected-set census (status column identical to baseline).
- [x] No regression on the soundness suite; convex fast path preserved
      (the `nlp_cvx_204_010` regression that the nonconvexity gate addresses passes).

## Tests

New `python/tests/test_factorable_reform.py` (8 tests): no-op, lifting,
sense preservation/flip, grazing-denominator soundness guard, transcendental
exclusion, optimum preservation, and the `nvs01` end-to-end certification.
`ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
