### PR TITLE
fix(mpec): MP-1/MP-2 — hidden complementarity infeasibility + swallowed solver failure

### DIFF
--- a/docs/dev/mpec-estimate-pooling-opf-review.md
+++ b/docs/dev/mpec-estimate-pooling-opf-review.md
@@ -13,10 +13,26 @@ forms.** The exception is one verified edge-case soundness gap in `mpec.py`.
 
 ## 1. Summary
 
+> **✅ RESOLVED MP-1, MP-2** — `python/tests/test_mpec_mp1_mp2.py` (this PR).
+> - **MP-1** (`tighten_complementarity_bounds`): fixing a partner to 0 now
+>   *intersects* only its upper bound (`ub = min(ub, 0)`) via the new
+>   `_fix_partner_to_zero` helper and never overwrites `lb`. When the partner
+>   carries a strictly positive lower bound the pair is genuinely infeasible, so it
+>   raises `ValueError` instead of silently collapsing to `[0, 0]`. The repro
+>   (`a, b` both `lb=0.5`) now raises; the blessed case (`b.lb=0`) still fixes to
+>   `[0, 0]` with `n_fixed=1`.
+> - **MP-2** (`solve_mpec`): the `except BaseException: break` is narrowed to
+>   `except Exception`; a first-iteration NLP failure now raises a `RuntimeError`
+>   with the iteration/`t` context instead of returning `None` silently (a later
+>   continuation failure still keeps the best point found so far).
+>
+> Verified fails-before/passes-after (2 tests fail on the pre-fix code); existing
+> mpec suite (9 tests) still passes. The full finding text is preserved below.
+
 | # | Severity | Module | Finding |
 |---|----------|--------|---------|
-| MP-1 | **P1 soundness** | `mpec.py:168-175` | `tighten_complementarity_bounds` overwrites a variable's **positive lower bound** with 0 when fixing the complementary partner, silently **hiding infeasibility** [CONFIRMED] |
-| MP-2 | P2 | `mpec.py:254` | `solve_mpec` Scholtes loop `except BaseException: break` swallows every solver error with no diagnostic [CONFIRMED by inspection] |
+| MP-1 | **P1 soundness** — ✅ RESOLVED | `mpec.py:168-175` | `tighten_complementarity_bounds` overwrites a variable's **positive lower bound** with 0 when fixing the complementary partner, silently **hiding infeasibility** [CONFIRMED] |
+| MP-2 | P2 — ✅ RESOLVED | `mpec.py:254` | `solve_mpec` Scholtes loop `except BaseException: break` swallows every solver error with no diagnostic [CONFIRMED by inspection] |
 | ES-1 | P3 stat | `estimate.py:199-208` | `confidence_intervals` uses Student-t with `dof = n_obs − n_params` while σ is *known/fixed* (cov not rescaled by reduced χ²) — with known σ the consistent interval is normal(z)-based; the t/z mix is statistically inconsistent (slightly conservative) [SUSPECTED] |
 
 Verified **correct** (with the evidence):

--- a/python/discopt/mpec.py
+++ b/python/discopt/mpec.py
@@ -160,20 +160,47 @@ def tighten_complementarity_bounds(model: Model, pairs: list[Complementarity]) -
     (``lb > 0``), the other side must be zero. Applied only to single-variable
     sides, where the implication is sound and exact. Returns the number of
     variables fixed to zero.
