### PR TITLE
Linear-fractional relaxation for ratio of products (#185)

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -390,6 +390,30 @@ class AffinePowerRelaxation:
 
 
 @dataclass
+class RatioRelaxation:
+    """Linear-fractional envelope for a ratio of products ``coeff·m/q`` (#185).
+
+    ``m`` is the lifted numerator product column and ``q`` the lifted denominator
+    product column (each a standard McCormick-enveloped bilinear/multilinear aux,
+    or an original variable). ``r`` is a fresh column standing for the *pure*
+    ratio ``m/q``; the division node is mapped to ``r`` with the scalar ``coeff``
+    applied by the linearizer (keeping a large numerator constant out of the
+    envelope coefficients). The McCormick envelope of the bilinear identity
+    ``r·q = m`` — emitted over ``[r_lb, r_ub] × [q bounds]`` — outer-approximates
+    the quotient: at any true point ``r = m/q`` so ``r·q = m`` holds exactly and
+    all four inequalities are satisfied, hence the relaxed feasible set is a
+    superset of the true one (sound lower bound). Requires ``q`` strictly
+    sign-definite and bounded away from zero on the node box.
+    """
+
+    r_col: int
+    q_col: int
+    m_col: int
+    r_lb: float
+    r_ub: float
+
+
+@dataclass
 class PiecewiseTrigSquareInterval:
     """Binary-selected interval for a direct trig-square relaxation."""
 
@@ -1105,6 +1129,7 @@ def _decompose_product(
     univariate_var_map: Optional[dict[object, int]] = None,
     monomial_var_map: Optional[dict[tuple[int, int], int]] = None,
     composite_var_map: Optional[dict[int, int]] = None,
+    composite_coeff_map: Optional[dict[int, float]] = None,
 ) -> tuple[float, list[int]] | None:
     """Decompose a product expression into (scalar, [flat_or_aux_idx, ...]).
 
@@ -1141,6 +1166,12 @@ def _decompose_product(
         if composite_var_map:
             aux_col = composite_var_map.get(id(e))
             if aux_col is not None:
+                # A composite node carrying a non-unit substitution coefficient
+                # (e.g. a ratio-of-products aux scaled by the numerator constant,
+                # issue #185) cannot be represented as a plain product factor here;
+                # abstain so the linearizer's coefficient-aware path handles it.
+                if composite_coeff_map and composite_coeff_map.get(id(e), 1.0) != 1.0:
+                    return False
                 var_indices.append(aux_col)
                 return True
         # Recognize var^p (fractional p) when an aux column was allocated.
@@ -1192,6 +1223,56 @@ def _decompose_product(
                 var_indices = collapsed
 
     return scalar[0], var_indices
+
+
+def _decompose_signed_monomial(expr: Expression, model: Model) -> tuple[float, list[int]] | None:
+    """Decompose a signed product / quotient-by-constant into ``(coeff, indices)``.
+
+    Folds every variable-free subexpression (including composite constants such as
+    gear4's ``neg(1e6)``) into ``coeff`` and collects the flat indices of the
+    original-variable factors (with repeats for integer powers ``x**n``,
+    ``2 ≤ n ≤ 4``). Returns ``None`` the moment a non-constant, non-variable,
+    non-product/​power leaf — a transcendental call, an additive operand, or a
+    division by a variable — is encountered, so the caller only ever sees a
+    genuine signed monomial in original variables.
+    """
+    const = _eval_constant_expr(expr)
+    if const is not None:
+        return const, []
+    flat = _get_flat_index(expr, model)
+    if flat is not None:
+        return 1.0, [flat]
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        sub = _decompose_signed_monomial(expr.operand, model)
+        if sub is None:
+            return None
+        c, idx = sub
+        return -c, idx
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        left = _decompose_signed_monomial(expr.left, model)
+        if left is None:
+            return None
+        right = _decompose_signed_monomial(expr.right, model)
+        if right is None:
+            return None
+        return left[0] * right[0], left[1] + right[1]
+    if isinstance(expr, BinaryOp) and expr.op == "/":
+        denom = _eval_constant_expr(expr.right)
+        if denom is None or denom == 0.0:
+            return None
+        sub = _decompose_signed_monomial(expr.left, model)
+        if sub is None:
+            return None
+        return sub[0] / denom, sub[1]
+    if isinstance(expr, BinaryOp) and expr.op == "**" and isinstance(expr.right, Constant):
+        p = _eval_constant_expr(expr.right)
+        if p is not None and p.is_integer() and 2 <= int(p) <= 4:
+            base = _decompose_signed_monomial(expr.left, model)
+            if base is None:
+                return None
+            bc, bidx = base
+            return bc ** int(p), bidx * int(p)
+    return None
 
 
 def _collect_lifted_bilinear_products(
@@ -3041,6 +3122,7 @@ def _linearize_expr(
     flat_lb: Optional[np.ndarray] = None,
     flat_ub: Optional[np.ndarray] = None,
     composite_var_map: Optional[dict[int, int]] = None,
+    composite_coeff_map: Optional[dict[int, float]] = None,
 ) -> tuple[np.ndarray, float]:
     """Walk expression tree and return (coeff, constant) for linearized form.
 
@@ -3078,7 +3160,8 @@ def _linearize_expr(
         if composite_var_map is not None:
             aux_col = composite_var_map.get(id(e))
             if aux_col is not None:
-                coeff[aux_col] += scale
+                sub_coeff = composite_coeff_map.get(id(e), 1.0) if composite_coeff_map else 1.0
+                coeff[aux_col] += scale * sub_coeff
                 return
 
         if isinstance(e, Constant):
@@ -3210,6 +3293,7 @@ def _linearize_expr(
                     univariate_var_map=univariate_var_map,
                     monomial_var_map=monomial_var_map,
                     composite_var_map=composite_var_map,
+                    composite_coeff_map=composite_coeff_map,
                 )
                 if decomp is None:
                     raise ValueError(f"Cannot decompose product: {e}")
@@ -3766,6 +3850,12 @@ def build_milp_relaxation(
         all_bounds.append(val_bounds)
         integrality_flags.append(0)
         col_idx += 1
+
+    # Per-node substitution coefficient for composite auxes whose value is a
+    # scalar multiple of the aux column (ratio-of-products lift, issue #185).
+    composite_coeff_map: dict[int, float] = {}
+    # Linear-fractional ``r·q = m`` envelopes accumulated by the ratio lift.
+    ratio_relaxations: list[RatioRelaxation] = []
 
     univariate_square_relaxations, univariate_square_var_map, univariate_square_bounds = (
         _collect_univariate_square_relaxations(
@@ -4337,6 +4427,106 @@ def build_milp_relaxation(
         cross_term_used[0] = True
         return {folded: coeff}, 0.0
 
+    def _try_lift_ratio_of_products(div_expr: BinaryOp) -> None:
+        """Linear-fractional lift of ``coeff·(Π num_i) / (Π den_j)`` (issue #185).
+
+        Without this, a ratio of products (e.g. gear4's ``-1e6·i1·i2/(i3·i4)``)
+        is dumped into ``general_nl`` and the whole enclosing constraint is dropped
+        from the relaxation, leaving a trivial dual bound. We relax it via the
+        bilinear identity ``r·q = m`` where ``m`` is the lifted numerator product,
+        ``q`` the lifted denominator product, and ``r`` a fresh column for the
+        *pure* ratio ``m/q``; the division node is mapped to ``r`` with the scalar
+        ``coeff`` applied by the linearizer (keeping the large numerator constant
+        out of the envelope coefficients, so the relaxation LP stays
+        well-conditioned).
+
+        Soundness: ``r``'s interval is the sign-aware interval product
+        ``[m] · (1/[q])`` which contains the true ``m/q`` at every feasible point
+        (``1/q`` is monotone on a sign-definite ``q``), so the McCormick envelope
+        of ``r·q`` set equal to ``m`` is a valid outer approximation. We *decline*
+        (leaving the constraint to drop, which only enlarges the relaxation — always
+        sound) when the denominator is not strictly sign-definite / bounded away
+        from zero on the node box, when any factor is unbounded, or when the
+        envelope magnitudes exceed the conditioning limit (an ill-conditioned LP
+        could otherwise yield an unsound bound).
+        """
+        nonlocal col_idx
+        eid = id(div_expr)
+        if eid in composite_var_map or eid in univariate_var_map:
+            return
+
+        num = _decompose_signed_monomial(div_expr.left, model)
+        if num is None:
+            return
+        coeff, num_idx = num
+        if not (np.isfinite(coeff) and coeff != 0.0) or not num_idx:
+            return
+
+        den = _decompose_signed_monomial(div_expr.right, model)
+        if den is None:
+            return
+        den_coeff, den_idx = den
+        if not (np.isfinite(den_coeff) and den_coeff != 0.0) or not den_idx:
+            return
+        coeff = coeff / den_coeff
+        if not np.isfinite(coeff):
+            return
+
+        # Fold each side's variable factors into a single bounded product-aux
+        # column (each carries a standard McCormick envelope tying it to the
+        # underlying variables); a single-variable factor maps to its own column.
+        m_col = _fold_cols_to_aux(num_idx)
+        if m_col is None:
+            return
+        q_col = _fold_cols_to_aux(den_idx)
+        if q_col is None or q_col == m_col:
+            return
+
+        q_lo, q_hi = (float(v) for v in all_bounds[q_col])
+        if not (np.isfinite(q_lo) and np.isfinite(q_hi)):
+            return
+        # Must-gate: denominator strictly sign-definite and bounded away from 0,
+        # else 1/q's interval is invalid (→ unsound r bound → false certification).
+        if not (q_lo > _RECIP_MIN_DENOM or q_hi < -_RECIP_MIN_DENOM):
+            return
+        m_lo, m_hi = (float(v) for v in all_bounds[m_col])
+        if not (np.isfinite(m_lo) and np.isfinite(m_hi)):
+            return
+
+        # 1/q is monotone on a sign-definite interval, so its range is exactly
+        # [1/q_hi, 1/q_lo]; the pure ratio r = m/q lies in the interval product.
+        inv_lo, inv_hi = 1.0 / q_hi, 1.0 / q_lo
+        corners = [m_lo * inv_lo, m_lo * inv_hi, m_hi * inv_lo, m_hi * inv_hi]
+        r_lo, r_hi = float(min(corners)), float(max(corners))
+        if not (np.isfinite(r_lo) and np.isfinite(r_hi)):
+            return
+
+        # Conditioning guard: keep every envelope coefficient / RHS below the
+        # cross-term magnitude limit so the fast simplex backend stays reliable.
+        env_mags = [
+            abs(r_lo),
+            abs(r_hi),
+            abs(q_lo),
+            abs(q_hi),
+            abs(r_lo * q_lo),
+            abs(r_hi * q_hi),
+            abs(r_hi * q_lo),
+            abs(r_lo * q_hi),
+        ]
+        if max(env_mags) > _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE:
+            return
+
+        r_col = col_idx
+        all_bounds.append((r_lo, r_hi))
+        integrality_flags.append(0)
+        col_idx += 1
+
+        ratio_relaxations.append(
+            RatioRelaxation(r_col=r_col, q_col=q_col, m_col=m_col, r_lb=r_lo, r_ub=r_hi)
+        )
+        composite_var_map[eid] = r_col
+        composite_coeff_map[eid] = float(coeff)
+
     def _try_lift_nested_division(div_expr: BinaryOp) -> None:
         """Lift ``num / g`` with a *non-constant* numerator (issue #154 increment
         3). The constant-numerator path scales an existing ``1/g`` aux by the
@@ -4457,7 +4647,12 @@ def build_milp_relaxation(
         if isinstance(expr, BinaryOp) and expr.op == "/":
             num = _constant_value(expr.left)
             if num is None:
-                # Non-constant numerator: nested-division lift (increment 3).
+                # Non-constant numerator. Try the ratio-of-products lift first
+                # (handles signed numerators and product denominators via the
+                # r·q = m identity, issue #185); fall back to the reciprocal-based
+                # nested-division lift (issue #154 increment 3). The fallback is a
+                # no-op once the ratio lift has claimed the node.
+                _try_lift_ratio_of_products(expr)
                 _try_lift_nested_division(expr)
                 return
             func_name, inner = "reciprocal", expr.right
@@ -5112,6 +5307,49 @@ def build_milp_relaxation(
             row[i] -= xj_ub_g
             row[j] -= xi_lb_g
             _add_row(row, -xi_lb_g * xj_ub_g)
+
+    # ── Ratio-of-products linear-fractional envelopes (issue #185) ──────────
+    # Each lifted ratio carries the bilinear identity ``r·q = m`` (m the lifted
+    # numerator product, q the lifted denominator product, r the pure ratio).
+    # Emitting the four McCormick inequalities of the product ``r·q`` with the
+    # product value substituted by the linear term ``m`` outer-approximates the
+    # quotient: at any true point r = m/q so r·q = m holds and every row is
+    # satisfied, so the relaxed region is a superset of the true one (sound).
+    for rr in ratio_relaxations:
+        r_col, q_col, m_col = rr.r_col, rr.q_col, rr.m_col
+        r_lb, r_ub = (float(v) for v in all_bounds[r_col])
+        q_lb, q_ub = (float(v) for v in all_bounds[q_col])
+        if not (
+            _is_effectively_finite(r_lb)
+            and _is_effectively_finite(r_ub)
+            and _is_effectively_finite(q_lb)
+            and _is_effectively_finite(q_ub)
+        ):
+            continue
+        # m ≥ r_lb·q + q_lb·r − r_lb·q_lb  →  −m + r_lb·q + q_lb·r ≤ r_lb·q_lb
+        row = np.zeros(n_total)
+        row[m_col] += -1.0
+        row[q_col] += r_lb
+        row[r_col] += q_lb
+        _add_row(row, r_lb * q_lb)
+        # m ≥ r_ub·q + q_ub·r − r_ub·q_ub
+        row = np.zeros(n_total)
+        row[m_col] += -1.0
+        row[q_col] += r_ub
+        row[r_col] += q_ub
+        _add_row(row, r_ub * q_ub)
+        # m ≤ r_ub·q + q_lb·r − r_ub·q_lb  →  m − r_ub·q − q_lb·r ≤ −r_ub·q_lb
+        row = np.zeros(n_total)
+        row[m_col] += 1.0
+        row[q_col] += -r_ub
+        row[r_col] += -q_lb
+        _add_row(row, -r_ub * q_lb)
+        # m ≤ r_lb·q + q_ub·r − r_lb·q_ub
+        row = np.zeros(n_total)
+        row[m_col] += 1.0
+        row[q_col] += -r_lb
+        row[r_col] += -q_ub
+        _add_row(row, -r_lb * q_ub)
 
     # ── Multilinear RLT convex-hull cuts (emission) ────────────────────────
     # For each recorded term, emit the |S|-degree bound-factor product cuts for
@@ -6026,6 +6264,7 @@ def build_milp_relaxation(
                     flat_lb=flat_lb,
                     flat_ub=flat_ub,
                     composite_var_map=composite_var_map,
+                    composite_coeff_map=composite_coeff_map,
                 )
             except ValueError as err:
                 logger.debug(
@@ -6072,6 +6311,7 @@ def build_milp_relaxation(
                 flat_lb=flat_lb,
                 flat_ub=flat_ub,
                 composite_var_map=composite_var_map,
+                composite_coeff_map=composite_coeff_map,
             )
             # body ≤ 0  →  c @ z + const ≤ 0  →  c @ z ≤ -const
             if sense == "<=":
@@ -6141,6 +6381,7 @@ def build_milp_relaxation(
                 flat_lb=flat_lb,
                 flat_ub=flat_ub,
                 composite_var_map=composite_var_map,
+                composite_coeff_map=composite_coeff_map,
             )
         objective_bound_valid = True
     except ValueError as err:

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -91,6 +91,14 @@ class NonlinearTerms:
     # the fractional power to an aux column and adds a McCormick envelope on the
     # resulting (linear, aux) bilinear product.
     bilinear_with_fp: list[tuple[_VarIdx, tuple[_VarIdx, float]]] = field(default_factory=list)
+    # Ratios of products ``(c·Πx_i)/(Πy_j)`` recorded as
+    # ``((num_var_indices), (den_var_indices))`` (sorted, distinct).  The MILP
+    # relaxation lifts each via the linear-fractional ``r·q = m`` identity
+    # (issue #185); the embedded numerator/denominator products are also recorded
+    # as bilinear/trilinear/multilinear terms so they receive McCormick envelopes.
+    ratio_of_products: list[tuple[tuple[_VarIdx, ...], tuple[_VarIdx, ...]]] = field(
+        default_factory=list
+    )
     general_nl: list[Expression] = field(default_factory=list)
     term_incidence: dict[_VarIdx, set[int]] = field(default_factory=dict)
     partition_candidates: list[_VarIdx] = field(default_factory=list)
@@ -389,6 +397,109 @@ def extract_single_var_power(expr: Expression, model: Model) -> tuple[int, float
     return _visit(expr)
 
 
+def _ratio_fold_const(expr: Expression) -> float | None:
+    """Fold a variable-free subexpression to a scalar, else ``None``.
+
+    Handles literal constants and composite constants (``neg(1e6)``, ``-3*-3``,
+    arithmetic over constants) so a numerator scale factor such as gear4's
+    ``-1000000`` does not abort product recognition. Conservative: returns
+    ``None`` the moment a variable / unhandled node is seen.
+    """
+    if isinstance(expr, Constant):
+        try:
+            return float(expr.value)
+        except (TypeError, ValueError):
+            return None
+    if isinstance(expr, UnaryOp):
+        sub = _ratio_fold_const(expr.operand)
+        if sub is None:
+            return None
+        if expr.op == "neg":
+            return -sub
+        if expr.op == "abs":
+            return abs(sub)
+        return None
+    if isinstance(expr, BinaryOp):
+        left = _ratio_fold_const(expr.left)
+        if left is None:
+            return None
+        right = _ratio_fold_const(expr.right)
+        if right is None:
+            return None
+        if expr.op == "+":
+            return left + right
+        if expr.op == "-":
+            return left - right
+        if expr.op == "*":
+            return left * right
+        if expr.op == "/":
+            return None if right == 0.0 else left / right
+        if expr.op == "**":
+            try:
+                result = left**right
+            except (ValueError, OverflowError, ZeroDivisionError):
+                return None
+            return None if isinstance(result, complex) else float(result)
+    return None
+
+
+def _collect_ratio_product_vars(expr: Expression, model: Model) -> list[int] | None:
+    """Flat variable indices of a pure product ``c·Πx_i`` (constants folded away).
+
+    Returns the list of flat indices (with repeats for integer powers ``x**n``,
+    ``2 ≤ n ≤ 4``) or ``None`` if any leaf is not a constant, a flat-indexable
+    variable, an integer power thereof, or a division by a constant.
+    """
+    indices: list[int] = []
+
+    def visit(e: Expression) -> bool:
+        if _ratio_fold_const(e) is not None:
+            return True
+        flat = _get_flat_index(e, model)
+        if flat is not None:
+            indices.append(flat)
+            return True
+        if isinstance(e, UnaryOp) and e.op == "neg":
+            return visit(e.operand)
+        if isinstance(e, BinaryOp) and e.op == "*":
+            return visit(e.left) and visit(e.right)
+        if isinstance(e, BinaryOp) and e.op == "**" and isinstance(e.right, Constant):
+            p = _ratio_fold_const(e.right)
+            base = _get_flat_index(e.left, model)
+            if base is not None and p is not None and p.is_integer() and 2 <= int(p) <= 4:
+                indices.extend([base] * int(p))
+                return True
+        if isinstance(e, BinaryOp) and e.op == "/":
+            d = _ratio_fold_const(e.right)
+            if d is not None and d != 0.0:
+                return visit(e.left)
+            return False
+        return False
+
+    if not visit(expr):
+        return None
+    return indices
+
+
+def extract_ratio_of_products(expr: Expression, model: Model) -> tuple[list[int], list[int]] | None:
+    """Recognize ``(c·Πx_i)/(Πy_j)`` and return ``(num_indices, den_indices)``.
+
+    Both numerator and denominator must reduce to a product of bounded original
+    variables (constant scale factors folded away); the denominator must contain
+    at least one variable (a constant denominator is plain scaling). Returns
+    ``None`` for anything else (e.g. a transcendental or additive operand).
+    """
+    if not (isinstance(expr, BinaryOp) and expr.op == "/"):
+        return None
+    num = _collect_ratio_product_vars(expr.left, model)
+    if not num:
+        return None
+    den = _collect_ratio_product_vars(expr.right, model)
+    if not den:
+        return None
+    return num, den
+
+
 def extract_reciprocal_power(expr: Expression, model: Model) -> tuple[int, float, float] | None:
     """Recognize ``expr`` as ``c / (x**p)`` → ``(flat_idx, -p, c)``.
 
@@ -547,6 +658,21 @@ def _classify_nonlinear_terms_python(model: Model) -> NonlinearTerms:
             result.bilinear_with_fp.append(key)
         _record_fractional_power(*fp_norm)
 
+    def _record_product_indices(indices: list[int]) -> None:
+        """Record a distinct-variable product as a bilinear/trilinear/multilinear
+        term so it receives a McCormick envelope. Repeated-factor products (powers)
+        are skipped here; their variables still become partition candidates via the
+        ``ratio_of_products`` record."""
+        unique = list(dict.fromkeys(indices))
+        if len(unique) != len(indices):
+            return
+        if len(unique) == 2:
+            _record_bilinear(unique[0], unique[1])
+        elif len(unique) == 3:
+            _record_trilinear(unique[0], unique[1], unique[2])
+        elif len(unique) >= 4:
+            _record_multilinear(unique)
+
     def _classify_node(expr: Expression) -> None:
         """Recursively classify all nonlinear nodes in the expression tree."""
         if isinstance(expr, Constant):
@@ -660,6 +786,23 @@ def _classify_nonlinear_terms_python(model: Model) -> NonlinearTerms:
                     _record_fractional_power(flat_idx, neg_exp)
                     result.general_nl.append(expr)
                     return
+                # (c·Πx)/(Πy) → ratio of products (issue #185). Register the
+                # numerator and denominator products so they receive McCormick
+                # envelopes and their variables become partition candidates; the
+                # MILP relaxation lifts the quotient via the r·q = m identity.
+                ratio = extract_ratio_of_products(expr, model)
+                if ratio is not None:
+                    num_idx, den_idx = ratio
+                    _record_product_indices(num_idx)
+                    _record_product_indices(den_idx)
+                    result.ratio_of_products.append(
+                        (
+                            tuple(sorted(dict.fromkeys(num_idx))),
+                            tuple(sorted(dict.fromkeys(den_idx))),
+                        )
+                    )
+                    result.general_nl.append(expr)
+                    return
                 # c / x or x / y → general nonlinear
                 result.general_nl.append(expr)
                 return
@@ -733,6 +876,11 @@ def _classify_nonlinear_terms_python(model: Model) -> NonlinearTerms:
         candidates.add(fp_base)
     for fp_base, _exp in result.fractional_power:
         candidates.add(fp_base)
+    # Ratio-of-products variables (numerator and denominator) drive the
+    # linear-fractional envelope; partitioning them tightens it (issue #185).
+    for num_vars, den_vars in result.ratio_of_products:
+        candidates.update(num_vars)
+        candidates.update(den_vars)
     result.partition_candidates = sorted(candidates)
 
     return result

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1752,6 +1752,26 @@ def solve_model(
     # spatial-branch on" fallback below (which the aux vars otherwise defeat).
     _origin_has_continuous_var = any(v.var_type == VarType.CONTINUOUS for v in model._variables)
 
+    # Whether any *original* continuous decision variable has a finite box to
+    # spatial-branch on, captured (like ``_origin_has_continuous_var``) before the
+    # factorable lift adds dependent continuous aux vars. A model whose only
+    # continuous variables are *unbounded* slacks (gear4's ``x4, x5``) has nothing
+    # to bisect on the spatial McCormick LP path: the tree dead-ends after the
+    # root and a no-incumbent exhaustion would be falsely certified infeasible
+    # (issue #185). Such models route to the NLP/alphaBB path instead.
+    _origin_lb_chk, _origin_ub_chk = flat_variable_bounds(model)
+    _origin_has_finite_continuous_var = False
+    _origin_chk_off = 0
+    for _ov in model._variables:
+        if _ov.var_type == VarType.CONTINUOUS:
+            _ov_seg = slice(_origin_chk_off, _origin_chk_off + _ov.size)
+            if np.all(np.isfinite(_origin_lb_chk[_ov_seg])) and np.all(
+                np.isfinite(_origin_ub_chk[_ov_seg])
+            ):
+                _origin_has_finite_continuous_var = True
+                break
+        _origin_chk_off += _ov.size
+
     if has_factorable_work(model):
         # Tighten variable bounds with FBBT *before* the reform so its interval
         # checks see finite bounds. A fractional-power-of-product lift (issue
@@ -2457,14 +2477,25 @@ def solve_model(
     if _mc_mode == "lp" and model._objective is not None:
         from discopt._jax.mccormick_lp import MccormickLPRelaxer
 
-        _has_continuous_var = _origin_has_continuous_var
+        # A continuous variable is only useful to the spatial path if it has a
+        # finite box to bisect. A model whose only continuous variables are
+        # *unbounded* slacks (ub=+inf) — e.g. gear4's ``x4, x5`` absorbing the
+        # ratio residual — has nothing to spatial-branch on, exactly like the
+        # integer-only case: the LP relaxer's integer-feasible root point need
+        # not satisfy the original nonlinear constraint, the tree dead-ends after
+        # the root, and a no-incumbent exhaustion would be *falsely* certified
+        # infeasible (the worst failure class, issue #185). Gate on the original
+        # finite-box continuous flag (computed pre-reform so dependent aux vars
+        # never mask the integer-only case), else fall back to NLP/alphaBB.
+        _has_continuous_var = _origin_has_finite_continuous_var
         if not _has_continuous_var:
-            # Spatial-BB on integer-only models has nothing to branch on:
-            # the LP relaxer's integer-feasible point doesn't satisfy the
-            # original bilinear constraints, and with no continuous var to
-            # bisect, the tree dead-ends after the root. Fall back to NLP.
+            # Spatial-BB on integer-only (or unbounded-slack-only) models has
+            # nothing to branch on: the LP relaxer's integer-feasible point
+            # doesn't satisfy the original bilinear constraints, and with no
+            # finite continuous var to bisect, the tree dead-ends after the
+            # root. Fall back to NLP.
             logger.info(
-                "McCormick LP requested but model has no continuous "
+                "McCormick LP requested but model has no finite-box continuous "
                 "variables; falling back to NLP relaxation."
             )
             _mc_lp_relaxer = None

--- a/python/tests/test_nested_division_soundness.py
+++ b/python/tests/test_nested_division_soundness.py
@@ -151,11 +151,14 @@ def test_nested_division_backends_agree(xb, yb):
     )
 
 
-def test_nested_division_abstains_on_negative_numerator():
-    """A *negative* numerator coefficient is out of scope — folding it into the
-    reciprocal argument would flip the denominator interval negative (the convex
-    reciprocal envelope needs a positive denominator). The lift must abstain, which
-    leaves the constraint un-lifted (sound: it only enlarges the relaxation)."""
+def test_negative_numerator_ratio_lifts_soundly():
+    """A *negative* numerator coefficient is out of scope for the reciprocal-based
+    nested-division lift (folding it into the reciprocal argument would flip the
+    denominator interval negative). The ratio-of-products lift (issue #185) handles
+    it soundly instead: ``(-0.5*y)/x`` becomes the pure ratio ``r = y/x`` with the
+    bilinear identity ``r*x = y`` and the ``-0.5`` applied as a substitution
+    coefficient (kept out of the envelope rows). The lift therefore *engages* now,
+    and the relaxation stays a valid lower bound."""
     m = dm.Model()
     x = m.continuous("x", lb=1.0, ub=3.0)
     y = m.continuous("y", lb=1.0, ub=3.0)
@@ -169,8 +172,16 @@ def test_nested_division_abstains_on_negative_numerator():
         bound_override=(np.asarray(lb), np.asarray(ub)),
         superposition=relaxer._superposition,
     )
-    # No lift → no aux columns beyond the 2 originals.
-    assert len(milp._c) == 2, "negative-numerator division should not lift"
+    # The ratio-of-products lift adds a pure-ratio aux column (issue #185).
+    assert len(milp._c) > 2, "negative-numerator ratio should lift via the #185 path"
+
+    # Soundness: the root lower bound never exceeds the true minimum, which is
+    # ``-0.5 * max(y/x) = -0.5 * 3 = -1.5`` at (x, y) = (1, 3).
+    res = relaxer.solve_at_node(np.asarray(lb, float), np.asarray(ub, float))
+    assert res.status == "optimal" and res.lower_bound is not None
+    assert res.lower_bound <= -1.5 + _TOL, (
+        f"unsound negative-numerator ratio bound {res.lower_bound} > true min -1.5"
+    )
 
 
 # nvs05/nvs22: constraint C2 = (0.5*x3)/x6 now lifts; (instance, optimum).

--- a/python/tests/test_ratio_of_products_relaxation.py
+++ b/python/tests/test_ratio_of_products_relaxation.py
@@ -1,0 +1,207 @@
+"""Linear-fractional relaxation for a ratio of products (issue #185).
+
+discopt previously dumped a quotient of products ``(c·Πx)/(Πy)`` into
+``general_nl`` and dropped the enclosing constraint from the McCormick
+relaxation, leaving a trivial dual bound (the gear4 "wall #2"). This module
+locks the new behavior:
+
+* the term classifier recognizes the ratio (including gear4's *negative*
+  numerator coefficient) and records the embedded products + partition
+  candidates;
+* :class:`MccormickLPRelaxer` lifts the quotient via the bilinear identity
+  ``r·q = m`` (``r`` the pure ratio, ``m``/``q`` the lifted numerator/denominator
+  products) and produces a **sound** lower bound — verified by a property test
+  over random positive-denominator ratios — that is *exact* when the variables
+  are pinned.
+
+The large numerator constant (gear4's ``1e6``) is applied by the linearizer as a
+substitution coefficient, never injected into the envelope rows, so the
+relaxation LP stays well-conditioned (this is what distinguishes the sound lift
+from the naive ``y·D = N`` route that produced a false-optimal on gear4 — see
+``test_quotient_certification`` scope note and issue #145).
+"""
+
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.term_classifier import (
+    classify_nonlinear_terms,
+    extract_ratio_of_products,
+)
+from discopt.modeling.core import from_nl
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+
+def _ratio_model(coeff: float) -> dm.Model:
+    """``minimize coeff·(x0·x1)/(x2·x3)`` over a positive-denominator box."""
+    m = dm.Model("ratio")
+    x0 = m.continuous("x0", lb=2.0, ub=4.0)
+    x1 = m.continuous("x1", lb=2.0, ub=4.0)
+    x2 = m.continuous("x2", lb=1.0, ub=2.0)
+    x3 = m.continuous("x3", lb=1.0, ub=2.0)
+    m.minimize(coeff * (x0 * x1) / (x2 * x3))
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Classifier recognition
+# ---------------------------------------------------------------------------
+
+
+def test_classifier_recognizes_ratio_of_products():
+    """The classifier records the ratio and its embedded products / candidates."""
+    m = _ratio_model(1.0)
+    terms = classify_nonlinear_terms(m)
+    assert terms.ratio_of_products == [((0, 1), (2, 3))]
+    # Numerator and denominator products are recorded as bilinear terms (so they
+    # get McCormick envelopes) and their variables become partition candidates.
+    assert (0, 1) in terms.bilinear
+    assert (2, 3) in terms.bilinear
+    assert set(terms.partition_candidates) == {0, 1, 2, 3}
+
+
+def test_classifier_recognizes_negative_coefficient_ratio():
+    """gear4's wall #2 shape: a *negative* numerator coefficient is recognized."""
+    m = dm.Model("gear4_shape")
+    i1 = m.integer("i1", lb=12, ub=60)
+    i2 = m.integer("i2", lb=12, ub=60)
+    i3 = m.integer("i3", lb=12, ub=60)
+    i4 = m.integer("i4", lb=12, ub=60)
+    x6 = m.continuous("x6", lb=0.0, ub=1e6)
+    x7 = m.continuous("x7", lb=0.0, ub=1e6)
+    m.minimize(x6 + x7)
+    m.subject_to(-(1e6 * i1 * i2) / (i3 * i4) - x6 + x7 == -144279.32477276)
+
+    terms = classify_nonlinear_terms(m)
+    assert terms.ratio_of_products == [((0, 1), (2, 3))]
+
+
+def test_extract_ratio_of_products_rejects_non_ratio():
+    """The matcher declines non-ratio / constant-denominator divisions."""
+    m = dm.Model("nr")
+    x0 = m.continuous("x0", lb=1.0, ub=2.0)
+    x1 = m.continuous("x1", lb=1.0, ub=2.0)
+    # x / constant is plain scaling, not a ratio of products.
+    assert extract_ratio_of_products((x0 * x1) / 3.0, m) is None
+    # numerator is additive, not a product.
+    assert extract_ratio_of_products((x0 + x1) / (x0 * x1), m) is None
+
+
+# ---------------------------------------------------------------------------
+# Relaxation soundness (the issue's must-gate property test)
+# ---------------------------------------------------------------------------
+
+
+def _sample_true_min(coeff, lb, ub, n=20000, seed=0):
+    rng = np.random.default_rng(seed)
+    pts = lb + rng.random((n, 4)) * (ub - lb)
+    vals = coeff * (pts[:, 0] * pts[:, 1]) / (pts[:, 2] * pts[:, 3])
+    return float(vals.min())
+
+
+@pytest.mark.parametrize("coeff", [1.0, -2.0, -1e6, 5.0])
+def test_relaxation_is_a_valid_lower_bound(coeff):
+    """The lifted relaxation LB never exceeds the true minimum over the box.
+
+    Lower-bound soundness: a valid relaxation underestimates the objective at
+    *every* feasible point, so its LP optimum is ≤ the true minimum sampled by
+    Monte Carlo (allowing a small tolerance for the finite sample)."""
+    m = _ratio_model(coeff)
+    lb = np.array([2.0, 2.0, 1.0, 1.0])
+    ub = np.array([4.0, 4.0, 2.0, 2.0])
+    relaxer = MccormickLPRelaxer(m)
+    res = relaxer.solve_at_node(lb, ub)
+    assert res.status == "optimal" and res.lower_bound is not None
+    true_min = _sample_true_min(coeff, lb, ub)
+    # Relaxation must lie at or below the true minimum (sound lower bound).
+    rel_scale = max(1.0, abs(true_min))
+    assert res.lower_bound <= true_min + 1e-4 * rel_scale, (
+        f"unsound: LB={res.lower_bound} > true_min={true_min} (coeff={coeff})"
+    )
+
+
+@pytest.mark.parametrize("coeff", [1.0, -2.0, -1e6])
+def test_relaxation_exact_when_pinned(coeff):
+    """Pinning all variables makes the lifted relaxation reproduce the exact ratio."""
+    m = _ratio_model(coeff)
+    pt = np.array([3.0, 4.0, 1.0, 2.0])  # x0=3,x1=4,x2=1,x3=2
+    relaxer = MccormickLPRelaxer(m)
+    res = relaxer.solve_at_node(pt.copy(), pt.copy())
+    assert res.status == "optimal" and res.lower_bound is not None
+    exact = coeff * (pt[0] * pt[1]) / (pt[2] * pt[3])
+    assert res.lower_bound == pytest.approx(exact, rel=1e-6, abs=1e-6)
+
+
+def test_relaxation_declines_sign_indefinite_denominator():
+    """A denominator straddling zero is *not* lifted (the must-gate guard).
+
+    The relaxation must stay sound: it declines the ratio lift and the bound is
+    never above the true minimum (here the LP simply omits the unbounded term).
+    """
+    m = dm.Model("signflip")
+    x0 = m.continuous("x0", lb=1.0, ub=2.0)
+    x1 = m.continuous("x1", lb=1.0, ub=2.0)
+    x2 = m.continuous("x2", lb=-1.0, ub=1.0)  # straddles 0
+    x3 = m.continuous("x3", lb=1.0, ub=2.0)
+    m.minimize((x0 * x1) / (x2 * x3))
+    relaxer = MccormickLPRelaxer(m)
+    # Build must not raise and any produced bound must be sound (≤ true values).
+    res = relaxer.solve_at_node(np.array([1.0, 1.0, -1.0, 1.0]), np.array([2.0, 2.0, 1.0, 2.0]))
+    if res.status == "optimal" and res.lower_bound is not None:
+        # true ratio is unbounded below near x2→0^-, so any finite LB is sound;
+        # the key property is that the lift did not fabricate a finite *upper*
+        # cut that excludes feasible points. A simple sound check: LB ≤ value at
+        # an interior feasible point.
+        val = (1.5 * 1.5) / (0.5 * 1.5)
+        assert res.lower_bound <= val + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# gear4: the motivating instance
+# ---------------------------------------------------------------------------
+
+
+def test_gear4_relaxation_retains_constraint_and_is_exact_at_optimum():
+    """gear4's quotient constraint is retained by the relaxation and the pinned
+    node reproduces the true global optimum 1.6434 (issue #185 acceptance #1)."""
+    from discopt._jax.model_utils import flat_variable_bounds
+
+    m = from_nl(str(_DATA / "gear4.nl"))
+    relaxer = MccormickLPRelaxer(m)
+    # Pin the integers to the known optimum (16,19,43,49); leave the slacks free.
+    lb, ub = (np.asarray(a, dtype=float).copy() for a in flat_variable_bounds(m))
+    n = lb.size
+    # Variables order: i1,i2,i3,i4, then continuous slacks.
+    opt = {0: 16.0, 1: 19.0, 2: 43.0, 3: 49.0}
+    for idx, val in opt.items():
+        lb[idx] = ub[idx] = val
+    res = relaxer.solve_at_node(lb, ub)
+    assert res.status == "optimal" and res.lower_bound is not None, (
+        "gear4 constraint e1 was dropped from the relaxation (wall #2 not fixed)"
+    )
+    assert res.lower_bound == pytest.approx(1.6434284730639774, abs=1e-3)
+    assert n >= 6
+
+
+def test_gear4_solve_stays_sound():
+    """End-to-end gear4 must never be certified infeasible (soundness must-gate)."""
+    r = from_nl(str(_DATA / "gear4.nl")).solve(time_limit=20, max_nodes=500)
+    assert not (r.status == "infeasible" and r.gap_certified), (
+        f"gear4 falsely certified: status={r.status} cert={r.gap_certified}"
+    )
+    assert r.status != "infeasible", f"gear4 is feasible but status={r.status}"
+    if r.bound is not None:
+        assert r.bound <= 1.6434284730639774 + 1e-3, f"unsound dual bound {r.bound}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes the gear4 "wall #2" from #185: discopt had no relaxation for a quotient of products `(c·Πx)/(Πy)`. The term classifier dumped the whole ratio into `general_nl`, so no aux columns or envelopes were built and the **enclosing constraint was dropped from the McCormick relaxation entirely** — a trivial dual bound and no spatial pruning.

This adds a sound **linear-fractional lift** via the bilinear identity `r·q = m`.

## What changed

- **`term_classifier.py`** — `extract_ratio_of_products` recognizes `(c·Πx)/(Πy)`, including gear4's composite-constant **negative** numerator (`-1e6`). It records the numerator/denominator products as bilinear/trilinear/multilinear terms (so they receive McCormick envelopes) and their variables as partition candidates. New `NonlinearTerms.ratio_of_products` field.
- **`milp_relaxation.py`** — `_try_lift_ratio_of_products` allocates a *pure* ratio aux `r` with the sign-aware interval `[m]·(1/[q])`, folds the numerator/denominator into McCormick-enveloped product columns `m`, `q`, emits the four McCormick rows of `r·q = m`, and maps the division node to `r`. The numerator constant (gear4's `1e6`) is applied as a **substitution coefficient** (new `composite_coeff_map`), never injected into the envelope rows, so the relaxation LP stays well-conditioned. This is precisely what distinguishes the sound lift from the naive `y·D = N` route that produced a false-optimal on gear4 (#145).
- **`solver.py`** — fixes a latent **false certification**: the spatial McCormick-LP path dead-ends after the root on models whose only continuous variables are unbounded slacks (gear4), and a no-incumbent exhaustion was being certified *infeasible* (the worst failure class). Spatial-LP engagement is now gated on the presence of a finite-box **original** continuous variable (computed pre-reform so dependent aux vars never mask the integer-only case), else it falls back to the NLP/alphaBB path — extending the existing integer-only guard.

## Soundness gates (issue must-haves)

- [x] **Decline** (fall back to the dropped-constraint behavior, which only enlarges the relaxation) when the denominator is not strictly sign-definite / bounded away from zero, when any factor is unbounded, or when envelope magnitudes exceed the conditioning limit.
- [x] **Property test**: relaxation value ≤ true value at sampled points for random positive-denominator ratios (coeff ∈ {1, −2, −1e6, 5}).
- [x] **No SUSPECT / no false certification**: gear4 soundness locks pass; the lift is exact when variables are pinned (gear4's optimum **1.6434** reproduced at the optimal integer assignment).

## Acceptance criteria

- [x] gear4's quotient constraint `e1` is **retained** by the relaxation and the pinned node produces the true optimum 1.6434 (proven directly via `MccormickLPRelaxer`).
- [x] Soundness gates pass; zero new failures across the suites run.

## Validation

- 13 new tests in `test_ratio_of_products_relaxation.py` pass (classifier recognition, lower-bound soundness property test, exactness when pinned, sign-indefinite-denominator decline, gear4 e1 retention).
- gear4 soundness locks (`test_gear4_false_infeasible.py`): pass.
- McCormick relaxation suite: 119 pass; convex/simplex: 40 pass.
- `test_amp.py`: the 7 failures (trig/HiGHS-related) are **pre-existing** on the branch — confirmed identical on baseline. **Zero new failures.** The nvs06 quotient-certification failure is likewise pre-existing.

## Scope note

gear4's *end-to-end* solve still routes off the spatial path (its unbounded slacks have nothing to spatial-branch on — the separate #145 pathology), so its solve result is unchanged from baseline; the relaxation capability itself is correct and engages for ratio models with a finite continuous variable to branch on. Note that `factorable_reform` clears most *bounded* ratios before they reach the relaxation, so the lift primarily matters for ratios that survive clearing (the gear4-class, sign-definite-but-unbounded-product case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6WdYJWaB7hwvFJzPSDABG)_