### PR TITLE
Issue #356: Pure-Rust LP certificates for sound spatial-B&B bounds

### DIFF
--- a/crates/discopt-core/src/expr.rs
+++ b/crates/discopt-core/src/expr.rs
@@ -1043,9 +1043,7 @@ impl ExprArena {
                         a0.max(a1)
                     }
                     MathFunc::Prod => self.reduction_values(args, x).iter().product(),
-                    MathFunc::Norm1 => {
-                        self.reduction_values(args, x).iter().map(|t| t.abs()).sum()
-                    }
+                    MathFunc::Norm1 => self.reduction_values(args, x).iter().map(|t| t.abs()).sum(),
                     MathFunc::Norm2 => self
                         .reduction_values(args, x)
                         .iter()
@@ -1451,9 +1449,7 @@ impl ModelRepr {
                         a0.max(a1)
                     }
                     MathFunc::Prod => self.reduction_values(args, x).iter().product(),
-                    MathFunc::Norm1 => {
-                        self.reduction_values(args, x).iter().map(|t| t.abs()).sum()
-                    }
+                    MathFunc::Norm1 => self.reduction_values(args, x).iter().map(|t| t.abs()).sum(),
                     MathFunc::Norm2 => self
                         .reduction_values(args, x)
                         .iter()

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -39,6 +39,12 @@ pub fn solve_lp_warm(lp: &LpView<'_>, b: &[f64], start: &Basis, opts: &SimplexOp
             let view = scaled.view();
             let mut sol = solve_lp_warm_scaled(&view, scaled.b(), start, opts);
             scaled.unscale_x(&mut sol.x);
+            // Map the certificate vectors back to the original space too (see the
+            // matching note in `primal::solve_lp`): the duals/Farkas ray are in
+            // scaled coordinates and must align with the unscaled A/b the caller
+            // checks against.
+            scaled.unscale_dual(&mut sol.dual);
+            scaled.unscale_ray(&mut sol.ray);
             sol
         }
         None => solve_lp_warm_scaled(lp, b, start, opts),
