### PR TITLE
docs(jupyter-book): fix copyright year (2023→2026) and add GitHub repo button

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,11 +1,16 @@
 title: discopt
 author: John Kitchin
+copyright: "2026, John Kitchin"
 logo: discopt-logo.png
 execute:
   execute_notebooks: "off"
 repository:
   url: https://github.com/jkitchin/discopt
   branch: main
+  path_to_book: docs
+html:
+  use_repository_button: true
+  use_issues_button: true
 sphinx:
   extra_extensions:
     - sphinxcontrib.bibtex


### PR DESCRIPTION
## Summary

The rendered Jupyter Book footer showed a stale **"2023"** copyright (no `copyright` key was set, so it defaulted) and exposed **no link back to the source repo** (`repository.url` was set but the repository button was never enabled).

- Add `copyright: "2026, John Kitchin"`
- Set `repository.path_to_book: docs`
- Enable `html.use_repository_button` / `use_issues_button`

Rebuilt with `jupyter-book build docs/`: footer now reads **"Copyright 2026, John Kitchin."**, with working GitHub repo + issue links in the header. **Zero build warnings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
