### PR TITLE
fix(solver): native simplex MILP engine honors time_limit, defers on stall (#291)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -9191,6 +9191,12 @@ def _root_dive(
     return None
 
 
+# Wall-clock cap (seconds) for the fast Rust simplex MILP engine before it defers
+# to the robust fallback. Bounds time wasted on a stalled reformulation regardless
+# of the overall time_limit (issue #291).
+_SIMPLEX_MILP_BUDGET_CAP_S = 10.0
+
+
 def _solve_milp_simplex(
     model: Model,
     time_limit: float,
@@ -9246,6 +9252,21 @@ def _solve_milp_simplex(
     _, _, _, int_offsets, int_sizes = _extract_variable_info(model)
     int_idx = [j for off, sz in zip(int_offsets, int_sizes) for j in range(off, off + int(sz))]
 
+    # Pass the remaining wall-clock budget so the Rust B&B's deadline (loop-top,
+    # per-node and per-LP) fires. Without it ``time_limit_s`` defaults to 0.0 -> no
+    # deadline, so a single node whose simplex fails to converge (or a degenerate
+    # cycle) runs unbounded, ignoring the user's ``time_limit`` entirely (issue
+    # #291: nvs12's integer-bilinear reformulation hung > 40 s on a 15 s limit).
+    # Bound the fast simplex engine to a modest slice of the remaining budget, so a
+    # stall on a pathological reformulation (issue #291) defers quickly (status
+    # node_limit -> None below) and leaves the rest for the robust spatial/POUNCE
+    # fallback. The absolute cap matters: with the default time_limit=3600 a plain
+    # fraction would let a stalled solve burn ~1800 s before falling back. The
+    # engine is the *fast* path — a well-behaved reformulation (ex126x) solves in
+    # ~1 s, far inside this cap — so capping costs nothing on the common case while
+    # bounding the wasted time before fallback to a few seconds.
+    _remaining = float(time_limit) - (time.perf_counter() - t_start)
+    _milp_budget = max(0.5, min(0.5 * _remaining, _SIMPLEX_MILP_BUDGET_CAP_S))
     status, x_struct, obj, bound, nodes, _lp_iters = solve_milp_py(
         np.ascontiguousarray(lp_data.c, dtype=np.float64),
         A,
@@ -9257,6 +9278,7 @@ def _solve_milp_simplex(
         float(lp_data.obj_const),
         int(max_nodes),
         float(gap_tolerance),
+        time_limit_s=float(_milp_budget),
     )
     wall_time = time.perf_counter() - t_start
     maximize = model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE
@@ -9319,9 +9341,14 @@ def _solve_milp_simplex(
     if status == "unbounded":
         return SolveResult(status="unbounded", wall_time=wall_time, node_count=nodes)
     if status == "node_limit":
-        return SolveResult(
-            status="node_limit", wall_time=wall_time, node_count=nodes, gap_certified=False
-        )
+        # The simplex MILP engine exhausted its node/time budget without proving
+        # optimality and found no usable incumbent here. Rather than surface a
+        # bare ``node_limit`` (no solution), defer (return None) so the caller falls
+        # back to the robust spatial / POUNCE path — which, e.g., solves nvs12's
+        # integer-bilinear reformulation in ~0.4 s where this engine stalls
+        # (issue #291). A genuine incumbent is returned via the optimal/feasible
+        # branch above, so deferral only discards a no-solution result.
+        return None
     return SolveResult(status="infeasible", wall_time=wall_time, node_count=nodes)
 
 

--- a/python/tests/test_issue_291_milp_simplex_hang.py
+++ b/python/tests/test_issue_291_milp_simplex_hang.py
@@ -1,0 +1,46 @@
+"""Regression for issue #291: the native simplex MILP engine must honor the time
+limit and never hang.
+
+nvs12 (=opt= -481.2, ~0.4 s on the prior build) has integer-bilinear/monomial
+terms that the #285 reformulation turns into a pure MILP, routed to the Rust
+``solve_milp_py`` engine. That engine was called with no time limit
+(``time_limit_s`` defaulting to 0.0 -> no deadline), so a node whose simplex failed
+to converge looped unbounded, ignoring the user's ``time_limit`` (>40 s on a 15 s
+limit; only an external kill stopped it).
+
+Fix: pass the remaining wall-clock budget (capped, so a stall defers quickly
+regardless of the overall limit), and defer (fall back to the robust spatial/POUNCE
+path) when the engine exhausts its budget without a usable incumbent — which solves
+nvs12 instead of returning a bare ``node_limit``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import pytest  # noqa: E402
+
+_DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib")
+
+
+@pytest.mark.slow
+@pytest.mark.requires_pounce
+def test_nvs12_does_not_hang_and_solves():
+    """nvs12 must return within the time limit (no unbounded hang) and solve to the
+    known optimum via the fallback after the simplex engine stalls."""
+    path = os.path.join(_DATA, "nvs12.nl")
+    if not os.path.exists(path):
+        pytest.skip("nvs12 instance unavailable")
+    t0 = time.perf_counter()
+    r = dm.from_nl(path).solve(time_limit=40, gap_tolerance=1e-4)
+    elapsed = time.perf_counter() - t0
+    # honored the time limit (with generous margin for the fallback handoff) —
+    # the bug ran unbounded past any limit
+    assert elapsed < 90, f"solve ran {elapsed:.0f}s — time limit not honored (hang)"
+    assert r.status != "node_limit"  # must not surface a bare no-solution result
+    assert r.objective is not None and r.objective == pytest.approx(-481.2, abs=1e-2)


### PR DESCRIPTION
## Summary

Fixes #291 — `nvs12` (=opt= −481.2) **hung indefinitely** in the native `solve_milp_py` MILP engine, ignoring `time_limit` (>40 s on a 15 s limit; only an external kill stopped it).

## Root cause

`nvs12`'s integer-bilinear/monomial terms are linearized by the #285 reformulation into a pure MILP and routed to the Rust `solve_milp_py` engine. That engine was called **without a time limit** — `time_limit_s` defaults to `0.0` → no deadline — so a node whose simplex failed to converge looped unbounded. `max_nodes=50` did not help (it's stuck in a single node, not exploring many).

The Rust driver already has full deadline machinery (loop-top, per-node, per-LP); the Python binding simply wasn't given a deadline. **Pure-Python fix, no Rust rebuild.**

## Fix

1. **Pass a wall-clock budget** to `solve_milp_py`, capped at **10 s** (a slice of the remaining time). A stall now defers in ~10 s regardless of the overall limit — a plain fraction would let the default `time_limit=3600` burn ~1800 s before falling back — while a well-behaved reformulation (ex126x, ~1 s) finishes far inside the cap.
2. **On `node_limit`** (budget exhausted, no usable incumbent), **defer** (return `None`) to the robust spatial/POUNCE fallback instead of surfacing a bare no-solution result.

## Verification

- `nvs12`: returns within the limit and **solves to −481.2** (~11 s, via fallback) — was an unbounded hang.
- No regression: `ex1263`/`ex1264`/`nvs14` still solve to the optimum via the simplex engine; integer-bilinear suite (20 tests) green; `ruff` + `mypy` clean.
- Regression test added (`test_issue_291_milp_simplex_hang.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
