### PR TITLE
feat(pyomo): optional SolverFactory('discopt') plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A hybrid Mixed-Integer Nonlinear Programming (MINLP) solver combining a Rust bac
 - **GNN branching policy** -- bipartite graph-neural-network scaffold for learned branching (experimental; ships untrained, see #236)
 - **Differentiable optimization** -- parameter sensitivity via envelope theorem and KKT implicit differentiation, including differentiable MILP/MIQP (fix-and-differentiate)
 - **.nl file import** -- read AMPL-format models via Rust parser
+- **Pyomo solver plugin** -- use discopt from existing Pyomo models via `SolverFactory("discopt")` (`pip install discopt[pyomo]`); see [docs/pyomo_solver.md](docs/pyomo_solver.md)
 - **Dynamic optimization** -- DAE collocation (Radau/Legendre) and finite differences for optimal control, parameter estimation, and PDE-constrained optimization
 - **CUTEst interface** -- NLP benchmarking against the CUTEst test set
 - **LLM integration** (optional) -- conversational model building, diagnostics, and reformulation suggestions

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -58,6 +58,8 @@ parts:
       - file: notebooks/suspect_head_to_head
       - file: notebooks/nlp_bb
       - file: notebooks/export_formats
+      - file: notebooks/pyomo_solver
+      - file: pyomo_solver
       - file: notebooks/callbacks
   - caption: Solver Backends
     chapters:

--- a/docs/notebooks/pyomo_solver.ipynb
+++ b/docs/notebooks/pyomo_solver.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bbc9f32b",
+   "metadata": {},
+   "source": [
+    "# Using discopt as a Pyomo solver\n",
+    "\n",
+    "discopt ships an optional [Pyomo](https://pyomo.org) {cite:p}`Hart2017` plugin so that models written with Pyomo's algebraic modeling layer can be solved with discopt through the familiar `SolverFactory` interface — no rewrite required.\n",
+    "\n",
+    "Install the extra:\n",
+    "\n",
+    "```bash\n",
+    "pip install discopt[pyomo]\n",
+    "```\n",
+    "\n",
+    "Under the hood the bridge round-trips the model through a temporary AMPL `.nl` file {cite:p}`Fourer2003`: Pyomo's `.nl` writer and discopt's `from_nl` agree on the variable *column order*, so the solution maps back by index. This notebook shows a basic solve, solver options, and dual values."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c3582d5",
+   "metadata": {},
+   "source": [
+    "## Activate the plugin\n",
+    "\n",
+    "Importing `discopt.pyomo` registers the `'discopt'` solver with Pyomo's `SolverFactory` (a `pyomo.solvers` entry point does the same automatically after installation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e46dd2f0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:14:26.894502Z",
+     "iopub.status.busy": "2026-06-29T01:14:26.894421Z",
+     "iopub.status.idle": "2026-06-29T01:14:27.058508Z",
+     "shell.execute_reply": "2026-06-29T01:14:27.058049Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "discopt registered: True\n",
+      "available: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pyomo.environ as pyo\n",
+    "import discopt.pyomo  # registers the 'discopt' solver\n",
+    "\n",
+    "print(\"discopt registered:\", \"discopt\" in pyo.SolverFactory)\n",
+    "opt = pyo.SolverFactory(\"discopt\")\n",
+    "print(\"available:\", opt.available())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38f72c05",
+   "metadata": {},
+   "source": [
+    "## A small MINLP\n",
+    "\n",
+    "A mixed-integer nonlinear program with one continuous variable, one binary variable, a quadratic objective, and a linear constraint:\n",
+    "\n",
+    "$$\\min_{x,\\,y}\\;(x-3)^2 + 2y \\quad\\text{s.t.}\\quad x + 5y \\ge 4,\\; x \\in [0,10],\\; y \\in \\{0,1\\}.$$\n",
+    "\n",
+    "The optimum is $x=4,\\,y=0$ with objective $1$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5c321855",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:14:27.059834Z",
+     "iopub.status.busy": "2026-06-29T01:14:27.059704Z",
+     "iopub.status.idle": "2026-06-29T01:14:27.592440Z",
+     "shell.execute_reply": "2026-06-29T01:14:27.592066Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      "objective:   0.9999999225074985\n",
+      "x = 3.9999999612537485   y = 0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "m = pyo.ConcreteModel()\n",
+    "m.x = pyo.Var(bounds=(0, 10))\n",
+    "m.y = pyo.Var(domain=pyo.Binary)\n",
+    "m.obj = pyo.Objective(expr=(m.x - 3) ** 2 + 2 * m.y, sense=pyo.minimize)\n",
+    "m.c = pyo.Constraint(expr=m.x + 5 * m.y >= 4)\n",
+    "\n",
+    "results = opt.solve(m)\n",
+    "print(\"termination:\", results.solver.termination_condition)\n",
+    "print(\"objective:  \", pyo.value(m.obj))\n",
+    "print(\"x =\", m.x.value, \"  y =\", m.y.value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "211df8b7",
+   "metadata": {},
+   "source": [
+    "discopt solved the model and loaded the solution back onto the Pyomo variables. The binary variable comes back as an exact integer (integrality drift is rounded away on load)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0de2894e",
+   "metadata": {},
+   "source": [
+    "## Solver options\n",
+    "\n",
+    "Standard Pyomo options map onto discopt's `solve()` keywords: `timelimit` → `time_limit`, `mipgap` → `gap_tolerance`, `threads` → `threads`, and `tee=True` streams progress. Unrecognised options are forwarded verbatim, so any discopt solve keyword works without a plugin change."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "40f65a27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:14:27.594062Z",
+     "iopub.status.busy": "2026-06-29T01:14:27.593872Z",
+     "iopub.status.idle": "2026-06-29T01:14:27.603731Z",
+     "shell.execute_reply": "2026-06-29T01:14:27.603354Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "termination: optimal\n",
+      "wall time (s): 0.004830209072679281\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = opt.solve(m, options={\"timelimit\": 30, \"mipgap\": 1e-4})\n",
+    "print(\"termination:\", results.solver.termination_condition)\n",
+    "print(\"wall time (s):\", results.solver.wallclock_time)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93df2abc",
+   "metadata": {},
+   "source": [
+    "## Dual values and reduced costs\n",
+    "\n",
+    "Declare an `import` `Suffix` and discopt's KKT multipliers are loaded best-effort. Consider a convex NLP whose optimum sits on an active constraint:\n",
+    "\n",
+    "$$\\min_x\\;(x-3)^2 \\quad\\text{s.t.}\\quad x \\ge 4.$$\n",
+    "\n",
+    "The optimum is $x=4$, and the constraint multiplier is $2$ (the AMPL/Pyomo sign convention, matching e.g. Ipopt)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "838a8352",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:14:27.604818Z",
+     "iopub.status.busy": "2026-06-29T01:14:27.604755Z",
+     "iopub.status.idle": "2026-06-29T01:14:27.610718Z",
+     "shell.execute_reply": "2026-06-29T01:14:27.610367Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x = 4.0\n",
+      "dual[c] = 1.999999922298516\n",
+      "rc[x]   = 2.0898053236939798e-10\n"
+     ]
+    }
+   ],
+   "source": [
+    "n = pyo.ConcreteModel()\n",
+    "n.x = pyo.Var(bounds=(0, 10))\n",
+    "n.obj = pyo.Objective(expr=(n.x - 3) ** 2, sense=pyo.minimize)\n",
+    "n.c = pyo.Constraint(expr=n.x >= 4)\n",
+    "n.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)\n",
+    "n.rc = pyo.Suffix(direction=pyo.Suffix.IMPORT)\n",
+    "\n",
+    "opt.solve(n)\n",
+    "print(\"x =\", round(n.x.value, 6))\n",
+    "print(\"dual[c] =\", n.dual.get(n.c))\n",
+    "print(\"rc[x]   =\", n.rc.get(n.x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f786d6b8",
+   "metadata": {},
+   "source": [
+    "Duals are populated only when discopt exposes multipliers (the NLP/KKT path); for problems solved by another route the `Suffix` is simply left empty — values are never fabricated.\n",
+    "\n",
+    "## How it works and limitations\n",
+    "\n",
+    "Pyomo's `.nl` writer emits the model in its original variable space (presolve and scaling disabled), discopt's `from_nl` reads it with the **same column/row order**, and the solution maps back by index. As a result:\n",
+    "\n",
+    "- Variable and constraint *values* map by column/row order, not by name (Pyomo and discopt name objects differently).\n",
+    "- Constraint names are not preserved through `.nl` (cosmetic; solving and duals are unaffected).\n",
+    "- A model whose operators discopt's reader does not support returns a structured `error` result rather than crashing.\n",
+    "\n",
+    "See [docs/pyomo_solver.md](../pyomo_solver.md) for the full reference."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/pyomo_solver.md
+++ b/docs/pyomo_solver.md
@@ -1,0 +1,88 @@
+# Using discopt as a Pyomo solver
+
+discopt ships an optional [Pyomo](https://pyomo.org) plugin so existing Pyomo
+models can be solved with discopt through the familiar `SolverFactory` interface.
+
+## Installation
+
+```bash
+pip install discopt[pyomo]
+```
+
+## Usage
+
+```python
+import pyomo.environ as pyo
+import discopt.pyomo  # registers the 'discopt' solver
+
+m = pyo.ConcreteModel()
+m.x = pyo.Var(bounds=(0, 10))
+m.y = pyo.Var(domain=pyo.Binary)
+m.obj = pyo.Objective(expr=(m.x - 3) ** 2 + 2 * m.y, sense=pyo.minimize)
+m.c = pyo.Constraint(expr=m.x + 5 * m.y >= 4)
+
+opt = pyo.SolverFactory("discopt")
+results = opt.solve(m, tee=True)
+
+print(results.solver.termination_condition)   # optimal
+print(m.x.value, m.y.value)                    # 4.0  0
+```
+
+Activation: `import discopt.pyomo` (or `discopt.pyomo.register()`) registers the
+solver. A `pyomo.solvers` entry point is also declared so discovery can happen
+automatically after installation.
+
+## Options
+
+Pyomo solver options map to `Model.solve` keyword arguments:
+
+| Pyomo option | discopt `solve()` kwarg |
+|---|---|
+| `timelimit` (or `time_limit`) | `time_limit` |
+| `mipgap` / `gap` | `gap_tolerance` |
+| `threads` | `threads` |
+| `tee=True` | `stream=True` |
+
+Pass them per solve or persistently:
+
+```python
+opt.solve(m, options={"timelimit": 60, "mipgap": 1e-4})
+# or
+opt.options["timelimit"] = 60
+```
+
+Unrecognised options are forwarded verbatim to `Model.solve`, so any discopt solve
+keyword works without a plugin change.
+
+## Duals and reduced costs
+
+Declare an `import` Suffix and discopt's KKT multipliers are loaded **best-effort**:
+
+```python
+m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+m.rc = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+opt.solve(m)
+print(m.dual[m.c], m.rc[m.x])
+```
+
+Duals follow the AMPL/Pyomo sign convention (cross-checked against ipopt). They are
+populated only when discopt exposes multipliers — i.e. on the NLP/KKT path. For
+problems solved by another route the Suffix is simply left empty; values are never
+fabricated.
+
+## How it works and limitations
+
+The bridge round-trips the model through a temporary AMPL `.nl` file in-process:
+Pyomo's NL writer emits the `.nl` (presolve and scaling disabled so it stays in the
+original variable space), `discopt.from_nl` reads it with the **same column/row
+order**, `Model.solve` runs, and the solution is mapped back by index. Consequences:
+
+- **Variable/constraint values map by column/row order, not name** — Pyomo and
+  discopt name things differently; this is handled internally.
+- **Constraint names are not preserved** through `.nl` (cosmetic; solving and dual
+  mapping are unaffected).
+- Models Pyomo can write to `.nl` but whose operators discopt's reader does not
+  support return a structured `error` result with a message rather than crashing.
+
+A future direct in-memory translator (`from_pyomo`) may replace the `.nl`
+round-trip without changing this interface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ cutest = ["pycutest>=1.8.0"]
 gams = ["gamsapi[core]>=45", "pyyaml>=6"]
 llm = ["litellm>=1.0"]
 nn = ["onnx>=1.14", "onnxruntime>=1.16"]
+# Use discopt as a Pyomo solver: `SolverFactory("discopt")`. Pure-Python bridge
+# that round-trips through a temporary AMPL .nl file. See docs/pyomo_solver.md.
+pyomo = ["pyomo>=6.7"]
 ml = ["scikit-learn>=1.0"]
 xgboost = ["xgboost>=1.7"]
 lightgbm = ["lightgbm>=4.0"]
@@ -75,13 +78,20 @@ dev = [
     "mypy==2.1.0",
     "highspy",
     "pre-commit",
+    "pyomo>=6.7",
 ]
-all = ["discopt[pounce,ipopt,highs,cutest,llm,gnn,nn,ml,doe,doe-gui,sympy]"]
+all = ["discopt[pounce,ipopt,highs,cutest,llm,gnn,nn,ml,doe,doe-gui,sympy,pyomo]"]
 
 [project.scripts]
 discopt = "discopt.cli:main"
 discopt-dev = "discopt.dev.cli:main"
 discopt-gams = "discopt.gams.link:main"
+
+# Convenience discovery hook for Pyomo. The reliable activation is
+# `import discopt.pyomo` (or `discopt.pyomo.register()`), which registers the
+# 'discopt' solver with Pyomo's SolverFactory.
+[project.entry-points."pyomo.solvers"]
+discopt = "discopt.pyomo.solver"
 
 [tool.maturin]
 manifest-path = "crates/discopt-python/Cargo.toml"

--- a/python/discopt/pyomo/__init__.py
+++ b/python/discopt/pyomo/__init__.py
@@ -1,0 +1,52 @@
+"""Optional Pyomo integration: use discopt as a Pyomo solver.
+
+Install with ``pip install discopt[pyomo]``. Once Pyomo is present, the solver is
+registered automatically (via the ``pyomo.solvers`` entry point, or on the first
+``import discopt.pyomo`` / call to :func:`register`)::
+
+    import pyomo.environ as pyo
+    import discopt.pyomo  # registers 'discopt'
+
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(0, 10))
+    m.obj = pyo.Objective(expr=(m.x - 3) ** 2)
+    res = pyo.SolverFactory("discopt").solve(m, tee=True)
+    print(m.x.value)
+
+The bridge round-trips through a temporary AMPL ``.nl`` file in-process and maps
+the solution back by column order. Duals/reduced costs are loaded best-effort into
+``dual`` / ``rc`` Suffixes when the model declares them and discopt exposes them.
+"""
+
+from __future__ import annotations
+
+
+def is_available() -> bool:
+    """True if Pyomo is installed and the solver plugin can be used."""
+    try:
+        import pyomo  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def register() -> None:
+    """Idempotently register ``'discopt'`` with Pyomo's ``SolverFactory``.
+
+    A no-op if Pyomo is not installed. Importing ``discopt.pyomo.solver`` applies
+    the ``@SolverFactory.register`` decorator; this wrapper makes that explicit and
+    safe to call repeatedly.
+    """
+    if not is_available():
+        return
+    from pyomo.opt import SolverFactory
+
+    if "discopt" not in SolverFactory:
+        from . import solver  # noqa: F401  (decorator registers on import)
+
+
+# Best-effort auto-registration on import (the documented manual activation path).
+register()
+
+__all__ = ["is_available", "register"]

--- a/python/discopt/pyomo/_mapping.py
+++ b/python/discopt/pyomo/_mapping.py
@@ -1,0 +1,161 @@
+"""Translate between discopt ``SolveResult`` and Pyomo results/options.
+
+Three concerns live here:
+
+* :func:`translate_options` — Pyomo solver options -> ``Model.solve`` kwargs.
+* :data:`STATUS_MAP` / :func:`termination_for` — discopt status -> Pyomo enums.
+* :func:`solution_flat` / :func:`load_solution` / :func:`load_duals` — index-aligned
+  primal/dual loading (the alignment is guaranteed by the ``.nl`` column/row order;
+  see ``_writer.write_nl``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+# discopt SolveResult.status -> (TerminationCondition name, SolverStatus name).
+# Strings (resolved lazily so importing this module never requires pyomo).
+STATUS_MAP: dict[str, tuple[str, str]] = {
+    "optimal": ("optimal", "ok"),
+    "feasible": ("feasible", "ok"),
+    "infeasible": ("infeasible", "ok"),
+    "unbounded": ("unbounded", "ok"),
+    "infeasible_or_unbounded": ("infeasibleOrUnbounded", "ok"),
+    "time_limit": ("maxTimeLimit", "ok"),
+    "node_limit": ("maxIterations", "ok"),
+    "iteration_limit": ("maxIterations", "ok"),
+    "error": ("error", "error"),
+}
+
+
+def termination_for(status: str):
+    """Resolve a discopt status string to ``(TerminationCondition, SolverStatus)``."""
+    from pyomo.opt import SolverStatus, TerminationCondition
+
+    tc_name, ss_name = STATUS_MAP.get(status, ("unknown", "warning"))
+    return getattr(TerminationCondition, tc_name), getattr(SolverStatus, ss_name)
+
+
+# Pyomo option name (lower-cased) -> discopt Model.solve kwarg.
+_OPTION_ALIASES: dict[str, str] = {
+    "timelimit": "time_limit",
+    "time_limit": "time_limit",
+    "maxtime": "time_limit",
+    "mipgap": "gap_tolerance",
+    "gap": "gap_tolerance",
+    "gap_tolerance": "gap_tolerance",
+    "threads": "threads",
+    "num_threads": "threads",
+}
+
+
+def translate_options(options: dict[str, Any]) -> dict[str, Any]:
+    """Map Pyomo solver options to ``Model.solve`` kwargs.
+
+    Recognised aliases are normalised; any other option is forwarded verbatim so a
+    new ``Model.solve`` kwarg works without touching this plugin.
+    """
+    out: dict[str, Any] = {}
+    for key, val in options.items():
+        out[_OPTION_ALIASES.get(str(key).lower(), str(key))] = val
+    return out
+
+
+def solution_flat(discopt_model: Any, result: Any) -> np.ndarray:
+    """Flatten ``SolveResult.x`` (keyed by var name) into ``.nl`` column order.
+
+    Iterates the discopt model's variables (declaration order == ``.nl`` column
+    order) and ravels each value, matching the per-element column expansion the NL
+    writer / ``result_io.write_sol`` use.
+    """
+    parts: list[np.ndarray] = []
+    for var in discopt_model._variables:
+        parts.append(np.asarray(result.x[var.name], dtype=np.float64).ravel())
+    if not parts:
+        return np.zeros(0, dtype=np.float64)
+    return np.concatenate(parts)
+
+
+def load_solution(pyomo_vars: list, flat: np.ndarray) -> None:
+    """Load *flat* (``.nl`` column order) into *pyomo_vars* (same order).
+
+    Integer/binary variables are rounded to defeat ~1e-5 integrality drift and
+    clamped to their declared bounds so ``set_value`` validation cannot trip.
+    """
+    if len(flat) != len(pyomo_vars):
+        raise AssertionError(
+            f"discopt/pyomo column-order mismatch: {len(flat)} solution values vs "
+            f"{len(pyomo_vars)} .nl columns — refusing to load a misaligned solution"
+        )
+    for vdata, raw in zip(pyomo_vars, flat):
+        val = float(raw)
+        if vdata.is_integer() or vdata.is_binary():
+            val = float(round(val))
+        lb, ub = vdata.lb, vdata.ub
+        if lb is not None and val < lb:
+            val = lb
+        if ub is not None and val > ub:
+            val = ub
+        vdata.set_value(val, skip_validation=True)
+
+
+def load_duals(
+    model: Any,
+    discopt_model: Any,
+    result: Any,
+    pyomo_vars: list,
+    pyomo_cons: list,
+) -> None:
+    """Best-effort dual / reduced-cost loading into the model's Suffixes.
+
+    Only runs when the model declares an importable ``dual`` (and/or ``rc``) Suffix
+    and discopt populated the corresponding multipliers (it does so only on the
+    KKT/NLP path; ``constraint_duals`` / ``bound_duals_*`` are ``None`` otherwise).
+
+    Both mappings are by **index/row order**, not by name: discopt and Pyomo name
+    variables/constraints differently. ``constraint_duals`` is keyed
+    ``c.name or f"c{idx}"`` in row order (``solver._unpack_constraint_duals``), so
+    we rebuild those keys in row order; ``bound_duals_*`` is keyed by discopt's
+    variable name, aligned to ``pyomo_vars[i]`` by column index.
+    """
+    dual_suf = _importable_suffix(model, "dual")
+    if dual_suf is not None and result.constraint_duals is not None:
+        flat_duals: list[float] = []
+        ok = True
+        for idx, con in enumerate(discopt_model._constraints):
+            key = con.name if con.name else f"c{idx}"
+            mult = result.constraint_duals.get(key)
+            if mult is None:
+                ok = False
+                break
+            flat_duals.extend(np.asarray(mult, dtype=np.float64).ravel().tolist())
+        if ok and len(flat_duals) == len(pyomo_cons):
+            for cdata, mu in zip(pyomo_cons, flat_duals):
+                dual_suf[cdata] = float(mu)
+
+    rc_suf = _importable_suffix(model, "rc")
+    if rc_suf is not None and (
+        result.bound_duals_lower is not None or result.bound_duals_upper is not None
+    ):
+        lower = result.bound_duals_lower or {}
+        upper = result.bound_duals_upper or {}
+        # rc = lower-bound multiplier - upper-bound multiplier; align by column index.
+        for dvar, vdata in zip(discopt_model._variables, pyomo_vars):
+            lo = np.asarray(lower.get(dvar.name, 0.0), dtype=np.float64).ravel()
+            hi = np.asarray(upper.get(dvar.name, 0.0), dtype=np.float64).ravel()
+            if lo.size == 1 and hi.size == 1:
+                rc_suf[vdata] = float(lo[0]) - float(hi[0])
+
+
+def _importable_suffix(model: Any, name: str):
+    """Return the model's Suffix *name* if present and import-enabled, else None."""
+    from pyomo.core.base.suffix import Suffix
+
+    suf = getattr(model, name, None)
+    if suf is None or not isinstance(suf, Suffix):
+        return None
+    if not suf.import_enabled():
+        return None
+    return suf

--- a/python/discopt/pyomo/_writer.py
+++ b/python/discopt/pyomo/_writer.py
@@ -1,0 +1,46 @@
+"""Write a Pyomo model to a temporary AMPL ``.nl`` file for discopt.
+
+The bridge round-trips through ``.nl`` and maps the solution back by **column
+order**, not by name (Pyomo and discopt name variables differently). To make that
+mapping a direct index identity we disable two NL-writer transforms:
+
+* ``linear_presolve=False`` — keep every model variable as a column, so the
+  solution covers all of them and there is no eliminated-variable back-substitution.
+* ``scale_model=False`` — emit the ``.nl`` in the original variable space, so the
+  values discopt returns need no un-scaling.
+
+The writer's :class:`NLWriterInfo` reports the exact variables (column order) and
+constraints (row order) it wrote; ``discopt.from_nl`` reads those same rows/columns
+in the same order, so ``info.variables[i]`` aligns with discopt's ``i``-th column
+and ``info.constraints[i]`` with discopt's ``i``-th constraint row.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def write_nl(model: Any, nl_path: str) -> tuple[list, list, list]:
+    """Write *model* to *nl_path* as an AMPL ``.nl`` file.
+
+    Returns ``(vars_in_col_order, cons_in_row_order, eliminated_vars)`` — the first
+    two are lists of Pyomo ``VarData`` / ``ConstraintData`` in the exact column/row
+    order the ``.nl`` encodes (for index-aligned solution and dual mapping); the
+    third is the (normally empty) list of presolve-eliminated ``(var, expr)`` pairs
+    to back-substitute defensively.
+    """
+    from pyomo.repn.plugins.nl_writer import NLWriter
+
+    with open(nl_path, "w") as stream:
+        info = NLWriter().write(
+            model,
+            stream,
+            linear_presolve=False,
+            scale_model=False,
+            skip_trivial_constraints=False,
+        )
+
+    # With presolve disabled this is normally empty; keep a defensive recovery so a
+    # future writer-default change can't silently drop a variable's value.
+    eliminated = list(getattr(info, "eliminated_vars", []) or [])
+    return list(info.variables), list(info.constraints), eliminated

--- a/python/discopt/pyomo/solver.py
+++ b/python/discopt/pyomo/solver.py
@@ -1,0 +1,254 @@
+"""``SolverFactory('discopt')`` — a Pyomo plugin backed by discopt.
+
+In-process ``.nl`` round-trip: Pyomo's NL writer emits a temporary ``.nl`` (in the
+original variable space, no presolve — see ``_writer``), ``discopt.from_nl`` reads
+it into a discopt ``Model`` with the *same* column/row order, ``Model.solve`` runs,
+and the primal (and best-effort dual) solution is mapped back by index.
+
+Importing this module registers the solver, so it activates via the
+``pyomo.solvers`` entry point or an explicit ``import discopt.pyomo``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+
+from pyomo.opt import OptSolver, SolverFactory, SolverResults
+
+from . import _mapping, _writer
+
+
+@SolverFactory.register("discopt", doc="discopt hybrid MINLP solver (in-process)")
+class DiscoptSolver(OptSolver):
+    """Pyomo ``OptSolver`` that solves a model in-process with discopt."""
+
+    def __init__(self, **kwds: Any):
+        kwds.setdefault("type", "discopt")
+        super().__init__(**kwds)
+        # discopt handles continuous, integer and nonlinear constraints natively.
+        self._capabilities.linear = True
+        self._capabilities.integer = True
+        self._capabilities.quadratic_objective = True
+        self._capabilities.quadratic_constraint = True
+        self._capabilities.sos1 = False
+        self._capabilities.sos2 = False
+
+    # -- Pyomo solver contract -------------------------------------------------
+    def available(self, exception_flag: bool = False) -> bool:
+        try:
+            import discopt.modeling  # noqa: F401
+
+            return True
+        except ImportError:
+            if exception_flag:
+                raise
+            return False
+
+    def version(self):
+        try:
+            from importlib.metadata import version
+
+            return tuple(int(p) for p in version("discopt").split(".")[:3] if p.isdigit())
+        except Exception:
+            return None
+
+    def warm_start_capable(self) -> bool:
+        return True
+
+    def solve(self, *args: Any, **kwds: Any) -> SolverResults:
+        if not args:
+            raise ValueError("DiscoptSolver.solve() requires a Pyomo model argument")
+        model = args[0]
+
+        tee = bool(kwds.pop("tee", False))
+        load_solutions = bool(kwds.pop("load_solutions", True))
+        keepfiles = bool(kwds.pop("keepfiles", False))
+        warmstart = bool(kwds.pop("warmstart", False))
+        timelimit = kwds.pop("timelimit", None)
+        kwds.pop("symbolic_solver_labels", None)
+        kwds.pop("report_timing", None)
+
+        # Merge persistent options (self.options) with this call's options.
+        options: dict[str, Any] = dict(self.options)
+        options.update(kwds.pop("options", {}) or {})
+        if timelimit is not None:
+            options.setdefault("time_limit", timelimit)
+        solve_kwargs = _mapping.translate_options(options)
+        if tee:
+            solve_kwargs.setdefault("stream", True)
+
+        return self._solve_via_nl(
+            model,
+            solve_kwargs,
+            load_solutions=load_solutions,
+            keepfiles=keepfiles,
+            warmstart=warmstart,
+        )
+
+    # -- Core flow -------------------------------------------------------------
+    def _solve_via_nl(
+        self,
+        model: Any,
+        solve_kwargs: dict[str, Any],
+        *,
+        load_solutions: bool,
+        keepfiles: bool,
+        warmstart: bool,
+    ) -> SolverResults:
+        import discopt.modeling as dm
+
+        if keepfiles:
+            ctx = None
+            workdir = tempfile.mkdtemp(prefix="discopt_pyomo_")
+        else:
+            ctx = tempfile.TemporaryDirectory(prefix="discopt_pyomo_")
+            workdir = ctx.name
+        try:
+            nl_path = os.path.join(workdir, "model.nl")
+            cols, rows, eliminated = _writer.write_nl(model, nl_path)
+
+            if not cols:
+                # Zero-variable / constant model: nothing to round-trip.
+                return self._trivial_results(model)
+
+            discopt_model = dm.from_nl(nl_path)
+
+            if warmstart:
+                seed = self._warmstart_seed(discopt_model, cols)
+                if seed:
+                    solve_kwargs.setdefault("initial_solution", seed)
+
+            try:
+                result = discopt_model.solve(**solve_kwargs)
+            except Exception as exc:  # noqa: BLE001 - surface as a structured result
+                return self._error_results(model, f"discopt.solve failed: {exc}")
+
+            return self._build_results(
+                model,
+                discopt_model,
+                result,
+                cols,
+                rows,
+                eliminated,
+                load_solutions=load_solutions,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return self._error_results(model, f"discopt pyomo bridge failed: {exc}")
+        finally:
+            if ctx is not None:
+                ctx.cleanup()
+
+    def _build_results(
+        self, model, discopt_model, result, cols, rows, eliminated, *, load_solutions
+    ) -> SolverResults:
+        from pyomo.opt import SolutionStatus
+
+        results = SolverResults()
+        results.solver.name = "discopt"
+        results.solver.wallclock_time = getattr(result, "wall_time", None)
+        tc, ss = _mapping.termination_for(result.status)
+        results.solver.termination_condition = tc
+        results.solver.status = ss
+        try:
+            results.solver.statistics.branch_and_bound.number_of_nodes = int(
+                getattr(result, "node_count", 0) or 0
+            )
+        except Exception:
+            pass
+
+        results.problem.name = getattr(model, "name", "unknown")
+        results.problem.number_of_variables = len(cols)
+        results.problem.number_of_constraints = len(rows)
+        sense, obj_bound_field = self._objective_sense(model)
+        if sense is not None:
+            results.problem.sense = sense
+        if result.objective is not None:
+            setattr(results.problem, obj_bound_field, result.objective)
+        if result.bound is not None:
+            other = "upper_bound" if obj_bound_field == "lower_bound" else "lower_bound"
+            setattr(results.problem, other, result.bound)
+
+        has_primal = getattr(result, "x", None) is not None
+        if has_primal:
+            flat = _mapping.solution_flat(discopt_model, result)
+            if load_solutions:
+                _mapping.load_solution(cols, flat)
+                self._backsub_eliminated(eliminated)
+                _mapping.load_duals(model, discopt_model, result, cols, rows)
+            else:
+                self._attach_solution(results, cols, flat, result, SolutionStatus)
+        return results
+
+    # -- Helpers ---------------------------------------------------------------
+    @staticmethod
+    def _objective_sense(model):
+        """Return ``(pyomo sense, bound-field)`` for the model's active objective."""
+        from pyomo.core.base.objective import Objective
+        from pyomo.opt import ProblemSense
+
+        for obj in model.component_data_objects(Objective, active=True):
+            if obj.sense == 1:  # minimize
+                return ProblemSense.minimize, "lower_bound"
+            return ProblemSense.maximize, "upper_bound"
+        return None, "lower_bound"
+
+    @staticmethod
+    def _warmstart_seed(discopt_model, cols) -> dict[str, Any]:
+        seed: dict[str, Any] = {}
+        for var, vdata in zip(discopt_model._variables, cols):
+            if vdata.value is not None:
+                seed[var.name] = float(vdata.value)
+        return seed
+
+    @staticmethod
+    def _backsub_eliminated(eliminated) -> None:
+        from pyomo.core.expr import value as pyo_value
+
+        for item in eliminated:
+            try:
+                var, expr = item
+                var.set_value(pyo_value(expr), skip_validation=True)
+            except Exception:
+                continue
+
+    @staticmethod
+    def _attach_solution(results, cols, flat, result, SolutionStatus) -> None:
+        soln = results.solution.add()
+        soln.status = SolutionStatus.feasible
+        if result.objective is not None:
+            soln.objective["__default_objective__"] = {"Value": result.objective}
+        for vdata, val in zip(cols, flat):
+            soln.variable[vdata.name] = {"Value": float(val)}
+
+    def _trivial_results(self, model) -> SolverResults:
+        from pyomo.core.expr import value as pyo_value
+
+        results = SolverResults()
+        results.solver.name = "discopt"
+        tc, ss = _mapping.termination_for("optimal")
+        results.solver.termination_condition = tc
+        results.solver.status = ss
+        results.problem.number_of_variables = 0
+        sense, field = self._objective_sense(model)
+        if sense is not None:
+            results.problem.sense = sense
+        try:
+            from pyomo.core.base.objective import Objective
+
+            for obj in model.component_data_objects(Objective, active=True):
+                setattr(results.problem, field, pyo_value(obj.expr))
+                break
+        except Exception:
+            pass
+        return results
+
+    def _error_results(self, model, message: str) -> SolverResults:
+        results = SolverResults()
+        results.solver.name = "discopt"
+        tc, ss = _mapping.termination_for("error")
+        results.solver.termination_condition = tc
+        results.solver.status = ss
+        results.solver.message = message
+        return results

--- a/python/tests/test_pyomo_interface.py
+++ b/python/tests/test_pyomo_interface.py
@@ -1,0 +1,159 @@
+"""Tests for the optional Pyomo ``SolverFactory('discopt')`` plugin.
+
+The bridge round-trips a Pyomo model through a temporary AMPL ``.nl`` file into
+discopt and maps the solution back by column order. These tests skip when Pyomo is
+not installed (``pip install discopt[pyomo]``).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import pytest  # noqa: E402
+
+pyo = pytest.importorskip("pyomo.environ")
+
+import discopt.pyomo  # noqa: E402,F401  (registers the solver)
+
+
+@pytest.fixture()
+def opt():
+    return pyo.SolverFactory("discopt")
+
+
+def _tiny_minlp(sense=None):
+    """min (x-3)^2 + 2y  s.t. x + 5y >= 4 ; x in [0,10], y binary -> x=4, y=0, obj=1."""
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(0, 10))
+    m.y = pyo.Var(domain=pyo.Binary)
+    m.obj = pyo.Objective(expr=(m.x - 3) ** 2 + 2 * m.y, sense=sense or pyo.minimize)
+    m.c = pyo.Constraint(expr=m.x + 5 * m.y >= 4)
+    return m
+
+
+def test_registration(opt):
+    assert "discopt" in pyo.SolverFactory
+    assert opt.available() is True
+
+
+def test_roundtrip_matches_from_nl(opt, tmp_path):
+    """The plugin must match a direct from_nl().solve() on the same .nl: same status,
+    objective, and variable values aligned by column order (names differ)."""
+    import discopt.modeling as dm
+
+    m = _tiny_minlp()
+    res = opt.solve(m)
+    assert res.solver.termination_condition == pyo.TerminationCondition.optimal
+    assert pyo.value(m.obj) == pytest.approx(1.0, abs=1e-3)
+    assert m.x.value == pytest.approx(4.0, abs=1e-3)
+    assert m.y.value == 0  # exact integer, not 1e-9 drift
+
+    # Independent reference: write the same model and solve via from_nl directly.
+    from pyomo.repn.plugins.nl_writer import NLWriter
+
+    nl = str(tmp_path / "ref.nl")
+    with open(nl, "w") as f:
+        info = NLWriter().write(m, f, linear_presolve=False, scale_model=False)
+    ref = dm.from_nl(nl).solve(time_limit=30, gap_tolerance=1e-4)
+    assert ref.status == "optimal"
+    assert ref.objective == pytest.approx(pyo.value(m.obj), rel=1e-4, abs=1e-6)
+    # Column-order alignment: the i-th .nl column value equals the plugin-loaded var.
+    flat = []
+    import numpy as np
+
+    dref = dm.from_nl(nl)
+    for v in dref._variables:
+        flat.extend(np.asarray(ref.x[v.name]).ravel())
+    pyomo_vals = [info.variables[i].value for i in range(len(info.variables))]
+    assert pyomo_vals == pytest.approx(flat, abs=1e-3)
+
+
+def test_maximize_sense(opt):
+    """max -(x-3)^2 over [0,10] -> x=3, obj=0 (no sign flip)."""
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(0, 10))
+    m.o = pyo.Objective(expr=-((m.x - 3) ** 2), sense=pyo.maximize)
+    res = opt.solve(m)
+    assert res.solver.termination_condition == pyo.TerminationCondition.optimal
+    assert m.x.value == pytest.approx(3.0, abs=1e-3)
+    assert pyo.value(m.o) == pytest.approx(0.0, abs=1e-3)
+
+
+def test_integer_rounding(opt):
+    """An integral optimum loads as an exact integer."""
+    m = _tiny_minlp()
+    opt.solve(m)
+    assert m.y.value in (0, 1)
+    assert float(m.y.value).is_integer()
+
+
+def test_infeasible(opt):
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(0, 1))
+    m.o = pyo.Objective(expr=m.x)
+    m.c = pyo.Constraint(expr=m.x >= 2)
+    res = opt.solve(m)
+    assert res.solver.termination_condition == pyo.TerminationCondition.infeasible
+
+
+def test_options_passthrough(opt, monkeypatch):
+    """Pyomo's `timelimit`/options reach Model.solve as the right kwargs."""
+    import discopt.modeling as dm
+
+    captured = {}
+    orig = dm.Model.solve
+
+    def spy(self, *a, **k):
+        captured.update(k)
+        return orig(self, *a, **k)
+
+    monkeypatch.setattr(dm.Model, "solve", spy)
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(0, 5))
+    m.o = pyo.Objective(expr=m.x)
+    opt.solve(m, options={"timelimit": 7, "mipgap": 1e-3})
+    assert captured.get("time_limit") == 7
+    assert captured.get("gap_tolerance") == 1e-3
+
+
+def test_duals_when_exposed(opt):
+    """Convex NLP min (x-3)^2 s.t. x>=4 -> KKT multiplier ~2; sign matches the
+    AMPL/Pyomo convention (cross-checked against ipopt's value 2.0)."""
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(0, 10))
+    m.o = pyo.Objective(expr=(m.x - 3) ** 2, sense=pyo.minimize)
+    m.c = pyo.Constraint(expr=m.x >= 4)
+    m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+    res = opt.solve(m)
+    assert res.solver.termination_condition == pyo.TerminationCondition.optimal
+    assert m.x.value == pytest.approx(4.0, abs=1e-3)
+    d = m.dual.get(m.c)
+    assert d is not None, "discopt exposed duals but the plugin did not load them"
+    assert d == pytest.approx(2.0, abs=1e-3)
+
+
+def test_duals_graceful_for_integer_model(opt):
+    """Solving an integer model with a `dual` Suffix declared must not error,
+    whether or not discopt exposes multipliers (it may surface relaxation duals).
+    Any loaded value must be a finite number, never garbage."""
+    import math
+
+    m = pyo.ConcreteModel()
+    m.y = pyo.Var(domain=pyo.Binary)
+    m.o = pyo.Objective(expr=m.y, sense=pyo.minimize)
+    m.c = pyo.Constraint(expr=m.y >= 0)
+    m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+    res = opt.solve(m)
+    assert res.solver.termination_condition in (
+        pyo.TerminationCondition.optimal,
+        pyo.TerminationCondition.feasible,
+    )
+    d = m.dual.get(m.c)
+    assert d is None or math.isfinite(d)  # absent or finite — never fabricated/NaN
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Adds an **optional Pyomo `SolverFactory('discopt')` plugin** so existing Pyomo
models can be solved with discopt without a rewrite (`pip install discopt[pyomo]`).
Previously `from_pyomo` was a `NotImplementedError` stub and the
`SolverFactory('discopt')` shown in the examples didn't exist.

## Strategy — in-process `.nl` round-trip

Pyomo's NL writer emits a temporary `.nl` (presolve + scaling disabled, so it stays
in the original variable space with every variable as a column), `discopt.from_nl`
reads it with the **same column/row order**, `Model.solve` runs, and the solution
maps back **by index, not name** (Pyomo and discopt name things differently). This
is cheaper and more robust than shelling out + parsing `.sol`, and the column-order
guarantee makes the mapping an index identity.

## What's included

- Primal loading with integer/binary rounding + bound clamping.
- Minimize/maximize (no sign flip — `from_nl` preserves sense, `SolveResult.objective`
  is user-sense).
- Status → Pyomo `TerminationCondition`/`SolverStatus`; node count, wall time.
- Option passthrough (`timelimit`/`mipgap`/`threads`/`tee` → `Model.solve` kwargs;
  unknown options forwarded verbatim).
- **Duals + reduced costs** into `dual`/`rc` Suffixes, aligned by row/column index.
  Sign matches AMPL/Pyomo — cross-checked: `dual == ipopt`'s `2.0` on a convex NLP.
  Best-effort: populated only when discopt exposes KKT multipliers; never fabricated.
- Structured `error` result for models discopt's reader can't handle; zero-variable
  models short-circuit.

Module `python/discopt/pyomo/` mirrors the `llm`/`nn` optional-integration pattern
(`is_available()`/`register()`, lazy imports). Activated by `import discopt.pyomo`
or a `pyomo.solvers` entry point. **`import discopt` does not eagerly import pyomo.**

## Tests & docs

- `python/tests/test_pyomo_interface.py` (skips if pyomo absent): registration,
  round-trip equivalence vs `from_nl` by column order, maximize, integer rounding,
  infeasible, option passthrough, duals (value + sign), graceful integer-model dual
  handling — **8 passed**.
- mypy + ruff clean; `import discopt` does not pull in pyomo.
- **Runnable notebook** `docs/notebooks/pyomo_solver.ipynb` (executed, real outputs),
  cites `Hart2017` (Pyomo) + `Fourer2003` (AMPL `.nl`); reference doc
  `docs/pyomo_solver.md`; both in the TOC. `jupyter-book build` clean (zero
  pyomo-related warnings).

## Follow-ups (out of scope)

- Direct `from_pyomo` DAG translator (no `.nl`) behind the same interface.
- Rich PSE-form `Model._repr_html_` / `_repr_latex_`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
