### PR TITLE
fix(correctness): C-33/SC-1 — do not certify nonconvex pure-continuous NLP fallback as optimal

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -118,7 +118,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-30 | P0 | classify/extract | maximize sense lost on `sum(const·var)` bodies (raises `ValueError` not `_NotLinearError`, mis-routes to sense-dropping fallback) → returns 0 instead of true max (= CORE-2, ro ADJ-1) | confirmed |
 | C-31 | P0 | presolve/FBBT | FBBT collapses an array-variable block to element-0's bounds and stamps them on every element → cuts feasible points AND false "infeasible"; chains into invalid conflict cuts AND (broadened) into the certified LP dual bound via `_fbbt_argument_box` (= TG-1) | confirmed |
 | C-32 | P0 | relaxation/mccormick | `relax_asin`/`relax_acos` inverted curvature regime → unsound convex envelope (cv > f) in the LIVE JAX layer → invalid dual bound (= NM-1) | confirmed |
-| C-33 | P0 | solver.py fallback | pure-continuous fallback certifies a nonconvex model's local optimum with `gap_certified=True` (= SC-1), DEFAULT path | confirmed |
+| C-33 | P0 | solver.py fallback | pure-continuous fallback certifies a nonconvex model's local optimum with `gap_certified=True` (= SC-1), DEFAULT path | fixed |
 | C-34 | P0 | gdp_reformulate | even-power bound over a zero-straddling base uses endpoint-only bounds (omits interior min at 0) → invalid aux box → false optimal (= FR-1), DEFAULT path | confirmed |
 | C-35 | P1 | oa.py / gdpopt_loa | non-rigorous NLP failure → unconditional no-good cut → possible false infeasible/optimal (= OA-1, opt-in OA/LOA path) | open |
 
@@ -1418,7 +1418,47 @@ false `gap_certified=True` to pin the bug.
 control still certifies; no node-count/objective drift on the certifying panel for
 models that were already convex; standing gates pass.
 
