### PR TITLE
feat(cli): discopt solve with a warm JAX daemon (timeout + kill + hard-deadline watchdog)

### DIFF
--- a/python/discopt/_daemon_core.py
+++ b/python/discopt/_daemon_core.py
@@ -1,0 +1,341 @@
+"""Generic warm-process solver daemon: protocol, lifecycle, and robustness.
+
+This is the engine shared by the GAMS solver link (:mod:`discopt.gams.daemon`)
+and the general ``discopt solve`` CLI (:mod:`discopt.daemon`). Both keep a single
+long-lived Python+JAX process warm so a solve is a thin socket round-trip instead
+of re-paying the multi-second import + first-JIT warmup every invocation.
+
+The core is solver-agnostic: a :class:`DaemonServer` is parameterized by a
+``solve_fn(request_dict) -> reply_dict`` callback and an env-var ``prefix`` for
+its recycle guards. Everything else -- the length-prefixed JSON-line protocol,
+the per-user unix socket, idle/lifetime/solve-count/RSS recycling, the
+source-fingerprint staleness handshake, stale-socket reaping, and lazy
+auto-spawn with in-process fallback -- is generic and lives here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from discopt import __version__
+
+_CONNECT_TIMEOUT = 5.0
+_SPAWN_WAIT = 30.0
+
+
+def _source_fingerprint() -> str:
+    """A staleness key that changes whenever the installed discopt source changes.
+
+    Returns ``__version__`` plus the newest modification time across the discopt
+    package's Python and compiled-extension files. In a released / site-packages
+    install those mtimes are fixed at install time, so the key is stable and the
+    warm daemon is reused across solves. In an editable / development install,
+    editing any source file (or rebuilding the Rust extension) bumps the max mtime,
+    so a client built from the edited tree no longer matches a daemon spawned
+    *before* the edit -- the solve handshake evicts and respawns it, and the change
+    takes effect on the next solve without a manual ``daemon stop``. Falls back to
+    ``__version__`` alone if the package tree cannot be scanned.
+    """
+    try:
+        import discopt
+
+        root = Path(discopt.__file__).resolve().parent
+        latest = 0
+        for pattern in ("*.py", "*.so", "*.pyd"):
+            for p in root.rglob(pattern):
+                try:
+                    m = p.stat().st_mtime_ns
+                except OSError:
+                    continue
+                if m > latest:
+                    latest = m
+        return f"{__version__}+{latest}" if latest else __version__
+    except Exception:
+        return __version__
+
+
+# Computed once at import. A daemon stamps this as its version when it spawns; a
+# client built from a newer source tree computes a different value and the version
+# handshake recycles the stale daemon (see _source_fingerprint).
+_FINGERPRINT = _source_fingerprint()
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "0").lower() in ("1", "true", "yes", "on")
+
+
+def _resolve(explicit, env_name: str, default, cast):
+    """Pick an explicit arg, else an env override, else a default; ``cast`` typed."""
+    if explicit is not None:
+        return cast(explicit)
+    raw = os.environ.get(env_name)
+    if raw is not None:
+        return cast(raw)
+    return cast(default)
+
+
+def _current_rss_mb() -> float:
+    """Resident set size of this process in MiB (peak; monotonic, no psutil dep)."""
+    import resource
+
+    kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # Linux reports KiB; macOS reports bytes.
+    return kb / (1024 * 1024) if sys.platform == "darwin" else kb / 1024
+
+
+def _clear_jax_caches() -> None:
+    """Drop JAX's compilation caches if (and only if) JAX is loaded."""
+    mod = sys.modules.get("jax")
+    if mod is not None:
+        try:
+            mod.clear_caches()
+        except Exception:
+            pass
+
+
+def socket_path_for(env_var: str, basename: str) -> Path:
+    """Per-user socket path, honouring ``env_var`` then ``XDG_RUNTIME_DIR``/``TMPDIR``."""
+    explicit = os.environ.get(env_var)
+    if explicit:
+        return Path(explicit)
+    runtime = os.environ.get("XDG_RUNTIME_DIR")
+    base = Path(runtime) if runtime else Path(os.environ.get("TMPDIR", "/tmp"))
+    return base / f"{basename}-{os.getuid()}.sock"
+
+
+def _pid_path(socket_path: Path) -> Path:
+    return socket_path.with_suffix(socket_path.suffix + ".pid")
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _recv_line(conn: socket.socket) -> bytes:
+    chunks: list[bytes] = []
+    while True:
+        b = conn.recv(65536)
+        if not b:
+            break
+        chunks.append(b)
+        if b.endswith(b"\n"):
+            break
+    return b"".join(chunks)
+
+
+# ── Server ───────────────────────────────────────────────────────────────────
+class DaemonServer:
+    """A warm, single-request-at-a-time solver server over a unix socket.
+
+    ``solve_fn`` receives the full request dict (``cmd == "solve"``) and returns
+    the reply payload dict to send back -- so a caller can return a rich result,
+    not just an exit code. ``env_prefix`` selects which ``<PREFIX>_*`` env vars
+    drive the recycle guards (e.g. ``DISCOPT_GAMS`` vs ``DISCOPT_SOLVE``).
+    """
+
+    def __init__(
+        self,
+        socket_path: Path,
+        solve_fn: Callable[[dict], dict],
+        *,
+        env_prefix: str,
+        version: str = _FINGERPRINT,
+        idle_timeout: float | None = None,
+        max_lifetime: float | None = None,
+        max_solves: int | None = None,
+        max_rss_mb: int | None = None,
+        jax_clear_every: int | None = None,
+    ):
+        # The benchmark preset disables count/age recycling by default so one warm
+        # daemon spans a whole study (an RSS ceiling remains the backstop).
+        bench = _env_flag(f"{env_prefix}_BENCHMARK")
+        self.socket_path = Path(socket_path)
+        self._solve_fn = solve_fn
+        # 0 / negative means "no limit" for every guard below.
+        self.idle_timeout = _resolve(
+            idle_timeout, f"{env_prefix}_IDLE_TIMEOUT", 1800 if bench else 600, float
+        )
+        self.max_lifetime = _resolve(
+            max_lifetime, f"{env_prefix}_MAX_LIFETIME", 0 if bench else 3600, float
+        )
+        self.max_solves = _resolve(max_solves, f"{env_prefix}_MAX_SOLVES", 0 if bench else 500, int)
+        self.max_rss_mb = _resolve(max_rss_mb, f"{env_prefix}_MAX_RSS_MB", 0, int)
+        self.jax_clear_every = _resolve(jax_clear_every, f"{env_prefix}_JAX_CLEAR_EVERY", 0, int)
+        self.version = version
+        self.solves = 0
+        self._sock: socket.socket | None = None
+
+    def _bind(self) -> None:
+        # Remove a stale socket from a dead daemon before binding.
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+        self.socket_path.parent.mkdir(parents=True, exist_ok=True)
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.bind(str(self.socket_path))
+        os.chmod(self.socket_path, 0o600)
+        s.listen(16)
+        self._sock = s
+        _pid_path(self.socket_path).write_text(str(os.getpid()))
+
+    def serve_forever(self) -> None:
+        """Accept and service requests until a shutdown condition fires."""
+        self._bind()
+        started = time.monotonic()
+        try:
+            while True:
+                assert self._sock is not None
+                # idle_timeout <= 0 means block indefinitely (no idle shutdown).
+                self._sock.settimeout(self.idle_timeout if self.idle_timeout > 0 else None)
+                try:
+                    conn, _ = self._sock.accept()
+                except socket.timeout:
+                    break  # idle timeout
+                before = self.solves
+                with conn:
+                    stop = self._handle(conn)
+                did_solve = self.solves > before
+                # Recycle guards are evaluated only after an actual solve, so
+                # pings/stops never trip them. A purely idle daemon exits via the
+                # accept() idle timeout instead.
+                if (
+                    did_solve
+                    and self.jax_clear_every > 0
+                    and (self.solves % self.jax_clear_every == 0)
+                ):
+                    _clear_jax_caches()
+                if stop:
+                    break
+                if did_solve:
+                    if self.max_solves > 0 and self.solves >= self.max_solves:
+                        break
+                    if self.max_lifetime > 0 and time.monotonic() - started >= self.max_lifetime:
+                        break
+                    if self.max_rss_mb > 0 and _current_rss_mb() >= self.max_rss_mb:
+                        break
+        finally:
+            self._cleanup()
+
+    def _handle(self, conn: socket.socket) -> bool:
+        """Service one request. Returns True if the daemon should stop."""
+        try:
+            req = json.loads(_recv_line(conn).decode() or "{}")
+        except (ValueError, OSError):
+            self._reply(conn, {"ok": False, "error": "bad request"})
+            return False
+
+        cmd = req.get("cmd")
+        if cmd == "ping":
+            self._reply(conn, {"ok": True, "version": self.version})
+            return False
+        if cmd == "stop":
+            self._reply(conn, {"ok": True})
+            return True
+        if cmd == "solve":
+            # A client built against a different discopt evicts the daemon so the
+            # upgrade takes effect; it serves this request first.
+            stop = req.get("version") not in (None, self.version)
+            try:
+                reply = self._solve_fn(req)
+            except Exception as exc:  # never let one model take the daemon down
+                reply = {"ok": False, "error": repr(exc)}
+            self._reply(conn, reply)
+            self.solves += 1
+            return stop
+        self._reply(conn, {"ok": False, "error": f"unknown cmd {cmd!r}"})
+        return False
+
+    @staticmethod
+    def _reply(conn: socket.socket, payload: dict) -> None:
+        try:
+            conn.sendall((json.dumps(payload) + "\n").encode())
+        except OSError:
+            pass
+
+    def _cleanup(self) -> None:
+        if self._sock is not None:
+            self._sock.close()
+        for p in (self.socket_path, _pid_path(self.socket_path)):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+
+# ── Client ───────────────────────────────────────────────────────────────────
+def request(socket_path: Path, payload: dict, timeout: float = _CONNECT_TIMEOUT) -> dict | None:
+    """Send one request to a daemon socket, return its reply (or ``None``)."""
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.settimeout(timeout)
+            s.connect(str(socket_path))
+            s.sendall((json.dumps(payload) + "\n").encode())
+            s.settimeout(None)  # the solve itself may take a while
+            data = _recv_line(s)
+        return json.loads(data.decode()) if data else None
+    except (OSError, ValueError):
+        return None
+
+
+def ping(socket_path: Path) -> dict | None:
+    """Return the running daemon's handshake, or ``None`` if not reachable."""
+    return request(socket_path, {"cmd": "ping"})
+
+
+def stop_daemon(socket_path: Path) -> bool:
+    """Ask a running daemon to shut down. Returns True if it acknowledged."""
+    resp = request(socket_path, {"cmd": "stop"})
+    return bool(resp and resp.get("ok"))
+
+
+def _reap_stale(socket_path: Path) -> None:
+    """Remove a socket/pid left behind by a dead daemon."""
+    pid_file = _pid_path(socket_path)
+    try:
+        pid = int(pid_file.read_text())
+    except (OSError, ValueError):
+        pid = None
+    if pid is not None and _pid_alive(pid):
+        return  # a live daemon owns it
+    for p in (socket_path, pid_file):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+
+
+def spawn_daemon(
+    socket_path: Path, module: str, socket_env: str, wait: float = _SPAWN_WAIT
+) -> bool:
+    """Start a detached ``python -m <module> serve`` daemon; wait for its socket."""
+    _reap_stale(socket_path)
+    env = dict(os.environ, **{socket_env: str(socket_path)})
+    try:
+        subprocess.Popen(
+            [sys.executable, "-m", module, "serve"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # outlive the launching client
+            env=env,
+        )
+    except OSError:
+        return False
+    deadline = time.monotonic() + wait
+    while time.monotonic() < deadline:
+        if ping(socket_path):
+            return True
+        time.sleep(0.05)
+    return False

--- a/python/discopt/_daemon_core.py
+++ b/python/discopt/_daemon_core.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -275,16 +276,40 @@ class DaemonServer:
 
 
 # ── Client ───────────────────────────────────────────────────────────────────
-def request(socket_path: Path, payload: dict, timeout: float = _CONNECT_TIMEOUT) -> dict | None:
-    """Send one request to a daemon socket, return its reply (or ``None``)."""
+class SolveTimeout(Exception):
+    """The daemon accepted a request but did not reply within ``recv_timeout`` --
+    a wedged or runaway solve. The caller should kill and recycle the daemon
+    rather than wait forever (a single-threaded daemon serves one solve at a time,
+    so one hang blocks every other client too)."""
+
+
+def request(
+    socket_path: Path,
+    payload: dict,
+    timeout: float = _CONNECT_TIMEOUT,
+    recv_timeout: float | None = None,
+) -> dict | None:
+    """Send one request to a daemon socket, return its reply (or ``None``).
+
+    ``timeout`` bounds the connect (so an absent daemon returns ``None`` fast).
+    ``recv_timeout`` bounds the wait for the reply *after* sending: ``None`` (the
+    default, used by fast ping/stop) blocks indefinitely; a value raises
+    :class:`SolveTimeout` if no reply arrives in time -- distinct from an
+    unreachable daemon -- so a stuck solve can be killed instead of hanging.
+    """
     try:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
             s.settimeout(timeout)
             s.connect(str(socket_path))
             s.sendall((json.dumps(payload) + "\n").encode())
-            s.settimeout(None)  # the solve itself may take a while
-            data = _recv_line(s)
+            s.settimeout(recv_timeout)  # None -> block; else bound the solve wait
+            try:
+                data = _recv_line(s)
+            except socket.timeout:
+                raise SolveTimeout() from None
         return json.loads(data.decode()) if data else None
+    except SolveTimeout:
+        raise
     except (OSError, ValueError):
         return None
 
@@ -295,9 +320,48 @@ def ping(socket_path: Path) -> dict | None:
 
 
 def stop_daemon(socket_path: Path) -> bool:
-    """Ask a running daemon to shut down. Returns True if it acknowledged."""
+    """Ask a running daemon to shut down. Returns True if it acknowledged.
+
+    Graceful but cooperative: a daemon wedged in a solve is not accepting
+    connections and will not hear this. Use :func:`kill_daemon` for that case.
+    """
     resp = request(socket_path, {"cmd": "stop"})
     return bool(resp and resp.get("ok"))
+
+
+def kill_daemon(socket_path: Path) -> bool:
+    """Forcibly terminate a daemon by its PID file (SIGTERM, then SIGKILL).
+
+    Works when the daemon is wedged in a runaway solve and cannot answer
+    :func:`stop`. Reaps the socket/PID files afterward. Returns True if a live
+    process was signalled.
+    """
+    pid_file = _pid_path(socket_path)
+    try:
+        pid = int(pid_file.read_text())
+    except (OSError, ValueError):
+        pid = None
+    killed = False
+    if pid is not None and _pid_alive(pid):
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and _pid_alive(pid):
+            time.sleep(0.05)
+        if _pid_alive(pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+        killed = True
+    for p in (socket_path, pid_file):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+    return killed
 
 
 def _reap_stale(socket_path: Path) -> None:

--- a/python/discopt/_daemon_core.py
+++ b/python/discopt/_daemon_core.py
@@ -125,6 +125,54 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
+class _DeadlineWatchdog:
+    """Fork a child that ``SIGKILL``s *this* process after ``deadline`` seconds
+    unless cancelled. The killer is a separate process, so it stops even a solve
+    wedged deep in a C extension (XLA / Rust) that no in-process signal or thread
+    could interrupt -- making the deadline hard and independent of the solver.
+
+    The child only sleeps, checks parentage, and kills (no JAX/locks touched), so
+    forking it from the warm JAX process is safe. On normal completion the daemon
+    cancels it (``__exit__``); on overrun the child kills the daemon, its socket
+    drops, and the client falls back. ``deadline <= 0`` (or no ``os.fork``) is a
+    no-op -- the default, so there is no hard limit unless one is requested.
+    """
+
+    def __init__(self, deadline: float):
+        self.deadline = float(deadline)
+        self.pid: int | None = None
+
+    def __enter__(self) -> "_DeadlineWatchdog":
+        if self.deadline <= 0 or not hasattr(os, "fork"):
+            return self
+        parent = os.getpid()
+        pid = os.fork()
+        if pid == 0:  # watchdog child
+            try:
+                time.sleep(self.deadline)
+                # Guard against PID reuse: only kill if the daemon is still our
+                # parent (if it already exited we were reparented away from it).
+                if os.getppid() == parent:
+                    os.kill(parent, signal.SIGKILL)
+            except BaseException:
+                pass
+            finally:
+                os._exit(0)
+        self.pid = pid
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self.pid:
+            try:
+                os.kill(self.pid, signal.SIGKILL)
+            except OSError:
+                pass
+            try:
+                os.waitpid(self.pid, 0)
+            except OSError:
+                pass
+
+
 def _recv_line(conn: socket.socket) -> bytes:
     chunks: list[bytes] = []
     while True:
@@ -248,8 +296,16 @@ class DaemonServer:
             # A client built against a different discopt evicts the daemon so the
             # upgrade takes effect; it serves this request first.
             stop = req.get("version") not in (None, self.version)
+            # Optional daemon-side hard deadline (default: none -> no limit). A
+            # forked watchdog SIGKILLs the daemon if this solve overruns, enforcing
+            # the limit independently of the solver AND of any waiting client.
             try:
-                reply = self._solve_fn(req)
+                deadline = float(req.get("hard_deadline") or 0.0)
+            except (TypeError, ValueError):
+                deadline = 0.0
+            try:
+                with _DeadlineWatchdog(deadline):
+                    reply = self._solve_fn(req)
             except Exception as exc:  # never let one model take the daemon down
                 reply = {"ok": False, "error": repr(exc)}
             self._reply(conn, reply)

--- a/python/discopt/cli.py
+++ b/python/discopt/cli.py
@@ -528,7 +528,9 @@ def main():
         help="Control the warm discopt solve daemon (serve/stop/status)",
     )
     p_daemon.add_argument(
-        "action", choices=["serve", "stop", "status"], help="serve (foreground), stop, or status."
+        "action",
+        choices=["serve", "stop", "kill", "status"],
+        help="serve (foreground), stop (graceful), kill (force, for a wedged daemon), or status.",
     )
     p_daemon.set_defaults(func=_cmd_daemon)
 
@@ -538,8 +540,8 @@ def main():
     )
     p_gamsd.add_argument(
         "action",
-        choices=["serve", "stop", "status"],
-        help="serve (run in foreground), stop, or status.",
+        choices=["serve", "stop", "kill", "status"],
+        help="serve (run in foreground), stop, kill (force), or status.",
     )
     p_gamsd.set_defaults(func=_cmd_gams_daemon)
 

