### PR TITLE
test(issue-297): guard st_ph10 against false-optimal certificate

### DIFF
--- a/python/tests/data/minlplib/st_ph10.nl
+++ b/python/tests/data/minlplib/st_ph10.nl
@@ -1,0 +1,62 @@
+g3 0 1 0	# problem st_ph10
+ 2 4 1 0 0	# vars, constraints, objectives, ranges, eqns
+ 0 1	# nonlinear constraints, objectives
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 8 2	# nonzeros in Jacobian, gradients
+ 3 2	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+b
+2 0
+1 0
+r
+1 1
+1 7
+1 5
+1 2
+C0
+n0
+C1
+n0
+C2
+n0
+C3
+n0
+O0 0
+o54
+4
+o2
+n-1.5
+o5
+v0
+n2
+o2
+n3
+v0
+o2
+n-3.5
+o5
+v1
+n2
+o2
+n7
+v1
+k1
+4
+J0 2
+0 -2
+1 1
+J1 2
+0 1
+1 2
+J2 2
+0 1
+1 1
+J3 2
+0 1
+1 -2
+G0 2
+0 0
+1 0

--- a/python/tests/test_issue_297_sound_certificate.py
+++ b/python/tests/test_issue_297_sound_certificate.py
@@ -1,0 +1,47 @@
+"""Regression for issue #297: st_ph10 must not return a false-optimal certificate.
+
+`st_ph10` (MINLPLib, minimization, known optimum -10.5) was deterministically
+returned as ``optimal`` with ``gap=0`` at an incumbent of -28.0556 — *below*
+discopt's own (correct) dual lower bound of -10.5. For a minimization the
+incumbent objective must be >= the lower bound, so ``obj < bound`` is an internally
+inconsistent, unsound certificate (the most severe class).
+
+This guards the soundness invariant robustly (no dependence on the exact optimum
+being reached): a returned certificate must never place the incumbent below the
+dual bound, and a ``gap=0`` ``optimal`` must sit at the true optimum -10.5.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import pytest  # noqa: E402
+
+_DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib")
+
+
+@pytest.mark.requires_pounce
+def test_st_ph10_certificate_is_sound():
+    """The returned certificate must be self-consistent: the incumbent is never
+    below the dual bound, and a ``gap=0`` ``optimal`` is at the true optimum."""
+    path = os.path.join(_DATA, "st_ph10.nl")
+    if not os.path.exists(path):
+        pytest.skip("st_ph10 instance unavailable")
+    r = dm.from_nl(path).solve(time_limit=10, gap_tolerance=1e-4)
+
+    # Minimization: a sound solve never reports an incumbent below its dual bound.
+    if r.objective is not None and r.bound is not None:
+        assert r.objective >= r.bound - 1e-4 * (1.0 + abs(r.bound)), (
+            f"unsound: incumbent {r.objective} is below the dual bound {r.bound} "
+            "(issue #297 false-optimal)"
+        )
+
+    # A certified optimum must be the real optimum, not a fabricated gap=0 point.
+    if r.status == "optimal":
+        assert r.objective == pytest.approx(-10.5, abs=1e-2), (
+            f"certified optimal at {r.objective}, expected the true optimum -10.5"
+        )


### PR DESCRIPTION
## Summary

Regression guard for issue #297. `st_ph10` (MINLPLib, min, opt **−10.5**) was
deterministically returned as `optimal`/`gap=0` at an incumbent of **−28.06** —
*below* discopt's own (correct) dual bound −10.5, an internally inconsistent and
unsound certificate. It **no longer reproduces** on current `main` (returns the
correct `optimal −10.5`, 3/3 runs); this adds a guard so it can't silently
regress.

The test vendors the 672-byte `st_ph10.nl` and asserts the soundness invariant
(robust, not tied to reaching the exact optimum): the incumbent is never below
the dual bound, and a `gap=0` `optimal` is at the true optimum −10.5.

Closes #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
