### PR TITLE
fix(gams): from_gams correctness on real GAMS files (1-D params + embedded objvar)

### DIFF
--- a/python/discopt/gams/data/manifest.json
+++ b/python/discopt/gams/data/manifest.json
@@ -64,8 +64,8 @@
       "objective_var": "z",
       "objective": 75.0,
       "tol": 1e-3,
-      "via_from_gams": false,
-      "notes": "Original 2x2 transport LP (sets/tables). GAMS-side only: discopt's from_gams() does not yet substitute indexed parameter data into objective coefficients."
+      "via_from_gams": true,
+      "notes": "Original 2x2 transport LP (sets/tables/1-D parameters). Regression lock for the indexed-parameter resolution bug: 1-D parameter data (cap(i), dem(j)) was stored under a bare element key but looked up as a 1-tuple, so every 1-D parameter silently resolved to 0 and the model solved to a false optimum of 0 instead of 75."
     }
   ]
 }

--- a/python/discopt/modeling/gams_parser.py
+++ b/python/discopt/modeling/gams_parser.py
@@ -1780,8 +1780,21 @@ class _ModelBuilder:
 
         # check params/tables
         if name in self.param_values:
-            key = tuple(str_indices) if len(str_indices) > 1 else (str_indices[0],)
-            val = self.param_values[name].get(key, 0.0)
+            pdata = self.param_values[name]
+            # 1-D parameter data is stored under the bare element key by
+            # ``_parse_param_data`` (e.g. ``"p1"``), while multi-dim data uses a
+            # tuple key. Earlier this looked up 1-D refs as a 1-tuple ``("p1",)``,
+            # which never matched the bare-string storage and silently fell back
+            # to the 0.0 default — quietly dropping every 1-D parameter value.
+            # Tolerate both key forms so the lookup matches regardless of how the
+            # entry was stored.
+            if len(str_indices) == 1:
+                key: object = str_indices[0]
+                if key not in pdata:
+                    key = (str_indices[0],)
+            else:
+                key = tuple(str_indices)
+            val = pdata.get(key, 0.0)
             return Constant(float(val))
         # check variables
         if name in self.dvar_map:

--- a/python/discopt/modeling/gams_parser.py
+++ b/python/discopt/modeling/gams_parser.py
@@ -1562,6 +1562,7 @@ class _ModelBuilder:
         """Build constraints and objective from equation definitions."""
         obj_var_name = solve.objective_var if solve else None
         obj_sense = solve.sense if solve else "minimizing"
+        obj_set = False
 
         for eqdef in self.p.equation_defs:
             # Build the constraint for each index combination
@@ -1614,8 +1615,26 @@ class _ModelBuilder:
                         m.minimize(obj_expr)
                     else:
                         m.maximize(obj_expr)
+                    obj_set = True
                 else:
                     self._add_constraint(m, lhs_expr, eqdef.sense, rhs_expr, eqdef.name)
+
+        # Fallback for the MINLPLib standard form: ``Solve m ... minimizing
+        # objvar`` where ``objvar`` is a free variable that does NOT appear as a
+        # bare ``objvar =e= expr`` definition but is instead embedded in a
+        # defining equation (e.g. ``defobj.. expr + objvar =E= 0``). No equation
+        # was recognized as the objective above, so minimize/maximize the
+        # objective variable directly and leave every equation (including the
+        # defining one, already added as a constraint) in place. This is the
+        # exact GAMS semantics — GAMS minimizes the scalar variable ``objvar``
+        # subject to all equations — so it is sound and value-preserving.
+        if obj_var_name and not obj_set:
+            obj_var = self.dvar_map.get(obj_var_name)
+            if obj_var is not None and getattr(obj_var, "shape", None) in ((), (1,)):
+                if obj_sense.startswith("min"):
+                    m.minimize(obj_var)
+                else:
+                    m.maximize(obj_var)
 
     def _is_obj_equation(self, eqdef, obj_var_name: str | None) -> bool:
         if obj_var_name is None:

--- a/python/tests/test_gams.py
+++ b/python/tests/test_gams.py
@@ -228,6 +228,53 @@ class TestGamsImportNLP:
         assert len(m._variables) == 3  # x1, x2, obj
 
 
+# MINLPLib standard form: a free ``objvar`` that is minimized but is *embedded*
+# in a defining equation (``defobj.. expr - objvar =E= 0``) rather than written
+# as a bare ``objvar =e= expr``. This is how every minlplib.org .gms file
+# encodes its objective, so from_gams must recognize it.
+MINLPLIB_OBJVAR_GMS = textwrap.dedent("""\
+    Variables  x1,x2,objvar;
+
+    Equations  e1,e2,defobj;
+
+    e1.. x1 + x2 =G= 4;
+    e2.. x1 - x2 =L= 1;
+    defobj.. sqr(x1) + sqr(x2) - objvar =E= 0;
+
+    x1.lo = 0; x2.lo = 0;
+
+    Model m / all /;
+    Solve m using NLP minimizing objvar;
+""")
+
+
+class TestGamsImportObjvarEmbedded:
+    def test_embedded_objvar_objective_is_set(self):
+        # Regression: the objective variable appears inside the defining
+        # equation rather than alone on one side, so _is_obj_equation does not
+        # match. from_gams must fall back to minimizing the objvar *variable*
+        # directly (exact GAMS semantics) instead of leaving the model with no
+        # objective at all.
+        m = parse_gams(MINLPLIB_OBJVAR_GMS)
+        assert m._objective is not None
+        assert m._objective.sense.value == "minimize"
+
+    def test_embedded_objvar_keeps_defining_equation_as_constraint(self):
+        # Minimizing the variable directly means every equation, including the
+        # objvar-defining one, stays a constraint (e1, e2, defobj = 3).
+        m = parse_gams(MINLPLIB_OBJVAR_GMS)
+        assert len(m._constraints) == 3
+
+    def test_embedded_objvar_solves_to_known_optimum(self):
+        # min x1^2 + x2^2 s.t. x1 + x2 >= 4, x1 - x2 <= 1, x>=0.
+        # x1 + x2 >= 4 binds; x1 - x2 <= 1 is slack, so the optimum is the
+        # symmetric point x1 = x2 = 2 -> objective 4 + 4 = 8.
+        m = parse_gams(MINLPLIB_OBJVAR_GMS)
+        res = m.solve(time_limit=30)
+        assert res.status in ("optimal", "feasible")
+        assert res.objective == pytest.approx(8.0, abs=1e-3)
+
+
 class TestGamsImportNonlinear:
     def test_exp_sqrt_sin_power(self):
         m = parse_gams(MINLP_NONLINEAR_GMS)

