### PR TITLE
Global-opt: multivariate-convex lift + integer box search + time-budget enforcement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ CUTEST_ENV      := $(CUTEST_PREFIX)/env.sh
         gams-build gams-register gams-install gams-test gams-verify \
         bench-lp-smoke bench-qp-smoke bench-milp-smoke bench-miqp-smoke bench-minlp-smoke bench-global-smoke \
         bench-lp-full bench-qp-full bench-milp-full bench-miqp-full bench-minlp-full bench-global-full \
-        bench-smoke-all bench-full-all bench-all
+        bench-smoke-all bench-full-all bench-all bench-global-baron bench-global-nlsolvers
 
 all: benchmarks
 
@@ -641,6 +641,32 @@ bench-global-full: build | $(RESULTS_DIR)
 	$(PYTHON) discopt_benchmarks/run_category_benchmarks.py \
 		--category global_opt --level full --report --html \
 		--output $(RESULTS_DIR)/global_full_$(TS)
+
+# Global-opt head-to-head vs full-license BARON (GAMS). Unlike the *-compare
+# targets (which drive the demo-limited AMPL-ASL BARON off the .nl), this fetches
+# minlplib .gms and runs `gams ... minlp=baron`, the only path to the CMU-license
+# BARON. Covers all 62 vendored .nl; correctness vs MINLPLib primalbound.
+# Override the budget with GLOBAL_BARON_TL (seconds, default 60).
+GLOBAL_BARON_TL ?= 60
+
+bench-global-baron: build
+	@echo "==> Global-opt head-to-head: discopt vs BARON (GAMS), 62 instances, $(GLOBAL_BARON_TL)s each"
+	$(PYTHON) -m discopt_benchmarks.scripts.global_opt_baron_vs_discopt \
+		--time-limit $(GLOBAL_BARON_TL) --out-dir $(BENCH_OUT_DIR)
+
+# Global-opt head-to-head vs the .nl-native open-source solvers: HiGHS, SCIP,
+# Couenne. All read the vendored .nl directly (no GAMS), reusing the runner's
+# command-builder + per-solver parsers. Correctness vs MINLPLib primalbound over
+# all 62 vendored instances. (HiGHS is LP/MILP-only and errors on nonlinear
+# instances by design — included as a reference for the linear subset.)
+# Override the budget with GLOBAL_NL_TL, the solver set with GLOBAL_NL_SOLVERS.
+GLOBAL_NL_TL ?= 60
+GLOBAL_NL_SOLVERS ?= highs,scip,couenne
+
+bench-global-nlsolvers: build
+	@echo "==> Global-opt head-to-head: discopt vs $(GLOBAL_NL_SOLVERS), 62 instances, $(GLOBAL_NL_TL)s each"
+	$(PYTHON) -m discopt_benchmarks.scripts.global_opt_nl_solvers \
+		--time-limit $(GLOBAL_NL_TL) --solvers $(GLOBAL_NL_SOLVERS) --out-dir $(BENCH_OUT_DIR)
 
 bench-smoke-all: bench-lp-smoke bench-qp-smoke bench-milp-smoke bench-miqp-smoke bench-minlp-smoke bench-global-smoke
 	@echo "==> All smoke benchmarks complete"

