### PR TITLE
Harden the Rust simplex toward a single robust LP engine + retire the JAX LP-IPM fallback (#364)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,8 +78,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "feral"
 version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737271f4c9f92a85444ea8142c6d10fc35a7521fc80a0b228614861f5316a438"
+source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -96,8 +95,7 @@ dependencies = [
 [[package]]
 name = "feral-amd"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead2f064dbcef0e0d3110202e9d6d7c293c1dffe6da5964513a20c5967e4d560"
+source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -105,8 +103,7 @@ dependencies = [
 [[package]]
 name = "feral-amf"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ea6dacabfa085e7f40080c894da245d9db60e9211f1f8ab08d715d6d0f5a29"
+source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -114,8 +111,7 @@ dependencies = [
 [[package]]
 name = "feral-kahip"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ba0d001a63e777227de4565c7f4cd14062b9fbe83d3cadcb292be74410b4f4"
+source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -125,8 +121,7 @@ dependencies = [
 [[package]]
 name = "feral-metis"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b34963682eaf680479bfd6018a5570bfd1ed9c1f05d8bf085ab49f13b308cb"
+source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -135,14 +130,12 @@ dependencies = [
 [[package]]
 name = "feral-ordering-core"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca94ad929e23c0adaa6edda42474aa71b5b2bfb3930b1f6b202e4b37c8e9b763"
+source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
 
 [[package]]
 name = "feral-scotch"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51fe24bffbef76e88803e801c2d8977f5d304dd6af43f70c1e91fdfabd0b530"
+source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -18,7 +18,15 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # (sc2000/sc4000) — the LU refactor went quadratic→cubic in the row count,
 # invisible on few-row knapsacks but catastrophic on 800–1500-row covering LPs.
 # `test_setcover_lp_regression.py` guards against a re-downgrade.
-feral = "0.11.3"
+#
+# TEMPORARY git-rev pin (not a crates.io release). HEAD carries the discopt#364
+# LU-hardening APIs merged as feral #96/#98/#97 but NOT yet published: the
+# element-growth getters (growth()/u_max0()), the unsymmetric-LU condition
+# estimate (condition_estimate_1), and the richer update() instability signal
+# (RefactorCause + last_refactor() + growth-aware/dense-parity should_refactor).
+# feral HEAD still reports version 0.11.3, so crates.io can't carry these yet.
+# SWAP BACK to `feral = "0.11.4"` once that release is published.
+feral = { git = "https://github.com/jkitchin/feral", rev = "a17fb7a33427b2b08a8f1777c28b576b260532cd" }
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to
 # 1.10 to keep the crate's MSRV (1.75); 1.12+ requires rustc 1.80.

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -387,7 +387,7 @@ impl<'a> PreparedDual<'a> {
                                     .is_some_and(|g| g > GROWTH_REFINE_TRIGGER)
                                 {
                                     crate::profile::incr(
-                                        crate::profile::Ctr::RefinedRecoveryAttempts,
+                                        crate::profile::Ctr::RefinedRecoveryAttemptsDual,
                                     );
                                     match refined_basic_values(sp, b, n, m, l, u, &basis, &stat) {
                                         Some(xb_r) => {
@@ -395,7 +395,7 @@ impl<'a> PreparedDual<'a> {
                                                 .is_some()
                                             {
                                                 crate::profile::incr(
-                                                    crate::profile::Ctr::RefinedRecoveryRescues,
+                                                    crate::profile::Ctr::RefinedRecoveryRescuesDual,
                                                 );
                                                 return None; // sharper x_B infeasible → cold fallback
                                             }

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -334,10 +334,19 @@ impl<'a> PreparedDual<'a> {
         // pricing. Pricing only chooses *which* primal-infeasible row leaves, never
         // affects correctness (any infeasible basic var is a valid leaving choice).
         let mut gamma = vec![1.0f64; m];
+        // Anti-cycling: consecutive degenerate dual pivots (entering reduced cost
+        // ≈ 0 → no dual-objective progress) accumulate `stall`; once it crosses the
+        // threshold the pivot rules switch to Bland's smallest-index selection
+        // (both leaving row and entering column), which is guaranteed cycle-free.
+        // A productive pivot resets the count. Without this the only cycle escape
+        // was the iteration cap → cold fallback; Bland resolves it in place.
+        let mut stall = 0usize;
+        let bland_threshold = 2 * (n + 1);
         // The loop index is the pivot count: each completed iteration performs one
         // pivot, and every early return happens at the loop top (before this
         // iteration's pivot), so `pivots` is exactly the number performed so far.
         for pivots in 0..opts.max_iter {
+            let bland = stall > bland_threshold;
             // Poll the wall-clock deadline (see SimplexOptions::deadline). On a
             // timeout we abandon the warm dual re-solve and request the cold
             // fallback by returning None; the cold primal solve re-checks the
@@ -362,82 +371,85 @@ impl<'a> PreparedDual<'a> {
             // feasibility, confirm with an *exact* recompute before declaring
             // optimality, and verify dual feasibility on *exact* reduced costs —
             // so a drifted increment can never return a wrong optimum.
-            let (r, to_lower, delta) = match select_leaving(m, &basis, l, u, &gamma, &xb, tol) {
-                Some(sel) => sel,
-                None => {
-                    xb = recompute_basic_values(&mut lu, sp, b, n, l, u, &stat)?;
-                    since_refresh = 0;
-                    match select_leaving(m, &basis, l, u, &gamma, &xb, tol) {
-                        Some(sel) => sel,
-                        None => {
-                            dvec = recompute_reduced_costs(&mut lu, sp, c, n, &basis)?;
-                            if dual_feasible(n, &stat, l, u, &dvec, tol) {
-                                // In-engine refined recovery (discopt#364): if the
-                                // working factor's growth signal flags possible digit
-                                // loss, recompute x_B from a fresh, refinement-polished
-                                // factorization and re-verify primal feasibility on the
-                                // sharper values. If the sharper x_B reveals an
-                                // infeasibility the drifted one hid, hand to the robust
-                                // cold solve rather than certify a wrong optimum;
-                                // otherwise certify with the sharper x_B. Sound either
-                                // way — the decision is only ever made *more* accurate,
-                                // and the common (benign-growth) path is untouched.
-                                let refined_xb: Option<Vec<f64>> = if lu
-                                    .growth()
-                                    .is_some_and(|g| g > GROWTH_REFINE_TRIGGER)
-                                {
-                                    crate::profile::incr(
-                                        crate::profile::Ctr::RefinedRecoveryAttemptsDual,
-                                    );
-                                    match refined_basic_values(sp, b, n, m, l, u, &basis, &stat) {
-                                        Some(xb_r) => {
-                                            if select_leaving(m, &basis, l, u, &gamma, &xb_r, tol)
-                                                .is_some()
-                                            {
-                                                crate::profile::incr(
+            let (r, to_lower, delta) =
+                match select_leaving(m, &basis, l, u, &gamma, &xb, tol, bland) {
+                    Some(sel) => sel,
+                    None => {
+                        xb = recompute_basic_values(&mut lu, sp, b, n, l, u, &stat)?;
+                        since_refresh = 0;
+                        match select_leaving(m, &basis, l, u, &gamma, &xb, tol, bland) {
+                            Some(sel) => sel,
+                            None => {
+                                dvec = recompute_reduced_costs(&mut lu, sp, c, n, &basis)?;
+                                if dual_feasible(n, &stat, l, u, &dvec, tol) {
+                                    // In-engine refined recovery (discopt#364): if the
+                                    // working factor's growth signal flags possible digit
+                                    // loss, recompute x_B from a fresh, refinement-polished
+                                    // factorization and re-verify primal feasibility on the
+                                    // sharper values. If the sharper x_B reveals an
+                                    // infeasibility the drifted one hid, hand to the robust
+                                    // cold solve rather than certify a wrong optimum;
+                                    // otherwise certify with the sharper x_B. Sound either
+                                    // way — the decision is only ever made *more* accurate,
+                                    // and the common (benign-growth) path is untouched.
+                                    let refined_xb: Option<Vec<f64>> =
+                                        if lu.growth().is_some_and(|g| g > GROWTH_REFINE_TRIGGER) {
+                                            crate::profile::incr(
+                                                crate::profile::Ctr::RefinedRecoveryAttemptsDual,
+                                            );
+                                            match refined_basic_values(
+                                                sp, b, n, m, l, u, &basis, &stat,
+                                            ) {
+                                                Some(xb_r) => {
+                                                    if select_leaving(
+                                                        m, &basis, l, u, &gamma, &xb_r, tol, bland,
+                                                    )
+                                                    .is_some()
+                                                    {
+                                                        crate::profile::incr(
                                                     crate::profile::Ctr::RefinedRecoveryRescuesDual,
                                                 );
-                                                return None; // sharper x_B infeasible → cold fallback
+                                                        return None; // sharper x_B infeasible → cold fallback
+                                                    }
+                                                    Some(xb_r)
+                                                }
+                                                None => None, // fresh factor failed; keep the exact x_B
                                             }
-                                            Some(xb_r)
-                                        }
-                                        None => None, // fresh factor failed; keep the exact x_B
-                                    }
-                                } else {
-                                    None
-                                };
-                                let xb_final: &[f64] = refined_xb.as_deref().unwrap_or(&xb);
-                                // Row duals `y = B⁻ᵀ c_B` for the safe dual bound;
-                                // empty (caller falls back) if the btran fails.
-                                let mut y: Vec<f64> = basis.iter().map(|&j| c[j]).collect();
-                                let dual = if lu.btran(&mut y).is_ok() {
-                                    y
-                                } else {
-                                    Vec::new()
-                                };
-                                return Some(assemble(
-                                    n,
-                                    m,
-                                    &basis,
-                                    &slot_of,
-                                    &stat,
-                                    xb_final,
-                                    c,
-                                    l,
-                                    u,
-                                    LpStatus::Optimal,
-                                    pivots,
-                                    dual,
-                                    Vec::new(),
-                                ));
+                                        } else {
+                                            None
+                                        };
+                                    let xb_final: &[f64] = refined_xb.as_deref().unwrap_or(&xb);
+                                    // Row duals `y = B⁻ᵀ c_B` for the safe dual bound;
+                                    // empty (caller falls back) if the btran fails.
+                                    let mut y: Vec<f64> = basis.iter().map(|&j| c[j]).collect();
+                                    let dual = if lu.btran(&mut y).is_ok() {
+                                        y
+                                    } else {
+                                        Vec::new()
+                                    };
+                                    return Some(assemble(
+                                        n,
+                                        m,
+                                        &basis,
+                                        &slot_of,
+                                        &stat,
+                                        xb_final,
+                                        c,
+                                        l,
+                                        u,
+                                        LpStatus::Optimal,
+                                        pivots,
+                                        dual,
+                                        Vec::new(),
+                                    ));
+                                }
+                                // Exact reduced costs reveal dual infeasibility (a drifted
+                                // pivot): hand off to the robust cold solve.
+                                return None;
                             }
-                            // Exact reduced costs reveal dual infeasibility (a drifted
-                            // pivot): hand off to the robust cold solve.
-                            return None;
                         }
                     }
-                }
-            };
+                };
 
             // Pivot row ρ = e_rᵀ B⁻¹, then α_rj = ρ·A_j for every nonbasic j (kept
             // for both the ratio test and the incremental reduced-cost update). No
@@ -489,23 +501,39 @@ impl<'a> PreparedDual<'a> {
                 }
             }
             cand.sort_by(|x, y| x.1.partial_cmp(&y.1).unwrap_or(std::cmp::Ordering::Equal));
-            // Walk breakpoints, flipping finite-bounded ones until `delta` is closed.
-            // The last candidate is always taken as the entering column (never
-            // flipped), so even if the bound gaps can't fully close `delta` the step
-            // is a valid dual pivot and the search makes progress.
-            let mut slope = 0.0f64;
-            let mut q = cand[cand.len() - 1].0;
-            let mut flips: Vec<usize> = Vec::new();
-            let last = cand.len() - 1;
-            for (idx, &(j, _ratio, aj)) in cand.iter().enumerate() {
-                let gap = u[j] - l[j];
-                slope += aj * gap;
-                if idx == last || gap >= INF || slope >= delta - tol {
-                    q = j; // this breakpoint enters the basis; stop flipping
-                    break;
+            let (q, flips): (usize, Vec<usize>) = if bland {
+                // Bland (anti-cycling): the plain min-ratio dual pivot with the
+                // smallest-index tie-break and NO bound flips (a short step). The
+                // long-step bound-flipping below can revisit a basis under
+                // degeneracy; the smallest-index rule provably cannot cycle.
+                let min_ratio = cand[0].1;
+                let q = cand
+                    .iter()
+                    .filter(|&&(_, ratio, _)| ratio <= min_ratio + tol)
+                    .map(|&(j, _, _)| j)
+                    .min()
+                    .expect("cand is non-empty");
+                (q, Vec::new())
+            } else {
+                // Walk breakpoints, flipping finite-bounded ones until `delta` is
+                // closed. The last candidate is always taken as the entering column
+                // (never flipped), so even if the bound gaps can't fully close
+                // `delta` the step is a valid dual pivot and the search progresses.
+                let mut slope = 0.0f64;
+                let mut q = cand[cand.len() - 1].0;
+                let mut flips: Vec<usize> = Vec::new();
+                let last = cand.len() - 1;
+                for (idx, &(j, _ratio, aj)) in cand.iter().enumerate() {
+                    let gap = u[j] - l[j];
+                    slope += aj * gap;
+                    if idx == last || gap >= INF || slope >= delta - tol {
+                        q = j; // this breakpoint enters the basis; stop flipping
+                        break;
+                    }
+                    flips.push(j); // fully traversed → flip to the opposite bound
                 }
-                flips.push(j); // fully traversed → flip to the opposite bound
-            }
+                (q, flips)
+            };
             // Apply the bound flips (no basis change); their effect on x_B and the
             // reduced costs is realized by the next iteration's exact recompute.
             for &j in &flips {
@@ -551,6 +579,12 @@ impl<'a> PreparedDual<'a> {
 
             // Pivot: q enters at slot r; leaving var pinned at the violated bound.
             let leaving = basis[r];
+
+            // Degeneracy for anti-cycling: a dual pivot makes no dual-objective
+            // progress when the entering variable's reduced cost is ≈ 0 (a
+            // zero-length dual step). Consecutive such pivots are what cycle;
+            // captured here (before `dvec[q]` is zeroed) and fed to `stall` below.
+            let degenerate = dvec[q].abs() <= tol;
 
             // Incremental reduced-cost update (rank-1): d_j −= (d_q/piv)·α_rj for
             // every nonbasic j; the entering q becomes basic (0) and the leaving
@@ -619,6 +653,19 @@ impl<'a> PreparedDual<'a> {
                 since_refresh = 0;
             } else {
                 since_refresh += 1;
+            }
+
+            // Anti-cycling bookkeeping: a degenerate pivot advances the stall count
+            // (and, once over the threshold, keeps Bland engaged); any productive
+            // pivot resets it. Count Bland-mode pivots for observability.
+            if bland {
+                crate::profile::incr(crate::profile::Ctr::DualBlandActivations);
+            }
+            if degenerate {
+                stall += 1;
+                crate::profile::incr(crate::profile::Ctr::DualDegeneratePivots);
+            } else {
+                stall = 0;
             }
         }
         None // iteration cap → cold fallback
@@ -741,6 +788,7 @@ fn recompute_reduced_costs(
 /// `None` if every basic variable is within its bounds (primal feasible). Returns
 /// `(slot, to_lower, violation)` where `to_lower` is the bound the leaving
 /// variable is pinned at. Pricing only — choosing any infeasible row is valid.
+#[allow(clippy::too_many_arguments)]
 fn select_leaving(
     m: usize,
     basis: &[usize],
@@ -749,9 +797,12 @@ fn select_leaving(
     gamma: &[f64],
     xb: &[f64],
     tol: f64,
+    bland: bool,
 ) -> Option<(usize, bool, f64)> {
     let mut r = None;
     let mut best_score = 0.0f64;
+    // Bland's rule tracks the smallest *variable* index among infeasible rows.
+    let mut best_var = usize::MAX;
     let mut to_lower = true;
     let mut delta = 0.0f64;
     for i in 0..m {
@@ -764,9 +815,18 @@ fn select_leaving(
             None
         };
         if let Some((v, lo)) = viol {
-            let score = v * v / gamma[i];
-            if score > best_score {
-                best_score = score;
+            // Bland (anti-cycling): smallest variable index. Devex (default):
+            // largest bound-violation steepest-edge score. Either choice is a
+            // *valid* leaving row — any primal-infeasible basic var may leave — so
+            // this only affects the pivot path, never correctness.
+            let take = if bland {
+                bi < best_var
+            } else {
+                v * v / gamma[i] > best_score
+            };
+            if take {
+                best_score = v * v / gamma[i];
+                best_var = bi;
                 r = Some(i);
                 to_lower = lo;
                 delta = v;
@@ -891,6 +951,32 @@ mod tests {
 
     fn opts() -> SimplexOptions {
         SimplexOptions::default()
+    }
+
+    #[test]
+    fn bland_leaving_selects_smallest_variable_index() {
+        // Two primal-infeasible basic rows with equal Devex scores: slot 0 holds
+        // variable 5, slot 1 holds variable 2, both 1 below their lower bound.
+        let m = 2;
+        let basis = [5usize, 2usize];
+        let l = vec![0.0; 6];
+        let u = vec![10.0; 6];
+        let gamma = [1.0, 1.0];
+        let xb = [-1.0, -1.0];
+
+        // Devex: equal scores, so the first infeasible slot (0) wins.
+        let dev = select_leaving(m, &basis, &l, &u, &gamma, &xb, 1e-7, false).unwrap();
+        assert_eq!(dev.0, 0, "Devex should take the first equal-score slot");
+        assert!(dev.1, "both violate the lower bound → leave toward lower");
+
+        // Bland: the smallest *variable* index wins — variable 2 sits in slot 1.
+        let bl = select_leaving(m, &basis, &l, &u, &gamma, &xb, 1e-7, true).unwrap();
+        assert_eq!(bl.0, 1, "Bland must pick slot 1 (variable 2 < variable 5)");
+
+        // Both modes agree there is no leaving row once feasible.
+        let feasible = [1.0, 1.0];
+        assert!(select_leaving(m, &basis, &l, &u, &gamma, &feasible, 1e-7, false).is_none());
+        assert!(select_leaving(m, &basis, &l, &u, &gamma, &feasible, 1e-7, true).is_none());
     }
 
     // Solve cold, then perturb one bound and re-solve warm from the cold basis;

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -372,6 +372,41 @@ impl<'a> PreparedDual<'a> {
                         None => {
                             dvec = recompute_reduced_costs(&mut lu, sp, c, n, &basis)?;
                             if dual_feasible(n, &stat, l, u, &dvec, tol) {
+                                // In-engine refined recovery (discopt#364): if the
+                                // working factor's growth signal flags possible digit
+                                // loss, recompute x_B from a fresh, refinement-polished
+                                // factorization and re-verify primal feasibility on the
+                                // sharper values. If the sharper x_B reveals an
+                                // infeasibility the drifted one hid, hand to the robust
+                                // cold solve rather than certify a wrong optimum;
+                                // otherwise certify with the sharper x_B. Sound either
+                                // way — the decision is only ever made *more* accurate,
+                                // and the common (benign-growth) path is untouched.
+                                let refined_xb: Option<Vec<f64>> = if lu
+                                    .growth()
+                                    .is_some_and(|g| g > GROWTH_REFINE_TRIGGER)
+                                {
+                                    crate::profile::incr(
+                                        crate::profile::Ctr::RefinedRecoveryAttempts,
+                                    );
+                                    match refined_basic_values(sp, b, n, m, l, u, &basis, &stat) {
+                                        Some(xb_r) => {
+                                            if select_leaving(m, &basis, l, u, &gamma, &xb_r, tol)
+                                                .is_some()
+                                            {
+                                                crate::profile::incr(
+                                                    crate::profile::Ctr::RefinedRecoveryRescues,
+                                                );
+                                                return None; // sharper x_B infeasible → cold fallback
+                                            }
+                                            Some(xb_r)
+                                        }
+                                        None => None, // fresh factor failed; keep the exact x_B
+                                    }
+                                } else {
+                                    None
+                                };
+                                let xb_final: &[f64] = refined_xb.as_deref().unwrap_or(&xb);
                                 // Row duals `y = B⁻ᵀ c_B` for the safe dual bound;
                                 // empty (caller falls back) if the btran fails.
                                 let mut y: Vec<f64> = basis.iter().map(|&j| c[j]).collect();
@@ -386,7 +421,7 @@ impl<'a> PreparedDual<'a> {
                                     &basis,
                                     &slot_of,
                                     &stat,
-                                    &xb,
+                                    xb_final,
                                     c,
                                     l,
                                     u,
@@ -594,15 +629,16 @@ impl<'a> PreparedDual<'a> {
 /// The soundness anchor for the incremental dual loop: the maintained `xb` is
 /// refreshed from this on a cadence and whenever optimality/infeasibility is
 /// claimed, so a drifted increment never decides the returned result.
-fn recompute_basic_values(
-    lu: &mut FeralLU,
+/// The right-hand side the basic-variable solve runs against:
+/// `b − Σ_{nonbasic} A_j x_j` (so that `B x_B = rhs`).
+fn reduced_rhs(
     sp: &SparseCols,
     b: &[f64],
     n: usize,
     l: &[f64],
     u: &[f64],
     stat: &[i8],
-) -> Option<Vec<f64>> {
+) -> Vec<f64> {
     let mut xb = b.to_vec();
     for j in 0..n {
         if stat[j] != BASIC {
@@ -621,9 +657,62 @@ fn recompute_basic_values(
             }
         }
     }
+    xb
+}
+
+fn recompute_basic_values(
+    lu: &mut FeralLU,
+    sp: &SparseCols,
+    b: &[f64],
+    n: usize,
+    l: &[f64],
+    u: &[f64],
+    stat: &[i8],
+) -> Option<Vec<f64>> {
+    let mut xb = reduced_rhs(sp, b, n, l, u, stat);
     if lu.ftran(&mut xb).is_err() {
         return None;
     }
+    Some(xb)
+}
+
+/// Growth high-water ratio (feral#93) above which the optimality gate re-solves
+/// `x_B` with a fresh refinement-polished factorization before certifying. A
+/// benign basis has growth ≈ 1; only a factor that lost digits (≫ 1) pays for the
+/// refined recompute, so well-conditioned nodes — the overwhelming majority — are
+/// untouched.
+const GROWTH_REFINE_TRIGGER: f64 = 1e4;
+
+/// Recompute `x_B` for the final basis via a **fresh** numeric-focus factorization
+/// with iterative refinement (discopt#364). The dual's working factor accumulates
+/// Forrest–Tomlin update error across pivots; a fresh factor of the same basis
+/// carries none of it, and refinement then polishes the residual `b − B·x`, so the
+/// optimality decision is made on the sharpest `x_B` available — recovered *inside*
+/// the engine rather than by handing off to another solver. Returns `None` if the
+/// fresh factorization or refined solve fails (the caller keeps its existing `x_B`).
+#[allow(clippy::too_many_arguments)]
+fn refined_basic_values(
+    sp: &SparseCols,
+    b: &[f64],
+    n: usize,
+    m: usize,
+    l: &[f64],
+    u: &[f64],
+    basis: &[usize],
+    stat: &[i8],
+) -> Option<Vec<f64>> {
+    let cols: Vec<Vec<f64>> = basis
+        .iter()
+        .map(|&j| {
+            let mut col = vec![0.0; m];
+            sp.scatter(j, &mut col);
+            col
+        })
+        .collect();
+    let mut lu = FeralLU::new().with_numeric_focus();
+    lu.factorize(m, &cols).ok()?;
+    let mut xb = reduced_rhs(sp, b, n, l, u, stat);
+    lu.ftran_refined(&mut xb).ok()?;
     Some(xb)
 }
 

--- a/crates/discopt-core/src/lp/simplex/linsolve.rs
+++ b/crates/discopt-core/src/lp/simplex/linsolve.rs
@@ -14,7 +14,10 @@
 //!   it refactorizes on every solve, so it is for bring-up, tiny bases, and
 //!   cross-checking `FeralLU` in tests — not performance.
 
-use feral::{should_use_dense_lu, DenseLu, LuParams, SparseColMatrix, SparseLu, SparseLuSymbolic};
+use feral::{
+    should_use_dense_lu, DenseLu, GeneralMatrix, LuParams, RefactorCause, SparseColMatrix,
+    SparseLu, SparseLuSymbolic,
+};
 
 /// Error from a basis factorization/solve.
 #[derive(Debug, Clone)]
@@ -61,6 +64,22 @@ pub trait LinearSolver {
     /// Replace the basic column in slot `leaving_slot` with `entering_col`
     /// (product-form update; the caller refactorizes when updates accumulate).
     fn update(&mut self, leaving_slot: usize, entering_col: &[f64]) -> Result<(), LinError>;
+
+    /// Solve `B x = rhs` in place, with iterative refinement when the backend
+    /// supports it and it is enabled. The default is a plain [`ftran`](Self::ftran)
+    /// — refinement is opt-in and backend-specific (see [`FeralLU::with_refine_steps`]),
+    /// so a backend that does not implement it (or has it disabled) degrades to the
+    /// unrefined solve with no behavior change.
+    fn ftran_refined(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
+        self.ftran(rhs)
+    }
+
+    /// Solve `Bᵀ y = rhs` in place, with iterative refinement when available
+    /// (see [`ftran_refined`](Self::ftran_refined)). Defaults to plain
+    /// [`btran`](Self::btran).
+    fn btran_refined(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
+        self.btran(rhs)
+    }
 
     /// Solve `B X = RHS` for several right-hand sides at once, each `rhs[k]` an
     /// `m`-vector solved in place. The point is to reuse the single existing
@@ -118,17 +137,140 @@ enum Factored {
 /// also gates on sparsity, would not. Above it we defer to feral's heuristic.
 const FORCE_DENSE_M: usize = 256;
 
+/// The retained basis matrix, in dense-column form, kept **in sync** with every
+/// [`update`](LinearSolver::update) so a refined solve or condition estimate can
+/// form the residual `r = b − B·x` against the matrix the factor *currently*
+/// represents — not the one it was originally factorized from. Only populated in
+/// numeric-focus mode (`refine_steps > 0`); off by default it stays empty, so the
+/// hot path pays no retention cost. Dense columns are the canonical form because
+/// [`update`](LinearSolver::update) hands us a dense `entering_col`, so keeping it
+/// in sync is a trivial `cols[slot] = entering_col` — the sparse/dense feral
+/// matrix is rebuilt lazily, only when a refined solve is actually requested.
+#[derive(Debug, Clone, Default)]
+struct RetainedBasis {
+    m: usize,
+    cols: Vec<Vec<f64>>,
+}
+
+/// A feral basis matrix in whichever form the current factor consumes.
+enum BasisMat {
+    Sparse(SparseColMatrix),
+    Dense(GeneralMatrix),
+}
+
+/// Number of iterative-refinement steps used in numeric-focus mode. feral's own
+/// refined solve caps at this many `r = b − B·x; B δ = r; x += δ` rounds and
+/// early-exits once `‖r‖/‖b‖ < refine_tol`, so 2 is a cheap, effective default
+/// (matches feral's internal refined-path default and the hand-rolled 3-round
+/// loop the root Gomory solve already used).
+const NUMERIC_FOCUS_REFINE_STEPS: usize = 2;
+
 /// Basis factorization backend: feral's LU, dispatched dense-or-sparse per
 /// basis at factorize time (see the [`Factored`] docs for the rationale).
 #[derive(Default, Clone)]
 pub struct FeralLU {
     lu: Option<Factored>,
+    /// Iterative-refinement steps baked into the factor's [`LuParams`] at
+    /// factorize time. `0` (default) → refinement is a no-op and no basis is
+    /// retained, i.e. byte-for-byte the pre-numeric-focus behavior.
+    refine_steps: usize,
+    /// The in-sync basis, populated iff `refine_steps > 0` (see [`RetainedBasis`]).
+    retained: Option<RetainedBasis>,
 }
 
 impl FeralLU {
     /// A new, unfactorized solver.
     pub fn new() -> Self {
-        Self { lu: None }
+        Self::default()
+    }
+
+    /// Enable numeric-focus mode with the default refinement depth: refined
+    /// [`ftran`](LinearSolver::ftran_refined)/[`btran`](LinearSolver::btran_refined)
+    /// solves and [`condition_estimate`](Self::condition_estimate)/[`growth`](Self::growth)
+    /// signals become available. The in-engine analogue of Gurobi's `NumericFocus`
+    /// — the principled alternative to falling back to a different solver on an
+    /// ill-conditioned basis (discopt#364).
+    pub fn with_numeric_focus(self) -> Self {
+        self.with_refine_steps(NUMERIC_FOCUS_REFINE_STEPS)
+    }
+
+    /// Set the iterative-refinement depth (0 disables; see [`with_numeric_focus`]).
+    /// Takes effect at the next factorization (the depth is baked into the
+    /// factor's [`LuParams`]). A positive depth turns on basis retention.
+    pub fn with_refine_steps(mut self, steps: usize) -> Self {
+        self.refine_steps = steps;
+        self
+    }
+
+    /// Whether refinement / signal queries are active (a positive refine depth).
+    fn refine_enabled(&self) -> bool {
+        self.refine_steps > 0
+    }
+
+    /// The [`LuParams`] for this solver's factorizations, carrying the configured
+    /// refinement depth. All other fields are feral's defaults (strict partial
+    /// pivoting, `zero_pivot_tol = 1e-13`, etc.).
+    fn params(&self) -> LuParams {
+        LuParams {
+            refine_steps: self.refine_steps,
+            ..LuParams::default()
+        }
+    }
+
+    /// Rebuild the retained basis as the feral matrix the current factor consumes
+    /// (sparse for a `SparseLu`, dense for a `DenseLu`). Returns `None` when not in
+    /// numeric-focus mode / unfactorized; propagates a construction error otherwise.
+    fn build_basis_matrix(&self) -> Option<Result<BasisMat, LinError>> {
+        let rb = self.retained.as_ref()?;
+        Some(match self.lu.as_ref()? {
+            Factored::Sparse(_) => SparseColMatrix::from_dense_columns(rb.m, &rb.cols)
+                .map(BasisMat::Sparse)
+                .map_err(feral_err),
+            Factored::Dense(_) => GeneralMatrix::from_columns(rb.m, &rb.cols)
+                .map(BasisMat::Dense)
+                .map_err(feral_err),
+        })
+    }
+
+    /// One-norm condition estimate `κ₁ ≈ ‖B‖₁·‖B⁻¹‖₁` of the current basis
+    /// (Hager–Higham, via feral#94). `None` unless in numeric-focus mode and
+    /// factorized. A large value flags an ill-conditioned node — the signal that
+    /// drives in-engine recovery (refine / perturb / branch) instead of a solver
+    /// swap (discopt#364).
+    pub fn condition_estimate(&mut self) -> Option<f64> {
+        let mat = self.build_basis_matrix()?.ok()?;
+        match (self.lu.as_mut()?, mat) {
+            (Factored::Sparse(lu), BasisMat::Sparse(b)) => lu.condition_estimate_1(&b).ok(),
+            (Factored::Dense(lu), BasisMat::Dense(b)) => lu.condition_estimate_1(&b).ok(),
+            // build_basis_matrix builds to match the live factor kind, so the
+            // cross arms are unreachable; degrade to None rather than panic.
+            _ => None,
+        }
+    }
+
+    /// The factor's element-growth high-water ratio `‖U‖∞ / ‖U₀‖∞` (feral#93), or
+    /// `None` when unfactorized. A cheap conditioning proxy: growth ≫ 1 signals a
+    /// factorization that lost digits. Available regardless of numeric-focus mode
+    /// (it is read straight off the factor, needing no retained basis).
+    pub fn growth(&self) -> Option<f64> {
+        match &self.lu {
+            Some(Factored::Sparse(lu)) => Some(lu.growth()),
+            Some(Factored::Dense(lu)) => Some(lu.growth()),
+            None => None,
+        }
+    }
+
+    /// Why the last [`update`](LinearSolver::update) demanded a refactorization,
+    /// with a cause-specific magnitude (feral#95): `Growth`/`TinyPivot` mean
+    /// *ill-conditioning* (refine-and-retry is the right response), `UpdateBudget`
+    /// is mere bookkeeping (a plain refactor suffices). `None` if the last update
+    /// succeeded or the solver is unfactorized.
+    pub fn last_refactor(&self) -> Option<(RefactorCause, f64)> {
+        match &self.lu {
+            Some(Factored::Sparse(lu)) => lu.last_refactor(),
+            Some(Factored::Dense(lu)) => lu.last_refactor(),
+            None => None,
+        }
     }
 
     /// Cumulative Forrest–Tomlin bump-update work (feral's `eta_ops`) accumulated
@@ -161,49 +303,67 @@ fn feral_err(e: feral::FeralError) -> LinError {
 impl LinearSolver for FeralLU {
     fn factorize(&mut self, m: usize, cols: &[Vec<f64>]) -> Result<(), LinError> {
         debug_assert_eq!(cols.len(), m);
-        let params = LuParams::default();
+        let params = self.params();
         let nnz: usize = cols
             .iter()
             .map(|c| c.iter().filter(|&&v| v != 0.0).count())
             .sum();
         self.lu = Some(
             if m <= FORCE_DENSE_M || should_use_dense_lu(m, nnz, &params) {
-                Factored::Dense(Box::new(DenseLu::factor(cols, m, params).map_err(feral_err)?))
+                Factored::Dense(Box::new(
+                    DenseLu::factor(cols, m, params).map_err(feral_err)?,
+                ))
             } else {
                 let a = SparseColMatrix::from_dense_columns(m, cols).map_err(feral_err)?;
                 let sym = SparseLuSymbolic::analyze(&a).map_err(feral_err)?;
-                Factored::Sparse(Box::new(SparseLu::factor(&a, &sym, params).map_err(feral_err)?))
+                Factored::Sparse(Box::new(
+                    SparseLu::factor(&a, &sym, params).map_err(feral_err)?,
+                ))
             },
         );
+        self.retained = self.refine_enabled().then(|| RetainedBasis {
+            m,
+            cols: cols.to_vec(),
+        });
         Ok(())
     }
 
     fn factorize_sparse(&mut self, m: usize, cols: &[Vec<(usize, f64)>]) -> Result<(), LinError> {
-        let params = LuParams::default();
+        let params = self.params();
         // nnz is the sum of column lengths — O(m), not the O(m²) dense scan the
         // `Vec<Vec<f64>>` path pays.
         let nnz: usize = cols.iter().map(|c| c.len()).sum();
-        self.lu = Some(
-            if m <= FORCE_DENSE_M || should_use_dense_lu(m, nnz, &params) {
-                // Small/dense basis: feral's dense LU wins and there is no symbolic
-                // phase. Densifying is O(m² + nnz), affordable only because this
-                // branch is gated to small `m` (<= FORCE_DENSE_M) or feral-judged-
-                // dense bases.
-                let mut dense = vec![vec![0.0; m]; m];
-                for (slot, col) in cols.iter().enumerate() {
-                    for &(row, v) in col {
-                        dense[slot][row] = v;
-                    }
+        // Densify once if either the dense LU branch needs it or numeric-focus
+        // retention does; reuse the single dense copy for both.
+        let want_dense = m <= FORCE_DENSE_M || should_use_dense_lu(m, nnz, &params);
+        let dense = (want_dense || self.refine_enabled()).then(|| {
+            let mut d = vec![vec![0.0; m]; m];
+            for (slot, col) in cols.iter().enumerate() {
+                for &(row, v) in col {
+                    d[slot][row] = v;
                 }
-                Factored::Dense(Box::new(DenseLu::factor(&dense, m, params).map_err(feral_err)?))
-            } else {
-                // Build feral's sparse matrix directly from the sparse columns —
-                // O(nnz), no dense m×m intermediate.
-                let a = SparseColMatrix::from_sparse_columns(m, cols).map_err(feral_err)?;
-                let sym = SparseLuSymbolic::analyze(&a).map_err(feral_err)?;
-                Factored::Sparse(Box::new(SparseLu::factor(&a, &sym, params).map_err(feral_err)?))
-            },
-        );
+            }
+            d
+        });
+        self.lu = Some(if want_dense {
+            // Small/dense basis: feral's dense LU wins and there is no symbolic
+            // phase.
+            let dense = dense.as_ref().expect("densified for the dense branch");
+            Factored::Dense(Box::new(
+                DenseLu::factor(dense, m, params).map_err(feral_err)?,
+            ))
+        } else {
+            // Build feral's sparse matrix directly from the sparse columns —
+            // O(nnz), no dense m×m intermediate.
+            let a = SparseColMatrix::from_sparse_columns(m, cols).map_err(feral_err)?;
+            let sym = SparseLuSymbolic::analyze(&a).map_err(feral_err)?;
+            Factored::Sparse(Box::new(
+                SparseLu::factor(&a, &sym, params).map_err(feral_err)?,
+            ))
+        });
+        self.retained = dense
+            .filter(|_| self.refine_enabled())
+            .map(|cols| RetainedBasis { m, cols });
         Ok(())
     }
 
@@ -222,9 +382,55 @@ impl LinearSolver for FeralLU {
     }
 
     fn update(&mut self, leaving_slot: usize, entering_col: &[f64]) -> Result<(), LinError> {
-        match self.lu.as_mut().ok_or(LinError::NotFactorized)? {
+        let res = match self.lu.as_mut().ok_or(LinError::NotFactorized)? {
             Factored::Sparse(lu) => lu.update(leaving_slot, entering_col).map_err(feral_err),
             Factored::Dense(lu) => lu.update(leaving_slot, entering_col).map_err(feral_err),
+        };
+        // Keep the retained basis in lock-step with the factor: only on a
+        // successful update (a failed one rolls the factor back and the caller
+        // refactorizes, which rebuilds `retained` from scratch). Without this the
+        // residual `b − B·x` in a refined solve would be formed against the stale
+        // pre-update basis and silently corrupt the correction.
+        if res.is_ok() {
+            if let Some(rb) = self.retained.as_mut() {
+                rb.cols[leaving_slot].clear();
+                rb.cols[leaving_slot].extend_from_slice(entering_col);
+            }
+        }
+        res
+    }
+
+    fn ftran_refined(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
+        // Build the basis matrix first (immutable borrow, produces an owned
+        // matrix), then solve (mutable borrow) — the two borrows don't overlap.
+        let mat = match self.build_basis_matrix() {
+            Some(m) => m?,
+            None => return self.ftran(rhs), // not in numeric-focus mode
+        };
+        match (self.lu.as_mut().ok_or(LinError::NotFactorized)?, mat) {
+            (Factored::Sparse(lu), BasisMat::Sparse(b)) => {
+                lu.ftran_refined(&b, rhs).map_err(feral_err)
+            }
+            (Factored::Dense(lu), BasisMat::Dense(b)) => {
+                lu.ftran_refined(&b, rhs).map_err(feral_err)
+            }
+            _ => self.ftran(rhs),
+        }
+    }
+
+    fn btran_refined(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
+        let mat = match self.build_basis_matrix() {
+            Some(m) => m?,
+            None => return self.btran(rhs),
+        };
+        match (self.lu.as_mut().ok_or(LinError::NotFactorized)?, mat) {
+            (Factored::Sparse(lu), BasisMat::Sparse(b)) => {
+                lu.btran_refined(&b, rhs).map_err(feral_err)
+            }
+            (Factored::Dense(lu), BasisMat::Dense(b)) => {
+                lu.btran_refined(&b, rhs).map_err(feral_err)
+            }
+            _ => self.btran(rhs),
         }
     }
 }
@@ -403,5 +609,164 @@ mod tests {
             fl.btran_multi(&mut batch).unwrap();
         }
         assert!(close(&c0, &y0, 1e-12) && close(&c1, &y1, 1e-12));
+    }
+
+    // ---- numeric-focus: iterative refinement + condition/growth signals ----
+
+    // Residual ‖B·x − rhs‖∞ of a candidate solution.
+    fn residual_inf(cols: &[Vec<f64>], x: &[f64], rhs: &[f64]) -> f64 {
+        bmatvec(cols, x)
+            .iter()
+            .zip(rhs)
+            .map(|(bx, r)| (bx - r).abs())
+            .fold(0.0, f64::max)
+    }
+
+    #[test]
+    fn refined_solve_matches_plain_on_well_conditioned() {
+        // On a benign basis, refinement must not perturb an already-accurate
+        // solution: refined == plain, both exact.
+        let cols = vec![
+            vec![2.0, 1.0, 0.0],
+            vec![1.0, 2.0, 1.0],
+            vec![0.0, 1.0, 2.0],
+        ];
+        let m = 3;
+        let mut fl = FeralLU::new().with_numeric_focus();
+        fl.factorize(m, &cols).unwrap();
+        let rhs = [1.0, 2.0, 3.0];
+        let (mut xr, mut xp) = (rhs, rhs);
+        fl.ftran_refined(&mut xr).unwrap();
+        fl.ftran(&mut xp).unwrap();
+        assert!(close(&xr, &xp, 1e-12), "refined {xr:?} vs plain {xp:?}");
+        assert!(residual_inf(&cols, &xr, &rhs) < 1e-9);
+    }
+
+    #[test]
+    fn refined_solve_valid_after_update_syncs_basis() {
+        // The stale-`b` trap: after a product-form update the factor represents
+        // the *updated* basis. If the retained basis is not kept in sync, the
+        // refined solve forms its residual against the old matrix and corrupts
+        // the answer. This asserts the refined solve satisfies the UPDATED system.
+        let cols = vec![
+            vec![2.0, 1.0, 0.0],
+            vec![1.0, 2.0, 1.0],
+            vec![0.0, 1.0, 2.0],
+        ];
+        let m = 3;
+        let mut fl = FeralLU::new().with_numeric_focus();
+        fl.factorize(m, &cols).unwrap();
+
+        let newcol = [0.0, 0.0, 1.0]; // keeps B nonsingular
+        fl.update(1, &newcol).unwrap();
+        let mut updated = cols.clone();
+        updated[1] = newcol.to_vec();
+
+        let rhs = [1.0, 2.0, 3.0];
+        let mut x = rhs;
+        fl.ftran_refined(&mut x).unwrap();
+        assert!(
+            residual_inf(&updated, &x, &rhs) < 1e-9,
+            "refined ftran must satisfy the UPDATED basis; residual too large (stale-b?)"
+        );
+
+        // btran against the updated basis transpose likewise.
+        let mut y = rhs;
+        fl.btran_refined(&mut y).unwrap();
+        // Bᵀ y = rhs  ⇔  residual of Bᵀ against y.
+        let mut byt = vec![0.0; m];
+        for (i, col) in updated.iter().enumerate() {
+            byt[i] = col.iter().zip(&y).map(|(a, yj)| a * yj).sum();
+        }
+        let rt = byt
+            .iter()
+            .zip(&rhs)
+            .map(|(a, r)| (a - r).abs())
+            .fold(0.0, f64::max);
+        assert!(rt < 1e-9, "refined btran must satisfy updated Bᵀ");
+    }
+
+    #[test]
+    fn refinement_does_not_worsen_residual_ill_conditioned() {
+        // A basis with a large dynamic range across columns. Refinement can only
+        // reduce (or leave) the residual, never worsen it — the safety property
+        // that makes it a sound in-engine recovery step.
+        // Moderate dynamic range: ill-conditioned enough to be a meaningful test,
+        // but the smallest pivot (~1e-3) stays well above feral's relative
+        // singular floor (zero_pivot_tol · ‖U₀‖∞ ≈ 1e-13 · 1e6), so both paths
+        // factorize.
+        let cols = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![1.0, 1e6, 0.0],
+            vec![1.0, 1.0, 1e-3],
+        ];
+        let m = 3;
+        let rhs = [1.0, 1.0, 1.0];
+
+        let mut plain = FeralLU::new();
+        plain.factorize(m, &cols).unwrap();
+        let mut xp = rhs;
+        plain.ftran(&mut xp).unwrap();
+
+        let mut nf = FeralLU::new().with_numeric_focus();
+        nf.factorize(m, &cols).unwrap();
+        let mut xr = rhs;
+        nf.ftran_refined(&mut xr).unwrap();
+
+        let rp = residual_inf(&cols, &xp, &rhs);
+        let rr = residual_inf(&cols, &xr, &rhs);
+        assert!(
+            rr <= rp + 1e-18,
+            "refined residual {rr:e} must not exceed plain {rp:e}"
+        );
+    }
+
+    #[test]
+    fn condition_estimate_tracks_conditioning() {
+        // Identity → κ₁ ≈ 1; a diagonal with a 1e10 dynamic range → κ₁ ≈ 1e10.
+        let ident = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
+        let mut fi = FeralLU::new().with_numeric_focus();
+        fi.factorize(2, &ident).unwrap();
+        let ki = fi.condition_estimate().expect("numeric-focus + factorized");
+        assert!((ki - 1.0).abs() < 1e-6, "κ₁(I) ≈ 1, got {ki}");
+
+        let ill = vec![vec![1.0, 0.0], vec![0.0, 1e-10]];
+        let mut fx = FeralLU::new().with_numeric_focus();
+        fx.factorize(2, &ill).unwrap();
+        let kx = fx.condition_estimate().expect("numeric-focus + factorized");
+        assert!(kx > 1e9, "κ₁(diag(1,1e-10)) ≈ 1e10, got {kx}");
+
+        // Off by default: no retained basis, so no estimate.
+        let mut plain = FeralLU::new();
+        plain.factorize(2, &ident).unwrap();
+        assert!(plain.condition_estimate().is_none());
+    }
+
+    #[test]
+    fn growth_signal_available_after_factorize() {
+        let cols = vec![vec![2.0, 1.0], vec![1.0, 2.0]];
+        let mut fl = FeralLU::new();
+        assert!(fl.growth().is_none(), "unfactorized → no growth");
+        fl.factorize(2, &cols).unwrap();
+        let g = fl.growth().expect("factorized");
+        assert!(
+            g.is_finite() && g >= 1.0,
+            "growth is a ≥1 high-water ratio, got {g}"
+        );
+    }
+
+    #[test]
+    fn numeric_focus_off_retains_nothing() {
+        // The default path must not pay retention cost or change behavior.
+        let cols = vec![vec![2.0, 1.0], vec![1.0, 2.0]];
+        let mut fl = FeralLU::new();
+        fl.factorize(2, &cols).unwrap();
+        assert!(fl.retained.is_none());
+        // ftran_refined with refinement off is exactly ftran.
+        let rhs = [1.0, 1.0];
+        let (mut a, mut b) = (rhs, rhs);
+        fl.ftran_refined(&mut a).unwrap();
+        fl.ftran(&mut b).unwrap();
+        assert_eq!(a, b);
     }
 }

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -80,7 +80,29 @@ pub fn solve_lp_cols(
 /// small absolute/relative tolerance. Used as the final feasibility audit before
 /// certifying an `Optimal` solve so incremental `x_B` drift (Harris bound
 /// excursions, deferred refactorization) cannot return a wrong optimum.
-fn solution_within_tolerance(
+/// Why the final feasibility audit rejected a point — the distinction that
+/// decides whether iterative refinement can help (discopt#364).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Feasibility {
+    /// Within tolerance on both bounds and `Ax=b`.
+    Ok,
+    /// A variable sits outside `[l, u]` beyond tolerance. On the degenerate lifted
+    /// relaxations this is typically a Harris ratio-test bound *excursion* (the
+    /// `delta_tol` δ-expansion letting a basic var settle just past a bound), not a
+    /// solve-accuracy problem — so recomputing `x_B` more accurately does **not**
+    /// fix it. Refinement is skipped for this kind.
+    Bounds,
+    /// The `Ax=b` row residual exceeds tolerance — a genuine linear-solve
+    /// inaccuracy (accumulated Forrest–Tomlin update error / ill-conditioning),
+    /// which a fresh refinement-polished factorization *can* recover.
+    Rows,
+}
+
+/// Classify a candidate point against its bounds and `Ax=b`. Bounds are checked
+/// first, so a point violating *both* reports [`Feasibility::Bounds`] — correct
+/// for the recovery decision, since refinement cannot repair a bound excursion
+/// even when it repairs the residual.
+fn audit_feasibility(
     cols: &SparseCols,
     m: usize,
     n: usize,
@@ -88,7 +110,7 @@ fn solution_within_tolerance(
     l: &[f64],
     u: &[f64],
     x: &[f64],
-) -> bool {
+) -> Feasibility {
     const FEAS: f64 = 1e-6;
     for j in 0..n {
         // Relative bound tolerance: a variable whose bound (and hence value) is
@@ -99,7 +121,7 @@ fn solution_within_tolerance(
         let lo_tol = FEAS * (1.0 + l[j].abs().min(INF));
         let hi_tol = FEAS * (1.0 + u[j].abs().min(INF));
         if x[j] < l[j] - lo_tol || x[j] > u[j] + hi_tol {
-            return false;
+            return Feasibility::Bounds;
         }
     }
     // Row activity `A x` accumulated over the sparse columns (O(nnz)), not a dense
@@ -117,10 +139,25 @@ fn solution_within_tolerance(
     }
     for i in 0..m {
         if (ax[i] - b[i]).abs() > FEAS * (1.0 + b[i].abs()) {
-            return false;
+            return Feasibility::Rows;
         }
     }
-    true
+    Feasibility::Ok
+}
+
+/// Bool convenience over [`audit_feasibility`] used by the unit tests (production
+/// code switches on the [`Feasibility`] reason to decide whether to refine).
+#[cfg(test)]
+fn solution_within_tolerance(
+    cols: &SparseCols,
+    m: usize,
+    n: usize,
+    b: &[f64],
+    l: &[f64],
+    u: &[f64],
+    x: &[f64],
+) -> bool {
+    audit_feasibility(cols, m, n, b, l, u, x) == Feasibility::Ok
 }
 
 struct Simplex<'a> {
@@ -740,32 +777,49 @@ impl<'a> Simplex<'a> {
         // Final feasibility audit before certifying Optimal. x_B is maintained
         // incrementally between the ~48-pivot refactorizations and the Harris
         // ratio test permits small bound excursions, so the returned point can
-        // drift. Verify it actually satisfies its bounds and Ax=b; on violation,
-        // first attempt an in-engine refined recovery (a fresh, refinement-polished
-        // refactorization of the same basis — no accumulated update error), and
-        // only downgrade to Numerical if that still fails the audit. The re-audit
-        // is the same soundness gate, so recovery can only rescue a solve that
-        // would otherwise be declared Numerical — never certify a wrong "Optimal".
-        // A genuine Numerical then flows to the caller as before (the warm path's
-        // cold fallback, or the MILP driver decertifying the gap and branching).
+        // drift. Verify it actually satisfies its bounds and Ax=b.
+        //
+        // On a *row-residual* failure (Ax=b drift — accumulated update error /
+        // ill-conditioning), attempt an in-engine refined recovery: recompute x_B
+        // from a fresh, refinement-polished factorization of the same basis and
+        // re-audit; only downgrade to Numerical if it still fails. The re-audit is
+        // the same soundness gate, so recovery can only rescue a solve that would
+        // otherwise be Numerical — never certify a wrong "Optimal".
+        //
+        // A *bounds* excursion is NOT retried: it is a Harris ratio-test artefact,
+        // not a solve-accuracy problem, so a sharper x_B cannot pull the variable
+        // back inside its bound (measured: on the lifted corpus every audit failure
+        // was a bounds excursion, so refining them was pure wasted work — discopt#364).
+        // Either way a genuine Numerical flows to the caller as before (the warm
+        // path's cold fallback, or the MILP driver decertifying the gap and branching).
         let audit = |slf: &Simplex, x: &[f64]| {
-            solution_within_tolerance(&slf.cols, slf.m, slf.n, slf.b, &slf.lb, &slf.ub, x)
+            audit_feasibility(&slf.cols, slf.m, slf.n, slf.b, &slf.lb, &slf.ub, x)
         };
-        let status = if status == LpStatus::Optimal && !audit(&self, &x) {
-            crate::profile::incr(crate::profile::Ctr::RefinedRecoveryAttempts);
-            match self.refined_basic_values(art_sign) {
-                Some(xb_r) => {
-                    let x_r = self.assemble_x(&xb_r);
-                    if audit(&self, &x_r) {
-                        crate::profile::incr(crate::profile::Ctr::RefinedRecoveryRescues);
-                        x = x_r;
-                        obj = (0..self.n).map(|j| self.c[j] * x[j]).sum();
-                        LpStatus::Optimal
-                    } else {
-                        LpStatus::Numerical
+        let status = if status == LpStatus::Optimal {
+            match audit(&self, &x) {
+                Feasibility::Ok => LpStatus::Optimal,
+                // Bound excursion: refinement can't help — downgrade directly.
+                Feasibility::Bounds => LpStatus::Numerical,
+                // Row residual: the failure mode iterative refinement can recover.
+                Feasibility::Rows => {
+                    crate::profile::incr(crate::profile::Ctr::RefinedRecoveryAttemptsPrimal);
+                    match self.refined_basic_values(art_sign) {
+                        Some(xb_r) => {
+                            let x_r = self.assemble_x(&xb_r);
+                            if audit(&self, &x_r) == Feasibility::Ok {
+                                crate::profile::incr(
+                                    crate::profile::Ctr::RefinedRecoveryRescuesPrimal,
+                                );
+                                x = x_r;
+                                obj = (0..self.n).map(|j| self.c[j] * x[j]).sum();
+                                LpStatus::Optimal
+                            } else {
+                                LpStatus::Numerical
+                            }
+                        }
+                        None => LpStatus::Numerical,
                     }
                 }
-                None => LpStatus::Numerical,
             }
         } else {
             status

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -511,6 +511,19 @@ impl<'a> Simplex<'a> {
         let mut xb = self
             .basic_values(art_sign)
             .map_err(|_| LpStatus::Numerical)?;
+        // EXPAND anti-degeneracy (Gill et al.): the Harris ratio-test feasibility
+        // tolerance grows slowly from δ_min to δ_max, and a guaranteed minimum step
+        // keeps every pivot strictly progressing — breaking the degenerate zero-step
+        // stalls that dominate the lifted relaxations, more cheaply than falling into
+        // Bland. δ resets to δ_min every EXPAND_RESET iterations (the incremental x_B
+        // is refreshed exactly on the ≤48-update refactorizations, so the sub-δ
+        // excursions never accumulate). δ_max stays at the pre-existing 1e-7 ceiling
+        // — 10× under the 1e-6 feasibility audit — so soundness is unchanged.
+        const EXPAND_MIN: f64 = 1e-8;
+        const EXPAND_MAX: f64 = 1e-7;
+        const EXPAND_RESET: usize = 10_000;
+        let expand_incr = (EXPAND_MAX - EXPAND_MIN) / EXPAND_RESET as f64;
+        let mut expand_tol = EXPAND_MIN;
         for _iter in 0..self.max_iter {
             // Poll the wall-clock deadline every 256 pivots (cheap relative to a
             // pricing+ftran iteration). A dense, degenerate lifted-McCormick LP
@@ -581,8 +594,9 @@ impl<'a> Simplex<'a> {
             // its bound; pass 2 picks, among columns that truly block within that
             // step, the one with the largest pivot |α_i| (numerical stability),
             // which may push others up to δ past a bound — the accepted Harris
-            // trade, with δ ≪ the 1e-6 feasibility tolerance used elsewhere.
-            let delta_tol = 1e-7;
+            // trade, with δ ≪ the 1e-6 feasibility tolerance used elsewhere. δ is
+            // the EXPAND tolerance for this iteration (grows toward EXPAND_MAX).
+            let delta_tol = expand_tol;
             // entering's own bound-flip cap (the step at which q hits its far bound)
             let cap = if self.ub[q] < INF && self.lb[q] > -INF {
                 self.ub[q] - self.lb[q]
@@ -647,6 +661,20 @@ impl<'a> Simplex<'a> {
                 t_max = cap; // no basic blocks → pure bound flip (or unbounded)
             }
 
+            // EXPAND minimum step: on a degenerate (≈zero) blocking step, advance by
+            // a guaranteed positive amount so the pivot strictly improves the
+            // objective and the search cannot stall. The excursion introduced is
+            // ≤ expand_tol (≤ 1e-7); the leaving variable is pinned exactly at its
+            // bound as it exits, so nothing persists past the next exact refresh.
+            // Bounded by the entering variable's own bound-flip distance `cap`.
+            if leave_slot.is_some() {
+                let t_min = (expand_tol / best_pivot.max(self.tol)).min(cap);
+                if t_max < t_min {
+                    t_max = t_min;
+                    crate::profile::incr(crate::profile::Ctr::ExpandMinSteps);
+                }
+            }
+
             if t_max >= INF {
                 // Capture the primal unbounded ray over the real columns (length
                 // `n`): entering `q` moves by `dir`, each basic variable follows
@@ -673,6 +701,13 @@ impl<'a> Simplex<'a> {
                 crate::profile::incr(crate::profile::Ctr::DegeneratePivots);
             } else {
                 stall = 0;
+            }
+            // Grow the EXPAND tolerance for the next iteration; reset periodically so
+            // it never exceeds EXPAND_MAX (the excursions are cleared by the exact
+            // x_B refresh on each refactorization, so the reset never loses ground).
+            expand_tol += expand_incr;
+            if expand_tol >= EXPAND_MAX {
+                expand_tol = EXPAND_MIN;
             }
             crate::profile::incr(if is_phase1 {
                 crate::profile::Ctr::Phase1Pivots

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -242,8 +242,9 @@ impl<'a> Simplex<'a> {
         }
     }
 
-    /// Recompute basic-variable values: x_B = B⁻¹ (b − Σ_{nonbasic} A_j x_j).
-    fn basic_values(&mut self, art_sign: &[f64]) -> Result<Vec<f64>, ()> {
+    /// The right-hand side the basic-variable solve runs against:
+    /// `b − Σ_{nonbasic} A_j x_j` (so that `B x_B = rhs`).
+    fn reduced_rhs(&self, art_sign: &[f64]) -> Vec<f64> {
         let mut rhs = self.b.to_vec();
         for j in 0..self.na {
             if self.stat[j] != BASIC {
@@ -260,8 +261,49 @@ impl<'a> Simplex<'a> {
                 }
             }
         }
+        rhs
+    }
+
+    /// Recompute basic-variable values: x_B = B⁻¹ (b − Σ_{nonbasic} A_j x_j).
+    fn basic_values(&mut self, art_sign: &[f64]) -> Result<Vec<f64>, ()> {
+        let mut rhs = self.reduced_rhs(art_sign);
         self.lu.ftran(&mut rhs).map_err(|_| ())?;
         Ok(rhs)
+    }
+
+    /// Recover `x_B` for the final basis via a **fresh** numeric-focus
+    /// factorization with iterative refinement (discopt#364). Used only when the
+    /// incremental factor's `x_B` fails the feasibility audit: a fresh factor
+    /// carries none of the accumulated Forrest–Tomlin update error, and
+    /// refinement then polishes the residual `b − B·x`, so an ill-conditioned or
+    /// update-drifted basis is recovered *inside the engine* rather than by
+    /// falling back to another solver. Returns `None` if the fresh factorization
+    /// or refined solve fails (the caller keeps the Numerical verdict).
+    fn refined_basic_values(&self, art_sign: &[f64]) -> Option<Vec<f64>> {
+        let cols: Vec<Vec<f64>> = self
+            .basis
+            .iter()
+            .map(|&j| self.column(j, art_sign))
+            .collect();
+        let mut lu = FeralLU::new().with_numeric_focus();
+        lu.factorize(self.m, &cols).ok()?;
+        let mut rhs = self.reduced_rhs(art_sign);
+        lu.ftran_refined(&mut rhs).ok()?;
+        Some(rhs)
+    }
+
+    /// Scatter a basic-values vector `x_B` into the full primal point `x`
+    /// (basic vars take their `x_B` slot, nonbasic vars sit at their bound).
+    fn assemble_x(&self, xb: &[f64]) -> Vec<f64> {
+        let mut x = vec![0.0; self.n];
+        for j in 0..self.n {
+            x[j] = if self.stat[j] == BASIC {
+                xb[self.slot_of[j] as usize]
+            } else {
+                self.nb_value(j)
+            };
+        }
+        x
     }
 
     fn refactorize(&mut self, art_sign: &[f64]) -> Result<(), ()> {
@@ -692,27 +734,39 @@ impl<'a> Simplex<'a> {
         let xb = self
             .basic_values(art_sign)
             .unwrap_or_else(|_| vec![0.0; self.m]);
-        let mut x = vec![0.0; self.n];
-        for j in 0..self.n {
-            x[j] = if self.stat[j] == BASIC {
-                xb[self.slot_of[j] as usize]
-            } else {
-                self.nb_value(j)
-            };
-        }
-        let obj: f64 = (0..self.n).map(|j| self.c[j] * x[j]).sum();
+        let mut x = self.assemble_x(&xb);
+        let mut obj: f64 = (0..self.n).map(|j| self.c[j] * x[j]).sum();
 
         // Final feasibility audit before certifying Optimal. x_B is maintained
         // incrementally between the ~48-pivot refactorizations and the Harris
         // ratio test permits small bound excursions, so the returned point can
-        // drift. Verify it actually satisfies its bounds and Ax=b; on violation
-        // downgrade to Numerical so the caller treats it as a failed solve (the
-        // warm path's cold fallback, or the MILP driver decertifying the gap and
-        // branching) rather than trusting a wrong "Optimal".
-        let status = if status == LpStatus::Optimal
-            && !solution_within_tolerance(&self.cols, self.m, self.n, self.b, &self.lb, &self.ub, &x)
-        {
-            LpStatus::Numerical
+        // drift. Verify it actually satisfies its bounds and Ax=b; on violation,
+        // first attempt an in-engine refined recovery (a fresh, refinement-polished
+        // refactorization of the same basis — no accumulated update error), and
+        // only downgrade to Numerical if that still fails the audit. The re-audit
+        // is the same soundness gate, so recovery can only rescue a solve that
+        // would otherwise be declared Numerical — never certify a wrong "Optimal".
+        // A genuine Numerical then flows to the caller as before (the warm path's
+        // cold fallback, or the MILP driver decertifying the gap and branching).
+        let audit = |slf: &Simplex, x: &[f64]| {
+            solution_within_tolerance(&slf.cols, slf.m, slf.n, slf.b, &slf.lb, &slf.ub, x)
+        };
+        let status = if status == LpStatus::Optimal && !audit(&self, &x) {
+            crate::profile::incr(crate::profile::Ctr::RefinedRecoveryAttempts);
+            match self.refined_basic_values(art_sign) {
+                Some(xb_r) => {
+                    let x_r = self.assemble_x(&xb_r);
+                    if audit(&self, &x_r) {
+                        crate::profile::incr(crate::profile::Ctr::RefinedRecoveryRescues);
+                        x = x_r;
+                        obj = (0..self.n).map(|j| self.c[j] * x[j]).sum();
+                        LpStatus::Optimal
+                    } else {
+                        LpStatus::Numerical
+                    }
+                }
+                None => LpStatus::Numerical,
+            }
         } else {
             status
         };

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -80,6 +80,12 @@ counters!(
     BoundFlips,
     BlandActivations,
     Refactorizations,
+    // Numeric-focus iterative-refinement recovery (discopt#364): a drifted
+    // "Optimal" that failed the feasibility audit triggered a fresh refined
+    // refactorization (Attempts); of those, how many the refined point rescued
+    // back to a sound Optimal (Rescues). Attempts − Rescues stayed Numerical.
+    RefinedRecoveryAttempts,
+    RefinedRecoveryRescues,
 );
 
 #[inline(always)]

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -102,6 +102,10 @@ counters!(
     // to Bland's smallest-index rule to break a potential cycle.
     DualDegeneratePivots,
     DualBlandActivations,
+    // Primal EXPAND anti-degeneracy (discopt#364): degenerate blocking steps that
+    // were bumped up to the guaranteed EXPAND minimum step (breaking the stall in
+    // place instead of accumulating toward the Bland switch).
+    ExpandMinSteps,
 );
 
 #[inline(always)]

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -96,6 +96,12 @@ counters!(
     // Attempt still certified Optimal, but with the sharper x_B values.
     RefinedRecoveryAttemptsDual,
     RefinedRecoveryRescuesDual,
+    // Dual-simplex anti-cycling (discopt#364): degenerate dual pivots (entering
+    // reduced cost ≈ 0 → no dual-objective progress) that accumulate the stall
+    // count, and how often that stall crossed the threshold and switched the dual
+    // to Bland's smallest-index rule to break a potential cycle.
+    DualDegeneratePivots,
+    DualBlandActivations,
 );
 
 #[inline(always)]

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -80,12 +80,22 @@ counters!(
     BoundFlips,
     BlandActivations,
     Refactorizations,
-    // Numeric-focus iterative-refinement recovery (discopt#364): a drifted
-    // "Optimal" that failed the feasibility audit triggered a fresh refined
-    // refactorization (Attempts); of those, how many the refined point rescued
-    // back to a sound Optimal (Rescues). Attempts − Rescues stayed Numerical.
-    RefinedRecoveryAttempts,
-    RefinedRecoveryRescues,
+    // Numeric-focus iterative-refinement recovery (discopt#364), split by path so
+    // the two very different triggers can be told apart when measuring.
+    //
+    // Primal (audit-failure driven): a drifted "Optimal" failed the feasibility
+    // audit and triggered a fresh refined refactorization (Attempts); Rescues =
+    // how many the refined point pulled back to a sound Optimal (the rest stayed
+    // Numerical and fell back to cold, as before).
+    RefinedRecoveryAttemptsPrimal,
+    RefinedRecoveryRescuesPrimal,
+    // Dual (growth-gated): the working factor's growth signal flagged possible
+    // digit loss at the optimality gate, triggering a fresh refined recompute
+    // (Attempts); Rescues = how many revealed a hidden infeasibility and so
+    // *prevented* a wrong "Optimal" (returning None → cold solve). A non-rescue
+    // Attempt still certified Optimal, but with the sharper x_B values.
+    RefinedRecoveryAttemptsDual,
+    RefinedRecoveryRescuesDual,
 );
 
 #[inline(always)]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -8533,14 +8533,16 @@ def _solve_lp(
     time_limit: float | None = None,
     prefer_pounce: bool = False,
 ) -> SolveResult:
-    """Solve an LP through the first available engine, then the JAX LP IPM.
+    """Solve an LP through the pure-Rust simplex (then POUNCE if installed).
 
-    Engine order is Rust simplex -> POUNCE -> JAX IPM, or POUNCE -> Rust simplex
-    -> JAX IPM when ``prefer_pounce`` is set (the user passed
-    ``nlp_solver="pounce"``, i.e. asked for POUNCE everywhere; roadmap P0.4). The
-    pure-JAX IPM struggles on problems whose declared bounds exceed ~1e15 (it
-    returns NaN via Newton blow-up on unbounded variables); the simplex and
-    POUNCE both handle unbounded columns natively, so the IPM is the last resort.
+    Engine order is Rust simplex -> POUNCE, or POUNCE -> Rust simplex when
+    ``prefer_pounce`` is set (the user passed ``nlp_solver="pounce"``). The
+    fragile JAX LP-IPM last resort was **retired** in issue #364: the hardened
+    pure-Rust simplex (iterative refinement, condition/growth signals, dual
+    anti-cycling, EXPAND anti-degeneracy) is the single robust LP engine, so a
+    genuine simplex(+POUNCE) failure now reports an honest ``error`` rather than
+    falling to the IPM — which returned NaN via Newton blow-up on declared bounds
+    exceeding ~1e15, i.e. was never a sound last resort.
     """
     engines = [_solve_lp_simplex, _solve_lp_pounce]
     if prefer_pounce:
@@ -8550,49 +8552,19 @@ def _solve_lp(
         if result is not None:
             return result
 
-    from discopt._jax.lp_ipm import lp_ipm_solve
-    from discopt._jax.problem_classifier import extract_lp_data
-
-    t_jax_start = time.perf_counter()
-    lp_data = extract_lp_data(model)
-    state = lp_ipm_solve(lp_data.c, lp_data.A_eq, lp_data.b_eq, lp_data.x_l, lp_data.x_u)
-    jax_time = time.perf_counter() - t_jax_start
+    # Single robust engine (issue #364): no JAX LP-IPM fallback. Both the simplex
+    # and POUNCE (if installed) returned None — a binding that is unavailable or a
+    # genuine numerical failure — so report it honestly instead of trusting the
+    # IPM's large-bound NaN. The Rust simplex is always built in, so in practice
+    # this is only reached on a true solve failure the IPM could not have fixed.
     wall_time = time.perf_counter() - t_start
-
-    from discopt.modeling.core import ObjectiveSense
-
-    n_orig = sum(v.size for v in model._variables)
-    x_flat = np.asarray(state.x[:n_orig])
-    obj_val = float(state.obj) + lp_data.obj_const
-
-    # Negate objective back for maximization (LP solver always minimizes)
-    assert model._objective is not None
-    if model._objective.sense == ObjectiveSense.MAXIMIZE:
-        obj_val = -obj_val
-
-    conv = int(state.converged)
-    if conv in (1, 2):
-        status = "optimal"
-    elif conv == 3:
-        status = "iteration_limit"
-    else:
-        status = "error"
-
-    sr = SolveResult(
-        status=status,
-        objective=obj_val,
-        bound=obj_val if status == "optimal" else None,
-        gap=_optimal_relative_gap(obj_val) if status == "optimal" else None,
-        x=_unpack_solution(model, x_flat),
+    return SolveResult(
+        status="error",
+        objective=None,
+        bound=None,
         wall_time=wall_time,
         node_count=0,
-        rust_time=0.0,
-        jax_time=jax_time,
-        python_time=wall_time - jax_time,
     )
-    # LPs are convex by definition; mark for parity with the QP/NLP fast paths.
-    sr.convex_fast_path = True
-    return sr
 
 
 def _solve_lp_simplex(


### PR DESCRIPTION
## Summary

Hardens discopt's pure-Rust LP engine toward the "single robust engine, no fallback chain" goal of #364, and retires the first (fragile) fallback. Every step was measured on the ill-conditioned lifted-LP corpus (nvs05/20/22/st_e36) and validated against the soundness gauntlet — no step regressed correctness.

Depends on unreleased **feral** APIs (#93/#94/#95), so the crate is temporarily pinned to a git rev; see *Housekeeping* below.

## What landed (7 commits)

1. **Numeric-focus LU infrastructure** (`linsolve.rs`) — opt-in iterative-refined solves (`ftran_refined`/`btran_refined`), a retained basis kept in sync through `update()` (the stale-`b` trap), and `condition_estimate()` / `growth()` / `last_refactor()` signal getters. Default-off = byte-for-byte prior behavior. Also pins feral to a git rev carrying the new LU-hardening APIs.
2. **Primal refined recovery** — on a drifted-Optimal audit failure, recompute `x_B` from a fresh refinement-polished factorization and re-audit before giving up. Sound by construction (same audit gates the result).
3. **Dual growth-gated recovery** — the same recovery at the dual optimality gate, gated on the feral#93 growth signal so benign nodes pay nothing.
4. **Residual-vs-bounds gate + split counters** — measurement showed the primal recovery was firing on Harris bound *excursions* (which refinement can't fix). Now it only fires on genuine `Ax=b` residual failures; counters split by path.
5. **Dual anti-cycling** — stall counter + Bland's smallest-index rule (leaving *and* entering), so a degenerate cycle is broken in place instead of timing out into the cold fallback.
6. **EXPAND anti-degeneracy** — expanding Harris tolerance + guaranteed minimum step. **Primal degenerate pivots 25,685 → 1,676 (~15×)** with identical objectives — the one change that meaningfully moved the numbers.
7. **Retire the JAX LP-IPM fallback** from the standalone `_solve_lp` path — the fragile last resort (NaN on >1e15 bounds) the issue names as first to retire. Genuine simplex(+POUNCE) failure now returns an honest `error`.

## Measurement highlights (the "measure, don't assume" theme)

| Mechanism | Measured effect on the corpus |
|---|---|
| Primal refined recovery | fires ~30×/solve, **0 rescues** (bounds excursions correctly skipped after commit 4) |
| Dual growth-gated recovery | fires 1–7×/solve, **rescues ~1** (prevents a wrong Optimal) |
| Dual anti-cycling | 14,870 degenerate dual pivots, **0 Bland activations** (never needed — pure termination guarantee) |
| **EXPAND** | **degenerate pivots 25,685 → 1,676 (~15×), 2,984 min-steps, same objectives** |

Takeaway: the recovery/anti-cycling mechanisms are cheap insurance the current corpus rarely needs (the existing equilibration + safe-bound machinery already keeps it sound); **EXPAND is the real throughput win**.

## Validation

- Rust: **353/353** lib tests, clippy + fmt clean at every commit.
- Python soundness gauntlet (sound/simplex/safe_bound/lp/relaxation/cert/milp/warm/branch, +obbt/pounce on the last commit): **1643–1746 passed, 0 failed** at every step, including nvs05/nvs22 bucket2 soundness on the simplex backend.
- Objectives on the corpus unchanged throughout (nvs05=5.47093412640568, nvs20=230.92216300555506, nvs22=6.0582199416…, st_e36=−246.0).

## Scope / not in this PR

"Retire the fallback chain" is several distinct things, not one chain. This PR retires **only** the fragile JAX LP-IPM from `_solve_lp`. Deliberately left for a follow-up (each is a judgment call about supported configurations, not a mechanical deletion):

- **POUNCE** as the LP/MILP selector fallback — decide whether "POUNCE-only, no Rust" is still supported.
- The other `lp_ipm_solve` sites (per-node relaxer, `differentiable_solve`, batch) — several are *primary* JAX-native engines, not fallbacks; each needs a measure-first audit before removal.

## Housekeeping ⚠️

`crates/discopt-core/Cargo.toml` pins **feral to a git rev** (`a17fb7a…`) because the LU-hardening APIs (feral #93/#94/#95) are merged but unreleased. **Before this can ship from crates.io, feral must publish 0.11.4 and this pin must revert to `feral = "0.11.4"`.** A git dependency will not build in a crates.io release.

## References
- Closes progress on #364. Builds on #356 (HiGHS removal), #357 (N–S safe bound, Farkas certs).
- Upstream feral: jkitchin/feral #93 (growth getter), #94 (LU condition estimate), #95 (richer `update()` signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
