### PR TITLE
feat(#155): square-of-affine-in-lifted-vars envelope (nvs16 sound bound)

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import itertools
 import logging
 import math
+from collections import Counter
 from dataclasses import dataclass
 from typing import Optional, Union
 
@@ -223,6 +224,23 @@ class UnivariateSquareRelaxation:
     aux_col: int
     base_lb: float
     base_ub: float
+
+
+@dataclass
+class AffineSquareRelaxation:
+    """Univariate square envelope on an affine residual over lifted columns.
+
+    ``r = const + Σ resid[col] * z[col]`` is an affine form whose factors (a
+    bilinear/monomial product) are already lifted to auxiliary columns. ``s`` is
+    the lifted ``r**2`` and ``[r_lb, r_ub]`` is an interval-arithmetic outer
+    bound on ``r`` used to build the tangent/secant square envelope (issue #155).
+    """
+
+    aux_col: int
+    resid: dict[int, float]
+    const: float
+    r_lb: float
+    r_ub: float
 
 
 @dataclass
@@ -434,6 +452,175 @@ def _collect_monomial_terms_for_lift(expr: Expression, model: Model) -> set[tupl
 
     visit(expr)
     return terms
+
+
+# Flat-variable monomial: a sorted tuple of original variable indices, repeated
+# by power (e.g. ``x1**2 * x0`` → ``(0, 1, 1)``).  An affine-square residual is
+# represented as ``(const, [(coeff, monomial), ...])``.
+_Monomial = tuple[int, ...]
+_AffineSquare = tuple[float, list[tuple[float, _Monomial]]]
+
+
+def _product_to_monomial(expr: Expression, model: Model) -> tuple[float, _Monomial] | None:
+    """Fold a pure product of original variables / integer powers / constants.
+
+    Returns ``(scalar, monomial)`` where ``monomial`` is the sorted tuple of
+    original flat variable indices (repeated by power), or ``None`` if the
+    product contains a non-polynomial leaf (a function call, a non-constant
+    division, a fractional power, …).
+    """
+    scalar = [1.0]
+    idxs: list[int] = []
+
+    def visit(e: Expression) -> bool:
+        if isinstance(e, BinaryOp) and e.op == "*":
+            return visit(e.left) and visit(e.right)
+        if isinstance(e, UnaryOp) and e.op == "neg":
+            scalar[0] *= -1.0
+            return visit(e.operand)
+        if isinstance(e, Constant):
+            scalar[0] *= float(e.value)
+            return True
+        flat = _get_flat_index(e, model)
+        if flat is not None:
+            idxs.append(flat)
+            return True
+        if isinstance(e, BinaryOp) and e.op == "**" and isinstance(e.right, Constant):
+            base_flat = _get_flat_index(e.left, model)
+            if base_flat is not None:
+                exp_val = float(e.right.value)
+                n = int(exp_val)
+                if exp_val == n and n >= 1:
+                    idxs.extend([base_flat] * n)
+                    return True
+        return False
+
+    if not visit(expr):
+        return None
+    return scalar[0], tuple(sorted(idxs))
+
+
+def _expr_to_polynomial(expr: Expression, model: Model) -> _AffineSquare | None:
+    """Walk a *distributed* expression into ``(const, [(coeff, monomial), ...])``.
+
+    Returns ``None`` if any leaf is not a polynomial in the original variables
+    (so the caller falls back to the existing relaxation paths instead of
+    misclassifying a transcendental residual).
+    """
+    const = [0.0]
+    terms: list[tuple[float, _Monomial]] = []
+
+    def visit(e: Expression, scale: float) -> bool:
+        if isinstance(e, Constant):
+            const[0] += scale * float(e.value)
+            return True
+        flat = _get_flat_index(e, model)
+        if flat is not None:
+            terms.append((scale, (flat,)))
+            return True
+        if isinstance(e, UnaryOp):
+            if e.op == "neg":
+                return visit(e.operand, -scale)
+            return False
+        if isinstance(e, SumExpression):
+            return visit(e.operand, scale)
+        if isinstance(e, BinaryOp):
+            if e.op == "+":
+                return visit(e.left, scale) and visit(e.right, scale)
+            if e.op == "-":
+                return visit(e.left, scale) and visit(e.right, -scale)
+            if e.op == "/":
+                if isinstance(e.right, Constant):
+                    denom = float(e.right.value)
+                    if denom == 0.0:
+                        return False
+                    return visit(e.left, scale / denom)
+                return False
+            if e.op == "*":
+                decomp = _product_to_monomial(e, model)
+                if decomp is None:
+                    return False
+                coeff, monomial = decomp
+                terms.append((scale * coeff, monomial))
+                return True
+            if e.op == "**":
+                decomp = _product_to_monomial(e, model)
+                if decomp is None:
+                    return False
+                coeff, monomial = decomp
+                terms.append((scale * coeff, monomial))
+                return True
+        return False
+
+    if not visit(expr, 1.0):
+        return None
+    return const[0], terms
+
+
+def _extract_affine_square(expr: Expression, model: Model) -> _AffineSquare | None:
+    """Recognize ``E**2`` where ``E`` is an affine combination of liftable products.
+
+    Returns the residual polynomial ``(const, terms)`` for ``E`` when ``E``
+    distributes into a sum of at least two addends with at least one genuinely
+    nonlinear term (a product or power ≥ 2) — the shape that, if the square were
+    distributed, would blow up into high-degree monomials (issue #155). Returns
+    ``None`` for transcendental residuals, pure quadratic forms of a linear
+    residual, and single-term squares (handled by the existing pipelines).
+    """
+    if not (
+        isinstance(expr, BinaryOp)
+        and expr.op == "**"
+        and isinstance(expr.right, Constant)
+        and float(expr.right.value) == 2.0
+    ):
+        return None
+    base = distribute_products(expr.left)
+    poly = _expr_to_polynomial(base, model)
+    if poly is None:
+        return None
+    const, terms = poly
+    if not any(len(monomial) >= 2 for _coeff, monomial in terms):
+        return None
+    n_addends = len(terms) + (1 if const != 0.0 else 0)
+    if n_addends < 2:
+        return None
+    return const, terms
+
+
+def _collect_affine_squares(model: Model) -> list[tuple[Expression, _AffineSquare]]:
+    """Find every ``E**2`` affine-square node in the objective and constraints."""
+    found: list[tuple[Expression, _AffineSquare]] = []
+    seen: set[int] = set()
+
+    def visit(e: Expression) -> None:
+        info = _extract_affine_square(e, model)
+        if info is not None and id(e) not in seen:
+            seen.add(id(e))
+            found.append((e, info))
+            # The residual is lifted wholesale; do not descend into it.
+            return
+        if isinstance(e, BinaryOp):
+            visit(e.left)
+            visit(e.right)
+        elif isinstance(e, UnaryOp):
+            visit(e.operand)
+        elif isinstance(e, FunctionCall):
+            for arg in e.args:
+                visit(arg)
+        elif isinstance(e, IndexExpression):
+            if not isinstance(e.base, Variable):
+                visit(e.base)
+        elif isinstance(e, SumExpression):
+            visit(e.operand)
+        elif isinstance(e, SumOverExpression):
+            for term in e.terms:
+                visit(term)
+
+    if model._objective is not None:
+        visit(model._objective.expression)
+    for constraint in model._constraints:
+        visit(constraint.body)
+    return found
 
 
 def _build_minmax_objective_lift(
@@ -2882,7 +3069,23 @@ def build_milp_relaxation(
                 distribute_products(model._objective.expression), model
             )
         )
-    monomial_terms = sorted(set(terms.monomial) | objective_lift_monomials)
+    # ── Square-of-affine-in-lifted-vars residuals (issue #155) ──────────────
+    # ``(1.5 - x0*(1-x1))**2``-style terms are lifted wholesale to a univariate
+    # square envelope on the affine residual rather than distributed into the
+    # catastrophic high-degree monomials (~1e18 on nvs16) that the magnitude cap
+    # would otherwise drop. Collect the squares now so every single-variable
+    # power factor (``x1**2``, ``x1**3``) the residual needs is allocated through
+    # the standard monomial machinery (column + tangent/secant envelope) below.
+    affine_squares = _collect_affine_squares(model)
+    affine_square_monomials: set[tuple[int, int]] = set()
+    for _node, (_const, sq_terms) in affine_squares:
+        for _coeff, monomial in sq_terms:
+            for var_idx, power in Counter(monomial).items():
+                if power >= 2:
+                    affine_square_monomials.add((var_idx, power))
+    monomial_terms = sorted(
+        set(terms.monomial) | objective_lift_monomials | affine_square_monomials
+    )
 
     def _record_generation_guardrail(
         kind: str,
@@ -3392,6 +3595,92 @@ def build_milp_relaxation(
         final_col, stages = _ensure_multilinear_aux(multi_term)
         multilinear_var_map[multi_term] = final_col
         multilinear_stage_map[multi_term] = stages
+
+    # ── Square-of-affine-in-lifted-vars envelopes (issue #155) ──────────────
+    # For each recognized ``E**2`` residual, lift every product factor to a
+    # column (monomial aux for ``x**n``, recursive bilinear chain for products),
+    # build the affine residual ``r`` over those columns, and allocate ``s = r^2``
+    # with an interval-arithmetic bound on ``r``. The tangent/secant envelope is
+    # emitted with the other square rows; the linearizer resolves the protected
+    # ``**2`` node to ``s`` through ``composite_var_map``.
+    affine_square_relaxations: list[AffineSquareRelaxation] = []
+    affine_square_protected_ids: set[int] = set()
+
+    def _lift_monomial_column(monomial: _Monomial) -> Optional[int]:
+        """Column for a product of original variables, or None if not liftable."""
+        power_cols: list[int] = []
+        for var_idx, power in sorted(Counter(monomial).items()):
+            if power == 1:
+                power_cols.append(var_idx)
+            else:
+                mono_col = monomial_var_map.get((var_idx, power))
+                if mono_col is None:
+                    # The monomial was dropped by the magnitude cap; the whole
+                    # square cannot be lifted soundly, so fall back (skip it).
+                    return None
+                power_cols.append(mono_col)
+        if not power_cols:
+            return None
+        col = power_cols[0]
+        for nxt in power_cols[1:]:
+            col = _ensure_bilinear_aux(col, nxt)
+        return col
+
+    for node, (sq_const, sq_terms) in affine_squares:
+        resid: dict[int, float] = {}
+        residual_const = float(sq_const)
+        liftable = True
+        for coeff, monomial in sq_terms:
+            if not monomial:
+                residual_const += coeff
+                continue
+            lifted_col = _lift_monomial_column(monomial)
+            if lifted_col is None:
+                liftable = False
+                break
+            resid[lifted_col] = resid.get(lifted_col, 0.0) + coeff
+        if not liftable or not resid:
+            continue
+
+        r_lb = residual_const
+        r_ub = residual_const
+        finite = True
+        for col, coeff in resid.items():
+            clo, chi = (float(v) for v in all_bounds[col])
+            if not (_is_effectively_finite(clo) and _is_effectively_finite(chi)):
+                finite = False
+                break
+            lo_contrib = coeff * clo if coeff >= 0.0 else coeff * chi
+            hi_contrib = coeff * chi if coeff >= 0.0 else coeff * clo
+            r_lb += lo_contrib
+            r_ub += hi_contrib
+        if not finite or not (np.isfinite(r_lb) and np.isfinite(r_ub)) or r_ub < r_lb:
+            continue
+
+        s_lb = 0.0 if r_lb <= 0.0 <= r_ub else min(r_lb * r_lb, r_ub * r_ub)
+        s_ub = max(r_lb * r_lb, r_ub * r_ub)
+        # Cap an extreme square upper bound to avoid a numerically degenerate LP
+        # (the residual range legitimately reaches ~1.6e9 on nvs16, so s_ub ~1e18).
+        # An unbounded-above aux is sound: the lower bound comes from the tangent
+        # underestimators and the column's own lower bound s_lb.
+        if not np.isfinite(s_ub) or s_ub > _MONOMIAL_AUX_BOUND_LIMIT:
+            s_ub = np.inf
+
+        s_col = col_idx
+        all_bounds.append((float(s_lb), float(s_ub)))
+        integrality_flags.append(0)
+        col_idx += 1
+        affine_square_relaxations.append(
+            AffineSquareRelaxation(
+                aux_col=s_col,
+                resid=resid,
+                const=residual_const,
+                r_lb=float(r_lb),
+                r_ub=float(r_ub),
+            )
+        )
+        composite_var_map[id(node)] = s_col
+        affine_square_protected_ids.add(id(node))
 
     bilinear_pw_map: dict[tuple[int, int], list] = {}
     bilinear_lambda_map: dict[tuple[int, int], dict] = {}
@@ -4445,6 +4734,48 @@ def build_milp_relaxation(
             row[square_relax.base_col] = -(lb_i + ub_i)
             _add_row(row, -lb_i * ub_i)
 
+    # ── Square-of-affine-in-lifted-vars envelopes (issue #155) ──────────────
+    # ``s = r**2`` over the affine residual ``r = const + Σ resid[col]*z[col]``,
+    # ``r ∈ [r_lb, r_ub]``. ``s`` convex → tangent under-estimators and a secant
+    # over-estimator. Every row is an individually valid bound, so any row whose
+    # coefficients or rhs reach an extreme magnitude (the residual range hits
+    # ~1.6e9 on nvs16, so a tangent at the far endpoint carries a ~1e18 constant)
+    # is dropped to keep the LP well-conditioned — omitting an over/under-estimator
+    # only enlarges the feasible region and keeps the dual bound sound. The
+    # tangent at ``r = 0`` (and the column lower bound ``s_lb``) still pins
+    # ``s ≥ 0``, recovering the trivial sum-of-squares bound.
+    def _affine_square_row_ok(row: np.ndarray, rhs: float) -> bool:
+        if not np.isfinite(rhs) or abs(rhs) > _MONOMIAL_AUX_BOUND_LIMIT:
+            return False
+        nz = np.flatnonzero(row)
+        return bool(nz.size) and float(np.max(np.abs(row[nz]))) <= _MONOMIAL_AUX_BOUND_LIMIT
+
+    for sq in affine_square_relaxations:
+        r_lb = sq.r_lb
+        r_ub = sq.r_ub
+        tangent_pts = [r_lb, r_ub]
+        if r_lb <= 0.0 <= r_ub:
+            tangent_pts.append(0.0)
+        # Tangent under-estimators: s ≥ 2t*r - t^2  →  -s + 2t*r ≤ t^2.
+        for t in _sorted_unique_points(tangent_pts):
+            row = np.zeros(n_total)
+            row[sq.aux_col] = -1.0
+            for col, coeff in sq.resid.items():
+                row[col] += 2.0 * t * coeff
+            rhs = t * t - 2.0 * t * sq.const
+            if _affine_square_row_ok(row, rhs):
+                _add_row(row, rhs)
+        # Secant over-estimator: s ≤ (r_lb+r_ub)*r - r_lb*r_ub.
+        if abs(r_ub - r_lb) > 1e-12:
+            slope = r_lb + r_ub
+            row = np.zeros(n_total)
+            row[sq.aux_col] = 1.0
+            for col, coeff in sq.resid.items():
+                row[col] += -slope * coeff
+            rhs = slope * sq.const - r_lb * r_ub
+            if _affine_square_row_ok(row, rhs):
+                _add_row(row, rhs)
+
     # ── Fractional-power envelope constraints ──────────────────────────────
     # For a = x^p with x in [lb, ub], lb ≥ 0:
     #   - 0 < p < 1 (concave on x ≥ 0):
@@ -4581,8 +4912,11 @@ def build_milp_relaxation(
                 _add_row(row, const_branch)
 
     # Model constraints
+    protected_squares = (
+        frozenset(affine_square_protected_ids) if affine_square_protected_ids else None
+    )
     for constraint in model._constraints:
-        body = distribute_products(constraint.body)
+        body = distribute_products(constraint.body, protected_squares)
         sense = constraint.sense
         if sense == "<=":
             exact_row = _exact_positive_reciprocal_row(body, model, flat_lb, flat_ub)
@@ -4653,7 +4987,7 @@ def build_milp_relaxation(
 
     # ── Objective ────────────────────────────────────────────────────────────
     assert model._objective is not None
-    obj_expr = distribute_products(model._objective.expression)
+    obj_expr = distribute_products(model._objective.expression, protected_squares)
     try:
         if objective_lift is not None:
             c_obj = np.zeros(n_total)

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -248,7 +248,9 @@ def _distribute_mul(left: Expression, right: Expression) -> Expression:
     return BinaryOp("*", left, right)
 
 
-def distribute_products(expr: Expression) -> Expression:
+def distribute_products(
+    expr: Expression, protected_squares: frozenset[int] | None = None
+) -> Expression:
     """Recursively distribute multiplication over addition/subtraction.
 
     ``(a + b) * c`` → ``a*c + b*c``;  ``c * (a - b)`` → ``c*a - c*b``.
@@ -263,13 +265,22 @@ def distribute_products(expr: Expression) -> Expression:
     and rebuilding already-flat subtrees — quadratic-to-exponential node creation
     even when the final expansion is small (e.g. a chain of small squared sums
     blew up to tens of millions of throwaway nodes).
+
+    ``protected_squares`` holds ``id()`` values of ``E**2`` nodes that must be
+    left intact rather than distributed.  The MILP relaxation lifts such a square
+    to a single auxiliary column with a univariate square envelope on the affine
+    residual ``E`` (issue #155); distributing it would re-expand ``E**2`` into the
+    catastrophic high-degree monomials the lift exists to avoid.  Preserving the
+    node's identity also lets the linearizer resolve it through its id-keyed map.
     """
     if isinstance(expr, BinaryOp):
         if expr.op == "**" and isinstance(expr.right, Constant) and float(expr.right.value) == 2.0:
-            left = distribute_products(expr.left)
+            if protected_squares is not None and id(expr) in protected_squares:
+                return expr
+            left = distribute_products(expr.left, protected_squares)
             return _distribute_mul(left, left)
-        left = distribute_products(expr.left)
-        right = distribute_products(expr.right)
+        left = distribute_products(expr.left, protected_squares)
+        right = distribute_products(expr.right, protected_squares)
         if expr.op == "*":
             return _distribute_mul(left, right)
         # Preserve node identity when nothing distributed, so id()-keyed maps
@@ -278,7 +289,7 @@ def distribute_products(expr: Expression) -> Expression:
             return expr
         return BinaryOp(expr.op, left, right)
     if isinstance(expr, UnaryOp):
-        operand = distribute_products(expr.operand)
+        operand = distribute_products(expr.operand, protected_squares)
         if operand is expr.operand:
             return expr
         return UnaryOp(expr.op, operand)

--- a/python/tests/test_affine_square_envelope.py
+++ b/python/tests/test_affine_square_envelope.py
@@ -1,0 +1,104 @@
+"""Adversarial soundness tests for the square-of-affine-in-lifted-vars envelope.
+
+Issue #155 lifts ``(affine-in-lifted-vars)**2`` residuals to a univariate square
+envelope instead of distributing them into catastrophic high-degree monomials.
+The soundness mandate is that the envelope must *underestimate* ``r**2`` over the
+*true* range of the residual ``r``; a wrong lifted-var range would make the dual
+bound unsound. These tests construct squares whose residual ranges straddle zero
+and sit fully on either side, and check the root McCormick LP bound never exceeds
+the true minimum of the objective sampled over the (integer) box.
+"""
+
+import itertools
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+import pytest
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.milp_relaxation import _extract_affine_square
+from discopt._jax.model_utils import flat_variable_bounds
+
+
+def _true_min_over_box(fn, lo, hi):
+    """Brute-force minimum of ``fn(x0, x1)`` over the integer box [lo, hi]^2."""
+    best = float("inf")
+    for x0, x1 in itertools.product(range(lo, hi + 1), range(lo, hi + 1)):
+        best = min(best, fn(x0, x1))
+    return best
+
+
+def _root_bound(model):
+    relaxer = MccormickLPRelaxer(model)
+    lb, ub = flat_variable_bounds(model)
+    res = relaxer.solve_at_node(lb, ub)
+    assert res.status == "optimal", f"root LP status {res.status}"
+    return res.lower_bound
+
+
+# (label, build_objective(x0, x1) -> Expression, true_fn(x0, x1) -> float, box)
+# Each residual is affine in lifted products (x0*x1 etc.) and its range crosses
+# zero, is strictly positive, or is strictly negative depending on the constant.
+_CASES = [
+    # Mixed-sign residual: r = x0*x1 - 9 ranges over [-9, 16] on [0,4]^2.
+    ("mixed_sign", lambda x0, x1: (x0 * x1 - 9) ** 2, lambda a, b: (a * b - 9) ** 2, (0, 4)),
+    # Strictly positive residual: r = x0*x1 + 5 ranges over [5, 21] on [0,4]^2.
+    ("positive", lambda x0, x1: (x0 * x1 + 5) ** 2, lambda a, b: (a * b + 5) ** 2, (0, 4)),
+    # Strictly negative residual: r = -x0*x1 - 2 ranges over [-18, -2] on [0,4]^2.
+    (
+        "negative",
+        lambda x0, x1: (-x0 * x1 - 2) ** 2,
+        lambda a, b: (-a * b - 2) ** 2,
+        (0, 4),
+    ),
+    # Affine sum residual: r = 1.5 - x0 + x0*x1 (the nvs16 r1 shape).
+    (
+        "nvs16_r1_shape",
+        lambda x0, x1: (1.5 - x0 * (1 - x1)) ** 2,
+        lambda a, b: (1.5 - a * (1 - b)) ** 2,
+        (0, 5),
+    ),
+]
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("label, build_obj, true_fn, box", _CASES)
+def test_affine_square_bound_is_sound(label, build_obj, true_fn, box):
+    lo, hi = box
+    m = dm.Model()
+    x = m.integer("x", shape=2, lb=lo, ub=hi)
+    m.minimize(build_obj(x[0], x[1]))
+
+    # The objective square must be recognized as an affine-square residual.
+    assert _extract_affine_square(m._objective.expression, m) is not None, (
+        f"[{label}] objective square not recognized as affine-in-lifted"
+    )
+
+    bound = _root_bound(m)
+    assert bound is not None, f"[{label}] objective dropped — no root bound"
+
+    true_min = _true_min_over_box(true_fn, lo, hi)
+    # The soundness invariant: a valid lower bound never exceeds the true optimum.
+    assert bound <= true_min + 1e-6, f"[{label}] UNSOUND bound {bound} > true min {true_min}"
+
+
+@pytest.mark.correctness
+def test_pure_quadratic_form_is_not_hijacked():
+    """A square of a *linear* residual (no lifted product) is left to the existing
+    bilinear/monomial pipeline — the affine-square detector must not fire on it."""
+    m = dm.Model()
+    x = m.continuous("x", shape=2, lb=0.0, ub=4.0)
+    m.minimize((2 * x[0] + 3 * x[1] - 1) ** 2)
+    assert _extract_affine_square(m._objective.expression, m) is None
+
+
+@pytest.mark.correctness
+def test_single_product_square_is_not_hijacked():
+    """``(x0*x1)**2`` is a single-term square; the detector defers to the
+    existing monomial/product handling rather than lifting a one-term residual."""
+    m = dm.Model()
+    x = m.continuous("x", shape=2, lb=0.0, ub=4.0)
+    m.minimize((x[0] * x[1]) ** 2)
+    assert _extract_affine_square(m._objective.expression, m) is None

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -11,11 +11,12 @@ the extreme-magnitude monomial guard now lift them soundly.
 
 Soundness is the invariant under test: a valid lower bound must NEVER exceed the
 true optimum. We assert the root McCormick LP bound is finite and ``<= opt`` for
-the eight liftable instances. ``nvs16`` is the lone exception — its objective is
-a Beale sum-of-squares that distributes into degree-8 monomials of magnitude
-~1e18 over the integer box ``[0, 200]**2``; a proper square-of-affine-in-lifted
-envelope is follow-up work. It currently yields no root objective bound on *main*
-too, so we assert only that it has not regressed (no bound, or a sound one).
+every liftable instance. ``nvs16`` — the Beale sum-of-squares over the integer
+box ``[0, 200]**2`` whose naive distribution explodes into degree-8 monomials of
+magnitude ~1e18 — is now lifted via the square-of-affine-in-lifted-vars envelope
+(issue #155): each residual ``r_i`` is affine in lifted product columns and
+``r_i**2`` gets a univariate square envelope, recovering the trivial sound bound
+``>= 0`` without any catastrophic expansion.
 
 Reference optima are the MINLPLib values (cross-checked against
 ``discopt_benchmarks`` problem definitions).
@@ -48,6 +49,7 @@ _SOUND_BOUND_CASES = [
     ("nvs22", 6.0584),
     ("chance", 29.8945),
     ("st_e36", -246.0),
+    ("nvs16", 0.703125),
 ]
 
 
@@ -73,12 +75,14 @@ def test_bucket2_instance_has_sound_root_bound(instance, optimum):
 
 
 @pytest.mark.correctness
-def test_nvs16_does_not_regress():
-    """``nvs16`` (Beale sum-of-squares, integer box [0,200]^2) distributes into
-    ~1e18-magnitude monomials, so its objective legitimately drops from the root
-    relaxation today. The bucket-2 acceptance requires only that it not regress:
-    the root LP must still solve (no spurious infeasibility), and any bound it
-    does produce must be sound (<= optimum 0.703125)."""
+def test_nvs16_produces_sound_finite_bound():
+    """``nvs16`` (Beale sum-of-squares, integer box [0,200]^2) used to distribute
+    into ~1e18-magnitude monomials and drop its objective. The
+    square-of-affine-in-lifted-vars envelope (issue #155) now lifts each residual
+    ``r_i`` affinely and applies a univariate square envelope on ``r_i**2``,
+    avoiding any distributive blow-up. We require a *finite* root bound (the
+    objective no longer drops) that is sound (``<= optimum 0.703125``); because the
+    objective is a sum of squares, the recovered bound is the trivial ``>= 0``."""
     nl = _DATA / "nvs16.nl"
     assert nl.exists(), f"missing {nl}"
     m = dm.from_nl(str(nl))
@@ -89,9 +93,10 @@ def test_nvs16_does_not_regress():
 
     # No false-infeasibility — the LP itself must solve cleanly.
     assert res.status == "optimal", f"nvs16 root LP status {res.status}"
-    # The objective may drop (no bound) — that is the current, non-regressed
-    # state — but if a bound IS produced it must underestimate the optimum.
-    if res.lower_bound is not None and math.isfinite(res.lower_bound):
-        assert res.lower_bound <= 0.703125 + 1e-3, (
-            f"nvs16 UNSOUND bound {res.lower_bound} > 0.703125"
-        )
+    # The objective no longer drops: a finite bound must be produced.
+    assert res.lower_bound is not None, "nvs16 objective dropped — no root bound"
+    assert math.isfinite(res.lower_bound), f"nvs16 non-finite bound {res.lower_bound}"
+    # Sum of squares ⇒ the sound bound is ≥ 0 and must not exceed the optimum.
+    assert -1e-6 <= res.lower_bound <= 0.703125 + 1e-3, (
+        f"nvs16 bound {res.lower_bound} outside sound range [0, 0.703125]"
+    )


### PR DESCRIPTION
nvs16 (Beale sum-of-squares over the integer box [0,200]^2) used to drop
its objective from the McCormick relaxation: distributing each squared
residual produced degree-8 monomials of magnitude ~1e18, which the #153
magnitude cap soundly omits, leaving bound=None.

Recognize ``(affine-in-lifted-vars)**2`` instead of distributing it:
each residual r_i is affine in lifted product columns (x0*x1, x1**2*x0,
x1**3*x0 — built via the existing monomial + recursive-bilinear
machinery), and r_i**2 gets a univariate square envelope (tangent
under-estimators + secant over-estimator) on the interval-arithmetic
range of r_i. Because the objective is a sum of squares, this recovers
the trivial sound bound >= 0 (true optimum 0.703125) with no
distributive blow-up.

Soundness guards: the square aux upper bound and any envelope row whose
coefficients/rhs reach an extreme magnitude are dropped (an omitted
over/under-estimator only enlarges the feasible region), so the residual
range legitimately reaching ~1.6e9 never injects a ~1e18 constant into
the LP. The detector fires only on multi-addend residuals with a genuine
nonlinear term, leaving pure quadratic forms and single-product squares
to the existing pipelines.

- term_classifier.distribute_products: optional protected_squares set so
  recognized E**2 nodes survive distribution with their identity intact.
- milp_relaxation: affine-square detection, residual lifting, square
  aux + tangent/secant envelope, linearizer mapping via composite map.
- tests: nvs16 promoted to a positive sound-bound assertion; new
  adversarial soundness suite over mixed-sign / one-sided residual ranges.