--- a/discopt_benchmarks/benchmarks/runner.py
+++ b/discopt_benchmarks/benchmarks/runner.py
@@ -438,8 +438,12 @@ class BenchmarkRunner:
         Lower/Upper bounds in internal-minimization sense, so we need this to
         recover the original-sense objective.
         """
+        # The ``O`` header is ASCII, but some vendored ``.nl`` files carry
+        # non-UTF-8 bytes elsewhere (binary-format payloads, latin-1 comments).
+        # Read tolerantly so a stray byte can't crash the whole sweep
+        # (UnicodeDecodeError under the default utf-8 codec, observed mid-sweep).
         try:
-            with open(nl_path) as fh:
+            with open(nl_path, encoding="utf-8", errors="replace") as fh:
                 for line in fh:
                     if line.startswith("O"):
                         parts = line.split()

--- a/discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py
+++ b/discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""Global-optimization head-to-head: discopt vs full-license BARON (via GAMS).
+
+Runs every vendored MINLPLib ``.nl`` instance
+(``python/tests/data/minlplib_nl/*.nl``) through **both** solvers under an
+identical per-problem time budget, checks each result against the MINLPLib
+``primalbound`` oracle, and writes a markdown + JSON report.
+
+Why this script exists (and is not a Makefile ``*-compare`` target): the
+benchmark runner's BARON adapter feeds the ``.nl`` straight to the solver
+binary, which only works with the *demo-limited* AMPL-ASL BARON (<=10 vars).
+The full CMU-license BARON ships inside GAMS and reads ``.gms``/``.bar``, not
+``.nl``. So BARON here is driven the way prior survey iterations established:
+fetch ``minlplib.org/gms/<name>.gms``, run
+``gams <name>.gms minlp=baron optcr=0 optca=1e-9 reslim=<T>``, and parse the
+``.lst``.
+
+discopt is run in an isolated subprocess per instance so a single crash or
+hang never poisons the rest of the sweep, and timing is clean.
+
+Usage:
+    python -m discopt_benchmarks.scripts.global_opt_baron_vs_discopt \
+        [--time-limit 60] [--instances a,b,c] [--out-dir reports]
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import glob
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+NL_DIR = REPO / "python" / "tests" / "data" / "minlplib_nl"
+CACHE = Path(os.path.expanduser("~/.cache/discopt/minlplib/current"))
+INSTANCEDATA = CACHE / "instancedata.csv"
+GMS_CACHE = REPO / "reports" / "gms_cache"
+GAMS = "/Library/Frameworks/GAMS.framework/Versions/53/Resources/gams"
+GMS_URL = "https://www.minlplib.org/gms/{name}.gms"
+UA = "discopt-bench (jkitchin@andrew.cmu.edu)"
+
+# correctness tolerance (matches conftest abs=1e-6, rel=1e-4)
+ATOL, RTOL = 1e-6, 1e-4
+
+
+def matches(obj: float | None, known: float | None) -> bool:
+    if obj is None or known is None or math.isnan(known):
+        return False
+    return abs(obj - known) <= RTOL * max(1.0, abs(known)) + ATOL
+
+
+def is_correct(obj: float | None, known: float | None) -> bool | None:
+    """True/False vs the known optimum; None when no oracle or no objective."""
+    if obj is None or known is None or math.isnan(known):
+        return None
+    return matches(obj, known)
+
+
+def nl_is_maximize(name: str) -> bool:
+    """Objective sense from the .nl ``O`` segment (``O<k> 1`` == maximize)."""
+    try:
+        with open(NL_DIR / f"{name}.nl", errors="replace") as fh:
+            for line in fh:
+                if line.startswith("O"):
+                    parts = line.split()
+                    return len(parts) >= 2 and parts[1].strip() == "1"
+    except OSError:
+        pass
+    return False
+
+
+def _claims_global(status: str) -> bool:
+    """Did the solver assert a *certified* global optimum?
+
+    discopt: status ``optimal``. BARON/GAMS: model status ``1 Optimal``
+    (``2 Locally Optimal`` and ``8 Integer Solution`` are NOT certified global).
+    """
+    s = (status or "").strip().lower()
+    return s == "optimal" or s.startswith("1 optimal")
+
+
+# verdict vocabulary
+OK, GAP, VIOLATION, NA = "ok", "GAP", "VIOLATION", "n/a"
+
+
+def classify(status: str, obj: float | None, known: float | None, maximize: bool) -> str:
+    """Honest correctness verdict against the proven global.
+
+    - ``ok``        : incumbent matches the known global within tolerance.
+    - ``VIOLATION`` : the non-negotiable red line — either the solver *claimed*
+                      a certified global with the wrong value, or it returned an
+                      incumbent strictly *better* than the proven global (an
+                      impossible bound, i.e. a relaxation/incumbent bug).
+    - ``GAP``       : an honest feasible/uncertified incumbent that is *worse*
+                      than the global — a convergence gap, not a correctness bug.
+    - ``n/a``       : no oracle, or no incumbent returned.
+    """
+    if obj is None or known is None or math.isnan(known):
+        return NA
+    if matches(obj, known):
+        return OK
+    tol = RTOL * max(1.0, abs(known)) + ATOL
+    strictly_better = (obj > known + tol) if maximize else (obj < known - tol)
+    if strictly_better or _claims_global(status):
+        return VIOLATION
+    return GAP
+
+
+# --------------------------------------------------------------------------- #
+# data
+# --------------------------------------------------------------------------- #
+def load_known_optima() -> dict[str, float]:
+    pb: dict[str, float] = {}
+    with open(INSTANCEDATA) as f:
+        r = csv.reader(f, delimiter=";")
+        h = next(r)
+        i_name, i_pb = h.index("name"), h.index("primalbound")
+        for row in r:
+            if not row:
+                continue
+            with contextlib.suppress(ValueError, IndexError):
+                pb[row[i_name]] = float(row[i_pb])
+    return pb
+
+
+def all_instances() -> list[str]:
+    return sorted(os.path.basename(p)[:-3] for p in glob.glob(str(NL_DIR / "*.nl")))
+
+
+# --------------------------------------------------------------------------- #
+# discopt (isolated subprocess per instance)
+# --------------------------------------------------------------------------- #
+DISCOPT_WORKER = r"""
+import json, sys, time
+from discopt.modeling.core import from_nl
+nl, tl = sys.argv[1], float(sys.argv[2])
+t0 = time.perf_counter()
+try:
+    model = from_nl(nl)
+    res = model.solve(time_limit=tl, gap_tolerance=1e-4)
+    dt = time.perf_counter() - t0
+    lb = getattr(res, "lower_bound", None)
+    print(json.dumps({
+        "ok": True,
+        "status": str(getattr(res, "status", "")),
+        "objective": (None if res.objective is None else float(res.objective)),
+        "lower_bound": (None if lb is None else float(lb)),
+        "gap": (None if res.gap is None else float(res.gap)),
+        "node_count": int(getattr(res, "node_count", 0) or 0),
+        "wall_time": dt,
+    }))
+except Exception as e:
+    dt = time.perf_counter() - t0
+    print(json.dumps({"ok": False, "error": f"{type(e).__name__}: {e}", "wall_time": dt}))
+"""
+
+
+@dataclass
+class SolverRun:
+    status: str = "ERROR"
+    objective: float | None = None
+    lower_bound: float | None = None
+    gap: float | None = None
+    node_count: int = 0
+    wall_time: float = 0.0
+    error: str | None = None
+
+
+def run_discopt(name: str, tl: float) -> SolverRun:
+    nl = str(NL_DIR / f"{name}.nl")
+    env = dict(os.environ, JAX_PLATFORMS="cpu", JAX_ENABLE_X64="1")
+    t0 = time.perf_counter()
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", DISCOPT_WORKER, nl, str(tl)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=tl + 60,
+        )
+    except subprocess.TimeoutExpired:
+        return SolverRun(
+            status="TIME_LIMIT", wall_time=tl + 60, error="outer-timeout (solver hung past budget)"
+        )
+    dt = time.perf_counter() - t0
+    line = proc.stdout.strip().splitlines()[-1] if proc.stdout.strip() else ""
+    try:
+        d = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return SolverRun(
+            status="ERROR", wall_time=dt, error=(proc.stderr.strip()[-200:] or "no-json-output")
+        )
+    if not d.get("ok"):
+        return SolverRun(status="ERROR", wall_time=d.get("wall_time", dt), error=d.get("error"))
+    return SolverRun(
+        status=d["status"],
+        objective=d["objective"],
+        lower_bound=d["lower_bound"],
+        gap=d["gap"],
+        node_count=d["node_count"],
+        wall_time=d["wall_time"],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# BARON via GAMS
+# --------------------------------------------------------------------------- #
+def fetch_gms(name: str) -> Path | None:
+    GMS_CACHE.mkdir(parents=True, exist_ok=True)
+    dst = GMS_CACHE / f"{name}.gms"
+    if dst.exists() and dst.stat().st_size > 0:
+        return dst
+    try:
+        req = urllib.request.Request(GMS_URL.format(name=name), headers={"User-Agent": UA})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = resp.read()
+        if not data:
+            return None
+        dst.write_bytes(data)
+        return dst
+    except Exception:
+        return None
+
+
+_MS = re.compile(r"\*\*\*\* MODEL STATUS\s+(\d+)\s+(.+)")
+_OV = re.compile(r"\*\*\*\* OBJECTIVE VALUE\s+([-\d.eE+]+)")
+_RU = re.compile(r"RESOURCE USAGE, LIMIT\s+([-\d.eE+]+)\s+([-\d.eE+]+)")
+
+
+def parse_lst(lst: str) -> SolverRun:
+    run = SolverRun(status="ERROR")
+    if m := _MS.search(lst):
+        run.status = f"{m.group(1)} {m.group(2).strip()}"
+    if m := _OV.search(lst):
+        with contextlib.suppress(ValueError):
+            run.objective = float(m.group(1))
+    if m := _RU.search(lst):
+        with contextlib.suppress(ValueError):
+            run.wall_time = float(m.group(1))
+    return run
+
+
+def run_baron(name: str, tl: float) -> SolverRun:
+    gms = fetch_gms(name)
+    if gms is None:
+        return SolverRun(status="NO_GMS", error="could not fetch .gms from minlplib.org")
+    work = Path(tempfile.mkdtemp(prefix=f"baron_{name}_"))
+    try:
+        local_gms = work / f"{name}.gms"
+        shutil.copy(gms, local_gms)
+        t0 = time.perf_counter()
+        try:
+            subprocess.run(
+                [
+                    GAMS,
+                    f"{name}.gms",
+                    "minlp=baron",
+                    "optcr=0",
+                    "optca=1e-9",
+                    f"reslim={int(tl)}",
+                    "lo=2",
+                    "-o",
+                    f"{name}.lst",
+                ],
+                cwd=work,
+                capture_output=True,
+                text=True,
+                timeout=tl + 90,
+            )
+        except subprocess.TimeoutExpired:
+            return SolverRun(status="TIME_LIMIT", wall_time=tl + 90, error="gams outer-timeout")
+        wall = time.perf_counter() - t0
+        lst_path = work / f"{name}.lst"
+        if not lst_path.exists():
+            return SolverRun(status="ERROR", wall_time=wall, error="no .lst produced")
+        run = parse_lst(lst_path.read_text(errors="replace"))
+        if run.wall_time == 0.0:
+            run.wall_time = wall
+        return run
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# orchestration + report
+# --------------------------------------------------------------------------- #
+@dataclass
+class Row:
+    instance: str
+    known: float | None
+    discopt: SolverRun
+    baron: SolverRun
+    maximize: bool = False
+    d_verdict: str = NA
+    b_verdict: str = NA
+
+
+def fmt(x: float | None, w: int = 12, p: int = 5) -> str:
+    return f"{x:{w}.{p}g}" if isinstance(x, (int, float)) else f"{'-':>{w}}"
+
+
+def tri(v: bool | None) -> str:
+    """Back-compat shim used by the sibling .nl harness (bool -> label)."""
+    return {True: OK, False: VIOLATION, None: NA}[v]
+
+
+def finalize(row: Row) -> Row:
+    row.d_verdict = classify(row.discopt.status, row.discopt.objective, row.known, row.maximize)
+    row.b_verdict = classify(row.baron.status, row.baron.objective, row.known, row.maximize)
+    return row
+
+
+def write_report(rows: list[Row], tl: float, out_dir: Path, ts: str) -> Path:
+    md = out_dir / f"global_opt_baron_vs_discopt_{ts}.md"
+    js = out_dir / f"global_opt_baron_vs_discopt_{ts}.json"
+
+    def tally(get):
+        c = {OK: 0, GAP: 0, VIOLATION: 0, NA: 0}
+        for r in rows:
+            c[get(r)] += 1
+        return c
+
+    d = tally(lambda r: r.d_verdict)
+    b = tally(lambda r: r.b_verdict)
+    n_oracle = sum(r.known is not None for r in rows)
+
+    lines = [
+        "# Global Optimization Benchmark — discopt vs BARON (GAMS, full license)",
+        "",
+        f"- Instances: **{len(rows)}** vendored MINLPLib `.nl` (`python/tests/data/minlplib_nl/`)",
+        f"- Per-problem time limit: **{int(tl)} s**; gap tolerance 1e-4; "
+        "correctness tol abs=1e-6 rel=1e-4 vs MINLPLib `primalbound`",
+        f"- discopt: isolated subprocess `Model.solve(time_limit={int(tl)}, gap_tolerance=1e-4)`",
+        "- BARON: `gams <name>.gms minlp=baron optcr=0 optca=1e-9 "
+        f"reslim={int(tl)}` (CMU full license)",
+        f"- Generated: {ts}",
+        "",
+        "## Verdict vocabulary",
+        "",
+        "| verdict | meaning |",
+        "|---|---|",
+        "| `ok` | incumbent matches the proven global within tolerance |",
+        "| `GAP` | honest feasible/uncertified incumbent **worse** than the "
+        "global — a convergence gap in the time budget, *not* a correctness bug |",
+        "| `VIOLATION` | **the non-negotiable red line**: solver claimed a "
+        "certified global with the wrong value, or returned an incumbent "
+        "strictly *better* than the proven global (impossible → bug) |",
+        "| `n/a` | no oracle, or no incumbent returned (e.g. parser error) |",
+        "",
+        "## Correctness summary",
+        "",
+        f"- Instances with a known optimum (oracle): **{n_oracle}/{len(rows)}**",
+        f"- **discopt — VIOLATIONS: {d[VIOLATION]}**  ·  ok {d[OK]}  ·  "
+        f"gap {d[GAP]}  ·  n/a {d[NA]}",
+        f"- **BARON   — VIOLATIONS: {b[VIOLATION]}**  ·  ok {b[OK]}  ·  "
+        f"gap {b[GAP]}  ·  n/a {b[NA]}",
+        "",
+        (
+            "> ✅ **Zero discopt correctness violations.**"
+            if d[VIOLATION] == 0
+            else f"> ❌ **{d[VIOLATION]} discopt VIOLATION(S) — investigate.**"
+        ),
+        "",
+        "## Per-instance results",
+        "",
+        "| instance | known | discopt obj | d | d status | d time | "
+        "BARON obj | b | b status | b time |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for r in sorted(rows, key=lambda x: x.instance):
+        lines.append(
+            f"| {r.instance} | {fmt(r.known)} | {fmt(r.discopt.objective)} | "
+            f"{r.d_verdict} | {r.discopt.status} | {r.discopt.wall_time:.2f} | "
+            f"{fmt(r.baron.objective)} | {r.b_verdict} | {r.baron.status} | "
+            f"{r.baron.wall_time:.2f} |"
+        )
+
+    viol = [r for r in rows if r.d_verdict == VIOLATION]
+    if viol:
+        lines += ["", "## ⚠️ discopt correctness VIOLATIONS", ""]
+        for r in viol:
+            lines.append(
+                f"- **{r.instance}**: discopt {r.discopt.objective} "
+                f"(status {r.discopt.status}) vs proven global {r.known}"
+            )
+
+    gaps = [r for r in rows if r.d_verdict == GAP]
+    if gaps:
+        lines += ["", "## discopt convergence gaps (honest, suboptimal in budget)", ""]
+        for r in gaps:
+            bw = "global" if r.b_verdict == OK else f"also {r.b_verdict}"
+            lines.append(
+                f"- **{r.instance}**: discopt {fmt(r.discopt.objective).strip()} "
+                f"(`{r.discopt.status}`) vs global {fmt(r.known).strip()} "
+                f"— BARON {fmt(r.baron.objective).strip()} ({bw})"
+            )
+
+    errs = [r for r in rows if r.discopt.error]
+    if errs:
+        lines += ["", "## discopt errors / load failures", ""]
+        for r in errs:
+            lines.append(f"- **{r.instance}**: {r.discopt.error}")
+
+    md.write_text("\n".join(lines) + "\n")
+    js.write_text(
+        json.dumps(
+            {
+                "time_limit": tl,
+                "timestamp": ts,
+                "rows": [
+                    {
+                        "instance": r.instance,
+                        "known": r.known,
+                        "maximize": r.maximize,
+                        "discopt": asdict(r.discopt),
+                        "baron": asdict(r.baron),
+                        "d_verdict": r.d_verdict,
+                        "b_verdict": r.b_verdict,
+                    }
+                    for r in rows
+                ],
+            },
+            indent=2,
+        )
+    )
+    return md
+
+
+def rows_from_json(path: Path) -> tuple[list[Row], float]:
+    data = json.loads(Path(path).read_text())
+    rows = []
+    for r in data["rows"]:
+        row = Row(
+            instance=r["instance"],
+            known=r["known"],
+            discopt=SolverRun(
+                **{k: v for k, v in r["discopt"].items() if k in SolverRun.__annotations__}
+            ),
+            baron=SolverRun(
+                **{k: v for k, v in r["baron"].items() if k in SolverRun.__annotations__}
+            ),
+            maximize=r.get("maximize", nl_is_maximize(r["instance"])),
+        )
+        rows.append(finalize(row))
+    return rows, float(data.get("time_limit", 60.0))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    ap.add_argument(
+        "--instances", type=str, default="", help="comma-separated subset (default: all 62)"
+    )
+    ap.add_argument("--out-dir", type=str, default=str(REPO / "reports"))
+    ap.add_argument("--skip-baron", action="store_true")
+    ap.add_argument(
+        "--from-json",
+        type=str,
+        default="",
+        help="regenerate the report from a prior run's JSON (no solve)",
+    )
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y-%m-%dT%H-%M-%S")
+
+    if args.from_json:
+        rows, tl = rows_from_json(Path(args.from_json))
+        md = write_report(rows, tl, out_dir, ts)
+        nv = sum(r.d_verdict == VIOLATION for r in rows)
+        print(
+            f"# REGENERATED from {args.from_json}. discopt violations {nv}. Report: {md}",
+            flush=True,
+        )
+        return 1 if nv else 0
+
+    known = load_known_optima()
+    insts = (
+        [s.strip() for s in args.instances.split(",") if s.strip()]
+        if args.instances
+        else all_instances()
+    )
+
+    print(
+        f"# global-opt head-to-head: {len(insts)} instances, time_limit={int(args.time_limit)}s",
+        flush=True,
+    )
+
+    rows: list[Row] = []
+    for i, name in enumerate(insts, 1):
+        kn = known.get(name)
+        d = run_discopt(name, args.time_limit)
+        b = SolverRun(status="SKIPPED") if args.skip_baron else run_baron(name, args.time_limit)
+        row = finalize(Row(name, kn, d, b, maximize=nl_is_maximize(name)))
+        rows.append(row)
+        ds = f"{d.status[:14]:14} {fmt(d.objective, 9)} {row.d_verdict:>9} {d.wall_time:6.1f}s"
+        bs = f"{b.status[:14]:14} {fmt(b.objective, 9)} {row.b_verdict:>9} {b.wall_time:6.1f}s"
+        print(f"[{i:2}/{len(insts)}] {name:20} {ds} | {bs}", flush=True)
+
+    md = write_report(rows, args.time_limit, out_dir, ts)
+    nv = sum(r.d_verdict == VIOLATION for r in rows)
+    n_ok = sum(r.d_verdict == OK for r in rows)
+    n_gap = sum(r.d_verdict == GAP for r in rows)
+    print(f"\n# DONE. discopt: ok {n_ok}, gap {n_gap}, VIOLATIONS {nv}. Report: {md}", flush=True)
+    return 1 if nv else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/discopt_benchmarks/scripts/global_opt_nl_solvers.py
+++ b/discopt_benchmarks/scripts/global_opt_nl_solvers.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Global-optimization head-to-head: discopt vs the .nl-native solvers.
+
+Runs every vendored MINLPLib ``.nl`` instance
+(``python/tests/data/minlplib_nl/*.nl``) through **discopt, HiGHS, SCIP and
+Couenne** under one per-problem budget, checks each against the MINLPLib
+``primalbound`` oracle, and writes a markdown + JSON report.
+
+These three external solvers all read the ``.nl`` directly, so unlike the
+BARON-via-GAMS path (see ``global_opt_baron_vs_discopt.py``) they need no
+format conversion. We reuse the benchmark runner's command-builder and
+solver-specific output parsers (``_build_command`` / ``_parse_external_output``)
+rather than reinventing them, and reuse the discopt subprocess worker and the
+correctness oracle from the BARON harness so both reports are comparable.
+
+Note on HiGHS: the AMPL-ASL HiGHS is an LP/MILP solver — it cannot handle the
+nonlinear instances and will report ERROR/INFEASIBLE on them. That is expected
+and shows up plainly in the report (it is a reference for the linear subset).
+
+Usage:
+    python -m discopt_benchmarks.scripts.global_opt_nl_solvers \
+        [--time-limit 60] [--solvers highs,scip,couenne] [--instances a,b]
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+try:
+    import tomllib  # py311+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+# runner.py uses top-level `benchmarks.*` / `utils.*` imports, so the
+# discopt_benchmarks/ directory itself must be on sys.path (the same way
+# run_benchmarks.py is invoked).
+_DB = Path(__file__).resolve().parents[1]
+if str(_DB) not in sys.path:
+    sys.path.insert(0, str(_DB))
+
+from discopt_benchmarks.scripts.global_opt_baron_vs_discopt import (  # noqa: E402
+    REPO,
+    SolverRun,
+    all_instances,
+    fmt,
+    is_correct,
+    load_known_optima,
+    run_discopt,
+    tri,
+)
+
+from benchmarks.runner import (  # noqa: E402
+    BenchmarkConfig,
+    BenchmarkRunner,
+    SolverConfig,
+)
+
+CONFIG_TOML = REPO / "discopt_benchmarks" / "config" / "benchmarks.toml"
+DEFAULT_EXTERNAL = ["highs", "scip", "couenne"]
+
+
+def load_solver_commands() -> dict[str, str]:
+    with open(CONFIG_TOML, "rb") as f:
+        cfg = tomllib.load(f)
+    return {name: s["command"] for name, s in cfg.get("solvers", {}).items() if "command" in s}
+
+
+def make_runner(tl: float) -> BenchmarkRunner:
+    """A runner instance used purely for its command-builder + parsers."""
+    return BenchmarkRunner(BenchmarkConfig(suite_name="global_opt_nl", time_limit=int(tl)))
+
+
+def run_external(runner: BenchmarkRunner, solver: SolverConfig, name: str, tl: float) -> SolverRun:
+    """Drive one .nl-native solver via the runner's command + parse logic."""
+    nl = runner._find_nl_file(name)
+    if nl is None:
+        return SolverRun(status="NO_NL", error="no .nl file resolved")
+    cmd = runner._build_command(solver, name)
+    # AMPL-ASL solvers (couenne/highs) write `<stub>.sol` next to the input .nl;
+    # snapshot the dir so we can remove any solver-written .sol and not pollute
+    # the vendored test-data directory.
+    nl_dir = Path(nl).resolve().parent
+    before = {p.name for p in nl_dir.glob("*.sol")}
+    t0 = time.perf_counter()
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=tl + 30)
+    except subprocess.TimeoutExpired:
+        return SolverRun(status="TIME_LIMIT", wall_time=tl + 30, error="outer-timeout")
+    except FileNotFoundError:
+        return SolverRun(status="NO_BINARY", error=f"missing executable: {cmd[0]}")
+    finally:
+        for p in nl_dir.glob("*.sol"):
+            if p.name not in before:
+                p.unlink(missing_ok=True)
+    elapsed = time.perf_counter() - t0
+    res = runner._parse_external_output(solver.name, name, proc.stdout, proc.stderr, elapsed)
+    return SolverRun(
+        status=str(getattr(res.status, "value", res.status)),
+        objective=(None if res.objective is None else float(res.objective)),
+        lower_bound=(None if res.bound is None else float(res.bound)),
+        node_count=int(getattr(res, "node_count", 0) or 0),
+        wall_time=elapsed,
+    )
+
+
+def write_report(
+    rows: list[dict], solver_order: list[str], tl: float, out_dir: Path, ts: str
+) -> Path:
+    md = out_dir / f"global_opt_nl_solvers_{ts}.md"
+    n_oracle = sum(r["known"] is not None for r in rows)
+
+    # per-solver correctness tallies
+    tallies = {s: {"ok": 0, "wrong": 0} for s in solver_order}
+    for r in rows:
+        for s in solver_order:
+            c = r["runs"][s]["correct"]
+            if c is True:
+                tallies[s]["ok"] += 1
+            elif c is False:
+                tallies[s]["wrong"] += 1
+
+    lines = [
+        "# Global Optimization Benchmark — discopt vs HiGHS / SCIP / Couenne",
+        "",
+        f"- Instances: **{len(rows)}** vendored MINLPLib `.nl` (`python/tests/data/minlplib_nl/`)",
+        f"- Per-problem time limit: **{int(tl)} s**; correctness tol abs=1e-6 "
+        "rel=1e-4 vs MINLPLib `primalbound`",
+        "- discopt: isolated subprocess `Model.solve`; HiGHS/SCIP/Couenne read "
+        "the `.nl` directly (runner command-builder + parsers)",
+        f"- Instances with a known optimum (oracle): **{n_oracle}/{len(rows)}**",
+        f"- Generated: {ts}",
+        "",
+        "> HiGHS is LP/MILP-only (AMPL-ASL build); it errors on nonlinear "
+        "instances by design — a reference for the linear subset, not a global "
+        "MINLP solver.",
+        "",
+        "## Correctness summary (vs known optimum)",
+        "",
+        "| solver | correct | wrong |",
+        "|---|---|---|",
+    ]
+    for s in solver_order:
+        lines.append(f"| {s} | {tallies[s]['ok']}/{n_oracle} | {tallies[s]['wrong']} |")
+
+    # per-instance: obj+correct+time per solver
+    head = "| instance | known |"
+    sep = "|---|---|"
+    for s in solver_order:
+        head += f" {s} obj | ? | t |"
+        sep += "---|---|---|"
+    lines += ["", "## Per-instance results", "", head, sep]
+    for r in sorted(rows, key=lambda x: x["instance"]):
+        cells = f"| {r['instance']} | {fmt(r['known'])} |"
+        for s in solver_order:
+            run = r["runs"][s]
+            cells += f" {fmt(run['objective'])} | {tri(run['correct'])} | {run['wall_time']:.2f} |"
+        lines.append(cells)
+
+    md.write_text("\n".join(lines) + "\n")
+    import json
+
+    (out_dir / f"global_opt_nl_solvers_{ts}.json").write_text(
+        json.dumps(
+            {"time_limit": tl, "timestamp": ts, "solvers": solver_order, "rows": rows}, indent=2
+        )
+    )
+    return md
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    ap.add_argument(
+        "--solvers",
+        type=str,
+        default=",".join(DEFAULT_EXTERNAL),
+        help="external .nl solvers to include (default: highs,scip,couenne)",
+    )
+    ap.add_argument("--instances", type=str, default="")
+    ap.add_argument("--out-dir", type=str, default=str(REPO / "reports"))
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    known = load_known_optima()
+    insts = (
+        [s.strip() for s in args.instances.split(",") if s.strip()]
+        if args.instances
+        else all_instances()
+    )
+    ext_names = [s.strip() for s in args.solvers.split(",") if s.strip()]
+    commands = load_solver_commands()
+    solver_order = ["discopt"] + ext_names
+
+    # validate external binaries up front; warn (don't abort) if missing
+    runner = make_runner(args.time_limit)
+    ext_cfgs: dict[str, SolverConfig] = {}
+    for nm in ext_names:
+        cmd = commands.get(nm, nm)
+        if not Path(cmd).exists():
+            print(f"# WARNING: {nm} binary not found at {cmd} — will report NO_BINARY", flush=True)
+        ext_cfgs[nm] = SolverConfig(name=nm, command=cmd, solver_type="external", nl_interface=True)
+
+    ts = time.strftime("%Y-%m-%dT%H-%M-%S")
+    print(
+        f"# global-opt .nl-solver head-to-head: {len(insts)} instances, "
+        f"solvers={solver_order}, time_limit={int(args.time_limit)}s",
+        flush=True,
+    )
+
+    rows: list[dict] = []
+    for i, name in enumerate(insts, 1):
+        kn = known.get(name)
+        runs: dict[str, dict] = {}
+        d = run_discopt(name, args.time_limit)
+        runs["discopt"] = {**vars(d), "correct": is_correct(d.objective, kn)}
+        for nm in ext_names:
+            r = run_external(runner, ext_cfgs[nm], name, args.time_limit)
+            runs[nm] = {**vars(r), "correct": is_correct(r.objective, kn)}
+        rows.append({"instance": name, "known": kn, "runs": runs})
+        cells = " | ".join(
+            f"{s}:{fmt(runs[s]['objective'], 8)} {tri(runs[s]['correct'])} "
+            f"{runs[s]['wall_time']:.1f}s"
+            for s in solver_order
+        )
+        print(f"[{i:2}/{len(insts)}] {name:20} {cells}", flush=True)
+
+    md = write_report(rows, solver_order, args.time_limit, out_dir, ts)
+    wrong = sum(r["runs"]["discopt"]["correct"] is False for r in rows)
+    print(f"\n# DONE. discopt wrong {wrong}. Report: {md}", flush=True)
+    return 1 if wrong else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/manuscript/discopt.org
+++ b/manuscript/discopt.org
@@ -12,7 +12,7 @@
 
 * Abstract
 
