### PR TITLE
perf(solver): gate structure-cut presolve on a cheap nonlinear-equality check (#281)

### DIFF
--- a/docs/dev/miqp-incumbent-latency.md
+++ b/docs/dev/miqp-incumbent-latency.md
@@ -43,11 +43,21 @@ with a one-line fix). The latency is distributed across compile + primal + searc
 
 ## Levers (ranked by breadth × impact ÷ effort)
 
-1. **Per-solve JAX-compile / startup overhead (~1.5 s, broadest).** Hits *every*
-   short-tier instance, not just MIQPs. Directions: cache compiled node-NLP
-   evaluators across the tree and across solves; lazy/avoid JAX for tiny models;
-   trim the convexity-routing trace. First experiment: attribute the 1.5 s precisely
-   (trace vs compile vs convexity) before optimizing. *Medium effort, wide payoff.*
+1. **Per-solve startup overhead (~1.5 s, broadest). — DONE (#281, structure-cut
+   gate).** Attribution (measured, warm process so JAX/SymPy import is amortized)
+   found the ~1.5 s was *not* JAX compile but the **SymPy structure-cut presolve**
+   (`recognize_and_inject` -> `model_to_sympy`), auto-engaged by default since #253
+   to close the gas-network gap (#15). Its size gate (vars+constraints <= 100)
+   wrongly assumed `model_to_sympy` cost tracks variable count; it actually tracks
+   *objective expression complexity*, so a dense-objective MIQP (smallinvDAX: 31
+   vars but a 465-term quadratic) paid ~1.0 s translating SymPy for a
+   guaranteed-empty recognition (no equality constraints -> the square-difference
+   pattern can never match). Fixed with a microsecond native-DAG necessary
+   condition (`has_square_difference_candidate`): skip `model_to_sympy` unless the
+   model has a nonlinear equality. Measured: recognizer 1.07 s -> 0.000 s,
+   end-to-end ~7.0 s -> ~5.7 s to the same optimum; gas-network (#15) keeps its
+   cuts. Any *residual* JAX-trace/compile cost (the original lever-1 hypothesis)
+   is now a smaller, separate follow-up if it proves to matter.
 2. **Stronger convex-MINLP primal (~2.7 s FP → 0.4%-off).** The FP finds wrong
    integers; a RENS / NLP-relaxation-rounding / diving heuristic that exploits the
    convex relaxation would land the optimal integers earlier (within budget).
@@ -60,8 +70,9 @@ with a one-line fix). The latency is distributed across compile + primal + searc
 ## Recommendation
 
 This is SCIP-gap-class work, not a one-liner. Sequence by payoff/risk:
-- **Start with lever 1** (JAX-compile/startup) — broadest (all short-tier), and the
-  first step is a measurement (attribute the 1.5 s) before any build.
+- **Lever 1 (startup overhead) — DONE.** The measurement showed it was the SymPy
+  structure-cut presolve, not JAX compile; gated cheaply (#281). ~1.3 s recovered
+  broadly across the short tier.
 - Then **lever 2** (convex-MINLP primal) to land good incumbents within budget.
 - **Lever 3 (OA)** last — the deep, highest-ceiling effort.
 

--- a/python/discopt/_jax/symbolic/cut_recognizer.py
+++ b/python/discopt/_jax/symbolic/cut_recognizer.py
@@ -331,12 +331,64 @@ def _derive_terminal_pressure_lb(p5, eqs, classes, fixed, bounds):
     return best
 
 
+def _expr_is_nonlinear(node) -> bool:
+    """True if a model-graph expression contains a nonlinear sub-term.
+
+    A cheap, SymPy-free walk over the native DAG: a power with a non-{0,1}
+    exponent, a product/quotient of two non-constant operands, or any function
+    call (``sqrt``/``exp``/...) makes the expression nonlinear. Used as a guard so
+    the (expensive) ``model_to_sympy`` translation is skipped on models that
+    cannot match the pattern.
+    """
+    from discopt.modeling import core
+
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if isinstance(n, core.BinaryOp):
+            if n.op == "**":
+                r = n.right
+                if not (isinstance(r, core.Constant) and float(r.value) in (0.0, 1.0)):
+                    return True
+            elif n.op in ("*", "/"):
+                if not (isinstance(n.left, core.Constant) or isinstance(n.right, core.Constant)):
+                    return True
+            stack.append(n.left)
+            stack.append(n.right)
+        elif isinstance(n, core.UnaryOp):
+            stack.append(n.operand)
+        elif isinstance(n, core.FunctionCall):
+            return True
+    return False
+
+
+def has_square_difference_candidate(model) -> bool:
+    """Cheap necessary condition for the square-difference-network recognizer.
+
+    The recognizer (:func:`recognize_and_derive_cuts`) can only derive cuts when
+    the model carries the Weymouth-style square-difference *equality* constraints
+    (``p_in**2 - p_out**2 = c*f**2``); :func:`_square_diff_eq` searches exactly
+    those. A model whose ``==`` constraints are all linear (or which has none —
+    e.g. a portfolio MIQP, where the quadratic lives in the objective) can never
+    match, so we can skip the ~1 s ``model_to_sympy`` translation of a dense
+    objective entirely. This is a microsecond native-DAG scan, not a SymPy build.
+    """
+    return any(
+        c.sense == "==" and _expr_is_nonlinear(c.body) for c in getattr(model, "_constraints", [])
+    )
+
+
 def recognize_and_derive_cuts(model, *, verify: bool = True) -> list[RecognizedCut]:
     """Auto-derive structured underestimator cuts from a model's graph.
 
     Returns a list of :class:`RecognizedCut` (possibly empty if the model does not
     match the square-difference-network pattern).
     """
+    # Cheap pre-check before the expensive SymPy translation: the pattern needs a
+    # nonlinear equality constraint. Without one (e.g. a dense-objective MIQP) the
+    # recognizer is a guaranteed no-op, so skip ``model_to_sympy`` outright.
+    if not has_square_difference_candidate(model):
+        return []
     sm = model_to_sympy(model)
     classes, fixed = _canonicalize(sm.equalities, sm.symbols)
     reverse = {sym: key for key, sym in sm.symbols.items()}

--- a/python/tests/test_cut_recognizer.py
+++ b/python/tests/test_cut_recognizer.py
@@ -497,3 +497,52 @@ def test_structure_cuts_presolve_noop_on_unrelated_model():
 
     assert r_on.objective == pytest.approx(r_off.objective, abs=1e-3)
     assert r_on.objective == pytest.approx(-2.0, abs=1e-3)
+
+
+# --------------------------------------------------------------------------
+# Cheap structural gate: skip the SymPy translation when nothing can match
+# (perf #281 — a dense-objective MIQP with no nonlinear equality was paying
+# ~1 s building SymPy for a guaranteed-empty recognition).
+# --------------------------------------------------------------------------
+
+
+def test_square_difference_candidate_gate_discriminates():
+    """The cheap necessary-condition gate is True only when a nonlinear equality
+    is present (the pattern's prerequisite), and False for a dense-objective MIQP
+    whose constraints are all linear/inequalities."""
+    # Dense quadratic objective, only an inequality constraint -> cannot match.
+    miqp = dm.Model("miqp")
+    x = miqp.continuous("x", lb=0.0, ub=1.0)
+    y = miqp.continuous("y", lb=0.0, ub=1.0)
+    miqp.minimize(x * x + 2.0 * x * y + y * y)
+    miqp.subject_to(x + y <= 1.0)
+    assert R.has_square_difference_candidate(miqp) is False
+
+    # A nonlinear equality (square-difference shape) -> candidate.
+    gas_like = dm.Model("gas_like")
+    p = gas_like.continuous("p", lb=1.0, ub=5.0)
+    q = gas_like.continuous("q", lb=1.0, ub=5.0)
+    f = gas_like.continuous("f", lb=0.0, ub=10.0)
+    gas_like.minimize(f)
+    gas_like.subject_to(p * p - q * q == 1.5 * f * f)
+    assert R.has_square_difference_candidate(gas_like) is True
+
+
+def test_gate_skips_sympy_translation_for_unmatchable_model(monkeypatch):
+    """`recognize_and_derive_cuts` must short-circuit to [] *without* calling the
+    expensive `model_to_sympy` when the model has no nonlinear equality — the
+    perf fix. Proven by making `model_to_sympy` raise: it must never be reached."""
+
+    def _boom(_model):
+        raise AssertionError("model_to_sympy must not run for an unmatchable model")
+
+    monkeypatch.setattr(R, "model_to_sympy", _boom)
+
+    miqp = dm.Model("miqp")
+    x = miqp.continuous("x", lb=0.0, ub=1.0)
+    y = miqp.continuous("y", lb=0.0, ub=1.0)
+    miqp.minimize(x * x + 2.0 * x * y + y * y)
+    miqp.subject_to(x + y <= 1.0)
+
+    assert R.recognize_and_derive_cuts(miqp) == []
+    assert R.recognize_and_inject(miqp) == 0


### PR DESCRIPTION
## Summary

Lever 1 of the MIQP/convex-MINLP incumbent-latency work (#281): eliminate the
~1.5 s per-solve startup overhead that pushes short-tier (5 s) incumbents past
the budget.

**Root cause (measured, not the original hypothesis).** The overhead was *not*
JAX compile — it was the **SymPy structure-cut presolve** (`recognize_and_inject`
→ `model_to_sympy`), auto-engaged by default since #253 to close the gas-network
gap (#15). Its gate caps model size by *vars + constraints* (≤ 100), assuming
`model_to_sympy` then stays cheap (~1 ms on the 39-var gas net). But the cost is
driven by **objective expression complexity**, not variable count: a dense-objective
MIQP sails through the size gate yet is expensive to translate.
`smallinvDAXr2b010-011` (31 vars, 4 inequality constraints, **465-term** quadratic
objective, **0 equality constraints**) spent **~1.0 s** building SymPy for a
*guaranteed-empty* recognition — the square-difference pattern needs a nonlinear
equality, which it doesn't have.

## Fix

A microsecond native-DAG necessary condition, `has_square_difference_candidate(model)`:
the recognizer can only fire when the model carries a **nonlinear equality** (the
Weymouth `p_in² − p_out² = c·f²` shape `_square_diff_eq` searches). `recognize_and_derive_cuts`
short-circuits to `[]` *before* `model_to_sympy` when that condition fails, so no
SymPy is built for a model that cannot match. The recognizer becomes self-protecting,
so every caller (including the solve-time gate) benefits.

## Measured

| | before | after |
|---|---|---|
| recognizer on smallinvDAX (warm) | 1.07 s | **0.000 s** |
| end-to-end solve (smallinvDAX, opt 0.3988) | ~7.0 s | **~5.7 s** |
| gas-network (#15): cuts / closure | 2 cuts, optimal | **2 cuts, optimal** (unchanged) |

## Tests

- `test_square_difference_candidate_gate_discriminates` — gate is True iff a
  nonlinear equality is present.
- `test_gate_skips_sympy_translation_for_unmatchable_model` — `model_to_sympy` is
  monkeypatched to raise; proves it is never reached for an unmatchable model.
- Existing #15 auto-close / opt-out / no-op recognizer tests still pass.

Docs: `docs/dev/miqp-incumbent-latency.md` updated to record the corrected
root cause and mark lever 1 done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
