### PR TITLE
fix(soundness): verify simplex "infeasible" before fathoming + certify nvs08

### DIFF
--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -130,6 +130,24 @@ class MccormickLPRelaxer:
             milp._integrality = None
 
         res = milp.solve(time_limit=time_limit, backend=self._backend)
+
+        # Soundness guard: a floating-point simplex "infeasible" verdict is NOT
+        # a proof that the relaxed feasible set is empty. The spatial-B&B driver
+        # treats a relaxation "infeasible" as a RIGOROUS fathom (it prunes the
+        # node's whole subtree), so an unverified false-infeasible silently
+        # fathoms a *feasible* node and certifies a suboptimal incumbent — a
+        # false-optimal. The fast Rust simplex can be fooled here: a fractional
+        # power x**p with |p| large over a domain reaching toward 0 (e.g.
+        # x in [1e-3, 200], p=-3.5) lifts to an LP whose tangent slopes and aux
+        # bounds span >1e13, and the simplex reports it infeasible while HiGHS
+        # solves it correctly. Re-verify any non-HiGHS "infeasible" with HiGHS
+        # before trusting it; on disagreement adopt HiGHS's (valid) bound so the
+        # node branches instead of being wrongly pruned.
+        if res.status == "infeasible" and self._backend != "auto":
+            verify = milp.solve(time_limit=time_limit, backend="auto")
+            if verify.status != "infeasible":
+                res = verify
+
         if res.objective is None or res.x is None:
             return MccormickLPResult(status=res.status)
         x_orig = np.asarray(res.x)[: self._n_orig].copy()

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -50,6 +50,7 @@ from discopt._jax.term_classifier import (
     _compute_var_offset,
     _get_flat_index,
     distribute_products,
+    extract_reciprocal_power,
 )
 from discopt.modeling.core import (
     BinaryOp,
@@ -2523,6 +2524,23 @@ def _linearize_expr(
                 if isinstance(e.right, Constant):
                     visit(e.left, scale / float(e.right.value))
                 elif isinstance(e.left, Constant):
+                    # c / (x**p)  →  fractional-power aux column for x**-p
+                    # (e.g. 1/(x**3*sqrt(x)) → x**-3.5 in nvs08). Try this before
+                    # the reciprocal univariate path so a monomial-product
+                    # denominator is relaxed instead of dropped.
+                    fp_aux = None
+                    if fractional_power_var_map is not None:
+                        recip = extract_reciprocal_power(e, model)
+                        if recip is not None:
+                            fp_idx, fp_exp, fp_coeff = recip
+                            pinned = _pinned_value(fp_idx)
+                            if pinned is not None:
+                                const_acc[0] += scale * fp_coeff * (pinned**fp_exp)
+                                return
+                            fp_aux = fractional_power_var_map.get((fp_idx, float(fp_exp)))
+                            if fp_aux is not None:
+                                coeff[fp_aux] += scale * fp_coeff
+                                return
                     aux_col = univariate_var_map.get(id(e))
                     if aux_col is None:
                         try:

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -333,6 +333,68 @@ def _collect_extended_factors(
     return None
 
 
+def extract_single_var_power(expr: Expression, model: Model) -> tuple[int, float] | None:
+    """Recognize ``expr`` as ``x**p`` for a single flat-indexable variable ``x``.
+
+    Folds a product / power / ``sqrt`` tree over ONE variable into a single
+    ``(flat_idx, exponent)``: e.g. ``sqrt(x)`` → ``(idx, 0.5)``, ``x**3`` →
+    ``(idx, 3.0)``, ``x**3 * sqrt(x)`` → ``(idx, 3.5)``. Returns ``None`` for
+    anything else (multiple variables, constant scale factors, transcendental
+    calls, sums). Constant scale factors are intentionally rejected so callers
+    do not silently drop a coefficient.
+
+    This is what lets a reciprocal of a monomial product — ``1/(x**3 * sqrt(x))``
+    in nvs08 — be canonicalized to the fractional power ``x**-3.5`` and relaxed,
+    rather than dropped as a non-constant division.
+    """
+
+    def _visit(e: Expression) -> tuple[int, float] | None:
+        flat = _get_flat_index(e, model)
+        if flat is not None:
+            return (flat, 1.0)
+        if isinstance(e, FunctionCall) and e.func_name == "sqrt" and len(e.args) == 1:
+            inner = _visit(e.args[0])
+            if inner is not None:
+                return (inner[0], 0.5 * inner[1])
+            return None
+        if isinstance(e, BinaryOp) and e.op == "**" and isinstance(e.right, Constant):
+            inner = _visit(e.left)
+            if inner is not None:
+                return (inner[0], inner[1] * float(e.right.value))
+            return None
+        if isinstance(e, BinaryOp) and e.op == "*":
+            left = _visit(e.left)
+            right = _visit(e.right)
+            if left is not None and right is not None and left[0] == right[0]:
+                return (left[0], left[1] + right[1])
+            return None
+        return None
+
+    return _visit(expr)
+
+
+def extract_reciprocal_power(expr: Expression, model: Model) -> tuple[int, float, float] | None:
+    """Recognize ``expr`` as ``c / (x**p)`` → ``(flat_idx, -p, c)``.
+
+    Returns ``(flat_idx, exponent, coeff)`` such that ``expr == coeff *
+    x_flat_idx ** exponent`` with a negative ``exponent``, or ``None``. Only a
+    constant numerator over a single-variable power denominator is matched (the
+    ``1/(x**3 * sqrt(x))`` shape in nvs08); a non-constant numerator or a
+    multi-variable / scaled denominator returns ``None``.
+    """
+    if not (isinstance(expr, BinaryOp) and expr.op == "/"):
+        return None
+    if not isinstance(expr.left, Constant):
+        return None
+    denom = extract_single_var_power(expr.right, model)
+    if denom is None:
+        return None
+    flat_idx, exponent = denom
+    if exponent <= 0.0:
+        return None
+    return (flat_idx, -exponent, float(expr.left.value))
+
+
 # ---------------------------------------------------------------------------
 # Main classifier
 # ---------------------------------------------------------------------------
@@ -572,6 +634,15 @@ def _classify_nonlinear_terms_python(model: Model) -> NonlinearTerms:
                 # x / c where c is constant → linear scaling
                 if isinstance(expr.right, Constant):
                     _classify_node(expr.left)
+                    return
+                # c / (x**p)  →  fractional power x**-p (e.g. 1/(x**3*sqrt(x))
+                # in nvs08 → x**-3.5). Record it so the MILP relaxation lifts it
+                # to an aux column instead of dropping the whole constraint.
+                recip = extract_reciprocal_power(expr, model)
+                if recip is not None:
+                    flat_idx, neg_exp, _coeff = recip
+                    _record_fractional_power(flat_idx, neg_exp)
+                    result.general_nl.append(expr)
                     return
                 # c / x or x / y → general nonlinear
                 result.general_nl.append(expr)

--- a/python/tests/test_fp_relaxation_soundness.py
+++ b/python/tests/test_fp_relaxation_soundness.py
@@ -1,0 +1,71 @@
+"""Regression test for an unsound spatial-B&B fathom on a fractional-power model.
+
+Found while digging into ``nvs08`` certification. A fractional power ``x**p``
+with ``|p|`` large over a domain reaching toward 0 (here ``x0 in [1e-3, 200]``,
+``p=-3.5``) lifts to an LP-form McCormick relaxation whose tangent slopes and
+aux-column bounds span more than 1e13. The fast Rust ``simplex`` backend reports
+that ill-conditioned relaxation **infeasible**, while HiGHS solves it correctly.
+
+The spatial-B&B driver treats a relaxation ``infeasible`` as a *rigorous fathom*
+(it prunes the node's whole subtree). So the unverified false-infeasible silently
+fathomed a feasible node and certified a suboptimal incumbent with a dual bound
+far ABOVE the true optimum — a false-optimal:
+
+    before:  optimal 2320.87   (bound 2320.87 >> true optimum 21.56)
+    after:   optimal 21.5551   (bound 21.5544 <= obj, sound)
+
+The fix (``MccormickLPRelaxer.solve_at_node``): a floating-point simplex
+"infeasible" verdict is not a proof of an empty relaxed feasible set, so it is
+re-verified with HiGHS before it is allowed to fathom a node.
+
+True optimum (brute force over integer ``x2``; for each, the binding constraint
+``x0**-3.5 <= x2**2`` fixes ``x0 = (x2**2)**(-1/3.5)``):
+
+    x2=3, x0=0.533776  ->  obj = (x0+4)**2 + (x2-2)**2 = 21.555127   (minimum)
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+import pytest
+
+# Global optimum, brute-forced and independently verified.
+_OPT = 21.555127
+_OPT_X0 = 0.533776
+_OPT_X2 = 3.0
+
+
+def _build():
+    m = dm.Model("fp_soundness")
+    x0 = m.continuous("x0", lb=0.001, ub=200.0)
+    x2 = m.integer("x2", lb=0, ub=200)
+    m.minimize((x0 + 4) ** 2 + (x2 - 2) ** 2)
+    m.subject_to(x0 ** (-3.5) - x2**2 <= 0)  # x0^-3.5 <= x2^2
+    return m
+
+
+@pytest.mark.correctness
+def test_fp_node_lp_no_false_optimal():
+    """The fractional-power model must not certify a dual bound above the optimum.
+
+    The headline soundness invariant: a valid dual (lower) bound never exceeds
+    the true optimum. The pre-fix solver reported bound 2320.87 >> 21.56.
+    """
+    r = _build().solve(time_limit=30, gap_tolerance=1e-4)
+    if r.bound is not None:
+        assert r.bound <= _OPT + 1e-2, f"invalid dual bound {r.bound} > true optimum {_OPT}"
+
+
+@pytest.mark.correctness
+def test_fp_certifies_true_optimum():
+    """The model certifies its true optimum with a valid dual bound."""
+    r = _build().solve(time_limit=30, gap_tolerance=1e-4)
+    assert r.status == "optimal", f"status={r.status}"
+    assert r.objective is not None
+    assert abs(r.objective - _OPT) <= 1e-2, f"obj={r.objective} != {_OPT}"
+    # Soundness invariant: dual bound never exceeds the optimum.
+    if r.bound is not None:
+        assert r.bound <= r.objective + 1e-4, f"invalid dual bound {r.bound} > obj {r.objective}"

--- a/python/tests/test_nvs08_certification.py
+++ b/python/tests/test_nvs08_certification.py
@@ -1,0 +1,50 @@
+"""Regression test: nvs08 certifies via reciprocal-power canonicalization.
+
+nvs08 (MINLPLib, optimum ≈ 23.4497) has the constraint factor
+``1/(x0**3 * sqrt(x0))``. Previously the MILP relaxation could not linearize
+the non-constant division, so it *dropped the whole constraint* and the solve
+returned ``feasible`` with no dual bound (``bound=None``) — it found the optimum
+but could not certify it.
+
+The fix canonicalizes ``1/(x0**3 * sqrt(x0))`` to the fractional power
+``x0**-3.5`` (``term_classifier.extract_reciprocal_power``) so the existing
+fractional-power relaxation lifts it to an aux column. The constraint also
+couples that fractional power with the integer monomial ``x2**2`` over wide
+bounds — the exact shape that, before the companion soundness fix, made the
+fast simplex falsely report the node LP infeasible. Both fixes together let
+nvs08 certify soundly.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+_NL = Path(__file__).parent / "data" / "minlplib" / "nvs08.nl"
+_OPT = 23.4497
+
+
+def test_nvs08_reciprocal_classified_as_fractional_power():
+    """1/(x0**3*sqrt(x0)) is recognized as the fractional power x0**-3.5."""
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    assert _NL.exists(), f"missing {_NL}"
+    terms = classify_nonlinear_terms(dm.from_nl(str(_NL)))
+    assert (0, -3.5) in terms.fractional_power
+
+
+@pytest.mark.correctness
+def test_nvs08_certifies_to_optimum():
+    """nvs08 certifies its MINLPLib optimum with a valid dual bound."""
+    r = dm.from_nl(str(_NL)).solve(time_limit=120, gap_tolerance=1e-4)
+    assert r.status == "optimal", f"status={r.status} (was 'feasible' before the fix)"
+    assert r.objective is not None
+    assert abs(r.objective - _OPT) <= 1e-2, f"obj={r.objective} != {_OPT}"
+    # Soundness invariant: a valid dual bound never exceeds the optimum.
+    assert r.bound is not None, "certified solve must report a dual bound"
+    assert r.bound <= r.objective + 1e-3, f"invalid dual bound {r.bound} > obj {r.objective}"

--- a/python/tests/test_reciprocal_power_recognition.py
+++ b/python/tests/test_reciprocal_power_recognition.py
@@ -1,0 +1,80 @@
+"""Unit tests for single-variable power / reciprocal-power canonicalization.
+
+These back the nvs08 fix: ``term_classifier.extract_single_var_power`` folds a
+product/power/sqrt tree over one variable into ``(flat_idx, exponent)``, and
+``extract_reciprocal_power`` turns ``c/(x**p)`` into ``(flat_idx, -p, c)`` so a
+reciprocal of a monomial product is relaxed as a fractional power rather than
+dropped.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+from discopt._jax.term_classifier import extract_reciprocal_power, extract_single_var_power
+
+
+def _model_one_var():
+    m = dm.Model("m")
+    x = m.continuous("x", lb=0.1, ub=10.0)
+    return m, x
+
+
+def test_bare_variable_is_power_one():
+    m, x = _model_one_var()
+    assert extract_single_var_power(x, m) == (0, 1.0)
+
+
+def test_sqrt_is_half_power():
+    m, x = _model_one_var()
+    assert extract_single_var_power(dm.sqrt(x), m) == (0, 0.5)
+
+
+def test_integer_power():
+    m, x = _model_one_var()
+    assert extract_single_var_power(x**3, m) == (0, 3.0)
+
+
+def test_product_of_powers_same_var():
+    m, x = _model_one_var()
+    # x**3 * sqrt(x) == x**3.5
+    assert extract_single_var_power(x**3 * dm.sqrt(x), m) == (0, 3.5)
+
+
+def test_nested_power_of_sqrt():
+    m, x = _model_one_var()
+    # sqrt(x)**3 == x**1.5
+    assert extract_single_var_power(dm.sqrt(x) ** 3, m) == (0, 1.5)
+
+
+def test_multi_variable_product_rejected():
+    m = dm.Model("m")
+    x = m.continuous("x", lb=0.1, ub=10.0)
+    y = m.continuous("y", lb=0.1, ub=10.0)
+    assert extract_single_var_power(x * y, m) is None
+
+
+def test_reciprocal_of_monomial_product():
+    m, x = _model_one_var()
+    # 1/(x**3 * sqrt(x)) == x**-3.5  (the nvs08 shape)
+    assert extract_reciprocal_power(1 / (x**3 * dm.sqrt(x)), m) == (0, -3.5, 1.0)
+
+
+def test_reciprocal_constant_numerator_scale():
+    m, x = _model_one_var()
+    assert extract_reciprocal_power(5 / (x**2), m) == (0, -2.0, 5.0)
+
+
+def test_non_reciprocal_returns_none():
+    m, x = _model_one_var()
+    assert extract_reciprocal_power(x**2, m) is None
+
+
+def test_reciprocal_non_constant_numerator_rejected():
+    m = dm.Model("m")
+    x = m.continuous("x", lb=0.1, ub=10.0)
+    y = m.continuous("y", lb=0.1, ub=10.0)
+    # y / x**2 — non-constant numerator is not a pure fractional power.
+    assert extract_reciprocal_power(y / (x**2), m) is None


### PR DESCRIPTION
## Summary

Two coupled changes that came out of digging into `nvs08` certification:

1. **Soundness fix** — eliminate a false-optimal on the spatial branch-and-bound.
2. **nvs08 certification** — canonicalize `1/(x**a·sqrt(x))` to a fractional
   power so the constraint is relaxed instead of dropped.

`nvs08` (MINLPLib optimum **23.4497**) went from `feasible` (no dual bound) to
`optimal 23.4497, bound 23.4494` — certified soundly.

## 1. Soundness: verify a simplex "infeasible" before fathoming a node

A floating-point simplex `infeasible` verdict is **not a proof** that the LP-form
McCormick relaxation's feasible set is empty. The spatial-B&B driver treats a
relaxation `infeasible` as a **rigorous fathom** (`solver.py:2628`), so an
unverified false-infeasible silently prunes a *feasible* node's subtree and
certifies a suboptimal incumbent with a dual bound **above** the true optimum.

```python
m.minimize((x0 + 4) ** 2 + (x2 - 2) ** 2)        # x0 in [1e-3, 200] cont
m.subject_to(x0 ** (-3.5) - x2 ** 2 <= 0)        # x2 in [0, 200] int
# before:  optimal 2320.87   (bound 2320.87 >> true optimum 21.56)  <-- false-optimal
# after:   optimal 21.5551    (bound 21.5544 <= obj, sound)
```

A fractional power `x**p` with `|p|` large over a domain reaching toward 0 lifts
to an LP whose tangent slopes and aux bounds span **>1e13** (tangent at `x0=1e-3`
has slope `≈ -1.1e14`). The fast Rust `simplex` backend reports it infeasible;
HiGHS solves it (`-379.99`).

**Fix** (`MccormickLPRelaxer.solve_at_node`): re-verify any non-HiGHS
`infeasible` with HiGHS before trusting it. On disagreement, adopt HiGHS's valid
bound so the node branches; when HiGHS agrees, the fathom stands on two
independent solvers. The re-solve only fires on an `infeasible` verdict from the
fast backend. A node we cannot prove infeasible is kept open (gap decertified),
never pruned.

## 2. nvs08: reciprocal-of-monomial-product → fractional power

`nvs08` has `1/(x0**3 * sqrt(x0))` in a constraint. The relaxation could not
linearize the non-constant division, so it dropped the whole constraint →
`feasible`, `bound=None`. Recognize it as the equivalent fractional power and
lift it to the existing fractional-power aux column:

```
1/(x0**3 * sqrt(x0))  ==  x0**-3.5
```

- `term_classifier.extract_single_var_power` folds a product/power/sqrt tree over
  ONE variable into `(flat_idx, exponent)`; `extract_reciprocal_power` turns
  `c/(x**p)` into `(flat_idx, -p, c)`. Multi-variable / non-constant numerators
  and constant scale factors are rejected, so no coefficient is silently dropped.
- The classifier records the fractional power; the linearizer maps the division
  onto the fp aux column.

This depends on change (1): nvs08's constraint couples `x0**-3.5` with the
integer monomial `x2**2` over wide bounds — the exact shape that otherwise
false-infeasibles.

## Tests

- `test_fp_relaxation_soundness.py` — dual bound never exceeds the true optimum;
  certifies to 21.5551.
- `test_nvs08_certification.py` — classification + sound certification to 23.4497.
- `test_reciprocal_power_recognition.py` — helper units (sqrt/power/product
  folding, reciprocal recognition, rejection of multi-var / non-constant cases).
- Bilinear certification (`min u+v s.t. u*v>=5` → `2√5`) still certifies.
- Green: McCormick / multivariate / piecewise / nvs16 / batch-sentinel /
  p1-milp-bb / nlp-bb soundness suites, relaxation suites, GP / posynomial,
  MINLPLib correctness benchmark, and the full `-m smoke` set. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
