### PR TITLE
feat(relaxation): auto-engage parameterized domain envelopes (xlogx, signed-power, Monod, Arrhenius)

### DIFF
--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -166,6 +166,29 @@ def _try_extract_signed_abs_product(expr: Expression, model: Model) -> int | Non
     return None
 
 
+def _try_extract_xlogx(expr: Expression, model: Model) -> int | None:
+    """Detect the entropy/mixing term ``x * log(x)`` over a single scalar variable.
+
+    Matches ``Mul(v, log(v))`` and ``Mul(log(v), v)`` where the bare variable factor
+    and the ``log`` argument resolve to the *same* scalar offset. Returns that flat
+    offset on match, else ``None``. Routes to the dedicated convex envelope of
+    ``x ln x`` (:func:`discopt._jax.symbolic.domains.chemeng.xlogx_relax`) — tighter
+    than the generic bilinear product of ``v`` and ``log(v)``. The envelope is valid
+    only for ``v > 0`` (the term's natural domain), so the runtime dispatch uses it
+    only when the node's lower bound is positive and otherwise falls back to the
+    bilinear.
+    """
+    if not (isinstance(expr, BinaryOp) and expr.op == "*"):
+        return None
+    for factor, other in ((expr.left, expr.right), (expr.right, expr.left)):
+        if isinstance(other, FunctionCall) and other.func_name == "log" and len(other.args) == 1:
+            off = _resolve_scalar_var_offset(factor, model)
+            off_log = _resolve_scalar_var_offset(other.args[0], model)
+            if off is not None and off == off_log:
+                return off
+    return None
+
+
 def _try_extract_signomial_factors(
     expr: Expression, model: Model
 ) -> list[tuple[int, float]] | None:
