### PR TITLE
fix(soundness): certify du-opt globally — epigraph relaxation + rank-1 Hessian + NLP-fathom fixes

### DIFF
--- a/.crucible/references.bib
+++ b/.crucible/references.bib
@@ -2516,3 +2516,9 @@
   year = {2005},
   doi = {10.1016/j.compchemeng.2005.04.003},
 }
+
+@article{khajavirad2012,
+  title = {Relaxations of factorable functions with convex-transformable intermediates},
+  author = {Khajavirad, A.; Michalek, J. J.; Sahinidis, N. V.},
+  year = {2012},
+}

--- a/.crucible/wiki/concepts/convex-transformable-functions.org
+++ b/.crucible/wiki/concepts/convex-transformable-functions.org
@@ -1,0 +1,105 @@
+#+TITLE: Convex-Transformable (G-convex) Functions
+#+FILETAGS: :concept:convexity:generalized-convexity:convex-relaxation:factorable:global-optimization:envelopes:
+
+* Convex-Transformable (G-convex) Functions
+:PROPERTIES:
+:ARTICLE_TYPE: concept
+:SOURCE_KEYS: khajavirad2012
+:STATUS: draft
+:CREATED: 2026-06-16
+:END:
+
+A nonconvex continuous function $\varphi : C \to \mathbb{R}$ over a convex set
+$C \subseteq \mathbb{R}^n$ is *convex-transformable*, or *G-convex*, if there
+exists a continuous increasing univariate function $G$ defined on the image
+$I_\varphi(C)$ such that the composition $G(\varphi)$ is convex over $C$
+citep:khajavirad2012. The class is a cornerstone of generalized convexity: it
+subsumes many functional forms — products and ratios of convex and/or concave
+functions, signomials, and log-concave functions — that appear repeatedly as the
+building blocks of nonconvex expressions, even though the *vast majority* of
+arbitrary nonconvex functions are not convex-transformable.
+
+G-convexity sits between convexity and pseudoconvexity. Every differentiable
+G-convex function is pseudoconvex (so its stationary points are global minima),
+and for twice-differentiable functions $\varphi$ is G-convex iff there is a
+function $\rho(x) \ge 0$ making the *augmented Hessian*
+$H(x;\rho) = \nabla^2\varphi(x) + \rho(x)\,\nabla\varphi(x)\nabla\varphi(x)^T$
+positive semidefinite over $C$ (a result tracing to Fenchel). The smallest
+admissible $\rho$, $\rho_0(x)$, is obtained from a Rayleigh-quotient style
+supremum restricted to the subspace orthogonal to $\nabla\varphi$.
+
+** Least Convexifying Transformation
+
+Among all $G$ that convexify $\varphi$, there is a *least convexifying
+transformation* $G^*$ (unique up to an increasing affine map), introduced by
+Debreu in the economics of concave utility. $G^*$ matters because it yields the
+*tightest* relaxation of the form below: any other convexifier $G$ differs from
+$G^*$ by a convex increasing reparametrization, which can only loosen the outer
+approximation. For a merely pseudoconvex $\varphi$ (nowhere locally convex),
+$G^*$ is strictly convex on the whole image. Convenient calculus rules let $G^*$
+propagate through composition: if $\varphi$ is $G^*$-convex and $f$ is increasing,
+then $f(\varphi)$ is least-convexified by $G^*(f^{-1})$, and affine inner maps
+preserve $G^*$.
+
+** Relaxation via Transformation
+
+The practical payoff is an outer approximation of the intermediate set
+$\Phi = \{(x,t) \in C \times I : \varphi(x) \le t\}$ that arises when an auxiliary
+variable $t$ is introduced for a sub-expression during factorable decomposition
+(see [[file:../concepts/expression-dag-and-ad.org][Expression DAG and AD]] and
+[[file:../methods/auxiliary-variable-reformulation.org][Auxiliary Variable Reformulation]]).
+Because $G$ is increasing, $\Phi = \{G(\varphi(x)) \le G(t)\}$; replacing the
+nonconcave $G(t)$ by a concave overestimator $\bar{G}(t)$ — tightest when
+$\bar{G} = \mathrm{conc}_I\,G$ — gives the convex relaxation
+$\tilde{\Phi} = \{(x,t) : G(\varphi(x)) \le \bar{G}(t)\}$. The induced convex
+underestimator is $\tilde{\varphi}^G(x) = \bar{G}^{-1}(G(\varphi(x)))$. Choosing
+$G = G^*$ with $\bar{G} = \mathrm{conc}_I\,G^*$ is provably the tightest
+relaxation of this form.
+
+A subtle and important caveat (Proposition 9 of citep:khajavirad2012): when the
+outer function $f$ in a composition $h = f(\varphi)$ is *convex* (or $f$ concave
+and $G$ convex), the recursive factorable outer-approximation already captures the
+G-convexity automatically — detecting $\tilde{G}$-convexity of the composite buys
+nothing. The transformation approach only adds strength where the standard
+recursive decomposition leaves a gap, e.g. nonconvex outer compositions,
+signomials, and log-concave forms.
+
+** Application Classes
+
+- *Signomials* (sums of $\prod_k x_k^{a_k}$ terms): the paper derives the
+  tightest term-wise transforming functions and a new overestimator; reported
+  gap reductions versus a conventional factorable scheme are large (in one
+  example a 99.72% reduction in total gap).
+- *Products and ratios of convex/concave functions*: a broad class of composite
+  intermediates is shown G-convex/G-concave with explicit transforming functions.
+- *Log-concave functions*: sums of log-concave terms (e.g. logistic-type
+  expressions) admit much tighter relaxations than recursive factorable
+  decomposition.
+
+** Effect on Branch-and-Bound
+
+Adding G-convexity cuts to a factorable relaxation tightens the root gap and
+shrinks the search tree. In the paper's Example 8 (a sum of two log-concave
+functions maximized over a box), BARON 9.3 needed 99 nodes with the standard
+factorable relaxation but only 11 with the G-convexity relaxation — a 99.83%
+reduction in the root-node gap and a 90% reduction in total nodes. Crucially for
+LP-based spatial solvers (see [[file:../methods/spatial-branch-and-bound.org][Spatial Branch and Bound]]),
+once a G-convex sub-expression is recognized its gradient supplies a valid
+supporting-hyperplane cut, so the more complex functional form of $\tilde{\varphi}^G$
+is no obstacle: it enters the LP relaxation as a linear cut rather than a
+nonlinear convex constraint.
+
+** Relevance to discopt
+
+discopt's [[file:../concepts/convexity-detection.org][Convexity Detection]] is
+currently DCP- and eigenvalue-based, classifying sub-expressions as
+convex/concave/affine/unknown on the
+[[file:../concepts/expression-dag-and-ad.org][expression DAG]]. G-convexity is a
+strictly larger class than DCP-convex, and recognizing it on intermediate
+expressions is a concrete route to tighter per-node
+[[file:../concepts/convex-relaxations.org][convex relaxations]] than
+[[file:../methods/mccormick-relaxations.org][McCormick]] or
+[[file:../methods/alphabb-underestimators.org][alphaBB]] alone — directly relevant
+to certifying more MINLPLib instances soundly, since a tighter valid lower bound
+closes more gaps without ever risking an invalid dual bound. The supporting-cut
+formulation maps naturally onto discopt's LP-relaxation node bounding.

--- a/.crucible/wiki/concepts/convexity-detection.org
+++ b/.crucible/wiki/concepts/convexity-detection.org
@@ -1,10 +1,10 @@
 #+TITLE: Convexity Detection
-#+FILETAGS: :concept:convexity:dcp:classification:optimization:
+#+FILETAGS: :concept:convexity:dcp:classification:optimization:generalized-convexity:
 
 * Convexity Detection
 :PROPERTIES:
 :ARTICLE_TYPE: concept
-:SOURCE_KEYS: adjiman1998 grant2006
+:SOURCE_KEYS: adjiman1998 grant2006 khajavirad2012
 :STATUS: draft
 :CREATED: 2026-04-04
 :END:
@@ -41,3 +41,16 @@ recognizing patterns like exp(affine), sum_of_convex, x**2, and others. When the
 model is detected as convex, the solver auto-selects NLP-BB (which requires
 convexity for valid lower bounds). When convexity cannot be verified, spatial B&B
 with convex relaxations is used instead.
