### PR TITLE
feat(relax): constant lower bound for reciprocal-of-positive-quadratic objectives

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -2574,45 +2574,104 @@ def _polynomial_lower_bound(
     return min(values)
 
 
+def _reciprocal_term_lower_bound(
+    scaled_numerator: float,
+    denominator: Expression,
+    model: Model,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> Optional[float]:
+    """Rigorous constant lower bound for ``scaled_numerator / denominator(x)``.
+
+    Encloses ``denominator`` over the box via the same separable-polynomial
+    machinery used for objective lifts (``_expression_lower_bound_for_lift`` /
+    ``_expression_upper_bound_for_lift``), which recovers ``D_lo``/``D_hi`` from a
+    distributed quadratic by per-variable vertex minimization — crucially, this
+    works on the live solve's already-distributed denominator (e.g. ``0.1 +
+    x0**2 - 8*x0 + 16 + ...``) where a naive interval evaluation of ``x*x`` on an
+    unbounded box would collapse to ``[-inf, inf]``. When the enclosure is
+    strictly positive (``D_lo > 0``), ``1/D`` is decreasing in ``D`` so the term
+    ``k/D`` is minimized at ``D_hi`` when ``k > 0`` and at ``D_lo`` when
+    ``k < 0``. Returns ``None`` (caller abstains) if the denominator cannot be
+    proven strictly positive or the bound is not finite.
+    """
+    if abs(scaled_numerator) <= 1e-12:
+        return 0.0
+    denom_lo = _expression_lower_bound_for_lift(denominator, model, flat_lb, flat_ub)
+    denom_hi = _expression_upper_bound_for_lift(denominator, model, flat_lb, flat_ub)
+    # A strictly-positive, finite lower end is required for a sound reciprocal;
+    # _expression_lower_bound_for_lift returns None when it cannot prove one.
+    if denom_lo is None or not np.isfinite(denom_lo) or denom_lo <= 1e-12:
+        return None
+    if scaled_numerator > 0.0:
+        # k/D minimized at the largest D; an unbounded/unknown D_hi drives the
+        # positive term toward 0 from above, which is still a valid lower bound.
+        bound = (
+            0.0
+            if (denom_hi is None or not np.isfinite(denom_hi))
+            else (scaled_numerator / denom_hi)
+        )
+    else:
+        bound = scaled_numerator / denom_lo
+    if not np.isfinite(bound):
+        return None
+    return float(bound)
+
+
 def _separable_objective_lower_bound(
     expr: Expression,
     model: Model,
     flat_lb: np.ndarray,
     flat_ub: np.ndarray,
 ) -> Optional[float]:
-    """Compute a conservative constant lower bound for simple separable objectives."""
+    """Compute a conservative constant lower bound for simple separable objectives.
+
+    ``expr`` is flattened additively and matched term-by-term.  Reciprocal terms
+    ``k / D(x)`` are matched on the term's ORIGINAL (un-distributed) structure so
+    the denominator's square/power shape survives for a sound interval enclosure;
+    every other term is distributed individually before the polynomial / affine
+    matchers run (the union over terms equals distributing the whole expression,
+    so non-reciprocal behavior is unchanged).
+    """
     terms: list[tuple[float, Expression]] = []
     _flatten_additive_terms(expr, 1.0, terms)
 
     total = 0.0
     polynomial_terms: dict[int, dict[int, float]] = {}
-    for scale, term in terms:
+
+    def _accumulate_simple_term(scale: float, term: Expression) -> bool:
+        """Fold one already-distributed, non-reciprocal term into the running bound.
+
+        Returns ``False`` (caller abstains entirely) when the term is not one of
+        the recognized separable shapes.
+        """
+        nonlocal total
         if abs(scale) <= 1e-12:
-            continue
+            return True
         const = _constant_value(term)
         if const is not None:
             total += scale * const
-            continue
+            return True
 
         x_exp = _match_x_exp_product(term, model)
         if x_exp is not None:
             scalar, var_idx = x_exp
             term_scale = scale * scalar
             if abs(term_scale) <= 1e-12:
-                continue
+                return True
             if term_scale > 0.0:
                 total += term_scale * (-1.0 / np.e)
-                continue
+                return True
             upper = _x_exp_upper_bound(var_idx, flat_lb, flat_ub)
             if upper is None:
-                return None
+                return False
             total += term_scale * upper
-            continue
+            return True
 
         if _is_cos_call(term):
             integer_lb = _integer_affine_cos_lower_bound(term, scale, model, flat_lb, flat_ub)
             total += integer_lb if integer_lb is not None else -abs(scale)
-            continue
+            return True
 
         monomial = _match_scaled_monomial(term, model)
         if monomial is not None:
@@ -2621,12 +2680,44 @@ def _separable_objective_lower_bound(
             polynomial_terms[var_idx][power] = (
                 polynomial_terms[var_idx].get(power, 0.0) + scale * scalar
             )
-            continue
+            return True
 
         affine_bound = _scaled_affine_lower_bound(term, scale, model, flat_lb, flat_ub)
         if affine_bound is None:
-            return None
+            return False
         total += affine_bound
+        return True
+
+    for scale, term in terms:
+        if abs(scale) <= 1e-12:
+            continue
+
+        # Reciprocal term ``k / D(x)`` with a strictly-positive denominator (e.g.
+        # ex8_1_6's ``-1/(0.1 + (x0-4)**2 + (x1-4)**2)``). The MILP linearizer
+        # cannot relax a non-constant division, so without this the whole
+        # objective is dropped and AMP can never certify. A rigorous interval
+        # enclosure ``D in [D_lo, D_hi]`` with ``D_lo > 0`` yields a valid
+        # constant lower bound for the term: ``k/D_hi`` when ``k > 0`` else
+        # ``k/D_lo`` (``1/D`` is decreasing in ``D``). The bound tightens as B&B
+        # branching shrinks the box, eventually enabling certification. Matched
+        # on the un-distributed term so ``D``'s ``(x-a)**2`` shape survives for a
+        # tight interval enclosure (distribution would expand it to a polynomial
+        # whose naive interval enclosure is uselessly loose on a wide box).
+        recip = _match_scaled_constant_division(term, scale)
+        if recip is not None:
+            recip_bound = _reciprocal_term_lower_bound(recip[0], recip[1], model, flat_lb, flat_ub)
+            if recip_bound is None:
+                return None
+            total += recip_bound
+            continue
+
+        # Distribute this single term and fold each resulting sub-term through the
+        # simple-shape matchers (polynomial path needs the expanded form).
+        sub_terms: list[tuple[float, Expression]] = []
+        _flatten_additive_terms(distribute_products(term), scale, sub_terms)
+        for sub_scale, sub_term in sub_terms:
+            if not _accumulate_simple_term(sub_scale, sub_term):
+                return None
 
     for var_idx, coeffs in polynomial_terms.items():
         lower = _polynomial_lower_bound(coeffs, float(flat_lb[var_idx]), float(flat_ub[var_idx]))
@@ -6525,7 +6616,13 @@ def build_milp_relaxation(
     except ValueError as err:
         fallback_lb = None
         if model._objective.sense == ObjectiveSense.MINIMIZE:
-            fallback_lb = _separable_objective_lower_bound(obj_expr, model, flat_lb, flat_ub)
+            # Pass the ORIGINAL (un-distributed) objective: the separable bound
+            # matches reciprocal terms on their native ``k/D(x)`` shape so the
+            # denominator's ``(x-a)**2`` structure survives for a tight interval
+            # enclosure (it distributes the non-reciprocal terms itself).
+            fallback_lb = _separable_objective_lower_bound(
+                model._objective.expression, model, flat_lb, flat_ub
+            )
         if fallback_lb is not None:
             c_obj = np.zeros(n_total)
             const_obj = float(fallback_lb)

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -461,6 +461,40 @@ def test_distributed_univariate_constraint_monomials_registered(caplog):
     assert "omitting constraint" not in caplog.text
 
 
+def test_reciprocal_of_positive_quadratic_objective_lower_bound():
+    """``min -1/(0.1+(x0-4)**2+(x1-4)**2)`` must get a finite, sound lower bound.
+
+    The MILP linearizer cannot relax a non-constant division, so the whole
+    objective is dropped and AMP would abstain (``bound=None``, can never
+    certify — the ex8_1_6 capability gap).  The separable fallback recognizes the
+    reciprocal term and bounds the denominator via the polynomial-vertex
+    machinery, which works even on the live solve's already-DISTRIBUTED
+    denominator ``0.1 + x0**2 - 8*x0 + 16 + ...`` (a naive interval evaluation of
+    ``x*x`` on a wide box collapses to ``[-inf, inf]``).  ``1/D`` is decreasing in
+    ``D`` so for ``k<0`` the term floor is ``k/D_lo``; the bound must never exceed
+    the true optimum.
+    """
+    from discopt._jax.milp_relaxation import _separable_objective_lower_bound
+    from discopt._jax.term_classifier import distribute_products
+
+    m = Model("reciprocal_quadratic")
+    x = m.continuous("x", lb=0.0, ub=8.0, shape=(2,))
+    m.minimize(-1.0 / (0.1 + (x[0] - 4.0) ** 2 + (x[1] - 4.0) ** 2))
+
+    flat_lb = np.array([0.0, 0.0])
+    flat_ub = np.array([8.0, 8.0])
+
+    # Match the live solve, whose objective arrives already distributed.
+    distributed = distribute_products(m._objective.expression)
+    bound = _separable_objective_lower_bound(distributed, m, flat_lb, flat_ub)
+
+    assert bound is not None
+    assert np.isfinite(bound)
+    # True optimum is -10 (denominator floor 0.1 at x=(4,4), inside the box).
+    # A valid lower bound for minimization must not exceed it.
+    assert bound <= -10.0 + 1e-6
+
+
 @pytest.mark.memory_heavy
 def test_amp_reports_shifted_square_minlptests_case_infeasible():
     """Regression for MINLPTests nlp_mi_007_020."""


### PR DESCRIPTION
## Summary

ex8_1_6 from the globallib global-optimization corpus minimizes
`-1/(0.1+(x0-4)**2+(x1-4)**2)`. discopt finds the optimum (-10.086, matching
BARON/published) but reports `bound=None` and `cert=False` — it can **never**
certify global optimality, no matter how long it runs.

This is a **capability gap, not a soundness bug**: discopt honestly abstains
(no false certification — not a SUSPECT) rather than fabricating a bound. The
MILP relaxation has no linearization for a division with a non-constant
denominator, so it drops the *entire* objective → no dual lower bound.

## Fix

Teach the separable-objective fallback (`_separable_objective_lower_bound`) to
recognize a reciprocal term `k/D(x)` and bound it via a new helper
`_reciprocal_term_lower_bound`. The denominator is enclosed with the same
separable-polynomial machinery used for objective lifts
(`_expression_lower_bound_for_lift` / `_expression_upper_bound_for_lift`),
which recovers `D_lo`/`D_hi` from a **distributed** quadratic by per-variable
vertex minimization (`x**2 - 8x ≥ -16` at `x=4`).

This detail is essential: inside the live solve the objective arrives already
distributed (denominator `0.1 + x0**2 - 8*x0 + 16 + ...`), where a naive
interval evaluation of `x*x` on a wide/unbounded box collapses to `[-inf, inf]`.
With a strictly-positive enclosure `D ∈ [D_lo, D_hi]`, `1/D` is decreasing in
`D`, so the term floor is `k/D_hi` when `k>0` and `k/D_lo` when `k<0`; a bound
is produced only when `D_lo > 0` is rigorously proven (else abstain).

`_separable_objective_lower_bound` now matches reciprocals on each term's
original shape first and otherwise distributes that single term and folds its
sub-terms through the existing const/`x*exp`/cos/monomial/affine matchers — the
union over terms equals distributing the whole expression, so the
non-reciprocal path is unchanged.

## Soundness

A bound is produced **only** when `D_lo > 0` is rigorously proven via the
already-trusted lift enclosure, and `k/D_hi` (`k<0`: `k/D_lo`) is a true lower
bound of `k/D` on that enclosure. It adds a valid dual bound where there was
none and never tightens past the true optimum.

## Result

- ex8_1_6: bound `None → -20.0` (sound: `-20 ≤ -10.086`); still finds
  -10.086; still `cert=False` at root (gap open) but the bound now **tightens
  as B&B shrinks the box**, so certification becomes reachable.
- iter7 re-run (ex7_2_1, ex3_1_1, ex5_2_2_case1, ex8_1_6, himmel11): all 5
  objectives match BARON/published, **0 SUSPECT**.
- No regressions: amp suite 128 pass; division/reciprocal/cert/unbounded/
  theorems 124 pass; separable/alphabb/p1-bb/fp/bucket2/constant-fold 41 pass.

## Test

`python/tests/test_amp.py::test_reciprocal_of_positive_quadratic_objective_lower_bound`
asserts a finite, sound lower bound on the **distributed** denominator
(`≤` true optimum -10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
