### PR TITLE
perf(lp): warm-start node LP re-solves in the cutting-plane loop (#229)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "feral"
 version = "0.11.0"
-source = "git+https://github.com/jkitchin/feral?rev=5ab8074b3c87c96d223e56e8012c38b1cf591e0e#5ab8074b3c87c96d223e56e8012c38b1cf591e0e"
+source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -95,7 +95,7 @@ dependencies = [
 [[package]]
 name = "feral-amd"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=5ab8074b3c87c96d223e56e8012c38b1cf591e0e#5ab8074b3c87c96d223e56e8012c38b1cf591e0e"
+source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -103,7 +103,7 @@ dependencies = [
 [[package]]
 name = "feral-amf"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=5ab8074b3c87c96d223e56e8012c38b1cf591e0e#5ab8074b3c87c96d223e56e8012c38b1cf591e0e"
+source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "feral-kahip"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=5ab8074b3c87c96d223e56e8012c38b1cf591e0e#5ab8074b3c87c96d223e56e8012c38b1cf591e0e"
+source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "feral-metis"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=5ab8074b3c87c96d223e56e8012c38b1cf591e0e#5ab8074b3c87c96d223e56e8012c38b1cf591e0e"
+source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -130,12 +130,12 @@ dependencies = [
 [[package]]
 name = "feral-ordering-core"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=5ab8074b3c87c96d223e56e8012c38b1cf591e0e#5ab8074b3c87c96d223e56e8012c38b1cf591e0e"
+source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
 
 [[package]]
 name = "feral-scotch"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=5ab8074b3c87c96d223e56e8012c38b1cf591e0e#5ab8074b3c87c96d223e56e8012c38b1cf591e0e"
+source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -10,7 +10,7 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # feral: pure-Rust sparse linear algebra. Provides the unsymmetric LU basis
 # engine (ftran/btran + product-form column updates) that backs the warm-started
 # simplex node engine for MILP. Pure-Rust, so clean-wheel builds are preserved.
-feral = { git = "https://github.com/jkitchin/feral", rev = "5ab8074b3c87c96d223e56e8012c38b1cf591e0e" }
+feral = { git = "https://github.com/jkitchin/feral", rev = "ee0ef3308a30782a1ece5406934c6bbedc290123" }
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to
 # 1.10 to keep the crate's MSRV (1.75); 1.12+ requires rustc 1.80.

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -1019,7 +1019,13 @@ fn try_rounding(
         (0..ns)
             .map(|j| {
                 let v = if is_int[j] { round(x[j]) } else { x[j] };
-                v.clamp(glb[j], gub[j])
+                // Guard against rounding-induced bound inversion (glb[j] a few ULP
+                // above gub[j] on a near-fixed variable): f64::clamp panics when
+                // min > max. Clamp into the well-ordered interval — identical to
+                // the direct clamp when bounds are ordered, and collapses to the
+                // degenerate (ULP-wide) box when they cross.
+                let (lo, hi) = if glb[j] <= gub[j] { (glb[j], gub[j]) } else { (gub[j], glb[j]) };
+                v.clamp(lo, hi)
             })
             .collect()
     };

--- a/crates/discopt-core/src/lp/crossover.rs
+++ b/crates/discopt-core/src/lp/crossover.rs
@@ -232,7 +232,13 @@ pub fn crossover_to_vertex(x: &[f64], lp: &LpView<'_>, tol: f64, max_iter: usize
 
         for j in 0..n {
             let xj = x[j] + t * d[j];
-            x[j] = xj.clamp(l[j], u[j]);
+            // Guard against rounding-induced bound inversion (l[j] a few ULP above
+            // u[j] on a near-fixed variable): f64::clamp panics when min > max.
+            // Clamp into the well-ordered interval instead — identical to the
+            // direct clamp when bounds are ordered, and collapses to the degenerate
+            // (ULP-wide) box when they cross, which is the correct projection.
+            let (lo, hi) = if l[j] <= u[j] { (l[j], u[j]) } else { (u[j], l[j]) };
+            x[j] = xj.clamp(lo, hi);
         }
     }
     x

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -572,10 +572,51 @@ impl<'a> Simplex<'a> {
             status
         };
 
-        // basis over the real columns (artificials excluded; if a real-var basis
-        // is wanted the caller post-processes — here basic_vars lists real basics)
-        let basic_vars: Vec<usize> = self.basis.iter().copied().filter(|&j| j < self.n).collect();
-        let col_status: Vec<i8> = (0..self.n).map(|j| self.stat[j]).collect();
+        // Export a *complete*, row-ordered basis of real columns (length m).
+        //
+        // Phase 2 can leave an artificial (column ≥ self.n) basic at value 0 on a
+        // degenerate/redundant row — common on the heavily-redundant lifted
+        // McCormick relaxations. Naively dropping those slots (the old behaviour)
+        // returned fewer than m basic vars, which the warm-start consumer and the
+        // dual simplex both reject (they require exactly m), so every
+        // cutting-plane re-solve silently cold-started. Substitute that row's own
+        // zero-valued structural singleton — its slack column in the [A_ub|I]
+        // standard form the warm path uses. Swapping the basic artificial (±eᵢ at
+        // 0) for a nonbasic singleton that sits in the same row at value 0 leaves
+        // B's support and x_B bit-identical (the entering column was contributing
+        // 0 to the RHS and its new basic value is 0), so this is a pure
+        // representation fix — the optimum and bound are unchanged.
+        let mut slack_for_row: Vec<i64> = vec![-1; self.m];
+        for j in 0..self.n {
+            if self.stat[j] == BASIC || self.nb_value(j) != 0.0 {
+                continue;
+            }
+            let (rows, _) = self.cols.col(j);
+            if rows.len() == 1 && slack_for_row[rows[0]] < 0 {
+                slack_for_row[rows[0]] = j as i64;
+            }
+        }
+        let mut col_status: Vec<i8> = (0..self.n).map(|j| self.stat[j]).collect();
+        let mut basic_vars: Vec<usize> = Vec::with_capacity(self.m);
+        for i in 0..self.m {
+            let bcol = self.basis[i];
+            if bcol < self.n {
+                basic_vars.push(bcol);
+                continue;
+            }
+            // Basic artificial in this slot: it covers constraint row
+            // `r = bcol - self.n` (column n+r is ±eᵣ), which need not equal the
+            // slot index `i` once pivots have permuted the basis. Substitute that
+            // row's zero-valued singleton (its slack).
+            let r = bcol - self.n;
+            if slack_for_row[r] >= 0 {
+                let s = slack_for_row[r] as usize;
+                col_status[s] = BASIC;
+                basic_vars.push(s);
+            }
+            // else: no real substitute available (non-[A_ub|I] caller); the basis
+            // stays short and the warm path declines it, exactly as before.
+        }
         LpSolve {
             status,
             x,

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -36,6 +36,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::gomory_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::mir_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_py, m)?)?;
+    m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_batch_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_py, m)?)?;
     Ok(())

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -12,12 +12,13 @@
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 
 use discopt_core::bnb::milp_driver::{solve_milp as core_solve_milp, MilpOptions, MilpStatus};
-use discopt_core::lp::basis::recover_basis;
+use discopt_core::lp::basis::{recover_basis, Basis, BASIC};
 use discopt_core::lp::crossover::{crossover_to_vertex, LpView};
 use discopt_core::lp::gomory::separate_gomory;
 use discopt_core::lp::mir::separate_mir;
 use discopt_core::lp::simplex::{
-    solve_lp as simplex_solve_lp, solve_lp_batch, LpInstance, LpStatus, SimplexOptions,
+    solve_lp as simplex_solve_lp, solve_lp_batch, solve_lp_warm, LpInstance, LpStatus,
+    SimplexOptions,
 };
 use numpy::{
     PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods,
@@ -253,6 +254,135 @@ pub fn solve_lp_py<'py>(
         PyArray1::from_vec(py, sol.x),
         sol.obj,
         sol.iters,
+    ))
+}
+
+/// Build a dual-simplex warm-start basis from a previous solve's
+/// `(col_status, basic_vars)`, extending it for rows/columns appended since.
+///
+/// The cutting-plane loop re-solves the SAME structural columns with only rows
+/// (cuts) appended, and the standard form is `[A_ub | I]` — one slack column per
+/// row — so each appended row adds exactly one trailing slack column. A starting
+/// basis with `n_old` columns / `m_old` rows is therefore valid for the current
+/// `n`/`m` iff `n - n_old == m - m_old >= 0`: the new columns are the appended
+/// slacks, which we make basic (the previous vertex stays a basis of the larger
+/// system, dual-feasible, so the dual simplex re-optimizes). Any inconsistency
+/// returns `None`, and the caller cold-starts — so this only affects speed.
+fn build_extended_basis(cs: &[i8], bv: &[i64], n: usize, m: usize) -> Option<Basis> {
+    let n_old = cs.len();
+    let m_old = bv.len();
+    if n_old > n || m_old > m {
+        return None;
+    }
+    let dn = n - n_old;
+    let dm = m - m_old;
+    if dn != dm {
+        return None; // not a clean one-slack-per-appended-row growth
+    }
+    let mut col_status: Vec<i8> = Vec::with_capacity(n);
+    col_status.extend_from_slice(cs);
+    col_status.resize(n, BASIC); // appended slacks (cols n_old..n) enter the basis
+    let mut basic_vars: Vec<usize> = Vec::with_capacity(m);
+    for &v in bv {
+        if v < 0 || (v as usize) >= n_old {
+            return None;
+        }
+        basic_vars.push(v as usize);
+    }
+    for j in n_old..n {
+        basic_vars.push(j);
+    }
+    // Enforce col_status/basic_vars consistency in case the incoming pair was
+    // slightly stale; `PreparedDual::prepare` validates further and the warm
+    // solver cold-falls-back on any residual inconsistency.
+    for &v in &basic_vars {
+        col_status[v] = BASIC;
+    }
+    Some(Basis {
+        col_status,
+        basic_vars,
+    })
+}
+
+/// Warm-startable standard-form LP solve: same problem as [`solve_lp_py`]
+/// (`min cᵀx s.t. A x = b, lb ≤ x ≤ ub`), but it accepts an optional starting
+/// basis (`start_col_status` length `n'`, `start_basic_vars` length `m'`) and
+/// returns the final basis alongside the solution. When the starting basis has
+/// fewer rows/columns than the current LP (rows appended since — the
+/// cutting-plane case), it is extended by making the appended slack columns
+/// basic so the dual simplex re-optimizes from the previous vertex.
+///
+/// Soundness: a missing/mismatched/singular basis is silently ignored
+/// (`solve_lp_warm` cold-falls-back internally), and the dual simplex converges
+/// to the LP optimum just like a cold solve — so the returned objective (hence
+/// any relaxation bound built on it) is unchanged; the basis only changes speed.
+/// Returns `(status, x, obj, iters, col_status, basic_vars)`.
+#[pyfunction]
+#[pyo3(signature = (c, a, b, lb, ub, start_col_status=None, start_basic_vars=None,
+                    tol=1e-9, max_iter=100_000))]
+#[allow(clippy::too_many_arguments)]
+pub fn solve_lp_warm_py<'py>(
+    py: Python<'py>,
+    c: PyReadonlyArray1<'py, f64>,
+    a: PyReadonlyArray2<'py, f64>,
+    b: PyReadonlyArray1<'py, f64>,
+    lb: PyReadonlyArray1<'py, f64>,
+    ub: PyReadonlyArray1<'py, f64>,
+    start_col_status: Option<PyReadonlyArray1<'py, i8>>,
+    start_basic_vars: Option<PyReadonlyArray1<'py, i64>>,
+    tol: f64,
+    max_iter: usize,
+) -> PyResult<(
+    String,
+    Bound<'py, PyArray1<f64>>,
+    f64,
+    usize,
+    Bound<'py, PyArray1<i8>>,
+    Bound<'py, PyArray1<i64>>,
+)> {
+    let dims = a.shape();
+    let (m, n) = (dims[0], dims[1]);
+    let a_flat = a
+        .as_slice()
+        .map_err(|_| PyValueError::new_err("`a` must be C-contiguous"))?;
+    let lp = LpView {
+        a: a_flat,
+        m,
+        n,
+        c: c.as_slice()?,
+        l: lb.as_slice()?,
+        u: ub.as_slice()?,
+    };
+    let opts = SimplexOptions {
+        tol,
+        max_iter,
+        deadline: None,
+    };
+    let b_slice = b.as_slice()?;
+
+    let start = match (start_col_status, start_basic_vars) {
+        (Some(cs), Some(bv)) => build_extended_basis(cs.as_slice()?, bv.as_slice()?, n, m),
+        _ => None,
+    };
+    let sol = match start {
+        Some(basis) => solve_lp_warm(&lp, b_slice, &basis, &opts),
+        None => simplex_solve_lp(&lp, b_slice, &opts),
+    };
+    let status = match sol.status {
+        LpStatus::Optimal => "optimal",
+        LpStatus::Infeasible => "infeasible",
+        LpStatus::Unbounded => "unbounded",
+        LpStatus::IterLimit => "iter_limit",
+        LpStatus::Numerical => "numerical",
+    };
+    let basic_vars_i64: Vec<i64> = sol.basis.basic_vars.iter().map(|&v| v as i64).collect();
+    Ok((
+        status.to_string(),
+        PyArray1::from_vec(py, sol.x),
+        sol.obj,
+        sol.iters,
+        PyArray1::from_vec(py, sol.basis.col_status),
+        PyArray1::from_vec(py, basic_vars_i64),
     ))
 }
 

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -277,6 +277,13 @@ class MilpRelaxationModel:
         self._obj_offset = obj_offset
         self._integrality = integrality
         self._objective_bound_valid = objective_bound_valid
+        # Warm-start state for the pure-LP simplex fast path (cutting-plane loop):
+        # the previous solve's optimal basis and the (structural-cols, rows) it was
+        # produced at, so the next ``.solve()`` on the SAME columns with rows only
+        # appended can dual-simplex re-optimize from it. See ``_solve_lp_warm``.
+        self._warm_basis: Optional[tuple[np.ndarray, np.ndarray]] = None
+        self._warm_struct_n: Optional[int] = None
+        self._warm_rows: Optional[int] = None
 
     def solve(
         self,
@@ -286,6 +293,23 @@ class MilpRelaxationModel:
     ) -> MilpRelaxationResult:
         from discopt.solvers import SolveStatus
         from discopt.solvers.lp_backend import get_milp_solver
+
+        # Warm-startable pure-LP fast path: the spatial cut-separation loop
+        # re-solves the SAME structural columns with only rows (cuts) appended, so
+        # the previous optimal basis is an ideal dual-simplex warm start. Engage
+        # only for the Rust simplex backend on a pure LP (no integrality). A
+        # bad/mismatched basis is ignored inside Rust (cold fallback) and the dual
+        # simplex converges to the same LP optimum, so the bound is unchanged --
+        # warm-start only changes speed. Disable with ``DISCOPT_LP_WARMSTART=0``.
+        if (
+            backend == "simplex"
+            and self._integrality is None
+            and self._A_ub is not None
+            and os.environ.get("DISCOPT_LP_WARMSTART", "1") != "0"
+        ):
+            warm = self._solve_lp_warm()
+            if warm is not None:
+                return warm
 
         # backend="auto": HiGHS if present, else POUNCE. backend="simplex" routes
         # to the warm-started-simplex B&B (falls back to auto if unavailable).
