### PR TITLE
fix(large-minlp): dense-Jacobian compile crash guard + sparse evaluate_jacobian + deadline-aware probing

### DIFF
--- a/crates/discopt-core/src/presolve/orchestrator.rs
+++ b/crates/discopt-core/src/presolve/orchestrator.rs
@@ -70,6 +70,13 @@ pub struct PresolveResult {
 pub fn run(model: crate::expr::ModelRepr, mut opts: OrchestratorOptions) -> PresolveResult {
     let started = Instant::now();
     let mut ctx = PresolveContext::from_model(model);
+    // Expose the run deadline so long passes (probing) can bail mid-loop
+    // instead of only being stopped by the between-passes check below.
+    ctx.deadline = if opts.time_limit_ms > 0 {
+        Some(started + std::time::Duration::from_millis(opts.time_limit_ms))
+    } else {
+        None
+    };
     let mut deltas: Vec<PresolveDelta> = Vec::new();
     let mut terminated_by = TerminationReason::IterationCap;
     let mut last_iter: u32 = 0;

--- a/crates/discopt-core/src/presolve/pass.rs
+++ b/crates/discopt-core/src/presolve/pass.rs
@@ -26,6 +26,8 @@
 //! unsorted `HashMap` iteration in the result path). New passes added
 //! later must preserve this.
 
+use std::time::Instant;
+
 use super::delta::PresolveDelta;
 use super::fbbt::Interval;
 use crate::expr::ModelRepr;
@@ -62,6 +64,13 @@ pub struct PresolveContext {
     pub work_units_used: u64,
     /// Cumulative wall time consumed by passes in this run.
     pub time_used_ms: f64,
+    /// Absolute wall-clock deadline for the whole presolve run, if set.
+    /// The orchestrator only checks the time budget *between* passes, so a
+    /// single long pass (e.g. probing, which clones the model and runs FBBT
+    /// per binary variable) can overrun it badly on large models. Passes that
+    /// loop over variables poll this to bail early with partial — and still
+    /// sound — results.
+    pub deadline: Option<Instant>,
 }
 
 impl PresolveContext {
@@ -85,6 +94,7 @@ impl PresolveContext {
             iter: 0,
             work_units_used: 0,
             time_used_ms: 0.0,
+            deadline: None,
         }
     }
 

--- a/crates/discopt-core/src/presolve/passes.rs
+++ b/crates/discopt-core/src/presolve/passes.rs
@@ -29,7 +29,7 @@ use super::fbbt_fp::{fbbt_fixed_point, FbbtFpOptions};
 use super::implied_bounds::propagate_implied_bounds;
 use super::pass::{PassCategory, PresolveContext, PresolvePass};
 use super::polynomial::reformulate_polynomial;
-use super::probing::probe_binary_vars;
+use super::probing::probe_binary_vars_until;
 use super::reduction_constraints::detect_reduction_constraints;
 use super::redundancy::detect_row_redundancy;
 use super::scaling::compute_equilibration;
@@ -136,7 +136,7 @@ impl PresolvePass for ProbingPass {
     }
     fn run(&mut self, ctx: &mut PresolveContext) -> PresolveDelta {
         let before = ctx.bounds.clone();
-        let result = probe_binary_vars(&ctx.model, &ctx.bounds);
+        let result = probe_binary_vars_until(&ctx.model, &ctx.bounds, ctx.deadline);
         // probing returns full tightened-bounds vector; intersect with
         // existing.
         let n = ctx.bounds.len().min(result.tightened_bounds.len());

--- a/crates/discopt-core/src/presolve/probing.rs
+++ b/crates/discopt-core/src/presolve/probing.rs
@@ -3,6 +3,8 @@
 //! For each binary variable, temporarily fix it to 0 and 1, run FBBT,
 //! and use the results to detect fixings, tightened bounds, and implications.
 
+use std::time::Instant;
+
 use super::fbbt::{fbbt, Interval, FEAS_TOL};
 use crate::expr::{ModelRepr, VarType};
 
@@ -37,6 +39,20 @@ pub struct Implication {
 /// - Tighter bounds from intersecting the two cases.
 /// - Implications for bound tightening.
 pub fn probe_binary_vars(model: &ModelRepr, var_bounds: &[Interval]) -> ProbingResult {
+    probe_binary_vars_until(model, var_bounds, None)
+}
+
+/// Like [`probe_binary_vars`] but stops once `deadline` passes, returning the
+/// implications gathered so far. Probing clones the model and runs FBBT per
+/// binary variable, so a full pass on a large model can take minutes — far
+/// past the orchestrator's *between-passes* time check. Bailing mid-loop only
+/// performs *fewer* tightenings; every implication already found stays valid,
+/// so the early exit is sound.
+pub fn probe_binary_vars_until(
+    model: &ModelRepr,
+    var_bounds: &[Interval],
+    deadline: Option<Instant>,
+) -> ProbingResult {
     let n = var_bounds.len();
     let mut fixed_vars: Vec<(usize, f64)> = Vec::new();
     let mut best_bounds = var_bounds.to_vec();
@@ -46,6 +62,11 @@ pub fn probe_binary_vars(model: &ModelRepr, var_bounds: &[Interval]) -> ProbingR
     let fbbt_tol = 1e-8;
 
     for (i, vinfo) in model.variables.iter().enumerate() {
+        if let Some(dl) = deadline {
+            if Instant::now() >= dl {
+                break;
+            }
+        }
         if vinfo.var_type != VarType::Binary {
             continue;
         }
@@ -231,6 +252,92 @@ mod tests {
         assert_eq!(result.fixed_vars.len(), 1);
         assert_eq!(result.fixed_vars[0].0, 1);
         assert!((result.fixed_vars[0].1 - 0.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_probing_honors_past_deadline() {
+        // Same model as `test_probing_fixes_binary_var` (probing would fix y=0),
+        // but with a deadline already in the past. The orchestrator only checks
+        // the time budget *between* passes, so probing — which clones the model
+        // and runs FBBT per binary — must poll the deadline itself and bail
+        // before doing work. Returning fewer tightenings is always sound.
+        let mut arena = ExprArena::new();
+        let x = arena.add(ExprNode::Variable {
+            name: "x".into(),
+            index: 0,
+            size: 1,
+            shape: vec![],
+        });
+        let y = arena.add(ExprNode::Variable {
+            name: "y".into(),
+            index: 1,
+            size: 1,
+            shape: vec![],
+        });
+        let c10 = arena.add(ExprNode::Constant(10.0));
+        let prod = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Mul,
+            left: c10,
+            right: y,
+        });
+        let sum = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Add,
+            left: x,
+            right: prod,
+        });
+        let model = ModelRepr {
+            arena,
+            objective: ExprId(0),
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body: sum,
+                sense: ConstraintSense::Le,
+                rhs: 5.0,
+                name: Some("c1".into()),
+            }],
+            variables: vec![
+                VarInfo {
+                    name: "x".into(),
+                    var_type: VarType::Continuous,
+                    offset: 0,
+                    size: 1,
+                    shape: vec![],
+                    lb: vec![0.0],
+                    ub: vec![10.0],
+                },
+                VarInfo {
+                    name: "y".into(),
+                    var_type: VarType::Binary,
+                    offset: 1,
+                    size: 1,
+                    shape: vec![],
+                    lb: vec![0.0],
+                    ub: vec![1.0],
+                },
+            ],
+            n_vars: 2,
+        };
+
+        let var_bounds = vec![Interval::new(0.0, 10.0), Interval::new(0.0, 1.0)];
+
+        // No deadline: probing does its work and fixes y=0 (control).
+        let unbounded = probe_binary_vars_until(&model, &var_bounds, None);
+        assert_eq!(unbounded.fixed_vars.len(), 1);
+
+        // Deadline already in the past: probing bails at the first loop check,
+        // before probing any binary, so no fixings are reported.
+        let past = std::time::Instant::now();
+        let bailed = probe_binary_vars_until(&model, &var_bounds, Some(past));
+        assert!(
+            bailed.fixed_vars.is_empty(),
+            "probing must bail before any work once the deadline has passed"
+        );
+        // Bounds pass through unchanged on the early exit.
+        assert_eq!(bailed.tightened_bounds.len(), var_bounds.len());
+        for (got, want) in bailed.tightened_bounds.iter().zip(var_bounds.iter()) {
+            assert_eq!(got.lo, want.lo);
+            assert_eq!(got.hi, want.hi);
+        }
     }
 
     #[test]

--- a/python/discopt/_jax/nlp_evaluator.py
+++ b/python/discopt/_jax/nlp_evaluator.py
@@ -28,6 +28,17 @@ from discopt._jax.dag_compiler import (
 )
 from discopt.modeling.core import Constraint, Model, ObjectiveSense
 
+# Above this many dense Jacobian entries (m * n), ``evaluate_jacobian`` routes
+# through the sparse coloring path instead of compiling the dense
+# ``jax.jacfwd``. The dense compile replicates the whole constraint program once
+# per input variable, so for a large model its XLA jaxpr explodes during MLIR
+# lowering and aborts the *process* with a native SIGBUS/SIGILL (rsyn0810m03hfsg:
+# 1935 x 1185 ~ 2.3M entries, yet only ~0.2% nonzero). The cap sits well above
+# any small/medium model — which keep the faster dense path with no behavior
+# change — and below the crash regime, where the dense compile is not a viable
+# option anyway, so sparse is strictly safer.
+_DENSE_JACOBIAN_COMPILE_LIMIT = 1_000_000
+
 
 def validate_sparse_values(evaluator, x: np.ndarray, atol: float = 1e-8) -> bool:
     """Check that sparse COO values agree with dense evaluation.
@@ -388,29 +399,20 @@ class NLPEvaluator:
             return np.array([], dtype=np.float64)
         return np.asarray(self._cons_fn_jit(x, self._current_params()))
 
-    def evaluate_jacobian(self, x: np.ndarray) -> np.ndarray:
-        """Evaluate Jacobian of constraints at x. Returns (m, n) array."""
+    def _evaluate_dense_jacobian(self, x: np.ndarray) -> np.ndarray:
+        """Raw dense Jacobian via the compiled ``jax.jacfwd``. Callers must size-
+        gate this: on a large model the dense compile aborts the process (see
+        ``_DENSE_JACOBIAN_COMPILE_LIMIT``). Use :meth:`evaluate_jacobian` for the
+        guarded, size-aware entry point."""
         if self._jac_fn_jit is None:
             return np.empty((0, self._n_variables), dtype=np.float64)
         return np.asarray(self._jac_fn_jit(x, self._current_params()))
 
-    def evaluate_sparse_jacobian(self, x: np.ndarray):
-        """Evaluate Jacobian as a sparse CSC matrix using compressed JVPs.
-
-        Uses sparsity detection and graph coloring to evaluate the Jacobian
-        in O(p) JVPs where p is the chromatic number (typically 5-20).
-        Falls back to dense evaluation if sparsity infrastructure is unavailable.
-
-        Returns:
-            scipy.sparse.csc_matrix of shape (m, n), or dense (m, n) ndarray
-            if sparse evaluation is not applicable.
-        """
+    def _ensure_sparse_jac_fn(self) -> bool:
+        """Lazily build the sparse (coloring-based) Jacobian function. Returns
+        True when a sparse evaluator is available for this model. Idempotent."""
         if self._cons_fn_jit is None:
-            import scipy.sparse as sp
-
-            return sp.csc_matrix((0, self._n_variables), dtype=np.float64)
-
-        # Lazy-initialize sparse infrastructure
+            return False
         if not hasattr(self, "_sparse_jac_fn"):
             self._sparse_jac_fn = None
             try:
@@ -430,12 +432,57 @@ class NLPEvaluator:
                     self._sparse_jac_fn = make_sparse_jac_fn(self._cons_fn, pattern, colors, seed)
             except Exception:
                 pass
+        return self._sparse_jac_fn is not None
 
-        if self._sparse_jac_fn is not None:
+    def evaluate_jacobian(self, x: np.ndarray) -> np.ndarray:
+        """Evaluate Jacobian of constraints at x. Returns a dense (m, n) array.
+
+        For a large model the dense ``jax.jacfwd`` compile explodes XLA — it
+        replicates the constraint program once per input variable — and aborts
+        the *process* with a native crash that no ``try/except`` can catch. Above
+        ``_DENSE_JACOBIAN_COMPILE_LIMIT`` (m * n) this routes through the sparse
+        coloring path (O(chromatic-number) JVPs) and densifies, so any caller
+        needing a full-model Jacobian at scale stays safe while still receiving
+        the same dense (m, n) array. Small/medium models keep the faster dense
+        path unchanged. Only triggers when the sparse evaluator is actually
+        available; otherwise the dense path is used as before.
+        """
+        if self._jac_fn_jit is None:
+            return np.empty((0, self._n_variables), dtype=np.float64)
+        if (
+            self._n_constraints * self._n_variables > _DENSE_JACOBIAN_COMPILE_LIMIT
+            and self._ensure_sparse_jac_fn()
+        ):
+            import scipy.sparse as sp
+
+            J = self._sparse_jac_fn(x)
+            if sp.issparse(J):
+                return np.asarray(J.toarray(), dtype=np.float64)
+            return np.asarray(J, dtype=np.float64)
+        return self._evaluate_dense_jacobian(x)
+
+    def evaluate_sparse_jacobian(self, x: np.ndarray):
+        """Evaluate Jacobian as a sparse CSC matrix using compressed JVPs.
+
+        Uses sparsity detection and graph coloring to evaluate the Jacobian
+        in O(p) JVPs where p is the chromatic number (typically 5-20).
+        Falls back to dense evaluation if sparsity infrastructure is unavailable.
+
+        Returns:
+            scipy.sparse.csc_matrix of shape (m, n), or dense (m, n) ndarray
+            if sparse evaluation is not applicable.
+        """
+        if self._cons_fn_jit is None:
+            import scipy.sparse as sp
+
+            return sp.csc_matrix((0, self._n_variables), dtype=np.float64)
+
+        if self._ensure_sparse_jac_fn():
             return self._sparse_jac_fn(x)
 
-        # Fallback to dense
-        return self.evaluate_jacobian(x)
+        # Fallback to the RAW dense path (not evaluate_jacobian, which would
+        # re-enter this method for a large model and recurse).
+        return self._evaluate_dense_jacobian(x)
 
     @property
     def sparsity_pattern(self):

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -192,6 +192,17 @@ _POUNCE_BATCH_MIN_VARS = 50
 # budget. Nodes that start fully past the deadline are skipped (see the serial
 # loop), so at most one node per batch can overrun by this floor.
 _DEADLINE_NODE_FLOOR_S = 0.1
+# Dense-Jacobian compilation guard. ``NLPEvaluator.evaluate_jacobian`` uses
+# ``jax.jit(jax.jacfwd(...))`` — a forward-mode dense Jacobian whose compiled XLA
+# program replicates the whole constraint system once per input variable. For a
+# large model (n inputs x m constraints) that jaxpr explodes during MLIR
+# lowering and XLA aborts the *process* with a native SIGBUS/SIGILL — not a
+# catchable Python exception. Above this many dense entries (n * m), code paths
+# that only need the Jacobian as an optimization skip the dense compile and use
+# a Jacobian-free fallback. rsyn0810m03hfsg (1185 x 1935 ~ 2.3M) crashed here
+# once presolve was fast enough to reach node bound-tightening; tln6 (~1.7k) and
+# the broad corpus sit far below the cap, so this is inert on normal models.
+_MAX_DENSE_JACOBIAN_ELEMS = 1_000_000
 # Per-node OBBT (Lever A) gates. Per-node optimization-based bound tightening is
 # powerful but costs O(n_vars) LPs per node, so it is enabled only for the
 # functionally-dependent-intermediate structural class and on small models, and
@@ -763,6 +774,17 @@ def _tighten_node_bounds_with_status(evaluator, node_lb, node_ub, cl_list, cu_li
     m = len(cl_list)
     cu = np.array(cu_list, dtype=np.float64)
     cl = np.array(cl_list, dtype=np.float64)
+
+    # Dense-Jacobian compilation guard (see _MAX_DENSE_JACOBIAN_ELEMS). The
+    # two-point linearity test below calls evaluate_jacobian, which JIT-compiles
+    # a forward-mode dense Jacobian; on a large model that XLA lowering aborts
+    # the process with a native SIGBUS/SIGILL the try/except cannot catch. Above
+    # the cap, skip the linearity test entirely and fall back to the structural
+    # / interval nonlinear tightening (the same fallback taken when no
+    # constraint is detected linear) — it needs no monolithic Jacobian compile,
+    # so it only forgoes an optimization and never changes a bound unsoundly.
+    if n * m > _MAX_DENSE_JACOBIAN_ELEMS:
+        return _apply_nonlinear_tightening_with_status(evaluator._model, lb, ub)
 
     # Detect which constraints are linear by checking if the Jacobian
     # changes between two distinct evaluation points.  FBBT via Jacobian

--- a/python/tests/test_dense_jacobian_compile_guard.py
+++ b/python/tests/test_dense_jacobian_compile_guard.py
@@ -1,0 +1,110 @@
+"""Regression: node bound-tightening must not compile a giant dense Jacobian.
+
+``NLPEvaluator.evaluate_jacobian`` uses ``jax.jit(jax.jacfwd(...))`` — a
+forward-mode *dense* Jacobian whose compiled XLA program replicates the whole
+constraint system once per input variable. On a large model the resulting jaxpr
+explodes during MLIR lowering and XLA aborts the **process** with a native
+SIGBUS / SIGILL — not a catchable Python exception, so the ``try/except`` around
+the call cannot save it.
+
+`rsyn0810m03hfsg` (1185 vars x 1935 constraints ~ 2.3M dense entries, but only
+~4.5k nonzeros — 0.2% dense) crashed in ``_tighten_node_bounds_with_status``
+once presolve was fast enough to reach node bound-tightening.
+
+Fix: above ``_MAX_DENSE_JACOBIAN_ELEMS`` (n * m), skip the dense two-point
+linearity test and fall back to the Jacobian-free structural / interval
+nonlinear tightening. (The downstream FBBT row loop there is O(m * n^2) in pure
+Python anyway — intractable at that scale — so skipping it loses nothing usable
+on large models.)
+
+This guards the crash deterministically without needing to actually compile the
+multi-million-entry Jacobian (which would crash the whole pytest process rather
+than fail this test).
+"""
+
+from __future__ import annotations
+
+import discopt.solver as S
+import numpy as np
+
+
+class _ExplodingEvaluator:
+    """Stand-in evaluator whose dense ``evaluate_jacobian`` must never be called
+    above the size cap (calling it on the real thing would crash the process)."""
+
+    def __init__(self, n_constraints: int):
+        self.n_constraints = n_constraints
+        self._model = object()  # opaque; the fallback is monkeypatched below
+
+    def evaluate_jacobian(self, x):  # pragma: no cover - must not be reached
+        raise AssertionError(
+            "dense evaluate_jacobian was called above the dense-Jacobian cap — "
+            "the guard did not short-circuit, risking the XLA process abort"
+        )
+
+    def evaluate_constraints(self, x):  # pragma: no cover
+        raise AssertionError("evaluate_constraints reached above the cap")
+
+
+def test_large_model_skips_dense_jacobian_and_falls_back(monkeypatch):
+    n = 2000
+    m = 2000  # n * m = 4,000,000 > _MAX_DENSE_JACOBIAN_ELEMS
+    assert n * m > S._MAX_DENSE_JACOBIAN_ELEMS
+
+    sentinel_lb = np.full(n, -1.0)
+    sentinel_ub = np.full(n, 2.0)
+
+    called = {"fallback": False}
+
+    def _fake_fallback(model, lb, ub):
+        called["fallback"] = True
+        return sentinel_lb, sentinel_ub, False
+
+    monkeypatch.setattr(S, "_apply_nonlinear_tightening_with_status", _fake_fallback)
+
+    ev = _ExplodingEvaluator(n_constraints=m)
+    node_lb = np.zeros(n)
+    node_ub = np.ones(n)
+    cl_list = [-1e20] * m  # non-empty so we pass the "no constraints" early return
+    cu_list = [1e20] * m
+
+    lb, ub, infeasible = S._tighten_node_bounds_with_status(ev, node_lb, node_ub, cl_list, cu_list)
+
+    assert called["fallback"], "guard did not route to the Jacobian-free fallback"
+    assert infeasible is False
+    np.testing.assert_array_equal(lb, sentinel_lb)
+    np.testing.assert_array_equal(ub, sentinel_ub)
+
+
+def test_small_model_still_attempts_jacobian_test(monkeypatch):
+    """Below the cap the guard must NOT short-circuit — evaluate_jacobian is
+    still consulted (here it raises, which the function's own try/except turns
+    into the same fallback, proving the dense path was entered)."""
+    n = 10
+    m = 10  # n * m = 100, far below the cap
+    assert n * m <= S._MAX_DENSE_JACOBIAN_ELEMS
+
+    entered = {"jac": False, "fallback": False}
+
+    class _SmallEval:
+        n_constraints = m
+        _model = object()
+
+        def evaluate_jacobian(self, x):
+            entered["jac"] = True
+            raise RuntimeError("force fallback after the dense path is entered")
+
+    def _fake_fallback(model, lb, ub):
+        entered["fallback"] = True
+        return np.zeros(n), np.ones(n), False
+
+    monkeypatch.setattr(S, "_apply_nonlinear_tightening_with_status", _fake_fallback)
+    # No structural mask for the opaque model.
+    monkeypatch.setattr(S, "_cached_structural_linear_mask", lambda *a, **k: None)
+
+    S._tighten_node_bounds_with_status(
+        _SmallEval(), np.zeros(n), np.ones(n), [-1e20] * m, [1e20] * m
+    )
+
+    assert entered["jac"], "dense Jacobian path should be entered below the cap"
+    assert entered["fallback"]

--- a/python/tests/test_evaluate_jacobian_sparse_routing.py
+++ b/python/tests/test_evaluate_jacobian_sparse_routing.py
@@ -1,0 +1,86 @@
+"""Regression: ``NLPEvaluator.evaluate_jacobian`` must route large models through
+the sparse coloring path instead of compiling the dense ``jax.jacfwd``.
+
+The dense compile replicates the constraint program once per input variable, so
+for a large model its XLA jaxpr explodes during MLIR lowering and aborts the
+process with a native SIGBUS/SIGILL — uncatchable. Above
+``_DENSE_JACOBIAN_COMPILE_LIMIT`` (m * n) the method computes the (sparse)
+Jacobian via O(chromatic-number) JVPs and densifies it, preserving the dense
+(m, n) return so every caller stays safe. Below the cap the faster dense path is
+unchanged.
+
+These tests pin the routing deterministically (without compiling a
+multi-million-entry Jacobian, which would crash the whole pytest process):
+above the cap the raw dense path must not be touched; below it, it must be.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt._jax.nlp_evaluator as NE  # noqa: E402
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import scipy.sparse as sp  # noqa: E402
+
+
+def _small_model() -> dm.Model:
+    m = dm.Model("nl")
+    x = m.continuous("x", lb=-1.0, ub=1.0)
+    y = m.continuous("y", lb=-1.0, ub=1.0)
+    m.minimize(x + y)
+    m.subject_to(x * y <= 0.5)  # nonlinear -> jac_fn_jit is built
+    m.subject_to(x + 2 * y <= 1.0)
+    return m
+
+
+def test_large_model_routes_to_sparse_and_skips_dense(monkeypatch):
+    ev = NE.NLPEvaluator(_small_model())
+    n = ev._n_variables
+    x = np.zeros(n)
+
+    # Force the "large model" branch for this tiny model.
+    monkeypatch.setattr(NE, "_DENSE_JACOBIAN_COMPILE_LIMIT", 0)
+
+    # Stand in a known sparse Jacobian and mark the sparse fn as available so
+    # _ensure_sparse_jac_fn() short-circuits to "available".
+    m_rows = ev._n_constraints
+    known = sp.csc_matrix(np.arange(m_rows * n, dtype=np.float64).reshape(m_rows, n))
+    ev._sparse_jac_fn = lambda _x: known  # hasattr -> True, not None -> available
+
+    # The raw dense path must NOT be exercised above the cap.
+    def _boom(_x):
+        raise AssertionError("raw dense Jacobian compiled above the cap")
+
+    monkeypatch.setattr(ev, "_evaluate_dense_jacobian", _boom)
+
+    J = ev.evaluate_jacobian(x)
+    assert isinstance(J, np.ndarray)
+    assert J.shape == (m_rows, n)
+    np.testing.assert_array_equal(J, known.toarray())
+
+
+def test_small_model_uses_dense_path(monkeypatch):
+    ev = NE.NLPEvaluator(_small_model())
+    x = np.zeros(ev._n_variables)
+
+    # Real cap (1e6) >> this model's m * n, so the dense path must be used.
+    called = {"dense": False}
+    real_dense = ev._evaluate_dense_jacobian
+
+    def _spy(xx):
+        called["dense"] = True
+        return real_dense(xx)
+
+    monkeypatch.setattr(ev, "_evaluate_dense_jacobian", _spy)
+    # If sparse were (wrongly) chosen it would short-circuit before _spy.
+    ev._sparse_jac_fn = lambda _x: (_ for _ in ()).throw(
+        AssertionError("sparse path used below the cap")
+    )
+
+    J = ev.evaluate_jacobian(x)
+    assert called["dense"], "small model must use the dense Jacobian path"
+    assert J.shape == (ev._n_constraints, ev._n_variables)


### PR DESCRIPTION
## Summary

Continues the `crudeoil_lee3_09` overrun investigation (the HiGHS-budget piece landed in #311). Three fixes for **large MINLP** instances: a native-crash guard, a general sparse-Jacobian fix for the same root cause, and the now-safe deadline-aware probing.

> Supersedes #312, which GitHub auto-closed when #311's branch (its base) was deleted on merge. Rebased onto `main`; identical commits.

## Root cause: a dense Jacobian that should be sparse

`NLPEvaluator.evaluate_jacobian` compiles `jax.jit(jax.jacfwd(...))` — a **dense** forward-mode Jacobian whose XLA program replicates the whole constraint system once per input variable. On a large model that jaxpr explodes during MLIR lowering and XLA aborts the **process** with a native SIGBUS/SIGILL (signal varies → memory corruption); no `try/except` can catch it. `rsyn0810m03hfsg` is 1185 × 1935 ≈ **2.3M dense entries but only ~4.5k nonzeros (0.2% dense)** — the real Jacobian is overwhelmingly sparse.

## 1. Bound-tightening guard (commit 1)

`_tighten_node_bounds_with_status` was the path that hit the dense compile at scale. Its Jacobian feeds an **O(m·n²) pure-Python FBBT loop** that is intractable at that size regardless, so above `_MAX_DENSE_JACOBIAN_ELEMS` (n·m) it skips the linearity test and uses the Jacobian-free structural/interval fallback (same one taken when no constraint is linear). Sound; only forgoes an optimization on huge models.

## 2. Sparse-aware `evaluate_jacobian` (commit 3)

The guard above only covered one caller; every other full-model-Jacobian caller (cuts, KKT, Lagrangian, sensitivity) shared the latent crash. So `evaluate_jacobian` is now size-aware: above `_DENSE_JACOBIAN_COMPILE_LIMIT` (m·n = 1e6) **and** when the sparse evaluator is available, it computes via the existing coloring path (O(chromatic-number) JVPs — already used for sparse NLP solves) and densifies, preserving the dense `(m, n)` return. Below the cap the dense path is verbatim, so the existing suite is unaffected. Verified on rsyn0810: `evaluate_jacobian` returns the correct dense matrix in ~2.8s, **exactly matching** the sparse values (max abs diff 0.0).

## 3. Deadline-aware probing (commit 2)

The presolve orchestrator only checks the budget **between passes**; `ProbingPass` runs FBBT per binary, so it overruns unbounded — **> 230 s** on crudeoil (every other pass ≤ 1.92 s), the dominant chunk of the 562 s overrun (presolve → ~7.5 s with this fix). Threads the deadline into `PresolveContext`, polled in probing's loop (`probe_binary_vars_until`), bailing early with partial — still sound — results. Held back until §1/§2: bounding presolve lets the solve reach node bound-tightening sooner, which used to crash.

## Verification
- `rsyn0810` / `rsyn0830` at `time_limit=30`: previously **crashed** (SIGBUS/SIGILL); now return `time_limit` cleanly (exit 0).
- Smoke 209✓; 149 jacobian/sparse/evaluator tests✓; Rust presolve 174 +1 new✓; 4 new Python guard/routing tests✓.
- pre-commit (ruff/format/mypy/cargo fmt) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
