### PR TITLE
feat(solver): typed SolverTuning replaces the algorithmic DISCOPT_* env flags

### DIFF
--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -166,6 +166,9 @@ from discopt.modeling.examples import (
 from discopt.modeling.examples import (
     example_transportation as example_transportation,
 )
+from discopt.solver_tuning import (
+    SolverTuning as SolverTuning,
+)
 
 # Lazy imports for optional modules (avoid import overhead at startup)
 

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -17,7 +17,6 @@ that fits the per-node call shape in :mod:`discopt.solver`.
 from __future__ import annotations
 
 import logging
-import os
 import time
 from dataclasses import dataclass
 from typing import Optional
@@ -35,6 +34,7 @@ from discopt._jax.milp_relaxation import (
 )
 from discopt._jax.term_classifier import NonlinearTerms, classify_nonlinear_terms
 from discopt.modeling.core import Model, VarType
+from discopt.solver_tuning import current as _tuning
 
 logger = logging.getLogger(__name__)
 # Dedup key set so the oversize-lift fallback warns once per (cols, rows) shape.
@@ -257,7 +257,7 @@ class MccormickLPRelaxer:
         # models (e.g. the indefinite integer QPs nvs17/nvs24, whose constraints
         # are all quadratic) from RLT entirely — exactly the dense-QP instances
         # whose McCormick bound is hopelessly loose without it.
-        self._rlt_applicable = (rlt_level1 or os.environ.get("DISCOPT_RLT", "0") == "1") and (
+        self._rlt_applicable = (rlt_level1 or _tuning().rlt) and (
             bool(_linear_constraint_forms(model, self._n_orig))
             or bool(_quadratic_constraint_forms(model, self._n_orig))
         )
@@ -271,7 +271,7 @@ class MccormickLPRelaxer:
         # the outer tree, not redundantly at every node. Set
         # ``DISCOPT_NODE_BOUND_MODE=milp`` to restore the legacy nested-MILP node
         # bound (for A/B comparison).
-        self._lp_node_bound = os.environ.get("DISCOPT_NODE_BOUND_MODE", "lp") == "lp"
+        self._lp_node_bound = _tuning().node_bound_mode == "lp"
         # Per-node lifted-LP FBBT (issue #184): propagate the relaxation's own
         # McCormick rows to recover bilinear-implied factor bounds (e.g. a pinned
         # binary forcing a continuous factor >= 1 *through* a bilinear constraint),
@@ -280,7 +280,7 @@ class MccormickLPRelaxer:
         # dual bound climb off a structural 0 on ``ex1252``. Opt-in via
         # ``DISCOPT_LIFTED_FBBT=1`` — it adds an FBBT sweep plus a conditional
         # relaxation rebuild per node, so it stays off the default B&B path.
-        self._lifted_fbbt = os.environ.get("DISCOPT_LIFTED_FBBT", "0") == "1"
+        self._lifted_fbbt = _tuning().lifted_fbbt
         # Original columns that participate in a nonlinear (product/power) term.
         # A McCormick/RLT envelope for such a term is only valid when its
         # variables have FINITE bounds: over an unbounded box the lifted aux is
@@ -773,9 +773,7 @@ class MccormickLPRelaxer:
         returned bound is always sound; on any failure the input ``res`` is
         returned unchanged.
         """
-        import os
-
-        if os.environ.get("DISCOPT_MULTILINEAR_SEPARATE", "1") == "0":
+        if not _tuning().multilinear_separate:
             return res
         if res is None or res.status != "optimal" or res.x is None:
             return res
@@ -784,7 +782,7 @@ class MccormickLPRelaxer:
 
             from discopt._jax.multilinear_separation import separate_multilinear_envelope
 
-            cap = int(os.environ.get("DISCOPT_MULTILINEAR_RLT_MAX", "4"))
+            cap = _tuning().multilinear_rlt_max
             n_total = len(milp._c)
             # Build (factor-columns, product-column) specs for over-cap products.
             specs: list[tuple[list[int], int]] = []
@@ -867,9 +865,7 @@ class MccormickLPRelaxer:
         so no feasible point is ever cut -- the bound stays sound at any round.
         On any failure the input ``res`` is returned unchanged.
         """
-        import os
-
-        if os.environ.get("DISCOPT_SQUARE_SEPARATE", "1") == "0":
+        if not _tuning().square_separate:
             return res
         if res is None or res.status != "optimal" or res.x is None:
             return res
@@ -1093,9 +1089,7 @@ class MccormickLPRelaxer:
         existing ``x_i^2`` / ``x_i x_j`` auxiliary columns (no lifting). Sound at
         any round; any failure returns the input ``res`` unchanged.
         """
-        import os
-
-        if os.environ.get("DISCOPT_EDGE_CONCAVE", "1") == "0":
+        if not _tuning().edge_concave:
             return res
         if res is None or res.status != "optimal" or res.x is None:
             return res

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import itertools
 import logging
 import math
-import os
 from collections import Counter
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
@@ -68,6 +67,7 @@ from discopt.modeling.core import (
     Variable,
     VarType,
 )
+from discopt.solver_tuning import current as _tuning
 
 logger = logging.getLogger(__name__)
 
@@ -316,7 +316,7 @@ class MilpRelaxationModel:
             backend == "simplex"
             and self._integrality is None
             and self._A_ub is not None
-            and os.environ.get("DISCOPT_LP_WARMSTART", "1") != "0"
+            and _tuning().lp_warmstart
         ):
             warm = self._solve_lp_warm()
             # A warm-start ``infeasible`` on an ill-conditioned LP can be a
@@ -5062,7 +5062,7 @@ def build_milp_relaxation(
         # soundness audit exercises. Selective (only constraints whose variables
         # touch the model's nonlinear support) and capped (bounded new columns) so
         # the LP does not blow up. Disable with ``DISCOPT_RLT_QUAD=0``.
-        if os.environ.get("DISCOPT_RLT_QUAD", "1") != "0":
+        if _tuning().rlt_quad:
             nonconvex_vars: set[int] = set()
             for bi, bj in terms.bilinear:
                 nonconvex_vars.update((bi, bj))
@@ -5073,7 +5073,7 @@ def build_milp_relaxation(
             for mono_idx, _mono_pow in monomial_terms:
                 nonconvex_vars.add(mono_idx)
 
-            _quad_col_cap = int(os.environ.get("DISCOPT_RLT_QUAD_MAX", "256"))
+            _quad_col_cap = _tuning().rlt_quad_max
             _quad_cols_start = col_idx
 
             def _ensure_monomial_aux(i: int, p: int) -> Optional[int]:
@@ -6211,8 +6211,8 @@ def build_milp_relaxation(
     # factors (default 4) to bound the 2^n column/row growth; larger products
     # keep the loose recursive chain.
     rlt_terms: list[tuple[tuple[int, ...], dict[frozenset, int]]] = []
-    if os.environ.get("DISCOPT_TRILINEAR_RLT", "1") != "0":
-        _rlt_cap = int(os.environ.get("DISCOPT_MULTILINEAR_RLT_MAX", "4"))
+    if _tuning().trilinear_rlt:
+        _rlt_cap = _tuning().multilinear_rlt_max
         _candidate_terms = set(trilinear_stage_map.keys()) | set(multilinear_stage_map.keys())
         for _term in _candidate_terms:
             _vars = tuple(sorted(set(_term)))

--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -9,7 +9,6 @@ jax.vmap.
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Callable, Optional
 
 import jax.numpy as jnp
@@ -71,6 +70,7 @@ from discopt.modeling.core import (
     UnaryOp,
     Variable,
 )
+from discopt.solver_tuning import current as _tuning
 
 
 def _compute_var_offset(var: Variable, model: Model) -> int:
@@ -575,7 +575,7 @@ def _compile_relax_node(
             # skips this dispatch and uses the original nested-bilinear
             # path. This is for debug / parity testing only and is not a
             # public API.
-            _trilinear_disabled = os.environ.get("DISCOPT_TRILINEAR") == "nested"
+            _trilinear_disabled = _tuning().trilinear_nested
             tri_offsets = None if _trilinear_disabled else _try_extract_trilinear_chain(expr, model)
             if tri_offsets is not None:
                 from discopt._jax.envelopes import relax_trilinear_exact

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -44,6 +44,7 @@ import numpy as np
 if TYPE_CHECKING:
     from discopt.modeling.indexed import IndexedParam, IndexedVar
     from discopt.modeling.sets import _SetBase
+    from discopt.solver_tuning import SolverTuning
 
 builtins_sum = _builtins.sum
 
@@ -2696,6 +2697,7 @@ class Model:
         solver: Optional[str] = None,
         validate: bool = False,
         gauss_newton: bool = False,
+        tuning: Optional["SolverTuning"] = None,
         **kwargs,
     ) -> Union[SolveResult, Iterator["SolveUpdate"]]:
         r"""
@@ -2785,6 +2787,14 @@ class Model:
             point and attach the :class:`~discopt.validation.ExaminerReport`
             to ``result.validation_report``. Errors during validation are
             swallowed and leave ``validation_report`` as ``None``.
+        tuning : SolverTuning, optional
+            Advanced relaxation / branch-and-bound tuning (RLT families, McCormick
+            separation toggles, node-bound mode, …) as a single typed, validated,
+            per-call object — the supported replacement for the legacy
+            ``DISCOPT_*`` environment variables (which remain as deprecated
+            defaults). ``None`` resolves each field from its env default, exactly
+            reproducing the prior behavior. Example:
+            ``model.solve(tuning=SolverTuning(rlt_quad=False, node_bound_mode="milp"))``.
         gauss_newton : bool, default False
             If True and the objective is a non-negative-weighted sum of squares
             (e.g. ``dm.sum((C @ S - D) ** 2)`` or an explicit
@@ -2867,6 +2877,7 @@ class Model:
                 incumbent_callback=incumbent_callback,
                 node_callback=node_callback,
                 solver=solver,
+                tuning=tuning,
                 **kwargs,
             )
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -14,7 +14,7 @@ import logging
 import math
 import os
 import time
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, cast
 
 import numpy as np
 from scipy.optimize import minimize as scipy_minimize
@@ -1886,13 +1886,20 @@ def _root_relaxation_lower_bound(
     return None
 
 
-def _scoped_tuning(fn):
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def _scoped_tuning(fn: _F) -> _F:
     """Publish the ``tuning`` kwarg as the active :class:`SolverTuning` for the
     call, then restore the previous context. Relaxer read sites consult
     ``solver_tuning.current()`` instead of ``os.environ`` — so the levers are
     per-call and typed. ``tuning=None`` resolves to a fresh env-default instance
     (the prior global behavior), and the reset prevents one solve's overrides from
-    leaking into a later relaxer built outside any solve (e.g. in tests)."""
+    leaking into a later relaxer built outside any solve (e.g. in tests).
+
+    Typed as ``(_F) -> _F`` so the decorated function keeps its original
+    signature/return type for callers and the type checker.
+    """
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
@@ -1902,7 +1909,7 @@ def _scoped_tuning(fn):
         finally:
             _reset_tuning(token)
 
-    return wrapper
+    return cast(_F, wrapper)
 
 
 @_scoped_tuning

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -9,6 +9,7 @@ Connects:
 
 from __future__ import annotations
 
+import functools
 import logging
 import math
 import os
@@ -37,6 +38,9 @@ from discopt.modeling.core import (
     SolveResult,
     VarType,
 )
+from discopt.solver_tuning import current as _tuning
+from discopt.solver_tuning import reset_current as _reset_tuning
+from discopt.solver_tuning import set_current as _set_tuning
 from discopt.solvers import SolveStatus
 
 # ``solve_nlp`` (cyipopt) is imported lazily at its nonlinear-path call site in
@@ -1882,6 +1886,26 @@ def _root_relaxation_lower_bound(
     return None
 
 
+def _scoped_tuning(fn):
+    """Publish the ``tuning`` kwarg as the active :class:`SolverTuning` for the
+    call, then restore the previous context. Relaxer read sites consult
+    ``solver_tuning.current()`` instead of ``os.environ`` — so the levers are
+    per-call and typed. ``tuning=None`` resolves to a fresh env-default instance
+    (the prior global behavior), and the reset prevents one solve's overrides from
+    leaking into a later relaxer built outside any solve (e.g. in tests)."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        token = _set_tuning(kwargs.pop("tuning", None))
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            _reset_tuning(token)
+
+    return wrapper
+
+
+@_scoped_tuning
 def solve_model(
     model: Model,
     time_limit: float = 3600.0,
@@ -3634,7 +3658,7 @@ def solve_model(
     # active it supplies every node's valid dual bound, so the ~2s alpha estimate
     # (and the per-node alphaBB it enables) is skipped. ``DISCOPT_ALPHABB_WITH_LP=1``
     # forces the estimate even under the LP relaxer (A/B / fallback safety).
-    _alphabb_force = os.environ.get("DISCOPT_ALPHABB_WITH_LP", "0") == "1"
+    _alphabb_force = _tuning().alphabb_with_lp
     if _alphabb_eligible and (_mc_lp_relaxer is None or _alphabb_force):
         try:
             from discopt._jax.alphabb import estimate_alpha as _estimate_alpha_jax
@@ -3819,7 +3843,7 @@ def solve_model(
     # structural 0 (see _branch_priority_integer_vars). Empty when disabled or
     # when the model has no such gating integers, leaving branching unchanged.
     _branch_priority_vars: frozenset[int] = frozenset()
-    if os.environ.get("DISCOPT_OBJ_BRANCH_PRIORITY", "0") == "1":
+    if _tuning().obj_branch_priority:
         try:
             _branch_priority_vars = _branch_priority_integer_vars(model)
         except Exception as e:  # pragma: no cover - defensive
@@ -4221,7 +4245,7 @@ def solve_model(
             # plus the strided NLP find incumbents. DISCOPT_NODE_NLP_STRIDE=1
             # restores the per-node NLP. Convex / no-LP-relaxer paths are
             # unaffected (the NLP bound matters there, so it runs every node).
-            _nlp_stride = int(os.environ.get("DISCOPT_NODE_NLP_STRIDE", "4"))
+            _nlp_stride = _tuning().node_nlp_stride
             _gate_node_nlp = _mc_lp_relaxer is not None and not _model_is_convex and _nlp_stride > 1
 
             for i in range(n_batch):

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1,0 +1,169 @@
+"""Typed, per-call solver tuning — the Pythonic replacement for ``DISCOPT_*`` flags.
+
+The spatial-B&B relaxation has a number of advanced tuning levers (RLT families,
+McCormick separation toggles, node-bound mode, …) that were historically read
+straight from ``DISCOPT_*`` environment variables at scattered points inside the
+relaxer. That made them global process state: not per-``Model``, not per-solve,
+not thread-safe, invisible to ``help(model.solve)``, and unvalidated.
+
+:class:`SolverTuning` collects them into one validated, typed object. Each field
+still *defaults* to its ``DISCOPT_*`` env var (read at instantiation, not at
+import — so it is never frozen and an explicit field always wins), so existing
+env-var workflows keep working as deprecated defaults while the object is the
+supported, discoverable surface::
+
+    from discopt import SolverTuning
+    model.solve(tuning=SolverTuning(rlt_quad=False, node_bound_mode="nlp"))
+
+Internally ``solve_model`` resolves the object once and publishes it on a
+:class:`~contextvars.ContextVar`; the relaxer read sites call :func:`current`
+instead of touching ``os.environ``. Outside a solve, :func:`current` falls back
+to a fresh env-resolved instance, so direct relaxer use (e.g. in tests) is
+unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+from contextvars import ContextVar
+from dataclasses import dataclass, field, fields
+
+
+def _env_flag(name: str, *, default: bool) -> bool:
+    """``DISCOPT_<name>`` as a boolean (``"0"`` is false, anything else true)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw != "0"
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    return default if raw is None else int(raw)
+
+
+@dataclass(frozen=True)
+class SolverTuning:
+    """Advanced relaxation / branch-and-bound tuning for :meth:`Model.solve`.
+
+    Every field defaults to its legacy ``DISCOPT_*`` environment variable
+    (resolved when the instance is created), so a bare ``SolverTuning()`` exactly
+    reproduces the env-driven behavior, and any explicitly-set field overrides
+    it. All fields are validated on construction.
+    """
+
+    # --- RLT (reformulation-linearization) families ---------------------------
+    rlt: bool = field(default_factory=lambda: _env_flag("DISCOPT_RLT", default=False))
+    """Legacy whole-relaxation RLT toggle (``DISCOPT_RLT``). The ``rlt=`` argument
+    to :meth:`Model.solve` is the primary control; this OR-s in alongside it."""
+
+    rlt_quad: bool = field(default_factory=lambda: _env_flag("DISCOPT_RLT_QUAD", default=True))
+    """Quadratic RLT row generation (``DISCOPT_RLT_QUAD``, default on)."""
+
+    rlt_quad_max: int = field(default_factory=lambda: _env_int("DISCOPT_RLT_QUAD_MAX", 256))
+    """Column cap for quadratic RLT (``DISCOPT_RLT_QUAD_MAX``, default 256)."""
+
+    multilinear_rlt_max: int = field(
+        default_factory=lambda: _env_int("DISCOPT_MULTILINEAR_RLT_MAX", 4)
+    )
+    """Max arity for multilinear RLT lifting (``DISCOPT_MULTILINEAR_RLT_MAX``)."""
+
+    multilinear_separate: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_MULTILINEAR_SEPARATE", default=True)
+    )
+    """Separate multilinear McCormick cuts (``DISCOPT_MULTILINEAR_SEPARATE``)."""
+
+    trilinear_nested: bool = field(
+        default_factory=lambda: os.environ.get("DISCOPT_TRILINEAR") == "nested"
+    )
+    """Use nested bilinear instead of the tight trilinear envelope
+    (``DISCOPT_TRILINEAR=nested``, default off)."""
+
+    trilinear_rlt: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_TRILINEAR_RLT", default=True)
+    )
+    """Trilinear RLT rows (``DISCOPT_TRILINEAR_RLT``, default on)."""
+
+    # --- McCormick separation toggles -----------------------------------------
+    square_separate: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_SQUARE_SEPARATE", default=True)
+    )
+    """Separate tightened square (``x**2``) cuts (``DISCOPT_SQUARE_SEPARATE``)."""
+
+    edge_concave: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_EDGE_CONCAVE", default=True)
+    )
+    """Edge-concave aggregation cuts (``DISCOPT_EDGE_CONCAVE``, default on)."""
+
+    # --- branch-and-bound / bound levers --------------------------------------
+    alphabb_with_lp: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_ALPHABB_WITH_LP", default=False)
+    )
+    """Force the alpha-BB bound alongside the LP relaxation
+    (``DISCOPT_ALPHABB_WITH_LP``, default off)."""
+
+    lifted_fbbt: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_LIFTED_FBBT", default=False)
+    )
+    """Feasibility-based bound tightening on lifted columns
+    (``DISCOPT_LIFTED_FBBT``, default off)."""
+
+    node_bound_mode: str = field(
+        default_factory=lambda: os.environ.get("DISCOPT_NODE_BOUND_MODE", "lp")
+    )
+    """Per-node dual bound: ``"lp"`` (default, lifted-McCormick LP) or ``"milp"``
+    (legacy nested integer MILP node solve) — ``DISCOPT_NODE_BOUND_MODE``."""
+
+    node_nlp_stride: int = field(default_factory=lambda: _env_int("DISCOPT_NODE_NLP_STRIDE", 4))
+    """Solve the node NLP every k-th node (``DISCOPT_NODE_NLP_STRIDE``, default 4)."""
+
+    obj_branch_priority: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_OBJ_BRANCH_PRIORITY", default=False)
+    )
+    """Prioritize branching on objective-defining variables
+    (``DISCOPT_OBJ_BRANCH_PRIORITY``, default off)."""
+
+    lp_warmstart: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_LP_WARMSTART", default=True)
+    )
+    """Warm-start the node LP from the parent basis (``DISCOPT_LP_WARMSTART``)."""
+
+    def __post_init__(self) -> None:
+        if self.rlt_quad_max < 1:
+            raise ValueError(f"rlt_quad_max must be >= 1, got {self.rlt_quad_max}")
+        if self.multilinear_rlt_max < 1:
+            raise ValueError(f"multilinear_rlt_max must be >= 1, got {self.multilinear_rlt_max}")
+        if self.node_nlp_stride < 1:
+            raise ValueError(f"node_nlp_stride must be >= 1, got {self.node_nlp_stride}")
+        if self.node_bound_mode not in ("lp", "milp"):
+            raise ValueError(
+                f"node_bound_mode must be 'lp' or 'milp', got {self.node_bound_mode!r}"
+            )
+
+    def replace(self, **changes) -> SolverTuning:
+        """Return a copy with ``changes`` applied (validated)."""
+        valid = {f.name for f in fields(self)}
+        bad = set(changes) - valid
+        if bad:
+            raise TypeError(f"unknown SolverTuning field(s): {sorted(bad)}")
+        return SolverTuning(**{**{f.name: getattr(self, f.name) for f in fields(self)}, **changes})
+
+
+# Published for the duration of a solve_model() call; relaxer read sites consult
+# current() instead of os.environ. Default None -> current() reads env fresh.
+_current: ContextVar[SolverTuning | None] = ContextVar("discopt_solver_tuning", default=None)
+
+
+def current() -> SolverTuning:
+    """The active :class:`SolverTuning` (a fresh env-resolved one outside a solve)."""
+    active = _current.get()
+    return active if active is not None else SolverTuning()
+
+
+def set_current(tuning: SolverTuning | None):
+    """Publish ``tuning`` (or a fresh env-resolved one) as active; returns the token."""
+    return _current.set(tuning if tuning is not None else SolverTuning())
+
+
+def reset_current(token) -> None:
+    _current.reset(token)

