### PR TITLE
Add explicit diagnostic for unsupported binary .nl format

### DIFF
--- a/crates/discopt-core/src/nl_parser.rs
+++ b/crates/discopt-core/src/nl_parser.rs
@@ -31,6 +31,8 @@ pub enum NlParseError {
     InvalidHeader(String),
     /// An expression opcode was not recognised.
     UnknownOpcode(i32),
+    /// The file uses the binary (`b`) .nl encoding, which is not supported.
+    BinaryUnsupported,
     /// General parse error with a human-readable message.
     Parse(String),
 }
@@ -41,6 +43,12 @@ impl fmt::Display for NlParseError {
             NlParseError::UnexpectedEof => write!(f, "unexpected end of .nl input"),
             NlParseError::InvalidHeader(msg) => write!(f, "invalid .nl header: {msg}"),
             NlParseError::UnknownOpcode(op) => write!(f, "unknown .nl opcode: o{op}"),
+            NlParseError::BinaryUnsupported => write!(
+                f,
+                "binary .nl format not supported: file uses the binary ('b') encoding, \
+                 but only the text/ASCII ('g') format is supported. Re-export the model \
+                 in text .nl format (e.g. AMPL `write g<stub>;` rather than `write b<stub>;`)"
+            ),
             NlParseError::Parse(msg) => write!(f, ".nl parse error: {msg}"),
         }
     }
