### PR TITLE
fix(nlp-bb): gate the LNS layer with the cost/benefit governor — restore clay0303hfsg certification (#347)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -6585,6 +6585,43 @@ def _solve_nlp_bb(
     _lns_k_schedule = (2, 5, 10)
     _lns_lb_calls = 0
     _lns_deadline = t_start + time_limit
+    # Adaptive cost/benefit governor for the improver-role LNS heuristics, mirrored
+    # from solve_model (see the _improver_allowed/_record_improver pair there). #321
+    # ported the improvers into this path but NOT this governor, so on instances
+    # where LNS never improves (e.g. clay0303hfsg, whose optimum is found early) the
+    # sub-MIPs fired at every node and starved the tree — certified-in-~21 s became a
+    # timeout with no bound (issue #347). The contingent is SCIP heur_subnlp-shaped:
+    # once an incumbent exists an improver may run only if it fits a success-weighted,
+    # node-proportional budget, so improvers that stop paying off shut themselves off.
+    # Soundness is untouched: B&B stays exhaustive, so a skipped improver can only
+    # cost nodes, never a wrong optimum. DISCOPT_HEUR_BUDGET=0 restores always-on.
+    _heur_budget_on = os.environ.get("DISCOPT_HEUR_BUDGET", "1") != "0"
+    _HEUR_BUDGET_OFFSET = float(os.environ.get("DISCOPT_HEUR_OFFSET", "0"))
+    _HEUR_BUDGET_QUOT = float(os.environ.get("DISCOPT_HEUR_QUOT", "0.5"))
+    _HEUR_SUCCESS_GAIN = 3.0
+    _HEUR_COST = {"rins": 5.0, "lbranch": 10.0}
+    _heur_state = {"calls": 0, "found": 0, "cost": 0.0}
+
+    def _improver_allowed(cost: float) -> bool:
+        """Whether an improver-role LNS heuristic costing ``cost`` may run now.
+
+        Never gated before the first incumbent (securing one for pruning wins).
+        Once an incumbent exists the call must fit the success-weighted,
+        node-proportional contingent (SCIP ``heur_subnlp`` shape)."""
+        if not _heur_budget_on or tree.incumbent() is None:
+            return True
+        _nodes = float(tree.stats().get("total_nodes", 0))
+        _weight = _HEUR_SUCCESS_GAIN * (_heur_state["found"] + 1) / (_heur_state["calls"] + 1)
+        _contingent = _HEUR_BUDGET_OFFSET + _HEUR_BUDGET_QUOT * _nodes * _weight
+        return (_heur_state["cost"] + cost) <= _contingent
+
+    def _record_improver(cost: float, improved: bool) -> None:
+        """Charge an improver-role run against the contingent and note success."""
+        _heur_state["calls"] += 1
+        _heur_state["cost"] += cost
+        if improved:
+            _heur_state["found"] += 1
+
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -7023,7 +7060,10 @@ def _solve_nlp_bb(
                     if (
                         _lns_best_idx is not None
                         and (_lns_deadline - time.perf_counter()) > _DEADLINE_NODE_FLOOR_S
+                        and _improver_allowed(_HEUR_COST["rins"])
                     ):
+                        _rins_obj0 = float(_lns_inc[1])
+                        _rins_improved = False
                         try:
                             from discopt._jax.primal_heuristics import rins
 
@@ -7048,14 +7088,20 @@ def _solve_nlp_bb(
                                     )
                                 ):
                                     tree.inject_incumbent(np.asarray(_x_ri).copy(), _obj_ri)
+                                    _rins_improved = _obj_ri < _rins_obj0 - 1e-9
                                     logger.info("NLP-BB LNS RINS incumbent: obj=%.6g", _obj_ri)
                         except Exception as _e:
                             logger.debug("NLP-BB LNS RINS failed: %s", _e)
+                        _record_improver(_HEUR_COST["rins"], _rins_improved)
                     # (2) Local branching — Hamming-ball sub-MIP, escalating k.
-                    if (_lns_deadline - time.perf_counter()) > 1.0:
+                    if (_lns_deadline - time.perf_counter()) > 1.0 and _improver_allowed(
+                        _HEUR_COST["lbranch"]
+                    ):
                         _lb_k = _lns_k_schedule[min(_lns_lb_calls, len(_lns_k_schedule) - 1)]
                         _lns_lb_calls += 1
                         _lb_slice = min(2.0, max(0.5, _lns_deadline - time.perf_counter() - 0.2))
+                        _lb_obj0 = float(_lns_inc[1])
+                        _lb_improved = False
                         try:
                             from discopt._jax.primal_heuristics import local_branching
 
@@ -7083,6 +7129,7 @@ def _solve_nlp_bb(
                                     )
                                 ):
                                     tree.inject_incumbent(np.asarray(_x_lb).copy(), _obj_lb)
