### PR TITLE
Soundness: never certify without an incumbent + correct 9 wrong MINLPLib known-optima

### DIFF
--- a/discopt_benchmarks/tests/conftest.py
+++ b/discopt_benchmarks/tests/conftest.py
@@ -70,9 +70,9 @@ def known_optima() -> dict[str, float]:
         "ex1222": 1.0765,
         "ex1223": 4.5796,
         "ex1224": -0.94347,
-        "ex1225": 0.0,
+        "ex1225": 31.0,  # was 0.0 (MINLPLib =opt=)
         "ex1226": -17.0,
-        "ex1233": 62.1833,
+        "ex1233": 155010.6713,  # was 62.1833 (MINLPLib =best=)
         "fuel": 8566.12,
         "gastrans": 89.08588,
     }

--- a/discopt_benchmarks/tests/test_correctness.py
+++ b/discopt_benchmarks/tests/test_correctness.py
@@ -48,22 +48,25 @@ def solve_instance(name: str, **kwargs) -> MockSolution:
 # 1. KNOWN OPTIMUM VALIDATION
 # ─────────────────────────────────────────────────────────────
 
-# Known optimal values from MINLPLib (subset for testing)
+# Known optimal values from MINLPLib (subset for testing).
+# Verified against the official MINLPLib `minlplib.solu`; nine entries were
+# demonstrably wrong (most ~100-1500x too small) and are corrected here to the
+# authoritative =opt= (proven) / =best= (best known) values.
 KNOWN_OPTIMA = {
     "ex1221":       7.6672,
     "ex1222":       1.0765,
     "ex1223":       4.5796,
     "ex1223a":      4.5796,
     "ex1224":      -0.94347,
-    "ex1225":       0.0,
+    "ex1225":      31.0,           # was 0.0 (=opt=)
     "ex1226":      -17.0,
-    "ex1233":      62.1833,
-    "ex1243":      83.6455,
-    "ex1244":      83.6455,
-    "ex1252":    1169.37,
-    "ex1252a":   1169.37,
-    "ex1263":      19.46,
-    "ex1263a":     19.46,
+    "ex1233":      155010.6713,    # was 62.1833 (=best=)
+    "ex1243":      83402.50641,    # was 83.6455 (=opt=)
+    "ex1244":      82042.90522,    # was 83.6455 (=opt=)
+    "ex1252":      128893.741,     # was 1169.37 (=opt=; Kocis-Grossmann batch plant)
+    "ex1252a":     128893.741,     # was 1169.37 (=opt=)
+    "ex1263":      19.6,           # was 19.46 (=opt=)
+    "ex1263a":     19.6,           # was 19.46 (=opt=)
     "ex1264":       8.6,
     "ex1264a":      8.6,
     "ex1265":      10.3,
@@ -72,9 +75,16 @@ KNOWN_OPTIMA = {
     "ex1266a":     16.3,
     "fuel":         8566.12,
     "gastrans":   89.08588,
-    "ghg_1veh":  -246.04,
-    "procurement1": 0.0,
-    "smallinvDAXr1b50": -3.83,
+    "ghg_1veh":    7.7816348850,   # was -246.04 (=opt=)
+    # `procurement1` (0.0) and `smallinvDAXr1b50` (-3.83) were phantom entries —
+    # those names match no MINLPLib instance and the values matched nothing.
+    # Replaced with the real instances the suites reference (=best= / =opt=).
+    "procurement1large":      3802.1797490,
+    "procurement1mot":         291.5416577,
+    "procurement2mot":         212.0707488,
+    "smallinvDAXr1b020-022":     1.5715279820,
+    "smallinvDAXr1b050-055":     9.7971434540,
+    "smallinvDAXr1b100-110":    39.1621418600,
 }
 
 ABS_TOL = 1e-4

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3518,9 +3518,17 @@ def solve_model(
         obj_val = None
         if stats["total_nodes"] >= max_nodes:
             status = "node_limit"
+            # No incumbent and a resource limit: nothing is certified. Without an
+            # incumbent there is no gap to certify, and a leftover tree bound
+            # describes an unexplored search, not a proven optimum — a certified
+            # exit here would claim optimality with no solution at all.
+            _gap_certified = False
         elif wall_time >= time_limit:
             status = "time_limit"
+            _gap_certified = False
         else:
+            # Tree exhausted with no feasible node: infeasibility *is* a certified
+            # conclusion, so leave _gap_certified untouched.
             status = "infeasible"
 
     from discopt.modeling.core import ObjectiveSense
@@ -4257,9 +4265,17 @@ def _solve_nlp_bb(
         obj_val = None
         if stats["total_nodes"] >= max_nodes:
             status = "node_limit"
+            # No incumbent and a resource limit: nothing is certified. Without an
+            # incumbent there is no gap to certify, and a leftover tree bound
+            # describes an unexplored search, not a proven optimum — a certified
+            # exit here would claim optimality with no solution at all.
+            _gap_certified = False
         elif wall_time >= time_limit:
             status = "time_limit"
+            _gap_certified = False
         else:
+            # Tree exhausted with no feasible node: infeasibility *is* a certified
+            # conclusion, so leave _gap_certified untouched.
             status = "infeasible"
 
     # Negate bound back for maximization
@@ -6973,9 +6989,17 @@ def _solve_milp_bb(
         obj_val = None
         if stats["total_nodes"] >= max_nodes:
             status = "node_limit"
+            # No incumbent and a resource limit: nothing is certified. Without an
+            # incumbent there is no gap to certify, and a leftover tree bound
+            # describes an unexplored search, not a proven optimum — a certified
+            # exit here would claim optimality with no solution at all.
+            _gap_certified = False
         elif wall_time >= time_limit:
             status = "time_limit"
+            _gap_certified = False
         else:
+            # Tree exhausted with no feasible node: infeasibility *is* a certified
+            # conclusion, so leave _gap_certified untouched.
             status = "infeasible"
 
     from discopt.modeling.core import ObjectiveSense
@@ -7427,9 +7451,17 @@ def _solve_miqp_bb(
         obj_val = None
         if stats["total_nodes"] >= max_nodes:
             status = "node_limit"
+            # No incumbent and a resource limit: nothing is certified. Without an
+            # incumbent there is no gap to certify, and a leftover tree bound
+            # describes an unexplored search, not a proven optimum — a certified
+            # exit here would claim optimality with no solution at all.
+            _gap_certified = False
         elif wall_time >= time_limit:
             status = "time_limit"
+            _gap_certified = False
         else:
+            # Tree exhausted with no feasible node: infeasibility *is* a certified
+            # conclusion, so leave _gap_certified untouched.
             status = "infeasible"
 
     from discopt.modeling.core import ObjectiveSense

--- a/python/tests/test_no_incumbent_certification.py
+++ b/python/tests/test_no_incumbent_certification.py
@@ -1,0 +1,38 @@
+"""Regression: never report ``gap_certified=True`` without an incumbent.
+
+``SolveResult.gap_certified`` defaults to ``True``, and the no-incumbent branch
+of every B&B finalizer (``solve_model``, ``_solve_nlp_bb``, ``_solve_milp_bb``,
+``_solve_miqp_bb``) set ``status`` to a resource limit but did not reset
+``_gap_certified``. A time-/node-limit exit that found no feasible solution
+therefore claimed certified optimality with *no incumbent at all*, leaking a
+leftover (phantom) tree bound — a prime-directive violation: optimality reported
+where none was proven. ``ex1233`` reproduces it (it hits the time limit before
+finding any feasible point).
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+
+@pytest.mark.correctness
+def test_no_certification_without_incumbent():
+    """A resource-limit exit with no incumbent must not certify optimality."""
+    nl = _DATA / "ex1233.nl"
+    assert nl.exists(), f"missing {nl}"
+    r = dm.from_nl(str(nl)).solve(time_limit=20, gap_tolerance=1e-4)
+
+    # The fundamental invariant: certification requires an incumbent. If the
+    # solver *did* find one within the budget the test still holds (the guard is
+    # only about the no-incumbent case), so this is robust to timing.
+    assert not (r.gap_certified and r.objective is None), (
+        f"certified with no incumbent: status={r.status} bound={r.bound} gap={r.gap}"
+    )


### PR DESCRIPTION
Two small, independent correctness fixes carved out of the #138 work so they can land without waiting on the larger relaxation reconciliation. Both are pure correctness, conflict-free with the in-flight relaxation work (#162), and apply cleanly onto current `main`.

## 1. Never report `gap_certified=True` without an incumbent

`SolveResult.gap_certified` defaults to `True`, and the no-incumbent branch of every B&B finalizer (`solve_model`, `_solve_nlp_bb`, `_solve_milp_bb`, `_solve_miqp_bb`) set `status` to a resource limit but never reset `_gap_certified`. So a time-/node-limit exit that found **no feasible solution** returned `gap_certified=True` with `objective=None` and a leaked phantom tree bound — a prime-directive violation (optimality reported with no solution at all).

`ex1233` reproduces it: on `main` it returns `cert=True, obj=None, bound=-2.7e-322`.

**Fix:** clear `_gap_certified` in the `node_limit`/`time_limit` no-incumbent cases of all four finalizers; an exhausted-tree `infeasible` conclusion stays certified (infeasibility *is* a proof). The existing `if not _gap_certified` guard then also nulls the phantom bound/gap, so `ex1233` now returns an honest `time_limit / bound=None / gap_certified=False`. A regression test locks the invariant: `gap_certified ⇒ objective is not None`.

## 2. Correct 9 wrong known-optima against MINLPLib `minlplib.solu`

Audited `KNOWN_OPTIMA` against the official MINLPLib `minlplib.solu`. Nine entries were wrong — most ~100–1500× too small (an apparently stale/mis-parsed import) — which silently inverts the correctness checks (a *sound* solver result would be flagged `INCORRECT`, or a genuinely wrong result would pass):

| instance | was | corrected | source |
|----------|-----|-----------|--------|
| ex1225 | 0.0 | 31.0 | `=opt=` (discopt also certifies 31.0) |
| ex1233 | 62.1833 | 155010.6713 | `=best=` (rigorous LB ~109649 rules out 62.18) |
| ex1243 | 83.6455 | 83402.50641 | `=opt=` |
| ex1244 | 83.6455 | 82042.90522 | `=opt=` |
| ex1252 | 1169.37 | 128893.741 | `=opt=` (Kocis–Grossmann batch plant) |
| ex1252a | 1169.37 | 128893.741 | `=opt=` |
| ex1263 | 19.46 | 19.6 | `=opt=` |
| ex1263a | 19.46 | 19.6 | `=opt=` |
| ghg_1veh | -246.04 | 7.7816348850 | `=opt=` |

Also replaced two **phantom** entries (`procurement1`=0.0, `smallinvDAXr1b50`=-3.83 — names that match no MINLPLib instance, values matching nothing) with the real instances the suites reference. All 29 entries now match `minlplib.solu` exactly; the `conftest.py` fallback's `ex1225`/`ex1233` are fixed to match.

## Validation
- ruff check + format clean on the changed `python/` files (CI scope); benchmark files parse.
- The 9 corrected values verified equal to `minlplib.solu` `=opt=`/`=best=` (29/29 match).
- `ex1233` gap-cert fix confirmed end-to-end (honest `cert=False`); new regression test passes.

https://claude.ai/code/session_0193eTCHkaXstRE19gaN3QCF

---
_Generated by [Claude Code](https://claude.ai/code/session_0193eTCHkaXstRE19gaN3QCF)_