### PR TITLE
ci: single-source-of-truth lint/typecheck via pre-commit (pin mypy 2.1.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,21 +54,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install ruff + mypy + lightweight deps for type resolution
-        run: |
-          python -m pip install --upgrade pip
-          pip install uv
-          # mypy needs the actual numpy/scipy/jax wheels so it can resolve
-          # array-returning functions to concrete types instead of Any.
-          # (Skipping cyipopt/highspy — neither ships type stubs and mypy
-          # treats them as Any either way.)
-          uv pip install --system "ruff==0.14.6" mypy numpy scipy jax jaxlib
-      - name: Ruff check
-        run: ruff check python/
-      - name: Ruff format
-        run: ruff format --check python/
-      - name: Mypy
-        run: mypy python/discopt/
+      # Run the SAME hooks (and the pinned ruff/mypy versions + mypy
+      # type-resolution deps) that developers run locally — .pre-commit-config.yaml
+      # is the single source of truth, so the local and CI toolchains can never
+      # drift. cargo-fmt is skipped here (the Rust job covers fmt; no Rust
+      # toolchain on this runner).
+      - name: pre-commit (ruff, ruff-format, mypy)
+        uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: cargo-fmt
+        with:
+          extra_args: --all-files
 
   python-fast:
     name: Python fast (3.12, ubuntu)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,17 +3,24 @@ repos:
     rev: v0.14.6
     hooks:
       - id: ruff
+        # Scope to the library/tests exactly like CI's `ruff check python/`
+        # (CI runs this hook). Excludes benchmarks, one-off scripts, docs
+        # notebooks, etc. — none of which CI lints today.
         args: [--fix]
-        exclude: ^discopt_benchmarks/
+        files: ^python/
       - id: ruff-format
-        exclude: ^discopt_benchmarks/
+        files: ^python/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v2.1.0
     hooks:
       - id: mypy
+        # Single source of truth for the typecheck: the same mypy version, import
+        # deps, and whole-package scope CI uses (CI runs this very hook). mypy
+        # errors are cross-file, so run on the whole package, not per changed file.
         files: ^python/discopt/
-        additional_dependencies: [numpy, jax]
-        args: [--ignore-missing-imports]
+        pass_filenames: false
+        additional_dependencies: [numpy, scipy, jax, jaxlib]
+        args: [python/discopt/, --ignore-missing-imports]
   - repo: local
     hooks:
       - id: cargo-fmt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,11 @@ dev = [
     "pytest-timeout",
     "pytest-cov",
     "pytest-xdist",
-    "ruff",
-    "mypy",
+    # Pin the lint/typecheck toolchain to the exact versions in
+    # .pre-commit-config.yaml (the single source of truth CI also runs), so a
+    # local `pip install -e .[dev]` cannot drift from CI.
+    "ruff==0.14.6",
+    "mypy==2.1.0",
     "highspy",
     "pre-commit",
 ]


### PR DESCRIPTION
## Problem

Local mypy disagreed with CI mypy (e.g. a `no-any-return` that only CI's mypy
caught). Root cause: **mypy had four uncoordinated version/config sources**, none
authoritative.

| Where | mypy version | resolution deps | scope |
|---|---|---|---|
| `pyproject.toml [dev]` | `"mypy"` — unpinned | dev env | — |
| `.pre-commit-config.yaml` | `v1.13.0` | `[numpy, jax]` | per-changed-file |
| **CI lint job** | unpinned → floated to **2.1.0** | numpy, scipy, jax, jaxlib | whole-package |
| dev's machine | whatever | local | whole-package |

So three independent drift axes — **version**, **import-dep set**, and **scope**
(per-file vs whole-package; cross-file errors only show whole-package). And CI
never ran pre-commit at all — it hand-rolled its own toolchain. (ruff was already
pinned to `0.14.6` everywhere, which is exactly why ruff never surprised us.)

## Fix — one source of truth

- **Pin mypy `v2.1.0`** in pre-commit (matches what CI is green on today); add
  `scipy` + `jaxlib` to the hook deps and run it **whole-package**
  (`pass_filenames: false`, `python/discopt/`) — identical to `mypy python/discopt/`.
- **Scope the ruff hooks to `^python/`** so pre-commit lints exactly what CI does
  (no notebooks / scripts / docs).
- **CI's lint job runs `pre-commit run --all-files`** (skipping `cargo-fmt`, which
  the Rust job covers) instead of installing its own tool versions — local and CI
  toolchains now *physically* cannot drift.
- **Pin `ruff==0.14.6` / `mypy==2.1.0` in `pyproject [dev]`** for installs that
  skip pre-commit.

Verified the pinned ruff + mypy 2.1.0 hooks pass clean whole-package locally.
Future bumps are a one-line `rev:` change (or `pre-commit autoupdate`) that flows
straight to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
