### PR TITLE
feat(cuts): make cuts="auto" the solver default

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1663,7 +1663,7 @@ def solve_model(
     cutting_planes: bool = False,
     psd_cuts: bool = False,
     rlt_cuts: bool = False,
-    cuts: str = "manual",
+    cuts: str = "auto",
     partitions: int = 0,
     branching_policy: str = "fractional",
     use_learned_relaxations: bool = False,
@@ -2909,11 +2909,14 @@ def solve_model(
                 _mc_lp_relaxer = None
                 _mc_mode = "nlp"
             else:
-                # Structure-gated cut policy (cuts="auto"): the A/B sweep showed
-                # RLT dominates on QCQP *with* linear constraints, PSD on box-QP
-                # (no constraints), and stacking the two is counter-productive. So
-                # pick exactly one by structure, gated by size, never both.
-                if cuts == "auto":
+                # Structure-gated cut policy (cuts="auto", the default): the A/B
+                # sweep showed RLT dominates on QCQP *with* linear constraints, PSD
+                # on box-QP (no constraints), and stacking the two is
+                # counter-productive. So pick exactly one by structure, gated by
+                # size, never both. An explicit psd_cuts/rlt_cuts flag takes
+                # precedence (the user opted into a specific family); cuts="manual"
+                # disables the policy entirely.
+                if cuts == "auto" and not psd_cuts and not rlt_cuts:
                     _apply_auto_cut_policy(model, _mc_lp_relaxer)
                 # A node is spatial-branchable if there is a finite-box continuous
                 # variable to bisect, OR an integer variable in a nonlinear term

--- a/python/tests/test_auto_cut_policy.py
+++ b/python/tests/test_auto_cut_policy.py
@@ -72,15 +72,27 @@ def test_policy_declines_above_size_gate():
 
 
 @pytest.mark.slow
+def test_auto_is_the_default():
+    """A default solve (no cuts kwarg) applies the auto policy; cuts='manual' opts out."""
+    default = _qcqp(6, 3, constrained=True).solve(time_limit=120)
+    manual = _qcqp(6, 3, constrained=True).solve(cuts="manual", time_limit=120)
+    auto = _qcqp(6, 3, constrained=True).solve(cuts="auto", time_limit=120)
+    assert abs(float(default.objective) - float(manual.objective)) < 1e-3
+    # Default behaves like auto, not like the cut-free manual baseline.
+    assert default.node_count == auto.node_count
+    assert default.node_count < manual.node_count
+
+
+@pytest.mark.slow
 def test_auto_matches_best_family_and_preserves_optimum():
     # Box-QP: auto should match PSD's node count.
-    base_b = _qcqp(6, 0, constrained=False).solve(time_limit=120)
+    base_b = _qcqp(6, 0, constrained=False).solve(cuts="manual", time_limit=120)
     auto_b = _qcqp(6, 0, constrained=False).solve(cuts="auto", time_limit=120)
     assert abs(float(base_b.objective) - float(auto_b.objective)) < 1e-3
     assert auto_b.node_count < base_b.node_count / 2
 
     # Constrained QCQP: auto should match RLT's node count.
-    base_c = _qcqp(6, 3, constrained=True).solve(time_limit=120)
+    base_c = _qcqp(6, 3, constrained=True).solve(cuts="manual", time_limit=120)
     auto_c = _qcqp(6, 3, constrained=True).solve(cuts="auto", time_limit=120)
     assert abs(float(base_c.objective) - float(auto_c.objective)) < 1e-3
     assert auto_c.node_count < base_c.node_count / 2

--- a/python/tests/test_psd_node_reduction.py
+++ b/python/tests/test_psd_node_reduction.py
@@ -38,7 +38,7 @@ def _dense_indefinite_qcqp(n: int, seed: int) -> dm.Model:
 
 def test_psd_preserves_optimum_and_never_adds_nodes():
     """Soundness + no-harm: same optimum, and PSD never increases the node count."""
-    base = _dense_indefinite_qcqp(6, 8).solve(psd_cuts=False, time_limit=60)
+    base = _dense_indefinite_qcqp(6, 8).solve(cuts="manual", time_limit=60)
     psd = _dense_indefinite_qcqp(6, 8).solve(psd_cuts=True, time_limit=60)
     assert base.status == "optimal" and psd.status == "optimal"
     assert abs(float(base.objective) - float(psd.objective)) < 1e-3
@@ -48,7 +48,7 @@ def test_psd_preserves_optimum_and_never_adds_nodes():
 @pytest.mark.slow
 def test_psd_substantially_reduces_nodes_on_hard_instance():
     """n6_s0 has a non-trivial tree; per-node PSD cuts cut it down sharply."""
-    base = _dense_indefinite_qcqp(6, 0).solve(psd_cuts=False, time_limit=120)
+    base = _dense_indefinite_qcqp(6, 0).solve(cuts="manual", time_limit=120)
     psd = _dense_indefinite_qcqp(6, 0).solve(psd_cuts=True, time_limit=120)
     assert abs(float(base.objective) - float(psd.objective)) < 1e-3
     # Baseline explores a real tree; PSD cuts more than halve it.

--- a/python/tests/test_rlt_node_reduction.py
+++ b/python/tests/test_rlt_node_reduction.py
@@ -36,7 +36,7 @@ def _constrained_qcqp(n: int, seed: int) -> dm.Model:
 
 
 def test_rlt_preserves_optimum_and_never_adds_nodes():
-    base = _constrained_qcqp(6, 0).solve(rlt_cuts=False, time_limit=60)
+    base = _constrained_qcqp(6, 0).solve(cuts="manual", time_limit=60)
     rlt = _constrained_qcqp(6, 0).solve(rlt_cuts=True, time_limit=60)
     assert base.status == "optimal" and rlt.status == "optimal"
     assert abs(float(base.objective) - float(rlt.objective)) < 1e-3
@@ -45,7 +45,7 @@ def test_rlt_preserves_optimum_and_never_adds_nodes():
 
 @pytest.mark.slow
 def test_rlt_substantially_reduces_nodes_on_constrained_qcqp():
-    base = _constrained_qcqp(6, 3).solve(rlt_cuts=False, time_limit=120)
+    base = _constrained_qcqp(6, 3).solve(cuts="manual", time_limit=120)
     rlt = _constrained_qcqp(6, 3).solve(rlt_cuts=True, time_limit=120)
     assert abs(float(base.objective) - float(rlt.objective)) < 1e-3
     assert base.node_count > 50  # a genuinely non-trivial tree


### PR DESCRIPTION
## Summary

The structure-gated **auto cut policy** (PSD for box-QP, RLT for constrained QCQP, never both, size-gated) was opt-in via `cuts="auto"`. This makes it the default, backed by a fresh full-suite measurement.

## The data (full nonconvex suite, 91 instances, `off` → `auto`)

- `base_nodes 495 → 489`
- **0 mismatch** (auto never changes an optimum vs the cut-free baseline)
- **0 incorrect** (every solve matches its known optimum)
- **0 regressions** — no instance's node count went *up* with auto

Improvements are concentrated on QCQP (`qcqp_indef_n4_s1` 5→3, `n5_s11` 3→1, `n6_s12` 5→3); everywhere else it's a correct **no-op**. The policy only engages on the spatial LP path with relaxable nonlinearity (gated by size), so linear / convex / non-quadratic solves are untouched. Defaulting it on is therefore **pure upside or neutral**.

## Change & precedence

- `solve_model`'s `cuts` parameter now defaults to `"auto"`.
- An explicit `psd_cuts=True` / `rlt_cuts=True` still **takes precedence** (the policy is skipped when either is set — the user opted into a specific family).
- `cuts="manual"` disables the policy entirely (the cut-free baseline / escape hatch).

## Tests

- Existing node-count tests (`test_psd_node_reduction`, `test_rlt_node_reduction`, `test_auto_cut_policy`) updated to request `cuts="manual"` for their genuinely cut-free baselines.
- New `test_auto_is_the_default`: a default solve (no `cuts` kwarg) behaves like `cuts="auto"` and beats the `cuts="manual"` baseline.
- **574 node-count / cut / soundness tests pass**, including the himmel16 no-false-certification guard. ruff + mypy clean. (The full marked correctness suite is long-running; CI exercises it.)

## Context

This closes the last outstanding decision from the Wave-2 cut work. The cut machinery (PSD/SOC/RLT separators, per-node wiring, structure-gated policy) is now on by default where it helps and inert where it doesn't.

## Test plan

```
pytest python/tests/test_auto_cut_policy.py -m "slow or not slow"
pytest python/tests/ -k "node_reduction or cut or qcqp or suspect or soundness"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr)_