### PR TITLE
cert:P3.1d — SCIP separator-family attribution + build-target verdict

### DIFF
--- a/discopt_benchmarks/results/p3_1d_separator_attribution_20260703T180253.json
+++ b/discopt_benchmarks/results/p3_1d_separator_attribution_20260703T180253.json
@@ -1,0 +1,1351 @@
+{
+  "task": "cert:P3.1d",
+  "generated": "20260703T180253",
+  "panel": [
+    "ex1263",
+    "ex1263a",
+    "graphpart_2pm-0044-0044",
+    "graphpart_2g-0044-1601",
+    "graphpart_2pm-0055-0055"
+  ],
+  "cap_seconds": 60.0,
+  "presolve": "disabled (presolving/maxrounds=0)",
+  "scip_separators": [
+    "aggregation",
+    "cgmip",
+    "clique",
+    "closecuts",
+    "cmir",
+    "convexproj",
+    "disjunctive",
+    "eccuts",
+    "flowcover",
+    "flower",
+    "gauge",
+    "gomory",
+    "gomorymi",
+    "impliedbounds",
+    "interminor",
+    "intobj",
+    "knapsackcover",
+    "lagromory",
+    "mcf",
+    "minor",
+    "mixing",
+    "oddcycle",
+    "rapidlearning",
+    "rlt",
+    "strongcg",
+    "zerohalf"
+  ],
+  "n_run": 5,
+  "n_skipped": 0,
+  "aggregate_only_one_on_median_gap_closed": {
+    "aggregation": 0.0,
+    "cgmip": 0.0,
+    "clique": 0.0,
+    "closecuts": 0.0,
+    "cmir": 0.0,
+    "convexproj": 0.0,
+    "disjunctive": 0.0,
+    "eccuts": 0.0,
+    "flowcover": 0.0,
+    "flower": 0.0,
+    "gauge": 0.0,
+    "gomory": 0.0,
+    "gomorymi": 0.0,
+    "impliedbounds": 0.0,
+    "interminor": 0.0,
+    "intobj": 0.0,
+    "knapsackcover": 0.0,
+    "lagromory": 0.0,
+    "mcf": 0.0,
+    "minor": 0.0,
+    "mixing": 0.0,
+    "oddcycle": 0.0,
+    "rapidlearning": 0.0,
+    "rlt": 0.0,
+    "strongcg": 0.0,
+    "zerohalf": 0.5999999999999998
+  },
+  "aggregate_leave_one_out_median_marginal_loss": {
+    "aggregation": 0.0,
+    "cgmip": 0.0,
+    "clique": 0.0,
+    "closecuts": 0.0,
+    "cmir": 0.0,
+    "convexproj": 0.0,
+    "disjunctive": 0.0,
+    "eccuts": 0.0,
+    "flowcover": 0.0,
+    "flower": 0.0,
+    "gauge": 0.0,
+    "gomory": 0.0,
+    "gomorymi": 0.0,
+    "impliedbounds": 0.0,
+    "interminor": 0.0,
+    "intobj": 0.0,
+    "knapsackcover": 0.0,
+    "lagromory": 0.0,
+    "mcf": 0.0,
+    "minor": 0.0,
+    "mixing": 0.0,
+    "oddcycle": 0.0,
+    "rapidlearning": 0.0,
+    "rlt": 0.0,
+    "strongcg": 0.0,
+    "zerohalf": 0.15259925636062333
+  },
+  "rows": [
+    {
+      "instance": "ex1263",
+      "oracle_opt": 19.6,
+      "scip_all_off": 19.1,
+      "scip_all_on": 19.1,
+      "gap_closed_all_on": 0.0,
+      "only_one_on": {
+        "aggregation": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "cgmip": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "clique": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "closecuts": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "cmir": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "convexproj": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "disjunctive": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "eccuts": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "flowcover": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "flower": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "gauge": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "gomory": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "gomorymi": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "impliedbounds": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "interminor": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "intobj": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "knapsackcover": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "lagromory": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "mcf": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "minor": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "mixing": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "oddcycle": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "rapidlearning": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "rlt": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "strongcg": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "zerohalf": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        }
+      },
+      "leave_one_out": {
+        "aggregation": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "cgmip": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "clique": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "closecuts": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "cmir": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "convexproj": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "disjunctive": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "eccuts": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "flowcover": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "flower": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "gauge": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "gomory": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "gomorymi": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "impliedbounds": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "interminor": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "intobj": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "knapsackcover": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "lagromory": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "mcf": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "minor": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "mixing": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "oddcycle": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "rapidlearning": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "rlt": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "strongcg": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        },
+        "zerohalf": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 0.0
+        }
+      },
+      "scip_status_off": "nodelimit",
+      "scip_status_on": "nodelimit",
+      "wall": 4.474353375378996,
+      "status": "run",
+      "note": ""
+    },
+    {
+      "instance": "ex1263a",
+      "oracle_opt": 19.6,
+      "scip_all_off": 19.1,
+      "scip_all_on": 19.6,
+      "gap_closed_all_on": 1.0,
+      "only_one_on": {
+        "aggregation": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "cgmip": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "clique": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "closecuts": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "cmir": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "convexproj": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "disjunctive": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "eccuts": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "flowcover": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "flower": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "gauge": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "gomory": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "gomorymi": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "impliedbounds": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "interminor": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "intobj": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "knapsackcover": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "lagromory": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "mcf": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "minor": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "mixing": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "oddcycle": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "rapidlearning": {
+          "bound": 19.6,
+          "gap_closed": 1.0
+        },
+        "rlt": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "strongcg": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        },
+        "zerohalf": {
+          "bound": 19.1,
+          "gap_closed": 0.0
+        }
+      },
+      "leave_one_out": {
+        "aggregation": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "cgmip": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "clique": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "closecuts": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "cmir": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "convexproj": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "disjunctive": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "eccuts": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "flowcover": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "flower": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "gauge": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "gomory": {
+          "bound": 19.600000000000005,
+          "gap_closed": 1.000000000000007,
+          "marginal_loss": -7.105427357601002e-15
+        },
+        "gomorymi": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "impliedbounds": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "interminor": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "intobj": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "knapsackcover": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "lagromory": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "mcf": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "minor": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "mixing": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "oddcycle": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "rapidlearning": {
+          "bound": 19.1,
+          "gap_closed": 0.0,
+          "marginal_loss": 1.0
+        },
+        "rlt": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "strongcg": {
+          "bound": 19.6,
+          "gap_closed": 1.0,
+          "marginal_loss": 0.0
+        },
+        "zerohalf": {
+          "bound": 19.600000000000005,
+          "gap_closed": 1.000000000000007,
+          "marginal_loss": -7.105427357601002e-15
+        }
+      },
+      "scip_status_off": "nodelimit",
+      "scip_status_on": "nodelimit",
+      "wall": 0.9684923328459263,
+      "status": "run",
+      "note": ""
+    },
+    {
+      "instance": "graphpart_2pm-0044-0044",
+      "oracle_opt": -13.0,
+      "scip_all_off": -16.0,
+      "scip_all_on": -13.000000000000002,
+      "gap_closed_all_on": 0.9999999999999994,
+      "only_one_on": {
+        "aggregation": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "cgmip": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "clique": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "closecuts": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "cmir": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "convexproj": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "disjunctive": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "eccuts": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "flowcover": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "flower": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "gauge": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "gomory": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "gomorymi": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "impliedbounds": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "interminor": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "intobj": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "knapsackcover": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "lagromory": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "mcf": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "minor": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "mixing": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "oddcycle": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "rapidlearning": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "rlt": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "strongcg": {
+          "bound": -16.0,
+          "gap_closed": 0.0
+        },
+        "zerohalf": {
+          "bound": -13.999999999999991,
+          "gap_closed": 0.6666666666666696
+        }
+      },
+      "leave_one_out": {
+        "aggregation": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "cgmip": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "clique": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "closecuts": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "cmir": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "convexproj": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "disjunctive": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "eccuts": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "flowcover": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "flower": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "gauge": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "gomory": {
+          "bound": -13.999999999999991,
+          "gap_closed": 0.6666666666666696,
+          "marginal_loss": 0.3333333333333298
+        },
+        "gomorymi": {
+          "bound": -13.5,
+          "gap_closed": 0.8333333333333334,
+          "marginal_loss": 0.16666666666666607
+        },
+        "impliedbounds": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "interminor": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "intobj": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "knapsackcover": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "lagromory": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "mcf": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "minor": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "mixing": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "oddcycle": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "rapidlearning": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "rlt": {
+          "bound": -13.000000000000002,
+          "gap_closed": 0.9999999999999994,
+          "marginal_loss": 0.0
+        },
+        "strongcg": {
+          "bound": -12.999999999999996,
+          "gap_closed": 1.000000000000001,
+          "marginal_loss": -1.6653345369377348e-15
+        },
+        "zerohalf": {
+          "bound": -14.600000000000005,
+          "gap_closed": 0.466666666666665,
+          "marginal_loss": 0.5333333333333344
+        }
+      },
+      "scip_status_off": "nodelimit",
+      "scip_status_on": "nodelimit",
+      "wall": 4.171615291852504,
+      "status": "run",
+      "note": ""
+    },
+    {
+      "instance": "graphpart_2g-0044-1601",
+      "oracle_opt": -954077.0,
+      "scip_all_off": -1025886.0,
+      "scip_all_on": -973177.0,
+      "gap_closed_all_on": 0.7340166274422426,
+      "only_one_on": {
+        "aggregation": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "cgmip": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "clique": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "closecuts": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "cmir": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "convexproj": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "disjunctive": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "eccuts": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "flowcover": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "flower": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "gauge": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "gomory": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "gomorymi": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "impliedbounds": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "interminor": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "intobj": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "knapsackcover": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "lagromory": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "mcf": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "minor": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "mixing": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "oddcycle": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "rapidlearning": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "rlt": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "strongcg": {
+          "bound": -1025886.0,
+          "gap_closed": 0.0
+        },
+        "zerohalf": {
+          "bound": -964281.0,
+          "gap_closed": 0.8579008202314473
+        }
+      },
+      "leave_one_out": {
+        "aggregation": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "cgmip": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "clique": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "closecuts": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "cmir": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "convexproj": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "disjunctive": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "eccuts": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "flowcover": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "flower": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "gauge": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "gomory": {
+          "bound": -964281.0,
+          "gap_closed": 0.8579008202314473,
+          "marginal_loss": -0.1238841927892047
+        },
+        "gomorymi": {
+          "bound": -965025.5,
+          "gap_closed": 0.8475330390341044,
+          "marginal_loss": -0.11351641159186177
+        },
+        "impliedbounds": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "interminor": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "intobj": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "knapsackcover": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "lagromory": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "mcf": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "minor": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "mixing": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "oddcycle": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "rapidlearning": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "rlt": {
+          "bound": -973177.0,
+          "gap_closed": 0.7340166274422426,
+          "marginal_loss": 0.0
+        },
+        "strongcg": {
+          "bound": -981201.5,
+          "gap_closed": 0.6222687963904246,
+          "marginal_loss": 0.11174783105181796
+        },
+        "zerohalf": {
+          "bound": -984135.0,
+          "gap_closed": 0.5814173710816193,
+          "marginal_loss": 0.15259925636062333
+        }
+      },
+      "scip_status_off": "nodelimit",
+      "scip_status_on": "nodelimit",
+      "wall": 4.80806591687724,
+      "status": "run",
+      "note": ""
+    },
+    {
+      "instance": "graphpart_2pm-0055-0055",
+      "oracle_opt": -20.0,
+      "scip_all_off": -24.999999999999996,
+      "scip_all_on": -21.75,
+      "gap_closed_all_on": 0.6499999999999998,
+      "only_one_on": {
+        "aggregation": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "cgmip": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "clique": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "closecuts": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "cmir": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "convexproj": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "disjunctive": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "eccuts": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "flowcover": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "flower": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "gauge": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "gomory": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "gomorymi": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "impliedbounds": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "interminor": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "intobj": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "knapsackcover": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "lagromory": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "mcf": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "minor": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "mixing": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "oddcycle": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "rapidlearning": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "rlt": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "strongcg": {
+          "bound": -24.999999999999996,
+          "gap_closed": 0.0
+        },
+        "zerohalf": {
+          "bound": -22.0,
+          "gap_closed": 0.5999999999999998
+        }
+      },
+      "leave_one_out": {
+        "aggregation": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "cgmip": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "clique": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "closecuts": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "cmir": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "convexproj": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "disjunctive": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "eccuts": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "flowcover": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "flower": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "gauge": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "gomory": {
+          "bound": -22.0,
+          "gap_closed": 0.5999999999999998,
+          "marginal_loss": 0.050000000000000044
+        },
+        "gomorymi": {
+          "bound": -21.66666666666666,
+          "gap_closed": 0.6666666666666676,
+          "marginal_loss": -0.01666666666666783
+        },
+        "impliedbounds": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "interminor": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "intobj": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "knapsackcover": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "lagromory": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "mcf": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "minor": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "mixing": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "oddcycle": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "rapidlearning": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "rlt": {
+          "bound": -21.75,
+          "gap_closed": 0.6499999999999998,
+          "marginal_loss": 0.0
+        },
+        "strongcg": {
+          "bound": -21.999999999999993,
+          "gap_closed": 0.6000000000000011,
+          "marginal_loss": 0.04999999999999871
+        },
+        "zerohalf": {
+          "bound": -23.66666666666666,
+          "gap_closed": 0.26666666666666733,
+          "marginal_loss": 0.38333333333333247
+        }
+      },
+      "scip_status_off": "nodelimit",
+      "scip_status_on": "nodelimit",
+      "wall": 8.061472916975617,
+      "status": "run",
+      "note": ""
+    }
+  ]
+}

