### PR TITLE
fix(oa): resolve mypy errors from #301 that broke main lint

### DIFF
--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -139,7 +139,7 @@ def _decompose_model(model: Model) -> _DecomposedProblem:
     # Without this the master MILP minimizes ``+f`` while the subproblems maximize
     # it, and OA converges to — and certifies as optimal — a wrong point
     # (e.g. syn05m: returned -831 as "optimal" vs the true maximum 837.73).
-    if obj_is_linear and raw_obj is not None and raw_obj.sense == ObjectiveSense.MAXIMIZE:
+    if obj_coeffs is not None and raw_obj is not None and raw_obj.sense == ObjectiveSense.MAXIMIZE:
         _c_vec, _c_off = obj_coeffs
         obj_coeffs = (-_c_vec, -_c_off)
 
@@ -945,7 +945,7 @@ def solve_oa(
     bound = LB if decomp.master_bound_valid and LB > -1e19 else None
     reported_gap = gap if bound is not None and UB < 1e19 else None
 
-    if incumbent is not None:
+    if incumbent is not None and incumbent_obj is not None:
         status = "optimal" if gap <= gap_tolerance else "feasible"
         return SolveResult(
             status=status,


### PR DESCRIPTION
## Summary

PR #301's maximize-sense fix introduced two type errors that the **pre-commit
mypy hook** flags (its config is stricter than a bare `mypy python/discopt/solvers/oa.py`,
which passed locally). The pre-commit watcher merged #301 on a stale "green" read
while this check was actually failing, so `main`'s `Lint + typecheck` is now red —
breaking lint for every subsequent PR (e.g. #304, a docs-only change, failed here).

Fixes:
- `_decompose_model`: guard the `obj_coeffs` unpack on `obj_coeffs is not None`
  (mypy doesn't correlate `obj_is_linear` with non-None).
- final `SolveResult`: narrow `incumbent_obj` with `is not None` before
  `_obj_sign * incumbent_obj` (it is always set together with `incumbent`, so
  behaviour is unchanged).

`pre-commit run mypy --all-files` now passes; ruff clean; OA maximize regression
tests pass. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
