### PR TITLE
fix(simplex): equilibrate ill-scaled LPs so the LU stays well-conditioned (#170)

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -22,8 +22,8 @@ use crate::lp::cover::separate_cover;
 use crate::lp::crossover::LpView;
 use crate::lp::gomory::{separate_gomory, GomoryCut};
 use crate::lp::simplex::{
-    solve_lp, solve_lp_scaled, solve_lp_warm_scaled, tighten_bounds, LpStatus, Scaling,
-    SimplexOptions,
+    solve_lp, solve_lp_scaled, solve_lp_warm_scaled, tighten_bounds, LpStatus, PreparedDual,
+    Scaling, SimplexOptions,
 };
 
 const INF: f64 = 1e20;
@@ -717,12 +717,16 @@ fn strong_branch(
 
     const INFEAS_DELTA: f64 = 1e7; // a pruned child is a strong branching signal
     let eps = 1e-6;
-    // Probes share the batch's pre-scaled matrix (`ctx.sa`/`sc`/`sb`): only the
-    // one perturbed bound is rescaled per probe. Branching bounds (floor/ceil of
-    // the fractional value) are set in the original space, then scaled to match.
-    // The basis is scaling-invariant and the objective gap `obj − node_obj` is
-    // invariant, so the scores are identical to an unscaled probe — and a wrong
-    // score could only pick a worse branching variable, never an unsound bound.
+    // Every probe re-optimizes from the *same* node basis on the *same* matrix,
+    // differing only in one bound. Prepare (factorize + verify dual feasibility)
+    // that basis once on the batch's pre-scaled matrix (`ctx.sa`/`sc`/`sb`); each
+    // probe then clones the pristine factorization instead of refactorizing the
+    // identical basis ~2·max_cands times. Branching bounds (floor/ceil of the
+    // fractional value) are set in the original space, then scaled to match. The
+    // basis is scaling-invariant and the objective gap `obj − node_obj` is
+    // invariant, so scores match an unscaled probe — and a wrong score could only
+    // pick a worse branching variable, never an unsound bound. If the basis is not
+    // warm-startable, fall back to a per-probe scaled warm solve.
     let mut l = orig_l.to_vec();
     let mut u = orig_u.to_vec();
     let scale_bounds = |l: &[f64], u: &[f64]| -> (Vec<f64>, Vec<f64>) {
@@ -731,17 +735,33 @@ fn strong_branch(
             None => (l.to_vec(), u.to_vec()),
         }
     };
+    // Reference scaled bounds (the node's own) at which the basis is dual-feasible.
+    let (ref_l, ref_u) = scale_bounds(orig_l, orig_u);
+    let prep_view = LpView {
+        a: ctx.sa,
+        m: ctx.m_w,
+        n: ctx.n_w,
+        c: ctx.sc,
+        l: &ref_l,
+        u: &ref_u,
+    };
+    let prepared = PreparedDual::prepare(&prep_view, basis, simplex);
     let probe = |l: &[f64], u: &[f64]| -> crate::lp::simplex::LpSolve {
         let (sl, su) = scale_bounds(l, u);
-        let view = LpView {
-            a: ctx.sa,
-            m: ctx.m_w,
-            n: ctx.n_w,
-            c: ctx.sc,
-            l: &sl,
-            u: &su,
-        };
-        solve_lp_warm_scaled(&view, ctx.sb, basis, simplex)
+        match &prepared {
+            Some(p) => p.reoptimize(&sl, &su, ctx.sb, simplex),
+            None => {
+                let view = LpView {
+                    a: ctx.sa,
+                    m: ctx.m_w,
+                    n: ctx.n_w,
+                    c: ctx.sc,
+                    l: &sl,
+                    u: &su,
+                };
+                solve_lp_warm_scaled(&view, ctx.sb, basis, simplex)
+            }
+        }
     };
     let mut best: Option<usize> = None;
     let mut best_score = f64::NEG_INFINITY;

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -21,7 +21,10 @@ use crate::lp::basis::{Basis, BASIC};
 use crate::lp::cover::separate_cover;
 use crate::lp::crossover::LpView;
 use crate::lp::gomory::{separate_gomory, GomoryCut};
-use crate::lp::simplex::{solve_lp, solve_lp_warm, tighten_bounds, LpStatus, SimplexOptions};
+use crate::lp::simplex::{
+    solve_lp, solve_lp_scaled, solve_lp_warm_scaled, tighten_bounds, LpStatus, Scaling,
+    SimplexOptions,
+};
 
 const INF: f64 = 1e20;
 const INFEAS_SENTINEL: f64 = 1e30;
@@ -270,6 +273,25 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
         if batch.node_ids.is_empty() {
             break;
         }
+
+        // Equilibration scaling for the working matrix, computed once per batch
+        // and shared by every node solve below. The matrix is constant within a
+        // batch (cuts are folded in only between batches), so re-equilibrating it
+        // per node — as the auto-scaling entry points would — is pure waste. On an
+        // ill-scaled lifted LP this is the dominant per-node cost; sharing it lets
+        // the 64 nodes pay one equilibration. When the matrix is well-conditioned
+        // (`None`) the nodes solve the original LP unchanged.
+        let scaling = Scaling::from_matrix(&a_w, m_w, n_w);
+        let (a_s, c_s, b_s) = match &scaling {
+            Some(s) => (s.scale_matrix(&a_w), s.scale_c(&c_w), s.scale_b(&b_w)),
+            None => (Vec::new(), Vec::new(), Vec::new()),
+        };
+        // Solve-space matrix/objective/rhs: the scaled copies when scaling, else
+        // the originals (borrowed). Node bounds are scaled per node (cheap).
+        let (sa, sc, sb): (&[f64], &[f64], &[f64]) = match &scaling {
+            Some(_) => (&a_s, &c_s, &b_s),
+            None => (&a_w, &c_w, &b_w),
+        };
         let sb_active = opts.strong_branch && tm.stats().total_nodes < opts.sb_node_budget;
         let mut results = Vec::with_capacity(batch.node_ids.len());
         let mut pending_cuts: Vec<GomoryCut> = Vec::new();
@@ -292,6 +314,10 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
                 c_w: &c_w,
                 l_w: &l_w,
                 u_w: &u_w,
+                scaling: scaling.as_ref(),
+                sa,
+                sc,
+                sb,
                 slack_l: &slack_l,
                 slack_u: &slack_u,
                 is_int: &is_int,
@@ -441,6 +467,15 @@ struct NodeCtx<'a> {
     c_w: &'a [f64],
     l_w: &'a [f64],
     u_w: &'a [f64],
+    /// Equilibration for the working matrix (shared across the batch), or `None`
+    /// when it is well-conditioned. When `Some`, the node LP is solved on the
+    /// pre-scaled `sa`/`sc`/`sb` and the solution is unscaled before use.
+    scaling: Option<&'a Scaling>,
+    /// Solve-space matrix / objective / rhs: scaled copies when `scaling` is
+    /// `Some`, else the originals (`a_w`/`c_w`/`b_w`).
+    sa: &'a [f64],
+    sc: &'a [f64],
+    sb: &'a [f64],
     slack_l: &'a [f64],
     slack_u: &'a [f64],
     is_int: &'a [bool],
@@ -494,6 +529,8 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
     full_u[..ctx.ns].copy_from_slice(ub_k);
     full_l[ctx.ns..].copy_from_slice(ctx.slack_l);
     full_u[ctx.ns..].copy_from_slice(ctx.slack_u);
+    // Original-space LP, used by the cut separators, rounding, and strong
+    // branching (which all reason about the model's true coefficients/values).
     let node_lp = LpView {
         a: ctx.a_w,
         m: ctx.m_w,
@@ -503,15 +540,37 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
         u: &full_u,
     };
 
+    // Solve on the batch's shared (pre-scaled, when ill-conditioned) matrix. Only
+    // the per-node bounds are scaled here; the matrix/objective/rhs were scaled
+    // once for the whole batch. The basis is scaling-invariant, so a warm start
+    // and the returned basis transfer across the original/scaled spaces; the
+    // objective is invariant too. We unscale the primal `x` back to the original
+    // space so everything downstream (separation, rounding, branching) is unchanged.
     // Lazily extend a basis stored before later cuts grew the matrix: the
     // appended cut slacks become basic (a valid, dual-repairable starting basis).
-    let sol = match ctx.tm.node_basis(id) {
+    let (sl, su) = match ctx.scaling {
+        Some(s) => (s.scale_lower(&full_l), s.scale_upper(&full_u)),
+        None => (full_l.clone(), full_u.clone()),
+    };
+    let solve_lp_view = LpView {
+        a: ctx.sa,
+        m: ctx.m_w,
+        n: ctx.n_w,
+        c: ctx.sc,
+        l: &sl,
+        u: &su,
+    };
+    let mut sol = match ctx.tm.node_basis(id) {
         Some(basis) => {
             let basis = extend_basis(basis, ctx.n_w);
-            solve_lp_warm(&node_lp, ctx.b_w, &basis, &ctx.opts.simplex)
+            solve_lp_warm_scaled(&solve_lp_view, ctx.sb, &basis, &ctx.opts.simplex)
         }
-        None => solve_lp(&node_lp, ctx.b_w, &ctx.opts.simplex),
+        None => solve_lp_scaled(&solve_lp_view, ctx.sb, &ctx.opts.simplex),
     };
+    if let Some(s) = ctx.scaling {
+        s.unscale_x(&mut sol.x);
+    }
+    let sol = sol;
 
     let mut out = NodeOutput {
         result: NodeResult {
@@ -582,17 +641,8 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
                     .unwrap_or(false);
                 if !prunable {
                     let cands = ctx.tm.score_candidates(xs);
-                    let (best, piv) = strong_branch(
-                        &node_lp,
-                        ctx.b_w,
-                        &sol.basis,
-                        &sol.x,
-                        sol.obj,
-                        &cands,
-                        ctx.reliability,
-                        ctx.opts.sb_max_cands,
-                        &ctx.opts.simplex,
-                    );
+                    let (best, piv) =
+                        strong_branch(ctx, &full_l, &full_u, &sol.basis, &sol.x, sol.obj, &cands);
                     out.iters += piv;
                     out.branch_hint = best;
                 }
@@ -638,22 +688,20 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
 /// prunes immediately). Returns the chosen structural variable, if any, and the
 /// simplex pivots spent. Cheap because each probe is a few warm pivots, and it
 /// tapers automatically as pseudocosts mature past the reliability threshold.
-#[allow(clippy::too_many_arguments)]
 fn strong_branch(
-    lp: &LpView<'_>,
-    b: &[f64],
+    ctx: &NodeCtx<'_>,
+    orig_l: &[f64],
+    orig_u: &[f64],
     basis: &Basis,
     x: &[f64],
     node_obj: f64,
     cands: &[(usize, f64, u32, f64)],
-    reliability: u32,
-    max_cands: usize,
-    simplex: &SimplexOptions,
 ) -> (Option<usize>, usize) {
+    let simplex = &ctx.opts.simplex;
     // Unreliable candidates, most-fractional (nearest 0.5) first.
     let mut cand: Vec<(usize, f64)> = cands
         .iter()
-        .filter(|c| c.2 < reliability)
+        .filter(|c| c.2 < ctx.reliability)
         .map(|c| (c.0, c.1))
         .collect();
     if cand.is_empty() {
@@ -665,34 +713,46 @@ fn strong_branch(
             .partial_cmp(&(a.1 - 0.5).abs())
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    cand.truncate(max_cands.max(1));
+    cand.truncate(ctx.opts.sb_max_cands.max(1));
 
     const INFEAS_DELTA: f64 = 1e7; // a pruned child is a strong branching signal
     let eps = 1e-6;
-    let mut l = lp.l.to_vec();
-    let mut u = lp.u.to_vec();
+    // Probes share the batch's pre-scaled matrix (`ctx.sa`/`sc`/`sb`): only the
+    // one perturbed bound is rescaled per probe. Branching bounds (floor/ceil of
+    // the fractional value) are set in the original space, then scaled to match.
+    // The basis is scaling-invariant and the objective gap `obj − node_obj` is
+    // invariant, so the scores are identical to an unscaled probe — and a wrong
+    // score could only pick a worse branching variable, never an unsound bound.
+    let mut l = orig_l.to_vec();
+    let mut u = orig_u.to_vec();
+    let scale_bounds = |l: &[f64], u: &[f64]| -> (Vec<f64>, Vec<f64>) {
+        match ctx.scaling {
+            Some(s) => (s.scale_lower(l), s.scale_upper(u)),
+            None => (l.to_vec(), u.to_vec()),
+        }
+    };
+    let probe = |l: &[f64], u: &[f64]| -> crate::lp::simplex::LpSolve {
+        let (sl, su) = scale_bounds(l, u);
+        let view = LpView {
+            a: ctx.sa,
+            m: ctx.m_w,
+            n: ctx.n_w,
+            c: ctx.sc,
+            l: &sl,
+            u: &su,
+        };
+        solve_lp_warm_scaled(&view, ctx.sb, basis, simplex)
+    };
     let mut best: Option<usize> = None;
     let mut best_score = f64::NEG_INFINITY;
     let mut pivots = 0usize;
     for (idx, _f) in cand {
         let xi = x[idx];
-        let (lo0, hi0) = (lp.l[idx], lp.u[idx]);
+        let (lo0, hi0) = (orig_l[idx], orig_u[idx]);
 
         // Down branch: x_idx ≤ floor(x_idx).
         u[idx] = xi.floor();
-        let dn = solve_lp_warm(
-            &LpView {
-                a: lp.a,
-                m: lp.m,
-                n: lp.n,
-                c: lp.c,
-                l: &l,
-                u: &u,
-            },
-            b,
-            basis,
-            simplex,
-        );
+        let dn = probe(&l, &u);
         u[idx] = hi0;
         pivots += dn.iters;
         let d_dn = match dn.status {
@@ -703,19 +763,7 @@ fn strong_branch(
 
         // Up branch: x_idx ≥ ceil(x_idx).
         l[idx] = xi.ceil();
-        let up = solve_lp_warm(
-            &LpView {
-                a: lp.a,
-                m: lp.m,
-                n: lp.n,
-                c: lp.c,
-                l: &l,
-                u: &u,
-            },
-            b,
-            basis,
-            simplex,
-        );
+        let up = probe(&l, &u);
         l[idx] = lo0;
         pivots += up.iters;
         let d_up = match up.status {

--- a/crates/discopt-core/src/lp/simplex/batch.rs
+++ b/crates/discopt-core/src/lp/simplex/batch.rs
@@ -1,0 +1,245 @@
+//! Batched LP solving over a shared constraint matrix.
+//!
+//! A great deal of the simplex's per-solve cost is *setup* that depends only on
+//! the constraint matrix `A`, not on the rhs or bounds: equilibration scaling
+//! ([`Scaling`]) and the dense→scaled matrix copy. In the contexts that dominate
+//! the solver — a spatial/MILP B&B re-solving thousands of nodes that all share
+//! the same `A`, strong-branching probes, and parametric/scenario sweeps — that
+//! setup is otherwise redone on every solve even though it is identical.
+//!
+//! [`solve_lp_batch`] amortizes it: the scaling and the scaled matrix/objective
+//! are computed once, then each instance (its own rhs and bounds) is solved
+//! independently and, under the `parallel` feature, concurrently. Results are
+//! returned in input order, each already mapped back to the original (unscaled)
+//! space, so a batch solve is observationally identical to solving each LP on its
+//! own with [`solve_lp`](super::solve_lp) — only faster.
+//!
+//! [`solve_lp_multi_rhs`] is the common special case: one LP (`A`, `c`, bounds)
+//! solved for several right-hand sides.
+
+use super::primal::solve_lp_scaled;
+use super::scaling::Scaling;
+use super::{LpSolve, SimplexOptions};
+use crate::lp::crossover::LpView;
+
+/// One LP in a batch: the right-hand side and variable bounds. The constraint
+/// matrix `A` and objective `c` are shared by the whole batch (see
+/// [`solve_lp_batch`]).
+#[derive(Debug, Clone)]
+pub struct LpInstance {
+    /// Right-hand side `b`, length `m`.
+    pub b: Vec<f64>,
+    /// Lower bounds `l`, length `n`.
+    pub l: Vec<f64>,
+    /// Upper bounds `u`, length `n`.
+    pub u: Vec<f64>,
+}
+
+/// Solve a batch of LPs `min cᵀx s.t. A x = bₖ, lₖ ≤ x ≤ uₖ` that share the
+/// row-major `m × n` matrix `a` and objective `c`. The equilibration scaling and
+/// scaled matrix are computed once and reused for every instance; instances are
+/// solved independently (concurrently under the `parallel` feature) and returned
+/// in order, with each solution mapped back to the original space.
+pub fn solve_lp_batch(
+    a: &[f64],
+    m: usize,
+    n: usize,
+    c: &[f64],
+    instances: &[LpInstance],
+    opts: &SimplexOptions,
+) -> Vec<LpSolve> {
+    // Shared setup: scale once if the matrix warrants it, else solve raw.
+    match Scaling::from_matrix(a, m, n) {
+        Some(scaling) => {
+            let a_s = scaling.scale_matrix(a);
+            let c_s = scaling.scale_c(c);
+            let solve_one = |inst: &LpInstance| -> LpSolve {
+                let b_s = scaling.scale_b(&inst.b);
+                let l_s = scaling.scale_lower(&inst.l);
+                let u_s = scaling.scale_upper(&inst.u);
+                let view = LpView {
+                    a: &a_s,
+                    m,
+                    n,
+                    c: &c_s,
+                    l: &l_s,
+                    u: &u_s,
+                };
+                let mut sol = solve_lp_scaled(&view, &b_s, opts);
+                scaling.unscale_x(&mut sol.x);
+                sol
+            };
+            map_instances(instances, solve_one)
+        }
+        None => {
+            let solve_one = |inst: &LpInstance| -> LpSolve {
+                let view = LpView {
+                    a,
+                    m,
+                    n,
+                    c,
+                    l: &inst.l,
+                    u: &inst.u,
+                };
+                solve_lp_scaled(&view, &inst.b, opts)
+            };
+            map_instances(instances, solve_one)
+        }
+    }
+}
+
+/// Solve one LP `min cᵀx s.t. A x = bₖ, l ≤ x ≤ u` for several right-hand sides
+/// `b_list`, sharing the matrix, objective, and bounds across all of them.
+pub fn solve_lp_multi_rhs(
+    lp: &LpView<'_>,
+    b_list: &[Vec<f64>],
+    opts: &SimplexOptions,
+) -> Vec<LpSolve> {
+    let instances: Vec<LpInstance> = b_list
+        .iter()
+        .map(|b| LpInstance {
+            b: b.clone(),
+            l: lp.l.to_vec(),
+            u: lp.u.to_vec(),
+        })
+        .collect();
+    solve_lp_batch(lp.a, lp.m, lp.n, lp.c, &instances, opts)
+}
+
+/// Map `solve_one` over the instances, in parallel when the `parallel` feature is
+/// on and the batch is large enough to amortize task-spawn overhead. Each solve
+/// is independent (its own factorization) and reads only the shared, immutable
+/// scaled matrix, so the result order is deterministic regardless of scheduling.
+fn map_instances<F>(instances: &[LpInstance], solve_one: F) -> Vec<LpSolve>
+where
+    F: Fn(&LpInstance) -> LpSolve + Sync,
+{
+    #[cfg(feature = "parallel")]
+    {
+        use rayon::prelude::*;
+        const PAR_MIN_BATCH: usize = 4;
+        if instances.len() >= PAR_MIN_BATCH {
+            return instances.par_iter().map(&solve_one).collect();
+        }
+    }
+    instances.iter().map(&solve_one).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lp::simplex::{solve_lp, LpStatus};
+
+    const INF: f64 = 1e20;
+
+    fn opts() -> SimplexOptions {
+        SimplexOptions::default()
+    }
+
+    // A batched solve must return exactly what solving each LP on its own does.
+    #[test]
+    fn batch_matches_individual_solves() {
+        // min -x0 - 2 x1 s.t. x0+x1+s0=B0, x0+3x1+s1=B1, x∈[0,inf], s∈[0,inf].
+        let a = [1.0, 1.0, 1.0, 0.0, 1.0, 3.0, 0.0, 1.0];
+        let (m, n) = (2, 4);
+        let c = [-1.0, -2.0, 0.0, 0.0];
+        let l = vec![0.0; 4];
+        let u = vec![INF; 4];
+        let instances: Vec<LpInstance> = [(4.0, 6.0), (5.0, 6.0), (2.0, 9.0), (10.0, 1.0)]
+            .iter()
+            .map(|&(b0, b1)| LpInstance {
+                b: vec![b0, b1],
+                l: l.clone(),
+                u: u.clone(),
+            })
+            .collect();
+
+        let batched = solve_lp_batch(&a, m, n, &c, &instances, &opts());
+        assert_eq!(batched.len(), instances.len());
+        for (inst, got) in instances.iter().zip(&batched) {
+            let lp = LpView {
+                a: &a,
+                m,
+                n,
+                c: &c,
+                l: &inst.l,
+                u: &inst.u,
+            };
+            let single = solve_lp(&lp, &inst.b, &opts());
+            assert_eq!(got.status, single.status);
+            assert!(
+                (got.obj - single.obj).abs() < 1e-9,
+                "batch {} vs single {}",
+                got.obj,
+                single.obj
+            );
+        }
+    }
+
+    // The same, but on an ill-scaled matrix so the shared-scaling path is taken.
+    #[test]
+    fn batch_matches_individual_on_ill_scaled() {
+        // Wide-range coefficients trigger equilibration; the batch shares it.
+        let a = [1e8, 1.0, 1.0, 1e8, 1.0, 0.0, 0.0, 1.0];
+        let (m, n) = (2, 4);
+        let c = [1.0, 1.0, 0.0, 0.0];
+        let l = vec![0.0; 4];
+        let u = vec![1e6, 1e6, INF, INF];
+        let instances: Vec<LpInstance> = [(2e8, 1.0), (1e8, 2.0)]
+            .iter()
+            .map(|&(b0, b1)| LpInstance {
+                b: vec![b0, b1],
+                l: l.clone(),
+                u: u.clone(),
+            })
+            .collect();
+
+        let batched = solve_lp_batch(&a, m, n, &c, &instances, &opts());
+        for (inst, got) in instances.iter().zip(&batched) {
+            let lp = LpView {
+                a: &a,
+                m,
+                n,
+                c: &c,
+                l: &inst.l,
+                u: &inst.u,
+            };
+            let single = solve_lp(&lp, &inst.b, &opts());
+            assert_eq!(got.status, single.status);
+            if single.status == LpStatus::Optimal {
+                assert!((got.obj - single.obj).abs() < 1e-6);
+            }
+        }
+    }
+
+    #[test]
+    fn multi_rhs_matches_individual() {
+        let a = [1.0, 1.0, 1.0, 0.0, 1.0, 3.0, 0.0, 1.0];
+        let (m, n) = (2, 4);
+        let c = [-1.0, -2.0, 0.0, 0.0];
+        let l = vec![0.0; 4];
+        let u = vec![INF; 4];
+        let lp = LpView {
+            a: &a,
+            m,
+            n,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let b_list = vec![vec![4.0, 6.0], vec![3.0, 3.0], vec![8.0, 2.0]];
+        let got = solve_lp_multi_rhs(&lp, &b_list, &opts());
+        for (b, sol) in b_list.iter().zip(&got) {
+            let single = solve_lp(&lp, b, &opts());
+            assert_eq!(sol.status, single.status);
+            assert!((sol.obj - single.obj).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn empty_batch_is_empty() {
+        let a = [1.0, 1.0];
+        let got = solve_lp_batch(&a, 1, 2, &[1.0, 0.0], &[], &opts());
+        assert!(got.is_empty());
+    }
+}

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -16,7 +16,8 @@
 #![allow(clippy::needless_range_loop)]
 
 use super::linsolve::{FeralLU, LinearSolver};
-use super::primal::solve_lp;
+use super::primal::solve_lp_scaled;
+use super::scaling::ScaledLp;
 use super::sparse::SparseCols;
 use super::{LpSolve, LpStatus, SimplexOptions};
 use crate::lp::basis::{Basis, AT_LOWER, AT_UPPER, BASIC};
@@ -26,10 +27,35 @@ const INF: f64 = 1e20;
 
 /// Re-optimize `min cᵀx s.t. A x = b, l ≤ x ≤ u` from a warm `start` basis via
 /// the dual simplex, falling back to a cold solve on any difficulty.
+///
+/// Like [`solve_lp`](super::solve_lp), an ill-scaled matrix is equilibrated
+/// first so the basis factorization stays well-conditioned, and the scaled
+/// solution is mapped back. The warm-start basis is scaling-invariant (a column
+/// is basic or not regardless of its scale) and the factors come from `A` alone,
+/// so the basis a child inherits from its parent stays valid across the tree.
 pub fn solve_lp_warm(lp: &LpView<'_>, b: &[f64], start: &Basis, opts: &SimplexOptions) -> LpSolve {
+    match ScaledLp::maybe_new(lp, b) {
+        Some(scaled) => {
+            let view = scaled.view();
+            let mut sol = solve_warm_scaled(&view, scaled.b(), start, opts);
+            scaled.unscale_x(&mut sol.x);
+            sol
+        }
+        None => solve_warm_scaled(lp, b, start, opts),
+    }
+}
+
+/// Warm dual re-optimization on an already-equilibrated LP, with the cold
+/// primal fallback (also on the scaled matrix, so it is never scaled twice).
+fn solve_warm_scaled(
+    lp: &LpView<'_>,
+    b: &[f64],
+    start: &Basis,
+    opts: &SimplexOptions,
+) -> LpSolve {
     match try_dual(lp, b, start, opts) {
         Some(sol) => sol,
-        None => solve_lp(lp, b, opts), // safe fallback — always correct
+        None => solve_lp_scaled(lp, b, opts), // safe fallback — always correct
     }
 }
 
@@ -299,6 +325,7 @@ fn assemble(
 
 #[cfg(test)]
 mod tests {
+    use super::super::primal::solve_lp;
     use super::*;
 
     fn opts() -> SimplexOptions {

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -37,17 +37,20 @@ pub fn solve_lp_warm(lp: &LpView<'_>, b: &[f64], start: &Basis, opts: &SimplexOp
     match ScaledLp::maybe_new(lp, b) {
         Some(scaled) => {
             let view = scaled.view();
-            let mut sol = solve_warm_scaled(&view, scaled.b(), start, opts);
+            let mut sol = solve_lp_warm_scaled(&view, scaled.b(), start, opts);
             scaled.unscale_x(&mut sol.x);
             sol
         }
-        None => solve_warm_scaled(lp, b, start, opts),
+        None => solve_lp_warm_scaled(lp, b, start, opts),
     }
 }
 
-/// Warm dual re-optimization on an already-equilibrated LP, with the cold
-/// primal fallback (also on the scaled matrix, so it is never scaled twice).
-fn solve_warm_scaled(
+/// Warm dual re-optimization on an already-equilibrated (or known well-scaled)
+/// LP, with the cold primal fallback (also on the scaled matrix, so it is never
+/// scaled twice). Like [`solve_lp_scaled`], the B&B driver calls this directly
+/// when it has equilibrated the working matrix once and shares it across nodes;
+/// the caller owns the [`scaling::Scaling`] and unscales the returned `x`.
+pub fn solve_lp_warm_scaled(
     lp: &LpView<'_>,
     b: &[f64],
     start: &Basis,

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -56,8 +56,8 @@ pub fn solve_lp_warm_scaled(
     start: &Basis,
     opts: &SimplexOptions,
 ) -> LpSolve {
-    match try_dual(lp, b, start, opts) {
-        Some(sol) => sol,
+    match PreparedDual::prepare(lp, start, opts) {
+        Some(p) => p.reoptimize(lp.l, lp.u, b, opts),
         None => solve_lp_scaled(lp, b, opts), // safe fallback — always correct
     }
 }
@@ -66,223 +66,279 @@ fn col(a: &[f64], m: usize, n: usize, j: usize) -> Vec<f64> {
     (0..m).map(|i| a[i * n + j]).collect()
 }
 
-/// The dual-simplex attempt. Returns `None` to request the cold fallback.
-fn try_dual(lp: &LpView<'_>, b: &[f64], start: &Basis, opts: &SimplexOptions) -> Option<LpSolve> {
-    let (a, m, n, l, u, c) = (lp.a, lp.m, lp.n, lp.l, lp.u, lp.c);
-    if start.basic_vars.len() != m {
-        return None;
-    }
-    let tol = opts.tol;
-    let mut basis = start.basic_vars.clone();
-    let mut slot_of = vec![-1i64; n];
-    for (slot, &j) in basis.iter().enumerate() {
-        slot_of[j] = slot as i64;
-    }
-    let mut stat = start.col_status.clone();
-    if stat.len() != n {
-        return None;
-    }
+/// A basis factorization prepared once for repeated dual re-optimizations that
+/// differ only in their bounds and right-hand side.
+///
+/// `prepare` builds the sparse matrix, factorizes the start basis, and verifies
+/// dual feasibility (the precondition the dual simplex maintains but does not
+/// establish). Each [`reoptimize`](Self::reoptimize) then **clones** the pristine
+/// factorization and runs dual pivots from it, so the expensive factorize and the
+/// sparse-matrix build are paid once rather than per solve. This is what lets the
+/// B&B probe a node's many strong-branching children (one bound each) from the
+/// single node-optimal factorization instead of refactorizing it every probe.
+///
+/// The dual-feasibility check is bound-*value* independent (it depends on the
+/// objective, the basis, and which bound each nonbasic sits at), and the
+/// re-optimizations only perturb bounds of basic variables (a branch tightens the
+/// fractional, hence basic, variable), so the precondition verified at `prepare`
+/// holds for every `reoptimize` from the same basis.
+pub struct PreparedDual<'a> {
+    a: &'a [f64],
+    m: usize,
+    n: usize,
+    c: &'a [f64],
+    sp: SparseCols,
+    lu: FeralLU, // pristine factorization of `basis`
+    basis: Vec<usize>,
+    slot_of: Vec<i64>,
+    stat: Vec<i8>,
+}
 
-    let sp = SparseCols::from_dense(a, m, n);
-    let mut lu = FeralLU::new();
-    let cols: Vec<Vec<f64>> = basis.iter().map(|&j| col(a, m, n, j)).collect();
-    if lu.factorize(m, &cols).is_err() {
-        return None; // singular warm basis → fall back to cold
-    }
-
-    let nb_value = |stat: &[i8], j: usize| -> f64 {
-        if stat[j] == AT_UPPER {
-            u[j]
-        } else if l[j] <= -INF {
-            0.0
-        } else {
-            l[j]
-        }
-    };
-
-    // Verify the starting basis is actually dual-feasible — the precondition
-    // the dual simplex *maintains* but does not *establish*. With y = B⁻ᵀc_B the
-    // reduced cost is d_j = c_j − yᵀA_j; a nonbasic-at-lower needs d_j ≥ −tol, a
-    // nonbasic-at-upper needs d_j ≤ tol, and a nonbasic *free* variable (both
-    // bounds infinite) needs |d_j| ≤ tol. A dual-infeasible start would silently
-    // converge to a wrong Optimal/Infeasible, so request the cold fallback.
-    {
-        let mut y: Vec<f64> = basis.iter().map(|&j| c[j]).collect();
-        if lu.btran(&mut y).is_err() {
+impl<'a> PreparedDual<'a> {
+    /// Factorize `start` for the LP `lp` and verify dual feasibility, or `None`
+    /// if the basis is unusable (wrong size, singular, or dual-infeasible) and the
+    /// caller should cold-solve instead. `lp.l`/`lp.u` are the bounds at which the
+    /// basis is dual-feasible (the reference for the precondition check).
+    pub fn prepare(lp: &LpView<'a>, start: &Basis, opts: &SimplexOptions) -> Option<Self> {
+        let (a, m, n, l, u, c) = (lp.a, lp.m, lp.n, lp.l, lp.u, lp.c);
+        if start.basic_vars.len() != m {
             return None;
         }
-        for j in 0..n {
-            if stat[j] == BASIC || u[j] - l[j] <= tol {
-                continue; // basic or fixed: dual feasibility is unconstrained
+        let tol = opts.tol;
+        let basis = start.basic_vars.clone();
+        let mut slot_of = vec![-1i64; n];
+        for (slot, &j) in basis.iter().enumerate() {
+            slot_of[j] = slot as i64;
+        }
+        let stat = start.col_status.clone();
+        if stat.len() != n {
+            return None;
+        }
+
+        let sp = SparseCols::from_dense(a, m, n);
+        let mut lu = FeralLU::new();
+        let cols: Vec<Vec<f64>> = basis.iter().map(|&j| col(a, m, n, j)).collect();
+        if lu.factorize(m, &cols).is_err() {
+            return None; // singular warm basis → fall back to cold
+        }
+
+        // Verify the starting basis is actually dual-feasible — the precondition
+        // the dual simplex *maintains* but does not *establish*. With y = B⁻ᵀc_B
+        // the reduced cost is d_j = c_j − yᵀA_j; a nonbasic-at-lower needs
+        // d_j ≥ −tol, a nonbasic-at-upper needs d_j ≤ tol, and a nonbasic *free*
+        // variable (both bounds infinite) needs |d_j| ≤ tol. A dual-infeasible
+        // start would silently converge to a wrong Optimal/Infeasible.
+        {
+            let mut y: Vec<f64> = basis.iter().map(|&j| c[j]).collect();
+            if lu.btran(&mut y).is_err() {
+                return None;
             }
-            let dj = c[j] - sp.dot(j, &y);
-            let free = l[j] <= -INF && u[j] >= INF;
-            let ok = if free {
-                dj.abs() <= tol
-            } else if stat[j] == AT_UPPER {
-                dj <= tol
-            } else {
-                dj >= -tol
-            };
-            if !ok {
-                return None; // dual-infeasible warm start → cold fallback
+            for j in 0..n {
+                if stat[j] == BASIC || u[j] - l[j] <= tol {
+                    continue; // basic or fixed: dual feasibility is unconstrained
+                }
+                let dj = c[j] - sp.dot(j, &y);
+                let free = l[j] <= -INF && u[j] >= INF;
+                let ok = if free {
+                    dj.abs() <= tol
+                } else if stat[j] == AT_UPPER {
+                    dj <= tol
+                } else {
+                    dj >= -tol
+                };
+                if !ok {
+                    return None; // dual-infeasible warm start → cold fallback
+                }
+            }
+        }
+
+        Some(PreparedDual {
+            a,
+            m,
+            n,
+            c,
+            sp,
+            lu,
+            basis,
+            slot_of,
+            stat,
+        })
+    }
+
+    /// Dual re-optimization from the prepared basis for bounds `l`/`u` and rhs
+    /// `b`, returning a valid solution. On any numerical difficulty it cold-solves
+    /// the same LP, so the result is always correct.
+    pub fn reoptimize(&self, l: &[f64], u: &[f64], b: &[f64], opts: &SimplexOptions) -> LpSolve {
+        match self.run_dual(l, u, b, opts) {
+            Some(sol) => sol,
+            None => {
+                let lp = LpView {
+                    a: self.a,
+                    m: self.m,
+                    n: self.n,
+                    c: self.c,
+                    l,
+                    u,
+                };
+                solve_lp_scaled(&lp, b, opts)
             }
         }
     }
 
-    let mut updates = 0usize;
-    let mut pivots = 0usize;
-    for _iter in 0..opts.max_iter {
-        // Basic values x_B = B⁻¹(b − Σ_nonbasic A_j x_j).
-        let mut xb = b.to_vec();
-        for j in 0..n {
-            if stat[j] != BASIC {
-                let v = nb_value(&stat, j);
-                if v != 0.0 {
-                    let (rows, vals) = sp.col(j);
-                    for (k, &rr) in rows.iter().enumerate() {
-                        xb[rr] -= vals[k] * v;
+    /// The dual pivots, on a fresh clone of the prepared factorization/basis.
+    /// `None` requests the cold fallback (numerical breakdown or iteration cap).
+    fn run_dual(&self, l: &[f64], u: &[f64], b: &[f64], opts: &SimplexOptions) -> Option<LpSolve> {
+        let (a, m, n, c, sp) = (self.a, self.m, self.n, self.c, &self.sp);
+        let tol = opts.tol;
+        // Clone the pristine prepared state; the loop mutates these in place.
+        let mut lu = self.lu.clone();
+        let mut basis = self.basis.clone();
+        let mut slot_of = self.slot_of.clone();
+        let mut stat = self.stat.clone();
+
+        let nb_value = |stat: &[i8], j: usize| -> f64 {
+            if stat[j] == AT_UPPER {
+                u[j]
+            } else if l[j] <= -INF {
+                0.0
+            } else {
+                l[j]
+            }
+        };
+
+        let mut updates = 0usize;
+        let mut pivots = 0usize;
+        for _iter in 0..opts.max_iter {
+            // Basic values x_B = B⁻¹(b − Σ_nonbasic A_j x_j).
+            let mut xb = b.to_vec();
+            for j in 0..n {
+                if stat[j] != BASIC {
+                    let v = nb_value(&stat, j);
+                    if v != 0.0 {
+                        let (rows, vals) = sp.col(j);
+                        for (k, &rr) in rows.iter().enumerate() {
+                            xb[rr] -= vals[k] * v;
+                        }
                     }
                 }
             }
-        }
-        if lu.ftran(&mut xb).is_err() {
-            return None;
-        }
-
-        // Most primal-infeasible basic variable leaves.
-        let mut r = None;
-        let mut worst = tol;
-        let mut to_lower = true;
-        for i in 0..m {
-            let bi = basis[i];
-            if xb[i] < l[bi] - tol {
-                let viol = l[bi] - xb[i];
-                if viol > worst {
-                    worst = viol;
-                    r = Some(i);
-                    to_lower = true; // leaving var pinned at its lower bound
-                }
-            } else if xb[i] > u[bi] + tol {
-                let viol = xb[i] - u[bi];
-                if viol > worst {
-                    worst = viol;
-                    r = Some(i);
-                    to_lower = false;
-                }
-            }
-        }
-        let r = match r {
-            Some(r) => r,
-            None => {
-                // primal feasible + dual feasible (maintained) ⇒ optimal
-                return Some(assemble(
-                    n,
-                    m,
-                    &basis,
-                    &slot_of,
-                    &stat,
-                    &xb,
-                    c,
-                    l,
-                    u,
-                    LpStatus::Optimal,
-                    pivots,
-                ));
-            }
-        };
-
-        // Pivot row ρ = e_rᵀ B⁻¹ ; alpha_rj = ρ·A_j for nonbasic j.
-        let mut rho = vec![0.0; m];
-        rho[r] = 1.0;
-        if lu.btran(&mut rho).is_err() {
-            return None;
-        }
-
-        // Reduced costs d_j = c_j − yᵀA_j with y = B⁻ᵀ c_B.
-        let mut y: Vec<f64> = basis.iter().map(|&j| c[j]).collect();
-        if lu.btran(&mut y).is_err() {
-            return None;
-        }
-
-        // Dual ratio test. Leaving direction sets which sign of alpha_rj is
-        // eligible; pick the entering j minimizing |d_j / alpha_rj| while
-        // keeping dual feasibility.
-        let mut enter = None;
-        let mut best_ratio = f64::INFINITY;
-        for j in 0..n {
-            if stat[j] == BASIC {
-                continue;
-            }
-            if u[j] - l[j] <= tol {
-                continue; // fixed var can't enter
-            }
-            let arj = sp.dot(j, &rho);
-            // Eligibility: increasing leaving (to_lower) wants the basic var to
-            // rise; the entering var that preserves dual feasibility satisfies:
-            //  - at lower:  arj < 0  (to_lower) /  arj > 0  (to_upper)
-            //  - at upper:  arj > 0  (to_lower) /  arj < 0  (to_upper)
-            let eligible = if stat[j] == AT_LOWER {
-                if to_lower {
-                    arj < -tol
-                } else {
-                    arj > tol
-                }
-            } else if to_lower {
-                arj > tol
-            } else {
-                arj < -tol
-            };
-            if eligible {
-                let dj = c[j] - sp.dot(j, &y);
-                let ratio = (dj / arj).abs();
-                if ratio < best_ratio - tol {
-                    best_ratio = ratio;
-                    enter = Some(j);
-                }
-            }
-        }
-        let q = match enter {
-            Some(q) => q,
-            None => {
-                // No eligible entering column: the LP is primal-infeasible. But
-                // only trust this if the start basis was genuinely dual-feasible;
-                // otherwise fall back to cold to be safe.
-                return Some(assemble(
-                    n,
-                    m,
-                    &basis,
-                    &slot_of,
-                    &stat,
-                    &xb,
-                    c,
-                    l,
-                    u,
-                    LpStatus::Infeasible,
-                    pivots,
-                ));
-            }
-        };
-
-        // Pivot: q enters at slot r; leaving var pinned at the violated bound.
-        let leaving = basis[r];
-        stat[leaving] = if to_lower { AT_LOWER } else { AT_UPPER };
-        slot_of[leaving] = -1;
-        basis[r] = q;
-        slot_of[q] = r as i64;
-        stat[q] = BASIC;
-        pivots += 1;
-        let need_refac = lu.update(r, &col(a, m, n, q)).is_err();
-        updates += 1;
-        if need_refac || updates >= 48 {
-            let cols: Vec<Vec<f64>> = basis.iter().map(|&j| col(a, m, n, j)).collect();
-            if lu.factorize(m, &cols).is_err() {
+            if lu.ftran(&mut xb).is_err() {
                 return None;
             }
-            updates = 0;
+
+            // Most primal-infeasible basic variable leaves.
+            let mut r = None;
+            let mut worst = tol;
+            let mut to_lower = true;
+            for i in 0..m {
+                let bi = basis[i];
+                if xb[i] < l[bi] - tol {
+                    let viol = l[bi] - xb[i];
+                    if viol > worst {
+                        worst = viol;
+                        r = Some(i);
+                        to_lower = true; // leaving var pinned at its lower bound
+                    }
+                } else if xb[i] > u[bi] + tol {
+                    let viol = xb[i] - u[bi];
+                    if viol > worst {
+                        worst = viol;
+                        r = Some(i);
+                        to_lower = false;
+                    }
+                }
+            }
+            let r = match r {
+                Some(r) => r,
+                None => {
+                    // primal feasible + dual feasible (maintained) ⇒ optimal
+                    return Some(assemble(
+                        n, m, &basis, &slot_of, &stat, &xb, c, l, u, LpStatus::Optimal, pivots,
+                    ));
+                }
+            };
+
+            // Pivot row ρ = e_rᵀ B⁻¹ ; alpha_rj = ρ·A_j for nonbasic j.
+            let mut rho = vec![0.0; m];
+            rho[r] = 1.0;
+            if lu.btran(&mut rho).is_err() {
+                return None;
+            }
+
+            // Reduced costs d_j = c_j − yᵀA_j with y = B⁻ᵀ c_B.
+            let mut y: Vec<f64> = basis.iter().map(|&j| c[j]).collect();
+            if lu.btran(&mut y).is_err() {
+                return None;
+            }
+
+            // Dual ratio test. Leaving direction sets which sign of alpha_rj is
+            // eligible; pick the entering j minimizing |d_j / alpha_rj| while
+            // keeping dual feasibility.
+            let mut enter = None;
+            let mut best_ratio = f64::INFINITY;
+            for j in 0..n {
+                if stat[j] == BASIC {
+                    continue;
+                }
+                if u[j] - l[j] <= tol {
+                    continue; // fixed var can't enter
+                }
+                let arj = sp.dot(j, &rho);
+                // Eligibility: increasing leaving (to_lower) wants the basic var to
+                // rise; the entering var that preserves dual feasibility satisfies:
+                //  - at lower:  arj < 0  (to_lower) /  arj > 0  (to_upper)
+                //  - at upper:  arj > 0  (to_lower) /  arj < 0  (to_upper)
+                let eligible = if stat[j] == AT_LOWER {
+                    if to_lower {
+                        arj < -tol
+                    } else {
+                        arj > tol
+                    }
+                } else if to_lower {
+                    arj > tol
+                } else {
+                    arj < -tol
+                };
+                if eligible {
+                    let dj = c[j] - sp.dot(j, &y);
+                    let ratio = (dj / arj).abs();
+                    if ratio < best_ratio - tol {
+                        best_ratio = ratio;
+                        enter = Some(j);
+                    }
+                }
+            }
+            let q = match enter {
+                Some(q) => q,
+                None => {
+                    // No eligible entering column: the LP is primal-infeasible.
+                    // Trustworthy because the start basis was verified dual-feasible.
+                    return Some(assemble(
+                        n, m, &basis, &slot_of, &stat, &xb, c, l, u, LpStatus::Infeasible, pivots,
+                    ));
+                }
+            };
+
+            // Pivot: q enters at slot r; leaving var pinned at the violated bound.
+            let leaving = basis[r];
+            stat[leaving] = if to_lower { AT_LOWER } else { AT_UPPER };
+            slot_of[leaving] = -1;
+            basis[r] = q;
+            slot_of[q] = r as i64;
+            stat[q] = BASIC;
+            pivots += 1;
+            let need_refac = lu.update(r, &col(a, m, n, q)).is_err();
+            updates += 1;
+            if need_refac || updates >= 48 {
+                let cols: Vec<Vec<f64>> = basis.iter().map(|&j| col(a, m, n, j)).collect();
+                if lu.factorize(m, &cols).is_err() {
+                    return None;
+                }
+                updates = 0;
+            }
         }
+        None // iteration cap → cold fallback
     }
-    None // iteration cap → cold fallback
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/discopt-core/src/lp/simplex/linsolve.rs
+++ b/crates/discopt-core/src/lp/simplex/linsolve.rs
@@ -65,7 +65,12 @@ pub trait LinearSolver {
 }
 
 /// Production backend: feral's sparse unsymmetric LU.
-#[derive(Default)]
+///
+/// `Clone` duplicates the factorization itself (feral's `SparseLu` is `Clone`),
+/// so a prepared basis factorization can be cloned and re-optimized from several
+/// times — the dual warm-start reuses one factorization across a node's
+/// strong-branching probes instead of refactorizing the identical basis per probe.
+#[derive(Default, Clone)]
 pub struct FeralLU {
     lu: Option<SparseLu>,
 }

--- a/crates/discopt-core/src/lp/simplex/linsolve.rs
+++ b/crates/discopt-core/src/lp/simplex/linsolve.rs
@@ -39,6 +39,29 @@ pub trait LinearSolver {
     /// Replace the basic column in slot `leaving_slot` with `entering_col`
     /// (product-form update; the caller refactorizes when updates accumulate).
     fn update(&mut self, leaving_slot: usize, entering_col: &[f64]) -> Result<(), LinError>;
+
+    /// Solve `B X = RHS` for several right-hand sides at once, each `rhs[k]` an
+    /// `m`-vector solved in place. The point is to reuse the single existing
+    /// factorization across all `k` solves (sensitivity / strong-branching probes
+    /// / multi-rhs LPs) instead of refactorizing per system. The default loops
+    /// over [`ftran`](Self::ftran); a backend with a true matrix solve may
+    /// override. On the first failing column it stops and returns the error
+    /// (later columns are left untouched).
+    fn ftran_multi(&mut self, rhs: &mut [&mut [f64]]) -> Result<(), LinError> {
+        for col in rhs.iter_mut() {
+            self.ftran(col)?;
+        }
+        Ok(())
+    }
+
+    /// Solve `Bᵀ Y = RHS` for several right-hand sides at once (see
+    /// [`ftran_multi`](Self::ftran_multi)).
+    fn btran_multi(&mut self, rhs: &mut [&mut [f64]]) -> Result<(), LinError> {
+        for col in rhs.iter_mut() {
+            self.btran(col)?;
+        }
+        Ok(())
+    }
 }
 
 /// Production backend: feral's sparse unsymmetric LU.
@@ -223,5 +246,49 @@ mod tests {
             close(&bmatvec(&updated, &xf2), &rhs, 1e-9),
             "post-update B·x != rhs"
         );
+    }
+
+    #[test]
+    fn multi_rhs_matches_per_column_solves() {
+        // ftran_multi / btran_multi over one factorization must reproduce
+        // solving each right-hand side individually.
+        let cols = vec![
+            vec![2.0, 1.0, 0.0],
+            vec![1.0, 2.0, 1.0],
+            vec![0.0, 1.0, 2.0],
+        ];
+        let m = 3;
+        let mut fl = FeralLU::new();
+        fl.factorize(m, &cols).unwrap();
+
+        let rhs0 = [1.0, 2.0, 3.0];
+        let rhs1 = [3.0, 0.0, -1.0];
+
+        // Reference: individual ftran.
+        let (mut r0, mut r1) = (rhs0, rhs1);
+        fl.ftran(&mut r0).unwrap();
+        fl.ftran(&mut r1).unwrap();
+
+        // Batched ftran_multi.
+        let (mut b0, mut b1) = (rhs0, rhs1);
+        {
+            let mut batch: [&mut [f64]; 2] = [&mut b0, &mut b1];
+            fl.ftran_multi(&mut batch).unwrap();
+        }
+        assert!(close(&b0, &r0, 1e-12) && close(&b1, &r1, 1e-12));
+        // Each solved system genuinely satisfies B·x = rhs.
+        assert!(close(&bmatvec(&cols, &b0), &rhs0, 1e-9));
+        assert!(close(&bmatvec(&cols, &b1), &rhs1, 1e-9));
+
+        // btran_multi likewise matches individual btran.
+        let (mut y0, mut y1) = (rhs0, rhs1);
+        fl.btran(&mut y0).unwrap();
+        fl.btran(&mut y1).unwrap();
+        let (mut c0, mut c1) = (rhs0, rhs1);
+        {
+            let mut batch: [&mut [f64]; 2] = [&mut c0, &mut c1];
+            fl.btran_multi(&mut batch).unwrap();
+        }
+        assert!(close(&c0, &y0, 1e-12) && close(&c1, &y1, 1e-12));
     }
 }

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -25,7 +25,7 @@ pub mod scaling;
 pub mod sparse;
 
 pub use batch::{solve_lp_batch, solve_lp_multi_rhs, LpInstance};
-pub use dual::{solve_lp_warm, solve_lp_warm_scaled};
+pub use dual::{solve_lp_warm, solve_lp_warm_scaled, PreparedDual};
 pub use presolve::tighten_bounds;
 pub use primal::{solve_lp, solve_lp_scaled};
 pub use scaling::Scaling;

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -25,9 +25,10 @@ pub mod scaling;
 pub mod sparse;
 
 pub use batch::{solve_lp_batch, solve_lp_multi_rhs, LpInstance};
-pub use dual::solve_lp_warm;
+pub use dual::{solve_lp_warm, solve_lp_warm_scaled};
 pub use presolve::tighten_bounds;
-pub use primal::solve_lp;
+pub use primal::{solve_lp, solve_lp_scaled};
+pub use scaling::Scaling;
 
 use crate::lp::basis::Basis;
 

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -16,6 +16,7 @@
 //! a dense oracle [`linsolve::DenseLU`]. The primal/dual simplex drivers build
 //! on this in subsequent increments.
 
+pub mod batch;
 pub mod dual;
 pub mod linsolve;
 pub mod presolve;
@@ -23,6 +24,7 @@ pub mod primal;
 pub mod scaling;
 pub mod sparse;
 
+pub use batch::{solve_lp_batch, solve_lp_multi_rhs, LpInstance};
 pub use dual::solve_lp_warm;
 pub use presolve::tighten_bounds;
 pub use primal::solve_lp;

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -20,6 +20,7 @@ pub mod dual;
 pub mod linsolve;
 pub mod presolve;
 pub mod primal;
+pub mod scaling;
 pub mod sparse;
 
 pub use dual::solve_lp_warm;

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -16,6 +16,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use super::linsolve::{FeralLU, LinearSolver};
+use super::scaling::ScaledLp;
 use super::sparse::SparseCols;
 use super::{LpSolve, LpStatus, SimplexOptions};
 use crate::lp::basis::{Basis, AT_LOWER, AT_UPPER, BASIC};
@@ -24,7 +25,28 @@ use crate::lp::crossover::LpView;
 const INF: f64 = 1e20;
 
 /// Solve the LP `min cᵀx s.t. A x = b, l ≤ x ≤ u` by two-phase primal simplex.
+///
+/// Ill-scaled matrices (lifted McCormick LPs whose coefficients span many orders
+/// of magnitude) are equilibrated first ([`ScaledLp`]) so the basis
+/// factorization stays well-conditioned; the scaled solution is mapped back to
+/// the original space. Well-conditioned LPs are solved directly (no copy,
+/// bit-identical to the unscaled path).
 pub fn solve_lp(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpSolve {
+    match ScaledLp::maybe_new(lp, b) {
+        Some(scaled) => {
+            let view = scaled.view();
+            let mut sol = solve_lp_scaled(&view, scaled.b(), opts);
+            scaled.unscale_x(&mut sol.x);
+            sol
+        }
+        None => solve_lp_scaled(lp, b, opts),
+    }
+}
+
+/// Two-phase primal simplex on an already-equilibrated (or known well-scaled) LP.
+/// The warm dual path's cold fallback calls this directly so the matrix is not
+/// scaled twice.
+pub(super) fn solve_lp_scaled(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpSolve {
     Simplex::new(lp, b, opts).run()
 }
 
@@ -43,7 +65,14 @@ fn solution_within_tolerance(
 ) -> bool {
     const FEAS: f64 = 1e-6;
     for j in 0..n {
-        if x[j] < l[j] - FEAS || x[j] > u[j] + FEAS {
+        // Relative bound tolerance: a variable whose bound (and hence value) is
+        // large carries proportionally larger floating-point drift, so an
+        // absolute 1e-6 would spuriously reject a sound optimum on ill-scaled
+        // lifted LPs (variable magnitudes ~1e9). Scale the slack by the bound
+        // magnitude, mirroring the relative test already used on the row residual.
+        let lo_tol = FEAS * (1.0 + l[j].abs().min(INF));
+        let hi_tol = FEAS * (1.0 + u[j].abs().min(INF));
+        if x[j] < l[j] - lo_tol || x[j] > u[j] + hi_tol {
             return false;
         }
     }

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -44,9 +44,11 @@ pub fn solve_lp(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpSolve {
 }
 
 /// Two-phase primal simplex on an already-equilibrated (or known well-scaled) LP.
-/// The warm dual path's cold fallback calls this directly so the matrix is not
-/// scaled twice.
-pub(super) fn solve_lp_scaled(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpSolve {
+/// The warm dual path's cold fallback and the B&B driver (which equilibrates the
+/// working matrix once and shares it across all node solves) call this directly
+/// so the matrix is not scaled twice; the caller owns the [`scaling::Scaling`]
+/// and unscales the returned `x` itself.
+pub fn solve_lp_scaled(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpSolve {
     Simplex::new(lp, b, opts).run()
 }
 

--- a/crates/discopt-core/src/lp/simplex/scaling.rs
+++ b/crates/discopt-core/src/lp/simplex/scaling.rs
@@ -1,0 +1,278 @@
+//! Power-of-two geometric-mean equilibration scaling for the simplex.
+//!
+//! The revised simplex factorizes its basis with [`feral`]'s LU, which declares
+//! a basis singular when its pivots are tiny relative to the matrix entries. On
+//! lifted McCormick LPs whose coefficients span many orders of magnitude — FBBT
+//! pushes product-aux bounds to ~1e9, so the secant-envelope slopes do too — the
+//! *raw* constraint matrix is so ill-scaled that the LU breaks down after a few
+//! dozen pivots and the solve returns [`LpStatus::Numerical`](super::LpStatus).
+//! The LP is benign once rescaled (HiGHS solves the same system in ~0.01 s),
+//! and a `Numerical` relaxation bound is uncertified, so a MILP B&B that relies
+//! on it can never fathom and degenerates into full enumeration (issue #170).
+//!
+//! This module equilibrates the matrix so every nonzero is brought near
+//! magnitude 1 before the simplex ever factorizes it, matching what HiGHS does.
+//! Scaling replaces `A` with `R A C` (`R`, `C` positive diagonal), and `x` with
+//! `C x̂`, giving the equivalent LP
+//!
+//! ```text
+//!   min ĉᵀx̂  s.t.  (R A C) x̂ = R b,   C⁻¹l ≤ x̂ ≤ C⁻¹u,   ĉ = C c.
+//! ```
+//!
+//! The objective is invariant (`ĉᵀx̂ = cᵀx`) and the optimal basis is unchanged
+//! (scaling permutes nothing — a column is basic or not regardless of its
+//! scale), so a warm-start basis stays valid across the B&B tree as long as the
+//! factors come from `A` alone — they do; only bounds change between nodes.
+//!
+//! Factors are snapped to powers of two, so every scaled quantity is an exact
+//! float (only the exponent shifts) and unscaling `x_j = c_j x̂_j` is exact.
+//! Scaling is applied only when the matrix's dynamic range warrants it
+//! ([`SCALE_TRIGGER`]); a well-conditioned LP is left untouched and bit-identical
+//! to the unscaled solve, so existing behavior is preserved exactly.
+
+use crate::lp::crossover::LpView;
+
+const INF: f64 = 1e20;
+
+/// Equilibrate only when the matrix's dynamic range (largest over smallest
+/// nonzero magnitude) exceeds this. The fast simplex is reliable on raw matrices
+/// up to a range of ~1e7; triggering at 1e6 leaves a margin while keeping every
+/// well-conditioned LP an exact no-op.
+const SCALE_TRIGGER: f64 = 1e6;
+
+/// Alternating column/row sweeps. Power-of-two geometric-mean equilibration
+/// converges within a few passes; the loop also stops early once no factor
+/// changes (and guards against the occasional pow2 limit-cycle that never
+/// fully settles).
+const MAX_PASSES: usize = 4;
+
+/// Round `v > 0` to the nearest power of two (an exact float scale factor).
+#[inline]
+fn nearest_pow2(v: f64) -> f64 {
+    if !v.is_finite() || v <= 0.0 {
+        return 1.0;
+    }
+    2f64.powi(v.log2().round() as i32)
+}
+
+/// An owned, equilibrated copy of an [`LpView`] together with its RHS and the
+/// column factors needed to map a scaled solution back to the original space.
+pub struct ScaledLp {
+    a: Vec<f64>,
+    b: Vec<f64>,
+    c: Vec<f64>,
+    l: Vec<f64>,
+    u: Vec<f64>,
+    m: usize,
+    n: usize,
+    col: Vec<f64>, // column scale factors c_j (for unscaling x)
+}
+
+impl ScaledLp {
+    /// Equilibrate `lp` (with rhs `b`) if its dynamic range exceeds
+    /// [`SCALE_TRIGGER`]; otherwise return `None` so the caller solves the
+    /// original system unchanged (zero copy, bit-identical).
+    pub fn maybe_new(lp: &LpView<'_>, b: &[f64]) -> Option<ScaledLp> {
+        let (m, n) = (lp.m, lp.n);
+        // Dynamic range of the matrix nonzeros.
+        let (mut lo, mut hi) = (f64::INFINITY, 0.0f64);
+        for &v in lp.a.iter() {
+            let av = v.abs();
+            if av > 0.0 {
+                lo = lo.min(av);
+                hi = hi.max(av);
+            }
+        }
+        if hi == 0.0 || hi / lo <= SCALE_TRIGGER {
+            return None; // empty or well-conditioned: no scaling
+        }
+
+        let (row, col) = equilibrate(lp.a, m, n);
+        let mut a = vec![0.0; m * n];
+        for i in 0..m {
+            let ri = row[i];
+            for j in 0..n {
+                a[i * n + j] = ri * lp.a[i * n + j] * col[j];
+            }
+        }
+        let b = (0..m).map(|i| row[i] * b[i]).collect();
+        let c = (0..n).map(|j| col[j] * lp.c[j]).collect();
+        // Bounds: l̂ = l / c_j (c_j > 0, so order is preserved). Infinite bounds
+        // stay infinite so free / one-sided variables keep their character.
+        let l = (0..n)
+            .map(|j| if lp.l[j] <= -INF { lp.l[j] } else { lp.l[j] / col[j] })
+            .collect();
+        let u = (0..n)
+            .map(|j| if lp.u[j] >= INF { lp.u[j] } else { lp.u[j] / col[j] })
+            .collect();
+        Some(ScaledLp {
+            a,
+            b,
+            c,
+            l,
+            u,
+            m,
+            n,
+            col,
+        })
+    }
+
+    /// Borrow the scaled LP as an [`LpView`].
+    pub fn view(&self) -> LpView<'_> {
+        LpView {
+            a: &self.a,
+            m: self.m,
+            n: self.n,
+            c: &self.c,
+            l: &self.l,
+            u: &self.u,
+        }
+    }
+
+    /// The scaled right-hand side.
+    pub fn b(&self) -> &[f64] {
+        &self.b
+    }
+
+    /// Map a scaled primal point back to the original space in place: the first
+    /// `n` entries are scaled `x_j ← c_j x̂_j` (exact — `c_j` is a power of two).
+    /// Any trailing entries are left untouched.
+    pub fn unscale_x(&self, x: &mut [f64]) {
+        for (j, c) in self.col.iter().enumerate() {
+            if j >= x.len() {
+                break;
+            }
+            x[j] *= *c;
+        }
+    }
+}
+
+/// Geometric-mean equilibration of the dense row-major `m × n` matrix `a`:
+/// alternating sweeps set each column/row factor to `1/sqrt(min·max)` of the
+/// current scaled magnitudes in that line, snapped to a power of two. Returns
+/// `(row, col)` factor vectors.
+fn equilibrate(a: &[f64], m: usize, n: usize) -> (Vec<f64>, Vec<f64>) {
+    let mut row = vec![1.0f64; m];
+    let mut col = vec![1.0f64; n];
+    for _ in 0..MAX_PASSES {
+        let mut changed = false;
+        // Column sweep.
+        for j in 0..n {
+            let (mut lo, mut hi) = (f64::INFINITY, 0.0f64);
+            for i in 0..m {
+                let v = (row[i] * a[i * n + j] * col[j]).abs();
+                if v > 0.0 {
+                    lo = lo.min(v);
+                    hi = hi.max(v);
+                }
+            }
+            if hi > 0.0 {
+                let f = nearest_pow2(1.0 / (lo * hi).sqrt());
+                if f != 1.0 {
+                    col[j] *= f;
+                    changed = true;
+                }
+            }
+        }
+        // Row sweep.
+        for i in 0..m {
+            let (mut lo, mut hi) = (f64::INFINITY, 0.0f64);
+            let base = i * n;
+            for j in 0..n {
+                let v = (row[i] * a[base + j] * col[j]).abs();
+                if v > 0.0 {
+                    lo = lo.min(v);
+                    hi = hi.max(v);
+                }
+            }
+            if hi > 0.0 {
+                let f = nearest_pow2(1.0 / (lo * hi).sqrt());
+                if f != 1.0 {
+                    row[i] *= f;
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    (row, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pow2_rounding() {
+        assert_eq!(nearest_pow2(1.0), 1.0);
+        assert_eq!(nearest_pow2(3.0), 4.0); // log2(3)=1.58 → 2^2
+        assert_eq!(nearest_pow2(1.4), 1.0); // log2(1.4)=0.49 → 2^0
+        assert_eq!(nearest_pow2(0.2), 0.25); // log2(0.2)=-2.32 → 2^-2
+        assert_eq!(nearest_pow2(0.0), 1.0);
+        assert_eq!(nearest_pow2(f64::INFINITY), 1.0);
+    }
+
+    #[test]
+    fn well_conditioned_is_no_op() {
+        // Entries in [1,5]: dynamic range 5 ≪ trigger → no scaling.
+        let a = [5.0, 5.0, 5.0, 5.0, 1.0];
+        let lp = LpView {
+            a: &a,
+            m: 1,
+            n: 5,
+            c: &[0.0; 5],
+            l: &[0.0; 5],
+            u: &[1.0; 5],
+        };
+        assert!(ScaledLp::maybe_new(&lp, &[9.0]).is_none());
+    }
+
+    #[test]
+    fn wide_range_triggers_and_equilibrates() {
+        // One huge and one tiny coefficient: range 1e9 ≫ trigger → scaled, and
+        // the equilibrated matrix has its nonzero magnitudes brought together.
+        let a = [1e9, 1.0, 1.0, 1e-3];
+        let lp = LpView {
+            a: &a,
+            m: 2,
+            n: 2,
+            c: &[1.0, 1.0],
+            l: &[0.0, 0.0],
+            u: &[1e12, 1e12],
+        };
+        let scaled = ScaledLp::maybe_new(&lp, &[1.0, 1.0]).expect("should scale");
+        let sv = scaled.view();
+        let (mut lo, mut hi) = (f64::INFINITY, 0.0f64);
+        for &v in sv.a.iter() {
+            let av = v.abs();
+            if av > 0.0 {
+                lo = lo.min(av);
+                hi = hi.max(av);
+            }
+        }
+        // Raw range was 1e9/1e-3 = 1e12; equilibration must shrink it sharply.
+        assert!(hi / lo < 1e4, "post-scale range {} too wide", hi / lo);
+    }
+
+    #[test]
+    fn unscale_recovers_original_scale() {
+        let a = [1e9, 0.0, 0.0, 1.0];
+        let lp = LpView {
+            a: &a,
+            m: 2,
+            n: 2,
+            c: &[1.0, 1.0],
+            l: &[0.0, 0.0],
+            u: &[1e12, 1e12],
+        };
+        let scaled = ScaledLp::maybe_new(&lp, &[1.0, 1.0]).expect("should scale");
+        // x̂ in scaled space maps back by the (power-of-two) column factors.
+        let mut x = vec![2.0, 3.0];
+        let xhat = x.clone();
+        scaled.unscale_x(&mut x);
+        assert_eq!(x[0], xhat[0] * scaled.col[0]);
+        assert_eq!(x[1], xhat[1] * scaled.col[1]);
+    }
+}

--- a/crates/discopt-core/src/lp/simplex/scaling.rs
+++ b/crates/discopt-core/src/lp/simplex/scaling.rs
@@ -29,6 +29,10 @@
 //! Scaling is applied only when the matrix's dynamic range warrants it
 //! ([`SCALE_TRIGGER`]); a well-conditioned LP is left untouched and bit-identical
 //! to the unscaled solve, so existing behavior is preserved exactly.
+//
+// The equilibration sweeps index the row-major matrix and the row/col factor
+// vectors by the same index, so range loops read clearer than zipping slices.
+#![allow(clippy::needless_range_loop)]
 
 use crate::lp::crossover::LpView;
 

--- a/crates/discopt-core/src/lp/simplex/scaling.rs
+++ b/crates/discopt-core/src/lp/simplex/scaling.rs
@@ -55,28 +55,25 @@ fn nearest_pow2(v: f64) -> f64 {
     2f64.powi(v.log2().round() as i32)
 }
 
-/// An owned, equilibrated copy of an [`LpView`] together with its RHS and the
-/// column factors needed to map a scaled solution back to the original space.
-pub struct ScaledLp {
-    a: Vec<f64>,
-    b: Vec<f64>,
-    c: Vec<f64>,
-    l: Vec<f64>,
-    u: Vec<f64>,
+/// Diagonal row/column equilibration factors for a fixed constraint matrix `A`,
+/// derived from `A` alone. Because the factors depend only on the matrix — not on
+/// the rhs or bounds — one `Scaling` can be reused to scale a whole family of LPs
+/// that share `A` (the B&B tree, a multi-rhs or batched solve): compute it once,
+/// then apply the cheap per-vector transforms below.
+pub struct Scaling {
+    row: Vec<f64>, // r_i, length m
+    col: Vec<f64>, // c_j, length n  (also the x unscale factors)
     m: usize,
     n: usize,
-    col: Vec<f64>, // column scale factors c_j (for unscaling x)
 }
 
-impl ScaledLp {
-    /// Equilibrate `lp` (with rhs `b`) if its dynamic range exceeds
-    /// [`SCALE_TRIGGER`]; otherwise return `None` so the caller solves the
-    /// original system unchanged (zero copy, bit-identical).
-    pub fn maybe_new(lp: &LpView<'_>, b: &[f64]) -> Option<ScaledLp> {
-        let (m, n) = (lp.m, lp.n);
-        // Dynamic range of the matrix nonzeros.
+impl Scaling {
+    /// Equilibration factors for the dense row-major `m × n` matrix `a`, or
+    /// `None` when its dynamic range is below [`SCALE_TRIGGER`] (well-conditioned
+    /// — the caller should solve unscaled, which is then bit-identical to before).
+    pub fn from_matrix(a: &[f64], m: usize, n: usize) -> Option<Scaling> {
         let (mut lo, mut hi) = (f64::INFINITY, 0.0f64);
-        for &v in lp.a.iter() {
+        for &v in a.iter() {
             let av = v.abs();
             if av > 0.0 {
                 lo = lo.min(av);
@@ -84,54 +81,47 @@ impl ScaledLp {
             }
         }
         if hi == 0.0 || hi / lo <= SCALE_TRIGGER {
-            return None; // empty or well-conditioned: no scaling
+            return None;
         }
+        let (row, col) = equilibrate(a, m, n);
+        Some(Scaling { row, col, m, n })
+    }
 
-        let (row, col) = equilibrate(lp.a, m, n);
-        let mut a = vec![0.0; m * n];
+    /// Scaled matrix `Â = R A C` (owned, row-major `m × n`).
+    pub fn scale_matrix(&self, a: &[f64]) -> Vec<f64> {
+        let (m, n) = (self.m, self.n);
+        let mut out = vec![0.0; m * n];
         for i in 0..m {
-            let ri = row[i];
+            let ri = self.row[i];
             for j in 0..n {
-                a[i * n + j] = ri * lp.a[i * n + j] * col[j];
+                out[i * n + j] = ri * a[i * n + j] * self.col[j];
             }
         }
-        let b = (0..m).map(|i| row[i] * b[i]).collect();
-        let c = (0..n).map(|j| col[j] * lp.c[j]).collect();
-        // Bounds: l̂ = l / c_j (c_j > 0, so order is preserved). Infinite bounds
-        // stay infinite so free / one-sided variables keep their character.
-        let l = (0..n)
-            .map(|j| if lp.l[j] <= -INF { lp.l[j] } else { lp.l[j] / col[j] })
-            .collect();
-        let u = (0..n)
-            .map(|j| if lp.u[j] >= INF { lp.u[j] } else { lp.u[j] / col[j] })
-            .collect();
-        Some(ScaledLp {
-            a,
-            b,
-            c,
-            l,
-            u,
-            m,
-            n,
-            col,
-        })
+        out
     }
 
-    /// Borrow the scaled LP as an [`LpView`].
-    pub fn view(&self) -> LpView<'_> {
-        LpView {
-            a: &self.a,
-            m: self.m,
-            n: self.n,
-            c: &self.c,
-            l: &self.l,
-            u: &self.u,
-        }
+    /// Scaled objective `ĉ = C c` (objective value is then invariant: `ĉᵀx̂ = cᵀx`).
+    pub fn scale_c(&self, c: &[f64]) -> Vec<f64> {
+        (0..self.n).map(|j| self.col[j] * c[j]).collect()
     }
 
-    /// The scaled right-hand side.
-    pub fn b(&self) -> &[f64] {
-        &self.b
+    /// Scaled rhs `b̂ = R b`.
+    pub fn scale_b(&self, b: &[f64]) -> Vec<f64> {
+        (0..self.m).map(|i| self.row[i] * b[i]).collect()
+    }
+
+    /// Scaled lower bounds `l̂ = C⁻¹ l` (infinite bounds preserved).
+    pub fn scale_lower(&self, l: &[f64]) -> Vec<f64> {
+        (0..self.n)
+            .map(|j| if l[j] <= -INF { l[j] } else { l[j] / self.col[j] })
+            .collect()
+    }
+
+    /// Scaled upper bounds `û = C⁻¹ u` (infinite bounds preserved).
+    pub fn scale_upper(&self, u: &[f64]) -> Vec<f64> {
+        (0..self.n)
+            .map(|j| if u[j] >= INF { u[j] } else { u[j] / self.col[j] })
+            .collect()
     }
 
     /// Map a scaled primal point back to the original space in place: the first
@@ -144,6 +134,56 @@ impl ScaledLp {
             }
             x[j] *= *c;
         }
+    }
+}
+
+/// An owned, equilibrated copy of an [`LpView`] together with its RHS, for a
+/// single solve. Thin convenience wrapper over [`Scaling`].
+pub struct ScaledLp {
+    scaling: Scaling,
+    a: Vec<f64>,
+    b: Vec<f64>,
+    c: Vec<f64>,
+    l: Vec<f64>,
+    u: Vec<f64>,
+}
+
+impl ScaledLp {
+    /// Equilibrate `lp` (with rhs `b`) if its dynamic range exceeds
+    /// [`SCALE_TRIGGER`]; otherwise return `None` so the caller solves the
+    /// original system unchanged (zero copy, bit-identical).
+    pub fn maybe_new(lp: &LpView<'_>, b: &[f64]) -> Option<ScaledLp> {
+        let scaling = Scaling::from_matrix(lp.a, lp.m, lp.n)?;
+        Some(ScaledLp {
+            a: scaling.scale_matrix(lp.a),
+            b: scaling.scale_b(b),
+            c: scaling.scale_c(lp.c),
+            l: scaling.scale_lower(lp.l),
+            u: scaling.scale_upper(lp.u),
+            scaling,
+        })
+    }
+
+    /// Borrow the scaled LP as an [`LpView`].
+    pub fn view(&self) -> LpView<'_> {
+        LpView {
+            a: &self.a,
+            m: self.scaling.m,
+            n: self.scaling.n,
+            c: &self.c,
+            l: &self.l,
+            u: &self.u,
+        }
+    }
+
+    /// The scaled right-hand side.
+    pub fn b(&self) -> &[f64] {
+        &self.b
+    }
+
+    /// Map a scaled primal point back to the original space in place.
+    pub fn unscale_x(&self, x: &mut [f64]) {
+        self.scaling.unscale_x(x);
     }
 }
 
@@ -258,21 +298,39 @@ mod tests {
 
     #[test]
     fn unscale_recovers_original_scale() {
+        // Scaling derived from a wide-range matrix; x̂ maps back exactly by the
+        // (power-of-two) column factors, and scale_lower/upper invert it.
         let a = [1e9, 0.0, 0.0, 1.0];
+        let scaling = Scaling::from_matrix(&a, 2, 2).expect("should scale");
+        let l = scaling.scale_lower(&[4.0, 8.0]);
+        let mut x = l.clone();
+        scaling.unscale_x(&mut x);
+        // unscale ∘ scale_lower is the identity (exact for power-of-two factors).
+        assert_eq!(x, vec![4.0, 8.0]);
+        // Infinite bounds are preserved, not divided.
+        assert_eq!(scaling.scale_upper(&[INF, 1e12])[0], INF);
+    }
+
+    #[test]
+    fn shared_scaling_matches_single_solve_transform() {
+        // The reusable Scaling applied piecewise must reproduce ScaledLp's combined
+        // transform (the batch path and the single-solve path agree).
+        let a = [1e8, 2.0, 3.0, 1e-2];
         let lp = LpView {
             a: &a,
             m: 2,
             n: 2,
-            c: &[1.0, 1.0],
+            c: &[5.0, 7.0],
             l: &[0.0, 0.0],
-            u: &[1e12, 1e12],
+            u: &[1e10, 1e10],
         };
-        let scaled = ScaledLp::maybe_new(&lp, &[1.0, 1.0]).expect("should scale");
-        // x̂ in scaled space maps back by the (power-of-two) column factors.
-        let mut x = vec![2.0, 3.0];
-        let xhat = x.clone();
-        scaled.unscale_x(&mut x);
-        assert_eq!(x[0], xhat[0] * scaled.col[0]);
-        assert_eq!(x[1], xhat[1] * scaled.col[1]);
+        let b = [1.0, 2.0];
+        let single = ScaledLp::maybe_new(&lp, &b).expect("should scale");
+        let sc = Scaling::from_matrix(lp.a, lp.m, lp.n).expect("should scale");
+        assert_eq!(single.a, sc.scale_matrix(lp.a));
+        assert_eq!(single.b, sc.scale_b(&b));
+        assert_eq!(single.c, sc.scale_c(lp.c));
+        assert_eq!(single.l, sc.scale_lower(lp.l));
+        assert_eq!(single.u, sc.scale_upper(lp.u));
     }
 }

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -36,6 +36,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::gomory_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::mir_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_py, m)?)?;
+    m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_batch_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_py, m)?)?;
     Ok(())
 }

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -16,7 +16,9 @@ use discopt_core::lp::basis::recover_basis;
 use discopt_core::lp::crossover::{crossover_to_vertex, LpView};
 use discopt_core::lp::gomory::separate_gomory;
 use discopt_core::lp::mir::separate_mir;
-use discopt_core::lp::simplex::{solve_lp as simplex_solve_lp, LpStatus, SimplexOptions};
+use discopt_core::lp::simplex::{
+    solve_lp as simplex_solve_lp, solve_lp_batch, LpInstance, LpStatus, SimplexOptions,
+};
 use numpy::{
     PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods,
 };
@@ -248,6 +250,83 @@ pub fn solve_lp_py<'py>(
         sol.obj,
         sol.iters,
     ))
+}
+
+/// Solve a batch of LPs that share the constraint matrix `a` (C-contiguous
+/// `m × n`) and objective `c`, each with its own right-hand side and bounds. The
+/// per-instance data are stacked: `b` is `k × m`, `lb`/`ub` are `k × n`. The
+/// equilibration scaling and scaled matrix are computed once and reused across
+/// the batch, and the instances are solved in parallel.
+///
+/// Returns `(statuses, x, objs)` where `statuses` is a length-`k` list of
+/// strings (`optimal`/`infeasible`/`unbounded`/`iter_limit`/`numerical`), `x` is
+/// a `k × n` array of solutions, and `objs` is length `k`.
+#[pyfunction]
+#[pyo3(signature = (c, a, b, lb, ub, tol=1e-9, max_iter=100_000))]
+pub fn solve_lp_batch_py<'py>(
+    py: Python<'py>,
+    c: PyReadonlyArray1<'py, f64>,
+    a: PyReadonlyArray2<'py, f64>,
+    b: PyReadonlyArray2<'py, f64>,
+    lb: PyReadonlyArray2<'py, f64>,
+    ub: PyReadonlyArray2<'py, f64>,
+    tol: f64,
+    max_iter: usize,
+) -> PyResult<(Vec<String>, Bound<'py, PyArray2<f64>>, Bound<'py, PyArray1<f64>>)> {
+    let dims = a.shape();
+    let (m, n) = (dims[0], dims[1]);
+    let k = b.shape()[0];
+    if b.shape()[1] != m {
+        return Err(PyValueError::new_err("`b` must be k × m"));
+    }
+    if lb.shape() != [k, n] || ub.shape() != [k, n] {
+        return Err(PyValueError::new_err("`lb`/`ub` must be k × n"));
+    }
+    let a_owned: Vec<f64> = a
+        .as_slice()
+        .map_err(|_| PyValueError::new_err("`a` must be C-contiguous"))?
+        .to_vec();
+    let c_owned: Vec<f64> = c.as_slice()?.to_vec();
+    let b_flat = b
+        .as_slice()
+        .map_err(|_| PyValueError::new_err("`b` must be C-contiguous"))?;
+    let lb_flat = lb
+        .as_slice()
+        .map_err(|_| PyValueError::new_err("`lb` must be C-contiguous"))?;
+    let ub_flat = ub
+        .as_slice()
+        .map_err(|_| PyValueError::new_err("`ub` must be C-contiguous"))?;
+    let instances: Vec<LpInstance> = (0..k)
+        .map(|t| LpInstance {
+            b: b_flat[t * m..(t + 1) * m].to_vec(),
+            l: lb_flat[t * n..(t + 1) * n].to_vec(),
+            u: ub_flat[t * n..(t + 1) * n].to_vec(),
+        })
+        .collect();
+    let opts = SimplexOptions { tol, max_iter };
+    // The solve touches no Python objects, so release the GIL to let the core's
+    // rayon workers run the batch concurrently without contending on it.
+    let sols = py.allow_threads(|| solve_lp_batch(&a_owned, m, n, &c_owned, &instances, &opts));
+
+    let mut statuses = Vec::with_capacity(k);
+    let mut x_flat = vec![0.0f64; k * n];
+    let mut objs = vec![0.0f64; k];
+    for (t, sol) in sols.iter().enumerate() {
+        statuses.push(
+            match sol.status {
+                LpStatus::Optimal => "optimal",
+                LpStatus::Infeasible => "infeasible",
+                LpStatus::Unbounded => "unbounded",
+                LpStatus::IterLimit => "iter_limit",
+                LpStatus::Numerical => "numerical",
+            }
+            .to_string(),
+        );
+        x_flat[t * n..(t + 1) * n].copy_from_slice(&sol.x[..n.min(sol.x.len())]);
+        objs[t] = sol.obj;
+    }
+    let x_arr = PyArray1::from_vec(py, x_flat).reshape([k, n])?;
+    Ok((statuses, x_arr, PyArray1::from_vec(py, objs)))
 }
 
 /// Solve a pure MILP `min cᵀx + obj_const s.t. A x = b, lb ≤ x ≤ ub`, with the

--- a/python/discopt/solvers/lp_simplex.py
+++ b/python/discopt/solvers/lp_simplex.py
@@ -84,3 +84,90 @@ def solve_lp(
         basis=None,
         wall_time=res.wall_time,
     )
+
+
+def solve_lp_batch(
+    c: np.ndarray,
+    A_ub: Union[np.ndarray, sp.spmatrix],
+    instances: list[tuple[np.ndarray, list[tuple[float, float]]]],
+    *,
+    tol: float = 1e-9,
+    max_iter: int = 100_000,
+) -> list[LPResult]:
+    """Solve many LPs ``min c^T x s.t. A_ub x <= b_ub, bounds`` that share ``c``
+    and ``A_ub``, one per ``instances`` entry ``(b_ub, bounds)``.
+
+    The shared constraint matrix is marshalled to standard form once and the
+    Rust batch path computes the equilibration scaling a single time, reusing it
+    for every instance and solving them in parallel. The result list is in input
+    order; each is observationally identical to calling :func:`solve_lp` on that
+    instance alone. This is the throughput path for re-solving an LP over many
+    right-hand sides or bound boxes (the B&B / OBBT / scenario pattern).
+
+    Raises :class:`SimplexBackendUnavailable` if the Rust binding is missing.
+    """
+    from discopt.solvers.milp_simplex import SimplexBackendUnavailable
+
+    try:
+        from discopt._rust import solve_lp_batch_py
+    except ImportError as err:  # pragma: no cover - exercised via the selector
+        raise SimplexBackendUnavailable(
+            "discopt._rust.solve_lp_batch_py is unavailable; build the Rust extension"
+        ) from err
+
+    c_arr = np.asarray(c, dtype=np.float64).ravel()
+    n = c_arr.shape[0]
+    a = (A_ub.toarray() if sp.issparse(A_ub) else np.asarray(A_ub, dtype=np.float64)).reshape(-1, n)
+    m = a.shape[0]
+
+    # Standard form A_eq z = b with one slack per row: [A_ub | I] z = b.
+    a_std = np.zeros((m, n + m), dtype=np.float64)
+    a_std[:, :n] = a
+    a_std[:, n:] = np.eye(m)
+    c_std = np.concatenate([c_arr, np.zeros(m)])
+
+    k = len(instances)
+    b_stack = np.zeros((k, m), dtype=np.float64)
+    lb_stack = np.zeros((k, n + m), dtype=np.float64)
+    ub_stack = np.zeros((k, n + m), dtype=np.float64)
+    for t, (b_ub, bounds) in enumerate(instances):
+        b_stack[t, :] = np.asarray(b_ub, dtype=np.float64).ravel()
+        if bounds is not None:
+            lb_stack[t, :n] = [lo for lo, _ in bounds]
+            ub_stack[t, :n] = [hi for _, hi in bounds]
+        else:
+            ub_stack[t, :n] = 1e20
+        ub_stack[t, n:] = 1e20  # slacks in [0, inf)
+
+    statuses, xs, objs = solve_lp_batch_py(
+        np.ascontiguousarray(c_std),
+        np.ascontiguousarray(a_std),
+        np.ascontiguousarray(b_stack),
+        np.ascontiguousarray(lb_stack),
+        np.ascontiguousarray(ub_stack),
+        tol,
+        int(max_iter),
+    )
+
+    status_map = {
+        "optimal": SolveStatus.OPTIMAL,
+        "infeasible": SolveStatus.INFEASIBLE,
+        "unbounded": SolveStatus.UNBOUNDED,
+        "iter_limit": SolveStatus.ITERATION_LIMIT,
+        "numerical": SolveStatus.ERROR,
+    }
+    results: list[LPResult] = []
+    for t in range(k):
+        st = status_map.get(statuses[t], SolveStatus.ERROR)
+        if st != SolveStatus.OPTIMAL:
+            results.append(LPResult(status=st))
+            continue
+        results.append(
+            LPResult(
+                status=SolveStatus.OPTIMAL,
+                x=np.asarray(xs[t])[:n].copy(),
+                objective=float(objs[t]),
+                basis=None,
+            )
+        )
+    return results

--- a/python/discopt/solvers/lp_simplex.py
+++ b/python/discopt/solvers/lp_simplex.py
@@ -25,7 +25,7 @@ signature compatibility and ignored).
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import numpy as np
 import scipy.sparse as sp
@@ -117,7 +117,11 @@ def solve_lp_batch(
 
     c_arr = np.asarray(c, dtype=np.float64).ravel()
     n = c_arr.shape[0]
-    a = (A_ub.toarray() if sp.issparse(A_ub) else np.asarray(A_ub, dtype=np.float64)).reshape(-1, n)
+    a = (
+        cast("sp.spmatrix", A_ub).toarray()
+        if sp.issparse(A_ub)
+        else np.asarray(A_ub, dtype=np.float64)
+    ).reshape(-1, n)
     m = a.shape[0]
 
     # Standard form A_eq z = b with one slack per row: [A_ub | I] z = b.

--- a/python/tests/test_bucket2_composition_soundness.py
+++ b/python/tests/test_bucket2_composition_soundness.py
@@ -74,15 +74,12 @@ _AFFECTED = [
 
 _BACKENDS = ["simplex", "auto"]
 
-# Per-solve wall-clock cap. The soundness invariant this file locks is about the
-# *value* of a returned finite bound, not about reaching the LP optimum — the
-# docstring explicitly accepts early termination ("looseness and early
-# termination are fine"). On ex1252's FBBT-tightened box the fast simplex grinds
-# ~54s before reporting the same sound ``lb=0.0`` that HiGHS returns instantly;
-# capping the solve preserves every assertion (the capped bound is identical and
-# still sound) while keeping this CI-visible test fast. A non-``optimal`` status
-# from an early stop is already an accepted outcome below.
-_SOLVE_TIME_LIMIT = 5.0
+# No per-solve wall-clock cap is needed. ex1252's FBBT-tightened box used to make
+# the fast simplex grind ~54s (its ill-scaled lifted LP broke the basis
+# factorization, returning a Numerical bound that the MILP B&B could never fathom,
+# so it enumerated the whole tree — issue #170). Equilibration scaling fixed that:
+# every cell here now solves to ``optimal`` in well under a second, so the test
+# runs the relaxer to completion and exercises the full solve path.
 
 
 def _bounds_for(m):
@@ -101,7 +98,7 @@ def _root_bound(m, backend, bounds):
     lb, ub = bounds
     lb = np.asarray(lb, dtype=float).copy()
     ub = np.asarray(ub, dtype=float).copy()
-    return relaxer.solve_at_node(lb, ub, time_limit=_SOLVE_TIME_LIMIT)
+    return relaxer.solve_at_node(lb, ub)
 
 
 @pytest.mark.parametrize("instance, optimum", _AFFECTED)

--- a/python/tests/test_fractional_power_product_envelope.py
+++ b/python/tests/test_fractional_power_product_envelope.py
@@ -105,27 +105,35 @@ def test_lift_is_value_preserving():
     max_rel = 0.0
     for _ in range(20):
         env = {v.name: rng.uniform(1.0, 4.0) for v in m0._variables}
-        # Solve each aux from its (cleared, aux-linear) defining constraint.
-        for c in m1._constraints:
-            auxes = set()
 
-            def collect(e):
-                if isinstance(e, Variable) and e.name.startswith("_fr_aux") and e.name not in env:
-                    auxes.add(e.name)
-                if isinstance(e, BinaryOp):
-                    collect(e.left)
-                    collect(e.right)
-                if isinstance(e, UnaryOp):
-                    collect(e.operand)
+        def collect(e, auxes):
+            if isinstance(e, Variable) and e.name.startswith("_fr_aux") and e.name not in env:
+                auxes.add(e.name)
+            if isinstance(e, BinaryOp):
+                collect(e.left, auxes)
+                collect(e.right, auxes)
+            if isinstance(e, UnaryOp):
+                collect(e.operand, auxes)
 
-            collect(c.body)
-            if len(auxes) == 1:
-                an = auxes.pop()
-                env[an] = 0.0
-                b0 = ev(c.body, env)
-                env[an] = 1.0
-                b1 = ev(c.body, env)
-                env[an] = -b0 / (b1 - b0)
+        # Solve each aux from its (cleared, aux-linear) defining constraint. The
+        # constraint list is not guaranteed to be topologically ordered, so an
+        # aux may depend on one defined by a later constraint; iterate to a
+        # fixpoint (each pass resolves every constraint with exactly one still-
+        # unknown aux) rather than assuming a single forward pass suffices.
+        progress = True
+        while progress:
+            progress = False
+            for c in m1._constraints:
+                auxes: set[str] = set()
+                collect(c.body, auxes)
+                if len(auxes) == 1:
+                    an = auxes.pop()
+                    env[an] = 0.0
+                    b0 = ev(c.body, env)
+                    env[an] = 1.0
+                    b1 = ev(c.body, env)
+                    env[an] = -b0 / (b1 - b0)
+                    progress = True
         if any(v.name.startswith("_fr_aux") and v.name not in env for v in m1._variables):
             continue
         o0 = ev(m0._objective.expression, env)

--- a/python/tests/test_lp_batch.py
+++ b/python/tests/test_lp_batch.py
@@ -1,0 +1,82 @@
+"""Batched / multiple-RHS LP solving over a shared constraint matrix.
+
+The Rust `solve_lp_batch` path computes the equilibration scaling and scaled
+matrix once and reuses them across every instance. These tests pin that a batch
+solve is observationally identical to solving each LP on its own (status and
+objective), including on an ill-scaled matrix where the shared-scaling path runs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.solvers import SolveStatus
+from discopt.solvers.lp_simplex import SIMPLEX_AVAILABLE, solve_lp, solve_lp_batch
+
+pytestmark = pytest.mark.skipif(not SIMPLEX_AVAILABLE, reason="Rust simplex binding not built")
+
+
+def _assert_matches(c, A_ub, instances):
+    batch = solve_lp_batch(c, A_ub, instances)
+    assert len(batch) == len(instances)
+    for (b_ub, bounds), got in zip(instances, batch):
+        single = solve_lp(c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+        assert got.status == single.status
+        if single.status == SolveStatus.OPTIMAL:
+            assert got.objective == pytest.approx(single.objective, abs=1e-7)
+            np.testing.assert_allclose(got.x, single.x, atol=1e-6)
+
+
+def test_batch_matches_individual_solves():
+    c = np.array([-1.0, -2.0])
+    A_ub = np.array([[1.0, 1.0], [1.0, 3.0]])
+    bounds = [(0.0, 10.0), (0.0, 10.0)]
+    instances = [
+        (np.array([4.0, 6.0]), bounds),
+        (np.array([5.0, 6.0]), bounds),
+        (np.array([2.0, 9.0]), bounds),
+        (np.array([10.0, 1.0]), bounds),
+    ]
+    _assert_matches(c, A_ub, instances)
+
+
+def test_batch_varies_bounds_too():
+    # Instances differ in both rhs and bounds (full batching, not just multi-rhs).
+    c = np.array([-3.0, -1.0])
+    A_ub = np.array([[2.0, 1.0], [1.0, 1.0]])
+    instances = [
+        (np.array([10.0, 8.0]), [(0.0, 3.0), (0.0, 5.0)]),
+        (np.array([10.0, 8.0]), [(0.0, 1.0), (0.0, 5.0)]),
+        (np.array([6.0, 6.0]), [(0.0, 10.0), (0.0, 10.0)]),
+    ]
+    _assert_matches(c, A_ub, instances)
+
+
+def test_batch_on_ill_scaled_matrix_shares_scaling():
+    # A 1e8 linking coefficient gives the matrix a wide dynamic range, so the
+    # shared equilibration path runs; the batch must still match single solves.
+    c = np.array([1.0, 1.0])
+    A_ub = np.array([[1e8, 1.0], [1.0, 1.0]])
+    bounds = [(0.0, 1e6), (0.0, 1e6)]
+    instances = [
+        (np.array([2e8, 5.0]), bounds),
+        (np.array([1e8, 9.0]), bounds),
+    ]
+    _assert_matches(c, A_ub, instances)
+
+
+def test_empty_batch():
+    c = np.array([1.0, 1.0])
+    A_ub = np.array([[1.0, 1.0]])
+    assert solve_lp_batch(c, A_ub, []) == []
+
+
+def test_multiple_rhs_shared_bounds():
+    # The common multiple-RHS case: same matrix and bounds, several right-hand
+    # sides. Expressed as a batch with a shared bounds list.
+    c = np.array([-1.0, -1.0])
+    A_ub = np.array([[1.0, 2.0], [3.0, 1.0]])
+    bounds = [(0.0, 100.0), (0.0, 100.0)]
+    rhs_list = [np.array([r, r + 1.0]) for r in (4.0, 7.0, 12.0, 20.0, 1.0)]
+    instances = [(b, bounds) for b in rhs_list]
+    _assert_matches(c, A_ub, instances)


### PR DESCRIPTION
The cold/warm simplex factorizes the raw basis with feral's LU, which
declares a basis singular when its pivots are tiny relative to the
matrix entries. On lifted McCormick LPs whose coefficients span many
orders of magnitude (FBBT pushes product-aux bounds to ~1e9, so the
secant-envelope slopes do too) the LU breaks down after a few dozen
pivots and solve_lp returns Numerical. A Numerical relaxation bound is
uncertified, so the MILP B&B can never fathom and degenerates into full
enumeration: ex1252 on its FBBT box explored 65,499 nodes (~2^16, the
entire binary tree of its 15 integers) and never certified optimality.

Add power-of-two geometric-mean equilibration (scaling.rs): replace A
with R A C before factorizing so every nonzero is brought near magnitude
1, mirroring HiGHS. The objective is invariant and the optimal basis is
scaling-invariant, so warm-start bases stay valid across the tree. Factors
snap to powers of two (scaling is exact, unscaling x is exact) and scaling
only triggers when the matrix dynamic range exceeds 1e6, leaving every
well-conditioned LP bit-identical to before. Also make the feasibility
audit's bound tolerance relative, so large-magnitude variables are not
spuriously rejected.

ex1252 FBBT-box McCormick MILP: 65,499 nodes / uncertified / 217s ->
31 nodes / status=optimal / ~0.95s.

https://claude.ai/code/session_01FUNVDCBQ76PpG1nQbrZeR3