### PR TITLE
feat(#154): lifted reciprocal/sqrt envelopes for bucket-2 (nvs05/nvs22 tighten)

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -75,14 +75,23 @@ _warned_messages: set[str] = set()
 _MAX_INTEGER_COS_ENUM = 10000
 _MAX_FINITE_EXP_ARG = float(np.log(np.finfo(np.float64).max))
 _MAX_TRIG_PIECEWISE_SPAN = 2.0 * math.pi
-# Conditioning guard for fractional-power envelopes (issue #158). A power
-# ``x**p`` with ``p<0`` (or ``0<p<1``) over a box whose lower bound reaches
-# toward zero has tangent/secant slopes (``p*t**(p-1)`` and the secant over
-# ``[lb,ub]``) that blow up, reaching ~1e9+. An LP row carrying such a coefficient
-# against an RHS of order 1 is numerically unreliable: HiGHS returns a polytope
-# that EXCLUDES feasible points, so OBBT shrinks a variable past its true feasible
-# range and the per-node relaxer reports a feasible node "infeasible" (the nvs08
-# false optimum). Refuse to emit any envelope cut whose slope exceeds this limit;
+# Lifted ``1/g`` (issue #154) is convex only on ``g > 0``; require the inner
+# interval's lower end to clear this strictly-positive floor so the reciprocal
+# and its tangent slopes (``-1/g**2``) stay finite and well-conditioned.
+_RECIP_MIN_DENOM = 1e-6
+# Lifted ``sqrt(g)`` needs ``g >= 0``; tolerate a tiny negative slack from loose
+# interval bounds on a provably-nonnegative argument (sum of squares) and clamp.
+_SQRT_NEG_TOL = 1e-9
+# Conditioning guard shared by the fractional-power envelopes (issue #158) and the
+# lifted reciprocal/sqrt envelopes (issue #154). A power ``x**p`` with ``p<0`` (or
+# ``0<p<1``) near a small lower bound, the convex ``1/g`` slope ``-1/g**2``, and the
+# concave ``sqrt(g)`` slope ``1/(2*sqrt(g))`` all blow up (reaching ~1e9+) as the
+# interval's lower end approaches zero. An LP row carrying such a coefficient against
+# an RHS of order 1 is numerically unreliable: HiGHS returns a polytope that EXCLUDES
+# feasible points (so OBBT shrinks a variable past its true feasible range and the
+# per-node relaxer reports a feasible node "infeasible" — the nvs08 false optimum),
+# or stalls at ``iteration_limit`` with a partial objective that is NOT a valid dual
+# bound. Refuse to emit/lift any envelope cut whose slope exceeds this limit;
 # dropping a cut only ENLARGES the relaxation, so abstention is always sound.
 _LIFT_MAX_ENVELOPE_SLOPE = 1e6
 
@@ -3706,6 +3715,256 @@ def build_milp_relaxation(
         composite_var_map[id(node)] = s_col
         affine_square_protected_ids.add(id(node))
 
+    # ── Lifted reciprocal / sqrt of a bounded inner expression (issue #154) ──
+    # ``c / g`` and ``sqrt(g)`` are dropped by the affine-only univariate path
+    # whenever ``g`` is itself nonlinear (a product or a sum of products), which
+    # leaves the defining equality (e.g. ``x4 = 4243.28/(x0*x1)``) omitted and
+    # the root bound loose. Here we *force-lift* ``g`` to an affine combination
+    # over the extended variable space: every multiplicative factor — including
+    # squares ``x*x`` (built as the McCormick bilinear ``x·x``) — becomes a
+    # bounded product aux column via ``_ensure_bilinear_aux``, which auto-emits
+    # its McCormick envelope through ``bilinear_relation_map``. When ``g`` resolves
+    # and its interval is finite with the right sign — ``g > 0`` for ``1/g``
+    # (convex), ``g >= 0`` for ``sqrt(g)`` (concave) — we lift an aux column for
+    # the outer atom and let the standard convex/concave envelope (tangents +
+    # secant) cut it.
+    #
+    # Soundness: at any true feasible point set each product aux to its exact
+    # value (the McCormick envelope contains the true product), so ``g`` is exact
+    # and the outer convex/concave envelope encloses the curve; the relaxation
+    # feasible set is therefore a superset of the true one and the dual bound
+    # stays valid. We deliberately abstain (fall back to warn-and-omit, which only
+    # enlarges the feasible region) on anything not provably sound here: a
+    # square-of-affine with cross terms ``(a·x+b·y)**2`` (deferred to the
+    # square-of-affine envelope, #155), a non-constant numerator, an unbounded or
+    # wrong-sign interval, or a product whose aux bound magnitude blows past the
+    # monomial limit (ex1252's ~1e15 terms).
+    def _extended_affine_interval(arg_coeff: np.ndarray, arg_const: float) -> tuple[float, float]:
+        lo = float(arg_const)
+        hi = float(arg_const)
+        for j in np.flatnonzero(arg_coeff):
+            c = float(arg_coeff[j])
+            clb, cub = all_bounds[j]
+            terms_j = (c * float(clb), c * float(cub))
+            lo += min(terms_j)
+            hi += max(terms_j)
+        return lo, hi
+
+    _MAX_FORCED_POWER = 4
+
+    def _ensure_bounded_bilinear(lhs_col: int, rhs_col: int) -> Optional[int]:
+        """Force-create the product aux for two bounded columns (``x*y``, or
+        ``x*x`` for a square), or ``None`` if a factor is unbounded or the product
+        aux's bound magnitude exceeds the monomial limit (kept numerically tame)."""
+        for c in (lhs_col, rhs_col):
+            lo, hi = all_bounds[c]
+            if not (np.isfinite(lo) and np.isfinite(hi)):
+                return None
+        a_lo, a_hi = (float(v) for v in all_bounds[lhs_col])
+        b_lo, b_hi = (float(v) for v in all_bounds[rhs_col])
+        corners = [a_lo * b_lo, a_lo * b_hi, a_hi * b_lo, a_hi * b_hi]
+        if max(abs(min(corners)), abs(max(corners))) > _MONOMIAL_AUX_BOUND_LIMIT:
+            return None
+        return _ensure_bilinear_aux(lhs_col, rhs_col)
+
+    def _lift_factor_to_col(expr: Expression) -> Optional[int]:
+        """Reduce one multiplicative factor to a single bounded column, creating
+        product aux columns as needed. Claims only bounded original variables,
+        their pairwise/iterated products, and positive-integer powers of a single
+        bounded variable. Abstains (``None``) on affine-base powers/squares so the
+        cross-term square-of-affine envelope (#155) stays the path for those."""
+        flat = _get_flat_index(expr, model)
+        if flat is not None:
+            lo, hi = all_bounds[flat]
+            if not (np.isfinite(lo) and np.isfinite(hi)):
+                return None
+            return flat
+        if isinstance(expr, BinaryOp) and expr.op == "*":
+            lcol = _lift_factor_to_col(expr.left)
+            if lcol is None:
+                return None
+            rcol = _lift_factor_to_col(expr.right)
+            if rcol is None:
+                return None
+            return _ensure_bounded_bilinear(lcol, rcol)
+        if isinstance(expr, BinaryOp) and expr.op == "**" and isinstance(expr.right, Constant):
+            p = float(expr.right.value)
+            if p.is_integer() and 2 <= int(p) <= _MAX_FORCED_POWER:
+                base = _lift_factor_to_col(expr.left)
+                if base is None:
+                    return None
+                col = base
+                for _ in range(int(p) - 1):
+                    nxt = _ensure_bounded_bilinear(col, base)
+                    if nxt is None:
+                        return None
+                    col = nxt
+                return col
+        return None
+
+    def _lift_inner_to_affine(expr: Expression) -> Optional[tuple[dict[int, float], float]]:
+        """Resolve ``g`` to ``(coeffs, const)`` over the extended column space,
+        force-lifting product factors. ``None`` to abstain on any unclaimed shape."""
+        c = _constant_value(expr)
+        if c is not None:
+            return {}, float(c)
+        if isinstance(expr, BinaryOp) and expr.op in ("+", "-"):
+            left = _lift_inner_to_affine(expr.left)
+            if left is None:
+                return None
+            right = _lift_inner_to_affine(expr.right)
+            if right is None:
+                return None
+            lc, lconst = left
+            rc, rconst = right
+            sign = 1.0 if expr.op == "+" else -1.0
+            out = dict(lc)
+            for k, v in rc.items():
+                out[k] = out.get(k, 0.0) + sign * v
+            return out, lconst + sign * rconst
+        if isinstance(expr, BinaryOp) and expr.op == "*":
+            lconst_val = _constant_value(expr.left)
+            rconst_val = _constant_value(expr.right)
+            scale = lconst_val if lconst_val is not None else rconst_val
+            if scale is not None:
+                sub = expr.right if lconst_val is not None else expr.left
+                inner = _lift_inner_to_affine(sub)
+                if inner is None:
+                    return None
+                sc, sconst = inner
+                return {k: scale * v for k, v in sc.items()}, scale * sconst
+        if isinstance(expr, UnaryOp) and expr.op == "-":
+            inner = _lift_inner_to_affine(expr.operand)
+            if inner is None:
+                return None
+            sc, sconst = inner
+            return {k: -v for k, v in sc.items()}, -sconst
+        col = _lift_factor_to_col(expr)
+        if col is None:
+            return None
+        return {col: 1.0}, 0.0
+
+    def _maybe_lift_outer_atom(expr: Expression) -> None:
+        nonlocal col_idx
+        eid = id(expr)
+        if eid in univariate_var_map or eid in composite_var_map:
+            return
+        if isinstance(expr, BinaryOp) and expr.op == "/":
+            num = _constant_value(expr.left)
+            if num is None:
+                return
+            func_name, inner = "reciprocal", expr.right
+        elif isinstance(expr, FunctionCall) and expr.func_name == "sqrt" and len(expr.args) == 1:
+            func_name, inner = "sqrt", expr.args[0]
+        else:
+            return
+
+        lifted = _lift_inner_to_affine(inner)
+        if lifted is None:
+            return
+        coeffs, arg_const = lifted
+
+        # A purely-affine inner over original variables is already handled by the
+        # standard univariate path; only claim genuinely lifted (aux-referencing)
+        # arguments so we never shadow or double-count that path.
+        if not any(col >= n_orig for col in coeffs):
+            return
+
+        arg_coeff = np.zeros(col_idx)
+        for col, val in coeffs.items():
+            arg_coeff[col] = val
+
+        gl, gh = _extended_affine_interval(arg_coeff, arg_const)
+        if not (np.isfinite(gl) and np.isfinite(gh)) or gh < gl:
+            return
+        if func_name == "reciprocal":
+            if gl <= _RECIP_MIN_DENOM:
+                return
+            # Tangent slope ``-1/gl**2`` is the largest coefficient the envelope
+            # injects; refuse a numerically degenerate cut.
+            if 1.0 / (gl * gl) > _LIFT_MAX_ENVELOPE_SLOPE:
+                return
+            val_lb, val_ub = 1.0 / gh, 1.0 / gl
+        else:  # sqrt
+            if gl < -_SQRT_NEG_TOL:
+                return
+            gl = max(gl, 0.0)
+            # Concave-tangent overestimator slope ``1/(2*sqrt(t))`` blows up as
+            # ``t→0``. The emission places tangents at ``[lb, mid, ub]`` but skips
+            # any ``pt <= 0`` (``_tangent_points``), so when ``gl == 0`` the worst
+            # emitted tangent sits at the midpoint ``gh/2`` (well-conditioned);
+            # otherwise it sits at ``gl``. Guard that worst emitted slope.
+            slope_pt = gl if gl > 0.0 else 0.5 * gh
+            if slope_pt <= 0.0 or 1.0 / (2.0 * np.sqrt(slope_pt)) > _LIFT_MAX_ENVELOPE_SLOPE:
+                return
+            val_lb, val_ub = float(np.sqrt(gl)), float(np.sqrt(gh))
+        if not (np.isfinite(val_lb) and np.isfinite(val_ub)):
+            return
+
+        aux_col = col_idx
+        univariate_var_map[eid] = aux_col
+        univariate_relaxations.append(
+            UnivariateRelaxation(
+                expr_id=eid,
+                func_name=func_name,
+                aux_col=aux_col,
+                arg_coeff=arg_coeff,
+                arg_const=float(arg_const),
+                arg_lb=float(gl),
+                arg_ub=float(gh),
+            )
+        )
+        all_bounds.append((float(val_lb), float(val_ub)))
+        integrality_flags.append(0)
+        col_idx += 1
+
+    def _walk_lift(expr: Expression) -> None:
+        _maybe_lift_outer_atom(expr)
+        if isinstance(expr, BinaryOp):
+            _walk_lift(expr.left)
+            _walk_lift(expr.right)
+        elif isinstance(expr, UnaryOp):
+            _walk_lift(expr.operand)
+        elif isinstance(expr, FunctionCall):
+            for arg in expr.args:
+                _walk_lift(arg)
+        elif isinstance(expr, IndexExpression):
+            if not isinstance(expr.base, Variable):
+                _walk_lift(expr.base)
+        elif isinstance(expr, SumExpression):
+            _walk_lift(expr.operand)
+        elif isinstance(expr, SumOverExpression):
+            for term in expr.terms:
+                _walk_lift(term)
+
+    # Distribute products ONCE and reuse the *same* trees for both this lift walk
+    # and the constraint/objective linearization later. ``distribute_products``
+    # rebuilds the operator tree (and expands ``(a+b)**2`` into its monomial/
+    # bilinear terms), so a second call would yield different node identities and
+    # the lifted ``univariate_var_map[id(div_or_sqrt_node)]`` keys would not match
+    # the nodes the linearizer visits. Sharing the trees keeps the keys aligned —
+    # and the square expansion lets ``sqrt`` of a cross-term quadratic lift too,
+    # each term enveloped by its own (sound) McCormick product aux.
+    # Protect the #155 affine-square nodes so ``distribute_products`` leaves their
+    # ``**2`` intact (the affine-square envelope resolves them through
+    # ``composite_var_map`` by original node id); every other ``(a+b)**2`` still
+    # expands so the #154 sqrt/reciprocal lift can envelope each product term.
+    protected_squares = (
+        frozenset(affine_square_protected_ids) if affine_square_protected_ids else None
+    )
+    distributed_objective = (
+        distribute_products(model._objective.expression, protected_squares)
+        if model._objective is not None
+        else None
+    )
+    distributed_bodies = {
+        id(c): distribute_products(c.body, protected_squares) for c in model._constraints
+    }
+    if distributed_objective is not None:
+        _walk_lift(distributed_objective)
+    for _constraint in model._constraints:
+        _walk_lift(distributed_bodies[id(_constraint)])
+
     bilinear_pw_map: dict[tuple[int, int], list] = {}
     bilinear_lambda_map: dict[tuple[int, int], dict] = {}
 
@@ -4393,23 +4652,29 @@ def build_milp_relaxation(
 
     # Supported univariate operator graph relaxations.
     def _add_lower_line(relax: UnivariateRelaxation, slope: float, intercept: float) -> None:
-        """Add t >= slope * arg + intercept."""
+        """Add t >= slope * arg + intercept.
+
+        ``arg_coeff`` is normally affine over the original variables
+        (``n_orig`` wide), but a lifted reciprocal/sqrt relaxation expresses its
+        argument over the *extended* space (original + product aux columns), so
+        the slice width follows ``arg_coeff`` rather than a fixed ``n_orig``.
+        """
         row = np.zeros(n_total)
-        row[:n_orig] = slope * relax.arg_coeff
+        row[: relax.arg_coeff.shape[0]] = slope * relax.arg_coeff
         row[relax.aux_col] = -1.0
         _add_row(row, -intercept - slope * relax.arg_const)
 
     def _add_upper_line(relax: UnivariateRelaxation, slope: float, intercept: float) -> None:
         """Add t <= slope * arg + intercept."""
         row = np.zeros(n_total)
-        row[:n_orig] = -slope * relax.arg_coeff
+        row[: relax.arg_coeff.shape[0]] = -slope * relax.arg_coeff
         row[relax.aux_col] = 1.0
         _add_row(row, intercept + slope * relax.arg_const)
 
     def _add_aux_equality(relax: UnivariateRelaxation, coeff: np.ndarray, rhs: float) -> None:
         """Add equality t + coeff @ x = rhs as two inequality rows."""
         row = np.zeros(n_total)
-        row[:n_orig] = coeff
+        row[: coeff.shape[0]] = coeff
         row[relax.aux_col] = 1.0
         _add_row(row, rhs)
         _add_row(-row, -rhs)
@@ -4961,11 +5226,8 @@ def build_milp_relaxation(
                 _add_row(row, const_branch)
 
     # Model constraints
-    protected_squares = (
-        frozenset(affine_square_protected_ids) if affine_square_protected_ids else None
-    )
     for constraint in model._constraints:
-        body = distribute_products(constraint.body, protected_squares)
+        body = distributed_bodies[id(constraint)]
         sense = constraint.sense
         if sense == "<=":
             exact_row = _exact_positive_reciprocal_row(body, model, flat_lb, flat_ub)
@@ -5036,7 +5298,8 @@ def build_milp_relaxation(
 
     # ── Objective ────────────────────────────────────────────────────────────
     assert model._objective is not None
-    obj_expr = distribute_products(model._objective.expression, protected_squares)
+    assert distributed_objective is not None
+    obj_expr = distributed_objective
     try:
         if objective_lift is not None:
             c_obj = np.zeros(n_total)

--- a/python/tests/test_lifted_reciprocal_sqrt_soundness.py
+++ b/python/tests/test_lifted_reciprocal_sqrt_soundness.py
@@ -1,0 +1,280 @@
+"""Adversarial soundness for the lifted reciprocal / sqrt envelopes (#154).
+
+``c / g`` (convex ``1/g`` on ``g > 0``) and ``sqrt(g)`` (concave on ``g >= 0``)
+are *force-lifted* when ``g`` is itself nonlinear (a product or a sum of
+products): every multiplicative factor becomes a bounded McCormick product aux
+and the outer atom gets the standard tangent/secant envelope. This file locks the
+two ways that lift can go wrong:
+
+1. **Unsound cut** — an envelope row that excludes a *true feasible point*. If the
+   underestimator ever rises above the curve (or the overestimator drops below
+   it) the dual bound is no longer valid. We prove enclosure directly: pin the
+   original variables to an interior grid point (a degenerate box), at which the
+   relaxation must still contain the exact curve value, and check the relaxation
+   brackets it from both sides — ``min`` bound ``<= f(pt) <=`` the ``max`` (negated)
+   bound. A bracket that holds at every sampled point means no cut excludes the
+   curve.
+
+2. **Numerically degenerate cut** — a tangent slope so large (``1/gl**2`` as the
+   denominator approaches 0, ``1/(2*sqrt(t))`` as a sqrt argument approaches 0)
+   that the LP is ill-conditioned and the solver returns an ``iteration_limit``
+   objective that is *not* a valid bound. The conditioning guards must make the
+   lift *abstain* (drop the constraint — which only enlarges the feasible region,
+   still sound) rather than emit a degenerate cut. We assert these adversarial
+   boxes never come back ``iteration_limit`` and never report an unsound bound.
+
+The invariant under test is the project's non-negotiable one: a valid lower
+bound never exceeds the true optimum, and the relaxation never excludes a
+feasible point.
+"""
+
+import math
+import os
+from pathlib import Path
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+import pytest
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+
+_TOL = 1e-6
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+
+def _root_bound(model, pin=None):
+    """Root McCormick LP bound, optionally pinning original columns to a point.
+
+    ``pin`` is a dict ``{col_index: value}``; pinning sets ``lb == ub == value``
+    so the box is degenerate at that point.
+    """
+    relaxer = MccormickLPRelaxer(model)
+    lb, ub = flat_variable_bounds(model)
+    lb = lb.copy()
+    ub = ub.copy()
+    if pin is not None:
+        for i, v in pin.items():
+            lb[i] = v
+            ub[i] = v
+    return relaxer.solve_at_node(lb, ub)
+
+
+# ── Curve-enclosure: the envelope never excludes a true feasible point ──────────
+
+
+def _recip_model(const, xb, yb, *, sign=1.0):
+    """``sign * const / (x*y)`` over the given boxes (a lifted reciprocal)."""
+    m = dm.Model()
+    x = m.continuous("x", lb=xb[0], ub=xb[1])
+    y = m.continuous("y", lb=yb[0], ub=yb[1])
+    m.minimize(sign * const / (x * y))
+    return m
+
+
+def _sqrt_model(ab, bb, *, sign=1.0):
+    """``sign * sqrt(a**2 + b**2)`` over the given boxes (a lifted sqrt)."""
+    m = dm.Model()
+    a = m.continuous("a", lb=ab[0], ub=ab[1])
+    b = m.continuous("b", lb=bb[0], ub=bb[1])
+    m.minimize(sign * dm.sqrt(a * a + b * b))
+    return m
+
+
+_RECIP_BOXES = [
+    (1.0, (1.0, 4.0), (2.0, 5.0)),
+    (4243.28, (2.0, 9.0), (3.0, 7.0)),
+    (0.5, (0.5, 2.0), (1.0, 3.0)),
+    (10.0, (1.0, 1.5), (4.0, 6.0)),
+]
+
+_SQRT_BOXES = [
+    ((3.0, 6.0), (4.0, 8.0)),
+    ((1.0, 5.0), (2.0, 9.0)),
+    ((0.5, 2.0), (0.5, 4.0)),
+]
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("const, xb, yb", _RECIP_BOXES)
+def test_reciprocal_envelope_encloses_curve(const, xb, yb):
+    """At every interior grid point the relaxation brackets ``const/(x*y)`` from
+    both sides — the lifted ``1/g`` envelope never excludes the true curve."""
+    xs = [xb[0], 0.5 * (xb[0] + xb[1]), xb[1]]
+    ys = [yb[0], 0.5 * (yb[0] + yb[1]), yb[1]]
+    for xv in xs:
+        for yv in ys:
+            true = const / (xv * yv)
+            lo = _root_bound(_recip_model(const, xb, yb, sign=1.0), pin={0: xv, 1: yv})
+            hi = _root_bound(_recip_model(const, xb, yb, sign=-1.0), pin={0: xv, 1: yv})
+            assert lo.status == "optimal" and lo.lower_bound is not None
+            assert hi.status == "optimal" and hi.lower_bound is not None
+            # underestimator never rises above the curve …
+            assert lo.lower_bound <= true + _TOL, (
+                f"recip under-cut excludes curve at ({xv},{yv}): {lo.lower_bound} > {true}"
+            )
+            # … overestimator never drops below it.
+            assert -hi.lower_bound >= true - _TOL, (
+                f"recip over-cut excludes curve at ({xv},{yv}): {-hi.lower_bound} < {true}"
+            )
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("ab, bb", _SQRT_BOXES)
+def test_sqrt_envelope_encloses_curve(ab, bb):
+    """At every interior grid point the relaxation brackets ``sqrt(a**2+b**2)``
+    from both sides — the lifted concave sqrt envelope never excludes the curve."""
+    as_ = [ab[0], 0.5 * (ab[0] + ab[1]), ab[1]]
+    bs = [bb[0], 0.5 * (bb[0] + bb[1]), bb[1]]
+    for av in as_:
+        for bv in bs:
+            true = math.sqrt(av * av + bv * bv)
+            lo = _root_bound(_sqrt_model(ab, bb, sign=1.0), pin={0: av, 1: bv})
+            hi = _root_bound(_sqrt_model(ab, bb, sign=-1.0), pin={0: av, 1: bv})
+            assert lo.status == "optimal" and lo.lower_bound is not None
+            assert hi.status == "optimal" and hi.lower_bound is not None
+            assert lo.lower_bound <= true + _TOL, (
+                f"sqrt under-cut excludes curve at ({av},{bv}): {lo.lower_bound} > {true}"
+            )
+            assert -hi.lower_bound >= true - _TOL, (
+                f"sqrt over-cut excludes curve at ({av},{bv}): {-hi.lower_bound} < {true}"
+            )
+
+
+# ── Whole-box objective soundness: bound <= true optimum ────────────────────────
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("const, xb, yb", _RECIP_BOXES)
+def test_reciprocal_box_bound_is_sound(const, xb, yb):
+    """The root bound on ``min const/(x*y)`` never exceeds the box optimum
+    (attained at the upper corner since ``1/(x*y)`` decreases in x,y)."""
+    res = _root_bound(_recip_model(const, xb, yb, sign=1.0))
+    true_min = const / (xb[1] * yb[1])
+    assert res.status == "optimal"
+    assert res.lower_bound is not None and math.isfinite(res.lower_bound)
+    assert res.lower_bound <= true_min + 1e-3, (
+        f"UNSOUND recip box bound {res.lower_bound} > opt {true_min}"
+    )
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("ab, bb", _SQRT_BOXES)
+def test_sqrt_box_bound_is_sound(ab, bb):
+    """The root bound on ``min sqrt(a**2+b**2)`` never exceeds the box optimum
+    (the lower corner, since the radius grows with |a|,|b| on positive boxes)."""
+    res = _root_bound(_sqrt_model(ab, bb, sign=1.0))
+    true_min = math.sqrt(ab[0] ** 2 + bb[0] ** 2)
+    assert res.status == "optimal"
+    assert res.lower_bound is not None and math.isfinite(res.lower_bound)
+    assert res.lower_bound <= true_min + 1e-3, (
+        f"UNSOUND sqrt box bound {res.lower_bound} > opt {true_min}"
+    )
+
+
+@pytest.mark.correctness
+def test_reciprocal_lift_actually_tightens():
+    """Sanity: on a well-conditioned box the reciprocal lift fires and returns a
+    finite (and exact-at-corner) bound, not a dropped objective. Guards against a
+    silent regression where the lift stops engaging and the bound goes to None."""
+    res = _root_bound(_recip_model(1.0, (1.0, 4.0), (2.0, 5.0), sign=1.0))
+    assert res.status == "optimal"
+    assert res.lower_bound is not None
+    # exact at the upper corner: 1/(4*5) = 0.05
+    assert res.lower_bound == pytest.approx(0.05, abs=1e-6)
+
+
+# ── Conditioning / domain guards: abstain, never emit a degenerate cut ──────────
+
+
+def _adversarial_recip_zero_crossing():
+    """``1/(x*y)`` where ``g = x*y`` spans 0 (``x in [-2, 3]``): ``1/g`` is not
+    convex across the singularity, so the lift must abstain."""
+    m = dm.Model()
+    x = m.continuous("x", lb=-2.0, ub=3.0)
+    y = m.continuous("y", lb=1.0, ub=2.0)
+    m.minimize(1.0 / (x * y))
+    return m
+
+
+def _adversarial_recip_tiny_denom():
+    """``g`` reaches ~1e-8, so the tangent slope ``1/gl**2`` ~ 1e16 blows past the
+    conditioning guard: the lift must abstain rather than build a degenerate LP."""
+    m = dm.Model()
+    x = m.continuous("x", lb=1e-4, ub=1.0)
+    y = m.continuous("y", lb=1e-4, ub=1.0)
+    m.minimize(1.0 / (x * y))
+    return m
+
+
+def _adversarial_sqrt_negative_arg():
+    """``sqrt(g)`` whose inner ``g`` can dip below 0 over the box; the sqrt is not
+    real there, so the lift must abstain (negative-slack guard)."""
+    m = dm.Model()
+    x = m.continuous("x", lb=-3.0, ub=2.0)
+    y = m.continuous("y", lb=-3.0, ub=2.0)
+    # x*y ranges to -6 over the box → inner can be negative.
+    m.minimize(dm.sqrt(x * y + 1.0))
+    return m
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize(
+    "name, build",
+    [
+        ("recip zero-crossing denom", _adversarial_recip_zero_crossing),
+        ("recip tiny denom (slope blow-up)", _adversarial_recip_tiny_denom),
+        ("sqrt negative inner arg", _adversarial_sqrt_negative_arg),
+    ],
+)
+def test_guard_abstains_never_unsound(name, build):
+    """Every adversarial box must (a) solve cleanly — no ``iteration_limit``
+    garbage objective masquerading as a bound — and (b) if it reports a bound at
+    all, that bound is sound (``<= 0``, since each objective's true minimum is
+    positive). Abstaining to ``bound=None`` is the expected, sound outcome."""
+    res = _root_bound(build())
+    assert res.status != "iteration_limit", (
+        f"[{name}] returned an iteration_limit objective — degenerate cut not guarded"
+    )
+    assert res.status in ("optimal", "infeasible"), f"[{name}] unexpected status {res.status}"
+    if res.lower_bound is not None and math.isfinite(res.lower_bound):
+        # The true min of each objective is strictly positive; a sound lower
+        # bound can only be <= it. A guard that emitted a bad cut would overshoot.
+        assert res.lower_bound <= 1.0 + 1e-6, (
+            f"[{name}] UNSOUND bound {res.lower_bound} from a guarded box"
+        )
+
+
+# ── Real-instance tightening lock (regression: the lift must keep engaging) ─────
+
+# Pre-#154 (lift-disengaged) root bounds vs the value the reciprocal/sqrt lift
+# now delivers at declared bounds. ``lock`` sits between the two so the test
+# fails loudly both if the lift silently disengages (bound falls back toward the
+# baseline) and is robust to small numerical drift. ``opt`` is the MINLPLib
+# optimum: the bound must stay sound (<= opt) on every iteration.
+_TIGHTENING_CASES = [
+    # instance, pre-lift baseline, post-lift lock floor, MINLPLib optimum
+    ("nvs05", 0.674, 1.20, 5.47093),
+    ("nvs22", 1.826, 2.30, 6.0584),
+]
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("instance, baseline, lock, optimum", _TIGHTENING_CASES)
+def test_lifted_instance_root_bound_tightens_and_stays_sound(instance, baseline, lock, optimum):
+    """``nvs05``/``nvs22`` carry a ``c/(x*y)``-style constraint the lift now
+    envelopes. The root bound must be strictly tighter than the pre-lift baseline
+    (the lift is engaging) and still <= the optimum (it stays sound)."""
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    res = _root_bound(dm.from_nl(str(nl)))
+    assert res.status == "optimal", f"[{instance}] root LP status {res.status}"
+    assert res.lower_bound is not None and math.isfinite(res.lower_bound)
+    assert res.lower_bound >= lock, (
+        f"[{instance}] lift disengaged: bound {res.lower_bound} fell back toward "
+        f"the pre-lift baseline {baseline} (expected >= {lock})"
+    )
+    assert res.lower_bound <= optimum + 1e-3, (
+        f"[{instance}] UNSOUND bound {res.lower_bound} > optimum {optimum}"
+    )


### PR DESCRIPTION
## Summary

Partial fix for #154. Bucket-2 instances `nvs05`/`nvs22` carry a `c/g` (and, for
the sum-of-squares family, `sqrt(g)`) constraint whose inner `g` is itself
nonlinear. The affine-only univariate path could not linearize the non-constant
division/sqrt, so it **dropped the whole constraint** — leaving the root bound
sound but loose. This PR **force-lifts** those atoms into the McCormick LP:

- every multiplicative factor of `g` (including squares `x*x`, built as the
  McCormick bilinear `x·x`) becomes a bounded product aux via
  `_ensure_bilinear_aux`, which auto-emits its envelope;
- the outer atom gets the standard convex `1/g` (g>0) / concave `sqrt(g)` (g≥0)
  tangent+secant envelope.

### Soundness (the invariant under test)

At any true feasible point each product aux can take its exact value (the
McCormick envelope contains the true product), so `g` is exact and the outer
convex/concave envelope encloses the curve. The relaxation feasible set stays a
**superset** of the true one ⇒ the dual bound stays valid. The lift **abstains**
(warn-and-omit, which only enlarges the feasible region) on anything not
provably sound: wrong-sign/unbounded inner interval, non-constant numerator,
cross-term square-of-affine (deferred to the #155 envelope), or a product whose
aux magnitude exceeds the monomial cap (`ex1252`'s ~1e15 terms).

**Conditioning guards** refuse a numerically degenerate cut rather than hand the
LP a slope it cannot solve: reciprocal tangents `1/gl²` and sqrt over-tangents
`1/(2√t)` are bounded by `_LIFT_MAX_ENVELOPE_SLOPE`; a denominator ≤
`_RECIP_MIN_DENOM` or a sqrt inner < `−_SQRT_NEG_TOL` abstains. This closes the
`nvs05` case where an unguarded ~1e8 tangent slope produced an `iteration_limit`
objective masquerading as a (false, super-optimal) bound.

### Result (root bound at declared bounds — all sound, `bound ≤ opt`)

| instance | before | after | opt | note |
|---|---|---|---|---|
| `nvs05` | 0.674 | **1.348** | 5.471 | reciprocal lift |
| `nvs22` | 1.826 | **2.548** | 6.058 | reciprocal lift |
| `nvs20` | 87.35 | 87.35 | 230.9 | #155 envelope; lift abstains (1e13+) |
| `ex1252` | — | — | 128894 | abstains (1e15 terms) |
| `chance` | 26.35 | 26.35 → **28.95** w/ FBBT | 29.89 | sqrt lift needs finite bounds |

### Merge note

`distribute_products` is now called **once** per body/objective and the same
tree is shared by the lift walk and the linearizer (so the lifted node ids match
at linearization). The shared call passes the #155 affine-square protection set,
so recognized `E**2` nodes survive for their envelope while every other
`(a+b)**2` still expands for term-by-term sqrt lifting. Rebased onto current
`main` (post #156/#149).

## Verification

- `python/tests/test_lifted_reciprocal_sqrt_soundness.py` → **20 passed**:
  two-sided pinned-point **curve enclosure** over a grid (the envelope never
  excludes a true feasible point), whole-box bound soundness, conditioning/domain
  guards never emit an unsound or `iteration_limit` cut, and an `nvs05`/`nvs22`
  tightening lock (regression guard against the lift silently disengaging).
- `test_bucket2_sound_bounds` (10) and the envelope/monomial/cert suites
  (37) re-run green; no regression.
- `ruff check` / `ruff format --check` clean.

## Scope / follow-ups

This is the **reciprocal + sqrt** increment of #154. Still open: full coverage
for `nvs20`/`ex1252` (extreme-magnitude terms — numerical territory), cross-term
`sqrt` of a square-of-affine (depends on #155), and nested divisions.

> ⚠️ **Out-of-band finding (not introduced here):** while running the
> `correctness`-marked suite I hit a **pre-existing false-optimal on `nvs08`**
> (`status=optimal, obj=12021.58` vs MINLPLib opt `23.45`, `nodes=1`,
> `gap=0`). It reproduces unchanged on `main` at #153/#149/#156, so it predates
> this branch. The *root* LP bound is sound (`−194.99 ≤ 23.45`); the fault is a
> **false-fathoming in B&B** (a node holding the true optimum is pruned — likely
> the documented wide-bound `x0**-3.5` fractional-power node going
> false-infeasible). CI does not catch it because CI runs `-m "not ...
> correctness"`. Filing/fixing tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
