### PR TITLE
fix(ro): RO-1/RO-2 — sign-indefinite coefficient under-protection + silently non-robust patterns

### DIFF
--- a/docs/dev/ro-module-review.md
+++ b/docs/dev/ro-module-review.md
@@ -20,10 +20,33 @@ wrong bound in the global solver.
 
 ## 1. Summary of findings
 
+> **✅ RESOLVED RO-1, RO-2** — `python/tests/test_ro_soundness.py` (this PR).
+> - **RO-1** (`box.py`): `_has_bilinear_param_var` now routes a bare
+>   `Parameter * Variable` through the `|coeff|` linearization path whenever the
+>   variable factor is not provably non-negative (new `_var_provably_nonneg`
+>   helper); sign-tracking is kept only for `x ≥ 0`, where it is sound and
+>   result-neutral. The repro (`max x s.t. p·x ≤ −1`) now returns the true robust
+>   `x = −2` (was −0.667, which violated the constraint at `p = 0.5`).
+> - **RO-2** (universal guard): `RobustCounterpart.formulate()` now calls
+>   `assert_no_uncertain_params_remain()` after every strategy build — if any
+>   uncertain parameter survives (an unsupported pattern was silently left at
+>   nominal), it raises `NotImplementedError` instead of returning a non-robust
+>   model. This converts the whole silent-non-robust class (RO-2 and the
+>   leftover-parameter cases of RO-4/RO-5/RO-6/RO-8) from silent to loud in one
+>   place. Scalar `p·x` and elementwise `dm.sum(p·x)` ellipsoidal now refuse
+>   loudly; the blessed `p @ x` / constant-coeff patterns still formulate cleanly.
+>
+> Verified fails-before/passes-after (4 tests fail on the pre-fix code); 96 ro
+> tests pass. **Still open:** RO-3 is *sound but over-conservative* (protects a
+> superset — not a false certificate), and RO-4/RO-5/RO-6 cases that silently
+> *substitute the wrong value* (rather than leaving a parameter) are not caught by
+> the guard; both are follow-ups, not blocking soundness holes. The full finding
+> text is preserved below.
+
 | # | Severity | Component | Finding |
 |---|----------|-----------|---------|
-| RO-1 | **P0 soundness** | `formulations/_common.py` (box path) | Sign-tracking assumes the parameter's variable coefficient is **nonnegative**; with a variable that can be negative the "robust" counterpart **under-protects** — returned solution violates the constraint at in-set realizations [CONFIRMED] |
-| RO-2 | **P0 soundness** | `formulations/ellipsoidal.py` | Only the literal `p @ x` / `x @ p` MatMul pattern is robustified; every other appearance of the parameter (`p * x`, `dm.sum(p*x)`, RHS `h(x) <= p`) is **left at nominal with zero penalty — silently non-robust** [CONFIRMED: constraint object provably unchanged; scalar case returns the nominal optimum] |
+| RO-1 | **P0 soundness** — ✅ RESOLVED | `formulations/_common.py` (box path) | Sign-tracking assumes the parameter's variable coefficient is **nonnegative**; with a variable that can be negative the "robust" counterpart **under-protects** — returned solution violates the constraint at in-set realizations [CONFIRMED] |
+| RO-2 | **P0 soundness** — ✅ RESOLVED | `formulations/ellipsoidal.py` | Only the literal `p @ x` / `x @ p` MatMul pattern is robustified; every other appearance of the parameter (`p * x`, `dm.sum(p*x)`, RHS `h(x) <= p`) is **left at nominal with zero penalty — silently non-robust** [CONFIRMED: constraint object provably unchanged; scalar case returns the nominal optimum] |
 | RO-3 | **P0 method** | `uncertainty.py:budget_uncertainty_set` + `polyhedral.py` | The stored `A,b` has only the all-plus/all-minus budget facets (2 of the 2^k needed); the compact `_is_budget/_delta/_gamma` attributes are **never read** by any formulation — the "Bertsimas–Sim" counterpart protects against a strict superset, **2× over-conservative** in mixed-sign directions at k=2 [CONFIRMED: support of [1,−1] = 2.0 vs true 1.0] |
 | RO-4 | **P1 soundness** | `_common.py` | Division/power propagate sign **without flipping**: `c/p` substitutes the wrong bound (non-conservative); non-monotone dependence (`p**2` on a straddling interval) picks the wrong endpoint [BY INSPECTION — mechanism unambiguous] |
 | RO-5 | P1 soundness | `polyhedral.py:_eval_constant_expr` | Unknown node types (SumExpression, MatMul, FunctionCall, IndexExpression) **evaluate to 0.0 silently** — a constant-coefficient constraint written with any of those shapes gets **zero protection** [BY INSPECTION] |

