### PR TITLE
fix(solver): make root cut-pool levers real per-call args, not frozen env constants

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1737,11 +1737,16 @@ _STRUCTURE_CUTS_MAX_SIZE = 100
 # (nvs17, 7 vars) the gate that now routes pure-integer nonconvex models onto the
 # McCormick-LP path already certifies via per-node separation (~41s); the
 # inherited pool cuts the node count ~5x but its per-node LP overhead makes
-# wall-clock ~30% worse there. Retained as an opt-in lever
-# (``DISCOPT_ROOT_CUT_ROUNDS=N``) for larger instances where per-node
-# re-separation, not LP size, dominates.
-_ROOT_CUT_POOL_ROUNDS = int(os.environ.get("DISCOPT_ROOT_CUT_ROUNDS", "0"))
-_ROOT_CUT_POOL_MAX = int(os.environ.get("DISCOPT_ROOT_CUT_MAX", "200"))
+# wall-clock ~30% worse there. Retained as an opt-in lever (the ``root_cut_rounds``
+# / ``root_cut_max`` arguments to :func:`solve_model`, defaulting to the
+# ``DISCOPT_ROOT_CUT_ROUNDS`` / ``DISCOPT_ROOT_CUT_MAX`` env vars) for larger
+# instances where per-node re-separation, not LP size, dominates.
+#
+# These env reads are *defaults only*: they are resolved per call inside
+# ``solve_model`` (kwarg wins when given), so unlike module-frozen constants they
+# can be set after ``import discopt`` and differ per Model/per solve.
+_ROOT_CUT_POOL_ROUNDS_ENV = int(os.environ.get("DISCOPT_ROOT_CUT_ROUNDS", "0"))
+_ROOT_CUT_POOL_MAX_ENV = int(os.environ.get("DISCOPT_ROOT_CUT_MAX", "200"))
 
 
 def _apply_auto_cut_policy(model: "Model", relaxer) -> None:
