### PR TITLE
feat(tightening): public FBBT bound-tightening API + bound-tightening docs (P2-G)

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -36,6 +36,7 @@ parts:
       - file: notebooks/advanced_features
       - file: notebooks/solver_internals
       - file: notebooks/presolve
+      - file: notebooks/bound_tightening
       - file: notebooks/sensitivity_analysis
       - file: notebooks/llm_integration
       - file: llm_features

--- a/docs/notebooks/bound_tightening.ipynb
+++ b/docs/notebooks/bound_tightening.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bound tightening: FBBT, row activity, and OBBT\n",
+    "\n",
+    "Tightening variable bounds is one of the highest-leverage steps in global\n",
+    "optimization: a smaller box yields tighter convex relaxations, fewer branch-and-bound\n",
+    "nodes, and faster convergence {cite:p}`Puranik2017`. discopt runs a layered\n",
+    "bound-tightening stack:\n",
+    "\n",
+    "1. **FBBT** (feasibility-based bound tightening) \u2014 propagate each constraint's *row\n",
+    "   activity* under the current bounds and isolate each variable, iterated across\n",
+    "   constraints to a fixpoint. Cheap (interval arithmetic, no LP) and exact on the\n",
+    "   constraint graph.\n",
+    "2. **Implied / row-activity propagation** \u2014 the linear specialization of the above.\n",
+    "3. **DBBT** (duality-based) \u2014 one objective LP's reduced costs tighten every variable\n",
+    "   at once when an incumbent cutoff is known.\n",
+    "4. **OBBT** (optimization-based) \u2014 solve ``min``/``max`` of each variable over the\n",
+    "   McCormick {cite:p}`McCormick1976` relaxation of the model, iterated as the box\n",
+    "   shrinks and the envelopes tighten {cite:p}`Tawarmalani2005`.\n",
+    "\n",
+    "Every layer only ever derives *valid* bounds, so the tightened box always contains the\n",
+    "whole feasible region \u2014 bound tightening never removes the optimum.\n",
+    "\n",
+    "This notebook focuses on the sound, LP-free core \u2014 FBBT \u2014 exposed publicly as\n",
+    "`discopt.tightening.fbbt_box`, and then shows the full stack at work inside a global\n",
+    "solve.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## FBBT row-activity propagation\n",
+    "\n",
+    "Consider $a \\ge b + 5$ and $b \\ge c + 3$ with $a, b, c \\in [0, 10]$. No single\n",
+    "constraint pins $a$, but propagating them together tightens the lower bounds: from the\n",
+    "second, $b \\ge 3$; feeding that into the first, $a \\ge 8$. FBBT reaches this fixpoint\n",
+    "automatically (and tightens the upper bounds the other way).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+    "os.environ[\"JAX_ENABLE_X64\"] = \"1\"\n",
+    "\n",
+    "import numpy as np\n",
+    "import discopt.modeling.core as dm\n",
+    "from discopt.tightening import fbbt_box\n",
+    "\n",
+    "m = dm.Model(\"chain\")\n",
+    "a = m.continuous(\"a\", lb=0, ub=10)\n",
+    "b = m.continuous(\"b\", lb=0, ub=10)\n",
+    "c = m.continuous(\"c\", lb=0, ub=10)\n",
+    "m.minimize(a + b + c)\n",
+    "m.subject_to(a - b >= 5)\n",
+    "m.subject_to(b - c >= 3)\n",
+    "\n",
+    "res = fbbt_box(m)\n",
+    "print(\"tightened lower bounds:\", np.round(res.lb, 3))   # -> [8, 3, 0]\n",
+    "print(\"tightened upper bounds:\", np.round(res.ub, 3))   # -> [10, 5, 2]\n",
+    "print(\"variables tightened   :\", res.n_tightened)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Proving infeasibility\n",
+    "\n",
+    "If propagation collapses a variable's interval to empty, the problem is infeasible \u2014\n",
+    "a result that downstream tools (e.g. conflict analysis) use to emit no-good cuts.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = dm.Model(\"infeasible\")\n",
+    "x = m2.continuous(\"x\", lb=0, ub=10)\n",
+    "m2.minimize(x)\n",
+    "m2.subject_to(x >= 5)\n",
+    "m2.subject_to(x <= 3)\n",
+    "\n",
+    "print(\"FBBT proves infeasible:\", fbbt_box(m2).infeasible)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The full stack inside a global solve\n",
+    "\n",
+    "On a nonconvex MINLP the solver applies the whole stack \u2014 FBBT at presolve, then\n",
+    "DBBT and OBBT over the McCormick relaxation at the root \u2014 before and during spatial\n",
+    "branch-and-bound. The bounds only ever shrink, so the certified global optimum is\n",
+    "unchanged; the tightening just gets there with less search {cite:p}`Puranik2017`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m3 = dm.Model(\"nonconvex\")\n",
+    "xi = m3.integer(\"xi\", lb=0, ub=4)\n",
+    "y = m3.continuous(\"y\", lb=0, ub=4)\n",
+    "m3.minimize((xi - 1.7) ** 2 + (y - 2.3) ** 2)\n",
+    "m3.subject_to(xi * y <= 3.0)   # nonconvex bilinear\n",
+    "\n",
+    "result = m3.solve()\n",
+    "print(f\"status: {result.status}, objective: {float(result.objective):.4f}\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/conflict.py
+++ b/python/discopt/conflict.py
@@ -80,13 +80,9 @@ def no_good_cut(assignment: list[tuple]) -> Constraint:
 
 def _fbbt_infeasible(model: Model, tol: float = 1e-9, max_iter: int = 20) -> bool:
     """True if FBBT proves the current model (with its present bounds) infeasible."""
-    from discopt._rust import model_to_repr
+    from discopt.tightening import fbbt_box
 
-    repr_ = model_to_repr(model)
-    lbs, ubs = repr_.fbbt(max_iter=max_iter, tol=tol)
-    lbs = np.asarray(lbs)
-    ubs = np.asarray(ubs)
-    return bool(np.any(lbs > ubs + tol))
+    return fbbt_box(model, max_iter=max_iter, tol=tol).infeasible
 
 
 def find_conflict_cuts(

--- a/python/discopt/tightening.py
+++ b/python/discopt/tightening.py
@@ -1,0 +1,126 @@
+"""Public bound-tightening utilities (feasibility-based / row-activity).
+
+discopt's solver already runs a sophisticated bound-tightening stack during
+presolve and at the root node — feasibility-based bound tightening (FBBT,
+iterated to a fixpoint), implied row-activity propagation, duality-based
+tightening (DBBT), and optimization-based bound tightening (OBBT) over the
+McCormick relaxation. This module exposes the *sound, LP-free* core of that
+stack — FBBT — as a small public API for analysis and for building custom
+workflows (e.g. conflict detection).
+
+FBBT propagates the **row activity** of each constraint under the current
+variable bounds: for a constraint ``g(x) ⋈ rhs`` it computes the interval the
+body can take, then isolates each variable to derive an implied bound, iterating
+across constraints until a fixpoint. It only ever derives *valid* bounds, so the
+tightened box always contains the entire feasible region — it never removes a
+feasible point, and in particular never excludes the optimum. If propagation
+produces an empty interval, the (sub)problem is proven infeasible.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+from discopt.modeling.core import Model
+
+__all__ = ["BoundTightening", "fbbt_box"]
+
+
+@dataclass
+class BoundTightening:
+    """Result of an FBBT bound-tightening pass.
+
+    Attributes
+    ----------
+    lb, ub : np.ndarray
+        Tightened flat (per-scalar) variable bounds. Always a subset of the
+        input box (each bound intersected, never loosened).
+    infeasible : bool
+        True if propagation derived an empty interval for some variable, which
+        proves the problem infeasible.
+    n_tightened : int
+        Number of scalar variables whose lower or upper bound was strictly
+        improved.
+    """
+
+    lb: np.ndarray
+    ub: np.ndarray
+    infeasible: bool
+    n_tightened: int
+
+
+def _block_sizes(shapes: list[list[int]]) -> list[int]:
+    sizes = []
+    for shp in shapes:
+        n = 1
+        for d in shp:
+            n *= d
+        sizes.append(n)
+    return sizes
+
+
+def fbbt_box(model: Model, *, max_iter: int = 20, tol: float = 1e-9) -> BoundTightening:
+    """Tighten ``model``'s variable bounds with feasibility-based bound tightening.
+
+    Runs FBBT (iterated to a fixpoint, up to ``max_iter`` sweeps) over the model's
+    constraints and returns the tightened flat bounds. The per-block bounds from
+    the Rust FBBT engine are expanded to per-scalar bounds and intersected with
+    the model's current bounds, so the result is always a sound subset of the
+    input box.
+
+    Parameters
+    ----------
+    model : Model
+        The model whose bounds to tighten.
+    max_iter : int
+        Maximum FBBT sweeps (cross-constraint propagation reaches a fixpoint when
+        a sweep changes nothing).
+    tol : float
+        Numerical tolerance for empty-interval (infeasibility) detection.
+
+    Returns
+    -------
+    BoundTightening
+    """
+    from discopt._rust import model_to_repr
+
+    repr_ = model_to_repr(model)
+    n_blocks = repr_.n_var_blocks
+    shapes = repr_.var_shapes()
+    sizes = _block_sizes(shapes)
+
+    # Original per-scalar bounds (block-by-block), and the FBBT per-block result.
+    orig_lb: list[float] = []
+    orig_ub: list[float] = []
+    for i in range(n_blocks):
+        orig_lb.extend(float(v) for v in repr_.var_lb(i))
+        orig_ub.extend(float(v) for v in repr_.var_ub(i))
+    orig_lb_arr = np.asarray(orig_lb, dtype=np.float64)
+    orig_ub_arr = np.asarray(orig_ub, dtype=np.float64)
+
+    block_lb, block_ub = repr_.fbbt(max_iter=max_iter, tol=tol)
+    block_lb = np.asarray(block_lb, dtype=np.float64)
+    block_ub = np.asarray(block_ub, dtype=np.float64)
+
+    # Expand each block's [lo, hi] to its scalar slots; intersect with originals.
+    # The block bound is a valid outer bound for every element of the block, so
+    # the intersection can only tighten — never loosen — and stays sound.
+    new_lb = orig_lb_arr.copy()
+    new_ub = orig_ub_arr.copy()
+    offset = 0
+    for i in range(n_blocks):
+        size = sizes[i]
+        lo = block_lb[i] if i < len(block_lb) else -math.inf
+        hi = block_ub[i] if i < len(block_ub) else math.inf
+        sl = slice(offset, offset + size)
+        new_lb[sl] = np.maximum(new_lb[sl], lo)
+        new_ub[sl] = np.minimum(new_ub[sl], hi)
+        offset += size
+
+    infeasible = bool(np.any(new_lb > new_ub + tol))
+    tightened = int(np.count_nonzero((new_lb > orig_lb_arr + tol) | (new_ub < orig_ub_arr - tol)))
+
+    return BoundTightening(lb=new_lb, ub=new_ub, infeasible=infeasible, n_tightened=tightened)

--- a/python/tests/test_tightening.py
+++ b/python/tests/test_tightening.py
@@ -1,0 +1,103 @@
+"""Tests for the public FBBT bound-tightening utility (discopt.tightening).
+
+The correctness-critical property: the tightened box is always a sound *outer*
+box — it contains every feasible point (hence the optimum) and only ever shrinks
+the input box. These tests pin cross-constraint (row-activity) propagation to its
+fixpoint, infeasibility detection, soundness on a known feasible point, and the
+never-loosen invariant (including for vector variables).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import numpy as np
+from discopt.tightening import fbbt_box
+
+
+def test_cross_row_propagation_reaches_fixpoint():
+    """a >= b+5, b >= c+3 on [0,10] -> lower bounds propagate to [8, 3, 0]."""
+    m = dm.Model("chain")
+    a = m.continuous("a", lb=0, ub=10)
+    b = m.continuous("b", lb=0, ub=10)
+    c = m.continuous("c", lb=0, ub=10)
+    m.minimize(a + b + c)
+    m.subject_to(a - b >= 5)
+    m.subject_to(b - c >= 3)
+
+    res = fbbt_box(m)
+    assert not res.infeasible
+    np.testing.assert_allclose(res.lb, [8.0, 3.0, 0.0], atol=1e-6)
+    # Upper bounds propagate the other way: b <= 5, c <= 2.
+    np.testing.assert_allclose(res.ub, [10.0, 5.0, 2.0], atol=1e-6)
+    assert res.n_tightened == 3  # a (lb), b (lb+ub), c (ub)
+
+
+def test_detects_infeasibility():
+    m = dm.Model("inf")
+    x = m.continuous("x", lb=0, ub=10)
+    m.minimize(x)
+    m.subject_to(x >= 5)
+    m.subject_to(x <= 3)
+    res = fbbt_box(m)
+    assert res.infeasible
+
+
+def test_tightened_box_contains_optimum():
+    """Soundness: the tightened box must still contain the true optimum."""
+    m = dm.Model("sound")
+    x = m.continuous("x", lb=0, ub=10)
+    y = m.continuous("y", lb=0, ub=10)
+    m.maximize(x + y)
+    m.subject_to(x + y <= 4)
+    m.subject_to(x - y >= 1)
+    res = fbbt_box(m)
+    # True optimum is x=2.5, y=1.5 (x+y=4, x-y=1). It must remain in the box.
+    assert res.lb[0] - 1e-9 <= 2.5 <= res.ub[0] + 1e-9
+    assert res.lb[1] - 1e-9 <= 1.5 <= res.ub[1] + 1e-9
+    # And the box only shrank.
+    assert res.lb[0] >= 0 and res.ub[0] <= 10
+    assert res.lb[1] >= 0 and res.ub[1] <= 10
+
+
+def test_never_loosens_and_handles_vector_vars():
+    m = dm.Model("vec")
+    xv = m.continuous("xv", shape=(3,), lb=0, ub=10)
+    s = m.continuous("s", lb=0, ub=100)
+    m.minimize(s)
+    m.subject_to(xv[0] + xv[1] + xv[2] == s)
+    m.subject_to(s <= 6)
+    res = fbbt_box(m)
+    assert not res.infeasible
+    # Never loosened beyond the original box (length 4: xv[0..2], s).
+    assert np.all(res.lb >= np.array([0, 0, 0, 0]) - 1e-9)
+    assert np.all(res.ub <= np.array([10, 10, 10, 100]) + 1e-9)
+    # s is tightened to <= 6 by the demand constraint.
+    assert res.ub[3] <= 6.0 + 1e-9
+
+
+def test_idempotent():
+    m = dm.Model("idem")
+    a = m.continuous("a", lb=0, ub=10)
+    b = m.continuous("b", lb=0, ub=10)
+    m.minimize(a + b)
+    m.subject_to(a - b >= 5)
+    first = fbbt_box(m)
+    # Re-tightening from the already-tight bounds yields the same box.
+    second = fbbt_box(m, max_iter=first.lb.size + 5)
+    np.testing.assert_allclose(first.lb, second.lb, atol=1e-9)
+    np.testing.assert_allclose(first.ub, second.ub, atol=1e-9)
+
+
+def test_no_constraints_returns_original_box():
+    m = dm.Model("free")
+    x = m.continuous("x", lb=-2, ub=7)
+    m.minimize(x)
+    res = fbbt_box(m)
+    assert res.n_tightened == 0
+    np.testing.assert_allclose(res.lb, [-2.0], atol=1e-12)
+    np.testing.assert_allclose(res.ub, [7.0], atol=1e-12)


### PR DESCRIPTION
## Summary

Closes the **P2-G (OBBT / row-activity)** workstream — the last of the SOTA gap-closing items (follow-up to #193, #197).

A thorough investigation first established that the bound-tightening **engine is already complete and high quality**, so rather than add redundant machinery to a soundness-critical path, this PR **surfaces, hardens, and documents** the existing stack.

### What the investigation found (already implemented)

- **Row-activity propagation is fully covered**: the default presolve `FbbtPass` uses `max_iter: 20`, so FBBT iterates to a fixpoint. Verified empirically — `a≥b+5, b≥c+3` on `[0,10]` correctly propagates to `a≥8`. The standalone `implied_bounds` pass is a faster *linear complement*, redundant for correctness.
- **OBBT is sophisticated and complete**: `obbt_tighten_root` iterates to a fixpoint, rebuilds the McCormick envelope each round, interleaves **DBBT** (duality-based tightening), rounds integer bounds, detects infeasibility, and is fully soundness-guarded — plus an exact-LP-oracle soundness lock (#145) and per-node OBBT in the AMP layer. The linear-only `run_obbt` provably can't benefit from iteration (a single LP already sees the whole polytope).

## What's included

- **`discopt.tightening.fbbt_box(model)`** — a sound, public FBBT bound-tightening API returning flat tightened bounds + an infeasibility flag. It expands the Rust engine's per-block bounds to per-scalar and intersects with current bounds, so the result is always a valid *outer* box — it never removes a feasible point or the optimum.
- **`conflict.py`** — refactored `_fbbt_infeasible` to reuse `fbbt_box`, removing duplicated FBBT plumbing.
- **`bound_tightening` notebook** — documents the full FBBT → row-activity → DBBT → OBBT stack with `Puranik2017` / `McCormick1976` / `Tawarmalani2005` citations; added to `_toc.yml`. Every cell executes.

## Soundness

Every layer derives only *valid* bounds; `fbbt_box` intersects (never loosens), so the tightened box always contains the feasible region. Pinned by `test_tightening.py`:

- cross-row fixpoint (`a≥8`),
- infeasibility detection (empty interval),
- optimum-contained soundness,
- never-loosen + vector-variable handling,
- idempotence,
- no-constraint passthrough.

13 tests green (6 new + 7 conflict regression after the refactor). ruff + mypy clean.

## Test plan

```
pytest python/tests/test_tightening.py python/tests/test_conflict_cuts.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr)_