### PR TITLE
ex1252 dual-bound mechanisms: per-node lifted-LP FBBT + objective-gating priority branching + LP equilibration (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ The release procedure that produces these entries is documented in
   only valid rows tighten, and the un-pin only enlarges the box. Regression
   locks in `test_bucket2_sound_bounds.py`.
 
+- **Lifted-relaxation LP equilibration** (`feat(relaxation)`, #184). The lifted
+  McCormick rows of a product over a wide variable box mix tiny constants (~1e-9)
+  with large bound-derived coefficients (~1e7), giving a >1e15 coefficient spread
+  on ex1252's boundary sub-boxes. HiGHS stalls on it (a 452×96 LP hits its time
+  limit; the per-node soundness re-verifications then dominate the solve) while
+  the pure-Rust simplex, which equilibrates internally, solves it in ~0.03s.
+  `equilibrate_relaxation_lp` (`discopt._jax.milp_relaxation`) applies
+  geometric-mean (Ruiz) row/column scaling, snapped to powers of two, before the
+  external (HiGHS/POUNCE) backend solve when the spread exceeds 1e6 — turning
+  previously timing-out boundary boxes into ~3-4s converged solves (e.g. the
+  `x36=1,x37=1` box: time-out → 4.5s). The rescaling is exact (bound/feasibility
+  unchanged, integer columns never scaled, solution mapped back through the
+  column scale), so it only ever conditions — never alters — the result.
+  Regression-locked in `test_bucket2_sound_bounds.py`.
+
 - **Objective-gating priority branching** (`feat(bnb)`, #184). Opt-in
   (`DISCOPT_OBJ_BRANCH_PRIORITY=1`) branching-order heuristic that branches the
   integer variables gating the objective's nonlinear terms (those appearing in,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ The release procedure that produces these entries is documented in
   only valid rows tighten, and the un-pin only enlarges the box. Regression
   locks in `test_bucket2_sound_bounds.py`.
 
+- **Objective-gating priority branching** (`feat(bnb)`, #184). Opt-in
+  (`DISCOPT_OBJ_BRANCH_PRIORITY=1`) branching-order heuristic that branches the
+  integer variables gating the objective's nonlinear terms (those appearing in,
+  or equality-linked to, a lifted product/monomial — e.g. ex1252's line-selection
+  binaries `x36/x37/x38`) before other integers. The global dual bound is the
+  minimum over the open frontier, so on problems whose bound is structurally 0
+  until a *set* of binaries is jointly fixed it stays pinned at 0 under
+  most-fractional branching (no single-variable score sees the joint jump);
+  branching the gating binaries first reaches the depth where the per-node
+  relaxation lifts each leaf off 0. Implemented via the existing `set_branch_hints`
+  path in `solve_model` (`discopt.solver`) — pure search reordering over already
+  fractional integer candidates, so it can never affect a bound or feasibility
+  verdict. Detector locked by `test_bucket2_sound_bounds.py`.
+
 - **POUNCE NLP backend declared as a dependency** (`feat(solvers)`). New
   `pounce` optional extra (`pip install discopt[pounce]`, dist `pounce-solver`)
   and a `requires_pounce` test marker. POUNCE is a standalone pure-Rust port of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ The release procedure that produces these entries is documented in
 
 ### Added
 
+- **Per-node lifted-LP FBBT** (`feat(relaxation)`, #184). Opt-in
+  (`DISCOPT_LIFTED_FBBT=1`) feasibility-based bound tightening that propagates
+  the McCormick relaxation's *own* rows (`A_ub·z ≤ b_ub`, spanning the lifted
+  product/monomial columns), recovering the bilinear-implied factor bounds that
+  purely linear FBBT misses, then rebuilds the relaxation on the tightened box.
+  This lifts `ex1252`'s structurally-zero node bound off 0 (a branched node goes
+  `bound 0 → ~18987`, sound) so the B&B can certify optimality. Implemented in
+  `discopt._jax.mccormick_lp` (vectorised over the sparse matrix); pinned
+  multilinear factors are un-pinned by a hair so the build keeps the term at
+  full arity and never drops `objective_bound_valid`. Sound by construction —
+  only valid rows tighten, and the un-pin only enlarges the box. Regression
+  locks in `test_bucket2_sound_bounds.py`.
+
 - **POUNCE NLP backend declared as a dependency** (`feat(solvers)`). New
   `pounce` optional extra (`pip install discopt[pounce]`, dist `pounce-solver`)
   and a `requires_pounce` test marker. POUNCE is a standalone pure-Rust port of

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -37,6 +37,98 @@ from discopt.modeling.core import Model, VarType
 # the deadline from receiving a zero/negative budget the backend would reject).
 _SOLVE_DEADLINE_FLOOR_S = 0.05
 
+# Lifted-LP FBBT (issue #184): number of feasibility-propagation sweeps over the
+# relaxation rows, and the width left around a factor that propagation pins to a
+# point so the build path keeps the multilinear term at full arity (see
+# ``solve_at_node`` for why un-pinning is needed and why it stays sound).
+_LIFTED_FBBT_ROUNDS = 30
+_LIFTED_FBBT_TOL = 1e-9
+_LIFTED_FBBT_UNPIN_EPS = 1e-6
+
+
+def _lifted_lp_fbbt(
+    A_ub: "object",
+    b_ub: np.ndarray,
+    lo: np.ndarray,
+    hi: np.ndarray,
+    *,
+    rounds: int = _LIFTED_FBBT_ROUNDS,
+    tol: float = _LIFTED_FBBT_TOL,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Feasibility-based bound tightening on the relaxation's own rows.
+
+    Propagates the lifted relaxation constraints ``A_ub · z <= b_ub`` (where ``z``
+    spans the original variables *and* every McCormick product/monomial column)
+    to tighten the column box ``[lo, hi]``. Because the McCormick rows of a
+    product column ``w = x_i·x_j`` include facets such as ``w <= ub_j·x_i``,
+    propagating a tightened ``w`` back through them recovers the *bilinear-implied*
+    factor bounds that purely linear FBBT on the original model misses (issue
+    #184: ``x18 = 0.0025·x9·x3`` with ``x18`` pinned to 1 forces ``x3 >= 1``).
+
+    Soundness: every row is a valid relaxation inequality, so each derived bound
+    is implied by valid constraints plus the incoming box — the result only ever
+    *tightens* and never excludes a point feasible for the node. Returns the
+    tightened ``(lo, hi)``; an empty result (``lo > hi`` on some column) is a
+    rigorous proof the node's relaxation is infeasible.
+
+    Vectorised over the sparse matrix (the per-row/per-element Python loop in the
+    issue prototype is too slow for the per-node path). Each sweep computes, for
+    every nonzero ``a_{r,j}``, the minimum activity of row ``r`` excluding column
+    ``j`` and back-solves the tightest implied bound on ``z_j``; infinite
+    contributions are handled by an explicit per-row infinity count so a single
+    open bound still propagates.
+    """
+    import scipy.sparse as sp
+
+    coo = sp.csr_matrix(A_ub).tocoo()
+    rows = coo.row
+    cols = coo.col
+    vals = coo.data
+    n_rows = coo.shape[0]
+    lo = lo.copy()
+    hi = hi.copy()
+    pos = vals > 0
+    neg = vals < 0
+
+    for _ in range(rounds):
+        # Bound each nonzero uses for the row's *minimum* activity: the lower
+        # endpoint where the coefficient is positive, the upper where negative.
+        bound_used = np.where(pos, lo[cols], hi[cols])
+        term = vals * bound_used  # may be -inf when a bound is open in that direction
+        is_ninf = ~np.isfinite(term)
+        # Per-row tally of infinite terms and the finite partial sum.
+        n_inf = np.zeros(n_rows)
+        np.add.at(n_inf, rows, is_ninf.astype(np.float64))
+        sum_fin = np.zeros(n_rows)
+        np.add.at(sum_fin, rows, np.where(is_ninf, 0.0, term))
+        # The activity excluding column j is finite iff every *other* term is
+        # finite, i.e. the row's infinity count drops to zero once j is removed.
+        valid = (n_inf[rows] - is_ninf.astype(np.float64)) == 0
+        min_others = sum_fin[rows] - np.where(is_ninf, 0.0, term)
+        nb = (b_ub[rows] - min_others) / vals
+        changed = False
+
+        sel = valid & pos
+        if sel.any():
+            new_hi = np.full(lo.shape[0], np.inf)
+            np.minimum.at(new_hi, cols[sel], nb[sel])
+            upd = new_hi < hi - tol
+            if upd.any():
+                hi = np.where(upd, np.minimum(hi, new_hi), hi)
+                changed = True
+        sel = valid & neg
+        if sel.any():
+            new_lo = np.full(lo.shape[0], -np.inf)
+            np.maximum.at(new_lo, cols[sel], nb[sel])
+            upd = new_lo > lo + tol
+            if upd.any():
+                lo = np.where(upd, np.maximum(lo, new_lo), lo)
+                changed = True
+        if not changed:
+            break
+
+    return lo, hi
+
 
 @dataclass
 class MccormickLPResult:
@@ -91,6 +183,15 @@ class MccormickLPRelaxer:
         self._rlt_applicable = os.environ.get("DISCOPT_RLT", "0") == "1" and bool(
             _linear_constraint_forms(model, self._n_orig)
         )
+        # Per-node lifted-LP FBBT (issue #184): propagate the relaxation's own
+        # McCormick rows to recover bilinear-implied factor bounds (e.g. a pinned
+        # binary forcing a continuous factor >= 1 *through* a bilinear constraint),
+        # then rebuild the relaxation on the tightened box so its envelopes no
+        # longer underestimate the product to zero. This is what lets the global
+        # dual bound climb off a structural 0 on ``ex1252``. Opt-in via
+        # ``DISCOPT_LIFTED_FBBT=1`` — it adds an FBBT sweep plus a conditional
+        # relaxation rebuild per node, so it stays off the default B&B path.
+        self._lifted_fbbt = os.environ.get("DISCOPT_LIFTED_FBBT", "0") == "1"
 
     @property
     def has_bilinear(self) -> bool:
@@ -149,6 +250,28 @@ class MccormickLPRelaxer:
             )
         except Exception:
             return MccormickLPResult(status="error")
+
+        # Per-node lifted-LP FBBT (issue #184): tighten the box by propagating the
+        # relaxation's own rows, then rebuild on the tightened original-variable
+        # box. The rebuild is what realises the bound improvement — tightening a
+        # factor's domain (``x0,x3 in [1,3]``) regenerates the McCormick envelope
+        # of ``x0·x3`` so it no longer underestimates the product to 0 in the box
+        # interior. Linear FBBT on the original model cannot reach this because the
+        # forcing runs through *bilinear* constraints; the relaxation's product
+        # rows expose it. Sound at every step (see :func:`_lifted_lp_fbbt`).
+        if self._lifted_fbbt:
+            try:
+                fb = self._lifted_fbbt_rebuild(milp, node_lb, node_ub)
+                if fb is not None:
+                    # Adopt the rebuilt relaxation *and* its varmap together: the
+                    # downstream separation routines index ``milp``'s product
+                    # columns through ``varmap``, so a stale map would address the
+                    # wrong columns of the rebuilt LP.
+                    milp, varmap = fb
+            except Exception:
+                # Tightening is a best-effort accelerator; on any failure keep the
+                # original (already valid) relaxation rather than losing the node.
+                pass
 
         # Pad original integrality flags to the lifted column count; aux cols
         # remain continuous (flag 0). If the model has no integers this is a
@@ -241,6 +364,77 @@ class MccormickLPRelaxer:
             lower_bound=float(res.objective),
             x=x_orig,
         )
+
+    def _lifted_fbbt_rebuild(self, milp, node_lb, node_ub):
+        """Tighten the node box via lifted-LP FBBT and rebuild the relaxation.
+
+        Returns ``(MilpRelaxationModel, varmap)`` built on the FBBT-tightened
+        original-variable box, or ``None`` to keep the input relaxation unchanged
+        (no original bound tightened, an empty box, a rebuild failure, or a
+        rebuild that would *lose* a previously valid objective bound).
+        """
+        if milp._A_ub is None:
+            return None
+
+        bnds = np.asarray(milp._bounds, dtype=np.float64)
+        lo = bnds[:, 0].copy()
+        hi = bnds[:, 1].copy()
+        node_lb = np.asarray(node_lb, dtype=np.float64)
+        node_ub = np.asarray(node_ub, dtype=np.float64)
+
+        lo, hi = _lifted_lp_fbbt(milp._A_ub, milp._b_ub, lo, hi)
+
+        n = self._n_orig
+        new_lb = lo[:n].copy()
+        new_ub = hi[:n].copy()
+
+        # An empty box anywhere is a rigorous infeasibility proof, but routing that
+        # verdict through a non-LP path would bypass the HiGHS re-verification the
+        # caller relies on for "infeasible". Conservatively skip the rebuild and let
+        # the (still valid) original relaxation solve report the node's status.
+        if np.any(new_lb > new_ub + _LIFTED_FBBT_TOL):
+            return None
+
+        # Only rebuild if an *original* variable's domain actually tightened — a
+        # rebuild that reproduces the same box is wasted work, and at shallow nodes
+        # (binaries still relaxed) FBBT typically tightens nothing useful.
+        tol = 1e-7
+        tightened = np.any(new_lb > node_lb[:n] + tol) or np.any(new_ub < node_ub[:n] - tol)
+        if not tightened:
+            return None
+
+        # Un-pin factors FBBT drove to a point. When a multilinear factor (e.g.
+        # ``x18``) is pinned to ``[1, 1]``, ``build_milp_relaxation`` folds the
+        # degree-4 objective term to a lower-arity product whose aux column it never
+        # allocated, and drops ``objective_bound_valid`` ("Trilinear (0,3,15) not in
+        # map"). Leaving a hair of width keeps the term at full arity. Widening a
+        # bound only *enlarges* the relaxation box (a superset of the proven point),
+        # so it stays a valid relaxation — never unsound. Branch-pinned variables
+        # (already a point on entry) are left pinned.
+        for i in range(n):
+            entry_pinned = (node_ub[i] - node_lb[i]) <= _LIFTED_FBBT_TOL
+            now_pinned = (new_ub[i] - new_lb[i]) <= _LIFTED_FBBT_TOL
+            if now_pinned and not entry_pinned:
+                w = max(1.0, abs(new_lb[i])) * _LIFTED_FBBT_UNPIN_EPS
+                if new_lb[i] > node_lb[i] + _LIFTED_FBBT_TOL:
+                    new_lb[i] -= w
+                else:
+                    new_ub[i] += w
+
+        rebuilt, rebuilt_varmap = build_milp_relaxation(
+            self._model,
+            self._terms,
+            self._disc,
+            bound_override=(new_lb, new_ub),
+            superposition=self._superposition,
+            rlt_level1=self._rlt_applicable,
+        )
+
+        # Never let tightening regress a node: if the rebuild would drop the
+        # objective bound that the original relaxation had, keep the original.
+        if milp._objective_bound_valid and not rebuilt._objective_bound_valid:
+            return None
+        return rebuilt, rebuilt_varmap
 
     def _separate_multilinear(self, milp, varmap, res, deadline):
         """Tighten products beyond the dense RLT cap by on-demand hull separation.

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -192,11 +192,7 @@ def equilibrate_relaxation_lp(
     col_scale = np.ones(n)
     row_scale = np.ones(m)
     # Columns we are allowed to scale: continuous only (integer cols stay at 1).
-    scalable = (
-        np.ones(n, dtype=bool)
-        if integrality is None
-        else (np.asarray(integrality) == 0)
-    )
+    scalable = np.ones(n, dtype=bool) if integrality is None else (np.asarray(integrality) == 0)
 
     for _ in range(iters):
         absA = A.copy()

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -143,6 +143,90 @@ _MAX_FINITE_DOMAIN_TRIG_TABLE_VALUES = 256
 # from 1e11 down to 1e6 on the affected instances.
 _RELAX_NUMERIC_CAP = 1e10
 
+# Equilibrate the lifted relaxation before an external LP/MILP solve when its
+# coefficient dynamic range exceeds this (matches the Rust simplex's own scaling
+# trigger). The lifted McCormick rows of a product over a wide variable box mix
+# tiny constants (~1e-9) with large bound-derived coefficients (~1e7), giving a
+# >1e15 spread on ex1252's boundary sub-boxes — HiGHS stalls on it (a 452x96 LP
+# hits its time limit) while the pure-Rust simplex, which equilibrates, solves it
+# in ~0.03s. Geometric-mean row/column scaling brings the spread down so the
+# external (HiGHS) path converges instead of timing out (issue #184).
+_RELAX_EQUILIBRATE_TRIGGER = 1e6
+
+
+def equilibrate_relaxation_lp(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]],
+    b_ub: Optional[np.ndarray],
+    bounds: list[tuple[float, float]],
+    integrality: Optional[np.ndarray],
+    *,
+    iters: int = 20,
+) -> tuple[
+    np.ndarray,
+    Optional[sp.spmatrix],
+    Optional[np.ndarray],
+    list[tuple[float, float]],
+    np.ndarray,
+]:
+    """Geometric-mean (Ruiz) equilibration of ``min c·x s.t. A_ub x <= b_ub``.
+
+    Alternating row/column infinity-norm sweeps drive every row and column to unit
+    scale; the factors are snapped to powers of two so the transform is exact in
+    floating point. **Integer columns are never scaled** (that would corrupt
+    integrality), so the conditioning of the integer part is left to the solver.
+
+    Soundness: this is an exact diagonal rescaling ``x = D·x'`` of the LP. Row
+    scaling ``s_r`` rewrites ``A_r x <= b_r`` as ``(s_r A_r) x <= s_r b_r`` — same
+    feasible set. Column scaling ``d_j`` substitutes ``x_j = d_j x'_j`` into the
+    objective and rows consistently. The optimal objective value is therefore
+    **unchanged**, so the LP/MILP bound from the scaled solve is the true bound;
+    only the returned point needs ``x = col_scale · x'`` to map back. Returns
+    ``(c', A', b', bounds', col_scale)``.
+    """
+    if A_ub is None or b_ub is None:
+        return np.asarray(c, dtype=np.float64), A_ub, b_ub, bounds, np.ones(len(c))
+
+    A = sp.csr_matrix(A_ub).astype(np.float64).copy()
+    m, n = A.shape
+    col_scale = np.ones(n)
+    row_scale = np.ones(m)
+    # Columns we are allowed to scale: continuous only (integer cols stay at 1).
+    scalable = (
+        np.ones(n, dtype=bool)
+        if integrality is None
+        else (np.asarray(integrality) == 0)
+    )
+
+    for _ in range(iters):
+        absA = A.copy()
+        absA.data = np.abs(absA.data)
+        rmax = np.asarray(absA.max(axis=1).todense()).ravel()
+        rmax[rmax == 0.0] = 1.0
+        dr = 2.0 ** np.round(np.log2(1.0 / np.sqrt(rmax)))
+        A = sp.diags(dr) @ A
+        row_scale *= dr
+
+        absA = A.copy()
+        absA.data = np.abs(absA.data)
+        cmax = np.asarray(absA.max(axis=0).todense()).ravel()
+        cmax[cmax == 0.0] = 1.0
+        dc = 2.0 ** np.round(np.log2(1.0 / np.sqrt(cmax)))
+        dc[~scalable] = 1.0
+        A = A @ sp.diags(dc)
+        col_scale *= dc
+
+    b2 = np.asarray(b_ub, dtype=np.float64) * row_scale
+    c2 = np.asarray(c, dtype=np.float64) * col_scale
+    bounds2 = [
+        (
+            lo / d if np.isfinite(lo) else lo,
+            hi / d if np.isfinite(hi) else hi,
+        )
+        for (lo, hi), d in zip(bounds, col_scale)
+    ]
+    return c2, sp.csr_matrix(A), b2, bounds2, col_scale
+
 
 def _warn_once(msg: str, *args) -> None:
     formatted = msg % args if args else msg
@@ -211,15 +295,39 @@ class MilpRelaxationModel:
         # to the warm-started-simplex B&B (falls back to auto if unavailable).
         solve_milp = get_milp_solver(backend=backend)
 
+        # Equilibrate the LP for the external (HiGHS/POUNCE) backends when it is
+        # badly scaled. The pure-Rust simplex already equilibrates internally, so
+        # skip the (redundant) Python pre-scaling there; HiGHS does not cope with
+        # the lifted relaxation's >1e15 coefficient spread and stalls without it
+        # (issue #184). The transform is exact, so the returned bound/objective is
+        # unchanged — only the solution point is mapped back through ``col_scale``.
+        c_s, A_s, b_s, bounds_s = self._c, self._A_ub, self._b_ub, self._bounds
+        col_scale = None
+        if backend != "simplex" and self._A_ub is not None:
+            data = sp.csr_matrix(self._A_ub).data
+            nz = np.abs(data[data != 0.0])
+            ill = bool(
+                nz.size
+                and np.isfinite(nz).all()
+                and nz.max() / nz.min() > _RELAX_EQUILIBRATE_TRIGGER
+            )
+            if ill:
+                c_s, A_s, b_s, bounds_s, col_scale = equilibrate_relaxation_lp(
+                    self._c, self._A_ub, self._b_ub, self._bounds, self._integrality
+                )
+
         result = solve_milp(
-            c=self._c,
-            A_ub=self._A_ub,
-            b_ub=self._b_ub,
-            bounds=self._bounds,
+            c=c_s,
+            A_ub=A_s,
+            b_ub=b_s,
+            bounds=bounds_s,
             integrality=self._integrality,
             time_limit=time_limit,
             gap_tolerance=gap_tolerance,
         )
+        # Map the scaled solution point back to original variables (x = D·x').
+        if col_scale is not None and result.x is not None:
+            result.x = np.asarray(result.x, dtype=np.float64) * col_scale
 
         # Map SolveStatus enum to string
         status_map = {

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -10,6 +10,8 @@ Connects:
 from __future__ import annotations
 
 import logging
+import math
+import os
 import time
 from typing import Any, Callable, Optional, cast
 
@@ -35,6 +37,133 @@ from discopt.solvers import SolveStatus
 from discopt.solvers.nlp_ipopt import solve_nlp
 
 logger = logging.getLogger(__name__)
+
+
+def _branch_priority_integer_vars(model: Model) -> frozenset[int]:
+    """Integer/binary flat indices that *gate* the model's nonlinear terms.
+
+    Branching these before other integers drives the global dual bound up on
+    problems whose relaxation bound is structurally 0 until a *set* of binaries
+    is jointly fixed. The objective products are nonnegative and zeroable on the
+    box boundary; a product's value is forced away from 0 only once the binaries
+    that select/activate it are all pinned (ex1252's line-selection binaries
+    ``x36/x37/x38``, tied to the product factors ``x18/x19/x20`` by the equality
+    constraints ``x18=x36`` ...). Because the bound moves only on the *joint*
+    fixing, no single-variable fractionality or pseudocost score points at these
+    variables, so most-fractional branching wanders with the bound pinned at 0.
+
+    The set is the integer variables that either (a) appear directly in a
+    nonlinear term, or (b) are tied to a nonlinear-term variable by a
+    two-variable linear *equality* constraint (``x_int = c·x_nl``). This is
+    branching-order metadata only — it never enters a bound or feasibility test,
+    so it cannot affect soundness.
+    """
+    from discopt._jax.term_classifier import _get_flat_index, classify_nonlinear_terms
+    from discopt.modeling.core import (
+        BinaryOp,
+        Constant,
+        IndexExpression,
+        UnaryOp,
+        Variable,
+    )
+
+    n = sum(v.size for v in model._variables)
+    is_int = [False] * n
+    fi = 0
+    for v in model._variables:
+        flag = v.var_type in (VarType.BINARY, VarType.INTEGER)
+        for _ in range(v.size):
+            if fi < n:
+                is_int[fi] = flag
+            fi += 1
+
+    # Variables appearing in any lifted nonlinear term (objective or constraint).
+    terms = classify_nonlinear_terms(model)
+    nl: set[int] = set()
+    for group in (terms.bilinear, terms.trilinear, terms.multilinear):
+        for term in group or []:
+            nl.update(int(x) for x in term)
+    for term in terms.monomial or []:
+        nl.add(int(term[0]))
+
+    priority: set[int] = {j for j in nl if 0 <= j < n and is_int[j]}
+
+    # Affine reduction of an expression to ``{idx: coeff}, const`` (None if the
+    # expression is not affine). Used to spot two-variable equality linkages.
+    def _affine(expr: Any, s: float = 1.0):
+        if isinstance(expr, Constant):
+            return ({}, s * float(expr.value))
+        if isinstance(expr, (Variable, IndexExpression)):
+            flat = _get_flat_index(expr, model)
+            if flat is None:
+                return None
+            return ({int(flat): s}, 0.0)
+        if isinstance(expr, UnaryOp) and expr.op == "neg":
+            return _affine(expr.operand, -s)
+        if isinstance(expr, BinaryOp):
+            if expr.op in ("+", "-"):
+                left = _affine(expr.left, s)
+                right = _affine(expr.right, s if expr.op == "+" else -s)
+                if left is None or right is None:
+                    return None
+                d = dict(left[0])
+                for k, val in right[0].items():
+                    d[k] = d.get(k, 0.0) + val
+                return (d, left[1] + right[1])
+            if expr.op == "*":
+                if isinstance(expr.left, Constant):
+                    return _affine(expr.right, s * float(expr.left.value))
+                if isinstance(expr.right, Constant):
+                    return _affine(expr.left, s * float(expr.right.value))
+        return None
+
+    for c in model._constraints:
+        if getattr(c, "sense", None) != "==":
+            continue
+        reduced = _affine(c.body)
+        if reduced is None:
+            continue
+        nz = [(k, v) for k, v in reduced[0].items() if abs(v) > 1e-12]
+        if len(nz) != 2:
+            continue
+        (i, _), (j, _) = nz
+        if is_int[i] and j in nl:
+            priority.add(i)
+        elif is_int[j] and i in nl:
+            priority.add(j)
+
+    return frozenset(priority)
+
+
+def _select_priority_branch_var(
+    solution: np.ndarray,
+    node_lb: np.ndarray,
+    node_ub: np.ndarray,
+    priority_vars: frozenset[int],
+    tol: float = 1e-5,
+) -> Optional[int]:
+    """Most-fractional priority var that is still a viable branch at this node.
+
+    Returns the flat index of the priority variable whose relaxation value is
+    most fractional and that is not already pinned by the node box, or ``None``
+    when no priority variable is branchable here (all fixed or integral — the
+    standard selector then applies). A hint is honoured by the Rust tree only
+    when the variable is fractional, matching this filter.
+    """
+    sol = np.asarray(solution)
+    best: Optional[int] = None
+    best_frac = tol
+    for j in priority_vars:
+        if j >= sol.shape[0] or node_ub[j] - node_lb[j] <= tol:
+            continue
+        val = float(sol[j])
+        frac = val - math.floor(val)
+        f = min(frac, 1.0 - frac)
+        if f > best_frac:
+            best_frac = f
+            best = int(j)
+    return best
+
 
 # --- POUNCE batched-NLP node solver tuning (Phase A, discopt#97) ---
 # The callback-based POUNCE batch path runs node NLPs through Python/JAX
@@ -2682,6 +2811,25 @@ def solve_model(
     _mc_nlp_period = 5  # run McCormick NLP every 5th iteration
     iteration = 0
     _deadline = t_start + time_limit
+
+    # Objective-gating priority branching (issue #184). Opt-in via
+    # ``DISCOPT_OBJ_BRANCH_PRIORITY=1``: branch the binaries that gate the
+    # objective's nonlinear terms first so the global bound can climb off a
+    # structural 0 (see _branch_priority_integer_vars). Empty when disabled or
+    # when the model has no such gating integers, leaving branching unchanged.
+    _branch_priority_vars: frozenset[int] = frozenset()
+    if os.environ.get("DISCOPT_OBJ_BRANCH_PRIORITY", "0") == "1":
+        try:
+            _branch_priority_vars = _branch_priority_integer_vars(model)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("objective-gating priority detection failed: %s", e)
+        if _branch_priority_vars:
+            logger.info(
+                "Objective-gating priority branching: %d integer var(s) %s",
+                len(_branch_priority_vars),
+                sorted(_branch_priority_vars),
+            )
+
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -3202,6 +3350,38 @@ def solve_model(
                 result_lbs[i] = _INFEASIBILITY_SENTINEL
                 result_feas[i] = False
 
+        # --- Objective-gating priority branching (issue #184) ---
+        # The global dual bound is the minimum over the open frontier, so it stays
+        # pinned at a structural 0 until *every* shallow node has had the binaries
+        # gating its objective products fixed. No single-variable fractionality or
+        # pseudocost score sees that joint jump (the bound moves only when a whole
+        # set of binaries is pinned), so most-fractional branching can wander for
+        # thousands of nodes at bound 0. Hinting the B&B to branch the gating
+        # binaries first reaches the depth where the per-node relaxation (lifted-LP
+        # FBBT) lifts each leaf off 0 — which is what raises the global bound. Pure
+        # search reordering over already-fractional integer candidates: it can
+        # never change a bound or a feasibility verdict.
+        priority_hinted: set[int] = set()
+        if _branch_priority_vars:
+            pb_ids: list[int] = []
+            pb_vars: list[int] = []
+            for i in range(n_batch):
+                if result_lbs[i] >= _SENTINEL_THRESHOLD:
+                    continue
+                pick = _select_priority_branch_var(
+                    result_sols[i], batch_lb[i], batch_ub[i], _branch_priority_vars
+                )
+                if pick is not None:
+                    nid = int(batch_ids[i])
+                    pb_ids.append(nid)
+                    pb_vars.append(pick)
+                    priority_hinted.add(nid)
+            if pb_ids:
+                tree.set_branch_hints(
+                    np.array(pb_ids, dtype=np.int64),
+                    np.array(pb_vars, dtype=np.int64),
+                )
+
         # --- Optional GNN branching scoring ---
         # GNN computes variable scores and passes hints to Rust TreeManager,
         # which uses them instead of most-fractional branching.
@@ -3212,7 +3392,7 @@ def solve_model(
             hint_node_ids = []
             hint_var_indices = []
             for i in range(n_batch):
-                if result_lbs[i] < _SENTINEL_THRESHOLD:
+                if result_lbs[i] < _SENTINEL_THRESHOLD and int(batch_ids[i]) not in priority_hinted:
                     node_lb_i = np.array(batch_lb[i])
                     node_ub_i = np.array(batch_ub[i])
                     graph = build_graph(model, result_sols[i], node_lb_i, node_ub_i)
@@ -3237,6 +3417,8 @@ def solve_model(
                 if result_lbs[i] >= _SENTINEL_THRESHOLD:
                     continue  # skip infeasible nodes
                 node_id = int(batch_ids[i])
+                if node_id in priority_hinted:
+                    continue  # gating-binary hint already set for this node
                 sol_i = result_sols[i]
                 var_indices, _frac_parts, obs_counts, _scores = tree.score_candidates(sol_i)
                 if len(var_indices) == 0:

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -261,9 +261,7 @@ def test_ex1252_objective_gating_priority_vars():
     m = dm.from_nl(str(nl))
 
     pri = _branch_priority_integer_vars(m)
-    assert sorted(pri) == [36, 37, 38], (
-        f"expected gating binaries {{36,37,38}}, got {sorted(pri)}"
-    )
+    assert sorted(pri) == [36, 37, 38], f"expected gating binaries {{36,37,38}}, got {sorted(pri)}"
 
     # The selector picks a fractional, unfixed priority var and skips a pinned one.
     import numpy as np
@@ -329,8 +327,13 @@ def test_ex1252_relaxation_equilibration_conditions_and_preserves_bound():
     from discopt._jax.milp_relaxation import MilpRelaxationModel
 
     scaled = MilpRelaxationModel(
-        c=c2, A_ub=A2, b_ub=b2, bounds=bounds2, obj_offset=milp._obj_offset,
-        integrality=None, objective_bound_valid=True,
+        c=c2,
+        A_ub=A2,
+        b_ub=b2,
+        bounds=bounds2,
+        obj_offset=milp._obj_offset,
+        integrality=None,
+        objective_bound_valid=True,
     ).solve(backend="simplex")
     assert raw.status == scaled.status == "optimal"
     assert abs(float(raw.bound) - float(scaled.bound)) <= 1e-6 + 1e-6 * abs(float(raw.bound))

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -279,3 +279,58 @@ def test_ex1252_objective_gating_priority_vars():
     lb_pinned[37] = ub_pinned[37] = 0.0
     sol_pinned = np.zeros(n)  # 36/38 integral, 37 fixed
     assert _select_priority_branch_var(sol_pinned, lb_pinned, ub_pinned, pri) is None
+
+
+@pytest.mark.correctness
+def test_ex1252_relaxation_equilibration_conditions_and_preserves_bound():
+    """LP conditioning (issue #184). ex1252's lifted relaxation on a boundary
+    sub-box (line 1+2 binaries both fixed) has a >1e12 coefficient spread, on
+    which HiGHS stalls. ``equilibrate_relaxation_lp`` (geometric-mean row/column
+    scaling) brings the spread down so the external LP backend converges instead
+    of timing out — and because the rescaling is exact, the bound is unchanged
+    and integer columns are never scaled.
+    """
+    import numpy as np
+    import scipy.sparse as sp
+    from discopt._jax.milp_relaxation import build_milp_relaxation, equilibrate_relaxation_lp
+
+    nl = _DATA / "ex1252.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+
+    nlb, nub = lb.copy(), ub.copy()
+    for k, val in zip((36, 37, 38), (1.0, 1.0, 0.0)):
+        nlb[k] = nub[k] = val
+    milp, _ = build_milp_relaxation(m, relaxer._terms, relaxer._disc, bound_override=(nlb, nub))
+
+    def _range(A):
+        d = np.abs(sp.csr_matrix(A).data)
+        d = d[d > 0]
+        return d.max() / d.min()
+
+    raw_range = _range(milp._A_ub)
+    assert raw_range > 1e12, f"expected ill-conditioned box, range only {raw_range:.1e}"
+
+    c2, A2, b2, bounds2, col_scale = equilibrate_relaxation_lp(
+        milp._c, milp._A_ub, milp._b_ub, milp._bounds, milp._integrality
+    )
+    assert _range(A2) < raw_range / 1e4, "equilibration did not materially reduce the spread"
+
+    # Integer columns must never be scaled (would corrupt integrality).
+    integ = np.asarray(milp._integrality)
+    assert np.all(col_scale[integ == 1] == 1.0)
+
+    # Exact rescaling ⇒ identical bound. Solve both the raw and equilibrated LP
+    # with the (fast, equilibrating) Rust simplex and require agreement.
+    milp._integrality = None
+    raw = milp.solve(backend="simplex")
+    from discopt._jax.milp_relaxation import MilpRelaxationModel
+
+    scaled = MilpRelaxationModel(
+        c=c2, A_ub=A2, b_ub=b2, bounds=bounds2, obj_offset=milp._obj_offset,
+        integrality=None, objective_bound_valid=True,
+    ).solve(backend="simplex")
+    assert raw.status == scaled.status == "optimal"
+    assert abs(float(raw.bound) - float(scaled.bound)) <= 1e-6 + 1e-6 * abs(float(raw.bound))

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -163,3 +163,84 @@ def test_ex1252_rlt_stays_sound(monkeypatch):
     assert res.lower_bound <= 128893.8 + 1e-3, (
         f"ex1252 RLT UNSOUND bound {res.lower_bound} > optimum 128893.8"
     )
+
+
+# Per-node lifted-LP FBBT (issue #184). ``ex1252``'s root bound is structurally 0
+# and no envelope/RLT cut can move it (the objective products are nonnegative and
+# zeroable on the box boundary). The bound only lifts once branching fixes the
+# line-selection binaries ``x36/x37/x38`` (≡ ``x18/x19/x20``): then propagating
+# the relaxation's *own* McCormick rows recovers the bilinear-implied factor
+# bounds (``x18=1`` ⟹ ``x9·x3=400`` ⟹ ``x3>=1``; ``x21=1`` ⟹ ``x0>=1``) that
+# purely linear FBBT misses, and rebuilding on the tightened box gives an
+# envelope that no longer underestimates the product to 0.
+_EX1252_LINE_BINARIES = (36, 37, 38)  # x18=x36, x19=x37, x20=x38 (constraints 40-42)
+
+
+@pytest.mark.correctness
+def test_ex1252_lifted_fbbt_tightens_branched_node(monkeypatch):
+    """At the branched node ``x36=1, x37=0, x38=0`` (line 1 selected), per-node
+    lifted-LP FBBT (``DISCOPT_LIFTED_FBBT=1``) drives the node bound off the
+    structural 0 — to ~18987 — while staying sound (``<= optimum 128893.8``). The
+    root bound is unchanged (binaries still relaxed there, so FBBT derives
+    nothing): the tightening is genuinely per-node, which is what lets the global
+    B&B certify optimality. This is the regression lock for #184.
+    """
+    monkeypatch.setenv("DISCOPT_LIFTED_FBBT", "1")
+    nl = _DATA / "ex1252.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+
+    # Root: binaries relaxed, so lifted FBBT cannot tighten — bound stays ~0.
+    root = relaxer.solve_at_node(lb, ub)
+    assert root.status == "optimal", f"ex1252 root LP status {root.status}"
+    assert root.lower_bound is not None and root.lower_bound <= 1.0, (
+        f"ex1252 root bound unexpectedly {root.lower_bound} (expected ~0)"
+    )
+
+    # Branched node: fix line-selection binaries (x36=1, x37=x38=0).
+    nlb, nub = lb.copy(), ub.copy()
+    for k in _EX1252_LINE_BINARIES:
+        val = 1.0 if k == 36 else 0.0
+        nlb[k] = nub[k] = val
+    node = relaxer.solve_at_node(nlb, nub)
+
+    assert node.status == "optimal", f"ex1252 branched LP status {node.status}"
+    assert node.lower_bound is not None and math.isfinite(node.lower_bound), (
+        "ex1252 branched node dropped its objective bound"
+    )
+    # Tightness lock: the bound must climb well off 0 (validated ~18987).
+    assert node.lower_bound > 1000.0, (
+        f"ex1252 lifted-FBBT bound {node.lower_bound} did not lift off the "
+        "structural 0 — per-node tightening regressed"
+    )
+    # Soundness: a valid lower bound never exceeds the true optimum.
+    assert node.lower_bound <= 128893.8 + 1e-3, (
+        f"ex1252 lifted-FBBT UNSOUND bound {node.lower_bound} > optimum 128893.8"
+    )
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("instance, optimum", _SOUND_BOUND_CASES)
+def test_bucket2_lifted_fbbt_stays_sound(monkeypatch, instance, optimum):
+    """Enabling per-node lifted-LP FBBT keeps every bucket-2 root bound sound
+    (finite and ``<= optimum``). Lifted FBBT only ever tightens with valid
+    relaxation rows, so no instance may gain an unsound (over-tight) bound."""
+    monkeypatch.setenv("DISCOPT_LIFTED_FBBT", "1")
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+    res = relaxer.solve_at_node(lb, ub)
+
+    assert res.status == "optimal", f"[{instance}] lifted-FBBT root LP status {res.status}"
+    assert res.lower_bound is not None and math.isfinite(res.lower_bound), (
+        f"[{instance}] lifted-FBBT dropped the root bound"
+    )
+    assert res.lower_bound <= optimum + 1e-3, (
+        f"[{instance}] lifted-FBBT UNSOUND root bound {res.lower_bound} > optimum {optimum}"
+    )

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -244,3 +244,38 @@ def test_bucket2_lifted_fbbt_stays_sound(monkeypatch, instance, optimum):
     assert res.lower_bound <= optimum + 1e-3, (
         f"[{instance}] lifted-FBBT UNSOUND root bound {res.lower_bound} > optimum {optimum}"
     )
+
+
+@pytest.mark.correctness
+def test_ex1252_objective_gating_priority_vars():
+    """The objective-gating branch-priority detector (issue #184) identifies
+    exactly ex1252's line-selection binaries ``x36/x37/x38`` — the integers tied
+    by the equalities ``x18=x36`` etc. to the objective's product factors
+    ``x18/x19/x20``. Branching these first is what lets the global dual bound
+    climb off its structural 0. This is branch-ORDER metadata only (never a bound
+    input), so the lock guards the heuristic, not soundness."""
+    from discopt.solver import _branch_priority_integer_vars, _select_priority_branch_var
+
+    nl = _DATA / "ex1252.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+
+    pri = _branch_priority_integer_vars(m)
+    assert sorted(pri) == [36, 37, 38], (
+        f"expected gating binaries {{36,37,38}}, got {sorted(pri)}"
+    )
+
+    # The selector picks a fractional, unfixed priority var and skips a pinned one.
+    import numpy as np
+
+    n = sum(v.size for v in m._variables)
+    lb, ub = flat_variable_bounds(m)
+    sol = np.zeros(n)
+    sol[37] = 0.5  # fractional gating binary
+    assert _select_priority_branch_var(sol, lb, ub, pri) == 37
+    # Pin x37 (already branched): no priority var is branchable → None.
+    ub_pinned = ub.copy()
+    lb_pinned = lb.copy()
+    lb_pinned[37] = ub_pinned[37] = 0.0
+    sol_pinned = np.zeros(n)  # 36/38 integral, 37 fixed
+    assert _select_priority_branch_var(sol_pinned, lb_pinned, ub_pinned, pri) is None


### PR DESCRIPTION
## Summary

Three sound mechanisms from #184 that drive `ex1252`'s structurally-zero node bound up, plus the supporting LP-conditioning work. All are validated and regression-locked. Full end-to-end *global*-bound certification on `ex1252` is **not** reached here — the remaining blockers are solver-performance (root cost, node throughput, SOS1 selectors) and are tracked in the follow-up #196.

### 1. Per-node lifted-LP FBBT — `509da8c` (opt-in `DISCOPT_LIFTED_FBBT=1`)
Propagates the McCormick relaxation's **own** rows `A_ub·z ≤ b_ub` (spanning the lifted product/monomial columns) to recover the **bilinear-implied** factor bounds that purely linear FBBT misses (`x18=0.0025·x9·x3` with `x18` pinned ⟹ `x3 ≥ 1`), then rebuilds the relaxation on the tightened box so its envelopes no longer underestimate the product to 0.
- `_lifted_lp_fbbt` (vectorised over the sparse matrix); `_lifted_fbbt_rebuild` un-pins factors driven to a point by a hair so `build_milp_relaxation` keeps the term at full arity and never drops `objective_bound_valid`.
- **Validated:** branched node `x36=1,x37=0,x38=0` → bound **0 → 18987**, sound (≤ opt 128893.8).
- Sound by construction: only valid rows tighten; un-pinning only enlarges the box.

### 2. Objective-gating priority branching — `b55afd1` (opt-in `DISCOPT_OBJ_BRANCH_PRIORITY=1`)
The global bound is the min over the frontier, so it stays at 0 until a *set* of binaries is jointly fixed — a joint jump no single-variable fractionality/pseudocost score sees. `_branch_priority_integer_vars` detects the integers gating the objective's nonlinear terms (those in, or equality-linked to, a lifted product/monomial — exactly `{x36,x37,x38}` on `ex1252`) and hints the B&B to branch them first via the existing `set_branch_hints` path. Pure search reordering over already-fractional integer candidates → cannot affect a bound or feasibility verdict.

### 3. Lifted-relaxation LP equilibration — `bd358ea` (automatic on ill-conditioned boxes)
The lifted McCormick rows mix ~1e-9 constants with large bound-derived coefficients, giving a **>1e15 spread** on `ex1252`'s boundary sub-boxes; HiGHS stalls (a 452×96 LP hits its time limit) while the pure-Rust simplex, which equilibrates internally, solves it in ~0.03s. `equilibrate_relaxation_lp` applies geometric-mean (Ruiz) row/column scaling (power-of-two snapped) before the external HiGHS/POUNCE solve when the spread exceeds 1e6. Exact rescaling → bound/feasibility unchanged, integer columns never scaled, solution mapped back through the column scale.
- **Effect:** `x36=1,x37=1` boundary box **time-out → 4.5s**; end-to-end throughput ~4× (the catastrophic 100s+ HiGHS hangs are gone).

## Regression locks (`test_bucket2_sound_bounds.py`)
- `test_ex1252_lifted_fbbt_tightens_branched_node` — node bound lifts 0 → ~18987, sound.
- `test_bucket2_lifted_fbbt_stays_sound` — all bucket-2 instances stay sound with lifted FBBT on.
- `test_ex1252_objective_gating_priority_vars` — detector returns exactly `{36,37,38}`; selector behaviour.
- `test_ex1252_relaxation_equilibration_conditions_and_preserves_bound` — spread reduction, integer-column invariance, exact bound preservation.

## Verification
- Full bucket-2 soundness + tightness suite: **23 passed**.
- `ruff check` / `ruff format --check` / `mypy python/discopt/`: clean on changed files.
- Lifted FBBT and priority branching default **off** (env-gated); equilibration is exact and only activates on ill-conditioned matrices, so the default B&B path's results are unchanged.

## Not in this PR (tracked in #196)
End-to-end global-bound closure on `ex1252` needs: cutting the ~64s root cost, raising per-node throughput (McCormick LP + ≤14 separation rounds dominate), an FBBT-corroborated infeasibility fathom, and SOS1-aware handling of the `x21+x22+x23=1` selectors.

Part of #184. Follow-up: #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nv1FXz9nGB1gvAdBdexXLS