### PR TITLE
fix(gams): recycle the warm daemon when discopt source changes

### DIFF
--- a/python/discopt/gams/daemon.py
+++ b/python/discopt/gams/daemon.py
@@ -37,6 +37,44 @@ _CONNECT_TIMEOUT = 5.0
 _SPAWN_WAIT = 30.0
 
 
+def _source_fingerprint() -> str:
+    """A staleness key that changes whenever the installed discopt source changes.
+
+    Returns ``__version__`` plus the newest modification time across the discopt
+    package's Python and compiled-extension files. In a released / site-packages
+    install those mtimes are fixed at install time, so the key is stable and the
+    warm daemon is reused across solves. In an editable / development install,
+    editing any source file (or rebuilding the Rust extension) bumps the max mtime,
+    so a client built from the edited tree no longer matches a daemon spawned
+    *before* the edit -- the solve handshake (:meth:`DaemonServer._handle`) then
+    evicts and respawns it, and the change takes effect on the next solve without a
+    manual ``daemon stop``. Falls back to ``__version__`` alone if the package tree
+    cannot be scanned, so the handshake never breaks.
+    """
+    try:
+        import discopt
+
+        root = Path(discopt.__file__).resolve().parent
+        latest = 0
+        for pattern in ("*.py", "*.so", "*.pyd"):
+            for p in root.rglob(pattern):
+                try:
+                    m = p.stat().st_mtime_ns
+                except OSError:
+                    continue
+                if m > latest:
+                    latest = m
+        return f"{__version__}+{latest}" if latest else __version__
+    except Exception:
+        return __version__
+
+
+# Computed once at import. The daemon stamps this as its version when it spawns;
+# a client built from a newer source tree computes a different value and the
+# version handshake recycles the stale daemon (see _source_fingerprint).
+_FINGERPRINT = _source_fingerprint()
+
+
 def _env_flag(name: str) -> bool:
     return os.environ.get(name, "0").lower() in ("1", "true", "yes", "on")
 
@@ -119,7 +157,7 @@ class DaemonServer:
         max_solves: int | None = None,
         max_rss_mb: int | None = None,
         jax_clear_every: int | None = None,
-        version: str = __version__,
+        version: str = _FINGERPRINT,
     ):
         # The benchmark preset disables count/age recycling by default so one
         # warm daemon spans a whole study (an RSS ceiling remains the backstop).
