### PR TITLE
fix(#158): conditioning guard on fractional-power envelopes (nvs08 false-optimal)

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -75,6 +75,30 @@ _warned_messages: set[str] = set()
 _MAX_INTEGER_COS_ENUM = 10000
 _MAX_FINITE_EXP_ARG = float(np.log(np.finfo(np.float64).max))
 _MAX_TRIG_PIECEWISE_SPAN = 2.0 * math.pi
+# Conditioning guard for fractional-power envelopes (issue #158). A power
+# ``x**p`` with ``p<0`` (or ``0<p<1``) over a box whose lower bound reaches
+# toward zero has tangent/secant slopes (``p*t**(p-1)`` and the secant over
+# ``[lb,ub]``) that blow up, reaching ~1e9+. An LP row carrying such a coefficient
+# against an RHS of order 1 is numerically unreliable: HiGHS returns a polytope
+# that EXCLUDES feasible points, so OBBT shrinks a variable past its true feasible
+# range and the per-node relaxer reports a feasible node "infeasible" (the nvs08
+# false optimum). Refuse to emit any envelope cut whose slope exceeds this limit;
+# dropping a cut only ENLARGES the relaxation, so abstention is always sound.
+_LIFT_MAX_ENVELOPE_SLOPE = 1e6
+
+
+def _envelope_slope_ok(slope: float) -> bool:
+    """True when an envelope cut's slope is well-conditioned enough to emit.
+
+    A finite slope at or below :data:`_LIFT_MAX_ENVELOPE_SLOPE` keeps the LP row
+    numerically reliable; anything steeper (e.g. ``p*t**(p-1)`` for ``x**p`` with
+    ``p<0`` near a small lower bound) makes HiGHS return an unsound polytope, so
+    the caller abstains. Dropping a cut only enlarges the relaxation, so an
+    abstention is always sound — at worst the aux column keeps its value bounds.
+    """
+    return bool(np.isfinite(slope)) and abs(slope) <= _LIFT_MAX_ENVELOPE_SLOPE
+
+
 _MAX_TRIG_PIECEWISE_INTERVALS = 32
 _MAX_TRIG_IMPORTED_BREAKPOINTS = _MAX_TRIG_PIECEWISE_INTERVALS + 1
 _MAX_TRIG_PIECEWISE_WIDTH = math.pi / 6.0
@@ -4819,6 +4843,18 @@ def build_milp_relaxation(
             secant_slope = 0.0
             secant_intercept = f_lb
 
+        # Conditioning guard (issue #158): for steep powers (``p<0`` near a small
+        # ``lb_i``, or ``0<p<1`` near zero) the tangent/secant slopes blow up
+        # (``p*t**(p-1)`` and the secant over ``[lb,ub]``), reaching ~1e9+.  An LP
+        # row with such a coefficient against an RHS of order 1 is numerically
+        # unreliable: HiGHS returns a polytope that EXCLUDES feasible points,
+        # which makes OBBT shrink a variable past its true feasible range and the
+        # per-node relaxer report a feasible node "infeasible" (nvs08 false
+        # optimum).  Dropping any individual cut only ENLARGES the relaxation, so
+        # abstaining on an ill-conditioned row is always sound — at worst the aux
+        # column degrades to its (exact) value bounds.
+        _slope_ok = _envelope_slope_ok
+
         if convexity == "concave":
             pw_intervals = piecewise_var_map.get(var_idx, [])
             if pw_intervals:
@@ -4828,6 +4864,7 @@ def build_milp_relaxation(
                 #   −a + Σ_k (slope_k x̄_k + (p_k^p − slope_k p_k) δ_k) ≤ 0.
                 row = np.zeros(n_total)
                 row[a_col] = -1.0
+                _pw_ill_conditioned = False
                 for delta_col, xbar_col, p_lo, p_hi in pw_intervals:
                     if abs(p_hi - p_lo) > 1e-12:
                         try:
@@ -4838,11 +4875,18 @@ def build_milp_relaxation(
                         if not (np.isfinite(f_plo) and np.isfinite(f_phi)):
                             continue
                         slope_k = (f_phi - f_plo) / (p_hi - p_lo)
+                        if not _slope_ok(slope_k):
+                            _pw_ill_conditioned = True
+                            break
                         intercept_k = f_plo - slope_k * p_lo
                         row[xbar_col] += slope_k
                         row[delta_col] += intercept_k
-                _add_row(row, 0.0)
-            else:
+                # A single aggregated row mixes every interval's slope; if any
+                # breakpoint is ill-conditioned the whole row is unreliable, so
+                # omit it rather than emit a partially-built (unsound) cut.
+                if not _pw_ill_conditioned:
+                    _add_row(row, 0.0)
+            elif _slope_ok(secant_slope):
                 # Global secant under-estimator: a ≥ secant_slope*x + secant_intercept
                 #   →  -a + secant_slope*x ≤ -secant_intercept
                 row = np.zeros(n_total)
@@ -4854,6 +4898,8 @@ def build_milp_relaxation(
             #   t_slope = p*t^(p-1);  t_const = t^p - t_slope*t = (1-p)*t^p
             for t in tangent_pts:
                 t_slope = p * (t ** (p - 1.0))
+                if not _slope_ok(t_slope):
+                    continue
                 t_const = (1.0 - p) * (t**p)
                 row = np.zeros(n_total)
                 row[a_col] = 1.0
@@ -4863,16 +4909,19 @@ def build_milp_relaxation(
             # Tangent under-estimators: a ≥ p*t^(p-1)*(x-t) + t^p
             for t in tangent_pts:
                 t_slope = p * (t ** (p - 1.0))
+                if not _slope_ok(t_slope):
+                    continue
                 t_const = (1.0 - p) * (t**p)
                 row = np.zeros(n_total)
                 row[a_col] = -1.0
                 row[var_idx] = t_slope
                 _add_row(row, -t_const)
             # Secant over-estimator: a ≤ secant_slope*x + secant_intercept
-            row = np.zeros(n_total)
-            row[a_col] = 1.0
-            row[var_idx] = -secant_slope
-            _add_row(row, secant_intercept)
+            if _slope_ok(secant_slope):
+                row = np.zeros(n_total)
+                row[a_col] = 1.0
+                row[var_idx] = -secant_slope
+                _add_row(row, secant_intercept)
 
     if objective_lift is not None:
         for branch_expr in objective_lift.branch_exprs:

--- a/python/tests/test_fractional_power_conditioning_soundness.py
+++ b/python/tests/test_fractional_power_conditioning_soundness.py
@@ -1,0 +1,150 @@
+"""Soundness guard for ill-conditioned fractional-power envelopes (issue #158).
+
+A fractional power ``x**p`` with ``p < 0`` (or ``0 < p < 1``) over a box whose
+lower bound reaches toward zero has tangent/secant slopes that blow up:
+``|p| * lb**(p-1)`` reaches ~1e9+ for ``nvs08`` (``x0**-3.5`` on ``x0 >= 0.0121``).
+Emitting an LP row with such a coefficient against an RHS of order 1 makes HiGHS
+return a polytope that *excludes feasible points*. Two downstream consumers then
+turn that unsound polytope into a false certificate:
+
+  * **Root OBBT** min/maxes each variable over the relaxation. On the poisoned
+    polytope it shrank ``nvs08``'s ``x0`` to the single point ``[0.0155, 0.0155]``
+    — far below the true optimum ``x0 = 0.6314`` — cutting the optimum away.
+  * **The per-node McCormick LP relaxer** then reports the (now genuinely
+    box-empty) node ``infeasible``; the spatial-B&B driver treats that as a
+    rigorous fathom and certifies the suboptimal incumbent ``12021.58`` (true
+    optimum ``23.4497``) as ``optimal`` with ``gap=0``.
+
+The fix drops any envelope cut whose slope exceeds ``_LIFT_MAX_ENVELOPE_SLOPE``.
+Dropping a cut only ENLARGES the relaxation, so it is always sound; the aux
+column degrades at worst to its (exact) value bounds. These tests assert the
+relaxation stays a valid OUTER approximation — OBBT must never shrink a variable
+past its true feasible range, and the root relaxer must not declare a feasible
+problem infeasible.
+
+Runs fast (relaxation/OBBT only, no full B&B) and is intentionally NOT marked
+``correctness`` so CI — which deselects ``correctness`` — still catches a
+regression here.
+"""
+
+import os
+import time
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import numpy as np
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.obbt import obbt_tighten_root
+from discopt.modeling.core import VarType
+from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+# nvs08 published optimum (MINLPLib).
+_NVS08_OPT = 23.4497
+_NVS08_OPT_POINT = {"x0": 0.63138504, "x1": 4.0, "x2": 3.0}
+
+
+def _int_offsets_sizes(model):
+    offsets, sizes, off = [], [], 0
+    for v in model._variables:
+        if v.var_type in (VarType.INTEGER, VarType.BINARY):
+            offsets.append(off)
+            sizes.append(v.size)
+        off += v.size
+    return offsets, sizes
+
+
+def _fbbt_then_obbt(model, deadline_s=8.0):
+    """Reproduce the solver's root presolve: FBBT then OBBT over the relaxation."""
+    lb, ub = flat_variable_bounds(model)
+    lb = np.asarray(lb, dtype=float)
+    ub = np.asarray(ub, dtype=float)
+    int_offsets, int_sizes = _int_offsets_sizes(model)
+    lb, ub, infeasible, _ = tighten_root_bounds_with_fbbt(
+        model, lb.copy(), ub.copy(), int_offsets, int_sizes, model_repr=None
+    )
+    assert not infeasible, "root FBBT must not call a feasible model infeasible"
+    res = obbt_tighten_root(
+        model,
+        lb.copy(),
+        ub.copy(),
+        rounds=3,
+        deadline=time.perf_counter() + deadline_s,
+        prefer_pounce=True,
+    )
+    assert not res.infeasible, "root OBBT must not call a feasible model infeasible"
+    return np.maximum(lb, res.lb), np.minimum(ub, res.ub)
+
+
+def test_nvs08_root_obbt_keeps_optimum_in_box():
+    """OBBT over the nvs08 relaxation must not cut the true optimum out of the box.
+
+    Reverting the conditioning guard collapses ``x0`` to ``[0.0155, 0.0155]`` — the
+    optimum ``x0 = 0.6314`` falls outside, the optimum is lost, and the run
+    certifies a suboptimal incumbent. The guard keeps the (loose, sound) box.
+    """
+    model = dm.from_nl(str(_DATA / "nvs08.nl"))
+    lb, ub = _fbbt_then_obbt(model)
+    x0_opt = _NVS08_OPT_POINT["x0"]
+    assert lb[0] <= x0_opt + 1e-9, f"OBBT lower bound {lb[0]} cut the optimum x0={x0_opt}"
+    assert ub[0] >= x0_opt - 1e-9, f"OBBT upper bound {ub[0]} cut the optimum x0={x0_opt}"
+    # Integer optimum (x1=4, x2=3) must likewise survive.
+    assert lb[1] <= _NVS08_OPT_POINT["x1"] <= ub[1]
+    assert lb[2] <= _NVS08_OPT_POINT["x2"] <= ub[2]
+
+
+def test_nvs08_root_relaxer_not_infeasible_and_bound_sound():
+    """The McCormick LP relaxer at the nvs08 root is a valid outer relaxation:
+
+    it must NOT report ``infeasible`` (the problem is feasible) and any finite
+    lower bound it returns must not exceed the true optimum.
+    """
+    model = dm.from_nl(str(_DATA / "nvs08.nl"))
+    lb, ub = _fbbt_then_obbt(model)
+    relaxer = MccormickLPRelaxer(model)
+    res = relaxer.solve_at_node(lb, ub)
+    assert res.status != "infeasible", "feasible nvs08 root reported infeasible by relaxer"
+    if res.lower_bound is not None and np.isfinite(res.lower_bound):
+        assert res.lower_bound <= _NVS08_OPT + 1e-4, (
+            f"root dual bound {res.lower_bound} exceeds true optimum {_NVS08_OPT}"
+        )
+
+
+def test_steep_negative_power_relaxation_stays_sound():
+    """Minimal adversarial model: ``x**-3.5 <= rhs`` with a tiny lower bound.
+
+    The true feasible region needs ``x >= rhs**(-1/3.5)``. The relaxation, being
+    an OUTER approximation, may only UNDER-state that threshold — never report a
+    box that contains feasible points as infeasible, and never bound the
+    objective above the true minimum.
+    """
+    rhs = 100.0
+    true_threshold = rhs ** (-1.0 / 3.5)  # x must be >= this to be feasible
+    model = dm.Model()
+    x = model.continuous("x", lb=1e-3, ub=200.0)
+    model.subject_to(1.0 / ((x**3) * dm.sqrt(x)) <= rhs)
+    model.minimize(x)
+
+    relaxer = MccormickLPRelaxer(model)
+    # On the full box the relaxation's min(x) is a valid LOWER bound on the true
+    # minimum (= true_threshold); it must not exceed it.
+    res = relaxer.solve_at_node(np.array([1e-3]), np.array([200.0]))
+    assert res.status == "optimal"
+    assert res.lower_bound <= true_threshold + 1e-6, (
+        f"relaxation min {res.lower_bound} exceeds true feasible min {true_threshold}"
+    )
+
+    # A box strictly inside the genuinely-infeasible region stays a sound
+    # infeasibility proof (truth: x must be >= 0.268, so [0.01, 0.02] is empty).
+    res_empty = relaxer.solve_at_node(np.array([0.01]), np.array([0.02]))
+    assert res_empty.status == "infeasible"
+
+    # A box straddling the threshold must remain feasible in the relaxation.
+    res_ok = relaxer.solve_at_node(np.array([true_threshold]), np.array([1.0]))
+    assert res_ok.status != "infeasible", "feasible box reported infeasible"


### PR DESCRIPTION
## Summary

Closes #158. `nvs08` (MINLPLib) was certified `optimal` with `obj=12021.58`,
`bound=12021.58`, `gap=0` — but the **true optimum is `23.4497`**. This is a
**false-optimal** (a certified `gap_certified=True` result at a
feasible-but-suboptimal point), the most serious soundness class.

```
before:  optimal  obj=12021.584  bound=12021.584  gap=0   (true optimum 23.4497)
after:   optimal  obj=23.4497    bound=23.4494    gap=1.5e-5
```

## Root cause

Constraint C2 of `nvs08` contains `1/(x0**3 * sqrt(x0))` → the fractional power
`x0**-3.5` (convex on `x0>0`). Its LP-form McCormick envelope
(`build_milp_relaxation`, `fractional_power_specs` loop) emits tangent
under-estimators with slope `p*t**(p-1)` plus a secant over-estimator. Once root
FBBT nudges `x0`'s lower bound `0.001 → 0.0121`, the tangent slope at the lower
endpoint is `3.5 * 0.0121**-4.5 ≈ 1.4e9`.

An LP row with a `~1e9` coefficient against an `O(1)` RHS is numerically
unreliable — HiGHS returns a polytope that **excludes feasible points**. Two
consumers then turn that unsound polytope into a false certificate:

1. **Root OBBT** min/maxes each variable over the relaxation and shrinks `x0` to
   the single point `[0.0155, 0.0155]` — below the true optimum `x0=0.6314`,
   cutting the optimum out of the search box.
2. **The per-node McCormick LP relaxer** then reports the (now genuinely
   box-empty) root node `infeasible`. The serial spatial-B&B path treats that as
   a rigorous fathom, which **skips the nonconvex gap-decertification finalize**,
   so the subnlp-seed incumbent (`12021.58`, a valid but suboptimal feasible
   point) becomes the global bound and the run certifies `gap=0`.

The bug only fires *after* FBBT's tiny bound change: with `lb=0.001` the slopes
are even steeper (`~1e14`) and HiGHS effectively ignores those rows (loose but
sound); the `~1e9` regime is the dangerous "just solvable, silently wrong" band.

## Fix

The `fractional_power_specs` envelope had no conditioning guard. This PR adds a
`_LIFT_MAX_ENVELOPE_SLOPE = 1e6` limit and applies it there: drop any tangent /
secant / piecewise cut whose slope magnitude exceeds the limit.
**Dropping a cut only ENLARGES the relaxation, so abstention is always sound** —
at worst the aux column degrades to its (exact) value bounds. The relaxation
stays a valid outer approximation, OBBT no longer poisons the box, and the
per-node relaxer no longer false-fathoms.

## Verification

- `test_fractional_power_conditioning_soundness.py` (new, **CI-visible** — not
  marked `correctness`): root OBBT keeps the optimum in the box; the root
  relaxer does not call a feasible problem infeasible; a minimal `x**-3.5 <= rhs`
  model stays a sound outer relaxation. **Confirmed the OBBT test fails when the
  guard is disabled** (`_LIFT_MAX_ENVELOPE_SLOPE = inf` → `x0` collapses to
  `[0.0155, 0.0155]`).
- `test_nvs08_certification.py` now certifies `23.4497` end-to-end with a valid
  dual bound.
- 274 passed across the relaxation / B&B soundness suites
  (`test_fp_relaxation_soundness`, `test_mccormick*`, `test_*_certification`,
  `test_bucket2_sound_bounds`, `test_lifted_reciprocal_sqrt_soundness`,
  `test_p1_milp_bb_soundness`, `test_doe_fractional`, …).
- `ruff check` / `ruff format --check` clean.

## Note: CI blind spot

Soundness suites marked `@pytest.mark.correctness` are deselected by the CI
filter, so this false-optimal was invisible to CI. The new regression test is
deliberately left unmarked so CI catches a recurrence. Broader restoration of
correctness coverage in CI is worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