@@ -146,12 +154,16 @@ fn split_ws(line: &str) -> Vec<&str> {
 // ─────────────────────────────────────────────────────────────
 
 fn parse_header(reader: &mut LineReader<'_>) -> Result<NlHeader, NlParseError> {
-    // Line 0: "g3 1 1 0" or similar — we just check it starts with 'g'.
+    // Line 0: "g3 1 1 0" or similar. The leading char selects the encoding of
+    // the file body: 'g' = text/ASCII, 'b' = binary. Only text is supported.
     let line0 = reader.next_line()?;
     let l0 = line0.trim();
-    if !l0.starts_with('g') && !l0.starts_with('b') {
+    if l0.starts_with('b') {
+        return Err(NlParseError::BinaryUnsupported);
+    }
+    if !l0.starts_with('g') {
         return Err(NlParseError::InvalidHeader(format!(
-            "expected 'g' or 'b' prefix, got: {l0}"
+            "expected 'g' (text) prefix, got: {l0}"
         )));
     }
 
@@ -1171,10 +1183,27 @@ fn is_zero_constant(arena: &ExprArena, id: ExprId) -> bool {
 }
 
 /// Parse a .nl file from a file path.
+///
+/// Reads the file as raw bytes and inspects the leading magic character to
+/// select the encoding: `g` = text/ASCII (supported), `b` = binary (not
+/// supported — yields an explicit [`NlParseError::BinaryUnsupported`] rather
+/// than a confusing UTF-8 decode error, since binary bodies embed raw IEEE-754
+/// doubles that are not valid UTF-8).
 pub fn parse_nl_file(path: &str) -> Result<ModelRepr, NlParseError> {
-    let content = std::fs::read_to_string(path)
+    let bytes = std::fs::read(path)
         .map_err(|e| NlParseError::Parse(format!("failed to read file '{path}': {e}")))?;
-    parse_nl(&content)
+
+    // Detect the format from the first non-whitespace byte.
+    if let Some(b'b') = bytes.iter().find(|b| !b.is_ascii_whitespace()) {
+        return Err(NlParseError::BinaryUnsupported);
+    }
+
+    let content = std::str::from_utf8(&bytes).map_err(|e| {
+        NlParseError::Parse(format!(
+            "failed to read file '{path}': not valid UTF-8 text .nl ({e})"
+        ))
+    })?;
+    parse_nl(content)
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -2085,6 +2114,28 @@ mod tests {
     fn test_parse_nl_file_missing() {
         let result = parse_nl_file("/nonexistent/path/to/file.nl");
         assert!(result.is_err());
+    }
+
+    // ─── Test: binary .nl format yields explicit diagnostic ───
+
+    #[test]
+    fn test_binary_header_rejected() {
+        // A 'b'-prefixed header signals the binary encoding.
+        let err = parse_nl("b3 1 1 0\n").unwrap_err();
+        assert!(matches!(err, NlParseError::BinaryUnsupported));
+        let msg = err.to_string();
+        assert!(msg.contains("binary .nl format not supported"), "{msg}");
+    }
+
+    #[test]
+    fn test_parse_nl_file_binary_detected() {
+        // Write a fake binary .nl: text header line plus a non-UTF-8 body byte.
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("discopt_binary_test_{}.nl", std::process::id()));
+        std::fs::write(&path, b"b3 0 1 0\t# problem\n\x00\xf0\x3f").unwrap();
+        let result = parse_nl_file(path.to_str().unwrap());
+        let _ = std::fs::remove_file(&path);
+        assert!(matches!(result, Err(NlParseError::BinaryUnsupported)));
     }
 
     // ─── Test: coefficient -1 optimization ────────────────

--- a/python/tests/test_binary_nl_unsupported.py
+++ b/python/tests/test_binary_nl_unsupported.py
@@ -1,0 +1,35 @@
+"""Regression test for issue #142: binary .nl format diagnostic.
+
+MINLPLib ``portfol_robust050_34`` is distributed in the *binary* .nl encoding
+(magic byte ``b``), whose body embeds raw little-endian IEEE-754 doubles. The
+old reader did a UTF-8 ``read_to_string`` and only handled the text (``g``)
+format, so loading this instance failed with a confusing
+
+    ValueError: .nl parse error: ... stream did not contain valid UTF-8
+
+The reader now detects the format from the leading magic byte and emits an
+explicit, accurate diagnostic instead of the UTF-8 noise.
+"""
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+_NL = Path(__file__).parent / "data" / "minlplib" / "portfol_robust050_34.nl"
+
+
+@pytest.mark.unit
+def test_binary_nl_explicit_error():
+    """Loading a binary .nl raises a clear 'binary not supported' error."""
+    assert _NL.exists(), f"missing {_NL}"
+    # Confirm the fixture really is the binary format.
+    assert _NL.read_bytes().lstrip()[:1] == b"b"
+
+    with pytest.raises(ValueError) as exc_info:
+        dm.from_nl(str(_NL))
+
+    msg = str(exc_info.value)
+    assert "binary .nl format not supported" in msg
+    # The old confusing UTF-8 message must not leak through.
+    assert "valid UTF-8" not in msg


### PR DESCRIPTION
## Summary

Adds detection and explicit error handling for binary-encoded `.nl` files (magic byte `b`), which are not supported by the parser. Previously, attempting to load a binary `.nl` file would fail with a confusing UTF-8 decode error. Now the parser detects the binary format early and emits a clear, actionable diagnostic message.

## Changes

- **New error variant**: `NlParseError::BinaryUnsupported` with a detailed message explaining that only text (`g`) format is supported and how to re-export in AMPL.

- **Early detection in `parse_nl_file()`**: Read file as raw bytes and inspect the leading magic byte before UTF-8 decoding. If the first non-whitespace byte is `b`, return `BinaryUnsupported` immediately rather than attempting UTF-8 conversion (which would fail on raw IEEE-754 doubles in the binary body).

- **Header validation**: Updated `parse_header()` to explicitly reject `b`-prefixed headers with the new error variant, and clarified comments about the encoding selection mechanism.

- **Tests**: Added two unit tests in Rust (`test_binary_header_rejected`, `test_parse_nl_file_binary_detected`) and one Python regression test (`test_binary_nl_explicit_error`) that validates the diagnostic on a real binary `.nl` fixture from MINLPLib.

## Implementation Details

- The binary detection happens at the file I/O boundary (`parse_nl_file`) to catch the issue before any parsing logic runs.
- The header-level check in `parse_header()` provides a secondary safety net for the `parse_nl()` string API.
- Error message includes concrete guidance: mention AMPL `write g<stub>;` syntax as the fix.
- Python test uses a real binary `.nl` file (`portfol_robust050_34.nl`) to ensure the diagnostic works on actual MINLPLib instances (issue #142).

https://claude.ai/code/session_01P1cZ4E2WvBguXQZdMgauCn