### PR TITLE
feat(relax): close asin/acos/acosh gaps, fix non-smooth abs/min/max, add coverage audit

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -1834,6 +1834,9 @@ def _univariate_arg(expr: Expression) -> tuple[str, Expression] | None:
             "sin",
             "cos",
             "tan",
+            "asin",
+            "acos",
+            "acosh",
             "entropy",
         }:
             return name, expr.args[0]
@@ -1866,6 +1869,12 @@ def _univariate_value(func_name: str, x: float) -> float:
         return float(np.cos(x))
     if func_name == "tan":
         return float(np.tan(x))
+    if func_name == "asin":
+        return float(np.arcsin(x))
+    if func_name == "acos":
+        return float(np.arccos(x))
+    if func_name == "acosh":
+        return float(np.arccosh(x))
     if func_name == "entropy":
         # entropy(x) = x*log(x), with the x -> 0+ limit equal to 0.
         if x <= 0.0:
@@ -1895,6 +1904,12 @@ def _univariate_grad(func_name: str, x: float) -> float:
     if func_name == "tan":
         c = float(np.cos(x))
         return float(1.0 / (c * c))
+    if func_name == "asin":
+        return float(1.0 / np.sqrt(1.0 - x * x))
+    if func_name == "acos":
+        return float(-1.0 / np.sqrt(1.0 - x * x))
+    if func_name == "acosh":
+        return float(1.0 / np.sqrt(x * x - 1.0))
     if func_name == "entropy":
         # d/dx [x*log(x)] = log(x) + 1 (finite only for x > 0).
         return float(np.log(x) + 1.0)
@@ -1937,6 +1952,13 @@ def _univariate_domain_ok(func_name: str, arg_lb: float, arg_ub: float) -> bool:
         return True
     if func_name == "tan":
         return _tan_range(arg_lb, arg_ub) is not None
+    if func_name in {"asin", "acos"}:
+        # Defined on [-1, 1]; the relaxation is built on the closed interval and
+        # the singular endpoint slopes are skipped (see ``_tangent_points``).
+        return bool(arg_lb >= -1.0 and arg_ub <= 1.0)
+    if func_name == "acosh":
+        # acosh is defined and real on x >= 1 (concave there).
+        return bool(arg_lb >= 1.0)
     return False
 
 
@@ -1977,6 +1999,13 @@ def _tangent_points(func_name: str, lb: float, ub: float) -> list[float]:
             continue
         if func_name == "tan" and not _is_effectively_finite(np.tan(pt)):
             continue
+        if func_name in {"asin", "acos"} and abs(pt) >= 1.0 - 1e-9:
+            # Slope diverges at +/-1; the secant still bounds the convex/concave
+            # branch, so we simply omit the singular endpoint tangent.
+            continue
+        if func_name == "acosh" and pt <= 1.0 + 1e-12:
+            # Slope diverges at x = 1; omit the singular endpoint tangent.
+            continue
         if not np.isfinite(pt):
             continue
         if all(abs(pt - seen) > 1e-12 for seen in points):
@@ -2002,6 +2031,26 @@ def _univariate_curvature(func_name: str, val_lb: float, val_ub: float) -> Optio
             return "convex"
         if val_ub <= tol:
             return "concave"
+    if func_name == "asin":
+        # asin is odd and increasing: value >= 0 <=> arg >= 0 (convex branch),
+        # value <= 0 <=> arg <= 0 (concave branch); mixed across the inflection.
+        if val_lb >= -tol:
+            return "convex"
+        if val_ub <= tol:
+            return "concave"
+        return None
+    if func_name == "acos":
+        # acos is decreasing with an inflection at arg = 0 (value = pi/2):
+        # arg >= 0 <=> value <= pi/2 (concave); arg <= 0 <=> value >= pi/2 (convex).
+        half_pi = 0.5 * math.pi
+        if val_ub <= half_pi + tol:
+            return "concave"
+        if val_lb >= half_pi - tol:
+            return "convex"
+        return None
+    if func_name == "acosh":
+        # acosh is concave on its entire domain x >= 1.
+        return "concave"
     return None
 
 
