### PR TITLE
fix(dae): C1/C2/C3 — Neumann sign, Radau ncp=1 quadrature, silent no-dynamics

### DIFF
--- a/docs/dev/dae-module-review.md
+++ b/docs/dev/dae-module-review.md
@@ -17,11 +17,28 @@ findings marked **[BY INSPECTION]** are unambiguous from control flow.
 
 ## 1. Summary of findings
 
+> **✅ RESOLVED C1, C2, C3** — `python/tests/test_dae_c1c2c3.py` (this PR).
+> - **C1** (`mol.py:_get_left_value`): sign fixed to `u[0] + dz*bc_val`, symmetric
+>   with the right boundary. A linear field now reconstructs the true left boundary
+>   (0.0, was 0.333) with zero second derivative.
+> - **C2** (`collocation.py:_quadrature_weights`): Radau weights now come from an
+>   interpolatory Vandermonde moment solve on the collocation points only — correct
+>   for all ncp (sum=1, exact to degree 2·ncp−2), and unchanged vs the old scipy
+>   values for ncp≥2. `integral(1)` over `[0,3]` is 3.0 for ncp=1..5 (was 1.5 at
+>   ncp=1). Also drops the per-call `scipy.integrate.quad`.
+> - **C3** (`collocation.py`, `finite_difference.py`): both transcribers now refuse
+>   loudly — a shared `validate_ode_rhs_keys` requires the RHS to key exactly the
+>   declared states (naming missing/unknown keys), and a second-order state with no
+>   `set_second_order_ode()` raises. No more silent no-dynamics models.
+>
+> Verified fails-before/passes-after (11 tests fail on the pre-fix code). The full
+> finding text is preserved below.
+
 | # | Severity | Component | Finding |
 |---|----------|-----------|---------|
-| C1 | **P0 correctness** | `mol.py` | Left Neumann BC has a **sign error**; any nonzero-flux left BC yields a wrong PDE solution [CONFIRMED] |
-| C2 | **P0 correctness** | `collocation.py` | `integral()` is wrong by **exactly 2×** for Radau `ncp=1` [CONFIRMED] |
-| C3 | **P0 correctness** | `collocation.py`, `finite_difference.py` | Two silent no-dynamics paths: (a) `add_second_order_state` without an RHS, (b) RHS dict key typo — both build a model with **no dynamics constraints**, no error [CONFIRMED] |
+| C1 | **P0 correctness** — ✅ RESOLVED | `mol.py` | Left Neumann BC has a **sign error**; any nonzero-flux left BC yields a wrong PDE solution [CONFIRMED] |
+| C2 | **P0 correctness** — ✅ RESOLVED | `collocation.py` | `integral()` is wrong by **exactly 2×** for Radau `ncp=1` [CONFIRMED] |
+| C3 | **P0 correctness** — ✅ RESOLVED | `collocation.py`, `finite_difference.py` | Two silent no-dynamics paths: (a) `add_second_order_state` without an RHS, (b) RHS dict key typo — both build a model with **no dynamics constraints**, no error [CONFIRMED] |
 | C4 | P1 | `mol.py` | `npts=1` crashes with an opaque `ValueError` [CONFIRMED] |
 | C5 | P1 | `finite_difference.py` | Forward Euler + algebraic DAE: off-by-one index alignment between `z_k` and the grid point where the ODE is evaluated [BY INSPECTION] |
 | R1–R7 | P1–P2 | all | Missing validation and API guards (§3) |

--- a/python/discopt/dae/collocation.py
+++ b/python/discopt/dae/collocation.py
@@ -100,6 +100,41 @@ class _SecondOrderInfo:
     initial_velocity: float | np.ndarray | None = None
 
 
+def validate_ode_rhs_keys(deriv_keys, states, *, builder: str) -> None:
+    """Require the ODE RHS to supply a derivative for *exactly* the states.
+
+    Shared by the collocation and finite-difference transcribers (C3). A missing
+    key silently drops a differential state's dynamics, leaving it unconstrained
+    (an under-determined transcription the solver will happily "optimize"); an
+    unknown key is a user typo the caller expects to have taken effect. Both are
+    refused loudly rather than approximated silently — per the development
+    philosophy, a wrong certificate is worse than a loud error.
+
+    Parameters
+    ----------
+    deriv_keys : iterable of str
+        Keys of the dict returned by the user's RHS callable.
+    states : iterable
+        The declared differential states (each with a ``.name``).
+    builder : str
+        Human-readable transcriber name, for the error message.
+    """
+    expected = {sv.name for sv in states}
+    got = set(deriv_keys)
+    missing = expected - got
+    unknown = got - expected
+    if missing or unknown:
+        parts = []
+        if missing:
+            parts.append(f"no derivative supplied for state(s) {sorted(missing)}")
+        if unknown:
+            parts.append(f"unknown key(s) {sorted(unknown)} match no declared state")
+        raise ValueError(
+            f"{builder} RHS keys do not match the declared states "
+            f"(expected exactly {sorted(expected)}): " + "; ".join(parts) + "."
+        )
+
+
 class DAEBuilder:
     """Transcribe an ODE/DAE system into algebraic constraints via collocation.
 
@@ -470,11 +505,19 @@ class DAEBuilder:
         A = self._A
         rhs_fn = self._ode_rhs
 
-        if rhs_fn is None and not self._second_order_info:
-            raise RuntimeError("No ODE RHS set. Call set_ode() or set_second_order_ode().")
+        # C3(a): second-order state(s) declared but no acceleration RHS set. The
+        # wrapper that would populate `_ode_rhs` was never built, so dynamics
+        # would be silently skipped. Refuse loudly.
+        if self._second_order_info and self._second_order_rhs is None:
+            raise RuntimeError(
+                "Second-order state(s) "
+                f"{[i.position_name for i in self._second_order_info]} were declared with "
+                "add_second_order_state() but no second-order ODE was set. "
+                "Call set_second_order_ode()."
+            )
 
         if rhs_fn is None:
-            return
+            raise RuntimeError("No ODE RHS set. Call set_ode() or set_second_order_ode().")
 
         tp = self._element_points()  # (nfe, ncp+1)
         t_arg = Constant(np.asarray(tp[:, 1:], dtype=np.float64))  # (nfe, ncp)
@@ -483,11 +526,11 @@ class DAEBuilder:
 
         states_vec, alg_vec, ctrl_vec = self._build_vec_dicts()
         derivs = rhs_fn(t_arg, states_vec, alg_vec, ctrl_vec)
+        # C3(b): every differential state must get a derivative, and no stray keys.
+        validate_ode_rhs_keys(derivs.keys(), self._states, builder="collocation ODE")
 
         constraints = []
         for sv in self._states:
-            if sv.name not in derivs:
-                continue
             var = self._vars[sv.name]
             if sv.n_components == 1:
                 # LHS shape (nfe, ncp) = var @ A.T
@@ -890,22 +933,19 @@ class DAEBuilder:
         if cs.scheme == "radau":
             from discopt.dae.polynomials import radau_roots
 
+            # Interpolatory (Radau IIA) quadrature weights on the collocation
+            # points ONLY: solve the Vandermonde moment system
+            #   sum_j w_j * cp_j^k = ∫_0^1 t^k dt = 1/(k+1),  k = 0..ncp-1
+            # This is exact for all ncp (including ncp=1) and, because the points
+            # are Gauss-Radau, is exact to degree 2*ncp-2. The previous
+            # implementation integrated the Lagrange basis over the *full* node
+            # set [0, cp...] and dropped node 0's weight — only valid when that
+            # weight is 0 (ncp >= 2); at ncp=1 it under-integrated by 2x. (C2)
             cp = radau_roots(cs.ncp)
-            # Compute weights by integrating the Lagrange basis on [0, 1]
-            # for the full node set [0, cp[0], ..., cp[ncp-1]]
-            nodes = np.concatenate([[0.0], cp])
-            weights = np.zeros(cs.ncp)
-            for j in range(cs.ncp):
-                # Integrate L_{j+1}(t) from 0 to 1 (basis for collocation points)
-                from scipy.integrate import quad
-
-                from discopt.dae.polynomials import lagrange_basis
-
-                def basis_fn(t, jj=j + 1):
-                    return lagrange_basis(nodes, t, jj)
-
-                weights[j], _ = quad(basis_fn, 0, 1)
-            return weights
+            k = np.arange(cs.ncp)
+            vander = cp[np.newaxis, :] ** k[:, np.newaxis]  # (ncp, ncp), rows=powers
+            moments = 1.0 / (k + 1.0)
+            return np.linalg.solve(vander, moments)
         else:
             _, w_gl = np.polynomial.legendre.leggauss(cs.ncp)
             return w_gl / 2.0  # transform from [-1,1] to [0,1]

--- a/python/discopt/dae/finite_difference.py
+++ b/python/discopt/dae/finite_difference.py
@@ -18,6 +18,7 @@ from discopt.dae.collocation import (
     ControlVar,
     StateVar,
     _SecondOrderInfo,
+    validate_ode_rhs_keys,
 )
 
 
@@ -253,7 +254,18 @@ class FDBuilder:
             self._build_second_order_wrapper()
 
         # Add FD constraints
-        if self._ode_rhs is None and not self._second_order_info:
+        # C3(a): second-order state(s) declared but no acceleration RHS set → the
+        # wrapper that populates `_ode_rhs` was never built, so dynamics would be
+        # silently skipped. Refuse loudly.
+        if self._second_order_info and self._second_order_rhs is None:
+            raise RuntimeError(
+                "Second-order state(s) "
+                f"{[i.position_name for i in self._second_order_info]} were declared with "
+                "add_second_order_state() but no second-order ODE was set. "
+                "Call set_second_order_ode()."
+            )
+
+        if self._ode_rhs is None:
             raise RuntimeError("No ODE RHS set. Call set_ode() or set_second_order_ode().")
 
         tp = self.time_points()
@@ -268,10 +280,11 @@ class FDBuilder:
                     alg_k = self._algebraic_dict_at(k - 1)
                     ctrl_k = self._control_dict_at(k - 1)
                     derivs = rhs_fn(tp[k], states_k, alg_k, ctrl_k)
+                    validate_ode_rhs_keys(
+                        derivs.keys(), self._states, builder="finite-difference ODE"
+                    )
 
                     for sv in self._states:
-                        if sv.name not in derivs:
-                            continue
                         var = self._vars[sv.name]
                         if sv.n_components == 1:
                             lhs = (var[k] - var[k - 1]) / h_k
@@ -288,10 +301,11 @@ class FDBuilder:
                     alg_k = self._algebraic_dict_at(k)
                     ctrl_k = self._control_dict_at(k)
                     derivs = rhs_fn(tp[k], states_k, alg_k, ctrl_k)
+                    validate_ode_rhs_keys(
+                        derivs.keys(), self._states, builder="finite-difference ODE"
+                    )
 
                     for sv in self._states:
-                        if sv.name not in derivs:
-                            continue
                         var = self._vars[sv.name]
                         if sv.n_components == 1:
                             lhs = (var[k + 1] - var[k]) / h_k
@@ -308,10 +322,11 @@ class FDBuilder:
                     alg_k = self._algebraic_dict_at(k - 1)
                     ctrl_k = self._control_dict_at(k - 1)
                     derivs = rhs_fn(tp[k], states_k, alg_k, ctrl_k)
+                    validate_ode_rhs_keys(
+                        derivs.keys(), self._states, builder="finite-difference ODE"
+                    )
 
                     for sv in self._states:
-                        if sv.name not in derivs:
-                            continue
                         var = self._vars[sv.name]
                         if sv.n_components == 1:
                             lhs = (var[k + 1] - var[k - 1]) / h_span
@@ -328,9 +343,8 @@ class FDBuilder:
                 alg_k = self._algebraic_dict_at(k - 1)
                 ctrl_k = self._control_dict_at(k - 1)
                 derivs = rhs_fn(tp[k], states_k, alg_k, ctrl_k)
+                validate_ode_rhs_keys(derivs.keys(), self._states, builder="finite-difference ODE")
                 for sv in self._states:
-                    if sv.name not in derivs:
-                        continue
                     var = self._vars[sv.name]
                     if sv.n_components == 1:
                         lhs = (var[k] - var[k - 1]) / h_k

--- a/python/discopt/dae/mol.py
+++ b/python/discopt/dae/mol.py
@@ -427,10 +427,12 @@ class MOLBuilder:
         bc_val = bc.eval(t) if not callable(bc.value) else bc.value(t)
         if bc.type == "dirichlet":
             return bc_val
-        # Neumann: -du/dz = bc_val at left boundary (outward normal)
-        # Ghost point: u_ghost = u[0] - dz * bc_val  (forward approx)
-        # bc_val is the outward normal derivative = -du/dz at left
-        return u[0] - dz * bc_val
+        # Neumann: bc_val = du/dn = outward normal derivative at the left
+        # boundary. The outward normal points in -z, so du/dz|_boundary = -bc_val.
+        # First-order Taylor from the first interior point u[0] (at z0 + dz):
+        #   u(z0) ≈ u[0] - dz * (du/dz) = u[0] - dz * (-bc_val) = u[0] + dz * bc_val
+        # Symmetric with the right boundary (_get_right_value, also `+`). (C1)
+        return u[0] + dz * bc_val
 
     def _get_right_value(self, fv: FieldVar, t, k: int, n: int, u, dz: float):
         """Get the field value to the right of interior point k.

