### PR TITLE
Add dense moment (PSD) cuts and per-node separation (W2d, W2e)

### DIFF
--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -169,12 +169,21 @@ class MccormickLPRelaxer:
     """
 
     def __init__(
-        self, model: Model, *, superposition: bool = False, backend: str = "simplex"
+        self,
+        model: Model,
+        *,
+        superposition: bool = False,
+        backend: str = "simplex",
+        psd_cuts: bool = False,
     ) -> None:
         self._model = model
         self._terms: NonlinearTerms = classify_nonlinear_terms(model)
         # Opt-in M8 superposition cuts for bilinear-of-nonlinear products.
         self._superposition = superposition
+        # Opt-in per-node PSD (moment) cut separation (W2e): enforce the lifted
+        # moment matrix M = [[1, x^T],[x, X]] >= 0 by separating dense clique cuts
+        # at each node, tightening the bound toward the SDP relaxation.
+        self._psd_cuts = psd_cuts
         # LP backend for the per-node relaxation solve: "simplex" routes to the
         # pure-Rust warm-started simplex (no JAX in the spatial-B&B relaxation
         # path); "auto" keeps HiGHS->POUNCE. Falls back automatically if the
@@ -438,6 +447,10 @@ class MccormickLPRelaxer:
         # Add the exact supporting tangent at the LP point each round (sound: a
         # tangent of a convex function is a global underestimator).
         res = self._separate_univariate_square(milp, varmap, res, _deadline)
+        # PSD (moment) cuts: enforce M = [[1,x^T],[x,X]] >= 0 over fully-lifted
+        # cliques. Each cut v^T M v >= 0 is a supporting hyperplane valid for every
+        # feasible point (X = x x^T), so adding them only tightens the bound.
+        res = self._separate_psd(milp, varmap, res, _deadline)
 
         # Soundness guard: a floating-point simplex "infeasible" verdict is NOT
         # a proof that the relaxed feasible set is empty. The spatial-B&B driver
@@ -822,6 +835,61 @@ class MccormickLPRelaxer:
                 if not rows:
                     break
                 _append(rows, rhs)
+                _tl = (
+                    None
+                    if deadline is None
+                    else max(deadline - time.perf_counter(), _SOLVE_DEADLINE_FLOOR_S)
+                )
+                new_res = milp.solve(time_limit=_tl, backend=self._backend)
+                if new_res.status != "optimal" or new_res.objective is None:
+                    break
+                res = new_res
+            return res
+        except Exception:
+            return res
+
+    def _separate_psd(self, milp, varmap, res, deadline):
+        """Separate moment (PSD) cuts on the lifted relaxation at the LP point.
+
+        Enforces ``M = [[1, x^T], [x, X]] >= 0`` over cliques of variables whose
+        pairwise products and squares are all lifted. Each separated cut
+        ``v^T M v >= 0`` is valid for every feasible point (``X = x x^T`` makes
+        ``M`` rank-1 PSD), so the bound only tightens; on any failure the input
+        ``res`` is returned unchanged. Off unless ``psd_cuts=True``.
+        """
+        if not self._psd_cuts:
+            return res
+        if res is None or res.status != "optimal" or res.x is None:
+            return res
+        try:
+            import scipy.sparse as sp
+
+            from discopt._jax.psd_cuts import separate_psd_cuts_on_relaxation
+
+            n_total = len(milp._c)
+
+            def _append(rows: list[np.ndarray], rhs: list[float]) -> None:
+                R = np.asarray(rows, dtype=np.float64)
+                b = np.asarray(rhs, dtype=np.float64)
+                if milp._A_ub is None:
+                    milp._A_ub, milp._b_ub = R, b
+                elif sp.issparse(milp._A_ub):
+                    milp._A_ub = sp.vstack([milp._A_ub, sp.csr_matrix(R)], format="csr")
+                    milp._b_ub = np.concatenate([milp._b_ub, b])
+                else:
+                    milp._A_ub = np.vstack([np.asarray(milp._A_ub), R])
+                    milp._b_ub = np.concatenate([milp._b_ub, b])
+
+            for _round in range(8):
+                if deadline is not None and time.perf_counter() >= deadline:
+                    break
+                cuts = separate_psd_cuts_on_relaxation(
+                    varmap, np.asarray(res.x, dtype=np.float64), n_total
+                )
+                if not cuts:
+                    break
+                # ``coeffs . z >= rhs``  ->  ``(-coeffs) . z <= -rhs`` for A_ub<=b_ub.
+                _append([-c.coeffs for c in cuts], [-c.rhs for c in cuts])
                 _tl = (
                     None
                     if deadline is None

--- a/python/discopt/_jax/psd_cuts.py
+++ b/python/discopt/_jax/psd_cuts.py
@@ -131,6 +131,84 @@ def _diag_col(info: dict, i: int) -> Optional[int]:
     return None
 
 
+def _moment_blocks_for_set(info: dict, S: Sequence[int]):
+    """Column indices needed for the moment submatrix over variables ``S``.
+
+    Returns ``(orig_cols, diag_cols, off_cols)`` or ``None`` if any required
+    lifted column (a square or a cross-product within ``S``) is missing.
+    """
+    orig = info.get("original", {})
+    bil = info.get("bilinear", {})
+    S = list(S)
+    if any(i not in orig for i in S):
+        return None
+    diag_cols = []
+    for i in S:
+        di = _diag_col(info, i)
+        if di is None:
+            return None
+        diag_cols.append(di)
+    k = len(S)
+    off = np.full((k, k), -1, dtype=int)
+    for a in range(k):
+        for b in range(a + 1, k):
+            key = (min(S[a], S[b]), max(S[a], S[b]))
+            if key not in bil:
+                return None
+            off[a, b] = off[b, a] = int(bil[key])
+    return [int(orig[i]) for i in S], diag_cols, off
+
+
+def _moment_clique_cut(
+    info: dict, x_full: np.ndarray, S: Sequence[int], n_total: int, *, tol: float
+) -> Optional[LinearCut]:
+    """Separate a single moment cut over the variable clique ``S`` (size >= 2)."""
+    blocks = _moment_blocks_for_set(info, S)
+    if blocks is None:
+        return None
+    orig_cols, diag_cols, off = blocks
+    k = len(S)
+    x_vals = np.array([x_full[c] for c in orig_cols], dtype=np.float64)
+    X_vals = np.empty((k, k), dtype=np.float64)
+    prod_cols = np.empty((k, k), dtype=int)
+    for a in range(k):
+        prod_cols[a, a] = diag_cols[a]
+        X_vals[a, a] = x_full[diag_cols[a]]
+        for b in range(a + 1, k):
+            prod_cols[a, b] = prod_cols[b, a] = off[a, b]
+            X_vals[a, b] = X_vals[b, a] = x_full[off[a, b]]
+    return psd_cut_from_submatrix(x_vals, X_vals, orig_cols, prod_cols, n_total, tol=tol)
+
+
+def _lifted_cliques(info: dict, max_dim: int) -> list[tuple[int, ...]]:
+    """Greedy cliques of variables whose pairwise products + squares are all lifted.
+
+    A clique ``S`` (all pairs in ``bilinear``, all squares lifted) is exactly the
+    set over which a dense moment submatrix can be formed. Dense ``k>=3`` cliques
+    capture multi-variable moment coupling that pairwise 2x2 minors miss.
+    """
+    bil = info.get("bilinear", {})
+    verts = [i for i in info.get("original", {}) if _diag_col(info, i) is not None]
+    adj: dict[int, set] = {i: set() for i in verts}
+    for i, j in bil:
+        if i in adj and j in adj:
+            adj[i].add(j)
+            adj[j].add(i)
+    cliques: set[tuple[int, ...]] = set()
+    # Seed a greedy clique from each vertex, extending by most-connected neighbours.
+    for seed in sorted(verts, key=lambda v: -len(adj[v])):
+        clique = [seed]
+        cand = sorted(adj[seed], key=lambda v: -len(adj[v]))
+        for v in cand:
+            if len(clique) >= max_dim:
+                break
+            if all(v in adj[u] for u in clique):
+                clique.append(v)
+        if len(clique) >= 2:
+            cliques.add(tuple(sorted(clique)))
+    return sorted(cliques, key=lambda c: (-len(c), c))
+
+
 def separate_psd_cuts_on_relaxation(
     info: dict,
     x_full: np.ndarray,
@@ -138,37 +216,48 @@ def separate_psd_cuts_on_relaxation(
     *,
     tol: float = 1e-7,
     max_cuts: int = 64,
+    max_dim: int = 6,
 ) -> list[LinearCut]:
-    """Separate pairwise (3x3) moment PSD cuts from a McCormick relaxation point.
+    """Separate moment (PSD) cuts from a McCormick relaxation point.
 
     ``info`` is the column-map dict returned by ``build_milp_relaxation``: it maps
     ``original`` variables, ``bilinear`` pairs ``(i, j) -> col(X_ij)``, and
     ``monomial``/``univariate_square`` ``(i, 2) -> col(X_ii)`` to relaxation
-    columns. For each bilinear pair whose two squares are also lifted, the 3x3
-    moment matrix over ``{i, j}``
+    columns. Cuts are separated over **cliques** of variables whose pairwise
+    products and squares are all lifted (up to ``max_dim`` variables): the moment
+    submatrix
 
-        [[1, x_i, x_j], [x_i, X_ii, X_ij], [x_j, X_ij, X_jj]]
+        [[1, x_S^T], [x_S, X_SS]]
 
-    is checked for PSD-ness at the current point ``x_full``; a negative eigenvalue
-    yields a valid linear cut (``X_ii X_jj >= X_ij**2`` plus the linkage to
-    ``x_i, x_j``). Pairwise 3x3 cuts are always available when the squares are
-    lifted and capture the core SDP strengthening for each product.
+    is checked for PSD-ness at the current point; a negative eigenvalue yields a
+    valid cut. Dense ``k>=3`` cliques capture multi-variable moment coupling that
+    pairwise 2x2 minors cannot; pairwise cuts remain the ``k=2`` special case.
     """
