### PR TITLE
fix(soundness): normalize cleared constraints to kill small-denominator false-optimal

### DIFF
--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -315,6 +315,25 @@ def has_factorable_work(model: Model) -> bool:
     return any(isinstance(c, Constraint) and scan(c.body) for c in model._constraints)
 
 
+def has_clearable_denominator(model: Model) -> bool:
+    """True if any constraint has a sign-definite, non-constant denominator that
+    denominator clearing would rewrite.
+
+    Distinct from :func:`has_factorable_work`, which also fires on mixed
+    repeated-factor products.  The solver uses this to decide whether a
+    *convex* model is worth clearing: a non-constant division drops to
+    ``general_nl`` and so cannot be bounded by the relaxation (no dual bound, no
+    certification), and clearing a sign-definite denominator is exact — so it is
+    a strict improvement for such models, unlike the mixed-product lift which can
+    only destroy convexity.  Objective ratios are excluded: clearing multiplies a
+    *constraint* through by its denominator and has no analogue for an objective.
+    """
+    return any(
+        isinstance(c, Constraint) and _find_clearable_denominator(c.body, model) is not None
+        for c in model._constraints
+    )
+
+
 def _scan_for_mixed_product(expr: Expression, model: Model) -> bool:
     if isinstance(expr, BinaryOp):
         if expr.op == "*":
@@ -331,13 +350,20 @@ def _scan_for_mixed_product(expr: Expression, model: Model) -> bool:
     return False
 
 
-def factorable_reformulate(model: Model) -> Model:
+def factorable_reformulate(model: Model, *, clear_only: bool = False) -> Model:
     """Return a model equivalent to *model* with sign-definite denominators
     cleared and mixed repeated-factor products lifted to bilinear form.
 
     If neither rewrite applies, *model* is returned unchanged.  On any
     unexpected error the original model is returned, so the pass can never make
     a previously-solvable model unsolvable.
+
+    ``clear_only`` restricts the pass to denominator clearing and skips the
+    mixed repeated-factor product lift entirely.  The lift distributes products
+    and introduces ``w == x**k`` aux variables, which destroys convex structure
+    even where it was unnecessary; clearing alone is the right rewrite for a
+    *convex* model that merely needs its non-constant division exposed to the
+    relaxation (see ``has_clearable_denominator``).
     """
     try:
         if not has_factorable_work(model):
@@ -356,6 +382,15 @@ def factorable_reformulate(model: Model) -> Model:
                 rebuilt.append(c)  # pass through anything exotic untouched
                 continue
             body, sense = _clear_divisions(c.body, c.sense, new_model)
+            if clear_only:
+                # Only touch constraints the clearing actually rewrote; leave
+                # everything else byte-for-byte identical so convex structure
+                # elsewhere is preserved.
+                if body is c.body and sense == c.sense:
+                    rebuilt.append(c)
+                else:
+                    rebuilt.append(Constraint(distribute_products(body), sense, c.rhs, c.name))
+                continue
             body = distribute_products(body)
             body = _lift_expr(body, new_model, lifter)
             if body is c.body and sense == c.sense:
@@ -365,7 +400,7 @@ def factorable_reformulate(model: Model) -> Model:
 
         # Lift the objective too (it may contain a mixed product); division
         # clearing is meaningless for an objective so only the lift applies.
-        if new_model._objective is not None:
+        if not clear_only and new_model._objective is not None:
             obj_expr = distribute_products(new_model._objective.expression)
             lifted_obj = _lift_expr(obj_expr, new_model, lifter)
             if lifted_obj is not new_model._objective.expression:

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -215,8 +215,8 @@ def _lift_expr(expr: Expression, model: Model, lifter: _Lifter) -> Expression:
 def _find_clearable_denominator(expr: Expression, model: Model):
     """Return the denominator ``D`` of the first division term ``N/D`` in
     *expr*'s additive structure whose ``D`` is non-constant and sign-definite
-    over the variable box, together with its sign (+1 or -1).  ``None`` if no
-    such division exists."""
+    over the variable box, as ``(D, sign, dmin)`` where ``sign`` is +1/-1 and
+    ``dmin = min |D|`` over the box.  ``None`` if no such division exists."""
     if isinstance(expr, BinaryOp):
         if expr.op in ("+", "-"):
             found = _find_clearable_denominator(expr.left, model)
@@ -228,9 +228,9 @@ def _find_clearable_denominator(expr: Expression, model: Model):
             if not isinstance(d, Constant):
                 lo, hi = _bound_expression(d, model)
                 if lo > _ZERO_MARGIN:
-                    return d, 1
+                    return d, 1, lo
                 if hi < -_ZERO_MARGIN:
-                    return d, -1
+                    return d, -1, -hi
             # Search the numerator for a nested division.
             return _find_clearable_denominator(expr.left, model)
     if isinstance(expr, UnaryOp) and expr.op == "neg":
@@ -263,15 +263,34 @@ _FLIP = {"<=": ">=", ">=": "<=", "==": "=="}
 
 def _clear_divisions(body: Expression, sense: str, model: Model):
     """Clear every sign-definite denominator from a constraint ``body sense 0``.
