### PR TITLE
test(amp): de-flake the alpha-BB cutoff-OBBT expired-deadline smoke test

### DIFF
--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -3368,10 +3368,19 @@ def test_alphabb_cutoff_obbt_prerequisite_respects_expired_deadline(monkeypatch)
 
     cutoff_obbt_calls = []
 
-    monkeypatch.setattr(
-        amp_mod,
-        "_solve_milp_with_oa_recovery",
-        lambda **kwargs: (
+    # Expire the global deadline by *logical phase*, not by perf_counter() call
+    # count: the relaxation result is produced in-budget (so the solve returns a
+    # feasible incumbent), and the deadline reads as expired only once that result
+    # exists — which is exactly when the cutoff-OBBT prerequisite runs (it needs the
+    # incumbent UB). This is robust to how many perf_counter() calls the solve makes
+    # before reaching the prerequisite; the previous fixed [0.0, 0.1, 2.0] clock
+    # sequence broke when that call count shifted (the "expired" reading landed
+    # after the check, which then ran with a stale in-budget value).
+    relax_solved = {"done": False}
+
+    def fake_milp(**kwargs):
+        relax_solved["done"] = True
+        return (
             MilpRelaxationResult(
                 status="optimal",
                 objective=-1.0,
@@ -3380,12 +3389,19 @@ def test_alphabb_cutoff_obbt_prerequisite_respects_expired_deadline(monkeypatch)
             {},
             [],
             1,
-        ),
-    )
+        )
+
+    monkeypatch.setattr(amp_mod, "_solve_milp_with_oa_recovery", fake_milp)
     monkeypatch.setattr(
         amp_mod,
         "_solve_best_nlp_candidate",
         lambda *args, **kwargs: (np.array([0.0, 0.0], dtype=np.float64), 0.0),
+    )
+    # In budget until the relaxation result exists, expired thereafter.
+    monkeypatch.setattr(
+        amp_mod,
+        "_remaining_wall_time",
+        lambda deadline: 0.0 if relax_solved["done"] else 100.0,
     )
 
     def fake_cutoff_obbt(**kwargs):
@@ -3399,13 +3415,6 @@ def test_alphabb_cutoff_obbt_prerequisite_respects_expired_deadline(monkeypatch)
         )
 
     monkeypatch.setattr(amp_mod, "_run_cutoff_obbt", fake_cutoff_obbt)
-
-    clock_values = iter([0.0, 0.1, 2.0])
-
-    def fake_perf_counter():
-        return next(clock_values, 2.0)
-
-    monkeypatch.setattr(amp_mod.time, "perf_counter", fake_perf_counter)
 
     m = Model("alphabb_cutoff_obbt_expired_deadline")
     x = m.continuous("x")


### PR DESCRIPTION
## Summary

Fixes a **pre-existing smoke-suite failure** on `main`: `test_amp.py::test_alphabb_cutoff_obbt_prerequisite_respects_expired_deadline` (surfaced while validating #287; it fails identically with/without that change).

## Root cause

The test mocked `time.perf_counter()` with a fixed 3-value sequence `[0.0, 0.1, 2.0]`, engineered so the global AMP deadline reads as **expired exactly at the cutoff-OBBT prerequisite check**. A shift in how many `perf_counter()` calls the AMP solve makes before that check moved the "expired" (2.0) reading *past* the check, so the deadline guard saw the stale in-budget `0.1`, ran cutoff-OBBT, and `cutoff_obbt_calls == [1]` tripped the assertion.

The **production guard is correct** (`_remaining_wall_time(deadline) > 0` against the real clock); only the test's call-count-coupled mock was brittle.

## Fix

Expire the deadline by **logical phase**, not call count: mock `_remaining_wall_time` to return budget until the (mocked) relaxation result exists, then `0`. So the solve still returns a feasible incumbent (result produced in budget), and the cutoff-OBBT prerequisite — which runs only *after* the incumbent UB exists — deterministically sees the deadline expired and is skipped. Robust to the solve's internal `perf_counter()` call count.

## Verification

- The test passes; **full smoke suite: 209 passed (was 1 failed)**.
- Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