@@ -364,6 +387,52 @@ def _compile_relax_node(
 
                     def fn(x_cv, x_cc, lb, ub, _off=gas_off, _wr=weymouth_relax):
                         return _wr(x_cv[_off], lb[_off], ub[_off])
+
+                    return fn
+
+            # x*log(x) entropy/mixing term over a single scalar variable. Routes to
+            # the dedicated convex envelope (tighter than the bilinear of x and
+            # log(x)) when x is provably positive at this node; otherwise — and when
+            # the optional [sympy]-derived domain pack is absent — falls back to the
+            # generic bilinear. Sound by construction: the tight branch is taken only
+            # where the envelope is valid (lb > _XLOGX_POS_FLOOR), so the positivity
+            # clamp below is always a no-op there and never shrinks the actual box.
+            xlogx_off = _try_extract_xlogx(expr, model)
+            if xlogx_off is not None:
+                try:
+                    from discopt._jax.symbolic.domains.chemeng import xlogx_relax
+                except ImportError:
+                    xlogx_relax = None  # type: ignore[assignment]
+                if xlogx_relax is not None:
+                    _XLOGX_POS_FLOOR = 1e-9
+
+                    def fn(
+                        x_cv,
+                        x_cc,
+                        lb,
+                        ub,
+                        _off=xlogx_off,
+                        _xl=xlogx_relax,
+                        _flo=_XLOGX_POS_FLOOR,
+                    ):
+                        # Tight branch is used only where lb > _flo, so flooring the
+                        # inputs at _flo is a no-op exactly when this value is kept;
+                        # it exists solely to keep the jnp.where-discarded branch from
+                        # evaluating log of a non-positive number and NaN-poisoning the
+                        # gradient on an lb<=0 node. The box is never shrunk where used.
+                        _x = jnp.maximum(x_cv[_off], _flo)
+                        _l = jnp.maximum(lb[_off], _flo)
+                        _u = jnp.maximum(ub[_off], _l)
+                        cv_t, cc_t = _xl(_x, _l, _u)
+                        # Generic bilinear fallback (the status-quo relaxation of
+                        # x*log(x)) for non-positive / undefined-domain nodes.
+                        cv_l, cc_l = left_fn(x_cv, x_cc, lb, ub)
+                        cv_r, cc_r = right_fn(x_cv, x_cc, lb, ub)
+                        mid_l = 0.5 * (cv_l + cc_l)
+                        mid_r = 0.5 * (cv_r + cc_r)
+                        cv_bl, cc_bl = relax_bilinear(mid_l, mid_r, cv_l, cc_l, cv_r, cc_r)
+                        pos = lb[_off] > _flo
+                        return jnp.where(pos, cv_t, cv_bl), jnp.where(pos, cc_t, cc_bl)
 
                     return fn
 

--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -166,6 +166,40 @@ def _try_extract_signed_abs_product(expr: Expression, model: Model) -> int | Non
     return None
 
 
+def _try_extract_signed_power(expr: Expression, model: Model) -> tuple[int, float] | None:
+    """Detect the signed-power flow term ``f * |f|**(beta-1)`` over one scalar var.
+
+    Matches ``Mul(v, Pow(Abs(v), p))`` / ``Mul(Pow(Abs(v), p), v)`` with ``p`` a
+    positive constant and both factors the *same* scalar variable. Returns
+    ``(offset, beta)`` with ``beta = p + 1`` on match, else ``None``. This is the
+    Panhandle generalization of the Weymouth term (``beta == 2``, handled by
+    :func:`_try_extract_signed_abs_product`); it routes to
+    :func:`discopt._jax.symbolic.domains.gas.signed_power_relax`, which is a tight
+    single-inflection envelope valid over any box (no domain restriction).
+    """
+    if not (isinstance(expr, BinaryOp) and expr.op == "*"):
+        return None
+    for factor, other in ((expr.left, expr.right), (expr.right, expr.left)):
+        if (
+            isinstance(other, BinaryOp)
+            and other.op == "**"
+            and isinstance(other.right, Constant)
+            and isinstance(other.left, UnaryOp)
+            and other.left.op == "abs"
+        ):
+            try:
+                p = float(other.right.value)
+            except (TypeError, ValueError):
+                continue
+            if p <= 0.0:
+                continue
+            off = _resolve_scalar_var_offset(factor, model)
+            off_abs = _resolve_scalar_var_offset(other.left.operand, model)
+            if off is not None and off == off_abs:
+                return (off, p + 1.0)
+    return None
+
+
 def _try_extract_xlogx(expr: Expression, model: Model) -> int | None:
     """Detect the entropy/mixing term ``x * log(x)`` over a single scalar variable.
 
@@ -386,6 +420,26 @@ def _compile_relax_node(
                 if weymouth_relax is not None:
 
                     def fn(x_cv, x_cc, lb, ub, _off=gas_off, _wr=weymouth_relax):
+                        return _wr(x_cv[_off], lb[_off], ub[_off])
+
+                    return fn
+
+            # Signed-power (Panhandle) flow term f*|f|**(beta-1) over a single
+            # scalar variable — the general-exponent sibling of Weymouth. Like
+            # Weymouth it is a single-inflection function valid over any box, so the
+            # tight envelope needs no domain guard. Falls through to the generic
+            # bilinear when the optional [sympy] domain pack is absent.
+            sp_match = _try_extract_signed_power(expr, model)
+            if sp_match is not None:
+                _sp_off, _sp_beta = sp_match
+                try:
+                    from discopt._jax.symbolic.domains.gas import signed_power_relax
+                except ImportError:
+                    signed_power_relax = None  # type: ignore[assignment]
+                if signed_power_relax is not None:
+                    _sp_fn = signed_power_relax(_sp_beta)
+
+                    def fn(x_cv, x_cc, lb, ub, _off=_sp_off, _wr=_sp_fn):
                         return _wr(x_cv[_off], lb[_off], ub[_off])
 
                     return fn

--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -223,6 +223,45 @@ def _try_extract_xlogx(expr: Expression, model: Model) -> int | None:
     return None
 
 
+def _try_extract_monod(expr: Expression, model: Model) -> tuple[int, float] | None:
+    """Detect the Monod / saturating term ``x/(K+x)`` over a single scalar var.
+
+    Matches ``Div(v, Add(K, v))`` / ``Div(v, Add(v, K))`` with ``K`` a positive
+    constant and the numerator and the additive variable the SAME scalar var.
+    Returns ``(offset, K)`` on match, else ``None``, routing to the dedicated
+    concave envelope (:func:`...chemeng.saturating_relax`).
+
+    The envelope is valid only for ``v >= 0``. That is enforced at COMPILE time by
+    requiring the variable's *declared* lower bound to be ``>= 0``: spatial B&B only
+    tightens bounds, so every node box then keeps ``v >= 0`` and no per-node guard
+    is needed. When the declared lower bound can be negative the term is left to the
+    generic division relaxation.
+    """
+    if not (isinstance(expr, BinaryOp) and expr.op == "/"):
+        return None
+    num_off = _resolve_scalar_var_offset(expr.left, model)
+    if num_off is None:
+        return None
+    den = expr.right
+    if not (isinstance(den, BinaryOp) and den.op == "+"):
+        return None
+    for kside, vside in ((den.left, den.right), (den.right, den.left)):
+        if not _is_constant_expr(kside):
+            continue
+        try:
+            kval = float(_get_constant_value(kside))
+        except (TypeError, ValueError):
+            continue
+        v_off = _resolve_scalar_var_offset(vside, model)
+        if kval > 0.0 and v_off is not None and v_off == num_off:
+            from discopt._jax.model_utils import flat_variable_bounds
+
+            lb0, _ = flat_variable_bounds(model)
+            if float(lb0[num_off]) >= 0.0:
+                return (num_off, kval)
+    return None
+
+
 def _try_extract_signomial_factors(
     expr: Expression, model: Model
 ) -> list[tuple[int, float]] | None:
@@ -622,6 +661,25 @@ def _compile_relax_node(
                     return new_cv, new_cc
 
                 return fn
+
+            # Monod / saturating term x/(K+x) over a single scalar variable with a
+            # nonneg declared domain. Routes to the dedicated concave envelope
+            # (tighter than the generic division relaxation); falls through to the
+            # generic path when the optional [sympy] domain pack is absent.
+            monod = _try_extract_monod(expr, model)
+            if monod is not None:
+                _mo_off, _mo_k = monod
+                try:
+                    from discopt._jax.symbolic.domains.chemeng import saturating_relax
+                except ImportError:
+                    saturating_relax = None  # type: ignore[assignment]
+                if saturating_relax is not None:
+                    _mo_fn = saturating_relax(_mo_k)
+
+                    def fn(x_cv, x_cc, lb, ub, _off=_mo_off, _wr=_mo_fn):
+                        return _wr(x_cv[_off], lb[_off], ub[_off])
+
+                    return fn
 
             def fn(x_cv, x_cc, lb, ub):
                 cv_l, cc_l = left_fn(x_cv, x_cc, lb, ub)

--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -262,6 +262,41 @@ def _try_extract_monod(expr: Expression, model: Model) -> tuple[int, float] | No
     return None
 
 
+def _try_extract_arrhenius(expr: Expression, model: Model) -> tuple[int, float] | None:
+    """Detect the Arrhenius rate term ``exp(-c/T)`` over a single scalar variable.
+
+    Matches ``exp(Div(Constant(neg), v))`` with ``neg < 0`` (so the term is
+    ``exp(-c/T)`` with ``c = -neg > 0``) and ``v`` a scalar variable. Returns
+    ``(offset, c)`` on match, else ``None``, routing to the dedicated
+    single-inflection envelope (:func:`...chemeng.arrhenius_relax`).
+
+    The term (and its envelope) require ``T > 0`` (a pole at ``T = 0``). That is
+    enforced at COMPILE time by requiring the variable's declared lower bound to be
+    strictly positive; spatial B&B only tightens bounds, so every node box keeps
+    ``T > 0`` and no per-node guard is needed.
+    """
+    if not (isinstance(expr, FunctionCall) and expr.func_name == "exp" and len(expr.args) == 1):
+        return None
+    arg = expr.args[0]
+    if not (isinstance(arg, BinaryOp) and arg.op == "/" and _is_constant_expr(arg.left)):
+        return None
+    try:
+        neg = float(_get_constant_value(arg.left))
+    except (TypeError, ValueError):
+        return None
+    if neg >= 0.0:  # need exp(-c/T) with c > 0
+        return None
+    v_off = _resolve_scalar_var_offset(arg.right, model)
+    if v_off is None:
+        return None
+    from discopt._jax.model_utils import flat_variable_bounds
+
+    lb0, _ = flat_variable_bounds(model)
+    if float(lb0[v_off]) > 0.0:
+        return (v_off, -neg)
+    return None
+
+
 def _try_extract_signomial_factors(
     expr: Expression, model: Model
 ) -> list[tuple[int, float]] | None:
@@ -904,6 +939,27 @@ def _compile_relax_node(
                             return _tf(x_cv[_fi], lb[_fi], ub[_fi])
 
                         return fn
+
+        # Arrhenius rate term exp(-c/T) over a single positive-domain scalar var.
+        # Routes the whole exp(-c/T) node to the dedicated single-inflection
+        # envelope (tighter than composing relax_exp with the relaxed reciprocal);
+        # falls through to the generic exp path when the optional [sympy] domain
+        # pack is absent.
+        if name == "exp" and len(expr.args) == 1:
+            arr = _try_extract_arrhenius(expr, model)
+            if arr is not None:
+                _ar_off, _ar_c = arr
+                try:
+                    from discopt._jax.symbolic.domains.chemeng import arrhenius_relax
+                except ImportError:
+                    arrhenius_relax = None  # type: ignore[assignment]
+                if arrhenius_relax is not None:
+                    _ar_fn = arrhenius_relax(_ar_c)
+
+                    def fn(x_cv, x_cc, lb, ub, _off=_ar_off, _wr=_ar_fn):
+                        return _wr(x_cv[_off], lb[_off], ub[_off])
+
+                    return fn
 
         # Piecewise-capable univariate operations
         _piecewise_relax = {

--- a/python/discopt/_jax/symbolic/domains/gas.py
+++ b/python/discopt/_jax/symbolic/domains/gas.py
@@ -79,6 +79,41 @@ def weymouth_relax(x, lb, ub):
     )
 
 
+def signed_power_relax(beta: float):
+    """Envelope factory for the signed-power (Panhandle) flow term.
+
+    Relaxes ``f * |f|**(beta-1) = sign(f) |f|**beta`` over ``[lb, ub]``. This
+    generalizes :func:`weymouth_relax` (the ``beta == 2`` case). For ``beta > 1``
+    the term is concave for ``f < 0`` and convex for ``f > 0`` with a single
+    inflection at ``0``, so it has a tight single-inflection envelope valid over
+    any box. The tangent point is transcendental for non-integer ``beta`` and is
+    solved numerically by the shared runtime construction.
+
+    Args:
+        beta: Flow exponent (Panhandle ~1.85-1.95; Weymouth = 2). Must be > 1.
+
+    Returns:
+        A closure ``(x, lb, ub) -> (cv, cc)`` with
+        ``cv <= sign(x)|x|**beta <= cc``; ``cv`` convex and ``cc`` concave.
+    """
+    b = float(beta)
+    if b <= 1.0:
+        raise ValueError("signed-power exponent beta must be > 1")
+    p = b - 1.0
+
+    def f(x):
+        return x * jnp.abs(x) ** p
+
+    def fp(x):
+        # d/dx (x|x|^p) = |x|^p + x*p*|x|^(p-1)*sign(x) = (1+p)|x|^p = beta*|x|^p
+        return b * jnp.abs(x) ** p
+
+    def relax(x, lb, ub):
+        return runtime.single_inflection_envelope(x, lb, ub, f=f, fp=fp, c=0.0, concavo_convex=True)
+
+    return relax
+
+
 def derive_weymouth_symbolic():
     """Return the SymPy-derived envelope closure for ``f|f|`` (design-time only).
 

--- a/python/tests/test_symbolic_domains.py
+++ b/python/tests/test_symbolic_domains.py
@@ -143,3 +143,60 @@ def test_sin_angle_matches_engine_construction_on_single_inflection_proxy():
     cv_s, cc_s = relax_s(xs, lbs, ubs)
     assert jnp.allclose(cv_h, cv_s, atol=1e-7)
     assert jnp.allclose(cc_h, cc_s, atol=1e-7)
+
+
+# --------------------------------------------------------------------------
+# End-to-end: relaxation compiler auto-routes x*log(x) to the tight envelope
+# --------------------------------------------------------------------------
+
+
+def test_compiler_routes_xlogx_pattern():
+    """The compiler detects ``x * log(x)`` and routes it to the dedicated convex
+    envelope (tighter than the generic bilinear of ``x`` and ``log(x)``), end to
+    end, on a positive box. Asserts soundness (``cv <= f <= cc``) and that the
+    routed result matches the standalone ``xlogx_relax`` closure."""
+    import discopt.modeling as M
+    import numpy as np
+    from discopt._jax.relaxation_compiler import compile_relaxation
+    from discopt.modeling.core import Model
+
+    m = Model("entropy")
+    x = m.continuous("x", lb=0.5, ub=5.0)
+    m.minimize(x * M.log(x))
+    expr = x * M.log(x)
+
+    relax_fn = compile_relaxation(expr.expression if hasattr(expr, "expression") else expr, m)
+    lb = jnp.array([0.5])
+    ub = jnp.array([5.0])
+    for xv in np.linspace(0.5, 5.0, 60):
+        xa = jnp.array([float(xv)])
+        cv, cc = relax_fn(xa, xa, lb, ub)
+        true = float(xv) * np.log(float(xv))
+        assert float(cv) <= true + 1e-6, f"unsound cv at x={xv}: {float(cv)} > {true}"
+        assert float(cc) >= true - 1e-6, f"unsound cc at x={xv}: {float(cc)} < {true}"
+        # Routed result == standalone closure (i.e. the dispatch fired).
+        cv_x, cc_x = chemeng.xlogx_relax(jnp.array(float(xv)), 0.5, 5.0)
+        assert float(cv) == pytest.approx(float(cv_x), abs=1e-7)
+        assert float(cc) == pytest.approx(float(cc_x), abs=1e-7)
+
+
+def test_compiler_xlogx_detector_no_misfire():
+    """The x*log(x) detector fires only on a bare variable times log of the SAME
+    variable — not on different variables, squares, or other transcendentals."""
+    import discopt.modeling as M
+    from discopt._jax.relaxation_compiler import _try_extract_xlogx
+    from discopt.modeling.core import Model
+
+    m = Model("t")
+    x = m.continuous("x", lb=0.5, ub=5.0)
+    y = m.continuous("y", lb=0.5, ub=5.0)
+
+    def ex(e):
+        return e.expression if hasattr(e, "expression") else e
+
+    assert _try_extract_xlogx(ex(x * M.log(x)), m) is not None
+    assert _try_extract_xlogx(ex(M.log(x) * x), m) is not None
+    assert _try_extract_xlogx(ex(x * M.log(y)), m) is None  # different variable
+    assert _try_extract_xlogx(ex(x * x), m) is None  # no log
+    assert _try_extract_xlogx(ex(x * M.exp(x)), m) is None  # not log
+    assert _try_extract_xlogx(ex(M.log(x) * M.log(x)), m) is None  # no bare var

--- a/python/tests/test_symbolic_domains.py
+++ b/python/tests/test_symbolic_domains.py
@@ -200,3 +200,45 @@ def test_compiler_xlogx_detector_no_misfire():
     assert _try_extract_xlogx(ex(x * x), m) is None  # no log
     assert _try_extract_xlogx(ex(x * M.exp(x)), m) is None  # not log
     assert _try_extract_xlogx(ex(M.log(x) * M.log(x)), m) is None  # no bare var
+
+
+def test_compiler_routes_monod_pattern():
+    """The compiler detects x/(K+x) on a nonneg-domain variable and routes it to
+    the dedicated concave envelope; sound, and matches the standalone closure."""
+    import numpy as np
+    from discopt._jax.relaxation_compiler import compile_relaxation
+    from discopt.modeling.core import Model
+
+    m = Model("monod")
+    x = m.continuous("x", lb=0.1, ub=5.0)
+    m.maximize(x / (2.0 + x))
+    relax_fn = compile_relaxation(x / (2.0 + x), m)
+    sat = chemeng.saturating_relax(2.0)
+    lb = jnp.array([0.1])
+    ub = jnp.array([5.0])
+    for xv in np.linspace(0.1, 5.0, 60):
+        xa = jnp.array([float(xv)])
+        cv, cc = relax_fn(xa, xa, lb, ub)
+        f = float(xv) / (2.0 + float(xv))
+        assert float(cv) <= f + 1e-6
+        assert float(cc) >= f - 1e-6
+        cv_s, cc_s = sat(jnp.array(float(xv)), 0.1, 5.0)
+        assert float(cv) == pytest.approx(float(cv_s), abs=1e-7)
+        assert float(cc) == pytest.approx(float(cc_s), abs=1e-7)
+
+
+def test_monod_detector_guards_and_no_misfire():
+    from discopt._jax.relaxation_compiler import _try_extract_monod
+    from discopt.modeling.core import Model
+
+    m = Model("t")
+    x = m.continuous("x", lb=0.1, ub=5.0)
+    y = m.continuous("y", lb=0.1, ub=5.0)
+    assert _try_extract_monod(x / (2.0 + x), m) == (0, pytest.approx(2.0))
+    assert _try_extract_monod(x / (x + 2.0), m) == (0, pytest.approx(2.0))
+    assert _try_extract_monod(x / (2.0 + y), m) is None  # different variable
+    assert _try_extract_monod(x / (2.0 * x), m) is None  # denominator not K+x
+    # Negative declared lower bound: envelope invalid -> must not engage.
+    mn = Model("n")
+    xn = mn.continuous("x", lb=-1.0, ub=5.0)
+    assert _try_extract_monod(xn / (2.0 + xn), mn) is None

--- a/python/tests/test_symbolic_domains.py
+++ b/python/tests/test_symbolic_domains.py
@@ -242,3 +242,46 @@ def test_monod_detector_guards_and_no_misfire():
     mn = Model("n")
     xn = mn.continuous("x", lb=-1.0, ub=5.0)
     assert _try_extract_monod(xn / (2.0 + xn), mn) is None
+
+
+def test_compiler_routes_arrhenius_pattern():
+    """The compiler detects exp(-c/T) on a positive-domain variable and routes it
+    to the dedicated single-inflection envelope; sound across the inflection."""
+    import discopt.modeling as M
+    import numpy as np
+    from discopt._jax.relaxation_compiler import compile_relaxation
+    from discopt.modeling.core import Model
+
+    # c = 800 -> inflection at T = c/2 = 400, inside [300, 600] (straddling).
+    m = Model("arr")
+    T = m.continuous("T", lb=300.0, ub=600.0)
+    m.maximize(M.exp(-800.0 / T))
+    relax_fn = compile_relaxation(M.exp(-800.0 / T), m)
+    arr = chemeng.arrhenius_relax(800.0)
+    lb = jnp.array([300.0])
+    ub = jnp.array([600.0])
+    for tv in np.linspace(300.0, 600.0, 80):
+        ta = jnp.array([float(tv)])
+        cv, cc = relax_fn(ta, ta, lb, ub)
+        f = float(np.exp(-800.0 / float(tv)))
+        assert float(cv) <= f + 1e-6
+        assert float(cc) >= f - 1e-6
+        cv_a, cc_a = arr(jnp.array(float(tv)), 300.0, 600.0)
+        assert float(cv) == pytest.approx(float(cv_a), abs=1e-7)
+        assert float(cc) == pytest.approx(float(cc_a), abs=1e-7)
+
+
+def test_arrhenius_detector_guards_and_no_misfire():
+    import discopt.modeling as M
+    from discopt._jax.relaxation_compiler import _try_extract_arrhenius
+    from discopt.modeling.core import Model
+
+    m = Model("t")
+    T = m.continuous("T", lb=300.0, ub=600.0)
+    assert _try_extract_arrhenius(M.exp(-8000.0 / T), m) == (0, pytest.approx(8000.0))
+    assert _try_extract_arrhenius(M.exp(8000.0 / T), m) is None  # +c/T (c<0), not Arrhenius
+    assert _try_extract_arrhenius(M.exp(T), m) is None  # not -c/T
+    # Non-positive declared lower bound: pole/invalid -> must not engage.
+    m0 = Model("z")
+    T0 = m0.continuous("T", lb=0.0, ub=600.0)
+    assert _try_extract_arrhenius(M.exp(-8000.0 / T0), m0) is None

--- a/python/tests/test_symbolic_gas.py
+++ b/python/tests/test_symbolic_gas.py
@@ -152,3 +152,52 @@ def test_signed_power_panhandle_sound(beta):
     cv, cc = jax.vmap(fn, in_axes=(0, None, None))(xs, lb, ub)
     assert jnp.all(cv <= f + 1e-6)
     assert jnp.all(cc >= f - 1e-6)
+
+
+# --------------------------------------------------------------------------
+# Signed-power (Panhandle) generalization of Weymouth, auto-engaged
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("beta", [1.5, 1.85, 1.95])
+def test_compiler_routes_signed_power_pattern(beta):
+    """The compiler detects ``f * |f|**(beta-1)`` and routes it to the tight
+    signed-power envelope end to end; sound over a box straddling 0."""
+    import numpy as np
+    from discopt._jax.relaxation_compiler import compile_relaxation
+    from discopt._jax.symbolic.domains.gas import signed_power_relax
+    from discopt.modeling.core import Model
+
+    p = beta - 1.0
+    m = Model("gas")
+    f = m.continuous("f", lb=-6.0, ub=6.0)
+    m.minimize(f)
+    expr = f * abs(f) ** p
+
+    relax_fn = compile_relaxation(expr, m)
+    lb = jnp.array([-6.0])
+    ub = jnp.array([6.0])
+    _sp = signed_power_relax(beta)
+    for xv in np.linspace(-6.0, 6.0, 60):
+        xa = jnp.array([float(xv)])
+        cv, cc = relax_fn(xa, xa, lb, ub)
+        true = float(np.sign(xv) * abs(float(xv)) ** beta)
+        assert float(cv) <= true + 1e-6
+        assert float(cc) >= true - 1e-6
+        cv_s, cc_s = _sp(xv, -6.0, 6.0)
+        assert float(cv) == pytest.approx(float(cv_s), abs=1e-7)
+        assert float(cc) == pytest.approx(float(cc_s), abs=1e-7)
+
+
+def test_signed_power_detector_no_misfire():
+    from discopt._jax.relaxation_compiler import _try_extract_signed_power
+    from discopt.modeling.core import Model
+
+    m = Model("t")
+    f = m.continuous("f", lb=-5.0, ub=5.0)
+    g = m.continuous("g", lb=-5.0, ub=5.0)
+    assert _try_extract_signed_power(f * abs(f) ** 0.85, m) == (0, pytest.approx(1.85))
+    assert _try_extract_signed_power(abs(f) ** 0.85 * f, m) == (0, pytest.approx(1.85))
+    assert _try_extract_signed_power(f * abs(g) ** 0.85, m) is None  # different variable
+    assert _try_extract_signed_power(f * f**0.85, m) is None  # no abs
+    assert _try_extract_signed_power(f * abs(f), m) is None  # Weymouth shape (no power)


### PR DESCRIPTION
## Summary

Extends the relaxation compiler's automatic envelope recognition (which already routes the Weymouth `f·|f|` term and `sin`/`cos`/`exp`/`log`/`sqrt` to tight envelopes) to the remaining **composite / parameterized** domain-pack envelopes that were previously relaxed by the generic (loose) path:

| term | envelope | engaged when |
|---|---|---|
| `x·log(x)` (entropy/mixing) | convex `xlogx_relax` | runtime `lb>0` guard + bilinear fallback |
| `f·\|f\|^(β−1)` (Panhandle signed-power) | single-inflection (generalizes Weymouth) | always (valid on any box) |
| `x/(K+x)` (Monod/saturating) | concave `saturating_relax` | declared `lb ≥ 0` |
| `exp(−c/T)` (Arrhenius) | single-inflection | declared `lb > 0` |

Adds a runtime `signed_power_relax(beta)` factory to `domains/gas.py` (pure-JAX, complements the existing design-time `derive_signed_power_symbolic`).

## Soundness (the main content)

Each addition is gated so it can never produce an invalid relaxation in the default solve path:

- **Strict, tested detectors** — every detector is verified to extract the right parameter (β / K / c) and to *not* misfire on different variables, missing `abs`, non-`Add` denominators, `+c/T`, etc.
- **Domain preconditions enforced two ways:** signed-power needs none (single inflection at 0, valid on any box, like Weymouth); Monod/Arrhenius use a **compile-time declared-bound check** — since spatial B&B only *tightens* bounds, a non-negative/positive *declared* lower bound guarantees the precondition at *every* node, so no per-node guard is needed and an out-of-domain model cleanly falls through to the generic relaxation. `x·log(x)` uses a runtime `lb`-floor whose threshold equals the engage condition, so the floor is always a no-op where the tight branch is used (the actual box is never shrunk) and only prevents NaN-poisoning of the discarded `jnp.where` branch.
- **Graceful degradation** — all wrapped in `try/except ImportError`, falling back to the generic path when the optional `[sympy]` extra is absent.

## Verification

- Each compiled routing is sound to machine precision in float64 — worst `cv−f`/`f−cc` ≤ ~1e-15 over random boxes (incl. ones straddling the inflection for signed-power and Arrhenius).
- Each end-to-end min/max solve reaches the true optimum.
- **smoke 10/10 solved / 10/10 proved / 0 incorrect** (these changes are in the default relaxation path, so this is the no-regression gate).
- 133 symbolic/envelope/compiler tests pass; +8 new routing/detector-guard regression tests.

## Scope note

This does **not** close #15 (the gas-network MINLP) — verified: that model's loose terms are `f²`/`p²` squares, `β^0.2857` fractional powers, and `w·(…)` bilinears, none of which these envelopes target. Closing #15's relaxation gap is done by the (opt-in) square-difference-network cut recognizer from #245, not by this envelope pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
