### PR TITLE
fix(soundness): reject fabricated finite bound on unbounded McCormick relaxation (himmel16 SUSPECT)

### DIFF
--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -112,6 +112,29 @@ class MccormickLPRelaxer:
         self._rlt_applicable = os.environ.get("DISCOPT_RLT", "0") == "1" and bool(
             _linear_constraint_forms(model, self._n_orig)
         )
+        # Original columns that participate in a nonlinear (product/power) term.
+        # A McCormick/RLT envelope for such a term is only valid when its
+        # variables have FINITE bounds: over an unbounded box the lifted aux is
+        # effectively free, so the relaxation has no valid finite lower bound for
+        # that term and is genuinely unbounded. The fast Rust simplex nonetheless
+        # fabricates a finite "optimal" there (himmel16: simplex says 0.0 / RLT
+        # cuts -0.6749 where HiGHS correctly says "unbounded"), which would be
+        # trusted as a too-high lower bound and certify a suboptimal incumbent.
+        # We record these columns to gate a HiGHS unboundedness cross-check in
+        # ``solve_at_node`` whenever any of them is still unbounded at a node.
+        nl_cols: set[int] = set()
+        t = self._terms
+        for i, j in t.bilinear:
+            nl_cols.update((int(i), int(j)))
+        for i, j, k in t.trilinear:
+            nl_cols.update((int(i), int(j), int(k)))
+        for term in t.multilinear:
+            nl_cols.update(int(c) for c in term)
+        for base, _power in t.monomial:
+            nl_cols.add(int(base))
+        for base, _exp in t.fractional_power:
+            nl_cols.add(int(base))
+        self._nonlinear_cols = nl_cols
 
     @property
     def has_bilinear(self) -> bool:
@@ -323,6 +346,37 @@ class MccormickLPRelaxer:
             ):
                 res = verify
 
+        # Soundness guard (unbounded relaxation): a McCormick/RLT envelope is only
+        # a valid relaxation when the participating variables have FINITE bounds.
+        # When a nonlinear-term variable is still unbounded at this node (e.g. the
+        # root box before FBBT could not bound it), the lifted aux is effectively
+        # free and the relaxation is genuinely UNBOUNDED — it carries no valid
+        # finite lower bound. The fast Rust simplex mis-handles the unbounded ray
+        # and fabricates a finite "optimal" (himmel16: simplex returns 0.0 / RLT
+        # cuts -0.6749 where HiGHS correctly returns "unbounded"); trusting that
+        # finite value as a lower bound is a too-high bound that fathoms feasible
+        # nodes and certifies a suboptimal incumbent — a false-"optimal", the
+        # worst failure class. When any nonlinear-participating column is
+        # unbounded, cross-check the fast "optimal" with HiGHS and adopt HiGHS's
+        # verdict; on "unbounded" the no-bound result below lets the driver
+        # branch (and decertify the gap) instead of certifying a fabricated
+        # bound. Gated on free nonlinear columns, so it is a no-op once FBBT /
+        # branching has bounded the box (the common case).
+        if (
+            res.status == "optimal"
+            and self._backend != "auto"
+            and self._nonlinear_cols
+            and self._has_unbounded_nonlinear_col(milp)
+        ):
+            verify = milp.solve(time_limit=_remaining(), backend="auto")
+            if verify.status == "unbounded" or (
+                verify.status == "optimal"
+                and verify.objective is not None
+                and res.objective is not None
+                and verify.objective < res.objective - 1e-6
+            ):
+                res = verify
+
         # A valid lower bound on the original problem requires the relaxation LP
         # to be solved to OPTIMALITY; any other terminal status yields no
         # certified bound, so report the status with no lower bound and let the
@@ -335,6 +389,24 @@ class MccormickLPRelaxer:
             lower_bound=float(res.objective),
             x=x_orig,
         )
