### PR TITLE
fix(solver): bound convexity classification so it can't blow time_limit

### DIFF
--- a/python/discopt/_jax/convexity/rules.py
+++ b/python/discopt/_jax/convexity/rules.py
@@ -786,7 +786,19 @@ def _constraint_convex_from_curvature(curv: Curvature, sense: str) -> bool:
     return False
 
 
-def classify_model(model: Model, *, use_certificate: bool = False) -> tuple[bool, list[bool]]:
+class ConvexityBudgetExceeded(Exception):
+    """Raised when convexity classification exceeds its wall-clock ``deadline``.
+
+    The classifier is per-constraint eigenvalue-heavy and on large quadratic
+    models can take tens of seconds; under a tight solver ``time_limit`` that
+    would blow the budget before search even starts. Callers catch this and treat
+    the model as convexity-unknown (sound: it routes to the spatial B&B).
+    """
+
+
+def classify_model(
+    model: Model, *, use_certificate: bool = False, deadline: float | None = None
+) -> tuple[bool, list[bool]]:
     """Classify a model's convexity.
 
     Returns ``(is_convex, per_constraint_mask)``. ``max f`` is treated
@@ -800,7 +812,14 @@ def classify_model(model: Model, *, use_certificate: bool = False) -> tuple[bool
     unproven. The certificate only tightens UNKNOWN verdicts; it never
     overrides an already-proven CONVEX/CONCAVE, preserving the
     soundness invariant.
+
+    ``deadline`` is an optional ``time.perf_counter()`` timestamp; if the
+    per-constraint walk crosses it, :class:`ConvexityBudgetExceeded` is raised so
+    the solver can fall back to the spatial path rather than overrun its
+    ``time_limit``.
     """
+    import time as _time
+
     cache: dict = {}
     ctx = build_linear_context(model)
     if ctx is not None:
