### PR TITLE
Add KKT structure-aware passthroughs to pounce NLP solver

### DIFF
--- a/python/discopt/_jax/differentiable.py
+++ b/python/discopt/_jax/differentiable.py
@@ -320,13 +320,13 @@ def _dispatch_nlp_solve(nlp_solver: str, evaluator, x0, options: dict):
     forward there without any in-trace solve.
     """
     if nlp_solver in ("ipm", "pounce"):
-        from discopt.solvers.nlp_pounce import solve_nlp
+        from discopt.solvers.nlp_pounce import solve_nlp as _solve_nlp_pounce
 
-        return solve_nlp(evaluator, x0, options=options)
+        return _solve_nlp_pounce(evaluator, x0, options=options)
     elif nlp_solver == "ipopt":
-        from discopt.solvers.nlp_ipopt import solve_nlp
+        from discopt.solvers.nlp_ipopt import solve_nlp as _solve_nlp_ipopt
 
-        return solve_nlp(evaluator, x0, options=options)
+        return _solve_nlp_ipopt(evaluator, x0, options=options)
     else:
         raise ValueError(f"Unknown nlp_solver: {nlp_solver!r}. Use 'ipm', 'pounce', or 'ipopt'.")
 

--- a/python/discopt/solvers/nlp_pounce.py
+++ b/python/discopt/solvers/nlp_pounce.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Optional
+from typing import Optional, Sequence
 
 import numpy as np
 
@@ -40,10 +40,27 @@ def solve_nlp(
     x0: np.ndarray,
     constraint_bounds: Optional[list[tuple[float, float]]] = None,
     options: Optional[dict] = None,
+    kkt_schur_block: Optional[Sequence[int]] = None,
+    ordering: Optional[Sequence[int]] = None,
 ) -> NLPResult:
     """Solve an NLP using pounce with the NLPEvaluator callbacks.
 
