### PR TITLE
feat(relax): engage LP relaxer for general transcendental nonlinearity

### DIFF
--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -297,6 +297,7 @@ class MccormickLPRelaxer:
             or t.multilinear
             or t.monomial
             or t.fractional_power
+            or t.general_nl
             or self._has_affine_power
         )
 

--- a/python/tests/test_transcendental_relaxation.py
+++ b/python/tests/test_transcendental_relaxation.py
@@ -1,0 +1,60 @@
+"""Engage the LP relaxer for general transcendental nonlinearity.
+
+Models whose only nonlinearity is a general transcendental term (sqrt, exp,
+sin/cos, ...) were routed away from the McCormick LP relaxer, so spatial B&B got
+*no* dual bound and could not prove optimality (minlptests_nlp_003: 179 nodes,
+status "feasible", root bound None). ``build_milp_relaxation`` already emits a
+valid polyhedral outer approximation for these terms, so engaging the relaxer
+yields a sound dual bound. These tests pin that the relaxer now engages and the
+resulting bound is valid (never beyond the true optimum).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import pytest
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+
+
+def test_relaxer_engages_on_general_transcendental():
+    m = dm.Model("sqrt_only")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    m.minimize(-dm.sqrt(x + 0.1))
+    assert MccormickLPRelaxer(m).has_relaxable_nonlinearity is True
+
+
+@pytest.mark.slow
+def test_transcendental_model_proves_optimality_with_valid_bound():
+    # nlp_003-style: sqrt objective, exp + sin^2 constraints.
+    m = dm.Model("nlp003")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=4.0)
+    m.maximize(dm.sqrt(x + 0.1))
+    m.subject_to(y >= dm.exp(x - 2) - 1.5)
+    m.subject_to(y <= dm.sin(x) ** 2 + 2)
+    res = m.solve(time_limit=60)
+    assert res.status == "optimal"  # was "feasible" (no bound) before
+    # The dual bound is valid: for a maximization it never *under*-states the
+    # optimum, and at proven optimality it matches the objective.
+    assert res.bound is not None
+    assert float(res.bound) >= float(res.objective) - 1e-4
+    assert res.node_count <= 50  # was 179 with no bound to prune on
+
+
+@pytest.mark.slow
+def test_exp_objective_minimization_bound_is_valid():
+    # min exp(x) over [-2, 2]: optimum exp(-2) ~ 0.1353; relaxer must not
+    # over-state the bound (a valid lower bound is <= the optimum).
+    m = dm.Model("exp_min")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    m.minimize(dm.exp(x))
+    res = m.solve(time_limit=30)
+    assert res.status == "optimal"
+    assert abs(float(res.objective) - 0.13533528) < 1e-4
+    if res.bound is not None:
+        assert float(res.bound) <= float(res.objective) + 1e-4  # valid lower bound


### PR DESCRIPTION
## Summary

Second fix from the benchmark-bottleneck diagnostic. Models whose only nonlinearity is a **general transcendental** term (`sqrt`, `exp`, `sin`/`cos`, …) classify as `general_nl`, which `has_relaxable_nonlinearity` excluded — so spatial branch-and-bound was **routed away from the McCormick LP relaxer and got no dual bound at all**, leaving B&B to wander with nothing to prune on (`minlptests_nlp_003_010`: 179 nodes, status `feasible`, root bound `None`, never proven optimal).

## The fix

One line: add `general_nl` to the `has_relaxable_nonlinearity` gate. `build_milp_relaxation` already emits a valid polyhedral outer approximation for these terms (`objective_bound_valid=True`), and any per-node term it cannot relax safely **errors out to "no bound" rather than an unsound one**. This mirrors the earlier #120 broadening of the same gate from `has_bilinear` to `monomial`/`fractional_power`.

## Result

- `minlptests_nlp_003_010`: **179 nodes (feasible, no bound) → 5 nodes (proven optimal, bound = optimum 1.832)**

## Soundness — validated hard

This is a relaxation **routing** change, so correctness was the priority:

- **71 nonconvex instances** across `global_opt` / `minlp` / `nlp_nonconvex` / `minlptests` / `qcqp` / `miqp` → **0 incorrect** (no SUSPECT introduced).
- The full soundness/SUSPECT/convexity/cert/unbounded suite — **832 tests** including the himmel16 no-false-certification guard — passes.
- 3 new tests pin: the relaxer engages on a transcendental-only model, a transcendental model proves optimality with a valid bound, and an `exp`-minimization lower bound is genuinely valid (`bound ≤ optimum`).

## Context

This is the second of two clean diagnostic wins (the first, periodic-variable bound reduction for `nlp_001`, is PR #215). The third diagnostic instance, `nvs05`, was investigated and found **not** to be a targeted-fix candidate — it's dual-limited by fundamental relaxation looseness on reciprocal-of-product / ratio structure, a separate deep effort rather than a surgical change.

## Test plan

```
pytest python/tests/test_transcendental_relaxation.py -m "slow or not slow"
pytest python/tests/ -k "suspect or soundness or convexity or cert or unbounded"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr)_