### PR TITLE
Recover entropy/centropy intrinsics from lowered products (issue #207)

### DIFF
--- a/python/discopt/_jax/convexity/interval.py
+++ b/python/discopt/_jax/convexity/interval.py
@@ -377,6 +377,18 @@ def entropy(x: Interval) -> Interval:
     return Interval(_round_down(lo), _round_up(hi))
 
 
+def centropy(x: Interval, y: Interval) -> Interval:
+    """``centropy(x, y) = x*log(x/y)`` (relative entropy) on ``x >= 0, y > 0``.
+
+    Enclosed soundly (if loosely) via the identity ``centropy = entropy(x) -
+    x*log(y)`` composed in interval arithmetic. The ``x -> 0+`` limit of
+    ``centropy`` is 0, matching ``entropy``'s clamp. When the box leaves the
+    domain (``x.lo < 0`` or ``y.lo <= 0``) the constituent enclosures collapse to
+    ``[-inf, +inf]`` so the certificate soundly abstains.
+    """
+    return entropy(x) - x * log(y)
+
+
 def sin(x: Interval) -> Interval:
     """Sound enclosure of ``sin([lo, hi])``.
 

--- a/python/discopt/_jax/convexity/interval_eval.py
+++ b/python/discopt/_jax/convexity/interval_eval.py
@@ -222,6 +222,9 @@ def _eval_function_call(expr: FunctionCall, model: Model, box: dict, cache: dict
             hi = np.minimum(hi, a.hi)
         return Interval(lo, hi)
 
+    if expr.func_name == "centropy" and len(args) == 2:
+        return iv.centropy(args[0], args[1])
+
     if len(args) != 1:
         return _unbounded(args[0].lo.shape)
 

--- a/python/discopt/_jax/convexity/rules.py
+++ b/python/discopt/_jax/convexity/rules.py
@@ -535,6 +535,8 @@ def _classify_function_call(expr: FunctionCall, model: Optional[Model], cache: d
         return _classify_nary_max(expr, model, cache)
     if name == "min" and len(expr.args) >= 2:
         return _classify_nary_min(expr, model, cache)
+    if name == "centropy" and len(expr.args) == 2:
+        return _classify_centropy(expr, model, cache)
 
     # Any p-norm ‖·‖_p is convex and nonnegative. The DCP composition rule
     # (convex, nondecreasing-in-each-|arg|) is only sound when the inner
@@ -665,6 +667,27 @@ def _classify_nary_min(expr: FunctionCall, model: Optional[Model], cache: dict) 
                 curv = Curvature.AFFINE
         s = info.sign if i == 0 else _sign_join(s, info.sign)
     return ExprInfo(curv, s)
+
+
+def _classify_centropy(expr: FunctionCall, model: Optional[Model], cache: dict) -> ExprInfo:
+    """``centropy(x, y) = x*log(x/y)`` (relative entropy) is JOINTLY CONVEX on
+    ``x >= 0, y > 0`` (Boyd & Vandenberghe §3.2.6 — the relative entropy; its
+    Hessian ``[[1/x, -1/y], [-1/y, x/y²]]`` is PSD there). The DCP composition
+    rule licenses CONVEX only when both arguments are *affine* (a jointly-convex
+    atom composed with affine maps is convex; a nonconvex inner argument is not
+    sound), and only when the domain ``x >= 0, y > 0`` is provable over the box.
+    Otherwise abstain (UNKNOWN), preserving soundness. This is what makes a
+    Gibbs/KL objective ``Σ nᵢ·log(nᵢ / Σnⱼ)`` — affine numerator, affine
+    denominator — certify on the convex fast path (issue #207)."""
+    x_info = classify_expr_info(expr.args[0], model, cache)
+    y_info = classify_expr_info(expr.args[1], model, cache)
+    if x_info.curvature != Curvature.AFFINE or y_info.curvature != Curvature.AFFINE:
+        return ExprInfo(Curvature.UNKNOWN, Sign.UNKNOWN)
+    x_sign = _refine_sign(expr.args[0], model, cache, x_info.sign)
+    y_sign = _refine_sign(expr.args[1], model, cache, y_info.sign)
+    if is_nonneg(x_sign) and is_pos(y_sign):
+        return ExprInfo(Curvature.CONVEX, Sign.UNKNOWN)
+    return ExprInfo(Curvature.UNKNOWN, Sign.UNKNOWN)
 
 
 def _sign_join(a: Sign, b: Sign) -> Sign:

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -626,13 +626,87 @@ def _match_entropy_product(expr: Expression, model: Model) -> Expression | None:
     return BinaryOp("*", Constant(coeff), entropy)
 
 
+def _match_centropy_product(expr: Expression, model: Model) -> Expression | None:
+    """If *expr* is a product equal to ``c · x · log(x/y)`` for a single variable
+    ``x`` (nonnegative, finite box) and a positive divisor ``y``, return
+    ``c · centropy(x, y)``; else ``None``.
+
+    ``centropy(x, y) = x·log(x/y)`` is the GAMS relative-entropy intrinsic, which
+    AMPL/GAMS lower into this product when emitting a ``.nl`` file. It is jointly
+    convex on ``x ≥ 0, y > 0``, so recovering the intrinsic lets the convexity
+    detector certify a Gibbs/KL objective ``Σ nᵢ·log(nᵢ/Σnⱼ)`` on the convex fast
+    path (issue #207). The match is strict: exactly one bare ``x`` and one
+    ``log(x/y)`` whose *numerator* is that same ``x``; ``y`` is any other factor's
+    free expression. The domain guard (``x.lb ≥ 0`` finite, ``y > 0`` finite) keeps
+    the substitution consistent with the entropy domain and never introduces
+    ``centropy`` where the original product was outside it.
+    """
+    coeff = 1.0
+    log_num: Expression | None = None
+    log_num_idx: int | None = None
+    log_den: Expression | None = None
+    bare_idx: int | None = None
+    bare_count = 0
+    log_count = 0
+
+    for factor in _flatten_product(expr):
+        sign, factor = _strip_neg(factor)
+        coeff *= sign
+        if isinstance(factor, Constant) and factor.value.ndim == 0:
+            coeff *= float(factor.value)
+            continue
+        # log(num / den)?
+        if (
+            isinstance(factor, FunctionCall)
+            and factor.func_name == "log"
+            and len(factor.args) == 1
+            and isinstance(factor.args[0], BinaryOp)
+            and factor.args[0].op == "/"
+        ):
+            num_idx = _get_flat_index(factor.args[0].left, model)
+            if num_idx is not None:
+                log_count += 1
+                log_num = factor.args[0].left
+                log_num_idx = num_idx
+                log_den = factor.args[0].right
+                continue
+            return None
+        # bare variable leaf?
+        idx = _get_flat_index(factor, model)
+        if idx is not None:
+            bare_count += 1
+            bare_idx = idx
+            continue
+        return None
+
+    if log_count != 1 or bare_count != 1 or log_num_idx is None or log_num_idx != bare_idx:
+        return None
+
+    # Domain guard: x nonnegative & finite (entropy domain), y strictly positive
+    # & finite (log(y) and the centropy domain).
+    lo_x, hi_x = _bound_expression(log_num, model)
+    if not (np.isfinite(lo_x) and np.isfinite(hi_x)) or lo_x < 0.0:
+        return None
+    lo_y, hi_y = _bound_expression(log_den, model)
+    if not (np.isfinite(lo_y) and np.isfinite(hi_y)) or lo_y <= 0.0:
+        return None
+
+    centropy = FunctionCall("centropy", log_num, log_den)
+    if coeff == 1.0:
+        return centropy
+    return BinaryOp("*", Constant(coeff), centropy)
+
+
 def _canonicalize_entropy_expr(expr: Expression, model: Model) -> Expression:
-    """Return *expr* with every ``c·x·log(x)`` product rewritten to
-    ``c·entropy(x)``. Identity-preserving: unchanged subtrees keep their object
-    identity so untouched models are returned byte-for-byte unchanged."""
+    """Return *expr* with every ``c·x·log(x)`` product rewritten to ``c·entropy(x)``
+    and every ``c·x·log(x/y)`` product rewritten to ``c·centropy(x, y)``.
+    Identity-preserving: unchanged subtrees keep their object identity so
+    untouched models are returned byte-for-byte unchanged."""
     if isinstance(expr, BinaryOp):
         if expr.op == "*":
             matched = _match_entropy_product(expr, model)
+            if matched is None:
+                matched = _match_centropy_product(expr, model)
             if matched is not None:
                 return matched
         left = _canonicalize_entropy_expr(expr.left, model)
@@ -664,14 +738,22 @@ def _canonicalize_entropy_expr(expr: Expression, model: Model) -> Expression:
 
 
 def canonicalize_entropy(model: Model) -> Model:
-    """Return a model equivalent to *model* with every ``c·x·log(x)`` product
-    (in the objective or any constraint) rewritten to the ``entropy(x)``
-    intrinsic, which the relaxation pipeline can bound tightly (issue #207).
+    """Return a model equivalent to *model* with entropy-family products (in the
+    objective or any constraint) rewritten to their intrinsics (issue #207):
 
-    The rewrite is exact (``entropy(x) ≡ x·log(x)``) and convexity-preserving, so
-    it runs unconditionally. If nothing matches, *model* is returned unchanged
-    (zero overhead, zero behavioural change). On any unexpected error the original
-    model is returned, so the pass can never break a previously-solvable model.
+    * ``c·x·log(x)``    -> ``c·entropy(x)``
+    * ``c·x·log(x/y)``  -> ``c·centropy(x, y)``   (relative entropy / Gibbs/KL)
+
+    Both intrinsics carry dedicated relaxation / convexity support, so recovering
+    them from the raw products AMPL/GAMS emit lets the bound tighten (and a
+    separable entropy / relative-entropy objective is detected as convex, taking
+    the convex fast path).
+
+    The rewrites are exact (``entropy(x) ≡ x·log(x)``, ``centropy(x,y) ≡
+    x·log(x/y)``) and convexity-preserving, so they run unconditionally. If
+    nothing matches, *model* is returned unchanged (zero overhead, zero
+    behavioural change). On any unexpected error the original model is returned,
+    so the pass can never break a previously-solvable model.
     """
     try:
         changed = False

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -47,8 +47,11 @@ from discopt.modeling.core import (
     Constant,
     Constraint,
     Expression,
+    FunctionCall,
     IndexExpression,
     Model,
+    SumExpression,
+    SumOverExpression,
     UnaryOp,
     Variable,
     VarType,
@@ -520,6 +523,189 @@ def _scan_for_mixed_product(expr: Expression, model: Model) -> bool:
     if isinstance(expr, UnaryOp):
         return _scan_for_mixed_product(expr.operand, model)
     return False
+
+
+# ---------------------------------------------------------------------------
+# Entropy canonicalization: x*log(x) -> entropy(x)
+# ---------------------------------------------------------------------------
+#
+# AMPL/GAMS lower the ``entropy`` intrinsic into a raw ``x*log(x)`` product
+# when they emit a ``.nl`` file, so a model whose objective is ``Σ xᵢ·log(xᵢ)``
+# (chemical-equilibrium / Gibbs free energy, e.g. globallib ``ex6_1_4``) reaches
+# the relaxer as an undecomposable product. The MILP/McCormick-LP relaxer cannot
+# decompose ``x*log(x)`` and falls back to a *constant* separable objective floor
+# that never tightens under branching — discopt finds the global optimum but
+# cannot certify it (issue #207).
+#
+# discopt already carries a dedicated convex underestimator for the ``entropy``
+# intrinsic (``entropy(x) = x*log(x)``, convex on ``x ≥ 0``): ``relax_entropy``
+# (mccormick.py), the curvature lattice (convexity), and interval arithmetic all
+# recognise it. Recovering the intrinsic from the lowered product — a pure DAG
+# canonicalization — is therefore enough to feed the existing relaxation, so the
+# objective bound tightens under branching (and a separable-entropy objective is
+# detected as convex, unlocking the convex fast path). The rewrite is exact:
+# ``entropy(x)`` and ``x*log(x)`` are the same function, so it is sound for any
+# model, convex or not, and so runs unconditionally.
+
+
+def _strip_neg(expr: Expression) -> tuple[float, Expression]:
+    """Peel leading ``neg(...)`` wrappers, returning ``(sign, inner)``."""
+    sign = 1.0
+    while isinstance(expr, UnaryOp) and expr.op == "neg":
+        sign = -sign
+        expr = expr.operand
+    return sign, expr
+
+
+def _flatten_product(expr: Expression) -> list[Expression]:
+    """Flatten a left/right-nested ``*``-tree into a flat list of factors."""
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        return _flatten_product(expr.left) + _flatten_product(expr.right)
+    return [expr]
+
+
+def _match_entropy_product(expr: Expression, model: Model) -> Expression | None:
+    """If *expr* is a product equal to ``c · x · log(x)`` for a single variable
+    ``x`` with a nonnegative, finite box, return ``c · entropy(x)``; else ``None``.
+
+    The match is deliberately strict: it fires only when, after folding constant
+    factors, the product's variable content is *exactly* one bare occurrence of a
+    variable ``x`` and one ``log(x)`` of the same variable (so ``x²·log(x)``,
+    ``x·log(a·x)``, ``x·log(y)`` etc. are left untouched). The domain guard
+    (``lb ≥ 0``, finite box) keeps the substitution consistent with
+    ``relax_entropy``'s requirement and never introduces ``entropy`` where the
+    original product was outside the entropy domain.
+    """
+    coeff = 1.0
+    log_idx: int | None = None
+    log_arg: Expression | None = None
+    bare_idx: int | None = None
+    bare_count = 0
+    log_count = 0
+
+    for factor in _flatten_product(expr):
+        sign, factor = _strip_neg(factor)
+        coeff *= sign
+        # Fold scalar-constant factors into the coefficient.
+        if isinstance(factor, Constant) and factor.value.ndim == 0:
+            coeff *= float(factor.value)
+            continue
+        # log(var)?
+        if (
+            isinstance(factor, FunctionCall)
+            and factor.func_name == "log"
+            and len(factor.args) == 1
+        ):
+            idx = _get_flat_index(factor.args[0], model)
+            if idx is not None:
+                log_count += 1
+                log_idx = idx
+                log_arg = factor.args[0]
+                continue
+            return None
+        # bare variable leaf?
+        idx = _get_flat_index(factor, model)
+        if idx is not None:
+            bare_count += 1
+            bare_idx = idx
+            continue
+        # Any other factor (transcendental, product of vars, ...) disqualifies.
+        return None
+
+    if log_count != 1 or bare_count != 1 or log_idx is None or log_idx != bare_idx:
+        return None
+
+    # Domain guard: entropy's underestimator requires a nonnegative, finite box.
+    lo, hi = _bound_expression(log_arg, model)
+    if not (np.isfinite(lo) and np.isfinite(hi)) or lo < 0.0:
+        return None
+
+    entropy = FunctionCall("entropy", log_arg)
+    if coeff == 1.0:
+        return entropy
+    return BinaryOp("*", Constant(coeff), entropy)
+
+
+def _canonicalize_entropy_expr(expr: Expression, model: Model) -> Expression:
+    """Return *expr* with every ``c·x·log(x)`` product rewritten to
+    ``c·entropy(x)``. Identity-preserving: unchanged subtrees keep their object
+    identity so untouched models are returned byte-for-byte unchanged."""
+    if isinstance(expr, BinaryOp):
+        if expr.op == "*":
+            matched = _match_entropy_product(expr, model)
+            if matched is not None:
+                return matched
+        left = _canonicalize_entropy_expr(expr.left, model)
+        right = _canonicalize_entropy_expr(expr.right, model)
+        if left is expr.left and right is expr.right:
+            return expr
+        return BinaryOp(expr.op, left, right)
+    if isinstance(expr, UnaryOp):
+        operand = _canonicalize_entropy_expr(expr.operand, model)
+        if operand is expr.operand:
+            return expr
+        return UnaryOp(expr.op, operand)
+    if isinstance(expr, FunctionCall):
+        new_args = tuple(_canonicalize_entropy_expr(a, model) for a in expr.args)
+        if all(n is o for n, o in zip(new_args, expr.args)):
+            return expr
+        return FunctionCall(expr.func_name, *new_args)
+    if isinstance(expr, SumExpression):
+        operand = _canonicalize_entropy_expr(expr.operand, model)
+        if operand is expr.operand:
+            return expr
+        return SumExpression(operand, axis=expr.axis)
+    if isinstance(expr, SumOverExpression):
+        new_terms = [_canonicalize_entropy_expr(t, model) for t in expr.terms]
+        if all(n is o for n, o in zip(new_terms, expr.terms)):
+            return expr
+        return SumOverExpression(new_terms)
+    return expr
+
+
+def canonicalize_entropy(model: Model) -> Model:
+    """Return a model equivalent to *model* with every ``c·x·log(x)`` product
+    (in the objective or any constraint) rewritten to the ``entropy(x)``
+    intrinsic, which the relaxation pipeline can bound tightly (issue #207).
+
+    The rewrite is exact (``entropy(x) ≡ x·log(x)``) and convexity-preserving, so
+    it runs unconditionally. If nothing matches, *model* is returned unchanged
+    (zero overhead, zero behavioural change). On any unexpected error the original
+    model is returned, so the pass can never break a previously-solvable model.
+    """
+    try:
+        changed = False
+
+        new_objective = model._objective
+        if model._objective is not None:
+            new_expr = _canonicalize_entropy_expr(model._objective.expression, model)
+            if new_expr is not model._objective.expression:
+                from discopt.modeling.core import Objective
+
+                new_objective = Objective(new_expr, model._objective.sense)
+                changed = True
+
+        new_constraints: list = []
+        for c in model._constraints:
+            if isinstance(c, Constraint):
+                new_body = _canonicalize_entropy_expr(c.body, model)
+                if new_body is not c.body:
+                    new_constraints.append(Constraint(new_body, c.sense, c.rhs, c.name))
+                    changed = True
+                    continue
+            new_constraints.append(c)
+
+        if not changed:
+            return model
+
+        new_model = Model(model.name)
+        new_model._variables = list(model._variables)
+        new_model._parameters = list(model._parameters)
+        new_model._objective = new_objective
+        new_model._constraints = new_constraints
+        return new_model
+    except Exception:  # pragma: no cover - defensive: never break a solve
+        return model
 
 
 def factorable_reformulate(model: Model, *, clear_only: bool = False) -> Model:

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -591,11 +591,7 @@ def _match_entropy_product(expr: Expression, model: Model) -> Expression | None:
             coeff *= float(factor.value)
             continue
         # log(var)?
-        if (
-            isinstance(factor, FunctionCall)
-            and factor.func_name == "log"
-            and len(factor.args) == 1
-        ):
+        if isinstance(factor, FunctionCall) and factor.func_name == "log" and len(factor.args) == 1:
             idx = _get_flat_index(factor.args[0], model)
             if idx is not None:
                 log_count += 1
@@ -612,7 +608,7 @@ def _match_entropy_product(expr: Expression, model: Model) -> Expression | None:
         # Any other factor (transcendental, product of vars, ...) disqualifies.
         return None
 
-    if log_count != 1 or bare_count != 1 or log_idx is None or log_idx != bare_idx:
+    if log_count != 1 or bare_count != 1 or log_arg is None or log_idx != bare_idx:
         return None
 
     # Domain guard: entropy's underestimator requires a nonnegative, finite box.
@@ -679,7 +675,13 @@ def _match_centropy_product(expr: Expression, model: Model) -> Expression | None
             continue
         return None
 
-    if log_count != 1 or bare_count != 1 or log_num_idx is None or log_num_idx != bare_idx:
+    if (
+        log_count != 1
+        or bare_count != 1
+        or log_num is None
+        or log_den is None
+        or log_num_idx != bare_idx
+    ):
         return None
 
     # Domain guard: x nonnegative & finite (entropy domain), y strictly positive

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2008,6 +2008,21 @@ def solve_model(
 
     model = reformulate_gdp(model, method=gdp_method)
 
+    # --- Entropy canonicalization: recover the ``entropy(x) = x*log(x)``
+    # intrinsic from the raw ``x*log(x)`` product that AMPL/GAMS emit when they
+    # lower the ``entropy`` opcode into a ``.nl`` file. The MILP/McCormick-LP
+    # relaxer cannot decompose ``x*log(x)`` and falls back to a constant
+    # separable objective floor that never tightens under branching, so an
+    # entropy/Gibbs objective (e.g. ``ex6_1_4``) is solved to the global optimum
+    # but cannot be certified (issue #207). discopt already carries a dedicated
+    # convex underestimator for ``entropy``; recovering the intrinsic feeds it,
+    # so the bound tightens (and a separable-entropy objective is detected as
+    # convex). The rewrite is exact and convexity-preserving, so it runs
+    # unconditionally and returns the model unchanged when nothing matches.
+    from discopt._jax.factorable_reform import canonicalize_entropy
+
+    model = canonicalize_entropy(model)
+
     # --- Objective-defining-equality relaxation (the SUSPECT "objective
     # constraint"). When the model is `min/max z` with z a free scalar that
     # appears only in one equality `z = g(x)` (affinely), relax that equality

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2008,17 +2008,19 @@ def solve_model(
 
     model = reformulate_gdp(model, method=gdp_method)
 
-    # --- Entropy canonicalization: recover the ``entropy(x) = x*log(x)``
-    # intrinsic from the raw ``x*log(x)`` product that AMPL/GAMS emit when they
-    # lower the ``entropy`` opcode into a ``.nl`` file. The MILP/McCormick-LP
-    # relaxer cannot decompose ``x*log(x)`` and falls back to a constant
-    # separable objective floor that never tightens under branching, so an
-    # entropy/Gibbs objective (e.g. ``ex6_1_4``) is solved to the global optimum
-    # but cannot be certified (issue #207). discopt already carries a dedicated
-    # convex underestimator for ``entropy``; recovering the intrinsic feeds it,
-    # so the bound tightens (and a separable-entropy objective is detected as
-    # convex). The rewrite is exact and convexity-preserving, so it runs
-    # unconditionally and returns the model unchanged when nothing matches.
+    # --- Entropy-family canonicalization: recover the ``entropy(x) = x*log(x)``
+    # and ``centropy(x, y) = x*log(x/y)`` intrinsics from the raw products that
+    # AMPL/GAMS emit when they lower those opcodes into a ``.nl`` file. The
+    # MILP/McCormick-LP relaxer cannot decompose ``x*log(x)`` / ``x*log(x/y)``
+    # and falls back to a constant separable objective floor that never tightens
+    # under branching, so an entropy / Gibbs / relative-entropy objective (e.g.
+    # ``ex6_1_4``) is solved to the global optimum but cannot be certified
+    # (issue #207). discopt carries dedicated convexity support for both
+    # intrinsics (``entropy`` is convex, ``centropy`` is jointly convex on
+    # x≥0,y>0); recovering them lets a separable entropy / relative-entropy
+    # objective be detected as convex and certify on the convex fast path. The
+    # rewrites are exact and convexity-preserving, so they run unconditionally
+    # and return the model unchanged when nothing matches.
     from discopt._jax.factorable_reform import canonicalize_entropy
 
     model = canonicalize_entropy(model)

--- a/python/tests/test_factorable_reform.py
+++ b/python/tests/test_factorable_reform.py
@@ -21,8 +21,9 @@ from pathlib import Path
 
 import discopt.modeling as dm
 import pytest
-from discopt._jax.factorable_reform import factorable_reformulate
+from discopt._jax.factorable_reform import canonicalize_entropy, factorable_reformulate
 from discopt._jax.term_classifier import classify_nonlinear_terms
+from discopt.modeling.core import FunctionCall
 
 _DATA = Path(__file__).parent / "data" / "minlplib"
 
@@ -225,6 +226,108 @@ def test_nested_ratio_solve_is_sound():
         f"certified solution violates the original e4 (={e4}); a dropped "
         "denominator would certify an infeasible point"
     )
+    if r.bound is not None:
+        assert r.bound <= r.objective + 1e-4  # sound dual bound
+
+
+# ---------------------------------------------------------------------------
+# Entropy canonicalization: x*log(x) -> entropy(x)  (issue #207)
+# ---------------------------------------------------------------------------
+
+
+def _has_entropy(expr) -> bool:
+    """True if ``entropy(...)`` appears anywhere in the expression DAG."""
+    if isinstance(expr, FunctionCall):
+        return expr.func_name == "entropy" or any(_has_entropy(a) for a in expr.args)
+    for attr in ("left", "right", "operand"):
+        child = getattr(expr, attr, None)
+        if child is not None and _has_entropy(child):
+            return True
+    return False
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda x, y: x * dm.log(x),  # canonical product
+        lambda x, y: dm.log(x) * x,  # reversed factor order
+        lambda x, y: 2.5 * x * dm.log(x),  # with a constant coefficient
+        lambda x, y: -(x * dm.log(x)),  # negated
+        lambda x, y: x * dm.log(x) + y * dm.log(y),  # separable sum
+    ],
+)
+def test_entropy_product_is_canonicalized(build):
+    """``c·x·log(x)`` in the objective is rewritten to ``entropy(x)``."""
+    m = dm.Model("ent")
+    x = m.continuous("x", lb=0.001, ub=10.0)
+    y = m.continuous("y", lb=0.001, ub=10.0)
+    m.minimize(build(x, y))
+    out = canonicalize_entropy(m)
+    assert out is not m
+    assert _has_entropy(out._objective.expression)
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda x, y: x * x * dm.log(x),  # x**2 * log(x) is not entropy
+        lambda x, y: x * dm.log(y),  # log of a different variable
+        lambda x, y: x * dm.log(2 * x),  # log of an affine argument
+        lambda x, y: x * y,  # no log factor at all
+        lambda x, y: x * dm.exp(x),  # transcendental that is not log
+    ],
+)
+def test_non_entropy_products_left_untouched(build):
+    """Structurally-different products must not be (mis)matched as entropy."""
+    m = dm.Model("noent")
+    x = m.continuous("x", lb=0.001, ub=10.0)
+    y = m.continuous("y", lb=0.001, ub=10.0)
+    m.minimize(build(x, y))
+    out = canonicalize_entropy(m)
+    assert out is m  # unchanged: same object
+    assert not _has_entropy(out._objective.expression)
+
+
+def test_entropy_domain_guard_rejects_negative_lb():
+    """``x·log(x)`` is only canonicalized when ``x``'s box is nonnegative —
+    consistent with ``relax_entropy``'s ``lb >= 0`` requirement."""
+    m = dm.Model("negdomain")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    m.minimize(x * dm.log(x))
+    out = canonicalize_entropy(m)
+    assert out is m
+    assert not _has_entropy(out._objective.expression)
+
+
+def test_entropy_canonicalized_in_constraint_body():
+    """The rewrite fires in constraint bodies too, not just the objective."""
+    m = dm.Model("entcon")
+    x = m.continuous("x", lb=0.001, ub=1.0)
+    m.minimize(x)
+    m.subject_to(x * dm.log(x) <= -0.1)
+    out = canonicalize_entropy(m)
+    assert out is not m
+    assert any(_has_entropy(c.body) for c in out._constraints)
+
+
+@pytest.mark.correctness
+def test_separable_entropy_objective_certifies():
+    """End-to-end: a separable ``Σ xᵢ·log(xᵢ)`` (entropy/Gibbs) objective is
+    solved to its optimum *and certified*, where the raw product previously left
+    the dual bound stuck at a constant separable floor (issue #207)."""
+    import math
+
+    m = dm.Model("gibbs")
+    xs = [m.continuous(f"x{i}", lb=0.001, ub=1.0) for i in range(3)]
+    m.subject_to(sum(xs) == 1.0)
+    m.minimize(sum(x * dm.log(x) for x in xs))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r = m.solve(time_limit=60, gap_tolerance=1e-4)
+    # Optimum of Σ xᵢ log xᵢ on the simplex is uniform xᵢ = 1/3 -> -log(3).
+    assert r.status == "optimal"
+    assert r.gap_certified, "separable entropy objective should certify"
+    assert r.objective == pytest.approx(-math.log(3), abs=1e-3)
     if r.bound is not None:
         assert r.bound <= r.objective + 1e-4  # sound dual bound
 

--- a/python/tests/test_factorable_reform.py
+++ b/python/tests/test_factorable_reform.py
@@ -332,6 +332,115 @@ def test_separable_entropy_objective_certifies():
         assert r.bound <= r.objective + 1e-4  # sound dual bound
 
 
+# ---------------------------------------------------------------------------
+# centropy canonicalization: x*log(x/y) -> centropy(x, y)  (issue #207)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda x, y: x * dm.log(x / y),  # variable denominator
+        lambda x, y: dm.log(x / y) * x,  # reversed factor order
+        lambda x, y: 2.5 * x * dm.log(x / y),  # with a constant coefficient
+        lambda x, y: -(x * dm.log(x / y)),  # negated
+        lambda x, y: x * dm.log(x / 0.5),  # constant denominator
+        lambda x, y: x * dm.log(x / (x + y)),  # affine-sum denominator (Gibbs form)
+    ],
+)
+def test_centropy_product_is_canonicalized(build):
+    """``c·x·log(x/y)`` is rewritten to ``centropy(x, y)``."""
+    m = dm.Model("cent")
+    x = m.continuous("x", lb=0.001, ub=10.0)
+    y = m.continuous("y", lb=0.1, ub=10.0)
+    m.minimize(build(x, y))
+    out = canonicalize_entropy(m)
+    assert out is not m
+
+    def has_centropy(e):
+        if isinstance(e, FunctionCall):
+            return e.func_name == "centropy" or any(has_centropy(a) for a in e.args)
+        for attr in ("left", "right", "operand"):
+            child = getattr(e, attr, None)
+            if child is not None and has_centropy(child):
+                return True
+        return False
+
+    assert has_centropy(out._objective.expression)
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda x, y: x * dm.log(y / x),  # numerator is the *wrong* variable
+        lambda x, y: y * dm.log(x / y),  # bare factor != log numerator
+        lambda x, y: x * x * dm.log(x / y),  # x²·log(x/y) is not centropy
+    ],
+)
+def test_non_centropy_products_left_untouched(build):
+    """Structurally-different ratios-in-log must not be matched as centropy."""
+    m = dm.Model("nocent")
+    x = m.continuous("x", lb=0.001, ub=10.0)
+    y = m.continuous("y", lb=0.1, ub=10.0)
+    m.minimize(build(x, y))
+    out = canonicalize_entropy(m)
+    assert out is m
+
+
+def test_centropy_domain_guard_rejects_nonpositive_denominator():
+    """``x·log(x/y)`` is only canonicalized when ``y`` is provably positive."""
+    m = dm.Model("centdom")
+    x = m.continuous("x", lb=0.001, ub=1.0)
+    y = m.continuous("y", lb=-1.0, ub=2.0)  # y can be <= 0
+    m.minimize(x * dm.log(x / y))
+    out = canonicalize_entropy(m)
+    assert out is m
+
+
+@pytest.mark.parametrize(
+    "name,x_lb,y_lb,expect_convex",
+    [
+        ("convex", 0.0, 0.1, True),  # x >= 0, y > 0  -> jointly convex
+        ("x_neg", -1.0, 0.1, False),  # x may be negative -> abstain
+        ("y_nonpos", 0.0, -1.0, False),  # y not provably > 0 -> abstain
+    ],
+)
+def test_centropy_curvature_rule(name, x_lb, y_lb, expect_convex):
+    """``centropy`` is detected jointly CONVEX only on a provable ``x≥0, y>0``
+    box with affine arguments; otherwise the rule soundly abstains (UNKNOWN)."""
+    from discopt._jax.convexity import classify_expr
+    from discopt._jax.convexity.lattice import Curvature
+
+    m = dm.Model(name)
+    x = m.continuous("x", lb=x_lb, ub=1.0)
+    y = m.continuous("y", lb=y_lb, ub=2.0)
+    curv = classify_expr(FunctionCall("centropy", x, y), m)
+    if expect_convex:
+        assert curv == Curvature.CONVEX
+    else:
+        assert curv == Curvature.UNKNOWN
+
+
+@pytest.mark.correctness
+def test_relative_entropy_objective_certifies():
+    """End-to-end: a separable relative-entropy / Gibbs objective
+    ``Σ xᵢ·log(xᵢ/yᵢ)`` with a *variable* denominator is solved and *certified*
+    on the convex fast path (jointly-convex centropy), with a sound bound."""
+    m = dm.Model("kl")
+    x = [m.continuous(f"x{i}", lb=0.01, ub=1.0) for i in range(3)]
+    y = [m.continuous(f"y{i}", lb=0.2, ub=0.8) for i in range(3)]
+    m.subject_to(sum(x) == 1.0)
+    m.subject_to(sum(y) == 1.5)
+    m.minimize(sum(xi * dm.log(xi / yi) for xi, yi in zip(x, y)))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r = m.solve(time_limit=60, gap_tolerance=1e-4)
+    assert r.status == "optimal"
+    assert r.gap_certified, "relative-entropy objective should certify (jointly convex)"
+    if r.bound is not None:
+        assert r.bound <= r.objective + 1e-4  # sound dual bound
+
+
 @pytest.mark.correctness
 @pytest.mark.slow
 def test_nvs01_certifies_with_sound_bound():


