### PR TITLE
Retire the JAX LP-IPM from all production paths (#370)

### DIFF
--- a/python/discopt/_jax/differentiable_solve.py
+++ b/python/discopt/_jax/differentiable_solve.py
@@ -122,8 +122,8 @@ def _solve_objective(model: Model, problem_class: ProblemClass) -> float | None:
     try:
         if problem_class == ProblemClass.LP:
             lp_data = extract_lp_data(model)
-            obj, _ = _lp_forward(lp_data)
-            return obj + lp_data.obj_const
+            lp_obj, _ = _lp_forward(lp_data)
+            return lp_obj + lp_data.obj_const
         elif problem_class == ProblemClass.QP:
             qp_data = extract_qp_data(model)
             from discopt._jax.qp_ipm import qp_ipm_solve

--- a/python/discopt/_jax/differentiable_solve.py
+++ b/python/discopt/_jax/differentiable_solve.py
@@ -100,15 +100,30 @@ class UnifiedDiffResult:
         return self.relaxation_obj
 
 
+def _lp_forward(lp_data) -> tuple[float, np.ndarray]:
+    """Forward LP solve for the differentiable path: POUNCE's interior-point KKT
+    solve, returning ``(obj, x)`` in the raw (no ``obj_const``) convention.
+
+    This is the same interior-point forward solver ``differentiable_lp`` uses for
+    its ``custom_jvp`` sensitivity (POUNCE returns the analytic center, so the KKT
+    system stays nonsingular). The pure-JAX ``lp_ipm_solve`` it replaced was
+    retired in #370 — differentiability comes from the implicit-KKT gradient, not
+    from the forward solver. Raises ``ImportError`` if POUNCE is unavailable (the
+    callers already wrap this in ``try``).
+    """
+    from discopt.solvers.lp_pounce import solve_lp_kkt
+
+    obj, x, *_ = solve_lp_kkt(lp_data.c, lp_data.A_eq, lp_data.b_eq, lp_data.x_l, lp_data.x_u)
+    return float(obj), np.asarray(x)
+
+
 def _solve_objective(model: Model, problem_class: ProblemClass) -> float | None:
     """Solve a model and return just the objective value."""
     try:
         if problem_class == ProblemClass.LP:
             lp_data = extract_lp_data(model)
-            from discopt._jax.lp_ipm import lp_ipm_solve
-
-            state = lp_ipm_solve(lp_data.c, lp_data.A_eq, lp_data.b_eq, lp_data.x_l, lp_data.x_u)
-            return float(state.obj) + lp_data.obj_const
+            obj, _ = _lp_forward(lp_data)
+            return obj + lp_data.obj_const
         elif problem_class == ProblemClass.QP:
             qp_data = extract_qp_data(model)
             from discopt._jax.qp_ipm import qp_ipm_solve
@@ -180,13 +195,11 @@ def differentiable_solve(
 
     if problem_class == ProblemClass.LP:
         lp_data = extract_lp_data(model)
-        from discopt._jax.lp_ipm import lp_ipm_solve
-
-        state = lp_ipm_solve(lp_data.c, lp_data.A_eq, lp_data.b_eq, lp_data.x_l, lp_data.x_u)
-        x_flat = np.asarray(state.x[:n_orig])
+        obj, x = _lp_forward(lp_data)
+        x_flat = np.asarray(x[:n_orig])
         return UnifiedDiffResult(
-            status="optimal" if int(state.converged) in (1, 2) else "iteration_limit",
-            objective=float(state.obj) + lp_data.obj_const,
+            status="optimal",
+            objective=obj + lp_data.obj_const,
             x=x_flat,
             x_dict=_unpack_solution(model, x_flat),
             problem_class=problem_class,
@@ -226,16 +239,7 @@ def differentiable_solve(
         try:
             if problem_class == ProblemClass.MILP:
                 lp_data = extract_lp_data(model)
-                from discopt._jax.lp_ipm import lp_ipm_solve
-
-                relax_state = lp_ipm_solve(
-                    lp_data.c,
-                    lp_data.A_eq,
-                    lp_data.b_eq,
-                    lp_data.x_l,
-                    lp_data.x_u,
-                )
-                relaxation_obj = float(relax_state.obj)
+                relaxation_obj, _ = _lp_forward(lp_data)
             else:
                 qp_data = extract_qp_data(model)
                 from discopt._jax.qp_ipm import qp_ipm_solve

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -10223,49 +10223,38 @@ def _cut_loop_relaxation_x(lp_data, prefer_pounce: bool):
     """Solve the (cut-augmented) root relaxation for the cut loop, returning the
     optimum ``x`` or ``None``.
 
-    In POUNCE mode the solve goes through POUNCE so the cut-augmented shape costs
-    no JAX recompile (consistent with the Path-B node engine); otherwise the JAX
-    IPM is used. Either way the returned point is just a separation seed —
-    crossover and cut validity do not depend on which engine produced it."""
-    if prefer_pounce:
-        try:
-            from discopt.solvers.lp_pounce import POUNCE_AVAILABLE
-            from discopt.solvers.lp_pounce import solve_lp as _pounce_solve
-        except ImportError:
-            POUNCE_AVAILABLE = False
-        if POUNCE_AVAILABLE:
-            try:
-                res = _pounce_solve(
-                    c=np.asarray(lp_data.c, dtype=np.float64),
-                    A_eq=np.asarray(lp_data.A_eq, dtype=np.float64),
-                    b_eq=np.asarray(lp_data.b_eq, dtype=np.float64),
-                    bounds=list(
-                        zip(
-                            np.asarray(lp_data.x_l, dtype=np.float64).tolist(),
-                            np.asarray(lp_data.x_u, dtype=np.float64).tolist(),
-                        )
-                    ),
-                )
-            except Exception as exc:
-                logger.debug("cut-loop POUNCE solve failed: %s", exc)
-                return None
-            if res.status == SolveStatus.OPTIMAL and res.x is not None:
-                return np.asarray(res.x, dtype=np.float64)
-            return None
-    import jax.numpy as jnp
-
-    from discopt._jax.lp_ipm import lp_ipm_solve
-
-    state = lp_ipm_solve(
-        jnp.asarray(lp_data.c),
-        jnp.asarray(lp_data.A_eq),
-        jnp.asarray(lp_data.b_eq),
-        jnp.asarray(lp_data.x_l),
-        jnp.asarray(lp_data.x_u),
-    )
-    if int(state.converged) != 1:
+    The seed always goes through POUNCE so the cut-augmented shape costs no JAX
+    recompile (consistent with the Path-B node engine); the JAX-IPM seed was
+    retired in #370. The returned point is just a separation seed — crossover and
+    cut validity do not depend on which engine produced it — so if POUNCE is
+    unavailable the cut loop is simply skipped (``None``). ``prefer_pounce`` is
+    kept for call-site symmetry."""
+    del prefer_pounce
+    try:
+        from discopt.solvers.lp_pounce import POUNCE_AVAILABLE
+        from discopt.solvers.lp_pounce import solve_lp as _pounce_solve
+    except ImportError:
         return None
-    return np.asarray(state.x, dtype=np.float64)
+    if not POUNCE_AVAILABLE:
+        return None
+    try:
+        res = _pounce_solve(
+            c=np.asarray(lp_data.c, dtype=np.float64),
+            A_eq=np.asarray(lp_data.A_eq, dtype=np.float64),
+            b_eq=np.asarray(lp_data.b_eq, dtype=np.float64),
+            bounds=list(
+                zip(
+                    np.asarray(lp_data.x_l, dtype=np.float64).tolist(),
+                    np.asarray(lp_data.x_u, dtype=np.float64).tolist(),
+                )
+            ),
+        )
+    except Exception as exc:
+        logger.debug("cut-loop POUNCE solve failed: %s", exc)
+        return None
+    if res.status == SolveStatus.OPTIMAL and res.x is not None:
+        return np.asarray(res.x, dtype=np.float64)
+    return None
 
 
 def _root_cover_cut_loop(
@@ -10470,34 +10459,10 @@ def _root_dive(
             xu[j] = v
         return None
 
-    import jax.numpy as jnp
-
-    from discopt._jax.lp_ipm import lp_ipm_solve
-
-    xl = np.asarray(lp_data.x_l, dtype=np.float64).copy()
-    xu = np.asarray(lp_data.x_u, dtype=np.float64).copy()
-    c = jnp.asarray(lp_data.c)
-    A = jnp.asarray(lp_data.A_eq)
-    b = jnp.asarray(lp_data.b_eq)
-    steps = max_steps if max_steps is not None else len(int_idx) + 1
-    for _ in range(steps):
-        if time.perf_counter() - t_start >= time_limit:
-            return None
-        state = lp_ipm_solve(c, A, b, jnp.asarray(xl), jnp.asarray(xu))
-        if int(state.converged) != 1:
-            return None  # infeasible/stalled fix -> abandon the dive
-        x = np.asarray(state.x)
-        fracs = [
-            (j, abs(x[j] - round(x[j])))
-            for j in int_idx
-            if xl[j] != xu[j] and abs(x[j] - round(x[j])) > 1e-6
-        ]
-        if not fracs:
-            return float(state.obj) + float(lp_data.obj_const), x[:n_orig]
-        j = max(fracs, key=lambda t: t[1])[0]
-        v = float(round(x[j]))
-        xl[j] = v
-        xu[j] = v
+    # No structured node engine selected: the root dive (an optional
+    # early-incumbent heuristic) is skipped. The JAX-IPM dive was retired (#370);
+    # on the default path this branch is unreachable — node_engine is always
+    # "simplex" (or prefer_pounce is set), so the structured dive above runs.
     return None
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3589,7 +3589,11 @@ def solve_model(
                 max_nodes,
                 t_start,
                 prefer_pounce=_pounce_only,
-                node_engine="simplex" if _pounce_only else "pounce",
+                # Node LP relaxations are linear — always solve them with the
+                # structured engine (exact-vertex Rust simplex, degrading to
+                # POUNCE), regardless of nlp_solver. nlp_solver governs only the
+                # NLP subproblem solver. The JAX LP-IPM node path was retired (#370).
+                node_engine="simplex",
                 lagrangian_bound=lagrangian_bound,
                 lagrangian_frequency=lagrangian_frequency,
             )
@@ -10709,9 +10713,7 @@ def _solve_milp_bb(
     auxiliary root cut-loop / dual recovery stay on POUNCE either way; only the
     hot per-node solve changes.
     """
-    import jax.numpy as jnp
 
-    from discopt._jax.lp_ipm import lp_ipm_solve
     from discopt._jax.problem_classifier import extract_lp_data
 
     rust_time = 0.0
@@ -10930,14 +10932,17 @@ def _solve_milp_bb(
     # simplex by default, or the POUNCE IPM. Checked once here. POUNCE
     # availability is still tracked because the dual recovery path uses it.
     _pounce_nodes_avail = False
-    if prefer_pounce:
-        try:
-            from discopt.solvers.lp_pounce import POUNCE_AVAILABLE as _PNA
+    try:
+        from discopt.solvers.lp_pounce import POUNCE_AVAILABLE as _PNA
 
-            _pounce_nodes_avail = bool(_PNA)
-        except ImportError:
-            _pounce_nodes_avail = False
-    _structured_avail = _simplex_nodes or (prefer_pounce and _pounce_nodes_avail)
+        _pounce_nodes_avail = bool(_PNA)
+    except ImportError:
+        _pounce_nodes_avail = False
+    # The structured engine (Rust simplex, or POUNCE as fallback) is the only node
+    # LP engine — the JAX LP-IPM node path was retired (#370). POUNCE now counts as
+    # a structured fallback regardless of prefer_pounce, so a no-Rust install still
+    # solves nodes with an exact/KKT-valid engine instead of the retired IPM.
+    _structured_avail = _simplex_nodes or _pounce_nodes_avail
 
     iteration = 0
     while True:
@@ -10955,7 +10960,6 @@ def _solve_milp_bb(
 
         t_jax_start = time.perf_counter()
         result_ids = np.array(batch_ids, dtype=np.int64)
-        n_slack = lp_data.x_l.shape[0] - n_orig
 
         if _structured_avail:
             # Path B: solve each node's relaxation with the structured engine
@@ -10983,112 +10987,15 @@ def _solve_milp_bb(
                     result_lbs[i] = _INFEASIBILITY_SENTINEL
                     result_sols[i] = _mid
                     _recover_or_decertify(i, result_lbs, result_sols, node_lb, node_ub)
-        elif n_batch > 1:
-            # Batch LP solve via vmap
-            from discopt._jax.lp_ipm import lp_ipm_solve_batch
-
-            xl_arr = jnp.array(batch_lb, dtype=jnp.float64)
-            xu_arr = jnp.array(batch_ub, dtype=jnp.float64)
-            slack_l = jnp.zeros((n_batch, n_slack), dtype=jnp.float64)
-            slack_u = jnp.full((n_batch, n_slack), 1e20, dtype=jnp.float64)
-            xl_full = jnp.concatenate([xl_arr, slack_l], axis=1)
-            xu_full = jnp.concatenate([xu_arr, slack_u], axis=1)
-
-            try:
-                state = lp_ipm_solve_batch(lp_data.c, lp_data.A_eq, lp_data.b_eq, xl_full, xu_full)
-                converged = np.asarray(state.converged)
-                obj_vals = np.asarray(state.obj)
-                x_vals = np.asarray(state.x)
-
-                ok = (converged == 1) | (converged == 2) | (converged == 3)
-                result_lbs = np.asarray(
-                    np.where(ok, obj_vals + float(lp_data.obj_const), _INFEASIBILITY_SENTINEL),
-                    dtype=np.float64,
-                )
-                result_sols = np.empty((n_batch, n_vars), dtype=np.float64)
-                for i in range(n_batch):
-                    if ok[i]:
-                        result_sols[i] = x_vals[i, :n_vars]
-                        # Reject LP solutions that violate constraints
-                        if not _check_lp_solution_feasibility(
-                            lp_data.A_eq, lp_data.b_eq, x_vals[i]
-                        ):
-                            result_lbs[i] = _INFEASIBILITY_SENTINEL
-                            lb_c = np.clip(np.array(batch_lb[i]), -_SPC, _SPC)
-                            ub_c = np.clip(np.array(batch_ub[i]), -_SPC, _SPC)
-                            result_sols[i] = 0.5 * (lb_c + ub_c)
-                        else:
-                            _maybe_inject_snapped(
-                                result_sols[i],
-                                np.array(batch_lb[i]),
-                                np.array(batch_ub[i]),
-                            )
-                    else:
-                        lb_c = np.clip(np.array(batch_lb[i]), -_SPC, _SPC)
-                        ub_c = np.clip(np.array(batch_ub[i]), -_SPC, _SPC)
-                        result_sols[i] = 0.5 * (lb_c + ub_c)
-                # Non-KKT (max-iter) LP bounds are recovered via POUNCE;
-                # unrecoverable ones decertify the gap.
-                for i in np.where((converged == 3) & (result_lbs < _SENTINEL_THRESHOLD))[0]:
-                    _recover_or_decertify(
-                        int(i),
-                        result_lbs,
-                        result_sols,
-                        np.array(batch_lb[i]),
-                        np.array(batch_ub[i]),
-                    )
-            except Exception as e:
-                logger.debug("Batch LP solve failed: %s", e)
-                result_lbs = np.full(n_batch, _INFEASIBILITY_SENTINEL, dtype=np.float64)
-                result_sols = np.empty((n_batch, n_vars), dtype=np.float64)
-                for i in range(n_batch):
-                    lb_c = np.clip(np.array(batch_lb[i]), -_SPC, _SPC)
-                    ub_c = np.clip(np.array(batch_ub[i]), -_SPC, _SPC)
-                    result_sols[i] = 0.5 * (lb_c + ub_c)
-            result_feas = np.zeros(n_batch, dtype=bool)
         else:
-            result_lbs = np.empty(n_batch, dtype=np.float64)
-            result_sols = np.empty((n_batch, n_vars), dtype=np.float64)
-            result_feas = np.zeros(n_batch, dtype=bool)
-
-            for i in range(n_batch):
-                node_lb = np.array(batch_lb[i])
-                node_ub = np.array(batch_ub[i])
-
-                x_l_node = jnp.array(node_lb, dtype=jnp.float64)
-                x_u_node = jnp.array(node_ub, dtype=jnp.float64)
-
-                x_l_full = jnp.concatenate([x_l_node, jnp.zeros(n_slack)])
-                x_u_full = jnp.concatenate([x_u_node, jnp.full(n_slack, 1e20)])
-
-                try:
-                    state = lp_ipm_solve(lp_data.c, lp_data.A_eq, lp_data.b_eq, x_l_full, x_u_full)
-                    conv = int(state.converged)
-                    if conv in (1, 2, 3):
-                        # Reject LP solutions that violate constraints
-                        if _check_lp_solution_feasibility(lp_data.A_eq, lp_data.b_eq, state.x):
-                            result_lbs[i] = float(state.obj) + lp_data.obj_const
-                            result_sols[i] = np.asarray(state.x[:n_vars])
-                            if conv == 3:  # non-KKT: recover via POUNCE
-                                _recover_or_decertify(i, result_lbs, result_sols, node_lb, node_ub)
-                            if result_lbs[i] < _SENTINEL_THRESHOLD:
-                                _maybe_inject_snapped(result_sols[i], node_lb, node_ub)
-                        else:
-                            result_lbs[i] = _INFEASIBILITY_SENTINEL
-                            lb_c = np.clip(node_lb, -_SPC, _SPC)
-                            ub_c = np.clip(node_ub, -_SPC, _SPC)
-                            result_sols[i] = 0.5 * (lb_c + ub_c)
-                    else:
-                        result_lbs[i] = _INFEASIBILITY_SENTINEL
-                        lb_c = np.clip(node_lb, -_SPC, _SPC)
-                        ub_c = np.clip(node_ub, -_SPC, _SPC)
-                        result_sols[i] = 0.5 * (lb_c + ub_c)
-                except Exception as e:
-                    logger.debug("Per-node LP/QP solve failed: %s", e)
-                    result_lbs[i] = _INFEASIBILITY_SENTINEL
-                    lb_c = np.clip(node_lb, -_SPC, _SPC)
-                    ub_c = np.clip(node_ub, -_SPC, _SPC)
-                    result_sols[i] = 0.5 * (lb_c + ub_c)
+            # The JAX LP-IPM node path was retired (#370). Node LP relaxations
+            # use the structured engine (Rust simplex, or POUNCE); reaching here
+            # means neither is available — an unsupported configuration.
+            raise RuntimeError(
+                "No structured node LP engine available (Rust simplex or POUNCE). "
+                "The JAX LP-IPM node fallback was retired in #370; build the Rust "
+                "extension or install POUNCE."
+            )
 
         # Lagrangian node bounds: combine a valid dual lower bound with each
         # node's LP relaxation bound. Gated by cadence and applied only to nodes

--- a/python/tests/test_p1_milp_bb_soundness.py
+++ b/python/tests/test_p1_milp_bb_soundness.py
@@ -80,33 +80,12 @@ def _force_code3(monkeypatch, module, name):
 
 class TestNonKKTRecoveredByPounce:
     """Increment 2: a stalled (code-3) node is re-solved with POUNCE, whose
-    KKT-valid optimum restores the bound — the solve certifies normally."""
+    KKT-valid optimum restores the bound — the solve certifies normally.
 
-    def test_milp_batch_non_kkt_recovered(self, monkeypatch):
-        import pytest as _pytest
-
-        _pytest.importorskip("pounce")
-        import discopt._jax.lp_ipm as lp_ipm
-
-        # batch_size=8 lets the tree export >1 node -> batch LP path.
-        _force_code3(monkeypatch, lp_ipm, "lp_ipm_solve_batch")
-        r = _knapsack_milp().solve(time_limit=60, batch_size=8)
-        assert r.status == "optimal"
-        assert r.gap_certified is True
-        assert abs(r.objective - (-8.0)) < 1e-4
-
-    def test_milp_serial_non_kkt_recovered(self, monkeypatch):
-        import pytest as _pytest
-
-        _pytest.importorskip("pounce")
-        import discopt._jax.lp_ipm as lp_ipm
-
-        # batch_size=1 forces the serial per-node LP path.
-        _force_code3(monkeypatch, lp_ipm, "lp_ipm_solve")
-        r = _knapsack_milp().solve(time_limit=60, batch_size=1)
-        assert r.status == "optimal"
-        assert r.gap_certified is True
-        assert abs(r.objective - (-8.0)) < 1e-4
+    The MILP variants were removed in #370: MILP node LP relaxations now always
+    solve with the structured engine (exact-vertex Rust simplex), which cannot
+    produce a non-KKT (code-3) node, so there is no such scenario to recover.
+    The MIQP case still exercises the QP node path."""
 
     def test_miqp_batch_non_kkt_recovered(self, monkeypatch):
         import pytest as _pytest
@@ -122,38 +101,13 @@ class TestNonKKTRecoveredByPounce:
 
 
 class TestNonKKTDecertifiesWhenUnrecoverable:
-    """When POUNCE recovery also fails, the gap must not be certified."""
+    """When POUNCE recovery also fails, the gap must not be certified.
 
-    def test_milp_batch_decertifies(self, monkeypatch):
-        import discopt._jax.lp_ipm as lp_ipm
-
-        # Disable root cover cuts: they solve this knapsack at the (serial)
-        # root, so the batch path under test would never run. Decertification
-        # is orthogonal to cutting.
-        monkeypatch.setattr(S, "_root_cover_cut_loop", lambda ld, *a, **k: (ld, 0))
-        _force_code3(monkeypatch, lp_ipm, "lp_ipm_solve_batch")
-        monkeypatch.setattr(S, "_pounce_recover_node_bound", lambda *a, **k: None)
-        # nlp_solver="ipm" exercises the JAX-IPM node path under test (the new
-        # default, "pounce", solves nodes via POUNCE, bypassing lp_ipm).
-        r = _knapsack_milp().solve(nlp_solver="ipm", time_limit=60, batch_size=8)
-        # Bounds are the real LP optima (just relabeled non-KKT), so the answer
-        # is still found, but optimality must not be certified.
-        assert r.gap_certified is False
-        assert r.status == "feasible"
-        assert r.bound is None and r.gap is None
-        assert abs(r.objective - (-8.0)) < 1e-4  # incumbent still correct
-
-    def test_milp_serial_decertifies(self, monkeypatch):
-        import discopt._jax.lp_ipm as lp_ipm
-
-        _force_code3(monkeypatch, lp_ipm, "lp_ipm_solve")
-        monkeypatch.setattr(S, "_pounce_recover_node_bound", lambda *a, **k: None)
-        # nlp_solver="ipm" exercises the JAX-IPM node path under test (the new
-        # default, "pounce", solves nodes via POUNCE, bypassing lp_ipm).
-        r = _knapsack_milp().solve(nlp_solver="ipm", time_limit=60, batch_size=1)
-        assert r.gap_certified is False
-        assert r.status == "feasible"
-        assert abs(r.objective - (-8.0)) < 1e-4
+    The MILP variants were removed in #370: with the JAX LP-IPM node path
+    retired, MILP nodes solve on the exact-vertex Rust simplex, which never
+    yields a non-KKT bound to decertify — so ``nlp_solver="ipm"`` MILP now
+    certifies normally (see TestPounceOnlyRouting::test_ipm_alias_milp_*). The
+    MIQP case remains, exercising the QP node path."""
 
     def test_miqp_batch_decertifies(self, monkeypatch):
         # MIQP node relaxations now solve via POUNCE (the JAX QP IPM is gone).

--- a/python/tests/test_root_dive.py
+++ b/python/tests/test_root_dive.py
@@ -32,7 +32,19 @@ class TestRootDive:
     def test_finds_integer_feasible_incumbent(self):
         m = _knapsack()
         ld = extract_lp_data(m)
-        dive = _root_dive(ld, 5, list(range(5)), time.perf_counter(), 30.0)
+        # The structured dive (exact-vertex Rust simplex) is the only engine after
+        # #370 retired the JAX-IPM dive; it needs the structural node bounds.
+        dive = _root_dive(
+            ld,
+            5,
+            list(range(5)),
+            time.perf_counter(),
+            30.0,
+            n_vars=5,
+            lb=np.zeros(5),
+            ub=np.ones(5),
+            node_engine="simplex",
+        )
         assert dive is not None
         obj, x = dive
         # All integer columns are exactly integral.


### PR DESCRIPTION
## Summary

Retires the pure-JAX LP interior-point method (`lp_ipm_solve` / `lp_ipm_solve_batch`) from **all production paths** — the second half of #364's "retire the fallback chain" (the first half, the JAX LP-IPM last resort in `_solve_lp`, landed in #368). Differentiability is unaffected: it already comes from implicit-KKT (IFT), not from unrolling the IPM.

Implements the agreed architecture decision: **B&B node LP relaxations always solve on the structured engine (exact-vertex Rust simplex, degrading to POUNCE); `nlp_solver` governs only the NLP subproblem solver.** The code comment already argued this — "an interior-point method is the wrong tool for the *linear* node LPs."

Net **−158 lines**. **POUNCE is kept** — it is the NLP solver for MINLP subproblems and the interior-point forward solver the differentiable LP/QP layers require.

## What changed (4 commits)

1. **`differentiable_solve` LP forward → POUNCE.** The unified differentiable dispatcher solved its LP forward with `lp_ipm_solve` in three spots; these now route through POUNCE's `solve_lp_kkt` (analytic center) — the same forward solver `differentiable_lp`'s `custom_jvp` already uses. Gradients are the implicit-KKT sensitivity, so nothing about differentiation changes.
2. **Node LP relaxations → structured engine.** The MILP/MINLP dispatch always passes `node_engine="simplex"`; `_structured_avail` treats POUNCE as a structured fallback (no longer gated on `prefer_pounce`); the two JAX-IPM node branches in `_solve_milp_bb` collapse to an `else: raise` (unsupported no-Rust-no-POUNCE config). `nlp_solver="ipm"` MILP nodes now solve exactly (KKT-valid bound) instead of via the JAX IPM.
3. **Root cut-loop + root dive → structured.** The cut-loop separation seed always uses POUNCE (skipped if unavailable — it is only a seed); the root dive uses the structured engine (skipped if none selected). These were the last two production JAX-IPM uses.
4. **Test:** `_root_dive` unit test updated to the structured engine.

Obsolete tests removed: the 4 MILP `lp_ipm` non-KKT tests in `test_p1_milp_bb_soundness.py` (they exercised the JAX-IPM node path's code-3 behavior, which the exact-vertex simplex cannot produce). The MIQP variants stay (the QP node path is separate, out of this PR's LP scope).

## Result

`python/discopt/` now has **no `lp_ipm` import or call** — only docstring references. The `nlp_solver="ipm"` MILP path is strictly more accurate (exact vertex vs. interior-point node bound).

## Validation

- Full soundness gauntlet (sound/simplex/safe_bound/lp/relaxation/cert/milp/warm/branch/obbt/pounce/ipm/crossover/deadline/dive): **1778 passed, 2 skipped, 0 failed**.
- BARON head-to-head smoke: **3/3 ok, 0 violations**; `nvs01` MINLP + `nlp_solver=ipm`/`pounce` MILP all solve to the correct optimum.
- Differentiable / parametric / estimate / DoE consumers: green (138 + 190).
- `test_milp_bb_pounce_no_jax_ipm`, `test_t24_batch_ipm`, `lp_backend_seam`, `orchestrator`, `amp` and the other JAX-IPM-adjacent files: green.
- ruff clean throughout.

## Not in this PR (tracked follow-up)

The `lp_ipm.py` module still exists — it is now imported **only by tests**: direct unit tests of the module (`test_t24_batch_ipm`, LP-IPM cases in `test_lp_qp_solvers`), test utilities that use it to generate an interior point (`test_crossover`, `test_rust_crossover`, `test_deadline`), and one that asserts it is *not* called (`test_milp_bb_pounce_no_jax_ipm`). Deleting the module is a mechanical but soundness-adjacent test cleanup, left as a fast follow so it can be done with care rather than rushed. The QP JAX-IPM (`qp_ipm.py`) is out of scope (this is the LP-IPM retirement).

## References
- Closes the production-path half of #370; completes the fallback-chain retirement started in #364 / #368.
- Differentiable layers: `_jax/differentiable_lp.py` (POUNCE + `custom_jvp`), `_jax/differentiable_qp.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
