### PR TITLE
test(quotient): lock sound variable/variable ratio certification (#138)

### DIFF
--- a/python/tests/test_quotient_certification.py
+++ b/python/tests/test_quotient_certification.py
@@ -1,0 +1,76 @@
+"""Regression locks for variable/variable ratio (quotient) certification (issue #138, bucket 1).
+
+A constraint term ``N / D`` with a non-constant, sign-definite denominator ``D``
+is cleared by multiplying the constraint through by ``D`` (exact and
+value-preserving over a box where ``D`` never vanishes; see
+``factorable_reform._clear_divisions``), exposing a polynomial term the McCormick
+relaxation can bound. Combined with the mixed repeated-factor product lift this
+already certifies a slice of bucket-1 instances **soundly** on ``main``:
+
+* the gear-train problems ``gear`` / ``gear2`` / ``gear3`` — bilinear/bilinear
+  ratio ``(x0*x1)/(x2*x3)`` whose continuous relaxation floor is 0 and whose
+  incumbent reaches ~0;
+* ``nvs01`` (12.46967) and ``nvs06`` (1.7703125) — quadratic/quadratic ratios.
+
+These tests pin that behavior. ``st_e17`` (``x0**2/x1`` via convex-clearing) is
+guarded separately by ``test_st_e17_certification.py``.
+
+Scope note (issue #138): the remaining bucket-1 instances ``gear4``, ``ex1233``,
+``nvs05``, ``nvs22``, ``st_e35`` currently return ``bound=None`` (the relaxation
+soundly *drops* the ratio rather than producing a false bound) and are **not**
+locked here. The naive "lift ``y = N/D`` to the bilinear equality ``y*D = N``"
+route is deliberately NOT taken: on ``gear4`` it produces a deterministic
+false-optimal (the large linking coefficient drives an invalid node lower bound),
+which would convert a sound ``bound=None`` into an unsound certified-optimal. That
+is tracked as a separate solver soundness bug (#145); closing bucket-1 soundly
+waits on it plus tighter division-specific envelopes.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("instance", ["gear", "gear2", "gear3"])
+def test_gear_ratio_certifies_near_zero(instance):
+    """Gear-train ``(x0*x1)/(x2*x3)`` ratios certify to ~0 with a sound bound."""
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    r = dm.from_nl(str(nl)).solve(time_limit=60, gap_tolerance=1e-4)
+
+    assert r.objective is not None and r.bound is not None, f"[{instance}] no bound produced"
+    # Global optimum of these gear problems is ~0; the incumbent reaches it.
+    assert r.objective <= 1e-3, f"[{instance}] obj={r.objective} not near 0"
+    # Soundness: a valid dual bound never exceeds the optimum.
+    assert r.bound <= r.objective + 1e-6, f"[{instance}] unsound bound {r.bound} > obj"
+    assert r.gap_certified, f"[{instance}] expected certified optimality"
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize(
+    "instance, optimum",
+    [
+        ("nvs01", 12.46966882),  # (18505*x1**2 + ...) / (x0**2 + 7200) quadratic/quadratic
+        ("nvs06", 1.7703125),  # variable/variable ratio
+    ],
+)
+def test_nvs_ratio_certifies(instance, optimum):
+    """nvs01 / nvs06 variable/variable ratios certify their optimum soundly."""
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    r = dm.from_nl(str(nl)).solve(time_limit=60, gap_tolerance=1e-4)
+
+    assert r.objective is not None and r.bound is not None, f"[{instance}] no bound produced"
+    assert abs(r.objective - optimum) <= 1e-2, f"[{instance}] obj={r.objective} != {optimum}"
+    # Soundness: a valid dual bound never exceeds the known global optimum.
+    assert r.bound <= optimum + 1e-2, f"[{instance}] unsound dual bound {r.bound} > {optimum}"
+    assert r.gap_certified, f"[{instance}] expected certified optimality"


### PR DESCRIPTION
## Summary

Investigation of **#138** (bucket 1, variable/variable ratios) + the requested
`gear4 bound=None` sub-investigation.

### Empirical state of the 11 bucket-1 instances on `main`

| instance | status | sound? |
|----------|--------|--------|
| `gear`, `gear2`, `gear3` | certify ~0 | ✅ (**now locked**) |
| `nvs01` (12.46967), `nvs06` (1.7703125) | certify | ✅ (**now locked**) |
| `st_e17` (376.29) | certify | ✅ (guarded by `test_st_e17_certification.py`) |
| `gear4`, `ex1233`, `nvs05`, `nvs22`, `st_e35` | `bound=None` | ✅ sound-but-weak (ratio dropped, never a false bound) |

The sign-definite denominator clearing + mixed repeated-factor product lift
(`factorable_reform`) already gives the first six a sound dual bound. This PR
**regression-locks** the five that were unguarded (`gear`/`gear2`/`gear3` and
`nvs01`/`nvs06`).

### Why the issue's Route 1 (lift `y = N/D` to `y*D = N`) is NOT taken

Prototyping that lift on `gear4` produces a **deterministic false-optimal**:
the solver certifies `obj = 19703` when the true optimum is `1.64`
(`bound = 19703 > true_opt`). gear4 is fundamentally combinatorial — its
continuous-relaxation floor is provably 0, so the entire gap is integrality —
and the lifted relaxation, unable to tighten, combines with the large linking
coefficient (`1e6`) to drive an invalid node lower bound that prunes the optimal
subtree. The trigger is the coefficient magnitude (sound at `K≤1e4`, false at
`K=1e6`).

So the lift would convert gear4's **sound** `bound=None` into an **unsound**
certified-optimal — strictly worse. It is filed as a separate solver soundness
bug **#145** and the lift route is gated behind fixing it.

## Changes

`python/tests/test_quotient_certification.py` — five `@pytest.mark.correctness`
locks (gear/gear2/gear3 → ~0; nvs01/nvs06 → optimum), each asserting
`bound ≤ optimum` and `gap_certified`. All pass in ~21 s; lint clean. No
solver-math change.

## Follow-ups (tracked, not in this PR)

- **#145** — fix the large-coefficient trilinear-equality false-optimal; this
  unblocks the sound quotient lift.
- A sound finite bound for `gear4` (objective-bound fallback when the relaxation
  build fails) — deferred until #145 lands, so the bound logic is touched only on
  a verified-sound foundation.
- `ex1233` / `st_e35`: ratios in the **objective** (clearing has no objective
  analogue) — need the lift (⇒ #145) plus fractional-power-of-product envelopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
