### PR TITLE
feat(diff): differentiable MILP/MIQP via fix-and-differentiate

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -23,6 +23,7 @@ parts:
       - file: notebooks/tutorial_solver_pounce
       - file: notebooks/tutorial_pounce_sipopt
       - file: notebooks/differentiable_pounce_layer
+      - file: notebooks/differentiable_milp
       - file: notebooks/tutorial_solver_cyipopt
       - file: notebooks/tutorial_solver_selection
   - caption: Tutorials

--- a/docs/notebooks/differentiable_milp.ipynb
+++ b/docs/notebooks/differentiable_milp.ipynb
@@ -1,0 +1,236 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Differentiable MILP / MIQP\n",
+    "\n",
+    "Optimization layers let a solver sit *inside* a differentiable program: you can\n",
+    "backpropagate a downstream loss through `argmin`. For convex problems this is the\n",
+    "OptNet / `cvxpylayers` construction {cite:p}`Amos2017,Agrawal2019`, which discopt\n",
+    "already provides for LP, QP, and NLP via implicit differentiation of the KKT\n",
+    "system (the sIPOPT sensitivity {cite:p}`Pirnay2012`).\n",
+    "\n",
+    "**Mixed-integer** programs are harder: the optimal integer assignment is a\n",
+    "*piecewise-constant* function of the parameters, so the objective is not globally\n",
+    "smooth and the naive gradient is zero almost everywhere {cite:p}`Ferber2020`. This\n",
+    "matters for **decision-focused learning** {cite:p}`Elmachtoub2022`, where we want\n",
+    "to train an upstream predictor through a downstream discrete decision.\n",
+    "\n",
+    "discopt handles integer models with **fix-and-differentiate**: solve the\n",
+    "MILP/MIQP, *fix the integers at their optimal values*, and differentiate the\n",
+    "resulting continuous restriction at the incumbent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The fix-and-differentiate gradient\n",
+    "\n",
+    "For a parametric mixed-integer program\n",
+    "\n",
+    "$$ \\min_{x,\\,y\\in\\mathbb{Z}^k}\\; f(x,y;p)\\quad\\text{s.t.}\\quad g(x,y;p)\\le 0, $$\n",
+    "\n",
+    "let $y^\\*(p)$ be the optimal integer assignment. Wherever $y^\\*$ is *locally\n",
+    "stable* in $p$, fixing $y=y^\\*$ leaves a continuous problem whose optimum\n",
+    "$x^\\*(p)$ varies smoothly, and the envelope theorem gives the exact objective\n",
+    "sensitivity\n",
+    "\n",
+    "$$ \\frac{d\\,\\text{obj}^\\*}{dp}\n",
+    "   = \\frac{\\partial \\mathcal{L}}{\\partial p}\\Big|_{x^\\*,\\,\\lambda^\\*}\n",
+    "   = \\frac{\\partial f}{\\partial p} + \\lambda^{\\*\\top}\\frac{\\partial g}{\\partial p}, $$\n",
+    "\n",
+    "evaluated at the fixed-integer optimum with its continuous multipliers\n",
+    "$\\lambda^\\*$. At parameter values where $y^\\*$ *switches* (breakpoints) the\n",
+    "objective has a kink and the gradient is one-sided \u2014 the value returned is that\n",
+    "of the incumbent assignment's restriction, which is the right object when the\n",
+    "discrete decision is being held fixed for learning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ.setdefault('JAX_PLATFORMS', 'cpu')\n",
+    "os.environ.setdefault('JAX_ENABLE_X64', '1')\n",
+    "\n",
+    "import numpy as np\n",
+    "import discopt.modeling as dm\n",
+    "from discopt._jax.differentiable import differentiable_solve"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A fixed-charge MILP\n",
+    "\n",
+    "Minimize $p\\,y + x$ subject to $x \\ge 3 - y$, with $y\\in\\{0,1\\}$ and\n",
+    "$x\\in[0,10]$. For a small fixed charge $p<1$ it pays to 'switch on' $y=1$,\n",
+    "giving $x=2$ and objective $p+2$ \u2014 so $d\\,\\text{obj}^\\*/dp = 1$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fixed_charge(p_value):\n",
+    "    m = dm.Model('fixed_charge')\n",
+    "    p = m.parameter('p', value=p_value)\n",
+    "    y = m.binary('y')\n",
+    "    x = m.continuous('x', lb=0, ub=10)\n",
+    "    m.subject_to(x >= 3 - y)\n",
+    "    m.minimize(p * y + x)\n",
+    "    return m, p\n",
+    "\n",
+    "m, p = fixed_charge(0.5)\n",
+    "res = differentiable_solve(m)\n",
+    "print('status   :', res.status)\n",
+    "print('objective:', round(float(res.objective), 6))\n",
+    "print('y*, x*   :', float(np.asarray(res.x['y'])), float(np.asarray(res.x['x'])))\n",
+    "print('d(obj)/dp:', round(float(res.gradient(p)), 6))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The analytic gradient matches a central finite difference of the *re-solved*\n",
+    "objective \u2014 confirming it is the true sensitivity, not a relaxation surrogate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fd_gradient(make_model, p0, eps=1e-5):\n",
+    "    mp, _ = make_model(p0 + eps)\n",
+    "    mm, _ = make_model(p0 - eps)\n",
+    "    return (differentiable_solve(mp).objective - differentiable_solve(mm).objective) / (2 * eps)\n",
+    "\n",
+    "print('analytic:', round(float(res.gradient(p)), 6))\n",
+    "print('finite-diff:', round(float(fd_gradient(fixed_charge, 0.5)), 6))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A MIQP with a binding constraint\n",
+    "\n",
+    "Minimize $(x-p)^2 + \\tfrac12 y$ subject to $x \\le 0.5$, $y\\in\\{0,1\\}$. For\n",
+    "$p>0.5$ the continuous optimum wants $x=p$ but the constraint binds at $x=0.5$\n",
+    "with $y=0$, so the gradient flows through the active constraint:\n",
+    "$d\\,\\text{obj}^\\*/dp = 2(p-0.5)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def miqp_binding(p_value):\n",
+    "    m = dm.Model('miqp_binding')\n",
+    "    p = m.parameter('p', value=p_value)\n",
+    "    y = m.binary('y')\n",
+    "    x = m.continuous('x', lb=-5, ub=5)\n",
+    "    m.subject_to(x <= 0.5)\n",
+    "    m.minimize((x - p) ** 2 + 0.5 * y)\n",
+    "    return m, p\n",
+    "\n",
+    "m2, p2 = miqp_binding(2.0)\n",
+    "r2 = differentiable_solve(m2)\n",
+    "print('objective:', round(float(r2.objective), 6), ' expected', (0.5 - 2.0) ** 2)\n",
+    "print('analytic :', round(float(r2.gradient(p2)), 6), ' expected 2*(2-0.5) =', 2 * (2.0 - 0.5))\n",
+    "print('finite-diff:', round(float(fd_gradient(miqp_binding, 2.0)), 6))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A JAX-composable layer for decision-focused learning\n",
+    "\n",
+    "`make_milp_objective_layer` wraps the MILP solve + fix-and-differentiate gradient\n",
+    "as a `jax.custom_vjp`, so it slots into `jax.grad` / `jax.jit` pipelines \u2014 the\n",
+    "composition decision-focused learning needs {cite:p}`Elmachtoub2022`. Here we\n",
+    "backpropagate a downstream squared loss on the optimal objective through the\n",
+    "integer solve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from discopt._jax.pounce_layer import make_milp_objective_layer\n",
+    "\n",
+    "m, p = fixed_charge(0.5)\n",
+    "layer = make_milp_objective_layer(m, [p])\n",
+    "\n",
+    "# Downstream loss: drive the optimal objective toward a target of 2.0.\n",
+    "def loss(p_vec, target=2.0):\n",
+    "    return (layer(p_vec) - target) ** 2\n",
+    "\n",
+    "p_vec = jnp.array([0.5])\n",
+    "print('obj       :', round(float(layer(p_vec)), 6))\n",
+    "print('d loss/dp :', round(float(np.asarray(jax.grad(loss)(p_vec))[0]), 6))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The gradient `2 * (obj - target) * d(obj)/dp = 2 * (2.5 - 2.0) * 1 = 1.0` is\n",
+    "computed end to end through the branch-and-bound solve.\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "- discopt differentiates **MILP / MIQP / integer MINLP** by fixing the integers\n",
+    "  at the optimum and applying the continuous envelope-theorem sensitivity\n",
+    "  {cite:p}`Pirnay2012` to the restriction.\n",
+    "- The objective gradient is **exact** wherever the optimal integer assignment is\n",
+    "  locally stable; at breakpoints it is the incumbent assignment's one-sided\n",
+    "  value \u2014 the right convention for decision-focused learning\n",
+    "  {cite:p}`Ferber2020,Elmachtoub2022`.\n",
+    "- `make_milp_objective_layer` exposes this as a `jax.custom_vjp` for use inside\n",
+    "  `jax.grad` / `jax.jit` / `jax.vmap`, mirroring the LP/QP/NLP layers\n",
+    "  {cite:p}`Amos2017,Agrawal2019`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1862,3 +1862,14 @@
   year      = {2004},
   doi       = {10.1080/10556780410001654241}
 }
