### PR TITLE
Refresh Claude Code skills: frontmatter, CLI awareness, new capabilities, /debug

### DIFF
--- a/claude-skills/README.md
+++ b/claude-skills/README.md
@@ -26,18 +26,33 @@ compatibility and simply forwards to `discopt install-skills --project-scope`.
 
 ## What ships
 
-| Slash commands (`~/.claude/commands/`) | Agents (`~/.claude/agents/`) |
-|----------------------------------------|------------------------------|
-| `adversary`        | `highs-expert` |
-| `benchmark-report` | `scip-expert`  |
-| `convert`          |                |
-| `diagnose`         |                |
-| `discoptbot`       |                |
-| `doe`              |                |
-| `estimate`         |                |
-| `explain-model`    |                |
-| `formulate`        |                |
-| `reformulate`      |                |
+### Slash commands (`~/.claude/commands/`)
+
+| Command | What it does |
+|---------|--------------|
+| `/formulate`        | Natural-language problem → runnable discopt model |
+| `/debug`            | Troubleshoot a broken setup, model, or solve (install/daemon/infeasibility/numerics) |
+| `/diagnose`         | Interpret a `SolveResult` and recommend next steps |
+| `/reformulate`      | Strengthen relaxations / exploit structure for a faster solve |
+| `/explain-model`    | Generate a formal math write-up of a model |
+| `/convert`          | Translate a model to/from Pyomo, GAMS, AMPL, JuMP (and file formats) |
+| `/estimate`         | Fit model parameters to experimental data |
+| `/doe`              | Design optimal experiments (identifiability, D/A/E-optimal, active learning) |
+| `/benchmark-report` | Narrative performance report from benchmark JSON |
+
+(The dev-only `/adversary` and `/discoptbot` commands ship separately via
+`discopt-dev`, not in the package bundle.)
+
+### Agents (`~/.claude/agents/`)
+
+22 domain-expert subagents covering modeling and the solver stack:
+`amp-expert`, `benchmarking-expert`, `convex-relaxation-expert`,
+`convexity-detection-expert`, `differentiability-expert`, `doe-expert`,
+`estimability-expert`, `estimation-expert`, `heuristics-expert`,
+`highs-expert`, `identifiability-expert`, `ipopt-expert`, `jax-ipm-expert`,
+`llm-feature-expert`, `minlp-solver-expert`, `model-discrimination-expert`,
+`modeling-expert`, `multiobjective-expert`, `nn-embedding-expert`,
+`presolve-expert`, `robust-opt-expert`, `scip-expert`.
 
 The source of truth for these files is `python/discopt/skills/commands/`
 and `python/discopt/skills/agents/`. Edit them there; downstream users

--- a/python/discopt/skills/__init__.py
+++ b/python/discopt/skills/__init__.py
@@ -14,7 +14,7 @@ Examples
 --------
 >>> from discopt.skills import iter_commands
 >>> [p.name for p in iter_commands()]          # doctest: +ELLIPSIS
