### PR TITLE
fix(benchmarks): honest GAP vs VIOLATION verdict in the .nl cross-solver harness

### DIFF
--- a/discopt_benchmarks/scripts/global_opt_nl_solvers.py
+++ b/discopt_benchmarks/scripts/global_opt_nl_solvers.py
@@ -43,14 +43,18 @@ if str(_DB) not in sys.path:
     sys.path.insert(0, str(_DB))
 
 from discopt_benchmarks.scripts.global_opt_baron_vs_discopt import (  # noqa: E402
+    GAP,
+    NA,
+    OK,
     REPO,
+    VIOLATION,
     SolverRun,
     all_instances,
+    classify,
     fmt,
-    is_correct,
     load_known_optima,
+    nl_is_maximize,
     run_discopt,
-    tri,
 )
 
 from benchmarks.runner import (  # noqa: E402
@@ -113,15 +117,11 @@ def write_report(
     md = out_dir / f"global_opt_nl_solvers_{ts}.md"
     n_oracle = sum(r["known"] is not None for r in rows)
 
-    # per-solver correctness tallies
-    tallies = {s: {"ok": 0, "wrong": 0} for s in solver_order}
+    # per-solver verdict tallies (honest OK / GAP / VIOLATION / n/a)
+    tallies = {s: {OK: 0, GAP: 0, VIOLATION: 0, NA: 0} for s in solver_order}
     for r in rows:
         for s in solver_order:
-            c = r["runs"][s]["correct"]
-            if c is True:
-                tallies[s]["ok"] += 1
-            elif c is False:
-                tallies[s]["wrong"] += 1
+            tallies[s][r["runs"][s]["verdict"]] += 1
 
     lines = [
         "# Global Optimization Benchmark — discopt vs HiGHS / SCIP / Couenne",
@@ -140,24 +140,35 @@ def write_report(
         "",
         "## Correctness summary (vs known optimum)",
         "",
-        "| solver | correct | wrong |",
-        "|---|---|---|",
+        "| verdict | meaning |",
+        "|---|---|",
+        "| `ok` | incumbent matches the known global within tolerance |",
+        "| `GAP` | honest feasible incumbent **worse** than the global — a "
+        "convergence gap in the time budget, *not* a correctness bug |",
+        "| `VIOLATION` | **the red line**: claimed a certified global with the "
+        "wrong value, or returned an incumbent strictly *better* than the proven "
+        "global (impossible → bug) |",
+        "| `n/a` | no oracle, or no incumbent returned |",
+        "",
+        "| solver | ok | GAP | VIOLATION | n/a |",
+        "|---|---|---|---|---|",
     ]
     for s in solver_order:
-        lines.append(f"| {s} | {tallies[s]['ok']}/{n_oracle} | {tallies[s]['wrong']} |")
+        t = tallies[s]
+        lines.append(f"| {s} | {t[OK]}/{n_oracle} | {t[GAP]} | {t[VIOLATION]} | {t[NA]} |")
 
-    # per-instance: obj+correct+time per solver
+    # per-instance: obj+verdict+time per solver
     head = "| instance | known |"
     sep = "|---|---|"
     for s in solver_order:
-        head += f" {s} obj | ? | t |"
+        head += f" {s} obj | v | t |"
         sep += "---|---|---|"
     lines += ["", "## Per-instance results", "", head, sep]
     for r in sorted(rows, key=lambda x: x["instance"]):
         cells = f"| {r['instance']} | {fmt(r['known'])} |"
         for s in solver_order:
             run = r["runs"][s]
-            cells += f" {fmt(run['objective'])} | {tri(run['correct'])} | {run['wall_time']:.2f} |"
+            cells += f" {fmt(run['objective'])} | {run['verdict']} | {run['wall_time']:.2f} |"
         lines.append(cells)
 
     md.write_text("\n".join(lines) + "\n")
@@ -215,24 +226,26 @@ def main() -> int:
     rows: list[dict] = []
     for i, name in enumerate(insts, 1):
         kn = known.get(name)
+        mx = nl_is_maximize(name)
         runs: dict[str, dict] = {}
         d = run_discopt(name, args.time_limit)
-        runs["discopt"] = {**vars(d), "correct": is_correct(d.objective, kn)}
+        runs["discopt"] = {**vars(d), "verdict": classify(d.status, d.objective, kn, mx)}
         for nm in ext_names:
             r = run_external(runner, ext_cfgs[nm], name, args.time_limit)
-            runs[nm] = {**vars(r), "correct": is_correct(r.objective, kn)}
-        rows.append({"instance": name, "known": kn, "runs": runs})
+            runs[nm] = {**vars(r), "verdict": classify(r.status, r.objective, kn, mx)}
+        rows.append({"instance": name, "known": kn, "maximize": mx, "runs": runs})
         cells = " | ".join(
-            f"{s}:{fmt(runs[s]['objective'], 8)} {tri(runs[s]['correct'])} "
-            f"{runs[s]['wall_time']:.1f}s"
+            f"{s}:{fmt(runs[s]['objective'], 8)} {runs[s]['verdict']:9} {runs[s]['wall_time']:.1f}s"
             for s in solver_order
         )
         print(f"[{i:2}/{len(insts)}] {name:20} {cells}", flush=True)
 
     md = write_report(rows, solver_order, args.time_limit, out_dir, ts)
-    wrong = sum(r["runs"]["discopt"]["correct"] is False for r in rows)
-    print(f"\n# DONE. discopt wrong {wrong}. Report: {md}", flush=True)
-    return 1 if wrong else 0
+    # The red line is a VIOLATION (wrong certified value / impossible bound), NOT
+    # an honest GAP (feasible incumbent that simply didn't converge in budget).
+    violations = sum(r["runs"]["discopt"]["verdict"] == VIOLATION for r in rows)
+    print(f"\n# DONE. discopt VIOLATIONS {violations}. Report: {md}", flush=True)
+    return 1 if violations else 0
 
 
 if __name__ == "__main__":

--- a/discopt_benchmarks/tests/test_nl_solvers_verdict.py
+++ b/discopt_benchmarks/tests/test_nl_solvers_verdict.py
@@ -1,0 +1,79 @@
+"""Verdict-honesty tests for the .nl cross-solver head-to-head harness.
+
+The harness used to label *every* objective that didn't equal the known
+optimum as ``VIOLATION`` (a binary correct/wrong flag with no GAP category).
+That conflated honest convergence gaps — a feasible incumbent that simply
+didn't close in the time budget — with the genuine red line: a solver that
+*claims* a certified global at the wrong value, or returns an incumbent
+strictly better than the proven global (an impossible bound).
+
+These tests pin the three-way classification (``ok`` / ``GAP`` / ``VIOLATION``
+/ ``n/a``) so a feasible-but-suboptimal result can never again be reported as a
+correctness violation, while real violations still are.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.global_opt_baron_vs_discopt import GAP, NA, OK, VIOLATION, classify
+from scripts.global_opt_nl_solvers import write_report
+
+pytestmark = pytest.mark.unit
+
+
+def test_feasible_suboptimal_is_gap_not_violation():
+    # discopt returns status=feasible at a worse-than-global value: honest GAP.
+    assert classify("feasible", 6.9358, 5.4709, maximize=False) == GAP
+    assert classify("feasible", 26.4358, 9.1635, maximize=False) == GAP
+
+
+def test_wrong_certified_global_is_violation():
+    # status=optimal asserts a certified global; a wrong value there is the red line.
+    assert classify("optimal", 6.9358, 5.4709, maximize=False) == VIOLATION
+
+
+def test_incumbent_better_than_proven_global_is_violation():
+    # An incumbent strictly *below* the proven min (or above the max) is impossible.
+    assert classify("feasible", 4.0, 5.4709, maximize=False) == VIOLATION
+    assert classify("feasible", 9.0, 5.4709, maximize=True) == VIOLATION
+
+
+def test_matching_optimum_is_ok_and_missing_oracle_is_na():
+    assert classify("optimal", 5.4709, 5.4709, maximize=False) == OK
+    assert classify("feasible", 5.4709, None, maximize=False) == NA
+    assert classify("feasible", None, 5.4709, maximize=False) == NA
+
+
+def test_report_distinguishes_gap_from_violation(tmp_path):
+    """A feasible-but-suboptimal row renders as GAP; the summary counts 0 violations."""
+    rows = [
+        {
+            "instance": "nvs05",
+            "known": 5.4709,
+            "maximize": False,
+            "runs": {
+                "discopt": {
+                    "objective": 6.9358,
+                    "verdict": classify("feasible", 6.9358, 5.4709, False),
+                    "wall_time": 60.5,
+                },
+                "scip": {
+                    "objective": 5.4709,
+                    "verdict": classify("optimal", 5.4709, 5.4709, False),
+                    "wall_time": 1.6,
+                },
+            },
+        }
+    ]
+    md = write_report(rows, ["discopt", "scip"], tl=60, out_dir=tmp_path, ts="T")
+    text = md.read_text()
+    # discopt's honest gap is reported as GAP, not VIOLATION.
+    assert "| discopt | 0/1 | 1 | 0 | 0 |" in text
+    assert "| scip | 1/1 | 0 | 0 | 0 |" in text
+    assert "VIOLATION" in text  # legend still documents the red line


### PR DESCRIPTION
## Summary

The `.nl` cross-solver head-to-head harness labeled **every** objective that did
not equal the known optimum as `"VIOLATION"` — a binary `is_correct`/`tri` flag
with no GAP category and no status/feasibility check. That made honest
convergence gaps on hard nonconvex instances (e.g. `nvs05`, `casctanks`,
`heatexch_gen2`) read as correctness violations, when discopt actually returned
`status=feasible` with a genuinely feasible incumbent (max constraint violation
`1e-8`…`3e-7`, well inside the `1e-4` accept tol) that simply did not close in
the time budget.

Adopt the same three-way classification the sibling BARON harness already uses:

- `ok` — incumbent matches the known global within tolerance
- `GAP` — honest feasible incumbent, worse than the global (a convergence gap, *not* a bug)
- `VIOLATION` — the red line: a *certified* global claim (`status=optimal`) with the wrong value, or an incumbent strictly *better* than the proven global (an impossible bound)
- `n/a` — no oracle or no incumbent

## Verification

Re-checked the three flagged instances: all return feasible incumbents and now
classify as **GAP**; the run reports **0 discopt VIOLATIONS**. Adds 5 unit tests
pinning the GAP-vs-VIOLATION distinction (and confirming genuine false-optimal /
better-than-global cases still classify as VIOLATION) so the harness can't
regress to binary labeling. Lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
