### PR TITLE
Fix AMP tan/abs MINLPTests certification

### DIFF
--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -512,6 +512,8 @@ def _solve_nlp_subproblem(
         # try cyipopt before falling back to POUNCE.
         solver_sequence = _normalize_nlp_solver_sequence(nlp_solver)
 
+        from discopt.solvers import SolveStatus
+
         result = None
         for solver_name in solver_sequence:
             remaining = _remaining_wall_time(local_deadline)
@@ -520,31 +522,32 @@ def _solve_nlp_subproblem(
             options: dict[str, float | int] = {"print_level": 0, "max_iter": 300}
             if remaining is not None:
                 options["max_wall_time"] = max(remaining, 0.05)
-            if solver_name == "ipopt":
-                from discopt.solvers.nlp_ipopt import solve_nlp
+            try:
+                if solver_name == "ipopt":
+                    from discopt.solvers.nlp_ipopt import solve_nlp
 
-                if remaining is not None:
-                    options["max_cpu_time"] = max(remaining, 0.05)
-                trial = solve_nlp(
-                    cast(Any, backend_evaluator),
-                    x0_clipped,
-                    options=options,
-                )
-            else:
-                from discopt.solvers.nlp_pounce import solve_nlp
+                    if remaining is not None:
+                        options["max_cpu_time"] = max(remaining, 0.05)
+                    trial = solve_nlp(
+                        cast(Any, backend_evaluator),
+                        x0_clipped,
+                        options=options,
+                    )
+                else:
+                    from discopt.solvers.nlp_pounce import solve_nlp
 
-                trial = solve_nlp(
-                    cast(Any, backend_evaluator),
-                    x0_clipped,
-                    options=options,
-                )
+                    trial = solve_nlp(
+                        cast(Any, backend_evaluator),
+                        x0_clipped,
+                        options=options,
+                    )
+            except Exception as e:
+                logger.debug("AMP NLP subproblem backend %s failed: %s", solver_name, e)
+                continue
             result = trial
-            from discopt.solvers import SolveStatus
 
             if trial.status == SolveStatus.OPTIMAL:
                 break
-
-        from discopt.solvers import SolveStatus
 
         if result is not None and result.status == SolveStatus.OPTIMAL:
             x_opt = np.asarray(result.x, dtype=np.float64)

--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -27,7 +27,7 @@ import time
 from dataclasses import dataclass
 from functools import lru_cache
 from importlib.util import find_spec
-from typing import Any, Callable, Optional, cast
+from typing import Any, Callable, Optional, Sequence, cast
 
 import numpy as np
 
@@ -69,6 +69,13 @@ _SMALL_INT_FALLBACK_MAX_ASSIGNMENTS = 128
 def _has_cyipopt() -> bool:
     """Return True when cyipopt is importable in the active environment."""
     return find_spec("cyipopt") is not None
+
+
+def _normalize_nlp_solver_sequence(nlp_solver: str | Sequence[str]) -> list[str]:
+    """Return the ordered local NLP backends to try for one candidate."""
+    if isinstance(nlp_solver, str):
+        return [nlp_solver]
+    return list(nlp_solver)
 
 
 def _build_x_dict(x_flat: np.ndarray, model: Model) -> dict:
@@ -483,7 +490,7 @@ def _solve_nlp_subproblem(
     x0: np.ndarray,
     lb: np.ndarray,
     ub: np.ndarray,
-    nlp_solver: str = "ipm",
+    nlp_solver: str | Sequence[str] = "ipm",
     time_limit: Optional[float] = None,
 ) -> tuple[Optional[np.ndarray], Optional[float]]:
     """Solve the NLP relaxation with given bounds.
@@ -500,10 +507,10 @@ def _solve_nlp_subproblem(
         from discopt.solver import _BoundOverrideEvaluator
 
         backend_evaluator = _BoundOverrideEvaluator(evaluator, lb, ub)
-        # "ipm"/"pounce" both route to POUNCE (a robust pure-Rust Ipopt port),
-        # so no separate Ipopt retry is needed for AMP's tightly-fixed integer
-        # subproblems. An explicit nlp_solver="ipopt" still uses cyipopt.
-        solver_sequence = [nlp_solver]
+        # "ipm"/"pounce" both route to POUNCE (a robust pure-Rust Ipopt port).
+        # Callers may pass a sequence when a pure-continuous AMP candidate should
+        # try cyipopt before falling back to POUNCE.
+        solver_sequence = _normalize_nlp_solver_sequence(nlp_solver)
 
         result = None
         for solver_name in solver_sequence:
@@ -782,7 +789,7 @@ def _select_best_nlp_candidate(
     flat_ub: np.ndarray,
     constraint_lb: np.ndarray,
     constraint_ub: np.ndarray,
-    nlp_solver: str,
+    nlp_solver: str | Sequence[str],
     deadline: Optional[float] = None,
 ) -> tuple[Optional[np.ndarray], Optional[float]]:
     """Return the best feasible NLP candidate from a prioritized candidate list."""
@@ -837,6 +844,9 @@ def _solve_best_nlp_candidate(
 ) -> tuple[Optional[np.ndarray], Optional[float]]:
     """Improve the incumbent from Alpine-ordered local NLP starts."""
     if all(v.var_type == VarType.CONTINUOUS for v in model._variables):
+        local_nlp_solver: str | Sequence[str] = nlp_solver
+        if nlp_solver == "ipm" and _has_cyipopt():
+            local_nlp_solver = ("ipopt", "ipm")
         starts: list[np.ndarray] = []
         for seed in (incumbent, initial_point, x0):
             if seed is not None:
@@ -844,6 +854,7 @@ def _solve_best_nlp_candidate(
         starts.extend(_continuous_recovery_starts(flat_lb, flat_ub))
         candidates = _dedupe_candidate_points(starts)
     else:
+        local_nlp_solver = nlp_solver
         candidates = []
         for seed in (incumbent, initial_point, x0, _default_nlp_start(flat_lb, flat_ub)):
             if seed is not None:
@@ -858,7 +869,7 @@ def _solve_best_nlp_candidate(
         flat_ub,
         constraint_lb,
         constraint_ub,
-        nlp_solver,
+        local_nlp_solver,
         deadline=deadline,
     )
 

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -2441,6 +2441,47 @@ def test_best_nlp_candidate_prioritizes_incumbent_start_then_model_start_then_mi
     assert seen_starts[:3] == [2.0, 4.0, 6.0]
 
 
+def test_best_nlp_candidate_uses_ipopt_fallback_for_pure_continuous_ipm(monkeypatch):
+    """Pure-continuous AMP candidates should try Ipopt before POUNCE when available."""
+    from discopt.solvers import amp as amp_mod
+
+    m = Model("continuous_candidate_backend")
+    m.continuous("x", lb=-1.0, ub=1.0)
+    seen = {}
+
+    monkeypatch.setattr(amp_mod, "_has_cyipopt", lambda: True)
+
+    def fake_select(
+        candidates,
+        model,
+        evaluator,
+        flat_lb,
+        flat_ub,
+        constraint_lb,
+        constraint_ub,
+        nlp_solver,
+        deadline=None,
+    ):
+        del candidates, model, evaluator, flat_lb, flat_ub, constraint_lb, constraint_ub, deadline
+        seen["nlp_solver"] = nlp_solver
+        return np.array([0.0], dtype=np.float64), 0.0
+
+    monkeypatch.setattr(amp_mod, "_select_best_nlp_candidate", fake_select)
+
+    amp_mod._solve_best_nlp_candidate(
+        np.array([0.25], dtype=np.float64),
+        m,
+        evaluator=object(),
+        flat_lb=np.array([-1.0], dtype=np.float64),
+        flat_ub=np.array([1.0], dtype=np.float64),
+        constraint_lb=np.array([], dtype=np.float64),
+        constraint_ub=np.array([], dtype=np.float64),
+        nlp_solver="ipm",
+    )
+
+    assert seen["nlp_solver"] == ("ipopt", "ipm")
+
+
 def test_best_nlp_candidate_rejects_noninteger_nlp_return(monkeypatch):
     """NLP candidates that violate integrality should be discarded."""
     from discopt.solvers import amp as amp_mod

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -594,6 +594,53 @@ def test_solve_nlp_subproblem_uses_pounce_and_restores_bounds(monkeypatch):
     np.testing.assert_allclose(x.ub, original_ub)
 
 
+def test_solve_nlp_subproblem_continues_after_backend_exception(monkeypatch):
+    """A failing first NLP backend should not suppress later fallback backends."""
+    import discopt.solvers.nlp_ipopt as ipopt_mod
+    import discopt.solvers.nlp_pounce as pounce_mod
+    from discopt.solvers import NLPResult, SolveStatus
+    from discopt.solvers import amp as amp_mod
+
+    m = Model("nlp_backend_exception_fallback")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    m.minimize((x - 0.25) ** 2)
+
+    class FakeEvaluator:
+        _model = m
+        _obj_fn = object()
+
+        def evaluate_objective(self, x_flat):
+            return float((x_flat[0] - 0.25) ** 2)
+
+    calls = []
+
+    def fake_ipopt(evaluator, x0, options=None):
+        del evaluator, x0, options
+        calls.append("ipopt")
+        raise RuntimeError("simulated ipopt failure")
+
+    def fake_pounce(evaluator, x0, options=None):
+        del evaluator, x0, options
+        calls.append("pounce")
+        return NLPResult(status=SolveStatus.OPTIMAL, x=np.array([0.25]), objective=0.0)
+
+    monkeypatch.setattr(ipopt_mod, "solve_nlp", fake_ipopt)
+    monkeypatch.setattr(pounce_mod, "solve_nlp", fake_pounce)
+
+    x_opt, obj = amp_mod._solve_nlp_subproblem(
+        FakeEvaluator(),
+        x0=np.array([0.0], dtype=np.float64),
+        lb=np.array([-1.0], dtype=np.float64),
+        ub=np.array([1.0], dtype=np.float64),
+        nlp_solver=("ipopt", "ipm"),
+        time_limit=10.0,
+    )
+
+    assert calls == ["ipopt", "pounce"]
+    np.testing.assert_allclose(x_opt, np.array([0.25]))
+    assert obj == pytest.approx(0.0)
+
+
 def test_repair_inverted_bounds_snaps_to_midpoint():
     from discopt.solvers import amp as amp_mod
 

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -2899,7 +2899,7 @@ class TestCurrentCodeWeaknesses:
         assert abs(result.objective - instance.expected_obj) <= tol
 
     def test_amp_certifies_tan_abs_nlp_004_010_at_issue_gap(self):
-        """The continuous tan/abs nlp_004 case should certify the issue-79 gap."""
+        """The continuous tan/abs nlp_004 case should certify the issue-89 gap."""
         instance = MINLPTESTS_NLP_BY_ID["nlp_004_010"]
         m = instance.build_fn()
 


### PR DESCRIPTION
## Summary

This fixes the current AMP certification failure for the continuous tan/abs MINLPTests case `nlp_004_010`.

Fork-side evidence:
- Merged fork PR: https://github.com/bernalde/discopt/pull/97
- Motivating fork issue: https://github.com/bernalde/discopt/issues/89

## Root Cause

For pure-continuous AMP candidates with `nlp_solver="ipm"`, the main AMP loop only tried the POUNCE path. The final pure-continuous recovery path already tried `ipopt` first when `cyipopt` was available, then fell back to `ipm`/POUNCE. As a result, `nlp_004_010` could spend 1000 AMP refinements without an in-loop incumbent, then recover only a final feasible incumbent with no certified bound.

This PR uses the same `ipopt` -> `ipm` sequence inside the pure-continuous AMP candidate path, and makes backend fallback robust when one backend raises.

## Changes

- Allows `_solve_nlp_subproblem` to accept an ordered NLP backend sequence.
- Uses `("ipopt", "ipm")` for pure-continuous `nlp_solver="ipm"` candidates when `cyipopt` is available.
- Keeps integer-fixed NLP subproblems on the existing single-backend behavior.
- Continues to later fallback backends if an earlier backend raises.
- Adds regression coverage for both backend selection and exception fallback.
- Corrects the issue reference in the existing tan/abs integration-test docstring.

## Validation

Fork PR #97 was reviewed and merged before opening this upstream PR.

Local validation reported on the fork branch:
- `python/tests/test_amp.py::test_solve_nlp_subproblem_uses_pounce_and_restores_bounds`
- `python/tests/test_amp.py::test_solve_nlp_subproblem_continues_after_backend_exception`
- `python/tests/test_amp.py::test_solve_nlp_subproblem_respects_expired_time_limit`
- `python/tests/test_amp.py::test_recover_pure_continuous_solution_uses_best_start_and_maximize_sign`
- `python/tests/test_amp.py::test_best_nlp_candidate_uses_ipopt_fallback_for_pure_continuous_ipm`
- `python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_certifies_tan_abs_nlp_004_010_at_issue_gap`
- `python/tests/test_amp_integration.py::TestCurrentCodeWeaknesses::test_amp_reports_bound_for_tan_abs_nlp_004_010`
- `python/tests/test_nlp_pounce.py` -> 18 passed
- Filtered AMP-fast selection from the Makefile -> 135 passed, 15 deselected
- `ruff check` on touched/relevant files -> passed
- Commit hook -> ruff, ruff format, mypy passed

The exact issue repro changed from a local failure after about 146 seconds (`status="feasible"`, no certified bound) to a pass with `status="optimal"` in about 1-2 seconds locally.

## Notes

This PR intentionally does not claim to close broader AMP slow-tail tracking. It addresses the current tan/abs certification failure surfaced while triaging the fork issue.
