### PR TITLE
fix(soundness): fold variable-free product factors + sound feasible-exit certs

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -469,6 +469,62 @@ def _constant_value(expr: Expression) -> Optional[float]:
     return float(values[0])
 
 
+def _eval_constant_expr(expr: Expression) -> Optional[float]:
+    """Evaluate a *variable-free* subexpression to a scalar, else return None.
+
+    Unlike :func:`_constant_value` (which only recognizes a literal ``Constant``
+    node), this folds composite constant subexpressions such as ``neg(2.5)``
+    (a unary negation of a literal), ``(-3) * (-3)``, and other arithmetic over
+    constants. It is deliberately conservative: it returns ``None`` the moment a
+    variable, index, function call, or any unhandled node is encountered, so it
+    can never mis-fold an expression that actually depends on a decision
+    variable. Folding such factors is exact (value-preserving), so using it in
+    the product linearizer only ever tightens the relaxation while staying
+    sound.
+    """
+    direct = _constant_value(expr)
+    if direct is not None:
+        return direct
+    if isinstance(expr, UnaryOp):
+        val = _eval_constant_expr(expr.operand)
+        if val is None:
+            return None
+        if expr.op == "neg":
+            return -val
+        if expr.op == "abs":
+            return abs(val)
+        return None
+    if isinstance(expr, BinaryOp):
+        left = _eval_constant_expr(expr.left)
+        if left is None:
+            return None
+        right = _eval_constant_expr(expr.right)
+        if right is None:
+            return None
+        if expr.op == "+":
+            return left + right
+        if expr.op == "-":
+            return left - right
+        if expr.op == "*":
+            return left * right
+        if expr.op == "/":
+            if right == 0.0:
+                return None
+            return left / right
+        if expr.op == "**":
+            try:
+                result = left**right
+            except (ValueError, OverflowError, ZeroDivisionError):
+                return None
+            # A negative base to a fractional power yields a complex result;
+            # that is not a real constant we can fold, so bail conservatively.
+            if isinstance(result, complex):
+                return None
+            return float(result)
+        return None
+    return None
+
+
 def _finite_bound_or_none(value: Optional[float]) -> Optional[float]:
     if value is None:
         return None
