### PR TITLE
fix(correctness): C-20 watch-list FBBT uses tolerance-aware infeasibility

### DIFF
--- a/crates/discopt-core/src/presolve/fbbt_fp.rs
+++ b/crates/discopt-core/src/presolve/fbbt_fp.rs
@@ -44,7 +44,9 @@
 
 use std::collections::VecDeque;
 
-use super::fbbt::{backward_propagate, forward_propagate, snap_integral_interval, Interval};
+use super::fbbt::{
+    backward_propagate, forward_propagate, snap_integral_interval, Interval, FEAS_TOL,
+};
 use crate::expr::{ConstraintSense, ExprArena, ExprId, ExprNode, ModelRepr, VarType};
 
 /// Per-pass statistics from watch-list FBBT.
@@ -145,7 +147,16 @@ pub fn fbbt_fixed_point(
             ConstraintSense::Eq => Interval::point(constr.rhs),
         };
         let body_bound = node_bounds[constr.body.0];
-        if body_bound.intersect(&output_bound).is_empty() {
+        // cert:C-20. Declare infeasibility only when the violation exceeds the
+        // feasibility tolerance, matching the main engine (fbbt.rs:1138-1140 /
+        // :1229-1231). A strict `lo > hi` check mistakes the ~1e-8 residuals that
+        // GDP hull perspective forms leave at integer faces (see fbbt.rs:74-87)
+        // for real infeasibility — a false "infeasible" when this opt-in engine
+        // is enabled.
+        if body_bound
+            .intersect(&output_bound)
+            .is_empty_beyond(FEAS_TOL)
+        {
             stats.infeasible = true;
             for b in bounds.iter_mut() {
                 *b = Interval::empty();
@@ -178,7 +189,11 @@ pub fn fbbt_fixed_point(
                 bounds[v] = snap_integral_interval(bounds[v]);
             }
             let cur = bounds[v];
-            if cur.is_empty() {
+            // cert:C-20. Same tolerance-aware rule as the constraint check above:
+            // an eps-empty variable interval (~1e-8 residual) is numerical noise,
+            // not infeasibility. The main engine has no strict per-variable check
+            // here at all; gate this one on FEAS_TOL to avoid a false "infeasible".
+            if cur.is_empty_beyond(FEAS_TOL) {
                 stats.infeasible = true;
                 for b in bounds.iter_mut() {
                     *b = Interval::empty();
@@ -441,5 +456,72 @@ mod tests {
         let stats = fbbt_fixed_point(&model, &mut bounds, FbbtFpOptions::default());
         assert!(stats.infeasible);
         assert!(bounds[0].is_empty());
+    }
+
+    // cert:C-20 regression: the watch-list engine declared infeasibility with a
+    // strict `lo > hi`, so an eps-residual equality (the ~1e-8 noise GDP hull
+    // perspective forms leave at integer faces) was a false "infeasible". It must
+    // agree with the main engine (fbbt.rs), which uses `is_empty_beyond(FEAS_TOL)`.
+
+    /// Build `x == (1.0 - eps)` with `x` fixed at `1.0`; the body forward-props to
+    /// a point `eps` off the rhs.
+    fn eps_residual_equality_model(eps: f64) -> ModelRepr {
+        let mut arena = ExprArena::new();
+        let x = scalar_var(&mut arena, "x", 0);
+        ModelRepr {
+            arena,
+            objective: x,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body: x,
+                sense: ConstraintSense::Eq,
+                rhs: 1.0 - eps,
+                name: None,
+            }],
+            variables: vec![vinfo("x", 0, 1.0, 1.0)],
+            n_vars: 1,
+        }
+    }
+
+    #[test]
+    fn c20_eps_residual_equality_matches_main_engine_feasible() {
+        let eps = 5e-7; // < FEAS_TOL (1e-6): numerical noise, not infeasibility.
+
+        // Main engine tolerates it (bounds not collapsed to empty).
+        let main_bounds = crate::presolve::fbbt::fbbt(&eps_residual_equality_model(eps), 100, 1e-9);
+        assert!(
+            !main_bounds.iter().any(|b| b.is_empty()),
+            "main engine (reference) should treat the eps residual as feasible"
+        );
+
+        // Watch-list engine must agree — false "infeasible" before the fix.
+        let model = eps_residual_equality_model(eps);
+        let mut bounds: Vec<Interval> = model
+            .variables
+            .iter()
+            .map(|v| Interval::new(v.lb[0], v.ub[0]))
+            .collect();
+        let stats = fbbt_fixed_point(&model, &mut bounds, FbbtFpOptions::default());
+        assert!(
+            !stats.infeasible,
+            "C-20: eps-residual equality falsely reported infeasible by the watch-list engine"
+        );
+        assert!(!bounds.iter().any(|b| b.is_empty()));
+    }
+
+    #[test]
+    fn c20_real_infeasibility_still_detected() {
+        // Guard against over-loosening: a residual >> FEAS_TOL stays infeasible.
+        let model = eps_residual_equality_model(4.0); // x fixed at 1, requires == -3
+        let mut bounds: Vec<Interval> = model
+            .variables
+            .iter()
+            .map(|v| Interval::new(v.lb[0], v.ub[0]))
+            .collect();
+        let stats = fbbt_fixed_point(&model, &mut bounds, FbbtFpOptions::default());
+        assert!(
+            stats.infeasible,
+            "a genuine residual (4.0 >> FEAS_TOL) must still be detected as infeasible"
+        );
     }
 }

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -60,7 +60,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-5 | P1 | .nl parser | floor/ceil/round/trunc→identity, intdiv→div, all silent | open |
 | C-6 | P1 | modeling API | integer vars silently clamped to [0, 1e6] | open |
 | C-18 | P1 | midpoint bound | `mccormick_bounds="midpoint"` returns u(mid), not a lower bound (opt-in mode) | open |
-| C-20 | P2 | fbbt_fp.rs | watch-list FBBT declares infeasibility with zero tolerance (opt-in engine) | open |
+| C-20 | P2 | fbbt_fp.rs | watch-list FBBT declares infeasibility with zero tolerance (opt-in engine) | fixed |
 | C-15 | P2 | obbt.py | `run_obbt` variant tightens to raw LP vertex, no NS safe-bound clamp | fixed |
 | C-14 | P2 | milp_driver | LP-infeasible fathom trusts status alone; Farkas ray never verified | open |
 | C-21 | P2 | incremental MC | soundness-gate validation boxes never exercise negative/zero-spanning bounds | open |
@@ -633,7 +633,23 @@ present), matching `fbbt.rs`.
 **Done criteria:** the differential test passes (both engines agree feasible);
 existing fbbt_fp tests green; standing gates pass.
 
-**Log:** —
+**Log:**
+- 2026-07-03 — **CONFIRMED then FIXED.** Confirmed via a new differential test:
+  an eps-residual equality (body forward-props to a point 5e-7 < FEAS_TOL off the
+  rhs) is feasible in the main engine (`fbbt`) but the watch-list engine reported
+  it infeasible (strict `lo > hi`). Verified fail-before by reverting the guards.
+- **Fix.** Both infeasibility-declaring sites in `presolve/fbbt_fp.rs` now use
+  `.is_empty_beyond(FEAS_TOL)` instead of `.is_empty()`: the constraint-body check
+  (`:148`) — matching `fbbt.rs:1138-1140/:1229-1231` exactly — and the per-variable
+  post-backprop check (`:181`), which the main engine doesn't even have (so it was
+  strictly harsher). Added `FEAS_TOL` to the `super::fbbt` import.
+- **Regression tests** (`presolve::fbbt_fp::tests`):
+  `c20_eps_residual_equality_matches_main_engine_feasible` (differential vs `fbbt`;
+  fails before the fix) and `c20_real_infeasibility_still_detected` (a residual
+  4.0 ≫ FEAS_TOL is still caught — guards against over-loosening).
+- **Gates:** `cargo test -p discopt-core` 373 lib + 4 + 1 doctest green, no
+  warnings. Python default path is unaffected (`fbbt_fixed_point` is off by
+  default); smoke + adversarial run in CI. PR: (pending).
 
 ---
 

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -649,7 +649,7 @@ existing fbbt_fp tests green; standing gates pass.
   4.0 ≫ FEAS_TOL is still caught — guards against over-loosening).
 - **Gates:** `cargo test -p discopt-core` 373 lib + 4 + 1 doctest green, no
   warnings. Python default path is unaffected (`fbbt_fixed_point` is off by
-  default); smoke + adversarial run in CI. PR: (pending).
+  default); smoke 211 + adversarial 10 green locally. PR: #403.
 
 ---
 