-    Returns ``(new_body, new_sense)``."""
+    Returns ``(new_body, new_sense)``.
+
+    Multiplying a constraint through by a denominator ``D`` rescales it by
+    ``D(x)``.  When ``|D|`` can be < 1 over the box, a *gross* violation of the
+    original constraint shrinks proportionally in the cleared form — e.g.
+    clearing ``6 - x0 + 0.2458 x0**2/x1 <= 0`` by ``x1 in [1e-5, 30]`` turns a
+    violation of 6.0 into ``6.0 * x1 ~ 6e-5``, which then slips *under* the
+    absolute incumbent-feasibility tolerance (1e-4).  The spatial-B&B would then
+    accept an infeasible point as a feasible incumbent and certify it — a
+    false-optimal.  To keep the fixed absolute tolerance sound, divide the
+    cleared body by ``dmin = min |D|`` so the scaled magnitude is never *smaller*
+    than the original (``|D(x)| / dmin >= 1`` everywhere in the box).  This is
+    exact (division by a positive constant preserves the feasible set) and only
+    ever makes the feasibility test stricter, never looser.
+    """
+    scale = 1.0
     for _ in range(8):  # bounded: each pass clears one denominator family
         found = _find_clearable_denominator(body, model)
         if found is None:
             break
-        denom, sign = found
+        denom, sign, dmin = found
         body = _multiply_through(body, denom)
         if sign < 0:
             sense = _FLIP[sense]
