### PR TITLE
chore: post-release version bump to 0.5.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "discopt"
-version = "0.5.0"
+version = "0.5.1.dev0"
 description = "Hybrid MINLP solver combining Rust and JAX"
 requires-python = ">=3.10"
 authors = [{name = "John Kitchin"}]

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -25,7 +25,7 @@ solvers
     NLP solver backends: POUNCE (pure-Rust Ipopt port), pure-JAX IPM (vmap batch), cyipopt (Ipopt).
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1.dev0"
 
 # Allow external distributions (e.g. the ``discopt-aggregation`` plugin) to
 # contribute submodules under the ``discopt`` namespace from a separate location


### PR DESCRIPTION
Standard §12 post-release step after publishing v0.5.0. Bumps pyproject + `__version__` to `0.5.1.dev0`; CITATION.cff stays at the released 0.5.0. Docs/metadata only.