+                                    _lb_improved = _obj_lb < _lb_obj0 - 1e-9
                                     logger.info(
                                         "NLP-BB LNS local-branching incumbent: obj=%.6g (k=%d)",
                                         _obj_lb,
@@ -7090,6 +7137,7 @@ def _solve_nlp_bb(
                                     )
                         except Exception as _e:
                             logger.debug("NLP-BB LNS local-branching failed: %s", _e)
+                        _record_improver(_HEUR_COST["lbranch"], _lb_improved)
 
         iteration += 1
 

--- a/python/tests/test_nlp_bb_lns_layer.py
+++ b/python/tests/test_nlp_bb_lns_layer.py
@@ -68,7 +68,31 @@ def test_lns_layer_terminates_and_is_sound(monkeypatch):
         assert r.objective <= 9.0 + 1e-4, f"FALSE-FEASIBLE: {r.objective} > opt 9"
 
 
-if __name__ == "__main__":
-    import pytest
+from pathlib import Path  # noqa: E402
 
+import pytest  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+
+_DATA = Path(__file__).parent / "data" / "minlplib_nl"
+_CLAY0303_OPT = 26669.10955143
+
+
+@pytest.mark.slow
+@pytest.mark.requires_pounce
+def test_clay0303hfsg_certifies_with_lns_governor():
+    """Regression for issue #347. The LNS improvement layer wired into
+    `_solve_nlp_bb` by #321 had no cost/benefit governor, so on clay0303hfsg —
+    whose optimum is found early, so LNS never improves — the per-node sub-MIPs
+    starved the tree: a ~21 s certify became a timeout with no dual bound. The
+    governor (ported from `solve_model`) must shut the improvers off so the tree
+    certifies again. Without it this times out at `status='feasible', bound=None`.
+    """
+    r = from_nl(str(_DATA / "clay0303hfsg.nl")).solve(time_limit=90, gap_tolerance=1e-4)
+    assert r.status == "optimal", f"clay0303hfsg did not certify (status={r.status})"
+    assert r.gap_certified, "clay0303hfsg reached optimum but gap was not certified"
+    assert r.bound is not None, "no dual bound — the LNS layer starved the tree (regression)"
+    assert r.objective == pytest.approx(_CLAY0303_OPT, rel=1e-4)
+
+
+if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Summary

Fixes #347. `clay0303hfsg` regressed from certifying in ~21 s to timing out with
**no dual bound** (`status=feasible`, `bound=None`). `git bisect` pinned the first
bad commit to **`e1ae380` (#321 — "wire LNS improvers into `_solve_nlp_bb`")**.

#321 ported the LNS improvers (RINS + local branching) into `_solve_nlp_bb` but
**dropped the adaptive cost/benefit governor** that keeps them inert in
`solve_model`. On instances where LNS never improves — e.g. `clay0303hfsg`, whose
optimum is found early — the sub-MIPs fired at **every** non-root node and starved
the tree (per-node cost ~91 ms → ~635 ms, throughput ~7× collapse), so it never
closed the gap. The dual bound is never corrupted; `bound=None` is just the
timeout return path.

`gear4` was unaffected (it takes the **spatial** path, not `_solve_nlp_bb`), which
is why the regression slipped #321's bound-neutral perf gate — and `clay0303hfsg`
is also not in the #317 perf panel.

## Fix

Port the `solve_model` governor into `_solve_nlp_bb`:

- `_heur_state` contingent + `_improver_allowed` / `_record_improver`, identical in
  shape to the proven pair at `solver.py:4310-4344` (SCIP `heur_subnlp`:
  success-weighted, node-proportional — `cost_spent + cost <= offset + quot ·
  nodes · 3·(found+1)/(calls+1)`).
- Gate the per-node RINS and local-branching calls behind `_improver_allowed(...)`
  and record their outcome.

When LNS keeps paying off (the instances #321 targeted), `found` keeps the
contingent generous and the improvers keep running, preserving the #321 gains.
When it stops paying off, the contingent tightens and they shut down. Sound by
construction: B&B stays exhaustive, so a skipped improver can only cost nodes,
never a wrong optimum. `DISCOPT_HEUR_BUDGET=0` restores the prior always-on
behaviour.

## Validation

| | before #321 | regressed (HEAD) | **with fix** |
|---|---|---|---|
| status | optimal | feasible | **optimal** |
| gap_certified | ✓ | ✗ | **✓** |
| wall | ~21 s | timeout | **24.0 s** |
| nodes | 229 | no progress | **229** |
| dual bound | 26669.1 | **null** | **26669.1** |

- `clay0303hfsg` certifies again (24.0 s, 229 nodes, bound = 26669.1).
- Fast LNS guard test still passes (layer fires + sound); `gear4` spatial path
  unchanged (7/7 fast tests).
- New slow regression test `test_clay0303hfsg_certifies_with_lns_governor` passes
  (30.6 s).
- `ruff check` + `ruff format` clean.

## Caveat

#321's own panel instances (`clay0204m`/`syn30m`/`rsyn0810m`) are not vendored in
this repo, so preservation of #321's *gains* is argued by design (identical
governor to the one already governing the same improvers in `solve_model`) rather
than re-run here. Follow-up from #347: add `clay0303hfsg` (or a faster clay
sibling) to the perf panel so this class is gated going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
