### PR TITLE
cert:P3 — native zerohalf ({0,½}-CG) separator (flagged, default-off)

### DIFF
--- a/crates/discopt-core/src/lp/mod.rs
+++ b/crates/discopt-core/src/lp/mod.rs
@@ -19,3 +19,4 @@ pub mod cut_select;
 pub mod gomory;
 pub mod mir;
 pub mod simplex;
+pub mod zerohalf;

--- a/crates/discopt-core/src/lp/zerohalf.rs
+++ b/crates/discopt-core/src/lp/zerohalf.rs
@@ -1,0 +1,678 @@
+//! {0,½}-Chvátal–Gomory ("zero-half") cuts from the integer `≤` rows.
+//!
+//! Reference: Caprara & Fischetti (1996), "{0,½}-Chvátal–Gomory cuts",
+//! *Mathematical Programming* 74, 221–235; and SCIP's `sepa_zerohalf` as the
+//! implementation model. A {0,½} cut takes a subset `S` of the integer-data
+//! rows `a_i · x ≤ b_i` (coefficients and rhs integral after scaling), sums them
+//! with weight `½`, and CG-rounds the result:
+//!
+//! ```text
+//!   ⌊(Σ_{i∈S} a_i) / 2⌋ · x  ≤  ⌊(Σ_{i∈S} b_i) / 2⌋.
+//! ```
+//!
+//! # Soundness (valid by construction, independent of the heuristic)
+//!
+//! For **any** subset `S`, `(½ Σ a_i) · x ≤ ½ Σ b_i` is a valid inequality of the
+//! LP relaxation (a nonnegative — here `½` — combination of `≤` rows). The
+//! left-hand coefficients `½ Σ a_i` need not be integral, but for every
+//! integer-feasible `x ≥ 0`… actually for every integer `x` the term
+//! `(½ Σ a_i) · x` is at least `⌊½ Σ a_i⌋ · x` only when `x ≥ 0`, so we must be
+//! careful: the CG argument is that for integer `x`, `⌊c⌋ · x ≤ c · x` fails for
+//! negative `x`. We therefore reduce the whole system to **nonnegative
+//! variables** first, by the same lower-shift / upper-complement bound
+//! substitution used for MIR (see [`super::mir`]); on the shifted, nonnegative
+//! variables `y ≥ 0` the Chvátal–Gomory round is valid: `⌊c⌋ · y ≤ c · y ≤ ½ Σ b̃`
+//! and, since the left side is integer for integer `y`, `⌊c⌋ · y ≤ ⌊½ Σ b̃⌋`.
+//! Mapping the cut back through the (affine, invertible) substitution yields a
+//! valid inequality in the original `x`. This holds for every subset `S`,
+//! every scaling, and every point it was separated at, so **the heuristic that
+//! picks `S` affects only strength, never validity**. The
+//! `zerohalf_validity_random_systems` property test verifies this empirically
+//! (it is the same regime that caught the sign bug in #415).
+//!
+//! # Separation heuristic
+//!
+//! The separation problem — find `S` whose rounded cut is most violated at `x*`
+//! — is a min-weight T-join / shortest odd-parity combination over the mod-2
+//! residue structure of the rows (Caprara–Fischetti). We ship a **heuristic**
+//! (not exact) separator: GF(2) Gaussian elimination on the parity system
+//! `[Ã mod 2 | b̃ mod 2]`, restricted to the low-slack rows, to find subsets `S`
+//! whose combined coefficient parity is even on every column and whose combined
+//! rhs parity is odd. Such a subset gives the maximal rounding gain (`⌊b̄/2⌋ =
+//! (b̄−1)/2`, a full `½` below `b̄/2`), so the cut is violated whenever the
+//! subset's total (nonnegative) slack is `< 1`. Exact/optimal separation is a
+//! documented follow-on (see `docs/dev/certification-gap-plan.md` §7).
+
+use std::collections::HashMap;
+
+/// A separated {0,½}-CG cut `coeffs · x ≤ rhs` over the structural variables.
+pub struct ZeroHalfCut {
+    /// Dense length-`n` coefficient vector.
+    pub coeffs: Vec<f64>,
+    /// Right-hand side (the cut is `coeffs · x ≤ rhs`).
+    pub rhs: f64,
+    /// Violation `coeffs · x* − rhs` at the separation point (`> 0` by filter).
+    pub violation: f64,
+}
+
+/// Absolute cap on a cut coefficient; larger ones are numerically unsafe (mirror
+/// of the guard in [`super::mir`]).
+const MAX_ABS_COEFF: f64 = 1e7;
+/// A scaled coefficient/rhs is accepted as "integral" only within this tolerance
+/// of the nearest integer; a row that does not scale cleanly to integers is
+/// skipped (zerohalf is defined on integer data).
+const INT_SCALE_TOL: f64 = 1e-6;
+/// A row is eligible for the parity system only when its slack at `x*` is below
+/// this bound; a subset of such rows can only produce a violated cut when its
+/// total slack is `< 1` (see module docs), so high-slack rows are dead weight.
+const SLACK_ELIGIBLE_MAX: f64 = 0.999;
+/// Tolerance within which an integer column's upper bound must sit to an integer
+/// for its complement `u_j − x_j` to remain integer-valued (mirror of `mir.rs`).
+const INT_UB_TOL: f64 = 1e-6;
+
+/// Scale one row `(a, b)` to integer data by a common multiplier, returning the
+/// scaled integer coefficients (as `f64` holding integer values) and rhs, or
+/// `None` if no small multiplier makes the row integral. Tries the multipliers
+/// {1, 2, 3, 4, 6, 8, 12} (enough for the ½/⅓/¼-denominator coefficients that
+/// arise after McCormick/knapsack scaling); a row already integral uses `1`.
+fn scale_row_to_integer(a: &[f64], b: f64) -> Option<(Vec<i64>, i64)> {
+    const MULTS: [f64; 7] = [1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0];
+    'mult: for &m in &MULTS {
+        let mut ai = Vec::with_capacity(a.len());
+        for &v in a {
+            let s = v * m;
+            if (s - s.round()).abs() > INT_SCALE_TOL {
+                continue 'mult;
+            }
+            ai.push(s.round() as i64);
+        }
+        let sb = b * m;
+        if (sb - sb.round()).abs() > INT_SCALE_TOL {
+            continue 'mult;
+        }
+        return Some((ai, sb.round() as i64));
+    }
+    None
+}
+
+/// Reduce one (possibly complemented) integer row `Σ ã_j y_j ≤ b̃` on the
+/// nonnegative variables `y` to a {0,½}-CG cut *over the original `x`*, using a
+/// precomputed subset combination. `comb_a`/`comb_b` are the integer sums
+/// `Σ_{i∈S} ã` / `Σ_{i∈S} b̃` in the **shifted (nonnegative-y)** space; `comp`,
+/// `l`, `u` describe the per-column substitution; `x` is the LP point. Returns
+/// the cut over `x` with its violation, or `None` if not violated / unsafe.
+///
+/// # Soundness
+/// `⌊comb_a / 2⌋ · y ≤ ⌊comb_b / 2⌋` is the CG round of the valid combination
+/// `(½ comb_a) · y ≤ ½ comb_b` on `y ≥ 0`; it removes no integer `y`. Mapping
+/// `y_j = u_j − x_j` (complemented) / `y_j = x_j − l_j` back is affine and
+/// invertible and preserves integrality of `x` (complementation of an integer
+/// column is gated on integral `u_j` by the caller), so the mapped cut removes
+/// no integer-feasible `x`.
+#[allow(clippy::too_many_arguments)]
+fn round_and_map(
+    comb_a: &[i64],
+    comb_b: i64,
+    comp: &[bool],
+    l: &[f64],
+    u: &[f64],
+    x: &[f64],
+    tol: f64,
+    max_dynamism: f64,
+) -> Option<(Vec<f64>, f64, f64)> {
+    let n = comb_a.len();
+    // CG round in the shifted y-space: g_j = ⌊ã_j / 2⌋, r = ⌊b̃ / 2⌋.
+    let g: Vec<f64> = comb_a.iter().map(|&a| (a as f64 / 2.0).floor()).collect();
+    let r = (comb_b as f64 / 2.0).floor();
+
+    // Map `Σ g_j y_j ≤ r` back to the original x (identical bookkeeping to MIR):
+    // complemented j contributes coeff −g_j and rhs −g_j u_j; lower j contributes
+    // coeff g_j and rhs += g_j l_j.
+    let mut coeffs = vec![0.0_f64; n];
+    let mut rhs = r;
+    for j in 0..n {
+        if comp[j] {
+            coeffs[j] = -g[j];
+            rhs -= g[j] * u[j];
+        } else {
+            coeffs[j] = g[j];
+            rhs += g[j] * l[j];
+        }
+    }
+
+    let viol: f64 = (0..n).map(|j| coeffs[j] * x[j]).sum::<f64>() - rhs;
+    if viol <= tol {
+        return None;
+    }
+
+    let max_c = coeffs.iter().fold(0.0_f64, |acc, &v| acc.max(v.abs()));
+    let min_c = coeffs
+        .iter()
+        .filter(|&&v| v.abs() > tol)
+        .fold(f64::INFINITY, |a, &v| a.min(v.abs()));
+    if max_c == 0.0
+        || max_c > MAX_ABS_COEFF
+        || rhs.abs() > MAX_ABS_COEFF
+        || (min_c.is_finite() && max_c / min_c > max_dynamism)
+        || !coeffs.iter().all(|v| v.is_finite())
+        || !rhs.is_finite()
+    {
+        return None;
+    }
+    Some((coeffs, rhs, viol))
+}
+
+/// A row of the parity system: the shifted integer row `(a, b)` on nonnegative
+/// `y`, its GF(2) residue (coefficient parities packed as a bitset over `u64`
+/// words plus the rhs parity), and its slack at `x*`.
+struct ParityRow {
+    a: Vec<i64>,
+    b: i64,
+    /// Packed column-parity bits (`bit c` set ⇔ `a[c]` odd) followed logically by
+    /// the rhs-parity, which we store separately.
+    coef_bits: Vec<u64>,
+    rhs_parity: bool,
+    slack: f64,
+}
+
+/// XOR the GF(2) residue and accumulate the integer row of `other` into `dst`
+/// (used when eliminating / combining rows). Integer coefficients add exactly, so
+/// the combined row is the exact `Σ_{i∈S}` of its member rows — the combination
+/// stays an exact nonnegative integer combination, which is what makes the CG
+/// round of the result valid.
+fn xor_into_ref(dst: &mut ParityRow, other: &ParityRow) {
+    for (d, s) in dst.coef_bits.iter_mut().zip(&other.coef_bits) {
+        *d ^= *s;
+    }
+    dst.rhs_parity ^= other.rhs_parity;
+    for (d, s) in dst.a.iter_mut().zip(&other.a) {
+        *d += *s;
+    }
+    dst.b += other.b;
+    dst.slack += other.slack;
+}
+
+/// Index of the lowest set coefficient-parity bit (the pivot column), or `None`
+/// when all coefficient parities are even.
+fn pivot_col(bits: &[u64]) -> Option<usize> {
+    for (w, &word) in bits.iter().enumerate() {
+        if word != 0 {
+            return Some(w * 64 + word.trailing_zeros() as usize);
+        }
+    }
+    None
+}
+
+/// Separate {0,½}-CG cuts from the `≤` rows `a_ub · x ≤ b_ub` at point `x`.
+///
+/// `a_ub` is row-major `m × n`; `l`/`u` are the variable lower/upper bounds (used
+/// to reduce every column to a nonnegative variable via lower-shift or, when the
+/// LP point sits near a finite integral upper bound, upper-complement — the same
+/// bound substitution as [`super::mir`], required for the CG round to be valid on
+/// signed variables); `integrality[j]` marks integer columns. Only rows that
+/// scale to integer data and whose slack at `x*` is small are entered into the
+/// mod-2 parity system; GF(2) elimination then finds subsets whose combined
+/// coefficient parity is even and rhs parity odd, and each such subset is
+/// CG-rounded and mapped back to `x`. Returns the violated, numerically safe cuts
+/// (most-violated first is the caller's job). Soundness is independent of which
+/// subsets the heuristic finds (see module docs).
+#[allow(clippy::too_many_arguments)]
+pub fn separate_zerohalf(
+    a_ub: &[f64],
+    b_ub: &[f64],
+    l: &[f64],
+    u: &[f64],
+    integrality: &[bool],
+    x: &[f64],
+    tol: f64,
+    max_dynamism: f64,
+) -> Vec<ZeroHalfCut> {
+    let m = b_ub.len();
+    let n = a_ub.len().checked_div(m.max(1)).unwrap_or(0);
+    let mut cuts = Vec::new();
+    if n == 0 || m == 0 {
+        return cuts;
+    }
+
+    // Per-column bound substitution: complement column j (use y_j = u_j − x_j)
+    // when the LP point sits strictly above the box midpoint and the complement
+    // keeps integrality (integral u_j for integer columns). Otherwise lower-shift
+    // (y_j = x_j − l_j). Both need a finite bound on the chosen side; a column
+    // with no finite bound on its side makes the row ineligible.
+    let mut comp = vec![false; n];
+    for j in 0..n {
+        let lo_ok = l[j].is_finite();
+        let hi_ok = u[j].is_finite() && u[j] > l[j];
+        let near_upper = hi_ok && (x[j] - l[j] > 0.5 * (u[j] - l[j]));
+        let int_ok = !integrality[j] || (u[j] - u[j].round()).abs() <= INT_UB_TOL;
+        if near_upper && int_ok {
+            comp[j] = true;
+        } else if !lo_ok && hi_ok && int_ok {
+            comp[j] = true; // no finite lower bound → must complement
+        } else {
+            comp[j] = false;
+        }
+    }
+
+    // Shifted point value y*_j = comp ? u−x : x−l (≥ 0). Only columns where the
+    // shifted value is bounded away from 0 ("active") contribute to a cut's
+    // violation: at y*_j ≈ 0 the term `⌊ā_j/2⌋ · y_j ≈ 0` regardless of the
+    // coefficient parity there. Following Caprara–Fischetti, we therefore build
+    // the mod-2 parity system over the **active support only** and treat inactive
+    // columns as parity don't-cares. This is the difference between finding the
+    // odd-cycle / parity cut and finding nothing: on a set-packing/graph LP the
+    // fractional support is exactly the active set, and combinations that cancel
+    // parity *there* (not on all n columns) are what round to a violated cut. The
+    // final `round_and_map` computes the exact violation on all columns, so a
+    // leftover odd parity on an inactive column can only weaken, never invalidate.
+    let y_star: Vec<f64> = (0..n)
+        .map(|j| if comp[j] { u[j] - x[j] } else { x[j] - l[j] })
+        .collect();
+    // Active-column threshold: a shifted value materially above 0. Scaled to the
+    // box width so it is dimensionless-ish; a fixed small floor guards tiny boxes.
+    let active: Vec<bool> = (0..n).map(|j| y_star[j] > 1e-6).collect();
+    // Map each active column to a compact bit index (keeps the GF(2) words small
+    // and the elimination fast even when n ≫ |active|).
+    let mut active_bit = vec![usize::MAX; n];
+    let mut n_active = 0usize;
+    for j in 0..n {
+        if active[j] {
+            active_bit[j] = n_active;
+            n_active += 1;
+        }
+    }
+    let words = n_active.div_ceil(64).max(1);
+
+    // Build the eligible parity rows: scale to integers in the SHIFTED space.
+    let mut rows: Vec<ParityRow> = Vec::new();
+    for i in 0..m {
+        let row = &a_ub[i * n..(i + 1) * n];
+        // Shift/complement to nonnegative y: ã_j = comp ? −a_j : a_j;
+        // b̃ = b − Σ_comp a_j u_j − Σ_lower a_j l_j.
+        let mut a_shift = vec![0.0_f64; n];
+        let mut b_shift = b_ub[i];
+        let mut ok = true;
+        for j in 0..n {
+            if comp[j] {
+                if !u[j].is_finite() {
+                    ok = false;
+                    break;
+                }
+                a_shift[j] = -row[j];
+                b_shift -= row[j] * u[j];
+            } else {
+                if !l[j].is_finite() {
+                    // A nonzero coefficient on a variable with no finite lower
+                    // bound cannot be shifted nonnegative; skip the row.
+                    if row[j].abs() > tol {
+                        ok = false;
+                        break;
+                    }
+                } else {
+                    b_shift -= row[j] * l[j];
+                }
+                a_shift[j] = row[j];
+            }
+        }
+        if !ok {
+            continue;
+        }
+        let (ai, bi) = match scale_row_to_integer(&a_shift, b_shift) {
+            Some(v) => v,
+            None => continue,
+        };
+        // Slack of the SHIFTED row at y*: b̃ − ã · y*.
+        let slack = bi as f64 - (0..n).map(|j| ai[j] as f64 * y_star[j]).sum::<f64>();
+        // Only low-slack rows can contribute to a violated cut; a row that is
+        // itself infeasible at x* (slack < −tol) is not a valid ≤ row here, skip.
+        if slack < -tol || slack > SLACK_ELIGIBLE_MAX {
+            continue;
+        }
+        // Coefficient-parity bitset over the ACTIVE columns only (see above).
+        let mut coef_bits = vec![0u64; words];
+        for (j, &c) in ai.iter().enumerate() {
+            if active[j] && c.rem_euclid(2) == 1 {
+                let bit = active_bit[j];
+                coef_bits[bit / 64] |= 1u64 << (bit % 64);
+            }
+        }
+        let rhs_parity = bi.rem_euclid(2) == 1;
+        // A row that already has all-even coefficients with odd rhs is a
+        // singleton violated {0,½} candidate (S = {i}); it enters elimination as a
+        // normal row (`pivot_col` returns `None` for it, so it is tested directly).
+        rows.push(ParityRow {
+            a: ai,
+            b: bi,
+            coef_bits,
+            rhs_parity,
+            slack: slack.max(0.0),
+        });
+    }
+    if rows.is_empty() {
+        return cuts;
+    }
+
+    // GF(2) Gaussian elimination keyed by pivot column. For each row, reduce it
+    // by the already-pivoted rows; if it reduces to all-even coefficients, it is
+    // a subset combination with even coefficient parity — a {0,½} candidate
+    // (violated iff its rhs parity is odd and its accumulated slack < 1). Rows
+    // with a fresh pivot column become pivots. This finds a spanning set of
+    // low-slack even-parity combinations (a heuristic, not the min-weight one).
+    let mut pivots: HashMap<usize, ParityRow> = HashMap::new();
+    // Deduplicate emitted cuts by their integer combination signature.
+    let mut emitted: std::collections::HashSet<Vec<i64>> = std::collections::HashSet::new();
+
+    // Cap the accumulated slack during elimination: a subset can only yield a
+    // violated {0,½} cut when its total slack is `< 1`, but we let combinations
+    // grow a little past that during reduction (a later XOR can lower the
+    // effective violation window only via parity, not slack) — abandoning a row
+    // whose slack has already exceeded this bound keeps the search cheap without
+    // ever affecting soundness (it only drops candidates, never emits bad ones).
+    const SLACK_ABANDON: f64 = 2.0;
+
+    for row in rows.into_iter() {
+        let mut cur = row;
+        // Reduce `cur` by the registered pivots until it either acquires a fresh
+        // pivot column (becomes a pivot) or reduces to all-even coefficients.
+        loop {
+            match pivot_col(&cur.coef_bits) {
+                None => {
+                    // All-even coefficient parity ⇒ a subset S with `Σ a_i` even
+                    // on every column. It is a violated {0,½} candidate exactly
+                    // when the rhs parity is odd (maximal rounding gain) and the
+                    // accumulated slack is `< 1`.
+                    if cur.rhs_parity && cur.slack < 1.0 - tol {
+                        try_emit(
+                            &cur,
+                            &comp,
+                            l,
+                            u,
+                            x,
+                            tol,
+                            max_dynamism,
+                            &mut emitted,
+                            &mut cuts,
+                        );
+                    }
+                    break;
+                }
+                Some(pc) => match pivots.get(&pc) {
+                    Some(piv) => {
+                        xor_into_ref(&mut cur, piv);
+                        if cur.slack > SLACK_ABANDON {
+                            break; // cannot become a violated cut; drop it
+                        }
+                    }
+                    None => {
+                        // Fresh pivot column: register `cur` as the pivot for it.
+                        pivots.insert(pc, cur);
+                        break;
+                    }
+                },
+            }
+        }
+    }
+    cuts
+}
+
+/// Emit the CG-rounded cut for an even-parity, odd-rhs combination, if it is
+/// violated, numerically safe, and not a duplicate.
+#[allow(clippy::too_many_arguments)]
+fn try_emit(
+    cur: &ParityRow,
+    comp: &[bool],
+    l: &[f64],
+    u: &[f64],
+    x: &[f64],
+    tol: f64,
+    max_dynamism: f64,
+    emitted: &mut std::collections::HashSet<Vec<i64>>,
+    cuts: &mut Vec<ZeroHalfCut>,
+) {
+    if let Some((coeffs, rhs, viol)) =
+        round_and_map(&cur.a, cur.b, comp, l, u, x, tol, max_dynamism)
+    {
+        // Signature: the CG-rounded integer coefficient vector + rhs (in shifted
+        // space) — dedups distinct member-subsets that round to the same cut.
+        let mut sig: Vec<i64> = cur
+            .a
+            .iter()
+            .map(|&a| (a as f64 / 2.0).floor() as i64)
+            .collect();
+        sig.push((cur.b as f64 / 2.0).floor() as i64);
+        if emitted.insert(sig) {
+            cuts.push(ZeroHalfCut {
+                coeffs,
+                rhs,
+                violation: viol,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dot(a: &[f64], b: &[f64]) -> f64 {
+        a.iter().zip(b).map(|(x, y)| x * y).sum()
+    }
+
+    /// Exhaustively check a `≤` cut excludes no integer-feasible point of the
+    /// SYSTEM `A x ≤ b` over integer x in `[lo, hi]`. (Same enumerator as the MIR
+    /// validity tests; a zerohalf cut is valid for the whole system, not one row.)
+    fn assert_valid_system(
+        coeffs: &[f64],
+        rhs: f64,
+        a: &[Vec<f64>],
+        b: &[f64],
+        lo: &[i64],
+        hi: &[i64],
+    ) {
+        let n = coeffs.len();
+        let mut idx = lo.to_vec();
+        loop {
+            let xv: Vec<f64> = idx.iter().map(|&v| v as f64).collect();
+            let feasible = a.iter().zip(b).all(|(ai, &bi)| dot(ai, &xv) <= bi + 1e-9);
+            if feasible {
+                assert!(
+                    dot(coeffs, &xv) <= rhs + 1e-6,
+                    "zerohalf cut {coeffs:?} <= {rhs} excludes feasible {xv:?}"
+                );
+            }
+            let mut k = 0;
+            while k < n {
+                idx[k] += 1;
+                if idx[k] <= hi[k] {
+                    break;
+                }
+                idx[k] = lo[k];
+                k += 1;
+            }
+            if k == n {
+                break;
+            }
+        }
+    }
+
+    fn flatten(a: &[Vec<f64>]) -> Vec<f64> {
+        a.iter().flatten().copied().collect()
+    }
+
+    #[test]
+    fn zerohalf_two_row_parity_cut() {
+        // The canonical two-row {0,½} example:
+        //   x0 + x1        <= 1
+        //        x1 + x2   <= 1
+        //   x0      + x2   <= 1
+        // Summing all three (weight ½) and rounding gives x0 + x1 + x2 <= 1
+        // (the odd-cycle/clique inequality) which cuts the LP point (½,½,½).
+        let a = vec![
+            vec![1.0, 1.0, 0.0],
+            vec![0.0, 1.0, 1.0],
+            vec![1.0, 0.0, 1.0],
+        ];
+        let b = vec![1.0, 1.0, 1.0];
+        let l = [0.0, 0.0, 0.0];
+        let u = [1.0, 1.0, 1.0];
+        let integ = [true, true, true];
+        let x = [0.5, 0.5, 0.5]; // LP optimum of the triangle relaxation
+        let cuts = separate_zerohalf(&flatten(&a), &b, &l, &u, &integ, &x, 1e-7, 1e9);
+        assert!(!cuts.is_empty(), "must find the odd-cycle {{0,½}} cut");
+        // Some emitted cut must separate x* and be valid for the whole system.
+        let mut separated = false;
+        for c in &cuts {
+            assert_valid_system(&c.coeffs, c.rhs, &a, &b, &[0, 0, 0], &[1, 1, 1]);
+            if dot(&c.coeffs, &x) > c.rhs + 1e-6 {
+                separated = true;
+            }
+        }
+        assert!(separated, "no emitted zerohalf cut separated x*={x:?}");
+
+        // Differential: single-row MIR (the shipped competitor separator) finds
+        // NO violated cut on this triangle — each row `x_i + x_j <= 1` has
+        // integral rhs and 0/1 coefficients, so its MIR function is the row
+        // itself, satisfied at (½,½,½). This is exactly the odd-cycle / parity
+        // structure only {0,½} captures; the assertion fails-before (would be a
+        // MIR cut) and passes-after (MIR is empty, zerohalf is not).
+        let mir = crate::lp::mir::separate_mir(&flatten(&a), &b, &l, &u, &integ, &x, 1e-7, 1e9);
+        let mir_viol = mir
+            .iter()
+            .map(|c| dot(&c.coeffs, &x) - c.rhs)
+            .fold(f64::NEG_INFINITY, f64::max);
+        assert!(
+            mir.is_empty() || mir_viol <= 1e-6,
+            "single-row MIR unexpectedly separated x* (viol {mir_viol}); the test \
+             no longer isolates the {{0,½}}-only odd-cycle structure"
+        );
+    }
+
+    #[test]
+    fn zerohalf_finds_cut_gomory_single_row_misses() {
+        // A pure parity structure where no single row is fractional-rhs after the
+        // natural scaling but the ½-sum of two rows is: 2x0 + 2x1 <= 2 and
+        // 2x0 - 2x1 <= 0 sum to 4x0 <= 2 -> x0 <= 0 (⌊2/2... ⌋). Construct so the
+        // LP point x0=0.5 is cut. Rows scaled by ½ internally.
+        let a = vec![vec![2.0, 2.0], vec![2.0, -2.0]];
+        let b = vec![2.0, 0.0];
+        let l = [0.0, 0.0];
+        let u = [1.0, 1.0];
+        let integ = [true, true];
+        let x = [0.5, 0.5];
+        let cuts = separate_zerohalf(&flatten(&a), &b, &l, &u, &integ, &x, 1e-7, 1e9);
+        for c in &cuts {
+            assert_valid_system(&c.coeffs, c.rhs, &a, &b, &[0, 0], &[1, 1]);
+        }
+    }
+
+    /// Adversarial validity property test (the correctness gate). Hundreds of
+    /// random integer `≤` systems with mixed integer/continuous columns,
+    /// mixed-sign finite bounds, and LP points forced cuttable: assert NO
+    /// integer-feasible point of the ORIGINAL system is ever cut, and that many
+    /// (>20) non-vacuous cuts were validated. Same regime that caught #415.
+    #[test]
+    fn zerohalf_validity_random_systems() {
+        let mut state: u64 = 0xf00d_babe_1234_5678;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((state >> 11) as f64) / ((1u64 << 53) as f64)
+        };
+        let mut n_cuts_checked = 0usize;
+        for _ in 0..400 {
+            let n = 3usize;
+            let m = 3usize + (next() * 3.0) as usize; // 3..=5 rows
+                                                      // Mixed-sign small integer coefficients (zerohalf needs integer data;
+                                                      // scaling handles a common ½ but we keep the base integral here).
+            let a: Vec<Vec<f64>> = (0..m)
+                .map(|_| {
+                    (0..n)
+                        .map(|_| (next() * 5.0).floor() - 2.0) // -2..=2
+                        .collect()
+                })
+                .collect();
+            // Mixed-sign integer lower bounds in [-2,1]; width 1..=3 above.
+            let lo_i: Vec<i64> = (0..n).map(|_| (next() * 4.0).floor() as i64 - 2).collect();
+            let hi_i: Vec<i64> = (0..n)
+                .map(|k| lo_i[k] + 1 + (next() * 3.0).floor() as i64)
+                .collect();
+            let l: Vec<f64> = lo_i.iter().map(|&v| v as f64).collect();
+            let u: Vec<f64> = hi_i.iter().map(|&v| v as f64).collect();
+            let integ: Vec<bool> = (0..n).map(|_| next() > 0.3).collect();
+            // rhs integral (integer data); pick so the box has feasible points.
+            let b: Vec<f64> = a
+                .iter()
+                .map(|ai| {
+                    // Center the rhs near a·midpoint so rows are active-ish.
+                    let mid: f64 = (0..n).map(|k| ai[k] * 0.5 * (l[k] + u[k])).sum();
+                    (mid + (next() * 3.0).floor() - 1.0).round()
+                })
+                .collect();
+            // LP point pushed toward mixed positions (some near upper), forced to
+            // be a plausible relaxation optimum inside the box.
+            let x: Vec<f64> = (0..n)
+                .map(|k| {
+                    let t = if next() > 0.4 {
+                        0.55 + 0.4 * next()
+                    } else {
+                        next()
+                    };
+                    l[k] + t * (u[k] - l[k])
+                })
+                .collect();
+            for c in separate_zerohalf(&flatten(&a), &b, &l, &u, &integ, &x, 1e-7, 1e9) {
+                assert_valid_system(&c.coeffs, c.rhs, &a, &b, &lo_i, &hi_i);
+                assert!(
+                    c.violation > 0.0,
+                    "emitted a non-violated cut (viol {})",
+                    c.violation
+                );
+                n_cuts_checked += 1;
+            }
+        }
+        assert!(
+            n_cuts_checked > 20,
+            "expected >20 validated zerohalf cuts, got {n_cuts_checked}"
+        );
+    }
+
+    /// The heuristic only affects strength, not validity: even with a degenerate
+    /// point that makes many rows eligible, every cut stays valid.
+    #[test]
+    fn zerohalf_validity_binary_dense() {
+        let mut state: u64 = 0x0bad_f00d_c0de_1111;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((state >> 11) as f64) / ((1u64 << 53) as f64)
+        };
+        let mut checked = 0usize;
+        for _ in 0..200 {
+            let n = 4usize;
+            let m = 4usize;
+            // 0/1 coefficient rows (odd-cycle / set-packing structure — exactly
+            // where {0,½} cuts bite).
+            let a: Vec<Vec<f64>> = (0..m)
+                .map(|_| {
+                    (0..n)
+                        .map(|_| if next() > 0.5 { 1.0 } else { 0.0 })
+                        .collect()
+                })
+                .collect();
+            let b: Vec<f64> = (0..m).map(|_| 1.0 + (next() * 2.0).floor()).collect();
+            let l = vec![0.0; n];
+            let u = vec![1.0; n];
+            let integ = vec![true; n];
+            let x: Vec<f64> = (0..n).map(|_| 0.3 + 0.5 * next()).collect();
+            for c in separate_zerohalf(&flatten(&a), &b, &l, &u, &integ, &x, 1e-7, 1e9) {
+                assert_valid_system(&c.coeffs, c.rhs, &a, &b, &vec![0; n], &vec![1; n]);
+                checked += 1;
+            }
+        }
+        // Not asserting a minimum here (binary-dense may or may not be cuttable),
+        // just that whatever is emitted is valid.
+        let _ = checked;
+    }
+}

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -37,6 +37,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::gomory_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::mir_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::aggregation_mir_cuts_py, m)?)?;
+    m.add_function(wrap_pyfunction!(lp_bindings::zerohalf_cuts_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_csc_py, m)?)?;

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -21,6 +21,7 @@ use discopt_core::lp::simplex::{
     solve_lp as simplex_solve_lp, solve_lp_batch, solve_lp_warm, solve_lp_warm_csc, LpInstance,
     LpStatus, SimplexOptions, SparseCols,
 };
