### PR TITLE
feat(solver): auto-engage level-1 RLT on small nonconvex models (closes nvs05 gap)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -203,6 +203,13 @@ _PER_NODE_OBBT_BUDGET_FRAC = 0.6
 _PER_NODE_OBBT_PER_NODE_S = 3.0
 _PER_NODE_OBBT_PER_LP_S = 0.3
 _PER_NODE_OBBT_ROUNDS = 3
+# Auto build-time level-1 RLT gate. ``rlt="auto"`` (the default) leaves build-time
+# level-1 RLT off, but its root-bound tightening certifies several small nonconvex
+# instances the per-node-only policy leaves open (nvs05: a 6.94 incumbent with a
+# 2.02 bound -> certified 5.4709). The constraint×bound product rows make the
+# per-node LP catastrophically slow on large models (casctanks, 500 vars: 359 s
+# for one node), so it is auto-engaged only at or below this lifted-variable count.
+_AUTO_RLT_LEVEL1_MAX_VARS = 50
 # Floor on the time budget handed to the end-of-solve root-relaxation fallback
 # bound (issue #138). On a hard nonconvex minimize the B&B loop can consume the
 # entire `time_limit` and exit uncertified, leaving no time for the rigorous
@@ -3435,6 +3442,15 @@ def solve_model(
         else:  # "auto" (or any unrecognized value) → let the policy decide
             _rlt_on = None
         _eff_rlt_cuts = True if _rlt_on else rlt_cuts
+        # Under "auto", additionally engage build-time level-1 RLT (root-bound
+        # tightening) on small models — it certifies instances the per-node cut
+        # policy alone leaves open (nvs05) at negligible LP cost, while staying off
+        # large models where the product rows blow up the per-node LP (casctanks).
+        # The per-node cut family is untouched (this only adds the root tightening),
+        # and RLT is sound, so this trades bound tightness for size, never
+        # correctness. An explicit rlt=True/False still wins.
+        _auto_rlt_level1 = _rlt_on is None and n_vars <= _AUTO_RLT_LEVEL1_MAX_VARS
+        _eff_rlt_level1 = bool(_rlt_on) or _auto_rlt_level1
 
         # The spatial path needs at least one variable it can branch on: a
         # finite-box continuous variable to bisect, or (issue #194) an integer
@@ -3450,7 +3466,7 @@ def solve_model(
                 superposition=(relaxation_arithmetic == "superposition"),
                 psd_cuts=psd_cuts,
                 rlt_cuts=_eff_rlt_cuts,
-                rlt_level1=bool(_rlt_on),
+                rlt_level1=_eff_rlt_level1,
             )
         except Exception as e:
             logger.warning("McCormick LP relaxer setup failed: %s", e)

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -168,6 +168,24 @@ def test_nvs16_full_solve_does_not_anchor_on_garbage_bound():
     assert r.bound <= 0.703125 + 1e-3, f"unsound bound {r.bound} > optimum 0.703125"
 
 
+@pytest.mark.slow
+def test_nvs05_certifies_under_default_via_auto_rlt():
+    """Build-time level-1 RLT is auto-engaged for *small* nonconvex models under
+    the default ``rlt="auto"`` (gated by ``_AUTO_RLT_LEVEL1_MAX_VARS``). Its
+    root-bound tightening lifts nvs05's bound from the cut-less ~2.02 to the
+    optimum, so nvs05 now certifies under the DEFAULT solve config — previously it
+    stalled at a 6.94 incumbent against a 2.02 bound (a frozen ~63% gap) unless
+    ``rlt=True`` was passed explicitly. Large models stay excluded (the
+    constraint×bound product rows blow up the per-node LP — casctanks, 500 vars)."""
+    m = dm.from_nl(str(_DATA / "nvs05.nl"))
+    r = m.solve(time_limit=60)  # DEFAULT config (no rlt kwarg)
+    assert r.objective is not None and abs(r.objective - 5.4709) < 1e-2
+    assert r.bound is not None and math.isfinite(r.bound)
+    assert r.bound <= 5.4709 + 1e-3, f"unsound bound {r.bound}"
+    # Auto-RLT engaged: the bound is far past the ~2.02 cut-less baseline.
+    assert r.bound >= 5.0, f"auto level-1 RLT did not tighten nvs05's bound: {r.bound}"
+
+
 # Recorded baselines: the standard McCormick root bound (RLT off) for the two
 # bucket-1 instances #175 targets. The tightness lock below guards against
 # silently reverting below these.


### PR DESCRIPTION
## Summary

Closes the first of the three flagged convergence gaps (nvs05) by auto-engaging
**build-time level-1 RLT** on small nonconvex models.

The default `rlt="auto"` deferred only per-node RLT *cuts* to the structure-gated
policy and left build-time level-1 RLT — the constraint×bound product rows that
tighten the **root** bound — off entirely (it engaged only under explicit
`rlt=True`). That left a class of small nonconvex instances stuck: **nvs05**
stalled at a 6.94 incumbent against a **2.02** dual bound (a frozen ~63% gap)
under the default, yet certifies the global optimum **5.4709** the moment
level-1 RLT is on.

## Change

Under `"auto"`, engage level-1 RLT for models at or below
`_AUTO_RLT_LEVEL1_MAX_VARS` (50 lifted variables). The size gate is essential —
the product rows scale as constraints×variables, so on large models the per-node
LP becomes catastrophic (**casctanks**, 500 vars: 359 s for a *single* node). It
only adds the root tightening; the per-node cut family is still chosen by the
auto policy. RLT is sound (a constraint×bound product is `>= 0` at every feasible
point), so this trades bound tightness for relaxation size, never correctness.
An explicit `rlt=True`/`False` still wins.

## Validation

- **nvs05 now certifies** (`optimal`, 5.4709) under the **default** solve — was a frozen gap.
- **casctanks** (500 vars) / **heatexch_gen2** (148 vars) correctly **excluded** by the gate.
- A/B over 17 small instances (default vs `rlt=False`) in **isolated processes**:
  identical certified count (**15/15**), identical total time (**negligible
  overhead**), **0 unsound**. (An apparent slowdown in an earlier same-process
  A/B was a cold-vs-warm JAX-cache artifact, not RLT cost.)
- ruff + mypy clean; adds a slow regression test.

## Note on the other two

casctanks and heatexch_gen2 are genuinely harder (bad incumbent + expensive
500-var nodes; and a missing dual bound, respectively) and do **not** yield to a
single knob — RLT actually makes casctanks worse. Those remain open follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
