### PR TITLE
fix(correctness): C-15 run_obbt clamps LP vertex to the NS-safe bound

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -717,7 +717,7 @@ function is removed; standing gates pass.
   seam.
 - **Gates:** `test_obbt.py` 48 passed; `test_amp` 135, `test_amp_integration` +
   `test_lp_backend_select` 17; `pytest -m smoke` 211 passed / 1 skipped;
-  adversarial suite 10 passed; ruff clean. PR: (pending).
+  adversarial suite 10 passed; ruff clean. PR: #401 (stacked on #399).
 
 ---
 

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -61,7 +61,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-6 | P1 | modeling API | integer vars silently clamped to [0, 1e6] | open |
 | C-18 | P1 | midpoint bound | `mccormick_bounds="midpoint"` returns u(mid), not a lower bound (opt-in mode) | open |
 | C-20 | P2 | fbbt_fp.rs | watch-list FBBT declares infeasibility with zero tolerance (opt-in engine) | open |
-| C-15 | P2 | obbt.py | `run_obbt` variant tightens to raw LP vertex, no NS safe-bound clamp | open |
+| C-15 | P2 | obbt.py | `run_obbt` variant tightens to raw LP vertex, no NS safe-bound clamp | fixed |
 | C-14 | P2 | milp_driver | LP-infeasible fathom trusts status alone; Farkas ray never verified | open |
 | C-21 | P2 | incremental MC | soundness-gate validation boxes never exercise negative/zero-spanning bounds | open |
 | C-7 | P2 | .nl parser | defined variables (V segments) discarded → hard parse error | open |
@@ -687,7 +687,37 @@ code — deletion is the better fix if nothing calls it).
 optimistic LP objective, the applied bound never exceeds the NS bound) or the dead
 function is removed; standing gates pass.
 
-**Log:** —
+**Log:**
+- 2026-07-02 — **CONFIRMED (not dead) then FIXED.** Static confirm: `run_obbt`
+  applied `result.objective` (raw LP vertex) with only a `+1e-8` gate; the NS
+  clamp + conditioning guard lived only in `run_obbt_on_relaxation`. Reachability:
+  `run_obbt` is **live** — called from the AMP path (`solvers/amp.py:1897,1941`)
+  and heavily tested — so deletion is off the table; routed the tightening
+  through the NS-safe bound instead.
+- **Fix.** `run_obbt` now (a) resolves its oracle via `get_exact_dual_lp_solver`
+  (vertex duals), (b) applies the `_cond > _OBBT_COND_LIMIT` → `require_ns`
+  conditioning guard mirroring `run_obbt_on_relaxation`, and (c) clamps every
+  min/max tightening to the Neumaier–Shcherbina safe bound `g` via a new
+  `_ns_clamp` closure. `_ns_safe_lp_lower_bound` gained an `n_eq` parameter so
+  the trailing **equality** rows (`run_obbt` sees `A_eq`, unlike the relaxation
+  variant) keep a *free-sign* multiplier while inequality rows stay clamped
+  `≥ 0`; `n_eq=0` default is byte-identical for the existing callers (DBBT,
+  `run_obbt_on_relaxation`). The local `_max_abs` in `run_obbt_on_relaxation`
+  was hoisted to module scope and reused. Equilibration was deliberately **not**
+  added here — the NS bound `g(y)` is a rigorous under-estimate for *any* duals
+  regardless of conditioning, so the clamp restores soundness on its own.
+- **Regression tests** (`python/tests/test_obbt.py::TestC15NsSafeClamp`,
+  fail-before/pass-after verified): `test_optimistic_vertex_is_clamped` (fake
+  oracle reports an optimistic vertex 5.0 with inactive duals → clamped to the
+  NS bound ~0, feasible region not cut; patches both oracle seams so it
+  discriminates the pre-fix path), and `test_ns_safe_lower_bound_free_equality_multiplier`
+  (equality `x==2`: `n_eq=1` recovers the tight bound 2.0 vs 0.0 when clamped as
+  `<=`, both rigorous under-estimates of the true min). Updated
+  `test_total_time_limit_stops_before_all_variables` to patch the new preferred
+  seam.
+- **Gates:** `test_obbt.py` 48 passed; `test_amp` 135, `test_amp_integration` +
+  `test_lp_backend_select` 17; `pytest -m smoke` 211 passed / 1 skipped;
+  adversarial suite 10 passed; ruff clean. PR: (pending).
 
 ---
 

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -717,7 +717,7 @@ function is removed; standing gates pass.
   seam.
 - **Gates:** `test_obbt.py` 48 passed; `test_amp` 135, `test_amp_integration` +
   `test_lp_backend_select` 17; `pytest -m smoke` 211 passed / 1 skipped;