@@ -347,6 +371,70 @@ class MilpRelaxationModel:
         if result.bound is not None and self._objective_bound_valid:
             bound = float(result.bound) + self._obj_offset
 
+        return MilpRelaxationResult(status=status_str, objective=obj, bound=bound, x=result.x)
+
+    def _solve_lp_warm(self) -> Optional["MilpRelaxationResult"]:
+        """Pure-LP warm-started re-solve via the Rust dual simplex.
+
+        Reuses the cached optimal basis from the previous ``.solve()`` when the
+        structural column set is unchanged and rows have only grown (the
+        cutting-plane case), extending it for the appended slacks. Returns the
+        mapped :class:`MilpRelaxationResult`, or ``None`` to defer to the generic
+        path (binding unavailable, or an ``iter_limit``/``numerical`` exit). The
+        returned objective/bound is the true LP optimum — warm-start is a pure
+        speed optimization, never a correctness one.
+        """
+        from discopt.solvers import SolveStatus
+
+        try:
+            from discopt.solvers.milp_simplex import solve_lp_warm_std
+        except Exception:  # pragma: no cover - binding absent
+            return None
+
+        n_struct = np.asarray(self._c, dtype=np.float64).ravel().shape[0]
+        m_now = 0 if self._A_ub is None else sp.csr_matrix(self._A_ub).shape[0]
+        in_basis = None
+        if (
+            self._warm_basis is not None
+            and self._warm_struct_n == n_struct
+            and self._warm_rows is not None
+            and self._warm_rows <= m_now
+        ):
+            in_basis = self._warm_basis
+
+        try:
+            result, out_basis = solve_lp_warm_std(
+                self._c, self._A_ub, self._b_ub, self._bounds, in_basis=in_basis
+            )
+        except Exception:  # pragma: no cover - defensive; fall back to generic path
+            return None
+        if result is None:
+            # iter_limit / numerical: let the generic path (with its HiGHS option)
+            # handle it; drop the stale basis so the next round cold-starts.
+            self._warm_basis = None
+            return None
+        if out_basis is not None:
+            self._warm_basis = out_basis
+            self._warm_struct_n = n_struct
+            self._warm_rows = m_now
+        else:
+            self._warm_basis = None
+
+        status_map = {
+            SolveStatus.OPTIMAL: "optimal",
+            SolveStatus.INFEASIBLE: "infeasible",
+            SolveStatus.UNBOUNDED: "unbounded",
+            SolveStatus.TIME_LIMIT: "time_limit",
+            SolveStatus.ITERATION_LIMIT: "iteration_limit",
+            SolveStatus.ERROR: "error",
+        }
+        status_str = status_map.get(result.status, str(result.status))
+        obj = None
+        if result.objective is not None and self._objective_bound_valid:
+            obj = float(result.objective) + self._obj_offset
+        bound = None
+        if result.bound is not None and self._objective_bound_valid:
+            bound = float(result.bound) + self._obj_offset
         return MilpRelaxationResult(status=status_str, objective=obj, bound=bound, x=result.x)
 
 

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -150,3 +150,91 @@ def solve_milp(
         bound=float(bound) if np.isfinite(bound) else None,
         node_count=int(nodes),
     )
