### PR TITLE
fix(correctness): C-31 — FBBT per-element array bounds in univariate-rescue envelope (no block collapse)

### DIFF
--- a/crates/discopt-core/src/presolve/fbbt.rs
+++ b/crates/discopt-core/src/presolve/fbbt.rs
@@ -1087,6 +1087,36 @@ fn snap_integral_bounds(model: &ModelRepr, var_bounds: &mut [Interval]) {
 // Fixed-point FBBT
 // ─────────────────────────────────────────────────────────────
 
+/// Seed a variable BLOCK's FBBT interval from its element-wise bounds.
+///
+/// The FBBT engine carries **one interval per variable block** (an array
+/// variable of `size > 1` is a single `var_bounds` slot). An `Index` node that
+/// selects element `k` resolves — in both forward and backward propagation — to
+/// this single shared block interval, so the interval must be a valid *outer*
+/// bound for **every** element of the block, not any one element's.
+///
+/// C-31: the previous seed used `v.lb.first()/v.ub.first()` — element 0's bounds
+/// — and stamped them onto the whole block. On heterogeneous per-element bounds
+/// that interval EXCLUDES feasible points of the other elements: a forward
+/// `Index` on element `k != 0` then evaluates against element 0's (wrong)
+/// interval, cutting feasible arguments and, on a genuine mismatch, declaring a
+/// feasible model infeasible. That collapsed box reaches the certified LP dual
+/// bound via `_fbbt_argument_box` (`milp_relaxation.py`), so the envelope built
+/// over it can be invalid. Seeding from the element-wise UNION
+/// (`min` lower, `max` upper) restores soundness: the block interval then
+/// contains every element's feasible interval, so interval arithmetic over it is
+/// a superset — FBBT can only *lose* tightening for the block, never cut a
+/// feasible point. For a homogeneous block the union equals element 0, so this
+/// is a no-op there (no regression for the common case).
+pub(crate) fn seed_block_interval(v: &crate::expr::VarInfo) -> Interval {
+    if v.lb.is_empty() || v.ub.is_empty() {
+        return Interval::new(f64::NEG_INFINITY, f64::INFINITY);
+    }
+    let lo = v.lb.iter().copied().fold(f64::INFINITY, f64::min);
+    let hi = v.ub.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    Interval::new(lo, hi)
+}
+
 /// Run FBBT to fixed-point on a model with an optional incumbent cutoff.
 ///
 /// When `incumbent_bound` is `Some(bound)`, an additional synthetic constraint
@@ -1102,16 +1132,7 @@ pub fn fbbt_with_cutoff(
     incumbent_bound: Option<f64>,
 ) -> Vec<Interval> {
     let n_vars = model.variables.len();
-    let mut var_bounds: Vec<Interval> = model
-        .variables
-        .iter()
-        .map(|v| {
-            Interval::new(
-                v.lb.first().copied().unwrap_or(f64::NEG_INFINITY),
-                v.ub.first().copied().unwrap_or(f64::INFINITY),
-            )
-        })
-        .collect();
+    let mut var_bounds: Vec<Interval> = model.variables.iter().map(seed_block_interval).collect();
 
     // Determine the objective cutoff constraint (if any).
     let obj_cutoff: Option<(ExprId, Interval)> = incumbent_bound.map(|bound| {
@@ -1197,17 +1218,9 @@ pub fn fbbt_with_cutoff(
 /// Returns tightened variable bounds (indexed by variable index, not offset).
 pub fn fbbt(model: &ModelRepr, max_iter: usize, tol: f64) -> Vec<Interval> {
     let n_vars = model.variables.len();
-    let mut var_bounds: Vec<Interval> = model
-        .variables
-        .iter()
-        .map(|v| {
-            // Use the first element's bounds (scalar variables).
-            Interval::new(
-                v.lb.first().copied().unwrap_or(f64::NEG_INFINITY),
-                v.ub.first().copied().unwrap_or(f64::INFINITY),
-            )
-        })
-        .collect();
+    // C-31: seed each block from the element-wise union of its bounds (a valid
+    // outer bound for every element), NOT element 0 — see `seed_block_interval`.
+    let mut var_bounds: Vec<Interval> = model.variables.iter().map(seed_block_interval).collect();
 
     for _ in 0..max_iter {
         let old_bounds = var_bounds.clone();
@@ -2384,16 +2397,21 @@ mod tests {
         );
     }
 
-    // ── C-31 (=TG-1) — FBBT collapses an array-variable block to element-0's ──
+    // ── C-31 (=TG-1) — FBBT array-block seeding (FIXED) ──
     //
-    // `fbbt()` seeds ONE `Interval` per variable *block* from `v.lb.first()` /
-    // `v.ub.first()` (fbbt.rs:1204-1208), and `eval_node_interval` resolves every
-    // `Index{base,col}` node to that single block interval (fbbt.rs:513-516 —
-    // the column is ignored). So an array variable with heterogeneous per-element
-    // bounds has element 0's (tighter) bounds illegally propagated onto every
-    // other element. The card C-31 documents two failure modes; both are pinned
-    // here. These assert the *current buggy behaviour* so the bug is captured in
-    // Rust; when C-31 is fixed (element-aware FBBT), INVERT these assertions.
+    // `fbbt()` carries ONE `Interval` per variable *block*, and `eval_node_interval`
+    // resolves every `Index{base,col}` node to that single shared block interval
+    // (the column is ignored). The old seed used `v.lb.first()`/`v.ub.first()` —
+    // element 0's bounds — so an array variable with heterogeneous per-element
+    // bounds had element 0's (tighter) bounds illegally propagated onto every
+    // other element, cutting feasible points and (on a genuine mismatch) declaring
+    // a feasible model infeasible. FIX (`seed_block_interval`): seed each block
+    // from the element-wise UNION [min lb, max ub], a valid outer bound for every
+    // element — so the block interval never excludes a feasible argument. These
+    // two tests assert the FIXED behaviour (no feasible cut; no false infeasible);
+    // they FAIL on the pre-fix element-0 seed. See also the Python-side consumer
+    // test `test_c31_fbbt_argument_box_envelope_contains_feasible` which pins the
+    // certified-LP-relaxation reach (`_fbbt_argument_box` / `milp_relaxation.py`).
 
     /// Build a single continuous array variable block `x` of `size` with the given
     /// element-wise bounds, plus a constraint on element `col`: `x[col] {sense} rhs`.
@@ -2440,14 +2458,14 @@ mod tests {
     }
 
     #[test]
-    fn c31_array_block_collapses_to_element0_bounds() {
-        // x is a length-2 continuous array with element 0 fixed near element 1's
-        // feasible interval but DIFFERENT bounds: lb=[8,0], ub=[10,10]. Element 1
-        // is genuinely free in [0,10]. Constraint touches element 1 trivially:
-        // `x[1] >= 0` (always satisfiable). Element-aware FBBT would leave
-        // x[1] ∈ [0,10]. The buggy collapse seeds the whole block from element 0
-        // → the returned block interval is element-0's [8,10], erasing the
-        // feasible region x[1] ∈ [0,8).
+    fn c31_array_block_seeds_from_element_union_not_element0() {
+        // x is a length-2 continuous array with heterogeneous per-element bounds:
+        // lb=[8,0], ub=[10,10]. Element 1 is genuinely free in [0,10]. Constraint
+        // touches element 1 trivially: `x[1] >= 0` (always satisfiable). The old
+        // C-31 collapse seeded the whole block from element 0 → [8,10], erasing
+        // the feasible region x[1] ∈ [0,8). The fix seeds each block from the
+        // element-wise UNION [min lb, max ub] = [0,10], a valid outer bound for
+        // every element, so the feasible region is preserved.
         let model = array_var_model(
             vec![8.0, 0.0],
             vec![10.0, 10.0],
@@ -2456,30 +2474,37 @@ mod tests {
             0.0,
         );
         let bounds = fbbt(&model, 8, 1e-9);
-        // One interval per BLOCK (n_vars here = variables.len() == 1), NOT per
-        // scalar element — itself a symptom of the collapse.
+        // One interval per BLOCK (n_vars here = variables.len() == 1).
         assert_eq!(
             bounds.len(),
             1,
             "fbbt returns one interval per block, not per element"
         );
-        // BUG (C-31): element 1's lower bound is stamped as 8.0 (element 0's),
-        // not its true 0.0. When fixed, this must become `bounds[0].lo <= 0.0`.
+        // C-31 FIXED: the block interval must be the element-wise union outer
+        // bound, so its lower bound is element 1's 0.0 — NOT element-0's 8.0.
+        // A lower bound above 0.0 would cut the feasible region x[1] ∈ [0,8).
         assert!(
-            (bounds[0].lo - 8.0).abs() < 1e-9,
-            "C-31: block collapsed to element-0 lb=8, got {:?} (invert when fixed)",
+            bounds[0].lo <= 0.0 + 1e-9,
+            "C-31: block must not collapse to element-0 lb=8; feasible x[1]∈[0,8) \
+             would be cut. got {:?}",
+            bounds[0]
+        );
+        assert!(
+            bounds[0].hi >= 10.0 - 1e-9,
+            "C-31: block upper bound must cover every element (10.0), got {:?}",
             bounds[0]
         );
     }
 
     #[test]
-    fn c31_heterogeneous_block_yields_false_infeasible() {
+    fn c31_heterogeneous_block_no_false_infeasible() {
         // x length-2: lb=[5,0], ub=[5,3]. Element 0 is fixed at 5; element 1 is
         // free in [0,3]. Constraint `x[1] <= 3` is trivially satisfiable
         // (x=[5, 0..3] is feasible), so FBBT must NOT report infeasible.
-        // The collapse seeds the block from element 0 → [5,5]; the Index on
-        // element 1 resolves to [5,5]; intersecting with the constraint output
-        // (-inf, 3] is empty → FBBT falsely declares the whole model infeasible.
+        // The old C-31 collapse seeded the block from element 0 → [5,5]; the
+        // Index on element 1 resolved to [5,5]; intersecting with (-inf,3] was
+        // empty → false infeasible. The union seed [0,5] intersected with
+        // (-inf,3] is [0,3] → feasible.
         let model = array_var_model(
             vec![5.0, 0.0],
             vec![5.0, 3.0],
@@ -2488,13 +2513,12 @@ mod tests {
             3.0,
         );
         let bounds = fbbt(&model, 8, 1e-9);
-        // BUG (C-31): a feasible model is reported infeasible (all-empty bounds).
-        // "FBBT never reports feasible as infeasible" is violated. When C-31 is
-        // fixed this must become `assert!(!bounds.iter().any(|b| b.is_empty()))`.
+        // C-31 FIXED: a feasible model must NOT be reported infeasible.
+        // "FBBT never reports feasible as infeasible."
         assert!(
-            bounds.iter().all(|b| b.is_empty()),
-            "C-31: expected the buggy false-infeasible (all-empty) collapse, got {:?} \
-             (invert this assertion when C-31 is fixed)",
+            !bounds.iter().any(|b| b.is_empty()),
+            "C-31: feasible model x=[5, 0..3] must not be declared infeasible, \
+             got {:?}",
             bounds
         );
     }

--- a/crates/discopt-core/src/presolve/pass.rs
+++ b/crates/discopt-core/src/presolve/pass.rs
@@ -74,19 +74,16 @@ pub struct PresolveContext {
 }
 
 impl PresolveContext {
-    /// Initialise a context from a model. The bounds vector is filled
-    /// from each variable block's first scalar `lb`/`ub`, matching
-    /// `fbbt_with_cutoff`'s convention.
+    /// Initialise a context from a model. The bounds vector is filled with one
+    /// interval per variable BLOCK, seeded from the element-wise UNION of that
+    /// block's bounds (`seed_block_interval`), matching `fbbt`/`fbbt_with_cutoff`.
+    /// C-31: seeding from element 0 alone collapsed heterogeneous array blocks
+    /// onto element-0's interval, cutting feasible points of the other elements.
     pub fn from_model(model: ModelRepr) -> Self {
         let bounds: Vec<Interval> = model
             .variables
             .iter()
-            .map(|v| {
-                Interval::new(
-                    v.lb.first().copied().unwrap_or(f64::NEG_INFINITY),
-                    v.ub.first().copied().unwrap_or(f64::INFINITY),
-                )
-            })
+            .map(super::fbbt::seed_block_interval)
             .collect();
         Self {
             model,
@@ -122,13 +119,17 @@ impl PresolveContext {
         let shrank = n < self.bounds.len();
         let mut new_bounds = Vec::with_capacity(n);
         for (i, v) in self.model.variables.iter().enumerate() {
-            let lb = v.lb.first().copied().unwrap_or(f64::NEG_INFINITY);
-            let ub = v.ub.first().copied().unwrap_or(f64::INFINITY);
+            // C-31: seed from the element-wise union, not element 0, so a
+            // heterogeneous array block is a valid outer bound for every element.
+            let declared = super::fbbt::seed_block_interval(v);
             if !shrank && i < self.bounds.len() {
                 let prior = self.bounds[i];
-                new_bounds.push(Interval::new(prior.lo.max(lb), prior.hi.min(ub)));
+                new_bounds.push(Interval::new(
+                    prior.lo.max(declared.lo),
+                    prior.hi.min(declared.hi),
+                ));
             } else {
-                new_bounds.push(Interval::new(lb, ub));
+                new_bounds.push(declared);
             }
         }
         self.bounds = new_bounds;

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -116,7 +116,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-28 | P2 | nn/readers/sklearn | sklearn classifier semantics silently embed logits / wrong base_score | in progress (nn-module-plan T-N1.2) |
 | C-29 | P0 | classify/extract | vector-body constraint collapses to one summed row ("array var treated as sum") → infeasible point certified optimal, DEFAULT path (= CORE-1, modeling M1) | confirmed |
 | C-30 | P0 | classify/extract | maximize sense lost on `sum(const·var)` bodies (raises `ValueError` not `_NotLinearError`, mis-routes to sense-dropping fallback) → returns 0 instead of true max (= CORE-2, ro ADJ-1) | confirmed |
-| C-31 | P0 | presolve/FBBT | FBBT collapses an array-variable block to element-0's bounds and stamps them on every element → cuts feasible points AND false "infeasible"; chains into invalid conflict cuts AND (broadened) into the certified LP dual bound via `_fbbt_argument_box` (= TG-1) | confirmed |
+| C-31 | P0 | presolve/FBBT | FBBT collapses an array-variable block to element-0's bounds and stamps them on every element → cuts feasible points AND false "infeasible"; chains into invalid conflict cuts AND (broadened) into the certified LP dual bound via `_fbbt_argument_box` (= TG-1) | fixed |
 | C-32 | P0 | relaxation/mccormick | `relax_asin`/`relax_acos` inverted curvature regime → unsound convex envelope (cv > f) in the LIVE JAX layer → invalid dual bound (= NM-1) | confirmed |
 | C-33 | P0 | solver.py fallback | pure-continuous fallback certifies a nonconvex model's local optimum with `gap_certified=True` (= SC-1), DEFAULT path | fixed |
 | C-34 | P0 | gdp_reformulate | even-power bound over a zero-straddling base uses endpoint-only bounds (omits interior min at 0) → invalid aux box → false optimal (= FR-1), DEFAULT path | confirmed |
@@ -1312,33 +1312,65 @@ elements. The claim "a valid outer bound for every element of the block" is fals
 - Chained: `find_conflict_cuts` on a model with the above `x` and a free binary
   returns two cuts that together make the binary infeasible.
 
-**Fix:** element-aware FBBT for array blocks — per-scalar intervals from the Rust
-engine, or a Python interim guard applying a block interval only to elements whose
-*original* bounds equal element-0's, and never deriving `infeasible` from a collapsed
-block. Fixing this fixes the chained conflict-cut invalidity (CF-1). Details:
-`tightening-conflict-warmstart-iis-review.md`. NOTE: `test_tightening.py:68` uses only
-*homogeneous* array bounds, which is exactly why CI is blind — the regression test
-must use heterogeneous bounds.
+**Fix (LANDED):** the FBBT engine carries **one interval per variable block** and,
+by design, resolves every `Index{base,col}` node — forward *and* backward — to that
+single shared block interval (the column is ignored). Backward tightening onto an
+array block (`size > 1`) is already a no-op (`backward_propagate`'s `Variable` arm
+only writes when `size == 1`, and the `Index` arm recurses into the `size > 1` base),
+so the block interval is never *narrowed* below its seed for arrays. The **only**
+unsoundness was the **seed**: it used element 0's bounds (`v.lb.first()/v.ub.first()`)
+as if they bounded every element. The fix seeds each block from the element-wise
+**UNION** `[min lb, max ub]` (`seed_block_interval`, `fbbt.rs`), a valid *outer* bound
+for every element — so a forward `Index` on element `k` evaluates against a superset
+of element `k`'s true interval: FBBT can only **lose** tightening for the block, never
+cut a feasible point. Where an array element's rescue box then remains out of domain
+(the union straddles 0 / is non-finite), `_collect_univariate_relaxations` correctly
+**abstains** (drops the op) rather than emitting an envelope over a box that excludes
+feasible arguments. The same element-0 seed in the presolve driver
+(`pass.rs::from_model`, `resync_bounds_after_rewrite`) was switched to the union too.
+For a **homogeneous** block the union equals element 0, so this is a no-op there (no
+regression / no lost tightening for the common case). This is an *abstain*-class fix
+per CLAUDE.md §3: array-block FBBT is now sound-but-conservative rather than tight; a
+future per-scalar FBBT (real per-element intervals + `Index`-column-aware
+forward/backward) would recover the lost tightness — tracked separately, not required
+for soundness.
 
-**Regression tests (required — fast):** two are already committed as Rust
-characterization tests pinning the *current buggy* behavior
-(`presolve::fbbt::tests::c31_array_block_collapses_to_element0_bounds`,
-`c31_heterogeneous_block_yields_false_infeasible` — they assert the collapse and
-carry "invert when fixed" comments). When the fix lands, **flip both** to assert
-per-element bounds are preserved / no false infeasible. Add a Python fast test on
-`_fbbt_argument_box` proving the univariate-rescue envelope over a heterogeneous
-block **contains all feasible arguments** (the new consumer #2). All sub-second.
+**Regression tests (LANDED):** the two Rust characterization tests were **flipped**
+from asserting the collapse to asserting the fixed behavior:
+`presolve::fbbt::tests::c31_array_block_seeds_from_element_union_not_element0`
+(feasible region `x[1]∈[0,8)` preserved; block covers every element) and
+`c31_heterogeneous_block_no_false_infeasible` (feasible `x=[5,0..3]` not declared
+infeasible). Three fast Python `@pytest.mark.smoke` tests added in
+`python/tests/test_tightening.py`:
+`test_c31_heterogeneous_array_block_not_overtightened`,
+`test_c31_heterogeneous_array_block_no_false_infeasible`, and — for the broadened
+certified-LP reach — `test_c31_fbbt_argument_box_envelope_contains_feasible_arg`
+(calls `_collect_univariate_relaxations` directly and asserts every emitted rescue
+envelope's arg box contains a feasible argument). All five FAIL on the pre-fix
+element-0 seed and PASS after; all sub-second.
 
-**Done criteria:** both repros fixed (no feasible cut; no false infeasible); the
-conflict-cut repro yields zero cuts on the feasible model; the `_fbbt_argument_box`
-envelope contains every feasible argument on a heterogeneous block; the two Rust
-characterization tests are flipped to assert correct behavior; homogeneous-bounds
-test still passes; `cargo test -p discopt-core`; differential-bound checks (this is a
-certified-path tightening change) per §0.
+**Done criteria:** ✅ both repros fixed (no feasible cut; no false infeasible); ✅ the
+`_fbbt_argument_box` envelope contains every feasible argument on a heterogeneous
+block (or the op is abstained — never an envelope over an excluding box); ✅ the two
+Rust characterization tests flipped to assert correct behavior; ✅ homogeneous-bounds
+tests still pass; ✅ `cargo test -p discopt-core` (386 tests, 0 failures, clippy clean);
+✅ full `python/tests -k "fbbt or envelope or relax or array or tighten"` green (639
+passed). Certified-path tightening only ever *loosens* the box (union ⊇ element-0
+seed), so it cannot raise the dual bound above the truth — no bound can cross the
+oracle.
 
-**Log:** 2026-07-03 — Rust characterization tests committed (pin current behavior,
-`fbbt.rs` tests). Blast radius broadened to the certified LP dual bound via
-`_fbbt_argument_box` (solver-core review, `docs/dev/solver-core-review.md` §1).
+**Log:**
+- 2026-07-03 — Rust characterization tests committed (pin current behavior,
+  `fbbt.rs` tests). Blast radius broadened to the certified LP dual bound via
+  `_fbbt_argument_box` (solver-core review, `docs/dev/solver-core-review.md` §1).
+- 2026-07-03 — **FIXED** on `fix-c31-fbbt-array-block-collapse` (PR #424). Root cause
+  is the block-granular FBBT *seed*, not per-scalar backward propagation (that is
+  already a no-op for arrays). Seed switched to the element-wise union in `fbbt`,
+  `fbbt_with_cutoff`, and the presolve driver (`pass.rs`); characterization tests
+  flipped; Python smoke regressions added. Demonstrated pre-fix invalid envelope:
+  `log(x[1])` on `x=continuous(shape=(2,), lb=[3,-1], ub=[3,5])` produced a rescue
+  envelope over arg box `[3,3]`, **excluding** the feasible argument `4.0`; post-fix
+  the union seed `[-1,5]` straddles 0 → the op is soundly abstained (0 relaxations).
 
 ---
 

--- a/python/discopt/tightening.py
+++ b/python/discopt/tightening.py
@@ -106,8 +106,14 @@ def fbbt_box(model: Model, *, max_iter: int = 20, tol: float = 1e-9) -> BoundTig
     block_ub = np.asarray(block_ub, dtype=np.float64)
 
     # Expand each block's [lo, hi] to its scalar slots; intersect with originals.
-    # The block bound is a valid outer bound for every element of the block, so
-    # the intersection can only tighten — never loosen — and stays sound.
+    # The Rust FBBT engine seeds each block from the element-wise UNION of its
+    # bounds (`seed_block_interval`, C-31), so the returned block interval is a
+    # valid *outer* bound for EVERY element of the block — stamping it onto every
+    # scalar slot and intersecting with the originals can only tighten, never
+    # loosen, and never excludes a feasible point. (Pre-C-31 the engine seeded
+    # from element 0 only, so on a heterogeneous array block this stamp cut the
+    # feasible region of the other elements and could reach the certified LP
+    # dual bound via `_fbbt_argument_box`.)
     new_lb = orig_lb_arr.copy()
     new_ub = orig_ub_arr.copy()
     offset = 0

--- a/python/tests/test_tightening.py
+++ b/python/tests/test_tightening.py
@@ -195,3 +195,92 @@ def test_bilinear_product_equality_skips_when_var_in_remainder():
 
     tl, tu = _run_bilinear_rule(m)
     assert tu[1] == np.inf  # not this rule's pattern; left for other machinery
+
+
+# ─────────────────────────────────────────────────────────────
+# C-31 (P0) — FBBT array-block collapse reaching the certified LP dual bound.
+#
+# The Rust FBBT engine carries one interval per variable BLOCK. Pre-fix it
+# seeded that interval from element 0's bounds and stamped it onto every scalar
+# slot, so on a HETEROGENEOUS per-element array block the box excluded the
+# feasible region of the other elements. That collapsed box reaches the certified
+# LP dual bound via `_fbbt_argument_box` (`milp_relaxation.py`), where an envelope
+# built over a box that excludes feasible arguments is unsound. The fix seeds
+# each block from the element-wise UNION [min lb, max ub] — a valid outer bound
+# for every element — so no feasible point is ever cut. These tests fail on the
+# element-0 seed and pass on the union seed.
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.smoke
+def test_c31_heterogeneous_array_block_not_overtightened():
+    """A heterogeneous array block must keep every element's own feasible range."""
+    m = dm.Model("c31_over")
+    # x[0] ∈ [8,10] (tight), x[1] ∈ [0,10] (free). Element-0 collapse would stamp
+    # [8,10] onto x[1], erasing the feasible region x[1] ∈ [0,8).
+    x = m.continuous("x", shape=(2,), lb=np.array([8.0, 0.0]), ub=np.array([10.0, 10.0]))
+    m.minimize(x[0])
+    m.subject_to(x[1] >= 0.0)
+    res = fbbt_box(m)
+    assert not res.infeasible
+    # The block interval must be a valid outer bound for EVERY element: x[1]'s
+    # feasible point 0.0 must remain inside the box (pre-fix lb[1] was 8.0).
+    feasible_pt = np.array([9.0, 0.0])
+    assert np.all(res.lb - 1e-9 <= feasible_pt), f"cut feasible point, lb={res.lb}"
+    assert np.all(feasible_pt <= res.ub + 1e-9), f"cut feasible point, ub={res.ub}"
+    assert res.lb[1] <= 0.0 + 1e-9, f"C-31: x[1] lb collapsed to element-0, got {res.lb[1]}"
+
+
+@pytest.mark.smoke
+def test_c31_heterogeneous_array_block_no_false_infeasible():
+    """A feasible heterogeneous-block model must not be reported infeasible."""
+    m = dm.Model("c31_infeas")
+    # x[0] fixed at 5; x[1] ∈ [0,3]. x=[5, 0..3] is feasible. Element-0 collapse
+    # stamps [5,5] onto x[1]; intersecting with x[1] <= 3 is empty → false infeasible.
+    x = m.continuous("x", shape=(2,), lb=np.array([5.0, 0.0]), ub=np.array([5.0, 3.0]))
+    m.minimize(x[0])
+    m.subject_to(x[1] <= 3.0)
+    res = fbbt_box(m)
+    assert not res.infeasible, f"C-31: feasible model declared infeasible, lb={res.lb} ub={res.ub}"
+    # The feasible point x=[5, 1] must remain inside the box.
+    feasible_pt = np.array([5.0, 1.0])
+    assert np.all(res.lb - 1e-9 <= feasible_pt)
+    assert np.all(feasible_pt <= res.ub + 1e-9)
+
+
+@pytest.mark.smoke
+def test_c31_fbbt_argument_box_envelope_contains_feasible_arg():
+    """The univariate-rescue envelope (certified LP path) must not exclude a
+    feasible argument of a heterogeneous array block.
+
+    `_collect_univariate_relaxations` builds a McCormick envelope over the FBBT
+    argument box for out-of-domain univariate ops (issue #219 rescue). Pre-fix,
+    a `log` on a heterogeneous array element got element-0's collapsed box, which
+    excluded the element's true feasible arguments → an invalid envelope in the
+    certified LP relaxation. Post-fix the union seed keeps the element's box, so
+    the op either (a) has an envelope whose arg box CONTAINS every feasible
+    argument, or (b) is soundly abstained (dropped) — never an envelope over a
+    box that excludes a feasible argument.
+    """
+    import discopt._jax.milp_relaxation as mr
+    from discopt.modeling import log as dlog
+
+    m = dm.Model("c31_env")
+    # x[0] fixed at [3,3] (in log domain); x[1] raw box [-1,5] straddles 0 → log
+    # out of domain raw → FBBT-rescue path fires. Element-0 collapse would give
+    # the log arg box [3,3], excluding x[1]'s feasible arguments in (0,5].
+    x = m.continuous("x", shape=(2,), lb=np.array([3.0, -1.0]), ub=np.array([3.0, 5.0]))
+    m.minimize(dlog(x[1]) + x[0])
+
+    flat_lb = np.array([3.0, -1.0])
+    flat_ub = np.array([3.0, 5.0])
+    relax, _var_map, _bounds = mr._collect_univariate_relaxations(
+        m, 2, flat_lb, flat_ub, start_col=2
+    )
+    # A feasible argument for x[1] under the model is any value in (0, 5], e.g. 4.0.
+    for r in relax:
+        assert r.arg_lb - 1e-9 <= 4.0 <= r.arg_ub + 1e-9, (
+            f"C-31: univariate-rescue envelope arg box [{r.arg_lb}, {r.arg_ub}] "
+            "excludes the feasible argument 4.0 → invalid envelope in the "
+            "certified LP relaxation"
+        )


### PR DESCRIPTION
## C-31 (P0, GREAT CARE) — FBBT array-block collapse reaching the CERTIFIED LP dual bound

Fixes the broadened C-31 finding from `docs/dev/solver-core-review.md` §1: an FBBT
array-block collapse that feeds an invalid McCormick envelope into the **certified LP
dual bound** (a box that EXCLUDES feasible points → the dual bound can exceed the true
optimum → false optimal). Catastrophic class.

### The bug (verified)

The Rust FBBT engine carries **one interval per variable BLOCK** and resolves every
`Index{base,col}` node — forward *and* backward — to that single shared block interval
(the column is ignored). It seeded that interval from **element 0's** bounds
(`v.lb.first()/v.ub.first()`) and stamped it onto every scalar slot. On a
**heterogeneous** per-element array block this box excludes the feasible region of the
other elements.

Broadened reach: the collapsed box reaches the certified LP dual bound via
`_fbbt_argument_box` (`milp_relaxation.py`). `_collect_univariate_relaxations` builds a
McCormick univariate-rescue envelope over the FBBT argument box; on a heterogeneous
block that box is element-0's, so the envelope **excludes feasible arguments**.

### Repro (before → after)

`log(x[1])` with `x = continuous(shape=(2,), lb=[3,-1], ub=[3,5])`:

| | rescue envelope arg box | contains feasible arg `4.0`? |
|---|---|---|
| **before** | `[3, 3]` (element-0 collapse) | **NO — invalid envelope in certified LP** |
| **after**  | union seed `[-1, 5]` straddles 0 → out of `log` domain → **op abstained** (0 relaxations) | n/a — no unsound envelope emitted |

Also fixed: `fbbt_box` over-tightening (`lb=[8,0],ub=[10,10]` no longer collapses
`x[1]` to `[8,10]`) and false-infeasible (`lb=[5,0],ub=[5,3]` with `x[1]<=3` no longer
declared infeasible).

### The fix (minimal, sound — abstain class per CLAUDE.md §3)

Root cause is the block-granular **seed**, not per-scalar backward propagation:
backward tightening onto an array block is already a no-op (`backward_propagate`'s
`Variable` arm writes only when `size == 1`; the `Index` arm recurses into the
`size > 1` base). So the fix seeds each block from the element-wise **UNION**
`[min lb, max ub]` (`seed_block_interval`), a valid outer bound for every element.
FBBT then only ever *loosens* an array block (union ⊇ element-0 seed) → never cuts a
feasible point, never raises the dual bound above the truth. Where the union leaves an
element out of domain, the univariate collector correctly **abstains** rather than
emitting an envelope over an excluding box.

- `crates/discopt-core/src/presolve/fbbt.rs` — `seed_block_interval`; `fbbt` &
  `fbbt_with_cutoff` seed from the union.
- `crates/discopt-core/src/presolve/pass.rs` — presolve driver (`from_model`,
  `resync_bounds_after_rewrite`) shared the identical collapse; switched to the union.
- `python/discopt/tightening.py` — corrected the now-true "valid outer bound for every
  element" comment.

For a **homogeneous** block the union equals element 0 — a no-op, no lost tightening.
A future per-scalar FBBT (real per-element intervals + Index-column-aware
forward/backward) would recover the tightness this conservative fix gives up; not
required for soundness, tracked separately.

### Tests (fail before, pass after; all sub-second)

- Rust characterization tests **flipped** from asserting the collapse to asserting the
  fix: `c31_array_block_seeds_from_element_union_not_element0`,
  `c31_heterogeneous_block_no_false_infeasible`.
- Python `@pytest.mark.smoke` in `test_tightening.py`:
  `test_c31_heterogeneous_array_block_not_overtightened`,
  `test_c31_heterogeneous_array_block_no_false_infeasible`, and — for the certified
  reach — `test_c31_fbbt_argument_box_envelope_contains_feasible_arg`.

### Gates run

- `cargo test -p discopt-core` — **386 passed, 0 failed**; `cargo clippy` — **0 warnings**
- `pytest -m smoke` — **196 passed, 1 skipped**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**
- `pytest -k "fbbt or envelope or relax or array or tighten"` — **639 passed, 1 skipped**
- `ruff check python/` — clean. (mypy shows only a pre-existing numpy-stub/`python_version`
  env error that reproduces on untouched files.)

Certified-path tightening only ever loosens the box, so no bound can cross the oracle;
`incorrect_count = 0`.

Updates `docs/dev/correctness-issues.md`: C-31 `confirmed` → `fixed`, with Log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
