### PR TITLE
test: per-case budget for AMP simplex certification-parity (concave_qp slow-runner flake)

### DIFF
--- a/python/tests/test_amp_simplex_backend.py
+++ b/python/tests/test_amp_simplex_backend.py
@@ -81,19 +81,17 @@ class TestAmpSimplexCertificationParity:
     """AMP must reach the same certified optimum with the simplex relaxation
     backend as with the default (HiGHS/POUNCE) backend."""
 
-    @pytest.mark.parametrize("build", [_concave_qp, _bilinear])
-    def test_same_certificate_as_default(self, build):
-        # A short budget is sufficient and keeps the test fast: ``_concave_qp``
-        # certifies optimal in well under a second, and ``_bilinear`` finds its
-        # global incumbent (-6.25) within the first second but its spatial-B&B
-        # bound never closes to ``rel_gap`` (a relaxation-tightness property, not
-        # a backend property — HiGHS, POUNCE and the simplex all return
-        # ``feasible`` here and would otherwise burn the whole budget). The seam
-        # under test is backend *parity*, which holds at any budget; a 60s limit
-        # only wasted wall-clock on the uncertifiable case (and timed out under
-        # parallel load).
-        ref = build().solve(solver="amp", rel_gap=1e-4, time_limit=5)
-        sx = build().solve(solver="amp", rel_gap=1e-4, time_limit=5, milp_solver="simplex")
+    # Per-case budget: ``_concave_qp`` *certifies* (its status is time-sensitive),
+    # so it needs enough wall-clock that both backends reach ``optimal`` even on a
+    # slow CI runner under parallel load — a 5s budget flaked as
+    # ``optimal vs feasible`` when only one backend certified in time. ``_bilinear``
+    # never certifies (``feasible`` at any budget — a relaxation-tightness property,
+    # not a backend property), so it stays short to avoid burning wall-clock. The
+    # seam under test is backend *parity*, which holds at any budget.
+    @pytest.mark.parametrize("build,time_limit", [(_concave_qp, 60), (_bilinear, 5)])
+    def test_same_certificate_as_default(self, build, time_limit):
+        ref = build().solve(solver="amp", rel_gap=1e-4, time_limit=time_limit)
+        sx = build().solve(solver="amp", rel_gap=1e-4, time_limit=time_limit, milp_solver="simplex")
         assert sx.status == ref.status, f"{sx.status} vs {ref.status}"
         if ref.status == "optimal":
             assert getattr(sx, "gap_certified", True) is True


### PR DESCRIPTION
## Per-case budget for the AMP simplex certification-parity test (slow-runner flake)

`test_same_certificate_as_default[_concave_qp]` failed on `main` (Python fast,
parallel) as `optimal vs feasible`. The `_concave_qp` case **certifies**, so its
status is time-sensitive; with a shared `time_limit=5`, under parallel load on the
slow CI runner one backend reached `optimal` while the other was still `feasible`,
breaking the exact-status parity assertion.

### Fix
Per-case budget via parametrize:
- `_concave_qp` → **60 s** ceiling. It certifies in <1 s and exits early on
  certification, so the larger ceiling costs no wall-clock on a normal run but
  guarantees both backends reach `optimal` even when the runner is slow.
- `_bilinear` → **5 s** (unchanged). It never certifies (`feasible` at any budget
  — a relaxation-tightness property, not a backend one), so a short budget avoids
  burning wall-clock; parity holds at `feasible`.

### Not a regression
Passes 3/3 locally (<1.3 s); surfaced only on the slow CI runner after the
#380/#382 merges, and is unrelated to either change (neither touched the AMP
backend). Same class as #382 — time-sensitive status assertions flaking under the
slow runner.
