### PR TITLE
Reject non-finite LP data before HiGHS

### DIFF
--- a/python/discopt/_jax/problem_classifier.py
+++ b/python/discopt/_jax/problem_classifier.py
@@ -116,6 +116,24 @@ class LPData(NamedTuple):
     obj_const: float = 0.0  # constant term in objective
 
 
+def _validate_lp_data(data: LPData) -> LPData:
+    """Reject LP data that is unsafe to pass to native solver backends."""
+    finite_fields = {
+        "c": np.asarray(data.c),
+        "A_eq": np.asarray(data.A_eq),
+        "b_eq": np.asarray(data.b_eq),
+    }
+    for name, arr in finite_fields.items():
+        if not np.all(np.isfinite(arr)):
+            raise _NotLinearError(f"LP extraction produced non-finite {name}.")
+    if not np.isfinite(float(data.obj_const)):
+        raise _NotLinearError("LP extraction produced non-finite objective constant.")
+    for name, arr in (("x_l", np.asarray(data.x_l)), ("x_u", np.asarray(data.x_u))):
+        if np.any(np.isnan(arr)):
+            raise _NotLinearError(f"LP extraction produced NaN {name}.")
+    return data
+
+
 class QPData(NamedTuple):
     """Standard-form QP: min 0.5 x'Qx + c'x + d s.t. A_eq x = b_eq, bounds."""
 
@@ -1170,12 +1188,12 @@ def extract_lp_data(model: Model) -> LPData:
     _builder = getattr(model, "_builder", None)
     if _builder is not None:
         try:
-            return _extract_lp_data_from_repr(model)
+            return _validate_lp_data(_extract_lp_data_from_repr(model))
         except Exception:
             pass
 
     try:
-        return extract_lp_data_algebraic(model)
+        return _validate_lp_data(extract_lp_data_algebraic(model))
     except (_NotLinearError, Exception):
         pass
 
@@ -1185,11 +1203,11 @@ def extract_lp_data(model: Model) -> LPData:
     # algebraic DAG walk can't run — skip the per-primitive eager-JAX autodiff
     # path (orders of magnitude faster on small instances; see #330).
     try:
-        return _extract_lp_data_from_repr(model)
+        return _validate_lp_data(_extract_lp_data_from_repr(model))
     except Exception:
         pass
 
-    return _extract_lp_data_autodiff(model)
+    return _validate_lp_data(_extract_lp_data_autodiff(model))
 
 
 def _extract_lp_data_autodiff(model: Model) -> LPData:

--- a/python/discopt/solvers/lp_highs.py
+++ b/python/discopt/solvers/lp_highs.py
@@ -71,6 +71,15 @@ def _build_constraint_matrix(
     return row_lower, row_upper, combined, m
 
 
+def _require_finite(name: str, value: Union[np.ndarray, sp.spmatrix]) -> None:
+    if sp.issparse(value):
+        arr = np.asarray(value.data, dtype=np.float64)
+    else:
+        arr = np.asarray(value, dtype=np.float64)
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} contains non-finite values")
+
+
 def solve_lp(
     c: np.ndarray,
     A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
@@ -107,6 +116,7 @@ def solve_lp(
     """
     c_arr = np.asarray(c, dtype=np.float64).ravel()
     n = len(c_arr)
+    _require_finite("c", c_arr)
 
     # ---- validate dimensions ------------------------------------------------
     if A_ub is not None:
@@ -118,6 +128,8 @@ def solve_lp(
         b_ub_arr = np.asarray(b_ub).ravel()
         if b_ub_arr.shape[0] != shape[0]:
             raise ValueError(f"A_ub has {shape[0]} rows but b_ub has {b_ub_arr.shape[0]} elements")
+        _require_finite("A_ub", A_ub)
+        _require_finite("b_ub", b_ub_arr)
     if A_eq is not None:
         shape = A_eq.shape if sp.issparse(A_eq) else np.asarray(A_eq).shape
         if len(shape) != 2 or shape[1] != n:
@@ -127,6 +139,8 @@ def solve_lp(
         b_eq_arr = np.asarray(b_eq).ravel()
         if b_eq_arr.shape[0] != shape[0]:
             raise ValueError(f"A_eq has {shape[0]} rows but b_eq has {b_eq_arr.shape[0]} elements")
+        _require_finite("A_eq", A_eq)
+        _require_finite("b_eq", b_eq_arr)
     if bounds is not None and len(bounds) != n:
         raise ValueError(f"bounds has {len(bounds)} entries but c has {n} elements")
 
@@ -138,6 +152,8 @@ def solve_lp(
     else:
         col_lower = np.zeros(n, dtype=np.float64)
         col_upper = np.full(n, inf, dtype=np.float64)
+    if np.any(np.isnan(col_lower)) or np.any(np.isnan(col_upper)):
+        raise ValueError("bounds contain NaN values")
 
     # Very large finite bounds (~1e19) fall just below HiGHS's internal
     # infinity threshold (~1e20) and can cause numerical issues. Translate

--- a/python/tests/test_lp_highs.py
+++ b/python/tests/test_lp_highs.py
@@ -267,6 +267,14 @@ class TestDimensionMismatch:
                 A_eq=np.array([[1.0]]),
             )
 
+    def test_non_finite_matrix_rejected_before_highs(self):
+        with pytest.raises(ValueError, match="A_eq contains non-finite values"):
+            solve_lp(
+                c=np.array([1.0]),
+                A_eq=np.array([[np.nan]]),
+                b_eq=np.array([0.0]),
+            )
+
 
 # ---------------------------------------------------------------------------
 # 10. Dual values


### PR DESCRIPTION
## Summary

Reject invalid LP data before it reaches native HiGHS calls.

This adds two layers of protection:

- `extract_lp_data` validates returned `LPData` and rejects non-finite objective, equality matrix, RHS, and objective constant data, while still allowing infinite bounds and rejecting NaN bounds.
- `solve_lp` performs a final defensive finite-value check on objective, constraint, and RHS arrays before calling `Highs.run()`.

The issue was found while testing a downstream GOA branch, but the bug is in the general LP path and can crash the Python process if NaN matrix data is passed into HiGHS.

Closes #342.

## Tests

- `PYTHONPATH=python pytest python/tests/test_dae_fd_mol.py::TestMOLCollocation::test_mol_collocation_solves python/tests/test_lp_highs.py::TestDimensionMismatch::test_non_finite_matrix_rejected_before_highs -q -vv --tb=short`
- `PYTHONPATH=python pytest python/tests/test_lp_highs.py -q --tb=short`
- `python -m ruff check python/discopt/_jax/problem_classifier.py python/discopt/solvers/lp_highs.py python/tests/test_lp_highs.py`
- `python -m ruff format --check python/discopt/_jax/problem_classifier.py python/discopt/solvers/lp_highs.py python/tests/test_lp_highs.py`
- `git diff --check upstream/main...HEAD`
- `pre-commit run --files python/discopt/_jax/problem_classifier.py python/discopt/solvers/lp_highs.py python/tests/test_lp_highs.py`

Local pytest emitted the existing read-only JAX persistent-cache warnings in this environment. The tests passed.

## Branch Hygiene

- Base branch: `jkitchin/discopt:main`.
- Head branch: `bernalde/discopt:fix/lp-nonfinite-highs-342`.
- Source branch point: `jkitchin/discopt:main@60e3fe3`.
- Stacked status: not stacked; this branch contains one LP-specific commit on upstream `main`.
- Related downstream PR waiting on this split: bernalde/discopt#129.