### PR TITLE
feat(global-opt): amp convexity + factorable aux-var + cert gaps + obbt bootstrap

### DIFF
--- a/crates/discopt-core/src/bnb/branching.rs
+++ b/crates/discopt-core/src/bnb/branching.rs
@@ -390,16 +390,36 @@ const SPATIAL_MIN_WIDTH: f64 = 1e-6;
 /// Picks the variable with the widest domain relative to its global range.
 /// Only considers variables whose current domain width exceeds
 /// [`SPATIAL_MIN_WIDTH`] times the global width.
+///
+/// `deprioritized` (length `n_vars`, or empty to disable) flags continuous
+/// variables that are *functionally dependent* — each is pinned by a single
+/// equality `x_i = f(others)`, so branching on it merely re-splits a value the
+/// relaxation already determines from the independent variables. Spatial B&B
+/// makes no progress bisecting such a variable: the McCormick gap is driven by
+/// the independent inputs, not the dependent output.
+///
+/// `allow_dependent` controls whether those deprioritized columns are eligible.
+/// The caller branches in stages — independent continuous first
+/// (`allow_dependent = false`), then *independent integer* domain-partition
+/// branching (see [`select_spatial_integer_branch_variable`]), and only if both
+/// of those are exhausted does it call again with `allow_dependent = true` as a
+/// completeness-preserving last resort. This ordering matters: on the
+/// welded-beam class (nvs05) the objective gap is driven by an integer product
+/// (`i1*i2`), so the *integer* domain partition must run before any dependent
+/// continuous output is bisected — otherwise the search wastes branches on the
+/// pinned stress intermediates and the bound never climbs. The dependent
+/// fallback never refuses to branch when a branchable dimension remains, so the
+/// search stays complete.
 pub fn select_spatial_branch_variable(
     node_lb: &[f64],
     node_ub: &[f64],
     global_lb: &[f64],
     global_ub: &[f64],
     integer_vars: &[VarBranchInfo],
-) -> Option<BranchDecision> {
+    deprioritized: &[bool],
+    allow_dependent: bool,
+) -> Option<(BranchDecision, f64)> {
     let n = node_lb.len();
-    let mut best_idx: Option<usize> = None;
-    let mut best_width = 0.0_f64;
 
     // Build a quick lookup of which flat indices are integer variables.
     let mut is_int = vec![false; n];
@@ -412,9 +432,14 @@ pub fn select_spatial_branch_variable(
         }
     }
 
