### PR TITLE
Implement from_pyomo() to import Pyomo models as discopt Models

### DIFF
--- a/docs/pyomo_solver.md
+++ b/docs/pyomo_solver.md
@@ -84,5 +84,24 @@ order**, `Model.solve` runs, and the solution is mapped back by index. Consequen
 - Models Pyomo can write to `.nl` but whose operators discopt's reader does not
   support return a structured `error` result with a message rather than crashing.
 
-A future direct in-memory translator (`from_pyomo`) may replace the `.nl`
+## Importing a Pyomo model as a discopt `Model`
+
+To get a native discopt `Model` from a Pyomo `ConcreteModel` (rather than just
+solving it), use `discopt.modeling.from_pyomo`:
+
+```python
+import pyomo.environ as pyo
+import discopt.modeling as dm
+
+m = pyo.ConcreteModel()
+m.x = pyo.Var(bounds=(0, 10))
+m.obj = pyo.Objective(expr=(m.x - 3) ** 2)
+
+dmodel = dm.from_pyomo(m)   # a discopt Model
+result = dmodel.solve()
+```
+
+`from_pyomo` reuses the same temporary `.nl` round-trip as the solver plugin, so
+variables/constraints come back in `.nl` column/row order (names differ from the
+Pyomo model). A future direct in-memory translator may replace the `.nl`
 round-trip without changing this interface.

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -3483,10 +3483,12 @@ class SolveUpdate:
 
 def from_pyomo(pyomo_model) -> Model:
     """
-    Import a Pyomo ConcreteModel as a discopt Model.
+    Import a Pyomo ``ConcreteModel`` as a discopt :class:`Model`.
 
-    Supports Var, Constraint, Objective, Param, Set.
-    GDP (Disjunct/Disjunction) is mapped to :meth:`Model.either_or`.
+    The bridge round-trips the Pyomo model through a temporary AMPL ``.nl`` file
+    (the same translation the ``SolverFactory('discopt')`` plugin uses) and reads
+    it back with :func:`from_nl`. Continuous, integer and binary variables,
+    linear/nonlinear constraints, and the objective are supported.
 
     Parameters
     ----------
@@ -3496,13 +3498,50 @@ def from_pyomo(pyomo_model) -> Model:
     Returns
     -------
     Model
+        A discopt ``Model`` ready to ``.solve()``. Its variables/constraints are
+        in the ``.nl`` column/row order, which may differ from the Pyomo model's
+        declaration order.
 
     Raises
     ------
-    NotImplementedError
-        Pyomo import is a Phase 4 feature.
+    ImportError
+        If Pyomo is not installed (``pip install discopt[pyomo]``).
+    ValueError
+        If the Pyomo model has no variables to import.
+
+    Examples
+    --------
+    >>> import pyomo.environ as pyo
+    >>> m = pyo.ConcreteModel()
+    >>> m.x = pyo.Var(bounds=(0, 10))
+    >>> m.obj = pyo.Objective(expr=(m.x - 3) ** 2)
+    >>> dmodel = dm.from_pyomo(m)  # doctest: +SKIP
+    >>> dmodel.solve().objective  # doctest: +SKIP
+    0.0
     """
-    raise NotImplementedError("Pyomo import requires pyomo bridge (Phase 4)")
+    try:
+        import pyomo.environ  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - exercised only without pyomo
+        raise ImportError(
+            "from_pyomo requires Pyomo. Install it with 'pip install discopt[pyomo]'."
+        ) from exc
+
+    import os
+    import tempfile
+
+    from discopt.pyomo import _writer
+
+    # Round-trip through a temporary .nl file. write_nl disables presolve/scaling so
+    # the emitted columns are exactly the model's variables in the original space,
+    # which is what from_nl reconstructs into a discopt Model.
+    with tempfile.TemporaryDirectory(prefix="discopt_from_pyomo_") as workdir:
+        nl_path = os.path.join(workdir, "model.nl")
+        cols, _rows, _eliminated = _writer.write_nl(pyomo_model, nl_path)
+        if not cols:
+            raise ValueError(
+                "from_pyomo: the Pyomo model has no variables to import (nothing to solve)."
+            )
+        return from_nl(nl_path)
 
 
 def from_nl(path: str) -> Model:

--- a/python/tests/test_indexed_correctness.py
+++ b/python/tests/test_indexed_correctness.py
@@ -132,13 +132,7 @@ class TestNlRoundTrip:
 
 
 class TestPyomoCrossCheck:
-    @pytest.mark.xfail(
-        raises=NotImplementedError,
-        reason="from_pyomo is a Phase 4 stub (not yet implemented); see ROADMAP",
-    )
     def test_transportation_matches_pyomo(self):
-        # importorskip only guards pyomo's *absence*; from_pyomo itself is an
-        # unimplemented stub, so the xfail above covers the pyomo-installed path.
         pyo = pytest.importorskip("pyomo.environ")
         model = pyo.ConcreteModel()
         model.P = pyo.RangeSet(0, 1)

--- a/python/tests/test_pyomo_interface.py
+++ b/python/tests/test_pyomo_interface.py
@@ -135,6 +135,64 @@ def test_duals_when_exposed(opt):
     assert d == pytest.approx(2.0, abs=1e-3)
 
 