--- a/python/discopt/ro/counterpart.py
+++ b/python/discopt/ro/counterpart.py
@@ -158,6 +158,17 @@ class RobustCounterpart:
 
         strategy = self._build_strategy()
         strategy.build()
+
+        # Universal soundness guard (RO-2): a correct counterpart eliminates every
+        # uncertain parameter. If any survived, the pattern was silently left at
+        # nominal — refuse loudly rather than return a non-robust model.
+        from discopt.ro.formulations._common import assert_no_uncertain_params_remain
+
+        assert_no_uncertain_params_remain(
+            self._model,
+            {u.parameter.name for u in self._uncertainty_sets},
+            kind=self.kind,
+        )
         self._formulated = True
 
     def _build_strategy(self):

--- a/python/discopt/ro/formulations/_common.py
+++ b/python/discopt/ro/formulations/_common.py
@@ -271,3 +271,36 @@ def _contains_uncertain_param(expr, param_names: set[str]) -> bool:
     if isinstance(expr, SumOverExpression):
         return any(_contains_uncertain_param(t, param_names) for t in expr.terms)
     return False
+
+
+def assert_no_uncertain_params_remain(model, param_names: set[str], *, kind: str) -> None:
+    """Refuse loudly if any uncertain parameter survived robustification (RO-2).
+
+    A correct robust counterpart eliminates every uncertain parameter (by
+    worst-case substitution, an SOC/dual penalty, etc.). If one remains, the
+    expression pattern was silently left at its nominal value — the user asked
+    for a robust model and would get a non-robust one. This universal post-check
+    turns every unsupported-pattern gap (RO-2, RO-4, RO-5, RO-6, RO-8) from a
+    silent wrong answer into a loud ``NotImplementedError`` at ``formulate()``
+    time, per the development philosophy (refuse loudly over silent approximation).
+    """
+    from discopt.modeling.core import Constraint
+
+    leftovers: list[str] = []
+    for con in model._constraints:
+        if isinstance(con, Constraint) and _contains_uncertain_param(con.body, param_names):
+            leftovers.append(con.name or "<unnamed constraint>")
+    obj = model._objective
+    if obj is not None and _contains_uncertain_param(obj.expression, param_names):
+        leftovers.append("<objective>")
+
+    if leftovers:
+        raise NotImplementedError(
+            f"The {kind} robust counterpart could not robustify uncertain "
+            f"parameter(s) appearing in {leftovers}. The expression pattern in "
+            "those terms is not supported by this formulation, so they were left "
+            "at their nominal value — which would silently produce a NON-robust "
+            "model. Rewrite the uncertain terms into a supported pattern (e.g. a "
+            "linear/affine dependence on the parameter) or use a different "
+            "uncertainty set. Refusing to return a silently non-robust model."
+        )

--- a/python/discopt/ro/formulations/box.py
+++ b/python/discopt/ro/formulations/box.py
@@ -322,6 +322,22 @@ def _contains_variable(expr) -> bool:
     return False
 
 