@@ -1922,6 +1927,8 @@ def solve_model(
     subnlp_max_calls: int = 200,
     subnlp_options: Optional[dict] = None,
     structure_cuts: bool = True,
+    root_cut_rounds: Optional[int] = None,
+    root_cut_max: Optional[int] = None,
     **kwargs,
 ) -> SolveResult:
     """
@@ -1989,6 +1996,17 @@ def solve_model(
     partitions : int, default 0
         Number of piecewise McCormick partitions (0 = standard convex
         relaxation, k > 0 = k partitions for tighter relaxations).
+    root_cut_rounds : int, optional
+        Opt-in root PSD cut-pool separation rounds: when > 0 and the relaxer
+        carries PSD cuts, a strong cut pool is separated once at the root box
+        and inherited at every node (sound; never removes a feasible point).
+        ``None`` (default) falls back to the ``DISCOPT_ROOT_CUT_ROUNDS`` env
+        var (default 0 = off). Resolved per call, so it can be set after import
+        and can differ per solve.
+    root_cut_max : int, optional
+        Cap on the number of inherited root-pool cut rows (keeps per-node LP
+        size bounded). ``None`` (default) falls back to ``DISCOPT_ROOT_CUT_MAX``
+        (default 200).
     branching_policy : str, default "fractional"
         Variable selection: ``"fractional"`` (most-fractional, default)
         or ``"gnn"`` (GNN scoring hook; Rust handles actual branching).
@@ -2087,6 +2105,20 @@ def solve_model(
             f"{sorted(_valid_nlp_solvers)}. (The 'ripopt' backend was replaced "
             "by 'pounce', a pure-Rust port of Ipopt.)"
         )
+
+    # Root PSD cut-pool levers: resolve the explicit kwargs against the env-var
+    # defaults (kwarg wins). Threading them here — instead of reading frozen
+    # module constants — means they can be set after ``import discopt`` and can
+    # differ per Model/per solve, while ``DISCOPT_ROOT_CUT_ROUNDS`` /
+    # ``DISCOPT_ROOT_CUT_MAX`` remain as deprecated process-wide defaults.
+    _root_cut_rounds = (
+        _ROOT_CUT_POOL_ROUNDS_ENV if root_cut_rounds is None else int(root_cut_rounds)
+    )
+    _root_cut_max = _ROOT_CUT_POOL_MAX_ENV if root_cut_max is None else int(root_cut_max)
+    if _root_cut_rounds < 0:
+        raise ValueError(f"root_cut_rounds must be >= 0, got {_root_cut_rounds}")
+    if _root_cut_max < 1:
+        raise ValueError(f"root_cut_max must be >= 1, got {_root_cut_max}")
 
     # Anchor the whole-solve clock HERE, before any reformulation / presolve /
     # relaxation-build work — not at the B&B loop entry below. Preprocessing
@@ -3533,7 +3565,7 @@ def solve_model(
                     if not _probe_useful:
                         _mc_lp_relaxer = None
                         _mc_mode = "none"
-                    elif _ROOT_CUT_POOL_ROUNDS > 0 and getattr(_mc_lp_relaxer, "_psd_cuts", False):
+                    elif _root_cut_rounds > 0 and getattr(_mc_lp_relaxer, "_psd_cuts", False):
                         # Root cut pool (P3, opt-in): the relaxer carries PSD cuts, so
                         # separate a strong pool ONCE at the root box (many
                         # rounds, near the Shor SDP bound) and capture its rows.
@@ -3555,7 +3587,7 @@ def solve_model(
                                 _probe_ub,
                                 time_limit=_pool_budget,
                                 out_cuts=_pool_chunks,
-                                psd_max_rounds=_ROOT_CUT_POOL_ROUNDS,
+                                psd_max_rounds=_root_cut_rounds,
                             )
                             if _pool_chunks and _pool_chunks[0] is not None:
                                 # solve_at_node captures each separated chunk as a
@@ -3564,13 +3596,13 @@ def solve_model(
                                 # takes the same (A, b) form.
                                 _A_pool, _b_pool = _pool_chunks[0]
                                 _n_pool = _A_pool.shape[0]
-                                if _n_pool > _ROOT_CUT_POOL_MAX:
+                                if _n_pool > _root_cut_max:
                                     # Keep the last (most-recently separated, i.e.
                                     # deepest-round) rows; they target the tightest
                                     # residual violation. Capping bounds per-node LP
                                     # size so inheritance stays cheap.
-                                    _A_pool = _A_pool[-_ROOT_CUT_POOL_MAX:]
-                                    _b_pool = _b_pool[-_ROOT_CUT_POOL_MAX:]
+                                    _A_pool = _A_pool[-_root_cut_max:]
+                                    _b_pool = _b_pool[-_root_cut_max:]
                                 _root_cut_pool = (_A_pool, _b_pool)
                                 # Keep the strengthened root bound: it is a valid
                                 # global lower bound (the pool relaxation holds over
@@ -3588,7 +3620,7 @@ def solve_model(
                                     "%d rounds), root bound %s — inherited at every node",
                                     _A_pool.shape[0],
                                     _n_pool,
-                                    _ROOT_CUT_POOL_ROUNDS,
+                                    _root_cut_rounds,
                                     f"{_pool_res.lower_bound:.4g}"
                                     if _pool_res is not None and _pool_res.lower_bound is not None
                                     else "n/a",

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -473,7 +473,7 @@ def test_negated_bilinear_two_vars_sound_bound():
 
 
 @pytest.mark.slow
-def test_root_pool_bound_propagates_to_global_bound(monkeypatch):
+def test_root_pool_bound_propagates_to_global_bound():
     """The root cut-pool's strong dual bound must reach the reported global bound.
 
     The pool is separated for its cut rows, which prune child nodes but never lift
@@ -482,16 +482,21 @@ def test_root_pool_bound_propagates_to_global_bound(monkeypatch):
     strengthened root relaxation had already proved a far tighter one (~-1156).
     The fix captures that root bound and adopts it at the exit.
 
