### PR TITLE
feat(solver): RENS root primal heuristic for convex MINLP (#281, lever 2)

### DIFF
--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -1176,6 +1176,82 @@ def rins(
             v.ub = ub_v
 
 
+def _restrict_slot(v: object, local: int, lo: float, hi: float) -> None:
+    """Restrict scalar slot ``local`` of ``v`` to the range ``[lo, hi]``.
+
+    Like :func:`_fix_slot` but sets a (possibly non-degenerate) bound range; the
+    caller saves/restores the originals.
+    """
+    new_lb = np.array(v.lb, dtype=np.float64)  # type: ignore[attr-defined]
+    new_ub = np.array(v.ub, dtype=np.float64)  # type: ignore[attr-defined]
+    new_lb.flat[local] = lo
+    new_ub.flat[local] = hi
+    v.lb = new_lb  # type: ignore[attr-defined]
+    v.ub = new_ub  # type: ignore[attr-defined]
+
+
+def rens(
+    model: Model,
+    x_relax: np.ndarray,
+    *,
+    sub_solver: Callable[[Model], Optional[tuple[np.ndarray, float]]],
+    integer_tol: float = 1e-5,
+    max_free: int = 24,
+) -> Optional[tuple[np.ndarray, float]]:
+    """RENS (Relaxation Enforced Neighborhood Search).
+
+    Fix every integer that is (near-)integral in the relaxation ``x_relax`` and
+    restrict each *fractional* integer to its ``{floor, ceil}`` unit box. The
+    resulting sub-MINLP — far smaller than the original, since only the fractional
+    integers stay free — is solved *exactly* by ``sub_solver(model)``, which sees
+    the tightened bounds and returns ``(x_flat, obj)`` or ``None``.
+
+    RENS thus lands the **optimal** integer assignment in the relaxation's
+    rounding neighbourhood, where all-at-once rounding (the feasibility pump) and
+    greedy single-direction diving settle for a feasible-but-suboptimal one. On a
+    near-integral convex relaxation (the typical MIQP case) the neighbourhood is
+    tiny and its optimum is usually the global optimum, so injecting it early
+    collapses the surrounding branch-and-bound search to a quick optimality proof.
+
+    Returns ``None`` (cheaply, after only a fractionality count) when more than
+    ``max_free`` integers are fractional — the neighbourhood is then too large to
+    be worth an exact sub-solve, and the caller should fall back to the pump /
+    diving. The model's bounds are always restored before returning; the dual
+    bound is never touched (the caller injects the result only on improvement).
+
+    Reference: Berthold, "RENS — the optimal rounding", Math. Prog. Comp. 2014.
+    """
+    int_mask = _get_integer_mask(model)
+    int_idx = np.nonzero(int_mask)[0]
+    if int_idx.size == 0:
+        return None
+    x = np.asarray(x_relax, dtype=np.float64)
+    if x.size <= int(int_idx.max()):
+        return None
+    lb0, ub0 = _get_variable_bounds(model)
+    frac = np.abs(x[int_idx] - np.round(x[int_idx]))
+    if int((frac > integer_tol).sum()) > max_free:
+        return None
+
+    slot_map = _flat_slot_map(model)
+    saved = [(v.lb.copy(), v.ub.copy()) for v in model._variables]
+    try:
+        for k, i in enumerate(int_idx):
+            xi = float(x[i])
+            if frac[k] <= integer_tol:
+                lo = hi = float(np.clip(np.round(xi), lb0[i], ub0[i]))
+            else:
+                lo = float(np.clip(np.floor(xi), lb0[i], ub0[i]))
+                hi = float(np.clip(np.ceil(xi), lb0[i], ub0[i]))
+            v, local = slot_map[i]
+            _restrict_slot(v, local, lo, hi)
+        return sub_solver(model)
+    finally:
+        for v, (lb_v, ub_v) in zip(model._variables, saved):
+            v.lb = lb_v
+            v.ub = ub_v
+
+
 def _binary_slot_term(model: Model, flat_idx: int):
     """Build a scalar modeling Expression for binary flat slot ``flat_idx``.
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1272,6 +1272,19 @@ def _unpack_solution(model: Model, x_flat: np.ndarray):
     return result
 
 
+def _pack_solution(model: Model, x_dict: dict, n_vars: int) -> np.ndarray:
+    """Inverse of :func:`_unpack_solution`: pack a ``{var_name: array}`` dict into
+    the flat solution vector, using the same per-variable layout (each variable
+    occupies ``v.size`` consecutive slots in ``model._variables`` order)."""
+    flat = np.zeros(int(n_vars), dtype=np.float64)
+    offset = 0
+    for v in model._variables:
+        size = int(v.size)
+        flat[offset : offset + size] = np.asarray(x_dict[v.name], dtype=np.float64).reshape(-1)
+        offset += size
+    return flat
+
+
 def _unpack_constraint_duals(
     evaluator, mult_g: Optional[np.ndarray]
 ) -> Optional[dict[str, np.ndarray]]:
@@ -1763,6 +1776,12 @@ _AUTO_CUTS_MAX_VARS = 40
 # cheap. Counted as (sum of scalar variable sizes) + (number of constraints).
 _STRUCTURE_CUTS_MAX_SIZE = 100
 
+# RENS root primal heuristic (#281): fraction of the remaining wall budget granted
+# to the bound-restricted sub-MINLP solve, and an absolute cap so it can never
+# starve the surrounding proof on a long overall budget.
+_RENS_BUDGET_FRAC = 0.5
+_RENS_BUDGET_CAP_S = 8.0
+
 # Root cut pool (P3). Rounds of spectral PSD separation to run once at the root
 # to build the inherited pool; more rounds drive the root bound toward the Shor
 # SDP bound (nvs17: 8 rounds -> -2453, ~60 -> -1300, ~150 -> -1221). The pool is
@@ -2037,6 +2056,7 @@ def solve_model(
     root_cut_rounds: Optional[int] = None,
     root_cut_max: Optional[int] = None,
     _lns_enabled: bool = True,
+    rens: bool = True,
     **kwargs,
 ) -> SolveResult:
     """
@@ -3074,6 +3094,7 @@ def solve_model(
             node_callback=node_callback,
             in_tree_presolve_stride=in_tree_presolve_stride,
             in_tree_presolve_repr=_model_repr,
+            rens_enabled=rens,
         )
 
     # --- Problem classification: dispatch LP/QP to specialized solvers ---
@@ -3315,6 +3336,7 @@ def solve_model(
                 node_callback=node_callback,
                 in_tree_presolve_stride=in_tree_presolve_stride,
                 in_tree_presolve_repr=_model_repr,
+                rens_enabled=rens,
             )
 
     # --- Extract variable info ---
@@ -6069,6 +6091,7 @@ def _solve_nlp_bb(
     node_callback=None,
     in_tree_presolve_stride: int = 0,
     in_tree_presolve_repr=None,
+    rens_enabled: bool = True,
 ) -> SolveResult:
     """Solve a MINLP via nonlinear Branch & Bound (NLP-BB).
 
@@ -6428,28 +6451,92 @@ def _solve_nlp_bb(
                     best_root_idx = i
             if best_root_idx is not None:
                 _root_incumbent = False
-                try:
-                    from discopt._jax.primal_heuristics import feasibility_pump
+                # --- RENS (Relaxation Enforced Neighborhood Search), primary ---
+                # Solve the relaxation's rounding neighbourhood EXACTLY (fix the
+                # integers already integral in the relaxation; restrict each
+                # fractional one to {floor, ceil}; solve the small sub-MINLP). On a
+                # near-integral convex relaxation this lands the *optimal* integers
+                # at the root, where the feasibility pump's all-at-once rounding
+                # settles for a feasible-but-suboptimal assignment (#281:
+                # smallinvDAX 0.4004 -> 0.3988). It returns cheaply when too many
+                # integers are fractional, so the pump/diving fallback below still
+                # covers set-partitioning-style relaxations parked at 0.5.
+                if rens_enabled:
+                    try:
+                        from discopt._jax.primal_heuristics import rens as _rens_heuristic
 
-                    fp_sol = feasibility_pump(
-                        model,
-                        result_sols[best_root_idx],
-                        max_rounds=5,
-                        backend=_resolve_heuristic_backend(nlp_solver),
-                        evaluator=evaluator,
-                        deadline=t_start + time_limit,
-                    )
-                    if fp_sol is not None:
-                        fp_obj = float(evaluator.evaluate_objective(fp_sol))
-                        fp_feas = not cl_list or _check_constraint_feasibility(
-                            evaluator, fp_sol, cl_list, cu_list
+                        _rens_budget = max(
+                            0.5,
+                            min(
+                                _RENS_BUDGET_FRAC * (time_limit - (time.perf_counter() - t_start)),
+                                _RENS_BUDGET_CAP_S,
+                            ),
                         )
-                        if np.isfinite(fp_obj) and fp_obj < _SENTINEL_THRESHOLD and fp_feas:
-                            tree.inject_incumbent(fp_sol, fp_obj)
-                            _root_incumbent = True
-                            logger.info("NLP-BB feasibility pump incumbent: obj=%.6g", fp_obj)
-                except Exception as e:
-                    logger.debug("Feasibility pump failed: %s", e)
+
+                        def _rens_sub_solver(_restricted, _tl=_rens_budget):
+                            # Solve the bound-restricted sub-MINLP with the full
+                            # engine (rens=False prevents nested RENS; structure_cuts
+                            # off — the SymPy presolve cannot help a bound-tightened
+                            # MIQP). Returns a flat solution aligned to the evaluator.
+                            sub = solve_model(
+                                _restricted,
+                                time_limit=_tl,
+                                gap_tolerance=gap_tolerance,
+                                nlp_solver=nlp_solver,
+                                rens=False,
+                                structure_cuts=False,
+                            )
+                            if sub.objective is None or sub.x is None:
+                                return None
+                            return _pack_solution(_restricted, sub.x, n_vars), float(sub.objective)
+
+                        rens_res = _rens_heuristic(
+                            model,
+                            result_sols[best_root_idx],
+                            sub_solver=_rens_sub_solver,
+                        )
+                        if rens_res is not None:
+                            rens_sol = np.asarray(rens_res[0], dtype=np.float64).copy()
+                            rens_obj = float(evaluator.evaluate_objective(rens_sol))
+                            rens_feas = not cl_list or _check_constraint_feasibility(
+                                evaluator, rens_sol, cl_list, cu_list
+                            )
+                            if (
+                                np.isfinite(rens_obj)
+                                and rens_obj < _SENTINEL_THRESHOLD
+                                and rens_feas
+                                and _is_integer_feasible_solution(rens_sol, int_offsets, int_sizes)
+                            ):
+                                tree.inject_incumbent(rens_sol, rens_obj)
+                                _root_incumbent = True
+                                logger.info("NLP-BB RENS incumbent: obj=%.6g", rens_obj)
+                    except Exception as e:
+                        logger.debug("RENS failed: %s", e)
+
+                # --- Feasibility pump (fallback when RENS does not apply) ---
+                if not _root_incumbent:
+                    try:
+                        from discopt._jax.primal_heuristics import feasibility_pump
+
+                        fp_sol = feasibility_pump(
+                            model,
+                            result_sols[best_root_idx],
+                            max_rounds=5,
+                            backend=_resolve_heuristic_backend(nlp_solver),
+                            evaluator=evaluator,
+                            deadline=t_start + time_limit,
+                        )
+                        if fp_sol is not None:
+                            fp_obj = float(evaluator.evaluate_objective(fp_sol))
+                            fp_feas = not cl_list or _check_constraint_feasibility(
+                                evaluator, fp_sol, cl_list, cu_list
+                            )
+                            if np.isfinite(fp_obj) and fp_obj < _SENTINEL_THRESHOLD and fp_feas:
+                                tree.inject_incumbent(fp_sol, fp_obj)
+                                _root_incumbent = True
+                                logger.info("NLP-BB feasibility pump incumbent: obj=%.6g", fp_obj)
+                    except Exception as e:
+                        logger.debug("Feasibility pump failed: %s", e)
 
                 # Fractional-diving fallback (issue #268). The feasibility pump
                 # rounds every integer at once, which lands on a constraint-

--- a/python/tests/test_rens.py
+++ b/python/tests/test_rens.py
@@ -1,0 +1,91 @@
+"""Tests for RENS (Relaxation Enforced Neighborhood Search), the convex-MINLP
+root primal heuristic (issue #281).
+
+RENS fixes the integers that are already integral in the continuous relaxation,
+restricts each fractional integer to its ``{floor, ceil}`` unit box, and solves
+the resulting small sub-MINLP exactly. On a near-integral convex relaxation this
+lands the *optimal* integer assignment at the root — where the feasibility pump's
+all-at-once rounding settles for a feasible-but-suboptimal one (or none).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt._jax.primal_heuristics import rens  # noqa: E402
+
+
+def _miqp():
+    """Convex integer QP. Continuous relaxation projects onto ``sum == 5`` at the
+    fractional point ~``[1.7, 2.5, 0.8]``; the in-box integer optimum is
+    ``[2, 2, 1]`` (obj 0.41), which all-at-once rounding of the relaxation misses
+    (e.g. it violates the budget)."""
+    m = dm.Model("miqp")
+    x = m.integer("x", shape=3, lb=0, ub=4)
+    m.minimize((x[0] - 1.6) ** 2 + (x[1] - 2.4) ** 2 + (x[2] - 0.7) ** 2)
+    m.subject_to(x[0] + x[1] + x[2] == 5)
+    return m, x
+
+
+def test_rens_neighborhood_restricts_and_restores():
+    """Integral relaxation integers are fixed to their rounding; fractional ones
+    are restricted to ``{floor, ceil}``; the model's bounds are restored after."""
+    m, _ = _miqp()
+    # x0 integral (2.0), x1 fractional (2.4), x2 integral (1.0).
+    x_relax = np.array([2.0, 2.4, 1.0])
+    saved = [(np.array(v.lb).copy(), np.array(v.ub).copy()) for v in m._variables]
+
+    seen: dict = {}
+
+    def sub_solver(model):
+        v = model._variables[0]
+        seen["lb"] = np.array(v.lb, dtype=float).copy()
+        seen["ub"] = np.array(v.ub, dtype=float).copy()
+        return np.array([2.0, 2.0, 1.0]), 0.41
+
+    res = rens(m, x_relax, sub_solver=sub_solver)
+    assert res is not None
+    assert seen["lb"].tolist() == [2.0, 2.0, 1.0]
+    assert seen["ub"].tolist() == [2.0, 3.0, 1.0]  # x1 free over {2, 3}
+    # Bounds restored to the originals.
+    for v, (lb, ub) in zip(m._variables, saved):
+        assert np.array_equal(np.array(v.lb), lb)
+        assert np.array_equal(np.array(v.ub), ub)
+
+
+def test_rens_returns_none_when_too_many_fractional():
+    """RENS bails (without invoking the sub-solver) when the neighbourhood is too
+    large — so the pump/diving fallback still covers many-fractional relaxations."""
+    m, _ = _miqp()
+    x_relax = np.array([1.5, 2.5, 0.5])  # all three fractional
+    called = {"n": 0}
+
+    def sub_solver(model):
+        called["n"] += 1
+        return None
+
+    assert rens(m, x_relax, sub_solver=sub_solver, max_free=2) is None
+    assert called["n"] == 0
+
+
+@pytest.mark.requires_pounce
+def test_rens_solve_reaches_optimum():
+    """End-to-end: the convex MIQP solves to its known optimum with RENS on."""
+    m, _ = _miqp()
+    r = m.solve(time_limit=30, gap_tolerance=1e-4, rens=True)
+    assert r.objective == pytest.approx(0.41, abs=1e-3)
+    assert np.round(np.asarray(r.x["x"])).astype(int).tolist() == [2, 2, 1]
+
+
+@pytest.mark.requires_pounce
+def test_rens_disabled_is_still_correct():
+    """Disabling RENS must not change correctness (the optimum is still reached)."""
+    m, _ = _miqp()
+    r = m.solve(time_limit=30, gap_tolerance=1e-4, rens=False)
+    assert r.objective == pytest.approx(0.41, abs=1e-3)


### PR DESCRIPTION
## Summary

Lever 2 of #281: a stronger convex-MINLP root primal heuristic so good incumbents
land within the (short) time budget.

The convex NLP-BB feasibility pump rounds every integer at once, settling for a
feasible-but-suboptimal assignment — or, at a tight budget, returning no incumbent
at all. **RENS** (Relaxation Enforced Neighborhood Search; Berthold, MPC 2014)
instead solves the relaxation's *rounding neighbourhood* exactly: fix the integers
already integral in the root relaxation, restrict each fractional one to its
`{floor, ceil}` unit box, and solve the small sub-MINLP. On a near-integral convex
relaxation (the typical MIQP) that box is tiny and its optimum is usually the
global optimum, so injecting it at the root returns the right incumbent early.

## Measured (smallinvDAX family r2b010…150, tight budgets)

| budget | rens=False | rens=True |
|---|---|---|
| 2 s | **no incumbent** on 4/5 instances | near-optimal on **all 5** |
| 3 s | incumbents 1.4–12% off optimum | optimal-or-much-better on all |

A soundness/quality sweep over the in-repo MINLP instances shows **no
optimal-vs-optimal mismatch** (RENS never changes a certified optimum) and cases
where RENS supplies an incumbent the baseline misses entirely (e.g. ex1252a:
none → 92117 feasible).

## Design

- New `primal_heuristics.rens(model, x_relax, *, sub_solver, max_free=24)`: pure
  neighbourhood logic (fix/restrict bounds with save/restore). Bails cheaply
  (after only a fractionality count) when more than `max_free` integers are
  fractional, so the pump/diving fallback still covers set-partitioning-style
  relaxations parked at 0.5.
- Wired as the **primary** root heuristic in `_solve_nlp_bb`; the sub-MINLP is
  solved by a budgeted recursive `solve_model` (`rens=False` prevents nesting,
  `structure_cuts=False`). The feasibility pump now runs only when RENS finds
  nothing — RENS *replaces*, not adds to, the pump on the instances it handles.
- New `rens=True` solve kwarg (default on). `rens=False` restores prior behaviour.

## Correctness

Every adopted point is integer- and constraint-feasibility checked before
injection, and the B&B tree enforces strict improvement — so the dual bound and
gap certification are untouched. RENS is a primal heuristic: it can only propose
a valid feasible incumbent or nothing.

Tests: `test_rens.py` (neighbourhood logic, `max_free` bail-out without invoking
the sub-solver, end-to-end optimum with RENS on and off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
