### PR TITLE
fix(solver): never declare nonconvex MINLP unbounded from a lossy linear projection (#286)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2773,8 +2773,27 @@ def solve_model(
             # no benefit — so the reformulation is discarded and the original model
             # is solved unchanged. This keeps the pass a strict improvement.
             from discopt._jax.problem_classifier import ProblemClass, classify_problem
+            from discopt._jax.term_classifier import classify_nonlinear_terms
 
-            if _ipx is not model and classify_problem(_ipx) == ProblemClass.MILP:
+            # Require the reformulation to be a *genuinely* pure MILP: classify_problem
+            # is largely extract_lp_data-based and can report MILP while nonlinear
+            # terms remain (which that linear projection silently drops). Confirm with
+            # the DAG-walking term classifier, else adopting + routing to the MILP
+            # engine would solve a lossy linear projection — falsely unbounded when a
+            # dropped nonlinear constraint was what bounded an open variable
+            # (carton7, issue #286).
+            _ipx_nl = classify_nonlinear_terms(_ipx) if _ipx is not model else None
+            _ipx_pure_milp = _ipx_nl is not None and not (
+                _ipx_nl.bilinear
+                or _ipx_nl.trilinear
+                or _ipx_nl.multilinear
+                or _ipx_nl.monomial
+                or _ipx_nl.fractional_power
+                or _ipx_nl.bilinear_with_fp
+                or _ipx_nl.ratio_of_products
+                or _ipx_nl.general_nl
+            )
+            if _ipx_pure_milp and classify_problem(_ipx) == ProblemClass.MILP:
                 model = _ipx
                 model._convexity_classification_cache = None
                 model._convexity_time_budget = _convexity_time_budget
@@ -9160,6 +9179,29 @@ def _solve_milp_simplex(
     try:
         from discopt._rust import solve_milp_py
     except ImportError:
+        return None
+
+    # ``extract_lp_data`` captures only the LINEAR part of the model; any nonlinear
+    # term is silently dropped. Solving that linear projection as if exact is sound
+    # ONLY for a genuinely linear model. Otherwise a dropped *bounding* nonlinear
+    # constraint can make the projection falsely unbounded/optimal — carton7
+    # (issue #286): continuous variables with infinite upper bounds, bounded only
+    # by the dropped nonlinear constraints, were reported as a false global
+    # ``unbounded`` at the root. Defer any model carrying nonlinear terms to the
+    # spatial / NLP path (which keeps those constraints).
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    _nl = classify_nonlinear_terms(model)
+    if (
+        _nl.bilinear
+        or _nl.trilinear
+        or _nl.multilinear
+        or _nl.monomial
+        or _nl.fractional_power
+        or _nl.bilinear_with_fp
+        or _nl.ratio_of_products
+        or _nl.general_nl
+    ):
         return None
 
     lp_data = extract_lp_data(model)

--- a/python/tests/test_issue_286_false_unbounded.py
+++ b/python/tests/test_issue_286_false_unbounded.py
@@ -1,0 +1,74 @@
+"""Regression for issue #286: a nonconvex MINLP must never be declared globally
+``unbounded`` because the *linear projection* of its relaxation is unbounded.
+
+carton7 (=opt= 191.73) was reported ``unbounded`` after one node: it reached the
+Rust pure-MILP simplex engine, whose ``extract_lp_data`` silently drops nonlinear
+terms — including the very constraints that bound its infinite-upper-bound
+continuous variables — so the dropped-down LP was genuinely unbounded. Two guards
+now prevent this: the integer-bilinear reformulation is adopted (and routed to the
+MILP engine) only when the *reformulated* model is a genuinely pure MILP, and
+``_solve_milp_simplex`` itself defers on any model carrying nonlinear terms.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import time  # noqa: E402
+
+import discopt.modeling as dm  # noqa: E402
+import pytest  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _nonlinear_with_inf_bound():
+    """min -x  s.t.  x**2 <= 100 (the only thing bounding x, ub=inf) and an
+    integer-bilinear constraint k*j >= 6 that triggers the reformulation path.
+    True optimum: x = 10 -> objective -10. The linear projection (dropping x**2)
+    is unbounded below in -x."""
+    m = dm.Model("i286")
+    k = m.integer("k", lb=1, ub=5)
+    j = m.integer("j", lb=1, ub=5)
+    x = m.continuous("x", lb=0, ub=1e20)
+    m.minimize(-x)
+    m.subject_to(k * j >= 6)
+    m.subject_to(x * x <= 100)
+    return m
+
+
+def test_no_false_unbounded():
+    """End-to-end: never returns a global ``unbounded`` verdict on a problem with
+    a finite optimum (the dropped nonlinear constraint bounds it)."""
+    r = _nonlinear_with_inf_bound().solve(time_limit=20, gap_tolerance=1e-4)
+    assert r.status != "unbounded"
+    assert r.objective is None or r.objective <= 1e-6  # never reports a +inf-style win
+    if r.objective is not None and r.status == "optimal":
+        assert r.objective == pytest.approx(-10.0, abs=1e-2)
+
+
+def test_milp_simplex_defers_on_nonlinear():
+    """The Rust pure-MILP simplex engine must return None (defer) for any model
+    carrying nonlinear terms — its extract_lp_data projection is lossy there."""
+    from discopt.solver import _solve_milp_simplex
+
+    m = _nonlinear_with_inf_bound()
+    out = _solve_milp_simplex(m, 10.0, 1e-4, 1000, time.perf_counter())
+    assert out is None
+
+
+def test_pure_milp_still_uses_simplex():
+    """Guard must be a no-op for a genuinely linear MILP (it still solves)."""
+    from discopt.solver import _solve_milp_simplex
+
+    m = dm.Model("milp")
+    x = m.integer("x", lb=0, ub=10)
+    y = m.integer("y", lb=0, ub=10)
+    m.minimize(-x - 2 * y)
+    m.subject_to(x + y <= 8)
+    m.subject_to(3 * x + y <= 15)
+    out = _solve_milp_simplex(m, 10.0, 1e-4, 100000, time.perf_counter())
+    assert out is not None and out.status == "optimal"
+    assert out.objective == pytest.approx(-16.0, abs=1e-6)

--- a/python/tests/test_issue_286_false_unbounded.py
+++ b/python/tests/test_issue_286_false_unbounded.py
@@ -9,6 +9,7 @@ now prevent this: the integer-bilinear reformulation is adopted (and routed to t
 MILP engine) only when the *reformulated* model is a genuinely pure MILP, and
 ``_solve_milp_simplex`` itself defers on any model carrying nonlinear terms.
 """
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Summary

Fixes #286 — `carton7` (and any nonconvex MINLP) being declared globally **`unbounded`** because the *linear projection* of its relaxation is unbounded. This is an unsound terminal status (same severity as false-infeasible/false-optimal).

## Root cause

`carton7` reached the Rust pure-MILP simplex engine (`_solve_milp_simplex`). That engine uses `extract_lp_data(model)`, which captures only the **linear** part and **silently drops nonlinear terms** — including the constraints that bound `carton7`'s infinite-upper-bound continuous variables (`x0..x4`, `ub=inf`). The dropped-down LP is genuinely unbounded, and that verdict was surfaced as a global `unbounded` for the original problem — which has a finite optimum (191.73). An unbounded *nonconvex relaxation* does not imply the original is unbounded.

It reached that engine via the integer-bilinear reformulation adoption gate, which trusted `classify_problem == MILP`. `classify_problem` is largely `extract_lp_data`-based, so it shares the same blind spot and can report MILP while nonlinear terms remain.

## Fix

Two guards, both keyed on the DAG-walking `classify_nonlinear_terms` (which sees terms that the `extract_lp_data`-based `classify_problem` drops):

1. **Adopt the integer-bilinear reformulation only when the reformulated model is a genuinely pure MILP** (no residual bilinear / monomial / multilinear / fractional-power / general nonlinear terms). carton7's reformulation leaves continuous nonlinearity → no longer adopted → stays on the spatial/NLP path that keeps the bounding constraints.
2. **`_solve_milp_simplex` defers (returns `None`) on any model carrying nonlinear terms** — a defense-in-depth backstop for any other route to the MILP engine.

## Verification

- New regression tests (`test_issue_286_false_unbounded.py`): no false-unbounded end-to-end; `_solve_milp_simplex` defers on nonlinear; pure MILP still uses simplex.
- No regression: `ex1263`/`ex1264`/`nvs14` (genuine integer-bilinear → pure MILP) still adopt the reformulation and solve to the optimum; the 20-test integer-bilinear suite passes; `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