--- a/python/tests/test_dae_c1c2c3.py
+++ b/python/tests/test_dae_c1c2c3.py
@@ -1,0 +1,201 @@
+"""Regression tests for DAE correctness fixes C1, C2, C3.
+
+- **C1** (`mol.py`): the left Neumann boundary reconstruction had a sign flip, so
+  any nonzero-flux left BC gave a wrong PDE solution. Tests are invisible to the
+  bug if the flux is 0 (as the pre-existing suite used), so these use nonzero flux.
+- **C2** (`collocation.py`): `integral()` under-integrated by exactly 2x for Radau
+  `ncp=1` (dropped node-0 weight). The pre-existing suite only exercised `ncp=3`.
+- **C3** (`collocation.py`, `finite_difference.py`): two silent no-dynamics paths —
+  a second-order state with no acceleration RHS, and an RHS dict key typo — both
+  built an under-constrained model with no error.
+
+All fast (direct calls / tiny LP solves), so marked ``smoke``. Each fails on the
+pre-fix code.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import pytest
+from discopt.dae import (
+    BoundaryCondition,
+    ContinuousSet,
+    DAEBuilder,
+    FDBuilder,
+    MOLBuilder,
+    SpatialSet,
+    radau_roots,
+)
+
+pytestmark = pytest.mark.smoke
+
+
+# --------------------------------------------------------------------------- C1
+def _mol_linear_field():
+    m = dm.Model("c1")
+    ts = ContinuousSet("t", bounds=(0, 1), nfe=2, ncp=2)
+    ss = SpatialSet("z", bounds=(0, 1), npts=5)
+    mol = MOLBuilder(m, ts, ss)
+    # u(z) = z on [0,1]: du/dz = 1. Outward-normal flux is -1 at the left, +1 at
+    # the right. The reconstructed boundary values must be the true 0.0 and 1.0.
+    mol.add_field(
+        "u",
+        bounds=(-5, 5),
+        initial=lambda z: z,
+        bc_left=BoundaryCondition("neumann", -1.0),
+        bc_right=BoundaryCondition("neumann", 1.0),
+    )
+    return mol, ss
+
+
+def test_c1_left_neumann_reconstruction_sign():
+    """Left Neumann reconstruction of a linear field returns the true boundary."""
+    mol, ss = _mol_linear_field()
+    fv = mol._fields[0]
+    u = ss.interior_points.copy()  # u(z) = z at interior points
+    dz = ss.dz
+    left = mol._get_left_value(fv, 0.0, 0, u, dz)
+    # Pre-fix: u[0] - dz*bc_val = u[0] + dz (wrong). Fixed: u[0] + dz*bc_val = 0.0.
+    assert left == pytest.approx(0.0, abs=1e-9)
+
+
+def test_c1_neumann_convention_is_symmetric():
+    """Left and right Neumann use the same outward-normal convention."""
+    mol, ss = _mol_linear_field()
+    fv = mol._fields[0]
+    u = ss.interior_points.copy()
+    dz = ss.dz
+    left = mol._get_left_value(fv, 0.0, 0, u, dz)
+    right = mol._get_right_value(fv, 0.0, len(u) - 1, len(u), u, dz)
+    assert left == pytest.approx(0.0, abs=1e-9)
+    assert right == pytest.approx(1.0, abs=1e-9)
+
+
+def test_c1_linear_field_has_zero_second_derivative():
+    """The reconstructed left boundary yields d2u/dz2 = 0 for a linear field."""
+    mol, ss = _mol_linear_field()
+    fv = mol._fields[0]
+    u = ss.interior_points.copy()
+    dz = ss.dz
+    left = mol._get_left_value(fv, 0.0, 0, u, dz)
+    fzz = (left - 2 * u[0] + u[1]) / dz**2
+    assert fzz == pytest.approx(0.0, abs=1e-9)
+
+
+# --------------------------------------------------------------------------- C2
+@pytest.mark.parametrize("ncp", [1, 2, 3, 4, 5])
+def test_c2_radau_weights_sum_to_one(ncp):
+    """Radau quadrature weights must sum to 1 for every ncp (was 0.5 at ncp=1)."""
+    m = dm.Model(f"w{ncp}")
+    cs = ContinuousSet("t", bounds=(0, 1), nfe=1, ncp=ncp, scheme="radau")
+    w = DAEBuilder(m, cs)._quadrature_weights()
+    assert float(w.sum()) == pytest.approx(1.0, abs=1e-12)
+
+
+@pytest.mark.parametrize("ncp", [1, 2, 3, 4, 5])
+def test_c2_radau_weights_exact_to_degree_2ncp_minus_2(ncp):
+    """Interpolatory Radau weights integrate t^k exactly up to degree 2*ncp-2."""
+    m = dm.Model(f"e{ncp}")
+    cs = ContinuousSet("t", bounds=(0, 1), nfe=1, ncp=ncp, scheme="radau")
+    w = DAEBuilder(m, cs)._quadrature_weights()
+    cp = radau_roots(ncp)
+    for deg in range(2 * ncp - 2 + 1):
+        approx = float((w * cp**deg).sum())
+        assert approx == pytest.approx(1.0 / (deg + 1), abs=1e-12)
+
+
+@pytest.mark.parametrize("ncp", [1, 2, 3, 4, 5])
+def test_c2_integral_of_constant_all_ncp(ncp):
+    """integral(1) over [0,3] == 3 for every ncp (bug returned 1.5 at ncp=1)."""
+    T = 3.0
+    m = dm.Model(f"int{ncp}")
+    cs = ContinuousSet("t", bounds=(0, T), nfe=4, ncp=ncp)
+    dae = DAEBuilder(m, cs)
+    dae.add_state("x", initial=0.0, bounds=(-10, 10))
+    dae.set_ode(lambda t, s, a, c: {"x": 1.0})
+    dae.discretize()
+    iv = dae.integral(lambda t, s, a, c: 1.0)
+    xv = dae.get_state("x")
+    m.minimize(0 * xv[0, 0] + iv)
+    result = m.solve()
+    assert result.objective == pytest.approx(T, abs=1e-6)
+
+
+# --------------------------------------------------------------------------- C3
+def test_c3a_collocation_second_order_without_rhs_raises():
+    m = dm.Model("c3a")
+    cs = ContinuousSet("t", bounds=(0, 1), nfe=4, ncp=3)
+    dae = DAEBuilder(m, cs)
+    dae.add_second_order_state("q", initial=0.0, initial_velocity=1.0)
+    with pytest.raises(RuntimeError, match="second-order ODE"):
+        dae.discretize()
+
+
+def test_c3a_fd_second_order_without_rhs_raises():
+    m = dm.Model("c3a_fd")
+    cs = ContinuousSet("t", bounds=(0, 1), nfe=4)
+    fd = FDBuilder(m, cs, method="backward")
+    fd.add_second_order_state("q", initial=0.0, initial_velocity=1.0)
+    with pytest.raises(RuntimeError, match="second-order ODE"):
+        fd.discretize()
+
+
+def test_c3b_collocation_rhs_key_typo_raises():
+    m = dm.Model("c3b")
+    cs = ContinuousSet("t", bounds=(0, 1), nfe=4, ncp=3)
+    dae = DAEBuilder(m, cs)
+    dae.add_state("x", initial=0.0)
+    dae.set_ode(lambda t, s, a, c: {"X": 1.0})  # typo: X vs x
+    with pytest.raises(ValueError, match="do not match the declared states"):
+        dae.discretize()
+
+
+def test_c3b_fd_rhs_key_typo_raises():
+    m = dm.Model("c3b_fd")
+    cs = ContinuousSet("t", bounds=(0, 1), nfe=4)
+    fd = FDBuilder(m, cs, method="backward")
+    fd.add_state("x", initial=0.0)
+    fd.set_ode(lambda t, s, a, c: {"X": 1.0})
+    with pytest.raises(ValueError, match="do not match the declared states"):
+        fd.discretize()
+
+
+def test_c3b_partial_rhs_raises():
+    """A dict that constrains only some states must raise (the rest would float)."""
+    m = dm.Model("c3b_partial")
+    cs = ContinuousSet("t", bounds=(0, 1), nfe=4, ncp=3)
+    dae = DAEBuilder(m, cs)
+    dae.add_state("x", initial=0.0)
+    dae.add_state("y", initial=0.0)
+    dae.set_ode(lambda t, s, a, c: {"x": 1.0})  # y missing
+    with pytest.raises(ValueError, match="y"):
+        dae.discretize()
+
+
+def test_c3_correct_models_still_discretize():
+    """No false positives: a correctly specified model discretizes cleanly."""
+    # collocation
+    m = dm.Model("ok_col")
+    cs = ContinuousSet("t", bounds=(0, 1), nfe=4, ncp=3)
+    dae = DAEBuilder(m, cs)
+    dae.add_state("x", initial=0.0)
+    dae.set_ode(lambda t, s, a, c: {"x": 1.0})
+    dae.discretize()  # must not raise
+
+    # finite difference
+    m2 = dm.Model("ok_fd")
+    cs2 = ContinuousSet("t", bounds=(0, 1), nfe=4)
+    fd = FDBuilder(m2, cs2, method="backward")
+    fd.add_state("x", initial=0.0)
+    fd.set_ode(lambda t, s, a, c: {"x": 1.0})
+    fd.discretize()  # must not raise
+
+
+def test_c3_second_order_correct_still_works():
+    """A properly configured second-order model discretizes cleanly."""
+    m = dm.Model("ok_so")
+    cs = ContinuousSet("t", bounds=(0, 1), nfe=4, ncp=3)
+    dae = DAEBuilder(m, cs)
+    dae.add_second_order_state("q", initial=0.0, initial_velocity=1.0)
+    dae.set_second_order_ode(lambda t, pos, vel, a, c: {"q": -pos["q"]})
+    dae.discretize()  # must not raise


### PR DESCRIPTION
## Summary

Fixes the three confirmed **P0 correctness** bugs in the DAE transcribers (dae-module-review.md, Tier 2). Each produced a wrong answer with no error — the worst class of failure for a certificate-producing solver. Isolated to the `dae/` module, so no conflict with the C-backlog correctness work. Part of the parallel-track effort under issue #413.

| # | Bug | Fix |
|---|-----|-----|
| **C1** | `mol.py:_get_left_value` — left Neumann reconstruction has a **sign flip**; any nonzero-flux left BC gives a wrong PDE solution | `u[0] + dz*bc_val` (symmetric with the right boundary) |
| **C2** | `collocation.py:_quadrature_weights` — `integral()` under-integrates by **exactly 2×** for Radau `ncp=1` | interpolatory Vandermonde moment solve on the collocation points |
| **C3** | `collocation.py` + `finite_difference.py` — two **silent no-dynamics** paths | refuse loudly (shared `validate_ode_rhs_keys` + second-order guard) |

## Detail

**C1.** `bc_val` is the outward-normal derivative (`= −du/dz` at the left boundary). A first-order Taylor step from the first interior point gives `u(z0) = u[0] − dz·(du/dz) = u[0] + dz·bc_val` — the code had `−`. The right boundary was already `+`, so the fix restores symmetry. The suite missed it because every Neumann test used flux `0.0`. Verified: for `u(z)=z`, the left boundary now reconstructs `0.0` (was `0.333`) with zero second derivative.

**C2.** The Radau branch integrated the Lagrange basis over the full node set `[0, cp…]` then dropped node 0's weight — valid only when that weight is 0 (`ncp≥2`). At `ncp=1` the dropped weight is 0.5, so `integral()` silently optimized half the true cost. Replaced with the interpolatory quadrature weights from a Vandermonde moment solve (`Σ wⱼ cpⱼᵏ = 1/(k+1)`): exact for all `ncp` (sum = 1, exact to degree `2·ncp−2`), **identical to the old scipy values for `ncp≥2`** (bound-neutral there), and drops the per-call `scipy.integrate.quad`. Verified: `integral(1)` over `[0,3]` = 3.0 for `ncp=1..5` (was 1.5 at `ncp=1`).

**C3.** Two paths built an under-constrained model (states floating, zero dynamics constraints) with no error: (a) `add_second_order_state(...)` without `set_second_order_ode(...)`, and (b) an RHS dict key typo (`{"X": …}` for state `"x"`) silently dropping that state's dynamics. Both transcribers now refuse loudly — a shared `validate_ode_rhs_keys()` requires the RHS to key **exactly** the declared differential states (naming the missing and unknown keys), and a second-order state with no acceleration RHS raises. Per the development philosophy: refuse loudly rather than approximate silently.

## Tests

New `python/tests/test_dae_c1c2c3.py` (`smoke`): C1 reconstruction sign + symmetry + zero-curvature; C2 weight sum/exactness and `integral(1)==T` for `ncp=1..5`; C3 raise paths for both collocation and FD (missing second-order RHS, key typo, partial coverage) plus no-false-positive checks. **11 fail on the pre-fix code** — verified fails-before/passes-after by reverting the sources to `main`.

**Verification run:** `test_dae_c1c2c3` (25) + `test_dae` + `test_dae_fd_mol` including `-m slow` (the MOL heat-equation solves that exercise C1) → **all pass, 0 regressions**. `ruff check` / `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm)_