### PR TITLE
Move OA selection to mip-nlp solver

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2782,6 +2782,11 @@ class Model:
             ``convhull_ebd_encoding``, ``use_start_as_incumbent``,
             ``obbt_at_root``, ``obbt_with_cutoff``, ``alphabb_cutoff_obbt``,
             and ``obbt_time_limit``.
+            Use ``solver="mip-nlp"`` to select the MIP-NLP decomposition
+            family. Current implemented ``mip_nlp_method`` values are ``"oa"``
+            and ``"ecp"``; ``"goa"``, ``"roa"``, ``"fp"``, and
+            ``"lp_nlp_bb"`` are reserved until their dedicated implementations
+            land.
         validate : bool, default False
             If True, run Examiner-style KKT validation on the returned
             point and attach the :class:`~discopt.validation.ExaminerReport`

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2179,6 +2179,8 @@ def solve_model(
     solver : str or None, default None
         Optional global-solver selector. Use ``"amp"`` to dispatch to
         Adaptive Multivariate Partitioning instead of branch-and-bound.
+        Use ``"mip-nlp"`` to dispatch to the MIP-NLP decomposition family
+        (OA/ECP now; GOA/ROA/FP/LP-NLP-BB are reserved method selectors).
         Use ``"gp"`` to dispatch to the geometric-programming fast path:
         the model is checked for GP structure (posynomial/monomial
         objective and constraints over strictly-positive continuous
@@ -2202,6 +2204,13 @@ def solve_model(
         ``disc_abs_width_tol``, ``convhull_formulation``, ``convhull_ebd``,
         ``convhull_ebd_encoding``, ``use_start_as_incumbent``, ``obbt_at_root``,
         ``obbt_with_cutoff``, ``alphabb_cutoff_obbt``, and ``obbt_time_limit``.
+    solver="mip-nlp" options
+        The MIP-NLP backend accepts ``mip_nlp_method`` and
+        ``mip_nlp_options``. Current implemented methods are ``"oa"`` and
+        ``"ecp"``; ``"goa"``, ``"roa"``, ``"fp"``, and ``"lp_nlp_bb"`` raise
+        ``NotImplementedError`` until their dedicated implementations land.
+        Existing OA options ``equality_relaxation``, ``ecp_mode``, and
+        ``feasibility_cuts`` may be passed as top-level aliases.
 
     Returns
     -------
@@ -2343,15 +2352,74 @@ def solve_model(
             except Exception as _sc_exc:  # pragma: no cover - defensive
                 logger.debug("structure-cut presolve skipped: %s", _sc_exc)
 
-    # --- AMP (Adaptive Multivariate Partitioning) global solver ---
+    # --- Solver-family dispatch ---
     _solver = solver if solver is not None else kwargs.pop("solver", None)
     # Recognised global-solver selectors: ``None`` (default branch-and-bound,
-    # with the automatic GP fast path below), ``"amp"``, ``"gp"`` (force the GP
-    # log-space path), and ``"bb"`` (force classic branch-and-bound, opting out
-    # of the automatic GP fast path). Reject anything else rather than silently
-    # falling through to B&B.
-    if _solver not in (None, "amp", "gp", "bb"):
-        raise ValueError(f"Unknown solver={_solver!r}. Choose one of None, 'amp', 'gp', 'bb'.")
+    # with the automatic GP fast path below), ``"amp"``, ``"mip-nlp"``,
+    # ``"gp"`` (force the GP log-space path), and ``"bb"`` (force classic
+    # branch-and-bound, opting out of the automatic GP fast path). Reject
+    # anything else rather than silently falling through to B&B.
+    if _solver not in (None, "amp", "mip-nlp", "gp", "bb"):
+        raise ValueError(
+            f"Unknown solver={_solver!r}. Choose one of None, 'amp', 'mip-nlp', 'gp', 'bb'."
+        )
+
+    # --- MIP-NLP decomposition solver family ---
+    if _solver == "mip-nlp":
+        import warnings
+
+        from discopt.solvers.mip_nlp import solve_mip_nlp
+
+        mip_nlp_method = kwargs.pop("mip_nlp_method", "oa")
+        mip_nlp_options = kwargs.pop("mip_nlp_options", None)
+        mip_nlp_kwargs = {}
+        for key in ("equality_relaxation", "ecp_mode", "feasibility_cuts"):
+            if key in kwargs:
+                mip_nlp_kwargs[key] = kwargs.pop(key)
+
+        gdp_methods = {"big-m", "hull", "mbigm", "auto"}
+        if gdp_method == "oa":
+            warnings.warn(
+                "gdp_method='oa' is deprecated for selecting MINLP OA. Use "
+                "solver='mip-nlp', mip_nlp_method='oa'. Interpreting gdp_method "
+                "as 'big-m' for GDP reformulation in this solve.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            resolved_gdp_method = "big-m"
+        elif gdp_method in gdp_methods:
+            resolved_gdp_method = gdp_method
+        else:
+            warnings.warn(
+                f"solver='mip-nlp' does not use gdp_method={gdp_method!r} as a "
+                "MINLP algorithm selector; using 'big-m' for GDP reformulation.",
+                stacklevel=2,
+            )
+            resolved_gdp_method = "big-m"
+
+        if kwargs:
+            warnings.warn(
+                "MIP-NLP solver ignores solve_model options: "
+                + ", ".join(sorted(dict.fromkeys(kwargs))),
+                stacklevel=2,
+            )
+
+        from discopt._jax.gdp_reformulate import reformulate_gdp
+
+        model = reformulate_gdp(model, method=resolved_gdp_method)
+
+        return solve_mip_nlp(
+            model,
+            method=mip_nlp_method,
+            mip_nlp_options=mip_nlp_options,
+            time_limit=time_limit,
+            gap_tolerance=gap_tolerance,
+            max_iterations=max_nodes,
+            nlp_solver=nlp_solver,
+            **mip_nlp_kwargs,
+        )
+
+    # --- AMP (Adaptive Multivariate Partitioning) global solver ---
     if _solver == "amp":
         import warnings
 
@@ -2548,23 +2616,33 @@ def solve_model(
             f"Unknown decomposition={decomposition!r}; choose 'benders' or 'lagrangian'."
         )
 
-    # --- OA decomposition: general-purpose Outer Approximation ---
+    # --- Deprecated compatibility route: OA is a MINLP solver strategy, not a GDP method. ---
     if gdp_method == "oa":
-        from discopt.solvers.oa import solve_oa
+        import warnings
+
+        from discopt.solvers.mip_nlp import solve_mip_nlp
+
+        warnings.warn(
+            "gdp_method='oa' is deprecated for selecting MINLP OA. Use "
+            "solver='mip-nlp', mip_nlp_method='oa' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         # Extract OA-specific kwargs that solve_model doesn't understand
-        oa_kwargs = {}
+        mip_nlp_kwargs = {}
         for key in ("equality_relaxation", "ecp_mode", "feasibility_cuts"):
             if key in kwargs:
-                oa_kwargs[key] = kwargs.pop(key)
+                mip_nlp_kwargs[key] = kwargs.pop(key)
 
-        return solve_oa(
+        return solve_mip_nlp(
             model,
+            method="ecp" if mip_nlp_kwargs.get("ecp_mode", False) else "oa",
             time_limit=time_limit,
             gap_tolerance=gap_tolerance,
             max_iterations=max_nodes,
             nlp_solver=nlp_solver,
-            **oa_kwargs,
+            **mip_nlp_kwargs,
         )
 
     # --- LOA decomposition: intercept before GDP reformulation ---

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2397,10 +2397,56 @@ def solve_model(
             )
             resolved_gdp_method = "big-m"
 
+        ignored_mip_nlp_options = []
+
+        def _note_ignored_mip_nlp(name: str, should_warn: bool) -> None:
+            if should_warn:
+                ignored_mip_nlp_options.append(name)
+
+        _note_ignored_mip_nlp("threads", threads != 1)
+        _note_ignored_mip_nlp("deterministic", deterministic is not True)
+        _note_ignored_mip_nlp("batch_size", batch_size != 16)
+        _note_ignored_mip_nlp("strategy", strategy != "best_first")
+        _note_ignored_mip_nlp("ipopt_options", ipopt_options is not None)
+        _note_ignored_mip_nlp("sparse", sparse is not None)
+        _note_ignored_mip_nlp("cutting_planes", cutting_planes is not False)
+        _note_ignored_mip_nlp("psd_cuts", psd_cuts is not False)
+        _note_ignored_mip_nlp("rlt_cuts", rlt_cuts is not False)
+        _note_ignored_mip_nlp("rlt", rlt != "auto")
+        _note_ignored_mip_nlp("cuts", cuts != "auto")
+        _note_ignored_mip_nlp("partitions", partitions != 0)
+        _note_ignored_mip_nlp("branching_policy", branching_policy != "fractional")
+        _note_ignored_mip_nlp("use_learned_relaxations", use_learned_relaxations is not False)
+        _note_ignored_mip_nlp("mccormick_bounds", mccormick_bounds != "auto")
+        _note_ignored_mip_nlp("decomposition", decomposition is not None)
+        _note_ignored_mip_nlp("lagrangian_bound", lagrangian_bound is not False)
+        _note_ignored_mip_nlp("lagrangian_frequency", lagrangian_frequency != 1)
+        _note_ignored_mip_nlp("initial_point", initial_point is not None)
+        _note_ignored_mip_nlp("skip_convex_check", skip_convex_check is not False)
+        _note_ignored_mip_nlp("nlp_bb", nlp_bb is not None)
+        _note_ignored_mip_nlp("lazy_constraints", lazy_constraints is not None)
+        _note_ignored_mip_nlp("incumbent_callback", incumbent_callback is not None)
+        _note_ignored_mip_nlp("node_callback", node_callback is not None)
+        _note_ignored_mip_nlp("use_highs_milp", use_highs_milp is not True)
+        _note_ignored_mip_nlp("presolve", presolve is not True)
+        _note_ignored_mip_nlp("presolve_polynomial", presolve_polynomial is not False)
+        _note_ignored_mip_nlp("presolve_reverse_ad", presolve_reverse_ad is not False)
+        _note_ignored_mip_nlp("in_tree_presolve_stride", in_tree_presolve_stride != 0)
+        _note_ignored_mip_nlp("eigenvalue_root_bound", eigenvalue_root_bound is not False)
+        _note_ignored_mip_nlp("relaxation_arithmetic", relaxation_arithmetic != "mccormick")
+        _note_ignored_mip_nlp("subnlp_enabled", subnlp_enabled is not True)
+        _note_ignored_mip_nlp("subnlp_backend", subnlp_backend != "auto")
+        _note_ignored_mip_nlp("subnlp_frequency", subnlp_frequency != 20)
+        _note_ignored_mip_nlp("subnlp_max_calls", subnlp_max_calls != 200)
+        _note_ignored_mip_nlp("subnlp_options", subnlp_options is not None)
+        _note_ignored_mip_nlp("root_cut_rounds", root_cut_rounds is not None)
+        _note_ignored_mip_nlp("root_cut_max", root_cut_max is not None)
         if kwargs:
+            ignored_mip_nlp_options.extend(sorted(kwargs))
+        if ignored_mip_nlp_options:
             warnings.warn(
                 "MIP-NLP solver ignores solve_model options: "
-                + ", ".join(sorted(dict.fromkeys(kwargs))),
+                + ", ".join(sorted(dict.fromkeys(ignored_mip_nlp_options))),
                 stacklevel=2,
             )
 
@@ -2620,11 +2666,13 @@ def solve_model(
     if gdp_method == "oa":
         import warnings
 
+        from discopt._jax.gdp_reformulate import reformulate_gdp
         from discopt.solvers.mip_nlp import solve_mip_nlp
 
         warnings.warn(
             "gdp_method='oa' is deprecated for selecting MINLP OA. Use "
-            "solver='mip-nlp', mip_nlp_method='oa' instead.",
+            "solver='mip-nlp', mip_nlp_method='oa' instead. Interpreting "
+            "gdp_method as 'big-m' for GDP reformulation in this solve.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -2634,6 +2682,8 @@ def solve_model(
         for key in ("equality_relaxation", "ecp_mode", "feasibility_cuts"):
             if key in kwargs:
                 mip_nlp_kwargs[key] = kwargs.pop(key)
+
+        model = reformulate_gdp(model, method="big-m")
 
         return solve_mip_nlp(
             model,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2372,7 +2372,7 @@ def solve_model(
 
         mip_nlp_method = kwargs.pop("mip_nlp_method", "oa")
         mip_nlp_options = kwargs.pop("mip_nlp_options", None)
-        mip_nlp_kwargs = {}
+        mip_nlp_kwargs: dict[str, Any] = {}
         for key in ("equality_relaxation", "ecp_mode", "feasibility_cuts"):
             if key in kwargs:
                 mip_nlp_kwargs[key] = kwargs.pop(key)

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -72,4 +72,3 @@ def solve_mip_nlp(
         f"mip_nlp_method={method!r} is reserved for the MIP-NLP decomposition "
         "family but is not implemented yet."
     )
-

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -1,0 +1,75 @@
+"""MIP-NLP decomposition solver-family facade."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from discopt.modeling.core import Model, SolveResult
+
+SUPPORTED_METHODS = {"oa", "ecp", "goa", "roa", "fp", "lp_nlp_bb"}
+_METHOD_ALIASES = {
+    "lp-nlp-bb": "lp_nlp_bb",
+    "lp/nlp-bb": "lp_nlp_bb",
+    "lp_nlp_bb": "lp_nlp_bb",
+}
+_OA_OPTION_KEYS = {"equality_relaxation", "ecp_mode", "feasibility_cuts"}
+
+
+def _normalize_method(method: str) -> str:
+    normalized = _METHOD_ALIASES.get(method, method)
+    if normalized not in SUPPORTED_METHODS:
+        raise ValueError(
+            f"Unknown mip_nlp_method={method!r}. Choose one of {sorted(SUPPORTED_METHODS)}."
+        )
+    return normalized
+
+
+def solve_mip_nlp(
+    model: Model,
+    *,
+    method: str = "oa",
+    mip_nlp_options: Optional[dict[str, Any]] = None,
+    time_limit: float = 3600.0,
+    gap_tolerance: float = 1e-4,
+    max_iterations: int = 100,
+    nlp_solver: str = "pounce",
+    **kwargs: Any,
+) -> SolveResult:
+    """Solve a MINLP with a MIP-NLP decomposition method."""
+    method = _normalize_method(method)
+    options: dict[str, Any] = {}
+    if mip_nlp_options:
+        options.update(mip_nlp_options)
+    options.update(kwargs)
+
+    if method in {"oa", "ecp"}:
+        unexpected = sorted(set(options) - _OA_OPTION_KEYS)
+        if unexpected:
+            raise ValueError(
+                "Unsupported MIP-NLP OA/ECP option(s): "
+                + ", ".join(unexpected)
+                + ". Supported options are: "
+                + ", ".join(sorted(_OA_OPTION_KEYS))
+            )
+
+        from discopt.solvers.oa import solve_oa
+
+        if method == "ecp":
+            options["ecp_mode"] = True
+        else:
+            options.setdefault("ecp_mode", False)
+
+        return solve_oa(
+            model,
+            time_limit=time_limit,
+            gap_tolerance=gap_tolerance,
+            max_iterations=max_iterations,
+            nlp_solver=nlp_solver,
+            **options,
+        )
+
+    raise NotImplementedError(
+        f"mip_nlp_method={method!r} is reserved for the MIP-NLP decomposition "
+        "family but is not implemented yet."
+    )
+

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -73,4 +73,3 @@ def test_mip_nlp_rejects_unsupported_oa_options():
             method="oa",
             mip_nlp_options={"add_slack": True},
         )
-

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -1,0 +1,76 @@
+import discopt.modeling as dm
+import pytest
+from discopt.modeling.core import SolveResult
+
+
+def _binary_model(name="mip_nlp_route"):
+    m = dm.Model(name)
+    x = m.binary("x")
+    m.minimize(x)
+    return m
+
+
+def test_model_solve_routes_mip_nlp_options(monkeypatch):
+    import discopt.solvers.mip_nlp as mip_nlp_module
+
+    calls = {}
+
+    def fake_solve_mip_nlp(model, **kwargs):
+        calls["model"] = model
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
+
+    result = _binary_model().solve(
+        solver="mip-nlp",
+        mip_nlp_method="ecp",
+        equality_relaxation=True,
+        skip_convex_check=True,
+    )
+
+    assert result.status == "optimal"
+    assert calls["method"] == "ecp"
+    assert calls["equality_relaxation"] is True
+
+
+def test_gdp_method_oa_deprecated_alias_routes_to_mip_nlp(monkeypatch):
+    import discopt.solvers.mip_nlp as mip_nlp_module
+
+    calls = {}
+
+    def fake_solve_mip_nlp(model, **kwargs):
+        calls.update(kwargs)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
+
+    with pytest.deprecated_call(match="gdp_method='oa' is deprecated"):
+        result = _binary_model("oa_alias").solve(
+            gdp_method="oa",
+            equality_relaxation=True,
+            skip_convex_check=True,
+        )
+
+    assert result.status == "optimal"
+    assert calls["method"] == "oa"
+    assert calls["equality_relaxation"] is True
+
+
+def test_mip_nlp_reserved_methods_raise():
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(NotImplementedError, match="mip_nlp_method='fp'"):
+        solve_mip_nlp(_binary_model("fp_reserved"), method="fp")
+
+
+def test_mip_nlp_rejects_unsupported_oa_options():
+    from discopt.solvers.mip_nlp import solve_mip_nlp
+
+    with pytest.raises(ValueError, match="Unsupported MIP-NLP OA/ECP option"):
+        solve_mip_nlp(
+            _binary_model("unsupported_oa_option"),
+            method="oa",
+            mip_nlp_options={"add_slack": True},
+        )
+

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -1,6 +1,6 @@
 import discopt.modeling as dm
 import pytest
-from discopt.modeling.core import SolveResult
+from discopt.modeling.core import SolveResult, _DisjunctiveConstraint
 
 
 def _binary_model(name="mip_nlp_route"):
@@ -8,6 +8,18 @@ def _binary_model(name="mip_nlp_route"):
     x = m.binary("x")
     m.minimize(x)
     return m
+
+
+def _gdp_model(name="mip_nlp_gdp_route"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=0, ub=10)
+    m.minimize(x)
+    m.either_or([[x <= 3], [x >= 7]], name="mode")
+    return m
+
+
+def _has_disjunctions(model):
+    return any(isinstance(c, _DisjunctiveConstraint) for c in model._constraints)
 
 
 def test_model_solve_routes_mip_nlp_options(monkeypatch):
@@ -22,12 +34,16 @@ def test_model_solve_routes_mip_nlp_options(monkeypatch):
 
     monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
 
-    result = _binary_model().solve(
-        solver="mip-nlp",
-        mip_nlp_method="ecp",
-        equality_relaxation=True,
-        skip_convex_check=True,
-    )
+    with pytest.warns(
+        UserWarning,
+        match="MIP-NLP solver ignores solve_model options: skip_convex_check",
+    ):
+        result = _binary_model().solve(
+            solver="mip-nlp",
+            mip_nlp_method="ecp",
+            equality_relaxation=True,
+            skip_convex_check=True,
+        )
 
     assert result.status == "optimal"
     assert calls["method"] == "ecp"
@@ -55,6 +71,26 @@ def test_gdp_method_oa_deprecated_alias_routes_to_mip_nlp(monkeypatch):
     assert result.status == "optimal"
     assert calls["method"] == "oa"
     assert calls["equality_relaxation"] is True
+
+
+def test_mip_nlp_and_deprecated_oa_alias_reformulate_gdp(monkeypatch):
+    import discopt.solvers.mip_nlp as mip_nlp_module
+
+    captured = []
+
+    def fake_solve_mip_nlp(model, **kwargs):
+        captured.append(model)
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(mip_nlp_module, "solve_mip_nlp", fake_solve_mip_nlp)
+
+    _gdp_model("mip_nlp_gdp").solve(solver="mip-nlp")
+    with pytest.deprecated_call(match="gdp_method='oa' is deprecated"):
+        _gdp_model("oa_alias_gdp").solve(gdp_method="oa")
+
+    assert len(captured) == 2
+    assert not _has_disjunctions(captured[0])
+    assert not _has_disjunctions(captured[1])
 
 
 def test_mip_nlp_reserved_methods_raise():

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -26,7 +26,7 @@ INTEGRALITY_TOL = 1e-5
 
 def _solve_oa(model, **kwargs):
     """Solve model with OA and return result."""
-    defaults = dict(gdp_method="oa", time_limit=60)
+    defaults = dict(solver="mip-nlp", mip_nlp_method="oa", time_limit=60)
     defaults.update(kwargs)
     return model.solve(**defaults)
 


### PR DESCRIPTION
## Summary

Closes #319.

This moves OA selection toward the solver-family API described in the issue:

- adds `solver="mip-nlp"` as a first-class MINLP decomposition selector
- adds `mip_nlp_method` / `mip_nlp_options`
- routes `mip_nlp_method="oa"` and `"ecp"` through the existing OA implementation
- keeps `gdp_method="oa"` as a deprecation-warning compatibility alias
- leaves `gdp_method` to describe GDP reformulation choices for the new route

The broader MindtPy-style methods (`goa`, `roa`, `fp`, `lp_nlp_bb`) are reserved by name and raise `NotImplementedError` until they are implemented.

## Validation

- `PYTHONPATH=python python -m ruff check python/discopt/solvers/mip_nlp.py python/discopt/solver.py python/discopt/modeling/core.py python/tests/test_mip_nlp.py python/tests/test_oa.py`
- `PYTHONPATH=python pytest python/tests/test_mip_nlp.py python/tests/test_oa.py -q`

Note: local commit hooks were skipped because `pre-commit` is not installed in this environment; the targeted Ruff and pytest checks above pass.
