### PR TITLE
test(ci): cap solve budgets on the two very-large fast-CI tests (no correctness loss)

### DIFF
--- a/python/tests/test_bucket2_composition_soundness.py
+++ b/python/tests/test_bucket2_composition_soundness.py
@@ -74,6 +74,16 @@ _AFFECTED = [
 
 _BACKENDS = ["simplex", "auto"]
 
+# Per-solve wall-clock cap. The soundness invariant this file locks is about the
+# *value* of a returned finite bound, not about reaching the LP optimum — the
+# docstring explicitly accepts early termination ("looseness and early
+# termination are fine"). On ex1252's FBBT-tightened box the fast simplex grinds
+# ~54s before reporting the same sound ``lb=0.0`` that HiGHS returns instantly;
+# capping the solve preserves every assertion (the capped bound is identical and
+# still sound) while keeping this CI-visible test fast. A non-``optimal`` status
+# from an early stop is already an accepted outcome below.
+_SOLVE_TIME_LIMIT = 5.0
+
 
 def _bounds_for(m):
     """Return ``(default_bounds, fbbt_bounds)`` as ``(lb, ub)`` pairs."""
@@ -91,7 +101,7 @@ def _root_bound(m, backend, bounds):
     lb, ub = bounds
     lb = np.asarray(lb, dtype=float).copy()
     ub = np.asarray(ub, dtype=float).copy()
-    return relaxer.solve_at_node(lb, ub)
+    return relaxer.solve_at_node(lb, ub, time_limit=_SOLVE_TIME_LIMIT)
 
 
 @pytest.mark.parametrize("instance, optimum", _AFFECTED)

--- a/python/tests/test_gp_corpus.py
+++ b/python/tests/test_gp_corpus.py
@@ -190,8 +190,10 @@ def test_bb_opt_out_skips_gp_fast_path() -> None:
         # exhausts the tree only after many minutes — the prior unbounded form
         # relied on an unsound NLP pruning bound (removed in #120) to terminate
         # fast. The classic-path assertions below hold the instant the
-        # incumbent is found, so cap the budget to keep the test deterministic.
-        result = model.solve(solver="bb", time_limit=30.0)
+        # incumbent is found (at the root), so a small budget suffices and keeps
+        # this off the fast-CI critical path; the cap only bounds the
+        # never-reached certification, not the assertions.
+        result = model.solve(solver="bb", time_limit=5.0)
     assert result.status in ("optimal", "feasible")
     assert result.objective == pytest.approx(2.0, abs=1e-4)
     # The classic path does not set the convex single-NLP fast-path flag.


### PR DESCRIPTION
## Problem

The "Python fast" CI job plateaued at ~8% of the progress bar for a long time. Profiling the fast suite (exact CI marker filter + `-n 2 --dist loadgroup`) showed two tests dwarfing everything else (next slowest is ~5s):

| test | before |
|---|---|
| `test_bucket2_composition_soundness.py::...backends_agree...[ex1252-128893.8]` | ~97s |
| `test_bucket2_composition_soundness.py::...sound_on_both...[simplex-ex1252-128893.8]` | ~97s |
| `test_gp_corpus.py::test_bb_opt_out_skips_gp_fast_path` | ~30s |

With 2 xdist workers the two ~97s `ex1252` cells serialize on one worker, which is the plateau.

## Root cause

- **bucket2 / ex1252:** on ex1252's FBBT-tightened box the fast Rust `simplex` grinds **~54s** to reach the same sound `lb=0.0` that HiGHS returns in **0.01s** (build + FBBT are both <0.01s; the cost is entirely inside the simplex solve). Filed as **#170**. This file is the deliberate, CI-visible soundness floor for the lifted-envelope work — its invariant is about the *value* of a returned finite bound, not reaching the LP optimum, and the docstring already states early termination is acceptable.
- **gp bb-opt-out:** the test always burned its full 30s budget. The optimum (2.0) is found at the root; all three assertions hold the instant the incumbent appears. The budget only bounds the never-reached *certification*.

## Change

Cap the wasted wall-clock past the point each test's assertions are already decided:

- `test_bucket2_composition_soundness.py`: pass `time_limit=5.0` to `solve_at_node`. The capped bound is **identical** (`lb=0.0`) and still sound, so every `(instance, backend, bound-set)` soundness assertion and the cross-backend agreement assertion are preserved. ex1252 cells: ~97s → ~5s; whole bucket2 suite: ~194s of these → ~13s total, all 15 pass.
- `test_gp_corpus.py::test_bb_opt_out_skips_gp_fast_path`: `time_limit` 30s → 5s. Still passes (`status` feasible/optimal, `objective ≈ 2.0`, `convex_fast_path is False`).

**No test removed; no soundness/correctness assertion weakened** — only the grind past the decision point. The fast suite's slowest test drops from ~97s to ~5s.

Refs #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
