### PR TITLE
test: cut PR-fast pytest duration ~65% by relocating the heavy tail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,10 @@ jobs:
       - name: Run pytest (PR-fast, parallel)
         run: |
           source .venv/bin/activate
-          # Keep worker count bounded so JAX compilation and AMP relaxations do
-          # not multiply peak memory unexpectedly.
+          # Use all 4 vCPUs of the ubuntu-latest runner. Peak memory stays well
+          # under the 16 GB runner (CPU-only JAX workers are ~1-2 GB RSS each),
+          # and the heaviest multi-minute solves now carry `slow` so they no
+          # longer pin a worker for the whole run.
           # --dist loadgroup keeps tests sharing a class on the same worker
           #   so xdist-incompatible fixtures stay serialized.
           # Coverage is intentionally dropped from the PR path — see the
@@ -123,7 +125,7 @@ jobs:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
           PYTEST_MEMORY_LIMIT_MB: "32768"
-          PYTEST_XDIST_WORKERS: "2"
+          PYTEST_XDIST_WORKERS: "4"
 
   python-coverage:
     name: Python coverage (3.12, ubuntu)
@@ -185,7 +187,7 @@ jobs:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
           PYTEST_MEMORY_LIMIT_MB: "32768"
-          PYTEST_XDIST_WORKERS: "2"
+          PYTEST_XDIST_WORKERS: "4"
       - name: Upload to Codecov
         if: always()
         uses: codecov/codecov-action@v5

--- a/python/tests/test_amp_simplex_backend.py
+++ b/python/tests/test_amp_simplex_backend.py
@@ -88,6 +88,7 @@ class TestAmpSimplexCertificationParity:
     # never certifies (``feasible`` at any budget — a relaxation-tightness property,
     # not a backend property), so it stays short to avoid burning wall-clock. The
     # seam under test is backend *parity*, which holds at any budget.
+    @pytest.mark.slow
     @pytest.mark.parametrize("build,time_limit", [(_concave_qp, 60), (_bilinear, 5)])
     def test_same_certificate_as_default(self, build, time_limit):
         ref = build().solve(solver="amp", rel_gap=1e-4, time_limit=time_limit)

