### PR TITLE
perf(simplex): dual Devex pricing + bound-flipping ratio test (#178)

### DIFF
--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -208,6 +208,12 @@ impl<'a> PreparedDual<'a> {
 
         let mut updates = 0usize;
         let mut pivots = 0usize;
+        // Dual Devex reference weights γ_i ≥ 1, one per basic slot. The leaving
+        // variable maximizes (bound violation)²/γ_i — a cheap steepest-edge
+        // approximation that cuts dual iterations versus plain largest-violation
+        // pricing. Pricing only chooses *which* primal-infeasible row leaves, never
+        // affects correctness (any infeasible basic var is a valid leaving choice).
+        let mut gamma = vec![1.0f64; m];
         for _iter in 0..opts.max_iter {
             // Basic values x_B = B⁻¹(b − Σ_nonbasic A_j x_j).
             let mut xb = b.to_vec();
@@ -226,25 +232,26 @@ impl<'a> PreparedDual<'a> {
                 return None;
             }
 
-            // Most primal-infeasible basic variable leaves.
+            // Leaving variable: most primal-infeasible basic var by Devex score
+            // (violation²/γ_i). `to_lower` = the bound the leaving var is pinned at.
             let mut r = None;
-            let mut worst = tol;
+            let mut best_score = 0.0f64;
             let mut to_lower = true;
             for i in 0..m {
                 let bi = basis[i];
-                if xb[i] < l[bi] - tol {
-                    let viol = l[bi] - xb[i];
-                    if viol > worst {
-                        worst = viol;
-                        r = Some(i);
-                        to_lower = true; // leaving var pinned at its lower bound
-                    }
+                let viol = if xb[i] < l[bi] - tol {
+                    Some((l[bi] - xb[i], true)) // below lower → pin at lower
                 } else if xb[i] > u[bi] + tol {
-                    let viol = xb[i] - u[bi];
-                    if viol > worst {
-                        worst = viol;
+                    Some((xb[i] - u[bi], false)) // above upper → pin at upper
+                } else {
+                    None
+                };
+                if let Some((v, lo)) = viol {
+                    let score = v * v / gamma[i];
+                    if score > best_score {
+                        best_score = score;
                         r = Some(i);
-                        to_lower = false;
+                        to_lower = lo;
                     }
                 }
             }
@@ -319,6 +326,34 @@ impl<'a> PreparedDual<'a> {
                 }
             };
 
+            // Entering column α = B⁻¹A_q for the Devex weight update (and reused as
+            // the raw column for the product-form basis update).
+            let raw_q = col(a, m, n, q);
+            let mut alpha = raw_q.clone();
+            if lu.ftran(&mut alpha).is_err() {
+                return None;
+            }
+            let piv = alpha[r];
+            if piv.abs() > tol {
+                // Goldfarb–Reid dual Devex update (uses the still-current basis).
+                let gamma_r = gamma[r];
+                for i in 0..m {
+                    if i != r {
+                        let cand = (alpha[i] / piv).powi(2) * gamma_r;
+                        if cand > gamma[i] {
+                            gamma[i] = cand;
+                        }
+                    }
+                }
+                // Slot r now holds the entering variable; give it a fresh weight.
+                gamma[r] = (gamma_r / (piv * piv)).max(1.0);
+                if gamma[r] > 1e10 {
+                    for g in gamma.iter_mut() {
+                        *g = 1.0; // reframe when weights blow up
+                    }
+                }
+            }
+
             // Pivot: q enters at slot r; leaving var pinned at the violated bound.
             let leaving = basis[r];
             stat[leaving] = if to_lower { AT_LOWER } else { AT_UPPER };
@@ -327,7 +362,7 @@ impl<'a> PreparedDual<'a> {
             slot_of[q] = r as i64;
             stat[q] = BASIC;
             pivots += 1;
-            let need_refac = lu.update(r, &col(a, m, n, q)).is_err();
+            let need_refac = lu.update(r, &raw_q).is_err();
             updates += 1;
             if need_refac || updates >= 48 {
                 let cols: Vec<Vec<f64>> = basis.iter().map(|&j| col(a, m, n, j)).collect();

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -237,6 +237,7 @@ impl<'a> PreparedDual<'a> {
             let mut r = None;
             let mut best_score = 0.0f64;
             let mut to_lower = true;
+            let mut delta = 0.0f64; // bound-violation magnitude of the chosen row
             for i in 0..m {
                 let bi = basis[i];
                 let viol = if xb[i] < l[bi] - tol {
@@ -252,6 +253,7 @@ impl<'a> PreparedDual<'a> {
                         best_score = score;
                         r = Some(i);
                         to_lower = lo;
+                        delta = v;
                     }
                 }
             }
@@ -278,23 +280,22 @@ impl<'a> PreparedDual<'a> {
                 return None;
             }
 
-            // Dual ratio test. Leaving direction sets which sign of alpha_rj is
-            // eligible; pick the entering j minimizing |d_j / alpha_rj| while
-            // keeping dual feasibility.
-            let mut enter = None;
-            let mut best_ratio = f64::INFINITY;
+            // Bound-flipping (long-step) dual ratio test. Eligible nonbasic columns
+            // are the breakpoints where some d_j would cross zero as the dual step
+            // grows; walking them in increasing |d_j/α_rj| and *flipping* each
+            // finite-bounded one to its opposite bound lets the leaving variable
+            // travel further in a single pivot (each flip closes |α_rj|·(u−l) of the
+            // infeasibility `delta`). The breakpoint that closes the rest — or the
+            // first with an infinite bound gap (can't flip) — is the entering column.
+            // Flips only change which bound a nonbasic sits at (`stat`); the next
+            // iteration's exact x_B/y recompute re-establishes primal values and dual
+            // feasibility, and any difficulty still falls back to the cold solve.
+            let mut cand: Vec<(usize, f64, f64)> = Vec::new(); // (j, ratio, |α_rj|)
             for j in 0..n {
-                if stat[j] == BASIC {
-                    continue;
-                }
-                if u[j] - l[j] <= tol {
-                    continue; // fixed var can't enter
+                if stat[j] == BASIC || u[j] - l[j] <= tol {
+                    continue; // basic or fixed
                 }
                 let arj = sp.dot(j, &rho);
-                // Eligibility: increasing leaving (to_lower) wants the basic var to
-                // rise; the entering var that preserves dual feasibility satisfies:
-                //  - at lower:  arj < 0  (to_lower) /  arj > 0  (to_upper)
-                //  - at upper:  arj > 0  (to_lower) /  arj < 0  (to_upper)
                 let eligible = if stat[j] == AT_LOWER {
                     if to_lower {
                         arj < -tol
@@ -308,23 +309,39 @@ impl<'a> PreparedDual<'a> {
                 };
                 if eligible {
                     let dj = c[j] - sp.dot(j, &y);
-                    let ratio = (dj / arj).abs();
-                    if ratio < best_ratio - tol {
-                        best_ratio = ratio;
-                        enter = Some(j);
-                    }
+                    cand.push((j, (dj / arj).abs(), arj.abs()));
                 }
             }
-            let q = match enter {
-                Some(q) => q,
-                None => {
-                    // No eligible entering column: the LP is primal-infeasible.
-                    // Trustworthy because the start basis was verified dual-feasible.
-                    return Some(assemble(
-                        n, m, &basis, &slot_of, &stat, &xb, c, l, u, LpStatus::Infeasible, pivots,
-                    ));
+            if cand.is_empty() {
+                // No eligible entering column: the LP is primal-infeasible.
+                // Trustworthy because the start basis was verified dual-feasible.
+                return Some(assemble(
+                    n, m, &basis, &slot_of, &stat, &xb, c, l, u, LpStatus::Infeasible, pivots,
+                ));
+            }
+            cand.sort_by(|x, y| x.1.partial_cmp(&y.1).unwrap_or(std::cmp::Ordering::Equal));
+            // Walk breakpoints, flipping finite-bounded ones until `delta` is closed.
+            // The last candidate is always taken as the entering column (never
+            // flipped), so even if the bound gaps can't fully close `delta` the step
+            // is a valid dual pivot and the search makes progress.
+            let mut slope = 0.0f64;
+            let mut q = cand[cand.len() - 1].0;
+            let mut flips: Vec<usize> = Vec::new();
+            let last = cand.len() - 1;
+            for (idx, &(j, _ratio, aj)) in cand.iter().enumerate() {
+                let gap = u[j] - l[j];
+                slope += aj * gap;
+                if idx == last || gap >= INF || slope >= delta - tol {
+                    q = j; // this breakpoint enters the basis; stop flipping
+                    break;
                 }
-            };
+                flips.push(j); // fully traversed → flip to the opposite bound
+            }
+            // Apply the bound flips (no basis change); their effect on x_B and the
+            // reduced costs is realized by the next iteration's exact recompute.
+            for &j in &flips {
+                stat[j] = if stat[j] == AT_LOWER { AT_UPPER } else { AT_LOWER };
+            }
 
             // Entering column α = B⁻¹A_q for the Devex weight update (and reused as
             // the raw column for the product-form basis update).


### PR DESCRIPTION
Closes #178.

Speeds up the warm-started dual simplex (the per-node LP engine of the MILP B&B)
by cutting **iteration count** — the lever #178's benchmarks identified — via the
two techniques commercial dual simplexes rely on.

## Results — `ex1252` FBBT-box McCormick MILP

| build | nodes | LP iters | wall |
|---|---|---|---|
| `main` | 31 | 2246 | ~0.59 s |
| + dual Devex pricing | 29 | 1586 | ~0.43 s |
| + bound-flipping ratio test | **11** | **694** | **~0.29 s** |

**Cumulative vs `main`: −65% nodes, −69% LP iters, −51% wall**, with
`status=optimal` / `bound=0.0` unchanged throughout.

## Changes

**1. Dual Devex pricing (`99cd5da`).** The leaving variable was chosen by largest
bound violation (Dantzig-style); switch to Devex reference weights — leaving =
`argmax (violation)² / γᵢ`, a cheap steepest-edge approximation. One weight per
basic slot, updated with the Goldfarb–Reid rule from the entering column
`α = B⁻¹A_q` (one extra ftran per pivot, repaid many times by the iteration drop),
reframing (reset to 1) on blow-up, mirroring the primal Devex in `primal.rs`.
**Correctness-safe by construction:** pricing only selects *which* primal-infeasible
row leaves — any infeasible basic variable is a valid choice.

**2. Bound-flipping (long-step) dual ratio test (`e22278f`).** Replace the
single-breakpoint test with the long-step test: walk eligible breakpoints in
increasing `|d_j/α_rj|` and flip each finite-bounded one to its opposite bound
(each closes `|α_rj|·(u−l)` of the leaving variable's infeasibility), until the
breakpoint that closes the rest — or the first with an infinite bound gap — enters
the basis. A flip is just a `stat` change that the next iteration's exact `x_B`/`y`
recompute realizes; the last candidate is always the entering column, so every
step is a valid dual pivot even when the bound gaps can't fully close the
infeasibility.

The dual-feasibility precondition, periodic refactorization, and cold-solve
fallback are all unchanged, so any difficulty still degrades to a correct cold
solve.

## What was investigated and *not* taken (recorded on #178)

- **Incremental `x_B`/`d` maintenance** (the issue's original title): implemented and
  abandoned — a net ~7% regression, because B&B warm re-solves are too short
  (~4–5 pivots) to amortize the per-solve fixed overhead, and the noisier `d`
  lengthened pivot paths.
- **Cross-node factorization carry-over** (the issue's prior scope): deferred — the
  per-node initial factorization is only ~7% of the work.

## Validation

- 324 Rust tests, including the 40 random-LP warm-vs-cold comparisons — the key
  correctness gate for the dual (a wrong bound-flip would change the objective).
- 139 targeted MILP / soundness / HiGHS cross-check tests.
- Full fast suite: **3309 passed, 0 failed** — no regressions (the dual is used
  across every MILP/LP path).

https://claude.ai/code/session_01FUNVDCBQ76PpG1nQbrZeR3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUNVDCBQ76PpG1nQbrZeR3)_