### PR TITLE
fix: keep JAX float64 default even when jax is imported before discopt

### DIFF
--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -39,9 +39,20 @@ __version__ = "0.4.1.dev0"
 # discopt`` free of the multi-second jax import for code paths (e.g. the GAMS
 # link's LP/MILP solves) that never touch jax.
 import os as _os
+import sys as _sys
 
 if _os.environ.get("JAX_ENABLE_X64", "1") != "0":
     _os.environ.setdefault("JAX_ENABLE_X64", "1")
+    # The env var only takes effect if jax has not been imported yet. If the
+    # caller did ``import jax`` *before* ``import discopt``, jax already read the
+    # (unset) variable and is in float32 — silently the wrong precision. Update
+    # its live config directly in that case. Guarded on ``jax in sys.modules`` so
+    # this never forces the multi-second jax import on jax-free code paths.
+    if "jax" in _sys.modules:
+        try:
+            _sys.modules["jax"].config.update("jax_enable_x64", True)
+        except Exception:
+            pass
 
 # Enable JAX's persistent (on-disk) compilation cache. A solve recompiles a
 # handful of small XLA kernels (relaxation evaluators, NLP residual/Jacobian,

--- a/python/tests/test_x64_default.py
+++ b/python/tests/test_x64_default.py
@@ -1,0 +1,54 @@
+"""discopt must default to JAX float64 unless the user opts out.
+
+float32 silently produces ~1e-6 residual noise that breaks IPOPT tolerances and
+solver correctness, so ``import discopt`` enables ``jax_enable_x64`` by default.
+These run in subprocesses to control jax-vs-discopt import order (this test
+process already has both imported with x64 on).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _run(code: str, x64_env: str | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("JAX_ENABLE_X64", None)  # start from "unset" unless overridden
+    if x64_env is not None:
+        env["JAX_ENABLE_X64"] = x64_env
+    return subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env, timeout=120
+    )
+
+
+def test_x64_on_when_discopt_imported_first():
+    p = _run("import discopt, jax; print('X64', jax.config.jax_enable_x64)")
+    assert p.returncode == 0, p.stderr[-400:]
+    assert "X64 True" in p.stdout
+
+
+def test_x64_on_when_jax_imported_first():
+    # The edge case: jax reads JAX_ENABLE_X64 at its own import, so importing it
+    # before discopt would leave it float32 unless discopt updates the live config.
+    p = _run("import jax, discopt; print('X64', jax.config.jax_enable_x64)")
+    assert p.returncode == 0, p.stderr[-400:]
+    assert "X64 True" in p.stdout
+
+
+def test_optout_respected():
+    p = _run("import jax, discopt; print('X64', jax.config.jax_enable_x64)", x64_env="0")
+    assert p.returncode == 0, p.stderr[-400:]
+    assert "X64 False" in p.stdout
+
+
+def test_import_discopt_does_not_force_jax_import():
+    # The x64 default must stay free: importing discopt must not pull in jax.
+    p = _run("import discopt, sys; print('JAX_LOADED', 'jax' in sys.modules)")
+    assert p.returncode == 0, p.stderr[-400:]
+    assert "JAX_LOADED False" in p.stdout


### PR DESCRIPTION
## Summary

discopt enables JAX 64-bit by default (float32 gives ~1e-6 residual noise that
breaks IPOPT tolerances and silently corrupts solver results). It did this by
setting `JAX_ENABLE_X64=1` in the environment at import, which JAX reads at its
own import.

**The gap:** if a caller did `import jax` *before* `import discopt`, JAX had
already read the unset variable and was stuck in **float32** — a silent
wrong-precision trap:

```python
import jax; import discopt
jax.config.jax_enable_x64   # -> False  (before this fix)
```

## Fix

Also update JAX's live config when jax is already imported, so the default holds
regardless of import order. Guarded on `"jax" in sys.modules`, so `import discopt`
still **never forces** the multi-second jax import on jax-free code paths (the
GAMS LP/MILP link, CLI parsing, etc.). The opt-out (`JAX_ENABLE_X64=0`) is still
honored — the whole block is skipped then.

| order (no env set) | before | after |
|---|---|---|
| `import discopt` then jax | x64 ✓ | x64 ✓ |
| **`import jax` then discopt** | **float32 ✗** | **x64 ✓** |
| `JAX_ENABLE_X64=0` opt-out | off ✓ | off ✓ |
| `import discopt` pulls in jax? | no ✓ | no ✓ |

Adds 4 subprocess regression tests pinning the import-order matrix. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