@@ -292,6 +298,14 @@ impl<'a> PreparedDual<'a> {
                         None => {
                             dvec = recompute_reduced_costs(&mut lu, sp, c, n, &basis)?;
                             if dual_feasible(n, &stat, l, u, &dvec, tol) {
+                                // Row duals `y = B⁻ᵀ c_B` for the safe dual bound;
+                                // empty (caller falls back) if the btran fails.
+                                let mut y: Vec<f64> = basis.iter().map(|&j| c[j]).collect();
+                                let dual = if lu.btran(&mut y).is_ok() {
+                                    y
+                                } else {
+                                    Vec::new()
+                                };
                                 return Some(assemble(
                                     n,
                                     m,
@@ -304,6 +318,8 @@ impl<'a> PreparedDual<'a> {
                                     u,
                                     LpStatus::Optimal,
                                     pivots,
+                                    dual,
+                                    Vec::new(),
                                 ));
                             }
                             // Exact reduced costs reveal dual infeasibility (a drifted
@@ -342,6 +358,10 @@ impl<'a> PreparedDual<'a> {
                 cand = build_candidates(n, &stat, l, u, &alpha_r, &dvec, to_lower, tol);
                 if cand.is_empty() {
                     xb = recompute_basic_values(&mut lu, sp, b, n, l, u, &stat)?;
+                    // Farkas dual ray: the leaving row's `ρ = eᵣᵀ B⁻¹`. With the
+                    // ratio test finding no entering column, `ρ` (or `−ρ`) is a
+                    // direction along which `bᵀy` beats the box-max of `(Aᵀy)ᵀz`,
+                    // certifying primal infeasibility — the caller verifies it.
                     return Some(assemble(
                         n,
                         m,
@@ -354,6 +374,8 @@ impl<'a> PreparedDual<'a> {
                         u,
                         LpStatus::Infeasible,
                         pivots,
+                        rho.clone(),
+                        Vec::new(),
                     ));
                 }
             }
@@ -665,6 +687,8 @@ fn assemble(
     u: &[f64],
     status: LpStatus,
     pivots: usize,
+    dual: Vec<f64>,
+    ray: Vec<f64>,
 ) -> LpSolve {
     let mut x = vec![0.0; n];
     for j in 0..n {
@@ -690,6 +714,8 @@ fn assemble(
             basic_vars,
         },
         iters: pivots,
+        dual,
+        ray,
     }
 }
 
@@ -750,6 +776,63 @@ mod tests {
         assert!(
             warm.iters >= 1,
             "dual warm-start did not run (fell back to cold)"
+        );
+    }
+
+    // After a warm dual re-optimization the exported row duals must still satisfy
+    // the safe-bound identity `bᵀy + Σ min_box((c−Aᵀy)z) ≈ obj` — i.e. the dual
+    // path populates `LpSolve::dual` correctly, not just the primal cold path.
+    #[test]
+    fn warm_optimal_exports_duals_matching_objective() {
+        let a = [1.0, 1.0, 1.0, 0.0, 1.0, 3.0, 0.0, 1.0];
+        let (m, n) = (2, 4);
+        let b = [4.0, 6.0];
+        let c = [-1.0, -2.0, 0.0, 0.0];
+        let l = [0.0; 4];
+        let u = [5.0, 5.0, INF, INF];
+        let lp = LpView {
+            a: &a,
+            m,
+            n,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let cold = solve_lp(&lp, &b, &opts());
+        assert_eq!(cold.status, LpStatus::Optimal);
+
+        // Tighten x1 ≤ 0.5 and re-solve warm from the cold basis (dual pivots run).
+        let u2 = [5.0, 0.5, INF, INF];
+        let lp2 = LpView {
+            a: &a,
+            m,
+            n,
+            c: &c,
+            l: &l,
+            u: &u2,
+        };
+        let warm = solve_lp_warm(&lp2, &b, &cold.basis, &opts());
+        assert_eq!(warm.status, LpStatus::Optimal);
+        assert_eq!(warm.dual.len(), m);
+        // Safe bound from the warm-path duals reproduces the warm objective.
+        let mut g = b
+            .iter()
+            .zip(&warm.dual)
+            .map(|(bi, yi)| bi * yi)
+            .sum::<f64>();
+        for j in 0..n {
+            let aty: f64 = (0..m).map(|i| a[i * n + j] * warm.dual[i]).sum();
+            let rc = c[j] - aty;
+            if rc > 0.0 {
+                g += rc * l[j];
+            } else if rc < 0.0 && u2[j] < INF {
+                g += rc * u2[j];
+            }
+        }
+        assert!(
+            (g - warm.obj).abs() < 1e-7,
+            "safe bound {g} vs warm obj {}",
+            warm.obj
         );
     }
 

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -58,6 +58,7 @@ pub fn solve_lp_warm(lp: &LpView<'_>, b: &[f64], start: &Basis, opts: &SimplexOp
 /// dense `m×n` matrix that [`solve_lp_warm`] builds via `from_dense` — the lifted
 /// relaxations are ~0.3% dense, so this is the difference between scanning 54M
 /// entries and touching ~19k per solve. `start` is `(col_status, basic_vars)`.
+#[allow(clippy::too_many_arguments)]
 pub fn solve_lp_warm_csc(
     mut sp: SparseCols,
     m: usize,

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -16,8 +16,8 @@
 #![allow(clippy::needless_range_loop)]
 
 use super::linsolve::{FeralLU, LinearSolver};
-use super::primal::solve_lp_scaled;
-use super::scaling::ScaledLp;
+use super::primal::{solve_lp_cols, solve_lp_scaled};
+use super::scaling::{ScaledLp, Scaling};
 use super::sparse::SparseCols;
 use super::{LpSolve, LpStatus, SimplexOptions};
 use crate::lp::basis::{Basis, AT_LOWER, AT_UPPER, BASIC};
@@ -48,6 +48,67 @@ pub fn solve_lp_warm(lp: &LpView<'_>, b: &[f64], start: &Basis, opts: &SimplexOp
             sol
         }
         None => solve_lp_warm_scaled(lp, b, start, opts),
+    }
+}
+
+/// Sparse-native warm LP solve from a CSC matrix: equilibrate (sparse factors +
+/// in-place scaling, `O(nnz)`), warm dual-simplex re-optimize from `start` (or
+/// cold-solve when absent / the basis is unusable), then map the solution and
+/// certificates back through the scaling. The whole path avoids materializing the
+/// dense `m×n` matrix that [`solve_lp_warm`] builds via `from_dense` — the lifted
+/// relaxations are ~0.3% dense, so this is the difference between scanning 54M
+/// entries and touching ~19k per solve. `start` is `(col_status, basic_vars)`.
+pub fn solve_lp_warm_csc(
+    mut sp: SparseCols,
+    m: usize,
+    n: usize,
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    start: Option<&Basis>,
+    opts: &SimplexOptions,
+) -> LpSolve {
+    match Scaling::from_sparse(&sp, m, n) {
+        Some(scaling) => {
+            scaling.scale_cols(&mut sp);
+            let c_s = scaling.scale_c(c);
+            let b_s = scaling.scale_b(b);
+            let l_s = scaling.scale_lower(l);
+            let u_s = scaling.scale_upper(u);
+            let mut sol = solve_csc_core(&sp, m, n, &c_s, &l_s, &u_s, &b_s, start, opts);
+            // Map x and the dual/Farkas/primal-ray certificates back to the
+            // original space (see the matching note in `solve_lp_warm`).
+            scaling.unscale_x(&mut sol.x);
+            scaling.unscale_dual(&mut sol.dual);
+            scaling.unscale_ray(&mut sol.ray);
+            sol
+        }
+        None => solve_csc_core(&sp, m, n, c, l, u, b, start, opts),
+    }
+}
+
+/// Warm dual (or cold) solve of an already-scaled CSC LP. Shared by the scaled and
+/// unscaled branches of [`solve_lp_warm_csc`].
+#[allow(clippy::too_many_arguments)]
+fn solve_csc_core(
+    sp: &SparseCols,
+    m: usize,
+    n: usize,
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    start: Option<&Basis>,
+    opts: &SimplexOptions,
+) -> LpSolve {
+    match start {
+        Some(basis) => match PreparedDual::prepare_cols(sp, m, n, c, l, u, basis, opts) {
+            Some(p) => p.reoptimize(l, u, b, opts),
+            // Unusable warm basis (wrong size / singular / dual-infeasible): cold.
+            None => solve_lp_cols(sp.clone(), m, n, c, l, u, b, opts),
+        },
+        None => solve_lp_cols(sp.clone(), m, n, c, l, u, b, opts),
     }
 }
 
@@ -87,9 +148,6 @@ pub fn solve_lp_warm_scaled_csc(
     }
 }
 
-fn col(a: &[f64], m: usize, n: usize, j: usize) -> Vec<f64> {
-    (0..m).map(|i| a[i * n + j]).collect()
-}
 
 /// A basis factorization prepared once for repeated dual re-optimizations that
 /// differ only in their bounds and right-hand side.
@@ -108,7 +166,6 @@ fn col(a: &[f64], m: usize, n: usize, j: usize) -> Vec<f64> {
 /// fractional, hence basic, variable), so the precondition verified at `prepare`
 /// holds for every `reoptimize` from the same basis.
 pub struct PreparedDual<'a> {
-    a: &'a [f64],
     m: usize,
     n: usize,
     c: &'a [f64],
@@ -130,7 +187,7 @@ impl<'a> PreparedDual<'a> {
         opts: &SimplexOptions,
         sp: &'a SparseCols,
     ) -> Option<Self> {
-        let (a, m, n, l, u, c) = (lp.a, lp.m, lp.n, lp.l, lp.u, lp.c);
+        let (m, n, l, u, c) = (lp.m, lp.n, lp.l, lp.u, lp.c);
         if start.basic_vars.len() != m {
             return None;
         }
@@ -190,7 +247,6 @@ impl<'a> PreparedDual<'a> {
         }
 
         Some(PreparedDual {
-            a,
             m,
             n,
             c,
@@ -202,30 +258,47 @@ impl<'a> PreparedDual<'a> {
         })
     }
 
+    /// As [`Self::prepare`] but from a borrowed CSC matrix + bound/cost slices
+    /// instead of a dense [`LpView`] — the sparse-native warm path. Identical
+    /// preconditions and factorization (both already build the basis from `sp`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn prepare_cols(
+        sp: &'a SparseCols,
+        m: usize,
+        n: usize,
+        c: &'a [f64],
+        l: &'a [f64],
+        u: &'a [f64],
+        start: &Basis,
+        opts: &SimplexOptions,
+    ) -> Option<Self> {
+        let lp = LpView {
+            a: &[],
+            m,
+            n,
+            c,
+            l,
+            u,
+        };
+        Self::prepare(&lp, start, opts, sp)
+    }
+
     /// Dual re-optimization from the prepared basis for bounds `l`/`u` and rhs
     /// `b`, returning a valid solution. On any numerical difficulty it cold-solves
     /// the same LP, so the result is always correct.
     pub fn reoptimize(&self, l: &[f64], u: &[f64], b: &[f64], opts: &SimplexOptions) -> LpSolve {
         match self.run_dual(l, u, b, opts) {
             Some(sol) => sol,
-            None => {
-                let lp = LpView {
-                    a: self.a,
-                    m: self.m,
-                    n: self.n,
-                    c: self.c,
-                    l,
-                    u,
-                };
-                solve_lp_scaled(&lp, b, opts)
-            }
+            // Cold fallback from the prepared CSC matrix (clone is O(nnz), paid only
+            // on the rare numerical-breakdown path) — no dense matrix is kept.
+            None => solve_lp_cols(self.sp.clone(), self.m, self.n, self.c, l, u, b, opts),
         }
     }
 
     /// The dual pivots, on a fresh clone of the prepared factorization/basis.
     /// `None` requests the cold fallback (numerical breakdown or iteration cap).
     fn run_dual(&self, l: &[f64], u: &[f64], b: &[f64], opts: &SimplexOptions) -> Option<LpSolve> {
-        let (a, m, n, c, sp) = (self.a, self.m, self.n, self.c, &self.sp);
+        let (m, n, c, sp) = (self.m, self.n, self.c, &self.sp);
         let tol = opts.tol;
         // Clone the pristine prepared state; the loop mutates these in place.
         let mut lu = self.lu.clone();
@@ -408,8 +481,10 @@ impl<'a> PreparedDual<'a> {
             }
 
             // Entering column α = B⁻¹A_q for the Devex weight update (and reused as
-            // the raw column for the product-form basis update).
-            let raw_q = col(a, m, n, q);
+            // the raw column for the product-form basis update). Scattered from the
+            // CSC view into a dense buffer (O(nnz_q)), not read from a dense matrix.
+            let mut raw_q = vec![0.0; m];
+            sp.scatter(q, &mut raw_q);
             let mut alpha = raw_q.clone();
             if lu.ftran(&mut alpha).is_err() {
                 return None;

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -91,4 +91,25 @@ pub struct LpSolve {
     pub basis: Basis,
     /// Simplex pivots performed.
     pub iters: usize,
+    /// Certificate vector of length `m` (one per row), interpreted by `status`:
+    ///
+    /// * [`LpStatus::Optimal`] — the row duals `y = B⁻ᵀ c_B`. Feeding these to a
+    ///   Neumaier–Shcherbina safe-bound evaluation yields a *rigorous* lower
+    ///   bound that holds at any conditioning (it never over-estimates even when
+    ///   the reported vertex objective drifts on an ill-conditioned basis), so a
+    ///   caller can certify the bound without a second independent solve.
+    /// * [`LpStatus::Infeasible`] — a **Farkas dual ray** candidate: a free-sign
+    ///   `y` such that `bᵀy` exceeds the box-maximum of `(Aᵀy)ᵀz`, a verifiable
+    ///   proof the feasible set is empty. The caller verifies it (trying ±y, with
+    ///   a magnitude-scaled margin) before trusting the infeasible verdict — so
+    ///   an imperfect candidate only forces a fallback, never an unsound fathom.
+    ///
+    /// Empty for every other status. Verification is the caller's job; this is a
+    /// *candidate*, sound only once independently checked.
+    pub dual: Vec<f64>,
+    /// Primal unbounded ray candidate of length `n`, populated only for
+    /// [`LpStatus::Unbounded`]: a direction `d` with `A d = 0`, box-feasible, and
+    /// `cᵀd < 0` along which the objective decreases without bound. Empty
+    /// otherwise. Like [`Self::dual`] it is a candidate for the caller to verify.
+    pub ray: Vec<f64>,
 }

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -25,10 +25,13 @@ pub mod scaling;
 pub mod sparse;
 
 pub use batch::{solve_lp_batch, solve_lp_multi_rhs, LpInstance};
-pub use dual::{solve_lp_warm, solve_lp_warm_scaled, solve_lp_warm_scaled_csc, PreparedDual};
+pub use dual::{
+    solve_lp_warm, solve_lp_warm_csc, solve_lp_warm_scaled, solve_lp_warm_scaled_csc, PreparedDual,
+};
 pub use presolve::tighten_bounds;
-pub use primal::{solve_lp, solve_lp_scaled};
+pub use primal::{solve_lp, solve_lp_cols, solve_lp_scaled};
 pub use scaling::Scaling;
+pub use sparse::SparseCols;
 
 use crate::lp::basis::Basis;
 

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -37,6 +37,13 @@ pub fn solve_lp(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpSolve {
             let view = scaled.view();
             let mut sol = solve_lp_scaled(&view, scaled.b(), opts);
             scaled.unscale_x(&mut sol.x);
+            // The certificate vectors are produced in scaled space; map them back
+            // so they are consistent with the *original* A/b/bounds the caller
+            // verifies against (a scaled dual against an unscaled matrix would make
+            // the safe bound / Farkas check spuriously fail — exactly on the
+            // ill-scaled LPs where the certificate matters most).
+            scaled.unscale_dual(&mut sol.dual);
+            scaled.unscale_ray(&mut sol.ray);
             sol
         }
         None => solve_lp_scaled(lp, b, opts),
@@ -106,6 +113,9 @@ struct Simplex<'a> {
     stat: Vec<i8>,     // column -> BASIC/AT_LOWER/AT_UPPER (len na)
     lb: Vec<f64>,      // len na
     ub: Vec<f64>,      // len na
+    /// Primal unbounded ray (length `n`), captured when [`Self::simplex_loop`]
+    /// detects unboundedness so [`Self::assemble`] can export it; empty until then.
+    unbounded_ray: Vec<f64>,
 }
 
 impl<'a> Simplex<'a> {
@@ -134,6 +144,7 @@ impl<'a> Simplex<'a> {
             stat: vec![AT_LOWER; na],
             lb,
             ub,
+            unbounded_ray: Vec::new(),
         }
     }
 
@@ -500,6 +511,24 @@ impl<'a> Simplex<'a> {
             }
 
             if t_max >= INF {
+                // Capture the primal unbounded ray over the real columns (length
+                // `n`): entering `q` moves by `dir`, each basic variable follows
+                // `x_B -= dir·α`, and `A d = 0` by construction (α = B⁻¹A_q ⇒
+                // A_q − B·α = 0). A caller verifies `A d = 0`, box-recession, and
+                // `cᵀd < 0` before trusting it, so an artificial leaking in (it is
+                // pinned to [0,0] in phase 2, so its ray entry is 0 anyway) cannot
+                // make the check pass spuriously.
+                let mut ray = vec![0.0; self.n];
+                if q < self.n {
+                    ray[q] = dir;
+                }
+                for i in 0..m {
+                    let bi = self.basis[i];
+                    if bi < self.n {
+                        ray[bi] = -dir * alpha[i];
+                    }
+                }
+                self.unbounded_ray = ray;
                 return Err(LpStatus::Unbounded);
             }
             if t_max <= self.tol {
@@ -630,6 +659,43 @@ impl<'a> Simplex<'a> {
             status
         };
 
+        // Certificate vector `y = B⁻ᵀ c_B` (length m). On `Optimal` use the real
+        // objective costs — these are the row duals feeding a safe (never-too-high)
+        // dual bound. On `Infeasible` use the phase-1 costs (1 on artificials, 0
+        // elsewhere): the phase-1 multipliers form a Farkas infeasibility ray. The
+        // btran is a read-only solve against the final factorization, so it neither
+        // perturbs the basis nor the returned `x`/`obj`. Empty on any other status
+        // (no meaningful certificate) — and empty too if the btran fails, so the
+        // caller simply falls back rather than trusting an unsound vector.
+        let dual: Vec<f64> = match status {
+            LpStatus::Optimal | LpStatus::Infeasible => {
+                let mut y: Vec<f64> = self
+                    .basis
+                    .iter()
+                    .map(|&j| {
+                        if status == LpStatus::Optimal {
+                            if j < self.n {
+                                self.c[j]
+                            } else {
+                                0.0
+                            }
+                        } else if j >= self.n {
+                            1.0 // basic artificial: phase-1 cost
+                        } else {
+                            0.0
+                        }
+                    })
+                    .collect();
+                if self.lu.btran(&mut y).is_ok() {
+                    y
+                } else {
+                    Vec::new()
+                }
+            }
+            _ => Vec::new(),
+        };
+        let ray = std::mem::take(&mut self.unbounded_ray);
+
         // Export a *complete*, row-ordered basis of real columns (length m).
         //
         // Phase 2 can leave an artificial (column ≥ self.n) basic at value 0 on a
@@ -684,6 +750,8 @@ impl<'a> Simplex<'a> {
                 basic_vars,
             },
             iters: 0,
+            dual,
+            ray,
         }
     }
 
@@ -698,6 +766,8 @@ impl<'a> Simplex<'a> {
                 basic_vars: Vec::new(),
             },
             iters: 0,
+            dual: Vec::new(),
+            ray: Vec::new(),
         }
     }
 }
@@ -825,6 +895,119 @@ mod tests {
             &u,
             &[1.0, 3.0 + 1e-9]
         ));
+    }
+
+    // --- certificate vectors (issue #356) ------------------------------------
+
+    const CERT_INF: f64 = 1e20;
+
+    /// Safe lower bound `g(y) = bᵀy + Σ_k min_{z_k∈[l,u]} (c−Aᵀy)_k z_k` from
+    /// free-sign multipliers `y`. `<= true optimum` for any `y` (weak duality).
+    fn safe_bound(
+        y: &[f64],
+        c: &[f64],
+        a: &[f64],
+        m: usize,
+        n: usize,
+        b: &[f64],
+        l: &[f64],
+        u: &[f64],
+    ) -> f64 {
+        let mut g = b.iter().zip(y).map(|(bi, yi)| bi * yi).sum::<f64>();
+        for j in 0..n {
+            let aty: f64 = (0..m).map(|i| a[i * n + j] * y[i]).sum();
+            let rc = c[j] - aty;
+            if rc > 0.0 {
+                g += if l[j] <= -CERT_INF {
+                    f64::NEG_INFINITY
+                } else {
+                    rc * l[j]
+                };
+            } else if rc < 0.0 {
+                g += if u[j] >= CERT_INF {
+                    f64::NEG_INFINITY
+                } else {
+                    rc * u[j]
+                };
+            }
+        }
+        g
+    }
+
+    #[test]
+    fn optimal_duals_reproduce_objective_via_safe_bound() {
+        // min -x0 - 2x1 s.t. x0+x1+s=4, x∈[0,5], s∈[0,inf]. Optimum -8.
+        let a = [1.0, 1.0, 1.0];
+        let c = [-1.0, -2.0, 0.0];
+        let l = [0.0, 0.0, 0.0];
+        let u = [5.0, 5.0, CERT_INF];
+        let r = solve(&a, 1, 3, &[4.0], &c, &l, &u);
+        assert_eq!(r.status, LpStatus::Optimal);
+        assert_eq!(r.dual.len(), 1);
+        let g = safe_bound(&r.dual, &c, &a, 1, 3, &[4.0], &l, &u);
+        // Safe bound from the simplex's own duals reproduces the optimum and is
+        // never above it (the soundness property the spatial-B&B relies on).
+        assert!((g - r.obj).abs() < 1e-9, "safe bound {g} vs obj {}", r.obj);
+        assert!(g <= r.obj + 1e-9);
+    }
+
+    #[test]
+    fn infeasible_emits_a_verifiable_farkas_ray() {
+        // x0 + s = 1, s∈[0,inf], x0∈[2,inf): x0≥2 but x0≤1 → infeasible.
+        let a = [1.0, 1.0];
+        let c = [1.0, 0.0];
+        let l = [2.0, 0.0];
+        let u = [CERT_INF, CERT_INF];
+        let r = solve(&a, 1, 2, &[1.0], &c, &l, &u);
+        assert_eq!(r.status, LpStatus::Infeasible);
+        assert_eq!(r.dual.len(), 1);
+        // Farkas: for some sign, the c=0 safe bound g0(±y) > 0 proves emptiness.
+        let zeros = [0.0, 0.0];
+        let pos = safe_bound(&r.dual, &zeros, &a, 1, 2, &[1.0], &l, &u);
+        let neg_y: Vec<f64> = r.dual.iter().map(|v| -v).collect();
+        let neg = safe_bound(&neg_y, &zeros, &a, 1, 2, &[1.0], &l, &u);
+        assert!(
+            pos > 0.0 || neg > 0.0,
+            "neither sign certifies: +{pos} -{neg}"
+        );
+    }
+
+    #[test]
+    fn unbounded_emits_a_valid_primal_ray() {
+        // min -x0 s.t. x0 - s = 0, x0,s∈[0,inf) → unbounded along x0=s growing.
+        let a = [1.0, -1.0];
+        let c = [-1.0, 0.0];
+        let l = [0.0, 0.0];
+        let u = [CERT_INF, CERT_INF];
+        let r = solve(&a, 1, 2, &[0.0], &c, &l, &u);
+        assert_eq!(r.status, LpStatus::Unbounded);
+        assert_eq!(r.ray.len(), 2);
+        // A d = 0 (stays on the constraint), and cᵀd < 0 (objective decreases).
+        let ad: f64 = (0..2).map(|j| a[j] * r.ray[j]).sum();
+        let cd: f64 = (0..2).map(|j| c[j] * r.ray[j]).sum();
+        assert!(ad.abs() < 1e-9, "A·d = {ad} (should be 0)");
+        assert!(cd < -1e-9, "c·d = {cd} (should be < 0)");
+    }
+
+    #[test]
+    fn ill_scaled_optimum_safe_bound_not_above_truth() {
+        // Wide-coefficient LP (range 1e9 → equilibration fires). The duals are
+        // unscaled, so the safe bound stays <= the true optimum.
+        let a = [1e9, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+        let c = [-1.0, -1.0, 0.0, 0.0];
+        let l = [0.0, 0.0, 0.0, 0.0];
+        let u = [1.0, 10.0, CERT_INF, CERT_INF];
+        let b = [1e9, 5.0];
+        let r = solve(&a, 2, 4, &b, &c, &l, &u);
+        assert_eq!(r.status, LpStatus::Optimal);
+        assert_eq!(r.dual.len(), 2);
+        let g = safe_bound(&r.dual, &c, &a, 2, 4, &b, &l, &u);
+        assert!(g <= r.obj + 1e-6, "safe bound {g} above obj {}", r.obj);
+        assert!(
+            (g - r.obj).abs() < 1e-3,
+            "safe bound {g} too loose vs {}",
+            r.obj
+        );
     }
 
     #[test]

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -64,7 +64,7 @@ pub fn solve_lp_scaled(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpS
 /// certifying an `Optimal` solve so incremental `x_B` drift (Harris bound
 /// excursions, deferred refactorization) cannot return a wrong optimum.
 fn solution_within_tolerance(
-    a: &[f64],
+    cols: &SparseCols,
     m: usize,
     n: usize,
     b: &[f64],
@@ -85,9 +85,21 @@ fn solution_within_tolerance(
             return false;
         }
     }
+    // Row activity `A x` accumulated over the sparse columns (O(nnz)), not a dense
+    // `m·n` matvec — the lifted relaxations are ~0.3% dense, so this is the
+    // difference between milliseconds and seconds on the per-solve audit.
+    let mut ax = vec![0.0f64; m];
+    for j in 0..n {
+        let xj = x[j];
+        if xj != 0.0 {
+            let (rows, vals) = cols.col(j);
+            for (k, &i) in rows.iter().enumerate() {
+                ax[i] += vals[k] * xj;
+            }
+        }
+    }
     for i in 0..m {
-        let row: f64 = (0..n).map(|j| a[i * n + j] * x[j]).sum();
-        if (row - b[i]).abs() > FEAS * (1.0 + b[i].abs()) {
+        if (ax[i] - b[i]).abs() > FEAS * (1.0 + b[i].abs()) {
             return false;
         }
     }
@@ -95,8 +107,8 @@ fn solution_within_tolerance(
 }
 
 struct Simplex<'a> {
-    a: &'a [f64],     // m×n row-major (structural+slack columns)
-    cols: SparseCols, // CSC view of `a`, built once (pricing hot path)
+    cols: SparseCols, // CSC of the constraint matrix; the sole matrix view (pricing,
+    // residual, audit all go through it — no dense `m×n` copy is kept)
     b: &'a [f64],     // length m
     c: &'a [f64],     // length n
     m: usize,
@@ -128,7 +140,6 @@ impl<'a> Simplex<'a> {
         ub[..n].copy_from_slice(lp.u);
         // Artificials: bounds set per phase (Phase 1 [0,inf], Phase 2 [0,0]).
         Self {
-            a: lp.a,
             cols: SparseCols::from_dense(lp.a, m, n),
             b,
             c: lp.c,
@@ -244,13 +255,18 @@ impl<'a> Simplex<'a> {
                 AT_LOWER // free → treated as at 0
             };
         }
-        // residual r = b − Σ A_j x_j over real nonbasic vars
+        // residual r = b − Σ A_j x_j over real nonbasic vars, accumulated through
+        // the sparse columns (O(nnz of the nonbasic-at-nonzero columns)) instead
+        // of a dense O(m·n) sweep — on the ~0.3%-dense lifted relaxations almost
+        // every nonbasic var sits at 0 (lower bound), so this touches almost
+        // nothing rather than scanning the whole matrix.
         let mut r = self.b.to_vec();
         for j in 0..self.n {
             let v = self.nb_value(j);
             if v != 0.0 {
-                for i in 0..m {
-                    r[i] -= self.a[i * self.n + j] * v;
+                let (rows, vals) = self.cols.col(j);
+                for (k, &i) in rows.iter().enumerate() {
+                    r[i] -= vals[k] * v;
                 }
             }
         }
@@ -652,7 +668,7 @@ impl<'a> Simplex<'a> {
         // warm path's cold fallback, or the MILP driver decertifying the gap and
         // branching) rather than trusting a wrong "Optimal".
         let status = if status == LpStatus::Optimal
-            && !solution_within_tolerance(self.a, self.m, self.n, self.b, &self.lb, &self.ub, &x)
+            && !solution_within_tolerance(&self.cols, self.m, self.n, self.b, &self.lb, &self.ub, &x)
         {
             LpStatus::Numerical
         } else {
@@ -860,14 +876,15 @@ mod tests {
     fn feasibility_audit_accepts_and_rejects() {
         // Row: x0 + x1 = 4, with x0,x1 ∈ [0, 5]. (n real cols = 2)
         let a = [1.0, 1.0];
+        let cols = SparseCols::from_dense(&a, 1, 2);
         let b = [4.0];
         let l = [0.0, 0.0];
         let u = [5.0, 5.0];
         // Exact feasible point passes.
-        assert!(solution_within_tolerance(&a, 1, 2, &b, &l, &u, &[1.0, 3.0]));
+        assert!(solution_within_tolerance(&cols, 1, 2, &b, &l, &u, &[1.0, 3.0]));
         // Ax=b drift beyond tolerance is rejected (would be a false "Optimal").
         assert!(!solution_within_tolerance(
-            &a,
+            &cols,
             1,
             2,
             &b,
@@ -877,7 +894,7 @@ mod tests {
         ));
         // A bound excursion beyond tolerance is rejected.
         assert!(!solution_within_tolerance(
-            &a,
+            &cols,
             1,
             2,
             &b,
@@ -887,7 +904,7 @@ mod tests {
         ));
         // Tiny within-tolerance noise still passes.
         assert!(solution_within_tolerance(
-            &a,
+            &cols,
             1,
             2,
             &b,
@@ -1020,8 +1037,9 @@ mod tests {
         let r = solve(&a, 2, 4, &[4.0, 6.0], &c, &l, &u);
         assert_eq!(r.status, LpStatus::Optimal);
         // The returned optimum genuinely satisfies the audit predicate.
+        let cols = SparseCols::from_dense(&a, 2, 4);
         assert!(solution_within_tolerance(
-            &a,
+            &cols,
             2,
             4,
             &[4.0, 6.0],

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -59,6 +59,23 @@ pub fn solve_lp_scaled(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpS
     Simplex::new(lp, b, opts).run()
 }
 
+/// Cold primal solve from an owned CSC matrix (already scaled by the caller, if at
+/// all) instead of a dense [`LpView`] — the sparse-native cold path used by the
+/// CSC warm entry and the dual fallback. Never materializes the dense `m×n` matrix.
+#[allow(clippy::too_many_arguments)]
+pub fn solve_lp_cols(
+    cols: SparseCols,
+    m: usize,
+    n: usize,
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    opts: &SimplexOptions,
+) -> LpSolve {
+    Simplex::new_from_cols(cols, m, n, c, l, u, b, opts).run()
+}
+
 /// Whether `x` satisfies the box `l ≤ x ≤ u` and the equalities `A x = b` to a
 /// small absolute/relative tolerance. Used as the final feasibility audit before
 /// certifying an `Optimal` solve so incremental `x_B` drift (Harris bound
@@ -132,17 +149,42 @@ struct Simplex<'a> {
 
 impl<'a> Simplex<'a> {
     fn new(lp: &'a LpView<'a>, b: &'a [f64], opts: &SimplexOptions) -> Self {
-        let (m, n) = (lp.m, lp.n);
+        Self::new_from_cols(
+            SparseCols::from_dense(lp.a, lp.m, lp.n),
+            lp.m,
+            lp.n,
+            lp.c,
+            lp.l,
+            lp.u,
+            b,
+            opts,
+        )
+    }
+
+    /// Build the cold primal solver from an owned CSC matrix instead of a dense
+    /// [`LpView`] — the sparse-native ingestion path (the CSC warm entry and its
+    /// cold fallback), which never materializes the dense `m×n` matrix.
+    #[allow(clippy::too_many_arguments)]
+    fn new_from_cols(
+        cols: SparseCols,
+        m: usize,
+        n: usize,
+        c: &'a [f64],
+        l: &'a [f64],
+        u: &'a [f64],
+        b: &'a [f64],
+        opts: &SimplexOptions,
+    ) -> Self {
         let na = n + m;
         let mut lb = vec![0.0; na];
         let mut ub = vec![0.0; na];
-        lb[..n].copy_from_slice(lp.l);
-        ub[..n].copy_from_slice(lp.u);
+        lb[..n].copy_from_slice(l);
+        ub[..n].copy_from_slice(u);
         // Artificials: bounds set per phase (Phase 1 [0,inf], Phase 2 [0,0]).
         Self {
-            cols: SparseCols::from_dense(lp.a, m, n),
+            cols,
             b,
-            c: lp.c,
+            c,
             m,
             n,
             na,

--- a/crates/discopt-core/src/lp/simplex/scaling.rs
+++ b/crates/discopt-core/src/lp/simplex/scaling.rs
@@ -146,6 +146,26 @@ impl Scaling {
             x[j] *= *c;
         }
     }
+
+    /// Map scaled row duals (or a scaled Farkas ray) back to the original space in
+    /// place: `y_i ← r_i ŷ_i`. The scaled constraint `i` was multiplied by `r_i`,
+    /// so its multiplier scales by the same factor (equivalently, the safe dual
+    /// bound `bᵀy + Σⱼ min_box((c−Aᵀy)ⱼ zⱼ)` is invariant under this map — see the
+    /// module identity `b̂ᵀŷ = bᵀ(Rŷ)` and `ĉ − Âᵀŷ = C(c − Aᵀ(Rŷ))`).
+    pub fn unscale_dual(&self, y: &mut [f64]) {
+        for (i, r) in self.row.iter().enumerate() {
+            if i >= y.len() {
+                break;
+            }
+            y[i] *= *r;
+        }
+    }
+
+    /// Map a scaled primal ray back to the original space: identical column
+    /// transform to [`Self::unscale_x`] (the ray lives in the primal `x` space).
+    pub fn unscale_ray(&self, d: &mut [f64]) {
+        self.unscale_x(d);
+    }
 }
 
 /// An owned, equilibrated copy of an [`LpView`] together with its RHS, for a
@@ -195,6 +215,16 @@ impl ScaledLp {
     /// Map a scaled primal point back to the original space in place.
     pub fn unscale_x(&self, x: &mut [f64]) {
         self.scaling.unscale_x(x);
+    }
+
+    /// Map scaled row duals / a scaled Farkas ray back to the original space.
+    pub fn unscale_dual(&self, y: &mut [f64]) {
+        self.scaling.unscale_dual(y);
+    }
+
+    /// Map a scaled primal ray back to the original space.
+    pub fn unscale_ray(&self, d: &mut [f64]) {
+        self.scaling.unscale_ray(d);
     }
 }
 

--- a/crates/discopt-core/src/lp/simplex/scaling.rs
+++ b/crates/discopt-core/src/lp/simplex/scaling.rs
@@ -95,8 +95,27 @@ impl Scaling {
         if hi == 0.0 || hi / lo <= SCALE_TRIGGER {
             return None;
         }
-        let (row, col) = equilibrate(a, m, n);
+        let (row, col) = equilibrate(&SparseCols::from_dense(a, m, n), m, n);
         Some(Scaling { row, col, m, n })
+    }
+
+    /// Equilibration factors for an already-CSC matrix, or `None` when its dynamic
+    /// range is below [`SCALE_TRIGGER`]. The sparse-native entry: identical factors
+    /// to [`Self::from_matrix`] (zeros never affect a line's significant min/max),
+    /// with no dense `m·n` materialization anywhere on the path.
+    pub fn from_sparse(sp: &SparseCols, m: usize, n: usize) -> Option<Scaling> {
+        let (lo, hi) = sp.value_range();
+        if hi == 0.0 || hi / lo <= SCALE_TRIGGER {
+            return None;
+        }
+        let (row, col) = equilibrate(sp, m, n);
+        Some(Scaling { row, col, m, n })
+    }
+
+    /// Scale a CSC matrix in place by the same `R A C` factors — the sparse
+    /// analogue of [`Self::scale_matrix`], `O(nnz)` with no dense copy.
+    pub fn scale_cols(&self, sp: &mut SparseCols) {
+        sp.scale_in_place(&self.row, &self.col);
     }
 
     /// Scaled matrix `Â = R A C` (owned, row-major `m × n`).
@@ -241,8 +260,7 @@ impl ScaledLp {
 /// seconds here alone). The factors are *bit-identical* to the old dense sweep: a
 /// zero entry never affects a line's significant min/max, so skipping the
 /// structural zeros changes nothing.
-fn equilibrate(a: &[f64], m: usize, n: usize) -> (Vec<f64>, Vec<f64>) {
-    let sp = SparseCols::from_dense(a, m, n);
+fn equilibrate(sp: &SparseCols, m: usize, n: usize) -> (Vec<f64>, Vec<f64>) {
     let (col_ptr, row_idx, vals) = sp.raw();
     let mut row = vec![1.0f64; m];
     let mut col = vec![1.0f64; n];

--- a/crates/discopt-core/src/lp/simplex/scaling.rs
+++ b/crates/discopt-core/src/lp/simplex/scaling.rs
@@ -35,6 +35,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use crate::lp::crossover::LpView;
+use crate::lp::simplex::sparse::SparseCols;
 
 const INF: f64 = 1e20;
 
@@ -228,18 +229,30 @@ impl ScaledLp {
     }
 }
 
-/// Geometric-mean equilibration of the dense row-major `m × n` matrix `a`:
-/// alternating sweeps set each column/row factor to `1/sqrt(min·max)` of the
-/// current scaled magnitudes in that line, snapped to a power of two. Returns
-/// `(row, col)` factor vectors.
+/// Geometric-mean equilibration of the `m × n` matrix `a`: alternating sweeps set
+/// each column/row factor to `1/sqrt(min·max)` of the current scaled magnitudes in
+/// that line, snapped to a power of two. Returns `(row, col)` factor vectors.
+///
+/// The sweeps read the matrix through a CSC view so they visit only the nonzeros,
+/// in cache-friendly storage order, rather than striding the dense row-major
+/// matrix per column — `O(nnz)` instead of `O(m·n)` cache-missing accesses, which
+/// was the dominant cost on the 0.3%-dense lifted McCormick relaxations (a
+/// zero-iteration solve of ex1252's 6908×7799 / 19k-nonzero relaxation spent
+/// seconds here alone). The factors are *bit-identical* to the old dense sweep: a
+/// zero entry never affects a line's significant min/max, so skipping the
+/// structural zeros changes nothing.
 fn equilibrate(a: &[f64], m: usize, n: usize) -> (Vec<f64>, Vec<f64>) {
+    let sp = SparseCols::from_dense(a, m, n);
+    let (col_ptr, row_idx, vals) = sp.raw();
     let mut row = vec![1.0f64; m];
     let mut col = vec![1.0f64; n];
     for _ in 0..MAX_PASSES {
         let mut changed = false;
-        // Column sweep.
+        // Column sweep: column-major storage makes each column's nonzeros contiguous.
         for j in 0..n {
-            let (lo, hi) = line_lo_hi((0..m).map(|i| row[i] * a[i * n + j] * col[j]));
+            let (lo, hi) = line_lo_hi(
+                (col_ptr[j]..col_ptr[j + 1]).map(|k| row[row_idx[k]] * vals[k] * col[j]),
+            );
             if hi > 0.0 {
                 let f = nearest_pow2(1.0 / (lo * hi).sqrt());
                 if f != 1.0 {
@@ -248,12 +261,34 @@ fn equilibrate(a: &[f64], m: usize, n: usize) -> (Vec<f64>, Vec<f64>) {
                 }
             }
         }
-        // Row sweep.
+        // Row sweep: accumulate per-row significant lo/hi over the same nonzeros.
+        // Two O(nnz) passes mirror `line_lo_hi`'s noise floor — the per-row max
+        // first, then the min over entries within `MAX_LINE_RANGE` of it.
+        let mut rhi = vec![0.0f64; m];
+        for j in 0..n {
+            let cj = col[j];
+            for k in col_ptr[j]..col_ptr[j + 1] {
+                let i = row_idx[k];
+                let av = (row[i] * vals[k] * cj).abs();
+                if av > rhi[i] {
+                    rhi[i] = av;
+                }
+            }
+        }
+        let mut rlo = vec![f64::INFINITY; m];
+        for j in 0..n {
+            let cj = col[j];
+            for k in col_ptr[j]..col_ptr[j + 1] {
+                let i = row_idx[k];
+                let av = (row[i] * vals[k] * cj).abs();
+                if av > 0.0 && av >= rhi[i] * MAX_LINE_RANGE && av < rlo[i] {
+                    rlo[i] = av;
+                }
+            }
+        }
         for i in 0..m {
-            let base = i * n;
-            let (lo, hi) = line_lo_hi((0..n).map(|j| row[i] * a[base + j] * col[j]));
-            if hi > 0.0 {
-                let f = nearest_pow2(1.0 / (lo * hi).sqrt());
+            if rhi[i] > 0.0 {
+                let f = nearest_pow2(1.0 / (rlo[i] * rhi[i]).sqrt());
                 if f != 1.0 {
                     row[i] *= f;
                     changed = true;

--- a/crates/discopt-core/src/lp/simplex/sparse.rs
+++ b/crates/discopt-core/src/lp/simplex/sparse.rs
@@ -101,8 +101,7 @@ impl SparseCols {
     /// `O(nnz)` — the sparse analogue of `scaling::Scaling::scale_matrix`, with no
     /// dense `m·n` copy.
     pub fn scale_in_place(&mut self, row: &[f64], col: &[f64]) {
-        for j in 0..self.ncols() {
-            let cj = col[j];
+        for (j, &cj) in col.iter().enumerate().take(self.ncols()) {
             for k in self.col_ptr[j]..self.col_ptr[j + 1] {
                 self.vals[k] *= row[self.row_idx[k]] * cj;
             }

--- a/crates/discopt-core/src/lp/simplex/sparse.rs
+++ b/crates/discopt-core/src/lp/simplex/sparse.rs
@@ -53,6 +53,14 @@ impl SparseCols {
         }
     }
 
+    /// Read-only view of the raw CSC arrays (`col_ptr`, `row_idx`, `vals`). Lets
+    /// the equilibration sweeps read every nonzero in storage order (cache-
+    /// friendly) instead of striding the dense row-major matrix per column.
+    #[inline]
+    pub fn raw(&self) -> (&[usize], &[usize], &[f64]) {
+        (&self.col_ptr, &self.row_idx, &self.vals)
+    }
+
     /// Nonzero `(row, value)` pairs of column `j`.
     #[inline]
     pub fn col(&self, j: usize) -> (&[usize], &[f64]) {

--- a/crates/discopt-core/src/lp/simplex/sparse.rs
+++ b/crates/discopt-core/src/lp/simplex/sparse.rs
@@ -9,6 +9,7 @@
 
 /// CSC storage of an `m × n` matrix: `col_ptr[j..j+1]` bounds column `j`'s
 /// nonzeros in `row_idx`/`vals`.
+#[derive(Clone)]
 pub struct SparseCols {
     col_ptr: Vec<usize>,
     row_idx: Vec<usize>,
@@ -59,6 +60,53 @@ impl SparseCols {
     #[inline]
     pub fn raw(&self) -> (&[usize], &[usize], &[f64]) {
         (&self.col_ptr, &self.row_idx, &self.vals)
+    }
+
+    /// Build directly from caller-supplied CSC arrays (one `O(nnz)` move, no dense
+    /// `m·n` scan). `col_ptr` has length `n_cols + 1`; `row_idx`/`vals` are the
+    /// column-major nonzeros. The sparse-native ingestion path for the warm LP
+    /// solve, so a 0.3%-dense lifted relaxation is never materialized dense.
+    pub fn from_csc(col_ptr: Vec<usize>, row_idx: Vec<usize>, vals: Vec<f64>) -> Self {
+        debug_assert!(!col_ptr.is_empty());
+        debug_assert_eq!(*col_ptr.last().unwrap(), row_idx.len());
+        debug_assert_eq!(row_idx.len(), vals.len());
+        Self {
+            col_ptr,
+            row_idx,
+            vals,
+        }
+    }
+
+    /// Number of columns.
+    #[inline]
+    pub fn ncols(&self) -> usize {
+        self.col_ptr.len() - 1
+    }
+
+    /// Smallest and largest nonzero magnitude (for the equilibration trigger), or
+    /// `(inf, 0)` when all-zero. `O(nnz)`.
+    pub fn value_range(&self) -> (f64, f64) {
+        let (mut lo, mut hi) = (f64::INFINITY, 0.0f64);
+        for &v in &self.vals {
+            let av = v.abs();
+            if av > 0.0 {
+                lo = lo.min(av);
+                hi = hi.max(av);
+            }
+        }
+        (lo, hi)
+    }
+
+    /// Apply diagonal row/column scaling in place: `A[i,j] *= row[i] * col[j]`.
+    /// `O(nnz)` — the sparse analogue of `scaling::Scaling::scale_matrix`, with no
+    /// dense `m·n` copy.
+    pub fn scale_in_place(&mut self, row: &[f64], col: &[f64]) {
+        for j in 0..self.ncols() {
+            let cj = col[j];
+            for k in self.col_ptr[j]..self.col_ptr[j + 1] {
+                self.vals[k] *= row[self.row_idx[k]] * cj;
+            }
+        }
     }
 
     /// Nonzero `(row, value)` pairs of column `j`.

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -37,6 +37,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::mir_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_py, m)?)?;
+    m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_csc_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_batch_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_py, m)?)?;
     Ok(())

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -316,7 +316,14 @@ fn build_extended_basis(cs: &[i8], bv: &[i64], n: usize, m: usize) -> Option<Bas
 /// (`solve_lp_warm` cold-falls-back internally), and the dual simplex converges
 /// to the LP optimum just like a cold solve — so the returned objective (hence
 /// any relaxation bound built on it) is unchanged; the basis only changes speed.
-/// Returns `(status, x, obj, iters, col_status, basic_vars)`.
+/// Returns `(status, x, obj, iters, col_status, basic_vars, dual, ray)`.
+///
+/// `dual` (length `m`) and `ray` (length `n`) are *certificate candidates* a
+/// caller verifies before trusting (see [`LpSolve::dual`]/[`LpSolve::ray`]): at
+/// `optimal` `dual` is the row duals (feed to a Neumaier–Shcherbina safe bound),
+/// at `infeasible` `dual` is a Farkas ray, at `unbounded` `ray` is a primal ray.
+/// They are mapped back from any internal equilibration, so they are consistent
+/// with the `a`/`b`/`lb`/`ub` passed in. Each is empty when not applicable.
 #[pyfunction]
 #[pyo3(signature = (c, a, b, lb, ub, start_col_status=None, start_basic_vars=None,
                     tol=1e-9, max_iter=100_000))]
@@ -339,6 +346,8 @@ pub fn solve_lp_warm_py<'py>(
     usize,
     Bound<'py, PyArray1<i8>>,
     Bound<'py, PyArray1<i64>>,
+    Bound<'py, PyArray1<f64>>,
+    Bound<'py, PyArray1<f64>>,
 )> {
     let dims = a.shape();
     let (m, n) = (dims[0], dims[1]);
@@ -383,6 +392,8 @@ pub fn solve_lp_warm_py<'py>(
         sol.iters,
         PyArray1::from_vec(py, sol.basis.col_status),
         PyArray1::from_vec(py, basic_vars_i64),
+        PyArray1::from_vec(py, sol.dual),
+        PyArray1::from_vec(py, sol.ray),
     ))
 }
 

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -17,8 +17,8 @@ use discopt_core::lp::crossover::{crossover_to_vertex, LpView};
 use discopt_core::lp::gomory::separate_gomory;
 use discopt_core::lp::mir::separate_mir;
 use discopt_core::lp::simplex::{
-    solve_lp as simplex_solve_lp, solve_lp_batch, solve_lp_warm, LpInstance, LpStatus,
-    SimplexOptions,
+    solve_lp as simplex_solve_lp, solve_lp_batch, solve_lp_warm, solve_lp_warm_csc, LpInstance,
+    LpStatus, SimplexOptions, SparseCols,
 };
 use numpy::{
     PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods,
@@ -377,6 +377,86 @@ pub fn solve_lp_warm_py<'py>(
         Some(basis) => solve_lp_warm(&lp, b_slice, &basis, &opts),
         None => simplex_solve_lp(&lp, b_slice, &opts),
     };
+    let status = match sol.status {
+        LpStatus::Optimal => "optimal",
+        LpStatus::Infeasible => "infeasible",
+        LpStatus::Unbounded => "unbounded",
+        LpStatus::IterLimit => "iter_limit",
+        LpStatus::Numerical => "numerical",
+    };
+    let basic_vars_i64: Vec<i64> = sol.basis.basic_vars.iter().map(|&v| v as i64).collect();
+    Ok((
+        status.to_string(),
+        PyArray1::from_vec(py, sol.x),
+        sol.obj,
+        sol.iters,
+        PyArray1::from_vec(py, sol.basis.col_status),
+        PyArray1::from_vec(py, basic_vars_i64),
+        PyArray1::from_vec(py, sol.dual),
+        PyArray1::from_vec(py, sol.ray),
+    ))
+}
+
+/// Sparse-native counterpart of [`solve_lp_warm_py`]: the constraint matrix is
+/// passed as CSC (`col_ptr`/`row_idx`/`vals`, column-major) instead of a dense
+/// `m × n` array, so the ~0.3%-dense lifted relaxations are never materialized
+/// dense on either side of the boundary. `n` is the total column count (structural
+/// + slacks, matching the CSC). Returns the same
+/// `(status, x, obj, iters, col_status, basic_vars, dual, ray)` 8-tuple as
+/// [`solve_lp_warm_py`], with the certificates mapped back from any equilibration.
+#[pyfunction]
+#[pyo3(signature = (c, m, n, col_ptr, row_idx, vals, b, lb, ub,
+                    start_col_status=None, start_basic_vars=None, tol=1e-9, max_iter=100_000))]
+#[allow(clippy::too_many_arguments)]
+pub fn solve_lp_warm_csc_py<'py>(
+    py: Python<'py>,
+    c: PyReadonlyArray1<'py, f64>,
+    m: usize,
+    n: usize,
+    col_ptr: PyReadonlyArray1<'py, i64>,
+    row_idx: PyReadonlyArray1<'py, i64>,
+    vals: PyReadonlyArray1<'py, f64>,
+    b: PyReadonlyArray1<'py, f64>,
+    lb: PyReadonlyArray1<'py, f64>,
+    ub: PyReadonlyArray1<'py, f64>,
+    start_col_status: Option<PyReadonlyArray1<'py, i8>>,
+    start_basic_vars: Option<PyReadonlyArray1<'py, i64>>,
+    tol: f64,
+    max_iter: usize,
+) -> PyResult<(
+    String,
+    Bound<'py, PyArray1<f64>>,
+    f64,
+    usize,
+    Bound<'py, PyArray1<i8>>,
+    Bound<'py, PyArray1<i64>>,
+    Bound<'py, PyArray1<f64>>,
+    Bound<'py, PyArray1<f64>>,
+)> {
+    let col_ptr: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
+    let row_idx: Vec<usize> = row_idx.as_slice()?.iter().map(|&x| x as usize).collect();
+    let vals_v: Vec<f64> = vals.as_slice()?.to_vec();
+    let sp = SparseCols::from_csc(col_ptr, row_idx, vals_v);
+    let opts = SimplexOptions {
+        tol,
+        max_iter,
+        deadline: None,
+    };
+    let start = match (start_col_status, start_basic_vars) {
+        (Some(cs), Some(bv)) => build_extended_basis(cs.as_slice()?, bv.as_slice()?, n, m),
+        _ => None,
+    };
+    let sol = solve_lp_warm_csc(
+        sp,
+        m,
+        n,
+        c.as_slice()?,
+        lb.as_slice()?,
+        ub.as_slice()?,
+        b.as_slice()?,
+        start.as_ref(),
+        &opts,
+    );
     let status = match sol.status {
         LpStatus::Optimal => "optimal",
         LpStatus::Infeasible => "infeasible",

--- a/python/discopt/_jax/convexity/linear_context.py
+++ b/python/discopt/_jax/convexity/linear_context.py
@@ -42,6 +42,11 @@ from discopt.modeling.core import (
     Variable,
 )
 
+# Relative margin widening the POUNCE-IPM affine-range enclosure so it stays a
+# sound outer bound despite the interior-point optimum's small tolerance (#356).
+_LP_ENCLOSURE_MARGIN = 1e-7
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Affine coefficient extraction
 # ──────────────────────────────────────────────────────────────────────
@@ -205,13 +210,11 @@ class LinearContext:
         if self.A_ub.size == 0 and self.A_eq.size == 0:
             return lo_box, hi_box
 
-        from scipy.optimize import linprog
+        from discopt.solvers import SolveStatus
+        from discopt.solvers.lp_pounce import solve_lp
 
-        # Replace ±inf in variable bounds with None for linprog's API.
-        bounds = [
-            (None if not np.isfinite(lo) else float(lo), None if not np.isfinite(hi) else float(hi))
-            for lo, hi in zip(self.lb, self.ub)
-        ]
+        # ``bounds`` as (lo, hi) tuples; POUNCE maps ±inf via its own sentinel.
+        bounds = [(float(lo), float(hi)) for lo, hi in zip(self.lb, self.ub)]
 
         A_ub = self.A_ub if self.A_ub.size else None
         b_ub = self.b_ub if self.b_ub.size else None
@@ -219,30 +222,24 @@ class LinearContext:
         b_eq = self.b_eq if self.b_eq.size else None
 
         try:
-            lo_res = linprog(
-                coeffs,
-                A_ub=A_ub,
-                b_ub=b_ub,
-                A_eq=A_eq,
-                b_eq=b_eq,
-                bounds=bounds,
-                method="highs",
-            )
-            hi_res = linprog(
-                -coeffs,
-                A_ub=A_ub,
-                b_ub=b_ub,
-                A_eq=A_eq,
-                b_eq=b_eq,
-                bounds=bounds,
-                method="highs",
-            )
-        except (ValueError, RuntimeError):
+            lo_res = solve_lp(coeffs, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
+            hi_res = solve_lp(-coeffs, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
+        except (ValueError, RuntimeError, ImportError):
             return lo_box, hi_box
 
-        lo = float(lo_res.fun) + const if lo_res.success else lo_box
-        hi = -float(hi_res.fun) + const if hi_res.success else hi_box
-        # Intersect with the box-only enclosure; linprog errors only widen.
+        # POUNCE is an interior-point method, so the reported optimum carries a
+        # small tolerance; widen each side by a magnitude-scaled margin so the
+        # range stays a *sound* enclosure (lo ≤ true min, hi ≥ true max) rather
+        # than risk an over-tight one that would misclassify convexity (#356).
+        lo = lo_box
+        if lo_res.status == SolveStatus.OPTIMAL and lo_res.objective is not None:
+            f = float(lo_res.objective)
+            lo = f - _LP_ENCLOSURE_MARGIN * (1.0 + abs(f)) + const
+        hi = hi_box
+        if hi_res.status == SolveStatus.OPTIMAL and hi_res.objective is not None:
+            f = -float(hi_res.objective)
+            hi = f + _LP_ENCLOSURE_MARGIN * (1.0 + abs(f)) + const
+        # Intersect with the box-only enclosure; LP errors / margins only widen.
         return max(lo, lo_box), min(hi, hi_box)
 
 

--- a/python/discopt/_jax/convexity/linear_context.py
+++ b/python/discopt/_jax/convexity/linear_context.py
@@ -46,6 +46,17 @@ from discopt.modeling.core import (
 # sound outer bound despite the interior-point optimum's small tolerance (#356).
 _LP_ENCLOSURE_MARGIN = 1e-7
 
+# Per-solve wall-clock cap for the POUNCE affine-range LP. POUNCE's interior-point
+# method is pathologically slow on the ill-conditioned LPs some convexity probes
+# produce (hda's signomial-equilibrium rows), and convexity analysis issues many
+# such probes, so an unbounded solve can hang the whole (CI-visible) analysis.
+# Bounding it is sound: a non-optimal result falls back to the box-only enclosure
+# below, which is a valid (looser) outer bound — convexity then abstains rather
+# than mis-proves, exactly the conservative direction. Well-conditioned probes
+# solve far inside this budget (~milliseconds), so proven-convex detection is
+# unaffected; only the pathological ill-conditioned probes hit the cap and abstain.
+_LP_POUNCE_TIME_LIMIT = 0.5
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Affine coefficient extraction
@@ -221,8 +232,14 @@ class LinearContext:
         b_eq = self.b_eq if self.b_eq.size else None
 
         try:
-            lo_res = solve_lp(coeffs, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
-            hi_res = solve_lp(-coeffs, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
+            lo_res = solve_lp(
+                coeffs, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
+                time_limit=_LP_POUNCE_TIME_LIMIT,
+            )
+            hi_res = solve_lp(
+                -coeffs, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
+                time_limit=_LP_POUNCE_TIME_LIMIT,
+            )
         except (ValueError, RuntimeError, ImportError):
             return lo_box, hi_box
 

--- a/python/discopt/_jax/convexity/linear_context.py
+++ b/python/discopt/_jax/convexity/linear_context.py
@@ -13,7 +13,7 @@ constraint ``x2 <= x1`` implies the argument is ``>= 1 > 0``.
 This module provides a ``LinearContext`` that holds the model's
 linear relaxation (variable bounds + linear inequality and equality
 constraints) and can answer range queries on affine expressions via
-two scipy ``linprog`` calls. The range is a sound enclosure over the
+two pure-Rust POUNCE LP solves. The range is a sound enclosure over the
 intersection of the box with the linear relaxation, so the resulting
 sign label is mathematically valid as a premise of a DCP rule.
 
@@ -199,9 +199,8 @@ class LinearContext:
         """Sound enclosure of ``coeffs · x + const`` over the relaxation.
 
         Uses the declared variable bounds as a free box-only enclosure;
-        invokes ``scipy.optimize.linprog`` only when linear constraints
-        are present, since the box-only bound is already optimal
-        otherwise.
+        invokes the pure-Rust POUNCE LP only when linear constraints are
+        present, since the box-only bound is already optimal otherwise.
         """
         # Box-only enclosure is optimal when there are no linear rows.
         lo_box, hi_box = _box_range(coeffs, self.lb, self.ub)

--- a/python/discopt/_jax/convexity/linear_context.py
+++ b/python/discopt/_jax/convexity/linear_context.py
@@ -233,11 +233,21 @@ class LinearContext:
 
         try:
             lo_res = solve_lp(
-                coeffs, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
+                coeffs,
+                A_ub=A_ub,
+                b_ub=b_ub,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                bounds=bounds,
                 time_limit=_LP_POUNCE_TIME_LIMIT,
             )
             hi_res = solve_lp(
-                -coeffs, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
+                -coeffs,
+                A_ub=A_ub,
+                b_ub=b_ub,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                bounds=bounds,
                 time_limit=_LP_POUNCE_TIME_LIMIT,
             )
         except (ValueError, RuntimeError, ImportError):

--- a/python/discopt/_jax/edge_concave.py
+++ b/python/discopt/_jax/edge_concave.py
@@ -36,13 +36,6 @@ from itertools import product
 
 import numpy as np
 
-try:
-    from scipy.optimize import linprog
-
-    _SCIPY = True
-except ImportError:  # pragma: no cover
-    _SCIPY = False
-
 
 @dataclass(frozen=True)
 class EdgeConcaveQuadratic:
@@ -170,9 +163,17 @@ def separate_edge_concave_quadratic(
     bounds ``q(v)`` at every box vertex (and hence ``q`` everywhere, by
     edge-concavity), so the cut is sound; it is returned only when ``q_star``
     violates it.
+
+    The vertex-hull LP is solved with the pure-Rust POUNCE IPM (issue #356 — no
+    SciPy/HiGHS). Only the dual *slope* ``A`` is taken from POUNCE; the intercept
+    ``B`` is recomputed to the exact validity boundary over the vertices
+    (``minᵥ(q(v)−A·v)`` under / ``maxᵥ`` over), so by edge-concavity the cut
+    bounds ``q`` everywhere for ANY slope — robust to POUNCE's analytic-center
+    dual / sign / scale. ``None`` if POUNCE is unavailable or did not converge.
     """
-    if not _SCIPY:
-        return None
+    from discopt.solvers import SolveStatus
+    from discopt.solvers.lp_pounce import solve_lp
+
     n = len(block.var_idxs)
     if n < 2 or not (np.all(np.isfinite(lb[:n])) and np.all(np.isfinite(ub[:n]))):
         return None
@@ -184,22 +185,28 @@ def separate_edge_concave_quadratic(
     b_eq = np.append(xs, 1.0)
     maximize = block.sense == "over"
     c = -vals if maximize else vals
-    res = linprog(c, A_eq=a_eq, b_eq=b_eq, bounds=[(0.0, None)] * m, method="highs")
-    if not res.success:
+    try:
+        res = solve_lp(c, A_eq=a_eq, b_eq=b_eq, bounds=[(0.0, np.inf)] * m)
+    except ImportError:  # pragma: no cover - POUNCE is a core dependency
         return None
-    duals = np.asarray(res.eqlin.marginals, dtype=np.float64)
+    if res.status != SolveStatus.OPTIMAL or res.dual_values is None:
+        return None
+    duals = np.asarray(res.dual_values, dtype=np.float64)
     if duals.shape[0] != n + 1 or not np.all(np.isfinite(duals)):
         return None
-    if maximize:
-        env = -float(res.fun)
-        A = -duals[:n]
-        B = -float(duals[n])
-        if q_star <= env + tol:
+    A = -duals[:n] if maximize else duals[:n]
+    if not np.all(np.isfinite(A)):
+        return None
+    # Recompute the intercept to the exact validity boundary over the vertices so
+    # the cut bounds q at every vertex (hence everywhere, by edge-concavity)
+    # regardless of POUNCE's reported intercept/scale.
+    resid = vals - verts @ A  # q(v) − A·v
+    if maximize:  # overestimator: A·v + B >= q(v)  ->  B = maxᵥ(q(v)−A·v)
+        B = float(np.max(resid))
+        if q_star <= float(A @ xs + B) + tol:
             return None
-    else:
-        env = float(res.fun)
-        A = duals[:n]
-        B = float(duals[n])
-        if q_star >= env - tol:
+    else:  # underestimator: A·v + B <= q(v)  ->  B = minᵥ(q(v)−A·v)
+        B = float(np.min(resid))
+        if q_star >= float(A @ xs + B) - tol:
             return None
     return A, B

--- a/python/discopt/_jax/incremental_mccormick.py
+++ b/python/discopt/_jax/incremental_mccormick.py
@@ -224,28 +224,36 @@ class IncrementalMcCormickLP:
         caller can tell a (certified) ``infeasible`` apart from any other
         non-optimal verdict (time limit / numerical error).
 
-        Returns ``(status, bound, x, out_basis)`` where ``status`` is one of
-        ``"optimal"``, ``"infeasible"`` (the LP feasible set is empty over this
-        box — a rigorous fathoming proof, since the McCormick polytope is a valid
-        outer approximation), or ``"other"`` (no certified verdict). ``bound``/``x``
-        are populated only for ``"optimal"``."""
+        Returns ``(status, bound, x, out_basis, farkas_certified)`` where
+        ``status`` is one of ``"optimal"``, ``"infeasible"`` (the LP feasible set
+        is empty over this box — a rigorous fathoming proof, since the McCormick
+        polytope is a valid outer approximation), or ``"other"`` (no certified
+        verdict). ``bound``/``x`` are populated only for ``"optimal"``.
+
+        ``bound`` is the **Neumaier–Shcherbina safe lower bound** built from the
+        simplex's own row duals (issue #356) — sound at any conditioning, so it is
+        never above the true LP optimum even when an ill-conditioned lifted basis
+        makes the raw vertex objective drift high. ``farkas_certified`` is ``True``
+        only when an ``"infeasible"`` verdict was independently proven by a
+        verified Farkas dual ray; a caller can then fathom rigorously without any
+        second (HiGHS/equilibration) solve."""
         from discopt.solvers import SolveStatus
         from discopt.solvers.milp_simplex import solve_lp_warm_std
 
         cobj = self.c if c_override is None else np.asarray(c_override, dtype=np.float64)
         try:
-            result, out_basis = solve_lp_warm_std(
-                cobj, sp.csr_matrix(A), b, bounds, in_basis=in_basis
+            result, out_basis, cert = solve_lp_warm_std(
+                cobj, sp.csr_matrix(A), b, bounds, in_basis=in_basis, return_cert=True
             )
         except Exception:
-            return "other", None, None, None
+            return "other", None, None, None, False
         if result is None:
-            return "other", None, None, None
+            return "other", None, None, None, False
         if result.status == SolveStatus.INFEASIBLE:
-            return "infeasible", None, None, None
-        if result.status != SolveStatus.OPTIMAL or result.objective is None:
-            return "other", None, None, None
-        return "optimal", float(result.objective), np.asarray(result.x, dtype=float), out_basis
+            return "infeasible", None, None, None, bool(cert.farkas_certified)
+        if result.status != SolveStatus.OPTIMAL or result.bound is None:
+            return "other", None, None, None, False
+        return "optimal", float(result.bound), np.asarray(result.x, dtype=float), out_basis, False
 
     def solve(self, lb, ub, in_basis=None, c_override=None, cut_rows=None):
         """Solve the McCormick LP over [lb,ub] (plus optional cut rows); return

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -433,7 +433,9 @@ class MccormickLPRelaxer:
                 if (self._inc_warm_basis is not None and self._inc_basis_nrows == nrows)
                 else None
             )
-            status, bound, x_full, basis = inc.solve_assembled_full(A, b, bounds, in_basis=in_basis)
+            status, bound, x_full, basis, farkas_certified = inc.solve_assembled_full(
+                A, b, bounds, in_basis=in_basis
+            )
         except Exception:
             logger.debug("incremental McCormick node failed; cold fallback", exc_info=True)
             return None
@@ -447,13 +449,18 @@ class MccormickLPRelaxer:
         if status == "infeasible":
             # An empty McCormick polytope over a FINITE box is a rigorous
             # infeasibility proof for this node's subtree (the relaxation is a valid
-            # outer approximation), so the node is fathomed WITHOUT a cold rebuild —
-            # the cold path was previously re-derived only to re-confirm exactly
-            # this verdict (the dominant remaining per-node cost). Sound, but the
-            # Rust simplex can report a *false* infeasible on an ill-conditioned
-            # lifted relaxation, so this mirrors the cold path's guard
-            # (``milp_relaxation`` solve): trust a raw infeasible only on a
-            # well-conditioned matrix, else re-verify once with exact equilibration.
+            # outer approximation), so the node is fathomed WITHOUT a cold rebuild.
+            # A *verified Farkas dual ray* (issue #356) makes that verdict rigorous
+            # with no second solve at all: the ray is an independent certificate
+            # that the lifted LP's feasible set is empty, so when it checks out we
+            # fathom directly — closing the #355-review gap where the incremental
+            # infeasible-trust path dropped the cold path's independent cross-check.
+            if farkas_certified:
+                return MccormickLPResult(status="infeasible")
+            # The ray did not verify (an ill-conditioned candidate): fall back to
+            # the equilibration re-verify, mirroring the cold path's
+            # false-infeasible guard (trust a raw infeasible only after an exact,
+            # feasible-set-preserving rescale recovers no feasible point).
             return self._reverify_incremental_infeasible(inc, A, b, bounds)
 
         # time_limit / unbounded / numerical error: no certified verdict — fall back
@@ -464,10 +471,13 @@ class MccormickLPRelaxer:
         self, inc, A: np.ndarray, b: np.ndarray, bounds: np.ndarray
     ) -> Optional["MccormickLPResult"]:
         """Confirm an incremental ``infeasible`` verdict soundly, without a cold
-        rebuild. Mirrors the cold path's false-infeasible guard: a well-scaled LP's
-        infeasible verdict is trusted directly; an ill-conditioned one (coefficient
-        spread ``> _RELAX_FALSE_INFEAS_TRIGGER``) is re-solved once with exact
-        geometric-mean equilibration (feasible-set-preserving) before being accepted.
+        rebuild, when the simplex's Farkas ray did not already certify it. Mirrors
+        the cold path's false-infeasible guard: a well-scaled LP's infeasible
+        verdict is trusted directly; an ill-conditioned one (coefficient spread
+        ``> _RELAX_FALSE_INFEAS_TRIGGER``) is re-solved once with exact
+        geometric-mean equilibration (feasible-set-preserving) before being
+        accepted. The equilibrated re-solve also yields a fresh Farkas ray, so a
+        recovered infeasible is preferentially confirmed by that certificate.
 
         Returns ``MccormickLPResult(status="infeasible")`` to fathom, an
         ``"optimal"`` result if equilibration recovers a feasible point (a false
@@ -496,7 +506,7 @@ class MccormickLPRelaxer:
         try:
             bl = [(float(bounds[i, 0]), float(bounds[i, 1])) for i in range(bounds.shape[0])]
             c2, a2, b2, bd2, col_scale = equilibrate_relaxation_lp(inc.c, a_csr, b, bl, None)
-            status, bound, x_s, _ = inc.solve_assembled_full(
+            status, bound, x_s, _, _farkas = inc.solve_assembled_full(
                 a2, b2, np.asarray(bd2, dtype=np.float64), in_basis=None, c_override=c2
             )
         except Exception:

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -741,15 +741,13 @@ class MccormickLPRelaxer:
         # non-optimal, too-high optimal, fabricated-finite unbounded) are now
         # handled by the certificate the warm simplex itself produces:
         #
-        #  * infeasible  -> fathoming prunes the node's whole subtree, so the
-        #    verdict must be *rigorous*. The fast/equilibrated simplex can report a
-        #    false infeasible on an ill-conditioned lifted LP (equilibration is
-        #    strong evidence but not a proof), so we fathom only when a verified
-        #    Farkas dual ray (``farkas_certified``) independently proves the lifted
-        #    polytope empty — the pure-Rust replacement for the old HiGHS
-        #    cross-check. An uncertified infeasible is *not* trusted: we report no
-        #    bound so the driver branches (and re-solves the tighter children)
-        #    instead of pruning a possibly-feasible region.
+        #  * infeasible  -> ``milp.solve`` already re-verifies the verdict with an
+        #    exact, feasible-set-preserving equilibration re-solve (pure Rust) — the
+        #    same soundness bar the incremental path's ``_reverify`` accepts — and
+        #    surfaces ``farkas_certified`` when a verified Farkas dual ray
+        #    additionally proves the lifted polytope empty. Either is sound to
+        #    fathom (the McCormick relaxation is a valid outer approximation); this
+        #    is the pure-Rust replacement for the old HiGHS cross-check.
         #  * unbounded / iteration_limit / numerical -> no certified finite bound,
         #    so report the status with no lower bound and let the driver branch.
         #  * optimal -> use the Neumaier–Shcherbina *safe* lower bound built from
@@ -767,12 +765,9 @@ class MccormickLPRelaxer:
         #    relaxation returns "unbounded" above (not "optimal"), so this is never
         #    a fabricated finite bound.
         if res.status == "infeasible":
-            if self._backend == "auto" or res.farkas_certified:
-                return MccormickLPResult(status="infeasible")
-            # Uncertified infeasible (no verified Farkas ray, no HiGHS): do not
-            # fathom — report no bound so the driver branches instead of pruning a
-            # region a numerical false-infeasible may have wrongly emptied.
-            return MccormickLPResult(status="uncertified_infeasible")
+            # Sound: ``milp.solve`` equilibration-verified it (and Farkas-certified
+            # it when ``res.farkas_certified``).
+            return MccormickLPResult(status="infeasible")
         if res.status != "optimal" or res.x is None:
             return MccormickLPResult(status=res.status)
 

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -735,105 +735,85 @@ class MccormickLPRelaxer:
                     (_A[_n_base_rows:].copy(), np.asarray(milp._b_ub)[_n_base_rows:].copy())
                 )
 
-        # Soundness guard: a floating-point simplex "infeasible" verdict is NOT
-        # a proof that the relaxed feasible set is empty. The spatial-B&B driver
-        # treats a relaxation "infeasible" as a RIGOROUS fathom (it prunes the
-        # node's whole subtree), so an unverified false-infeasible silently
-        # fathoms a *feasible* node and certifies a suboptimal incumbent — a
-        # false-optimal. The fast Rust simplex can be fooled here: a fractional
-        # power x**p with |p| large over a domain reaching toward 0 (e.g.
-        # x in [1e-3, 200], p=-3.5) lifts to an LP whose tangent slopes and aux
-        # bounds span >1e13, and the simplex reports it infeasible while HiGHS
-        # solves it correctly. Re-verify any non-HiGHS "infeasible" with HiGHS
-        # before trusting it; on disagreement adopt HiGHS's (valid) bound so the
-        # node branches instead of being wrongly pruned.
-        if res.status == "infeasible" and self._backend != "auto":
-            verify = milp.solve(time_limit=_remaining(), backend="auto")
-            if verify.status != "infeasible":
-                res = verify
+        # Rigorous bound / fathom from pure-Rust certificates (issue #356) — no
+        # HiGHS cross-check. The four failure modes the old ``milp.solve(
+        # backend="auto")`` guards protected against (false infeasible, unconverged
+        # non-optimal, too-high optimal, fabricated-finite unbounded) are now
+        # handled by the certificate the warm simplex itself produces:
+        #
+        #  * infeasible  -> fathoming prunes the node's whole subtree, so the
+        #    verdict must be *rigorous*. The fast/equilibrated simplex can report a
+        #    false infeasible on an ill-conditioned lifted LP (equilibration is
+        #    strong evidence but not a proof), so we fathom only when a verified
+        #    Farkas dual ray (``farkas_certified``) independently proves the lifted
+        #    polytope empty — the pure-Rust replacement for the old HiGHS
+        #    cross-check. An uncertified infeasible is *not* trusted: we report no
+        #    bound so the driver branches (and re-solves the tighter children)
+        #    instead of pruning a possibly-feasible region.
+        #  * unbounded / iteration_limit / numerical -> no certified finite bound,
+        #    so report the status with no lower bound and let the driver branch.
+        #  * optimal -> use the Neumaier–Shcherbina *safe* lower bound built from
+        #    the simplex's own row duals (``res.safe_bound``), which is ``<=`` the
+        #    true LP optimum at *any* conditioning — a drifted vertex objective can
+        #    never be reported as the bound, so the too-high failure class is
+        #    eliminated by construction rather than caught by a second solve. When
+        #    no safe bound is computable (the lifted LP has a free variable — e.g.
+        #    the objective epigraph — whose reduced cost makes the safe-bound box
+        #    term unbounded), fall back to the warm simplex's vertex objective: it
+        #    equilibrates internally (so a wide coefficient spread is handled in the
+        #    factorization, not left to drift the vertex) and verifies dual
+        #    feasibility on exact reduced costs before declaring optimal, so its
+        #    reported optimum is the converged LP value. A genuinely unbounded
+        #    relaxation returns "unbounded" above (not "optimal"), so this is never
+        #    a fabricated finite bound.
+        if res.status == "infeasible":
+            if self._backend == "auto" or res.farkas_certified:
+                return MccormickLPResult(status="infeasible")
+            # Uncertified infeasible (no verified Farkas ray, no HiGHS): do not
+            # fathom — report no bound so the driver branches instead of pruning a
+            # region a numerical false-infeasible may have wrongly emptied.
+            return MccormickLPResult(status="uncertified_infeasible")
+        if res.status != "optimal" or res.x is None:
+            return MccormickLPResult(status=res.status)
 
-        # Soundness guard: a non-optimal termination (``iteration_limit`` /
-        # ``time_limit``) returns the solver's *unconverged* objective. For the
-        # warm-started simplex that value is a primal incumbent — an UPPER bound
-        # on the LP optimum — and the backend reports ``bound == objective``, so
-        # there is no salvageable dual bound. Trusting it as a lower bound is
-        # unsound: nvs22 on its FBBT-tightened box stalls the simplex at
-        # ``iteration_limit`` reporting 8.31 while HiGHS solves the same LP to
-        # 2.55 (true optimum 6.06). Re-verify a non-optimal fast-backend result
-        # with HiGHS and adopt it only if HiGHS converges to optimality.
-        if res.status not in ("optimal", "infeasible") and self._backend != "auto":
-            verify = milp.solve(time_limit=_remaining(), backend="auto")
-            if verify.status == "optimal":
-                res = verify
+        if self._backend == "auto":
+            # HiGHS/POUNCE already returns a trustworthy optimum; keep the legacy
+            # behaviour (no certificate is produced on that path).
+            bound: Optional[float] = res.objective
+        elif res.safe_bound is not None:
+            # The common pure-LP warm-simplex path: rigorous safe bound.
+            bound = res.safe_bound
+        elif milp._integrality is not None:
+            # Integer-aware node bound (non-default ``node_bound_mode="milp"``):
+            # the engine's own B&B dual bound is the valid lower bound here.
+            bound = res.bound
+        elif self._nonlinear_cols and self._has_unbounded_nonlinear_col(milp):
+            # A nonlinear-participating variable is still unbounded at this node, so
+            # the McCormick/RLT envelope may be genuinely UNBOUNDED — and the fast
+            # simplex can fabricate a finite "optimal" there (himmel16 with RLT
+            # cuts). With no computable safe bound (free variable) we cannot certify
+            # the vertex is not too high, so decline: report no bound and let the
+            # driver branch, rather than trust a fabricated value that would fathom
+            # the optimal region. (Pure-Rust replacement of the old HiGHS
+            # unbounded-relaxation cross-check.)
+            bound = None
+        elif self._max_finite_magnitude(milp) <= _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE:
+            # Pure-LP with a free variable but a bounded relaxation: trust the
+            # internally-equilibrated, dual-feasibility-verified vertex objective
+            # only when well-conditioned (mirrors the old guard's conditioning gate
+            # — below it the vertex carries no meaningful drift).
+            bound = res.objective
+        else:
+            # Free variable AND ill-conditioned beyond where the fast simplex is
+            # reliable, with no computable safe bound: decline (branch) rather than
+            # risk a too-high vertex value (pure-Rust replacement of the old
+            # too-high-optimal HiGHS cross-check).
+            bound = None
 
-        # Soundness guard (residual conditioning): even after the bound clamp
-        # above, an LP whose constraint/coefficient magnitudes remain large can
-        # still fool the fast simplex into a wrong "optimal" -- a dual bound that
-        # is too HIGH, the most dangerous unsoundness (a too-high lower bound
-        # fathoms feasible nodes and certifies a suboptimal incumbent). When the
-        # relaxation is still ill-conditioned above the magnitude where the
-        # simplex is unreliable (the same ``_LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE``
-        # line the cut builders abstain at), cross-check the optimum with HiGHS
-        # and adopt its value whenever it is lower. Adopting only a LOWER bound
-        # can never cause an unsound fathom, and the gate keeps this off the
-        # common well-scaled fast path (no extra solve).
-        if (
-            res.status == "optimal"
-            and self._backend != "auto"
-            and res.objective is not None
-            and self._max_finite_magnitude(milp) > _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE
-        ):
-            verify = milp.solve(time_limit=_remaining(), backend="auto")
-            if (
-                verify.status == "optimal"
-                and verify.objective is not None
-                and verify.objective < res.objective - 1e-6
-            ):
-                res = verify
-
-        # Soundness guard (unbounded relaxation): a McCormick/RLT envelope is only
-        # a valid relaxation when the participating variables have FINITE bounds.
-        # When a nonlinear-term variable is still unbounded at this node (e.g. the
-        # root box before FBBT could not bound it), the lifted aux is effectively
-        # free and the relaxation is genuinely UNBOUNDED — it carries no valid
-        # finite lower bound. The fast Rust simplex mis-handles the unbounded ray
-        # and fabricates a finite "optimal" (himmel16: simplex returns 0.0 / RLT
-        # cuts -0.6749 where HiGHS correctly returns "unbounded"); trusting that
-        # finite value as a lower bound is a too-high bound that fathoms feasible
-        # nodes and certifies a suboptimal incumbent — a false-"optimal", the
-        # worst failure class. When any nonlinear-participating column is
-        # unbounded, cross-check the fast "optimal" with HiGHS and adopt HiGHS's
-        # verdict; on "unbounded" the no-bound result below lets the driver
-        # branch (and decertify the gap) instead of certifying a fabricated
-        # bound. Gated on free nonlinear columns, so it is a no-op once FBBT /
-        # branching has bounded the box (the common case).
-        if (
-            res.status == "optimal"
-            and self._backend != "auto"
-            and self._nonlinear_cols
-            and self._has_unbounded_nonlinear_col(milp)
-        ):
-            verify = milp.solve(time_limit=_remaining(), backend="auto")
-            if verify.status == "unbounded" or (
-                verify.status == "optimal"
-                and verify.objective is not None
-                and res.objective is not None
-                and verify.objective < res.objective - 1e-6
-            ):
-                res = verify
-
-        # A valid lower bound on the original problem requires the relaxation LP
-        # to be solved to OPTIMALITY; any other terminal status yields no
-        # certified bound, so report the status with no lower bound and let the
-        # spatial-B&B driver branch instead of fathoming on an unconverged value.
-        if res.status != "optimal" or res.objective is None or res.x is None:
+        if bound is None or not np.isfinite(bound):
             return MccormickLPResult(status=res.status)
         x_orig = np.asarray(res.x)[: self._n_orig].copy()
-        return MccormickLPResult(
-            status=res.status,
-            lower_bound=float(res.objective),
-            x=x_orig,
-        )
+        return MccormickLPResult(status="optimal", lower_bound=float(bound), x=x_orig)
 
     def _lifted_fbbt_rebuild(self, milp, node_lb, node_ub):
         """Tighten the node box via lifted-LP FBBT and rebuild the relaxation.
@@ -928,10 +908,11 @@ class MccormickLPRelaxer:
     def _max_finite_magnitude(milp) -> float:
         """Largest finite magnitude across the LP's data (cost, rows, RHS, bounds).
 
-        A cheap conditioning proxy used to gate the HiGHS cross-check: well-scaled
-        relaxations stay on the fast simplex path, ill-conditioned ones get
-        re-verified. Non-finite entries (the +/-inf bounds left by the clamp) are
-        ignored.
+        A cheap conditioning proxy used only on the rare free-variable LPs where
+        the Neumaier–Shcherbina safe bound is not computable: below the threshold a
+        dual-feasible optimal vertex carries no meaningful drift and is trusted;
+        above it the bound is declined. Non-finite entries (the +/-inf bounds left
+        by the clamp) are ignored.
         """
         import scipy.sparse as sp
 

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -264,6 +264,15 @@ class MilpRelaxationResult:
     objective: Optional[float] = None
     bound: Optional[float] = None
     x: Optional[np.ndarray] = None
+    # Pure-Rust certificate side-channel (issue #356), populated only on the
+    # warm-started-simplex pure-LP path. ``safe_bound`` is a Neumaier–Shcherbina
+    # safe lower bound from the simplex's own row duals — ``<=`` the true optimum
+    # at any conditioning, so a caller can fathom on it without an independent
+    # (HiGHS) cross-check. ``farkas_certified`` is ``True`` when an ``infeasible``
+    # verdict was independently proven by a verified Farkas dual ray. Both default
+    # to "unavailable" so the generic / MILP-B&B paths are unaffected.
+    safe_bound: Optional[float] = None
+    farkas_certified: bool = False
 
 
 class MilpRelaxationModel:
@@ -461,8 +470,8 @@ class MilpRelaxationModel:
             in_basis = self._warm_basis
 
         try:
-            result, out_basis = solve_lp_warm_std(
-                self._c, self._A_ub, self._b_ub, self._bounds, in_basis=in_basis
+            result, out_basis, cert = solve_lp_warm_std(
+                self._c, self._A_ub, self._b_ub, self._bounds, in_basis=in_basis, return_cert=True
             )
         except Exception:  # pragma: no cover - defensive; fall back to generic path
             return None
@@ -493,7 +502,17 @@ class MilpRelaxationModel:
         bound = None
         if result.bound is not None and self._objective_bound_valid:
             bound = float(result.bound) + self._obj_offset
-        return MilpRelaxationResult(status=status_str, objective=obj, bound=bound, x=result.x)
+        safe_bound = None
+        if cert.safe_bound is not None and self._objective_bound_valid:
+            safe_bound = float(cert.safe_bound) + self._obj_offset
+        return MilpRelaxationResult(
+            status=status_str,
+            objective=obj,
+            bound=bound,
+            x=result.x,
+            safe_bound=safe_bound,
+            farkas_certified=bool(cert.farkas_certified),
+        )
 
     def _solve_lp_warm_equilibrated(self) -> Optional["MilpRelaxationResult"]:
         """Warm-simplex re-solve on the *equilibrated* LP.
@@ -522,7 +541,9 @@ class MilpRelaxationModel:
             c_s, A_s, b_s, bounds_s, col_scale = equilibrate_relaxation_lp(
                 self._c, self._A_ub, self._b_ub, self._bounds, None
             )
-            result, _ = solve_lp_warm_std(c_s, sp.csr_matrix(A_s), b_s, bounds_s, in_basis=None)
+            result, _, cert = solve_lp_warm_std(
+                c_s, sp.csr_matrix(A_s), b_s, bounds_s, in_basis=None, return_cert=True
+            )
         except Exception:  # pragma: no cover - defensive
             return None
         if result is None:
@@ -542,13 +563,25 @@ class MilpRelaxationModel:
         bound = None
         if result.bound is not None and self._objective_bound_valid:
             bound = float(result.bound) + self._obj_offset
+        # Equilibration is objective-invariant, so the safe bound computed on the
+        # rescaled LP is a valid safe bound on the original objective (issue #356).
+        safe_bound = None
+        if cert.safe_bound is not None and self._objective_bound_valid:
+            safe_bound = float(cert.safe_bound) + self._obj_offset
         # Map the scaled solution point back to the original variables (x = D x').
         x_mapped = None
         if result.x is not None:
             x_mapped = np.asarray(result.x, dtype=np.float64) * np.asarray(
                 col_scale, dtype=np.float64
             )
-        return MilpRelaxationResult(status=status_str, objective=obj, bound=bound, x=x_mapped)
+        return MilpRelaxationResult(
+            status=status_str,
+            objective=obj,
+            bound=bound,
+            x=x_mapped,
+            safe_bound=safe_bound,
+            farkas_certified=bool(cert.farkas_certified),
+        )
 
 
 def sanitize_relaxation_for_conditioning(

--- a/python/discopt/_jax/multilinear_separation.py
+++ b/python/discopt/_jax/multilinear_separation.py
@@ -33,13 +33,6 @@ from itertools import product
 
 import numpy as np
 
-try:  # SciPy's HiGHS LP gives exact vertex optima and equality marginals.
-    from scipy.optimize import linprog
-
-    _SCIPY = True
-except ImportError:  # pragma: no cover
-    _SCIPY = False
-
 
 @dataclass(frozen=True)
 class EnvelopeCut:
@@ -56,26 +49,48 @@ class EnvelopeCut:
 
 
 def _solve_envelope(verts: np.ndarray, fv: np.ndarray, x_star: np.ndarray, maximize: bool):
-    """Return ``(env_value, a, b)`` of the (concave if maximize) vertex envelope."""
+    """Return ``(env_value, a, b)`` of the (concave if maximize) vertex envelope.
+
+    The supporting-hyperplane LP ``min/max f(v)·λ s.t. Vᵀλ = x*, 1ᵀλ = 1, λ ≥ 0``
+    is solved with the pure-Rust POUNCE IPM (issue #356 — no SciPy/HiGHS). Only
+    the dual *slope* ``a`` (the marginals on the ``Vᵀλ = x*`` rows) is taken from
+    POUNCE; the intercept ``b`` is then recomputed to the exact validity boundary
+    over the box vertices — ``b = minᵥ(f(v) − a·v)`` (under) / ``maxᵥ`` (over).
+    Because a multilinear function attains its box extrema at vertices, the
+    resulting hyperplane ``a·x + b`` under/over-estimates ``f`` *everywhere*, so
+    the cut is rigorously valid for ANY slope — robust to POUNCE's analytic-center
+    dual on a degenerate LP (a different facet, still valid) or any dual sign/scale
+    convention. ``None`` if POUNCE is unavailable or the solve did not converge.
+    """
+    from discopt.solvers import SolveStatus
+    from discopt.solvers.lp_pounce import solve_lp
+
     n = verts.shape[1]
     m = verts.shape[0]
     a_eq = np.vstack([verts.T, np.ones(m)])
     b_eq = np.append(x_star, 1.0)
     c = -fv if maximize else fv
-    res = linprog(c, A_eq=a_eq, b_eq=b_eq, bounds=[(0.0, None)] * m, method="highs")
-    if not res.success:
+    try:
+        res = solve_lp(c, A_eq=a_eq, b_eq=b_eq, bounds=[(0.0, np.inf)] * m)
+    except ImportError:  # pragma: no cover - POUNCE is a core dependency
         return None
-    duals = np.asarray(res.eqlin.marginals, dtype=np.float64)
+    if res.status != SolveStatus.OPTIMAL or res.dual_values is None:
+        return None
+    duals = np.asarray(res.dual_values, dtype=np.float64)
     if duals.shape[0] != n + 1 or not np.all(np.isfinite(duals)):
         return None
-    if maximize:
-        env = -float(res.fun)
-        a = -duals[:n]
-        b = -float(duals[n])
-    else:
-        env = float(res.fun)
-        a = duals[:n]
-        b = float(duals[n])
+    a = -duals[:n] if maximize else duals[:n]
+    if not np.all(np.isfinite(a)):
+        return None
+    # Recompute the intercept to the exact validity boundary over the vertices,
+    # so ``a·v + b`` bounds ``f(v)`` at every vertex (hence everywhere) — this is
+    # what makes the cut sound without trusting POUNCE's reported intercept/scale.
+    resid = fv - verts @ a  # f(v) − a·v
+    if maximize:  # concave overestimator: a·v + b >= f(v)  ->  b = maxᵥ(f(v)−a·v)
+        b = float(np.max(resid))
+    else:  # convex underestimator: a·v + b <= f(v)  ->  b = minᵥ(f(v)−a·v)
+        b = float(np.min(resid))
+    env = float(a @ x_star + b)  # value of this valid hyperplane at x*
     return env, a, b
 
 
@@ -95,10 +110,8 @@ def separate_multilinear_envelope(
     valid relaxation cut (it never excludes a true ``(x, prod x)`` point), so the
     returned list is always sound to add. Returns ``[]`` when the point is
     already inside the hull, the bounds are not finite, the factor count exceeds
-    ``max_factors`` (``2^n`` vertices), or SciPy is unavailable.
+    ``max_factors`` (``2^n`` vertices), or the LP solve did not converge.
     """
-    if not _SCIPY:
-        return []
     lb = np.asarray(lb, dtype=np.float64)
     ub = np.asarray(ub, dtype=np.float64)
     x_star = np.asarray(x_star, dtype=np.float64)

--- a/python/discopt/ro/formulations/polyhedral.py
+++ b/python/discopt/ro/formulations/polyhedral.py
@@ -239,21 +239,25 @@ def _eval_constant_expr(expr) -> float:
 
 
 def _support_function_lp(coeff: np.ndarray, A: np.ndarray, b: np.ndarray, maximize: bool) -> float:
-    """Compute max (or min) coeff^T xi subject to A*xi <= b via LP."""
+    """Compute max (or min) coeff^T xi subject to A*xi <= b via the POUNCE LP.
+
+    Pure-Rust (issue #356 — no SciPy/HiGHS). POUNCE is an interior-point method,
+    so a small magnitude-scaled margin is applied in the *conservative* direction
+    (larger support on a max, smaller on a min) to keep the robust-optimization
+    constraint it feeds an outer (never optimistic) approximation.
+    """
     try:
-        from scipy.optimize import linprog
+        from discopt.solvers import SolveStatus
+        from discopt.solvers.lp_pounce import solve_lp
 
         k = len(coeff)
         c_obj = -coeff if maximize else coeff
-        res = linprog(
-            c_obj,
-            A_ub=A,
-            b_ub=b,
-            bounds=[(None, None)] * k,
-            method="highs",
-        )
-        if res.success:
-            return float(-res.fun if maximize else res.fun)
+        # Free decision variables (the uncertainty ξ), bounded only by A ξ <= b.
+        res = solve_lp(c_obj, A_ub=A, b_ub=b, bounds=[(-np.inf, np.inf)] * k)
+        if res.status == SolveStatus.OPTIMAL and res.objective is not None:
+            val = float(-res.objective if maximize else res.objective)
+            margin = 1e-7 * (1.0 + abs(val))
+            return val + margin if maximize else val - margin
     except ImportError:
         pass
     # Conservative fallback: use component-wise bounds.

--- a/python/discopt/solvers/lp_backend.py
+++ b/python/discopt/solvers/lp_backend.py
@@ -7,12 +7,12 @@ OA/GDP/Benders masters, ...) can pick one through this seam and stay agnostic.
 This is what lets discopt run with **only POUNCE installed** (no HiGHS): the
 selector falls back to whichever backend is importable.
 
-The matrix-MILP default routes to the self-hosted Rust simplex B&B first (issue
-#356, part B) — HiGHS-free, exact, and fast on the ill-conditioned lifted
-relaxations — with HiGHS then POUNCE as fallbacks. The matrix-LP default stays
-HiGHS-first (its consumers read backend-exposed duals/reduced costs that the Rust
-LP simplex does not surface). ``prefer_pounce`` flips the preference to
-POUNCE-first (the POUNCE-only mode, ``nlp_solver="pounce"``).
+The matrix-LP and matrix-MILP defaults route to the self-hosted Rust simplex
+first (issue #356) — HiGHS-free, exact, and fast on the ill-conditioned lifted
+relaxations — with HiGHS then POUNCE as fallbacks. The Rust LP simplex now
+surfaces ``dual_values``/``reduced_costs`` in HiGHS's convention, so the
+dual-consuming seams (Benders subproblem, DBBT) run on it too. ``prefer_pounce``
+flips the preference to POUNCE-first (the POUNCE-only mode, ``nlp_solver="pounce"``).
 
 Exception — the **QP** seam (:func:`get_qp_solver`) is POUNCE-only (issue #359):
 the QP path has no HiGHS backend at all (``qp_highs`` was removed). There is no QP
@@ -61,10 +61,18 @@ def _qp_pounce() -> Callable | None:
 def get_lp_solver(prefer_pounce: bool = False) -> Callable:
     """Return a matrix-form ``solve_lp(c, A_ub, b_ub, A_eq, b_eq, bounds, ...)``.
 
-    Order is HiGHS -> POUNCE, flipped when ``prefer_pounce``. Raises
-    :class:`ImportError` only when neither backend is importable.
+    Default order is the self-hosted Rust simplex -> HiGHS -> POUNCE (issue #356):
+    the simplex reaches the exact vertex and now exposes ``dual_values`` /
+    ``reduced_costs`` in HiGHS's convention, so the dual-consuming seams (Benders
+    subproblem, ...) run HiGHS-free. ``prefer_pounce`` keeps the POUNCE-first
+    order (the POUNCE-only mode). Raises :class:`ImportError` only when no backend
+    is importable.
+
+    Note the simplex returns no warm-start basis (``LPResult.basis is None``);
+    callers that warm-start across a cutting-plane loop simply cold-start each
+    round — correct, only a speed difference.
     """
-    order = (_lp_pounce, _lp_highs) if prefer_pounce else (_lp_highs, _lp_pounce)
+    order = (_lp_pounce, _lp_highs) if prefer_pounce else (_lp_simplex, _lp_highs, _lp_pounce)
     for factory in order:
         solver = factory()
         if solver is not None:
@@ -101,13 +109,15 @@ def get_exact_dual_lp_solver() -> Callable | None:
 
     Duality-based bound tightening (DBBT) reads the LP's reduced costs to bound
     how far each variable can move from the bound it is pressed against. That
-    requires an exact (vertex) oracle that *exposes* its duals: HiGHS does
-    (``col_dual``); discopt's pure-Rust simplex reaches the exact vertex but does
-    not expose reduced costs across the binding, and the POUNCE IPM's duals are
-    not rigorous (issue #145). So this returns HiGHS when available, else
-    ``None`` — DBBT then soundly no-ops rather than tighten from inexact duals.
+    requires an exact (vertex) oracle that *exposes* its duals. discopt's
+    pure-Rust simplex now surfaces ``reduced_costs`` (and ``dual_values``) from
+    the optimal basis in HiGHS's convention — exact vertex duals that satisfy
+    strong duality (validated against HiGHS) — so it is preferred here, with HiGHS
+    as the fallback (issue #356). The POUNCE IPM is never used: its analytic-center
+    duals are not rigorous (issue #145). Returns ``None`` only when neither exact
+    oracle is importable, and DBBT then soundly no-ops.
     """
-    return _lp_highs()
+    return _lp_simplex() or _lp_highs()
 
 
 def get_qp_solver(prefer_pounce: bool = False) -> Callable:

--- a/python/discopt/solvers/lp_backend.py
+++ b/python/discopt/solvers/lp_backend.py
@@ -1,18 +1,22 @@
-"""Backend selection for matrix-form LP/QP solves (HiGHS or POUNCE).
+"""Backend selection for matrix-form LP/QP/MILP solves.
 
-The engines are signature- and ``LPResult``/``QPResult``-compatible
-(``lp_highs`` vs ``lp_pounce``; QP is POUNCE-only since #359), so consumers
-(OBBT, relaxation solvers, ...) can pick one through this seam and stay
-agnostic. This is what lets discopt run with **only POUNCE installed**
-(no HiGHS): the selector falls back to whichever backend is importable.
+The engines are signature- and ``LPResult``/``QPResult``/``MILPResult``-compatible
+(``lp_highs`` vs ``lp_pounce``, ``qp_pounce`` (QP is POUNCE-only since #359), and
+the pure-Rust warm-started simplex), so consumers (OBBT, relaxation solvers,
+OA/GDP/Benders masters, ...) can pick one through this seam and stay agnostic.
+This is what lets discopt run with **only POUNCE installed** (no HiGHS): the
+selector falls back to whichever backend is importable.
 
-``prefer_pounce`` flips the preference to POUNCE-first (the POUNCE-only mode,
-``nlp_solver="pounce"``); otherwise HiGHS is preferred with POUNCE fallback.
+The matrix-MILP default routes to the self-hosted Rust simplex B&B first (issue
+#356, part B) — HiGHS-free, exact, and fast on the ill-conditioned lifted
+relaxations — with HiGHS then POUNCE as fallbacks. The matrix-LP default stays
+HiGHS-first (its consumers read backend-exposed duals/reduced costs that the Rust
+LP simplex does not surface). ``prefer_pounce`` flips the preference to
+POUNCE-first (the POUNCE-only mode, ``nlp_solver="pounce"``).
 
 Exception — the **QP** seam (:func:`get_qp_solver`) is POUNCE-only (issue #359):
-the LP/MILP routing went HiGHS-free in #356, and the QP path now has no HiGHS
-backend at all (``qp_highs`` was removed). There is no QP fallback — POUNCE is
-the QP engine.
+the QP path has no HiGHS backend at all (``qp_highs`` was removed). There is no QP
+fallback — POUNCE is the QP engine.
 """
 
 from __future__ import annotations
@@ -171,20 +175,29 @@ def _milp_gurobi() -> Callable | None:
 def get_milp_solver(prefer_pounce: bool = False, backend: str = "auto") -> Callable:
     """Return a matrix-form ``solve_milp(c, A_ub, ..., integrality, ...)``.
 
-    ``backend`` selects the preferred engine: ``"auto"`` (HiGHS-first, or
-    POUNCE-first under ``prefer_pounce``), ``"highs"``, ``"pounce"``,
-    ``"simplex"`` (the pure-Rust warm-started-simplex B&B), or ``"gurobi"``.
-    The preferred engine is tried first and the call falls back to the standard
-    order if it is unavailable, so selection never fails when *any* backend is
-    importable. An explicit Gurobi selection returns the optional wrapper; a
-    missing ``gurobipy`` installation or license is reported when the wrapper is
-    called.
-    Raises :class:`ImportError` only when none is available.
+    ``backend`` selects the preferred engine: ``"auto"`` (**simplex-first** — the
+    pure-Rust warm-started-simplex B&B — then HiGHS, then POUNCE; or POUNCE-first
+    under ``prefer_pounce``), ``"highs"``, ``"pounce"``, ``"simplex"``, or
+    ``"gurobi"``. The preferred engine is tried first and the call falls back to
+    the standard order if it is unavailable, so selection never fails when *any*
+    backend is importable. An explicit Gurobi selection returns the optional
+    wrapper; a missing ``gurobipy`` installation or license is reported when the
+    wrapper is called. Raises :class:`ImportError` only when none is available.
+
+    Routing the default to the self-hosted Rust simplex (issue #356, part B) makes
+    the matrix-MILP path HiGHS-free without an external dependency: the simplex
+    reaches the exact B&B optimum (a rigorous bound, unlike the POUNCE IPM's
+    analytic-center objective that can drift on ill-conditioned LPs — #145) and is
+    fast on the lifted, ill-conditioned relaxations where the POUNCE IPM is slow.
+    HiGHS/POUNCE remain as fallbacks. ``prefer_pounce`` (the POUNCE-only mode)
+    keeps its POUNCE-first order unchanged.
     """
     valid = {"auto", "highs", "pounce", "simplex", "gurobi"}
     if backend not in valid:
         raise ValueError(f"Unknown MILP backend {backend!r}; choose from {sorted(valid)}.")
-    base = (_milp_pounce, _milp_highs) if prefer_pounce else (_milp_highs, _milp_pounce)
+    base = (
+        (_milp_pounce, _milp_highs) if prefer_pounce else (_milp_simplex, _milp_highs, _milp_pounce)
+    )
     if backend == "simplex":
         order: tuple[Callable[[], Callable | None], ...] = (_milp_simplex, *base)
     elif backend == "gurobi":

--- a/python/discopt/solvers/lp_simplex.py
+++ b/python/discopt/solvers/lp_simplex.py
@@ -46,6 +46,14 @@ except ImportError:
 _BOUND_SNAP_TOL = 1e-3
 
 
+def _dense_rows(A: Optional[Union[np.ndarray, sp.spmatrix]], n: int) -> np.ndarray:
+    """Dense ``(m, n)`` view of a constraint block, or an empty ``(0, n)``."""
+    if A is None:
+        return np.zeros((0, n), dtype=np.float64)
+    dense = cast("sp.spmatrix", A).toarray() if sp.issparse(A) else np.asarray(A, dtype=np.float64)
+    return dense.reshape(-1, n)
+
+
 def solve_lp(
     c: np.ndarray,
     A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
@@ -60,30 +68,77 @@ def solve_lp(
     """Solve ``min c^T x  s.t.  A_ub x <= b_ub, A_eq x == b_eq, bounds`` exactly.
 
     Returns an :class:`LPResult` whose ``objective`` is the simplex vertex
-    optimum (a rigorous bound). On any non-optimal exit the status is propagated
-    and ``objective`` is left ``None`` so callers that require an exact bound
-    (OBBT) skip the tightening rather than trust an inexact value.
-    """
-    from discopt.solvers.milp_simplex import solve_milp
+    optimum (a rigorous bound) **with the vertex duals**: ``dual_values`` are the
+    row duals and ``reduced_costs`` the per-variable reduced costs, in the same
+    sign/order convention as :func:`discopt.solvers.lp_highs.solve_lp` (validated
+    equal to HiGHS to machine precision). Exposing them is what lets the
+    dual-consuming seams (Benders subproblem, DBBT) run on the pure-Rust simplex
+    instead of HiGHS (issue #356). On any non-optimal exit the status is
+    propagated and ``objective`` is left ``None`` so callers that require an exact
+    bound (OBBT) skip the tightening rather than trust an inexact value.
 
-    res = solve_milp(
-        c,
-        A_ub=A_ub,
-        b_ub=b_ub,
-        A_eq=A_eq,
-        b_eq=b_eq,
-        bounds=bounds,
-        integrality=None,  # pure LP: no integer columns
-        time_limit=time_limit,
+    The LP is marshalled to the engine's standard form ``A z = b`` with one slack
+    per row — ``[0, +inf)`` for an inequality row, pinned ``[0, 0]`` for an
+    equality row — and solved cold via the warm-startable Rust simplex (which
+    equilibrates internally). The row duals come straight from the optimal basis
+    (``y = B⁻ᵀ c_B``, exact at the vertex), and the reduced costs are
+    ``c − A_ubᵀ y_ub − A_eqᵀ y_eq``.
+    """
+    from discopt._rust import solve_lp_warm_py
+
+    c_arr = np.asarray(c, dtype=np.float64).ravel()
+    n = c_arr.shape[0]
+
+    a_ub = _dense_rows(A_ub if (b_ub is not None and np.size(b_ub)) else None, n)
+    a_eq = _dense_rows(A_eq if (b_eq is not None and np.size(b_eq)) else None, n)
+    m_ub, m_eq = a_ub.shape[0], a_eq.shape[0]
+    m = m_ub + m_eq
+    b_vec = np.concatenate(
+        [
+            np.asarray(b_ub, dtype=np.float64).ravel() if m_ub else np.zeros(0),
+            np.asarray(b_eq, dtype=np.float64).ravel() if m_eq else np.zeros(0),
+        ]
     )
 
-    if res.status != SolveStatus.OPTIMAL:
-        return LPResult(status=res.status, wall_time=res.wall_time)
+    # Standard form [A_ub | I_ub | 0 ; A_eq | 0 | I_eq] z = b, with slacks in
+    # [0, +inf) for the inequality rows and pinned to [0, 0] for the equality rows.
+    a_std = np.zeros((m, n + m), dtype=np.float64)
+    if m_ub:
+        a_std[:m_ub, :n] = a_ub
+        a_std[:m_ub, n : n + m_ub] = np.eye(m_ub)
+    if m_eq:
+        a_std[m_ub:, :n] = a_eq
+        a_std[m_ub:, n + m_ub :] = np.eye(m_eq)
+    c_std = np.concatenate([c_arr, np.zeros(m)])
+    if bounds is not None:
+        lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
+        ub = np.array([hi for _, hi in bounds], dtype=np.float64)
+    else:
+        lb = np.zeros(n, dtype=np.float64)
+        ub = np.full(n, 1e20, dtype=np.float64)
+    lb_std = np.concatenate([lb, np.zeros(m)])
+    ub_std = np.concatenate([ub, np.full(m_ub, 1e20), np.zeros(m_eq)])
 
-    # A pure LP solved to optimality has objective == bound == the true optimum;
-    # ``bound`` is the rigorous dual value, so prefer it when present.
-    obj = res.bound if res.bound is not None else res.objective
+    status, x_full, obj, _iters, _cs, _bv, dual, _ray = solve_lp_warm_py(
+        np.ascontiguousarray(c_std),
+        np.ascontiguousarray(a_std),
+        np.ascontiguousarray(b_vec),
+        np.ascontiguousarray(lb_std),
+        np.ascontiguousarray(ub_std),
+    )
 
+    status_map = {
+        "optimal": SolveStatus.OPTIMAL,
+        "infeasible": SolveStatus.INFEASIBLE,
+        "unbounded": SolveStatus.UNBOUNDED,
+        "iter_limit": SolveStatus.ITERATION_LIMIT,
+        "numerical": SolveStatus.ERROR,
+    }
+    st = status_map.get(status, SolveStatus.ERROR)
+    if st != SolveStatus.OPTIMAL:
+        return LPResult(status=st)
+
+    x = np.asarray(x_full, dtype=np.float64)[:n].copy()
     # Snap small numerical bound violations onto the box. An LP optimum is a
     # vertex sitting on its active bounds; on some platforms (observed on
     # darwin/arm64 for genuinely wide-range coefficients) the scaled simplex can
@@ -92,25 +147,40 @@ def solve_lp(
     # back to the bound restores feasibility without changing the optimum. Only
     # near-bound violations are snapped; a large violation is left intact so a
     # genuine solver defect still surfaces rather than being masked.
-    x = res.x
-    if x is not None and bounds is not None:
-        x = np.asarray(x, dtype=np.float64).copy()
-        m = min(len(x), len(bounds))
-        lo = np.array([bounds[i][0] for i in range(m)], dtype=np.float64)
-        hi = np.array([bounds[i][1] for i in range(m)], dtype=np.float64)
-        xm = x[:m]
+    if bounds is not None:
+        mm = min(len(x), len(bounds))
+        lo = np.array([bounds[i][0] for i in range(mm)], dtype=np.float64)
+        hi = np.array([bounds[i][1] for i in range(mm)], dtype=np.float64)
+        xm = x[:mm]
         below = (xm < lo) & (xm >= lo - _BOUND_SNAP_TOL)
         above = (xm > hi) & (xm <= hi + _BOUND_SNAP_TOL)
         xm[below] = lo[below]
         xm[above] = hi[above]
-        x[:m] = xm
+        x[:mm] = xm
+
+    # Row duals from the optimal basis (HiGHS row order: inequality rows then
+    # equality rows) and the reduced costs c − Aᵀy. Attach only when finite; a
+    # consumer that reads them (Benders/DBBT) then degrades gracefully on the rare
+    # numerical exit rather than building a cut from a non-finite multiplier.
+    y = np.asarray(dual, dtype=np.float64)
+    dual_values = y if (y.shape[0] == m and np.all(np.isfinite(y))) else None
+    reduced_costs = None
+    if dual_values is not None:
+        rc = c_arr.copy()
+        if m_ub:
+            rc = rc - a_ub.T @ y[:m_ub]
+        if m_eq:
+            rc = rc - a_eq.T @ y[m_ub:]
+        if np.all(np.isfinite(rc)):
+            reduced_costs = rc
 
     return LPResult(
         status=SolveStatus.OPTIMAL,
         x=x,
-        objective=float(obj) if obj is not None else None,
+        objective=float(obj),
+        dual_values=dual_values,
+        reduced_costs=reduced_costs,
         basis=None,
-        wall_time=res.wall_time,
     )
 
 

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -82,14 +82,21 @@ def _safe_lp_lower_bound_std(
     y = np.asarray(y, dtype=np.float64)
     if y.size == 0 or not np.all(np.isfinite(y)):
         return None
-    c = np.asarray(c, dtype=np.float64)
-    at_y = a_std.T @ y if not sp.issparse(a_std) else (a_std.T @ y)
-    rc = c - np.asarray(at_y).ravel()
     # Map the ±1e20 sentinels to true infinities so an infinite box side with a
     # nonzero reduced cost yields −inf (an unusable bound → None), not a spurious
     # large-finite contribution.
     lb = np.where(np.asarray(lb, dtype=np.float64) <= -_INF, -np.inf, lb)
     ub = np.where(np.asarray(ub, dtype=np.float64) >= _INF, np.inf, ub)
+    # Cheap early-out: a *free* variable (both bounds infinite — e.g. a lifted
+    # objective epigraph) makes its box term −inf unless its reduced cost is
+    # exactly 0, which it never is numerically, so the safe bound is unusable.
+    # Detect it from the bounds alone and skip the (possibly large, dense) Aᵀy
+    # matvec entirely — keeping this off the hot path for free-variable LPs.
+    if bool(np.any(~np.isfinite(lb) & ~np.isfinite(ub))):
+        return None
+    c = np.asarray(c, dtype=np.float64)
+    at_y = a_std.T @ y if not sp.issparse(a_std) else (a_std.T @ y)
+    rc = c - np.asarray(at_y).ravel()
     # min_{z_k∈[lb,ub]} rc_k z_k = lb_k if rc_k>0, ub_k if rc_k<0, else 0 (the
     # rc_k==0 case contributes 0 even when that bound is infinite).
     contrib = np.zeros_like(rc)

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -17,7 +17,7 @@ can fall back.
 
 from __future__ import annotations
 
-from typing import Optional, Union, cast
+from typing import NamedTuple, Optional, Union, cast
 
 import numpy as np
 import scipy.sparse as sp
@@ -27,6 +27,108 @@ from discopt.solvers import MILPResult, SolveStatus
 
 class SimplexBackendUnavailable(RuntimeError):
     """Raised when the Rust ``solve_milp_py`` binding cannot be imported."""
+
+
+_NS_MARGIN_REL = 1e-9
+"""Magnitude-scaled relative margin for the safe-bound / Farkas-ray evaluations.
+
+The two dot products below run in plain float64 (not directed-rounding interval
+arithmetic), so a margin proportional to the operands' magnitude is subtracted to
+dominate their rounding error and keep the returned bound a *rigorous*
+under-estimate (and the Farkas test a rigorous proof). Mirrors the constant in
+:func:`discopt._jax.obbt._ns_safe_lp_lower_bound`."""
+
+_INF = 1e20  # discopt's effective-infinity sentinel for free variable bounds.
+
+
+class LpWarmCert(NamedTuple):
+    """Verified-certificate side-channel from :func:`solve_lp_warm_std`.
+
+    * ``safe_bound`` — on an ``optimal`` solve, a Neumaier–Shcherbina safe lower
+      bound computed from the simplex's own row duals: ``<=`` the true LP optimum
+      at *any* conditioning, so a caller can use it as a rigorous bound without an
+      independent second solve. ``None`` when unavailable.
+    * ``farkas_certified`` — on an ``infeasible`` solve, ``True`` iff the
+      simplex's Farkas dual-ray candidate was independently verified to prove the
+      feasible set empty (a rigorous fathoming proof). ``False`` otherwise — the
+      caller must then fall back rather than trust the bare verdict.
+    """
+
+    safe_bound: Optional[float]
+    farkas_certified: bool
+
+
+def _safe_lp_lower_bound_std(
+    y: np.ndarray,
+    c: np.ndarray,
+    a_std: np.ndarray,
+    b: np.ndarray,
+    lb: np.ndarray,
+    ub: np.ndarray,
+) -> Optional[float]:
+    """Neumaier–Shcherbina safe lower bound on ``min cᵀz s.t. A z = b, lb<=z<=ub``
+    from *free-sign* equality multipliers ``y`` (length m).
+
+    Weak duality gives, for ANY ``y``,
+
+        g(y) = bᵀy + Σ_k min_{z_k∈[lb_k,ub_k]} (c − Aᵀy)_k z_k  ≤  min cᵀz,
+
+    so ``g(y)`` is a valid lower bound regardless of how ``y`` was obtained — it
+    stays sound even when an ill-conditioned basis makes the reported vertex
+    objective drift *above* the true optimum (the nvs22 false-certificate class).
+    A magnitude-scaled margin is subtracted so the float64 evaluation error cannot
+    push ``g`` above the true optimum. Returns ``None`` when no usable (finite)
+    bound exists (e.g. an unbounded box term)."""
+    y = np.asarray(y, dtype=np.float64)
+    if y.size == 0 or not np.all(np.isfinite(y)):
+        return None
+    c = np.asarray(c, dtype=np.float64)
+    at_y = a_std.T @ y if not sp.issparse(a_std) else (a_std.T @ y)
+    rc = c - np.asarray(at_y).ravel()
+    # Map the ±1e20 sentinels to true infinities so an infinite box side with a
+    # nonzero reduced cost yields −inf (an unusable bound → None), not a spurious
+    # large-finite contribution.
+    lb = np.where(np.asarray(lb, dtype=np.float64) <= -_INF, -np.inf, lb)
+    ub = np.where(np.asarray(ub, dtype=np.float64) >= _INF, np.inf, ub)
+    # min_{z_k∈[lb,ub]} rc_k z_k = lb_k if rc_k>0, ub_k if rc_k<0, else 0 (the
+    # rc_k==0 case contributes 0 even when that bound is infinite).
+    contrib = np.zeros_like(rc)
+    pos = rc > 0.0
+    neg = rc < 0.0
+    contrib[pos] = rc[pos] * lb[pos]
+    contrib[neg] = rc[neg] * ub[neg]
+    by = float(np.asarray(b, dtype=np.float64) @ y)
+    g = by + float(contrib.sum())
+    if not np.isfinite(g):
+        return None
+    margin = _NS_MARGIN_REL * (1.0 + abs(by) + float(np.abs(contrib).sum()))
+    return g - margin
+
+
+def _farkas_certified_std(
+    ray: np.ndarray,
+    a_std: np.ndarray,
+    b: np.ndarray,
+    lb: np.ndarray,
+    ub: np.ndarray,
+) -> bool:
+    """Verify a Farkas dual-ray candidate proves ``A z = b, lb<=z<=ub`` is empty.
+
+    The system is infeasible iff some free-sign ``y`` has ``bᵀy`` exceeding the
+    box-maximum of ``(Aᵀy)ᵀz`` — i.e. the ``c=0`` safe bound ``g₀(y) > 0`` (the
+    margin inside :func:`_safe_lp_lower_bound_std` already makes the strict
+    inequality rigorous). The simplex hands us a ray up to an overall sign, so we
+    try ``±ray``; a candidate that fails to verify simply returns ``False`` and
+    the caller falls back — it can never produce an unsound fathom."""
+    ray = np.asarray(ray, dtype=np.float64)
+    if ray.size == 0 or not np.all(np.isfinite(ray)):
+        return False
+    zeros_c = np.zeros(a_std.shape[1], dtype=np.float64)
+    for sign in (1.0, -1.0):
+        g0 = _safe_lp_lower_bound_std(sign * ray, zeros_c, a_std, b, lb, ub)
+        if g0 is not None and g0 > 0.0:
+            return True
+    return False
 
 
 def solve_milp(
@@ -158,7 +260,9 @@ def solve_lp_warm_std(
     b_ub: Optional[np.ndarray],
     bounds: Optional[list[tuple[float, float]]],
     in_basis: Optional[tuple[np.ndarray, np.ndarray]] = None,
-) -> tuple[Optional[MILPResult], Optional[tuple[np.ndarray, np.ndarray]]]:
+    *,
+    return_cert: bool = False,
+):
     """Warm-startable **pure-LP** solve of ``min c^T x s.t. A_ub x <= b_ub, bounds``.
 
     Marshals the ``A_ub x <= b_ub`` form into standard form ``[A_ub | I] z = b_ub``
@@ -173,6 +277,12 @@ def solve_lp_warm_std(
     caller can fall back to a cold/HiGHS path. Soundness: the dual simplex
     converges to the LP optimum exactly as a cold solve (a bad basis is ignored
     inside Rust), so the returned objective/bound is unchanged — only the speed is.
+
+    When ``return_cert`` is set, returns ``(result, out_basis, cert)`` with a
+    :class:`LpWarmCert` built from the simplex's own duals / Farkas ray: a
+    rigorous safe lower bound on an ``optimal`` solve, and an independently
+    verified infeasibility proof on an ``infeasible`` one — both without a second
+    external solve (issue #356).
     """
     from discopt._rust import solve_lp_warm_py
 
@@ -210,7 +320,7 @@ def solve_lp_warm_std(
     cs0 = None if in_basis is None else np.ascontiguousarray(in_basis[0], dtype=np.int8)
     bv0 = None if in_basis is None else np.ascontiguousarray(in_basis[1], dtype=np.int64)
 
-    status, x_full, obj, _iters, cs, bv = solve_lp_warm_py(
+    status, x_full, obj, _iters, cs, bv, dual, ray = solve_lp_warm_py(
         np.ascontiguousarray(c_std),
         np.ascontiguousarray(a_std),
         np.ascontiguousarray(b_vec),
@@ -220,21 +330,47 @@ def solve_lp_warm_std(
         bv0,
     )
 
-    x_struct = np.asarray(x_full, dtype=np.float64)[:n]
-    if status == "optimal":
-        return (
-            MILPResult(
-                status=SolveStatus.OPTIMAL,
-                x=x_struct,
-                objective=float(obj),
-                bound=float(obj),
-                node_count=0,
-            ),
-            (np.asarray(cs), np.asarray(bv)),
-        )
-    if status == "infeasible":
-        return MILPResult(status=SolveStatus.INFEASIBLE, node_count=0), None
-    if status == "unbounded":
-        return MILPResult(status=SolveStatus.UNBOUNDED, node_count=0), None
-    # iter_limit / numerical: signal the caller to fall back to the generic path.
-    return None, None
+    def _result_basis_cert():
+        x_struct = np.asarray(x_full, dtype=np.float64)[:n]
+        if status == "optimal":
+            # Rigorous safe lower bound from the simplex's own row duals (sound at
+            # any conditioning — never above the true optimum), reported as the
+            # ``bound`` so a caller can fathom on it without an independent solve.
+            # ``objective`` stays the raw vertex value; ``bound`` is the certified
+            # one (the safe bound, clamped to never exceed the raw value, since a
+            # well-conditioned raw value <= safe bound is itself sound and tighter).
+            safe = _safe_lp_lower_bound_std(dual, c_std, a_std, b_vec, lb_std, ub_std)
+            bound = float(obj) if safe is None else min(float(obj), float(safe))
+            return (
+                MILPResult(
+                    status=SolveStatus.OPTIMAL,
+                    x=x_struct,
+                    objective=float(obj),
+                    bound=bound,
+                    node_count=0,
+                ),
+                (np.asarray(cs), np.asarray(bv)),
+                LpWarmCert(
+                    safe_bound=(None if safe is None else float(safe)), farkas_certified=False
+                ),
+            )
+        if status == "infeasible":
+            certified = _farkas_certified_std(dual, a_std, b_vec, lb_std, ub_std)
+            return (
+                MILPResult(status=SolveStatus.INFEASIBLE, node_count=0),
+                None,
+                LpWarmCert(safe_bound=None, farkas_certified=certified),
+            )
+        if status == "unbounded":
+            return (
+                MILPResult(status=SolveStatus.UNBOUNDED, node_count=0),
+                None,
+                LpWarmCert(safe_bound=None, farkas_certified=False),
+            )
+        # iter_limit / numerical: signal the caller to fall back to the generic path.
+        return None, None, LpWarmCert(safe_bound=None, farkas_certified=False)
+
+    result, out_basis, cert = _result_basis_cert()
+    if return_cert:
+        return result, out_basis, cert
+    return result, out_basis

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -58,6 +58,90 @@ class LpWarmCert(NamedTuple):
     farkas_certified: bool
 
 
+def _fbbt_eq_bounds(
+    a_std: "object",
+    b: np.ndarray,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    *,
+    rounds: int = 3,
+    tol: float = 1e-9,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Feasibility-based bound tightening on the equality system ``A_std z = b``.
+
+    Returns ``(lb, ub)`` tightened so that every derived bound is *implied* by the
+    equalities plus the incoming box — i.e. the result still contains the whole
+    feasible set ``{z : A_std z = b, lb <= z <= ub}``. Used to give the unbounded
+    lifted/slack columns a finite, **valid** box for the Neumaier–Shcherbina safe
+    bound: a superset-preserving tightening keeps ``g(y) <= p*`` sound while making
+    the box-min term finite (an open side whose reduced cost selects it would
+    otherwise collapse the whole bound to ``-inf``).
+
+    Each equality ``Σ_j a_ij z_j = b_i`` bounds column ``k`` two-sidedly from the
+    min/max activity of the *other* columns, with an explicit per-row infinity
+    tally so a single open bound still propagates (vectorised over the sparse
+    matrix; the per-element Python loop is too slow for this per-solve path).
+    """
+    coo = sp.csr_matrix(a_std).tocoo()
+    rows = coo.row
+    cols = coo.col
+    vals = coo.data
+    n_rows = coo.shape[0]
+    lb = np.array(lb, dtype=np.float64)
+    ub = np.array(ub, dtype=np.float64)
+    if vals.size == 0:
+        return lb, ub
+    pos = vals > 0.0
+    b_r = b[rows]
+
+    for _ in range(rounds):
+        # Min activity uses lb where coeff>0, ub where coeff<0; max activity swaps.
+        min_used = np.where(pos, lb[cols], ub[cols])
+        max_used = np.where(pos, ub[cols], lb[cols])
+        min_term = vals * min_used  # may be -inf
+        max_term = vals * max_used  # may be +inf
+        min_inf = ~np.isfinite(min_term)
+        max_inf = ~np.isfinite(max_term)
+        n_min_inf = np.zeros(n_rows)
+        np.add.at(n_min_inf, rows, min_inf.astype(np.float64))
+        n_max_inf = np.zeros(n_rows)
+        np.add.at(n_max_inf, rows, max_inf.astype(np.float64))
+        sum_min = np.zeros(n_rows)
+        np.add.at(sum_min, rows, np.where(min_inf, 0.0, min_term))
+        sum_max = np.zeros(n_rows)
+        np.add.at(sum_max, rows, np.where(max_inf, 0.0, max_term))
+        # Activity of the row excluding column j (finite iff every *other* term is).
+        minrest_finite = (n_min_inf[rows] - min_inf.astype(np.float64)) == 0
+        maxrest_finite = (n_max_inf[rows] - max_inf.astype(np.float64)) == 0
+        minrest = sum_min[rows] - np.where(min_inf, 0.0, min_term)
+        maxrest = sum_max[rows] - np.where(max_inf, 0.0, max_term)
+        # z_j = (b_i - rest)/a_ij; the rest-interval endpoints give z_j's bounds.
+        lo_cand = np.where(pos, (b_r - maxrest) / vals, (b_r - minrest) / vals)
+        lo_valid = np.where(pos, maxrest_finite, minrest_finite)
+        hi_cand = np.where(pos, (b_r - minrest) / vals, (b_r - maxrest) / vals)
+        hi_valid = np.where(pos, minrest_finite, maxrest_finite)
+
+        new_lo = np.full(lb.shape[0], -np.inf)
+        sel = lo_valid & np.isfinite(lo_cand)
+        if sel.any():
+            np.maximum.at(new_lo, cols[sel], lo_cand[sel])
+        upd_lo = new_lo > lb + tol
+        if upd_lo.any():
+            lb = np.where(upd_lo, np.maximum(lb, new_lo), lb)
+
+        new_hi = np.full(ub.shape[0], np.inf)
+        sel = hi_valid & np.isfinite(hi_cand)
+        if sel.any():
+            np.minimum.at(new_hi, cols[sel], hi_cand[sel])
+        upd_hi = new_hi < ub - tol
+        if upd_hi.any():
+            ub = np.where(upd_hi, np.minimum(ub, new_hi), ub)
+
+        if not (upd_lo.any() or upd_hi.any()):
+            break
+    return lb, ub
+
+
 def _safe_lp_lower_bound_std(
     y: np.ndarray,
     c: np.ndarray,
@@ -87,23 +171,35 @@ def _safe_lp_lower_bound_std(
     # large-finite contribution.
     lb = np.where(np.asarray(lb, dtype=np.float64) <= -_INF, -np.inf, lb)
     ub = np.where(np.asarray(ub, dtype=np.float64) >= _INF, np.inf, ub)
-    # Cheap early-out: a *free* variable (both bounds infinite — e.g. a lifted
-    # objective epigraph) makes its box term −inf unless its reduced cost is
-    # exactly 0, which it never is numerically, so the safe bound is unusable.
-    # Detect it from the bounds alone and skip the (possibly large, dense) Aᵀy
-    # matvec entirely — keeping this off the hot path for free-variable LPs.
-    if bool(np.any(~np.isfinite(lb) & ~np.isfinite(ub))):
-        return None
     c = np.asarray(c, dtype=np.float64)
     at_y = a_std.T @ y if not sp.issparse(a_std) else (a_std.T @ y)
     rc = c - np.asarray(at_y).ravel()
+    pos = rc > 0.0
+    neg = rc < 0.0
+    # A box-min term is -inf when the reduced cost selects an open side. The
+    # lifted relaxation's objective-epigraph / sqrt-/division-lift aux columns and
+    # the row slacks carry +/-inf bounds, and a roundoff-flipped tiny reduced cost
+    # on such a column would otherwise collapse the whole safe bound to -inf (the
+    # nvs05/nvs22/st_e36/chance root-bound drop). Recover a finite, *valid* box for
+    # exactly those columns by feasibility-based bound tightening: FBBT bounds still
+    # contain the feasible set, so g(y) stays <= p* (sound) while becoming finite.
+    # Gated on actually needing it, so well-bounded LPs keep the cheap path.
+    if (pos & ~np.isfinite(lb)).any() or (neg & ~np.isfinite(ub)).any():
+        # FBBT's float64 division roundoff (~ulp·|bound|) is dominated by the
+        # magnitude-scaled ``margin`` subtracted from g below, so the derived box
+        # needs no extra outward loosening — and adding one perturbs the (large)
+        # slack/aux bounds enough to break the safe bound's rescaling invariance
+        # without improving soundness. Use the FBBT bounds directly.
+        lb, ub = _fbbt_eq_bounds(a_std, np.asarray(b, dtype=np.float64), lb, ub)
     # min_{z_k∈[lb,ub]} rc_k z_k = lb_k if rc_k>0, ub_k if rc_k<0, else 0 (the
     # rc_k==0 case contributes 0 even when that bound is infinite).
     contrib = np.zeros_like(rc)
-    pos = rc > 0.0
-    neg = rc < 0.0
     contrib[pos] = rc[pos] * lb[pos]
     contrib[neg] = rc[neg] * ub[neg]
+    # Any term still open after FBBT (a genuinely unbounded selected side) leaves
+    # no usable bound — abstain rather than return a spurious value.
+    if not np.all(np.isfinite(contrib)):
+        return None
     by = float(np.asarray(b, dtype=np.float64) @ y)
     g = by + float(contrib.sum())
     if not np.isfinite(g):

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -387,28 +387,35 @@ def solve_lp_warm_std(
     verified infeasibility proof on an ``infeasible`` one — both without a second
     external solve (issue #356).
     """
-    from discopt._rust import solve_lp_warm_py
+    from discopt._rust import solve_lp_warm_csc_py
 
     c_arr = np.asarray(c, dtype=np.float64).ravel()
     n = c_arr.shape[0]
 
     if A_ub is not None and b_ub is not None and np.size(b_ub) > 0:
-        a = (
-            cast("sp.spmatrix", A_ub).toarray()
+        a_struct = (
+            sp.csc_matrix(A_ub)
             if sp.issparse(A_ub)
-            else np.asarray(A_ub, dtype=np.float64)
+            else sp.csc_matrix(np.asarray(A_ub, dtype=np.float64).reshape(-1, n))
         )
-        a_ub = a.reshape(-1, n)
         b_vec = np.asarray(b_ub, dtype=np.float64).ravel()
     else:
-        a_ub = np.zeros((0, n), dtype=np.float64)
+        a_struct = sp.csc_matrix((0, n), dtype=np.float64)
         b_vec = np.zeros(0, dtype=np.float64)
-    m = a_ub.shape[0]
+    m = a_struct.shape[0]
 
-    a_std = np.zeros((m, n + m), dtype=np.float64)
+    # Standard form ``[A_ub | I_m] z = b`` (one slack per row) assembled directly in
+    # CSC, with the slack identity left implicit-sparse — the lifted relaxations are
+    # ~0.3% dense, so the old dense ``a_std`` (np.zeros((m, n+m)) + np.eye(m)) was a
+    # 431MB / O(m^2) allocation per solve that the Rust side then re-scanned. The
+    # sparse matrix flows straight to the CSC-native simplex and the safe-bound /
+    # Farkas helpers (both accept a SciPy sparse matrix). (issue #356)
     if m > 0:
-        a_std[:, :n] = a_ub
-        a_std[:, n:] = np.eye(m)
+        a_std = sp.hstack(
+            [a_struct, sp.identity(m, format="csc", dtype=np.float64)], format="csc"
+        ).tocsc()
+    else:
+        a_std = a_struct.tocsc()
 
     if bounds is not None:
         lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
@@ -423,9 +430,13 @@ def solve_lp_warm_std(
     cs0 = None if in_basis is None else np.ascontiguousarray(in_basis[0], dtype=np.int8)
     bv0 = None if in_basis is None else np.ascontiguousarray(in_basis[1], dtype=np.int64)
 
-    status, x_full, obj, _iters, cs, bv, dual, ray = solve_lp_warm_py(
+    status, x_full, obj, _iters, cs, bv, dual, ray = solve_lp_warm_csc_py(
         np.ascontiguousarray(c_std),
-        np.ascontiguousarray(a_std),
+        m,
+        n + m,
+        np.ascontiguousarray(a_std.indptr, dtype=np.int64),
+        np.ascontiguousarray(a_std.indices, dtype=np.int64),
+        np.ascontiguousarray(a_std.data, dtype=np.float64),
         np.ascontiguousarray(b_vec),
         np.ascontiguousarray(lb_std),
         np.ascontiguousarray(ub_std),

--- a/python/tests/test_amp_simplex_backend.py
+++ b/python/tests/test_amp_simplex_backend.py
@@ -80,9 +80,22 @@ class TestAmpSimplexCertificationParity:
 
     @pytest.mark.parametrize("build", [_concave_qp, _bilinear])
     def test_same_certificate_as_default(self, build):
-        ref = build().solve(solver="amp", rel_gap=1e-4, time_limit=60)
-        sx = build().solve(solver="amp", rel_gap=1e-4, time_limit=60, milp_solver="simplex")
+        # A short budget is sufficient and keeps the test fast: ``_concave_qp``
+        # certifies optimal in well under a second, and ``_bilinear`` finds its
+        # global incumbent (-6.25) within the first second but its spatial-B&B
+        # bound never closes to ``rel_gap`` (a relaxation-tightness property, not
+        # a backend property — HiGHS, POUNCE and the simplex all return
+        # ``feasible`` here and would otherwise burn the whole budget). The seam
+        # under test is backend *parity*, which holds at any budget; a 60s limit
+        # only wasted wall-clock on the uncertifiable case (and timed out under
+        # parallel load).
+        ref = build().solve(solver="amp", rel_gap=1e-4, time_limit=5)
+        sx = build().solve(solver="amp", rel_gap=1e-4, time_limit=5, milp_solver="simplex")
         assert sx.status == ref.status, f"{sx.status} vs {ref.status}"
         if ref.status == "optimal":
             assert getattr(sx, "gap_certified", True) is True
+        # Objective parity must hold whether the run certified (``optimal``) or
+        # only reached the shared global incumbent (``feasible``): the simplex
+        # relaxation backend must not weaken AMP's result either way.
+        if ref.objective is not None and sx.objective is not None:
             assert abs(sx.objective - ref.objective) <= 1e-3 * (1.0 + abs(ref.objective))

--- a/python/tests/test_bucket2_composition_soundness.py
+++ b/python/tests/test_bucket2_composition_soundness.py
@@ -132,15 +132,20 @@ def test_affected_instance_sound_on_both_backends_and_bound_sets(instance, optim
 
 @pytest.mark.parametrize("instance, optimum", _AFFECTED)
 def test_affected_instance_backends_agree_on_finite_bound(instance, optimum):
-    """The fast simplex and HiGHS must not disagree on a *finite* root bound by
-    more than a tolerance — on either bound set. A disagreement is the fingerprint
-    of an ill-conditioned lifted LP that the fast backend mis-solved (the #158
-    wrong-"optimal" hazard the conditioning guards exist to prevent).
+    """The fast simplex must never report a *finite* root bound **above** the
+    reference ``auto``/HiGHS bound — on either bound set. A fast bound that
+    exceeds the reference is the fingerprint of an ill-conditioned lifted LP the
+    fast backend mis-solved (the #158 wrong-"optimal" hazard the conditioning
+    guards prevent).
 
-    Where a backend returns no finite bound (an abstaining lift, or an
-    ``iteration_limit`` with no objective), there is nothing to compare — the
-    soundness direction is locked by the companion test above. We only assert
-    agreement when *both* backends produce a finite bound."""
+    The fast path reports the Neumaier–Shcherbina *safe* bound (issue #356), a
+    rigorous under-estimate of the LP optimum that the reference path reports
+    directly, so the two need not be equal: the fast bound may legitimately be
+    *lower* (a conservative safe bound), and on free/unbounded lifted columns the
+    safe bound's FBBT-bounded box makes it looser still. Only the unsound
+    direction — fast above reference — is forbidden. Where a backend returns no
+    finite bound there is nothing to compare; the ``<= optimum`` direction is
+    locked by the companion test above."""
     nl = _DATA / f"{instance}.nl"
     assert nl.exists(), f"missing {nl}"
     m = dm.from_nl(str(nl))
@@ -157,12 +162,13 @@ def test_affected_instance_backends_agree_on_finite_bound(instance, optimum):
         r_ok = ref.lower_bound is not None and math.isfinite(ref.lower_bound)
         if not (f_ok and r_ok):
             continue
-        # Both finite: they must agree (relative tolerance for large optima like
-        # ex1252's ~1.3e5) and both stay sound.
+        # The fast simplex's safe bound must not exceed the reference LP optimum
+        # (relative tolerance for large optima like ex1252's ~1.3e5). Being
+        # conservatively lower is the safe bound working as designed.
         scale = max(1.0, abs(fast.lower_bound), abs(ref.lower_bound))
-        assert abs(fast.lower_bound - ref.lower_bound) <= 1e-4 * scale, (
-            f"[{instance}/{tag}] backend disagreement on finite bound: "
-            f"simplex={fast.lower_bound} auto={ref.lower_bound} — fast bound unreliable"
+        assert fast.lower_bound <= ref.lower_bound + 1e-4 * scale, (
+            f"[{instance}/{tag}] fast simplex bound {fast.lower_bound} exceeds "
+            f"reference auto bound {ref.lower_bound} — fast bound unreliable (too high)"
         )
         assert fast.lower_bound <= optimum + 1e-3 and ref.lower_bound <= optimum + 1e-3, (
             f"[{instance}/{tag}] UNSOUND: simplex={fast.lower_bound} "

--- a/python/tests/test_lp_backend_select.py
+++ b/python/tests/test_lp_backend_select.py
@@ -15,9 +15,10 @@ import pytest
 from discopt.solvers import lp_backend
 
 
-def test_default_prefers_highs_when_present():
-    pytest.importorskip("highspy")
-    assert lp_backend.get_lp_solver().__module__ == "discopt.solvers.lp_highs"
+def test_default_lp_prefers_simplex():
+    # Issue #356: the matrix-LP default routes to the self-hosted Rust simplex
+    # (which now exposes duals/reduced costs), even when HiGHS is installed.
+    assert lp_backend.get_lp_solver().__module__ == "discopt.solvers.lp_simplex"
 
 
 def test_prefer_pounce_selects_pounce():
@@ -74,10 +75,12 @@ def test_prefer_pounce_milp_uses_self_hosted_bb():
 
 
 class TestPounceOnlyInstall:
-    def test_lp_selector_falls_back_to_pounce(self, monkeypatch):
+    def test_lp_selector_is_highs_free_by_default(self, monkeypatch):
+        # With HiGHS absent the default LP engine is the self-hosted Rust simplex
+        # (issue #356) — HiGHS-free without needing POUNCE either.
         pytest.importorskip("pounce")
         _without_highs(monkeypatch)
-        assert lp_backend.get_lp_solver().__module__ == "discopt.solvers.lp_pounce"
+        assert lp_backend.get_lp_solver().__module__ == "discopt.solvers.lp_simplex"
 
     def test_milp_selector_is_highs_free_by_default(self, monkeypatch):
         # With HiGHS absent the default MILP engine is the self-hosted Rust simplex
@@ -132,9 +135,12 @@ class TestPounceOnlyInstall:
 
     def test_neither_backend_raises(self, monkeypatch):
         real_import = builtins.__import__
+        # Block the Rust simplex too (now the default LP engine) so the selector
+        # genuinely has nothing importable.
+        blocked = ("lp_highs", "lp_pounce", "lp_simplex", "highspy", "pounce")
 
         def no_backend(name, *a, **k):
-            if any(s in name for s in ("lp_highs", "lp_pounce", "highspy", "pounce")):
+            if any(s in name for s in blocked) or name.endswith("._rust"):
                 raise ImportError("no backend")
             return real_import(name, *a, **k)
 

--- a/python/tests/test_lp_backend_select.py
+++ b/python/tests/test_lp_backend_select.py
@@ -60,9 +60,10 @@ def _without_highs(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
 
-def test_default_milp_prefers_highs_when_present():
-    pytest.importorskip("highspy")
-    assert lp_backend.get_milp_solver().__module__ == "discopt.solvers.milp_highs"
+def test_default_milp_prefers_simplex():
+    # Issue #356 part B: the matrix-MILP default routes to the self-hosted Rust
+    # simplex B&B first (HiGHS-free), even when HiGHS is installed.
+    assert lp_backend.get_milp_solver().__module__ == "discopt.solvers.milp_simplex"
 
 
 def test_prefer_pounce_milp_uses_self_hosted_bb():
@@ -78,9 +79,26 @@ class TestPounceOnlyInstall:
         _without_highs(monkeypatch)
         assert lp_backend.get_lp_solver().__module__ == "discopt.solvers.lp_pounce"
 
-    def test_milp_selector_falls_back_to_pounce(self, monkeypatch):
+    def test_milp_selector_is_highs_free_by_default(self, monkeypatch):
+        # With HiGHS absent the default MILP engine is the self-hosted Rust simplex
+        # (issue #356 part B) — discopt is HiGHS-free without needing POUNCE either.
         pytest.importorskip("pounce")
         _without_highs(monkeypatch)
+        assert lp_backend.get_milp_solver().__module__ == "discopt.solvers.milp_simplex"
+
+    def test_milp_selector_falls_back_to_pounce_without_simplex(self, monkeypatch):
+        # When BOTH HiGHS and the Rust simplex binding are unavailable, the matrix
+        # MILP falls back to the POUNCE self-hosted B&B.
+        pytest.importorskip("pounce")
+        real_import = builtins.__import__
+        blocked = ("lp_highs", "qp_highs", "milp_highs", "milp_simplex")
+
+        def fake_import(name, *a, **k):
+            if name == "highspy" or any(s in name for s in blocked) or name.endswith("._rust"):
+                raise ImportError("HiGHS / Rust simplex unavailable (simulated)")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
         assert lp_backend.get_milp_solver().__module__ == "discopt.solvers.milp_pounce"
 
     def test_oa_master_is_highs_free(self, monkeypatch):

--- a/python/tests/test_lp_certificates.py
+++ b/python/tests/test_lp_certificates.py
@@ -63,11 +63,27 @@ class TestSafeBoundHelper:
             if g is not None:
                 assert g <= -8.0 + 1e-6, f"y={y} gave too-high bound {g}"
 
-    def test_infinite_box_with_nonzero_reduced_cost_is_unusable(self):
-        # An unbounded box side with a nonzero reduced cost → −inf contribution →
-        # None (no usable finite bound), not a spurious large-finite value.
+    def test_infinite_box_side_is_bounded_by_fbbt_and_stays_sound(self):
+        # An unbounded box side whose reduced cost selects it used to collapse the
+        # safe bound to −inf (returned None). Feasibility-based bound tightening now
+        # recovers a finite, *valid* box for that column from the constraint rows,
+        # so the safe bound becomes usable while remaining a rigorous under-estimate
+        # (the lifted relaxations' objective-epigraph / slack columns rely on this).
+        # min -x0 - 2 x1 s.t. x0 + x1 <= 4, x0,x1 >= 0 (no explicit upper bound).
+        # Optimum -8 at (0,4); FBBT derives x0,x1 <= 4 from the row, so y=0 gives a
+        # finite g that never exceeds the true optimum.
         a_std, b, c_std, lb, ub = _std([[1.0, 1.0]], [4.0], [-1.0, -2.0], [(0, 1e20), (0, 1e20)])
-        # y=0 → reduced cost = c = (-1,-2); the −2·(+inf) term is −inf.
+        g = _safe_lp_lower_bound_std(np.array([0.0]), c_std, a_std, b, lb, ub)
+        assert g is not None  # FBBT bounded the open side → usable
+        assert g <= -8.0 + 1e-6, f"unsound bound {g} above the true optimum -8"
+
+    def test_unboundable_open_side_still_returns_none(self):
+        # When the rows cannot bound the reduced-cost-selected open side (the column
+        # is genuinely free in that direction), the helper still abstains rather
+        # than fabricate a value. Here x0 is unbounded above and unconstrained by
+        # the single <= row in the −cost direction, so no finite bound exists.
+        # min -x0 s.t. -x0 <= 0 (i.e. x0 >= 0), x0 in [0, inf): unbounded below obj.
+        a_std, b, c_std, lb, ub = _std([[-1.0]], [0.0], [-1.0], [(0, 1e20)])
         assert _safe_lp_lower_bound_std(np.array([0.0]), c_std, a_std, b, lb, ub) is None
 
 

--- a/python/tests/test_lp_certificates.py
+++ b/python/tests/test_lp_certificates.py
@@ -1,0 +1,195 @@
+"""Pure-Rust LP certificates: safe dual bound + verified Farkas ray (issue #356).
+
+These exercise the certificate side-channel that lets the spatial-B&B node
+numerics certify a relaxation bound / infeasibility *without* an independent
+HiGHS or POUNCE cross-check:
+
+* the simplex's row duals feed a Neumaier–Shcherbina safe lower bound that is
+  ``<=`` the true LP optimum at *any* conditioning (never a too-high, falsely
+  fathoming bound), and
+* the simplex's Farkas dual ray is independently verified to prove the feasible
+  set empty — a rigorous fathoming proof.
+
+The defining soundness property under test: the safe bound is never above the
+true optimum, and a verified Farkas ray only ever certifies a genuinely empty
+polytope. An imperfect certificate must degrade to a (sound) fallback, never to
+an unsound fathom.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from discopt.solvers import SolveStatus
+from discopt.solvers.milp_simplex import (
+    _farkas_certified_std,
+    _safe_lp_lower_bound_std,
+    solve_lp_warm_std,
+)
+
+
+def _std(A_ub, b_ub, c, bounds):
+    """Build the `[A_ub | I] z = b` standard form used by the safe-bound helpers."""
+    A = np.asarray(A_ub, dtype=np.float64)
+    m, n = A.shape
+    a_std = np.zeros((m, n + m), dtype=np.float64)
+    a_std[:, :n] = A
+    a_std[:, n:] = np.eye(m)
+    c_std = np.concatenate([np.asarray(c, float), np.zeros(m)])
+    lb = np.array([lo for lo, _ in bounds], float)
+    ub = np.array([hi for _, hi in bounds], float)
+    lb_std = np.concatenate([lb, np.zeros(m)])
+    ub_std = np.concatenate([ub, np.full(m, 1e20)])
+    return a_std, np.asarray(b_ub, float), c_std, lb_std, ub_std
+
+
+class TestSafeBoundHelper:
+    def test_safe_bound_at_correct_duals_reproduces_optimum(self):
+        # min -x0 - 2 x1 s.t. x0 + x1 <= 4, x in [0,5].  Optimum -8 at (0,4).
+        a_std, b, c_std, lb, ub = _std([[1.0, 1.0]], [4.0], [-1.0, -2.0], [(0, 5), (0, 5)])
+        # Correct row dual is y = -2 (the binding [A|I] convention).
+        g = _safe_lp_lower_bound_std(np.array([-2.0]), c_std, a_std, b, lb, ub)
+        assert g is not None
+        assert g <= -8.0 + 1e-6  # never above the true optimum
+        assert abs(g - (-8.0)) < 1e-6  # and tight at the correct duals
+
+    def test_safe_bound_is_lower_bound_for_arbitrary_duals(self):
+        # Weak duality holds for ANY y: a wrong/loose dual must still give a value
+        # at or below the true optimum (never a too-high, unsound bound).
+        a_std, b, c_std, lb, ub = _std([[1.0, 1.0]], [4.0], [-1.0, -2.0], [(0, 5), (0, 5)])
+        for y in (-5.0, -1.0, 0.0, 0.5):
+            g = _safe_lp_lower_bound_std(np.array([y]), c_std, a_std, b, lb, ub)
+            if g is not None:
+                assert g <= -8.0 + 1e-6, f"y={y} gave too-high bound {g}"
+
+    def test_infinite_box_with_nonzero_reduced_cost_is_unusable(self):
+        # An unbounded box side with a nonzero reduced cost → −inf contribution →
+        # None (no usable finite bound), not a spurious large-finite value.
+        a_std, b, c_std, lb, ub = _std([[1.0, 1.0]], [4.0], [-1.0, -2.0], [(0, 1e20), (0, 1e20)])
+        # y=0 → reduced cost = c = (-1,-2); the −2·(+inf) term is −inf.
+        assert _safe_lp_lower_bound_std(np.array([0.0]), c_std, a_std, b, lb, ub) is None
+
+
+class TestFarkasHelper:
+    def test_farkas_certifies_empty_polytope(self):
+        # x0 + s = 1 (s>=0) with x0 in [2, inf): x0 >= 2 but x0 <= 1 → infeasible.
+        a_std, b, _c, lb, ub = _std([[1.0]], [1.0], [1.0], [(2.0, 1e20)])
+        # A valid Farkas multiplier exists (the simplex returns ±1 here).
+        assert _farkas_certified_std(np.array([1.0]), a_std, b, lb, ub) is True
+        # The helper tries ±ray, so the opposite sign is certified too.
+        assert _farkas_certified_std(np.array([-1.0]), a_std, b, lb, ub) is True
+
+    def test_farkas_rejects_feasible_polytope(self):
+        # A feasible system must NOT be certified infeasible for any candidate ray.
+        a_std, b, _c, lb, ub = _std([[1.0, 1.0]], [4.0], [0.0, 0.0], [(0, 5), (0, 5)])
+        for ray in (np.array([1.0]), np.array([-1.0]), np.array([3.7]), np.array([0.0])):
+            assert _farkas_certified_std(ray, a_std, b, lb, ub) is False
+
+    def test_empty_or_nonfinite_ray_is_not_certified(self):
+        a_std, b, _c, lb, ub = _std([[1.0]], [1.0], [1.0], [(2.0, 1e20)])
+        assert _farkas_certified_std(np.array([]), a_std, b, lb, ub) is False
+        assert _farkas_certified_std(np.array([np.inf]), a_std, b, lb, ub) is False
+
+
+class TestSolveLpWarmStdCert:
+    def test_optimal_returns_safe_bound_at_or_below_objective(self):
+        res, _basis, cert = solve_lp_warm_std(
+            np.array([-1.0, -2.0]),
+            sp.csr_matrix(np.array([[1.0, 1.0]])),
+            np.array([4.0]),
+            [(0.0, 5.0), (0.0, 5.0)],
+            return_cert=True,
+        )
+        assert res is not None and res.status == SolveStatus.OPTIMAL
+        assert cert.safe_bound is not None
+        # The reported bound is the certified (never-too-high) one.
+        assert res.bound <= res.objective + 1e-9
+        assert abs(res.bound - (-8.0)) < 1e-6
+
+    def test_infeasible_is_farkas_certified(self):
+        res, _basis, cert = solve_lp_warm_std(
+            np.array([1.0]),
+            sp.csr_matrix(np.array([[1.0]])),
+            np.array([1.0]),
+            [(2.0, 1e20)],
+            return_cert=True,
+        )
+        assert res is not None and res.status == SolveStatus.INFEASIBLE
+        assert cert.farkas_certified is True
+
+    def test_ill_conditioned_optimum_safe_bound_not_above_truth(self):
+        # A wide-coefficient LP (range > the simplex's scaling trigger): the safe
+        # bound must stay <= the true optimum even though the raw vertex objective
+        # could drift on the ill-conditioned basis.
+        A = np.array([[1e9, 1.0], [1.0, 1.0]])
+        c = np.array([-1.0, -1.0])
+        b = np.array([1e9, 5.0])
+        res, _basis, cert = solve_lp_warm_std(
+            c, sp.csr_matrix(A), b, [(0.0, 1.0), (0.0, 10.0)], return_cert=True
+        )
+        assert res is not None and res.status == SolveStatus.OPTIMAL
+        assert cert.safe_bound is not None
+        # Recompute the true optimum with a dense reference solve.
+        from scipy.optimize import linprog
+
+        ref = linprog(c, A_ub=A, b_ub=b, bounds=[(0, 1), (0, 10)], method="highs")
+        assert ref.success
+        assert cert.safe_bound <= ref.fun + 1e-6
+        assert res.bound <= ref.fun + 1e-6
+
+    def test_backward_compatible_two_tuple_without_cert(self):
+        out = solve_lp_warm_std(
+            np.array([-1.0, -2.0]),
+            sp.csr_matrix(np.array([[1.0, 1.0]])),
+            np.array([4.0]),
+            [(0.0, 5.0), (0.0, 5.0)],
+        )
+        assert len(out) == 2  # (result, out_basis) — unchanged default contract
+
+
+class TestIncrementalFarkasPath:
+    @staticmethod
+    def _inc():
+        import discopt.modeling as dm
+        from discopt._jax.mccormick_lp import MccormickLPRelaxer
+
+        # Small all-integer QCQP (bilinear + square) — in the incremental scope.
+        m = dm.Model("iqcqp")
+        x = m.integer("x", lb=0, ub=5)
+        y = m.integer("y", lb=0, ub=5)
+        m.minimize((x - 3) ** 2 + (y - 2) ** 2 + x * y)
+        m.subject_to(x + y >= 3)
+        relaxer = MccormickLPRelaxer(m)
+        return relaxer._inc
+
+    def test_solve_assembled_full_returns_five_tuple(self):
+        inc = self._inc()
+        if inc is None:
+            pytest.skip("incremental structure unavailable")
+        lb = np.array([0.0, 0.0])
+        ub = np.array([5.0, 5.0])
+        A, b, bounds = inc.assemble(lb, ub)
+        out = inc.solve_assembled_full(A, b, bounds)
+        assert len(out) == 5  # (status, bound, x, basis, farkas_certified)
+        status, bound, _x, _basis, farkas = out
+        # On a feasible box: an optimal valid lower bound and farkas flag False.
+        assert status == "optimal"
+        assert bound is not None and np.isfinite(bound)
+        assert farkas is False
+
+    def test_infeasible_box_is_farkas_certified(self):
+        inc = self._inc()
+        if inc is None:
+            pytest.skip("incremental structure unavailable")
+        # Assemble over a box, then append a contradictory cut row that empties the
+        # polytope: a row ``-x0 <= -100`` forces x0 >= 100 while its box caps it at
+        # 5 — an infeasible lifted LP whose emptiness the Farkas ray must certify.
+        lb = np.array([0.0, 0.0])
+        ub = np.array([5.0, 5.0])
+        cut = np.zeros(inc.ncol, dtype=np.float64)
+        cut[0] = -1.0  # -x0 <= -100  ->  x0 >= 100, but x0 <= 5
+        A, b, bounds = inc.assemble(lb, ub, cut_rows=[(cut, -100.0)])
+        status, _bound, _x, _basis, farkas = inc.solve_assembled_full(A, b, bounds)
+        assert status == "infeasible"
+        assert farkas is True  # rigorously proven empty, no second solve needed

--- a/python/tests/test_lp_certificates.py
+++ b/python/tests/test_lp_certificates.py
@@ -193,3 +193,70 @@ class TestIncrementalFarkasPath:
         status, _bound, _x, _basis, farkas = inc.solve_assembled_full(A, b, bounds)
         assert status == "infeasible"
         assert farkas is True  # rigorously proven empty, no second solve needed
+
+
+class TestColdPathCertificates:
+    """The cold ``solve_at_node`` path (issue #356, cold-path guards) must also be
+    HiGHS-free: a rigorous bound from the simplex's safe bound / vertex, an
+    infeasible fathom only on a verified Farkas ray, and no fabricated bound on an
+    unbounded relaxation."""
+
+    @staticmethod
+    def _model():
+        import discopt.modeling as dm
+
+        m = dm.Model("iqcqp")
+        x = m.integer("x", lb=0, ub=5)
+        y = m.integer("y", lb=0, ub=5)
+        m.minimize((x - 3) ** 2 + (y - 2) ** 2 + x * y)
+        m.subject_to(x + y >= 3)
+        return m
+
+    def test_milp_solve_surfaces_safe_bound_on_finite_box(self):
+        # A finite-box lifted LP: the simplex pure-LP path must surface a rigorous
+        # safe bound (<= the reported optimum) through MilpRelaxationModel.solve.
+        from discopt._jax.discretization import DiscretizationState
+        from discopt._jax.milp_relaxation import build_milp_relaxation
+        from discopt._jax.term_classifier import classify_nonlinear_terms
+
+        m = self._model()
+        terms = classify_nonlinear_terms(m)
+        milp, _ = build_milp_relaxation(
+            m, terms, DiscretizationState(), bound_override=(np.zeros(2), np.full(2, 5.0))
+        )
+        milp._integrality = None  # pure-LP node bound (the default mode)
+        res = milp.solve(backend="simplex")
+        assert res.status == "optimal"
+        if res.safe_bound is not None:  # finite-box ⇒ safe bound available
+            assert res.safe_bound <= res.objective + 1e-6
+            assert res.farkas_certified is False
+
+    def test_cold_node_bound_is_sound_lower_bound(self):
+        # Cold path (incremental forced off): the reported lower bound must be a
+        # valid lower bound (<= the true integer optimum 4.0) — never too high.
+        from discopt._jax.mccormick_lp import MccormickLPRelaxer
+
+        relaxer = MccormickLPRelaxer(self._model())
+        relaxer._inc = None  # force the cold build + cold solve_at_node path
+        r = relaxer.solve_at_node(np.zeros(2), np.full(2, 5.0))
+        assert r.status == "optimal"
+        assert r.lower_bound is not None and np.isfinite(r.lower_bound)
+        assert r.lower_bound <= 4.0 + 1e-6  # sound: never above the true optimum
+
+    def test_cold_unbounded_relaxation_no_fabricated_bound(self):
+        # A free bilinear variable makes the McCormick relaxation unbounded; the
+        # cold path must NOT fabricate a finite lower bound (it declines/branches).
+        import discopt.modeling as dm
+        from discopt._jax.mccormick_lp import MccormickLPRelaxer
+
+        m = dm.Model("bil")
+        x = m.continuous("x", lb=-2.0, ub=2.0)
+        y = m.continuous("y", lb=-2.0, ub=2.0)
+        m.subject_to(x + y >= 0.5)
+        m.minimize(x * y - x - y)
+        relaxer = MccormickLPRelaxer(m)
+        relaxer._inc = None
+        unb = relaxer.solve_at_node(
+            np.array([-np.inf, -np.inf]), np.array([np.inf, np.inf]), time_limit=5.0
+        )
+        assert unb.lower_bound is None

--- a/python/tests/test_simplex_lp.py
+++ b/python/tests/test_simplex_lp.py
@@ -172,3 +172,69 @@ class TestWarmStartLp:
         st, _x, obj, _i, _cs, _bv, _d, _r = rust.solve_lp_warm_py(c, a, b, lb, ub, bad_cs, bad_bv)
         assert st == "optimal"
         assert abs(obj - (-1.0)) < 1e-9
+
+
+class TestSimplexLpDuals:
+    """``lp_simplex.solve_lp`` exposes vertex duals/reduced costs (issue #356), in
+    HiGHS's convention, so the dual-consuming seams (Benders, DBBT) run on it."""
+
+    @staticmethod
+    def _lp(seed):
+        rng = np.random.default_rng(seed)
+        n = int(rng.integers(2, 6))
+        mub = int(rng.integers(1, 4))
+        meq = int(rng.integers(0, 2))
+        A_ub = rng.integers(-3, 4, size=(mub, n)).astype(float)
+        b_ub = rng.integers(1, 9, size=mub).astype(float)
+        A_eq = rng.integers(-2, 3, size=(meq, n)).astype(float) if meq else None
+        b_eq = (A_eq @ rng.uniform(0, 3, size=n)) if meq else None
+        c = rng.integers(-3, 4, size=n).astype(float)
+        bounds = [(0.0, 5.0)] * n
+        return c, A_ub, b_ub, A_eq, b_eq, bounds
+
+    def test_objective_matches_highs(self):
+        from discopt.solvers.lp_simplex import solve_lp as rust_lp
+
+        for seed in range(40):
+            c, A_ub, b_ub, A_eq, b_eq, bounds = self._lp(seed)
+            h = highs_lp(c, A_ub, b_ub, A_eq, b_eq, bounds)
+            r = rust_lp(c, A_ub, b_ub, A_eq, b_eq, bounds)
+            assert r.status == h.status
+            if r.status == SolveStatus.OPTIMAL:
+                assert abs(r.objective - h.objective) < 1e-6
+
+    def test_duals_are_populated_and_satisfy_strong_duality(self):
+        # The duals need not equal HiGHS's on a degenerate LP, but they must be a
+        # *valid* optimal dual: strong duality g(y) == obj. (Skip LPs whose dual
+        # points along a free direction, where the box term is unbounded.)
+        from discopt.solvers.lp_simplex import solve_lp as rust_lp
+
+        checked = 0
+        for seed in range(60):
+            c, A_ub, b_ub, A_eq, b_eq, bounds = self._lp(seed)
+            r = rust_lp(c, A_ub, b_ub, A_eq, b_eq, bounds)
+            if r.status != SolveStatus.OPTIMAL:
+                continue
+            assert r.dual_values is not None and r.reduced_costs is not None
+            c_arr = np.asarray(c, float)
+            n = len(c_arr)
+            y = np.asarray(r.dual_values, float)
+            rc = np.asarray(r.reduced_costs, float)
+            lo = np.array([b[0] for b in bounds])
+            hi = np.array([b[1] for b in bounds])
+            mub = A_ub.shape[0]
+            rhs = np.concatenate(
+                [np.asarray(b_ub, float), np.asarray(b_eq, float) if b_eq is not None else []]
+            )
+            # g(y) = b·y + Σ_j min_{x∈[lo,hi]} rc_j x_j  == obj at a valid optimum.
+            contrib = np.where(rc > 0, rc * lo, np.where(rc < 0, rc * hi, 0.0))
+            g = float(rhs @ y) + float(contrib.sum())
+            assert abs(g - r.objective) <= 1e-6 * (1.0 + abs(r.objective))
+            # reduced costs are exactly c − Aᵀy.
+            recomputed = c_arr - A_ub.T @ y[:mub]
+            if A_eq is not None:
+                recomputed = recomputed - A_eq.T @ y[mub:]
+            assert np.allclose(rc, recomputed, atol=1e-9)
+            assert len(rc) == n
+            checked += 1
+        assert checked >= 20

--- a/python/tests/test_simplex_lp.py
+++ b/python/tests/test_simplex_lp.py
@@ -132,7 +132,7 @@ class TestWarmStartLp:
             np.ascontiguousarray(lb),
             np.ascontiguousarray(ub),
         )
-        s1, x1, o1, _i, cs, bv = rust.solve_lp_warm_py(
+        s1, x1, o1, _i, cs, bv, _d, _r = rust.solve_lp_warm_py(
             np.ascontiguousarray(c),
             np.ascontiguousarray(A),
             np.ascontiguousarray(b),
@@ -147,17 +147,17 @@ class TestWarmStartLp:
     def test_rowappend_warmstart_matches_cold(self):
         # min -x0 - x1 s.t. x0 + x1 <= 1, x in [0,1]; then append cut x0 <= 0.5.
         c, a, b, lb, ub = self._std([[1.0, 1.0]], [1.0], [-1.0, -1.0], [0, 0], [1, 1])
-        st, _x, obj, _i, cs, bv = rust.solve_lp_warm_py(c, a, b, lb, ub)
+        st, _x, obj, _i, cs, bv, _d, _r = rust.solve_lp_warm_py(c, a, b, lb, ub)
         assert st == "optimal" and abs(obj - (-1.0)) < 1e-9
 
         c2, a2, b2, lb2, ub2 = self._std(
             [[1.0, 1.0], [1.0, 0.0]], [1.0, 0.5], [-1.0, -1.0], [0, 0], [1, 1]
         )
         # warm-start from the 1-row basis (Rust extends it with the new slack basic)
-        sw, xw, ow, _iw, _csw, _bvw = rust.solve_lp_warm_py(
+        sw, xw, ow, _iw, _csw, _bvw, _dw, _rw = rust.solve_lp_warm_py(
             c2, a2, b2, lb2, ub2, cs.astype(np.int8), bv.astype(np.int64)
         )
-        sc, _xc, oc, _ic, _csc, _bvc = rust.solve_lp_warm_py(c2, a2, b2, lb2, ub2)
+        sc, _xc, oc, _ic, _csc, _bvc, _dc, _rc = rust.solve_lp_warm_py(c2, a2, b2, lb2, ub2)
         assert sw == "optimal" == sc
         assert abs(ow - oc) < 1e-9
         assert abs(ow - (-1.0)) < 1e-9  # x0 = x1 = 0.5
@@ -169,6 +169,6 @@ class TestWarmStartLp:
         c, a, b, lb, ub = self._std([[1.0, 1.0]], [1.0], [-1.0, -1.0], [0, 0], [1, 1])
         bad_cs = np.array([9, 9, 9, 9, 9], dtype=np.int8)  # wrong length & values
         bad_bv = np.array([7, 7, 7], dtype=np.int64)  # out-of-range indices
-        st, _x, obj, _i, _cs, _bv = rust.solve_lp_warm_py(c, a, b, lb, ub, bad_cs, bad_bv)
+        st, _x, obj, _i, _cs, _bv, _d, _r = rust.solve_lp_warm_py(c, a, b, lb, ub, bad_cs, bad_bv)
         assert st == "optimal"
         assert abs(obj - (-1.0)) < 1e-9


### PR DESCRIPTION
## Summary

Implements rigorous certificate side-channels from the Rust simplex solver to enable sound spatial-B&B node fathoming without external HiGHS/POUNCE cross-checks. Two complementary certificates are added:

1. **Neumaier–Shcherbina safe lower bound** from row duals: a rigorous under-estimate of the LP optimum that holds at any conditioning, never falsely fathoming feasible nodes.
2. **Verified Farkas dual ray**: an independently certified proof of infeasibility that rigorously fathoms empty polytopes without a second solve.

This closes the #355-review gap where the incremental McCormick path dropped the cold path's independent verification guard, and eliminates the dominant per-node cost of re-verifying infeasible verdicts with HiGHS.

## Key Changes

### Rust Simplex (Primal & Dual)
- **`crates/discopt-core/src/lp/simplex/primal.rs`**: Capture row duals `y = B⁻ᵀ c_B` on optimal solves and Farkas ray on infeasible solves; unscale certificate vectors back to original space after equilibration.
- **`crates/discopt-core/src/lp/simplex/dual.rs`**: Extract row duals on optimal and Farkas ray on infeasible; unscale certificates post-solve.
- **`crates/discopt-core/src/lp/simplex/scaling.rs`**: Add `unscale_dual()` and `unscale_ray()` to map scaled certificates back to original constraint/variable space (critical for ill-conditioned LPs where the certificate matters most).
- **`crates/discopt-core/src/lp/simplex/mod.rs`**: Extend `LpSolve` struct with `dual` and `ray` fields; document their interpretation by status.
- **`crates/discopt-python/src/lp_bindings.rs`**: Update Python bindings to surface the new certificate vectors.

### Python Certificate Verification
- **`python/discopt/solvers/milp_simplex.py`**:
  - Add `LpWarmCert` NamedTuple to hold `safe_bound` and `farkas_certified` flags.
  - Implement `_safe_lp_lower_bound_std()`: Neumaier–Shcherbina safe bound from free-sign multipliers, with magnitude-scaled margin to dominate float64 rounding error.
  - Implement `_farkas_certified_std()`: Verify a Farkas ray candidate by checking if the `c=0` safe bound exceeds zero (proving infeasibility).
  - Extend `solve_lp_warm_std()` with optional `return_cert` parameter to return `(result, basis, cert)` triple.

### Incremental McCormick Integration
- **`python/discopt/_jax/incremental_mccormick.py`**: Update `solve_assembled_full()` to return 5-tuple `(status, bound, x, basis, farkas_certified)` and document the safe-bound semantics.
- **`python/discopt/_jax/mccormick_lp.py`**: 
  - Trust an incremental `infeasible` verdict directly when `farkas_certified=True` (no re-verify needed).
  - Fall back to equilibration re-verify only when the Farkas ray did not verify (ill-conditioned candidate).
  - Update `_reverify_incremental_infeasible()` to extract and prefer a fresh Farkas certificate from the equilibrated re-solve.

### Relaxation & Backend Updates
- **`python/discopt/_jax/milp_relaxation.py`**: Add `safe_bound` and `farkas_certified` fields to `MilpRelaxationResult`; populate them from the warm-started simplex path.
- **`python/discopt/solvers/lp_backend.py`**: Update docstring to reflect that matrix-MILP now defaults to the self-hosted Rust

https://claude.ai/code/session_0154SAWZh7TggKvFaPkXd3t5