@@ -831,6 +850,11 @@ def classify_model(model: Model, *, use_certificate: bool = False) -> tuple[bool
     constraint_mask: list[bool] = []
     all_convex = obj_convex
     for c in model._constraints:
+        if deadline is not None and _time.perf_counter() > deadline:
+            raise ConvexityBudgetExceeded(
+                f"convexity classification exceeded its time budget after "
+                f"{len(constraint_mask)}/{len(model._constraints)} constraints"
+            )
         if isinstance(c, Constraint):
             is_cvx = classify_constraint(c, model, cache, use_certificate=use_certificate)
             constraint_mask.append(is_cvx)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1600,7 +1600,7 @@ def _classify_model_convexity(
     """
     cached = getattr(model, "_convexity_classification_cache", None)
     if cached is not None:
-        return cached
+        return cast("tuple[bool, bool, list[bool] | None]", cached)
 
     from discopt._jax.convexity.rules import ConvexityBudgetExceeded
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1585,19 +1585,52 @@ def _classify_model_convexity(
     failure_label: str = "Convexity detection failed",
     log_nonconvex_continuous: bool = False,
 ) -> tuple[bool, bool, list[bool] | None]:
-    """Run the sound model convexity classifier once for solver dispatch."""
+    """Run the sound model convexity classifier once for solver dispatch.
+
+    The result is memoized on the model (``solve_model`` clears the cache at the
+    start of every solve), so the classifier — which is eigenvalue-heavy and can
+    cost tens of seconds on large quadratic models — runs at most once per solve
+    instead of at each of its several dispatch call sites.
+
+    Classification is also bounded by ``model._convexity_time_budget`` (a fraction
+    of ``time_limit``, set by ``solve_model``): if the per-constraint walk would
+    overrun that budget it is abandoned and the model is reported as
+    convexity-unknown, which routes to the sound spatial Branch and Bound. This
+    keeps a tight ``time_limit`` from being blown by classification alone.
+    """
+    cached = getattr(model, "_convexity_classification_cache", None)
+    if cached is not None:
+        return cached
+
+    from discopt._jax.convexity.rules import ConvexityBudgetExceeded
+
+    # Default cap (15 s) bounds classification even when called outside a budgeted
+    # solve_model (e.g. on a model produced by factorable reformulation).
+    budget = getattr(model, "_convexity_time_budget", 15.0)
+    deadline = (time.perf_counter() + budget) if budget else None
+    result: tuple[bool, bool, list[bool] | None]
     try:
         from discopt._jax.convexity import classify_model as _classify_convexity
 
         # use_certificate=True enables the sound interval-Hessian fallback
         # for constraints/objective the syntactic walker leaves unproven.
-        is_convex, constraint_mask = _classify_convexity(model, use_certificate=True)
+        is_convex, constraint_mask = _classify_convexity(
+            model, use_certificate=True, deadline=deadline
+        )
         if log_nonconvex_continuous and not is_convex:
             logger.info("Nonconvex continuous model detected — using spatial Branch and Bound")
-        return True, bool(is_convex), list(constraint_mask)
+        result = (True, bool(is_convex), list(constraint_mask))
+    except ConvexityBudgetExceeded as exc:
+        logger.info("Convexity classification skipped (time budget): %s", exc)
+        result = (False, False, None)
     except Exception as exc:
         logger.debug("%s: %s", failure_label, exc)
-        return False, False, None
+        result = (False, False, None)
+    try:
+        model._convexity_classification_cache = result
+    except Exception:
+        pass
+    return result
 
 
 # Size gate for the auto cut policy: above this many scalar variables the
@@ -1940,6 +1973,14 @@ def solve_model(
             f"{sorted(_valid_nlp_solvers)}. (The 'ripopt' backend was replaced "
             "by 'pounce', a pure-Rust port of Ipopt.)"
         )
+
+    # Reset the per-solve convexity-classification memo (a previous solve, or an
+    # IIS feasibility probe, may have cached a verdict for a different constraint
+    # set), and budget classification to a fraction of the time limit so it
+    # cannot, on its own, overrun ``time_limit`` (issue: tens of seconds of
+    # eigenvalue work on large quadratic models before search even starts).
+    model._convexity_classification_cache = None
+    model._convexity_time_budget = min(max(0.2 * float(time_limit), 0.5), 20.0)
 
     # --- AMP (Adaptive Multivariate Partitioning) global solver ---
     _solver = solver if solver is not None else kwargs.pop("solver", None)
@@ -4579,11 +4620,17 @@ def solve_model(
     # MILP path already seeds such a root bound; this brings the spatial path to
     # parity. Surfaced lazily — only when the search yielded nothing — and never
     # overrides an existing finite bound.
-    if (bound_val is None or not np.isfinite(bound_val)) and (
-        model._objective.sense == ObjectiveSense.MINIMIZE
+    _rr_remaining = time_limit - (time.perf_counter() - t_start)
+    if (
+        (bound_val is None or not np.isfinite(bound_val))
+        and (model._objective.sense == ObjectiveSense.MINIMIZE)
+        and _rr_remaining > 0.0
     ):
+        # Budget the fallback to the time actually left: it runs *after* the B&B
+        # loop already consumed the limit, so passing the full ``time_limit`` here
+        # would let it overrun by a second whole budget.
         _rr = _root_relaxation_lower_bound(
-            model, _root_lb_snapshot, _root_ub_snapshot, time_limit, psd_cuts=psd_cuts
+            model, _root_lb_snapshot, _root_ub_snapshot, _rr_remaining, psd_cuts=psd_cuts
         )
         if _rr is not None and np.isfinite(_rr):
             bound_val = _rr

--- a/python/tests/test_convexity_budget.py
+++ b/python/tests/test_convexity_budget.py
@@ -1,0 +1,93 @@
+"""Convexity-classification cost controls (time-limit overshoot fix).
+
+Convexity classification is eigenvalue-heavy and was called at several solver
+dispatch sites — each running the full ~O(constraints) walk — and never checked
+the time budget. On a large quadratic model this could spend tens of seconds
+before search even started, blowing a tight ``time_limit``. Two controls:
+
+* the result is memoized per solve (``classify_model`` runs at most once), and
+* the walk honors a ``deadline`` and aborts to convexity-unknown (sound: routes
+  to the spatial Branch and Bound) rather than overrunning the budget.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import discopt.solver as S
+import pytest
+from discopt._jax.convexity.rules import ConvexityBudgetExceeded, classify_model
+
+
+def _qp(n: int = 4) -> dm.Model:
+    m = dm.Model("qp")
+    x = m.continuous("x", shape=(n,), lb=0, ub=1)
+    m.minimize(dm.sum([x[i] * x[i] for i in range(n)]))
+    for i in range(n - 1):
+        m.subject_to(x[i] + x[i + 1] <= 1.5, name=f"c{i}")
+    return m
+
+
+def test_classify_model_honors_deadline():
+    """A deadline already in the past aborts the per-constraint walk."""
+    m = _qp(6)
+    with pytest.raises(ConvexityBudgetExceeded):
+        classify_model(m, use_certificate=True, deadline=time.perf_counter() - 1.0)
+
+
+def test_classify_model_no_deadline_completes():
+    m = _qp(4)
+    is_convex, mask = classify_model(m, use_certificate=True, deadline=None)
+    assert is_convex is True  # sum of squares with linear constraints is convex
+    assert len(mask) == 3
+
+
+def test_classification_is_memoized_per_solve():
+    """``_classify_model_convexity`` runs the underlying classifier at most once."""
+    m = _qp(4)
+    m._convexity_classification_cache = None
+    m._convexity_time_budget = 5.0
+
+    import discopt._jax.convexity as cvx
+
+    calls = {"n": 0}
+    orig = cvx.classify_model
+
+    def _counting(model, **kw):
+        calls["n"] += 1
+        return orig(model, **kw)
+
+    cvx.classify_model = _counting
+    try:
+        r1 = S._classify_model_convexity(m)
+        r2 = S._classify_model_convexity(m)
+        r3 = S._classify_model_convexity(m, log_nonconvex_continuous=True)
+    finally:
+        cvx.classify_model = orig
+
+    assert r1 == r2 == r3
+    assert calls["n"] == 1, f"classifier ran {calls['n']} times, expected 1 (memoized)"
+
+
+def test_budget_exceeded_reports_unknown_not_crash():
+    """When classification times out, the solver treats the model as unknown."""
+    m = _qp(4)
+    m._convexity_classification_cache = None
+    m._convexity_time_budget = 1e-9  # effectively zero -> immediate timeout
+    ok, is_convex, mask = S._classify_model_convexity(m)
+    assert ok is False and is_convex is False and mask is None
+
+
+@pytest.mark.parametrize("n", [3, 5])
+def test_tight_time_limit_still_solves_correctly(n):
+    """A tight limit caps classification but never changes the answer."""
+    m = _qp(n)
+    res = m.solve(time_limit=20)
+    assert res.status == "optimal"
+    # min sum x_i^2 over x>=0 with x_i+x_{i+1}<=1.5 -> all x=0, obj 0.
+    assert abs(float(res.objective)) < 1e-4


### PR DESCRIPTION
Profiling a benchmark instance (casctanks) that overshot its time_limit ~37x
(296s wall on an 8s limit) showed the dominant cost was convexity
classification: ~20s of eigenvalue-heavy per-constraint work, run at *each* of
the solver's several dispatch sites (the function's own docstring claimed it ran
"once") and never checked the time budget — so on a large quadratic model it
spent tens of seconds before search even started.

Two controls:
- Memoize _classify_model_convexity on the model (solve_model clears the cache
  at the start of each solve, and before each IIS feasibility probe), so the
  classifier runs at most once per solve instead of up to four times.
- classify_model gains a `deadline`; the per-constraint walk aborts with
  ConvexityBudgetExceeded if it would overrun. solve_model budgets classification
  to min(max(0.2*time_limit, 0.5), 20)s; on timeout the model is reported
  convexity-unknown, which routes to the sound spatial Branch and Bound — never
  changing the answer, only the path.

Also fix a post-loop overshoot: the root-relaxation lower-bound fallback was
passed the full original time_limit even though it runs *after* the B&B loop
already consumed the budget; it now gets only the remaining time and is skipped
when none is left.

Result on casctanks (8s limit): 296s -> 94s (37x -> 11.8x); clay0303hfsg
unchanged-correct. The remaining overshoot is one-time root setup (Rust
presolve, relaxation build, node NLP) — necessary work, a separate perf
follow-on. 142 convexity tests + new test_convexity_budget.py (6) + 183 smoke
pass; ruff/mypy clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FtXNkZY5moEkDRkZPLCZtr