### PR TITLE
chore(deps): bump feral to the FT-update LU fix (O(bump²)→O(bump)) — #268 LP speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "feral"
 version = "0.11.2"
-source = "git+https://github.com/jkitchin/feral?tag=v0.11.2#75b03220d6396649fdfc9cf8a1f3e8120adfa68e"
+source = "git+https://github.com/jkitchin/feral?rev=a9cea82f99c996551805f1b2d145a750c5f6bbca#a9cea82f99c996551805f1b2d145a750c5f6bbca"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -95,7 +95,7 @@ dependencies = [
 [[package]]
 name = "feral-amd"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?tag=v0.11.2#75b03220d6396649fdfc9cf8a1f3e8120adfa68e"
+source = "git+https://github.com/jkitchin/feral?rev=a9cea82f99c996551805f1b2d145a750c5f6bbca#a9cea82f99c996551805f1b2d145a750c5f6bbca"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -103,7 +103,7 @@ dependencies = [
 [[package]]
 name = "feral-amf"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?tag=v0.11.2#75b03220d6396649fdfc9cf8a1f3e8120adfa68e"
+source = "git+https://github.com/jkitchin/feral?rev=a9cea82f99c996551805f1b2d145a750c5f6bbca#a9cea82f99c996551805f1b2d145a750c5f6bbca"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "feral-kahip"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?tag=v0.11.2#75b03220d6396649fdfc9cf8a1f3e8120adfa68e"
+source = "git+https://github.com/jkitchin/feral?rev=a9cea82f99c996551805f1b2d145a750c5f6bbca#a9cea82f99c996551805f1b2d145a750c5f6bbca"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "feral-metis"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?tag=v0.11.2#75b03220d6396649fdfc9cf8a1f3e8120adfa68e"
+source = "git+https://github.com/jkitchin/feral?rev=a9cea82f99c996551805f1b2d145a750c5f6bbca#a9cea82f99c996551805f1b2d145a750c5f6bbca"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -130,12 +130,12 @@ dependencies = [
 [[package]]
 name = "feral-ordering-core"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?tag=v0.11.2#75b03220d6396649fdfc9cf8a1f3e8120adfa68e"
+source = "git+https://github.com/jkitchin/feral?rev=a9cea82f99c996551805f1b2d145a750c5f6bbca#a9cea82f99c996551805f1b2d145a750c5f6bbca"
 
 [[package]]
 name = "feral-scotch"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?tag=v0.11.2#75b03220d6396649fdfc9cf8a1f3e8120adfa68e"
+source = "git+https://github.com/jkitchin/feral?rev=a9cea82f99c996551805f1b2d145a750c5f6bbca#a9cea82f99c996551805f1b2d145a750c5f6bbca"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -10,7 +10,7 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # feral: pure-Rust sparse linear algebra. Provides the unsymmetric LU basis
 # engine (ftran/btran + product-form column updates) that backs the warm-started
 # simplex node engine for MILP. Pure-Rust, so clean-wheel builds are preserved.
-feral = { git = "https://github.com/jkitchin/feral", tag = "v0.11.2" }
+feral = { git = "https://github.com/jkitchin/feral", rev = "a9cea82f99c996551805f1b2d145a750c5f6bbca" }
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to
 # 1.10 to keep the crate's MSRV (1.75); 1.12+ requires rustc 1.80.


### PR DESCRIPTION
## Summary

Pins feral to **`a9cea82`** (feral PR #88, *"Forrest–Tomlin row-elimination LU update O(bump²) → O(bump)"*) — the Step-2 fix for **feral#87 / discopt#229**, and the deepest McCormick-LP bottleneck behind **#268**'s continuous-nonconvex tier.

Background (from the #268 profiling): on a wide lifted-McCormick basis the FT basis update produced dense spikes whose bump elimination was O(bump²) — a single node LP relaxation could take hundreds of ms, with the FT update measured at **~89% of the solve**. #273 (sparse factorize + adaptive refactor) trimmed it driver-side; this bump fixes it at the source.

## Result — `autocorr_bern20-05` root McCormick-LP solve

| build | time | vs original |
|---|---|---|
| feral v0.11.2 (original) | 3.6 s | 1× |
| + #273 (sparse factorize + adaptive refactor) | 1.24 s | 2.9× |
| **+ feral a9cea82 (this PR)** | **0.141 s** | **~25×** |

Approaching HiGHS (~0.015 s). Faster node LPs let the spatial B&B explore far more nodes within budget — the throughput limiter for the continuous-nonconvex tier.

## Soundness / validation

The FT-update redesign is a build-artifact / numerical-conditioning change — it does not alter any solve's certified result. Validated:
- **333** discopt-core Rust tests pass.
- **1144** Python LP / spatial / mccormick / simplex / correctness / sound / minlp tests pass — **incorrect_count = 0**.

## Notes

- Pins the **commit** (feral has not cut a release past v0.11.2 yet). Re-pin to a tag once feral tags it.
- Completes the **LP-throughput** lever of #268. The residual combinatorial instances (`ex1263`, `ex1266`) that find no feasible integer point remain open (they need a stronger combinatorial primal heuristic, not LP speed) — so this does not auto-close #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
