### PR TITLE
Recognize convex exp-reciprocal products and shifted affine powers

### DIFF
--- a/python/discopt/_jax/convexity/patterns.py
+++ b/python/discopt/_jax/convexity/patterns.py
@@ -14,6 +14,9 @@ shapes where a dedicated proof exists:
   a homogeneous PSD quadratic.
 * **Perspective of exp: ``y * exp(x / y)`` with ``y > 0``**
   (:func:`classify_product_pattern`).
+* **Exp times reciprocal powers: ``exp(affine) * prod_i g_i(x)**a_i``**
+  with each ``g_i`` affine, strictly positive, and ``a_i <= 0``
+  (:func:`classify_product_pattern`).
 * **Weighted geometric mean ``prod_i x_i^{a_i}``** with ``x_i >= 0``,
   ``0 <= a_i <= 1``, and ``sum_i a_i == 1`` (:func:`classify_product_pattern`).
 * **Norm ``sqrt(x^T Q x)`` with Q PSD**
@@ -644,6 +647,9 @@ def classify_product_pattern(
 
     * ``y * exp(x / y)`` with ``y > 0`` and ``x`` affine — perspective of
       ``exp``: CONVEX.
+    * ``exp(affine) * prod_i g_i(x)**a_i`` where every ``g_i`` is affine and
+      strictly positive and every ``a_i <= 0``: CONVEX because it is
+      ``exp(affine + Σ a_i log(g_i(x)))`` with a convex exponent.
     * **Signomial monomial** ``c * prod_i base_i ** a_i`` with every base
       affine, classified by exponent sign pattern on the positive orthant
       (Boyd & Vandenberghe §3.1.5):
@@ -674,9 +680,8 @@ def classify_product_pattern(
                 ):
                     return Curvature.CONVEX
 
-    # Signomial monomial: c * prod_i base_i ** a_i, each base affine.
-    # Peel the leading scalar constant, then classify the product of powers
-    # by its exponent sign pattern (see the function docstring). A negative
+    # Peel the leading scalar constant. The remaining product is inspected by
+    # the exp-times-reciprocal-power and signomial recognizers below. A negative
     # constant flips the curvature.
     const, core = _split_const_mul(expr)
     if core is None or abs(const) <= 1e-12:
@@ -685,6 +690,37 @@ def classify_product_pattern(
     _flatten_product(core, factors)
     if len(factors) < 2:
         return None
+
+    exp_factor_count = 0
+    power_factors: list[tuple[Expression, float]] = []
+    exp_power_candidate = True
+    for factor in factors:
+        if (
+            isinstance(factor, FunctionCall)
+            and factor.func_name == "exp"
+            and len(factor.args) == 1
+            and classify_expr(factor.args[0], model, cache) == Curvature.AFFINE
+        ):
+            exp_factor_count += 1
+            continue
+        extracted = _extract_power_factor(factor)
+        if extracted is None:
+            exp_power_candidate = False
+            break
+        base, exponent = extracted
+        if classify_expr(base, model, cache) != Curvature.AFFINE:
+            exp_power_candidate = False
+            break
+        power_factors.append((base, exponent))
+
+    tol = 1e-10
+    if (
+        exp_power_candidate
+        and exp_factor_count >= 1
+        and all(exp <= tol for _base, exp in power_factors)
+        and all(_affine_strictly_positive(base, model) for base, _exp in power_factors)
+    ):
+        return Curvature.CONCAVE if const < 0 else Curvature.CONVEX
 
     parsed: list[tuple[Expression, float]] = []
     for factor in factors:
@@ -699,7 +735,6 @@ def classify_product_pattern(
     exps = [exp for _, exp in parsed]
     bases = [base for base, _ in parsed]
     total = sum(exps)
-    tol = 1e-10
 
     base_curv: Optional[Curvature] = None
     if (

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3439,7 +3439,9 @@ def _should_claim_composite(expr: Expression, model: Model, n_orig: int) -> bool
     * ``(base)**p`` with a *non-bare* base and either a non-integer constant
       exponent or an integer exponent ``p >= 3``.  A bare variable base is a
       monomial / fractional-power column, and integer squares of non-bare bases
-      stay on the dedicated square lift.
+      stay on the dedicated square lift.  Non-affine integer-power bases are
+      only claimed here; they still need certified curvature before any
+      envelope is emitted.
     """
     if isinstance(expr, FunctionCall) and len(expr.args) == 1:
         op_info = _univariate_arg(expr)
@@ -3473,6 +3475,10 @@ def _affine_base_power_curvature(expr: Expression, model: Model, box: dict) -> O
         return None
     p = float(expr.right.value)
     if p in (0.0, 1.0):
+        return None
+    try:
+        _linearize_affine_expr(expr.left, model, sum(v.size for v in model._variables))
+    except ValueError:
         return None
     from discopt._jax.convexity.interval_eval import evaluate_interval
 

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3436,10 +3436,10 @@ def _should_claim_composite(expr: Expression, model: Model, n_orig: int) -> bool
 
     * a named univariate call whose argument is *non-affine* (the affine case is
       handled by :func:`_collect_univariate_relaxations`), or
-    * ``(base)**p`` with a *non-integer* constant exponent ``p`` and a *non-bare*
-      base (a bare variable base is a monomial / fractional power; integer powers
-      of a non-bare base are squares/monomials handled by the dedicated square and
-      ``distribute_products`` machinery, so claiming them duplicates aux columns).
+    * ``(base)**p`` with a *non-bare* base and either a non-integer constant
+      exponent or an integer exponent ``p >= 3``.  A bare variable base is a
+      monomial / fractional-power column, and integer squares of non-bare bases
+      stay on the dedicated square lift.
     """
     if isinstance(expr, FunctionCall) and len(expr.args) == 1:
         op_info = _univariate_arg(expr)
@@ -3453,11 +3453,11 @@ def _should_claim_composite(expr: Expression, model: Model, n_orig: int) -> bool
         return False
     if isinstance(expr, BinaryOp) and expr.op == "**" and isinstance(expr.right, Constant):
         p = float(expr.right.value)
-        if p == int(p):
-            return False  # integer powers → monomial / square / distribute machinery
         # Bare variable / indexed base is a fractional power already.
         if _get_flat_index(expr.left, model) is not None:
             return False
+        if p == int(p):
+            return int(p) >= 3
         return True
     return False
 
@@ -3486,6 +3486,10 @@ def _affine_base_power_curvature(expr: Expression, model: Model, box: dict) -> O
     # Outward interval rounding can render a true 0 as a tiny negative; a small
     # tolerance keeps the nonnegativity test from spuriously abstaining.
     tol = 1e-9
+    p_int = int(round(p))
+    p_is_int = abs(p - p_int) <= 1e-12
+    if p_is_int and p_int >= 2 and p_int % 2 == 0:
+        return "convex"
     if p < 0.0:
         return "convex" if base_lo > tol else None
     if base_lo < -tol:

--- a/python/tests/test_convexity.py
+++ b/python/tests/test_convexity.py
@@ -90,6 +90,13 @@ class TestConvexExpressions:
         x = m.continuous("x", lb=-5, ub=5)
         assert classify_expr(dm.exp(2.0 * x + 1.0), m) == Curvature.CONVEX
 
+    def test_exp_affine_times_reciprocal_power(self):
+        m = Model("test")
+        x = m.continuous("x", lb=-5, ub=5)
+        y = m.continuous("y", lb=1, ub=10)
+        expr = dm.exp(2.0 * x) * (y ** (-4.0))
+        assert classify_expr(expr, m) == Curvature.CONVEX
+
     def test_exp_of_convex(self):
         """exp(convex) = convex because exp is convex & nondecreasing."""
         m = Model("test")

--- a/python/tests/test_power_certification.py
+++ b/python/tests/test_power_certification.py
@@ -47,6 +47,21 @@ def test_affine_base_fractional_power_certifies():
 
 
 @pytest.mark.correctness
+def test_shifted_even_integer_power_certifies():
+    """``(x - 1)**4`` uses the composite power lift and certifies soundly."""
+    m = dm.Model()
+    x = m.continuous("x", lb=-2.0, ub=3.0)
+    m.minimize((x - 1.0) ** 4)
+    r = m.solve(time_limit=15, gap_tolerance=1e-4)
+
+    assert r.status == "optimal"
+    assert r.objective is not None and r.bound is not None
+    assert math.isclose(r.objective, 0.0, abs_tol=1e-4)
+    assert r.bound <= r.objective + 1e-4, "dual bound must not exceed the optimum"
+    assert r.gap_certified
+
+
+@pytest.mark.correctness
 def test_product_base_fractional_power_certifies():
     """``(x*y)**0.75`` (product base) certifies soundly with a valid bound."""
     m = dm.Model()

--- a/python/tests/test_power_certification.py
+++ b/python/tests/test_power_certification.py
@@ -61,6 +61,28 @@ def test_shifted_even_integer_power_certifies():
     assert r.gap_certified
 
 
+def test_nonaffine_even_integer_power_abstains_from_affine_curvature_shortcut():
+    from discopt._jax.milp_relaxation import _affine_base_power_curvature
+
+    m = dm.Model()
+    x = m.continuous("x", lb=math.pi / 2.0 - 1.0, ub=math.pi / 2.0 + 1.0)
+
+    assert _affine_base_power_curvature(dm.sin(x) ** 4, m, {}) is None
+
+
+def test_nonaffine_even_integer_power_bound_remains_sound():
+    m = dm.Model()
+    x = m.continuous("x", lb=math.pi / 2.0 - 1.0, ub=math.pi / 2.0 + 1.0)
+    m.minimize(dm.sin(x) ** 4)
+    r = m.solve(time_limit=15, gap_tolerance=1e-4)
+
+    true_min = math.cos(1.0) ** 4
+    assert r.status == "optimal"
+    assert r.objective is not None and r.bound is not None
+    assert math.isclose(r.objective, true_min, abs_tol=1e-3)
+    assert r.bound <= true_min + 1e-3, "dual bound must not exceed the true optimum"
+
+
 @pytest.mark.correctness
 def test_product_base_fractional_power_certifies():
     """``(x*y)**0.75`` (product base) certifies soundly with a valid bound."""


### PR DESCRIPTION
## Summary

Closes jkitchin/discopt#327.

This adds two small, conservative improvements to discopt's convexity and relaxation machinery:

- recognize `exp(affine) * prod_i g_i(x)**a_i` as convex when each `g_i` is affine and strictly positive on its bounds and each exponent `a_i <= 0`;
- lift non-bare affine integer powers with exponent `p >= 3`, and classify even affine integer powers as convex even when the affine base crosses zero.

These forms came up while testing the downstream GOA/MIP-NLP work in bernalde/discopt#118 and bernalde/discopt#129, specifically on a MindtPy MINLP5-style convex fixture containing `exp(2*x) * y**(-4)` and `(y - 6)**4`.

## Rationale

The product rule is conservative. The expression

```text
exp(affine) * prod_i g_i(x)**a_i
```

can be written as

```text
exp(affine + sum_i a_i * log(g_i(x)))
```

For `g_i(x) > 0` and `a_i <= 0`, each `a_i * log(g_i(x))` is convex, and composition with the nondecreasing convex `exp` preserves convexity.

For shifted even integer powers, `(affine)**(2k)` is convex over the full real line, so the relaxation gate should not require the affine base to be nonnegative.

## Tests

- `python -m ruff check python/discopt/_jax/convexity/patterns.py python/discopt/_jax/milp_relaxation.py python/tests/test_convexity.py python/tests/test_power_certification.py`
- `python -m ruff format --check python/discopt/_jax/convexity/patterns.py python/discopt/_jax/milp_relaxation.py python/tests/test_convexity.py python/tests/test_power_certification.py`
- `git diff --check`
- `PYTHONPATH=python pytest python/tests/test_convexity.py::TestConvexExpressions::test_exp_affine_times_reciprocal_power -q`
- `PYTHONPATH=python pytest python/tests/test_power_certification.py::test_shifted_even_integer_power_certifies -q -m correctness`
- `pre-commit run` via the commit hook

The correctness test emitted the existing local JAX persistent-cache warning because `/home/bernalde/.cache/discopt/jax-cache` is read-only in this environment; the test passed.