-    Same signature and semantics as :func:`discopt.solvers.nlp_ipopt.solve_nlp`.
+    Same signature and semantics as :func:`discopt.solvers.nlp_ipopt.solve_nlp`,
+    plus two optional structure-aware passthroughs to the underlying
+    ``pounce.Problem`` (see pounce#180).
+
+    Args:
+        kkt_schur_block: Optional sequence of **KKT-space indices** (``0..dim``,
+            block order ``x, slack, eq-dual, ineq-dual``) identifying a
+            block-triangular / Schur partition of the KKT system. Handed to
+            ``pounce.Problem.set_kkt_schur_block`` before solving; pounce falls
+            back to the full-space path transparently when the partition is
+            unsuitable, so the solution is unchanged and only factorization time
+            differs (Parker, Garcia & Bent, arXiv:2602.17968). Honored only on
+            the default FERAL + exact-Hessian path.
+        ordering: Optional sequence of KKT-space indices giving a custom
+            factorization ordering, handed to ``pounce.Problem.set_ordering``.
+            Correctness-safe for the same reason as ``kkt_schur_block``.
     """
     if not POUNCE_AVAILABLE:
         raise ImportError(
@@ -103,6 +120,30 @@ def solve_nlp(
         except (TypeError, ValueError, RuntimeError):
             _logger.debug("pounce option '%s' not accepted, skipping", key)
 
+    # Structure-aware KKT passthroughs (pounce#180). Both are correctness-safe:
+    # pounce transparently falls back to the full-space path when the partition
+    # or ordering is unsuitable, so only factorization time changes. Guarded so
+    # an older pounce without these methods degrades gracefully to the
+    # full-space solve rather than raising.
+    if kkt_schur_block is not None:
+        block = [int(i) for i in kkt_schur_block]
+        if hasattr(problem, "set_kkt_schur_block"):
+            try:
+                problem.set_kkt_schur_block(block)
+            except (TypeError, ValueError, RuntimeError):
+                _logger.debug("pounce rejected kkt_schur_block, using full space")
+        else:
+            _logger.debug("pounce has no set_kkt_schur_block; ignoring passthrough")
+    if ordering is not None:
+        order = [int(i) for i in ordering]
+        if hasattr(problem, "set_ordering"):
+            try:
+                problem.set_ordering(order)
+            except (TypeError, ValueError, RuntimeError):
+                _logger.debug("pounce rejected ordering, using default")
+        else:
+            _logger.debug("pounce has no set_ordering; ignoring passthrough")
+
     t0 = time.perf_counter()
     x, info = problem.solve(x0.astype(np.float64))
     wall_time = time.perf_counter() - t0
@@ -136,6 +177,8 @@ def solve_nlp_from_model(
     model: Model,
     x0: Optional[np.ndarray] = None,
     options: Optional[dict] = None,
+    kkt_schur_block: Optional[Sequence[int]] = None,
+    ordering: Optional[Sequence[int]] = None,
 ) -> NLPResult:
     """Convenience: create an NLPEvaluator from a model and solve with POUNCE.
 
@@ -146,6 +189,12 @@ def solve_nlp_from_model(
         model: A Model with objective and constraints set.
         x0: Initial point (n,). If None, uses midpoint of bounds clipped to [-100, 100].
         options: POUNCE/Ipopt options dict.
+        kkt_schur_block: Optional Schur/block-triangular KKT partition forwarded
+            to :func:`solve_nlp` (see its docstring). For an equality-only model,
+            ``discopt.aggregation.schur.kkt_schur_indices(model)`` produces a
+            suitable block. Correctness-safe: pounce falls back transparently.
+        ordering: Optional custom factorization ordering forwarded to
+            :func:`solve_nlp`.
 
     Returns:
         NLPResult with solution.
@@ -158,4 +207,10 @@ def solve_nlp_from_model(
         ub_clipped = np.clip(ub, -100.0, 100.0)
         x0 = 0.5 * (lb_clipped + ub_clipped)
 
-    return solve_nlp(evaluator, x0, options=options)
+    return solve_nlp(
+        evaluator,
+        x0,
+        options=options,
+        kkt_schur_block=kkt_schur_block,
+        ordering=ordering,
+    )

--- a/python/tests/test_nlp_pounce.py
+++ b/python/tests/test_nlp_pounce.py
@@ -315,3 +315,105 @@ class TestMaximize:
         result = solve_nlp_from_model(m)
         assert result.status == SolveStatus.OPTIMAL
         assert abs(result.x[0] - 5.0) < 1e-5
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 10: Structure-aware KKT passthroughs (kkt_schur_block / ordering)
+# ─────────────────────────────────────────────────────────────
+
+
+class TestSchurPassthrough:
+    def _eq_model(self):
+        """min x^2 + y^2 s.t. x + y == 2 => optimal at (1, 1). n=2, m=1."""
+        m = Model("schur_eq")
+        x = m.continuous("x", lb=-10, ub=10)
+        y = m.continuous("y", lb=-10, ub=10)
+        m.minimize(x**2 + y**2)
+        m.subject_to(x + y == 2)
+        return m
+
+    def test_kkt_schur_block_forwarded_to_problem(self, monkeypatch):
+        """The block reaches pounce.Problem.set_kkt_schur_block verbatim."""
+        captured = {}
+        original_problem = pounce.Problem
+
+        def make_problem(*args, **kwargs):
+            prob = original_problem(*args, **kwargs)
+            if hasattr(prob, "set_kkt_schur_block"):
+                orig = prob.set_kkt_schur_block
+
+                def spy(block):
+                    captured["block"] = list(block)
+                    return orig(block)
+
+                monkeypatch.setattr(prob, "set_kkt_schur_block", spy, raising=False)
+            else:
+                captured["no_method"] = True
+            return prob
+
+        monkeypatch.setattr(pounce, "Problem", make_problem)
+
+        m = self._eq_model()
+        # KKT dim = n + m = 3; all-duals block [n, n+m) = [2].
+        result = solve_nlp_from_model(m, x0=np.array([3.0, 1.0]), kkt_schur_block=[2])
+
+        assert result.status == SolveStatus.OPTIMAL
+        assert np.allclose(result.x, [1.0, 1.0], atol=1e-5)
+        if "no_method" not in captured:
+            assert captured.get("block") == [2]
+
+    def test_solution_unchanged_with_schur_block(self):
+        """Installing a Schur block must not change the solution (fallback-safe)."""
+        m = self._eq_model()
+        baseline = solve_nlp_from_model(m, x0=np.array([3.0, 1.0]))
+        schur = solve_nlp_from_model(m, x0=np.array([3.0, 1.0]), kkt_schur_block=[2])
+
+        assert schur.status == baseline.status == SolveStatus.OPTIMAL
+        assert np.allclose(schur.x, baseline.x, atol=1e-6)
+        assert abs(schur.objective - baseline.objective) < 1e-8
+
+    def test_none_block_is_noop(self):
+        """kkt_schur_block=None behaves exactly like omitting it."""
+        m = self._eq_model()
+        result = solve_nlp_from_model(
+            m, x0=np.array([3.0, 1.0]), kkt_schur_block=None, ordering=None
+        )
+        assert result.status == SolveStatus.OPTIMAL
+        assert np.allclose(result.x, [1.0, 1.0], atol=1e-5)
+
+    def test_unsuitable_block_falls_back(self):
+        """A nonsensical block must not corrupt the solve (pounce fallback)."""
+        m = self._eq_model()
+        # Out-of-range / garbage indices: pounce should reject or ignore and
+        # still return the correct solution via the full-space path.
+        result = solve_nlp_from_model(m, x0=np.array([3.0, 1.0]), kkt_schur_block=[999])
+        assert result.status == SolveStatus.OPTIMAL
+        assert np.allclose(result.x, [1.0, 1.0], atol=1e-5)
+
+    def test_ordering_forwarded(self, monkeypatch):
+        """ordering reaches pounce.Problem.set_ordering when supported."""
+        captured = {}
+        original_problem = pounce.Problem
+
+        def make_problem(*args, **kwargs):
+            prob = original_problem(*args, **kwargs)
+            if hasattr(prob, "set_ordering"):
+                orig = prob.set_ordering
+
+                def spy(order):
+                    captured["order"] = list(order)
+                    return orig(order)
+
+                monkeypatch.setattr(prob, "set_ordering", spy, raising=False)
+            else:
+                captured["no_method"] = True
+            return prob
+
+        monkeypatch.setattr(pounce, "Problem", make_problem)
+
+        m = self._eq_model()
+        result = solve_nlp_from_model(m, x0=np.array([3.0, 1.0]), ordering=[0, 1, 2])
+
+        assert result.status == SolveStatus.OPTIMAL
+        if "no_method" not in captured:
+            assert captured.get("order") == [0, 1, 2]


### PR DESCRIPTION
## Summary

Adds optional `kkt_schur_block` and `ordering` parameters to the pounce NLP solver integration, enabling structure-aware factorization optimizations while maintaining correctness safety through pounce's transparent fallback mechanism.

## Changes

- **`python/discopt/solvers/nlp_pounce.py`**:
  - Added `Sequence` to type imports
  - Extended `solve_nlp()` signature with two optional parameters:
    - `kkt_schur_block`: KKT-space indices identifying a block-triangular/Schur partition
    - `ordering`: Custom factorization ordering
  - Implemented guarded passthroughs to `pounce.Problem.set_kkt_schur_block()` and `pounce.Problem.set_ordering()` with graceful degradation for older pounce versions
  - Added comprehensive docstring documentation explaining correctness safety (pounce falls back transparently when partition/ordering is unsuitable)
  - Extended `solve_nlp_from_model()` to forward both parameters through to `solve_nlp()`

- **`python/tests/test_nlp_pounce.py`**:
  - Added `TestSchurPassthrough` test class with five test methods:
    - `test_kkt_schur_block_forwarded_to_problem`: Verifies block is passed verbatim to pounce via monkeypatch spy
    - `test_solution_unchanged_with_schur_block`: Confirms solution quality is unaffected by Schur block installation
    - `test_none_block_is_noop`: Validates `None` parameters behave as omitted
    - `test_unsuitable_block_falls_back`: Ensures out-of-range indices don't corrupt the solve (pounce fallback)
    - `test_ordering_forwarded`: Verifies ordering parameter reaches `pounce.Problem.set_ordering()`

## Implementation Details

- Both passthroughs are **correctness-safe**: pounce transparently falls back to the full-space path when the partition or ordering is unsuitable, so only factorization time changes, never the solution
- Guarded with `hasattr()` checks to degrade gracefully when methods are unavailable in older pounce versions
- Integer conversion (`[int(i) for i in ...]`) ensures type safety before passing to pounce
- Exceptions during passthrough are caught and logged; solve continues via fallback path
- Comprehensive logging at debug level documents when passthroughs are skipped or rejected
- Tests use monkeypatch spies to verify parameters reach pounce without modifying behavior
- Baseline solution comparison confirms numerical equivalence with/without Schur block

References pounce#180 and Parker, Garcia & Bent arXiv:2602.17968 for the underlying optimization technique.

https://claude.ai/code/session_01Xg4VTteVRew2FrGaAAGEs3