### PR TITLE
feat(relax): cross-term sqrt/reciprocal monomial lift + conditioning guard (#154)

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -95,6 +95,19 @@ _SQRT_NEG_TOL = 1e-9
 # dropping a cut only ENLARGES the relaxation, so abstention is always sound.
 _LIFT_MAX_ENVELOPE_SLOPE = 1e6
 
+# Largest argument magnitude a *cross-term* sqrt/reciprocal lift (issue #154,
+# increment 2) may carry. Lifting ``sqrt(g)`` of a cross-term polynomial (e.g.
+# nvs05/nvs22 ``sqrt(x4**2 + 2*x4*x5*x7 + x5**2)``) folds the product factors
+# into McCormick aux columns whose bounds — and the resulting envelope row
+# coefficients — scale with ``|g|``. When that magnitude reaches ~1e9 the LP is
+# ill-conditioned: the fast simplex backend returns a wrong "optimal" bound that
+# can exceed the true optimum (an unsound dual bound), while HiGHS still solves
+# it correctly. Fast-simplex is demonstrated reliable up to ~1e7 on these
+# relaxations, so cross-term lifts abstain above this limit. Abstention only
+# drops a cut (the constraint is simply left un-lifted), which ENLARGES the
+# relaxation and is therefore always sound.
+_LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE = 1e7
+
 
 def _envelope_slope_ok(slope: float) -> bool:
     """True when an envelope cut's slope is well-conditioned enough to emit.
@@ -3752,6 +3765,11 @@ def build_milp_relaxation(
 
     _MAX_FORCED_POWER = 4
 
+    # Set by ``_lift_inner_to_affine`` whenever the cross-term-monomial fallback
+    # (issue #154 increment 2) claims a factor; read by ``_maybe_lift_outer_atom``
+    # to apply the cross-term conditioning guard. Reset before each outer lift.
+    cross_term_used = [False]
+
     def _ensure_bounded_bilinear(lhs_col: int, rhs_col: int) -> Optional[int]:
         """Force-create the product aux for two bounded columns (``x*y``, or
         ``x*x`` for a square), or ``None`` if a factor is unbounded or the product
@@ -3802,6 +3820,68 @@ def build_milp_relaxation(
                 return col
         return None
 
+    def _lift_monomial_with_coeff(expr: Expression) -> Optional[tuple[list[int], float]]:
+        """Decompose a multiplicative monomial into ``(variable-factor columns,
+        scalar coefficient)``. Unlike :func:`_lift_factor_to_col`, embedded
+        constant factors are folded into the coefficient rather than rejected, so
+        a cross term such as ``2*x4*x5*x7`` (nvs05/nvs22 constraint C4) resolves to
+        ``([x4, x5, x7], 2.0)``. Mirrors ``_lift_factor_to_col``'s claims (bounded
+        original variables, products, integer powers) and likewise abstains on
+        affine-base powers so the #155 square-of-affine envelope keeps that path.
+        Returns ``None`` on any non-monomial / unbounded shape."""
+        c = _constant_value(expr)
+        if c is not None:
+            return [], float(c)
+        flat = _get_flat_index(expr, model)
+        if flat is not None:
+            lo, hi = all_bounds[flat]
+            if not (np.isfinite(lo) and np.isfinite(hi)):
+                return None
+            return [flat], 1.0
+        if isinstance(expr, UnaryOp) and expr.op == "-":
+            sub = _lift_monomial_with_coeff(expr.operand)
+            if sub is None:
+                return None
+            cols, coeff = sub
+            return cols, -coeff
+        if isinstance(expr, BinaryOp) and expr.op == "*":
+            left = _lift_monomial_with_coeff(expr.left)
+            if left is None:
+                return None
+            right = _lift_monomial_with_coeff(expr.right)
+            if right is None:
+                return None
+            lcols, lc = left
+            rcols, rc = right
+            return lcols + rcols, lc * rc
+        if isinstance(expr, BinaryOp) and expr.op == "**" and isinstance(expr.right, Constant):
+            p = float(expr.right.value)
+            if p.is_integer() and 2 <= int(p) <= _MAX_FORCED_POWER:
+                base = _lift_monomial_with_coeff(expr.left)
+                if base is None:
+                    return None
+                bcols, bc = base
+                return bcols * int(p), bc ** int(p)
+        return None
+
+    def _fold_cols_to_aux(cols: list[int]) -> Optional[int]:
+        """Fold a list of bounded columns into a single product aux via iterated
+        bilinear lifting, or ``None`` if any factor is unbounded / the product aux
+        bound exceeds the monomial limit. Empty list yields ``None`` (the caller
+        treats a coefficient-only monomial as a constant)."""
+        if not cols:
+            return None
+        col = cols[0]
+        lo, hi = all_bounds[col]
+        if not (np.isfinite(lo) and np.isfinite(hi)):
+            return None
+        for nxt in cols[1:]:
+            folded = _ensure_bounded_bilinear(col, nxt)
+            if folded is None:
+                return None
+            col = folded
+        return col
+
     def _lift_inner_to_affine(expr: Expression) -> Optional[tuple[dict[int, float], float]]:
         """Resolve ``g`` to ``(coeffs, const)`` over the extended column space,
         force-lifting product factors. ``None`` to abstain on any unclaimed shape."""
@@ -3840,9 +3920,22 @@ def build_milp_relaxation(
             sc, sconst = inner
             return {k: -v for k, v in sc.items()}, -sconst
         col = _lift_factor_to_col(expr)
-        if col is None:
+        if col is not None:
+            return {col: 1.0}, 0.0
+        # Increment #2 (issue #154): a monomial carrying an embedded constant
+        # factor — e.g. the cross term ``2*x4*x5*x7`` in nvs05/nvs22 constraint
+        # C4 — abstains above because ``_lift_factor_to_col`` rejects the scalar
+        # ``2``. Strip the coefficient and fold the variable factors into one
+        # product aux so ``sqrt`` of a cross-term quadratic lifts soundly.
+        mono = _lift_monomial_with_coeff(expr)
+        if mono is None:
             return None
-        return {col: 1.0}, 0.0
+        cols, coeff = mono
+        folded = _fold_cols_to_aux(cols)
+        if folded is None:
+            return None
+        cross_term_used[0] = True
+        return {folded: coeff}, 0.0
 
     def _maybe_lift_outer_atom(expr: Expression) -> None:
         nonlocal col_idx
@@ -3859,6 +3952,7 @@ def build_milp_relaxation(
         else:
             return
 
+        cross_term_used[0] = False
         lifted = _lift_inner_to_affine(inner)
         if lifted is None:
             return
@@ -3876,6 +3970,13 @@ def build_milp_relaxation(
 
         gl, gh = _extended_affine_interval(arg_coeff, arg_const)
         if not (np.isfinite(gl) and np.isfinite(gh)) or gh < gl:
+            return
+        # Cross-term conditioning guard (issue #154 increment 2): a cross-term
+        # lift whose argument magnitude is large enough to make the LP
+        # ill-conditioned can produce a wrong "optimal" — and therefore an
+        # *unsound* dual bound — from the fast simplex backend. Abstain (drop the
+        # lift, enlarging the relaxation, which is always sound) above the limit.
+        if cross_term_used[0] and max(abs(gl), abs(gh)) > _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE:
             return
         if func_name == "reciprocal":
             if gl <= _RECIP_MIN_DENOM:

--- a/python/tests/test_cross_term_sqrt_soundness.py
+++ b/python/tests/test_cross_term_sqrt_soundness.py
@@ -1,0 +1,219 @@
+"""Adversarial soundness for the cross-term sqrt lift (issue #154, increment 2).
+
+The lifted ``sqrt(g)`` envelope (#157) force-lifts each multiplicative factor of
+``g`` into a bounded McCormick product aux. Increment 2 extends the inner-factor
+parser so a monomial carrying an *embedded constant* — the cross term
+``2*x4*x5*x7`` in nvs05/nvs22 constraint ``C4 = sqrt(x4**2 + 2*x4*x5*x7 + x5**2)``
+— lifts too: the scalar is stripped into a coefficient and the variable factors
+fold into one product aux. Previously ``_lift_factor_to_col`` rejected the scalar
+and the whole sqrt abstained.
+
+Two failure modes are locked here:
+
+1. **Unsound cut** — an envelope row that excludes a true feasible point. We pin
+   the variables to interior grid points (degenerate boxes) and check the
+   relaxation brackets the exact curve value from both sides. A bracket that
+   holds everywhere means no cut excludes ``sqrt(g)``.
+
+2. **Ill-conditioned LP → wrong "optimal"** — folding a cross term over a *wide*
+   box yields product-aux bounds of order ``1e8``–``1e9`` (nvs05/nvs22's
+   ``g`` reaches ``~1.2e9``). The fast simplex backend then returns a wrong
+   "optimal" objective that *exceeds the true optimum* — an unsound dual bound
+   (HiGHS still solves it correctly). The cross-term conditioning guard
+   (``_LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE``) must make the lift *abstain* above the
+   magnitude limit, so the relaxation stays sound on every backend. The two
+   MINLPLib cases are the regression: before the guard the nvs22 root bound came
+   back ``8.31 > 6.0584`` (a false, super-optimal dual bound).
+
+The invariant under test is the project's non-negotiable one: a valid lower
+bound never exceeds the true optimum, and the relaxation never excludes a
+feasible point.
+"""
+
+import math
+import os
+from pathlib import Path
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.milp_relaxation import build_milp_relaxation
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt.solver import _extract_variable_info
+from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+_TOL = 1e-6
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+
+def _cross_sqrt_model(xb, yb, zb, *, sign=1.0):
+    """``sign * sqrt(x**2 + 2*x*y*z + y**2)`` over the given boxes.
+
+    The cross term ``2*x*y*z`` is the shape increment 2 unlocks: a trilinear
+    monomial with an embedded scalar ``2``.
+    """
+    m = dm.Model()
+    x = m.continuous("x", lb=xb[0], ub=xb[1])
+    y = m.continuous("y", lb=yb[0], ub=yb[1])
+    z = m.continuous("z", lb=zb[0], ub=zb[1])
+    m.minimize(sign * dm.sqrt(x * x + 2.0 * x * y * z + y * y))
+    return m
+
+
+def _root_bound(model, backend="simplex", pin=None, bounds=None):
+    relaxer = MccormickLPRelaxer(model)
+    relaxer._backend = backend
+    if bounds is None:
+        lb, ub = flat_variable_bounds(model)
+    else:
+        lb, ub = bounds
+    lb = lb.copy()
+    ub = ub.copy()
+    if pin is not None:
+        for i, v in pin.items():
+            lb[i] = v
+            ub[i] = v
+    return relaxer.solve_at_node(lb, ub)
+
+
+# Well-conditioned boxes: |g| stays well below the cross-term magnitude guard, so
+# the lift engages and the fast simplex is reliable.
+_WELL_CONDITIONED = [
+    ((1.0, 3.0), (1.0, 3.0), (1.0, 3.0)),
+    ((0.5, 2.0), (1.0, 4.0), (0.5, 2.5)),
+    ((2.0, 5.0), (1.0, 3.0), (1.0, 2.0)),
+]
+
+
+@pytest.mark.parametrize("xb, yb, zb", _WELL_CONDITIONED)
+def test_cross_term_sqrt_lift_engages(xb, yb, zb):
+    """On a well-conditioned box the cross-term sqrt lift creates aux columns —
+    i.e. it actually engages rather than silently abstaining."""
+    m = _cross_sqrt_model(xb, yb, zb)
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+    milp, _ = build_milp_relaxation(
+        relaxer._model,
+        relaxer._terms,
+        relaxer._disc,
+        bound_override=(np.asarray(lb), np.asarray(ub)),
+        superposition=relaxer._superposition,
+    )
+    # 3 original variables; a lifted cross-term sqrt adds product + sqrt aux cols.
+    assert len(milp._c) > 3, "cross-term sqrt lift did not engage (no aux columns)"
+
+
+@pytest.mark.parametrize("xb, yb, zb", _WELL_CONDITIONED)
+def test_cross_term_sqrt_encloses_curve(xb, yb, zb):
+    """At every interior grid point the relaxation brackets
+    ``sqrt(x**2 + 2*x*y*z + y**2)`` from both sides — the cross-term lift never
+    excludes the true curve."""
+    xs = [xb[0], 0.5 * (xb[0] + xb[1]), xb[1]]
+    ys = [yb[0], 0.5 * (yb[0] + yb[1]), yb[1]]
+    zs = [zb[0], 0.5 * (zb[0] + zb[1]), zb[1]]
+    for xv in xs:
+        for yv in ys:
+            for zv in zs:
+                true = math.sqrt(xv * xv + 2.0 * xv * yv * zv + yv * yv)
+                pin = {0: xv, 1: yv, 2: zv}
+                lo = _root_bound(_cross_sqrt_model(xb, yb, zb, sign=1.0), pin=pin)
+                hi = _root_bound(_cross_sqrt_model(xb, yb, zb, sign=-1.0), pin=pin)
+                assert lo.status == "optimal" and lo.lower_bound is not None
+                assert hi.status == "optimal" and hi.lower_bound is not None
+                # underestimator never rises above the curve …
+                assert lo.lower_bound <= true + _TOL, (
+                    f"cross-sqrt under-cut excludes curve at ({xv},{yv},{zv}): "
+                    f"{lo.lower_bound} > {true}"
+                )
+                # … overestimator never drops below it.
+                assert -hi.lower_bound >= true - _TOL, (
+                    f"cross-sqrt over-cut excludes curve at ({xv},{yv},{zv}): "
+                    f"{-hi.lower_bound} < {true}"
+                )
+
+
+@pytest.mark.parametrize("xb, yb, zb", _WELL_CONDITIONED)
+def test_cross_term_sqrt_backends_agree(xb, yb, zb):
+    """In the well-conditioned regime the fast simplex and HiGHS must agree — a
+    disagreement would mean the lifted LP is already ill-conditioned and the fast
+    bound is untrustworthy."""
+    m = _cross_sqrt_model(xb, yb, zb)
+    fast = _root_bound(m, backend="simplex")
+    ref = _root_bound(m, backend="auto")
+    assert fast.status == "optimal" and ref.status == "optimal"
+    assert abs(fast.lower_bound - ref.lower_bound) <= 1e-4, (
+        f"backend disagreement {fast.lower_bound} vs {ref.lower_bound} — fast bound unreliable"
+    )
+
+
+# nvs05/nvs22: |g| ~ 1.2e9 trips the cross-term magnitude guard. (instance, opt).
+_MINLPLIB_GUARDED = [("nvs05", 5.47093), ("nvs22", 6.0584)]
+
+
+@pytest.mark.parametrize("instance, optimum", _MINLPLIB_GUARDED)
+@pytest.mark.parametrize("backend", ["simplex", "auto"])
+def test_cross_term_guard_keeps_minlplib_sound(instance, optimum, backend):
+    """The conditioning guard keeps nvs05/nvs22 root bounds sound on *both*
+    backends. This is the regression: before the guard, folding C4's cross term
+    over the wide FBBT box gave the fast simplex a wrong ``8.31 > 6.0584`` root
+    bound for nvs22 — a false, super-optimal dual bound."""
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+    _, elb, eub, io, isz = _extract_variable_info(m)
+    tlb, tub, _, _ = tighten_root_bounds_with_fbbt(m, elb.copy(), eub.copy(), io, isz)
+
+    for bounds in ((None), (tlb, tub)):
+        res = _root_bound(m, backend=backend, bounds=bounds)
+        # The fast simplex may stop at ``iteration_limit`` on the wide FBBT box
+        # rather than ``optimal`` — that is fine. What is non-negotiable is the
+        # soundness direction: whenever a *finite* lower bound is returned, it may
+        # never exceed the true optimum. Before the cross-term conditioning guard
+        # the simplex returned a wrong ``optimal`` bound of 8.31 > 6.0584 here;
+        # the guard makes C4's cross-term sqrt abstain so the bound stays sound.
+        if res.lower_bound is None or not math.isfinite(res.lower_bound):
+            continue
+        assert res.lower_bound <= optimum + 1e-3, (
+            f"[{instance}/{backend}] UNSOUND root bound {res.lower_bound} > optimum {optimum}"
+        )
+
+
+def test_cross_term_guard_abstains_on_wide_box():
+    """An *ill-conditioned* cross-term sqrt (wide box → ``|g| > 1e7``) must abstain
+    rather than emit a lift the fast simplex would mis-solve.
+
+    When the cross-term lift abstains, the only ``sqrt`` term in the objective can
+    no longer be linearized, so the relaxation falls back to a feasibility
+    objective and returns *no* lower bound (``lower_bound is None``) on both
+    backends. That is the sound outcome — abstention drops a cut, it never
+    fabricates one. The regression this locks out is the *opposite*: a finite
+    ``optimal`` bound from the fast simplex that exceeds the true curve minimum
+    (the #158-class wrong-"optimal" on the ill-conditioned lifted LP)."""
+    # x,y in [1,4000], z in [1,4000]: g = x^2 + 2xyz + y^2 reaches ~5e10 ≫ 1e7.
+    m = _cross_sqrt_model((1.0, 4000.0), (1.0, 4000.0), (1.0, 4000.0))
+    fast = _root_bound(m, backend="simplex")
+    ref = _root_bound(m, backend="auto")
+    # True minimum of sqrt(g) over the box is at x=y=z=1: sqrt(1+2+1)=2.
+    true_min = 2.0
+    # Neither backend may return a finite bound that exceeds the truth. With the
+    # lift abstained both return None (sound); the point is that *if* a bound were
+    # returned it could not be the old super-optimal 8.31-style value.
+    for tag, res in (("simplex", fast), ("auto", ref)):
+        if res.lower_bound is not None and math.isfinite(res.lower_bound):
+            assert res.lower_bound <= true_min + _TOL, (
+                f"wide-box {tag} bound {res.lower_bound} exceeds true min {true_min} — unsound"
+            )
+    # And the two backends must not disagree on whether a bound exists / its value.
+    if fast.lower_bound is not None and ref.lower_bound is not None:
+        assert abs(fast.lower_bound - ref.lower_bound) <= 1e-3, (
+            f"wide-box backend disagreement {fast.lower_bound} vs {ref.lower_bound}"
+        )
+    else:
+        assert fast.lower_bound is None and ref.lower_bound is None, (
+            f"wide-box backend disagreement on bound existence: "
+            f"simplex={fast.lower_bound} auto={ref.lower_bound}"
+        )


### PR DESCRIPTION
## Summary

Issue #154, **increment 2** — cross-term `sqrt`/reciprocal envelope lift.

The lifted `sqrt(g)`/`c/g` envelope (#157) force-lifts each multiplicative
factor of `g` into a bounded McCormick product aux. Its inner-factor parser
(`_lift_factor_to_col`) only accepted bare variables, products of variables and
integer powers — it **rejected any embedded scalar**, so a cross term like
`2*x4*x5*x7` (nvs05 / nvs22 constraint `C4 = sqrt(x4**2 + 2*x4*x5*x7 + x5**2)`)
made the whole `sqrt` abstain.

This PR adds:

- `_lift_monomial_with_coeff` — strips the scalar of a monomial into a
  coefficient and returns the variable-factor columns (`2*x4*x5*x7` →
  `([x4,x5,x7], 2.0)`). It mirrors the existing factor-lift's claims (bounded
  original variables, products, integer powers 2–4) and keeps abstaining on
  affine-base powers, so the #155 square-of-affine envelope path is untouched.
- `_fold_cols_to_aux` — folds those columns into one bounded product aux via
  iterated bilinear lifting (guarded by the existing monomial aux-bound limit).

## Soundness — and why there is a conditioning guard

Folding a cross term over a **wide** box yields product-aux bounds of order
`1e8`–`1e9` (nvs05/nvs22's `g` reaches `~1.2e9`). At that magnitude the lifted
LP is ill-conditioned and the **fast Rust simplex returns a wrong "optimal"
objective that *exceeds* the true optimum** — a #158-class *unsound* dual bound
(HiGHS still solves it correctly). Before the guard, folding C4 over nvs22's
wide FBBT box gave the simplex a root bound of **`8.31 > 6.0584`** — a false,
super-optimal bound.

The new `_LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE = 1e7` guard, scoped via a
`cross_term_used` flag to **only** the new monomial path, makes the cross-term
lift abstain once `max(|gl|,|gh|) > 1e7`. Abstention merely drops a cut (the
constraint is left un-lifted), which **enlarges** the relaxation — always sound,
on every backend.

## Honest scope note: inert for nvs05/nvs22 certification

This lift **does not move nvs05/nvs22's certification** and is not intended to.
Their objective depends only on `x0..x3`; `C4` constrains aux columns `x4/x5/x7`
that the objective never reads, so even an exact `C4` leaves the root bound
unchanged (`2.548`). And over their wide FBBT box the cross term trips the
conditioning guard and abstains anyway. The lift is added for
**completeness/robustness** — it engages soundly only on well-conditioned
cross-term `sqrt` arguments (the synthetic cases in the test). Those instances
remain gated by B&B's ability to close the gap, not by this envelope.

## Tests

`test_cross_term_sqrt_soundness.py` (new, **CI-visible** — unmarked):

- `test_cross_term_sqrt_lift_engages` — aux columns are created on a
  well-conditioned box (the lift actually fires, not silently abstains).
- `test_cross_term_sqrt_encloses_curve` — at interior grid points the
  relaxation brackets `sqrt(x²+2xyz+y²)` from both sides (no cut excludes the
  true curve).
- `test_cross_term_sqrt_backends_agree` — fast simplex == HiGHS in the
  well-conditioned regime.
- `test_cross_term_guard_keeps_minlplib_sound` — nvs05/nvs22 root bounds stay
  `≤ optimum` on **both** backends, default and FBBT bounds (the `8.31`
  regression lock).
- `test_cross_term_guard_abstains_on_wide_box` — an ill-conditioned wide-box
  cross term abstains: no finite bound exceeds the truth and the backends do not
  disagree (both return no bound — the sound outcome).

```
14 passed
```

Broad relaxation/certification soundness suite: `215 passed`.
`ruff check` / `ruff format --check` / `mypy python/discopt/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
