### PR TITLE
fix(#139): st_e36 sound bound via extreme-monomial guard + bucket-wide soundness regression

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3062,6 +3062,43 @@ def build_milp_relaxation(
         multilinear_var_map[multi_term] = final_col
         multilinear_stage_map[multi_term] = stages
 
+    # Numerical-conditioning guard: a lifted monomial whose auxiliary bound spans
+    # an extreme magnitude (e.g. ``x1**9`` over ``[15, 25]`` → ~3.8e12) injects
+    # coefficients ranging over >1e12 into the LP. The relaxation is still
+    # logically sound — it contains every true feasible point — but the badly
+    # scaled system drives the LP solver to report *spurious* infeasibility
+    # (a false infeasibility, as serious as a false bound: a feasible problem
+    # would look infeasible and produce no dual bound). Such a monomial is not
+    # lifted; the linearizer then raises on the missing aux and the containing
+    # constraint is omitted entirely (omission only enlarges the feasible region,
+    # so the dual bound stays valid). The cap sits far above every monomial any
+    # currently-bounding instance needs (the largest, nvs20/nvs21, peak at
+    # ~1.6e9) and triggers only on pathological high-degree polynomials such as
+    # st_e36's degree-10 equality constraint (issue #139, bucket 2).
+    _MONOMIAL_AUX_BOUND_LIMIT = 1e10
+    _kept_monomial_terms: list[tuple[int, int]] = []
+    for var_idx, n in monomial_terms:
+        lb_i = float(flat_lb[var_idx])
+        ub_i = float(flat_ub[var_idx])
+        blo, bhi = _monomial_aux_bounds(lb_i, ub_i, n)
+        mag = max(
+            abs(blo) if np.isfinite(blo) else 0.0,
+            abs(bhi) if np.isfinite(bhi) else 0.0,
+        )
+        if mag > _MONOMIAL_AUX_BOUND_LIMIT:
+            logger.debug(
+                "AMP: not lifting monomial x%d**%d (aux bound magnitude %.3g exceeds "
+                "%.0e); constraints/terms referencing it are omitted to avoid a "
+                "numerically degenerate LP relaxation.",
+                var_idx,
+                n,
+                mag,
+                _MONOMIAL_AUX_BOUND_LIMIT,
+            )
+            continue
+        _kept_monomial_terms.append((var_idx, n))
+    monomial_terms = _kept_monomial_terms
+
     for var_idx, n in monomial_terms:
         lb_i = float(flat_lb[var_idx])
         ub_i = float(flat_ub[var_idx])

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -1,0 +1,97 @@
+"""Bucket-2 (#139) regression: every "product with a nonlinear factor" instance
+produces a *sound* root lower bound — or, for the one slice that legitimately
+drops, does not regress relative to a known-good baseline.
+
+Bucket 2 covers products where at least one factor is itself nonlinear (a square,
+a product, or another aux expression): ``ex1225``, ``ex1226``, ``ex1252``,
+``nvs05``, ``nvs16``, ``nvs20``, ``nvs22``, ``chance``, ``st_e36``. Before #139
+each of these dropped from the McCormick relaxation ("Cannot decompose product")
+and produced no dual bound; recursive bilinear/trilinear/multilinear lifting plus
+the extreme-magnitude monomial guard now lift them soundly.
+
+Soundness is the invariant under test: a valid lower bound must NEVER exceed the
+true optimum. We assert the root McCormick LP bound is finite and ``<= opt`` for
+the eight liftable instances. ``nvs16`` is the lone exception — its objective is
+a Beale sum-of-squares that distributes into degree-8 monomials of magnitude
+~1e18 over the integer box ``[0, 200]**2``; a proper square-of-affine-in-lifted
+envelope is follow-up work. It currently yields no root objective bound on *main*
+too, so we assert only that it has not regressed (no bound, or a sound one).
+
+Reference optima are the MINLPLib values (cross-checked against
+``discopt_benchmarks`` problem definitions).
+"""
+
+import math
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+# (instance, MINLPLib optimum). These eight must each produce a finite, sound
+# root lower bound (bound <= opt). Bounds may be loose where division/sqrt
+# constraints remain un-linearized — looseness is fine, unsoundness is not.
+_SOUND_BOUND_CASES = [
+    ("ex1225", 31.0),
+    ("ex1226", -17.0),
+    ("ex1252", 128893.8),
+    ("nvs05", 5.47093),
+    ("nvs20", 230.922),
+    ("nvs22", 6.0584),
+    ("chance", 29.8945),
+    ("st_e36", -246.0),
+]
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("instance, optimum", _SOUND_BOUND_CASES)
+def test_bucket2_instance_has_sound_root_bound(instance, optimum):
+    """Each liftable bucket-2 instance yields a finite root bound <= optimum."""
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+    res = relaxer.solve_at_node(lb, ub)
+
+    assert res.status == "optimal", f"[{instance}] root LP status {res.status}"
+    assert res.lower_bound is not None, f"[{instance}] objective dropped — no root bound"
+    assert math.isfinite(res.lower_bound), f"[{instance}] non-finite bound {res.lower_bound}"
+    # The soundness invariant: a valid lower bound never exceeds the true optimum.
+    assert res.lower_bound <= optimum + 1e-3, (
+        f"[{instance}] UNSOUND root bound {res.lower_bound} > optimum {optimum}"
+    )
+
+
+@pytest.mark.correctness
+def test_nvs16_does_not_regress():
+    """``nvs16`` (Beale sum-of-squares, integer box [0,200]^2) distributes into
+    ~1e18-magnitude monomials, so its objective legitimately drops from the root
+    relaxation today. The bucket-2 acceptance requires only that it not regress:
+    the root LP must still solve (no spurious infeasibility), and any bound it
+    does produce must be sound (<= optimum 0.703125)."""
+    nl = _DATA / "nvs16.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+    res = relaxer.solve_at_node(lb, ub)
+
+    # No false-infeasibility — the LP itself must solve cleanly.
+    assert res.status == "optimal", f"nvs16 root LP status {res.status}"
+    # The objective may drop (no bound) — that is the current, non-regressed
+    # state — but if a bound IS produced it must underestimate the optimum.
+    if res.lower_bound is not None and math.isfinite(res.lower_bound):
+        assert res.lower_bound <= 0.703125 + 1e-3, (
+            f"nvs16 UNSOUND bound {res.lower_bound} > 0.703125"
+        )

--- a/python/tests/test_monomial_var_product.py
+++ b/python/tests/test_monomial_var_product.py
@@ -204,3 +204,36 @@ def test_lifted_trilinear_sound_over_mixed_sign_box():
     assert r.objective == pytest.approx(true_min, abs=1e-2)
     assert r.bound is not None, "objective dropped — no dual bound"
     assert r.bound <= true_min + 1e-4, f"unsound bound {r.bound} > {true_min}"
+
+
+@pytest.mark.correctness
+def test_st_e36_extreme_monomial_does_not_false_infeasible():
+    """st_e36 carries a degree-10 polynomial equality constraint. Lifting its
+    high-degree monomial (e.g. ``x1**9`` over ``[15, 25]`` → aux bound ~3.8e12)
+    injects coefficients spanning >1e12 into the McCormick LP. The relaxation is
+    *logically* sound — it contains the true feasible point — but the badly
+    scaled system drives HiGHS to report **spurious infeasibility**, so the root
+    relaxation produced no dual bound at all (issue #139, bucket 2).
+
+    The builder now refuses to lift a monomial whose auxiliary bound magnitude
+    exceeds ``_MONOMIAL_AUX_BOUND_LIMIT`` (1e10). The offending constraint is then
+    omitted (omission only enlarges the feasible region, keeping the dual bound
+    valid), so the root LP solves to a finite, sound lower bound instead of a
+    false ``infeasible``. The bound must underestimate the known optimum -246."""
+    from discopt._jax.mccormick_lp import MccormickLPRelaxer
+    from discopt._jax.model_utils import flat_variable_bounds
+
+    nl = _DATA / "st_e36.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+    res = relaxer.solve_at_node(lb, ub)
+
+    # Must NOT be the spurious infeasible the degree-10 lift used to produce.
+    assert res.status == "optimal", f"root LP status {res.status} (false infeasibility?)"
+    assert res.lower_bound is not None, "no root bound produced"
+    assert math.isfinite(res.lower_bound), f"non-finite root bound {res.lower_bound}"
+    # Soundness: a valid lower bound never exceeds the true optimum (-246).
+    assert res.lower_bound <= -246.0 + 1e-4, f"unsound bound {res.lower_bound} > -246"


### PR DESCRIPTION
## Summary

Closes the last bucket-2 (#139) instance that produced **no dual bound** and locks
in the bucket-wide soundness invariant with a regression test.

Bucket 2 = "products with a nonlinear factor" (`x·x·y`, `exp(g)·y`, bilinear-of-
nonlinear). After #148's recursive lifted-product envelopes, eight of the nine
bucket-2 instances produced sound root bounds. `st_e36` was the lone holdout:
its root McCormick LP reported **spurious infeasibility** (no bound at all).

### Root cause — `st_e36` false-infeasibility

`st_e36` carries a degree-10 polynomial equality. Lifting its high-degree
monomial (`x1**9` over `[15, 25]` → aux bound **~3.8e12**) injects coefficients
spanning >1e12 into the McCormick LP. The relaxation is **logically sound** — it
contains the true feasible point — but the badly scaled system drives HiGHS to
report *spurious infeasibility*, so the root relaxation produced no dual bound.
A false infeasibility is as serious as a false bound: a feasible problem looks
infeasible and yields no certificate.

### Fix — extreme-magnitude monomial guard

`build_milp_relaxation` now refuses to lift any monomial whose auxiliary bound
magnitude exceeds `_MONOMIAL_AUX_BOUND_LIMIT = 1e10`. The dropped monomial's
constraint is then omitted by the linearizer — and **omission only enlarges the
feasible region, so the dual bound stays valid**. The cap sits far above every
monomial any currently-bounding instance needs (the largest, nvs20/nvs21, peaks
at ~1.6e9) and triggers only on pathological high-degree polynomials.

**Result:** `st_e36` root LP `infeasible / bound=None` → `optimal / bound=-290.18`
(sound, ≤ true optimum −246).

### Soundness verification (no regression)

| instance | root bound | optimum | sound |
|----------|-----------|---------|-------|
| ex1225   | 31.0      | 31.0    | ✓ |
| ex1226   | −21.0     | −17.0   | ✓ |
| ex1252   | 0.0       | 128893.8| ✓ |
| nvs05    | 0.674     | 5.471   | ✓ |
| nvs20    | 87.35     | 230.922 | ✓ |
| nvs22    | 1.826     | 6.0584  | ✓ |
| chance   | 26.35     | 29.8945 | ✓ |
| st_e36   | **−290.18** (was none) | −246.0 | ✓ |

`nvs16` (Beale sum-of-squares over the integer box `[0, 200]²`) distributes into
degree-8 monomials of magnitude ~1e18 and legitimately produces no objective
bound — **identical to `main`, so no regression**. A proper square-of-affine-in-
lifted-vars envelope (avoiding the catastrophic distributive expansion) is the
right fix and is tracked as follow-up. The bucket-2 acceptance places `nvs16` in
the "already-handled / do not regress" group, which holds.

## Tests

- `test_monomial_var_product.py::test_st_e36_extreme_monomial_does_not_false_infeasible`
  — st_e36 root LP solves to a sound finite bound instead of spurious infeasible.
- `test_bucket2_sound_bounds.py` (new) — bucket-wide regression: all eight liftable
  instances yield a finite root bound ≤ optimum; `nvs16` asserted not to regress.
- Related suites green: `test_cert_finite_bound_soundness`, `test_power_certification`,
  `test_quotient_certification`, `test_monomial_var_product` (27 passed).

## Scope note

Division (`a/g`) and `sqrt(g)` envelope tightening — which would tighten the loose
(but sound) bounds on nvs20/ex1252/nvs05/chance/nvs22 — overlap bucket #1 per the
#139 issue text and are deferred to a separate increment. This PR delivers the
#139 acceptance: *each instance produces a sound lower bound; nvs16 and other
already-handled slices do not regress; no `bound > opt`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
