### PR TITLE
fix(factorable-reform): depth-robust _find_clearable_denominator walk (closes #271)

### DIFF
--- a/python/discopt/_jax/convexity/rules.py
+++ b/python/discopt/_jax/convexity/rules.py
@@ -1030,7 +1030,10 @@ class ConvexityBudgetExceeded(Exception):
 # common (shallow) case keeps running inline with the default limit.
 _DEEP_RECURSION_SIZE_GATE = 700
 _DEEP_RECURSION_LIMIT_CAP = 200_000
-_DEEP_RECURSION_STACK_BYTES = 256 * 1024 * 1024
+# 512 MiB: large enough for the deepest MINLPLib expression graphs that drive the
+# headroom path (issue #271's whole-solve walk can need a recursion limit of a few
+# hundred thousand frames; 256 MiB grazed the C-stack ceiling at that depth).
+_DEEP_RECURSION_STACK_BYTES = 512 * 1024 * 1024
 
 
 def _recursion_headroom_need(model: Model) -> int:

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -40,6 +40,8 @@ unconditional once invoked.
 
 from __future__ import annotations
 
+from typing import Callable, TypeVar
+
 import numpy as np
 
 from discopt.modeling.core import (
@@ -67,6 +69,96 @@ _ZERO_MARGIN = 1e-9
 # Reject an aux lift whose induced bound magnitude is effectively infinite: an
 # unbounded monomial aux would make the relaxation/NLP unbounded.
 _INF_THRESH = 1e15
+
+
+# The factorable-reform walkers (``_find_clearable_denominator``, ``_lift_expr``,
+# the ``has_factorable_work`` scanners, ...) recurse one Python frame per
+# expression node.  ``from_nl`` rebuilds a sum/product of N terms as a left-deep
+# binary tree of depth ~N, so a *single* constraint body can be tens of
+# thousands of nodes deep (watercontamination0202r: ~53k, graphpart_clique-30:
+# ~7.6k) and overrun CPython's default 1000-frame recursion limit, raising an
+# *uncaught* ``RecursionError`` (issue #271).  Mirroring the convexity walk's fix
+# (issue #266), the public entry points run the walk with a depth-scaled
+# recursion limit on a large-stack worker thread; this is gated on the deepest
+# expression so the common (shallow) case still runs inline with the default
+# limit, leaving behaviour byte-for-byte identical there.
+#
+# NOTE: the gate is driven by the *maximum single-expression node count*, not the
+# constraint/variable count used by the convexity walk's gate — the hazard here
+# is depth concentrated in one giant body, which a constraint count misses
+# entirely (this model has only ~280 constraints but a 53k-node body).
+_DEEP_RECURSION_SIZE_GATE = 700
+
+
+def _expr_node_count(expr: Expression) -> int:
+    """Count the nodes in *expr* iteratively (so this measurement never itself
+    recurses into the very depth it is trying to size)."""
+    count = 0
+    stack: list[Expression] = [expr]
+    while stack:
+        node = stack.pop()
+        count += 1
+        if isinstance(node, BinaryOp):
+            stack.append(node.left)
+            stack.append(node.right)
+        elif isinstance(node, UnaryOp):
+            stack.append(node.operand)
+        elif isinstance(node, FunctionCall):
+            stack.extend(node.args)
+        elif isinstance(node, SumExpression):
+            stack.append(node.operand)
+        elif isinstance(node, SumOverExpression):
+            stack.extend(node.terms)
+    return count
+
+
+def _max_expr_node_count(model: Model) -> int:
+    """Largest single-expression node count across the objective and constraint
+    bodies — an upper bound on how deep the per-expression walk can recurse."""
+    largest = 0
+    obj = getattr(model, "_objective", None)
+    if obj is not None:
+        largest = _expr_node_count(obj.expression)
+    for c in getattr(model, "_constraints", []) or []:
+        if isinstance(c, Constraint):
+            largest = max(largest, _expr_node_count(c.body))
+    return largest
+
+
+def _recursion_headroom_need(model: Model) -> int:
+    """Estimate the recursion-limit headroom the factorable walk may need.
+
+    Returns 0 when the deepest expression is small enough that the default limit
+    is safe. The estimate is a deliberate over-approximation (recursion depth is
+    bounded by node count); it only affects whether the deep-stack path engages,
+    never what the walk detects.
+    """
+    try:
+        size = _max_expr_node_count(model)
+    except Exception:
+        return 0
+    if size <= _DEEP_RECURSION_SIZE_GATE:
+        return 0
+    # A few Python frames are entered per expression node along the deepest path;
+    # add a fixed cushion for the surrounding call stack.  Capped (matching the
+    # convexity walk's, issue #266) so a pathological size can't request an
+    # unsatisfiable limit.
+    return min(2000 + 6 * size, 600_000)
+
+
+_T = TypeVar("_T")
+
+
+def _run_factorable_with_headroom(model: Model, fn: Callable[[], _T]) -> _T:
+    """Run ``fn`` (a factorable-reform walk over *model*) with size-scaled
+    recursion headroom so deep expression graphs don't ``RecursionError``.
+
+    Delegates to the proven worker-thread runner from the convexity module
+    (issue #266); shallow models run ``fn`` inline at the default limit.
+    """
+    from .convexity.rules import _run_with_deep_recursion
+
+    return _run_with_deep_recursion(fn, depth_need=_recursion_headroom_need(model))
 
 
 def _leaf_index_and_exp(expr: Expression, model: Model):
@@ -706,8 +798,15 @@ def has_factorable_work(model: Model) -> bool:
     expensive convexity classification used to gate the (convexity-destroying)
     rewrite: only nonconvex models that actually have liftable terms pay for
     convexity detection.
-    """
 
+    The structural scan recurses one frame per expression node; on a deep
+    ``from_nl`` graph that can exceed the default recursion limit, so it runs
+    with size-scaled recursion headroom (issue #271).
+    """
+    return _run_factorable_with_headroom(model, lambda: _has_factorable_work_inner(model))
+
+
+def _has_factorable_work_inner(model: Model) -> bool:
     def scan(expr: Expression) -> bool:
         if _find_clearable_denominator(expr, model) is not None:
             return True
@@ -735,10 +834,17 @@ def has_clearable_denominator(model: Model) -> bool:
     a strict improvement for such models, unlike the mixed-product lift which can
     only destroy convexity.  Objective ratios are excluded: clearing multiplies a
     *constraint* through by its denominator and has no analogue for an objective.
+
+    ``_find_clearable_denominator`` recurses one frame per additive node; on a
+    deep ``from_nl`` graph that can exceed the default recursion limit, so the
+    scan runs with size-scaled recursion headroom (issue #271).
     """
-    return any(
-        isinstance(c, Constraint) and _find_clearable_denominator(c.body, model) is not None
-        for c in model._constraints
+    return _run_factorable_with_headroom(
+        model,
+        lambda: any(
+            isinstance(c, Constraint) and _find_clearable_denominator(c.body, model) is not None
+            for c in model._constraints
+        ),
     )
 
 
@@ -1245,9 +1351,19 @@ def factorable_reformulate(model: Model, *, clear_only: bool = False) -> Model:
     even where it was unnecessary; clearing alone is the right rewrite for a
     *convex* model that merely needs its non-constant division exposed to the
     relaxation (see ``has_clearable_denominator``).
+
+    The rewrite walkers recurse one frame per expression node; on a deep
+    ``from_nl`` graph that can exceed the default recursion limit, so the whole
+    pass runs with size-scaled recursion headroom (issue #271).
     """
+    return _run_factorable_with_headroom(
+        model, lambda: _factorable_reformulate_inner(model, clear_only=clear_only)
+    )
+
+
+def _factorable_reformulate_inner(model: Model, *, clear_only: bool = False) -> Model:
     try:
-        if not has_factorable_work(model):
+        if not _has_factorable_work_inner(model):
             return model
 
         new_model = Model(model.name)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1586,31 +1586,34 @@ def _model_contains_custom_call(model: Model) -> bool:
     branch-and-bound (see ``solve_model``). See issue #27b.
     """
 
-    def _walk(expr) -> bool:
-        if isinstance(expr, CustomCall):
-            return True
-        # Generic child traversal mirroring the DAG node fields used elsewhere
-        # (e.g. discopt._jax.cutting_planes): BinaryOp/MatMul -> left/right,
-        # UnaryOp/SumExpression -> operand, FunctionCall/CustomCall -> args,
-        # SumOverExpression -> terms, IndexExpression -> base.
-        left = getattr(expr, "left", None)
-        if left is not None and _walk(left):
-            return True
-        right = getattr(expr, "right", None)
-        if right is not None and _walk(right):
-            return True
-        operand = getattr(expr, "operand", None)
-        if operand is not None and _walk(operand):
-            return True
-        base = getattr(expr, "base", None)
-        if base is not None and _walk(base):
-            return True
-        for a in getattr(expr, "args", ()) or ():
-            if _walk(a):
+    def _walk(root) -> bool:
+        # Explicit-stack DFS (not Python recursion): ``from_nl`` can build a
+        # single body tens of thousands of nodes deep, which a per-node recursive
+        # walk would overflow the default recursion limit on (issue #271).
+        stack = [root]
+        while stack:
+            expr = stack.pop()
+            if isinstance(expr, CustomCall):
                 return True
-        for t in getattr(expr, "terms", ()) or ():
-            if _walk(t):
-                return True
+            # Generic child traversal mirroring the DAG node fields used
+            # elsewhere (e.g. discopt._jax.cutting_planes): BinaryOp/MatMul ->
+            # left/right, UnaryOp/SumExpression -> operand,
+            # FunctionCall/CustomCall -> args, SumOverExpression -> terms,
+            # IndexExpression -> base.
+            left = getattr(expr, "left", None)
+            if left is not None:
+                stack.append(left)
+            right = getattr(expr, "right", None)
+            if right is not None:
+                stack.append(right)
+            operand = getattr(expr, "operand", None)
+            if operand is not None:
+                stack.append(operand)
+            base = getattr(expr, "base", None)
+            if base is not None:
+                stack.append(base)
+            stack.extend(getattr(expr, "args", ()) or ())
+            stack.extend(getattr(expr, "terms", ()) or ())
         return False
 
     obj = getattr(model, "_objective", None)
@@ -1919,6 +1922,50 @@ def _scoped_tuning(fn: _F) -> _F:
     return cast(_F, wrapper)
 
 
+# Several walkers along the solve path (factorable reformulation, the relaxation
+# compiler's ``_compile_node``, FBBT, ...) recurse one Python frame per
+# expression node. ``from_nl`` can rebuild a *single* constraint body tens of
+# thousands of nodes deep (watercontamination0202r ~53k, graphpart_clique-30
+# ~7.6k), overrunning CPython's default 1000-frame recursion limit and raising an
+# uncaught ``RecursionError`` (issue #271). Mirroring the convexity walk's fix
+# (issue #266), the whole solve runs with a depth-scaled recursion limit on a
+# large-stack worker thread when — and only when — the model has such a deep
+# expression. Shallow models (the overwhelming majority) run inline at the
+# default limit, byte-for-byte unchanged.
+_DEEP_SOLVE_DEPTH_GATE = 700
+
+
+def _scoped_deep_recursion(fn: _F) -> _F:
+    """Run ``fn(model, ...)`` with size-scaled recursion headroom so a model with
+    a very deep expression graph cannot crash the solve with ``RecursionError``.
+
+    The headroom is gated on the deepest single expression in the model, so the
+    common shallow case keeps the default limit and runs inline with no worker
+    thread (zero behavioural change). Deep models run on a large-stack worker
+    thread with a raised limit, the proven mechanism from issue #266.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(model, *args, **kwargs):
+        from discopt._jax.convexity.rules import _run_with_deep_recursion
+        from discopt._jax.factorable_reform import _max_expr_node_count
+
+        try:
+            depth = _max_expr_node_count(model)
+        except Exception:
+            depth = 0
+        if depth <= _DEEP_SOLVE_DEPTH_GATE:
+            return fn(model, *args, **kwargs)
+        # A handful of Python frames are entered per node along the deepest path
+        # (factorable walk, then the compiler's node walk); cushion generously and
+        # cap so a pathological size can't request an unsatisfiable limit.
+        depth_need = min(4000 + 8 * depth, 1_000_000)
+        return _run_with_deep_recursion(lambda: fn(model, *args, **kwargs), depth_need=depth_need)
+
+    return cast(_F, wrapper)
+
+
+@_scoped_deep_recursion
 @_scoped_tuning
 def solve_model(
     model: Model,

--- a/python/tests/test_issue_271_factorable_recursion.py
+++ b/python/tests/test_issue_271_factorable_recursion.py
@@ -1,0 +1,184 @@
+"""Issue #271: deep expression graphs must not crash factorable reformulation
+(or the solve it feeds) with an uncaught ``RecursionError``.
+
+``_find_clearable_denominator`` (and the other factorable-reform expression
+walkers, plus the relaxation compiler's node walk downstream) recurse one Python
+frame per expression node. ``from_nl`` rebuilds a sum/division chain of N terms
+as a left-deep binary tree of depth ~N, so a single constraint body of tens of
+thousands of nodes (e.g. MINLPLib's watercontamination0202r ~53k,
+graphpart_clique-30 ~7.6k) exceeded CPython's default 1000-frame recursion limit
+and raised an *uncaught* ``RecursionError`` straight out of ``solve()``.
+
+The fix mirrors the convexity walk's issue-#266 fix: the public factorable-reform
+entry points (and the whole solve) run the deep walk with a size-scaled recursion
+limit on a large-stack worker thread, gated so shallow models are unaffected; the
+``_model_contains_custom_call`` walker was made explicit-stack iterative.
+
+These tests are written to be robust to the *ambient* recursion limit (CI runs at
+the default 1000; pytest may raise it locally): the model is sized relative to
+``sys.getrecursionlimit()`` so the inner walk is always deeper than the ambient
+limit, and any explicit limit change is restored in a ``finally``.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import sys  # noqa: E402
+
+import discopt.modeling as dm  # noqa: E402
+import pytest  # noqa: E402
+from discopt._jax.factorable_reform import (  # noqa: E402
+    _find_clearable_denominator,
+    _max_expr_node_count,
+    _recursion_headroom_need,
+    factorable_reformulate,
+    has_clearable_denominator,
+    has_factorable_work,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _deep_division_model(n: int) -> dm.Model:
+    """A model whose single constraint body is a depth-``n`` left-deep sum of
+    sign-definite divisions ``x[i] / x[i+1]``.
+
+    The variables are bounded strictly away from zero so every denominator is
+    sign-definite and clearable — exercising the ``_find_clearable_denominator``
+    recursion the bug was reported against. The chain of ``n`` ``+`` terms builds
+    a binary-add tree of depth ~``n``; with ``n`` above the recursion limit the
+    per-node walk would ``RecursionError`` without the headroom fix.
+    """
+    m = dm.Model("deep_div")
+    x = m.continuous("x", shape=(n,), lb=1.0, ub=2.0)
+    body = x[0] / x[1]
+    for i in range(1, n - 1):
+        body = body + x[i] / x[i + 1]
+    m.subject_to(body <= float(n))
+    m.minimize(dm.sum([x[i] for i in range(n)]))
+    return m
+
+
+def _depth_for_limit() -> int:
+    """A node depth comfortably above the ambient recursion limit, so the inner
+    (unwrapped) walk would overflow it but the wrapped entry points must not."""
+    return sys.getrecursionlimit() + 1500
+
+
+def test_headroom_gate_small_model_is_zero():
+    """A shallow model keeps the default limit (no thread, no headroom)."""
+    m = _deep_division_model(20)
+    assert _recursion_headroom_need(m) == 0
+
+
+def test_headroom_scales_for_deep_expression():
+    """A deep single body trips the gate even with few constraints/variables.
+
+    This is the watercontamination0202r failure mode: ~hundreds of constraints
+    but one body of tens of thousands of nodes. The node-count gate must catch it
+    where a constraint/variable count would not.
+    """
+    m = _deep_division_model(2000)
+    assert _max_expr_node_count(m) > 1000
+    assert _recursion_headroom_need(m) > sys.getrecursionlimit()
+
+
+def test_inner_walker_recurses_past_default_limit():
+    """Sanity: the bare recursive walker DOES overflow a limit below the depth.
+
+    Guards the regression: if a future refactor makes the inner walk shallow (or
+    iterative) this asserts the test model is still deep enough to be meaningful
+    against the lowered limit used below.
+    """
+    n = 1200
+    m = _deep_division_model(n)
+    body = m._constraints[0].body
+    old = sys.getrecursionlimit()
+    sys.setrecursionlimit(300)
+    try:
+        with pytest.raises(RecursionError):
+            _find_clearable_denominator(body, m)
+    finally:
+        sys.setrecursionlimit(old)
+
+
+def test_has_factorable_work_no_recursion_error():
+    """The public scan completes on a deep graph instead of ``RecursionError``."""
+    n = _depth_for_limit()
+    m = _deep_division_model(n)
+    # A sign-definite division chain is clearable work, so this is True — and it
+    # must be reached without overflowing the ambient recursion limit.
+    assert has_factorable_work(m) is True
+
+
+def test_has_clearable_denominator_no_recursion_error():
+    n = _depth_for_limit()
+    m = _deep_division_model(n)
+    assert has_clearable_denominator(m) is True
+
+
+def test_factorable_reformulate_no_recursion_error():
+    """The full reformulation pass completes on a deep graph and stays sound."""
+    n = _depth_for_limit()
+    m = _deep_division_model(n)
+    out = factorable_reformulate(m)
+    # The pass returns a model (rewritten or, defensively, the original) — never
+    # a crash. Clearing the sign-definite denominators changes the model.
+    assert isinstance(out, dm.Model)
+
+
+def test_factorable_walk_under_lowered_limit(monkeypatch):
+    """With the size gate dropped and the limit lowered below the model depth, the
+    headroom path must engage and classify, not ``RecursionError``.
+
+    pytest can raise the interpreter limit well above production's default, so we
+    simulate production by lowering the limit and dropping the gate onto a modest
+    model — exactly the strategy of ``test_issue_266``'s deep-graph test.
+    """
+    from discopt._jax import factorable_reform
+
+    monkeypatch.setattr(factorable_reform, "_DEEP_RECURSION_SIZE_GATE", 50)
+    n = 700
+    m = _deep_division_model(n)
+    old = sys.getrecursionlimit()
+    sys.setrecursionlimit(400)  # below the ~n-deep walk; the runner must raise it
+    try:
+        assert has_factorable_work(m) is True
+        out = factorable_reformulate(m)
+    finally:
+        sys.setrecursionlimit(old)
+    assert isinstance(out, dm.Model)
+
+
+def test_deep_division_solve_does_not_crash(monkeypatch):
+    """A deep-body model solves to a sound status, not a ``RecursionError``.
+
+    End-to-end: ``solve()`` routes through factorable reformulation and the
+    relaxation compiler, both of which walk the deep body. The whole solve runs
+    under size-scaled recursion headroom (``_scoped_deep_recursion``), so it must
+    return a valid status rather than crashing.
+
+    To keep the test fast and deterministic we simulate production rather than
+    build a giant model: drop the solve-path depth gate onto a modest body and
+    lower the recursion limit below that body's depth, so the headroom worker
+    thread is what carries the solve (mirroring ``test_issue_266``'s deep-graph
+    test). Without the fix the solve would ``RecursionError`` at the lowered
+    limit; with it the solve completes with a sound status.
+    """
+    from discopt import solver as solver_mod
+
+    monkeypatch.setattr(solver_mod, "_DEEP_SOLVE_DEPTH_GATE", 50)
+    n = 250  # body depth ~250, comfortably above the lowered limit below
+    m = _deep_division_model(n)
+    old = sys.getrecursionlimit()
+    sys.setrecursionlimit(150)  # below the ~n-deep walk; the runner must raise it
+    try:
+        r = m.solve(time_limit=15.0)
+    finally:
+        sys.setrecursionlimit(old)
+    assert r.status != "error", f"got error result: {getattr(r, '_explanation', None)}"
+    assert r.status in ("optimal", "feasible", "time_limit", "infeasible", "limit")


### PR DESCRIPTION
## Summary

Fixes #271: discopt crashed with an **uncaught** `RecursionError: maximum recursion depth exceeded` in `_find_clearable_denominator` (`python/discopt/_jax/factorable_reform.py`) when solving MINLPLib instances whose `from_nl`-rebuilt expression graph is very deep. The factorable-reform walkers recurse one Python frame per expression node, and a single constraint body can be tens of thousands of nodes deep (graphpart_clique-30 ~7.6k, watercontamination0202r ~53k), overrunning CPython's default 1000-frame recursion limit.

## Approach

This is the same bug class as #266 (convexity walker). I used the **proven worker-thread recursion-headroom** pattern rather than rewriting every walker iteratively, because `factorable_reform.py` has *many* mutually/self-recursive walkers (`_find_clearable_denominator`, `_lift_expr`, `_lift_objective_atoms`, `_prelift_blowup_products`, the three `has_factorable_work` scanners, ...). Wrapping the small set of public entry points protects all of them at once with zero change to what any walker detects — far less risky than converting each one by hand.

- **`factorable_reform.py`**: the public entry points (`has_factorable_work`, `has_clearable_denominator`, `factorable_reformulate`) now run their walk via `_run_factorable_with_headroom`, which reuses the convexity module's `_run_with_deep_recursion` (large-stack worker thread + raised limit). The headroom is gated on the **maximum single-expression node count** (`_max_expr_node_count`), not the constraint/variable count the convexity gate uses — the hazard here is depth concentrated in one giant body, which a constraint count misses entirely (this model has only ~280 constraints but a 53k-node body). Shallow models run inline at the default limit, byte-for-byte unchanged.
- **`solver.py`**: the same RecursionError then surfaced *downstream* of the (now-fixed) factorable pass — in the relaxation compiler's `_compile_node` walk and `_model_contains_custom_call`. So the whole solve additionally runs under the same size-scaled headroom via a new `_scoped_deep_recursion` decorator on `solve_model` (gated identically), and `_model_contains_custom_call` was converted to an explicit-stack iterative walk.
- **`convexity/rules.py`**: raised the shared worker-thread stack from 256 MiB to 512 MiB so the deepest graphs' raised limit (a few hundred thousand frames) doesn't graze the C stack. Increase only — no behavioural change to #266.

Semantics are unchanged: every walker still detects exactly what it did before; only how deep it can walk is affected.

## Before / after (both target instances)

| instance | before | after |
|---|---|---|
| watercontamination0202r | `RecursionError` | `optimal`, obj 97.904 |
| graphpart_clique-30 | `RecursionError` | `feasible`, obj 495.0 |

(via the plain `dm.from_nl(...).solve(time_limit=30, gap_tolerance=1e-4)` path, no manual recursion tweaks.)

## Tests

- New `python/tests/test_issue_271_factorable_recursion.py` (8 tests, all pass). Mirrors `test_issue_266_deep_recursion.py`: the gate/headroom helpers, a sanity check that the bare walker *does* overflow a lowered limit, the public entry points completing on a deep graph, and an end-to-end deep-body `solve()`. All are **robust to the ambient recursion limit** — the model is sized relative to `sys.getrecursionlimit()` (or the gate is dropped and the limit lowered, restored in a `finally`) so they behave identically at CI's default 1000 and pytest's local 3000.
- `pytest python/tests/ -k "factorable or reform or clearable"` → **127 passed**.
- `test_issue_266_deep_recursion.py` → all pass (the touched stack constant).
- `ruff check` + `ruff format --check` clean on all changed files; `mypy python/discopt/_jax/factorable_reform.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
