### PR TITLE
fix(correctness): C-21 harden incremental-McCormick validation across sign regimes

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -63,7 +63,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-20 | P2 | fbbt_fp.rs | watch-list FBBT declares infeasibility with zero tolerance (opt-in engine) | open |
 | C-15 | P2 | obbt.py | `run_obbt` variant tightens to raw LP vertex, no NS safe-bound clamp | fixed |
 | C-14 | P2 | milp_driver | LP-infeasible fathom trusts status alone; Farkas ray never verified | open |
-| C-21 | P2 | incremental MC | soundness-gate validation boxes never exercise negative/zero-spanning bounds | open |
+| C-21 | P2 | incremental MC | soundness-gate validation boxes never exercise negative/zero-spanning bounds | fixed |
 | C-7 | P2 | .nl parser | defined variables (V segments) discarded → hard parse error | open |
 | C-8 | P2 | .nl parser | common opcodes unhandled (o76/o77/o78/o48/o11/o12/o35) | open |
 | C-9 | P2 | .nl parser | nlvo>nlvc integer-block classification unverified | open |
@@ -658,7 +658,41 @@ lb==ub box) to the validation set; keep the count small (construction-time cost)
 `_bilinear_rows` sign flip is caught by the gate (mutation test); standing gates
 pass.
 
-**Log:** —
+**Log:**
+- 2026-07-03 — **CONFIRMED (not unsound), then HARDENED.** Static confirm of
+  `_validate`'s box construction: for every variable with `_root_sign >= 0`
+  (positive *and* zero-spanning), each validation box used `lb >= 0` (`lo = 0.0`
+  or `lo = 0.5+0.3*i`); negative-definite vars used `ub <= 0`. So a variable whose
+  root box **strictly spans zero** — which is what dominates real bilinear nodes —
+  was only ever probed on its nonnegative sub-boxes. No box was zero-spanning
+  (`lb<0<ub`), negative-lb-for-a-spanning-var, or degenerate (`lb==ub`). The
+  closed forms themselves ARE sound on those regimes (verified: the hardened gate
+  passes on all of them), so this was a **gate-coverage** gap, not a live
+  soundness bug — no P0 escalation.
+- **Fix** (`incremental_mccormick.py`): split the old `>= 0` branch so
+  *sign-definite* vars still stay in their reachable root regime, but **spanning**
+  vars (`_root_sign==0`, which carry no monomial — only bilinear rows) are now
+  driven through six per-trial profiles: `shift_pos`, `zero_lb` (`lb==0<ub`),
+  `span` (`lb<0<ub`), `neg` (`ub<0`), `span_wide`, and `degen` (`lb==ub`). Box
+  count unchanged at 6 (construction-time cost neutral). Added `_box_sign_regime`
+  + `_validated_regimes` so the gate records which regimes it exercised; no solver
+  math changed (row builders, patch, aux bounds untouched). On a two-spanning-var
+  bilinear model the set now covers 5 regimes {pos, zero_lb, span, neg, degen}.
+- **Regression tests** (`python/tests/test_incremental_mccormick_node.py`):
+  `test_validate_exercises_at_least_four_sign_regimes` (asserts span/neg/degen/
+  zero_lb all present, ≥4 total) and the **mutation test**
+  `test_validate_catches_negative_box_sign_flip_mutation` — monkeypatches
+  `_bilinear_rows` to clip negative lower bounds to 0 (identity on `lb>=0`,
+  wrong on negative/spanning boxes); the hardened gate rejects it (`_inc is None`).
+  Verified FAIL-before/PASS-after by stashing the `_validate` change: both new
+  tests fail (mutation slips through the old `lb>=0`-only set), pass with the fix.
+- **Gates:** `test_incremental_mccormick_node.py` 9 passed; `-m smoke` 211 passed /
+  1 skipped / 0 failed; adversarial `test_adversarial_recent_fixes.py -m slow` 10
+  passed; `ruff check` + `ruff format --check` clean; `pre-commit run mypy` passed.
+  No Rust touched (no `cargo test`). `incorrect_count` unchanged (0 failures across
+  all suites; no correctness assertion weakened). PR #404.
+
+**Status:** open → fixed.
 
 ---
 

