### PR TITLE
test(amp): patch solve_nlp at backend module after JAX-free lazy import

### DIFF
--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -2446,6 +2446,7 @@ class TestCurrentCodeWeaknesses:
         import time
 
         import discopt.solver as solver_mod
+        import discopt.solvers.nlp_ipopt as nlp_ipopt_mod
         from discopt.solvers import NLPResult, SolveStatus
 
         captured: dict[str, np.ndarray] = {}
@@ -2458,7 +2459,13 @@ class TestCurrentCodeWeaknesses:
             captured["x0"] = np.asarray(x0, dtype=np.float64).copy()
             return NLPResult(status=SolveStatus.OPTIMAL, x=captured["x0"], objective=0.0)
 
-        monkeypatch.setattr(solver_mod, "solve_nlp", fake_solve_nlp)
+        # The JAX-free refactor (#224) made ``_solve_continuous`` import
+        # ``solve_nlp`` lazily from its backend module at the call site
+        # (``from discopt.solvers.nlp_ipopt import solve_nlp`` for
+        # nlp_solver="ipopt"), so it is no longer an attribute of
+        # ``discopt.solver``. Patch the name on the origin module the lazy
+        # import reads from.
+        monkeypatch.setattr(nlp_ipopt_mod, "solve_nlp", fake_solve_nlp)
 
         m = Model("bt_sqrt_backend_bounds")
         x = m.continuous("x", lb=-1e20, ub=1e20)


### PR DESCRIPTION
## Problem

The opt-in **AMP integration** workflow went red on `main` (commit dd9d1e1, #225):

```
FAILED python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_continuous_solver_backend_receives_tightened_bounds
  - AttributeError: module 'discopt.solver' has no attribute 'solve_nlp'
1 failed, 188 passed
```

This suite is default-deselected by the normal CI markers, so it only surfaces in the dedicated `AMP integration` workflow — which is why it landed on `main` before being caught.

## Root cause

Not a solver bug. The JAX-free refactor (#224) moved `solve_nlp` from a module-level import to a **lazy, backend-specific import inside `_solve_continuous`** (`from discopt.solvers.nlp_ipopt import solve_nlp` for `nlp_solver="ipopt"`), so it is no longer an attribute of `discopt.solver`. The test's `monkeypatch.setattr(discopt.solver, "solve_nlp", ...)` therefore raises `AttributeError`.

## Fix

Per the established "update the stale test, don't revert sound source" rule (same as #222), repoint the monkeypatch at the origin module the lazy import reads from — `discopt.solvers.nlp_ipopt`. The test drives the ipopt backend explicitly via `nlp_solver="ipopt"`, so that is the correct patch target; the lazy `from discopt.solvers.nlp_ipopt import solve_nlp` then picks up the fake at call time.

One-line change plus an explanatory comment. Verified locally: the test passes, and `ruff check` is clean. The full AMP suite runs in this PR's `AMP integration` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
