### PR TITLE
fix(solver): skip per-node OBBT on the root node so it doesn't starve the primal (#287)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4192,6 +4192,17 @@ def solve_model(
                 else None
             )
             for i in range(n_batch):
+                # Skip per-node OBBT on the ROOT batch (iteration 0). It is redundant
+                # there with the global root OBBT just run, and — at up to 60% of the
+                # time budget (4.8s on an 8s limit) — it runs *before* the root
+                # primal heuristic, pushing time-to-first-incumbent past the limit on
+                # nonconvex models (issue #287: kall's first incumbent landed at
+                # 10.4s on an 8s budget). Its value is on *branched* nodes, where it
+                # pins the functionally-dependent outputs once the independent
+                # drivers are fixed (welded-beam / nvs05 fathoming) — those run from
+                # iteration 1 on, so deferring the root costs nothing there.
+                if iteration == 0:
+                    break
                 if node_infeasible_mask[i]:
                     continue
                 if _pn_obbt_spent >= _pn_obbt_budget_total:

--- a/python/tests/test_issue_287_incumbent_latency.py
+++ b/python/tests/test_issue_287_incumbent_latency.py
@@ -1,0 +1,46 @@
+"""Regression for issue #287: per-node OBBT must not starve the root primal.
+
+The per-node OBBT lever (`_PER_NODE_OBBT_BUDGET_FRAC = 0.6`) ran on the ROOT node
+before the root primal heuristic, spending up to 60% of the time budget on bound
+tightening *before any incumbent existed*. On nonconvex models with
+functionally-dependent intermediates this pushed time-to-first-incumbent past the
+limit (kall_congruentcircles_c72: first incumbent at ~10.8 s on an 8 s budget ->
+`hard_timeout`, no incumbent, under the benchmark's hard kill).
+
+Fix: skip per-node OBBT on the root iteration (it is redundant there with the
+global root OBBT, and cutoff-driven OBBT wants an incumbent anyway). It still runs
+on branched nodes, where it does its work (welded-beam / nvs05 fathoming).
+
+Measured before/after (kall, time_limit=8): first incumbent 10.8 s -> 8.6 s, wall
+11.0 s -> 8.7 s — i.e. it now returns under a 10 s hard budget.
+
+This test guards the property robustly (no tight timing): a dependent-var nonconvex
+instance still reaches its optimum incumbent within a generous budget — which would
+fail if the root primal were starved badly enough to miss it.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import pytest  # noqa: E402
+
+_DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib")
+
+
+@pytest.mark.slow
+@pytest.mark.requires_pounce
+def test_st_e31_reaches_optimum_incumbent():
+    """st_e31 (functionally-dependent nonconvex, per-node-OBBT-eligible, opt -2.0)
+    must surface its optimal incumbent within a generous budget — the root primal
+    is not starved by per-node OBBT."""
+    path = os.path.join(_DATA, "st_e31.nl")
+    if not os.path.exists(path):
+        pytest.skip("st_e31 instance unavailable")
+    r = dm.from_nl(path).solve(time_limit=30, gap_tolerance=1e-4)
+    assert r.objective is not None  # an incumbent was found (not hard_timeout)
+    assert r.objective == pytest.approx(-2.0, abs=1e-2)


### PR DESCRIPTION
## Summary

Fixes the **#287 incumbent-latency regression**: on nonconvex models with functionally-dependent intermediates, the first feasible incumbent landed *past* the time limit (→ `hard_timeout`, no incumbent under the benchmark's hard kill).

## Root cause

The per-node OBBT lever (`_PER_NODE_OBBT_BUDGET_FRAC = 0.6`) ran on the **root node before the root primal heuristic**, spending up to 60% of the budget (4.8 s on an 8 s limit) on bound tightening *before any incumbent existed*. Timestamped trace (kall, `time_limit=8`): root OBBT @1 s → **per-node OBBT enabled, 4.8 s budget @3.5 s** → first incumbent only @**10.4 s**.

## Fix

Skip per-node OBBT on the **root iteration**. It's redundant there with the global root OBBT just run, and its value is on *branched* nodes (pinning the dependent outputs once the independent drivers are fixed — the welded-beam/nvs05 fathoming), which run from iteration 1 on. One-line guard; deferring the root costs nothing there.

## Before/after (measured, `time_limit=8`)

| instance | BEFORE first-inc / wall | AFTER first-inc / wall |
|---|---|---|
| **kall_congruentcircles_c72** | **10.8 s / 11.0 s** (→ hard_timeout @10 s) | **8.6 s / 8.7 s** (returns under 10 s) |
| tln4 | 8.4 s (optimal) | 8.4 s (unchanged) |
| flay04h | 9.2 s | 9.2 s (unchanged) |
| graphpart_2g-0077-0077 | 4.3 s | 4.4 s (unchanged) |

**No regression:** tln4/flay04h/graphpart unchanged; nvs05's suboptimal incumbent is **pre-existing** (identical with the fix stashed). Regression test (`st_e31`, dependent-var nonconvex, opt −2.0) guards the property without tight timing. `ruff` + `mypy` clean.

Scope: this removes the per-node-OBBT contribution to incumbent latency (the clearest sub-cause). Residual latency on continuous instances (root NLP solve cost) is separate/deeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