--- a/python/discopt/cli.py
+++ b/python/discopt/cli.py
@@ -410,7 +410,7 @@ def _cmd_solve(args):
     if not args.no_daemon:
         from discopt import daemon
 
-        resp = daemon.solve_via_daemon(nl, payload)
+        resp = daemon.solve_via_daemon(nl, payload, hard_deadline=args.hard_timeout)
         if resp is not None:
             if not resp.get("ok"):
                 print(f"Error (daemon): {resp.get('error')}", file=sys.stderr)
@@ -513,6 +513,14 @@ def main():
     )
     p_solve.add_argument(
         "--no-daemon", action="store_true", help="Solve in-process (do not use the daemon)."
+    )
+    p_solve.add_argument(
+        "--hard-timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="Daemon-side hard wall: the daemon SIGKILLs itself if this solve "
+        "overruns (enforced independently of the solver/client). Default: no limit.",
     )
     p_solve.add_argument(
         "--format", default="text", choices=["text", "json"], help="Stdout format (default text)."

--- a/python/discopt/cli.py
+++ b/python/discopt/cli.py
@@ -3,6 +3,8 @@
 Usage:
     discopt about
     discopt test
+    discopt solve model.nl [--profile NAME] [--time-limit S] [--json] [--sol] ...
+    discopt daemon {serve|stop|status}    # warm solve daemon (auto-spawned by solve)
     discopt convert input.gms output.nl
     discopt install-skills [--project-scope] [--dev] [--force]
     discopt tutor [list|start|resume|next|reset|install] ...
@@ -299,6 +301,154 @@ def _cmd_install_skills(args):
         print(f"  {verb_counts['skip']} already existed; pass --force to overwrite.")
 
 
+def _cmd_daemon(args):
+    """Control the warm ``discopt solve`` daemon (serve/stop/status)."""
+    from discopt import daemon
+
+    return daemon.main([args.action])
+
+
+def _coerce_tuning_value(s: str, type_hint):
+    """Coerce a ``--tuning key=value`` string by a SolverTuning field's type."""
+    name = type_hint if isinstance(type_hint, str) else getattr(type_hint, "__name__", "str")
+    if name == "bool":
+        low = s.lower()
+        if low in ("true", "1", "yes", "on"):
+            return True
+        if low in ("false", "0", "no", "off"):
+            return False
+        raise ValueError(f"expected a boolean, got {s!r}")
+    if name == "int":
+        return int(s)
+    if name == "float":
+        return float(s)
+    return s
+
+
+def _parse_tuning(pairs):
+    """``["key=val", ...]`` -> dict, validated/coerced against SolverTuning fields."""
+    import dataclasses
+
+    from discopt.solver_tuning import SolverTuning
+
+    types = {f.name: f.type for f in dataclasses.fields(SolverTuning)}
+    out = {}
+    for p in pairs or []:
+        if "=" not in p:
+            print(f"Error: --tuning expects key=value, got {p!r}", file=sys.stderr)
+            sys.exit(2)
+        k, v = p.split("=", 1)
+        k = k.strip()
+        if k not in types:
+            print(f"Error: unknown tuning field {k!r}; valid: {sorted(types)}", file=sys.stderr)
+            sys.exit(2)
+        try:
+            out[k] = _coerce_tuning_value(v.strip(), types[k])
+        except ValueError as exc:
+            print(f"Error: --tuning {k}: {exc}", file=sys.stderr)
+            sys.exit(2)
+    return out
+
+
+def _cmd_solve(args):
+    """Solve a ``.nl`` model, warm-routed through the solve daemon when available."""
+    import json
+
+    nl = os.path.abspath(args.file)
+    if not os.path.exists(nl):
+        print(f"Error: no such file: {args.file}", file=sys.stderr)
+        sys.exit(1)
+    if os.path.splitext(nl)[1].lower() != ".nl":
+        print(f"Error: discopt solve expects a .nl file, got {args.file!r}", file=sys.stderr)
+        sys.exit(1)
+
+    # Only the flags the user explicitly set become overrides (so a profile's
+    # values are not clobbered by argparse defaults). CLI > profile > defaults.
+    overrides = {}
+    if args.time_limit is not None:
+        overrides["time_limit"] = args.time_limit
+    if args.gap is not None:
+        overrides["gap_tolerance"] = args.gap
+    if args.threads is not None:
+        overrides["threads"] = args.threads
+    if args.solver is not None:
+        overrides["solver"] = args.solver
+    if args.partitions is not None:
+        overrides["partitions"] = args.partitions
+    if args.branching_policy is not None:
+        overrides["branching_policy"] = args.branching_policy
+    if args.rlt is not None:
+        overrides["rlt"] = args.rlt
+    if args.nlp_bb is not None:
+        overrides["nlp_bb"] = args.nlp_bb
+    tuning = _parse_tuning(args.tuning)
+    if tuning:
+        overrides["tuning"] = tuning
+
+    from discopt.profiles import resolve_options
+
+    try:
+        options = resolve_options(args.profile, overrides)
+    except KeyError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    from discopt.result_io import (
+        deserialize_result,
+        options_from_payload,
+        options_to_payload,
+        serialize_result,
+        summary_text,
+        write_json,
+        write_sol,
+    )
+
+    payload = options_to_payload(options)
+
+    # Solve: warm daemon when available, in-process fallback otherwise.
+    result = None
+    if not args.no_daemon:
+        from discopt import daemon
+
+        resp = daemon.solve_via_daemon(nl, payload)
+        if resp is not None:
+            if not resp.get("ok"):
+                print(f"Error (daemon): {resp.get('error')}", file=sys.stderr)
+                sys.exit(1)
+            result = deserialize_result(resp["result"])
+    if result is None:
+        if not args.no_daemon and not args.quiet:
+            print("daemon unavailable; solving in-process", file=sys.stderr)
+        from discopt.modeling.core import from_nl
+
+        result = from_nl(nl).solve(**options_from_payload(payload))
+
+    # Outputs: stdout by default; files only when explicitly requested.
+    stub = os.path.splitext(os.path.basename(nl))[0]
+    base_dir = Path(args.out_dir) if args.out_dir else Path(os.path.dirname(nl) or ".")
+    wrote = []
+    if args.json:
+        p = base_dir / f"{stub}.result.json"
+        write_json(result, p)
+        wrote.append(str(p))
+    if args.sol:
+        from discopt.modeling.core import from_nl
+
+        var_names = [v.name for v in from_nl(nl)._variables]
+        p = base_dir / f"{stub}.sol"
+        write_sol(result, var_names, p)
+        wrote.append(str(p))
+
+    if args.format == "json":
+        print(json.dumps(serialize_result(result), indent=2))
+    elif not args.quiet:
+        print(summary_text(result))
+    for w in wrote:
+        print(f"-> wrote {w}", file=sys.stderr)
+
+    sys.exit(0 if result.status in ("optimal", "feasible") else 1)
+
+
 def main():
     parser = argparse.ArgumentParser(prog="discopt", description="discopt CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -333,6 +483,54 @@ def main():
         help="Only run the gamsapi diagnostic; do not write any files.",
     )
     p_gams.set_defaults(func=_cmd_gams_register)
+
+    p_solve = subparsers.add_parser(
+        "solve",
+        help="Solve a .nl model (warm-routed through the solve daemon)",
+    )
+    p_solve.add_argument("file", help="Input model file (.nl)")
+    p_solve.add_argument("--profile", default=None, help="Named option profile (e.g. fast, exact).")
+    p_solve.add_argument("--time-limit", type=float, default=None, help="Wall-clock limit (s).")
+    p_solve.add_argument("--gap", type=float, default=None, help="Relative optimality gap tol.")
+    p_solve.add_argument("--threads", type=int, default=None, help="Rust threads.")
+    p_solve.add_argument("--solver", default=None, help="Backend selector (e.g. amp, gp).")
+    p_solve.add_argument("--partitions", type=int, default=None, help="McCormick partitions.")
+    p_solve.add_argument(
+        "--branching-policy",
+        default=None,
+        choices=["fractional", "gnn"],
+        help="Variable selection.",
+    )
+    p_solve.add_argument("--rlt", default=None, choices=["auto", "on", "off"], help="RLT control.")
+    p_solve.add_argument(
+        "--nlp-bb", action=argparse.BooleanOptionalAction, default=None, help="Force NLP-BB on/off."
+    )
+    p_solve.add_argument(
+        "--tuning",
+        action="append",
+        metavar="KEY=VAL",
+        help="SolverTuning field override (repeatable), e.g. --tuning rlt_quad=false.",
+    )
+    p_solve.add_argument(
+        "--no-daemon", action="store_true", help="Solve in-process (do not use the daemon)."
+    )
+    p_solve.add_argument(
+        "--format", default="text", choices=["text", "json"], help="Stdout format (default text)."
+    )
+    p_solve.add_argument("--json", action="store_true", help="Write <stub>.result.json.")
+    p_solve.add_argument("--sol", action="store_true", help="Write an AMPL-style <stub>.sol.")
+    p_solve.add_argument("--out-dir", default=None, help="Directory for --json/--sol output.")
+    p_solve.add_argument("--quiet", action="store_true", help="Suppress the stdout summary.")
+    p_solve.set_defaults(func=_cmd_solve)
+
+    p_daemon = subparsers.add_parser(
+        "daemon",
+        help="Control the warm discopt solve daemon (serve/stop/status)",
+    )
+    p_daemon.add_argument(
+        "action", choices=["serve", "stop", "status"], help="serve (foreground), stop, or status."
+    )
+    p_daemon.set_defaults(func=_cmd_daemon)
 
     p_gamsd = subparsers.add_parser(
         "gams-daemon",
@@ -375,13 +573,20 @@ def main():
     )
     p_skills.set_defaults(func=_cmd_install_skills)
 
-    from discopt.tutor import add_subparser as _add_tutor_subparser
+    # The tutor and (especially) DOE subparsers pull heavy optional deps
+    # (``discopt.doe.cli`` ~0.4 s: streamlit/pandas), so register them lazily --
+    # only for their own command or when full help is requested. This keeps every
+    # other command (notably ``discopt solve``) at the light CLI floor.
+    _argv1 = sys.argv[1] if len(sys.argv) > 1 else None
+    _want_all = _argv1 in (None, "help", "-h", "--help")
+    if _want_all or _argv1 == "tutor":
+        from discopt.tutor import add_subparser as _add_tutor_subparser
 
-    _add_tutor_subparser(subparsers)
+        _add_tutor_subparser(subparsers)
+    if _want_all or _argv1 == "doe":
+        from discopt.doe.cli import add_subparser as _add_doe_subparser
 
-    from discopt.doe.cli import add_subparser as _add_doe_subparser
-
-    _add_doe_subparser(subparsers)
+        _add_doe_subparser(subparsers)
 
     p_help = subparsers.add_parser("help", help="Show this help message and exit")
     p_help.set_defaults(func=lambda _args: parser.print_help())

--- a/python/discopt/daemon.py
+++ b/python/discopt/daemon.py
@@ -126,7 +126,10 @@ def _recv_timeout_for(options: dict | None) -> float:
 
 
 def solve_via_daemon(
-    nl_file: str, options: dict | None = None, socket_path: Path | None = None
+    nl_file: str,
+    options: dict | None = None,
+    socket_path: Path | None = None,
+    hard_deadline: float | None = None,
 ) -> dict | None:
     """Solve ``nl_file`` through the warm daemon, spawning it if needed.
 
@@ -136,6 +139,11 @@ def solve_via_daemon(
     runaway solve past ``time_limit + grace`` -- in which case it is killed and the
     caller falls back to an in-process solve, so one stuck model can never block a
     run.
+
+    ``hard_deadline`` (seconds, default ``None`` = no limit) additionally asks the
+    *daemon* to fork a watchdog that ``SIGKILL``s itself if this solve overruns,
+    enforcing the limit even with no client waiting (orphaned worker) and even for
+    a solver wedged in a C extension.
     """
     path = socket_path or default_socket_path()
     recv_timeout = _recv_timeout_for(options)
@@ -153,12 +161,17 @@ def solve_via_daemon(
     if info is not None and info.get("version") not in (None, _FINGERPRINT):
         stop_daemon(path)
         spawn_daemon(path)
-    payload = {
+    payload: dict[str, object] = {
         "cmd": "solve",
         "nl_file": nl_file,
         "options": options or {},
         "version": _FINGERPRINT,
     }
+    if hard_deadline is not None and hard_deadline > 0:
+        payload["hard_deadline"] = float(hard_deadline)
+        # The client must wait at least as long as the daemon's own deadline,
+        # else the client would give up (and kill) before the watchdog fires.
+        recv_timeout = max(recv_timeout, float(hard_deadline) + 5.0)
     try:
         resp = _request(path, payload, recv_timeout=recv_timeout)
     except SolveTimeout:

--- a/python/discopt/daemon.py
+++ b/python/discopt/daemon.py
@@ -1,0 +1,158 @@
+"""Warm ``discopt solve`` daemon.
+
+Keeps a single long-lived Python+JAX process warm so ``discopt solve <file.nl>``
+is a thin socket round-trip (~0.1 s) instead of re-paying the ~1 s JAX backend
+init + tracing on every invocation. The generic protocol / lifecycle / robustness
+engine lives in :mod:`discopt._daemon_core`; this module is the thin solve-specific
+layer (an ``.nl`` + options ``solve_fn`` that returns a serialized result, the
+``discopt-solve`` socket name, and the client used by the CLI).
+
+Client contract: :func:`solve_via_daemon` returns the reply dict
+(``{"ok": True, "result": {...}}`` or ``{"ok": False, "error": ...}``), or
+``None`` if the daemon is unreachable and could not be started -- the CLI then
+solves in-process, so correctness never depends on the daemon being up.
+
+Lifecycle knobs (mirroring the GAMS daemon, ``DISCOPT_SOLVE_*``): idle timeout
+(default 600 s), max lifetime (3600 s), max solves (500), max RSS, JAX-clear
+stride, plus the source-fingerprint recycle that evicts a daemon running stale
+code after an editable-install edit.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from discopt._daemon_core import (
+    _FINGERPRINT,
+    _SPAWN_WAIT,
+    DaemonServer,
+    socket_path_for,
+)
+from discopt._daemon_core import (
+    ping as _core_ping,
+)
+from discopt._daemon_core import (
+    request as _request,
+)
+from discopt._daemon_core import (
+    spawn_daemon as _core_spawn,
+)
+from discopt._daemon_core import (
+    stop_daemon as _core_stop,
+)
+
+__all__ = [
+    "default_socket_path",
+    "ping",
+    "stop_daemon",
+    "spawn_daemon",
+    "solve_via_daemon",
+    "make_server",
+    "main",
+]
+
+_MODULE = "discopt.daemon"
+_SOCKET_ENV = "DISCOPT_SOLVE_SOCKET"
+
+
+def default_socket_path() -> Path:
+    """Per-user solve-daemon socket (honours ``DISCOPT_SOLVE_SOCKET``)."""
+    return socket_path_for(_SOCKET_ENV, "discopt-solve")
+
+
+def _solve_request(req: dict) -> dict:
+    """Daemon ``solve_fn``: build the model from the ``.nl`` and solve it.
+
+    Path resolution and any file output stay on the CLI side (the daemon may run
+    with a different cwd); the daemon is a pure executor returning a serialized
+    result. Exceptions propagate to the core, which isolates them so one bad model
+    never takes the daemon down.
+    """
+    from typing import cast
+
+    from discopt.modeling.core import SolveResult, from_nl
+    from discopt.result_io import options_from_payload, serialize_result
+
+    nl_file = req["nl_file"]
+    options = options_from_payload(req.get("options") or {})
+    # The daemon never passes stream=True, so solve() returns a SolveResult.
+    result = cast(SolveResult, from_nl(nl_file).solve(**options))
+    return {"ok": True, "result": serialize_result(result)}
+
+
+def make_server(socket_path: Path | None = None) -> DaemonServer:
+    return DaemonServer(
+        socket_path or default_socket_path(),
+        _solve_request,
+        env_prefix="DISCOPT_SOLVE",
+    )
+
+
+# ── Client ───────────────────────────────────────────────────────────────────
+def ping(socket_path: Path | None = None) -> dict | None:
+    return _core_ping(socket_path or default_socket_path())
+
+
+def stop_daemon(socket_path: Path | None = None) -> bool:
+    return _core_stop(socket_path or default_socket_path())
+
+
+def spawn_daemon(socket_path: Path | None = None, wait: float = _SPAWN_WAIT) -> bool:
+    return _core_spawn(socket_path or default_socket_path(), _MODULE, _SOCKET_ENV, wait)
+
+
+def solve_via_daemon(
+    nl_file: str, options: dict | None = None, socket_path: Path | None = None
+) -> dict | None:
+    """Solve ``nl_file`` through the warm daemon, spawning it if needed.
+
+    ``options`` is the JSON-safe solve-options payload (see
+    :func:`discopt.result_io.options_to_payload`). Returns the reply dict, or
+    ``None`` if the daemon is unreachable and could not be started.
+    """
+    path = socket_path or default_socket_path()
+    # Evict a daemon running stale code before solving (editable-install edits).
+    info = ping(path)
+    if info is not None and info.get("version") not in (None, _FINGERPRINT):
+        stop_daemon(path)
+        spawn_daemon(path)
+    payload = {
+        "cmd": "solve",
+        "nl_file": nl_file,
+        "options": options or {},
+        "version": _FINGERPRINT,
+    }
+    resp = _request(path, payload)
+    if resp is None:
+        if not spawn_daemon(path):
+            return None
+        resp = _request(path, payload)
+    return resp
+
+
+# ── Entry points ─────────────────────────────────────────────────────────────
+def main(argv: list[str] | None = None) -> int:
+    """``python -m discopt.daemon {serve,stop,status}``."""
+    args = sys.argv[1:] if argv is None else argv
+    cmd = args[0] if args else "serve"
+    if cmd == "serve":
+        make_server().serve_forever()
+        return 0
+    if cmd == "stop":
+        ok = stop_daemon()
+        print("stopped" if ok else "no running daemon")
+        return 0 if ok else 1
+    if cmd == "status":
+        info = ping()
+        if info:
+            print(f"running (version {info.get('version')}) at {default_socket_path()}")
+            return 0
+        print("not running")
+        return 1
+    sys.stderr.write("usage: python -m discopt.daemon {serve,stop,status}\n")
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/python/discopt/daemon.py
+++ b/python/discopt/daemon.py
@@ -27,7 +27,11 @@ from discopt._daemon_core import (
     _FINGERPRINT,
     _SPAWN_WAIT,
     DaemonServer,
+    SolveTimeout,
     socket_path_for,
+)
+from discopt._daemon_core import (
+    kill_daemon as _core_kill,
 )
 from discopt._daemon_core import (
     ping as _core_ping,
@@ -46,6 +50,7 @@ __all__ = [
     "default_socket_path",
     "ping",
     "stop_daemon",
+    "kill_daemon",
     "spawn_daemon",
     "solve_via_daemon",
     "make_server",
@@ -54,6 +59,11 @@ __all__ = [
 
 _MODULE = "discopt.daemon"
 _SOCKET_ENV = "DISCOPT_SOLVE_SOCKET"
+# Extra wall-clock the client allows a solve beyond its own ``time_limit`` before
+# declaring the daemon wedged: covers a cold daemon's JAX warmup/compile and
+# result serialization. Past ``time_limit + _SOLVE_GRACE`` the client kills the
+# daemon and falls back in-process, so one runaway solve can never wedge a run.
+_SOLVE_GRACE = 120.0
 
 
 def default_socket_path() -> Path:
@@ -98,8 +108,21 @@ def stop_daemon(socket_path: Path | None = None) -> bool:
     return _core_stop(socket_path or default_socket_path())
 
 
+def kill_daemon(socket_path: Path | None = None) -> bool:
+    """SIGTERM/SIGKILL the solve daemon by its PID file (use when it is wedged)."""
+    return _core_kill(socket_path or default_socket_path())
+
+
 def spawn_daemon(socket_path: Path | None = None, wait: float = _SPAWN_WAIT) -> bool:
     return _core_spawn(socket_path or default_socket_path(), _MODULE, _SOCKET_ENV, wait)
+
+
+def _recv_timeout_for(options: dict | None) -> float:
+    try:
+        tl = float((options or {}).get("time_limit", 3600.0))
+    except (TypeError, ValueError):
+        tl = 3600.0
+    return max(tl, 0.0) + _SOLVE_GRACE
 
 
 def solve_via_daemon(
@@ -109,11 +132,24 @@ def solve_via_daemon(
 
     ``options`` is the JSON-safe solve-options payload (see
     :func:`discopt.result_io.options_to_payload`). Returns the reply dict, or
-    ``None`` if the daemon is unreachable and could not be started.
+    ``None`` if the daemon is unreachable, could not be started, or **wedged** on a
+    runaway solve past ``time_limit + grace`` -- in which case it is killed and the
+    caller falls back to an in-process solve, so one stuck model can never block a
+    run.
     """
     path = socket_path or default_socket_path()
-    # Evict a daemon running stale code before solving (editable-install edits).
-    info = ping(path)
+    recv_timeout = _recv_timeout_for(options)
+    # Version-check the daemon before solving (evict stale code on editable
+    # installs). Use a BOUNDED probe, not the unbounded ``ping``: a single-threaded
+    # daemon already wedged in another solve will not answer the probe either, so
+    # an unbounded wait here would hang the client forever. If the probe times out,
+    # treat the daemon as wedged -- kill and respawn a fresh one.
+    try:
+        info = _request(path, {"cmd": "ping"}, recv_timeout=recv_timeout)
+    except SolveTimeout:
+        kill_daemon(path)
+        spawn_daemon(path)
+        info = None
     if info is not None and info.get("version") not in (None, _FINGERPRINT):
         stop_daemon(path)
         spawn_daemon(path)
@@ -123,11 +159,19 @@ def solve_via_daemon(
         "options": options or {},
         "version": _FINGERPRINT,
     }
-    resp = _request(path, payload)
+    try:
+        resp = _request(path, payload, recv_timeout=recv_timeout)
+    except SolveTimeout:
+        kill_daemon(path)  # wedged -> kill so the next solve gets a fresh daemon
+        return None
     if resp is None:
         if not spawn_daemon(path):
             return None
-        resp = _request(path, payload)
+        try:
+            resp = _request(path, payload, recv_timeout=recv_timeout)
+        except SolveTimeout:
+            kill_daemon(path)
+            return None
     return resp
 
 
@@ -143,6 +187,10 @@ def main(argv: list[str] | None = None) -> int:
         ok = stop_daemon()
         print("stopped" if ok else "no running daemon")
         return 0 if ok else 1
+    if cmd == "kill":
+        ok = kill_daemon()
+        print("killed" if ok else "no running daemon")
+        return 0 if ok else 1
     if cmd == "status":
         info = ping()
         if info:
@@ -150,7 +198,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         print("not running")
         return 1
-    sys.stderr.write("usage: python -m discopt.daemon {serve,stop,status}\n")
+    sys.stderr.write("usage: python -m discopt.daemon {serve,stop,kill,status}\n")
     return 2
 
 

--- a/python/discopt/gams/daemon.py
+++ b/python/discopt/gams/daemon.py
@@ -5,153 +5,94 @@ re-pays Python + JAX import and first-JIT warmup (seconds), even though a warm
 solve is ~10 ms.  This module keeps a single long-lived process warm and turns
 the per-solve launch into a thin socket round-trip.
 
-Pieces
-------
-* :class:`DaemonServer` -- listens on a per-user unix socket, services one
-  request at a time (solves are serialized: one warm interpreter, GIL + JAX
-  thread-safety), and self-terminates on idle timeout / max lifetime / max
-  solves / version mismatch.
-* :func:`solve_via_daemon` -- the client used by the GAMS link: connect (lazily
-  spawning a detached daemon if needed), relay the control-file path, return the
-  exit code.  Returns ``None`` to signal the caller should fall back to an
-  in-process solve, so correctness never depends on the daemon being up.
-
-The lifecycle (idle timeout + lazy auto-respawn + direct-solve fallback) is
-exercised in tests with a fake solve function, so it needs no GAMS install.
+The generic protocol / lifecycle / robustness machinery now lives in
+:mod:`discopt._daemon_core`; this module is the GAMS-specific layer (the
+control-file ``solve_fn``, the ``discopt-gams`` socket name, and the
+``(control_file, sysdir) -> int`` client contract the GAMS link relies on). It
+re-exports the core helpers under their historical names so existing imports
+keep working.
 """
 
 from __future__ import annotations
 
-import json
-import os
-import socket
-import subprocess
 import sys
-import time
-from collections.abc import Callable
 from pathlib import Path
 
 from discopt import __version__
+from discopt._daemon_core import (
+    _FINGERPRINT,
+    _SPAWN_WAIT,
+    _clear_jax_caches,
+    _current_rss_mb,
+    _env_flag,
+    _pid_alive,
+    _pid_path,
+    _reap_stale,
+    _recv_line,
+    _resolve,
+    _source_fingerprint,
+    socket_path_for,
+)
+from discopt._daemon_core import (
+    DaemonServer as _CoreDaemonServer,
+)
+from discopt._daemon_core import (
+    ping as _core_ping,
+)
+from discopt._daemon_core import (
+    request as _request,
+)
+from discopt._daemon_core import (
+    spawn_daemon as _core_spawn,
+)
+from discopt._daemon_core import (
+    stop_daemon as _core_stop,
+)
 
-_CONNECT_TIMEOUT = 5.0
-_SPAWN_WAIT = 30.0
+__all__ = [
+    "DaemonServer",
+    "default_socket_path",
+    "ping",
+    "stop_daemon",
+    "spawn_daemon",
+    "solve_via_daemon",
+    "main",
+]
 
+# Silence "imported but unused" for the names we re-export for back-compat.
+_REEXPORTS = (
+    _FINGERPRINT,
+    _source_fingerprint,
+    _env_flag,
+    _resolve,
+    _recv_line,
+    _pid_path,
+    _pid_alive,
+    _reap_stale,
+    _request,
+    _clear_jax_caches,
+    _current_rss_mb,
+    __version__,
+)
 
-def _source_fingerprint() -> str:
-    """A staleness key that changes whenever the installed discopt source changes.
-
-    Returns ``__version__`` plus the newest modification time across the discopt
-    package's Python and compiled-extension files. In a released / site-packages
-    install those mtimes are fixed at install time, so the key is stable and the
-    warm daemon is reused across solves. In an editable / development install,
-    editing any source file (or rebuilding the Rust extension) bumps the max mtime,
-    so a client built from the edited tree no longer matches a daemon spawned
-    *before* the edit -- the solve handshake (:meth:`DaemonServer._handle`) then
-    evicts and respawns it, and the change takes effect on the next solve without a
-    manual ``daemon stop``. Falls back to ``__version__`` alone if the package tree
-    cannot be scanned, so the handshake never breaks.
-    """
-    try:
-        import discopt
-
-        root = Path(discopt.__file__).resolve().parent
-        latest = 0
-        for pattern in ("*.py", "*.so", "*.pyd"):
-            for p in root.rglob(pattern):
-                try:
-                    m = p.stat().st_mtime_ns
-                except OSError:
-                    continue
-                if m > latest:
-                    latest = m
-        return f"{__version__}+{latest}" if latest else __version__
-    except Exception:
-        return __version__
-
-
-# Computed once at import. The daemon stamps this as its version when it spawns;
-# a client built from a newer source tree computes a different value and the
-# version handshake recycles the stale daemon (see _source_fingerprint).
-_FINGERPRINT = _source_fingerprint()
-
-
-def _env_flag(name: str) -> bool:
-    return os.environ.get(name, "0").lower() in ("1", "true", "yes", "on")
-
-
-def _resolve(explicit, env_name: str, default, cast):
-    """Pick an explicit arg, else an env override, else a default; ``cast`` typed."""
-    if explicit is not None:
-        return cast(explicit)
-    raw = os.environ.get(env_name)
-    if raw is not None:
-        return cast(raw)
-    return cast(default)
-
-
-def _current_rss_mb() -> float:
-    """Resident set size of this process in MiB (peak; monotonic, no psutil dep)."""
-    import resource
-
-    kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-    # Linux reports KiB; macOS reports bytes.
-    return kb / (1024 * 1024) if sys.platform == "darwin" else kb / 1024
-
-
-def _clear_jax_caches() -> None:
-    """Drop JAX's compilation caches if (and only if) JAX is loaded."""
-    mod = sys.modules.get("jax")
-    if mod is not None:
-        try:
-            mod.clear_caches()
-        except Exception:
-            pass
+_MODULE = "discopt.gams.daemon"
+_SOCKET_ENV = "DISCOPT_GAMS_SOCKET"
 
 
 def default_socket_path() -> Path:
     """Per-user socket path (honours ``DISCOPT_GAMS_SOCKET`` / ``XDG_RUNTIME_DIR``)."""
-    explicit = os.environ.get("DISCOPT_GAMS_SOCKET")
-    if explicit:
-        return Path(explicit)
-    runtime = os.environ.get("XDG_RUNTIME_DIR")
-    base = Path(runtime) if runtime else Path(os.environ.get("TMPDIR", "/tmp"))
-    return base / f"discopt-gams-{os.getuid()}.sock"
+    return socket_path_for(_SOCKET_ENV, "discopt-gams")
 
 
-def _pid_path(socket_path: Path) -> Path:
-    return socket_path.with_suffix(socket_path.suffix + ".pid")
-
-
-def _pid_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    return True
-
-
-def _recv_line(conn: socket.socket) -> bytes:
-    chunks: list[bytes] = []
-    while True:
-        b = conn.recv(65536)
-        if not b:
-            break
-        chunks.append(b)
-        if b.endswith(b"\n"):
-            break
-    return b"".join(chunks)
-
-
-# ── Server ───────────────────────────────────────────────────────────────────
-class DaemonServer:
-    """A warm, single-request-at-a-time solver server over a unix socket."""
+class DaemonServer(_CoreDaemonServer):
+    """Warm GAMS solver server. Wraps the historical ``(control_file, sysdir) ->
+    int`` solve callback into the core's ``request -> reply`` contract so the GAMS
+    link and its tests keep their signature."""
 
     def __init__(
         self,
         socket_path: Path | None = None,
-        solve_fn: Callable[[str, str | None], int] | None = None,
+        solve_fn=None,
         idle_timeout: float | None = None,
         max_lifetime: float | None = None,
         max_solves: int | None = None,
@@ -159,121 +100,29 @@ class DaemonServer:
         jax_clear_every: int | None = None,
         version: str = _FINGERPRINT,
     ):
-        # The benchmark preset disables count/age recycling by default so one
-        # warm daemon spans a whole study (an RSS ceiling remains the backstop).
-        bench = _env_flag("DISCOPT_GAMS_BENCHMARK")
-        self.socket_path = Path(socket_path) if socket_path else default_socket_path()
-        self._solve_fn = solve_fn or _default_solve_fn
-        # 0 / negative means "no limit" for every guard below.
-        self.idle_timeout = _resolve(
-            idle_timeout, "DISCOPT_GAMS_IDLE_TIMEOUT", 1800 if bench else 600, float
-        )
-        self.max_lifetime = _resolve(
-            max_lifetime, "DISCOPT_GAMS_MAX_LIFETIME", 0 if bench else 3600, float
-        )
-        self.max_solves = _resolve(max_solves, "DISCOPT_GAMS_MAX_SOLVES", 0 if bench else 500, int)
-        self.max_rss_mb = _resolve(max_rss_mb, "DISCOPT_GAMS_MAX_RSS_MB", 0, int)
-        self.jax_clear_every = _resolve(jax_clear_every, "DISCOPT_GAMS_JAX_CLEAR_EVERY", 0, int)
-        self.version = version
-        self.solves = 0
-        self._sock: socket.socket | None = None
+        sp = Path(socket_path) if socket_path else default_socket_path()
+        legacy = solve_fn or _default_solve_fn
 
-    def _bind(self) -> None:
-        # Remove a stale socket from a dead daemon before binding.
-        if self.socket_path.exists():
-            self.socket_path.unlink()
-        self.socket_path.parent.mkdir(parents=True, exist_ok=True)
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.bind(str(self.socket_path))
-        os.chmod(self.socket_path, 0o600)
-        s.listen(16)
-        self._sock = s
-        _pid_path(self.socket_path).write_text(str(os.getpid()))
-
-    def serve_forever(self) -> None:
-        """Accept and service requests until a shutdown condition fires."""
-        self._bind()
-        started = time.monotonic()
-        try:
-            while True:
-                assert self._sock is not None
-                # idle_timeout <= 0 means block indefinitely (no idle shutdown).
-                self._sock.settimeout(self.idle_timeout if self.idle_timeout > 0 else None)
-                try:
-                    conn, _ = self._sock.accept()
-                except socket.timeout:
-                    break  # idle timeout
-                before = self.solves
-                with conn:
-                    stop = self._handle(conn)
-                did_solve = self.solves > before
-                # Recycle guards are evaluated only after an actual solve, so
-                # pings/stops never trip them. A purely idle daemon exits via the
-                # accept() idle timeout instead.
-                if (
-                    did_solve
-                    and self.jax_clear_every > 0
-                    and (self.solves % self.jax_clear_every == 0)
-                ):
-                    _clear_jax_caches()
-                if stop:
-                    break
-                if did_solve:
-                    if self.max_solves > 0 and self.solves >= self.max_solves:
-                        break
-                    if self.max_lifetime > 0 and time.monotonic() - started >= self.max_lifetime:
-                        break
-                    if self.max_rss_mb > 0 and _current_rss_mb() >= self.max_rss_mb:
-                        break
-        finally:
-            self._cleanup()
-
-    def _handle(self, conn: socket.socket) -> bool:
-        """Service one request. Returns True if the daemon should stop."""
-        try:
-            req = json.loads(_recv_line(conn).decode() or "{}")
-        except (ValueError, OSError):
-            self._reply(conn, {"ok": False, "error": "bad request"})
-            return False
-
-        cmd = req.get("cmd")
-        if cmd == "ping":
-            self._reply(conn, {"ok": True, "version": self.version})
-            return False
-        if cmd == "stop":
-            self._reply(conn, {"ok": True})
-            return True
-        if cmd == "solve":
-            # A client built against a different discopt evicts the daemon so
-            # the upgrade takes effect; it serves this request first.
-            stop = req.get("version") not in (None, self.version)
-            control_file = req.get("control_file", "")
+        def _req_solve(req: dict) -> dict:
+            cf = req.get("control_file", "")
             sysdir = req.get("sysdir")
             try:
-                rc = int(self._solve_fn(control_file, sysdir))
-                self._reply(conn, {"ok": rc == 0, "rc": rc})
-            except Exception as exc:  # never let one model take the daemon down
-                self._reply(conn, {"ok": False, "rc": 1, "error": repr(exc)})
-            self.solves += 1
-            return stop
-        self._reply(conn, {"ok": False, "error": f"unknown cmd {cmd!r}"})
-        return False
+                rc = int(legacy(cf, sysdir))
+                return {"ok": rc == 0, "rc": rc}
+            except Exception as exc:  # surfaced as a failed solve, daemon survives
+                return {"ok": False, "rc": 1, "error": repr(exc)}
 
-    @staticmethod
-    def _reply(conn: socket.socket, payload: dict) -> None:
-        try:
-            conn.sendall((json.dumps(payload) + "\n").encode())
-        except OSError:
-            pass
-
-    def _cleanup(self) -> None:
-        if self._sock is not None:
-            self._sock.close()
-        for p in (self.socket_path, _pid_path(self.socket_path)):
-            try:
-                p.unlink()
-            except OSError:
-                pass
+        super().__init__(
+            sp,
+            _req_solve,
+            env_prefix="DISCOPT_GAMS",
+            version=version,
+            idle_timeout=idle_timeout,
+            max_lifetime=max_lifetime,
+            max_solves=max_solves,
+            max_rss_mb=max_rss_mb,
+            jax_clear_every=jax_clear_every,
+        )
 
 
 def _default_solve_fn(control_file: str, sysdir: str | None = None) -> int:
@@ -284,68 +133,19 @@ def _default_solve_fn(control_file: str, sysdir: str | None = None) -> int:
 
 
 # ── Client ───────────────────────────────────────────────────────────────────
-def _request(socket_path: Path, payload: dict, timeout: float = _CONNECT_TIMEOUT) -> dict | None:
-    try:
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
-            s.settimeout(timeout)
-            s.connect(str(socket_path))
-            s.sendall((json.dumps(payload) + "\n").encode())
-            s.settimeout(None)  # the solve itself may take a while
-            data = _recv_line(s)
-        return json.loads(data.decode()) if data else None
-    except (OSError, ValueError):
-        return None
-
-
 def ping(socket_path: Path | None = None) -> dict | None:
     """Return the running daemon's handshake, or ``None`` if not reachable."""
-    return _request(socket_path or default_socket_path(), {"cmd": "ping"})
+    return _core_ping(socket_path or default_socket_path())
 
 
 def stop_daemon(socket_path: Path | None = None) -> bool:
     """Ask a running daemon to shut down. Returns True if it acknowledged."""
-    resp = _request(socket_path or default_socket_path(), {"cmd": "stop"})
-    return bool(resp and resp.get("ok"))
+    return _core_stop(socket_path or default_socket_path())
 
 
 def spawn_daemon(socket_path: Path | None = None, wait: float = _SPAWN_WAIT) -> bool:
-    """Start a detached daemon and wait until its socket answers."""
-    path = socket_path or default_socket_path()
-    _reap_stale(path)
-    env = dict(os.environ, DISCOPT_GAMS_SOCKET=str(path))
-    try:
-        subprocess.Popen(
-            [sys.executable, "-m", "discopt.gams.daemon", "serve"],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,  # outlive the GAMS-launched client
-            env=env,
-        )
-    except OSError:
-        return False
-    deadline = time.monotonic() + wait
-    while time.monotonic() < deadline:
-        if ping(path):
-            return True
-        time.sleep(0.05)
-    return False
-
-
-def _reap_stale(socket_path: Path) -> None:
-    """Remove a socket/pid left behind by a dead daemon."""
-    pid_file = _pid_path(socket_path)
-    try:
-        pid = int(pid_file.read_text())
-    except (OSError, ValueError):
-        pid = None
-    if pid is not None and _pid_alive(pid):
-        return  # a live daemon owns it
-    for p in (socket_path, pid_file):
-        try:
-            p.unlink()
-        except OSError:
-            pass
+    """Start a detached GAMS daemon and wait until its socket answers."""
+    return _core_spawn(socket_path or default_socket_path(), _MODULE, _SOCKET_ENV, wait)
 
 
 def solve_via_daemon(
@@ -359,11 +159,9 @@ def solve_via_daemon(
     path = socket_path or default_socket_path()
     # Recycle a daemon running stale code BEFORE solving, so the current code is
     # used on this very solve (not one solve later). A running daemon stamps the
-    # source fingerprint it was spawned with; if ours differs -- e.g. an editable
-    # install was edited, or the package upgraded -- stop it and spawn fresh first.
-    # In a stable install the fingerprint never changes, so this is a one-ping
-    # no-op. (The daemon's own version check in ``_handle`` remains as a backstop
-    # for older clients that do not pre-check.)
+    # source fingerprint it was spawned with; if ours differs, stop it and spawn
+    # fresh first. In a stable install the fingerprint never changes, so this is a
+    # one-ping no-op. (The daemon's own version check remains a backstop.)
     info = ping(path)
     if info is not None and info.get("version") not in (None, _FINGERPRINT):
         stop_daemon(path)

--- a/python/discopt/gams/daemon.py
+++ b/python/discopt/gams/daemon.py
@@ -37,6 +37,9 @@ from discopt._daemon_core import (
     DaemonServer as _CoreDaemonServer,
 )
 from discopt._daemon_core import (
+    kill_daemon as _core_kill,
+)
+from discopt._daemon_core import (
     ping as _core_ping,
 )
 from discopt._daemon_core import (
@@ -143,6 +146,11 @@ def stop_daemon(socket_path: Path | None = None) -> bool:
     return _core_stop(socket_path or default_socket_path())
 
 
+def kill_daemon(socket_path: Path | None = None) -> bool:
+    """SIGTERM/SIGKILL the daemon by its PID file (use when it is wedged)."""
+    return _core_kill(socket_path or default_socket_path())
+
+
 def spawn_daemon(socket_path: Path | None = None, wait: float = _SPAWN_WAIT) -> bool:
     """Start a detached GAMS daemon and wait until its socket answers."""
     return _core_spawn(socket_path or default_socket_path(), _MODULE, _SOCKET_ENV, wait)
@@ -194,6 +202,10 @@ def main(argv: list[str] | None = None) -> int:
         ok = stop_daemon()
         print("stopped" if ok else "no running daemon")
         return 0 if ok else 1
+    if cmd == "kill":
+        ok = kill_daemon()
+        print("killed" if ok else "no running daemon")
+        return 0 if ok else 1
     if cmd == "status":
         info = ping()
         if info:
@@ -201,7 +213,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         print("not running")
         return 1
-    sys.stderr.write("usage: python -m discopt.gams.daemon {serve,stop,status}\n")
+    sys.stderr.write("usage: python -m discopt.gams.daemon {serve,stop,kill,status}\n")
     return 2
 
 

--- a/python/discopt/profiles.py
+++ b/python/discopt/profiles.py
@@ -1,0 +1,103 @@
+"""Named solve profiles for the ``discopt solve`` CLI.
+
+A *profile* is a named bundle of :meth:`Model.solve` options (including a nested
+``tuning`` dict for :class:`~discopt.solver_tuning.SolverTuning`). Built-in
+profiles ship with discopt; users add or override them in a TOML file. Precedence
+when resolving the options for a solve is: **explicit CLI flag > profile >
+built-in defaults**.
+
+User config is read (later wins) from:
+  1. ``~/.config/discopt/profiles.toml``   (or ``$XDG_CONFIG_HOME/discopt/profiles.toml``)
+  2. ``./discopt.toml``                     (a ``[profiles.<name>]`` table in cwd)
+
+Schema mirrors the benchmark solver-config style::
+
+    [profiles.fast]
+    time_limit = 10
+    gap_tolerance = 1e-2
+    tuning = { node_bound_mode = "lp", node_nlp_stride = 8 }
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+from pathlib import Path
+from typing import Any
+
+# Built-in profiles. ``tuning`` is a plain dict (validated against SolverTuning
+# fields when the solve is built); everything else is a Model.solve kwarg.
+BUILTIN_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {},
+    "fast": {
+        "time_limit": 10.0,
+        "gap_tolerance": 1e-2,
+        "tuning": {"node_bound_mode": "lp", "node_nlp_stride": 8},
+    },
+    "exact": {
+        "time_limit": 3600.0,
+        "gap_tolerance": 1e-6,
+    },
+    "feasible": {
+        "nlp_bb": True,
+        "gap_tolerance": 1e-1,
+    },
+}
+
+
+def _user_config_paths() -> list[Path]:
+    cfg_home = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(cfg_home) if cfg_home else Path.home() / ".config"
+    return [base / "discopt" / "profiles.toml", Path.cwd() / "discopt.toml"]
+
+
+def _load_toml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        import tomllib  # py311+
+    except ModuleNotFoundError:  # pragma: no cover - py310 fallback
+        try:
+            import tomli as tomllib  # type: ignore
+        except ModuleNotFoundError:
+            return {}  # no TOML reader -> user config silently unavailable
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, ValueError):
+        return {}
+    profs = data.get("profiles", data)  # accept a bare table or a [profiles.*] block
+    return profs if isinstance(profs, dict) else {}
+
+
+def load_profiles() -> dict[str, dict[str, Any]]:
+    """Built-in profiles overlaid by user TOML (cwd wins over the home config)."""
+    profiles = copy.deepcopy(BUILTIN_PROFILES)
+    for path in _user_config_paths():
+        for name, opts in _load_toml(path).items():
+            if isinstance(opts, dict):
+                profiles[name] = opts
+    return profiles
+
+
+def resolve_options(profile_name: str | None, cli_overrides: dict[str, Any]) -> dict[str, Any]:
+    """Merge a profile with explicit CLI overrides (CLI wins).
+
+    The ``tuning`` sub-dict is merged key-wise, so a single ``--tuning rlt_quad=…``
+    flag overrides only that field, not the whole profile bundle. Raises
+    ``KeyError`` with the available names if ``profile_name`` is unknown.
+    """
+    profiles = load_profiles()
+    base: dict[str, Any] = {}
+    if profile_name is not None:
+        if profile_name not in profiles:
+            raise KeyError(f"unknown profile {profile_name!r}; available: {sorted(profiles)}")
+        base = copy.deepcopy(profiles[profile_name])
+
+    merged = dict(base)
+    cli_tuning = cli_overrides.pop("tuning", None)
+    for k, v in cli_overrides.items():
+        merged[k] = v
+    if cli_tuning:
+        merged["tuning"] = {**base.get("tuning", {}), **cli_tuning}
+    return merged

--- a/python/discopt/result_io.py
+++ b/python/discopt/result_io.py
@@ -1,0 +1,164 @@
+"""Serialize / render a :class:`~discopt.modeling.core.SolveResult`.
+
+Shared by the ``discopt solve`` CLI, the solve daemon, and their tests. The
+daemon returns a result over a socket as JSON, and the CLI renders it (or writes
+it) -- both go through here so there is one implementation and it is testable
+without a socket or a real solve.
+
+Non-JSON-safe fields (``_model``, ``infeasibility_certificate``,
+``validation_report``) are dropped; numpy arrays become nested lists.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, fields, is_dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from discopt.modeling.core import SolveResult
+
+SCHEMA_VERSION = 1
+
+# Scalar SolveResult fields that round-trip as-is.
+_SCALAR_FIELDS = (
+    "status",
+    "objective",
+    "bound",
+    "gap",
+    "wall_time",
+    "node_count",
+    "mip_count",
+    "rust_time",
+    "jax_time",
+    "python_time",
+    "convex_fast_path",
+    "nlp_bb",
+    "gap_certified",
+    "subnlp_calls",
+    "subnlp_feasible",
+    "subnlp_incumbent_updates",
+)
+_DICT_ARRAY_FIELDS = (
+    "x",
+    "constraint_duals",
+    "bound_duals_lower",
+    "bound_duals_upper",
+)
+
+
+def _jsonify_arrays(d: Optional[dict]) -> Optional[dict]:
+    """``{name: ndarray|scalar}`` -> ``{name: list|number}`` (or ``None``)."""
+    if d is None:
+        return None
+    return {k: np.asarray(v).tolist() for k, v in d.items()}
+
+
+def serialize_result(r: SolveResult) -> dict:
+    """A JSON-safe dict capturing the solver-relevant fields of *r*."""
+    out: dict[str, Any] = {"schema_version": SCHEMA_VERSION}
+    for name in _SCALAR_FIELDS:
+        out[name] = getattr(r, name, None)
+    for name in _DICT_ARRAY_FIELDS:
+        val = _jsonify_arrays(getattr(r, name, None))
+        if val is not None:
+            out[name] = val
+    expl = getattr(r, "_explanation", None)
+    if expl:
+        out["explanation"] = str(expl)
+    return out
+
+
+def deserialize_result(d: dict) -> SolveResult:
+    """Rebuild a :class:`SolveResult` from :func:`serialize_result` output."""
+    kwargs: dict[str, Any] = {}
+    for name in _SCALAR_FIELDS:
+        if name in d:
+            kwargs[name] = d[name]
+    for name in _DICT_ARRAY_FIELDS:
+        if d.get(name) is not None:
+            kwargs[name] = {k: np.asarray(v) for k, v in d[name].items()}
+    r = SolveResult(**kwargs)
+    if d.get("explanation"):
+        r._explanation = d["explanation"]
+    return r
+
+
+def options_to_payload(options: dict) -> dict:
+    """JSON-safe copy of solve options for the wire.
+
+    A ``SolverTuning`` (frozen dataclass) under ``options["tuning"]`` is flattened
+    to a plain dict via :func:`dataclasses.asdict`. Any callable-valued option
+    (callbacks) is dropped defensively -- the CLI never sets them, and they cannot
+    cross a socket.
+    """
+    out: dict[str, Any] = {}
+    for k, v in options.items():
+        if callable(v):
+            continue
+        if is_dataclass(v) and not isinstance(v, type):
+            out[k] = asdict(v)
+        else:
+            out[k] = v
+    return out
+
+
+def options_from_payload(payload: dict) -> dict:
+    """Inverse of :func:`options_to_payload` for the daemon: rebuild ``tuning``."""
+    out = dict(payload)
+    tuning = out.get("tuning")
+    if isinstance(tuning, dict):
+        from discopt.solver_tuning import SolverTuning
+
+        valid = {f.name for f in fields(SolverTuning)}
+        out["tuning"] = SolverTuning(**{k: v for k, v in tuning.items() if k in valid})
+    return out
+
+
+# ── Rendering / file outputs ─────────────────────────────────────────────────
+def summary_text(r: SolveResult, *, max_vars: int = 20) -> str:
+    """A compact human-readable summary for stdout."""
+    lines = [f"status:    {r.status}"]
+    if r.objective is not None:
+        lines.append(f"objective: {r.objective:.8g}")
+    if r.bound is not None:
+        lines.append(f"bound:     {r.bound:.8g}")
+    if r.gap is not None:
+        cert = "" if r.gap_certified else "  (uncertified)"
+        lines.append(f"gap:       {r.gap:.4g}{cert}")
+    lines.append(f"nodes:     {r.node_count}   wall: {r.wall_time:.3f}s")
+    if r.x:
+        lines.append("solution:")
+        for i, (name, val) in enumerate(r.x.items()):
+            if i >= max_vars:
+                lines.append(f"  ... ({len(r.x) - max_vars} more)")
+                break
+            arr = np.asarray(val)
+            shown = arr.item() if arr.ndim == 0 else np.array2string(arr, threshold=8)
+            lines.append(f"  {name} = {shown}")
+    return "\n".join(lines)
+
+
+def write_json(r: SolveResult, path: Path) -> None:
+    path.write_text(json.dumps(serialize_result(r), indent=2) + "\n")
+
+
+def write_sol(r: SolveResult, var_names: list[str], path: Path) -> None:
+    """Write a minimal AMPL-style ``.sol``: a status line + one primal per variable.
+
+    ``var_names`` must be the ``.nl`` column order (``[v.name for v in model._variables]``)
+    so AMPL-side tools read the values back into the right columns.
+    """
+    lines = [f"discopt {r.status}"]
+    if r.objective is not None:
+        lines.append(f"objective {r.objective:.17g}")
+    x = r.x or {}
+    for name in var_names:
+        if name not in x:
+            continue
+        arr = np.asarray(x[name]).ravel()
+        for val in arr:
+            lines.append(f"{float(val):.17g}")
+    path.write_text("\n".join(lines) + "\n")

--- a/python/tests/test_cli_solve.py
+++ b/python/tests/test_cli_solve.py
@@ -1,0 +1,126 @@
+"""Tests for the ``discopt solve`` CLI command."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+from discopt.cli import _cmd_solve
+
+pytestmark = pytest.mark.unit
+
+
+def _make_nl(tmp_path: Path) -> Path:
+    m = dm.Model("m")
+    x = m.continuous("x", lb=0, ub=10)
+    m.minimize(x)
+    m.subject_to(x >= 1, name="c")
+    nl = tmp_path / "m.nl"
+    m.to_nl(str(nl))
+    return nl
+
+
+def _args(nl: Path, **over) -> argparse.Namespace:
+    base = dict(
+        file=str(nl),
+        profile=None,
+        time_limit=None,
+        gap=None,
+        threads=None,
+        solver=None,
+        partitions=None,
+        branching_policy=None,
+        rlt=None,
+        nlp_bb=None,
+        tuning=None,
+        no_daemon=True,  # in-process: deterministic, no socket
+        format="text",
+        json=False,
+        sol=False,
+        out_dir=None,
+        quiet=False,
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def test_solve_in_process_prints_and_writes_no_files(tmp_path, capsys):
+    nl = _make_nl(tmp_path)
+    before = set(tmp_path.iterdir())
+    with pytest.raises(SystemExit) as ei:
+        _cmd_solve(_args(nl))
+    assert ei.value.code == 0
+    out = capsys.readouterr().out
+    assert "status:" in out and "optimal" in out
+    # The litter guard: a default solve writes NO files next to the .nl.
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_solve_json_and_sol_outputs(tmp_path):
+    nl = _make_nl(tmp_path)
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(SystemExit) as ei:
+        _cmd_solve(_args(nl, json=True, sol=True, out_dir=str(out), quiet=True))
+    assert ei.value.code == 0
+    assert (out / "m.result.json").exists()
+    assert (out / "m.sol").exists()
+    import json
+
+    assert json.loads((out / "m.result.json").read_text())["status"] == "optimal"
+    assert (out / "m.sol").read_text().startswith("discopt optimal")
+
+
+def test_solve_format_json_to_stdout(tmp_path, capsys):
+    nl = _make_nl(tmp_path)
+    with pytest.raises(SystemExit):
+        _cmd_solve(_args(nl, format="json"))
+    import json
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == 1 and payload["status"] == "optimal"
+
+
+def test_solve_unknown_profile_errors(tmp_path):
+    nl = _make_nl(tmp_path)
+    with pytest.raises(SystemExit) as ei:
+        _cmd_solve(_args(nl, profile="nope"))
+    assert ei.value.code == 2
+
+
+def test_solve_bad_extension_errors(tmp_path):
+    p = tmp_path / "m.txt"
+    p.write_text("x")
+    with pytest.raises(SystemExit) as ei:
+        _cmd_solve(_args(p))
+    assert ei.value.code == 1
+
+
+@pytest.mark.slow
+def test_solve_end_to_end_via_daemon(tmp_path):
+    """Real subprocess: spawn the daemon, solve, then a warm solve; clean up."""
+    nl = _make_nl(tmp_path)
+    env = dict(__import__("os").environ, JAX_ENABLE_X64="1", JAX_PLATFORMS="cpu")
+
+    def run(args):
+        return subprocess.run(
+            [sys.executable, "-m", "discopt.cli", *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+
+    try:
+        r1 = run(["solve", str(nl), "--quiet"])  # spawns daemon
+        assert r1.returncode == 0, r1.stderr[-500:]
+        r2 = run(["solve", str(nl)])  # warm
+        assert r2.returncode == 0 and "optimal" in r2.stdout
+        status = run(["daemon", "status"])
+        assert "running" in status.stdout
+    finally:
+        run(["daemon", "stop"])

--- a/python/tests/test_profiles.py
+++ b/python/tests/test_profiles.py
@@ -1,0 +1,57 @@
+"""Tests for the ``discopt solve`` named-profile mechanism."""
+
+from __future__ import annotations
+
+import pytest
+from discopt import profiles as P
+
+pytestmark = pytest.mark.unit
+
+
+def test_builtin_profiles_present():
+    profs = P.load_profiles()
+    for name in ("default", "fast", "exact", "feasible"):
+        assert name in profs
+    assert profs["fast"]["time_limit"] == 10.0
+    assert profs["fast"]["tuning"]["node_bound_mode"] == "lp"
+
+
+def test_resolve_precedence_cli_over_profile(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)  # no user discopt.toml here
+    # CLI override wins over the profile's value.
+    opts = P.resolve_options("fast", {"time_limit": 99.0})
+    assert opts["time_limit"] == 99.0
+    assert opts["gap_tolerance"] == 1e-2  # untouched profile value survives
+
+
+def test_resolve_tuning_merges_key_wise(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    # fast sets node_bound_mode + node_nlp_stride; override only one field.
+    opts = P.resolve_options("fast", {"tuning": {"node_nlp_stride": 2}})
+    assert opts["tuning"]["node_nlp_stride"] == 2  # overridden
+    assert opts["tuning"]["node_bound_mode"] == "lp"  # preserved from profile
+
+
+def test_unknown_profile_raises(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(KeyError, match="unknown profile"):
+        P.resolve_options("nope", {})
+
+
+def test_user_toml_overrides_and_adds(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "discopt.toml").write_text(
+        "[profiles.fast]\ntime_limit = 5\n\n[profiles.mine]\nsolver = 'amp'\n"
+    )
+    profs = P.load_profiles()
+    assert profs["fast"]["time_limit"] == 5  # cwd file overrode the built-in
+    assert profs["mine"]["solver"] == "amp"  # new user profile
+    opts = P.resolve_options("mine", {})
+    assert opts["solver"] == "amp"
+
+
+def test_no_profile_just_overrides(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    opts = P.resolve_options(None, {"time_limit": 7.0})
+    assert opts == {"time_limit": 7.0}

--- a/python/tests/test_result_io.py
+++ b/python/tests/test_result_io.py
@@ -1,0 +1,115 @@
+"""Tests for SolveResult serialization and the CLI option/result helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.modeling.core import SolveResult
+from discopt.result_io import (
+    deserialize_result,
+    options_from_payload,
+    options_to_payload,
+    serialize_result,
+    summary_text,
+    write_json,
+    write_sol,
+)
+from discopt.solver_tuning import SolverTuning
+
+pytestmark = pytest.mark.unit
+
+
+def _optimal_result() -> SolveResult:
+    return SolveResult(
+        status="optimal",
+        objective=4.5796,
+        bound=4.5796,
+        gap=0.0,
+        x={"x": np.array(1.5), "y": np.array([0.0, 2.0])},
+        wall_time=0.09,
+        node_count=3,
+    )
+
+
+def test_serialize_round_trip_optimal():
+    r = _optimal_result()
+    d = serialize_result(r)
+    assert d["schema_version"] == 1
+    assert d["status"] == "optimal" and d["objective"] == pytest.approx(4.5796)
+    # ndarray -> list/number
+    assert d["x"]["x"] == pytest.approx(1.5)
+    assert d["x"]["y"] == [0.0, 2.0]
+
+    r2 = deserialize_result(d)
+    assert r2.status == "optimal"
+    assert r2.objective == pytest.approx(4.5796)
+    np.testing.assert_allclose(r2.x["y"], [0.0, 2.0])
+
+
+def test_serialize_infeasible_and_no_solution():
+    r = SolveResult(status="infeasible", objective=None, bound=None, gap=None, x=None)
+    d = serialize_result(r)
+    assert d["status"] == "infeasible"
+    assert d["objective"] is None
+    assert "x" not in d  # None dict fields are omitted
+    r2 = deserialize_result(d)
+    assert r2.status == "infeasible" and r2.x is None
+
+
+def test_non_serializable_fields_are_dropped():
+    r = _optimal_result()
+    r._model = object()  # not JSON-safe
+    r.infeasibility_certificate = object()
+    d = serialize_result(r)
+    import json
+
+    json.dumps(d)  # must not raise
+    assert "_model" not in d and "infeasibility_certificate" not in d
+
+
+def test_options_to_payload_flattens_tuning_and_drops_callables():
+    opts = {
+        "time_limit": 60.0,
+        "tuning": SolverTuning(rlt_quad=False, node_nlp_stride=8),
+        "incumbent_callback": lambda *a: True,  # callbacks cannot cross a socket
+    }
+    payload = options_to_payload(opts)
+    assert payload["time_limit"] == 60.0
+    assert isinstance(payload["tuning"], dict)
+    assert payload["tuning"]["rlt_quad"] is False
+    assert "incumbent_callback" not in payload
+    import json
+
+    json.dumps(payload)  # JSON-safe
+
+
+def test_options_from_payload_rebuilds_tuning():
+    payload = {"time_limit": 30.0, "tuning": {"rlt_quad": False, "node_nlp_stride": 8}}
+    opts = options_from_payload(payload)
+    assert isinstance(opts["tuning"], SolverTuning)
+    assert opts["tuning"].rlt_quad is False and opts["tuning"].node_nlp_stride == 8
+    # unknown tuning keys are filtered, not crash
+    opts2 = options_from_payload({"tuning": {"rlt_quad": True, "bogus": 1}})
+    assert opts2["tuning"].rlt_quad is True
+
+
+def test_write_json_and_sol(tmp_path):
+    r = _optimal_result()
+    jp = tmp_path / "m.result.json"
+    write_json(r, jp)
+    import json
+
+    loaded = json.loads(jp.read_text())
+    assert loaded["status"] == "optimal"
+
+    sp = tmp_path / "m.sol"
+    write_sol(r, ["x", "y"], sp)  # .nl column order
+    text = sp.read_text()
+    assert text.startswith("discopt optimal")
+    # x (1 value) + y (2 values) = 3 primal lines
+    assert text.count("\n") >= 4
+
+
+def test_summary_text_renders():
+    s = summary_text(_optimal_result())
+    assert "status:" in s and "optimal" in s and "objective:" in s

--- a/python/tests/test_solve_daemon.py
+++ b/python/tests/test_solve_daemon.py
@@ -144,3 +144,82 @@ def test_solve_via_daemon_kills_wedged_and_falls_back(sock, monkeypatch):
     finally:
         core.stop_daemon(sock)
         t.join(timeout=5)
+
+
+# ── daemon-side forked watchdog (hard deadline, default off) ──────────────────
+def test_watchdog_kills_overrunning_process():
+    """A process that overruns its watchdog deadline is SIGKILLed by the forked
+    child -- run in a subprocess so the signal never reaches the test runner."""
+    code = (
+        "import time\n"
+        "from discopt._daemon_core import _DeadlineWatchdog\n"
+        "with _DeadlineWatchdog(0.3):\n"
+        "    time.sleep(30)\n"
+        "print('REACHED')\n"
+    )
+    t0 = time.monotonic()
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=20)
+    dt = time.monotonic() - t0
+    assert proc.returncode == -9  # SIGKILL
+    assert dt < 5.0  # killed at ~0.3 s, not after 30 s
+    assert "REACHED" not in proc.stdout
+
+
+def test_watchdog_cancels_on_completion():
+    """On normal completion the watchdog child is killed and reaped, so it never
+    fires. A long deadline guarantees the child cannot kill the test process."""
+    with core._DeadlineWatchdog(60.0) as wd:
+        child = wd.pid
+        assert child is not None and core._pid_alive(child)
+    time.sleep(0.1)
+    assert not core._pid_alive(child)  # cancelled (killed + reaped) on exit
+
+
+def test_watchdog_disabled_when_no_deadline():
+    with core._DeadlineWatchdog(0.0) as wd:
+        assert wd.pid is None  # deadline <= 0 -> no fork, no limit (the default)
+
+
+def test_handle_arms_watchdog_with_request_deadline(sock, monkeypatch):
+    armed = {}
+
+    class _FakeWD:
+        def __init__(self, deadline):
+            armed["deadline"] = deadline
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(core, "_DeadlineWatchdog", _FakeWD)
+    srv = core.DaemonServer(
+        sock, lambda req: {"ok": True, "result": {}}, env_prefix="DISCOPT_SOLVE"
+    )
+    t = _start(srv)
+    try:
+        core.request(sock, {"cmd": "solve", "version": core._FINGERPRINT, "hard_deadline": 12.5})
+        assert armed.get("deadline") == 12.5
+    finally:
+        core.stop_daemon(sock)
+        t.join(timeout=5)
+
+
+def test_solve_via_daemon_sends_hard_deadline(monkeypatch):
+    sent = {}
+
+    def fake_request(path, payload, timeout=5.0, recv_timeout=None):
+        if payload.get("cmd") == "solve":
+            sent.update(payload)
+            sent["_recv_timeout"] = recv_timeout
+            return {"ok": True, "result": {}}
+        return {"ok": True}  # ping (no version mismatch)
+
+    monkeypatch.setattr(d, "_request", fake_request)
+    d.solve_via_daemon(
+        "x.nl", {"time_limit": 1.0}, socket_path=Path("/tmp/x.sock"), hard_deadline=7.0
+    )
+    assert sent["hard_deadline"] == 7.0
+    # client must wait at least the daemon's own deadline before giving up.
+    assert sent["_recv_timeout"] >= 7.0

--- a/python/tests/test_solve_daemon.py
+++ b/python/tests/test_solve_daemon.py
@@ -9,6 +9,10 @@ exercised by ``test_cli_solve.py`` via a real subprocess.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
 
 import discopt.daemon as d
@@ -19,6 +23,21 @@ from discopt.modeling.core import SolveResult
 from discopt.solver_tuning import SolverTuning
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def sock(tmp_path) -> Path:
+    return tmp_path / "d.sock"
+
+
+def _start(server) -> threading.Thread:
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    for _ in range(200):
+        if core.ping(server.socket_path):
+            break
+        time.sleep(0.01)
+    return t
 
 
 class _FakeModel:
@@ -66,3 +85,62 @@ def test_solve_and_gams_sockets_differ():
 
     assert d.default_socket_path() != g.default_socket_path()
     assert "discopt-solve" in str(d.default_socket_path())
+
+
+# ── kill (PID-based force terminate) ─────────────────────────────────────────
+def test_kill_daemon_signals_pid_and_reaps(tmp_path):
+    """``kill_daemon`` SIGKILLs the process in the PID file and reaps socket/pid.
+
+    Uses a real ``sleep`` subprocess (not a thread) so the signal goes to a
+    process we own, never the test runner.
+    """
+    sk = tmp_path / "k.sock"
+    sk.write_text("")  # stand-in socket file
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    core._pid_path(sk).write_text(str(proc.pid))
+
+    assert core.kill_daemon(sk) is True
+    assert proc.wait(timeout=5) is not None  # the process was terminated
+    assert not sk.exists() and not core._pid_path(sk).exists()
+    # Idempotent: nothing to kill -> False.
+    assert core.kill_daemon(sk) is False
+
+
+def test_recv_timeout_derivation():
+    assert d._recv_timeout_for({"time_limit": 60.0}) == 60.0 + d._SOLVE_GRACE
+    assert d._recv_timeout_for(None) == 3600.0 + d._SOLVE_GRACE  # default budget
+
+
+# ── client timeout on a wedged solve (socket-backed; short basetemp) ─────────
+def _slow_server(sock: Path, delay: float):
+    return core.DaemonServer(
+        sock,
+        lambda req: (time.sleep(delay), {"ok": True, "result": {}})[1],
+        env_prefix="DISCOPT_SOLVE",
+    )
+
+
+def test_request_recv_timeout_raises_solvetimeout(sock):
+    srv = _slow_server(sock, delay=1.0)
+    t = _start(srv)
+    try:
+        with pytest.raises(core.SolveTimeout):
+            core.request(sock, {"cmd": "solve", "version": core._FINGERPRINT}, recv_timeout=0.2)
+    finally:
+        core.stop_daemon(sock)
+        t.join(timeout=5)
+
+
+def test_solve_via_daemon_kills_wedged_and_falls_back(sock, monkeypatch):
+    srv = _slow_server(sock, delay=1.0)
+    t = _start(srv)
+    monkeypatch.setattr(d, "_SOLVE_GRACE", 0.1)  # recv_timeout = time_limit + 0.1
+    killed = {}
+    monkeypatch.setattr(d, "kill_daemon", lambda p=None: killed.setdefault("k", True))
+    try:
+        resp = d.solve_via_daemon("x.nl", {"time_limit": 0.0}, socket_path=sock)
+        assert resp is None  # client gave up -> caller falls back in-process
+        assert killed.get("k") is True  # the wedged daemon was killed
+    finally:
+        core.stop_daemon(sock)
+        t.join(timeout=5)

--- a/python/tests/test_solve_daemon.py
+++ b/python/tests/test_solve_daemon.py
@@ -1,0 +1,68 @@
+"""Socket-free tests for the ``discopt solve`` daemon layer.
+
+The socket protocol / lifecycle itself is covered by ``test_gams_daemon.py``
+(both daemons now share ``discopt._daemon_core``); these tests exercise the
+solve-specific glue: the ``DISCOPT_SOLVE_*`` env prefix, the ``_solve_request``
+serializer, and the client's in-process fallback. End-to-end socket use is
+exercised by ``test_cli_solve.py`` via a real subprocess.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import discopt.daemon as d
+import numpy as np
+import pytest
+from discopt import _daemon_core as core
+from discopt.modeling.core import SolveResult
+from discopt.solver_tuning import SolverTuning
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeModel:
+    def __init__(self, capture=None):
+        self._capture = capture
+
+    def solve(self, **kw):
+        if self._capture is not None:
+            self._capture.update(kw)
+        return SolveResult(status="optimal", objective=1.0, x={"x": np.array(1.0)})
+
+
+def test_make_server_uses_solve_prefix_and_socket(monkeypatch):
+    monkeypatch.setenv("DISCOPT_SOLVE_MAX_SOLVES", "7")
+    srv = d.make_server(Path("/tmp/probe.sock"))
+    assert isinstance(srv, core.DaemonServer)
+    assert srv.version == core._FINGERPRINT
+    assert srv.max_solves == 7  # the DISCOPT_SOLVE_* prefix resolved
+
+
+def test_solve_request_serializes(monkeypatch):
+    monkeypatch.setattr("discopt.modeling.core.from_nl", lambda p: _FakeModel())
+    reply = d._solve_request({"nl_file": "x.nl", "options": {"time_limit": 5}})
+    assert reply["ok"] is True
+    assert reply["result"]["status"] == "optimal"
+    assert reply["result"]["objective"] == 1.0
+
+
+def test_solve_request_rebuilds_tuning(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr("discopt.modeling.core.from_nl", lambda p: _FakeModel(captured))
+    d._solve_request({"nl_file": "x.nl", "options": {"tuning": {"rlt_quad": False}}})
+    assert isinstance(captured["tuning"], SolverTuning)
+    assert captured["tuning"].rlt_quad is False
+
+
+def test_client_fallback_when_daemon_unavailable(monkeypatch, tmp_path):
+    # No daemon, and spawning disabled -> client signals in-process fallback.
+    monkeypatch.setattr(d, "spawn_daemon", lambda *a, **k: False)
+    assert d.solve_via_daemon("x.nl", {}, socket_path=tmp_path / "none.sock") is None
+
+
+def test_solve_and_gams_sockets_differ():
+    from discopt.gams import daemon as g
+
+    assert d.default_socket_path() != g.default_socket_path()
+    assert "discopt-solve" in str(d.default_socket_path())


### PR DESCRIPTION
## Summary

A one-shot `.nl` solve in a fresh process pays ~1 s of JAX backend init + tracing
before any work (the warm solve itself is ~0.1 s). This adds **`discopt solve
<file.nl>`** backed by a **persistent warm daemon**, so repeated solves are a thin
socket round-trip — mirroring the existing GAMS solver daemon, whose generic
engine is extracted into a shared `discopt._daemon_core`.

```bash
discopt solve model.nl                      # warm-routed, ~0.2 s after the first
discopt solve model.nl --profile fast --json
discopt solve model.nl --tuning rlt_quad=false --no-daemon
discopt daemon {serve|stop|kill|status}
```

## What's included
- **`_daemon_core.py`** — the GAMS daemon's generic engine (JSON-line protocol
  over a per-user unix socket, idle/lifetime/solve-count/RSS recycling,
  source-fingerprint staleness handshake, stale-socket reaping, lazy auto-spawn +
  in-process fallback). `DaemonServer` is parameterized by `solve_fn(req)->reply`
  and an env prefix so two daemons coexist. **`gams/daemon.py` is refactored to a
  thin layer over it — all 18 GAMS daemon tests stay green.**
- **`daemon.py`** — the solve daemon (`from_nl(nl).solve(**options)` → serialized
  result), `DISCOPT_SOLVE_*` knobs, `discopt-solve` socket.
- **`result_io.py`** — JSON (de)serialization for `SolveResult` (none existed),
  options↔wire helpers (`SolverTuning`↔dict, callbacks dropped), stdout summary,
  AMPL `.sol` / JSON writers.
- **`profiles.py`** — named option profiles (built-in `fast`/`exact`/`feasible` +
  user TOML at `~/.config/discopt/profiles.toml` and `./discopt.toml`).
  Precedence CLI flag > profile > defaults; `tuning` merged key-wise.
- **`cli.py`** — `discopt solve` (+ flags, `--profile`, `--tuning key=val`,
  `--no-daemon`, `--json`/`--sol`/`--out-dir`, `--format`, `--hard-timeout`) and
  `discopt daemon`. Output is **stdout-only by default** (litter-safe); files only
  on request. Also made the heavy `doe`/`tutor` subparsers lazy — `import
  discopt.doe.cli` alone is ~0.4 s, paid by every CLI command; warm `discopt
  solve` dropped **0.56 s → 0.18 s**.

## Robustness (the part that matters for a benchmark)
A single-threaded daemon serves one solve at a time, so a wedged solve must not
block the run:
- **Client-side timeout** — the request `recv` is bounded at `time_limit + grace`
  (and the pre-solve version probe too, another hang vector). On timeout the
  client kills the daemon and falls back in-process. A stuck solve can't hang the
  worker forever.
- **`kill_daemon` / `discopt daemon kill`** — SIGTERM→SIGKILL by PID file, for a
  wedged daemon that won't answer the cooperative `stop`.
- **Daemon-side forked watchdog** (`--hard-timeout`, **default off**) — the daemon
  forks a child that SIGKILLs it on overrun, enforcing a hard deadline
  **independently of the solver AND any client** (covers an orphaned worker, and a
  solve wedged deep in XLA/Rust that no in-process signal could interrupt).

The client imports no JAX, so the warm path is ~0.2 s vs ~1.5 s cold. Correctness
never depends on the daemon: an unreachable/disabled/wedged daemon falls back to
in-process. Warm-daemon results verified byte-identical to in-process on 9/9
instances.

## Tests
37 daemon tests + 41 feature tests (serialization, profiles, daemon glue, CLI,
kill, recv-timeout, watchdog) + a slow real-subprocess end-to-end (spawn → warm →
status → stop). GAMS daemon regression 18/18. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
