### PR TITLE
fix(benchmarks): make per-class suites actually filter by problem class

### DIFF
--- a/discopt_benchmarks/config/benchmarks.toml
+++ b/discopt_benchmarks/config/benchmarks.toml
@@ -215,59 +215,85 @@ description = "Release gate (Month 48)"
 # ─────────────────────────────────────────────────────────────
 
 # Per-category benchmark suites
+# NOTE: these per-class suites filter by problem class. The bundled local set
+# (python/tests/data/minlplib*) contains NO pure-LP or MILP instances, so
+# lp_*/milp_* populate only when the full MINLPLib is fetched (--fetch /
+# --use-cache, which filters off MINLPLib's official `cat` field). The
+# locally-runnable classes (qp/miqp/minlp/global_opt) use an explicit
+# instance_list_inline of verified bundled instances so they work out of the box
+# instead of silently grabbing the first N generic instances alphabetically.
+
 [suites.lp_smoke]
-description = "LP smoke tests"
+description = "LP smoke tests (no LP bundled locally — requires --fetch)"
+sources = ["minlplib"]
+problem_class = "lp"
 max_instances = 5
 time_limit_seconds = 60
 
 [suites.lp_full]
-description = "LP full benchmark"
+description = "LP full benchmark (requires --fetch)"
+sources = ["minlplib"]
+problem_class = "lp"
 max_instances = 20
 time_limit_seconds = 300
 
 [suites.qp_smoke]
 description = "QP smoke tests"
-max_instances = 5
+sources = ["minlplib"]
+instance_list_inline = ["meanvar"]
 time_limit_seconds = 60
 
 [suites.qp_full]
-description = "QP full benchmark"
+description = "QP full benchmark (more instances with --fetch)"
+sources = ["minlplib"]
+problem_class = "qp"
 max_instances = 20
 time_limit_seconds = 300
 
 [suites.milp_smoke]
-description = "MILP smoke tests"
+description = "MILP smoke tests (no MILP bundled locally — requires --fetch)"
+sources = ["minlplib"]
+problem_class = "milp"
 max_instances = 5
 time_limit_seconds = 120
 
 [suites.milp_full]
-description = "MILP full benchmark"
+description = "MILP full benchmark (requires --fetch)"
+sources = ["minlplib"]
+problem_class = "milp"
 max_instances = 20
 time_limit_seconds = 600
 
 [suites.miqp_smoke]
 description = "MIQP smoke tests"
-max_instances = 5
+sources = ["minlplib"]
+instance_list_inline = ["alan", "gbd", "meanvarx", "nvs15", "st_e27"]
 time_limit_seconds = 120
 
 [suites.miqp_full]
-description = "MIQP full benchmark"
+description = "MIQP full benchmark (more instances with --fetch)"
+sources = ["minlplib"]
+problem_class = "miqp"
 max_instances = 15
 time_limit_seconds = 600
 
 [suites.minlp_smoke]
 description = "MINLP smoke tests"
-max_instances = 5
+sources = ["minlplib"]
+instance_list_inline = ["ex1221", "ex1226", "nvs01", "nvs03", "gear"]
 time_limit_seconds = 120
 
 [suites.minlp_full]
-description = "MINLP full benchmark"
+description = "MINLP full benchmark (more instances with --fetch)"
+sources = ["minlplib"]
+problem_class = "minlp"
 max_instances = 30
 time_limit_seconds = 600
 
 [suites.global_opt_smoke]
-description = "Global optimization smoke tests"
-max_instances = 5
+description = "Global optimization smoke tests (known-optima nonconvex instances)"
+sources = ["minlplib"]
+instance_list_inline = ["ex1221", "ex1225", "ex1226", "nvs01", "nvs03"]
 time_limit_seconds = 120
 
 [suites.global_opt_full]

--- a/discopt_benchmarks/config/instance_classes.toml
+++ b/discopt_benchmarks/config/instance_classes.toml
@@ -33,9 +33,9 @@ nvs16 = "nonconvex_minlp"
 nvs21 = "nonconvex_minlp"
 
 # MILP/QP instances
-gear = "milp"
-gear3 = "milp"
-gear4 = "milp"
+gear = "nonconvex_minlp"  # corrected: nonlinear gear-ratio obj + integers
+gear3 = "nonconvex_minlp"  # corrected: nonlinear gear-ratio obj + integers
+gear4 = "nonconvex_minlp"  # corrected: nonlinear gear-ratio obj + integers
 chance = "nonconvex_minlp"
 dispatch = "nonconvex_minlp"
 meanvar = "qp"


### PR DESCRIPTION
## Summary

The per-class benchmark suites (`lp/qp/milp/miqp/minlp/global_opt` `_smoke` and `_full`) declared **no class filter** — no `sources`, no `problem_class`, no `instance_list_inline` — so they silently fell back to the first N instances alphabetically. Every one of them resolved to the **same generic set** (`bchoco*`, `4stufen`) regardless of its name. A discopt-vs-SCIP run made this obvious: `lp_smoke`/`qp_smoke` reported **1/5 for *both* solvers** (they were solving hard generic MINLP, not LP/QP), and `milp/miqp/minlp/global_opt_smoke` all selected identical instances.

## Root cause (twofold)

1. The suites declared no class filter.
2. The local filter reads `config/instance_classes.toml`, whose taxonomy is sparse and partly inconsistent with discopt's own classifier — e.g. `gear/gear3/gear4` (nonconvex MINLP: nonlinear gear-ratio objective + integer variables) were labeled `"milp"`.

The bundled local set (`python/tests/data/minlplib*`, ~110 instances) is MINLP/MIQP/NLP-heavy and contains **no pure-LP or MILP instances at all** (distribution: minlp 79, nlp 19, miqp 11, qp 1).

## Fix

- **Locally-runnable classes** (`qp`/`miqp`/`minlp`/`global_opt`) now use an explicit `instance_list_inline` of **verified bundled instances** — the same robust pattern the `global_opt` / `nonconvex_qcp_smoke` suites already use — so they select the right class out of the box without depending on the sparse toml.
- **`lp`/`milp`** have nothing bundled, so they keep a correct `problem_class` filter + a description noting they populate only under `--fetch` (which filters off MINLPLib's official `cat`). They now resolve to **0 cleanly** instead of grabbing wrong instances.
- Corrected the 3 mislabeled `gear*` entries in `instance_classes.toml` (`milp` → `nonconvex_minlp`), per discopt's classifier.

## Verification

| suite | discopt | SCIP |
|---|---|---|
| qp_smoke | 1/1 | 1/1 |
| miqp_smoke | 5/5 | 5/5 |
| minlp_smoke | 5/5 | 5/5 |
| global_opt_smoke | 5/5 | 5/5 |
| lp_smoke / milp_smoke | 0 instances (clean) | — |

All 0 incorrect. Empty `lp_smoke`/`milp_smoke` run cleanly ("0 instances").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
