### PR TITLE
fix(milp): close soundness gap on power/product over a non-variable base

### DIFF
--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -634,7 +634,8 @@ def _classify_nonlinear_terms_rust(model: Model) -> NonlinearTerms | None:
         return None
 
     try:
-        payload = model_to_repr(model).classify_nonlinear_terms()
+        repr = model_to_repr(model)
+        payload = repr.classify_nonlinear_terms()
     except Exception:
         return None
 
@@ -643,7 +644,41 @@ def _classify_nonlinear_terms_rust(model: Model) -> NonlinearTerms | None:
     if int(payload.get("general_nl_count", 0)) != 0:
         return None
 
-    return _terms_from_rust_payload(payload)
+    terms = _terms_from_rust_payload(payload)
+
+    # Cross-check against the authoritative degree analysis. The Rust term
+    # classifier has blind spots — a power/product over a *non-variable* base
+    # (e.g. fac2's ``(x36+…+x41)**2.5``) is not categorised and reports zero
+    # general_nl. If the model is provably *not* linear (objective or some
+    # constraint has degree > 1 per ``max_degree``) yet the payload caught no
+    # terms at all, the classification is incomplete: defer to the thorough
+    # Python walk, which records the term in ``general_nl`` so the relaxation
+    # builder and the simplex engine guard both see it.
+    if not _terms_are_empty(terms):
+        return terms
+    try:
+        fully_linear = repr.is_objective_linear() and all(
+            repr.is_constraint_linear(i) for i in range(repr.n_constraints)
+        )
+    except Exception:
+        return None
+    if not fully_linear:
+        return None  # nonlinear but nothing catalogued → Python path
+    return terms
+
+
+def _terms_are_empty(terms: NonlinearTerms) -> bool:
+    """True if no nonlinear term of any category was recorded."""
+    return not (
+        terms.bilinear
+        or terms.trilinear
+        or terms.multilinear
+        or terms.monomial
+        or terms.fractional_power
+        or terms.bilinear_with_fp
+        or terms.ratio_of_products
+        or terms.general_nl
+    )
 
 
 def _terms_from_rust_payload(payload: dict[str, Any]) -> NonlinearTerms:
@@ -789,7 +824,21 @@ def _classify_nonlinear_terms_python(model: Model) -> NonlinearTerms:
                         _record_fractional_power(flat, exp_val)
                         result.general_nl.append(expr)
                         return
-                # Recurse for complex bases
+                # Power whose base is NOT a single variable (or whose exponent is
+                # not constant). Anything other than a variable-free constant power
+                # or a degree-1 passthrough is genuinely nonlinear and would be
+                # SILENTLY DROPPED by the linear projection (extract_lp_data),
+                # making the simplex engine certify a wrong 'optimal' — e.g. fac2's
+                # ``(x36+…+x41)**2.5`` objective (carton7/#286 class). Flag it as
+                # general_nl so the engine guard defers and the relaxation lifts it.
+                exp_const = _ratio_fold_const(expr.right)
+                whole_is_const = _ratio_fold_const(expr.left) is not None and exp_const is not None
+                if whole_is_const:
+                    return  # variable-free → folds to a constant
+                if exp_const is not None and exp_const == 1.0:
+                    _classify_node(expr.left)  # base**1 == base (linear iff base is)
+                    return
+                result.general_nl.append(expr)
                 _classify_node(expr.left)
                 _classify_node(expr.right)
                 return
@@ -846,7 +895,15 @@ def _classify_nonlinear_terms_python(model: Model) -> NonlinearTerms:
                     _classify_node(expr.left)
                     _classify_node(expr.right)
                     return
-                # If product decomposition failed, recurse on children
+                # Product decomposition failed. A product of two non-constant
+                # sub-expressions — e.g. (x+y)*(z+w) or (x+y)*z — is nonlinear and
+                # would be silently dropped by the linear projection; flag it.
+                # If either side folds to a constant the product is just linear
+                # scaling, so only recurse (the existing behaviour).
+                left_const = _ratio_fold_const(expr.left) is not None
+                right_const = _ratio_fold_const(expr.right) is not None
+                if not left_const and not right_const:
+                    result.general_nl.append(expr)
                 _classify_node(expr.left)
                 _classify_node(expr.right)
                 return

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -10219,6 +10219,30 @@ def _solve_milp_simplex(
     ):
         return None
 
+    # Authoritative linearity backstop (defense-in-depth). The term classifier
+    # above can have blind spots: a power/product over a *non-variable* base —
+    # e.g. fac2's ``(x36+…+x41)**2.5`` objective — is missed by both the Rust and
+    # Python term classifiers, yet ``extract_lp_data`` still silently drops it,
+    # so the engine would certify a wrong 'optimal' on the linear projection
+    # (off by 134x on fac2). The degree analysis behind ``is_objective_linear`` /
+    # ``is_constraint_linear`` (the same check the router trusts to reach this
+    # MILP branch) catches every such term, so defer unless the model is provably
+    # linear in its objective and every constraint. For models that reach here
+    # through the normal MILP route this is a no-op (the router already proved
+    # linearity); it only guards direct calls, future re-routing, and any
+    # router/extractor representation discrepancy.
+    try:
+        from discopt._rust import model_to_repr
+
+        _repr = model_to_repr(model, getattr(model, "_builder", None))
+        _fully_linear = bool(_repr.is_objective_linear()) and all(
+            _repr.is_constraint_linear(i) for i in range(_repr.n_constraints)
+        )
+    except Exception:
+        _fully_linear = False
+    if not _fully_linear:
+        return None
+
     lp_data = extract_lp_data(model)
     A = np.ascontiguousarray(lp_data.A_eq, dtype=np.float64)
     if A.shape[0] == 0:

