### PR TITLE
fix(presolve): FBBT forward-substitution bounds free aux vars — nvs05 certifies

### DIFF
--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -2443,7 +2443,171 @@ class PeriodicVariableBoundRule(NonlinearBoundTighteningRule):
             return np.asarray(flat_lb, dtype=np.float64), np.asarray(flat_ub, dtype=np.float64)
 
 
+_EXPR_CHILD_ATTRS = ("left", "right", "operand", "base")
+_EXPR_CHILD_SEQS = ("args", "operands", "terms")
+
+
+def _collect_expr_flat_indices(expr, metadata: FlatVariableMetadata, out: set) -> None:
+    """Collect the flat variable indices referenced anywhere in ``expr``."""
+    si = metadata.scalar_flat_index(expr)
+    if si is not None:
+        out.add(si)
+        return
+    if isinstance(expr, Variable):
+        off = metadata.base_offsets.get(id(expr))
+        if off is not None:
+            out.update(range(off, off + expr.size))
+        return
+    if isinstance(expr, (Constant, Parameter)):
+        return
+    for attr in _EXPR_CHILD_ATTRS:
+        child = getattr(expr, attr, None)
+        if isinstance(child, _EXPR_TYPES):
+            _collect_expr_flat_indices(child, metadata, out)
+    for attr in _EXPR_CHILD_SEQS:
+        seq = getattr(expr, attr, None)
+        if seq:
+            for child in seq:
+                if isinstance(child, _EXPR_TYPES):
+                    _collect_expr_flat_indices(child, metadata, out)
+
+
+class DefinedVariableForwardRule(NonlinearBoundTighteningRule):
+    """Forward-substitution FBBT for variables *defined* by an equality.
+
+    When a scalar variable appears linearly and in isolation in an equality —
+    ``c·x_def + g(others) == rhs`` with ``x_def`` absent from ``g`` — it is fully
+    determined: ``x_def = (rhs - g)/c``. Bounding ``x_def`` by the interval
+    enclosure of ``(rhs - g)/c`` over the current box turns an *unbounded* auxiliary
+    (e.g. a division/sqrt slack ``x4 = 4243.28/(x0·x1)``, gear4/nvs05-class) into a
+    finite range. That is what lets the McCormick relaxation over the variable's
+    subtree stay bounded, so the spatial dual bound becomes *certifiable* instead of
+    being dropped as un-rigorous on an unbounded node (issue: nvs/gear unbounded
+    auxiliaries). Sound: an interval enclosure of the defining expression is a valid
+    enclosure of the variable; bounds are only ever intersected, never loosened. The
+    fixpoint loop in :func:`tighten_nonlinear_bounds` resolves chained definitions
+    (``x7`` defined via ``x6`` resolves once ``x6`` is bounded).
+    """
+
+    name = "defined_variable_forward"
+
+    def tighten(self, model, flat_lb, flat_ub, metadata):
+        from discopt._jax.convexity.interval import Interval
+        from discopt._jax.convexity.interval_eval import evaluate_interval
+
+        out_lb = flat_lb.copy()
+        out_ub = flat_ub.copy()
+
+        # Reverse map: flat scalar index -> Variable (for in-call box updates).
+        idx_to_var: dict[int, Variable] = {}
+        box: dict = {}
+        for var in model._variables:
+            off = metadata.base_offsets[id(var)]
+            sz = var.size
+            box[var] = Interval(
+                float(np.min(out_lb[off : off + sz])),
+                float(np.max(out_ub[off : off + sz])),
+            )
+            if sz == 1:
+                idx_to_var[off] = var
+
+        for con in model._constraints:
+            if getattr(con, "sense", None) != "==":
+                continue
+            rhs = float(getattr(con, "rhs", 0.0) or 0.0)
+            if not np.isfinite(rhs):
+                continue
+            terms = _cached_flat_terms(model, con.body)
+            if len(terms) < 2:
+                continue
+            iso = self._isolated_defined_var(terms, metadata, out_lb, out_ub)
+            if iso is None:
+                continue
+            iso_pos, iso_idx, c_iso = iso
+
+            # Interval of the rest = sum_{k != iso_pos} c_k * I(leaf_k).
+            rest_lo = 0.0
+            rest_hi = 0.0
+            ok = True
+            for k, (c_k, leaf_k) in enumerate(terms):
+                if k == iso_pos:
+                    continue
+                iv = evaluate_interval(leaf_k, model, box)
+                if iv is None or not (np.isfinite(iv.lo) and np.isfinite(iv.hi)):
+                    ok = False
+                    break
+                a, b = c_k * iv.lo, c_k * iv.hi
+                rest_lo += min(a, b)
+                rest_hi += max(a, b)
+            if not ok:
+                continue
+
+            # x_iso = (rhs - rest) / c_iso.
+            num_lo, num_hi = rhs - rest_hi, rhs - rest_lo
+            if c_iso > 0:
+                new_lo, new_hi = num_lo / c_iso, num_hi / c_iso
+            else:
+                new_lo, new_hi = num_hi / c_iso, num_lo / c_iso
+            if not (np.isfinite(new_lo) and np.isfinite(new_hi)):
+                continue
+
+            upd_lo = max(out_lb[iso_idx], new_lo)
+            upd_hi = min(out_ub[iso_idx], new_hi)
+            tightened = (
+                not np.isfinite(out_lb[iso_idx])
+                or not np.isfinite(out_ub[iso_idx])
+                or upd_lo > out_lb[iso_idx] + 1e-12
+                or upd_hi < out_ub[iso_idx] - 1e-12
+            )
+            if tightened and upd_lo <= upd_hi + _EMPTY_INTERVAL_FEAS_TOL:
+                out_lb[iso_idx] = upd_lo
+                out_ub[iso_idx] = upd_hi
+                var = idx_to_var.get(iso_idx)
+                if var is not None:  # let later constraints in this pass use it
+                    box[var] = Interval(upd_lo, upd_hi)
+        return out_lb, out_ub
+
+    @staticmethod
+    def _isolated_defined_var(terms, metadata, lb, ub):
+        """Find a term whose leaf is a scalar variable that (a) is currently
+        unbounded on a side and (b) appears in no other term. Returns
+        ``(term_pos, flat_idx, coeff)`` or ``None``."""
+        for pos, (coeff, leaf) in enumerate(terms):
+            if abs(coeff) < 1e-12:
+                continue
+            idx = metadata.scalar_flat_index(leaf)
+            if idx is None:
+                continue
+            if np.isfinite(lb[idx]) and np.isfinite(ub[idx]):
+                continue  # already bounded; this rule targets free aux variables
+            others: set = set()
+            for k, (_c, other_leaf) in enumerate(terms):
+                if k == pos:
+                    continue
+                _collect_expr_flat_indices(other_leaf, metadata, others)
+            if idx in others:
+                continue  # not isolated (appears elsewhere) → cannot forward-solve
+            return pos, idx, coeff
+        return None
+
+
+_EXPR_TYPES = (
+    Variable,
+    Constant,
+    Parameter,
+    BinaryOp,
+    UnaryOp,
+    FunctionCall,
+    CustomCall,
+    IndexExpression,
+    MatMulExpression,
+    SumExpression,
+    SumOverExpression,
+)
+
+
 DEFAULT_NONLINEAR_BOUND_RULES: tuple[NonlinearBoundTighteningRule, ...] = (
+    DefinedVariableForwardRule(),
     MonotoneFunctionEqualityRule(),
     QuadraticEqualityBoundsRule(),
     SquareDifferenceLowerBoundRule(),

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3583,6 +3583,31 @@ def solve_model(
             python_time=wall_time - rust_time - jax_time,
         )
 
+    # --- Python nonlinear forward-substitution FBBT (on top of the Rust FBBT) ---
+    # The Rust FBBT above does not forward-*define* unbounded auxiliary variables —
+    # division/sqrt slacks of the form ``x = f(others)`` (gear4/nvs05 class). The
+    # DefinedVariableForwardRule in tighten_nonlinear_bounds bounds them by the
+    # interval enclosure of their defining expression. This is what keeps the
+    # per-node McCormick relaxation bounded over the whole tree: an unbounded-
+    # relaxation node is otherwise sentinel-pruned, which taints the spatial dual
+    # bound so the (already-found) optimum cannot be certified. Runs before the root
+    # OBBT below so OBBT's min/max LPs over the relaxation are themselves bounded.
+    lb, ub, _nl_root_infeasible = _apply_nonlinear_tightening_with_status(model, lb, ub)
+    if _nl_root_infeasible:
+        wall_time = time.perf_counter() - t_start
+        return SolveResult(
+            status="infeasible",
+            objective=None,
+            bound=None,
+            gap=None,
+            x=None,
+            wall_time=wall_time,
+            node_count=0,
+            rust_time=rust_time,
+            jax_time=jax_time,
+            python_time=wall_time - rust_time - jax_time,
+        )
+
     # --- Root OBBT over the McCormick relaxation (range reduction) ---
     # For nonconvex models the spatial B&B solves an LP-form McCormick
     # relaxation at every node; tightening the root box here strengthens that

--- a/python/tests/test_defined_variable_forward_fbbt.py
+++ b/python/tests/test_defined_variable_forward_fbbt.py
@@ -1,0 +1,98 @@
+"""FBBT forward-substitution for variables defined by an equality (issue: nvs/gear
+unbounded auxiliaries).
+
+A variable that appears linearly and in isolation in an equality —
+``c·x_def + g(others) == rhs`` with ``x_def`` absent from ``g`` — is fully
+determined: ``x_def = (rhs - g)/c``. ``DefinedVariableForwardRule`` bounds it by the
+interval enclosure of the defining expression. This turns the *unbounded* division/
+sqrt auxiliary slacks of the nvs05/gear4 class into finite ranges, which keeps the
+per-node McCormick relaxation bounded over the whole spatial tree. Without it an
+unbounded-relaxation node is sentinel-pruned (an unsound fathom), permanently
+tainting the dual bound so the (already-found) global optimum can never be
+certified.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+from discopt.modeling.core import from_nl
+from discopt.solver import _extract_variable_info
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+
+def test_forward_substitution_bounds_division_slack():
+    """A free slack ``s = c/(x*y)`` over a positive box gets a finite, *sound* range."""
+    m = dm.Model("recip_slack")
+    x = m.continuous("x", lb=1.0, ub=10.0)
+    y = m.continuous("y", lb=2.0, ub=4.0)
+    s = m.continuous("s", lb=-float("inf"), ub=float("inf"))  # defined by the equality
+    m.minimize(x + y)
+    m.subject_to(s == 12.0 / (x * y))
+
+    _, lb, ub, _, _ = _extract_variable_info(m)
+    s_idx = [v.name for v in m._variables].index("s")
+    assert not np.isfinite(lb[s_idx]) and not np.isfinite(ub[s_idx])  # free to start
+
+    tl, tu, stats = tighten_nonlinear_bounds(m, lb.copy(), ub.copy())
+    assert np.isfinite(tl[s_idx]) and np.isfinite(tu[s_idx]), "slack still unbounded"
+    # True range of 12/(x*y) over x∈[1,10], y∈[2,4] is [12/40, 12/2] = [0.3, 6.0].
+    # The enclosure must be sound: contain the true range, never exclude it.
+    assert tl[s_idx] <= 0.3 + 1e-9
+    assert tu[s_idx] >= 6.0 - 1e-9
+    assert "defined_variable_forward" in stats.applied_rules
+
+
+def test_forward_substitution_chains_through_definitions():
+    """``b`` defined via ``a`` resolves once ``a`` is bounded (fixpoint iteration)."""
+    m = dm.Model("chain")
+    x = m.continuous("x", lb=1.0, ub=4.0)
+    a = m.continuous("a", lb=-float("inf"), ub=float("inf"))
+    b = m.continuous("b", lb=-float("inf"), ub=float("inf"))
+    m.minimize(x)
+    m.subject_to(a == x * x)  # a in [1, 16]
+    m.subject_to(b == a + 5.0)  # b in [6, 21], only after a is bounded
+
+    _, lb, ub, _, _ = _extract_variable_info(m)
+    names = [v.name for v in m._variables]
+    tl, tu, _ = tighten_nonlinear_bounds(m, lb.copy(), ub.copy())
+    for nm in ("a", "b"):
+        k = names.index(nm)
+        assert np.isfinite(tl[k]) and np.isfinite(tu[k]), f"{nm} unbounded (chain failed)"
+
+
+def test_nvs05_aux_vars_bounded():
+    """nvs05's four free auxiliaries (division/sqrt slacks) all become finite."""
+    m = from_nl(str(_DATA / "nvs05.nl"))
+    _, lb, ub, _, _ = _extract_variable_info(m)
+    tl, tu, stats = tighten_nonlinear_bounds(m, lb.copy(), ub.copy())
+    assert np.all(np.isfinite(tl)) and np.all(np.isfinite(tu)), "an nvs05 var stayed unbounded"
+    assert stats.n_tightened >= 8  # four aux vars x two bounds
+
+
+@pytest.mark.slow
+@pytest.mark.requires_pounce
+def test_nvs05_certifies():
+    """With the aux vars bounded, the spatial McCormick relaxation is bounded at
+    every node, so the rigorous dual bound is no longer dropped on an unbounded node
+    and nvs05 *certifies* its global optimum (it never did before — it reported
+    ``feasible`` with a loose bound at any time limit)."""
+    r = from_nl(str(_DATA / "nvs05.nl")).solve(time_limit=180, gap_tolerance=1e-4)
+    assert r.status == "optimal", f"nvs05 did not certify (status={r.status})"
+    assert r.gap_certified
+    assert r.objective == pytest.approx(5.4709341, abs=1e-3)
+    assert r.bound is not None and r.bound <= 5.4709341 + 1e-3
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Closes a **certification gap** on the nvs/gear unbounded-auxiliary class: discopt
*found* the global optimum but reported `feasible` with a loose bound at any time
limit. **nvs05 now certifies** (`status=optimal`, `bound=5.471`, `gap_certified=True`)
— it never did before.

## Root cause (diagnosed on nvs05)

nvs05's auxiliary slacks `x4–x7` are defined by division/sqrt equalities
(`x4 = 4243.28/(x0·x1)`, …) and left **unbounded** by both the Rust FBBT and the
Python nonlinear tightening. An unbounded auxiliary makes the per-node McCormick LP
**unbounded**; an unbounded-relaxation node is then **sentinel-pruned** — an unsound
fathom that permanently trips `_gap_certified=False`. Instrumentation showed the
rigorous per-node McCormick bound climbs to the incumbent (5.47) and the *only*
decertifying node had `mc_status=unbounded`; every other prune was a sound
`infeasible`. So the spatial tree reaches the optimum but its (rigorous) dual bound
is discarded on the uncertified exit.

## Fix

`DefinedVariableForwardRule` (FBBT forward-substitution) in
`nonlinear_bound_tightening.py`: for an equality `c·x_def + g(others) == rhs` with
`x_def` absent from `g`, bound `x_def` by the interval enclosure of `(rhs - g)/c`.

- **Sound by construction**: an interval enclosure of the defining expression is a
  valid enclosure of the variable; bounds are only intersected, never loosened.
- The existing fixpoint loop resolves **chained** definitions (`x7 ← x6`).
- Wired into the spatial **root presolve** (`solver.py`) right after the Rust FBBT
  and before the root OBBT, so the McCormick relaxation is bounded at every node
  (and OBBT's own min/max LPs are bounded too).

## Result

- nvs05 aux vars `x4–x7`: unbounded → finite. The unbounded-node decertification is
  gone, and **nvs05 certifies its global optimum** (proven; it reported `feasible`
  at any time limit before).
- Caveat: certification currently takes longer (the finite-but-wide aux bounds let
  the spatial B&B branch the dependent aux vars). Tightening that — per-node
  re-pinning + treating the FBBT-defined vars as non-branchable dependents — is a
  follow-up; this PR is the **soundness/certification** fix.

## Validation

- `test_defined_variable_forward_fbbt.py`: sound division-slack bounding, chained
  definitions, nvs05 aux vars finite (fast) + nvs05 certifies (slow).
- gear4 soundness suite green (6/6); adversarial/soundness suite **478 passed**.
- The 3 suite failures (`test_lifted_reciprocal_sqrt_soundness` nvs05/nvs22,
  `test_batch_sentinel_soundness`) are **pre-existing on `main`** — confirmed by
  stashing this change; unrelated, worth a separate look.
- ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
