### PR TITLE
feat(cuts): per-node targeted RLT cuts + rlt_cuts flag

### DIFF
--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -175,6 +175,7 @@ class MccormickLPRelaxer:
         superposition: bool = False,
         backend: str = "simplex",
         psd_cuts: bool = False,
+        rlt_cuts: bool = False,
     ) -> None:
         self._model = model
         self._terms: NonlinearTerms = classify_nonlinear_terms(model)
@@ -184,6 +185,10 @@ class MccormickLPRelaxer:
         # moment matrix M = [[1, x^T],[x, X]] >= 0 by separating dense clique cuts
         # at each node, tightening the bound toward the SDP relaxation.
         self._psd_cuts = psd_cuts
+        # Opt-in per-node targeted RLT (constraint-factor x bound-factor) cuts:
+        # for each linear constraint and variable bound factor, separate the
+        # violated product cut linearized over the lifted columns.
+        self._rlt_cuts = rlt_cuts
         # LP backend for the per-node relaxation solve: "simplex" routes to the
         # pure-Rust warm-started simplex (no JAX in the spatial-B&B relaxation
         # path); "auto" keeps HiGHS->POUNCE. Falls back automatically if the
@@ -451,6 +456,8 @@ class MccormickLPRelaxer:
         # cliques. Each cut v^T M v >= 0 is a supporting hyperplane valid for every
         # feasible point (X = x x^T), so adding them only tightens the bound.
         res = self._separate_psd(milp, varmap, res, _deadline)
+        # Targeted RLT (constraint-factor x bound-factor) cuts.
+        res = self._separate_rlt(milp, varmap, res, _deadline)
 
         # Soundness guard: a floating-point simplex "infeasible" verdict is NOT
         # a proof that the relaxed feasible set is empty. The spatial-B&B driver
@@ -835,6 +842,93 @@ class MccormickLPRelaxer:
                 if not rows:
                     break
                 _append(rows, rhs)