+
+    The partner is fixed by *intersecting* its upper bound with 0 — the lower
+    bound is never overwritten. If the partner already carries a strictly
+    positive lower bound the complementarity is genuinely infeasible (both sides
+    would be > 0); that is surfaced as a ``ValueError`` rather than silently
+    collapsing the box to ``[0, 0]`` and hiding the infeasibility (MP-1).
+
+    Raises
+    ------
+    ValueError
+        If a fixed-to-zero partner has a strictly positive declared lower bound,
+        i.e. the complementarity pair is infeasible.
     """
     fixed = 0
     for p in pairs:
         f_var = p.f if isinstance(p.f, Variable) and p.f.size == 1 else None
         g_var = p.g if isinstance(p.g, Variable) and p.g.size == 1 else None
         if f_var is not None and float(f_var.lb) > 0.0 and g_var is not None:
-            g_var.ub = np.zeros_like(np.array(g_var.ub))
-            g_var.lb = np.zeros_like(np.array(g_var.lb))
+            _fix_partner_to_zero(g_var, driver=f_var, tag=p.name)
             fixed += 1
         elif g_var is not None and float(g_var.lb) > 0.0 and f_var is not None:
-            f_var.ub = np.zeros_like(np.array(f_var.ub))
-            f_var.lb = np.zeros_like(np.array(f_var.lb))
+            _fix_partner_to_zero(f_var, driver=g_var, tag=p.name)
             fixed += 1
     return fixed
+
+
+def _fix_partner_to_zero(partner: Variable, *, driver: Variable, tag: str | None) -> None:
+    """Force a complementarity partner to 0 by intersecting its ub with 0.
+
+    ``driver`` is strictly positive (``lb > 0``), so ``0 <= f ⊥ g >= 0`` forces
+    ``partner == 0``. Intersect ``partner.ub`` with 0 without touching
+    ``partner.lb``; if that lower bound is itself positive the box is empty and
+    the pair is infeasible — raise rather than overwrite ``lb`` (MP-1).
+    """
+    if float(partner.lb) > 0.0:
+        raise ValueError(
+            f"Complementarity {tag or '<unnamed>'} is infeasible: one side has "
+            f"lb={float(driver.lb):g} > 0, forcing the partner to 0, but the partner "
+            f"has lb={float(partner.lb):g} > 0 — 0 <= f _|_ g >= 0 cannot hold."
+        )
+    partner.ub = np.minimum(np.array(partner.ub, dtype=np.float64), 0.0)
 
 
 # ─────────────────────────────── solve ───────────────────────────────
@@ -251,7 +278,14 @@ def solve_mpec(
         evaluator = NLPEvaluator(model)
         try:
             result = backend(evaluator, x_cur, options=opts)
-        except BaseException:
+        except Exception as e:
+            # MP-2: never swallow silently. A first-iteration failure has no
+            # result to fall back on — surface it; a later continuation failure
+            # keeps the best point found so far (valid at a larger t).
+            if result is None:
+                raise RuntimeError(
+                    f"MPEC NLP solve failed on the first homotopy iteration (t={tv:g}): {e}"
+                ) from e
             break
         if result.x is not None:
             x_cur = np.asarray(result.x, dtype=np.float64)

--- a/python/tests/test_mpec_mp1_mp2.py
+++ b/python/tests/test_mpec_mp1_mp2.py
@@ -1,0 +1,79 @@
+"""Regression tests for MPEC fixes MP-1 and MP-2.
+
+- **MP-1** (`mpec.py:tighten_complementarity_bounds`): fixing a complementarity
+  partner to 0 overwrote its lower bound as well as its upper bound. When the
+  partner carried a strictly positive lower bound the pair is genuinely infeasible,
+  but the old code silently collapsed the box to ``[0, 0]`` and reported
+  ``n_fixed=1`` — a subsequent solve then certifies the infeasible model optimal.
+  The fix intersects only the upper bound and raises on the infeasible case.
+- **MP-2** (`mpec.py:solve_mpec`): a first-iteration NLP failure was swallowed by
+  ``except BaseException: break`` and returned ``None`` silently. The fix narrows
+  the catch and surfaces a first-iteration failure as a ``RuntimeError``.
+
+Each fails on the pre-fix code.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import pytest
+from discopt.mpec import complementarity, solve_mpec, tighten_complementarity_bounds
+
+pytestmark = pytest.mark.smoke
+
+
+# ---------------------------------------------------------------------------- MP-1
+def test_mp1_infeasible_pair_raises_not_hidden():
+    """0 <= a _|_ b >= 0 with a.lb=b.lb=0.5 is infeasible -> must raise."""
+    m = dm.Model("infeas")
+    a = m.continuous("a", lb=0.5, ub=5.0)
+    b = m.continuous("b", lb=0.5, ub=5.0)
+    with pytest.raises(ValueError, match="infeasible"):
+        tighten_complementarity_bounds(m, [complementarity(a, b, name="ab")])
+
+
+def test_mp1_feasible_case_still_fixes_to_zero():
+    """The blessed case (partner lb=0) still fixes the partner to [0, 0]."""
+    m = dm.Model("feas")
+    a = m.continuous("a", lb=0.5, ub=3.0)
+    b = m.continuous("b", lb=0.0, ub=3.0)
+    n_fixed = tighten_complementarity_bounds(m, [complementarity(a, b)])
+    assert n_fixed == 1
+    assert float(b.lb) == 0.0 and float(b.ub) == 0.0
+    assert float(a.lb) == 0.5  # driver untouched
+
+
+def test_mp1_intersects_tighter_upper_bound():
+    """Fixing to zero intersects ub (never widens it) and keeps lb=0."""
+    m = dm.Model("intersect")
+    a = m.continuous("a", lb=1.0, ub=5.0)
+    b = m.continuous("b", lb=0.0, ub=0.2)
+    tighten_complementarity_bounds(m, [complementarity(a, b)])
+    assert float(b.lb) == 0.0 and float(b.ub) == 0.0
+
+
+def test_mp1_no_fix_when_both_sides_free():
+    m = dm.Model("free")
+    a = m.continuous("a", lb=0.0, ub=3.0)
+    b = m.continuous("b", lb=0.0, ub=3.0)
+    assert tighten_complementarity_bounds(m, [complementarity(a, b)]) == 0
+
+
+# ---------------------------------------------------------------------------- MP-2
+def test_mp2_first_iteration_solver_failure_surfaces(monkeypatch):
+    """A first-iteration NLP failure must raise, not silently return None."""
+
+    def _boom(*_args, **_kwargs):
+        raise ValueError("backend exploded")
+
+    def _fake_get_nlp_solver(_name):
+        return _boom
+
+    monkeypatch.setattr("discopt.solvers.nlp_backend.get_nlp_solver", _fake_get_nlp_solver)
+
+    m = dm.Model("mp2")
+    x = m.continuous("x", lb=0.0, ub=5.0)
+    y = m.continuous("y", lb=0.0, ub=5.0)
+    m.minimize(x + y)
+    with pytest.raises(RuntimeError, match="first homotopy iteration"):
+        solve_mpec(m, [complementarity(x, y)], max_iter=4)