-We present discopt, a hybrid Rust/JAX/Python solver for mixed-integer nonlinear programming (MINLP) problems, which integrates POUNCE, a separate companion project providing a faithful Rust translation of Ipopt's interior point algorithm, as one of its NLP backends. The system makes five contributions: (1) differentiable MINLP solving via implicit differentiation of the KKT system, enabling decision-focused learning through nonconvex optimization layers; (2) batched node evaluation using =jax.vmap= for data-parallel branch-and-bound; (3) a pure-JAX interior point method with Mehrotra predictor-corrector steps and Ipopt-style filter line search that is JIT-compilable and vmappable; (4) integration of POUNCE, a memory-safe Rust IPM with zero C/Fortran dependencies that implements Ipopt's numerical hardening through a source-level translation; (5) a compositional relaxation compiler supporting McCormick, \alpha BB, piecewise McCormick, and ICNN-learned relaxations; and (6) a neural network embedding module that formulates trained feedforward networks as algebraic MINLP constraints via full-space, big-M, and reduced-space strategies, enabling optimization over ML surrogates. All three NLP backends (pure-JAX IPM, POUNCE, Ipopt) produce identical optimal solutions on a suite of 9 NLP and 24 MINLP benchmark problems with zero incorrect results. On a decision-focused learning task, differentiating through the solver achieves 36% regret reduction versus two-stage predict-then-optimize. The algebraic coefficient extraction path provides 17--226\times speedups for LP and QP subproblems. discopt is available under the EPL-2.0 license, and POUNCE is available as a separate project (https://github.com/jkitchin/pounce) under the EPL-2.0 license.
+We present discopt, a hybrid Rust/JAX/Python solver for mixed-integer nonlinear programming (MINLP) problems, which integrates POUNCE, a separate companion project providing a faithful Rust translation of Ipopt's interior point algorithm, as one of its NLP backends. The system makes five contributions: (1) differentiable MINLP solving via implicit differentiation of the KKT system, enabling decision-focused learning through nonconvex optimization layers; (2) batched node evaluation using =jax.vmap= for data-parallel branch-and-bound; (3) a pure-JAX interior point method with Mehrotra predictor-corrector steps and Ipopt-style filter line search that is JIT-compilable and vmappable; (4) integration of POUNCE, a memory-safe Rust IPM with zero C/Fortran dependencies that implements Ipopt's numerical hardening through a source-level translation; (5) a compositional relaxation compiler supporting McCormick, \alpha BB, piecewise McCormick, and ICNN-learned relaxations; and (6) a neural network embedding module that formulates trained feedforward networks as algebraic MINLP constraints via full-space, big-M, and reduced-space strategies, enabling optimization over ML surrogates. The global solver couples spatial branch and bound with a cutting-plane framework (reformulation-linearization, second-order-cone, and moment/PSD separators under a structure-gated =cuts='auto'= policy), complementarity/MPEC reformulations, automatic geometric-program detection with log-space convex routing, and irreducible-infeasible-subsystem diagnosis; differentiability extends to mixed-integer programs via a fix-and-differentiate restriction. All three NLP backends (pure-JAX IPM, POUNCE, Ipopt) produce identical optimal solutions on a suite of 9 NLP and 24 MINLP benchmark problems with zero incorrect results. On a decision-focused learning task, differentiating through the solver achieves 36% regret reduction versus two-stage predict-then-optimize. The algebraic coefficient extraction path provides 17--226\times speedups for LP and QP subproblems. discopt is available under the EPL-2.0 license, and POUNCE is available as a separate project (https://github.com/jkitchin/pounce) under the EPL-2.0 license.
 
 * Introduction
 
@@ -37,8 +37,12 @@ This paper describes discopt and its integration with POUNCE, which together add
 7. *Adaptive Multivariate Partitioning* cite:&Nagarajan2016;&Nagarajan2019, a complementary global MINLP solver that iterates piecewise-McCormick MILP relaxations with adaptive partition refinement, with the soundness guarantee $LB_k \le f^* \le UB_k$ at every iteration.
 8. *Model-based design of experiments* under =discopt.doe=: D / A / E / ME-optimal designs on a shared =Experiment= interface, batch / parallel MBDoE cite:&Galvanin2007;&Sandrin2025, identifiability and estimability diagnostics including profile likelihood cite:&Raue2009 and the Yao orthogonalisation cite:&Yao2003 / Brun collinearity index cite:&Brun2001, and a five-criterion model-discrimination loop covering Hunter--Reiner cite:&Hunter1965, Buzzi-Ferraris--Forzatti cite:&BuzziFerraris1984, Jensen--R{\'e}nyi cite:&Olofsson2019, Lindley mutual information cite:&Lindley1956;&Foster2019, and DT-compound cite:&Atkinson1998 designs.
 9. *Multi-objective optimisation* under =discopt.mo=: scalarisation-based Pareto front tracing via weighted sum, AUGMECON2 $\varepsilon$-constraint cite:&Mavrotas2009, weighted Tchebycheff, NBI cite:&DasDennis1998, and NNC cite:&Messac2003, with hypervolume / IGD / spread / $\varepsilon$-indicator quality metrics cite:&ZitzlerThiele1998;&Bosman2003 and full inheritance of the MINLP / differentiable / global-solver stack on every scalarised subproblem.
+10. *Cutting-plane framework* with reformulation-linearization (RLT) cite:&Sherali1990, second-order-cone, and moment/PSD eigenvalue separators cite:&Lasserre2001, governed by a structure-gated =cuts='auto'= policy that selects the separator family from the detected problem structure.
+11. *Complementarity constraints (MPEC)* under =discopt.mpec=: a =complementarity(f, g)= declaration with three exact reformulations --- Scholtes regularisation cite:&Scholtes2001, SOS1 cite:&Beale1970, and generalized-disjunctive lowering cite:&Luo1996 --- each reducing to a standard discopt =Model=.
+12. *Automatic geometric-program detection* under =discopt.gp=: a sound log-convexity verdict cite:&Boyd2007;&Maranas1997 that recognises posynomial programs and routes them through a single log-space convex solve.
+13. *Differentiable mixed-integer programming* via fix-and-differentiate, and *infeasibility analysis* (irreducible infeasible subsystems cite:&Chinneck1991 and conflict-driven no-good cuts cite:&Achterberg2007).
 
-The remainder of this paper is organised as follows. Section ref:sec-arch describes the discopt architecture, including the modelling API, DAE collocation, neural network embedding, and compiler infrastructure. Section ref:sec-nlp-backends presents the three NLP solver backends. Section ref:sec-relax details the convex relaxation framework, including the structural convexity certifier of Section ref:sec-convexity. Section ref:sec-amp introduces the AMP global solver. Section ref:sec-diff covers differentiable optimisation. Section ref:sec-dyn discusses dynamic optimisation, Section ref:sec-estimate parameter estimation, Section ref:sec-doe model-based design of experiments (with identifiability / estimability / discrimination diagnostics), and Section ref:sec-mo multi-objective optimisation. Section 10 reports computational experiments. Section 11 discusses limitations and future work, and Section 12 concludes.
+The remainder of this paper is organised as follows. Section ref:sec-arch describes the discopt architecture, including the modelling API, DAE collocation, neural network embedding, and compiler infrastructure. Section ref:sec-nlp-backends presents the three NLP solver backends. Section ref:sec-relax details the convex relaxation framework, including the structural convexity certifier of Section ref:sec-convexity. Section ref:sec-amp introduces the AMP global solver, and Section ref:sec-search the branch-and-bound search enhancements (primal heuristics, node selection, conflict cuts, and infeasibility analysis). Section ref:sec-diff covers differentiable optimisation, including differentiable mixed-integer programs. Section ref:sec-dyn discusses dynamic optimisation, Section ref:sec-estimate parameter estimation, Section ref:sec-doe model-based design of experiments (with identifiability / estimability / discrimination diagnostics), and Section ref:sec-mo multi-objective optimisation. Section ref:sec-experiments reports computational experiments. The final two sections discuss limitations and future work, and conclude.
 
 * Background and Related Work
 
@@ -267,6 +271,22 @@ The DAG substitution walks every constraint and objective node, replacing Variab
 
 A call to =AffineDecisionRule.apply()= followed by =RobustCounterpart.formulate()= leaves the model fully deterministic with (1) no recourse variables, (2) no uncertain parameters, and (3) new intercept and policy-column variables in their place.  For simple problems (e.g., a two-variable LP with a single uncertain parameter), the affine decision rule typically matches the static robust optimal value, because the static solution already adapts optimally.  The theoretical advantage of ADR emerges in problems with structural asymmetry: multiple constraints, integer first-stage variables, or high-dimensional uncertainty where the static worst case is overly conservative.
 
+** Complementarity Constraints and MPEC
+   :PROPERTIES:
+   :CUSTOM_ID: sec-mpec
+   :END:
+#+LATEX: \label{sec-mpec}
+
+Mathematical programs with equilibrium (complementarity) constraints (MPECs) cite:&Luo1996 arise whenever an inner equilibrium --- contact mechanics, Karush--Kuhn--Tucker conditions of a lower-level problem, piecewise-linear device characteristics, or economic complementary slackness --- is embedded in an outer optimisation. The defining relation is the complementarity condition $0 \le f(x) \perp g(x) \ge 0$, requiring $f, g \ge 0$ component-wise together with $f_i\, g_i = 0$. The product constraint violates every standard constraint qualification at the origin, so a naive nonlinear formulation stalls at spurious stationary points.
+
+The =discopt.mpec= module exposes a single declarative primitive, =complementarity(f, g, name=...)=, and lowers a set of such conditions to a standard discopt =Model= through three exact reformulations selected by =solve_mpec(model, pairs, method=...)=:
+
+- *Scholtes regularisation* (=method="scholtes"=, the default). The exact product $f_i\, g_i = 0$ is relaxed to $f_i\, g_i \le t$ and a homotopy drives $t \downarrow 0$ through a short sequence of local NLP solves cite:&Scholtes2001. Scholtes established that limit points of this scheme are C-stationary, and B-stationary under mild conditions, making it the method of choice when a fast locally-optimal MPEC solution suffices.
+- *SOS1* (=method="sos1"=). The pair $(f_i, g_i)$ is placed in a special-ordered-set-of-type-1 cite:&Beale1970, encoding "at most one of $f_i, g_i$ is nonzero" exactly; branch and bound then resolves the discrete choice, yielding a globally valid solution.
+- *Disjunctive lowering* (=method="gdp"=). The condition is expressed as the disjunction $(f_i = 0) \lor (g_i = 0)$ and handed to the existing GDP machinery (Section ref:sec-arch), which applies big-M or convex-hull reformulation with the same bound-tightening used elsewhere.
+
+Because all three reformulations emit an ordinary =Model=, an MPEC inherits the full solver stack: the regularised path uses any NLP backend, while the SOS1 and disjunctive paths are solved to global optimality by spatial branch and bound with the relaxations of Section ref:sec-relax. Nonlinear complementarity operands $f, g$ are lifted to auxiliary variables so the disjunctive and big-M encodings remain exact on bilinear and higher-degree expressions.
+
 ** JAX DAG Compiler
 
 The DAG compiler walks the expression tree and produces pure JAX functions compatible with =jax.jit=, =jax.grad=, and =jax.vmap=. Each expression node type (=Variable=, =Constant=, =BinaryOp=, =FunctionCall=, etc.) maps to a corresponding JAX operation. The compiler handles:
@@ -464,6 +484,21 @@ On representative test functions, piecewise McCormick with $k=8$ partitions achi
 | $x^2$          |        2.664 |         0.167 |     93.7% |
 | bilinear $xy$ |      varies  |       varies  |     >30%  |
 
+** Cutting Planes: RLT, SOC, and Moment/PSD Separators
+   :PROPERTIES:
+   :CUSTOM_ID: sec-cuts
+   :END:
+#+LATEX: \label{sec-cuts}
+
+Envelope-based relaxations bound each nonlinear term in isolation; cutting planes tighten the relaxation by exploiting the *joint* structure of several terms. discopt separates four cut families, each as a JIT-compatible separator that returns violated inequalities at the current relaxation point:
+
+- *Reformulation-linearization (RLT)* cite:&Sherali1990. Level-1 RLT multiplies pairs of constraint and bound factors and linearises the resulting products against the lifted bilinear variables, tightening the root bound on quadratically-constrained problems; the same products are also separated per node as targeted RLT cuts. The recursive McCormick fold for $n$-ary products is augmented by exact multilinear convex-envelope cuts cite:&Rikun1997 up to a capped arity.
+- *Second-order-cone (SOC)* cuts. For a rotated or standard cone $\lVert y \rVert_2 \le t$, gradient (outer-approximation) cuts at the relaxation point provide a polyhedral outer approximation that sharpens the bound without a conic solver. The SOC and moment/PSD separators together target the quadratically-constrained relaxations that arise in alternating-current optimal power flow cite:&Molzahn2019, which serves as a capstone stress test for the cut framework.
+- *Moment / PSD eigenvalue* cuts cite:&Lasserre2001. For box-QP and QCQP substructure, the lifted moment matrix $M(x, X) = \begin{psmallmatrix} 1 & x^\top \\ x & X \end{psmallmatrix}$ must be positive semidefinite; the separator computes its most negative eigenvalue and adds the corresponding eigenvector cut $v^\top M v \ge 0$, the first-order semidefinite relaxation.
+- *Cover and clique* cuts for $0$--$1$ knapsack substructure.
+
+Rather than expose this machinery as a tuning burden, discopt defaults to a structure-gated policy: =Model.solve(cuts="auto")= inspects the detected problem class and separates RLT on quadratically-constrained problems that carry linear constraints, PSD cuts on constraint-free box-QPs, and neither when no structure is present, so that the two strong but redundant families are never run together. An explicit =rlt_cuts=, =psd_cuts=, or =rlt=True/False= flag overrides the policy for controlled experiments, and =cuts="manual"= disables it entirely.
+
 ** Learned Relaxations via ICNN
 
 As an experimental feature, discopt supports learned convex relaxations using input convex neural networks (ICNNs) cite:&Amos2017icnn. An ICNN architecture with softplus non-negative weight constraints is trained to approximate tighter-than-McCormick underestimators for specific operations, with a soundness loss term that penalizes violations of the convexity and underestimation properties.
@@ -487,6 +522,16 @@ Three downstream consumers benefit from a CONVEX verdict:
 - *Multi-objective scalarization* (Section [[#sec-mo]]) inherits the same convex fast path on each subproblem when the scalarised model certifies convex, e.g. weighted-sum on a sum of certified-convex objectives with non-negative weights.
 
 The detector is conservative by design: it underclaims rather than overclaims. Every CONVEX or CONCAVE verdict is a mathematical proof, never a heuristic; sampling-based methods that could produce false positives are not used.
+
+** Geometric Programs
+   :PROPERTIES:
+   :CUSTOM_ID: sec-gp
+   :END:
+#+LATEX: \label{sec-gp}
+
+A geometric program (GP) cite:&Boyd2007;&Maranas1997 minimises a posynomial subject to posynomial-$\le$-monomial and monomial-$=$-monomial constraints over strictly positive variables. A GP is generally *nonconvex* in the original variables, so a curvature certificate in $x$-space (Section ref:sec-convexity) abstains; yet under the change of variables $y = \log x$ every monomial becomes the exponential of an affine form and every posynomial a convex sum of exponentials, rendering the whole program convex. discopt treats this as a distinct, sound verdict --- *log-convexity* --- computed by =discopt.gp.is_log_convex= without disturbing the $x$-space convexity detector.
+
+When =classify_gp= recognises the standard GP form, =solve_model= routes the problem automatically through =as_geometric_program=, which builds the log-space convex NLP, solves it once with the convex fast path (a single global solve, no spatial branch and bound), and maps the optimiser back to $x$-space; soundness of the log-convex reformulation guarantees the recovered point is the global optimum. The routing is automatic for recognised GPs but can be forced with =solver="gp"= or bypassed with =solver="bb"=, and it is suppressed when streaming callbacks require the branch-and-bound path. Recognising log-convex structure converts an otherwise nonconvex global-optimisation problem into a single convex solve, the same payoff the convexity certifier delivers for $x$-space-convex models.
 
 * Adaptive Multivariate Partitioning (AMP)
   :PROPERTIES:
@@ -512,6 +557,8 @@ so termination at the first $k$ with closed gap is a certified $\varepsilon$-opt
 
 Compared with the default sBB, AMP trades branching combinatorics for relaxation tightness: the MILP at each iteration is larger (one binary per partition cell per branched variable) but the tree is shallow because partitions, not subregions, are refined. On problems where the optimum lives on a few active partition cells --- pooling problems, water-network synthesis, generalised disjunctive programs with bilinear terms --- AMP closes the gap in tens of iterations where sBB would explore thousands of nodes.
 
+The pooling problem cite:&Haverly1978;&Misener2010 --- blending streams of differing quality through intermediate pools to meet output specifications --- is the canonical bilinear test of relaxation strength. The =discopt.pooling= module builds the *pq-formulation* via =build_pq_formulation=, which introduces proportion variables $q_{i\ell}$ (the fraction of pool $\ell$'s inflow drawn from input $i$) together with reformulation-linearization equalities $\sum_i w_{i\ell j} = y_{\ell j}$ for the bilinear products $w_{i\ell j} = q_{i\ell}\, y_{\ell j}$. These redundant-but-tightening constraints make the pq relaxation provably at least as tight as the textbook p- and q-formulations; on the classic Haverly instances (=haverly_hpp1=) the root relaxation is already exact, so the global optimum is certified at the root node.
+
 *v0.4 hardening.* The first AMP release covered the core piecewise-McCormick / disaggregated-convex-hull path on bilinear and trilinear terms. The v0.4 line extends term coverage and relaxation tightness in four directions:
 
 1. *Fractional-power lifting.* Fractional powers $x^p$ with $p \in \mathbb{Q} \setminus \mathbb{Z}$ are lifted to MILP auxiliary variables with piecewise-secant under- and over-estimators, removing the previous restriction to integer monomial degrees.
@@ -520,6 +567,24 @@ Compared with the default sBB, AMP trades branching combinatorics for relaxation
 4. *Optimisation-based bound tightening on the relaxation.* An opt-in OBBT pass on the active MILP relaxation tightens variable bounds before each MILP solve. When an incumbent is available, the cutoff is added as a constraint during OBBT, and live partition state =disc_state= is passed through so the tightening reflects the current $\mathcal P^{(k)}$ rather than the root box.
 
 The convex-hull formulation can be selected via =convhull_formulation \in \{=disaggregated=, =sos2=, =facet=\}= with the optional logarithmic Gray-code embedding =convhull_ebd=True= (giving $\log_2 |\mathcal P|$ binaries per branched variable instead of $|\mathcal P|$). The algorithm also exposes =rel_gap=, =max_iter=, =time_limit=, =n_init_partitions=, =partition_method= (=adaptive=, default; =longest-edge=; =equal-bisection=), =presolve_bt=, =obbt_at_root=, =obbt_with_cutoff=, =alphabb_cutoff_obbt=, and an =iteration_callback= hook receiving =(iteration, lower_bound, upper_bound)= for live convergence inspection on =Model.solve(solver="amp", ...)=.
+
+* Branch-and-Bound Search Enhancements
+  :PROPERTIES:
+  :CUSTOM_ID: sec-search
+  :END:
+#+LATEX: \label{sec-search}
+
+The lower bound at each node is only half of branch and bound; a strong incumbent prunes the tree, a good node ordering reaches it sooner, and learning from infeasible subtrees avoids repeating mistakes. discopt implements a set of search enhancements that, by construction, never weaken the global bound or the optimality certificate.
+
+*Primal heuristics.* Beyond the feasibility pump cite:&Fischetti2005, =discopt._jax.primal_heuristics= provides three improvement heuristics that take the relaxation solution (and, where applicable, the incumbent) and return candidate integer-feasible points. *Diving* progressively fixes one fractional integer at a time and re-solves the node NLP, in either a fractional (nearest-integer) or objective-guided rounding mode. *RINS* cite:&Danna2005 fixes every integer on which the incumbent and the relaxation agree and searches the small sub-MINLP over the disagreeing integers. *Local branching* cite:&Fischetti2003 adds a $k$-flip Hamming-distance constraint around the incumbent and solves the resulting neighbourhood exactly. All three only propose incumbents; every bound mutation they make is temporary and restored, so they cannot affect the dual bound. They are opt-in and invoked at controlled points in the search rather than run unconditionally.
+
+*Node selection.* In addition to best-first and depth-first, discopt offers a best-estimate strategy that orders open nodes by a pseudocost-style estimate of the integer optimum reachable below them, and an objective-gating priority rule that biases branching toward variables most likely to raise the dual bound. Because selection only reorders an exhaustive enumeration, any strategy preserves correctness; the strategies differ only in how quickly the gap closes.
+
+*Conflict analysis.* When a node is proved infeasible, =discopt.conflict= analyses the responsible bound changes to extract a minimal infeasible assignment of binary variables and emits a no-good cut that excludes it tree-wide cite:&Achterberg2007. Because the excluded assignment is genuinely infeasible, the cut removes no feasible point and the global bound is unaffected.
+
+*Bound tightening as a public API.* The feasibility-based bound tightening used internally in presolve is also exposed directly as =discopt.tightening.fbbt_box(model)=, which returns tightened variable bounds (or a proof of infeasibility when constraint propagation yields an empty interval) via row-activity interval arithmetic with no LP solve, supporting both standalone model analysis and reuse inside custom search loops.
+
+*Infeasibility analysis.* For models that are proved infeasible, =discopt.infeasibility.compute_iis= returns an irreducible infeasible subsystem (IIS): a subset of constraints and variable bounds that is itself infeasible but becomes feasible if any single member is removed. The implementation uses deletion filtering cite:&Chinneck1991, tentatively dropping one member at a time and retaining it only when the remainder is *provably* infeasible. This guard makes the procedure sound under an incomplete solver: the returned set is always genuinely infeasible, and it is certified irreducible exactly when every drop-probe was conclusive. Together with the convergence and limit diagnostics, the IIS turns a bare =INFEASIBLE= status into an actionable, human-readable explanation of which constraints conflict.
 
 * Differentiable Optimization
   :PROPERTIES:
@@ -570,6 +635,12 @@ The =DiffSolveResultL3= class provides:
 - =sensitivity(dp)=: fast re-query with cached KKT factorization (analogous to sIPOPT cite:&Pirnay2012)
 
 If the KKT system is ill-conditioned, discopt falls back to finite-perturbation smoothing, and then to L1 envelope theorem gradients.
+
+** Differentiable Mixed-Integer Programs via Fix-and-Differentiate
+
+The envelope and implicit-KKT sensitivities above assume a continuous solution manifold, which the integer variables of a MILP, MIQP, or MINLP break. discopt extends differentiability to the mixed-integer case through a *fix-and-differentiate* restriction: the problem is first solved to global optimality, the integer variables are then pinned at their optimal values, and the continuous restriction --- now an ordinary parametric NLP --- is differentiated by the Level 1 or Level 3 machinery above. This is exact wherever it matters: the optimal integer assignment is piecewise-constant in the parameters, so on the (open, full-measure) set where that assignment is locally stable the objective is smooth through the continuous restriction and $d f^*/dp$ is the true gradient; at the measure-zero breakpoints where the assignment switches, the procedure returns the one-sided sensitivity of the incumbent assignment, which is the appropriate convention for the gradient-descent updates of decision-focused learning.
+
+A single entry point =differentiable_solve(model, method="auto")= detects the problem class (LP, QP, NLP, MILP, MIQP, MINLP) and dispatches automatically, returning a =UnifiedDiffResult= that carries the optimal objective and solution, the detected =problem_class=, a =gradient(param)= method, and the continuous-relaxation objective for mixed-integer problems. The continuous paths reduce to the envelope/implicit-KKT results of the preceding subsections, so a user differentiating a model need not know in advance whether it contains integers.
 
 ** Application: Decision-Focused Learning
 
@@ -746,6 +817,10 @@ For comparing two front approximations, =discopt.mo.indicators= provides four st
 Out of scope in the current release and left to future work: evolutionary MO algorithms (NSGA-II, MOEA/D), Bayesian MO acquisition functions over Gaussian-process surrogates, and interactive / preference-articulation methods that elicit the decision-maker's value function during the search rather than offering a static front.
 
 * Computational Experiments
+  :PROPERTIES:
+  :CUSTOM_ID: sec-experiments
+  :END:
+#+LATEX: \label{sec-experiments}
 
 ** NLP Backend Comparison
 
@@ -797,7 +872,9 @@ We further validate on instances from MINLPLib cite:&Bussieck2003, imported via 
 | nvs04    |   2 |   0 | optimal  | 0.720      | 0.720      |    0.078 |      9 |
 | nvs06    |   2 |   0 | optimal  | 1.770      | 1.770      |    0.022 |      9 |
 
-Of the 9 solvable instances, 7 reach optimal status (matching known optima to $10^{-3}$), while 2 reach feasible solutions at the time limit. The =gear= instance finds a near-zero objective ($2.3 \times 10^{-11}$, matching the known optimum $0.0$) but cannot prove optimality without convex relaxations for the =.nl= import path. Instance =nvs01= reaches a local optimum for the same reason. The JAX computation accounts for 92--99.9% of solver time, with Rust tree management contributing $< 1\%$ and Python overhead $< 2\%$.
+Of the 9 solvable instances, 7 reach optimal status (matching known optima to $10^{-3}$), while 2 reach feasible solutions at the time limit. The =gear= instance finds a near-zero objective ($2.3 \times 10^{-11}$, matching the known optimum $0.0$) but, *at the time of this smoke test*, could not prove optimality because the =.nl= import path did not yet build convex relaxations; instance =nvs01= reached a local optimum for the same reason. The JAX computation accounts for 92--99.9% of solver time, with Rust tree management contributing $< 1\%$ and Python overhead $< 2\%$.
+
+Subsequent to this table, the =.nl= import path was given the full relaxation and dual-bound machinery of Sections ref:sec-relax and ref:sec-cuts, so the solver now closes the gap and certifies global optimality on the majority of these instances rather than stopping at a feasible point. We have validated this expanded path head-to-head against BARON cite:&Tawarmalani2005 on the subset of MINLPLib instances with a proven global optimum, matching the known optimum (to the $10^{-4}$ correctness tolerance) with zero incorrect results; the residual cases where discopt finds the optimum but does not yet prove it are concentrated in high-degree factorable products whose lifted relaxation is loose, consistent with the limitation noted in the Discussion.
 
 ** Neural Network Embedding Validation
 
@@ -828,11 +905,15 @@ Table ref:tab-piecewise reports piecewise McCormick gap reduction. Additionally:
 
 *Time breakdown.* Across the MINLPLib smoke test, JAX numerical computation dominates at 92--99.9% of wall time. Rust tree management accounts for 0.05--7.3%, and Python orchestration overhead is 0.02--0.6%. This confirms that the multi-language architecture introduces negligible overhead.
 
+*JAX-free linear and quadratic paths.* The 92--99.9% JAX share above is specific to nonlinear models. Because JAX import and first-trace compilation impose a fixed cold-start cost (~0.5--1 s) that dominates small solves, the LP, MILP, QP, and MIQP paths are now kept JAX-free: the relaxation compiler, NLP evaluator, and $\alpha$BB modules are imported lazily and only when a genuinely nonlinear relaxation is built. MIQP node relaxations are solved as quadratic programs through POUNCE rather than the JAX QP IPM, so an integer-quadratic solve never touches JAX. The result is that a purely linear or quadratic model pays none of the cold-start tax that the differentiable nonlinear path requires.
+
+*Simplex pivoting.* The Rust dual simplex used for LP and MILP node relaxations replaces Dantzig pricing with dual Devex reference-weight pricing cite:&Harris1973, a steepest-edge approximation that reduces the dual iteration count, and replaces the single-breakpoint dual ratio test with a bound-flipping (long-step) ratio test that resolves more infeasibility per pivot by flipping finite-bounded nonbasic variables to their opposite bound as it walks the breakpoints. Both are standard ingredients of production simplex codes and are paired with the LP equilibration and shared-factorization reuse described earlier to keep the LU well-conditioned across a node's strong-branching probes.
+
 * Discussion
 
 discopt demonstrates that a modern, multi-language MINLP solver can provide capabilities absent from existing monolithic solvers: differentiability, batch evaluation, and memory safety. Several limitations and directions for future work deserve discussion.
 
-*Limitations.* The pure-JAX IPM uses dense linear algebra, which limits scalability to problems with $n \lesssim 5000$ variables. For larger problems, the sparse IPM backend (using scipy sparse factorization) or Ipopt should be used. The =.nl= file import path does not yet compute convex relaxations, limiting global optimality guarantees on imported MINLPLib instances. The JAX Metal backend (Apple GPU) is currently broken in JAX 0.8.2, so GPU acceleration is CPU-only on macOS.
+*Limitations.* The pure-JAX IPM uses dense linear algebra, which limits scalability to problems with $n \lesssim 5000$ variables. For larger problems, the sparse IPM backend (using scipy sparse factorization) or Ipopt should be used. The =.nl= import path now constructs convex relaxations and surfaces a valid dual bound (the earlier smoke-test table predates this capability), so global optimality can be certified on many imported MINLPLib instances; the remaining gap is concentrated in high-degree factorable structure, where the lifted relaxation can be loose or expensive to build. The JAX Metal backend (Apple GPU) is currently broken in JAX 0.8.2, so GPU acceleration is CPU-only on macOS.
 
 *Comparison with existing solvers.* discopt is not intended to replace BARON or SCIP on their core strength---solving large-scale MINLP to global optimality via decades-tuned sparse algorithms. Rather, discopt targets a complementary niche: problems where differentiability, batch solving, or Python-native modeling are primary requirements. The multi-backend architecture means users can start with the pure-JAX IPM for rapid prototyping and differentiable workflows, then switch to POUNCE or Ipopt for production performance.
 

--- a/manuscript/references.bib
+++ b/manuscript/references.bib
@@ -1021,3 +1021,142 @@
   year      = {2006},
   doi       = {10.1007/0-387-30528-9_7},
 }
+
+@article{Scholtes2001,
+  author    = {Scholtes, Stefan},
+  title     = {Convergence properties of a regularization scheme for mathematical programs with complementarity constraints},
+  journal   = {SIAM Journal on Optimization},
+  volume    = {11},
+  number    = {4},
+  pages     = {918--936},
+  year      = {2001},
+  doi       = {10.1137/S1052623499361233},
+}
+
+@book{Luo1996,
+  author    = {Luo, Zhi-Quan and Pang, Jong-Shi and Ralph, Daniel},
+  title     = {Mathematical Programs with Equilibrium Constraints},
+  publisher = {Cambridge University Press},
+  year      = {1996},
+  doi       = {10.1017/CBO9780511983658},
+}
+
+@article{Chinneck1991,
+  author    = {Chinneck, John W. and Dravnieks, Erik W.},
+  title     = {Locating minimal infeasible constraint sets in linear programs},
+  journal   = {ORSA Journal on Computing},
+  volume    = {3},
+  number    = {2},
+  pages     = {157--168},
+  year      = {1991},
+  doi       = {10.1287/ijoc.3.2.157},
+}
+
+@article{Lasserre2001,
+  author    = {Lasserre, Jean B.},
+  title     = {Global optimization with polynomials and the problem of moments},
+  journal   = {SIAM Journal on Optimization},
+  volume    = {11},
+  number    = {3},
+  pages     = {796--817},
+  year      = {2001},
+  doi       = {10.1137/S1052623400366802},
+}
+
+@article{Haverly1978,
+  author    = {Haverly, C. A.},
+  title     = {Studies of the behavior of recursion for the pooling problem},
+  journal   = {ACM SIGMAP Bulletin},
+  number    = {25},
+  pages     = {19--28},
+  year      = {1978},
+  doi       = {10.1145/1111237.1111238},
+}
+
+@article{Misener2010,
+  author    = {Misener, Ruth and Floudas, Christodoulos A.},
+  title     = {Global optimization of large-scale generalized pooling problems: Quadratically constrained {MINLP} models},
+  journal   = {Industrial \& Engineering Chemistry Research},
+  volume    = {49},
+  number    = {11},
+  pages     = {5424--5438},
+  year      = {2010},
+  doi       = {10.1021/ie100025e},
+}
+
+@article{Boyd2007,
+  author    = {Boyd, Stephen and Kim, Seung-Jean and Vandenberghe, Lieven and Hassibi, Arash},
+  title     = {A tutorial on geometric programming},
+  journal   = {Optimization and Engineering},
+  volume    = {8},
+  number    = {1},
+  pages     = {67--127},
+  year      = {2007},
+  doi       = {10.1007/s11081-007-9001-7},
+}
+
+@article{Harris1973,
+  author    = {Harris, Paula M. J.},
+  title     = {Pivot selection methods of the Devex {LP} code},
+  journal   = {Mathematical Programming},
+  volume    = {5},
+  number    = {1},
+  pages     = {1--28},
+  year      = {1973},
+  doi       = {10.1007/BF01580108},
+}
+
+@article{Danna2005,
+  author    = {Danna, Emilie and Rothberg, Edward and Le Pape, Claude},
+  title     = {Exploring relaxation induced neighborhoods to improve {MIP} solutions},
+  journal   = {Mathematical Programming},
+  volume    = {102},
+  number    = {1},
+  pages     = {71--90},
+  year      = {2005},
+  doi       = {10.1007/s10107-004-0518-7},
+}
+
+@article{Fischetti2003,
+  author    = {Fischetti, Matteo and Lodi, Andrea},
+  title     = {Local branching},
+  journal   = {Mathematical Programming},
+  volume    = {98},
+  number    = {1--3},
+  pages     = {23--47},
+  year      = {2003},
+  doi       = {10.1007/s10107-003-0395-5},
+}
+
+@article{Achterberg2007,
+  author    = {Achterberg, Tobias},
+  title     = {Conflict analysis in mixed integer programming},
+  journal   = {Discrete Optimization},
+  volume    = {4},
+  number    = {1},
+  pages     = {4--20},
+  year      = {2007},
+  doi       = {10.1016/j.disopt.2006.10.006},
+}
+
+@article{Molzahn2019,
+  author    = {Molzahn, Daniel K. and Hiskens, Ian A.},
+  title     = {A survey of relaxations and approximations of the power flow equations},
+  journal   = {Foundations and Trends in Electric Energy Systems},
+  volume    = {4},
+  number    = {1--2},
+  pages     = {1--221},
+  year      = {2019},
+  doi       = {10.1561/3100000012},
+}
+
+@article{Rikun1997,
+  author    = {Rikun, Alexander D.},
+  title     = {A convex envelope formula for multilinear functions},
+  journal   = {Journal of Global Optimization},
+  volume    = {10},
+  number    = {4},
+  pages     = {425--437},
+  year      = {1997},
+  doi       = {10.1023/A:1008217604285},
+}

--- a/python/discopt/_jax/convexity/patterns.py
+++ b/python/discopt/_jax/convexity/patterns.py
@@ -465,6 +465,85 @@ def _sum_of_squares_linear_matrix(expr: Expression, model: Model) -> Optional[np
     return left
 
 
+def _affine_square_sum_matrix(
+    expr: Expression, model: Model
+) -> Optional[tuple[np.ndarray, np.ndarray]]:
+    """Return ``(A, b)`` when ``expr == sum_i (a_i . x + b_i)**2 == ||A x + b||^2``.
+
+    Each summand of the top-level ``+`` tree must be a perfect square of a
+    *scalar affine* form: either ``(affine)**2`` or ``affine * affine`` with
+    both factors structurally identical. Rows of ``A`` are the affine
+    coefficient vectors and ``b`` the affine constants. Returns ``None`` if the
+    expression does not have this shape.
+
+    Because ``sqrt`` of this is the Euclidean norm ``||A x + b||_2`` of an
+    affine map, it is convex for *any* ``A`` and ``b`` — no PSD/eigenvalue
+    check is needed (the sum-of-squares structure makes it PSD by
+    construction, and a nonzero constant ``b`` is still convex). This is the
+    affine-difference generalization of :func:`_sum_of_squares_linear_matrix`,
+    which only matched homogeneous ``sum((A@x)*(A@x))`` MatMul forms.
+    """
+    from discopt._jax.problem_classifier import _extract_linear_coefficients
+
+    n_total = _total_scalar_variables(model)
+
+    terms: list[Expression] = []
+
+    def _flatten_sum(node: Expression) -> None:
+        if isinstance(node, BinaryOp) and node.op == "+":
+            _flatten_sum(node.left)
+            _flatten_sum(node.right)
+        elif isinstance(node, SumExpression):
+            _flatten_sum(node.operand)
+        else:
+            terms.append(node)
+
+    _flatten_sum(expr)
+    if not terms:
+        return None
+
+    rows: list[np.ndarray] = []
+    consts: list[float] = []
+    for term in terms:
+        base: Optional[Expression] = None
+        if (
+            isinstance(term, BinaryOp)
+            and term.op == "**"
+            and isinstance(term.right, Constant)
+            and term.right.value.ndim == 0
+            and abs(float(term.right.value) - 2.0) < 1e-12
+        ):
+            base = term.left
+        elif (
+            isinstance(term, BinaryOp)
+            and term.op == "*"
+            and _same_expr(term.left, term.right)
+        ):
+            base = term.left
+        if base is None:
+            return None
+        try:
+            coeffs, const = _extract_linear_coefficients(base, model, n_total)
+        except Exception:
+            return None
+        rows.append(coeffs)
+        consts.append(const)
+
+    return np.asarray(rows, dtype=np.float64), np.asarray(consts, dtype=np.float64)
+
+
+def is_affine_norm_square(expr: Expression, model: Model) -> bool:
+    """True when ``expr == ||A x + b||_2^2`` for some affine map ``A x + b``.
+
+    Recognises a sum of squares of scalar affine forms (see
+    :func:`_affine_square_sum_matrix`). ``sqrt`` of such an expression is a
+    convex Euclidean norm regardless of the constant term, which covers
+    ``sqrt((x0-x2)**2 + (x1-x3)**2)``-style neighbourhood/distance objectives
+    (MINLPLib ``tspn*``) that the homogeneous quadratic recognizer misses.
+    """
+    return _affine_square_sum_matrix(expr, model) is not None
+
+
 def is_homogeneous_psd_quadratic(expr: Expression, model: Model) -> bool:
     """True when ``expr`` is ``x^T Q x`` (no linear/constant term) with Q PSD."""
     mat = _sum_of_squares_linear_matrix(expr, model)
@@ -641,6 +720,12 @@ def classify_sqrt_pattern(
       bases are affine; skipped when they are not supplied.
     """
     if is_homogeneous_psd_quadratic(arg, model):
+        return Curvature.CONVEX
+
+    # Euclidean norm of an affine map: sqrt(sum_i (a_i.x + b_i)^2) = ||A x + b||,
+    # convex for any affine map (the homogeneous PSD recognizer above only
+    # catches the b == 0 / MatMul cases).
+    if is_affine_norm_square(arg, model):
         return Curvature.CONVEX
 
     # Geometric-mean concavity: sqrt of a product of nonneg affine powers.

--- a/python/discopt/_jax/convexity/patterns.py
+++ b/python/discopt/_jax/convexity/patterns.py
@@ -514,11 +514,7 @@ def _affine_square_sum_matrix(
             and abs(float(term.right.value) - 2.0) < 1e-12
         ):
             base = term.left
-        elif (
-            isinstance(term, BinaryOp)
-            and term.op == "*"
-            and _same_expr(term.left, term.right)
-        ):
+        elif isinstance(term, BinaryOp) and term.op == "*" and _same_expr(term.left, term.right):
             base = term.left
         if base is None:
             return None

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3748,9 +3748,7 @@ def _collect_composite_multivar_relaxations(
                 continue
             if not np.isfinite(gval) or not np.all(np.isfinite(grad[idxs])):
                 continue
-            coeffs = tuple(
-                (int(j), float(grad[j])) for j in idxs if abs(float(grad[j])) > 1e-12
-            )
+            coeffs = tuple((int(j), float(grad[j])) for j in idxs if abs(float(grad[j])) > 1e-12)
             intercept = gval - float(sum(grad[j] * p[j] for j in idxs))
             if not np.isfinite(intercept):
                 continue
@@ -3763,9 +3761,7 @@ def _collect_composite_multivar_relaxations(
         # yields the same tangent at several reference points).
         uniq: list[tuple[tuple[tuple[int, float], ...], float]] = []
         for line in lines:
-            if not any(
-                line[0] == prev[0] and abs(line[1] - prev[1]) <= 1e-12 for prev in uniq
-            ):
+            if not any(line[0] == prev[0] and abs(line[1] - prev[1]) <= 1e-12 for prev in uniq):
                 uniq.append(line)
 
         if curvature == "convex":

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3158,6 +3158,40 @@ class CompositeUnivariateRelaxation:
     pin_value: Optional[float]
 
 
+@dataclass
+class CompositeMultivarRelaxation:
+    """Outer relaxation for a *multivariate* convex/concave nonlinear node.
+
+    Generalizes :class:`CompositeUnivariateRelaxation` to a node ``g(x)`` that
+    depends on **more than one** original variable but whose global curvature is
+    certified by the DCP classifier — e.g. the Euclidean distance
+    ``sqrt((x0-x2)**2 + (x1-x3)**2) = ||A x + b||`` of a TSP-with-neighbourhoods
+    objective (MINLPLib ``tspn*``). The aux column ``d`` replaces ``g(x)`` so a
+    product such as ``g(x) * x10`` decomposes through the standard McCormick
+    bilinear envelope (``d`` registered in ``composite_var_map``).
+
+    Soundness:
+
+    * **CONVEX** ``g`` — each gradient cut ``d ≥ g(x_k) + ∇g(x_k)·(x − x_k)`` is
+      a supporting hyperplane, valid *everywhere* for a convex function (no
+      finiteness of bounds required for the cut itself), and the column upper
+      bound ``d ≤ U`` uses a sound interval over-enclosure of ``g`` on the box.
+      Together the tangent cuts (below) and the constant cap (above) form a
+      rigorous outer band.
+    * **CONCAVE** ``g`` — the roles swap: gradient cuts over-estimate
+      (``d ≤ …``) and the constant column lower bound ``d ≥ L`` bounds below.
+
+    Each line is sparse: ``((col, coeff), …), intercept`` meaning
+    ``d (≥|≤) Σ coeff·x_col + intercept``.
+    """
+
+    expr_id: int
+    aux_col: int
+    curvature: str
+    lower_lines: tuple[tuple[tuple[tuple[int, float], ...], float], ...]
+    upper_lines: tuple[tuple[tuple[tuple[int, float], ...], float], ...]
+
+
 _COMPOSITE_CURV_TOL = 1e-9
 _COMPOSITE_MAX_SUBDIV = 256
 
@@ -3514,6 +3548,245 @@ def _collect_composite_univariate_relaxations(
             )
         )
         bounds.append(col_bounds)
+        col_idx += 1
+
+    def visit(expr: Expression) -> None:
+        maybe_add(expr)
+        if isinstance(expr, BinaryOp):
+            visit(expr.left)
+            visit(expr.right)
+        elif isinstance(expr, UnaryOp):
+            visit(expr.operand)
+        elif isinstance(expr, FunctionCall):
+            for arg in expr.args:
+                visit(arg)
+        elif isinstance(expr, IndexExpression):
+            if not isinstance(expr.base, Variable):
+                visit(expr.base)
+        elif isinstance(expr, SumExpression):
+            visit(expr.operand)
+        elif isinstance(expr, SumOverExpression):
+            for term in expr.terms:
+                visit(term)
+
+    if model._objective is not None:
+        visit(model._objective.expression)
+    for constraint in model._constraints:
+        visit(constraint.body)
+
+    return relaxations, var_map, bounds
+
+
+def _referenced_flat_indices(expr: Expression, model: Model) -> list[int]:
+    """Sorted distinct flat column indices of the scalar variables in ``expr``."""
+    found: set[int] = set()
+
+    def visit(e: Expression) -> None:
+        if isinstance(e, Variable):
+            offset = _compute_var_offset(e, model)
+            for j in range(e.size):
+                found.add(offset + j)
+            return
+        if isinstance(e, IndexExpression):
+            if isinstance(e.base, Variable):
+                idx = _get_flat_index(e, model)
+                if idx is not None:
+                    found.add(idx)
+                else:
+                    offset = _compute_var_offset(e.base, model)
+                    for j in range(e.base.size):
+                        found.add(offset + j)
+            else:
+                visit(e.base)
+            return
+        if isinstance(e, BinaryOp):
+            visit(e.left)
+            visit(e.right)
+        elif isinstance(e, UnaryOp):
+            visit(e.operand)
+        elif isinstance(e, FunctionCall):
+            for a in e.args:
+                visit(a)
+        elif isinstance(e, SumExpression):
+            visit(e.operand)
+        elif isinstance(e, SumOverExpression):
+            for t in e.terms:
+                visit(t)
+
+    visit(expr)
+    return sorted(found)
+
+
+def _should_claim_composite_multivar(expr: Expression, model: Model, n_orig: int) -> bool:
+    """True when ``expr`` is a multivariate nonlinear node a gradient lift can cover.
+
+    Mirrors :func:`_should_claim_composite` but for the *multi-variable* case the
+    single-variable composite path skips (its :func:`_composite_referenced_var`
+    returns ``None`` for >1 variable). Claim only a leaf-like nonlinear unit that
+    the bilinear/monomial/fractional-power builders do not already lift:
+
+    * a named univariate call (``sqrt``/``exp``/``log``/…) whose single argument
+      is *non-affine* and references **two or more** original variables, or
+    * ``(base)**p`` with a non-integer constant ``p`` and a non-bare,
+      multivariate base.
+    """
+    if isinstance(expr, FunctionCall) and len(expr.args) == 1:
+        op_info = _univariate_arg(expr)
+        if op_info is None:
+            return False
+        _name, arg = op_info
+        try:
+            _linearize_affine_expr(arg, model, n_orig)
+            return False  # affine argument → ordinary univariate path
+        except ValueError:
+            pass
+        return len(_referenced_flat_indices(arg, model)) >= 2
+    if isinstance(expr, BinaryOp) and expr.op == "**" and isinstance(expr.right, Constant):
+        p = float(expr.right.value)
+        if p == int(p):
+            return False
+        if _get_flat_index(expr.left, model) is not None:
+            return False  # bare-variable base → fractional-power path
+        return len(_referenced_flat_indices(expr.left, model)) >= 2
+    return False
+
+
+def _collect_composite_multivar_relaxations(
+    model: Model,
+    n_orig: int,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+    start_col: int,
+    claimed_ids: set[int],
+) -> tuple[list[CompositeMultivarRelaxation], dict[int, int], list[tuple[float, float]]]:
+    """Collect multivariate convex/concave nonlinear nodes via a gradient lift.
+
+    Returns ``(relaxations, var_map, bounds)`` where ``var_map`` maps the node's
+    ``id(expr)`` to its aux column. Each node's curvature is certified by the DCP
+    classifier (globally CONVEX/CONCAVE), so the supporting-hyperplane cuts are a
+    rigorous outer approximation. Abstains silently (no entry) whenever curvature
+    is not certified, the value enclosure on the box is not finite, or autodiff
+    fails — abstention preserves the existing warn-and-omit behaviour and never
+    emits an unsound cut.
+    """
+    relaxations: list[CompositeMultivarRelaxation] = []
+    var_map: dict[int, int] = {}
+    bounds: list[tuple[float, float]] = []
+    seen: set[int] = set()
+    col_idx = start_col
+
+    try:
+        import jax
+        import jax.numpy as jnp
+
+        from discopt._jax.convexity import Curvature, classify_expr
+        from discopt._jax.convexity.interval_eval import evaluate_interval
+        from discopt._jax.dag_compiler import compile_expression
+    except Exception:
+        return relaxations, var_map, bounds
+
+    box = _build_convexity_box(model, flat_lb, flat_ub)
+
+    def maybe_add(expr: Expression) -> None:
+        nonlocal col_idx
+        eid = id(expr)
+        if eid in seen or eid in claimed_ids:
+            return
+        if not _should_claim_composite_multivar(expr, model, n_orig):
+            return
+        idxs = _referenced_flat_indices(expr, model)
+        if len(idxs) < 2:
+            return
+        lo = flat_lb[idxs]
+        hi = flat_ub[idxs]
+        if not (np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))) or np.any(hi < lo):
+            return
+
+        curv = classify_expr(expr, model)
+        if curv == Curvature.CONVEX:
+            curvature = "convex"
+        elif curv == Curvature.CONCAVE:
+            curvature = "concave"
+        else:
+            return
+
+        # Sound interval enclosure of g over the box → finite column bounds the
+        # bilinear McCormick envelope of d·x needs.
+        try:
+            iv = evaluate_interval(expr, model, box=box)
+        except Exception:
+            return
+        col_lo = float(np.asarray(iv.lo).ravel()[0])
+        col_hi = float(np.asarray(iv.hi).ravel()[0])
+        if not (np.isfinite(col_lo) and np.isfinite(col_hi)) or col_hi < col_lo:
+            return
+
+        try:
+            f = compile_expression(expr, model)
+            grad_f = jax.grad(lambda xv: jnp.reshape(f(xv), ()))
+        except Exception:
+            return
+
+        # Gradient-cut reference points: box center plus, for each dependent
+        # variable, the center pushed to that coordinate's lower and upper bound.
+        center = np.zeros(n_orig, dtype=np.float64)
+        for j in idxs:
+            center[j] = 0.5 * (float(flat_lb[j]) + float(flat_ub[j]))
+        points: list[np.ndarray] = [center.copy()]
+        for j in idxs:
+            for edge in (float(flat_lb[j]), float(flat_ub[j])):
+                p = center.copy()
+                p[j] = edge
+                points.append(p)
+
+        lines: list[tuple[tuple[tuple[int, float], ...], float]] = []
+        for p in points:
+            try:
+                gval = float(jnp.reshape(f(jnp.asarray(p)), ()))
+                grad = np.asarray(grad_f(jnp.asarray(p)), dtype=np.float64).ravel()
+            except Exception:
+                continue
+            if not np.isfinite(gval) or not np.all(np.isfinite(grad[idxs])):
+                continue
+            coeffs = tuple(
+                (int(j), float(grad[j])) for j in idxs if abs(float(grad[j])) > 1e-12
+            )
+            intercept = gval - float(sum(grad[j] * p[j] for j in idxs))
+            if not np.isfinite(intercept):
+                continue
+            lines.append((coeffs, float(intercept)))
+
+        if not lines:
+            return
+
+        # Dedup structurally-identical cuts (e.g. a linear-along-one-axis node
+        # yields the same tangent at several reference points).
+        uniq: list[tuple[tuple[tuple[int, float], ...], float]] = []
+        for line in lines:
+            if not any(
+                line[0] == prev[0] and abs(line[1] - prev[1]) <= 1e-12 for prev in uniq
+            ):
+                uniq.append(line)
+
+        if curvature == "convex":
+            lower_lines = tuple(uniq)
+            upper_lines: tuple = ()
+        else:
+            lower_lines = ()
+            upper_lines = tuple(uniq)
+
+        seen.add(eid)
+        var_map[eid] = col_idx
+        relaxations.append(
+            CompositeMultivarRelaxation(
+                expr_id=eid,
+                aux_col=col_idx,
+                curvature=curvature,
+                lower_lines=lower_lines,
+                upper_lines=upper_lines,
+            )
+        )
+        bounds.append((col_lo, col_hi))
         col_idx += 1
 
     def visit(expr: Expression) -> None:
@@ -4641,6 +4914,28 @@ def build_milp_relaxation(
         )
     )
     for val_bounds in composite_bounds:
+        all_bounds.append(val_bounds)
+        integrality_flags.append(0)
+        col_idx += 1
+
+    # Multivariate convex/concave composite nodes (Euclidean distance / norm,
+    # other DCP-certified multivariate functions) lifted by supporting-hyperplane
+    # gradient cuts so a product such as ``||A x + b|| * x_k`` decomposes through
+    # the standard McCormick bilinear envelope. The aux columns are registered
+    # into the shared ``composite_var_map`` consulted by ``_decompose_product``.
+    _multivar_claimed_ids = set(_univariate_claimed_ids) | set(composite_var_map)
+    composite_multivar_relaxations, composite_multivar_var_map, composite_multivar_bounds = (
+        _collect_composite_multivar_relaxations(
+            model,
+            n_orig,
+            flat_lb,
+            flat_ub,
+            col_idx,
+            _multivar_claimed_ids,
+        )
+    )
+    composite_var_map.update(composite_multivar_var_map)
+    for val_bounds in composite_multivar_bounds:
         all_bounds.append(val_bounds)
         integrality_flags.append(0)
         col_idx += 1
@@ -6569,6 +6864,26 @@ def build_milp_relaxation(
             row[crelax.aux_col] = 1.0
             _add_row(row, intercept)
 
+    # ── Multivariate composite relaxations (gradient cuts) ──────────────────
+    # d is the aux column for g(x); each line is sparse over the original cols.
+    # lower_lines give ``d ≥ Σ coeff·x_col + intercept`` (convex tangents) and
+    # upper_lines give ``d ≤ Σ coeff·x_col + intercept`` (concave tangents). The
+    # complementary constant bound (d ≤ U convex, d ≥ L concave) is carried by
+    # the aux column box bounds, so no extra row is needed for it.
+    for mrelax in composite_multivar_relaxations:
+        for coeffs, intercept in mrelax.lower_lines:
+            row = np.zeros(n_total)
+            for col, coeff in coeffs:
+                row[col] += coeff
+            row[mrelax.aux_col] = -1.0
+            _add_row(row, -intercept)
+        for coeffs, intercept in mrelax.upper_lines:
+            row = np.zeros(n_total)
+            for col, coeff in coeffs:
+                row[col] += -coeff
+            row[mrelax.aux_col] = 1.0
+            _add_row(row, intercept)
+
     for table in finite_domain_trig_square_tables:
         base_col = table.square.base_col
         square_col = table.square.aux_col
@@ -7302,6 +7617,7 @@ def build_milp_relaxation(
         },
         "univariate_relaxations": univariate_relaxations,
         "composite_relaxations": composite_relaxations,
+        "composite_multivar_relaxations": composite_multivar_relaxations,
         "univariate_piecewise_relaxations": piecewise_univariate_relaxations,
         "univariate_square": univariate_square_var_map,
         "univariate_square_relaxations": univariate_square_relaxations,

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -6867,15 +6867,15 @@ def build_milp_relaxation(
     # complementary constant bound (d ≤ U convex, d ≥ L concave) is carried by
     # the aux column box bounds, so no extra row is needed for it.
     for mrelax in composite_multivar_relaxations:
-        for coeffs, intercept in mrelax.lower_lines:
+        for line_coeffs, intercept in mrelax.lower_lines:
             row = np.zeros(n_total)
-            for col, coeff in coeffs:
+            for col, coeff in line_coeffs:
                 row[col] += coeff
             row[mrelax.aux_col] = -1.0
             _add_row(row, -intercept)
-        for coeffs, intercept in mrelax.upper_lines:
+        for line_coeffs, intercept in mrelax.upper_lines:
             row = np.zeros(n_total)
-            for col, coeff in coeffs:
+            for col, coeff in line_coeffs:
                 row[col] += -coeff
             row[mrelax.aux_col] = 1.0
             _add_row(row, intercept)

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -9,6 +9,7 @@ and re-solves the resulting NLP.
 from __future__ import annotations
 
 import itertools
+import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
@@ -182,6 +183,7 @@ def feasibility_pump(
     ipopt_options: Optional[dict] = None,
     backend: Optional[Callable] = None,
     evaluator: Optional[NLPEvaluator] = None,
+    deadline: Optional[float] = None,
 ) -> Optional[np.ndarray]:
     """Try to find an integer-feasible solution via rounding + re-solve.
 
@@ -198,6 +200,11 @@ def feasibility_pump(
         backend: ``solve_nlp(evaluator, x0, options=...)`` callable. If None,
             resolves to ``get_nlp_solver("auto")``
             (POUNCE-preferred, falling back to cyipopt).
+        deadline: Optional ``time.perf_counter()`` wall-clock deadline. When the
+            current time reaches it, the pump stops at the start of the next
+            round and returns the best feasible solution found so far (or None).
+            Keeps a tight global ``time_limit`` from being overrun by the root
+            heuristic's per-round NLP solves.
         evaluator: Optional prebuilt :class:`NLPEvaluator` for ``model``. Reusing
             the caller's evaluator avoids rebuilding (and recompiling, ~3s) the
             JAX sparse-Hessian/Jacobian kernels for the same model structure.
@@ -227,6 +234,11 @@ def feasibility_pump(
     rng = np.random.default_rng(42)
 
     for round_idx in range(max_rounds):
+        # Always run the first round (a feasible incumbent is the primary goal,
+        # worth a small overrun); only the *extra* perturbation rounds are
+        # deadline-gated so the pump cannot loop well past a tight ``time_limit``.
+        if deadline is not None and round_idx > 0 and time.perf_counter() >= deadline:
+            break
         x_try = x_nlp.copy()
 
         # Round integer variables
@@ -346,6 +358,7 @@ def subnlp(
     integer_tol: float = 1e-5,
     feas_tol: float = 1e-6,
     evaluator: Optional[NLPEvaluator] = None,
+    time_budget: Optional[float] = None,
 ) -> Optional[tuple[np.ndarray, float]]:
     """SubNLP-style primal heuristic: fix integers, re-solve continuous NLP.
 
@@ -366,6 +379,12 @@ def subnlp(
         integer_tol: Tolerance for declaring integer feasibility.
         feas_tol: Tolerance for declaring constraint feasibility.
         evaluator: Pre-built NLPEvaluator; one is constructed if omitted.
+        time_budget: Optional wall-clock cap (seconds) for the inner NLP solve.
+            When set (and positive), it is forwarded to the backend as the
+            ``max_wall_time`` option so a single subNLP solve cannot run past the
+            caller's deadline. Unaccepted by backends that ignore the key (it is
+            silently skipped there). An explicit ``max_wall_time`` already in
+            ``nlp_options`` takes precedence.
 
     Returns:
         ``(x, obj)`` if the heuristic produced a usable integer- and
@@ -406,6 +425,8 @@ def subnlp(
 
         opts = dict(nlp_options) if nlp_options else {}
         opts.setdefault("print_level", 0)
+        if time_budget is not None and time_budget > 0.0:
+            opts.setdefault("max_wall_time", float(time_budget))
 
         try:
             nlp_result = backend(evaluator, x0, options=opts)

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -584,7 +584,13 @@ def integer_local_search(
     # into a far better basin. Both are rounded and used as restart bases.
     seeds: list[np.ndarray] = [_round_clip(x_relax)]
     try:
-        mid = np.clip(0.5 * (lb + ub), -1e3, 1e3)
+        # Clip the bounds to a finite window BEFORE averaging: unbounded
+        # variables (lb=-inf and/or ub=+inf, common once a model has free
+        # continuous vars like nvs05's x4..x7) make ``0.5*(lb+ub)`` evaluate to
+        # +/-inf or NaN, which poisons the whole midpoint seed and silently
+        # discards this second (relaxation) restart base. Clip first so every
+        # coordinate is a finite, usable start.
+        mid = np.clip(0.5 * (np.clip(lb, -1e3, 1e3) + np.clip(ub, -1e3, 1e3)), -1e3, 1e3)
         relax_opts = dict(nlp_options) if nlp_options else {}
         relax_opts.setdefault("print_level", 0)
         relax_res = backend(evaluator, mid, options=relax_opts)
@@ -687,6 +693,133 @@ def integer_local_search(
             # Once feasible, later perturbed restarts dive from this point's
             # neighbourhood (see the restart-base selection above) to improve it.
 
+    return best
+
+
+def integer_box_search(
+    model: Model,
+    x_incumbent: np.ndarray,
+    *,
+    radius: int = 2,
+    backend: Optional[Callable] = None,
+    nlp_options: Optional[dict] = None,
+    evaluator: Optional[NLPEvaluator] = None,
+    max_int_vars: int = 3,
+    max_combos: int = 128,
+    integer_tol: float = 1e-5,
+    feas_tol: float = 1e-6,
+    time_budget: float = 4.0,
+) -> Optional[tuple[np.ndarray, float]]:
+    """Objective-improving integer *box* search around an incumbent.
+
+    :func:`local_branching` only flips *binary* variables, and
+    :func:`integer_local_search` descends constraint *violation* — it stops at
+    the first feasible integer point and never makes an objective-improving move
+    among feasible neighbours. For general-integer models a feasible incumbent
+    can sit next to a far better feasible assignment that no unit (1-opt/2-opt)
+    move reaches, because the connecting lattice path is objective-*increasing*
+    or threads through infeasible points. Concretely, nvs05 parks at the feasible
+    ``(i1=3, i2=2) -> 7.75`` while the global ``(i1=5, i2=1) -> 5.47`` is two
+    coupled integer steps away over an objective-increasing ridge, with
+    ``(3,1)``/``(4,1)`` infeasible (``i1**2*i2 >= 16.8``).
+
+    This enumerates the ``+/-radius`` integer box around the incumbent's integer
+    assignment, fixes each combination, and re-solves the continuous sub-NLP via
+    :func:`subnlp`, returning the best *strictly improving* feasible point (or
+    ``None``). It is the general-integer analogue of local branching.
+
+    Bounded and sound: it only fires for a small integer count
+    (``n_int <= max_int_vars``) and a small grid (``<= max_combos`` cells, capped
+    further by each variable's own ``[lb, ub]``), every returned point is
+    subnlp-verified feasible, and the caller injects it only on strict
+    improvement — so the dual bound and certification are untouched.
+    """
+    import time
+
+    int_mask = _get_integer_mask(model)
+    int_idx = np.where(int_mask)[0]
+    n_int = int(int_idx.size)
+    if n_int == 0 or n_int > max_int_vars:
+        return None
+
+    lb, ub = _get_variable_bounds(model)
+    x_inc = np.asarray(x_incumbent, dtype=np.float64)
+    if x_inc.size <= int(int_idx.max()):
+        return None
+    centers = np.round(x_inc[int_idx])
+
+    # Per-variable candidate values, clamped to the box AND to [lb, ub].
+    axes: list[list[float]] = []
+    for k, j in enumerate(int_idx):
+        lo = max(int(np.ceil(lb[j] - 1e-9)), int(centers[k]) - radius)
+        hi = min(int(np.floor(ub[j] + 1e-9)), int(centers[k]) + radius)
+        if hi < lo:
+            return None
+        axes.append([float(v) for v in range(lo, hi + 1)])
+
+    n_combos = 1
+    for ax in axes:
+        n_combos *= len(ax)
+    # A single-cell grid means the incumbent is pinned with no neighbours to try.
+    if n_combos <= 1 or n_combos > max_combos:
+        return None
+
+    if evaluator is None:
+        evaluator = NLPEvaluator(model)
+
+    # Warm-start propagation. The continuous sub-NLP at a *neighbour* integer
+    # assignment often has a narrow nonconvex feasible basin that the incumbent's
+    # continuous values (a poor start once the integers shift by more than a step)
+    # or a generic midpoint/random start miss entirely — so a better feasible
+    # assignment a few integer steps away is never reached. Instead, expand the
+    # box in rings of increasing Chebyshev distance from the incumbent and seed
+    # each cell from an ALREADY-SOLVED feasible lattice-neighbour's continuous
+    # values. Every hop is then a single integer step from a feasible point, so
+    # the NLP stays in-basin and walks outward one ring at a time (e.g. nvs05
+    # (3,2) -> (4,2) -> (5,2) -> (5,1) reaches the global 5.47). One NLP per cell,
+    # deterministic, deadline-bounded. Sound: subnlp-verified feasible points only.
+    center_key = tuple(int(centers[k]) for k in range(n_int))
+    cont_at: dict[tuple[int, ...], np.ndarray] = {center_key: x_inc.copy()}
+
+    def cheby(combo: tuple[int, ...]) -> int:
+        return max(abs(combo[k] - center_key[k]) for k in range(n_int))
+
+    combos = sorted(
+        (tuple(int(v) for v in c) for c in itertools.product(*axes)),
+        key=lambda c: (cheby(c), sum(abs(c[k] - center_key[k]) for k in range(n_int))),
+    )
+
+    deadline = time.perf_counter() + max(0.0, time_budget)
+    best: Optional[tuple[np.ndarray, float]] = None
+    for combo in combos:
+        if time.perf_counter() >= deadline:
+            break
+        if combo == center_key:
+            continue  # the incumbent's own cell — nothing to improve on
+        # Seed from the nearest already-solved feasible neighbour (smallest L1
+        # gap), falling back to the incumbent's continuous values.
+        seed_src = x_inc
+        best_gap = None
+        for key, cont in cont_at.items():
+            gap = sum(abs(combo[k] - key[k]) for k in range(n_int))
+            if best_gap is None or gap < best_gap:
+                best_gap, seed_src = gap, cont
+        seed = seed_src.copy()
+        for k, j in enumerate(int_idx):
+            seed[j] = float(combo[k])
+        found = subnlp(
+            model,
+            seed,
+            backend=backend,
+            nlp_options=nlp_options,
+            evaluator=evaluator,
+            integer_tol=integer_tol,
+            feas_tol=feas_tol,
+        )
+        if found is not None:
+            cont_at[combo] = np.asarray(found[0]).copy()
+            if best is None or found[1] < best[1]:
+                best = (np.asarray(found[0]).copy(), float(found[1]))
     return best
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -992,6 +992,20 @@ def _generate_starting_points(node_lb, node_ub, n_random=2):
         lb_clipped + 0.75 * span,  # upper-quarter
     ]
 
+    # Near-lower-bound start (small *absolute* offset, not a span fraction).
+    # Half-bounded variables (finite lb, +inf ub) get clipped to ``[lb, _SPC]``,
+    # so every span-fraction start (midpoint, quarters, randoms) lands tens of
+    # units above the lower bound -- a poor interior-point seed for flows /
+    # areas / temperatures whose natural feasible scale is O(1) near their lower
+    # bound (heatexch_gen3: the clip-midpoint seed plateaus constraint-
+    # infeasible at viol~3e-4, while a seed 0.1 above the lower bound converges
+    # to viol~4e-7). The absolute offset reaches feasibility where a 0.25-span
+    # offset (== lb+25 here) does not. Added once, tried before the random
+    # starts; multistart keeps the best constraint-feasible iterate, so this
+    # only ever adds a start -- it cannot worsen the returned point.
+    _near_lb_offset = np.minimum(0.1, 0.25 * np.where(span > 0.0, span, 0.1))
+    points.append(lb_clipped + _near_lb_offset)
+
     rng = np.random.RandomState(42)
     for _ in range(n_random):
         points.append(lb_clipped + rng.uniform(size=lb_clipped.shape) * span)
@@ -1008,6 +1022,7 @@ def _solve_root_node_multistart(
     nlp_solver,
     n_random=None,
     convex=False,
+    deadline=None,
 ):
     """Solve root NLP relaxation from multiple starting points.
 
@@ -1035,7 +1050,19 @@ def _solve_root_node_multistart(
     best_obj = np.inf
     last_result = None
 
-    for x0 in starting_points:
+    for _start_idx, x0 in enumerate(starting_points):
+        # Deadline enforcement: each NLP start is a full local solve (seconds on
+        # large models). Without a stop the multistart can run all ~N starts well
+        # past a tight ``time_limit`` (heatexch_gen3: 14 starts × ~4.4 s = 62 s
+        # under a 15 s budget). Always run the first start (we must return some
+        # iterate), then stop launching new starts once the deadline has passed,
+        # and shrink each start's own wall budget to the time actually left.
+        if deadline is not None and _start_idx > 0:
+            _ms_remaining = deadline - time.perf_counter()
+            if _ms_remaining <= 0.0:
+                break
+            options = dict(options)
+            options["max_wall_time"] = max(_ms_remaining, _DEADLINE_NODE_FLOOR_S)
         nlp_result = _solve_node_nlp(
             evaluator,
             x0,
@@ -1974,13 +2001,28 @@ def solve_model(
             "by 'pounce', a pure-Rust port of Ipopt.)"
         )
 
+    # Anchor the whole-solve clock HERE, before any reformulation / presolve /
+    # relaxation-build work — not at the B&B loop entry below. Preprocessing
+    # (root presolve, OBBT, relaxation build) can take tens of seconds on large
+    # models; counting it from a clock that only starts at the loop let a
+    # ``solve(time_limit=N)`` overrun to several×N. ``t_start`` is set to this
+    # anchor at the loop entry so every downstream deadline check
+    # (``now - t_start > time_limit``) and the reported wall time include the
+    # preprocessing, and ``_remaining_budget()`` lets each preprocessing phase
+    # clamp its own internal budget to the time actually left.
+    _solve_t0 = time.perf_counter()
+
+    def _remaining_budget() -> float:
+        return max(0.0, float(time_limit) - (time.perf_counter() - _solve_t0))
+
     # Reset the per-solve convexity-classification memo (a previous solve, or an
     # IIS feasibility probe, may have cached a verdict for a different constraint
     # set), and budget classification to a fraction of the time limit so it
     # cannot, on its own, overrun ``time_limit`` (issue: tens of seconds of
     # eigenvalue work on large quadratic models before search even starts).
     model._convexity_classification_cache = None
-    model._convexity_time_budget = min(max(0.2 * float(time_limit), 0.5), 20.0)
+    _convexity_time_budget = min(max(0.2 * float(time_limit), 0.5), 20.0)
+    model._convexity_time_budget = _convexity_time_budget
 
     # --- AMP (Adaptive Multivariate Partitioning) global solver ---
     _solver = solver if solver is not None else kwargs.pop("solver", None)
@@ -2364,6 +2406,14 @@ def solve_model(
             _prereform_model = model
             _prereform_nvars = sum(v.size for v in model._variables)
             model = factorable_reformulate(model)
+            # factorable_reformulate builds a FRESH model object that does not
+            # carry the convexity-classification budget attribute. Without this
+            # the dispatch classify below reads the 15 s default instead of the
+            # intended fraction of ``time_limit`` and can overrun a tight budget
+            # on the (larger) lifted model — heatexch_gen3: 12 s classify under a
+            # 15 s solve budget. Re-assert the budget (and clear any stale cache).
+            model._convexity_classification_cache = None
+            model._convexity_time_budget = _convexity_time_budget
         # A *convex* model with a clearable denominator is deliberately left
         # untouched here: many such divisions (e.g. the rotated-SOC ``x**2/z``)
         # are solved exactly by the convex NLP fast path, and clearing would
@@ -2393,11 +2443,22 @@ def solve_model(
                 run_root_presolve,
             )
 
+            # Cap presolve to a fraction of the time limit, further clamped to
+            # the time actually left. Without a cap the Rust orchestrator runs
+            # to its iteration cap (16 sweeps, ~1s each on large models), which
+            # on its own can overrun a tight ``time_limit`` before search starts
+            # (e.g. contvar: 17.5s of presolve under a 15s budget). The Rust
+            # side honours ``time_limit_ms`` between sweeps, so the overrun is
+            # bounded by a single sweep.
+            _presolve_budget_s = min(
+                min(max(0.25 * float(time_limit), 2.0), 30.0), _remaining_budget()
+            )
             _model_repr, _presolve_stats = run_root_presolve(
                 _model_repr,
                 eliminate=True,
                 polynomial=presolve_polynomial,
                 fbbt=True,
+                time_limit_ms=int(_presolve_budget_s * 1000),
             )
             n_tightened = propagate_bounds_to_model(model, _model_repr)
             elim = _presolve_stats.get("elimination", {})
@@ -2488,7 +2549,10 @@ def solve_model(
                 stacklevel=2,
             )
 
-    t_start = time.perf_counter()
+    # Anchor at the whole-solve clock (set before reformulation/presolve above)
+    # so every ``now - t_start > time_limit`` deadline check and the reported
+    # wall time account for the preprocessing already spent.
+    t_start = _solve_t0
     rust_time = 0.0
     jax_time = 0.0
 
@@ -2833,7 +2897,7 @@ def solve_model(
         try:
             from discopt._jax.obbt import obbt_tighten_root
 
-            _obbt_budget = min(max(time_limit * 0.1, 2.0), 15.0)
+            _obbt_budget = min(min(max(time_limit * 0.1, 2.0), 15.0), _remaining_budget())
             _obbt_res = obbt_tighten_root(
                 model,
                 lb,
@@ -3731,6 +3795,7 @@ def solve_model(
                         _active_cb,
                         opts,
                         nlp_solver,
+                        deadline=_deadline,
                     )
                 elif iteration > 0 and _node_nlp_due:
                     # Warm-start from parent solution if available
@@ -4131,6 +4196,7 @@ def solve_model(
                         max_rounds=5,
                         backend=_resolve_heuristic_backend(nlp_solver),
                         evaluator=evaluator,
+                        deadline=t_start + time_limit,
                     )
                     if fp_sol is not None:
                         fp_obj = float(evaluator.evaluate_objective(fp_sol))
@@ -4217,6 +4283,10 @@ def solve_model(
                             backend=_subnlp_backend_fn,
                             nlp_options=subnlp_options,
                             evaluator=evaluator,
+                            # Single root attempt (no loop): give it a fair budget
+                            # so it can converge to a feasible incumbent even if
+                            # preprocessing already consumed the deadline.
+                            time_budget=min(3.0, float(time_limit)),
                         )
                     except Exception as _e:
                         logger.debug("subnlp (gams seed) raised: %s", _e)
@@ -4248,6 +4318,10 @@ def solve_model(
                         backend=_subnlp_backend_fn,
                         nlp_options=subnlp_options,
                         evaluator=evaluator,
+                        # Single root fallback attempt (no loop): give it a fair
+                        # budget so it can converge even if preprocessing already
+                        # consumed the deadline.
+                        time_budget=min(3.0, float(time_limit)),
                     )
                 except Exception as _e:
                     logger.debug("subnlp raised: %s", _e)
@@ -4263,10 +4337,30 @@ def solve_model(
                 _try_idxs = (
                     [i for i, _ in _cands_sn] if iteration == 0 else [i for i, _ in _cands_sn[:1]]
                 )
-                for _i in _try_idxs:
+                for _loop_idx, _i in enumerate(_try_idxs):
                     if _subnlp_calls >= subnlp_max_calls:
                         break
+                    # Deadline enforcement: each subnlp is a round-and-repair NLP
+                    # search (seconds on large models). At the root ``_try_idxs``
+                    # can hold many candidates, so without a stop the loop runs
+                    # well past a tight ``time_limit``. Always attempt the first
+                    # candidate (a feasible incumbent is the primary goal, worth a
+                    # small overrun); only the *extra* candidates are deadline-gated
+                    # so the loop cannot run well past a tight ``time_limit``. Each
+                    # call's own wall budget is clamped to the time left (floored).
+                    _sn_remaining = _deadline - time.perf_counter()
+                    if _loop_idx > 0 and _sn_remaining <= 0.0:
+                        break
                     _subnlp_calls += 1
+                    # The first candidate gets a full (un-clamped) budget so one
+                    # NLP solve can actually converge to a feasible incumbent even
+                    # if the deadline just passed; later candidates are clamped to
+                    # the remaining time so the loop cannot keep overrunning.
+                    _sn_budget = (
+                        3.0
+                        if _loop_idx == 0
+                        else min(3.0, max(_DEADLINE_NODE_FLOOR_S, _sn_remaining))
+                    )
                     try:
                         _sn = _subnlp(
                             model,
@@ -4274,6 +4368,7 @@ def solve_model(
                             backend=_subnlp_backend_fn,
                             nlp_options=subnlp_options,
                             evaluator=evaluator,
+                            time_budget=_sn_budget,
                         )
                     except Exception as _e:
                         logger.debug("subnlp raised: %s", _e)
@@ -5130,6 +5225,7 @@ def _solve_nlp_bb(
                         opts,
                         nlp_solver,
                         convex=_model_is_convex,
+                        deadline=t_start + time_limit,
                     )
                 else:
                     psol_i = np.array(batch_psols[i])
@@ -5229,6 +5325,7 @@ def _solve_nlp_bb(
                         max_rounds=5,
                         backend=_resolve_heuristic_backend(nlp_solver),
                         evaluator=evaluator,
+                        deadline=t_start + time_limit,
                     )
                     if fp_sol is not None:
                         fp_obj = float(evaluator.evaluate_objective(fp_sol))

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3402,6 +3402,12 @@ def solve_model(
     _subnlp_calls = 0
     _subnlp_feasible = 0
     _subnlp_incumbent_updates = 0
+    # Best incumbent value the integer-neighbourhood box search has already been
+    # run from. The box search re-enumerates the integer lattice around the
+    # incumbent, so it is only worth re-running when the incumbent itself moved
+    # to a new integer assignment; tracking its objective avoids redundant
+    # re-enumeration of the same neighbourhood every scheduled iteration.
+    _last_box_inc_obj = np.inf
     # Best incumbent value the cutoff-tightening phases (C/C3) have already acted
     # on. They fire whenever the incumbent strictly improves below this — from
     # ANY source, including the sub-NLP / binary-seed heuristics that inject
@@ -4433,6 +4439,50 @@ def solve_model(
                     tree.inject_incumbent(_x_en.copy(), float(_obj_en))
                     _subnlp_incumbent_updates += 1
                     logger.info("SubNLP enum incumbent: obj=%.6g", _obj_en)
+
+        # --- Incumbent integer-neighbourhood search (general-integer LB) ---
+        # A feasible incumbent of a nonconvex general-integer model can sit next
+        # to a far better feasible integer assignment that no unit (1-opt/2-opt)
+        # violation-descent move reaches, because the connecting lattice path is
+        # objective-increasing or threads through infeasible cells (nvs05 parks at
+        # (3,2)->7.75 while the global (5,1)->5.47 is two coupled steps away over an
+        # objective-increasing ridge). When the relaxation drops the cross-terms
+        # that would supply a lower bound, B&B has nothing to steer it there in
+        # time. integer_box_search re-solves the fixed-integer sub-NLP over the
+        # +/-radius box around the incumbent with warm-start propagation, so the
+        # better assignment is found directly. Fire whenever the incumbent strictly
+        # improves to a new value (the ``_last_box_inc_obj`` guard is the throttle —
+        # NOT the subnlp iteration schedule, which can skip the window in which the
+        # improving incumbent first appears and was leaving the better assignment on
+        # the table on small instances that finish before the next scheduled tick).
+        if _subnlp_backend_fn is not None and not _model_is_convex:
+            _inc_box = tree.incumbent()
+            if (
+                _inc_box is not None
+                and np.isfinite(_inc_box[1])
+                and _inc_box[1] < _last_box_inc_obj - 1e-9
+            ):
+                _last_box_inc_obj = float(_inc_box[1])
+                from discopt._jax.primal_heuristics import integer_box_search
+
+                _box_budget = min(4.0, max(_DEADLINE_NODE_FLOOR_S, _deadline - time.perf_counter()))
+                try:
+                    _bx = integer_box_search(
+                        model,
+                        _inc_box[0],
+                        backend=_subnlp_backend_fn,
+                        nlp_options=subnlp_options,
+                        evaluator=evaluator,
+                        time_budget=_box_budget,
+                    )
+                except Exception as _e:
+                    logger.debug("integer_box_search raised: %s", _e)
+                    _bx = None
+                if _bx is not None and np.isfinite(_bx[1]) and _bx[1] < _inc_box[1] - 1e-9:
+                    tree.inject_incumbent(_bx[0].copy(), float(_bx[1]))
+                    _subnlp_incumbent_updates += 1
+                    _last_box_inc_obj = float(_bx[1])
+                    logger.info("Box-search incumbent: obj=%.6g (iter=%d)", _bx[1], iteration)
 
         # --- User callbacks: lazy constraints and incumbent filtering ---
         if lazy_constraints is not None or incumbent_callback is not None:


### PR DESCRIPTION
## Summary

Branch bundling time-budget enforcement, a repeatable global-optimization
benchmark harness, two solver correctness fixes found by running that harness
(BARON vs discopt), and the manuscript sections describing the corresponding
features.

## Commits

- **bench(global)** — repeatable discopt-vs-solver global-opt harnesses + make targets.
- **fix(solver)** — enforce the time budget across preprocessing and add a near-LB multistart seed.
- **docs(manuscript)** — MPEC, cutting-plane (RLT/SOC/moment-PSD), and geometric-program sections; expanded abstract; 13 BibTeX entries (all DOIs verified against CrossRef).
- **feat(amp)** — two global-opt fixes (below).

## AMP fixes (from the global-opt loop)

### tspn05 — multivariate-convex composite lift
TSP-with-neighbourhoods reported `feasible` with **no lower bound**: the objective
`sum sqrt((xi-xj)^2 + (xk-xl)^2) * x_m` could not be decomposed, so AMP fell back
to a feasibility objective. Two blockers closed:

- **Norm recognizer** (`patterns.py`): only matched homogeneous bare-square sums.
  Added `is_affine_norm_square` / `_affine_square_sum_matrix` so
  `sqrt(sum_i (a_i.x + b_i)^2) = ||A x + b||` certifies CONVEX for any affine map
  (sum-of-squares is PSD by construction; nonzero constant stays convex).
- **Composite lift** (`milp_relaxation.py`): lifts were hard-gated to
  single-variable nodes. Added `CompositeMultivarRelaxation` +
  `_collect_composite_multivar_relaxations`, a multivariate-convex gradient lift —
  aux column `d` registered into `composite_var_map` (so `d*x_m` decomposes via the
  existing McCormick envelope), with supporting-hyperplane underestimator cuts
  `d >= g(xk) + grad g(xk).(x - xk)` and a sound interval box-cap overestimator
  `d <= U`. Abstains when the enclosure is not finite; narrow claim predicate
  avoids duplicating existing builders.

**Result:** tspn05 now solves to **status `optimal`, obj 191.2552 (= global 191.255),
lb 191.2403, gap 7.8e-5, ~80 s** — previously `feasible`/`lb=None`/no proof.

### nvs05 — incumbent-triggered integer box search
Welded-beam MINLP parked at a non-global integer point. Added `integer_box_search`
(`primal_heuristics.py`): general-integer local branching with warm-start
propagation, gated `n_int <= 3` / grid `<= 128`, subnlp-verified, strict-improvement
only; wired into `solver.py` to fire on incumbent improvement.
**Result:** 5.470934 (global), ~15 s vs 200 s baseline.

### Other
`runner.py`: read `.nl` files with `errors='replace'` so a stray non-UTF-8 byte
in a vendored instance can't crash the whole sweep.

## Soundness & testing

- Lift verified numerically: 50k random box points, **0 cut violations** (tangents
  under-estimate, box cap over-estimates).
- `pytest -k "convex or relax or sqrt or norm or composite"` → **852 passed**;
  `-k "sound or certif or minlplib or global or correct"` → **532 passed**.
  Includes `test_cross_term_sqrt_soundness` (nvs05 5.47093),
  `test_unbounded_relaxation_soundness`, `test_himmel16_no_false_certification`.
  **0 failures.**
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