-**Log:** 2026-07-03 — VERIFIED new default-path P0 (solver-core review §1).
+**Log:**
+- 2026-07-03 — VERIFIED new default-path P0 (solver-core review §1).
+- 2026-07-03 — **CONFIRMED then FIXED.** Confirmed the false certificate with the
+  nonconvex asymmetric quartic double-well `f(x)=x**4-16x**2+5x` on `[-4, 6]`
+  (midpoint start x=1 sits in the shallow well's basin): the pure-continuous
+  fallback returned `objective=-50.06, bound=-50.06, gap_certified=True` while the
+  true global minimum is `-78.33` at x≈-2.90 — a false optimality certificate. The
+  trigger used was `skip_convex_check=True` (one of the two documented triggers,
+  the other being classifier abstention → `not _pure_continuous_convexity_known`);
+  both reach the same fallback with convexity **not established**. Verified
+  fail-before/pass-after by stashing the fix.
+- **Fix** (`solver.py`, pure-continuous fallback at the `if _pure_continuous and
+  not _pure_continuous_force_spatial and (skip_convex_check or not
+  _pure_continuous_convexity_known)` block): reaching this branch means convexity
+  was never established — the KNOWN-convex case already returned via the convex
+  fast path above, so **no convex certificate can be lost here**. On any
+  non-error, non-infeasible fallback result the code now **withholds the
+  certificate**: keeps the feasible incumbent (`objective`, `x`, `status`) but
+  sets `gap_certified=False` and drops the fabricated dual bound/gap
+  (`bound=None, root_bound=None, gap=None, root_gap=None`). The local NLP
+  objective is no longer emitted as a proven bound. No safety mechanism was
+  weakened — the gate was made stricter (refuse to certify per CLAUDE.md §1/§3).
+  Rigorous `status="infeasible"` (from nonlinear tightening / NLP infeasibility)
+  is left untouched. The DEFAULT non-skip path on a *known*-nonconvex model is
+  unaffected (it routes to spatial B&B, which finds the true global -78.33 with a
+  valid bound and legitimately certifies).
+- **Regression test** (`python/tests/test_c33_nonconvex_fallback_cert.py`, all
+  `@pytest.mark.smoke`, fail-before/pass-after verified):
+  `test_c33_nonconvex_fallback_not_certified_optimal` (the double-well repro —
+  asserts `gap_certified is False` and `bound is None`; fails before the fix with
+  the -50.06-certified-as-optimal assertion),
+  `test_c33_convex_control_still_certifies` (convex `exp(x)+x**2` still certifies
+  via the convex fast path — guards against over-correction), and
+  `test_c33_default_path_nonconvex_uses_spatial_bb` (default path on the same
+  nonconvex model finds the true global via spatial B&B — guards the sound path).
+- **Gates:** new test 3 passed; `pytest -k "convex or certif or gap"` 635 passed /
+  1 skipped / 2 xfailed; `pytest -m smoke` 246 passed / 1 skipped; adversarial
+  `test_adversarial_recent_fixes.py -m slow` green; `ruff check` + `ruff
+  format --check` clean; `pre-commit run mypy` passed. No Rust touched. PR: #422.
+
+**Status:** confirmed → fixed.
 
 ---
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3829,6 +3829,26 @@ def solve_model(
         # under the time limit. The user-requested skip_convex_check path keeps its
         # local-only result on any non-error status. (issue #266)
         if _cont_result.status != "error":
+            # C-33/SC-1 (P0, DEFAULT path): reaching this fallback means convexity
+            # was NOT established — either the user set skip_convex_check, or the
+            # classifier abstained (`not _pure_continuous_convexity_known`). The
+            # KNOWN-convex case already returned via the convex fast path above
+            # (line ~3745), so a *convex* certificate can never be lost here.
+            # On a nonconvex model the single NLP finds only a LOCAL optimum, which
+            # is not global — emitting it with gap_certified=True (and bound set to
+            # the local objective) is a FALSE optimality certificate (a nonconvex
+            # double-well returned obj=-50 certified while the true min was -78).
+            # Withhold the certificate: keep the feasible incumbent (objective, x)
+            # but strip the fabricated dual bound/gap and mark it uncertified. Do
+            # NOT weaken this into "trust the NLP" — refuse to certify (CLAUDE.md
+            # §1, §3). Genuine infeasibility from _solve_continuous is a rigorous
+            # nonlinear-tightening / NLP-infeasibility claim, not a gap, so leave it.
+            if _cont_result.status != "infeasible":
+                _cont_result.gap_certified = False
+                _cont_result.bound = None
+                _cont_result.root_bound = None
+                _cont_result.gap = None
+                _cont_result.root_gap = None
             return _cont_result
         logger.info(
             "Local NLP on convexity-unknown continuous model returned error; "

--- a/python/tests/test_c33_nonconvex_fallback_cert.py
+++ b/python/tests/test_c33_nonconvex_fallback_cert.py
@@ -1,0 +1,107 @@
+"""C-33 / SC-1 (P0, DEFAULT path) — the pure-continuous NLP fallback must NOT
+certify a nonconvex model's local optimum as global.
+
+The pure-continuous fallback in ``solver.py`` routes a model whose convexity is
+*not established* (``skip_convex_check`` set, or the convexity classifier
+abstained) to a single local NLP solve. Before the fix that local optimum was
+emitted with ``bound = objective`` and ``gap_certified=True`` — a FALSE
+optimality certificate on any nonconvex model, because a local minimum need not
+be global.
+
+Fails-before / passes-after: on the nonconvex double-well with
+``skip_convex_check=True`` the local NLP lands in the shallow well
+(objective ≈ -50.06) while the true global minimum is ≈ -78.33; before the fix
+the solver returned that shallow point with ``gap_certified=True`` and
+``bound == objective``.
+
+Control: a genuinely convex pure-continuous model must STILL certify via the
+convex fast path (guards against over-correcting into never certifying).
+"""
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+
+def _double_well(lb=-4.0, ub=6.0):
+    """Nonconvex asymmetric quartic double-well.
+
+    ``f(x) = x**4 - 16 x**2 + 5 x`` on ``[lb, ub]`` has two minima: a deep
+    (global) well at x ≈ -2.90 with f ≈ -78.33 and a shallow (local) well at
+    x ≈ +2.75 with f ≈ -50.06. On ``[-4, 6]`` the midpoint start (x=1) sits in
+    the shallow well's basin, so a single local NLP converges to the *local*
+    optimum — not the global one.
+    """
+    m = dm.Model("c33_double_well")
+    x = m.continuous("x", lb=lb, ub=ub)
+    m.minimize(x**4 - 16 * x**2 + 5 * x)
+    xs = np.linspace(lb, ub, 400001)
+    fvals = xs**4 - 16 * xs**2 + 5 * xs
+    true_global = float(fvals.min())
+    return m, true_global
+
+
+@pytest.mark.smoke
+def test_c33_nonconvex_fallback_not_certified_optimal():
+    """The pure-continuous fallback must not certify a nonconvex local optimum.
+
+    With ``skip_convex_check=True`` the fallback fires without a convexity proof.
+    The returned point may be kept as a feasible incumbent, but it must NOT be
+    certified optimal, and no fabricated dual bound may be reported.
+    """
+    m, true_global = _double_well()
+    r = m.solve(skip_convex_check=True)
+
+    # Feasible incumbent is fine; a *certified* optimum here would be false.
+    assert not r.gap_certified, (
+        "false optimality certificate: nonconvex local optimum certified as global "
+        f"(obj={r.objective}, true global={true_global})"
+    )
+    # The fabricated dual bound (local objective) must be withheld.
+    assert r.bound is None, f"fabricated dual bound {r.bound} on unproven-convex fallback"
+
+    # Soundness invariant (min sense): a *reported* dual bound must never exceed
+    # the true global optimum. bound is None here, but if a future change routes
+    # this to a genuine bound, it must still respect this.
+    if r.bound is not None:
+        assert r.bound <= true_global + 1e-6
+
+    # If the solver did emit a certified optimum, it must be the true global one
+    # (this is the pin that fails before the fix, where obj≈-50.06 was certified).
+    if r.gap_certified and r.objective is not None:
+        assert r.objective <= true_global + 1e-4
+
+
+@pytest.mark.smoke
+def test_c33_convex_control_still_certifies():
+    """Control: a convex pure-continuous model still certifies (no over-correction).
+
+    ``exp(x) + x**2`` is convex; the convex fast path must still fire and emit a
+    certified optimum with a finite bound.
+    """
+    m = dm.Model("c33_convex_control")
+    x = m.continuous("x", lb=-5, ub=5)
+    m.minimize(dm.exp(x) + x**2)
+    r = m.solve()
+
+    assert r.status == "optimal"
+    assert r.gap_certified, "convex model lost its valid optimality certificate"
+    assert r.bound is not None and np.isfinite(r.bound)
+    assert r.convex_fast_path is True
+
+
+@pytest.mark.smoke
+def test_c33_default_path_nonconvex_uses_spatial_bb():
+    """Default path (no skip flag) on the same nonconvex model routes to spatial
+    B&B, finds the true global optimum, and certifies it with a valid bound.
+
+    Guards against the fix accidentally decertifying the sound spatial path.
+    """
+    m, true_global = _double_well()
+    r = m.solve()
+
+    assert r.status == "optimal"
+    # Spatial B&B finds the deep well and certifies it with a bound at or below obj.
+    assert r.objective <= true_global + 1e-3
+    if r.gap_certified:
+        assert r.bound is not None and r.bound <= true_global + 1e-3


### PR DESCRIPTION
## C-33 / SC-1 (P0, DEFAULT path) — do not certify nonconvex pure-continuous NLP fallback as optimal

Fixes the catastrophic bug class: the solver certified a WRONG optimum.

### The bug (verified)
The pure-continuous NLP fallback in `solver.py` routes a model whose convexity is
**not established** — either `skip_convex_check=True`, or the convexity classifier
abstained (`not _pure_continuous_convexity_known`) — to a single local NLP solve,
and emitted its LOCAL optimum with `bound == objective` and `gap_certified=True`.
On any nonconvex model a local minimum need not be global, so this is a **false
optimality certificate**.

Repro (nonconvex asymmetric double-well `f(x)=x**4-16x**2+5x` on `[-4, 6]`, where
the midpoint start x=1 falls in the shallow well's basin), `skip_convex_check=True`:

| | objective | bound | gap_certified |
|---|---|---|---|
| **before** | -50.06 | -50.06 | **True** (FALSE — true global is **-78.33** at x≈-2.90) |
| **after** | -50.06 | None | **False** (feasible incumbent kept, optimality NOT claimed) |

### The fix
Reaching this fallback means convexity was never established — the KNOWN-convex
case already returns via the convex fast path above, so **no convex certificate
can be lost here**. On any non-error, non-infeasible fallback result the code now
**withholds the certificate**: it keeps the feasible incumbent (`objective`, `x`,
`status`) but sets `gap_certified=False` and drops the fabricated dual bound/gap
(`bound`/`root_bound`/`gap`/`root_gap` → `None`). The local NLP objective is no
longer emitted as a proven bound.

The gate was made **stricter, not weaker** (refuse to certify, per CLAUDE.md §1/§3).
Rigorous `status="infeasible"` is untouched. The DEFAULT non-skip path on a
*known*-nonconvex model is unaffected — it routes to spatial B&B, finds the true
global -78.33 with a valid bound, and legitimately certifies (verified).

### Regression test
`python/tests/test_c33_nonconvex_fallback_cert.py` (all `@pytest.mark.smoke`,
fail-before/pass-after verified by stashing the fix):
- `test_c33_nonconvex_fallback_not_certified_optimal` — the double-well repro
  (asserts `gap_certified is False` and `bound is None`); **fails before** the fix.
- `test_c33_convex_control_still_certifies` — convex `exp(x)+x**2` still certifies
  via the convex fast path (guards against over-correcting into never certifying).
- `test_c33_default_path_nonconvex_uses_spatial_bb` — default path on the same
  nonconvex model finds the true global via spatial B&B (guards the sound path).

### Gates (all green)
- new test: **3 passed**
- `pytest -k "convex or certif or gap"`: **635 passed, 1 skipped, 2 xfailed**
- `pytest -m smoke`: **246 passed, 1 skipped**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed**
- `ruff check` + `ruff format --check`: clean
- `pre-commit run mypy`: passed
- No Rust touched (no `cargo test` needed); `incorrect_count = 0`.

Backlog: `docs/dev/correctness-issues.md` C-33 → **fixed** (Log updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm
