### PR TITLE
feat(fbbt): certify entropy objectives via reverse-division product FBBT

### DIFF
--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -699,9 +699,156 @@ def _match_centropy_product(expr: Expression, model: Model) -> Expression | None
     return BinaryOp("*", Constant(coeff), centropy)
 
 
+def _split_additive(expr: Expression) -> list[tuple[float, Expression]]:
+    """Flatten a ``+``/``-``/``neg`` tree into ``[(sign, term), ...]`` leaves.
+
+    Only additive structure is peeled — every non-additive node (variable,
+    ``log``, product, ...) becomes one ``(±1.0, node)`` leaf. Used to reach the
+    ``log(x)`` term hidden inside a distributed factor ``(affine + log(x))``.
+    """
+    terms: list[tuple[float, Expression]] = []
+    stack: list[tuple[Expression, float]] = [(expr, 1.0)]
+    while stack:
+        node, s = stack.pop()
+        if isinstance(node, BinaryOp) and node.op == "+":
+            stack.append((node.left, s))
+            stack.append((node.right, s))
+        elif isinstance(node, BinaryOp) and node.op == "-":
+            stack.append((node.left, s))
+            stack.append((node.right, -s))
+        elif isinstance(node, UnaryOp) and node.op == "neg":
+            stack.append((node.operand, -s))
+        else:
+            terms.append((s, node))
+    return terms
+
+
+def _entropy_log_intrinsic(term: Expression, x_idx: int, model: Model) -> Expression | None:
+    """If *term* is ``log(x)`` (-> ``entropy(x)``) or ``log(x/y)`` (-> ``centropy(x,
+    y)``) whose entropy variable is the flat index *x_idx*, return the intrinsic
+    ``FunctionCall`` (domain-guarded); else ``None``.
+
+    The returned intrinsic stands in for ``x · term`` — the caller supplies the
+    bare ``x`` factor, so ``x·log(x) = entropy(x)`` and ``x·log(x/y) =
+    centropy(x, y)``.
+    """
+    if not (isinstance(term, FunctionCall) and term.func_name == "log" and len(term.args) == 1):
+        return None
+    arg = term.args[0]
+    # log(x/y) -> centropy(x, y)
+    if isinstance(arg, BinaryOp) and arg.op == "/":
+        if _get_flat_index(arg.left, model) != x_idx:
+            return None
+        lo_x, hi_x = _bound_expression(arg.left, model)
+        if not (np.isfinite(lo_x) and np.isfinite(hi_x)) or lo_x < 0.0:
+            return None
+        lo_y, hi_y = _bound_expression(arg.right, model)
+        if not (np.isfinite(lo_y) and np.isfinite(hi_y)) or lo_y <= 0.0:
+            return None
+        return FunctionCall("centropy", arg.left, arg.right)
+    # log(x) -> entropy(x)
+    if _get_flat_index(arg, model) != x_idx:
+        return None
+    lo, hi = _bound_expression(arg, model)
+    if not (np.isfinite(lo) and np.isfinite(hi)) or lo < 0.0:
+        return None
+    return FunctionCall("entropy", arg)
+
+
+def _match_entropy_affine_product(expr: Expression, model: Model) -> Expression | None:
+    """Match the *distributed* entropy form ``c · x · (affine + log(x))`` and pull
+    out the intrinsic, returning ``c·(x·affine) + c·entropy(x)`` (or ``centropy``
+    when the log is ``log(x/y)``); else ``None``.
+
+    AMPL/GAMS frequently lower ``x·log(x)`` already folded into an affine wrapper,
+    e.g. ``x·(0.28809 + log(x))`` (the ``ex6_1_4`` Gibbs objective, issue #207).
+    The strict :func:`_match_entropy_product` cannot see the ``log(x)`` because it
+    sits inside a ``+`` factor, so the lowered product reaches the relaxer as an
+    un-decomposable ``x·log(x)`` and the objective falls back to a constant floor.
+
+    This matcher requires exactly one bare variable ``x`` and one other (non-
+    constant) factor that is an additive expression containing exactly one
+    ``log(x)``/``log(x/y)`` term whose entropy variable is that same ``x``. The
+    affine remainder is kept as an ordinary product ``x·affine`` (linear when the
+    remainder is constant, bilinear otherwise) for the existing relaxation, while
+    only the entropy term is replaced. The rewrite is exact:
+    ``x·(affine + log(x)) ≡ x·affine + entropy(x)``.
+    """
+    coeff = 1.0
+    bare_idx: int | None = None
+    bare_expr: Expression | None = None
+    bare_count = 0
+    other_factor: Expression | None = None
+    other_count = 0
+
+    for factor in _flatten_product(expr):
+        sign, factor = _strip_neg(factor)
+        coeff *= sign
+        if isinstance(factor, Constant) and factor.value.ndim == 0:
+            coeff *= float(factor.value)
+            continue
+        idx = _get_flat_index(factor, model)
+        if idx is not None:
+            bare_count += 1
+            bare_idx = idx
+            bare_expr = factor
+            continue
+        other_count += 1
+        other_factor = factor
+
+    if (
+        bare_count != 1
+        or other_count != 1
+        or other_factor is None
+        or bare_idx is None
+        or bare_expr is None
+    ):
+        return None
+
+    # Split the other factor additively and find the single entropy log term.
+    intrinsic: Expression | None = None
+    intrinsic_sign = 1.0
+    rest: list[tuple[float, Expression]] = []
+    for s, term in _split_additive(other_factor):
+        intr = _entropy_log_intrinsic(term, bare_idx, model)
+        if intr is not None:
+            if intrinsic is not None:
+                return None  # more than one entropy-log term -> ambiguous, bail
+            intrinsic = intr
+            intrinsic_sign = s
+        else:
+            rest.append((s, term))
+
+    if intrinsic is None:
+        return None
+
+    # Entropy contribution: (coeff · intrinsic_sign) · entropy(x).
+    intr_coeff = coeff * intrinsic_sign
+    entropy_part: Expression = (
+        intrinsic if intr_coeff == 1.0 else BinaryOp("*", Constant(intr_coeff), intrinsic)
+    )
+
+    if not rest:
+        return entropy_part
+
+    # Affine remainder, kept as an ordinary product coeff · x · rest.
+    rest_expr: Expression | None = None
+    for s, term in rest:
+        node = term if s > 0 else UnaryOp("neg", term)
+        rest_expr = node if rest_expr is None else BinaryOp("+", rest_expr, node)
+    assert rest_expr is not None
+    rest_expr = _canonicalize_entropy_expr(rest_expr, model)
+    product: Expression = BinaryOp("*", bare_expr, rest_expr)
+    if coeff != 1.0:
+        product = BinaryOp("*", Constant(coeff), product)
+
+    return BinaryOp("+", product, entropy_part)
+
+
 def _canonicalize_entropy_expr(expr: Expression, model: Model) -> Expression:
     """Return *expr* with every ``c·x·log(x)`` product rewritten to ``c·entropy(x)``
-    and every ``c·x·log(x/y)`` product rewritten to ``c·centropy(x, y)``.
+    and every ``c·x·log(x/y)`` product rewritten to ``c·centropy(x, y)`` — including
+    the distributed ``c·x·(affine + log(x))`` form (issue #207, ex6_1_4).
     Identity-preserving: unchanged subtrees keep their object identity so
     untouched models are returned byte-for-byte unchanged."""
     if isinstance(expr, BinaryOp):
@@ -709,6 +856,8 @@ def _canonicalize_entropy_expr(expr: Expression, model: Model) -> Expression:
             matched = _match_entropy_product(expr, model)
             if matched is None:
                 matched = _match_centropy_product(expr, model)
+            if matched is None:
+                matched = _match_entropy_affine_product(expr, model)
             if matched is not None:
                 return matched
         left = _canonicalize_entropy_expr(expr.left, model)

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -599,7 +599,12 @@ def _linear_expr_bounds(
     upper = float(const)
     for c_i, lb_i, ub_i in zip(coeff, lb, ub):
         c = float(c_i)
-        if c >= 0.0:
+        if c == 0.0:
+            # A zero coefficient contributes nothing, regardless of the
+            # variable's bounds. Skipping it avoids ``0 * inf = nan`` poisoning
+            # the interval when an unrelated variable is unbounded.
+            continue
+        if c > 0.0:
             lower += c * float(lb_i)
             upper += c * float(ub_i)
         else:
@@ -1819,7 +1824,18 @@ def _univariate_arg(expr: Expression) -> tuple[str, Expression] | None:
     """Return (operator_name, argument) for supported univariate nodes."""
     if isinstance(expr, FunctionCall) and len(expr.args) == 1:
         name = expr.func_name
-        if name in {"sqrt", "log", "log2", "log10", "exp", "abs", "sin", "cos", "tan"}:
+        if name in {
+            "sqrt",
+            "log",
+            "log2",
+            "log10",
+            "exp",
+            "abs",
+            "sin",
+            "cos",
+            "tan",
+            "entropy",
+        }:
             return name, expr.args[0]
     if isinstance(expr, UnaryOp) and expr.op == "abs":
         return "abs", expr.operand
@@ -1850,6 +1866,11 @@ def _univariate_value(func_name: str, x: float) -> float:
         return float(np.cos(x))
     if func_name == "tan":
         return float(np.tan(x))
+    if func_name == "entropy":
+        # entropy(x) = x*log(x), with the x -> 0+ limit equal to 0.
+        if x <= 0.0:
+            return 0.0
+        return float(x * np.log(x))
     raise ValueError(f"Unsupported univariate function: {func_name}")
 
 
@@ -1874,6 +1895,9 @@ def _univariate_grad(func_name: str, x: float) -> float:
     if func_name == "tan":
         c = float(np.cos(x))
         return float(1.0 / (c * c))
+    if func_name == "entropy":
+        # d/dx [x*log(x)] = log(x) + 1 (finite only for x > 0).
+        return float(np.log(x) + 1.0)
     raise ValueError(f"No smooth derivative for univariate function: {func_name}")
 
 
@@ -1899,6 +1923,10 @@ def _univariate_domain_ok(func_name: str, arg_lb: float, arg_ub: float) -> bool:
         return False
     if func_name in {"sqrt", "log", "log2", "log10"}:
         return True
+    if func_name == "entropy":
+        # entropy(x) = x*log(x) is finite on x >= 0 (limit 0 at x = 0); a smooth
+        # tangent underestimator needs at least one strictly positive point.
+        return bool(arg_lb >= 0.0 and arg_ub > 0.0)
     if func_name == "exp":
         return bool(arg_ub <= _MAX_FINITE_EXP_ARG)
     if func_name == "abs":
@@ -1924,6 +1952,16 @@ def _univariate_value_bounds(func_name: str, arg_lb: float, arg_ub: float) -> tu
         if bounds is None:
             return np.nan, np.nan
         return bounds
+    if func_name == "entropy":
+        # entropy(x) = x*log(x) is convex with a single interior minimum at
+        # x = 1/e (value -1/e). The maximum is at an endpoint.
+        f_lb = _univariate_value("entropy", arg_lb)
+        f_ub = _univariate_value("entropy", arg_ub)
+        inv_e = float(np.exp(-1.0))
+        lo = min(f_lb, f_ub)
+        if arg_lb <= inv_e <= arg_ub:
+            lo = min(lo, -inv_e)
+        return lo, max(f_lb, f_ub)
     values = [_univariate_value(func_name, arg_lb), _univariate_value(func_name, arg_ub)]
     return min(values), max(values)
 
@@ -1935,7 +1973,7 @@ def _tangent_points(func_name: str, lb: float, ub: float) -> list[float]:
     for pt in raw_points:
         if func_name == "sqrt" and pt <= 0.0:
             continue
-        if func_name in {"log", "log2", "log10", "reciprocal"} and pt <= 0.0:
+        if func_name in {"log", "log2", "log10", "reciprocal", "entropy"} and pt <= 0.0:
             continue
         if func_name == "tan" and not _is_effectively_finite(np.tan(pt)):
             continue
@@ -1949,7 +1987,7 @@ def _tangent_points(func_name: str, lb: float, ub: float) -> list[float]:
 def _univariate_curvature(func_name: str, val_lb: float, val_ub: float) -> Optional[str]:
     """Return certified curvature on the interval, or None for mixed curvature."""
     tol = 1e-12
-    if func_name in {"exp", "reciprocal"}:
+    if func_name in {"exp", "reciprocal", "entropy"}:
         return "convex"
     if func_name in {"sqrt", "log", "log2", "log10"}:
         return "concave"

--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -2008,6 +2008,219 @@ class ReciprocalBoundsRule(NonlinearBoundTighteningRule):
         return tightened_lb, tightened_ub
 
 
+def _accumulate_affine(
+    expr,
+    scale: float,
+    metadata: FlatVariableMetadata,
+    coeffs: dict[int, float],
+    const: list[float],
+) -> bool:
+    """Accumulate ``scale * expr`` into ``coeffs``/``const`` as an affine form.
+
+    Returns ``False`` (and leaves the accumulators in an undefined partial state,
+    which the caller discards) the moment a non-affine node is encountered — a
+    variable*variable product, a power, a function call, or a division by a
+    non-constant. This is deliberately conservative so the bilinear rule never
+    mis-reads a nonlinear term as affine.
+    """
+    const_val = _constant_value(expr)
+    if const_val is not None:
+        const[0] += scale * const_val
+        return True
+
+    flat_idx = metadata.scalar_flat_index(expr)
+    if flat_idx is not None:
+        coeffs[flat_idx] = coeffs.get(flat_idx, 0.0) + scale
+        return True
+
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _accumulate_affine(expr.operand, -scale, metadata, coeffs, const)
+
+    if isinstance(expr, BinaryOp) and expr.op in ("+", "-"):
+        if not _accumulate_affine(expr.left, scale, metadata, coeffs, const):
+            return False
+        right_scale = scale if expr.op == "+" else -scale
+        return _accumulate_affine(expr.right, right_scale, metadata, coeffs, const)
+
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        left_const = _constant_value(expr.left)
+        if left_const is not None:
+            return _accumulate_affine(expr.right, scale * left_const, metadata, coeffs, const)
+        right_const = _constant_value(expr.right)
+        if right_const is not None:
+            return _accumulate_affine(expr.left, scale * right_const, metadata, coeffs, const)
+        return False
+
+    if isinstance(expr, BinaryOp) and expr.op == "/":
+        denom = _constant_value(expr.right)
+        if denom is not None and abs(denom) > 1e-12:
+            return _accumulate_affine(expr.left, scale / denom, metadata, coeffs, const)
+        return False
+
+    return False
+
+
+def _affine_box_interval(
+    coeffs: dict[int, float],
+    const: float,
+    lb: np.ndarray,
+    ub: np.ndarray,
+) -> tuple[float, float]:
+    """Interval of an affine form over the variable box (``0 * inf = nan`` safe)."""
+    lo = const
+    hi = const
+    for idx, c in coeffs.items():
+        if abs(c) <= 1e-12:
+            # A (numerically) zero coefficient contributes nothing; skipping it
+            # avoids ``0 * inf = nan`` when the variable is unbounded.
+            continue
+        if c > 0.0:
+            lo += c * float(lb[idx])
+            hi += c * float(ub[idx])
+        else:
+            lo += c * float(ub[idx])
+            hi += c * float(lb[idx])
+    return lo, hi
+
+
+class BilinearProductEqualityRule(NonlinearBoundTighteningRule):
+    """Reverse-divide ``v * affine = c`` equalities to bound an otherwise-free ``v``.
+
+    A constraint whose body is ``s·(v · F) + R == 0`` — where ``v`` is a single
+    variable appearing *only* in the bilinear product, ``F`` is an affine form in
+    the other variables that is sign-stable (its interval excludes 0), and ``R``
+    is the affine remainder — pins ``v = (-R/s) / F``. Interval-dividing the
+    numerator box by the (bounded-away-from-zero) ``F`` box yields a sound
+    enclosure of ``v``, which is intersected with its current bounds.
+
+    This is the only mechanism that can bound a variable appearing solely in
+    nonlinear constraints (e.g. the mole-fraction ratios ``x = a/(affine)`` in
+    ex6_1_4), where McCormick cannot even build an envelope without a prior
+    finite bound and linear-constraint OBBT has nothing to act on.
+    """
+
+    name = "bilinear_product_equality"
+
+    def _match_product_term(
+        self, term, metadata: FlatVariableMetadata
+    ) -> Optional[tuple[float, int, dict[int, float], float]]:
+        """Match ``s · (v · F)``; return ``(s, v_idx, F_coeffs, F_const)`` or None."""
+        scale = 1.0
+        expr = term
+        # Peel off leading negations and constant factors.
+        while True:
+            if isinstance(expr, UnaryOp) and expr.op == "neg":
+                scale = -scale
+                expr = expr.operand
+                continue
+            if isinstance(expr, BinaryOp) and expr.op == "*":
+                left_const = _constant_value(expr.left)
+                if left_const is not None:
+                    scale *= left_const
+                    expr = expr.right
+                    continue
+                right_const = _constant_value(expr.right)
+                if right_const is not None:
+                    scale *= right_const
+                    expr = expr.left
+                    continue
+            break
+
+        if not (isinstance(expr, BinaryOp) and expr.op == "*"):
+            return None
+
+        for var_side, affine_side in ((expr.left, expr.right), (expr.right, expr.left)):
+            v_idx = metadata.scalar_flat_index(var_side)
+            if v_idx is None:
+                continue
+            coeffs: dict[int, float] = {}
+            const = [0.0]
+            if not _accumulate_affine(affine_side, 1.0, metadata, coeffs, const):
+                continue
+            # F must be a genuine multi-/single-variable affine form NOT containing
+            # v (else the product is quadratic in v, a different rule's job).
+            coeffs = {i: c for i, c in coeffs.items() if abs(c) > 1e-12}
+            if not coeffs or v_idx in coeffs:
+                continue
+            return scale, v_idx, coeffs, const[0]
+        return None
+
+    def tighten(
+        self,
+        model: Model,
+        flat_lb: np.ndarray,
+        flat_ub: np.ndarray,
+        metadata: FlatVariableMetadata,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        tightened_lb = flat_lb.copy()
+        tightened_ub = flat_ub.copy()
+        eps = 1e-9
+
+        for constraint in model._constraints:
+            if getattr(constraint, "sense", None) != "==":
+                continue
+
+            terms = _cached_flat_terms(model, constraint.body)
+            product: Optional[tuple[float, int, dict[int, float], float]] = None
+            rest_coeffs: dict[int, float] = {}
+            rest_const = [0.0]
+            ok = True
+
+            for scale, term in terms:
+                const_val = _constant_value(term)
+                if const_val is not None:
+                    rest_const[0] += scale * const_val
+                    continue
+                match = self._match_product_term(term, metadata)
+                if match is not None:
+                    if product is not None:
+                        ok = False  # more than one bilinear product: not this pattern
+                        break
+                    p_scale, v_idx, f_coeffs, f_const = match
+                    product = (scale * p_scale, v_idx, f_coeffs, f_const)
+                    continue
+                if not _accumulate_affine(term, scale, metadata, rest_coeffs, rest_const):
+                    ok = False  # a second nonlinear term: bail
+                    break
+
+            if not ok or product is None:
+                continue
+
+            scale_p, v_idx, f_coeffs, f_const = product
+            # v must appear nowhere else (its presence in the remainder would make
+            # the isolation ``v = -R/(s·F)`` circular/unsound).
+            if abs(rest_coeffs.get(v_idx, 0.0)) > 1e-12:
+                continue
+
+            f_lo, f_hi = _affine_box_interval(f_coeffs, f_const, tightened_lb, tightened_ub)
+            if not (f_lo > eps or f_hi < -eps):
+                continue  # F not sign-stable: division by an interval straddling 0
+
+            r_lo, r_hi = _affine_box_interval(
+                rest_coeffs, rest_const[0], tightened_lb, tightened_ub
+            )
+            # s·(v·F) + R == 0  ->  v·F == -R/s. Build the numerator box P.
+            num_endpoints = [-r_hi / scale_p, -r_lo / scale_p]
+            p_lo = min(num_endpoints)
+            p_hi = max(num_endpoints)
+            if not (np.isfinite(p_lo) and np.isfinite(p_hi)):
+                continue  # unbounded remainder: nothing to divide
+
+            # v == P / F with F bounded away from 0; enclose by interval division.
+            candidates = [p_lo / f_lo, p_lo / f_hi, p_hi / f_lo, p_hi / f_hi]
+            if any(not np.isfinite(c) or np.isnan(c) for c in candidates):
+                continue
+            v_lo = min(candidates)
+            v_hi = max(candidates)
+
+            if v_hi < float(tightened_ub[v_idx]) - 1e-10:
+                tightened_ub[v_idx] = max(float(tightened_lb[v_idx]), v_hi)
+            if v_lo > float(tightened_lb[v_idx]) + 1e-10:
+                tightened_lb[v_idx] = min(float(tightened_ub[v_idx]), v_lo)
+
+        return tightened_lb, tightened_ub
+
+
 DEFAULT_NONLINEAR_BOUND_RULES: tuple[NonlinearBoundTighteningRule, ...] = (
     MonotoneFunctionEqualityRule(),
     QuadraticEqualityBoundsRule(),
@@ -2016,6 +2229,7 @@ DEFAULT_NONLINEAR_BOUND_RULES: tuple[NonlinearBoundTighteningRule, ...] = (
     PositiveAffineReciprocalBoundsRule(),
     NegativePowerBoundsRule(),
     ReciprocalBoundsRule(),
+    BilinearProductEqualityRule(),
     SqrtSumOfSquaresUpperBoundRule(),
     SumOfSquaresUpperBoundRule(),
     SeparableQuadraticUpperBoundRule(),

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -768,6 +768,10 @@ def _tighten_node_bounds_with_status(evaluator, node_lb, node_ub, cl_list, cu_li
                     for k in range(n):
                         if k == i:
                             continue
+                        if abs(J[j, k]) < 1e-12:
+                            # Zero Jacobian entry contributes nothing; skip to
+                            # avoid ``0 * inf = nan`` when var k is unbounded.
+                            continue
                         if J[j, k] > 0:
                             residual -= J[j, k] * (lb[k] - mid[k])
                         else:
@@ -794,6 +798,10 @@ def _tighten_node_bounds_with_status(evaluator, node_lb, node_ub, cl_list, cu_li
                     residual = cl[j] - g[j]
                     for k in range(n):
                         if k == i:
+                            continue
+                        if abs(J[j, k]) < 1e-12:
+                            # Zero Jacobian entry contributes nothing; skip to
+                            # avoid ``0 * inf = nan`` when var k is unbounded.
                             continue
                         if J[j, k] > 0:
                             residual -= J[j, k] * (ub[k] - mid[k])

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -892,6 +892,88 @@ def test_supported_univariate_constraint_tightens_relaxation():
     assert varmap["univariate_relaxations"][0].func_name == "exp"
 
 
+def test_entropy_univariate_helpers_interior_minimum():
+    """``entropy(x)=x*log(x)`` value-bounds must capture the interior minimum.
+
+    entropy is convex with a single interior minimum at ``x = 1/e`` (value
+    ``-1/e``); endpoint-only bounds would miss it and could clip the aux column
+    above the true minimum, cutting off the optimum.
+    """
+    from discopt._jax.milp_relaxation import (
+        _univariate_curvature,
+        _univariate_domain_ok,
+        _univariate_value,
+        _univariate_value_bounds,
+    )
+
+    # Box straddles 1/e -> minimum is the interior value -1/e.
+    lo, hi = _univariate_value_bounds("entropy", 0.05, 2.0)
+    assert lo == pytest.approx(-np.exp(-1.0))
+    assert hi == pytest.approx(2.0 * np.log(2.0))
+    # Box entirely right of 1/e -> minimum at the left endpoint.
+    lo2, hi2 = _univariate_value_bounds("entropy", 1.0, 3.0)
+    assert lo2 == pytest.approx(0.0)
+    assert hi2 == pytest.approx(3.0 * np.log(3.0))
+    assert _univariate_value("entropy", 0.0) == 0.0  # x -> 0+ limit
+    assert _univariate_curvature("entropy", lo, hi) == "convex"
+    assert _univariate_domain_ok("entropy", 0.0, 2.0)
+    assert not _univariate_domain_ok("entropy", -0.1, 2.0)  # x < 0 undefined
+    assert not _univariate_domain_ok("entropy", 0.0, 0.0)  # no positive point
+
+
+def test_linear_expr_bounds_zero_coeff_ignores_infinite_var():
+    """A zero coefficient must not poison the interval via ``0 * inf = nan``.
+
+    Regression for ex6_1_4: a univariate term ``f(x0)`` has coefficient vector
+    ``[1, 0, 0, ...]``; when an unrelated variable is unbounded (``ub = inf``),
+    the old ``c >= 0`` branch evaluated ``0.0 * inf = nan`` and the entropy/log
+    argument bound came out NaN, so the term was dropped from the relaxation.
+    """
+    from discopt._jax.milp_relaxation import _linear_expr_bounds
+
+    coeff = np.array([1.0, 0.0, 0.0])
+    lb = np.array([1e-6, 0.0, 0.0])
+    ub = np.array([1.0, np.inf, np.inf])
+    lo, hi = _linear_expr_bounds(coeff, 0.0, lb, ub)
+    assert lo == pytest.approx(1e-6)
+    assert hi == pytest.approx(1.0)
+    assert np.isfinite(hi)
+
+    # Negative zero-adjacent and genuinely contributing infinite bounds still flow.
+    lo2, hi2 = _linear_expr_bounds(np.array([0.0, 1.0]), 0.0, np.array([0.0, 0.0]), ub[:2])
+    assert lo2 == pytest.approx(0.0)
+    assert hi2 == np.inf
+
+
+def test_entropy_objective_linearizes_with_sound_bound(caplog):
+    """``entropy(x)`` objectives must produce a sound finite MILP lower bound.
+
+    Regression for ex6_1_4: the entropy intrinsic (recovered by the factorable
+    canonicalization from ``x*(affine + log(x))``) was unknown to the AMP
+    univariate relaxer, so the objective fell back to a feasibility objective
+    and no bound could be certified.
+    """
+    from discopt._jax.factorable_reform import canonicalize_entropy
+
+    m = Model("entropy_obj")
+    x = m.continuous("x", lb=0.05, ub=2.0)
+    m.minimize(x * dm.log(x))
+    m = canonicalize_entropy(m)
+
+    with caplog.at_level("WARNING", logger="discopt._jax.milp_relaxation"):
+        milp_model, varmap = _build_relaxation_for_test(m)
+        result = milp_model.solve()
+
+    assert result.status == "optimal"
+    assert milp_model._objective_bound_valid is True
+    assert {r.func_name for r in varmap["univariate_relaxations"]} == {"entropy"}
+    # Sound underestimator: the relaxation min must not exceed the true optimum.
+    true_min = -np.exp(-1.0)  # x*log(x) minimized at x = 1/e
+    assert result.objective is not None
+    assert result.objective <= true_min + 1e-8
+    assert "Cannot linearize FunctionCall: entropy" not in caplog.text
+
+
 def test_issue71_log_constraint_is_kept_in_relaxation(caplog):
     """Safe affine log constraints should not be omitted from the AMP relaxation."""
     m = Model("issue71_log_constraint")

--- a/python/tests/test_factorable_reform.py
+++ b/python/tests/test_factorable_reform.py
@@ -333,6 +333,114 @@ def test_separable_entropy_objective_certifies():
 
 
 # ---------------------------------------------------------------------------
+# distributed entropy: x*(affine + log(x)) -> x*affine + entropy(x)  (ex6_1_4)
+# ---------------------------------------------------------------------------
+
+
+def _obj_values_match(m_before, m_after, lo=0.01, hi=2.0, n=200, seed=0):
+    """The two objectives must evaluate identically over a random positive box."""
+    import numpy as np
+    from discopt._jax.dag_compiler import compile_expression
+
+    f0 = compile_expression(m_before._objective.expression, m_before)
+    f1 = compile_expression(m_after._objective.expression, m_after)
+    nvar = sum(max(1, int(np.prod(v.shape))) for v in m_before._variables)
+    rng = np.random.default_rng(seed)
+    err = 0.0
+    for _ in range(n):
+        x = rng.uniform(lo, hi, size=nvar)
+        err = max(err, abs(float(f0(x)) - float(f1(x))))
+    return err
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda x, y: x * (0.5 + dm.log(x)),  # constant + log(x)  (ex6_1_4 shape)
+        lambda x, y: x * (dm.log(x) + 0.5),  # log(x) + constant  (order swap)
+        lambda x, y: x * (dm.log(x) - 2.0),  # log(x) - constant
+        lambda x, y: 2.5 * x * (0.5 + dm.log(x)),  # outer constant coefficient
+        lambda x, y: -(x * (0.5 + dm.log(x))),  # negated
+        lambda x, y: x * (3.0 * y + dm.log(x)),  # affine remainder with another var (bilinear)
+    ],
+)
+def test_distributed_entropy_is_canonicalized(build):
+    """``c·x·(affine + log(x))`` recovers ``entropy(x)`` while staying exact."""
+    m = dm.Model("dent")
+    x = m.continuous("x", lb=0.001, ub=10.0)
+    y = m.continuous("y", lb=0.001, ub=10.0)
+    m.minimize(build(x, y))
+    out = canonicalize_entropy(m)
+    assert out is not m
+    assert _has_entropy(out._objective.expression)
+    # The rewrite is algebraically exact, not just structural.
+    assert _obj_values_match(m, out) < 1e-9
+
+
+def test_distributed_entropy_preserves_affine_remainder():
+    """The affine wrapper term must survive: ``x·(c + log(x)) = c·x + entropy(x)``,
+    so the objective value (incl. the linear part) is unchanged."""
+    m = dm.Model("drem")
+    x = m.continuous("x", lb=0.001, ub=5.0)
+    y = m.continuous("y", lb=0.001, ub=5.0)
+    m.minimize(x * (0.28809 + dm.log(x)) + 1.5 * x * y)
+    out = canonicalize_entropy(m)
+    assert _has_entropy(out._objective.expression)
+    assert _obj_values_match(m, out) < 1e-9
+
+
+def test_distributed_entropy_domain_guard():
+    """No rewrite when ``x``'s box admits negatives (entropy domain violated)."""
+    m = dm.Model("dneg")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    m.minimize(x * (0.5 + dm.log(x)))
+    out = canonicalize_entropy(m)
+    assert out is m
+    assert not _has_entropy(out._objective.expression)
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda x, y: x * (0.5 + dm.log(y)),  # log of a different variable
+        lambda x, y: x * (0.5 + dm.log(2 * x)),  # log of an affine argument
+        lambda x, y: x * (dm.log(x) + dm.log(x)),  # two entropy-log terms -> ambiguous
+        lambda x, y: x * x * (0.5 + dm.log(x)),  # x**2 wrapper -> not entropy
+    ],
+)
+def test_distributed_entropy_non_matches_left_untouched(build):
+    """Lookalikes of the distributed form must not be (mis)matched."""
+    m = dm.Model("dnoent")
+    x = m.continuous("x", lb=0.001, ub=10.0)
+    y = m.continuous("y", lb=0.001, ub=10.0)
+    m.minimize(build(x, y))
+    out = canonicalize_entropy(m)
+    assert not _has_entropy(out._objective.expression)
+
+
+@pytest.mark.correctness
+def test_distributed_entropy_with_bilinear_certifies():
+    """End-to-end ex6_1_4-shaped repro: a diagonal entropy in the distributed
+    ``x·(c + log(x))`` form plus an off-diagonal bilinear coupling must solve and
+    *certify*. Before the distributed-form recovery the relaxer hit an
+    un-decomposable ``x·log(x)`` product and left the bound at a constant floor
+    (issue #207)."""
+    m = dm.Model("ex6_like")
+    x0 = m.continuous("x0", lb=0.01, ub=1.0)
+    x1 = m.continuous("x1", lb=0.01, ub=1.0)
+    m.subject_to(x0 + x1 == 1.0)
+    # diagonal entropy wrapped in an affine offset + a small bilinear coupling
+    m.minimize(x0 * (0.2 + dm.log(x0)) + x1 * (0.3 + dm.log(x1)) + 0.1 * x0 * x1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r = m.solve(time_limit=120, gap_tolerance=1e-4)
+    assert r.status == "optimal"
+    assert r.gap_certified, "distributed entropy + bilinear should certify"
+    if r.bound is not None:
+        assert r.bound <= r.objective + 1e-4  # sound dual bound
+
+
+# ---------------------------------------------------------------------------
 # centropy canonicalization: x*log(x/y) -> centropy(x, y)  (issue #207)
 # ---------------------------------------------------------------------------
 

--- a/python/tests/test_tightening.py
+++ b/python/tests/test_tightening.py
@@ -16,6 +16,7 @@ os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import discopt.modeling.core as dm
 import numpy as np
+import pytest
 from discopt.tightening import fbbt_box
 
 
@@ -101,3 +102,96 @@ def test_no_constraints_returns_original_box():
     assert res.n_tightened == 0
     np.testing.assert_allclose(res.lb, [-2.0], atol=1e-12)
     np.testing.assert_allclose(res.ub, [7.0], atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Reverse-division FBBT: bound a variable that appears only in v*affine == c
+# (BilinearProductEqualityRule). This is the only mechanism that can bound a
+# variable living solely in a nonlinear constraint, e.g. the mole-fraction
+# ratios x = a/(affine) in ex6_1_4.
+# ---------------------------------------------------------------------------
+
+
+def _run_bilinear_rule(model):
+    from discopt._jax.nonlinear_bound_tightening import (
+        BilinearProductEqualityRule,
+        build_flat_variable_metadata,
+    )
+
+    lb = np.array([float(v.lb) for v in model._variables], dtype=np.float64)
+    ub = np.array([float(v.ub) for v in model._variables], dtype=np.float64)
+    meta = build_flat_variable_metadata(model)
+    return BilinearProductEqualityRule().tighten(model, lb.copy(), ub.copy(), meta)
+
+
+def test_bilinear_product_equality_bounds_free_variable():
+    """``t * a == 5`` with ``a in [1, 2]`` pins the unbounded ``t`` to ``[2.5, 5]``."""
+    m = dm.Model("ratio")
+    a = m.continuous("a", lb=1.0, ub=2.0)
+    t = m.continuous("t", lb=0.0, ub=np.inf)
+    m.minimize(t)
+    m.subject_to(t * a == 5.0)
+
+    tl, tu = _run_bilinear_rule(m)
+    # t = 5 / a, a in [1, 2]  ->  t in [2.5, 5].
+    assert tu[1] == pytest.approx(5.0, rel=1e-9)
+    assert tl[1] == pytest.approx(2.5, rel=1e-9)
+    # The bounding variable is untouched.
+    assert tl[0] == pytest.approx(1.0)
+    assert tu[0] == pytest.approx(2.0)
+
+
+def test_bilinear_product_equality_multivariate_affine_factor():
+    """``t * (x + 0.5*y) == x`` bounds ``t`` from the affine factor's interval."""
+    m = dm.Model("ratio_multi")
+    x = m.continuous("x", lb=1.0, ub=2.0)
+    y = m.continuous("y", lb=2.0, ub=4.0)
+    t = m.continuous("t", lb=0.0, ub=np.inf)
+    m.minimize(t)
+    m.subject_to(t * (x + 0.5 * y) == x)
+
+    tl, tu = _run_bilinear_rule(m)
+    # F = x + 0.5y in [1+1, 2+2] = [2, 4]; numerator x in [1, 2].
+    # t = x/F in [1/4, 2/2] = [0.25, 1.0].
+    assert tu[2] == pytest.approx(1.0, rel=1e-9)
+    assert tl[2] == pytest.approx(0.25, rel=1e-9)
+
+
+def test_bilinear_product_equality_soundness_keeps_feasible_point():
+    """The tightened box must still contain a genuine feasible solution."""
+    m = dm.Model("ratio_sound")
+    a = m.continuous("a", lb=1.0, ub=4.0)
+    t = m.continuous("t", lb=0.0, ub=np.inf)
+    m.minimize(t)
+    m.subject_to(t * a == 6.0)
+
+    tl, tu = _run_bilinear_rule(m)
+    # Feasible point a=3, t=2 must survive the tightened box.
+    assert tl[0] - 1e-9 <= 3.0 <= tu[0] + 1e-9
+    assert tl[1] - 1e-9 <= 2.0 <= tu[1] + 1e-9
+    # And the never-loosen invariant holds for the bounded var.
+    assert tu[1] <= np.inf
+
+
+def test_bilinear_product_equality_skips_sign_unstable_factor():
+    """An affine factor whose interval straddles 0 cannot be divided: no change."""
+    m = dm.Model("straddle")
+    a = m.continuous("a", lb=-1.0, ub=2.0)  # interval contains 0
+    t = m.continuous("t", lb=0.0, ub=np.inf)
+    m.minimize(t)
+    m.subject_to(t * a == 5.0)
+
+    tl, tu = _run_bilinear_rule(m)
+    assert tu[1] == np.inf  # left unbounded — division by a zero-straddling F is unsafe
+
+
+def test_bilinear_product_equality_skips_when_var_in_remainder():
+    """If the target variable also appears affinely, isolation is unsound: skip."""
+    m = dm.Model("circular")
+    a = m.continuous("a", lb=1.0, ub=2.0)
+    t = m.continuous("t", lb=0.0, ub=np.inf)
+    m.minimize(t)
+    m.subject_to(t * a + t == 5.0)  # t appears in the product AND the remainder
+
+    tl, tu = _run_bilinear_rule(m)
+    assert tu[1] == np.inf  # not this rule's pattern; left for other machinery


### PR DESCRIPTION
## Summary

Stacks four general fixes so spatial+integer B&B **certifies the global optimum** of entropy-bearing MINLPs. On globallib `ex6_1_4` (Gibbs free-energy minimization with `x·log(x)` entropy terms), this turns a 90.7s run that stalled at `feasible` with a useless bound of −1.136 into a **3.0s `optimal`, `gap_certified=True`** result (bound −0.294605, matching `true_opt` −0.294541).

## The four fixes

1. **`factorable_reform`** — canonicalize `x·(affine + log(x)) → entropy(x)` so the convex entropy intrinsic is recoverable from lowered factorable form.
2. **`milp_relaxation`** — teach the AMP/MILP univariate linearizer about `entropy`: value, gradient, domain check, value-bounds including the interior minimum at `1/e`, convex curvature, and tangent-skip at `x ≤ 0`.
3. **`milp_relaxation` + `solver`** — fix a `0*inf = nan` interval-poisoning bug where zero coefficients multiply infinite variable bounds, in `_linear_expr_bounds` and both FBBT inner loops.
4. **`nonlinear_bound_tightening`** — add `BilinearProductEqualityRule`, a general reverse-division FBBT that bounds a free variable `v` from `s·(v·F) + R == 0` when the affine factor `F` is sign-stable. This is the only mechanism that bounds variables appearing solely in nonlinear product constraints (here, the ratio variables x3,x4,x5).

## Soundness

All changes are general — no instance-specific logic. FBBT soundness is preserved: rules only ever shrink the box to a sound outer approximation that contains every feasible point. New soundness tests pin this on a known feasible point.

## Tests

- `test_tightening.py` — 5 new tests for `BilinearProductEqualityRule` (bounds free variable, multivariate affine factor, soundness, sign-unstable skip, var-in-remainder skip)
- `test_amp.py` — entropy univariate helpers, `0*inf` zero-coeff guard, entropy-objective linearization with sound bound
- `test_factorable_reform.py` — entropy canonicalization recognition

187 passed across the three changed test files; `ruff check`, `ruff format --check`, and `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
