### PR TITLE
test(lp): non-finite rejection tests for solve_lp (closes #342)

### DIFF
--- a/python/tests/test_lp_highs.py
+++ b/python/tests/test_lp_highs.py
@@ -269,6 +269,53 @@ class TestDimensionMismatch:
 
 
 # ---------------------------------------------------------------------------
+# 9b. Non-finite data rejection (issue #342)
+# ---------------------------------------------------------------------------
+class TestNonFiniteRejection:
+    """`solve_lp` must reject NaN/Inf LP data with a clear ValueError instead of
+    handing it to HiGHS, which has no defined behaviour for it (segfault on macOS,
+    unbounded simplex spin on Linux). NaN in the LP extraction reaches here as a
+    real upstream bug; failing loudly beats a native crash. Infinite *bounds* are
+    legitimate (free / one-sided variables and constraints) and must be accepted.
+    """
+
+    def test_nan_objective_rejected(self):
+        with pytest.raises(ValueError, match="non-finite|objective"):
+            solve_lp(c=np.array([1.0, np.nan]), bounds=[(0.0, 1.0), (0.0, 1.0)])
+
+    def test_nan_matrix_rejected(self):
+        with pytest.raises(ValueError, match="non-finite|matrix"):
+            solve_lp(
+                c=np.array([1.0, 1.0]),
+                A_ub=np.array([[1.0, np.nan]]),
+                b_ub=np.array([1.0]),
+            )
+
+    def test_nan_rhs_rejected(self):
+        with pytest.raises(ValueError, match="non-finite|NaN|bound"):
+            solve_lp(
+                c=np.array([1.0, 1.0]),
+                A_eq=np.array([[1.0, 1.0]]),
+                b_eq=np.array([np.nan]),
+            )
+
+    def test_infinite_bounds_accepted(self):
+        """Inf bounds are valid (one-sided variables) — must NOT be rejected.
+
+        min x, x in [0, +inf), s.t. x >= 2 (as -x <= -2). Optimal at x=2; the
+        infinite upper bound passes the guard and the solve succeeds.
+        """
+        result = solve_lp(
+            c=np.array([1.0]),
+            A_ub=np.array([[-1.0]]),
+            b_ub=np.array([-2.0]),
+            bounds=[(0.0, float("inf"))],
+        )
+        assert result.status == SolveStatus.OPTIMAL
+        assert result.x[0] == pytest.approx(2.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
 # 10. Dual values
 # ---------------------------------------------------------------------------
 class TestDualValues:


### PR DESCRIPTION
## Summary

Closes #342 (Reject non-finite LP data before calling HiGHS).

The **code** fixes for #342 already shipped in #339 (the HiGHS hang fix) — that PR was diagnosing/fixing the exact crash #342 describes (`test_mol_collocation_solves` segfaulting at `h.run()`):

- `_extract_lp_data_from_repr` now **declines** (raises `_NotLinearError`) on any non-finite coefficient, so `extract_lp_data` falls through to the autodiff path that handles the model correctly.
- `lp_highs.solve_lp` has a **final finite-value guard** before `Highs.run()` — rejects non-finite objective / matrix / RHS, allows infinite bounds (one-sided variables), rejects NaN bounds.

The one item of #342 not yet covered was its explicit ask: *"Add a regression test proving NaN matrix data is rejected before HiGHS is called."* The existing coverage was only the end-to-end collocation model.

This PR adds `TestNonFiniteRejection` to `test_lp_highs.py`:
- NaN in the **objective** → `ValueError`
- NaN in the **constraint matrix** → `ValueError`
- NaN in the **RHS** → `ValueError`
- **Infinite bounds** (one-sided variable) → accepted, solves to optimal

All four pass; full `test_lp_highs.py` green (24 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
