### PR TITLE
chore(deps): pin feral to crates.io 0.12.0 (drop git-rev pin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,8 +77,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "feral"
-version = "0.11.3"
-source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef91918cdb92a5ea18d2a40563014b84102ec41ebf621fe4a5c0d9d337d59326"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -95,7 +96,8 @@ dependencies = [
 [[package]]
 name = "feral-amd"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead2f064dbcef0e0d3110202e9d6d7c293c1dffe6da5964513a20c5967e4d560"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -103,7 +105,8 @@ dependencies = [
 [[package]]
 name = "feral-amf"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ea6dacabfa085e7f40080c894da245d9db60e9211f1f8ab08d715d6d0f5a29"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -111,7 +114,8 @@ dependencies = [
 [[package]]
 name = "feral-kahip"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ba0d001a63e777227de4565c7f4cd14062b9fbe83d3cadcb292be74410b4f4"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -121,7 +125,8 @@ dependencies = [
 [[package]]
 name = "feral-metis"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b34963682eaf680479bfd6018a5570bfd1ed9c1f05d8bf085ab49f13b308cb"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -130,12 +135,14 @@ dependencies = [
 [[package]]
 name = "feral-ordering-core"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca94ad929e23c0adaa6edda42474aa71b5b2bfb3930b1f6b202e4b37c8e9b763"
 
 [[package]]
 name = "feral-scotch"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=a17fb7a33427b2b08a8f1777c28b576b260532cd#a17fb7a33427b2b08a8f1777c28b576b260532cd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51fe24bffbef76e88803e801c2d8977f5d304dd6af43f70c1e91fdfabd0b530"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -19,14 +19,13 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # invisible on few-row knapsacks but catastrophic on 800–1500-row covering LPs.
 # `test_setcover_lp_regression.py` guards against a re-downgrade.
 #
-# TEMPORARY git-rev pin (not a crates.io release). HEAD carries the discopt#364
-# LU-hardening APIs merged as feral #96/#98/#97 but NOT yet published: the
-# element-growth getters (growth()/u_max0()), the unsymmetric-LU condition
-# estimate (condition_estimate_1), and the richer update() instability signal
+# 0.12.0 is the first crates.io release carrying the discopt#364 LU-hardening APIs
+# (feral #93/#94/#95) the numeric-focus simplex consumes: the element-growth
+# getters (growth()/u_max0()), the unsymmetric-LU condition estimate
+# (condition_estimate_1), and the richer update() instability signal
 # (RefactorCause + last_refactor() + growth-aware/dense-parity should_refactor).
-# feral HEAD still reports version 0.11.3, so crates.io can't carry these yet.
-# SWAP BACK to `feral = "0.11.4"` once that release is published.
-feral = { git = "https://github.com/jkitchin/feral", rev = "a17fb7a33427b2b08a8f1777c28b576b260532cd" }
+# It replaces the temporary git-rev pin used while those APIs were unreleased.
+feral = "0.12.0"
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to
 # 1.10 to keep the crate's MSRV (1.75); 1.12+ requires rustc 1.80.


### PR DESCRIPTION
## Summary

Pins `feral` to the published crates.io **0.12.0** release, dropping the temporary git-rev pin that was in place while the discopt#364 LU-hardening APIs (feral #93/#94/#95) were unreleased. This unblocks any crates.io release of `discopt-core` — a git dependency cannot be published.

feral 0.12.0 carries those APIs (`growth()`/`u_max0()`, `condition_estimate_1()`, `RefactorCause`/`last_refactor()`) plus additional 0.12.0 work (#99 packed BLAS-3, #102 deadlock fix, #105 ordering escalation). The APIs the numeric-focus simplex consumes are unchanged, so it's a drop-in.

## Validation

- `discopt-core` builds against crates.io 0.12.0; **353/353** lib tests pass; clippy clean.
- Extension rebuilt; BARON smoke **3/3 ok, 0 violations**.
- Soundness gauntlet (sound/simplex/safe_bound/lp/relaxation/cert/milp/warm/branch/obbt/setcover): **1676 passed, 2 skipped, 0 failed** — the LU numeric/ordering changes in 0.12.0 preserve soundness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