+
+@inproceedings{Ferber2020,
+  author    = {Ferber, Aaron and Wilder, Bryan and Dilkina, Bistra and Tambe, Milind},
+  title     = {{MIPaaL}: Mixed Integer Program as a Layer},
+  booktitle = {Proceedings of the AAAI Conference on Artificial Intelligence},
+  volume    = {34},
+  number    = {02},
+  pages     = {1504--1511},
+  year      = {2020},
+  doi       = {10.1609/aaai.v34i02.5509}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,10 @@ module = "discopt._jax.nl_evaluator"
 disable_error_code = "no-any-return"
 
 [[tool.mypy.overrides]]
+module = "discopt._jax.pounce_layer"
+disable_error_code = "no-any-return"
+
+[[tool.mypy.overrides]]
 module = "discopt.solver"
 disable_error_code = "attr-defined"
 

--- a/python/discopt/_jax/differentiable.py
+++ b/python/discopt/_jax/differentiable.py
@@ -394,13 +394,14 @@ def differentiable_solve(
 
     model.validate()
 
-    # Check all variables are continuous
-    for v in model._variables:
-        if v.var_type != VarType.CONTINUOUS:
-            raise ValueError(
-                "differentiable_solve only supports continuous models. "
-                f"Variable '{v.name}' is {v.var_type.value}."
-            )
+    # Models with integer/binary variables are differentiated by fixing the
+    # integers at their optimal values and differentiating the resulting
+    # continuous restriction at the incumbent (the integer assignment is locally
+    # piecewise-constant in the parameters, so the envelope theorem gives the
+    # exact gradient wherever that optimum is stable). See
+    # ``_differentiable_solve_integer``.
+    if any(v.var_type != VarType.CONTINUOUS for v in model._variables):
+        return _differentiable_solve_integer(model, nlp_solver=nlp_solver, solver_options=opts)
 
     # Solve the NLP
     evaluator = NLPEvaluator(model)
@@ -467,6 +468,81 @@ def differentiable_solve(
     return DiffSolveResult(
         status="optimal",
         objective=nlp_result.objective,
+        x=x_dict,
+        _model=model,
+        _sensitivity=sensitivity,
+    )
+
+
+def _differentiable_solve_integer(
+    model: Model,
+    *,
+    nlp_solver: str = "pounce",
+    solver_options: Optional[dict] = None,
+) -> "DiffSolveResult":
+    """Differentiable solve for models with integer/binary variables.
+
+    Uses **fix-and-differentiate**: solve the MILP/MIQP/MINLP to optimality,
+    fix the integer variables at their optimal integer values, and apply the
+    continuous envelope-theorem sensitivity (:func:`_compute_sensitivity_at_solution`)
+    to the resulting continuous restriction.
+
+    Validity: at a parameter value where the optimal integer assignment is
+    *locally stable*, the optimal objective is a smooth function of the
+    parameter through the continuous restriction, and the envelope theorem at
+    the fixed-integer optimum gives the exact gradient ``d(obj*)/dp``. At
+    parameter values where the integer optimum switches (breakpoints) the
+    gradient is one-sided / undefined; the analytic value returned is that of
+    the incumbent assignment's restriction (the right object for decision-focused
+    learning, where the discrete decision is held).
+
+    Parameters in *variable bounds* are not differentiated through here (the
+    envelope term covers the objective and explicit constraints); parameters in
+    the objective or constraints — the headline case — are.
+    """
+    from discopt.modeling.core import VarType
+    from discopt.solver import solve_model
+
+    # 1. Solve the integer problem to optimality.
+    result = solve_model(model)
+    if result.status != "optimal" or result.x is None:
+        return DiffSolveResult(
+            status=result.status,
+            objective=result.objective,
+            x=result.x,
+            _model=model,
+            _sensitivity=np.zeros(_param_total_size(model)),
+        )
+
+    x_dict = {name: np.asarray(val, dtype=np.float64) for name, val in result.x.items()}
+
+    # 2. Fix integer/binary variables at their (rounded) optimal values, in
+    #    place, so the model becomes a continuous restriction. Bounds are
+    #    restored in the finally block.
+    saved_bounds: list[tuple[np.ndarray, np.ndarray]] = []
+    try:
+        for v in model._variables:
+            saved_bounds.append((v.lb.copy(), v.ub.copy()))
+            if v.var_type in (VarType.BINARY, VarType.INTEGER):
+                fixed = np.round(x_dict[v.name]).reshape(v.lb.shape)
+                v.lb = fixed.copy()
+                v.ub = fixed.copy()
+
+        # 3. Envelope-theorem sensitivity on the continuous restriction.
+        sensitivity = _compute_sensitivity_at_solution(
+            model,
+            x_dict,
+            nlp_solver=nlp_solver,
+            solver_options=solver_options,
+        )
+    finally:
+        for v, (lb_v, ub_v) in zip(model._variables, saved_bounds):
+            v.lb = lb_v
+            v.ub = ub_v
+
+    return DiffSolveResult(
+        status="optimal",
+        objective=result.objective,
         x=x_dict,
         _model=model,
         _sensitivity=sensitivity,

--- a/python/discopt/_jax/pounce_layer.py
+++ b/python/discopt/_jax/pounce_layer.py
@@ -179,3 +179,79 @@ def make_nlp_layer(
 
     solve.defvjp(solve_fwd, solve_bwd)
     return solve
+
+
+def make_milp_objective_layer(
+    model,
+    parameters: list,
+    solver_options: Optional[dict] = None,
+) -> Callable:
+    """Build a differentiable MILP/MIQP objective layer over ``parameters``.
+
+    Returns ``solve(p) -> obj`` differentiable w.r.t. the JAX vector ``p`` of
+    parameter values. The forward solve runs the integer branch-and-bound; the
+    VJP is the **fix-and-differentiate** sensitivity — the integers are fixed at
+    the optimum and the envelope theorem is applied to the continuous restriction
+    (see :func:`discopt._jax.differentiable._differentiable_solve_integer`).
+
+    This is the JAX-composable form of ``differentiable_solve(...).gradient(...)``
+    for integer models: it slots into ``jax.grad``/``jax.jit``/``jax.vmap``
+    pipelines, which is what decision-focused learning needs. The gradient is
+    exact wherever the optimal integer assignment is locally stable in ``p``; at
+    breakpoints it is the incumbent assignment's one-sided value.
+
+    Scope: objective sensitivity ``d(obj*)/dp`` (the headline use case).
+    Solution sensitivity ``dx*/dp`` through the integers is a follow-on.
+
+    Parameters
+    ----------
+    model : dm.Model
+        A model with integer/binary variables, objective, and constraints set.
+    parameters : list of dm.Parameter
+        Scalar parameters to differentiate with respect to.
+    solver_options : dict, optional
+        Options forwarded to the continuous sensitivity solve.
+    """
+    from discopt._jax.differentiable import differentiable_solve
+
+    params = list(parameters)
+    n_p = len(params)
+
+    def _set_params(p_np: np.ndarray) -> None:
+        for k, prm in enumerate(params):
+            prm.value = np.float64(p_np[k])
+
+    def _host_solve(p_np):
+        _set_params(np.asarray(p_np, dtype=np.float64))
+        res = differentiable_solve(model, solver_options=solver_options)
+        obj = float(res.objective) if res.objective is not None else 0.0
+        # Per-parameter envelope sensitivity (gradient() applies the correct
+        # parameter offset, so this is robust to the layer's parameter ordering).
+        sens = np.array([float(res.gradient(prm)) for prm in params], dtype=np.float64)
+        return (np.float64(obj), sens)
+
+    @jax.custom_vjp
+    def solve(p):
+        obj, _ = jax.pure_callback(
+            _host_solve,
+            (jax.ShapeDtypeStruct((), _F64), jax.ShapeDtypeStruct((n_p,), _F64)),
+            p,
+            vmap_method="sequential",
+        )
+        return obj
+
+    def solve_fwd(p):
+        obj, sens = jax.pure_callback(
+            _host_solve,
+            (jax.ShapeDtypeStruct((), _F64), jax.ShapeDtypeStruct((n_p,), _F64)),
+            p,
+            vmap_method="sequential",
+        )
+        return obj, sens
+
+    def solve_bwd(sens, g):
+        # d(loss)/dp = g * d(obj*)/dp.
+        return (g * sens,)
+
+    solve.defvjp(solve_fwd, solve_bwd)
+    return solve

--- a/python/tests/test_differentiable.py
+++ b/python/tests/test_differentiable.py
@@ -227,16 +227,24 @@ class TestDifferentiableSolve:
         # d(obj*)/dp = x* = 2.0 (by envelope theorem)
         assert float(grad) == pytest.approx(2.0, abs=1e-2)
 
-    def test_rejects_integer_variables(self):
-        """differentiable_solve should raise for models with integer vars."""
-        m = dm.Model("int_model")
-        m.parameter("p", value=1.0)
-        m.binary("y")
-        m.continuous("x", lb=0, ub=10)
-        m.minimize(m._variables[1])
+    def test_supports_integer_variables_via_fix_and_diff(self):
+        """Integer models are now differentiated by fixing integers at the optimum.
 
-        with pytest.raises(ValueError, match="continuous"):
-            differentiable_solve(m)
+        (Previously rejected; see test_differentiable_milp.py for FD-validated
+        gradient coverage of the fix-and-differentiate path.)
+        """
+        m = dm.Model("int_model")
+        p = m.parameter("p", value=0.5)
+        y = m.binary("y")
+        x = m.continuous("x", lb=0, ub=10)
+        m.subject_to(x >= 3 - y)
+        m.minimize(p * y + x)
+
+        result = differentiable_solve(m)
+        assert result.status == "optimal"
+        # p=0.5 < 1 -> y = 1, x = 2; obj = p + 2, so d(obj)/dp = 1.
+        assert float(result.objective) == pytest.approx(2.5, abs=1e-4)
+        assert float(result.gradient(p)) == pytest.approx(1.0, abs=1e-3)
 
 
 # ──────────────────────────────────────────────────────────

--- a/python/tests/test_differentiable_milp.py
+++ b/python/tests/test_differentiable_milp.py
@@ -1,0 +1,162 @@
+"""Differentiable MILP/MIQP via fix-and-differentiate.
+
+``differentiable_solve`` handles integer/binary models by solving the integer
+problem, fixing the integers at their optimal values, and differentiating the
+resulting continuous restriction at the incumbent (the envelope theorem at the
+fixed-integer optimum). The optimal integer assignment is locally
+piecewise-constant in the parameters, so wherever that optimum is stable the
+gradient ``d(obj*)/dp`` is exact — which these tests pin against central finite
+differences.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.differentiable import differentiable_solve
+
+
+def _fd_obj_gradient(make_model, p0, eps=1e-5):
+    """Central finite-difference d(obj*)/dp at p0 using full re-solves."""
+    m_plus, _ = make_model(p0 + eps)
+    m_minus, _ = make_model(p0 - eps)
+    return (differentiable_solve(m_plus).objective - differentiable_solve(m_minus).objective) / (
+        2 * eps
+    )
+
+
+# ───────────────────────────── MILP ─────────────────────────────
+
+
+def _milp_fixed_charge(p0):
+    """min p*y + x  s.t.  x >= 3 - y,  y∈{0,1}, x∈[0,10].
+
+    For small p the optimum is y=1, x=2 (obj = p + 2), so d(obj)/dp = 1.
+    """
+    m = dm.Model("milp_fc")
+    p = m.parameter("p", value=p0)
+    y = m.binary("y")
+    x = m.continuous("x", lb=0, ub=10)
+    m.subject_to(x >= 3 - y)
+    m.minimize(p * y + x)
+    return m, p
+
+
+def test_milp_solution_is_integer_optimum():
+    m, _ = _milp_fixed_charge(0.5)
+    r = differentiable_solve(m)
+    assert r.status == "optimal"
+    assert float(r.objective) == pytest.approx(2.5, abs=1e-4)
+    assert float(np.asarray(r.x["y"])) == pytest.approx(1.0, abs=1e-6)
+    assert float(np.asarray(r.x["x"])) == pytest.approx(2.0, abs=1e-4)
+
+
+def test_milp_gradient_matches_finite_difference():
+    m, p = _milp_fixed_charge(0.5)
+    r = differentiable_solve(m)
+    analytic = float(r.gradient(p))
+    fd = _fd_obj_gradient(_milp_fixed_charge, 0.5)
+    assert analytic == pytest.approx(fd, abs=1e-4)
+    assert analytic == pytest.approx(1.0, abs=1e-4)
+
+
+def _milp_param_rhs(b0):
+    """min x + 2*z*  s.t.  x >= b,  z binary unused; tests RHS sensitivity."""
+    m = dm.Model("milp_rhs")
+    b = m.parameter("b", value=b0)
+    z = m.binary("z")
+    x = m.continuous("x", lb=0, ub=10)
+    m.subject_to(x >= b)
+    m.minimize(x + 2 * z)
+    return m, b
+
+
+def test_milp_rhs_gradient_matches_finite_difference():
+    # Optimum: z=0, x=b -> obj=b -> d(obj)/db = 1.
+    m, b = _milp_param_rhs(2.0)
+    r = differentiable_solve(m)
+    analytic = float(r.gradient(b))
+    fd = _fd_obj_gradient(_milp_param_rhs, 2.0)
+    assert analytic == pytest.approx(fd, abs=1e-4)
+    assert analytic == pytest.approx(1.0, abs=1e-4)
+
+
+# ───────────────────────────── MIQP ─────────────────────────────
+
+
+def _miqp_binding(p0):
+    """min (x - p)^2 + 0.5*y  s.t.  x <= 0.5,  y∈{0,1}, x∈[-5,5].
+
+    For p>0.5 the box/constraint binds at x=0.5, y=0, obj=(0.5-p)^2; the
+    gradient flows through the binding constraint: d(obj)/dp = 2(p-0.5).
+    """
+    m = dm.Model("miqp_bind")
+    p = m.parameter("p", value=p0)
+    y = m.binary("y")
+    x = m.continuous("x", lb=-5, ub=5)
+    m.subject_to(x <= 0.5)
+    m.minimize((x - p) ** 2 + 0.5 * y)
+    return m, p
+
+
+def test_miqp_gradient_matches_finite_difference():
+    m, p = _miqp_binding(2.0)
+    r = differentiable_solve(m)
+    assert r.status == "optimal"
+    analytic = float(r.gradient(p))
+    fd = _fd_obj_gradient(_miqp_binding, 2.0)
+    assert analytic == pytest.approx(fd, abs=1e-3)
+    # Analytic envelope value: 2*(p - 0.5) = 3.0 at p=2.
+    assert analytic == pytest.approx(3.0, abs=1e-2)
+
+
+def _miqp_interior(p0):
+    """min (x - p)^2 + 0.5*y  s.t.  x >= y,  y∈{0,1}, x∈[-5,5].
+
+    For 0<p<5 the unconstrained continuous optimum x=p is feasible with y=0,
+    so obj=0 and d(obj)/dp = 0 (a flat-objective stability check).
+    """
+    m = dm.Model("miqp_int")
+    p = m.parameter("p", value=p0)
+    y = m.binary("y")
+    x = m.continuous("x", lb=-5, ub=5)
+    m.subject_to(x >= y)
+    m.minimize((x - p) ** 2 + 0.5 * y)
+    return m, p
+
+
+def test_miqp_interior_gradient_is_zero():
+    m, p = _miqp_interior(0.7)
+    r = differentiable_solve(m)
+    assert float(r.objective) == pytest.approx(0.0, abs=1e-4)
+    assert float(r.gradient(p)) == pytest.approx(0.0, abs=1e-3)
+
+
+# ──────────────────── JAX-composable MILP layer ────────────────────
+
+
+def test_milp_objective_layer_composes_under_jax_grad():
+    """make_milp_objective_layer is differentiable inside a jax.grad pipeline."""
+    import jax
+    import jax.numpy as jnp
+    from discopt._jax.pounce_layer import make_milp_objective_layer
+
+    m, p = _milp_fixed_charge(0.5)
+    layer = make_milp_objective_layer(m, [p])
+
+    obj = float(layer(jnp.array([0.5])))
+    assert obj == pytest.approx(2.5, abs=1e-3)
+
+    # d(obj)/dp = 1.
+    g = jax.grad(lambda pv: layer(pv))(jnp.array([0.5]))
+    assert float(np.asarray(g)[0]) == pytest.approx(1.0, abs=1e-3)
+
+    # Composes through a downstream loss: d/dp (obj - 2)^2 = 2*(2.5-2)*1 = 1.
+    lg = jax.grad(lambda pv: (layer(pv) - 2.0) ** 2)(jnp.array([0.5]))
+    assert float(np.asarray(lg)[0]) == pytest.approx(1.0, abs=1e-3)


### PR DESCRIPTION
## Summary

Extends `differentiable_solve` (the canonical envelope-theorem path) to **integer models** — the headline capability the POUNCE-only stack was built to enable (roadmap Phase 8 / P5). Previously integer models were rejected (`"only supports continuous models"`), and the separate unified dispatcher only computed a *root-relaxation* gradient by finite differences, which ignores the integer solution entirely.

## Approach — fix-and-differentiate

Solve the MILP/MIQP/integer-MINLP, **fix the integers at their optimal values**, and apply the existing continuous envelope-theorem sensitivity to the resulting restriction.

The optimal integer assignment $y^\*(p)$ is locally piecewise-constant in the parameters, so wherever it is stable the objective is smooth through the continuous restriction and

$$\frac{d\,\text{obj}^\*}{dp} = \frac{\partial f}{\partial p} + \lambda^{\*\top}\frac{\partial g}{\partial p}$$

is **exact**. At breakpoints (where $y^\*$ switches) the gradient is one-sided — the value returned is the incumbent assignment's restriction, which is the right convention for decision-focused learning.

## Changes

- **`_differentiable_solve_integer`** (`_jax/differentiable.py`): solve, pin integer bounds at the optimum (restored in a `finally`), reuse `_compute_sensitivity_at_solution` on the restriction. Wired into `differentiable_solve` ahead of the continuous path.
- **`make_milp_objective_layer`** (`_jax/pounce_layer.py`): a `jax.custom_vjp` exposing `d(obj*)/dp`, so the integer solve composes inside `jax.grad` / `jit` / `vmap`, mirroring the existing LP/QP/NLP layers.
- **Tests**: flip the old integer-rejection test to a support test; new `test_differentiable_milp.py` validates MILP, MIQP (binding + interior), RHS sensitivity, and the JAX layer — all against central finite differences.
- **Docs**: `docs/notebooks/differentiable_milp.ipynb` (fix-and-diff derivation, breakpoint caveat, decision-focused-learning layer demo) with citations; `Ferber2020` (MIPaaL) added to `references.bib`; registered in `_toc.yml`.
- **mypy**: per-module `no-any-return` override for `pounce_layer` (a `jax.custom_vjp` returns `Any`), matching the convention already used for `nlp_evaluator` / `nlp_pounce`.

## Validation (analytic vs. central finite difference)

| case | analytic | FD |
|------|----------|-----|
| fixed-charge MILP | 1.0 | 1.0 |
| MIQP, binding constraint | 3.0 | 3.0 |
| MIQP, interior optimum | 0.0 | 0.0 |
| MILP RHS sensitivity | 1.0 | 1.0 |
| JAX layer through a downstream loss | 1.0 | 1.0 |

## Tests

- `test_differentiable_milp.py` (6) + `test_differentiable.py` + `test_pounce_layer.py` + `test_lp_qp_solvers.py`: **118 passed**.
- ruff + format + mypy clean on touched files.
- Notebook code cells execute cleanly. (The full `jupyter-book build` runs in CI — the doc tooling isn't installed in the dev sandbox.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr