### PR TITLE
fix(global-opt): propagate the root cut-pool's dual bound to the global bound

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3211,6 +3211,13 @@ def solve_model(
     # warm LP solve instead of re-separating the PSD/RLT cuts from scratch. Stays
     # None unless the relaxer carries PSD cuts (the nvs* / box-QP regime).
     _root_cut_pool = None
+    # The dual bound the root cut-pool relaxation proves over the whole feasible
+    # region (a valid global lower bound for a MINIMIZE). The pool is separated for
+    # its CUT ROWS, but the strengthened relaxation also yields a far tighter root
+    # bound than the cut-less tree path (nvs19: -1156 vs the McCormick -88237);
+    # captured here so the final bound / certification can use it instead of
+    # discarding it. ``None`` when no pool is separated.
+    _root_pool_bound = None
 
     if _mc_mode == "auto":
         # The McCormick "nlp" objective bound is a *valid* dual bound only when
@@ -3489,6 +3496,17 @@ def solve_model(
                                     _A_pool = _A_pool[-_ROOT_CUT_POOL_MAX:]
                                     _b_pool = _b_pool[-_ROOT_CUT_POOL_MAX:]
                                 _root_cut_pool = (_A_pool, _b_pool)
+                                # Keep the strengthened root bound: it is a valid
+                                # global lower bound (the pool relaxation holds over
+                                # the whole feasible region) and is far tighter than
+                                # the cut-less tree path — so the final certificate
+                                # should use it rather than recomputing from scratch.
+                                if (
+                                    _pool_res is not None
+                                    and _pool_res.lower_bound is not None
+                                    and np.isfinite(_pool_res.lower_bound)
+                                ):
+                                    _root_pool_bound = float(_pool_res.lower_bound)
                                 logger.info(
                                     "Root PSD cut pool: %d cuts (of %d separated, "
                                     "%d rounds), root bound %s — inherited at every node",
@@ -5167,6 +5185,24 @@ def solve_model(
     if not _gap_certified:
         bound_val = None
         gap_val = None
+
+    # Root cut-pool bound: a rigorous global lower bound the strengthened root
+    # relaxation already proved during setup (nvs19: -1156 vs the cut-less tree's
+    # -88237). The tree's per-node cuts prune children but never lift the frontier
+    # minimum, so an uncertified feasible exit reports the loose McCormick bound
+    # and a ~99% gap while we have a far tighter one in hand. Adopt it here (for a
+    # MINIMIZE, mirroring the recompute-fallback's soundness gate) before that
+    # fallback recomputes from scratch — it is both stronger and free. If it meets
+    # the incumbent, the re-certification below upgrades the exit to "optimal".
+    if (
+        _root_pool_bound is not None
+        and np.isfinite(_root_pool_bound)
+        and model._objective.sense == ObjectiveSense.MINIMIZE
+        and (bound_val is None or not np.isfinite(bound_val) or _root_pool_bound > bound_val)
+    ):
+        bound_val = _root_pool_bound
+        if obj_val is not None and np.isfinite(obj_val):
+            gap_val = max(0.0, obj_val - bound_val) / max(1.0, abs(obj_val))
 
     # When the tree produced no usable dual bound (uncertified exit, or a
     # relaxation the LP backend could not solve), fall back to a rigorous global

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -470,3 +470,33 @@ def test_negated_bilinear_two_vars_sound_bound():
     res = relaxer.solve_at_node(lb, ub, time_limit=10.0)
     assert res.lower_bound is not None, "neg(x)*y dropped from the relaxation"
     assert float(res.lower_bound) <= -16.0 + 1e-6
+
+
+@pytest.mark.slow
+def test_root_pool_bound_propagates_to_global_bound(monkeypatch):
+    """The root cut-pool's strong dual bound must reach the reported global bound.
+
+    The pool is separated for its cut rows, which prune child nodes but never lift
+    the tree's frontier minimum — so before this fix an uncertified feasible exit
+    on nvs19 reported the cut-less McCormick bound (~-88237, a ~99% gap) while the
+    strengthened root relaxation had already proved a far tighter one (~-1156).
+    The fix captures that root bound and adopts it at the exit.
+
+    Asserts the two invariants that matter, both robust to machine speed:
+      * SOUND — the reported bound never exceeds the true optimum (-1098.4).
+      * PROPAGATED — it is far tighter than the cut-less McCormick value, i.e. the
+        pool bound actually reached `r.bound` instead of being discarded.
+    """
+    monkeypatch.setenv("DISCOPT_ROOT_CUT_ROUNDS", "80")
+    nl = _DATA / "nvs19.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+    r = m.solve(time_limit=25.0)
+    assert r.bound is not None and math.isfinite(r.bound), "no dual bound reported"
+    # Sound: a valid lower bound for a MINIMIZE never exceeds the optimum.
+    assert r.bound <= -1098.4 + 1e-3, f"UNSOUND bound {r.bound} > optimum -1098.4"
+    # Propagated: the cut-less McCormick bound is ~-88237; the pool bound is ~-1.3e3.
+    # A bound tighter than -10000 proves the pool bound reached the global bound.
+    assert r.bound > -10000.0, (
+        f"pool bound did not propagate: r.bound={r.bound} (cut-less McCormick ~ -88237)"
+    )


### PR DESCRIPTION
## Summary

When the root cut pool is enabled (`DISCOPT_ROOT_CUT_ROUNDS>0`), the strengthened root relaxation proves a far tighter dual bound than the cut-less tree path — **nvs19: −1156 vs the McCormick −88237** (optimum −1098.4) — but that bound was being **thrown away**. The pool was kept only for its cut *rows*, which prune child nodes but never lift the Rust tree's frontier minimum, so an uncertified `feasible` exit reported the loose McCormick bound and a **~99% gap** while a near-optimal bound was already in hand.

This was found while building the cut-pool orchestration: a sweep showed the pool reduces node count 3–15× but the reported `bound` column was **byte-identical** across 0/80/150/300 rounds. Tracing it pinpointed the discard (`solve_model`): the tree's global bound (`stats["global_lower_bound"]`) is the loose value; on a feasible exit it's set to `None`; and the post-loop fallback (`_root_relaxation_lower_bound`) recomputes from scratch in whatever time is left (≈0s after the search), getting the loose value again.

## Fix

Capture the pool relaxation's `lower_bound` at separation (`_root_pool_bound`) and adopt it at the spatial exit **before** the recompute-fallback — it is a rigorous global lower bound (the pool relaxation holds over the whole feasible region), stronger, and free. Gated on `MINIMIZE` (mirroring the existing fallback's soundness gate) and taken as `max()` with any existing bound, so it never lowers a tighter tree bound. The existing re-certification then upgrades `feasible → optimal` automatically when the bound meets the incumbent.

## Effect & safety

- **nvs19 (60s, 150 rounds): reported gap 98.8% → 5.5%.**
- **Sound**: every reported bound stays below the true optimum (verified). The re-cert still requires `bound ≤ incumbent`, so it can't fabricate a certificate.
- **Default path untouched**: `_root_pool_bound` is `None` unless a pool separates (rounds default 0), so this is a **no-op when the pool is off** — smoke 10/10 proved / 0 incorrect; nvs17 rounds=0 still certifies in 41s.

## Scope note

This fixes bound **propagation**, not bound **strength**. The nvs* cluster still doesn't certify at 60s because the pool bounds themselves are often too weak (nvs23 −2525, nvs24 −7594) or hit a McCormick conditioning blowup (nvs16 ~−5e11), and some have an open primal gap. Bound strength / conditioning is tracked separately.

Adds a slow regression test asserting the bound is both **sound** (≤ optimum) and **propagated** (far tighter than the cut-less McCormick value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
