### PR TITLE
docs: MIQP/convex-MINLP incumbent-latency diagnosis & plan (#281, #287)

### DIFF
--- a/docs/dev/miqp-incumbent-latency.md
+++ b/docs/dev/miqp-incumbent-latency.md
@@ -1,0 +1,74 @@
+# MIQP / convex-MINLP incumbent latency (#281, #287) — diagnosis & plan
+
+**Status:** diagnosis done (evidence below); implementation scoped, not started.
+Companion to the #287 fix (root per-node-OBBT skip, merged in #294) and the polish
+fix (#298).
+
+## Problem
+
+On the short-tier benchmark (5 s budget) the `smallinvDAX_*` portfolio MIQPs (and
+similar convex MINLPs) return *near-optimal-but-suboptimal* incumbents or no
+incumbent — #281. The root cause is **incumbent latency**, not search capability or
+continuous-completion polish: they solve to the proven optimum given more time.
+
+## Evidence (measured)
+
+`smallinvDAXr2b010-011` (=opt= 0.39880), `time_limit` varied:
+
+| budget | result |
+|---|---|
+| 5 s | feasible 0.4004 (0.4% off) — or, run-to-run, no incumbent |
+| 8 s | first incumbent @5.7 s, optimal @7.0 s |
+| 12 s | **optimal 0.39880** |
+
+It is classified **Convex MINLP → NLP-BB** (NLP relaxation solved per node). Phase
+breakdown of the 7 s solve (timestamped trace + cProfile):
+
+| phase | ~time | what |
+|---|---|---|
+| setup + JAX compile | ~1.5 s | model finalize, convexity routing, first JAX trace/lower of the NLP evaluator |
+| feasibility pump | ~2.7 s | several NLP solves; yields a 0.4%-off incumbent (wrong integers) |
+| branch-and-bound | ~2.8 s | 249 nodes (NLP per node) to the optimum |
+
+- Fixing the incumbent's integers + a continuous solve does **not** close the gap →
+  the 5 s incumbent has *wrong integers* (a polish cannot help; confirms #298's
+  scope note).
+- cProfile: dominated by JAX `bind`/`eval_jaxpr`/MLIR lowering + one-time
+  `sparsity._collect_variable_indices`. The sparsity pattern is already cached
+  (`NLPEvaluator.sparsity_pattern`), so it is a one-time ~0.5 s cost, not per node.
+- SCIP solves all of these in <5 s (0.3–2.9 s) via LP-based outer approximation.
+
+There is **no single hot spot** — unlike #287 (a redundant root per-node-OBBT pass
+with a one-line fix). The latency is distributed across compile + primal + search.
+
+## Levers (ranked by breadth × impact ÷ effort)
+
+1. **Per-solve JAX-compile / startup overhead (~1.5 s, broadest).** Hits *every*
+   short-tier instance, not just MIQPs. Directions: cache compiled node-NLP
+   evaluators across the tree and across solves; lazy/avoid JAX for tiny models;
+   trim the convexity-routing trace. First experiment: attribute the 1.5 s precisely
+   (trace vs compile vs convexity) before optimizing. *Medium effort, wide payoff.*
+2. **Stronger convex-MINLP primal (~2.7 s FP → 0.4%-off).** The FP finds wrong
+   integers; a RENS / NLP-relaxation-rounding / diving heuristic that exploits the
+   convex relaxation would land the optimal integers earlier (within budget).
+   *Medium effort; directly closes #281's incumbent quality.*
+3. **Outer approximation (OA) for convex MINLP (the SCIP method).** Replace
+   NLP-per-node with an LP master + NLP subproblems: orders of magnitude fewer/cheaper
+   nodes (SCIP's 0.3 s vs our 249-node 2.8 s). *Largest effort; the principled fix
+   for convex-MINLP search efficiency.*
+
+## Recommendation
+
+This is SCIP-gap-class work, not a one-liner. Sequence by payoff/risk:
+- **Start with lever 1** (JAX-compile/startup) — broadest (all short-tier), and the
+  first step is a measurement (attribute the 1.5 s) before any build.
+- Then **lever 2** (convex-MINLP primal) to land good incumbents within budget.
+- **Lever 3 (OA)** last — the deep, highest-ceiling effort.
+
+Each lever is gated on the existing short-tier benchmark harness
+(`discopt-minlp-benchmark`), tracking per-instance incumbent-latency and gap so
+progress is measured and regressions caught.
+
+## Non-goals
+- Matching SCIP's raw speed on every instance; target is "return the optimum (or a
+  tight incumbent) within the short-tier budget."


### PR DESCRIPTION
## Summary

Diagnosis + scoped plan for the **MIQP / convex-MINLP incumbent latency** that underlies #281 (and overlaps #287). Documentation only.

## Finding

`smallinvDAX_*` are classified **Convex MINLP → NLP-BB** and **solve to the proven optimum given time** — at the 5 s short-tier budget the incumbent is just late/suboptimal (it's latency, not search capability or continuous-completion polish; fixing the incumbent's integers doesn't close the gap → wrong integers, which a polish can't fix).

Phase breakdown (r2b010, 7 s solve): **~1.5 s setup + JAX compile**, **~2.7 s feasibility pump** (0.4%-off, wrong-integer incumbent), **~2.8 s branching** (249 NLP-per-node). cProfile: JAX trace/lower + one-time sparsity; **no single hot spot** — so no #287-style one-liner. SCIP solves these in 0.3–2.9 s via LP-based outer approximation.

## Scoped levers (ranked)

1. **Per-solve JAX-compile / startup overhead (~1.5 s, broadest)** — hits every short-tier instance; first step is to attribute the 1.5 s before optimizing (cache compiled node evaluators / lazy JAX / trim convexity-routing trace).
2. **Stronger convex-MINLP primal** — RENS / NLP-relaxation rounding / diving to land the optimal integers within budget (the FP currently finds wrong integers).
3. **Outer approximation (OA) for convex MINLP** — the SCIP method (LP master + NLP subproblems); largest effort, highest ceiling.

Each gated on the existing short-tier benchmark harness. This is SCIP-gap-class work, not a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