+def _var_provably_nonneg(expr) -> bool:
+    """True only if *expr* is a Variable expression provably >= 0 (lb >= 0).
+
+    Conservative: returns False for anything but a bare ``Variable`` with a
+    non-negative lower bound (index expressions, sums, products, etc. resolve to
+    False and are routed through the sign-safe |coeff| linearization). Used to
+    keep the sign-tracking fast path only where it is sound (RO-1).
+    """
+    from discopt.modeling.core import Variable
+
+    if isinstance(expr, Variable):
+        lb = getattr(expr, "lb", None)
+        return lb is not None and bool(np.all(np.asarray(lb) >= 0))
+    return False
+
+
 def _has_bilinear_param_var(expr, param_names: set[str]) -> bool:
     """Check whether expr has a true bilinear product: Variable * f(Parameter).
 
@@ -364,11 +380,25 @@ def _has_bilinear_param_var(expr, param_names: set[str]) -> bool:
                     return True  # left has var, right has both var and param
                 if r_var and l_param and l_var:
                     return True  # right has var, left has both var and param
-                # Also: variable-only * param-containing (but not a bare Parameter)
+                # Variable-only * param-containing expression, e.g. Y*(p - p_bar).
                 if l_var and not l_param and r_param and not isinstance(expr.right, Parameter):
                     return True
                 if r_var and not r_param and l_param and not isinstance(expr.left, Parameter):
                     return True
+                # RO-1: bare Parameter * Variable (`p * x`). Sign-tracking treats
+                # the parameter AS the coefficient and picks its worst-case value
+                # by sign — correct ONLY when the variable factor is provably
+                # nonnegative. For a sign-indefinite variable the worst-case
+                # parameter sign depends on the (unknown) sign of the variable, so
+                # sign-tracking under-protects (returns a non-counterpart). Route
+                # such terms through the |coeff| linearization path, which is
+                # correct for any sign; keep sign-tracking only for x >= 0.
+                if l_var and not l_param and isinstance(expr.right, Parameter):
+                    if not _var_provably_nonneg(expr.left):
+                        return True
+                if r_var and not r_param and isinstance(expr.left, Parameter):
+                    if not _var_provably_nonneg(expr.right):
+                        return True
         return _has_bilinear_param_var(expr.left, param_names) or _has_bilinear_param_var(
             expr.right, param_names
         )

--- a/python/tests/test_ro_soundness.py
+++ b/python/tests/test_ro_soundness.py
@@ -1,0 +1,117 @@
+"""Regression tests for robust-optimization soundness fixes RO-1 and RO-2.
+
+- **RO-1** (`box.py`): sign-tracking treated a bare ``Parameter * Variable`` as if
+  the parameter were the coefficient, correct only when the variable is provably
+  ``>= 0``. For a sign-indefinite variable the "robust" counterpart under-protected
+  (returned a point that violates the constraint at an in-set realization — not a
+  counterpart). Such terms now route through the ``|coeff|`` linearization path.
+- **RO-2** (universal guard): several formulations silently left an uncertain
+  parameter at its nominal value when the expression pattern was unsupported (e.g.
+  ellipsoidal robustifies only ``p @ x``). The counterpart now refuses loudly if
+  any uncertain parameter survives ``formulate()`` — no silently non-robust models.
+
+Each fails on the pre-fix code (RO-1 returns the wrong optimum; RO-2 returns the
+nominal model with no error).
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.ro import (
+    BoxUncertaintySet,
+    EllipsoidalUncertaintySet,
+    RobustCounterpart,
+)
+
+pytestmark = pytest.mark.smoke
+
+
+# --------------------------------------------------------------------------- RO-1
+def test_ro1_sign_indefinite_variable_coefficient():
+    """max x s.t. p*x <= -1, x in [-10,10], pbar=1, delta=0.5 -> robust x = -2."""
+    m = dm.Model("ro1")
+    x = m.continuous("x", shape=(1,), lb=-10, ub=10)
+    p = m.parameter("p", value=1.0)
+    m.maximize(x[0])
+    m.subject_to(p * x[0] <= -1, name="c")
+    RobustCounterpart(m, BoxUncertaintySet(p, delta=0.5)).formulate()
+    r = m.solve()
+    xval = float(r.value(x)[0])
+    # Pre-fix returned x = -0.667 (violates the constraint at p=0.5).
+    assert xval == pytest.approx(-2.0, abs=1e-4)
+
+
+def test_ro1_solution_is_actually_robust():
+    """The RO-1 solution must satisfy the constraint at the worst-case realization."""
+    m = dm.Model("ro1r")
+    x = m.continuous("x", shape=(1,), lb=-10, ub=10)
+    p = m.parameter("p", value=1.0)
+    m.maximize(x[0])
+    m.subject_to(p * x[0] <= -1, name="c")
+    RobustCounterpart(m, BoxUncertaintySet(p, delta=0.5)).formulate()
+    xval = float(m.solve().value(x)[0])
+    # For every p in [0.5, 1.5], p*x <= -1 must hold (x < 0, so p=0.5 is worst).
+    for pval in np.linspace(0.5, 1.5, 11):
+        assert pval * xval <= -1 + 1e-6, f"violated at p={pval}"
+
+
+def test_ro1_nonnegative_variable_fast_path_still_correct():
+    """Control: x >= 0 keeps the sign-tracking fast path and stays correct."""
+    m = dm.Model("ro1pos")
+    x = m.continuous("x", shape=(1,), lb=0, ub=10)
+    p = m.parameter("p", value=1.0)
+    m.maximize(x[0])
+    m.subject_to(p * x[0] <= 4, name="c")
+    RobustCounterpart(m, BoxUncertaintySet(p, delta=0.5)).formulate()
+    xval = float(m.solve().value(x)[0])
+    # Worst case p = 1.5, so 1.5*x <= 4 -> x <= 2.667.
+    assert xval == pytest.approx(4.0 / 1.5, abs=1e-4)
+    for pval in np.linspace(0.5, 1.5, 11):
+        assert pval * xval <= 4 + 1e-6
+
+
+# --------------------------------------------------------------------------- RO-2
+def test_ro2_scalar_ellipsoidal_refuses_loudly():
+    """Scalar p*x is not the p@x pattern -> must raise, not silently no-op."""
+    m = dm.Model("ro2s")
+    x = m.continuous("x", shape=(1,), lb=0, ub=10)
+    p = m.parameter("p", value=1.0)
+    m.maximize(x[0])
+    m.subject_to(p * x[0] <= 4, name="c")
+    with pytest.raises(NotImplementedError, match="silently non-robust|could not robustify"):
+        RobustCounterpart(m, EllipsoidalUncertaintySet(p, rho=0.5)).formulate()
+
+
+def test_ro2_elementwise_sum_ellipsoidal_refuses_loudly():
+    """dm.sum(p * x) (elementwise, not MatMul) must raise, not silently no-op."""
+    m = dm.Model("ro2e")
+    x = m.continuous("x", shape=(3,), lb=0, ub=1)
+    p = m.parameter("p", value=np.array([1.0, 2.0, 3.0]))
+    m.maximize(dm.sum(p * x))
+    m.subject_to(dm.sum(x) <= 1, name="budget")
+    with pytest.raises(NotImplementedError, match="silently non-robust|could not robustify"):
+        RobustCounterpart(m, EllipsoidalUncertaintySet(p, rho=0.5)).formulate()
+
+
+def test_ro2_blessed_matmul_still_formulates():
+    """Control: the supported p @ x pattern must NOT trip the guard."""
+    m = dm.Model("blessed")
+    x = m.continuous("x", shape=(3,), lb=0, ub=1)
+    p = m.parameter("p", value=np.array([1.0, 2.0, 3.0]))
+    m.maximize(p @ x)
+    m.subject_to(dm.sum(x) <= 1, name="budget")
+    RobustCounterpart(m, EllipsoidalUncertaintySet(p, rho=0.5)).formulate()
+    assert m.solve().status == "optimal"
+
+
+def test_ro2_blessed_box_still_formulates():
+    """Control: constant-coeff box counterpart must NOT trip the guard."""
+    m = dm.Model("blessedbox")
+    x = m.continuous("x", shape=(3,), lb=0, ub=1)
+    c = m.parameter("c", value=np.array([1.0, 2.0, 3.0]))
+    m.minimize(dm.sum(c * x))
+    m.subject_to(dm.sum(x) >= 1, name="cover")
+    RobustCounterpart(m, BoxUncertaintySet(c, delta=0.1 * np.ones(3))).formulate()
+    assert m.solve().status == "optimal"