-    orig = info.get("original", {})
-    bil = info.get("bilinear", {})
     cuts: list[LinearCut] = []
-    for (i, j), w_col in bil.items():
+    seen_pairs: set[tuple[int, int]] = set()
+    # Dense cliques first (strongest), then any remaining pairwise products.
+    for S in _lifted_cliques(info, max_dim):
         if len(cuts) >= max_cuts:
             break
+        cut = _moment_clique_cut(info, x_full, S, n_total, tol=tol)
+        if cut is not None:
+            cuts.append(cut)
+        for a in range(len(S)):
+            for b in range(a + 1, len(S)):
+                seen_pairs.add((S[a], S[b]))
+
+    orig = info.get("original", {})
+    bil = info.get("bilinear", {})
+    for i, j in bil:
+        if len(cuts) >= max_cuts:
+            break
+        if (min(i, j), max(i, j)) in seen_pairs:
+            continue
         di = _diag_col(info, i)
         dj = _diag_col(info, j)
         if di is None or dj is None or i not in orig or j not in orig:
             continue
-        ci, cj, w = int(orig[i]), int(orig[j]), int(w_col)
-        x_vals = np.array([x_full[ci], x_full[cj]], dtype=np.float64)
-        X_vals = np.array([[x_full[di], x_full[w]], [x_full[w], x_full[dj]]], dtype=np.float64)
-        prod_cols = np.array([[di, w], [w, dj]], dtype=int)
-        cut = psd_cut_from_submatrix(x_vals, X_vals, [ci, cj], prod_cols, n_total, tol=tol)
+        cut = _moment_clique_cut(info, x_full, (i, j), n_total, tol=tol)
         if cut is not None:
             cuts.append(cut)
     return cuts

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1506,6 +1506,7 @@ def _root_relaxation_lower_bound(
     root_lb: np.ndarray,
     root_ub: np.ndarray,
     time_limit: float,
+    psd_cuts: bool = False,
 ) -> Optional[float]:
     """Solve the root MILP relaxation once and return its LP value as a rigorous
     global lower bound, or ``None`` if unavailable.
@@ -1534,7 +1535,7 @@ def _root_relaxation_lower_bound(
 
     try:
         terms = classify_nonlinear_terms(model)
-        relax, _ = build_milp_relaxation(
+        relax, _relax_info = build_milp_relaxation(
             model,
             terms,
             DiscretizationState(),
@@ -1543,6 +1544,23 @@ def _root_relaxation_lower_bound(
         if not relax._objective_bound_valid:
             return None
         relax = sanitize_relaxation_for_conditioning(relax)
+
+        # PSD (moment) cuts strengthen the McCormick relaxation toward the SDP
+        # bound on nonconvex QCQP. `sanitize_*` only drops rows, so the column
+        # map `_relax_info` still matches `relax`. Each cut is valid for the whole
+        # feasible region, so the strengthened LP value is a *valid* lower bound
+        # (>= the plain bound); it joins the candidates below and `max` keeps the
+        # tightest. Opt-in via `psd_cuts=True`; any failure is a sound no-op.
+        psd_bound: Optional[float] = None
+        if psd_cuts:
+            try:
+                from discopt._jax.psd_cuts import psd_strengthen_relaxation_bound
+
+                _zb, _za, _nc = psd_strengthen_relaxation_bound(relax, _relax_info)
+                if _nc and _za is not None and np.isfinite(_za):
+                    psd_bound = float(_za)
+            except Exception as psd_exc:  # pragma: no cover - defensive
+                logger.debug("root PSD-strengthened bound skipped: %s", psd_exc)
         budget = min(10.0, max(1.0, time_limit * 0.1))
         result = relax.solve(time_limit=budget, gap_tolerance=1e-6)
         # Only an OPTIMAL relaxation solve yields a valid lower bound. An
@@ -1581,7 +1599,7 @@ def _root_relaxation_lower_bound(
 
         # Both values are valid lower bounds for a minimization, so the larger
         # (tighter) one is the better rigorous bound.
-        candidates = [b for b in (plain_bound, sep_bound) if b is not None]
+        candidates = [b for b in (plain_bound, sep_bound, psd_bound) if b is not None]
         if candidates:
             return max(candidates)
     except Exception as exc:  # pragma: no cover - defensive
@@ -1602,6 +1620,7 @@ def solve_model(
     nlp_solver: str = "ipm",
     sparse: Optional[bool] = None,
     cutting_planes: bool = False,
+    psd_cuts: bool = False,
     partitions: int = 0,
     branching_policy: str = "fractional",
     use_learned_relaxations: bool = False,
@@ -4297,7 +4316,9 @@ def solve_model(
     if (bound_val is None or not np.isfinite(bound_val)) and (
         model._objective.sense == ObjectiveSense.MINIMIZE
     ):
-        _rr = _root_relaxation_lower_bound(model, _root_lb_snapshot, _root_ub_snapshot, time_limit)
+        _rr = _root_relaxation_lower_bound(
+            model, _root_lb_snapshot, _root_ub_snapshot, time_limit, psd_cuts=psd_cuts
+        )
         if _rr is not None and np.isfinite(_rr):
             bound_val = _rr
             if obj_val is not None and np.isfinite(obj_val):

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2812,6 +2812,7 @@ def solve_model(
             _mc_lp_relaxer = MccormickLPRelaxer(
                 model,
                 superposition=(relaxation_arithmetic == "superposition"),
+                psd_cuts=psd_cuts,
             )
         except Exception as e:
             logger.warning("McCormick LP relaxer setup failed: %s", e)

--- a/python/tests/test_psd_cuts_solve.py
+++ b/python/tests/test_psd_cuts_solve.py
@@ -1,0 +1,93 @@
+"""End-to-end tests for the ``psd_cuts`` solve flag (Wave 2, W2c).
+
+PSD (moment) cuts strengthen the McCormick relaxation toward the SDP bound on
+nonconvex QCQP. Two properties are pinned here:
+
+* **soundness** — ``Model.solve(psd_cuts=True)`` returns the same global optimum
+  as the baseline (cuts only tighten the relaxation; they never remove a point);
+* **strength** — at the relaxation level the PSD loop closes the plain-McCormick
+  root gap to the true optimum on an indefinite QCQP.
+
+Note: on small box-QPs discopt's existing per-node separation already reaches the
+optimum, so PSD cuts *match* (do not beat) the baseline node count there; their
+distinct value is closing the gap with a cheap root LP-cut loop.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import numpy as np
+
+# Symmetric, indefinite Q on the unit box; optimum is at a vertex.
+_Q = np.array([[1.0, -3.0, 0.0], [-3.0, 1.0, -2.0], [0.0, -2.0, 1.0]])
+
+
+def _build():
+    m = dm.Model("indef3")
+    x = m.continuous("x", shape=(3,), lb=0, ub=1)
+    expr = None
+    for i in range(3):
+        for j in range(3):
+            if _Q[i, j] != 0.0:
+                term = _Q[i, j] * x[i] * x[j]
+                expr = term if expr is None else expr + term
+    m.minimize(expr)
+    return m
+
+
+def _vertex_optimum() -> float:
+    best = np.inf
+    for v in itertools.product((0.0, 1.0), repeat=3):
+        v = np.array(v)
+        best = min(best, float(v @ _Q @ v))
+    return best
+
+
+def test_psd_cuts_flag_preserves_global_optimum():
+    opt = _vertex_optimum()
+    res = _build().solve(psd_cuts=True, time_limit=30)
+    assert res.status == "optimal"
+    assert abs(float(res.objective) - opt) < 1e-4
+
+
+def test_psd_cuts_match_baseline_optimum():
+    base = _build().solve(psd_cuts=False, time_limit=30)
+    psd = _build().solve(psd_cuts=True, time_limit=30)
+    assert abs(float(base.objective) - float(psd.objective)) < 1e-4
+
+
+def test_psd_closes_plain_mccormick_root_gap():
+    """At the relaxation level, pairwise PSD cuts close the plain-McCormick gap.
+
+    Uses ``min x0^2 + x1^2 - 3 x0 x1`` on ``[0,1]^2`` (optimum -1, plain McCormick
+    bound -1.5) — a single 2-variable moment cut closes it exactly. (Pairwise PSD
+    cuts capture 2-variable minors; genuinely 3-way moment coupling would need
+    dense k>=3 cuts, a documented follow-on.)
+    """
+    from discopt._jax.discretization import DiscretizationState
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+    from discopt._jax.psd_cuts import psd_strengthen_relaxation_bound
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    m = dm.Model("indef2")
+    x = m.continuous("x", shape=(2,), lb=0, ub=1)
+    m.minimize(x[0] * x[0] + x[1] * x[1] - 3 * x[0] * x[1])
+    lb = np.zeros(2)
+    ub = np.ones(2)
+    terms = classify_nonlinear_terms(m)
+    relax, info = build_milp_relaxation(m, terms, DiscretizationState(), bound_override=(lb, ub))
+    z_before, z_after, n_cuts = psd_strengthen_relaxation_bound(relax, info, max_rounds=12)
+
+    opt = -1.0
+    assert n_cuts >= 1
+    assert z_before < opt - 1e-3  # plain McCormick is loose (-1.5)
+    assert z_after > z_before + 1e-4  # PSD tightens it
+    assert z_after <= opt + 1e-6  # and stays a valid bound
+    # Gap (largely) closed: PSD reaches >= 90% of the way to the optimum.
+    assert z_after >= z_before + 0.9 * (opt - z_before)