--- a/discopt_benchmarks/scripts/p3_1d_separator_attribution.py
+++ b/discopt_benchmarks/scripts/p3_1d_separator_attribution.py
@@ -1,0 +1,368 @@
+"""Phase 3 entry experiment 1d (cert:P3.1d) — SCIP per-separator attribution.
+
+The decisive spike that follows the 1c NO-GO (``certification-gap-plan.md`` §7,
+"Phase 3 1c"): 1c falsified the *reachability* hypothesis — making discopt's
+cover/clique/GMI/1-row-MIR/2-row-c-MIR family reachable and armed at the root
+closes ~0% of the gap SCIP closes ~100% of on the graphpart / integer-product
+class. The residual is **separator DEPTH**, not plumbing. Before any invasive
+Rust cut-seam work, this experiment answers the one question that pins the next
+build target:
+
+    Of SCIP's cut families, WHICH ONE(S) carry the root bound on this class?
+
+Design — SCIP per-separator attribution at the ROOT (node limit 1), pyscipopt:
+
+  * anchors:
+      - all-OFF  : every separator disabled -> the LP/relaxation floor.
+      - all-ON   : SCIP's default separator set -> the full SCIP root bound.
+  * only-one-on (per family F): disable ALL separators, enable exactly F at its
+      default freq -> the root gap closed BY F alone.
+  * leave-one-out (per family F): all separators on, disable F -> the root gap
+      LOST without F (marginal contribution).
+
+Gap closed by a root bound B (min sense), anchored on THIS SCIP build so every
+config is comparable:
+      gap_closed(B) = (B - all_off) / (opt - all_off)
+with ``opt`` the oracle optimum from ``minlplib.solu``. all_off is the shared LP
+floor (separators off); opt - all_off is the reachable root gap.
+
+Presolve is DISABLED across every config (``presolving/maxrounds = 0``) and
+propagation is left at SCIP defaults but node-limited to 1, so the only thing
+that moves the root bound between configs is the separator set — a clean
+attribution. (With presolve on, a presolve reduction could masquerade as a
+separator win; we want the separator signal, isolated.)
+
+Hard guardrails (P3.1d): panel <= 6; root-only; per-instance SCIP solve 60s hard
+cap; results persisted to ``discopt_benchmarks/results/`` as JSON; errored /
+over-cap configs are LABELED skipped, never silently dropped. SCIP-side only —
+touches no discopt solver code; SCIP reads the ``.nl`` directly, so discopt need
+not import.
+
+Usage:
+    JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 \
+        python discopt_benchmarks/scripts/p3_1d_separator_attribution.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import math
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _BENCH_ROOT.parent
+_SNAPSHOT = Path.home() / "Dropbox/projects/discopt-minlp-benchmark"
+_NL_DIR = _SNAPSHOT / "minlplib/nl"
+_SOLU = _SNAPSHOT / "minlplib.solu"
+_CERT_OPTIMA = _REPO_ROOT / "docs/dev/data/cert-optima.json"
+_RESULTS_DIR = _BENCH_ROOT / "results"
+
+# Small integer-product / graphpart panel (the 0b/1c set; fac1-3 dropped — they
+# route to spatial-McCormick and are already ~1.0 closed at the root). <= 6.
+PANEL = [
+    "ex1263",
+    "ex1263a",
+    "graphpart_2pm-0044-0044",
+    "graphpart_2g-0044-1601",
+    "graphpart_2pm-0055-0055",
+]
+
+CAP_SECONDS = 60.0
+
+
+def _load_oracle(name: str) -> float | None:
+    """Return the known optimum for *name* from solu, else cert-optima.json."""
+    if _SOLU.exists():
+        best = None
+        with _SOLU.open() as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) >= 3 and parts[1] == name:
+                    tag = parts[0]
+                    try:
+                        val = float(parts[2])
+                    except ValueError:
+                        continue
+                    if tag == "=opt=":
+                        return val
+                    if tag == "=best=" and best is None:
+                        best = val
+        if best is not None:
+            return best
+    if _CERT_OPTIMA.exists():
+        data = json.loads(_CERT_OPTIMA.read_text())
+        if name in data:
+            return float(data[name])
+    return None
+
+
+def _list_separators(nl_path: Path) -> list[str]:
+    """Enumerate the separator families THIS SCIP build exposes (freq params)."""
+    from pyscipopt import Model
+
+    m = Model()
+    m.hideOutput()
+    m.readProblem(str(nl_path))
+    params = m.getParams()
+    return sorted(
+        {k.split("/")[1] for k in params if k.startswith("separating/") and k.endswith("/freq")}
+    )
+
+
+def _new_model(nl_path: Path):
+    from pyscipopt import Model
+
+    m = Model()
+    m.hideOutput()
+    m.readProblem(str(nl_path))
+    # Root-only; presolve OFF so separators are the only mover of the root bound.
+    m.setParam("limits/nodes", 1)
+    m.setParam("limits/time", CAP_SECONDS)
+    m.setParam("presolving/maxrounds", 0)
+    return m
+
+
+def _root_bound(m) -> tuple[float | None, str]:
+    m.optimize()
+    status = m.getStatus()
+    try:
+        db = float(m.getDualbound())
+        if not math.isfinite(db):
+            db = None
+    except Exception:
+        db = None
+    return db, status
+
+
+def _set_all_separators(m, seps: list[str], freq: int) -> None:
+    """Force every separator freq to *freq* (-1 disables)."""
+    for s in seps:
+        # a family without a settable freq — leave it
+        with contextlib.suppress(Exception):
+            m.setParam(f"separating/{s}/freq", freq)
+
+
+def _reset_separator(m, seps: list[str], enable: str) -> None:
+    """Disable all separators except *enable*, which is reset to its default."""
+    _set_all_separators(m, seps, -1)
+    with contextlib.suppress(Exception):
+        m.resetParam(f"separating/{enable}/freq")
+
+
+def _gap_closed(bound: float | None, all_off: float | None, opt: float | None) -> float | None:
+    if bound is None or all_off is None or opt is None:
+        return None
+    denom = opt - all_off
+    if abs(denom) < 1e-9:
+        return 1.0
+    return (bound - all_off) / denom
+
+
+def _finite(x: float | None) -> bool:
+    return x is not None and math.isfinite(x)
+
+
+def main() -> int:
+    _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Enumerate the separator families once (build-specific).
+    probe = _NL_DIR / f"{PANEL[0]}.nl"
+    if not probe.exists():
+        # fall back to the first existing instance
+        for name in PANEL:
+            if (_NL_DIR / f"{name}.nl").exists():
+                probe = _NL_DIR / f"{name}.nl"
+                break
+    separators = _list_separators(probe)
+    print(f"cert:P3.1d — SCIP per-separator attribution over {len(PANEL)} instances")
+    print(f"SCIP separator families ({len(separators)}): {', '.join(separators)}\n")
+
+    rows: list[dict] = []
+    n_run = 0
+    n_skip = 0
+
+    for name in PANEL:
+        nl_path = _NL_DIR / f"{name}.nl"
+        row: dict = {"instance": name}
+        if not nl_path.exists():
+            row["status"] = "skipped"
+            row["note"] = "nl-missing"
+            rows.append(row)
+            n_skip += 1
+            print(f"{name:<26} SKIP (nl missing)")
+            continue
+
+        opt = _load_oracle(name)
+        row["oracle_opt"] = opt
+
+        t0 = time.monotonic()
+
+        # --- anchor: all separators OFF (LP floor) ---
+        try:
+            m = _new_model(nl_path)
+            _set_all_separators(m, separators, -1)
+            all_off, st_off = _root_bound(m)
+        except Exception as exc:  # noqa: BLE001
+            row["status"] = "skipped"
+            row["note"] = f"scip-alloff-error: {type(exc).__name__}: {exc}"
+            rows.append(row)
+            n_skip += 1
+            print(f"{name:<26} SKIP  all-off error: {exc}")
+            continue
+
+        # --- anchor: all separators ON (full SCIP root) ---
+        try:
+            m = _new_model(nl_path)
+            all_on, st_on = _root_bound(m)
+        except Exception as exc:  # noqa: BLE001
+            row["status"] = "skipped"
+            row["note"] = f"scip-allon-error: {type(exc).__name__}: {exc}"
+            rows.append(row)
+            n_skip += 1
+            print(f"{name:<26} SKIP  all-on error: {exc}")
+            continue
+
+        row["scip_all_off"] = all_off
+        row["scip_all_on"] = all_on
+        row["gap_closed_all_on"] = _gap_closed(all_on, all_off, opt)
+
+        # --- only-one-on: disable all, enable exactly F ---
+        only_one: dict[str, dict] = {}
+        for f in separators:
+            try:
+                m = _new_model(nl_path)
+                _reset_separator(m, separators, f)
+                b, _ = _root_bound(m)
+                only_one[f] = {
+                    "bound": b,
+                    "gap_closed": _gap_closed(b, all_off, opt),
+                }
+            except Exception as exc:  # noqa: BLE001
+                only_one[f] = {
+                    "bound": None,
+                    "gap_closed": None,
+                    "note": f"{type(exc).__name__}: {exc}",
+                }
+
+        # --- leave-one-out: all on, disable F -> marginal loss ---
+        leave_one_out: dict[str, dict] = {}
+        for f in separators:
+            try:
+                m = _new_model(nl_path)
+                with contextlib.suppress(Exception):
+                    m.setParam(f"separating/{f}/freq", -1)
+                b, _ = _root_bound(m)
+                gc = _gap_closed(b, all_off, opt)
+                gc_on = row["gap_closed_all_on"]
+                marginal = None
+                if _finite(gc) and _finite(gc_on):
+                    marginal = gc_on - gc  # gap lost when F removed
+                leave_one_out[f] = {
+                    "bound": b,
+                    "gap_closed": gc,
+                    "marginal_loss": marginal,
+                }
+            except Exception as exc:  # noqa: BLE001
+                leave_one_out[f] = {
+                    "bound": None,
+                    "gap_closed": None,
+                    "marginal_loss": None,
+                    "note": f"{type(exc).__name__}: {exc}",
+                }
+
+        row["only_one_on"] = only_one
+        row["leave_one_out"] = leave_one_out
+        row["scip_status_off"] = st_off
+        row["scip_status_on"] = st_on
+        row["wall"] = time.monotonic() - t0
+        row["status"] = "run"
+        note = "" if opt is not None else "no-oracle"
+        row["note"] = note
+        rows.append(row)
+        n_run += 1
+
+        # Per-instance console summary: top only-one-on families + top LOO losses.
+        def _fmt(x, w=8):
+            return f"{x:>{w}.3f}" if _finite(x) else f"{'--':>{w}}"
+
+        oo_sorted = sorted(
+            ((f, d.get("gap_closed")) for f, d in only_one.items()),
+            key=lambda kv: (kv[1] is not None, kv[1] or 0.0),
+            reverse=True,
+        )
+        loo_sorted = sorted(
+            ((f, d.get("marginal_loss")) for f, d in leave_one_out.items()),
+            key=lambda kv: (kv[1] is not None, kv[1] or 0.0),
+            reverse=True,
+        )
+        print(
+            f"{name:<26} opt={_fmt(opt, 10)} off={_fmt(all_off, 10)} "
+            f"on={_fmt(all_on, 10)} gc_on={_fmt(row['gap_closed_all_on'])} "
+            f"({row['wall']:.1f}s) {note}"
+        )
+        top_oo = ", ".join(f"{f}={_fmt(g, 0).strip()}" for f, g in oo_sorted[:4] if _finite(g))
+        top_loo = ", ".join(
+            f"{f}={_fmt(g, 0).strip()}" for f, g in loo_sorted[:4] if _finite(g) and g > 1e-6
+        )
+        print(f"    only-one-on top: {top_oo or '(none close gap)'}")
+        print(f"    leave-one-out loss: {top_loo or '(no family is load-bearing)'}")
+
+    # --- Aggregate attribution across run instances ---
+    run_rows = [r for r in rows if r.get("status") == "run"]
+
+    def _agg(field: str, sub: str) -> dict[str, float]:
+        """Median of *sub* over run instances, per family."""
+        acc: dict[str, list[float]] = {}
+        for r in run_rows:
+            for f, d in r.get(field, {}).items():
+                v = d.get(sub)
+                if _finite(v):
+                    acc.setdefault(f, []).append(v)
+        out = {}
+        for f, xs in acc.items():
+            xs = sorted(xs)
+            n = len(xs)
+            out[f] = xs[n // 2] if n % 2 else 0.5 * (xs[n // 2 - 1] + xs[n // 2])
+        return out
+
+    only_med = _agg("only_one_on", "gap_closed")
+    loo_med = _agg("leave_one_out", "marginal_loss")
+
+    print("\n--- aggregate (median over run instances) ---")
+    print("only-one-on gap-closed (top 8):")
+    for f, v in sorted(only_med.items(), key=lambda kv: kv[1], reverse=True)[:8]:
+        print(f"    {f:<16} {v:>7.3f}")
+    print("leave-one-out marginal loss (top 8):")
+    for f, v in sorted(loo_med.items(), key=lambda kv: kv[1], reverse=True)[:8]:
+        print(f"    {f:<16} {v:>7.3f}")
+    print(f"\nRun: {n_run}   Skipped: {n_skip}")
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    out = _RESULTS_DIR / f"p3_1d_separator_attribution_{stamp}.json"
+    payload = {
+        "task": "cert:P3.1d",
+        "generated": stamp,
+        "panel": PANEL,
+        "cap_seconds": CAP_SECONDS,
+        "presolve": "disabled (presolving/maxrounds=0)",
+        "scip_separators": separators,
+        "n_run": n_run,
+        "n_skipped": n_skip,
+        "aggregate_only_one_on_median_gap_closed": only_med,
+        "aggregate_leave_one_out_median_marginal_loss": loo_med,
+        "rows": rows,
+    }
+    out.write_text(json.dumps(payload, indent=2))
+    print(f"\nPersisted -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -129,6 +129,8 @@ experiment may run.
 | T2.5 OBBT escalation policy | **NOT BUILT** (T2.1 NO-GO) | — | same |
 | T2.6 cert2 gate wiring + default-on | **moot** (T2.3–T2.5 not built) | — | residual gap re-scoped to Phases 3–4 |
 | Phase 3 entry experiment (0b) | done — **GO on c-MIR** | (this PR) | SCIP root-bound proxy (`scripts/p3_0b_scip_rootbound.py`): median root gap closed **discopt 0.0 vs SCIP 1.0** over 8 (graphpart/ex1263/fac). SEPARATOR-QUALITY, not relaxation/branching → build native aggregation/c-MIR (§7 part 2). See §7 "0b RESULTS / VERDICT (2026-07-03)" |
+| Phase 3 1c reachability entry experiment | done — **NO-GO / re-scope** | #(prior) | Cuts made reachable+armed close ~0% (median gap-closed 0.000, best +0.55% on ex1263a) vs SCIP ~1.0. Residual is separator DEPTH, not plumbing. Do NOT build the Rust cut-callback seam yet. See §7 "Phase 3 1c" |
+| Phase 3 1d separator-family attribution | done — **build zerohalf** | (this PR) | SCIP per-separator attribution (`scripts/p3_1d_separator_attribution.py`): on graphpart `zerohalf` alone closes 60–86% of the reachable root gap and is the sole load-bearing family (leave-one-out 15–53%); every other cut family (flowcover/aggregation/cmir/clique/…) closes 0. Build target = native zero-half separator; expected ~0.6–0.9 root-gap close. See §7 "Phase 3 1d" |
 | Phase 4 T-CSE/V-segments | **locked** (§0.1.2) | — | may parallel Phase 1 once specced |
 | Phase 5 | **locked** (§0.1.2) | — | requires post-Phase-1 re-profile |
 
@@ -705,6 +707,71 @@ math-neutral): it changes no default behavior and is not a shipping feature.
 This experiment measures only; the one code toggle it adds is default-off and
 math-neutral (with it unset the `:3327` reroute is unchanged) — bound-neutral by
 construction on the default path, so no correctness gate is weakened.
+
+### Phase 3 1d — separator-family attribution (2026-07-03)
+
+The strength spike the 1c NO-GO demanded: 1c proved the residual is separator
+*depth*, not plumbing, but did not say *which* family SCIP uses. This experiment
+attributes SCIP's ~100% root close on the graphpart / integer-product class to
+specific separators, so the next build targets the right cut instead of guessing.
+
+**Method (SCIP-side only, pyscipopt / SCIP 10.0, `scripts/p3_1d_separator_attribution.py`):**
+root-only (node limit 1), **presolve DISABLED** (`presolving/maxrounds=0`) so the
+separator set is the *only* mover of the root bound — a clean attribution. Two
+anchors per instance — all-separators-OFF (LP floor) and all-ON (full SCIP root)
+— then, over all 26 families this SCIP build exposes: **only-one-on** (disable
+all, enable exactly F at default freq → gap F closes alone) and **leave-one-out**
+(all on, disable F → marginal gap lost). Gap-closed anchored on THIS build:
+`(bound − all_off)/(opt − all_off)`, `opt` from `minlplib.solu`. Panel = the 0b/1c
+set (ex1263, ex1263a, 3 small graphparts; fac1–3 dropped — already ~1.0). 60 s
+cap. **5 run, 0 skipped**; raw JSON
+`results/p3_1d_separator_attribution_20260703T180253.json`.
+
+only-one-on root-gap-closed (fraction of reachable root gap closed by F alone):
+
+| instance | all_off→all_on gc | **zerohalf** | gomory | gomorymi | strongcg | any other cut family |
+|---|---:|---:|---:|---:|---:|---:|
+| graphpart_2pm-0044-0044 | 1.000 | **0.667** | 0 | 0 | 0 | 0 |
+| graphpart_2g-0044-1601 | 0.734 | **0.858** | 0 | 0 | 0 | 0 |
+| graphpart_2pm-0055-0055 | 0.650 | **0.600** | 0 | 0 | 0 | 0 |
+| ex1263 | 0.000 | 0 | 0 | 0 | 0 | 0 (root LP already 19.1 vs opt 19.6; nothing to cut) |
+| ex1263a | 1.000 | 0 | 0 | 0 | 0 | `rapidlearning`=1.0 — a **primal heuristic**, not a cut |
+
+leave-one-out marginal loss (gap lost when F removed from the full set):
+
+| instance | **zerohalf** | gomory | gomorymi | strongcg |
+|---|---:|---:|---:|---:|
+| graphpart_2pm-0044-0044 | **0.533** | 0.333 | 0.167 | 0 |
+| graphpart_2g-0044-1601 | **0.153** | −0.124 | −0.114 | 0.112 |
+| graphpart_2pm-0055-0055 | **0.383** | 0.050 | −0.017 | 0.050 |
+
+Aggregate (median over the 5): only-one-on **zerohalf 0.600**, every other cut
+family 0.000; leave-one-out **zerohalf 0.153**, all others ≤0.05. On no instance
+does flowcover / aggregation / cmir / clique / knapsackcover / rlt / mcf /
+impliedbounds close *anything*.
+
+**VERDICT — the family that carries the bound is `zerohalf` ({0,½}-Chvátal–Gomory
+cuts). Build target: a native zero-half separator.** On the graphpart class
+zerohalf alone closes **60–86%** of the reachable root gap and is the single
+load-bearing family under leave-one-out (15–53% marginal); gomory / gomorymi /
+strongcg are secondary and partly redundant with it (negative marginal on
+2g-0044-1601 → SCIP's selection trades them off against zerohalf). Expected
+magnitude if discopt gains a working zerohalf separator on this class: **~0.6–0.9
+of the root gap** the whole Phase-3 line has been chasing, i.e. the bulk of
+SCIP's edge — *not* the flow-cover / lifted-aggregation / deeper-c-MIR guesses the
+1b/1c notes floated, and not the aggregation c-MIR already built in #416 (which
+closes 0 here). This is a **single-family** target, not diffuse: one separator
+(zerohalf) matches most of SCIP on graphpart.
+
+**Scope notes for the build:** (i) zerohalf needs the *integer* constraint rows
+(these graphparts read as ~48 int + 1 cont), which the class already carries;
+(ii) the two non-graphpart panel members are *not* separator-depth problems and
+should not distract the build — ex1263's root LP is already tight (0% closable at
+root by anything), and ex1263a's "close" is a primal heuristic (`rapidlearning`)
+finding the incumbent, not a cut. So the zerohalf build's measurable target is
+the pure-integer graphpart subset, exactly where 0b/1c measured the 0% discopt
+close. Measurement-only spike: touches no discopt solver code, so no correctness
+gate applies.
 
 ---
 


### PR DESCRIPTION
## cert:P3.1d — SCIP separator-family attribution

Measurement-only entry experiment following the **1c NO-GO** (§7 "Phase 3 1c"). 1c proved the graphpart / integer-product residual is separator **depth**, not plumbing, but didn't name the family SCIP uses. This spike attributes SCIP's ~100% root close to specific separators so the next build targets the right cut instead of guessing.

### Method (SCIP-side only)

pyscipopt / SCIP 10.0, **root-only** (`limits/nodes=1`), **presolve DISABLED** (`presolving/maxrounds=0`) so the separator set is the *only* mover of the root bound. Two anchors per instance (all-separators-OFF = LP floor; all-ON = full SCIP root), then over all **26** separator families this build exposes:
- **only-one-on** — disable all, enable exactly F at default freq -> gap F closes alone.
- **leave-one-out** — all on, disable F -> marginal gap lost.

Gap-closed anchored on this build: `(bound - all_off)/(opt - all_off)`, `opt` from `minlplib.solu`. Panel = the 0b/1c set (ex1263, ex1263a, 3 small graphparts; fac1-3 dropped, already ~1.0). Harness `discopt_benchmarks/scripts/p3_1d_separator_attribution.py`; raw JSON in `results/`. **5 run, 0 skipped**, ~23 s total.

### only-one-on root-gap-closed

| instance | all-off->all-on | **zerohalf** | every other cut family |
|---|---:|---:|---:|
| graphpart_2pm-0044-0044 | 1.000 | **0.667** | 0 |
| graphpart_2g-0044-1601 | 0.734 | **0.858** | 0 |
| graphpart_2pm-0055-0055 | 0.650 | **0.600** | 0 |
| ex1263 | 0.000 | 0 | 0 (root LP already 19.1 vs opt 19.6) |
| ex1263a | 1.000 | 0 | `rapidlearning`=1.0 — a **primal heuristic**, not a cut |

### leave-one-out marginal loss

| instance | **zerohalf** | gomory | gomorymi | strongcg |
|---|---:|---:|---:|---:|
| graphpart_2pm-0044-0044 | **0.533** | 0.333 | 0.167 | 0 |
| graphpart_2g-0044-1601 | **0.153** | -0.124 | -0.114 | 0.112 |
| graphpart_2pm-0055-0055 | **0.383** | 0.050 | -0.017 | 0.050 |

Aggregate (median over 5): only-one-on **zerohalf 0.600**, every other cut family 0.000; leave-one-out **zerohalf 0.153**, all others <=0.05. flowcover / aggregation / cmir / clique / knapsackcover / rlt / mcf / impliedbounds close **nothing** on any instance.

### VERDICT — build a native **zerohalf** ({0,1/2}-Chvatal-Gomory) separator

On the graphpart class zerohalf alone closes **60-86%** of the reachable root gap and is the single load-bearing family (leave-one-out 15-53%); gomory/gomorymi/strongcg are secondary and partly redundant with it (negative marginal on 2g-0044-1601 -> SCIP trades them off against zerohalf). Expected magnitude if discopt gains a working zerohalf separator: **~0.6-0.9 of the root gap** — the bulk of SCIP's edge. This is a **single-family** target, *not* the flow-cover / lifted-aggregation / deeper-c-MIR guesses 1b/1c floated, and *not* the aggregation c-MIR already built in #416 (closes 0 here).

Scope notes: zerohalf needs the integer constraint rows (graphparts read ~48 int + 1 cont — already carried); ex1263 is not a separator problem (root LP tight); ex1263a's "close" is a primal heuristic, not a cut. The measurable build target is the pure-integer graphpart subset.

### Tests / gates

Touches **no** discopt solver code (SCIP reads the `.nl` directly; discopt not imported). `ruff check` + `ruff format --check` clean on the new script. No correctness gate applies — measurement-only. **Do NOT merge** without review; this pins the Phase 3 build target.

Recorded as §7 "Phase 3 1d — separator-family attribution" and the §14 status table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