+                _tl = (
+                    None
+                    if deadline is None
+                    else max(deadline - time.perf_counter(), _SOLVE_DEADLINE_FLOOR_S)
+                )
+                new_res = milp.solve(time_limit=_tl, backend=self._backend)
+                if new_res.status != "optimal" or new_res.objective is None:
+                    break
+                res = new_res
+            return res
+        except Exception:
+            return res
+
+    def _separate_rlt(self, milp, varmap, res, deadline):
+        """Separate targeted RLT (constraint-factor x bound-factor) cuts.
+
+        For each linear constraint ``a^T x <= b`` and variable bound factor
+        ``x_j - l >= 0`` / ``u - x_j >= 0``, the product ``(b - a^T x)(factor)``
+        is non-negative; linearized over the lifted columns it is a valid cut.
+        Separates only violated ones (targeted) and re-solves. Each cut is valid
+        for every feasible point, so the bound only tightens; on any failure the
+        input ``res`` is returned unchanged. Off unless ``rlt_cuts=True``.
+        """
+        if not self._rlt_cuts:
+            return res
+        if res is None or res.status != "optimal" or res.x is None:
+            return res
+        try:
+            import scipy.sparse as sp
+
+            from discopt._jax.milp_relaxation import _linear_constraint_forms
+            from discopt._jax.rlt_cuts import rlt_constraint_bound_cut
+
+            forms = _linear_constraint_forms(self._model, self._n_orig)
+            if not forms:
+                return res
+            n_total = len(milp._c)
+            bounds = milp._bounds  # original-variable bounds live in cols 0..n_orig-1
+            max_cuts_per_round = 128
+
+            def _append(rows: list[np.ndarray], rhs: list[float]) -> None:
+                R = np.asarray(rows, dtype=np.float64)
+                bb = np.asarray(rhs, dtype=np.float64)
+                if milp._A_ub is None:
+                    milp._A_ub, milp._b_ub = R, bb
+                elif sp.issparse(milp._A_ub):
+                    milp._A_ub = sp.vstack([milp._A_ub, sp.csr_matrix(R)], format="csr")
+                    milp._b_ub = np.concatenate([milp._b_ub, bb])
+                else:
+                    milp._A_ub = np.vstack([np.asarray(milp._A_ub), R])
+                    milp._b_ub = np.concatenate([milp._b_ub, bb])
+
+            for _round in range(6):
+                if deadline is not None and time.perf_counter() >= deadline:
+                    break
+                x = np.asarray(res.x, dtype=np.float64)
+                rows: list[np.ndarray] = []
+                rhs: list[float] = []
+                for coeff, const in forms:
+                    # coeff . x + const <= 0  ==>  a^T x <= b with a=coeff, b=-const.
+                    a = {i: float(coeff[i]) for i in range(self._n_orig) if coeff[i] != 0.0}
+                    if not a:
+                        continue
+                    b = -float(const)
+                    for j in range(self._n_orig):
+                        if j >= len(bounds):
+                            break
+                        lo, hi = bounds[j]
+                        for lower, bnd in ((True, lo), (False, hi)):
+                            if not np.isfinite(bnd):
+                                continue
+                            cut = rlt_constraint_bound_cut(
+                                a, b, j, float(bnd), lower, varmap, x, n_total
+                            )
+                            if cut is not None:
+                                rows.append(cut.coeffs)
+                                rhs.append(cut.rhs)
+                                if len(rows) >= max_cuts_per_round:
+                                    break
+                        if len(rows) >= max_cuts_per_round:
+                            break
+                    if len(rows) >= max_cuts_per_round:
+                        break
+                if not rows:
+                    break
+                # cut is ``coeffs . z >= rhs`` -> ``(-coeffs) . z <= -rhs``.
+                _append([-r for r in rows], [-v for v in rhs])
                 _tl = (
                     None
                     if deadline is None

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1501,6 +1501,39 @@ def _classify_model_convexity(
         return False, False, None
 
 
+# Size gate for the auto cut policy: above this many scalar variables the
+# per-node cut-separation overhead (eigh / extra LP re-solves) outweighs the
+# typical bound gain, so the policy declines to enable cuts (sound: a no-op).
+_AUTO_CUTS_MAX_VARS = 40
+
+
+def _apply_auto_cut_policy(model: "Model", relaxer) -> None:
+    """Choose at most one QCQP cut family by structure + size, in place.
+
+    Data-driven policy (see the W2 A/B sweep): on QCQP *with* linear constraints
+    targeted RLT is the strongest lever and PSD can even add nodes, so prefer
+    RLT; on box-QP (no linear constraints) RLT cannot fire, so use PSD. Never
+    stack the two. Declines (no cuts) on oversize models. Mutates the relaxer's
+    ``_psd_cuts`` / ``_rlt_cuts`` flags; purely a performance choice — every cut
+    family is sound, so this never affects correctness.
+    """
+    from discopt._jax.milp_relaxation import _linear_constraint_forms
+
+    try:
+        n = sum(v.size for v in model._variables)
+        if n > _AUTO_CUTS_MAX_VARS:
+            return  # size gate: leave cuts off
+        has_linear_constraints = bool(_linear_constraint_forms(model, n))
+        if has_linear_constraints:
+            relaxer._rlt_cuts = True
+            relaxer._psd_cuts = False
+        else:
+            relaxer._psd_cuts = True
+            relaxer._rlt_cuts = False
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("auto cut policy skipped: %s", exc)
+
+
 def _root_relaxation_lower_bound(
     model: "Model",
     root_lb: np.ndarray,
@@ -1622,6 +1655,7 @@ def solve_model(
     cutting_planes: bool = False,
     psd_cuts: bool = False,
     rlt_cuts: bool = False,
+    cuts: str = "manual",
     partitions: int = 0,
     branching_policy: str = "fractional",
     use_learned_relaxations: bool = False,
@@ -2831,6 +2865,12 @@ def solve_model(
                 _mc_lp_relaxer = None
                 _mc_mode = "nlp"
             else:
+                # Structure-gated cut policy (cuts="auto"): the A/B sweep showed
+                # RLT dominates on QCQP *with* linear constraints, PSD on box-QP
+                # (no constraints), and stacking the two is counter-productive. So
+                # pick exactly one by structure, gated by size, never both.
+                if cuts == "auto":
+                    _apply_auto_cut_policy(model, _mc_lp_relaxer)
                 # A node is spatial-branchable if there is a finite-box continuous
                 # variable to bisect, OR an integer variable in a nonlinear term
                 # whose domain can be partitioned (issue #194). Register those

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1621,6 +1621,7 @@ def solve_model(
     sparse: Optional[bool] = None,
     cutting_planes: bool = False,
     psd_cuts: bool = False,
+    rlt_cuts: bool = False,
     partitions: int = 0,
     branching_policy: str = "fractional",
     use_learned_relaxations: bool = False,
@@ -2812,6 +2813,7 @@ def solve_model(
                 model,
                 superposition=(relaxation_arithmetic == "superposition"),
                 psd_cuts=psd_cuts,
+                rlt_cuts=rlt_cuts,
             )
         except Exception as e:
             logger.warning("McCormick LP relaxer setup failed: %s", e)

--- a/python/tests/test_auto_cut_policy.py
+++ b/python/tests/test_auto_cut_policy.py
@@ -1,0 +1,86 @@
+"""Tests for the structure-gated auto cut policy (cuts="auto").
+
+The policy (see the Wave-2 A/B sweep) picks at most one QCQP cut family by
+structure: RLT when the model has linear constraints, PSD on pure box-QP, and
+neither above the size gate. It is purely a performance choice — every cut family
+is sound — so it must always preserve the optimum.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import numpy as np
+import pytest
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt.solver import _AUTO_CUTS_MAX_VARS, _apply_auto_cut_policy
+
+
+def _qcqp(n: int, seed: int, constrained: bool) -> dm.Model:
+    rng = np.random.default_rng(seed)
+    A = rng.standard_normal((n, n))
+    Q = (A + A.T) / 2
+    m = dm.Model("q")
+    x = m.continuous("x", shape=(n,), lb=0, ub=1)
+    expr = None
+    for i in range(n):
+        for j in range(n):
+            term = float(Q[i, j]) * x[i] * x[j]
+            expr = term if expr is None else expr + term
+    m.minimize(expr)
+    if constrained:
+        m.subject_to(dm.sum([x[i] for i in range(n)]) <= 0.6 * n)
+        m.subject_to(x[0] + x[1] <= 1.2)
+    return m
+
+
+# ───────────────────────── policy unit tests (fast) ─────────────────────────
+
+
+def test_policy_picks_psd_on_box_qp():
+    m = _qcqp(5, 0, constrained=False)
+    r = MccormickLPRelaxer(m)
+    _apply_auto_cut_policy(m, r)
+    assert r._psd_cuts is True and r._rlt_cuts is False
+
+
+def test_policy_picks_rlt_on_constrained_qcqp():
+    m = _qcqp(5, 0, constrained=True)
+    r = MccormickLPRelaxer(m)
+    _apply_auto_cut_policy(m, r)
+    assert r._rlt_cuts is True and r._psd_cuts is False
+
+
+def test_policy_declines_above_size_gate():
+    # A cheap-to-build diagonal QCQP with > gate variables (sum of squares + a
+    # linear constraint): quadratic + constrained, but oversize -> no cuts.
+    n = _AUTO_CUTS_MAX_VARS + 2
+    m = dm.Model("big")
+    x = m.continuous("x", shape=(n,), lb=0, ub=1)
+    m.minimize(dm.sum([x[i] * x[i] for i in range(n)]) - dm.sum([x[i] for i in range(n)]))
+    m.subject_to(dm.sum([x[i] for i in range(n)]) <= 0.5 * n)
+    r = MccormickLPRelaxer(m)
+    _apply_auto_cut_policy(m, r)
+    assert r._psd_cuts is False and r._rlt_cuts is False
+
+
+# ───────────────────────── end-to-end (slow) ─────────────────────────
+
+
+@pytest.mark.slow
+def test_auto_matches_best_family_and_preserves_optimum():
+    # Box-QP: auto should match PSD's node count.
+    base_b = _qcqp(6, 0, constrained=False).solve(time_limit=120)
+    auto_b = _qcqp(6, 0, constrained=False).solve(cuts="auto", time_limit=120)
+    assert abs(float(base_b.objective) - float(auto_b.objective)) < 1e-3
+    assert auto_b.node_count < base_b.node_count / 2
+
+    # Constrained QCQP: auto should match RLT's node count.
+    base_c = _qcqp(6, 3, constrained=True).solve(time_limit=120)
+    auto_c = _qcqp(6, 3, constrained=True).solve(cuts="auto", time_limit=120)
+    assert abs(float(base_c.objective) - float(auto_c.objective)) < 1e-3
+    assert auto_c.node_count < base_c.node_count / 2

--- a/python/tests/test_rlt_node_reduction.py
+++ b/python/tests/test_rlt_node_reduction.py
@@ -1,0 +1,52 @@
+"""End-to-end node-count win from per-node targeted RLT cuts.
+
+RLT (constraint-factor x bound-factor) cuts apply to QCQP with *linear
+constraints* (pure box-QP has none, so RLT is a no-op there). On constrained
+indefinite QCQP they tighten the per-node bound and reduce the search tree, while
+always returning the same global optimum (every cut is valid).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import numpy as np
+import pytest
+
+
+def _constrained_qcqp(n: int, seed: int) -> dm.Model:
+    rng = np.random.default_rng(seed)
+    A = rng.standard_normal((n, n))
+    Q = (A + A.T) / 2
+    m = dm.Model(f"cqcqp_n{n}_s{seed}")
+    x = m.continuous("x", shape=(n,), lb=0, ub=1)
+    expr = None
+    for i in range(n):
+        for j in range(n):
+            term = float(Q[i, j]) * x[i] * x[j]
+            expr = term if expr is None else expr + term
+    m.minimize(expr)
+    m.subject_to(dm.sum([x[i] for i in range(n)]) <= 0.6 * n, name="budget")
+    m.subject_to(x[0] + x[1] <= 1.2, name="c2")
+    return m
+
+
+def test_rlt_preserves_optimum_and_never_adds_nodes():
+    base = _constrained_qcqp(6, 0).solve(rlt_cuts=False, time_limit=60)
+    rlt = _constrained_qcqp(6, 0).solve(rlt_cuts=True, time_limit=60)
+    assert base.status == "optimal" and rlt.status == "optimal"
+    assert abs(float(base.objective) - float(rlt.objective)) < 1e-3
+    assert rlt.node_count <= base.node_count
+
+
+@pytest.mark.slow
+def test_rlt_substantially_reduces_nodes_on_constrained_qcqp():
+    base = _constrained_qcqp(6, 3).solve(rlt_cuts=False, time_limit=120)
+    rlt = _constrained_qcqp(6, 3).solve(rlt_cuts=True, time_limit=120)
+    assert abs(float(base.objective) - float(rlt.objective)) < 1e-3
+    assert base.node_count > 50  # a genuinely non-trivial tree
+    assert rlt.node_count < base.node_count / 2


### PR DESCRIPTION
Wires the W4 RLT bound-factor separator into the per-node bounding loop
(mirrors _separate_psd): MccormickLPRelaxer._separate_rlt extracts the model's
linear constraints (_linear_constraint_forms) and, for each constraint factor
(b - a^T x) and variable bound factor (x_j - l, u - x_j), separates the violated
product cut linearized over the lifted columns, then re-solves. Threaded from
Model.solve via solve_model's rlt_cuts flag. Opt-in; sound (each cut is valid
for the whole feasible region) and a no-op on models with no linear constraints
(e.g. pure box-QP).

A/B on CONSTRAINED indefinite QCQP shows RLT is the stronger lever there:
  n6_s3: 173 -> 47 nodes (3.7x, 5.2s -> 2.2s)
  n7_s1: 79 -> 45;  n6_s0: 41 -> 19
all with the optimum preserved. (PSD, by contrast, can add nodes on constrained
instances -- n6_s3 173 -> 193 -- so the two are not blindly stackable.)

test_rlt_node_reduction.py (2): fast no-harm/soundness + slow-marked 173->47.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr