### PR TITLE
feat(presolve): periodic-variable bound reduction (unblocks free angular vars)

### DIFF
--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -17,9 +17,13 @@ from discopt._jax._numeric import is_effectively_finite as _is_effectively_finit
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
+    CustomCall,
     FunctionCall,
     IndexExpression,
+    MatMulExpression,
     Model,
+    Parameter,
+    SumExpression,
     SumOverExpression,
     UnaryOp,
     Variable,
@@ -2221,6 +2225,121 @@ class BilinearProductEqualityRule(NonlinearBoundTighteningRule):
         return tightened_lb, tightened_ub
 
 
+_PERIODIC_FUNCS = frozenset({"sin", "cos"})
+_TWO_PI = 2.0 * np.pi
+
+
+class PeriodicVariableBoundRule(NonlinearBoundTighteningRule):
+    """Restrict a periodic-only variable to a single period (lossless).
+
+    A continuous variable that appears in the model *solely* as the bare argument
+    of ``sin``/``cos`` enters the objective and constraints only through
+    ``(sin x, cos x)``, which is fully covered by any ``2*pi``-wide window. So the
+    box can be shrunk to one period with no loss of feasible behaviour — and a
+    finite, single-period box is what lets spatial branch-and-bound and the local
+    sub-NLP actually converge on otherwise-unbounded angular variables (e.g.
+    ``cos(y)`` over a free ``y``; AC-OPF voltage angles).
+
+    Soundness: the reduction only ever *shrinks* the box (an unbounded side to
+    ``[-pi, pi]`` / one period from the finite anchor; a ``> 2*pi`` finite box to
+    its first period), and a full period preserves every ``(sin, cos)`` value the
+    original box could take. A variable used anywhere outside ``sin``/``cos`` (or
+    inside a non-bare argument such as ``cos(2*y)``) is conservatively skipped.
+    """
+
+    name = "periodic_variable_bound"
+
+    def tighten(self, model, flat_lb, flat_ub, metadata):
+        lb = np.asarray(flat_lb, dtype=np.float64).copy()
+        ub = np.asarray(flat_ub, dtype=np.float64).copy()
+        try:
+            periodic: set[int] = set()
+            disqualified: set[int] = set()
+            complete = [True]  # cleared if an unrecognized node is encountered
+
+            def _subexprs(expr):
+                """Child sub-expressions, or ``None`` if the node type is unknown."""
+                if isinstance(expr, BinaryOp):
+                    return [expr.left, expr.right]
+                if isinstance(expr, UnaryOp):
+                    return [expr.operand]
+                if isinstance(expr, (FunctionCall, CustomCall)):
+                    return list(expr.args)
+                if isinstance(expr, IndexExpression):
+                    return [expr.base]
+                if isinstance(expr, SumExpression):
+                    return [expr.operand]
+                if isinstance(expr, SumOverExpression):
+                    return list(expr.terms)
+                if isinstance(expr, MatMulExpression):
+                    return [expr.left, expr.right]
+                return None
+
+            def walk(expr):
+                if not complete[0]:
+                    return
+                # A bare scalar-variable leaf reached here is a *non-periodic* use
+                # (the sin/cos branch below returns before recursing into its arg).
+                idx = metadata.scalar_flat_index(expr)
+                if idx is not None:
+                    disqualified.add(idx)
+                    return
+                if isinstance(expr, Variable):  # bare vector variable: non-periodic use
+                    off = metadata.base_offsets.get(id(expr))
+                    if off is not None:
+                        for k in range(expr.size):
+                            disqualified.add(off + k)
+                    return
+                if isinstance(expr, (Constant, Parameter)):
+                    return  # childless, no variables
+                if (
+                    isinstance(expr, FunctionCall)
+                    and expr.func_name in _PERIODIC_FUNCS
+                    and len(expr.args) == 1
+                ):
+                    aidx = metadata.scalar_flat_index(expr.args[0])
+                    if aidx is not None:
+                        periodic.add(aidx)
+                        return  # bare var inside sin/cos: accounted for
+                subs = _subexprs(expr)
+                if subs is None:
+                    # Unknown node type: cannot prove the variable is periodic-only,
+                    # so abstain from the whole rule (sound).
+                    complete[0] = False
+                    return
+                for sub in subs:
+                    walk(sub)
+
+            if model._objective is not None:
+                walk(model._objective.expression)
+            for c in model._constraints:
+                walk(c.body)
+
+            if not complete[0]:
+                return lb, ub  # saw an unrecognized node -> change nothing
+
+            for idx in periodic - disqualified:
+                if idx >= len(metadata.flat_var_types):
+                    continue
+                if metadata.flat_var_types[idx] != VarType.CONTINUOUS:
+                    continue
+                lo, hi = float(lb[idx]), float(ub[idx])
+                finite_lo, finite_hi = lo > -1e15, hi < 1e15
+                if finite_lo and finite_hi:
+                    if hi - lo > _TWO_PI + 1e-9:
+                        hi = lo + _TWO_PI
+                elif finite_lo:
+                    hi = lo + _TWO_PI
+                elif finite_hi:
+                    lo = hi - _TWO_PI
+                else:
+                    lo, hi = -np.pi, np.pi
+                lb[idx], ub[idx] = lo, hi
+            return lb, ub
+        except Exception:
+            return np.asarray(flat_lb, dtype=np.float64), np.asarray(flat_ub, dtype=np.float64)
+
+
 DEFAULT_NONLINEAR_BOUND_RULES: tuple[NonlinearBoundTighteningRule, ...] = (
     MonotoneFunctionEqualityRule(),
     QuadraticEqualityBoundsRule(),
@@ -2233,6 +2352,7 @@ DEFAULT_NONLINEAR_BOUND_RULES: tuple[NonlinearBoundTighteningRule, ...] = (
     SqrtSumOfSquaresUpperBoundRule(),
     SumOfSquaresUpperBoundRule(),
     SeparableQuadraticUpperBoundRule(),
+    PeriodicVariableBoundRule(),
 )
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2121,6 +2121,25 @@ def solve_model(
     # root and a no-incumbent exhaustion would be falsely certified infeasible
     # (issue #185). Such models route to the NLP/alphaBB path instead.
     _origin_lb_chk, _origin_ub_chk = flat_variable_bounds(model)
+    # Periodic-variable reduction: a free continuous variable used only inside
+    # sin/cos is restricted to one period [-pi, pi]. Spatial B&B cannot partition
+    # an infinite domain, so an angular variable like cos(y) over a free y never
+    # converges (nlp_001: 237 nodes -> 1). Surgical: only this rule runs here, so
+    # variables the relaxation already handles analytically (e.g. x*exp(x) over a
+    # free x) are left untouched. Sound: the reduction only shrinks the box.
+    try:
+        from discopt._jax.nonlinear_bound_tightening import PeriodicVariableBoundRule
+
+        _per_lb, _per_ub, _per_stats = tighten_nonlinear_bounds(
+            model, _origin_lb_chk, _origin_ub_chk, rules=(PeriodicVariableBoundRule(),)
+        )
+        if _per_stats.n_tightened > 0:
+            from discopt.solvers.amp import _apply_flat_bounds_to_model
+
+            _apply_flat_bounds_to_model(model, _per_lb, _per_ub)
+            _origin_lb_chk, _origin_ub_chk = _per_lb, _per_ub
+    except Exception as _per_exc:  # pragma: no cover - defensive
+        logger.debug("periodic-variable bound reduction skipped: %s", _per_exc)
     _origin_has_finite_continuous_var = False
     _origin_chk_off = 0
     for _ov in model._variables:

--- a/python/tests/test_periodic_bound.py
+++ b/python/tests/test_periodic_bound.py
@@ -1,0 +1,92 @@
+"""Tests for the periodic-variable bound reduction.
+
+A continuous variable used only inside sin/cos can be restricted to one period
+without loss of optimality. The rule must (a) reduce such variables, (b) leave
+variables used anywhere else untouched, and (c) only ever shrink the box (sound).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.nonlinear_bound_tightening import (
+    PeriodicVariableBoundRule,
+    build_flat_variable_metadata,
+)
+
+_RULE = PeriodicVariableBoundRule()
+_PI = np.pi
+
+
+def _apply(m, lb, ub):
+    md = build_flat_variable_metadata(m)
+    return _RULE.tighten(m, np.array(lb, float), np.array(ub, float), md)
+
+
+def test_reduces_free_periodic_only_variable():
+    m = dm.Model("p")
+    y = m.continuous("y")
+    m.minimize(dm.cos(y))
+    nlb, nub = _apply(m, [-1e20], [1e20])
+    assert np.isclose(nlb[0], -_PI) and np.isclose(nub[0], _PI)
+
+
+def test_skips_variable_used_outside_cos():
+    m = dm.Model("p")
+    y = m.continuous("y")
+    m.minimize(y + dm.cos(y))  # y also appears linearly -> not periodic-only
+    nlb, nub = _apply(m, [-1e20], [1e20])
+    assert nlb[0] == -1e20 and nub[0] == 1e20
+
+
+def test_skips_non_bare_argument():
+    m = dm.Model("p")
+    y = m.continuous("y")
+    m.minimize(dm.cos(2 * y))  # period is pi, not 2pi -> conservatively skip
+    nlb, nub = _apply(m, [-1e20], [1e20])
+    assert nlb[0] == -1e20 and nub[0] == 1e20
+
+
+def test_shrinks_wide_finite_box_to_one_period():
+    m = dm.Model("p")
+    y = m.continuous("y", lb=0.0, ub=100.0)
+    m.minimize(dm.sin(y))
+    nlb, nub = _apply(m, [0.0], [100.0])
+    # Anchored at the lower bound, shrunk to exactly one period.
+    assert np.isclose(nlb[0], 0.0) and np.isclose(nub[0], 2 * _PI)
+
+
+def test_no_change_when_already_within_period():
+    m = dm.Model("p")
+    y = m.continuous("y", lb=0.0, ub=1.0)
+    m.minimize(dm.cos(y))
+    nlb, nub = _apply(m, [0.0], [1.0])
+    assert nlb[0] == 0.0 and nub[0] == 1.0
+
+
+def test_integer_periodic_variable_untouched():
+    m = dm.Model("p")
+    y = m.integer("y", lb=-1000, ub=1000)
+    m.minimize(dm.cos(y))
+    nlb, nub = _apply(m, [-1000.0], [1000.0])
+    assert nlb[0] == -1000.0 and nub[0] == 1000.0  # only continuous vars reduced
+
+
+@pytest.mark.slow
+def test_end_to_end_unblocks_free_angular_variable():
+    # nlp_001-style: cos(y) over a free y blocks convergence without the rule.
+    m = dm.Model("nlp001")
+    x = m.continuous("x")
+    y = m.continuous("y")
+    z = m.continuous("z", lb=1.0)
+    m.minimize(x * dm.exp(x) + dm.cos(y) + z**3 - z**2)
+    res = m.solve(time_limit=60)
+    assert res.status == "optimal"
+    assert abs(float(res.objective) - (-1.3679)) < 1e-2
+    assert res.node_count <= 5  # was 237 (non-converging) before the rule


### PR DESCRIPTION
## Summary

A diagnostic of discopt's hardest **global-benchmark** instances found their bottleneck is **not** quadratic relaxation strength (the focus of the recent cut work) but something structural: **unbounded variables**. Spatial branch-and-bound cannot partition an infinite domain, so an angular variable like `cos(y)` over a free `y` never converges — `minlptests_nlp_001_010` was stuck at a suboptimal incumbent at **237 nodes**, never proving optimality.

This PR adds a sound, surgical fix and lands the **first change in this arc that moves an actual benchmark instance**.

## The fix

`PeriodicVariableBoundRule` restricts a continuous variable used **only** inside `sin`/`cos` (as the bare argument) to a single period `[-π, π]`. The model value then depends on that variable *solely* through `(sin, cos)`, which any 2π-wide window covers fully — so the reduction only ever **shrinks** the box and loses no optimum.

- Applied at the spatial-B&B root, **surgically** — just this one rule, so variables the relaxation already handles analytically (e.g. `x·exp(x)` over a free `x`) are left untouched. (Bounding *those* actually *hurt* in testing: forcing them finite makes them branchable against a loose envelope.)
- Also added to the default nonlinear bound-tightening rule set.

## Soundness hardening

This is a correctness-critical path, so the detector is conservative by construction:
- **Abstains entirely** if it encounters any unrecognized expression node type (it can never misclassify a non-periodic use).
- **Disqualifies** any variable used anywhere outside a bare `sin`/`cos`.
- **Skips non-bare arguments** like `cos(2y)` (period π, not 2π).
- For a wide *finite* box it shrinks to one period anchored at the existing bound (never a blind intersection); integer variables are untouched.

## Result

- `minlptests_nlp_001_010`: **237 nodes (feasible, never optimal) → 1 node (proven optimal, −1.368)**
- Smoke suite: **40 instances, 0 incorrect** — no regressions
- Bonus: AC-OPF in polar form has voltage *angles* that are exactly periodic-only variables, so this also helps the W5 OPF capstone class.

(The diagnostic's other prediction held precisely: `nlp_003_010` is unchanged at 179 nodes because its bottleneck is different — the relaxation produces *no bound at all* for `sqrt`/`exp`/`sin²`; that's the next item.)

## Tests

`test_periodic_bound.py` (7): reduction of a free periodic-only var, skip-when-used-elsewhere, non-bare-argument skip, finite period-shrink, within-period no-op, integer-untouched, and a slow end-to-end confirming the 237→≤5 node collapse. Existing bound-tightening tests pass; ruff + mypy clean.

## Test plan

```
pytest python/tests/test_periodic_bound.py -m "slow or not slow"
pytest python/tests/test_nonlinear_bound_tightening_tol.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr)_