--- a/python/tests/test_solver_tuning.py
+++ b/python/tests/test_solver_tuning.py
@@ -1,0 +1,165 @@
+"""Tests for :class:`discopt.SolverTuning` — the typed replacement for the
+algorithmic ``DISCOPT_*`` tuning environment variables.
+
+Covers three properties that the old scattered ``os.environ.get`` reads lacked:
+per-call resolution (env is a *default*, resolved at construction, never frozen),
+explicit-field-wins-over-env, and up-front validation. A functional test proves
+the relaxer read sites actually consult the published tuning rather than the
+environment.
+"""
+
+from __future__ import annotations
+
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import discopt.modeling as dm  # noqa: E402
+from discopt import SolverTuning  # noqa: E402
+from discopt.solver_tuning import current, reset_current, set_current  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# env-default resolution (the de-freeze) + explicit override
+# --------------------------------------------------------------------------- #
+def test_defaults_match_legacy_env_defaults():
+    t = SolverTuning()
+    assert t.rlt_quad is True
+    assert t.rlt_quad_max == 256
+    assert t.multilinear_rlt_max == 4
+    assert t.node_bound_mode == "lp"
+    assert t.node_nlp_stride == 4
+    assert t.lp_warmstart is True
+    assert t.rlt is False
+    assert t.lifted_fbbt is False
+    assert t.trilinear_nested is False
+
+
+@pytest.mark.parametrize(
+    "env_name, env_val, field, expected",
+    [
+        ("DISCOPT_RLT_QUAD", "0", "rlt_quad", False),
+        ("DISCOPT_RLT", "1", "rlt", True),
+        ("DISCOPT_LIFTED_FBBT", "1", "lifted_fbbt", True),
+        ("DISCOPT_NODE_BOUND_MODE", "milp", "node_bound_mode", "milp"),
+        ("DISCOPT_NODE_NLP_STRIDE", "2", "node_nlp_stride", 2),
+        ("DISCOPT_RLT_QUAD_MAX", "64", "rlt_quad_max", 64),
+        ("DISCOPT_TRILINEAR", "nested", "trilinear_nested", True),
+        ("DISCOPT_SQUARE_SEPARATE", "0", "square_separate", False),
+        ("DISCOPT_LP_WARMSTART", "0", "lp_warmstart", False),
+    ],
+)
+def test_env_is_resolved_at_construction_not_import(
+    monkeypatch, env_name, env_val, field, expected
+):
+    # setenv happens *after* discopt is imported; the default_factory reads it at
+    # construction, so the value is picked up (the old module-frozen reads could not).
+    monkeypatch.setenv(env_name, env_val)
+    assert getattr(SolverTuning(), field) == expected
+
+
+def test_explicit_field_overrides_env(monkeypatch):
+    monkeypatch.setenv("DISCOPT_RLT_QUAD", "0")
+    monkeypatch.setenv("DISCOPT_NODE_BOUND_MODE", "milp")
+    t = SolverTuning(rlt_quad=True, node_bound_mode="lp")
+    assert t.rlt_quad is True  # explicit beats env
+    assert t.node_bound_mode == "lp"
+
+
+# --------------------------------------------------------------------------- #
+# validation
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        (dict(rlt_quad_max=0), "rlt_quad_max must be >= 1"),
+        (dict(multilinear_rlt_max=0), "multilinear_rlt_max must be >= 1"),
+        (dict(node_nlp_stride=0), "node_nlp_stride must be >= 1"),
+        (dict(node_bound_mode="bogus"), "node_bound_mode must be 'lp' or 'milp'"),
+    ],
+)
+def test_validation_rejects_out_of_range(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        SolverTuning(**kwargs)
+
+
+def test_replace_validates_and_rejects_unknown_field():
+    t = SolverTuning()
+    assert t.replace(rlt_quad=False).rlt_quad is False
+    with pytest.raises(ValueError, match="node_nlp_stride"):
+        t.replace(node_nlp_stride=-1)
+    with pytest.raises(TypeError, match="unknown SolverTuning field"):
+        t.replace(not_a_field=1)
+
+
+def test_is_frozen():
+    t = SolverTuning()
+    with pytest.raises(Exception):  # dataclass(frozen=True) -> FrozenInstanceError
+        t.rlt_quad = False  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# context var publish/reset
+# --------------------------------------------------------------------------- #
+def test_current_outside_scope_is_env_default(monkeypatch):
+    monkeypatch.setenv("DISCOPT_NODE_NLP_STRIDE", "7")
+    assert current().node_nlp_stride == 7  # fresh env-resolved, no scope active
+
+
+def test_set_and_reset_current_round_trip():
+    token = set_current(SolverTuning(node_nlp_stride=9))
+    try:
+        assert current().node_nlp_stride == 9
+    finally:
+        reset_current(token)
+    # back to env default (4) once the scope is reset
+    assert current().node_nlp_stride == 4
+
+
+# --------------------------------------------------------------------------- #
+# functional: the relaxer read sites consult current(), not os.environ
+# --------------------------------------------------------------------------- #
+def test_relaxer_reads_published_tuning():
+    from discopt._jax.mccormick_lp import MccormickLPRelaxer
+
+    m = dm.Model("r")
+    x = m.continuous("x", lb=-1.0, ub=2.0)
+    y = m.continuous("y", lb=-1.0, ub=2.0)
+    m.minimize(x * y)
+    m.subject_to(x + y <= 1.0)
+
+    token = set_current(SolverTuning(node_bound_mode="milp", lifted_fbbt=True))
+    try:
+        relaxer = MccormickLPRelaxer(m)
+        assert relaxer._lp_node_bound is False  # node_bound_mode="milp" -> not LP
+        assert relaxer._lifted_fbbt is True
+    finally:
+        reset_current(token)
+
+
+def test_solve_accepts_tuning_object():
+    m = dm.Model("s")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    m.minimize(x * y + x * x)
+    m.subject_to(x + y >= -1.0)
+    r = m.solve(time_limit=10.0, tuning=SolverTuning(rlt_quad=False, node_nlp_stride=2))
+    assert r.objective is not None
+
+
+def test_solve_does_not_leak_tuning_to_later_relaxer():
+    """A solve's tuning override is scoped to that call — it must not linger and
+    pollute a relaxer built afterwards outside any solve (regression: the publish
+    used to never reset)."""
+    m = dm.Model("leak")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    m.minimize(x * y + x * x)
+    m.subject_to(x + y >= -1.0)
+    m.solve(time_limit=10.0, tuning=SolverTuning(node_bound_mode="milp", lifted_fbbt=True))
+    # Back to env defaults once the solve returns.
+    assert current().node_bound_mode == "lp"
+    assert current().lifted_fbbt is False


### PR DESCRIPTION
## Summary

Finishes the env-var → typed-options migration ("Group B"). The **16 algorithmic
relaxation / branch-and-bound tuning levers** that were read straight from
`DISCOPT_*` environment variables at scattered points in the relaxer (RLT
families, McCormick separation toggles, node-bound mode, node-NLP stride,
objective-branch priority, LP warm-start, …) are promoted into one typed,
validated, **per-call** object: `discopt.SolverTuning`.

### Why
Those env reads were global process state — not per-`Model`, not per-solve, not
thread-safe, invisible to `help(model.solve)`, and unvalidated. (The two
*frozen-at-first-solve* root cut-pool levers were handled in #255.) The
operational / GAMS-daemon env vars and the pure perf-dispatch
`DISCOPT_MCCORMICK_NUMPY_THRESHOLD` intentionally **stay** as env.

### How
- **`SolverTuning`** (frozen dataclass): each field defaults to its legacy
  `DISCOPT_*` var, resolved *at construction* (never frozen at import); explicit
  fields win over env; ranges validated in `__post_init__`.
- Published on a `ContextVar` for the duration of a solve via a `_scoped_tuning`
  decorator on `solve_model` (set on entry, **reset in `finally`** — so one
  solve's overrides never leak into a later relaxer built outside a solve).
- The 16 read sites (`mccormick_lp` / `milp_relaxation` / `relaxation_compiler` /
  `solver`) now call `current().<field>` instead of `os.environ.get(...)`.
- `Model.solve(tuning=...)` accepts the object; `tuning=None` resolves to env
  defaults — exact behavior parity.

```python
from discopt import SolverTuning
model.solve(tuning=SolverTuning(rlt_quad=False, node_bound_mode="milp"))
```

## Verification
- Parity: the existing `DISCOPT_RLT` / `DISCOPT_LIFTED_FBBT` / `DISCOPT_RLT_QUAD`
  monkeypatch tests still pass (env is read at solve time).
- New `test_solver_tuning.py` (22 tests): env-default resolution, explicit
  override, validation, frozen-ness, context publish/reset, a functional check
  that the relaxer consults the published tuning, and a **no-leak** regression.
- ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
