### PR TITLE
Lift fractional powers of polynomials in objectives (#138)

### DIFF
--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -135,10 +135,11 @@ class _Lifter:
     def __init__(self, model: Model):
         self.model = model
         self._cache: dict[tuple[int, int], Variable] = {}
+        self._expr_cache: dict[int, Variable] = {}
         self.aux_constraints: list[Constraint] = []
         self._counter = 0
 
-    def monomial(self, leaf: Expression, flat_index: int, exp: int):
+    def monomial(self, leaf: Expression, flat_index: int, exp: int) -> Variable | None:
         """Return an aux variable equal to ``leaf**exp`` (creating it on first
         use), or ``None`` if a finite bound for it cannot be established."""
         key = (flat_index, exp)
@@ -157,6 +158,63 @@ class _Lifter:
         # Normalised form ``body == 0`` with body = w - leaf**exp.
         self.aux_constraints.append(Constraint(BinaryOp("-", w, pow_expr), "==", 0.0))
         return w
+
+    def expression(self, expr: Expression) -> Variable | None:
+        """Return an aux variable equal to *expr* (creating it on first use), or
+        ``None`` if a finite bound for it cannot be established.
+
+        Used to expose a fractional power ``base ** p`` of a composite *base* to
+        the relaxation: the relaxation can bound ``t ** p`` (a fractional power of
+        a single variable) but not ``base ** p`` (a fractional power of a
+        polynomial). The defining equality ``t == base`` is itself run through the
+        monomial lift so any mixed products inside *base* become bilinear aux too.
+        Deduplicated by structural identity of the (already-distributed) node.
+        """
+        key = id(expr)
+        cached = self._expr_cache.get(key)
+        if cached is not None:
+            return cached
+        lo, hi = _bound_expression(expr, self.model)
+        if not (np.isfinite(lo) and np.isfinite(hi)) or max(abs(lo), abs(hi)) >= _INF_THRESH:
+            return None
+        name = f"_fr_aux_{self._counter}"
+        self._counter += 1
+        w = Variable(name, VarType.CONTINUOUS, (), lo, hi, self.model)
+        self.model._variables.append(w)
+        self._expr_cache[key] = w
+        # Clear any sign-definite division in the defining equality ``w == expr``
+        # (so a ratio ``w == N / D`` becomes the bilinear ``w*D == N`` the
+        # relaxation can McCormick), then lift its mixed products.
+        body, _sense = _clear_divisions(BinaryOp("-", w, expr), "==", self.model)
+        body = _lift_expr(distribute_products(body), self.model, self)
+        self.aux_constraints.append(Constraint(body, "==", 0.0))
+        return w
+
+    def fractional_power(self, base_var: Variable, p: float) -> Variable | None:
+        """Return an aux variable equal to ``base_var ** p`` for a fractional *p*,
+        or ``None`` if it cannot be soundly bounded.
+
+        ``base_var`` is a single variable (typically an aux from :meth:`expression`
+        holding a polynomial), so ``base_var ** p`` is a fractional power of a
+        *variable* — which the relaxation can bound. Lifting the *value* of the
+        power (not just its base) turns e.g. ``N / g**(1/3)`` into ``N / d`` with
+        ``d`` a plain variable, the ratio form the objective linearizer accepts.
+        Requires ``base_var >= 0`` so the power is real and monotone increasing.
+        """
+        lo = float(np.min(base_var.lb))
+        hi = float(np.max(base_var.ub))
+        if not (np.isfinite(lo) and np.isfinite(hi)) or lo < 0.0:
+            return None
+        d_lo, d_hi = lo**p, hi**p
+        if not (np.isfinite(d_lo) and np.isfinite(d_hi)) or max(d_lo, d_hi) >= _INF_THRESH:
+            return None
+        name = f"_fr_aux_{self._counter}"
+        self._counter += 1
+        d = Variable(name, VarType.CONTINUOUS, (), d_lo, d_hi, self.model)
+        self.model._variables.append(d)
+        pow_expr = BinaryOp("**", base_var, Constant(float(p)))
+        self.aux_constraints.append(Constraint(BinaryOp("-", d, pow_expr), "==", 0.0))
+        return d
 
 
 def _rebuild_product(coeff: float, atoms: list[Expression]) -> Expression:
@@ -209,6 +267,77 @@ def _lift_expr(expr: Expression, model: Model, lifter: _Lifter) -> Expression:
     # Do not descend into FunctionCall args: lifting inside a transcendental
     # does not help the relaxation (the call is general_nl regardless) and must
     # not disturb composite/univariate handling of e.g. sqrt(x**2 + c).
+    return expr
+
+
+def _is_simple_power_base(expr: Expression, model: Model) -> bool:
+    """A power base the relaxation already handles directly: a variable leaf or
+    an integer power of one (the monomial path), so it must not be lifted."""
+    return _leaf_index_and_exp(expr, model) is not None
+
+
+def _lift_objective_atoms(expr: Expression, model: Model, lifter: "_Lifter") -> Expression:
+    """Decompose composite fractional-power and variable/variable-ratio atoms into
+    elementary auxiliary variables, so an objective the relaxation would otherwise
+    drop becomes linear in supported terms.
+
+    The relaxation can bound a fractional power of a *single variable*
+    (``fractional_power_var_map``) and a sign-definite ratio (via clearing), but
+    not a fractional power of a polynomial or a ratio whose value sits raw in the
+    objective (the objective linearizer rejects a non-constant division). So,
+    bottom-up:
+
+    * ``base ** p`` (non-integer *p*) -> a plain aux ``d == t ** p`` where ``t``
+      is *base* lifted to a variable. Exposes ``N / d`` instead of ``N / base**p``.
+    * ``N / D`` (non-constant *D*) -> a plain aux ``r == N / D`` (whose defining
+      equality is cleared to the bilinear ``r*D == N``).
+
+    Recursion composes these: ``(N / g**(1/3))**0.83`` (st_e35) becomes
+    ``g->t, t**(1/3)->d, N/d->r, r**0.83->s`` and ``N / g**(1/3)`` (ex1233) becomes
+    ``g->t, t**(1/3)->d, N/d->r``, leaving the objective linear in the aux.
+    Identity-preserving; leaves a node untouched when an operand has no finite
+    interval (e.g. an unbounded variable), so the rewrite is never unsound — at
+    worst the term stays dropped, exactly as before.
+    """
+    if isinstance(expr, BinaryOp):
+        if (
+            expr.op == "**"
+            and isinstance(expr.right, Constant)
+            and float(expr.right.value) != int(float(expr.right.value))
+        ):
+            p = float(expr.right.value)
+            base = _lift_objective_atoms(expr.left, model, lifter)
+            # The fractional power needs a single-variable argument ``t``.
+            t: Variable | IndexExpression | None
+            if isinstance(base, (Variable, IndexExpression)):
+                t = base
+            else:
+                t = lifter.expression(distribute_products(base))
+            if isinstance(t, Variable):
+                d = lifter.fractional_power(t, p)
+                if d is not None:
+                    return d
+            if base is not expr.left:
+                return BinaryOp("**", base, expr.right)
+            return expr
+        if expr.op == "/" and not isinstance(expr.right, Constant):
+            num = _lift_objective_atoms(expr.left, model, lifter)
+            den = _lift_objective_atoms(expr.right, model, lifter)
+            ratio = expr if (num is expr.left and den is expr.right) else BinaryOp("/", num, den)
+            r = lifter.expression(distribute_products(ratio))
+            if r is not None:
+                return r
+            return ratio
+        left = _lift_objective_atoms(expr.left, model, lifter)
+        right = _lift_objective_atoms(expr.right, model, lifter)
+        if left is expr.left and right is expr.right:
+            return expr
+        return BinaryOp(expr.op, left, right)
+    if isinstance(expr, UnaryOp):
+        operand = _lift_objective_atoms(expr.operand, model, lifter)
+        if operand is expr.operand:
+            return expr
+        return UnaryOp(expr.op, operand)
     return expr
 
 
@@ -436,16 +565,19 @@ def factorable_reformulate(model: Model, *, clear_only: bool = False) -> Model:
                     rebuilt.append(Constraint(distribute_products(body), sense, c.rhs, c.name))
                 continue
             body = distribute_products(body)
+            body = _lift_objective_atoms(body, new_model, lifter)
             body = _lift_expr(body, new_model, lifter)
             if body is c.body and sense == c.sense:
                 rebuilt.append(c)
             else:
                 rebuilt.append(Constraint(body, sense, c.rhs, c.name))
 
-        # Lift the objective too (it may contain a mixed product); division
-        # clearing is meaningless for an objective so only the lift applies.
+        # Lift the objective too (it may contain a mixed product or a fractional
+        # power of a polynomial base); division clearing is meaningless for an
+        # objective so only the lifts apply.
         if not clear_only and new_model._objective is not None:
             obj_expr = distribute_products(new_model._objective.expression)
+            obj_expr = _lift_objective_atoms(obj_expr, new_model, lifter)
             lifted_obj = _lift_expr(obj_expr, new_model, lifter)
             if lifted_obj is not new_model._objective.expression:
                 from discopt.modeling.core import Objective

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -129,6 +129,20 @@ _MAX_RELAXATION_PARTITION_INTERVALS = 128
 _MAX_OBJECTIVE_LIFT_POWER = 6
 _MAX_FINITE_DOMAIN_TRIG_TABLE_VALUES = 256
 
+# A relaxation row coefficient / RHS, or a variable bound, at or above this
+# magnitude is "numerically catastrophic": it comes from a McCormick/secant
+# envelope over a variable with an enormous (or effectively infinite) range, and
+# leaves the LP so ill-conditioned (dynamic range ~1e13+) that the backend
+# (HiGHS) returns kSolveError and *no* bound at all. The cap sits above any
+# legitimate modeling coefficient (big-M ~1e9, gear4's 1e6 linking term) and
+# below the 1e11..1e37 entries such envelopes produce, so well-scaled models are
+# never affected. Used only by ``sanitize_relaxation_for_conditioning``, which in
+# turn only feeds the last-resort root-relaxation fallback bound — never the main
+# solve — so dropping a borderline-large row can at most weaken that fallback,
+# never the primary result. The recovered bound is empirically stable for caps
+# from 1e11 down to 1e6 on the affected instances.
+_RELAX_NUMERIC_CAP = 1e10
+
 
 def _warn_once(msg: str, *args) -> None:
     formatted = msg % args if args else msg
@@ -230,6 +244,71 @@ class MilpRelaxationModel:
             bound = float(result.bound) + self._obj_offset
 
         return MilpRelaxationResult(status=status_str, objective=obj, bound=bound, x=result.x)
+
+
+def sanitize_relaxation_for_conditioning(
+    model: "MilpRelaxationModel",
+) -> "MilpRelaxationModel":
+    """Return a copy of *model* with numerically catastrophic content removed, so
+    the LP backend can produce a (sound, possibly weaker) bound instead of failing.
+
+    Two transforms, both of which only *relax* the feasible set — the LP optimum
+    therefore remains a valid lower bound for a minimization (weaker, never
+    higher than the true optimum):
+
+    1. Drop any constraint row whose coefficient or RHS is non-finite or has
+       magnitude >= ``_RELAX_NUMERIC_CAP``. Removing a constraint enlarges the
+       feasible set.
+    2. Clamp any variable bound of magnitude >= ``_RELAX_NUMERIC_CAP`` to +/-inf.
+       Widening a variable's box enlarges the feasible set. (A clamped objective
+       variable can make the LP unbounded -> bound becomes -inf/None, still sound.)
+
+    Both are no-ops on well-scaled models (no row or bound reaches the cap), so
+    this is safe to apply unconditionally before a fallback root-bound solve.
+    """
+    cap = _RELAX_NUMERIC_CAP
+
+    A = model._A_ub
+    b = model._b_ub
+    if A is not None and b is not None and A.shape[0] > 0:
+        A = A.tocsr()
+        b = np.asarray(b, dtype=np.float64)
+        row_of_nz = np.repeat(np.arange(A.shape[0]), np.diff(A.indptr))
+        bad_nz = ~np.isfinite(A.data) | (np.abs(A.data) >= cap)
+        keep = np.isfinite(b) & (np.abs(b) < cap)
+        if bad_nz.any():
+            keep[row_of_nz[bad_nz]] = False
+        if not keep.all():
+            logger.debug(
+                "relaxation conditioning: dropped %d catastrophic constraint row(s)",
+                int((~keep).sum()),
+            )
+            A = A[keep]
+            b = b[keep]
+        if A.shape[0] == 0:
+            A = None
+            b = None
+    else:
+        A = None
+        b = None
+
+    bounds = [
+        (
+            lo if abs(lo) < cap else (-np.inf if lo < 0 else np.inf),
+            hi if abs(hi) < cap else (np.inf if hi > 0 else -np.inf),
+        )
+        for (lo, hi) in model._bounds
+    ]
+
+    return MilpRelaxationModel(
+        c=model._c,
+        A_ub=A,
+        b_ub=b,
+        bounds=bounds,
+        obj_offset=model._obj_offset,
+        integrality=model._integrality,
+        objective_bound_valid=model._objective_bound_valid,
+    )
 
 
 @dataclass

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -271,7 +271,7 @@ def sanitize_relaxation_for_conditioning(
     A = model._A_ub
     b = model._b_ub
     if A is not None and b is not None and A.shape[0] > 0:
-        A = A.tocsr()
+        A = sp.csr_matrix(A)  # accepts dense or sparse; typed CSR for .data/.indptr
         b = np.asarray(b, dtype=np.float64)
         row_of_nz = np.repeat(np.arange(A.shape[0]), np.diff(A.indptr))
         bad_nz = ~np.isfinite(A.data) | (np.abs(A.data) >= cap)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1242,6 +1242,57 @@ def _classify_model_convexity(
         return False, False, None
 
 
+def _root_relaxation_lower_bound(
+    model: "Model",
+    root_lb: np.ndarray,
+    root_ub: np.ndarray,
+    time_limit: float,
+) -> Optional[float]:
+    """Solve the root MILP relaxation once and return its LP value as a rigorous
+    global lower bound, or ``None`` if unavailable.
+
+    The MILP relaxation built by ``build_milp_relaxation`` is a convex outer
+    approximation of *model* over the box ``[root_lb, root_ub]`` (the same one AMP
+    uses). When its objective is fully linearized (``objective_bound_valid``), the
+    relaxation LP's optimal value is a valid lower bound on the original objective
+    over that box — hence over the whole feasible set — for a *minimization*. This
+    mirrors the root-LP-bound seeding ``_solve_milp_bb`` already performs, but for
+    the spatial path, whose tree ``global_lower_bound`` can be tainted up to the
+    incumbent on a nonconvex model and is dropped on an uncertified exit.
+
+    Numerically catastrophic envelopes (e.g. cleared-division equalities over
+    wide-ranged defined variables) are sanitized away first so the backend can
+    return a bound instead of failing on the conditioning. Only ever called for a
+    MINIMIZE objective; defensively returns ``None`` on any failure so it can
+    never make a previously-bounded solve worse.
+    """
+    from discopt._jax.discretization import DiscretizationState
+    from discopt._jax.milp_relaxation import (
+        build_milp_relaxation,
+        sanitize_relaxation_for_conditioning,
+    )
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    try:
+        terms = classify_nonlinear_terms(model)
+        relax, _ = build_milp_relaxation(
+            model,
+            terms,
+            DiscretizationState(),
+            bound_override=(root_lb, root_ub),
+        )
+        if not relax._objective_bound_valid:
+            return None
+        relax = sanitize_relaxation_for_conditioning(relax)
+        budget = min(10.0, max(1.0, time_limit * 0.1))
+        result = relax.solve(time_limit=budget, gap_tolerance=1e-6)
+        if result.bound is not None and np.isfinite(result.bound):
+            return float(result.bound)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("root MILP-relaxation bound skipped: %s", exc)
+    return None
+
+
 def solve_model(
     model: Model,
     time_limit: float = 3600.0,
@@ -1660,6 +1711,37 @@ def solve_model(
     _origin_has_continuous_var = any(v.var_type == VarType.CONTINUOUS for v in model._variables)
 
     if has_factorable_work(model):
+        # Tighten variable bounds with FBBT *before* the reform so its interval
+        # checks see finite bounds. A fractional-power-of-product lift (issue
+        # #138) only fires when the lifted base has a finite interval; constraint
+        # propagation supplies that for models whose denominator variables are
+        # *declared* unbounded but are pinned finitely by other constraints (e.g.
+        # ex1233's geometric vars x12..x20, bounded by the assignment rows). Cheap
+        # and only run when the reform is about to fire; sound (FBBT only removes
+        # infeasible regions, so the tightened box still contains every feasible
+        # point). The later root presolve re-tightens, so this never loosens.
+        try:
+            from discopt.solvers._root_presolve import tighten_root_bounds_with_fbbt
+
+            _fr_off: list[int] = []
+            _fr_sz: list[int] = []
+            _fr_o = 0
+            for _v in model._variables:
+                if _v.var_type in (VarType.BINARY, VarType.INTEGER):
+                    _fr_off.append(_fr_o)
+                    _fr_sz.append(_v.size)
+                _fr_o += _v.size
+            _, _fr_lb, _fr_ub, _, _ = _extract_variable_info(model)
+            _fr_lb, _fr_ub, _fr_infeas, _fr_changed = tighten_root_bounds_with_fbbt(
+                model, _fr_lb, _fr_ub, _fr_off, _fr_sz
+            )
+            if not _fr_infeas and _fr_changed:
+                from discopt.solvers.amp import _apply_flat_bounds_to_model
+
+                _apply_flat_bounds_to_model(model, _fr_lb, _fr_ub)
+        except Exception as _fr_fbbt_exc:  # pragma: no cover - defensive
+            logger.debug("pre-reform FBBT skipped: %s", _fr_fbbt_exc)
+
         _fr_ok, _fr_convex, _ = _classify_model_convexity(model)
         if _fr_ok and not _fr_convex:
             model = factorable_reformulate(model)
@@ -2149,6 +2231,13 @@ def solve_model(
                 )
         except Exception as e:  # pragma: no cover - defensive
             logger.debug("Root OBBT failed: %s", e)
+
+    # Snapshot the root-global box (root FBBT + non-cutoff root OBBT only) so a
+    # rigorous root MILP-relaxation fallback bound can be computed at the end if
+    # the spatial tree yields nothing usable. Taken here, before the search
+    # loop's incumbent-cutoff OBBT, whose bounds are not valid for a global bound.
+    _root_lb_snapshot = np.asarray(lb, dtype=np.float64).copy()
+    _root_ub_snapshot = np.asarray(ub, dtype=np.float64).copy()
 
     # --- Create PyTreeManager (Rust) ---
     t_rust_start = time.perf_counter()
@@ -3551,6 +3640,22 @@ def solve_model(
     if not _gap_certified:
         bound_val = None
         gap_val = None
+
+    # When the tree produced no usable dual bound (uncertified exit, or a
+    # relaxation the LP backend could not solve), fall back to a rigorous global
+    # lower bound from the root MILP relaxation over the root box, so a
+    # minimization reports a finite sound bound instead of None (issue #138). The
+    # MILP path already seeds such a root bound; this brings the spatial path to
+    # parity. Surfaced lazily — only when the search yielded nothing — and never
+    # overrides an existing finite bound.
+    if (bound_val is None or not np.isfinite(bound_val)) and (
+        model._objective.sense == ObjectiveSense.MINIMIZE
+    ):
+        _rr = _root_relaxation_lower_bound(model, _root_lb_snapshot, _root_ub_snapshot, time_limit)
+        if _rr is not None and np.isfinite(_rr):
+            bound_val = _rr
+            if obj_val is not None and np.isfinite(obj_val):
+                gap_val = max(0.0, obj_val - bound_val) / max(1.0, abs(obj_val))
 
     return SolveResult(
         status=status,

--- a/python/tests/test_batch_sentinel_soundness.py
+++ b/python/tests/test_batch_sentinel_soundness.py
@@ -99,14 +99,19 @@ class TestBatchSentinelSoundness:
         )
         # The incumbent (warm start or better) survives as a feasible point...
         assert result.objective is not None
-        # ...but the gap must NOT be certified: every pruned node carried a
-        # failure sentinel, not an infeasibility proof or valid bound.
+        # ...but the gap must NOT be *certified* off failure sentinels: every
+        # pruned node carried a failure sentinel, not an infeasibility proof.
         assert result.status != "optimal", (
             f"Unsound certification: status={result.status!r} with "
             f"obj={result.objective} after pruning failed nodes"
         )
-        assert result.bound is None
-        assert result.gap is None
+        assert not result.gap_certified, "sentinel failures must not certify the gap"
+        # A dual bound MAY now be reported — not from the failed batch nodes, but
+        # from the independent root-relaxation fallback (issue #138); when present
+        # it must be sound (never above the true optimum), never a false bound.
+        assert result.bound is None or result.bound <= _OPT + 1e-6, (
+            f"unsound bound {result.bound} > optimum {_OPT}"
+        )
 
         monkeypatch.setattr(S, "_solve_batch_pounce", real_batch)
 

--- a/python/tests/test_fractional_power_product_envelope.py
+++ b/python/tests/test_fractional_power_product_envelope.py
@@ -1,0 +1,134 @@
+"""Soundness locks for the fractional-power-of-product objective lift (issue #138).
+
+A fractional power of a polynomial — ``N / g**(1/3)`` and ``(N / g**(1/3))**0.83``
+with ``g`` a product/polynomial — is what the relaxation could not linearize at
+all (``objective_bound_valid=False``), so such terms were dropped from the
+objective and no bound was produced. ``factorable_reform`` now decomposes the
+composite chain into elementary aux variables, each with a defining equality the
+relaxation can relax:
+
+* ``base ** p`` (fractional ``p``)  ->  aux ``d == t**p`` (``t`` = base lifted to a
+  variable), exposing a fractional power of a *single variable*;
+* ``N / D`` (non-constant ``D``)   ->  aux ``r`` whose defining equality is cleared
+  to the bilinear ``r*D == N``.
+
+Recursion composes these so the objective becomes linear in the aux. These tests
+pin the *envelope itself* on small, fully-bounded instances whose true optimum is
+known by hand, independent of the slow MINLPLib ``.nl`` solves and of the
+end-to-end bound-surfacing layer.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+
+
+def test_ex1233_shaped_ratio_certifies_sound():
+    """``300 x / g**(1/3)`` with bounded positive vars certifies its true optimum.
+
+    Optimum 60.0 by hand: minimise the numerator (x=1), maximise the denominator
+    (xa=xb=5 -> g = 0.5*(25*5 + 5*25) = 125, g**(1/3) = 5), so 300*1/5 = 60.
+    """
+    m = dm.Model("ex1233_ratio")
+    x = m.continuous("x", lb=1.0, ub=10.0)
+    xa = m.continuous("xa", lb=1.0, ub=5.0)
+    xb = m.continuous("xb", lb=1.0, ub=5.0)
+    m.minimize(300 * x / (0.5 * (xa**2 * xb + xa * xb**2)) ** 0.3333)
+
+    r = m.solve(time_limit=30, gap_tolerance=1e-4)
+
+    assert r.objective is not None and r.bound is not None
+    assert abs(r.objective - 60.00966) <= 1e-1, f"obj {r.objective} != 60.01"
+    # Soundness: the dual bound never exceeds the objective at the optimum.
+    assert r.bound <= r.objective + 1e-4, f"unsound bound {r.bound} > obj {r.objective}"
+    assert r.gap_certified, "small fully-bounded instance should certify"
+
+
+def test_st_e35_shaped_power_of_ratio_certifies_sound():
+    """``670 (x / g**(1/3))**0.83`` with bounded positive vars certifies soundly."""
+    m = dm.Model("st_e35_power")
+    x = m.continuous("x", lb=1.0, ub=10.0)
+    xa = m.continuous("xa", lb=1.0, ub=5.0)
+    xb = m.continuous("xb", lb=1.0, ub=5.0)
+    m.minimize(670 * (x / (0.5 * (xa**2 * xb + xb**2 * xa)) ** 0.333333) ** 0.83)
+
+    r = m.solve(time_limit=30, gap_tolerance=1e-4)
+
+    assert r.objective is not None and r.bound is not None
+    assert abs(r.objective - 176.16932) <= 1e-1, f"obj {r.objective} != 176.17"
+    assert r.bound <= r.objective + 1e-4, f"unsound bound {r.bound} > obj {r.objective}"
+    assert r.gap_certified, "small fully-bounded instance should certify"
+
+
+def test_lift_is_value_preserving():
+    """The reform must reproduce the original objective exactly (sound by being a
+    relaxation of an *equivalent* model). Checked numerically against the lifted
+    model's defining equalities at random feasible points."""
+    import numpy as np
+    from discopt._jax import factorable_reform as fr
+    from discopt.modeling.core import (
+        BinaryOp,
+        Constant,
+        IndexExpression,
+        UnaryOp,
+        Variable,
+    )
+
+    def ev(expr, env):
+        if isinstance(expr, Constant):
+            return float(np.asarray(expr.value).flatten()[0])
+        if isinstance(expr, Variable):
+            return env[expr.name]
+        if isinstance(expr, IndexExpression):
+            return env[expr.base.name]
+        if isinstance(expr, BinaryOp):
+            a, b = ev(expr.left, env), ev(expr.right, env)
+            if expr.op == "**":
+                return float(a) ** float(b)
+            return {"+": a + b, "-": a - b, "*": a * b, "/": a / b}[expr.op]
+        if isinstance(expr, UnaryOp):
+            a = ev(expr.operand, env)
+            return -a if expr.op == "neg" else abs(a)
+        raise ValueError(type(expr))
+
+    m0 = dm.Model("vp")
+    x = m0.continuous("x", lb=1.0, ub=4.0)
+    xa = m0.continuous("xa", lb=1.0, ub=4.0)
+    xb = m0.continuous("xb", lb=1.0, ub=4.0)
+    m0.minimize(670 * (x / (0.5 * (xa**2 * xb + xb**2 * xa)) ** 0.333333) ** 0.83)
+    m1 = fr.factorable_reformulate(m0)
+
+    rng = np.random.default_rng(0)
+    max_rel = 0.0
+    for _ in range(20):
+        env = {v.name: rng.uniform(1.0, 4.0) for v in m0._variables}
+        # Solve each aux from its (cleared, aux-linear) defining constraint.
+        for c in m1._constraints:
+            auxes = set()
+
+            def collect(e):
+                if isinstance(e, Variable) and e.name.startswith("_fr_aux") and e.name not in env:
+                    auxes.add(e.name)
+                if isinstance(e, BinaryOp):
+                    collect(e.left)
+                    collect(e.right)
+                if isinstance(e, UnaryOp):
+                    collect(e.operand)
+
+            collect(c.body)
+            if len(auxes) == 1:
+                an = auxes.pop()
+                env[an] = 0.0
+                b0 = ev(c.body, env)
+                env[an] = 1.0
+                b1 = ev(c.body, env)
+                env[an] = -b0 / (b1 - b0)
+        if any(v.name.startswith("_fr_aux") and v.name not in env for v in m1._variables):
+            continue
+        o0 = ev(m0._objective.expression, env)
+        o1 = ev(m1._objective.expression, env)
+        max_rel = max(max_rel, abs(o0 - o1) / max(1.0, abs(o0)))
+    assert max_rel <= 1e-9, f"reform not value-preserving: max rel diff {max_rel:.2e}"

--- a/python/tests/test_root_relaxation_surfacing.py
+++ b/python/tests/test_root_relaxation_surfacing.py
@@ -1,0 +1,52 @@
+"""End-to-end locks for root-relaxation bound surfacing on the #138 bucket.
+
+The spatial ``solve_model`` path previously dropped its tree bound on an
+uncertified exit and reported ``bound=None`` for the hard bucket-1 instances. It
+now falls back to a rigorous root MILP-relaxation bound over the root box (the
+MILP path already did this; this brings the spatial path to parity), combined
+with the fractional-power-of-product objective lift and a pre-reform FBBT pass.
+The result: the whole bucket reports a finite, *sound* dual bound.
+
+Soundness is the bar — a dual bound for a minimization must never exceed the true
+optimum. These pin both that the bound is now finite (no regression to ``None``)
+and that it stays sound.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+# MINLPLib optima (minlplib.solu): a valid dual lower bound can never exceed these.
+_BUCKET = {
+    "gear4": 1.64342847,  # trilinear ratio, integrality gap; floor 0 from x4,x5>=0
+    "nvs22": 6.0581153,  # var/var ratio
+    "st_e35": 64868.6,  # (x / g**(1/3))**0.83 fractional-power-of-product
+    "ex1233": 155010.6713,  # x / g**(1/3); geometric vars finitized by pre-reform FBBT
+}
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("instance, optimum", sorted(_BUCKET.items()))
+def test_bucket_returns_finite_sound_bound(instance, optimum):
+    """Each hard bucket-1 instance now reports a finite, sound dual bound."""
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    r = dm.from_nl(str(nl)).solve(time_limit=40, gap_tolerance=1e-4)
+
+    assert r.bound is not None, f"[{instance}] regressed to bound=None"
+    # Soundness: the dual bound never exceeds the known optimum.
+    assert r.bound <= optimum + max(1e-2, abs(optimum) * 1e-3), (
+        f"[{instance}] unsound dual bound {r.bound} > optimum {optimum}"
+    )
+    # And never certifies optimality without an incumbent.
+    assert not (r.gap_certified and r.objective is None), (
+        f"[{instance}] certified with no incumbent"
+    )


### PR DESCRIPTION
## Summary

This PR enables the solver to handle fractional powers of polynomial expressions in objectives by decomposing them into elementary auxiliary variables. Previously, such terms (e.g., `N / g**(1/3)` or `(N / g**(1/3))**0.83`) were dropped from the objective entirely, yielding no dual bound. Now they are systematically lifted into a chain of auxiliary variables that the relaxation can bound.

## Key Changes

### Objective Lifting (`factorable_reform.py`)

- **New `_Lifter` methods**:
  - `expression()`: Lifts a composite expression (e.g., a polynomial) to an auxiliary variable with a defining equality, enabling fractional powers of non-variable bases.
  - `fractional_power()`: Lifts a fractional power of a single variable (which the relaxation can already bound) to an auxiliary, exposing the power value itself to the objective linearizer.

- **New `_lift_objective_atoms()` function**: Recursively decomposes fractional-power and variable/variable-ratio atoms in objectives bottom-up:
  - `base ** p` (non-integer *p*) → aux `d == t**p` where `t` is *base* lifted to a variable
  - `N / D` (non-constant *D*) → aux `r` whose defining equality is cleared to the bilinear `r*D == N`
  
  Composition handles chains like `(N / g**(1/3))**0.83` → `g→t, t**(1/3)→d, N/d→r, r**0.83→s`.

- **Integration**: Applied to both constraints and objectives in `factorable_reformulate()` before the existing monomial lift.

### Bound Surfacing (`solver.py`)

- **Pre-reform FBBT**: Tightens variable bounds with constraint propagation before the factorable reform fires, ensuring lifted bases see finite intervals (critical for models where denominator variables are declared unbounded but pinned by constraints).

- **Root relaxation fallback** (`_root_relaxation_lower_bound()`): When the spatial B&B tree yields no usable dual bound (uncertified exit or LP failure), solves the root MILP relaxation over the root box as a rigorous fallback. Mirrors the MILP path's root-bound seeding, bringing the spatial path to parity.

- **Relaxation conditioning** (`sanitize_relaxation_for_conditioning()`): Removes numerically catastrophic rows/bounds (magnitude ≥ 1e10) from the relaxation before the fallback solve, allowing the LP backend to return a (sound, possibly weaker) bound instead of failing on ill-conditioning.

### Testing

- **`test_fractional_power_product_envelope.py`**: Pins soundness on small fully-bounded instances with known optima:
  - `ex1233`: `300 x / g**(1/3)` certifies optimum 60.01
  - `st_e35`: `670 (x / g**(1/3))**0.83` certifies optimum 176.17
  - Value-preservation check: lifted model reproduces original objective exactly at random feasible points

- **`test_root_relaxation_surfacing.py`**: End-to-end locks on hard MINLPLib instances (gear4, nvs22, st_e35, ex1233) ensuring finite, sound dual bounds are now reported.

- **`test_batch_sentinel_soundness.py`**: Updated to allow root-relaxation fallback bounds while still enforcing that failure sentinels do not certify optimality.

## Implementation Details

- **Identity-preserving**: Lifting is a no-op when an operand has no finite interval (e.g., unbounded variable), so the rewrite is never unsound — at worst the term stays dropped.
- **Deduplication**: Expression lifting uses `id(expr)` to cache by structural identity of the distributed node, avoiding redundant aux creation.
- **Soundness**: All transforms (FBBT, expression lifting, relaxation conditioning) only relax the feasible set, so LP optima remain valid lower bounds for minim

https://claude.ai/code/session_0193eTCHkaXstRE19gaN3QCF