--- a/python/tests/test_psd_dense_cuts.py
+++ b/python/tests/test_psd_dense_cuts.py
@@ -1,0 +1,84 @@
+"""Tests for dense (k>=3) moment PSD cuts (Wave 2, W2d).
+
+Pairwise 2x2 moment minors cannot capture multi-variable coupling: a moment
+submatrix can have every 2x2 principal minor PSD while the full k x k block is
+indefinite. Dense clique cuts close that gap. These tests prove dense cuts are
+(a) strictly stronger than pairwise and (b) still valid (never cut a feasible
+point).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from discopt._jax.psd_cuts import (
+    _lifted_cliques,
+    separate_psd_cuts_on_relaxation,
+)
+
+# 3 variables with all squares and all cross-products lifted.
+_INFO = {
+    "original": {0: 0, 1: 1, 2: 2},
+    "monomial": {(0, 2): 3, (1, 2): 4, (2, 2): 5},
+    "bilinear": {(0, 1): 6, (0, 2): 7, (1, 2): 8},
+}
+_N = 9
+
+
+def _correlation_point(r: float) -> np.ndarray:
+    """Point with x = 0, X_ii = 1, X_ij = r (a 3x3 correlation matrix block)."""
+    z = np.zeros(_N)
+    z[3] = z[4] = z[5] = 1.0
+    z[6] = z[7] = z[8] = r
+    return z
+
+
+def test_dense_separates_where_pairwise_cannot():
+    # r=-0.6: every 2x2 minor 1-r^2=0.64>0 (PSD) but the 3x3 has eig 1+2r=-0.2<0.
+    z = _correlation_point(-0.6)
+    pairwise = separate_psd_cuts_on_relaxation(_INFO, z, _N, max_dim=2)
+    dense = separate_psd_cuts_on_relaxation(_INFO, z, _N, max_dim=3)
+    assert len(pairwise) == 0
+    assert len(dense) >= 1
+
+
+def test_dense_cut_is_valid_for_feasible_points():
+    z = _correlation_point(-0.6)
+    cuts = separate_psd_cuts_on_relaxation(_INFO, z, _N, max_dim=3)
+    assert cuts
+    cut = cuts[0]
+    rng = np.random.default_rng(0)
+    worst = np.inf
+    for _ in range(3000):
+        x = rng.uniform(-2, 2, 3)
+        true = np.zeros(_N)
+        true[0:3] = x
+        true[3], true[4], true[5] = x[0] ** 2, x[1] ** 2, x[2] ** 2
+        true[6], true[7], true[8] = x[0] * x[1], x[0] * x[2], x[1] * x[2]
+        worst = min(worst, float(cut.coeffs @ true - cut.rhs))
+    assert worst >= -1e-9, f"dense cut violated a feasible point by {worst}"
+
+
+def test_consistent_point_yields_no_dense_cut():
+    # A genuine rank-1 moment point (X = x x^T) is PSD -> no cut.
+    x = np.array([0.3, 0.7, 0.5])
+    z = np.zeros(_N)
+    z[0:3] = x
+    z[3], z[4], z[5] = x[0] ** 2, x[1] ** 2, x[2] ** 2
+    z[6], z[7], z[8] = x[0] * x[1], x[0] * x[2], x[1] * x[2]
+    assert separate_psd_cuts_on_relaxation(_INFO, z, _N, max_dim=3) == []
+
+
+def test_clique_detection_full_and_partial():
+    # Fully lifted -> one 3-clique.
+    cliques = _lifted_cliques(_INFO, max_dim=6)
+    assert (0, 1, 2) in cliques
+
+    # Drop one cross-product -> no 3-clique, only pairs survive.
+    partial = {
+        "original": {0: 0, 1: 1, 2: 2},
+        "monomial": {(0, 2): 3, (1, 2): 4, (2, 2): 5},
+        "bilinear": {(0, 1): 6, (1, 2): 8},  # (0,2) missing
+    }
+    cliques2 = _lifted_cliques(partial, max_dim=6)
+    assert all(len(c) <= 2 for c in cliques2)
+    assert (0, 1) in cliques2 and (1, 2) in cliques2

--- a/python/tests/test_psd_node_reduction.py
+++ b/python/tests/test_psd_node_reduction.py
@@ -1,0 +1,56 @@
+"""End-to-end node-count win from per-node PSD cuts (Wave 2, W2e).
+
+W2c applied PSD cuts only at the root global bound, which cannot reduce the B&B
+node count (pruning is driven by the *per-node* relaxation bounds). W2e wires PSD
+separation into ``MccormickLPRelaxer.solve_at_node``, so every node's bound is
+tightened toward the SDP bound. On dense indefinite QCQP with a non-trivial
+search tree this measurably reduces nodes — while always returning the same
+global optimum (PSD cuts are valid, so they never remove a feasible point).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import numpy as np
+import pytest
+
+
+def _dense_indefinite_qcqp(n: int, seed: int) -> dm.Model:
+    """min x^T Q x over [0,1]^n with a dense symmetric (indefinite) Q."""
+    rng = np.random.default_rng(seed)
+    A = rng.standard_normal((n, n))
+    Q = (A + A.T) / 2
+    m = dm.Model(f"qcqp_n{n}_s{seed}")
+    x = m.continuous("x", shape=(n,), lb=0, ub=1)
+    expr = None
+    for i in range(n):
+        for j in range(n):
+            term = float(Q[i, j]) * x[i] * x[j]
+            expr = term if expr is None else expr + term
+    m.minimize(expr)
+    return m
+
+
+def test_psd_preserves_optimum_and_never_adds_nodes():
+    """Soundness + no-harm: same optimum, and PSD never increases the node count."""
+    base = _dense_indefinite_qcqp(6, 8).solve(psd_cuts=False, time_limit=60)
+    psd = _dense_indefinite_qcqp(6, 8).solve(psd_cuts=True, time_limit=60)
+    assert base.status == "optimal" and psd.status == "optimal"
+    assert abs(float(base.objective) - float(psd.objective)) < 1e-3
+    assert psd.node_count <= base.node_count
+
+
+@pytest.mark.slow
+def test_psd_substantially_reduces_nodes_on_hard_instance():
+    """n6_s0 has a non-trivial tree; per-node PSD cuts cut it down sharply."""
+    base = _dense_indefinite_qcqp(6, 0).solve(psd_cuts=False, time_limit=120)
+    psd = _dense_indefinite_qcqp(6, 0).solve(psd_cuts=True, time_limit=120)
+    assert abs(float(base.objective) - float(psd.objective)) < 1e-3
+    # Baseline explores a real tree; PSD cuts more than halve it.
+    assert base.node_count > 20
+    assert psd.node_count < base.node_count / 2


