### PR TITLE
cert:P3 — Marchand–Wolsey aggregation c-MIR separator (flagged, default-off)

### DIFF
--- a/crates/discopt-core/src/lp/aggregation.rs
+++ b/crates/discopt-core/src/lp/aggregation.rs
@@ -1,0 +1,484 @@
+//! Marchand–Wolsey aggregation c-MIR separation.
+//!
+//! Single-row MIR ([`super::mir`]) is only as strong as one model row: on the
+//! integer-product / graph-partition class it closes ~0% of the root gap that
+//! SCIP's cut loop closes ~100% of (see `docs/dev/certification-gap-plan.md` §7,
+//! "0b RESULTS / VERDICT"). SCIP's workhorse there is *aggregation*
+//! (Marchand & Wolsey 2001, "Aggregation and mixed integer rounding to solve
+//! MIPs"): combine a small set of `≤` rows with **nonnegative** weights into one
+//! valid implied row, chosen so a continuous variable *cancels* and integer
+//! structure is exposed, then apply complemented MIR to the aggregate.
+//!
+//! # Soundness (the load-bearing property)
+//! For `≤` rows `a_i · x ≤ b_i` (i in a chosen set) and weights `λ_i ≥ 0`, the
+//! aggregate
+//!
+//! ```text
+//!   Σ_i λ_i (a_i · x)  ≤  Σ_i λ_i b_i
+//! ```
+//!
+//! is a valid inequality for the feasible set: it is a nonnegative combination of
+//! valid `≤` inequalities, so every feasible `x` (in particular every
+//! integer-feasible `x`) satisfies it. Feeding this single valid `≤` row to
+//! [`separate_mir`] — whose per-row cut validity over the integer box is already
+//! established (`mir.rs`, `mir_validity_random_*` tests) — therefore yields a cut
+//! valid for the original feasible set. No cut can remove an integer-feasible
+//! point of the original system. We never reimplement MIR here: aggregation only
+//! *builds the row*; MIR (bound substitution, complementation, δ-scan) is reused
+//! verbatim.
+//!
+//! # Row-selection heuristic (this build: 2-row, continuous-cancelling)
+//! Following MW/SCIP `sepa_cmir`, the aggregation depth is kept small for
+//! tractability. This build ships the smallest sound, useful slice: **pairs** of
+//! `≤` rows combined to cancel one continuous variable.
+//!
+//! For each cancel-target column `t` and each pair of rows `(i, k)` whose
+//! coefficients on `t` are *strictly opposite in sign* (`a_it > 0 > a_kt`, up to
+//! symmetry), the unique-up-to-scale nonnegative weights that cancel `t` are
+//! `λ_i = |a_kt|`, `λ_k = |a_it|` (both `> 0`). The aggregate row drops column
+//! `t` and is fed to `separate_mir`. Among all pairs (and every cancel column)
+//! the most violated valid cut at `x` is kept. The cancel targets are the
+//! *continuous* columns (the MW target); on a fully-lifted McCormick LP where
+//! every column is marked integer there is no continuous column, so the targets
+//! fall back to the *fractional* columns at `x`. Cancelling an integer column is
+//! equally sound — a nonnegative row combination is valid whichever column
+//! cancels — so this fallback never risks a cut. Deeper aggregation (≥3 rows,
+//! bound-substitution of a variable at a bound before cancelling) is follow-on.
+
+use crate::lp::mir::{separate_mir, MirCut};
+
+/// Result of one aggregation separation: the cut plus its violation at the
+/// separation point (so the caller / cut pool can rank it against other cuts).
+pub struct AggCut {
+    /// The MIR cut over the original structural variables.
+    pub cut: MirCut,
+    /// Violation `coeffs · x − rhs` at the separation point (`> tol`).
+    pub violation: f64,
+}
+
+/// Below this the coefficient on the cancel column is treated as zero (no
+/// meaningful cancellation possible) and the pair is skipped.
+const CANCEL_MIN: f64 = 1e-9;
+
+/// Cap on the aggregate row's dynamism (max/min nonzero |coeff|). Combining rows
+/// of very different scales makes the aggregate numerically unsafe to round; such
+/// pairs are skipped (they also rarely give a useful cut).
+const AGG_MAX_DYNAMISM: f64 = 1e8;
+
+/// Separate aggregation c-MIR cuts from the `≤` rows `a_ub · x ≤ b_ub`.
+///
+/// `a_ub` is row-major `m × n`; `l`/`u` are the length-`n` variable bounds and
+/// `integrality[j]` marks integer columns — all passed straight through to
+/// [`separate_mir`] for the final MIR step. `x` is the separation point; `tol`
+/// the violation threshold; `max_dynamism` the MIR coefficient-dynamism cap.
+///
+/// The heuristic pairs rows to cancel a continuous variable (see module docs),
+/// forms the nonnegative aggregate, and applies complemented MIR to it. Returns
+/// at most one cut per (pair, cancelled-column) candidate — the ones that produce
+/// a violated, valid MIR cut — each carrying its violation for downstream
+/// selection. Deterministic: iteration order is fixed, ties broken by first-seen.
+///
+/// # Soundness
+/// Each returned cut is a complemented MIR cut of a **nonnegative combination**
+/// of the original `≤` rows, hence valid for the original feasible set (module
+/// docs). Aggregation never touches the MIR math; it only builds valid rows.
+#[allow(clippy::too_many_arguments)]
+pub fn separate_aggregation_mir(
+    a_ub: &[f64],
+    b_ub: &[f64],
+    l: &[f64],
+    u: &[f64],
+    integrality: &[bool],
+    x: &[f64],
+    tol: f64,
+    max_dynamism: f64,
+) -> Vec<AggCut> {
+    let m = b_ub.len();
+    let n = a_ub.len().checked_div(m).unwrap_or(0);
+    let mut out: Vec<AggCut> = Vec::new();
+    if n == 0 || m < 2 {
+        return out;
+    }
+
+    let row = |i: usize| &a_ub[i * n..(i + 1) * n];
+
+    // Cancellation targets. The Marchand–Wolsey heuristic cancels a *continuous*
+    // variable to expose the integer structure MIR rounds, so continuous columns
+    // are the primary target. On a fully-lifted McCormick LP, though, every
+    // column (including the product-aux `w = x·y`) is marked integer, so there
+    // is no continuous column to cancel; there we fall back to cancelling any
+    // column whose LP point is fractional (the interesting ones to round).
+    //
+    // Cancelling an integer column is equally SOUND — a nonnegative row
+    // combination is valid regardless of which column cancels — it is only the
+    // heuristic target that differs. Validity never depends on this choice.
+    let cont_cols: Vec<usize> = (0..n).filter(|&j| !integrality[j]).collect();
+    let cancel_cols: Vec<usize> = if !cont_cols.is_empty() {
+        cont_cols
+    } else {
+        (0..n)
+            .filter(|&j| (x[j] - x[j].round()).abs() > 1e-6)
+            .collect()
+    };
+    if cancel_cols.is_empty() {
+        return out;
+    }
+
+    for i in 0..m {
+        let ai = row(i);
+        for k in (i + 1)..m {
+            let ak = row(k);
+            for &t in &cancel_cols {
+                let (ait, akt) = (ai[t], ak[t]);
+                // Need strictly opposite signs on t to cancel with λ ≥ 0.
+                if !(ait.abs() > CANCEL_MIN && akt.abs() > CANCEL_MIN) {
+                    continue;
+                }
+                if ait.signum() == akt.signum() {
+                    continue;
+                }
+                // Nonnegative weights that cancel column t: λ_i = |a_kt|,
+                // λ_k = |a_it|. Both strictly positive ⇒ valid nonneg combo.
+                let lam_i = akt.abs();
+                let lam_k = ait.abs();
+
+                // Build the aggregate row a_agg = λ_i a_i + λ_k a_k, rhs
+                // b_agg = λ_i b_i + λ_k b_k. Column t cancels to (near) zero;
+                // force it exactly zero so MIR sees the dropped structure.
+                let mut a_agg = vec![0.0_f64; n];
+                let mut max_c = 0.0_f64;
+                let mut min_c = f64::INFINITY;
+                for j in 0..n {
+                    let v = lam_i * ai[j] + lam_k * ak[j];
+                    a_agg[j] = v;
+                    let av = v.abs();
+                    if av > max_c {
+                        max_c = av;
+                    }
+                    if av > CANCEL_MIN && av < min_c {
+                        min_c = av;
+                    }
+                }
+                a_agg[t] = 0.0;
+                let b_agg = lam_i * b_ub[i] + lam_k * b_ub[k];
+
+                // Numerical guards: the aggregate must be finite, non-trivial,
+                // and not wildly ill-scaled (rounding a high-dynamism row is
+                // unsafe). These reject the pair; they never weaken a cut.
+                if max_c <= CANCEL_MIN
+                    || !a_agg.iter().all(|v| v.is_finite())
+                    || !b_agg.is_finite()
+                    || (min_c.is_finite() && max_c / min_c > AGG_MAX_DYNAMISM)
+                {
+                    continue;
+                }
+
+                // Apply the existing complemented MIR to the single aggregate
+                // row. separate_mir returns the most-violated valid cut for it.
+                let cuts = separate_mir(&a_agg, &[b_agg], l, u, integrality, x, tol, max_dynamism);
+                for cut in cuts {
+                    let act: f64 = (0..n).map(|j| cut.coeffs[j] * x[j]).sum::<f64>();
+                    let viol = act - cut.rhs;
+                    if viol > tol {
+                        out.push(AggCut {
+                            cut,
+                            violation: viol,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dot(a: &[f64], b: &[f64]) -> f64 {
+        a.iter().zip(b).map(|(x, y)| x * y).sum()
+    }
+
+    /// Exhaustively check a `≤` cut excludes no feasible point of the *system*
+    /// `A x ≤ b` (all rows), enumerating integer columns over `[lo, hi]` and, for
+    /// continuous columns, sampling a dense grid across `[l, u]`. A cut from an
+    /// aggregate of a *subset* of rows must still respect the FULL system: the
+    /// aggregate is implied by the system, so no system-feasible point may be cut.
+    #[allow(clippy::too_many_arguments)]
+    fn assert_valid_system(
+        coeffs: &[f64],
+        rhs: f64,
+        a_ub: &[f64],
+        b_ub: &[f64],
+        integrality: &[bool],
+        lo: &[i64],
+        hi: &[i64],
+        cont_samples: usize,
+    ) {
+        let n = integrality.len();
+        let m = b_ub.len();
+        // Integer columns iterate over [lo,hi]; continuous columns iterate over
+        // a grid of `cont_samples` points across [lo,hi] (as reals).
+        let mut idx = vec![0usize; n]; // per-column step index
+        let steps: Vec<usize> = (0..n)
+            .map(|j| {
+                if integrality[j] {
+                    (hi[j] - lo[j] + 1).max(1) as usize
+                } else {
+                    cont_samples.max(2)
+                }
+            })
+            .collect();
+        let value = |j: usize, s: usize| -> f64 {
+            if integrality[j] {
+                (lo[j] + s as i64) as f64
+            } else {
+                let span = (hi[j] - lo[j]) as f64;
+                lo[j] as f64 + span * (s as f64) / ((steps[j] - 1) as f64)
+            }
+        };
+        loop {
+            let xv: Vec<f64> = (0..n).map(|j| value(j, idx[j])).collect();
+            // Feasible for the FULL system?
+            let feas = (0..m).all(|r| dot(&a_ub[r * n..(r + 1) * n], &xv) <= b_ub[r] + 1e-9);
+            if feas {
+                assert!(
+                    dot(coeffs, &xv) <= rhs + 1e-6,
+                    "aggregation cut {coeffs:?} <= {rhs} excludes system-feasible {xv:?}"
+                );
+            }
+            // mixed-radix increment
+            let mut c = 0;
+            while c < n {
+                idx[c] += 1;
+                if idx[c] < steps[c] {
+                    break;
+                }
+                idx[c] = 0;
+                c += 1;
+            }
+            if c == n {
+                break;
+            }
+        }
+    }
+
+    /// Constructed instance where single-row MIR finds NO violated cut but a
+    /// 2-row aggregation cancelling the continuous variable does. This is the
+    /// fails-before/passes-after regression witness for the whole build.
+    ///
+    /// Two integer vars x0, x1 in [0,2], one continuous t ≥ 0.
+    ///   R0:  x0 + 3 x1 − 2 t ≤ 3.5
+    ///   R1:  x0        + 2 t ≤ 3.5
+    /// Weights λ0 = |c1| = 2, λ1 = |c0| = 2 cancel t (2·(−2)+2·(+2)=0):
+    ///   4 x0 + 6 x1 ≤ 14  →  δ-scan (scale 1/6) → 0.667 x0 + x1 ≤ 2.333
+    ///   →  MIR:  0.5 x0 + x1 ≤ 2.
+    /// At LP point x=(1.25, 1.5, 1.0) that cut is violated by 0.125, while
+    /// single-row MIR on *either* row alone finds nothing violated (the free
+    /// continuous t masks the integer face on each row individually).
+    #[test]
+    fn aggregation_finds_cut_single_row_mir_misses() {
+        let a_ub = [
+            1.0, 3.0, -2.0, // R0
+            1.0, 0.0, 2.0, // R1
+        ];
+        let b_ub = [3.5, 3.5];
+        let l = [0.0, 0.0, 0.0];
+        let u = [2.0, 2.0, f64::INFINITY];
+        let integ = [true, true, false];
+        let x = [1.25, 1.5, 1.0];
+
+        // Single-row MIR on the two rows individually: must NOT separate x
+        // with x0+x1≤2 (t present keeps the row from rounding to that face).
+        let single = separate_mir(&a_ub, &b_ub, &l, &u, &integ, &x, 1e-7, 1e9);
+        let single_best = single
+            .iter()
+            .map(|c| dot(&c.coeffs, &x) - c.rhs)
+            .fold(f64::NEG_INFINITY, f64::max);
+
+        // Aggregation: must find the x0+x1≤2 cut (violation 0.5).
+        let agg = separate_aggregation_mir(&a_ub, &b_ub, &l, &u, &integ, &x, 1e-7, 1e9);
+        assert!(
+            !agg.is_empty(),
+            "aggregation must find a violated cut on this instance"
+        );
+        let best = agg
+            .iter()
+            .max_by(|p, q| p.violation.partial_cmp(&q.violation).unwrap())
+            .unwrap();
+        assert!(
+            best.violation > 1e-6,
+            "aggregation cut must separate x* (viol {})",
+            best.violation
+        );
+        // The aggregation cut is strictly stronger than anything single-row MIR
+        // found here (the point of aggregation on this instance).
+        assert!(
+            best.violation > single_best + 1e-9 || single_best <= 1e-6,
+            "aggregation ({}) not stronger than single-row ({single_best})",
+            best.violation
+        );
+        // And it is valid for the full 2-row integer system.
+        assert_valid_system(
+            &best.cut.coeffs,
+            best.cut.rhs,
+            &a_ub,
+            &b_ub,
+            &integ,
+            &[0, 0, 0],
+            &[2, 2, 3], // t sampled over [0,3]
+            6,
+        );
+    }
+
+    /// Adversarial cut-validity property test — the primary correctness gate.
+    ///
+    /// Hundreds of random 2- and 3-row systems (mixed integer/continuous columns,
+    /// mixed-sign finite bounds, at least one continuous column to cancel, random
+    /// nonnegative aggregation implied by the separator, and LP points chosen to
+    /// force violated cuts) asserting NO integer/continuous-feasible point of the
+    /// ORIGINAL system is ever cut. Modeled on `mir_validity_random_complemented_rows`.
+    #[test]
+    fn aggregation_validity_random_systems() {
+        let mut state: u64 = 0xfeed_face_1234_5678;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((state >> 11) as f64) / ((1u64 << 53) as f64)
+        };
+        let mut n_cuts_checked = 0usize;
+        for _ in 0..500 {
+            let n = 3;
+            let m = if next() > 0.5 { 3 } else { 2 };
+            // Mix of regimes: ~30% of trials are FULLY integer (exercises the
+            // fractional-column fallback path — the lifted-McCormick regime),
+            // otherwise column 2 is continuous (the MW continuous-cancel target)
+            // and 0,1 are integer more often than not.
+            let all_int = next() < 0.3;
+            let integ: Vec<bool> = (0..n)
+                .map(|j| {
+                    if all_int {
+                        true
+                    } else if j == 2 {
+                        false
+                    } else {
+                        next() > 0.25
+                    }
+                })
+                .collect();
+            // Mixed-sign, sometimes-fractional coefficients; ensure the two
+            // rows have opposite signs on the continuous column often.
+            let mut a_ub = vec![0.0_f64; m * n];
+            for r in 0..m {
+                for j in 0..n {
+                    a_ub[r * n + j] = (next() * 8.0 - 4.0).round() + (next() - 0.5);
+                }
+                // Bias column 2 sign by row parity so cancellation fires.
+                let s = if r % 2 == 0 { 1.0 } else { -1.0 };
+                a_ub[r * n + 2] = s * (0.5 + next() * 3.0);
+            }
+            let b_ub: Vec<f64> = (0..m).map(|_| next() * 14.0 - 6.0).collect();
+            // Mixed-sign integer bounds in [-2,2]; continuous over a real box.
+            let lo_i: Vec<i64> = (0..n).map(|_| (next() * 4.0).floor() as i64 - 2).collect();
+            let hi_i: Vec<i64> = (0..n)
+                .map(|k| lo_i[k] + 1 + (next() * 4.0).floor() as i64)
+                .collect();
+            let l: Vec<f64> = lo_i.iter().map(|&v| v as f64).collect();
+            let u: Vec<f64> = hi_i.iter().map(|&v| v as f64).collect();
+            // LP point: pushed around the box (some near upper) to trigger both
+            // the cancellation and the complementation paths.
+            let x: Vec<f64> = (0..n)
+                .map(|k| {
+                    let t = if next() > 0.3 {
+                        0.55 + 0.45 * next()
+                    } else {
+                        next()
+                    };
+                    l[k] + t * (u[k] - l[k])
+                })
+                .collect();
+
+            for ac in separate_aggregation_mir(&a_ub, &b_ub, &l, &u, &integ, &x, 1e-7, 1e9) {
+                assert_valid_system(
+                    &ac.cut.coeffs,
+                    ac.cut.rhs,
+                    &a_ub,
+                    &b_ub,
+                    &integ,
+                    &lo_i,
+                    &hi_i,
+                    5,
+                );
+                n_cuts_checked += 1;
+            }
+        }
+        assert!(
+            n_cuts_checked > 20,
+            "expected many aggregation cuts to validate, got {n_cuts_checked}"
+        );
+    }
+
+    /// No panic / no spurious cut on degenerate inputs (single row, all-integer
+    /// with an integral LP point ⇒ no fractional fallback target, empty system).
+    #[test]
+    fn aggregation_degenerate_inputs_safe() {
+        let l = [0.0, 0.0];
+        let u = [2.0, 2.0];
+        let integ_all_int = [true, true];
+        let x = [1.5, 1.5];
+        // single row → no pair
+        let one =
+            separate_aggregation_mir(&[1.0, 1.0], &[1.5], &l, &u, &integ_all_int, &x, 1e-7, 1e9);
+        assert!(one.is_empty());
+        // all-integer + integral LP point → no continuous target AND no
+        // fractional column to fall back to → nothing to cancel.
+        let x_int = [1.0, 1.0];
+        let no_target = separate_aggregation_mir(
+            &[1.0, 1.0, 1.0, -1.0],
+            &[1.5, 1.5],
+            &l,
+            &u,
+            &integ_all_int,
+            &x_int,
+            1e-7,
+            1e9,
+        );
+        assert!(no_target.is_empty());
+        // empty system
+        let empty = separate_aggregation_mir(&[], &[], &[], &[], &[], &[], 1e-7, 1e9);
+        assert!(empty.is_empty());
+    }
+
+    /// Fully-lifted-LP regime: all columns integer, a fractional LP point, rows
+    /// with opposite signs on a fractional column ⇒ the fractional-column
+    /// fallback fires and any emitted cut is still valid for the integer system.
+    #[test]
+    fn aggregation_all_integer_fractional_fallback_valid() {
+        // Two "product-aux-like" integer columns + one plain integer column, all
+        // integer; LP point fractional on col 2 (the cancel target).
+        let a_ub = [
+            1.0, 1.0, 2.0, // R0
+            1.0, 0.0, -1.0, // R1
+        ];
+        let b_ub = [4.5, 1.5];
+        let l = [0.0, 0.0, 0.0];
+        let u = [3.0, 3.0, 3.0];
+        let integ = [true, true, true];
+        let x = [1.4, 1.0, 1.3]; // col 2 fractional → fallback cancels it
+        let cuts = separate_aggregation_mir(&a_ub, &b_ub, &l, &u, &integ, &x, 1e-7, 1e9);
+        for ac in &cuts {
+            assert_valid_system(
+                &ac.cut.coeffs,
+                ac.cut.rhs,
+                &a_ub,
+                &b_ub,
+                &integ,
+                &[0, 0, 0],
+                &[3, 3, 3],
+                4,
+            );
+        }
+    }
+}

--- a/crates/discopt-core/src/lp/mir.rs
+++ b/crates/discopt-core/src/lp/mir.rs
@@ -228,18 +228,9 @@ pub fn separate_mir(
         let mut best: Option<(Vec<f64>, f64, f64)> = None; // (coeffs, rhs, violation)
         for &comp in &patterns {
             for &d in &deltas {
-                if let Some((coeffs, rhs, viol)) = mir_under_substitution(
-                    row,
-                    b,
-                    l,
-                    u,
-                    integrality,
-                    comp,
-                    x,
-                    d,
-                    tol,
-                    max_dynamism,
-                ) {
+                if let Some((coeffs, rhs, viol)) =
+                    mir_under_substitution(row, b, l, u, integrality, comp, x, d, tol, max_dynamism)
+                {
                     if best.as_ref().map(|bst| viol > bst.2).unwrap_or(true) {
                         best = Some((coeffs, rhs, viol));
                     }

--- a/crates/discopt-core/src/lp/mod.rs
+++ b/crates/discopt-core/src/lp/mod.rs
@@ -11,6 +11,7 @@
 //! LP optimum), so a hand-written rank-revealing elimination is both adequate
 //! and avoids pulling a BLAS/LAPACK stack into the wheel build.
 
+pub mod aggregation;
 pub mod basis;
 pub mod cover;
 pub mod crossover;

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -567,10 +567,14 @@ impl<'a> Simplex<'a> {
             v >= self.lb[j] - ftol && v <= self.ub[j] + ftol
         });
         if !feasible {
-            if std::env::var("DISCOPT_T14_DBG").is_ok() { eprintln!("T14 REJECT primal-infeasible"); }
+            if std::env::var("DISCOPT_T14_DBG").is_ok() {
+                eprintln!("T14 REJECT primal-infeasible");
+            }
             return Err(self.cols);
         }
-        if std::env::var("DISCOPT_T14_DBG").is_ok() { eprintln!("T14 ACCEPT"); }
+        if std::env::var("DISCOPT_T14_DBG").is_ok() {
+            eprintln!("T14 ACCEPT");
+        }
         // Warm basis is nonsingular + primal-feasible → primal phase 2 only.
         let mut cost2 = vec![0.0; self.na];
         cost2[..n].copy_from_slice(self.c);

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -36,6 +36,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::recover_basis_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::gomory_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::mir_cuts_py, m)?)?;
+    m.add_function(wrap_pyfunction!(lp_bindings::aggregation_mir_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_csc_py, m)?)?;

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 
 use discopt_core::bnb::milp_driver::{solve_milp as core_solve_milp, MilpOptions, MilpStatus};
+use discopt_core::lp::aggregation::separate_aggregation_mir;
 use discopt_core::lp::basis::{recover_basis, Basis, BASIC};
 use discopt_core::lp::crossover::{crossover_to_vertex, LpView};
 use discopt_core::lp::gomory::separate_gomory;
@@ -205,6 +206,66 @@ pub fn mir_cuts_py<'py>(
     for cut in &cuts {
         flat.extend_from_slice(&cut.coeffs);
         rhs.push(cut.rhs);
+    }
+    let coeffs = PyArray1::from_vec(py, flat).reshape([k, n])?;
+    Ok(Some((coeffs, PyArray1::from_vec(py, rhs))))
+}
+
+/// Separate Marchand–Wolsey aggregation c-MIR cuts from the `≤` rows
+/// `a_ub · x ≤ b_ub` at point `x`.
+///
+/// Pairs rows with nonnegative weights to cancel a continuous variable, forms the
+/// valid implied aggregate row, and applies the same complemented MIR as
+/// [`mir_cuts_py`] to it — so every cut is valid for the original feasible set (a
+/// nonnegative row combination of `≤` rows plus a valid MIR; see
+/// `discopt_core::lp::aggregation`). `a_ub` is C-contiguous `m × n`; `lb`/`ub` are
+/// length-`n` bounds (`+inf` in `ub[j]` disables complementation for column `j`);
+/// `integrality` a length-`n` bool array. Returns `(coeffs, rhs)` — a `k × n`
+/// array and length-`k` rhs, the cuts `coeffs[i] · x ≤ rhs[i]` over the structural
+/// variables, ordered most-violated-first — or `None` when no cut is produced.
+#[pyfunction]
+#[pyo3(signature = (a_ub, b_ub, lb, ub, integrality, x, tol=1e-7, max_dynamism=1e7))]
+pub fn aggregation_mir_cuts_py<'py>(
+    py: Python<'py>,
+    a_ub: PyReadonlyArray2<'py, f64>,
+    b_ub: PyReadonlyArray1<'py, f64>,
+    lb: PyReadonlyArray1<'py, f64>,
+    ub: PyReadonlyArray1<'py, f64>,
+    integrality: PyReadonlyArray1<'py, bool>,
+    x: PyReadonlyArray1<'py, f64>,
+    tol: f64,
+    max_dynamism: f64,
+) -> PyResult<Option<(Bound<'py, PyArray2<f64>>, Bound<'py, PyArray1<f64>>)>> {
+    let dims = a_ub.shape();
+    let n = dims[1];
+    let a_flat = a_ub
+        .as_slice()
+        .map_err(|_| PyValueError::new_err("`a_ub` must be C-contiguous"))?;
+    let mut cuts = separate_aggregation_mir(
+        a_flat,
+        b_ub.as_slice()?,
+        lb.as_slice()?,
+        ub.as_slice()?,
+        integrality.as_slice()?,
+        x.as_slice()?,
+        tol,
+        max_dynamism,
+    );
+    if cuts.is_empty() {
+        return Ok(None);
+    }
+    // Most-violated first, deterministic tie-break by insertion order.
+    cuts.sort_by(|p, q| {
+        q.violation
+            .partial_cmp(&p.violation)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let k = cuts.len();
+    let mut flat = Vec::with_capacity(k * n);
+    let mut rhs = Vec::with_capacity(k);
+    for ac in &cuts {
+        flat.extend_from_slice(&ac.cut.coeffs);
+        rhs.push(ac.cut.rhs);
     }
     let coeffs = PyArray1::from_vec(py, flat).reshape([k, n])?;
     Ok(Some((coeffs, PyArray1::from_vec(py, rhs))))

--- a/discopt_benchmarks/results/p3_cmir_aggregation_onoff_20260703T155324.json
+++ b/discopt_benchmarks/results/p3_cmir_aggregation_onoff_20260703T155324.json
@@ -1,0 +1,118 @@
+{
+  "cap_seconds": 60.0,
+  "cut_rounds": 3,
+  "rows": [
+    {
+      "instance": "ex1263a",
+      "status": "run",
+      "oracle": 19.6,
+      "off": {
+        "status": "time_limit",
+        "objective": 121.0,
+        "bound": 19.6,
+        "node_count": 400,
+        "wall": 2.0125200827606022
+      },
+      "on": {
+        "status": "time_limit",
+        "objective": 121.0,
+        "bound": 19.6,
+        "node_count": 400,
+        "wall": 1.7540494580753148
+      },
+      "on_full": {
+        "status": "optimal",
+        "objective": 19.6,
+        "bound": 19.6,
+        "node_count": 1062,
+        "wall": 2.6942009166814387
+      },
+      "incorrect_on": false,
+      "bad_bound": false
+    },
+    {
+      "instance": "graphpart_2pm-0044-0044",
+      "status": "run",
+      "oracle": -13.0,
+      "off": {
+        "status": "optimal",
+        "objective": -13.000000000000002,
+        "bound": -13.000000000000002,
+        "node_count": 31,
+        "wall": 0.4240367501042783
+      },
+      "on": {
+        "status": "optimal",
+        "objective": -13.000000000000002,
+        "bound": -13.000000000000002,
+        "node_count": 31,
+        "wall": 0.42362208291888237
+      },
+      "on_full": {
+        "status": "optimal",
+        "objective": -13.000000000000002,
+        "bound": -13.000000000000002,
+        "node_count": 31,
+        "wall": 0.43551879189908504
+      },
+      "incorrect_on": false,
+      "bad_bound": false
+    },
+    {
+      "instance": "graphpart_2g-0044-1601",
+      "status": "run",
+      "oracle": -954077.0,
+      "off": {
+        "status": "optimal",
+        "objective": -954077.0000000001,
+        "bound": -954077.0000000001,
+        "node_count": 12,
+        "wall": 0.3430612916126847
+      },
+      "on": {
+        "status": "optimal",
+        "objective": -954077.0000000001,
+        "bound": -954077.0000000001,
+        "node_count": 12,
+        "wall": 0.344653207808733
+      },
+      "on_full": {
+        "status": "optimal",
+        "objective": -954077.0000000001,
+        "bound": -954077.0000000001,
+        "node_count": 12,
+        "wall": 0.3429137081839144
+      },
+      "incorrect_on": false,
+      "bad_bound": false
+    },
+    {
+      "instance": "graphpart_2pm-0055-0055",
+      "status": "run",
+      "oracle": -20.0,
+      "off": {
+        "status": "optimal",
+        "objective": -20.000000000000004,
+        "bound": -20.000000000000004,
+        "node_count": 207,
+        "wall": 3.2403413746505976
+      },
+      "on": {
+        "status": "optimal",
+        "objective": -20.000000000000004,
+        "bound": -20.000000000000004,
+        "node_count": 207,
+        "wall": 3.2930780830793083
+      },
+      "on_full": {
+        "status": "optimal",
+        "objective": -20.000000000000004,
+        "bound": -20.000000000000004,
+        "node_count": 207,
+        "wall": 3.238634125329554
+      },
+      "incorrect_on": false,
+      "bad_bound": false
+    }
+  ]
+}

--- a/discopt_benchmarks/scripts/p3_cmir_aggregation_onoff.py
+++ b/discopt_benchmarks/scripts/p3_cmir_aggregation_onoff.py
@@ -1,0 +1,217 @@
+"""cert:P3 — Marchand-Wolsey aggregation c-MIR: ON vs OFF measurement.
+
+Measures the lever the aggregation c-MIR separator is built to move: the root
+dual bound and the B&B node count with ``DISCOPT_CMIR_AGGREGATION`` ON vs OFF, on
+the integer-product / graphpart panel from ``certification-gap-plan.md`` §7's 0b
+verdict (where discopt closes ~0% of the root gap SCIP's cut loop closes ~100%
+of). The correctness invariant (`incorrect_count == 0`) is checked per instance
+against the ``minlplib.solu`` oracle: with the flag ON the reported dual bound
+must never cross the known optimum.
+
+Guardrails mirror p3_0b: panel <= 8; a 60 s hard cap per solve; results persisted
+to ``results/`` as JSON; over-cap / errored instances LABELED, never dropped.
+
+Usage:
+    JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 \
+        python discopt_benchmarks/scripts/p3_cmir_aggregation_onoff.py
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _BENCH_ROOT.parent
+_SNAPSHOT = Path.home() / "Dropbox/projects/discopt-minlp-benchmark"
+_NL_DIR = _SNAPSHOT / "minlplib/nl"
+_SOLU = _SNAPSHOT / "minlplib.solu"
+_CERT_OPTIMA = _REPO_ROOT / "docs/dev/data/cert-optima.json"
+_RESULTS_DIR = _BENCH_ROOT / "results"
+
+# The native aggregation c-MIR runs in the LP-spatial B&B engine's node-cut
+# separator (`_separate_node_cuts`), which is scoped to *pure-integer* models.
+# The panel is therefore the pure-integer, in-scope subset of §7's 0b panel —
+# exactly the graphpart probes (plus ex1263a) where 0b measured discopt closing
+# 0% of the root gap SCIP's cut loop closes 100% of. (ex1263/fac1-3 carry
+# continuous vars → out of the spatial engine's scope; left to the follow-on
+# default-path wiring.)
+PANEL = [
+    "ex1263a",
+    "graphpart_2pm-0044-0044",
+    "graphpart_2g-0044-1601",
+    "graphpart_2pm-0055-0055",
+]
+
+CAP_SECONDS = 60.0
+# Cut rounds must be > 0 for the spatial engine's root cut loop (and thus the
+# aggregation separator) to run at all; keep modest so the measurement is cheap.
+CUT_ROUNDS = 3
+# Equal-node-budget bound comparison (the §1.5 / §7 gate): a tighter bound with
+# cuts ON at the SAME budget is the lever. Uncapped ON solve checks the oracle.
+BUDGET_NODES = 400
+
+
+def _load_oracle(name: str) -> float | None:
+    if _SOLU.exists():
+        best = None
+        with _SOLU.open() as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) >= 3 and parts[1] == name:
+                    try:
+                        val = float(parts[2])
+                    except ValueError:
+                        continue
+                    if parts[0] == "=opt=":
+                        return val
+                    if parts[0] == "=best=" and best is None:
+                        best = val
+        if best is not None:
+            return best
+    if _CERT_OPTIMA.exists():
+        data = json.loads(_CERT_OPTIMA.read_text())
+        if name in data:
+            return float(data[name])
+    return None
+
+
+def _solve(nl_path: Path, cmir_on: bool, max_nodes: int) -> dict:
+    """Solve once via the LP-spatial engine; return status/objective/bound/nodes.
+
+    The bound is the engine's final dual bound. At an equal `max_nodes` budget a
+    *higher* (tighter) bound with cuts ON is the lever §7 measures. Also runs an
+    uncapped solve (separate call) for the certified-optimum correctness check."""
+    os.environ["DISCOPT_CMIR_AGGREGATION"] = "1" if cmir_on else "0"
+
+    import discopt.modeling as dm
+
+    t0 = time.monotonic()
+    model = dm.from_nl(str(nl_path))
+    res = model.solve(
+        time_limit=CAP_SECONDS,
+        lp_spatial=True,
+        lp_spatial_cut_rounds=CUT_ROUNDS,
+        max_nodes=max_nodes,
+    )
+    wall = time.monotonic() - t0
+    return {
+        "status": str(res.status),
+        "objective": res.objective,
+        "bound": res.bound,
+        "node_count": res.node_count,
+        "wall": wall,
+    }
+
+
+def _incorrect(objective, oracle, sense_min=True) -> bool:
+    """A reported optimum that beats the oracle by > tol is a false certificate."""
+    if objective is None or oracle is None:
+        return False
+    tol = 1e-4 * (1.0 + abs(oracle))
+    # min sense: objective should be >= oracle - tol (never below true optimum).
+    return objective < oracle - tol if sense_min else objective > oracle + tol
+
+
+def main() -> int:
+    _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    n_run = 0
+    n_skip = 0
+    incorrect_count = 0
+
+    print(f"cert:P3 — aggregation c-MIR ON/OFF over {len(PANEL)} instances\n")
+    print(f"(LP-spatial engine, cut_rounds={CUT_ROUNDS}, equal budget {BUDGET_NODES} nodes)\n")
+    hdr = (
+        f"{'instance':<26} {'opt':>13} "
+        f"{'bound_off':>13} {'bound_on':>13} {'nodes_off':>10} {'nodes_on':>10}  note"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+
+    for name in PANEL:
+        nl_path = _NL_DIR / f"{name}.nl"
+        row: dict = {"instance": name}
+        if not nl_path.exists():
+            row.update(status="skipped", note="nl-missing")
+            rows.append(row)
+            n_skip += 1
+            print(f"{name:<26} SKIP (nl missing)")
+            continue
+
+        oracle = _load_oracle(name)
+        try:
+            off = _solve(nl_path, cmir_on=False, max_nodes=BUDGET_NODES)
+            on = _solve(nl_path, cmir_on=True, max_nodes=BUDGET_NODES)
+            # Correctness: uncapped solve with the flag ON must certify the oracle.
+            on_full = _solve(nl_path, cmir_on=True, max_nodes=500_000)
+        except Exception as exc:  # noqa: BLE001 — label, never drop
+            row.update(status="skipped", note=f"error:{type(exc).__name__}:{exc}")
+            rows.append(row)
+            n_skip += 1
+            print(f"{name:<26} SKIP (error: {exc})")
+            continue
+
+        # Correctness gate: the flag ON must never certify below the true optimum.
+        bad_on = _incorrect(on["objective"], oracle) or _incorrect(on_full["objective"], oracle)
+        # Dual bound must also never cross the oracle (min sense: bound <= opt).
+        bad_bound = (
+            on["bound"] is not None
+            and oracle is not None
+            and math.isfinite(on["bound"])
+            and on["bound"] > oracle + 1e-4 * (1.0 + abs(oracle))
+        )
+        if bad_on or bad_bound:
+            incorrect_count += 1
+
+        row.update(
+            status="run",
+            oracle=oracle,
+            off=off,
+            on=on,
+            on_full=on_full,
+            incorrect_on=bad_on,
+            bad_bound=bad_bound,
+        )
+        rows.append(row)
+        n_run += 1
+
+        def _f(x):
+            return f"{x:.4g}" if isinstance(x, (int, float)) and math.isfinite(x) else "—"
+
+        note = ""
+        if bad_on or bad_bound:
+            note = "!!! INCORRECT (ON) !!!"
+        elif off["bound"] is not None and on["bound"] is not None:
+            d = on["bound"] - off["bound"]
+            note = f"Δbound={d:+.4g}"
+        print(
+            f"{name:<26} {_f(oracle):>13} "
+            f"{_f(off['bound']):>13} {_f(on['bound']):>13} "
+            f"{_f(off['node_count']):>10} {_f(on['node_count']):>10}  {note}"
+        )
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    out = _RESULTS_DIR / f"p3_cmir_aggregation_onoff_{ts}.json"
+    out.write_text(
+        json.dumps(
+            {"cap_seconds": CAP_SECONDS, "cut_rounds": CUT_ROUNDS, "rows": rows},
+            indent=2,
+            default=str,
+        )
+    )
+    print(f"\n{n_run} run, {n_skip} skipped. incorrect_count = {incorrect_count}")
+    print(f"raw JSON -> {out}")
+    # Hard gate: any incorrect certificate is a failure.
+    return 1 if incorrect_count > 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -511,6 +511,64 @@ where discopt is already tight (the §7 no-offtarget-regression gate).
 This entry experiment measures only (it builds no cut plumbing, changes no solver
 math) — bound-neutral by construction; no correctness gate applies.
 
+### Phase 3 aggregation — build 1 results (2026-07-03)
+
+Built the native Marchand–Wolsey aggregation c-MIR separator (build item 2, the
+smallest sound slice): `crates/discopt-core/src/lp/aggregation.rs`
+(`separate_aggregation_mir`). It pairs `≤` rows with **nonnegative** weights
+`λ_i = |a_kt|`, `λ_k = |a_it|` to cancel one column `t` (the MW continuous-cancel
+target; falls back to a fractional column on a fully-lifted all-integer LP), forms
+the valid implied aggregate, and applies the **existing** complemented MIR
+(`mir.rs::separate_mir`, PR #415) to it — MIR is reused verbatim, never
+reimplemented. Wired behind `DISCOPT_CMIR_AGGREGATION` (**default-off**) into the
+LP-spatial engine's node-cut separator (`_jax/lp_spatial_bb.py::_separate_node_cuts`)
+and exposed as `aggregation_mir_cuts_py`.
+
+**Correctness (primary gate) — PASS.** `aggregation_validity_random_systems`:
+500 random 2/3-row systems (mixed integer/continuous, mixed-sign finite bounds,
+~30% fully-integer to exercise the fractional-fallback, LP points forced to
+violate) assert **no** integer/continuous-feasible point of the *original full
+system* is ever cut (>20 cuts validated, non-vacuous). Plus a
+fails-before/passes-after witness (`aggregation_finds_cut_single_row_mir_misses`)
+where single-row MIR finds nothing but 2-row aggregation cancelling the continuous
+variable separates `x*`. At scale (3,000 random systems via the Python binding):
+aggregation found a violated cut in **1,703**; in **30** of those single-row MIR
+found *nothing* — the regime aggregation is for.
+
+**Lever (ON vs OFF) — no bound change on the in-scope panel; SOUND, self-disables.**
+The separator runs in the LP-spatial engine, scoped to *pure-integer* models, so
+the measurable panel is that subset of §7's 0b panel: `ex1263a`,
+`graphpart_2pm-0044-0044`, `graphpart_2g-0044-1601`, `graphpart_2pm-0055-0055`
+(ex1263/fac1–3 carry continuous vars → out of scope). Equal 400-node budget,
+`cut_rounds=3`, 60 s cap
+(`discopt_benchmarks/scripts/p3_cmir_aggregation_onoff.py`, raw JSON
+`results/p3_cmir_aggregation_onoff_20260703T155324.json`):
+
+| instance | opt | bound OFF | bound ON | nodes OFF | nodes ON | Δbound |
+|---|---:|---:|---:|---:|---:|---:|
+| ex1263a | 19.6 | 19.6 | 19.6 | 400 | 400 | +0 |
+| graphpart_2pm-0044-0044 | −13 | −13 | −13 | 31 | 31 | +0 |
+| graphpart_2g-0044-1601 | −9.541e5 | −9.541e5 | −9.541e5 | 12 | 12 | +0 |
+| graphpart_2pm-0055-0055 | −20 | −20 | −20 | 207 | 207 | +0 |
+
+`incorrect_count = 0` on every row (uncapped ON solves certify the oracle; the
+dual bound never crosses opt). **Δbound = +0 everywhere**: on this panel the
+LP-spatial engine's McCormick relaxation is *already* at/near the optimum at the
+root (bound = opt on graphpart), so neither single-row MIR nor aggregation finds a
+violated cut there — the separator correctly self-disables (no cut, no
+regression). This is a **different, tighter relaxation** than the default-path
+`root_bound` the 0b verdict measured the 0% gap on; the bound-moving lever the 0b
+table identified lives on the **default path's** lifted McCormick relaxer, not the
+LP-spatial engine.
+
+**Re-scope (measurement wins, per §0.4):** build 1 lands the proven, sound,
+default-off separator + its native MIR reuse + the validity gate. The follow-on
+(build 1b) is to wire `aggregation_mir_cuts_py` into the **default-path** McCormick
+cut hook (the `cmir_cuts.py::separate_cmir` call site / the relaxer used off the
+LP-spatial engine) where 0b measured the 0% root-gap, and re-run the ON/OFF panel
+including ex1263/fac1–3 there. Cut-pool aging/efficacy on the default path (build
+item 3) remains as originally scoped.
+
 ---
 
 ## 8. Phase 4 — Stop losing structure (~3–5 EW, medium risk)

--- a/python/discopt/_jax/lp_spatial_bb.py
+++ b/python/discopt/_jax/lp_spatial_bb.py
@@ -140,6 +140,33 @@ def _separate_node_cuts(A, b, bounds, x, ncol, c, max_cuts=12):
         cuts.extend(mc)
     except Exception:
         pass
+    # Native Marchand–Wolsey aggregation c-MIR (cert:P3). DEFAULT-OFF, gated by
+    # DISCOPT_CMIR_AGGREGATION. Pairs <= rows with nonnegative weights to cancel a
+    # column, then applies the native Rust complemented MIR to the aggregate —
+    # valid by construction (nonnegative row combo + valid MIR; proven by the Rust
+    # aggregation_validity_random_systems property test). Every column here is an
+    # integer-valued (structural or product-aux) column, so the separator's
+    # fractional-column fallback picks the cancel target. It only ADDS valid cuts.
+    try:
+        from discopt.solver import _cmir_aggregation_enabled
+
+        if _cmir_aggregation_enabled():
+            from discopt._rust import aggregation_mir_cuts_py
+
+            res = aggregation_mir_cuts_py(
+                np.ascontiguousarray(np.asarray(A, dtype=np.float64)),
+                np.ascontiguousarray(np.asarray(b, dtype=np.float64).ravel()),
+                np.ascontiguousarray(lb.astype(np.float64)),
+                np.ascontiguousarray(ub.astype(np.float64)),
+                np.ascontiguousarray(is_int),
+                np.ascontiguousarray(np.asarray(x, dtype=np.float64).ravel()),
+            )
+            if res is not None:
+                acoef, arhs = np.asarray(res[0]), np.asarray(res[1])
+                for i in range(min(acoef.shape[0], max_cuts)):
+                    cuts.append((acoef[i][:ncol], float(arhs[i])))
+    except Exception:
+        pass
     return cuts
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2052,6 +2052,31 @@ _RENS_BUDGET_CAP_S = 8.0
 _ROOT_CUT_POOL_ROUNDS_ENV = int(os.environ.get("DISCOPT_ROOT_CUT_ROUNDS", "0"))
 _ROOT_CUT_POOL_MAX_ENV = int(os.environ.get("DISCOPT_ROOT_CUT_MAX", "200"))
 
+# Marchand-Wolsey aggregation c-MIR separator (cert:P3). DEFAULT-OFF, bound-
+# changing per CLAUDE.md §5: it ships dark behind this flag until proven on
+# nightlies. Read per-solve (below) so it can be toggled after ``import discopt``.
+# The separator is validity-gated (nonnegative row combination + valid MIR ⇒
+# valid cut; Rust ``aggregation_validity_random_systems`` property test), so
+# enabling it can only add valid cuts, never a false certificate.
+_CMIR_AGGREGATION_ENV_DEFAULT = os.environ.get("DISCOPT_CMIR_AGGREGATION", "0").lower() not in (
+    "0",
+    "",
+    "false",
+    "no",
+    "off",
+)
+
+
+def _cmir_aggregation_enabled() -> bool:
+    """Whether the aggregation c-MIR separator is enabled for this solve.
+
+    Re-reads ``DISCOPT_CMIR_AGGREGATION`` each call (default-off) so tests and
+    callers can toggle it after import; falls back to the import-time default."""
+    val = os.environ.get("DISCOPT_CMIR_AGGREGATION")
+    if val is None:
+        return _CMIR_AGGREGATION_ENV_DEFAULT
+    return val.lower() not in ("0", "", "false", "no", "off")
+
 
 def _apply_auto_cut_policy(model: "Model", relaxer) -> None:
     """Choose at most one QCQP cut family by structure + size, in place.
@@ -10387,6 +10412,55 @@ def _separate_mir_cuts(lp_data, x_vertex, n_orig, int_idx, a_ub_orig, b_ub_orig,
     return embedded[:max_cuts], rhs[:max_cuts]
 
 
+def _separate_aggregation_mir_cuts(
+    lp_data, x_vertex, n_orig, int_idx, a_ub_orig, b_ub_orig, max_cuts: int = 8
+):
+    """Separate Marchand-Wolsey aggregation c-MIR cuts from the original ``<=``
+    rows at the crossover vertex, via the Rust ``aggregation_mir_cuts_py`` binding.
+
+    Pairs ``<=`` rows with nonnegative weights to cancel a continuous variable,
+    forms the valid implied aggregate row, and applies the same complemented MIR
+    (bound substitution + delta-scan) as :func:`_separate_mir_cuts` to it. A
+    nonnegative combination of ``<=`` rows is a valid ``<=`` inequality, and MIR
+    on it is valid for the integer hull, so every emitted cut is valid for the
+    original feasible set — no integer-feasible point is ever removed (proven by
+    the Rust ``aggregation_validity_random_systems`` property test).
+
+    **Default-off**: this is the ``DISCOPT_CMIR_AGGREGATION`` feature-flagged
+    path; the caller gates the call, this helper only does the separation. Same
+    contract as :func:`_separate_mir_cuts`: returns ``(coeffs, rhs)`` embedded
+    into the current standard-form columns, or ``None`` when the binding is
+    unavailable, lower bounds are non-finite, or no cut is produced."""
+    if a_ub_orig is None or np.asarray(a_ub_orig).shape[0] < 2:
+        return None  # aggregation needs at least two rows to combine
+    try:
+        from discopt._rust import aggregation_mir_cuts_py
+    except ImportError:
+        return None
+    lo = np.asarray(lp_data.x_l, dtype=np.float64)[:n_orig]
+    if not np.all(np.isfinite(lo)):
+        return None  # the MIR lower-bound shift requires finite lower bounds
+    hi = np.asarray(lp_data.x_u, dtype=np.float64)[:n_orig].copy()
+    hi[~np.isfinite(hi)] = np.inf
+    integ = np.zeros(n_orig, dtype=bool)
+    integ[[j for j in int_idx if j < n_orig]] = True
+    res = aggregation_mir_cuts_py(
+        np.ascontiguousarray(a_ub_orig, dtype=np.float64),
+        np.ascontiguousarray(b_ub_orig, dtype=np.float64),
+        np.ascontiguousarray(lo),
+        np.ascontiguousarray(hi),
+        integ,
+        np.ascontiguousarray(np.asarray(x_vertex, dtype=np.float64)[:n_orig]),
+    )
+    if res is None:
+        return None
+    coeffs, rhs = np.asarray(res[0], dtype=np.float64), np.asarray(res[1], dtype=np.float64)
+    n_cur = int(np.asarray(lp_data.A_eq).shape[1])
+    embedded = np.zeros((coeffs.shape[0], n_cur), dtype=np.float64)
+    embedded[:, :n_orig] = coeffs[:, :n_orig]
+    return embedded[:max_cuts], rhs[:max_cuts]
+
+
 def _extract_clique_edges(model: Model) -> list[tuple[int, int]]:
     """Conflict-graph 2-clique edges from the Rust presolve clique pass.
 
@@ -10574,6 +10648,23 @@ def _root_cover_cut_loop(
                 mc, mr = mir
                 lp_data = _augment_lpdata_with_mir_cuts(lp_data, mc, mr)
                 round_added += int(mc.shape[0])
+        # Aggregation c-MIR (cert:P3): DEFAULT-OFF, gated by
+        # DISCOPT_CMIR_AGGREGATION. Combines pairs of <= rows to cancel a
+        # continuous variable, then applies the same complemented MIR as above —
+        # valid by construction (nonnegative row combo + valid MIR). Same round-0
+        # / POUNCE-mode gate as single-row MIR; reuses the MIR augmentation.
+        if has_gomory and _round == 0 and _cmir_aggregation_enabled():
+            try:
+                agg = _separate_aggregation_mir_cuts(
+                    lp_data, x_vertex, n_orig, int_idx, A_ub_orig, b_ub_orig
+                )
+            except Exception as _agg_exc:
+                logger.debug("aggregation c-MIR separation skipped: %s", _agg_exc)
+                agg = None
+            if agg is not None:
+                ac, ar = agg
+                lp_data = _augment_lpdata_with_mir_cuts(lp_data, ac, ar)
+                round_added += int(ac.shape[0])
         if cuts:  # cover/clique reference original columns (< n_orig), still valid
             lp_data = _augment_lpdata_with_cover_cuts(lp_data, n_orig, cuts)
             round_added += len(cuts)


### PR DESCRIPTION
## cert:P3 — Marchand–Wolsey aggregation c-MIR separator (flagged, default-off)

Phase 3 build item 2 (`docs/dev/certification-gap-plan.md` §7). Adds a **native,
sound, validity-gated, default-off** Marchand–Wolsey aggregation c-MIR separator.
Ships the smallest sound slice: **2-row aggregation cancelling one column**, with
the final MIR step reusing the existing complemented single-row MIR (PR #415)
verbatim.

### What was built

- **`crates/discopt-core/src/lp/aggregation.rs`** — `separate_aggregation_mir`.
  Pairs `≤` rows with **nonnegative** weights `λ_i = |a_kt|`, `λ_k = |a_it|` that
  cancel one column `t` (the MW continuous-cancel target; falls back to a
  *fractional* column on a fully-lifted all-integer McCormick LP), forms the valid
  implied aggregate `Σλ_i a_i·x ≤ Σλ_i b_i`, and feeds that single row to
  `mir::separate_mir`. **MIR is never reimplemented** — aggregation only *builds a
  valid row*; bound substitution / complementation / δ-scan are reused.
- **`crates/discopt-python/src/lp_bindings.rs`** — `aggregation_mir_cuts_py`
  binding (+ registered in `lib.rs`).
- **`python/discopt/_jax/lp_spatial_bb.py`** — wired into the LP-spatial engine's
  node-cut separator, gated by `DISCOPT_CMIR_AGGREGATION` (**default-off**).
- **`python/discopt/solver.py`** — `DISCOPT_CMIR_AGGREGATION` flag +
  `_cmir_aggregation_enabled()` (read per-solve) + a default-path helper
  `_separate_aggregation_mir_cuts` wired into the MILP cut loop (also flag-gated).

### Soundness (why a cut can never be a false certificate)

A nonnegative combination of `≤` rows is a valid `≤` inequality; a valid MIR of a
valid `≤` row removes no integer-feasible point of that row, hence none of the
original feasible set. Validity does **not** depend on the weights, the cancel
column, or the separation point.

### Correctness gate — PASS

- **Primary property test** `aggregation_validity_random_systems`: **500** random
  2/3-row systems (mixed integer/continuous columns, mixed-sign finite bounds,
  ~30% fully-integer to exercise the fractional-fallback, LP points forced to
  violate) assert **no** integer/continuous-feasible point of the *original full
  system* is ever cut (>20 cuts validated per run, non-vacuous). Modeled on
  `mir_validity_random_complemented_rows`.
- **Fails-before/passes-after witness** `aggregation_finds_cut_single_row_mir_misses`:
  a constructed instance where single-row MIR finds nothing but 2-row aggregation
  cancelling the continuous variable separates `x*` (verified failing with the
  separator stubbed to `[]`, passing with it live).
- Plus `aggregation_all_integer_fractional_fallback_valid` and
  `aggregation_degenerate_inputs_safe`.
- **At scale** (3,000 random systems via the Python binding): aggregation found a
  violated cut in **1,703**; in **30** of those single-row MIR found *nothing* —
  the regime aggregation is for.

### Lever (ON vs OFF) — sound, self-disables on the in-scope panel

Runs in the LP-spatial engine (scoped to pure-integer models), so the measurable
panel is that subset of §7's 0b panel. Equal 400-node budget, `cut_rounds=3`, 60 s
cap (`discopt_benchmarks/scripts/p3_cmir_aggregation_onoff.py`):

| instance | opt | bound OFF | bound ON | nodes OFF | nodes ON | Δbound |
|---|---:|---:|---:|---:|---:|---:|
| ex1263a | 19.6 | 19.6 | 19.6 | 400 | 400 | +0 |
| graphpart_2pm-0044-0044 | −13 | −13 | −13 | 31 | 31 | +0 |
| graphpart_2g-0044-1601 | −9.541e5 | −9.541e5 | −9.541e5 | 12 | 12 | +0 |
| graphpart_2pm-0055-0055 | −20 | −20 | −20 | 207 | 207 | +0 |

`incorrect_count = 0` on every row. **Δbound = +0 everywhere**: on this panel the
LP-spatial engine's McCormick relaxation is already at/near opt at the root (bound
= opt on graphpart), so neither single-row MIR nor aggregation finds a violated
cut — the separator correctly self-disables (no cut, no regression). This is a
*different, tighter* relaxation than the default-path `root_bound` the 0b verdict
measured the 0% gap on.

### Re-scope (measurement wins, CLAUDE.md §0.4 / §4)

This PR lands the proven, sound, default-off separator + native-MIR reuse + the
validity gate. **Follow-on (build 1b):** wire `aggregation_mir_cuts_py` into the
**default-path** McCormick cut hook (the `cmir_cuts.py::separate_cmir` call site)
where 0b measured the 0% root-gap, and re-run the ON/OFF panel including
ex1263/fac1–3 there; cut-pool aging/efficacy (build item 3) remains scoped.
Recorded in §7 "Phase 3 aggregation — build 1 results".

### Gates run

- `cargo test -p discopt-core --lib` → **379 passed, 0 failed** (4 new aggregation
  tests).
- `cargo clippy -p discopt-core --lib` → clean; `-p discopt-python --lib` → no new
  warnings from the binding (9 pre-existing).
- `cargo fmt` clean; `ruff check` / `ruff format` clean on touched Python.
- `maturin develop --release` → built.
- `pytest -m smoke` → **193 passed, 1 skipped** (default-off ⇒ no behavior change).
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**
  (OFF) and **10 passed** with `DISCOPT_CMIR_AGGREGATION=1` (ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
