### PR TITLE
perf(doe): reuse one compiled Jacobian across the design-refinement loop

### DIFF
--- a/python/discopt/doe/design.py
+++ b/python/discopt/doe/design.py
@@ -13,7 +13,12 @@ from typing import Callable, Sequence
 import numpy as np
 from scipy.optimize import minimize
 
-from discopt.doe.fim import FIMResult, compute_fim, compute_fim_batch
+from discopt.doe.fim import (
+    FIMResult,
+    _make_direct_fim_evaluator,
+    compute_fim,
+    compute_fim_batch,
+)
 from discopt.estimate import Experiment
 
 _SINGULAR_SENTINEL = 1e12
@@ -495,13 +500,26 @@ def _refine_single_design(
     bounds = [design_bounds[n] for n in design_names]
     x0 = np.array([seed_design[n] for n in design_names], dtype=float)
 
+    # The scipy refiner evaluates the FIM many times (each L-BFGS-B / SLSQP step
+    # plus its finite-difference gradient). For a pure explicit response model,
+    # build the model and JIT-compile the response Jacobian ONCE here and reuse
+    # it across every evaluation, instead of rebuilding + re-tracing per call
+    # inside compute_fim. Falls back to per-call compute_fim (which solves) for
+    # constrained / implicit-state models, where the evaluator is None.
+    evaluator = _make_direct_fim_evaluator(experiment, param_values, prior_fim=prior_fim)
+
+    def eval_fim(design: dict[str, float]) -> FIMResult:
+        if evaluator is not None:
+            return evaluator(design)
+        return compute_fim(experiment, param_values, design, prior_fim=prior_fim)
+
     def to_design(x: np.ndarray) -> dict[str, float]:
         return {n: float(v) for n, v in zip(design_names, x)}
 
     def objective(x: np.ndarray) -> float:
         design = to_design(x)
         try:
-            fim_result = compute_fim(experiment, param_values, design, prior_fim=prior_fim)
+            fim_result = eval_fim(design)
             crit = _evaluate_criterion(fim_result, criterion)
         except Exception:
             return _SINGULAR_SENTINEL
@@ -533,7 +551,7 @@ def _refine_single_design(
 
     design = to_design(np.asarray(res.x))
     try:
-        fim_result = compute_fim(experiment, param_values, design, prior_fim=prior_fim)
+        fim_result = eval_fim(design)
     except Exception:
         return None
     crit_val = _evaluate_criterion(fim_result, criterion)

--- a/python/discopt/doe/fim.py
+++ b/python/discopt/doe/fim.py
@@ -23,7 +23,7 @@ The FIM is used to:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 
@@ -381,6 +381,72 @@ def compute_fim_batch(
             )
         )
     return results
+
+
+def _make_direct_fim_evaluator(
+    experiment: Experiment,
+    param_values: dict[str, float],
+    *,
+    prior_fim: np.ndarray | None = None,
+) -> Callable[[dict[str, float] | None], FIMResult] | None:
+    """Return a reusable FIM evaluator that compiles the response Jacobian once.
+
+    For a *pure explicit response model* (see :func:`_design_source_map`) the
+    model is built and the response Jacobian JIT-compiled a *single* time; the
+    returned ``evaluator(design_values) -> FIMResult`` then reuses that compiled
+    Jacobian for every design point, assembling ``x*`` directly (no solve). This
+    is the single-point analogue of :func:`compute_fim_batch`, intended for the
+    adaptive scipy refinement loop in :mod:`discopt.doe.design`, where design
+    points are chosen one at a time and the same Jacobian is evaluated many
+    times.
+
+    Returns ``None`` when the model has constraints or implicit state (the
+    caller falls back to per-call :func:`compute_fim`, which solves). For every
+    design point the returned FIM is identical (to float tolerance) to calling
+    :func:`compute_fim` on that point — only the per-call model rebuild and JAX
+    re-trace are eliminated.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    from discopt._jax.differentiable import _compile_parametric_node
+
+    em = experiment.create_model(**param_values)
+    if _design_source_map(em) is None:
+        return None
+
+    response_fns = [_compile_parametric_node(em.responses[n], em.model) for n in em.response_names]
+    param_indices = _get_param_indices(em)
+    p_flat = _build_p_flat(em.model)
+
+    def response_vector(x_flat_arg):
+        return jnp.stack([fn(x_flat_arg, p_flat) for fn in response_fns])
+
+    # Compile the Jacobian once; the JIT cache keys on x*'s (fixed) shape, so
+    # every subsequent design point reuses the same compiled trace.
+    jac = jax.jit(jax.jacobian(response_vector))
+    sigma = np.array([em.measurement_error[name] for name in em.response_names])
+    Sigma_inv = np.diag(1.0 / sigma**2)
+    param_names = em.parameter_names
+    response_names = em.response_names
+
+    def evaluator(design_values: dict[str, float] | None) -> FIMResult:
+        x_flat = _assemble_x_flat_direct(em, param_values, design_values)
+        if x_flat is None:
+            # Per-point shape/missing-design mismatch: fall back to the solve.
+            return compute_fim(experiment, param_values, design_values, prior_fim=prior_fim)
+        J = np.asarray(jac(x_flat))[:, param_indices]
+        fim = J.T @ Sigma_inv @ J
+        if prior_fim is not None:
+            fim = fim + prior_fim
+        return FIMResult(
+            fim=np.asarray(fim),
+            jacobian=np.asarray(J),
+            parameter_names=param_names,
+            response_names=response_names,
+        )
+
+    return evaluator
 
 
 @dataclass

--- a/python/tests/test_fim.py
+++ b/python/tests/test_fim.py
@@ -419,3 +419,58 @@ class TestSolveFreeAndBatch:
         # And compute_fim still works through the solve fallback.
         result = compute_fim(exp, {"k": 1.0}, {"x": 2.0})
         assert result.fim.shape == (1, 1)
+
+    def test_evaluator_matches_compute_fim(self):
+        """The reusable refinement evaluator returns FIMs identical to compute_fim.
+
+        The evaluator hoists the model build + JAX Jacobian compile out of the
+        scipy refinement loop and reuses one compiled Jacobian across every
+        design point. It must be numerically indistinguishable from calling
+        compute_fim per point — only the per-call overhead is removed."""
+        from discopt.doe.fim import _make_direct_fim_evaluator
+
+        exp, pv = self._rsm_experiment()
+        evaluator = _make_direct_fim_evaluator(exp, pv)
+        assert evaluator is not None  # explicit response model -> fast path eligible
+
+        rng = np.random.default_rng(1)
+        for _ in range(8):
+            dp = {"x1": float(rng.uniform(0, 10)), "x2": float(rng.uniform(-5, 5))}
+            single = compute_fim(exp, pv, dp)
+            via_eval = evaluator(dp)
+            np.testing.assert_allclose(via_eval.fim, single.fim, rtol=1e-9, atol=1e-9)
+            np.testing.assert_allclose(via_eval.jacobian, single.jacobian, rtol=1e-9, atol=1e-9)
+
+    def test_evaluator_matches_compute_fim_with_prior(self):
+        """The evaluator folds prior_fim exactly like compute_fim."""
+        from discopt.doe.fim import _make_direct_fim_evaluator
+
+        exp, pv = self._rsm_experiment()
+        n_p = len(exp.create_model(**pv).parameter_names)
+        prior = 0.5 * np.eye(n_p)
+        evaluator = _make_direct_fim_evaluator(exp, pv, prior_fim=prior)
+        assert evaluator is not None
+
+        dp = {"x1": 6.0, "x2": -1.0}
+        single = compute_fim(exp, pv, dp, prior_fim=prior)
+        np.testing.assert_allclose(evaluator(dp).fim, single.fim, rtol=1e-9, atol=1e-9)
+
+    def test_evaluator_none_for_constrained_model(self):
+        """A model that needs a solve yields no fast evaluator (caller falls back)."""
+        from discopt.doe.fim import _make_direct_fim_evaluator
+
+        class ConstrainedExp(Experiment):
+            def create_model(self, **kwargs):
+                m = dm.Model("constrained")
+                k = m.continuous("k", lb=0.01, ub=20)
+                x = m.continuous("x", lb=0.1, ub=10)
+                m.subject_to(x <= 5.0)
+                return ExperimentModel(
+                    model=m,
+                    unknown_parameters={"k": k},
+                    design_inputs={"x": x},
+                    responses={"y": k * x},
+                    measurement_error={"y": 0.1},
+                )
+
+        assert _make_direct_fim_evaluator(ConstrainedExp(), {"k": 1.0}) is None


### PR DESCRIPTION
## Problem

Profiling the "Python fast" CI job (where the 7m50s wall-clock actually goes) surfaced `test_doe_cli.py::test_new_response_surface_2d` at **26.7s** — even after #169 made `compute_fim` solve-free.

Root cause: the DOE multistart refiner (`_refine_single_design`) runs scipy L-BFGS-B / SLSQP, whose objective calls the **single** `compute_fim` on every step and every finite-difference gradient probe. Each such call **rebuilds the experiment model from scratch and re-traces/compiles a fresh JAX Jacobian**. A single `do_new` for a response-surface design issues **~288 `compute_fim` calls** (48 per experiment × 6 experiments).

#169 batched only the candidate *scan* (the cheap 30-point part, 6 batched calls); the refinement loop — the dominant ~288 calls — was left rebuilding + recompiling per call.

## Fix

Hoist the model build + response-Jacobian JIT compile out of the scipy loop. `_make_direct_fim_evaluator` builds the model and `jax.jit(jax.jacobian(...))` **once** for a pure explicit response model, then reuses that compiled Jacobian for every design point (assembling `x*` directly, no solve). The refiner calls it through `eval_fim`, falling back to per-call `compute_fim` (which solves) for constrained / implicit-state models, where the evaluator is `None`.

## Soundness / correctness

This is pure overhead elimination — **no behavior change**:

- Per-design-point FIM is numerically identical to the `compute_fim` it replaces (same direct-assembled `x*`, proven `== solve` in #169; same Jacobian; same `JᵀΣ⁻¹J`).
- The designs produced by `do_new` are **bit-identical** before and after the patch (verified by a before/after run on `main` vs this branch) — the optimization trajectory is unchanged because scipy sees the same objective values.
- Constrained / implicit-state models are untouched: the evaluator is `None` and the refiner falls back to the solve path.

New tests lock evaluator ≡ `compute_fim` (FIM and Jacobian, with and without a prior) and the constrained-model `None` fallback.

## Measured

| | per-call FIM | `do_new` RSM-2d n=6 (local) |
|---|---|---|
| before | 26 ms | 3.3 s |
| after | 2 ms (**13×**) | 1.0 s (**3.3×**) |

Speeds up the user-facing `do_new` / `do_extend` for explicit response models, and drops the slow CI test without removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