--- a/python/tests/test_convex_objective_bound.py
+++ b/python/tests/test_convex_objective_bound.py
@@ -142,6 +142,7 @@ def test_supporting_hyperplane_is_a_valid_lower_bound():
             assert bound <= f(xs) + 1e-6
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not os.path.exists(_NVS17), reason="nvs17.nl not vendored")
 def test_nvs17_certifies_via_convex_objective_bound():
     """End-to-end: nvs17 (convex quadratic objective, nonconvex constraints,

--- a/python/tests/test_convexity_minlplib_suspect.py
+++ b/python/tests/test_convexity_minlplib_suspect.py
@@ -56,10 +56,12 @@ only path. Each instance falls into one of three pinned buckets:
   this corpus has been closed.
 
 Most instances are vendored under ``data/minlplib_nl/`` and run in the PR-fast
-job. Two vendored negative controls (``casctanks``, ``heatexch_gen3``) classify
-in ~2 minutes — past the 120 s per-test timeout — so they live in ``NEGATIVE_SLOW``
-and are marked ``slow`` (deselected on the PR-fast / coverage path, exercised in
-full / slow runs). A few large negative controls (``super1``..``super3t``)
+job. The negative controls that classify too slowly for the PR-fast per-test
+budget (``casctanks`` / ``heatexch_gen3`` at ~2 min, ``hda`` at ~90 s, and the
+mid-weight ``contvar`` / ``bchoco07`` / ``bchoco08`` at ~5-10 s) live in
+``NEGATIVE_SLOW`` and are marked ``slow`` (deselected on the PR-fast / coverage
+path, exercised in full / slow runs, so their non-convex soundness coverage is
+preserved). A few large negative controls (``super1``..``super3t``)
 classify in tens of seconds and are left in the local MINLPLib cache only; they
 are exercised when present (``--instances super1,super2,super3,super3t`` via
 ``fetch_minlplib``) and skipped otherwise.
@@ -87,7 +89,6 @@ NEGATIVE = (
     # heat-exchanger / scheduling / supply-chain instances (MINLPLib convex=False)
     "4stufen",
     "beuster",
-    "contvar",
     "ex1224",
     "gkocis",
     "st_e29",
@@ -99,25 +100,31 @@ NEGATIVE = (
     "heatexch_gen1",
     "heatexch_gen2",
     "oaer",
-    # hda: signomial equilibrium constraints; its convex structure is in
-    # log-space, explicitly out of scope for #40 — discopt soundly stays
-    # non-convex here, which is the behaviour we pin.
-    "hda",
     # batch chocolate scheduling (power-law sizing + big-M); unlabelled in the
-    # current MINLPLib snapshot, genuine non-convexities.
+    # current MINLPLib snapshot, genuine non-convexities. bchoco06 classifies
+    # fast; the larger 07/08 DAGs are in NEGATIVE_SLOW.
     "bchoco06",
-    "bchoco07",
-    "bchoco08",
 )
 
 # Slow vendored negative controls: same soundness gate as ``NEGATIVE`` but each
-# classifies in ~2 minutes (dense Hessian / large signomial DAGs), which exceeds
-# the PR-fast job's 120 s per-test timeout. Marked ``@pytest.mark.slow`` so the
-# PR-fast and coverage jobs deselect them; still vendored and exercised in full /
-# slow runs, preserving their non-convex soundness coverage.
+# classifies too slowly for the PR-fast per-test budget — from ~5 s (dense DAGs)
+# up to ~2 minutes (``casctanks`` / ``heatexch_gen3``). Marked
+# ``@pytest.mark.slow`` so the PR-fast and coverage jobs deselect them; still
+# vendored and exercised in full / slow runs, preserving their non-convex
+# soundness coverage.
 NEGATIVE_SLOW = (
     "casctanks",
     "heatexch_gen3",
+    # hda: signomial equilibrium constraints; its convex structure is in
+    # log-space, explicitly out of scope for #40 — discopt soundly stays
+    # non-convex here. Classifies in ~90 s (large signomial DAG), so it lives
+    # on the slow path rather than the 120 s PR-fast budget.
+    "hda",
+    # contvar (~10 s) and the larger batch-chocolate DAG bchoco08/07 (~5-6 s):
+    # correct non-convex verdicts, but too slow for the PR-fast budget.
+    "contvar",
+    "bchoco07",
+    "bchoco08",
 )
 
 # Large negative controls kept in the local cache only (not vendored: each

--- a/python/tests/test_gbd.py
+++ b/python/tests/test_gbd.py
@@ -191,6 +191,7 @@ def test_project_mu_sign_convention():
             assert out[k] == pytest.approx(mu[k])
 
 
+@pytest.mark.slow
 def test_lagrangian_anchor_sound_under_inexact_recourse(monkeypatch):
     """The GBD cut anchors at the Lagrangian dual value, not the NLP primal, so a
     *suboptimal* recourse solve cannot produce an unsound bound.
@@ -235,6 +236,7 @@ def test_lagrangian_anchor_sound_under_inexact_recourse(monkeypatch):
     assert not (r.status == "optimal" and r.objective is not None and r.objective > true_opt + 1e-2)
 
 
+@pytest.mark.slow
 def test_nonconvex_reports_no_bound():
     """A nonconvex (concave) objective must not produce a numeric lower bound;
     soundness gate -> bound is None even though a heuristic incumbent is found."""

--- a/python/tests/test_gdp.py
+++ b/python/tests/test_gdp.py
@@ -1313,6 +1313,7 @@ class TestIfElse:
         with pytest.raises(TypeError):
             dm.udf(123)
 
+    @pytest.mark.slow
     def test_solve_piecewise_reaches_global_optimum(self):
         """End-to-end: minimize a piecewise function with a unique optimum.
 

--- a/python/tests/test_gear4_false_infeasible.py
+++ b/python/tests/test_gear4_false_infeasible.py
@@ -100,6 +100,7 @@ def test_clearing_skipped_for_unbounded_slack_product():
     )
 
 
+@pytest.mark.slow
 def test_gear4_not_false_infeasible():
     """gear4 must never be reported certified-infeasible; bounds stay sound."""
     r = from_nl(str(_DATA / "gear4.nl")).solve(time_limit=10, max_nodes=200)
@@ -121,6 +122,7 @@ def test_gear4_not_false_infeasible():
         )
 
 
+@pytest.mark.slow
 def test_synthetic_unbounded_slack_quotient_not_false_infeasible():
     """Self-contained gear4-class model (issue #145): a large-coefficient quotient
     equality with unbounded continuous slacks must not be certified infeasible."""

--- a/python/tests/test_gp_corpus.py
+++ b/python/tests/test_gp_corpus.py
@@ -179,6 +179,7 @@ def test_corpus_auto_route_matches_solve_gp(case: GPCase) -> None:
     assert auto_result.objective == pytest.approx(direct_result.objective, abs=1e-6)
 
 
+@pytest.mark.slow
 def test_bb_opt_out_skips_gp_fast_path() -> None:
     """``solver="bb"`` forces classic branch-and-bound, not the GP fast path."""
     model = _monomial_balance()

--- a/python/tests/test_incumbent_injection_soundness.py
+++ b/python/tests/test_incumbent_injection_soundness.py
@@ -36,6 +36,7 @@ _SUBOPTIMAL_SEEDS = [
 ]
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not os.path.exists(_NVS19), reason="nvs19.nl not vendored")
 @pytest.mark.parametrize("seed", _SUBOPTIMAL_SEEDS)
 def test_suboptimal_warm_start_never_false_certifies(seed):

--- a/python/tests/test_issue_266_deep_recursion.py
+++ b/python/tests/test_issue_266_deep_recursion.py
@@ -157,6 +157,7 @@ def test_quadratic_fallback_runs_once_per_maximal_region(monkeypatch):
     assert calls["n"] <= 8, f"quadratic_curvature called {calls['n']} times for n={n}"
 
 
+@pytest.mark.slow
 def test_deep_pure_continuous_solve_does_not_return_error():
     """A convexity-unknown deep continuous model returns a sound status, not error.
 

--- a/python/tests/test_issue_267_univariate_product_lift.py
+++ b/python/tests/test_issue_267_univariate_product_lift.py
@@ -265,6 +265,7 @@ def test_inscribedsquare02_constraints_not_dropped(caplog):
     assert not omitted, f"inscribedsquare02 constraints dropped: {omitted}"
 
 
+@pytest.mark.slow
 def test_inscribedsquare02_finite_valid_bound():
     m = _inscribedsquare02_model()
     r = m.solve(time_limit=20, gap_tolerance=1e-4)

--- a/python/tests/test_issue_271_factorable_recursion.py
+++ b/python/tests/test_issue_271_factorable_recursion.py
@@ -154,6 +154,7 @@ def test_factorable_walk_under_lowered_limit(monkeypatch):
     assert isinstance(out, dm.Model)
 
 
+@pytest.mark.slow
 def test_deep_division_solve_does_not_crash(monkeypatch):
     """A deep-body model solves to a sound status, not a ``RecursionError``.
 

--- a/python/tests/test_ratio_of_products_relaxation.py
+++ b/python/tests/test_ratio_of_products_relaxation.py
@@ -192,6 +192,7 @@ def test_gear4_relaxation_retains_constraint_and_is_exact_at_optimum():
     assert n >= 6
 
 
+@pytest.mark.slow
 def test_gear4_solve_stays_sound():
     """End-to-end gear4 must never be certified infeasible (soundness must-gate)."""
     r = from_nl(str(_DATA / "gear4.nl")).solve(time_limit=20, max_nodes=500)

--- a/python/tests/test_relaxation_coverage.py
+++ b/python/tests/test_relaxation_coverage.py
@@ -68,7 +68,10 @@ _OPERATORS = [
     ("log1p", dm.log1p, np.log1p, -0.5, 3.0),
     ("sigmoid", dm.sigmoid, lambda x: 1.0 / (1.0 + np.exp(-x)), -3.0, 3.0),
     ("softplus", dm.softplus, lambda x: np.log1p(np.exp(x)), -3.0, 3.0),
-    ("abs", dm.abs, np.abs, -2.0, 2.0),
+    # abs certifies via the exact piecewise spatial B&B, which is ~15 s (kink at
+    # 0); heavy for the PR-fast budget, so this one operator runs on the slow
+    # path. The other operators stay in the PR-fast set.
+    pytest.param("abs", dm.abs, np.abs, -2.0, 2.0, marks=pytest.mark.slow, id="abs"),
     ("pow2", _pow2, lambda x: x**2, -2.0, 2.0),
     ("pow3", _pow3, lambda x: x**3, -2.0, 2.0),
     ("pow_half", _pow_half, lambda x: x**0.5, 0.1, 4.0),
@@ -93,7 +96,11 @@ def _solve(build_fn, lb, ub, sense):
 
 
 @pytest.mark.relaxation
-@pytest.mark.parametrize("name,build_fn,ref_fn,lb,ub", _OPERATORS, ids=[o[0] for o in _OPERATORS])
+@pytest.mark.parametrize(
+    "name,build_fn,ref_fn,lb,ub",
+    _OPERATORS,
+    ids=[getattr(o, "id", None) or o[0] for o in _OPERATORS],
+)
 def test_operator_has_valid_tight_bound(name, build_fn, ref_fn, lb, ub):
     """Each operator solves to a certified global optimum matching brute force."""
     true_min, true_max = _brute_optima(ref_fn, lb, ub)
@@ -123,6 +130,7 @@ def test_bilinear_lifted_moment_bound():
     assert abs(float(res.objective)) < _TOL
 
 
+@pytest.mark.slow
 @pytest.mark.relaxation
 @pytest.mark.parametrize("lb,ub", [(-1.0, 1.0), (-2.0, 2.0), (-2.0, 3.0)])
 def test_abs_zero_crossing_certifies(lb, ub):

--- a/python/tests/test_signed_signomial.py
+++ b/python/tests/test_signed_signomial.py
@@ -43,6 +43,7 @@ def _box(n):
     return jnp.asarray(u_lb), jnp.asarray(u_ub)
 
 
+@pytest.mark.slow
 def test_soundness_cv_below_cc_above():
     """cv(u) <= s(u) <= cc(u) for many random signed signomials and samples."""
     rng = np.random.default_rng(0)
@@ -60,6 +61,7 @@ def test_soundness_cv_below_cc_above():
                 assert float(cc) >= float(s) - 1e-9
 
 
+@pytest.mark.slow
 def test_curvature_cv_convex_cc_concave():
     """Midpoint Jensen check: cv convex, cc concave along random chords."""
     rng = np.random.default_rng(1)

--- a/python/tests/test_st_e17_certification.py
+++ b/python/tests/test_st_e17_certification.py
@@ -52,6 +52,7 @@ def test_st_e17_certifies_to_optimum():
     assert r.bound <= r.objective + 1e-2, f"invalid dual bound {r.bound} > obj {r.objective}"
 
 
+@pytest.mark.slow
 def test_st_e17_returned_point_is_feasible():
     """The certified incumbent satisfies the original ratio constraint."""
     r = dm.from_nl(str(_NL)).solve(time_limit=90, gap_tolerance=1e-4)

--- a/python/tests/test_symbolic_domains.py
+++ b/python/tests/test_symbolic_domains.py
@@ -244,6 +244,7 @@ def test_monod_detector_guards_and_no_misfire():
     assert _try_extract_monod(xn / (2.0 + xn), mn) is None
 
 
+@pytest.mark.slow
 def test_compiler_routes_arrhenius_pattern():
     """The compiler detects exp(-c/T) on a positive-domain variable and routes it
     to the dedicated single-inflection envelope; sound across the inflection."""

--- a/python/tests/test_symbolic_gas.py
+++ b/python/tests/test_symbolic_gas.py
@@ -159,6 +159,7 @@ def test_signed_power_panhandle_sound(beta):
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("beta", [1.5, 1.85, 1.95])
 def test_compiler_routes_signed_power_pattern(beta):
     """The compiler detects ``f * |f|**(beta-1)`` and routes it to the tight

--- a/python/tests/test_tainted_tree_bound.py
+++ b/python/tests/test_tainted_tree_bound.py
@@ -45,6 +45,7 @@ def _has(path: str) -> bool:
     return os.path.exists(path)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not _has(_NVS17), reason="nvs17.nl not vendored")
 def test_uncertified_feasible_exit_reports_valid_finite_dual_bound():
     """A budget-limited nonconvex feasible exit surfaces the valid tree bound.
@@ -69,6 +70,7 @@ def test_uncertified_feasible_exit_reports_valid_finite_dual_bound():
         assert r.gap is not None and np.isfinite(r.gap)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not _has(_NVS17), reason="nvs17.nl not vendored")
 def test_reported_bound_is_a_valid_lower_bound_not_a_false_certificate():
     """Whatever the exit status, a reported bound never exceeds the optimum and a

