### PR TITLE
fix(obbt): exact LP oracle + ill-conditioning guard for sound bound tightening (#145)

### DIFF
--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -18,7 +18,21 @@ import numpy as np
 
 from discopt.modeling.core import Model
 from discopt.solvers import SolveStatus
-from discopt.solvers.lp_backend import get_lp_solver
+from discopt.solvers.lp_backend import get_exact_lp_solver, get_lp_solver
+
+# Beyond this magnitude the McCormick relaxation's LP is too ill-conditioned for
+# an OBBT tightening to be rigorous. OBBT shrinks a variable's domain to an LP
+# optimum, and a feasibility tolerance ``ftol`` against a constraint coefficient
+# of size ``M`` lets the LP vertex sit ~``M*ftol`` past the true feasible point
+# in that variable. Once that absolute slack approaches the integrality /
+# feasibility tolerances the tightening can cut off a feasible (even optimal)
+# point — e.g. the fractional power ``x**-3.5`` near 0 builds envelope slopes
+# ~1e14 and OBBT then prunes the true optimum (the nvs08/fp soundness model).
+# When the relaxation's largest magnitude exceeds this limit OBBT returns the
+# box untightened: skipping is always sound, only weaker. Well-conditioned
+# stiff models (e.g. the 1e6-coefficient #145 ratio) stay well under it and are
+# still tightened by the exact (HiGHS) oracle.
+_OBBT_COND_LIMIT = 1e10
 
 
 def solve_lp(**kwargs):
@@ -392,7 +406,21 @@ def run_obbt(
     if total_time_limit is not None and total_time_limit < 0.0:
         raise ValueError("total_time_limit must be non-negative")
 
-    _lp = get_lp_solver(prefer_pounce=True) if prefer_pounce else solve_lp
+    # OBBT requires an EXACT LP oracle for sound tightening — see
+    # ``run_obbt_on_relaxation`` / ``get_exact_lp_solver`` (issue #145). The IPM
+    # is never used here; if no exact (HiGHS) oracle is available the pass is a
+    # sound no-op. ``prefer_pounce`` is kept for signature compatibility.
+    _lp = get_exact_lp_solver()
+    if _lp is None:
+        eff_lb = lb if lb is not None else _get_var_bounds(model)[0].copy()
+        eff_ub = ub if ub is not None else _get_var_bounds(model)[1].copy()
+        return ObbtResult(
+            tightened_lb=np.asarray(eff_lb, dtype=np.float64),
+            tightened_ub=np.asarray(eff_ub, dtype=np.float64),
+            n_lp_solves=0,
+            n_tightened=0,
+            total_lp_time=0.0,
+        )
     model_lb, model_ub = _get_var_bounds(model)
     if lb is None:
         lb = model_lb.copy()
@@ -585,13 +613,54 @@ def run_obbt_on_relaxation(
 
     import scipy.sparse as sp
 
-    _lp = get_lp_solver(prefer_pounce=True) if prefer_pounce else solve_lp
+    # OBBT must solve its min/max subproblems with an EXACT LP oracle: the
+    # tightened bound is taken from the LP optimum, so an inexact optimum (the
+    # POUNCE IPM's analytic-center objective, which can be grossly wrong on
+    # ill-conditioned LPs while still reporting OPTIMAL) yields an unsound
+    # tightening that cuts off feasible points (issue #145). ``prefer_pounce``
+    # is accepted for signature compatibility but never honoured here — when no
+    # exact (HiGHS) oracle is available we return the box untightened rather
+    # than risk an unsound shrink.
+    _lp = get_exact_lp_solver()
+    if _lp is None:
+        return ObbtResult(
+            tightened_lb=np.array([b[0] for b in relaxation._bounds[:n_orig]], dtype=np.float64),
+            tightened_ub=np.array([b[1] for b in relaxation._bounds[:n_orig]], dtype=np.float64),
+            n_lp_solves=0,
+            n_tightened=0,
+            total_lp_time=0.0,
+        )
     A_ub = relaxation._A_ub
     b_ub = relaxation._b_ub
     bounds = list(relaxation._bounds)
     n_total = len(bounds)
     c_obj = relaxation._c
     obj_offset = float(relaxation._obj_offset)
+
+    # Refuse to tighten over a numerically ill-conditioned relaxation: an OBBT
+    # bound from such an LP is not rigorous and can prune feasible points (see
+    # ``_OBBT_COND_LIMIT``). Returning the box untightened is sound.
+    def _max_abs(x) -> float:
+        if x is None:
+            return 0.0
+        if sp.issparse(x):
+            return float(np.abs(x.data).max()) if x.nnz else 0.0
+        arr = np.asarray(x, dtype=np.float64)
+        if arr.size == 0:
+            return 0.0
+        finite = arr[np.isfinite(arr)]
+        return float(np.abs(finite).max()) if finite.size else 0.0
+
+    _bound_vals = np.array([v for pair in bounds for v in pair], dtype=np.float64)
+    _cond = max(_max_abs(A_ub), _max_abs(b_ub), _max_abs(_bound_vals))
+    if _cond > _OBBT_COND_LIMIT:
+        return ObbtResult(
+            tightened_lb=np.array([b[0] for b in bounds[:n_orig]], dtype=np.float64),
+            tightened_ub=np.array([b[1] for b in bounds[:n_orig]], dtype=np.float64),
+            n_lp_solves=0,
+            n_tightened=0,
+            total_lp_time=0.0,
+        )
 
     if incumbent_cutoff is not None and c_obj is not None:
         cutoff_row = np.asarray(c_obj, dtype=np.float64).reshape(1, -1)

--- a/python/discopt/solvers/lp_backend.py
+++ b/python/discopt/solvers/lp_backend.py
@@ -67,6 +67,24 @@ def get_lp_solver(prefer_pounce: bool = False) -> Callable:
     )
 
 
+def get_exact_lp_solver() -> Callable | None:
+    """Return an *exact* (simplex/vertex) LP oracle, or ``None`` if unavailable.
+
+    This is HiGHS only — never the POUNCE IPM. OBBT tightens a variable's bound
+    to the optimum of ``min``/``max x_i`` over the relaxation polytope, which is
+    sound **only when that LP is solved to its true optimum**. POUNCE's
+    interior-point method returns the analytic center of the optimal face; its
+    reported objective normally matches the simplex optimum but can be grossly
+    wrong on ill-conditioned LPs (e.g. a 1e6 coefficient spread) while still
+    reporting ``OPTIMAL`` — an over-tightening that cuts off feasible, even
+    globally-optimal, points (issue #145). HiGHS dual simplex reaches the exact
+    vertex, so its optimum is a rigorous bound. Callers that need a *sound*
+    bound (OBBT) must use this; when it returns ``None`` they must skip
+    tightening rather than fall back to the IPM.
+    """
+    return _lp_highs()
+
+
 def get_qp_solver(prefer_pounce: bool = False) -> Callable:
     """Return a matrix-form ``solve_qp(Q, c, A_ub, ...)``; see
     :func:`get_lp_solver`. POUNCE handles continuous QPs only (MIQPs go

--- a/python/tests/test_lp_backend_select.py
+++ b/python/tests/test_lp_backend_select.py
@@ -171,7 +171,15 @@ class TestHighspyConsumersRetired:
 
 
 class TestObbtRetired:
-    """OBBT runs through the backend seam, so it works POUNCE-only."""
+    """OBBT bound tightening requires an *exact* LP oracle (HiGHS).
+
+    OBBT tightens a variable's bound to the optimum of ``min``/``max x_i`` over
+    the relaxation polytope, so the subproblem LP must be solved to its true
+    optimum to stay sound. The POUNCE IPM returns an analytic-center objective
+    that can be wrong on ill-conditioned LPs while reporting ``OPTIMAL`` (#145),
+    so OBBT routes through HiGHS regardless of ``prefer_pounce`` and is a sound
+    no-op when no exact oracle is available.
+    """
 
     def _model(self):
         import discopt.modeling as dm
@@ -185,8 +193,10 @@ class TestObbtRetired:
         m.subject_to(xv <= 4)
         return m
 
-    def test_obbt_via_pounce_tightens(self):
-        pytest.importorskip("pounce")
+    def test_obbt_tightens_via_exact_oracle(self):
+        # Tightening requires the exact (HiGHS) oracle; ``prefer_pounce`` is a
+        # no-op for the solver selection (#145).
+        pytest.importorskip("highspy")
         from discopt._jax.obbt import run_obbt
 
         res = run_obbt(self._model(), prefer_pounce=True, time_limit_per_lp=5.0)
@@ -194,8 +204,10 @@ class TestObbtRetired:
         assert res.tightened_ub[0] == pytest.approx(4.0, abs=1e-4)
         assert res.n_lp_solves >= 1
 
-    def test_obbt_matches_across_backends(self):
-        pytest.importorskip("pounce")
+    def test_obbt_ignores_prefer_pounce(self):
+        # Both calls must route through the exact oracle, so the tightened box
+        # is identical regardless of ``prefer_pounce`` (it no longer selects the
+        # IPM backend for OBBT — #145).
         pytest.importorskip("highspy")
         from discopt._jax.obbt import run_obbt
 

--- a/python/tests/test_obbt.py
+++ b/python/tests/test_obbt.py
@@ -225,7 +225,10 @@ class TestObbtBasic:
             clock["now"] += 0.11
             return LPResult(status=SolveStatus.OPTIMAL, objective=0.0, wall_time=0.11)
 
-        monkeypatch.setattr(obbt_mod, "solve_lp", fake_solve_lp)
+        # OBBT now resolves its LP oracle through ``get_exact_lp_solver`` (it
+        # must use an exact simplex backend for sound tightening — see #145),
+        # so patch that seam rather than the module-level ``solve_lp``.
+        monkeypatch.setattr(obbt_mod, "get_exact_lp_solver", lambda: fake_solve_lp)
 
         result = run_obbt(m, time_limit_per_lp=1.0, total_time_limit=0.2)
 

--- a/python/tests/test_obbt_soundness.py
+++ b/python/tests/test_obbt_soundness.py
@@ -1,0 +1,142 @@
+"""Soundness regression lock for OBBT bound tightening (issue #145).
+
+OBBT tightens a variable's bound to the optimum of ``min``/``max x_i`` over the
+McCormick LP relaxation polytope. That is sound **only when the subproblem LP is
+solved to its true optimum**: the returned objective becomes a hard variable
+bound, so an inexact optimum cuts off feasible points.
+
+The POUNCE interior-point backend returns the analytic center of the optimal
+face; its reported objective normally matches the simplex optimum, but on an
+ill-conditioned LP (here a ``1e6`` linking coefficient) it can be grossly wrong
+while still reporting ``OPTIMAL``. Before the fix, the *default* solve
+(``nlp_solver="ipm"`` silently routes to POUNCE) ran OBBT through that IPM and
+over-tightened ``x0`` to ``[17, 17]`` — excluding the optimal ``x0 = 16`` — and
+then certified a false optimum of ~2538 on a problem whose true optimum is ~1.64.
+
+The fix routes OBBT through an *exact* LP oracle (HiGHS simplex) regardless of
+``nlp_solver``; when no exact oracle is available it skips tightening rather than
+trust the IPM. This test pins the soundness invariant on the minimal repro: a
+large-coefficient trilinear equality with integer branching. The dual bound must
+never exceed the true optimum, and the solver must never certify a false one.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+import pytest
+
+# True optimum of the box below: at (x0,x1,x2,x3)=(16,19,43,49), y=323/2107 and
+# the objective x4+x5 ~= 1.642. The global minimum over the box is <= that, so a
+# valid lower (dual) bound can never exceed it. The pre-fix bug reported ~2538.
+_TRUE_OPT = 1.642
+_FALSE_OPT_FLOOR = 5.0  # cleanly separates true (~1.64) from the false (~2538)
+
+
+def _build_stiff_ratio_model():
+    """Lifted gear4-style slice: trilinear equality + 1e6 linking coefficient.
+
+    ``y * x2 * x3 == x0 * x1`` lifts the bilinear/bilinear ratio, and the linking
+    row ``1e6*y + x4 - x5 == 144279.32...`` is what makes the relaxation LPs
+    ill-conditioned. Integer branching on x0..x3 closes the combinatorial gap.
+    """
+    m = dm.Model("obbt_soundness")
+    x0 = m.integer("x0", lb=16, ub=18)
+    x1 = m.integer("x1", lb=18, ub=20)
+    x2 = m.integer("x2", lb=42, ub=44)
+    x3 = m.integer("x3", lb=48, ub=50)
+    x4 = m.continuous("x4", lb=0.0, ub=2e5)
+    x5 = m.continuous("x5", lb=0.0, ub=2e5)
+    y = m.continuous("y", lb=0.04, ub=25.0)
+    m.minimize(x4 + x5)
+    m.subject_to(y * x2 * x3 - x0 * x1 == 0)
+    m.subject_to(1e6 * y + x4 - x5 == 144279.32477276)
+    return m
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("obbt_at_root", [True, False])
+@pytest.mark.parametrize("presolve", [True, False])
+def test_stiff_ratio_obbt_is_sound(presolve, obbt_at_root):
+    """OBBT must never over-tighten and certify a false optimum (#145).
+
+    Across every presolve/OBBT toggle the dual bound must stay <= the true
+    optimum, and the solver must never report ``gap_certified`` at a false
+    incumbent. An honest non-certified result (``bound=None``) is acceptable —
+    only an *unsound* certification is a failure.
+    """
+    from discopt.solver import solve_model
+
+    r = solve_model(
+        _build_stiff_ratio_model(),
+        time_limit=20,
+        gap_tolerance=1e-4,
+        presolve=presolve,
+        obbt_at_root=obbt_at_root,
+    )
+
+    # Core soundness invariant: a dual bound is a valid lower bound on the global
+    # optimum, so it can never exceed the true optimum (~1.642).
+    if r.bound is not None:
+        assert r.bound <= _TRUE_OPT + 1e-2, (
+            f"unsound dual bound {r.bound} > true optimum {_TRUE_OPT} "
+            f"(presolve={presolve}, obbt_at_root={obbt_at_root})"
+        )
+
+    # A feasible incumbent must reflect the true optimum, not a box that OBBT
+    # wrongly carved away.
+    if r.objective is not None:
+        assert r.objective < _FALSE_OPT_FLOOR, (
+            f"incumbent {r.objective} is the pre-fix false optimum "
+            f"(presolve={presolve}, obbt_at_root={obbt_at_root})"
+        )
+
+    # Never certify a false optimum.
+    if r.gap_certified:
+        assert r.objective is not None and r.objective <= _TRUE_OPT + 1e-2, (
+            f"certified false optimum obj={r.objective} "
+            f"(presolve={presolve}, obbt_at_root={obbt_at_root})"
+        )
+
+
+@pytest.mark.correctness
+def test_root_obbt_keeps_optimum_even_when_pounce_requested():
+    """``obbt_tighten_root`` must not exclude a feasible point (#145, unit-level).
+
+    Fast guard on the OBBT layer itself: passing ``prefer_pounce=True`` must NOT
+    route the bound-tightening LPs through the IPM (whose inexact optimum carved
+    ``x0`` to ``[17,17]`` before the fix). The optimal integer assignment
+    ``(16,19,43,49)`` must survive every OBBT sweep.
+    """
+    import time
+
+    import numpy as np
+    from discopt._jax.obbt import obbt_tighten_root
+
+    m = _build_stiff_ratio_model()
+    lb = np.array([v.lb for v in m._variables], dtype=float)
+    ub = np.array([v.ub for v in m._variables], dtype=float)
+    opt = {
+        "x0": 16.0,
+        "x1": 19.0,
+        "x2": 43.0,
+        "x3": 49.0,
+        "x4": 0.0,
+        "x5": 1.6434,
+        "y": 323.0 / 2107.0,
+    }
+
+    res = obbt_tighten_root(
+        m, lb, ub, rounds=3, deadline=time.perf_counter() + 15, prefer_pounce=True
+    )
+    assert not res.infeasible
+    tlb = np.maximum(lb, res.lb)
+    tub = np.minimum(ub, res.ub)
+    for i, v in enumerate(m._variables):
+        if v.name in opt:
+            val = opt[v.name]
+            assert tlb[i] - 1e-6 <= val <= tub[i] + 1e-6, (
+                f"OBBT excluded feasible {v.name}={val}: tightened to [{tlb[i]}, {tub[i]}]"
+            )


### PR DESCRIPTION
## Summary

Fixes #145 — root OBBT was certifying **false optima** on ill-conditioned relaxations. Soundness is non-negotiable: a valid dual (lower) bound must never exceed the true optimum, and the solver must never report `gap_certified=True` at a wrong incumbent. This closes two independent OBBT unsoundness modes, both **sound-by-construction** (the fallback is *less* tightening, never an unsound shrink).

## Root cause

OBBT tightens each variable's bound to the optimum of `min`/`max xᵢ` over the McCormick LP relaxation polytope. That is only sound when (a) the subproblem LP is solved to its **true** optimum and (b) the relaxation is numerically well enough conditioned that the LP optimum is a rigorous bound. Both assumptions were silently violated:

1. **IPM-as-LP-oracle.** The default solve maps `nlp_solver="ipm"` → POUNCE. Root OBBT then solved its subproblems with POUNCE's interior-point method, which returns the *analytic center of the optimal face* — an objective that on an ill-conditioned LP (e.g. a `1e6` linking coefficient) can be grossly wrong while still reporting `OPTIMAL`. On a lifted gear4 slice this over-tightened `x0` to `[17,17]`, excluding the optimal `x0=16`, and certified **2538 vs the true 1.64**.

2. **Exact-but-degenerate relaxation.** Swapping to exact HiGHS fixes (1) but is *still* unsound when the relaxation itself is numerically degenerate: the fractional power `x**-3.5` near 0 builds envelope slopes `~1e14`, and exact OBBT then prunes the true optimum of the nvs08/fp soundness model (true opt **21.56**, was certifying 2320). Caught because the HiGHS swap alone briefly regressed `test_fp_relaxation_soundness`.

## Fix

- **Exact LP oracle for OBBT** (`get_exact_lp_solver()`): OBBT resolves its min/max LPs through HiGHS simplex only — never the IPM. When no exact oracle is available (POUNCE-only install) OBBT is a sound no-op.
- **Ill-conditioning guard** (`_OBBT_COND_LIMIT = 1e10`): OBBT refuses to tighten when the relaxation's largest coefficient/bound magnitude exceeds the limit, where a feasibility-tolerance violation against a large coefficient lets the LP vertex sit past the true feasible point. Well-conditioned stiff models (the `1e6` #145 ratio) stay under the limit and are still tightened.

## Verification

| model | before | after |
|---|---|---|
| lifted gear4 slice (#145) | `optimal 2538` (cert, bound 2538 ≫ 1.64) | `feasible 1.64`, sound (no false cert) |
| nvs08/fp `x**-3.5` | `optimal 2320` (cert, bound ≫ 21.56) | `optimal 21.56`, sound bound |

- New `test_obbt_soundness.py`: end-to-end soundness across every `presolve` × `obbt_at_root` toggle, plus a fast unit-level lock that `obbt_tighten_root` never excludes a feasible point even when `prefer_pounce=True`.
- Updated OBBT timing/backend tests to the new exact-oracle seam.
- Full `-m correctness` suite: **176 passed, 4 failed** — the 4 are pre-existing `nvs16` (#120) and `st_e11` failures that also fail on clean `main` and are unrelated to OBBT (`nvs16` is pure-integer, so OBBT never runs on it). `test_fp_relaxation_soundness` now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