--- a/python/discopt/_jax/incremental_mccormick.py
+++ b/python/discopt/_jax/incremental_mccormick.py
@@ -107,6 +107,7 @@ class IncrementalMcCormickLP:
         self.ok = False
         self.model = model
         self.terms = terms
+        self._validated_regimes = frozenset()  # sign regimes _validate exercised
         try:
             self._build_structure()
             self._validate()
@@ -221,26 +222,85 @@ class IncrementalMcCormickLP:
         rows = np.hstack([np.round(A, 6), np.round(b, 6).reshape(-1, 1)])
         return sorted(map(tuple, rows.tolist()))
 
-    def _validate(self, trials=6):
-        # Sign-matched validation boxes (cert:T1.2): each variable's box must stay
-        # in its root sign regime (positive/spanning vars → ``lb >= 0``; negative
-        # vars → ``ub <= 0``), so the patched convex/concave power rows are
-        # compared against a cold build in the *same* regime. Widths and offsets
-        # vary per trial; even trials touch the ``lb == 0`` boundary.
-        rng_boxes = []
-        for t in range(trials):
-            w = 2.0 + (t % 4)
+    @staticmethod
+    def _box_sign_regime(lo, hi):
+        """Classify a single variable's box ``[lo,hi]`` into a sign regime label so
+        the validation set can prove it spans several. ``"pos"`` (``lo>0``),
+        ``"neg"`` (``hi<0``), ``"span"`` (``lo<0<hi``, strictly crosses zero),
+        ``"degen"`` (``lo==hi``), ``"zero_lb"`` (``lo==0<hi``, the boundary)."""
+        if lo == hi:
+            return "degen"
+        if lo == 0.0:
+            return "zero_lb"
+        if lo > 0.0:
+            return "pos"
+        if hi <= 0.0:
+            return "neg"
+        return "span"
+
+    def _validation_boxes(self):
+        """The validation boxes fed to :meth:`_validate`, as ``(lo, hi)`` pairs.
+
+        Every box is a *reachable* B&B sub-box of the root: branching only shrinks a
+        box, so a var that is sign-definite at the root (``_root_sign != 0``) keeps
+        that sign — a positive var never gets ``lb<0``, a negative var never gets
+        ``ub>0``. A **spanning** var (``_root_sign==0``), however, carries no
+        monomial (gated out in :meth:`_build_structure`) and its real nodes DO carry
+        negative / zero-spanning bounds, so the boxes below deliberately drive those
+        vars through negative-lb, zero-spanning (``lb<0<ub``), mixed-sign and
+        degenerate (``lb==ub``) regimes — exactly the sign regimes that dominate
+        real nodes and that the earlier ``lb>=0``-only set never exercised (C-21).
+        """
+        # Per trial, ``kind`` says how each spanning var sits relative to zero;
+        # sign-definite vars follow their root sign with a varying width/offset.
+        kinds = ["shift_pos", "zero_lb", "span", "neg", "span_wide", "degen"]
+        boxes = []
+        for t, kind in enumerate(kinds):
+            w = 2.0 + (t % 3)
             lo = np.empty(self.n)
             hi = np.empty(self.n)
             for i in range(self.n):
                 if self._root_sign[i] < 0:
+                    # Negative-definite root: stay ub<=0 (reachable sub-box).
                     hi[i] = -0.5 - 0.3 * i
                     lo[i] = hi[i] - w
-                else:
+                elif self._root_sign[i] > 0:
+                    # Positive-definite root: stay lb>=0 (reachable sub-box). Even
+                    # trials touch the lb==0 boundary.
                     lo[i] = (0.5 + 0.3 * i) if (t % 2) else 0.0
                     hi[i] = lo[i] + w
