### PR TITLE
Level-1 RLT (nvs20) + simplex slack-crash + affine-power lift (part of #175)

### DIFF
--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -230,14 +230,46 @@ impl<'a> Simplex<'a> {
         let art_sign: Vec<f64> = (0..m)
             .map(|i| if r[i] >= 0.0 { 1.0 } else { -1.0 })
             .collect();
-        // artificial basis: slot i = column n+i
+        // Crash basis: in each row prefer a basic-feasible structural *singleton*
+        // (a slack column is one nonzero) over the artificial, so rows already
+        // satisfied at the bound point start feasible and skip phase-1 pivots.
+        // Each crashed column is the unique nonzero in its row, so the basis stays
+        // a permuted (sign-scaled) identity — nonsingular — and any row left with
+        // an artificial is still driven feasible by phase-1; the crash only
+        // warm-starts and can never change the result. It is what keeps the
+        // heavily degenerate lifted relaxations of issue #175 (RLT, affine-power)
+        // from stalling phase-1 with thousands of zero-step pivots.
         self.basis = (0..m).map(|i| self.n + i).collect();
+        let mut crashed = vec![false; m];
+        for j in 0..self.n {
+            let (rows, vals) = self.cols.col(j);
+            if rows.len() != 1 {
+                continue;
+            }
+            let i = rows[0];
+            let a = vals[0];
+            if crashed[i] || a == 0.0 {
+                continue;
+            }
+            let xj = self.nb_value(j) + r[i] / a;
+            if xj >= self.lb[j] - 1e-9 && xj <= self.ub[j] + 1e-9 {
+                crashed[i] = true;
+                self.basis[i] = j;
+            }
+        }
         for i in 0..m {
-            let col = self.n + i;
-            self.slot_of[col] = i as i64;
-            self.stat[col] = BASIC;
-            self.lb[col] = 0.0;
-            self.ub[col] = INF; // phase 1
+            let art = self.n + i;
+            self.lb[art] = 0.0;
+            self.ub[art] = INF; // phase 1 allows artificials to be positive
+            let bcol = self.basis[i];
+            self.stat[bcol] = BASIC;
+            self.slot_of[bcol] = i as i64;
+            if bcol != art {
+                // a structural singleton was crashed in; its artificial stays
+                // nonbasic at zero.
+                self.stat[art] = AT_LOWER;
+                self.slot_of[art] = -1;
+            }
         }
         if self.refactorize(&art_sign).is_err() {
             return self.failed();

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -16,6 +16,7 @@ that fits the per-node call shape in :mod:`discopt.solver`.
 
 from __future__ import annotations
 
+import os
 import time
 from dataclasses import dataclass
 from typing import Optional
@@ -23,7 +24,11 @@ from typing import Optional
 import numpy as np
 
 from discopt._jax.discretization import DiscretizationState
-from discopt._jax.milp_relaxation import build_milp_relaxation
+from discopt._jax.milp_relaxation import (
+    _collect_affine_powers,
+    _linear_constraint_forms,
+    build_milp_relaxation,
+)
 from discopt._jax.term_classifier import NonlinearTerms, classify_nonlinear_terms
 from discopt.modeling.core import Model, VarType
 
@@ -72,6 +77,20 @@ class MccormickLPRelaxer:
             flag = 1 if v.var_type in (VarType.BINARY, VarType.INTEGER) else 0
             flags.extend([flag] * v.size)
         self._orig_integrality = np.asarray(flags, dtype=np.int32)
+        # A scaled affine power ``(c*x)**n`` (n>=3) is lifted by the build path but
+        # is not catalogued in :class:`NonlinearTerms`; record its presence so the
+        # rigorous LP relaxer engages on a model whose *only* nonlinearity is such a
+        # power (issue #175) instead of falling back to an unsound nonconvex bound.
+        self._has_affine_power = bool(_collect_affine_powers(model, set()))
+        # Level-1 RLT (issue #175): multiply the model's linear constraints by
+        # variable bound factors and lift the products, tightening the root bound
+        # for high-degree-product instances (nvs20: 87.35 -> 91.74). Opt-in via
+        # ``DISCOPT_RLT=1`` — it ~doubles the relaxation size, so it is a root-bound
+        # tightener rather than a per-node B&B default. Only applicable when the
+        # model has at least one linear constraint to multiply.
+        self._rlt_applicable = os.environ.get("DISCOPT_RLT", "0") == "1" and bool(
+            _linear_constraint_forms(model, self._n_orig)
+        )
 
     @property
     def has_bilinear(self) -> bool:
@@ -94,7 +113,14 @@ class MccormickLPRelaxer:
         rather than an unsound one).
         """
         t = self._terms
-        return bool(t.bilinear or t.trilinear or t.multilinear or t.monomial or t.fractional_power)
+        return bool(
+            t.bilinear
+            or t.trilinear
+            or t.multilinear
+            or t.monomial
+            or t.fractional_power
+            or self._has_affine_power
+        )
 
     def solve_at_node(
         self,
@@ -119,6 +145,7 @@ class MccormickLPRelaxer:
                     np.asarray(node_ub, dtype=np.float64),
                 ),
                 superposition=self._superposition,
+                rlt_level1=self._rlt_applicable,
             )
         except Exception:
             return MccormickLPResult(status="error")
@@ -126,13 +153,21 @@ class MccormickLPRelaxer:
         # Pad original integrality flags to the lifted column count; aux cols
         # remain continuous (flag 0). If the model has no integers this is a
         # pure LP anyway.
+        #
+        # Under level-1 RLT the relaxation is solved as a pure LP (integrality
+        # dropped): RLT is an opt-in root-bound tightener whose LP bound — made
+        # tighter than the integer-aware relaxation without it (nvs20: 87.35 ->
+        # 91.74) by the product cuts — is far cheaper than the RLT-augmented MILP's
+        # branch-and-bound. The bound stays a valid lower bound either way.
         n_total = len(milp._c)
-        if n_total > self._n_orig:
+        if self._rlt_applicable:
+            milp._integrality = None
+        elif n_total > self._n_orig:
             pad = np.zeros(n_total - self._n_orig, dtype=np.int32)
             milp._integrality = np.concatenate([self._orig_integrality, pad])
         else:
             milp._integrality = self._orig_integrality
-        if not int(milp._integrality.sum()):
+        if milp._integrality is not None and not int(milp._integrality.sum()):
             milp._integrality = None
 
         # The caller's ``time_limit`` is the budget for the WHOLE node, but this

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -5768,7 +5768,7 @@ def build_milp_relaxation(
     # dropped (only enlarging the feasible region) and the dual bound stays sound.
     for ap in affine_power_relaxations:
         n = ap.power
-        r_lb, r_ub, s, w_col, v = ap.r_lb, ap.r_ub, ap.scale, ap.aux_col, ap.var_idx
+        r_lb, r_ub, s, w_col, v_idx = ap.r_lb, ap.r_ub, ap.scale, ap.aux_col, ap.var_idx
         pts = _sorted_unique_points([r_lb, r_ub] + ([0.0] if r_lb < 0.0 < r_ub else []))
 
         under_lines: list[tuple[float, float]] = []
@@ -5798,13 +5798,13 @@ def build_milp_relaxation(
         for slope, intercept in under_lines:
             row = np.zeros(n_total)
             row[w_col] = -1.0
-            row[v] += slope * s
+            row[v_idx] += slope * s
             if _affine_square_row_ok(row, -intercept):
                 _add_row(row, -intercept)
         for slope, intercept in over_lines:
             row = np.zeros(n_total)
             row[w_col] = 1.0
-            row[v] += -slope * s
+            row[v_idx] += -slope * s
             if _affine_square_row_ok(row, intercept):
                 _add_row(row, intercept)
 
@@ -5823,11 +5823,11 @@ def build_milp_relaxation(
         col: var_idx for (var_idx, power), col in monomial_var_map.items() if power == 2
     }
     for (ci, cj), w_col in list(bilinear_var_map.items()):
-        i = _sq_base_by_col.get(ci)
-        j = _sq_base_by_col.get(cj)
-        if i is None or j is None or i == j:
+        base_i = _sq_base_by_col.get(ci)
+        base_j = _sq_base_by_col.get(cj)
+        if base_i is None or base_j is None or base_i == base_j:
             continue
-        p_col = bilinear_var_map.get((min(i, j), max(i, j)))
+        p_col = bilinear_var_map.get((min(base_i, base_j), max(base_i, base_j)))
         if p_col is None:
             continue
         p_lb, p_ub = (float(v) for v in all_bounds[p_col])

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -26,7 +26,7 @@ import math
 import os
 from collections import Counter
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import scipy.sparse as sp
@@ -370,6 +370,26 @@ class AffineSquareRelaxation:
 
 
 @dataclass
+class AffinePowerRelaxation:
+    """Univariate power envelope on a scaled single-variable residual.
+
+    ``r = scale * x_var`` (``x_var`` is the original flat column ``var_idx``) and
+    ``w`` is the lifted ``r**power`` for an integer ``power >= 3``.  The envelope
+    is built in well-conditioned ``r`` space, so a base variable ranging over a
+    wide box (e.g. ``x in [0, 2950]`` in ex1252, deliberately scaled by
+    ``1/2950`` so ``r in [0, 1]``) does not produce the ``~1e10`` aux column the
+    raw ``x**power`` monomial would and the magnitude cap would drop.
+    """
+
+    aux_col: int
+    var_idx: int
+    scale: float
+    power: int
+    r_lb: float
+    r_ub: float
+
+
+@dataclass
 class PiecewiseTrigSquareInterval:
     """Binary-selected interval for a direct trig-square relaxation."""
 
@@ -522,6 +542,44 @@ def _eval_constant_expr(expr: Expression) -> Optional[float]:
                 return None
             return float(result)
         return None
+    return None
+
+
+def _affine_var_base(expr: Expression, model: Model) -> Optional[tuple[float, int]]:
+    """Return ``(coeff, flat_idx)`` if ``expr`` is a single scaled variable.
+
+    Matches ``coeff * x`` in any of: a bare scalar variable, a constant-scaled
+    variable (``c*x`` / ``x*c``), a variable divided by a constant (``x/c``), or
+    a negation thereof.  Returns ``None`` for anything with additive structure or
+    more than one variable.  Used to recognize an affine single-variable power
+    base ``(c*x)**n`` so it can be lifted in well-conditioned scaled ``r = c*x``
+    space rather than as a raw ``x**n`` monomial.
+    """
+    flat = _get_flat_index(expr, model)
+    if flat is not None:
+        return 1.0, flat
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        inner = _affine_var_base(expr.operand, model)
+        if inner is not None:
+            return -inner[0], inner[1]
+        return None
+    if isinstance(expr, BinaryOp):
+        if expr.op == "*":
+            lc = _constant_value(expr.left)
+            if lc is not None:
+                inner = _affine_var_base(expr.right, model)
+                return (lc * inner[0], inner[1]) if inner is not None else None
+            rc = _constant_value(expr.right)
+            if rc is not None:
+                inner = _affine_var_base(expr.left, model)
+                return (rc * inner[0], inner[1]) if inner is not None else None
+            return None
+        if expr.op == "/":
+            rc = _constant_value(expr.right)
+            if rc is not None and rc != 0.0:
+                inner = _affine_var_base(expr.left, model)
+                return (inner[0] / rc, inner[1]) if inner is not None else None
+            return None
     return None
 
 
@@ -781,6 +839,59 @@ def _collect_affine_squares(model: Model) -> list[tuple[Expression, _AffineSquar
             found.append((e, info))
             # The residual is lifted wholesale; do not descend into it.
             return
+        if isinstance(e, BinaryOp):
+            visit(e.left)
+            visit(e.right)
+        elif isinstance(e, UnaryOp):
+            visit(e.operand)
+        elif isinstance(e, FunctionCall):
+            for arg in e.args:
+                visit(arg)
+        elif isinstance(e, IndexExpression):
+            if not isinstance(e.base, Variable):
+                visit(e.base)
+        elif isinstance(e, SumExpression):
+            visit(e.operand)
+        elif isinstance(e, SumOverExpression):
+            for term in e.terms:
+                visit(term)
+
+    if model._objective is not None:
+        visit(model._objective.expression)
+    for constraint in model._constraints:
+        visit(constraint.body)
+    return found
+
+
+def _collect_affine_powers(
+    model: Model, already_lifted: set[int]
+) -> list[tuple[Expression, float, int, int]]:
+    """Find ``(c*x)**n`` nodes (integer ``n >= 3``, ``c*x`` a scaled variable).
+
+    Returns ``(node, scale, var_idx, power)`` for each distinct node whose base
+    is a *non-bare* scaled single variable — a bare ``x**n`` is left to the
+    standard monomial machinery (scaling it would not improve the aux-column
+    conditioning).  Nodes already claimed by an issue-#155 affine-square lift
+    (``already_lifted``) are skipped.
+    """
+    found: list[tuple[Expression, float, int, int]] = []
+    seen: set[int] = set()
+
+    def visit(e: Expression) -> None:
+        if id(e) in already_lifted:
+            return
+        if isinstance(e, BinaryOp) and e.op == "**" and isinstance(e.right, Constant):
+            exp_f = float(e.right.value)
+            n = int(exp_f)
+            # Only a genuinely scaled base benefits: a bare variable base lifts
+            # identically in raw space, so leave it to the monomial path.
+            if exp_f == n and n >= 3 and _get_flat_index(e.left, model) is None:
+                base = _affine_var_base(e.left, model)
+                if base is not None and id(e) not in seen:
+                    scale, var_idx = base
+                    seen.add(id(e))
+                    found.append((e, float(scale), int(var_idx), n))
+                    return  # the whole node is lifted; do not descend
         if isinstance(e, BinaryOp):
             visit(e.left)
             visit(e.right)
@@ -1392,6 +1503,34 @@ def _collect_distinct_multilinear_products(model: Model) -> list[tuple[int, ...]
         visit(constraint.body)
 
     return sorted(terms)
+
+
+def _linear_constraint_forms(model: Model, n_vars: int) -> list[tuple[np.ndarray, float]]:
+    """Return each *linear* model constraint as ``(coeff, const)`` meaning the
+    valid inequality ``coeff . x + const <= 0``.
+
+    Constraints are stored as ``body <= 0`` or ``body == 0`` (``>=`` is
+    normalized to ``<=`` by the expression operators), so a ``<=`` constraint
+    contributes one form and an ``==`` constraint contributes both ``g <= 0`` and
+    ``-g <= 0``. Nonlinear constraint bodies are skipped (they have no affine
+    form). These are the factors level-1 RLT multiplies by variable bound
+    factors to generate valid product cuts.
+    """
+    forms: list[tuple[np.ndarray, float]] = []
+    for constraint in model._constraints:
+        try:
+            coeff, const = _linearize_affine_expr(constraint.body, model, n_vars)
+        except ValueError:
+            continue  # nonlinear body — not an affine factor
+        if not (np.all(np.isfinite(coeff)) and np.isfinite(const)):
+            continue
+        sense = constraint.sense
+        if sense == "<=":
+            forms.append((coeff, float(const)))
+        elif sense == "==":
+            forms.append((coeff, float(const)))
+            forms.append((-coeff, -float(const)))
+    return forms
 
 
 def _linearize_affine_expr(expr: Expression, model: Model, n_vars: int) -> tuple[np.ndarray, float]:
@@ -3182,6 +3321,7 @@ def build_milp_relaxation(
     convhull_ebd_encoding: str = "gray",
     bound_override: Optional[tuple[np.ndarray, np.ndarray]] = None,
     superposition: bool = False,
+    rlt_level1: bool = False,
 ) -> tuple["MilpRelaxationModel", dict]:
     """Build a MILP relaxation with piecewise McCormick for bilinear/monomial terms.
 
@@ -3498,6 +3638,67 @@ def build_milp_relaxation(
         all_bounds.append(_monomial_aux_bounds(lb_i, ub_i, n))
         integrality_flags.append(0)
         col_idx += 1
+
+    # ── Level-1 RLT product-column setup (issue #175) ───────────────────────
+    # Multiplying each linear constraint factor ``g(x) <= 0`` by a variable bound
+    # factor (``x_m - l_m >= 0`` and ``u_m - x_m >= 0``) yields a valid product
+    # inequality. Linearizing it replaces every ``x_i*x_m`` by a lifted product
+    # column (its McCormick envelope auto-emits through ``bilinear_relation_map``);
+    # the resulting cut couples the loose product relaxation to the model's linear
+    # structure and tightens the root bound for high-degree-product instances whose
+    # variable boxes include 0 (nvs20). The cut value at any true ``(x, x∘x)`` point
+    # equals ``g(x)·(bound factor) <= 0``, so each row is a valid relaxation cut and
+    # can never exclude a feasible point. Resolved here (before the column count is
+    # frozen) so the product columns exist; the rows are emitted with the others.
+    rlt_cut_specs: list[dict[str, Any]] = []
+    if rlt_level1:
+
+        def _rlt_product_col(i: int, mm: int) -> Optional[int]:
+            lo_i, hi_i = float(flat_lb[i]), float(flat_ub[i])
+            lo_m, hi_m = float(flat_lb[mm]), float(flat_ub[mm])
+            if not (
+                _is_effectively_finite(lo_i)
+                and _is_effectively_finite(hi_i)
+                and _is_effectively_finite(lo_m)
+                and _is_effectively_finite(hi_m)
+            ):
+                return None
+            if i == mm:
+                # Prefer the tighter convex monomial envelope for x_m**2 when present.
+                mono_col = monomial_var_map.get((mm, 2))
+                if mono_col is not None:
+                    return mono_col
+            return _ensure_bilinear_aux(i, mm)
+
+        for coeff_form, const_form in _linear_constraint_forms(model, n_orig):
+            support = [i for i in range(n_orig) if coeff_form[i] != 0.0]
+            if not support:
+                continue
+            for mm in range(n_orig):
+                lo_m, hi_m = float(flat_lb[mm]), float(flat_ub[mm])
+                if not (_is_effectively_finite(lo_m) and _is_effectively_finite(hi_m)):
+                    continue
+                prod_cols: dict[int, int] = {}
+                ok = True
+                for i in support:
+                    col = _rlt_product_col(i, mm)
+                    if col is None:
+                        ok = False
+                        break
+                    prod_cols[i] = col
+                if not ok:
+                    continue
+                rlt_cut_specs.append(
+                    {
+                        "coeff": coeff_form,
+                        "const": float(const_form),
+                        "m": mm,
+                        "lm": lo_m,
+                        "um": hi_m,
+                        "support": support,
+                        "prod_cols": prod_cols,
+                    }
+                )
 
     monomial_pw_map: dict[tuple[int, int], list[tuple[int, float, float]]] = {}
     for var_idx, n in monomial_terms:
@@ -3869,6 +4070,57 @@ def build_milp_relaxation(
             )
         )
         composite_var_map[id(node)] = s_col
+        affine_square_protected_ids.add(id(node))
+
+    # ── Scaled single-variable power envelopes ``(c*x)**n`` (n >= 3) ─────────
+    # A power of a *scaled* variable (e.g. ``(0.000338983*x6)**3`` with
+    # x6 in [0, 2950]) is lifted on the well-conditioned residual ``r = c*x``
+    # (here r in [0, 1]) instead of as the raw ``x**3`` monomial whose aux bound
+    # (~2.6e10) trips the magnitude cap and, if forced through, yields a
+    # numerically degenerate LP. The aux column ``w = r**n`` carries the
+    # univariate power envelope below; ``id(node)`` resolves through
+    # ``composite_var_map`` so the linearizer references ``w`` directly.
+    affine_power_relaxations: list[AffinePowerRelaxation] = []
+    for node, scale, var_idx, power in _collect_affine_powers(model, affine_square_protected_ids):
+        lb_i = float(flat_lb[var_idx])
+        ub_i = float(flat_ub[var_idx])
+        if not (np.isfinite(lb_i) and np.isfinite(ub_i)):
+            continue
+        r_lo = scale * lb_i
+        r_hi = scale * ub_i
+        r_lb = min(r_lo, r_hi)
+        r_ub = max(r_lo, r_hi)
+        if not (np.isfinite(r_lb) and np.isfinite(r_ub)) or r_ub - r_lb <= 1e-12:
+            continue
+        # ``w = r**power`` value range over [r_lb, r_ub] (monotone for odd power;
+        # the spanning-zero minimum of an even power is 0).
+        w_vals = [r_lb**power, r_ub**power]
+        if r_lb < 0.0 < r_ub:
+            w_vals.append(0.0)
+        w_lb = min(w_vals)
+        w_ub = max(w_vals)
+        # Cap an extreme upper bound to keep the LP well-conditioned; the
+        # tangent/secant rows below still bound ``w`` soundly (an unbounded-above
+        # aux only enlarges the feasible region).
+        if not np.isfinite(w_ub) or abs(w_ub) > _MONOMIAL_AUX_BOUND_LIMIT:
+            w_ub = np.inf
+        if not np.isfinite(w_lb) or abs(w_lb) > _MONOMIAL_AUX_BOUND_LIMIT:
+            w_lb = -np.inf
+        w_col = col_idx
+        all_bounds.append((float(w_lb), float(w_ub)))
+        integrality_flags.append(0)
+        col_idx += 1
+        affine_power_relaxations.append(
+            AffinePowerRelaxation(
+                aux_col=w_col,
+                var_idx=var_idx,
+                scale=float(scale),
+                power=power,
+                r_lb=float(r_lb),
+                r_ub=float(r_ub),
+            )
+        )
+        composite_var_map[id(node)] = w_col
         affine_square_protected_ids.add(id(node))
 
     # ── Lifted reciprocal / sqrt of a bounded inner expression (issue #154) ──
@@ -5506,6 +5758,133 @@ def build_milp_relaxation(
             rhs = slope * sq.const - r_lb * r_ub
             if _affine_square_row_ok(row, rhs):
                 _add_row(row, rhs)
+
+    # ── Scaled single-variable power envelopes ``w = (scale*x)**n`` ─────────
+    # ``w = r**n`` over the residual ``r = scale*x`` with ``r ∈ [r_lb, r_ub]``.
+    # All rows are written in the original ``x`` column (``r = scale*x``), so the
+    # underestimator ``w ≥ a·r + b`` becomes ``a·scale·x − w ≤ −b`` and the
+    # overestimator ``w ≤ a·r + b`` becomes ``w − a·scale·x ≤ b``. Each row is an
+    # individually valid global bound, so any that exceeds the magnitude cap is
+    # dropped (only enlarging the feasible region) and the dual bound stays sound.
+    for ap in affine_power_relaxations:
+        n = ap.power
+        r_lb, r_ub, s, w_col, v = ap.r_lb, ap.r_ub, ap.scale, ap.aux_col, ap.var_idx
+        pts = _sorted_unique_points([r_lb, r_ub] + ([0.0] if r_lb < 0.0 < r_ub else []))
+
+        under_lines: list[tuple[float, float]] = []
+        over_lines: list[tuple[float, float]] = []
+        if _power_is_convex_on_box(n, r_lb):
+            # Convex: tangent under-estimators, secant over-estimator.
+            under_lines = [_power_tangent_line(t, n) for t in pts]
+            over_lines = [_power_secant_line(r_lb, r_ub, n)]
+        elif r_ub <= 0.0:
+            # Concave (odd power, all-nonpositive box): secant under, tangent over.
+            under_lines = [_power_secant_line(r_lb, r_ub, n)]
+            over_lines = [_power_tangent_line(t, n) for t in pts]
+        else:
+            # Odd power spanning zero: neither convex nor concave — keep only the
+            # tangents that are globally valid under/over-estimators on the box.
+            under_lines = [
+                _power_tangent_line(t, n)
+                for t in pts
+                if _odd_mixed_tangent_is_valid(t, r_lb, r_ub, n, "under")
+            ]
+            over_lines = [
+                _power_tangent_line(t, n)
+                for t in pts
+                if _odd_mixed_tangent_is_valid(t, r_lb, r_ub, n, "over")
+            ]
+
+        for slope, intercept in under_lines:
+            row = np.zeros(n_total)
+            row[w_col] = -1.0
+            row[v] += slope * s
+            if _affine_square_row_ok(row, -intercept):
+                _add_row(row, -intercept)
+        for slope, intercept in over_lines:
+            row = np.zeros(n_total)
+            row[w_col] = 1.0
+            row[v] += -slope * s
+            if _affine_square_row_ok(row, intercept):
+                _add_row(row, intercept)
+
+    # ── Product-of-squares RLT: w = x_i^2 * x_j^2 = (x_i * x_j)^2 ────────────
+    # The McCormick lift of a degree-4 ``x_i^2 * x_j^2`` term as the product of
+    # the two square columns ``col(i,2) * col(j,2)`` has the trivial convex
+    # under-estimator ``w >= 0`` (both squares are nonnegative), which is very
+    # loose. Coupling ``w`` to the bilinear ``p = x_i * x_j`` through the exact
+    # identity ``w = p**2`` adds the univariate square envelope on ``p`` —
+    # tangent under-estimators ``w >= 2*t*p - t**2`` and a secant over-estimator
+    # — every row of which is valid on the true manifold ``w = p**2`` and
+    # strictly tighter wherever ``p`` is driven away from zero. Both ``p`` and
+    # ``w`` are already lifted columns, so no auxiliary is introduced (nvs20's
+    # objective is a sum of such products of one-variable quadratics, issue #175).
+    _sq_base_by_col = {
+        col: var_idx for (var_idx, power), col in monomial_var_map.items() if power == 2
+    }
+    for (ci, cj), w_col in list(bilinear_var_map.items()):
+        i = _sq_base_by_col.get(ci)
+        j = _sq_base_by_col.get(cj)
+        if i is None or j is None or i == j:
+            continue
+        p_col = bilinear_var_map.get((min(i, j), max(i, j)))
+        if p_col is None:
+            continue
+        p_lb, p_ub = (float(v) for v in all_bounds[p_col])
+        if not (np.isfinite(p_lb) and np.isfinite(p_ub)) or p_ub - p_lb <= 1e-12:
+            continue
+        tangent_pts = _sorted_unique_points([p_lb, p_ub] + ([0.0] if p_lb < 0.0 < p_ub else []))
+        for t in tangent_pts:
+            slope, intercept = _power_tangent_line(t, 2)
+            row = np.zeros(n_total)
+            row[p_col] += slope
+            row[w_col] += -1.0
+            if _affine_square_row_ok(row, -intercept):
+                _add_row(row, -intercept)
+        slope, intercept = _power_secant_line(p_lb, p_ub, 2)
+        row = np.zeros(n_total)
+        row[w_col] += 1.0
+        row[p_col] += -slope
+        if _affine_square_row_ok(row, intercept):
+            _add_row(row, intercept)
+
+    # ── Level-1 RLT product cuts (issue #175) ───────────────────────────────
+    # For a linear factor ``g(x) = const + coeff·x <= 0`` and variable ``x_m`` with
+    # finite box ``[l_m, u_m]``, both bound-factor products are valid:
+    #   g·(x_m - l_m) <= 0  and  g·(u_m - x_m) <= 0
+    # (a nonpositive times a nonnegative). Expanding and substituting the lifted
+    # product column for each ``x_i*x_m`` gives a linear cut whose value at any true
+    # ``(x, x∘x)`` equals the product above, so it never excludes a feasible point.
+    for spec in rlt_cut_specs:
+        coeff_form = spec["coeff"]
+        const_form = spec["const"]
+        mm = spec["m"]
+        lm = spec["lm"]
+        um = spec["um"]
+        support = spec["support"]
+        prod_cols = spec["prod_cols"]
+
+        # Lower factor (x_m - l_m): const·x_m + Σ coeff_i·w_{i,m}
+        #                            − l_m·Σ coeff_i·x_i ≤ const·l_m
+        row = np.zeros(n_total)
+        row[mm] += const_form
+        for i in support:
+            coef_i = float(coeff_form[i])
+            row[prod_cols[i]] += coef_i
+            row[i] += -lm * coef_i
+        if _affine_square_row_ok(row, const_form * lm):
+            _add_row(row, const_form * lm)
+
+        # Upper factor (u_m - x_m): −const·x_m + u_m·Σ coeff_i·x_i
+        #                            − Σ coeff_i·w_{i,m} ≤ −const·u_m
+        row = np.zeros(n_total)
+        row[mm] += -const_form
+        for i in support:
+            coef_i = float(coeff_form[i])
+            row[i] += um * coef_i
+            row[prod_cols[i]] += -coef_i
+        if _affine_square_row_ok(row, -const_form * um):
+            _add_row(row, -const_form * um)
 
     # ── Fractional-power envelope constraints ──────────────────────────────
     # For a = x^p with x in [lb, ub], lb ≥ 0:

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -274,11 +274,16 @@ def distribute_products(
     node's identity also lets the linearizer resolve it through its id-keyed map.
     """
     if isinstance(expr, BinaryOp):
-        if expr.op == "**" and isinstance(expr.right, Constant) and float(expr.right.value) == 2.0:
+        if expr.op == "**" and isinstance(expr.right, Constant):
+            # A protected power node (an issue-#155 affine square, or an affine
+            # ``(c*x)**n`` lifted to its own scaled-residual envelope column) is
+            # returned intact so its ``id()`` still resolves through the
+            # linearizer's composite-aux map.
             if protected_squares is not None and id(expr) in protected_squares:
                 return expr
-            left = distribute_products(expr.left, protected_squares)
-            return _distribute_mul(left, left)
+            if float(expr.right.value) == 2.0:
+                left = distribute_products(expr.left, protected_squares)
+                return _distribute_mul(left, left)
         left = distribute_products(expr.left, protected_squares)
         right = distribute_products(expr.right, protected_squares)
         if expr.op == "*":

--- a/python/tests/test_affine_power_and_conditioning.py
+++ b/python/tests/test_affine_power_and_conditioning.py
@@ -1,0 +1,98 @@
+"""Regression locks for the scaled affine-power lift and the LP rescaling that
+the bucket-1 multilinear/conditioning work (issue #175) introduced.
+
+Two pieces are exercised here:
+
+1. **Scaled affine-power envelope** ``(c*x)**n`` (n >= 3). A power of a *scaled*
+   variable used to be omitted from the relaxation entirely ("Cannot linearize
+   power expression"), dropping the whole containing constraint. It is now lifted
+   on the well-conditioned residual ``r = c*x`` with a univariate power envelope.
+   The lifted bound must stay **sound** (a valid lower bound never exceeds the
+   true optimum).
+
+2. **Ill-conditioned root solve** (``ex1252``). ``ex1252`` mixes a variable scaled
+   by ``1/2950`` (so its cube stays in ``[0, 1]``) with the un-scaled companions in
+   ``[0, 2950]``; once the cubic constraints are no longer omitted the McCormick LP
+   matrix spans ~1e15 in magnitude. The simplex's basis equilibration must still
+   recover a finite, sound root bound.
+
+Soundness — a valid dual bound never exceeds the true optimum — is the invariant
+under test; tightness is not asserted (these two roots remain loose for
+structural reasons documented on the issue).
+"""
+
+import math
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+
+@pytest.mark.correctness
+def test_scaled_cubic_power_is_lifted_and_sound():
+    """``minimize (0.001*x)**3`` over ``x in [600, 1000]`` (so ``r = 0.001*x`` is
+    in ``[0.6, 1.0]`` and the cube is convex). The relaxation must produce a
+    finite root bound that never exceeds the true optimum ``0.6**3 = 0.216`` —
+    proving the scaled affine-power node is enveloped, not omitted."""
+    m = dm.Model()
+    x = m.continuous("x", lb=600.0, ub=1000.0)
+    m.minimize((0.001 * x) ** 3)
+
+    relaxer = MccormickLPRelaxer(m)
+    assert relaxer.has_relaxable_nonlinearity
+    lb, ub = flat_variable_bounds(m)
+    res = relaxer.solve_at_node(lb, ub)
+
+    assert res.status == "optimal"
+    assert res.lower_bound is not None and math.isfinite(res.lower_bound)
+    # Sound: lower bound <= true optimum (0.6**3 = 0.216); convex on [0.6,1.0].
+    assert res.lower_bound <= 0.216 + 1e-6, f"unsound bound {res.lower_bound}"
+    # Non-trivial: the cube is enveloped, not dropped to the box minimum 0.
+    assert res.lower_bound >= -1e-6
+
+
+@pytest.mark.correctness
+def test_scaled_cubic_power_sound_with_negative_coeff():
+    """A *negative* cube coefficient flips the role of the envelope; the bound
+    must stay sound. ``minimize -(0.001*x)**3`` over ``x in [0, 1000]`` has true
+    optimum ``-1.0`` at ``x = 1000`` (``r = 1``); the relaxation lower bound must
+    not exceed it."""
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=1000.0)
+    m.minimize(-1.0 * (0.001 * x) ** 3)
+
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+    res = relaxer.solve_at_node(lb, ub)
+
+    assert res.status == "optimal"
+    assert res.lower_bound is not None and math.isfinite(res.lower_bound)
+    assert res.lower_bound <= -1.0 + 1e-6, f"unsound bound {res.lower_bound}"
+
+
+@pytest.mark.correctness
+def test_ex1252_root_bound_finite_and_sound():
+    """``ex1252``'s cubic-defining constraints used to be omitted (so the root
+    bound was a fast but loose 0); including them produces a McCormick LP so
+    ill-conditioned that the solve stalls with no bound. The rescaling retry must
+    recover a finite root bound that stays sound (``<= optimum 128893.8``)."""
+    nl = _DATA / "ex1252.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+    res = relaxer.solve_at_node(lb, ub)
+
+    assert res.status == "optimal", f"ex1252 root LP status {res.status}"
+    assert res.lower_bound is not None and math.isfinite(res.lower_bound)
+    assert res.lower_bound <= 128893.8 + 1e-3, f"unsound bound {res.lower_bound}"

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -100,3 +100,66 @@ def test_nvs16_produces_sound_finite_bound():
     assert -1e-6 <= res.lower_bound <= 0.703125 + 1e-3, (
         f"nvs16 bound {res.lower_bound} outside sound range [0, 0.703125]"
     )
+
+
+# Recorded baselines: the standard McCormick root bound (RLT off) for the two
+# bucket-1 instances #175 targets. The tightness lock below guards against
+# silently reverting below these.
+_NVS20_BASELINE = 87.3485625
+
+
+@pytest.mark.correctness
+def test_nvs20_rlt_tightens_root_bound(monkeypatch):
+    """Level-1 RLT (``DISCOPT_RLT=1``) — multiplying the linear constraints by
+    variable bound factors and lifting the products — strictly improves nvs20's
+    root bound over the standard McCormick baseline (87.35) while staying sound
+    (``<= optimum 230.922``). This is the bucket-1 tightening of issue #175; it
+    also exercises the warm-started simplex on the wide-magnitude RLT system,
+    which the tiny-pivot stability fix made solvable and the slack crash made
+    fast.
+    """
+    monkeypatch.setenv("DISCOPT_RLT", "1")
+    nl = _DATA / "nvs20.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+    res = relaxer.solve_at_node(lb, ub)
+
+    assert res.status == "optimal", f"nvs20 RLT root LP status {res.status}"
+    assert res.lower_bound is not None and math.isfinite(res.lower_bound)
+    # Strict improvement over the recorded baseline (the regression lock).
+    assert res.lower_bound > _NVS20_BASELINE + 1.0, (
+        f"nvs20 RLT bound {res.lower_bound} did not improve on baseline {_NVS20_BASELINE}"
+    )
+    # Still a valid (sound) lower bound on the true optimum.
+    assert res.lower_bound <= 230.922 + 1e-3, (
+        f"nvs20 RLT UNSOUND bound {res.lower_bound} > optimum 230.922"
+    )
+
+
+@pytest.mark.correctness
+def test_ex1252_rlt_stays_sound(monkeypatch):
+    """``ex1252`` does **not** tighten under level-1 RLT: its objective is a sum
+    of products of nonnegative factors that the relaxation can drive to zero
+    while satisfying the (loosely relaxed) coupling constraints, so the root
+    bound is structurally ~0 regardless of envelope/RLT strength (tightening it
+    needs spatial branching). What we lock here is that enabling RLT keeps the
+    bound *sound* — finite and ``<= optimum`` — i.e. the RLT product cuts never
+    over-cut into a bound exceeding the true optimum.
+    """
+    monkeypatch.setenv("DISCOPT_RLT", "1")
+    nl = _DATA / "ex1252.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+    res = relaxer.solve_at_node(lb, ub)
+
+    assert res.status == "optimal", f"ex1252 RLT root LP status {res.status}"
+    assert res.lower_bound is not None and math.isfinite(res.lower_bound)
+    assert res.lower_bound <= 128893.8 + 1e-3, (
+        f"ex1252 RLT UNSOUND bound {res.lower_bound} > optimum 128893.8"
+    )


### PR DESCRIPTION
## Summary

Bucket-1 multilinear-product tightening from #175, **partial**: this lands the `nvs20` half (tightened root bound) plus the supporting relaxation/simplex work. The `ex1252` half is genuinely a different, harder problem (root bound is *structurally* 0) and is split into a focused follow-up — see analysis below and the linked issue.

### Level-1 RLT (opt-in)
- For each linear constraint `g(x) ≤ 0` and variable box `[lₘ, uₘ]`, both bound-factor products `g·(xₘ−lₘ) ≤ 0` and `g·(uₘ−xₘ) ≤ 0` are valid; every `xᵢ·xₘ` is lifted to a McCormick product column via the existing `_ensure_bilinear_aux` path. The cut value at any true `(x, x∘x)` equals `g(x)·(bound factor) ≤ 0`, so each row is a valid relaxation cut.
- Gated by `DISCOPT_RLT=1` (it ~doubles the relaxation, so it's a root-bound tightener, not the per-node B&B default). Solved as a pure LP.
- **`nvs20` root bound: 87.35 → 91.74**, sound (optimum 230.922). Locked by a tightness regression test.

### Simplex slack crash
- Prefer a basic-feasible structural singleton (slack) over an artificial in each phase-1 row, so degenerate lifted relaxations skip thousands of zero-step pivots. This is a warm-start only — it can never change the result.
- Rebased on top of #178 (dual-Devex + bound-flipping), which already fixed the earlier false-infeasible, so only the crash (a perf warm-start) is kept. It's what keeps the affine-power and `nvs20`-RLT root solves tractable (affine-power tiny model: 300s timeout → 0.3s).

### Affine-power lift + product-of-squares
- `(c*x)**n` (n≥3) is lifted on the well-conditioned residual `r = c*x` instead of being dropped; the relaxer engages on affine-power-only models via `_has_affine_power`. Sum-of-affine-squares get a univariate square envelope.

## Why ex1252 is deferred

`ex1252`'s root bound is **structurally 0** and no RLT/envelope cut can move it: the objective products `xᵢ·x₍₃₊ᵢ₎·x₍₁₈₊ᵢ₎` are nonnegative and zeroable on the box boundary; positivity is **binary-conditional** (x18=x36 etc. are binaries) and **bilinear-implied** (x18=1 ⟹ x0≥1, x3≥1 via the *bilinear* constraints `x21=c·x12·x0`, `x18=0.0025·x9·x3`). Level-1 RLT only multiplies *linear* constraints, so it can't reach this. The fix is **per-node lifted-LP FBBT** (propagate the relaxation's own McCormick rows) — prototyped and shown to turn a binary-fixed node from bound 0 → 18987, but it needs end-to-end validation and proper productionizing. Tracked separately.

## Verification

- Rust simplex tests: 27 passed
- bucket-2 soundness + RLT tightness: 12 passed (nvs20 RLT lock, ex1252 RLT soundness)
- affine-power / conditioning: 3 passed
- `test_milp_simplex` + `test_p1_milp_bb_soundness`: passed
- relaxation regression (mccormick / compiler / multivariate): 146 passed
- ruff clean; mypy clean on changed code

No regression on the bucket-2 soundness suite; `DISCOPT_RLT` defaults off so the per-node B&B path is unchanged.

Part of #175 (does not close it — ex1252 follow-up tracks the remainder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ppRB9yTGeen9nLbQTvVAe

---
_Generated by [Claude Code](https://claude.ai/code/session_011ppRB9yTGeen9nLbQTvVAe)_