### PR TITLE
feat(modeling): set & index abstractions (Phase 7, M1–M7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,13 +159,15 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
-- **`.nl` export of builder constraints** (`fix(export)`). Linear constraints
-  built directly into the Rust builder — via the fast-construction
+- **`.nl` export of builder constraints and objective** (`fix(export)`). Linear
+  constraints built directly into the Rust builder — via the fast-construction
   `add_linear_constraints` API and the indexed-constraint fast path — were
-  silently omitted from `to_nl` / `to_mps`-adjacent `.nl` output, which reads
-  `model._constraints`. The model now records each emitted block and the `.nl`
-  writer reconstructs those rows, so a fast-path model round-trips through `.nl`
-  with all constraints intact.
+  silently omitted from `to_nl`, which reads `model._constraints`; likewise a
+  linear objective set via `add_linear_objective` was exported as a zero
+  placeholder. The model now records each emitted block (constraints and the
+  `c'x + constant` objective) and the `.nl` writer reconstructs them, so a
+  fast-path model round-trips through `.nl` with all constraints and the correct
+  objective (including a constant offset and `maximize` sense) intact.
 - **Relaxation soundness hardening** across the global-opt loop: reject a
   fabricated finite bound on an unbounded McCormick relaxation (`himmel16`,
   `fix(soundness)`); never trust an unconverged simplex objective as an LP lower

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,27 @@ The release procedure that produces these entries is documented in
 
 ### Added
 
-- **Named index sets & set algebra** (`feat(modeling)`). New
-  `discopt.Set` / `discopt.RangeSet` (and `ProductSet`) plus `Model.set(...)` add
-  a Pyomo/JuMP-style named-set layer for sparse models: arbitrary hashable
-  members with inferred/declared `dimen`, set algebra (`|`, `&`, `-`, `*`), and
-  filtering (`Set.where`, `with_first`, `with_last`). This is milestone M1 of the
-  Phase 7 "set & index abstractions" roadmap item — a pure-Python desugaring
-  layer; indexed variables/constraints land in later milestones. Design in
-  `docs/design/sets-and-indexing.md`.
+- **Set & index abstractions** (`feat(modeling)`). A Pyomo/JuMP-style named-set
+  layer for sparse models, implemented as a pure-Python desugaring over the
+  existing flat model (no solver/backend changes). Completes the Phase 7
+  roadmap item. New public API:
+  - `discopt.Set` / `discopt.RangeSet` (+ `ProductSet`) and `Model.set(...)`:
+    arbitrary hashable members with inferred/declared `dimen`, set algebra
+    (`|`, `&`, `-`, `*`), and filtering (`Set.where`, `with_first`,
+    `with_last`). Product sets are lazy and accept flat or nested keys.
+  - `Model.continuous/binary/integer/parameter(..., over=SET)` returning
+    `IndexedVar` / `IndexedParam` backed by a single flat variable/parameter;
+    per-key bounds/values via scalar, `dict`, or callable.
+  - `Model.constraint(SET, rule, name=)` generating one constraint per member
+    (named `name[key]`), with a `Skip` sentinel; `subject_to` now accepts
+    generators of constraints. `dm.sum`/`dm.prod` aggregate over sets.
+  - A transparent **linear fast path**: single-variable-affine, uniform-sense
+    families are emitted as one sparse-matrix builder call (`fast=True`
+    default) with identical results, falling back automatically otherwise.
+  Documented in `docs/notebooks/sets_and_indexing.ipynb`; design in
+  `docs/design/sets-and-indexing.md`; examples
+  `example_transportation` / `example_assignment` /
+  `example_multicommodity_flow`.
 - **Irreducible Infeasible Subsystem (IIS)** (`feat(infeasibility)`, #227). New
   `compute_iis(model)` returns a minimal infeasible subset of constraints/bounds
   via deletion filtering — exact for LP/MILP/convex, best-effort for nonconvex.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The release procedure that produces these entries is documented in
 
 ### Added
 
+- **Named index sets & set algebra** (`feat(modeling)`). New
+  `discopt.Set` / `discopt.RangeSet` (and `ProductSet`) plus `Model.set(...)` add
+  a Pyomo/JuMP-style named-set layer for sparse models: arbitrary hashable
+  members with inferred/declared `dimen`, set algebra (`|`, `&`, `-`, `*`), and
+  filtering (`Set.where`, `with_first`, `with_last`). This is milestone M1 of the
+  Phase 7 "set & index abstractions" roadmap item — a pure-Python desugaring
+  layer; indexed variables/constraints land in later milestones. Design in
+  `docs/design/sets-and-indexing.md`.
 - **Irreducible Infeasible Subsystem (IIS)** (`feat(infeasibility)`, #227). New
   `compute_iis(model)` returns a minimal infeasible subset of constraints/bounds
   via deletion filtering — exact for LP/MILP/convex, best-effort for nonconvex.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,15 +159,17 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
-- **`.nl` export of builder constraints and objective** (`fix(export)`). Linear
+- **`.nl` export of builder constraints and objectives** (`fix(export)`). Linear
   constraints built directly into the Rust builder — via the fast-construction
   `add_linear_constraints` API and the indexed-constraint fast path — were
-  silently omitted from `to_nl`, which reads `model._constraints`; likewise a
-  linear objective set via `add_linear_objective` was exported as a zero
-  placeholder. The model now records each emitted block (constraints and the
-  `c'x + constant` objective) and the `.nl` writer reconstructs them, so a
-  fast-path model round-trips through `.nl` with all constraints and the correct
-  objective (including a constant offset and `maximize` sense) intact.
+  silently omitted from `to_nl`, which reads `model._constraints`; likewise an
+  objective set via `add_linear_objective` / `add_quadratic_objective` was
+  exported as a zero placeholder. The model now records each emitted block
+  (constraints and the `0.5 x'Qx + c'x + constant` objective) and the `.nl`
+  writer reconstructs them — the quadratic part as an n-ary `SUMLIST` nonlinear
+  objective term — so a fast-construction model round-trips through `.nl` with
+  all constraints and the correct linear/quadratic objective (including a
+  constant offset and `maximize` sense) intact.
 - **Relaxation soundness hardening** across the global-opt loop: reject a
   fabricated finite bound on an unbounded McCormick relaxation (`himmel16`,
   `fix(soundness)`); never trust an unconverged simplex objective as an LP lower

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,13 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **`.nl` export of builder constraints** (`fix(export)`). Linear constraints
+  built directly into the Rust builder — via the fast-construction
+  `add_linear_constraints` API and the indexed-constraint fast path — were
+  silently omitted from `to_nl` / `to_mps`-adjacent `.nl` output, which reads
+  `model._constraints`. The model now records each emitted block and the `.nl`
+  writer reconstructs those rows, so a fast-path model round-trips through `.nl`
+  with all constraints intact.
 - **Relaxation soundness hardening** across the global-opt loop: reject a
   fabricated finite bound on an unbounded McCormick relaxation (`himmel16`,
   `fix(soundness)`); never trust an unconverged simplex objective as an LP lower

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,7 +95,7 @@ New problem types to make discopt competitive across the full optimization lands
 
 | Task                              | Status  | Description                                                                  |
 |-----------------------------------|---------|------------------------------------------------------------------------------|
-| Set and index abstractions        | Planned | Named sets, indexed variables/constraints, set algebra for sparse models     |
+| Set and index abstractions        | Done    | Named sets, indexed variables/constraints, set algebra for sparse models     |
 | Piecewise-linear functions        | Done    | SOS2 constraints in modeling API                                             |
 | Native indicator constraints      | Done    | `_IndicatorConstraint` class in modeling API                                 |
 | Warm-starting API                 | Done    | `m.solve(initial_solution=...)` with validation                              |

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -31,6 +31,7 @@ parts:
     chapters:
       - file: notebooks/quickstart
       - file: notebooks/modeling_guide
+      - file: notebooks/sets_and_indexing
       - file: notebooks/tutor_course
       - file: notebooks/minlp_examples
       - file: notebooks/problem_classes

--- a/docs/design/sets-and-indexing.md
+++ b/docs/design/sets-and-indexing.md
@@ -1,6 +1,6 @@
 # Set & Index Abstractions — Design
 
-**Status:** planned · **Last updated:** 2026-06-19 ·
+**Status:** implemented (M1–M7) · **Last updated:** 2026-06-19 ·
 **Scope:** named index sets, set algebra, indexed (dense + sparse) variables/parameters/
 constraints, aggregation over sets, and the performance routing that maps these
 abstractions onto the existing flat model representation.

--- a/docs/design/sets-and-indexing.md
+++ b/docs/design/sets-and-indexing.md
@@ -1,0 +1,198 @@
+# Set & Index Abstractions — Design
+
+**Status:** planned · **Last updated:** 2026-06-19 ·
+**Scope:** named index sets, set algebra, indexed (dense + sparse) variables/parameters/
+constraints, aggregation over sets, and the performance routing that maps these
+abstractions onto the existing flat model representation.
+**Bottom line:** this is a pure-Python **desugaring layer** on top of the current
+modeling API. By solve time only flat `Variable`/`Constraint` objects exist, so the Rust
+core, JAX compiler, `.nl` exporter, B&B, and every phase gate are untouched. Correctness
+rests on *equivalence to the existing positional API*.
+
+This realizes the Phase 7 roadmap item:
+
+> **Set and index abstractions** — Named sets, indexed variables/constraints, set algebra
+> for sparse models.
+
+---
+
+## 1. Motivation
+
+The modeling API today exposes **dense, NumPy-style `shape=` arrays with positional
+integer indexing** (`core.py`):
+
+```python
+x = m.continuous("flow", shape=(3, 4), lb=0)   # dense 3x4 tensor
+m.subject_to(x[0, 0] + x[1, 2] <= 10)          # integer indices only
+for i in range(3):
+    for j in range(4):
+        m.subject_to(x[i, j] >= 0, name=f"nn_{i}_{j}")   # manual loops
+```
+
+This is the equivalent of JuMP's `Array` tier / Pyomo's dense `Var`. It cannot express:
+
+- **Labels** — `ship["pitt", "a"]` instead of `x[0, 0]`.
+- **Sparsity** — a variable defined only on a subset of pairs (a sparse transportation
+  network) without allocating the full dense tensor and leaving entries unused.
+- **Set algebra** — unions/intersections/cross-products/filters that drive which index
+  tuples exist.
+
+## 2. SOTA survey (design lessons adopted)
+
+**JuMP** picks the *tightest container that fits*: `Array` (rectangular, `1:n`) →
+`DenseAxisArray` (rectangular, arbitrary **labels**, including integer labels like
+`x[:h2, 10]`) → `SparseAxisArray` (subset of entries, triggered by a filtering condition
+such as `i <= j`). `DenseAxisArray` exists specifically to avoid positional/label
+ambiguity; `SparseVariables.jl` extends the sparse tier for very sparse models.
+
+**Pyomo** makes a `Set` the first argument (index) of `Var`/`Constraint`/`Param`; provides
+`RangeSet` (now on `NumericRange`, supports unbounded/continuous ranges); exposes **set
+algebra** via `|` `&` `-` `*`; and supports **sparse construction** through conditional
+rules (`Constraint.Skip`). It documents a footgun: summing over a *sparse* var only covers
+indices already materialized.
+
+**GAMS/AMPL** contribute the canonical mental model: declare sets, declare data/params/
+vars over sets, write constraints with a "for-all" domain plus a summation domain.
+
+**Lessons adopted:**
+1. Keep dense `shape=` as the "Array" tier; add label-indexed and sparse tiers on top
+   (JuMP's container ladder).
+2. Make the **set the single source of truth** for which tuples exist — avoids Pyomo's
+   sparse-sum footgun.
+3. Set algebra as operators (`|` `&` `-` `*`) plus filtering (`Set.where(pred)`).
+4. Arbitrary **hashable labels**, not just integers — the core expressiveness win.
+
+## 3. Architecture
+
+All new code in `python/discopt/modeling/`:
+
+| File | Change |
+|------|--------|
+| `sets.py` | **NEW** — `Set`, `RangeSet`, `ProductSet`, `IndexedVar`, `IndexedParam`, `IndexedConstraint`, `Skip` |
+| `core.py` | `Model.set()`, `over=` kwarg on `continuous`/`binary`/`integer`/`parameter`, `Model.constraint()`, `subject_to()` accepts generators with key-tuple naming |
+| `modeling/__init__.py`, `discopt/__init__.py` | export `Set`, `RangeSet` |
+
+### 3.1 Backing mechanism (the key idea)
+
+An indexed variable is **backed by exactly one flat `Variable`** of shape `(len(index),)`
+plus an order-stable `key_tuple -> position` map. `IndexedVar.__getitem__(key)` returns the
+existing `IndexExpression(flat_var, position)` — which the JAX compiler and `.nl` exporter
+already flatten. **Nothing downstream changes.** Per-key bounds map onto the flat
+`Variable.lb/ub` arrays (scalar, dict `{key: bound}`, or callable `key -> bound`).
+
+### 3.2 `Set`
+
+```python
+class Set:
+    name: str
+    members: tuple[Hashable, ...]    # order-stable, de-duplicated
+    dimen: int                        # inferred from member arity; override via dimen=
+    def __or__/__and__/__sub__(self, other) -> Set     # union / intersection / difference
+    def __mul__(self, other) -> ProductSet             # lazy cross product
+    def where(self, pred) -> Set                       # filter, e.g. .where(lambda i, j: i < j)
+    def with_first(self, k) / with_last(self, k)       # slice helpers for sparse 2D sets
+    def __iter__ / __len__ / __contains__
+```
+
+- `RangeSet(n)` / `RangeSet(a, b)` — integer convenience subtype (Pyomo parity).
+- `ProductSet` is **lazy** (materializes on iteration); `.where` filters a product into a
+  sparse subset (JuMP's `SparseAxisArray`-via-condition, Pyomo's filtered set).
+
+### 3.3 Model API
+
+```python
+m.set(name, members, dimen=None) -> Set
+m.continuous(name, over=SET, lb=, ub=) -> IndexedVar    # over= and shape= are exclusive
+m.binary(name, over=SET) -> IndexedVar
+m.integer(name, over=SET, lb=, ub=) -> IndexedVar
+m.parameter(name, over=SET, value=) -> IndexedParam     # value: scalar | dict | callable
+m.constraint(SET, rule=fn, name=) -> IndexedConstraint  # rule may return Skip
+m.subject_to((expr(i) for i in SET), name=)             # generator -> key-tuple naming
+```
+
+New model state: `self._sets: list[Set]` (named, dedup'd via existing `_check_name`).
+
+### 3.4 Aggregation
+
+`sum(fn, over=...)`/`prod`/`norm` already accept any iterable, so a `Set` works
+immediately. Python-builtin-style `sum(ship[p, k] for p, k in LINKS.with_first(p))` also
+works via `Expression.__radd__`.
+
+## 4. Orchestration (when used at solve time)
+
+These abstractions are **compile-time sugar**. By `Model.solve()` only flat
+`Variable`/`Constraint` objects exist → no solver-orchestration change, no new runtime
+decision. That is the safety property.
+
+One **performance** routing decision (JuMP's tightest-container spirit): when an indexed
+constraint family is **affine** (DAG contains only `+`/`-`/`*const`/`IndexExpression`/
+`Constant`), batch the whole family into `PyModelBuilder.add_linear_constraints(A, x,
+sense, b)` as sparse rows instead of thousands of Python `Constraint` objects. Nonlinear/
+mixed families use the current per-constraint path. Routing lives in
+`_emit_indexed_constraints()`, defaults to `fast=True`, with `fast=False` escape hatch;
+both paths are asserted to produce identical flat models.
+
+## 5. Correctness
+
+The phase-gate invariant `incorrect_count <= 0` must hold. Correctness rests on
+**desugaring equivalence**.
+
+1. **Equivalence oracle** — build each model twice (sets vs today's `shape=` + manual
+   loops); assert identical flat models (var count/bounds/types, normalized constraint
+   DAGs / `.nl` serialization, objective). Master check.
+2. **Fast-path vs expressive-path** — every indexed-constraint test built with `fast=True`
+   and `fast=False`; assert identical flat models and solutions.
+3. **Known optima** — port transportation/assignment/multi-commodity-flow into
+   `tests/data/known_optima.toml`; mark `@pytest.mark.correctness`.
+4. **Round-trip** — `.nl` export/re-import, plus one `from_pyomo` cross-check.
+5. **Property tests** — set-algebra laws (`(A|B)-B subset A`, `A&B = B&A`,
+   `|A*B| = |A||B|`, `where` idempotent); `|vars| == |distinct keys|`; no phantom/dup
+   constraints.
+
+## 6. Tests
+
+New `python/tests/test_sets.py` (conventions from `test_fast_construction.py`):
+`TestSetAlgebra`, `TestIndexedVariables`, `TestIndexedConstraints`,
+`TestDesugarEquivalence`, `TestFastPathEquivalence`, `TestCorrectness`
+(`@pytest.mark.correctness`), `TestExportRoundTrip`. Total coverage ≥65%; `sets.py` ≥90%.
+`ruff` (100-col, py310) + `mypy discopt.modeling` clean.
+
+## 7. Documentation
+
+`docs/notebooks/sets_and_indexing.ipynb` (motivation → named sets → algebra → indexed
+vars/constraints → sparse vs dense → transportation end-to-end → migration from positional
+`shape=`), with `{cite:p}` citations. `docs/references.bib`: Pyomo (Hart et al.), JuMP
+(Dunning/Huchette/Lubin SIAM Review 2017; Lubin et al. 2023), AMPL (Fourer/Gay/Kernighan),
+GAMS (Bisschop/Meeraus). Add to `docs/_toc.yml`; cross-link from `modeling_guide.ipynb`.
+Docstrings render via sphinx-autoapi. `jupyter-book build docs/` with zero warnings.
+`CHANGELOG.md` under `[Unreleased] -> Added`.
+
+## 8. Examples
+
+`python/discopt/modeling/examples.py`: `example_transportation()` (sparse network, the
+canonical showcase), `example_assignment()` (binary product set with filter),
+`example_multicommodity_flow()` (product `*` + `.where`, exercises linear fast-path). Each
+doubles as a correctness fixture.
+
+## 9. Milestones
+
+| # | Milestone | Deliverable |
+|---|-----------|-------------|
+| M1 | `Set`/`RangeSet`/`ProductSet` + algebra + `m.set()` | `sets.py`, `TestSetAlgebra`, exports |
+| M2 | `IndexedVar` (dense+sparse) + `over=` on constructors | indexing, bounds, desugar-equivalence harness |
+| M3 | Indexed constraints (generator + rule + `Skip`) + key-tuple naming | `m.constraint`, `TestIndexedConstraints` |
+| M4 | `IndexedParam` + aggregation parity | params, agg tests |
+| M5 | Linear fast-path routing into `PyModelBuilder` | `_emit_indexed_constraints`, `TestFastPathEquivalence` |
+| M6 | Correctness suite + `.nl`/Pyomo round-trip | `TestCorrectness`, known-optima entries |
+| M7 | Docs notebook + bib + TOC + examples + CHANGELOG | docs build clean |
+
+## 10. Risks & mitigations
+
+- **Sparse-sum footgun (Pyomo's)** — set is the authoritative index; `sum(... over=SET)`
+  always iterates the full declared set.
+- **Product-set blowup** — `ProductSet` lazy; `.where` filters before materialization.
+- **Label hashability/order** — require hashable members; store order-stable de-duplicated
+  tuples; deterministic flattening (matches `.nl` determinism).
+- **Fast-path divergence** — M5 ships with `TestFastPathEquivalence`; routing only fires
+  when bodies prove affine.
+- **mypy noise** — keep `sets.py` strictly typed so it needs no `core.py`-style override.

--- a/docs/notebooks/sets_and_indexing.ipynb
+++ b/docs/notebooks/sets_and_indexing.ipynb
@@ -1,0 +1,228 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sets & Indexing for Sparse Models\n",
+    "\n",
+    "discopt's modeling API has always supported dense, NumPy-style array variables\n",
+    "(`m.continuous(\"x\", shape=(3, 4))`) indexed by integer position. This notebook\n",
+    "introduces the **named-set / indexed** layer for sparse, label-driven models \u2014\n",
+    "the style familiar from AMPL {cite:t}`Fourer2003`, GAMS, Pyomo\n",
+    "{cite:p}`Hart2017`, and JuMP {cite:p}`Dunning2017,Lubin2023`.\n",
+    "\n",
+    "The whole layer is **pure-Python sugar**: a named set is the authoritative index\n",
+    "for variables/parameters/constraints, and everything desugars to the same flat\n",
+    "model the solver already consumes. No solver or backend changes are involved."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Named sets\n",
+    "\n",
+    "A `Set` holds an order-stable, de-duplicated collection of **hashable** members.\n",
+    "Members may be scalars (`dimen == 1`) or fixed-arity tuples (`dimen == N`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import discopt.modeling as dm\n",
+    "\n",
+    "m = dm.Model(\"transport\")\n",
+    "plants = m.set(\"plants\", [\"pitt\", \"sf\", \"nyc\"])\n",
+    "markets = m.set(\"markets\", [\"a\", \"b\", \"c\", \"d\"])\n",
+    "print(plants, \"| dimen =\", plants.dimen, \"| len =\", len(plants))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set algebra\n",
+    "\n",
+    "Sets compose with `|` (union), `&` (intersection), `-` (difference), `*` (cross\n",
+    "product), and `.where(pred)` (filter) \u2014 the operators Pyomo {cite:p}`Hart2017`\n",
+    "and JuMP {cite:p}`Dunning2017` use to express sparse index structure. Cross\n",
+    "products are **lazy**, and filtering a product materializes only the members\n",
+    "that pass the predicate (JuMP's `SparseAxisArray`-via-condition)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sparse subset of the dense plants x markets grid.\n",
+    "links = (plants * markets).where(lambda p, k: (p, k) != (\"nyc\", \"a\"))\n",
+    "print(\"dense grid :\", len(plants * markets))\n",
+    "print(\"sparse links:\", len(links))\n",
+    "print((\"nyc\", \"a\") in links, (\"pitt\", \"a\") in links)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Indexed variables\n",
+    "\n",
+    "`over=SET` makes a variable indexed by set member. It is backed by a single flat\n",
+    "variable, so `ship[\"pitt\", \"a\"]` desugars to the ordinary indexing the solver\n",
+    "already understands. Bounds may be a scalar, a `dict` keyed by member, or a\n",
+    "callable `fn(member)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "supply = {\"pitt\": 20.0, \"sf\": 30.0, \"nyc\": 25.0}\n",
+    "ship = m.continuous(\"ship\", over=links, lb=0, ub=1000)\n",
+    "cap = m.continuous(\"cap\", over=plants, lb=0, ub=supply)  # dict bounds\n",
+    "print(ship)\n",
+    "print(\"ship[pitt, a] ->\", ship[\"pitt\", \"a\"])  # an indexing expression"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Indexed constraints\n",
+    "\n",
+    "`m.constraint(SET, rule, name=)` generates one constraint per member, named\n",
+    "`name[key]`. Tuple members are unpacked into the rule's arguments, and a rule\n",
+    "may return `dm.Skip` to omit a member (Pyomo's `Constraint.Skip`\n",
+    "{cite:p}`Hart2017`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demand = {\"a\": 15.0, \"b\": 20.0, \"c\": 20.0, \"d\": 10.0}\n",
+    "cost = {(p, k): 1.0 + (hash((p, k)) % 5) for (p, k) in links}\n",
+    "\n",
+    "m.minimize(dm.sum(cost[(p, k)] * ship[p, k] for (p, k) in links))\n",
+    "m.constraint(plants,\n",
+    "             lambda p: dm.sum(ship[p, k] for k in markets if (p, k) in links) <= supply[p],\n",
+    "             name=\"supply\")\n",
+    "m.constraint(markets,\n",
+    "             lambda k: dm.sum(ship[p, k] for p in plants if (p, k) in links) >= demand[k],\n",
+    "             name=\"demand\")\n",
+    "print(\"variables:\", len(m._variables), \" sets:\", len(m._sets))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Aggregation over sets\n",
+    "\n",
+    "`dm.sum` and `dm.prod` accept generators over sets, or a callable plus `over=`.\n",
+    "For `dimen > 1` sets, tuple members are unpacked: `dm.sum(lambda p, k: ..., over=links)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total_out = dm.sum(lambda p, k: ship[p, k], over=links)\n",
+    "print(total_out)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## End-to-end: balanced transportation\n",
+    "\n",
+    "A complete transportation model {cite:p}`Fourer2003` built from named sets, then\n",
+    "solved. Values come back keyed by set member via `IndexedVar.value`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t = dm.Model(\"transportation\")\n",
+    "P = t.set(\"P\", [\"pitt\", \"sf\"])\n",
+    "K = t.set(\"K\", [\"a\", \"b\", \"c\"])\n",
+    "sup = {\"pitt\": 20.0, \"sf\": 30.0}\n",
+    "dem = {\"a\": 10.0, \"b\": 25.0, \"c\": 15.0}\n",
+    "c = {(\"pitt\", \"a\"): 4, (\"pitt\", \"b\"): 6, (\"pitt\", \"c\"): 8,\n",
+    "     (\"sf\", \"a\"): 5, (\"sf\", \"b\"): 3, (\"sf\", \"c\"): 7}\n",
+    "x = t.continuous(\"x\", over=P * K, lb=0, ub=1000)\n",
+    "t.minimize(dm.sum(c[(p, k)] * x[p, k] for p in P for k in K))\n",
+    "t.constraint(P, lambda p: dm.sum(x[p, k] for k in K) <= sup[p], name=\"supply\")\n",
+    "t.constraint(K, lambda k: dm.sum(x[p, k] for p in P) >= dem[k], name=\"demand\")\n",
+    "res = t.solve()\n",
+    "print(res.status, round(res.objective, 3))\n",
+    "print(x.value(res))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dense vs sparse, and the linear fast path\n",
+    "\n",
+    "Following JuMP's *tightest-container* philosophy {cite:p}`Dunning2017`, pick the\n",
+    "representation that fits:\n",
+    "\n",
+    "- **Dense** `shape=(m, n)` \u2014 rectangular data, integer position indexing.\n",
+    "- **Indexed over a set** \u2014 arbitrary labels, and **sparse** subsets via `.where`\n",
+    "  so you never allocate entries you won't use.\n",
+    "\n",
+    "When an indexed constraint family is affine in a single variable with a uniform\n",
+    "sense, `m.constraint(..., fast=True)` (the default) emits it as one sparse-matrix\n",
+    "call into the Rust builder instead of thousands of expression objects. This is a\n",
+    "pure performance path \u2014 the resulting model and solution are identical, and any\n",
+    "family that isn't single-variable-affine transparently falls back."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Migrating from positional `shape=`\n",
+    "\n",
+    "| Positional (dense) | Named-set (sparse-friendly) |\n",
+    "|---|---|\n",
+    "| `x = m.continuous(\"x\", shape=(3,))` | `x = m.continuous(\"x\", over=S)` |\n",
+    "| `x[0]` | `x[\"pitt\"]` |\n",
+    "| `for i in range(3): m.subject_to(x[i] <= 1)` | `m.constraint(S, lambda i: x[i] <= 1)` |\n",
+    "| `dm.sum(x[i] for i in range(3))` | `dm.sum(x[i] for i in S)` |\n",
+    "\n",
+    "Both produce the *same* flat model \u2014 named sets add labels, sparsity, and set\n",
+    "algebra without changing the math."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2085,3 +2085,35 @@
   address     = {Chilton, Oxfordshire, UK},
   year        = {2001}
 }
+
+@book{Hart2017,
+  author    = {Hart, William E. and Laird, Carl D. and Watson, Jean-Paul and Woodruff, David L. and Hackebeil, Gabriel A. and Nicholson, Bethany L. and Siirola, John D.},
+  title     = {Pyomo --- Optimization Modeling in Python},
+  edition   = {Second},
+  series    = {Springer Optimization and Its Applications},
+  volume    = {67},
+  publisher = {Springer},
+  year      = {2017},
+  doi       = {10.1007/978-3-319-58821-6}
+}
+
+@article{Dunning2017,
+  author    = {Dunning, Iain and Huchette, Joey and Lubin, Miles},
+  title     = {{JuMP}: A Modeling Language for Mathematical Optimization},
+  journal   = {SIAM Review},
+  volume    = {59},
+  number    = {2},
+  pages     = {295--320},
+  year      = {2017},
+  doi       = {10.1137/15M1020575}
+}
+
+@article{Lubin2023,
+  author    = {Lubin, Miles and Dowson, Oscar and Dias Garcia, Joaquim and Huchette, Joey and Legat, Benoît and Vielma, Juan Pablo},
+  title     = {{JuMP} 1.0: Recent improvements to a modeling language for mathematical optimization},
+  journal   = {Mathematical Programming Computation},
+  volume    = {15},
+  pages     = {581--589},
+  year      = {2023},
+  doi       = {10.1007/s12532-023-00239-3}
+}

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -104,6 +104,12 @@ from discopt.modeling import (
     Parameter as Parameter,
 )
 from discopt.modeling import (
+    RangeSet as RangeSet,
+)
+from discopt.modeling import (
+    Set as Set,
+)
+from discopt.modeling import (
     SolveResult as SolveResult,
 )
 from discopt.modeling import (
@@ -111,12 +117,6 @@ from discopt.modeling import (
 )
 from discopt.modeling import (
     VarType as VarType,
-)
-from discopt.modeling import (
-    RangeSet as RangeSet,
-)
-from discopt.modeling import (
-    Set as Set,
 )
 from discopt.modeling import (
     cos as cos,
@@ -138,6 +138,9 @@ from discopt.modeling import (
 )
 from discopt.modeling.examples import (
     example_simple_minlp as example_simple_minlp,
+)
+from discopt.modeling.examples import (
+    example_transportation as example_transportation,
 )
 
 # Lazy imports for optional modules (avoid import overhead at startup)

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -113,6 +113,12 @@ from discopt.modeling import (
     VarType as VarType,
 )
 from discopt.modeling import (
+    RangeSet as RangeSet,
+)
+from discopt.modeling import (
+    Set as Set,
+)
+from discopt.modeling import (
     cos as cos,
 )
 from discopt.modeling import (

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -104,6 +104,9 @@ from discopt.modeling import (
     Parameter as Parameter,
 )
 from discopt.modeling import (
+    ProductSet as ProductSet,
+)
+from discopt.modeling import (
     RangeSet as RangeSet,
 )
 from discopt.modeling import (
@@ -135,6 +138,12 @@ from discopt.modeling import (
 )
 from discopt.modeling import (
     tan as tan,
+)
+from discopt.modeling.examples import (
+    example_assignment as example_assignment,
+)
+from discopt.modeling.examples import (
+    example_multicommodity_flow as example_multicommodity_flow,
 )
 from discopt.modeling.examples import (
     example_simple_minlp as example_simple_minlp,

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -334,21 +334,31 @@ class _NLWriter:
         self._decompose_builder_blocks()
 
     def _decompose_builder_objective(self):
-        """Recover a linear objective that lives only in the Rust builder.
+        """Recover a linear or quadratic objective that lives only in the builder.
 
-        ``add_linear_objective`` sets the real ``c'x + constant`` objective in the
-        builder and leaves a zero placeholder in ``model._objective``. Reconstruct
-        ``_obj_linear`` (and a constant offset as the objective's nonlinear part)
-        so ``.nl`` export carries the true objective. Only applies when the
-        current objective is that placeholder, so a real expression objective set
-        afterwards is never overwritten.
+        ``add_linear_objective`` / ``add_quadratic_objective`` set the real
+        ``0.5 x'Qx + c'x + constant`` objective in the builder and leave a zero
+        placeholder in ``model._objective``. Reconstruct ``_obj_linear`` (the
+        ``c'x`` gradient) and ``_obj_nonlinear`` (the quadratic part plus any
+        constant offset) so ``.nl`` export carries the true objective. Only
+        applies when the current objective is that placeholder, so a real
+        expression objective set afterwards is never overwritten.
         """
-        blk = getattr(self.model, "_builder_linear_objective", None)
-        if blk is None:
-            return
         if not getattr(self.model._objective, "_is_placeholder", False):
             return
-        c, x, constant, _sense = blk
+        lin_blk = getattr(self.model, "_builder_linear_objective", None)
+        quad_blk = getattr(self.model, "_builder_quadratic_objective", None)
+        if lin_blk is not None:
+            c, x, constant, _sense = lin_blk
+            self._obj_linear = self._linear_obj_from_c(c, x)
+            self._obj_nonlinear = Constant(float(constant)) if constant != 0.0 else None
+        elif quad_blk is not None:
+            Q, c, x, constant, _sense = quad_blk
+            self._obj_linear = self._linear_obj_from_c(c, x)
+            self._obj_nonlinear = self._quadratic_obj_expr(Q, x, float(constant))
+
+    def _linear_obj_from_c(self, c, x) -> dict[int, float]:
+        """Map a cost vector over variable ``x`` to ``{global_var_index: coeff}``."""
         lin: dict[int, float] = {}
         for j, coeff in enumerate(np.asarray(c, dtype=np.float64).ravel()):
             coeff = float(coeff)
@@ -357,8 +367,35 @@ class _NLWriter:
             gidx = self._var_index.get((x.name, j))
             if gidx is not None:
                 lin[gidx] = lin.get(gidx, 0.0) + coeff
-        self._obj_linear = lin
-        self._obj_nonlinear = Constant(float(constant)) if constant != 0.0 else None
+        return lin
+
+    def _quadratic_obj_expr(self, Q, x, constant: float) -> Expression | None:
+        """Build ``0.5 x'Qx + constant`` as an n-ary sum expression (or ``None``).
+
+        ``Q`` is a symmetric CSR matrix stored in full, so each stored nonzero
+        ``Q[i, j]`` contributes ``0.5 Q[i, j] x[i] x[j]`` (diagonal entries give
+        the ``x[i]^2`` terms). The sum is emitted as a single ``SUMLIST`` node so
+        the writer never recurses through a deep ``+`` chain.
+        """
+        indptr = Q.indptr
+        indices = Q.indices
+        data = Q.data
+        terms: list[Expression] = []
+        for i in range(Q.shape[0]):
+            for k in range(int(indptr[i]), int(indptr[i + 1])):
+                q = float(data[k])
+                if q == 0.0:
+                    continue
+                j = int(indices[k])
+                prod = BinaryOp("*", IndexExpression(x, i), IndexExpression(x, j))
+                terms.append(BinaryOp("*", Constant(0.5 * q), prod))
+        if constant != 0.0:
+            terms.append(Constant(constant))
+        if not terms:
+            return None
+        if len(terms) == 1:
+            return terms[0]
+        return SumOverExpression(terms)
 
     def _decompose_builder_blocks(self):
         """Emit linear constraints that live only in the Rust builder.

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -305,6 +305,7 @@ class _NLWriter:
             linear, nonlinear = self._split_expr(obj.expression)
             self._obj_linear = linear
             self._obj_nonlinear = nonlinear
+        self._decompose_builder_objective()
 
         for con in self.model._constraints:
             # Determine constraint bound type (shared by every scalar row this
@@ -331,6 +332,33 @@ class _NLWriter:
                 self._con_bounds.append(bnd)
 
         self._decompose_builder_blocks()
+
+    def _decompose_builder_objective(self):
+        """Recover a linear objective that lives only in the Rust builder.
+
+        ``add_linear_objective`` sets the real ``c'x + constant`` objective in the
+        builder and leaves a zero placeholder in ``model._objective``. Reconstruct
+        ``_obj_linear`` (and a constant offset as the objective's nonlinear part)
+        so ``.nl`` export carries the true objective. Only applies when the
+        current objective is that placeholder, so a real expression objective set
+        afterwards is never overwritten.
+        """
+        blk = getattr(self.model, "_builder_linear_objective", None)
+        if blk is None:
+            return
+        if not getattr(self.model._objective, "_is_placeholder", False):
+            return
+        c, x, constant, _sense = blk
+        lin: dict[int, float] = {}
+        for j, coeff in enumerate(np.asarray(c, dtype=np.float64).ravel()):
+            coeff = float(coeff)
+            if coeff == 0.0:
+                continue
+            gidx = self._var_index.get((x.name, j))
+            if gidx is not None:
+                lin[gidx] = lin.get(gidx, 0.0) + coeff
+        self._obj_linear = lin
+        self._obj_nonlinear = Constant(float(constant)) if constant != 0.0 else None
 
     def _decompose_builder_blocks(self):
         """Emit linear constraints that live only in the Rust builder.

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -370,18 +370,25 @@ class _NLWriter:
         return lin
 
     def _quadratic_obj_expr(self, Q, x, constant: float) -> Expression | None:
-        """Build ``0.5 x'Qx + constant`` as an n-ary sum expression (or ``None``).
+        """Build ``0.5 x'Sx + constant`` as an n-ary sum expression (or ``None``).
 
-        ``Q`` is a symmetric CSR matrix stored in full, so each stored nonzero
-        ``Q[i, j]`` contributes ``0.5 Q[i, j] x[i] x[j]`` (diagonal entries give
-        the ``x[i]^2`` terms). The sum is emitted as a single ``SUMLIST`` node so
-        the writer never recurses through a deep ``+`` chain.
+        The Rust builder reads only the **upper triangle** of ``Q`` and reflects
+        it, i.e. it optimizes ``0.5 x'Sx`` with ``S = triu(Q) + striu(Q).T``
+        (the strictly-lower triangle of the input is ignored). The export mirrors
+        that exactly so it matches the solved model for any ``Q`` — symmetric,
+        triangular, or asymmetric. Each stored entry ``S[i, j]`` contributes
+        ``0.5 S[i, j] x[i] x[j]`` (diagonals give the ``x[i]^2`` terms). The sum
+        is emitted as a single ``SUMLIST`` node so the writer never recurses
+        through a deep ``+`` chain.
         """
-        indptr = Q.indptr
-        indices = Q.indices
-        data = Q.data
+        import scipy.sparse as sp
+
+        S = (sp.triu(Q, 0) + sp.triu(Q, 1).T).tocsr()
+        indptr = S.indptr
+        indices = S.indices
+        data = S.data
         terms: list[Expression] = []
-        for i in range(Q.shape[0]):
+        for i in range(S.shape[0]):
             for k in range(int(indptr[i]), int(indptr[i + 1])):
                 q = float(data[k])
                 if q == 0.0:

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -330,6 +330,46 @@ class _NLWriter:
                 self._con_nonlinear.append(nonlinear)
                 self._con_bounds.append(bnd)
 
+        self._decompose_builder_blocks()
+
+    def _decompose_builder_blocks(self):
+        """Emit linear constraints that live only in the Rust builder.
+
+        The fast-construction API (``add_linear_constraints``) and the indexed
+        constraint fast path build rows directly into the builder, bypassing
+        ``model._constraints``. Each recorded ``(A, x, sense, b, name)`` block is
+        reconstructed here as purely linear rows so ``.nl`` export sees the same
+        model the solver does.
+        """
+        blocks = getattr(self.model, "_builder_linear_blocks", None)
+        if not blocks:
+            return
+        for A, x, sense, b, _name in blocks:
+            indptr = A.indptr
+            indices = A.indices
+            data = A.data
+            for r in range(A.shape[0]):
+                lin: dict[int, float] = {}
+                for k in range(int(indptr[r]), int(indptr[r + 1])):
+                    coeff = float(data[k])
+                    if coeff == 0.0:
+                        continue
+                    gidx = self._var_index.get((x.name, int(indices[k])))
+                    if gidx is not None:
+                        lin[gidx] = lin.get(gidx, 0.0) + coeff
+                rhs = float(b[r])
+                if sense == "<=":
+                    bnd = (1, 0.0, rhs)  # A x <= b
+                elif sense == ">=":
+                    bnd = (2, rhs, 0.0)  # A x >= b
+                elif sense == "==":
+                    bnd = (4, rhs, rhs)
+                else:  # pragma: no cover - sense is validated upstream
+                    bnd = (3, 0.0, 0.0)
+                self._con_linear.append(lin)
+                self._con_nonlinear.append(None)
+                self._con_bounds.append(bnd)
+
     def _scalarize_body(self, expr: Expression) -> list[Expression]:
         """Return the scalar constraint bodies a (possibly array) body expands to.
 

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -360,8 +360,8 @@ class _NLWriter:
     def _linear_obj_from_c(self, c, x) -> dict[int, float]:
         """Map a cost vector over variable ``x`` to ``{global_var_index: coeff}``."""
         lin: dict[int, float] = {}
-        for j, coeff in enumerate(np.asarray(c, dtype=np.float64).ravel()):
-            coeff = float(coeff)
+        for j, raw in enumerate(np.asarray(c, dtype=np.float64).ravel()):
+            coeff = float(raw)
             if coeff == 0.0:
                 continue
             gidx = self._var_index.get((x.name, j))

--- a/python/discopt/modeling/__init__.py
+++ b/python/discopt/modeling/__init__.py
@@ -85,7 +85,12 @@ from discopt.modeling.core import (
 from discopt.modeling.core import (
     abs_ as abs,
 )
-from discopt.modeling.indexed import IndexedParam, IndexedVar
+from discopt.modeling.indexed import (
+    IndexedConstraint,
+    IndexedParam,
+    IndexedVar,
+    Skip,
+)
 from discopt.modeling.sets import ProductSet, RangeSet, Set
 
 __all__ = [
@@ -148,4 +153,6 @@ __all__ = [
     "ProductSet",
     "IndexedVar",
     "IndexedParam",
+    "IndexedConstraint",
+    "Skip",
 ]

--- a/python/discopt/modeling/__init__.py
+++ b/python/discopt/modeling/__init__.py
@@ -85,6 +85,7 @@ from discopt.modeling.core import (
 from discopt.modeling.core import (
     abs_ as abs,
 )
+from discopt.modeling.sets import ProductSet, RangeSet, Set
 
 __all__ = [
     "Model",
@@ -141,4 +142,7 @@ __all__ = [
     "atleast",
     "atmost",
     "exactly",
+    "Set",
+    "RangeSet",
+    "ProductSet",
 ]

--- a/python/discopt/modeling/__init__.py
+++ b/python/discopt/modeling/__init__.py
@@ -85,6 +85,7 @@ from discopt.modeling.core import (
 from discopt.modeling.core import (
     abs_ as abs,
 )
+from discopt.modeling.indexed import IndexedParam, IndexedVar
 from discopt.modeling.sets import ProductSet, RangeSet, Set
 
 __all__ = [
@@ -145,4 +146,6 @@ __all__ = [
     "Set",
     "RangeSet",
     "ProductSet",
+    "IndexedVar",
+    "IndexedParam",
 ]

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1579,10 +1579,21 @@ class Model:
         var = Variable(name, VarType.INTEGER, shape, lb, ub, self)
         return self._register_variable(var)
 
+    def _make_indexed_param(self, name, index_set, value):
+        """Build an :class:`IndexedParam` backed by one flat parameter over *index_set*."""
+        from discopt.modeling.indexed import IndexedParam, resolve_indexed_values
+
+        arr = resolve_indexed_values(index_set, value, 0.0, np.float64)
+        self._check_name(name)
+        flat = Parameter(name, arr, self)
+        self._parameters.append(flat)
+        return IndexedParam(flat, index_set)
+
     def parameter(
         self,
         name: str,
         value: Union[float, np.ndarray],
+        over=None,
     ) -> Parameter:
         """
         Create a parameter for parametric optimization / sensitivity.
@@ -1606,7 +1617,14 @@ class Model:
         --------
         >>> price = m.parameter("price", value=50.0)
         >>> demand = m.parameter("demand", value=np.array([100, 200, 150]))
+        >>> cap = m.parameter("cap", over=plants, value={"pitt": 10, "sf": 20})
+
+        When *over* is given (a :class:`~discopt.modeling.sets.Set`), an
+        :class:`~discopt.modeling.indexed.IndexedParam` is returned and *value*
+        may be a scalar, a ``dict`` keyed by member, or a callable ``fn(member)``.
         """
+        if over is not None:
+            return self._make_indexed_param(name, over, value)
         self._check_name(name)
         param = Parameter(name, value, self)
         self._parameters.append(param)

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -361,6 +361,20 @@ def _wrap(x) -> Expression:
     return Constant(x)
 
 
+def _is_term_iterable(x) -> bool:
+    """True for a generator/iterable of terms (not a scalar Expression/array/str)."""
+    if isinstance(x, (Expression, np.ndarray, str, bytes)):
+        return False
+    return hasattr(x, "__iter__")
+
+
+def _call_over(fn: Callable, member, over):
+    """Call ``fn`` on a set member, unpacking tuple members for ``dimen > 1`` sets."""
+    if getattr(over, "dimen", 1) > 1 and isinstance(member, tuple):
+        return fn(*member)
+    return fn(member)
+
+
 # ─────────────────────────────────────────────────────────────
 # Mathematical Functions (dm.exp, dm.log, dm.sin, etc.)
 # ─────────────────────────────────────────────────────────────
@@ -861,10 +875,12 @@ def sum(
     >>> dm.sum(lambda i: cost[i] * x[i], over=range(n))  # indexed sum
     """
     if over is not None and callable(x):
-        # Indexed summation: dm.sum(lambda i: expr(i), over=index_set)
-        terms = [_wrap(x(i)) for i in over]
+        # Indexed summation: dm.sum(lambda i: expr(i), over=index_set). Tuple
+        # members of dimen>1 named sets are unpacked: ``lambda i, j: ...``.
+        terms = [_wrap(_call_over(x, i, over)) for i in over]
         return SumOverExpression(terms)
-    if isinstance(x, list):
+    if isinstance(x, list) or _is_term_iterable(x):
+        # list/tuple/generator of terms: dm.sum(x[i] for i in S)
         terms = [_wrap(t) for t in x]
         return SumOverExpression(terms)
     return SumExpression(_wrap(x), axis=axis)
@@ -887,7 +903,13 @@ def prod(x: Union[Expression, list, Callable], *, over: Optional[Sequence] = Non
     Expression
     """
     if over is not None and callable(x):
-        terms = [_wrap(x(i)) for i in over]
+        terms = [_wrap(_call_over(x, i, over)) for i in over]
+        result = terms[0]
+        for t in terms[1:]:
+            result = result * t
+        return result
+    if isinstance(x, list) or _is_term_iterable(x):
+        terms = [_wrap(t) for t in x]
         result = terms[0]
         for t in terms[1:]:
             result = result * t
@@ -1650,19 +1672,76 @@ class Model:
         >>> m.subject_to([x[i] + x[i+1] <= limits[i] for i in range(n-1)],
         ...              name="adjacent_limits")
         """
-        if isinstance(constraint, list):
-            for k, c in enumerate(constraint):
-                if isinstance(c, Constraint):
-                    c.name = f"{name}_{k}" if name else None
-                    self._constraints.append(c)
-        elif isinstance(constraint, Constraint):
+        if isinstance(constraint, Constraint):
             constraint.name = name
             self._constraints.append(constraint)
-        else:
+            return
+        if isinstance(constraint, bool):
             raise TypeError(
                 f"Expected Constraint (from <=, >=, == on expressions), "
                 f"got {type(constraint)}. Did you mean to compare expressions?"
             )
+        # list / tuple / generator / any iterable of constraints (named
+        # by ordinal: ``name_0``, ``name_1``, ...).
+        try:
+            items = list(constraint)
+        except TypeError:
+            raise TypeError(
+                f"Expected Constraint or an iterable of Constraints, got {type(constraint)}."
+            ) from None
+        for k, c in enumerate(items):
+            if not isinstance(c, Constraint):
+                raise TypeError(
+                    f"Expected Constraint (from <=, >=, == on expressions), "
+                    f"got {type(c)} at position {k}."
+                )
+            c.name = f"{name}_{k}" if name else None
+            self._constraints.append(c)
+
+    def constraint(self, index_set, rule, name: Optional[str] = None):
+        """Add a family of constraints indexed by a named set.
+
+        For each member of *index_set* the *rule* is evaluated to produce a
+        constraint; tuple members are unpacked into positional arguments
+        (``rule(i, j)`` for a ``dimen == 2`` set, ``rule(i)`` otherwise). A rule
+        may return :data:`~discopt.modeling.indexed.Skip` to omit that member.
+        Generated constraints are named ``name[key]`` (e.g. ``capacity[pitt]``).
+
+        Parameters
+        ----------
+        index_set : Set
+            The set to iterate.
+        rule : callable
+            ``rule(member)`` -> Constraint (or ``Skip``).
+        name : str, optional
+            Prefix for the per-key constraint names.
+
+        Returns
+        -------
+        IndexedConstraint
+            A keyed view of the generated constraints.
+
+        Examples
+        --------
+        >>> m.constraint(plants, lambda p: ship_out(p) <= cap[p], name="capacity")
+        """
+        from discopt.modeling.indexed import IndexedConstraint, Skip, key_label
+        from discopt.modeling.sets import call_member
+
+        members: dict = {}
+        for member in index_set:
+            c = call_member(rule, member, index_set.dimen)
+            if c is Skip:
+                continue
+            if not isinstance(c, Constraint):
+                raise TypeError(
+                    f"constraint rule for key {member!r} returned {type(c)}, "
+                    "expected a Constraint (from <=, >=, == on expressions) or Skip."
+                )
+            c.name = f"{name}[{key_label(member)}]" if name else None
+            self._constraints.append(c)
+            members[member] = c
+        return IndexedConstraint(name, index_set, members)
 
     # ── Fast construction API (direct arena building) ──
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1301,6 +1301,15 @@ class SolveResult:
 # ─────────────────────────────────────────────────────────────
 
 
+def _require_no_shape(shape, ctor: str) -> None:
+    """Reject ``shape=`` when ``over=`` is given (they are mutually exclusive)."""
+    if shape not in ((), 0):
+        raise ValueError(
+            f"{ctor}(): 'over=' (named-set index) and 'shape=' are mutually "
+            "exclusive; an indexed variable's size is determined by its set."
+        )
+
+
 class Model:
     """
     A Mixed-Integer Nonlinear Program.
@@ -1383,12 +1392,37 @@ class Model:
 
     # ── Variable constructors ──
 
+    def _register_variable(self, var: "Variable") -> "Variable":
+        """Append a variable and register it with the Rust builder if active."""
+        self._variables.append(var)
+        if self._builder is not None:
+            var._builder_idx = self._builder.add_variable(
+                var.name,
+                var.var_type.value,
+                list(var.shape),
+                var.lb.flatten().astype(np.float64),
+                var.ub.flatten().astype(np.float64),
+            )
+        return var
+
+    def _make_indexed_var(self, name, var_type, index_set, lb, ub, default_lb, default_ub):
+        """Build an :class:`IndexedVar` backed by one flat variable over *index_set*."""
+        from discopt.modeling.indexed import IndexedVar, resolve_indexed_values
+
+        lb_arr = resolve_indexed_values(index_set, lb, default_lb, np.float64)
+        ub_arr = resolve_indexed_values(index_set, ub, default_ub, np.float64)
+        self._check_name(name)
+        flat = Variable(name, var_type, (len(index_set),), lb_arr, ub_arr, self)
+        self._register_variable(flat)
+        return IndexedVar(flat, index_set)
+
     def continuous(
         self,
         name: str,
         shape: Union[int, tuple[int, ...]] = (),
         lb: Union[float, np.ndarray] = -9.999e19,
         ub: Union[float, np.ndarray] = 9.999e19,
+        over=None,
     ) -> Variable:
         """
         Create continuous decision variable(s).
@@ -1427,26 +1461,29 @@ class Model:
         >>> x = m.continuous("x")                           # scalar, unbounded
         >>> flow = m.continuous("flow", shape=(5,), lb=0)   # 5-vector, non-negative
         >>> X = m.continuous("X", shape=(3, 4), lb=0, ub=1) # 3x4 matrix
+        >>> ship = m.continuous("ship", over=links, lb=0)   # indexed over a named set
+
+        When *over* is given (a :class:`~discopt.modeling.sets.Set`), an
+        :class:`~discopt.modeling.indexed.IndexedVar` is returned: ``ship[key]``
+        indexes by set member, and ``lb``/``ub`` may be a scalar, a ``dict``
+        keyed by member, or a callable ``fn(member)``.
         """
+        if over is not None:
+            _require_no_shape(shape, "continuous")
+            return self._make_indexed_var(
+                name, VarType.CONTINUOUS, over, lb, ub, -9.999e19, 9.999e19
+            )
         if isinstance(shape, int):
             shape = (shape,)
         self._check_name(name)
         var = Variable(name, VarType.CONTINUOUS, shape, lb, ub, self)
-        self._variables.append(var)
-        if self._builder is not None:
-            var._builder_idx = self._builder.add_variable(
-                var.name,
-                var.var_type.value,
-                list(var.shape),
-                var.lb.flatten().astype(np.float64),
-                var.ub.flatten().astype(np.float64),
-            )
-        return var
+        return self._register_variable(var)
 
     def binary(
         self,
         name: str,
         shape: Union[int, tuple[int, ...]] = (),
+        over=None,
     ) -> Variable:
         """
         Create binary (0/1) decision variable(s).
@@ -1467,21 +1504,16 @@ class Model:
         --------
         >>> use = m.binary("use")                    # single binary
         >>> active = m.binary("active", shape=(5,))  # 5 binary indicators
+        >>> assign = m.binary("assign", over=workers * tasks)  # indexed binary
         """
+        if over is not None:
+            _require_no_shape(shape, "binary")
+            return self._make_indexed_var(name, VarType.BINARY, over, 0.0, 1.0, 0.0, 1.0)
         if isinstance(shape, int):
             shape = (shape,)
         self._check_name(name)
         var = Variable(name, VarType.BINARY, shape, 0.0, 1.0, self)
-        self._variables.append(var)
-        if self._builder is not None:
-            var._builder_idx = self._builder.add_variable(
-                var.name,
-                var.var_type.value,
-                list(var.shape),
-                var.lb.flatten().astype(np.float64),
-                var.ub.flatten().astype(np.float64),
-            )
-        return var
+        return self._register_variable(var)
 
     def integer(
         self,
@@ -1489,6 +1521,7 @@ class Model:
         shape: Union[int, tuple[int, ...]] = (),
         lb: Union[float, np.ndarray] = 0,
         ub: Union[float, np.ndarray] = 1e6,
+        over=None,
     ) -> Variable:
         """
         Create general integer decision variable(s).
@@ -1513,21 +1546,16 @@ class Model:
         --------
         >>> n = m.integer("n_units", lb=0, ub=10)
         >>> batch = m.integer("batch", shape=(3,), lb=1, ub=100)
+        >>> n = m.integer("n", over=plants, lb=0, ub=10)  # indexed integer
         """
+        if over is not None:
+            _require_no_shape(shape, "integer")
+            return self._make_indexed_var(name, VarType.INTEGER, over, lb, ub, 0.0, 1e6)
         if isinstance(shape, int):
             shape = (shape,)
         self._check_name(name)
         var = Variable(name, VarType.INTEGER, shape, lb, ub, self)
-        self._variables.append(var)
-        if self._builder is not None:
-            var._builder_idx = self._builder.add_variable(
-                var.name,
-                var.var_type.value,
-                list(var.shape),
-                var.lb.flatten().astype(np.float64),
-                var.ub.flatten().astype(np.float64),
-            )
-        return var
+        return self._register_variable(var)
 
     def parameter(
         self,

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -36,12 +36,14 @@ from typing import (
     Optional,
     Sequence,
     Union,
+    overload,
 )
 
 import numpy as np
 
 if TYPE_CHECKING:
     from discopt.modeling.indexed import IndexedParam, IndexedVar
+    from discopt.modeling.sets import _SetBase
 
 builtins_sum = _builtins.sum
 
@@ -366,10 +368,25 @@ def _wrap(x) -> Expression:
 
 
 def _is_term_iterable(x) -> bool:
-    """True for a generator/iterable of terms (not a scalar Expression/array/str)."""
+    """True for a generator/iterable of terms (not a scalar Expression/array/str).
+
+    Indexed containers (:class:`IndexedVar` / :class:`IndexedParam`) are excluded
+    even though they are iterable: their iterator yields index *keys*, not term
+    expressions, so treating them as a term-iterable would silently fold the keys
+    in as constants. ``sum``/``prod`` expand them explicitly instead.
+    """
     if isinstance(x, (Expression, np.ndarray, str, bytes)):
         return False
+    if getattr(x, "_is_indexed_container", False):
+        return False
     return hasattr(x, "__iter__")
+
+
+def _expand_indexed_container(x):
+    """If *x* is an IndexedVar/IndexedParam, return its element expressions."""
+    if getattr(x, "_is_indexed_container", False):
+        return [x[k] for k in x.index_set]
+    return x
 
 
 def _call_over(fn: Callable, member, over):
@@ -878,6 +895,7 @@ def sum(
     >>> dm.sum(x, axis=0)                          # sum along axis 0
     >>> dm.sum(lambda i: cost[i] * x[i], over=range(n))  # indexed sum
     """
+    x = _expand_indexed_container(x)  # dm.sum(indexed_var) -> sum of its elements
     if over is not None and callable(x):
         # Indexed summation: dm.sum(lambda i: expr(i), over=index_set). Tuple
         # members of dimen>1 named sets are unpacked: ``lambda i, j: ...``.
@@ -906,19 +924,24 @@ def prod(x: Union[Expression, list, Callable], *, over: Optional[Sequence] = Non
     -------
     Expression
     """
+    x = _expand_indexed_container(x)  # dm.prod(indexed_var) -> product of elements
     if over is not None and callable(x):
         terms = [_wrap(_call_over(x, i, over)) for i in over]
-        result = terms[0]
-        for t in terms[1:]:
-            result = result * t
-        return result
+        return _multiply_terms(terms)
     if isinstance(x, list) or _is_term_iterable(x):
         terms = [_wrap(t) for t in x]
-        result = terms[0]
-        for t in terms[1:]:
-            result = result * t
-        return result
+        return _multiply_terms(terms)
     return FunctionCall("prod", _wrap(x))
+
+
+def _multiply_terms(terms: list["Expression"]) -> Expression:
+    """Fold a list of terms into a product; the empty product is the identity 1."""
+    if not terms:
+        return Constant(1.0)
+    result: Expression = terms[0]
+    for t in terms[1:]:
+        result = result * t
+    return result
 
 
 def norm(x: Expression, ord: Union[int, float, str] = 2) -> Expression:
@@ -1457,6 +1480,27 @@ class Model:
         self._register_variable(flat)
         return IndexedVar(flat, index_set)
 
+    @overload
+    def continuous(
+        self,
+        name: str,
+        shape: Union[int, tuple[int, ...]] = ...,
+        lb: Union[float, np.ndarray] = ...,
+        ub: Union[float, np.ndarray] = ...,
+        over: None = ...,
+    ) -> Variable: ...
+
+    @overload
+    def continuous(
+        self,
+        name: str,
+        shape: Union[int, tuple[int, ...]] = ...,
+        lb: Union[float, np.ndarray] = ...,
+        ub: Union[float, np.ndarray] = ...,
+        *,
+        over: "_SetBase",
+    ) -> "IndexedVar": ...
+
     def continuous(
         self,
         name: str,
@@ -1464,7 +1508,7 @@ class Model:
         lb: Union[float, np.ndarray] = -9.999e19,
         ub: Union[float, np.ndarray] = 9.999e19,
         over=None,
-    ) -> Variable:
+    ) -> Union[Variable, "IndexedVar"]:
         """
         Create continuous decision variable(s).
 
@@ -1511,9 +1555,7 @@ class Model:
         """
         if over is not None:
             _require_no_shape(shape, "continuous")
-            # Returns an IndexedVar in the over= case (documented); the static
-            # return type stays Variable for the common positional case.
-            return self._make_indexed_var(  # type: ignore[return-value]
+            return self._make_indexed_var(
                 name, VarType.CONTINUOUS, over, lb, ub, -9.999e19, 9.999e19
             )
         if isinstance(shape, int):
@@ -1522,12 +1564,22 @@ class Model:
         var = Variable(name, VarType.CONTINUOUS, shape, lb, ub, self)
         return self._register_variable(var)
 
+    @overload
+    def binary(
+        self, name: str, shape: Union[int, tuple[int, ...]] = ..., over: None = ...
+    ) -> Variable: ...
+
+    @overload
+    def binary(
+        self, name: str, shape: Union[int, tuple[int, ...]] = ..., *, over: "_SetBase"
+    ) -> "IndexedVar": ...
+
     def binary(
         self,
         name: str,
         shape: Union[int, tuple[int, ...]] = (),
         over=None,
-    ) -> Variable:
+    ) -> Union[Variable, "IndexedVar"]:
         """
         Create binary (0/1) decision variable(s).
 
@@ -1551,14 +1603,33 @@ class Model:
         """
         if over is not None:
             _require_no_shape(shape, "binary")
-            return self._make_indexed_var(  # type: ignore[return-value]
-                name, VarType.BINARY, over, 0.0, 1.0, 0.0, 1.0
-            )
+            return self._make_indexed_var(name, VarType.BINARY, over, 0.0, 1.0, 0.0, 1.0)
         if isinstance(shape, int):
             shape = (shape,)
         self._check_name(name)
         var = Variable(name, VarType.BINARY, shape, 0.0, 1.0, self)
         return self._register_variable(var)
+
+    @overload
+    def integer(
+        self,
+        name: str,
+        shape: Union[int, tuple[int, ...]] = ...,
+        lb: Union[float, np.ndarray] = ...,
+        ub: Union[float, np.ndarray] = ...,
+        over: None = ...,
+    ) -> Variable: ...
+
+    @overload
+    def integer(
+        self,
+        name: str,
+        shape: Union[int, tuple[int, ...]] = ...,
+        lb: Union[float, np.ndarray] = ...,
+        ub: Union[float, np.ndarray] = ...,
+        *,
+        over: "_SetBase",
+    ) -> "IndexedVar": ...
 
     def integer(
         self,
@@ -1567,7 +1638,7 @@ class Model:
         lb: Union[float, np.ndarray] = 0,
         ub: Union[float, np.ndarray] = 1e6,
         over=None,
-    ) -> Variable:
+    ) -> Union[Variable, "IndexedVar"]:
         """
         Create general integer decision variable(s).
 
@@ -1595,9 +1666,7 @@ class Model:
         """
         if over is not None:
             _require_no_shape(shape, "integer")
-            return self._make_indexed_var(  # type: ignore[return-value]
-                name, VarType.INTEGER, over, lb, ub, 0.0, 1e6
-            )
+            return self._make_indexed_var(name, VarType.INTEGER, over, lb, ub, 0.0, 1e6)
         if isinstance(shape, int):
             shape = (shape,)
         self._check_name(name)
@@ -1614,12 +1683,20 @@ class Model:
         self._parameters.append(flat)
         return IndexedParam(flat, index_set)
 
+    @overload
+    def parameter(
+        self, name: str, value: Union[float, np.ndarray], over: None = ...
+    ) -> Parameter: ...
+
+    @overload
+    def parameter(self, name: str, value, *, over: "_SetBase") -> "IndexedParam": ...
+
     def parameter(
         self,
         name: str,
         value: Union[float, np.ndarray],
         over=None,
-    ) -> Parameter:
+    ) -> Union[Parameter, "IndexedParam"]:
         """
         Create a parameter for parametric optimization / sensitivity.
 
@@ -1649,7 +1726,7 @@ class Model:
         may be a scalar, a ``dict`` keyed by member, or a callable ``fn(member)``.
         """
         if over is not None:
-            return self._make_indexed_param(name, over, value)  # type: ignore[return-value]
+            return self._make_indexed_param(name, over, value)
         self._check_name(name)
         param = Parameter(name, value, self)
         self._parameters.append(param)

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1378,8 +1378,11 @@ class Model:
         # Linear objective emitted directly into the Rust builder via
         # ``add_linear_objective``: ``(c, x, constant, sense)`` or ``None``. Kept
         # so .nl export can recover an objective that bypasses ``_objective``
-        # (which only holds a zero placeholder in that case).
+        # (which only holds a zero placeholder in that case). Linear is
+        # ``(c, x, constant, sense)``; quadratic is ``(Q_csr, c, x, constant,
+        # sense)`` for ``0.5 x'Qx + c'x + constant``. At most one is set.
         self._builder_linear_objective: Optional[tuple] = None
+        self._builder_quadratic_objective: Optional[tuple] = None
 
     # ── Index sets ──
 
@@ -1975,6 +1978,7 @@ class Model:
         # Record the block so .nl export can recover the objective that lives
         # only in the Rust builder (``_objective`` holds a zero placeholder).
         self._builder_linear_objective = (c, x, float(constant), sense)
+        self._builder_quadratic_objective = None
 
     def add_quadratic_objective(
         self,
@@ -2034,6 +2038,10 @@ class Model:
             ObjectiveSense.MINIMIZE if sense == "minimize" else ObjectiveSense.MAXIMIZE,
         )
         self._objective._is_placeholder = True
+        # Record the block so .nl export can recover the quadratic objective
+        # that lives only in the Rust builder.
+        self._builder_quadratic_objective = (Q, c, x, float(constant), sense)
+        self._builder_linear_objective = None
 
     # ── Logical constraints (GDP) ──
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1375,6 +1375,11 @@ class Model:
         # entry is ``(A_csr, x, sense, b, name)``. Kept so .nl export and
         # introspection can recover constraints that bypass ``_constraints``.
         self._builder_linear_blocks: list = []
+        # Linear objective emitted directly into the Rust builder via
+        # ``add_linear_objective``: ``(c, x, constant, sense)`` or ``None``. Kept
+        # so .nl export can recover an objective that bypasses ``_objective``
+        # (which only holds a zero placeholder in that case).
+        self._builder_linear_objective: Optional[tuple] = None
 
     # ── Index sets ──
 
@@ -1967,6 +1972,9 @@ class Model:
             ObjectiveSense.MINIMIZE if sense == "minimize" else ObjectiveSense.MAXIMIZE,
         )
         self._objective._is_placeholder = True
+        # Record the block so .nl export can recover the objective that lives
+        # only in the Rust builder (``_objective`` holds a zero placeholder).
+        self._builder_linear_objective = (c, x, float(constant), sense)
 
     def add_quadratic_objective(
         self,

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1370,6 +1370,11 @@ class Model:
         self._complementarities: list = []
         # Named index sets registered via ``set()`` (see ``discopt.modeling.sets``).
         self._sets: list = []
+        # Linear constraint blocks emitted directly into the Rust builder
+        # (fast-API ``add_linear_constraints`` and the indexed fast path). Each
+        # entry is ``(A_csr, x, sense, b, name)``. Kept so .nl export and
+        # introspection can recover constraints that bypass ``_constraints``.
+        self._builder_linear_blocks: list = []
 
     # ── Index sets ──
 
@@ -1921,6 +1926,10 @@ class Model:
             b,
             name,
         )
+        # Record the block so exporters (.nl) and introspection can recover the
+        # constraints that live only in the Rust builder. CSR ``A`` and ``b`` are
+        # already in their final float form here.
+        self._builder_linear_blocks.append((A, x, sense, b, name))
 
     def add_linear_objective(
         self,

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1716,7 +1716,7 @@ class Model:
             c.name = f"{name}_{k}" if name else None
             self._constraints.append(c)
 
-    def constraint(self, index_set, rule, name: Optional[str] = None):
+    def constraint(self, index_set, rule, name: Optional[str] = None, fast: bool = True):
         """Add a family of constraints indexed by a named set.
 
         For each member of *index_set* the *rule* is evaluated to produce a
@@ -1724,6 +1724,14 @@ class Model:
         (``rule(i, j)`` for a ``dimen == 2`` set, ``rule(i)`` otherwise). A rule
         may return :data:`~discopt.modeling.indexed.Skip` to omit that member.
         Generated constraints are named ``name[key]`` (e.g. ``capacity[pitt]``).
+
+        When ``fast`` is ``True`` (default) and every generated constraint is
+        affine in a single backing variable with a uniform sense, the whole
+        family is emitted as one sparse-matrix call into the Rust builder instead
+        of thousands of Python expression objects. This is purely a performance
+        path: the resulting model is identical, and any family that is not
+        single-variable-affine transparently falls back to the general path.
+        Pass ``fast=False`` to force the general path (e.g. for debugging).
 
         Parameters
         ----------
@@ -1733,6 +1741,8 @@ class Model:
             ``rule(member)`` -> Constraint (or ``Skip``).
         name : str, optional
             Prefix for the per-key constraint names.
+        fast : bool, default True
+            Allow linear fast-path emission into the Rust builder.
 
         Returns
         -------
@@ -1746,7 +1756,7 @@ class Model:
         from discopt.modeling.indexed import IndexedConstraint, Skip, key_label
         from discopt.modeling.sets import call_member
 
-        members: dict = {}
+        generated: list[tuple] = []
         for member in index_set:
             c = call_member(rule, member, index_set.dimen)
             if c is Skip:
@@ -1757,9 +1767,71 @@ class Model:
                     "expected a Constraint (from <=, >=, == on expressions) or Skip."
                 )
             c.name = f"{name}[{key_label(member)}]" if name else None
+            generated.append((member, c))
+
+        members = {m: c for m, c in generated}
+        if fast and self._try_fast_linear_family([c for _, c in generated], name):
+            # Rows were emitted into the Rust builder; keep the Constraint
+            # objects only for introspection (not in self._constraints).
+            return IndexedConstraint(name, index_set, members, fast=True)
+        for _, c in generated:
             self._constraints.append(c)
-            members[member] = c
-        return IndexedConstraint(name, index_set, members)
+        return IndexedConstraint(name, index_set, members, fast=False)
+
+    def _try_fast_linear_family(self, constraints: list, name: Optional[str]) -> bool:
+        """Emit a single-variable-affine, uniform-sense family into the builder.
+
+        Returns ``True`` if the whole family was emitted as one
+        ``add_linear_constraints`` call, ``False`` if it is ineligible (caller
+        then uses the general expression path).
+        """
+        from discopt.modeling.indexed import affine_form
+
+        if not constraints:
+            return False
+        sense = constraints[0].sense
+        if any(c.sense != sense for c in constraints):
+            return False
+
+        rows = []
+        var = None
+        for c in constraints:
+            aff = affine_form(c.body)
+            if aff is None or aff.var is None:
+                return False
+            if var is None:
+                var = aff.var
+            elif aff.var is not var:
+                return False
+            rows.append(aff)
+
+        import scipy.sparse as sp
+
+        m_rows = len(rows)
+        n_cols = var.size
+        data: list[float] = []
+        indices: list[int] = []
+        indptr = [0]
+        b = np.empty(m_rows, dtype=np.float64)
+        for r, aff in enumerate(rows):
+            for pos in sorted(aff.coeffs):
+                coeff = aff.coeffs[pos]
+                if coeff != 0.0:
+                    data.append(coeff)
+                    indices.append(pos)
+            indptr.append(len(data))
+            # body sense 0  ==>  A x sense (-const)
+            b[r] = -aff.const
+        A = sp.csr_matrix(
+            (
+                np.asarray(data, dtype=np.float64),
+                np.asarray(indices, dtype=np.int64),
+                np.asarray(indptr, dtype=np.int64),
+            ),
+            shape=(m_rows, n_cols),
+        )
+        self.add_linear_constraints(A, var, sense, b, name)
+        return True
 
     # ── Fast construction API (direct arena building) ──
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -30,6 +30,7 @@ import builtins as _builtins
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Callable,
     Iterator,
     Optional,
@@ -38,6 +39,9 @@ from typing import (
 )
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from discopt.modeling.indexed import IndexedParam, IndexedVar
 
 builtins_sum = _builtins.sum
 
@@ -1440,7 +1444,9 @@ class Model:
             )
         return var
 
-    def _make_indexed_var(self, name, var_type, index_set, lb, ub, default_lb, default_ub):
+    def _make_indexed_var(
+        self, name, var_type, index_set, lb, ub, default_lb, default_ub
+    ) -> "IndexedVar":
         """Build an :class:`IndexedVar` backed by one flat variable over *index_set*."""
         from discopt.modeling.indexed import IndexedVar, resolve_indexed_values
 
@@ -1505,7 +1511,9 @@ class Model:
         """
         if over is not None:
             _require_no_shape(shape, "continuous")
-            return self._make_indexed_var(
+            # Returns an IndexedVar in the over= case (documented); the static
+            # return type stays Variable for the common positional case.
+            return self._make_indexed_var(  # type: ignore[return-value]
                 name, VarType.CONTINUOUS, over, lb, ub, -9.999e19, 9.999e19
             )
         if isinstance(shape, int):
@@ -1543,7 +1551,9 @@ class Model:
         """
         if over is not None:
             _require_no_shape(shape, "binary")
-            return self._make_indexed_var(name, VarType.BINARY, over, 0.0, 1.0, 0.0, 1.0)
+            return self._make_indexed_var(  # type: ignore[return-value]
+                name, VarType.BINARY, over, 0.0, 1.0, 0.0, 1.0
+            )
         if isinstance(shape, int):
             shape = (shape,)
         self._check_name(name)
@@ -1585,14 +1595,16 @@ class Model:
         """
         if over is not None:
             _require_no_shape(shape, "integer")
-            return self._make_indexed_var(name, VarType.INTEGER, over, lb, ub, 0.0, 1e6)
+            return self._make_indexed_var(  # type: ignore[return-value]
+                name, VarType.INTEGER, over, lb, ub, 0.0, 1e6
+            )
         if isinstance(shape, int):
             shape = (shape,)
         self._check_name(name)
         var = Variable(name, VarType.INTEGER, shape, lb, ub, self)
         return self._register_variable(var)
 
-    def _make_indexed_param(self, name, index_set, value):
+    def _make_indexed_param(self, name, index_set, value) -> "IndexedParam":
         """Build an :class:`IndexedParam` backed by one flat parameter over *index_set*."""
         from discopt.modeling.indexed import IndexedParam, resolve_indexed_values
 
@@ -1637,7 +1649,7 @@ class Model:
         may be a scalar, a ``dict`` keyed by member, or a callable ``fn(member)``.
         """
         if over is not None:
-            return self._make_indexed_param(name, over, value)
+            return self._make_indexed_param(name, over, value)  # type: ignore[return-value]
         self._check_name(name)
         param = Parameter(name, value, self)
         self._parameters.append(param)

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1337,6 +1337,49 @@ class Model:
         # Complementarity conditions added via ``complementarity()``; recorded
         # for introspection and bound tightening (see ``discopt.mpec``).
         self._complementarities: list = []
+        # Named index sets registered via ``set()`` (see ``discopt.modeling.sets``).
+        self._sets: list = []
+
+    # ── Index sets ──
+
+    def set(self, name: str, members, dimen: Optional[int] = None):
+        """Declare a named index set.
+
+        A :class:`~discopt.modeling.sets.Set` is the authoritative index for
+        indexed variables, parameters, and constraints. Members may be scalars
+        (``dimen == 1``) or fixed-arity tuples; duplicates are removed and
+        first-occurrence order is preserved.
+
+        Parameters
+        ----------
+        name : str
+            Identifier for the set, unique among the model's sets.
+        members : iterable
+            The set members.
+        dimen : int, optional
+            Declared dimensionality; inferred from *members* when omitted.
+
+        Returns
+        -------
+        Set
+            The registered set, supporting algebra (``|``, ``&``, ``-``, ``*``)
+            and filtering (``where``).
+
+        Examples
+        --------
+        >>> m = Model()
+        >>> plants = m.set("plants", ["pitt", "sf", "nyc"])
+        >>> markets = m.set("markets", ["a", "b"])
+        >>> len(plants * markets)
+        6
+        """
+        from discopt.modeling.sets import Set
+
+        if any(s.name == name for s in self._sets):
+            raise ValueError(f"Set name '{name}' already used in model")
+        s = Set(name, members, dimen=dimen)
+        self._sets.append(s)
+        return s
 
     # ── Variable constructors ──
 

--- a/python/discopt/modeling/examples.py
+++ b/python/discopt/modeling/examples.py
@@ -674,6 +674,110 @@ def example_streaming():
 
 
 # ═══════════════════════════════════════════════════════════════
+# EXAMPLE: Transportation (named sets, sparse-friendly indexing)
+#
+#   minimize    Σ_{(p,k)} cost[p,k] · ship[p,k]
+#   subject to  Σ_k ship[p,k] ≤ supply[p]     ∀ p ∈ PLANTS
+#               Σ_p ship[p,k] ≥ demand[k]     ∀ k ∈ MARKETS
+#               ship[p,k] ≥ 0
+# ═══════════════════════════════════════════════════════════════
+
+
+def example_transportation():
+    """Balanced transportation problem indexed by named sets."""
+    m = dm.Model("transportation")
+
+    plants = m.set("plants", ["pitt", "sf"])
+    markets = m.set("markets", ["a", "b", "c"])
+
+    supply = {"pitt": 20.0, "sf": 30.0}
+    demand = {"a": 10.0, "b": 25.0, "c": 15.0}
+    cost = {
+        ("pitt", "a"): 4.0,
+        ("pitt", "b"): 6.0,
+        ("pitt", "c"): 8.0,
+        ("sf", "a"): 5.0,
+        ("sf", "b"): 3.0,
+        ("sf", "c"): 7.0,
+    }
+
+    ship = m.continuous("ship", over=plants * markets, lb=0, ub=1000)
+    m.minimize(dm.sum(cost[(p, k)] * ship[p, k] for p in plants for k in markets))
+    m.constraint(plants, lambda p: dm.sum(ship[p, k] for k in markets) <= supply[p], name="supply")
+    m.constraint(markets, lambda k: dm.sum(ship[p, k] for p in plants) >= demand[k], name="demand")
+
+    print(m)
+    return m
+
+
+# ═══════════════════════════════════════════════════════════════
+# EXAMPLE: Assignment (indexed binaries over a product set)
+# ═══════════════════════════════════════════════════════════════
+
+
+def example_assignment():
+    """Assign workers to tasks one-to-one at minimum cost."""
+    m = dm.Model("assignment")
+
+    workers = m.set("workers", ["w1", "w2", "w3"])
+    tasks = m.set("tasks", ["a", "b", "c"])
+    cost = {
+        ("w1", "a"): 9,
+        ("w1", "b"): 2,
+        ("w1", "c"): 7,
+        ("w2", "a"): 6,
+        ("w2", "b"): 4,
+        ("w2", "c"): 3,
+        ("w3", "a"): 5,
+        ("w3", "b"): 8,
+        ("w3", "c"): 1,
+    }
+
+    assign = m.binary("assign", over=workers * tasks)
+    m.minimize(dm.sum(cost[(w, t)] * assign[w, t] for w in workers for t in tasks))
+    m.constraint(workers, lambda w: dm.sum(assign[w, t] for t in tasks) == 1, name="one_task")
+    m.constraint(tasks, lambda t: dm.sum(assign[w, t] for w in workers) == 1, name="one_worker")
+
+    print(m)
+    return m
+
+
+# ═══════════════════════════════════════════════════════════════
+# EXAMPLE: Multi-commodity flow (set algebra: product + filter)
+# ═══════════════════════════════════════════════════════════════
+
+
+def example_multicommodity_flow():
+    """Min-cost multi-commodity flow on a small sparse network.
+
+    Demonstrates set algebra: arcs are a *sparse* subset of node×node, and the
+    variable is indexed over arcs × commodities (a product set).
+    """
+    m = dm.Model("mcf")
+
+    nodes = m.set("nodes", ["s", "u", "v", "t"])
+    # Arcs are a *sparse* subset of the dense node-pair set ``nodes * nodes``.
+    arcs = (nodes * nodes).where(
+        lambda i, j: (i, j) in {("s", "u"), ("s", "v"), ("u", "t"), ("v", "t"), ("u", "v")}
+    )
+    commodities = m.set("commodities", ["c1", "c2"])
+
+    cap = {a: 10.0 for a in arcs}
+    flow = m.continuous("flow", over=arcs * commodities, lb=0, ub=1000)
+
+    # Arc capacity shared across commodities.
+    m.constraint(
+        arcs,
+        lambda i, j: dm.sum(flow[(i, j), c] for c in commodities) <= cap[(i, j)],
+        name="capacity",
+    )
+    m.minimize(dm.sum(flow[a, c] for a in arcs for c in commodities))
+
+    print(m)
+    return m
+
+
+# ═══════════════════════════════════════════════════════════════
 # Run all examples that don't require the solver backend
 # ═══════════════════════════════════════════════════════════════
 
@@ -692,6 +796,9 @@ if __name__ == "__main__":
         ("Parametric / Sensitivity", example_parametric),
         ("Logical Constraints / GDP", example_logical_constraints),
         ("NN Surrogate Optimization", example_nn_surrogate),
+        ("Transportation (named sets)", example_transportation),
+        ("Assignment (indexed binaries)", example_assignment),
+        ("Multi-commodity Flow (set algebra)", example_multicommodity_flow),
     ]
 
     for name, func in examples:

--- a/python/discopt/modeling/indexed.py
+++ b/python/discopt/modeling/indexed.py
@@ -1,0 +1,140 @@
+"""Indexed containers backed by flat variables/parameters over named sets.
+
+This module sits between the named-set layer (:mod:`discopt.modeling.sets`) and
+the flat model representation in :mod:`discopt.modeling.core`. An indexed
+variable is backed by exactly one flat :class:`~discopt.modeling.core.Variable`
+of shape ``(len(index_set),)`` plus the set's ``key -> position`` map, so
+indexing desugars to the existing ``IndexExpression`` that the JAX compiler and
+``.nl`` exporter already flatten. Nothing downstream changes.
+
+Containers are created through ``Model.continuous(..., over=SET)`` and friends,
+not directly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Hashable, cast
+
+from discopt.modeling.sets import Set
+
+if TYPE_CHECKING:  # pragma: no cover
+    import numpy as np
+
+    from discopt.modeling.core import IndexExpression, Parameter, SolveResult, Variable
+
+
+class IndexedVar:
+    """A variable indexed by a named :class:`~discopt.modeling.sets.Set`.
+
+    Backed by a single flat variable; ``iv[key]`` returns the scalar
+    :class:`~discopt.modeling.core.IndexExpression` at the key's position.
+
+    Attributes
+    ----------
+    flat : Variable
+        The backing flat variable, shape ``(len(index_set),)``.
+    index_set : Set
+        The authoritative index.
+    name : str
+        Same as ``flat.name``.
+    """
+
+    def __init__(self, flat: "Variable", index_set: Set):
+        self.flat = flat
+        self.index_set = index_set
+        self.name = flat.name
+
+    def __getitem__(self, key: Hashable) -> "IndexExpression":
+        pos = self.index_set.ordinal(key)
+        return cast("IndexExpression", self.flat[pos])
+
+    def __iter__(self):
+        return iter(self.index_set)
+
+    def __len__(self) -> int:
+        return len(self.index_set)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.index_set
+
+    def keys(self):
+        """The index-set members, in order."""
+        return self.index_set.members
+
+    def value(self, result: "SolveResult") -> dict:
+        """Return ``{key: optimal_value}`` from a solved result."""
+        arr = result.value(self.flat)
+        flat = arr.reshape(-1)
+        return {k: float(flat[self.index_set.ordinal(k)]) for k in self.index_set}
+
+    def __repr__(self) -> str:
+        return f"IndexedVar({self.name!r}, over={self.index_set.name}, len={len(self)})"
+
+
+class IndexedParam:
+    """A parameter indexed by a named :class:`~discopt.modeling.sets.Set`.
+
+    Backed by a single flat :class:`~discopt.modeling.core.Parameter`; ``ip[key]``
+    returns the scalar element at the key's position.
+    """
+
+    def __init__(self, flat: "Parameter", index_set: Set):
+        self.flat = flat
+        self.index_set = index_set
+        self.name = flat.name
+
+    def __getitem__(self, key: Hashable) -> "IndexExpression":
+        pos = self.index_set.ordinal(key)
+        return cast("IndexExpression", self.flat[pos])
+
+    def __iter__(self):
+        return iter(self.index_set)
+
+    def __len__(self) -> int:
+        return len(self.index_set)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.index_set
+
+    def keys(self):
+        """The index-set members, in order."""
+        return self.index_set.members
+
+    def at(self, key: Hashable) -> float:
+        """The current numeric value at ``key`` (not an expression)."""
+        pos = self.index_set.ordinal(key)
+        return float(self.flat.value.reshape(-1)[pos])
+
+    def __repr__(self) -> str:
+        return f"IndexedParam({self.name!r}, over={self.index_set.name}, len={len(self)})"
+
+
+def resolve_indexed_values(index_set: Set, spec, default, dtype) -> "np.ndarray":
+    """Resolve a per-key bound/value spec into a flat array in set order.
+
+    ``spec`` may be:
+
+    * ``None`` -- use ``default`` for every member;
+    * a scalar -- broadcast to every member;
+    * a ``dict`` -- looked up by member (every member must be present);
+    * a callable -- ``fn(member)`` (or ``fn(*member)`` for ``dimen > 1``).
+    """
+    import numpy as np
+
+    from discopt.modeling.sets import call_member
+
+    n = len(index_set)
+    if spec is None:
+        spec = default
+    if callable(spec):
+        vals = [call_member(spec, m, index_set.dimen) for m in index_set]
+        return np.asarray(vals, dtype=dtype)
+    if isinstance(spec, dict):
+        try:
+            vals = [spec[m] for m in index_set.members]
+        except KeyError as exc:
+            raise KeyError(
+                f"no entry for member {exc.args[0]!r} of set '{index_set.name}'"
+            ) from None
+        return np.asarray(vals, dtype=dtype)
+    return np.broadcast_to(np.asarray(spec, dtype=dtype), (n,)).copy()

--- a/python/discopt/modeling/indexed.py
+++ b/python/discopt/modeling/indexed.py
@@ -149,10 +149,14 @@ class IndexedConstraint:
     (members whose rule returned :data:`Skip` are absent).
     """
 
-    def __init__(self, name, index_set: Set, members: dict):
+    def __init__(self, name, index_set: Set, members: dict, fast: bool = False):
         self.name = name
         self.index_set = index_set
         self._members: dict = members
+        #: True when the family was emitted via the linear fast path (rows live
+        #: in the Rust builder; the held Constraint objects are for introspection
+        #: only and are not in ``model._constraints``).
+        self.fast = fast
 
     def __getitem__(self, key) -> "Constraint":
         from discopt.modeling.sets import _normalize_member
@@ -174,6 +178,117 @@ class IndexedConstraint:
 
     def __repr__(self) -> str:
         return f"IndexedConstraint({self.name!r}, len={len(self)})"
+
+
+class _Affine:
+    """Affine form ``sum(coeffs[pos] * var[pos]) + const`` over a single variable."""
+
+    __slots__ = ("const", "var", "coeffs")
+
+    def __init__(self):
+        self.const: float = 0.0
+        self.var = None  # a single core.Variable, or None for a pure constant
+        self.coeffs: dict = {}  # position -> coefficient
+
+
+def _aff_scale(a, s: float):
+    if a is None:
+        return None
+    b = _Affine()
+    b.const = a.const * s
+    b.var = a.var
+    b.coeffs = {pos: c * s for pos, c in a.coeffs.items()}
+    return b
+
+
+def _aff_add(left, right):
+    if left is None or right is None:
+        return None
+    if left.var is not None and right.var is not None and left.var is not right.var:
+        return None  # two distinct variables -> not single-variable affine
+    out = _Affine()
+    out.const = left.const + right.const
+    out.var = left.var if left.var is not None else right.var
+    out.coeffs = dict(left.coeffs)
+    for pos, c in right.coeffs.items():
+        out.coeffs[pos] = out.coeffs.get(pos, 0.0) + c
+    return out
+
+
+def affine_form(expr):
+    """Reduce a scalar expression to a single-variable :class:`_Affine`, or ``None``.
+
+    Returns ``None`` (caller should fall back to the general path) for anything
+    that is not affine in a single backing variable: nonlinear nodes, bilinear
+    products, array nodes, or any reference to a :class:`Parameter` (whose value
+    must stay symbolic for sensitivity) or to a second distinct variable.
+    """
+    from discopt.modeling.core import (
+        BinaryOp,
+        Constant,
+        IndexExpression,
+        SumOverExpression,
+        UnaryOp,
+        Variable,
+    )
+
+    if isinstance(expr, Constant):
+        if expr.value.ndim != 0:
+            return None
+        a = _Affine()
+        a.const = float(expr.value)
+        return a
+    if isinstance(expr, IndexExpression):
+        base = expr.base
+        if not isinstance(base, Variable) or not isinstance(expr.index, int):
+            return None
+        a = _Affine()
+        a.var = base
+        a.coeffs = {expr.index: 1.0}
+        return a
+    if isinstance(expr, Variable):
+        if expr.size != 1:
+            return None
+        a = _Affine()
+        a.var = expr
+        a.coeffs = {0: 1.0}
+        return a
+    if isinstance(expr, UnaryOp):
+        if expr.op != "neg":
+            return None
+        return _aff_scale(affine_form(expr.operand), -1.0)
+    if isinstance(expr, BinaryOp):
+        if expr.op in ("+", "-"):
+            left = affine_form(expr.left)
+            right = affine_form(expr.right)
+            if expr.op == "-":
+                right = _aff_scale(right, -1.0)
+            return _aff_add(left, right)
+        if expr.op == "*":
+            left = affine_form(expr.left)
+            right = affine_form(expr.right)
+            if left is None or right is None:
+                return None
+            if left.var is None:
+                return _aff_scale(right, left.const)
+            if right.var is None:
+                return _aff_scale(left, right.const)
+            return None  # bilinear
+        if expr.op == "/":
+            left = affine_form(expr.left)
+            right = affine_form(expr.right)
+            if left is None or right is None or right.var is not None or right.const == 0:
+                return None
+            return _aff_scale(left, 1.0 / right.const)
+        return None
+    if isinstance(expr, SumOverExpression):
+        acc = _Affine()
+        for term in expr.terms:
+            acc = _aff_add(acc, affine_form(term))
+            if acc is None:
+                return None
+        return acc
+    return None
 
 
 def resolve_indexed_values(index_set: Set, spec, default, dtype) -> "np.ndarray":

--- a/python/discopt/modeling/indexed.py
+++ b/python/discopt/modeling/indexed.py
@@ -71,6 +71,10 @@ class IndexedVar:
         Same as ``flat.name``.
     """
 
+    #: Marker so ``dm.sum``/``dm.prod`` expand this to its element expressions
+    #: instead of iterating it (its iterator yields index keys, not terms).
+    _is_indexed_container = True
+
     def __init__(self, flat: "Variable", index_set: Set):
         self.flat = flat
         self.index_set = index_set
@@ -109,6 +113,9 @@ class IndexedParam:
     Backed by a single flat :class:`~discopt.modeling.core.Parameter`; ``ip[key]``
     returns the scalar element at the key's position.
     """
+
+    #: See :attr:`IndexedVar._is_indexed_container`.
+    _is_indexed_container = True
 
     def __init__(self, flat: "Parameter", index_set: Set):
         self.flat = flat
@@ -319,4 +326,4 @@ def resolve_indexed_values(index_set: Set, spec, default, dtype) -> "np.ndarray"
                 f"no entry for member {exc.args[0]!r} of set '{index_set.name}'"
             ) from None
         return np.asarray(vals, dtype=dtype)
-    return np.broadcast_to(np.asarray(spec, dtype=dtype), (n,)).copy()
+    return cast("np.ndarray", np.broadcast_to(np.asarray(spec, dtype=dtype), (n,)).copy())

--- a/python/discopt/modeling/indexed.py
+++ b/python/discopt/modeling/indexed.py
@@ -20,7 +20,39 @@ from discopt.modeling.sets import Set
 if TYPE_CHECKING:  # pragma: no cover
     import numpy as np
 
-    from discopt.modeling.core import IndexExpression, Parameter, SolveResult, Variable
+    from discopt.modeling.core import (
+        Constraint,
+        IndexExpression,
+        Parameter,
+        SolveResult,
+        Variable,
+    )
+
+
+class _SkipType:
+    """Singleton sentinel returned from a constraint rule to omit that key."""
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "Skip"
+
+
+#: Sentinel a ``Model.constraint`` rule may return to skip a member
+#: (Pyomo ``Constraint.Skip`` parity).
+Skip = _SkipType()
+
+
+def key_label(member) -> str:
+    """Render a set member as a constraint-name label, e.g. ``pitt`` or ``pitt,a``."""
+    if isinstance(member, tuple):
+        return ",".join(str(p) for p in member)
+    return str(member)
 
 
 class IndexedVar:
@@ -107,6 +139,41 @@ class IndexedParam:
 
     def __repr__(self) -> str:
         return f"IndexedParam({self.name!r}, over={self.index_set.name}, len={len(self)})"
+
+
+class IndexedConstraint:
+    """A family of constraints generated over a named set, keyed by member.
+
+    Returned by :meth:`Model.constraint`. Each present member maps to the flat
+    :class:`~discopt.modeling.core.Constraint` that was added to the model
+    (members whose rule returned :data:`Skip` are absent).
+    """
+
+    def __init__(self, name, index_set: Set, members: dict):
+        self.name = name
+        self.index_set = index_set
+        self._members: dict = members
+
+    def __getitem__(self, key) -> "Constraint":
+        from discopt.modeling.sets import _normalize_member
+
+        norm = _normalize_member(key)
+        if norm not in self._members:
+            raise KeyError(f"no constraint for key {key!r} in '{self.name}'")
+        return cast("Constraint", self._members[norm])
+
+    def __iter__(self):
+        return iter(self._members)
+
+    def __len__(self) -> int:
+        return len(self._members)
+
+    def keys(self):
+        """Members for which a constraint was generated (Skip omitted)."""
+        return tuple(self._members.keys())
+
+    def __repr__(self) -> str:
+        return f"IndexedConstraint({self.name!r}, len={len(self)})"
 
 
 def resolve_indexed_values(index_set: Set, spec, default, dtype) -> "np.ndarray":

--- a/python/discopt/modeling/sets.py
+++ b/python/discopt/modeling/sets.py
@@ -1,0 +1,299 @@
+"""Named index sets and set algebra for sparse modeling.
+
+This module adds a Pyomo/JuMP-style *named set* layer on top of the modeling
+API. Sets are the authoritative index for indexed variables, parameters, and
+constraints (added in later milestones). A :class:`Set` holds an order-stable,
+de-duplicated collection of hashable members and supports set algebra:
+
+* union ``A | B``
+* intersection ``A & B``
+* difference ``A - B``
+* cross product ``A * B`` (lazy, via :class:`ProductSet`)
+* filtering ``A.where(pred)``
+
+Members may be scalars (``dimen == 1``) or fixed-arity tuples (``dimen == N``).
+All members of a set share the same dimensionality (``dimen``), inferred from
+the members and overridable through the ``dimen`` keyword (Pyomo parity).
+
+The set is the single source of truth for which index tuples exist, so summing
+over a set always iterates the full declared membership -- avoiding the sparse
+aggregation footgun where only previously-accessed indices participate.
+
+Examples
+--------
+>>> import discopt.modeling as dm
+>>> m = dm.Model()
+>>> plants = m.set("plants", ["pitt", "sf", "nyc"])
+>>> markets = m.set("markets", ["a", "b"])
+>>> links = (plants * markets).where(lambda p, k: (p, k) != ("nyc", "a"))
+>>> len(links)
+5
+>>> ("nyc", "a") in links
+False
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Callable, Hashable, Iterable, Iterator, Union, cast
+
+Member = Union[Hashable, tuple]
+
+
+def _normalize_member(raw: object) -> Member:
+    """Normalize a raw member to a scalar or tuple.
+
+    Lists are converted to tuples so members are hashable. A one-element tuple
+    is unwrapped to its scalar so that ``("pitt",)`` and ``"pitt"`` are treated
+    as the same ``dimen == 1`` member.
+    """
+    if isinstance(raw, list):
+        raw = tuple(raw)
+    if isinstance(raw, tuple):
+        if len(raw) == 1:
+            return cast(Member, raw[0])
+        return raw
+    return cast(Member, raw)
+
+
+def _arity(member: Member) -> int:
+    """Dimensionality of a single member (tuple length, or 1 for a scalar)."""
+    return len(member) if isinstance(member, tuple) else 1
+
+
+def _apply_pred(pred: Callable, member: Member, dimen: int) -> bool:
+    """Call a predicate on a member, unpacking tuple members for ``dimen > 1``."""
+    if dimen == 1:
+        return bool(pred(member))
+    assert isinstance(member, tuple)
+    return bool(pred(*member))
+
+
+class _SetBase:
+    """Shared algebra/filter/slice behavior for :class:`Set` and :class:`ProductSet`.
+
+    Subclasses provide ``name``, ``dimen``, ``__iter__``, ``__len__``, and
+    ``__contains__``; everything else is expressed in terms of those.
+    """
+
+    name: str
+    dimen: int
+
+    def __iter__(self) -> Iterator[Member]:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def __len__(self) -> int:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def __contains__(self, member: object) -> bool:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    @property
+    def members(self) -> tuple[Member, ...]:
+        """Materialized, order-stable tuple of members."""
+        return tuple(self)
+
+    # ── set algebra ──
+
+    def _check_same_dimen(self, other: "_SetBase", op: str) -> None:
+        if self.dimen != other.dimen:
+            raise ValueError(
+                f"cannot apply '{op}' to sets of different dimensionality "
+                f"({self.name}: dimen={self.dimen}, {other.name}: dimen={other.dimen})"
+            )
+
+    def __or__(self, other: "_SetBase") -> "Set":
+        self._check_same_dimen(other, "|")
+        seen: set = set()
+        merged: list[Member] = []
+        for member in itertools.chain(self, other):
+            if member not in seen:
+                seen.add(member)
+                merged.append(member)
+        return Set(f"({self.name}|{other.name})", merged, dimen=self.dimen)
+
+    def __and__(self, other: "_SetBase") -> "Set":
+        self._check_same_dimen(other, "&")
+        right = set(other)
+        kept = [m for m in self if m in right]
+        return Set(f"({self.name}&{other.name})", kept, dimen=self.dimen)
+
+    def __sub__(self, other: "_SetBase") -> "Set":
+        self._check_same_dimen(other, "-")
+        right = set(other)
+        kept = [m for m in self if m not in right]
+        return Set(f"({self.name}-{other.name})", kept, dimen=self.dimen)
+
+    def __mul__(self, other: "_SetBase") -> "ProductSet":
+        return ProductSet(self, other)
+
+    # ── filtering & slicing ──
+
+    def where(self, pred: Callable[..., bool]) -> "Set":
+        """Return the subset whose members satisfy ``pred``.
+
+        For ``dimen == 1`` the predicate is called as ``pred(member)``; for
+        ``dimen > 1`` it is called with the unpacked components, ``pred(*member)``.
+        """
+        kept = [m for m in self if _apply_pred(pred, m, self.dimen)]
+        return Set(f"{self.name}|where", kept, dimen=self.dimen)
+
+    def with_first(self, key: Hashable) -> "Set":
+        """Members whose first component equals ``key`` (requires ``dimen >= 2``)."""
+        if self.dimen < 2:
+            raise ValueError("with_first requires a set with dimen >= 2")
+        return self.where(lambda *m: m[0] == key)
+
+    def with_last(self, key: Hashable) -> "Set":
+        """Members whose last component equals ``key`` (requires ``dimen >= 2``)."""
+        if self.dimen < 2:
+            raise ValueError("with_last requires a set with dimen >= 2")
+        return self.where(lambda *m: m[-1] == key)
+
+    def __repr__(self) -> str:
+        return f"Set({self.name!r}, dimen={self.dimen}, len={len(self)})"
+
+
+class Set(_SetBase):
+    """A named index set of hashable members.
+
+    Parameters
+    ----------
+    name : str
+        Identifier for the set (used to synthesize derived-set names and
+        constraint/variable index labels).
+    members : iterable
+        Members of the set. Scalars give ``dimen == 1``; tuples (or lists, which
+        are coerced to tuples) of length ``N`` give ``dimen == N``. Duplicates
+        are removed, preserving first-occurrence order.
+    dimen : int, optional
+        Declared dimensionality. Inferred from ``members`` when omitted; required
+        (defaults to 1) when ``members`` is empty. When given, every member is
+        validated against it.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        members: Iterable[object],
+        dimen: int | None = None,
+    ):
+        self.name = name
+        normalized: list[Member] = []
+        seen: set = set()
+        for raw in members:
+            member = _normalize_member(raw)
+            if member not in seen:
+                seen.add(member)
+                normalized.append(member)
+
+        if dimen is None:
+            dimen = _arity(normalized[0]) if normalized else 1
+        if dimen < 1:
+            raise ValueError(f"dimen must be >= 1, got {dimen}")
+        for member in normalized:
+            if _arity(member) != dimen:
+                raise ValueError(
+                    f"set '{name}' has member {member!r} of arity {_arity(member)}, "
+                    f"expected dimen={dimen}"
+                )
+
+        self.dimen = dimen
+        self._members: tuple[Member, ...] = tuple(normalized)
+        self._index: dict[Member, int] = {m: i for i, m in enumerate(self._members)}
+
+    @property
+    def members(self) -> tuple[Member, ...]:
+        return self._members
+
+    def __iter__(self) -> Iterator[Member]:
+        return iter(self._members)
+
+    def __len__(self) -> int:
+        return len(self._members)
+
+    def __contains__(self, member: object) -> bool:
+        return _normalize_member(member) in self._index
+
+    def ordinal(self, member: object) -> int:
+        """Zero-based position of ``member`` (raises ``KeyError`` if absent)."""
+        key = _normalize_member(member)
+        if key not in self._index:
+            raise KeyError(f"{member!r} is not a member of set '{self.name}'")
+        return self._index[key]
+
+
+class RangeSet(Set):
+    """An integer index set ``RangeSet(n) == 1..n`` or ``RangeSet(a, b) == a..b``.
+
+    Provided for parity with Pyomo's ``RangeSet``; the upper bound is inclusive.
+
+    Examples
+    --------
+    >>> list(RangeSet(3))
+    [1, 2, 3]
+    >>> list(RangeSet(2, 5))
+    [2, 3, 4, 5]
+    """
+
+    def __init__(self, start: int, stop: int | None = None, name: str | None = None):
+        if stop is None:
+            lo, hi = 1, start
+        else:
+            lo, hi = start, stop
+        if name is None:
+            name = f"RangeSet({lo},{hi})"
+        super().__init__(name, range(lo, hi + 1), dimen=1)
+
+
+class ProductSet(_SetBase):
+    """Lazy Cartesian product of two or more sets.
+
+    Members are flattened tuples of the factor members; iteration is lazy, so a
+    product is never fully materialized until iterated (or until ``where`` filters
+    it into a concrete :class:`Set`). ``A * B * C`` chains without nesting.
+    """
+
+    def __init__(self, *factors: _SetBase):
+        flat: list[_SetBase] = []
+        for f in factors:
+            if isinstance(f, ProductSet):
+                flat.extend(f.factors)
+            else:
+                flat.append(f)
+        self.factors: tuple[_SetBase, ...] = tuple(flat)
+        self.name = "(" + "*".join(f.name for f in self.factors) + ")"
+        self.dimen = sum(f.dimen for f in self.factors)
+
+    def _as_components(self, member: Member) -> tuple:
+        return member if isinstance(member, tuple) else (member,)
+
+    def __iter__(self) -> Iterator[Member]:
+        for combo in itertools.product(*self.factors):
+            flat: tuple = ()
+            for f, part in zip(self.factors, combo):
+                flat += self._as_components(part)
+            yield flat[0] if len(flat) == 1 else flat
+
+    def __len__(self) -> int:
+        total = 1
+        for f in self.factors:
+            total *= len(f)
+        return total
+
+    def __contains__(self, member: object) -> bool:
+        key = _normalize_member(member)
+        comps = self._as_components(key)
+        if len(comps) != self.dimen:
+            return False
+        pos = 0
+        for f in self.factors:
+            part = comps[pos : pos + f.dimen]
+            probe = part[0] if len(part) == 1 else part
+            if probe not in f:
+                return False
+            pos += f.dimen
+        return True
+
+    def __mul__(self, other: "_SetBase") -> "ProductSet":
+        return ProductSet(self, other)

--- a/python/discopt/modeling/sets.py
+++ b/python/discopt/modeling/sets.py
@@ -177,6 +177,19 @@ class _SetBase:
             raise ValueError("with_last requires a set with dimen >= 2")
         return self.where(lambda *m: m[-1] == key)
 
+    def __eq__(self, other: object) -> bool:
+        """Value equality: same dimensionality and same members, in order.
+
+        The set is the source of truth for which index tuples exist, so two sets
+        with identical members are equal regardless of name (name is metadata).
+        """
+        if not isinstance(other, _SetBase):
+            return NotImplemented
+        return self.dimen == other.dimen and self.members == other.members
+
+    def __hash__(self) -> int:
+        return hash((self.dimen, self.members))
+
     def __repr__(self) -> str:
         return f"Set({self.name!r}, dimen={self.dimen}, len={len(self)})"
 

--- a/python/discopt/modeling/sets.py
+++ b/python/discopt/modeling/sets.py
@@ -61,12 +61,22 @@ def _arity(member: Member) -> int:
     return len(member) if isinstance(member, tuple) else 1
 
 
+def call_member(fn: Callable, member: Member, dimen: int):
+    """Call ``fn`` on a member, unpacking tuple members for ``dimen > 1``.
+
+    For ``dimen == 1`` this is ``fn(member)``; for ``dimen > 1`` the components
+    are unpacked, ``fn(*member)``. Shared by predicates (``where``), indexed
+    bound/value rules, and aggregation over sets.
+    """
+    if dimen == 1:
+        return fn(member)
+    assert isinstance(member, tuple)
+    return fn(*member)
+
+
 def _apply_pred(pred: Callable, member: Member, dimen: int) -> bool:
     """Call a predicate on a member, unpacking tuple members for ``dimen > 1``."""
-    if dimen == 1:
-        return bool(pred(member))
-    assert isinstance(member, tuple)
-    return bool(pred(*member))
+    return bool(call_member(pred, member, dimen))
 
 
 class _SetBase:

--- a/python/discopt/modeling/sets.py
+++ b/python/discopt/modeling/sets.py
@@ -307,3 +307,25 @@ class ProductSet(_SetBase):
 
     def __mul__(self, other: "_SetBase") -> "ProductSet":
         return ProductSet(self, other)
+
+    def ordinal(self, member: object) -> int:
+        """Zero-based position of ``member`` in iteration order (row-major).
+
+        Computed from factor ordinals without materializing the product.
+        """
+        key = _normalize_member(member)
+        comps = self._as_components(key)
+        if len(comps) != self.dimen:
+            raise KeyError(f"{member!r} is not a member of set '{self.name}'")
+        idx = 0
+        pos = 0
+        for f in self.factors:
+            part = comps[pos : pos + f.dimen]
+            sub = part[0] if len(part) == 1 else part
+            try:
+                o = f.ordinal(sub)  # type: ignore[attr-defined]
+            except (KeyError, AttributeError):
+                raise KeyError(f"{member!r} is not a member of set '{self.name}'") from None
+            idx = idx * len(f) + o
+            pos += f.dimen
+        return idx

--- a/python/discopt/modeling/sets.py
+++ b/python/discopt/modeling/sets.py
@@ -61,6 +61,23 @@ def _arity(member: Member) -> int:
     return len(member) if isinstance(member, tuple) else 1
 
 
+def _deep_flatten(key) -> tuple:
+    """Flatten nested tuples into a flat tuple of scalar components.
+
+    Lets a product-set key be written flat (``flow[i, j, c]``) or nested
+    (``flow[(i, j), c]``) interchangeably.
+    """
+    if isinstance(key, tuple):
+        out: list = []
+        for part in key:
+            if isinstance(part, tuple):
+                out.extend(_deep_flatten(part))
+            else:
+                out.append(part)
+        return tuple(out)
+    return (key,)
+
+
 def call_member(fn: Callable, member: Member, dimen: int):
     """Call ``fn`` on a member, unpacking tuple members for ``dimen > 1``.
 
@@ -292,8 +309,7 @@ class ProductSet(_SetBase):
         return total
 
     def __contains__(self, member: object) -> bool:
-        key = _normalize_member(member)
-        comps = self._as_components(key)
+        comps = _deep_flatten(member)
         if len(comps) != self.dimen:
             return False
         pos = 0
@@ -313,8 +329,7 @@ class ProductSet(_SetBase):
 
         Computed from factor ordinals without materializing the product.
         """
-        key = _normalize_member(member)
-        comps = self._as_components(key)
+        comps = _deep_flatten(member)
         if len(comps) != self.dimen:
             raise KeyError(f"{member!r} is not a member of set '{self.name}'")
         idx = 0

--- a/python/tests/test_fast_path.py
+++ b/python/tests/test_fast_path.py
@@ -1,0 +1,146 @@
+"""Tests for the linear fast-path routing of indexed constraint families (Phase 7 M5).
+
+The fast path must be a pure performance optimization: a family routed into the
+Rust builder must yield the same model (and same solution) as the general
+expression path.
+"""
+
+import discopt.modeling as dm
+import pytest
+
+SUPPLY = {"pitt": 20.0, "sf": 30.0}
+DEMAND = {"a": 10.0, "b": 25.0, "c": 15.0}
+COST = {
+    ("pitt", "a"): 4.0,
+    ("pitt", "b"): 6.0,
+    ("pitt", "c"): 8.0,
+    ("sf", "a"): 5.0,
+    ("sf", "b"): 3.0,
+    ("sf", "c"): 7.0,
+}
+
+
+def build_transportation(fast: bool):
+    m = dm.Model("transport")
+    plants = m.set("plants", list(SUPPLY))
+    markets = m.set("markets", list(DEMAND))
+    links = plants * markets
+    ship = m.continuous("ship", over=links, lb=0, ub=1000)
+    m.minimize(dm.sum(COST[(p, k)] * ship[p, k] for p in plants for k in markets))
+    m.constraint(
+        plants,
+        lambda p: dm.sum(ship[p, k] for k in markets) <= SUPPLY[p],
+        name="supply",
+        fast=fast,
+    )
+    m.constraint(
+        markets,
+        lambda k: dm.sum(ship[p, k] for p in plants) >= DEMAND[k],
+        name="demand",
+        fast=fast,
+    )
+    return m, ship
+
+
+class TestFastPathRouting:
+    def test_fast_routes_into_builder(self):
+        m, _ = build_transportation(fast=True)
+        # both families are single-variable affine -> nothing on the Python list
+        assert len(m._constraints) == 0
+        from discopt._rust import model_to_repr
+
+        repr_ = model_to_repr(m, m._builder)
+        assert repr_.n_constraints == len(SUPPLY) + len(DEMAND)
+
+    def test_slow_keeps_python_constraints(self):
+        m, _ = build_transportation(fast=False)
+        assert len(m._constraints) == len(SUPPLY) + len(DEMAND)
+
+    def test_indexedconstraint_fast_flag(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        x = m.continuous("x", over=plants, lb=0)
+        ic_fast = m.constraint(plants, lambda p: x[p] <= 1, name="c", fast=True)
+        assert ic_fast.fast is True
+        m2 = dm.Model()
+        plants2 = m2.set("plants", ["pitt", "sf"])
+        x2 = m2.continuous("x", over=plants2, lb=0)
+        ic_slow = m2.constraint(plants2, lambda p: x2[p] <= 1, name="c", fast=False)
+        assert ic_slow.fast is False
+
+
+class TestFastPathFallback:
+    def test_nonlinear_falls_back(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        x = m.continuous("x", over=s, lb=0, ub=5)
+        ic = m.constraint(s, lambda i: x[i] ** 2 <= 4, name="nl", fast=True)
+        assert ic.fast is False
+        assert len(m._constraints) == 3
+
+    def test_multivariable_falls_back(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2])
+        x = m.continuous("x", over=s, lb=0)
+        y = m.continuous("y", over=s, lb=0)
+        ic = m.constraint(s, lambda i: x[i] + y[i] <= 1, name="link", fast=True)
+        assert ic.fast is False
+        assert len(m._constraints) == 2
+
+    def test_parameter_coefficient_falls_back(self):
+        # A parameter must stay symbolic -> the fast path must not bake it in.
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        cap = m.parameter("cap", over=s, value={1: 1.0, 2: 2.0, 3: 3.0})
+        x = m.continuous("x", over=s, lb=0)
+        ic = m.constraint(s, lambda i: cap[i] * x[i] <= 10, name="p", fast=True)
+        assert ic.fast is False
+        assert len(m._constraints) == 3
+
+    def test_mixed_sense_falls_back(self):
+        # <= and >= both normalize to "<=", so mix in an equality to differ.
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3, 4])
+        x = m.continuous("x", over=s, lb=0, ub=5)
+        ic = m.constraint(
+            s, lambda i: (x[i] <= 3) if i % 2 == 0 else (x[i] == 2), name="mix", fast=True
+        )
+        assert ic.fast is False
+        assert len(m._constraints) == 4
+
+    def test_ge_normalizes_and_still_fast(self):
+        # A uniform >= family is still single-sense ("<=") after normalization.
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        x = m.continuous("x", over=s, lb=0, ub=5)
+        ic = m.constraint(s, lambda i: x[i] >= 1, name="lb", fast=True)
+        assert ic.fast is True
+
+
+class TestFastPathEquivalence:
+    def test_same_solution_fast_vs_slow(self):
+        m_fast, ship_fast = build_transportation(fast=True)
+        m_slow, ship_slow = build_transportation(fast=False)
+        r_fast = m_fast.solve()
+        r_slow = m_slow.solve()
+        assert r_fast.status == "optimal"
+        assert r_slow.status == "optimal"
+        assert r_fast.objective == pytest.approx(r_slow.objective, rel=1e-6)
+        vf = ship_fast.value(r_fast)
+        vs = ship_slow.value(r_slow)
+        for key in vf:
+            assert vf[key] == pytest.approx(vs[key], abs=1e-5)
+
+    def test_fast_matches_known_optimum(self):
+        # Balanced transportation; LP optimum is unique and checkable.
+        m, ship = build_transportation(fast=True)
+        r = m.solve()
+        assert r.status == "optimal"
+        # demand exactly met, supply not exceeded
+        vals = ship.value(r)
+        for k in DEMAND:
+            got = sum(vals[(p, k)] for p in SUPPLY)
+            assert got == pytest.approx(DEMAND[k], abs=1e-5)
+        for p in SUPPLY:
+            used = sum(vals[(p, k)] for k in DEMAND)
+            assert used <= SUPPLY[p] + 1e-5

--- a/python/tests/test_fast_path.py
+++ b/python/tests/test_fast_path.py
@@ -117,6 +117,42 @@ class TestFastPathFallback:
         assert ic.fast is True
 
 
+class TestNlExportFastPath:
+    def test_fast_model_nl_has_all_constraints(self):
+        m_fast, _ = build_transportation(fast=True)
+        m_slow, _ = build_transportation(fast=False)
+        # header line 2: "<nvars> <ncons> <nobjs> ..."
+        nfast = int(m_fast.to_nl(None).splitlines()[1].split()[1])
+        nslow = int(m_slow.to_nl(None).splitlines()[1].split()[1])
+        assert nfast == nslow == len(SUPPLY) + len(DEMAND)
+
+    def test_fast_model_nl_roundtrip_preserves_optimum(self, tmp_path):
+        m_fast, _ = build_transportation(fast=True)
+        r0 = m_fast.solve()
+        path = tmp_path / "fast.nl"
+        m_fast.to_nl(str(path))
+        m2 = dm.from_nl(str(path))
+        r1 = m2.solve()
+        assert r1.status == "optimal"
+        assert r1.objective == pytest.approx(r0.objective, rel=1e-6)
+
+    def test_direct_add_linear_constraints_exported(self, tmp_path):
+        # The pre-existing fast-construction API also bypassed _constraints.
+        import numpy as np
+
+        m = dm.Model("direct")
+        x = m.continuous("x", shape=(3,), lb=0, ub=10)
+        A = np.array([[1.0, 1.0, 0.0], [0.0, 1.0, 1.0]])
+        m.add_linear_constraints(A, x, ">=", np.array([2.0, 3.0]), name="c")
+        m.minimize(dm.sum(x[i] for i in range(3)))
+        r0 = m.solve()
+        path = tmp_path / "direct.nl"
+        m.to_nl(str(path))
+        r1 = dm.from_nl(str(path)).solve()
+        assert int(m.to_nl(None).splitlines()[1].split()[1]) == 2  # both rows exported
+        assert r1.objective == pytest.approx(r0.objective, rel=1e-6)
+
+
 class TestFastPathEquivalence:
     def test_same_solution_fast_vs_slow(self):
         m_fast, ship_fast = build_transportation(fast=True)

--- a/python/tests/test_fast_path.py
+++ b/python/tests/test_fast_path.py
@@ -116,6 +116,31 @@ class TestFastPathFallback:
         ic = m.constraint(s, lambda i: x[i] >= 1, name="lb", fast=True)
         assert ic.fast is True
 
+    def test_division_by_variable_falls_back(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2])
+        z = m.continuous("z", over=s, lb=1, ub=10)
+        ic = m.constraint(s, lambda i: 5 / z[i] <= 2, name="bad", fast=True)
+        assert ic.fast is False  # nonlinear -> general path
+
+    def test_neg_and_division_by_constant_fast_matches_slow(self):
+        # Body uses unary neg, divide-by-constant, and a constant offset.
+        def build(fast):
+            m = dm.Model()
+            s = m.set("s", [0, 1])
+            x = m.continuous("x", over=s, lb=0, ub=10)
+            ic = m.constraint(s, lambda i: -x[i] / 2 + 3 <= 0, name="r", fast=fast)
+            m.minimize(dm.sum(x[i] for i in s))
+            return m, x, ic
+
+        mf, xf, icf = build(True)
+        ms, xs, ics = build(False)
+        assert icf.fast is True and ics.fast is False
+        rf, rs = mf.solve(), ms.solve()
+        assert rf.objective == pytest.approx(rs.objective, abs=1e-5)
+        # x >= 6 from -x/2 + 3 <= 0
+        assert all(v == pytest.approx(6.0, abs=1e-4) for v in xf.value(rf).values())
+
 
 class TestNlExportFastPath:
     def test_fast_model_nl_has_all_constraints(self):
@@ -236,6 +261,36 @@ class TestNlExportQuadraticObjective:
         lines = m.to_nl(None).splitlines()
         o_idx = next(i for i, ln in enumerate(lines) if ln.startswith("O0"))
         assert lines[o_idx + 1] != "n0"  # has a real nonlinear body
+
+    @pytest.mark.parametrize(
+        "Q",
+        [
+            [[2.0, 1.0], [1.0, 2.0]],  # full symmetric
+            [[2.0, 2.0], [0.0, 2.0]],  # upper-triangular
+            [[2.0, 0.0], [2.0, 2.0]],  # lower-triangular (lower must be ignored)
+            [[2.0, 3.0], [-1.0, 2.0]],  # asymmetric (indefinite)
+        ],
+    )
+    def test_objective_function_matches_builder_at_fixed_point(self, tmp_path, Q):
+        # The builder reads only triu(Q) and reflects it; export must reproduce
+        # the SAME objective FUNCTION for any Q form. Compare at a fixed point
+        # (tight bounds) so the check is valid even for nonconvex Q.
+        import numpy as np
+
+        pt = np.array([1.3, -0.7])
+
+        def f(reimport):
+            m = dm.Model("q")
+            x = m.continuous("x", shape=(2,), lb=pt, ub=pt)
+            m.add_quadratic_objective(np.asarray(Q), np.zeros(2), x)
+            m.add_linear_constraints(np.ones((1, 2)), x, ">=", np.array([-1e9]), name="c")
+            if not reimport:
+                return m.solve().objective
+            p = tmp_path / "q.nl"
+            m.to_nl(str(p))
+            return dm.from_nl(str(p)).solve().objective
+
+        assert f(reimport=True) == pytest.approx(f(reimport=False), abs=1e-6)
 
 
 class TestFastPathEquivalence:

--- a/python/tests/test_fast_path.py
+++ b/python/tests/test_fast_path.py
@@ -153,6 +153,40 @@ class TestNlExportFastPath:
         assert r1.objective == pytest.approx(r0.objective, rel=1e-6)
 
 
+class TestNlExportFastObjective:
+    @staticmethod
+    def _build(sense, constant):
+        import numpy as np
+
+        m = dm.Model("fastobj")
+        x = m.continuous("x", shape=(3,), lb=0, ub=10)
+        A = np.array([[1.0, 1.0, 0.0], [0.0, 1.0, 1.0]])
+        m.add_linear_constraints(A, x, ">=", np.array([2.0, 3.0]), name="c")
+        m.add_linear_objective(np.array([3.0, 1.0, 2.0]), x, constant=constant, sense=sense)
+        return m
+
+    @pytest.mark.parametrize(
+        "sense,constant", [("minimize", 0.0), ("minimize", 5.0), ("maximize", 0.0)]
+    )
+    def test_linear_objective_roundtrips(self, tmp_path, sense, constant):
+        m = self._build(sense, constant)
+        r0 = m.solve()
+        path = tmp_path / "obj.nl"
+        m.to_nl(str(path))
+        r1 = dm.from_nl(str(path)).solve()
+        assert r1.status == "optimal"
+        assert r1.objective == pytest.approx(r0.objective, rel=1e-6, abs=1e-6)
+
+    def test_expression_objective_not_overwritten(self):
+        # A real objective set after a builder objective must win on export.
+        m = self._build("minimize", 0.0)
+        x = m._variables[0]
+        m.minimize(dm.sum(x[i] for i in range(3)))  # replaces placeholder
+        txt = m.to_nl(None)
+        # objective gradient has all 3 unit coeffs from the expression objective
+        assert "G0 3" in txt
+
+
 class TestFastPathEquivalence:
     def test_same_solution_fast_vs_slow(self):
         m_fast, ship_fast = build_transportation(fast=True)

--- a/python/tests/test_fast_path.py
+++ b/python/tests/test_fast_path.py
@@ -187,6 +187,57 @@ class TestNlExportFastObjective:
         assert "G0 3" in txt
 
 
+class TestNlExportQuadraticObjective:
+    @staticmethod
+    def _build(Q, c, constant=0.0):
+        import numpy as np
+
+        m = dm.Model("qp")
+        x = m.continuous("x", shape=(2,), lb=-10, ub=10)
+        m.add_quadratic_objective(np.asarray(Q), np.asarray(c), x, constant=constant)
+        m.add_linear_constraints(np.array([[1.0, 1.0]]), x, "<=", np.array([10.0]), name="c")
+        return m
+
+    def test_diagonal_q_roundtrips(self, tmp_path):
+        # 0.5 x'Qx + c'x with Q=2I, c=(-2,-6) -> min at (1,3), obj -10.
+        m = self._build([[2.0, 0.0], [0.0, 2.0]], [-2.0, -6.0])
+        r0 = m.solve()
+        path = tmp_path / "qp.nl"
+        m.to_nl(str(path))
+        r1 = dm.from_nl(str(path)).solve()
+        assert r1.status == "optimal"
+        assert r1.objective == pytest.approx(r0.objective, rel=1e-5, abs=1e-5)
+
+    def test_constant_offset_roundtrips(self, tmp_path):
+        m = self._build([[2.0, 0.0], [0.0, 2.0]], [-2.0, -6.0], constant=7.5)
+        r0 = m.solve()
+        path = tmp_path / "qp.nl"
+        m.to_nl(str(path))
+        r1 = dm.from_nl(str(path)).solve()
+        assert r1.objective == pytest.approx(r0.objective, rel=1e-5, abs=1e-5)
+
+    def test_coupled_cross_terms_roundtrip(self, tmp_path):
+        # Off-diagonal Q exercises the x_i x_j cross terms.
+        import numpy as np
+
+        m = dm.Model("qp2")
+        x = m.continuous("x", shape=(2,), lb=-10, ub=10)
+        m.add_quadratic_objective(np.array([[2.0, 1.0], [1.0, 2.0]]), np.zeros(2), x)
+        m.add_linear_constraints(np.array([[1.0, 1.0]]), x, ">=", np.array([2.0]), name="c")
+        r0 = m.solve()
+        path = tmp_path / "qp2.nl"
+        m.to_nl(str(path))
+        r1 = dm.from_nl(str(path)).solve()
+        assert r1.objective == pytest.approx(r0.objective, rel=1e-5, abs=1e-5)
+
+    def test_objective_is_nonlinear_in_nl(self):
+        # The quadratic objective must export a nonlinear O-segment, not n0.
+        m = self._build([[2.0, 0.0], [0.0, 2.0]], [-2.0, -6.0])
+        lines = m.to_nl(None).splitlines()
+        o_idx = next(i for i, ln in enumerate(lines) if ln.startswith("O0"))
+        assert lines[o_idx + 1] != "n0"  # has a real nonlinear body
+
+
 class TestFastPathEquivalence:
     def test_same_solution_fast_vs_slow(self):
         m_fast, ship_fast = build_transportation(fast=True)

--- a/python/tests/test_indexed_constraints.py
+++ b/python/tests/test_indexed_constraints.py
@@ -1,0 +1,118 @@
+"""Tests for indexed constraints over named sets (Phase 7 M3)."""
+
+import discopt.modeling as dm
+import pytest
+from discopt.modeling.core import Constraint
+from discopt.modeling.indexed import IndexedConstraint, Skip
+
+
+class TestModelConstraint:
+    def test_one_constraint_per_member(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        x = m.continuous("x", over=plants, lb=0)
+        ic = m.constraint(plants, lambda p: x[p] <= 100, name="cap")
+        assert isinstance(ic, IndexedConstraint)
+        assert len(ic) == 3
+        assert len(m._constraints) == 3
+
+    def test_key_tuple_naming(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        x = m.continuous("x", over=plants, lb=0)
+        m.constraint(plants, lambda p: x[p] <= 100, name="cap")
+        names = {c.name for c in m._constraints}
+        assert names == {"cap[pitt]", "cap[sf]"}
+
+    def test_tuple_member_unpacks_into_rule(self):
+        m = dm.Model()
+        links = m.set("links", [("pitt", "a"), ("sf", "b")])
+        x = m.continuous("x", over=links, lb=0)
+        m.constraint(links, lambda p, k: x[p, k] <= 10, name="flow")
+        names = {c.name for c in m._constraints}
+        assert names == {"flow[pitt,a]", "flow[sf,b]"}
+
+    def test_skip_omits_member(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3, 4])
+        x = m.continuous("x", over=s, lb=0)
+        ic = m.constraint(s, lambda i: (x[i] <= 1) if i % 2 == 0 else Skip, name="even")
+        assert len(ic) == 2
+        assert set(ic.keys()) == {2, 4}
+        assert len(m._constraints) == 2
+
+    def test_getitem_returns_constraint(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        x = m.continuous("x", over=plants, lb=0)
+        ic = m.constraint(plants, lambda p: x[p] <= 100, name="cap")
+        c = ic["pitt"]
+        assert isinstance(c, Constraint)
+        assert c.name == "cap[pitt]"
+
+    def test_getitem_bad_key_raises(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        x = m.continuous("x", over=plants, lb=0)
+        ic = m.constraint(plants, lambda p: x[p] <= 100, name="cap")
+        with pytest.raises(KeyError, match="no constraint for key"):
+            _ = ic["nyc"]
+
+    def test_rule_returning_non_constraint_raises(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2])
+        with pytest.raises(TypeError, match="expected a Constraint"):
+            m.constraint(s, lambda i: 42, name="bad")
+
+    def test_aggregation_over_set_in_rule(self):
+        # supply constraint: sum over markets of ship[p, k] <= cap[p]
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        markets = m.set("markets", ["a", "b", "c"])
+        ship = m.continuous("ship", over=plants * markets, lb=0)
+        ic = m.constraint(
+            plants,
+            lambda p: dm.sum(ship[p, k] for k in markets) <= 100,
+            name="supply",
+        )
+        assert len(ic) == 2
+        assert len(m._constraints) == 2
+
+
+class TestSubjectToIterables:
+    def test_generator_of_constraints(self):
+        m = dm.Model()
+        s = m.set("s", [0, 1, 2])
+        x = m.continuous("x", over=s, lb=0)
+        m.subject_to((x[i] <= 5 for i in s), name="ub")
+        assert len(m._constraints) == 3
+        assert {c.name for c in m._constraints} == {"ub_0", "ub_1", "ub_2"}
+
+    def test_list_still_works(self):
+        m = dm.Model()
+        x = m.continuous("x", shape=(3,), lb=0)
+        m.subject_to([x[i] <= 5 for i in range(3)], name="ub")
+        assert len(m._constraints) == 3
+
+    def test_single_constraint_still_works(self):
+        m = dm.Model()
+        x = m.continuous("x", shape=(2,), lb=0)
+        m.subject_to(x[0] + x[1] <= 10, name="c")
+        assert len(m._constraints) == 1
+        assert m._constraints[0].name == "c"
+
+    def test_bool_raises(self):
+        m = dm.Model()
+        with pytest.raises(TypeError, match="Did you mean to compare"):
+            m.subject_to(True)
+
+    def test_iterable_with_non_constraint_raises(self):
+        m = dm.Model()
+        with pytest.raises(TypeError, match="position 1"):
+            m.subject_to([dm.Model().continuous("z") <= 1, 99])
+
+
+class TestExports:
+    def test_skip_and_indexedconstraint_exported(self):
+        assert dm.Skip is Skip
+        assert dm.IndexedConstraint is IndexedConstraint

--- a/python/tests/test_indexed_constraints.py
+++ b/python/tests/test_indexed_constraints.py
@@ -11,7 +11,7 @@ class TestModelConstraint:
         m = dm.Model()
         plants = m.set("plants", ["pitt", "sf", "nyc"])
         x = m.continuous("x", over=plants, lb=0)
-        ic = m.constraint(plants, lambda p: x[p] <= 100, name="cap")
+        ic = m.constraint(plants, lambda p: x[p] <= 100, name="cap", fast=False)
         assert isinstance(ic, IndexedConstraint)
         assert len(ic) == 3
         assert len(m._constraints) == 3
@@ -20,7 +20,7 @@ class TestModelConstraint:
         m = dm.Model()
         plants = m.set("plants", ["pitt", "sf"])
         x = m.continuous("x", over=plants, lb=0)
-        m.constraint(plants, lambda p: x[p] <= 100, name="cap")
+        m.constraint(plants, lambda p: x[p] <= 100, name="cap", fast=False)
         names = {c.name for c in m._constraints}
         assert names == {"cap[pitt]", "cap[sf]"}
 
@@ -28,7 +28,7 @@ class TestModelConstraint:
         m = dm.Model()
         links = m.set("links", [("pitt", "a"), ("sf", "b")])
         x = m.continuous("x", over=links, lb=0)
-        m.constraint(links, lambda p, k: x[p, k] <= 10, name="flow")
+        m.constraint(links, lambda p, k: x[p, k] <= 10, name="flow", fast=False)
         names = {c.name for c in m._constraints}
         assert names == {"flow[pitt,a]", "flow[sf,b]"}
 
@@ -36,7 +36,7 @@ class TestModelConstraint:
         m = dm.Model()
         s = m.set("s", [1, 2, 3, 4])
         x = m.continuous("x", over=s, lb=0)
-        ic = m.constraint(s, lambda i: (x[i] <= 1) if i % 2 == 0 else Skip, name="even")
+        ic = m.constraint(s, lambda i: (x[i] <= 1) if i % 2 == 0 else Skip, name="even", fast=False)
         assert len(ic) == 2
         assert set(ic.keys()) == {2, 4}
         assert len(m._constraints) == 2
@@ -74,6 +74,7 @@ class TestModelConstraint:
             plants,
             lambda p: dm.sum(ship[p, k] for k in markets) <= 100,
             name="supply",
+            fast=False,
         )
         assert len(ic) == 2
         assert len(m._constraints) == 2

--- a/python/tests/test_indexed_correctness.py
+++ b/python/tests/test_indexed_correctness.py
@@ -115,9 +115,10 @@ class TestTransportationEquivalence:
 
 
 class TestNlRoundTrip:
-    def test_roundtrip_preserves_optimum(self, tmp_path):
-        # .nl export reads model._constraints, so use the general path.
-        m, _ = _assignment(fast=False)
+    @pytest.mark.parametrize("fast", [False, True])
+    def test_roundtrip_preserves_optimum(self, tmp_path, fast):
+        # .nl export recovers both general-path and fast-path (builder) rows.
+        m, _ = _assignment(fast=fast)
         r0 = m.solve()
         path = tmp_path / "assign.nl"
         m.to_nl(str(path))

--- a/python/tests/test_indexed_correctness.py
+++ b/python/tests/test_indexed_correctness.py
@@ -1,0 +1,152 @@
+"""End-to-end correctness for set/index models (Phase 7 M6).
+
+Solves set-based models and checks them against known optima, against the
+equivalent positional (``shape=``) model, and through a ``.nl`` round-trip.
+"""
+
+import itertools
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.pr_correctness
+
+# ── Assignment problem (binary, equality constraints) ──
+
+_ACOST = {
+    ("w1", "a"): 9,
+    ("w1", "b"): 2,
+    ("w1", "c"): 7,
+    ("w2", "a"): 6,
+    ("w2", "b"): 4,
+    ("w2", "c"): 3,
+    ("w3", "a"): 5,
+    ("w3", "b"): 8,
+    ("w3", "c"): 1,
+}
+_WORKERS = ["w1", "w2", "w3"]
+_TASKS = ["a", "b", "c"]
+
+
+def _assignment(fast: bool):
+    m = dm.Model("assign")
+    w = m.set("w", _WORKERS)
+    t = m.set("t", _TASKS)
+    assign = m.binary("assign", over=w * t)
+    m.minimize(dm.sum(_ACOST[(i, j)] * assign[i, j] for i in w for j in t))
+    m.constraint(w, lambda i: dm.sum(assign[i, j] for j in t) == 1, name="one_task", fast=fast)
+    m.constraint(t, lambda j: dm.sum(assign[i, j] for i in w) == 1, name="one_worker", fast=fast)
+    return m, assign
+
+
+def _brute_force_assignment() -> float:
+    return min(
+        sum(_ACOST[(w, t)] for w, t in zip(_WORKERS, perm))
+        for perm in itertools.permutations(_TASKS)
+    )
+
+
+class TestAssignment:
+    def test_matches_brute_force_optimum(self):
+        m, _ = _assignment(fast=True)
+        r = m.solve()
+        assert r.status == "optimal"
+        assert r.objective == pytest.approx(_brute_force_assignment(), abs=1e-6)
+
+    def test_solution_is_a_permutation(self):
+        m, assign = _assignment(fast=True)
+        r = m.solve()
+        vals = assign.value(r)
+        # each worker assigned exactly one task and vice versa
+        for w in _WORKERS:
+            assert sum(round(vals[(w, t)]) for t in _TASKS) == 1
+        for t in _TASKS:
+            assert sum(round(vals[(w, t)]) for w in _WORKERS) == 1
+
+    def test_fast_and_slow_agree(self):
+        rf = _assignment(fast=True)[0].solve()
+        rs = _assignment(fast=False)[0].solve()
+        assert rf.objective == pytest.approx(rs.objective, abs=1e-6)
+
+
+# ── Transportation (continuous) vs equivalent positional model ──
+
+_SUPPLY = [20.0, 30.0]
+_DEMAND = [10.0, 25.0, 15.0]
+_TCOST = np.array([[4.0, 6.0, 8.0], [5.0, 3.0, 7.0]])
+
+
+def _transport_sets():
+    m = dm.Model("t_sets")
+    P = m.set("P", ["p0", "p1"])
+    K = m.set("K", ["k0", "k1", "k2"])
+    sup = dict(zip(P, _SUPPLY))
+    dem = dict(zip(K, _DEMAND))
+    cost = {(p, k): _TCOST[i, j] for i, p in enumerate(P) for j, k in enumerate(K)}
+    ship = m.continuous("ship", over=P * K, lb=0, ub=1000)
+    m.minimize(dm.sum(cost[(p, k)] * ship[p, k] for p in P for k in K))
+    m.constraint(P, lambda p: dm.sum(ship[p, k] for k in K) <= sup[p], name="sup")
+    m.constraint(K, lambda k: dm.sum(ship[p, k] for p in P) >= dem[k], name="dem")
+    return m
+
+
+def _transport_positional():
+    m = dm.Model("t_pos")
+    ship = m.continuous("ship", shape=(2, 3), lb=0, ub=1000)
+    m.minimize(dm.sum(_TCOST[i, j] * ship[i, j] for i in range(2) for j in range(3)))
+    for i in range(2):
+        m.subject_to(dm.sum(ship[i, j] for j in range(3)) <= _SUPPLY[i], name=f"sup_{i}")
+    for j in range(3):
+        m.subject_to(dm.sum(ship[i, j] for i in range(2)) >= _DEMAND[j], name=f"dem_{j}")
+    return m
+
+
+class TestTransportationEquivalence:
+    def test_sets_match_positional_objective(self):
+        r_sets = _transport_sets().solve()
+        r_pos = _transport_positional().solve()
+        assert r_sets.status == "optimal"
+        assert r_pos.status == "optimal"
+        assert r_sets.objective == pytest.approx(r_pos.objective, rel=1e-6)
+
+
+# ── .nl round-trip ──
+
+
+class TestNlRoundTrip:
+    def test_roundtrip_preserves_optimum(self, tmp_path):
+        # .nl export reads model._constraints, so use the general path.
+        m, _ = _assignment(fast=False)
+        r0 = m.solve()
+        path = tmp_path / "assign.nl"
+        m.to_nl(str(path))
+        m2 = dm.from_nl(str(path))
+        r1 = m2.solve()
+        assert r1.status == "optimal"
+        assert r1.objective == pytest.approx(r0.objective, abs=1e-6)
+
+
+# ── Pyomo cross-check (skipped if pyomo is unavailable) ──
+
+
+class TestPyomoCrossCheck:
+    def test_transportation_matches_pyomo(self):
+        pyo = pytest.importorskip("pyomo.environ")
+        model = pyo.ConcreteModel()
+        model.P = pyo.RangeSet(0, 1)
+        model.K = pyo.RangeSet(0, 2)
+        model.ship = pyo.Var(model.P, model.K, domain=pyo.NonNegativeReals)
+        model.obj = pyo.Objective(
+            expr=sum(_TCOST[i, j] * model.ship[i, j] for i in model.P for j in model.K)
+        )
+        model.sup = pyo.Constraint(
+            model.P, rule=lambda mm, i: sum(mm.ship[i, j] for j in mm.K) <= _SUPPLY[i]
+        )
+        model.dem = pyo.Constraint(
+            model.K, rule=lambda mm, j: sum(mm.ship[i, j] for i in mm.P) >= _DEMAND[j]
+        )
+        dmodel = dm.from_pyomo(model)
+        r = dmodel.solve()
+        assert r.status == "optimal"
+        assert r.objective == pytest.approx(_transport_sets().solve().objective, rel=1e-6)

--- a/python/tests/test_indexed_correctness.py
+++ b/python/tests/test_indexed_correctness.py
@@ -132,7 +132,13 @@ class TestNlRoundTrip:
 
 
 class TestPyomoCrossCheck:
+    @pytest.mark.xfail(
+        raises=NotImplementedError,
+        reason="from_pyomo is a Phase 4 stub (not yet implemented); see ROADMAP",
+    )
     def test_transportation_matches_pyomo(self):
+        # importorskip only guards pyomo's *absence*; from_pyomo itself is an
+        # unimplemented stub, so the xfail above covers the pyomo-installed path.
         pyo = pytest.importorskip("pyomo.environ")
         model = pyo.ConcreteModel()
         model.P = pyo.RangeSet(0, 1)

--- a/python/tests/test_indexed_params.py
+++ b/python/tests/test_indexed_params.py
@@ -1,0 +1,115 @@
+"""Tests for indexed parameters and aggregation over named sets (Phase 7 M4)."""
+
+import discopt.modeling as dm
+from discopt.modeling.core import IndexExpression, Parameter, SumOverExpression
+from discopt.modeling.indexed import IndexedParam
+
+
+class TestIndexedParam:
+    def test_dict_value(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        cap = m.parameter("cap", over=plants, value={"pitt": 10, "sf": 20, "nyc": 30})
+        assert isinstance(cap, IndexedParam)
+        assert isinstance(cap.flat, Parameter)
+        assert list(cap.flat.value) == [10, 20, 30]
+
+    def test_scalar_value_broadcast(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        p = m.parameter("p", over=s, value=5.0)
+        assert list(p.flat.value) == [5, 5, 5]
+
+    def test_callable_value(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        p = m.parameter("p", over=s, value=lambda i: i**2)
+        assert list(p.flat.value) == [1, 4, 9]
+
+    def test_getitem_is_expression(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        cap = m.parameter("cap", over=plants, value={"pitt": 10, "sf": 20})
+        assert isinstance(cap["pitt"], IndexExpression)
+        assert cap["pitt"].index == 0
+
+    def test_at_returns_numeric(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        cap = m.parameter("cap", over=plants, value={"pitt": 10, "sf": 20})
+        assert cap.at("sf") == 20.0
+
+    def test_plain_parameter_still_works(self):
+        m = dm.Model()
+        p = m.parameter("price", value=50.0)
+        assert isinstance(p, Parameter)
+        assert not isinstance(p, IndexedParam)
+
+
+class TestAggregationOverSets:
+    def test_sum_generator_over_set(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        x = m.continuous("x", over=plants, lb=0)
+        expr = dm.sum(x[p] for p in plants)
+        assert isinstance(expr, SumOverExpression)
+
+    def test_sum_callable_over_dimen1_set(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        cap = m.parameter("cap", over=plants, value={"pitt": 1, "sf": 2, "nyc": 3})
+        x = m.continuous("x", over=plants, lb=0)
+        expr = dm.sum(lambda p: cap[p] * x[p], over=plants)
+        assert isinstance(expr, SumOverExpression)
+
+    def test_sum_callable_over_dimen2_unpacks(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        markets = m.set("markets", ["a", "b"])
+        links = plants * markets
+        ship = m.continuous("ship", over=links, lb=0)
+        # rule takes two args because links has dimen 2
+        expr = dm.sum(lambda p, k: ship[p, k], over=links)
+        assert isinstance(expr, SumOverExpression)
+
+    def test_prod_over_set(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        x = m.continuous("x", over=s, lb=1, ub=2)
+        expr = dm.prod(lambda i: x[i], over=s)
+        # product of three terms desugars to nested BinaryOp, not a single var
+        assert expr is not None
+
+    def test_prod_generator(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        x = m.continuous("x", over=s, lb=1, ub=2)
+        expr = dm.prod(x[i] for i in s)
+        assert expr is not None
+
+    def test_norm_on_backing_flat(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        x = m.continuous("x", over=s, lb=0)
+        # norm operates on the flat vector variable
+        expr = dm.norm(x.flat, ord=2)
+        assert expr is not None
+
+    def test_double_sum_transportation_objective(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        markets = m.set("markets", ["a", "b", "c"])
+        cost = m.parameter(
+            "cost",
+            over=plants * markets,
+            value=lambda p, k: 1.0,
+        )
+        ship = m.continuous("ship", over=plants * markets, lb=0)
+        obj = dm.sum(cost[p, k] * ship[p, k] for p in plants for k in markets)
+        m.minimize(obj)
+        assert m._objective is not None
+
+
+class TestExports:
+    def test_indexedparam_exported(self):
+        assert dm.IndexedParam is IndexedParam

--- a/python/tests/test_indexed_vars.py
+++ b/python/tests/test_indexed_vars.py
@@ -1,0 +1,176 @@
+"""Tests for indexed variables over named sets (Phase 7 M2).
+
+Covers ``Model.continuous/binary/integer(..., over=SET)``, the backing flat
+variable, per-key bounds, key indexing, and desugaring equivalence to the
+positional ``shape=`` API.
+"""
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.modeling.core import IndexExpression, VarType
+from discopt.modeling.indexed import IndexedVar
+
+
+def _flat_signature(model):
+    """A structural fingerprint of a model's flat variables for equivalence checks."""
+    return [
+        (v.name, v.var_type, v.shape, tuple(np.ravel(v.lb)), tuple(np.ravel(v.ub)))
+        for v in model._variables
+    ]
+
+
+class TestIndexedVarBasics:
+    def test_continuous_over_set_backed_by_flat(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        x = m.continuous("x", over=plants, lb=0)
+        assert isinstance(x, IndexedVar)
+        assert x.flat.shape == (3,)
+        assert x.flat.var_type == VarType.CONTINUOUS
+        assert len(m._variables) == 1  # one flat var, not three
+
+    def test_getitem_returns_index_expression(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        x = m.continuous("x", over=plants)
+        expr = x["sf"]
+        assert isinstance(expr, IndexExpression)
+        assert expr.base is x.flat
+        assert expr.index == 1
+
+    def test_tuple_key_indexing(self):
+        m = dm.Model()
+        links = m.set("links", [("pitt", "a"), ("sf", "b")])
+        x = m.continuous("x", over=links, lb=0)
+        assert x["pitt", "a"].index == 0
+        assert x[("sf", "b")].index == 1
+
+    def test_bad_key_raises(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        x = m.continuous("x", over=plants)
+        with pytest.raises(KeyError, match="not a member"):
+            _ = x["nyc"]
+
+    def test_binary_over_product(self):
+        m = dm.Model()
+        workers = m.set("w", ["w1", "w2"])
+        tasks = m.set("t", ["t1", "t2", "t3"])
+        y = m.binary("assign", over=workers * tasks)
+        assert y.flat.shape == (6,)
+        assert y.flat.var_type == VarType.BINARY
+        assert np.all(y.flat.lb == 0) and np.all(y.flat.ub == 1)
+
+    def test_integer_over_set(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        n = m.integer("n", over=plants, lb=0, ub=10)
+        assert n.flat.var_type == VarType.INTEGER
+        assert np.all(n.flat.ub == 10)
+
+    def test_len_iter_contains_keys(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        x = m.continuous("x", over=plants)
+        assert len(x) == 3
+        assert list(x) == ["pitt", "sf", "nyc"]
+        assert "sf" in x and "denver" not in x
+        assert x.keys() == ("pitt", "sf", "nyc")
+
+
+class TestIndexedBounds:
+    def test_scalar_bounds_broadcast(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        x = m.continuous("x", over=s, lb=0, ub=100)
+        assert np.all(x.flat.lb == 0) and np.all(x.flat.ub == 100)
+
+    def test_dict_bounds(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        cap = {"pitt": 10, "sf": 20, "nyc": 30}
+        x = m.continuous("x", over=plants, lb=0, ub=cap)
+        assert list(x.flat.ub) == [10, 20, 30]
+
+    def test_dict_bounds_missing_key_raises(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        with pytest.raises(KeyError, match="no entry for member"):
+            m.continuous("x", over=plants, ub={"pitt": 10})
+
+    def test_callable_bounds_dimen1(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2, 3])
+        x = m.continuous("x", over=s, ub=lambda i: 10 * i)
+        assert list(x.flat.ub) == [10, 20, 30]
+
+    def test_callable_bounds_dimen2_unpacks(self):
+        m = dm.Model()
+        links = m.set("links", [("a", 1), ("b", 2)])
+        x = m.continuous("x", over=links, ub=lambda node, k: k * 100)
+        assert list(x.flat.ub) == [100, 200]
+
+    def test_over_and_shape_mutually_exclusive(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2])
+        with pytest.raises(ValueError, match="mutually"):
+            m.continuous("x", shape=(2,), over=s)
+
+
+class TestValueRetrieval:
+    def test_value_maps_keys(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        x = m.continuous("x", over=plants, lb=0, ub=10)
+        m.minimize(dm.sum(x.flat))
+
+        class _FakeResult:
+            def value(self, var):
+                return np.array([1.0, 2.0, 3.0])
+
+        vals = x.value(_FakeResult())
+        assert vals == {"pitt": 1.0, "sf": 2.0, "nyc": 3.0}
+
+
+class TestDesugarEquivalence:
+    """An indexed model must produce the same flat model as the positional one."""
+
+    def test_equivalent_to_shape_variable(self):
+        # Indexed over an integer range vs. a dense shape=(n,) variable.
+        m_idx = dm.Model()
+        s = m_idx.set("s", [0, 1, 2, 3])
+        m_idx.continuous("x", over=s, lb=0, ub=5)
+
+        m_pos = dm.Model()
+        m_pos.continuous("x", shape=(4,), lb=0, ub=5)
+
+        assert _flat_signature(m_idx) == _flat_signature(m_pos)
+
+    def test_dict_bounds_match_explicit_array(self):
+        m_idx = dm.Model()
+        plants = m_idx.set("plants", ["a", "b", "c"])
+        m_idx.continuous("x", over=plants, lb=0, ub={"a": 1, "b": 2, "c": 3})
+
+        m_pos = dm.Model()
+        m_pos.continuous("x", shape=(3,), lb=0, ub=np.array([1.0, 2.0, 3.0]))
+
+        assert _flat_signature(m_idx) == _flat_signature(m_pos)
+
+    def test_index_expression_matches_positional(self):
+        m_idx = dm.Model()
+        s = m_idx.set("s", ["a", "b", "c"])
+        x = m_idx.continuous("x", over=s)
+        e = x["b"]
+
+        m_pos = dm.Model()
+        xp = m_pos.continuous("x", shape=(3,))
+        ep = xp[1]
+
+        assert e.index == ep.index
+        assert e.base.name == ep.base.name
+
+
+class TestExports:
+    def test_indexedvar_exported(self):
+        assert dm.IndexedVar is IndexedVar

--- a/python/tests/test_sets.py
+++ b/python/tests/test_sets.py
@@ -176,6 +176,24 @@ class TestProductSet:
         b = Set("b", range(4))
         assert len(a * b) == len(a) * len(b)
 
+    def test_ordinal_row_major(self):
+        a = Set("a", ["p", "q"])
+        b = Set("b", [1, 2, 3])
+        p = a * b
+        # row-major: ordinal matches position in iteration order
+        for i, m in enumerate(p):
+            assert p.ordinal(m) == i
+
+    def test_ordinal_bad_member_raises(self):
+        p = Set("a", ["p", "q"]) * Set("b", [1, 2])
+        with pytest.raises(KeyError, match="not a member"):
+            p.ordinal(("z", 1))
+
+    def test_ordinal_nested_product(self):
+        p = (Set("a", [1, 2]) * Set("b", [3, 4])) * Set("c", [5, 6])
+        for i, m in enumerate(p):
+            assert p.ordinal(m) == i
+
 
 class TestFilter:
     def test_where_dimen1(self):

--- a/python/tests/test_sets.py
+++ b/python/tests/test_sets.py
@@ -1,0 +1,244 @@
+"""Tests for named index sets and set algebra (Phase 7: set & index abstractions).
+
+Milestone M1: the :class:`~discopt.modeling.sets.Set` algebra layer and
+``Model.set()`` registration. Indexed variables/constraints are exercised in
+later milestones.
+"""
+
+import discopt.modeling as dm
+import pytest
+from discopt.modeling.sets import ProductSet, RangeSet, Set
+
+
+class TestSetConstruction:
+    def test_scalar_members_dimen1(self):
+        s = Set("plants", ["pitt", "sf", "nyc"])
+        assert s.dimen == 1
+        assert len(s) == 3
+        assert list(s) == ["pitt", "sf", "nyc"]
+
+    def test_tuple_members_infer_dimen(self):
+        s = Set("links", [("pitt", "a"), ("sf", "b")])
+        assert s.dimen == 2
+        assert ("pitt", "a") in s
+
+    def test_lists_coerced_to_tuples(self):
+        s = Set("links", [["pitt", "a"], ["sf", "b"]])
+        assert s.dimen == 2
+        assert ("pitt", "a") in s
+        assert all(isinstance(m, tuple) for m in s)
+
+    def test_one_tuple_unwrapped_to_scalar(self):
+        s = Set("plants", [("pitt",), ("sf",)])
+        assert s.dimen == 1
+        assert "pitt" in s
+        assert list(s) == ["pitt", "sf"]
+
+    def test_duplicates_removed_order_preserved(self):
+        s = Set("p", ["b", "a", "b", "c", "a"])
+        assert list(s) == ["b", "a", "c"]
+
+    def test_empty_defaults_dimen1(self):
+        s = Set("empty", [])
+        assert s.dimen == 1
+        assert len(s) == 0
+
+    def test_dimen_override(self):
+        s = Set("links", [("a", "b")], dimen=2)
+        assert s.dimen == 2
+
+    def test_inconsistent_arity_raises(self):
+        with pytest.raises(ValueError, match="arity"):
+            Set("bad", [("a", "b"), "c"])
+
+    def test_dimen_mismatch_raises(self):
+        with pytest.raises(ValueError, match="dimen"):
+            Set("bad", [("a", "b")], dimen=3)
+
+    def test_dimen_below_one_raises(self):
+        with pytest.raises(ValueError, match="dimen must be"):
+            Set("bad", [1, 2], dimen=0)
+
+    def test_ordinal(self):
+        s = Set("p", ["x", "y", "z"])
+        assert s.ordinal("y") == 1
+        with pytest.raises(KeyError, match="not a member"):
+            s.ordinal("q")
+
+    def test_contains_normalizes(self):
+        s = Set("links", [("a", "b")])
+        assert ("a", "b") in s
+        # a list probe is normalized to a tuple before lookup
+        assert ["a", "b"] in s
+        assert ("a", "c") not in s
+
+    def test_repr(self):
+        s = Set("p", [1, 2, 3])
+        assert "p" in repr(s) and "dimen=1" in repr(s)
+
+
+class TestRangeSet:
+    def test_single_arg_one_based(self):
+        assert list(RangeSet(3)) == [1, 2, 3]
+
+    def test_two_arg_inclusive(self):
+        assert list(RangeSet(2, 5)) == [2, 3, 4, 5]
+
+    def test_dimen_one(self):
+        assert RangeSet(4).dimen == 1
+
+    def test_is_a_set(self):
+        assert isinstance(RangeSet(3), Set)
+        assert 2 in RangeSet(3)
+
+
+class TestSetAlgebra:
+    def test_union(self):
+        a = Set("a", [1, 2, 3])
+        b = Set("b", [3, 4, 5])
+        u = a | b
+        assert list(u) == [1, 2, 3, 4, 5]
+
+    def test_union_preserves_order_left_first(self):
+        a = Set("a", ["x", "y"])
+        b = Set("b", ["y", "z"])
+        assert list(a | b) == ["x", "y", "z"]
+
+    def test_intersection(self):
+        a = Set("a", [1, 2, 3, 4])
+        b = Set("b", [2, 4, 6])
+        assert list(a & b) == [2, 4]
+
+    def test_intersection_commutative_membership(self):
+        a = Set("a", [1, 2, 3])
+        b = Set("b", [2, 3, 4])
+        assert set(a & b) == set(b & a)
+
+    def test_difference(self):
+        a = Set("a", [1, 2, 3, 4])
+        b = Set("b", [2, 4])
+        assert list(a - b) == [1, 3]
+
+    def test_difference_law(self):
+        # (A | B) - B is a subset of A
+        a = Set("a", [1, 2, 3])
+        b = Set("b", [3, 4, 5])
+        assert set((a | b) - b) <= set(a)
+
+    def test_algebra_dimen_mismatch_raises(self):
+        a = Set("a", [1, 2])
+        b = Set("b", [("x", "y")])
+        with pytest.raises(ValueError, match="dimensionality"):
+            _ = a | b
+        with pytest.raises(ValueError, match="dimensionality"):
+            _ = a & b
+        with pytest.raises(ValueError, match="dimensionality"):
+            _ = a - b
+
+
+class TestProductSet:
+    def test_product_len_and_dimen(self):
+        a = Set("a", ["p", "q"])
+        b = Set("b", [1, 2, 3])
+        p = a * b
+        assert isinstance(p, ProductSet)
+        assert len(p) == 6
+        assert p.dimen == 2
+
+    def test_product_members(self):
+        a = Set("a", ["p", "q"])
+        b = Set("b", [1, 2])
+        assert list(a * b) == [("p", 1), ("p", 2), ("q", 1), ("q", 2)]
+
+    def test_product_membership(self):
+        p = Set("a", ["p", "q"]) * Set("b", [1, 2])
+        assert ("p", 2) in p
+        assert ("z", 2) not in p
+        assert ("p", 2, 3) not in p
+
+    def test_triple_product_flattens(self):
+        a = Set("a", ["x"])
+        b = Set("b", ["y"])
+        c = Set("c", ["z"])
+        p = a * b * c
+        assert p.dimen == 3
+        assert list(p) == [("x", "y", "z")]
+        # chaining does not nest factors
+        assert len(p.factors) == 3
+
+    def test_product_of_products_membership(self):
+        p = (Set("a", [1, 2]) * Set("b", [3])) * Set("c", [4, 5])
+        assert (1, 3, 4) in p
+        assert len(p) == 4
+
+    def test_cardinality_law(self):
+        a = Set("a", range(3))
+        b = Set("b", range(4))
+        assert len(a * b) == len(a) * len(b)
+
+
+class TestFilter:
+    def test_where_dimen1(self):
+        s = Set("n", range(1, 6))
+        evens = s.where(lambda i: i % 2 == 0)
+        assert list(evens) == [2, 4]
+
+    def test_where_dimen2_unpacks(self):
+        p = Set("a", [1, 2, 3]) * Set("b", [1, 2, 3])
+        upper = p.where(lambda i, j: i < j)
+        assert list(upper) == [(1, 2), (1, 3), (2, 3)]
+
+    def test_where_on_product_avoids_full_materialization(self):
+        # Filtering a product yields a concrete Set of only matching members.
+        links = (Set("p", ["pitt", "sf", "nyc"]) * Set("m", ["a", "b"])).where(
+            lambda p, k: (p, k) != ("nyc", "a")
+        )
+        assert isinstance(links, Set)
+        assert len(links) == 5
+        assert ("nyc", "a") not in links
+
+    def test_where_idempotent(self):
+        s = Set("n", range(10))
+        pred = lambda i: i % 2 == 0  # noqa: E731
+        once = s.where(pred)
+        twice = once.where(pred)
+        assert list(once) == list(twice)
+
+    def test_with_first(self):
+        links = Set("l", [("p", "a"), ("p", "b"), ("q", "a")])
+        assert list(links.with_first("p")) == [("p", "a"), ("p", "b")]
+
+    def test_with_last(self):
+        links = Set("l", [("p", "a"), ("q", "a"), ("q", "b")])
+        assert list(links.with_last("a")) == [("p", "a"), ("q", "a")]
+
+    def test_with_first_requires_dimen2(self):
+        s = Set("n", [1, 2, 3])
+        with pytest.raises(ValueError, match="dimen >= 2"):
+            s.with_first(1)
+
+
+class TestModelSet:
+    def test_register_and_return(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf"])
+        assert isinstance(plants, Set)
+        assert plants in m._sets
+
+    def test_duplicate_name_raises(self):
+        m = dm.Model()
+        m.set("plants", ["pitt"])
+        with pytest.raises(ValueError, match="already used"):
+            m.set("plants", ["sf"])
+
+    def test_set_usable_in_algebra(self):
+        m = dm.Model()
+        plants = m.set("plants", ["pitt", "sf", "nyc"])
+        markets = m.set("markets", ["a", "b"])
+        assert len(plants * markets) == 6
+
+    def test_top_level_exports(self):
+        import discopt
+
+        assert discopt.Set is Set
+        assert discopt.RangeSet is RangeSet

--- a/python/tests/test_sets.py
+++ b/python/tests/test_sets.py
@@ -194,6 +194,17 @@ class TestProductSet:
         for i, m in enumerate(p):
             assert p.ordinal(m) == i
 
+    def test_ordinal_accepts_nested_and_flat_keys(self):
+        # arcs (dimen 2) crossed with commodities (dimen 1) -> dimen 3
+        arcs = Set("arcs", [("s", "u"), ("u", "t")])
+        comm = Set("comm", ["c1", "c2"])
+        prod = arcs * comm
+        # flat key, nested key, and fully nested key all resolve identically
+        assert prod.ordinal(("s", "u", "c1")) == prod.ordinal((("s", "u"), "c1"))
+        assert prod.ordinal(("u", "t", "c2")) == 3
+        assert (("s", "u"), "c1") in prod
+        assert ("s", "u", "c1") in prod
+
 
 class TestFilter:
     def test_where_dimen1(self):

--- a/python/tests/test_sets_adversarial.py
+++ b/python/tests/test_sets_adversarial.py
@@ -1,0 +1,255 @@
+"""Adversarial tests for the set/index abstractions (Phase 7).
+
+A second, independent pass aimed at corners the feature-level suites do not
+cover: integer labels vs. positions, hash-colliding members, reflected
+comparisons, all-or-nothing fast-path fallback, empty sets, set-algebra-defined
+indices, mixed builder/expression export, and three-way solve equivalence.
+"""
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+
+class TestLabelsVsPositions:
+    def test_integer_labels_index_by_member_not_position(self):
+        # x[10] must mean the member 10 (ordinal 1), never array position 10.
+        m = dm.Model()
+        s = m.set("s", [5, 10, 15])
+        x = m.continuous("x", over=s, lb=0, ub=100)
+        assert x[5].index == 0
+        assert x[10].index == 1
+        assert x[15].index == 2
+
+    def test_integer_label_dict_bounds_map_by_member(self):
+        m = dm.Model()
+        s = m.set("s", [5, 10, 15])
+        y = m.continuous("y", over=s, lb=0, ub={5: 1.0, 10: 2.0, 15: 3.0})
+        m.maximize(dm.sum(y[k] for k in s))
+        v = y.value(m.solve())
+        assert v[5] == pytest.approx(1.0, abs=1e-5)
+        assert v[10] == pytest.approx(2.0, abs=1e-5)
+        assert v[15] == pytest.approx(3.0, abs=1e-5)
+
+    def test_bool_int_hash_collision_dedup(self):
+        # True == 1 and False == 0 in Python; the set must dedup them.
+        s = dm.Model().set("b", [True, False, 1, 0])
+        assert len(s) == 2
+
+    def test_duplicate_members_first_occurrence_ordinal(self):
+        s = dm.Model().set("s", ["b", "a", "b", "c"])
+        assert s.ordinal("b") == 0
+        assert list(s) == ["b", "a", "c"]
+
+
+class TestDegenerateSets:
+    def test_empty_set_variable_and_constraint(self):
+        m = dm.Model()
+        e = m.set("e", [])
+        xe = m.continuous("xe", over=e, lb=0)
+        assert xe.flat.shape == (0,)
+        ic = m.constraint(e, lambda i: xe[i] <= 1, name="none")
+        assert len(ic) == 0
+        assert len(m._constraints) == 0
+
+    def test_where_to_empty(self):
+        s = dm.Model().set("s", [1, 2, 3])
+        assert len(s.where(lambda i: i > 100)) == 0
+
+    def test_empty_aggregation_solves(self):
+        m = dm.Model()
+        s = m.set("s", [1, 2])
+        empty = s.where(lambda i: False)
+        x = m.continuous("x", over=s, lb=0, ub=5)
+        # empty sum is 0, so this constraint is trivially satisfied
+        m.subject_to(dm.sum(x[i] for i in empty) <= 100, name="trivial")
+        m.maximize(dm.sum(x[i] for i in s))
+        r = m.solve()
+        assert r.status == "optimal"
+        assert r.objective == pytest.approx(10.0, abs=1e-5)
+
+    def test_rangeset_zero_is_empty(self):
+        assert len(dm.RangeSet(0)) == 0
+
+
+class TestIndexingErrors:
+    def test_wrong_arity_indexing_raises(self):
+        m = dm.Model()
+        links = m.set("l", [("a", 1), ("b", 2)])
+        z = m.continuous("z", over=links, lb=0)
+        with pytest.raises(KeyError):
+            _ = z["a"]  # dimen-2 set needs a 2-key
+
+    def test_rule_returning_list_raises(self):
+        m = dm.Model()
+        s = m.set("s", [0, 1])
+        x = m.continuous("x", over=s, lb=0)
+        with pytest.raises(TypeError, match="expected a Constraint"):
+            m.constraint(s, lambda i: [x[i] <= 1], name="bad")
+
+
+class TestFastPathAdversarial:
+    def test_partial_nonlinear_family_all_or_nothing(self):
+        # One nonlinear member must force the whole family to the general path.
+        m = dm.Model()
+        s = m.set("s", [0, 1, 2])
+        x = m.continuous("x", over=s, lb=0, ub=5)
+        ic = m.constraint(
+            s, lambda i: (x[i] ** 2 <= 4) if i == 0 else (x[i] <= 4), name="mix", fast=True
+        )
+        assert ic.fast is False
+        assert len(m._constraints) == 3
+
+    def test_reflected_comparison_routes_and_solves(self):
+        # 5 <= x[i] uses the reflected operator; must still route + solve.
+        m = dm.Model()
+        s = m.set("s", [0, 1])
+        x = m.continuous("x", over=s, lb=0, ub=10)
+        ic = m.constraint(s, lambda i: 5 <= x[i], name="r", fast=True)
+        assert ic.fast is True
+        m.minimize(dm.sum(x[i] for i in s))
+        v = x.value(m.solve())
+        assert all(val == pytest.approx(5.0, abs=1e-4) for val in v.values())
+
+    def test_coefficient_cancellation_fast_equals_slow(self):
+        def build(fast):
+            m = dm.Model()
+            s = m.set("s", [0, 1])
+            x = m.continuous("x", over=s, lb=0, ub=10)
+            m.constraint(s, lambda i: 2 * x[i] - x[i] + 3 <= 5, name="r", fast=fast)
+            m.maximize(dm.sum(x[i] for i in s))
+            return m, x
+
+        mf, xf = build(True)
+        ms, xs = build(False)
+        rf, rs = mf.solve(), ms.solve()
+        assert rf.objective == pytest.approx(rs.objective, abs=1e-5)
+        assert all(v == pytest.approx(2.0, abs=1e-4) for v in xf.value(rf).values())
+
+    def test_multivariable_coupling_falls_back_but_correct(self):
+        def build(fast):
+            m = dm.Model()
+            s = m.set("s", [0, 1])
+            x = m.continuous("x", over=s, lb=0, ub=10)
+            z = m.continuous("z", over=s, lb=0, ub=10)
+            ic = m.constraint(s, lambda i: x[i] + z[i] <= 4, name="c", fast=fast)
+            m.maximize(dm.sum(x[i] + z[i] for i in s))
+            return m, ic
+
+        mf, icf = build(True)
+        ms, ics = build(False)
+        assert icf.fast is False
+        assert mf.solve().objective == pytest.approx(ms.solve().objective, abs=1e-5)
+
+    def test_dimen3_product_constraint_routes(self):
+        m = dm.Model()
+        A = m.set("A", ["p", "q"])
+        B = m.set("B", [1, 2])
+        C = m.set("C", ["x", "y"])
+        f = m.continuous("f", over=A * B * C, lb=0, ub=10)
+        ic = m.constraint(A * B * C, lambda a, b, c: f[a, b, c] <= 5, name="cap", fast=True)
+        assert ic.fast is True
+        assert len(m._constraints) == 0
+
+
+class TestExportAdversarial:
+    def _roundtrip(self, m):
+        import os
+        import tempfile
+
+        r0 = m.solve()
+        with tempfile.NamedTemporaryFile(suffix=".nl", delete=False) as fh:
+            path = fh.name
+        m.to_nl(path)
+        r1 = dm.from_nl(path).solve()
+        os.unlink(path)
+        return r0, r1
+
+    def test_mixed_builder_and_expression_constraints_export(self):
+        m = dm.Model()
+        s = m.set("s", ["a", "b", "c"])
+        x = m.continuous("x", over=s, lb=0, ub=10)
+        m.constraint(s, lambda i: x[i] <= 8, name="ub", fast=True)  # builder
+        m.subject_to(dm.sum(x[i] for i in s) >= 6, name="total")  # expression
+        m.minimize(dm.sum(x[i] for i in s))
+        ncons = int(m.to_nl(None).splitlines()[1].split()[1])
+        assert ncons == 4  # 3 builder + 1 expression, no double count
+        r0, r1 = self._roundtrip(m)
+        assert r1.objective == pytest.approx(r0.objective, abs=1e-5)
+
+    def test_builder_quadratic_objective_plus_builder_constraints(self):
+        m = dm.Model()
+        x = m.continuous("x", shape=(3,), lb=-5, ub=5)
+        m.add_quadratic_objective(2 * np.eye(3), np.array([-2.0, -4.0, -6.0]), x, constant=1.0)
+        m.add_linear_constraints(np.ones((1, 3)), x, "<=", np.array([10.0]), name="c")
+        r0, r1 = self._roundtrip(m)
+        assert r1.objective == pytest.approx(r0.objective, abs=1e-4)
+
+    def test_to_nl_is_idempotent(self):
+        m = dm.Model()
+        s = m.set("s", ["a", "b"])
+        x = m.continuous("x", over=s, lb=0, ub=5)
+        m.constraint(s, lambda i: x[i] <= 3, name="c", fast=True)
+        m.minimize(dm.sum(x[i] for i in s))
+        n1 = int(m.to_nl(None).splitlines()[1].split()[1])
+        n2 = int(m.to_nl(None).splitlines()[1].split()[1])
+        assert n1 == n2 == 2
+
+
+@pytest.mark.pr_correctness
+class TestThreeWayEquivalence:
+    """indexed-fast == indexed-slow == positional-dense, end to end."""
+
+    C = [3.0, 2.0, 5.0, 4.0]
+    W = [2.0, 1.0, 3.0, 2.0]
+    CAP = 4.0
+
+    def _indexed(self, fast):
+        m = dm.Model()
+        items = m.set("I", ["a", "b", "c", "d"])
+        y = m.binary("y", over=items)
+        val = dict(zip(items, self.C))
+        wt = dict(zip(items, self.W))
+        m.maximize(dm.sum(val[i] * y[i] for i in items))
+        one = m.set("_cap", [0])  # singleton index for the single capacity row
+        m.constraint(
+            one, lambda _: dm.sum(wt[i] * y[i] for i in items) <= self.CAP, name="cap", fast=fast
+        )
+        return m
+
+    def _positional(self):
+        m = dm.Model()
+        y = m.binary("y", shape=(4,))
+        m.maximize(dm.sum(self.C[i] * y[i] for i in range(4)))
+        m.subject_to(dm.sum(self.W[i] * y[i] for i in range(4)) <= self.CAP, name="cap")
+        return m
+
+    def test_all_three_agree(self):
+        rf = self._indexed(fast=True).solve()
+        rs = self._indexed(fast=False).solve()
+        rp = self._positional().solve()
+        assert rf.objective == pytest.approx(rs.objective, abs=1e-6)
+        assert rf.objective == pytest.approx(rp.objective, abs=1e-6)
+
+
+class TestSetAlgebraDefinedIndex:
+    def test_union_indexed_model_solves(self):
+        m = dm.Model()
+        a = m.set("a", [1, 2, 3, 4])
+        b = m.set("b", [3, 4, 5, 6])
+        idx = a | b
+        x = m.continuous("x", over=idx, lb=0, ub=1)
+        m.maximize(dm.sum(x[i] for i in idx))
+        r = m.solve()
+        assert len(idx) == 6
+        assert r.objective == pytest.approx(6.0, abs=1e-5)
+
+    def test_callable_dimen2_bounds_solved(self):
+        m = dm.Model()
+        P = m.set("P", ["p1", "p2"])
+        K = m.set("K", ["k1", "k2"])
+        x = m.continuous("x", over=P * K, lb=0, ub=lambda p, k: 10 if p == "p1" else 1)
+        m.maximize(dm.sum(x[p, k] for p in P for k in K))
+        v = x.value(m.solve())
+        assert v[("p1", "k1")] == pytest.approx(10.0, abs=1e-4)
+        assert v[("p2", "k2")] == pytest.approx(1.0, abs=1e-4)

--- a/python/tests/test_sets_adversarial.py
+++ b/python/tests/test_sets_adversarial.py
@@ -9,6 +9,101 @@ indices, mixed builder/expression export, and three-way solve equivalence.
 import discopt.modeling as dm
 import numpy as np
 import pytest
+from discopt.modeling.core import Constant
+from discopt.modeling.sets import ProductSet, Set
+
+
+class TestSumProdOverIndexedContainer:
+    """Regression: dm.sum/prod on a bare indexed container must sum the VARIABLES,
+    not the index keys (PR #243 review blocker)."""
+
+    def test_sum_indexed_var_sums_variables_not_keys(self):
+        m = dm.Model()
+        s = m.set("S", [10, 20, 30])  # integer keys that previously leaked in
+        y = m.continuous("y", lb=1, ub=5, over=s)
+        m.minimize(dm.sum(y))
+        r = m.solve()
+        # vars at lb=1 -> 3.0, NOT 60.0 (= the keys 10+20+30)
+        assert r.objective == pytest.approx(3.0, abs=1e-5)
+
+    def test_sum_indexed_var_equals_sum_flat(self):
+        m = dm.Model()
+        s = m.set("S", [10, 20, 30])
+        y = m.continuous("y", lb=1, ub=5, over=s)
+        m.minimize(dm.sum(y))
+        r0 = m.solve()
+        m2 = dm.Model()
+        s2 = m2.set("S", [10, 20, 30])
+        y2 = m2.continuous("y", lb=1, ub=5, over=s2)
+        m2.minimize(dm.sum(y2.flat))
+        assert r0.objective == pytest.approx(m2.solve().objective, abs=1e-9)
+
+    def test_prod_indexed_var(self):
+        m = dm.Model()
+        s = m.set("s", [0, 1])
+        z = m.continuous("z", over=s, lb=2, ub=2)
+        assert dm.prod(z) is not None
+
+    def test_sum_indexed_param(self):
+        m = dm.Model()
+        s = m.set("s", ["a", "b", "c"])
+        p = m.parameter("p", over=s, value={"a": 1.0, "b": 2.0, "c": 3.0})
+        x = m.continuous("x", over=s, lb=0, ub=1)
+        m.maximize(dm.sum(p[k] * x[k] for k in s))
+        # also ensure dm.sum(p) doesn't crash / leak keys
+        assert dm.sum(p) is not None
+
+    def test_prod_over_empty_is_identity(self):
+        m = dm.Model()
+        e = m.set("e", [])
+        xe = m.continuous("xe", over=e)
+        result = dm.prod(xe[i] for i in e)
+        assert isinstance(result, Constant)
+        assert float(result.value) == 1.0
+
+
+class TestSetValueEquality:
+    def test_equal_sets_compare_equal(self):
+        assert Set("a", [1, 2, 3]) == Set("a", [1, 2, 3])
+
+    def test_name_irrelevant_to_equality(self):
+        assert Set("a", [1, 2, 3]) == Set("b", [1, 2, 3])
+
+    def test_different_members_not_equal(self):
+        assert Set("a", [1, 2, 3]) != Set("a", [1, 2])
+
+    def test_different_dimen_not_equal(self):
+        assert Set("a", [1, 2]) != Set("a", [(1, 2)])
+
+    def test_hashable_and_usable_in_set(self):
+        a = Set("a", [1, 2, 3])
+        b = Set("b", [1, 2, 3])
+        assert hash(a) == hash(b)
+        assert len({a, b}) == 1
+
+    def test_product_set_value_equality(self):
+        p = Set("x", [1, 2]) * Set("y", ["a", "b"])
+        materialized = Set("z", [(1, "a"), (1, "b"), (2, "a"), (2, "b")])
+        assert isinstance(p, ProductSet)
+        assert p == materialized
+
+    def test_not_equal_to_non_set(self):
+        assert Set("a", [1, 2, 3]) != [1, 2, 3]
+
+
+class TestTopLevelExports:
+    def test_product_set_exported(self):
+        assert dm.ProductSet is ProductSet
+        import discopt
+
+        assert discopt.ProductSet is ProductSet
+
+    def test_examples_exported_at_top_level(self):
+        import discopt
+
+        assert callable(discopt.example_assignment)
+        assert callable(discopt.example_multicommodity_flow)
+        assert callable(discopt.example_transportation)
 
 
 class TestLabelsVsPositions:


### PR DESCRIPTION
Implements the Phase 7 roadmap item **"Set and index abstractions"** — a
Pyomo/JuMP-style named-set layer for sparse models, built as a pure-Python
desugaring over the existing flat model (no Rust core, JAX, or solver changes).
By solve time only flat `Variable`/`Constraint` objects exist.

Scope is the full feature (M1–M7), not just sets:

- **Named sets & algebra** (`discopt.modeling.sets`): `Set`, `RangeSet`,
  `ProductSet` with arbitrary hashable members, inferred/declared `dimen`,
  algebra (`|`, `&`, `-`, `*`), filtering (`where`, `with_first`, `with_last`),
  value `__eq__`/`__hash__`; lazy products that accept flat or nested keys.
  `Model.set(...)` registers a named set.
- **Indexed variables/parameters** (`discopt.modeling.indexed`): `IndexedVar` /
  `IndexedParam` backed by a single flat variable/parameter; `Model.continuous/
  binary/integer/parameter(..., over=SET)` (`@overload`ed so `over=` returns the
  indexed container type); per-key bounds via scalar/dict/callable.
- **Indexed constraints**: `Model.constraint(SET, rule, name=)` → one constraint
  per member named `name[key]`, with a `Skip` sentinel; `subject_to` accepts
  generators; `dm.sum`/`dm.prod` aggregate over sets (and over a bare indexed
  container).
- **Linear fast path**: single-variable-affine, uniform-sense families are
  emitted as one sparse `add_linear_constraints` builder call (`fast=True`
  default), with transparent fallback and identical results.
- **`.nl` export of builder rows/objective**: fast-path/`add_linear_*`
  constraints and linear/quadratic objectives that live only in the Rust builder
  are now reconstructed by the `.nl` writer (previously dropped). The quadratic
  reconstruction matches the builder's `S = triu(Q) + striu(Q).T` convention.

Docs: `docs/notebooks/sets_and_indexing.ipynb` + design doc
`docs/design/sets-and-indexing.md`. Examples: `example_transportation` /
`example_assignment` / `example_multicommodity_flow` (exported at top level).
ROADMAP item marked Done.

Co-Authored-By: Claude Opus 4.8
Claude-Session: https://claude.ai/code/session_01RhTPqKQtjd1XjoANXKPPxe