### PR TITLE
perf(milp): sparse reduced-cost fixing + feral 0.11.3 — fix #341 covering fallout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,8 +77,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "feral"
-version = "0.11.2"
-source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "737271f4c9f92a85444ea8142c6d10fc35a7521fc80a0b228614861f5316a438"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -95,7 +96,8 @@ dependencies = [
 [[package]]
 name = "feral-amd"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead2f064dbcef0e0d3110202e9d6d7c293c1dffe6da5964513a20c5967e4d560"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -103,7 +105,8 @@ dependencies = [
 [[package]]
 name = "feral-amf"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ea6dacabfa085e7f40080c894da245d9db60e9211f1f8ab08d715d6d0f5a29"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -111,7 +114,8 @@ dependencies = [
 [[package]]
 name = "feral-kahip"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ba0d001a63e777227de4565c7f4cd14062b9fbe83d3cadcb292be74410b4f4"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -121,7 +125,8 @@ dependencies = [
 [[package]]
 name = "feral-metis"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b34963682eaf680479bfd6018a5570bfd1ed9c1f05d8bf085ab49f13b308cb"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -130,12 +135,14 @@ dependencies = [
 [[package]]
 name = "feral-ordering-core"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca94ad929e23c0adaa6edda42474aa71b5b2bfb3930b1f6b202e4b37c8e9b763"
 
 [[package]]
 name = "feral-scotch"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a5c789f92d928446b2373af434268adb800c2f10#a5c789f92d928446b2373af434268adb800c2f10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51fe24bffbef76e88803e801c2d8977f5d304dd6af43f70c1e91fdfabd0b530"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -11,14 +11,14 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # engine (ftran/btran + product-form column updates) that backs the warm-started
 # simplex node engine for MILP.
 #
-# PINNED to this git rev — do NOT move to the crates.io release (currently 0.11.2)
-# without re-benchmarking sparse MILP. This rev carries the issue-#89 fix
-# (`u_above` reindex, O(m³)→O(m²) on many-row bases) that the published 0.11.x
-# does not. #341 switched to `feral = "0.11"` and silently regressed set-covering
-# from ~3s to a >30s timeout (sc2000/sc4000) — the LU refactor went quadratic→cubic
-# in the row count, invisible on few-row knapsacks but catastrophic on 800–1500-row
-# covering LPs. Re-point at crates.io only once a release includes the #89 fix.
-feral = { git = "https://github.com/jkitchin/feral", rev = "a5c789f92d928446b2373af434268adb800c2f10" }
+# Floor is 0.11.3 — do NOT downgrade below it. 0.11.3 is the first crates.io
+# release carrying the issue-#89 fix (`u_above` reindex, O(m³)→O(m²) on many-row
+# bases). Earlier 0.11.x (≤0.11.2) lack it: #341 used `feral = "0.11"`, picked up
+# 0.11.2, and silently regressed set-covering from ~3s to a >30s timeout
+# (sc2000/sc4000) — the LU refactor went quadratic→cubic in the row count,
+# invisible on few-row knapsacks but catastrophic on 800–1500-row covering LPs.
+# `test_setcover_lp_regression.py` guards against a re-downgrade.
+feral = "0.11.3"
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to
 # 1.10 to keep the crate's MSRV (1.75); 1.12+ requires rustc 1.80.

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -21,7 +21,8 @@ use crate::lp::basis::{Basis, AT_LOWER, AT_UPPER, BASIC};
 use crate::lp::cover::separate_cover;
 use crate::lp::crossover::LpView;
 use crate::lp::cut_select::select_cuts;
-use crate::lp::gomory::{separate_gomory, solve_dense, GomoryCut};
+use crate::lp::gomory::{separate_gomory, GomoryCut};
+use crate::lp::simplex::linsolve::{FeralLU, LinearSolver};
 use crate::lp::simplex::sparse::SparseCols;
 use crate::lp::simplex::{
     solve_lp, solve_lp_scaled, solve_lp_warm, solve_lp_warm_scaled_csc, tighten_bounds, LpStatus,
@@ -404,6 +405,14 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
         // in this batch (the matrix is constant within a batch). This lifts the
         // per-node `SparseCols::from_dense` O(m·n) rebuild out of the warm solve.
         let csc_batch = SparseCols::from_dense(sa, m_w, n_w);
+        // Reduced-cost fixing needs the *unscaled* duals/reduced costs (the integer
+        // bound fixing reasons in true objective units), so it gets the CSC of the
+        // unscaled working matrix. When the matrix isn't scaled this is exactly
+        // `csc_batch` (no second build); otherwise build it once for the batch.
+        let csc_unscaled_owned = scaling
+            .as_ref()
+            .map(|_| SparseCols::from_dense(&a_w, m_w, n_w));
+        let csc_rc: &SparseCols = csc_unscaled_owned.as_ref().unwrap_or(&csc_batch);
         let sb_active = opts.strong_branch && tm.stats().total_nodes < opts.sb_node_budget;
         let mut results = Vec::with_capacity(batch.node_ids.len());
         let mut pending_cuts: Vec<GomoryCut> = Vec::new();
@@ -431,6 +440,7 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
                 sc,
                 sb,
                 csc: &csc_batch,
+                csc_rc,
                 slack_l: &slack_l,
                 slack_u: &slack_u,
                 is_int: &is_int,
@@ -619,6 +629,13 @@ struct NodeCtx<'a> {
     /// solve. Built from `sa`, so it matches whichever (scaled or raw) matrix the
     /// node solves see.
     csc: &'a SparseCols,
+    /// CSC view of the **unscaled** working matrix `a_w`, for reduced-cost fixing
+    /// (which reasons in true objective units, so it needs unscaled duals/reduced
+    /// costs). Equals `csc` when the matrix isn't scaled. Lets `reduced_cost_fix`
+    /// compute the node duals via the sparse LU (btran, O(nnz)) instead of a dense
+    /// O(m³) refactor — the asymmetry that made it cheap on knapsack but ruinous
+    /// on many-row covering LPs.
+    csc_rc: &'a SparseCols,
     slack_l: &'a [f64],
     slack_u: &'a [f64],
     is_int: &'a [bool],
@@ -914,9 +931,8 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             // contraction — never touches the node's own valid LP bound.
             if ctx.opts.reduced_cost_fixing && !feasible {
                 if let Some((rl, ru)) = reduced_cost_fix(
-                    ctx.a_w,
+                    ctx.csc_rc,
                     ctx.m_w,
-                    ctx.n_w,
                     ctx.c_w,
                     &sol.basis,
                     sol.obj + ctx.obj_const,
@@ -1193,9 +1209,8 @@ fn strong_branch(
 /// a singular/ill-conditioned basis solve returns `None` (no fixing).
 #[allow(clippy::too_many_arguments)]
 fn reduced_cost_fix(
-    a: &[f64],
+    sp: &SparseCols,
     m: usize,
-    n: usize,
     c: &[f64],
     basis: &Basis,
     node_obj: f64,
@@ -1216,17 +1231,26 @@ fn reduced_cost_fix(
         return None; // node should be pruned anyway; nothing improving here
     }
 
-    // Bᵀ (row-major m×m): row k is basis column basic_vars[k]; rhs is c_B.
-    let mut bt = vec![0.0_f64; m * m];
-    let mut c_b = vec![0.0_f64; m];
-    for (k, &bv) in basis.basic_vars.iter().enumerate() {
-        c_b[k] = c[bv];
-        for i in 0..m {
-            bt[k * m + i] = a[i * n + bv];
-        }
+    // Node duals y = B⁻ᵀ c_B via the *sparse* LU (factorize O(nnz) + btran), the
+    // same path the dual simplex uses — not a dense m×m refactor. The earlier dense
+    // `solve_dense` was O(m³) per node: trivial on few-row knapsacks but ruinous on
+    // 800–1500-row covering LPs, where it dominated the whole solve. The basis is
+    // scaling-invariant and `sp`/`c` are unscaled, so `y` is the unscaled dual the
+    // integer bound fixing needs. A singular basis ⇒ `None` (sound: just no fixing).
+    let mut lu = FeralLU::new();
+    let cols: Vec<Vec<(usize, f64)>> = basis
+        .basic_vars
+        .iter()
+        .map(|&bv| {
+            let (rows, vals) = sp.col(bv);
+            rows.iter().zip(vals).map(|(&r, &v)| (r, v)).collect()
+        })
+        .collect();
+    if lu.factorize_sparse(m, &cols).is_err() {
+        return None;
     }
-    let y = solve_dense(&bt, m, &c_b, tol)?;
-    if !y.iter().all(|v| v.is_finite()) {
+    let mut y: Vec<f64> = basis.basic_vars.iter().map(|&bv| c[bv]).collect();
+    if lu.btran(&mut y).is_err() || !y.iter().all(|v| v.is_finite()) {
         return None;
     }
 
@@ -1237,8 +1261,8 @@ fn reduced_cost_fix(
         if !is_int[j] || basis.col_status[j] == BASIC {
             continue;
         }
-        // Reduced cost d_j = c_j − A_jᵀ y.
-        let dj = c[j] - (0..m).map(|i| a[i * n + j] * y[i]).sum::<f64>();
+        // Reduced cost d_j = c_j − A_jᵀ y (sparse dot over column j's nonzeros).
+        let dj = c[j] - sp.dot(j, &y);
         match basis.col_status[j] {
             x if x == AT_LOWER && dj > tol => {
                 let maxk = (gap / dj).floor();


### PR DESCRIPTION
## Summary

Properly resolves the #341 covering fallout so `reduced_cost_fixing=true` is correct on **every** problem family — no per-instance toggling, no hack. Two changes:

### 1. Sparse-duals reduced-cost fixing (the real fix)

`reduced_cost_fix` recomputed the node duals `y = B⁻ᵀ c_B` from scratch with a **dense `solve_dense` — O(m³) per node**. Trivial on few-row knapsacks (#331), ruinous on 800–1500-row covering LPs (#332), where it dominated the whole solve:

> sc4000: **10.3s with RCF on vs 4.1s with RCF off — same node count**. Pure overhead: a 0.3% root gap fixes almost nothing, yet every node still paid the O(m³).

I earlier mislabeled this a "tradeoff" and floated an adaptive on-for-dense/off-for-sparse switch — that was wrong. It's an **implementation bug**: RCF reinvents the basis factorization densely instead of reusing the one the simplex already computed. SCIP/BARON make RCF nearly free precisely because reduced costs fall out of the existing factorization.

Now RCF computes `y` via the **sparse LU** (`FeralLU` factorize + btran, O(nnz)) and the reduced costs via `SparseCols::dot` (O(nnz_j)) — the exact path the dual simplex already uses (`dual.rs`). The duals are taken in the **unscaled** space the integer bound fixing needs; the batch shares an unscaled CSC (`csc_rc`, equal to the existing scaled `csc` when the matrix isn't scaled, so no extra build on the common path). Pure bound contraction, soundness unchanged; a singular basis ⇒ no fixing.

### 2. feral 0.11.3

Replaces the git-rev pin from #344 with the crates.io release that carries the issue-#89 fix (`u_above` reindex, O(m³)→O(m²) FT refactor — the underlying cause of the #341 timeout). Restores clean-wheel builds with the fix in place. Cargo.toml documents 0.11.3 as the floor; `test_setcover_lp_regression.py` guards a downgrade.

## Results (engine vs SCIP, TL=30s; `reduced_cost_fixing=true` left ON)

| instance | #341 | **this PR** | #340 ref |
|---|---|---|---|
| sc2000x800 | 30.6s timeout | **2.61s opt** | 2.49s |
| sc4000x1500 | 10.3s | **4.21s opt** | 4.26s |
| mdk250x10 | 1.29s | **1.41s opt** | (4.6s pre-#341) |

**Covering fully restored AND #341's knapsack gain preserved** — both #331 and #332 win, because the dense-O(m³) refactor was a bug, not a real tradeoff.

## Tests

- Soundness: covering optima still match SCIP exactly (910 / 1832 / 2232 / 4090).
- 340 discopt-core + 296 Python MILP/simplex/branch + the covering regression guard, all green.
- clippy clean (both feature variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