-            rng_boxes.append((lo, hi))
+                else:
+                    # Spanning root: exercise the negative / zero-spanning regimes
+                    # that real nodes reach and the old validation set never did.
+                    off = 0.2 * i
+                    if kind == "shift_pos":
+                        lo[i], hi[i] = 0.5 + off, 0.5 + off + w
+                    elif kind == "zero_lb":
+                        lo[i], hi[i] = 0.0, w
+                    elif kind == "span":
+                        lo[i], hi[i] = -(1.0 + off), 1.0 + off
+                    elif kind == "neg":
+                        hi[i] = -0.5 - off
+                        lo[i] = hi[i] - w
+                    elif kind == "span_wide":
+                        lo[i], hi[i] = -(2.0 + off + w), 1.5 + off
+                    else:  # degen
+                        lo[i] = hi[i] = -0.5 - off
+            boxes.append((lo, hi))
+        return boxes
+
+    def _validate(self):
+        # Reachable, sign-diverse validation boxes (C-21 / cert:T1.2): each box is a
+        # sub-box of the root (so the patched convex/concave power rows are compared
+        # against a cold build in the *same* regime), but spanning vars are driven
+        # through negative-lb, zero-spanning, mixed-sign and degenerate boxes — the
+        # sign regimes real nodes reach. The patched row-set + aux bounds must
+        # reproduce the cold ``build_milp_relaxation`` exactly on every one.
+        rng_boxes = self._validation_boxes()
+        regimes = set()
         for lb, ub in rng_boxes:
+            for i in range(self.n):
+                regimes.add(self._box_sign_regime(float(lb[i]), float(ub[i])))
             Ap, bp, bdp = self._patch(lb, ub)
             Af, bf, bdf, _, _, _ = self._full_build(lb, ub)
             if Ap.shape != Af.shape:
@@ -249,6 +309,7 @@ class IncrementalMcCormickLP:
                 raise ValueError("row-set mismatch")
             if not np.allclose(bdp, bdf, atol=1e-6, rtol=1e-6):
                 raise ValueError("bounds mismatch")
+        self._validated_regimes = frozenset(regimes)
         self.ok = True
 
     # -- solve ------------------------------------------------------------- #

--- a/python/tests/test_incremental_mccormick_node.py
+++ b/python/tests/test_incremental_mccormick_node.py
@@ -39,8 +39,59 @@ def _int_qcqp():
     return m
 
 
+def _span_bilinear():
+    """Bilinear model whose BOTH factors span zero at the root, so real B&B nodes
+    (and the validation set) carry negative / zero-spanning boxes for those vars."""
+    m = dm.Model("span")
+    x = m.continuous("x", lb=-3, ub=4)  # root box spans zero
+    y = m.continuous("y", lb=-2, ub=5)  # root box spans zero
+    m.minimize(x * y)
+    m.subject_to(x + y >= 1)
+    return m
+
+
 def test_incremental_active_for_integer_qcqp():
     assert MccormickLPRelaxer(_int_qcqp())._inc is not None
+
+
+def test_validate_exercises_at_least_four_sign_regimes():
+    """C-21: the soundness gate must probe negative-lb / zero-spanning / mixed-sign
+    / degenerate boxes, not just ``lb>=0``. On a model with zero-spanning root
+    factors the validation set covers >= 4 distinct sign regimes."""
+    inc = MccormickLPRelaxer(_span_bilinear())._inc
+    assert inc is not None and inc.ok
+    regimes = inc._validated_regimes
+    # span (lb<0<ub), zero_lb (lb==0<ub), neg (ub<=0), degen (lb==ub), pos (lb>0)
+    for needed in ("span", "neg", "degen", "zero_lb"):
+        assert needed in regimes, f"validation set never exercised the {needed!r} regime"
+    assert len(regimes) >= 4, f"only {len(regimes)} sign regimes: {sorted(regimes)}"
+
+
+def test_validate_catches_negative_box_sign_flip_mutation(monkeypatch):
+    """C-21 mutation test. A ``_bilinear_rows`` that clips negative lower bounds to
+    zero is the IDENTITY on ``lb>=0`` boxes (so the pre-C-21 validation set, which
+    only used such boxes, would have accepted it — a silent divergence in exactly
+    the sign regimes that dominate real nodes) but WRONG on negative / zero-spanning
+    boxes. The hardened gate now includes such boxes, so the mutation must make
+    ``_validate`` reject the fast path (``ok`` False / ``_inc`` None).
+
+    Reverting the box set to ``lb>=0``-only makes this assertion fail (verified
+    manually during C-21): the mutation then slips through undetected.
+    """
+    import discopt._jax.incremental_mccormick as ic
+
+    # Sanity: the unmutated engine engages on this model.
+    assert MccormickLPRelaxer(_span_bilinear())._inc is not None
+
+    _orig_rows = ic._bilinear_rows
+
+    def _clip_negative_lb(i, j, a, li, ui, lj, uj):
+        # Identity when li,lj >= 0; diverges once a lower bound goes negative.
+        return _orig_rows(i, j, a, max(li, 0.0), ui, max(lj, 0.0), uj)
+
+    monkeypatch.setattr(ic, "_bilinear_rows", _clip_negative_lb)
+    inc = MccormickLPRelaxer(_span_bilinear())._inc
+    assert inc is None, "sign-flip mutation must be caught by the hardened validation gate"
 
 
 def test_incremental_sound_for_mixed_and_division():


