### PR TITLE
fix(oa): correct objective-sense handling for MAXIMIZE problems

### DIFF
--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
-from discopt.modeling.core import Constraint, Model, SolveResult, VarType
+from discopt.modeling.core import Constraint, Model, ObjectiveSense, SolveResult, VarType
 
 if TYPE_CHECKING:
     from discopt._jax.nlp_evaluator import NLPEvaluator
@@ -133,6 +133,15 @@ def _decompose_model(model: Model) -> _DecomposedProblem:
         _extract_body_coeffs(raw_obj.expression, model, n_vars) if raw_obj is not None else None
     )
     obj_is_linear = obj_coeffs is not None
+    # The NLPEvaluator works in minimization convention: it negates a MAXIMIZE
+    # objective, so the NLP subproblems and the epigraph objective OA cuts all
+    # optimize ``-f``. Put the *linear* master objective in the same convention.
+    # Without this the master MILP minimizes ``+f`` while the subproblems maximize
+    # it, and OA converges to — and certifies as optimal — a wrong point
+    # (e.g. syn05m: returned -831 as "optimal" vs the true maximum 837.73).
+    if obj_is_linear and raw_obj is not None and raw_obj.sense == ObjectiveSense.MAXIMIZE:
+        _c_vec, _c_off = obj_coeffs
+        obj_coeffs = (-_c_vec, -_c_off)
 
     return _DecomposedProblem(
         evaluator=evaluator,
@@ -652,6 +661,14 @@ def solve_oa(
     evaluator = decomp.evaluator
     n_vars = decomp.n_vars
     n_cons = decomp.n_cons
+    # The whole OA loop runs in the evaluator's minimization convention (it
+    # negates a MAXIMIZE objective). Un-negate the user-facing objective/bound at
+    # the return sites with this sign; the gap is convention-invariant.
+    _obj_sign = (
+        -1.0
+        if (model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE)
+        else 1.0
+    )
     if decomp.oa_constraint_mask is not None and not all(decomp.oa_constraint_mask):
         logger.warning(
             "OA: generating OA cuts only for %d of %d constraints classified convex",
@@ -671,8 +688,8 @@ def solve_oa(
         if x_sol is not None:
             return SolveResult(
                 status="optimal",
-                objective=obj,
-                bound=obj,
+                objective=_obj_sign * obj,
+                bound=_obj_sign * obj,
                 gap=0.0,
                 x=_build_x_dict(x_sol, model),
                 wall_time=wall_time,
@@ -932,8 +949,8 @@ def solve_oa(
         status = "optimal" if gap <= gap_tolerance else "feasible"
         return SolveResult(
             status=status,
-            objective=incumbent_obj,
-            bound=bound,
+            objective=_obj_sign * incumbent_obj,
+            bound=(_obj_sign * bound if bound is not None else None),
             gap=reported_gap,
             x=_build_x_dict(incumbent, model),
             wall_time=wall_time,
@@ -942,7 +959,7 @@ def solve_oa(
     return SolveResult(
         status="infeasible",
         objective=None,
-        bound=bound,
+        bound=(_obj_sign * bound if bound is not None else None),
         gap=None,
         x={},
         wall_time=wall_time,

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -329,3 +329,37 @@ class TestOAMatchesBnB:
         # Objectives should be close (within tolerance)
         if result_oa.objective is not None and result_bb.objective is not None:
             assert result_oa.objective == pytest.approx(result_bb.objective, abs=0.5)
+
+
+# ── Maximize objective (sense handling) ───────────────────────
+# Regression for the OA minimization-convention bug: the master MILP minimized
+# the raw objective coefficients while the NLP subproblems and epigraph cuts ran
+# in the evaluator's minimization convention (which negates a MAXIMIZE
+# objective). The two disagreed on direction, so OA converged to — and reported
+# as "optimal" — the *minimum* of a maximize problem (syn05m: -831 vs the true
+# maximum 837.73). These guard that OA optimizes the correct direction.
+
+
+def test_oa_maximize_linear_objective_is_not_the_minimum():
+    """A MAXIMIZE model must return the maximum, not the (certified-wrong) min."""
+    m = dm.Model("oa_max")
+    x = m.integer("x", lb=0, ub=5)
+    y = m.integer("y", lb=0, ub=5)
+    m.maximize(x + y)
+    m.subject_to(x**2 + y**2 <= 10)
+    r = _solve_oa(m)
+    assert r.status == "optimal"
+    _assert_optimal(r, 4.0)  # max x+y over integers with x^2+y^2 <= 10
+    _assert_integer_feasible(r, ["x", "y"], m)
+    # For a maximization the dual bound sits at/above the optimum.
+    assert r.bound is None or r.bound >= r.objective - ABS_TOL
+
+
+def test_oa_maximize_scalar_reaches_true_max():
+    """The pre-fix bug returned 0 (the minimum) as 'optimal'; the true max is 9."""
+    m = dm.Model("oa_max2")
+    x = m.integer("x", lb=0, ub=4)
+    m.maximize(3 * x)
+    m.subject_to(x**2 <= 9)  # x <= 3
+    r = _solve_oa(m)
+    assert r.objective == pytest.approx(9.0, abs=ABS_TOL)


### PR DESCRIPTION
## Summary

The Outer Approximation solver (`gdp_method="oa"`) had **no objective-sense
handling**, making it return wrong answers — *certified as optimal* — on
MAXIMIZE problems.

The `NLPEvaluator` works in minimization convention: it negates a MAXIMIZE
objective, so OA's NLP subproblems and epigraph objective cuts all optimize
`-f`. But the master MILP took its linear objective straight from the raw
expression coefficients (`+f`). For a maximize model the master therefore
*minimized* `+f` while the subproblems *maximized* it — the two converged to a
common wrong point that OA reported as `status="optimal"`.

Found while evaluating OA as the convex-MINLP engine (lever 3 of #281):

| instance | sense | true opt | OA before | OA after |
|---|---|---|---|---|
| syn05m | max | 837.73 | **−831 "optimal"** ❌ | **837.73 optimal** ✅ |
| batch | min | 285506.5 | 285506.5 ✅ | 285506.5 ✅ |
| clay0203m | min | 41573.26 | 41573.26 ✅ | 41573.26 ✅ |
| batchdes | min | 167427.66 | 167427.66 ✅ | 167427.66 ✅ |

## Fix

The whole OA loop already runs in minimization convention; only the linear
master objective and the final reporting were sense-blind:

- `_decompose_model` negates the linear `obj_coeffs` when the objective is
  MAXIMIZE, so the master MILP minimizes `-f` consistently with the subproblems
  and the (evaluator-based) epigraph cuts.
- the returned `objective`/`bound` are un-negated via `_obj_sign` at every
  `SolveResult` site; the gap is convention-invariant.

## Tests

The OA suite had **no maximize test** — which is how this slipped through. Adds
two regression tests (`test_oa_maximize_linear_objective_is_not_the_minimum`,
`test_oa_maximize_scalar_reaches_true_max`). Full OA suite: 131 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
