### PR TITLE
fix(amp): keep wrongly-omitted constraints in the MILP relaxation

### DIFF
--- a/crates/discopt-core/src/amp.rs
+++ b/crates/discopt-core/src/amp.rs
@@ -283,6 +283,15 @@ impl<'a> TermClassifier<'a> {
                     && self.collect_product_factors_inner(*right, out)
             }
             ExprNode::Constant(_) => true,
+            // Unary negation is just a sign on a scalar factor, never a variable
+            // factor — make it transparent.  A leading negative coefficient such
+            // as ``-c*x*y`` parses as ``((neg(c) * x) * y)``; without this the
+            // whole product term is rejected and silently dropped from
+            // classification (then omitted from the MILP relaxation).
+            ExprNode::UnaryOp {
+                op: UnOp::Neg,
+                operand,
+            } => self.collect_product_factors_inner(*operand, out),
             _ => {
                 if let Some(flat) = self.flat_index(id) {
                     out.push(flat);
@@ -407,6 +416,64 @@ mod tests {
         assert_eq!(terms.term_incidence.get(&0).unwrap().len(), 2);
         assert_eq!(terms.term_incidence.get(&1).unwrap().len(), 1);
         assert_eq!(terms.term_incidence.get(&2).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn negated_constant_product_classifies_as_bilinear() {
+        // A leading negative coefficient ``-c*x0*x1`` parses as
+        // ``((neg(c) * x0) * x1)``.  The ``neg`` over the scalar must be
+        // transparent to the product-factor walker, otherwise the whole term is
+        // rejected and the constraint is dropped from the relaxation (st_e40).
+        let mut arena = ExprArena::new();
+        let x = arena.add(ExprNode::Variable {
+            name: "x".to_string(),
+            index: 0,
+            size: 2,
+            shape: vec![2],
+        });
+        let x0 = arena.add(ExprNode::Index {
+            base: x,
+            index: IndexSpec::Scalar(0),
+        });
+        let x1 = arena.add(ExprNode::Index {
+            base: x,
+            index: IndexSpec::Scalar(1),
+        });
+        let c = arena.add(ExprNode::Constant(0.15));
+        let neg_c = arena.add(ExprNode::UnaryOp {
+            op: UnOp::Neg,
+            operand: c,
+        });
+        let neg_c_x0 = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Mul,
+            left: neg_c,
+            right: x0,
+        });
+        let objective = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Mul,
+            left: neg_c_x0,
+            right: x1,
+        });
+
+        let model = ModelRepr {
+            arena,
+            objective,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![],
+            variables: vec![VarInfo {
+                name: "x".to_string(),
+                var_type: VarType::Continuous,
+                offset: 0,
+                size: 2,
+                shape: vec![2],
+                lb: vec![0.0; 2],
+                ub: vec![10.0; 2],
+            }],
+            n_vars: 2,
+        };
+
+        let terms = classify_nonlinear_terms(&model);
+        assert_eq!(terms.bilinear, vec![(0, 1)]);
     }
 
     #[test]

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3610,8 +3610,32 @@ def build_milp_relaxation(
             for var_idx, power in Counter(monomial).items():
                 if power >= 2:
                     affine_square_monomials.add((var_idx, power))
+    # ── Multi-factor univariate products in CONSTRAINTS (st_e40) ────────────
+    # A constraint such as ``(i-1)*(i-2)*...*(i-12) == 0`` (st_e40's degree-7
+    # set-membership polynomials forcing ``i in {1,2,3,5,8,10,12}``) exposes its
+    # monomials ``i**2 .. i**7`` only AFTER distribution. The objective is
+    # already distributed before monomial collection (above), but constraints
+    # were not — so those monomials were never registered, the linearizer raised
+    # ``"Monomial (i, k) not in map"`` and DROPPED THE WHOLE CONSTRAINT from the
+    # relaxation. The result was a uselessly loose dual bound (st_e40: root bound
+    # 4.41 against a true optimum of 30.41, so the spatial B&B never prunes).
+    # Collecting them here registers the aux columns + rigorous monomial power
+    # envelopes so the constraint is KEPT. Sound: re-including a previously
+    # dropped constraint only shrinks the relaxed feasible set toward the true
+    # one, so the bound can only rise toward (never above) the optimum.
+    constraint_lift_monomials: set[tuple[int, int]] = set()
+    for _con in model._constraints:
+        try:
+            constraint_lift_monomials.update(
+                _collect_monomial_terms_for_lift(distribute_products(_con.body), model)
+            )
+        except Exception:  # pragma: no cover - defensive: never break the build
+            continue
     monomial_terms = sorted(
-        set(terms.monomial) | objective_lift_monomials | affine_square_monomials
+        set(terms.monomial)
+        | objective_lift_monomials
+        | affine_square_monomials
+        | constraint_lift_monomials
     )
 
     def _record_generation_guardrail(

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -216,6 +216,12 @@ def _collect_product_factors(expr: Expression, model: Model) -> list[int] | None
     def _visit(e: Expression) -> bool:
         if isinstance(e, BinaryOp) and e.op == "*":
             return _visit(e.left) and _visit(e.right)
+        # Unary negation is just a sign on a scalar factor, never a variable
+        # factor — make it transparent.  A leading negative coefficient such as
+        # ``-c*x*y`` parses as ``((neg(Constant(c)) * x) * y)``; without this the
+        # whole product term is rejected and silently dropped from classification.
+        if isinstance(e, UnaryOp) and e.op == "neg":
+            return _visit(e.operand)
         flat = _get_flat_index(e, model)
         if flat is not None:
             indices.append(flat)
@@ -331,6 +337,11 @@ def _collect_extended_factors(
             return _visit(e.left) and _visit(e.right)
         if isinstance(e, Constant):
             return True
+        # Unary negation is just a sign on a scalar factor (see
+        # ``_collect_product_factors``); make it transparent so a leading
+        # negative coefficient does not drop the whole product term.
+        if isinstance(e, UnaryOp) and e.op == "neg":
+            return _visit(e.operand)
         flat = _get_flat_index(e, model)
         if flat is not None:
             flat_factors.append(flat)

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -394,6 +394,73 @@ def test_issue90_unbounded_square_constraint_linearizes_with_lifted_aux(caplog):
     assert "omitting constraint" not in caplog.text
 
 
+def test_negated_constant_product_classifies_as_bilinear_both_paths():
+    """A leading negative coefficient ``-c*x*y`` must still classify as bilinear.
+
+    The term parses as ``((neg(c) * x) * y)`` with a ``UnaryOp('neg')`` wrapping
+    the scalar.  The product-factor walkers (Rust and Python) must treat ``neg``
+    as transparent — a sign on a scalar, never a variable factor — otherwise the
+    whole term is rejected and the constraint is silently dropped from the MILP
+    relaxation, leaving a uselessly loose bound (st_e40 regression).
+    """
+    from discopt._jax.term_classifier import (
+        _classify_nonlinear_terms_python,
+        _classify_nonlinear_terms_rust,
+        classify_nonlinear_terms,
+    )
+
+    m = Model("neg_const_bilinear")
+    x = m.continuous("x", lb=0.0, ub=5.0, shape=(2,))
+    m.minimize(x[0] + x[1])
+    m.subject_to(-0.15 * x[0] * x[1] >= -1.0)
+
+    # Default dispatch (Rust fast path for this product-only model).
+    assert (0, 1) in classify_nonlinear_terms(m).bilinear
+    # Both backends must agree.
+    rust_terms = _classify_nonlinear_terms_rust(m)
+    assert rust_terms is not None
+    assert (0, 1) in rust_terms.bilinear
+    assert (0, 1) in _classify_nonlinear_terms_python(m).bilinear
+
+
+def test_negated_constant_product_constraint_not_omitted(caplog):
+    """The ``-c*x*y`` constraint must survive into the MILP relaxation."""
+    m = Model("neg_const_bilinear_relax")
+    x = m.continuous("x", lb=0.0, ub=5.0, shape=(2,))
+    m.minimize(x[0] + x[1])
+    m.subject_to(-0.15 * x[0] * x[1] >= -1.0)
+
+    with caplog.at_level("WARNING", logger="discopt._jax.milp_relaxation"):
+        milp_model, varmap = _build_relaxation_for_test(m)
+        milp_model.solve()
+
+    assert (0, 1) in set(varmap["bilinear"])
+    assert "omitting constraint" not in caplog.text
+    assert "Bilinear (0, 1) not in map" not in caplog.text
+
+
+def test_distributed_univariate_constraint_monomials_registered(caplog):
+    """High-degree univariate products in a constraint must register their monomials.
+
+    A constraint such as ``(i-1)*(i-2)*...*(i-4) == 0`` exposes its monomials
+    ``i**2..i**4`` only after distribution.  The objective is distributed before
+    monomial collection, but constraints were not — so these monomials went
+    unregistered and the constraint was dropped from the relaxation (st_e40
+    e6/e7/e8 regression).
+    """
+    m = Model("distributed_univariate_constraint")
+    i = m.integer("i", lb=1, ub=4)
+    m.minimize(i)
+    m.subject_to((i - 1) * (i - 2) * (i - 3) * (i - 4) == 0.0)
+
+    with caplog.at_level("WARNING", logger="discopt._jax.milp_relaxation"):
+        milp_model, varmap = _build_relaxation_for_test(m)
+        milp_model.solve()
+
+    assert {(0, 2), (0, 3), (0, 4)} <= set(varmap["monomial"])
+    assert "omitting constraint" not in caplog.text
+
+
 @pytest.mark.memory_heavy
 def test_amp_reports_shifted_square_minlptests_case_infeasible():
     """Regression for MINLPTests nlp_mi_007_020."""


### PR DESCRIPTION
## Summary

The per-node MILP relaxation was **silently dropping genuine constraints**
whose monomial/bilinear aux columns were never registered, leaving uselessly
loose dual bounds. On `st_e40` this gave a root bound of **4.41 against a true
optimum of 30.41** (brute-forced over the discrete combos; BARON agrees), so the
spatial B&B never prunes and the run never certifies. Not a SUSPECT — the bound
stayed sound, just useless.

Two distinct registration gaps caused four of `st_e40`'s nine constraints to be
omitted:

### Bug A — monomial-registration asymmetry (`e6`/`e7`/`e8` dropped)
Univariate high-degree constraints like `(i-1)*(i-2)*...*(i-12) == 0` (the
degree-7 set-membership polynomials pinning each integer to `{1,2,3,5,8,10,12}`)
expose their monomials `i**2..i**7` only **after distribution**. The objective
was `distribute_products()`'d before monomial collection, but constraints were
not — so those monomials went unregistered, the linearizer raised
`"Monomial (k, n) not in map"`, and the whole constraint was dropped.

**Fix:** collect constraint monomials over `distribute_products(con.body)` and
union them into the lift set, mirroring the objective.

### Bug B — neg-on-constant blindness in the product-factor walkers (`e1` dropped)
`e1`'s term `-0.15*i1*i2` parses as `((neg(Constant(0.15)) * i1) * i2)`. The
product-factor walkers had no case for `UnaryOp('neg')`, so they rejected the
whole product → the bilinear `(i1,i2)` was never classified →
`"Bilinear (0,1) not in map"` → constraint dropped. Affects **any** product with
a leading negative coefficient `-c*x*y`. `st_e40` dispatches to the **Rust**
classifier, so the fix spans both the Python walkers
(`_collect_product_factors`, `_collect_extended_factors`) and the Rust
`collect_product_factors_inner`. Negation is only a sign on a scalar, never a
variable factor, so `neg` is made transparent in all three.

## Why this is sound (cannot create a false certification)

Both fixes only **re-include genuine model constraints / aux columns** that were
being wrongly omitted. Adding a true constraint to a relaxation can only shrink
the relaxed feasible set toward the true one, so the dual bound can only rise
**toward** (never above) the optimum. It is provably impossible for either fix to
turn a valid bound into a SUSPECT.

## Result

| metric (st_e40) | before | after |
|---|---|---|
| omitted constraints | 4 | **0** |
| root/dual bound | 4.41 | **22.24** |
| incumbent | 43.31 | **31.07** (true 30.41) |

The residual primal gap (31.07 vs 30.41, still uncertified at 600 s / 8643 nodes)
is a separate, slower-convergence branching weakness on this hard all-discrete
problem — not an omission or soundness bug.

## Tests
- `python/tests/test_amp.py`: `test_negated_constant_product_classifies_as_bilinear_both_paths` (Rust + Python), `test_negated_constant_product_constraint_not_omitted`, `test_distributed_univariate_constraint_monomials_registered`
- `crates/discopt-core/src/amp.rs`: `negated_constant_product_classifies_as_bilinear`
- 629 classifier/relaxation + 485 soundness tests pass; 8 Rust amp unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
