### PR TITLE
chore: gitignore solver-written .sol litter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,8 @@ docs/_build/
 
 # DoE demo workbook artifacts
 docs/notebooks/*.xlsx
+
+# Solver-written .sol files (POUNCE / AMPL solvers like couenne/scip write a
+# <stub>.sol next to the input .nl when run over the vendored instance tree).
+# These are run artifacts, never fixtures (0 are tracked) — keep them out.
+*.sol


### PR DESCRIPTION
Solver runs (POUNCE, and AMPL solvers like couenne/scip) write a `<stub>.sol`
next to the input `.nl` over the vendored `python/tests/data/minlplib*/` tree,
leaving stray files (e.g. `st_e31.sol`) in the working tree. None are fixtures —
**0 `.sol` files are tracked** — so this ignores `*.sol` and removes the existing
stray. Keeps `git status` clean after benchmark/solve runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