### PR DESCRIPTION
## Summary

Fixes the two `mpec.py` findings from mpec-estimate-pooling-opf-review.md. Isolated to `mpec.py`, so no conflict with the C-backlog work. Part of the parallel-track effort under issue #413.

**MP-1 (P1 soundness — hidden infeasibility → false certificate).** `tighten_complementarity_bounds` implements the sound inference "if one side of `0 ≤ f ⊥ g ≥ 0` has `lb > 0`, the partner must be 0." But it fixed the partner by setting **both** `lb` and `ub` to 0, discarding any pre-existing positive lower bound. When the partner *itself* has `lb > 0`, the pair is genuinely infeasible (both sides would be `> 0`) — yet the old code silently collapsed the box to `[0, 0]` and returned `n_fixed=1`, so a subsequent solve certifies the infeasible model optimal.

Confirmed: `a, b` both `lb=0.5, ub=5` → old code returns `n_fixed=1`, `b=[0,0]` (infeasibility hidden). Fixed by a new `_fix_partner_to_zero` helper that **intersects only the upper bound** (`ub = min(ub, 0)`), never touches `lb`, and raises `ValueError` when the partner's `lb` is positive (provable infeasibility). The blessed case (`b.lb=0`) is unchanged — still fixes to `[0, 0]` with `n_fixed=1`.

**MP-2 (P2 — swallowed solver failure).** The Scholtes homotopy loop caught `except BaseException: break`, swallowing every error (including `KeyboardInterrupt`/`SystemExit`) and returning `None` silently on a first-iteration failure. Narrowed to `except Exception`; a first-iteration failure now raises `RuntimeError` with the `t` context, while a later continuation-step failure still keeps the best point found so far (a valid point at a larger `t`).

## Tests

New `python/tests/test_mpec_mp1_mp2.py` (`smoke`): MP-1 infeasible pair raises; blessed / intersect-tighter-ub / no-fix controls unchanged; MP-2 first-iteration backend failure surfaces as `RuntimeError` (monkeypatched failing backend). **2 fail on the pre-fix code** — verified fails-before/passes-after by reverting `mpec.py` to `main`.

**Verification run:** `test_mpec_mp1_mp2` (5) + existing `test_mpec` (9) → **all pass, 0 regressions**. `ruff check` / `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm)_