### PR TITLE
fix(presolve): make factorable_elim deadline-aware (residual overrun)

### DIFF
--- a/crates/discopt-core/src/presolve/factorable_elim.rs
+++ b/crates/discopt-core/src/presolve/factorable_elim.rs
@@ -65,6 +65,7 @@
 //! equations and will simply drop them.
 
 use std::collections::HashSet;
+use std::time::Instant;
 
 use super::fbbt::{forward_propagate, Interval};
 use super::polynomial::try_polynomial;
@@ -90,12 +91,31 @@ pub struct FactorableElimStats {
 /// Pure function: input is not modified. The caller decides whether
 /// to swap in the result.
 pub fn factorable_eliminate(model: &ModelRepr) -> (ModelRepr, FactorableElimStats) {
+    factorable_eliminate_until(model, None)
+}
+
+/// Like [`factorable_eliminate`] but stops once `deadline` passes, returning the
+/// eliminations performed so far. Each outer iteration re-scans every candidate
+/// leaf against every constraint (an O(K · leaves · constraints · body) loop to a
+/// fixed point), so on a large model a single pass can run for tens of seconds —
+/// far past the orchestrator's *between-passes* time check. Bailing mid-loop only
+/// performs *fewer* sound eliminations: the returned model keeps the not-yet-
+/// eliminated constraints, so it remains equivalent to the input.
+pub fn factorable_eliminate_until(
+    model: &ModelRepr,
+    deadline: Option<Instant>,
+) -> (ModelRepr, FactorableElimStats) {
     let mut out = model.clone();
     let mut stats = FactorableElimStats::default();
 
     // Iterate to a fixed point — dropping a constraint may expose
     // another newly-singleton variable.
     loop {
+        if let Some(dl) = deadline {
+            if Instant::now() >= dl {
+                break;
+            }
+        }
         let removed_before = stats.constraints_removed;
         let leaves = scalar_continuous_var_leaves(&out);
         stats.candidates_examined += leaves.len();
@@ -103,6 +123,14 @@ pub fn factorable_eliminate(model: &ModelRepr) -> (ModelRepr, FactorableElimStat
         let mut victim_ci: Option<usize> = None;
 
         'cands: for (vblock, leaf) in &leaves {
+            // A single re-scan over all candidates can itself be slow on a large
+            // model (per candidate it walks every constraint body); poll the
+            // deadline here too so one outer iteration cannot overrun unbounded.
+            if let Some(dl) = deadline {
+                if Instant::now() >= dl {
+                    break 'cands;
+                }
+            }
             // Skip variables already pinned (lb == ub).
             let lb = out.variables[*vblock].lb[0];
             let ub = out.variables[*vblock].ub[0];
@@ -349,6 +377,66 @@ mod tests {
         assert_eq!(stats.variables_freed, 1);
         assert_eq!(out.constraints.len(), 0);
         assert_eq!(stats.removed_constraint_indices, vec![0]);
+    }
+
+    #[test]
+    fn honors_past_deadline() {
+        // Same eliminable model as `drops_equation_with_nonlinear_other_term`,
+        // but with a deadline already in the past. The fixed-point loop re-scans
+        // every candidate against every constraint, so on a large model a single
+        // pass overruns the orchestrator's between-passes time check; it must poll
+        // the deadline and bail. Bailing performs *fewer* sound eliminations, so
+        // the returned model keeps the (still-valid) constraint.
+        let mut arena = ExprArena::new();
+        let v = scalar_var(&mut arena, "v", 0);
+        let x = scalar_var(&mut arena, "x", 1);
+        let y = scalar_var(&mut arena, "y", 2);
+        let xy = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Mul,
+            left: x,
+            right: y,
+        });
+        let neg_xy = arena.add(ExprNode::UnaryOp {
+            op: crate::expr::UnOp::Neg,
+            operand: xy,
+        });
+        let body = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Add,
+            left: v,
+            right: neg_xy,
+        });
+        let obj = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Add,
+            left: x,
+            right: y,
+        });
+        let model = ModelRepr {
+            arena,
+            objective: obj,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body,
+                sense: ConstraintSense::Eq,
+                rhs: 0.0,
+                name: None,
+            }],
+            variables: vec![
+                vinfo("v", -100.0, 100.0),
+                vinfo("x", 0.0, 2.0),
+                vinfo("y", 0.0, 3.0),
+            ],
+            n_vars: 3,
+        };
+
+        // No deadline: the equation is eliminated (control).
+        let (_out, stats) = factorable_eliminate_until(&model, None);
+        assert_eq!(stats.constraints_removed, 1);
+
+        // Deadline already passed: bail before any elimination; model unchanged.
+        let past = std::time::Instant::now();
+        let (out, stats) = factorable_eliminate_until(&model, Some(past));
+        assert_eq!(stats.constraints_removed, 0);
+        assert_eq!(out.constraints.len(), 1);
     }
 
     #[test]

