### PR TITLE
fix: MINLP soundness + perf hardening bundle from global-opt loop

### DIFF
--- a/crates/discopt-core/examples/par_bench.rs
+++ b/crates/discopt-core/examples/par_bench.rs
@@ -122,6 +122,7 @@ fn opts(inst: &Instance) -> MilpOptions {
         simplex: SimplexOptions {
             tol: 1e-9,
             max_iter: 100_000,
+            deadline: None,
         },
     }
 }

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -178,6 +178,22 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
     // the tree are added once and shared by all nodes.
     let mut pool_sigs: HashSet<Vec<(u32, i64)>> = HashSet::new();
 
+    // Absolute wall-clock deadline for the whole solve (root cuts + B&B),
+    // computed up front so even the root-cut LP solves below honour it. The
+    // simplex options carry it into every primal/dual loop, so a single
+    // pathological dense LP cannot run past the budget; `node_simplex` is the
+    // deadline-aware variant used for all LP solves here. See
+    // `SimplexOptions::deadline`.
+    let t_start = std::time::Instant::now();
+    let deadline = opts
+        .time_limit_s
+        .map(|tl| t_start + std::time::Duration::from_secs_f64(tl));
+    let node_simplex = {
+        let mut sx = opts.simplex.clone();
+        sx.deadline = deadline;
+        sx
+    };
+
     // --- P5/P8: multi-round root GMI cuts from the native simplex basis ---
     // Each round re-solves the (growing) root LP and separates GMI cuts off its
     // native basis, adding them as `coeffs·x − s = rhs` surplus rows. Iterating
@@ -199,7 +215,7 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
                 l: &l_w,
                 u: &u_w,
             };
