### PR TITLE
fix(presolve): derive log/sqrt domain bounds to stop a false infeasible (#265)

### DIFF
--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -2225,6 +2225,92 @@ class BilinearProductEqualityRule(NonlinearBoundTighteningRule):
         return tightened_lb, tightened_ub
 
 
+class FunctionDomainBoundRule(NonlinearBoundTighteningRule):
+    """Apply a monotone function's natural domain to its single-variable argument.
+
+    ``log``/``log2``/``log10`` require a strictly positive argument, ``sqrt`` a
+    non-negative one, ``log1p`` an argument ``>= -1`` (see ``_MONOTONE_DOMAINS``).
+    Wherever such a function appears in the model — objective *or* constraint, and
+    inside *any* surrounding expression (e.g. the ``log(x)`` in ``x*log(x)``) — its
+    argument must lie in the domain at every evaluable point, so the implied bound
+    on the argument variable holds globally.
+
+    :class:`MonotoneFunctionBoundsRule` only derives domain bounds for a function
+    that is the *whole* body of a ``<=``/``==`` constraint; it misses functions in
+    the objective or nested in products. A free variable fed to ``log`` (e.g.
+    MINLPLib ``ex8_5_4``'s ``log(x0)*x0`` objective with all-free variables) then
+    keeps an unbounded, sign-unconstrained box: the local NLP wanders into
+    ``x <= 0`` where ``log`` is undefined, every node solve fails, and the search
+    exhausts with no incumbent — falsely reported ``infeasible`` (issue #265).
+
+    This rule closes that gap for any single-variable affine argument. Soundness:
+    the domain bound never removes a point where the function is defined, so no
+    feasible solution is cut; multi-variable arguments (``log(x1 - x2)``) and
+    non-affine ones are conservatively skipped.
+    """
+
+    name = "function_domain_bound"
+
+    def tighten(self, model, flat_lb, flat_ub, metadata):
+        lb = np.asarray(flat_lb, dtype=np.float64).copy()
+        ub = np.asarray(flat_ub, dtype=np.float64).copy()
+
+        def _subexprs(expr):
+            if isinstance(expr, BinaryOp):
+                return [expr.left, expr.right]
+            if isinstance(expr, UnaryOp):
+                return [expr.operand]
+            if isinstance(expr, (FunctionCall, CustomCall)):
+                return list(expr.args)
+            if isinstance(expr, IndexExpression):
+                return [expr.base]
+            if isinstance(expr, SumExpression):
+                return [expr.operand]
+            if isinstance(expr, SumOverExpression):
+                return list(expr.terms)
+            if isinstance(expr, MatMulExpression):
+                return [expr.left, expr.right]
+            return []
+
+        def walk(expr):
+            if (
+                isinstance(expr, FunctionCall)
+                and expr.func_name in _MONOTONE_DOMAINS
+                and len(expr.args) == 1
+            ):
+                domain_lb, domain_ub = _MONOTONE_DOMAINS[expr.func_name]
+                if domain_lb is not None or domain_ub is not None:
+                    match = _match_affine_var(expr.args[0], 1.0, metadata)
+                    if match is not None:
+                        flat_idx, coeff, offset = match
+                        if flat_idx is not None and abs(coeff) > 1e-12:
+                            _tighten_affine_argument_interval(
+                                lb,
+                                ub,
+                                metadata,
+                                flat_idx,
+                                coeff,
+                                offset,
+                                arg_lb=domain_lb,
+                                arg_ub=domain_ub,
+                            )
+            for sub in _subexprs(expr):
+                walk(sub)
+
+        try:
+            if model._objective is not None:
+                walk(model._objective.expression)
+            for c in model._constraints:
+                walk(c.body)
+        except NonlinearBoundTighteningInfeasible:
+            # An empty argument domain is a genuine infeasibility proof; let it
+            # propagate so the caller can certify it.
+            raise
+        except Exception:
+            return np.asarray(flat_lb, dtype=np.float64), np.asarray(flat_ub, dtype=np.float64)
+        return lb, ub
+
+
 _PERIODIC_FUNCS = frozenset({"sin", "cos"})
 _TWO_PI = 2.0 * np.pi
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2544,12 +2544,21 @@ def solve_model(
     # free x) are left untouched. Sound: the reduction only shrinks the box.
     try:
         from discopt._jax.nonlinear_bound_tightening import (
+            FunctionDomainBoundRule,
             PeriodicVariableBoundRule,
             tighten_nonlinear_bounds,
         )
 
+        # Two domain/period reductions that hand the spatial+NLP paths a valid
+        # box on otherwise-free nonlinear variables: restrict sin/cos-only angles
+        # to one period, and clamp log/sqrt arguments to their natural domain so
+        # the local NLP never wanders into the undefined region (issue #265's
+        # false-infeasible from a free log argument).
         _per_lb, _per_ub, _per_stats = tighten_nonlinear_bounds(
-            model, _origin_lb_chk, _origin_ub_chk, rules=(PeriodicVariableBoundRule(),)
+            model,
+            _origin_lb_chk,
+            _origin_ub_chk,
+            rules=(PeriodicVariableBoundRule(), FunctionDomainBoundRule()),
         )
         if _per_stats.n_tightened > 0:
             from discopt.solvers.amp import _apply_flat_bounds_to_model

--- a/python/tests/test_issue_265_log_domain_bounds.py
+++ b/python/tests/test_issue_265_log_domain_bounds.py
@@ -1,0 +1,97 @@
+"""Issue #265: a free variable fed to ``log`` must not yield a false ``infeasible``.
+
+MINLPLib ``ex8_5_4`` is feasible (optimum ``-0.0004251471``) but discopt reported
+``infeasible``: all five variables are declared *free* and the objective contains
+``log(x0)*x0``. With no bound forcing ``x0 > 0`` the local NLP wandered into the
+undefined ``log`` domain, every node solve failed, and the search exhausted with no
+incumbent — which the spatial B&B reports as ``infeasible``.
+
+``FunctionDomainBoundRule`` derives the implied domain bound (``log`` argument
+``> 0``, ``sqrt`` argument ``>= 0``, …) wherever the function appears — objective
+or constraint, nested in any expression — so the NLP stays in-domain and the
+feasible optimum is found. Only single-variable affine arguments are bounded; a
+multi-variable argument such as ``log(x1 - x2)`` is conservatively left alone.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt._jax.nonlinear_bound_tightening import (  # noqa: E402
+    FunctionDomainBoundRule,
+    build_flat_variable_metadata,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _tighten(model):
+    meta = build_flat_variable_metadata(model)
+    n = len(meta.flat_var_types)
+    lb = np.full(n, -np.inf)
+    ub = np.full(n, np.inf)
+    return FunctionDomainBoundRule().tighten(model, lb, ub, meta)
+
+
+def test_log_argument_gets_nonnegative_lower_bound():
+    m = dm.Model("logobj")
+    x = m.continuous("x", lb=-np.inf, ub=np.inf)
+    m.minimize(x * dm.log(x))  # log nested inside a product, in the objective
+    lb, ub = _tighten(m)
+    assert lb[0] == 0.0
+    assert ub[0] == np.inf
+
+
+def test_sqrt_argument_gets_nonnegative_lower_bound():
+    m = dm.Model("sqrtobj")
+    y = m.continuous("y", lb=-np.inf, ub=np.inf)
+    m.minimize(dm.sqrt(y) + y)
+    lb, _ = _tighten(m)
+    assert lb[0] == 0.0
+
+
+def test_affine_log_argument_inverts_bound():
+    m = dm.Model("afflog")
+    z = m.continuous("z", lb=-np.inf, ub=np.inf)
+    m.minimize(dm.log(2.0 * z + 1.0))  # 2z + 1 > 0  ->  z >= -0.5
+    lb, _ = _tighten(m)
+    assert lb[0] == pytest.approx(-0.5)
+
+
+def test_multivariable_log_argument_is_not_bounded():
+    """log(x0 - x1) > 0 implies nothing about x0 or x1 individually — abstain."""
+    m = dm.Model("multivar")
+    x = m.continuous("x", shape=(2,), lb=-np.inf, ub=np.inf)
+    m.minimize(dm.log(x[0] - x[1]) + x[0])
+    lb, ub = _tighten(m)
+    assert np.all(lb == -np.inf)
+    assert np.all(ub == np.inf)
+
+
+def test_log_in_constraint_body_is_bounded():
+    m = dm.Model("logcon")
+    x = m.continuous("x", lb=-np.inf, ub=np.inf)
+    y = m.continuous("y", lb=0, ub=10)
+    m.minimize(y)
+    m.subject_to(dm.log(x) + y >= 1.0)  # x must be > 0 for log to be defined
+    lb, _ = _tighten(m)
+    assert lb[0] == 0.0
+
+
+def test_free_variable_xlogx_is_feasible_not_infeasible():
+    """The end-to-end #265 symptom: free log argument → feasible, never infeasible."""
+    m = dm.Model("xlogx")
+    x = m.continuous("x", lb=-np.inf, ub=np.inf)
+    m.minimize(x * dm.log(x))  # min at x = 1/e, value -1/e
+    m.subject_to(x <= 5.0)
+    r = m.solve(time_limit=5, gap_tolerance=1e-4)
+    assert r.status != "infeasible"
+    assert r.status in ("optimal", "feasible")
+    assert r.objective is not None
+    assert r.objective == pytest.approx(-1.0 / np.e, abs=1e-3)


### PR DESCRIPTION
## Summary

Fixes #265. MINLPLib `ex8_5_4` is **feasible** (optimum `-0.0004251471`) but discopt reported **`infeasible`** — a false-infeasible soundness bug.

### Root cause
All five variables are declared **free** (`.nl` bound type 3) and the objective is `log(x0)*x0`. With no bound forcing `x0 > 0`, the local NLP wandered into the undefined `log` domain (NaN), every node solve failed, and the spatial B&B exhausted with **no incumbent** — which it reports as `infeasible` (no resource limit hit).

`MonotoneFunctionBoundsRule` already knows each function's natural domain (`_MONOTONE_DOMAINS`: `log → arg>0`, `sqrt → arg≥0`, …) but only applies it when the function is the **whole body of a `<=`/`==` constraint**. It misses functions in the **objective** or **nested inside a product** like `log(x0)*x0`, so the free `log` argument kept an unbounded, sign-unconstrained box.

### Fix
Add `FunctionDomainBoundRule`, which applies the domain bound to any **single-variable affine argument** of a monotone-domain function **wherever it appears** — objective or constraint, nested in any expression — and wire it into the early presolve next to `PeriodicVariableBoundRule`.

| | status | objective |
|---|---|---|
| before | `infeasible` | `None` |
| after | `feasible` | `-0.0004251471` (= MINLPLib `=best=`) |

### Soundness
A domain bound never removes a point where the function is defined, so **no feasible solution is cut**. The bound is the *closed* domain (`arg ≥ 0`), which only ever adds a measure-zero infeasible boundary point — no epsilon nudging that could clip a feasible optimum. Multi-variable arguments (`log(x1 - x2)`) and non-affine ones are conservatively skipped; an empty argument domain is allowed to propagate as a genuine infeasibility proof.

## Testing
- New `python/tests/test_issue_265_log_domain_bounds.py` (6 tests): single-variable `log`/`sqrt` bounding, affine-argument inversion (`log(2z+1) → z ≥ −0.5`), the multi-variable abstain case, `log` in a constraint body, and the end-to-end free-variable `x·log(x)` returning `feasible -1/e` (never `infeasible`).
- Bound-tightening suite: **179 passed**. Log/sqrt/infeasible slice (incl. `gear4_false_infeasible`): **283 passed**.
- `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