+
+    def _has_unbounded_nonlinear_col(self, milp) -> bool:
+        """True if any nonlinear-term original column has a non-finite bound.
+
+        After the ``solve_at_node`` clamp, a variable that was effectively
+        unbounded (``|bound| >= _RELAX_NUMERIC_CAP``) carries a true ``+/-inf``
+        bound. A McCormick/RLT envelope over such a column is not a valid finite
+        relaxation, so the LP is genuinely unbounded and the fast simplex's
+        finite "optimal" cannot be trusted.
+        """
+        bounds = milp._bounds
+        for col in self._nonlinear_cols:
+            if col >= len(bounds):
+                continue
+            lo, hi = bounds[col]
+            if not (np.isfinite(lo) and np.isfinite(hi)):
+                return True
+        return False
 
     @staticmethod
     def _max_finite_magnitude(milp) -> float:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1416,7 +1416,15 @@ def _root_relaxation_lower_bound(
         relax = sanitize_relaxation_for_conditioning(relax)
         budget = min(10.0, max(1.0, time_limit * 0.1))
         result = relax.solve(time_limit=budget, gap_tolerance=1e-6)
-        if result.bound is not None and np.isfinite(result.bound):
+        # Only an OPTIMAL relaxation solve yields a valid lower bound. An
+        # "unbounded" verdict means the relaxation (e.g. a McCormick envelope over
+        # a box where a nonlinear-term variable is still unbounded) has no finite
+        # lower bound, yet the backend still reports ``bound = 0.0`` — a finite
+        # value that is NOT a valid bound. On himmel16 the root relaxation is
+        # unbounded and 0.0 > the true optimum -0.866; surfacing it as the
+        # fallback bound would publish an invalid (above-incumbent) dual bound.
+        # Gate on optimality so an unbounded/limit solve returns no bound instead.
+        if result.status == "optimal" and result.bound is not None and np.isfinite(result.bound):
             return float(result.bound)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("root MILP-relaxation bound skipped: %s", exc)

--- a/python/tests/test_unbounded_relaxation_soundness.py
+++ b/python/tests/test_unbounded_relaxation_soundness.py
@@ -1,0 +1,150 @@
+"""Unbounded McCormick relaxation must not fabricate a finite lower bound (#24).
+
+A McCormick/RLT envelope for a product/power term is only a valid relaxation when
+its variables have FINITE bounds. Over a box where a nonlinear-term variable is
+still unbounded (e.g. the root box before FBBT could bound it), the lifted aux is
+effectively free and the relaxation is genuinely UNBOUNDED -- it carries no valid
+finite lower bound. HiGHS correctly reports "unbounded"; the fast warm-started
+Rust simplex instead mis-handles the unbounded ray and fabricates a finite
+"optimal" (on himmel16's root relaxation the simplex returns 0.0 / with RLT cuts
+-0.6749 where HiGHS returns "unbounded"). Trusting that finite value as a lower
+bound is a too-high dual bound: it fathoms feasible nodes and certifies a
+suboptimal incumbent -- a false-"optimal", the worst failure class.
+
+himmel16 (the "largest small hexagon" with only pairwise-diameter constraints)
+admits a self-intersecting doubly-traced equilateral triangle of area 0.866, so
+its true optimum is objvar = -0.866; discopt previously certified -0.6749 (the
+*convex* hexagon optimum) as global. These tests pin the two soundness guards
+that close that gap: ``MccormickLPRelaxer.solve_at_node`` cross-checks an
+unbounded relaxation with HiGHS, and ``_root_relaxation_lower_bound`` requires an
+OPTIMAL relaxation solve before surfacing a fallback bound.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import discopt
+import discopt._jax.mccormick_lp as mc
+import numpy as np
+
+
+def _bilinear_obj():
+    """Minimize a bilinear objective; the unbounded box makes x*y unbounded."""
+    m = discopt.Model("bil_unbounded")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    m.subject_to(x + y >= 0.5)
+    m.minimize(x * y - x - y)
+    return m
+
+
+def test_solve_at_node_unbounded_box_returns_no_finite_bound():
+    """Directly: over an UNBOUNDED box the bilinear relaxation is unbounded, so
+    ``solve_at_node`` must NOT return a finite ``lower_bound`` -- even though the
+    fast simplex fabricates a finite "optimal" there. A fabricated finite bound
+    would be a too-high dual bound and certify a suboptimal incumbent."""
+    relaxer = mc.MccormickLPRelaxer(_bilinear_obj())
+
+    # Bounded box: a real finite LP bound is fine (relaxation is bounded).
+    lb_f = np.array([-2.0, -2.0], dtype=np.float64)
+    ub_f = np.array([2.0, 2.0], dtype=np.float64)
+    bounded = relaxer.solve_at_node(lb_f, ub_f, time_limit=5.0)
+    assert bounded.status != "skipped_oversize"
+
+    # Unbounded box: the McCormick envelope of x*y is free -> the LP is unbounded.
+    # The guard must decline (no finite lower bound), never fabricate one.
+    lb_u = np.array([-np.inf, -np.inf], dtype=np.float64)
+    ub_u = np.array([np.inf, np.inf], dtype=np.float64)
+    unb = relaxer.solve_at_node(lb_u, ub_u, time_limit=5.0)
+    assert unb.lower_bound is None, (
+        f"unbounded relaxation fabricated a finite bound {unb.lower_bound} (status={unb.status})"
+    )
+
+
+def test_has_unbounded_nonlinear_col_flags_free_bilinear_var():
+    """The gate fires iff a nonlinear-participating column is non-finite."""
+    relaxer = mc.MccormickLPRelaxer(_bilinear_obj())
+    assert relaxer._nonlinear_cols  # x*y registers both columns
+
+    class _Milp:
+        def __init__(self, bounds):
+            self._bounds = bounds
+
+    finite = _Milp([(-2.0, 2.0), (-2.0, 2.0)])
+    assert not relaxer._has_unbounded_nonlinear_col(finite)
+
+    free = _Milp([(-np.inf, 2.0), (-2.0, 2.0)])
+    assert relaxer._has_unbounded_nonlinear_col(free)
+
+
+def test_himmel16_no_false_certification():
+    """End-to-end: the largest-small-hexagon model with only pairwise-diameter
+    constraints has a feasible self-intersecting solution at objvar=-0.866. The
+    solver must EITHER report a bound <= the incumbent (sound), OR not certify --
+    it must never certify a value above -0.866."""
+    m = _himmel16_model()
+    r = m.solve(time_limit=40.0)
+    # discopt finds the true optimum (-0.866) via local search.
+    assert r.objective is not None
+    assert r.objective <= -0.86 + 1e-3, f"missed the -0.866 incumbent: {r.objective}"
+    # Soundness: a certified bound can never sit above the incumbent it certifies.
+    if getattr(r, "gap_certified", False):
+        assert r.bound is not None and r.bound <= r.objective + 1e-4, (
+            f"certified an invalid (above-incumbent) bound: "
+            f"bound={r.bound} > objective={r.objective}"
+        )
+    # A reported finite bound must be a valid lower bound (<= incumbent).
+    if r.bound is not None and np.isfinite(r.bound):
+        assert r.bound <= r.objective + 1e-4, (
+            f"surfaced an invalid lower bound {r.bound} > incumbent {r.objective}"
+        )
+
+
+def _himmel16_model():
+    """himmel16 (GLOBALLib): maximize hexagon area (min objvar=-area) with all
+    pairwise vertex distances <= 1. Vertices (x_i, x_{i+6}), i=1..6; x1=x7=x8=0
+    fixed; coordinates otherwise free. The shoelace area terms are bilinear."""
+    m = discopt.Model("himmel16")
+    x = {i: m.continuous(f"x{i}", lb=-1e20, ub=1e20) for i in range(1, 19)}
+    objvar = m.continuous("objvar", lb=-1e20, ub=1e20)
+    # x1, x7, x8 fixed at 0
+    for i in (1, 7, 8):
+        m.subject_to(x[i] == 0.0)
+    # pairwise diameter constraints e1..e15: sqr(xa-xb)+sqr(xc-xd) <= 1
+    pairs = [
+        (1, 2),
+        (1, 3),
+        (1, 4),
+        (1, 5),
+        (1, 6),
+        (2, 3),
+        (2, 4),
+        (2, 5),
+        (2, 6),
+        (3, 4),
+        (3, 5),
+        (3, 6),
+        (4, 5),
+        (4, 6),
+        (5, 6),
+    ]
+    for a, b in pairs:
+        m.subject_to((x[a] - x[b]) ** 2 + (x[a + 6] - x[b + 6]) ** 2 <= 1.0)
+    # shoelace area pieces x13..x18 (e17..e22)
+    m.subject_to(-0.5 * (x[1] * x[8] - x[7] * x[2]) + x[13] == 0.0)
+    m.subject_to(-0.5 * (x[2] * x[9] - x[8] * x[3]) + x[14] == 0.0)
+    m.subject_to(-0.5 * (x[3] * x[10] - x[9] * x[4]) + x[15] == 0.0)
+    m.subject_to(-0.5 * (x[4] * x[11] - x[10] * x[5]) + x[16] == 0.0)
+    m.subject_to(-0.5 * (x[5] * x[12] - x[11] * x[6]) + x[17] == 0.0)
+    m.subject_to(-0.5 * (x[6] * x[7] - x[12] * x[1]) + x[18] == 0.0)
+    # e16: objvar = -(x13+...+x18)
+    m.subject_to(-(x[13] + x[14] + x[15] + x[16] + x[17] + x[18]) - objvar == 0.0)
+    m.minimize(objvar)
+    return m


### PR DESCRIPTION
## Summary

Closes a **false global certification** on GLOBALLib **himmel16** ("largest small hexagon") — a SUSPECT, the worst failure class. discopt certified `objvar = -0.6749` (the *convex*-hexagon optimum) as the global minimum, but the model only constrains pairwise vertex distances `<= 1`; it does **not** forbid self-intersection, so a feasible doubly-traced equilateral triangle reaches `objvar = -0.866`. The certified dual bound `-0.6749` therefore sat **above** the true optimum — an invalid (too-high) lower bound flying `gap_certified=True`.

## Root cause

A McCormick/RLT envelope for a product term is a valid relaxation **only when its variables have finite bounds**. The hexagon coordinates stay unbounded at the root (FBBT does not bound them from the `sqr(x_i-x_j) <= 1` diameter constraints), so the lifted bilinear auxes are effectively free and the relaxation is genuinely **unbounded**.

- HiGHS reports this correctly (`status=unbounded`).
- The fast warm-started Rust `simplex` backend mis-handles the unbounded ray and fabricates a finite `optimal` (base relaxation `0.0`; with the RLT/cut machinery `-0.6749`).

Two code paths trusted that fabricated finite value as a valid lower bound:
1. `MccormickLPRelaxer.solve_at_node` — its existing HiGHS cross-checks fire only on a non-`optimal` status or above a magnitude threshold; neither caught a clean-but-wrong `optimal` on O(1)-scaled data.
2. `_root_relaxation_lower_bound` — returned `result.bound` whenever finite, without checking status (an `unbounded` solve still carries `bound=0.0`).

## Fix (general, sound, pure-Python)

- **`mccormick_lp.py`** — precompute `self._nonlinear_cols` (every original column in a bilinear/trilinear/multilinear/monomial/fractional-power term). New guard in `solve_at_node`: when the fast backend says `optimal` **and** any nonlinear column is unbounded at this node (`_has_unbounded_nonlinear_col`), cross-check with HiGHS and adopt its verdict — on `unbounded`, yield **no bound** so the driver branches / decertifies instead of certifying a fabricated one. Gated on free nonlinear columns, so it is a no-op once FBBT/branching bounds the box (the common case → no extra solve).
- **`solver.py`** — `_root_relaxation_lower_bound` now requires `result.status == "optimal"` before surfacing the fallback bound; an `unbounded`/limit solve returns `None`.

Both guards key on the real invariant ("a nonlinear-term variable with a non-finite bound ⇒ the relaxation may be unbounded ⇒ a fast-backend finite optimum cannot be trusted") and protect **any** model whose relaxation is unbounded at a node, not just himmel16.

## Result

After the fix discopt **finds the true optimum** (`-0.866`) via local multistart and honestly does **not** certify (no valid finite dual bound exists over the un-tightened box):

```
before:  obj=-0.674981  status=optimal   gap_certified=True   bound=-0.674981   <-- SUSPECT
after:   obj=-0.866025  status=feasible  gap_certified=False  bound=None        <-- sound + honest
```

## Tests

New `python/tests/test_unbounded_relaxation_soundness.py` (3 tests):
- `test_solve_at_node_unbounded_box_returns_no_finite_bound` — deterministic unit test; `solve_at_node` over an unbounded box on a bilinear objective must return `lower_bound is None`. **Fails without the guard** (simplex fabricates a finite bound), passes with it.
- `test_has_unbounded_nonlinear_col_flags_free_bilinear_var` — the gate predicate.
- `test_himmel16_no_false_certification` — end-to-end (model built via the modeling API, no external `.gms`): incumbent reaches `-0.866` and any certified/surfaced bound is `<= incumbent`.

Existing soundness suites unaffected (test_mccormick*, test_root_relaxation_surfacing, test_cert_finite_bound_soundness, test_alphabb/batch_sentinel/interval/convexity/monomial soundness — all green). ruff + ruff format + mypy clean.

Found via the global-optimization benchmark loop (discopt vs BARON); documented in the loop's FINDINGS log as Issue #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
