### PR TITLE
docs(281): OA auto-routing investigated — no safe static gate (lever 3)

### DIFF
--- a/docs/dev/data/oa-vs-nlpbb-convex-bench.jsonl
+++ b/docs/dev/data/oa-vs-nlpbb-convex-bench.jsonl
@@ -1,0 +1,18 @@
+# OA vs NLP-BB+RENS on convex-MINLP instances (lever-3 routing study, #281).
+# Each line: instance features + both engines' (status, objective, wall) at 20s budget.
+# Conclusion: no static gate safely separates OA-wins from OA-losses (see miqp-incumbent-latency.md).
+{"name": "batch", "nint": 24, "nvars": 46, "ncons": 73, "trans": true, "sense": "MINIMIZE", "bb": {"status": "optimal", "obj": 285506.50468, "t": 11.3, "nlp_bb": true}, "oa": {"status": "optimal", "obj": 285506.50428, "t": 0.6, "nlp_bb": false}}
+{"name": "batchdes", "nint": 9, "nvars": 19, "ncons": 19, "trans": true, "sense": "MINIMIZE", "bb": {"status": "optimal", "obj": 167427.64981, "t": 0.5, "nlp_bb": true}, "oa": {"status": "optimal", "obj": 167427.64976, "t": 0.2, "nlp_bb": false}}
+{"name": "batchs201210m", "nint": 251, "nvars": 558, "ncons": 2327, "trans": true, "sense": "MINIMIZE", "bb": {"status": "time_limit", "obj": null, "t": 47.7, "nlp_bb": true}, "oa": {"status": "infeasible", "obj": null, "t": 47.5, "nlp_bb": false}}
+{"name": "clay0203hfsg", "nint": 18, "nvars": 90, "ncons": 132, "trans": false, "sense": "MINIMIZE", "bb": {"status": "feasible", "obj": 41709.76922, "t": 20.3, "nlp_bb": true}, "oa": {"status": "optimal", "obj": 3559.99998, "t": 2.9, "nlp_bb": false}}
+{"name": "clay0303hfsg", "nint": 21, "nvars": 99, "ncons": 150, "trans": false, "sense": "MINIMIZE", "bb": {"status": "feasible", "obj": 26669.10955, "t": 20.4, "nlp_bb": true}, "oa": {"status": "optimal", "obj": 3559.99998, "t": 3.5, "nlp_bb": false}}
+{"name": "clay0305m", "nint": 55, "nvars": 85, "ncons": 155, "trans": false, "sense": "MINIMIZE", "bb": {"status": "time_limit", "obj": null, "t": 20.3, "nlp_bb": true}, "oa": {"status": "feasible", "obj": 8278.47052, "t": 20.0, "nlp_bb": false}}
+{"name": "du-opt", "error": "load:ValueError"}
+{"name": "du-opt5", "error": "load:ValueError"}
+{"name": "ex1223", "nint": 4, "nvars": 11, "ncons": 13, "trans": true, "sense": "MINIMIZE", "bb": {"status": "optimal", "obj": 4.57958, "t": 0.4, "nlp_bb": true}, "oa": {"status": "optimal", "obj": 4.57958, "t": 0.2, "nlp_bb": false}}
+{"name": "ex1223a", "nint": 4, "nvars": 7, "ncons": 9, "trans": false, "sense": "MINIMIZE", "bb": {"status": "optimal", "obj": 4.57958, "t": 0.3, "nlp_bb": true}, "oa": {"status": "optimal", "obj": 4.57958, "t": 0.1, "nlp_bb": false}}
+{"name": "ex1223b", "nint": 4, "nvars": 7, "ncons": 9, "trans": true, "sense": "MINIMIZE", "bb": {"status": "optimal", "obj": 4.57958, "t": 0.3, "nlp_bb": true}, "oa": {"status": "optimal", "obj": 4.57958, "t": 0.2, "nlp_bb": false}}
+{"name": "ex1224", "nint": 8, "nvars": 11, "ncons": 7, "trans": true, "sense": "MINIMIZE", "bb": {"status": "feasible", "obj": -0.94347, "t": 20.0, "nlp_bb": false}, "oa": {"status": "feasible", "obj": -0.6392, "t": 20.0, "nlp_bb": false}}
+{"name": "ex1225", "nint": 6, "nvars": 8, "ncons": 10, "trans": true, "sense": "MINIMIZE", "bb": {"status": "optimal", "obj": 31.0, "t": 1.4, "nlp_bb": false}, "oa": {"status": "optimal", "obj": 31.0, "t": 0.1, "nlp_bb": false}}
+{"name": "ex1226", "nint": 3, "nvars": 5, "ncons": 5, "trans": true, "sense": "MINIMIZE", "bb": {"status": "optimal", "obj": -17.0, "t": 0.7, "nlp_bb": false}, "oa": {"status": "feasible", "obj": -3.3353, "t": 20.0, "nlp_bb": false}}
+{"name": "fac1", "nint": 6, "nvars": 22, "ncons": 18, "trans": true, "sense": "MINIMIZE", "bb": {"status": "optimal", "obj": 160912612.35016, "t": 0.5, "nlp_bb": true}, "oa": {"status": "optimal", "obj": 160912612.34991, "t": 0.4, "nlp_bb": false}}

--- a/docs/dev/miqp-incumbent-latency.md
+++ b/docs/dev/miqp-incumbent-latency.md
@@ -86,12 +86,35 @@ with a one-line fix). The latency is distributed across compile + primal + searc
      handling meant maximize problems were optimized in the wrong direction and
      certified wrong (syn05m: −831 "optimal" vs true 837.73). Fixed in #301.
 
