### PR TITLE
chore(deps): bump feral to v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,8 +77,8 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "feral"
-version = "0.11.0"
-source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
+version = "0.11.1"
+source = "git+https://github.com/jkitchin/feral?tag=v0.11.1#e5587b317efcd2555a73a60a92f62aa356c626b2"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -95,7 +95,7 @@ dependencies = [
 [[package]]
 name = "feral-amd"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
+source = "git+https://github.com/jkitchin/feral?tag=v0.11.1#e5587b317efcd2555a73a60a92f62aa356c626b2"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -103,7 +103,7 @@ dependencies = [
 [[package]]
 name = "feral-amf"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
+source = "git+https://github.com/jkitchin/feral?tag=v0.11.1#e5587b317efcd2555a73a60a92f62aa356c626b2"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "feral-kahip"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
+source = "git+https://github.com/jkitchin/feral?tag=v0.11.1#e5587b317efcd2555a73a60a92f62aa356c626b2"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "feral-metis"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
+source = "git+https://github.com/jkitchin/feral?tag=v0.11.1#e5587b317efcd2555a73a60a92f62aa356c626b2"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -130,12 +130,12 @@ dependencies = [
 [[package]]
 name = "feral-ordering-core"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
+source = "git+https://github.com/jkitchin/feral?tag=v0.11.1#e5587b317efcd2555a73a60a92f62aa356c626b2"
 
 [[package]]
 name = "feral-scotch"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=ee0ef3308a30782a1ece5406934c6bbedc290123#ee0ef3308a30782a1ece5406934c6bbedc290123"
+source = "git+https://github.com/jkitchin/feral?tag=v0.11.1#e5587b317efcd2555a73a60a92f62aa356c626b2"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -10,7 +10,7 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # feral: pure-Rust sparse linear algebra. Provides the unsymmetric LU basis
 # engine (ftran/btran + product-form column updates) that backs the warm-started
 # simplex node engine for MILP. Pure-Rust, so clean-wheel builds are preserved.
-feral = { git = "https://github.com/jkitchin/feral", rev = "ee0ef3308a30782a1ece5406934c6bbedc290123" }
+feral = { git = "https://github.com/jkitchin/feral", tag = "v0.11.1" }
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to
 # 1.10 to keep the crate's MSRV (1.75); 1.12+ requires rustc 1.80.


### PR DESCRIPTION
## Summary

Bumps the `feral` dependency from a floating git rev (`ee0ef33`) to the released **v0.11.1** tag.

- `crates/discopt-core/Cargo.toml` — `rev = "ee0ef33…"` → `tag = "v0.11.1"`.
- `Cargo.lock` — `feral` and its sub-crates (`feral-amd`/`amf`/`kahip`/`metis`/`ordering-core`/`scotch`) repointed to `tag=v0.11.1` (commit `e5587b31`).

Kept the git source so the sub-crate build topology is unchanged — this is the minimal, faithful bump. `feral` provides the unsymmetric LU basis engine backing the warm-started simplex node engine.

## Verification

`cargo check -p discopt-core` (the only direct `feral` consumer) builds clean against v0.11.1.

## Note

`feral` 0.11.1 is also published on crates.io; switching the dependency from git to a crates.io version (`feral = "0.11.1"`) could be a separate follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