--- a/python/tests/test_issue_286_false_unbounded.py
+++ b/python/tests/test_issue_286_false_unbounded.py
@@ -78,6 +78,43 @@ def test_pure_milp_still_uses_simplex():
     assert out.objective == pytest.approx(-16.0, abs=1e-6)
 
 
+def test_milp_simplex_defers_on_power_of_sum():
+    """Regression: a power of a *sum of variables* — e.g. fac2's
+    ``(x36+…+x41)**2.5`` objective — was missed by both the Rust and Python term
+    classifiers (they only catalogue powers over a single variable), so the
+    simplex engine accepted the model and certified a WRONG 'optimal' on the
+    linear projection, which silently drops the power. The term classifier must
+    now flag it and the engine must defer."""
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+    from discopt.solver import _solve_milp_simplex
+
+    m = dm.Model("powsum")
+    x = m.integer("x", lb=0, ub=5)
+    y = m.integer("y", lb=0, ub=5)
+    m.minimize((x + y) ** 2.5)
+    m.subject_to(x + y >= 2)
+    assert classify_nonlinear_terms(m).general_nl, "power-of-sum not flagged nonlinear"
+    assert _solve_milp_simplex(m, 10.0, 1e-4, 100000, time.perf_counter()) is None
+
+
+def test_milp_simplex_authoritative_linearity_backstop():
+    """Defense-in-depth: the engine defers unless the model is provably linear in
+    its objective and every constraint per the degree analysis the router uses,
+    so a nonlinear term slipping past the term classifier can never be certified
+    'optimal' on the lossy linear projection. Verified on fac2, whose
+    ``(sum)**2.5`` objective made the projection optimum 2_476_128 vs the true
+    331_837_498."""
+    import os.path
+
+    from discopt.solver import _solve_milp_simplex
+
+    path = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl", "fac2.nl")
+    if not os.path.exists(path):
+        pytest.skip("fac2 instance unavailable")
+    m = dm.from_nl(path)
+    assert _solve_milp_simplex(m, 30.0, 1e-4, 1_000_000, time.perf_counter()) is None
+
+
 # --------------------------------------------------------------------------- #
 # the actual carton7 root cause: big-M reformulation of a product whose other
 # factor has an infinite (or astronomical) bound is invalid -> must abort


### PR DESCRIPTION
## Summary

Closes a **soundness gap** in the pure-MILP simplex engine: it could certify a **wrong optimum** on a model whose objective or a constraint carries a nonlinear term over a **non-variable base** — e.g. fac2's `792.912 * (x36+…+x41)**2.5`.

Found while benchmarking the MILP engine. fac2's linear projection optimum is **2,476,128** vs the true **331,837,498** (134× off), yet `_solve_milp_simplex` returned it labeled `optimal`.

## Root cause

Two independent nonlinearity detectors disagreed:

| | fac2 verdict |
|---|---|
| Router — `classify_problem` → `max_degree` | **nonlinear** (`(sum)**2.5` is degree > 1) → routes to MINLP ✓ |
| Engine guard — `classify_nonlinear_terms` (Rust fast-path **and** Python walk) | **linear** (only catalogues powers/products over a *single variable*) ✗ |

Production was safe *only* because the router sent fac2 to the spatial path before the engine was reached. But the guard — the backstop added for carton7/#286 — was **weaker than the router it backstops**: a power of a *sum* (or a product of two linear forms) fell through, and `extract_lp_data` then silently dropped the term.

## Fix (three layers)

1. **Python term classifier** (`term_classifier.py`): the `**` branch flags any non-constant power that isn't a degree-1 passthrough (`(x+y)**2.5`, `(x+y)**2`, `c**x`) as `general_nl`; the `*` branch flags a product of two non-constant sub-expressions `(x+y)*(z+w)`. Previously dropped — itself unsound for the relaxation builder, which now lifts them.
2. **Rust fast-path reconciliation** (`_classify_nonlinear_terms_rust`): if the Rust payload catalogues nothing yet the model isn't provably linear per the degree analysis, defer to the thorough Python walk instead of trusting an empty result.
3. **Authoritative engine backstop** (`_solve_milp_simplex`): defer unless the model is provably linear in objective and every constraint per the same `is_objective_linear()`/`is_constraint_linear()` the router trusts. A no-op on the normal MILP route; hardens direct calls, future re-routing, and any router/extractor discrepancy so a dropped nonlinear term can never be certified "optimal".

## Tests & validation

New regression tests in `test_issue_286_false_unbounded.py`:
- `test_milp_simplex_defers_on_power_of_sum` — classifier flags `(x+y)**2.5` and the engine defers.
- `test_milp_simplex_authoritative_linearity_backstop` — fac2 itself defers.

A genuinely-linear MILP still uses the fast engine (existing `test_pure_milp_still_uses_simplex`).

- Targeted soundness suite: **31 passed**
- Relaxation/AMP/MINLP batch (amp, mccormick, factorable_reform, relaxation_coverage, fp/unbounded soundness, minlptests): **342 passed**
- Benchmark smoke: **37 passed**
- ruff clean, formatted

No routing change — the router was already correct; this hardens the engine's deferral guard to match it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