@@ -2993,12 +3049,19 @@ def _linearize_expr(
                 raise ValueError(f"Cannot linearize power expression: {e}")
 
             elif e.op == "*":
-                # Constant scaling?
-                if isinstance(e.left, Constant):
-                    visit(e.right, scale * float(e.left.value))
+                # Constant scaling? Fold a variable-free factor (including
+                # composite constants such as ``neg(2.5)`` or ``(-3)*(-3)``)
+                # before attempting product decomposition. Without this, a term
+                # like ``(-2.5) * x`` (parsed as ``neg(2.5) * x``) is treated as
+                # an undecomposable bilinear product and the whole constraint is
+                # dropped from the relaxation, weakening the bound.
+                lconst = _eval_constant_expr(e.left)
+                if lconst is not None:
+                    visit(e.right, scale * lconst)
                     return
-                if isinstance(e.right, Constant):
-                    visit(e.left, scale * float(e.right.value))
+                rconst = _eval_constant_expr(e.right)
+                if rconst is not None:
+                    visit(e.left, scale * rconst)
                     return
                 # Full product decomposition
                 decomp = _decompose_product(

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3637,6 +3637,19 @@ def solve_model(
     if bound_val is not None and model._objective.sense == ObjectiveSense.MAXIMIZE:
         bound_val = -bound_val
     gap_val = stats["gap"]
+
+    # A *feasible* exit never inherits the tree's validity flag as a certificate.
+    # The flag means no node invalidated the tree bound — NOT that the gap is
+    # closed; a budget/node-limited feasible exit leaves that valid bound strictly
+    # below the incumbent (open gap). Reporting gap_certified=True there would
+    # falsely claim global optimality (max_nodes=1 root-only exit: obj 19029,
+    # bound -583, gap 1.03 — yet previously "certified"). Drop the flag here and
+    # re-earn it below only if a rigorous global bound actually closes the gap.
+    # "optimal" already implies a closed certified search; infeasible/limit exits
+    # are handled above and keep their own certification semantics.
+    if status == "feasible":
+        _gap_certified = False
+
     if not _gap_certified:
         bound_val = None
         gap_val = None
@@ -3656,6 +3669,24 @@ def solve_model(
             bound_val = _rr
             if obj_val is not None and np.isfinite(obj_val):
                 gap_val = max(0.0, obj_val - bound_val) / max(1.0, abs(obj_val))
+
+    # Re-earn certification on a feasible exit iff a *rigorous* global lower bound
+    # (here the root-relaxation fallback, itself only returned when the objective
+    # is validly linearized) meets the incumbent within tolerance — then the
+    # incumbent is provably global and the honest status is "optimal". The
+    # bound <= incumbent guard stops a spurious above-incumbent bound (which the
+    # max(0, …) gap clamp would otherwise read as gap 0) from certifying.
+    if (
+        status == "feasible"
+        and obj_val is not None
+        and bound_val is not None
+        and np.isfinite(bound_val)
+        and bound_val <= obj_val + 1e-9
+        and gap_val is not None
+        and gap_val <= gap_tolerance
+    ):
+        _gap_certified = True
+        status = "optimal"
 
     return SolveResult(
         status=status,
@@ -4400,6 +4431,15 @@ def _solve_nlp_bb(
 
     # An uncertified gap is not a rigorous dual bound; do not present one.
     gap_val = stats["gap"]
+
+    # A *feasible* exit never inherits the tree's validity flag as a certificate:
+    # the flag attests bound validity, not gap closure, and a node/budget-limited
+    # feasible exit leaves the tree gap open. See the spatial-path note above
+    # (max_nodes=1 false-certification regression). This path carries no rigorous
+    # root-relaxation fallback, so a dropped certificate is not re-earned here.
+    if status == "feasible":
+        _gap_certified = False
+
     if not _gap_certified:
         bound_val = None
         gap_val = None
@@ -7126,6 +7166,15 @@ def _solve_milp_bb(
         bound_val = -bound_val
 
     gap_val = stats["gap"]
+
+    # A *feasible* exit never inherits the tree's validity flag as a certificate:
+    # the flag attests bound validity, not gap closure, and a node/budget-limited
+    # feasible exit leaves the tree gap open. See the spatial-path note above
+    # (max_nodes=1 false-certification regression). This path carries no rigorous
+    # root-relaxation fallback, so a dropped certificate is not re-earned here.
+    if status == "feasible":
+        _gap_certified = False
+
     if not _gap_certified:
         # Tree bound/gap are not rigorous on an uncertified exit (a node may
         # have been pruned without proof); drop them.
@@ -7588,6 +7637,15 @@ def _solve_miqp_bb(
 
     # An uncertified gap is not a rigorous dual bound; do not present one.
     gap_val = stats["gap"]
+
+    # A *feasible* exit never inherits the tree's validity flag as a certificate:
+    # the flag attests bound validity, not gap closure, and a node/budget-limited
+    # feasible exit leaves the tree gap open. See the spatial-path note above
+    # (max_nodes=1 false-certification regression). This path carries no rigorous
+    # root-relaxation fallback, so a dropped certificate is not re-earned here.
+    if status == "feasible":
+        _gap_certified = False
+
     if not _gap_certified:
         bound_val = None
         gap_val = None

--- a/python/tests/test_batch_sentinel_soundness.py
+++ b/python/tests/test_batch_sentinel_soundness.py
@@ -1,18 +1,22 @@
 """
-Soundness regression: batch-path failure sentinels must decertify the gap.
+Soundness regression: batch-path failure sentinels must never certify a wrong
+objective.
 
 A node whose NLP relaxation solve fails (error, divergence, or *local*
 infeasibility) carries ``INFEASIBILITY_SENTINEL`` as its lower bound and is
 pruned by the Rust tree as soon as an incumbent exists — without any proof
 that the subtree is suboptimal or infeasible. The serial node path already
-decertifies the gap in that case (issue #27a) so the result downgrades from
-"optimal" to "feasible". These tests pin the same guarantee onto the batch
-IPM/POUNCE path, which previously pruned silently and could report a
-certified "optimal" for a wrong objective.
+decertifies the gap in that case (issue #27a); these tests pin the same
+guarantee onto the batch IPM/POUNCE path, which previously pruned silently and
+could report a certified "optimal" for a wrong objective.
 
-The batch solver is monkeypatched to simulate universal node-solve failure;
-the warm-started incumbent then makes every sentinel node prunable, the tree
-exhausts, and an unguarded solver would claim a certified optimum.
+The batch solver is monkeypatched to simulate universal node-solve failure, so
+the *failed nodes themselves* never license a certification. A certification
+may still arise — soundly — from an INDEPENDENT rigorous global bound (the root
+MILP-relaxation fallback, issue #138) when that bound proves the incumbent
+globally optimal. The invariant under test is therefore the soundness one: any
+reported bound is valid (never above the true optimum) and any certification is
+of the TRUE optimum, never of a suboptimal point.
 """
 
 from __future__ import annotations
@@ -97,28 +101,33 @@ class TestBatchSentinelSoundness:
             "Batch path was never exercised; test setup no longer matches "
             "the solver's dispatch (check _use_pounce_batch conditions)."
         )
-        # The incumbent (warm start or better) survives as a feasible point...
+        # The incumbent survives as a feasible point...
         assert result.objective is not None
-        # ...but the gap must NOT be *certified* off failure sentinels: every
-        # pruned node carried a failure sentinel, not an infeasibility proof.
-        assert result.status != "optimal", (
-            f"Unsound certification: status={result.status!r} with "
-            f"obj={result.objective} after pruning failed nodes"
-        )
-        assert not result.gap_certified, "sentinel failures must not certify the gap"
-        # A dual bound MAY now be reported — not from the failed batch nodes, but
-        # from the independent root-relaxation fallback (issue #138); when present
-        # it must be sound (never above the true optimum), never a false bound.
+        # ...and SOUNDNESS is the real invariant: a failed batch node carries a
+        # sentinel, not a proof, so the *failed nodes* may never certify the gap.
+        # Certification is legitimate ONLY when an INDEPENDENT rigorous global
+        # bound — the root-relaxation fallback (issue #138), never the failed
+        # nodes — proves the incumbent globally optimal. Two guarantees, both held:
+        #   (1) any reported dual bound is sound (never above the true optimum);
+        #   (2) any certification is of the TRUE optimum, never a suboptimal point
+        #       (this is exactly the "certified a wrong objective" failure the
+        #       batch path could previously commit).
         assert result.bound is None or result.bound <= _OPT + 1e-6, (
             f"unsound bound {result.bound} > optimum {_OPT}"
         )
+        if result.gap_certified:
+            assert result.status == "optimal"
+            assert abs(result.objective - _OPT) <= 1e-2, (
+                f"certified a non-optimal objective {result.objective} "
+                f"(true optimum {_OPT}) after pruning failed nodes"
+            )
 
         monkeypatch.setattr(S, "_solve_batch_pounce", real_batch)
 
     def test_unpatched_solver_still_certifies(self) -> None:
-        """Control: the real batch solver reaches the optimum with a valid
-        (certified) bound, so the decertification above is attributable to the
-        injected sentinels and not to the model being unsolvable."""
+        """Control: the real batch solver reaches the true optimum with a valid
+        (certified) bound, confirming the model is solvable and that the sentinel
+        test above exercises failure handling on a genuinely tractable problem."""
         m, _ = _build_nonconvex_minlp()
         result = m.solve(
             nlp_solver="pounce",

--- a/python/tests/test_constant_fold_and_cert_soundness.py
+++ b/python/tests/test_constant_fold_and_cert_soundness.py
@@ -1,0 +1,119 @@
+"""Soundness regressions for two coupled relaxation/certification fixes.
+
+1. **Constant-factor folding in the product linearizer.** A product factor that
+   is a *variable-free* subexpression — e.g. ``neg(2.5)`` (the unary negation of
+   a literal, how ``(-2.5)`` is parsed) or ``(-3) * (-3)`` from an expanded
+   square — was not recognized as a constant. The term ``(-2.5) * x`` (an exact
+   linear term!) was therefore sent to bilinear decomposition, which failed with
+   ``Cannot decompose product: (neg(3) * neg(3))``, and the *entire constraint*
+   was dropped from the MILP relaxation. With an objective-defining constraint
+   omitted, the dual bound could not rise to the incumbent and the gap never
+   closed. This is exactly how MINLPLib's ``nvs08`` (whose objective equation
+   contains ``sqr((-3) + i1)``, expanding to ``(-3) * (-3)``) failed to certify:
+   bound stuck at ~16.1 against the true optimum 23.4497. Folding such factors
+   is exact, so it only tightens the relaxation while staying sound
+   (``bound <= optimum``).
+
+2. **Certification invariant.** A merely-*feasible* exit (search not closed —
+   budget exhausted with an open gap) must never be reported as
+   ``gap_certified=True``. The no-incumbent resource-limit branch cleared the
+   flag, but a feasible exit *with* an incumbent had its own path and could
+   retain a stale ``gap_certified=True`` — a false certification of a
+   non-optimal point. The invariant now holds: ``status != "optimal"`` implies
+   ``gap_certified is False``.
+
+Both guards are deterministic and self-contained: the constant-fold case builds
+the exact ``neg(3) * neg(3)`` AST the GAMS tokenizer emits (Python's own
+``-3 * -3`` would fold to a literal and never exercise the bug), and the
+certification case stops B&B after the root node with ``max_nodes=1``.
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+import pytest
+from discopt.modeling.core import BinaryOp, Constant, UnaryOp, sqrt
+
+
+def test_eval_constant_expr_folds_negated_literals():
+    """A variable-free factor must fold to its value, not reach bilinear decomp."""
+    from discopt._jax.milp_relaxation import _eval_constant_expr
+
+    # neg(2.5) folds to -2.5 (the exact case that broke the linearizer: a
+    # ``(-2.5)`` literal parses as the unary negation of a Constant).
+    assert _eval_constant_expr(UnaryOp("neg", Constant(2.5))) == -2.5
+    # (-3) * (-3), produced when an expanded square's constant term is built
+    # from two negated literals, folds to 9.
+    prod = BinaryOp("*", UnaryOp("neg", Constant(3.0)), UnaryOp("neg", Constant(3.0)))
+    assert _eval_constant_expr(prod) == 9.0
+
+
+def test_eval_constant_expr_returns_none_for_variable_terms():
+    """The folder must never mis-fold an expression that depends on a variable."""
+    from discopt._jax.milp_relaxation import _eval_constant_expr
+
+    m = dm.Model("t")
+    x = m.continuous("x", lb=0, ub=10)
+    assert _eval_constant_expr(-x) is None
+    assert _eval_constant_expr(2.0 * x) is None
+
+
+@pytest.mark.correctness
+def test_negated_constant_product_keeps_constraint_and_certifies():
+    """A nonlinear constraint carrying a ``(-3)*(-3)`` constant term must be kept.
+
+    This mirrors MINLPLib ``nvs08``'s objective equation, where expanding
+    ``sqr((-3) + i1)`` produces the literal product ``(-3) * (-3)``. The
+    surrounding ``x*y`` term forces the constraint through product
+    decomposition, where the constant factor used to raise
+    ``Cannot decompose product: (neg(3) * neg(3))`` and the whole constraint
+    was dropped — leaving the relaxation unable to certify the optimum.
+    """
+    m = dm.Model("negconst_product")
+    x = m.continuous("x", lb=0, ub=5)
+    y = m.continuous("y", lb=0, ub=5)
+    # Build the exact AST a tokenizer emits for ``(-3) * (-3)`` (== 9.0).
+    nine = BinaryOp("*", UnaryOp("neg", Constant(3.0)), UnaryOp("neg", Constant(3.0)))
+    # x*y + 9 <= 13  =>  x*y <= 4. Active at the optimum, so dropping it would
+    # loosen the bound from x+y<=10 down to the real best 5.8.
+    m.subject_to(x * y + nine <= 13)
+    m.maximize(x + y)
+    r = m.solve(time_limit=30, gap_tolerance=1e-4)
+
+    assert r.status == "optimal", f"status={r.status} (constraint dropped → uncertified before fix)"
+    assert r.objective is not None and abs(r.objective - 5.8) <= 1e-3, f"obj={r.objective}"
+    # Soundness invariant: a valid dual bound never exceeds the optimum.
+    assert r.bound is not None, "certified solve must report a dual bound"
+    assert r.bound >= r.objective - 1e-3, f"dual bound {r.bound} below maximized obj {r.objective}"
+
+
+@pytest.mark.correctness
+def test_feasible_exit_is_never_certified():
+    """A budget-capped feasible exit with an incumbent must not be gap_certified.
+
+    ``max_nodes=1`` deterministically stops B&B after the root node: the root
+    subsolve yields a feasible incumbent but the gap is wide open, so the search
+    is not closed. This is precisely the path that used to retain a stale
+    ``gap_certified=True``, falsely certifying a non-optimal point.
+    """
+    m = dm.Model("mini_minlp")
+    i1 = m.integer("i1", lb=0, ub=200)
+    i2 = m.integer("i2", lb=0, ub=200)
+    x3 = m.continuous("x3", lb=0.001, ub=200)
+    m.subject_to(sqrt(x3) + i1 + 2 * i2 >= 10)
+    m.subject_to(i2**2 - 4 * i1 >= -12)
+    m.minimize((i1 - 3) ** 2 + (i2 - 2) ** 2 + (x3 + 4) ** 2)
+    r = m.solve(time_limit=30, max_nodes=1)
+
+    # The core invariant: only an 'optimal' status may be certified.
+    if r.status != "optimal":
+        assert r.gap_certified is False, (
+            f"status={r.status} but gap_certified={r.gap_certified} (false certification)"
+        )
+    # And whenever a solve IS certified, the bound must be sound.
+    if r.gap_certified:
+        assert r.bound is not None and r.objective is not None
+        assert r.bound <= r.objective + 1e-3


### PR DESCRIPTION
## Summary

Two soundness fixes uncovered while diagnosing why discopt finds correct
incumbents on MINLPLib problems but fails to **certify** global optimality
(e.g. `nvs08`: correct incumbent 23.4497 but the dual bound was stuck at
~16.1, gap never closing). Both relate directly to the project's
non-negotiable soundness mandate: a certified (`gap_certified=True`) result
must be a *proven* global optimum, and a valid dual bound must never exceed
the true optimum.

### 1. Constant-factor folding in the product linearizer (`milp_relaxation.py`)

The MILP relaxation's product linearizer only recognized a **literal**
`Constant` node as a foldable scalar factor. A *variable-free* composite —
e.g. `neg(2.5)` (how `(-2.5)` is parsed) or `(-3) * (-3)` (the constant term
of an expanded `sqr((-3) + i1)`) — was not folded. The exact linear/constant
term was instead sent to bilinear decomposition, which failed with
`Cannot decompose product: (neg(3) * neg(3))`, and the **entire constraint was
dropped** from the relaxation. When the dropped constraint is the
objective-defining equation, the dual bound can never rise to the incumbent
and the gap never closes — turning a solvable problem into an uncertifiable
one.

Fix: add `_eval_constant_expr`, a conservative recursive evaluator that folds
variable-free subexpressions (`neg`, `abs`, `+`, `-`, `*`, `/`, `**`) to a
scalar and returns `None` the instant a variable / index / function /
complex-result / unhandled node appears — so it can never mis-fold a
variable-dependent term. The product linearizer now folds either factor
through it. Folding is exact, so it only tightens the relaxation while staying
sound (`bound <= optimum`).

**Effect on real `nvs08`** (via the GAMS interface): bound 16.10 → 23.4494,
`feasible` → `optimal`, `gap_certified` False → True.

### 2. Certification on feasible exits: clear, then re-earn on a rigorous bound (`solver.py`)

A merely-*feasible* exit (search not closed — budget/node-limited with an open
gap) could retain a stale `gap_certified=True` at all four finalization sites.
This was independently visible: a `max_nodes=1` root-only exit reported
`obj=19029, bound=-583, gap=1.03 (103%)` and yet **`gap_certified=True`** — a
false certification of a non-optimal point (the worst soundness failure class).

The `_gap_certified` flag means "no node invalidated the tree's dual bound"
(bound *validity*), **not** "the gap is closed". Those are different, and the
old code conflated them.

Fix (two parts, all four sites):

- A feasible exit no longer inherits the tree's validity flag as a
  certificate: `_gap_certified` is cleared unconditionally for `status ==
  "feasible"`.
- On the spatial path, which already surfaces a **rigorous** root
  MILP-relaxation bound on uncertified exits (issue #138; that bound is only
  returned when the objective is validly linearized, so it is a genuine global
  underestimate), certification is then *re-earned* — and the status upgraded
  to `"optimal"` — **iff that rigorous bound actually closes the gap**:

  ```python
  if (status == "feasible" and obj_val is not None
          and bound_val is not None and np.isfinite(bound_val)
          and bound_val <= obj_val + 1e-9          # bound never above incumbent
          and gap_val is not None and gap_val <= gap_tolerance):
      _gap_certified = True
      status = "optimal"
  ```

This is sound by construction: the rigorous bound satisfies `bound <=
true_opt <= obj`, and re-certification additionally requires `bound <= obj`
and a closed relative gap, so the certified incumbent is provably within
tolerance of the true optimum — it **cannot certify a suboptimal point**. The
`bound <= obj` guard specifically blocks a spurious above-incumbent bound
(which the `max(0, …)` gap clamp would otherwise read as gap 0) from
certifying.

Net effect: the `max_nodes=1` false certification is gone (loose bound −583,
gap 1.03 → stays `feasible`, uncertified), while a genuinely-solved feasible
exit whose rigorous root bound meets the incumbent is now *soundly* certified
`optimal` — a capability gain, not a loss. The invariant `status != "optimal"
⟹ gap_certified is False` now holds.

## Tests

`python/tests/test_constant_fold_and_cert_soundness.py` (new) — 4
deterministic, self-contained regression guards (no GAMS / external-solver
dependency):

- `_eval_constant_expr` folds `neg(2.5)→-2.5` and `(-3)*(-3)→9`, and returns
  `None` for any variable-dependent term.
- A nonlinear constraint carrying a `(-3)*(-3)` constant term (the exact AST a
  tokenizer emits) is kept in the relaxation and the model certifies its
  optimum soundly.
- A `max_nodes=1` feasible exit is never `gap_certified`, and any certified
  solve has a sound bound.

**Reviewer note — change to a maintainer soundness control test.**
`python/tests/test_batch_sentinel_soundness.py::test_batch_failure_sentinels_decertify_gap`
previously asserted `status != "optimal"` and `not gap_certified` under
injected universal batch-node failure. With the rigorous root-relaxation
fallback (#138) in place, that solve now reaches the true optimum (−1.0) **and**
the independent root bound (−1.0, never the failed nodes) proves it — a *sound*
certification. The assertions are updated to test the precise soundness
invariant they were protecting: any reported bound is valid (`<= true_opt`) and
**any certification is of the true optimum, never a suboptimal point**. This is
strictly the property the test name protects ("certify a wrong objective"); it
still fails loudly if a suboptimal incumbent is ever certified. Please
sanity-check this framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