--- a/crates/discopt-core/src/presolve/passes.rs
+++ b/crates/discopt-core/src/presolve/passes.rs
@@ -23,7 +23,7 @@ use super::coefficient_strengthening::coefficient_strengthening;
 use super::delta::{count_tightened, Implication as DeltaImpl, PresolveDelta, VarAggregation};
 use super::duality::{reduced_cost_fixing, ReducedCostInfo};
 use super::eliminate::eliminate_variables;
-use super::factorable_elim::factorable_eliminate;
+use super::factorable_elim::factorable_eliminate_until;
 use super::fbbt::{fbbt_with_cutoff, Interval};
 use super::fbbt_fp::{fbbt_fixed_point, FbbtFpOptions};
 use super::implied_bounds::propagate_implied_bounds;
@@ -627,7 +627,7 @@ impl PresolvePass for FactorableElimPass {
         PassCategory::RewritesModel
     }
     fn run(&mut self, ctx: &mut PresolveContext) -> PresolveDelta {
-        let (new_model, stats) = factorable_eliminate(&ctx.model);
+        let (new_model, stats) = factorable_eliminate_until(&ctx.model, ctx.deadline);
         ctx.model = new_model;
 
         let mut delta = PresolveDelta::empty("factorable_elim", ctx.iter);


### PR DESCRIPTION
## Summary

Investigates the residual time-limit overrun flagged after #313 (rsyn0830m03hfsg overran ~15 s; crudeoil's family). Found and fixed the now-dominant phase: the `factorable_elim` presolve pass.

## Finding

The overrun was a **fixed ~45 s phase independent of `time_limit`** (46.5 s @ tl=5, 45.1 @ tl=15, 44.7 @ tl=30) — not loop-scaling. Per-pass timing of the Rust presolve orchestrator pinned it:

```
[presolve-timing] sweep=0 pass=eliminate       elapsed=411.9ms
[presolve-timing] sweep=0 pass=factorable_elim elapsed=36009.6ms   <-- here
```

The orchestrator only checks its budget **between passes**, and `factorable_elim` iterates to a fixed point, each outer iteration re-scanning every candidate leaf against every constraint body (O(K · leaves · constraints · body)). On rsyn0830 (1758 vars, 2934 constraints) that single pass ran **36 s on a 5 s budget** — the same shape as the earlier probing overrun.

## Fix

Thread the run deadline (already on `PresolveContext` from the probing fix in #313) into the pass via `factorable_eliminate_until`, polling it at the top of the outer fixed-point loop and inside the candidate scan. Bailing mid-loop performs **fewer** sound eliminations — the returned model keeps the not-yet-eliminated equality constraints, so it stays equivalent. **rsyn0830 at tl=5: ~46 s → ~10 s.**

## Honest residual

At larger budgets the overrun is now **diffuse**, not one phase: POUNCE NLP solves (which already receive per-solve budgets via the node/AMP paths) plus **uninterruptible JAX/XLA relaxation compiles** that straddle the deadline. XLA compilation cannot be interrupted mid-call, so a few-second overrun when a compile crosses the deadline is largely inherent. This is the third presolve pass bounded (probing, now factorable_elim); the node-solve/compile layer is a separate, deeper effort and is documented rather than forced.

## Verification
- rsyn0830 returns a **sound** `feasible` (incumbent 776.8 under bound 4312.7 — open gap, no false claim; the fix only reduces eliminations so it cannot affect soundness).
- Rust presolve 175 tests +1 new (`honors_past_deadline`); smoke 209 passed; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq9NRuyCAWVxWoFv6AFuAt