### PR DESCRIPTION
## C-21 (P2) — harden incremental-McCormick soundness gate across sign regimes

### Mechanism
`IncrementalMcCormickLP._validate` (`python/discopt/_jax/incremental_mccormick.py`)
is the safety gate that promises the incremental McCormick fast path "can never
change a result": it patches box-dependent rows in closed form and asserts they
reproduce the cold `build_milp_relaxation` row-for-row on a set of probe boxes.

Confirmed by static read: every probe box gave any variable with `_root_sign >= 0`
(positive **and** zero-spanning) a bound `lb >= 0` (`lo = 0.0` or `lo = 0.5+0.3*i`);
negative-definite vars used `ub <= 0`. So a variable whose root box **strictly spans
zero** — the regime that dominates real bilinear B&B nodes — was only ever validated
on its nonnegative sub-boxes. No box was zero-spanning (`lb<0<ub`), negative-lb for a
spanning var, or degenerate (`lb==ub`).

The closed-form envelopes **are** sound on those regimes (verified: the hardened gate
passes on all of them), so this was a **gate-coverage** gap, not a live soundness bug
— **no P0 escalation**. The risk was a *future* divergence in exactly the sign regimes
real nodes reach slipping past the gate cert:T1.2 leans on.

### Fix
Split the old `>= 0` branch in the validation-box builder: sign-definite vars stay in
their reachable root regime (branching only shrinks a box, so a positive var never
gets `lb<0`), but **spanning** vars (`_root_sign==0`, which carry no monomial — only
bilinear rows) are now driven through six per-trial profiles — `shift_pos`,
`zero_lb` (`lb==0<ub`), `span` (`lb<0<ub`), `neg` (`ub<0`), `span_wide`, `degen`
(`lb==ub`). Box count unchanged at 6 (construction-time cost neutral). Added
`_box_sign_regime` + `_validated_regimes` so the gate records which regimes it
exercised. **No solver math changed** — row builders, `_patch`, and aux bounds are
untouched; only the validation probe set is strengthened.

### Mutation test
`test_validate_catches_negative_box_sign_flip_mutation` monkeypatches `_bilinear_rows`
to clip negative lower bounds to zero — the **identity** on `lb>=0` boxes (so the
pre-C-21 validation set accepted it) but **wrong** on negative/zero-spanning boxes.
The hardened gate now rejects it (`_inc is None`). Verified FAIL-before/PASS-after by
stashing the `_validate` change: both new tests fail (mutation slips through the old
`lb>=0`-only set), and pass with the fix. Also added
`test_validate_exercises_at_least_four_sign_regimes` (asserts span/neg/degen/zero_lb
present, ≥4 total).

### Gate results
- `pytest python/tests/test_incremental_mccormick_node.py -q` — **9 passed**
- `pytest -m smoke -q` — **211 passed, 1 skipped, 0 failed**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py -q` — **10 passed**
- `ruff check` + `ruff format --check` (both changed files) — **clean**
- `pre-commit run mypy --files ...` — **passed**
- No Rust touched (no `cargo test`). `incorrect_count` unchanged (0 failures across
  all suites; no correctness assertion weakened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