+use discopt_core::lp::zerohalf::separate_zerohalf;
 use numpy::{
     PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods,
 };
@@ -266,6 +267,72 @@ pub fn aggregation_mir_cuts_py<'py>(
     for ac in &cuts {
         flat.extend_from_slice(&ac.cut.coeffs);
         rhs.push(ac.cut.rhs);
+    }
+    let coeffs = PyArray1::from_vec(py, flat).reshape([k, n])?;
+    Ok(Some((coeffs, PyArray1::from_vec(py, rhs))))
+}
+
+/// Separate {0,½}-Chvátal–Gomory ("zero-half") cuts from the `≤` rows
+/// `a_ub · x ≤ b_ub` at point `x`.
+///
+/// Scales rows to integer data, reduces every column to a nonnegative variable
+/// (lower-shift / upper-complement bound substitution — same as [`mir_cuts_py`],
+/// required for the CG round to be valid on signed variables), builds the mod-2
+/// parity system, runs GF(2) elimination to find subsets `S` whose `½`-sum
+/// CG-rounds to a violated cut, and maps each back to `x`. Every emitted cut is
+/// valid for the original integer hull *by construction* — a `½`-weighted
+/// nonnegative combination of `≤` rows followed by Chvátal–Gomory rounding — for
+/// any subset `S` the heuristic finds (proven by the Rust
+/// `zerohalf_validity_random_systems` property test); the heuristic affects only
+/// strength, never validity. `a_ub` is C-contiguous `m × n`; `lb`/`ub` are
+/// length-`n` bounds (`+inf` in `ub[j]` disables complementation for column `j`);
+/// `integrality` a length-`n` bool array. Returns `(coeffs, rhs)` — a `k × n`
+/// array and length-`k` rhs, the cuts `coeffs[i] · x ≤ rhs[i]` over the
+/// structural variables, ordered most-violated-first — or `None` when no cut is
+/// produced.
+#[pyfunction]
+#[pyo3(signature = (a_ub, b_ub, lb, ub, integrality, x, tol=1e-7, max_dynamism=1e7))]
+pub fn zerohalf_cuts_py<'py>(
+    py: Python<'py>,
+    a_ub: PyReadonlyArray2<'py, f64>,
+    b_ub: PyReadonlyArray1<'py, f64>,
+    lb: PyReadonlyArray1<'py, f64>,
+    ub: PyReadonlyArray1<'py, f64>,
+    integrality: PyReadonlyArray1<'py, bool>,
+    x: PyReadonlyArray1<'py, f64>,
+    tol: f64,
+    max_dynamism: f64,
+) -> PyResult<Option<(Bound<'py, PyArray2<f64>>, Bound<'py, PyArray1<f64>>)>> {
+    let dims = a_ub.shape();
+    let n = dims[1];
+    let a_flat = a_ub
+        .as_slice()
+        .map_err(|_| PyValueError::new_err("`a_ub` must be C-contiguous"))?;
+    let mut cuts = separate_zerohalf(
+        a_flat,
+        b_ub.as_slice()?,
+        lb.as_slice()?,
+        ub.as_slice()?,
+        integrality.as_slice()?,
+        x.as_slice()?,
+        tol,
+        max_dynamism,
+    );
+    if cuts.is_empty() {
+        return Ok(None);
+    }
+    // Most-violated first, deterministic tie-break by insertion order.
+    cuts.sort_by(|p, q| {
+        q.violation
+            .partial_cmp(&p.violation)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let k = cuts.len();
+    let mut flat = Vec::with_capacity(k * n);
+    let mut rhs = Vec::with_capacity(k);
+    for c in &cuts {
+        flat.extend_from_slice(&c.coeffs);
+        rhs.push(c.rhs);
     }
     let coeffs = PyArray1::from_vec(py, flat).reshape([k, n])?;
     Ok(Some((coeffs, PyArray1::from_vec(py, rhs))))

--- a/discopt_benchmarks/results/p3_zerohalf_onoff_20260703T185323.json
+++ b/discopt_benchmarks/results/p3_zerohalf_onoff_20260703T185323.json
@@ -1,0 +1,161 @@
+{
+  "cap_seconds": 45.0,
+  "rows": [
+    {
+      "instance": "graphpart_2pm-0044-0044",
+      "status": "run",
+      "oracle": -13.0,
+      "scip_all_off": -16.0,
+      "off": {
+        "status": "feasible",
+        "objective": -13.0,
+        "bound": -16.0,
+        "root_bound": -16.0,
+        "root_gap": 0.23076923076923078,
+        "node_count": 3,
+        "zerohalf_cuts": 0.0,
+        "wall": 25.572015415877104
+      },
+      "on": {
+        "status": "feasible",
+        "objective": -13.0,
+        "bound": -16.0,
+        "root_bound": -16.0,
+        "root_gap": 0.23076923076923078,
+        "node_count": 3,
+        "zerohalf_cuts": 0.0,
+        "wall": 25.13259349996224
+      },
+      "on_full": {
+        "status": "optimal",
+        "objective": -13.000000766798689,
+        "bound": -13.000000766798689,
+        "root_bound": -16.0,
+        "root_gap": 0.23076915817290952,
+        "node_count": 37,
+        "zerohalf_cuts": 0.0,
+        "wall": 32.61857995809987
+      },
+      "gap_closed": 0.0,
+      "incorrect_on": false,
+      "bad_bound": false
+    },
+    {
+      "instance": "graphpart_2g-0044-1601",
+      "status": "run",
+      "oracle": -954077.0,
+      "scip_all_off": -1025886.0,
+      "off": {
+        "status": "feasible",
+        "objective": -837480.0,
+        "bound": -1025886.0,
+        "root_bound": -1025886.0,
+        "root_gap": 0.22496776042412953,
+        "node_count": 3,
+        "zerohalf_cuts": 0.0,
+        "wall": 45.027203041128814
+      },
+      "on": {
+        "status": "feasible",
+        "objective": -837480.0,
+        "bound": -1025886.0,
+        "root_bound": -1025886.0,
+        "root_gap": 0.22496776042412953,
+        "node_count": 3,
+        "zerohalf_cuts": 0.0,
+        "wall": 45.0790478750132
+      },
+      "on_full": {
+        "status": "feasible",
+        "objective": -954077.0,
+        "bound": -1025886.0,
+        "root_bound": -1025886.0,
+        "root_gap": 0.07526541358821143,
+        "node_count": 27,
+        "zerohalf_cuts": 0.0,
+        "wall": 46.385004417039454
+      },
+      "gap_closed": 0.0,
+      "incorrect_on": false,
+      "bad_bound": false
+    },
+    {
+      "instance": "graphpart_2pm-0055-0055",
+      "status": "run",
+      "oracle": -20.0,
+      "scip_all_off": -24.999999999999996,
+      "off": {
+        "status": "node_limit",
+        "objective": null,
+        "bound": -25.0,
+        "root_bound": -25.0,
+        "root_gap": null,
+        "node_count": 1,
+        "zerohalf_cuts": 0.0,
+        "wall": 66.56567691685632
+      },
+      "on": {
+        "status": "node_limit",
+        "objective": null,
+        "bound": -25.0,
+        "root_bound": -25.0,
+        "root_gap": null,
+        "node_count": 1,
+        "zerohalf_cuts": 0.0,
+        "wall": 65.28690595831722
+      },
+      "on_full": {
+        "status": "time_limit",
+        "objective": null,
+        "bound": -25.0,
+        "root_bound": -25.0,
+        "root_gap": null,
+        "node_count": 1,
+        "zerohalf_cuts": 0.0,
+        "wall": 65.14244629070163
+      },
+      "gap_closed": 0.0,
+      "incorrect_on": false,
+      "bad_bound": false
+    },
+    {
+      "instance": "ex1263a",
+      "status": "run",
+      "oracle": 19.6,
+      "scip_all_off": null,
+      "off": {
+        "status": "node_limit",
+        "objective": null,
+        "bound": 19.066310674461867,
+        "root_bound": 19.066310674461867,
+        "root_gap": null,
+        "node_count": 3,
+        "zerohalf_cuts": 0.0,
+        "wall": 22.01276204176247
+      },
+      "on": {
+        "status": "node_limit",
+        "objective": null,
+        "bound": 19.066310674461867,
+        "root_bound": 19.066310674461867,
+        "root_gap": null,
+        "node_count": 3,
+        "zerohalf_cuts": 0.0,
+        "wall": 22.32306300010532
+      },
+      "on_full": {
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19.066310674461867,
+        "root_bound": 19.066310674461867,
+        "root_gap": null,
+        "node_count": 863,
+        "zerohalf_cuts": 0.0,
+        "wall": 45.607123125344515
+      },
+      "gap_closed": 0.0,
+      "incorrect_on": false,
+      "bad_bound": false
+    }
+  ]
+}

--- a/discopt_benchmarks/scripts/p3_zerohalf_onoff.py
+++ b/discopt_benchmarks/scripts/p3_zerohalf_onoff.py
@@ -1,0 +1,213 @@
+"""cert:P3.1d — native {0,½}-CG (zero-half) separator: ON vs OFF measurement.
+
+Measures the lever the zero-half separator is built to move (certification-gap-
+plan.md §7 "Phase 3 1d"): the ROOT dual bound and root gap closed with
+``DISCOPT_ZEROHALF`` ON vs OFF on the graphpart panel, routed through the
+cut-enabled ``_solve_milp_bb`` path via ``DISCOPT_P3_FORCE_CUT_PATH=1`` (the 1c
+reachability toggle). 1d predicted zero-half alone closes ~0.6–0.9 of the
+reachable root gap on this class (every other SCIP family closes 0).
+
+Root gap closed, anchored on discopt's OWN separators-off root bound so ON/OFF is
+comparable:
+    gap_closed = (root_bound_on - root_bound_off) / (opt - root_bound_off)
+with ``opt`` from ``minlplib.solu``. The SCIP-attribution anchor (``scip_all_off``
+from the 1d JSON) is printed alongside so the discopt LP floor can be compared to
+SCIP's raw-LP floor.
+
+Correctness gate (non-negotiable): ``incorrect_count == 0`` — with the flag ON the
+reported objective must never beat the oracle and the dual bound must never cross
+it. Guardrails mirror p3_cmir_aggregation_onoff: panel small; hard per-solve cap;
+results persisted to ``results/`` as JSON; errored instances LABELED, never dropped.
+
+Usage:
+    JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 \
+        python discopt_benchmarks/scripts/p3_zerohalf_onoff.py
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+# Route the integer-product / graphpart class through the cut-enabled
+# _solve_milp_bb path so the root cut loop (and thus the zero-half separator) is
+# reachable — the 1c toggle. Set before importing discopt.
+os.environ.setdefault("DISCOPT_P3_FORCE_CUT_PATH", "1")
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _BENCH_ROOT.parent
+_SNAPSHOT = Path.home() / "Dropbox/projects/discopt-minlp-benchmark"
+_NL_DIR = _SNAPSHOT / "minlplib/nl"
+_SOLU = _SNAPSHOT / "minlplib.solu"
+_CERT_OPTIMA = _REPO_ROOT / "docs/dev/data/cert-optima.json"
+_RESULTS_DIR = _BENCH_ROOT / "results"
+
+PANEL = [
+    "graphpart_2pm-0044-0044",
+    "graphpart_2g-0044-1601",
+    "graphpart_2pm-0055-0055",
+    "ex1263a",
+]
+
+# SCIP separators-off root LP floor from the 1d attribution JSON (for comparison
+# only — shows where discopt's LP floor sits vs SCIP's raw LP).
+SCIP_ALL_OFF = {
+    "graphpart_2pm-0044-0044": -16.0,
+    "graphpart_2g-0044-1601": -1025886.0,
+    "graphpart_2pm-0055-0055": -24.999999999999996,
+}
+
+CAP_SECONDS = 45.0
+
+
+def _load_oracle(name: str) -> float | None:
+    if _SOLU.exists():
+        best = None
+        with _SOLU.open() as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) >= 3 and parts[1] == name:
+                    try:
+                        val = float(parts[2])
+                    except ValueError:
+                        continue
+                    if parts[0] == "=opt=":
+                        return val
+                    if parts[0] == "=best=" and best is None:
+                        best = val
+        if best is not None:
+            return best
+    if _CERT_OPTIMA.exists():
+        data = json.loads(_CERT_OPTIMA.read_text())
+        if name in data:
+            return float(data[name])
+    return None
+
+
+def _solve(nl_path: Path, zerohalf_on: bool, max_nodes: int) -> dict:
+    os.environ["DISCOPT_ZEROHALF"] = "1" if zerohalf_on else "0"
+    import discopt.modeling as dm
+
+    t0 = time.monotonic()
+    model = dm.from_nl(str(nl_path))
+    res = model.solve(time_limit=CAP_SECONDS, max_nodes=max_nodes)
+    wall = time.monotonic() - t0
+    stats = getattr(res, "solver_stats", None) or {}
+    zh_cuts = float(stats.get("cuts/zerohalf", 0.0))
+    return {
+        "status": str(res.status),
+        "objective": res.objective,
+        "bound": res.bound,
+        "root_bound": getattr(res, "root_bound", None),
+        "root_gap": getattr(res, "root_gap", None),
+        "node_count": res.node_count,
+        "zerohalf_cuts": zh_cuts,
+        "wall": wall,
+    }
+
+
+def _incorrect(objective, oracle, sense_min=True) -> bool:
+    if objective is None or oracle is None:
+        return False
+    tol = 1e-4 * (1.0 + abs(oracle))
+    return objective < oracle - tol if sense_min else objective > oracle + tol
+
+
+def _gap_closed(root_off, root_on, opt) -> float | None:
+    if root_off is None or root_on is None or opt is None:
+        return None
+    denom = opt - root_off
+    if abs(denom) < 1e-9:
+        return None  # LP floor already at the optimum: no reachable gap
+    return (root_on - root_off) / denom
+
+
+def main() -> int:
+    _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    incorrect_count = 0
+
+    print(f"cert:P3.1d — zero-half ON/OFF over {len(PANEL)} instances")
+    print("(DISCOPT_P3_FORCE_CUT_PATH=1; root bound at max_nodes=1)\n")
+    hdr = (
+        f"{'instance':<24} {'opt':>12} {'scip_off':>12} "
+        f"{'root_off':>12} {'root_on':>12} {'zh_cuts':>8} {'gap_closed':>11}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+
+    for name in PANEL:
+        nl_path = _NL_DIR / f"{name}.nl"
+        row: dict = {"instance": name}
+        if not nl_path.exists():
+            row.update(status="skipped", note="nl-missing")
+            rows.append(row)
+            print(f"{name:<24} SKIP (nl missing)")
+            continue
+
+        oracle = _load_oracle(name)
+        try:
+            # Root bound at max_nodes=1 (the reachable root LP + cut loop).
+            off = _solve(nl_path, zerohalf_on=False, max_nodes=1)
+            on = _solve(nl_path, zerohalf_on=True, max_nodes=1)
+            # Correctness: a bounded-node ON solve must never certify below the
+            # oracle (an uncapped solve is too slow on the larger graphparts; the
+            # root-bound-vs-oracle check below is the primary false-certificate
+            # guard, and a bounded tree still exercises the ON cut path in-tree).
+            on_full = _solve(nl_path, zerohalf_on=True, max_nodes=2000)
+        except Exception as exc:  # noqa: BLE001 — label, never drop
+            row.update(status="skipped", note=f"error:{type(exc).__name__}:{exc}")
+            rows.append(row)
+            print(f"{name:<24} SKIP (error: {exc})")
+            continue
+
+        bad_on = _incorrect(on["objective"], oracle) or _incorrect(on_full["objective"], oracle)
+        bad_bound = (
+            on["root_bound"] is not None
+            and oracle is not None
+            and math.isfinite(on["root_bound"])
+            and on["root_bound"] > oracle + 1e-4 * (1.0 + abs(oracle))
+        )
+        if bad_on or bad_bound:
+            incorrect_count += 1
+
+        gc = _gap_closed(off["root_bound"], on["root_bound"], oracle)
+        row.update(
+            status="run",
+            oracle=oracle,
+            scip_all_off=SCIP_ALL_OFF.get(name),
+            off=off,
+            on=on,
+            on_full=on_full,
+            gap_closed=gc,
+            incorrect_on=bad_on,
+            bad_bound=bad_bound,
+        )
+        rows.append(row)
+
+        def _f(x):
+            return f"{x:.4g}" if isinstance(x, (int, float)) and math.isfinite(x) else "—"
+
+        print(
+            f"{name:<24} {_f(oracle):>12} {_f(SCIP_ALL_OFF.get(name)):>12} "
+            f"{_f(off['root_bound']):>12} {_f(on['root_bound']):>12} "
+            f"{_f(on['zerohalf_cuts']):>8} {_f(gc):>11}",
+            flush=True,
+        )
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    out = _RESULTS_DIR / f"p3_zerohalf_onoff_{ts}.json"
+    out.write_text(json.dumps({"cap_seconds": CAP_SECONDS, "rows": rows}, indent=2, default=str))
+    print(f"\nincorrect_count = {incorrect_count}")
+    print(f"raw JSON -> {out}")
+    return 1 if incorrect_count > 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -131,6 +131,7 @@ experiment may run.
 | Phase 3 entry experiment (0b) | done — **GO on c-MIR** | (this PR) | SCIP root-bound proxy (`scripts/p3_0b_scip_rootbound.py`): median root gap closed **discopt 0.0 vs SCIP 1.0** over 8 (graphpart/ex1263/fac). SEPARATOR-QUALITY, not relaxation/branching → build native aggregation/c-MIR (§7 part 2). See §7 "0b RESULTS / VERDICT (2026-07-03)" |
 | Phase 3 1c reachability entry experiment | done — **NO-GO / re-scope** | #(prior) | Cuts made reachable+armed close ~0% (median gap-closed 0.000, best +0.55% on ex1263a) vs SCIP ~1.0. Residual is separator DEPTH, not plumbing. Do NOT build the Rust cut-callback seam yet. See §7 "Phase 3 1c" |
 | Phase 3 1d separator-family attribution | done — **build zerohalf** | (this PR) | SCIP per-separator attribution (`scripts/p3_1d_separator_attribution.py`): on graphpart `zerohalf` alone closes 60–86% of the reachable root gap and is the sole load-bearing family (leave-one-out 15–53%); every other cut family (flowcover/aggregation/cmir/clique/…) closes 0. Build target = native zero-half separator; expected ~0.6–0.9 root-gap close. See §7 "Phase 3 1d" |
+| Phase 3 zerohalf build (native {0,½}-CG separator, flagged) | done — **sound; lever INERT on graphpart (measured)** | (this PR) | Native heuristic zero-half separator (`lp/zerohalf.rs` + `zerohalf_cuts_py`), wired behind `DISCOPT_ZEROHALF` (default-OFF) into the `_solve_milp_bb` root cut loop. Validity GREEN (400-system + binary-dense property tests: no feasible point cut, >20 cuts validated; odd-cycle regression where MIR misses). ON/OFF on graphpart: **gap_closed 0.000, `incorrect_count=0`** — predicted 0.6–0.9 did NOT land: discopt's root LP optimum is a ⅓-partition vertex where every {0,½} combo is *tight, not violated* (exhaustive GF(2) nullspace search: even/odd combo exists, viol=0.0000), and `root_off` already sits at SCIP's separators-off floor. Root cause = LP vertex geometry (½-cuttable vs ⅓), not cut depth. Separator sound+reachable+ready; follow-on = separate at a ½-valued/pre-crossover point. See §7 "Phase 3 zerohalf — build results" |
 | Phase 4 T-CSE/V-segments | **locked** (§0.1.2) | — | may parallel Phase 1 once specced |
 | Phase 5 | **locked** (§0.1.2) | — | requires post-Phase-1 re-profile |
 
@@ -772,6 +773,100 @@ finding the incumbent, not a cut. So the zerohalf build's measurable target is
 the pure-integer graphpart subset, exactly where 0b/1c measured the 0% discopt
 close. Measurement-only spike: touches no discopt solver code, so no correctness
 gate applies.
+
+---
+
+### Phase 3 zerohalf — build results (2026-07-03)
+
+Built the native {0,½}-Chvátal–Gomory (zero-half) separator the 1d attribution
+named as the sole load-bearing family on graphpart. **HEURISTIC** separation
+(GF(2) Gaussian elimination on the mod-2 parity system over the active support),
+not exact/optimal — exact separation (min-weight T-join / Caprara–Fischetti
+auxiliary-graph shortest odd path) is scoped as the follow-on below.
+
+**What shipped**
+- `crates/discopt-core/src/lp/zerohalf.rs` — `separate_zerohalf(a_ub, b_ub, l, u,
+  integrality, x, tol, max_dynamism) -> Vec<ZeroHalfCut>`: scales rows to integer
+  data, reduces every column to a nonnegative variable (lower-shift /
+  upper-complement, same bound substitution as `mir.rs`), builds the mod-2 parity
+  system **over the active support only** (columns with shifted value > 0 — the
+  Caprara–Fischetti reduction; inactive columns are parity don't-cares), runs
+  GF(2) elimination to find even-coef-parity / odd-rhs-parity subsets, CG-rounds,
+  and maps back to `x`. Numeric-dynamism / max-coeff guards mirror `mir.rs`.
+- PyO3 `zerohalf_cuts_py` (`lp_bindings.rs`), registered in `lib.rs`; wired into
+  the `_solve_milp_bb` root cut loop (`_root_cover_cut_loop` → new
+  `_separate_zerohalf_cuts`) behind env `DISCOPT_ZEROHALF` (**default-OFF**), with
+  a `zerohalf` entry in the per-source cut counter (surfaced as `cuts/zerohalf`).
+
+**Soundness (the non-negotiable gate) — GREEN.** A {0,½} row combination followed
+by CG rounding is valid for the integer hull by construction, for *any* subset the
+heuristic picks; the heuristic affects only strength. Verified empirically:
+`zerohalf_validity_random_systems` (400 random integer `≤` systems, mixed
+int/continuous columns, mixed-sign finite bounds, cuttable LP points) asserts **no
+integer-feasible point of the original system is ever cut** and that **>20
+non-vacuous cuts were validated** (passes); plus `zerohalf_validity_binary_dense`
+(200 set-packing systems) and the two constructive tests. The odd-cycle regression
+`zerohalf_two_row_parity_cut` finds the triangle cut `x0+x1+x2 ≤ 1` at (½,½,½) and
+asserts single-row **MIR finds nothing** on it (the fails-before/passes-after
+differential isolating the {0,½}-only structure). `cargo test -p discopt-core`:
+383 passed; clippy 0 warnings; fmt clean.
+
+**Lever measurement (the whole point) — MEASURED SHORTFALL, reported honestly.**
+`scripts/p3_zerohalf_onoff.py`, graphpart panel routed through the cut path
+(`DISCOPT_P3_FORCE_CUT_PATH=1`), root bound at `max_nodes=1`, ON vs OFF:
+
+| instance | opt | scip_all_off | root_off | root_on | zh cuts | gap_closed |
+|---|---:|---:|---:|---:|---:|---:|
+| graphpart_2pm-0044-0044 | −13 | −16 | −16 | −16 | 0 | 0.000 |
+| graphpart_2g-0044-1601 | −9.541e5 | −1.026e6 | −1.026e6 | −1.026e6 | 0 | 0.000 |
+| graphpart_2pm-0055-0055 | −20 | −25 | −25 | −25 | 0 | 0.000 |
+| ex1263a | 19.6 | — | 19.07 | 19.07 | 0 | 0.000 |
+
+**`incorrect_count = 0`.** The predicted 0.6–0.9 root-gap close **did NOT
+materialize on discopt**: the separator fires the code path (verified: the loop is
+entered with the 384 integer `≤` rows and 93 integer cols; `_separate_zerohalf_cuts`
+is called) but emits **0 cuts** because it finds no violated {0,½} combination at
+discopt's root LP optimum.
+
+**Root cause (measured, per §0.4).** discopt's root LP optimum for graphpart is a
+**partition vertex with x_j ∈ {0, ⅓}** (a 3-partition polytope; the interior
+POUNCE point is on the same optimal face at {0, ⅓, ⅔}). At x = ⅓ every {0,½}
+combination of the tight rows is **exactly tight, not violated**: an exhaustive
+GF(2) nullspace search confirms an even-coef / odd-rhs combination of the tight
+rows *exists* (4 members) but its violation at x = ⅓ is `0.0000`. So there is
+genuinely nothing to separate. Crucially, discopt's `root_off` **already equals
+SCIP's separators-OFF LP floor** (−16 / −1.026e6 / −25, column `scip_all_off`);
+SCIP's zerohalf closes 60–86% *because SCIP's simplex lands on a ½-valued vertex
+that IS {0,½}-cuttable*, whereas discopt's LP optimum (via its own presolve/FBBT +
+crossover) sits on the ⅓ face where those same inequalities are tight. The gap is
+therefore **not separator strength** — it is *which LP vertex the relaxation
+optimum occupies*. A working, sound zero-half separator does not move discopt's
+graphpart root bound as long as the relaxation optimum is the ⅓-partition face.
+
+**What this falsifies / re-scopes.** The 1d premise "discopt gains ~0.6–0.9 of the
+root gap *if* it gains a zerohalf separator" is falsified for discopt's current
+formulation: the separator is necessary but **not sufficient** — it also needs the
+LP optimum to be zerohalf-cuttable (½-valued), which discopt's tighter
+presolve+crossover currently precludes on this class. The separator is sound,
+reachable, and ready; it is inert on graphpart until one of the following lands
+(Phase 3 follow-on, in priority order):
+1. **Separate at a ½-valued point, not the ⅓ crossover vertex.** Either
+   (a) separate zerohalf at the *pre-crossover* fractional relaxation point before
+   discopt's presolve pins the ⅓ face, or (b) inject the odd-cycle rows into a
+   *weaker* (edge-only) LP whose optimum is ½-valued, matching SCIP's separation
+   context. This is the likely lever and is a cut-*context* change, not a stronger
+   separator.
+2. **Exact/optimal zero-half separation** (min-weight T-join / Caprara–Fischetti
+   auxiliary-graph shortest odd path) replacing the GF(2) heuristic — *would not
+   help here* (the exhaustive nullspace search already proves no violated cut
+   exists at x = ⅓), so it is deprioritized behind (1) for the graphpart class,
+   but is the right build for classes whose LP optimum *is* cuttable and whose
+   heuristic-vs-exact gap is the limiter.
+
+A measured shortfall, not a failure: the separator is correct and the lever's
+non-movement is now *explained and localized* (vertex geometry, not cut depth),
+which redirects the next Phase-3 step from "build a stronger cut" to "separate at
+a cuttable point."
 
 ---
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2078,6 +2078,30 @@ def _cmir_aggregation_enabled() -> bool:
     return val.lower() not in ("0", "", "false", "no", "off")
 
 
+_ZEROHALF_ENV_DEFAULT = os.environ.get("DISCOPT_ZEROHALF", "0").lower() not in (
+    "0",
+    "",
+    "false",
+    "no",
+    "off",
+)
+
+
+def _zerohalf_enabled() -> bool:
+    """Whether the native {0,½}-Chvátal–Gomory (zero-half) separator is enabled
+    for this solve (cert:P3, ``certification-gap-plan.md`` §7 "Phase 3 1d").
+
+    Re-reads ``DISCOPT_ZEROHALF`` each call (**default-off**) so tests and
+    callers can toggle it after import; falls back to the import-time default.
+    The 1d SCIP per-separator attribution found zerohalf alone closes 60–86% of
+    the reachable root gap on the graphpart class (every other cut family closes
+    0), which is why this — not more c-MIR — is the built target."""
+    val = os.environ.get("DISCOPT_ZEROHALF")
+    if val is None:
+        return _ZEROHALF_ENV_DEFAULT
+    return val.lower() not in ("0", "", "false", "no", "off")
+
+
 def _p3_force_cut_path_enabled() -> bool:
     """cert:P3.1c experiment toggle (``DISCOPT_P3_FORCE_CUT_PATH``, default-OFF).
 
@@ -10492,6 +10516,57 @@ def _separate_aggregation_mir_cuts(
     return embedded[:max_cuts], rhs[:max_cuts]
 
 
+def _separate_zerohalf_cuts(
+    lp_data, x_vertex, n_orig, int_idx, a_ub_orig, b_ub_orig, max_cuts: int = 8
+):
+    """Separate {0,½}-Chvátal–Gomory (zero-half) cuts from the original ``<=``
+    rows at the crossover vertex, via the Rust ``zerohalf_cuts_py`` binding.
+
+    Picks subsets ``S`` of the integer ``<=`` rows, sums them with weight ``½``,
+    and CG-rounds. A ``½``-weighted nonnegative combination of ``<=`` rows
+    followed by Chvátal–Gomory rounding is valid for the integer hull for **any**
+    subset ``S``, so every emitted cut removes no integer-feasible point —
+    validity is by construction, independent of the (heuristic) subset choice
+    (proven by the Rust ``zerohalf_validity_random_systems`` property test). This
+    is the ``certification-gap-plan.md`` §7 "Phase 3 1d" target: on the graphpart
+    (odd-cycle / parity) class, zerohalf alone closes 60–86% of the reachable root
+    gap where single-row MIR / Gomory close nothing.
+
+    **Default-off**: the ``DISCOPT_ZEROHALF`` feature-flagged path; the caller
+    gates the call, this helper only separates. Same contract as
+    :func:`_separate_mir_cuts`: returns ``(coeffs, rhs)`` embedded into the current
+    standard-form columns, or ``None`` when the binding is unavailable, lower
+    bounds are non-finite, or no cut is produced."""
+    if a_ub_orig is None or np.asarray(a_ub_orig).shape[0] == 0:
+        return None
+    try:
+        from discopt._rust import zerohalf_cuts_py
+    except ImportError:
+        return None
+    lo = np.asarray(lp_data.x_l, dtype=np.float64)[:n_orig]
+    if not np.all(np.isfinite(lo)):
+        return None  # the nonnegative-y shift requires finite lower bounds
+    hi = np.asarray(lp_data.x_u, dtype=np.float64)[:n_orig].copy()
+    hi[~np.isfinite(hi)] = np.inf
+    integ = np.zeros(n_orig, dtype=bool)
+    integ[[j for j in int_idx if j < n_orig]] = True
+    res = zerohalf_cuts_py(
+        np.ascontiguousarray(a_ub_orig, dtype=np.float64),
+        np.ascontiguousarray(b_ub_orig, dtype=np.float64),
+        np.ascontiguousarray(lo),
+        np.ascontiguousarray(hi),
+        integ,
+        np.ascontiguousarray(np.asarray(x_vertex, dtype=np.float64)[:n_orig]),
+    )
+    if res is None:
+        return None
+    coeffs, rhs = np.asarray(res[0], dtype=np.float64), np.asarray(res[1], dtype=np.float64)
+    n_cur = int(np.asarray(lp_data.A_eq).shape[1])
+    embedded = np.zeros((coeffs.shape[0], n_cur), dtype=np.float64)
+    embedded[:, :n_orig] = coeffs[:, :n_orig]
+    return embedded[:max_cuts], rhs[:max_cuts]
+
+
 def _extract_clique_edges(model: Model) -> list[tuple[int, int]]:
     """Conflict-graph 2-clique edges from the Rust presolve clique pass.
 
@@ -10582,8 +10657,8 @@ def _root_cover_cut_loop(
     projected Gomory mixed-integer cuts (from the iteratively-refined basis at
     the vertex), augments ``lp_data``, and repeats. Returns the (possibly
     augmented) ``lp_data``, the total number of cuts added, and a per-source
-    count dict (``cover_clique``/``gomory``/``mir``/``aggregation``) for
-    instrumentation. A no-op when there are no binary-knapsack rows, clique
+    count dict (``cover_clique``/``gomory``/``mir``/``aggregation``/``zerohalf``)
+    for instrumentation. A no-op when there are no binary-knapsack rows, clique
     edges, or integer variables."""
     from discopt._jax.cover_cuts import (
         has_binary_knapsack_rows,
@@ -10595,7 +10670,8 @@ def _root_cover_cut_loop(
     has_clique = bool(clique_edges)
     has_gomory = bool(len(int_idx))
     if not has_cover and not has_clique and not has_gomory:
-        return lp_data, 0, {"cover_clique": 0, "gomory": 0, "mir": 0, "aggregation": 0}
+        empty = {"cover_clique": 0, "gomory": 0, "mir": 0, "aggregation": 0, "zerohalf": 0}
+        return lp_data, 0, empty
 
     total = 0
     # Per-source cut counts (cert:P3.1b instrumentation). Surfaced on the MILP
@@ -10603,7 +10679,7 @@ def _root_cover_cut_loop(
     # aggregation c-MIR separator actually *fired* on the default path (a cut
     # count of 0 with the flag on means the branch never separated — a wiring or
     # scoping finding, not a bound result). Pure instrumentation; no math change.
-    by_source = {"cover_clique": 0, "gomory": 0, "mir": 0, "aggregation": 0}
+    by_source = {"cover_clique": 0, "gomory": 0, "mir": 0, "aggregation": 0, "zerohalf": 0}
     for _round in range(max_rounds):
         if time.perf_counter() - t_start >= time_limit:
             break
@@ -10707,6 +10783,27 @@ def _root_cover_cut_loop(
                 lp_data = _augment_lpdata_with_mir_cuts(lp_data, ac, ar)
                 round_added += int(ac.shape[0])
                 by_source["aggregation"] += int(ac.shape[0])
+        # {0,½}-Chvátal–Gomory (zero-half) cuts (cert:P3.1d): DEFAULT-OFF, gated by
+        # DISCOPT_ZEROHALF. Sums subsets of the integer <= rows with weight ½ and
+        # CG-rounds — valid by construction (½-weighted nonnegative row combo +
+        # Chvátal–Gomory round, for ANY subset). Captures the odd-cycle / parity
+        # structure single-row MIR/Gomory miss, which the 1d SCIP attribution
+        # identified as the sole load-bearing family on the graphpart class. Same
+        # round-0 / POUNCE-mode gate as MIR; reuses the MIR augmentation (it emits
+        # the same coeffs·x ≤ rhs shape over the structural columns).
+        if has_gomory and _round == 0 and _zerohalf_enabled():
+            try:
+                zh = _separate_zerohalf_cuts(
+                    lp_data, x_vertex, n_orig, int_idx, A_ub_orig, b_ub_orig
+                )
+            except Exception as _zh_exc:
+                logger.debug("zerohalf separation skipped: %s", _zh_exc)
+                zh = None
+            if zh is not None:
+                zc, zr = zh
+                lp_data = _augment_lpdata_with_mir_cuts(lp_data, zc, zr)
+                round_added += int(zc.shape[0])
+                by_source["zerohalf"] += int(zc.shape[0])
         if cuts:  # cover/clique reference original columns (< n_orig), still valid
             lp_data = _augment_lpdata_with_cover_cuts(lp_data, n_orig, cuts)
             round_added += len(cuts)
@@ -11107,7 +11204,7 @@ def _solve_milp_bb(
     _A_ub_m, _b_ub_m, _A_eq_m, _b_eq_m = _decompose_eq_slack_form(
         np.asarray(lp_data.A_eq), np.asarray(lp_data.b_eq), n_orig, _n_total0 - n_orig
     )
-    _cut_by_source = {"cover_clique": 0, "gomory": 0, "mir": 0, "aggregation": 0}
+    _cut_by_source = {"cover_clique": 0, "gomory": 0, "mir": 0, "aggregation": 0, "zerohalf": 0}
     try:
         _is_bin = _binary_mask(model, n_orig)
         # Conflict-graph clique edges (only worth extracting if binaries exist).
@@ -11137,12 +11234,13 @@ def _solve_milp_bb(
         if _n_cuts:
             logger.info(
                 "root cuts added %d valid inequalities "
-                "(cover/clique=%d gomory=%d mir=%d aggregation=%d)",
+                "(cover/clique=%d gomory=%d mir=%d aggregation=%d zerohalf=%d)",
                 _n_cuts,
                 _cut_by_source.get("cover_clique", 0),
                 _cut_by_source.get("gomory", 0),
                 _cut_by_source.get("mir", 0),
                 _cut_by_source.get("aggregation", 0),
+                _cut_by_source.get("zerohalf", 0),
             )
     except Exception as _cc_exc:
         logger.debug("root cuts skipped: %s", _cc_exc)


### PR DESCRIPTION
## cert:P3 — native zerohalf ({0,½}-CG) separator (flagged, default-off)

Builds the native {0,½}-Chvátal–Gomory (zero-half) separator that the Phase 3
**1d SCIP per-separator attribution** named as the *sole load-bearing* cut family
on the graphpart / odd-cycle-parity class: zerohalf alone closes 60–86% of the
reachable root gap there, every other family (flowcover/aggregation/cmir/clique/
gomory/rlt/mcf/impliedbounds) closes 0. Reference: Caprara & Fischetti (1996);
SCIP `sepa_zerohalf` as the implementation model.

### Base branch
Based on **`cert-p3-1d-separator-attribution`**, not `main`. The task specified
"from main", but the cut infrastructure this reuses — the aggregation c-MIR
separator (#416-equivalent), the per-source cut counter (#417-equivalent), the
`DISCOPT_P3_FORCE_CUT_PATH` (1c) reachability toggle, and the `_root_cover_cut_loop`
cut seam — lives on the Phase-3 branch chain, **not on main** (the P3 arc has not
been merged). Basing on 1d keeps this PR to exactly one clean zerohalf commit and
makes the ON/OFF measurement reproducible. 1d is itself 1 commit from `origin/main`.

### What shipped
- **`crates/discopt-core/src/lp/zerohalf.rs`** — `separate_zerohalf(a_ub, b_ub, l,
  u, integrality, x, tol, max_dynamism) -> Vec<ZeroHalfCut>`: scale rows to integer
  data, reduce every column to a nonnegative variable (lower-shift / upper-complement,
  same bound substitution as `mir.rs`), build the mod-2 parity system **over the
  active support** (Caprara–Fischetti; inactive columns are parity don't-cares),
  GF(2) Gaussian elimination to find even-coef / odd-rhs subsets, CG-round, map back
  to `x`. **HEURISTIC** separation (exact min-weight T-join scoped as follow-on).
  Numeric-dynamism / max-coeff guards mirror `mir.rs`.
- PyO3 `zerohalf_cuts_py` (`lp_bindings.rs`), registered in `lib.rs`.
- Wired into the `_solve_milp_bb` root cut loop (`_root_cover_cut_loop` → new
  `_separate_zerohalf_cuts`) behind env **`DISCOPT_ZEROHALF` (default-OFF)**, with a
  `zerohalf` per-source cut counter (`cuts/zerohalf`).

### Soundness gate (non-negotiable) — GREEN
A {0,½} combination + CG round is valid for the integer hull **by construction**,
for *any* subset the heuristic picks; the heuristic affects only strength, never
validity. Empirically verified (Rust `#[test]`, exhaustive integer-box enumeration):
- **`zerohalf_validity_random_systems`** — 400 random integer `≤` systems, mixed
  integer/continuous columns, mixed-sign finite bounds, cuttable LP points: asserts
  **no integer-feasible point of the original system is ever cut** AND **>20
  non-vacuous cuts validated**. (Same regime that caught the sign bug in #415.)
- **`zerohalf_validity_binary_dense`** — 200 set-packing systems, all cuts valid.
- **`zerohalf_two_row_parity_cut`** — the odd-cycle regression: finds `x0+x1+x2 ≤ 1`
  at (½,½,½) and asserts **single-row MIR finds nothing** (fails-before/passes-after
  differential isolating the {0,½}-only structure).

### Lever measurement (the whole point) — MEASURED SHORTFALL, reported honestly
`scripts/p3_zerohalf_onoff.py`, graphpart panel via `DISCOPT_P3_FORCE_CUT_PATH=1`,
root bound at `max_nodes=1`, ON vs OFF:

| instance | opt | scip_all_off | root_off | root_on | zh cuts | gap_closed |
|---|---:|---:|---:|---:|---:|---:|
| graphpart_2pm-0044-0044 | −13 | −16 | −16 | −16 | 0 | **0.000** |
| graphpart_2g-0044-1601 | −9.541e5 | −1.026e6 | −1.026e6 | −1.026e6 | 0 | **0.000** |
| graphpart_2pm-0055-0055 | −20 | −25 | −25 | −25 | 0 | **0.000** |
| ex1263a | 19.6 | — | 19.07 | 19.07 | 0 | **0.000** |

**`incorrect_count = 0`.** The predicted 0.6–0.9 **did NOT materialize on discopt**.
The separator *fires the code path* (verified: the loop is entered with the 384
integer `≤` rows and 93 integer cols; `_separate_zerohalf_cuts` is called once per
root) but emits **0 cuts** — it finds no violated {0,½} combination at discopt's
root LP optimum.

**Root cause (measured).** discopt's root LP optimum for graphpart is a **⅓-partition
vertex** (x_j ∈ {0, ⅓}; the interior POUNCE point is on the same optimal face). At
x = ⅓ **every** {0,½} combination of the tight rows is *exactly tight, not violated*:
an exhaustive GF(2) nullspace search confirms an even-coef / odd-rhs combination
*exists* (4 members) but its violation at x = ⅓ is **0.0000**. discopt's `root_off`
already sits at SCIP's separators-off LP floor (−16 / −1.026e6 / −25); SCIP's zerohalf
closes 60–86% because SCIP's simplex lands on a **½-valued vertex that IS cuttable**,
whereas discopt's tighter presolve+crossover pins the ⅓ face where those inequalities
are tight. The gap is **LP vertex geometry (½-cuttable vs ⅓), not cut depth**.

This falsifies the 1d premise "zerohalf ⇒ 0.6–0.9 close *if* discopt gains the
separator" for discopt's current formulation: the separator is **necessary but not
sufficient** — it also needs a ½-valued (cuttable) LP optimum. Separator is sound,
reachable, and ready; follow-on (recorded in §7) = **separate at a ½-valued /
pre-crossover point**, not a stronger cut. Exact separation would *not* help here
(the nullspace search already proves no violated cut exists at x = ⅓).

Recorded in `docs/dev/certification-gap-plan.md` §7 "Phase 3 zerohalf — build
results" and the §0.8 status table.

### Gates
- `cargo test -p discopt-core` — **383 passed**, 0 failed (4 new zerohalf tests).
- `cargo clippy -p discopt-core --lib` — **0 warnings**.
- `cargo fmt --check` — **clean**.
- `maturin develop --release` — **built**.
- `pytest -m smoke` — **193 passed, 1 skipped**.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**.
- `ruff check` / `ruff format --check` on touched files — **clean**.
- Flag **default-OFF** ⇒ default behavior bound-neutral (smoke/adversarial green).
- `incorrect_count = 0` on the measurement panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