### PR DESCRIPTION
## Summary

Extends PSD (moment) cut separation to handle dense cliques of variables (k≥3), not just pairwise (k=2) cuts. Adds per-node PSD separation in the spatial B&B tree to tighten relaxation bounds at every node, reducing the search tree on indefinite QCQP instances while preserving correctness.

## Key Changes

**Dense clique cuts (W2d)**
- `_moment_blocks_for_set()`: Extract moment submatrix column indices for an arbitrary variable clique S
- `_moment_clique_cut()`: Separate a single PSD cut over a clique (generalizes the pairwise case)
- `_lifted_cliques()`: Greedy clique detection—finds maximal cliques where all pairwise products and squares are lifted, up to `max_dim` variables
- `separate_psd_cuts_on_relaxation()`: Refactored to separate dense cliques first (strongest), then remaining pairwise products; added `max_dim` parameter (default 6)

**Per-node PSD separation (W2e)**
- `MccormickLPRelaxer.__init__()`: Added `psd_cuts` boolean flag (opt-in)
- `MccormickLPRelaxer.solve_at_node()`: New `_separate_psd()` method that iteratively separates PSD cuts at each B&B node, tightening the relaxation bound toward the SDP bound
- `solve_model()`: Added `psd_cuts` parameter, wired through to `MccormickLPRelaxer`
- `_root_relaxation_lower_bound()`: Added `psd_cuts` parameter; calls `psd_strengthen_relaxation_bound()` to tighten the root bound before solving

