### PR TITLE
feat(modeling): implicit-function expression node (m.implicit) — #379

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -57,6 +57,7 @@ parts:
       - file: notebooks/symbolic_envelopes
       - file: notebooks/suspect_head_to_head
       - file: notebooks/nlp_bb
+      - file: notebooks/implicit_function_node
       - file: notebooks/export_formats
       - file: notebooks/model_representations
       - file: notebooks/pyomo_solver

--- a/docs/notebooks/implicit_function_node.ipynb
+++ b/docs/notebooks/implicit_function_node.ipynb
@@ -1,0 +1,293 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2407c9ae",
+   "metadata": {},
+   "source": [
+    "# Implicit-Function Node: Recycle Streams and Algebraic Loops\n",
+    "\n",
+    "Equation-oriented process models routinely contain **algebraic loops** — a\n",
+    "recycle stream whose flow depends on a reactor output that in turn depends on the\n",
+    "recycle. Such a variable is defined only *implicitly*, as the solution of a\n",
+    "square nonlinear system $g(u, v) = 0$ with no closed form {cite:p}`Biegler2010`.\n",
+    "\n",
+    "discopt exposes these through **`m.implicit(...)`**: a vector $v$ defined by\n",
+    "$g(u, v) = 0$ is compiled to a *differentiable inner solve* — a Newton iteration\n",
+    "for the forward map, and **implicit-function-theorem** derivatives for the\n",
+    "reverse, so the outer optimizer sees exact gradients without differentiating\n",
+    "through the Newton iterations {cite:p}`Blondel2022`. This is the core-side\n",
+    "primitive that lets reduced-space **variable aggregation** eliminate irreducible\n",
+    "*cyclic* blocks instead of leaving them in the model {cite:p}`Naik2025`.\n",
+    "\n",
+    "```{note}\n",
+    "An implicitly-defined $\\varphi(u)$ has no McCormick relaxation, so — like any\n",
+    "opaque AD-only node — a model containing `m.implicit` is solved on the **local\n",
+    "NLP path only** (no global optimality certificate), and integer variables are\n",
+    "rejected. It is a tool for *local* reduced-space solves, exactly the setting\n",
+    "where recycle loops arise.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "55dc6582",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T11:29:00.350977Z",
+     "iopub.status.busy": "2026-07-02T11:29:00.350891Z",
+     "iopub.status.idle": "2026-07-02T11:29:01.054733Z",
+     "shell.execute_reply": "2026-07-02T11:29:01.054185Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "import jax.numpy as jnp\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import discopt.modeling as dm\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a65ffa7",
+   "metadata": {},
+   "source": [
+    "## A reactor with recycle\n",
+    "\n",
+    "Fresh feed $F_0$ of reactant A enters a mixer, joins a recycle stream $R$, and\n",
+    "passes through a reactor of volume $V$. For a first-order reaction the\n",
+    "single-pass conversion is $X = kV / (T + kV)$, where $T = F_0 + R$ is the total\n",
+    "reactor feed, so the unreacted flow leaving is $T\\,(1 - X) = T^2/(T + kV)$. A\n",
+    "separator returns a fraction $\\alpha$ of the unreacted A as recycle,\n",
+    "$R = \\alpha\\, T^2/(T + kV)$.\n",
+    "\n",
+    "Substituting $R = T - F_0$ closes the loop into a single implicit equation for\n",
+    "the total reactor feed $T$ given the design variable $V$:\n",
+    "\n",
+    "$$\n",
+    "g(T; V) \\;=\\; (T - F_0)\\,(T + kV) \\;-\\; \\alpha\\,T^2 \\;=\\; 0 .\n",
+    "$$\n",
+    "\n",
+    "There is no explicit $T(V)$ to substitute — this is precisely the irreducible\n",
+    "cyclic block that `m.implicit` handles. We choose the reactor volume $V$ to hit a\n",
+    "target throughput $T^\\star = 18$, minimizing $(T - T^\\star)^2$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fbd8c6d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T11:29:01.056293Z",
+     "iopub.status.busy": "2026-07-02T11:29:01.056154Z",
+     "iopub.status.idle": "2026-07-02T11:29:01.991719Z",
+     "shell.execute_reply": "2026-07-02T11:29:01.991180Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "status        : optimal\n",
+      "V*            : 12.6000\n",
+      "objective     : 3.187e-20\n",
+      "gap_certified : False   (local NLP path — no global cert)\n"
+     ]
+    }
+   ],
+   "source": [
+    "F0, k, alpha = 10.0, 0.5, 0.6   # feed (mol/s), rate constant (1/s), recycle fraction\n",
+    "T_target = 18.0\n",
+    "\n",
+    "\n",
+    "def recycle_residual(u, v):\n",
+    "    # u = [V] (design), v = [T] (implicit unknown): g(T; V) = 0\n",
+    "    V, T = u[0], v[0]\n",
+    "    return jnp.array([(T - F0) * (T + k * V) - alpha * T**2])\n",
+    "\n",
+    "\n",
+    "m = dm.Model()\n",
+    "V = m.continuous(\"V\", lb=0.1, ub=50.0)\n",
+    "T = m.implicit(recycle_residual, [V], n_unknowns=1, x0=jnp.array([20.0]))\n",
+    "m.minimize((T[0] - T_target) ** 2)\n",
+    "\n",
+    "r = m.solve(initial_solution={V: 5.0})\n",
+    "print(f\"status        : {r.status}\")\n",
+    "print(f\"V*            : {float(r.x['V']):.4f}\")\n",
+    "print(f\"objective     : {r.objective:.3e}\")\n",
+    "print(f\"gap_certified : {getattr(r, 'gap_certified', False)}   (local NLP path — no global cert)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf71eeb3",
+   "metadata": {},
+   "source": [
+    "The optimizer drove $V$ using the derivative $\\mathrm{d}T/\\mathrm{d}V$ that flows\n",
+    "through the implicit solve by the implicit-function theorem,\n",
+    "$\\mathrm{d}T/\\mathrm{d}V = -(\\partial g/\\partial T)^{-1}\\,(\\partial g/\\partial V)$\n",
+    "— no differentiation through the Newton iterations.\n",
+    "\n",
+    "## The forward map $T(V)$\n",
+    "\n",
+    "Because $g$ is quadratic in $T$ here, we can also write the root in closed form\n",
+    "and use it to *verify* discopt's answer and to visualize the block $T(V)$ the\n",
+    "optimizer navigated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7ce49728",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T11:29:01.992948Z",
+     "iopub.status.busy": "2026-07-02T11:29:01.992799Z",
+     "iopub.status.idle": "2026-07-02T11:29:02.095440Z",
+     "shell.execute_reply": "2026-07-02T11:29:02.095030Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "analytic V for T=18 : 12.6000\n",
+      "discopt V*          : 12.6000\n",
+      "T(V*) check         : 18.0000  (target 18.0)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAGGCAYAAACNCg6xAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAcYRJREFUeJzt3Qd4U1UbB/CXbjqg0FKgjLI3lL03CiiigIAiGwRBliKKqIjiJyAqy4WggigKggKCTNl77z3KHi0FOunO9/xPuTFJ05KWtEnb/+95LjQ3yc3JvTc3b855zzl5dDqdToiIiIjosRwe/xAiIiIiAgZORERERBZi4ERERERkIQZORERERBZi4ERERERkIQZORERERBZi4ERERERkIQZORERERBZi4ERERERkIQZOlGlatmypFs3ly5clT548Mn/+/HRtB4/H8/D8jIqMjJRXX31VihQporb1xhtvSE5VqlQp6devn62Lke1Z47yzpY8++kiV/3HwGa1WrZrYCs5VT09PyUky49yx9HhS5mPglINpH94DBw5ITvPtt9+mKwCbNGmSevzQoUPll19+kd69e2dq+YgscfPmTfWFeOTIEcnJoqOj1fvcsmWL5CS4rixfvtzWxaAsxsCJskxAQIA8fPgw3UELHo/n4fkZDZw2bdokDRs2lAkTJkivXr2kTp066SoD5T7mzrvMCJw+/vjjXBE44X3mlsApM86dDz74QG2TbI+BE2UZ1H65ubmJo6Njup6Hx+N5T1JNHRwcLN7e3mItCQkJEhcXJ7YQFRVlk9fNbaxx3lHulBnnjpOTk9pmVklKSpKYmJgse73shIFTLqPlE1y9elWee+459XexYsXkm2++UfcfP35cWrduLR4eHurX0m+//Wa2+W/btm3y2muviY+Pj+TLl0/69Okj9+/fT/O1U8txOnPmjHTv3l0KFSokefPmlYoVK8r777+far4AcnhOnjwpW7duVeuxGOZSGcIvXNwfFBQk//zzj/7x2rYQUA0cOFAKFy6sLkqBgYHy888/my33F198ITNmzJCyZcuKq6urKoOvr6+MHj3a6GKDAA0XzgcPHujXf/bZZ+rCh1wrOHbsmDoWZcqUUa+L3KsBAwZIaGio2byGU6dOySuvvCIFChSQpk2bqvt0Op3873//k+LFi4u7u7u0atVKlckShu8Jxx7lwDbatm0r165dU9v+5JNP1LZxTF544QW5d++e0TZWrFghHTp0EH9/f7U/sF/wnMTERLM5NAcPHpTGjRur7ZUuXVpmz55tUVlRzuHDh6tf9tgOXqtq1aqydu1ao8dduXJFXn/9dXX+4DVwbnbr1s0ozwTN1tie6TGGdevWqftWrVqVap4Kji+OCd6zts9xbEzzyrCvxowZI9WrV1efMXxGnnnmGTl69KjRuVmvXj31d//+/fXnpuHnY+/evdK+fXvJnz+/er0WLVrIzp07U5R9x44dals4l3Acvv/+e0mvtI4PzltcE0aNGpXiedevX1fn++TJk81uF/sPn21ArZP2PrEfDd24cUM6deqk9hcej/1nei5h/+MziOOP94rPLa5Dj7v2GNY8N2vWTL0XfE5xXp8+fdrsZ067LuHY4VzCezcMJPAY/IjBuaS9J+0cMHfu4BzBNRfHvW7dumo/4/zQauH++usvdRvvCzXihw8fNlsuDV5Le13TxXDfxsbGqpr2cuXKqc9OiRIl5J133lHrzX3OFi5cqPYvHmv6GaNkTo/+p1wEFyNcxJs3by5Tp05VHxR8YHAxQcDSs2dP6dKli7pwIiBq1KiRupAawuNx4cEH9OzZs/Ldd9+pLy4tULEUAghcyJydnWXw4MHq4nLx4kVZuXKlfPrpp2afgwvniBEj1AVWC7BwATWncuXKKqfpzTffVEHAW2+9pdbjwoxqb3ypX7hwQb0fvMclS5aoCxKCHtMviXnz5qkLJ8qJiwoupk2aNFFBpOH7CQsLEwcHB/UFh8ACtm/fLrVq1dInwW7YsEEuXbqkvjARNCHgmTNnjvp/z549KfYhAoDy5curpgEENfDhhx+qwOnZZ59Vy6FDh1Tgk56aMBx7PB77E1/2OB/wZYHgGcdy7Nixav989dVX6ovsp59+0j8XXw54Pwgc8T++lFCm8PBw+fzzz41eB19sKCO23aNHD/njjz9UvpmLi4sKGB8HgQG+WBAYeXl5yaxZs+TFF19UPwBwHGD//v2ya9cuefnll9WxxpcWzkscYwQ3CDzwhYUgEa/ft29fo9dYvHixCkzbtWuXajnGjRun9lHHjh3V4xAI4X/TX+Y4tgj0cNxwXt25c0cFMwh8UBYEXjg3J06cqPYZzil8DgDBC2B/4nOKL1F88eGcwjmIY4PzqX79+vofOzjuOKfxeURtKB6f2mfCnMcdHxzfzp07q300bdo0o1rj33//XZ2TuG6Yg3LhOGB72AauLVCjRg2jaxL2Y4MGDVQw/++//8qXX36pgkA8T4MgCecdPjcjR45UP4i+/vprFWTg84brSGqwTexPHH/sJ3z+cV7jM4zPDq49hrAvsA4BIT6TOOewnxYsWKDux3UFHU5wHHD8AOVNCz5L+AGE94GUAbxXnEu41r733nvq/Aa8Jl4f11Ycd3OwjaeeespoHQIdfKb9/Pz0gebzzz+vPj8oI845nC/Tp0+Xc+fOpWhmxDmHY4/rIX4Umu4TekRHOda8efPwDavbv3+/fl3fvn3VukmTJunX3b9/X5c3b15dnjx5dIsWLdKvP3PmjHrshAkTUmyzTp06uri4OP36qVOnqvUrVqzQr2vRooVaNEFBQeox2IamefPmOi8vL92VK1eMyp6UlJTiNfF8TdWqVY22/TgBAQG6Dh06GK2bMWOG2u6vv/6qX4f31KhRI52np6cuPDzcqNz58uXTBQcHG23j888/1zk6OuofO2vWLPVa9evX140dO1atS0xM1Hl7e+vefPNN/fOio6NTlPH3339Xr7Nt2zb9Oux7rOvRo4fRY1EOFxcX9Z4M99V7772nHo/jnBbtPRUqVEj34MED/fpx48ap9YGBgbr4+Hj9erw+Xi8mJibN9/Daa6/p3N3djR6H44Rtfvnll/p1sbGxupo1a+r8/PyMziNz8Fy89oULF/Trjh49qtZ/9dVXaZZn9+7d6nELFiwweo/Ozs66e/fuGZUHx2jAgAGpnne3b9/WOTk56Tp16mT0Gh999FGKfY73j+NuCNtxdXXVTZw4Ub8On03TzwTgmJYvX17Xrl07o+OL91i6dGnd008/rV+H8ri5uRl9hk6dOqXOS0su8ZYen3Xr1qnHrVmzxuj5NWrUeOxnMSQkJMW1xPSaZLhfoFatWuo6o9m+fbt63MKFC40et3btWrPrTWnvJzQ01Og8cnBw0PXp0yfFZ+755583ev7rr7+u1uM5Gg8PD7OfNXPXLFwXsG7Xrl36ddo+xfXX8Ph9//33av3mzZtTlCs158+f1+XPn1+dGwkJCWrdL7/8ot4f9p2h2bNnq23t3LlTvw638diTJ0+m+hqUjE11uRR+KWlQc4TmDdQ44VeOButwH349m8KvF8Nfd/hViKao1atXW1yGkJAQVVuDX7QlS5Y0ui8r8kpQVtT24Be2Bu8Jv2TRNIGmQEOo4dCaHDSoJcCvZdR0AGoCsA4L/oYTJ06oGiytRgFQTa9BbcXdu3dV8jrg16+pIUOGpPj1rNUUGe6r9A6zgBoRNANp8Isf8GsYx9NwPV4PzSnm3kNERIR6D3iPSARGM4chbAu/kDWoycBtNJWiiehx8Mva8Nc8aivQhGJ4bhqWJz4+XjV7onkC57DhPn3ppZfU/ajB0qxfv14dI9yXmo0bN6raHK1WQINjYAo1klpNAc4PlAW1NvhMmTu+ppAsfv78eVU7gedi32JB01CbNm3U5wa1Cdg2mhjRxGX4GULNQlo1Z6YsOT44BqgpQ42GBuc2allxvjwp03Mc55Lh8UVtMM7Vp59+Wr8/sKBGDvt28+bNqW771q1bap+iNrlgwYJG5xG2Z+66NWzYMLPHOT3XOFNVqlRRNfimnzfUIhoeP229uWuvOTgvUJuHGlPUAGo1gthnOBcqVapktM/wemC6z1AjijJS2hg45UJoQzcNAHBBQvOGacCC9ebyB9BsZAgXrqJFi6Zr3BLtomCrMWTQtIj3YVoVjguNdr8h0+ZKqF27tmoC0oIkLXBCMyjyaRAUafdpuUmAZjE0BaI5BV/4OB7a9tHUZ8r0tbWymR4HbAcXT0uZBqxaEIU8CHPrDc8FNCviYo37EMTgtbUvUNP3gC9cBOaGKlSooP635JwxLSfgfRqWB00vaPZC2RG4oKkBZUJAZFge5LHhiwTNThr8jcdrXyjmaPscwZghfBGb7nMENWgOwfExLIvWlPs4CJoAzYl4nuHyww8/qPwUbAc/PvC+Tc8DQJBmKUuODz4naI5D8w6CY0AQhesJAnBrX5NMjy/2Cd4zmqFM9wl+6CDIe9yxM7dP8HnXglJDpvsUgTv2wZOMzfQkn7e0DBo0SKU4LFu2TN90re0zfE5N95d2bE33mblrHKXEHKdcKLVebamt13JqcjvDGg3DGir8OkQNAPIXbt++rQInBESo1UByLwInfFEbfjGgZg+1VG+//bbUrFlTBZ74skUiMP635LVteS4gGMGvUwRMyNPBlwq+/FCbgrwoc+8hM8ppeG6iRgA5QKh1w696fPnghwBynkzLg5ol5NDhCxM5U3///beqeTSsZXsSyEUbP368qk1FwjyCK3zpomyW7BvtMcgVw/lhDs4Z0wTfzIacR5QJwRP2FzqPIOHZsNYyIyzpaYt9gqDJsMbLkGngZW3WqAXPjGvvzJkzVS3Tr7/+muJcwT5Dwjny0swxDdgy6zqT0zBwogzBLxn0KNLgFx+qw5FgaikkaWrV/ba4iKHXIGoAcHExrHXSmpksHYMFgRJ6zaH5DDULCJJQPvRMQdCEBV8uGvyKRLMPehihhsS0lsHSsmvP0fYjoAbC0l+pTwKJ42hCQnMXatc0SNZNbbwi/KI3rNVAcipYKwF16dKlqoYGScUa1PgZ9m40DJyw///8808V5CKhHQGWJfscAbLhL3PsB9N9jrLg8/Hjjz8arUdZcI487jzWmiURmJomABvSeqKaO3eQWGwpS48PaofRyQHBC2qokZyPBOus+Lxin+AzhmTu9H7Ba8fO3D7B5x3HxLTGDfvU8DjjuONaYbg/bD1UBa4t6LSBgNxccj72GTowoHnX1mXNSdhURxmCHmCoUdGg1wzyP9BrxVK46ONLFz21cAFOzy8tXOTMfSGmB4I81BAZNtngPeCLAL/mUaNiaeCEX/7o7YfmOO0ChfXoeYMvJcP8Ju3Xpel7xPMthS9T1HahrIbbSc82noS594AcKAxMag72q2EXeTwWt3EOWGswUpTJdJ9i/5h2adeaZ/BLHMceC5qZDQNAc/DlgxopnOuG0KvLkrIg38QwRwy0L2vTcxn7BF966HWlDWFhCAGy9jrIZUINkOFnCF3skftkqfQcHwzuiJwwnGtoFrLkM4/mbHPvMz1QS4tjiRo8c+VPa9s4vqiNwdABho/Djza8F3M/+LQhWjRagGj4fq1xHcoo/FDFPsE1x7QXqwb345ybO3duivvQxMsx4TKGNU6UIbiw4otE6zKLL0x8gNH1NT3QxRfPQ64QEs7xCw85BBhzKa3RlHExxxcYuuMj5wRV+Gnlp5iD18OXAxJGkQCLX5KoKUC3ZnwpoAnHEmgWwhcq9oPWLRnwRax9yRoGTqhF0IaCQPCJcbRw8U6ttsYcbZwbdFtGbRYu/OiSvWbNGqMajcyCLvPIQUEND5LpESwiSEwt4EUODWrlcGyRX4FgBccXAXhaXcjTA/sBZUCzERJcd+/erWooDHM+TGudUOOHJkaM5ZVat28NaqaQl4YaLZznaFbFr3ltnxv+okdZ0ISJbvPYV+gCjloaw9pBQHCE5HV0R8f5hi9iNP3ic4BcJnxJo+YS28F5gi9BJPTiHMKQHYCaM3RDxzmGxHUt+MfzUKNqifQcHySsYxwg5NOgU4glxw81RDgm2C62j6ZL1F6lJ78RP2SQsI5zHmXDEAx4bdQMIShFk1XXrl1TfT6CC+xPfF5xvLXhCHC+mI4pBfg8ascZ5xKawvDekSNneB3COYamMOxDHDctsTuz4XOHABrHYtGiRUb3IekdC4JcDC+AxHucN6itQ/CJWjasR3CNIToonR71rqNcNBwButCaQndidPF/XDd+bZtbt27VDR48WFegQAHVdb9nz55G3XwtHY4ATpw4oevcubPqDo5u1RUrVtSNHz8+za696BqOcmEoA9z3uO7Q5oYjgDt37uj69++v8/X1VV3eq1evnqJ8Wrkx9EBq6tWrpx6zd+9e/brr16+rdSVKlEjxeNynvWd0Ie7WrZvu5s2bKbpsa12Q0Z3bFLq7f/zxx7qiRYuq7swtW7ZU+xLv1dLhCEzfE7o/Y/2SJUseey6hK3PDhg3Va/v7++veeecdffdqw27U2rl14MABNdQDjjHK+PXXX+ssge0NGzYsxXrT94lhNbRjiXMSXfkxpEZq+wPdt7FtLDt27Ehxv7nzDt28cW4WKVJEve/WrVvrTp8+rfPx8dENGTLEaDiCt956S39smjRpooZGMP1MAIbwqFKlihrqwPTzcfjwYV2XLl3U9jGUAd5L9+7ddRs3bjTaBj6P6LqPc7hMmTKqu/njuq8/yfF59tlnU3Stfxw8Viuj4Xme2jUptfLPmTNHbQf7FZ9/fGZx7uHz8zj//vuvOhZ4LoYX6dixoxq6wdzrYn3Xrl3Va+A6N3z4cN3Dhw+NHovzC0OqYHuGQ1KkNhyBuWuQufPb3OfTdH9ow0iYWwyvIRhO4rPPPlPHGOcQ3gv2H64dYWFhaZaDzMuDf9IbbFHupQ0+h8EG+UuFLIEBKJGEnZFctuwATTWofUPtp+GI9zkZelOiFg15PzkNap9Qi4fanKyovaXshzlOREQWMjfJqpZXltq0PzkNcmvQlJ7eybqJcgrmOBERWQg5Oqh1RU4ZOhBgKgt0BUe+DfJHcjLk/CD/D7lXyC0yHDCTKDdh4EREZCEk3KIjABL7MYSBljCOZrqcDiPpo5kegziidxpG3SfKjZjjRERERGQh5jgRERERWYiBExEREZGFckWOE4bJx+jNGGCOw84TERGRIWQtRUREqIFMHzcYbq4InBA0mU5mSERERGTo2rVrah5Gye2BkzZ1BnYIpiogIiIi0qCXLCpYLJlqK1cETlrzHIImBk5ERERkjiXpPEwOJyIiIrIQAyciIiIiCzFwIiIiIrJQrshxIiKiZImJiRIfH2/rYhBlKcyv6OjoaJVtMXAiIsol49Tcvn1bHjx4YOuiENmEt7e3mmPxScdzZOBERJQLaEGTn5+fuLu7czBgylU/GqKjoyU4OFjdLlq06BNtj4ETEVEuaJ7TgiYfHx9bF4coy+XNm1f9j+AJn4MnabZjcjgRUQ6n5TShpokot3J/dP4/aY4fAyciolyCzXOUm+Wx0vnPwMkKomITJOwhe6kQERHldAycntDms8HS+sst8tnaM7YuChEREWUyBk5PyMPFSe6Ex8rv+67KiRthti4OERERZSIGTk+ofumC0jHQX3Q6kY9XnlTdHomIKOuEhoaqnlKXL19O1/Nefvll+fLLLzP0Gi1btpQ33nhDMpvp66T3dTNSTkue09LK7/9x20vPscpsDJysYNwzlcTN2UH2X74vK4/dsnVxiIhyhHXr1qmE3rSW9evXy6effiovvPCClCpVSj2vatWqMmHCBLPbnDx5shqSAYHQBx98oJ4bFvb41gLT1/jrr7/kk08+kayW3tc1fHxWBXuZIT3HKrMxcLICf++88nrLcurvyatPS3Rcgq2LRESU7TVv3lxu3bqlXxDwjB8/3mhdkyZN5Mcff5SBAwfqn1e9enU5ceJEiu3h8ZMmTZKJEyeqbVWrVk3Kli0rv/76a5rlwOCJpq9RsGBB8fLykqyW3te1VTmtzdJjlRUYOFnJ4OZlpHiBvHIrLEZmb7lo6+IQEeWIQQsxRQYWDOKJWqJmzZrp12FZs2aNuLq6SsOGDfXPq1GjhtnA6b333pPSpUvLkCFD9Os6duwoixYtSrMcq1evTvEa5prQRowYodYVKFBAChcuLHPnzpWoqCjp37+/Cl7KlSunymv4nOHDh6slf/784uvrqwLDtFI+TF83KSlJpk6dqraNMpYsWVLVzJg+vl+/frJ161aZOXOmvrYurabNhISEdJUrNjZWRo4cqZoz3dzcpGnTprJ//36Ly2nqn3/+Ua+9cOHCdB2rrMDAyUrcnB3l/Wcrq7+/33ZJrt2LtnWRiIjSnoYiLiHLl4zmgR4+fFj9X7t2baP127dvlzp16hitQ43TxYsXJSYmRr/u4MGDsmDBApk1a5bRqNH169eXffv2qS/+1Jh7DXN+/vlnFWRgewiihg4dKt26dZPGjRvLoUOHpG3bttK7d29Vg2X4HCcnJ/UcBDXTpk2TH374wcK9IjJu3DiZMmWKCmxOnTolv/32mwraTGHbjRo1kkGDBulr60qUKJHme0lPud555x35888/1fPwXhEgtWvXTu7du5eucgLu69Gjhwqaevbsma5jlRU45YoVta9WRBqV8ZHdl0Jl0urT8l2vx3/QiIhs4WF8olT5cF2Wv+6pie3E3SX9Xz34MsYXvemUMVeuXBF/f3+jdahxQg3VmTNnpGbNmmodal1efPFFVQNjCM+Ni4tTc/kFBASYfW1zr2FOYGCgysUxDBQQSCFYgQ8//FC+++47OXbsmL72Cu9p+vTpqgaoYsWKcvz4cXVbe05aIiIiVFDz9ddfS9++fdU6NGehtscUam9cXFzU6NmoqXuc9JQrKipKva/58+fLM888o9ahtm3Dhg2qiRM1fJaW85tvvpH3339fVq5cKS1atEj3scoKrHGyIpxgE56vIg55RNacuC27Lty1dZGIiHIEBE6mtU3w8OFD1TRkCF+qCBS05rrFixerGqcvvvgi1TnMDGuBLHkNcxCwaVCrhSAPtV8arYZFm2wWEEAZjmiNWqHz58+rwO9xTp8+rWpf2rRpI9aWnnJdvHhRTWOCfDONs7OzqiFCGS0t59KlS+XNN99UAZdp0GTpscoKrHGyskpF8kmvhgGyYPcV+XjlKflnZFNxcmR8SkT2Ja+zo6r9scXrZjRwevXVV1OsR43O/fv3zSYTI3BCc93YsWPVgrwaU1pTUqFChVJ97dRewxSCBUMIPAzXaYEI8n2sQQsk7F1eC8tZq1YtdZx/+uknqVu3boopUiw5VlmB3+iZYPTTFcTb3VnO3omQhXuv2ro4REQp4EsJTWZZvWRkvrC7d+/KtWvXzNY44csWOTOmtARxrZYJOTjm4DHFixdXwVFqUnsNa9i7d6/R7T179kj58uWN8rBSg8chKNm4caNFr4WmOktqstJbrrJly6pt79y5U78ONVBIDq9SpYrF5cR2Nm/eLCtWrFA5Yhk5VlmBgVMm8HZ3kbfaVlR/T9twTu5Hxdm6SERE2RZqIcBc4IQE5JMnT6aoEUITGRKJkWeE4Cm1Wg8kfiNpOy2pvYY1XL16VUaPHi1nz56V33//Xb766isZNWqURc9F8yFq0hAUIvEdTWYIcJBXZA7GoEJAhN50CEbTqvlKT7k8PDxUIvzbb78ta9euVUEmcqHQpIYhHNJTzgoVKqjgCYnmpmNOWXKssgKb6jLJK/VLysI9V+TM7Qj5csNZ+V+n/9q5iYgofT3qkB9kLkEbARICqj/++ENee+01oxqnkJAQadWqlXTt2tXsdtGMt3z5cvVln5bUXsMa+vTpo3KokA+E2hwEJ4MHD7b4+eilht5vSDy/efOmFC1a1Gi4BUNjxoxRydmoBcJrBgUF6Qf0fNJyTZkyRQVi6DWIpHU0tWEAUwzNkN5yIhl906ZNKpEfr40Rwy09Vlkhjy4XzBESHh6uEgUx4mi+fPmy7HX3XAqVl+fsUcnifw9vKtWK5c+y1yYi0uBLB1+SGMPIkiTn7AZj/qC2A005Dg6WN6SgJ9iyZcvU6OOZ9RppQWCAXn8zZsywyvZysu/Scawy8jlIT5zAprpM1LCMj5rHLkknMn7FCUnCH0REZFUdOnRQtSE3btxI1/OQuI0mqMx8DbKO9ByrzMamukyGQTE3nb4jh68+kKWHrkv3uqkPOEZERBmTkTnYzPXSs/ZrkHWk91hlJtY4ZbIi+d3kjacqqL+nrDkjYdHxti4SERHZgS1btrCZLhuyeeCEmarr1aun5vHBHDedOnVSWfzmIB0Lo5KiOyuSxLKLfk1KSXk/T7kXFSdfrDf/3oiIiMj+2TxwwqSDw4YNU10TMVooxn5Ad0MM4W4KkXlGxgCxNWdHB5n4QjX19697r8jx62G2LhIRERFlxxwn066FmOsGNU8YHr958+b69UeOHFFdEg8cOKC6MWY3jcr6yAs1/WXFkZsqUfyvoY3FAd3tiIiIKNuweY2TKXQFhIIFC+rXYRCtV155RU3+Z8nkhPbqvWcri4eLoxy59kCWHLxm6+IQERFRdg6cMHgWei1gokDMM6TBpH+NGzeWF154waLtYDJBjMlguNiDwvnc5M2n/0sUfxDNEcWJiIiyE7sKnJDrhMHFFi1apF/3999/qxFE09PzAAnnGMhKW0qUsJ8hAPo2LiUVCnvK/eh4+XwdE8WJiIiyE7sJnIYPHy6rVq1Sc9RgEj8NgibMa+Pt7a2Ga8cCL774ohp11Zxx48apJj9tweSQ9pgo/tu+q0wUJyIiykZsHjhhiAEETRhKHUEShkI39O6778qxY8dUcri2wPTp02XevHlmt+nq6qqGTDdc7G1E8U41/QWT3XzAEcWJiIiyDSd7aJ777bffZMWKFWosp9u3b6v1aGLDbNZIBjeXEF6yZMkUQVZ2SxT/93SwHL32QNU89WoYYOsiERGRHVQmZMdhd3ITB3uYuA/NaWh2wzAD2rJ48WLJyfzyucmYtsmJ4p+tPSPBETG2LhIREdnQuXPnZNu2bbYuBtl74ITo2tzSr1+/NJ+DEcazu96NSkmN4vklIiZBPll12tbFISKyO/hRbU9zxFlSnnXr1qlao7SW9evXpxgMulu3bjJo0CCVupIZEJR17NhR/P39U52BIzExUcaPH69adNDqU7ZsWfnkk0/U9y7ZSeCUmzk65JFJnasLxsFcefSmbDsXYusiERHlOHFxWTv0CwZvvnXrln7x8fFRwYjhujZt2hg9p0WLFlK4cGGVk9u5c+dMKRdm5AgMDFRjIqbms88+Uy1BX3/9tZw+fVrdnjp1qnz11VeZUqbsiIGTjVUrll/6NU7O1fpg+QmJiU+0dZGIiOwCWh5QEzNz5kx9Tc3ly5fVjBNNmzZVva0RlDz33HOq97VhrRA6HaFmyNfXV9q1a6fWR0RESM+ePcXDw0OlhKCTkWkNEsYTxJA2Wo0LAo2lS5emWR5Thvm5qMEJDQ2VZs2a6ddhcXR0NHoOHjd37lxZvXq1KmdmwFyv//vf/9IMzHbt2qXGTOzQoYOUKlVKunbtqqZB27dvX6aUKTti4GQHRretIEXzu8nVe9Hy9aYLti4OEZFdQIDSqFEj1Xyl1dRgXD7UnIwePVpNwbVx40ZxcHBQwQCCHs3PP/8sLi4usnPnTpk9e7Zah+fgNsYHxNyo27dvl0OHDhm9JoKmBQsWqOecPHlSDcDcq1cvfcBkrjxpOXz4sPq/du3aaT4OgVRAQICacgwdpdIyadIk8fT0THO5evWqZAQGm8Y+Rb4VHD16VHbs2KGCLrKTXnUk4unqJBM6VpUhvx6U77ddlE61/KWcX9ofHCKinA69qxH8uLu7G/Wuxjh+hn766ScpVKiQnDp1Sj/rRPny5VUTkwa1OAim0ItbaybDkDbI9zGcdQJByb///qsCJChTpowKHL7//nv1XHPlSQsCMwRXqBmzliFDhkj37t3TfIzh+0oPDAGE2TYqVaqkgjnUhH366aeqpo6SMXCyE+2qFpanKvupIQre++uELBrckJMAE1GmQ0ARGRlptM7NzU0KFCggCQkJEhKSMvdSm2j97t27Eh8fb3Qfms/QVIVaIdPprlAT8rjaFEucP39ePvzwQ9m7d68qg1bThFoWLXCqU6eO0XMuXbqkylq/fn2jwKxixYr62xcuXFBzoz799NMpcqRq1aqVobIicHpcbVN6YS5Xw/lcremPP/6QhQsXqiCxatWqauxENGUiEOvbt2+mvGZ2w8DJTqCt/KPnq8rOC6Gy7/I9WXrwunSvZz9TxRBRznTw4EHVDGWoevXq0qVLFxX4zJkzJ8VzJkyYoP7H+HvXr183ug9NZjVq1FDNXGvWrEmRAJ3ajA/pgZ5haNZCThC+0BE4IWAyTAJHHlN6aQHkP//8I8WKFUsxsHJGA6dXX31VrAm1YljSgto3jHeYXm+//baqdXr55Zf158KVK1dUEyYDp2QMnOxI8QLuMvrpCvLp6tMyac1paVPZT3w8M/ZhJSKyBGpmDGtdtBonQA+vwYMHp/pcJBGbq3EC1FaY5v+gxim90DSG5iINEq3Pnj2rgiYkXAOa0h4HTW7Ozs6yf/9+fUCBMQSRy4NecFClShUVIKHmCkGeJeVJC2rDMOWXtWucMrOpDjVuyBkzhCY7w/yx3I6Bk53p36SU/HX4hpy+FS6TVp+RL7sH2rpIRJSDoeksteYzzA2qNcuZgx5rqUGNT0ZqfUyhZxea5NB7DYEXmqiQL4SaMJQNQQ5qSB4H7xE1JqhRwTaQhI2aMwQJ2kjdeMyYMWNUQjgCBfTcQ3CFhHIEkXi+ufKYBhoaLfHcXprqUKOG5khNUFCQaorDtrRgErV5yGnCbQS/SG6fNm2aDBgwwKrvIVvT5QJhYWEYuUv9nx0cunJPV+rdVbqAsat0O8+H2Lo4RJTNPXz4UHfq1Cn1f3Zz9uxZXcOGDXV58+ZV1/GgoCDdhg0bdJUrV9a5urrqatSooduyZYu6b9myZeo5LVq00I0aNSrFtsLDw3WvvPKKzt3dXVekSBHdtGnTdPXr19e9++67+sckJSXpZsyYoatYsaLO2dlZV6hQIV27du10W7duTbU8qZkyZYqucOHCOnuxefNmVWbTpW/fvkb7CPuuZMmSOjc3N12ZMmV077//vi42NlaXkz8HYemIE/LgH8nh0E6PJED8crC3CX9T8+GKE7Jg9xUJ8HGXtaOaS14X4zE/iIgsFRMTo2oXMDaR1gxHyQNCIpfpyy+/lIEDB9q6OGTDz0F64gSO42Sn3m5XUY3tdCU0Wmb8mzyeBhERZRyanX7//Xc1WCaa0bQu9sjVIrIUAyc75eXmLP/rlNytdu72S3L8epiti0RElO198cUXajTwp556StU4YRDMtHK1iEwxOdyOtalcWDoG+qt57N7585j8PbyJODsy1iUiygiMxYThF4ieBL+F7dyEjlXE291Z9bKbs+2SrYtDRESUqzFwsnO+nq7y4XNV1N8zN56XiyHGI/wSERFR1mHglA10rlVMmlcoJHEJSTLuz+OSlJTjO0ISERHZJQZO2QAGZ/u0UzVxd3FU07H8vj9js14TERHRk2HglE2UKOguY9omT4swZfUZuR0WY+siERER5ToMnLKRvo1LSc0S3hIRmyAfLD+BUd9tXSQiIqJchYFTNuLokEemdq0hzo555N/Td2TlsVu2LhIREVGuwsApm6lQ2Eteb1lO/T1hxQkJiYi1dZGIiIhyDQZO2dCwVuWkctF8cj86XsazyY6IiCjLMHDKhlycHOSLbjXEySGPrD15m012REREWYSBUzZV1T+/qnkCNtkRERFlDQZOOaTJ7oPlx9lkR0REivZ98NFHHxndpifHwCmHNNmtO3lH/j5609ZFIiIiO/Ddd9/JnDlzJCoqSt59913Ztm2brYuUYzBwygFNdsNbP2qy+/ukBEdwYEwiosdp2bKlvPHGG5JTvf766xIWFiazZs2Sjh07SosWLWxdpByDgVMOabKrUjSfPECT3TL2siMielyQ9Ndff8knn3wi2UXVqlVlwoQJZu+bPHmy+Pj4SGhoqH7d7NmzJX/+/DJy5EhZuXKlbN++3epl2rZtmwrK/P391dRgy5cvN1u2evXqiZeXl/j5+UmnTp3k7Nmzj932jRs3pFevXup95c2bV6pXry4HDhwwesw333wjpUqVEjc3N2nQoIHs27dPsgIDpxzA2RFNdoGqyW79KTbZEVHm0CUmStTefRK26h/1P25nVwULFlRf5tkFAocTJ06kWH/r1i2ZNGmSTJw4UQUZmtdee00GDx4sHh4eMmXKFGnatKnVyxQVFSWBgYEqgEnN1q1bZdiwYbJnzx7ZsGGDxMfHS9u2bdVzU3P//n1p0qSJODs7y5o1a+TUqVPy5ZdfSoECBfSPWbx4sYwePVoFk4cOHVLlaNeunQQHB0um0+UCYWFhqIJR/+dkMzac0wWMXaUL/Hid7k74Q1sXh4jsxMOHD3WnTp1S/2dU2Lp1unMtWupOVaykX3Ab6zNTTEyMbsSIEbpChQrpXF1ddU2aNNHt27dPf3+LFi10w4YNU0u+fPl0Pj4+ug8++ECXlJSk7u/bt6+6/hsuQUFB6nmjRo0y2s7w4cPVOm9vb52fn59uzpw5usjISF2/fv10np6eurJly+pWr15tVL6AgADd9OnTjdYFBgbqJkyY8ETbNfXpp5/qKlSokGI9tlG9enVdQkKCzpZERLds2bLHPi44OFg9duvWrak+ZuzYsbqmTZumuZ369eurY65JTEzU+fv76yZPnpyhz0F64gTWOOUgr7cqK1X9k5vsxv3JXnZEZB3h69fLjVFvSMLt20brE+7cUetxf2Z555135M8//5Sff/5Z1SyUK1dO1Szcu3dP/xjc5+TkpJpqZs6cKdOmTZMffvhB3YfbjRo1kkGDBqnaGSwlSpQw+1rYjq+vr9rOiBEjZOjQodKtWzdp3Lixem3UlPTu3Vuio6PT9R6ssV3UOF28eFFiYv7LYz148KAsWLBA5TE5OjpKRqC2ytPTM83l6tWrYi1hYWH6Gr/U/P3331K3bl21j9C8V6tWLZk7d67+/ri4OPXen3rqKf06BwcHdXv37t2S2Rg45bAmuy+7B4qLo4NsPBMsi/dfs3WRiCibQ3PcnUmT0Txh5s7kdbg/M5rt0JyD3mGff/65PPPMM1KlShX1BYqclx9//FH/OARC06dPl4oVK0rPnj1VcILbgDwfFxcXcXd3lyJFiqgltSADzT0ffPCBlC9fXsaNG6dyZxDwIOjCug8//FDlER07dixd78Ma261Ro4YkJibKmTNn9OuQt/Xiiy+qHK6MGjJkiBw5ciTNBTlM1pCUlKTKjGa4atWqpfq4S5cuqeOOfbNu3ToVaCJXCwEo3L17V+2LwoULGz0Pt2+bBPeZwSnTX4GyVKUi+WRMuwoyafUZmbjqlDQq6yMBPh62LhYRZVPRBw6mqGkyotOp+/E4jwb1rfraqGFBTgy+aDXIe6lfv76cPn1av65hw4YqOVmDGibkxODLNT01MQhONHgecoZQ06PRvqjTm0djje0GBASoIBB5TjVr1lQ5Pqh1MQykMgI1P2nV/ljTsGHDVPl37Njx2AALNU6oDQPUOOF5SHjv27ev2BprnHKggU3LSIPSBSU6LlFG/3FUEpPYZEdEGZMQEmLVx9kzBGWGEIwZrtOCM3yxGzYRmaZFINh70u2ag1oaBBBorhs7dqxaSpYsKU8iq5rqhg8fLqtWrZLNmzdL8eLF03xs0aJFVe2iocqVK+vLgdo6BKB37twxegxuo0YxxwdOj+uqiHZsVLuiChbVszhJUGWntZNSSo4OeVSTnaerkxy8cl9mb71o6yIRUTblVKiQVR+XHmXLllXNbDt37jQKSvbv32/0xbp3716j56EHF5p5tNombAO1T5mhUKFCKm9KEx4eLkFBQZnyWqi5QuD0xRdf6PO/nlRmN9XpdDoVNC1btkw2bdokpUuXfuxzUMNoOmTBuXPnVK2bdjzr1KkjGzdu1N+PoBO3UduY45vqtK6KCJ4SEhLkvffeU4ly6H6IbpQ3b95UC04UfFCuXLmiDjTWLV261NbFt1vFC7jLR89XlTFLjsr0DeekRYVCUq1YflsXi4iyGfe6dcSpSBGVCG42zylPHnEqXFg9ztrwHYD8lrfffls1J+GH89SpU1US9cCBA/WPQ00EuqajCz6Srb/66ivVVKfBWD8Iri5fvqxqUKzZNNW6dWuZP3++Gs/I29tb5StlNFH7cdC8h++9LVu2qNdEZcKTepKmusjISLlw4YL+NgJGBFrasQJ8v//222+yYsUKVUGi5SCh2RHl//rrr1VQZRgEvfnmmypxHrVh3bt3V0n1GAUdiwbHG812aNJD0+2MGTNUTlz//v0lxwdOa9euNbqNkwE1T2i7bd68uaqaRI8Kw18gn376qRoYC4EWelKQeS/WLiYbTt1W07G8ufiIrBzRVNycM+cDTUQ5Ux5HRyn83jjVew5BklHw9KiJCffjcZkBYxChNgG9ziIiItQXJRKGDcf06dOnjzx8+FB9gSJoGTVqlBrDSDNmzBj1JYsf33icNWuEkOyN7T333HMqGMCgmplZ4xQSEiKtWrWSrl27iq0dOHBAlcUwmAHsa3yXA5K8wTSBfd68edKvXz+V6I1cNkOoSEEwhX2L8alQS4XACIn/mpdeekntCwSqCMaQ94V4wjRhPDPkwZgEYkcQvaKK9fjx46lm3aObKXYodpo5sbGxajGsOkWvCzTv5cuXT3KT0MhYaTdju9yNjJWBTUvL+OeM242JKOdDTgy+zPEFhB5dGYEhB9B7zjBRHDVRCJrytW0rtoIvZHxp4ouVKKOfA8QJCHwtiRPsqrrGkq6KiE4R0Rv+mjCXN/Xxxx9nYkmzDx9PV5natboMmH9AftwRJG0q+Unjcr62LhYRZTMIjrzatEnuZRcSonKa0DyXWTVNRPbK5snh5roqLlq0yOz9iAg7dOigqls/+uijVLeD2ihEjdpy7VruHs+odaXC0qN+cnszcp7CHhr3+CAisgSCJAw5kP+5Dup/Bk2UG9lNjZPWVRGTBprrqoi27fbt26vkMrR9mnbvNOTq6qoW+s8HHSrLrot35UpotHy44oTMfLmWrYtERPTEkChNlKtqnCzpqoiaJvS0QxdEDMWe0Tb63MzD1Ummda+phipYceSm/HXouq2LRERElO042EPz3K+//qq6K2pdFbGg54Nh0IRuhhhiH7e1x2TWuBw5VZ2AAjKqTXn19/jlJ+Ty3dRnpyYiIiI7DJzQVRF5SOgZgdFCtQXDyQPG5MD4G+hlh8kdDR+T23OXMmJYq3JSv1RBiYpLlFGLDktcQtoj1RIREZGdNdWZWzC+AyCgSu0xGNSM0gdNddNfrin53Jzk6PUwmf7vOVsXiYiIKGcGTv/++2+KOXko+ynmnVc+ezF50klMx7Lrwl1bF4mIiCjnBU7t2rVLddBJyl6eqV5UetQvoQYBfmPxEbkXFWfrIhFRJuMPX8rNdFY6/9MVOPFDl7NgFPGyhTwkOCJW3ll6lMeXKIfShm/BHG9EuVX0o/M/reGMstU4TpT13F2cZFaPWtL5m13y7+lg+XXPFendiHljRDkN5m/DBLTBwcHqtru7u+R5NM8cUU6n0+lU0ITzH5+DJ52E2SkjveCaNm0qtWvXNppkkbKnqv75ZewzleSTVafkf/+clvqlfaRiES9bF4uIrKxIkSLqfy14IsptvL299Z+DLJvk18HBQXx8fCQ0NFT9WsHEuQigDBdrFMra0jN5X26EU6D//P2y5WyIlPfzlBXDm6jaKCLKeTD+XXw8p12i3MXZ2TnNmqb0xAnpDpww8GRCQoIcPnxYjbGkLRhTCcEUAqcbN26IPWHg9Hh3I2PlmZnbJSQiVrrVKS6fdwu0dZGIiIjsLk5IV7WC1ibu7++vFky4q0Et1MGDB+XIkSMZLTfZkK+nq8x8uab0+mGvLDl4XRqU8ZGudVLOGUhERJSbZajGyc/PT7IT1jhZbtbG8zJtwzlxc3aQv4c3lQqFme9EREQ5W3g64oR0DUewdu1atWHK2VOyNCvvKzHxSTJs4SGJjkuwdZGIiIjsRroCJ0y26+rqmnmlIfuYkuWlmuLn5SrngyNl/PKTti4SERGR3bD5XHVkn/lOGN/JIY/In4euyx8HOJkyERERMHAisxqW8ZHRT1dQf3+44oScvR1h6yIRERHZHAMnStXrLf/Ld3p94UGJimW+ExER5W4MnChVDg55ZMZLNaVwPle5GBIlHyw/wfnsiIgoV7N4HKfRo0dbvNFp06ZltDxkZ3w8XeWrHrWlx9w9suzwDakdUEB6NwywdbGIiIjsO3DCSOGGMFo4RhCvWLGiun3u3Dk1nHmdOnWsX0qyqfqlC8rY9hVl0uozMnHlSalSNJ/UCeA8hURElPtYHDht3rzZqEbJy8tLfv75Z/1Ev/fv35f+/ftLs2bNMqekZFODmpWRI9ceyOrjt1W+06oRzaSQF4emICKi3CVdI4drihUrJuvXr5eqVasarT9x4oQa6+nmzZtiTzhyuHVExiZIp292yoXgSGlQuqAsfLWBODkyTY6IiLK3TBs53PAFQkJCUqzHuogIdlvPqTxdnWR2rzrq/71B92TKmjO2LhIREVGWylDg1LlzZ9Us99dff8n169fV8ueff8rAgQOlS5cu1i8l2Y1yfp7yRbca6u8fdgTJyqP2VbtIRERkd4HT7Nmz5ZlnnpFXXnlFAgIC1IK/27dvL99++631S0l2pX21ojKkRVn199g/j8m5O6xlJCKi3CFDOU6aqKgouXjxovq7bNmy4uHhIfaIOU7Wl5CYJH3n7ZOdF0KljK+HLB/eRPK5Odu6WERERPaX46RBoFSjRg212GvQRJkDSeGzXq4l/vnd5NLdKBnzx1FJSuLgmERElLNlOHDavn279OrVSxo1aiQ3btxQ63755RfZsWOHNctHdj445ne96oiLo4OsP3VHZm06b+siERER2V/ghETwdu3aSd68edXAmLGxsWo9qrgmTZpk7TKSHQss4S3/61xN/T3j3/Oy9sQtWxeJiIjIvgKn//3vfypBfO7cueLs/F9eS5MmTdSI4pS7dK9bQgY0Ka3+fnPxUTl1M9zWRSIiIrKfwOns2bPSvHnzFOuRWPXgwQNrlIuymfeerSTNyvvKw/hEGbTggIRGJtdCEhERSW4PnIoUKSIXLlxIsR75TWXKlLFGuSgbJot/3aO2lPJxlxsPHsrQhYckLiHJ1sUiIiKyfeA0aNAgGTVqlOzdu1fy5MmjplhZuHChjBkzRoYOHWrdElK2kd/dWX7oW1eNLL4v6J58tPKkrYtERERkm0l+Db377ruSlJQkbdq0kejoaNVs5+rqqgKnESNGWLeElK2U8/OSWT1qysCfD8hve69K5aL5pHfDAFsXi4iIyPYDYMbFxakmu8jISKlSpYp4enqKPeIAmFlv9taLai47J4c8smBgfWlc1tfWRSIiIrLdAJgYx2nAgAHy6quvSrFixVTQxHGcSPNa8zLSqaa/JCTpZNjCQ3IlNMrWRSIiIrL9OE4YfuBJxnGaPHmy1KtXT7y8vMTPz086deqkeu0ZiomJkWHDhomPj48K0F588UW5c+dORopOWQS5b1NerCGBxfPL/eh46T9/v4RFx9u6WERERNl7HKetW7eqoGjPnj2yYcMGiY+Pl7Zt26p58DRvvvmmrFy5UpYsWaIej2T0Ll26ZKTolIXcnB1lTp+6ydOyhETJkF8PsqcdERHlvhwnd3d3OXXqlJQqVUrVFB09elQNQ3Dp0iWV64QaoowKCQlRNU8IkJB0jlqsQoUKyW+//SZdu3ZVjzlz5oxUrlxZdu/eLQ0bNnzsNpnjZFunb4VLt9m7JTI2QbrVKS5Tu9ZQNVJERES5IscpM8dxQqGhYMGC6v+DBw+qWqinnnpK/5hKlSpJyZIlVeBkDpoOsRMMF7Id9Kz76pVa4pBHZMnB6/Ltlou2LhIREVH2H8cJQxy88cYbqsmvWrXk+c9u374tLi4u4u3tbfTYwoULq/tSy5tC5KgtJUqUyHCZyDpaVfSTj5+vqv7+fN1ZWXn0pq2LRERElL3HcUKu04kTJ564Z964ceNk9OjR+tuocWLwZHu9G5WSy6HR8uOOIHlryVHx984rdQIK2LpYRERE1q9xOnbsmAqWALVM77//vty7d08FOkjsRm7SJ598Ihk1fPhwWbVqlWzevFmKFy9u1CyI8aJM58BDrzrcZw6COLRRGi5kH957trI8VbmwShLHnHZXQ6NtXSQiIiLrB061atWSu3fvqr+RxxQaGqqa0JAMXr9+/QwPfoncdARNy5Ytk02bNknp0qWN7q9Tp47qubdx40b9OgxXcPXqVWnUqFGGXpNsx9EhjxpZvFqxfHIvKk76z9/HYQqIiCjnBU7IMQoKClJ/X758WV/79KTQPPfrr7+qXnPooYe8JSwPHz5U9yNHaeDAgarpDbVRSBbv37+/Cpos6VFH9sfdxUl+7FtPiuZ3k4shUTLolwMSE59o62IRERFZbziCwYMHy4IFC6Ro0aKqtgfNaY6OjmYfi2EJLJVat/R58+ZJv3791N8Y3uCtt96S33//XfWYw+Cb3377bapNdaY4HIH9DlPQffZuiYhNkGeqFZGvX6mtaqSIiIiyUnrihHSN47R27Vo1DMHIkSNl4sSJqobIHPS4sycMnOzX7ouh0venfRKXmCR9GgWonncc44mIiOw1TkhXr7r27dur/9FchuAotcCJyFKNyvrItJcCZcTvh2XB7itSOJ+bDGtVztbFIiIist44TmhGY9BE1vJcDX/58Lkq+jGelhy4ZusiERERWS9wIrK2/k1Ky5AWZdXf7/51XDafDbZ1kYiIiFJg4ER2Y2z7itKlVjFJTNLJ678ekiPXjMfuIiIisjUGTmQ3kBT+Wdca0rxCIXkYnygD5u+XSyGRti4WERFRxgMnTLiLqVbOnz+f3qcSPZazo4N817O2VC+WXw2Q2fvHfXLzQfKYXkRERNkucMIo3ph+hSizeLg6ybz+9aSMr4fcePBQev24V+5Gxtq6WERERBlrquvVq5f8+OOP1i8N0SO+nq7yy6sNxD+/m1wKiZI+P+6TsIecmoWIiGwrXeM4aRISEuSnn36Sf//9V80l5+HhYXT/tGnTrFU+ysWKeeeVX19tIN2/3y2nboXLwPn7ZcHA+mrKFiIiIltI18jhmlatWqW+wTx51GS99oQjh2dvp26Gy0tzdktETII0K+8rP/StK65O5qf7ISIispspV7IrBk7Z38Er96TXD/tUbzvMa/dVj1ri5MhOoURElLVxAr95KFuoE1BQ5vapKy6ODrLmxG01SGZSUo6P+YmIyM5kOFnkwYMHKkH89OnT6naVKlVk4MCBKmIjygxNy/vKrB61ZNhvh2Tpwevi6eokEzpW4aTARESUZTJU43TgwAEpW7asTJ8+Xe7du6cW/I11hw4dsn4piR5pX62ITH2xhvp7/q7L8uk/pyUXtDYTEZGdyFCOU7NmzaRcuXIyd+5ccXJy0ve0e/XVV+XSpUuybds2sSfMccp5ftt7Vd5bdlz9/VqLMvJu+0qseSIiIvtMDs+bN68cPnxYKlWqZLT+1KlTUrduXYmOjhZ7wsApZ/plzxUZv/yE+vv1lmXl7XYVGTwREZH9JYdjo1evXk2x/tq1a+Ll5ZWRTRKlW++GAfJRxyrq72+3XJTp/3IaICIiylwZCpxeeukllQi+ePFiFSxhWbRokWqq69Gjh/VLSZSKfk1Ky/jnkoOnWRvPy0wGT0REZG+96r744gvVJNKnTx+V26TNYTd06FCZMmWKtctIlKaBTUuroQk+XX1apv97Tpwc88iwVuVsXSwiIsqBMpTjhGa64sWLS0xMjFy8eFGtQ4865D6h9qlkyZJiT5jjlDt8t+WifLb2jPp7bPtKMrRlWVsXiYiIsoH0xAkZqnEqXbq03Lp1S/z8/KR69er69aGhoeq+xMTEjGyW6IkgUEpMSpIv1p9TAVRCYpKMaFPe1sUiIqLcnuOUWiVVZGSkuLm5PWmZiDJseOvyMqZtBfX3lxvOyRfrznKcJyIispp01TiNHj1a/Y/8pg8//FDc3d3196GWae/evVKzZk3rlY4og8ETJgFGztPXmy9ITHyivN+hMocqICKirA2cMHYT4Bf88ePHxcXFRX8f/g4MDJQxY8Y8eamIntCg5mXE1dlBPlxxUn7YESSxCUny8fNVxcGBwRMREWVR4LR582b1f//+/WXmzJlMtCa71qdRKTUp8Lhlx9VgmXEJSTKpS3VxZPBEREQZlKHk8Hnz5mX09Yiy1Mv1S6qap7f+OCqLD1yTuMQk+bxrDXFyzFB6HxER5XIZ+vaYPHmy/PTTTynWY91nn31mjXIRWU3nWsXlqx61xckhjyw7fENGLjqsap+IiIiyJHD6/vvvU8xTB1WrVpXZs2dnZJNEmapDjaLybc/aqulu9fHbMvDn/RIdlzx4KxERUaYGTrdv35aiRYumWF+oUCE1vhORPWpbtYj80Leu5HV2lO3n78orc/fK/ag4WxeLiIhyeuBUokQJ2blzZ4r1WOfv72+NchFliuYVCsnCQQ3E291Zjlx7IN2/3y23w2JsXSwiIsrJgdOgQYPkjTfeUEniV65cUQvym9588011H5E9q12ygCx5rZEUyecm54Mj5cXvdknQ3ShbF4uIiHLqXHV4yrvvviuzZs2SuLg4dRvz1I0dO1bGjx9vdwMNcq46Muf6/Wjp/eM+FTT5eLjIzwPqS7Vi+W1dLCIisuM4IUOBk+EUK6dPn1ZBU/ny5cXV1VXsEQMnSs3dyFjp+9M+OXkzXLxcnWRu37rSsIyPrYtFRER2Gic80WA2V69eVRP7Xrp0SdatWyd///23WtJj27Zt0rFjR5UbhZqq5cuXpwjOhg8fLsWLF1cBWpUqVdhzj6zG19NVFg1uKA1KF5SI2ATp89M+WXM8uYODLjFRovbuk7BV/6j/cZuIiHK3DA2AiUCpc+fOatoVBDtapZXWRId56ywVFRWlpmoZMGCAdOnSxez8eJs2bZJff/1VSpUqJevXr5fXX39dBVrPP/98RopPZMTLzVk10438/bCsP3VHXv/tkEwrcl+qLftREm7f1j/OqUgRKfzeOMnXtq1Ny0tERLaToRqnUaNGSenSpSU4OFhN9HvixAlVc1S3bl3ZsmVLurb1zDPPyP/+9z8ViJmza9cu6du3r7Rs2VIFToMHD1aB1r59+zJSdCKz3Jwd5btedaRPowBpdOO4VPzuU4k3CJog4c4duTHqDQlfv95m5SQiomwYOO3evVsmTpwovr6+4uDgII6OjtK0aVM1ovjIkSOtWsDGjRur5r8bN26omi3Ml3fu3Dlpy1/9ZGWYw+6jDpXknfP/qNspujg8qlm9M2kym+2IiHKpDDXVoSnOy8tL/Y3g6ebNm1KxYkUJCAiQs2fPWrWAX331laplQo6Tk5OTCtTmzp0rzZs3T/U5sbGxajFM+tIG7kTToMbNzU0KFCggCQkJEhISkmI72iCfd+/elfj4eKP7vL29Vc4VtqdtX+Pi4iI+Pj6SlJQkd+7cSbFdPz8/FWzeu3fPqJyA/erp6SkPHz6UBw8eGN2H949BRsHcQKM4Fs7Ozup5eL4hDw8PlfCG18PrGsI+LVy4sPob5UW5DRUsWFAl/uN9Gu4/wD7AvsD+wX5KbR9i/2I/m9uHyGOLiIgwug+vh9fFuYaaTVMoL8qNHDv07DSE94n3a24fYv9gP6W2Dz2CLovr/ZTvQ0+nU81319avF+eaNfWrcTxxXFPbhzgfcF6Y24eotUVSorl9iObvIkWKpLoPcf7iPDa3D7XzO7V9iO1i++b2IcqDckVHR6tkSXPnN37I4DOV2vl9//59iYmJMXt+Yz3uT+38xnZN+61o5zfKg3KZO7/xPvB+Uju/sR9MUwm08xv7D/vR3D7kNYLXCA32L/azufMbxwXHx9w+5DXCvq8ROM8yNXCqVq2aHD16VDXXNWjQQKZOnap21Jw5c6RMmTJi7cBpz549qtYJgRmaBIcNG6ZynJ566imzz0HN18cff5xiPcadwomiqV69usqrwomKspuaMGGC+n/FihVy/fp1o/vQtFijRg05efKkrFmzxui+smXLSq9evdRJbm67Y8aMUQcRCfWoPTOEmrRGjRqpPLKlS5emOIlfe+019fePP/6Y4gtg6NCh6oTEPjp8+LDRfU2aNFH7CxeCn3/+OcWJilwyWLhwYYoPF5pK0UyK5lHTgU9r1aqlcs1wgpu+V3wwPvjgA/X3X3/9leID1LVrVzVND3LlkLtmqEKFCtKjRw/14TG3DzEcBi6c2PcXL15M0fxbv359OX/+vCxbtszoPgTgAwcOVH+b2+6rFVNOJWTOv38skWsGzcW4+Gi1rQsWLEjxoUUOHwaORW0tzmdDaOLu0KGDuiCalgmfq3Hjxqm/lyxZkuLL++WXX1Y/WnC8kQtoCB0punXrpi7C5t7r+++/ry5EK1euVGOxGUKHjdq1a8uZM2fU/YbwOezXr586/8xtF+O54QL177//yqlTp4zua926tTRr1ky93qJFi4zuwwUR+YvaZ9X0Qo0fUPiS3bFjhxw4cMDovoYNG0q7du3UF5LpPJq4uL/99tvqb7ym6cW4Z8+eUq5cOTl48KBs3brV6D5eI5LxGvGfESNGqIANrR8ol6EWLVqotJJr166p/WSI1wj7vkZonxtLZGg4AnyYsaNxQblw4YI899xz6sONCHPx4sXqjWcEIlucxJ06dVK38WsAUS3W4aTRvPrqq+oitXbtWotrnHBCojZMqykD/ppMxl+TBvsp6LLcGDAgxfoUj5s+jTVO2ejXJGucjPchrxGscQJeI4xrnLJkHCdDOElwAJ5k8EvTwEkbV2H16tXqF4IGkWFQUFCKXyCp4ThOZCnkLl1o85RKBNdymgzhUpfoU0iqb9sseRwdbVJGIiLKpuM4GULkn5GgCVHwkSNH1AIIiPA3xohC4VH1iWp29NbDffPnz1fVnKn1wiN6EgiGMORA8g3j8xlhFNZMKfusfL7hvCQlWeU3BxERZSMZrnHavn27fP/996rtGO3sxYoVk19++UXlPaGHnaUQELVq1SrFerSZI0hCdRzab1G7hFottJ2iHRNtpJYGaqxxovTCkAPoPWc6jtOeZ/vI+HvJ1e3tqhaW6S/VFHeXDKUKEhFRbply5c8//5TevXurpEoES0juQlL4119/rZrVsNgTBk6U0Wa76AMHJSEkRJwKFRL3unVUjdRfh67Lu38el7jEJKlSNJ/80Leu+Htb3iODiIhyWeCEXhKo8enTp49K5EIPOwROyNpHLpK5ZDBbYuBE1nbwyj157ZeDcjcyTk3bMrdPHalVsoCti0VERPaY44TeaebGUcKLmvZQIMqJ6gQUlOXDmkilIl5qouCX5uyRZYeNu6MTEVHOk6HACV0UMQyBKYydYO1xnIjsVfEC7rJ0aGN5qnJhiUtIkjcXH5WPV56U+ETjbsZERJTLA6dBgwap+er27t2rErQxcjgG+8KgbRhgjSi38HR1kjm968jI1uXU7Xk7L0uvH/aqWigiIsp5MpTjhKdMmjRJjdCtDTKFwcgQOH3yySdib5jjRFlh3cnb8tYfRyUyNkGK5ndTkwbXLOFt62IREZEtk8Mxcmn79u1l9uzZamgANNlhLCYM3Y7RPu0RAyfKKheCI2XwLwfkUkiUuDg6yCedqspL9UraulhERGSr5HAMZ37s2DH9sOoImDDnj70GTURZqZyfp6wY1kTaVimshisY++dxeX/ZcZUDRUREuTTHCZNTYgJJIkrJy81ZZveqI289XUENPr5w71Xp/v1uufHAeG4wIiLKfjI05DEmEcTswpjZuE6dOmryPEPTpk2zVvmIsiUHhzwyok15qVYsv4xadFiOXHsgHWZtl2ndA6V1peTJUomIKJckh5ubIkW/wTx5ZNOmTWJPmONEtnTtXrQM/+2QHL2ePIP4kBZlZUzbCuLkaLWpIomIyJ5HDs9uGDiRrcUmJMrk1Wdk/q7L6na9UgXkqx61pUh+N1sXjYgo1wvP7JHDiSh9XJ0c5aPnq8q3PWursZ/2X74vz87aLtvOhdi6aERElA4MnIiy0LPVi8qqEU3V5MD3ouKk77x98uX6s5LA0caJiLIFBk5EWayUr4f89XpjeaVBSUFD+VebLqhed8iFIiIi+8bAicgG3JwdZVLn6vJVj1ri5eokh64+kGdnbpcVR27YumhERJQGBk5ENtQx0F9Wj2omdQIKSERsgoxadERGLz6ipm0hIiL7w8CJyMZKFHSXxYMbyqg25cUhj8hfh2+oMZ8w9hMREdkXi4cjGD16tMUbtbcBMDkcAWUX+y/fkzcWHVGjjDs55JE3n66gxn1yRERFREQ2jxMsHjn88OHDFj0OA2ASUcbUK1VQNd29t+y4/HPslny+7qxsPH1HvuxeU0r7Go/QT0REWY8DYBLZIXws/zx0Qz7++6TKfcrr7CjvPVtJejUM4I8TIqLsOnL4qVOn5OrVqxIXF/ffBvPkkY4dO4o9YeBE2RWa7N5eclR2XQxVt5uV95WpXWtI0fx5bV00IqIcI9MDp0uXLknnzp3l+PHjKlDSNqH9Ek5MTBR7wsCJsrOkJJ0s2H1Zpqw9IzHxSeLl5iQfP19VOtcqxtonIqLsMOXKqFGjpHTp0hIcHCzu7u5y8uRJ2bZtm9StW1e2bNmS0XITkRkODnmkX5PSsnpkM6lZwlsiYhJk9B9HZcivByU4IsbWxSMiylUyFDjt3r1bJk6cKL6+vuLg4KCWpk2byuTJk2XkyJHWLyURSZlCnrJ0SCN5u11FcXbMI+tO3pGnp22TPw9e19f6EhGRHQZOaIrz8vJSfyN4unnzpvo7ICBAzp49a90SEpGek6ODDGtVTlYMayrViuWTsIfx8taSo9Jv3n6VD0VERHYYOFWrVk2OHj2q/m7QoIFMnTpVdu7cqWqhypQpY+0yEpGJKv75ZPnrTeSd9hXFxclBtp4LkbbTtsovuy+rnCgiIsocGUoOX7dunURFRUmXLl3kwoUL8txzz8m5c+fEx8dHFi9eLK1btxZ7wuRwyskuhkTK2KXH5MCV++p2/VIFZcqL1VXTHhER2dFwBIbu3bsnBQoUsMtePgycKLf0vJu67qxExyWqWqgRrcrJ4BZlxNXJ0dbFIyLK3b3qMHaTabxVsGBBFTThPiKyTc+7dW80V2M9xSUkyZcbzsmzM7fLnkvJY0AREdGTy1DghKEIQkJCUqwPDQ1V9xGR7SYMXjCgvsx4qab4errIxZAoeXnOHnnrj6NyL+q/gWqJiCgLAyfUNplrkouMjBQ3N7cMFoWIrAGfzU61isnG0S3llQYl1bo/D12X1l9ukT/2X2PyOBHRE7B4kl8YPXq0/sI8fvx4Nfil4RAFe/fulZo1az5JeYjISvK7O8ukztXlxdrF5f1lx+XM7Qh5589jsvTgdZnYqapUKsJ8PyKiTA2cDh8+rK9xwnQrLi4u+vvwd2BgoIwZMybdhSCizFMnoICsHNFU5u0Mkukbzsu+y/ekw6wd0rthgLz5VAUVYBERkWUy1Kuuf//+MnPmzGzTQ4296oiSXb8fLf9bdVrWnrytbhf0cJF32lWU7nVLqARzIqLcKDyze9XNmzdPkpKS5Msvv5RXX31VLdOnT1cvmF6Y465jx47i7++vmgCXL1+e4jGnT5+W559/Xr0pDw8PqVevHnvvEWVA8QLuMrt3Hfl1YAMp5+epEsbf/eu4dP52pxy+mjwOFBERWTlwOnDggJQtW1YFSxi/Ccu0adPUukOHDqVrWxhIE01833zzjdn7L168qObBq1SpkppA+NixYyq/iknoRBnXtLyvrBnVTD7oUFk8XZ3k6PUw6fztLhmz5KiERMTaunhERDmrqa5Zs2ZSrlw5mTt3rjg5JadJJSQkqJqnS5cuqVqkDBUmTx5ZtmyZdOrUSb/u5ZdfFmdnZ/nll18ko9hUR5S64IgY+WzNWdXzDjxcHOX1VuVkYNPS4ubMwTOJKOcLz+ymOtQ4jR07Vh80Af5+55131H3WgubAf/75RypUqCDt2rUTPz8/NTeeueY8Q7GxsWonGC5EZJ6fl5t82T1Q/nq9sQQWzy9RcYny+bqz0vqLLbLiyA0OX0BE9KSBE6IxczlG165dEy8vL7GW4OBgNTbUlClTpH379rJ+/Xrp3LmzmiNv69atqT5v8uTJKnLUlhIlSlitTEQ5Ve2SBWTZ601k5ss1xT+/m9wMi5FRi45I5+92yYHL92xdPCKi7NtUN3LkSNWk9sUXX0jjxo3Vup07d8rbb78tL774osyYMcMqTXU3b96UYsWKSY8ePeS3337TPw6J4kgS//3331OtccKiQY0Tgic21RFZJiY+UX7cESTfbr6gaqDg2epFZGz7ShLg42Hr4hER2aypLl3jOGkQMCHI6dOnj8ptAuQhDR06VNUOWYuvr69qAqxSpYrR+sqVK8uOHTtSfZ6rq6taiChjkNs0rFU56Va3uEzfcE4W778mq4/flvUn70iP+iVlRJtyqomPiCi3yVBT3e3bt1WPuvv378uRI0fUovWsu3PnjtUKh0E1MfTA2bNnjdafO3dOAgICrPY6RGQegqPJXWrI6lHNpHmFQpKQpJNf9lyRFlO3yOfrzkjYw3hbF5GIKEtlqMYJE/neunVLJWtXr149xSS/mH7FUshhunDhgv52UFCQCsQKFiwoJUuWVM1/L730kjRv3lxatWola9eulZUrV6qhCYgoa2B6FkwevPtiqExdd0YOX30g32y+KL/uuSqvtywrfRuXYg88IsoVMpTj5ODgoGqdEDgZunLlimpWw9hMlkIAhIDIVN++fWX+/Pnq759++kklfF+/fl0qVqwoH3/8sbzwwgsWvwaHIyCyHlwyNpy6o3renQ+OVOsK53OVN56qIN3qFBcnxwxVZBMR2Ux64oR0BU7aJL+YbmXQoEFmJ/l1dHRUieL2hIETkfUlJulk2eEbKgfqxoOHal1pXw8Z/XQF6VC9KKdwIaJsI9MCJ61mCEMBNGrUKMUkv6VKlVKT/JYvX17sCQMnoswTm5Aov+29Kl9vuiChUXFqXcXCXjKyTXl5ploRBlBElHsDJw0n+SUiU5GxCfLj9iD5YfsliYhN7m1bobCnCqCercYaKCLKxYFTdsPAiSjrhEXHy087g9QSEZMcQJX385QRbcqrJjxHBlBEZGcYOJlg4ESU9TBUwbydQWogTS2AKocAqnU5ea6GPwMoIrIbDJxMMHAism0ANX/nZflxxyUJfxRAlS3kIcMfBVDO7IVHRDbGwMkEAyci2wuPiZefd16WH3YE6QfOLOadVwY1Ky0v1SspeV04DhQR2QYDJxMMnIjsR0RMvCzYfUV+2hGk74VX0MNF+jUuJX0aBYi3+3+9dYmIsgIDJxMMnIjscyLhJQeuyZztl+TaveRxoNxdHNVceK82Ky1F8+e1dRGJKJcIZ+BkjIETkf1KSEyS1Sduy3dbLsrpW+FqnbNjHnmhZjEZ0qKMlPPzsnURiSiHC2fgZIyBE5H9w6Vo67kQmb31ouy5dE+/vlXFQjKwaRlpUs5H8uRhTzwisj4GTiYYOBFlL4ev3lc1UBtO3xHtCoXBNAc0KS2dahXjhMJEZFUMnEwwcCLKnoLuRsnPuy7LHweuSXRcoj6RvGeDktK7YYD45XOzdRGJKAdg4GSCgRNR9obhC/7Yf03m77qsn1AYeVAda/jLgKalpVqx/LYuIhFlYwycTDBwIso5ieTrT91RQxkcuHJfv75uQAHp3ShA2lcrIq5ObMYjovRh4GSCgRNRznP02gM1pcuqY7ckISn5Mubj4SIv1SuhhjQoUdDd1kUkomyCgZMJBk5EOded8BhZtO+a/LbvitwJj1Xr0PmudUU/6dUwQJpXKMR58YgoTQycTDBwIsr54hOTZOPpO/Lrnquy48Jd/foSBfNKzwYB0r1uCZVYTkRkioGTCQZORLnLxZBIWbjnqiw9eE0/sbCLo4O0q1ZEXqpbQhqX9REH1kIR0SMMnEwwcCLKnR7GJcrKozfllz1X5PiNMP364gXyqhqornWKi783p3Yhyu3CGTgZY+BERMevh8niA1dlxeGbEhGboM+Fal6+kLxcr4S0qVxYXJwcbF1MIrIBBk4mGDgRkWEt1JoTt2Tx/muyN+i/qV3QI69zrWKqV175wpwfjyg3CWfgZIyBExGlNjI5RiVfevC6hEQk98iD6sXyS5faxaRjoL/4erratIxElPkYOJlg4EREjxtYc/PZEFULteVssH5cKAxj0LJCIelSu7i0qezHOfKIcigGTiYYOBGRpUIjY1VC+bLDN+To9f8Syr3cnOS5GkVVEIWRyvMgQYqIcgQGTiYYOBFRRlwIjpC/Dt2Q5YdvyM2wGKOxoV4ITG7Kq1iE+VBE2R0DJxMMnIjoSSQl6WRPUKgsO3RDVh+/JVFxifr7KhT2VJMNI4gq5eth03ISUcYwcDLBwImIrNkrb8PpO6o5b+vZEIlLTNLfV6N4fhVEdahRlONDEWUjDJxMMHAioswQ9jBe1p+8LX8fvSm7LoZK4qOkcqhfqqA8F1hU2lUtIoXzudm0nESUNgZOJhg4EVFmuxsZK2tO3JaVR27Kvsv/jQ8FdQIKSPuqRaR9tSJSoqC7zcpIROYxcDLBwImIstKtsIfyz7FbKh/q0NUHRvdVK5ZPnqmWXBNVzs/TZmUkov8wcDLBwImIbOV2WIysO3lbjVa+L+ieGLTmSXk/T3mmGmqiikrlol4c4oDIRhg4mWDgRET2MkbUhlN3VJPerot3JT7xv8tvgI+7qoVqU8lPNe05OXLePKKswsDJBAMnIrLHxPJNZ+7ImuO3Zeu5EIlN+K93Xv68ztKqYiE18XCLioUkn5uzTctKlNOFpyNOsPlPmm3btknHjh3F399fVVMvX7481ccOGTJEPWbGjBlZWkYiImtDcNS5VnGZ06euHBr/tHzbs7Z0qVVMCrg7q6Bq+ZGbMuL3w1J74gZ5Ze4e+XFHkFwJjbJ1sYlyPSdbFyAqKkoCAwNlwIAB0qVLl1Qft2zZMtmzZ48KsIiIchIPVyd5tnpRtWBIg0NX78u/p+7Iv6fvyMWQKDXUAZZPVp1SCeWYN++pyoWldskCaj49IspFgdMzzzyjlrTcuHFDRowYIevWrZMOHTpkWdmIiLIaAqF6pQqqZdyzleXy3SgVQG08HSz7L9+TC8GRavl+6yVVa9WsvK+0qFBILX4cL4oo5wdOj5OUlCS9e/eWt99+W6pWrWrr4hARZSlM4/JqszJqQRMe8qE2nr4jW86GqNurjt1SC1Qumk8fRCHB3MXJ5tkYRDmO3QdOn332mTg5OcnIkSMtfk5sbKxaDJO+iIiyO9QwPR/or5aExCQ5ev2BmvYFwdSxG2Fy+la4WmZvvSgeLo7SuNx/tVEceJMoFwROBw8elJkzZ8qhQ4fSNb7J5MmT5eOPP87UshER2RKGK6gTUFAto9tWVEMd7LhwVwVS286HyN3IODX0ARYoU8hDmpXzlSblfKVhWR/21CPKILsajgDBEZLAO3XqpG6j99zo0aPFweG/6ubExER1u0SJEnL58mWLa5zweA5HQES5QVKSTk7dClc1UVgOXrlvNI8e8smrF/eWpuV8pElZX6kdUEDcnB1tWmYiW8q24ziZBk6hoaFy61Zy272mXbt2Kuepf//+UrFiRYu2y3GciCg3C4+Jl10XQmXnhbuy8+JduRRiPKyBq5ODSkZv/CiQqlYsP3vrUa4Sno44weZNdZGRkXLhwgX97aCgIDly5IgULFhQSpYsKT4+PkaPd3Z2liJFilgcNBER5XZolsMEw1i0ufR2XgiVXY8CqTvhyc18WETOSj43J2lU1kcalfGR+qV9pFIRL3FgIEVkH4HTgQMHpFWrVvrbaJqDvn37yvz5821YMiKinKlo/rzStU5xtaDR4WJIpAqkUCO1+1KohMckyLqTd9SiJaWjRqphmYLSoLSPVPHPxxopyrXsqqkus7CpjojIMuitd+JmuAqi9gbdk4OX70lUXKLRY7xcnaRuqQLSoIyPNChdUDXtOXNuPcrGsm2OU2Zh4ERE9GSB1N5LoSqQ2h90TyJiE4we4+7iqMaNQq1U3YACEljCW42GTpRdMHAywcCJiMg60DsPY0XteRRI7Qu6pwbiNIRmvMpFvaSuGi6hgFr8vfParMxEj8PAyQQDJyKizBv64OydCBVAHbhyXzXt3QyLSfE4//xuUudRjRQCKSScYywqInvAwMkEAycioqxz88FDNXYUlgNX7snpWxFG40gBRjavWdJb6pQsoMaRCizuLQU8XGxWZsrdwhk4GWPgRERkO1GxCXL02gNVI4Xl8JX7KfKkoJSPu8qPqlnCW/1fpWg+DsxJWYKBkwkGTkRE9gO1T+eDI+TA5eRaqSPXHkjQXeNBOcHZEblS+ZIDqeLJwVQZXw+OKUVWx8DJBAMnIiL79iA6To5eD1M1U1gQTIVGxaV4nJebkwqiEEzVKJ5fqhfPL0XyuaVrPlMiUwycTDBwIiLKXvDVdP3+Qzl6/YEcufpA/X/8RpjExCeleKyvp4saS6qaf/7k/4vlk2LeeRlMkcUYOJlg4ERElP3FJybJuTsRcvRamBy5dl+OXQ+T88GRKRLPoYC786MgKr9UfxRUlSjIYIrMY+BkgoETEVHOFBOfqMaVOnEjTE7cCFe1UgiuEswEU5g6BrVRCKIwbQzyp0r7enDUcxIGTiYYOBER5R6xCYly9naECqIQTCGowu24xJTNfC5ODlLez1MFUcmLl+rN5+3OoRFyk3AGTsYYOBER5W5xCcnNfKpm6maYGlvqzK3wFPPwaYrmd1ODdP4XUCXXTnFy45yJgZMJBk5ERGRu1PNr96NVUx8CKfX/7XC5du+h2ce7OTtIxcJeUqlIcs1UhcJeUqGIl/h6umZ52cm6GDiZYOBERESWCo+JV017yQFVclCF2w/jzddOFfRwUc19FYt4SXkEU36eKqjiSOjZBwMnEwyciIjoSaDn3pXQKH3N1Jnb4XLuTqSqsUrtW7SQl6tUKOwp5f28VFCl/i7sJfncnLO6+PQYDJxMMHAiIqLM8DAuUS4ER6r8qf+WSLnxwHxzH2DATjTxoZaqbCEsHlLWz1N8PFw4XIKNMHAywcCJiIiyUmRsQnJAdftRMBUcKefvRMitsJhUn4PhElQQhWDqUVBVzs9TShTIK04cMiFTMXAywcCJiIjsQdjDeLkQnFwrhcDqYkjyglHSU/s2xpx9pXy0gOrR/4U8pUwhD/Fis59VMHAywcCJiIjsfSBPTHSsAqngR/+HRMqlkKhUk9IBPfpK+7qrwKqUr4caMiH5b3dxd3HK0veQnTFwMsHAiYiIsuuQCbfCY+SiQe2UFlgFR8Sm+dzC+VxVEKWCKYOACv+7OTtm2XvIDhg4mWDgREREOXHYhMt3o1RN1eW70arXX1Ao/o6S+9HxaT4XA3z+V0v1X41ViQLuktcl9wVV4QycjDFwIiKi3CQsOl4fRKnAyuDv8JiENJ+LYRRKFnRXS4lH/2uLn5erOOTA0dMZOJlg4ERERCSCr3zURiXXUiUHVFpghRHTkbyeFhcnB9XLzzCwMgyuPFydcnyckD3fIREREaUbxonCSOdY6gQUMFtThUE9r977b7n26P8b9x+qOf8uhiDHKsrs9jEWFQKp4gXySvEC7lIM/3vnVf8X886bbQMrQ9n/HRAREZFV5Hd3lvzu+aVasfwp7ktITFLjUGmBlGlghZqs0Kg4tRy59sDs9gu4O+uDqGLeyQGWdht/Yywrex8ElIETERERPRYG4SzxqGmucSrJ6iqICo1WI6djbCos+PvG/WiVW4XgCsuJG+FmX8PT1Sk5qNKCK1Vz9d/fhTxdbR5YMceJiIiIMl14TLxq7lOLCqySAyzt9t3IuMdu4/OuNaRb3RLWLxtznIiIiMie5HNzlnxFnaVy0XypzvunAqlHwZRpYHU7PEbVOtkaAyciIiKyubwujmpuPizmIDHdHkZCYOBEREREds/FyT4mOraPUhARERFlAwyciIiIiCzEwImIiIjIQgyciIiIiLJL4LRt2zbp2LGj+Pv7q0Gtli9frr8vPj5exo4dK9WrVxcPDw/1mD59+sjNmzdtWmYiIiLKnWweOEVFRUlgYKB88803Ke6Ljo6WQ4cOyfjx49X/f/31l5w9e1aef/55m5SViIiIcje7GjkcNU7Lli2TTp06pfqY/fv3S/369eXKlStSsmRJi7bLkcOJiIgoV44cjjeFAMvb2zvVx8TGxqrFcIcQERERPSmbN9WlR0xMjMp56tGjR5oR4eTJk1XkqC0lSlh/XhsiIiLKfbJN4IRE8e7duwtaFr/77rs0Hztu3DhVM6Ut165dy7JyEhERUc7llJ2CJuQ1bdq06bHtj66urmrRaGlcbLIjIiIiU1p8YEnat1N2CZrOnz8vmzdvFh8fn3RvIyIiQv3PJjsiIiJKK15Aio9dB06RkZFy4cIF/e2goCA5cuSIFCxYUIoWLSpdu3ZVQxGsWrVKEhMT5fbt2+pxuN/FxcWi18D4T2iu8/LyUonl1o5SEZBh++yxl7W4722H+952uO9th/vedjJ736OmCUET4gW7H45gy5Yt0qpVqxTr+/btKx999JGULl3a7PNQ+9SyZUuxNQ51YDvc97bDfW873Pe2w31vO/a0721e44TgJ63YzY6GmSIiIqJcLtv0qiMiIiKyNQZOTwi99yZMmGDUi4+yBve97XDf2w73ve1w39uOPe17m+c4EREREWUXrHEiIiIishADJyIiIiILMXAiIiIishADpyfwzTffSKlSpcTNzU0aNGgg+/bts3WRcqRt27ZJx44d1cBkGMB0+fLlRvcjTe/DDz9UA6bmzZtXnnrqKTXSPD0ZTJZdr149NXCsn5+fdOrUSc6ePZti4u1hw4apEf09PT3lxRdflDt37tiszDkF5uOsUaOGGq8GS6NGjWTNmjX6+7nfs86UKVPUdeeNN97Qr+P+zzwYvxH723CpVKmSXe17Bk4ZtHjxYhk9erTK8sfI5oGBgdKuXTsJDg62ddFynKioKLV/EaiaM3XqVJk1a5bMnj1b9u7dKx4eHupY4ANGGbd161Z1gdqzZ49s2LBBTX/Utm1bdTw0b775pqxcuVKWLFmiHn/z5k3p0qWLTcudExQvXlx9YR88eFAOHDggrVu3lhdeeEFOnjyp7ud+zxr79++X77//XgWxhrj/M1fVqlXl1q1b+mXHjh32te/Rq47Sr379+rphw4bpbycmJur8/f11kydPtmm5cjqcssuWLdPfTkpK0hUpUkT3+eef69c9ePBA5+rqqvv9999tVMqcKTg4WO3/rVu36vezs7OzbsmSJfrHnD59Wj1m9+7dNixpzlSgQAHdDz/8wP2eRSIiInTly5fXbdiwQdeiRQvdqFGj1Hru/8w1YcIEXWBgoNn77GXfs8YpA+Li4tQvQTQJaRwcHNTt3bt327RsuQ3mNsT8hYbHAsPyo+mUx8K6MNWBNk8k4DOAWijDfY8q9ZIlS3LfWxHm6Fy0aJGq6UOTHfd71kBta4cOHYz2M3D/Zz6kWiA1o0yZMtKzZ0+5evWqXe17m0+5kh3dvXtXXcwKFy5stB63z5w5Y7Ny5UbapM/mjoV2Hz25pKQklePRpEkTqVatmlqH/YuJtr29vY0ey31vHcePH1eBEpqckcuxbNkyqVKlipoEnfs9cyFQRQoGmupM8bzPXPjRO3/+fKlYsaJqpvv444+lWbNmcuLECbvZ9wyciMiiX9+4cBnmGlDmwhcHgiTU9C1dulRNfI6cDspc165dk1GjRqm8PnT8oaz1zDPP6P9GbhkCqYCAAPnjjz9U5x97wKa6DPD19RVHR8cUmfy4XaRIEZuVKzfS9jePReYZPny4rFq1SjZv3qySljXYv2i2fvDggdHjue+tA7+sy5UrJ3Xq1FE9HNFBYubMmdzvmQzNQejkU7t2bXFyclILAlZ0QMHfqN3g/s86qF2qUKGCXLhwwW7OfQZOGbyg4WK2ceNGo6YM3EbVOmWd0qVLqw+M4bEIDw9Xvet4LJ4McvERNKGJaNOmTWpfG8JnwNnZ2WjfY7gC5CNw31sfrjGxsbHc75msTZs2qpkUtX3aUrduXZVro/3N/Z91IiMj5eLFi2q4Gbs597MsDT2HWbRokeq5NX/+fN2pU6d0gwcP1nl7e+tu375t66LlyN4thw8fVgtO2WnTpqm/r1y5ou6fMmWK2vcrVqzQHTt2TPfCCy/oSpcurXv48KGti56tDR06VJc/f37dli1bdLdu3dIv0dHR+scMGTJEV7JkSd2mTZt0Bw4c0DVq1Egt9GTeffdd1XsxKChIndO4nSdPHt369evV/dzvWcuwVx1w/2eet956S11zcO7v3LlT99RTT+l8fX1Vr1572fcMnJ7AV199pQ6gi4uLGp5gz549ti5SjrR582YVMJkuffv21Q9JMH78eF3hwoVVMNumTRvd2bNnbV3sbM/cPscyb948/WMQnL7++uuqq7y7u7uuc+fOKriiJzNgwABdQECAurYUKlRIndNa0ATc77YNnLj/M89LL72kK1q0qDr3ixUrpm5fuHDBrvZ9HvyTdfVbRERERNkXc5yIiIiILMTAiYiIiMhCDJyIiIiILMTAiYiIiMhCDJyIiIiILMTAiYiIiMhCDJyIiIiILMTAiYiIiMhCDJyIiIiILMTAiYjIAi1btpQ33njD1sUgIhtj4ERENseg5MlUrVpVJkyYYPa+yZMni4+Pj4SGhmZ5uYhyIgZORJSquLg4yU6yW3mtpXr16nLixIkU62/duiWTJk2SiRMnquCJiJ4cAyciMqr5GT58uKr98fX1lXbt2klSUpKqtShdurTkzZtXAgMDZenSpUbPW7t2rTRt2lS8vb3VF/Rzzz0nFy9e1N+PbUydOlXKlSsnrq6uUrJkSfn000/Vff369ZOtW7fKzJkzJU+ePGq5fPmyxMbGysiRI8XPz0/c3NzU9vfv3//Y8pqaM2eO+Pv7qzIYeuGFF2TAgAHqb0tey1CpUqVkxowZRutq1qwpH330kVHZRowYocpWoEABKVy4sMydO1eioqKkf//+4uXlpfbHmjVrjLZjyf42VaNGDbOB03vvvae2M2TIkDSfT0SWY+BEREZ+/vlncXFxkZ07d8rs2bPVl/iCBQvU3ydPnpQ333xTevXqpYIdDYKB0aNHy4EDB2Tjxo3i4OAgnTt31gcr48aNkylTpsj48ePl1KlT8ttvv6lAAhAwNWrUSAYNGqRqSLCUKFFC3nnnHfnzzz9VeQ4dOqSCDARG9+7dS7O8prp166aaqTZv3qxfh20g2OvZs6e6belrZWRfIqDbt2+fCqKGDh2qytO4cWP1Om3btpXevXtLdHS0/jmW7G9zNU4IVGNiYvTrDh48qLYza9YscXR0fKL3QUQGdEREj7Ro0UJXq1Yt/e2YmBidu7u7bteuXUaPGzhwoK5Hjx6pbickJESHy8vx48d14eHhOldXV93cuXPTfN1Ro0bpb0dGRuqcnZ11Cxcu1K+Li4vT+fv766ZOnZpqeVPzwgsv6AYMGKC//f3336ttJSYmpuu1tDIGBATopk+fbvQagYGBugkTJhg9vmnTpvrbCQkJOg8PD13v3r31627duqX20+7du59of1++fFlt5/Dhw/p1eO1u3bo9dt8QUfo4GQZRRER16tTR/33hwgVVG/L000+nyCWqVauW/vb58+flww8/lL1798rdu3f1NU1Xr15Vz0dTWJs2bSwuA2pP4uPjpUmTJvp1zs7OUr9+fTl9+nSq5U0NapZQo/Xtt9+qpsKFCxfKyy+/rGrG0vNa6YUmNA1qfdCMidohjVbrFhwcnK79bSogIEDy58+vmuvQZLh48WJV43TmzJknKj8RpcTAiYiMeHh46P+OjIxU///zzz9SrFgxo8chANF07NhRfXkjh0fLJ6pWrZr6wkeeTlaVNzUon06nU++jXr16sn37dpk+fXqGXxMBF7ZnCMGXKQRghpC/ZbgOt0ELNC3d3+ZgfyNwQnPd2LFj1YJcMiKyLuY4EVGqqlSpor6wUXOEvB/DBXlIgPyhs2fPygcffKBqlSpXriz379/Xb6N8+fIqeELuU2qQo5SYmKi/XbZsWX3ekmFggoRtlCm9kPDdpUsXVdP0+++/S8WKFaV27doZfq1ChQqpXCxNeHi4BAUFSVbs78cliH/xxRf6vC0isj7WOBFRqtDza8yYMSpBGbUi6G0WFhamgox8+fJJ3759VY8xNEGh91rRokXVl/67775rFLSg9gNf5AhQ0CQWEhKiEp8HDhyo76WGZj70pvP09JSCBQuqROq3335b/Y2aE/TKQzOW9pz0QnMdevvhdZFsbVhjld7Xat26tcyfP1/VZKEnIZoprZGAbcn+Tg2aANH7bsuWLapsmV3TR5RbMXAiojR98sknqoYFvb0uXbqkAgXU1qCru9ZstWjRItWdH81FqM1BTy50x9egN52Tk5MKMG7evKkCLMMu8ggWEBSgxuXhw4eq9ga98BA8oNdZRESE1K1bV9atW6cCtYxAsIPACLVjr7zyitF96X0t9BJEGRGIIbcI+8gaNU6W7O+0apwQkLZq1Uq6du1qlbIQUUp5kCFuZj0RERERmWCOExEREZGFGDgRERERWYiBExEREZGFGDgRERERWYiBExEREZGFGDgRERERWYiBExEREZGFGDgRERERWYiBExEREZGFGDgRERERWYiBExEREZGFGDgRERERiWX+DyMUEGTgmIaNAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 600x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def T_of_V(Vval):\n",
+    "    # positive root of (1-alpha) T^2 + (kV - F0) T - F0 kV = 0\n",
+    "    a, b, c = (1 - alpha), (k * Vval - F0), -F0 * k * Vval\n",
+    "    return (-b + np.sqrt(b**2 - 4 * a * c)) / (2 * a)\n",
+    "\n",
+    "\n",
+    "Vstar = float(r.x[\"V\"])\n",
+    "print(f\"analytic V for T=18 : {(alpha * T_target**2 / (T_target - F0) - T_target) / k:.4f}\")\n",
+    "print(f\"discopt V*          : {Vstar:.4f}\")\n",
+    "print(f\"T(V*) check         : {T_of_V(Vstar):.4f}  (target {T_target})\")\n",
+    "\n",
+    "grid = np.linspace(0.1, 50, 200)\n",
+    "plt.figure(figsize=(6, 4))\n",
+    "plt.plot(grid, [T_of_V(v) for v in grid], label=\"$T(V)$ (implicit block)\")\n",
+    "plt.axhline(T_target, ls=\"--\", color=\"gray\", lw=1, label=\"target $T^\\star=18$\")\n",
+    "plt.plot([Vstar], [T_of_V(Vstar)], \"o\", color=\"C3\", label=f\"optimum $V^*={Vstar:.2f}$\")\n",
+    "plt.xlabel(\"reactor volume $V$\")\n",
+    "plt.ylabel(\"total reactor feed $T$\")\n",
+    "plt.legend()\n",
+    "plt.title(\"Implicit forward map navigated by the optimizer\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4204c112",
+   "metadata": {},
+   "source": [
+    "## The contract: local, and integer-free\n",
+    "\n",
+    "The node inherits discopt's opaque-AD-only contract. Adding an integer variable\n",
+    "to a model with an implicit block is rejected up front, because spatial\n",
+    "branch-and-bound has no valid relaxation for $\\varphi(u)$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4691be79",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T11:29:02.096696Z",
+     "iopub.status.busy": "2026-07-02T11:29:02.096584Z",
+     "iopub.status.idle": "2026-07-02T11:29:02.099978Z",
+     "shell.execute_reply": "2026-07-02T11:29:02.099592Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rejected as expected: ValueError: Model contains a dm.custom(...) AD-only user function together with integer/binary variabl\n"
+     ]
+    }
+   ],
+   "source": [
+    "m_bad = dm.Model()\n",
+    "Vb = m_bad.continuous(\"V\", lb=0.1, ub=50.0)\n",
+    "m_bad.integer(\"stages\", lb=1, ub=5)\n",
+    "Tb = m_bad.implicit(recycle_residual, [Vb], n_unknowns=1, x0=jnp.array([20.0]))\n",
+    "m_bad.minimize((Tb[0] - T_target) ** 2)\n",
+    "\n",
+    "try:\n",
+    "    m_bad.solve()\n",
+    "except Exception as exc:\n",
+    "    print(f\"rejected as expected: {type(exc).__name__}: {str(exc)[:90]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de924003",
+   "metadata": {},
+   "source": [
+    "## Takeaways\n",
+    "\n",
+    "- **`m.implicit(residual, u_inputs, n_unknowns, x0=)`** represents a variable\n",
+    "  defined by a square system $g(u, v) = 0$ as a differentiable inner solve.\n",
+    "- Forward: Newton with nonsingular-Jacobian and convergence gates (a failure\n",
+    "  surfaces as a failed evaluation rather than a wrong root). Reverse: exact\n",
+    "  implicit-function-theorem derivatives {cite:p}`Blondel2022`.\n",
+    "- It is **local-NLP-only** and rejects integers — the correct contract for an\n",
+    "  unrelaxable node, and the natural setting for recycle / algebraic-loop models\n",
+    "  {cite:p}`Biegler2010`.\n",
+    "- This is the primitive that enables implicit **variable aggregation** of cyclic\n",
+    "  blocks {cite:p}`Naik2025`, shrinking tightly-coupled models the explicit,\n",
+    "  acyclic elimination cannot touch."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2192,3 +2192,20 @@
   year      = {2016},
   doi       = {10.1109/TPWRS.2015.2463111}
 }
+
+@article{Naik2025,
+  author  = {Naik, Shantanu and Biegler, Lorenz T. and Bent, Russell and Parker, Robert B.},
+  title   = {Variable aggregation for nonlinear optimization problems},
+  journal = {arXiv preprint arXiv:2502.13869},
+  year    = {2025},
+  doi     = {10.48550/arXiv.2502.13869}
+}
+
+@article{Blondel2022,
+  author  = {Blondel, Mathieu and Berthet, Quentin and Cuturi, Marco and Frostig, Roy and Hoyer, Stephan and Llinares-L{\'o}pez, Felipe and Pedregosa, Fabian and Vert, Jean-Philippe},
+  title   = {Efficient and modular implicit differentiation},
+  journal = {Advances in Neural Information Processing Systems},
+  volume  = {35},
+  pages   = {5230--5242},
+  year    = {2022}
+}

--- a/python/discopt/modeling/__init__.py
+++ b/python/discopt/modeling/__init__.py
@@ -85,6 +85,9 @@ from discopt.modeling.core import (
 from discopt.modeling.core import (
     abs_ as abs,
 )
+from discopt.modeling.implicit import (
+    implicit,
+)
 from discopt.modeling.indexed import (
     IndexedConstraint,
     IndexedParam,
@@ -127,6 +130,7 @@ __all__ = [
     "if_else",
     "udf",
     "custom",
+    "implicit",
     "CustomCall",
     "sum",
     "prod",

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1815,6 +1815,39 @@ class Model:
         """
         self._objective = Objective(_wrap(expr), ObjectiveSense.MAXIMIZE)
 
+    def implicit(
+        self,
+        residual: Callable,
+        u_inputs: Sequence,
+        n_unknowns: int,
+        x0=None,
+        *,
+        tol: float = 1e-10,
+        max_iter: int = 50,
+        name: str = "implicit",
+    ) -> Expression:
+        """Define a vector ``v`` implicitly by ``residual(u, v) = 0`` (issue #379).
+
+        ``v`` (length ``n_unknowns``) is compiled to a differentiable JAX inner
+        solve (Newton forward, implicit-function-theorem derivatives), returned
+        as an expression node you index (``v[i]``) and use like any other. It
+        rides on :func:`custom`, so a model containing it is solved on the
+        **local NLP path only** (no global certificate) and integers are
+        rejected. ``u_inputs`` are the model expressions the block depends on
+        (the DAG edges into the solve); they are required, not inferred.
+
+        See :func:`discopt.modeling.implicit` for parameter details.
+
+        Examples
+        --------
+        >>> u = m.continuous("u", lb=0.1, ub=100.0)
+        >>> v = m.implicit(lambda U, V: [V[0] ** 2 - U[0]], [u], n_unknowns=1)
+        >>> m.minimize((v[0] - 3.0) ** 2)   # v = sqrt(u); optimum at u = 9
+        """
+        from discopt.modeling.implicit import implicit as _implicit
+
+        return _implicit(residual, u_inputs, n_unknowns, x0, tol=tol, max_iter=max_iter, name=name)
+
     # ── Constraints ──
 
     def subject_to(

--- a/python/discopt/modeling/implicit.py
+++ b/python/discopt/modeling/implicit.py
@@ -29,17 +29,26 @@ from discopt.modeling.core import Expression, custom
 def _implicit_solver(
     residual: Callable,
     x0,
-    newton_iters: int = 30,
+    *,
+    tol: float = 1e-10,
+    max_iter: int = 50,
 ) -> Callable:
     """Build the JAX callable ``phi(u) -> v`` solving ``residual(u, v) = 0``.
 
-    Forward: fixed-iteration Newton from ``x0``.  Derivatives w.r.t. ``u`` come
-    from :func:`jax.lax.custom_root`, which differentiates the root through the
-    implicit-function theorem (one linear solve with the block Jacobian) *and*
-    supports higher-order AD -- so the NLP solver's Hessian (forward-over-reverse
-    through this node) works, which a hand-rolled ``custom_vjp`` (reverse only)
-    would break.  Exposed separately from :func:`implicit` so the numerics are
-    unit-testable without building a full model.
+    Forward: convergence-based Newton from ``x0`` with two gates the issue
+    requires -- a **nonsingular-Jacobian** gate (a non-finite Newton step means a
+    singular/ill-conditioned block) and a **convergence** gate (residual must
+    reach ``tol`` within ``max_iter``).  On either failure the solve returns
+    ``NaN``: we cannot raise inside a JAX-traced solve, so the failure propagates
+    into the objective/constraint value and the NLP solver reports it as a failed
+    evaluation rather than silently returning a wrong root.
+
+    Derivatives w.r.t. ``u`` come from :func:`jax.lax.custom_root`, which
+    differentiates the root through the implicit-function theorem (one linear
+    solve with the block Jacobian) *and* supports higher-order AD -- so the NLP
+    solver's Hessian (forward-over-reverse through this node) works, which a
+    hand-rolled ``custom_vjp`` (reverse only) would break.  Exposed separately
+    from :func:`implicit` so the numerics are unit-testable without a full model.
     """
     import jax
     import jax.numpy as jnp
@@ -51,10 +60,21 @@ def _implicit_solver(
             return jnp.asarray(residual(u, v), dtype=float)
 
         def solve(f, y0):
-            def body(_, v):
-                return v - jnp.linalg.solve(jax.jacobian(f)(v), f(v))
+            def cond(state):
+                _, it, rnorm, ok = state
+                return (rnorm > tol) & (it < max_iter) & ok
 
-            return jax.lax.fori_loop(0, newton_iters, body, y0)
+            def body(state):
+                v, it, _, _ = state
+                step = jnp.linalg.solve(jax.jacobian(f)(v), f(v))
+                ok = jnp.all(jnp.isfinite(step))  # nonsingular-Jacobian gate
+                v_new = v - step
+                return (v_new, it + 1, jnp.linalg.norm(f(v_new)), ok)
+
+            state0 = (y0, 0, jnp.linalg.norm(f(y0)), jnp.bool_(True))
+            v, _, rnorm, ok = jax.lax.while_loop(cond, body, state0)
+            converged = ok & jnp.isfinite(rnorm) & (rnorm <= tol)
+            return jnp.where(converged, v, jnp.full_like(v, jnp.nan))
 
         def tangent_solve(g, y):  # g is the (linear) JVP of f; solve J z = y
             jac = jax.jacobian(g)(jnp.zeros_like(y))
@@ -71,7 +91,8 @@ def implicit(
     n_unknowns: int,
     x0=None,
     *,
-    newton_iters: int = 30,
+    tol: float = 1e-10,
+    max_iter: int = 50,
     name: str = "implicit",
 ) -> Expression:
     """Define ``v`` (length ``n_unknowns``) implicitly by ``residual(u, v) = 0``.
@@ -90,8 +111,11 @@ def implicit(
     x0 : array-like, optional
         Initial guess for the Newton solve (default zeros of length
         ``n_unknowns``).
-    newton_iters : int
-        Fixed Newton iterations for the forward solve.
+    tol : float
+        Residual tolerance for the forward Newton solve.
+    max_iter : int
+        Maximum Newton iterations; exceeding it without reaching ``tol`` is a
+        non-convergence failure (propagated as ``NaN``).
     name : str
         Display name used in reprs/errors.
 
@@ -100,12 +124,36 @@ def implicit(
     Expression
         A :class:`CustomCall` node evaluating to the solved ``v`` vector; index
         it (``node[i]``) for components.  Local-NLP-only, no global certificate.
+
+    Raises
+    ------
+    ValueError
+        If ``n_unknowns < 1``, ``x0`` has the wrong length, or ``residual``
+        probed at a dummy point does not return exactly ``n_unknowns`` entries.
     """
     import jax.numpy as jnp
 
+    if n_unknowns < 1:
+        raise ValueError(f"n_unknowns must be >= 1, got {n_unknowns}")
     if x0 is None:
         x0 = jnp.zeros(n_unknowns, dtype=float)
-    phi = _implicit_solver(residual, x0, newton_iters=newton_iters)
+    x0 = jnp.asarray(x0, dtype=float)
+    if x0.shape != (n_unknowns,):
+        raise ValueError(f"x0 must have shape ({n_unknowns},), got {tuple(x0.shape)}")
+
+    # Best-effort build-time shape check: the residual must return n_unknowns
+    # entries.  Probe at a dummy point; if the probe itself errors (residual not
+    # defined there) defer to runtime rather than false-failing.
+    try:
+        probe = jnp.asarray(residual(jnp.zeros(len(u_inputs)), x0), dtype=float)
+    except Exception:
+        probe = None
+    if probe is not None and probe.shape != (n_unknowns,):
+        raise ValueError(
+            f"residual must return {n_unknowns} entries, got shape {tuple(probe.shape)}"
+        )
+
+    phi = _implicit_solver(residual, x0, tol=tol, max_iter=max_iter)
 
     def solve_fn(*u_vals):
         u = jnp.stack([jnp.asarray(x, dtype=float) for x in u_vals]) if u_vals else jnp.zeros(0)

--- a/python/discopt/modeling/implicit.py
+++ b/python/discopt/modeling/implicit.py
@@ -1,0 +1,114 @@
+"""Implicit-function expression node (issue #379) -- prototype.
+
+A vector ``v`` defined as the solution of a square nonlinear system
+``g(u, v) = 0`` is compiled to a differentiable JAX inner solve: the forward is a
+Newton iteration; the reverse is the implicit-function-theorem (IFT) VJP
+
+    dv/du = -(dg/dv)^{-1} (dg/du),
+
+so we never differentiate through the Newton iterations.
+
+This rides entirely on :class:`~discopt.modeling.core.CustomCall`: the returned
+node is opaque and AD-only, so a model containing an implicit node is solved on
+the **local NLP path only** (no global optimality certificate) and the solver
+raises if integer/binary variables are present -- exactly the CustomCall
+contract.  It is the core-side primitive that lets reduced-space / variable
+aggregation eliminate an irreducible *cyclic* block ``g_B(u, v_B) = 0`` instead
+of leaving its variables in the reduced model.
+
+Prototype for #379 -- API and scope may still change.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+from discopt.modeling.core import Expression, custom
+
+
+def _implicit_solver(
+    residual: Callable,
+    x0,
+    newton_iters: int = 30,
+) -> Callable:
+    """Build the JAX callable ``phi(u) -> v`` solving ``residual(u, v) = 0``.
+
+    Forward: fixed-iteration Newton from ``x0``.  Derivatives w.r.t. ``u`` come
+    from :func:`jax.lax.custom_root`, which differentiates the root through the
+    implicit-function theorem (one linear solve with the block Jacobian) *and*
+    supports higher-order AD -- so the NLP solver's Hessian (forward-over-reverse
+    through this node) works, which a hand-rolled ``custom_vjp`` (reverse only)
+    would break.  Exposed separately from :func:`implicit` so the numerics are
+    unit-testable without building a full model.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    x0_arr = jnp.asarray(x0, dtype=float)
+
+    def phi(u):
+        def f(v):  # root sought: residual(u, v) == 0, with u closed over
+            return jnp.asarray(residual(u, v), dtype=float)
+
+        def solve(f, y0):
+            def body(_, v):
+                return v - jnp.linalg.solve(jax.jacobian(f)(v), f(v))
+
+            return jax.lax.fori_loop(0, newton_iters, body, y0)
+
+        def tangent_solve(g, y):  # g is the (linear) JVP of f; solve J z = y
+            jac = jax.jacobian(g)(jnp.zeros_like(y))
+            return jnp.linalg.solve(jac, y)
+
+        return jax.lax.custom_root(f, x0_arr, solve, tangent_solve)
+
+    return phi
+
+
+def implicit(
+    residual: Callable,
+    u_inputs: Sequence,
+    n_unknowns: int,
+    x0=None,
+    *,
+    newton_iters: int = 30,
+    name: str = "implicit",
+) -> Expression:
+    """Define ``v`` (length ``n_unknowns``) implicitly by ``residual(u, v) = 0``.
+
+    Parameters
+    ----------
+    residual : callable
+        ``residual(u, v) -> array`` of length ``n_unknowns``, written with
+        ``jax.numpy`` so it is JAX-traceable.  ``u`` is a 1-D array of the
+        evaluated ``u_inputs``; ``v`` is the unknown vector.
+    u_inputs : sequence of Expression
+        The model expressions the block depends on (the ``u``).  Their scalar
+        values are stacked into the ``u`` array passed to ``residual``.
+    n_unknowns : int
+        Number of components of ``v``.
+    x0 : array-like, optional
+        Initial guess for the Newton solve (default zeros of length
+        ``n_unknowns``).
+    newton_iters : int
+        Fixed Newton iterations for the forward solve.
+    name : str
+        Display name used in reprs/errors.
+
+    Returns
+    -------
+    Expression
+        A :class:`CustomCall` node evaluating to the solved ``v`` vector; index
+        it (``node[i]``) for components.  Local-NLP-only, no global certificate.
+    """
+    import jax.numpy as jnp
+
+    if x0 is None:
+        x0 = jnp.zeros(n_unknowns, dtype=float)
+    phi = _implicit_solver(residual, x0, newton_iters=newton_iters)
+
+    def solve_fn(*u_vals):
+        u = jnp.stack([jnp.asarray(x, dtype=float) for x in u_vals]) if u_vals else jnp.zeros(0)
+        return phi(u)
+
+    return custom(solve_fn, name=name)(*u_inputs)

--- a/python/discopt/modeling/implicit.py
+++ b/python/discopt/modeling/implicit.py
@@ -166,4 +166,5 @@ def implicit(
             u = jnp.zeros(0)
         return phi(u)
 
-    return custom(solve_fn, name=name)(*u_inputs)
+    node: Expression = custom(solve_fn, name=name)(*u_inputs)
+    return node

--- a/python/discopt/modeling/implicit.py
+++ b/python/discopt/modeling/implicit.py
@@ -156,7 +156,14 @@ def implicit(
     phi = _implicit_solver(residual, x0, tol=tol, max_iter=max_iter)
 
     def solve_fn(*u_vals):
-        u = jnp.stack([jnp.asarray(x, dtype=float) for x in u_vals]) if u_vals else jnp.zeros(0)
+        # Flatten each input (scalar -> length 1, vector -> raveled) and
+        # concatenate, so ``u`` is a flat 1-D array of all dependency values.
+        if u_vals:
+            u = jnp.concatenate(
+                [jnp.atleast_1d(jnp.asarray(x, dtype=float)).ravel() for x in u_vals]
+            )
+        else:
+            u = jnp.zeros(0)
         return phi(u)
 
     return custom(solve_fn, name=name)(*u_inputs)

--- a/python/tests/test_implicit_node.py
+++ b/python/tests/test_implicit_node.py
@@ -1,0 +1,73 @@
+"""Tests for the implicit-function expression node (issue #379, prototype).
+
+Validates (1) the JAX inner-solve numerics: forward Newton correctness and the
+implicit-function-theorem VJP against the analytic derivative and finite
+differences; and (2) the CustomCall contract inherited by ``dm.implicit`` --
+local-NLP-only with no global certificate, and integers rejected.
+"""
+
+import pytest
+
+jax = pytest.importorskip("jax")
+import discopt.modeling as dm  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+from discopt.modeling.implicit import _implicit_solver  # noqa: E402
+
+
+def _sqrt_residual(u, v):
+    # v defined by v**2 - u = 0  ->  v = sqrt(u)  (with a positive initial guess)
+    return jnp.array([v[0] ** 2 - u[0]])
+
+
+def test_forward_solve_matches_sqrt():
+    phi = _implicit_solver(_sqrt_residual, x0=jnp.array([1.0]))
+    for uval in (0.25, 1.0, 4.0, 9.0, 50.0):
+        v = phi(jnp.array([uval]))
+        assert float(v[0]) == pytest.approx(uval**0.5, rel=1e-6)
+
+
+def test_ift_vjp_matches_analytic_and_finite_difference():
+    phi = _implicit_solver(_sqrt_residual, x0=jnp.array([1.0]))
+    u0 = jnp.array([4.0])
+    # jacobian dv/du from the custom IFT VJP
+    jac = jax.jacobian(phi)(u0)
+    analytic = 1.0 / (2.0 * 4.0**0.5)  # d/du sqrt(u) = 1/(2 sqrt(u)) = 0.25
+    assert float(jac[0, 0]) == pytest.approx(analytic, rel=1e-6)
+    # finite difference
+    eps = 1e-4
+    fd = (float(phi(u0 + eps)[0]) - float(phi(u0 - eps)[0])) / (2 * eps)
+    assert float(jac[0, 0]) == pytest.approx(fd, rel=1e-4)
+
+
+def test_vector_block_two_by_two():
+    # v0 + v1 = u0 ;  v0 - v1 = u1   ->  v0 = (u0+u1)/2, v1 = (u0-u1)/2  (linear)
+    def resid(u, v):
+        return jnp.array([v[0] + v[1] - u[0], v[0] - v[1] - u[1]])
+
+    phi = _implicit_solver(resid, x0=jnp.zeros(2))
+    v = phi(jnp.array([10.0, 4.0]))
+    assert float(v[0]) == pytest.approx(7.0, rel=1e-9)
+    assert float(v[1]) == pytest.approx(3.0, rel=1e-9)
+
+
+def test_implicit_in_model_solves_locally():
+    # minimize (v - 3)^2 where v = sqrt(u), u in [0.1, 100]  ->  u* = 9, v* = 3
+    m = dm.Model()
+    u = m.continuous("u", lb=0.1, ub=100.0)
+    v = dm.implicit(_sqrt_residual, [u], n_unknowns=1, x0=jnp.array([1.0]))
+    m.minimize((v[0] - 3.0) ** 2)
+    r = m.solve(initial_solution={u: 4.0})
+    assert r.status in ("optimal", "feasible")
+    assert float(r.x["u"]) == pytest.approx(9.0, rel=1e-3)
+    # CustomCall contract: local NLP path only, no global certificate.
+    assert getattr(r, "gap_certified", False) is False
+
+
+def test_integers_are_rejected():
+    m = dm.Model()
+    u = m.continuous("u", lb=0.1, ub=100.0)
+    m.integer("k", lb=0, ub=5)
+    v = dm.implicit(_sqrt_residual, [u], n_unknowns=1, x0=jnp.array([1.0]))
+    m.minimize((v[0] - 3.0) ** 2)
+    with pytest.raises(Exception):
+        m.solve()

--- a/python/tests/test_implicit_node.py
+++ b/python/tests/test_implicit_node.py
@@ -71,3 +71,41 @@ def test_integers_are_rejected():
     m.minimize((v[0] - 3.0) ** 2)
     with pytest.raises(Exception):
         m.solve()
+
+
+def test_nonconvergence_returns_nan():
+    # v**2 + u = 0 has no real root for u > 0 -> Newton cannot converge -> NaN,
+    # so the failure propagates instead of returning a wrong finite root.
+    phi = _implicit_solver(lambda u, v: jnp.array([v[0] ** 2 + u[0]]), x0=jnp.array([1.0]))
+    v = phi(jnp.array([4.0]))
+    assert not bool(jnp.isfinite(v[0]))
+
+
+def test_singular_jacobian_returns_nan():
+    # residual independent of v -> dg/dv = 0 (singular block) -> non-finite step
+    # -> nonsingular-Jacobian gate trips -> NaN.
+    phi = _implicit_solver(lambda u, v: jnp.array([u[0] - 1.0]), x0=jnp.array([1.0]))
+    v = phi(jnp.array([4.0]))
+    assert not bool(jnp.isfinite(v[0]))
+
+
+def test_build_time_shape_check():
+    # residual returns 2 entries but n_unknowns=1 -> caught at build time.
+    with pytest.raises(ValueError):
+        dm.implicit(lambda u, v: jnp.array([v[0] - 1.0, v[0]]), [], n_unknowns=1)
+    # bad x0 length
+    with pytest.raises(ValueError):
+        dm.implicit(_sqrt_residual, [], n_unknowns=1, x0=jnp.zeros(2))
+
+
+def test_nonconvergence_fails_model_solve():
+    # A model whose implicit block cannot converge should not report a clean
+    # optimum with a bogus value; the NaN poisons the objective.
+    m = dm.Model()
+    u = m.continuous("u", lb=1.0, ub=10.0)
+    v = dm.implicit(
+        lambda U, V: jnp.array([V[0] ** 2 + U[0]]), [u], n_unknowns=1, x0=jnp.array([1.0])
+    )
+    m.minimize((v[0] - 3.0) ** 2)
+    r = m.solve(initial_solution={u: 4.0})
+    assert r.status not in ("optimal", "feasible") or not bool(jnp.isfinite(r.objective))

--- a/python/tests/test_implicit_node.py
+++ b/python/tests/test_implicit_node.py
@@ -109,3 +109,26 @@ def test_nonconvergence_fails_model_solve():
     m.minimize((v[0] - 3.0) ** 2)
     r = m.solve(initial_solution={u: 4.0})
     assert r.status not in ("optimal", "feasible") or not bool(jnp.isfinite(r.objective))
+
+
+def test_model_method_form():
+    # m.implicit(...) (the Model-method form) matches the module-level builder.
+    m = dm.Model()
+    u = m.continuous("u", lb=0.1, ub=100.0)
+    v = m.implicit(_sqrt_residual, [u], n_unknowns=1, x0=jnp.array([1.0]))
+    m.minimize((v[0] - 3.0) ** 2)
+    r = m.solve(initial_solution={u: 4.0})
+    assert r.status in ("optimal", "feasible")
+    assert float(r.x["u"]) == pytest.approx(9.0, rel=1e-3)
+
+
+def test_multiple_u_inputs():
+    # Two scalar inputs feeding a block: v = u0 + u1 (u concatenated flat).
+    m = dm.Model()
+    a = m.continuous("a", lb=0.0, ub=10.0)
+    b = m.continuous("b", lb=0.0, ub=10.0)
+    v = m.implicit(lambda U, V: jnp.array([V[0] - (U[0] + U[1])]), [a, b], n_unknowns=1)
+    m.minimize((v[0] - 5.0) ** 2 + a**2)  # want a+b=5 with a small -> a~0, b~5
+    r = m.solve(initial_solution={a: 1.0, b: 1.0})
+    assert r.status in ("optimal", "feasible")
+    assert float(r.x["a"]) + float(r.x["b"]) == pytest.approx(5.0, abs=1e-2)


### PR DESCRIPTION
## Implicit-function expression node (`m.implicit`) — closes the core-side gap for #379

Adds `m.implicit(residual, u_inputs, n_unknowns, x0=)` / `dm.implicit(...)`: a
vector `v` defined by a square system `g(u, v) = 0`, compiled to a differentiable
JAX inner solve — Newton forward, **implicit-function-theorem** derivatives — so
it is transparent to the NLP solver and carries exact gradients. This is the
core-side primitive the external `discopt-aggregation` plugin needs to eliminate
irreducible **cyclic blocks** instead of dropping them (#379).

### Design
- **Rides on `CustomCall`.** The node is opaque/AD-only, so it inherits the
  existing contract for free: solved on the **local NLP path only** (no global
  certificate, `gap_certified=False`), and **integer/binary variables are
  rejected** (an implicit `φ(u)` has no relaxation for spatial B&B). This is the
  correct contract — implicit/reduced-space elimination is a *local* technique.
- **Derivatives via `jax.lax.custom_root`, not a hand-rolled `custom_vjp`.**
  Worth recording: `custom_vjp` (reverse-only) fails the moment the NLP solver
  needs the **Hessian** (`can't apply jvp to a custom_vjp function`);
  `custom_root` supports the higher-order AD, so forward-over-reverse works.
- **Robustness gates** (per the issue): convergence-based Newton with a
  nonsingular-Jacobian gate and a convergence gate; on either failure the solve
  returns `NaN`, which propagates so the NLP solver reports a failed evaluation
  rather than a silently-wrong root. Plus build-time validation.

### Tests (11, all green) + docs
Forward solve vs `√u`, IFT gradient vs analytic + finite-diff, 2×2 vector block,
in-model solve (`u*=9` exact), integers-rejected, non-convergence→NaN,
singular-Jacobian→NaN, build-time shape check, `m.implicit` method form, and a
two-input block. No regression in `test_custom_udf` / the modeling suite.

New tutorial `docs/notebooks/implicit_function_node.ipynb` (reactor-with-recycle
algebraic loop; `V*=12.6` verified against the closed-form root) — executes clean
and adds **zero** new jupyter-book warnings. New citations `Naik2025`,
`Blondel2022`.

### Out of scope
The plugin-side substitution (wiring the node into a reduced aggregated model)
lives in `discopt-aggregation`; this PR provides the core node it consumes.

Closes #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
