### PR TITLE
SOTA gap-closing, wave 1: relaxation theorems, best-estimate search, improvement heuristics, MPEC, conflict cuts

### DIFF
--- a/crates/discopt-core/src/bnb/branching.rs
+++ b/crates/discopt-core/src/bnb/branching.rs
@@ -306,6 +306,7 @@ pub fn create_children(
         lb: parent.lb.clone(),
         ub: left_ub,
         local_lower_bound: inherited_lb,
+        best_estimate: inherited_lb,
         status: NodeStatus::Pending,
         parent_solution: parent_sol.clone(),
         basis: parent_basis.clone(),
@@ -321,6 +322,7 @@ pub fn create_children(
         lb: right_lb,
         ub: parent.ub.clone(),
         local_lower_bound: inherited_lb,
+        best_estimate: inherited_lb,
         status: NodeStatus::Pending,
         parent_solution: parent_sol,
         basis: parent_basis,
@@ -354,6 +356,7 @@ pub fn create_children_spatial(
         lb: parent.lb.clone(),
         ub: left_ub,
         local_lower_bound: inherited_lb,
+        best_estimate: inherited_lb,
         status: NodeStatus::Pending,
         parent_solution: parent_sol.clone(),
         basis: None, // spatial branching is MINLP-side; no simplex basis
@@ -369,6 +372,7 @@ pub fn create_children_spatial(
         lb: right_lb,
         ub: parent.ub.clone(),
         local_lower_bound: inherited_lb,
+        best_estimate: inherited_lb,
         status: NodeStatus::Pending,
         parent_solution: parent_sol,
         basis: None, // spatial branching is MINLP-side; no simplex basis

--- a/crates/discopt-core/src/bnb/node.rs
+++ b/crates/discopt-core/src/bnb/node.rs
@@ -36,6 +36,12 @@ pub struct Node {
     pub ub: Vec<f64>,
     /// Relaxation objective bound at this node.
     pub local_lower_bound: f64,
+    /// Best-estimate of the optimal objective in this node's subtree, used by the
+    /// `BestEstimate` selection strategy. Computed from the parent's pseudocosts
+    /// at branch time. `NEG_INFINITY` means "unset" — selection falls back to
+    /// `local_lower_bound`, so best-estimate degrades gracefully to best-first
+    /// before any pseudocost history exists.
+    pub best_estimate: f64,
     /// Current status.
     pub status: NodeStatus,
     /// Parent node's NLP solution, used as warm-start for child solves.
@@ -62,6 +68,7 @@ impl Node {
             lb,
             ub,
             local_lower_bound: f64::NEG_INFINITY,
+            best_estimate: f64::NEG_INFINITY,
             status: NodeStatus::Pending,
             parent_solution: None,
             basis: None,

--- a/crates/discopt-core/src/bnb/pool.rs
+++ b/crates/discopt-core/src/bnb/pool.rs
@@ -12,6 +12,10 @@ pub enum SelectionStrategy {
     BestFirst,
     /// Select the deepest node, breaking ties by lowest lower bound (depth-first).
     DepthFirst,
+    /// Select the node with the lowest best-estimate of its subtree optimum
+    /// (Forrest/Achterberg best-estimate search). Finds good incumbents earlier;
+    /// falls back to the lower bound when a node's estimate is unset.
+    BestEstimate,
 }
 
 /// Entry in the priority queue, wrapping a NodeId with ordering metadata.
@@ -19,6 +23,9 @@ pub enum SelectionStrategy {
 struct HeapEntry {
     node_id: NodeId,
     lower_bound: f64,
+    /// Best-estimate of the subtree optimum; equals `lower_bound` when the node's
+    /// estimate was never set, so `BestEstimate` degrades to `BestFirst`.
+    estimate: f64,
     depth: usize,
     strategy: SelectionStrategy,
 }
@@ -72,6 +79,21 @@ impl Ord for HeapEntry {
                         self.node_id.0.cmp(&other.node_id.0)
                     })
             }
+            SelectionStrategy::BestEstimate => {
+                // Max-heap: reverse so the lowest estimate is selected first.
+                other
+                    .estimate
+                    .partial_cmp(&self.estimate)
+                    .unwrap_or(Ordering::Equal)
+                    .then_with(|| {
+                        // Tie-break on the (valid) lower bound, then determinism.
+                        other
+                            .lower_bound
+                            .partial_cmp(&self.lower_bound)
+                            .unwrap_or(Ordering::Equal)
+                    })
+                    .then_with(|| other.node_id.0.cmp(&self.node_id.0))
+            }
         }
     }
 }
@@ -102,9 +124,17 @@ impl NodePool {
         let id = node.id;
         assert_eq!(id.0, self.nodes.len(), "Node ID must match insertion order");
         if node.status == NodeStatus::Pending {
+            // An unset estimate (NEG_INFINITY) falls back to the lower bound so
+            // best-estimate ordering matches best-first until pseudocosts exist.
+            let estimate = if node.best_estimate.is_finite() {
+                node.best_estimate
+            } else {
+                node.local_lower_bound
+            };
             self.open.push(HeapEntry {
                 node_id: id,
                 lower_bound: node.local_lower_bound,
+                estimate,
                 depth: node.depth,
                 strategy: self.strategy,
             });
@@ -174,6 +204,12 @@ mod tests {
     fn make_pending_node(id: usize, depth: usize, lb: f64) -> Node {
         let mut node = Node::new(NodeId(id), None, depth, vec![], vec![]);
         node.local_lower_bound = lb;
+        node
+    }
+
+    fn make_estimate_node(id: usize, lb: f64, estimate: f64) -> Node {
+        let mut node = make_pending_node(id, 0, lb);
+        node.best_estimate = estimate;
         node
     }
 
@@ -262,6 +298,43 @@ mod tests {
         pool.add(make_pending_node(0, 0, 1.0));
         pool.add(make_pending_node(1, 0, 2.0));
         assert_eq!(pool.total_count(), 2);
+    }
+
+    #[test]
+    fn test_best_estimate_selects_lowest_estimate() {
+        let mut pool = NodePool::new(SelectionStrategy::BestEstimate);
+        // Lower bounds are equal; only the estimate differentiates the nodes.
+        pool.add(make_estimate_node(0, 5.0, 12.0));
+        pool.add(make_estimate_node(1, 5.0, 7.0));
+        pool.add(make_estimate_node(2, 5.0, 9.0));
+
+        assert_eq!(pool.select_next(), Some(NodeId(1))); // estimate 7
+        assert_eq!(pool.select_next(), Some(NodeId(2))); // estimate 9
+        assert_eq!(pool.select_next(), Some(NodeId(0))); // estimate 12
+        assert_eq!(pool.select_next(), None);
+    }
+
+    #[test]
+    fn test_best_estimate_falls_back_to_lower_bound_when_unset() {
+        // With no estimate set, BestEstimate must behave like BestFirst.
+        let mut pool = NodePool::new(SelectionStrategy::BestEstimate);
+        pool.add(make_pending_node(0, 0, 10.0));
+        pool.add(make_pending_node(1, 0, 5.0));
+        pool.add(make_pending_node(2, 0, 8.0));
+
+        assert_eq!(pool.select_next(), Some(NodeId(1))); // lb 5
+        assert_eq!(pool.select_next(), Some(NodeId(2))); // lb 8
+        assert_eq!(pool.select_next(), Some(NodeId(0))); // lb 10
+    }
+
+    #[test]
+    fn test_best_estimate_differs_from_best_first() {
+        // Node 0 has the lower bound but a worse (higher) estimate; best-estimate
+        // should prefer node 1, whereas best-first would pick node 0.
+        let mut pool = NodePool::new(SelectionStrategy::BestEstimate);
+        pool.add(make_estimate_node(0, 1.0, 20.0));
+        pool.add(make_estimate_node(1, 3.0, 6.0));
+        assert_eq!(pool.select_next(), Some(NodeId(1)));
     }
 
     #[test]

--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -355,7 +355,17 @@ impl TreeManager {
                 let parent = self.pool.get(result.node_id).clone();
                 self.pool.get_mut(result.node_id).status = NodeStatus::Branched;
 
-                let (left, right) = create_children(&parent, decision, || self.next_id());
+                let (mut left, mut right) = create_children(&parent, decision, || self.next_id());
+
+                // Best-estimate: predict each child's bound from pseudocosts so
+                // the BestEstimate strategy can order the open set. The down child
+                // (left, x <= floor) is charged the down pseudocost over the
+                // rounded-off fraction; the up child (right) the up pseudocost.
+                // Harmless for other strategies, which ignore best_estimate.
+                left.best_estimate =
+                    node_lb + self.pseudocosts.down_cost(decision.var_index) * frac_part;
+                right.best_estimate =
+                    node_lb + self.pseudocosts.up_cost(decision.var_index) * (1.0 - frac_part);
 
                 // Record branch info for both children.
                 let record = BranchRecord {

--- a/crates/discopt-python/src/bnb_bindings.rs
+++ b/crates/discopt-python/src/bnb_bindings.rs
@@ -60,9 +60,10 @@ impl PyTreeManager {
         let sel_strategy = match strategy {
             "best_first" => SelectionStrategy::BestFirst,
             "depth_first" => SelectionStrategy::DepthFirst,
+            "best_estimate" => SelectionStrategy::BestEstimate,
             _ => {
                 return Err(PyValueError::new_err(format!(
-                    "Unknown strategy: '{}'. Use 'best_first' or 'depth_first'.",
+                    "Unknown strategy: '{}'. Use 'best_first', 'depth_first', or 'best_estimate'.",
                     strategy
                 )));
             }

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -14,6 +14,7 @@ parts:
       - file: notebooks/tutorial_robust
       - file: notebooks/robust_adjustable
       - file: notebooks/tutorial_multiobjective
+      - file: notebooks/complementarity_mpec
   - caption: "Tutorials \u2014 Solver Backends"
     chapters:
       - file: notebooks/tutorial_oa

--- a/docs/notebooks/complementarity_mpec.ipynb
+++ b/docs/notebooks/complementarity_mpec.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Complementarity and MPEC Models\n",
+    "\n",
+    "Many equilibrium, bilevel, and contact problems include **complementarity**\n",
+    "conditions\n",
+    "\n",
+    "$$ 0 \\le f(x) \\;\\perp\\; g(x) \\ge 0 \\qquad\\Longleftrightarrow\\qquad f \\ge 0,\\; g \\ge 0,\\; f\\cdot g = 0. $$\n",
+    "\n",
+    "A program with such constraints is a *Mathematical Program with Equilibrium\n",
+    "Constraints* (MPEC). The product condition $f\\cdot g = 0$ is nonconvex and\n",
+    "violates the standard constraint qualifications, so a naive NLP solve stalls\n",
+    "{cite:p}`LuoPangRalph1996`.\n",
+    "\n",
+    "`discopt.mpec` provides the two standard reformulations:\n",
+    "\n",
+    "1. **Scholtes regularization** {cite:p}`Scholtes2001` \u2014 relax $f\\cdot g = 0$ to\n",
+    "   $f\\cdot g \\le t$ and drive $t \\to 0$ through a homotopy of *local* NLP solves.\n",
+    "2. **SOS1 / disjunctive** \u2014 encode \"at most one of $f$, $g$ is nonzero\" exactly\n",
+    "   with a Special Ordered Set of type 1, solved by the global MINLP\n",
+    "   branch-and-bound. This is the discrete analogue of solving the MPEC as an NLP\n",
+    "   {cite:p}`FletcherLeyffer2004`.\n",
+    "\n",
+    "Both build an ordinary discopt model, so the global-optimality machinery is\n",
+    "reused unchanged.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+    "os.environ[\"JAX_ENABLE_X64\"] = \"1\"\n",
+    "\n",
+    "import numpy as np\n",
+    "import discopt.modeling.core as dm\n",
+    "from discopt.mpec import complementarity, solve_mpec, tighten_complementarity_bounds\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A reference MPEC\n",
+    "\n",
+    "We minimize the distance from $(x, y)$ to $(1, 1)$ subject to\n",
+    "$0 \\le x \\perp y \\ge 0$. The complementarity forces $x\\cdot y = 0$, so the\n",
+    "global optima sit at $(1, 0)$ and $(0, 1)$, both with objective $1$.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def distance_model():\n",
+    "    m = dm.Model(\"mpec_distance\")\n",
+    "    x = m.continuous(\"x\", lb=0, ub=10)\n",
+    "    y = m.continuous(\"y\", lb=0, ub=10)\n",
+    "    m.minimize((x - 1) ** 2 + (y - 1) ** 2)\n",
+    "    return m, x, y\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scholtes regularization\n",
+    "\n",
+    "The homotopy solves a sequence of smooth NLPs with $t = 1, 10^{-1}, \\dots$,\n",
+    "warm-starting each from the previous solution. As $t \\to 0$ the iterate\n",
+    "approaches the complementary set.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m, x, y = distance_model()\n",
+    "res = solve_mpec(m, [complementarity(x, y)], method=\"scholtes\")\n",
+    "print(\"x, y =\", np.round(res.x, 6))\n",
+    "print(\"objective =\", round(float(res.objective), 6))\n",
+    "print(\"x*y =\", float(res.x[0] * res.x[1]))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The iterate converges to $(0, 1)$ (up to the regularization tolerance) with\n",
+    "objective $1$ and $x\\cdot y \\approx 0$ \u2014 a global optimum of the MPEC.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exact SOS1 reformulation\n",
+    "\n",
+    "For a certifiable answer we encode the complementarity exactly. The SOS1 set\n",
+    "$\\{x, y\\}$ allows at most one member to be nonzero; the global MINLP solver\n",
+    "branches on the two disjuncts $x = 0$ and $y = 0$.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2, x2, y2 = distance_model()\n",
+    "res2 = solve_mpec(m2, [complementarity(x2, y2)], method=\"sos1\")\n",
+    "print(\"status   =\", res2.status)\n",
+    "print(\"objective =\", round(float(res2.objective), 6))\n",
+    "# Model.solve returns a name -> value mapping.\n",
+    "print(\"x, y =\", float(np.asarray(res2.x[\"x\"])), float(np.asarray(res2.x[\"y\"])))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Both reformulations reach objective $1$, confirming the same global optimum\n",
+    "by two independent routes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Complementarity bound propagation\n",
+    "\n",
+    "When one side of $0 \\le x \\perp y \\ge 0$ is provably strictly positive\n",
+    "($\\text{lb} > 0$), the other side must be zero. This sound implication is\n",
+    "exact for single-variable sides and tightens the model before search.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m3 = dm.Model(\"bp\")\n",
+    "a = m3.continuous(\"a\", lb=0.5, ub=3.0)   # strictly positive lower bound\n",
+    "b = m3.continuous(\"b\", lb=0.0, ub=3.0)\n",
+    "n_fixed = tighten_complementarity_bounds(m3, [complementarity(a, b)])\n",
+    "print(\"variables fixed to zero:\", n_fixed)\n",
+    "print(\"b bounds:\", float(b.lb), float(b.ub))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## When to use which\n",
+    "\n",
+    "| Method | Path | Best for |\n",
+    "|--------|------|----------|\n",
+    "| `scholtes` | homotopy of local NLPs | smooth continuous MPECs; fast |\n",
+    "| `sos1` | global MINLP branch-and-bound | exact certificates; small/medium discrete blocks |\n",
+    "\n",
+    "Scholtes is the workhorse for large continuous equilibrium models; the SOS1\n",
+    "route provides a global certificate and pairs naturally with discopt's\n",
+    "branch-and-bound when the complementary blocks are modest in number.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/solver_internals.ipynb
+++ b/docs/notebooks/solver_internals.ipynb
@@ -10,13 +10,13 @@
     "This notebook documents the algorithmic features that close the gap between discopt and commercial global solvers like BARON {cite:p}`Tawarmalani2005`. These are internal solver improvements that users benefit from automatically, but understanding them helps with tuning.\n",
     "\n",
     "Topics covered:\n",
-    "1. **Convexity detection** — automatic classification of expressions, constraints, and models\n",
-    "2. **Adaptive solver dispatch** — skipping unnecessary relaxation overhead for convex problems\n",
-    "3. **Per-constraint OA cuts** — outer approximation for individually convex constraints\n",
-    "4. **Reliability branching** — pseudocost-guided variable selection in Branch & Bound\n",
-    "5. **OBBT with incumbent cutoff** — tighter bounds using the best known solution\n",
-    "6. **FBBT with incumbent cutoff** — fast constraint propagation with objective cutoff\n",
-    "7. **Specialized envelopes** — tight relaxations for trig, signomial, and additional functions"
+    "1. **Convexity detection** \u2014 automatic classification of expressions, constraints, and models\n",
+    "2. **Adaptive solver dispatch** \u2014 skipping unnecessary relaxation overhead for convex problems\n",
+    "3. **Per-constraint OA cuts** \u2014 outer approximation for individually convex constraints\n",
+    "4. **Reliability branching** \u2014 pseudocost-guided variable selection in Branch & Bound\n",
+    "5. **OBBT with incumbent cutoff** \u2014 tighter bounds using the best known solution\n",
+    "6. **FBBT with incumbent cutoff** \u2014 fast constraint propagation with objective cutoff\n",
+    "7. **Specialized envelopes** \u2014 tight relaxations for trig, signomial, and additional functions"
    ]
   },
   {
@@ -200,7 +200,7 @@
    "source": [
     "### Model-Level Classification\n",
     "\n",
-    "`classify_model()` checks whether the entire optimization problem is convex — meaning the objective is convex (for minimization) and all constraints are convex."
+    "`classify_model()` checks whether the entire optimization problem is convex \u2014 meaning the objective is convex (for minimization) and all constraints are convex."
    ]
   },
   {
@@ -261,9 +261,9 @@
     "\n",
     "When the convexity detector classifies a model as convex, the solver automatically:\n",
     "\n",
-    "1. **Skips alphaBB convexification** — no need to add convexifying terms since the problem is already convex\n",
-    "2. **Skips McCormick relaxation overhead** — the NLP solution is already a valid lower bound\n",
-    "3. **Treats NLP solutions as global optima** — no need for spatial Branch & Bound for the continuous relaxation\n",
+    "1. **Skips alphaBB convexification** \u2014 no need to add convexifying terms since the problem is already convex\n",
+    "2. **Skips McCormick relaxation overhead** \u2014 the NLP solution is already a valid lower bound\n",
+    "3. **Treats NLP solutions as global optima** \u2014 no need for spatial Branch & Bound for the continuous relaxation\n",
     "\n",
     "This can provide significant speedups on convex problems (QPs, SOCPs, geometric programs) that happen to be formulated through the MINLP interface."
    ]
@@ -309,7 +309,7 @@
     "logger = logging.getLogger(\"discopt.solver\")\n",
     "logger.setLevel(logging.INFO)\n",
     "\n",
-    "# Solve a convex MIQP — the solver detects convexity and skips relaxation overhead\n",
+    "# Solve a convex MIQP \u2014 the solver detects convexity and skips relaxation overhead\n",
     "m = dm.Model(\"convex_miqp\")\n",
     "x = m.continuous(\"x\", lb=0, ub=10)\n",
     "y = m.continuous(\"y\", lb=0, ub=10)\n",
@@ -341,7 +341,7 @@
     "\n",
     "## 3. Per-Constraint Outer Approximation\n",
     "\n",
-    "Outer approximation (OA) cuts {cite:p}`Duran1986,Fletcher1994` are tangent hyperplanes that provide valid linear underestimators of convex constraints. In a nonconvex problem, some constraints may still be individually convex — OA cuts are valid for those constraints even though the overall problem is nonconvex.\n",
+    "Outer approximation (OA) cuts {cite:p}`Duran1986,Fletcher1994` are tangent hyperplanes that provide valid linear underestimators of convex constraints. In a nonconvex problem, some constraints may still be individually convex \u2014 OA cuts are valid for those constraints even though the overall problem is nonconvex.\n",
     "\n",
     "discopt uses the convexity detector to identify which constraints are convex, then generates OA cuts only for those. This replaces the earlier approach that only generated OA for affine (linear) constraints."
    ]
@@ -2582,7 +2582,7 @@
     "print(\"  constraint 2 (x+y <= 6z):      convex =\", mask[2])\n",
     "print()\n",
     "\n",
-    "# Solve with cutting planes — OA cuts generated for constraints 0 and 2\n",
+    "# Solve with cutting planes \u2014 OA cuts generated for constraints 0 and 2\n",
     "result = m.solve(cutting_planes=True, max_nodes=200)\n",
     "print(f\"Status: {result.status}, Objective: {result.objective:.4f}\")"
    ]
@@ -2824,14 +2824,14 @@
     "| `exp(x)` | `relax_exp_tight` | Convex envelope = exp(x), concave envelope = secant line |\n",
     "| `log(x)` | `relax_log_tight` | Concave envelope = log(x), convex envelope = secant line |\n",
     "| `sin(x)` | `relax_sin_tight` | Regime-aware: concave/convex/mixed {cite:p}`Locatelli2014` |\n",
-    "| `cos(x)` | `relax_cos_tight` | Via cos(x) = sin(x + π/2) |\n",
-    "| `∏xᵢ^aᵢ` | `relax_signomial_multi` | Log-space decomposition {cite:p}`Maranas1997` |\n",
-    "| `asinh(x)` | `relax_asinh` | Concave on [0,∞), convex on (-∞,0] |\n",
-    "| `acosh(x)` | `relax_acosh` | Concave on [1,∞) |\n",
+    "| `cos(x)` | `relax_cos_tight` | Via cos(x) = sin(x + \u03c0/2) |\n",
+    "| `\u220fx\u1d62^a\u1d62` | `relax_signomial_multi` | Log-space decomposition {cite:p}`Maranas1997` |\n",
+    "| `asinh(x)` | `relax_asinh` | Concave on [0,\u221e), convex on (-\u221e,0] |\n",
+    "| `acosh(x)` | `relax_acosh` | Concave on [1,\u221e) |\n",
     "| `atanh(x)` | `relax_atanh` | Convex on [0,1), concave on (-1,0] |\n",
-    "| `erf(x)` | `relax_erf` | Convex on (-∞,0], concave on [0,∞) |\n",
+    "| `erf(x)` | `relax_erf` | Convex on (-\u221e,0], concave on [0,\u221e) |\n",
     "| `log(1+x)` | `relax_log1p` | Concave; numerically stable near x=0 |\n",
-    "| `1/x` | `relax_reciprocal` | Convex on (0,∞), concave on (-∞,0) |\n",
+    "| `1/x` | `relax_reciprocal` | Convex on (0,\u221e), concave on (-\u221e,0) |\n",
     "| `exp(x)*y` | `relax_exp_bilinear` | Decomposed bilinear-exponential |\n",
     "| `log(x+y)` | `relax_log_sum` | Concave envelope using log concavity |\n",
     "| `x*y*z` | `relax_trilinear` | Trilinear term relaxation |\n",
@@ -2921,7 +2921,7 @@
    "source": [
     "### Tight trigonometric envelopes\n",
     "\n",
-    "For `sin(x)` on a bounded interval, the relaxation quality depends on the curvature regime {cite:p}`Locatelli2014`. `relax_sin_tight` identifies whether the interval lies in the concave, convex, or mixed regime and selects the appropriate secant/function construction. `relax_cos_tight` delegates via `cos(x) = sin(x + π/2)`."
+    "For `sin(x)` on a bounded interval, the relaxation quality depends on the curvature regime {cite:p}`Locatelli2014`. `relax_sin_tight` identifies whether the interval lies in the concave, convex, or mixed regime and selects the appropriate secant/function construction. `relax_cos_tight` delegates via `cos(x) = sin(x + \u03c0/2)`."
    ]
   },
   {
@@ -5572,7 +5572,53 @@
    "cell_type": "markdown",
    "id": "cell-20",
    "metadata": {},
-   "source": "---\n\n## Summary: Solver Options for Tuning\n\nAll these features are enabled automatically by default. Key parameters for tuning:\n\n| Parameter | Default | Description |\n|-----------|---------|-------------|\n| `branching_policy` | `\"reliability\"` | `\"fractional\"`, `\"reliability\"`, or `\"gnn\"` |\n| `cutting_planes` | `True` | Enable RLT + per-constraint OA cuts |\n| `mccormick_bounds` | `\"auto\"` | `\"auto\"`, `\"nlp\"`, `\"lp\"` (valid global LB; recommended for nonconvex + bilinear, pair with `subnlp_frequency=1`), `\"midpoint\"`, `\"none\"` |\n| `partitions` | `0` | Piecewise McCormick partition count |\n| `max_nodes` | `10000` | Node limit for B&B tree |\n| `gap_tolerance` | `1e-4` | Relative optimality gap tolerance |\n\n### When to set `mccormick_bounds=\"lp\"`\n\nThe default `\"auto\"` resolves to `\"nlp\"` for nonconvex problems — an NLP relaxation gives a *local* optimum, which is not a valid global lower bound when the model is nonconvex. For pure-continuous nonconvex problems with bilinear/multilinear terms (pooling, polynomial NLP, QCQP), set `mccormick_bounds=\"lp\"` and `subnlp_frequency=1`: this builds the full McCormick LP reformulation (a valid global LB), and the SubNLP heuristic turns each LP primal into a feasible incumbent. On a 22-instance MINLPLib bilinear+continuous sweep this delivered 13 strict wins (5 better objectives, 8 speedups to certified global optimum) over the default — at the cost of 2 instances that lose feasibility when the LP relaxation is loose. Stay with the default for convex or pure-integer models.\n\nThe convexity detector, adaptive dispatch, OBBT with incumbent cutoff, and specialized envelopes all operate automatically without user configuration."
+   "source": "---\n\n## Summary: Solver Options for Tuning\n\nAll these features are enabled automatically by default. Key parameters for tuning:\n\n| Parameter | Default | Description |\n|-----------|---------|-------------|\n| `branching_policy` | `\"reliability\"` | `\"fractional\"`, `\"reliability\"`, or `\"gnn\"` |\n| `cutting_planes` | `True` | Enable RLT + per-constraint OA cuts |\n| `mccormick_bounds` | `\"auto\"` | `\"auto\"`, `\"nlp\"`, `\"lp\"` (valid global LB; recommended for nonconvex + bilinear, pair with `subnlp_frequency=1`), `\"midpoint\"`, `\"none\"` |\n| `partitions` | `0` | Piecewise McCormick partition count |\n| `max_nodes` | `10000` | Node limit for B&B tree |\n| `gap_tolerance` | `1e-4` | Relative optimality gap tolerance |\n\n### When to set `mccormick_bounds=\"lp\"`\n\nThe default `\"auto\"` resolves to `\"nlp\"` for nonconvex problems \u2014 an NLP relaxation gives a *local* optimum, which is not a valid global lower bound when the model is nonconvex. For pure-continuous nonconvex problems with bilinear/multilinear terms (pooling, polynomial NLP, QCQP), set `mccormick_bounds=\"lp\"` and `subnlp_frequency=1`: this builds the full McCormick LP reformulation (a valid global LB), and the SubNLP heuristic turns each LP primal into a feasible incumbent. On a 22-instance MINLPLib bilinear+continuous sweep this delivered 13 strict wins (5 better objectives, 8 speedups to certified global optimum) over the default \u2014 at the cost of 2 instances that lose feasibility when the LP relaxation is loose. Stay with the default for convex or pure-integer models.\n\nThe convexity detector, adaptive dispatch, OBBT with incumbent cutoff, and specialized envelopes all operate automatically without user configuration."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conflict analysis and no-good cuts\n",
+    "\n",
+    "When a partial assignment of binary variables is *jointly* infeasible, it can\n",
+    "be excluded tree-wide with a **no-good cut**\n",
+    "\n",
+    "$$ \\sum_{j:\\,a_j=1}(1-x_j) + \\sum_{j:\\,a_j=0} x_j \\;\\ge\\; 1, $$\n",
+    "\n",
+    "which removes exactly that assignment and nothing else. `discopt.conflict`\n",
+    "uses feasibility-based bound tightening (FBBT) as the infeasibility oracle \u2014\n",
+    "FBBT never reports a feasible subproblem as infeasible, so every emitted cut is\n",
+    "sound and never removes the global optimum. The detector keeps only *minimal*\n",
+    "conflicts (it skips assignments already excluded by a shorter one).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+    "os.environ[\"JAX_ENABLE_X64\"] = \"1\"\n",
+    "\n",
+    "import discopt.modeling.core as dm\n",
+    "from discopt.conflict import find_conflict_cuts, add_conflict_cuts\n",
+    "\n",
+    "# A small packing model: at most one of three binaries may be 1.\n",
+    "m = dm.Model(\"conflict_demo\")\n",
+    "x = [m.binary(f\"x{i}\") for i in range(3)]\n",
+    "m.maximize(x[0] + 2 * x[1] + 3 * x[2])\n",
+    "m.subject_to(x[0] + x[1] + x[2] <= 1)\n",
+    "\n",
+    "# Each pair set to (1, 1) is jointly infeasible -> three minimal no-goods.\n",
+    "cuts = find_conflict_cuts(m, max_order=2)\n",
+    "print(\"minimal conflict cuts found:\", len(cuts))\n",
+    "\n",
+    "n_added = add_conflict_cuts(m, max_order=2)\n",
+    "res = m.solve()\n",
+    "print(f\"added {n_added} no-good cuts; optimum still {float(res.objective):.1f}\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1813,3 +1813,33 @@
   year    = {1983},
   doi     = {10.1287/opre.31.5.803},
 }
+
+@article{Scholtes2001,
+  author    = {Scholtes, Stefan},
+  title     = {Convergence Properties of a Regularization Scheme for Mathematical Programs with Complementarity Constraints},
+  journal   = {SIAM Journal on Optimization},
+  volume    = {11},
+  number    = {4},
+  pages     = {918--936},
+  year      = {2001},
+  doi       = {10.1137/S1052623499361233}
+}
+
+@book{LuoPangRalph1996,
+  author    = {Luo, Zhi-Quan and Pang, Jong-Shi and Ralph, Daniel},
+  title     = {Mathematical Programs with Equilibrium Constraints},
+  publisher = {Cambridge University Press},
+  year      = {1996},
+  doi       = {10.1017/CBO9780511983658}
+}
+
+@article{FletcherLeyffer2004,
+  author    = {Fletcher, Roger and Leyffer, Sven},
+  title     = {Solving Mathematical Programs with Complementarity Constraints as Nonlinear Programs},
+  journal   = {Optimization Methods and Software},
+  volume    = {19},
+  number    = {1},
+  pages     = {15--40},
+  year      = {2004},
+  doi       = {10.1080/10556780410001654241}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,7 @@ markers = [
     "requires_cyipopt: requires the optional cyipopt/Ipopt solver stack",
     "requires_pounce: requires the optional POUNCE (pure-Rust Ipopt port) solver",
     "gpu: requires GPU",
+    "relaxation: theorem-style property tests for relaxation rules (containment, tightening); fast",
     "correctness: known-optima validation tests; usually also `slow`",
     "pr_correctness: small known-optima subset run on every PR; <30 s total",
     "cutest: requires pycutest and CUTEst installation",

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -755,3 +755,299 @@ def enumerate_binary_seeds_subnlp(
             if found is not None:
                 results.append(found)
     return results
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Improvement heuristics: diving, RINS, local branching
+#
+# These follow the SOTA rule inventory's "incumbent search" component. They only
+# ever *propose* feasible incumbents; they never alter the dual (lower) bound, so
+# they cannot weaken the global optimality certificate. All bound mutations on
+# the model are temporary and restored in a ``finally`` block.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _flat_slot_map(model: Model) -> list[tuple[object, int]]:
+    """Map each flat variable index to ``(variable, local_offset)``.
+
+    Lets a heuristic fix a single scalar slot of a (possibly vector) variable by
+    writing into ``v.lb.flat[local]`` / ``v.ub.flat[local]``.
+    """
+    slots: list[tuple[object, int]] = []
+    for v in model._variables:
+        for local in range(v.size):
+            slots.append((v, local))
+    return slots
+
+
+def _resolve_backend(backend: Optional[Callable]) -> Callable:
+    if backend is None:
+        from discopt.solvers.nlp_backend import get_nlp_solver
+
+        return get_nlp_solver("auto")
+    return backend
+
+
+def _fix_slot(v: object, local: int, value: float) -> None:
+    """Fix scalar slot ``local`` of variable ``v`` to ``value``.
+
+    Variable bound arrays are read-only, so we replace them with writable copies
+    (the caller saves/restores the originals).
+    """
+    new_lb = np.array(v.lb, dtype=np.float64)  # type: ignore[attr-defined]
+    new_ub = np.array(v.ub, dtype=np.float64)  # type: ignore[attr-defined]
+    new_lb.flat[local] = value
+    new_ub.flat[local] = value
+    v.lb = new_lb  # type: ignore[attr-defined]
+    v.ub = new_ub  # type: ignore[attr-defined]
+
+
+def _finalize_candidate(
+    evaluator: NLPEvaluator,
+    x: np.ndarray,
+    int_mask: np.ndarray,
+    integer_tol: float,
+    feas_tol: float,
+) -> Optional[tuple[np.ndarray, float]]:
+    """Snap integers, verify integer + constraint feasibility, return (x, obj)."""
+    x_out = np.asarray(x, dtype=np.float64).copy()
+    if np.any(int_mask):
+        x_out[int_mask] = np.round(x_out[int_mask])
+        if not _is_integer_feasible(x_out, int_mask, tol=integer_tol):
+            return None
+    if not _check_constraint_feasibility(evaluator, x_out, tol=feas_tol):
+        return None
+    obj = float(evaluator.evaluate_objective(x_out))
+    return x_out, obj
+
+
+def diving(
+    model: Model,
+    x_relax: np.ndarray,
+    *,
+    mode: str = "fractional",
+    backend: Optional[Callable] = None,
+    nlp_options: Optional[dict] = None,
+    max_dives: Optional[int] = None,
+    integer_tol: float = 1e-5,
+    feas_tol: float = 1e-6,
+    evaluator: Optional[NLPEvaluator] = None,
+) -> Optional[tuple[np.ndarray, float]]:
+    """Diving heuristic: progressively fix one fractional integer and re-solve.
+
+    Starting from a relaxation point, each dive step selects one fractional
+    integer variable, fixes it to a rounded value, and re-solves the continuous
+    NLP relaxation under the accumulated fixings. The dive ends when all integers
+    are integral (success) or a sub-NLP is infeasible (failure).
+
+    ``mode`` selects the variable/direction rule:
+
+    * ``"fractional"`` — fix the most fractional integer (closest to 0.5),
+      rounding to the nearest integer.
+    * ``"objective"`` — fix the most fractional integer, rounding in the
+      direction the objective gradient prefers (down where ``dF/dx_i > 0`` for a
+      minimization, i.e. toward the cheaper neighbour).
+
+    Returns ``(x, obj)`` for a feasible incumbent, else ``None``. The dual bound
+    is never touched.
+    """
+    int_mask = _get_integer_mask(model)
+    int_idx = np.nonzero(int_mask)[0]
+    if int_idx.size == 0:
+        return None
+
+    backend = _resolve_backend(backend)
+    if evaluator is None:
+        evaluator = NLPEvaluator(model)
+    lb0, ub0 = _get_variable_bounds(model)
+    slot_map = _flat_slot_map(model)
+
+    opts = dict(nlp_options) if nlp_options else {}
+    opts.setdefault("print_level", 0)
+
+    fixed = np.zeros(int_mask.shape[0], dtype=bool)
+    x_cur = np.clip(np.asarray(x_relax, dtype=np.float64), lb0, ub0)
+    saved = [(v.lb.copy(), v.ub.copy()) for v in model._variables]
+    budget = max_dives if max_dives is not None else int(int_idx.size) + 1
+
+    try:
+        for _ in range(budget):
+            try:
+                res = backend(evaluator, x_cur, options=opts)
+            except BaseException:
+                return None
+            if not _is_nlp_feasible(res):
+                return None
+            x = np.asarray(res.x, dtype=np.float64)
+
+            frac = np.abs(x - np.round(x))
+            cand = [i for i in int_idx if not fixed[i] and frac[i] > integer_tol]
+            if not cand:
+                return _finalize_candidate(evaluator, x, int_mask, integer_tol, feas_tol)
+
+            # Select the most fractional unfixed integer (closest to 0.5).
+            sel = min(cand, key=lambda i: abs(frac[i] - 0.5))
+
+            if mode == "objective":
+                try:
+                    grad = np.asarray(evaluator.evaluate_gradient(x))
+                    # Minimization: round toward the cheaper neighbour.
+                    rounded = np.floor(x[sel]) if grad[sel] > 0 else np.ceil(x[sel])
+                except BaseException:
+                    rounded = np.round(x[sel])
+            else:
+                rounded = np.round(x[sel])
+            rounded = float(np.clip(rounded, lb0[sel], ub0[sel]))
+
+            v, local = slot_map[sel]
+            _fix_slot(v, local, rounded)
+            fixed[sel] = True
+            x_cur = x.copy()
+            x_cur[sel] = rounded
+            x_cur = np.clip(x_cur, lb0, ub0)
+        return None
+    finally:
+        for v, (lb_v, ub_v) in zip(model._variables, saved):
+            v.lb = lb_v
+            v.ub = ub_v
+
+
+def fractional_diving(
+    model: Model, x_relax: np.ndarray, **kwargs
+) -> Optional[tuple[np.ndarray, float]]:
+    """Diving that fixes the most fractional integer, rounding to nearest."""
+    return diving(model, x_relax, mode="fractional", **kwargs)
+
+
+def objective_diving(
+    model: Model, x_relax: np.ndarray, **kwargs
+) -> Optional[tuple[np.ndarray, float]]:
+    """Diving that rounds toward the objective-preferred neighbour."""
+    return diving(model, x_relax, mode="objective", **kwargs)
+
+
+def rins(
+    model: Model,
+    x_incumbent: np.ndarray,
+    x_relax: np.ndarray,
+    *,
+    backend: Optional[Callable] = None,
+    nlp_options: Optional[dict] = None,
+    integer_tol: float = 1e-5,
+    feas_tol: float = 1e-6,
+    evaluator: Optional[NLPEvaluator] = None,
+) -> Optional[tuple[np.ndarray, float]]:
+    """RINS (Relaxation Induced Neighborhood Search).
+
+    Fix every integer variable on which the incumbent and the relaxation agree,
+    then dive on the remaining (disagreeing) integers. This searches the
+    neighbourhood "between" the incumbent and the relaxation — often where better
+    incumbents hide — at the cost of one restricted dive. Returns ``(x, obj)`` or
+    ``None``; the dual bound is never touched.
+    """
+    int_mask = _get_integer_mask(model)
+    int_idx = np.nonzero(int_mask)[0]
+    if int_idx.size == 0:
+        return None
+
+    if evaluator is None:
+        evaluator = NLPEvaluator(model)
+    lb0, ub0 = _get_variable_bounds(model)
+    slot_map = _flat_slot_map(model)
+
+    x_inc = np.asarray(x_incumbent, dtype=np.float64)
+    x_rel = np.asarray(x_relax, dtype=np.float64)
+
+    agree = [
+        i
+        for i in int_idx
+        if abs(np.round(x_inc[i]) - np.round(x_rel[i])) <= integer_tol
+        and abs(x_rel[i] - np.round(x_rel[i])) <= integer_tol
+    ]
+    # Nothing fixed (full disagreement) degenerates to a plain dive; nothing free
+    # (full agreement) means RINS has no neighbourhood to explore.
+    if len(agree) == int_idx.size:
+        return None
+
+    saved = [(v.lb.copy(), v.ub.copy()) for v in model._variables]
+    try:
+        for i in agree:
+            val = float(np.clip(np.round(x_inc[i]), lb0[i], ub0[i]))
+            v, local = slot_map[i]
+            _fix_slot(v, local, val)
+        # Dive on the restricted model (fresh evaluator reads the tightened bounds).
+        return diving(
+            model,
+            x_rel,
+            mode="fractional",
+            backend=backend,
+            nlp_options=nlp_options,
+            integer_tol=integer_tol,
+            feas_tol=feas_tol,
+        )
+    finally:
+        for v, (lb_v, ub_v) in zip(model._variables, saved):
+            v.lb = lb_v
+            v.ub = ub_v
+
+
+def local_branching(
+    model: Model,
+    x_incumbent: np.ndarray,
+    *,
+    k: int = 2,
+    backend: Optional[Callable] = None,
+    nlp_options: Optional[dict] = None,
+    integer_tol: float = 1e-5,
+    feas_tol: float = 1e-6,
+    evaluator: Optional[NLPEvaluator] = None,
+    max_binaries: int = 12,
+) -> Optional[tuple[np.ndarray, float]]:
+    """Local branching: search the Hamming-radius-``k`` neighbourhood of a binary
+    incumbent for a better feasible point.
+
+    Classic local branching adds the constraint ``sum_{j: x*_j=0} x_j +
+    sum_{j: x*_j=1}(1 - x_j) <= k`` and re-solves a sub-MIP. We realise the same
+    neighbourhood directly: enumerate every flip of up to ``k`` binaries, fix
+    them, and solve the continuous sub-NLP (via :func:`subnlp`) for each. This is
+    exact for the neighbourhood and self-contained (no recursive MIP solve),
+    which keeps it cheap and certifiable for the small/medium binary blocks where
+    local branching pays off.
+
+    Returns the best feasible ``(x, obj)`` found in the neighbourhood, or
+    ``None``. Only proposes incumbents — the dual bound is untouched.
+    """
+    int_mask = _get_integer_mask(model)
+    lb0, ub0 = _get_variable_bounds(model)
+    binary_idx = [i for i in np.nonzero(int_mask)[0] if lb0[i] >= -1e-9 and ub0[i] <= 1.0 + 1e-9]
+    if not binary_idx or len(binary_idx) > max_binaries:
+        return None
+
+    if evaluator is None:
+        evaluator = NLPEvaluator(model)
+
+    x_inc = np.asarray(x_incumbent, dtype=np.float64)
+    incumbent_bits = {i: float(np.round(x_inc[i])) for i in binary_idx}
+    k = max(1, min(k, len(binary_idx)))
+
+    best: Optional[tuple[np.ndarray, float]] = None
+    # Enumerate flip sets of size 0..k (size 0 re-evaluates the incumbent itself).
+    for radius in range(k + 1):
+        for flip in itertools.combinations(binary_idx, radius):
+            seed = x_inc.copy()
+            for i in binary_idx:
+                seed[i] = incumbent_bits[i]
+            for i in flip:
+                seed[i] = 1.0 - incumbent_bits[i]
+            found = subnlp(
+                model,
+                seed,
+                backend=backend,
+                nlp_options=nlp_options,
+                evaluator=evaluator,
+                integer_tol=integer_tol,
+                feas_tol=feas_tol,
+            )
+            if found is not None and (best is None or found[1] < best[1]):
+                best = found
+    return best

--- a/python/discopt/conflict.py
+++ b/python/discopt/conflict.py
@@ -1,0 +1,170 @@
+"""Conflict analysis and no-good cuts.
+
+When a partial assignment of binary variables is *jointly* infeasible — no
+feasible solution sets those binaries that way — the assignment can be excluded
+tree-wide with a **no-good cut**
+
+    sum_{j: a_j = 1} (1 - x_j) + sum_{j: a_j = 0} x_j  >= 1,
+
+which removes exactly the assignment ``a`` (on the involved binaries) and nothing
+else. Adding such cuts prunes dead subtrees without weakening the global
+optimality certificate.
+
+Soundness rests on **feasibility-based bound tightening (FBBT)** as the
+infeasibility oracle: FBBT only ever derives valid bounds, so if it produces an
+empty interval for a subproblem, that subproblem is genuinely infeasible (FBBT
+never reports a feasible problem as infeasible). A no-good cut emitted from an
+FBBT-proven conflict therefore never excludes a feasible point — in particular
+it never cuts off the global optimum.
+
+The detector probes small subsets of binaries (up to ``max_order``) and keeps
+only *minimal* conflicts (it skips assignments already excluded by a shorter
+conflict). This mirrors the conflict analysis in SOTA MINLP solvers, realised
+here entirely through the existing, validated FBBT engine.
+
+Example
+-------
+>>> import discopt.modeling.core as dm
+>>> from discopt.conflict import add_conflict_cuts
+>>> m = dm.Model("c")
+>>> x = [m.binary(f"x{i}") for i in range(3)]
+>>> m.maximize(x[0] + 2 * x[1] + 3 * x[2])
+>>> m.subject_to(x[0] + x[1] + x[2] <= 1)      # any two ones is infeasible
+>>> add_conflict_cuts(m, max_order=2) > 0
+True
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Optional
+
+import numpy as np
+
+from discopt.modeling.core import Constraint, Expression, Model, VarType
+
+__all__ = [
+    "no_good_cut",
+    "find_conflict_cuts",
+    "add_conflict_cuts",
+]
+
+
+def _scalar_binaries(model: Model) -> list:
+    """Return the model's scalar binary variables (size 1, type BINARY)."""
+    return [v for v in model._variables if v.var_type == VarType.BINARY and v.size == 1]
+
+
+def no_good_cut(assignment: list[tuple]) -> Constraint:
+    """Build a no-good constraint excluding ``assignment``.
+
+    ``assignment`` is a list of ``(binary_variable, value)`` pairs with
+    ``value`` in ``{0, 1}``. The returned constraint is
+
+        sum_{value=1} (1 - var) + sum_{value=0} var >= 1,
+
+    which is violated only by the exact assignment and is satisfied by every
+    other 0/1 combination of the involved variables.
+    """
+    if not assignment:
+        raise ValueError("no_good_cut requires a non-empty assignment")
+    expr: Optional[Expression] = None
+    for var, val in assignment:
+        term: Expression = (1 - var) if round(val) == 1 else var
+        expr = term if expr is None else expr + term
+    assert expr is not None
+    result = expr >= 1
+    assert isinstance(result, Constraint)
+    return result
+
+
+def _fbbt_infeasible(model: Model, tol: float = 1e-9, max_iter: int = 20) -> bool:
+    """True if FBBT proves the current model (with its present bounds) infeasible."""
+    from discopt._rust import model_to_repr
+
+    repr_ = model_to_repr(model)
+    lbs, ubs = repr_.fbbt(max_iter=max_iter, tol=tol)
+    lbs = np.asarray(lbs)
+    ubs = np.asarray(ubs)
+    return bool(np.any(lbs > ubs + tol))
+
+
+def find_conflict_cuts(
+    model: Model,
+    *,
+    max_order: int = 2,
+    max_binaries: int = 24,
+    tol: float = 1e-9,
+) -> list[Constraint]:
+    """Detect jointly-infeasible binary assignments and return no-good cuts.
+
+    Probes subsets of up to ``max_order`` scalar binaries; for each assignment
+    not already excluded by a shorter (minimal) conflict, fixes those binaries
+    and runs FBBT. An FBBT-proven infeasible assignment yields a no-good cut.
+
+    Returns the list of no-good :class:`Constraint` objects (not yet added to the
+    model). Returns an empty list when the model has no scalar binaries or the
+    binary count exceeds ``max_binaries``.
+    """
+    binaries = _scalar_binaries(model)
+    if not binaries or len(binaries) > max_binaries:
+        return []
+
+    # Save/restore variable bounds around each probe.
+    saved = [(np.array(v.lb), np.array(v.ub)) for v in model._variables]
+    var_index = {id(v): i for i, v in enumerate(model._variables)}
+
+    # Found minimal conflicts as frozensets of (var_id, value); a candidate
+    # assignment is skipped if it is a superset of a known conflict.
+    found: list[frozenset] = []
+    cuts: list[Constraint] = []
+
+    def _covered(assign_set: frozenset) -> bool:
+        return any(c <= assign_set for c in found)
+
+    try:
+        for order in range(1, max_order + 1):
+            for combo in itertools.combinations(binaries, order):
+                for values in itertools.product((0, 1), repeat=order):
+                    assign_set = frozenset((id(v), val) for v, val in zip(combo, values))
+                    if _covered(assign_set):
+                        continue
+                    # Fix this assignment.
+                    for v, val in zip(combo, values):
+                        v.lb = np.array([float(val)])
+                        v.ub = np.array([float(val)])
+                    infeasible = _fbbt_infeasible(model, tol=tol)
+                    # Restore the probed binaries before the next candidate.
+                    for v, val in zip(combo, values):
+                        i = var_index[id(v)]
+                        v.lb = np.array(saved[i][0])
+                        v.ub = np.array(saved[i][1])
+                    if infeasible:
+                        found.append(assign_set)
+                        cuts.append(no_good_cut(list(zip(combo, values))))
+    finally:
+        for v, (lb, ub) in zip(model._variables, saved):
+            v.lb = np.array(lb)
+            v.ub = np.array(ub)
+
+    return cuts
+
+
+def add_conflict_cuts(
+    model: Model,
+    *,
+    max_order: int = 2,
+    max_binaries: int = 24,
+    tol: float = 1e-9,
+    name: Optional[str] = "no_good",
+) -> int:
+    """Detect conflicts and add the resulting no-good cuts to ``model``.
+
+    Returns the number of cuts added. Every cut excludes only an FBBT-proven
+    infeasible assignment, so the model's feasible region — and its optimum — is
+    unchanged; only dead assignments are pruned.
+    """
+    cuts = find_conflict_cuts(model, max_order=max_order, max_binaries=max_binaries, tol=tol)
+    for k, cut in enumerate(cuts):
+        model.subject_to(cut, name=f"{name}_{k}" if name else None)
+    return len(cuts)

--- a/python/discopt/mpec.py
+++ b/python/discopt/mpec.py
@@ -1,0 +1,223 @@
+"""Complementarity / MPEC handler.
+
+Mathematical Programs with Equilibrium Constraints (MPECs) carry complementarity
+conditions of the form
+
+    0 <= f(x)  ⊥  g(x) >= 0          (i.e. f >= 0, g >= 0, f·g = 0)
+
+which are nonconvex and violate standard constraint qualifications, so a naive
+NLP solve stalls. This module provides the two standard reformulations from the
+SOTA rule inventory:
+
+* **Scholtes regularization** — replace ``f·g = 0`` with ``f·g <= t`` and drive
+  ``t -> 0`` through a homotopy of *local* NLP solves. Smooth, fast, and the
+  workhorse for continuous MPECs.
+* **SOS1 / disjunctive** — encode "at most one of ``f``, ``g`` is nonzero"
+  exactly with a Special Ordered Set of type 1, solved by the global MINLP
+  branch-and-bound. Exact, at the cost of discrete search.
+
+Both build a standard discopt model, so no solver-core changes are required and
+the global optimality machinery is reused unchanged.
+
+Example
+-------
+>>> import discopt.modeling.core as dm
+>>> from discopt.mpec import complementarity, solve_mpec
+>>> m = dm.Model("toy")
+>>> x = m.continuous("x", lb=0, ub=10)
+>>> y = m.continuous("y", lb=0, ub=10)
+>>> m.minimize((x - 1) ** 2 + (y - 1) ** 2)
+>>> pairs = [complementarity(x, y)]          # 0 <= x ⊥ y >= 0
+>>> res = solve_mpec(m, pairs, method="scholtes")
+>>> round(res.objective, 3)
+1.0
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from discopt.modeling.core import Expression, Model, Variable
+
+__all__ = [
+    "Complementarity",
+    "complementarity",
+    "reformulate_scholtes",
+    "reformulate_sos1",
+    "tighten_complementarity_bounds",
+    "solve_mpec",
+]
+
+
+@dataclass
+class Complementarity:
+    """A single complementarity condition ``0 <= f ⊥ g >= 0`` (``f·g = 0``).
+
+    ``f`` and ``g`` are discopt expressions that are required to be nonnegative;
+    at a feasible point at most one of them is nonzero.
+    """
+
+    f: Expression
+    g: Expression
+    name: Optional[str] = None
+
+
+def complementarity(f: Expression, g: Expression, name: Optional[str] = None) -> Complementarity:
+    """Construct a :class:`Complementarity` condition ``0 <= f ⊥ g >= 0``."""
+    return Complementarity(f, g, name)
+
+
+# ─────────────────────────── reformulations ───────────────────────────
+
+
+def reformulate_scholtes(model: Model, pairs: list[Complementarity], t) -> None:
+    """Add Scholtes constraints ``f >= 0``, ``g >= 0``, ``f·g <= t`` for each pair.
+
+    ``t`` may be a float or a :class:`~discopt.modeling.core.Parameter`; using a
+    parameter lets :func:`solve_mpec` drive the homotopy without rebuilding the
+    model.
+    """
+    for i, p in enumerate(pairs):
+        tag = p.name or f"compl{i}"
+        model.subject_to(p.f >= 0, name=f"{tag}_f_nonneg")
+        model.subject_to(p.g >= 0, name=f"{tag}_g_nonneg")
+        model.subject_to(p.f * p.g <= t, name=f"{tag}_reg")
+
+
+def reformulate_sos1(model: Model, pairs: list[Complementarity]) -> None:
+    """Encode each complementarity exactly with an SOS1 set.
+
+    Requires ``f >= 0`` and ``g >= 0`` and that at most one is nonzero. When
+    ``f``/``g`` are plain variables they enter the SOS1 set directly; otherwise
+    nonnegative auxiliary variables ``af == f``, ``ag == g`` are introduced.
+    """
+    for i, p in enumerate(pairs):
+        tag = p.name or f"compl{i}"
+        members: list[Variable] = []
+        for side, expr in (("f", p.f), ("g", p.g)):
+            if isinstance(expr, Variable) and expr.size == 1:
+                model.subject_to(expr >= 0, name=f"{tag}_{side}_nonneg")
+                members.append(expr)
+            else:
+                aux = model.continuous(f"{tag}_{side}_aux", lb=0.0, ub=np.inf)
+                model.subject_to(aux == expr, name=f"{tag}_{side}_link")
+                members.append(aux)
+        model.sos1(members, name=f"{tag}_sos1")
+
+
+def tighten_complementarity_bounds(model: Model, pairs: list[Complementarity]) -> int:
+    """Complementarity bound propagation for plain variable pairs.
+
+    If one side of ``0 <= x ⊥ y >= 0`` is provably strictly positive
+    (``lb > 0``), the other side must be zero. Applied only to single-variable
+    sides, where the implication is sound and exact. Returns the number of
+    variables fixed to zero.
+    """
+    fixed = 0
+    for p in pairs:
+        f_var = p.f if isinstance(p.f, Variable) and p.f.size == 1 else None
+        g_var = p.g if isinstance(p.g, Variable) and p.g.size == 1 else None
+        if f_var is not None and float(f_var.lb) > 0.0 and g_var is not None:
+            g_var.ub = np.zeros_like(np.array(g_var.ub))
+            g_var.lb = np.zeros_like(np.array(g_var.lb))
+            fixed += 1
+        elif g_var is not None and float(g_var.lb) > 0.0 and f_var is not None:
+            f_var.ub = np.zeros_like(np.array(f_var.ub))
+            f_var.lb = np.zeros_like(np.array(f_var.lb))
+            fixed += 1
+    return fixed
+
+
+# ─────────────────────────────── solve ───────────────────────────────
+
+
+def solve_mpec(
+    model: Model,
+    pairs: list[Complementarity],
+    *,
+    method: str = "scholtes",
+    t0: float = 1.0,
+    sigma: float = 0.1,
+    t_min: float = 1e-8,
+    max_iter: int = 16,
+    x0: Optional[np.ndarray] = None,
+    nlp_options: Optional[dict] = None,
+    **solve_kwargs,
+):
+    """Solve an MPEC by reformulating its complementarity conditions.
+
+    Parameters
+    ----------
+    model : Model
+        Model carrying the objective and any ordinary constraints. It is
+        augmented in place with the reformulation constraints.
+    pairs : list[Complementarity]
+        The complementarity conditions ``0 <= f ⊥ g >= 0``.
+    method : {"scholtes", "sos1"}
+        ``"scholtes"`` runs a homotopy of *local* NLP solves with the
+        regularization ``t`` shrinking ``t0 -> t0·sigma -> ...`` until ``t_min``.
+        ``"sos1"`` builds the exact disjunctive model and calls the global
+        MINLP solver (``solve_kwargs`` forwarded to :meth:`Model.solve`).
+
+    Returns
+    -------
+    The solver result. For ``"scholtes"`` this is the final NLP result
+    (with ``.x`` and ``.objective``); for ``"sos1"`` it is the
+    :meth:`Model.solve` result.
+    """
+    if method == "sos1":
+        reformulate_sos1(model, pairs)
+        return model.solve(**solve_kwargs)
+
+    if method != "scholtes":
+        raise ValueError(f"unknown MPEC method {method!r}; use 'scholtes' or 'sos1'")
+
+    # Scholtes regularization homotopy via local NLP solves.
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+    from discopt.solvers.nlp_backend import get_nlp_solver
+
+    t = model.parameter("_mpec_t", value=t0)
+    reformulate_scholtes(model, pairs, t)
+
+    backend = get_nlp_solver("auto")
+    opts = dict(nlp_options) if nlp_options else {}
+    opts.setdefault("print_level", 0)
+
+    lb, ub = _flat_bounds(model)
+    x_cur = (
+        np.clip(np.asarray(x0, dtype=np.float64), lb, ub) if x0 is not None else _midpoint(lb, ub)
+    )
+
+    result = None
+    tv = t0
+    for _ in range(max_iter):
+        t.value = tv
+        # Rebuild the evaluator so the updated parameter value is compiled in.
+        evaluator = NLPEvaluator(model)
+        try:
+            result = backend(evaluator, x_cur, options=opts)
+        except BaseException:
+            break
+        if result.x is not None:
+            x_cur = np.asarray(result.x, dtype=np.float64)
+        if tv <= t_min:
+            break
+        tv = max(tv * sigma, t_min)
+    return result
+
+
+def _flat_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
+    lbs, ubs = [], []
+    for v in model._variables:
+        lbs.append(np.asarray(v.lb).flatten())
+        ubs.append(np.asarray(v.ub).flatten())
+    return np.concatenate(lbs), np.concatenate(ubs)
+
+
+def _midpoint(lb: np.ndarray, ub: np.ndarray) -> np.ndarray:
+    lo = np.clip(lb, -1e6, 1e6)
+    hi = np.clip(ub, -1e6, 1e6)
+    return 0.5 * (lo + hi)

--- a/python/discopt/mpec.py
+++ b/python/discopt/mpec.py
@@ -194,7 +194,7 @@ def solve_mpec(
     result = None
     tv = t0
     for _ in range(max_iter):
-        t.value = tv
+        t.value = np.asarray(tv, dtype=np.float64)
         # Rebuild the evaluator so the updated parameter value is compiled in.
         evaluator = NLPEvaluator(model)
         try:
@@ -220,4 +220,4 @@ def _flat_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
 def _midpoint(lb: np.ndarray, ub: np.ndarray) -> np.ndarray:
     lo = np.clip(lb, -1e6, 1e6)
     hi = np.clip(ub, -1e6, 1e6)
-    return 0.5 * (lo + hi)
+    return np.asarray(0.5 * (lo + hi), dtype=np.float64)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1488,7 +1488,10 @@ def solve_model(
     batch_size : int, default 16
         Number of B&B nodes to export per iteration.
     strategy : str, default "best_first"
-        Node selection strategy: ``"best_first"`` or ``"depth_first"``.
+        Node selection strategy: ``"best_first"`` (lowest dual bound),
+        ``"depth_first"``, or ``"best_estimate"`` (lowest pseudocost-based
+        estimate of the subtree optimum — finds good incumbents earlier while
+        ``best_first`` still drives the proof of optimality).
     max_nodes : int, default 100_000
         Maximum number of B&B nodes before stopping.
     ipopt_options : dict, optional

--- a/python/tests/relaxation_harness.py
+++ b/python/tests/relaxation_harness.py
@@ -1,0 +1,271 @@
+"""Theorem-style property harness for relaxation rules.
+
+Implements the testing discipline from the SOTA rule inventory: *every relaxation
+rule should be tested as a theorem*. A relaxation ``(cv, cc)`` for a factorable
+expression ``f`` over a box ``[lb, ub]`` must satisfy, for the proof to be valid:
+
+1. **Containment** — every true graph point satisfies ``cv(x) <= f(x) <= cc(x)``.
+   A single violated point invalidates the global optimality certificate.
+2. **Corner exactness** — at the box vertices the envelope is tight
+   (``cv == cc == f``) for the McCormick-exact primitives (bilinear, monotone
+   convex/concave, powers). Tested opt-in since wide-interval trig falls back to
+   range bounds that are not corner-exact.
+3. **Monotone tightening** — as the box shrinks around a point the envelope gap
+   ``cc - cv`` is non-increasing and tends to zero. This is *why* spatial
+   branching converges.
+4. **Convexity classification** — no false convex/concave verdicts from the DCP
+   detector (a wrong verdict can produce an invalid convex-handler relaxation).
+
+These helpers are shared by ``test_relaxation_theorems.py`` (parametrized over
+the full operator-coverage matrix) and are reusable by any future relaxation work.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Callable, Optional, Sequence
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from discopt._jax.dag_compiler import compile_expression
+from discopt._jax.relaxation_compiler import compile_relaxation
+from discopt.modeling.core import Model
+
+# Tolerances mirror conftest numerical policy (abs=1e-6); we use a slightly
+# looser absolute slack to absorb float64 round-off in the vmapped evaluators.
+CONTAINMENT_TOL = 1e-7
+EXACTNESS_TOL = 1e-6
+TIGHTENING_TOL = 1e-7
+
+Bounds = Sequence[tuple[float, float]]
+
+
+def build_relaxation(
+    expr_fn: Callable,
+    bounds: Bounds,
+) -> tuple[Callable, Callable, jnp.ndarray, jnp.ndarray]:
+    """Compile a relaxation + true evaluator for ``expr_fn`` over ``bounds``.
+
+    ``expr_fn`` receives one variable handle per entry in ``bounds`` and returns
+    a single scalar expression. Returns ``(relax_fn, true_fn, lb, ub)`` where
+    ``relax_fn(x_cv, x_cc, lb, ub) -> (cv, cc)`` and ``true_fn(x) -> value`` use
+    the flat variable layout.
+    """
+    m = Model("harness")
+    handles = [m.continuous(f"x{i}", lb=lo, ub=hi) for i, (lo, hi) in enumerate(bounds)]
+    expr = expr_fn(*handles)
+    # A minimize target is required for a well-formed model; the objective itself
+    # is irrelevant to relaxation compilation of ``expr``.
+    m.minimize(handles[0])
+
+    relax_fn = compile_relaxation(expr, m)
+    true_fn = compile_expression(expr, m)
+
+    lb = jnp.array([lo for lo, _ in bounds], dtype=jnp.float64)
+    ub = jnp.array([hi for _, hi in bounds], dtype=jnp.float64)
+    return relax_fn, true_fn, lb, ub
+
+
+def _sample_points(
+    lb: jnp.ndarray,
+    ub: jnp.ndarray,
+    n_interior: int,
+    seed: int,
+) -> jnp.ndarray:
+    """Interior (random) + boundary-face + corner samples within ``[lb, ub]``."""
+    rng = np.random.default_rng(seed)
+    n = lb.shape[0]
+    width = np.maximum(np.asarray(ub) - np.asarray(lb), 1e-12)
+
+    # Interior: strictly inside to avoid coinciding with corners.
+    t = rng.uniform(0.02, 0.98, size=(n_interior, n))
+    interior = np.asarray(lb) + t * width
+
+    # Corners: all 2^n vertices (capped for high dimension).
+    if n <= 8:
+        corners = np.array(list(itertools.product(*zip(np.asarray(lb), np.asarray(ub)))))
+    else:
+        corners = np.stack([np.asarray(lb), np.asarray(ub)])
+
+    # Boundary faces: pin one coordinate to a bound, randomize the rest.
+    faces = []
+    for j in range(n):
+        for bound in (np.asarray(lb)[j], np.asarray(ub)[j]):
+            pt = np.asarray(lb) + rng.uniform(0.02, 0.98, size=n) * width
+            pt[j] = bound
+            faces.append(pt)
+    faces = np.array(faces) if faces else np.empty((0, n))
+
+    pts = np.concatenate([interior, corners, faces], axis=0)
+    return jnp.array(pts, dtype=jnp.float64)
+
+
+def evaluate(
+    relax_fn: Callable,
+    true_fn: Callable,
+    lb: jnp.ndarray,
+    ub: jnp.ndarray,
+    xs: jnp.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Vmapped evaluation of ``(cv, cc, f)`` over a batch of points ``xs``."""
+
+    @jax.jit
+    def _eval(xs):
+        cv_cc = jax.vmap(lambda x: relax_fn(x, x, lb, ub))(xs)
+        f = jax.vmap(true_fn)(xs)
+        return cv_cc, f
+
+    (cv, cc), f = _eval(xs)
+    return np.asarray(cv), np.asarray(cc), np.asarray(f)
+
+
+def assert_containment(
+    expr_fn: Callable,
+    bounds: Bounds,
+    *,
+    n_interior: int = 2000,
+    seed: int = 0,
+    tol: float = CONTAINMENT_TOL,
+    label: Optional[str] = None,
+) -> None:
+    """Theorem 1: ``cv(x) <= f(x) <= cc(x)`` for all sampled true graph points."""
+    relax_fn, true_fn, lb, ub = build_relaxation(expr_fn, bounds)
+    xs = _sample_points(lb, ub, n_interior, seed)
+    cv, cc, f = evaluate(relax_fn, true_fn, lb, ub, xs)
+
+    cv_viol = int(np.sum(cv > f + tol))
+    cc_viol = int(np.sum(cc < f - tol))
+    name = label or getattr(expr_fn, "__name__", "expr")
+    if cv_viol or cc_viol:
+        worst_cv = float(np.max(cv - f)) if cv.size else 0.0
+        worst_cc = float(np.max(f - cc)) if cc.size else 0.0
+        raise AssertionError(
+            f"[{name}] containment violated over {bounds}: "
+            f"cv>f at {cv_viol} pts (worst +{worst_cv:.2e}), "
+            f"cc<f at {cc_viol} pts (worst +{worst_cc:.2e})"
+        )
+
+
+def assert_corner_exactness(
+    expr_fn: Callable,
+    bounds: Bounds,
+    *,
+    tol: float = EXACTNESS_TOL,
+    label: Optional[str] = None,
+) -> None:
+    """Theorem 2: envelope is tight (cv == cc == f) at every box vertex.
+
+    Only valid for McCormick-exact primitives (bilinear, monotone convex/concave,
+    powers). Wide-interval periodic relaxations are intentionally *not* corner
+    exact and should not be checked here.
+    """
+    relax_fn, true_fn, lb, ub = build_relaxation(expr_fn, bounds)
+    corners = jnp.array(
+        list(itertools.product(*zip(np.asarray(lb), np.asarray(ub)))),
+        dtype=jnp.float64,
+    )
+    cv, cc, f = evaluate(relax_fn, true_fn, lb, ub, corners)
+    name = label or getattr(expr_fn, "__name__", "expr")
+    gap_cv = float(np.max(np.abs(cv - f))) if cv.size else 0.0
+    gap_cc = float(np.max(np.abs(cc - f))) if cc.size else 0.0
+    if gap_cv > tol or gap_cc > tol:
+        raise AssertionError(
+            f"[{name}] corner exactness failed over {bounds}: "
+            f"max|cv-f|={gap_cv:.2e}, max|cc-f|={gap_cc:.2e}"
+        )
+
+
+def assert_monotone_tightening(
+    expr_fn: Callable,
+    bounds: Bounds,
+    *,
+    shrink_factors: Sequence[float] = (1.0, 0.5, 0.25, 0.1, 0.02),
+    tol: float = TIGHTENING_TOL,
+    label: Optional[str] = None,
+) -> None:
+    """Theorem 3: the envelope gap ``cc - cv`` is non-increasing as the box
+    shrinks symmetrically toward its center, and tends to zero.
+
+    The compiled ``relax_fn`` already takes ``(lb, ub)`` as arguments, so we
+    evaluate the same relaxation on progressively tighter boxes without
+    recompiling, measuring the gap at the (fixed) center point.
+    """
+    relax_fn, true_fn, lb0, ub0 = build_relaxation(expr_fn, bounds)
+    center = 0.5 * (lb0 + ub0)
+    half = 0.5 * (ub0 - lb0)
+
+    name = label or getattr(expr_fn, "__name__", "expr")
+    prev_gap = np.inf
+    first_gap = None
+    last_gap = np.inf
+    for s in shrink_factors:
+        lb = center - s * half
+        ub = center + s * half
+        cv, cc = relax_fn(center, center, lb, ub)
+        gap = float(np.asarray(cc) - np.asarray(cv))
+        gap = max(gap, 0.0)
+        if gap > prev_gap + tol:
+            raise AssertionError(
+                f"[{name}] gap increased as box shrank over {bounds}: "
+                f"{prev_gap:.3e} -> {gap:.3e} at factor {s}"
+            )
+        if first_gap is None:
+            first_gap = gap
+        prev_gap = gap
+        last_gap = gap
+    # The tightest box must collapse the gap toward zero. The gap on a smooth
+    # node shrinks with the box (e.g. ~width^2 for a quadratic), so the
+    # vanishing criterion is relative to the initial gap rather than absolute.
+    assert first_gap is not None
+    if last_gap > max(1e-6, 0.05 * first_gap):
+        raise AssertionError(
+            f"[{name}] gap did not collapse as box shrank over {bounds}: "
+            f"{first_gap:.3e} -> {last_gap:.3e}"
+        )
+
+
+def assert_convexity(
+    expr_fn: Callable,
+    bounds: Bounds,
+    expected: str,
+    *,
+    label: Optional[str] = None,
+) -> None:
+    """Theorem 4: the DCP detector returns ``expected`` and never a false
+    convex/concave verdict.
+
+    ``expected`` is one of ``"CONVEX"``, ``"CONCAVE"``, ``"AFFINE"`` or
+    ``"UNKNOWN"``. For ``"UNKNOWN"`` we only require that the detector does not
+    *over*-claim convex or concave (UNKNOWN/AFFINE are acceptable; a wrong
+    CONVEX/CONCAVE is a soundness failure).
+    """
+    from discopt._jax.convexity import Curvature, classify_expr
+
+    m = Model("harness")
+    handles = [m.continuous(f"x{i}", lb=lo, ub=hi) for i, (lo, hi) in enumerate(bounds)]
+    expr = expr_fn(*handles)
+    m.minimize(handles[0])
+    verdict = classify_expr(expr, m)
+
+    name = label or getattr(expr_fn, "__name__", "expr")
+    if expected == "UNKNOWN":
+        # Only flag an over-claim (a definite wrong convex/concave label).
+        if verdict in (Curvature.CONVEX, Curvature.CONCAVE):
+            raise AssertionError(
+                f"[{name}] DCP over-claimed {verdict.name} for a non-convex/concave expr"
+            )
+        return
+    want = Curvature[expected]
+    # AFFINE is a strict refinement of both CONVEX and CONCAVE; accept it.
+    if (
+        verdict == want
+        or verdict == Curvature.AFFINE
+        and want
+        in (
+            Curvature.CONVEX,
+            Curvature.CONCAVE,
+        )
+    ):
+        return
+    raise AssertionError(f"[{name}] DCP verdict {verdict.name}, expected {expected}")

--- a/python/tests/test_conflict_cuts.py
+++ b/python/tests/test_conflict_cuts.py
@@ -14,7 +14,6 @@ os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import discopt.modeling.core as dm
 import pytest
-
 from discopt.conflict import add_conflict_cuts, find_conflict_cuts, no_good_cut
 
 

--- a/python/tests/test_conflict_cuts.py
+++ b/python/tests/test_conflict_cuts.py
@@ -1,0 +1,102 @@
+"""Tests for conflict analysis / no-good cuts (discopt.conflict).
+
+The correctness-critical property: a no-good cut excludes only an FBBT-proven
+infeasible assignment, never a feasible point — so the feasible region's optimum
+is unchanged. These tests pin that property directly.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import pytest
+
+from discopt.conflict import add_conflict_cuts, find_conflict_cuts, no_good_cut
+
+
+def _packing_model() -> tuple[dm.Model, list]:
+    """max x0 + 2 x1 + 3 x2 s.t. x0+x1+x2 <= 1 — any two ones is infeasible."""
+    m = dm.Model("conflict")
+    x = [m.binary(f"x{i}") for i in range(3)]
+    m.maximize(x[0] + 2 * x[1] + 3 * x[2])
+    m.subject_to(x[0] + x[1] + x[2] <= 1)
+    return m, x
+
+
+# ───────────────────────── no_good_cut semantics ─────────────────────────
+
+
+def test_no_good_cut_excludes_only_target():
+    """Excluding (x0=1, x1=1) must drop only that combination."""
+    m = dm.Model("ng")
+    x0 = m.binary("x0")
+    x1 = m.binary("x1")
+    m.maximize(x0 + x1)  # unconstrained optimum is (1, 1) -> 2
+    m.subject_to(no_good_cut([(x0, 1), (x1, 1)]))
+    res = m.solve()
+    assert res.status == "optimal"
+    # (1,1) is excluded; the best remaining is a single one -> objective 1.
+    assert abs(float(res.objective) - 1.0) < 1e-6
+
+
+def test_no_good_cut_empty_assignment_raises():
+    with pytest.raises(ValueError):
+        no_good_cut([])
+
+
+# ───────────────────────── conflict detection ─────────────────────────
+
+
+def test_finds_pairwise_conflicts():
+    m, _ = _packing_model()
+    cuts = find_conflict_cuts(m, max_order=2)
+    # The three pairs (0,1), (0,2), (1,2) set to (1,1) are each infeasible.
+    assert len(cuts) == 3
+
+
+def test_conflict_detection_restores_bounds():
+    m, x = _packing_model()
+    before = [(float(v.lb), float(v.ub)) for v in m._variables]
+    find_conflict_cuts(m, max_order=2)
+    after = [(float(v.lb), float(v.ub)) for v in m._variables]
+    assert before == after
+
+
+def test_minimal_conflicts_only():
+    """An order-1 conflict must suppress its order-2 supersets."""
+    m = dm.Model("min")
+    x = [m.binary(f"x{i}") for i in range(3)]
+    m.maximize(x[0] + x[1] + x[2])
+    m.subject_to(x[0] <= 0)  # x0 = 1 is infeasible on its own
+    cuts = find_conflict_cuts(m, max_order=2)
+    # The minimal conflict {x0=1} is found; no superset pair conflict involving
+    # x0=1 is reported (it is already covered).
+    assert len(cuts) == 1
+
+
+def test_no_binaries_returns_empty():
+    m = dm.Model("cont")
+    y = m.continuous("y", lb=0, ub=5)
+    m.minimize((y - 1) ** 2)
+    assert find_conflict_cuts(m) == []
+
+
+# ───────────────────────── soundness: optimum preserved ─────────────────────────
+
+
+def test_adding_conflict_cuts_preserves_optimum():
+    m1, _ = _packing_model()
+    opt_without = float(m1.solve().objective)
+
+    m2, _ = _packing_model()
+    n = add_conflict_cuts(m2, max_order=2)
+    assert n == 3
+    opt_with = float(m2.solve().objective)
+
+    # No-good cuts only remove proven-infeasible assignments -> optimum identical.
+    assert abs(opt_without - opt_with) < 1e-6
+    assert abs(opt_with - 3.0) < 1e-6  # x2 = 1

--- a/python/tests/test_improvement_heuristics.py
+++ b/python/tests/test_improvement_heuristics.py
@@ -1,0 +1,161 @@
+"""Tests for the improvement heuristics: diving, RINS, local branching.
+
+These heuristics may only *propose* feasible incumbents; they must never mutate
+the model permanently nor (by construction) affect the dual bound. The tests
+assert: produced points are integer- and constraint-feasible, never beat the
+known global optimum, and the model's variable bounds are restored afterwards.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pounce")
+
+from discopt._jax.nlp_evaluator import NLPEvaluator  # noqa: E402
+from discopt._jax.primal_heuristics import (  # noqa: E402
+    _get_integer_mask,
+    _is_integer_feasible,
+    diving,
+    fractional_diving,
+    local_branching,
+    objective_diving,
+    rins,
+)
+from discopt.modeling.core import Model  # noqa: E402
+from discopt.solvers.nlp_backend import get_nlp_solver  # noqa: E402
+
+pytestmark = pytest.mark.requires_pounce
+
+
+def _bounds_snapshot(model: Model):
+    return [(np.array(v.lb), np.array(v.ub)) for v in model._variables]
+
+
+def _assert_bounds_restored(model: Model, snap) -> None:
+    for v, (lb, ub) in zip(model._variables, snap):
+        assert np.allclose(np.array(v.lb), lb), "variable lb not restored"
+        assert np.allclose(np.array(v.ub), ub), "variable ub not restored"
+
+
+def _quad_minlp() -> tuple[Model, np.ndarray]:
+    """min (x-2.3)^2 + (y-0.4)^2 ; x integer in [0,5], y cont in [0,5].
+
+    Integer optimum: x=2, y=0.4, objective 0.09.
+    """
+    m = Model("quad_minlp")
+    x = m.integer("x", lb=0, ub=5)
+    y = m.continuous("y", lb=0, ub=5)
+    m.minimize((x - 2.3) ** 2 + (y - 0.4) ** 2)
+    return m, np.array([2.3, 0.4])
+
+
+def _relax(model: Model, x0: np.ndarray) -> np.ndarray:
+    ev = NLPEvaluator(model)
+    res = get_nlp_solver("auto")(ev, x0, options={"print_level": 0})
+    assert res.x is not None
+    return np.asarray(res.x)
+
+
+# ───────────────────────────── diving ─────────────────────────────
+
+
+def test_fractional_diving_finds_feasible_incumbent():
+    m, x0 = _quad_minlp()
+    snap = _bounds_snapshot(m)
+    x_relax = _relax(m, x0)
+
+    out = fractional_diving(m, x_relax)
+    assert out is not None
+    x, obj = out
+    int_mask = _get_integer_mask(m)
+    assert _is_integer_feasible(x, int_mask)
+    # Nearest-integer optimum is x=2 -> objective 0.09; never beats it.
+    assert obj >= 0.09 - 1e-6
+    assert abs(obj - 0.09) < 1e-4
+    _assert_bounds_restored(m, snap)
+
+
+def test_objective_diving_feasible():
+    m, x0 = _quad_minlp()
+    x_relax = _relax(m, x0)
+    out = objective_diving(m, x_relax)
+    assert out is not None
+    x, obj = out
+    assert _is_integer_feasible(x, _get_integer_mask(m))
+    assert obj >= 0.09 - 1e-6
+
+
+def test_diving_pure_continuous_returns_none():
+    m = Model("cont")
+    x = m.continuous("x", lb=0, ub=5)
+    m.minimize((x - 1.5) ** 2)
+    assert diving(m, np.array([1.5])) is None
+
+
+# ───────────────────────────── RINS ─────────────────────────────
+
+
+def test_rins_improves_on_poor_incumbent():
+    m, x0 = _quad_minlp()
+    snap = _bounds_snapshot(m)
+    x_relax = _relax(m, x0)
+    # Poor incumbent x=3 (objective 0.49) disagrees with the relaxation (x≈2.3).
+    incumbent = np.array([3.0, 0.4])
+    out = rins(m, incumbent, x_relax)
+    assert out is not None
+    x, obj = out
+    assert _is_integer_feasible(x, _get_integer_mask(m))
+    assert obj < 0.49  # strictly better than the seed incumbent
+    _assert_bounds_restored(m, snap)
+
+
+def test_rins_full_agreement_returns_none():
+    m, x0 = _quad_minlp()
+    x_relax = _relax(m, x0)
+    # Build an incumbent that agrees with the (rounded) relaxation on all ints
+    # by first rounding the relaxation to an integer-feasible point.
+    rounded = x_relax.copy()
+    int_mask = _get_integer_mask(m)
+    rounded[int_mask] = np.round(rounded[int_mask])
+    # Make the relaxation itself integral so agreement is full.
+    assert rins(m, rounded, rounded) is None
+
+
+# ─────────────────────────── local branching ───────────────────────────
+
+
+def _binary_model() -> Model:
+    """min (a+b-1)^2 + (z-0.5)^2 ; a,b binary, z cont. Optimum a+b=1, z=0.5."""
+    m = Model("binmodel")
+    a = m.binary("a")
+    b = m.binary("b")
+    z = m.continuous("z", lb=-5, ub=5)
+    m.minimize((a + b - 1) ** 2 + (z - 0.5) ** 2)
+    return m
+
+
+def test_local_branching_improves_incumbent():
+    m = _binary_model()
+    snap = _bounds_snapshot(m)
+    # Start from a=0,b=0 (objective 1.0 + 0 = 1.0 at z=0.5).
+    incumbent = np.array([0.0, 0.0, 0.5])
+    out = local_branching(m, incumbent, k=1)
+    assert out is not None
+    x, obj = out
+    assert _is_integer_feasible(x, _get_integer_mask(m))
+    assert obj < 1.0 - 1e-6  # found a strictly better neighbour
+    assert abs(obj) < 1e-4  # the true optimum (objective 0)
+    _assert_bounds_restored(m, snap)
+
+
+def test_local_branching_too_many_binaries_returns_none():
+    m = _binary_model()
+    out = local_branching(m, np.array([0.0, 0.0, 0.5]), k=1, max_binaries=1)
+    assert out is None

--- a/python/tests/test_mpec.py
+++ b/python/tests/test_mpec.py
@@ -1,0 +1,112 @@
+"""Tests for the complementarity / MPEC handler (discopt.mpec).
+
+Reference problem (a standard MPEC test):
+
+    min (x-1)^2 + (y-1)^2   s.t.   0 <= x ⊥ y >= 0
+
+The complementarity forces x·y = 0, so a global optimum sits at (1, 0) or
+(0, 1), both with objective 1. We verify that:
+  * the Scholtes homotopy drives x·y -> 0 and reaches objective 1,
+  * the exact SOS1 reformulation reaches the same global optimum,
+  * the two reformulations agree,
+  * single-variable complementarity bound propagation is sound.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import numpy as np
+import pytest
+
+pytest.importorskip("pounce")
+
+from discopt.mpec import (  # noqa: E402
+    Complementarity,
+    complementarity,
+    reformulate_scholtes,
+    solve_mpec,
+    tighten_complementarity_bounds,
+)
+
+pytestmark = pytest.mark.requires_pounce
+
+
+def _distance_model() -> tuple[dm.Model, dm.Variable, dm.Variable]:
+    m = dm.Model("mpec_distance")
+    x = m.continuous("x", lb=0, ub=10)
+    y = m.continuous("y", lb=0, ub=10)
+    m.minimize((x - 1) ** 2 + (y - 1) ** 2)
+    return m, x, y
+
+
+def test_complementarity_factory():
+    m, x, y = _distance_model()
+    p = complementarity(x, y, name="c0")
+    assert isinstance(p, Complementarity)
+    assert p.f is x and p.g is y and p.name == "c0"
+
+
+def test_scholtes_reaches_global_optimum():
+    m, x, y = _distance_model()
+    res = solve_mpec(m, [complementarity(x, y)], method="scholtes")
+    assert res is not None and res.x is not None
+    xv, yv = float(res.x[0]), float(res.x[1])
+    # Objective ~ 1 and complementarity ~ satisfied.
+    assert abs(float(res.objective) - 1.0) < 1e-3
+    assert xv * yv < 1e-5
+    assert min(abs(xv), abs(yv)) < 1e-3  # one side driven to zero
+
+
+def test_sos1_reaches_global_optimum():
+    m, x, y = _distance_model()
+    res = solve_mpec(m, [complementarity(x, y)], method="sos1")
+    # Model.solve returns x as a name->value dict.
+    assert res.objective is not None
+    assert abs(float(res.objective) - 1.0) < 1e-3
+    xv = float(np.asarray(res.x["x"]))
+    yv = float(np.asarray(res.x["y"]))
+    assert min(abs(xv), abs(yv)) < 1e-4  # exact complementarity
+
+
+def test_scholtes_and_sos1_agree():
+    m1, x1, y1 = _distance_model()
+    r1 = solve_mpec(m1, [complementarity(x1, y1)], method="scholtes")
+    m2, x2, y2 = _distance_model()
+    r2 = solve_mpec(m2, [complementarity(x2, y2)], method="sos1")
+    assert abs(float(r1.objective) - float(r2.objective)) < 1e-3
+
+
+def test_reformulate_scholtes_adds_three_constraints_per_pair():
+    m, x, y = _distance_model()
+    before = len(m._constraints)
+    reformulate_scholtes(m, [complementarity(x, y)], t=1e-3)
+    assert len(m._constraints) - before == 3
+
+
+def test_bound_propagation_fixes_zero_side():
+    m = dm.Model("bp")
+    a = m.continuous("a", lb=0.5, ub=3.0)  # strictly positive lower bound
+    b = m.continuous("b", lb=0.0, ub=3.0)
+    n_fixed = tighten_complementarity_bounds(m, [complementarity(a, b)])
+    assert n_fixed == 1
+    assert float(b.ub) == 0.0 and float(b.lb) == 0.0
+    # a is untouched.
+    assert float(a.lb) == 0.5
+
+
+def test_bound_propagation_no_fix_when_both_free():
+    m = dm.Model("bp2")
+    a = m.continuous("a", lb=0.0, ub=3.0)
+    b = m.continuous("b", lb=0.0, ub=3.0)
+    assert tighten_complementarity_bounds(m, [complementarity(a, b)]) == 0
+
+
+def test_unknown_method_raises():
+    m, x, y = _distance_model()
+    with pytest.raises(ValueError):
+        solve_mpec(m, [complementarity(x, y)], method="bogus")

--- a/python/tests/test_node_selection.py
+++ b/python/tests/test_node_selection.py
@@ -1,0 +1,51 @@
+"""Tests for B&B node-selection strategies, including best-estimate search.
+
+Best-estimate ordering is a *heuristic* over the open node set; it must never
+change the proven optimum, only the order in which nodes are explored. We verify
+that ``best_estimate`` returns the same global optimum as ``best_first`` and that
+an unknown strategy is rejected.
+
+The model is a small nonconvex MINLP (integer ``x``, continuous ``y``, a bilinear
+constraint ``x*y <= 3``) so that the solve routes through the spatial
+branch-and-bound engine (``PyTreeManager``) where the selection strategy actually
+takes effect — pure-linear MILPs use the simplex driver, which is best-first.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import pytest
+
+
+def _minlp() -> dm.Model:
+    m = dm.Model("minlp_select")
+    x = m.integer("x", lb=0, ub=4)
+    y = m.continuous("y", lb=0, ub=4)
+    m.minimize((x - 1.7) ** 2 + (y - 2.3) ** 2)
+    m.subject_to(x * y <= 3.0)  # nonconvex bilinear -> spatial B&B path
+    return m
+
+
+# Optimum: x=2, y=1.5 (x*y=3 binding) gives 0.09 + 0.64 = 0.73? — let the solver
+# decide; the assertion below pins both strategies to the *same* value instead.
+def test_best_estimate_matches_best_first():
+    r1 = _minlp().solve(strategy="best_first")
+    r2 = _minlp().solve(strategy="best_estimate")
+    assert r1.status == "optimal" and r2.status == "optimal"
+    assert abs(float(r1.objective) - float(r2.objective)) < 1e-4
+
+
+@pytest.mark.parametrize("strategy", ["best_first", "depth_first", "best_estimate"])
+def test_strategy_solves_to_optimal(strategy):
+    res = _minlp().solve(strategy=strategy)
+    assert res.status == "optimal"
+
+
+def test_unknown_strategy_rejected():
+    with pytest.raises(ValueError):
+        _minlp().solve(strategy="bogus")

--- a/python/tests/test_relaxation_theorems.py
+++ b/python/tests/test_relaxation_theorems.py
@@ -1,0 +1,139 @@
+"""Theorem-style property tests for every relaxation primitive.
+
+Each relaxation rule is exercised as a theorem (see ``relaxation_harness``):
+containment over the box, corner exactness for McCormick-exact primitives,
+monotone tightening as the box shrinks, and sound convexity classification.
+
+Run just these with::
+
+    pytest python/tests/test_relaxation_theorems.py -m relaxation
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import pytest
+from relaxation_harness import (
+    assert_containment,
+    assert_convexity,
+    assert_corner_exactness,
+    assert_monotone_tightening,
+)
+
+pytestmark = pytest.mark.relaxation
+
+
+# ───────────────────────── operator matrix ─────────────────────────
+# (id, expr_fn, bounds, corner_exact, curvature)
+#   corner_exact : True if cv==cc==f at box vertices (McCormick-exact)
+#   curvature    : expected DCP verdict over the box, or "UNKNOWN"
+CASES = [
+    # ---- arithmetic / bilinear ----
+    ("affine", lambda x, y: 2 * x + 3 * y - 1, [(-2.0, 2.0), (-2.0, 2.0)], True, "AFFINE"),
+    ("bilinear_pos", lambda x, y: x * y, [(0.5, 5.0), (0.5, 5.0)], True, "UNKNOWN"),
+    ("bilinear_mixed", lambda x, y: x * y, [(-3.0, 2.0), (-1.0, 4.0)], True, "UNKNOWN"),
+    (
+        "trilinear",
+        lambda x, y, z: x * y * z,
+        [(0.5, 2.0), (0.5, 2.0), (0.5, 2.0)],
+        False,
+        "UNKNOWN",
+    ),
+    # ---- division / reciprocal ----
+    ("reciprocal_pos", lambda x: 1.0 / x, [(0.3, 4.0)], False, "CONVEX"),
+    ("division", lambda x, y: x / y, [(1.0, 5.0), (0.5, 3.0)], False, "UNKNOWN"),
+    # ---- powers ----
+    ("square", lambda x: x**2, [(-3.0, 2.0)], True, "CONVEX"),
+    ("cube_pos", lambda x: x**3, [(0.2, 2.5)], False, "CONVEX"),
+    ("pow_frac_concave", lambda x: x**0.4, [(0.2, 5.0)], True, "CONCAVE"),
+    ("pow_frac_convex", lambda x: x**1.7, [(0.2, 5.0)], True, "CONVEX"),
+    # ---- exp / log ----
+    ("exp", lambda x: dm.exp(x), [(-2.0, 2.0)], True, "CONVEX"),
+    ("log", lambda x: dm.log(x), [(0.2, 6.0)], True, "CONCAVE"),
+    ("log2", lambda x: dm.log2(x), [(0.2, 6.0)], True, "CONCAVE"),
+    ("log10", lambda x: dm.log10(x), [(0.2, 6.0)], True, "CONCAVE"),
+    ("log1p", lambda x: dm.log1p(x), [(0.0, 6.0)], True, "CONCAVE"),
+    ("entropy", lambda x: x * dm.log(x), [(0.2, 4.0)], False, "UNKNOWN"),
+    # ---- sqrt / abs ----
+    ("sqrt", lambda x: dm.sqrt(x), [(0.1, 9.0)], True, "CONCAVE"),
+    ("abs", lambda x: abs(x), [(-3.0, 2.0)], True, "CONVEX"),
+    # ---- trig (narrow single-curvature regimes) ----
+    ("sin_concave", lambda x: dm.sin(x), [(0.2, 2.8)], False, "UNKNOWN"),
+    ("cos_regime", lambda x: dm.cos(x), [(0.2, 2.8)], False, "UNKNOWN"),
+    ("tan_regime", lambda x: dm.tan(x), [(-1.2, 1.2)], False, "UNKNOWN"),
+    # ---- inverse trig ----
+    ("atan", lambda x: dm.atan(x), [(-3.0, 3.0)], False, "UNKNOWN"),
+    ("asin", lambda x: dm.asin(x), [(-0.9, 0.9)], False, "UNKNOWN"),
+    ("acos", lambda x: dm.acos(x), [(-0.9, 0.9)], False, "UNKNOWN"),
+    # ---- hyperbolic ----
+    ("sinh", lambda x: dm.sinh(x), [(-2.0, 2.0)], False, "UNKNOWN"),
+    ("cosh", lambda x: dm.cosh(x), [(-2.0, 2.0)], True, "CONVEX"),
+    ("tanh", lambda x: dm.tanh(x), [(-2.0, 2.0)], False, "UNKNOWN"),
+    # ---- sigmoidal / special ----
+    ("sigmoid", lambda x: dm.sigmoid(x), [(-3.0, 3.0)], False, "UNKNOWN"),
+    ("softplus", lambda x: dm.softplus(x), [(-3.0, 3.0)], True, "CONVEX"),
+    ("erf", lambda x: dm.erf(x), [(-2.0, 2.0)], False, "UNKNOWN"),
+    # ---- min / max ----
+    ("maximum", lambda x, y: dm.maximum(x, y), [(-2.0, 3.0), (-1.0, 2.0)], False, "CONVEX"),
+    ("minimum", lambda x, y: dm.minimum(x, y), [(-2.0, 3.0), (-1.0, 2.0)], False, "CONCAVE"),
+    # ---- signomial / geometric mean (positive domain) ----
+    ("geomean", lambda x, y: x**0.5 * y**0.5, [(0.3, 4.0), (0.3, 4.0)], False, "CONCAVE"),
+]
+
+_ID = {c[0]: c for c in CASES}
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c[0] for c in CASES])
+def test_containment(case):
+    """Theorem 1: cv(x) <= f(x) <= cc(x) at interior, boundary and corner points."""
+    name, fn, bounds, _, _ = case
+    assert_containment(fn, bounds, label=name)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [c for c in CASES if c[3]],
+    ids=[c[0] for c in CASES if c[3]],
+)
+def test_corner_exactness(case):
+    """Theorem 2: McCormick-exact envelopes are tight at the box vertices."""
+    name, fn, bounds, _, _ = case
+    assert_corner_exactness(fn, bounds, label=name)
+
+
+# Tightening is checked on the smooth, single-curvature primitives where the
+# gap is expected to vanish monotonically; periodic/wide cases are excluded.
+_TIGHTENING_IDS = [
+    "bilinear_pos",
+    "bilinear_mixed",
+    "square",
+    "cube_pos",
+    "exp",
+    "log",
+    "sqrt",
+    "reciprocal_pos",
+    "pow_frac_concave",
+    "pow_frac_convex",
+    "cosh",
+    "softplus",
+    "entropy",
+]
+
+
+@pytest.mark.parametrize("case", [_ID[i] for i in _TIGHTENING_IDS], ids=_TIGHTENING_IDS)
+def test_monotone_tightening(case):
+    """Theorem 3: envelope gap is non-increasing and -> 0 as the box shrinks."""
+    name, fn, bounds, _, _ = case
+    assert_monotone_tightening(fn, bounds, label=name)
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c[0] for c in CASES])
+def test_convexity_classification(case):
+    """Theorem 4: DCP detector never returns a false convex/concave verdict."""
+    name, fn, bounds, _, curv = case
+    assert_convexity(fn, bounds, curv, label=name)


### PR DESCRIPTION
## Summary

First wave of changes from comparing discopt against the *"Rule Inventory for a State-of-the-Art Deterministic Global Optimizer"* checklist (factorable nonconvex NLP/MINLP, in the spirit of BARON/SCIP/ANTIGONE/Couenne). The audit found discopt already implements most of the inventory's Layers 1–5; this PR closes five of the genuine remaining gaps. Each is **sound by construction** and ships with tests (and docs where a new capability is user-facing), so the non-negotiable `incorrect_count ≤ 0` gate holds.

**121 new tests pass.** Cross-checks: full `cargo test -p discopt-core` (322 pass) and existing FBBT/OBBT/NLP-BB suites (58 pass, no regressions). Lint/type/clippy clean.

## What's included (5 commits)

- **Relaxation theorem harness** (`python/tests/relaxation_harness.py`, `test_relaxation_theorems.py`) — every relaxation rule tested as a theorem over the full operator matrix: containment (`cv ≤ f ≤ cc`), corner exactness for McCormick-exact primitives, monotone gap tightening as the box shrinks, and no false convexity verdicts. New `relaxation` pytest marker. (94 cases)

- **Best-estimate node selection** (`crates/discopt-core/src/bnb/`, `bnb_bindings.rs`, `solver.py`) — adds `SelectionStrategy::BestEstimate` (Forrest/Achterberg). Each node carries a pseudocost-based estimate of its subtree optimum computed at branch time; the strategy orders the open set by it (falling back to the dual bound when unset, so it degrades to best-first). Opt-in via `Model.solve(strategy="best_estimate")`; never changes the proven optimum. *(While wiring this, found that reliability branching — strong-branch on unreliable pseudocost candidates — is already implemented in the Rust MILP driver.)* (3 Rust + 5 Python tests)

- **Improvement heuristics** (`python/discopt/_jax/primal_heuristics.py`) — `diving`/`fractional_diving`/`objective_diving`, `rins`, and `local_branching`. All only *propose* feasible incumbents and restore model bounds in a `finally` block, so they never touch the dual bound or the global certificate. (7 tests)

- **Complementarity / MPEC handler** (`python/discopt/mpec.py`) — `0 ≤ f ⊥ g ≥ 0` via Scholtes regularization (homotopy of local NLP solves) and an exact SOS1 reformulation (global MINLP), plus sound `lb>0 ⇒ other side = 0` bound propagation. Both reach the global optimum on the reference distance MPEC by independent routes. New `complementarity_mpec` notebook. (8 tests)

- **Conflict analysis / no-good cuts** (`python/discopt/conflict.py`) — detects jointly-infeasible binary assignments using FBBT as the infeasibility oracle and emits minimal no-good cuts `Σ_{a_j=1}(1−x_j) + Σ_{a_j=0} x_j ≥ 1`. FBBT never reports a feasible subproblem infeasible, so every cut excludes only a proven-dead assignment and never removes the optimum. Conflict-analysis subsection added to the solver-internals notebook. (7 tests)

## Soundness notes

Heuristics propose incumbents only; best-estimate only reorders open nodes; MPEC reformulations build standard discopt models reusing the global machinery unchanged; no-good cuts exclude only FBBT-proven-infeasible assignments. No change touches bound *validity*.

## Not included (follow-ups, with reasons)

- **Pooling pq-formulation** — deferred: the existing Haverly p-formulation doesn't solve within 4 min in the dev environment, so a new pq-formulation can't be validated against known optima fast enough to satisfy the correctness gate without a pinned-optimum oracle.
- **OBBT wiring / row-activity pass** — deferred: largely already present (`implied_bounds` + FBBT do linear row-activity propagation; `obbt.rs` carries the candidate/extract/apply machinery).

## Test plan

```
pytest python/tests/test_relaxation_theorems.py python/tests/test_improvement_heuristics.py \
       python/tests/test_mpec.py python/tests/test_node_selection.py python/tests/test_conflict_cuts.py
cargo test -p discopt-core
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr