### PR TITLE
test(doe): cut DOE-CLI fast-path runtime ~3x by bypassing redundant D-optimal search

### DIFF
--- a/python/tests/test_doe_cli.py
+++ b/python/tests/test_doe_cli.py
@@ -78,7 +78,7 @@ def test_templates_lists_all():
 # ──────────────────────────────────────────────────────────────────
 
 
-def _new_params(tmpdir, *, template, inputs, n, degree=None, response="y", error=1.0, n_starts=3):
+def _new_params(tmpdir, *, template, inputs, n, degree=None, response="y", error=1.0, n_starts=1):
     return NewParams(
         output=Path(tmpdir) / f"{template}.xlsx",
         n=n,
@@ -220,7 +220,7 @@ def test_extend_appends_new_batch(tmp_path):
     before_status = do_status({"workbook": str(wb_path)})
     assert before_status["n_pending"] == 0
 
-    ext = do_extend(ExtendParams(workbook=wb_path, n=3, n_starts=3))
+    ext = do_extend(ExtendParams(workbook=wb_path, n=3, n_starts=1))
     assert ext["batch"] == 2
     assert len(ext["new_run_ids"]) == 3
     assert sorted(ext["new_run_ids"]) == ext["new_run_ids"]  # contiguous & sorted
@@ -369,16 +369,25 @@ def test_status_missing_workbook(tmp_path):
 
 
 def test_workbook_metadata_roundtrip(tmp_path):
-    out = do_new(
-        _new_params(
-            tmp_path,
-            template="response-surface-2d",
-            inputs=[("x1", 0.0, 10.0), ("x2", -5.0, 5.0)],
-            n=4,
-            error=0.5,
-        )
+    # Metadata is written at workbook *creation*; this test asserts only the
+    # persistence round-trip, not anything about the generated design. Build
+    # the workbook directly rather than paying do_new's ~15s D-optimal search
+    # (the model-based design path is covered by test_new_response_surface_2d).
+    inputs = [("x1", 0.0, 10.0), ("x2", -5.0, 5.0)]
+    wb_path = tmp_path / "response-surface-2d.xlsx"
+    wb = Workbook.create(
+        wb_path,
+        template="response-surface-2d",
+        template_args={},
+        input_specs=[InputSpec(name, lb, ub) for name, lb, ub in inputs],
+        criterion="determinant",
+        measurement_error=0.5,
+        seed=0,
+        response_name="y",
     )
-    wb = Workbook.open(out["workbook_path"])
+    wb.save()
+
+    wb = Workbook.open(wb_path)
     assert wb.template_name() == "response-surface-2d"
     assert wb.response_name() == "y"
     assert wb.measurement_error() == 0.5
@@ -392,11 +401,26 @@ def test_workbook_metadata_roundtrip(tmp_path):
 
 
 def test_fim_persisted_and_used_by_extend(tmp_path):
+    # Asserts the FIM is persisted by do_fit and positive-definite — not that
+    # the design is D-optimal. Build a fixed, well-conditioned 3x3-grid design
+    # directly (as in test_fit_recovers_known_truth_response_surface) to skip
+    # do_new's ~18s D-optimal search, which this test does not exercise.
     inputs = [("x1", 0.0, 10.0), ("x2", -5.0, 5.0)]
-    out = do_new(
-        _new_params(tmp_path, template="response-surface-2d", inputs=inputs, n=6, error=0.5)
+    wb_path = tmp_path / "response-surface-2d.xlsx"
+    wb = Workbook.create(
+        wb_path,
+        template="response-surface-2d",
+        template_args={},
+        input_specs=[InputSpec(name, lb, ub) for name, lb, ub in inputs],
+        criterion="determinant",
+        measurement_error=0.5,
+        seed=0,
+        response_name="y",
     )
-    wb_path = Path(out["workbook_path"])
+    design = [{"x1": x1, "x2": x2} for x1 in (0.0, 5.0, 10.0) for x2 in (-5.0, 0.0, 5.0)]
+    design.append({"x1": 5.0, "x2": 0.0})
+    wb.append_runs(1, design)
+    wb.save()
 
     def predict(row):
         return 1 + 0.5 * row["x1"] - 0.3 * row["x2"]


### PR DESCRIPTION
## Problem

The Python "fast" CI job was dominated by a handful of DOE-CLI smoke tests. Two of them each paid `do_new`'s full ~15–18s D-optimal multistart search but asserted nothing about the resulting design:

- `test_workbook_metadata_roundtrip` — only checks the metadata persistence round-trip (template / response / measurement error / input specs / parameter names), all written at workbook **creation** time.
- `test_fim_persisted_and_used_by_extend` — only checks that `do_fit` persists a **positive-definite** FIM.

## Change

Both tests now build the workbook directly via `Workbook.create` with a fixed, well-conditioned 3×3-grid design — the exact pattern already established and documented in `test_fit_recovers_known_truth_response_surface` — skipping the D-optimal search they never exercised. The model-based design path stays fully covered by `test_new_response_surface_2d` and `test_new_polynomial_1d`.

Also drops the structural `do_new` tests' `n_starts` 3→1 (they assert parameter names / design counts / variable bounds, not design optimality; `n_starts=1` still runs the complete search-and-refine path).

## Measurements (local, `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`)

| Test | Before | After |
|---|---|---|
| `test_fim_persisted_and_used_by_extend` | 18.35s | 0.03s |
| `test_workbook_metadata_roundtrip` | 14.58s | 0.01s |
| `test_new_response_surface_2d` | 8.28s | 6.90s |
| `test_new_polynomial_1d` | 5.23s | 5.23s |

Fast-path DOE-CLI work (excluding the already-`slow`-marked 3D test) drops from **~51s → ~16s**. All 15 tests still pass.

## Scope / soundness

Test-only change — no solver, DOE, or FIM math is touched. The remaining `do_new` cost (`test_new_response_surface_2d` ~7s, `test_new_polynomial_1d` ~5s) is genuine coverage of the D-optimal model-based search; cutting it further would require optimizing `compute_fim` itself (it rebuilds the model + runs a HiGHS QP solve + a fresh un-jitted `jax.jacobian` per design candidate), which touches core DOE math and is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
