### PR TITLE
Increase time limit for st_e04 certification test to 60s

### DIFF
--- a/python/tests/test_exp_certification.py
+++ b/python/tests/test_exp_certification.py
@@ -85,10 +85,14 @@ def test_st_e04_certifies_with_sound_bound():
     (~5194.866) and the within-gap incumbent sits just above it; the gap closes
     at the 1e-4 tolerance. The invariant we lock is soundness + certification,
     not the exact incumbent value.
+
+    The time budget matches the sibling corpus locks (60 s): the exact-LP-oracle
+    OBBT path (#145) deliberately trades per-node speed for soundness, which puts
+    this instance's ~33 s solve just over a tighter limit.
     """
     nl = _DATA / "st_e04.nl"
     assert nl.exists(), f"missing {nl}"
-    r = dm.from_nl(str(nl)).solve(time_limit=30, gap_tolerance=1e-4)
+    r = dm.from_nl(str(nl)).solve(time_limit=60, gap_tolerance=1e-4)
 
     assert r.status == "optimal"
     assert r.objective is not None and r.bound is not None


### PR DESCRIPTION
Closes #140

## Summary
Increase the time budget for the `test_st_e04_certifies_with_sound_bound` test from 30 seconds to 60 seconds to accommodate the exact-LP-oracle OBBT path, which trades per-node speed for soundness guarantees.

This is the final follow-up for **#140** (bucket 3, the `exp` quick win). The substantive work — confirming the convex `exp` envelope certifies soundly and adding the regression locks in `test_exp_certification.py` — landed in #143. After that merged, the exact-LP-oracle OBBT changes (#145/#147/#150) deliberately traded per-node speed for soundness, pushing st_e04's solve to ~33s and breaking the 30s lock. This restores the lock. The remaining out-of-scope items are tracked elsewhere: `st_e36` → #139, `prob10`/`sin` → #137.

## Changes
- **Time limit**: Increased `time_limit` parameter from 30s to 60s in the `st_e04.nl` solve call
- **Documentation**: Added explanatory comment clarifying that the 60s budget aligns with sibling corpus locks and that the ~33s solve time for this instance was previously exceeding a tighter limit due to the soundness-focused OBBT implementation (issue #145)

## Details
The exact-LP-oracle OBBT path deliberately prioritizes soundness over per-node speed, which causes this particular instance to require approximately 33 seconds to solve. The previous 30-second limit was too tight and could cause flaky test behavior. The new 60-second limit matches the time budget used by related test cases in the corpus and provides sufficient headroom while still maintaining reasonable test execution time. The dual bound and optimality certification are unchanged and still sound.

https://claude.ai/code/session_017griXTWrvSFKZuJvvGVnB1