+
+
+def solve_lp_warm_std(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]],
+    b_ub: Optional[np.ndarray],
+    bounds: Optional[list[tuple[float, float]]],
+    in_basis: Optional[tuple[np.ndarray, np.ndarray]] = None,
+) -> tuple[Optional[MILPResult], Optional[tuple[np.ndarray, np.ndarray]]]:
+    """Warm-startable **pure-LP** solve of ``min c^T x s.t. A_ub x <= b_ub, bounds``.
+
+    Marshals the ``A_ub x <= b_ub`` form into standard form ``[A_ub | I] z = b_ub``
+    (one explicit slack per row, structural columns first) and calls the Rust
+    ``solve_lp_warm_py``. ``in_basis`` is a ``(col_status, basic_vars)`` pair from a
+    previous solve of a *prefix* of the same column set (rows since appended); Rust
+    extends it by making the appended slacks basic and dual-simplex re-optimizes.
+
+    Returns ``(result, out_basis)``. ``out_basis`` is the final ``(col_status,
+    basic_vars)`` to thread into the next re-solve (``None`` when the LP is not
+    optimal). ``result`` is ``None`` for ``iter_limit``/``numerical`` exits so the
+    caller can fall back to a cold/HiGHS path. Soundness: the dual simplex
+    converges to the LP optimum exactly as a cold solve (a bad basis is ignored
+    inside Rust), so the returned objective/bound is unchanged — only the speed is.
+    """
+    from discopt._rust import solve_lp_warm_py
+
+    c_arr = np.asarray(c, dtype=np.float64).ravel()
+    n = c_arr.shape[0]
+
+    if A_ub is not None and b_ub is not None and np.size(b_ub) > 0:
+        a = (
+            cast("sp.spmatrix", A_ub).toarray()
+            if sp.issparse(A_ub)
+            else np.asarray(A_ub, dtype=np.float64)
+        )
+        a_ub = a.reshape(-1, n)
+        b_vec = np.asarray(b_ub, dtype=np.float64).ravel()
+    else:
+        a_ub = np.zeros((0, n), dtype=np.float64)
+        b_vec = np.zeros(0, dtype=np.float64)
+    m = a_ub.shape[0]
+
+    a_std = np.zeros((m, n + m), dtype=np.float64)
+    if m > 0:
+        a_std[:, :n] = a_ub
+        a_std[:, n:] = np.eye(m)
+
+    if bounds is not None:
+        lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
+        ub = np.array([hi for _, hi in bounds], dtype=np.float64)
+    else:
+        lb = np.zeros(n, dtype=np.float64)
+        ub = np.full(n, 1e20, dtype=np.float64)
+    lb_std = np.concatenate([lb, np.zeros(m)])
+    ub_std = np.concatenate([ub, np.full(m, 1e20)])
+    c_std = np.concatenate([c_arr, np.zeros(m)])
+
+    cs0 = None if in_basis is None else np.ascontiguousarray(in_basis[0], dtype=np.int8)
+    bv0 = None if in_basis is None else np.ascontiguousarray(in_basis[1], dtype=np.int64)
+
+    status, x_full, obj, _iters, cs, bv = solve_lp_warm_py(
+        np.ascontiguousarray(c_std),
+        np.ascontiguousarray(a_std),
+        np.ascontiguousarray(b_vec),
+        np.ascontiguousarray(lb_std),
+        np.ascontiguousarray(ub_std),
+        cs0,
+        bv0,
+    )
+
+    x_struct = np.asarray(x_full, dtype=np.float64)[:n]
+    if status == "optimal":
+        return (
+            MILPResult(
+                status=SolveStatus.OPTIMAL,
+                x=x_struct,
+                objective=float(obj),
+                bound=float(obj),
+                node_count=0,
+            ),
+            (np.asarray(cs), np.asarray(bv)),
+        )
+    if status == "infeasible":
+        return MILPResult(status=SolveStatus.INFEASIBLE, node_count=0), None
+    if status == "unbounded":
+        return MILPResult(status=SolveStatus.UNBOUNDED, node_count=0), None
+    # iter_limit / numerical: signal the caller to fall back to the generic path.
+    return None, None

