### PR TITLE
fix(nl-parser): type objective-only integers when nlvo > nlvc (ex1252a false-feasible)

### DIFF
--- a/crates/discopt-core/src/nl_parser.rs
+++ b/crates/discopt-core/src/nl_parser.rs
@@ -754,12 +754,25 @@ pub fn parse_nl(content: &str) -> Result<ModelRepr, NlParseError> {
         }
     }
 
-    // Last nlvoi of the (nlvo - nlvb) group (starts at max(nlvc, nlvb))
+    // Last nlvoi of the objective-only nonlinear group. The group's bounds depend
+    // on whether more nonlinear variables live in objectives than in constraints:
+    //   * nlvc >= nlvo (common): block = [max(nlvc,nlvb), max(nlvc,nlvb)+(nlvo-nlvb))
+    //   * nlvo  >  nlvc (AMPL edge case): the whole nonlinear block is [0, nlvo) and
+    //     the objective-only group is [nlvc, nlvo); its integer tail is
+    //     [nlvo-nlvoi, nlvo).  The old `(nlvo - nlvb)`-sized formula placed that tail
+    //     out of range here, silently leaving the variables continuous — which on
+    //     ex1252a relaxed its 3 binaries (b22..b24) to [0,1], enlarging the feasible
+    //     set and yielding a *false-feasible* incumbent below the true optimum.
     if nlvoi > 0 && nlvo > nlvb {
-        let obj_start = std::cmp::max(nlvc, nlvb);
-        let group_size = nlvo - nlvb;
-        if group_size >= nlvoi {
-            let start = obj_start + group_size - nlvoi;
+        let (obj_only_start, obj_only_end) = if nlvo > nlvc {
+            (nlvc, nlvo)
+        } else {
+            let s = std::cmp::max(nlvc, nlvb);
+            (s, s + (nlvo - nlvb))
+        };
+        let group_size = obj_only_end.saturating_sub(obj_only_start);
+        if group_size >= nlvoi && obj_only_end <= n_vars {
+            let start = obj_only_end - nlvoi;
             for vt in var_types.iter_mut().skip(start).take(nlvoi) {
                 *vt = VarType::Integer;
             }

--- a/python/tests/test_nl_parser_objonly_integers.py
+++ b/python/tests/test_nl_parser_objonly_integers.py
@@ -1,0 +1,80 @@
+"""Regression: .nl parser must type objective-only integer variables when
+``nlvo > nlvc`` (AMPL variable-ordering edge case).
+
+ex1252a's header has ``nlvc=15, nlvo=21, nlvb=6, nlvoi=3``: its 3 binaries
+(b22,b23,b24) are integer variables that appear nonlinearly only in the
+*objective*. The old parser sized the objective-only group as ``nlvo - nlvb`` and
+placed its integer tail at index 27 — out of range for a 24-variable model — so
+the binaries were silently left **continuous**. That relaxed them from {0,1} to
+[0,1], enlarging the feasible set, and the solver returned a *false-feasible*
+incumbent (obj ~92117, below the proven optimum 128893.74).
+
+Correct AMPL layout when ``nlvo > nlvc``: the nonlinear block is ``[0, nlvo)`` and
+the objective-only group is ``[nlvc, nlvo)``, with its integer tail at
+``[nlvo-nlvoi, nlvo)``. Both ex1252a and ghg_1veh are the only vendored instances
+whose types change under the fix.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import Counter
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt.modeling.core import VarType  # noqa: E402
+
+_DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib")
+_EX1252A_OPT = 128893.741
+
+
+def _flat_types(model):
+    out = []
+    for v in model._variables:
+        out.extend([v.var_type] * v.size)
+    return out
+
+
+def test_ex1252a_objective_only_binaries_typed_integer():
+    """The 3 objective-only binaries must parse as discrete, not continuous."""
+    path = os.path.join(_DATA, "ex1252a.nl")
+    if not os.path.exists(path):
+        pytest.skip("ex1252a instance unavailable")
+    m = dm.from_nl(path)
+    types = _flat_types(m)
+    counts = Counter(str(t).split(".")[-1] for t in types)
+    # 6 nonlinear-in-both integers (i16..i21) + 3 objective-only binaries (b22..b24).
+    assert counts.get("INTEGER", 0) + counts.get("BINARY", 0) == 9, (
+        f"expected 9 discrete vars, got {dict(counts)} (objective-only binaries "
+        "were dropped to continuous)"
+    )
+    # The 3 binaries are discrete with a [0,1] box.
+    lbs, ubs = [], []
+    for v in m._variables:
+        lbs.extend(np.atleast_1d(np.asarray(v.lb, float)).ravel().tolist())
+        ubs.extend(np.atleast_1d(np.asarray(v.ub, float)).ravel().tolist())
+    n_binary_box = sum(
+        1
+        for t, lo, hi in zip(types, lbs, ubs)
+        if t in (VarType.BINARY, VarType.INTEGER) and lo == 0.0 and hi == 1.0
+    )
+    assert n_binary_box >= 3, f"expected >=3 discrete [0,1] vars, got {n_binary_box}"
+
+
+@pytest.mark.slow
+@pytest.mark.requires_pounce
+def test_ex1252a_not_false_feasible():
+    """With the binaries correctly discrete, no incumbent may sit below the proven
+    optimum (the pre-fix relaxed-binary feasible set yielded obj ~92117 < opt)."""
+    path = os.path.join(_DATA, "ex1252a.nl")
+    if not os.path.exists(path):
+        pytest.skip("ex1252a instance unavailable")
+    r = dm.from_nl(path).solve(time_limit=40, gap_tolerance=1e-4)
+    if r.objective is not None:
+        assert r.objective >= _EX1252A_OPT - 1e-2, (
+            f"false-feasible: incumbent {r.objective} is below the proven optimum {_EX1252A_OPT}"
+        )


### PR DESCRIPTION
## Summary

Found and fixed a **false-feasible soundness bug** while investigating #196: the
`.nl` parser mis-types objective-only integer variables in the AMPL ordering edge
case `nlvo > nlvc`.

On **ex1252a** the 3 binaries `b22,b23,b24` were parsed as **continuous** (the
parser placed the objective-only integer tail at index 27, out of range for a
24-variable model). That relaxed them from {0,1} to [0,1], enlarging the feasible
set, and discopt returned a **`feasible` incumbent obj≈92117 — below the proven
optimum 128893.74** (BARON independently confirms 128893.74). A feasible point
below the global minimum is unsound.

## Root cause

AMPL `.nl` orders variables as `[both | cons-only | obj-only | linear]` with the
integer tail at the end of each nonlinear group. The objective-only group is
`[nlvc, nlvo)` **when `nlvo > nlvc`** (the whole nonlinear block is `[0, nlvo)`),
so its integer tail is `[nlvo-nlvoi, nlvo)`. The parser instead used a
`(nlvo - nlvb)`-sized group from `max(nlvc,nlvb)`, overshooting the vector.

## Fix + blast radius

One-branch fix to the `nlvoi` placement; the common `nlvc >= nlvo` path is
untouched. Scanning **all 1610** MINLPLib `.nl` headers, exactly **2** instances
change types — and both become sound:

| instance | before | after | opt |
|---|---|---|---|
| ex1252a | feasible **92117** (false) | feasible **134471** (≥ opt) | 128893.74 |
| ghg_1veh | (b10 continuous) | b10 discrete, feasible **7.7816** | 7.78163 |

The other 120 `nlvo>cnlvc` instances had `old_start == new_start` (no change).
Regression: smoke 10/10 / 0-incorrect; 55 Python + 36 Rust `nl_parser` tests pass.

## Tests
`test_nl_parser_objonly_integers.py`: the objective-only binaries parse discrete,
and (slow) ex1252a never returns an incumbent below the proven optimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