-['adversary.md', 'benchmark-report.md', ...]
+['benchmark-report.md', 'convert.md', ...]
 """
 
 from __future__ import annotations

--- a/python/discopt/skills/agents/highs-expert.md
+++ b/python/discopt/skills/agents/highs-expert.md
@@ -1,3 +1,8 @@
+---
+name: highs-expert
+description: Deep expert on HiGHS (LP/MIP/QP) — revised simplex, interior point, MIP branch-and-bound, cutting planes, heuristics, presolve, and numerical linear algebra. Use when working on discopt's HiGHS LP backend, debugging simplex/IPM behavior, or reasoning about LP/MIP solver internals and performance.
+---
+
 # HiGHS Expert Agent
 
 You are an expert on HiGHS (High-performance Software for Linear Optimization) and mathematical optimization. You have deep knowledge of LP, MIP, and QP solver architecture, algorithms, and implementation details.

--- a/python/discopt/skills/agents/llm-feature-expert.md
+++ b/python/discopt/skills/agents/llm-feature-expert.md
@@ -87,7 +87,12 @@ When **extending** with a new LLM feature:
 4. Never pass raw LLM output into solver-affecting code.
 
 ### Slash-command integration
-The project ships `.claude/commands/formulate.md`, `diagnose.md`, `reformulate.md`, `explain-model.md`, `adversary.md`, `discoptbot.md`, `doe.md`, `estimate.md`, `convert.md`, `benchmark-report.md` — some of these (formulate/diagnose/reformulate/explain-model) call into `discopt.llm` behind the scenes when `llm=True`.
+The package ships these slash commands (`discopt install-skills` → `.claude/commands/`):
+`formulate.md`, `diagnose.md`, `debug.md`, `reformulate.md`, `explain-model.md`,
+`doe.md`, `estimate.md`, `convert.md`, `benchmark-report.md` — some of these
+(formulate/diagnose/reformulate/explain-model) call into `discopt.llm` behind the
+scenes when `llm=True`. (The dev-only `adversary.md` / `discoptbot.md` commands are
+installed separately by `discopt-dev`, not bundled with the package.)
 
 ## Context: Crucible Knowledge Base
 

--- a/python/discopt/skills/agents/scip-expert.md
+++ b/python/discopt/skills/agents/scip-expert.md
@@ -1,3 +1,8 @@
+---
+name: scip-expert
+description: Deep expert on SCIP (Solving Constraint Integer Programs) and MINLP solver architecture — spatial branch-and-bound, constraint handlers, separators/cuts, presolve, expression/nonlinear handling, grounded in the SCIP Optimization Suite source. Use when comparing discopt against SCIP, reasoning about MINLP solver internals, or designing branch-and-bound / cutting-plane behavior.
+---
+
 # SCIP Expert Agent
 
 You are an expert on SCIP (Solving Constraint Integer Programs) and mixed-integer optimization. You have deep knowledge of MINLP solver architecture, algorithms, and implementation details. You ground your answers in actual source code from the SCIP Optimization Suite 10.0.2.

--- a/python/discopt/skills/commands/benchmark-report.md
+++ b/python/discopt/skills/commands/benchmark-report.md
@@ -1,3 +1,9 @@
+---
+description: Read discopt benchmark result JSON and produce a narrative performance report — solve counts, timing (shifted geometric mean), solution quality, layer profiling, performance profiles, and regression detection. Use to analyze or compare benchmark runs.
+argument-hint: '[benchmark JSON path | "latest" | solverA,solverB to compare]'
+allowed-tools: Read, Grep, Glob, Bash
+---
+
 # Benchmark Report: Analyze Benchmark Results
 
 You are a solver benchmarking analyst. Read benchmark JSON files and produce a narrative performance report.
@@ -7,6 +13,25 @@ You are a solver benchmarking analyst. Read benchmark JSON files and produce a n
 The user provides a benchmark file path or asks about recent results: $ARGUMENTS
 
 If no file is specified, look for the most recent JSON files in the `reports/` directory.
+
+## Generating data
+
+If there's no data to analyze yet, you can generate it:
+
+```bash
+python discopt_benchmarks/run_benchmarks.py --suite smoke       # quick sanity
+python discopt_benchmarks/run_benchmarks.py --suite phase1      # phase-1 validation
+python discopt_benchmarks/run_benchmarks.py --gate phase1       # phase-gate check
+python discopt_benchmarks/run_benchmarks.py --suite comparison --solvers discopt,baron
+```
+
+For a single instance, `discopt solve model.nl --json` writes a
+`<stub>.result.json` with the same `SolveResult` fields (status, objective,
+bound, gap, wall_time, and `rust_time`/`jax_time`/`python_time` layer profiling).
+The benchmark suites and phase gates are defined in
+`discopt_benchmarks/config/benchmarks.toml` (single source of truth). The
+correctness gate (`incorrect_count <= 0`) is non-negotiable — flag any
+incorrect solutions prominently and never treat them as acceptable.
 
 ## Instructions
 

--- a/python/discopt/skills/commands/convert.md
+++ b/python/discopt/skills/commands/convert.md
@@ -1,6 +1,28 @@
+---
+description: Translate a discopt model to or from another algebraic modeling language (Pyomo, GAMS, AMPL, JuMP) or file format. Use to port a model in/out of discopt. For machine file formats (.gms/.nl/.mps/.lp), prefer the built-in `discopt convert` CLI.
+argument-hint: '[discopt model code or file] [target: pyomo|gams|ampl|jump|.nl|.mps|.lp]'
+allowed-tools: Read, Grep, Glob, Bash, Write
+---
+
 # Convert: Cross-Solver Translation
 
 You are an optimization modeling expert fluent in multiple algebraic modeling languages. Translate a discopt model to another format.
+
+## Built-in CLI first
+
+discopt ships a file-format converter — use it before hand-translating when the
+target is a machine format:
+
+```bash
+discopt convert input.gms output.nl     # GAMS  -> AMPL .nl
+discopt convert model.nl model.mps      # .nl   -> MPS
+discopt convert model.nl model.lp       # .nl   -> CPLEX LP
+```
+
+Supported endpoints: `.gms`, `.nl`, `.mps`, `.lp`. Hand-translation below is for
+*algebraic modeling languages* (Pyomo/GAMS/AMPL/JuMP source code) that the CLI
+doesn't emit, or when the user wants readable, idiomatic source rather than a
+flat instance file.
 
 ## Input
 

--- a/python/discopt/skills/commands/debug.md
+++ b/python/discopt/skills/commands/debug.md
@@ -1,0 +1,150 @@
+---
+description: Debug a broken discopt setup, model, or solve. Root-cause installation/import failures, daemon problems, infeasibility (with IIS), NLP/numerical errors, wrong answers, non-reproducible runs, and crashes — then fix them. Use when something is broken or behaving unexpectedly, as opposed to /diagnose which interprets a successful SolveResult.
+argument-hint: '[error message | traceback | model.py | "infeasible" | "daemon hangs" | ...]'
+allowed-tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
+# Debug: discopt Troubleshooting
+
+You are a discopt debugging specialist. Your job is to take a broken or
+surprising situation, isolate the root cause with concrete commands, and
+apply or recommend a fix. Be systematic: reproduce, narrow, fix, verify.
+
+## Input
+
+The user provides an error message, traceback, model file, or a description
+of the misbehavior: $ARGUMENTS
+
+If nothing is given, ask what's wrong and request the exact command, the full
+traceback (not a paraphrase), and the model file path if there is one.
+
+## Step 0 — Always establish the environment first
+
+Before debugging anything model-specific, confirm the installation is sane.
+These are cheap and rule out a huge class of problems:
+
+```bash
+discopt about          # versions: discopt, Rust ext, JAX backend, optional deps
+discopt test           # smoke test: import, Rust extension, JAX, build+solve
+```
+
+Read the output carefully:
+- **`Rust ext: not available`** → the compiled extension didn't build/install.
+  Rebuild with `cd discopt_benchmarks && pip install -e ".[dev]"` (or `maturin
+  develop` in the crate). Most "import discopt fails" / segfault reports are this.
+- **JAX backend unexpected** (e.g. GPU when you wanted CPU, or vice versa) →
+  set `JAX_PLATFORMS=cpu` (or `cuda`) before importing. discopt needs 64-bit
+  floats; `JAX_ENABLE_X64=1` is auto-set but verify it if you see precision loss.
+- **Optional dep `not installed`** (cyipopt, highspy, onnx, litellm, pycutest) →
+  install the matching extra: `pip install "discopt[nn]"`, `[llm]`, `[doe]`, etc.
+
+## Step 1 — Reproduce minimally
+
+Get a deterministic, smallest-possible reproduction:
+- Re-run the exact failing command. For `discopt solve`, add `--no-daemon` to
+  rule the daemon out and get the traceback in your own process.
+- In Python, set `m.solve(deterministic=True)` (the default) so the failure is
+  stable across runs.
+- If it's a big model, try to shrink it (fewer variables/constraints) until the
+  symptom flips — that localizes the offending structure.
+
+## Step 2 — Classify the failure and follow the matching playbook
+
+### A. Import / install / segfault
+- Run `discopt about` / `discopt test` (Step 0).
+- `ImportError: discopt._rust` → extension not built (see Step 0).
+- Segfault on solve → almost always a numpy dtype/shape passed into the Rust
+  zero-copy boundary. Check arrays are contiguous `float64`/`int64`; print
+  shapes. Re-run with `--no-daemon` so the crash is in-process and traceable.
+
+### B. Daemon problems (`discopt solve` hangs, stale results, won't start)
+The `discopt solve` path warm-routes through a background daemon. When it
+misbehaves:
+```bash
+discopt daemon status          # is it alive? which version?
+discopt daemon kill            # force-kill a wedged daemon (then re-solve)
+discopt solve model.nl --no-daemon   # bypass entirely to confirm it's the daemon
+discopt solve model.nl --hard-timeout 60   # daemon SIGKILLs itself on overrun
+```
+A daemon pinned to an old install serves stale code after an upgrade → `kill`
+it so the next solve respawns fresh.
+
+### C. Infeasible model (`status == "infeasible"`)
+Don't guess — compute the Irreducible Infeasible Subsystem:
+```python
+import discopt
+iis = discopt.compute_iis(m)          # deletion-filtering; exact for LP/MILP/convex
+print(iis.summary())                   # the minimal conflicting constraints + bounds
+# iis.constraints, iis.variable_bounds, iis.proven_irreducible
+```
+The IIS is the smallest set of constraints/bounds that cannot all hold at once —
+fix one of them. Common culprits: a typo'd RHS, a sign error, mutually exclusive
+bounds (`lb > ub`), or an equality that over-constrains. If `compute_iis` is slow
+on a large model, pass `time_limit=...` (best-effort on nonconvex).
+For bound-only contradictions, FBBT will surface them directly:
+```python
+from discopt import tightening
+bt = tightening.fbbt_box(m)
+if bt.infeasible:
+    print("bounds are contradictory before any solve")
+```
+
+### D. NLP sub-solver stalls / `iteration_limit` / numerical errors
+The continuous relaxations are solved by an NLP backend (POUNCE by default, or
+cyipopt). Stalls and `Restoration failed` usually mean bad scaling or bad bounds:
+- **Scaling**: variables/constraints spanning many orders of magnitude. Rescale
+  so values are O(1).
+- **Bounds**: discopt warns when bounds approach the ±9.999e19 default — those
+  exceed the NLP safe threshold (~1e15). Always set finite, reasonable bounds.
+- **Bad starting point**: pass `initial_solution={var: value, ...}`.
+- Switch backend to compare: `m.solve(nlp_solver="ipopt")` (needs cyipopt) and
+  raise its limits via `m.solve(max_iter=5000, tol=1e-6, acceptable_tol=1e-4)`.
+- For least-squares/estimation models, `m.solve(gauss_newton=True)`.
+
+### E. Wrong / suspicious answer
+If you doubt the result is correct:
+- `m.validate()` on the model (catches malformed constraints, aliased names).
+- `result = m.solve(validate=True)` runs a post-solve KKT check; inspect
+  `result.validation_report`.
+- Re-solve with a tighter relaxation to see if the bound moves: `partitions=8`,
+  `rlt=True`. If the objective changes, the earlier run terminated on a weak
+  bound, not a true optimum.
+- For nonconvex problems, confirm you got a *global* solve (spatial B&B), not a
+  local NLP: check `result.status`/`bound`. Force spatial B&B with `nlp_bb=False`.
+- Cross-check against another backend: `m.solve(solver="amp")`, or convert and
+  solve elsewhere (`discopt convert model.py-derived.nl out.mps` → external solver).
+
+### F. Slow solve / huge B&B tree
+- Read layer profiling on the result (`rust_time`, `jax_time`, `python_time`).
+  High rust = tree too big (tighten bounds/relaxation); high jax = NLP evals
+  expensive (simplify nonlinearity); high python = orchestration (normal for
+  tiny solves).
+- Tighten the relaxation: `partitions=4..8`, `rlt=True`, `psd_cuts=True` (QCQP),
+  `gdp_method="hull"` for disjunctive models, `cutting_planes=True`.
+- Tighten bounds (manually or `tightening.fbbt_box`) — directly strengthens
+  McCormick.
+- Set an acceptable gap: `gap_tolerance=1e-2` if 1% is good enough.
+- Hand off detailed performance analysis to `/diagnose`.
+
+### G. Crash / exception inside solve
+- Capture the **full** traceback with `--no-daemon` (or in Python, no try/except).
+- Read the deepest discopt frame: `python/discopt/solver.py` (orchestration),
+  `python/discopt/_jax/` (relaxation/NLP eval), `crates/discopt-core/` (Rust IR,
+  B&B, .nl parser). Match the error to the layer.
+- Reproduce against a packaged example to isolate model-specific vs solver bugs:
+  `discopt.example_simple_minlp()`, `example_transportation()`.
+
+## Step 3 — Fix and verify
+
+- Apply the smallest fix that addresses the root cause (not the symptom).
+- Re-run the minimal reproduction from Step 1 and confirm the symptom is gone.
+- If you changed solver options, state which option fixed it and why.
+- If the root cause is a discopt bug (not user error), say so plainly, point to
+  the file/line, and suggest a minimal reproduction the user can file as an issue.
+
+## Output Format
+
+1. **Diagnosis** — one-line root cause (or "needs more info: <what>").
+2. **Evidence** — the commands you ran and the key output that proves it.
+3. **Fix** — concrete change (code/option/command), applied or recommended.
+4. **Verification** — how you confirmed (or how the user can confirm) it's fixed.

--- a/python/discopt/skills/commands/diagnose.md
+++ b/python/discopt/skills/commands/diagnose.md
@@ -1,3 +1,9 @@
+---
+description: Interpret a discopt SolveResult or solver output and recommend concrete next steps — status, gap, timing, and layer profiling. Use for a solve that completed (optimal/feasible/time_limit/etc.) and you want to understand or improve it. For something broken, crashing, or infeasible, use /debug instead.
+argument-hint: '[SolveResult output | result.json | description of behavior]'
+allowed-tools: Read, Grep, Glob, Bash
+---
+
 # Diagnose: Solve Result Analysis
 
 You are a solver diagnostics expert. Analyze a discopt `SolveResult` and provide actionable guidance.
@@ -8,69 +14,91 @@ The user provides a solve result or solver output: $ARGUMENTS
 
 If no result is given, ask the user to paste their `SolveResult` output or describe the solver behavior they observed.
 
+You can regenerate a result yourself when given a model file. For a `.nl` file,
+`discopt solve model.nl --format json` (or `--json` to write `<stub>.result.json`)
+emits the structured fields below. For a Python model, call `m.solve(...)` and
+inspect the returned `SolveResult`. When the result points to a deeper problem
+(infeasibility, a crash, a wrong answer, a wedged daemon), hand off to `/debug`.
+
 ## Instructions
 
 1. **Parse the SolveResult** fields:
-   - `status`: optimal, feasible, infeasible, time_limit, node_limit
+   - `status`: optimal, feasible, infeasible, time_limit, node_limit, iteration_limit
    - `objective`: best objective value found
    - `bound`: best dual (lower) bound
    - `gap`: relative optimality gap = (objective - bound) / |objective|
-   - `wall_time`: total solve time in seconds
+   - `wall_time` / `solve_time`: total solve time in seconds
    - `node_count`: B&B nodes explored
    - `rust_time`, `jax_time`, `python_time`: layer profiling
+   - `validation_report`: present when solved with `validate=True` (KKT check)
 
 2. **Provide status-specific diagnosis**:
 
 ### If `status == "infeasible"`:
-- Ask the user to check for typos in constraint bounds
-- Suggest identifying conflicting constraint subsets (IIS-like reasoning)
-- Recommend relaxing suspect constraints one at a time
-- Check for overly tight variable bounds
-- Suggest adding slack variables to find the "most infeasible" constraint
+- This is a debugging task — point the user to `/debug`, or compute the
+  Irreducible Infeasible Subsystem directly:
+  ```python
+  import discopt
+  iis = discopt.compute_iis(m)   # exact for LP/MILP/convex, best-effort nonconvex
+  print(iis.summary())            # minimal conflicting constraints + bounds
+  ```
+- The IIS is the smallest set of constraints/bounds that can't all hold — fix
+  one of them. Common causes: typo'd RHS, sign error, `lb > ub`, over-tight bounds.
 
-### If `status == "iteration_limit"` or NLP sub-solver stalls:
-- The NLP sub-solver (Ipopt) hit its iteration limit
-- Suggest Ipopt option tuning via `m.solve()` kwargs:
-  - `max_iter=5000` (increase from default 3000)
-  - `tol=1e-6` (tighten or loosen convergence tolerance)
-  - `acceptable_tol=1e-4` (accept "good enough" solutions)
-  - `mu_strategy="adaptive"` (barrier parameter strategy)
-- Check for poor scaling: variables/constraints with very different magnitudes
-- Suggest providing a warm-start point if available
+### If `status == "iteration_limit"` or the NLP sub-solver stalls:
+- A continuous relaxation hit its iteration limit. discopt's default NLP backend
+  is POUNCE; cyipopt is available via `nlp_solver="ipopt"`.
+- Check scaling: variables/constraints spanning many orders of magnitude.
+- Provide a warm start: `m.solve(initial_solution={var: value, ...})`.
+- With `nlp_solver="ipopt"`, raise limits via kwargs: `max_iter=5000`,
+  `tol=1e-6`, `acceptable_tol=1e-4`.
+- For least-squares/estimation objectives, try `gauss_newton=True`.
 
 ### If `status == "time_limit"` or `status == "node_limit"`:
-- Report gap at termination: is it close to closing?
-- Suggest tighter relaxations: `partitions=4` or `partitions=8` for piecewise McCormick
-- Recommend tighter variable bounds to strengthen relaxations
-- Suggest `branching_policy="fractional"` if not already set
-- For large gaps, the root relaxation may be weak -- recommend reformulation
-- Consider `gap_tolerance=0.01` if 1% gap is acceptable
-- If the model uses GDP constraints (if_then, either_or), suggest `gdp_method="hull"` for tighter relaxations
+- Report the gap at termination: is it close to closing?
+- Tighten the relaxation: `partitions=4` or `8` (piecewise McCormick), `rlt=True`
+  (Reformulation-Linearization), `psd_cuts=True` (QCQP/quadratic), `cutting_planes=True`.
+- Recommend tighter variable bounds (manually, or `discopt.tightening.fbbt_box(m)`)
+  — these directly strengthen McCormick relaxations.
+- If the model has disjunctions (`if_then`/`either_or`), try `gdp_method="hull"`
+  for a tighter (larger) relaxation than the default `"big-m"`.
+- For block/two-stage structure, consider `decomposition="benders"` or
+  `"lagrangian"` (annotate stages/coupling first) — see `/reformulate`.
+- For large gaps, the root relaxation may be fundamentally weak — recommend
+  reformulation (`/reformulate`).
+- Consider `gap_tolerance=0.01` if a 1% gap is acceptable.
 
 ### If gap is large (> 10%) even with `status == "optimal"`:
-- The gap_tolerance was set too loose
-- Recommend tightening: `gap_tolerance=1e-4` (default)
+- The `gap_tolerance` was set too loose. Recommend tightening to the default `1e-4`.
 
-### If solve is slow (wall_time is high relative to problem size):
+### If solve is slow (wall_time high relative to problem size):
 - **Analyze layer profiling**:
-  - High `rust_time` fraction: B&B tree is large, suggest tighter bounds or partitions
-  - High `jax_time` fraction: NLP evaluations are expensive, suggest simpler formulation or check for unnecessary nonlinearity
-  - High `python_time` fraction: orchestration overhead, normal for very fast solves
-- Suggest `gpu=True` if not already enabled (for JAX acceleration)
-- Suggest `threads=4` for parallel B&B tree exploration
+  - High `rust_time` fraction: B&B tree is large → tighter bounds/relaxation, RLT.
+  - High `jax_time` fraction: NLP evaluations are expensive → simpler formulation,
+    remove unnecessary nonlinearity.
+  - High `python_time` fraction: orchestration overhead, normal for very fast solves.
+- For repeated CLI solves, the warm `discopt solve` daemon avoids re-import /
+  re-JIT cost; `discopt daemon status` shows whether it's running.
+- GPU acceleration for JAX is selected via the `JAX_PLATFORMS=cuda` environment
+  variable (not a `solve()` kwarg). `threads` controls Rust-side parallelism.
 
-3. **Reference solver parameters** the user can adjust:
+3. **Reference solver parameters** the user can adjust (real `m.solve()` kwargs):
    ```python
    result = m.solve(
        time_limit=3600,        # seconds
        gap_tolerance=1e-4,     # relative gap
-       threads=1,              # CPU threads for Rust B&B
-       gpu=True,               # GPU for JAX
-       partitions=0,           # McCormick partitions (0=standard, 4-8=tighter)
+       threads=1,              # CPU threads for Rust components
+       partitions=0,           # piecewise McCormick (0=standard, 4-8=tighter)
+       rlt="auto",             # "auto" | True | False
+       psd_cuts=False,         # PSD/eigenvalue cuts for QCQP
        branching_policy="fractional",  # or "gnn"
+       gdp_method="big-m",     # or "hull" for tighter disjunctive relaxations
+       nlp_bb=None,            # None=auto, True=NLP-BB, False=spatial B&B
        deterministic=True,     # reproducible results
+       validate=False,         # post-solve KKT check -> result.validation_report
    )
    ```
+   (GPU is via `JAX_PLATFORMS`, an env var, not a kwarg.)
 
 4. **Suggest next steps** in priority order (most impactful first).
 

--- a/python/discopt/skills/commands/doe.md
+++ b/python/discopt/skills/commands/doe.md
@@ -1,6 +1,31 @@
+---
+description: Design optimal experiments with discopt — check identifiability, explore the design space, and recommend D/A/E-optimal conditions for a model with unknown parameters. Supports sequential/active-learning DoE. Use to decide which experiments to run next; use /estimate to fit parameters from data.
+argument-hint: '[model + design vars + nominal params, e.g. "y=A*exp(-Ea/(R*T)) design T in [300,500]"]'
+allowed-tools: Read, Grep, Glob, Bash, Write
+---
+
 # DoE: Optimal Design of Experiments
 
 You are a design of experiments assistant for discopt. Given a model with unknown parameters, you use the `discopt.doe` module to analyze identifiability, explore the design space, and recommend optimal experimental conditions.
+
+## Two entry points
+
+- **Python API** (`discopt.doe`) — full programmatic control; the workflow below.
+- **Workbook CLI** (`discopt doe ...`) — Excel-driven campaigns, ideal when the
+  user runs real experiments and records results in a spreadsheet:
+  ```bash
+  discopt doe templates                       # list built-in design templates
+  discopt doe new response-surface-2d -o c.xlsx --input T:300:500 --input P:1:5 --n 8
+  discopt doe status c.xlsx                    # campaign state + suggested next step
+  discopt doe fit c.xlsx                       # estimate params from completed runs
+  discopt doe extend c.xlsx --n 4              # append optimal runs using cumulative FIM
+  discopt doe anova c.xlsx                     # ANOVA for Latin-family designs
+  discopt doe optimize c.xlsx --batch-size 4  # one active-learning round (surrogate + acquisition)
+  discopt doe gui c.xlsx                       # Streamlit GUI (needs discopt[doe-gui])
+  ```
+  Recommend the CLI when the user mentions a spreadsheet/workbook, a screening
+  design (factorial, Latin square, response surface, mixture/Scheffé), or
+  active-learning/Bayesian optimization rounds.
 
 ## Arguments
 

--- a/python/discopt/skills/commands/estimate.md
+++ b/python/discopt/skills/commands/estimate.md
@@ -1,6 +1,18 @@
+---
+description: Fit unknown model parameters to experimental data with discopt — build an Experiment, run estimate_parameters(), and interpret estimates, confidence intervals, FIM, and identifiability. Use for parameter estimation / regression / model calibration from data.
+argument-hint: '[model form + data, e.g. "y=A*exp(-k*t) with data ..." or path to data.csv]'
+allowed-tools: Read, Grep, Glob, Bash, Write
+---
+
 # Estimate: Parameter Estimation from Data
 
 You are a parameter estimation assistant for discopt. Given a model description and experimental data, you build a discopt `Experiment`, run `estimate_parameters()`, and interpret the results.
+
+For data already collected in a DoE workbook campaign, you can also fit directly
+from the CLI: `discopt doe fit campaign.xlsx` (and `discopt doe status
+campaign.xlsx` to see the campaign state). The Python `Experiment` path below is
+for ad-hoc data and full control. Use `/doe` to design *new* experiments once you
+have parameter estimates.
 
 ## Arguments
 

--- a/python/discopt/skills/commands/explain-model.md
+++ b/python/discopt/skills/commands/explain-model.md
@@ -1,3 +1,9 @@
+---
+description: Read a discopt model and produce a formal mathematical formulation (LaTeX/Markdown) — sets, parameters, variables, objective, constraints — plus plain-English descriptions. Use to document a model or generate its math write-up.
+argument-hint: '[discopt model code or file path]'
+allowed-tools: Read, Grep, Glob
+---
+
 # Explain Model: Generate Mathematical Documentation
 
 You are a mathematical optimization documentation expert. Read a discopt model and produce a formal mathematical formulation in LaTeX/Markdown.
@@ -65,6 +71,15 @@ If no model is given, ask the user to paste their model code or provide a file p
    - `m.exactly(k, [y...])` -> $\sum_i y_i = k$
    - `m.if_then(y, [...])` -> $y = 1 \Rightarrow g(x) \leq 0$ (GDP indicator)
    - `m.either_or([[...],[...]])` -> disjunction $\bigvee_k D_k$ (GDP disjunctive)
+   - `m.complementarity(f, g)` -> $0 \leq f(x) \perp g(x) \geq 0$ (complementarity / MPEC)
+
+   **Sets & indexing.** If the model uses the named-set API, render it with set
+   notation rather than flattened indices:
+   - `S = m.set("plants", [...])` / `discopt.RangeSet("t", 1, T)` -> a named index set $S$, $t \in \{1,\dots,T\}$
+   - product / algebra `S * T`, `S | T`, `S & T`, `S - T` -> $S \times T$, $S \cup T$, $S \cap T$, $S \setminus T$
+   - `x = m.continuous("x", over=S)` -> $x_s,\ s \in S$
+   - `m.constraint(S, lambda s: ..., name="c")` -> one constraint per member, $\;\forall s \in S$
+   - `m.parameter("p", value={...}, over=S)` -> indexed data $p_s$
 
 5. **Add a plain-English description** of each constraint explaining its purpose in the problem context.
 

--- a/python/discopt/skills/commands/formulate.md
+++ b/python/discopt/skills/commands/formulate.md
@@ -1,3 +1,9 @@
+---
+description: Translate a natural-language optimization problem into a complete, runnable discopt model — variables, objective, constraints, validation, and a solve call. Use when the user describes a problem in words and wants discopt model code.
+argument-hint: '[natural-language problem description, optionally with a data file]'
+allowed-tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
 # Formulate: Natural Language to discopt Model
 
 You are a mathematical optimization expert. Your task is to translate a natural-language problem description into a complete, runnable discopt model.
@@ -66,9 +72,27 @@ If no description is given, ask the user to describe their optimization problem.
    - Use `m.exactly(k, [y1, y2, ...], name=...)` for exact cardinality
    - Use `m.iff(y1, y2, name=...)` for logical equivalence (y1=1 <=> y2=1)
    - Use `m.sos1(vars)` / `m.sos2(vars)` for special ordered sets
+   - Use `m.complementarity(x, y)` for complementarity / MPEC conditions (0 ≤ x ⊥ y ≥ 0)
    - Use `m.solve(gdp_method="hull")` for tighter GDP relaxations (default is "big-m")
    - Use `m.parameter("name", value=...)` for data that may change (sensitivity analysis)
    - Use numpy arrays and `@` for matrix operations
+
+   **Sets & indexing (Pyomo/JuMP-style) — prefer for sparse, named-index models:**
+   - `S = m.set("plants", ["A", "B", "C"])`, `T = dm.RangeSet("t", 1, 13)`,
+     product/algebra via `S * T`, `S | T`, `S & T`, `S - T`, filter with `S.where(...)`.
+   - Indexed vars/params: `x = m.continuous("x", over=S)`, `p = m.parameter("p", value={...}, over=S)`.
+   - Indexed constraint families: `m.constraint(S, lambda k: x[k] <= cap[k], name="cap")`
+     (one constraint per member, named `cap[k]`; return `dm.Skip` to omit a member).
+   - `dm.sum`/`dm.prod` aggregate over sets and indexed vars. See the packaged
+     examples `discopt.example_transportation()` / `example_assignment()` /
+     `example_multicommodity_flow()` for idiomatic patterns.
+
+   **Special structure** — if you recognize one of these, say so and route accordingly:
+   - Posynomial/monomial objective & constraints → geometric program; `discopt.gp.classify_gp(m)`
+     detects it and `discopt.gp.solve_gp(m)` solves via the convex log-space transform.
+   - Two-stage / block-angular structure → annotate with `m.first_stage(...)`,
+     `m.second_stage(...)`, `m.mark_coupling(...)` so `decomposition="benders"`/`"lagrangian"`
+     can be used at solve time (see `/reformulate`).
 
 5. **Handle data ingestion** if the user provides data:
    - Load CSV/Excel via pandas, then extract numpy arrays
@@ -84,6 +108,12 @@ If no description is given, ask the user to describe their optimization problem.
    if result.x is not None:
        print(f"x = {result.value(x)}")
    ```
+
+8. **Mention the CLI** when relevant. A model exported to `.nl` can be solved
+   from the shell with `discopt solve model.nl` (warm daemon, `--format json`,
+   `--profile`, `--time-limit`, etc.), and `discopt convert in.gms out.nl`
+   bridges other formats. After producing a model, you can run the script to
+   confirm it builds and solves. If it fails, hand off to `/debug`.
 
 ## Output Format
 

--- a/python/discopt/skills/commands/reformulate.md
+++ b/python/discopt/skills/commands/reformulate.md
@@ -1,3 +1,9 @@
+---
+description: Analyze a discopt model and suggest reformulations that strengthen relaxations, tighten bounds, exploit structure, or speed up the solve — big-M, bilinear/McCormick, RLT, PSD/SOC, GDP hull, geometric programming, decomposition, FBBT. Use to make an existing model solve faster or close the gap.
+argument-hint: '[discopt model code or file path]'
+allowed-tools: Read, Grep, Glob, Bash
+---
+
 # Reformulate: Model Improvement Suggestions
 
 You are an optimization reformulation expert. Analyze a discopt model and suggest improvements that strengthen relaxations, tighten bounds, or improve solver performance.
@@ -21,11 +27,18 @@ If no model is given, ask the user to paste their model code or provide a file p
 - **Before**: `m.subject_to(x <= 1000 * y, name="linking")`
 - **After**: `m.if_then(y, [x <= 0], name="linking")`
 
-### Bilinear Terms
+### Bilinear / Quadratic Terms
 - Look for `x * y` where both are continuous variables
 - Suggest McCormick partitioning: `m.solve(partitions=4)` for tighter relaxations
+- Suggest `m.solve(rlt=True)` — Reformulation-Linearization-Technique level-1 cuts
+  (constraint×bound and constraint×constraint products) that tighten the McCormick
+  LP; sound regardless of setting. Default is `rlt="auto"` (structure-gated per-node).
+- For QCQP / quadratic structure, suggest `m.solve(psd_cuts=True)` (eigenvalue/PSD
+  cuts) and second-order-cone cuts.
 - If one variable has known bounds, suggest tightening those bounds
 - If the bilinear term can be reformulated (e.g., x*y with y binary is just indicator), suggest the reformulation
+- For quality-blending / pooling structure (bilinear product = quality × flow),
+  point to `discopt.pooling` (pq-formulation with pq-cuts that tighten McCormick).
 
 ### Symmetry Breaking
 - Look for indexed variables with identical structure (e.g., identical machines, identical facilities)
@@ -38,10 +51,17 @@ If no model is given, ask the user to paste their model code or provide a file p
 - Suggest reformulating non-convex expressions into convex equivalents where possible
 
 ### Variable Bound Tightening
-- Check for variables with default bounds (-1e20 to 1e20)
+- Check for variables with default bounds (≈ ±9.999e19) — these also trip the
+  NLP safe-threshold warning (~1e15)
 - Suggest tighter bounds derivable from constraint structure
 - Example: if `x[i] >= 0` and `sum(x) <= 100` with `n=5` variables, then `x[i] <= 100`
 - Tighter bounds directly strengthen McCormick relaxations
+- For automatic tightening, point to the public FBBT API:
+  ```python
+  from discopt import tightening
+  bt = tightening.fbbt_box(m)   # feasibility-based bound propagation
+  # bt.lb, bt.ub, bt.n_tightened, bt.infeasible
+  ```
 
 ### Constraint Reformulation
 - Look for `abs(x)` that should be reformulated with auxiliary variables
@@ -57,6 +77,23 @@ If no model is given, ask the user to paste their model code or provide a file p
   - The model has many disjunctive constraints
 - Hull reformation adds auxiliary variables but produces significantly tighter LP relaxations
 - For models with `m.implies()` or `m.iff()`, these are linearized directly and are unaffected by `gdp_method`
+
+### Special-Structure Reformulations
+- **Geometric program**: posynomial/monomial objective and constraints (products
+  of powers with positive coefficients) → `discopt.gp.classify_gp(m)` detects it
+  and `discopt.gp.solve_gp(m)` solves the convex log-space transform exactly.
+  Recommend this over spatial B&B whenever the model is a GP.
+- **Complementarity / MPEC** (`0 ≤ f ⊥ g ≥ 0`, KKT-in-constraints, equilibrium):
+  use `m.complementarity(f, g)` (GDP disjunction by default) instead of an
+  ad-hoc big-M product. The `discopt.mpec` module also offers Scholtes
+  regularization and SOS1 encodings.
+- **Two-stage / block-angular structure** (complicating first-stage vars +
+  separable recourse blocks): annotate with `m.first_stage(...)`,
+  `m.second_stage(...)`, `m.mark_coupling(...)`, then solve with
+  `m.solve(decomposition="benders")` (also handles convex nonlinear recourse via
+  GBD) or `m.solve(decomposition="lagrangian")` for a dual bound. `m.solve(
+  lagrangian_bound=True)` adds a per-node Lagrangian bound to ordinary B&B.
+  Use `discopt.detect_decomposition(m)` to check whether structure is present.
 
 ### Redundant Constraints
 - Check for constraints implied by variable bounds


### PR DESCRIPTION
Brings the packaged Claude Code skills (`python/discopt/skills/`, installed via `discopt install-skills`) up to date with the current solver capabilities and the latest skill-authoring recommendations.

## Slash commands (`.claude/commands/`)
- **Added YAML frontmatter** (`description`, `argument-hint`, `allowed-tools`) to every command — they previously had none. Confirmed against current Claude Code docs and validated that all values parse as proper YAML strings.
- **New `/debug` command** — a dedicated troubleshooting playbook, distinct from `/diagnose` (which interprets a *successful* `SolveResult`). Covers install/env checks (`discopt about`/`test`), daemon issues (`status`/`kill`/`--no-daemon`/`--hard-timeout`), IIS-based infeasibility (`compute_iis`), NLP/numerical failures, wrong answers, slow solves, and crashes, with a reproduce → narrow → fix → verify structure.
- **Taught the commands the discopt CLI**: `solve` (`--format json`, `--profile`, daemon), `convert` (`.gms/.nl/.mps/.lp`), `doe` workbook campaigns, `run_benchmarks.py`.
- **Surfaced new capabilities**: IIS, FBBT bound tightening, RLT/PSD cuts, pooling pq-cuts, geometric programming, complementarity/MPEC, Benders/Lagrangian decomposition, sets & indexing, and current `m.solve()` options. Corrected stale references (the nonexistent `gpu=` kwarg → `JAX_PLATFORMS` env var; Ipopt-only kwargs gated on `nlp_solver="ipopt"`).

## Agents (`.claude/agents/`)
- Added required `name`/`description` frontmatter to `highs-expert` and `scip-expert` (the only two of 22 agents missing it).
- Fixed `llm-feature-expert`'s shipped-command list (dropped dev-only `adversary`/`discoptbot`, added `debug`).

## Docs / packaging
- Updated `claude-skills/README.md` command/agent tables to match what actually ships.
- Fixed the stale `iter_commands()` doctest in `skills/__init__.py`.

## Verification
- Frontmatter parses as valid YAML strings across all commands and agents.
- `debug.md` is discovered by `iter_commands()`; all agents have frontmatter.
- The `test_cli_install_skills` invariants still hold (≥5 commands, no `adversary`/`discoptbot`, agents alphabetical).
- Every referenced API name was checked against the source (`compute_iis`/`IISResult`, `tightening.fbbt_box`, `gp.classify_gp`/`solve_gp`, `Model.set`/`second_stage`/`complementarity`, `decomposition`/`rlt`/`psd_cuts`/`gdp_method` kwargs, `dm.Skip`).

Note: `pytest`/`numpy` aren't installed in the dev container, so validation was done via direct filesystem/YAML checks rather than the test runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4feE7t5u3DWgFheqNHMnb)_