+def test_from_pyomo_matches_solver_plugin(opt):
+    """`from_pyomo(m).solve()` must reach the same optimum as `SolverFactory('discopt')`
+    on the same model (the issue #381 round-trip acceptance test)."""
+    import discopt.modeling as dm
+
+    # Reference: solve via the registered Pyomo solver plugin.
+    m_ref = _tiny_minlp()
+    res = opt.solve(m_ref)
+    assert res.solver.termination_condition == pyo.TerminationCondition.optimal
+    ref_obj = pyo.value(m_ref.obj)
+
+    # Import the same model into a discopt Model and solve natively.
+    m_imp = _tiny_minlp()
+    dmodel = dm.from_pyomo(m_imp)
+    assert isinstance(dmodel, dm.Model)
+    r = dmodel.solve(time_limit=30, gap_tolerance=1e-4)
+    assert r.status == "optimal"
+    assert r.objective == pytest.approx(ref_obj, rel=1e-4, abs=1e-6)
+    assert r.objective == pytest.approx(1.0, abs=1e-3)
+
+
+def test_from_pyomo_indexed_transportation():
+    """A small indexed (Var/Constraint over sets) LP imports and solves correctly."""
+    import discopt.modeling as dm
+
+    supply = {0: 20.0, 1: 30.0}
+    demand = {0: 10.0, 1: 25.0, 2: 15.0}
+    cost = {(0, 0): 2.0, (0, 1): 3.0, (0, 2): 1.0, (1, 0): 5.0, (1, 1): 4.0, (1, 2): 8.0}
+
+    m = pyo.ConcreteModel()
+    m.P = pyo.RangeSet(0, 1)
+    m.K = pyo.RangeSet(0, 2)
+    m.ship = pyo.Var(m.P, m.K, domain=pyo.NonNegativeReals)
+    m.obj = pyo.Objective(expr=sum(cost[i, j] * m.ship[i, j] for i in m.P for j in m.K))
+    m.sup = pyo.Constraint(m.P, rule=lambda mm, i: sum(mm.ship[i, j] for j in mm.K) <= supply[i])
+    m.dem = pyo.Constraint(m.K, rule=lambda mm, j: sum(mm.ship[i, j] for i in mm.P) >= demand[j])
+
+    dmodel = dm.from_pyomo(m)
+    r = dmodel.solve(time_limit=30, gap_tolerance=1e-4)
+    assert r.status == "optimal"
+
+    # Independent reference via the registered plugin.
+    opt = pyo.SolverFactory("discopt")
+    m2 = m.clone()
+    opt.solve(m2)
+    assert r.objective == pytest.approx(pyo.value(m2.obj), rel=1e-4, abs=1e-6)
+
+
+def test_from_pyomo_no_variables_raises():
+    """A variable-free Pyomo model has nothing to import -> ValueError."""
+    import discopt.modeling as dm
+
+    m = pyo.ConcreteModel()
+    m.o = pyo.Objective(expr=1.0)
+    with pytest.raises(ValueError, match="no variables"):
+        dm.from_pyomo(m)
+
+
 def test_duals_graceful_for_integer_model(opt):
     """Solving an integer model with a `dual` Suffix declared must not error,
     whether or not discopt exposes multipliers (it may surface relaxation duals).


### PR DESCRIPTION
## Summary

Implements the `from_pyomo()` function to enable direct import of Pyomo `ConcreteModel` instances as native discopt `Model` objects. This completes the round-trip bridge between Pyomo and discopt, allowing users to formulate problems in Pyomo and solve them natively with discopt's solver.

## Key Changes

- **`python/discopt/modeling/core.py`**: Replaced the `NotImplementedError` stub in `from_pyomo()` with a working implementation that:
  - Round-trips the Pyomo model through a temporary `.nl` file using the existing `_writer.write_nl()` infrastructure (same path as the `SolverFactory('discopt')` plugin)
  - Validates that the model has variables to import, raising `ValueError` if empty
  - Returns a discopt `Model` via `from_nl()` with variables/constraints in `.nl` column/row order
  - Includes comprehensive docstring with parameters, returns, raises, and usage examples
  - Gracefully handles missing Pyomo with an informative `ImportError`

- **`python/tests/test_pyomo_interface.py`**: Added three new test cases:
  - `test_from_pyomo_matches_solver_plugin()`: Verifies that solving via `from_pyomo(m).solve()` reaches the same optimum as the registered Pyomo solver plugin on a tiny MINLP
  - `test_from_pyomo_indexed_transportation()`: Tests import and solve of an indexed LP with variables/constraints over sets, cross-checking against the plugin
  - `test_from_pyomo_no_variables_raises()`: Confirms that variable-free models raise `ValueError` with appropriate message

- **`python/tests/test_indexed_correctness.py`**: Removed `@pytest.mark.xfail` decorator from `TestPyomoCrossCheck.test_transportation_matches_pyomo()` since `from_pyomo()` is now implemented

- **`docs/pyomo_solver.md`**: Added new section documenting the `from_pyomo()` API with usage example and explanation of the `.nl` round-trip behavior

## Implementation Details

The implementation reuses the existing `.nl` round-trip infrastructure rather than building a direct in-memory translator. This approach:
- Leverages battle-tested `_writer.write_nl()` and `from_nl()` functions
- Ensures consistency with the `SolverFactory('discopt')` plugin behavior
- Maintains the same variable/constraint ordering semantics
- Allows for future optimization (direct translator) without API changes

Variables and constraints are returned in `.nl` column/row order, which may differ from Pyomo's declaration order—this is documented in the docstring and examples.

https://claude.ai/code/session_015ppYVyjDmvuHbxiwN1Mgnk