--- a/python/tests/test_simplex_lp.py
+++ b/python/tests/test_simplex_lp.py
@@ -86,3 +86,89 @@ class TestSimplexVsHighs:
         ub = np.array([1e20, 1e20])
         status, _x, _obj, _ = rust.solve_lp_py(c, a, b, lb, ub)
         assert status == "unbounded"
+
+
+@pytest.mark.skipif(
+    not hasattr(rust, "solve_lp_warm_py"),
+    reason="warm-start LP binding not built",
+)
+class TestWarmStartLp:
+    """``solve_lp_warm_py`` is the cutting-plane re-solve engine: it must (a) match
+    the cold solver when given no basis, (b) return the SAME optimum when warm-
+    started from a previous basis after rows (cuts) are appended, and (c) ignore a
+    garbage basis (cold fallback) rather than return a wrong value. Warm-start is a
+    speed optimization only — the optimum, hence any relaxation bound, is invariant.
+    """
+
+    def _std(self, A_ub, b_ub, c, lb, ub):
+        """[A_ub | I] z = b_ub standard form with one slack per row."""
+        A_ub = np.asarray(A_ub, float)
+        m, n = A_ub.shape
+        a_std = np.zeros((m, n + m))
+        a_std[:, :n] = A_ub
+        a_std[:, n:] = np.eye(m)
+        c_std = np.concatenate([np.asarray(c, float), np.zeros(m)])
+        lb_std = np.concatenate([np.asarray(lb, float), np.zeros(m)])
+        ub_std = np.concatenate([np.asarray(ub, float), np.full(m, 1e20)])
+        return (
+            np.ascontiguousarray(c_std),
+            np.ascontiguousarray(a_std),
+            np.ascontiguousarray(np.asarray(b_ub, float)),
+            np.ascontiguousarray(lb_std),
+            np.ascontiguousarray(ub_std),
+        )
+
+    @pytest.mark.parametrize("seed", list(range(20)))
+    def test_cold_matches_solve_lp_py(self, seed):
+        # n > m (as the cutting-plane form ``[A_ub | I]`` always is), so a full
+        # basis of m columns exists.
+        m = 2 + seed % 4
+        n = m + 2 + seed % 3
+        c, A, b, lb, ub = _rand_standard_form(seed, m, n)
+        s0, x0, o0, _ = rust.solve_lp_py(
+            np.ascontiguousarray(c),
+            np.ascontiguousarray(A),
+            np.ascontiguousarray(b),
+            np.ascontiguousarray(lb),
+            np.ascontiguousarray(ub),
+        )
+        s1, x1, o1, _i, cs, bv = rust.solve_lp_warm_py(
+            np.ascontiguousarray(c),
+            np.ascontiguousarray(A),
+            np.ascontiguousarray(b),
+            np.ascontiguousarray(lb),
+            np.ascontiguousarray(ub),
+        )
+        assert s1 == s0
+        if s0 == "optimal":
+            assert abs(o1 - o0) < 1e-9
+            assert len(cs) == A.shape[1] and len(bv) == A.shape[0]
+
+    def test_rowappend_warmstart_matches_cold(self):
+        # min -x0 - x1 s.t. x0 + x1 <= 1, x in [0,1]; then append cut x0 <= 0.5.
+        c, a, b, lb, ub = self._std([[1.0, 1.0]], [1.0], [-1.0, -1.0], [0, 0], [1, 1])
+        st, _x, obj, _i, cs, bv = rust.solve_lp_warm_py(c, a, b, lb, ub)
+        assert st == "optimal" and abs(obj - (-1.0)) < 1e-9
+
+        c2, a2, b2, lb2, ub2 = self._std(
+            [[1.0, 1.0], [1.0, 0.0]], [1.0, 0.5], [-1.0, -1.0], [0, 0], [1, 1]
+        )
+        # warm-start from the 1-row basis (Rust extends it with the new slack basic)
+        sw, xw, ow, _iw, _csw, _bvw = rust.solve_lp_warm_py(
+            c2, a2, b2, lb2, ub2, cs.astype(np.int8), bv.astype(np.int64)
+        )
+        sc, _xc, oc, _ic, _csc, _bvc = rust.solve_lp_warm_py(c2, a2, b2, lb2, ub2)
+        assert sw == "optimal" == sc
+        assert abs(ow - oc) < 1e-9
+        assert abs(ow - (-1.0)) < 1e-9  # x0 = x1 = 0.5
+        assert abs(np.asarray(xw)[0] - 0.5) < 1e-9
+
+    def test_garbage_basis_is_ignored(self):
+        # A dimensionally-inconsistent basis must be ignored (cold fallback), not
+        # trusted into a wrong optimum.
+        c, a, b, lb, ub = self._std([[1.0, 1.0]], [1.0], [-1.0, -1.0], [0, 0], [1, 1])
+        bad_cs = np.array([9, 9, 9, 9, 9], dtype=np.int8)  # wrong length & values
+        bad_bv = np.array([7, 7, 7], dtype=np.int64)  # out-of-range indices
+        st, _x, obj, _i, _cs, _bv = rust.solve_lp_warm_py(c, a, b, lb, ub, bad_cs, bad_bv)
+        assert st == "optimal"
+        assert abs(obj - (-1.0)) < 1e-9