-   Conclusion: a blanket "route convex MINLP to OA" would *regress* the QP and
-   non-convex-objective classes. Safe auto-routing needs a structural gate (route
-   to OA only for transcendental/expensive-NLP convex MINLP with an OA-valid
-   master bound, i.e. `master_bound_valid` true and non-quadratic nonlinearity),
-   validated on the full convex-MINLP benchmark. *That gate is the remaining
-   lever-3 work; the engine and its correctness are ready.*
+   **Auto-routing investigated and found unsafe (no static gate).** A
+   convex-MINLP benchmark (NLP-BB+RENS vs OA, both engines, ~per-instance
+   features) was run to design a routing gate. Every candidate static
+   discriminator regresses some class:
+
+   | instance | objective | nl-constraints | transcendental | OA vs NLP-BB+RENS |
+   |---|---|---|---|---|
+   | batch, batchdes, ex1223, ex1225 | lin/cvx | 1–4 | mixed | **OA wins** (≤0.6 s vs 11 s) |
+   | clay0203hfsg/0303hfsg/0305m | linear | 24–60 | no | **OA wins** (NLP-BB times out / 41709 vs 3560) |
+   | smallinvDAX (QCQP) | linear | 1 (quadratic) | no | **OA regresses** — false `infeasible` @3 s vs RENS 0.40 |
+   | syn05hfsg | concave (max) | yes | yes | **OA regresses** — 837.44 vs 837.73 |
+   | rsyn0805hfsg | linear | yes | yes | **OA regresses** — feasible 1272 vs NLP-BB optimal 1136 |
+   | ex1224, ex1226, alan | — | — | — | not OA-convex → NLP-BB (correctly) |
+
+   The discriminators all fail: "has nonlinear constraint" routes smallinvDAX
+   (regress); "transcendental" routes syn/rsyn (regress); "fully-OA-convex" admits
+   both winners and losers; a nl-constraint *count* threshold is fragile and
+   unvalidated. OA's advantage is **convergence-dependent (problem-specific)**, not
+   predictable from structure — when OA is a poor fit it stalls and, at a tight
+   budget, returns a false `infeasible`/suboptimal incumbent, reintroducing the
+   exact #281 symptom. So a blanket or simple-structural auto-route is *not* safe.
+
+   **Decision: keep OA opt-in (`m.solve(gdp_method="oa")`), now soundness-correct
+   (#301).** The only zero-regression auto-route would be *dynamic*: give OA a
+   short bounded slice and adopt it only if it proves optimality quickly, else
+   fall back to NLP-BB+RENS — but even a short wasted slice causes a bounded
+   tight-budget regression on the RENS-favourable QCQP class (smallinvDAX@5 s:
+   0.3988 → ~0.40), so it is deferred pending a budget-adaptive design that avoids
+   that cost. The engine and its correctness are ready for whoever takes that on.
 
 ## Recommendation
 
@@ -101,10 +124,12 @@ This is SCIP-gap-class work, not a one-liner. Sequence by payoff/risk:
   broadly across the short tier.
 - **Lever 2 (convex-MINLP primal) — DONE.** RENS lands near-optimal incumbents at
   tight budgets where the pump returned none/poor ones (#281, #302).
-- **Lever 3 (OA) — engine ready, correctness fixed (#301); structural auto-routing
-  gate is the remaining work.** OA is a large win on transcendental convex MINLP
-  but regresses QP / non-convex-objective classes, so routing must be gated and
-  benchmark-validated rather than blanket-enabled.
+- **Lever 3 (OA) — engine ready, correctness fixed (#301); auto-routing
+  investigated and shelved (no safe static gate).** OA is a large win on some
+  convex MINLPs (batch, clay) but regresses others (smallinvDAX false-infeasible,
+  syn/rsyn suboptimal); the win is convergence-dependent, not statically
+  predictable, so OA stays opt-in. A budget-adaptive dynamic probe is the only
+  candidate for safe auto-routing and is left as future work.
 
 Each lever is gated on the existing short-tier benchmark harness
 (`discopt-minlp-benchmark`), tracking per-instance incumbent-latency and gap so


### PR DESCRIPTION
## Summary

Completes the lever-3 (Outer Approximation) investigation for #281. I ran a
convex-MINLP benchmark (NLP-BB+RENS vs OA, both engines, per-instance structural
features) to design an auto-routing gate, and the data shows **no static gate
safely routes convex MINLP to OA** — every candidate discriminator regresses some
class:

| discriminator | captures | but regresses |
|---|---|---|
| has nonlinear constraint | clay, batch | smallinvDAX (QCQP) → false `infeasible` @3s |
| transcendental | batch, ex1223 | syn05hfsg, rsyn0805hfsg → suboptimal |
| fully-OA-convex | batch, clay | admits smallinvDAX (regress) too |

OA's advantage is **convergence-dependent (problem-specific)**, not predictable
from structure: when OA is a poor fit it stalls and, at a tight budget, returns a
false `infeasible`/suboptimal incumbent — reintroducing the exact #281 symptom.

**Decision (chosen): keep OA opt-in** (`m.solve(gdp_method="oa")`), now
soundness-correct after #301. The only zero-regression auto-route would be a
*budget-adaptive dynamic probe* (give OA a short slice; adopt only if it proves
optimality fast, else fall back to NLP-BB+RENS) — but even a short wasted slice
causes a bounded tight-budget regression on the RENS-favourable QCQP class, so it
is documented as future work rather than shipped.

Docs-only: updates `docs/dev/miqp-incumbent-latency.md` lever-3 section with the
evidence table and decision, and saves the raw benchmark data under
`docs/dev/data/oa-vs-nlpbb-convex-bench.jsonl` for reproducibility. No solver
behavior change (the unsafe static gate prototype was reverted, not merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