+        if dmin < 1.0:
+            scale /= dmin
+    if scale != 1.0:
+        body = BinaryOp("*", Constant(scale), body)
     return body, sense
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1651,6 +1651,12 @@ def solve_model(
         _fr_ok, _fr_convex, _ = _classify_model_convexity(model)
         if _fr_ok and not _fr_convex:
             model = factorable_reformulate(model)
+        # A *convex* model with a clearable denominator is deliberately left
+        # untouched here: many such divisions (e.g. the rotated-SOC ``x**2/z``)
+        # are solved exactly by the convex NLP fast path, and clearing would
+        # needlessly destroy that structure. Only if the convex NLP later *fails*
+        # to certify do we clear and fall back to spatial B&B (see the convex
+        # fast-path block below).
 
     # --- Build Rust model representation for FBBT ---
     _model_repr = None
@@ -1958,7 +1964,41 @@ def solve_model(
             initial_point=initial_point,
         )
         result.convex_fast_path = True
-        return result
+        if result.status == "optimal":
+            return result
+        # The convex NLP did not certify (e.g. an ill-conditioned division whose
+        # denominator reaches toward zero, like st_e17's 0.2458*x0**2/x1 with
+        # x1 down to 1e-5). If the model has a sign-definite non-constant
+        # denominator — which the relaxation otherwise drops to general_nl —
+        # clear it (exact, value-preserving) and fall back to the sound spatial
+        # B&B, which can certify it. Only clearing is applied (no
+        # convexity-destroying mixed-product lift). When nothing is clearable,
+        # return the NLP result unchanged (no regression).
+        from discopt._jax.factorable_reform import has_clearable_denominator
+
+        if has_clearable_denominator(model):
+            cleared = factorable_reformulate(model, clear_only=True)
+            if cleared is not model:
+                logger.info(
+                    "Convex NLP did not certify (status=%s); clearing sign-definite "
+                    "denominator and retrying via spatial B&B",
+                    result.status,
+                )
+                model = cleared
+                _pure_continuous_is_convex = False
+                _root_is_convex = False
+                _root_constraint_mask = None  # stale: cleared constraint is nonconvex
+                try:
+                    from discopt._rust import model_to_repr
+
+                    _model_repr = model_to_repr(model, getattr(model, "_builder", None))
+                except Exception:
+                    _model_repr = None
+                # Fall through to the spatial B&B below (rebuilt from `model`).
+            else:
+                return result
+        else:
+            return result
 
     # --- Pure continuous: solve directly only when spatial search was not requested ---
     if (

--- a/python/tests/test_division_clearing_scale_soundness.py
+++ b/python/tests/test_division_clearing_scale_soundness.py
@@ -1,0 +1,137 @@
+"""Regression test: denominator clearing must not shrink violations below tol.
+
+Sign-definite denominator clearing (issue #130) multiplies a constraint
+``N/D sense 0`` through by ``D`` to expose a polynomial the relaxation can
+bound.  Multiplying rescales the constraint by ``D(x)``, so when ``|D|`` can be
+small over the box, a *gross* violation of the original constraint shrinks
+proportionally in the cleared form.
+
+Concretely, clearing ``6 - (x0 - 0.2458 x0**2 / x1) <= 0`` by ``x1 in
+[1e-5, 30]`` turns an original violation of ``6.0`` into ``6.0 * x1 ~ 6.3e-5`` —
+which slips *under* the absolute incumbent-feasibility tolerance (1e-4).  The
+spatial-B&B then accepts a wildly infeasible near-origin point as a feasible
+incumbent and certifies it: a false-optimal.
+
+    before:  optimal 0.000311   (point x0~4e-6, x1~1e-5 violates the original
+                                 constraint by ~6.0 — infeasible)
+    after:   optimal 376.29     (the true optimum, valid dual bound)
+
+The fix (``factorable_reform._clear_divisions``): divide the cleared body by
+``dmin = min |D|`` so its magnitude is never smaller than the original, keeping
+the fixed absolute feasibility tolerance sound.
+
+st_e17 itself is classified convex (so production gates clearing off and never
+hit this), but the bug is *not* about convexity — any nonconvex model with a
+clearable small denominator triggers it on the production solve path.  The first
+test reproduces exactly that.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+import pytest
+
+# Brute-forced true optimum of the st_e17 ratio constraint (verified
+# independently): min 29.4 x0 + 18 x1 s.t. x0 - 0.2458 x0**2/x1 >= 6.
+_OPT = 376.291932
+_OPT_X0 = 8.17003
+_OPT_X1 = 7.56073
+
+
+def _st_e17_core():
+    """The st_e17 feasible region: a single ratio constraint, linear objective."""
+    m = dm.Model("st_e17_core")
+    x0 = m.continuous("x0", lb=0.0, ub=115.8)
+    x1 = m.continuous("x1", lb=1e-5, ub=30.0)
+    m.minimize(29.4 * x0 + 18 * x1)
+    m.subject_to(6 - (x0 - 0.2458 * x0**2 / x1) <= 0)
+    return m
+
+
+@pytest.mark.correctness
+def test_nonconvex_small_denominator_no_false_optimal():
+    """A nonconvex model with a clearable small denominator must not false-optimize.
+
+    Adds a bilinear constraint so the model is provably nonconvex — that routes
+    it through the production denominator-clearing path (gated to nonconvex
+    models), which is where the pre-fix false-optimal fired.
+    """
+    m = _st_e17_core()
+    # Bilinear term -> nonconvex -> production applies denominator clearing.
+    m.subject_to(m._variables[0] * m._variables[1] <= 2000)
+
+    r = m.solve(time_limit=60, gap_tolerance=1e-4)
+
+    # The headline soundness invariant: no dual bound below the true optimum may
+    # be paired with a near-zero incumbent.  Pre-fix this certified obj ~ 3e-4.
+    assert r.objective is not None
+    assert r.objective >= _OPT - 1.0, (
+        f"false-optimal: certified obj {r.objective} << true optimum {_OPT}"
+    )
+    # Valid dual bound never exceeds the incumbent.
+    if r.bound is not None:
+        assert r.bound <= r.objective + 1e-3, f"invalid dual bound {r.bound} > obj {r.objective}"
+
+
+@pytest.mark.correctness
+def test_cleared_constraint_certifies_true_optimum():
+    """Forcing the reformulation certifies the true optimum with a valid bound."""
+    from discopt._jax.factorable_reform import factorable_reformulate
+
+    m = factorable_reformulate(_st_e17_core())
+    r = m.solve(time_limit=60, gap_tolerance=1e-4)
+    assert r.status == "optimal", f"status={r.status}"
+    assert r.objective is not None
+    assert abs(r.objective - _OPT) <= 1e-1, f"obj={r.objective} != {_OPT}"
+    # Soundness invariant: dual bound never exceeds the optimum.
+    assert r.bound is not None, "certified solve must report a dual bound"
+    assert r.bound <= r.objective + 1e-2, f"invalid dual bound {r.bound} > obj {r.objective}"
+
+
+def test_returned_point_satisfies_original_constraint():
+    """The certified incumbent must satisfy the *original* ratio constraint.
+
+    Directly guards the failure mode: the pre-fix solver returned a point that
+    satisfied the *cleared* constraint within tolerance but violated the
+    original division constraint by ~6.0.
+    """
+    from discopt._jax.factorable_reform import factorable_reformulate
+
+    r = factorable_reformulate(_st_e17_core()).solve(time_limit=60, gap_tolerance=1e-4)
+    assert r.x is not None
+    x0 = float(r.x["x0"])
+    x1 = float(r.x["x1"])
+    # Original constraint: 6 - (x0 - 0.2458 x0**2/x1) <= 0.
+    orig = 6 - (x0 - 0.2458 * x0**2 / x1)
+    assert orig <= 1e-4, f"certified point violates original constraint: body={orig}"
+
+
+def test_large_denominator_clearing_unchanged():
+    """A denominator with ``min|D| >= 1`` is cleared without rescaling.
+
+    The scale guard must only engage for sub-unit denominators so models that
+    already certify (gear family, nvs: ``D`` a product of vars with ``lb >= 1``)
+    are untouched.
+    """
+    from discopt._jax.factorable_reform import _clear_divisions
+
+    m = dm.Model("big_denom")
+    x0 = m.continuous("x0", lb=2.0, ub=10.0)
+    x1 = m.continuous("x1", lb=3.0, ub=10.0)
+    # denom = x0*x1 in [6, 100] -> dmin = 6 >= 1 -> no rescale.
+    con_body = (5 / (x0 * x1)) - 1
+    new_body, sense = _clear_divisions(con_body, "<=", m)
+    # No leading constant-scale wrapper: the top node is the multiply-through,
+    # not a ``Constant(1/dmin) * (...)``.
+    from discopt.modeling.core import BinaryOp, Constant
+
+    is_scaled = (
+        isinstance(new_body, BinaryOp)
+        and new_body.op == "*"
+        and isinstance(new_body.left, Constant)
+        and float(new_body.left.value) != 1.0
+    )
+    assert not is_scaled, "large denominator (dmin>=1) must not be rescaled"

--- a/python/tests/test_st_e17_certification.py
+++ b/python/tests/test_st_e17_certification.py
@@ -1,0 +1,63 @@
+"""Regression test: st_e17 certifies via convex-NLP-failure -> clear -> spatial B&B.
+
+st_e17 (MINLPLib) is convex — ``min 29.4 x0 + 18 x1`` s.t.
+``6 - (x0 - 0.2458 x0**2 / x1) <= 0`` with ``x1 in [1e-5, 30]`` (a
+quadratic-over-linear / rotated-SOC constraint). It is therefore routed to the
+convex NLP fast path, but the NLP fails to converge: the ``x0**2 / x1`` term is
+badly conditioned as ``x1`` reaches toward its 1e-5 lower bound, so the solver
+returns a non-certified iterate (status ``iteration_limit``) far from the
+optimum.
+
+The solver now treats that as a signal: when the convex NLP does not certify and
+the model has a sign-definite non-constant denominator (which the relaxation
+otherwise drops to ``general_nl``), it clears the denominator — exact and
+value-preserving — and falls back to the sound spatial B&B, which certifies it:
+
+    before:  iteration_limit, obj ~ 203.96, bound None   (uncertified)
+    after:   optimal 376.29, bound 376.28                (certified)
+
+Convex models whose division the NLP *can* handle (e.g. the rotated SOC
+``x**2/z <= y`` in ``nlp_cvx_204``) are unaffected — they certify on the fast
+path and are never cleared. The companion scale guard in
+``factorable_reform._clear_divisions`` keeps the cleared constraint sound under
+the small ``x1`` denominator.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+_NL = Path(__file__).parent / "data" / "minlplib" / "st_e17.nl"
+# Brute-forced true optimum (independently verified):
+#   min 29.4 x0 + 18 x1 s.t. x0 - 0.2458 x0**2/x1 >= 6.
+_OPT = 376.291932
+
+
+@pytest.mark.correctness
+def test_st_e17_certifies_to_optimum():
+    """st_e17 certifies its true optimum with a valid dual bound."""
+    assert _NL.exists(), f"missing {_NL}"
+    r = dm.from_nl(str(_NL)).solve(time_limit=90, gap_tolerance=1e-4)
+    assert r.status == "optimal", f"status={r.status} (was 'iteration_limit' before the fix)"
+    assert r.objective is not None
+    assert abs(r.objective - _OPT) <= 1e-1, f"obj={r.objective} != {_OPT}"
+    # Soundness invariant: a valid dual bound never exceeds the optimum.
+    assert r.bound is not None, "certified solve must report a dual bound"
+    assert r.bound <= r.objective + 1e-2, f"invalid dual bound {r.bound} > obj {r.objective}"
+
+
+def test_st_e17_returned_point_is_feasible():
+    """The certified incumbent satisfies the original ratio constraint."""
+    r = dm.from_nl(str(_NL)).solve(time_limit=90, gap_tolerance=1e-4)
+    assert r.x is not None
+    x0 = float(r.x["x0"])
+    x1 = float(r.x["x1"])
+    # Original constraint: 6 - (x0 - 0.2458 x0**2/x1) <= 0.
+    body = 6 - (x0 - 0.2458 * x0**2 / x1)
+    assert body <= 1e-4, f"certified point violates original constraint: body={body}"


### PR DESCRIPTION
## Summary

Two soundness/certification fixes in the issue-#130 sign-definite denominator-clearing path.

### 1. Kill the small-denominator false-optimal (commit `877be06`)

Clearing a constraint `N/D <= rhs` by multiplying through by a sign-definite
denominator `D(x)` is exact, but it **rescales the constraint residual by `D(x)`**.
When `|D|` can be `< 1` over the box, a gross original violation shrinks
proportionally in the cleared form and slips under the absolute incumbent-feasibility
tolerance (`1e-4`). The spatial B&B then accepts an infeasible point as a feasible
incumbent and certifies a **false optimum** (reproduced on st_e17's core: returned
`x0=4e-6, x1=1e-5`, obj `0.0003`, violating the original constraint by ~6.0).

**Fix:** normalize the cleared body by `dmin = min|D|` over the box when `dmin < 1`,
so `|D(x)|/dmin >= 1` everywhere — the scaled residual is never smaller than the
original, keeping abs-tol feasibility sound. Division by a positive constant is
exact; it only ever makes feasibility **stricter**, never looser.

### 2. Certify st_e17 via convex-NLP-failure → clear → spatial B&B (commit `909524a`)

st_e17 is convex (`6 - (x0 - 0.2458 x0**2/x1) <= 0`, rotated-SOC) so it routes to
the convex NLP fast path — but the NLP fails to converge (the `x0**2/x1` term is
badly conditioned as `x1 -> 1e-5`), returning an uncertified iterate.

**Fix:** make denominator-clearing a **fallback**, not a pre-emption. The convex
fast path runs unchanged; only when it returns a non-`optimal` status *and* the
model has a sign-definite non-constant denominator does the solver clear
(`clear_only=True`), mark the model nonconvex, and fall through to the sound
spatial B&B — which certifies it.

    before:  iteration_limit, obj ~ 203.96, bound None   (uncertified)
    after:   optimal 376.29, bound 376.28                (certified)

Convex models whose division the NLP *can* handle (e.g. the rotated SOC `x**2/z <= y`
in `nlp_cvx_204`) certify on the fast path and are never cleared — no regression.

## Tests

- `test_division_clearing_scale_soundness.py` — 4 tests: nonconvex false-optimal
  guard, forced-reform certification, original-constraint feasibility of the
  returned point, and large-denominator (`dmin >= 1`) no-op.
- `test_st_e17_certification.py` — 2 tests: production solve certifies the true
  optimum (376.29) with a valid dual bound, and the returned incumbent satisfies
  the original ratio constraint.
- Full default suite green (3318 passed); convex-fast-path suite green (45);
  division models nvs01, gear/gear2/gear3, nvs06 still certify to reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