### PR DESCRIPTION
## Summary

Closes the residual node-LP gap from #229 by **warm-starting the per-node cutting-plane LP re-solves** through the Rust dual simplex.

The spatial cut-separation loop re-solves the node relaxation LP once per tangent round (~5×/node on casctanks), each round only **appending** ~57 cut rows. The previous optimal basis is an ideal dual-simplex warm start — but every re-solve was silently **cold-starting**.

### Root cause

The primal simplex's basis export was incomplete. Phase 2 can leave an artificial basic at value 0 on a degenerate/redundant row — pervasive on the heavily-redundant lifted McCormick relaxations (~145 such rows on casctanks). The old export dropped those slots and returned **fewer than `m`** basic vars; the warm-start consumer and the dual simplex both require exactly `m` and reject a short basis, so the loop fell back to a full cold solve every round.

### Fix

`primal.rs` now exports a **complete, row-ordered length-`m` basis**: each basic artificial covering constraint row `r` is substituted by that row's own zero-valued structural singleton (its slack column in the `[A_ub | I]` form the warm path uses). Swapping the basic artificial (±eᵣ at 0) for a nonbasic singleton sitting in the same row at value 0 leaves `B`'s support and `x_B` **bit-identical** — a pure representation fix; the optimum and bound are unchanged.