-  adversarial suite 10 passed; ruff clean. PR: #401 (stacked on #399).
+  adversarial suite 10 passed; ruff clean. PR: #402 (→ main; supersedes #401).
 
 ---
 

--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -735,7 +735,7 @@ def run_obbt(
         if g is None:
             return None if require_ns else raw
         if raw > g + _OBBT_NS_GUARD * (1.0 + abs(raw)):
-            return g
+            return float(g)
         return raw
 
     for var_idx in candidates:

--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -52,7 +52,7 @@ _OBBT_COND_LIMIT = 1e10
 _OBBT_NS_GUARD = 1e-6
 
 
-def _ns_safe_lp_lower_bound(c, dual_values, A_ub, b_ub, lo, hi, *, rc_snap_tol=0.0):
+def _ns_safe_lp_lower_bound(c, dual_values, A_ub, b_ub, lo, hi, *, rc_snap_tol=0.0, n_eq=0):
     """Neumaier-Shcherbina rigorous lower bound on ``min c^T x`` over the box LP.
 
     The LP is ``min c^T x  s.t.  A_ub x <= b_ub,  lo <= x <= hi``. For *any*
@@ -94,6 +94,15 @@ def _ns_safe_lp_lower_bound(c, dual_values, A_ub, b_ub, lo, hi, *, rc_snap_tol=0
     nonzero reduced cost on an infinite-bound column exceeds the tol, is NOT
     snapped, and correctly yields ``None`` -- so the tol also guards against
     masking real unboundedness.
+
+    ``n_eq`` (default ``0``) marks the last ``n_eq`` rows of ``(A_ub, b_ub)`` as
+    *equality* rows (``A_eq x == b_eq``, appended after the inequality rows —
+    the simplex/HiGHS ``dual_values`` order). An equality contributes
+    ``v^T(A_eq x - b_eq) == 0`` for every feasible ``x`` regardless of the sign
+    of ``v``, so its multiplier is *free*: only the leading inequality block is
+    clamped to ``>= 0``. Clamping an equality multiplier would still be sound
+    (it just picks a different valid ``y``) but needlessly weakens ``g``; leaving
+    it free keeps the bound as tight as the vertex duals allow.
     """
     import scipy.sparse as sp
 
@@ -102,7 +111,14 @@ def _ns_safe_lp_lower_bound(c, dual_values, A_ub, b_ub, lo, hi, *, rc_snap_tol=0
     y = np.array(dual_values, dtype=np.float64)  # copy: must not mutate caller's duals
     if y.size == 0:
         return None
-    np.clip(-y, 0.0, None, out=y)  # y := max(-row_dual, 0) >= 0
+    # HiGHS reports ``rc = c - A^T·dual`` so the weak-duality multiplier is
+    # ``-dual``. Inequality (``<=``) rows require a non-negative multiplier for
+    # ``g(y) <= min`` to hold; the trailing ``n_eq`` equality rows carry a
+    # free-sign multiplier and are left unclamped.
+    y = -y
+    n_ub = y.size - int(n_eq)
+    if n_ub > 0:
+        np.clip(y[:n_ub], 0.0, None, out=y[:n_ub])  # inequality rows: max(-dual, 0)
     c = np.asarray(c, dtype=np.float64)
     if A_ub is None or b_ub is None:
         rc = c.copy()
@@ -140,6 +156,25 @@ def _ns_safe_lp_lower_bound(c, dual_values, A_ub, b_ub, lo, hi, *, rc_snap_tol=0
     # (~n * eps * magnitude); keeps g a rigorous under-estimate.
     margin = 1e-10 * (1.0 + abs(const) + float(np.abs(contrib).sum()))
     return g - margin
+
+
+def _max_abs(x) -> float:
+    """Largest finite absolute entry of ``x`` (0.0 for ``None``/empty).
+
+    Used to gauge an OBBT projection LP's conditioning (coefficient spread) so
+    the caller can require the rigorous NS-safe bound on ill-conditioned systems.
+    """
+    if x is None:
+        return 0.0
+    import scipy.sparse as sp
+
+    if sp.issparse(x):
+        return float(np.abs(x.data).max()) if x.nnz else 0.0
+    arr = np.asarray(x, dtype=np.float64)
+    if arr.size == 0:
+        return 0.0
+    finite = arr[np.isfinite(arr)]
+    return float(np.abs(finite).max()) if finite.size else 0.0
 
 
 def _equilibrate_rows(A_ub, b_ub):
@@ -558,7 +593,13 @@ def run_obbt(
     # ``run_obbt_on_relaxation`` / ``get_exact_lp_solver`` (issue #145). The IPM
     # is never used here; if no exact (Rust simplex / HiGHS) oracle is available
     # the pass is a sound no-op. ``prefer_pounce`` is kept for compatibility.
-    _lp = get_exact_lp_solver()
+    # Prefer the dual-exposing exact oracle: its vertex duals let every
+    # tightening be clamped to the rigorous Neumaier-Shcherbina safe bound
+    # (C-15), so an ill-conditioned LP whose reported vertex drifts *above* the
+    # true projection can no longer over-tighten and cut feasible points.
+    _dual_lp = get_exact_dual_lp_solver()
+    _lp = _dual_lp or get_exact_lp_solver()
+    _use_ns = _dual_lp is not None
     if _lp is None:
         eff_lb = lb if lb is not None else _get_var_bounds(model)[0].copy()
         eff_ub = ub if ub is not None else _get_var_bounds(model)[1].copy()
@@ -612,6 +653,42 @@ def run_obbt(
             total_lp_time=0.0,
         )
 
+    # Conditioning guard + NS-safe clamp setup (C-15). The reported LP vertex
+    # can drift *above* the true projection on an ill-conditioned system and
+    # over-tighten a bound, cutting feasible (possibly optimal) points. Every
+    # tightening below is clamped to the rigorous Neumaier-Shcherbina bound ``g``
+    # (sound at any conditioning); on an ill-conditioned LP we additionally
+    # *require* that safe bound, leaving a variable untightened rather than
+    # trusting a non-rigorous vertex. ``dual_values`` are ordered inequality rows
+    # then equality rows, so the NS eval stacks ``[A_ub; A_eq]`` and marks the
+    # ``A_eq`` rows as free-multiplier via ``n_eq``.
+    _bound_vals = np.concatenate([lb, ub]) if n_vars else np.array([], dtype=np.float64)
+    _cond = max(
+        _max_abs(A_ub),
+        _max_abs(b_ub),
+        _max_abs(A_eq),
+        _max_abs(b_eq),
+        _max_abs(_bound_vals),
+    )
+    require_ns = _cond > _OBBT_COND_LIMIT
+    if require_ns and not _use_ns:
+        return ObbtResult(
+            tightened_lb=lb,
+            tightened_ub=ub,
+            n_lp_solves=0,
+            n_tightened=0,
+            total_lp_time=0.0,
+        )
+    _ns_parts_A = [p for p in (A_ub, A_eq) if p is not None]
+    _ns_parts_b = [p for p in (b_ub, b_eq) if p is not None]
+    _ns_A = np.vstack(_ns_parts_A) if _ns_parts_A else None
+    _ns_b = (
+        np.concatenate([np.asarray(p, dtype=np.float64) for p in _ns_parts_b])
+        if _ns_parts_b
+        else None
+    )
+    _ns_neq = 0 if A_eq is None else int(np.asarray(A_eq).shape[0])
+
     # Identify candidate variables
     candidates = []
     for i in range(n_vars):
@@ -642,6 +719,25 @@ def run_obbt(
             return remaining
         return min(time_limit_per_lp, remaining)
 
+    def _ns_clamp(c_vec: np.ndarray, raw: float, result) -> Optional[float]:
+        """Clamp a raw LP-vertex objective ``min c_vec^T x`` to the NS-safe bound.
+
+        Returns the value to tighten to (the raw vertex when it is trustworthy,
+        else the rigorous under-estimate ``g``), or ``None`` when no safe bound
+        is available on an ill-conditioned LP (``require_ns``) — the caller then
+        leaves the bound untightened. See ``_ns_safe_lp_lower_bound``.
+        """
+        if not _use_ns:
+            return raw
+        g = _ns_safe_lp_lower_bound(
+            c_vec, getattr(result, "dual_values", None), _ns_A, _ns_b, lb, ub, n_eq=_ns_neq
+        )
+        if g is None:
+            return None if require_ns else raw
+        if raw > g + _OBBT_NS_GUARD * (1.0 + abs(raw)):
+            return g
+        return raw
+
     for var_idx in candidates:
         lp_time_limit = _lp_time_limit()
         if lp_time_limit is None and deadline is not None:
@@ -664,11 +760,11 @@ def run_obbt(
         n_lp_solves += 1
         total_lp_time += result.wall_time
 
-        if result.status == SolveStatus.OPTIMAL:
+        if result.status == SolveStatus.OPTIMAL and result.objective is not None:
             warm_basis = result.basis
-            new_lb = result.objective
+            new_lb = _ns_clamp(c, float(result.objective), result)
             if new_lb is not None and new_lb > lb[var_idx] + 1e-8:
-                lb[var_idx] = new_lb
+                lb[var_idx] = min(new_lb, ub[var_idx])  # never cross the upper bound
                 bounds_list[var_idx] = (float(lb[var_idx]), float(ub[var_idx]))
                 n_tightened += 1
 
@@ -692,13 +788,17 @@ def run_obbt(
         n_lp_solves += 1
         total_lp_time += result.wall_time
 
-        if result.status == SolveStatus.OPTIMAL:
+        if result.status == SolveStatus.OPTIMAL and result.objective is not None:
             warm_basis = result.basis
-            new_ub = -result.objective if result.objective is not None else None
-            if new_ub is not None and new_ub < ub[var_idx] - 1e-8:
-                ub[var_idx] = new_ub
-                bounds_list[var_idx] = (float(lb[var_idx]), float(ub[var_idx]))
-                n_tightened += 1
+            # ``g`` bounds ``min(-x_i)`` from below, so ``-g`` is the sound
+            # (looser) upper bound on ``x_i`` when the vertex is untrustworthy.
+            lp_min = _ns_clamp(c, float(result.objective), result)
+            if lp_min is not None:
+                new_ub = -lp_min
+                if new_ub < ub[var_idx] - 1e-8:
+                    ub[var_idx] = max(new_ub, lb[var_idx])  # never cross the lower bound
+                    bounds_list[var_idx] = (float(lb[var_idx]), float(ub[var_idx]))
+                    n_tightened += 1
 
     return ObbtResult(
         tightened_lb=lb,
@@ -798,17 +898,6 @@ def run_obbt_on_relaxation(
     # Refuse to tighten over a numerically ill-conditioned relaxation: an OBBT
     # bound from such an LP is not rigorous and can prune feasible points (see
     # ``_OBBT_COND_LIMIT``). Returning the box untightened is sound.
-    def _max_abs(x) -> float:
-        if x is None:
-            return 0.0
-        if sp.issparse(x):
-            return float(np.abs(x.data).max()) if x.nnz else 0.0
-        arr = np.asarray(x, dtype=np.float64)
-        if arr.size == 0:
-            return 0.0
-        finite = arr[np.isfinite(arr)]
-        return float(np.abs(finite).max()) if finite.size else 0.0
-
     _bound_vals = np.array([v for pair in bounds for v in pair], dtype=np.float64)
     _cond = max(_max_abs(A_ub), _max_abs(b_ub), _max_abs(_bound_vals))
     # Conditioning guard. The raw vertex objective from an ill-conditioned LP can

--- a/python/tests/test_obbt.py
+++ b/python/tests/test_obbt.py
@@ -227,9 +227,11 @@ class TestObbtBasic:
             clock["now"] += 0.11
             return LPResult(status=SolveStatus.OPTIMAL, objective=0.0, wall_time=0.11)
 
-        # OBBT now resolves its LP oracle through ``get_exact_lp_solver`` (it
-        # must use an exact simplex backend for sound tightening — see #145),
-        # so patch that seam rather than the module-level ``solve_lp``.
+        # OBBT resolves its LP oracle through the exact-oracle seams (it must use
+        # an exact simplex backend for sound tightening — see #145); since C-15 it
+        # prefers ``get_exact_dual_lp_solver`` (vertex duals feed the NS-safe
+        # clamp), falling back to ``get_exact_lp_solver``. Patch both.
+        monkeypatch.setattr(obbt_mod, "get_exact_dual_lp_solver", lambda: fake_solve_lp)
         monkeypatch.setattr(obbt_mod, "get_exact_lp_solver", lambda: fake_solve_lp)
 
         result = run_obbt(m, time_limit_per_lp=1.0, total_time_limit=0.2)
@@ -776,3 +778,113 @@ class TestReverseFbbtFromAux:
         # The true optimum x=y=2 (obj 4) must remain inside the cascade box.
         assert on.lb[0] <= 2.0 + 1e-6 <= on.ub[0]
         assert on.lb[1] <= 2.0 + 1e-6 <= on.ub[1]
+
+
+# ─────────────────────────────────────────────────────────────
+# C-15: run_obbt must clamp the raw LP vertex to the NS-safe bound
+# ─────────────────────────────────────────────────────────────
+
+
+class TestC15NsSafeClamp:
+    """`run_obbt` tightens through the Neumaier-Shcherbina safe bound, never the
+    raw (possibly optimistic) LP vertex — the C-15 fix. Before the fix the
+    model-linear variant applied ``result.objective`` directly, so an
+    ill-conditioned solve reporting a vertex *above* the true projection could
+    cut off feasible points.
+    """
+
+    def _fake_optimistic_solver(self):
+        """An LP oracle that reports OPTIMAL with an *optimistic* objective whose
+        duals (via NS) prove a much looser true bound. min-x claims obj 5.0 while
+        the constraint is inactive (dual 0 ⇒ safe bound at the box lower bound);
+        max-x claims max=3 while the box allows 10.
+        """
+
+        def _fake(
+            c,
+            A_ub=None,
+            b_ub=None,
+            A_eq=None,
+            b_eq=None,
+            bounds=None,
+            warm_basis=None,
+            time_limit=None,
+            **kw,
+        ):
+            c = np.asarray(c, dtype=np.float64)
+            n_rows = 0 if b_ub is None else int(np.size(b_ub))
+            duals = np.zeros(n_rows, dtype=np.float64)  # claim all rows inactive
+            # Direction: +1 on some column ⇒ min x_i; -1 ⇒ max x_i (min -x_i).
+            if c.max() > 0:
+                obj = 5.0  # optimistic min: true min is 0 at the box corner
+            else:
+                obj = -3.0  # optimistic max: min(-x)=-3 ⇒ max x=3, true max is 8
+            return LPResult(
+                status=SolveStatus.OPTIMAL,
+                x=np.zeros(len(c)),
+                objective=obj,
+                dual_values=duals,
+                reduced_costs=None,
+                basis=None,
+                iterations=0,
+                wall_time=0.0,
+                infeasibility_certificate=None,
+            )
+
+        return _fake
+
+    def test_optimistic_vertex_is_clamped(self, monkeypatch):
+        import discopt._jax.obbt as obbt_mod
+
+        m = Model("c15")
+        m.continuous("x", lb=0.0, ub=10.0)
+        m.continuous("y", lb=0.0, ub=10.0)
+        x, y = m._variables[0], m._variables[1]
+        m.minimize(x)
+        m.subject_to(x + y <= 8.0)  # a genuine 2-var row (won't fold to a bound)
+
+        fake = self._fake_optimistic_solver()
+        # Patch BOTH getters: pre-fix run_obbt used get_exact_lp_solver (no NS
+        # clamp → would apply obj 5.0); post-fix uses get_exact_dual_lp_solver
+        # (NS clamp → rejects it). Patching both makes this fail-before/pass-after.
+        monkeypatch.setattr(obbt_mod, "get_exact_lp_solver", lambda: fake)
+        monkeypatch.setattr(obbt_mod, "get_exact_dual_lp_solver", lambda: fake)
+
+        result = run_obbt(m)
+
+        # The optimistic vertex (5.0) is clamped to the NS-safe bound (~0), so the
+        # feasible region x ∈ [0, 5) is NOT cut. Pre-fix this asserted 5.0.
+        assert result.tightened_lb[0] < 1e-6, (
+            f"raw optimistic vertex was trusted: lb={result.tightened_lb[0]}"
+        )
+        # Likewise the spurious max-tightening (to 3) is rejected; ub stays 10.
+        assert result.tightened_ub[0] > 10.0 - 1e-6, (
+            f"raw optimistic vertex cut the upper bound: ub={result.tightened_ub[0]}"
+        )
+
+    def test_ns_safe_lower_bound_free_equality_multiplier(self):
+        """`_ns_safe_lp_lower_bound` treats trailing ``n_eq`` rows as equalities
+        with a *free-sign* multiplier — sound and tighter than clamping them.
+        LP: min x s.t. x == 2, x ∈ [0, 5] ⇒ true min = 2.
+        """
+        from discopt._jax.obbt import _ns_safe_lp_lower_bound
+
+        c = np.array([1.0])
+        A = np.array([[1.0]])
+        b = np.array([2.0])
+        lo = np.array([0.0])
+        hi = np.array([5.0])
+        dual = np.array([1.0])  # HiGHS convention y_eq = +1 (rc = c - Aᵀy_eq = 0)
+
+        # Treated as an inequality (default): the clamp forces y = max(-1, 0) = 0,
+        # giving the valid-but-loose bound 0.
+        g_ineq = _ns_safe_lp_lower_bound(c, dual, A, b, lo, hi)
+        assert g_ineq is not None
+        assert abs(g_ineq - 0.0) < 1e-9
+
+        # Treated as an equality (free multiplier): recovers the tight bound 2.
+        g_eq = _ns_safe_lp_lower_bound(c, dual, A, b, lo, hi, n_eq=1)
+        assert g_eq is not None
+        assert abs(g_eq - 2.0) < 1e-6
+        # Both must be rigorous under-estimates of the true min (= 2).
+        assert g_ineq <= 2.0 + 1e-9 and g_eq <= 2.0 + 1e-9


### PR DESCRIPTION
## C-15 (P2) — `run_obbt` tightens to the raw LP vertex without the NS-safe clamp

Second item of the Phase 2 correctness pre-flight (T2.0). **Stacked on #399**
(base branch `cert-c16-presolve-bound-resync`) — retarget to `main` once #399
merges.

### The bug
The model-linear OBBT variant `run_obbt` applied the raw LP vertex objective as
the tightened bound (`lb[i] = result.objective`, gated only by `+1e-8`), with **no
Neumaier–Shcherbina safe-bound clamp and no conditioning guard** — those hardenings
existed only in `run_obbt_on_relaxation`. On an ill-conditioned constraint matrix
the reported vertex can drift *above* the true projection, so the tightening cuts
off feasible (possibly optimal) points — an unsound reduction, a false-certificate
seed. `run_obbt` is **live** (AMP path: `solvers/amp.py:1897,1941`), so deletion is
off the table; it is hardened to match the relaxation variant.

### The fix
- `run_obbt` resolves its oracle via `get_exact_dual_lp_solver` (vertex duals),
  applies the `_cond > _OBBT_COND_LIMIT` → `require_ns` conditioning guard, and
  clamps every min/max tightening to the NS-safe bound `g` (new `_ns_clamp`
  closure) — mirroring `run_obbt_on_relaxation`.
- `_ns_safe_lp_lower_bound` gains an `n_eq` parameter: the trailing **equality**
  rows (which `run_obbt` sees via `A_eq`, unlike the relaxation variant) keep a
  *free-sign* multiplier, while inequality rows stay clamped `≥ 0`. `n_eq=0`
  default → byte-identical for the existing callers (DBBT, `run_obbt_on_relaxation`).
- Hoisted `_max_abs` to module scope (was local to `run_obbt_on_relaxation`).
- Equilibration deliberately **not** added here: `g(y)` is a rigorous
  under-estimate for *any* duals at *any* conditioning, so the clamp alone
  restores soundness (equilibration only improves vertex accuracy/tightness).

### Tests (fail-before / pass-after verified by stashing the fix)
`python/tests/test_obbt.py::TestC15NsSafeClamp`:
- `test_optimistic_vertex_is_clamped` — fake oracle reports an optimistic vertex
  (5.0) with inactive duals; the NS clamp rejects it (→ ~0), so the feasible
  region `x ∈ [0, 5)` is not cut. Patches **both** oracle seams so it
  discriminates the pre-fix path.
- `test_ns_safe_lower_bound_free_equality_multiplier` — equality `x == 2`: `n_eq=1`
  recovers the tight bound 2.0 vs 0.0 when the row is clamped as `<=`; both remain
  rigorous under-estimates of the true min.
- Updated `test_total_time_limit_stops_before_all_variables` to patch the new
  preferred oracle seam (`get_exact_dual_lp_solver`).

### Gates run
- `test_obbt.py` — 48 passed
- `test_amp` — 135 passed; `test_amp_integration` + `test_lp_backend_select` — 17 passed
- `pytest -m smoke` — 211 passed, 1 skipped
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed
- `ruff check` / `ruff format` — clean
- `incorrect_count` unaffected (the clamp only ever *relaxes* an over-tight bound)

Tracker: `docs/dev/correctness-issues.md` C-15 → `fixed` with Log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
