### PR TITLE
feat(modeling): rich LaTeX/HTML representation of Model in standard PSE form

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -58,6 +58,7 @@ parts:
       - file: notebooks/suspect_head_to_head
       - file: notebooks/nlp_bb
       - file: notebooks/export_formats
+      - file: notebooks/model_representations
       - file: notebooks/pyomo_solver
       - file: pyomo_solver
       - file: notebooks/callbacks

--- a/docs/notebooks/model_representations.ipynb
+++ b/docs/notebooks/model_representations.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2eddaf04",
+   "metadata": {},
+   "source": [
+    "# Rich model representations\n",
+    "\n",
+    "A discopt {py:class}`~discopt.modeling.core.Model` renders itself as a typeset optimization problem in standard form {cite:p}`Williams2013` — `minimize f(x)` / `subject to g(x) ≤ 0` / variable domains. In Jupyter the model displays automatically; you can also export the LaTeX or HTML for papers and docs.\n",
+    "\n",
+    "Let us build a small mixed-integer nonlinear program and just *look* at it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "466e952b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.608989Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.608792Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.650516Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.650097Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"discopt-model\"><div style=\"font-weight:600\">Model <code>blend</code> <span style=\"color:#888;font-weight:400\">(2 variables, 2 constraints)</span></div>$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+       "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+       "&  \\quad && \\exp\\!\\left(x\\right) \\le 100 \\\\\n",
+       "& \\text{with} \\quad && 0 \\le x \\le 10 \\\\\n",
+       "&  \\quad && y \\in \\{0, 1\\} \\\\\n",
+       "\\end{aligned}\n",
+       "$$</div>"
+      ],
+      "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+       "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+       "&  \\quad && \\exp\\!\\left(x\\right) \\le 100 \\\\\n",
+       "& \\text{with} \\quad && 0 \\le x \\le 10 \\\\\n",
+       "&  \\quad && y \\in \\{0, 1\\} \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/plain": [
+       "Model: blend\n",
+       "  Variables: 2 (1 continuous, 1 integer/binary)\n",
+       "  Constraints: 2\n",
+       "  Objective: minimize (((x - 3) ** 2) + (2 * y))\n",
+       "  Parameters: 0"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import discopt.modeling as dm\n",
+    "\n",
+    "m = dm.Model(\"blend\")\n",
+    "x = m.continuous(\"x\", lb=0, ub=10)\n",
+    "y = m.binary(\"y\")\n",
+    "m.minimize((x - 3) ** 2 + 2 * y)\n",
+    "m.subject_to(x + 5 * y >= 4)\n",
+    "m.subject_to(dm.exp(x) <= 100)\n",
+    "\n",
+    "m  # renders as a typeset problem (HTML/LaTeX via MathJax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2fcfe10",
+   "metadata": {},
+   "source": [
+    "The constraints are shown in their natural form (`x + 5y ≥ 4`), even though they are stored internally in normalised `g(x) ≤ 0` form. To get the markup directly — e.g. to paste into a paper — use `to_latex()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bfeb6e27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.651838Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.651749Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.653577Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.653271Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\\begin{aligned}\n",
+      "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+      "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+      "&  \\quad && \\exp\\!\\left(x\\right) \\le 100 \\\\\n",
+      "& \\text{with} \\quad && 0 \\le x \\le 10 \\\\\n",
+      "&  \\quad && y \\in \\{0, 1\\} \\\\\n",
+      "\\end{aligned}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(m.to_latex())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e68f5b8b",
+   "metadata": {},
+   "source": [
+    "## Nonlinear expressions\n",
+    "\n",
+    "The renderer handles powers (superscripts), division (fractions), and the elementary functions (`exp`, `log`, `sqrt`, the trig family, …)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e60f9d81",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.654634Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.654581Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.656713Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.656422Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"discopt-model\"><div style=\"font-weight:600\">Model <code>nlp</code> <span style=\"color:#888;font-weight:400\">(2 variables, 1 constraint)</span></div>$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{maximize} \\quad && \\frac{\\exp\\!\\left(a\\right)}{b + 1} \\\\\n",
+       "& \\text{subject to} \\quad && \\sqrt{a} + b^{2} \\le 10 \\\\\n",
+       "& \\text{with} \\quad && 1 \\le a \\le 5 \\\\\n",
+       "&  \\quad && 1 \\le b \\le 5 \\\\\n",
+       "\\end{aligned}\n",
+       "$$</div>"
+      ],
+      "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{maximize} \\quad && \\frac{\\exp\\!\\left(a\\right)}{b + 1} \\\\\n",
+       "& \\text{subject to} \\quad && \\sqrt{a} + b^{2} \\le 10 \\\\\n",
+       "& \\text{with} \\quad && 1 \\le a \\le 5 \\\\\n",
+       "&  \\quad && 1 \\le b \\le 5 \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/plain": [
+       "Model: nlp\n",
+       "  Variables: 2 (2 continuous, 0 integer/binary)\n",
+       "  Constraints: 1\n",
+       "  Objective: maximize (exp(a) / (b + 1))\n",
+       "  Parameters: 0"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n = dm.Model(\"nlp\")\n",
+    "a = n.continuous(\"a\", lb=1, ub=5)\n",
+    "b = n.continuous(\"b\", lb=1, ub=5)\n",
+    "n.maximize(dm.exp(a) / (b + 1))\n",
+    "n.subject_to(dm.sqrt(a) + b**2 <= 10)\n",
+    "n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "667ba3be",
+   "metadata": {},
+   "source": [
+    "## Large models are summarised\n",
+    "\n",
+    "Auto-display truncates large models so a notebook is never flooded: the first few constraints are shown, then a `⋮` row with the totals, and variables are summarised by type. Pass `max_rows=None` to `to_latex()` / `to_html()` for the complete form."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "62f921ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.657791Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.657736Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.660149Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.659840Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"discopt-model\"><div style=\"font-weight:600\">Model <code>assignment</code> <span style=\"color:#888;font-weight:400\">(40 variables, 40 constraints)</span></div>$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && 0 + 1 \\cdot z_{0} + 2 \\cdot z_{1} + 3 \\cdot z_{2} + 4 \\cdot z_{3} + 5 \\cdot z_{4} + 6 \\cdot z_{5} + 7 \\cdot z_{6} + 8 \\cdot z_{7} + 9 \\cdot z_{8} + 10 \\cdot z_{9} + 11 \\cdot z_{10} + 12 \\cdot z_{11} + 13 \\cdot z_{12} + 14 \\cdot z_{13} + 15 \\cdot z_{14} + 16 \\cdot z_{15} + 17 \\cdot z_{16} + 18 \\cdot z_{17} + 19 \\cdot z_{18} + 20 \\cdot z_{19} + 21 \\cdot z_{20} + 22 \\cdot z_{21} + 23 \\cdot z_{22} + 24 \\cdot z_{23} + 25 \\cdot z_{24} + 26 \\cdot z_{25} + 27 \\cdot z_{26} + 28 \\cdot z_{27} + 29 \\cdot z_{28} + 30 \\cdot z_{29} + 31 \\cdot z_{30} + 32 \\cdot z_{31} + 33 \\cdot z_{32} + 34 \\cdot z_{33} + 35 \\cdot z_{34} + 36 \\cdot z_{35} + 37 \\cdot z_{36} + 38 \\cdot z_{37} + 39 \\cdot z_{38} + 40 \\cdot z_{39} \\\\\n",
+       "& \\text{subject to} \\quad && z_{0} + z_{1} \\le 1 \\\\\n",
+       "&  \\quad && z_{1} + z_{2} \\le 1 \\\\\n",
+       "&  \\quad && z_{2} + z_{3} \\le 1 \\\\\n",
+       "&  \\quad && z_{3} + z_{4} \\le 1 \\\\\n",
+       "&  \\quad && z_{4} + z_{5} \\le 1 \\\\\n",
+       "&  \\quad && z_{5} + z_{6} \\le 1 \\\\\n",
+       "&  \\quad && z_{6} + z_{7} \\le 1 \\\\\n",
+       "&  \\quad && z_{7} + z_{8} \\le 1 \\\\\n",
+       "&  \\quad && z_{8} + z_{9} \\le 1 \\\\\n",
+       "&  \\quad && z_{9} + z_{10} \\le 1 \\\\\n",
+       "&  \\quad && z_{10} + z_{11} \\le 1 \\\\\n",
+       "&  \\quad && z_{11} + z_{12} \\le 1 \\\\\n",
+       "&  \\quad && z_{12} + z_{13} \\le 1 \\\\\n",
+       "&  \\quad && z_{13} + z_{14} \\le 1 \\\\\n",
+       "&  \\quad && z_{14} + z_{15} \\le 1 \\\\\n",
+       "&  \\quad && z_{15} + z_{16} \\le 1 \\\\\n",
+       "&  \\quad && z_{16} + z_{17} \\le 1 \\\\\n",
+       "&  \\quad && z_{17} + z_{18} \\le 1 \\\\\n",
+       "&  \\quad && z_{18} + z_{19} \\le 1 \\\\\n",
+       "&  \\quad && z_{19} + z_{20} \\le 1 \\\\\n",
+       "&  \\quad && z_{20} + z_{21} \\le 1 \\\\\n",
+       "&  \\quad && z_{21} + z_{22} \\le 1 \\\\\n",
+       "&  \\quad && z_{22} + z_{23} \\le 1 \\\\\n",
+       "&  \\quad && z_{23} + z_{24} \\le 1 \\\\\n",
+       "&  \\quad && \\vdots \\quad (\\text{40 constraints}) \\\\\n",
+       "& \\text{with} \\quad && 40\\ \\text{binary} \\text{ variables} \\\\\n",
+       "\\end{aligned}\n",
+       "$$</div>"
+      ],
+      "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && 0 + 1 \\cdot z_{0} + 2 \\cdot z_{1} + 3 \\cdot z_{2} + 4 \\cdot z_{3} + 5 \\cdot z_{4} + 6 \\cdot z_{5} + 7 \\cdot z_{6} + 8 \\cdot z_{7} + 9 \\cdot z_{8} + 10 \\cdot z_{9} + 11 \\cdot z_{10} + 12 \\cdot z_{11} + 13 \\cdot z_{12} + 14 \\cdot z_{13} + 15 \\cdot z_{14} + 16 \\cdot z_{15} + 17 \\cdot z_{16} + 18 \\cdot z_{17} + 19 \\cdot z_{18} + 20 \\cdot z_{19} + 21 \\cdot z_{20} + 22 \\cdot z_{21} + 23 \\cdot z_{22} + 24 \\cdot z_{23} + 25 \\cdot z_{24} + 26 \\cdot z_{25} + 27 \\cdot z_{26} + 28 \\cdot z_{27} + 29 \\cdot z_{28} + 30 \\cdot z_{29} + 31 \\cdot z_{30} + 32 \\cdot z_{31} + 33 \\cdot z_{32} + 34 \\cdot z_{33} + 35 \\cdot z_{34} + 36 \\cdot z_{35} + 37 \\cdot z_{36} + 38 \\cdot z_{37} + 39 \\cdot z_{38} + 40 \\cdot z_{39} \\\\\n",
+       "& \\text{subject to} \\quad && z_{0} + z_{1} \\le 1 \\\\\n",
+       "&  \\quad && z_{1} + z_{2} \\le 1 \\\\\n",
+       "&  \\quad && z_{2} + z_{3} \\le 1 \\\\\n",
+       "&  \\quad && z_{3} + z_{4} \\le 1 \\\\\n",
+       "&  \\quad && z_{4} + z_{5} \\le 1 \\\\\n",
+       "&  \\quad && z_{5} + z_{6} \\le 1 \\\\\n",
+       "&  \\quad && z_{6} + z_{7} \\le 1 \\\\\n",
+       "&  \\quad && z_{7} + z_{8} \\le 1 \\\\\n",
+       "&  \\quad && z_{8} + z_{9} \\le 1 \\\\\n",
+       "&  \\quad && z_{9} + z_{10} \\le 1 \\\\\n",
+       "&  \\quad && z_{10} + z_{11} \\le 1 \\\\\n",
+       "&  \\quad && z_{11} + z_{12} \\le 1 \\\\\n",
+       "&  \\quad && z_{12} + z_{13} \\le 1 \\\\\n",
+       "&  \\quad && z_{13} + z_{14} \\le 1 \\\\\n",
+       "&  \\quad && z_{14} + z_{15} \\le 1 \\\\\n",
+       "&  \\quad && z_{15} + z_{16} \\le 1 \\\\\n",
+       "&  \\quad && z_{16} + z_{17} \\le 1 \\\\\n",
+       "&  \\quad && z_{17} + z_{18} \\le 1 \\\\\n",
+       "&  \\quad && z_{18} + z_{19} \\le 1 \\\\\n",
+       "&  \\quad && z_{19} + z_{20} \\le 1 \\\\\n",
+       "&  \\quad && z_{20} + z_{21} \\le 1 \\\\\n",
+       "&  \\quad && z_{21} + z_{22} \\le 1 \\\\\n",
+       "&  \\quad && z_{22} + z_{23} \\le 1 \\\\\n",
+       "&  \\quad && z_{23} + z_{24} \\le 1 \\\\\n",
+       "&  \\quad && \\vdots \\quad (\\text{40 constraints}) \\\\\n",
+       "& \\text{with} \\quad && 40\\ \\text{binary} \\text{ variables} \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/plain": [
+       "Model: assignment\n",
+       "  Variables: 40 (0 continuous, 40 integer/binary)\n",
+       "  Constraints: 40\n",
+       "  Objective: minimize ((((((((((((((((((((((((((((((((((((((((0 + (1 * z0)) + (2 * z1)) + (3 * z2)) + (4 * z3)) + (5 * z4)) + (6 * z5)) + (7 * z6)) + (8 * z7)) + (9 * z8)) + (10 * z9)) + (11 * z10)) + (12 * z11)) + (13 * z12)) + (14 * z13)) + (15 * z14)) + (16 * z15)) + (17 * z16)) + (18 * z17)) + (19 * z18)) + (20 * z19)) + (21 * z20)) + (22 * z21)) + (23 * z22)) + (24 * z23)) + (25 * z24)) + (26 * z25)) + (27 * z26)) + (28 * z27)) + (29 * z28)) + (30 * z29)) + (31 * z30)) + (32 * z31)) + (33 * z32)) + (34 * z33)) + (35 * z34)) + (36 * z35)) + (37 * z36)) + (38 * z37)) + (39 * z38)) + (40 * z39))\n",
+       "  Parameters: 0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "big = dm.Model(\"assignment\")\n",
+    "z = [big.binary(f\"z{i}\") for i in range(40)]\n",
+    "big.minimize(sum((i + 1) * z[i] for i in range(40)))\n",
+    "for i in range(40):\n",
+    "    big.subject_to(z[i] + z[(i + 1) % 40] <= 1)\n",
+    "big  # truncated summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddd91a4f",
+   "metadata": {},
+   "source": [
+    "## Exporting\n",
+    "\n",
+    "`to_latex()` returns a LaTeX `aligned` block; `to_html()` returns a self-contained HTML fragment (the LaTeX typeset via MathJax) with a header naming the model. Both take `max_rows` to control truncation. The plain-text `repr` / `Model.summary()` remain available for terminals and logging."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "744cec0e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T01:35:35.661201Z",
+     "iopub.status.busy": "2026-06-29T01:35:35.661141Z",
+     "iopub.status.idle": "2026-06-29T01:35:35.662813Z",
+     "shell.execute_reply": "2026-06-29T01:35:35.662504Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<div class=\"discopt-model\"><div style=\"font-weight:600\">Model <code>blend</code> <span style=\"color:#888;font-weight:400\">(2 variables, 2 constraints)</span></div>$$\n",
+      "\\begin{aligned}\n",
+      "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+      "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+      "& ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(m.to_html()[:300], \"...\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/model_representations.ipynb
+++ b/docs/notebooks/model_representations.ipynb
@@ -18,10 +18,10 @@
    "id": "466e952b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.608989Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.608792Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.650516Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.650097Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.488323Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.487947Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.554832Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.554405Z"
     }
    },
    "outputs": [
@@ -39,6 +39,17 @@
        "$$</div>"
       ],
       "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
+       "& \\text{subject to} \\quad && 4 \\le x + 5 \\cdot y \\\\\n",
+       "&  \\quad && \\exp\\!\\left(x\\right) \\le 100 \\\\\n",
+       "& \\text{with} \\quad && 0 \\le x \\le 10 \\\\\n",
+       "&  \\quad && y \\in \\{0, 1\\} \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/markdown": [
        "$$\n",
        "\\begin{aligned}\n",
        "& \\text{minimize} \\quad && \\left(x - 3\\right)^{2} + 2 \\cdot y \\\\\n",
@@ -89,10 +100,10 @@
    "id": "bfeb6e27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.651838Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.651749Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.653577Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.653271Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.556335Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.556227Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.558071Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.557663Z"
     }
    },
    "outputs": [
@@ -130,10 +141,10 @@
    "id": "e60f9d81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.654634Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.654581Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.656713Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.656422Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.559072Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.558996Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.561261Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.560933Z"
     }
    },
    "outputs": [
@@ -150,6 +161,16 @@
        "$$</div>"
       ],
       "text/latex": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{maximize} \\quad && \\frac{\\exp\\!\\left(a\\right)}{b + 1} \\\\\n",
+       "& \\text{subject to} \\quad && \\sqrt{a} + b^{2} \\le 10 \\\\\n",
+       "& \\text{with} \\quad && 1 \\le a \\le 5 \\\\\n",
+       "&  \\quad && 1 \\le b \\le 5 \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
+      "text/markdown": [
        "$$\n",
        "\\begin{aligned}\n",
        "& \\text{maximize} \\quad && \\frac{\\exp\\!\\left(a\\right)}{b + 1} \\\\\n",
@@ -197,10 +218,10 @@
    "id": "62f921ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.657791Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.657736Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.660149Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.659840Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.562343Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.562279Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.565141Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.564770Z"
     }
    },
    "outputs": [
@@ -272,6 +293,39 @@
        "\\end{aligned}\n",
        "$$"
       ],
+      "text/markdown": [
+       "$$\n",
+       "\\begin{aligned}\n",
+       "& \\text{minimize} \\quad && 0 + 1 \\cdot z_{0} + 2 \\cdot z_{1} + 3 \\cdot z_{2} + 4 \\cdot z_{3} + 5 \\cdot z_{4} + 6 \\cdot z_{5} + 7 \\cdot z_{6} + 8 \\cdot z_{7} + 9 \\cdot z_{8} + 10 \\cdot z_{9} + 11 \\cdot z_{10} + 12 \\cdot z_{11} + 13 \\cdot z_{12} + 14 \\cdot z_{13} + 15 \\cdot z_{14} + 16 \\cdot z_{15} + 17 \\cdot z_{16} + 18 \\cdot z_{17} + 19 \\cdot z_{18} + 20 \\cdot z_{19} + 21 \\cdot z_{20} + 22 \\cdot z_{21} + 23 \\cdot z_{22} + 24 \\cdot z_{23} + 25 \\cdot z_{24} + 26 \\cdot z_{25} + 27 \\cdot z_{26} + 28 \\cdot z_{27} + 29 \\cdot z_{28} + 30 \\cdot z_{29} + 31 \\cdot z_{30} + 32 \\cdot z_{31} + 33 \\cdot z_{32} + 34 \\cdot z_{33} + 35 \\cdot z_{34} + 36 \\cdot z_{35} + 37 \\cdot z_{36} + 38 \\cdot z_{37} + 39 \\cdot z_{38} + 40 \\cdot z_{39} \\\\\n",
+       "& \\text{subject to} \\quad && z_{0} + z_{1} \\le 1 \\\\\n",
+       "&  \\quad && z_{1} + z_{2} \\le 1 \\\\\n",
+       "&  \\quad && z_{2} + z_{3} \\le 1 \\\\\n",
+       "&  \\quad && z_{3} + z_{4} \\le 1 \\\\\n",
+       "&  \\quad && z_{4} + z_{5} \\le 1 \\\\\n",
+       "&  \\quad && z_{5} + z_{6} \\le 1 \\\\\n",
+       "&  \\quad && z_{6} + z_{7} \\le 1 \\\\\n",
+       "&  \\quad && z_{7} + z_{8} \\le 1 \\\\\n",
+       "&  \\quad && z_{8} + z_{9} \\le 1 \\\\\n",
+       "&  \\quad && z_{9} + z_{10} \\le 1 \\\\\n",
+       "&  \\quad && z_{10} + z_{11} \\le 1 \\\\\n",
+       "&  \\quad && z_{11} + z_{12} \\le 1 \\\\\n",
+       "&  \\quad && z_{12} + z_{13} \\le 1 \\\\\n",
+       "&  \\quad && z_{13} + z_{14} \\le 1 \\\\\n",
+       "&  \\quad && z_{14} + z_{15} \\le 1 \\\\\n",
+       "&  \\quad && z_{15} + z_{16} \\le 1 \\\\\n",
+       "&  \\quad && z_{16} + z_{17} \\le 1 \\\\\n",
+       "&  \\quad && z_{17} + z_{18} \\le 1 \\\\\n",
+       "&  \\quad && z_{18} + z_{19} \\le 1 \\\\\n",
+       "&  \\quad && z_{19} + z_{20} \\le 1 \\\\\n",
+       "&  \\quad && z_{20} + z_{21} \\le 1 \\\\\n",
+       "&  \\quad && z_{21} + z_{22} \\le 1 \\\\\n",
+       "&  \\quad && z_{22} + z_{23} \\le 1 \\\\\n",
+       "&  \\quad && z_{23} + z_{24} \\le 1 \\\\\n",
+       "&  \\quad && \\vdots \\quad (\\text{40 constraints}) \\\\\n",
+       "& \\text{with} \\quad && 40\\ \\text{binary} \\text{ variables} \\\\\n",
+       "\\end{aligned}\n",
+       "$$"
+      ],
       "text/plain": [
        "Model: assignment\n",
        "  Variables: 40 (0 continuous, 40 integer/binary)\n",
@@ -310,10 +364,10 @@
    "id": "744cec0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:35:35.661201Z",
-     "iopub.status.busy": "2026-06-29T01:35:35.661141Z",
-     "iopub.status.idle": "2026-06-29T01:35:35.662813Z",
-     "shell.execute_reply": "2026-06-29T01:35:35.662504Z"
+     "iopub.execute_input": "2026-06-29T10:42:10.566163Z",
+     "iopub.status.busy": "2026-06-29T10:42:10.566101Z",
+     "iopub.status.idle": "2026-06-29T10:42:10.567650Z",
+     "shell.execute_reply": "2026-06-29T10:42:10.567316Z"
     }
    },
    "outputs": [

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1447,6 +1447,15 @@ class Model:
 
         return f"$$\n{latex.model_to_latex(self, max_rows=latex._DEFAULT_MAX_ROWS)}\n$$"
 
+    def _repr_markdown_(self) -> str:
+        # VS Code's notebook renderer typesets ``text/markdown`` outputs with
+        # KaTeX but does not reliably render ``text/latex`` outputs; emit the
+        # same PSE block as fenced display math so it renders there too.
+        # Jupyter/MathJax frontends prefer ``_repr_latex_``/``_repr_html_``.
+        from discopt.modeling import latex
+
+        return f"$$\n{latex.model_to_latex(self, max_rows=latex._DEFAULT_MAX_ROWS)}\n$$"
+
     def _repr_html_(self) -> str:
         from discopt.modeling import latex
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1419,6 +1419,39 @@ class Model:
         self._builder_linear_objective: Optional[tuple] = None
         self._builder_quadratic_objective: Optional[tuple] = None
 
+    # ── Rich representation (LaTeX / HTML in standard PSE form) ──
+
+    def to_latex(self, max_rows: Optional[int] = None) -> str:
+        """Render the model as a LaTeX ``aligned`` block in standard problem form
+        (``minimize f(x)`` / ``subject to g(x) <= 0`` / variable domains).
+
+        Parameters
+        ----------
+        max_rows : int, optional
+            Cap on the number of constraint/variable rows shown; excess is
+            summarised with a ``\\vdots`` row. ``None`` (default) renders everything.
+        """
+        from discopt.modeling import latex
+
+        return latex.model_to_latex(self, max_rows=max_rows)
+
+    def to_html(self, max_rows: Optional[int] = None) -> str:
+        """Render the model as standalone HTML (the PSE LaTeX typeset via MathJax,
+        with a header naming the model and its size). See :meth:`to_latex`."""
+        from discopt.modeling import latex
+
+        return latex.model_to_html(self, max_rows=max_rows)
+
+    def _repr_latex_(self) -> str:
+        from discopt.modeling import latex
+
+        return f"$$\n{latex.model_to_latex(self, max_rows=latex._DEFAULT_MAX_ROWS)}\n$$"
+
+    def _repr_html_(self) -> str:
+        from discopt.modeling import latex
+
+        return latex.model_to_html(self, max_rows=latex._DEFAULT_MAX_ROWS)
+
     # ── Index sets ──
 
     def set(self, name: str, members, dimen: Optional[int] = None):

--- a/python/discopt/modeling/latex.py
+++ b/python/discopt/modeling/latex.py
@@ -1,0 +1,260 @@
+"""Rich rendering of :class:`~discopt.modeling.core.Model` objects.
+
+Produces LaTeX (and MathJax-backed HTML) in **standard PSE problem form**::
+
+    minimize/maximize   f(x)
+    subject to          g_i(x)  <=/>=/=  c_i
+                        bounds and integrality on the variables
+
+A small recursive visitor maps the expression DAG to LaTeX with minimal
+parenthesisation (operator precedence), proper superscripts/fractions/function
+names, and variable subscripts. Large models are summarised so an auto-rendered
+``_repr_`` cannot flood a notebook; the public ``model_to_latex`` / ``model_to_html``
+take ``max_rows=None`` for the full, untruncated form.
+
+Imported lazily by ``core.Model`` (the ``to_latex``/``_repr_latex_`` methods) to
+avoid a circular import.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import numpy as np
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    CustomCall,
+    Expression,
+    FunctionCall,
+    IndexExpression,
+    MatMulExpression,
+    SumExpression,
+    UnaryOp,
+    Variable,
+)
+
+# Default number of constraint / variable rows shown in an auto ``_repr_``.
+_DEFAULT_MAX_ROWS = 24
+
+# LaTeX renderings for known unary/elementary functions; ``None`` => special-cased.
+_FUNC_LATEX = {
+    "exp": r"\exp",
+    "log": r"\ln",
+    "log10": r"\log_{10}",
+    "sqrt": None,  # \sqrt{...}
+    "sin": r"\sin",
+    "cos": r"\cos",
+    "tan": r"\tan",
+    "sinh": r"\sinh",
+    "cosh": r"\cosh",
+    "tanh": r"\tanh",
+    "abs": None,  # \left|...\right|
+}
+
+# Binary-operator precedence (higher binds tighter) for minimal parenthesisation.
+_PREC = {"+": 1, "-": 1, "*": 2, "/": 2, "@": 2, "**": 4}
+
+
+def _fmt_num(v: float) -> str:
+    f = float(v)
+    if f == int(f) and abs(f) < 1e15:
+        return str(int(f))
+    return f"{f:.6g}"
+
+
+def _const_to_latex(value: Any) -> str:
+    """Render a constant: scalars as numbers, small vectors/matrices inline, and
+    larger arrays as a shape-annotated bold placeholder (the model does not name
+    numpy coefficients, so a shaped placeholder is the most honest compact form)."""
+    arr = np.asarray(value)
+    if arr.ndim == 0:
+        return _fmt_num(float(arr))
+    if arr.size <= 6 and arr.ndim == 1:
+        return r"\begin{bmatrix}" + r" \\ ".join(_fmt_num(x) for x in arr) + r"\end{bmatrix}"
+    if arr.size <= 6 and arr.ndim == 2:
+        return (
+            r"\begin{bmatrix}"
+            + r" \\ ".join(" & ".join(_fmt_num(x) for x in row) for row in arr)
+            + r"\end{bmatrix}"
+        )
+    shape = r"{\times}".join(str(d) for d in arr.shape)
+    return rf"\mathbf{{C}}_{{[{shape}]}}"
+
+
+def _sym(name: str) -> str:
+    """Render a variable name: ``x3`` -> ``x_{3}``; escape underscores otherwise."""
+    m = re.fullmatch(r"([A-Za-z]+)(\d+)", name)
+    if m:
+        return f"{m.group(1)}_{{{m.group(2)}}}"
+    return name.replace("_", r"\_")
+
+
+def expr_to_latex(e: Any, parent_prec: int = 0) -> str:
+    """Render an expression DAG node to LaTeX. Never raises — unknown nodes fall
+    back to an escaped string form so a display can't crash a model build."""
+    try:
+        if isinstance(e, Constant):
+            return _const_to_latex(e.value)
+        if isinstance(e, Variable):
+            return _sym(e.name)
+        if isinstance(e, IndexExpression):
+            idx = e.index
+            idx_s = ",".join(str(i) for i in idx) if isinstance(idx, tuple) else str(idx)
+            return f"{expr_to_latex(e.base, 5)}_{{{idx_s}}}"
+        if isinstance(e, BinaryOp):
+            return _binop_to_latex(e, parent_prec)
+        if isinstance(e, UnaryOp):
+            if e.op == "neg":
+                return f"-{expr_to_latex(e.operand, 3)}"
+            if e.op == "abs":
+                return rf"\left|{expr_to_latex(e.operand)}\right|"
+            return rf"\mathrm{{{e.op}}}\!\left({expr_to_latex(e.operand)}\right)"
+        if isinstance(e, FunctionCall):
+            args = ", ".join(expr_to_latex(a) for a in e.args)
+            if e.func_name == "sqrt":
+                return rf"\sqrt{{{args}}}"
+            name = _FUNC_LATEX.get(e.func_name) or rf"\mathrm{{{_sym(str(e.func_name))}}}"
+            return rf"{name}\!\left({args}\right)"
+        if isinstance(e, CustomCall):
+            args = ", ".join(expr_to_latex(a) for a in e.args)
+            return rf"\mathrm{{{_sym(str(e.name))}}}\!\left({args}\right)"
+        if isinstance(e, MatMulExpression):
+            return f"{expr_to_latex(e.left, 2)}\\,{expr_to_latex(e.right, 2)}"
+        if isinstance(e, SumExpression):
+            return rf"\textstyle\sum {expr_to_latex(e.operand, 3)}"
+        if isinstance(e, Expression):
+            return _escape_text(repr(e))
+        return _fmt_num(e) if _is_number(e) else _escape_text(str(e))
+    except Exception:
+        return _escape_text(repr(e))
+
+
+def _binop_to_latex(e: Any, parent_prec: int) -> str:
+    op = e.op
+    if op == "/":
+        return rf"\frac{{{expr_to_latex(e.left)}}}{{{expr_to_latex(e.right)}}}"
+    if op == "**":
+        return f"{expr_to_latex(e.left, 5)}^{{{expr_to_latex(e.right)}}}"
+    prec = _PREC.get(op, 1)
+    left = expr_to_latex(e.left, prec)
+    # right operand of a non-associative op needs one extra precedence level
+    right = expr_to_latex(e.right, prec + (1 if op in ("-", "/") else 0))
+    sym = {"+": "+", "-": "-", "*": r"\cdot", "@": r"\,"}[op]
+    s = f"{left} {sym} {right}"
+    if prec < parent_prec:
+        return rf"\left({s}\right)"
+    return s
+
+
+def _constraint_to_latex(c: Any) -> str:
+    """Render a constraint. Constraints are normalised to ``body sense 0``; when the
+    body is a top-level subtraction ``L - R`` we un-normalise to ``L sense R`` for a
+    natural reading (e.g. ``x + 5y >= 4`` instead of ``4 - (x + 5y) <= 0``)."""
+    sense = {"<=": r"\le", ">=": r"\ge", "==": "="}.get(c.sense, c.sense)
+    body = c.body
+    if isinstance(body, BinaryOp) and body.op == "-":
+        return f"{expr_to_latex(body.left)} {sense} {expr_to_latex(body.right)}"
+    rhs = _fmt_num(c.rhs) if getattr(c, "rhs", 0.0) else "0"
+    return f"{expr_to_latex(body)} {sense} {rhs}"
+
+
+def _var_domain_to_latex(v: Any) -> str:
+    vtype = v.var_type.value if hasattr(v.var_type, "value") else str(v.var_type)
+    lb = float(np.min(v.lb))
+    ub = float(np.max(v.ub))
+    big = 1e15
+    name = _sym(v.name) + (r"_{i}" if getattr(v, "size", 1) > 1 else "")
+    if vtype == "binary":
+        return rf"{name} \in \{{0, 1\}}"
+    if lb > -big and ub < big:
+        rng = rf"{_fmt_num(lb)} \le {name} \le {_fmt_num(ub)}"
+    elif lb > -big:
+        rng = rf"{name} \ge {_fmt_num(lb)}"
+    elif ub < big:
+        rng = rf"{name} \le {_fmt_num(ub)}"
+    else:
+        rng = ""
+    domain = {"integer": r"\mathbb{Z}", "continuous": r"\mathbb{R}"}.get(vtype, "")
+    if vtype == "integer":
+        return rf"{rng},\ {name} \in \mathbb{{Z}}" if rng else rf"{name} \in \mathbb{{Z}}"
+    return rng or rf"{name} \in {domain}"
+
+
+def model_to_latex(model: Any, max_rows: int | None = None, env: str = "aligned") -> str:
+    """Render *model* to a LaTeX ``aligned`` block in standard PSE form.
+
+    ``max_rows`` caps the number of constraint and variable rows shown (``None`` =
+    no limit); excess is replaced with a ``\\vdots`` summary row.
+    """
+    rows: list[str] = []
+    obj = getattr(model, "_objective", None)
+    if obj is not None:
+        sense = "minimize" if obj.sense.value == "minimize" else "maximize"
+        rows.append(rf"& \text{{{sense}}} \quad && {expr_to_latex(obj.expression)} \\")
+    else:
+        rows.append(r"& \text{find} \quad && x \\")
+
+    cons = list(getattr(model, "_constraints", []) or [])
+    shown = cons if max_rows is None else cons[:max_rows]
+    for i, c in enumerate(shown):
+        lead = r"\text{subject to}" if i == 0 else ""
+        rows.append(rf"& {lead} \quad && {_constraint_to_latex(c)} \\")
+    if max_rows is not None and len(cons) > max_rows:
+        lead = r"\text{subject to}" if not shown else ""
+        rows.append(rf"& {lead} \quad && \vdots \quad (\text{{{len(cons)} constraints}}) \\")
+
+    variables = list(getattr(model, "_variables", []) or [])
+    rows.extend(_variable_rows(variables, max_rows))
+    body = "\n".join(rows)
+    return f"\\begin{{{env}}}\n{body}\n\\end{{{env}}}"
+
+
+def _variable_rows(variables: list, max_rows: int | None) -> list[str]:
+    if not variables:
+        return []
+    if max_rows is not None and len(variables) > max_rows:
+        # Summarise by type rather than listing hundreds of declarations.
+        counts: dict[str, int] = {}
+        for v in variables:
+            t = v.var_type.value if hasattr(v.var_type, "value") else str(v.var_type)
+            counts[t] = counts.get(t, 0) + 1
+        parts = ", ".join(f"{n}\\ \\text{{{t}}}" for t, n in counts.items())
+        return [rf"& \text{{with}} \quad && {parts} \text{{ variables}} \\"]
+    out = []
+    for j, v in enumerate(variables):
+        lead = r"\text{with}" if j == 0 else ""
+        out.append(rf"& {lead} \quad && {_var_domain_to_latex(v)} \\")
+    return out
+
+
+def model_to_html(model: Any, max_rows: int | None = None) -> str:
+    """Standalone HTML rendering: a titled block with the PSE LaTeX rendered via the
+    notebook's MathJax. Falls back gracefully to showing the LaTeX source."""
+    name = getattr(model, "name", "model")
+    n_v = len(getattr(model, "_variables", []) or [])
+    n_c = len(getattr(model, "_constraints", []) or [])
+    latex = model_to_latex(model, max_rows=max_rows)
+    return (
+        f'<div class="discopt-model">'
+        f'<div style="font-weight:600">Model <code>{_escape_text(str(name))}</code>'
+        f' <span style="color:#888;font-weight:400">'
+        f"({n_v} variable{'s' if n_v != 1 else ''}, "
+        f"{n_c} constraint{'s' if n_c != 1 else ''})</span></div>"
+        f"$$\n{latex}\n$$"
+        f"</div>"
+    )
+
+
+def _escape_text(s: str) -> str:
+    return (
+        s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        if "<" in s or ">" in s or "&" in s
+        else s
+    )
+
+
+def _is_number(x: Any) -> bool:
+    return isinstance(x, (int, float, np.integer, np.floating))

--- a/python/tests/test_model_latex.py
+++ b/python/tests/test_model_latex.py
@@ -1,0 +1,122 @@
+"""Rich LaTeX / HTML representation of Model objects (standard PSE problem form)."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt.modeling import latex  # noqa: E402
+
+
+def _minlp():
+    m = dm.Model("demo")
+    x = m.continuous("x", lb=0, ub=10)
+    y = m.binary("y")
+    m.minimize((x - 3) ** 2 + 2 * y)
+    m.subject_to(x + 5 * y >= 4)
+    return m
+
+
+def test_to_latex_structure():
+    s = _minlp().to_latex()
+    assert s.startswith("\\begin{aligned}") and s.endswith("\\end{aligned}")
+    assert r"\text{minimize}" in s
+    assert r"\text{subject to}" in s
+    # power -> superscript, product -> \cdot
+    assert "^{2}" in s
+    assert r"\cdot" in s
+    # un-normalised natural constraint form (not "4 - (...) <= 0")
+    assert r"4 \le x + 5 \cdot y" in s
+    # variable domains
+    assert r"0 \le x \le 10" in s
+    assert r"y \in \{0, 1\}" in s
+
+
+def test_operator_rendering():
+    m = dm.Model("ops")
+    a = m.continuous("a", lb=1, ub=5)
+    b = m.continuous("b", lb=1, ub=5)
+    m.maximize(dm.exp(a) / (b + 1))
+    m.subject_to(a * b <= 6)
+    s = m.to_latex()
+    assert r"\text{maximize}" in s
+    assert r"\frac{" in s  # division
+    assert r"\exp" in s  # function name
+
+
+def test_integer_and_continuous_domains():
+    m = dm.Model("d")
+    k = m.integer("k", lb=0, ub=7)
+    z = m.continuous("z", lb=-1, ub=1)
+    m.minimize(k + z)
+    s = m.to_latex()
+    assert r"\mathbb{Z}" in s
+    assert r"-1 \le z \le 1" in s
+
+
+def test_maximize_sense():
+    m = dm.Model("mx")
+    x = m.continuous("x", lb=0, ub=10)
+    m.maximize(-((x - 3) ** 2))
+    assert r"\text{maximize}" in m.to_latex()
+
+
+def test_constant_vector_rendering():
+    m = dm.Model("vec")
+    v = m.continuous("v", shape=(3,), lb=0, ub=5)
+    m.minimize(np.array([1.0, 2.0, 3.0]) @ v)
+    s = m.to_latex()
+    assert "bmatrix" in s  # small constant vector rendered inline
+
+
+def test_truncation_and_full():
+    m = dm.Model("big")
+    xs = [m.continuous(f"x{i}", lb=0, ub=1) for i in range(60)]
+    m.minimize(sum(xs))
+    for i in range(60):
+        m.subject_to(xs[i] >= 0.0)
+    truncated = m.to_latex(max_rows=5)
+    assert r"\vdots" in truncated
+    assert "60 constraints" in truncated
+    # variable summary instead of 60 rows
+    assert r"\text{continuous}" in truncated
+    full = m.to_latex(max_rows=None)
+    assert r"\vdots" not in full
+    assert full.count(r"\\") > 60  # all constraints + vars rendered
+
+
+def test_repr_latex_and_html():
+    m = _minlp()
+    lx = m._repr_latex_()
+    assert lx.startswith("$$") and lx.endswith("$$")
+    html = m._repr_html_()
+    assert "discopt-model" in html
+    assert "demo" in html  # model name in header
+    assert "2 variables" in html and "1 constraint" in html
+
+
+def test_never_crashes_on_empty_model():
+    m = dm.Model("empty")
+    # no objective, no constraints, no vars
+    assert isinstance(m.to_latex(), str)
+    assert isinstance(m.to_html(), str)
+    assert r"\text{find}" in m.to_latex()
+
+
+def test_expr_to_latex_is_total():
+    """The visitor must return a string for every node type, never raising."""
+    m = dm.Model("nodes")
+    x = m.continuous("x", shape=(2,), lb=0, ub=5)
+    exprs = [x[0] ** 2, abs(x[0]), -x[1], dm.sqrt(x[0]), dm.log(x[1] + 1), x[0] * x[1]]
+    for e in exprs:
+        out = latex.expr_to_latex(e)
+        assert isinstance(out, str) and out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

`Model` objects now render as a **typeset optimization problem in standard PSE
form** in Jupyter, and export to LaTeX/HTML. Previously only `Expression` had a
trivial `_repr_latex_` (the Python repr wrapped in `$...$`, showing `**`, `*`,
`neg()`); `Model` had no rich representation at all.

## What's added

`python/discopt/modeling/latex.py` — a recursive DAG→LaTeX visitor with:
- minimal parenthesisation (operator precedence),
- superscripts (`x^{2}`), fractions (`\frac`), function names (`\exp`, `\ln`,
  `\sqrt`, trig…), variable subscripts, and `|·|`,
- constants rendered inline when small, else a shape-annotated placeholder,
- **totality** — never raises; unknown nodes fall back to an escaped string.

assembled into standard form:

```
minimize/maximize   f(x)
subject to          g_i(x) <=/>=/=  c_i      (un-normalised for natural reading)
                    variable bounds and integrality (ℝ / ℤ / {0,1})
```

`Model` gains:
- `to_latex(max_rows=None)` / `to_html(max_rows=None)` — public export.
- `_repr_latex_` / `_repr_html_` — Jupyter auto-display.
- The existing `__repr__` → `summary()` text form is **unchanged**.

**Large models are summarised** in the auto-display (first ~24 constraints, then a
`⋮` row with totals, and a by-type variable count) so a notebook is never flooded;
the public methods take `max_rows=None` for the complete form.

## Example

```python
m = dm.Model("blend")
x = m.continuous("x", lb=0, ub=10); y = m.binary("y")
m.minimize((x - 3) ** 2 + 2 * y)
m.subject_to(x + 5 * y >= 4)
m   # renders as:  minimize (x-3)^2 + 2·y  s.t.  4 ≤ x + 5·y ;  0 ≤ x ≤ 10 ;  y ∈ {0,1}
```

## Tests & docs

- `python/tests/test_model_latex.py` (9): structure, operator rendering, sense,
  domains, constant vectors, truncation vs full, `_repr_` hooks, empty model,
  visitor totality. ruff + mypy clean; 215 modeling tests still pass.
- Runnable notebook `docs/notebooks/model_representations.ipynb` (executed, real
  rendered outputs), cites `Williams2013`; in the TOC; `jupyter-book` build clean.

## Follow-up (out of scope)

- A direct `from_pyomo` translator and other interop are tracked separately; this
  PR is the representation layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
