### PR TITLE
feat(infeasibility): Irreducible Infeasible Subsystem (IIS) computation

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -38,6 +38,7 @@ parts:
       - file: notebooks/solver_internals
       - file: notebooks/presolve
       - file: notebooks/bound_tightening
+      - file: notebooks/infeasibility_iis
       - file: notebooks/sensitivity_analysis
       - file: notebooks/llm_integration
       - file: llm_features

--- a/docs/notebooks/infeasibility_iis.ipynb
+++ b/docs/notebooks/infeasibility_iis.ipynb
@@ -1,0 +1,217 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Debugging infeasible models with an IIS\n",
+    "\n",
+    "When `solve()` returns `status == \"infeasible\"`, the model has no solution \u2014 but\n",
+    "the full constraint list rarely tells you *why*: most constraints are innocent\n",
+    "bystanders. An **Irreducible Infeasible Subsystem (IIS)** is a *minimal* set of\n",
+    "constraints (and variable bounds) that is infeasible on its own, yet becomes\n",
+    "feasible if **any single member is removed** {cite:p}`Chinneck2008`. It is the\n",
+    "smallest self-contained explanation of the conflict \u2014 the analogue of Gurobi's\n",
+    "`computeIIS` and CPLEX's conflict refiner."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The algorithm: deletion filtering\n",
+    "\n",
+    "discopt computes an IIS by **deletion filtering** {cite:p}`Chinneck1991`:\n",
+    "\n",
+    "1. Confirm the full model is (provably) infeasible.\n",
+    "2. Tentatively drop one candidate (a constraint or a finite variable bound) and\n",
+    "   re-solve a *feasibility* problem.\n",
+    "3. If the remainder is still **provably infeasible**, the candidate is redundant\n",
+    "   to the conflict \u2014 drop it for good. If feasibility is restored, the candidate\n",
+    "   is **essential** \u2014 keep it.\n",
+    "4. What survives is an IIS.\n",
+    "\n",
+    "**Soundness with an incomplete solver.** A candidate is removed only when the\n",
+    "reduced model is *proven* infeasible. A solve that is merely inconclusive (a\n",
+    "nonconvex MINLP that times out without a proof) is conservatively treated as\n",
+    "\"keep the candidate\". The result is therefore always a genuine infeasible\n",
+    "subsystem; it is *irreducible* exactly when every probe was conclusive \u2014 always\n",
+    "the case for LP / MILP / convex models. `IISResult.proven_irreducible` reports\n",
+    "which guarantee you have."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ.setdefault('JAX_PLATFORMS', 'cpu')\n",
+    "os.environ.setdefault('JAX_ENABLE_X64', '1')\n",
+    "\n",
+    "import discopt.modeling as dm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A constraint conflict hidden among red herrings\n",
+    "\n",
+    "Here `x` is pushed above 5 and below 2 \u2014 a contradiction \u2014 while two other\n",
+    "constraints are perfectly satisfiable. `solve()` only reports *infeasible*; the\n",
+    "IIS pinpoints the two constraints that actually clash."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = dm.Model('blend')\n",
+    "x = m.continuous('x', lb=-10, ub=10)\n",
+    "y = m.continuous('y', lb=-10, ub=10)\n",
+    "m.subject_to(x >= 5, name='demand_floor')\n",
+    "m.subject_to(x <= 2, name='capacity_cap')\n",
+    "m.subject_to(y <= 3, name='side_limit')        # red herring\n",
+    "m.subject_to(x + y <= 8, name='budget')        # red herring\n",
+    "m.minimize(x + y)\n",
+    "\n",
+    "res = m.solve()\n",
+    "print('solve status:', res.status)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iis = m.compute_iis()\n",
+    "print(iis.summary())\n",
+    "print('\\nfeasibility solves used:', iis.n_solves)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Out of four constraints, the IIS names exactly `demand_floor` and\n",
+    "`capacity_cap` \u2014 the two you would edit to fix the model \u2014 and confirms the\n",
+    "result is provably minimal."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conflicts involving variable bounds\n",
+    "\n",
+    "Infeasibility is often driven by a **bound**, not a constraint. By default\n",
+    "`compute_iis` also treats finite variable bounds as removable members, so it can\n",
+    "surface a clash between a bound and a constraint. Here the lower bound `x >= 5`\n",
+    "fights the constraint `x <= 2`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = dm.Model('bound_conflict')\n",
+    "x2 = m2.continuous('x', lb=5, ub=10)   # the lower bound is the culprit\n",
+    "z = m2.continuous('z', lb=-1, ub=1)\n",
+    "m2.subject_to(x2 <= 2, name='cap')\n",
+    "m2.subject_to(z >= -0.5, name='unrelated')\n",
+    "m2.minimize(x2)\n",
+    "\n",
+    "iis2 = m2.compute_iis()\n",
+    "print(iis2.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The IIS reports both the constraint `cap` **and** the variable bound `x >= 5`,\n",
+    "while ignoring the unrelated variable `z`. Pass `include_bounds=False` to restrict\n",
+    "the IIS to explicit constraints only."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Integer-domain infeasibility\n",
+    "\n",
+    "Deletion filtering works for any class the solver can certify infeasible \u2014\n",
+    "including integrality. Requiring an integer strictly between 3 and 4 is\n",
+    "infeasible, and the IIS isolates the two bracketing constraints:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m3 = dm.Model('integer_gap')\n",
+    "yv = m3.integer('y', lb=0, ub=10)\n",
+    "m3.subject_to(yv >= 3.2, name='lower')\n",
+    "m3.subject_to(yv <= 3.8, name='upper')\n",
+    "m3.minimize(yv)\n",
+    "\n",
+    "print('status:', m3.solve().status)\n",
+    "print(m3.compute_iis(include_bounds=False).summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Practical notes\n",
+    "\n",
+    "- **Cost.** Deletion filtering performs up to one feasibility solve per\n",
+    "  candidate, so it scales with the number of constraints and finite bounds. Run\n",
+    "  it on demand (when a solve returns infeasible), not in the hot loop.\n",
+    "- **Reliability.** Most precise on LP / MILP / convex models, where infeasibility\n",
+    "  is certifiable. On nonconvex MINLP a probe may time out without a proof;\n",
+    "  `compute_iis` then keeps the candidate and sets\n",
+    "  `proven_irreducible = False`, so the returned set stays a valid (if possibly\n",
+    "  non-minimal) infeasible subsystem {cite:p}`Chinneck2008`.\n",
+    "- **Not unique.** A model can have several IISes; `compute_iis` returns one.\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "`Model.compute_iis()` turns an opaque *infeasible* verdict into a short,\n",
+    "actionable list of the constraints and bounds that conflict \u2014 computed by sound\n",
+    "deletion filtering {cite:p}`Chinneck1991` on discopt's own solver, with an\n",
+    "explicit minimality guarantee."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1873,3 +1873,24 @@
   year      = {2020},
   doi       = {10.1609/aaai.v34i02.5509}
 }
