### PR TITLE
fix(reform): abort integer-bilinear reformulation on unbounded product factors (#286, real fix)

### DIFF
--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -59,6 +59,10 @@ from .term_classifier import distribute_products
 # blow up the model for no practical gain (and such a variable is better left to
 # spatial branching). 12 bits covers ranges up to 4095.
 _MAX_BITS = 12
+# Beyond this magnitude a big-M coefficient is numerically meaningless (matches the
+# solver's large-bound warning threshold); products with such a factor are not
+# big-M-linearizable and the reformulation aborts (issue #286).
+_BIGM_BOUND_CAP = 1e15
 
 
 def _scalar_var_ref(expr: Expression) -> Optional[tuple[Variable, int]]:
@@ -147,6 +151,17 @@ class _Expander:
         At ``e in {0,1}`` these force ``v = 0`` (e=0) or ``v = other`` (e=1), so the
         product is reproduced exactly — no McCormick gap, and no bilinear term
         remains in the model."""
+        # The big-M coefficients ARE the other factor's bounds; an infinite (or
+        # astronomically large) bound makes the rows ``v <= hi_o*e`` /
+        # ``v >= other - hi_o*(1-e)`` vacuous, so the aux ``v`` (hence the product) is
+        # left unbounded and the reformulated "MILP" is spuriously unbounded though
+        # the original problem is bounded (carton7, issue #286). Abort the whole
+        # pass; the caller's guard returns the original model and the solver keeps
+        # the (bound-aware) spatial path. ``_BIGM_BOUND_CAP`` matches discopt's
+        # large-bound warning threshold — beyond it the big-M is numerically
+        # meaningless, not just at true infinity.
+        if not (abs(lo_o) <= _BIGM_BOUND_CAP and abs(hi_o) <= _BIGM_BOUND_CAP):
+            raise ValueError("cannot big-M-linearize a product with an unbounded factor")
         v = Variable(
             f"_ipx_v{self._counter}",
             VarType.CONTINUOUS,

--- a/python/tests/test_issue_286_false_unbounded.py
+++ b/python/tests/test_issue_286_false_unbounded.py
@@ -1,13 +1,16 @@
 """Regression for issue #286: a nonconvex MINLP must never be declared globally
 ``unbounded`` because the *linear projection* of its relaxation is unbounded.
 
-carton7 (=opt= 191.73) was reported ``unbounded`` after one node: it reached the
-Rust pure-MILP simplex engine, whose ``extract_lp_data`` silently drops nonlinear
-terms — including the very constraints that bound its infinite-upper-bound
-continuous variables — so the dropped-down LP was genuinely unbounded. Two guards
-now prevent this: the integer-bilinear reformulation is adopted (and routed to the
-MILP engine) only when the *reformulated* model is a genuinely pure MILP, and
-``_solve_milp_simplex`` itself defers on any model carrying nonlinear terms.
+carton7 (=opt= 191.73, 64 variables with infinite upper bounds) was reported
+``unbounded`` after one node. The integer-bilinear reformulation linearized every
+``binary * other`` product with a big-M equal to ``other``'s bounds; for the
+infinite-upper-bound factors that big-M is infinite, making the linearized rows
+vacuous, so the reformulated "pure MILP" was spuriously unbounded although the
+original problem is bounded. The reformulation now ABORTS (returns the original
+model -> solver keeps the bound-aware spatial path) when any product factor has an
+infinite/astronomical bound. Two earlier guards remain as defense-in-depth: the
+reformulation is adopted only when the result is a genuinely pure MILP, and
+``_solve_milp_simplex`` defers on any model carrying nonlinear terms.
 """
 
 from __future__ import annotations
@@ -73,3 +76,53 @@ def test_pure_milp_still_uses_simplex():
     out = _solve_milp_simplex(m, 10.0, 1e-4, 100000, time.perf_counter())
     assert out is not None and out.status == "optimal"
     assert out.objective == pytest.approx(-16.0, abs=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# the actual carton7 root cause: big-M reformulation of a product whose other
+# factor has an infinite (or astronomical) bound is invalid -> must abort
+# --------------------------------------------------------------------------- #
+
+
+def _int_times_unbounded(ub):
+    """``k * x`` with k integer in [1,5] and continuous x in [0, ub]; the
+    reformulation would big-M-linearize ``binary * x`` with M = ub."""
+    m = dm.Model("ib")
+    k = m.integer("k", lb=1, ub=5)
+    x = m.continuous("x", lb=0, ub=ub)
+    m.minimize(k)
+    m.subject_to(k * x >= 10)
+    return m
+
+
+@pytest.mark.parametrize("ub", [float("inf"), 1e20])
+def test_reformulation_aborts_on_unbounded_factor(ub):
+    """An infinite/astronomical other-factor bound makes the big-M vacuous, so the
+    reformulation must abort (return the input model unchanged) rather than emit a
+    spuriously unbounded MILP (carton7, issue #286)."""
+    from discopt._jax.integer_product_reform import reformulate_integer_bilinear
+
+    m = _int_times_unbounded(ub)
+    assert reformulate_integer_bilinear(m) is m
+
+
+def test_reformulation_still_fires_on_finite_factor():
+    """The guard is not over-broad: a finitely-bounded other factor is still
+    reformulated (a new model is returned)."""
+    from discopt._jax.integer_product_reform import reformulate_integer_bilinear
+
+    m = _int_times_unbounded(20.0)
+    assert reformulate_integer_bilinear(m) is not m
+
+
+@pytest.mark.requires_pounce
+def test_inf_bound_bilinear_not_unbounded():
+    """End-to-end: an integer*continuous product with an unbounded continuous factor
+    must not yield a global ``unbounded`` verdict (the spatial path bounds it)."""
+    m = dm.Model("e2e")
+    k = m.integer("k", lb=1, ub=5)
+    x = m.continuous("x", lb=0, ub=float("inf"))
+    m.minimize(k + x)
+    m.subject_to(k * x >= 10)  # x >= 10/k > 0, objective bounded below
+    r = m.solve(time_limit=15, gap_tolerance=1e-4)
+    assert r.status != "unbounded"


### PR DESCRIPTION
## Summary

Real fix for #286 — carton7 (=opt= 191.73) still returned **`unbounded`** after #288. This addresses the actual root cause.

## Why #288 missed it

#288 guarded on `classify_nonlinear_terms` (adoption + `_solve_milp_simplex`). But carton7's integer-bilinear reformulation produces a **genuinely linear** model — all 200 bilinears are big-M-linearized — so those guards passed. The problem is that **64 variables have infinite upper bounds**: the big-M for `binary * other` equals `other`'s bound, so an infinite bound makes the linearized rows (`v <= hi_o*e`, `v >= other - hi_o*(1-e)`, …) vacuous. The aux product variable is then unbounded and the reformulated "pure MILP" is spuriously unbounded — though carton7 is bounded (191.73).

## Fix

Root cause, in the reformulation itself: `bigm_product` raises (and `expand_integer_products` aborts, returning the **original** model) when a product's other-factor bound exceeds `1e15` — true infinity or a numerically meaningless big-M. carton7 then keeps the bound-aware **spatial path** and returns `time_limit`, never a false `unbounded`. The #288 guards remain as defense-in-depth.

## Verification

- carton7 → `time_limit` (was `unbounded`).
- Reformulation aborts on `inf` and `1e20` factor bounds; still fires on finite bounds.
- No regression: ex1263/ex1264/nvs14 (finite-bound integer-bilinear) still adopt the reformulation and solve to the optimum; 20-test integer-bilinear suite green; `ruff` + `mypy` clean.
- Regression tests added/updated in `test_issue_286_false_unbounded.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
