### PR TITLE
docs(changelog): document the implicit-function node under [0.5.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ The release procedure that produces these entries is documented in
 
 ### Added
 
+- **Implicit-function expression node** (`feat(modeling)`, #379). `m.implicit(
+  residual, u_inputs, n_unknowns, x0=)` defines a vector `v` by a square system
+  `g(u, v) = 0`, compiled to a differentiable JAX inner solve (Newton forward;
+  implicit-function-theorem derivatives via `jax.lax.custom_root`, which supports
+  the higher-order AD the NLP Hessian needs). Rides on `CustomCall`, so it is
+  **local-NLP-only** (no global certificate) and rejects integers. The core-side
+  primitive for implicit variable-aggregation of irreducible cyclic blocks;
+  documented in `docs/notebooks/implicit_function_node.ipynb`.
 - **Hardened pure-Rust LP engine** (`feat(lp)`, #368). Numeric-focus LU with
   in-engine iterative refinement and condition/growth signals (via `feral`
   0.12.0), primal + dual refined recovery on a drifted-Optimal, dual-simplex


### PR DESCRIPTION
## Document the implicit-function node under `[0.5.0]`

`v0.5.0` will be tagged from the current `main` HEAD (per the release decision),
which includes the implicit-function node (#380, closes #379) that landed after
the release-prep commit. This adds the corresponding entry to the `[0.5.0]`
`Added` section so the changelog / release notes match what ships in the 0.5.0
wheel. Docs-only.