-            let root = solve_lp(&root_lp, &b_w, &opts.simplex);
+            let root = solve_lp(&root_lp, &b_w, &node_simplex);
             lp_iters += root.iters;
             if root.status != LpStatus::Optimal {
                 break;
@@ -254,19 +270,16 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
     let mut slack_l = l_w[ns..].to_vec();
     let mut slack_u = u_w[ns..].to_vec();
 
-    let t_start = std::time::Instant::now();
-    // Absolute wall-clock deadline. The loop-top check below stops *dispatching*
-    // new batches once it passes, but a 64-node batch with strong branching can
-    // itself run several seconds, so a sub-second `time_limit_s` would overshoot
-    // by that whole batch. `solve_node` reads this deadline to drop each node's
+    // `deadline` (computed above, before the root cuts) drives two layers of
+    // budget enforcement: the loop-top check below stops *dispatching* new
+    // batches once it passes; `solve_node` reads it to drop each node's
     // *optional* effort (strong branching, cover separation, rounding) once it is
     // reached — leaving only the cheap LP solve that yields the node's valid
     // bound — so the in-flight batch drains quickly instead of running to
-    // completion. Soundness is untouched: those steps only change branching
-    // choice / cut tightness / early incumbents, never a bound's validity.
-    let deadline = opts
-        .time_limit_s
-        .map(|tl| t_start + std::time::Duration::from_secs_f64(tl));
+    // completion; and `node_simplex.deadline` bounds each individual LP solve
+    // from inside the simplex loop. Soundness is untouched: those steps only
+    // change branching choice / cut tightness / early incumbents, never a
+    // bound's validity.
     'search: loop {
         if tm.is_finished() || tm.gap() <= opts.gap_tol {
             break;
@@ -340,6 +353,7 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
                 n_orig_rows,
                 obj_const,
                 opts,
+                simplex: &node_simplex,
                 sb_active,
                 inc_snapshot: tm.incumbent().map(|(_, inc)| inc),
                 reliability: tm.get_reliability_threshold(),
@@ -377,6 +391,15 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
         for (k, out) in outputs.into_iter().enumerate() {
             let id = batch.node_ids[k];
             lp_iters += out.iters;
+            if out.deferred {
+                // Deadline hit before this node's LP solve. Skip it entirely: do
+                // not import a result, so the node keeps its parent-inherited
+                // bound and stays a valid open node. The gap cannot be certified
+                // once any node went unsolved, and the loop-top deadline check
+                // breaks the search on the next iteration.
+                gap_certified = false;
+                continue;
+            }
             if out.unbounded {
                 hit_unbounded = true;
                 break;
@@ -499,6 +522,10 @@ struct NodeCtx<'a> {
     n_orig_rows: usize,
     obj_const: f64,
     opts: &'a MilpOptions,
+    /// Deadline-aware simplex options (a clone of `opts.simplex` carrying the
+    /// solve's wall-clock `deadline`). Used for every node/strong-branch LP solve
+    /// so a single dense, degenerate relaxation cannot overrun the time budget.
+    simplex: &'a SimplexOptions,
     sb_active: bool,
     /// Incumbent value at batch start (for the strong-branch prunable check).
     inc_snapshot: Option<f64>,
@@ -533,6 +560,13 @@ struct NodeOutput {
     unbounded: bool,
     /// LP hit iter-limit / numerical breakdown — gap can't be certified.
     uncertified: bool,
+    /// The wall-clock deadline had already passed when this node was dequeued, so
+    /// its (expensive) LP solve was skipped entirely. The reduce drops it without
+    /// importing a result, leaving the node Evaluated with its parent-inherited
+    /// bound — so the returned dual bound stays valid (just not sharpened by this
+    /// node) and the in-flight batch drains in O(0) instead of running every
+    /// remaining node's relaxation past the deadline.
+    deferred: bool,
 }
 
 /// Evaluate a single B&B node: solve its LP relaxation (cold, or warm from the
@@ -541,6 +575,37 @@ struct NodeOutput {
 /// plus a read-only tree snapshot), so it is safe to call concurrently across a
 /// batch. Returns a [`NodeOutput`] the caller folds into the tree sequentially.
 fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> NodeOutput {
+    // Deadline guard BEFORE the expensive LP solve. The loop-top check only stops
+    // *dispatching* new batches; a single batch of N nodes whose per-node LP costs
+    // ~seconds (e.g. a dense lifted McCormick relaxation) would otherwise run the
+    // whole batch past the deadline — N x per-node-LP overshoot. Checking here lets
+    // every node dequeued after the deadline return immediately, so the in-flight
+    // batch drains and the loop-top check fires, bounding overshoot to the handful
+    // of nodes already mid-solve. Sound: the node is left Evaluated with its
+    // parent-inherited bound (the reduce skips importing a deferred result), so the
+    // returned dual lower bound stays valid — only sharpening is skipped, never a
+    // bound's validity. gap is decertified on the deadline path regardless.
+    if ctx
+        .deadline
+        .is_some_and(|d| std::time::Instant::now() >= d)
+    {
+        return NodeOutput {
+            result: NodeResult {
+                node_id: id,
+                lower_bound: f64::NEG_INFINITY,
+                solution: Vec::new(),
+                is_feasible: false,
+            },
+            basis: None,
+            incumbent: None,
+            found_cuts: Vec::new(),
+            branch_hint: None,
+            iters: 0,
+            unbounded: false,
+            uncertified: true,
+            deferred: true,
+        };
+    }
     let mut full_l = vec![0.0; ctx.n_w];
     let mut full_u = vec![0.0; ctx.n_w];
     full_l[..ctx.ns].copy_from_slice(lb_k);
@@ -581,9 +646,9 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
     let mut sol = match ctx.tm.node_basis(id) {
         Some(basis) => {
             let basis = extend_basis(basis, ctx.n_w);
-            solve_lp_warm_scaled(&solve_lp_view, ctx.sb, &basis, &ctx.opts.simplex)
+            solve_lp_warm_scaled(&solve_lp_view, ctx.sb, &basis, ctx.simplex)
         }
-        None => solve_lp_scaled(&solve_lp_view, ctx.sb, &ctx.opts.simplex),
+        None => solve_lp_scaled(&solve_lp_view, ctx.sb, ctx.simplex),
     };
     if let Some(s) = ctx.scaling {
         s.unscale_x(&mut sol.x);
@@ -604,6 +669,7 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
         iters: sol.iters,
         unbounded: false,
         uncertified: false,
+        deferred: false,
     };
 
     match sol.status {
@@ -725,7 +791,7 @@ fn strong_branch(
     node_obj: f64,
     cands: &[(usize, f64, u32, f64)],
 ) -> (Option<usize>, usize) {
-    let simplex = &ctx.opts.simplex;
+    let simplex = ctx.simplex;
     // Unreliable candidates, most-fractional (nearest 0.5) first.
     let mut cand: Vec<(usize, f64)> = cands
         .iter()

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -215,6 +215,19 @@ impl<'a> PreparedDual<'a> {
         // affects correctness (any infeasible basic var is a valid leaving choice).
         let mut gamma = vec![1.0f64; m];
         for _iter in 0..opts.max_iter {
+            // Poll the wall-clock deadline (see SimplexOptions::deadline). On a
+            // timeout we abandon the warm dual re-solve and request the cold
+            // fallback by returning None; the cold primal solve re-checks the
+            // same deadline on its first iteration and returns IterLimit, which
+            // the B&B treats soundly. Polled every 256 pivots to keep the now()
+            // cost negligible against a full ftran iteration.
+            if (_iter & 255) == 0
+                && opts
+                    .deadline
+                    .is_some_and(|d| std::time::Instant::now() >= d)
+            {
+                return None;
+            }
             // Basic values x_B = B⁻¹(b − Σ_nonbasic A_j x_j).
             let mut xb = b.to_vec();
             for j in 0..n {

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -54,6 +54,17 @@ pub struct SimplexOptions {
     pub tol: f64,
     /// Maximum pivots before declaring [`LpStatus::IterLimit`].
     pub max_iter: usize,
+    /// Optional absolute wall-clock deadline. When set, the primal and dual
+    /// iteration loops poll it every few hundred pivots and bail out with
+    /// [`LpStatus::IterLimit`] once it passes. This bounds the cost of a *single*
+    /// pathological LP solve — e.g. a dense, degenerate lifted-McCormick
+    /// relaxation that would otherwise grind all the way to `max_iter` and blow
+    /// past the enclosing MILP/B&B time budget. The bail is reported exactly like
+    /// the iteration cap, which every caller already treats soundly: the node
+    /// gets a non-pruning bound and the gap is left uncertified, so optimality is
+    /// never falsely claimed. `None` (the default) disables the check, leaving
+    /// short LP solves bit-identical to before.
+    pub deadline: Option<std::time::Instant>,
 }
 
 impl Default for SimplexOptions {
@@ -61,6 +72,7 @@ impl Default for SimplexOptions {
         Self {
             tol: 1e-9,
             max_iter: 100_000,
+            deadline: None,
         }
     }
 }

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -97,6 +97,9 @@ struct Simplex<'a> {
     na: usize, // n + m (with artificials appended)
     tol: f64,
     max_iter: usize,
+    /// Absolute wall-clock deadline (polled inside the iteration loop); `None`
+    /// disables the check. See [`SimplexOptions::deadline`].
+    deadline: Option<std::time::Instant>,
     lu: FeralLU,
     basis: Vec<usize>, // slot -> column (len m)
     slot_of: Vec<i64>, // column -> slot, or -1
@@ -124,6 +127,7 @@ impl<'a> Simplex<'a> {
             na,
             tol: opts.tol,
             max_iter: opts.max_iter,
+            deadline: opts.deadline,
             lu: FeralLU::new(),
             basis: Vec::new(),
             slot_of: vec![-1; na],
@@ -331,6 +335,20 @@ impl<'a> Simplex<'a> {
             .basic_values(art_sign)
             .map_err(|_| LpStatus::Numerical)?;
         for _iter in 0..self.max_iter {
+            // Poll the wall-clock deadline every 256 pivots (cheap relative to a
+            // pricing+ftran iteration). A dense, degenerate lifted-McCormick LP
+            // can otherwise grind toward `max_iter` and run uninterruptibly for
+            // minutes; bailing as IterLimit keeps the enclosing B&B inside its
+            // time budget, and the caller treats the loose bound soundly (no
+            // prune, gap left uncertified). Checks at _iter == 0 too, so a cold
+            // fallback entered already past the deadline returns immediately.
+            if (_iter & 255) == 0
+                && self
+                    .deadline
+                    .is_some_and(|d| std::time::Instant::now() >= d)
+            {
+                return Err(LpStatus::IterLimit);
+            }
             // price: y = B⁻ᵀ c_B ; reduced cost d_j = c_j − yᵀA_j
             let mut y: Vec<f64> = self.basis.iter().map(|&j| cost[j]).collect();
             if self.lu.btran(&mut y).is_err() {

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -235,7 +235,11 @@ pub fn solve_lp_py<'py>(
         l: lb.as_slice()?,
         u: ub.as_slice()?,
     };
-    let opts = SimplexOptions { tol, max_iter };
+    let opts = SimplexOptions {
+        tol,
+        max_iter,
+        deadline: None,
+    };
     let sol = simplex_solve_lp(&lp, b.as_slice()?, &opts);
     let status = match sol.status {
         LpStatus::Optimal => "optimal",
@@ -303,7 +307,11 @@ pub fn solve_lp_batch_py<'py>(
             u: ub_flat[t * n..(t + 1) * n].to_vec(),
         })
         .collect();
-    let opts = SimplexOptions { tol, max_iter };
+    let opts = SimplexOptions {
+        tol,
+        max_iter,
+        deadline: None,
+    };
     // The solve touches no Python objects, so release the GIL to let the core's
     // rayon workers run the batch concurrently without contending on it.
     let sols = py.allow_threads(|| solve_lp_batch(&a_owned, m, n, &c_owned, &instances, &opts));
@@ -408,6 +416,9 @@ pub fn solve_milp_py<'py>(
         simplex: SimplexOptions {
             tol,
             max_iter: 100_000,
+            // The MILP driver clones this and injects its own wall-clock deadline
+            // from `time_limit_s`, so the base options leave it unset.
+            deadline: None,
         },
     };
     let res = py.allow_threads(|| {

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -135,7 +135,16 @@ class _Lifter:
     def __init__(self, model: Model):
         self.model = model
         self._cache: dict[tuple[int, int], Variable] = {}
-        self._expr_cache: dict[int, Variable] = {}
+        # Keyed by a STRUCTURAL representation of the expression, never ``id()``:
+        # CPython recycles the ``id()`` of a garbage-collected object, so a later,
+        # structurally *different* expression can reuse a freed address and score a
+        # false cache hit — returning a stale aux for the wrong sub-expression.
+        # In ex7_2_3 that dropped a ``/x8`` denominator from a lifted ratio,
+        # producing a non-feasibility-preserving reformulation that certified an
+        # infeasible box corner as the global optimum (a false "optimal"). A
+        # structural key can only ever *fail* to dedup (harmless — an extra aux),
+        # never falsely merge two distinct expressions.
+        self._expr_cache: dict[str, Variable] = {}
         self.aux_constraints: list[Constraint] = []
         self._counter = 0
 
@@ -170,7 +179,7 @@ class _Lifter:
         monomial lift so any mixed products inside *base* become bilinear aux too.
         Deduplicated by structural identity of the (already-distributed) node.
         """
-        key = id(expr)
+        key = repr(expr)
         cached = self._expr_cache.get(key)
         if cached is not None:
             return cached

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -16,6 +16,7 @@ that fits the per-node call shape in :mod:`discopt.solver`.
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from dataclasses import dataclass
@@ -25,6 +26,8 @@ import numpy as np
 
 from discopt._jax.discretization import DiscretizationState
 from discopt._jax.milp_relaxation import (
+    _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE,
+    _RELAX_NUMERIC_CAP,
     _collect_affine_powers,
     _linear_constraint_forms,
     build_milp_relaxation,
@@ -32,10 +35,28 @@ from discopt._jax.milp_relaxation import (
 from discopt._jax.term_classifier import NonlinearTerms, classify_nonlinear_terms
 from discopt.modeling.core import Model, VarType
 
+logger = logging.getLogger(__name__)
+# Dedup key set so the oversize-lift fallback warns once per (cols, rows) shape.
+_oversize_warned: set[int] = set()
+
 # When a per-node wall-clock budget is threaded through solve_at_node, no single
 # internal re-solve is handed less than this floor (keeps a node that straddles
 # the deadline from receiving a zero/negative budget the backend would reject).
 _SOLVE_DEADLINE_FLOOR_S = 0.05
+
+# Densification cap for the lifted relaxation. The matrix-form MILP backends
+# (warm-started Rust simplex, POUNCE) materialize a DENSE ``(m, n+m)`` constraint
+# array plus a dense ``m×m`` slack identity, so their footprint scales as
+# ``(n_cols + n_rows) * n_rows`` cells. A binary-multilinear lift explodes the row
+# count -- e.g. autocorr_bern's degree-4 objective lifts to ~3.7k cols × ~85k rows,
+# whose dense form is ~7.5e9 cells (~60 GB): the allocation thrashes swap and never
+# returns (a hang, not a bound). Above this cap the LP relaxer declines the node
+# (returns no bound) and the spatial/integer B&B falls back to the rigorous
+# alphaBB/interval underestimator -- a valid, if weaker, lower bound -- so the
+# solve still returns its incumbent within the time limit instead of hanging.
+# ~1e8 cells ≈ 800 MB dense: far above any well-posed relaxation in practice
+# (typical MINLP lifts are < 1e6 cells) and far below the multi-GB blowup.
+_MAX_RELAX_DENSE_CELLS = 1.0e8
 
 
 @dataclass
@@ -150,6 +171,31 @@ class MccormickLPRelaxer:
         except Exception:
             return MccormickLPResult(status="error")
 
+        # Densification guard: decline nodes whose lifted relaxation would force a
+        # multi-GB dense allocation in the matrix-form backend (see
+        # ``_MAX_RELAX_DENSE_CELLS``). Returning no bound here is sound -- it only
+        # forgoes this node's LP underestimator; the caller keeps the rigorous
+        # alphaBB/interval bound and the incumbent search, so the solve respects
+        # its time limit instead of hanging on the dense solve.
+        n_cols = int(np.size(milp._c))
+        _a_ub = milp._A_ub
+        n_rows = 0 if _a_ub is None else int(_a_ub.shape[0])
+        if (n_cols + n_rows) * n_rows > _MAX_RELAX_DENSE_CELLS:
+            key = (n_cols, n_rows).__hash__()
+            if key not in _oversize_warned:
+                _oversize_warned.add(key)
+                logger.warning(
+                    "McCormick LP relaxation too large to solve densely "
+                    "(%d cols x %d rows ~ %.1e dense cells > cap %.0e); declining "
+                    "the per-node LP bound and falling back to the rigorous "
+                    "alphaBB/interval underestimator.",
+                    n_cols,
+                    n_rows,
+                    float((n_cols + n_rows) * n_rows),
+                    _MAX_RELAX_DENSE_CELLS,
+                )
+            return MccormickLPResult(status="skipped_oversize")
+
         # Pad original integrality flags to the lifted column count; aux cols
         # remain continuous (flag 0). If the model has no integers this is a
         # pure LP anyway.
@@ -169,6 +215,29 @@ class MccormickLPRelaxer:
             milp._integrality = self._orig_integrality
         if milp._integrality is not None and not int(milp._integrality.sum()):
             milp._integrality = None
+
+        # Soundness/conditioning guard (issue #15): the warm-started Rust simplex
+        # mishandles effectively-infinite *finite* variable bounds -- the ``1e20``
+        # sentinel discopt assigns to unbounded variables -- and declares a
+        # premature "optimal" at a wrong value. On ex9_2_6's root McCormick LP the
+        # simplex returns 0.0 where HiGHS returns -406.0; the bogus 0.0 (which
+        # exceeds the true optimum) then prunes the root and certifies a
+        # suboptimal incumbent -- a false-"optimal", the worst failure class.
+        # Clamp any bound whose magnitude reaches the effective-infinity cap to a
+        # true +/-inf before solving. This only WIDENS a variable's box, so it
+        # merely enlarges the relaxed feasible set and the LP optimum stays a
+        # valid (never-too-high) lower bound; it is a no-op on well-scaled boxes
+        # and routes genuine unbounded variables through the simplex's correct
+        # free-variable handling. Mirrors the root path's
+        # ``sanitize_relaxation_for_conditioning``.
+        _cap = _RELAX_NUMERIC_CAP
+        milp._bounds = [
+            (
+                lo if abs(lo) < _cap else (-np.inf if lo < 0 else np.inf),
+                hi if abs(hi) < _cap else (np.inf if hi > 0 else -np.inf),
+            )
+            for (lo, hi) in milp._bounds
+        ]
 
         # The caller's ``time_limit`` is the budget for the WHOLE node, but this
         # method re-solves the relaxation many times (the initial solve, up to
@@ -229,6 +298,31 @@ class MccormickLPRelaxer:
             if verify.status == "optimal":
                 res = verify
 
+        # Soundness guard (residual conditioning): even after the bound clamp
+        # above, an LP whose constraint/coefficient magnitudes remain large can
+        # still fool the fast simplex into a wrong "optimal" -- a dual bound that
+        # is too HIGH, the most dangerous unsoundness (a too-high lower bound
+        # fathoms feasible nodes and certifies a suboptimal incumbent). When the
+        # relaxation is still ill-conditioned above the magnitude where the
+        # simplex is unreliable (the same ``_LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE``
+        # line the cut builders abstain at), cross-check the optimum with HiGHS
+        # and adopt its value whenever it is lower. Adopting only a LOWER bound
+        # can never cause an unsound fathom, and the gate keeps this off the
+        # common well-scaled fast path (no extra solve).
+        if (
+            res.status == "optimal"
+            and self._backend != "auto"
+            and res.objective is not None
+            and self._max_finite_magnitude(milp) > _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE
+        ):
+            verify = milp.solve(time_limit=_remaining(), backend="auto")
+            if (
+                verify.status == "optimal"
+                and verify.objective is not None
+                and verify.objective < res.objective - 1e-6
+            ):
+                res = verify
+
         # A valid lower bound on the original problem requires the relaxation LP
         # to be solved to OPTIMALITY; any other terminal status yields no
         # certified bound, so report the status with no lower bound and let the
@@ -241,6 +335,37 @@ class MccormickLPRelaxer:
             lower_bound=float(res.objective),
             x=x_orig,
         )
+
+    @staticmethod
+    def _max_finite_magnitude(milp) -> float:
+        """Largest finite magnitude across the LP's data (cost, rows, RHS, bounds).
+
+        A cheap conditioning proxy used to gate the HiGHS cross-check: well-scaled
+        relaxations stay on the fast simplex path, ill-conditioned ones get
+        re-verified. Non-finite entries (the +/-inf bounds left by the clamp) are
+        ignored.
+        """
+        import scipy.sparse as sp
+
+        worst = 0.0
+        A = milp._A_ub
+        if A is not None:
+            data = A.data if sp.issparse(A) else np.asarray(A).ravel()
+            if np.size(data):
+                fin = np.abs(data[np.isfinite(data)])
+                if fin.size:
+                    worst = max(worst, float(fin.max()))
+        for arr in (milp._b_ub, milp._c):
+            if arr is not None and np.size(arr):
+                a = np.abs(np.asarray(arr, dtype=np.float64).ravel())
+                fin = a[np.isfinite(a)]
+                if fin.size:
+                    worst = max(worst, float(fin.max()))
+        for lo, hi in milp._bounds:
+            for v in (lo, hi):
+                if np.isfinite(v):
+                    worst = max(worst, abs(float(v)))
+        return worst
 
     def _separate_multilinear(self, milp, varmap, res, deadline):
         """Tighten products beyond the dense RLT cap by on-demand hull separation.

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -1156,6 +1156,16 @@ def _decompose_product(
                 if key in fractional_power_var_map:
                     var_indices.append(fractional_power_var_map[key])
                     return True
+        # Fold a *composite* variable-free factor (e.g. ``neg(1e6)`` from a
+        # parsed ``-1e6*i1*i2``, or ``(-3)*(-3)``) into the scalar. A bare
+        # ``Constant`` is handled above; this catches negations/arithmetic over
+        # constants that would otherwise look like an undecomposable factor and
+        # cause the whole product (and its constraint) to be dropped from the
+        # relaxation. Exact and variable-free, so it only ever tightens.
+        cval = _eval_constant_expr(e)
+        if cval is not None:
+            scalar[0] *= cval
+            return True
         return False
 
     if not visit(expr):

--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -83,6 +83,71 @@ def build_flat_variable_metadata(model: Model) -> FlatVariableMetadata:
     return FlatVariableMetadata(base_offsets=base_offsets, flat_var_types=tuple(flat_var_types))
 
 
+def _model_structural_token(model: Model) -> tuple[int, int]:
+    """Identity token for a model's constraint set, used to validate caches.
+
+    Nonlinear tightening runs once per branch-and-bound node on the *same* model
+    with only the numeric variable box changing; the symbolic constraint DAG is
+    invariant. This token detects the rare case of the model being mutated
+    (constraints rebuilt, added, or removed) between calls so that structural
+    caches are dropped rather than reused stale.
+    """
+    constraints = model._constraints
+    return (id(constraints), len(constraints))
+
+
+def _get_struct_cache(model: Model) -> dict:
+    """Return (building if needed) the per-model structural cache.
+
+    Holds bound-independent decompositions reused across B&B nodes: the flat
+    variable metadata and the additive flattening of constraint bodies. The cache
+    is keyed to a structural token and rebuilt if the model's constraint set
+    changes. If the model cannot store an attribute, a fresh (non-persistent)
+    cache is returned so callers degrade gracefully to recomputation.
+    """
+    token = _model_structural_token(model)
+    cache = getattr(model, "_nl_struct_cache", None)
+    if cache is None or cache.get("token") != token:
+        cache = {
+            "token": token,
+            "flatten": {},
+            "metadata": build_flat_variable_metadata(model),
+        }
+        try:
+            setattr(model, "_nl_struct_cache", cache)
+        except Exception:
+            pass
+    return cache
+
+
+def _cached_flat_metadata(model: Model) -> FlatVariableMetadata:
+    """Return per-model flat-variable metadata, cached across B&B nodes."""
+    metadata: FlatVariableMetadata = _get_struct_cache(model)["metadata"]
+    return metadata
+
+
+def _cached_flat_terms(model: Model, expr) -> list[tuple[float, object]]:
+    """Return the additive flattening of ``expr`` at unit scale, cached per model.
+
+    ``_flatten_sum`` walks the symbolic expression DAG with isinstance dispatch on
+    every node. That structure is invariant across B&B nodes (only the numeric box
+    changes), so the result is memoized keyed by expression identity. The returned
+    list is identical to a fresh ``_flatten_sum`` call — exact-math-preserving.
+
+    Callers MUST treat the returned list as read-only; it is shared with the cache.
+    All current rules iterate it read-only.
+    """
+    cache = _get_struct_cache(model)
+    flatten = cache["flatten"]
+    key = id(expr)
+    terms: Optional[list[tuple[float, object]]] = flatten.get(key)
+    if terms is None:
+        terms = []
+        _flatten_sum(expr, 1.0, terms)
+        flatten[key] = terms
+    return terms
+
+
 @dataclass(frozen=True)
 class NonlinearBoundTighteningStats:
     """Summary of a nonlinear tightening pass."""
@@ -536,8 +601,7 @@ class SumOfSquaresUpperBoundRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
-            terms: list[tuple[float, object]] = []
-            _flatten_sum(constraint.body, 1.0, terms)
+            terms = _cached_flat_terms(model, constraint.body)
 
             constant_term = 0.0
             square_coeffs: dict[int, float] = {}
@@ -689,8 +753,7 @@ class SqrtSumOfSquaresUpperBoundRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
-            terms: list[tuple[float, object]] = []
-            _flatten_sum(constraint.body, 1.0, terms)
+            terms = _cached_flat_terms(model, constraint.body)
 
             constant_term = 0.0
             sqrt_match: Optional[tuple[float, dict[int, float]]] = None
@@ -776,8 +839,7 @@ class SeparableQuadraticUpperBoundRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
-            terms: list[tuple[float, object]] = []
-            _flatten_sum(constraint.body, 1.0, terms)
+            terms = _cached_flat_terms(model, constraint.body)
 
             constant_term = 0.0
             quad_coeffs: dict[int, float] = {}
@@ -1024,8 +1086,7 @@ class MonotoneFunctionEqualityRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) != "==":
                 continue
 
-            terms: list[tuple[float, object]] = []
-            _flatten_sum(constraint.body, 1.0, terms)
+            terms = _cached_flat_terms(model, constraint.body)
 
             constant_term = 0.0
             affine_match: Optional[tuple[Optional[int], float, float]] = None
@@ -1208,8 +1269,7 @@ class MonotoneFunctionBoundsRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
-            terms: list[tuple[float, object]] = []
-            _flatten_sum(constraint.body, 1.0, terms)
+            terms = _cached_flat_terms(model, constraint.body)
 
             constant_term = 0.0
             function_match: Optional[tuple[str, float, int, float, float]] = None
@@ -1345,8 +1405,7 @@ class QuadraticEqualityBoundsRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) != "==":
                 continue
 
-            terms: list[tuple[float, object]] = []
-            _flatten_sum(constraint.body, 1.0, terms)
+            terms = _cached_flat_terms(model, constraint.body)
 
             constant_term = 0.0
             affine_match: Optional[tuple[Optional[int], float, float]] = None
@@ -1674,8 +1733,7 @@ class PositiveAffineReciprocalBoundsRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
-            terms: list[tuple[float, object]] = []
-            _flatten_sum(constraint.body, 1.0, terms)
+            terms = _cached_flat_terms(model, constraint.body)
 
             constant_term = 0.0
             reciprocal_match: Optional[tuple[float, object]] = None
@@ -1744,8 +1802,7 @@ class NegativePowerBoundsRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
-            terms: list[tuple[float, object]] = []
-            _flatten_sum(constraint.body, 1.0, terms)
+            terms = _cached_flat_terms(model, constraint.body)
 
             power_match: Optional[tuple[int, float, float]] = None
             affine_coeff = np.zeros(n_vars, dtype=np.float64)
@@ -1891,8 +1948,7 @@ class ReciprocalBoundsRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
-            terms: list[tuple[float, object]] = []
-            _flatten_sum(constraint.body, 1.0, terms)
+            terms = _cached_flat_terms(model, constraint.body)
 
             constant_term = 0.0
             reciprocal_match: Optional[tuple[float, int, float, float]] = None
@@ -1992,7 +2048,7 @@ def tighten_nonlinear_bounds(
     tightened_ub = np.asarray(flat_ub, dtype=np.float64).copy()
     initial_lb = tightened_lb.copy()
     initial_ub = tightened_ub.copy()
-    metadata = build_flat_variable_metadata(model)
+    metadata = _cached_flat_metadata(model)
 
     applied_rules: list[str] = []
 

--- a/python/discopt/_jax/presolve_pipeline.py
+++ b/python/discopt/_jax/presolve_pipeline.py
@@ -279,9 +279,34 @@ def propagate_bounds_to_model(model, model_repr) -> int:
 
     n_tightened = 0
     py_blocks = list(model._variables)
-    n_blocks = min(len(py_blocks), model_repr.n_var_blocks)
-    for bi in range(n_blocks):
-        block = py_blocks[bi]
+
+    # Map Rust blocks to Python variable blocks *by name*, not by position.
+    # Variable-eliminating passes (``aggregate``/``eliminate``) call
+    # ``variables.remove(elim_block)`` on the Rust side, which shifts every
+    # subsequent block index down. A positional ``min(len, n_blocks)`` mapping
+    # then silently cross-assigns each surviving block's (tighter) bounds onto
+    # the *wrong* Python variable — for models with adjacent fixed/negatively
+    # bounded variables (e.g. gastransnlp) this fabricates empty boxes and a
+    # false ``infeasible`` verdict. Matching on the Rust-side ``var_names``
+    # keeps the mapping correct regardless of how many variables were removed.
+    try:
+        rust_names = list(model_repr.var_names())
+    except Exception:  # pragma: no cover - older repr without var_names
+        rust_names = None
+
+    if rust_names is not None and len(rust_names) == model_repr.n_var_blocks:
+        py_by_name = {blk.name: blk for blk in py_blocks}
+        block_iter = [(py_by_name[nm], ri) for ri, nm in enumerate(rust_names) if nm in py_by_name]
+    else:
+        # Fallback: only trust positional mapping when the index space is
+        # provably unchanged (no variable was eliminated). Otherwise skip
+        # propagation entirely — forgoing presolve tightening is sound; a
+        # misaligned positional copy is not.
+        if model_repr.n_var_blocks != len(py_blocks):
+            return 0
+        block_iter = [(py_blocks[bi], bi) for bi in range(len(py_blocks))]
+
+    for block, bi in block_iter:
         py_lb = np.asarray(block.lb, dtype=np.float64)
         py_ub = np.asarray(block.ub, dtype=np.float64)
         rust_lb = np.asarray(model_repr.var_lb(bi), dtype=np.float64)

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -181,6 +181,7 @@ def feasibility_pump(
     max_rounds: int = 5,
     ipopt_options: Optional[dict] = None,
     backend: Optional[Callable] = None,
+    evaluator: Optional[NLPEvaluator] = None,
 ) -> Optional[np.ndarray]:
     """Try to find an integer-feasible solution via rounding + re-solve.
 
@@ -197,6 +198,12 @@ def feasibility_pump(
         backend: ``solve_nlp(evaluator, x0, options=...)`` callable. If None,
             resolves to ``get_nlp_solver("auto")``
             (POUNCE-preferred, falling back to cyipopt).
+        evaluator: Optional prebuilt :class:`NLPEvaluator` for ``model``. Reusing
+            the caller's evaluator avoids rebuilding (and recompiling, ~3s) the
+            JAX sparse-Hessian/Jacobian kernels for the same model structure.
+            The evaluator reads variable bounds from the model on each solve, so
+            the integer-pinning below is honoured regardless of which evaluator
+            is used. If None, a fresh one is constructed.
 
     Returns:
         An integer-feasible solution vector, or None if not found.
@@ -207,7 +214,8 @@ def feasibility_pump(
         return x_nlp.copy()
 
     lb, ub = _get_variable_bounds(model)
-    evaluator = NLPEvaluator(model)
+    if evaluator is None:
+        evaluator = NLPEvaluator(model)
 
     opts = dict(ipopt_options) if ipopt_options else {}
     opts.setdefault("print_level", 0)
@@ -232,20 +240,54 @@ def feasibility_pump(
 
         # Clip to bounds
         x_try = np.clip(x_try, lb, ub)
-
-        # Fix integer variables: set lb = ub for them in a modified evaluator
-        # Instead of rebuilding the evaluator, we fix by tightening bounds on x0
-        # and re-solving with the original evaluator. The rounded integer values
-        # are used as the starting point. Ipopt will respect variable bounds.
         x0 = x_try.copy()
 
-        nlp_result = backend(evaluator, x0, options=opts)
-        if not _is_nlp_feasible(nlp_result):
+        # Actually FIX the integer variables at their rounded values by pinning
+        # lb = ub = rounded value on the model (NLPEvaluator reads bounds from the
+        # model each call), then re-solve only the continuous variables. Without
+        # this, the re-solve uses the original (open) bounds and drifts the
+        # integers straight back to their fractional relaxation values, so the
+        # rounding — and the perturbation below — accomplishes nothing. Bounds are
+        # always restored in the finally so the search tree is left untouched.
+        saved_bounds: list[tuple[np.ndarray, np.ndarray]] = []
+        try:
+            offset = 0
+            for v in model._variables:
+                sz = v.size
+                saved_bounds.append((v.lb.copy(), v.ub.copy()))
+                if v.var_type in (VarType.BINARY, VarType.INTEGER):
+                    fixed = x0[offset : offset + sz].reshape(v.lb.shape)
+                    v.lb = fixed.copy()
+                    v.ub = fixed.copy()
+                offset += sz
+            try:
+                nlp_result = backend(evaluator, x0, options=opts)
+            except BaseException:
+                # Some NLP backends (pounce via PyO3) raise PanicException, which
+                # is not a subclass of Exception; treat any failure as this round
+                # producing no point and perturb on the next round.
+                continue
+        finally:
+            for v, (lb_v, ub_v) in zip(model._variables, saved_bounds):
+                v.lb = lb_v
+                v.ub = ub_v
+
+        if not _is_nlp_feasible(nlp_result) or nlp_result.x is None:
             continue
 
-        assert nlp_result.x is not None
-        if _is_integer_feasible(nlp_result.x, int_mask):
-            return nlp_result.x.copy()
+        x_cand = np.asarray(nlp_result.x).copy()
+        # Snap any tiny drift on the pinned integers, then require BOTH integer
+        # and constraint feasibility. Checking constraints here (not just
+        # integrality, which is trivially satisfied once integers are pinned) is
+        # what makes the perturbation loop useful: an infeasible rounding is
+        # rejected and the next round tries a perturbed neighbour instead of
+        # returning a point the caller will only discard.
+        x_cand[int_mask] = np.round(x_cand[int_mask])
+        if not _is_integer_feasible(x_cand, int_mask):
+            continue
+        if not _check_constraint_feasibility(evaluator, x_cand):
+            continue
+        return x_cand
 
     return None
 
@@ -254,15 +296,46 @@ def _check_constraint_feasibility(
     evaluator: NLPEvaluator,
     x: np.ndarray,
     tol: float = 1e-6,
+    rtol: float = 1e-9,
 ) -> bool:
-    """Check that ``x`` satisfies the model's constraints to within ``tol``."""
+    """Check that ``x`` satisfies the model's constraints to within tolerance.
+
+    A pure ABSOLUTE tolerance (``tol``) is too strict for constraints built from
+    large-magnitude nonlinear terms: an objective-linking row such as
+    ``592*x1**0.65 + ... - objvar <= 0`` evaluates as the difference of two
+    quantities near 1.5e5, so its floating-point cancellation noise alone is
+    ~1e-6 -- exactly the absolute tolerance. discopt then rejects a genuinely
+    optimal point (prob07: the true global basin at obj 154990 carries a 2.4e-6
+    residual on that one row and was discarded, leaving a worse 162070 incumbent)
+    while BARON, which scales feasibility by constraint magnitude, accepts it.
+
+    Use the conventional combined test ``|viol| <= tol + rtol*scale`` where the
+    per-row ``scale`` is the absolute linearized magnitude ``sum_j |J_ij|*|x_j|``
+    -- the size of the row's additive terms, derived from the Jacobian and NOT
+    from the (possibly +/-1e20 sentinel) bound values, so an unbounded row cannot
+    inflate the tolerance. ``rtol`` is kept extremely tight (1e-9) so this only
+    ever forgives cancellation noise proportional to the terms; any violation of
+    real consequence is still rejected. The absolute test is tried first and the
+    Jacobian (the only added cost) is evaluated only for rows that fail it, so
+    well-scaled feasible points keep the original cheap path unchanged.
+    """
     if evaluator.n_constraints == 0:
         return True
     g = np.asarray(evaluator.evaluate_constraints(x))
     from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
 
-    cl, cu = _infer_constraint_bounds(evaluator)
-    return bool(np.all(g >= cl - tol) and np.all(g <= cu + tol))
+    cl, cu = (np.asarray(b, dtype=np.float64) for b in _infer_constraint_bounds(evaluator))
+    viol = np.maximum(np.maximum(cl - g, 0.0), np.maximum(g - cu, 0.0))
+    if bool(np.all(viol <= tol)):
+        return True
+    # Some row exceeds the absolute tolerance: re-test those rows against a
+    # term-magnitude-scaled tolerance before declaring infeasibility.
+    try:
+        jac = np.abs(np.asarray(evaluator.evaluate_jacobian(x), dtype=np.float64))
+        scale = jac @ np.abs(np.asarray(x, dtype=np.float64))
+    except Exception:
+        return False
+    return bool(np.all(viol <= tol + rtol * scale))
 
 
 def subnlp(
@@ -345,7 +418,17 @@ def subnlp(
             v.lb = lb_v
             v.ub = ub_v
 
-    if not _is_nlp_feasible(nlp_result):
+    # Accept either a converged (OPTIMAL) solve or an ITERATION_LIMIT one: an
+    # interior-point solver routinely caps out one step short of its convergence
+    # test at a point that is already constraint-feasible (prob07's true-global
+    # basin terminates at ITERATION_LIMIT, obj 154990). The shared
+    # ``_is_nlp_feasible`` gate accepts OPTIMAL only and so discarded that point,
+    # leaving a worse incumbent. Trusting the returned point is sound here only
+    # because subnlp re-verifies genuine constraint- and integer-feasibility
+    # below (``_check_constraint_feasibility`` / ``_is_integer_feasible``), and
+    # ``inject_incumbent`` enforces strict improvement -- this mirrors the
+    # acceptance set ``_solve_root_node_multistart`` already uses.
+    if nlp_result.status not in (SolveStatus.OPTIMAL, SolveStatus.ITERATION_LIMIT):
         return None
     if nlp_result.x is None or nlp_result.objective is None:
         return None
@@ -366,6 +449,210 @@ def subnlp(
     # Recompute objective at the snapped point to keep it consistent.
     obj = float(evaluator.evaluate_objective(x_out))
     return x_out, obj
+
+
+def integer_local_search(
+    model: Model,
+    x_relax: np.ndarray,
+    backend: Optional[Callable] = None,
+    evaluator: Optional[NLPEvaluator] = None,
+    nlp_options: Optional[dict] = None,
+    max_restarts: int = 24,
+    max_steps: int = 60,
+    pair_cap: int = 40,
+    time_budget: float = 3.0,
+    feas_tol: float = 1e-6,
+    seed: int = 0,
+) -> Optional[tuple[np.ndarray, float]]:
+    """Constraint-violation-guided integer local search (1-opt + 2-opt).
+
+    The round-and-repair heuristics (:func:`feasibility_pump`, :func:`subnlp`)
+    only repair the *continuous* variables — they take the relaxation's integer
+    assignment as given. For integer-heavy nonconvex problems the relaxation's
+    integers are optimal for the *relaxed* (e.g. McCormick) constraints yet
+    violate the TRUE constraints, and no continuous re-solve fixes that. This
+    heuristic instead searches the integer lattice directly: it descends the
+    total true-constraint violation by unit moves (1-opt steepest descent; with
+    pairwise 2-opt moves when 1-opt stalls — essential for bilinear constraints
+    such as ``x*y >= c`` where a single variable cannot move the product), then
+    repairs the continuous variables and verifies true feasibility via
+    :func:`subnlp` at each local minimum. A few perturbation restarts escape
+    shallow local minima.
+
+    Sound by construction: only points that pass subnlp's integer- and
+    constraint-feasibility checks are returned, so the caller may inject them as
+    incumbents without affecting any dual bound or certification. The cost is
+    bounded by ``time_budget`` (wall-clock), ``max_restarts`` and ``max_steps``;
+    2-opt is skipped when the integer count exceeds ``pair_cap`` to avoid the
+    O(n^2) neighbourhood blowing up on large models.
+
+    Args:
+        model: The optimization model.
+        x_relax: Relaxation point (a B&B node's relaxed solution).
+        backend: NLP backend for the continuous repair; resolved via
+            ``get_nlp_solver('auto')`` when None.
+        evaluator: Pre-built NLPEvaluator; one is constructed if omitted.
+        nlp_options: Options forwarded to the NLP backend during repair.
+        max_restarts: Number of perturbation restarts.
+        max_steps: Max descent steps per restart.
+        pair_cap: Max integer count for which 2-opt is enabled.
+        time_budget: Wall-clock budget in seconds (the whole call returns early
+            once exceeded).
+        feas_tol: Constraint feasibility tolerance.
+        seed: RNG seed for reproducible perturbations.
+
+    Returns:
+        ``(x, obj)`` for the best feasible point found, else ``None``.
+    """
+    import time
+
+    if evaluator is None:
+        evaluator = NLPEvaluator(model)
+    int_mask = _get_integer_mask(model)
+    if not np.any(int_mask) or evaluator.n_constraints == 0:
+        # Pure-continuous or unconstrained: nothing for an integer lattice
+        # search to do — the continuous repair heuristics cover those.
+        return None
+
+    if backend is None:
+        from discopt.solvers.nlp_backend import get_nlp_solver
+
+        backend = get_nlp_solver("auto")
+
+    from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+    lb, ub = _get_variable_bounds(model)
+    cl, cu = _infer_constraint_bounds(evaluator)
+    cl = np.asarray(cl, dtype=np.float64)
+    cu = np.asarray(cu, dtype=np.float64)
+    int_idx = np.where(int_mask)[0]
+    n_int = int(int_idx.size)
+    use_2opt = n_int <= pair_cap
+
+    def violation(x: np.ndarray) -> float:
+        g = np.asarray(evaluator.evaluate_constraints(x))
+        return float(np.sum(np.maximum(0.0, cl - g)) + np.sum(np.maximum(0.0, g - cu)))
+
+    deadline = time.perf_counter() + max(0.0, time_budget)
+
+    def _round_clip(x: np.ndarray) -> np.ndarray:
+        y = np.asarray(x, dtype=np.float64).copy()
+        y[int_mask] = np.round(y[int_mask])
+        return np.clip(y, lb, ub)
+
+    # Seed pool. The caller's relaxation point can be a degenerate vertex of a
+    # *different* relaxation (e.g. a McCormick node solution that parks integer
+    # multipliers at a bound, killing every bilinear product) — a dead basin for
+    # local moves. So also seed from the model's own continuous relaxation: the
+    # NLPEvaluator treats integers as continuous in [lb, ub], so a single NLP
+    # solve from the box midpoint yields a balanced fractional point that rounds
+    # into a far better basin. Both are rounded and used as restart bases.
+    seeds: list[np.ndarray] = [_round_clip(x_relax)]
+    try:
+        mid = np.clip(0.5 * (lb + ub), -1e3, 1e3)
+        relax_opts = dict(nlp_options) if nlp_options else {}
+        relax_opts.setdefault("print_level", 0)
+        relax_res = backend(evaluator, mid, options=relax_opts)
+        if relax_res is not None and relax_res.x is not None:
+            seeds.append(_round_clip(np.asarray(relax_res.x)))
+    except BaseException:
+        # Backend may panic (pounce/PyO3); fall back to the caller's seed alone.
+        pass
+
+    rng = np.random.default_rng(seed)
+    best: Optional[tuple[np.ndarray, float]] = None
+    n_seeds = len(seeds)
+
+    for restart in range(max(max_restarts, n_seeds)):
+        if time.perf_counter() >= deadline:
+            break
+        # Try each seed clean first (descent alone often suffices), then spend
+        # remaining restarts perturbing — from a feasible base once one is found,
+        # else cycling the seed pool to diversify the basin.
+        if restart < n_seeds:
+            xc = seeds[restart].copy()
+        else:
+            base = best[0] if best is not None else seeds[restart % n_seeds]
+            xc = _round_clip(base)
+            sel = rng.choice(int_idx, size=int(rng.integers(1, n_int + 1)), replace=False)
+            if rng.random() < 0.5:
+                # Local ±1 nudge: explore the current basin's neighbourhood.
+                step = rng.choice([-1.0, 0.0, 1.0], size=sel.size)
+                xc[sel] = np.clip(xc[sel] + step, lb[sel], ub[sel])
+            else:
+                # Full-domain random resample: a global jump that can reach a
+                # disconnected feasible well. Essential when feasibility lives on
+                # an isolated discrete set — e.g. integers pinned by a high-degree
+                # equality (i-1)(i-2)...(i-k)=0, where every ±1 step off a root
+                # explodes the violation, so local moves can never hop roots.
+                # Descent from the random point then drives each integer to its
+                # nearest root, so diverse random draws cover diverse root combos.
+                for j in sel:
+                    xc[j] = float(rng.integers(int(lb[j]), int(ub[j]) + 1))
+
+        cur = violation(xc)
+        for _ in range(max_steps):
+            if cur <= feas_tol or time.perf_counter() >= deadline:
+                break
+            best_v = cur
+            best_move: Optional[tuple[tuple[int, float], ...]] = None
+            # 1-opt steepest descent.
+            for j in int_idx:
+                for d in (-1.0, 1.0):
+                    nv = xc[j] + d
+                    if nv < lb[j] - 1e-9 or nv > ub[j] + 1e-9:
+                        continue
+                    xt = xc.copy()
+                    xt[j] = nv
+                    v = violation(xt)
+                    if v < best_v - 1e-9:
+                        best_v, best_move = v, ((j, nv),)
+            # 2-opt fallback only when 1-opt cannot improve (bilinear coupling).
+            if best_move is None and use_2opt and time.perf_counter() < deadline:
+                for a in range(n_int):
+                    ja = int_idx[a]
+                    for b in range(a + 1, n_int):
+                        jb = int_idx[b]
+                        for da in (-1.0, 1.0):
+                            na = xc[ja] + da
+                            if na < lb[ja] - 1e-9 or na > ub[ja] + 1e-9:
+                                continue
+                            for db in (-1.0, 1.0):
+                                nb = xc[jb] + db
+                                if nb < lb[jb] - 1e-9 or nb > ub[jb] + 1e-9:
+                                    continue
+                                xt = xc.copy()
+                                xt[ja] = na
+                                xt[jb] = nb
+                                v = violation(xt)
+                                if v < best_v - 1e-9:
+                                    best_v, best_move = v, ((ja, na), (jb, nb))
+            if best_move is None:
+                break  # local minimum
+            for j, nv in best_move:
+                xc[j] = nv
+            cur = best_v
+
+        # Repair the continuous variables at this (locally good) integer
+        # assignment and verify TRUE feasibility. subnlp only returns feasible,
+        # integer-consistent points, so anything it gives back is a valid
+        # incumbent candidate.
+        repaired = subnlp(
+            model,
+            xc,
+            backend=backend,
+            nlp_options=nlp_options,
+            evaluator=evaluator,
+            feas_tol=feas_tol,
+        )
+        if repaired is not None:
+            x_ok, obj_ok = repaired
+            if best is None or obj_ok < best[1]:
+                best = (np.asarray(x_ok).copy(), float(obj_ok))
+            # Once feasible, later perturbed restarts dive from this point's
+            # neighbourhood (see the restart-base selection above) to improve it.
+
+    return best
 
 
 def enumerate_binary_seeds_subnlp(

--- a/python/discopt/modeling/gams_parser.py
+++ b/python/discopt/modeling/gams_parser.py
@@ -948,9 +948,19 @@ class _Parser:
         model_name = self._expect(_Tok.IDENT).value
         self._expect(_Tok.IDENT, "using")
         model_type = self._expect(_Tok.IDENT).value.lower()
-        sense_tok = self._expect(_Tok.IDENT)
-        sense = sense_tok.value.lower()
-        obj_var = self._expect(_Tok.IDENT).value
+        # Optimization solves carry a sense keyword + objective variable
+        # ("... minimizing z"). Objectiveless model types — CNS (Constrained
+        # Nonlinear System) and MCP (Mixed Complementarity Problem) — have
+        # neither; they are pure feasibility / square-system solves. Only consume
+        # the sense + objective when a sense keyword actually follows, so an
+        # objectiveless solve parses as a feasibility problem (no objective set)
+        # instead of failing on the missing "minimizing"/"maximizing" token.
+        sense = "minimizing"
+        obj_var = ""
+        cur = self._cur()
+        if cur.kind == _Tok.IDENT and cur.value.lower() in ("minimizing", "maximizing"):
+            sense = self._advance().value.lower()
+            obj_var = self._expect(_Tok.IDENT).value
         self._skip_semi()
         self.solves.append(GamsSolve(model_name, model_type, sense, obj_var))
 
@@ -1045,6 +1055,7 @@ class _Parser:
         "tanh",
         "power",
         "sign",
+        "signpower",
         "min",
         "max",
         "ceil",
@@ -1636,6 +1647,19 @@ class _ModelBuilder:
                 else:
                     m.maximize(obj_var)
 
+        # Objectiveless solves (CNS — Constrained Nonlinear System, MCP — Mixed
+        # Complementarity) and any solve whose objective variable could not be
+        # resolved leave no objective set. GAMS treats CNS/MCP as pure
+        # feasibility / square-system solves ("find x satisfying all equations").
+        # Model that exactly as "minimize 0 subject to the constraints": a
+        # constant objective makes every feasible point optimal, which is the
+        # CNS semantics, and lets the model validate + solve instead of raising
+        # "No objective set". Gated on an EMPTY objective variable so a genuine
+        # optimization solve whose objective var failed to resolve still raises
+        # loudly rather than being silently downgraded to a feasibility solve.
+        if m._objective is None and not obj_var_name:
+            m.minimize(0.0)
+
     def _is_obj_equation(self, eqdef, obj_var_name: str | None) -> bool:
         if obj_var_name is None:
             return False
@@ -1728,22 +1752,25 @@ class _ModelBuilder:
             raise GamsParseError(f"Cannot resolve indexed ref: {name}")
 
         if isinstance(ast_node, ExprBinOp):
-            left = self._build_expr(ast_node.left, env)
-            right = self._build_expr(ast_node.right, env)
-            # handle string returns (index values) — convert to constants
-            left = self._ensure_expr(left)
-            right = self._ensure_expr(right)
-            if ast_node.op == "+":
-                return left + right
-            if ast_node.op == "-":
-                return left - right
-            if ast_node.op == "*":
-                return left * right
-            if ast_node.op == "/":
-                return left / right
-            if ast_node.op == "**":
-                return left**right
-            raise GamsParseError(f"Unknown operator: {ast_node.op}")
+            # Iteratively unwind the LEFT-associative operator spine instead of
+            # recursing into ``ast_node.left``. The precedence-climbing parser
+            # builds long flat chains (e.g. a 1000-term autocorrelation sum) as a
+            # left-deep tree ``(((a+b)+c)+d)``; a naive recursion descends once
+            # per term and overflows the (C) stack on large models — manifesting
+            # as a RecursionError at the default limit or a hard hang/segfault
+            # once the recursion limit is raised. Walking the left spine in a
+            # loop makes this O(N) iterative while preserving exact left-to-right
+            # evaluation order (so ``-``/``/`` and float rounding are unchanged).
+            chain = []  # (op, right_ast), collected top-down
+            node: object = ast_node
+            while isinstance(node, ExprBinOp):
+                chain.append((node.op, node.right))
+                node = node.left
+            acc = self._ensure_expr(self._build_expr(node, env))
+            for op, right_ast in reversed(chain):
+                right = self._ensure_expr(self._build_expr(right_ast, env))
+                acc = self._apply_binop(op, acc, right)
+            return acc
 
         if isinstance(ast_node, ExprUnaryMinus):
             operand = self._build_expr(ast_node.operand, env)
@@ -1777,6 +1804,21 @@ class _ModelBuilder:
             return dm.Constant(1.0)
 
         raise GamsParseError(f"Unknown AST node: {type(ast_node)}")
+
+    @staticmethod
+    def _apply_binop(op, left, right):
+        """Apply a binary operator to two already-built Expression operands."""
+        if op == "+":
+            return left + right
+        if op == "-":
+            return left - right
+        if op == "*":
+            return left * right
+        if op == "/":
+            return left / right
+        if op == "**":
+            return left**right
+        raise GamsParseError(f"Unknown operator: {op}")
 
     def _ensure_expr(self, val):
         """Convert non-Expression values (strings, ints, floats) to Constant."""
@@ -2049,6 +2091,26 @@ class _ModelBuilder:
             return args[0] ** args[1]
         if fn == "sign":
             return dm.sign(args[0])
+        if fn == "signpower":
+            # GAMS signpower(x, p) = sign(x) * |x|^p, exactly equal to the
+            # smooth form x * |x|^(p-1) for all p >= 0 (both are 0 at x=0).
+            # Using x*|x|^(p-1) avoids a spurious sign() discontinuity that
+            # would otherwise wreck the relaxation.  Fold a constant exponent
+            # so the relaxation/FBBT see a clean form (for p=2 this is x*|x|).
+            base = args[0]
+            pexp = args[1]
+            pval: float | None = None
+            if isinstance(pexp, dm.Constant):
+                pval = float(pexp.value)
+            elif isinstance(pexp, (int, float)):
+                pval = float(pexp)
+            if pval is not None:
+                if pval == 2.0:
+                    return base * dm.abs_(base)
+                if pval == 1.0:
+                    return base
+                return base * dm.abs_(base) ** (pval - 1.0)
+            return base * dm.abs_(base) ** (pexp - 1)
         if fn == "min":
             return dm.minimum(args[0], args[1])
         if fn == "max":

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -287,25 +287,54 @@ def _compute_alphabb_bound(evaluator, node_lb, node_ub, alpha):
 
     L(x) = f(x) - sum_i alpha_i * (x_i - lb_i) * (ub_i - x_i)
 
-    Returns the minimum of L over [node_lb, node_ub], or -inf on failure.
+    The perturbation term is non-negative for x in [node_lb, node_ub], so
+    L(x) <= f(x) there and the minimum of L over the box is a valid lower
+    bound on f. The minimization domain MUST be exactly the true node box and
+    the perturbation MUST use the same lb/ub arrays as the optimizer bounds:
+    evaluating L at any x OUTSIDE [node_lb, node_ub] makes the perturbation
+    NEGATIVE, which flips L into an over-estimator and yields an invalid
+    (too-high) "lower bound".
+
+    Returns the minimum of L over [node_lb, node_ub], or -inf when the box is
+    unbounded / so wide that alphaBB is numerically meaningless (in which case
+    alphaBB abstains and the caller's interval / LP relaxation bounds stand).
     """
+    node_lb = np.asarray(node_lb, dtype=np.float64)
+    node_ub = np.asarray(node_ub, dtype=np.float64)
+
+    # alphaBB is only valid on a finite box. Unbounded or huge dimensions make
+    # the quadratic perturbation astronomically large and scipy's
+    # finite-difference gradient unreliable, so abstain instead of risking an
+    # invalid bound.
+    #
+    # NOTE: a previous implementation instead CLIPPED the optimizer domain to
+    # [-1e4, 1e4] while leaving node_lb/node_ub unclipped in the perturbation.
+    # On any node with a bound outside that range (e.g. a big-M ~1e19 on an
+    # unbounded variable) the clip pushed the optimizer outside the true box,
+    # turned the perturbation negative, and produced a spurious ~1e17 "lower
+    # bound" that fathomed the optimum region and falsely certified suboptimal
+    # incumbents as global. Optimizing over the true box keeps L <= f, so any
+    # value returned here is a sound lower bound.
+    _ALPHABB_BOX_LIMIT = 1e8
+    if not (np.all(np.isfinite(node_lb)) and np.all(np.isfinite(node_ub))):
+        return -np.inf
+    if np.any(np.abs(node_lb) > _ALPHABB_BOX_LIMIT) or np.any(np.abs(node_ub) > _ALPHABB_BOX_LIMIT):
+        return -np.inf
+    if np.any(node_ub < node_lb):
+        return -np.inf
 
     def underestimator(x):
         f_val = evaluator.evaluate_objective(x)
         perturbation = np.sum(alpha * (x - node_lb) * (node_ub - x))
         return f_val - perturbation
 
-    # Multiple starting points for robustness. Clip bounds to a finite range
-    # before forming start points or passing them to scipy: unbounded
-    # variables produce inf*inf or inf-inf in finite-difference gradients,
-    # propagating NaN into L-BFGS-B and silently breaking the bound.
-    lb_clip = np.clip(node_lb, -1e4, 1e4)
-    ub_clip = np.clip(node_ub, -1e4, 1e4)
-    mid = 0.5 * (lb_clip + ub_clip)
-    bounds = list(zip(lb_clip, ub_clip))
+    # Multiple starting points for robustness, all strictly inside the box.
+    width = node_ub - node_lb
+    mid = 0.5 * (node_lb + node_ub)
+    bounds = list(zip(node_lb, node_ub))
 
     best_val = np.inf
-    for x0 in [mid, lb_clip + 0.25 * (ub_clip - lb_clip), lb_clip + 0.75 * (ub_clip - lb_clip)]:
+    for x0 in (mid, node_lb + 0.25 * width, node_lb + 0.75 * width):
         try:
             result = scipy_minimize(underestimator, x0, method="L-BFGS-B", bounds=bounds)
             if result.fun < best_val:
@@ -480,6 +509,33 @@ def _structural_linear_row_mask(model, sizes, m):
     return np.asarray(flags, dtype=bool)
 
 
+def _cached_structural_linear_mask(evaluator, m):
+    """Return the structural linear-row mask for ``evaluator``'s model, cached.
+
+    The mask (a row is structurally affine iff its body has no nonlinear
+    operator) depends only on the constraint bodies, which are invariant across
+    B&B nodes. Recomputing it every node re-walks every constraint DAG, so it is
+    memoized on the evaluator and keyed by the row count ``m`` to stay robust if
+    the row layout ever differs. Returns ``None`` when the mask is unavailable or
+    cannot be aligned to ``m`` rows, so callers fall back to the numeric
+    two-point Jacobian classification.
+    """
+    cached = getattr(evaluator, "_structural_linear_mask_cache", None)
+    if cached is not None and cached[0] == m:
+        return cached[1]
+    mask = None
+    try:
+        sizes = getattr(evaluator, "_constraint_flat_sizes", None)
+        mask = _structural_linear_row_mask(evaluator._model, sizes, m)
+    except Exception:
+        mask = None
+    try:
+        evaluator._structural_linear_mask_cache = (m, mask)
+    except Exception:
+        pass
+    return mask
+
+
 def _tighten_node_bounds_with_status(evaluator, node_lb, node_ub, cl_list, cu_list, max_rounds=3):
     """Constraint-based bound tightening (FBBT) for a single B&B node.
 
@@ -538,13 +594,9 @@ def _tighten_node_bounds_with_status(evaluator, node_lb, node_ub, cl_list, cu_li
     # (max/abs/clamped exprs) when both samples fall in one locally-flat piece;
     # require structural affineness as well so FBBT never linearizes a nonlinear
     # body and over-tightens it (issue #27a).
-    try:
-        _sizes = getattr(evaluator, "_constraint_flat_sizes", None)
-        _structural = _structural_linear_row_mask(evaluator._model, _sizes, len(is_linear))
-        if _structural is not None:
-            is_linear = is_linear & _structural
-    except Exception:
-        pass
+    _structural = _cached_structural_linear_mask(evaluator, len(is_linear))
+    if _structural is not None:
+        is_linear = is_linear & _structural
 
     if not np.any(is_linear):
         return _apply_nonlinear_tightening_with_status(evaluator._model, lb, ub)
@@ -713,6 +765,47 @@ def _infer_constraint_bounds(model: Model, evaluator=None):
     return cl_list, cu_list
 
 
+def _gams_initial_seed(model, node_lb, node_ub):
+    """Build a flat start vector from a model's GAMS-provided initial values.
+
+    ``from_gams`` parses ``x.l`` assignments into ``model._gams_initial_values``
+    (``var_name -> float`` for scalars, ``var_name -> {flat_idx: float}`` for
+    indexed variables) but nothing in the solver consumed them, so a modeler's
+    (often near-optimal) starting point was ignored -- discopt re-derived its
+    primal solely from relaxation/midpoint seeds. For nonconvex models whose good
+    basin is hard to reach from those generic seeds (prob07's true global at
+    154990 sits in a basin only the published start lands in), this left a worse
+    incumbent. Return the provided point, filled with the bound midpoint for any
+    variable the file did not initialize and clipped into ``[node_lb, node_ub]``;
+    return ``None`` when the model carries no initial values (the common case),
+    so callers add no work for models without a start.
+    """
+    iv = getattr(model, "_gams_initial_values", None)
+    if not iv:
+        return None
+    lb_c = np.clip(node_lb, -_SPC, _SPC)
+    ub_c = np.clip(node_ub, -_SPC, _SPC)
+    x0 = 0.5 * (lb_c + ub_c)
+    offset = 0
+    found = False
+    for v in model._variables:
+        sz = v.size
+        entry = iv.get(v.name)
+        if entry is not None:
+            if isinstance(entry, dict):
+                for flat_idx, val in entry.items():
+                    if 0 <= int(flat_idx) < sz:
+                        x0[offset + int(flat_idx)] = float(val)
+                        found = True
+            else:
+                x0[offset : offset + sz] = float(entry)
+                found = True
+        offset += sz
+    if not found:
+        return None
+    return np.clip(x0, node_lb, node_ub)
+
+
 def _generate_starting_points(node_lb, node_ub, n_random=2):
     """Generate diverse starting points for multi-start NLP at root node."""
     lb_clipped = np.clip(node_lb, -_SPC, _SPC)
@@ -740,12 +833,21 @@ def _solve_root_node_multistart(
     options,
     nlp_solver,
     n_random=2,
+    convex=False,
 ):
     """Solve root NLP relaxation from multiple starting points.
 
     On nonconvex problems, different starting points can converge to
     different local minima. Multi-start at the root increases the
     chance of finding the global optimum for the initial bound/incumbent.
+
+    On *convex* problems the relaxation has a unique optimum, so any start that
+    converges to a feasible KKT point has already found the global optimum and
+    further starts only re-find it. With ``convex=True`` the search short-circuits
+    on the first feasible OPTIMAL result (the midpoint start, tried first), while
+    still falling through to additional starts when a start fails to converge or
+    lands constraint-infeasible — so robustness is preserved and only the
+    redundant convex re-solves are skipped.
     """
     starting_points = _generate_starting_points(node_lb, node_ub, n_random=n_random)
 
@@ -789,6 +891,11 @@ def _solve_root_node_multistart(
             best_result = nlp_result
             best_feasible = feasible
             best_obj = obj
+
+        # Convex relaxation: a feasible KKT (OPTIMAL) point is the unique global
+        # optimum, so the remaining starts would only re-converge to it. Stop.
+        if convex and feasible and nlp_result.status == SolveStatus.OPTIMAL:
+            break
 
     if best_result is not None:
         return best_result
@@ -1701,6 +1808,12 @@ def solve_model(
             max_iterations=max_nodes,
             nlp_solver=nlp_solver,
         )
+
+    # Capture any modeler-provided GAMS start (``x.l`` -> _gams_initial_values)
+    # BEFORE the reform passes below rebuild ``model`` into fresh objects that
+    # drop this dynamically-attached attribute. It is re-attached by name to the
+    # working model just before the B&B loop so the root subnlp can seed from it.
+    _captured_gams_initial_values = getattr(model, "_gams_initial_values", None)
 
     # --- GDP reformulation: convert indicator/disjunctive/SOS to standard MINLP ---
     from discopt._jax.gdp_reformulate import reformulate_gdp
@@ -2660,11 +2773,23 @@ def solve_model(
     # Try to find an integer-feasible incumbent before B&B starts.
     _fp_ran = False
 
+    # Re-attach the captured modeler start (by name) to the post-reform working
+    # model so ``_gams_initial_seed`` can build a root subnlp seed from it. Only
+    # set when the reforms did not already carry it forward; a no-op when no
+    # start was provided.
+    if _captured_gams_initial_values and not getattr(model, "_gams_initial_values", None):
+        model._gams_initial_values = _captured_gams_initial_values
+
     # --- SubNLP primal heuristic state ---
     _subnlp_backend_fn = None
     _subnlp_calls = 0
     _subnlp_feasible = 0
     _subnlp_incumbent_updates = 0
+    # Best incumbent value the cutoff-tightening phases (C/C3) have already acted
+    # on. They fire whenever the incumbent strictly improves below this — from
+    # ANY source, including the sub-NLP / binary-seed heuristics that inject
+    # directly and are not counted in proc_stats["incumbent_updates"].
+    _last_tighten_inc = np.inf
     if subnlp_enabled:
         try:
             from typing import cast
@@ -2700,10 +2825,36 @@ def solve_model(
         if n_batch == 0:
             break
 
-        # Tighten node bounds via constraint propagation (FBBT).
         node_infeasible_mask = np.zeros(n_batch, dtype=bool)
+
+        # Apply the current global box to each exported node (issue: cutoff
+        # tightening was dead). Phase C (incumbent-cutoff OBBT) and Phase C3
+        # (incumbent-cutoff FBBT) shrink the global lb/ub once an incumbent is
+        # found, but the Rust tree has no bound-update API and re-exports nodes
+        # with their original (wide) boxes. Intersecting each node box with the
+        # current global lb/ub here is what makes that cutoff tightening
+        # actually prune: a region cut away only holds solutions no better than
+        # the incumbent, so dropping it is sound (open nodes keep lb < inc, so
+        # best_bound stays a valid lower bound <= the true optimum). Before any
+        # incumbent, lb/ub equal the root box and this is a no-op.
+        _gl = np.asarray(lb, dtype=np.float64)
+        _gu = np.asarray(ub, dtype=np.float64)
+        for i in range(n_batch):
+            bl = np.maximum(np.asarray(batch_lb[i], dtype=np.float64), _gl)
+            bu = np.minimum(np.asarray(batch_ub[i], dtype=np.float64), _gu)
+            if np.any(bl > bu + 1e-9):
+                # Empty intersection: node lies entirely outside the cutoff box,
+                # so its subtree cannot improve on the incumbent — fathom it.
+                node_infeasible_mask[i] = True
+                continue
+            batch_lb[i] = bl.tolist()
+            batch_ub[i] = bu.tolist()
+
+        # Tighten node bounds via constraint propagation (FBBT).
         if cl_list:
             for i in range(n_batch):
+                if node_infeasible_mask[i]:
+                    continue
                 node_lb_i = np.array(batch_lb[i])
                 node_ub_i = np.array(batch_ub[i])
                 t_lb, t_ub, node_infeasible = _tighten_node_bounds_with_status(
@@ -3336,6 +3487,7 @@ def solve_model(
                         result_sols[best_root_idx],
                         max_rounds=5,
                         backend=_resolve_heuristic_backend(nlp_solver),
+                        evaluator=evaluator,
                     )
                     if fp_sol is not None:
                         fp_obj = float(evaluator.evaluate_objective(fp_sol))
@@ -3347,6 +3499,48 @@ def solve_model(
                             logger.info("Feasibility pump found incumbent: obj=%.6g", fp_obj)
                 except Exception as e:
                     logger.debug("Feasibility pump failed: %s", e)
+
+                # --- Integer local search (1-opt + 2-opt) ---
+                # Two roles, both at the root:
+                #   (1) Feasibility recovery — if round-and-repair found no
+                #       incumbent, the relaxation's integer assignment is likely
+                #       true-infeasible (common for nonconvex integer-heavy
+                #       problems: the McCormick relaxation's integers satisfy the
+                #       relaxed but not the true constraints).
+                #   (2) Incumbent improvement — round-and-repair (feasibility
+                #       pump / nearest-rounding subnlp) only repairs the
+                #       *continuous* variables around ONE relaxation rounding, so
+                #       it routinely lands on a far-suboptimal integer assignment
+                #       (e.g. nvs23: it parks at obj=-287 while the global is
+                #       -1125). The lattice search seeds from the model's own
+                #       continuous relaxation and descends the integer lattice, so
+                #       it reaches much better integer assignments. Running it
+                #       even when an incumbent already exists lets it IMPROVE that
+                #       incumbent, not just recover feasibility.
+                # Sound either way: only subnlp-verified feasible points are
+                # injected, and inject_incumbent accepts a point only if it
+                # strictly beats the current incumbent.
+                if not _model_is_convex and best_root_idx is not None:
+                    try:
+                        from discopt._jax.primal_heuristics import integer_local_search
+
+                        ils = integer_local_search(
+                            model,
+                            result_sols[best_root_idx],
+                            backend=_resolve_heuristic_backend(nlp_solver),
+                            evaluator=evaluator,
+                            time_budget=min(5.0, 0.15 * max(1.0, time_limit)),
+                        )
+                        if ils is not None:
+                            _x_ils, _obj_ils = ils
+                            if np.isfinite(_obj_ils) and _obj_ils < _SENTINEL_THRESHOLD:
+                                tree.inject_incumbent(_x_ils.copy(), float(_obj_ils))
+                                logger.info(
+                                    "Integer local search found incumbent: obj=%.6g",
+                                    _obj_ils,
+                                )
+                    except Exception as e:
+                        logger.debug("Integer local search failed: %s", e)
 
         # --- SubNLP primal heuristic ---
         # Fix integers in the best relaxation solution, then solve the
@@ -3362,6 +3556,35 @@ def solve_model(
             and (iteration == 0 or iteration % max(1, subnlp_frequency) == 0)
         ):
             from discopt._jax.primal_heuristics import subnlp as _subnlp
+
+            # Root only: seed one subnlp from the modeler's GAMS-provided start
+            # (parsed into model._gams_initial_values). For nonconvex models the
+            # published point often lands in the global basin that generic
+            # relaxation/midpoint seeds miss (prob07: 162070 -> 154990). No-op
+            # when the model carries no initial values. Sound: subnlp re-verifies
+            # feasibility and inject_incumbent enforces strict improvement.
+            if iteration == 0 and _subnlp_calls < subnlp_max_calls:
+                _gseed = _gams_initial_seed(model, lb, ub)
+                if _gseed is not None:
+                    _subnlp_calls += 1
+                    try:
+                        _sn = _subnlp(
+                            model,
+                            _gseed,
+                            backend=_subnlp_backend_fn,
+                            nlp_options=subnlp_options,
+                            evaluator=evaluator,
+                        )
+                    except Exception as _e:
+                        logger.debug("subnlp (gams seed) raised: %s", _e)
+                        _sn = None
+                    if _sn is not None:
+                        _x_sn, _obj_sn = _sn
+                        _subnlp_feasible += 1
+                        if np.isfinite(_obj_sn) and _obj_sn < _SENTINEL_THRESHOLD:
+                            tree.inject_incumbent(_x_sn.copy(), float(_obj_sn))
+                            _subnlp_incumbent_updates += 1
+                            logger.info("SubNLP incumbent (gams seed): obj=%.6g", _obj_sn)
 
             _cands_sn = [
                 (i, float(result_lbs[i]))
@@ -3495,13 +3718,30 @@ def solve_model(
         # Import results back to Rust tree
         t_rust_start = time.perf_counter()
         tree.import_results(result_ids, result_lbs, result_sols, result_feas)
-        proc_stats = tree.process_evaluated()
+        tree.process_evaluated()
         rust_time += time.perf_counter() - t_rust_start
+
+        # Did the incumbent strictly improve this iteration, from ANY source?
+        # proc_stats["incumbent_updates"] counts only incumbents found in the
+        # batch evaluation — NOT the sub-NLP / binary-seed heuristics, which
+        # inject directly via tree.inject_incumbent. For small nonconvex MINLPs
+        # the optimum is routinely found by those heuristics, so gating the
+        # cutoff-tightening phases on the batch counter alone left the tightened
+        # global box (and thus all pruning) on the table and the gap never
+        # closed. Tracking the incumbent value across iterations fires the
+        # tightening once per genuine improvement regardless of who found it.
+        _inc_now = tree.incumbent()
+        _inc_obj_now = (
+            float(_inc_now[1]) if _inc_now is not None and np.isfinite(_inc_now[1]) else np.inf
+        )
+        _incumbent_improved = _inc_obj_now < _last_tighten_inc - 1e-9
+        if _incumbent_improved:
+            _last_tighten_inc = _inc_obj_now
 
         # --- Periodic OBBT with incumbent cutoff (Phase C) ---
         # When a new incumbent is found and bounds are still wide,
         # re-run OBBT with the incumbent objective as a cutoff.
-        if proc_stats["incumbent_updates"] > 0 and n_vars <= 200:
+        if _incumbent_improved and n_vars <= 200:
             incumbent_info = tree.incumbent()
             if incumbent_info is not None:
                 inc_sol, inc_obj = incumbent_info
@@ -3539,8 +3779,8 @@ def solve_model(
 
         # --- FBBT with incumbent cutoff (Phase C3) ---
         # Cheap bound tightening via Rust FBBT (no LP solves).
-        # Run on every incumbent update, complementing OBBT.
-        if _model_repr is not None and proc_stats["incumbent_updates"] > 0:
+        # Run on every incumbent improvement, complementing OBBT.
+        if _model_repr is not None and _incumbent_improved:
             incumbent_info = tree.incumbent()
             if incumbent_info is not None:
                 inc_sol, inc_obj = incumbent_info
@@ -4236,6 +4476,7 @@ def _solve_nlp_bb(
                         constraint_bounds,
                         opts,
                         nlp_solver,
+                        convex=_model_is_convex,
                     )
                 else:
                     psol_i = np.array(batch_psols[i])
@@ -4334,6 +4575,7 @@ def _solve_nlp_bb(
                         result_sols[best_root_idx],
                         max_rounds=5,
                         backend=_resolve_heuristic_backend(nlp_solver),
+                        evaluator=evaluator,
                     )
                     if fp_sol is not None:
                         fp_obj = float(evaluator.evaluate_objective(fp_sol))

--- a/python/tests/test_alphabb_bound_soundness.py
+++ b/python/tests/test_alphabb_bound_soundness.py
@@ -1,0 +1,111 @@
+"""Soundness regression tests for ``solver._compute_alphabb_bound``.
+
+The alphaBB underestimator L(x) = f(x) - sum_i alpha_i (x_i-lb_i)(ub_i-x_i) is a
+valid lower bound on f ONLY for x inside [node_lb, node_ub]; there the
+perturbation term is >= 0 so L <= f. A previous implementation minimized L over
+a domain CLIPPED to [-1e4, 1e4] while the perturbation kept using the unclipped
+node bounds. On any node with a bound outside that range (e.g. a big-M ~1e19 on
+an unbounded variable) the optimizer was pushed OUTSIDE the true box, the
+perturbation went NEGATIVE, and L turned into an over-estimator — producing a
+spurious ~1e17 "lower bound" that falsely certified suboptimal incumbents as
+global (regression: gms60/prob07 reported obj=160488 glob=True; true opt
+154990).
+
+A lower bound must NEVER exceed the true minimum of f over the box. These tests
+pin that invariant for the large/unbounded-box cases that triggered the bug, and
+the in-box soundness that alphaBB must still deliver.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+from discopt.solver import _compute_alphabb_bound
+
+
+class _StubEvaluator:
+    """Minimal evaluator exposing only ``evaluate_objective`` like the real one."""
+
+    def __init__(self, f):
+        self._f = f
+
+    def evaluate_objective(self, x):
+        return float(self._f(np.asarray(x, dtype=np.float64)))
+
+
+def test_large_lower_bound_does_not_fabricate_positive_bound():
+    """The exact prob07 trigger: node_lb >> 1e4 with a huge node_ub.
+
+    f(x) = x is linear, so its true minimum over the box is node_lb. The old
+    clip-mismatch returned ~+9e17 here; the fix must return a SOUND bound, i.e.
+    <= the true minimum (it abstains to -inf because the box is unbounded).
+    """
+    ev = _StubEvaluator(lambda x: x[0])
+    node_lb = np.array([1.0e5])
+    node_ub = np.array([1.0e19])
+    alpha = np.array([1.0e-6])
+
+    bound = _compute_alphabb_bound(ev, node_lb, node_ub, alpha)
+    true_min = 1.0e5
+    assert bound <= true_min + 1e-6, f"unsound alphaBB bound {bound} > true min {true_min}"
+    assert bound == -np.inf  # abstains on the oversized box
+
+
+def test_infinite_bound_abstains():
+    """A genuinely unbounded variable yields -inf (abstain), never a finite lie."""
+    ev = _StubEvaluator(lambda x: x[0] ** 2)
+    node_lb = np.array([0.0])
+    node_ub = np.array([np.inf])
+    alpha = np.array([1.0])
+    assert _compute_alphabb_bound(ev, node_lb, node_ub, alpha) == -np.inf
+
+
+def test_bound_above_box_limit_abstains():
+    """|bound| > 1e8 (big-M territory) abstains rather than risk corruption."""
+    ev = _StubEvaluator(lambda x: x[0])
+    node_lb = np.array([0.0])
+    node_ub = np.array([1.0e9])
+    alpha = np.array([1.0])
+    assert _compute_alphabb_bound(ev, node_lb, node_ub, np.array([1e-3])) == -np.inf
+    # ...but a box just under the limit is honored (and stays sound).
+    node_ub_ok = np.array([1.0e7])
+    b = _compute_alphabb_bound(ev, node_lb, node_ub_ok, alpha)
+    assert b <= 0.0 + 1e-6  # true min of f=x over [0, 1e7] is 0
+
+
+def test_in_box_bound_is_sound_on_finite_nonconvex():
+    """On a finite box alphaBB still produces a valid (<= true min) lower bound."""
+    # f(x) = -x^2 is concave on [1, 5]; true min over the box is -25 (at x=5).
+    ev = _StubEvaluator(lambda x: -(x[0] ** 2))
+    node_lb = np.array([1.0])
+    node_ub = np.array([5.0])
+    alpha = np.array([1.5])  # >= 1 convexifies (Hessian of -x^2 is -2)
+
+    bound = _compute_alphabb_bound(ev, node_lb, node_ub, alpha)
+    true_min = -25.0
+    assert np.isfinite(bound)
+    assert bound <= true_min + 1e-6, f"unsound: {bound} > {true_min}"
+
+
+def test_zero_alpha_recovers_objective_minimum():
+    """alpha = 0 makes L == f, so the bound is exactly min f over the box."""
+    ev = _StubEvaluator(lambda x: (x[0] - 3.0) ** 2 + 1.0)
+    node_lb = np.array([0.0])
+    node_ub = np.array([10.0])
+    alpha = np.array([0.0])
+
+    bound = _compute_alphabb_bound(ev, node_lb, node_ub, alpha)
+    assert abs(bound - 1.0) < 1e-4  # minimum at x=3 is 1.0
+
+
+def test_multivariable_box_with_one_huge_dimension_abstains():
+    """A single unbounded dimension is enough to abstain (mirrors lifted prob07)."""
+    ev = _StubEvaluator(lambda x: x[0] + x[1])
+    node_lb = np.array([10.0, 100.0])
+    node_ub = np.array([20.0, 1.0e19])  # second dim is big-M
+    alpha = np.array([1e-3, 1e-3])
+    assert _compute_alphabb_bound(ev, node_lb, node_ub, alpha) == -np.inf

--- a/python/tests/test_constant_fold_and_cert_soundness.py
+++ b/python/tests/test_constant_fold_and_cert_soundness.py
@@ -61,6 +61,34 @@ def test_eval_constant_expr_returns_none_for_variable_terms():
     assert _eval_constant_expr(2.0 * x) is None
 
 
+def test_decompose_product_folds_composite_constant_factor():
+    """A composite-constant factor inside a *product decomposition* must fold.
+
+    The linearizer's ``*`` handler already folds variable-free factors before
+    decomposition, but :func:`_decompose_product` itself only recognized a bare
+    ``Constant`` leaf — a *composite* constant such as ``neg(1e6)`` (how the
+    GAMS tokenizer emits ``-1000000`` when the term sits inside a quotient, as
+    in MINLPLib ``gear4``'s ``-1e6*i1*i2/(i3*i4)``) made decomposition return
+    ``None`` (``Cannot decompose product: ((neg(1e+06) * i1) * i2)``), dropping
+    the whole constraint. The fold is exact and variable-free, so it only ever
+    lets a product be relaxed that was previously discarded.
+    """
+    from discopt._jax.milp_relaxation import _decompose_product, _get_flat_index
+
+    m = dm.Model("gear")
+    i1 = m.integer("i1", lb=12, ub=60)
+    i2 = m.integer("i2", lb=12, ub=60)
+    # Exactly the AST gear4 produces for the numerator ``-1000000 * i1 * i2``.
+    expr = BinaryOp("*", BinaryOp("*", UnaryOp("neg", Constant(1.0e6)), i1), i2)
+
+    decomp = _decompose_product(expr, m)
+    assert decomp is not None, "composite-constant factor must not abort decomposition"
+    scalar, indices = decomp
+    assert scalar == -1.0e6
+    # The two surviving factors are the bilinear pair (i1, i2).
+    assert sorted(indices) == sorted([_get_flat_index(i1, m), _get_flat_index(i2, m)])
+
+
 @pytest.mark.correctness
 def test_negated_constant_product_keeps_constraint_and_certifies():
     """A nonlinear constraint carrying a ``(-3)*(-3)`` constant term must be kept.

--- a/python/tests/test_factorable_reform.py
+++ b/python/tests/test_factorable_reform.py
@@ -155,6 +155,80 @@ def test_lifted_model_preserves_optimum():
         assert r.bound <= r.objective + 1e-4
 
 
+def test_lifter_expression_dedups_by_structure_not_identity():
+    """Regression for the ex7_2_3 false-"optimal" SUSPECT.
+
+    ``_Lifter.expression`` deduplicates lifted sub-expressions by a *structural*
+    key (``repr``), never ``id()``. CPython recycles the ``id`` of a
+    garbage-collected node, so an ``id()``-keyed cache could hand a later,
+    structurally *different* ratio the aux of a freed one — silently dropping a
+    denominator. In MINLPLib ``ex7_2_3`` that made the constraint
+    ``1.25e6/(x3*x8) + x5/x8 - 2500*x5/x3/x8 <= 1`` satisfiable at the infeasible
+    box corner ``x_i = lb_i``, so spatial B&B certified the corner (objvar = sum
+    of lower bounds = 2100) as the global optimum — a false "optimal" (the true
+    optimum is 7049.2479).
+
+    The structural contract: two distinct objects with identical structure share
+    one aux; structurally different expressions never do. The first assertion
+    deterministically fails under ``id()`` keying — two distinct objects have
+    distinct ids and would each allocate their own aux instead of deduping.
+    """
+    from discopt._jax.factorable_reform import _Lifter
+    from discopt._jax.term_classifier import distribute_products
+    from discopt.modeling.core import BinaryOp, Constant
+
+    m = dm.Model("dedup")
+    x5 = m.continuous("x5", lb=10, ub=1000)
+    x3 = m.continuous("x3", lb=1000, ub=10000)
+    x8 = m.continuous("x8", lb=10, ub=1000)
+    lifter = _Lifter(m)
+
+    def ratio_2500_x5_over_x3():
+        return distribute_products(BinaryOp("/", BinaryOp("*", Constant(2500.0), x5), x3))
+
+    e1, e2 = ratio_2500_x5_over_x3(), ratio_2500_x5_over_x3()
+    assert e1 is not e2 and repr(e1) == repr(e2)
+    a1 = lifter.expression(e1)
+    a2 = lifter.expression(e2)
+    # Structurally identical -> one shared aux. Fails under id(): the two distinct
+    # objects miss each other's cache entry and allocate separate auxes.
+    assert a1 is a2
+
+    # A structurally different ratio gets its own aux, never the stale one.
+    a3 = lifter.expression(distribute_products(BinaryOp("/", x5, x8)))
+    assert a3 is not a1
+
+
+@pytest.mark.correctness
+def test_nested_ratio_solve_is_sound():
+    """End-to-end soundness for nested ratios (ex7_2_3's e4 shape).
+
+    A certified-global solution MUST satisfy the *original* constraint. Before
+    the structural-key fix the lifted reform dropped a denominator and the solver
+    certified an infeasible point; here we solve the constraint's small sibling
+    and assert the returned, certified optimum honors the original e4.
+    """
+    m = dm.Model("nested_ratio_solve")
+    x3 = m.continuous("x3", lb=1000, ub=10000)
+    x5 = m.continuous("x5", lb=10, ub=1000)
+    x8 = m.continuous("x8", lb=10, ub=1000)
+    m.subject_to(1.25e6 / (x3 * x8) + x5 / x8 - 2500 * x5 / x3 / x8 <= 1)
+    m.minimize(x3 + x5)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r = m.solve(time_limit=60, gap_tolerance=1e-4)
+    assert r.status == "optimal"
+    assert r.gap_certified, "small nested-ratio model should certify global"
+    x3v, x5v, x8v = (float(r.x[n]) for n in ("x3", "x5", "x8"))
+    e4 = 1.25e6 / (x3v * x8v) + x5v / x8v - 2500 * x5v / x3v / x8v
+    assert e4 <= 1 + 1e-4, (
+        f"certified solution violates the original e4 (={e4}); a dropped "
+        "denominator would certify an infeasible point"
+    )
+    if r.bound is not None:
+        assert r.bound <= r.objective + 1e-4  # sound dual bound
+
+
 @pytest.mark.correctness
 @pytest.mark.slow
 def test_nvs01_certifies_with_sound_bound():

--- a/python/tests/test_mccormick_lp_densify_guard.py
+++ b/python/tests/test_mccormick_lp_densify_guard.py
@@ -1,0 +1,77 @@
+"""Densification guard for the LP-form McCormick relaxer (autocorr HANG, Issue #20).
+
+The matrix-form MILP backends (warm-started Rust simplex, POUNCE) materialize the
+lifted relaxation as a DENSE ``(m, n+m)`` array plus a dense ``m×m`` slack
+identity. A binary-multilinear lift explodes the row count -- autocorr_bern's
+degree-4 objective lifts to ~3.7k cols x ~85k rows, a ~7.5e9-cell (~60 GB) dense
+allocation that thrashes swap forever (a hang, not a bound). ``solve_at_node``
+caps the densified size (``_MAX_RELAX_DENSE_CELLS``) and declines above it.
+
+Declining is SOUND: it only forgoes a node's LP underestimator; the spatial B&B
+keeps the rigorous alphaBB/interval bound and still converges to the same global
+optimum, just with a weaker per-node bound (more nodes). These tests pin both the
+graceful-degradation (same certified optimum) and the direct gate behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import discopt
+import discopt._jax.mccormick_lp as mc
+import numpy as np
+import pytest
+
+
+def _small_bilinear():
+    m = discopt.Model("bil")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    m.subject_to(x + y >= 0.5)
+    m.minimize(x * y - x - y)
+    return m
+
+
+def test_densify_guard_degrades_to_same_optimum(monkeypatch):
+    """Forcing the cap absurdly low disables the LP bound on every node, yet the
+    solve still reaches the SAME global optimum and stays certified -- proving the
+    alphaBB fallback is sound and the guard never changes the answer."""
+    res_normal = _small_bilinear().solve(time_limit=20.0)
+    assert res_normal.status in ("optimal", "feasible")
+
+    # Cap = 1 cell: any lifted relaxation with a single constraint row trips it.
+    monkeypatch.setattr(mc, "_MAX_RELAX_DENSE_CELLS", 1.0)
+    res_gated = _small_bilinear().solve(time_limit=20.0)
+    assert res_gated.status in ("optimal", "feasible")
+    # Same optimum, to the solver's global tolerance.
+    assert res_gated.objective == pytest.approx(res_normal.objective, abs=1e-4, rel=1e-4)
+    # The guard must never *certify* a different value than the ungated path.
+    if getattr(res_normal, "gap_certified", False):
+        assert getattr(res_gated, "gap_certified", False)
+
+
+def test_solve_at_node_declines_oversize(monkeypatch):
+    """Directly: above the cap, ``solve_at_node`` returns no bound (never an
+    unsound one and never a false ``infeasible`` that would fathom the node)."""
+    m = _small_bilinear()
+    relaxer = mc.MccormickLPRelaxer(m)
+
+    lb = np.array([-2.0, -2.0], dtype=np.float64)
+    ub = np.array([2.0, 2.0], dtype=np.float64)
+
+    # Below cap (default): a real LP bound (or a clean status), never oversize.
+    ok = relaxer.solve_at_node(lb, ub, time_limit=5.0)
+    assert ok.status != "skipped_oversize"
+
+    # Above cap: declined with no bound, and crucially NOT "infeasible".
+    monkeypatch.setattr(mc, "_MAX_RELAX_DENSE_CELLS", 1.0)
+    gated = relaxer.solve_at_node(lb, ub, time_limit=5.0)
+    assert gated.status == "skipped_oversize"
+    assert gated.lower_bound is None
+    assert gated.status != "infeasible"  # a declined node must never be fathomed

--- a/python/tests/test_presolve_pipeline.py
+++ b/python/tests/test_presolve_pipeline.py
@@ -71,6 +71,77 @@ def test_propagate_bounds_to_python_model():
     assert float(np.asarray(x.ub)) == pytest.approx(7.5)
 
 
+class _ShiftedRepr:
+    """Fake ModelRepr that mimics a presolve which *eliminated* a variable.
+
+    When the ``aggregate``/``eliminate`` passes drop a variable block, the Rust
+    repr's block indices shift down by one (``n_var_blocks`` shrinks). The block
+    list here drops ``a`` (the eliminated var), so the surviving blocks are
+    ``[b, c]`` — a positional mapping would cross-assign ``c``'s bounds onto the
+    Python ``b`` variable. ``var_names`` is the signal that keeps the mapping
+    honest.
+    """
+
+    def __init__(self, names, lbs, ubs):
+        self._names = list(names)
+        self._lbs = [np.asarray(v, dtype=np.float64).reshape(-1) for v in lbs]
+        self._ubs = [np.asarray(v, dtype=np.float64).reshape(-1) for v in ubs]
+
+    @property
+    def n_var_blocks(self):
+        return len(self._names)
+
+    def var_names(self):
+        return list(self._names)
+
+    def var_lb(self, bi):
+        return self._lbs[bi]
+
+    def var_ub(self, bi):
+        return self._ubs[bi]
+
+
+def test_propagate_bounds_maps_by_name_after_elimination():
+    """Regression (Issue #19): a variable-eliminating presolve shifts Rust block
+    indices, so bounds must flow back BY NAME — never positionally. A positional
+    map would cross-assign the wrong variable's (tighter) bounds and can fabricate
+    an empty box -> a false ``infeasible`` verdict on a feasible model."""
+    m = discopt.Model("agg_shift")
+    a = m.continuous("a", lb=-100.0, ub=100.0)
+    b = m.continuous("b", lb=-100.0, ub=100.0)
+    # ``c`` has a negative upper bound — exactly the gastransnlp x30 pattern that
+    # turns a cross-assignment into an empty box.
+    c = m.continuous("c", lb=-100.0, ub=-5.0)
+    m.minimize(b * b + c * c)
+
+    # Simulate the post-``aggregate`` repr: ``a`` was eliminated, so only ``b``
+    # and ``c`` survive (indices shifted down by one). ``b``'s lb is legitimately
+    # tightened to -20; ``c`` is unchanged.
+    shifted = _ShiftedRepr(
+        names=["b", "c"],
+        lbs=[-20.0, -100.0],
+        ubs=[100.0, -5.0],
+    )
+
+    n_tightened = propagate_bounds_to_model(m, shifted)
+
+    # ``b`` gets ONLY its own tightened lb; its ub must stay 100 (a positional
+    # map would have cross-assigned c's [-100, -5] onto ``b``).
+    assert float(np.asarray(b.lb)) == pytest.approx(-20.0)
+    assert float(np.asarray(b.ub)) == pytest.approx(100.0)
+    # ``c`` stays exactly as declared — not overwritten, not emptied.
+    assert float(np.asarray(c.lb)) == pytest.approx(-100.0)
+    assert float(np.asarray(c.ub)) == pytest.approx(-5.0)
+    # ``a`` was eliminated on the Rust side; it is simply skipped (untouched).
+    assert float(np.asarray(a.lb)) == pytest.approx(-100.0)
+    assert float(np.asarray(a.ub)) == pytest.approx(100.0)
+    assert n_tightened == 1  # only b.lb moved
+
+    # No variable may end up with an empty box.
+    for v in m._variables:
+        assert float(np.asarray(v.lb)) <= float(np.asarray(v.ub))
+
+
 def test_polynomial_reformulation_runs():
     """Opt-in polynomial reformulation completes and returns stats."""
     m = discopt.Model("poly")


### PR DESCRIPTION
## Summary

Accumulated soundness + performance hardening from the BARON-vs-discopt
global-optimization audit loop. Every change preserves the core invariant
(**0 SUSPECT** — a valid dual bound never exceeds the true optimum; no feasible
problem reported infeasible; no `gap_certified=True` at a suboptimal/infeasible
point). Detailed root-cause writeups live in the loop FINDINGS log.

### Soundness (correctness-critical)
- **factorable_reform — closed a live SUSPECT (worst failure class).**
  `_Lifter.expression` deduped lifted sub-expressions by `id(expr)`. CPython
  recycles a garbage-collected object's `id()`, so a later, structurally
  *different* nested ratio scored a false cache hit and was handed the aux of a
  freed one — **dropping a denominator**. In `ex7_2_3` that made the infeasible
  box corner (objvar = sum of lower bounds = **2100**) look feasible, so spatial
  B&B certified it as the global optimum. True optimum is **7049.248** (matches
  BARON). Fix: key the cache structurally (`repr`), which can only ever fail to
  dedup (harmless) and never falsely merge. After the fix discopt finds the true
  optimum, feasible, and soundly *not* certified. (FINDINGS #23)
- **alphaBB per-node bound** hardening in `solver.py` + a dedicated soundness test.
- **constant-fold / certificate soundness** in `milp_relaxation` + regression test.
- **gastransnlp false-infeasible** fixed: `SignPower` intrinsic + an
  aggregate-presolve variable-index off-by-one. (FINDINGS #19)

### Relaxation tightness / capability
- **milp_relaxation**: composite-constant decompose so the McCormick lifter no
  longer drops constraints (e.g. gear4's ratio-of-bilinears). (FINDINGS #21 wall 1)
- **mccormick_lp**: dense-McCormick densify guard with a clean alphaBB fallback,
  avoiding the `autocorr_bern*` dense-lift memory blowup. (FINDINGS #20 wall 1)
- **nonlinear_bound_tightening**: flat-variable metadata + extra monotone /
  quadratic / reciprocal bound rules feeding tighter FBBT.

### Performance / robustness
- Rust MILP driver + simplex (`milp_driver`, dual/primal/mod, `lp_bindings`):
  per-node solve-path hardening.
- `primal_heuristics`: feasibility-pump and subnlp improvements for incumbents
  on integer-heavy nonconvex MINLPs.
- `solver.py`: root-node multistart, structural linear-row mask, constraint
  bound inference.

## Test plan
- [x] Affected + new Python test files pass (30 tests, incl. the new soundness
  regressions: `test_factorable_reform`, `test_alphabb_bound_soundness`,
  `test_constant_fold_and_cert_soundness`, `test_mccormick_lp_densify_guard`,
  `test_presolve_pipeline`).
- [x] The new `test_lifter_expression_dedups_by_structure_not_identity` was
  verified to **fail under the old `id()` keying** and pass under `repr()`.
- [x] `ruff check` + `ruff format --check` clean; `mypy` clean (217 files).
- [x] `cargo check` clean on `discopt-core` and `discopt-python`.
- [ ] Full 62-problem corpus regression sweep (in progress at hand-off; 0 SUSPECT
  in the problems scored so far).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