@@ -319,11 +357,22 @@ def solve_via_daemon(
     could not be started -- the caller should then solve in-process.
     """
     path = socket_path or default_socket_path()
+    # Recycle a daemon running stale code BEFORE solving, so the current code is
+    # used on this very solve (not one solve later). A running daemon stamps the
+    # source fingerprint it was spawned with; if ours differs -- e.g. an editable
+    # install was edited, or the package upgraded -- stop it and spawn fresh first.
+    # In a stable install the fingerprint never changes, so this is a one-ping
+    # no-op. (The daemon's own version check in ``_handle`` remains as a backstop
+    # for older clients that do not pre-check.)
+    info = ping(path)
+    if info is not None and info.get("version") not in (None, _FINGERPRINT):
+        stop_daemon(path)
+        spawn_daemon(path)
     payload = {
         "cmd": "solve",
         "control_file": control_file,
         "sysdir": sysdir,
-        "version": __version__,
+        "version": _FINGERPRINT,
     }
     resp = _request(path, payload)
     if resp is None:

--- a/python/tests/test_gams_daemon.py
+++ b/python/tests/test_gams_daemon.py
@@ -113,12 +113,32 @@ def test_max_solves(sock):
     assert not t.is_alive()  # stopped after hitting the cap
 
 
-def test_version_eviction(sock):
+def test_version_eviction(sock, monkeypatch):
+    # A daemon advertising a different fingerprint is running stale code. The
+    # client must recycle it BEFORE solving, rather than trusting its handshake
+    # to serve-then-stop one solve later. Stub spawn so no real daemon launches;
+    # we only assert the stale one was stopped and a fresh spawn was attempted.
     srv = d.DaemonServer(socket_path=sock, solve_fn=lambda cf, sysdir=None: 0, version="9.9.9")
     t = _start(srv)
-    # client __version__ != server version -> daemon serves then exits
+    spawns = []
+    monkeypatch.setattr(d, "spawn_daemon", lambda *a, **k: (spawns.append(True), False)[1])
     rc = d.solve_via_daemon("x", socket_path=sock)
-    assert rc == 0
+    t.join(timeout=5)
+    assert not t.is_alive()  # the stale daemon was stopped by the pre-check
+    assert spawns  # client attempted to spawn a fresh daemon
+    assert rc is None  # no live daemon after the stubbed spawn -> in-process fallback
+    assert d.ping(sock) is None
+
+
+def test_handle_serves_then_stops_on_version_mismatch(sock):
+    # Server-side backstop for older clients that do NOT pre-check: a solve
+    # request carrying a mismatched version is served, then the daemon exits.
+    srv = d.DaemonServer(socket_path=sock, solve_fn=lambda cf, sysdir=None: 0)
+    t = _start(srv)
+    resp = d._request(
+        sock, {"cmd": "solve", "control_file": "x", "sysdir": None, "version": "0.0.0"}
+    )
+    assert resp is not None and resp.get("rc") == 0
     t.join(timeout=5)
     assert not t.is_alive()
 
@@ -194,3 +214,23 @@ def test_jax_clear_every_is_safe_without_jax(sock):
     finally:
         d.stop_daemon(sock)
         t.join(timeout=5)
+
+
+def test_source_fingerprint_is_stable_and_edit_sensitive(tmp_path):
+    """The daemon's staleness key (its handshake ``version``) is stable across
+    calls but changes when a discopt source file is edited -- so a warm daemon
+    spawned from an editable install is recycled after an edit instead of serving
+    stale code. Socket-free (no AF_UNIX bind)."""
+    import os
+
+    import discopt
+
+    fp = d._source_fingerprint()
+    assert fp == d._source_fingerprint()  # deterministic across calls
+    assert fp.startswith(d.__version__)  # carries the package version
+    # A fresh DaemonServer stamps the fingerprint as its handshake version.
+    assert d.DaemonServer(socket_path=tmp_path / "x.sock").version == d._FINGERPRINT
+    # Bumping a discopt source file's mtime changes the fingerprint -> recycle.
+    src = os.path.join(os.path.dirname(discopt.__file__), "gams", "daemon.py")
+    os.utime(src, None)
+    assert d._source_fingerprint() != fp


### PR DESCRIPTION
## Summary

A warm GAMS daemon kept alive during development served **stale discopt code
indefinitely** — this is what hid the structure-cut presolve from a
GAMS-submitted gas network until the daemon was manually killed.

Root cause: the staleness handshake compared the static package `__version__`,
which does not change on a source edit (or a Rust rebuild within the same
version). The idle timeout works fine (verified empirically); the daemon simply
never recycled because solves kept connecting within the idle window.

## Fix

Stamp the handshake with a **source fingerprint** (`__version__` + newest mtime
across discopt's `.py`/`.so`/`.pyd`):

- Released / site-packages install → mtimes fixed → fingerprint stable → daemon
  reused (one-ping no-op, no behavior change).
- Editable install → any edit or rebuild bumps the fingerprint → mismatch →
  recycle.
- The client also **pre-checks and recycles before solving**, so the current
  code runs on *that* solve rather than one later.

## Verification

- End-to-end: editing a source file makes the next solve respawn the daemon
  (new PID, fingerprint == current code).
- Socket-free unit test `test_source_fingerprint_is_stable_and_edit_sensitive`.
  (The existing socket-based daemon tests fail in this sandbox with
  `AF_UNIX path too long` — a pre-existing tmp-path-length limit, identical with
  and without this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