@@ -2083,6 +2132,37 @@ def _trig_piecewise_interval_specs(
         curvature = None
         if local_bounds is not None:
             curvature = _univariate_curvature(relax.func_name, local_bounds[0], local_bounds[1])
+        intervals.append((float(a), float(b), curvature))
+    if sum(1 for _a, _b, curvature in intervals if curvature is not None) < 2:
+        return []
+    return intervals
+
+
+def _inverse_trig_piecewise_interval_specs(
+    relax: UnivariateRelaxation,
+) -> list[tuple[float, float, Optional[str]]]:
+    """Build certified curvature subintervals for asin/acos across the inflection.
+
+    ``asin``/``acos`` change curvature at the argument value 0 (the inflection
+    point).  When the argument interval straddles 0 we split it there into two
+    sign-definite, single-curvature pieces; otherwise the single-curvature path
+    in the main builder already applies.
+    """
+    if relax.func_name not in {"asin", "acos"}:
+        return []
+    lb = float(relax.arg_lb)
+    ub = float(relax.arg_ub)
+    if not (np.isfinite(lb) and np.isfinite(ub)):
+        return []
+    if not (lb < -1e-12 and ub > 1e-12):
+        return []
+
+    intervals: list[tuple[float, float, Optional[str]]] = []
+    for a, b in ((lb, 0.0), (0.0, ub)):
+        if b <= a + 1e-12:
+            continue
+        val_lb, val_ub = _univariate_value_bounds(relax.func_name, a, b)
+        curvature = _univariate_curvature(relax.func_name, val_lb, val_ub)
         intervals.append((float(a), float(b), curvature))
     if sum(1 for _a, _b, curvature in intervals if curvature is not None) < 2:
         return []
@@ -4351,6 +4431,8 @@ def build_milp_relaxation(
     piecewise_univariate_relaxations: list[PiecewiseUnivariateRelaxation] = []
     for relax in univariate_relaxations:
         interval_specs = _trig_piecewise_interval_specs(relax, disc_state, n_orig)
+        if not interval_specs:
+            interval_specs = _inverse_trig_piecewise_interval_specs(relax)
         if not interval_specs:
             continue
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1488,6 +1488,56 @@ def _model_contains_custom_call(model: Model) -> bool:
     return False
 
 
+def _model_contains_nonsmooth_node(model: Model) -> bool:
+    """True if any objective/constraint body contains a non-smooth node.
+
+    ``abs``/``min``/``max`` are convex (or concave) but non-differentiable at
+    their kink. A smooth gradient-based NLP can oscillate there and fail to
+    certify (e.g. ``min |x|`` over an interval straddling 0 returns the wrong
+    point with ``iteration_limit``). The solver uses this to route such models
+    to the spatial McCormick B&B, whose exact piecewise relaxation certifies
+    them. ``abs`` is either ``UnaryOp("abs")`` or ``FunctionCall("abs")``;
+    ``min``/``max`` are ``FunctionCall("min"|"max")``.
+    """
+    from discopt.modeling.core import FunctionCall, UnaryOp
+
+    _nonsmooth_funcs = {"abs", "min", "max"}
+
+    def _walk(expr) -> bool:
+        if isinstance(expr, UnaryOp) and expr.op == "abs":
+            return True
+        if isinstance(expr, FunctionCall) and expr.func_name in _nonsmooth_funcs:
+            return True
+        left = getattr(expr, "left", None)
+        if left is not None and _walk(left):
+            return True
+        right = getattr(expr, "right", None)
+        if right is not None and _walk(right):
+            return True
+        operand = getattr(expr, "operand", None)
+        if operand is not None and _walk(operand):
+            return True
+        base = getattr(expr, "base", None)
+        if base is not None and _walk(base):
+            return True
+        for a in getattr(expr, "args", ()) or ():
+            if _walk(a):
+                return True
+        for t in getattr(expr, "terms", ()) or ():
+            if _walk(t):
+                return True
+        return False
+
+    obj = getattr(model, "_objective", None)
+    if obj is not None and getattr(obj, "expression", None) is not None and _walk(obj.expression):
+        return True
+    for c in model._constraints:
+        body = getattr(c, "body", None)
+        if body is not None and _walk(body):
+            return True
+    return False
+
+
 def _classify_model_convexity(
     model: Model,
     *,
@@ -2524,17 +2574,33 @@ def solve_model(
         result.convex_fast_path = True
         if result.status == "optimal":
             return result
-        # The convex NLP did not certify (e.g. an ill-conditioned division whose
-        # denominator reaches toward zero, like st_e17's 0.2458*x0**2/x1 with
-        # x1 down to 1e-5). If the model has a sign-definite non-constant
-        # denominator — which the relaxation otherwise drops to general_nl —
-        # clear it (exact, value-preserving) and fall back to the sound spatial
-        # B&B, which can certify it. Only clearing is applied (no
-        # convexity-destroying mixed-product lift). When nothing is clearable,
-        # return the NLP result unchanged (no regression).
+        # The convex NLP may fail to certify for two reasons handled here.
         from discopt._jax.factorable_reform import has_clearable_denominator
 
-        if has_clearable_denominator(model):
+        if _model_contains_nonsmooth_node(model):
+            # (1) Non-smooth objective/constraints (abs/min/max): a smooth
+            # gradient-based solver oscillates at the kink (e.g. min |x| over
+            # [-1, 1] returns ~0.99 with iteration_limit). The spatial McCormick
+            # B&B has an *exact* piecewise relaxation for these nodes and
+            # certifies them, so fall back to it rather than returning the
+            # unconverged point.
+            logger.info(
+                "Convex NLP did not certify (status=%s) on a non-smooth model; "
+                "retrying via spatial B&B (exact piecewise relaxation)",
+                result.status,
+            )
+            _pure_continuous_is_convex = False
+            _root_is_convex = False
+            _pure_continuous_force_spatial = True
+            # Fall through to the spatial B&B below.
+        elif has_clearable_denominator(model):
+            # (2) An ill-conditioned division whose denominator reaches toward
+            # zero (like st_e17's 0.2458*x0**2/x1 with x1 down to 1e-5). If the
+            # model has a sign-definite non-constant denominator — which the
+            # relaxation otherwise drops to general_nl — clear it (exact,
+            # value-preserving) and fall back to the sound spatial B&B, which can
+            # certify it. Only clearing is applied (no convexity-destroying
+            # mixed-product lift).
             cleared = factorable_reformulate(model, clear_only=True)
             if cleared is not model:
                 logger.info(
@@ -2556,6 +2622,8 @@ def solve_model(
             else:
                 return result
         else:
+            # Nothing clearable and the model is smooth: return the NLP result
+            # unchanged (no regression).
             return result
 
     # --- Pure continuous: solve directly only when spatial search was not requested ---

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -15,3 +15,6 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "integration: solver-dependent integration tests")
     config.addinivalue_line("markers", "amp_benchmark: opt-in AMP benchmark/incidence tests")
     config.addinivalue_line("markers", "requires_cyipopt: requires cyipopt/Ipopt")
+    config.addinivalue_line(
+        "markers", "relaxation: per-operator relaxation soundness/coverage audit"
+    )

--- a/python/tests/test_relaxation_coverage.py
+++ b/python/tests/test_relaxation_coverage.py
@@ -1,0 +1,162 @@
+"""Relaxation coverage audit: every common univariate operator must yield a
+*valid, tight* global bound.
+
+Each operator is solved as a single-operator model (minimize and maximize) over a
+representative box.  Because these are one-dimensional we compute the reference
+optimum by a dense brute-force grid, so the test is self-validating: it pins both
+
+* **soundness** — the relaxation never excludes the true optimum, and
+* **tightness** — spatial B&B closes the gap and reports ``status == "optimal"``
+  with the correct objective.
+
+This guards against regressions in the operator-coverage matrix and documents the
+operators discopt can globally bound.  ``asin``/``acos``/``acosh`` were added here
+after the Wave-2 coverage audit found they previously produced no valid bound.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+_TOL = 1e-2
+
+
+def _reciprocal(x):
+    return 1.0 / x
+
+
+def _pow2(x):
+    return x**2
+
+
+def _pow3(x):
+    return x**3
+
+
+def _pow_half(x):
+    return x**0.5
+
+
+# (id, model-builder fn, numpy reference fn, lb, ub)
+_OPERATORS = [
+    ("exp", dm.exp, np.exp, -1.0, 1.0),
+    ("log", dm.log, np.log, 0.5, 3.0),
+    ("log2", dm.log2, np.log2, 0.5, 3.0),
+    ("log10", dm.log10, np.log10, 0.5, 3.0),
+    ("sqrt", dm.sqrt, np.sqrt, 0.1, 4.0),
+    ("reciprocal", _reciprocal, lambda x: 1.0 / x, 0.5, 3.0),
+    ("sin", dm.sin, np.sin, 0.0, 3.0),
+    ("cos", dm.cos, np.cos, 0.0, 3.0),
+    ("tan", dm.tan, np.tan, -1.0, 1.0),
+    ("atan", dm.atan, np.arctan, -2.0, 2.0),
+    ("asin", dm.asin, np.arcsin, -1.0, 1.0),
+    ("acos", dm.acos, np.arccos, -1.0, 1.0),
+    ("acosh", dm.acosh, np.arccosh, 1.0, 3.0),
+    ("sinh", dm.sinh, np.sinh, -2.0, 2.0),
+    ("cosh", dm.cosh, np.cosh, -2.0, 2.0),
+    ("tanh", dm.tanh, np.tanh, -2.0, 2.0),
+    ("asinh", dm.asinh, np.arcsinh, -2.0, 2.0),
+    ("atanh", dm.atanh, np.arctanh, -0.9, 0.9),
+    ("erf", dm.erf, lambda x: np.vectorize(__import__("math").erf)(x), -2.0, 2.0),
+    ("log1p", dm.log1p, np.log1p, -0.5, 3.0),
+    ("sigmoid", dm.sigmoid, lambda x: 1.0 / (1.0 + np.exp(-x)), -3.0, 3.0),
+    ("softplus", dm.softplus, lambda x: np.log1p(np.exp(x)), -3.0, 3.0),
+    # abs over a strictly sign-definite box certifies; the zero-crossing case is a
+    # separate convergence gap, pinned by test_abs_zero_crossing_gap below.
+    ("abs", dm.abs, np.abs, 0.5, 2.0),
+    ("pow2", _pow2, lambda x: x**2, -2.0, 2.0),
+    ("pow3", _pow3, lambda x: x**3, -2.0, 2.0),
+    ("pow_half", _pow_half, lambda x: x**0.5, 0.1, 4.0),
+]
+
+
+def _brute_optima(ref_fn, lb, ub):
+    xs = np.linspace(lb, ub, 200_001)
+    vals = ref_fn(xs)
+    return float(np.min(vals)), float(np.max(vals))
+
+
+def _solve(build_fn, lb, ub, sense):
+    m = dm.Model("op")
+    x = m.continuous("x", lb=lb, ub=ub)
+    expr = build_fn(x)
+    if sense == "min":
+        m.minimize(expr)
+    else:
+        m.maximize(expr)
+    return m.solve(time_limit=60)
+
+
+@pytest.mark.relaxation
+@pytest.mark.parametrize("name,build_fn,ref_fn,lb,ub", _OPERATORS, ids=[o[0] for o in _OPERATORS])
+def test_operator_has_valid_tight_bound(name, build_fn, ref_fn, lb, ub):
+    """Each operator solves to a certified global optimum matching brute force."""
+    true_min, true_max = _brute_optima(ref_fn, lb, ub)
+
+    res_min = _solve(build_fn, lb, ub, "min")
+    assert res_min.status == "optimal", f"{name}: minimize did not certify optimality"
+    assert abs(float(res_min.objective) - true_min) < _TOL, (
+        f"{name}: min objective {float(res_min.objective)} != brute force {true_min}"
+    )
+
+    res_max = _solve(build_fn, lb, ub, "max")
+    assert res_max.status == "optimal", f"{name}: maximize did not certify optimality"
+    assert abs(float(res_max.objective) - true_max) < _TOL, (
+        f"{name}: max objective {float(res_max.objective)} != brute force {true_max}"
+    )
+
+
+@pytest.mark.relaxation
+def test_bilinear_lifted_moment_bound():
+    """The lifted-moment path bounds a bilinear product (min x*y over [0,1]^2 = 0)."""
+    m = dm.Model("bilinear")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    y = m.continuous("y", lb=0.0, ub=1.0)
+    m.minimize(x * y)
+    res = m.solve(time_limit=60)
+    assert res.status == "optimal"
+    assert abs(float(res.objective)) < _TOL
+
+
+@pytest.mark.relaxation
+@pytest.mark.xfail(
+    reason="abs over a zero-crossing box does not yet certify optimality "
+    "(separate convergence gap; the relaxation is exact but B&B iteration-limits)",
+    strict=False,
+)
+def test_abs_zero_crossing_gap():
+    """Documents a known gap: minimize |x| over an interval straddling 0.
+
+    The convex-envelope relaxation is exact, yet the spatial loop currently
+    iteration-limits instead of certifying the optimum of 0.  Recorded as xfail so
+    CI flags it the day the convergence gap is closed.
+    """
+    res = _solve(dm.abs, -1.0, 1.0, "min")
+    assert res.status == "optimal"
+    assert abs(float(res.objective)) < _TOL
+
+
+@pytest.mark.relaxation
+@pytest.mark.parametrize("name", ["asin", "acos", "acosh"])
+def test_inverse_trig_gap_closed(name):
+    """Regression guard for the three operators that previously had no valid bound.
+
+    Before the Wave-2 fix these returned ``status == "feasible"`` with an objective
+    that missed the true optimum (no dual bound).  They must now certify optimality.
+    """
+    build_fn, ref_fn, lb, ub = {
+        "asin": (dm.asin, np.arcsin, -1.0, 1.0),
+        "acos": (dm.acos, np.arccos, -1.0, 1.0),
+        "acosh": (dm.acosh, np.arccosh, 1.0, 3.0),
+    }[name]
+    true_min, _ = _brute_optima(ref_fn, lb, ub)
+    res = _solve(build_fn, lb, ub, "min")
+    assert res.status == "optimal"
+    assert abs(float(res.objective) - true_min) < _TOL

--- a/python/tests/test_relaxation_coverage.py
+++ b/python/tests/test_relaxation_coverage.py
@@ -68,9 +68,7 @@ _OPERATORS = [
     ("log1p", dm.log1p, np.log1p, -0.5, 3.0),
     ("sigmoid", dm.sigmoid, lambda x: 1.0 / (1.0 + np.exp(-x)), -3.0, 3.0),
     ("softplus", dm.softplus, lambda x: np.log1p(np.exp(x)), -3.0, 3.0),
-    # abs over a strictly sign-definite box certifies; the zero-crossing case is a
-    # separate convergence gap, pinned by test_abs_zero_crossing_gap below.
-    ("abs", dm.abs, np.abs, 0.5, 2.0),
+    ("abs", dm.abs, np.abs, -2.0, 2.0),
     ("pow2", _pow2, lambda x: x**2, -2.0, 2.0),
     ("pow3", _pow3, lambda x: x**3, -2.0, 2.0),
     ("pow_half", _pow_half, lambda x: x**0.5, 0.1, 4.0),
@@ -126,19 +124,16 @@ def test_bilinear_lifted_moment_bound():
 
 
 @pytest.mark.relaxation
-@pytest.mark.xfail(
-    reason="abs over a zero-crossing box does not yet certify optimality "
-    "(separate convergence gap; the relaxation is exact but B&B iteration-limits)",
-    strict=False,
-)
-def test_abs_zero_crossing_gap():
-    """Documents a known gap: minimize |x| over an interval straddling 0.
+@pytest.mark.parametrize("lb,ub", [(-1.0, 1.0), (-2.0, 2.0), (-2.0, 3.0)])
+def test_abs_zero_crossing_certifies(lb, ub):
+    """Regression guard: minimize |x| over an interval straddling 0 certifies 0.
 
-    The convex-envelope relaxation is exact, yet the spatial loop currently
-    iteration-limits instead of certifying the optimum of 0.  Recorded as xfail so
-    CI flags it the day the convergence gap is closed.
+    A smooth gradient-based NLP oscillates at the kink (it used to return ~0.99
+    with ``iteration_limit``); non-smooth models now fall back to the spatial
+    McCormick B&B, whose exact piecewise ``abs`` relaxation certifies the
+    optimum of 0.
     """
-    res = _solve(dm.abs, -1.0, 1.0, "min")
+    res = _solve(dm.abs, lb, ub, "min")
     assert res.status == "optimal"
     assert abs(float(res.objective)) < _TOL
 


### PR DESCRIPTION
## Summary

A Wave-2 coverage audit of the univariate relaxation library surfaced operators that produced **no valid global bound** — they returned `status=feasible` with an objective that missed the true optimum. This PR closes those gaps, fixes a related non-smooth routing bug, and adds a self-validating coverage audit so CI catches future regressions.

## 1. Close the asin/acos/acosh relaxation gaps

The spatial LP relaxer could not linearize these `FunctionCall` nodes ("Cannot linearize FunctionCall: asin(x)"), so solves silently fell back to a feasibility objective.

Wired them into the existing univariate operator machinery in `milp_relaxation.py`:

- Recognition + math (`_univariate_arg` / `_value` / `_grad` / `_domain_ok`).
- Curvature from value bounds: `asin` convex for arg≥0 / concave for arg≤0; `acos` the mirror (concave below π/2, convex above); `acosh` concave on its whole domain x≥1.
- `_tangent_points` skips the singular endpoints (±1 for asin/acos, 1 for acosh) where the slope diverges — the secant still bounds the convex/concave branch, exactly as `sqrt` already handles its infinite slope at 0.
- `_inverse_trig_piecewise_interval_specs` splits asin/acos at the inflection (arg=0) into two sign-definite, single-curvature pieces, reusing the existing piecewise-univariate path.

Every line is a valid under/over-estimator, so the optimum is never excluded. All three now certify optimality matching brute force:

| op | before | after |
|----|--------|-------|
| asin min/max | feasible, −0.0 (wrong) | **optimal**, ±1.5708 |
| acos min/max | feasible, −1.571 (wrong) | **optimal**, 0 / π |
| acosh min/max | feasible, 1.317 (wrong) | **optimal**, 0 / 1.763 |

## 2. Fix non-smooth abs/min/max routing

The audit also revealed `min |x|` over a zero-crossing interval returned a **wrong** point (~0.99 with `iteration_limit`). Root cause was routing, not the relaxation: `abs` is convex, so it went to the convex NLP fast path, where a smooth gradient solver oscillates at the kink. The spatial McCormick B&B already has an *exact* piecewise relaxation (solves `abs` in 1 node).

- Add `_model_contains_nonsmooth_node` (`UnaryOp("abs")`, `FunctionCall` in {abs, min, max}), mirroring `_model_contains_custom_call`.
- When the convex NLP fast path does not certify **and** the model is non-smooth, drop the convex verdict and fall back to the spatial B&B — structured as `if non-smooth / elif clearable-denominator / else return`, reusing the existing fallback pattern.
- Smooth convex models are untouched (still take the fast path in 0 nodes).

`min |x|` over [−1,1], [−2,2], [−2,3] now all certify **0.0 / optimal**; `minimum`/`maximum` and abs-in-constraint/composite also certify.

## 3. Coverage-audit test

New `python/tests/test_relaxation_coverage.py` (registers the `relaxation` marker): a self-validating per-operator audit that solves each common univariate operator (min **and** max) and checks the certified optimum against a dense brute-force grid — no brittle hard-coded optima. Includes a lifted-moment bilinear check, a regression guard for the three closed inverse-trig gaps, and a regression guard for the zero-crossing `abs` fix.

## Tests

- `test_relaxation_coverage.py`: **33 passed**.
- Convex / continuous / non-smooth regression sweep (incl. all of `test_convex_fast_path.py`): **545 passed, 0 failed**.
- Relaxation/soundness suites (transcendental, theorems, monotone certification, envelopes, fp-soundness, p1 B&B soundness): all green.
- ruff + format + mypy clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr)_