**Root-level PSD strengthening (W2c)**
- `psd_strengthen_relaxation_bound()` (in `psd_cuts.py`): Iteratively separates PSD cuts at the root relaxation, returning the tightened bound and cut count

## Implementation Details

- Dense k≥3 cliques capture multi-variable moment coupling that pairwise 2x2 minors cannot detect (e.g., a 3×3 correlation matrix can have all 2×2 principal minors PSD while the full matrix is indefinite)
- All PSD cuts are valid for the entire feasible region (they enforce M = [[1, x^T], [x, X]] ≥ 0, which holds for any feasible point where X = xx^T), so adding them only tightens the bound—never removes a feasible point
- Per-node separation (W2e) drives the node-count reduction; root-level separation (W2c) closes the plain-McCormick gap at the global bound
- Graceful degradation: any exception in PSD separation returns the input result unchanged

## Tests

- `test_psd_cuts_solve.py`: End-to-end soundness (same optimum with/without PSD cuts) and strength (PSD closes the plain-McCormick root gap on indefinite QCQP)
- `test_psd_dense_cuts.py`: Dense cuts separate where pairwise cannot; dense cuts remain valid for feasible points; clique detection (full and partial lifting)
- `test_psd_node_reduction.py`: Per-node PSD cuts reduce node count on hard instances while preserving optimality

https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr