### PR TITLE
fix(export): preserve integrality for discrete vars in nonlinear .nl export

### DIFF
--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -141,10 +141,20 @@ class _NLWriter:
         self._con_linear: list[dict[int, float]] = []  # per constraint
         self._con_nonlinear: list[Expression | None] = []
         self._con_bounds: list[tuple[int, float, float]] = []  # (type, lb, ub)
+        # Header discrete/nonlinear counts, filled by _reorder_vars_canonical.
+        self._nlvc_total = 0  # total nonlinear vars in constraints (incl. both)
+        self._nlvo_total = 0  # total nonlinear vars in objectives (incl. both)
+        self._nlvb = 0  # nonlinear vars in both cons + objs
+        self._nlvbi = 0  # integer/binary vars nonlinear in both
+        self._nlvci = 0  # integer/binary vars nonlinear in cons only
+        self._nlvoi = 0  # integer/binary vars nonlinear in objs only
+        self._nbv = 0  # linear binary vars
+        self._niv = 0  # linear integer vars
 
     def write(self) -> str:
         self._build_var_map()
         self._decompose_expressions()
+        self._reorder_vars_canonical()
         buf = io.StringIO()
         self._write_header(buf)
         self._write_C_sections(buf)
@@ -182,6 +192,109 @@ class _NLWriter:
 
         for idx, (var, elem) in enumerate(self._flat_vars):
             self._var_index[(var.name, elem)] = idx
+
+    # ── Reorder variables into canonical AMPL .nl order ──
+
+    def _reorder_vars_canonical(self):
+        """Reorder ``_flat_vars`` into the canonical AMPL ``.nl`` sequence.
+
+        The ``.nl`` format requires nonlinear variables to occupy the lowest
+        indices, grouped as ``[nl in both cons+objs | nl in cons only |
+        nl in objs only | linear]``; within each nonlinear group the integer
+        (and binary) members come **last**, and the linear tail is ordered
+        ``[continuous | binary | integer]``. The header's discrete-count line
+        (``nbv niv nlvbi nlvci nlvoi``) then declares how many of each group
+        are discrete.
+
+        The previous order (all continuous, then all discrete) wrote *every*
+        discrete variable as linear-discrete (``nbv``/``niv``) with
+        ``nlvbi=nlvci=nlvoi=0``. AMPL-compatible solvers (SCIP, BARON, Couenne,
+        Ipopt) read a discrete variable appearing in a nonlinear expression as
+        **continuous** under that encoding and silently solve a relaxation
+        (issue #210). Pure MILP/LP export is unaffected — there the discrete
+        vars are genuinely linear, so ``nbv``/``niv`` are already correct.
+
+        Must run after :meth:`_decompose_expressions` (it needs the nonlinear
+        expressions and the linear-coefficient dicts). It rebuilds
+        ``_var_index`` and remaps the index-keyed ``_obj_linear`` /
+        ``_con_linear`` dicts; nonlinear expressions resolve through
+        ``_var_index`` at write time and so remap automatically.
+        """
+        # Classify variables (by current index) appearing in nonlinear parts.
+        nl_cons: set[int] = set()
+        nl_objs: set[int] = set()
+        for nl in self._con_nonlinear:
+            if nl is not None:
+                self._collect_var_indices(nl, nl_cons)
+        if self._obj_nonlinear is not None:
+            self._collect_var_indices(self._obj_nonlinear, nl_objs)
+        nl_both = nl_cons & nl_objs
+        nl_cons_only = nl_cons - nl_both
+        nl_objs_only = nl_objs - nl_both
+        nl_all = nl_cons | nl_objs
+
+        def is_discrete(old_idx: int) -> bool:
+            var, _ = self._flat_vars[old_idx]
+            return var.var_type in (VarType.BINARY, VarType.INTEGER)
+
+        def split_group(idxs: set[int]) -> tuple[list[int], list[int]]:
+            """Continuous members first, discrete members last (stable by index)."""
+            ordered = sorted(idxs)
+            cont = [i for i in ordered if not is_discrete(i)]
+            disc = [i for i in ordered if is_discrete(i)]
+            return cont, disc
+
+        both_cont, both_disc = split_group(nl_both)
+        cons_cont, cons_disc = split_group(nl_cons_only)
+        objs_cont, objs_disc = split_group(nl_objs_only)
+
+        # Linear tail: continuous, then binary, then integer (preserving order).
+        lin_cont: list[int] = []
+        lin_bin: list[int] = []
+        lin_int: list[int] = []
+        for old_idx, (var, _elem) in enumerate(self._flat_vars):
+            if old_idx in nl_all:
+                continue
+            if var.var_type == VarType.BINARY:
+                lin_bin.append(old_idx)
+            elif var.var_type == VarType.INTEGER:
+                lin_int.append(old_idx)
+            else:
+                lin_cont.append(old_idx)
+
+        new_order = (
+            both_cont
+            + both_disc
+            + cons_cont
+            + cons_disc
+            + objs_cont
+            + objs_disc
+            + lin_cont
+            + lin_bin
+            + lin_int
+        )
+
+        # Rebuild flat var list and the (name, elem) -> index map.
+        old_flat = self._flat_vars
+        self._flat_vars = [old_flat[i] for i in new_order]
+        old2new = {old: new for new, old in enumerate(new_order)}
+        self._var_index = {}
+        for new_idx, (var, elem) in enumerate(self._flat_vars):
+            self._var_index[(var.name, elem)] = new_idx
+
+        # Remap index-keyed linear coefficient dicts.
+        self._obj_linear = {old2new[k]: v for k, v in self._obj_linear.items()}
+        self._con_linear = [{old2new[k]: v for k, v in lin.items()} for lin in self._con_linear]
+
+        # Stash header counts (line 4: nlvc/nlvo totals + nlvb; line 6: discrete).
+        self._nlvc_total = len(nl_cons)
+        self._nlvo_total = len(nl_objs)
+        self._nlvb = len(nl_both)
+        self._nlvbi = len(both_disc)
+        self._nlvci = len(cons_disc)
+        self._nlvoi = len(objs_disc)
+        self._nbv = len(lin_bin)
+        self._niv = len(lin_int)
 
     # ── Decompose expressions into linear + nonlinear parts ──
 
@@ -540,18 +653,6 @@ class _NLWriter:
         n_nl_cons = sum(1 for nl in self._con_nonlinear if nl is not None)
         n_nl_objs = 1 if self._obj_nonlinear is not None else 0
 
-        # Count variables appearing in nonlinear expressions
-        nl_var_set_cons: set[int] = set()
-        nl_var_set_objs: set[int] = set()
-        for nl in self._con_nonlinear:
-            if nl is not None:
-                self._collect_var_indices(nl, nl_var_set_cons)
-        if self._obj_nonlinear is not None:
-            self._collect_var_indices(self._obj_nonlinear, nl_var_set_objs)
-        nl_both = nl_var_set_cons & nl_var_set_objs
-        nl_cons_only = nl_var_set_cons - nl_both
-        nl_objs_only = nl_var_set_objs - nl_both
-
         # Count Jacobian nonzeros (linear + nonlinear vars in each constraint)
         n_jac_nz = sum(len(lin) for lin in self._con_linear)
         # Add nonlinear variable references in constraints
@@ -576,15 +677,20 @@ class _NLWriter:
         buf.write(f" {n_nl_cons} {n_nl_objs}\t# nonlinear constraints, objectives\n")
         # Line 3: network (unused)
         buf.write(" 0 0\t# network constraints\n")
-        # Line 4: nonlinear variable distribution
+        # Line 4: nonlinear variable distribution (nlvc/nlvo are TOTALS, incl. both)
         buf.write(
-            f" {len(nl_cons_only)} {len(nl_objs_only)} {len(nl_both)}"
+            f" {self._nlvc_total} {self._nlvo_total} {self._nlvb}"
             "\t# nonlinear vars in cons, objs, both\n"
         )
         # Line 5: flags
         buf.write(" 0 0 0 1 0\t# flags\n")
-        # Line 6: discrete variable counts
-        buf.write(f" {self._n_binary} {self._n_integer} 0 0 0\t# binary, integer vars\n")
+        # Line 6: discrete variable counts: nbv niv nlvbi nlvci nlvoi
+        # (linear-binary, linear-integer, then integer/binary vars nonlinear in
+        #  both / cons-only / objs-only — see _reorder_vars_canonical, issue #210)
+        buf.write(
+            f" {self._nbv} {self._niv} {self._nlvbi} {self._nlvci} {self._nlvoi}"
+            "\t# nbv niv nlvbi nlvci nlvoi\n"
+        )
         # Line 7: sparsity
         buf.write(f" {n_jac_nz} {n_grad_nz}\t# Jacobian, gradient nonzeros\n")
         # Line 8: name lengths

--- a/python/tests/test_nl_writer.py
+++ b/python/tests/test_nl_writer.py
@@ -158,6 +158,170 @@ class TestNLWriterMINLP:
         assert "1 0 0 0 0" in lines[6]  # 1 binary
 
 
+class TestNLWriterDiscreteInNonlinear:
+    """Discrete variables that appear in nonlinear expressions (issue #210).
+
+    AMPL requires nonlinear variables to occupy the lowest indices and declares
+    the discrete ones among them via the header's ``nbv niv nlvbi nlvci nlvoi``
+    line (linear-binary, linear-integer, then integer/binary nonlinear in
+    both / cons-only / objs-only). The previous writer wrote *every* discrete
+    var as linear-discrete (``nbv``/``niv``) with ``nlvbi=nlvci=nlvoi=0``, so an
+    AMPL-compatible solver read a discrete-in-nonlinear var as continuous and
+    silently solved a relaxation.
+    """
+
+    @staticmethod
+    def _disc_line(nl: str) -> str:
+        return nl.split("\n")[6].split("#")[0].strip()
+
+    @staticmethod
+    def _nlvar_line(nl: str) -> str:
+        return nl.split("\n")[4].split("#")[0].strip()
+
+    def test_integer_in_nonlinear_objective(self):
+        """An integer var inside the objective's nonlinear part -> nlvoi."""
+        m = dm.Model("int_in_nl_obj")
+        n = m.integer("n", lb=1, ub=5)
+        m.minimize(n**2)
+        nl = m.to_nl()
+        # 1 nonlinear var in objectives (total), 0 in cons, 0 in both
+        assert self._nlvar_line(nl) == "0 1 0"
+        # nbv niv nlvbi nlvci nlvoi -> the integer is nonlinear-in-obj-only
+        assert self._disc_line(nl) == "0 0 0 0 1"
+
+    def test_binary_in_nonlinear_objective(self):
+        """A binary var in a nonlinear objective counts as nonlinear-integer."""
+        m = dm.Model("bin_in_nl_obj")
+        x = m.continuous("x", lb=0, ub=5)
+        y = m.binary("y")
+        # y appears nonlinearly (product with x) -> nonlinear discrete in obj
+        m.minimize(x * y + dm.exp(x))
+        nl = m.to_nl()
+        # x and y both nonlinear in obj only
+        assert self._nlvar_line(nl) == "0 2 0"
+        # one of the two nonlinear-obj vars is discrete (binary y) -> nlvoi=1
+        assert self._disc_line(nl) == "0 0 0 0 1"
+
+    def test_integer_in_nonlinear_constraint(self):
+        """An integer var nonlinear in a constraint only -> nlvci."""
+        m = dm.Model("int_in_nl_con")
+        x = m.continuous("x", lb=0, ub=10)
+        n = m.integer("n", lb=0, ub=5)
+        m.minimize(x + n)  # n linear in obj
+        m.subject_to(n**2 + x <= 20)  # n nonlinear in constraint
+        nl = m.to_nl()
+        assert self._nlvar_line(nl) == "1 0 0"  # 1 nl var in cons (n)
+        assert self._disc_line(nl) == "0 0 0 1 0"  # nlvci = 1
+
+    def test_integer_nonlinear_in_both(self):
+        """An integer var nonlinear in both obj and a constraint -> nlvbi."""
+        m = dm.Model("int_in_both")
+        n = m.integer("n", lb=1, ub=5)
+        m.minimize(n**2)
+        m.subject_to(n**2 <= 16)
+        nl = m.to_nl()
+        # n is nonlinear in both -> nlvc=1, nlvo=1, nlvb=1
+        assert self._nlvar_line(nl) == "1 1 1"
+        assert self._disc_line(nl) == "0 0 1 0 0"  # nlvbi = 1
+
+    def test_mixed_linear_and_nonlinear_discrete(self):
+        """Discrete vars split correctly between linear (nbv/niv) and nonlinear."""
+        m = dm.Model("mixed")
+        x = m.continuous("x", lb=0, ub=5)
+        y = m.binary("y")  # linear in obj
+        n = m.integer("n", lb=0, ub=4)  # nonlinear in obj
+        m.minimize(n**2 + 3 * y + x)
+        m.subject_to(x <= 10 * y)
+        nl = m.to_nl()
+        # nbv=1 (linear binary y), niv=0, nlvoi=1 (integer n nonlinear in obj)
+        assert self._disc_line(nl) == "1 0 0 0 1"
+
+    def test_nonlinear_var_gets_lowest_index(self):
+        """Variables nonlinear in the objective must occupy the lowest indices."""
+        m = dm.Model("ordering")
+        a = m.binary("a")  # linear
+        n = m.integer("n", lb=0, ub=4)  # nonlinear in obj
+        x = m.continuous("x", lb=0, ub=5)  # nonlinear in obj
+        m.minimize(n**2 + dm.exp(x) + 2 * a)
+        nl = m.to_nl()
+        # The objective's nonlinear section must reference v0 and v1 (the two
+        # nonlinear vars x, n), never v2 (the linear binary a).
+        o_start = nl.index("O0")
+        # objective body runs until the next top-level section (r or b)
+        end = min(i for i in (nl.find("\nr\n", o_start), nl.find("\nb\n", o_start)) if i != -1)
+        o_section = nl[o_start:end]
+        assert "v2" not in o_section  # the linear binary is not in the nl body
+        assert "v0" in o_section and "v1" in o_section
+
+    def test_rust_parser_reads_discrete_in_nonlinear(self, tmp_path):
+        """Round-trip: the Rust parser must read the nonlinear-discrete var as integer."""
+        try:
+            from discopt._rust import parse_nl_file
+        except ImportError:
+            pytest.skip("Rust .nl parser not available")
+        m = dm.Model("rt_disc_nl")
+        x = m.continuous("x", lb=0, ub=5)
+        n = m.integer("n", lb=0, ub=4)
+        m.minimize(n**2 + dm.exp(x))
+        nl_path = tmp_path / "disc_nl.nl"
+        m.to_nl(str(nl_path))
+        rep = parse_nl_file(str(nl_path))
+        # exactly one integer var survives the round-trip
+        vtypes = list(rep.var_types())
+        assert vtypes.count("integer") == 1
+        assert vtypes.count("continuous") == 1
+
+    def test_minlplib_integer_nonlinear_roundtrip_header(self):
+        """to_nl(from_nl(f)) reproduces the original discrete-count header line.
+
+        nvs15's objective is nonlinear in 3 integer variables; the original
+        MINLPLib header declares them as ``0 0 0 0 3`` (nlvoi=3). The export
+        must reproduce that, not bury them in ``niv`` (the #210 regression).
+        """
+        import os
+
+        data = os.path.join(os.path.dirname(__file__), "data", "minlplib", "nvs15.nl")
+        if not os.path.exists(data):
+            pytest.skip("nvs15.nl fixture not available")
+        orig = open(data).read().splitlines()
+        m = dm.from_nl(data)
+        out = m.to_nl().splitlines()
+
+        def discrete(lines):
+            toks = lines[6].split("#")[0].split()
+            return [int(t) for t in toks] + [0] * (5 - len(toks))
+
+        def nlvars(lines):
+            toks = lines[4].split("#")[0].split()
+            return [int(t) for t in toks] + [0] * (3 - len(toks))
+
+        assert discrete(out) == discrete(orig)  # 0 0 0 0 3
+        assert nlvars(out) == nlvars(orig)  # 0 3 0
+
+
+class TestNLWriterMILPRegression:
+    """MILP/LP export must be byte-for-byte unaffected by the #210 reorder.
+
+    When every discrete variable is linear, the canonical reorder must leave
+    the variable order and header exactly as before: discrete vars stay in
+    ``nbv``/``niv`` with ``nlvbi=nlvci=nlvoi=0``.
+    """
+
+    def test_pure_milp_discrete_line_unchanged(self):
+        m = dm.Model("milp")
+        x = m.continuous("x", lb=0, ub=10)
+        y = m.binary("y")
+        z = m.integer("z", lb=0, ub=5)
+        m.minimize(2 * x + 3 * y + z)
+        m.subject_to(x + y + z <= 12)
+        nl = m.to_nl()
+        line6 = nl.split("\n")[6].split("#")[0].strip()
+        # 1 linear binary, 1 linear integer, no nonlinear discrete
+        assert line6 == "1 1 0 0 0"
+        # no nonlinear vars at all
+        assert nl.split("\n")[4].split("#")[0].strip() == "0 0 0"
+
+
 class TestNLWriterArrayVars:
     """Test .nl export for models with array variables."""
 


### PR DESCRIPTION
## Summary

Fixes **#210**: `to_nl()` dropped integrality for discrete variables that appear only inside nonlinear expressions, so exported MINLP/MIQP `.nl` files declared those variables as **continuous**. A downstream solver (BARON, Couenne, SCIP) reading the file then solved a **relaxation** of the problem rather than the true discrete model — a silent correctness bug.

## Root cause

The AMPL `.nl` header's discrete-count line (line 6) and nonlinear-variable distribution (line 4) were computed without accounting for integer/binary variables that are nonlinear-only. AMPL also requires variables to be emitted in a specific canonical order; the previous writer did not enforce it, so even correct counts would not line up with the variable stream.

## Fix

Add a `_reorder_vars_canonical` pass that:

- reorders variables into AMPL's required order — nonlinear-in-both → nonlinear-in-constraints → nonlinear-in-objectives → linear; within each group continuous → binary → integer;
- computes header **line 4** (`nlvc`/`nlvo` totals + `nlvb`) and **line 6** discrete counts (`nbv niv nlvbi nlvci nlvoi`), including integer/binary vars nonlinear in both / constraints-only / objectives-only;
- remaps the index-keyed linear-coefficient dicts after the reordering.

## Tests

New `TestNLWriterDiscreteInNonlinear` covering integer and binary variables nonlinear in objectives and in constraints. Full `test_nl_writer.py` suite: **34 passed**. `ruff check`, `ruff format --check`, and `mypy` all clean.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
