### PR TITLE
perf(milp): feed strong-branch probes into pseudocosts + trim SB budget (#332)

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -589,6 +589,11 @@ struct NodeCtx<'a> {
     tm: &'a TreeManager,
 }
 
+/// One strong-branch pseudocost sample harvested from a probe:
+/// `(var_index, frac, Δobj, is_down)`. Fed into the shared pseudocost tracker so
+/// the reliability mechanism can graduate the variable. See [`strong_branch`].
+type SbObservation = (usize, f64, f64, bool);
+
 /// The product of one node's evaluation, applied to the tree later in the
 /// sequential reduce (in batch order). Keeping every tree mutation out of the
 /// parallel region is what preserves determinism: parallelism changes only
@@ -608,7 +613,7 @@ struct NodeOutput {
     /// in the sequential reduce (batch order) so the reliability mechanism can
     /// graduate these variables and stop re-probing them. Empty when the node did
     /// no strong branching.
-    sb_observations: Vec<(usize, f64, f64, bool)>,
+    sb_observations: Vec<SbObservation>,
     /// Simplex pivots spent on this node (LP solve + strong-branch probes).
     iters: usize,
     /// Relaxation was unbounded — the whole search terminates.
@@ -895,7 +900,7 @@ fn strong_branch(
     x: &[f64],
     node_obj: f64,
     cands: &[(usize, f64, u32, f64)],
-) -> (Option<usize>, usize, Vec<(usize, f64, f64, bool)>) {
+) -> (Option<usize>, usize, Vec<SbObservation>) {
     let simplex = ctx.simplex;
     // Unreliable candidates, most-fractional (nearest 0.5) first.
     let mut cand: Vec<(usize, f64)> = cands
@@ -972,7 +977,7 @@ fn strong_branch(
     // instead of being re-probed every time it turns up fractional. Infeasible /
     // non-optimal probes are excluded — a pruned child is a branching signal, not
     // a finite degradation sample, and feeding it would corrupt the average.
-    let mut obs: Vec<(usize, f64, f64, bool)> = Vec::new();
+    let mut obs: Vec<SbObservation> = Vec::new();
     for (idx, _f) in cand {
         let xi = x[idx];
         let (lo0, hi0) = (orig_l[idx], orig_u[idx]);

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -454,6 +454,13 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
             if let Some(v) = out.branch_hint {
                 tm.set_branch_hint(id, v);
             }
+            // Feed this node's strong-branch probes into the shared pseudocosts,
+            // in batch order, so the reliability mechanism graduates those
+            // variables and stops re-probing them at later nodes. Selection-only:
+            // never affects a bound, so determinism and soundness hold.
+            if !out.sb_observations.is_empty() {
+                tm.record_sb_observations(&out.sb_observations);
+            }
             // Dedup this node's cuts against the shared pool *in order*, with the
             // same room check the serial path applied, so the pool is identical.
             if !out.found_cuts.is_empty() && pool_sigs.len() < opts.max_pool_cuts {
@@ -596,6 +603,12 @@ struct NodeOutput {
     found_cuts: Vec<GomoryCut>,
     /// Strong-branching variable hint.
     branch_hint: Option<usize>,
+    /// Pseudocost samples harvested from the strong-branch probes at this node,
+    /// each `(var, frac, Δobj, is_down)`. Applied to the shared pseudocost tracker
+    /// in the sequential reduce (batch order) so the reliability mechanism can
+    /// graduate these variables and stop re-probing them. Empty when the node did
+    /// no strong branching.
+    sb_observations: Vec<(usize, f64, f64, bool)>,
     /// Simplex pivots spent on this node (LP solve + strong-branch probes).
     iters: usize,
     /// Relaxation was unbounded — the whole search terminates.
@@ -639,6 +652,7 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             incumbent: None,
             found_cuts: Vec::new(),
             branch_hint: None,
+            sb_observations: Vec::new(),
             iters: 0,
             unbounded: false,
             uncertified: true,
@@ -742,6 +756,7 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
         incumbent: None,
         found_cuts: Vec::new(),
         branch_hint: None,
+        sb_observations: Vec::new(),
         iters: sol.iters,
         unbounded: false,
         uncertified: false,
@@ -824,10 +839,11 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
                 if !prunable {
                     let _t = crate::profile::Timer::new(crate::profile::Phase::StrongBranch);
                     let cands = ctx.tm.score_candidates(xs);
-                    let (best, piv) =
+                    let (best, piv, sb_obs) =
                         strong_branch(ctx, &full_l, &full_u, &sol.basis, &sol.x, sol.obj, &cands);
                     out.iters += piv;
                     out.branch_hint = best;
+                    out.sb_observations = sb_obs;
                 }
             }
             out.result = NodeResult {
@@ -879,7 +895,7 @@ fn strong_branch(
     x: &[f64],
     node_obj: f64,
     cands: &[(usize, f64, u32, f64)],
-) -> (Option<usize>, usize) {
+) -> (Option<usize>, usize, Vec<(usize, f64, f64, bool)>) {
     let simplex = ctx.simplex;
     // Unreliable candidates, most-fractional (nearest 0.5) first.
     let mut cand: Vec<(usize, f64)> = cands
@@ -888,7 +904,7 @@ fn strong_branch(
         .map(|c| (c.0, c.1))
         .collect();
     if cand.is_empty() {
-        return (None, 0);
+        return (None, 0, Vec::new());
     }
     cand.sort_by(|a, c| {
         (c.1 - 0.5)
@@ -949,9 +965,18 @@ fn strong_branch(
     let mut best: Option<usize> = None;
     let mut best_score = f64::NEG_INFINITY;
     let mut pivots = 0usize;
+    // Exact pseudocost samples harvested from the probes: `(var, frac, Δobj,
+    // is_down)`. Each optimal probe *is* a pseudocost observation (the canonical
+    // reliability-branching feedback); recording them lets a variable reach the
+    // reliability threshold and drop out of strong branching at later nodes,
+    // instead of being re-probed every time it turns up fractional. Infeasible /
+    // non-optimal probes are excluded — a pruned child is a branching signal, not
+    // a finite degradation sample, and feeding it would corrupt the average.
+    let mut obs: Vec<(usize, f64, f64, bool)> = Vec::new();
     for (idx, _f) in cand {
         let xi = x[idx];
         let (lo0, hi0) = (orig_l[idx], orig_u[idx]);
+        let frac = xi - xi.floor();
 
         // Down branch: x_idx ≤ floor(x_idx).
         u[idx] = xi.floor();
@@ -959,7 +984,11 @@ fn strong_branch(
         u[idx] = hi0;
         pivots += dn.iters;
         let d_dn = match dn.status {
-            LpStatus::Optimal => (dn.obj - node_obj).max(0.0),
+            LpStatus::Optimal => {
+                let d = (dn.obj - node_obj).max(0.0);
+                obs.push((idx, frac, d, true));
+                d
+            }
             LpStatus::Infeasible => INFEAS_DELTA,
             _ => 0.0,
         };
@@ -970,7 +999,11 @@ fn strong_branch(
         l[idx] = lo0;
         pivots += up.iters;
         let d_up = match up.status {
-            LpStatus::Optimal => (up.obj - node_obj).max(0.0),
+            LpStatus::Optimal => {
+                let d = (up.obj - node_obj).max(0.0);
+                obs.push((idx, frac, d, false));
+                d
+            }
             LpStatus::Infeasible => INFEAS_DELTA,
             _ => 0.0,
         };
@@ -981,7 +1014,7 @@ fn strong_branch(
             best = Some(idx);
         }
     }
-    (best, pivots)
+    (best, pivots, obs)
 }
 
 /// Append `cuts` (each `coeffs·x ≥ rhs`, coeffs length `n_w`) to the working LP

--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -675,6 +675,21 @@ impl TreeManager {
         self.reliability_threshold
     }
 
+    /// Fold strong-branching probe results into the pseudocost tracker. Each
+    /// optimal probe is an exact pseudocost observation `(var, frac, Δobj,
+    /// is_down)`; recording them (in addition to the retroactive child-result
+    /// updates) is the reliability-branching feedback loop that lets a probed
+    /// variable reach the reliability threshold and stop being re-probed. The
+    /// delta is passed as `child_lb - parent_lb` with `parent_lb = 0`, matching
+    /// `Pseudocosts::update`'s use of only the difference. Affects branching
+    /// variable *selection* only — never a bound — so soundness is untouched.
+    pub fn record_sb_observations(&mut self, obs: &[(usize, f64, f64, bool)]) {
+        for &(var_index, frac, delta, is_down) in obs {
+            self.pseudocosts
+                .update(var_index, 0.0, delta, frac, is_down);
+        }
+    }
+
     /// Inject an externally-found incumbent (e.g. from a primal heuristic).
     ///
     /// Updates the incumbent only if `obj_val` is strictly better than the

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -406,7 +406,11 @@ pub fn solve_lp_batch_py<'py>(
     ub: PyReadonlyArray2<'py, f64>,
     tol: f64,
     max_iter: usize,
-) -> PyResult<(Vec<String>, Bound<'py, PyArray2<f64>>, Bound<'py, PyArray1<f64>>)> {
+) -> PyResult<(
+    Vec<String>,
+    Bound<'py, PyArray2<f64>>,
+    Bound<'py, PyArray1<f64>>,
+)> {
     let dims = a.shape();
     let (m, n) = (dims[0], dims[1]);
     let k = b.shape()[0];
@@ -477,7 +481,7 @@ pub fn solve_lp_batch_py<'py>(
 #[pyo3(signature = (c, a, b, lb, ub, integer_cols, n_struct, obj_const=0.0,
                     max_nodes=1_000_000, gap_tol=1e-6, tol=1e-9, root_cuts=16,
                     cut_rounds=1, node_cuts=false, max_pool_cuts=128, heuristics=true,
-                    presolve=true, strong_branch=true, sb_max_cands=8, sb_node_budget=128,
+                    presolve=true, strong_branch=true, sb_max_cands=6, sb_node_budget=48,
                     time_limit_s=0.0))]
 pub fn solve_milp_py<'py>(
     py: Python<'py>,


### PR DESCRIPTION
## Summary

Continues the sparse-MILP performance work on #332. After the root-node warm-start (#338), the profiling harness pinned the residual cost to **strong branching** — on sc4000 it was ~62% of the B&B work (18s thread-time), dwarfing the node LP solves.

**Root inefficiency:** every strong-branch probe computes an exact objective degradation for a candidate's up/down child — i.e. an exact *pseudocost observation* — but the result was discarded after scoring. Variables only accumulated pseudocost data from actual branchings (one sample per branch), so they never reached the reliability threshold and got re-probed every time they turned up fractional. This is the canonical reliability-branching feedback loop, simply missing.

## Changes

1. **Record the probes.** `strong_branch` now returns its optimal-probe deltas as pseudocost samples `(var, frac, Δobj, is_down)`; the sequential reduce folds them into the shared tracker in batch order via `record_sb_observations`. Infeasible/non-optimal probes are excluded (a pruned child is a branching signal, not a finite degradation sample). **Selection-only** — it changes which variable is branched, never a bound — so determinism and soundness are untouched. This alone cut nodes 28–36% on the covering set (better branching).

2. **Trim the SB budget** now that pseudocosts mature within the first few dozen nodes: `sb_max_cands` 8→6 and `sb_node_budget` 128→48 (binding default). The richer pseudocosts make the heavy SB budget pure overhead.

## Results (engine vs SCIP, TL=30s; baseline = #338 warm-start, now on main)

| instance | before | after | vs SCIP |
|---|---|---|---|
| sc1000x500 | 1.09s | **0.59s** | 0.8× → **0.4× (2.5× faster than SCIP)** |
| sc2000x800 | 4.71s | **2.57s** | 2.7× → 1.4× |
| sc4000x1500 | 10.32s | **4.20s** | 2.9× → **1.3× (near parity)** |

Node counts drop too (sc4000 549 → 239). **Robust across seeds** — `6/48` wins or ties on sc4000 seeds 3/7/11. Dense (knapsack/GAP) and set-packing are unchanged.

## Soundness & tests

- Covering optima still match SCIP exactly (910 / 1832 / 2232 / 4090).
- 335 discopt-core + 296 Python MILP/simplex/branch + 42 benchmark correctness — all green.

## Follow-up

sc4000 seed=11 remains hard for both discopt and SCIP (both feasible-not-optimal at 40s / 24s). The remaining gap on the hardest covering instances is cut strength / presolve, a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