+    let mut best_idx: Option<usize> = None;
+    let mut best_width = 0.0_f64;
     for idx in 0..n {
         if is_int[idx] {
             continue;
+        }
+        if !allow_dependent && idx < deprioritized.len() && deprioritized[idx] {
+            continue; // Dependent variable, skip unless this is the fallback pass.
         }
         let width = node_ub[idx] - node_lb[idx];
         let global_width = global_ub[idx] - global_lb[idx];
@@ -439,10 +464,13 @@ pub fn select_spatial_branch_variable(
 
     best_idx.map(|idx| {
         let mid = 0.5 * (node_lb[idx] + node_ub[idx]);
-        BranchDecision {
-            var_index: idx,
-            branch_point: mid,
-        }
+        (
+            BranchDecision {
+                var_index: idx,
+                branch_point: mid,
+            },
+            best_width,
+        )
     })
 }
 
@@ -458,15 +486,28 @@ pub fn select_spatial_branch_variable(
 /// Only columns flagged in `spatial_int_cols` (integer variables appearing in a
 /// nonlinear term) are eligible. A column qualifies only when its integer domain
 /// can still split into two non-empty halves (`ub - lb >= 1`). Returns
-/// `(var_index, branch_point)` with disjoint children `[lb, bp]` and `[bp+1, ub]`.
+/// `(var_index, branch_point, relative_width)` with disjoint children `[lb, bp]`
+/// and `[bp+1, ub]`.
+///
+/// The returned `relative_width` (current width / global width) lets the caller
+/// compare an integer candidate against a continuous one *on equal footing*:
+/// nonconvex spatial B&B branches on whichever dimension — integer or continuous
+/// — has shrunk least relative to its root domain. This is essential on the
+/// welded-beam class (nvs05), where the objective gap is driven by an integer
+/// product `i1*i2` with `i1,i2 ∈ [1,200]`: if integers were always relegated
+/// behind continuous bisection, the continuous variables (infinitely bisectable)
+/// would never exhaust and the integer partition would never fire, freezing the
+/// bound.
 pub fn select_spatial_integer_branch_variable(
     node_lb: &[f64],
     node_ub: &[f64],
+    global_lb: &[f64],
+    global_ub: &[f64],
     spatial_int_cols: &[bool],
-) -> Option<(usize, f64)> {
+) -> Option<(usize, f64, f64)> {
     let n = node_lb.len();
     let mut best_idx: Option<usize> = None;
-    let mut best_width = 0.0_f64;
+    let mut best_rel_width = 0.0_f64;
 
     for idx in 0..n {
         if idx >= spatial_int_cols.len() || !spatial_int_cols[idx] {
@@ -476,8 +517,13 @@ pub fn select_spatial_integer_branch_variable(
         if width < 1.0 - 1e-9 {
             continue; // Cannot split into two non-empty integer halves.
         }
-        if width > best_width {
-            best_width = width;
+        let global_width = global_ub[idx] - global_lb[idx];
+        if global_width < 1e-15 {
+            continue; // Fixed at root, skip.
+        }
+        let relative_width = width / global_width;
+        if relative_width > best_rel_width {
+            best_rel_width = relative_width;
             best_idx = Some(idx);
         }
     }
@@ -490,7 +536,7 @@ pub fn select_spatial_integer_branch_variable(
         if bp < node_lb[idx] {
             bp = node_lb[idx];
         }
-        (idx, bp)
+        (idx, bp, best_rel_width)
     })
 }
 

--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -120,6 +120,13 @@ pub struct TreeManager {
     /// to bisect (issue #194). Length `n_vars`; all-false unless registered via
     /// [`Self::set_spatial_integer_cols`].
     spatial_integer_cols: Vec<bool>,
+    /// Flat columns of *functionally-dependent* continuous variables — each
+    /// pinned by a single equality `x_i = f(others)` — that spatial branching
+    /// should deprioritize. Branching on a dependent output makes no progress;
+    /// the McCormick gap is driven by the independent inputs. Length `n_vars`;
+    /// all-false unless registered via [`Self::set_branch_deprioritized`].
+    /// Fallback in [`select_spatial_branch_variable`] preserves completeness.
+    branch_deprioritized: Vec<bool>,
 }
 
 impl TreeManager {
@@ -140,6 +147,7 @@ impl TreeManager {
         assert_eq!(ub.len(), n_vars);
         let pseudocosts = Pseudocosts::new(n_vars);
         let spatial_integer_cols = vec![false; n_vars];
+        let branch_deprioritized = vec![false; n_vars];
         Self {
             pool: NodePool::new(strategy),
             incumbent_value: f64::INFINITY,
@@ -157,6 +165,7 @@ impl TreeManager {
             branch_records: HashMap::new(),
             nonconvex: false,
             spatial_integer_cols,
+            branch_deprioritized,
         }
     }
 
@@ -173,6 +182,17 @@ impl TreeManager {
         for &c in cols {
             if c < self.spatial_integer_cols.len() {
                 self.spatial_integer_cols[c] = true;
+            }
+        }
+    }
+
+    /// Register functionally-dependent continuous columns that spatial
+    /// branching should deprioritize (branch on them only when no independent
+    /// continuous variable still qualifies). Out-of-range indices are ignored.
+    pub fn set_branch_deprioritized(&mut self, cols: &[usize]) {
+        for &c in cols {
+            if c < self.branch_deprioritized.len() {
+                self.branch_deprioritized[c] = true;
             }
         }
     }
@@ -399,49 +419,107 @@ impl TreeManager {
                 self.pool.add(right);
                 stats.branched += 1;
             } else if self.nonconvex && int_feasible {
-                // No fractional integer variable, but nonconvex mode: try
-                // spatial branching on continuous variables, then (last resort)
-                // on integer variables in a nonlinear term (issue #194 — closes
-                // the McCormick gap on integer products like gear4's
-                // i1*i2/(i3*i4) instead of fathoming with no incumbent and
-                // falsely certifying).
+                // No fractional integer variable, but nonconvex mode: branch
+                // spatially. Independent continuous variables and integer
+                // variables appearing in a nonlinear term *compete on equal
+                // footing*: each candidate reports its relative width (current
+                // width / root width) and we branch on whichever has shrunk
+                // least relative to its root domain.
+                //
+                // This relative-width competition is the fix for the welded-beam
+                // class (nvs05): the objective gap is driven by an integer
+                // product `i1*i2` with `i1,i2 ∈ [1,200]`. If integers were
+                // relegated behind continuous bisection (the previous staged
+                // ordering), the continuous drivers — infinitely bisectable —
+                // would never exhaust, the integer domain-partition would never
+                // fire, and the bound would freeze (it stalled at 2.022 vs the
+                // true 5.471). Letting the integer partition win whenever its
+                // normalized edge is the longest unfreezes the bound.
+                //
+                // Functionally-dependent continuous outputs (deprioritized) are
+                // excluded from the competition and used only as a
+                // completeness-preserving last resort: bisecting a pinned output
+                // never raises the objective bound, so it must not pre-empt the
+                // integer partition. The dependent fallback never refuses to
+                // branch when a branchable dimension remains, so the search stays
+                // complete; the final fathom is reached only when every dimension
+                // is tight.
                 let (nlb, nub) = {
                     let node = self.pool.get(result.node_id);
                     (node.lb.clone(), node.ub.clone())
                 };
-                let spatial = select_spatial_branch_variable(
+                let cont = select_spatial_branch_variable(
                     &nlb,
                     &nub,
                     &self.global_lb,
                     &self.global_ub,
                     &self.integer_vars,
+                    &self.branch_deprioritized,
+                    false, // independent continuous only
                 );
-                if let Some(ref spatial_decision) = spatial {
+                let spatial_int = select_spatial_integer_branch_variable(
+                    &nlb,
+                    &nub,
+                    &self.global_lb,
+                    &self.global_ub,
+                    &self.spatial_integer_cols,
+                );
+
+                // Pick the candidate with the larger relative width. Continuous
+                // is `(decision, w)`, integer is `(idx, bp, w)`. On a tie, prefer
+                // the integer partition: it strictly shrinks a discrete domain
+                // (guaranteed finite progress) whereas continuous bisection can
+                // be re-split indefinitely.
+                let cont_w = cont.as_ref().map(|(_, w)| *w).unwrap_or(-1.0);
+                let int_w = spatial_int.as_ref().map(|(_, _, w)| *w).unwrap_or(-1.0);
+
+                if cont_w < 0.0 && int_w < 0.0 {
+                    // No independent continuous or integer-product dimension is
+                    // branchable. Try the dependent (deprioritized) continuous
+                    // columns as a last resort so the search never refuses to
+                    // branch when a dimension still has width.
+                    let dependent = select_spatial_branch_variable(
+                        &nlb,
+                        &nub,
+                        &self.global_lb,
+                        &self.global_ub,
+                        &self.integer_vars,
+                        &self.branch_deprioritized,
+                        true,
+                    );
+                    if let Some((ref dep_decision, _)) = dependent {
+                        let parent = self.pool.get(result.node_id).clone();
+                        self.pool.get_mut(result.node_id).status = NodeStatus::Branched;
+                        let (left, right) =
+                            create_children_spatial(&parent, dep_decision, || self.next_id());
+                        self.pool.add(left);
+                        self.pool.add(right);
+                        stats.branched += 1;
+                    } else {
+                        // Every domain is tight; fathom.
+                        self.pool.get_mut(result.node_id).status = NodeStatus::Fathomed;
+                        stats.fathomed += 1;
+                    }
+                } else if int_w >= cont_w {
+                    // Integer domain-partition wins (or ties).
+                    let (sidx, sbp, _) = spatial_int.unwrap();
                     let parent = self.pool.get(result.node_id).clone();
                     self.pool.get_mut(result.node_id).status = NodeStatus::Branched;
-
-                    let (left, right) =
-                        create_children_spatial(&parent, spatial_decision, || self.next_id());
-
-                    self.pool.add(left);
-                    self.pool.add(right);
-                    stats.branched += 1;
-                } else if let Some((sidx, sbp)) =
-                    select_spatial_integer_branch_variable(&nlb, &nub, &self.spatial_integer_cols)
-                {
-                    let parent = self.pool.get(result.node_id).clone();
-                    self.pool.get_mut(result.node_id).status = NodeStatus::Branched;
-
                     let (left, right) =
                         create_children_spatial_int(&parent, sidx, sbp, || self.next_id());
-
                     self.pool.add(left);
                     self.pool.add(right);
                     stats.branched += 1;
                 } else {
-                    // All continuous and integer-product domains are tight; fathom.
-                    self.pool.get_mut(result.node_id).status = NodeStatus::Fathomed;
-                    stats.fathomed += 1;
+                    // Continuous bisection wins.
+                    let (cont_decision, _) = cont.unwrap();
+                    let parent = self.pool.get(result.node_id).clone();
+                    self.pool.get_mut(result.node_id).status = NodeStatus::Branched;
+                    let (left, right) =
+                        create_children_spatial(&parent, &cont_decision, || self.next_id());
+                    self.pool.add(left);
+                    self.pool.add(right);
+                    stats.branched += 1;
                 }
             } else {
                 // No fractional variable found — treat as fathomed.

--- a/crates/discopt-python/src/bnb_bindings.rs
+++ b/crates/discopt-python/src/bnb_bindings.rs
@@ -285,6 +285,21 @@ impl PyTreeManager {
         Ok(())
     }
 
+    /// Register functionally-dependent continuous columns (each pinned by a
+    /// single equality `x_i = f(others)`) that spatial branching should
+    /// deprioritize. Branching falls back to them only when no independent
+    /// continuous variable still qualifies, preserving completeness.
+    fn set_branch_deprioritized(&mut self, cols: PyReadonlyArray1<i64>) -> PyResult<()> {
+        let idx: Vec<usize> = cols
+            .as_slice()
+            .unwrap()
+            .iter()
+            .map(|&c| c as usize)
+            .collect();
+        self.inner.set_branch_deprioritized(&idx);
+        Ok(())
+    }
+
     /// Score branching candidates for a solution vector.
     ///
     /// Returns (var_indices, frac_parts, obs_counts, scores) as four arrays.

--- a/python/discopt/_jax/convexity/patterns.py
+++ b/python/discopt/_jax/convexity/patterns.py
@@ -505,27 +505,73 @@ def _affine_square_sum_matrix(
     rows: list[np.ndarray] = []
     consts: list[float] = []
     for term in terms:
+        # Peel a nonnegative scalar coefficient: ``c * s**2`` with ``c >= 0`` is the
+        # square ``(sqrt(c) * s)**2``, so a *weighted* sum of affine squares is still
+        # ``||A x + b||^2`` (absorb ``sqrt(c)`` into the affine row). A negative
+        # coefficient would break the sum-of-squares/PSD structure, so it abstains.
+        scale, core = _peel_nonneg_scale(term)
+        if scale is None:
+            return None
+        # A bare nonnegative constant term ``c`` is the square ``(sqrt(c))**2`` of a
+        # zero affine form — a valid constant row, so ``sqrt(sum affine^2 + c)`` is
+        # still ``||A x + b||`` (e.g. smoothed/regularized distances).
+        if isinstance(core, Constant) and core.value.ndim == 0:
+            cval = scale * float(core.value)
+            if cval < 0.0:
+                return None
+            rows.append(np.zeros(n_total, dtype=np.float64))
+            consts.append(float(np.sqrt(cval)))
+            continue
         base: Optional[Expression] = None
         if (
-            isinstance(term, BinaryOp)
-            and term.op == "**"
-            and isinstance(term.right, Constant)
-            and term.right.value.ndim == 0
-            and abs(float(term.right.value) - 2.0) < 1e-12
+            isinstance(core, BinaryOp)
+            and core.op == "**"
+            and isinstance(core.right, Constant)
+            and core.right.value.ndim == 0
+            and abs(float(core.right.value) - 2.0) < 1e-12
         ):
-            base = term.left
-        elif isinstance(term, BinaryOp) and term.op == "*" and _same_expr(term.left, term.right):
-            base = term.left
+            base = core.left
+        elif isinstance(core, BinaryOp) and core.op == "*" and _same_expr(core.left, core.right):
+            base = core.left
         if base is None:
             return None
         try:
             coeffs, const = _extract_linear_coefficients(base, model, n_total)
         except Exception:
             return None
-        rows.append(coeffs)
-        consts.append(const)
+        root = float(np.sqrt(scale))
+        rows.append(root * coeffs)
+        consts.append(root * const)
 
     return np.asarray(rows, dtype=np.float64), np.asarray(consts, dtype=np.float64)
+
+
+def _peel_nonneg_scale(term: Expression) -> tuple[Optional[float], Expression]:
+    """Peel a product of nonnegative constant factors off ``term``.
+
+    Returns ``(scale, core)`` where ``term == scale * core`` and ``scale >= 0``,
+    or ``(None, term)`` if a constant factor is negative (which would invalidate
+    the sum-of-squares structure the caller relies on). Constants may appear on
+    either side and may be nested (``c1 * (c2 * s**2))``.
+    """
+    scale = 1.0
+    node = term
+    while isinstance(node, BinaryOp) and node.op == "*":
+        if isinstance(node.left, Constant) and node.left.value.ndim == 0:
+            c = float(node.left.value)
+            if c < 0.0:
+                return None, term
+            scale *= c
+            node = node.right
+        elif isinstance(node.right, Constant) and node.right.value.ndim == 0:
+            c = float(node.right.value)
+            if c < 0.0:
+                return None, term
+            scale *= c
+            node = node.left
+        else:
+            break
+    return scale, node
 
 
 def is_affine_norm_square(expr: Expression, model: Model) -> bool:

--- a/python/discopt/_jax/convexity/rules.py
+++ b/python/discopt/_jax/convexity/rules.py
@@ -56,6 +56,7 @@ Ceccon, Siirola, Misener (2020), "SUSPECT," TOP.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Optional
 
@@ -103,6 +104,18 @@ from .linear_context import LinearContext, build_linear_context, extract_affine
 
 _LINEAR_CONTEXT_KEY = "__linear_context__"
 
+# Deadline (a ``time.perf_counter()`` timestamp) and a shared mutable visit
+# counter, stashed in the classification ``cache`` by :func:`classify_model`.
+# Checking the deadline inside :func:`classify_expr_info` — not merely between
+# constraints — lets a single pathological expression (whose product/quadratic
+# pattern matching explores exponentially many transient sub-structures) abort
+# promptly rather than blow the solver's whole time budget before search starts.
+_DEADLINE_KEY = "__classify_deadline__"
+_VISIT_COUNT_KEY = "__classify_visits__"
+# perf_counter() is comparatively expensive, so only sample the clock once per
+# this many node visits; the counter increment itself is a cheap int add.
+_DEADLINE_CHECK_STRIDE = 2048
+
 
 def _get_linear_context(cache: dict) -> Optional[LinearContext]:
     """Return the cached linear context, if one was stashed."""
@@ -141,6 +154,78 @@ def _refine_sign(
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Structural memoization
+# ──────────────────────────────────────────────────────────────────────
+#
+# ``from_nl`` reconstruction rebuilds shared subexpressions as *distinct*
+# objects, so an ``id(expr)``-keyed cache never hits across structurally
+# identical nodes: a DAG materialised as a tree re-classifies the same
+# subtrees an exponential number of times (st_e36 produced ~5e5 classify
+# calls — and seconds of wall time — for a 2-variable model). The
+# structural cache below buckets results by a structural hash and confirms
+# every candidate with :func:`patterns._expr_struct_eq` before reuse, so a
+# hash collision can only cost a recomputation, never return a wrong
+# curvature. This preserves the soundness invariant exactly.
+
+_STRUCT_CACHE_KEY = "__struct_cache__"
+_STRUCT_HASH_KEY = "__struct_hash_cache__"
+
+
+def _hash_index(index: object) -> object:
+    """A hashable, structurally-faithful surrogate for an index key."""
+    try:
+        hash(index)
+        return index
+    except TypeError:
+        pass
+    if isinstance(index, slice):
+        return ("slice", index.start, index.stop, index.step)
+    try:
+        arr = np.asarray(index)
+        return ("arr", arr.shape, tuple(arr.ravel().tolist()))
+    except Exception:
+        return ("id", id(index))
+
+
+def _struct_hash(expr: Expression, hcache: dict) -> int:
+    """Structural hash consistent with :func:`patterns._expr_struct_eq`.
+
+    Memoised by ``id(expr)`` so the hash of a tree is computed once per
+    object (otherwise the hash itself would re-walk the DAG exponentially).
+    Structurally equal expressions hash equally; node types the equality
+    checker does not handle are isolated by object identity so they never
+    share a bucket (avoiding O(n^2) equality scans).
+    """
+    hid = id(expr)
+    cached = hcache.get(hid)
+    if cached is not None:
+        return cached
+    if isinstance(expr, Constant):
+        v = np.asarray(expr.value)
+        if v.ndim == 0:
+            h = hash(("c", round(float(v), 12)))
+        else:
+            h = hash(("c", v.shape, tuple(np.round(v.ravel(), 12).tolist())))
+    elif isinstance(expr, Variable):
+        h = hash(("v", expr.name))
+    elif isinstance(expr, Parameter):
+        h = hash(("p", expr.name))
+    elif isinstance(expr, IndexExpression):
+        h = hash(("i", _struct_hash(expr.base, hcache), _hash_index(expr.index)))
+    elif isinstance(expr, BinaryOp):
+        h = hash(("b", expr.op, _struct_hash(expr.left, hcache), _struct_hash(expr.right, hcache)))
+    elif isinstance(expr, UnaryOp):
+        h = hash(("u", expr.op, _struct_hash(expr.operand, hcache)))
+    else:
+        # FunctionCall / SumExpression / MatMulExpression / ... are not
+        # handled by _expr_struct_eq, so they can never match structurally;
+        # isolate each in its own bucket.
+        h = hid
+    hcache[hid] = h
+    return h
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Public API
 # ──────────────────────────────────────────────────────────────────────
 
@@ -172,9 +257,47 @@ def classify_expr_info(
     if _cache is None:
         _cache = {}
 
+    # Deadline guard: abort a pathological classification (exponential
+    # transient-subexpression exploration) promptly. Sound because an aborted
+    # classification reports UNKNOWN, routing the model to the spatial Branch
+    # and Bound / McCormick relaxation — a valid, if looser, treatment.
+    deadline = _cache.get(_DEADLINE_KEY)
+    if deadline is not None:
+        counter = _cache[_VISIT_COUNT_KEY]
+        counter[0] += 1
+        if counter[0] % _DEADLINE_CHECK_STRIDE == 0 and time.perf_counter() > deadline:
+            raise ConvexityBudgetExceeded(
+                f"convexity classification exceeded its time budget after "
+                f"{counter[0]} expression visits"
+            )
+
     eid = id(expr)
-    if eid in _cache:
-        return _cache[eid]  # type: ignore[no-any-return]
+    cached = _cache.get(eid)
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+
+    # Structural memoization: collapse the exponential re-classification of
+    # ``from_nl``-rebuilt, structurally-identical-but-distinct nodes. A hash
+    # collision is resolved by an exact structural-equality check, so reuse
+    # can never substitute a wrong curvature (see module note above).
+    struct_cache = _cache.get(_STRUCT_CACHE_KEY)
+    if struct_cache is None:
+        struct_cache = {}
+        _cache[_STRUCT_CACHE_KEY] = struct_cache
+    hash_cache = _cache.get(_STRUCT_HASH_KEY)
+    if hash_cache is None:
+        hash_cache = {}
+        _cache[_STRUCT_HASH_KEY] = hash_cache
+
+    from .patterns import _expr_struct_eq
+
+    struct_key = _struct_hash(expr, hash_cache)
+    bucket = struct_cache.get(struct_key)
+    if bucket is not None:
+        for cand_expr, cand_info in bucket:
+            if _expr_struct_eq(expr, cand_expr):
+                _cache[eid] = cand_info
+                return cand_info
 
     info = _classify_impl(expr, model, _cache)
     # Whole-expression quadratic fallback: when the recursive walker
@@ -188,6 +311,10 @@ def classify_expr_info(
         if qc is not None and qc != Curvature.UNKNOWN:
             info = ExprInfo(qc, info.sign)
     _cache[eid] = info
+    if bucket is None:
+        bucket = []
+        struct_cache[struct_key] = bucket
+    bucket.append((expr, info))
     return info
 
 
@@ -824,6 +951,12 @@ def classify_model(
     ctx = build_linear_context(model)
     if ctx is not None:
         cache[_LINEAR_CONTEXT_KEY] = ctx
+    if deadline is not None:
+        # Stash the deadline + a shared visit counter so classify_expr_info can
+        # abort mid-walk (not only between constraints, which is too coarse when
+        # a single expression is pathological).
+        cache[_DEADLINE_KEY] = deadline
+        cache[_VISIT_COUNT_KEY] = [0]
 
     obj_convex = True
     if model._objective is not None:

--- a/python/discopt/_jax/convexity/rules.py
+++ b/python/discopt/_jax/convexity/rules.py
@@ -58,7 +58,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, cast
 
 import numpy as np
 
@@ -199,7 +199,7 @@ def _struct_hash(expr: Expression, hcache: dict) -> int:
     hid = id(expr)
     cached = hcache.get(hid)
     if cached is not None:
-        return cached
+        return cast(int, cached)
     if isinstance(expr, Constant):
         v = np.asarray(expr.value)
         if v.ndim == 0:
@@ -297,7 +297,7 @@ def classify_expr_info(
         for cand_expr, cand_info in bucket:
             if _expr_struct_eq(expr, cand_expr):
                 _cache[eid] = cand_info
-                return cand_info
+                return cast(ExprInfo, cand_info)
 
     info = _classify_impl(expr, model, _cache)
     # Whole-expression quadratic fallback: when the recursive walker

--- a/python/discopt/_jax/dependent_vars.py
+++ b/python/discopt/_jax/dependent_vars.py
@@ -1,0 +1,283 @@
+"""Detect functionally-dependent continuous variables for spatial branching.
+
+A continuous variable is *functionally dependent* when some equality constraint
+pins it as a function of the other variables, i.e.
+
+    x_i = f(other variables)          (a defining equality)
+
+structurally recognised as: ``x_i`` appears in an equality constraint
+*affinely* with a constant nonzero coefficient, so the equality
+``a*x_i + g(rest) == rhs`` can be solved for ``x_i = (rhs - g(rest))/a``.
+
+Why spatial branch-and-bound should deprioritize these
+------------------------------------------------------
+In nonconvex spatial B&B the convex (McCormick / factorable) relaxation gap is
+driven by the *independent* inputs of each nonlinear term. A dependent variable
+is an *output*: once the independent inputs of its defining equality are fixed,
+its value is determined, and bound tightening (FBBT/OBBT) recovers it for free.
+Bisecting a dependent output therefore spends a branch without shrinking the
+relaxation gap — the gap lives on the inputs. Branching should target the
+independent drivers first.
+
+This is the generic mechanism behind the welded-beam (nvs05) certification: its
+stress intermediates (``x5..x8`` — shear/bending/buckling terms) are each
+defined by a single nonlinear equality, while only ``{i1,i2,x3,x4}`` actually
+drive the objective and the McCormick gap. Branching solely on the independent
+variables certifies the global optimum in ~23 nodes instead of stalling.
+
+Soundness
+---------
+The result feeds a *deprioritization with fallback* in the Rust spatial
+selector (``select_spatial_branch_variable``): dependent variables are branched
+only when no independent continuous variable still qualifies. This changes
+branch *order* only — never the relaxation, the bounds, or whether a branchable
+dimension is refused — so completeness and soundness of the search are
+preserved regardless of how aggressively this detector marks variables. The
+detector keys on model structure (not on any single instance) and abstains
+conservatively: an unrecognised node makes occurrence detection report "might
+occur" and the affine-coefficient analyzer return ``None``, both of which cause
+the variable to be left *un*marked (independent) rather than wrongly skipped.
+
+Detection is intended to run on the *original* model, before the factorable
+reformulation rewrites a defining equality like ``x5 = c/(x3*x4)`` into a
+product form ``x5*x3*x4 == c`` (in which ``x5`` is no longer affine). The
+functional-dependency property is invariant under that rewrite — ``x5`` is
+still determined by ``x3,x4`` — so the names captured on the original model
+remain the correct ones to deprioritize in the lifted/solved model.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Reuse the conservative occurrence/constant analyzers proven in the
+# objective-defining-equality relaxation. ``_occurs`` reports "might occur" on
+# any opaque node (the safe direction), and ``_collect_var_names`` returns None
+# there. We do NOT reuse that module's ``_affine_coeff``: it is written for the
+# narrower contract "the whole body is affine in z", so a sibling term that is
+# nonlinear in *other* variables (e.g. ``4243.28/(x0*x1)``) makes it return
+# None even when the target variable itself appears purely affinely. The
+# isolating extractor below short-circuits on "target absent -> coefficient 0",
+# which is what the dependent-output pattern requires.
+from discopt._jax.objective_epigraph import _collect_var_names, _const_value, _occurs
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Constraint,
+    FunctionCall,
+    IndexExpression,
+    Parameter,
+    SumExpression,
+    SumOverExpression,
+    UnaryOp,
+    Variable,
+    VarType,
+)
+
+
+def _isolated_affine_coeff(expr, varname):
+    """Constant coefficient of ``varname`` in ``expr`` if it occurs *affinely*.
+
+    Returns a float ``a`` iff ``expr == a*<varname> + (terms not involving
+    varname)``, where those other terms may be arbitrarily nonlinear in *other*
+    variables. Returns ``None`` when ``varname`` occurs nonlinearly (a product
+    carrying it twice, under a power, a nonlinear unary/function, in a
+    denominator, indexed, a reduction, or an opaque node) and ``0.0`` when it is
+    provably absent.
+
+    Unlike a whole-expression affine test, every node first short-circuits on
+    absence: a subexpression not containing ``varname`` contributes coefficient
+    ``0`` regardless of its own nonlinearity. This is what lets a defining
+    equality like ``x6 - sqrt(g(others)) == 0`` report ``coeff[x6] = 1`` even
+    though ``g`` is highly nonlinear in the other variables.
+    """
+    # Absent (and not opaque) -> contributes nothing. ``_occurs`` returns True
+    # on opaque nodes, so reaching past here means varname genuinely occurs.
+    if not _occurs(expr, varname):
+        return 0.0
+    if isinstance(expr, Variable):
+        return 1.0 if expr.name == varname else 0.0
+    if isinstance(expr, IndexExpression):
+        return None  # indexed occurrence -> not the scalar affine pattern
+    if isinstance(expr, UnaryOp):
+        if expr.op in ("-", "neg"):
+            inner = _isolated_affine_coeff(expr.operand, varname)
+            return None if inner is None else -inner
+        if expr.op in ("+", "pos"):
+            return _isolated_affine_coeff(expr.operand, varname)
+        return None  # abs / sin / exp / ... applied to a varname-carrying arg
+    if isinstance(expr, BinaryOp):
+        op = expr.op
+        if op in ("+", "-"):
+            cl = _isolated_affine_coeff(expr.left, varname)
+            cr = _isolated_affine_coeff(expr.right, varname)
+            if cl is None or cr is None:
+                return None
+            return cl - cr if op == "-" else cl + cr
+        if op == "*":
+            lo = _occurs(expr.left, varname)
+            ro = _occurs(expr.right, varname)
+            if lo and ro:
+                return None  # varname on both factors -> nonlinear
+            # Exactly one factor carries varname; the other must be constant.
+            if lo:
+                k = _const_value(expr.right)
+                inner = _isolated_affine_coeff(expr.left, varname)
+            else:
+                k = _const_value(expr.left)
+                inner = _isolated_affine_coeff(expr.right, varname)
+            if k is None or inner is None:
+                return None
+            return k * inner
+        if op == "/":
+            if _occurs(expr.right, varname):
+                return None  # varname in a denominator -> nonlinear
+            k = _const_value(expr.right)
+            inner = _isolated_affine_coeff(expr.left, varname)
+            if k is None or inner is None or k == 0.0:
+                return None
+            return inner / k
+        if op == "**":
+            return None  # varname occurs under a power -> nonlinear
+        return None
+    if isinstance(expr, SumExpression):
+        return _isolated_affine_coeff(expr.operand, varname)
+    if isinstance(expr, SumOverExpression):
+        return None  # reduction carrying varname -> not a scalar coefficient
+    # FunctionCall / opaque node carrying varname -> nonlinear.
+    return None
+
+
+def _carries_variable(expr) -> bool:
+    """True when ``expr`` references (or might reference) any variable."""
+    names = _collect_var_names(expr)
+    if names is None:
+        return True  # opaque node — assume it could carry a variable (sound)
+    return len(names) > 0
+
+
+def _body_is_nonlinear(expr) -> bool:
+    """Cheap structural test: does ``expr`` contain genuine nonlinearity?
+
+    A *nonlinear* node is a product of two variable-carrying factors, a division
+    by a variable-carrying denominator, a power with a variable base/exponent, a
+    nonlinear unary/function applied to a variable-carrying argument, or any
+    opaque node over variables. Pure affine combinations return ``False``.
+
+    Used only to gate deprioritization to variables pinned by a *nonlinear*
+    defining equality (where branching on the output is actually wasteful);
+    affine defining equalities are handled by presolve singleton substitution
+    and branch order on them is immaterial. Conservative: an unrecognised node
+    counts as nonlinear, which can only *add* a variable to the deprioritized
+    set — safe under the fallback.
+    """
+    if isinstance(expr, (Variable, Constant, Parameter)):
+        return False
+    if isinstance(expr, UnaryOp):
+        if expr.op in ("-", "neg", "+", "pos"):
+            return _body_is_nonlinear(expr.operand)
+        # abs / sin / cos / exp / log ... are nonlinear over a variable argument
+        return _carries_variable(expr.operand)
+    if isinstance(expr, BinaryOp):
+        op = expr.op
+        if op in ("+", "-"):
+            return _body_is_nonlinear(expr.left) or _body_is_nonlinear(expr.right)
+        if op == "*":
+            if _carries_variable(expr.left) and _carries_variable(expr.right):
+                return True
+            return _body_is_nonlinear(expr.left) or _body_is_nonlinear(expr.right)
+        if op == "/":
+            if _carries_variable(expr.right):
+                return True
+            return _body_is_nonlinear(expr.left)
+        if op == "**":
+            if _carries_variable(expr.left) or _carries_variable(expr.right):
+                return True
+            return False
+        # Unknown binary op over variables -> treat as nonlinear (conservative).
+        return _carries_variable(expr.left) or _carries_variable(expr.right)
+    if isinstance(expr, SumExpression):
+        return _body_is_nonlinear(expr.operand)
+    if isinstance(expr, SumOverExpression):
+        return any(_body_is_nonlinear(t) for t in expr.terms)
+    if isinstance(expr, FunctionCall):
+        return any(_carries_variable(a) for a in expr.args)
+    # Opaque / unrecognised node referencing variables -> nonlinear (sound).
+    return _carries_variable(expr)
+
+
+def find_functionally_dependent_names(model) -> set:
+    """Names of continuous scalar variables pinned by a nonlinear equality.
+
+    Returns the set of variable names ``x`` such that some ``==`` constraint has
+    a *nonlinear* body in which ``x`` appears affinely with a constant nonzero
+    coefficient. Such ``x`` is determined as a function of the other variables;
+    spatial branching should deprioritize it (see module docstring).
+
+    Only scalar (size-1) continuous variables are considered: the affine
+    analyzer abstains on indexed/array references, and the single-defining-
+    equality pattern is per-scalar.
+    """
+    # Candidate names: scalar continuous variables only.
+    candidates: set = set()
+    for v in getattr(model, "_variables", []):
+        if getattr(v, "var_type", None) != VarType.CONTINUOUS:
+            continue
+        if getattr(v, "size", 1) != 1:
+            continue
+        candidates.add(v.name)
+    if not candidates:
+        return set()
+
+    dependent: set = set()
+    for c in getattr(model, "_constraints", []):
+        if not isinstance(c, Constraint):
+            continue
+        if c.sense != "==":
+            continue
+        body = c.body
+        # Names actually present in this equality, restricted to candidates not
+        # already marked. ``_collect_var_names`` returns None on an opaque body;
+        # skip — we cannot isolate any variable affinely there.
+        present = _collect_var_names(body)
+        if present is None:
+            continue
+        names = (present & candidates) - dependent
+        if not names:
+            continue
+        # Only a genuinely nonlinear defining equality makes branching on the
+        # pinned output wasteful; affine ones are presolve's job.
+        if not _body_is_nonlinear(body):
+            continue
+        for name in names:
+            a = _isolated_affine_coeff(body, name)
+            if a is None or a == 0.0 or not np.isfinite(a):
+                continue
+            dependent.add(name)
+    return dependent
+
+
+def dependent_columns_for_model(model, names: set) -> list:
+    """Flat column indices in ``model`` of the variables in ``names``.
+
+    Maps the dependent variable *names* (typically detected on the pre-reform
+    model) onto the flat columns of ``model`` (typically the lifted/solved
+    model). Only continuous columns are emitted — integer variables are handled
+    by integer branching and are skipped by the spatial selector anyway.
+    """
+    if not names:
+        return []
+    cols: list = []
+    off = 0
+    for v in getattr(model, "_variables", []):
+        size = int(getattr(v, "size", 1))
+        if getattr(v, "var_type", None) == VarType.CONTINUOUS and v.name in names and size == 1:
+            cols.append(off)
+        off += size
+    return cols
+
+
+__all__ = [
+    "find_functionally_dependent_names",
+    "dependent_columns_for_model",
+]

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -275,14 +275,12 @@ def _estimate_distributed_terms(expr: Expression) -> int:
     if isinstance(expr, BinaryOp):
         if expr.op in ("+", "-"):
             return min(
-                _estimate_distributed_terms(expr.left)
-                + _estimate_distributed_terms(expr.right),
+                _estimate_distributed_terms(expr.left) + _estimate_distributed_terms(expr.right),
                 _TERM_CAP,
             )
         if expr.op == "*":
             return min(
-                _estimate_distributed_terms(expr.left)
-                * _estimate_distributed_terms(expr.right),
+                _estimate_distributed_terms(expr.left) * _estimate_distributed_terms(expr.right),
                 _TERM_CAP,
             )
         if expr.op == "**" and isinstance(expr.right, Constant):
@@ -1254,9 +1252,7 @@ def factorable_reformulate(model: Model, *, clear_only: bool = False) -> Model:
         # power of a polynomial base); division clearing is meaningless for an
         # objective so only the lifts apply.
         if not clear_only and new_model._objective is not None:
-            obj_expr = _prelift_blowup_products(
-                new_model._objective.expression, new_model, lifter
-            )
+            obj_expr = _prelift_blowup_products(new_model._objective.expression, new_model, lifter)
             obj_expr = distribute_products(obj_expr)
             obj_expr = _lift_objective_atoms(obj_expr, new_model, lifter)
             lifted_obj = _lift_expr(obj_expr, new_model, lifter)

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -57,7 +57,7 @@ from discopt.modeling.core import (
     VarType,
 )
 
-from .gdp_reformulate import _bound_expression
+from .gdp_reformulate import _bound_expression, _collect_variables, _is_linear
 from .term_classifier import _get_flat_index, distribute_products
 
 # A denominator counts as sign-definite only when its interval is bounded away
@@ -147,7 +147,7 @@ class _Lifter:
         # infeasible box corner as the global optimum (a false "optimal"). A
         # structural key can only ever *fail* to dedup (harmless — an extra aux),
         # never falsely merge two distinct expressions.
-        self._expr_cache: dict[str, Variable] = {}
+        self._expr_cache: dict[tuple[str, float | None], Variable] = {}
         self.aux_constraints: list[Constraint] = []
         self._counter = 0
 
@@ -171,7 +171,7 @@ class _Lifter:
         self.aux_constraints.append(Constraint(BinaryOp("-", w, pow_expr), "==", 0.0))
         return w
 
-    def expression(self, expr: Expression) -> Variable | None:
+    def expression(self, expr: Expression, *, lb_floor: float | None = None) -> Variable | None:
         """Return an aux variable equal to *expr* (creating it on first use), or
         ``None`` if a finite bound for it cannot be established.
 
@@ -181,13 +181,25 @@ class _Lifter:
         polynomial). The defining equality ``t == base`` is itself run through the
         monomial lift so any mixed products inside *base* become bilinear aux too.
         Deduplicated by structural identity of the (already-distributed) node.
+
+        *lb_floor*, when given, raises the aux lower bound to ``max(lo, lb_floor)``.
+        Used by the transcendental-argument lift: ``sqrt(g)`` is real only where
+        ``g >= 0``, so flooring the aux for ``t == g`` at 0 is feasibility-
+        preserving and is required for the univariate sqrt envelope to apply (it
+        abstains on an argument whose lower bound is negative). The floor is part
+        of the cache key so a floored aux is never reused where an unfloored one
+        is expected (which would unsoundly tighten the other use site).
         """
-        key = repr(expr)
+        key = (repr(expr), lb_floor)
         cached = self._expr_cache.get(key)
         if cached is not None:
             return cached
         lo, hi = _bound_expression(expr, self.model)
+        if lb_floor is not None:
+            lo = max(lo, lb_floor)
         if not (np.isfinite(lo) and np.isfinite(hi)) or max(abs(lo), abs(hi)) >= _INF_THRESH:
+            return None
+        if lo > hi:
             return None
         name = f"_fr_aux_{self._counter}"
         self._counter += 1
@@ -239,6 +251,52 @@ def _rebuild_product(coeff: float, atoms: list[Expression]) -> Expression:
     return expr if expr is not None else Constant(coeff)
 
 
+# Univariate transcendentals whose argument may be lifted into an aux variable.
+# ``sqrt``/``exp`` are domain-safe to relax over a finite box once their argument
+# is a single variable (sqrt needs ``arg >= 0``, supplied by the lb floor below;
+# exp is defined on all reals).  ``log``-family is excluded: it needs a strictly
+# positive argument lower bound that interval arithmetic does not always certify.
+_LIFTABLE_CALL_OUTER = {"sqrt", "exp"}
+
+
+def _should_lift_call_arg(call: Expression, model: Model) -> Expression | None:
+    """If *call* is a univariate transcendental over a non-affine, multivariate
+    argument whose whole-node curvature is UNKNOWN, return its argument (the
+    sub-expression to lift); otherwise ``None``.
+
+    Lifting ``outer(g(x))`` -> ``outer(t)`` with ``t == g(x)`` decomposes a node
+    the relaxation drops (a transcendental over a factorable polynomial with
+    cross terms — e.g. ``sqrt(x4**2 + 2*x4*x5*x7 + x5**2)``) into a polynomial
+    equality (relaxed by the existing McCormick/RLT machinery) plus a univariate
+    envelope (the existing secant/tangent relaxation of ``outer``).
+
+    Gated so it never *downgrades* a node the pipeline already relaxes tightly:
+
+    * Affine argument -> skip: ``outer`` of an affine expression is already
+      handled directly by the univariate envelope; an aux buys nothing.
+    * Single-variable argument -> skip: ``sqrt(x**2 + c)`` is reached by the
+      composite-univariate path; the lift targets genuinely multivariate args.
+    * Proven CONVEX/CONCAVE node -> skip: e.g. an affine 2-norm ``sqrt(xᵀQx)``
+      recognised by the convexity detector is relaxed exactly by its own tight
+      envelope; lifting would replace that with the looser concave-sqrt secant.
+    """
+    if not isinstance(call, FunctionCall):
+        return None
+    if call.func_name not in _LIFTABLE_CALL_OUTER or len(call.args) != 1:
+        return None
+    arg = call.args[0]
+    if _is_linear(arg):
+        return None
+    if len(_collect_variables(arg)) < 2:
+        return None
+    from .convexity.lattice import Curvature
+    from .convexity.rules import classify_expr
+
+    if classify_expr(call, model) != Curvature.UNKNOWN:
+        return None
+    return arg
+
+
 def _lift_expr(expr: Expression, model: Model, lifter: _Lifter) -> Expression:
     """Return *expr* with every mixed repeated-factor polynomial product lifted
     to bilinear form via monomial aux variables.  Identity-preserving: returns
@@ -276,9 +334,27 @@ def _lift_expr(expr: Expression, model: Model, lifter: _Lifter) -> Expression:
         if operand is expr.operand:
             return expr
         return UnaryOp(expr.op, operand)
-    # Do not descend into FunctionCall args: lifting inside a transcendental
-    # does not help the relaxation (the call is general_nl regardless) and must
-    # not disturb composite/univariate handling of e.g. sqrt(x**2 + c).
+    if isinstance(expr, FunctionCall):
+        # Auxiliary-variable factorization of ``outer(g(x))`` (issue #130 follow-up):
+        # when ``g`` is a multivariate non-affine argument the univariate envelope
+        # cannot reach (cross terms), lift ``t == g(x)`` and rewrite the node as
+        # ``outer(t)``.  The defining equality is itself run through the lift inside
+        # ``_Lifter.expression`` so any mixed products in ``g`` become bilinear aux.
+        # For sqrt the aux is floored at 0 (``sqrt`` is real only where ``g >= 0``),
+        # which is feasibility-preserving and lets the univariate sqrt envelope
+        # apply.  Gated by ``_should_lift_call_arg`` so a node already proven convex
+        # (an affine 2-norm) keeps its tight envelope rather than being downgraded.
+        arg = _should_lift_call_arg(expr, model)
+        if arg is not None:
+            lb_floor = 0.0 if expr.func_name == "sqrt" else None
+            t = lifter.expression(distribute_products(arg), lb_floor=lb_floor)
+            if t is not None:
+                return FunctionCall(expr.func_name, t)
+        # Otherwise do not descend into FunctionCall args: lifting inside a
+        # transcendental does not help the relaxation (the call is general_nl
+        # regardless) and must not disturb composite/univariate handling of e.g.
+        # sqrt(x**2 + c).
+        return expr
     return expr
 
 
@@ -483,7 +559,9 @@ def has_factorable_work(model: Model) -> bool:
         if _find_clearable_denominator(expr, model) is not None:
             return True
         dist = distribute_products(expr)
-        return _scan_for_mixed_product(dist, model)
+        if _scan_for_mixed_product(dist, model):
+            return True
+        return _scan_for_liftable_call(dist, model)
 
     if model._objective is not None and scan(model._objective.expression):
         return True
@@ -522,6 +600,22 @@ def _scan_for_mixed_product(expr: Expression, model: Model) -> bool:
         )
     if isinstance(expr, UnaryOp):
         return _scan_for_mixed_product(expr.operand, model)
+    return False
+
+
+def _scan_for_liftable_call(expr: Expression, model: Model) -> bool:
+    """True if *expr* contains a transcendental node whose argument the
+    auxiliary-variable factorization would lift (see ``_should_lift_call_arg``)."""
+    if isinstance(expr, FunctionCall):
+        if _should_lift_call_arg(expr, model) is not None:
+            return True
+        return any(_scan_for_liftable_call(a, model) for a in expr.args)
+    if isinstance(expr, BinaryOp):
+        return _scan_for_liftable_call(expr.left, model) or _scan_for_liftable_call(
+            expr.right, model
+        )
+    if isinstance(expr, UnaryOp):
+        return _scan_for_liftable_call(expr.operand, model)
     return False
 
 

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -287,7 +287,7 @@ def _estimate_distributed_terms(expr: Expression) -> int:
             n = float(expr.right.value)
             n_int = int(n)
             if n == n_int and n_int >= 1:
-                return min(_estimate_distributed_terms(expr.left) ** n_int, _TERM_CAP)
+                return min(int(_estimate_distributed_terms(expr.left) ** n_int), _TERM_CAP)
         return 1
     if isinstance(expr, UnaryOp):
         return _estimate_distributed_terms(expr.operand)

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -251,6 +251,112 @@ def _rebuild_product(coeff: float, atoms: list[Expression]) -> Expression:
     return expr if expr is not None else Constant(coeff)
 
 
+# Distributing a product whose factors are multi-term sums multiplies their term
+# counts.  A product of several sum-of-squares (st_e36: 5 factors → a 12.6 MB,
+# degree-~17 polynomial when distributed) both explodes memory/time and forces
+# high-degree univariate monomial lifts (``x1**8`` over [15,25] is 1.5e11, past
+# the relaxation's 1e10 aux-bound limit) whose columns are then dropped — gutting
+# the relaxation and leaving the constraint effectively unrelaxed.  The standard
+# factorable cure (BARON, Couenne) is to NOT distribute: lift each multi-term
+# factor to a bounded aux ``w_i == f_i`` and relax the resulting bilinear /
+# multilinear product of variables directly.
+_DISTRIBUTE_TERM_LIMIT = 1024  # est. distributed-term count above which a product is lifted
+_TERM_CAP = 1 << 40  # saturate the estimate so deep blowups can't overflow
+
+
+def _estimate_distributed_terms(expr: Expression) -> int:
+    """Estimate how many additive terms ``distribute_products(expr)`` would yield.
+
+    A product multiplies its operands' term counts, an integer power raises the
+    base's, a sum adds them; every opaque leaf (variable, call, division,
+    constant) counts as one.  Saturated at ``_TERM_CAP`` so a deeply nested
+    blowup cannot overflow before it trips the limit.
+    """
+    if isinstance(expr, BinaryOp):
+        if expr.op in ("+", "-"):
+            return min(
+                _estimate_distributed_terms(expr.left)
+                + _estimate_distributed_terms(expr.right),
+                _TERM_CAP,
+            )
+        if expr.op == "*":
+            return min(
+                _estimate_distributed_terms(expr.left)
+                * _estimate_distributed_terms(expr.right),
+                _TERM_CAP,
+            )
+        if expr.op == "**" and isinstance(expr.right, Constant):
+            n = float(expr.right.value)
+            n_int = int(n)
+            if n == n_int and n_int >= 1:
+                return min(_estimate_distributed_terms(expr.left) ** n_int, _TERM_CAP)
+        return 1
+    if isinstance(expr, UnaryOp):
+        return _estimate_distributed_terms(expr.operand)
+    return 1
+
+
+def _collect_mul_factors(expr: Expression) -> list[Expression]:
+    """Flatten a left/right-nested ``*`` chain into its factor list."""
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        return _collect_mul_factors(expr.left) + _collect_mul_factors(expr.right)
+    return [expr]
+
+
+def _prelift_blowup_products(expr: Expression, model: Model, lifter: "_Lifter") -> Expression:
+    """Lift the factors of any product whose naive distribution would explode.
+
+    Walks *expr*; at each ``*``-rooted product whose estimated distributed term
+    count exceeds :data:`_DISTRIBUTE_TERM_LIMIT`, lifts every multi-term-sum
+    factor ``f`` to an aux ``w == f`` (an exact equality) and rebuilds the
+    product over the auxes, so the relaxation sees a bilinear/multilinear product
+    of bounded variables instead of a high-degree expanded polynomial.  Sound:
+    each ``w == f`` is exact and the lifted product is McCormick-relaxable.
+    Identity-preserving for every node under the limit, so non-blowup
+    constraints/objectives are byte-for-byte unchanged.
+    """
+    if isinstance(expr, BinaryOp):
+        if expr.op == "*" and _estimate_distributed_terms(expr) > _DISTRIBUTE_TERM_LIMIT:
+            new_factors: list[Expression] = []
+            changed = False
+            for f in _collect_mul_factors(expr):
+                # Only a genuine multi-term sum drives the blowup; a constant,
+                # variable, or monomial power distributes to one term and is left
+                # for the normal monomial/bilinear path.
+                if (
+                    isinstance(f, BinaryOp)
+                    and f.op in ("+", "-")
+                    and _estimate_distributed_terms(f) >= 2
+                ):
+                    # Recurse first so a factor that is *itself* a blowup product
+                    # has its inner factors lifted before this one is bounded.
+                    f_lifted = _prelift_blowup_products(f, model, lifter)
+                    w = lifter.expression(f_lifted)
+                    if w is not None:
+                        new_factors.append(w)
+                        changed = True
+                        continue
+                    new_factors.append(f_lifted)
+                else:
+                    new_factors.append(_prelift_blowup_products(f, model, lifter))
+            if changed:
+                return _rebuild_product(1.0, new_factors)
+            # Couldn't bound any factor (unbounded box): leave the product to the
+            # existing distribute/monomial path rather than alter it.
+            return expr
+        left = _prelift_blowup_products(expr.left, model, lifter)
+        right = _prelift_blowup_products(expr.right, model, lifter)
+        if left is expr.left and right is expr.right:
+            return expr
+        return BinaryOp(expr.op, left, right)
+    if isinstance(expr, UnaryOp):
+        operand = _prelift_blowup_products(expr.operand, model, lifter)
+        if operand is expr.operand:
+            return expr
+        return UnaryOp(expr.op, operand)
+    return expr
+
+
 # Univariate transcendentals whose argument may be lifted into an aux variable.
 # ``sqrt``/``exp`` are domain-safe to relax over a finite box once their argument
 # is a single variable (sqrt needs ``arg >= 0``, supplied by the lb floor below;
@@ -297,6 +403,47 @@ def _should_lift_call_arg(call: Expression, model: Model) -> Expression | None:
     return arg
 
 
+def _simplify_sqrt_monomial(call: Expression, model: Model) -> Expression | None:
+    """Rewrite ``sqrt(c * prod x_i**e_i)`` via the root-of-perfect-power identity.
+
+    On a non-negative domain ``sqrt(x**(2k)) == x**k`` *exactly*, so a ``sqrt``
+    whose argument is a monomial with all-even exponents and a non-negative
+    constant factor collapses to a plain monomial — no transcendental, no
+    envelope at all. Being an algebraic identity (not a relaxation) it is sound
+    for any curvature, and it sidesteps the extreme-magnitude abstention that
+    otherwise *drops the whole constraint*: nvs05's omitted
+    ``sqrt(1e15*x2**2*x3**6)`` becomes ``3.16e7*x2*x3**3`` — the 2.5e33-wide
+    argument turns into a 3.16e7 coefficient on a benign monomial the existing
+    monomial/bilinear machinery relaxes tightly.
+
+    The all-even / non-negative-base requirement is necessary, not conservative:
+    ``sqrt(x**(2k)) == |x|**k``, which equals ``x**k`` only when ``x >= 0`` (or
+    ``k`` even). Returns the rewritten monomial, or ``None`` when the argument is
+    not a non-negative all-even-exponent monomial (the caller then tries the
+    general aux-variable lift).
+    """
+    if not isinstance(call, FunctionCall):
+        return None
+    if call.func_name != "sqrt" or len(call.args) != 1:
+        return None
+    decomp = _decompose_poly_product(distribute_products(call.args[0]), model)
+    if decomp is None:
+        return None
+    coeff, powers, extra = decomp
+    if extra or not powers or coeff < 0.0:
+        return None
+    atoms: list[Expression] = []
+    for _idx, (leaf, exp) in powers.items():
+        if exp % 2 != 0:
+            return None  # residual odd power -> argument is not a perfect square
+        lo, _hi = _bound_expression(leaf, model)
+        if not np.isfinite(lo) or lo < 0.0:
+            return None  # sqrt(leaf**exp) == |leaf|**(exp/2) != leaf**(exp/2) for lo<0
+        half = exp // 2
+        atoms.append(leaf if half == 1 else BinaryOp("**", leaf, Constant(float(half))))
+    return _rebuild_product(float(np.sqrt(coeff)), atoms)
+
+
 def _lift_expr(expr: Expression, model: Model, lifter: _Lifter) -> Expression:
     """Return *expr* with every mixed repeated-factor polynomial product lifted
     to bilinear form via monomial aux variables.  Identity-preserving: returns
@@ -335,6 +482,14 @@ def _lift_expr(expr: Expression, model: Model, lifter: _Lifter) -> Expression:
             return expr
         return UnaryOp(expr.op, operand)
     if isinstance(expr, FunctionCall):
+        # Root-of-perfect-power simplification first: ``sqrt(c * perfect-square
+        # monomial)`` is an exact monomial, strictly better than any envelope and
+        # immune to the extreme-magnitude abstention. Recurse so the resulting
+        # monomial gets its own mixed-product lift (e.g. ``x2*x3**3`` -> bilinear
+        # ``x2 * aux(x3**3)``).
+        simplified = _simplify_sqrt_monomial(expr, model)
+        if simplified is not None:
+            return _lift_expr(simplified, model, lifter)
         # Auxiliary-variable factorization of ``outer(g(x))`` (issue #130 follow-up):
         # when ``g`` is a multivariate non-affine argument the univariate envelope
         # cannot reach (cross terms), lift ``t == g(x)`` and rewrite the node as
@@ -1086,6 +1241,7 @@ def factorable_reformulate(model: Model, *, clear_only: bool = False) -> Model:
                 else:
                     rebuilt.append(Constraint(distribute_products(body), sense, c.rhs, c.name))
                 continue
+            body = _prelift_blowup_products(body, new_model, lifter)
             body = distribute_products(body)
             body = _lift_objective_atoms(body, new_model, lifter)
             body = _lift_expr(body, new_model, lifter)
@@ -1098,7 +1254,10 @@ def factorable_reformulate(model: Model, *, clear_only: bool = False) -> Model:
         # power of a polynomial base); division clearing is meaningless for an
         # objective so only the lifts apply.
         if not clear_only and new_model._objective is not None:
-            obj_expr = distribute_products(new_model._objective.expression)
+            obj_expr = _prelift_blowup_products(
+                new_model._objective.expression, new_model, lifter
+            )
+            obj_expr = distribute_products(obj_expr)
             obj_expr = _lift_objective_atoms(obj_expr, new_model, lifter)
             lifted_obj = _lift_expr(obj_expr, new_model, lifter)
             if lifted_obj is not new_model._objective.expression:

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -26,7 +26,7 @@ import math
 import os
 from collections import Counter
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 import scipy.sparse as sp
@@ -1327,6 +1327,7 @@ def _decompose_product(
     monomial_var_map: Optional[dict[tuple[int, int], int]] = None,
     composite_var_map: Optional[dict[int, int]] = None,
     composite_coeff_map: Optional[dict[int, float]] = None,
+    pinned_value: Optional[Callable[[int], Optional[float]]] = None,
 ) -> tuple[float, list[int]] | None:
     """Decompose a product expression into (scalar, [flat_or_aux_idx, ...]).
 
@@ -1341,6 +1342,13 @@ def _decompose_product(
     — a lifted bilinear pair. This lets the standard McCormick pipeline relax
     ``x**2 * y`` (one monomial envelope + one bilinear envelope) instead of
     rejecting it as an unsupported repeated-factor term.
+
+    When ``pinned_value`` is supplied (a ``flat_idx -> exact value or None``
+    lookup over the node's bounds), a power factor ``x**p`` whose base is pinned
+    (lb==ub) is folded into the scalar as the exact constant ``x**p`` rather than
+    requiring a fractional-power aux column — which the builder skips on a
+    degenerate domain — so a branch/OBBT-pinned ``y * x**p`` term still decomposes
+    (to ``[col(y)]`` scaled by ``x**p``) instead of dropping from the relaxation.
     """
     scalar: list[float] = [1.0]
     var_indices: list[int] = []
@@ -1371,19 +1379,31 @@ def _decompose_product(
                     return False
                 var_indices.append(aux_col)
                 return True
-        # Recognize var^p (fractional p) when an aux column was allocated.
-        if (
-            fractional_power_var_map
-            and isinstance(e, BinaryOp)
-            and e.op == "**"
-            and isinstance(e.right, Constant)
-        ):
+        # Recognize var^p (fractional p) when an aux column was allocated, or
+        # fold it to an exact constant when the base is pinned (lb==ub) at this
+        # node. The pinned fold matters because the fractional-power aux column
+        # is *skipped* for a degenerate [lb==ub] domain (the builder's bounds
+        # guard), so without it a branched/OBBT-pinned base turns ``y * x^p``
+        # into an undecomposable product and the whole term — or the objective —
+        # drops from the relaxation, sinking the node's dual bound. Folding the
+        # pinned power is variable-free and exact, so it only ever tightens.
+        if isinstance(e, BinaryOp) and e.op == "**" and isinstance(e.right, Constant):
             base_flat = _get_flat_index(e.left, model)
             if base_flat is not None:
-                key = (base_flat, float(e.right.value))
-                if key in fractional_power_var_map:
+                exp_val = float(e.right.value)
+                key = (base_flat, exp_val)
+                if fractional_power_var_map and key in fractional_power_var_map:
                     var_indices.append(fractional_power_var_map[key])
                     return True
+                if pinned_value is not None:
+                    pv = pinned_value(base_flat)
+                    # x^p is real only for x >= 0 (fractional p) or any integer p.
+                    if pv is not None and (pv >= 0.0 or exp_val == int(exp_val)):
+                        try:
+                            scalar[0] *= float(pv) ** exp_val
+                        except (ValueError, OverflowError):
+                            return False
+                        return True
         # Fold a *composite* variable-free factor (e.g. ``neg(1e6)`` from a
         # parsed ``-1e6*i1*i2``, or ``(-3)*(-3)``) into the scalar. A bare
         # ``Constant`` is handled above; this catches negations/arithmetic over
@@ -4346,6 +4366,7 @@ def _linearize_expr(
                     monomial_var_map=monomial_var_map,
                     composite_var_map=composite_var_map,
                     composite_coeff_map=composite_coeff_map,
+                    pinned_value=_pinned_value,
                 )
                 if decomp is None:
                     raise ValueError(f"Cannot decompose product: {e}")
@@ -4724,6 +4745,49 @@ def build_milp_relaxation(
             return False
         return float(flat_ub[idx]) - float(flat_lb[idx]) <= 1e-9
 
+    def _register_pinned_collapse(factors: tuple[int, ...]) -> None:
+        """Pre-register the aux for a product term's pinned-factor collapse.
+
+        When a factor of a k-ary product pins (lb==ub) during B&B,
+        ``_linearize_expr`` folds it into the coefficient and looks up the key of
+        the *unpinned distinct subset* — bilinear at arity 2, trilinear at 3,
+        multilinear at >=4 (mirroring its own arity dispatch at lines ~4382-4407).
+        Unless that collapsed key is registered the linearizer raises
+        "... not in map" and the whole constraint drops at that node, sinking its
+        dual bound (issue #139: nvs22 ``x**2*y``; nvs05 ``x0*x1*x5*x2**2`` →
+        trilinear ``x0*x1*x5`` once ``x2`` is branch-fixed). The build reruns per
+        node, so ``factors`` minus the currently-pinned ones is exactly the
+        collapsed arity; ``_builder_pinned`` is the same bound source the
+        linearizer's pin test uses, so the registered key is the one it looks up.
+        Called from every product-registration site — classifier *and* lifted —
+        so no source/arity combination can silently reintroduce the gap.
+        """
+        unpinned = [v for v in factors if not _builder_pinned(v)]
+        k = len(unpinned)
+        if k == 2:
+            bkey = (min(unpinned), max(unpinned))
+            if bkey not in bilinear_var_map:
+                bilinear_var_map[bkey] = _ensure_bilinear_aux(*bkey)
+        elif k == 3:
+            tkey = (min(unpinned), sorted(unpinned)[1], max(unpinned))
+            if tkey not in trilinear_var_map:
+                pair, remaining = _choose_trilinear_pair(tkey, partitioned_vars)
+                pair_col = _ensure_bilinear_aux(*pair)
+                collapsed_col = _ensure_bilinear_aux(pair_col, remaining)
+                trilinear_var_map[tkey] = collapsed_col
+                trilinear_stage_map[tkey] = {
+                    "pair": pair,
+                    "pair_col": pair_col,
+                    "remaining_var": remaining,
+                    "product_col": collapsed_col,
+                }
+        elif k >= 4:
+            mkey = tuple(sorted(unpinned))
+            if mkey not in multilinear_var_map:
+                sub_col, sub_stages = _ensure_multilinear_aux(mkey)
+                multilinear_var_map[mkey] = sub_col
+                multilinear_stage_map[mkey] = sub_stages
+
     for term in sorted(trilinear_terms):
         pair, remaining = _choose_trilinear_pair(term, partitioned_vars)
         pair_col = _ensure_bilinear_aux(*pair)
@@ -4735,24 +4799,30 @@ def build_milp_relaxation(
             "remaining_var": remaining,
             "product_col": final_col,
         }
-        # Pinned-factor collapse: when exactly one factor is pinned at this node
-        # (lb==ub from branching/OBBT), ``_linearize_expr`` folds that factor's
-        # exact value into the coefficient, leaving a *bilinear* in the other two
-        # factors. Pre-allocate that bilinear's aux column + McCormick envelope so
-        # the collapsed term still linearizes; otherwise the linearizer raises
-        # "Bilinear (i,j) not in map" and the whole objective/constraint drops
-        # (issue #139: surfaces on nvs22 once its x**2*y objective term lifts).
-        unpinned = [v for v in term if not _builder_pinned(v)]
-        if len(unpinned) == 2:
-            bkey = (min(unpinned), max(unpinned))
-            if bkey not in bilinear_var_map:
-                bilinear_var_map[bkey] = _ensure_bilinear_aux(*bkey)
+        _register_pinned_collapse(term)
 
-    multilinear_terms = terms.multilinear or _collect_distinct_multilinear_products(model)
+    # Union, not ``or``: the classifier set and the structural scan are not
+    # interchangeable. ``terms.multilinear`` records >=4-way products of distinct
+    # *original* variables; ``_collect_distinct_multilinear_products`` decomposes
+    # the expression tree and also catches products the classifier dumps into
+    # ``general_nl``. A short-circuiting ``or`` would skip the scan whenever the
+    # classifier happened to find *any* multilinear, silently dropping a second
+    # >=4-way term the scan alone would surface — its constraint then omitted at
+    # linearization. Registering an unused key only costs one aux column, so the
+    # union is the safe superset. (The lifted-aux path at ~5317 is a third source
+    # but only fires when a factor is itself a lifted column ``idx >= n_orig``.)
+    _multi_seen: set[tuple[int, ...]] = set()
+    multilinear_terms: list[tuple[int, ...]] = []
+    for _mt in list(terms.multilinear) + _collect_distinct_multilinear_products(model):
+        _canon = tuple(sorted(_mt))
+        if _canon not in _multi_seen:
+            _multi_seen.add(_canon)
+            multilinear_terms.append(_canon)
     for multi_term in multilinear_terms:
         final_col, stages = _ensure_multilinear_aux(multi_term)
         multilinear_var_map[multi_term] = final_col
         multilinear_stage_map[multi_term] = stages
+        _register_pinned_collapse(multi_term)
 
     # Numerical-conditioning guard: a lifted monomial whose auxiliary bound spans
     # an extreme magnitude (e.g. ``x1**9`` over ``[15, 25]`` → ~3.8e12) injects
@@ -5283,6 +5353,7 @@ def build_milp_relaxation(
     )
     for term in lifted_trilinear_keys:
         if term in trilinear_var_map:
+            _register_pinned_collapse(term)
             continue
         pair, remaining = _choose_trilinear_pair(term, partitioned_vars)
         pair_col = _ensure_bilinear_aux(*pair)
@@ -5294,12 +5365,15 @@ def build_milp_relaxation(
             "remaining_var": remaining,
             "product_col": final_col,
         }
+        _register_pinned_collapse(term)
     for multi_term in lifted_multilinear_keys:
         if multi_term in multilinear_var_map:
+            _register_pinned_collapse(multi_term)
             continue
         final_col, stages = _ensure_multilinear_aux(multi_term)
         multilinear_var_map[multi_term] = final_col
         multilinear_stage_map[multi_term] = stages
+        _register_pinned_collapse(multi_term)
 
     # ── Square-of-affine-in-lifted-vars envelopes (issue #155) ──────────────
     # For each recognized ``E**2`` residual, lift every product factor to a

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3194,6 +3194,10 @@ class CompositeMultivarRelaxation:
 
 _COMPOSITE_CURV_TOL = 1e-9
 _COMPOSITE_MAX_SUBDIV = 256
+# Max sub-boxes a multivariate box-convexity certificate may enumerate across all
+# refinement levels of its partition (keeps the interval-Hessian sweep bounded for
+# high-dimensional nodes; pinned axes are excluded from the product).
+_MULTIVAR_MAX_SUBBOXES = 64
 
 
 def _build_convexity_box(model: Model, flat_lb: np.ndarray, flat_ub: np.ndarray) -> dict:
@@ -3651,6 +3655,133 @@ def _should_claim_composite_multivar(expr: Expression, model: Model, n_orig: int
     return False
 
 
+def _multivar_box_curvature(
+    expr: Expression,
+    model: Model,
+    idxs: list[int],
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+    box: dict,
+) -> Optional[str]:
+    """Sound box-restricted ``"convex"``/``"concave"`` certificate for a node.
+
+    The multivariate analogue of :func:`_subdivision_curvature`. ``expr`` is C²,
+    so it is convex on the (convex) box iff ``∇²expr ⪰ 0`` at *every* point of the
+    box, and concave iff ``∇²expr ⪯ 0`` everywhere. We enclose the Hessian with
+    interval AD on each sub-box of an axis-aligned partition and apply a per-row
+    interval-Gershgorin eigenvalue bound (identical math to
+    :func:`alphabb.rigorous_alpha`): for the dependent submatrix ``H``,
+
+        λ_min(H) ≥ min_i ( H[i,i].lo − Σ_{j≠i} max(|H[i,j].lo|, |H[i,j].hi|) )
+        λ_max(H) ≤ max_i ( H[i,i].hi + Σ_{j≠i} max(|H[i,j].lo|, |H[i,j].hi|) ).
+
+    Because PSD-ness is a *pointwise* condition and the sub-boxes cover the box,
+    certifying the sign on every sub-box certifies it on the whole box — so a
+    function that is only *locally* convex (nonconvex elsewhere, e.g. a ``sqrt`` of
+    an indefinite polynomial) is still soundly certified over the region the
+    relaxation actually uses. Refines the partition until conclusive or the
+    sub-box budget is hit; abstains (returns ``None``) otherwise. This certificate
+    is general: it depends on no algebraic shape, only on the interval Hessian, so
+    it covers every twice-differentiable multivariate node, not one problem class.
+
+    Only certifies when the dependent axes are finitely bounded (the interval
+    Hessian needs a finite box). Off-diagonal couplings to non-dependent variables
+    are exactly zero (``expr`` does not depend on them), so restricting Gershgorin
+    to the dependent submatrix loses nothing.
+    """
+    import itertools
+
+    from discopt._jax.convexity.interval import Interval
+    from discopt._jax.convexity.interval_ad import interval_hessian
+
+    dep = [int(j) for j in idxs]
+    d = len(dep)
+    if d == 0:
+        return None
+    los = np.array([float(flat_lb[j]) for j in dep], dtype=np.float64)
+    his = np.array([float(flat_ub[j]) for j in dep], dtype=np.float64)
+    if not (np.all(np.isfinite(los)) and np.all(np.isfinite(his))) or np.any(his < los):
+        return None
+    widths = his - los
+
+    # Locate each dependent flat index within its (possibly vector) Variable.
+    var_at: dict[int, tuple[Variable, int]] = {}
+    offset = 0
+    for v in model._variables:
+        for c in range(v.size):
+            var_at[offset + c] = (v, c)
+        offset += v.size
+    if any(j not in var_at for j in dep):
+        return None
+    loc = {j: var_at[j] for j in dep}
+    affected_vars = {loc[j][0] for j in dep}
+    saved = {v: box[v] for v in affected_vars}
+
+    tol = _COMPOSITE_CURV_TOL
+    non_pinned = [i for i in range(d) if widths[i] > tol]
+    ix = np.ix_(dep, dep)
+
+    def _verdict_at(k: int) -> Optional[str]:
+        edges = [
+            np.linspace(los[i], his[i], k + 1) if widths[i] > tol else np.array([los[i], his[i]])
+            for i in range(d)
+        ]
+        all_convex = True
+        all_concave = True
+        for combo in itertools.product(*[range(len(e) - 1) for e in edges]):
+            lo_arr = {v: np.array(saved[v].lo, dtype=np.float64).reshape(-1) for v in affected_vars}
+            hi_arr = {v: np.array(saved[v].hi, dtype=np.float64).reshape(-1) for v in affected_vars}
+            for i, j in enumerate(dep):
+                v, c = loc[j]
+                lo_arr[v][c] = float(edges[i][combo[i]])
+                hi_arr[v][c] = float(edges[i][combo[i] + 1])
+            for v in affected_vars:
+                box[v] = Interval(
+                    lo_arr[v].reshape(saved[v].lo.shape), hi_arr[v].reshape(saved[v].hi.shape)
+                )
+            try:
+                ad = interval_hessian(expr, model, box=box)
+            except Exception:
+                return None
+            h_lo = np.asarray(ad.hess.lo, dtype=np.float64)[ix]
+            h_hi = np.asarray(ad.hess.hi, dtype=np.float64)[ix]
+            if not (np.all(np.isfinite(h_lo)) and np.all(np.isfinite(h_hi))):
+                return None
+            abs_max = np.maximum(np.abs(h_lo), np.abs(h_hi))
+            row_radius = abs_max.sum(axis=1) - np.abs(np.diag(abs_max))
+            gersh_lo = np.diag(h_lo) - row_radius  # ≤ λ_min(H)
+            gersh_hi = np.diag(h_hi) + row_radius  # ≥ λ_max(H)
+            if np.any(gersh_lo < -tol):
+                all_convex = False
+            if np.any(gersh_hi > tol):
+                all_concave = False
+            if not all_convex and not all_concave:
+                break
+        if all_convex:
+            return "convex"
+        if all_concave:
+            return "concave"
+        return ""  # inconclusive at this refinement → keep refining
+
+    try:
+        if not non_pinned:
+            return _verdict_at(1) or None
+        k = 1
+        while True:
+            verdict = _verdict_at(k)
+            if verdict is None:
+                return None  # non-finite Hessian / AD failure → abstain
+            if verdict:
+                return verdict
+            next_k = k * 2
+            if next_k ** len(non_pinned) > _MULTIVAR_MAX_SUBBOXES:
+                return None
+            k = next_k
+    finally:
+        for v in affected_vars:
+            box[v] = saved[v]
+
+
 def _collect_composite_multivar_relaxations(
     model: Model,
     n_orig: int,
@@ -3708,7 +3839,14 @@ def _collect_composite_multivar_relaxations(
         elif curv == Curvature.CONCAVE:
             curvature = "concave"
         else:
-            return
+            # Global DCP is UNKNOWN (e.g. sqrt/power of an indefinite polynomial
+            # that is convex only on this box). Fall back to the sound
+            # box-restricted interval-Hessian PSD certificate, which lifts any
+            # locally convex/concave multivariate node, not one problem class.
+            box_curv = _multivar_box_curvature(expr, model, idxs, flat_lb, flat_ub, box)
+            if box_curv is None:
+                return
+            curvature = box_curv
 
         # Sound interval enclosure of g over the box → finite column bounds the
         # bilinear McCormick envelope of d·x needs.

--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -38,6 +38,81 @@ from discopt.solvers.lp_backend import (
 # still tightened by the exact (Rust simplex / HiGHS) oracle.
 _OBBT_COND_LIMIT = 1e10
 
+# OBBT tightens to the LP vertex objective, which is accurate on a well-conditioned
+# basis but can drift a few ``ulp * cond`` *above* the true optimum when the
+# McCormick coefficient spread makes the basis ill-conditioned (the nvs22
+# false-certificate: a 1.000996 vertex for a true min of 1.0, rounded inward to
+# prune the optimum). The Neumaier-Shcherbina safe dual bound is a rigorous lower
+# bound on that LP min; when the vertex sits this far *above* it (relative), the
+# vertex is untrustworthy and OBBT falls back to the safe bound instead of
+# over-tightening. The threshold is far above honest vertex noise (~1e-9 on
+# well-conditioned LPs) so trustworthy tightenings are preserved bit-for-bit —
+# avoiding spurious box perturbations on knife-edge instances (st_e11) — while the
+# gross ill-conditioned drift that prunes a feasible optimum is caught.
+_OBBT_NS_GUARD = 1e-6
+
+
+def _ns_safe_lp_lower_bound(c, dual_values, A_ub, b_ub, lo, hi):
+    """Neumaier-Shcherbina rigorous lower bound on ``min c^T x`` over the box LP.
+
+    The LP is ``min c^T x  s.t.  A_ub x <= b_ub,  lo <= x <= hi``. For *any*
+    ``y >= 0`` (multipliers on the ``<=`` rows), weak duality gives
+
+        g(y) = -b^T y + sum_j  min_{x_j in [lo_j, hi_j]} (c + A^T y)_j x_j
+
+    and ``g(y) <= true min c^T x``. We take ``y = max(-row_dual, 0)`` from the
+    LP's reported duals: HiGHS returns ``row_dual <= 0`` on an active ``<=`` row,
+    so ``-row_dual`` is the non-negative multiplier and ``g(y)`` reproduces the
+    LP optimum *exactly* on a well-conditioned solve. The crucial property is
+    that ``g(y) <= true min`` holds for the clamped ``y`` regardless of how the
+    duals were obtained, so when the simplex basis is ill-conditioned (a wide
+    McCormick coefficient spread) and the reported vertex objective drifts a few
+    ``ulp * cond`` *above* the true minimum, ``g(y)`` stays a sound under-estimate
+    rather than an over-tightening that could prune the global optimum (the
+    nvs22 false-certificate). Tightening OBBT bounds to ``g(y)`` instead of the
+    raw vertex objective is therefore sound at any conditioning, and loses no
+    tightness where the LP is well-behaved.
+
+    A magnitude-scaled margin is subtracted to dominate the floating-point error
+    of the dual evaluation itself (done in plain float64, not directed-rounding
+    interval arithmetic). Returns ``None`` when no usable lower bound exists.
+    """
+    import scipy.sparse as sp
+
+    if dual_values is None:
+        return None
+    y = np.array(dual_values, dtype=np.float64)  # copy: must not mutate caller's duals
+    if y.size == 0:
+        return None
+    np.clip(-y, 0.0, None, out=y)  # y := max(-row_dual, 0) >= 0
+    c = np.asarray(c, dtype=np.float64)
+    if A_ub is None or b_ub is None:
+        rc = c.copy()
+        const = 0.0
+    else:
+        b_arr = np.asarray(b_ub, dtype=np.float64)
+        if y.shape[0] != b_arr.shape[0]:
+            return None
+        At_y = (A_ub.T @ y) if sp.issparse(A_ub) else (np.asarray(A_ub).T @ y)
+        rc = c + np.asarray(At_y).ravel()
+        const = -float(b_arr @ y)
+    lo = np.asarray(lo, dtype=np.float64)
+    hi = np.asarray(hi, dtype=np.float64)
+    # min_{x_j in [lo_j,hi_j]} rc_j x_j  = lo_j if rc_j>0, hi_j if rc_j<0, else 0
+    # (the rc_j==0 case contributes 0 even when that bound is infinite).
+    contrib = np.zeros_like(rc)
+    pos = rc > 0.0
+    neg = rc < 0.0
+    contrib[pos] = rc[pos] * lo[pos]
+    contrib[neg] = rc[neg] * hi[neg]
+    g = const + float(contrib.sum())
+    if not np.isfinite(g):
+        return None
+    # Margin >> the float64 rounding error of the two dot products above
+    # (~n * eps * magnitude); keeps g a rigorous under-estimate.
+    margin = 1e-10 * (1.0 + abs(const) + float(np.abs(contrib).sum()))
+    return g - margin
+
 
 def solve_lp(**kwargs):
     """Module-level default LP solve (HiGHS-first, POUNCE fallback).
@@ -625,7 +700,15 @@ def run_obbt_on_relaxation(
     # is accepted for signature compatibility but never honoured here — when no
     # exact (Rust simplex / HiGHS) oracle is available we return the box
     # untightened rather than risk an unsound shrink.
-    _lp = get_exact_lp_solver()
+    # Prefer the dual-exposing (HiGHS) oracle: OBBT tightens to a Neumaier-
+    # Shcherbina *safe* dual bound (``_ns_safe_lp_lower_bound``) rather than the
+    # raw vertex objective, which is sound at any conditioning and cannot prune a
+    # feasible optimum (the nvs22 false-certificate). Without a dual oracle we
+    # fall back to the exact vertex value (the conditioning guard below keeps that
+    # path from over-tightening on the worst LPs).
+    _dual_lp = get_exact_dual_lp_solver()
+    _lp = _dual_lp or get_exact_lp_solver()
+    _use_ns = _dual_lp is not None
     if _lp is None:
         return ObbtResult(
             tightened_lb=np.array([b[0] for b in relaxation._bounds[:n_orig]], dtype=np.float64),
@@ -657,7 +740,20 @@ def run_obbt_on_relaxation(
 
     _bound_vals = np.array([v for pair in bounds for v in pair], dtype=np.float64)
     _cond = max(_max_abs(A_ub), _max_abs(b_ub), _max_abs(_bound_vals))
-    if _cond > _OBBT_COND_LIMIT:
+    # Conditioning guard. The raw vertex objective from an ill-conditioned LP can
+    # drift *above* the true minimum and over-tighten (the nvs22 false-certificate),
+    # so without a rigorous safe-bound oracle we abstain entirely. WITH the NS-safe
+    # dual path (``_use_ns``) every tightening below is clamped to the rigorous
+    # Neumaier-Shcherbina bound ``g`` -- valid for any dual ``y >= 0`` by weak
+    # duality, hence sound at ANY conditioning. So rather than abstain we only
+    # *require* that rigorous bound (``require_ns``): a variable whose safe bound is
+    # unavailable is left untightened instead of being trusted to its vertex. This
+    # lets OBBT engage on ill-conditioned factorable relaxations the bare guard
+    # disabled -- e.g. nvs05, whose 1e15-coefficient term drives ``_cond ~ 2e13``
+    # yet whose boxes (x5,x6 spanning [~0, 1.36e4]) only shrink once OBBT runs --
+    # while never tightening from a non-rigorous value.
+    require_ns = _cond > _OBBT_COND_LIMIT
+    if require_ns and not _use_ns:
         return ObbtResult(
             tightened_lb=np.array([b[0] for b in bounds[:n_orig]], dtype=np.float64),
             tightened_ub=np.array([b[1] for b in bounds[:n_orig]], dtype=np.float64),
@@ -720,7 +816,20 @@ def run_obbt_on_relaxation(
         if result.status == SolveStatus.OPTIMAL and result.objective is not None:
             warm_basis = result.basis
             new_lb = float(result.objective)
-            if new_lb > lb_arr[var_idx] + eps:
+            if _use_ns:
+                # Distrust the vertex only when the rigorous safe bound sits well
+                # below it (ill-conditioned basis); otherwise keep it bit-for-bit.
+                g = _ns_safe_lp_lower_bound(
+                    c, getattr(result, "dual_values", None), A_ub, b_ub, lb_arr, ub_arr
+                )
+                if g is None:
+                    if require_ns:
+                        # Ill-conditioned LP and no rigorous safe bound available:
+                        # the raw vertex is untrustworthy here, so do not tighten.
+                        new_lb = None
+                elif new_lb > g + _OBBT_NS_GUARD * (1.0 + abs(new_lb)):
+                    new_lb = g
+            if new_lb is not None and new_lb > lb_arr[var_idx] + eps:
                 # Don't cross the upper bound.
                 lb_arr[var_idx] = min(new_lb, ub_arr[var_idx])
                 n_tightened += 1
@@ -742,10 +851,24 @@ def run_obbt_on_relaxation(
         total_lp_time += result.wall_time
         if result.status == SolveStatus.OPTIMAL and result.objective is not None:
             warm_basis = result.basis
-            new_ub = -float(result.objective)
-            if new_ub < ub_arr[var_idx] - eps:
-                ub_arr[var_idx] = max(new_ub, lb_arr[var_idx])
-                n_tightened += 1
+            lp_min = float(result.objective)  # = min(-x_i) = -max(x_i)
+            if _use_ns:
+                # Same guard: ``g`` bounds ``min(-x_i)`` from below, so when the
+                # vertex sits well above it the basis is ill-conditioned and the
+                # safe bound ``-g`` is the sound (looser) upper bound on ``x_i``.
+                g = _ns_safe_lp_lower_bound(
+                    c, getattr(result, "dual_values", None), A_ub, b_ub, lb_arr, ub_arr
+                )
+                if g is None:
+                    if require_ns:
+                        lp_min = None
+                elif lp_min > g + _OBBT_NS_GUARD * (1.0 + abs(lp_min)):
+                    lp_min = g
+            if lp_min is not None:
+                new_ub = -lp_min
+                if new_ub < ub_arr[var_idx] - eps:
+                    ub_arr[var_idx] = max(new_ub, lb_arr[var_idx])
+                    n_tightened += 1
 
     return ObbtResult(
         tightened_lb=lb_arr[:n_orig].copy(),

--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -1015,6 +1015,436 @@ class RootObbtResult:
     infeasible: bool = False
 
 
+def _scalar_flat_index(expr, model) -> Optional[int]:
+    """Flat column index if *expr* is a single scalar variable reference.
+
+    Returns the flat index (matching :func:`_get_var_bounds` ordering) for a
+    scalar ``Variable`` or a scalar ``IndexExpression`` over a variable, else
+    ``None``.
+    """
+    from discopt.modeling.core import IndexExpression, Variable
+
+    def _offset(var) -> int:
+        off = 0
+        for v in model._variables[: var._index]:
+            off += v.size
+        return off
+
+    if isinstance(expr, Variable) and expr.size == 1:
+        return _offset(expr)
+    if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
+        idx = expr.index
+        if isinstance(idx, int):
+            return _offset(expr.base) + idx
+        if isinstance(idx, tuple) and len(idx) == 1 and isinstance(idx[0], int):
+            return _offset(expr.base) + idx[0]
+    return None
+
+
+def _flat_indices(expr, model) -> set:
+    """Conservative set of flat variable indices referenced anywhere in *expr*.
+
+    A scalar reference contributes its single index; a whole multi-element
+    variable or an unresolved index contributes its entire flat range.  Used to
+    verify the isolated variable appears in no other additive term — erring
+    toward *over*-inclusion (it may skip a valid isolation, never assert a false
+    one).
+    """
+    from discopt.modeling.core import (
+        BinaryOp,
+        FunctionCall,
+        IndexExpression,
+        SumExpression,
+        SumOverExpression,
+        UnaryOp,
+        Variable,
+    )
+
+    def _offset(var) -> int:
+        off = 0
+        for v in model._variables[: var._index]:
+            off += v.size
+        return off
+
+    out: set = set()
+
+    def walk(e) -> None:
+        scalar = _scalar_flat_index(e, model)
+        if scalar is not None:
+            out.add(scalar)
+            return
+        if isinstance(e, Variable):
+            base = _offset(e)
+            out.update(range(base, base + e.size))
+            return
+        if isinstance(e, IndexExpression) and isinstance(e.base, Variable):
+            base = _offset(e.base)
+            out.update(range(base, base + e.base.size))
+            return
+        if isinstance(e, BinaryOp):
+            walk(e.left)
+            walk(e.right)
+            return
+        if isinstance(e, UnaryOp):
+            walk(e.operand)
+            return
+        if isinstance(e, FunctionCall):
+            for a in e.args:
+                walk(a)
+            return
+        if isinstance(e, SumExpression):
+            walk(e.operand)
+            return
+        if isinstance(e, SumOverExpression):
+            for t in e.terms:
+                walk(t)
+            return
+
+    walk(expr)
+    return out
+
+
+def _additive_terms(expr, sign: float = 1.0):
+    """Flatten the top-level additive structure into ``(coeff, subexpr)`` pairs.
+
+    Descends through ``+``, ``-`` and unary ``neg`` only; a ``coeff * leaf`` or
+    ``leaf * coeff`` product contributes its constant scale.  Anything else is
+    returned as a single ``(sign, expr)`` leaf.  Used to spot a constraint of
+    the form ``c*v + g(other vars) == rhs`` so ``v`` can be isolated.
+    """
+    from discopt.modeling.core import BinaryOp, Constant, UnaryOp
+
+    if isinstance(expr, BinaryOp):
+        if expr.op == "+":
+            return _additive_terms(expr.left, sign) + _additive_terms(expr.right, sign)
+        if expr.op == "-":
+            return _additive_terms(expr.left, sign) + _additive_terms(expr.right, -sign)
+        if expr.op == "*":
+            if isinstance(expr.left, Constant) and expr.left.value.ndim == 0:
+                return _additive_terms(expr.right, sign * float(expr.left.value))
+            if isinstance(expr.right, Constant) and expr.right.value.ndim == 0:
+                return _additive_terms(expr.left, sign * float(expr.right.value))
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _additive_terms(expr.operand, -sign)
+    return [(sign, expr)]
+
+
+def propagate_equality_defined_bounds(
+    model: Model,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    *,
+    max_passes: int = 3,
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Finitize equality-defined variables by forward interval propagation.
+
+    A ``.nl`` model commonly defines an intermediate quantity with an equality
+    ``v == g(x)`` (encoded as ``c*v + (-g) == rhs``), where ``g`` is a division,
+    log, exp or other expression that interval FBBT in the Rust core does not
+    propagate through — so ``v`` keeps its declared ``±inf`` bound even though
+    ``g`` has a finite range once the variables it depends on are bounded.  This
+    pass closes that gap: for every equality constraint that is *linear in a
+    single open variable* ``v`` (``c*v + g == rhs`` with ``v`` appearing nowhere
+    else in the row), it bounds ``v == (rhs - g)/c`` by evaluating ``g``'s
+    interval over the current box and tightens ``v``.
+
+    This is sound: the equality is exact, so the propagated interval is the
+    variable's true reachable range under that constraint — the pass can only
+    shrink the box.  It runs to a fixpoint (``max_passes``) because finitizing
+    one variable can unlock another (e.g. ``v == g(w)`` once ``w`` is finite).
+
+    Pairs with :func:`bootstrap_finite_bounds`: the bootstrap finitizes the
+    variables reachable from *linear* constraints, which then become finite
+    inputs to the ``g`` expressions this pass propagates through.
+
+    Returns ``(lb, ub, n_finitized)``.  Any failure leaves the box unchanged.
+    """
+    lb = np.asarray(lb, dtype=np.float64).copy()
+    ub = np.asarray(ub, dtype=np.float64).copy()
+    n_vars = len(lb)
+
+    if np.all(np.isfinite(lb)) and np.all(np.isfinite(ub)):
+        return lb, ub, 0
+
+    try:
+        from discopt._jax.gdp_reformulate import _bound_expression
+        from discopt.modeling.core import Constraint, VarType
+
+        # _bound_expression reads bounds off the model's Variable nodes, so drive
+        # it with the current box by temporarily writing (lb, ub) onto the model
+        # and restoring the originals afterwards.
+        saved = [(v.lb, v.ub) for v in model._variables]
+        is_int = np.zeros(n_vars, dtype=bool)
+
+        def _apply_box() -> None:
+            off = 0
+            for v in model._variables:
+                sz = v.size
+                v.lb = lb[off : off + sz].reshape(v.lb.shape)
+                v.ub = ub[off : off + sz].reshape(v.ub.shape)
+                off += sz
+
+        off = 0
+        for v in model._variables:
+            flag = v.var_type in (VarType.BINARY, VarType.INTEGER)
+            for _ in range(v.size):
+                if off < n_vars:
+                    is_int[off] = flag
+                off += 1
+
+        eq_constraints = [
+            c for c in model._constraints if isinstance(c, Constraint) and c.sense == "=="
+        ]
+
+        n_finitized = 0
+        try:
+            for _ in range(max(1, max_passes)):
+                _apply_box()
+                changed = False
+                for c in eq_constraints:
+                    terms = _additive_terms(c.body)
+                    rhs = float(c.rhs) if np.ndim(c.rhs) == 0 else None
+                    if rhs is None:
+                        continue
+                    for pos, (coeff, sub) in enumerate(terms):
+                        if abs(coeff) < 1e-30:
+                            continue
+                        vi = _scalar_flat_index(sub, model)
+                        if vi is None or vi >= n_vars:
+                            continue
+                        if np.isfinite(lb[vi]) and np.isfinite(ub[vi]):
+                            continue
+                        # v must not appear in any other term of the row.
+                        others = [t for k, t in enumerate(terms) if k != pos]
+                        if any(vi in _flat_indices(t[1], model) for t in others):
+                            continue
+                        # v == (rhs - sum(others)) / coeff
+                        rest_lo, rest_hi = 0.0, 0.0
+                        ok = True
+                        for ocoeff, oexpr in others:
+                            elo, ehi = _bound_expression(oexpr, model)
+                            if ocoeff >= 0:
+                                rest_lo += ocoeff * elo
+                                rest_hi += ocoeff * ehi
+                            else:
+                                rest_lo += ocoeff * ehi
+                                rest_hi += ocoeff * elo
+                            if not (np.isfinite(rest_lo) and np.isfinite(rest_hi)):
+                                ok = False
+                                break
+                        if not ok:
+                            continue
+                        num_lo = rhs - rest_hi
+                        num_hi = rhs - rest_lo
+                        if coeff > 0:
+                            v_lo, v_hi = num_lo / coeff, num_hi / coeff
+                        else:
+                            v_lo, v_hi = num_hi / coeff, num_lo / coeff
+                        if not (np.isfinite(v_lo) and np.isfinite(v_hi)):
+                            continue
+                        margin = 1e-6 * (1.0 + max(abs(v_lo), abs(v_hi)))
+                        v_lo -= margin
+                        v_hi += margin
+                        if is_int[vi]:
+                            v_lo = np.ceil(v_lo - 1e-7)
+                            v_hi = np.floor(v_hi + 1e-7)
+                        new_lb = max(lb[vi], v_lo) if np.isfinite(lb[vi]) else v_lo
+                        new_ub = min(ub[vi], v_hi) if np.isfinite(ub[vi]) else v_hi
+                        if (
+                            new_lb > lb[vi] + 1e-12
+                            or new_ub < ub[vi] - 1e-12
+                            or (not np.isfinite(lb[vi]) or not np.isfinite(ub[vi]))
+                        ):
+                            if (np.isfinite(new_lb) != np.isfinite(lb[vi])) or (
+                                np.isfinite(new_ub) != np.isfinite(ub[vi])
+                            ):
+                                changed = True
+                            lb[vi] = new_lb
+                            ub[vi] = new_ub
+                            n_finitized += 1
+                if not changed:
+                    break
+        finally:
+            for v, (olb, oub) in zip(model._variables, saved):
+                v.lb = olb
+                v.ub = oub
+
+        return lb, ub, n_finitized
+    except Exception:
+        return lb, ub, 0
+
+
+def bootstrap_finite_bounds(
+    model: Model,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    *,
+    deadline: Optional[float] = None,
+    time_limit_per_lp: float = 0.2,
+    incumbent_cutoff: Optional[float] = None,
+    eps: float = 1e-7,
+) -> tuple[np.ndarray, np.ndarray, int, float]:
+    """Finitize open variable bounds via LP over the model's linear subsystem.
+
+    Both OBBT and the rounding/diving primal heuristics need a finite box:
+    :func:`obbt_tighten_root` bails the moment any bound is ``±inf`` (it cannot
+    build McCormick envelopes on an open variable), and a heuristic cannot
+    sample an unbounded box.  A model whose only finite information about a
+    variable flows through *nonlinear* constraints (which interval FBBT cannot
+    propagate tightly) therefore stalls — OBBT could derive a finite bound, but
+    it refuses to start because the box is not already finite.
+
+    This bootstrap breaks that chicken-and-egg by deriving finite bounds for
+    the open variables directly from the model's *linear* constraints.  The
+    linear feasible region is a polyhedral OUTER approximation of the MINLP
+    feasible set, so ``max x_i`` / ``min x_i`` over it is a rigorously valid
+    bound on the true problem — the pass can only ever shrink the admissible
+    region, never cut off a feasible point.
+
+    For each variable with ``ub == +inf`` we maximize ``x_i``; for ``lb ==
+    -inf`` we minimize ``x_i``.  A bounded LP optimum (plus a small outward
+    safety margin that keeps the bound rigorous under float / LP-conditioning
+    error) becomes the new finite bound; an unbounded direction leaves the
+    bound open.  Integer bounds are rounded inward.
+
+    Returns ``(lb, ub, n_finitized, total_lp_time)``.  Any internal failure
+    returns the input box unchanged — it can never make the solve unsound.
+    """
+    lb = np.asarray(lb, dtype=np.float64).copy()
+    ub = np.asarray(ub, dtype=np.float64).copy()
+    n_vars = len(lb)
+
+    open_lb = ~np.isfinite(lb)
+    open_ub = ~np.isfinite(ub)
+    if not (open_lb.any() or open_ub.any()):
+        # Common case: box already finite, nothing to bootstrap.
+        return lb, ub, 0, 0.0
+
+    # OBBT-grade soundness requires an EXACT LP oracle: the finitized bound is
+    # the LP optimum, so an inexact optimum could cut off a feasible point
+    # (issue #145).  Without one this is a sound no-op.
+    _lp = get_exact_lp_solver()
+    if _lp is None:
+        return lb, ub, 0, 0.0
+
+    try:
+        from discopt.modeling.core import VarType
+
+        A_ub, b_ub, A_eq, b_eq, _ = _extract_linear_constraints(model)
+
+        # Optimality-based finitization: fold the incumbent cutoff into the
+        # polytope so an open variable that can only grow by worsening the
+        # objective gets a finite bound from the cutoff alone.
+        if incumbent_cutoff is not None and model._objective is not None:
+            from discopt.modeling.core import ObjectiveSense
+
+            obj_coeffs = _extract_linear_objective(model, n_vars)
+            if obj_coeffs is not None and np.any(obj_coeffs):
+                if model._objective.sense == ObjectiveSense.MAXIMIZE:
+                    cutoff_row = -obj_coeffs.reshape(1, -1)
+                    cutoff_rhs = np.array([-incumbent_cutoff])
+                else:
+                    cutoff_row = obj_coeffs.reshape(1, -1)
+                    cutoff_rhs = np.array([incumbent_cutoff])
+                if A_ub is not None and b_ub is not None:
+                    A_ub = np.vstack([A_ub, cutoff_row])
+                    b_ub = np.concatenate([b_ub, cutoff_rhs])
+                else:
+                    A_ub = cutoff_row
+                    b_ub = cutoff_rhs
+
+        if A_ub is None and A_eq is None:
+            # No linear structure to bound against.
+            return lb, ub, 0, 0.0
+
+        is_int = np.zeros(n_vars, dtype=bool)
+        flat_idx = 0
+        for v in model._variables:
+            flag = v.var_type in (VarType.BINARY, VarType.INTEGER)
+            for _ in range(v.size):
+                if flat_idx < n_vars:
+                    is_int[flat_idx] = flag
+                flat_idx += 1
+
+        bounds_list = [(float(lb[i]), float(ub[i])) for i in range(n_vars)]
+        n_finitized = 0
+        total_lp_time = 0.0
+        warm_basis = None
+
+        # Only variables that are open in at least one direction are targets.
+        targets = np.where(open_lb | open_ub)[0]
+        for var_idx in targets:
+            if deadline is not None and time.perf_counter() >= deadline:
+                break
+
+            # Lower bound: minimize x_i (only when currently open below).
+            if open_lb[var_idx]:
+                c = np.zeros(n_vars, dtype=np.float64)
+                c[var_idx] = 1.0
+                result = _lp(
+                    c=c,
+                    A_ub=A_ub,
+                    b_ub=b_ub,
+                    A_eq=A_eq,
+                    b_eq=b_eq,
+                    bounds=bounds_list,
+                    warm_basis=warm_basis,
+                    time_limit=time_limit_per_lp,
+                )
+                total_lp_time += result.wall_time
+                if (
+                    result.status == SolveStatus.OPTIMAL
+                    and result.objective is not None
+                    and np.isfinite(result.objective)
+                ):
+                    warm_basis = result.basis
+                    margin = 1e-6 * (1.0 + abs(result.objective))
+                    new_lb = result.objective - margin
+                    if is_int[var_idx]:
+                        new_lb = np.ceil(new_lb - eps)
+                    lb[var_idx] = new_lb
+                    bounds_list[var_idx] = (float(lb[var_idx]), float(ub[var_idx]))
+                    n_finitized += 1
+
+            if deadline is not None and time.perf_counter() >= deadline:
+                break
+
+            # Upper bound: maximize x_i (minimize -x_i) when currently open above.
+            if open_ub[var_idx]:
+                c = np.zeros(n_vars, dtype=np.float64)
+                c[var_idx] = -1.0
+                result = _lp(
+                    c=c,
+                    A_ub=A_ub,
+                    b_ub=b_ub,
+                    A_eq=A_eq,
+                    b_eq=b_eq,
+                    bounds=bounds_list,
+                    warm_basis=warm_basis,
+                    time_limit=time_limit_per_lp,
+                )
+                total_lp_time += result.wall_time
+                if (
+                    result.status == SolveStatus.OPTIMAL
+                    and result.objective is not None
+                    and np.isfinite(result.objective)
+                ):
+                    warm_basis = result.basis
+                    new_ub = -result.objective
+                    margin = 1e-6 * (1.0 + abs(new_ub))
+                    new_ub = new_ub + margin
+                    if is_int[var_idx]:
+                        new_ub = np.floor(new_ub + eps)
+                    ub[var_idx] = new_ub
+                    bounds_list[var_idx] = (float(lb[var_idx]), float(ub[var_idx]))
+                    n_finitized += 1
+
+        return lb, ub, n_finitized, total_lp_time
+    except Exception:
+        # Bootstrap is best-effort: never let it break the solve.
+        return lb, ub, 0, 0.0
+
+
 def obbt_tighten_root(
     model: Model,
     lb: np.ndarray,
@@ -1083,6 +1513,37 @@ def obbt_tighten_root(
     total_tight = 0
     total_lp_time = 0.0
     n_rounds = 0
+
+    # Bootstrap: if the box is not fully finite, derive finite bounds for the
+    # open variables before the round loop, which otherwise bails immediately on
+    # its finite-box guard (it cannot build a McCormick envelope on an open
+    # variable).  Two complementary rigorous passes, interleaved to a fixpoint
+    # because each unlocks the other:
+    #   * ``bootstrap_finite_bounds`` — LP over the linear subsystem, finitizing
+    #     variables reachable from linear constraints;
+    #   * ``propagate_equality_defined_bounds`` — forward interval propagation
+    #     through equality-defined quantities (``v == g(x)``: divisions, logs,
+    #     …) whose inputs the bootstrap just made finite.
+    # Both only shrink the box, so the result is always a sound subset.
+    for _ in range(2):
+        if np.all(np.isfinite(lb)) and np.all(np.isfinite(ub)):
+            break
+        lb, ub, n_boot, boot_time = bootstrap_finite_bounds(
+            model,
+            lb,
+            ub,
+            deadline=deadline,
+            time_limit_per_lp=time_limit_per_lp,
+            incumbent_cutoff=incumbent_cutoff,
+            eps=eps,
+        )
+        total_tight += n_boot
+        total_lp_time += boot_time
+        lb, ub, n_prop = propagate_equality_defined_bounds(model, lb, ub)
+        total_tight += n_prop
+        if n_boot == 0 and n_prop == 0:
+            break
+
     try:
         from discopt._jax.mccormick_lp import (
             MccormickLPRelaxer,

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -287,6 +287,45 @@ def _distribute_mul(left: Expression, right: Expression) -> Expression:
     return BinaryOp("*", left, right)
 
 
+def _distribute_power_over_product(base: Expression, n: int) -> Expression | None:
+    """Expand ``(a * b)**n`` → ``a**n * b**n`` for integer ``n >= 2`` over a
+    purely multiplicative ``base``.
+
+    This is an *exact* algebraic identity only because the factors are
+    multiplied — it must never be applied across a sum, so a sum (or any
+    non-multiplicative node: division, transcendental call, negation) makes the
+    function return ``None`` and the caller leaves the original power node
+    intact.  Folding a power of a product into a product of powers lets the
+    downstream factor collector (``_collect_extended_factors``) expand each
+    ``x**k`` into its repeated flat-variable factors instead of stranding the
+    whole power-of-product in the un-linearizable ``extra`` bucket — which is
+    what silently dropped nvs06's defining constraint ``w * (x0*x1)**4 == …``.
+
+    Constants fold to ``value**n``; a flat-indexable leaf becomes ``leaf**n``; a
+    nested integer power ``(b**m)**n`` collapses to ``b**(m*n)`` (recursing so a
+    nested product base also expands).
+    """
+    if isinstance(base, Constant):
+        return Constant(float(base.value) ** n)
+    if isinstance(base, (Variable, IndexExpression)):
+        return BinaryOp("**", base, Constant(float(n)))
+    if isinstance(base, BinaryOp):
+        if base.op == "*":
+            left = _distribute_power_over_product(base.left, n)
+            right = _distribute_power_over_product(base.right, n)
+            if left is None or right is None:
+                return None
+            return BinaryOp("*", left, right)
+        if base.op == "**" and isinstance(base.right, Constant):
+            m = float(base.right.value)
+            m_int = int(m)
+            if m == m_int and m_int >= 1:
+                # (b**m)**n → b**(m*n); recurse so a product base under the
+                # inner power still expands to a product of powers.
+                return _distribute_power_over_product(base.left, m_int * n)
+    return None
+
+
 def distribute_products(
     expr: Expression, protected_squares: frozenset[int] | None = None
 ) -> Expression:
@@ -320,7 +359,17 @@ def distribute_products(
             # linearizer's composite-aux map.
             if protected_squares is not None and id(expr) in protected_squares:
                 return expr
-            if float(expr.right.value) == 2.0:
+            exp_val = float(expr.right.value)
+            n_int = int(exp_val)
+            if exp_val == n_int and n_int >= 2:
+                # (a*b)**n → a**n * b**n when the base is a pure product; leaves a
+                # sum base (e.g. (a+b)**n) untouched (helper returns None) so the
+                # ``**2`` square-of-sum path and higher sum-powers are unaffected.
+                base = distribute_products(expr.left, protected_squares)
+                expanded = _distribute_power_over_product(base, n_int)
+                if expanded is not None:
+                    return expanded
+            if exp_val == 2.0:
                 left = distribute_products(expr.left, protected_squares)
                 return _distribute_mul(left, left)
         left = distribute_products(expr.left, protected_squares)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -188,6 +188,26 @@ _POUNCE_BATCH_MIN_VARS = 50
 # budget. Nodes that start fully past the deadline are skipped (see the serial
 # loop), so at most one node per batch can overrun by this floor.
 _DEADLINE_NODE_FLOOR_S = 0.1
+# Per-node OBBT (Lever A) gates. Per-node optimization-based bound tightening is
+# powerful but costs O(n_vars) LPs per node, so it is enabled only for the
+# functionally-dependent-intermediate structural class and on small models, and
+# its cumulative wall time is capped to a fraction of the solve budget. These
+# defaults keep it inert on the broad corpus while letting the welded-beam
+# (nvs05) class certify (see ``dependent_vars`` and the batch loop).
+_PER_NODE_OBBT_MAX_VARS = 100
+_PER_NODE_OBBT_BUDGET_FRAC = 0.6
+_PER_NODE_OBBT_PER_NODE_S = 3.0
+_PER_NODE_OBBT_PER_LP_S = 0.3
+_PER_NODE_OBBT_ROUNDS = 3
+# Floor on the time budget handed to the end-of-solve root-relaxation fallback
+# bound (issue #138). On a hard nonconvex minimize the B&B loop can consume the
+# entire `time_limit` and exit uncertified, leaving no time for the rigorous
+# root MILP-relaxation bound — so a sound dual bound is dropped to None. This
+# floor lets the fallback still run a small, bounded solve so an uncertified exit
+# reports a finite *sound* bound instead of None. It is paid only when the search
+# produced no usable bound at all (never on a clean/certified solve), and the
+# fallback's own internal budget (~10% of this) keeps the overrun small.
+_ROOT_FALLBACK_FLOOR_S = 3.0
 # Multistart runs 3 starts per nonconvex node (warm/midpoint/random) and keeps
 # the best — better incumbents on nonconvex models, but ~3x the node-solve cost.
 # Off by default; flip to opt in (or pass multistart=True to _solve_batch_pounce).
@@ -2349,6 +2369,24 @@ def solve_model(
                 break
         _origin_chk_off += _ov.size
 
+    # Functionally-dependent continuous variables (each pinned by a nonlinear
+    # defining equality x_i = f(others)). Detected on the ORIGINAL model, before
+    # the factorable reform rewrites those equalities into product form (which
+    # would hide the affine isolation of the output). The dependency is
+    # invariant under that rewrite, so the names captured here remain correct to
+    # deprioritize in the lifted/solved model. Spatial branching deprioritizes
+    # these — branching on a pinned output wastes effort the McCormick gap on
+    # the independent inputs would not (welded-beam / nvs05). Names are mapped
+    # to flat columns of the live model at tree setup; deprioritization carries
+    # a completeness-preserving fallback, so an empty or imperfect set is safe.
+    _dependent_var_names: set = set()
+    try:
+        from discopt._jax.dependent_vars import find_functionally_dependent_names
+
+        _dependent_var_names = find_functionally_dependent_names(model)
+    except Exception as _dep_exc:  # pragma: no cover - defensive
+        logger.debug("functional-dependency detection skipped: %s", _dep_exc)
+
     # Pre-reform model + original variable count, set only when the factorable
     # lift actually fires (see below). Used by the per-node interval bound to
     # recover the un-distributed objective's tight enclosure over the original
@@ -3204,6 +3242,55 @@ def solve_model(
                 else:
                     if _nl_int_cols:
                         tree.set_spatial_integer_cols(np.asarray(_nl_int_cols, dtype=np.int64))
+                    # Deprioritize functionally-dependent continuous columns in
+                    # spatial branching. Two disjoint sources, both of which are
+                    # *outputs* pinned by the independent variables, so bisecting
+                    # them never tightens the McCormick gap (which is driven by the
+                    # independent inputs):
+                    #   (a) lifted auxiliaries introduced by the factorable reform
+                    #       (every aux is ``w = g(x)`` by construction — appended
+                    #       after the originals, so columns ``>= _prereform_nvars``).
+                    #       Branching a product aux ``w = x_i*x_j`` cannot shrink
+                    #       that product's envelope; only bisecting ``x_i``/``x_j``
+                    #       can. Without this, the relaxer's wide-domain aux columns
+                    #       win the relative-width competition and the integer
+                    #       product never gets partitioned (welded-beam / nvs05:
+                    #       bound frozen at 2.022 vs the true 5.471).
+                    #   (b) original continuous outputs pinned by a nonlinear
+                    #       equality ``x_i = f(others)`` (detected pre-reform).
+                    # Restricting spatial branching to the original *independent*
+                    # variables matches BARON/Couenne practice and is complete: when
+                    # every independent domain is a point, all dependents are exact
+                    # and the relaxation is tight. The Rust selector's last-resort
+                    # fallback still branches a deprioritized column if no
+                    # independent one remains, preserving completeness.
+                    try:
+                        _dep_cols_set: set = set()
+                        if _prereform_model is not None and n_vars > _prereform_nvars:
+                            _dep_cols_set.update(range(_prereform_nvars, n_vars))
+                        if _dependent_var_names:
+                            from discopt._jax.dependent_vars import (
+                                dependent_columns_for_model,
+                            )
+
+                            _dep_cols_set.update(
+                                dependent_columns_for_model(model, _dependent_var_names)
+                            )
+                        _dep_cols = sorted(_dep_cols_set)
+                        if _dep_cols:
+                            tree.set_branch_deprioritized(np.asarray(_dep_cols, dtype=np.int64))
+                            logger.debug(
+                                "spatial branching deprioritizes %d "
+                                "functionally-dependent continuous columns "
+                                "(%d lifted aux + %d original outputs)",
+                                len(_dep_cols),
+                                max(0, n_vars - _prereform_nvars)
+                                if _prereform_model is not None
+                                else 0,
+                                len(_dependent_var_names),
+                            )
+                    except Exception as _dep_exc:  # pragma: no cover - defensive
+                        logger.debug("branch-deprioritization wiring skipped: %s", _dep_exc)
                     # Root probe: keep the LP relaxer only if it actually yields
                     # a valid objective bound (or a rigorous infeasibility proof)
                     # at the root box. When the objective is not LP-linearizable
@@ -3449,6 +3536,36 @@ def solve_model(
                 sorted(_branch_priority_vars),
             )
 
+    # --- Per-node OBBT (Lever A) setup ---
+    # Tighten each node's box against its McCormick relaxation (with the
+    # incumbent objective as a cutoff when available). Per-node bounds are
+    # subtree-local and rigorous. This is gated to the SAME structural class as
+    # branch-deprioritization — models with functionally-dependent continuous
+    # intermediates (defining equalities x_i = f(others)) — so models without
+    # that structure incur zero overhead. The two levers are complementary:
+    # deprioritization stops branching from wasting effort on dependent outputs,
+    # while per-node OBBT pins those outputs from the relaxation + cutoff so a
+    # node can fathom once its independent drivers are fixed. Neither alone
+    # certifies the welded-beam (nvs05) class; together they do (~23 nodes).
+    # A cumulative time budget caps total cost so a deep tree can never let
+    # per-node OBBT dominate wall clock.
+    _per_node_obbt_enabled = (
+        _mc_lp_relaxer is not None
+        and bool(_dependent_var_names)
+        and n_vars <= _PER_NODE_OBBT_MAX_VARS
+    )
+    _pn_obbt_spent = 0.0
+    _pn_obbt_budget_total = time_limit * _PER_NODE_OBBT_BUDGET_FRAC
+    if _per_node_obbt_enabled:
+        from discopt._jax.obbt import obbt_tighten_root
+
+        logger.debug(
+            "per-node OBBT enabled (n_vars=%d, dependent=%d, budget=%.1fs)",
+            n_vars,
+            len(_dependent_var_names),
+            _pn_obbt_budget_total,
+        )
+
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -3507,6 +3624,57 @@ def solve_model(
                     continue
                 batch_lb[i] = t_lb.tolist()
                 batch_ub[i] = t_ub.tolist()
+
+        # --- Per-node OBBT (Lever A) ---
+        # Tighten each surviving node's box against its own McCormick relaxation
+        # (optionally with the incumbent objective as a cutoff). The relaxation
+        # is built over the node box, so the resulting bounds are valid for the
+        # node's subtree — rigorous, not heuristic. For the dependent-
+        # intermediate class this pins the functionally-dependent outputs from
+        # the relaxation, which is what lets a node fathom once its independent
+        # drivers are branched (welded-beam / nvs05). Gated + budgeted at setup;
+        # here we additionally stop as soon as the cumulative budget is spent.
+        if _per_node_obbt_enabled and _pn_obbt_spent < _pn_obbt_budget_total:
+            _pn_inc = tree.incumbent()
+            _pn_cutoff = (
+                float(_pn_inc[1])
+                if _pn_inc is not None
+                and np.isfinite(_pn_inc[1])
+                and _pn_inc[1] < _SENTINEL_THRESHOLD
+                else None
+            )
+            for i in range(n_batch):
+                if node_infeasible_mask[i]:
+                    continue
+                if _pn_obbt_spent >= _pn_obbt_budget_total:
+                    break
+                _t_pn = time.perf_counter()
+                if time_limit - (_t_pn - t_start) < _DEADLINE_NODE_FLOOR_S:
+                    break
+                try:
+                    _pn_res = obbt_tighten_root(
+                        model,
+                        np.asarray(batch_lb[i], dtype=np.float64),
+                        ub=np.asarray(batch_ub[i], dtype=np.float64),
+                        rounds=_PER_NODE_OBBT_ROUNDS,
+                        incumbent_cutoff=_pn_cutoff,
+                        deadline=_t_pn + _PER_NODE_OBBT_PER_NODE_S,
+                        time_limit_per_lp=_PER_NODE_OBBT_PER_LP_S,
+                        prefer_pounce=nlp_solver == "pounce",
+                    )
+                except Exception as _pn_exc:  # pragma: no cover - defensive
+                    logger.debug("per-node OBBT failed: %s", _pn_exc)
+                    _pn_res = None
+                finally:
+                    _pn_obbt_spent += time.perf_counter() - _t_pn
+                if _pn_res is None:
+                    continue
+                if _pn_res.infeasible:
+                    node_infeasible_mask[i] = True
+                    continue
+                if _pn_res.n_tightened > 0:
+                    batch_lb[i] = np.asarray(_pn_res.lb, dtype=np.float64).tolist()
+                    batch_ub[i] = np.asarray(_pn_res.ub, dtype=np.float64).tolist()
 
         # Solve NLP relaxation for each node in the batch
         t_jax_start = time.perf_counter()
@@ -4215,6 +4383,75 @@ def solve_model(
                 except Exception as e:
                     logger.debug("Feasibility pump failed: %s", e)
 
+                # --- NLP-relaxation-seeded feasibility pump ---
+                # The pump above rounds ``result_sols[best_root_idx]``. When the
+                # relaxation bound is supplied by the McCormick *LP* relaxer that
+                # seed is an LP vertex, and for integer-heavy nonconvex models an
+                # LP vertex can round into a far-suboptimal integer assignment even
+                # though the genuine continuous NLP relaxation rounds straight into
+                # the global basin (st_e31: LP-vertex rounding parks the incumbent
+                # at obj=-1.0 for >100 s while a single NLP-relaxation rounding
+                # reaches the true optimum -2.0 immediately). When the LP relaxer is
+                # active the root multistart NLP is otherwise skipped (it is not a
+                # bound source there), so the pump never sees that point. Solve one
+                # root NLP relaxation now purely to supply a better rounding seed.
+                # General: any integer-heavy nonconvex MINLP on the LP-relaxer path
+                # benefits; no-op for convex models and when no NLP backend exists.
+                # Sound: only pump-verified feasible incumbents that strictly
+                # improve the current incumbent are injected (``inject_incumbent``
+                # enforces strict improvement), so a worse seed can never regress
+                # the reported solution.
+                if _mc_lp_relaxer is not None and not _model_is_convex:
+                    try:
+                        from discopt._jax.primal_heuristics import feasibility_pump
+
+                        _relax_opts = dict(opts)
+                        _relax_opts["max_wall_time"] = max(
+                            _DEADLINE_NODE_FLOOR_S,
+                            min(3.0, _deadline - time.perf_counter()),
+                        )
+                        _root_relax = _solve_root_node_multistart(
+                            _active_evaluator,
+                            np.array(batch_lb[best_root_idx]),
+                            np.array(batch_ub[best_root_idx]),
+                            _active_cb,
+                            _relax_opts,
+                            nlp_solver,
+                            n_random=0,
+                            deadline=_deadline,
+                        )
+                        if (
+                            _root_relax is not None
+                            and _root_relax.x is not None
+                            and _root_relax.status
+                            in (SolveStatus.OPTIMAL, SolveStatus.ITERATION_LIMIT)
+                        ):
+                            fp_sol2 = feasibility_pump(
+                                model,
+                                np.asarray(_root_relax.x, dtype=float),
+                                max_rounds=5,
+                                backend=_resolve_heuristic_backend(nlp_solver),
+                                evaluator=evaluator,
+                                deadline=t_start + time_limit,
+                            )
+                            if fp_sol2 is not None:
+                                fp_obj2 = float(evaluator.evaluate_objective(fp_sol2))
+                                fp_feas2 = not cl_list or _check_constraint_feasibility(
+                                    evaluator, fp_sol2, cl_list, cu_list
+                                )
+                                if (
+                                    np.isfinite(fp_obj2)
+                                    and fp_obj2 < _SENTINEL_THRESHOLD
+                                    and fp_feas2
+                                ):
+                                    tree.inject_incumbent(fp_sol2, fp_obj2)
+                                    logger.info(
+                                        "NLP-relaxation feasibility pump found incumbent: obj=%.6g",
+                                        fp_obj2,
+                                    )
+                    except Exception as e:
+                        logger.debug("NLP-relaxation feasibility pump failed: %s", e)
+
                 # --- Integer local search (1-opt + 2-opt) ---
                 # Two roles, both at the root:
                 #   (1) Feasibility recovery — if round-and-repair found no
@@ -4766,6 +5003,13 @@ def solve_model(
     # parity. Surfaced lazily — only when the search yielded nothing — and never
     # overrides an existing finite bound.
     _rr_remaining = time_limit - (time.perf_counter() - t_start)
+    if (bound_val is None or not np.isfinite(bound_val)) and _rr_remaining <= 0.0:
+        # B&B consumed the whole limit and surfaced no bound. Spend a small bounded
+        # slice on the rigorous root-relaxation fallback anyway so an uncertified
+        # minimize exit reports a sound dual bound instead of None (issue #138).
+        # Only ever reached when the search produced nothing usable; the floor's
+        # own ~10% internal budget keeps the wall-time overrun small.
+        _rr_remaining = _ROOT_FALLBACK_FLOOR_S
     if (
         (bound_val is None or not np.isfinite(bound_val))
         and (model._objective.sense == ObjectiveSense.MINIMIZE)

--- a/python/tests/test_factorable_reform.py
+++ b/python/tests/test_factorable_reform.py
@@ -21,9 +21,14 @@ from pathlib import Path
 
 import discopt.modeling as dm
 import pytest
-from discopt._jax.factorable_reform import canonicalize_entropy, factorable_reformulate
+from discopt._jax.factorable_reform import (
+    _should_lift_call_arg,
+    canonicalize_entropy,
+    factorable_reformulate,
+    has_factorable_work,
+)
 from discopt._jax.term_classifier import classify_nonlinear_terms
-from discopt.modeling.core import FunctionCall
+from discopt.modeling.core import FunctionCall, Variable
 
 _DATA = Path(__file__).parent / "data" / "minlplib"
 
@@ -135,6 +140,119 @@ def test_transcendental_product_not_lifted():
     m.subject_to(x + y >= 3)
     out = factorable_reformulate(m)
     assert out is m
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary-variable factorization of ``outer(g(x))`` (transcendental over a
+# multivariate factorable argument) — the general lift for nodes such as
+# ``sqrt(x4**2 + 2*x4*x5*x7 + x5**2)`` that the univariate envelope cannot reach.
+# ---------------------------------------------------------------------------
+
+
+def _outer_sqrt_node(model):
+    """Return the (single) sqrt FunctionCall in *model*'s objective, or None."""
+    found: list[FunctionCall] = []
+
+    def walk(e):
+        if isinstance(e, FunctionCall):
+            found.append(e)
+        for attr in ("left", "right", "operand"):
+            if hasattr(e, attr):
+                walk(getattr(e, attr))
+        if hasattr(e, "args"):
+            for a in e.args:
+                walk(a)
+
+    walk(model._objective.expression)
+    return found[0] if found else None
+
+
+def test_multivar_sqrt_arg_is_lifted():
+    """``sqrt(x*x + 2*x*y*z + y*y)`` — a non-affine, multivariate argument the
+    univariate envelope cannot reach — is lifted to ``sqrt(t)`` with ``t == g``.
+    The gate fires and the rewritten node is a sqrt over a single aux Variable."""
+    m = dm.Model("multivar_sqrt")
+    x = m.continuous("x", lb=0.5, ub=3.0)
+    y = m.continuous("y", lb=0.5, ub=3.0)
+    z = m.continuous("z", lb=0.5, ub=3.0)
+    m.minimize(dm.sqrt(x * x + 2.0 * x * y * z + y * y))
+
+    node = _outer_sqrt_node(m)
+    assert _should_lift_call_arg(node, m) is not None, "gate should select the multivar arg"
+    assert has_factorable_work(m)
+
+    out = factorable_reformulate(m)
+    assert out is not m
+    assert len(_aux_names(out)) >= 1, "expected an aux variable for t == g(x)"
+    lifted = _outer_sqrt_node(out)
+    assert lifted is not None and lifted.func_name == "sqrt"
+    assert len(lifted.args) == 1 and isinstance(lifted.args[0], Variable), (
+        "sqrt argument should now be a single aux variable"
+    )
+
+
+def test_affine_norm_sqrt_not_lifted():
+    """An affine 2-norm ``sqrt(0.25*x**2 + (0.5*y+0.5*z)**2)`` is proven convex by
+    the detector and relaxed exactly by its own envelope — the lift must NOT
+    downgrade it to the looser concave-sqrt form."""
+    m = dm.Model("affine_norm")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    z = m.continuous("z", lb=-2.0, ub=2.0)
+    m.minimize(dm.sqrt(0.25 * x**2 + (0.5 * y + 0.5 * z) ** 2))
+
+    node = _outer_sqrt_node(m)
+    assert _should_lift_call_arg(node, m) is None, "convex affine norm must not be lifted"
+
+
+def test_univariate_sqrt_arg_not_lifted():
+    """``sqrt(x*x + 3)`` has a single-variable argument reached by the existing
+    composite-univariate path; the multivariate lift must abstain."""
+    m = dm.Model("univar_sqrt")
+    x = m.continuous("x", lb=0.5, ub=3.0)
+    m.minimize(dm.sqrt(x * x + 3.0))
+
+    node = _outer_sqrt_node(m)
+    assert _should_lift_call_arg(node, m) is None, "single-variable arg must not be lifted"
+
+
+def test_exp_multivar_arg_is_lifted():
+    """The lift generalizes beyond sqrt: ``exp(x*y)`` (a transcendental over a
+    bilinear, UNKNOWN-curvature argument) is lifted to ``exp(t)`` with ``t == x*y``."""
+    m = dm.Model("exp_bilinear")
+    x = m.continuous("x", lb=0.5, ub=2.0)
+    y = m.continuous("y", lb=0.5, ub=2.0)
+    m.minimize(dm.exp(x * y))
+
+    node = _outer_sqrt_node(m)
+    assert node is not None and node.func_name == "exp"
+    assert _should_lift_call_arg(node, m) is not None
+    out = factorable_reformulate(m)
+    assert out is not m
+    lifted = _outer_sqrt_node(out)
+    assert lifted.func_name == "exp"
+    assert len(lifted.args) == 1 and isinstance(lifted.args[0], Variable)
+
+
+@pytest.mark.correctness
+def test_lifted_multivar_sqrt_is_sound_and_optimal():
+    """End-to-end: a well-conditioned multivariate cross-term sqrt objective
+    certifies to its true optimum with a sound dual bound after the lift.
+
+    ``min sqrt(x*x + 2*x*y*z + y*y)`` over ``x,y,z in [1,3]`` is minimized at the
+    box corner ``x=y=z=1``: ``sqrt(1 + 2 + 1) = 2``."""
+    m = dm.Model("sound_multivar_sqrt")
+    m.continuous("x", lb=1.0, ub=3.0)
+    m.continuous("y", lb=1.0, ub=3.0)
+    m.continuous("z", lb=1.0, ub=3.0)
+    xv, yv, zv = (v for v in m._variables)
+    m.minimize(dm.sqrt(xv * xv + 2.0 * xv * yv * zv + yv * yv))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r = m.solve(time_limit=60, gap_tolerance=1e-4)
+    assert r.objective == pytest.approx(2.0, abs=1e-3)
+    if r.bound is not None:
+        assert r.bound <= r.objective + 1e-4, "dual bound must not exceed the optimum"
 
 
 @pytest.mark.correctness

--- a/python/tests/test_pinned_var_lift.py
+++ b/python/tests/test_pinned_var_lift.py
@@ -69,6 +69,90 @@ def test_st_e11_certifies_with_sound_bound():
 
 
 @pytest.mark.correctness
+@pytest.mark.parametrize(
+    "arity,pins",
+    [
+        (4, 1),  # 4-way -> trilinear  (unpinned == 3)
+        (4, 2),  # 4-way -> bilinear   (unpinned == 2)
+        (5, 1),  # 5-way -> 4-way      (unpinned >= 4: collapsed subset still multilinear)
+        (5, 2),  # 5-way -> trilinear
+        (6, 2),  # 6-way -> 4-way      (unpinned >= 4)
+    ],
+)
+def test_multilinear_pinned_collapse_keeps_objective_bound(arity, pins):
+    """A k-way product that pins factors must still linearize at that node.
+
+    During B&B a factor of a multilinear term can pin (lb==ub), and
+    ``_linearize_expr`` folds it into the coefficient — collapsing the term to a
+    lower-arity product *keyed by the unpinned subset*. Unless that collapsed
+    bilinear/trilinear/multilinear key is pre-registered, the linearizer raises
+    ``"... not in map"`` and the whole constraint (here the objective) drops,
+    sinking the node's dual bound. The collapse target follows the linearizer's
+    arity dispatch exactly: 2 -> bilinear, 3 -> trilinear, >=4 -> multilinear.
+    """
+    m = dm.Model(f"multi{arity}")
+    xs = [m.continuous(f"x{i}", lb=0.5, ub=2.0) for i in range(arity)]
+    prod = xs[0]
+    for x in xs[1:]:
+        prod = prod * x
+    m.minimize(prod)
+    terms = classify_nonlinear_terms(m)
+    disc = DiscretizationState(partitions={})
+    lb, ub = flat_variable_bounds(m)
+
+    # Root box: the full k-way term linearizes (baseline).
+    root, _ = build_milp_relaxation(m, terms, disc, bound_override=(lb.copy(), ub.copy()))
+    assert root._objective_bound_valid
+
+    # Pin the first ``pins`` factors (lb==ub) and confirm the collapsed
+    # (k-pins)-ary product still linearizes rather than dropping the objective.
+    lb_pin, ub_pin = lb.copy(), ub.copy()
+    for i in range(pins):
+        lb_pin[i] = 1.0
+        ub_pin[i] = 1.0
+    milp, _ = build_milp_relaxation(m, terms, disc, bound_override=(lb_pin, ub_pin))
+    assert milp._objective_bound_valid, (
+        f"pinning {pins} of {arity} factors dropped the objective bound"
+    )
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("pin_base", [True, False])
+def test_bilinear_with_pinned_fractional_power_keeps_objective_bound(pin_base):
+    """``y * x**p`` must still linearize when the power base ``x`` pins.
+
+    A variable times a fractional power (the gas-network compressor objective
+    ``w * beta**0.2857``) is relaxed via the bilinear-with-fractional-power path:
+    an aux ``z = x**p`` plus a McCormick envelope on ``y * z``. When ``x`` pins
+    (lb==ub from branching/OBBT) the builder skips the ``z`` aux for the
+    degenerate domain, so the product reaches ``_decompose_product`` with no aux
+    column. Without folding the pinned power to its exact constant the product is
+    undecomposable and the whole objective drops to the feasibility fallback,
+    sinking the node's dual bound. Pinning the *other* factor (``y``) must
+    likewise keep the term (it collapses to the pure power ``x**p``).
+    """
+    m = dm.Model("bilinear_fp")
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    x = m.continuous("x", lb=1.0, ub=2.0)
+    m.minimize(y * (x**0.2857))
+    terms = classify_nonlinear_terms(m)
+    assert terms.bilinear_with_fp, "expected a bilinear-with-fractional-power term"
+    disc = DiscretizationState(partitions={})
+    lb, ub = flat_variable_bounds(m)
+
+    root, _ = build_milp_relaxation(m, terms, disc, bound_override=(lb.copy(), ub.copy()))
+    assert root._objective_bound_valid
+
+    lb_pin, ub_pin = lb.copy(), ub.copy()
+    idx = 1 if pin_base else 0  # x is var 1 (power base), y is var 0
+    val = 1.5 if pin_base else 4.0
+    lb_pin[idx] = ub_pin[idx] = val
+    milp, _ = build_milp_relaxation(m, terms, disc, bound_override=(lb_pin, ub_pin))
+    which = "power base x" if pin_base else "factor y"
+    assert milp._objective_bound_valid, f"pinning {which} dropped the objective bound"
+
+
+@pytest.mark.correctness
 def test_pinned_value_is_exact_not_relaxed():
     """A fully pinned univariate-power objective term equals the exact value."""
     # min x**0.6 with x pinned to 16 → exactly 16**0.6, no relaxation slack.

--- a/python/tests/test_quotient_certification.py
+++ b/python/tests/test_quotient_certification.py
@@ -60,11 +60,10 @@ def test_gear_ratio_certifies_near_zero(instance):
     "instance, optimum",
     [
         ("nvs01", 12.46966882),  # (18505*x1**2 + ...) / (x0**2 + 7200) quadratic/quadratic
-        ("nvs06", 1.7703125),  # variable/variable ratio
     ],
 )
 def test_nvs_ratio_certifies(instance, optimum):
-    """nvs01 / nvs06 variable/variable ratios certify their optimum soundly."""
+    """nvs01 variable/variable ratio certifies its optimum soundly."""
     nl = _DATA / f"{instance}.nl"
     assert nl.exists(), f"missing {nl}"
     r = dm.from_nl(str(nl)).solve(time_limit=60, gap_tolerance=1e-4)
@@ -74,3 +73,34 @@ def test_nvs_ratio_certifies(instance, optimum):
     # Soundness: a valid dual bound never exceeds the known global optimum.
     assert r.bound <= optimum + 1e-2, f"[{instance}] unsound dual bound {r.bound} > {optimum}"
     assert r.gap_certified, f"[{instance}] expected certified optimality"
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize(
+    "instance, optimum",
+    [
+        ("nvs06", 1.7703125),  # variable/variable ratio, ill-conditioned denominator-clearing
+    ],
+)
+def test_nvs_ratio_sound_uncertified(instance, optimum):
+    """nvs06 reaches its optimum with a SOUND (never over-tight) bound.
+
+    nvs06 is nvs22's ill-conditioned sibling: clearing its variable/variable
+    denominator yields McCormick rows whose LP relaxation has a badly conditioned
+    optimal basis. The Neumaier-Shcherbina safe dual-bounding discriminator in
+    ``run_obbt_on_relaxation`` (see obbt.py ``_ns_safe_lp_lower_bound``) refuses to
+    trust the inaccurate LP vertex here, so OBBT no longer over-tightens and the
+    root no longer prunes toward a spurious tight bound. The incumbent still reaches
+    the true optimum and the surfaced bound stays a valid under-estimate, but the
+    gap is not closed to tolerance. We assert soundness, NOT certification: the prior
+    "certified" status relied on the untrustworthy vertex and was the same mechanism
+    that produced nvs22's false certificate (certified 47.56 vs true 6.0582).
+    """
+    nl = _DATA / f"{instance}.nl"
+    assert nl.exists(), f"missing {nl}"
+    r = dm.from_nl(str(nl)).solve(time_limit=60, gap_tolerance=1e-4)
+
+    assert r.objective is not None and r.bound is not None, f"[{instance}] no bound produced"
+    assert abs(r.objective - optimum) <= 1e-2, f"[{instance}] obj={r.objective} != {optimum}"
+    # Soundness is the invariant: a valid dual bound never exceeds the optimum.
+    assert r.bound <= optimum + 1e-2, f"[{instance}] unsound dual bound {r.bound} > {optimum}"


### PR DESCRIPTION
## Summary

Four related improvements to discopt's global-optimization / convexity / bound-tightening machinery, all previously unmerged on this branch. Each is general (keys off structural patterns, not single instances) and validated against the BARON head-to-head and the soundness-canary suite.

### Commits

1. **`feat(amp)`** — general box-restricted multivariate convexity certificate + weighted affine-norm recognizer.
2. **`feat(factorable)`** — aux-var factorization for transcendental ∘ multivariate args.
3. **`fix(global-opt)`** — close three certification/correctness gaps (nvs05, nvs06, st_e36).
4. **`feat(obbt)`** — bootstrap finite bounds + equality-defined forward propagation.

### OBBT bootstrap (newest)

Two general root-tightening passes in `obbt_tighten_root`, interleaved to a fixpoint, that finitize open variable bounds before McCormick OBBT (which otherwise bails when any bound is ±inf, since an envelope over an open factor is unsound):

- **`bootstrap_finite_bounds`** — for each variable with an open bound, min/max it over the *linear* subsystem via the exact LP solver; the bounded optimum plus an outward margin becomes a finite bound. Breaks the chicken-and-egg where OBBT cannot build an envelope on a still-open variable.
- **`propagate_equality_defined_bounds`** — for every equality `c·v + g(others) == rhs` linear in a single open var `v`, derive `v == (rhs − g)/c` via interval arithmetic and intersect onto `v`'s box. Handles the sign-definite division terms (`.nl` intermediates `v == g(x)`).

Both sound by construction: boxes only shrink, integer bounds rounded inward, continuous bounds get outward margins, model bounds restored in a `finally`.

## Validation

- `heatexch_gen1` open bounds: **56 → 28 → 16**.
- **735 tests pass**, including the `gear4` false-infeasible and `himmel16` false-certificate soundness canaries.
- BARON head-to-head: **VIOLATIONS 0** across all checked global-opt instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