+
+@article{Chinneck1991,
+  author  = {Chinneck, John W. and Dravnieks, Erik W.},
+  title   = {Locating Minimal Infeasible Constraint Sets in Linear Programs},
+  journal = {ORSA Journal on Computing},
+  volume  = {3},
+  number  = {2},
+  pages   = {157--168},
+  year    = {1991},
+  doi     = {10.1287/ijoc.3.2.157}
+}
+
+@book{Chinneck2008,
+  author    = {Chinneck, John W.},
+  title     = {Feasibility and Infeasibility in Optimization: Algorithms and Computational Methods},
+  publisher = {Springer},
+  series    = {International Series in Operations Research \& Management Science},
+  volume    = {118},
+  year      = {2008},
+  doi       = {10.1007/978-0-387-74932-7}
+}

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -85,6 +85,12 @@ from discopt.callbacks import (
 from discopt.callbacks import (
     CutResult as CutResult,
 )
+from discopt.infeasibility import (
+    IISResult as IISResult,
+)
+from discopt.infeasibility import (
+    compute_iis as compute_iis,
+)
 from discopt.modeling import (
     Constraint as Constraint,
 )

--- a/python/discopt/infeasibility.py
+++ b/python/discopt/infeasibility.py
@@ -1,0 +1,256 @@
+"""Irreducible Infeasible Subsystem (IIS) computation.
+
+When a model is infeasible, the full constraint set does not explain *why* — most
+constraints are irrelevant to the conflict. An **IIS** is a minimal subset of
+constraints (and variable bounds) that is itself infeasible but becomes feasible
+if *any* single member is removed. It is the smallest self-contained explanation
+of the infeasibility, the analogue of Gurobi's ``computeIIS`` / CPLEX's conflict
+refiner.
+
+The algorithm is **deletion filtering** (Chinneck & Dravnieks 1991): start from
+the full (infeasible) model and tentatively drop one candidate at a time; if the
+remainder is still *provably* infeasible the candidate is redundant and is
+dropped permanently, otherwise it is essential and kept. What remains is an IIS.
+
+Soundness with an incomplete solver: a candidate is dropped only when the reduced
+model is **proven** infeasible (``status == "infeasible"``). A solve that is
+merely inconclusive (e.g. a nonconvex MINLP that hits the time limit without a
+proof) is treated as "keep the candidate". The returned set is therefore always a
+genuine infeasible subsystem; it is *irreducible* exactly when every filtering
+solve was conclusive (always the case for LP/MILP/convex models). See
+:attr:`IISResult.proven_irreducible`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from discopt.modeling.core import (
+    Constant,
+    Constraint,
+    Objective,
+    ObjectiveSense,
+    VarType,
+)
+
+if TYPE_CHECKING:
+    from discopt.modeling.core import Model, Variable
+
+logger = logging.getLogger(__name__)
+
+# discopt treats |bound| >= this as unbounded; relaxing a bound sets it here.
+_INF = 1e20
+_FINITE = 1e19
+
+
+@dataclass
+class IISResult:
+    """An Irreducible Infeasible Subsystem.
+
+    Attributes
+    ----------
+    constraints : list[Constraint]
+        Constraints belonging to the IIS.
+    variable_bounds : list[tuple[Variable, str]]
+        Variable bounds in the IIS, each as ``(variable, "lower"|"upper")``.
+    n_solves : int
+        Number of feasibility solves performed (deletion-filter cost).
+    proven_irreducible : bool
+        ``True`` when every filtering solve was conclusive, so the result is a
+        true (minimal) IIS. ``False`` means some solves were inconclusive and the
+        set is a valid — but possibly non-minimal — infeasible subsystem.
+    """
+
+    constraints: list[Constraint] = field(default_factory=list)
+    variable_bounds: list[tuple["Variable", str]] = field(default_factory=list)
+    n_solves: int = 0
+    proven_irreducible: bool = True
+
+    def __len__(self) -> int:
+        return len(self.constraints) + len(self.variable_bounds)
+
+    def __bool__(self) -> bool:
+        return len(self) > 0
+
+    def summary(self) -> str:
+        """A human-readable multi-line explanation of the infeasibility."""
+        lines = [
+            f"Irreducible Infeasible Subsystem ({len(self)} members"
+            + ("" if self.proven_irreducible else ", not proven minimal")
+            + "):"
+        ]
+        if self.constraints:
+            lines.append("  Constraints:")
+            for c in self.constraints:
+                label = c.name if c.name else repr(c)
+                lines.append(f"    - {label}:  {c.body} {c.sense} {c.rhs:g}")
+        if self.variable_bounds:
+            lines.append("  Variable bounds:")
+            for var, which in self.variable_bounds:
+                bound = var.lb if which == "lower" else var.ub
+                op = ">=" if which == "lower" else "<="
+                val = float(np.min(bound)) if which == "lower" else float(np.max(bound))
+                lines.append(f"    - {var.name} {op} {val:g}")
+        if not self:
+            lines.append("  (empty)")
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return self.summary()
+
+
+def _bound_candidates(model: "Model") -> list[tuple[int, str]]:
+    """Finite lower/upper bounds of non-binary variables, as (var_index, side).
+
+    Binary variables are skipped: their ``{0, 1}`` domain is intrinsic, not a
+    removable bound. Infinite bounds cannot cause infeasibility and are excluded.
+    """
+    items: list[tuple[int, str]] = []
+    for vi, v in enumerate(model._variables):
+        if v.var_type == VarType.BINARY:
+            continue
+        if float(np.min(np.asarray(v.lb))) > -_FINITE:
+            items.append((vi, "lower"))
+        if float(np.max(np.asarray(v.ub))) < _FINITE:
+            items.append((vi, "upper"))
+    return items
+
+
+def _solve_is_infeasible(
+    model: "Model",
+    active_constraints: list[Constraint],
+    relaxed_bounds: set[tuple[int, str]],
+    saved_bounds: list[tuple[np.ndarray, np.ndarray]],
+    time_limit: float,
+) -> tuple[bool, bool]:
+    """Solve the model restricted to ``active_constraints`` with ``relaxed_bounds``
+    dropped, under a feasibility (constant) objective.
+
+    Returns ``(is_infeasible, conclusive)``: ``is_infeasible`` is True only on a
+    proven ``"infeasible"`` status; ``conclusive`` is False when the solver could
+    neither prove infeasibility nor find a feasible point.
+    """
+    saved_cons = model._constraints
+    saved_obj = model._objective
+    model._constraints = active_constraints
+    model._objective = Objective(Constant(0.0), ObjectiveSense.MINIMIZE)
+    for vi, side in relaxed_bounds:
+        v = model._variables[vi]
+        if side == "lower":
+            v.lb = np.full_like(np.asarray(v.lb, dtype=np.float64), -_INF)
+        else:
+            v.ub = np.full_like(np.asarray(v.ub, dtype=np.float64), _INF)
+    try:
+        # ``solve`` is typed ``SolveResult | Iterator`` (streaming overload); the
+        # non-streaming call returns a SolveResult with ``.status``.
+        status = getattr(model.solve(time_limit=time_limit), "status", "error")
+    except Exception as exc:  # noqa: BLE001 - a crashed feasibility probe is inconclusive
+        logger.debug("IIS feasibility probe raised: %s", exc)
+        status = "error"
+    finally:
+        model._constraints = saved_cons
+        model._objective = saved_obj
+        for vi, (lb, ub) in zip(range(len(model._variables)), saved_bounds):
+            model._variables[vi].lb = lb
+            model._variables[vi].ub = ub
+
+    if status == "infeasible":
+        return True, True
+    if status in ("optimal", "feasible"):
+        return False, True
+    return False, False  # inconclusive (time_limit / error / unbounded)
+
+
+def compute_iis(
+    model: "Model",
+    *,
+    include_bounds: bool = True,
+    time_limit: float = 30.0,
+) -> IISResult:
+    """Compute an Irreducible Infeasible Subsystem of an infeasible ``model``.
+
+    Parameters
+    ----------
+    model : Model
+        A model whose constraints (and optionally variable bounds) are
+        collectively infeasible.
+    include_bounds : bool, default True
+        Also consider finite variable bounds as removable members of the IIS.
+        Required to explain infeasibilities driven by bounds (e.g. ``x >= 5`` and
+        ``x <= 2`` declared as bounds rather than constraints).
+    time_limit : float, default 30.0
+        Per-solve wall-clock limit for each feasibility probe.
+
+    Returns
+    -------
+    IISResult
+        The constraints and variable bounds forming the IIS.
+
+    Raises
+    ------
+    ValueError
+        If ``model`` is not (provably) infeasible to begin with — there is no
+        infeasibility to explain.
+    """
+    all_constraints = list(model._constraints)
+    bound_items = _bound_candidates(model) if include_bounds else []
+
+    # Snapshot every variable's bounds once; each probe restores from this.
+    saved_bounds = [(np.asarray(v.lb).copy(), np.asarray(v.ub).copy()) for v in model._variables]
+
+    # Active set: indices into all_constraints, plus active bound items.
+    active_con_idx = set(range(len(all_constraints)))
+    active_bounds = set(bound_items)
+    n_solves = 0
+    proven = True
+
+    def probe() -> tuple[bool, bool]:
+        nonlocal n_solves
+        n_solves += 1
+        cons = [all_constraints[i] for i in sorted(active_con_idx)]
+        relaxed = set(bound_items) - active_bounds
+        return _solve_is_infeasible(model, cons, relaxed, saved_bounds, time_limit)
+
+    # Baseline: the full system must be provably infeasible.
+    base_infeasible, base_conclusive = probe()
+    if not base_infeasible:
+        if base_conclusive:
+            raise ValueError(
+                "compute_iis: the model is feasible — there is no infeasibility to explain."
+            )
+        raise ValueError(
+            "compute_iis: could not prove the model infeasible within the time limit; "
+            "an IIS is only defined for an infeasible model."
+        )
+
+    # Deletion filter over constraints, then bounds. Drop a member only when the
+    # remainder is *proven* infeasible; an inconclusive probe keeps the member
+    # (and flags the result as not-proven-minimal).
+    for i in list(active_con_idx):
+        active_con_idx.discard(i)
+        infeasible, conclusive = probe()
+        if infeasible:
+            continue  # constraint i is redundant to the conflict
+        active_con_idx.add(i)  # essential — keep it
+        if not conclusive:
+            proven = False
+
+    for item in list(active_bounds):
+        active_bounds.discard(item)
+        infeasible, conclusive = probe()
+        if infeasible:
+            continue
+        active_bounds.add(item)
+        if not conclusive:
+            proven = False
+
+    return IISResult(
+        constraints=[all_constraints[i] for i in sorted(active_con_idx)],
+        variable_bounds=[(model._variables[vi], side) for (vi, side) in sorted(active_bounds)],
+        n_solves=n_solves,
+        proven_irreducible=proven,
+    )

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2381,6 +2381,25 @@ class Model:
         """Streaming solve that yields updates during B&B."""
         raise NotImplementedError("Streaming solve requires solver backend")
 
+    # ── Infeasibility analysis ──
+
+    def compute_iis(self, *, include_bounds: bool = True, time_limit: float = 30.0):
+        """Compute an Irreducible Infeasible Subsystem explaining infeasibility.
+
+        Returns an :class:`~discopt.infeasibility.IISResult` — a minimal set of
+        constraints (and, by default, variable bounds) that is infeasible but
+        becomes feasible if any single member is removed. Use it to debug *why*
+        ``solve()`` returned ``"infeasible"``. Raises ``ValueError`` if the model
+        is not provably infeasible.
+
+        >>> res = m.solve()
+        >>> if res.status == "infeasible":
+        ...     print(m.compute_iis().summary())
+        """
+        from discopt.infeasibility import compute_iis
+
+        return compute_iis(self, include_bounds=include_bounds, time_limit=time_limit)
+
     # ── Validation ──
 
     def validate(self):

--- a/python/tests/test_iis.py
+++ b/python/tests/test_iis.py
@@ -1,0 +1,145 @@
+"""Tests for Irreducible Infeasible Subsystem (IIS) computation.
+
+An IIS must be (a) infeasible on its own and (b) irreducible — removing any one
+member restores feasibility. These tests pin both properties plus the API
+contract (raises on feasible models, finds bound- and integer-driven conflicts).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import pytest
+from discopt.infeasibility import IISResult, compute_iis
+
+
+def _names(iis: IISResult) -> set[str]:
+    return {c.name for c in iis.constraints}
+
+
+def _is_infeasible(build) -> bool:
+    return build().solve(time_limit=30).status == "infeasible"
+
+
+# ───────────────────────── constraint conflicts ─────────────────────────
+
+
+def test_isolates_two_constraint_conflict_from_red_herrings():
+    m = dm.Model("c")
+    x = m.continuous("x", lb=-10, ub=10)
+    y = m.continuous("y", lb=-10, ub=10)
+    m.subject_to(x >= 5, name="x_big")
+    m.subject_to(x <= 2, name="x_small")
+    m.subject_to(y <= 3, name="rh1")
+    m.subject_to(x + y <= 8, name="rh2")
+    m.minimize(x + y)
+
+    iis = m.compute_iis()
+    assert _names(iis) == {"x_big", "x_small"}
+    assert iis.proven_irreducible
+
+
+def test_iis_is_infeasible_and_irreducible():
+    """Property test: the IIS is infeasible, and dropping any member feasibilizes."""
+    m = dm.Model("c")
+    x = m.continuous("x", lb=-10, ub=10)
+    m.subject_to(x >= 5, name="a")
+    m.subject_to(x <= 2, name="b")
+    m.subject_to(x <= 9, name="loose")  # redundant red herring
+    m.minimize(x)
+
+    iis = compute_iis(m, include_bounds=False)
+    members = list(iis.constraints)
+    assert len(members) >= 2
+
+    # (a) The IIS alone is infeasible.
+    def _with(cons):
+        mm = dm.Model("sub")
+        xx = mm.continuous("x", lb=-10, ub=10)
+        mm.minimize(xx)
+        # rebuild the member constraints against the fresh variable
+        mapping = {"a": xx >= 5, "b": xx <= 2, "loose": xx <= 9}
+        for c in cons:
+            mm.subject_to(mapping[c.name])
+        return mm
+
+    assert _is_infeasible(lambda: _with(members))
+    # (b) Dropping any single member restores feasibility.
+    for drop in members:
+        rest = [c for c in members if c is not drop]
+        assert not _is_infeasible(lambda: _with(rest)), f"dropping {drop.name} stayed infeasible"
+
+
+# ───────────────────────── bound-driven conflicts ─────────────────────────
+
+
+def test_finds_bound_vs_constraint_conflict():
+    m = dm.Model("b")
+    x = m.continuous("x", lb=5, ub=10)  # lower bound 5 is the culprit
+    z = m.continuous("z", lb=-1, ub=1)
+    m.subject_to(x <= 2, name="cap")
+    m.subject_to(z >= -0.5, name="unrelated")
+    m.minimize(x)
+
+    iis = m.compute_iis()
+    assert _names(iis) == {"cap"}
+    assert [(v.name, side) for v, side in iis.variable_bounds] == [("x", "lower")]
+
+
+def test_include_bounds_false_skips_bound_members():
+    m = dm.Model("b")
+    x = m.continuous("x", lb=5, ub=10)
+    m.subject_to(x <= 2, name="cap")
+    m.minimize(x)
+
+    # Without bounds, the single constraint cannot explain the infeasibility, so
+    # the (constraint-only) reduction keeps the constraint but is not minimal.
+    iis = compute_iis(m, include_bounds=False)
+    assert iis.variable_bounds == []
+    assert _names(iis) == {"cap"}
+
+
+# ───────────────────────── integer-driven conflict ─────────────────────────
+
+
+def test_integer_domain_conflict():
+    # 3 < y < 4 with y integer is infeasible; the two constraints form the IIS.
+    m = dm.Model("i")
+    y = m.integer("y", lb=0, ub=10)
+    m.subject_to(y >= 3.2, name="lo")
+    m.subject_to(y <= 3.8, name="hi")
+    m.minimize(y)
+    assert m.solve(time_limit=30).status == "infeasible"
+
+    iis = m.compute_iis(include_bounds=False)
+    assert _names(iis) == {"lo", "hi"}
+
+
+# ───────────────────────── API contract ─────────────────────────
+
+
+def test_raises_on_feasible_model():
+    m = dm.Model("f")
+    a = m.continuous("a", lb=0, ub=5)
+    m.subject_to(a <= 3)
+    m.minimize(a)
+    with pytest.raises(ValueError, match="feasible"):
+        m.compute_iis()
+
+
+def test_result_len_and_bool_and_summary():
+    m = dm.Model("c")
+    x = m.continuous("x", lb=-10, ub=10)
+    m.subject_to(x >= 5, name="a")
+    m.subject_to(x <= 2, name="b")
+    m.minimize(x)
+    iis = m.compute_iis(include_bounds=False)
+    assert len(iis) == 2
+    assert bool(iis) is True
+    text = iis.summary()
+    assert "Irreducible Infeasible Subsystem" in text
+    assert "a" in text and "b" in text


### PR DESCRIPTION
Adds Phase-7 infeasibility analysis: when solve() returns "infeasible",
Model.compute_iis() explains *why* by returning a minimal set of constraints
(and finite variable bounds) that is infeasible on its own but feasible if any
single member is removed — the analogue of Gurobi computeIIS / CPLEX conflict
refiner.

- python/discopt/infeasibility.py: deletion-filtering IIS (Chinneck & Dravnieks
  1991) over constraints + variable bounds, on top of discopt's own solver.
  IISResult carries the members, the solve count, and a proven_irreducible flag.
- API: Model.compute_iis(include_bounds=True, time_limit=30) plus top-level
  discopt.compute_iis / discopt.IISResult.

Soundness with an incomplete solver: a member is dropped only when the reduced
model is *proven* infeasible; an inconclusive probe (e.g. a nonconvex MINLP that
times out) keeps the member and sets proven_irreducible=False, so the result is
always a valid infeasible subsystem and is truly minimal exactly when every
probe was conclusive (LP/MILP/convex).

Tests (test_iis.py, 7): constraint conflict isolated from red herrings;
property test that the IIS is infeasible and every single removal feasibilizes;
bound-vs-constraint conflict; integer-domain (3.2 <= y <= 3.8) conflict;
include_bounds toggle; raises on feasible models; result API.

Docs: docs/notebooks/infeasibility_iis.ipynb (executes clean) with citations;
add Chinneck1991 / Chinneck2008 to references.bib; register in _toc.yml.
``import discopt`` stays JAX-free; ruff + mypy clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr