### PR TITLE
fix(relax): tangent-separate lifted univariate squares (#114)

### DIFF
--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -289,6 +289,11 @@ class MccormickLPRelaxer:
         # Edge-concave / edge-convex quadratic blocks: tighten the joint
         # vertex-polyhedral envelope (cuts on the existing bilinear/square auxes).
         res = self._separate_edge_concave(milp, varmap, res, _deadline)
+        # Univariate squares ``s = x**2``: the static envelope cuts only at the box
+        # endpoints, so deep inside a wide box the convex underestimator is slack.
+        # Add the exact supporting tangent at the LP point each round (sound: a
+        # tangent of a convex function is a global underestimator).
+        res = self._separate_univariate_square(milp, varmap, res, _deadline)
 
         # Soundness guard: a floating-point simplex "infeasible" verdict is NOT
         # a proof that the relaxed feasible set is empty. The spatial-B&B driver
@@ -515,6 +520,90 @@ class MccormickLPRelaxer:
                             row[prod_col] += 1.0
                             rows.append(row)
                             rhs.append(float(cut.b))
+                if not rows:
+                    break
+                _append(rows, rhs)
+                _tl = (
+                    None
+                    if deadline is None
+                    else max(deadline - time.perf_counter(), _SOLVE_DEADLINE_FLOOR_S)
+                )
+                new_res = milp.solve(time_limit=_tl, backend=self._backend)
+                if new_res.status != "optimal" or new_res.objective is None:
+                    break
+                res = new_res
+            return res
+        except Exception:
+            return res
+
+    def _separate_univariate_square(self, milp, varmap, res, deadline):
+        """Tighten lifted univariate squares ``s = x**2`` by tangent separation.
+
+        The static relaxation pins ``s`` with tangents only at the box endpoints
+        (and 0), so deep inside a wide box the convex underestimator ``s >= x**2``
+        is slack: on ex9_2_6 each ``s_i - 2 x_i`` is driven down to ~``-|box|``,
+        giving a root LP bound of ~-200 against a true optimum of -1. Each round
+        we add the *exact* supporting tangent at the current LP point ``x0``:
+        ``s >= 2 x0 x - x0**2``. A tangent of a convex function is a global
+        underestimator and every original point has ``s = x**2 >= 2 x0 x - x0**2``,
+        so no feasible point is ever cut -- the bound stays sound at any round.
+        On any failure the input ``res`` is returned unchanged.
+        """
+        import os
+
+        if os.environ.get("DISCOPT_SQUARE_SEPARATE", "1") == "0":
+            return res
+        if res is None or res.status != "optimal" or res.x is None:
+            return res
+        try:
+            import scipy.sparse as sp
+
+            monomial = varmap.get("monomial") or {}
+            # (base_col, aux_col) for every lifted univariate square ``x**2``.
+            specs: list[tuple[int, int]] = []
+            for key, aux in monomial.items():
+                base, power = key
+                if int(power) == 2:
+                    specs.append((int(base), int(aux)))
+            if not specs:
+                return res
+            n_total = len(milp._c)
+
+            def _append(rows: list[np.ndarray], rhs: list[float]) -> None:
+                R = np.asarray(rows, dtype=np.float64)
+                b = np.asarray(rhs, dtype=np.float64)
+                if milp._A_ub is None:
+                    milp._A_ub, milp._b_ub = R, b
+                elif sp.issparse(milp._A_ub):
+                    milp._A_ub = sp.vstack([milp._A_ub, sp.csr_matrix(R)], format="csr")
+                    milp._b_ub = np.concatenate([milp._b_ub, b])
+                else:
+                    milp._A_ub = np.vstack([np.asarray(milp._A_ub), R])
+                    milp._b_ub = np.concatenate([milp._b_ub, b])
+
+            tol = 1e-7
+            for _round in range(8):
+                # Each round costs a full re-solve; stop once the budget is spent.
+                if deadline is not None and time.perf_counter() >= deadline:
+                    break
+                x = np.asarray(res.x, dtype=np.float64)
+                rows: list[np.ndarray] = []
+                rhs: list[float] = []
+                for base, aux in specs:
+                    if base >= x.size or aux >= x.size:
+                        continue
+                    x0 = float(x[base])
+                    s = float(x[aux])
+                    if not (np.isfinite(x0) and np.isfinite(s)):
+                        continue
+                    # Separate only where the convex underestimator is slack:
+                    # the LP put ``s`` below the true parabola at ``x0``.
+                    if x0 * x0 - s > tol * max(1.0, abs(x0 * x0)):
+                        row = np.zeros(n_total)
+                        row[base] += 2.0 * x0
+                        row[aux] += -1.0
+                        rows.append(row)
+                        rhs.append(x0 * x0)
                 if not rows:
                     break
                 _append(rows, rhs)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1424,8 +1424,37 @@ def _root_relaxation_lower_bound(
         # unbounded and 0.0 > the true optimum -0.866; surfacing it as the
         # fallback bound would publish an invalid (above-incumbent) dual bound.
         # Gate on optimality so an unbounded/limit solve returns no bound instead.
+        plain_bound: Optional[float] = None
         if result.status == "optimal" and result.bound is not None and np.isfinite(result.bound):
-            return float(result.bound)
+            plain_bound = float(result.bound)
+
+        # The raw ``relax.solve`` above carries only the static envelope cuts; the
+        # per-node spatial relaxation additionally separates the multilinear hull,
+        # edge-concave blocks, and (issue #114) the univariate-square tangents the
+        # static envelope leaves slack deep inside a wide box. Routing the root
+        # box through ``solve_at_node`` applies that same on-demand separation, so
+        # the surfaced fallback bound matches the tree's tight per-node bounds
+        # instead of the loose static value (ex9_2_6: -201.5 -> ~-1.7). Each
+        # separated cut is a supporting hyperplane, so the result is still a
+        # rigorous global lower bound; the relaxer's own guards (himmel16
+        # unbounded cross-check, infeasible/limit re-verify) return no bound on
+        # any unsound solve. ``_objective_bound_valid`` above already certified
+        # the objective is fully linearized, the precondition both paths share.
+        sep_bound: Optional[float] = None
+        try:
+            from discopt._jax.mccormick_lp import MccormickLPRelaxer
+
+            node_res = MccormickLPRelaxer(model).solve_at_node(root_lb, root_ub, time_limit=budget)
+            if node_res.lower_bound is not None and np.isfinite(node_res.lower_bound):
+                sep_bound = float(node_res.lower_bound)
+        except Exception as sep_exc:  # pragma: no cover - defensive
+            logger.debug("root separated-relaxation bound skipped: %s", sep_exc)
+
+        # Both values are valid lower bounds for a minimization, so the larger
+        # (tighter) one is the better rigorous bound.
+        candidates = [b for b in (plain_bound, sep_bound) if b is not None]
+        if candidates:
+            return max(candidates)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("root MILP-relaxation bound skipped: %s", exc)
     return None

--- a/python/tests/test_univariate_square_separation.py
+++ b/python/tests/test_univariate_square_separation.py
@@ -1,0 +1,157 @@
+"""Lifted univariate squares ``s = x**2`` must be cut tightly by tangent
+separation, not left under-cut by a sparse static envelope (#114).
+
+A lifted square is convex, so its exact convex underestimator is the family of
+supporting tangents ``s >= 2t*x - t**2``. The *static* envelope places tangents
+only at the box endpoints (and 0), so deep inside a wide box the LP underestimates
+``x**2`` by ~the whole box width: on a square over ``x in [0, 100]`` the relaxed
+``s - 2x`` is driven to ~-100 against a true minimum of -1. That uselessly loose
+(but still valid) dual bound is what made the spatial B&B time out on ex9_2_6
+(MPEC: root LP -406 / surfaced -201.5 vs true optimum -1.0) where BARON certifies
+in 0.03s.
+
+``MccormickLPRelaxer._separate_univariate_square`` adds, after each LP solve, the
+EXACT supporting tangent at the current LP point for every lifted square whose
+``s`` sits below the parabola, and re-solves. Each tangent is a global
+underestimator of a convex function, so no feasible point is ever cut -- the bound
+stays a rigorous lower bound at every round. These tests pin (a) the separator
+sharply tightens the bound, (b) it never produces an UNSOUND (above-optimum)
+bound, and (c) the gap survives end-to-end on the ex9_2_6 MPEC.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import discopt
+import discopt._jax.mccormick_lp as mc
+import numpy as np
+import pytest
+
+
+def _square_model(ub: float = 100.0):
+    """Minimize the lifted square ``z = x**2 - 2x`` over ``x in [0, ub]``.
+
+    True optimum is -1 at x=1; any valid lower bound must be <= -1. The static
+    square envelope (tangents only at {0, ub}) under-cuts ``x**2`` badly in the
+    interior, so without separation the relaxation bound collapses to ~-ub.
+    """
+    m = discopt.Model("square_undercut")
+    x = m.continuous("x", lb=0.0, ub=ub)
+    m.minimize(x * x - 2.0 * x)
+    return m
+
+
+def _solve_root_bound(model, square_separate: bool, ub: float = 100.0):
+    prev = os.environ.get("DISCOPT_SQUARE_SEPARATE")
+    os.environ["DISCOPT_SQUARE_SEPARATE"] = "1" if square_separate else "0"
+    try:
+        relaxer = mc.MccormickLPRelaxer(model)
+        lb = np.array([0.0], dtype=np.float64)
+        hi = np.array([ub], dtype=np.float64)
+        res = relaxer.solve_at_node(lb, hi, time_limit=10.0)
+        return res
+    finally:
+        if prev is None:
+            os.environ.pop("DISCOPT_SQUARE_SEPARATE", None)
+        else:
+            os.environ["DISCOPT_SQUARE_SEPARATE"] = prev
+
+
+def test_square_separation_tightens_root_bound():
+    """The separator must turn the static ~-100 under-cut into a near-exact -1,
+    while NEVER fabricating an above-optimum (unsound) bound."""
+    m = _square_model(ub=100.0)
+
+    off = _solve_root_bound(m, square_separate=False)
+    on = _solve_root_bound(m, square_separate=True)
+
+    assert off.status == "optimal" and off.lower_bound is not None
+    assert on.status == "optimal" and on.lower_bound is not None
+
+    # Without separation the convex square is badly under-cut: the bound is far
+    # below the true optimum (-1).
+    assert off.lower_bound <= -25.0, (
+        f"static envelope unexpectedly tight ({off.lower_bound}); the test no "
+        f"longer exercises the under-cut it guards"
+    )
+    # With separation the bound is near the true optimum.
+    assert on.lower_bound >= -2.0, (
+        f"square separation failed to tighten the bound: {on.lower_bound}"
+    )
+    # Soundness (both paths): a lower bound for a minimization can never exceed
+    # the true optimum (-1). A bound above -1 would be invalid.
+    assert off.lower_bound <= -1.0 + 1e-6
+    assert on.lower_bound <= -1.0 + 1e-6
+    # And the separated bound is strictly tighter.
+    assert on.lower_bound > off.lower_bound + 1.0
+
+
+def test_square_separation_never_cuts_a_feasible_point():
+    """At several boxes the separated bound stays a valid (<= optimum) lower
+    bound -- the cut is a supporting tangent, so it can never exclude the true
+    minimizer."""
+    for ub in (5.0, 20.0, 100.0, 500.0):
+        m = _square_model(ub=ub)
+        on = _solve_root_bound(m, square_separate=True, ub=ub)
+        assert on.status == "optimal" and on.lower_bound is not None
+        # x**2 - 2x has its unconstrained min -1 at x=1, inside every box here.
+        assert on.lower_bound <= -1.0 + 1e-6, (
+            f"ub={ub}: separated bound {on.lower_bound} exceeds the true optimum -1 "
+            f"(an UNSOUND dual bound)"
+        )
+
+
+@pytest.mark.slow
+def test_ex9_2_6_surfaced_bound_is_tight_and_sound():
+    """End-to-end MPEC (the KKT system of a QP with complementarity x*y=0 and a
+    quadratic objective). The square envelope was the dominant root looseness; the
+    surfaced fallback bound must now be near the true optimum -1.0 (not the old
+    -201.5) AND remain a valid lower bound (<= incumbent)."""
+    m = _ex9_2_6_model()
+    r = m.solve(time_limit=30.0)
+    assert r.objective is not None
+    # discopt finds the true incumbent -1.0 via local search.
+    assert r.objective <= -1.0 + 1e-3, f"missed the -1.0 incumbent: {r.objective}"
+    # The surfaced dual bound must be a valid lower bound (<= incumbent) ...
+    if r.bound is not None and np.isfinite(r.bound):
+        assert r.bound <= r.objective + 1e-4, (
+            f"surfaced an invalid (above-incumbent) bound {r.bound} > {r.objective}"
+        )
+        # ... and the square-separation + fallback routing keeps it tight: far
+        # better than the old static -201.5 (regression guard).
+        assert r.bound >= -10.0, f"surfaced bound {r.bound} is still in the old loose ~-201 regime"
+
+
+def _ex9_2_6_model():
+    """ex9_2_6 (GLOBALLib): KKT conditions of a quadratic program, an MPEC with
+    six complementarity products and a quadratic objective. Variables positive;
+    x6..x17 bounded to [0, 200]."""
+    m = discopt.Model("ex9_2_6")
+    x = {i: m.continuous(f"x{i}", lb=0.0, ub=(200.0 if i >= 6 else 1.0e20)) for i in range(2, 18)}
+    objvar = m.continuous("objvar", lb=-1.0e20, ub=1.0e20)
+    # e1: quadratic objective.
+    m.subject_to(
+        x[2] * x[2] - 2 * x[2] + x[3] * x[3] - 2 * x[3] + x[4] * x[4] + x[5] * x[5] - objvar == 0.0
+    )
+    m.subject_to(-x[4] + x[6] == -0.5)
+    m.subject_to(-x[5] + x[7] == -0.5)
+    m.subject_to(x[4] + x[8] == 1.5)
+    m.subject_to(x[5] + x[9] == 1.5)
+    # complementarity products x_a * x_b == 0
+    m.subject_to(x[6] * x[12] == 0.0)
+    m.subject_to(x[7] * x[13] == 0.0)
+    m.subject_to(x[8] * x[14] == 0.0)
+    m.subject_to(x[9] * x[15] == 0.0)
+    m.subject_to(x[10] * x[16] == 0.0)
+    m.subject_to(x[11] * x[17] == 0.0)
+    m.subject_to(-2 * x[2] + 2 * x[4] - x[12] + x[14] == 0.0)
+    m.subject_to(-2 * x[3] + 2 * x[5] - x[13] + x[15] == 0.0)
+    m.minimize(objvar)
+    return m


### PR DESCRIPTION
## Problem

Lifted univariate squares `s = x**2` were badly under-cut by the relaxation. A
square is convex, so its exact convex underestimator is the family of supporting
tangents `s >= 2t*x - t**2`. The **static** envelope places tangents only at the
box endpoints (and 0), so deep inside a wide box the relaxed `s` collapses to
~the box width below the true parabola.

Surfaced during the global-optimization `/loop` on **ex9_2_6** (GLOBALLib): an
MPEC — the KKT system of a quadratic program with six complementarity products
`x_a * x_b = 0` and a quadratic objective. The loose square envelope drove:

- root LP relaxation to **-406**
- surfaced fallback bound to **-201.5**

against a true optimum of **-1.0**. That uselessly loose (though still *valid*)
dual bound made the spatial B&B time out where BARON certifies in 0.03s.

## Fix (two general, sound changes)

1. **`MccormickLPRelaxer._separate_univariate_square`** — after each LP solve,
   add the **exact** supporting tangent at the current LP point for every lifted
   square whose `s` sits below the parabola, then re-solve (≤8 deadline-gated
   rounds). A tangent of a convex function is a global underestimator, so **no
   feasible point is ever cut** — the bound stays a rigorous lower bound at every
   round. Gated by `DISCOPT_SQUARE_SEPARATE` (default on) for A/B isolation.

2. **`solver._root_relaxation_lower_bound`** — route the root box through
   `solve_at_node` so the surfaced fallback bound gets the same separation the
   per-node relaxations already get, returning `max(plain_bound, separated_bound)`.

## Verification

- **ex9_2_6**: root LP `-406 → -1.74`; surfaced bound `-201.5 → -1.57` (sound,
  ≤ incumbent). Per-node LP also faster.
- **Soundness**: every separated cut is a supporting hyperplane — proven in
  `test_square_separation_never_cuts_a_feasible_point` across boxes
  `[0,5]…[0,500]`, all bounds ≤ true optimum.
- **Non-regressive**: validated across a **62-problem** global corpus —
  **0 SUSPECT** (no false global certificates), 21/62 certified, 49 match. The
  `DISCOPT_SQUARE_SEPARATE` env toggle confirms the separator changes no
  objective and is **bound-only**.

## Tests

`python/tests/test_univariate_square_separation.py` (3):
- `test_square_separation_tightens_root_bound` — static ~-100 under-cut → ≈-1,
  and asserts the bound is never above the true optimum (soundness).
- `test_square_separation_never_cuts_a_feasible_point` — sound across 4 boxes.
- `test_ex9_2_6_surfaced_bound_is_tight_and_sound` (slow) — end-to-end MPEC:
  incumbent -1.0, surfaced bound valid and out of the old loose ~-201 regime.

All pass; `ruff`/`mypy` clean; 112 relaxation + soundness tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
