### PR TITLE
fix(gams-export): quote set labels + rPower for fractional exponents

### DIFF
--- a/python/discopt/export/gams.py
+++ b/python/discopt/export/gams.py
@@ -330,12 +330,16 @@ class _GamsWriter:
 
         if isinstance(expr, IndexExpression):
             base = self._expr_to_gams(expr.base)
+            # GAMS is 1-based and requires quoted set labels for concrete element
+            # references (f_pipe('1'), not f_pipe(1)). Symbolic indices (set/alias
+            # names from a loop) are emitted bare via _expr_to_gams.
             if isinstance(expr.index, tuple):
                 idx_str = ", ".join(
-                    str(i + 1) if isinstance(i, int) else self._expr_to_gams(i) for i in expr.index
+                    f"'{i + 1}'" if isinstance(i, int) else self._expr_to_gams(i)
+                    for i in expr.index
                 )
             elif isinstance(expr.index, int):
-                idx_str = str(expr.index + 1)  # GAMS is 1-based
+                idx_str = f"'{expr.index + 1}'"
             else:
                 idx_str = self._expr_to_gams(expr.index)
             return f"{base}({idx_str})"
@@ -344,7 +348,13 @@ class _GamsWriter:
             left = self._expr_to_gams(expr.left)
             right = self._expr_to_gams(expr.right)
             if expr.op == "**":
-                return f"power({left}, {right})"
+                # GAMS power(x, n) requires an INTEGER exponent; a fractional or
+                # symbolic exponent must use rPower(x, r) (== x ** r, base >= 0).
+                if isinstance(expr.right, Constant) and float(expr.right.value) == int(
+                    float(expr.right.value)
+                ):
+                    return f"power({left}, {right})"
+                return f"rPower({left}, {right})"
             return f"({left} {expr.op} {right})"
 
         if isinstance(expr, UnaryOp):

--- a/python/tests/test_gams.py
+++ b/python/tests/test_gams.py
@@ -566,6 +566,37 @@ class TestGamsExport:
         content = outpath.read_text()
         assert "Solve filetest" in content
 
+    def test_indexed_var_refs_are_quoted(self):
+        """Regression (#250): element references in equations must use quoted
+        GAMS labels (f('1')), not bare numbers (f(1)) which raise Error 145/148."""
+        import re
+
+        m = dm.Model("idx")
+        x = m.continuous("x", shape=(3,), lb=0, ub=10)
+        m.minimize(x[0] + x[1] + x[2])
+        m.subject_to(x[0] + 2 * x[1] >= 4)
+
+        gms = m.to_gams()
+        # The declaration is over a set name (x(s1)); only equation-body element
+        # refs are concrete. No bare-integer index like name(0)/name(1) may remain.
+        assert not re.search(r"[A-Za-z_]\w*\(\d+\)", gms), gms
+        assert "x('1')" in gms and "x('2')" in gms
+
+    def test_fractional_power_uses_rpower(self):
+        """Regression (#250): GAMS power(x, n) is integer-only; a fractional
+        exponent must export as rPower(x, r), while integer powers stay power()."""
+        m = dm.Model("pw")
+        x = m.continuous("x", lb=0.5, ub=4.0)
+        m.minimize(x**0.2857 + x**2)
+
+        gms = m.to_gams()
+        assert "rPower(x, 0.2857)" in gms
+        assert "power(x, 2)" in gms  # integer exponent unchanged
+        # no fractional literal inside a power() call
+        import re
+
+        assert not re.search(r"power\([^,]+,\s*\d*\.\d+", gms), gms
+
 
 # ── Round-trip tests ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`Model.to_gams()` produced GAMS source that **failed to compile** for any model
with indexed variables or fractional powers. Found while round-tripping the
gas-network MINLP through the GAMS link. Two independent bugs, both in
`_expr_to_gams`:

- **Bug 1 — unquoted set labels.** Equation bodies referenced concrete elements
  with bare numbers (`f_pipe(1)`), which GAMS rejects with Error 145/148. Now
  emits quoted labels (`f_pipe('1')`). Symbolic loop/alias indices stay bare.
- **Bug 2 — integer-only `power()`.** Every `x ** r` exported as `power(x, r)`,
  but GAMS `power()` requires an integer exponent and aborts with
  `pow(x,i), i not integer` on a fractional power. Non-integer / non-constant
  exponents now route to `rPower(x, r)`; integer exponents keep `power(x, n)`.

## Verification

- **Real round-trip:** the exported gas-network `.gms` now compiles with **0
  errors** and BARON solves it to **Optimal, objective 3.0026** (the expected
  value) with zero hand-editing.
- **Regression tests:** `test_indexed_var_refs_are_quoted` and
  `test_fractional_power_uses_rpower` (pure text-level checks, no GAMS needed in
  CI). Full `test_gams.py`: 43 passed, 2 skipped (gamspy-gated). Lint + format clean.

Closes #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