On top of that, the warm path is wired end to end:
- **`lp_bindings.rs`** — `build_extended_basis` + `solve_lp_warm_py` dispatch the dual simplex from an exported basis, falling back to cold on any ill-formed/singular basis.
- **`milp_simplex.py`** — `solve_lp_warm_std` assembles the `[A_ub | I]` standard form and threads the optional incoming basis.
- **`milp_relaxation.py`** — `_solve_lp_warm` engages only for the Rust `simplex` backend on a pure LP, gated on matching structural width and non-shrinking row count; carries the basis across re-solves. Disable with `DISCOPT_LP_WARMSTART=0`.

### Correctness

Warm-start changes only **speed**, never the math: each individual LP solve returns the same optimum cold or warm. New tests cover randomized cold-vs-warm parity, row-append warm re-solve, and graceful rejection of a garbage basis.

### Result (casctanks `solve_at_node`)

| | cold | warm | speedup |
|---|---|---|---|
| time | 5.76 s | 1.11 s | **5.2×** |
| bound | −99.46302 | −99.46306 | Δ 4e-5 (alternative-optimal-vertex noise on degenerate LPs) |

### Tests

27 Rust simplex + 65 Python `test_simplex_lp`, plus `lp_backend_seam`, `lp_backend_select`, `mccormick_lp_densify_guard`, `correctness`, and `relaxation_compiler` suites — **161 green**.

### Scope note

This PR is the warm-start **mechanism** only. A separate cutting-plane stall early-exit heuristic (which trades bound tightness for fewer rounds) was deliberately left out to keep this change's "pure speed, exact math" guarantee clean; it can be evaluated on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