### PR DESCRIPTION
## C-20 (P2) — watch-list FBBT declares infeasibility with zero tolerance

Third T2.0 correctness pre-flight item. Fixes a false-"infeasible" in the opt-in
`fbbt_fixed_point` engine.

### The bug
The watch-list FBBT engine (`crates/discopt-core/src/presolve/fbbt_fp.rs`, off by
default via `run_root_presolve(..., fbbt_fixed_point=False)`) declared infeasibility
with a strict `lo > hi` (`Interval::is_empty()`) at two sites, whereas the main
engine deliberately uses `is_empty_beyond(FEAS_TOL)` (`fbbt.rs:1138-1140`/`:1229-1231`,
rationale documented at `fbbt.rs:74-87`). GDP hull perspective forms `y·f(v/y)` leave
~1e-8 residuals at integer faces; the strict check mistakes that numerical noise for
infeasibility → a **false "infeasible"** when this engine is enabled.

### The fix
Both infeasibility-declaring checks now use `is_empty_beyond(FEAS_TOL)`:
- the constraint-body feasibility check (`:148`) — matching the main engine exactly;
- the per-variable post-backward-propagation check (`:181`) — the main engine has no
  equivalent, so this one was strictly harsher.

Added `FEAS_TOL` to the `super::fbbt` import. No behavior change on the default path
(the engine is off by default); this only affects soundness when it is opted into
(and is a prerequisite before any Phase 2 loop config may enable `fbbt_fixed_point`).

### Tests (fail-before / pass-after verified by reverting the guards)
`presolve::fbbt_fp::tests`:
- `c20_eps_residual_equality_matches_main_engine_feasible` — an eps-residual equality
  (5e-7 < FEAS_TOL) is feasible in the main engine `fbbt`; the watch-list engine must
  agree. Reported infeasible before the fix.
- `c20_real_infeasibility_still_detected` — a residual 4.0 ≫ FEAS_TOL is still detected
  (guards against over-loosening).

### Gates
- `cargo test -p discopt-core` — 373 lib + 4 determinism + 1 doctest green, no warnings
- `pytest -m smoke` — 211 passed, 1 skipped
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed

Tracker: `docs/dev/correctness-issues.md` C-20 → `fixed` with Log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