--- a/python/tests/test_gams.py
+++ b/python/tests/test_gams.py
@@ -168,6 +168,17 @@ class TestGamsImportTransport:
         assert m._objective is not None
         assert m._objective.sense.value == "minimize"
 
+    def test_one_dim_parameter_values_resolve(self):
+        # Regression: 1-D parameter data (a(i), b(j)) is stored under a bare
+        # element key, but _resolve_indexed once looked it up as a 1-tuple and
+        # silently fell back to 0.0 — so every supply/demand RHS became 0 and
+        # the model solved to a false optimum. Assert the declared values
+        # actually reach the constraint expressions.
+        m = parse_gams(TRANSPORT_GMS)
+        rendered = " ".join(str(c) for c in m._constraints)
+        for val in ("350", "600", "325", "300", "275"):
+            assert val in rendered, f"1-D parameter value {val} missing from constraints"
+
 
 class TestGamsImportKnapsack:
     def test_binary_variables(self):


### PR DESCRIPTION
## Two `from_gams()` soundness/correctness fixes for real GAMS files

Both bugs surfaced while standing up a GAMS-interface global-optimization
benchmark (discopt via `from_gams` vs BARON via the GAMS CLI). Each one made
`from_gams` silently wrong on a whole class of models.

### 1. 1-D parameter values silently dropped → **false certified optimum**

`from_gams()` resolved every **1-D parameter** reference to `0.0`. The classic
2×2 transport LP

```gams
Parameter a(i) / Seattle 350, San_Diego 600 / ;
supply(i).. sum(j, x(i,j)) =l= a(i) ;
```

parsed its supply/demand RHS as `0` instead of `350`/`600`/…, so the model
collapsed to `x = 0` and discopt reported **`obj = 0`, `gap_certified=True`** — a
provably-global *false* optimum (true `z = 75`). This is the worst soundness
failure class: a confidently-certified answer at the wrong point.

**Root cause:** `_parse_param_data` stores 1-D parameter data under the **bare
element key** (`"Seattle"`) while `_resolve_indexed` looked it up as a **1-tuple**
(`("Seattle",)`), so `dict.get(key, 0.0)` always fell through to the `0.0`
default. (The const-eval path already tried the bare key first, so only the
indexed-equation path was affected.)

**Fix:** `_resolve_indexed` tolerates both key forms for 1-D parameters (bare key
first, 1-tuple fallback). Multi-dim lookup unchanged.

### 2. Embedded-`objvar` objective not recognized → **no objective at all**

`from_gams()` only recognized an objective when the objective variable stood
alone on one side of its defining equation (`objvar =e= expr`). Every
minlplib.org `.gms` file instead embeds `objvar` inside the equation:

```gams
Solve m using MINLP minimizing objvar;
defobj.. expr - objvar =E= 0;
```

so `_is_obj_equation` never matched and the model was built with **no objective**
(`m._objective is None`) — making `from_gams` unusable on essentially every real
MINLPLib instance.

**Fix:** when the Solve statement names an objective variable but no equation is
its bare definition, minimize/maximize the `objvar` **variable** directly and
leave every equation (including the defining one) as a constraint. This is the
exact GAMS semantics (GAMS minimizes the scalar variable `objvar` subject to all
equations) — sound and value-preserving.

**Cross-checked against BARON** via the GAMS interface on 6 MINLPLib instances:

| instance | discopt obj | BARON obj (certified) | match |
|----------|------------:|----------------------:|:-----:|
| ex5_2_5  | −3500 | −3500 | ✅ |
| nvs07    | 4 | 4 | ✅ |
| nvs08    | 23.45 | 23.45 | ✅ |
| st_e27   | 2 | 2 | ✅ |
| st_test1 | 0 (certified) | 0 | ✅ |
| ex1263a  | no feasible pt in 30s | 19.6 | — |

discopt reaches BARON's optimum on every instance it finds a feasible point, and
reports them honestly as `feasible`/`optimal` (not falsely `gap_certified`).

### Regression locks

- `TestGamsImportTransport::test_one_dim_parameter_values_resolve` — declared 1-D
  values reach the parsed constraints.
- `manifest.json` → `lp_transport.gms` flipped to `via_from_gams: true`, so the
  end-to-end smoke test solves it and asserts the true optimum `z = 75`.
- `TestGamsImportObjvarEmbedded` — embedded-`objvar` objective is recognized, the
  defining equation stays a constraint, and the model solves to the known
  optimum.

Full `test_gams.py` (41 passed) and `test_gams_link.py` parser/link suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