### PR DESCRIPTION
## Summary

Fixes the two **P0 soundness** holes in the robust-optimization counterpart layer (ro-module-review.md). Both let `RobustCounterpart.formulate()` return a model that is **not actually robust** — one silently, one with a wrong certified answer. Isolated to the `ro/` module, so no conflict with the C-backlog work. Part of the parallel-track effort under issue #413.

| # | Bug | Fix |
|---|-----|-----|
| **RO-1** | `box.py` — sign-tracking treats `p*x` as if the parameter were the coefficient; **under-protects** for a sign-indefinite variable (returns a non-counterpart) | route through the `\|coeff\|` linearization unless the variable is provably `≥ 0` |
| **RO-2** | unsupported patterns (`p*x`, `sum(p*x)`, RHS uncertainty) are **silently left at nominal** with zero penalty | universal post-`formulate()` guard: refuse loudly if any uncertain parameter survives |

## Detail

**RO-1.** `_has_bilinear_param_var` deliberately excluded a bare `Parameter * Variable` from the linearization path, treating the parameter as the coefficient and choosing its worst-case value by sign. That is correct **only when the variable is provably `≥ 0`** — for a sign-indefinite variable the worst-case parameter sign depends on the (unknown) sign of the variable, so the counterpart under-protects. Repro `max x s.t. p·x ≤ −1`, `x∈[−10,10]`, `p̄=1, δ=0.5` returned `x=−0.667`, which **violates the constraint at the in-set realization `p=0.5`**. Fixed by routing such terms through the existing `|coeff|` absolute-value linearization whenever the variable factor is not provably non-negative (new `_var_provably_nonneg` helper); sign-tracking stays the fast path for `x≥0`, where it is sound and result-neutral (`|x|=x`). Now returns the true robust `x=−2`, feasible for all `p∈[0.5,1.5]`.