+
+** Generalized Convexity (G-convexity)
+
+DCP and eigenvalue tests certify ordinary convexity. A strictly larger class,
+*convex-transformable* (G-convex) functions, becomes convex after a monotone
+univariate transformation $G$ and still has the property that local minima are
+global. citet:khajavirad2012 show that recognizing G-convexity of intermediate
+sub-expressions yields convex relaxations provably tighter than the standard
+factorable scheme — large root-gap and node-count reductions in branch-and-bound,
+and the relaxation contributes a valid supporting-hyperplane cut usable directly
+in an LP-based node relaxation. This is a concrete avenue for discopt to tighten
+per-node bounds beyond DCP-convex recognition without ever risking an invalid
+dual bound. See [[file:convex-transformable-functions.org][Convex-Transformable (G-convex) Functions]].

--- a/.crucible/wiki/summaries/khajavirad-2012-convex-transformable.org
+++ b/.crucible/wiki/summaries/khajavirad-2012-convex-transformable.org
@@ -1,0 +1,70 @@
+#+TITLE: Summary — Relaxations of Factorable Functions with Convex-Transformable Intermediates (Khajavirad, Michalek, Sahinidis 2012)
+#+FILETAGS: :summary:convexity:generalized-convexity:convex-relaxation:factorable:global-optimization:baron:
+
+* Summary — Relaxations of Factorable Functions with Convex-Transformable Intermediates
+:PROPERTIES:
+:ARTICLE_TYPE: summary
+:SOURCE_KEYS: khajavirad2012
+:STATUS: draft
+:CREATED: 2026-06-16
+:END:
+
+citet:khajavirad2012 (Mathematical Programming, Ser. A, 2012) strengthen the
+standard factorable relaxations used in deterministic global optimization by
+exploiting *convex transformability* (G-convexity) of intermediate expressions.
+Rather than recursively decomposing a nonconvex function until every intermediate
+has a known convex/concave envelope, they outer-approximate richer
+sub-expressions after a monotone functional transformation, yielding relaxations
+that are provably tighter than the conventional scheme.
+
+** Key Contributions
+
+1. *Properties of G-convex functions* (Sect. 2): composition rules (scalar,
+   vector, affine) under which G-convexity is preserved; the equivalence to
+   pseudoconvexity and to positive-semidefiniteness of an augmented Hessian; and
+   the *least convexifying transformation* $G^*$, unique up to an increasing
+   affine map and strictly convex for merely pseudoconvex functions.
+2. *Convexification via transformation* (Sect. 3): the relaxation
+   $\tilde{\Phi} = \{(x,t): G(\varphi(x)) \le \mathrm{conc}_I\,G(t)\}$ of the
+   intermediate set $\{\varphi(x) \le t\}$, with a dominance theory
+   (Proposition 8) showing $G^*$ gives the tightest relaxation (Corollary 4), and
+   Proposition 9 characterizing exactly when recursive factorable decomposition
+   already captures the transformation (so it adds nothing) versus when it leaves
+   an exploitable gap.
+3. *Signomials* (Sect. 4): tightest term-wise transforming functions and a new
+   signomial overestimator, with theoretical and computational gap comparisons.
+4. *Products and ratios of convex/concave functions* (Sect. 5): generalization to
+   a large class of composite intermediates.
+5. *Log-concave functions* (Sect. 6): a further application class with large gap
+   reductions.
+6. *Integration into the factorable framework* (Sect. 7): an integrated
+   decomposition strategy and a branch-and-bound demonstration.
+
+** Headline Results
+
+- Transformation relaxations were consistently and often dramatically tighter
+  than a widely used factorable scheme (e.g. 99.72% total-gap reduction for one
+  signomial overestimation example).
+- In Example 8 (sum of two log-concave functions, box constraints), feeding
+  G-convexity cuts to BARON 9.3 cut the search from 99 nodes to 11 — a 99.83%
+  reduction in the root-node relaxation gap and a 90% reduction in total nodes —
+  with similar gains at tighter optimality tolerances.
+- For LP-based spatial branch-and-bound solvers, a recognized G-convex
+  sub-expression contributes a valid supporting-hyperplane cut (gradient of
+  $\tilde{\varphi}^G$), so the more complex convex form is not a barrier to use.
+
+** Significance
+
+The paper is "a step towards bridging the gap between generalized convexity and
+global optimization." Because G-convexity is a strictly larger class than
+DCP-convexity, recognizing it on intermediates is a principled way to obtain
+tighter *valid* lower bounds — exactly the lever that lets a spatial solver
+certify global optimality on more instances without ever compromising soundness.
+
+See [[file:../concepts/convex-transformable-functions.org][Convex-Transformable (G-convex) Functions]]
+for the concept article, and
+[[file:../concepts/convexity-detection.org][Convexity Detection]],
+[[file:../concepts/convex-relaxations.org][Convex Relaxations for Global Optimization]],
+[[file:../methods/mccormick-relaxations.org][McCormick Relaxations]], and
+[[file:../methods/spatial-branch-and-bound.org][Spatial Branch and Bound]] for
+context within the discopt knowledge base.

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -624,7 +624,7 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             // overshot by a batch of expensive strong-branch probes.
             let time_up = ctx
                 .deadline
-                .map_or(false, |d| std::time::Instant::now() >= d);
+                .is_some_and(|d| std::time::Instant::now() >= d);
             // Primal heuristic: round this fractional point so the reduce can
             // inject a feasible incumbent early and prune more of the tree.
             if ctx.opts.heuristics && !feasible && !time_up {

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -255,6 +255,18 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
     let mut slack_u = u_w[ns..].to_vec();
 
     let t_start = std::time::Instant::now();
+    // Absolute wall-clock deadline. The loop-top check below stops *dispatching*
+    // new batches once it passes, but a 64-node batch with strong branching can
+    // itself run several seconds, so a sub-second `time_limit_s` would overshoot
+    // by that whole batch. `solve_node` reads this deadline to drop each node's
+    // *optional* effort (strong branching, cover separation, rounding) once it is
+    // reached — leaving only the cheap LP solve that yields the node's valid
+    // bound — so the in-flight batch drains quickly instead of running to
+    // completion. Soundness is untouched: those steps only change branching
+    // choice / cut tightness / early incumbents, never a bound's validity.
+    let deadline = opts
+        .time_limit_s
+        .map(|tl| t_start + std::time::Duration::from_secs_f64(tl));
     'search: loop {
         if tm.is_finished() || tm.gap() <= opts.gap_tol {
             break;
@@ -332,6 +344,7 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
                 inc_snapshot: tm.incumbent().map(|(_, inc)| inc),
                 reliability: tm.get_reliability_threshold(),
                 pool_room: pool_sigs.len() < opts.max_pool_cuts,
+                deadline,
                 tm: &tm,
             };
             #[cfg(feature = "parallel")]
@@ -492,6 +505,11 @@ struct NodeCtx<'a> {
     reliability: u32,
     /// Whether the cut pool had room at batch start (gates separation work).
     pool_room: bool,
+    /// Absolute wall-clock deadline. Once passed, each node still computes its
+    /// (valid) LP bound but skips the optional rounding heuristic, cover
+    /// separation, and strong branching — none of which affect bound validity
+    /// or feasibility — so the in-flight batch drains quickly. `None` = no limit.
+    deadline: Option<std::time::Instant>,
     tm: &'a TreeManager,
 }
 
@@ -597,9 +615,19 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
                 .iter()
                 .enumerate()
                 .all(|(j, &it)| !it || frac(xs[j]) <= INT_TOL);
+            // Past the deadline, skip every optional per-node effort below. The
+            // LP bound (above) is already computed and valid; the heuristic,
+            // cover separation, and strong branching only sharpen branching /
+            // cuts / early incumbents, never the bound or feasibility. Dropping
+            // them lets the in-flight batch drain in cheap-LP time so the
+            // loop-top deadline check can actually fire instead of being
+            // overshot by a batch of expensive strong-branch probes.
+            let time_up = ctx
+                .deadline
+                .map_or(false, |d| std::time::Instant::now() >= d);
             // Primal heuristic: round this fractional point so the reduce can
             // inject a feasible incumbent early and prune more of the tree.
