### PR TITLE
feat(api): #389 public discopt.parametric API + generic CLI plugin hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ The release procedure that produces these entries is documented in
 
 ## [Unreleased]
 
+### Added
+
+- **Public parametric-compilation API** (`feat(api)`, #389). New
+  `discopt.parametric` module — the stable contract for external plugins
+  (discopt-doe, discopt-mkm, ...) that compile model expressions into
+  JAX-differentiable functions of `(x_flat, p_flat)`: `compile_expression`,
+  `compile_response_function`, `extract_x_flat`, `flatten_params`,
+  `param_total_size`, `variable_total_size`, `variable_slices`. The in-tree
+  DOE module and `discopt.estimate` now consume this API instead of reaching
+  into `discopt._jax` internals.
+- **Generic CLI plugin subcommands** (`feat(cli)`, #389). External packages
+  can register subcommands via the `"discopt.cli"` entry-point group (name =
+  subcommand; value = module exposing `add_subparser(subparsers)` and
+  `run(args)`). Plugin modules load lazily — only for their own subcommand or
+  full help — and built-in names cannot be shadowed. The in-tree `discopt doe`
+  subcommand now registers through this mechanism, ahead of its extraction to
+  the standalone `discopt-doe` package (#389).
+
+### Changed
+
+- Version bumped to 0.6.0.dev0; 0.6.0 will be the first release with the DOE
+  module extracted to the `discopt-doe` plugin package.
+
 ## [0.5.0] - 2026-07-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "discopt"
-version = "0.5.1.dev0"
+version = "0.6.0.dev0"
 description = "Hybrid MINLP solver combining Rust and JAX"
 requires-python = ">=3.10"
 authors = [{name = "John Kitchin"}]
@@ -90,6 +90,12 @@ discopt-gams = "discopt.gams.link:main"
 # 'discopt' solver with Pyomo's SolverFactory.
 [project.entry-points."pyomo.solvers"]
 discopt = "discopt.pyomo.solver"
+
+# CLI plugin subcommands (see the protocol in discopt/cli.py). The doe entry
+# will move to the standalone discopt-doe package when the module is extracted
+# (#389); registering the in-tree module here exercises the same mechanism.
+[project.entry-points."discopt.cli"]
+doe = "discopt.doe.cli"
 
 [tool.maturin]
 manifest-path = "crates/discopt-python/Cargo.toml"

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -25,7 +25,7 @@ solvers
     NLP solver backends: POUNCE (pure-Rust Ipopt port), pure-JAX IPM (vmap batch), cyipopt (Ipopt).
 """
 
-__version__ = "0.5.1.dev0"
+__version__ = "0.6.0.dev0"
 
 # Allow external distributions (e.g. the ``discopt-aggregation`` plugin) to
 # contribute submodules under the ``discopt`` namespace from a separate location

--- a/python/discopt/cli.py
+++ b/python/discopt/cli.py
@@ -12,6 +12,21 @@ Usage:
 Developer-only commands (``lit-scan``, ``adversary``, ``search-arxiv``,
 ``search-openalex``, ``write-report``) live under ``discopt-dev`` in
 :mod:`discopt.dev.cli`.
+
+Plugin subcommands
+------------------
+External packages can add subcommands through the ``"discopt.cli"``
+entry-point group. The entry-point *name* is the subcommand name; the value
+must resolve to a module exposing ``add_subparser(subparsers) -> None``
+(which registers a subparser with exactly that name) and
+``run(args) -> int | None``. Example::
+
+    [project.entry-points."discopt.cli"]
+    doe = "discopt.doe.cli"
+
+Plugin modules are imported lazily: only for their own subcommand or when
+full help is requested, never on the built-in command paths. Built-in names
+cannot be shadowed.
 """
 
 import argparse
@@ -449,6 +464,31 @@ def _cmd_solve(args):
     sys.exit(0 if result.status in ("optimal", "feasible") else 1)
 
 
+_BUILTIN_COMMANDS = frozenset(
+    {
+        "about",
+        "test",
+        "convert",
+        "gams-register",
+        "solve",
+        "daemon",
+        "gams-daemon",
+        "gams-verify",
+        "install-skills",
+        "tutor",
+        "help",
+    }
+)
+
+
+def _cli_plugin_entry_points():
+    """``discopt.cli`` entry points, sorted by name. Separate function = test seam."""
+    try:
+        return sorted(importlib.metadata.entry_points(group="discopt.cli"), key=lambda ep: ep.name)
+    except Exception:
+        return []
+
+
 def main():
     parser = argparse.ArgumentParser(prog="discopt", description="discopt CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -583,20 +623,40 @@ def main():
     )
     p_skills.set_defaults(func=_cmd_install_skills)
 
-    # The tutor and (especially) DOE subparsers pull heavy optional deps
-    # (``discopt.doe.cli`` ~0.4 s: streamlit/pandas), so register them lazily --
-    # only for their own command or when full help is requested. This keeps every
-    # other command (notably ``discopt solve``) at the light CLI floor.
+    # The tutor subparser and plugin subcommands can pull heavy optional deps
+    # (e.g. ``discopt.doe.cli`` ~0.4 s: streamlit/pandas), so register them
+    # lazily -- only for their own command or when full help is requested. This
+    # keeps every other command (notably ``discopt solve``) at the light CLI
+    # floor; built-in commands never even scan the entry-point metadata.
     _argv1 = sys.argv[1] if len(sys.argv) > 1 else None
     _want_all = _argv1 in (None, "help", "-h", "--help")
     if _want_all or _argv1 == "tutor":
         from discopt.tutor import add_subparser as _add_tutor_subparser
 
         _add_tutor_subparser(subparsers)
-    if _want_all or _argv1 == "doe":
-        from discopt.doe.cli import add_subparser as _add_doe_subparser
 
-        _add_doe_subparser(subparsers)
+    plugin_runners = {}
+    if _want_all or _argv1 not in _BUILTIN_COMMANDS:
+        for ep in _cli_plugin_entry_points():
+            if ep.name in _BUILTIN_COMMANDS or ep.name in plugin_runners:
+                print(
+                    f"warning: ignoring discopt.cli plugin {ep.name!r} "
+                    f"({ep.value}): name already taken",
+                    file=sys.stderr,
+                )
+                continue
+            if not (_want_all or _argv1 == ep.name):
+                continue
+            try:
+                mod = ep.load()
+                mod.add_subparser(subparsers)
+                plugin_runners[ep.name] = mod.run
+            except Exception as exc:
+                msg = f"discopt.cli plugin {ep.name!r} ({ep.value}) failed to load: {exc}"
+                if _argv1 == ep.name:
+                    print(f"Error: {msg}", file=sys.stderr)
+                    sys.exit(1)
+                print(f"warning: {msg} (skipped)", file=sys.stderr)
 
     p_help = subparsers.add_parser("help", help="Show this help message and exit")
     p_help.set_defaults(func=lambda _args: parser.print_help())
@@ -609,10 +669,9 @@ def main():
         from discopt.tutor import run as _run_tutor
 
         sys.exit(_run_tutor(args) or 0)
-    if args.command == "doe":
-        from discopt.doe.cli import run as _run_doe
-
-        sys.exit(_run_doe(args) or 0)
+    runner = plugin_runners.get(args.command)
+    if runner is not None:
+        sys.exit(runner(args) or 0)
     args.func(args)
 
 

--- a/python/discopt/doe/discrimination.py
+++ b/python/discopt/doe/discrimination.py
@@ -385,9 +385,8 @@ def _predict_with_covariance(
     read the predicted response values from the same solve, avoiding a
     second model build per design point.
     """
-    from discopt._jax.differentiable import _compile_parametric_node
-    from discopt._jax.parametric import extract_x_flat
-    from discopt.doe.fim import _build_p_flat, _compute_jacobian_autodiff, _get_param_indices
+    from discopt.doe.fim import _compute_jacobian_autodiff, _get_param_indices
+    from discopt.parametric import compile_expression, extract_x_flat, flatten_params
 
     em = experiment.create_model(**param_values)
 
@@ -411,8 +410,8 @@ def _predict_with_covariance(
     x_flat = extract_x_flat(result, em.model)
 
     # Compile response functions and compute predicted means.
-    response_fns = [_compile_parametric_node(em.responses[n], em.model) for n in em.response_names]
-    p_flat = _build_p_flat(em.model)
+    response_fns = [compile_expression(em.responses[n], em.model) for n in em.response_names]
+    p_flat = flatten_params(em.model)
     y_hat = np.array([float(np.asarray(fn(x_flat, p_flat)).flat[0]) for fn in response_fns])
 
     # Jacobian of responses w.r.t. unknown parameters.

--- a/python/discopt/doe/fim.py
+++ b/python/discopt/doe/fim.py
@@ -106,15 +106,17 @@ def _design_source_map(em: ExperimentModel) -> dict | None:
     Returns ``None`` when the model has constraints or any other variable (an
     implicit state that genuinely requires a solve).
     """
+    from discopt.parametric import variable_slices
+
     if getattr(em.model, "_constraints", None):
         return None
-    src: dict[int, tuple[str, str, Any]] = {}
+    src: dict[str, tuple[str, str, Any]] = {}
     for name, var in em.unknown_parameters.items():
-        src[id(var)] = ("param", name, var)
+        src[var.name] = ("param", name, var)
     for name, var in em.design_inputs.items():
-        src[id(var)] = ("design", name, var)
-    for v in em.model._variables:
-        if id(v) not in src:
+        src[var.name] = ("design", name, var)
+    for vname in variable_slices(em.model):
+        if vname not in src:
             return None
     return src
 
@@ -163,12 +165,14 @@ def _assemble_x_flat_direct(em, param_values, design_values):
     :func:`_design_source_map`). The result is identical to solving
     ``min Σ(θ - θ_nom)²`` with the design fixed, but with no solver call.
     """
+    from discopt.parametric import variable_slices
+
     src = _design_source_map(em)
     if src is None:
         return None
     parts = []
-    for v in em.model._variables:
-        arr = _direct_var_values(src[id(v)], param_values, design_values)
+    for vname in variable_slices(em.model):
+        arr = _direct_var_values(src[vname], param_values, design_values)
         if arr is None:
             return None
         parts.append(arr)
@@ -179,14 +183,17 @@ def _assemble_x_flat_direct(em, param_values, design_values):
 
 def _assemble_x_flat_batch_direct(em, param_values, design_points):
     """Stack ``x*`` for many design points into one ``(B, n)`` array, or ``None``."""
+    from discopt.parametric import variable_slices
+
     src = _design_source_map(em)
     if src is None:
         return None
+    var_names = list(variable_slices(em.model))
     rows = []
     for dp in design_points:
         parts = []
-        for v in em.model._variables:
-            arr = _direct_var_values(src[id(v)], param_values, dp)
+        for vname in var_names:
+            arr = _direct_var_values(src[vname], param_values, dp)
             if arr is None:
                 return None
             parts.append(arr)
@@ -236,8 +243,7 @@ def compute_fim(
         FIM, Jacobian, and optimality metrics.
     """
 
-    from discopt._jax.differentiable import _compile_parametric_node
-    from discopt._jax.parametric import extract_x_flat
+    from discopt.parametric import compile_expression, extract_x_flat, flatten_params
 
     # Build the model at nominal parameter values
     em = experiment.create_model(**param_values)
@@ -274,14 +280,14 @@ def compute_fim(
     # Compile response functions
     response_fns = []
     for name in em.response_names:
-        fn = _compile_parametric_node(em.responses[name], em.model)
+        fn = compile_expression(em.responses[name], em.model)
         response_fns.append(fn)
 
     # Find indices of unknown parameter variables in x_flat
     param_indices = _get_param_indices(em)
 
     # Build p_flat for any model Parameters (distinct from unknown_parameters)
-    p_flat = _build_p_flat(em.model)
+    p_flat = flatten_params(em.model)
 
     if method == "autodiff":
         J = _compute_jacobian_autodiff(response_fns, x_flat, p_flat, param_indices)
@@ -331,7 +337,7 @@ def compute_fim_batch(
     a non-autodiff ``method``, so the result is always identical to calling
     :func:`compute_fim` on each point.
     """
-    from discopt._jax.differentiable import _compile_parametric_node
+    from discopt.parametric import compile_expression, flatten_params
 
     if not design_points:
         return []
@@ -352,9 +358,9 @@ def compute_fim_batch(
     import jax
     import jax.numpy as jnp
 
-    response_fns = [_compile_parametric_node(em.responses[n], em.model) for n in em.response_names]
+    response_fns = [compile_expression(em.responses[n], em.model) for n in em.response_names]
     param_indices = _get_param_indices(em)
-    p_flat = _build_p_flat(em.model)
+    p_flat = flatten_params(em.model)
 
     def response_vector(x_flat_arg):
         return jnp.stack([fn(x_flat_arg, p_flat) for fn in response_fns])
@@ -409,15 +415,15 @@ def _make_direct_fim_evaluator(
     import jax
     import jax.numpy as jnp
 
-    from discopt._jax.differentiable import _compile_parametric_node
+    from discopt.parametric import compile_expression, flatten_params
 
     em = experiment.create_model(**param_values)
     if _design_source_map(em) is None:
         return None
 
-    response_fns = [_compile_parametric_node(em.responses[n], em.model) for n in em.response_names]
+    response_fns = [compile_expression(em.responses[n], em.model) for n in em.response_names]
     param_indices = _get_param_indices(em)
-    p_flat = _build_p_flat(em.model)
+    p_flat = flatten_params(em.model)
 
     def response_vector(x_flat_arg):
         return jnp.stack([fn(x_flat_arg, p_flat) for fn in response_fns])
@@ -866,28 +872,14 @@ def check_identifiability(
 
 def _get_param_indices(em: ExperimentModel) -> list[int]:
     """Find indices of unknown parameter variables in the flat x vector."""
-    param_indices = []
-    for name, var in em.unknown_parameters.items():
-        offset = 0
-        for v in em.model._variables:
-            if v is var:
-                for i in range(v.size):
-                    param_indices.append(offset + i)
-                break
-            offset += v.size
+    from discopt.parametric import variable_slices
+
+    slices = variable_slices(em.model)
+    param_indices: list[int] = []
+    for var in em.unknown_parameters.values():
+        sl = slices[var.name]
+        param_indices.extend(range(sl.start, sl.stop))
     return param_indices
-
-
-def _build_p_flat(model):
-    """Build parameter flat vector for any model Parameters."""
-    import jax.numpy as jnp
-
-    p_parts = []
-    for p in model._parameters:
-        p_parts.append(np.asarray(p.value, dtype=np.float64).ravel())
-    if p_parts:
-        return jnp.array(np.concatenate(p_parts), dtype=jnp.float64)
-    return jnp.zeros(0, dtype=jnp.float64)
 
 
 def _compute_jacobian_autodiff(response_fns, x_flat, p_flat, param_indices):

--- a/python/discopt/doe/model_based.py
+++ b/python/discopt/doe/model_based.py
@@ -205,7 +205,7 @@ class ParametricSurrogate:
         import jax
         import jax.numpy as jnp
 
-        from discopt._jax.differentiable import _compile_parametric_node
+        from discopt.parametric import compile_expression, flatten_params, variable_slices
 
         em = self.experiment.create_model(**self.initial_guess)
         if self.response_name not in em.responses:
@@ -222,26 +222,16 @@ class ParametricSurrogate:
         self.parameter_names_ = list(em.unknown_parameters.keys())
 
         # Flat offsets for every variable in the model.
-        offsets: dict[int, int] = {}
-        offset = 0
-        for v in em.model._variables:
-            offsets[id(v)] = offset
-            offset += v.size
-        n_x = offset
+        slices = variable_slices(em.model)
+        n_x = max((sl.stop for sl in slices.values()), default=0)
 
-        design_idx = [offsets[id(em.design_inputs[n])] for n in self.input_names]
-        param_idx = [offsets[id(em.unknown_parameters[n])] for n in self.parameter_names_]
+        design_idx = [slices[em.design_inputs[n].name].start for n in self.input_names]
+        param_idx = [slices[em.unknown_parameters[n].name].start for n in self.parameter_names_]
 
         # p_flat for any model Parameters (distinct from unknown parameters).
-        p_parts: list[np.ndarray] = []
-        for p in em.model._parameters:
-            p_parts.append(np.asarray(p.value, dtype=np.float64).ravel())
-        if p_parts:
-            p_flat_const = jnp.array(np.concatenate(p_parts), dtype=jnp.float64)
-        else:
-            p_flat_const = jnp.zeros(0, dtype=jnp.float64)
+        p_flat_const = flatten_params(em.model)
 
-        response_fn = _compile_parametric_node(em.responses[self.response_name], em.model)
+        response_fn = compile_expression(em.responses[self.response_name], em.model)
         d_idx = jnp.asarray(design_idx, dtype=jnp.int32)
         p_idx = jnp.asarray(param_idx, dtype=jnp.int32)
 

--- a/python/discopt/doe/selection.py
+++ b/python/discopt/doe/selection.py
@@ -329,9 +329,7 @@ def _per_obs_loglik(experiment: Experiment, result: EstimationResult, data: dict
     response, and applies the Gaussian log-pdf ``-0.5 * [log(2πσ²) +
     ((y − ŷ)/σ)²]`` per observation.
     """
-    from discopt._jax.differentiable import _compile_parametric_node
-    from discopt._jax.parametric import extract_x_flat
-    from discopt.doe.fim import _build_p_flat
+    from discopt.parametric import compile_expression, extract_x_flat, flatten_params
 
     em = experiment.create_model(**result.parameters)
     # Pin every parameter at the fitted value so the solve is trivial.
@@ -348,7 +346,7 @@ def _per_obs_loglik(experiment: Experiment, result: EstimationResult, data: dict
     )
     solve = em.model.solve()
     x_flat = extract_x_flat(solve, em.model)
-    p_flat = _build_p_flat(em.model)
+    p_flat = flatten_params(em.model)
 
     y_hat: list[float] = []
     sigma: list[float] = []
@@ -356,7 +354,7 @@ def _per_obs_loglik(experiment: Experiment, result: EstimationResult, data: dict
     for name in em.response_names:
         if name not in data:
             continue
-        fn = _compile_parametric_node(em.responses[name], em.model)
+        fn = compile_expression(em.responses[name], em.model)
         y_hat.append(float(np.asarray(fn(x_flat, p_flat)).flat[0]))
         sigma.append(float(em.measurement_error[name]))
         y_obs.append(float(np.asarray(data[name]).flat[0]))

--- a/python/discopt/estimate.py
+++ b/python/discopt/estimate.py
@@ -416,8 +416,12 @@ def _compute_estimation_fim(
     import jax
     import jax.numpy as jnp
 
-    from discopt._jax.differentiable import _compile_parametric_node
-    from discopt._jax.parametric import extract_x_flat
+    from discopt.parametric import (
+        compile_expression,
+        extract_x_flat,
+        flatten_params,
+        variable_slices,
+    )
 
     model = em.model
     x_flat = extract_x_flat(result, model)
@@ -426,7 +430,7 @@ def _compute_estimation_fim(
     # These are functions of x_flat (variables include the unknown params)
     response_fns = []
     for name in em.response_names:
-        fn = _compile_parametric_node(em.responses[name], model)
+        fn = compile_expression(em.responses[name], model)
         response_fns.append(fn)
 
     # We need the Jacobian of responses w.r.t. the unknown parameter
@@ -434,24 +438,14 @@ def _compute_estimation_fim(
     # we compute d(responses)/d(x_flat) and extract the relevant columns.
 
     # Find indices of unknown parameter variables in x_flat
-    param_indices = []
-    for name, var in em.unknown_parameters.items():
-        offset = 0
-        for v in model._variables:
-            if v is var:
-                for i in range(v.size):
-                    param_indices.append(offset + i)
-                break
-            offset += v.size
+    slices = variable_slices(model)
+    param_indices: list[int] = []
+    for var in em.unknown_parameters.values():
+        sl = slices[var.name]
+        param_indices.extend(range(sl.start, sl.stop))
 
     # Build a dummy p_flat (model may or may not have Parameters)
-    p_parts = []
-    for p in model._parameters:
-        p_parts.append(np.asarray(p.value, dtype=np.float64).ravel())
-    if p_parts:
-        p_flat = jnp.array(np.concatenate(p_parts), dtype=jnp.float64)
-    else:
-        p_flat = jnp.zeros(0, dtype=jnp.float64)
+    p_flat = flatten_params(model)
 
     def response_vector(x_flat_arg):
         return jnp.stack([fn(x_flat_arg, p_flat) for fn in response_fns])

--- a/python/discopt/parametric.py
+++ b/python/discopt/parametric.py
@@ -1,0 +1,178 @@
+"""Public parametric-compilation API.
+
+Stable contract for code built on top of discopt — external plugins
+(``discopt-doe``, ``discopt-mkm``, ...) and in-tree consumers such as
+:mod:`discopt.estimate` — to compile model :class:`~discopt.modeling.core.Expression`
+objects into JAX-differentiable functions of ``(x_flat, p_flat)``.
+
+The flat-vector contract
+------------------------
+``x_flat`` concatenates the values of every model :class:`Variable` in
+declaration order, each flattened in C order; ``p_flat`` does the same for
+every model :class:`Parameter`. :func:`variable_slices` exposes the layout of
+``x_flat``; :func:`extract_x_flat` and :func:`flatten_params` build the two
+vectors from a solved result and the model's nominal parameter values.
+
+All functions import JAX lazily, so ``import discopt.parametric`` does not pull
+``jax`` (or any other heavy dependency) into the process.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    import jax.numpy as jnp
+
+    from discopt.modeling.core import Expression, Model
+
+__all__ = [
+    "compile_expression",
+    "compile_response_function",
+    "extract_x_flat",
+    "flatten_params",
+    "param_total_size",
+    "variable_slices",
+    "variable_total_size",
+]
+
+
+def compile_expression(expr: Expression, model: Model) -> Callable:
+    """Compile a single expression into ``f(x_flat, p_flat) -> value``.
+
+    The returned function is a pure JAX computation: it can be transformed
+    with ``jax.jit``, ``jax.grad``, ``jax.jacobian``, ``jax.vmap``, etc.
+    Unlike the standard DAG compiler, Parameter values are *not* baked in as
+    constants — they are read from ``p_flat``, so derivatives with respect to
+    parameters are available via ``argnums=1``.
+
+    Parameters
+    ----------
+    expr : Expression
+        The model expression to compile.
+    model : Model
+        The discopt model that owns the expression's variables and parameters
+        (defines the ``x_flat``/``p_flat`` layout).
+
+    Returns
+    -------
+    callable
+        Function ``f(x_flat, p_flat) -> jnp.ndarray`` evaluating the
+        expression at the given flat vectors.
+    """
+    from discopt._jax.differentiable import _compile_parametric_node
+
+    return _compile_parametric_node(expr, model)
+
+
+def compile_response_function(
+    responses: dict[str, Expression],
+    model: Model,
+) -> Callable:
+    """Compile named expressions into a stacked JAX-differentiable function.
+
+    Parameters
+    ----------
+    responses : dict[str, Expression]
+        Named response expressions. Each should evaluate to a scalar.
+    model : Model
+        The discopt model containing the variables and parameters.
+
+    Returns
+    -------
+    callable
+        Function ``f(x_flat, p_flat) -> jnp.ndarray`` returning a 1-D array of
+        response values in ``responses`` order, with ``response_names`` and
+        ``n_responses`` attributes attached.
+
+    Raises
+    ------
+    ValueError
+        If ``responses`` is empty.
+    """
+    from discopt._jax.parametric import compile_response_function as _impl
+
+    return _impl(responses, model)
+
+
+def extract_x_flat(result, model: Model) -> jnp.ndarray:
+    """Extract the flat variable vector from a solved result.
+
+    Parameters
+    ----------
+    result : SolveResult
+        A solved result with ``result.x`` populated.
+    model : Model
+        The discopt model (defines the ``x_flat`` layout).
+
+    Returns
+    -------
+    jnp.ndarray
+        1-D array of all variable values at the solution.
+
+    Raises
+    ------
+    ValueError
+        If the result has no solution.
+    """
+    from discopt._jax.parametric import extract_x_flat as _impl
+
+    return _impl(result, model)
+
+
+def flatten_params(model: Model) -> jnp.ndarray:
+    """Concatenate all model Parameter values into ``p_flat``.
+
+    Returns a zero-length array when the model has no Parameters, so the
+    result is always a valid second argument for compiled functions.
+
+    Parameters
+    ----------
+    model : Model
+        The discopt model.
+
+    Returns
+    -------
+    jnp.ndarray
+        1-D array of all parameter values in declaration order.
+    """
+    from discopt._jax.differentiable import _flatten_params
+
+    return _flatten_params(model)
+
+
+def param_total_size(model: Model) -> int:
+    """Total number of scalar parameter values in the model."""
+    from discopt._jax.differentiable import _param_total_size
+
+    return _param_total_size(model)
+
+
+def variable_total_size(model: Model) -> int:
+    """Total number of scalar variable values in the model."""
+    return sum(v.size for v in model._variables)
+
+
+def variable_slices(model: Model) -> dict[str, slice]:
+    """Map each variable's name to its slice of ``x_flat``.
+
+    Variable names are unique within a model (they key ``result.x``), so this
+    fully describes the ``x_flat`` layout: declaration order, each variable
+    flattened C-order to ``v.size`` entries.
+
+    Parameters
+    ----------
+    model : Model
+        The discopt model.
+
+    Returns
+    -------
+    dict[str, slice]
+        ``{variable_name: slice(start, stop)}`` into ``x_flat``.
+    """
+    out: dict[str, slice] = {}
+    offset = 0
+    for v in model._variables:
+        out[v.name] = slice(offset, offset + v.size)
+        offset += v.size
+    return out

--- a/python/discopt/parametric.py
+++ b/python/discopt/parametric.py
@@ -62,7 +62,8 @@ def compile_expression(expr: Expression, model: Model) -> Callable:
     """
     from discopt._jax.differentiable import _compile_parametric_node
 
-    return _compile_parametric_node(expr, model)
+    fn: Callable = _compile_parametric_node(expr, model)
+    return fn
 
 
 def compile_response_function(

--- a/python/tests/test_cli_plugins.py
+++ b/python/tests/test_cli_plugins.py
@@ -1,0 +1,131 @@
+"""Tests for the generic ``discopt.cli`` entry-point plugin mechanism.
+
+The seam is ``discopt.cli._cli_plugin_entry_points``: tests monkeypatch it
+with fake entry points, so no real plugin package needs to be installed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import discopt.cli as cli
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+class FakeEntryPoint:
+    def __init__(self, name, module=None, error=None, value="fake.plugin.cli"):
+        self.name = name
+        self.value = value
+        self._module = module
+        self._error = error
+
+    def load(self):
+        if self._error is not None:
+            raise self._error
+        return self._module
+
+
+def _plugin_module(name, run_result=0):
+    """A module-like namespace conforming to the add_subparser/run protocol."""
+    calls = {}
+
+    def add_subparser(subparsers):
+        p = subparsers.add_parser(name, help=f"{name} plugin")
+        p.add_argument("--flag", default="unset")
+
+    def run(args):
+        calls["args"] = args
+        return run_result
+
+    return SimpleNamespace(add_subparser=add_subparser, run=run), calls
+
+
+def _main_with(eps, argv):
+    with patch.object(cli, "_cli_plugin_entry_points", lambda: eps):
+        with patch("sys.argv", ["discopt", *argv]):
+            cli.main()
+
+
+class TestDispatch:
+    def test_plugin_command_dispatches_with_parsed_args(self):
+        mod, calls = _plugin_module("fake")
+        with pytest.raises(SystemExit) as exc:
+            _main_with([FakeEntryPoint("fake", mod)], ["fake", "--flag", "on"])
+        assert exc.value.code == 0
+        assert calls["args"].flag == "on"
+
+    def test_nonzero_return_code_propagates(self):
+        mod, _ = _plugin_module("fake", run_result=3)
+        with pytest.raises(SystemExit) as exc:
+            _main_with([FakeEntryPoint("fake", mod)], ["fake"])
+        assert exc.value.code == 3
+
+    def test_none_return_means_success(self):
+        mod, _ = _plugin_module("fake", run_result=None)
+        with pytest.raises(SystemExit) as exc:
+            _main_with([FakeEntryPoint("fake", mod)], ["fake"])
+        assert exc.value.code == 0
+
+
+class TestHelp:
+    def test_help_lists_plugin_subcommand(self, capsys):
+        mod, _ = _plugin_module("fake")
+        _main_with([FakeEntryPoint("fake", mod)], ["help"])
+        assert "fake" in capsys.readouterr().out
+
+    def test_broken_plugin_warns_but_help_prints(self, capsys):
+        broken = FakeEntryPoint("broken", error=ImportError("missing dep"))
+        _main_with([broken], ["help"])
+        captured = capsys.readouterr()
+        assert "failed to load" in captured.err
+        assert "usage" in captured.out.lower()
+
+
+class TestErrors:
+    def test_broken_plugin_own_command_exits_1(self, capsys):
+        broken = FakeEntryPoint("broken", error=ImportError("missing dep"))
+        with pytest.raises(SystemExit) as exc:
+            _main_with([broken], ["broken"])
+        assert exc.value.code == 1
+        assert "Error:" in capsys.readouterr().err
+
+    def test_builtin_name_cannot_be_shadowed(self, capsys):
+        mod, calls = _plugin_module("solve")
+        # `help` path scans plugins; the reserved name is skipped with a warning.
+        _main_with([FakeEntryPoint("solve", mod)], ["help"])
+        captured = capsys.readouterr()
+        assert "name already taken" in captured.err
+        assert calls == {}
+
+    def test_duplicate_plugin_names_first_wins(self, capsys):
+        mod1, calls1 = _plugin_module("fake")
+        mod2, calls2 = _plugin_module("fake")
+        with pytest.raises(SystemExit):
+            _main_with(
+                [FakeEntryPoint("fake", mod1), FakeEntryPoint("fake", mod2)],
+                ["fake"],
+            )
+        assert "args" in calls1
+        assert calls2 == {}
+        assert "name already taken" in capsys.readouterr().err
+
+
+class TestLaziness:
+    def test_builtin_command_never_scans_entry_points(self, capsys):
+        def fail():
+            pytest.fail("entry-point scan must be skipped for builtin commands")
+
+        with patch.object(cli, "_cli_plugin_entry_points", fail):
+            with patch("sys.argv", ["discopt", "about"]):
+                cli.main()
+        assert "discopt" in capsys.readouterr().out
+
+    def test_other_plugins_not_loaded_for_plugin_command(self):
+        mod, _ = _plugin_module("fake")
+        never = FakeEntryPoint("other", error=AssertionError("must not be loaded"))
+        with pytest.raises(SystemExit) as exc:
+            _main_with([FakeEntryPoint("fake", mod), never], ["fake"])
+        assert exc.value.code == 0

--- a/python/tests/test_parametric_public.py
+++ b/python/tests/test_parametric_public.py
@@ -1,0 +1,134 @@
+"""Tests for the public parametric-compilation API (discopt.parametric).
+
+This module is the stable contract external plugins (discopt-doe, ...) build
+on, so these tests pin the public names, the flat-vector layout, and the
+differentiability guarantees — independently of the ``_jax`` internals that
+implement them (covered in ``test_parametric.py``).
+"""
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import discopt.modeling as dm
+import jax
+import numpy as np
+import pytest
+from discopt.parametric import (
+    compile_expression,
+    compile_response_function,
+    extract_x_flat,
+    flatten_params,
+    param_total_size,
+    variable_slices,
+    variable_total_size,
+)
+
+pytestmark = pytest.mark.smoke
+
+
+def _model():
+    """y = a*x1 + b*x2**2 with one Parameter c: exercises vars and params."""
+    m = dm.Model()
+    a = m.continuous("a", lb=-10, ub=10)
+    b = m.continuous("b", lb=-10, ub=10)
+    c = m.parameter("c", value=3.0)
+    x = m.continuous("x", lb=0, ub=5)
+    y = a * x + b * x**2 + c
+    return m, y
+
+
+class TestCompileExpression:
+    def test_value_matches_analytic(self):
+        m, y = _model()
+        fn = compile_expression(y, m)
+        # x_flat layout: a, b, x (declaration order); p_flat: c
+        x_flat = np.array([2.0, 0.5, 4.0])
+        p_flat = np.array([3.0])
+        # 2*4 + 0.5*16 + 3 = 19
+        assert float(fn(x_flat, p_flat)) == pytest.approx(19.0)
+
+    def test_gradient_wrt_variables(self):
+        m, y = _model()
+        fn = compile_expression(y, m)
+        x_flat = np.array([2.0, 0.5, 4.0])
+        p_flat = np.array([3.0])
+        g = jax.grad(fn, argnums=0)(x_flat, p_flat)
+        # dy/da = x = 4, dy/db = x^2 = 16, dy/dx = a + 2bx = 2 + 4 = 6
+        np.testing.assert_allclose(np.asarray(g), [4.0, 16.0, 6.0])
+
+    def test_gradient_wrt_parameters(self):
+        m, y = _model()
+        fn = compile_expression(y, m)
+        g = jax.grad(fn, argnums=1)(np.array([2.0, 0.5, 4.0]), np.array([3.0]))
+        np.testing.assert_allclose(np.asarray(g), [1.0])  # dy/dc = 1
+
+
+class TestCompileResponseFunction:
+    def test_ordering_matches_dict(self):
+        m = dm.Model()
+        x = m.continuous("x", lb=0, ub=10)
+        fn = compile_response_function({"double": 2 * x, "square": x * x}, m)
+        out = np.asarray(fn(np.array([3.0]), np.zeros(0)))
+        np.testing.assert_allclose(out, [6.0, 9.0])
+        assert fn.response_names == ["double", "square"]
+        assert fn.n_responses == 2
+
+    def test_empty_responses_raises(self):
+        m = dm.Model()
+        m.continuous("x", lb=0, ub=1)
+        with pytest.raises(ValueError):
+            compile_response_function({}, m)
+
+
+class TestFlatVectorLayout:
+    def test_variable_slices_layout(self):
+        m = dm.Model()
+        m.continuous("s", lb=0, ub=1)
+        m.continuous("v", lb=0, ub=1, shape=(3,))
+        m.continuous("t", lb=0, ub=1)
+        slices = variable_slices(m)
+        assert slices == {"s": slice(0, 1), "v": slice(1, 4), "t": slice(4, 5)}
+        assert variable_total_size(m) == 5
+
+    def test_extract_x_flat_consistent_with_slices(self):
+        m = dm.Model()
+        m.continuous("s", lb=0, ub=10)
+        m.continuous("v", lb=0, ub=10, shape=(2,))
+        result = SimpleNamespace(x={"s": 1.5, "v": np.array([2.5, 3.5])})
+        x_flat = np.asarray(extract_x_flat(result, m))
+        slices = variable_slices(m)
+        np.testing.assert_allclose(x_flat[slices["s"]], [1.5])
+        np.testing.assert_allclose(x_flat[slices["v"]], [2.5, 3.5])
+
+    def test_extract_x_flat_no_solution_raises(self):
+        m = dm.Model()
+        m.continuous("s", lb=0, ub=1)
+        with pytest.raises(ValueError):
+            extract_x_flat(SimpleNamespace(x=None), m)
+
+    def test_flatten_params_concatenates_in_order(self):
+        m = dm.Model()
+        m.parameter("p1", value=1.0)
+        m.parameter("p2", value=np.array([2.0, 3.0]))
+        np.testing.assert_allclose(np.asarray(flatten_params(m)), [1.0, 2.0, 3.0])
+        assert param_total_size(m) == 3
+
+    def test_flatten_params_empty(self):
+        m = dm.Model()
+        m.continuous("x", lb=0, ub=1)
+        p_flat = np.asarray(flatten_params(m))
+        assert p_flat.shape == (0,)
+        assert param_total_size(m) == 0
+
+
+def test_import_is_jax_free():
+    """`import discopt.parametric` must not pull jax (plugin CLI light floor)."""
+    code = "import sys; import discopt.parametric; sys.exit(1 if 'jax' in sys.modules else 0)"
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
## Summary

First of two PRs for #389 (move the DOE module to an external plugin). This one is **purely additive** — DOE stays in-tree and fully working, but now runs through the two public mechanisms the standalone `discopt-doe` package will use:

### 1. Public parametric-compilation API — `discopt.parametric`

New top-level module exposing the stable contract for code built on top of discopt (external plugins and `discopt.estimate`):

- `compile_expression(expr, model)` — public name for the raw parametric compiler (`_jax.differentiable._compile_parametric_node`)
- `compile_response_function(responses, model)` — stacked response vector for `jax.jacobian`
- `extract_x_flat(result, model)`, `flatten_params(model)`, `param_total_size(model)`, `variable_total_size(model)`
- `variable_slices(model)` — name → slice layout of `x_flat`, eliminating the last direct reach into `Model._variables`/`Model._parameters`

All functions delegate lazily, so `import discopt.parametric` stays jax-free (pinned by a subprocess test). Consumers rerouted in this PR: `doe/fim.py`, `doe/discrimination.py`, `doe/selection.py`, `doe/model_based.py`, and `estimate.py` (core dogfooding). `doe/fim.py`'s duplicate `_build_p_flat` helper is deleted in favor of `flatten_params`.

### 2. Generic CLI plugin subcommands — entry-point group `"discopt.cli"`

The hard-coded lazy `doe` wiring in `cli.py` is replaced by a general mechanism: entry-point *name* = subcommand, *value* = module exposing `add_subparser(subparsers)` / `run(args)` (exactly the protocol `discopt.doe.cli` already had). Properties:

- **Lazy**: built-in commands never scan entry-point metadata; a plugin module is imported only for its own subcommand or full help (the ~0.4 s `discopt.doe.cli` import stays off `discopt solve`).
- **Robust**: a broken plugin warns and is skipped during `help`, hard-errors (exit 1) only when its own command is invoked; built-in names cannot be shadowed; duplicate names — first (sorted) wins.
- The in-tree doe subcommand now registers through this hook (`[project.entry-points."discopt.cli"] doe = "discopt.doe.cli"`), so CI exercises the real mechanism via the existing `test_doe_cli.py` before extraction.

### Version

Bumped to `0.6.0.dev0`. Per the extraction plan, `v0.6.0` is tagged only after the follow-up removal PR, so the first 0.6 release ships no `discopt/doe/` directory (which would shadow the namespace-package plugin).

## Verification

- `pytest -m smoke`: 234 passed, 1 skipped (one failure in `test_nn_equivalence.py` — an **untracked local file**, not in git history, unrelated to this change)
- Adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`): 10 passed
- Makefile `TEST_AMP` slice (exercises every rerouted DOE import): 404 passed
- New tests: `test_parametric_public.py` (public contract: values, jacobians vs analytic, layout, jax-free import) and `test_cli_plugins.py` (dispatch, exit codes, help listing, broken plugin, shadowing, laziness) — 21 passed
- Manual: `discopt help` lists doe via the entry point; `discopt doe templates` dispatches; `discopt about` runs without scanning plugin metadata
- `ruff check` / `ruff format --check` clean; no Rust touched (no `cargo test` needed); `mypy` currently fails repo-wide on numpy stubs vs `python_version = "3.10"` (pre-existing, unrelated)

Node-count/objective certification is unaffected: no solver-path code touched (bound-neutral by construction — CLI + compile-facade only).

Refs #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018crRWGQ1e4XXqDQ2bTFHWc