**RO-2.** The ellipsoidal formulation robustifies only the literal `p @ x` MatMul; every other appearance (`p*x`, `dm.sum(p*x)`, RHS `h(x) ≤ p`) was substituted at nominal with **no penalty** and no error — the user asked for a robust model and got the nominal one. Rather than chase every pattern, I added the review's recommended linchpin: `assert_no_uncertain_params_remain()`, called at the single `RobustCounterpart.formulate()` choke point after every strategy build. A correct counterpart eliminates every uncertain parameter; if one survives, it raises `NotImplementedError` naming the offending constraints. This converts the **entire silent-non-robust class** (RO-2 plus the leftover-parameter cases of RO-4/RO-5/RO-6/RO-8) from silent-wrong to loud — per the development philosophy, refuse loudly over silent approximation.

**Deliberately out of scope** (follow-ups, *not* blocking soundness holes, noted in the review doc):
- **RO-3** — the budget set is *sound but over-conservative* (protects a strict superset), so it is never a false certificate.
- **RO-4/RO-5/RO-6** cases that silently *substitute a wrong value* rather than leaving a parameter are not caught by the guard (the guard only fires on a surviving parameter); these need per-pattern refusals.

## Tests

New `python/tests/test_ro_soundness.py` (`smoke`): RO-1 correct robust optimum + in-set feasibility sweep + `x≥0` fast-path control; RO-2 scalar and elementwise ellipsoidal refuse loudly + blessed `p@x` / constant-coeff box controls (guard must not false-fire). **4 fail on the pre-fix code** — verified fails-before/passes-after by reverting the sources to `main`.

**Verification run:** `test_ro_soundness` (7) + `test_robust_counterpart` + `test_robust_solve` + `test_robust_uncertainty` + `test_affine_decision_rule` → **96 passed, 0 regressions**. `ruff check` / `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm)_