### PR TITLE
fix(amp): expand self-product squared differences in the relaxation

### DIFF
--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -167,7 +167,28 @@ def _get_flat_index(expr: Expression, model: Model) -> int | None:
 
 
 def _contains_expandable_square(model: Model) -> bool:
-    """Return True if Python classification should expand a non-leaf square."""
+    """Return True if Python classification should distribute a non-leaf product.
+
+    Covers two shapes the Rust arena classifier does NOT distribute, both of
+    which hide bilinear/monomial cross-terms behind an additive composite:
+
+    * ``(expr)**2`` with a non-leaf base, e.g. ``(x_i - x_j)**2``; and
+    * an explicit self-/cross-product of additive composites written without the
+      power operator, e.g. ``(x_i - x_j) * (x_i - x_j)`` (the form MINLPLib's
+      circle-packing distance constraints use). The Rust classifier sees the
+      ``*`` but never expands the ``-`` inside, so it misses the ``x_i*x_j``
+      cross-term; the linearizer then raises "Bilinear (i,j) not in map" and the
+      whole constraint is dropped, collapsing the relaxation bound to a trivial
+      value (kall_congruentcircles_* never certified for exactly this reason).
+
+    Routing such models to the Python classifier, which distributes via
+    ``_distribute_mul``, recovers the full term set. Classification runs once per
+    solve (not per node), so the cost of the Python path here is negligible.
+    """
+
+    def _is_additive_composite(e: Expression) -> bool:
+        """A ``+``/``-`` node whose distribution can expose product cross-terms."""
+        return isinstance(e, BinaryOp) and e.op in ("+", "-")
 
     def visit(expr: Expression) -> bool:
         if isinstance(expr, BinaryOp):
@@ -176,6 +197,10 @@ def _contains_expandable_square(model: Model) -> bool:
                 and isinstance(expr.right, Constant)
                 and float(expr.right.value) == 2.0
                 and _get_flat_index(expr.left, model) is None
+            ):
+                return True
+            if expr.op == "*" and (
+                _is_additive_composite(expr.left) or _is_additive_composite(expr.right)
             ):
                 return True
             return visit(expr.left) or visit(expr.right)

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -326,6 +326,37 @@ def test_weymouth_like_squares_extend_builtin_partition_selection():
     }
 
 
+def test_self_product_difference_classifies_cross_term():
+    """``(a-b)*(a-b)`` (a squared difference written WITHOUT ``**2``) must expand.
+
+    MINLPLib's circle-packing distance constraints write the squared difference as
+    an explicit self-product ``(x_i - x_j) * (x_i - x_j)`` rather than ``(x_i -
+    x_j)**2``. The Rust arena classifier does not distribute the ``-`` inside the
+    product, so it misses the ``x_i*x_j`` cross-term; the linearizer then raises
+    "Bilinear (i,j) not in map" and DROPS the whole constraint, collapsing the
+    relaxation bound to a trivial value (kall_congruentcircles_* never certified).
+    The expandable-product gate must route such models to the Python classifier.
+    """
+    from discopt._jax.term_classifier import (
+        _contains_expandable_square,
+        classify_nonlinear_terms,
+    )
+
+    m = Model("self_product_distance")
+    x = m.continuous("x", lb=-2.0, ub=2.0, shape=(2,))
+    m.minimize(x[0] + x[1])
+    # squared distance written as a self-product, not (x0-x1)**2
+    m.subject_to((x[0] - x[1]) * (x[0] - x[1]) >= 1.0)
+
+    assert _contains_expandable_square(m) is True
+
+    terms = classify_nonlinear_terms(m)
+    # the cross-term and both squares must be recovered, not dropped
+    assert (0, 1) in terms.bilinear
+    assert (0, 2) in terms.monomial
+    assert (1, 2) in terms.monomial
+
+
 def test_partitioned_square_secants_tighten_circle_superlevel_bound():
     """Local square secants should close the Alpine circle MILP lower bound."""
     m = _make_circle()


### PR DESCRIPTION
## Summary

MINLPLib's circle-packing distance constraints write a squared difference as an explicit self-product `(x_i - x_j) * (x_i - x_j)` rather than `(x_i - x_j)**2`. The expandable-square gate `_contains_expandable_square` only recognized the **power** form, so these models took the Rust arena classifier — which sees the `*` but never distributes the `-` inside it, missing the `x_i*x_j` cross-term. The linearizer then raised `Bilinear (i,j) not in map` and **silently dropped the whole constraint**, weakening the relaxation.

## Fix

Route `(additive) * (additive)` products to the Python classifier (which distributes via `_distribute_mul`) alongside the existing non-leaf-square case. Classification runs **once per solve**, not per node, so the cost is negligible.

## Why it's worth it (measured before/after)

`kall_congruentcircles_c41`, 60 s budget, 1e-4 gap:

| | status | nodes | time | dropped constraints |
|---|---|---|---|---|
| **before** | feasible (never certifies) | 12239 | 60 s timeout | 6 |
| **after** | **optimal** | **167** | **2.3 s** | **0** |

Same global incumbent either way (0.8584073) — the dropped constraints only blocked **certification**, not the answer. Removing the silent constraint-drop lets the relaxation close the gap.

## Tests

- New regression test `test_self_product_difference_classifies_cross_term` asserts the cross-term and both squares are recovered for `(a-b)*(a-b)`. It **fails on `main`** (returns `False`/drops the term) and passes with this fix.
- No regression: `test_amp.py`, `test_multivariate_mccormick.py`, `test_mccormick.py` — 227 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
