### PR TITLE
fix(deps): pin feral to the #89-fix rev — restore sparse set-covering (#332)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,8 +78,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "feral"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7695a95dae6fdef1d1923752d70bd992d42b7ce4f8f7b23fe48e01bd463301d"
+source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -96,8 +95,7 @@ dependencies = [
 [[package]]
 name = "feral-amd"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead2f064dbcef0e0d3110202e9d6d7c293c1dffe6da5964513a20c5967e4d560"
+source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -105,8 +103,7 @@ dependencies = [
 [[package]]
 name = "feral-amf"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ea6dacabfa085e7f40080c894da245d9db60e9211f1f8ab08d715d6d0f5a29"
+source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -114,8 +111,7 @@ dependencies = [
 [[package]]
 name = "feral-kahip"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ba0d001a63e777227de4565c7f4cd14062b9fbe83d3cadcb292be74410b4f4"
+source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -125,8 +121,7 @@ dependencies = [
 [[package]]
 name = "feral-metis"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b34963682eaf680479bfd6018a5570bfd1ed9c1f05d8bf085ab49f13b308cb"
+source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -135,14 +130,12 @@ dependencies = [
 [[package]]
 name = "feral-ordering-core"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca94ad929e23c0adaa6edda42474aa71b5b2bfb3930b1f6b202e4b37c8e9b763"
+source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
 
 [[package]]
 name = "feral-scotch"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51fe24bffbef76e88803e801c2d8977f5d304dd6af43f70c1e91fdfabd0b530"
+source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -9,8 +9,16 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 [dependencies]
 # feral: pure-Rust sparse linear algebra. Provides the unsymmetric LU basis
 # engine (ftran/btran + product-form column updates) that backs the warm-started
-# simplex node engine for MILP. Pure-Rust, so clean-wheel builds are preserved.
-feral = "0.11"
+# simplex node engine for MILP.
+#
+# PINNED to this git rev — do NOT move to the crates.io release (currently 0.11.2)
+# without re-benchmarking sparse MILP. This rev carries the issue-#89 fix
+# (`u_above` reindex, O(m³)→O(m²) on many-row bases) that the published 0.11.x
+# does not. #341 switched to `feral = "0.11"` and silently regressed set-covering
+# from ~3s to a >30s timeout (sc2000/sc4000) — the LU refactor went quadratic→cubic
+# in the row count, invisible on few-row knapsacks but catastrophic on 800–1500-row
+# covering LPs. Re-point at crates.io only once a release includes the #89 fix.
+feral = { git = "https://github.com/jkitchin/feral", rev = "a5c789f92d928446b2373af434268adb800c2f10" }
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to
 # 1.10 to keep the crate's MSRV (1.75); 1.12+ requires rustc 1.80.

--- a/discopt_benchmarks/tests/test_setcover_lp_regression.py
+++ b/discopt_benchmarks/tests/test_setcover_lp_regression.py
@@ -1,0 +1,91 @@
+"""Regression guard for the sparse set-covering LP path (issues #332 / #341).
+
+A many-row set-covering MILP is the canonical sparse instance: its warm-started
+node LPs stress the `feral` sparse-LU refactor, whose cost is O(m²) per refactor
+*only* with the issue-#89 `u_above` reindex fix. Without that fix the refactor is
+O(m³) in the row count — invisible on few-row knapsacks but catastrophic on the
+800+ row covering LPs, where it turned a ~3 s solve into a >30 s timeout (#341
+moved `feral` to the crates.io 0.11.x release, which lacks the fix; reverting to
+the pinned git rev restored it).
+
+This test pins that behaviour: a 2000-col / 800-row covering instance must solve
+to **proven optimality** (not merely feasible at the deadline) with the known
+objective, inside a deadline generous enough to be healthy-fast but far below the
+regressed timeout. It asserts a *status* + *objective*, not a wall-clock number,
+so it is not timing-flaky — a feral LU regression flips optimal→feasible and trips
+it; a marginally slower machine does not.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.regression
+
+dm = pytest.importorskip("discopt.modeling")
+_rust = pytest.importorskip("discopt._rust")
+if not hasattr(_rust, "solve_milp_py"):
+    pytest.skip("discopt._rust.solve_milp_py unavailable", allow_module_level=True)
+
+
+def _gen_setcover(ncol: int, nrow: int, seed: int, per_col: int = 6):
+    """Deterministic random set-covering model (each column covers ~per_col rows)."""
+    rng = np.random.default_rng(seed)
+    cols = [rng.choice(nrow, size=per_col, replace=False) for _ in range(ncol)]
+    r2c: dict[int, list[int]] = {i: [] for i in range(nrow)}
+    for j, c in enumerate(cols):
+        for i in c:
+            r2c[i].append(j)
+    for i in range(nrow):
+        if not r2c[i]:
+            r2c[i].append(int(rng.integers(0, ncol)))
+    cost = rng.integers(1, 100, ncol).astype(float)
+    m = dm.Model(f"sc{ncol}x{nrow}")
+    x = m.binary("x", shape=(ncol,))
+    m.minimize(dm.sum(lambda j: cost[j] * x[j], over=range(ncol)))
+    m.subject_to([dm.sum(lambda j: x[j], over=r2c[i]) >= 1 for i in range(nrow)], name="cov")
+    return m
+
+
+def _solve_engine(model, time_limit_s: float):
+    """Call the Rust MILP engine directly (no Python budget cap), like the bench."""
+    from discopt._jax.problem_classifier import extract_lp_data
+    from discopt.solver import _extract_variable_info
+
+    lp = extract_lp_data(model)
+    n_orig = sum(v.size for v in model._variables)
+    _, _, _, ioff, isz = _extract_variable_info(model)
+    int_idx = [j for off, s in zip(ioff, isz, strict=False) for j in range(off, off + int(s))]
+    args = (
+        np.ascontiguousarray(lp.c, dtype=np.float64),
+        np.ascontiguousarray(lp.A_eq, dtype=np.float64),
+        np.ascontiguousarray(lp.b_eq, dtype=np.float64),
+        np.ascontiguousarray(lp.x_l, dtype=np.float64),
+        np.ascontiguousarray(lp.x_u, dtype=np.float64),
+        np.ascontiguousarray(np.asarray(int_idx, dtype=np.int64)),
+        n_orig,
+        float(lp.obj_const),
+        5_000_000,
+        1e-6,
+    )
+    status, _x, obj, _bound, _nodes, _ = _rust.solve_milp_py(*args, time_limit_s=time_limit_s)
+    return status, obj
+
+
+def test_setcover_2000x800_solves_to_optimality():
+    """sc2000x800 must prove optimality (obj=2232) well inside the deadline.
+
+    Healthy: ~3 s. A feral-LU regression (O(m³) refactor) blows this past 30 s and
+    the engine returns 'feasible' at the deadline instead of 'optimal' — the
+    assertion below flips and fails. The 20 s deadline is ~6× the healthy solve and
+    far below the regressed timeout, so it is robust to machine-speed variation.
+    """
+    model = _gen_setcover(2000, 800, seed=3)
+    status, obj = _solve_engine(model, time_limit_s=20.0)
+    assert status == "optimal", (
+        f"expected proven optimality, got {status!r} — a sparse-LP (feral LU) "
+        f"regression makes the covering node solves O(m³) and the engine only "
+        f"reaches a feasible point by the deadline. See Cargo.toml feral pin."
+    )
+    assert abs(obj - 2232.0) <= 1e-4 * (1 + 2232.0), f"wrong optimum {obj} (expected 2232)"


### PR DESCRIPTION
## Summary

**Fixes a severe, silent regression that #341 introduced on sparse set-covering (#332).**

#341 (issue #331, knapsack node-efficiency) moved the `feral` dependency from the pinned git rev `a5c789f` to the crates.io release (`feral = "0.11"`, currently 0.11.2). That published version **lacks the issue-#89 fix** — the `u_above` reindex that makes the sparse-LU refactor **O(m²) instead of O(m³)** in the row count.

The covering instances (#332) have 800–1500-row node LPs, so the O(m³) refactor dominates and the solve falls off a cliff. Knapsack LPs (8–25 rows) are unaffected — which is exactly why #341's knapsack-only benches never saw it.

| instance | #340 (pinned) | main / #341 | **this fix** |
|---|---|---|---|
| sc1000x500 | 0.57s opt | 3.54s opt (6.2×) | **0.48s opt** |
| sc2000x800 | 2.49s opt | **30.6s FEASIBLE (timeout)** | **2.91s opt** |
| sc4000x1500 | 4.26s opt | **31.1s FEASIBLE (timeout)** | **10.3s opt** |

## How it was diagnosed

Clean rebuilds of both commits (the first attempt was confounded by stale build artifacts across #341's `Cargo.lock` change — caught and corrected). The only difference between fast and slow is the `feral` dependency; **pivot counts are identical**, per-pivot ftran/btran cost is not — a classic LU-refactor complexity regression scaling with row count.

## What this changes

- **Dependency only.** Reverts `feral` to the `a5c789f` rev. It does **not** touch #341's solver code or option defaults, so #341's knapsack gains are fully preserved (mdk250x10 1.3s vs the old 4.6s, reduced-cost fixing intact).
- **Cargo.toml comment** explains why the pin must not be moved back to crates.io until a release carries the #89 fix (you're the feral maintainer — publishing a fixed release is the clean long-term path, after which this can re-point at crates.io).
- **Regression guard** (`test_setcover_lp_regression.py`): solves a 2000×800 covering instance and asserts *proven optimality* (obj=2232) within a 20 s deadline. It's a status+objective assertion, not a wall-clock one, so it's not timing-flaky — a feral LU regression flips optimal→feasible and trips it. The gap that let #341 through was the absence of any set-covering test (the perf bench is knapsack-only).

## Tests

- 340 `discopt-core` tests + the new regression guard, green.
- Covering restored to optimal; knapsack gains preserved.

## Note (not in this PR)

`reduced_cost_fixing=true` (a #341 default) is an intentional knapsack/covering tradeoff: it makes mdk250 3.5× faster but large covering ~2.4× slower (sc4000 10.3s vs 4.1s with it off). Left as-is here since it's #341's deliberate tuning and sc4000 still solves optimally; making it adaptive (on for dense, off for sparse) is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