### PR DESCRIPTION
## Summary

Recover the `entropy(x) = x·log(x)` and `centropy(x, y) = x·log(x/y)` intrinsics from the raw products that AMPL/GAMS emit when lowering these opcodes into `.nl` files. This enables the existing dedicated relaxation and convexity support to tighten bounds and certify separable entropy/relative-entropy objectives on the convex fast path.

## Problem

Models with entropy or relative-entropy objectives (e.g., chemical equilibrium, Gibbs free energy) are lowered by AMPL/GAMS as raw `x·log(x)` and `x·log(x/y)` products in the `.nl` file. The MILP/McCormick-LP relaxer cannot decompose these products and falls back to a constant separable objective floor that never tightens under branching. As a result, discopt finds the global optimum but cannot certify it (issue #207).

## Solution

Implement a pure DAG canonicalization pass that:
1. **Detects entropy products**: Matches `c·x·log(x)` patterns and rewrites to `c·entropy(x)`
2. **Detects relative-entropy products**: Matches `c·x·log(x/y)` patterns and rewrites to `c·centropy(x, y)`
3. **Applies domain guards**: Only rewrites when the variable box is provably nonnegative (entropy) or nonnegative/positive (centropy), consistent with the relaxer's requirements
4. **Preserves identity**: Unchanged subtrees keep object identity, so untouched models are returned byte-for-byte unchanged

The rewrites are exact (`entropy(x) ≡ x·log(x)`, `centropy(x,y) ≡ x·log(x/y)`) and convexity-preserving, so they run unconditionally.

## Key Changes

- **`factorable_reform.py`**: Added `canonicalize_entropy()` pass with helper functions:
  - `_strip_neg()`: Peel leading negation wrappers
  - `_flatten_product()`: Flatten nested multiplication into a factor list
  - `_match_entropy_product()`: Detect and rewrite `c·x·log(x)` → `c·entropy(x)`
  - `_match_centropy_product()`: Detect and rewrite `c·x·log(x/y)` → `c·centropy(x, y)`
  - `_canonicalize_entropy_expr()`: Recursively traverse and rewrite expressions

- **`convexity/rules.py`**: Added `_classify_centropy()` curvature rule that detects `centropy(x, y)` as **jointly convex** on `x ≥ 0, y > 0` with affine arguments (DCP composition rule), enabling a Gibbs/KL objective `Σ nᵢ·log(nᵢ / Σnⱼ)` to certify on the convex fast path

- **`convexity/interval.py`**: Added `centropy()` interval arithmetic via the identity `centropy(x, y) = entropy(x) - x·log(y)`

- **`convexity/interval_eval.py`**: Added interval evaluation for `centropy` function calls

- **`solver.py`**: Integrated `canonicalize_entropy()` into the solve pipeline (after GDP reformulation, before objective-defining-equality relaxation)

- **`test_factorable_reform.py`**: Comprehensive test suite covering:
  - Entropy product canonicalization (various factor orders, coefficients, negation, separable sums)
  - Non-entropy products left untouched (x², log of different variable, log of affine argument, etc.)
  - Domain guard validation (rejects negative lower bounds)
  - Constraint body rewriting
  - End-to-end correctness: separable entropy objective solves and certifies
  - Centropy product canonicalization (variable/constant denominators, affine-sum denominators)

https://claude.ai/code/session_01RxPBuaQ7Wn5ueaDzD6GzhX