### PR TITLE
feat(profile): warm→cold dual fallback counters (measure #376 headroom)

### DIFF
--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -288,11 +288,15 @@ impl<'a> PreparedDual<'a> {
     /// `b`, returning a valid solution. On any numerical difficulty it cold-solves
     /// the same LP, so the result is always correct.
     pub fn reoptimize(&self, l: &[f64], u: &[f64], b: &[f64], opts: &SimplexOptions) -> LpSolve {
+        crate::profile::incr(crate::profile::Ctr::DualWarmSolves);
         match self.run_dual(l, u, b, opts) {
             Some(sol) => sol,
             // Cold fallback from the prepared CSC matrix (clone is O(nnz), paid only
             // on the rare numerical-breakdown path) — no dense matrix is kept.
-            None => solve_lp_cols(self.sp.clone(), self.m, self.n, self.c, l, u, b, opts),
+            None => {
+                crate::profile::incr(crate::profile::Ctr::DualColdFallbacks);
+                solve_lp_cols(self.sp.clone(), self.m, self.n, self.c, l, u, b, opts)
+            }
         }
     }
 

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -106,6 +106,13 @@ counters!(
     // were bumped up to the guaranteed EXPAND minimum step (breaking the stall in
     // place instead of accumulating toward the Bland switch).
     ExpandMinSteps,
+    // Warm dual-simplex reoptimizations (DualWarmSolves) and how many of them the
+    // dual could not solve and fell back to a cold primal re-solve (DualColdFallbacks
+    // — numerical breakdown / iteration cap on a *valid* warm start, i.e. the
+    // "engine swap" the framework-LP-error-handling policy of #376 would try to
+    // pre-empt by escalating in place). The ratio is the escalation headroom.
+    DualWarmSolves,
+    DualColdFallbacks,
 );
 
 #[inline(always)]


### PR DESCRIPTION
## Summary

Adds `DualWarmSolves` / `DualColdFallbacks` profiling counters (profiling-gated, zero cost when off) so the warm dual-simplex → cold-primal fallback **rate** is measurable — the escalation headroom the #376 framework-LP-error-handling policy would target.

Used to gate #376: on the ill-conditioned corpus the rate is **1.65%** (726 warm solves, 12 cold fallbacks), and outcomes are already correct (0 violations), so #376 is **deferred** — this counter makes the headroom re-checkable on any future corpus.

## Validation
- discopt-core: 42 simplex tests pass, clippy clean. Behavior-neutral (counters only, gated on `DISCOPT_PROFILE`).

Refs #376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
