### PR TITLE
feat(global-opt): auto-engage the square-difference-network cut presolve

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1721,6 +1721,12 @@ def _classify_model_convexity(
 # typical bound gain, so the policy declines to enable cuts (sound: a no-op).
 _AUTO_CUTS_MAX_VARS = 40
 
+# Structure-cut presolve size gate: the symbolic recognizer runs `model_to_sympy`
+# (and SymPy `solve`/`simplify` when objective product terms are present)
+# unconditionally, so it is only auto-engaged on models small enough that this is
+# cheap. Counted as (sum of scalar variable sizes) + (number of constraints).
+_STRUCTURE_CUTS_MAX_SIZE = 100
+
 # Root cut pool (P3). Rounds of spectral PSD separation to run once at the root
 # to build the inherited pool; more rounds drive the root bound toward the Shor
 # SDP bound (nvs17: 8 rounds -> -2453, ~60 -> -1300, ~150 -> -1221). The pool is
@@ -1915,6 +1921,7 @@ def solve_model(
     subnlp_frequency: int = 20,
     subnlp_max_calls: int = 200,
     subnlp_options: Optional[dict] = None,
+    structure_cuts: bool = True,
     **kwargs,
 ) -> SolveResult:
     """
@@ -2103,6 +2110,38 @@ def solve_model(
     model._convexity_classification_cache = None
     _convexity_time_budget = min(max(0.2 * float(time_limit), 0.5), 20.0)
     model._convexity_time_budget = _convexity_time_budget
+
+    # --- Structure-cut presolve (auto-engaged square-difference-network cuts) ---
+    # The symbolic cut recognizer auto-derives sound coupling cuts for the
+    # square-difference (Weymouth gas/water) network structure directly from the
+    # model graph, collapsing the otherwise-catastrophic McCormick relaxation gap
+    # on those models (gas-network MINLP, issue #15: bound 1.0 vs optimum 3.0026 ->
+    # bound = optimum; 2821 nodes / 182 s -> 5 nodes / ~3 s). Each injected cut is a
+    # verified valid underestimator (sound), and the pass is a genuine no-op on a
+    # model without the structure. It is auto-engaged but gated, because it runs
+    # SymPy analysis: opt out with ``structure_cuts=False``; only when SymPy is
+    # importable; only on small models (so ``model_to_sympy`` stays cheap); only
+    # with budget remaining. Runs *before* the relaxation build so the tightened
+    # model flows through the normal pipeline. Only the square-difference detector
+    # is auto-engaged here — the broader ``inject_all_patterns`` battery stays
+    # opt-in. Any failure is swallowed so the recognizer can never break a solve.
+    if structure_cuts and model._objective is not None and _remaining_budget() > 1.0:
+        _struct_size = sum(v.size for v in model._variables) + len(model._constraints)
+        if _struct_size <= _STRUCTURE_CUTS_MAX_SIZE:
+            try:
+                from discopt._jax.symbolic.cut_recognizer import recognize_and_inject
+
+                _n_struct_cuts = recognize_and_inject(model)
+                if _n_struct_cuts:
+                    logger.info(
+                        "Structure-cut presolve: injected %d square-difference-network "
+                        "coupling cut(s) (auto-engaged; opt out with structure_cuts=False)",
+                        _n_struct_cuts,
+                    )
+            except ImportError:
+                pass  # optional [sympy] extra not installed -> skip silently
+            except Exception as _sc_exc:  # pragma: no cover - defensive
+                logger.debug("structure-cut presolve skipped: %s", _sc_exc)
 
     # --- AMP (Adaptive Multivariate Partitioning) global solver ---
     _solver = solver if solver is not None else kwargs.pop("solver", None)

--- a/python/tests/test_cut_recognizer.py
+++ b/python/tests/test_cut_recognizer.py
@@ -443,3 +443,57 @@ def test_signed_signomial_fires_on_cvxnonsep_nsig30():
     m = dm.from_nl("python/tests/data/minlplib_nl/cvxnonsep_nsig30.nl")
     n = R.inject_signed_signomial_constraint_cuts(m)
     assert n == 1
+
+
+# --------------------------------------------------------------------------
+# Auto-engaged structure-cut presolve in solve_model (issue #15)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_structure_cuts_presolve_auto_closes_gas_network():
+    """The default `m.solve()` auto-runs the square-difference recognizer as a
+    presolve and closes the gas-network gap (issue #15): the bound reaches the
+    optimum and the search is tiny — without any manual `inject_all_patterns`."""
+    from discopt.benchmarks.problems.gas_network_minlp import build_gas_network_minlp
+
+    m = build_gas_network_minlp()
+    r = m.solve(time_limit=90, gap_tolerance=1e-4)
+    assert r.status == "optimal", f"auto structure-cuts did not certify (status={r.status})"
+    assert r.objective == pytest.approx(3.0026, abs=1e-2)
+    # Bound reached the optimum (gap closed) — the cut tightened the relaxation.
+    assert r.bound is not None and r.bound == pytest.approx(3.0026, abs=1e-2)
+    assert r.node_count <= 100, f"expected a tiny search after the cut, got {r.node_count} nodes"
+
+
+@pytest.mark.slow
+def test_structure_cuts_optout_leaves_gap_open():
+    """`structure_cuts=False` disables the presolve: the gas network then exits
+    uncertified on the loose McCormick bound (the pre-fix behaviour)."""
+    from discopt.benchmarks.problems.gas_network_minlp import build_gas_network_minlp
+
+    m = build_gas_network_minlp()
+    r = m.solve(time_limit=20, gap_tolerance=1e-4, structure_cuts=False)
+    # No cut -> bound stuck far below the optimum (loose), search does not close.
+    assert r.bound is None or r.bound < 2.0
+
+
+def test_structure_cuts_presolve_noop_on_unrelated_model():
+    """The presolve is a sound no-op on a model without the square-difference
+    structure: same result with and without it, no spurious cuts."""
+    m = dm.Model("nc")
+    x = m.continuous("x", lb=-3.0, ub=3.0)
+    y = m.continuous("y", lb=-3.0, ub=3.0)
+    m.minimize(x * y)
+    m.subject_to(x * x + y * y <= 4.0)
+    r_on = m.solve(time_limit=20)
+
+    m2 = dm.Model("nc")
+    x2 = m2.continuous("x", lb=-3.0, ub=3.0)
+    y2 = m2.continuous("y", lb=-3.0, ub=3.0)
+    m2.minimize(x2 * y2)
+    m2.subject_to(x2 * x2 + y2 * y2 <= 4.0)
+    r_off = m2.solve(time_limit=20, structure_cuts=False)
+
+    assert r_on.objective == pytest.approx(r_off.objective, abs=1e-3)
+    assert r_on.objective == pytest.approx(-2.0, abs=1e-3)

--- a/python/tests/test_recognizer_adversarial.py
+++ b/python/tests/test_recognizer_adversarial.py
@@ -31,7 +31,12 @@ TL = 25
 
 
 def _opt(model):
-    r = model.solve(time_limit=TL, gap_tolerance=1e-4)
+    # Disable the auto-engaged structure-cut presolve so these tests isolate the
+    # MANUAL inject_all_patterns under test: otherwise the presolve also injects on
+    # the baseline solve and accumulates with the manual cuts across the helper's
+    # repeated solve+inject on one model object. The auto-presolve has its own
+    # dedicated tests in test_cut_recognizer.py.
+    r = model.solve(time_limit=TL, gap_tolerance=1e-4, structure_cuts=False)
     return r.status, (None if r.objective is None else float(r.objective))
 
 


### PR DESCRIPTION
## Summary

Auto-engages the square-difference-network cut recognizer
(`recognize_and_inject`) as a presolve step in `Model.solve()`, behind a new
`structure_cuts: bool = True` parameter. On a matching model (e.g. the
gas-network MINLP) it injects the structured cuts that collapse the spatial
search; on everything else it is a near-instant no-op.

Guards keep it off the hot path and safe:

- Only runs when there is an objective and time budget remains.
- Size-gated (`sum(var sizes) + len(constraints) <= 100`) so it never touches
  large models.
- SymPy is imported lazily inside the recognizer; `ImportError` falls back
  cleanly (no hard dependency), and any recognizer exception is logged and
  swallowed rather than failing the solve.
- `structure_cuts=False` opts out entirely.

## Impact

Resolves the long-standing gas-network blowup: **182s → ~3.1s**. The recognizer
is value-preserving (verified by the adversarial optimum-preservation suite in
`test_recognizer_adversarial.py`).

## Verification

- Phase 1/2/3 benchmarks identical to baseline, **0 incorrect** — the presolve
  is a clean no-op on every MINLPLib instance.
- Adversarial suite (sign/bound/sense flips) all pass; cut-recognizer presolve
  tests cover auto-close, opt-out, and no-op paths.

Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