+    Engages the pool via the explicit ``root_cut_rounds`` argument (not the
+    ``DISCOPT_ROOT_CUT_ROUNDS`` env var): the env default is resolved at the
+    first solve's lazy ``discopt.solver`` import, so a post-import ``setenv`` is
+    order-dependent — a prior solve in the same process freezes it. The kwarg is
+    per-call and deterministic regardless of import order.
+
     Asserts the two invariants that matter, both robust to machine speed:
       * SOUND — the reported bound never exceeds the true optimum (-1098.4).
       * PROPAGATED — it is far tighter than the cut-less McCormick value, i.e. the
         pool bound actually reached `r.bound` instead of being discarded.
     """
-    monkeypatch.setenv("DISCOPT_ROOT_CUT_ROUNDS", "80")
     nl = _DATA / "nvs19.nl"
     assert nl.exists(), f"missing {nl}"
     m = dm.from_nl(str(nl))
-    r = m.solve(time_limit=25.0)
+    r = m.solve(time_limit=25.0, root_cut_rounds=80)
     assert r.bound is not None and math.isfinite(r.bound), "no dual bound reported"
     # Sound: a valid lower bound for a MINIMIZE never exceeds the optimum.
     assert r.bound <= -1098.4 + 1e-3, f"UNSOUND bound {r.bound} > optimum -1098.4"
@@ -500,3 +505,27 @@ def test_root_pool_bound_propagates_to_global_bound(monkeypatch):
     assert r.bound > -10000.0, (
         f"pool bound did not propagate: r.bound={r.bound} (cut-less McCormick ~ -88237)"
     )
+
+
+def test_root_cut_rounds_kwarg_resolves_and_validates():
+    """The root cut-pool levers are real per-call args, not frozen env constants.
+
+    ``DISCOPT_ROOT_CUT_ROUNDS`` / ``DISCOPT_ROOT_CUT_MAX`` are resolved at the
+    first lazy ``discopt.solver`` import, so a post-import ``setenv`` is a no-op.
+    ``root_cut_rounds`` / ``root_cut_max`` are honoured per call regardless of
+    import order, and out-of-range values are rejected up front.
+    """
+    m = dm.Model("rc")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    m.minimize(x * y + x * x)
+    m.subject_to(x + y >= -1.0)
+
+    # Honoured per call (no env var set in this already-imported process).
+    r = m.solve(time_limit=10.0, root_cut_rounds=2, root_cut_max=50)
+    assert r.objective is not None
+
+    with pytest.raises(ValueError, match="root_cut_rounds must be >= 0"):
+        m.solve(time_limit=2.0, root_cut_rounds=-1)
+    with pytest.raises(ValueError, match="root_cut_max must be >= 1"):
+        m.solve(time_limit=2.0, root_cut_max=0)


### PR DESCRIPTION
## Summary

`DISCOPT_ROOT_CUT_ROUNDS` / `DISCOPT_ROOT_CUT_MAX` were read once into
module-level constants. Because `discopt.solver` is imported **lazily at the
first `Model.solve()`**, that read actually freezes at *first-solve* time — so
setting the env var after import (or after any prior solve in the process) is a
silent no-op, and the behavior is order-dependent across calls/tests. The
cut-pool propagation test only passed because it happened to set the env before
any solve ran.

## Fix

Thread them as explicit `solve_model()` arguments:

- `root_cut_rounds` / `root_cut_max` (`Optional[int]`) flow through `Model.solve(**kwargs)`.
- Resolved per call: the kwarg wins; `None` falls back to the env var, retained
  as a deprecated process-wide default. They can now be set after import and
  differ per Model / per solve.
- Validated up front (`rounds >= 0`, `max >= 1`) instead of failing deep in the relaxer.

## Verification

`nvs19` root bound **−88237 → −1293** via `root_cut_rounds=80` (pool engages
deterministically, no env, regardless of import order). Converts the fragile
propagation test to the kwarg and adds a fast unit test pinning per-call
resolution + validation. Lint + format + mypy clean.

First slice of the broader env-var → typed-option migration (Group B tuning
flags); the operational / GAMS-daemon env vars are intentionally left as env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
