### PR TITLE
fix(factorable): reject denominator clearing that fabricates a false infeasibility (gear4, #145)

### DIFF
--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -294,6 +294,40 @@ def _clear_divisions(body: Expression, sense: str, model: Model):
     return body, sense
 
 
+def _has_unbounded_nonlinear_term(body: Expression, model: Model) -> bool:
+    """True if the distributed *body* contains a nonlinear product term (total
+    variable degree >= 2) whose interval bound is non-finite over the model box.
+
+    Denominator clearing multiplies the *whole* constraint through by ``D``, so a
+    benign linear term in an unbounded variable (e.g. a continuous slack ``x4``
+    with ``ub = +inf``) becomes a nonlinear product ``x4 * D``.  A product with a
+    non-finitely-bounded factor has no valid finite McCormick/bilinear envelope:
+    the relaxation built on it can *exclude* feasible points and report a false
+    infeasibility (gear4, a feasible MINLPLib instance whose linear slacks are
+    unbounded above).  When clearing introduces such a term the rewrite must be
+    rejected and the original quotient kept — the McCormick-``lp`` path bounds the
+    division soundly.
+    """
+    dist = distribute_products(body)
+
+    def walk(e: Expression) -> bool:
+        if isinstance(e, BinaryOp) and e.op in ("+", "-"):
+            return walk(e.left) or walk(e.right)
+        if isinstance(e, UnaryOp) and e.op == "neg":
+            return walk(e.operand)
+        decomp = _decompose_poly_product(e, model)
+        if decomp is not None:
+            _coeff, powers, extra = decomp
+            total_degree = sum(exp for _leaf, exp in powers.values())
+            if not extra and total_degree >= 2:
+                lo, hi = _bound_expression(e, model)
+                if not (np.isfinite(lo) and np.isfinite(hi)):
+                    return True
+        return False
+
+    return walk(dist)
+
+
 def has_factorable_work(model: Model) -> bool:
     """True if any constraint/objective has a clearable division or a mixed
     repeated-factor product — i.e. the pass would change the model.
@@ -382,6 +416,16 @@ def factorable_reformulate(model: Model, *, clear_only: bool = False) -> Model:
                 rebuilt.append(c)  # pass through anything exotic untouched
                 continue
             body, sense = _clear_divisions(c.body, c.sense, new_model)
+            # Soundness gate: clearing multiplies the constraint through by the
+            # denominator, which can pull an unbounded linear term into a
+            # nonlinear product (``x4 * D``) that has no valid finite envelope.
+            # Such a cleared relaxation can exclude feasible points and certify a
+            # false infeasibility (gear4). Keep the original quotient in that case.
+            if (body is not c.body or sense != c.sense) and _has_unbounded_nonlinear_term(
+                body, new_model
+            ):
+                rebuilt.append(c)
+                continue
             if clear_only:
                 # Only touch constraints the clearing actually rewrote; leave
                 # everything else byte-for-byte identical so convex structure

--- a/python/tests/test_gear4_false_infeasible.py
+++ b/python/tests/test_gear4_false_infeasible.py
@@ -1,0 +1,150 @@
+"""Soundness lock: division clearing must not fabricate a false infeasibility.
+
+``gear4`` (a *feasible* MINLPLib instance, optimum ``1.64342847``) was reported
+``status="infeasible", gap_certified=True`` — a certified wrong answer, the worst
+failure class — on ``main``. It is also a member of the smoke suite, so the bug
+silently corrupted the smoke correctness gate.
+
+Root cause (issue #145). gear4's single nonlinear constraint is a quotient with
+two *unbounded* continuous slacks ``x4, x5`` (``ub = +inf``) used to model
+``min |target - (1e6 x0 x1)/(x2 x3)|``::
+
+    -(1e6 x0 x1)/(x2 x3) - x4 + x5 == -144279.32 ,  x4, x5 >= 0 .
+
+Sign-definite denominator clearing multiplies the *whole* constraint through by
+``D = x2 x3``, which turns the benign linear slack terms ``-x4 + x5`` into the
+trilinear products ``-x4 x2 x3 + x5 x2 x3``. A product with a non-finitely-bounded
+factor (``x4``/``x5`` are unbounded above) has no valid finite McCormick envelope:
+the cleared relaxation *excludes* feasible points, the root LP is reported
+infeasible, the whole tree is fathomed as infeasible, and the leftover
+``status != "infeasible"`` exemption in ``SolveResult.__post_init__`` lets it pass
+through as ``gap_certified=True``.
+
+The fix (``factorable_reform``): reject denominator clearing for a constraint
+when multiplying through introduces a nonlinear product whose interval bound is
+non-finite. gear4 then keeps its quotient, which the McCormick-``lp`` path bounds
+soundly (feasible incumbent, valid dual bound at the relaxation floor ~0).
+
+These tests are intentionally *unmarked* (CI-visible): the false-infeasible fired
+at the root node, so a tiny bounded solve reproduces it, and the regression must
+never be invisible to CI the way ``@pytest.mark.correctness`` tests are.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+from discopt.modeling.core import BinaryOp, Expression, from_nl
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+_GEAR4_OPT = 1.64342847
+
+
+def _contains_division(expr: Expression) -> bool:
+    """True if *expr* still contains an unrewritten ``/`` node."""
+    if isinstance(expr, BinaryOp):
+        if expr.op == "/":
+            return True
+        return _contains_division(expr.left) or _contains_division(expr.right)
+    for attr in ("operand", "left", "right"):
+        child = getattr(expr, attr, None)
+        if isinstance(child, Expression) and _contains_division(child):
+            return True
+    return False
+
+
+def test_has_unbounded_nonlinear_term_unit():
+    """The guard flags a nonlinear product with an unbounded factor, not a bounded one."""
+    from discopt._jax.factorable_reform import _has_unbounded_nonlinear_term
+
+    m = dm.Model("unit")
+    a = m.continuous("a", lb=1.0, ub=10.0)  # bounded
+    b = m.continuous("b", lb=0.0, ub=float("inf"))  # unbounded above (a slack)
+
+    # a * a : both factors bounded -> safe.
+    assert not _has_unbounded_nonlinear_term(a * a, m)
+    # b alone is linear -> safe (degree 1, never enveloped as a product).
+    assert not _has_unbounded_nonlinear_term(3.0 * b, m)
+    # a * b : a bounded but b unbounded -> no valid finite envelope -> flagged.
+    assert _has_unbounded_nonlinear_term(a * b, m)
+
+
+def test_clearing_skipped_for_unbounded_slack_product():
+    """``factorable_reformulate`` must keep gear4's quotient, not clear it into an
+    unbounded trilinear product."""
+    from discopt._jax.factorable_reform import (
+        _clear_divisions,
+        _has_unbounded_nonlinear_term,
+        factorable_reformulate,
+    )
+
+    m = from_nl(str(_DATA / "gear4.nl"))
+
+    # Sanity: clearing this constraint *would* introduce an unbounded product...
+    con = m._constraints[0]
+    cleared_body, _sense = _clear_divisions(con.body, con.sense, m)
+    assert cleared_body is not con.body, "expected the denominator to be clearable"
+    assert _has_unbounded_nonlinear_term(cleared_body, m), (
+        "test premise: cleared gear4 body must contain an unbounded nonlinear product"
+    )
+
+    # ...so the guard must reject it and keep the quotient intact.
+    m2 = factorable_reformulate(m)
+    assert any(_contains_division(c.body) for c in m2._constraints), (
+        "guard failed: gear4 quotient was cleared into an unbounded-product relaxation"
+    )
+
+
+def test_gear4_not_false_infeasible():
+    """gear4 must never be reported certified-infeasible; bounds stay sound."""
+    r = from_nl(str(_DATA / "gear4.nl")).solve(time_limit=10, max_nodes=200)
+
+    # Headline: the certified-wrong-answer must be gone.
+    assert not (r.status == "infeasible" and r.gap_certified), (
+        f"gear4 falsely certified infeasible: status={r.status} cert={r.gap_certified}"
+    )
+    # gear4 is feasible, so it must not be reported infeasible at all.
+    assert r.status != "infeasible", f"gear4 is feasible but status={r.status}"
+
+    # Soundness: any reported dual bound never exceeds the true optimum.
+    if r.bound is not None:
+        assert r.bound <= _GEAR4_OPT + 1e-3, f"unsound dual bound {r.bound} > optimum {_GEAR4_OPT}"
+    # Any feasible incumbent is >= the true optimum (it cannot beat it).
+    if r.objective is not None:
+        assert r.objective >= _GEAR4_OPT - 1e-3, (
+            f"incumbent {r.objective} below true optimum {_GEAR4_OPT}"
+        )
+
+
+def test_synthetic_unbounded_slack_quotient_not_false_infeasible():
+    """Self-contained gear4-class model (issue #145): a large-coefficient quotient
+    equality with unbounded continuous slacks must not be certified infeasible."""
+    m = dm.Model("synthetic_unbounded_slack_quotient")
+    x0 = m.integer("x0", lb=12, ub=60)
+    x1 = m.integer("x1", lb=12, ub=60)
+    x2 = m.integer("x2", lb=12, ub=60)
+    x3 = m.integer("x3", lb=12, ub=60)
+    x4 = m.continuous("x4", lb=0.0, ub=float("inf"))
+    x5 = m.continuous("x5", lb=0.0, ub=float("inf"))
+    m.minimize(x4 + x5)
+    # x4 - x5 = target - ratio  =>  the slacks absorb the residual, so every
+    # integer assignment is feasible: the model is unconditionally feasible.
+    m.subject_to(-(1e6 * x0 * x1) / (x2 * x3) - x4 + x5 == -144279.32477276)
+
+    r = m.solve(time_limit=10, max_nodes=200)
+
+    assert not (r.status == "infeasible" and r.gap_certified), (
+        f"synthetic quotient falsely certified infeasible: status={r.status} cert={r.gap_certified}"
+    )
+    assert r.status != "infeasible", f"model is feasible but status={r.status}"
+    # A feasible point exists (e.g. any gears + slacks); the solver must find one.
+    assert r.objective is not None, "feasible model returned no incumbent"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`gear4` (a **feasible** MINLPLib instance, optimum `1.64342847`, and a member of the **smoke** suite) was reported `status="infeasible", gap_certified=True` on `main` — a **certified wrong answer**, the worst failure class. Because gear4 is in the smoke suite, this silently corrupted the smoke correctness gate.

This is a standalone, sound fix off `main`. It also unblocks gear4 for #162 and the broader certification reconciliation.

## Root cause (#145)

gear4's single nonlinear constraint is a quotient with two **unbounded** continuous slacks `x4, x5` (`ub = +inf`) modeling `min |target - (1e6·x0·x1)/(x2·x3)|`:

```
-(1e6·x0·x1)/(x2·x3) - x4 + x5 == -144279.32 ,   x4, x5 >= 0
```

Sign-definite **denominator clearing** multiplies the *whole* constraint through by `D = x2·x3`, turning the benign linear slack terms `-x4 + x5` into the trilinear products `-x4·x2·x3 + x5·x2·x3`. A product with a non-finitely-bounded factor (`x4`/`x5` are unbounded above) has **no valid finite McCormick envelope**: the cleared relaxation *excludes* feasible points, the root LP is reported infeasible, the whole tree is fathomed as infeasible, and the `status != "infeasible"` exemption in `SolveResult.__post_init__` lets it pass through as `gap_certified=True`.

## Fix

A soundness gate in `factorable_reformulate`: after clearing, if the rewritten body contains a nonlinear product term (total variable degree ≥ 2) whose interval bound over the model box is **non-finite**, reject the rewrite and keep the original quotient — which the McCormick-`lp` path bounds soundly (feasible incumbent, valid dual bound at the relaxation floor). `gear`/`gear2`/`gear3` (no unbounded slacks) still certify unchanged.

## Tests

New `python/tests/test_gear4_false_infeasible.py` (4 tests, intentionally **unmarked** so CI sees them — the false-infeasible fired at the root node, so a tiny bounded solve reproduces it):

- `test_has_unbounded_nonlinear_term_unit` — guard flags an unbounded-factor product, not a bounded one.
- `test_clearing_skipped_for_unbounded_slack_product` — `factorable_reformulate(gear4)` keeps the quotient.
- `test_gear4_not_false_infeasible` — gear4 is never certified-infeasible; dual bound ≤ optimum, incumbent ≥ optimum.
- `test_synthetic_unbounded_slack_quotient_not_false_infeasible` — self-contained #145-class model.

Local: 4 passed in ~7s; `ruff check`/`ruff format --check`/`mypy` all clean on the changed files. No regressions across the factorable / quotient-certification / scale-soundness suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