-            if ctx.opts.heuristics && !feasible {
+            if ctx.opts.heuristics && !feasible && !time_up {
                 out.incumbent = try_rounding(
                     &sol.x,
                     ctx.ns,
@@ -617,7 +645,7 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             // Node-level cover separation: a fractional node exposes violated
             // covers the root never sees. These are globally valid; the reduce
             // dedups them into the shared pool to tighten the whole tree.
-            if ctx.opts.node_cuts && !feasible && ctx.pool_room {
+            if ctx.opts.node_cuts && !feasible && ctx.pool_room && !time_up {
                 out.found_cuts = separate_cover(
                     &node_lp,
                     ctx.b_w,
@@ -633,7 +661,7 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             // Only the *choice* of variable changes, so this never affects
             // correctness — only the node count. The prunable check uses the
             // batch-start incumbent snapshot (an effort decision, not a bound).
-            if ctx.sb_active && !feasible {
+            if ctx.sb_active && !feasible && !time_up {
                 let node_bound = sol.obj + ctx.obj_const;
                 let prunable = ctx
                     .inc_snapshot

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -16,6 +16,7 @@ that fits the per-node call shape in :mod:`discopt.solver`.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Optional
 
@@ -25,6 +26,11 @@ from discopt._jax.discretization import DiscretizationState
 from discopt._jax.milp_relaxation import build_milp_relaxation
 from discopt._jax.term_classifier import NonlinearTerms, classify_nonlinear_terms
 from discopt.modeling.core import Model, VarType
+
+# When a per-node wall-clock budget is threaded through solve_at_node, no single
+# internal re-solve is handed less than this floor (keeps a node that straddles
+# the deadline from receiving a zero/negative budget the backend would reject).
+_SOLVE_DEADLINE_FLOOR_S = 0.05
 
 
 @dataclass
@@ -129,17 +135,33 @@ class MccormickLPRelaxer:
         if not int(milp._integrality.sum()):
             milp._integrality = None
 
-        res = milp.solve(time_limit=time_limit, backend=self._backend)
+        # The caller's ``time_limit`` is the budget for the WHOLE node, but this
+        # method re-solves the relaxation many times (the initial solve, up to
+        # 8+6 cut-separation rounds, and up to two HiGHS soundness re-verifies).
+        # Passing the same duration to each gave every re-solve the full budget,
+        # so one node could run (1 + rounds + verifies) x time_limit — e.g.
+        # du-opt's hard relaxation overshot a 2s budget to 7.3s wall, and the
+        # spatial B&B (one such node per step) blew a 25s limit out to ~75s.
+        # Convert the duration to a single deadline and hand each internal solve
+        # only the time that remains, so the node's TOTAL respects the budget.
+        _deadline = None if time_limit is None else time.perf_counter() + time_limit
+
+        def _remaining() -> Optional[float]:
+            if _deadline is None:
+                return None
+            return max(_deadline - time.perf_counter(), _SOLVE_DEADLINE_FLOOR_S)
+
+        res = milp.solve(time_limit=_remaining(), backend=self._backend)
 
         # On-demand separation of the exact multilinear hull for products with
         # more factors than the dense RLT cap (those carry only the loose
         # recursive chain). Every separated cut is a supporting hyperplane of the
         # convex/concave envelope, hence valid; adding them only tightens the
         # bound, so the loop is sound at any round.
-        res = self._separate_multilinear(milp, varmap, res, time_limit)
+        res = self._separate_multilinear(milp, varmap, res, _deadline)
         # Edge-concave / edge-convex quadratic blocks: tighten the joint
         # vertex-polyhedral envelope (cuts on the existing bilinear/square auxes).
-        res = self._separate_edge_concave(milp, varmap, res, time_limit)
+        res = self._separate_edge_concave(milp, varmap, res, _deadline)
 
         # Soundness guard: a floating-point simplex "infeasible" verdict is NOT
         # a proof that the relaxed feasible set is empty. The spatial-B&B driver
@@ -154,7 +176,7 @@ class MccormickLPRelaxer:
         # before trusting it; on disagreement adopt HiGHS's (valid) bound so the
         # node branches instead of being wrongly pruned.
         if res.status == "infeasible" and self._backend != "auto":
-            verify = milp.solve(time_limit=time_limit, backend="auto")
+            verify = milp.solve(time_limit=_remaining(), backend="auto")
             if verify.status != "infeasible":
                 res = verify
 
@@ -168,7 +190,7 @@ class MccormickLPRelaxer:
         # 2.55 (true optimum 6.06). Re-verify a non-optimal fast-backend result
         # with HiGHS and adopt it only if HiGHS converges to optimality.
         if res.status not in ("optimal", "infeasible") and self._backend != "auto":
-            verify = milp.solve(time_limit=time_limit, backend="auto")
+            verify = milp.solve(time_limit=_remaining(), backend="auto")
             if verify.status == "optimal":
                 res = verify
 
@@ -185,7 +207,7 @@ class MccormickLPRelaxer:
             x=x_orig,
         )
 
-    def _separate_multilinear(self, milp, varmap, res, time_limit):
+    def _separate_multilinear(self, milp, varmap, res, deadline):
         """Tighten products beyond the dense RLT cap by on-demand hull separation.
 
         For each multilinear/trilinear product with more factors than
@@ -233,6 +255,10 @@ class MccormickLPRelaxer:
                     milp._b_ub = np.concatenate([np.asarray(milp._b_ub), b])
 
             for _round in range(8):
+                # Stop separating once the node's wall-clock budget is spent;
+                # each round costs a full MILP re-solve.
+                if deadline is not None and time.perf_counter() >= deadline:
+                    break
                 x = np.asarray(res.x, dtype=np.float64)
                 rows: list[np.ndarray] = []
                 rhs: list[float] = []
@@ -260,7 +286,12 @@ class MccormickLPRelaxer:
                 if not rows:
                     break
                 _append(rows, rhs)
-                new_res = milp.solve(time_limit=time_limit, backend=self._backend)
+                _tl = (
+                    None
+                    if deadline is None
+                    else max(deadline - time.perf_counter(), _SOLVE_DEADLINE_FLOOR_S)
+                )
+                new_res = milp.solve(time_limit=_tl, backend=self._backend)
                 if new_res.status != "optimal" or new_res.objective is None:
                     break
                 res = new_res
@@ -268,7 +299,7 @@ class MccormickLPRelaxer:
         except Exception:
             return res
 
-    def _separate_edge_concave(self, milp, varmap, res, time_limit):
+    def _separate_edge_concave(self, milp, varmap, res, deadline):
         """Tighten edge-concave/edge-convex quadratic blocks by hull separation.
 
         Each block's vertex-hull supporting hyperplane gives a valid cut on the
@@ -338,6 +369,10 @@ class MccormickLPRelaxer:
                     milp._b_ub = np.concatenate([np.asarray(milp._b_ub), b])
 
             for _round in range(6):
+                # Stop separating once the node's wall-clock budget is spent;
+                # each round costs a full MILP re-solve.
+                if deadline is not None and time.perf_counter() >= deadline:
+                    break
                 x = np.asarray(res.x, dtype=np.float64)
                 rows, rhs = [], []
                 for blk, cols_sq, cols_bl in specs:
@@ -384,7 +419,12 @@ class MccormickLPRelaxer:
                 if not rows:
                     break
                 _append(rows, rhs)
-                new_res = milp.solve(time_limit=time_limit, backend=self._backend)
+                _tl = (
+                    None
+                    if deadline is None
+                    else max(deadline - time.perf_counter(), _SOLVE_DEADLINE_FLOOR_S)
+                )
+                new_res = milp.solve(time_limit=_tl, backend=self._backend)
                 if new_res.status != "optimal" or new_res.objective is None:
                     break
                 res = new_res

--- a/python/discopt/_jax/nlp_evaluator.py
+++ b/python/discopt/_jax/nlp_evaluator.py
@@ -168,7 +168,19 @@ class NLPEvaluator:
                 return jnp.concatenate(parts)
 
             self._cons_fn_jit = jax.jit(concat_constraints)
-            self._jac_fn_jit = jax.jit(jax.jacobian(concat_constraints, argnums=0))
+            # Dense constraint Jacobian via FORWARD-mode AD. ``jax.jacobian``
+            # defaults to reverse-mode (jacrev); its XLA codegen for the
+            # transpose of certain nonlinear graphs (e.g. fractional powers
+            # x**0.75 in MINLPLib's chakra) blows up super-linearly and a single
+            # compile can hang for >90s — long enough to starve the solver's
+            # own time-limit check, since the compile is an uninterruptible C
+            # call. Forward-mode (jacfwd) produces the identical matrix (AD mode
+            # never changes the value) and compiles the same case in ~0.2s. The
+            # heavy NLP-iteration Jacobian uses the sparse coloring path
+            # (evaluate_sparse_jacobian); this dense form backs FBBT linearity
+            # detection and the sparse fallback, where forward-mode's robust
+            # compile matters far more than its O(n)-vs-O(m) runtime constant.
+            self._jac_fn_jit = jax.jit(jax.jacfwd(concat_constraints, argnums=0))
         else:
             self._constraint_flat_sizes = np.zeros(0, dtype=np.intp)
             self._n_constraints = 0

--- a/python/discopt/_jax/nlp_evaluator.py
+++ b/python/discopt/_jax/nlp_evaluator.py
@@ -196,11 +196,16 @@ class NLPEvaluator:
         gn_obj_hess_fn = self._build_gauss_newton_obj_hessian(model) if gauss_newton else None
         self._gauss_newton = gn_obj_hess_fn is not None
 
-        # Objective Hessian ∇²f(x).
+        # Objective Hessian ∇²f(x). Forward-over-forward for the same compile-
+        # robustness reason as the Lagrangian Hessian below: the default
+        # ``jax.hessian`` reverse inner pass can blow up XLA codegen on large
+        # nonlinear objective graphs. Identical values, faster/robuster compile.
         if gn_obj_hess_fn is not None:
             self._hess_fn_jit = jax.jit(gn_obj_hess_fn)
         else:
-            self._hess_fn_jit = jax.jit(jax.hessian(obj_fn, argnums=0))
+            self._hess_fn_jit = jax.jit(
+                jax.jacfwd(jax.jacfwd(obj_fn, argnums=0), argnums=0)
+            )
 
         # Lagrangian Hessian: obj_factor * ∇²f(x) + Σᵢ λᵢ ∇²gᵢ(x).
         if gn_obj_hess_fn is not None:
@@ -230,7 +235,21 @@ class NLPEvaluator:
                     L = L + jnp.dot(lam, cons_fn_jit(x, params))
                 return L
 
-            self._lagrangian_hess_fn_jit = jax.jit(jax.hessian(lagrangian, argnums=0))
+            # Dense Lagrangian Hessian via FORWARD-over-FORWARD AD. ``jax.hessian``
+            # is ``jacfwd(jacrev(...))``; its inner reverse pass hits the same
+            # super-linear XLA transpose codegen documented for the constraint
+            # Jacobian above — on a large lifted DAG (e.g. MINLPLib's du-opt, 21
+            # vars but a heavy constraint graph) that single compile runs ~12s,
+            # and because it is an uninterruptible C call it blows straight past
+            # the solver's per-node time budget. ``jacfwd(jacfwd(...))`` produces
+            # the identical matrix (AD mode never changes the value) and compiles
+            # it in ~half the time. This dense form is only taken when the sparse
+            # colored-HVP path declines (small ``n``, or a dense Hessian), so the
+            # O(n^2)-vs-O(n) forward-mode runtime constant is immaterial while the
+            # compile robustness is what matters.
+            self._lagrangian_hess_fn_jit = jax.jit(
+                jax.jacfwd(jax.jacfwd(lagrangian, argnums=0), argnums=0)
+            )
 
             # Matrix-free Lagrangian Hessian-vector product (forward-over-reverse).
             # Used by the compressed sparse-Hessian path to recover the block-

--- a/python/discopt/_jax/nlp_evaluator.py
+++ b/python/discopt/_jax/nlp_evaluator.py
@@ -203,9 +203,7 @@ class NLPEvaluator:
         if gn_obj_hess_fn is not None:
             self._hess_fn_jit = jax.jit(gn_obj_hess_fn)
         else:
-            self._hess_fn_jit = jax.jit(
-                jax.jacfwd(jax.jacfwd(obj_fn, argnums=0), argnums=0)
-            )
+            self._hess_fn_jit = jax.jit(jax.jacfwd(jax.jacfwd(obj_fn, argnums=0), argnums=0))
 
         # Lagrangian Hessian: obj_factor * ∇²f(x) + Σᵢ λᵢ ∇²gᵢ(x).
         if gn_obj_hess_fn is not None:

--- a/python/discopt/_jax/objective_epigraph.py
+++ b/python/discopt/_jax/objective_epigraph.py
@@ -1,0 +1,341 @@
+"""Objective-defining-equality relaxation (the SUSPECT "objective constraint").
+
+Many MINLP models — especially MINLPLib / GAMS instances — are written as
+
+    minimize  z
+    s.t.      z = g(x)            (a single equality "defining" the objective)
+              other constraints not involving z
+
+where ``z`` is a *free* scalar variable that appears in exactly one
+constraint, affinely. When ``g`` is convex this is a convex problem in
+disguise, yet the equality ``z = g(x)`` has a *non-convex* feasible set
+(an equality is convex only when its body is affine), so a syntactic
+convexity check correctly rejects it and the solver falls back to
+nonconvex spatial branch-and-bound — with no valid lower bound and an
+erratic NLP multistart incumbent (issue: du-opt).
+
+The classical fix (BARON, SCIP, and SUSPECT all do this internally) is to
+relax the *defining equality* to the inequality the objective binds
+against:
+
+    minimize z   s.t.  z >= g(x)        (for ``min``, ``z`` free below)
+
+This relaxation is **exact at the optimum**: at any optimum ``(z*, x*)``
+of the relaxed problem with ``z* > g(x*)`` we could lower ``z*`` to
+``g(x*)`` — still feasible (``z >= g`` holds), the other constraints do
+not involve ``z``, and the objective strictly improves — contradicting
+optimality. Hence ``z* = g(x*)``: the relaxed optimum is feasible for the
+original equality and has the same objective value. The argument needs no
+assumption on the curvature of ``g`` (it is exact for convex *and*
+nonconvex ``g``); convexity only governs whether the *relaxed* constraint
+is itself convex and therefore unlocks the convex solve path.
+
+Soundness invariant
+-------------------
+The transform fires only when the rewrite is provably exact *and* turns
+the constraint convex:
+
+1. The objective is exactly a single scalar variable ``z`` (a maximize or
+   minimize of ``z``).
+2. ``z`` is free in the binding direction (``lb <= -1e15`` for ``min``,
+   ``ub >= 1e15`` for ``max``) so the objective can always drive the
+   inequality tight.
+3. ``z`` appears in exactly one constraint, which is an equality, and in
+   that constraint ``z`` appears *affinely* with a constant nonzero
+   coefficient (a structural proof, not sampling — see
+   :func:`_affine_coeff`). ``z`` appears in no other constraint.
+4. The body is genuinely curved (not affine — an affine defining equality
+   is better handled by presolve's singleton-equality substitution) and
+   the relaxed inequality is convex by the syntactic curvature walker.
+
+Every structural analyzer here abstains *conservatively*: an
+unrecognised node makes occurrence detection report "might occur" and the
+affine-coefficient analyzer return ``None``. Both directions cause the
+transform to skip, never to fire on an unproven model. The transform is
+therefore general (it keys on structure, not on any single instance) and
+can only ever leave the optimum unchanged.
+
+References
+----------
+Ceccon, Siirola, Misener (2020), "SUSPECT," TOP — the "objective
+  constraint" detection this mirrors.
+Tawarmalani, Sahinidis (2005), "A polyhedral branch-and-cut approach to
+  global optimization," Math. Prog. — BARON's epigraph handling.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Constraint,
+    FunctionCall,
+    IndexExpression,
+    ObjectiveSense,
+    Parameter,
+    SumExpression,
+    SumOverExpression,
+    UnaryOp,
+    Variable,
+)
+
+# A bound is treated as "free" in the binding direction when its magnitude
+# exceeds this threshold. Mirrors the solver's own large-bound handling
+# (declared ±1e20 free variables in GAMS imports).
+_FREE_BOUND = 1e15
+
+
+def _collect_var_names(expr) -> Optional[set]:
+    """Return the complete set of variable names referenced by ``expr``.
+
+    Returns ``None`` if an unrecognised / opaque node is encountered — the
+    caller must then treat the variable of interest as *possibly* present
+    (the sound direction for an occurrence test).
+    """
+    if isinstance(expr, Variable):
+        return {expr.name}
+    if isinstance(expr, (Constant, Parameter)):
+        return set()
+    if isinstance(expr, IndexExpression):
+        return _collect_var_names(expr.base)
+    if isinstance(expr, UnaryOp):
+        return _collect_var_names(expr.operand)
+    if isinstance(expr, BinaryOp):
+        left = _collect_var_names(expr.left)
+        right = _collect_var_names(expr.right)
+        if left is None or right is None:
+            return None
+        return left | right
+    if isinstance(expr, FunctionCall):
+        acc: set = set()
+        for a in expr.args:
+            names = _collect_var_names(a)
+            if names is None:
+                return None
+            acc |= names
+        return acc
+    if isinstance(expr, SumExpression):
+        return _collect_var_names(expr.operand)
+    if isinstance(expr, SumOverExpression):
+        acc = set()
+        for t in expr.terms:
+            names = _collect_var_names(t)
+            if names is None:
+                return None
+            acc |= names
+        return acc
+    # Unknown / opaque node (CustomCall, MatMul, ...): cannot prove the
+    # variable is absent — abstain.
+    return None
+
+
+def _occurs(expr, varname: str) -> bool:
+    """True when ``varname`` *might* appear in ``expr`` (conservative)."""
+    names = _collect_var_names(expr)
+    if names is None:
+        return True  # opaque node — assume it might occur (sound)
+    return varname in names
+
+
+def _affine_coeff(expr, varname: str) -> Optional[float]:
+    """Constant coefficient of ``varname`` in ``expr``, or ``None``.
+
+    Returns a float ``a`` iff ``expr`` depends on ``varname`` *only*
+    affinely, i.e. ``expr == a * <varname> + (terms free of varname)`` with
+    ``a`` a compile-time constant (``0.0`` means it does not appear). Returns
+    ``None`` whenever the dependence is nonlinear, indexed, or routed
+    through an unanalyzable node — a conservative abstention.
+    """
+    if isinstance(expr, Variable):
+        return 1.0 if expr.name == varname else 0.0
+    if isinstance(expr, (Constant, Parameter)):
+        return 0.0
+    if isinstance(expr, IndexExpression):
+        # An indexed reference to the target variable means the target is an
+        # array element; the single-free-scalar pattern does not apply.
+        if _occurs(expr.base, varname):
+            return None
+        return 0.0
+    if isinstance(expr, UnaryOp):
+        inner = _affine_coeff(expr.operand, varname)
+        if inner is None:
+            return None
+        if expr.op in ("-", "neg"):
+            return -inner
+        if expr.op in ("+", "pos"):
+            return inner
+        # abs / other unary atoms are nonlinear in their argument
+        return None if _occurs(expr.operand, varname) else 0.0
+    if isinstance(expr, BinaryOp):
+        op = expr.op
+        if op == "+":
+            cl = _affine_coeff(expr.left, varname)
+            cr = _affine_coeff(expr.right, varname)
+            if cl is None or cr is None:
+                return None
+            return cl + cr
+        if op == "-":
+            cl = _affine_coeff(expr.left, varname)
+            cr = _affine_coeff(expr.right, varname)
+            if cl is None or cr is None:
+                return None
+            return cl - cr
+        if op == "*":
+            lo = _occurs(expr.left, varname)
+            ro = _occurs(expr.right, varname)
+            if lo and ro:
+                return None  # var on both sides -> nonlinear
+            if not lo and not ro:
+                return 0.0
+            # exactly one side carries the var; the other must be a constant
+            if lo:
+                k = _const_value(expr.right)
+                inner = _affine_coeff(expr.left, varname)
+            else:
+                k = _const_value(expr.left)
+                inner = _affine_coeff(expr.right, varname)
+            if k is None or inner is None:
+                return None
+            return k * inner
+        if op == "/":
+            # var only allowed in the numerator, denominator must be constant
+            if _occurs(expr.right, varname):
+                return None
+            k = _const_value(expr.right)
+            inner = _affine_coeff(expr.left, varname)
+            if k is None or inner is None or k == 0.0:
+                return None
+            return inner / k
+        if op == "**":
+            # var under a power is nonlinear; only var-free bases are fine
+            if _occurs(expr.left, varname) or _occurs(expr.right, varname):
+                return None
+            return 0.0
+        return None if (_occurs(expr.left, varname) or _occurs(expr.right, varname)) else 0.0
+    # FunctionCall / Sum / opaque: var-free -> 0, otherwise nonlinear/unknown.
+    return None if _occurs(expr, varname) else 0.0
+
+
+def _const_value(expr) -> Optional[float]:
+    """Return a scalar constant value for ``expr`` if it is one, else ``None``."""
+    if isinstance(expr, Constant):
+        try:
+            v = np.asarray(expr.value, dtype=np.float64)
+        except (TypeError, ValueError):
+            return None
+        if v.size == 1:
+            return float(v.reshape(-1)[0])
+    if isinstance(expr, Parameter):
+        try:
+            v = np.asarray(expr.value, dtype=np.float64)
+        except (TypeError, ValueError):
+            return None
+        if v.size == 1:
+            return float(v.reshape(-1)[0])
+    return None
+
+
+def relax_objective_defining_equality(model):
+    """Relax an objective-defining equality to its (exact) binding inequality.
+
+    Returns ``(model, changed)``. When the structural pattern in the module
+    docstring holds and the relaxed inequality is convex, returns a shallow
+    copy of ``model`` with the defining equality's ``sense`` flipped to the
+    binding inequality; otherwise returns ``(model, False)`` unchanged.
+
+    The returned model never aliases the caller's constraint objects: a new
+    ``Constraint`` replaces the rewritten one in a fresh ``_constraints``
+    list on a shallow-copied ``Model``.
+    """
+    import copy as _copy
+
+    obj = getattr(model, "_objective", None)
+    if obj is None:
+        return model, False
+    oe = obj.expression
+    # (1) objective must be exactly a single scalar variable z.
+    if not isinstance(oe, Variable) or oe.size != 1:
+        return model, False
+    z = oe
+    zname = z.name
+
+    is_min = obj.sense == ObjectiveSense.MINIMIZE
+
+    # (2) z must be free in the binding direction.
+    try:
+        z_lb = float(np.asarray(z.lb).reshape(-1)[0])
+        z_ub = float(np.asarray(z.ub).reshape(-1)[0])
+    except (TypeError, ValueError, IndexError):
+        return model, False
+    if is_min and z_lb > -_FREE_BOUND:
+        return model, False
+    if (not is_min) and z_ub < _FREE_BOUND:
+        return model, False
+
+    # (3) z appears in exactly one constraint, an equality, affinely.
+    defining_idx = None
+    coeff = None
+    for ci, c in enumerate(model._constraints):
+        if not isinstance(c, Constraint):
+            # opaque constraint type (SOS / disjunction); if it might touch
+            # z we cannot prove sole occurrence -> abstain.
+            body = getattr(c, "body", None)
+            if body is not None and _occurs(body, zname):
+                return model, False
+            continue
+        if not _occurs(c.body, zname):
+            continue
+        # z occurs in this constraint.
+        if defining_idx is not None:
+            return model, False  # second occurrence -> not a sole-defining var
+        if c.sense != "==":
+            return model, False  # z occurs in a non-equality -> abstain
+        a = _affine_coeff(c.body, zname)
+        if a is None or a == 0.0:
+            return model, False
+        defining_idx = ci
+        coeff = a
+    if defining_idx is None:
+        return model, False
+
+    # (4) Determine the binding inequality sense and require it convex and
+    #     genuinely curved (skip affine bodies — presolve substitution is
+    #     better there).
+    defining = model._constraints[defining_idx]
+    if is_min:
+        relaxed_sense = ">=" if coeff > 0 else "<="
+    else:
+        relaxed_sense = "<=" if coeff > 0 else ">="
+
+    from discopt._jax.convexity import Curvature, classify_expr
+
+    try:
+        curv = classify_expr(defining.body, model)
+    except Exception:
+        return model, False
+    if curv == Curvature.AFFINE:
+        return model, False
+    relaxed_is_convex = (relaxed_sense == ">=" and curv == Curvature.CONCAVE) or (
+        relaxed_sense == "<=" and curv == Curvature.CONVEX
+    )
+    if not relaxed_is_convex:
+        return model, False
+
+    # Build the rewritten model without mutating the caller's objects.
+    new_constraints = list(model._constraints)
+    new_constraints[defining_idx] = Constraint(
+        body=defining.body,
+        sense=relaxed_sense,
+        rhs=defining.rhs,
+        name=defining.name,
+    )
+    new_model = _copy.copy(model)
+    new_model._constraints = new_constraints
+    return new_model, True
+
+
+__all__ = ["relax_objective_defining_equality"]

--- a/python/discopt/_jax/sparsity.py
+++ b/python/discopt/_jax/sparsity.py
@@ -95,11 +95,27 @@ def _collect_variable_indices(expr: Expression, model: Model) -> set[int]:
         return set()
     if isinstance(expr, IndexExpression):
         if isinstance(expr.base, Variable):
-            offset = _var_offset(expr.base, model)
+            base = expr.base
+            offset = _var_offset(base, model)
             idx = expr.index
             if isinstance(idx, (int, np.integer)):
                 return {offset + int(idx)}
-            return set(range(offset, offset + expr.base.size))
+            # Resolve a multi-dimensional / slice / fancy index (e.g. the 2-D
+            # ``a0[i, j]`` of a collocation variable) to the exact flat element
+            # set, rather than returning the whole variable. Over-reporting here
+            # is amplified by the Hessian-pair collection below: a squared
+            # element ``(a0[i, j] - c)**2`` would otherwise be treated as a dense
+            # block over EVERY entry of ``a0``, spuriously densifying a genuinely
+            # sparse (arrowhead) Hessian and forcing it off the colored-HVP path.
+            shape = base.shape if base.shape else (base.size,)
+            try:
+                flat = np.arange(base.size).reshape(shape)
+                sel = flat[idx]
+                return {offset + int(k) for k in np.atleast_1d(np.asarray(sel)).ravel()}
+            except (IndexError, ValueError, TypeError):
+                # Anything we cannot resolve statically: fall back to the whole
+                # variable (a sound over-approximation for sparsity).
+                return set(range(offset, offset + base.size))
         return _collect_variable_indices(expr.base, model)
     if isinstance(expr, BinaryOp):
         left = _collect_variable_indices(expr.left, model)
@@ -130,6 +146,45 @@ def _collect_variable_indices(expr: Expression, model: Model) -> set[int]:
     return set()
 
 
+def _expr_is_scalar(expr: Expression, model: Model) -> bool:
+    """Best-effort: does ``expr`` evaluate to a single scalar (not an array)?
+
+    This distinguishes a scalar reduction like ``sqr(Σ aₖ xₖ)`` — whose Hessian
+    is a DENSE block over every base variable — from an element-wise array power
+    like ``x**2`` (``x`` a vector), whose Hessian is diagonal. Getting this wrong
+    is only ever an efficiency cost in the SAFE direction: an unrecognized
+    construct defaults to scalar (→ a denser, still-sound Hessian pattern), never
+    to a too-small one that would corrupt the colored-HVP sparse-Hessian values.
+    """
+    if isinstance(expr, Variable):
+        return expr.size == 1
+    if isinstance(expr, Parameter):
+        return int(getattr(expr, "size", 1)) == 1
+    if isinstance(expr, Constant):
+        return np.size(getattr(expr, "value", 0)) == 1
+    if isinstance(expr, IndexExpression):
+        idx = expr.index
+        if isinstance(idx, (int, np.integer)):
+            return True
+        # A tuple of plain integers selects one element of an N-D array.
+        if isinstance(idx, tuple) and all(isinstance(k, (int, np.integer)) for k in idx):
+            return True
+        # Slice / fancy index → still an array.
+        return False
+    if isinstance(expr, (SumExpression, SumOverExpression)):
+        return True
+    if isinstance(expr, UnaryOp):
+        return _expr_is_scalar(expr.operand, model)
+    if isinstance(expr, FunctionCall):
+        return all(_expr_is_scalar(a, model) for a in expr.args)
+    if isinstance(expr, BinaryOp):
+        # ``+ - * / **`` broadcast: scalar only when BOTH sides are scalar.
+        return _expr_is_scalar(expr.left, model) and _expr_is_scalar(expr.right, model)
+    # MatMul / anything unrecognized: assume scalar so the Hessian block is the
+    # dense (sound) over-approximation rather than a potentially-too-small one.
+    return True
+
+
 def _collect_nonlinear_pairs(expr: Expression, model: Model) -> set[tuple[int, int]]:
     """Collect pairs of variable indices that interact nonlinearly.
 
@@ -152,8 +207,25 @@ def _collect_nonlinear_pairs(expr: Expression, model: Model) -> set[tuple[int, i
                     pairs.add((a, b))
 
         if expr.op == "**" and left_vars:
-            for i in left_vars:
-                pairs.add((i, i))
+            # A power g(x)**p whose base g is a SCALAR mixing several variables
+            # has Hessian d²/dxᵢdxⱼ (g^p) = p(p-1) g^(p-2) gᵢ gⱼ + p g^(p-1) gᵢⱼ,
+            # whose first term couples EVERY pair (i, j) in the base (gᵢ gⱼ ≠ 0 in
+            # general). Recording only the diagonal — as this did before — under-
+            # reports the Hessian for squared linear forms like sqr(Σ aₖ xₖ) (e.g.
+            # MINLPLib's du-opt is built entirely from these), whose true Hessian
+            # is the dense 2aaᵀ; a too-small pattern would make the colored-HVP
+            # sparse path recover a diagonal approximation of a dense matrix.
+            # An ELEMENT-WISE array power like ``x**2`` (x a vector), by contrast,
+            # has a genuinely diagonal Hessian — so emit the dense block only when
+            # the base is scalar; otherwise keep the per-variable diagonal.
+            if len(left_vars) > 1 and _expr_is_scalar(expr.left, model):
+                for i in left_vars:
+                    for j in left_vars:
+                        a, b = (i, j) if i <= j else (j, i)
+                        pairs.add((a, b))
+            else:
+                for i in left_vars:
+                    pairs.add((i, i))
 
         pairs |= _collect_nonlinear_pairs(expr.left, model)
         pairs |= _collect_nonlinear_pairs(expr.right, model)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1707,6 +1707,25 @@ def solve_model(
 
     model = reformulate_gdp(model, method=gdp_method)
 
+    # --- Objective-defining-equality relaxation (the SUSPECT "objective
+    # constraint"). When the model is `min/max z` with z a free scalar that
+    # appears only in one equality `z = g(x)` (affinely), relax that equality
+    # to the inequality the objective binds against (`z >= g(x)` for min). The
+    # rewrite is EXACT at the optimum — lowering z to g(x) is always feasible
+    # and improves the objective, so the relaxed optimum satisfies the original
+    # equality — and turns a convex-defining equality (non-convex *as an
+    # equality*) into a convex inequality, unlocking the convex solve path with
+    # a valid lower bound instead of erratic nonconvex NLP-BB (issue: du-opt).
+    # The transform is structurally gated and abstains conservatively, so it is
+    # general and never alters the optimum. Skipped when streaming B&B callbacks
+    # are attached so node/incumbent indices stay aligned with the user's model.
+    if not _has_bb_callbacks:
+        from discopt._jax.objective_epigraph import relax_objective_defining_equality
+
+        model, _epi_changed = relax_objective_defining_equality(model)
+        if _epi_changed:
+            logger.debug("relaxed objective-defining equality to binding inequality")
+
     # --- Factorable reformulation: clear sign-definite denominators and lift
     # mixed repeated-factor products (e.g. x*x*y) into bilinear form via
     # monomial aux variables, so terms the relaxation pipeline would otherwise

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -749,8 +749,15 @@ def _solve_root_node_multistart(
     """
     starting_points = _generate_starting_points(node_lb, node_ub, n_random=n_random)
 
+    cl = cu = None
+    if constraint_bounds:
+        cl = [b[0] for b in constraint_bounds]
+        cu = [b[1] for b in constraint_bounds]
+
     best_result = None
+    best_feasible = False
     best_obj = np.inf
+    last_result = None
 
     for x0 in starting_points:
         nlp_result = _solve_node_nlp(
@@ -762,15 +769,31 @@ def _solve_root_node_multistart(
             options,
             nlp_solver=nlp_solver,
         )
-        if nlp_result.status in (SolveStatus.OPTIMAL, SolveStatus.ITERATION_LIMIT):
-            if nlp_result.objective < best_obj:
-                best_obj = nlp_result.objective
-                best_result = nlp_result
+        last_result = nlp_result
+        if nlp_result.status not in (SolveStatus.OPTIMAL, SolveStatus.ITERATION_LIMIT):
+            continue
+        feasible = cl is None or _check_constraint_feasibility(evaluator, nlp_result.x, cl, cu)
+        obj = nlp_result.objective
+        # Prefer a constraint-FEASIBLE iterate over any infeasible one; within the
+        # same feasibility class, prefer the lower objective. An interior-point
+        # solver can hit ITERATION_LIMIT at a low-objective but constraint-
+        # infeasible point (e.g. division constraints from an interior start).
+        # Selecting that over a feasible higher-objective iterate would mark the
+        # root constraint-infeasible and unsoundly fathom the whole tree as
+        # "infeasible" on a feasible problem.
+        if (
+            best_result is None
+            or (feasible and not best_feasible)
+            or (feasible == best_feasible and obj < best_obj)
+        ):
+            best_result = nlp_result
+            best_feasible = feasible
+            best_obj = obj
 
     if best_result is not None:
         return best_result
     # All failed — return the last result
-    return nlp_result
+    return last_result
 
 
 def _invoke_pre_import_callbacks(
@@ -4010,6 +4033,18 @@ def _solve_nlp_bb(
     # --- Feasibility pump flag ---
     _fp_ran = False
 
+    # --- Soundness: distinguish a PROVEN-infeasible fathom from a merely
+    # UNCONVERGED one. A node whose NLP returns SolveStatus.INFEASIBLE (or whose
+    # FBBT interval arithmetic proves the box empty) is a valid infeasibility
+    # certificate. A node whose NLP merely hit ITERATION_LIMIT / ERROR with a
+    # constraint-violating iterate is NON-convergence, NOT a proof — an
+    # interior-point method can stall at an infeasible point on a perfectly
+    # feasible convex NLP (e.g. division constraints 40/x7 <= x5 need ~5k iters
+    # to reach feasibility; the 3k default stalls). If the tree later empties
+    # with no incumbent, an "infeasible" verdict is only sound when NO node was
+    # fathomed on non-convergence; otherwise feasibility is genuinely UNKNOWN.
+    _unconverged_fathom = False
+
     # --- NLP-BB loop ---
     # POUNCE batches node NLPs via solve_nlp_batch (Phase A, discopt#97); it is
     # a true KKT solver, so its converged objective is a reliable lower bound
@@ -4105,6 +4140,13 @@ def _solve_nlp_bb(
                             evaluator, result_sols[i], cl_list, cu_list
                         ):
                             result_lbs[i] = _INFEASIBILITY_SENTINEL
+                            # Batch IPM returned an objective (not a clean
+                            # infeasibility verdict) but the iterate violates
+                            # constraints: a stall, not a proof. Untrusted nodes
+                            # are unconverged by definition; tainting on any
+                            # constraint-infeasible batch fathom is conservative
+                            # and sound.
+                            _unconverged_fathom = True
             # For nonconvex: NLP objective is NOT a valid lower bound.
             # Keep it for integer-feasible nodes (incumbent candidates),
             # but reset to -inf for others so we don't prune incorrectly.
@@ -4176,6 +4218,11 @@ def _solve_nlp_bb(
                         evaluator, nlp_result.x, cl_list, cu_list
                     ):
                         nlp_lb = _INFEASIBILITY_SENTINEL
+                        # The solver returned OPTIMAL/ITERATION_LIMIT yet the
+                        # iterate violates constraints — this is non-convergence
+                        # (a stall), not a SolveStatus.INFEASIBLE proof. Fathoming
+                        # it cannot certify global infeasibility.
+                        _unconverged_fathom = True
                     # For nonconvex: reset non-integer-feasible to -inf
                     elif not _model_is_convex:
                         sol_is_int_feas = True
@@ -4197,6 +4244,12 @@ def _solve_nlp_bb(
                     result_feas[i] = False
                 else:
                     result_lbs[i] = _INFEASIBILITY_SENTINEL
+                    # A clean SolveStatus.INFEASIBLE is a valid infeasibility
+                    # certificate (for a convex node); ERROR/TIME_LIMIT/UNBOUNDED
+                    # are not — they are solver failures that must not masquerade
+                    # as a proof of global infeasibility.
+                    if nlp_result.status != SolveStatus.INFEASIBLE:
+                        _unconverged_fathom = True
                     lb_c = np.clip(node_lb, -_SPC, _SPC)
                     ub_c = np.clip(node_ub, -_SPC, _SPC)
                     result_sols[i] = 0.5 * (lb_c + ub_c)
@@ -4418,9 +4471,21 @@ def _solve_nlp_bb(
         elif wall_time >= time_limit:
             status = "time_limit"
             _gap_certified = False
+        elif _unconverged_fathom:
+            # Tree exhausted with no incumbent, but at least one node was fathomed
+            # on NLP NON-convergence (a stall), not a valid infeasibility
+            # certificate. We cannot soundly claim the problem is infeasible — its
+            # feasibility is genuinely undetermined. Report "unknown" rather than a
+            # false "infeasible" (the worst-class error: a feasible problem
+            # declared infeasible). Conservative by design: if any fathom was
+            # unconverged we forgo certifying infeasibility we might otherwise have
+            # proven — soundness over capability.
+            status = "unknown"
+            _gap_certified = False
         else:
-            # Tree exhausted with no feasible node: infeasibility *is* a certified
-            # conclusion, so leave _gap_certified untouched.
+            # Tree exhausted with no feasible node and every fathom was a valid
+            # certificate (FBBT-empty box or SolveStatus.INFEASIBLE): infeasibility
+            # *is* a certified conclusion, so leave _gap_certified untouched.
             status = "infeasible"
 
     # Negate bound back for maximization

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2484,7 +2484,27 @@ def solve_model(
                     # can actually relax.
                     try:
                         _probe_lb, _probe_ub = flat_variable_bounds(model)
-                        _probe = _mc_lp_relaxer.solve_at_node(_probe_lb, _probe_ub)
+                        # Bound the probe's MILP relaxation solve to a SMALL slice
+                        # of the budget. Without any limit it inherited
+                        # solve_at_node's default time_limit=None -> the Rust MILP
+                        # B&B ran unbounded (up to max_nodes=1e6), solving the root
+                        # relaxation to optimality; on a hard MINLP root (e.g.
+                        # du-opt) that single *discarded* probe consumed the whole
+                        # wall-clock (~77s vs a 25s limit) before the spatial search
+                        # even began. The probe only needs to learn whether the
+                        # relaxer yields a usable bound / infeasibility proof — the
+                        # Rust solver returns a valid dual bound even on an early
+                        # timeout — so a brief cap suffices and leaves the bulk of
+                        # the budget for the actual B&B. Mirror the OBBT root-budget
+                        # heuristic above, never exceeding the live remaining time.
+                        _probe_remaining = time_limit - (time.perf_counter() - t_start)
+                        _probe_budget = min(
+                            max(time_limit * 0.1, 2.0),
+                            max(_probe_remaining, _DEADLINE_NODE_FLOOR_S),
+                        )
+                        _probe = _mc_lp_relaxer.solve_at_node(
+                            _probe_lb, _probe_ub, time_limit=_probe_budget
+                        )
                     except Exception as e:  # pragma: no cover - defensive
                         logger.debug("McCormick LP root probe failed: %s", e)
                         _probe = None
@@ -2841,12 +2861,26 @@ def solve_model(
                 for i in range(n_batch):
                     if node_infeasible_mask[i]:
                         continue
+                    # Deadline enforcement (time_limit overrun fix). A single
+                    # McCormick LP solve has an irreducible ~1s floor on a large
+                    # lifted relaxation, so clamping the per-node budget to
+                    # _DEADLINE_NODE_FLOOR_S still lets a batch of N nodes run
+                    # ~N s past the cap. Once the deadline has passed, stop
+                    # solving the rest of the batch: leave each remaining node's
+                    # bound at -inf (unpruned, it is the default) and decertify
+                    # the gap, mirroring the serial path. -inf never fabricates a
+                    # false "optimal"; the loop exits at the next batch top.
+                    _node_remaining = _deadline - time.perf_counter()
+                    if _node_remaining <= 0.0:
+                        if not _model_is_convex:
+                            _gap_certified = False
+                        continue
                     nlp_failed = result_lbs[i] >= _SENTINEL_THRESHOLD
                     try:
                         mc_res = _mc_lp_relaxer.solve_at_node(
                             np.asarray(batch_lb[i]),
                             np.asarray(batch_ub[i]),
-                            time_limit=max(_deadline - time.perf_counter(), _DEADLINE_NODE_FLOOR_S),
+                            time_limit=max(_node_remaining, _DEADLINE_NODE_FLOOR_S),
                         )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", i, e)

--- a/python/tests/test_objective_epigraph.py
+++ b/python/tests/test_objective_epigraph.py
@@ -1,0 +1,149 @@
+"""Tests for the objective-defining-equality relaxation.
+
+The transform (``discopt._jax.objective_epigraph``) rewrites the SUSPECT
+"objective constraint" pattern ``min z  s.t.  z = g(x)`` into the binding
+inequality ``z >= g(x)``. The rewrite is exact at the optimum and unlocks
+the convex solve path when ``g`` is convex.
+
+These tests pin both directions of the soundness gate: the transform fires
+only on the proven pattern, abstains conservatively otherwise, never
+mutates the caller's model, and never changes the optimum.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import pytest
+from discopt._jax.convexity import classify_model
+from discopt._jax.objective_epigraph import (
+    _affine_coeff,
+    _occurs,
+    relax_objective_defining_equality,
+)
+
+
+def _min_sumsq_model(z_lb=-1e20, z_ub=1e20):
+    """``min z  s.t.  z = x^2 + y^2`` — convex defining equality."""
+    m = dm.Model("sumsq")
+    x = m.continuous("x", lb=-5, ub=5)
+    y = m.continuous("y", lb=-5, ub=5)
+    z = m.continuous("z", lb=z_lb, ub=z_ub)
+    m.subject_to(z == x * x + y * y)
+    m.minimize(z)
+    return m
+
+
+class TestFires:
+    def test_relaxes_convex_defining_equality(self):
+        m = _min_sumsq_model()
+        assert classify_model(m, use_certificate=True)[0] is False
+        m2, changed = relax_objective_defining_equality(m)
+        assert changed is True
+        # original is untouched; the copy carries the relaxed inequality.
+        assert m._constraints[0].sense == "=="
+        assert m2._constraints[0].sense == ">="
+        assert classify_model(m2, use_certificate=True)[0] is True
+
+    def test_exact_optimum_preserved(self):
+        m = _min_sumsq_model()
+        m2, changed = relax_objective_defining_equality(m)
+        assert changed
+        r = m2.solve(time_limit=30)
+        assert r.status == "optimal"
+        assert getattr(r, "gap_certified", False) is True
+        # true minimum of x^2 + y^2 is 0 at x=y=0.
+        assert r.objective == pytest.approx(0.0, abs=1e-5)
+
+    def test_maximize_concave_defining_equality(self):
+        # max z s.t. z = -(x^2) -> concave body -> relax to <=, convex.
+        m = dm.Model("maxconcave")
+        x = m.continuous("x", lb=-3, ub=3)
+        z = m.continuous("z", lb=-1e20, ub=1e20)
+        m.subject_to(z == -(x * x))
+        m.maximize(z)
+        m2, changed = relax_objective_defining_equality(m)
+        assert changed is True
+        assert m2._constraints[0].sense == "<="
+        assert classify_model(m2, use_certificate=True)[0] is True
+
+
+class TestAbstains:
+    def test_bounded_below_does_not_fire_for_min(self):
+        # z not free below -> the binding direction is blocked -> abstain.
+        m = _min_sumsq_model(z_lb=0.0)
+        _, changed = relax_objective_defining_equality(m)
+        assert changed is False
+
+    def test_affine_defining_equality_left_for_substitution(self):
+        # z = 2x + 3y is affine -> presolve substitution is better; abstain.
+        m = dm.Model("affine")
+        x = m.continuous("x", lb=-5, ub=5)
+        y = m.continuous("y", lb=-5, ub=5)
+        z = m.continuous("z", lb=-1e20, ub=1e20)
+        m.subject_to(z == 2 * x + 3 * y)
+        m.minimize(z)
+        _, changed = relax_objective_defining_equality(m)
+        assert changed is False
+
+    def test_z_in_two_constraints_abstains(self):
+        m = _min_sumsq_model()
+        x = m._variables[0]
+        z = m._variables[2]
+        m.subject_to(z >= x)  # second occurrence of z
+        _, changed = relax_objective_defining_equality(m)
+        assert changed is False
+
+    def test_concave_g_for_min_abstains(self):
+        # min z s.t. z = -(x^2): relaxing to z >= -(x^2) is convex BUT the
+        # body z - (-(x^2)) = z + x^2 is convex, not concave -> not convex
+        # as a >= constraint -> abstain (genuinely nonconvex problem).
+        m = dm.Model("minconcave")
+        x = m.continuous("x", lb=-3, ub=3)
+        z = m.continuous("z", lb=-1e20, ub=1e20)
+        m.subject_to(z == -(x * x))
+        m.minimize(z)
+        _, changed = relax_objective_defining_equality(m)
+        assert changed is False
+
+    def test_nonlinear_in_z_abstains(self):
+        # z appears nonlinearly (z^2) in the defining constraint.
+        m = dm.Model("nonlinz")
+        x = m.continuous("x", lb=-3, ub=3)
+        z = m.continuous("z", lb=-1e20, ub=1e20)
+        m.subject_to(z * z == x * x)
+        m.minimize(z)
+        _, changed = relax_objective_defining_equality(m)
+        assert changed is False
+
+    def test_objective_not_single_variable_abstains(self):
+        # objective is z + x, not a bare variable.
+        m = dm.Model("notbare")
+        x = m.continuous("x", lb=-3, ub=3)
+        z = m.continuous("z", lb=-1e20, ub=1e20)
+        m.subject_to(z == x * x)
+        m.minimize(z + x)
+        _, changed = relax_objective_defining_equality(m)
+        assert changed is False
+
+
+class TestStructuralAnalyzers:
+    def test_affine_coeff_linear(self):
+        m = dm.Model("c")
+        x = m.continuous("x", lb=-1, ub=1)
+        z = m.continuous("z", lb=-1, ub=1)
+        body = z + 2.0 * x
+        assert _affine_coeff(body, "z") == pytest.approx(1.0)
+        assert _affine_coeff(2.0 * z + x, "z") == pytest.approx(2.0)
+        assert _affine_coeff(x - z, "z") == pytest.approx(-1.0)
+
+    def test_affine_coeff_nonlinear_returns_none(self):
+        m = dm.Model("c")
+        z = m.continuous("z", lb=-1, ub=1)
+        assert _affine_coeff(z * z, "z") is None
+
+    def test_occurs(self):
+        m = dm.Model("c")
+        x = m.continuous("x", lb=-1, ub=1)
+        z = m.continuous("z", lb=-1, ub=1)
+        assert _occurs(z + x, "z") is True
+        assert _occurs(x * x, "z") is False


### PR DESCRIPTION
## Summary

Soundness + performance work from the global-optimization `/loop`, centered on **certifying du-opt (MINLPLib) globally and soundly** while fixing two latent correctness bugs and an XLA compile blowup uncovered along the way. All changes are general (they key on structure, not on any single instance).

The headline outcome: **du-opt now certifies `status=optimal obj=3.556339590876679 gap_certified=True`**, matching BARON's global optimum (3.55634) — previously discopt either returned a garbage incumbent (3802) or finished with no valid lower bound.

## What's in here (7 commits)

**Correctness**
- `fix(convexity): dense rank-1 Hessian block for squared linear forms` — the sparsity detector treated `(Σ aᵢxᵢ)²` as having a diagonal Hessian; it is dense rank-1 (`aᵢaⱼ`). The wrong sparsity pattern produced a garbage NLP incumbent on du-opt. Now emits the dense rank-1 block only for a scalar linear form of >1 vars.
- `fix(nlp-bb): never certify infeasibility from a non-converged NLP fathom` — a non-converged NLP solve could be mistaken for an infeasibility certificate. Soundness-critical: a feasible problem must never be reported infeasible.
- `fix(nlp): forward-mode dense constraint Jacobian to avoid XLA compile hang` — reverse-mode dense Jacobian triggered a super-linear XLA transpose blowup at compile time.

**Tighter bound / new global certification**
- `feat(convexity): relax objective-defining equality to its binding inequality` — the SUSPECT/BARON "objective constraint" (epigraph) relaxation: `min z s.t. z = g(x)` with `z` free → `z ≥ g(x)`. Exact at the optimum (proof in the module docstring), and turns a convex-defining equality (non-convex *as an equality*) into a convex inequality, unlocking a valid lower bound. Fires only on a structurally-proven pattern and abstains conservatively otherwise (`objective_epigraph.py`, 12 new tests).

**Performance**
- `feat(bnb): honor time limit per node + bound McCormick root probe budget` — per-node deadline gating of heuristics/cuts/strong-branching (LP bound always computed); bounds the root McCormick probe budget so it can't eat the whole time limit.
- `perf(nlp): forward-over-forward Hessians avoid XLA transpose blowup` — `jacfwd(jacfwd(...))` instead of `jax.hessian`'s `jacfwd(jacrev(...))`: identical values, ~2× faster compile, no transpose blowup.

**Docs**
- `docs(crucible): add G-convexity / convex-transformable-functions notes` — Crucible wiki notes on Khajavirad-Michalek-Sahinidis (2012), source material for follow-up tracking issue #181.

## Soundness

The objective-epigraph relaxation is exact at the optimum for convex *and* nonconvex `g` (the proof needs no curvature assumption); convexity only governs whether the relaxed constraint unlocks the convex solve path. Every structural analyzer abstains conservatively — an unrecognized node makes occurrence detection report "might occur" and the affine-coefficient analyzer return `None`, both of which skip the transform. The two correctness fixes only ever *remove* invalid certifications.

## Testing

- 884 Python + 82 DAE + 319 Rust tests pass; 12 new `test_objective_epigraph.py` tests.
- du-opt cross-checked against BARON: true global = 3.55634; discopt now certifies 3.5563 with `gap_certified=True`.
- from_gams smoke tests (rosenbrock, minlp_exp, circle — all `obj =E= …` epigraph pattern) keep their correct optima.
- ruff clean.

## Follow-up

Tracking issue #181 catalogs the broader G-convexity relaxation methods from the same paper not yet in discopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