--- a/python/tests/test_unbounded_relaxation_soundness.py
+++ b/python/tests/test_unbounded_relaxation_soundness.py
@@ -33,6 +33,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import discopt
 import discopt._jax.mccormick_lp as mc
 import numpy as np
+import pytest
 
 
 def _bilinear_obj():
@@ -84,6 +85,7 @@ def test_has_unbounded_nonlinear_col_flags_free_bilinear_var():
     assert relaxer._has_unbounded_nonlinear_col(free)
 
 
+@pytest.mark.slow
 def test_himmel16_no_false_certification():
     """End-to-end: the largest-small-hexagon model with only pairwise-diameter
     constraints has a feasible self-intersecting solution at objvar=-0.866. The


### PR DESCRIPTION
The `-m "not slow ..."` PR-fast suite (4.3k tests) was dominated by a
long tail: ~30 real-solver soundness/certification tests each running
5-96 s (the single worst, convexity classification of `hda`, took 96 s
and nearly hit the 120 s per-test timeout). These ~30 tests accounted
for ~47% of total suite CPU and set the wall-time floor.

Move that tail onto the existing `slow` path (the same convention the
repo already uses for its other heavy tests, e.g. the vendored
`casctanks`/`heatexch_gen3` convexity controls). Nothing is deleted or
weakened — every relocated test still runs under `-m slow` / the full
suite; it just leaves the every-PR path.

- test_convexity_minlplib_suspect: move hda/contvar/bchoco07/bchoco08
  from NEGATIVE into the slow-marked NEGATIVE_SLOW bucket (same
  soundness assertion), and refresh the docstring.
- Mark the remaining heavy solves `slow`: incumbent-injection warm-start,
  himmel16 / issue_266 / issue_271 recursion solves, gbd Lagrangian +
  nonconvex, issue_267 inscribedsquare, ratio-of-products gear4,
  gear4-false-infeasible, signed-signomial envelopes, symbolic gas/domain
  routing, gdp piecewise, tainted-tree bounds, st_e17, gp_corpus,
  amp-simplex parity, and the abs zero-crossing coverage.
- test_relaxation_coverage: mark only the `abs` operator param slow (via
  pytest.param) so the other 25 cheap operator checks stay on the PR path.
- ci.yml: bump PR-fast + coverage jobs to 4 xdist workers (all vCPUs on
  the 16 GB ubuntu-latest runner; CPU-only JAX workers are ~1-2 GB each).

Measured on a 4-core box (JAX_PLATFORMS=cpu, -n 4): fast suite drops from
340 s to 113 s wall (-67%); slowest single test 96 s -> 4.65 s;
4313 passed / 0 failures.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QeWYXg7Hi5A6rA7PYXF9eE