### PR TITLE
fix(display): MO1 NBI axis + L1/L5/L6/L8 latex rendering crashes

### DIFF
--- a/docs/dev/mo-module-review.md
+++ b/docs/dev/mo-module-review.md
@@ -21,9 +21,15 @@ and test blind spots.
 
 ## 1. Summary of findings
 
+> **✅ RESOLVED MO1** — `python/tests/test_display_cluster.py` (this PR). The
+> quasi-normal is extracted into a `_quasi_normal(phi)` helper computing the
+> Das–Dennis `n̂ = -Φe = -phi.sum(axis=0)` (negated sum of the anchor rows), fixing
+> the `axis=1` slip. Verified fails-before/passes-after; the k=2 case is unchanged
+> (symmetric payoff). The full finding text is preserved below.
+
 | # | Severity | Component | Finding |
 |---|----------|-----------|---------|
-| MO1 | **P1 method-correctness** | `nbi.py:128` | NBI quasi-normal computed with the **wrong axis** (`phi.sum(axis=1)` instead of `axis=0`) — deviates from the cited Das–Dennis (1998) formula for k ≥ 3; invisible at k = 2 by symmetry [CONFIRMED] |
+| MO1 | **P1 method-correctness** — ✅ RESOLVED | `nbi.py:128` | NBI quasi-normal computed with the **wrong axis** (`phi.sum(axis=1)` instead of `axis=0`) — deviates from the cited Das–Dennis (1998) formula for k ≥ 3; invisible at k = 2 by symmetry [CONFIRMED] |
 | MO2 | P2 method-fidelity | `scalarization.py` | The `epsilon_constraint` implementation is **AUGMECON, not AUGMECON2**: the bypass/jump acceleration that defines AUGMECON2 is absent, and the payoff table is not built lexicographically as Mavrotas prescribes [BY INSPECTION] |
 | MO3 | P2 | `pareto.py` | `filtered()` keeps **duplicate points** (identical objective vectors from different scalarization parameters survive weak-dominance filtering) [CONFIRMED] |
 | MO4 | P2 (doc/API) | `indicators.py` | Default hypervolume reference is **front-dependent** — comparing two fronts via `front.hypervolume()` silently compares against different references [CONFIRMED: 2.16 vs 0.08 for nested fronts] |

--- a/docs/dev/modeling-module-review.md
+++ b/docs/dev/modeling-module-review.md
@@ -334,9 +334,24 @@ tables, comma'd data, unquoted labels, lowercase-consistent names).
 
 ### 6.3 `latex.py`
 
+> **✅ RESOLVED L1, L5, L6, L8** — `python/tests/test_display_cluster.py` (display-cluster PR).
+> - **L1**: `_constraint_to_latex` now renders a `\text{[Type: name]}` placeholder
+>   for non-arithmetic constraint types (indicator/disjunctive/SOS/logical) instead
+>   of raising `AttributeError` — GDP models display without crashing.
+> - **L5**: indexed digit-suffixed variables merge into a single subscript
+>   (`y1[0]` → `y_{1,0}`, not the invalid `y_{1}_{0}`); other bases are brace-wrapped.
+> - **L6**: `_fmt_num` guards non-finite input (`\infty`/`-\infty`/`\mathrm{nan}`)
+>   instead of `int(inf)` raising `OverflowError`.
+> - **L8**: `Expression._repr_latex_` now renders the DAG via `expr_to_latex`.
+>
+> Verified fails-before/passes-after. **Still open** (this PR did not touch them):
+> L2 (fast-path rows invisible — part of the X-1 builder-rows root), L3
+> (`SumOverExpression`/`Parameter`), L4 (precedence on non-BinaryOp nodes), L6's
+> slice rendering, L7 (HTML vs LaTeX escaping).
+
 | ID | Loc | Finding |
 |----|-----|---------|
-| L1 | `:152-161` | **`to_latex`/`_repr_latex_`/`_repr_html_` crash on any model containing `if_then`/`either_or`/`m.logical` constraints** [VERIFIED]: `_constraint_to_latex` reads `.sense`/`.body` on `_IndicatorConstraint` et al. Merely *displaying* such a model in Jupyter raises `AttributeError`. |
+| L1 | `:152-161` — ✅ RESOLVED | **`to_latex`/`_repr_latex_`/`_repr_html_` crash on any model containing `if_then`/`either_or`/`m.logical` constraints** [VERIFIED]: `_constraint_to_latex` reads `.sense`/`.body` on `_IndicatorConstraint` et al. Merely *displaying* such a model in Jupyter raises `AttributeError`. |
 | L2 | `:200-209` | **Fast-path constraint families are invisible** [VERIFIED]: renderer reads only `_constraints`, so a `m.constraint(...)` model renders "(1 variable, 0 constraints)" — a display that misrepresents the model. |
 | L3 | `:26-37` | **`SumOverExpression` and `Parameter` unhandled** [VERIFIED]: the dominant `dm.sum(..., over=...)` pattern renders as literal `Σ[6 terms]`; `Parameter` as `param(price_A)` with a bare `_` in math mode. |
 | L4 | `:109-127` | **Precedence bugs on non-BinaryOp nodes** [VERIFIED]: `(-x)**2` → `-x^{2}`; `dm.sum(x)**2` → `\sum x^{2}`; `(A@x)**2` → `A\,x^{2}` — all mathematically wrong renderings (UnaryOp/Sum/MatMul ignore `parent_prec`). |

--- a/python/discopt/mo/nbi.py
+++ b/python/discopt/mo/nbi.py
@@ -38,7 +38,7 @@ def _quasi_normal(phi: np.ndarray) -> np.ndarray:
     which only coincides with the correct direction when ``phi`` is symmetric
     (i.e. ``k = 2``); for ``k >= 3`` it deviates from the cited formula (MO1).
     """
-    return -phi.sum(axis=0)
+    return np.asarray(-phi.sum(axis=0))
 
 
 def _payoff_matrix(

--- a/python/discopt/mo/nbi.py
+++ b/python/discopt/mo/nbi.py
@@ -29,6 +29,18 @@ from discopt.mo.utils import (
 )
 
 
+def _quasi_normal(phi: np.ndarray) -> np.ndarray:
+    """Das-Dennis quasi-normal direction ``n̂ = -Φe``.
+
+    ``phi[i, j]`` is objective ``j`` at anchor ``i`` (row layout), so ``Φe`` — the
+    sum of the anchor payoff vectors (the rows) — is ``phi.sum(axis=0)``. Summing
+    ``axis=1`` instead collapses the objective components *within* each anchor,
+    which only coincides with the correct direction when ``phi`` is symmetric
+    (i.e. ``k = 2``); for ``k >= 3`` it deviates from the cited formula (MO1).
+    """
+    return -phi.sum(axis=0)
+
+
 def _payoff_matrix(
     model,
     objectives: list,
@@ -123,9 +135,7 @@ def normal_boundary_intersection(
         for i in range(k):
             for j in range(k):
                 phi[i, j] = signs[j] * (raw_payoff[i, j] - ideal_arr[j]) / span[j]
-        # Quasi-normal direction: negative of column-sum (points inward from
-        # the CHIM into the dominated region).
-        n_hat = -phi.sum(axis=1)  # shape (k,)
+        n_hat = _quasi_normal(phi)  # shape (k,)
 
         # Weight grid on simplex (convex combinations of anchors).
         weights = _simplex_lattice(k, n_points)

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -172,7 +172,14 @@ class Expression:
 
     def _repr_latex_(self):
         """Jupyter/IPython LaTeX rendering."""
-        return f"${self}$"
+        # Render the expression DAG as real math rather than wrapping the plain
+        # repr in $...$ (which shows broken math in Jupyter) (L8).
+        try:
+            from discopt.modeling.latex import expr_to_latex
+
+            return f"${expr_to_latex(self)}$"
+        except Exception:
+            return f"${self}$"
 
 
 class Constant(Expression):

--- a/python/discopt/modeling/latex.py
+++ b/python/discopt/modeling/latex.py
@@ -60,6 +60,10 @@ _PREC = {"+": 1, "-": 1, "*": 2, "/": 2, "@": 2, "**": 4}
 
 def _fmt_num(v: float) -> str:
     f = float(v)
+    if not np.isfinite(f):  # int(inf) raises OverflowError (L6)
+        if np.isnan(f):
+            return r"\mathrm{nan}"
+        return r"\infty" if f > 0 else r"-\infty"
     if f == int(f) and abs(f) < 1e15:
         return str(int(f))
     return f"{f:.6g}"
@@ -103,7 +107,17 @@ def expr_to_latex(e: Any, parent_prec: int = 0) -> str:
         if isinstance(e, IndexExpression):
             idx = e.index
             idx_s = ",".join(str(i) for i in idx) if isinstance(idx, tuple) else str(idx)
-            return f"{expr_to_latex(e.base, 5)}_{{{idx_s}}}"
+            base = e.base
+            # Merge a trailing-digit variable subscript with the index so `y1[0]`
+            # renders as a single subscript `y_{1,0}` rather than the invalid
+            # double subscript `y_{1}_{0}` (a MathJax error) (L5).
+            if isinstance(base, Variable):
+                mm = re.fullmatch(r"([A-Za-z]+)(\d+)", base.name)
+                if mm:
+                    return f"{mm.group(1)}_{{{mm.group(2)},{idx_s}}}"
+                return f"{_sym(base.name)}_{{{idx_s}}}"
+            # Brace-wrap any other base so its own subscripts nest validly.
+            return f"{{{expr_to_latex(base, 5)}}}_{{{idx_s}}}"
         if isinstance(e, BinaryOp):
             return _binop_to_latex(e, parent_prec)
         if isinstance(e, UnaryOp):
@@ -153,6 +167,16 @@ def _constraint_to_latex(c: Any) -> str:
     """Render a constraint. Constraints are normalised to ``body sense 0``; when the
     body is a top-level subtraction ``L - R`` we un-normalise to ``L sense R`` for a
     natural reading (e.g. ``x + 5y >= 4`` instead of ``4 - (x + 5y) <= 0``)."""
+    # Non-arithmetic constraint types (indicator / disjunctive / SOS / logical,
+    # from if_then/either_or/m.logical) carry no .body/.sense — render a readable
+    # placeholder instead of raising AttributeError and crashing the whole model
+    # display / Jupyter _repr_ (L1).
+    if not (hasattr(c, "sense") and hasattr(c, "body")):
+        kind = type(c).__name__.lstrip("_")
+        label = getattr(c, "name", None)
+        text = f"{kind}: {label}" if label else kind
+        escaped = text.replace("_", r"\_")
+        return rf"\text{{[{escaped}]}}"
     sense = {"<=": r"\le", ">=": r"\ge", "==": "="}.get(c.sense, c.sense)
     body = c.body
     if isinstance(body, BinaryOp) and body.op == "-":

--- a/python/tests/test_display_cluster.py
+++ b/python/tests/test_display_cluster.py
@@ -1,0 +1,106 @@
+"""Regression tests for the display-cluster fixes MO1 and L1/L5/L6/L8.
+
+- **MO1** (`mo/nbi.py`): the NBI quasi-normal was computed with the wrong matrix
+  axis (`phi.sum(axis=1)` instead of `axis=0`), deviating from Das-Dennis for
+  k >= 3 (invisible at k = 2 by symmetry).
+- **L1** (`modeling/latex.py`): `to_latex` / Jupyter `_repr_` crashed with
+  `AttributeError` on any model containing a GDP constraint (`if_then`/`either_or`/
+  `logical`), because the renderer read `.body`/`.sense` on constraint types that
+  carry neither.
+- **L5**: an indexed variable whose name ends in a digit rendered an invalid double
+  subscript (`y_{1}_{0}` -> MathJax error).
+- **L6**: `_fmt_num(inf)` raised `OverflowError` via `int(inf)`.
+- **L8**: `Expression._repr_latex_` wrapped the plain repr in `$...$` instead of
+  rendering the DAG as math.
+
+Each fails on the pre-fix code.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.mo.nbi import _quasi_normal
+from discopt.modeling.latex import _fmt_num, expr_to_latex, model_to_latex
+
+pytestmark = pytest.mark.smoke
+
+
+# ---------------------------------------------------------------------------- MO1
+def test_mo1_quasi_normal_sums_anchor_vectors_axis0():
+    """n̂ = -Φe is the negated sum of the anchor rows (axis=0), not axis=1."""
+    # Asymmetric k=3 payoff (phi[i, j] = objective j at anchor i).
+    phi = np.array([[0.0, 0.7, 0.9], [0.6, 0.0, 0.3], [0.8, 0.2, 0.0]])
+    expected = -(phi[0] + phi[1] + phi[2])  # negated sum of anchor payoff vectors
+    np.testing.assert_allclose(_quasi_normal(phi), expected)
+    # The buggy axis=1 direction must be different for this asymmetric payoff.
+    assert not np.allclose(_quasi_normal(phi), -phi.sum(axis=1))
+
+
+def test_mo1_symmetric_k2_is_unchanged():
+    """At k=2 the ideal/nadir-normalized payoff is symmetric, so both axes agree."""
+    phi = np.array([[0.0, 1.0], [1.0, 0.0]])
+    np.testing.assert_allclose(_quasi_normal(phi), -phi.sum(axis=1))
+
+
+# ----------------------------------------------------------------------------- L6
+def test_l6_fmt_num_handles_non_finite():
+    assert _fmt_num(float("inf")) == r"\infty"
+    assert _fmt_num(float("-inf")) == r"-\infty"
+    assert _fmt_num(float("nan")) == r"\mathrm{nan}"
+    # sanity: finite values unchanged
+    assert _fmt_num(3.0) == "3"
+
+
+def test_l6_unbounded_variable_model_renders():
+    m = dm.Model("unbounded")
+    w = m.continuous("w")  # +/- inf bounds
+    m.minimize(w)
+    # Must not raise (previously _fmt_num(inf) could crash the domain row).
+    assert isinstance(model_to_latex(m), str)
+
+
+# ----------------------------------------------------------------------------- L5
+def test_l5_indexed_digit_name_single_subscript():
+    m = dm.Model("l5")
+    y1 = m.continuous("y1", shape=(3,), lb=0)
+    rendered = expr_to_latex(y1[0])
+    assert rendered == "y_{1,0}"
+    assert "}_{" not in rendered  # no invalid double subscript
+
+
+def test_l5_plain_indexed_variable():
+    m = dm.Model("l5b")
+    x = m.continuous("x", shape=(3,), lb=0)
+    assert expr_to_latex(x[0]) == "x_{0}"
+
+
+# ----------------------------------------------------------------------------- L8
+def test_l8_expression_repr_latex_renders_math():
+    m = dm.Model("l8")
+    x = m.continuous("x", shape=(2,), lb=0)
+    out = (x[0] + 2 * x[1])._repr_latex_()
+    assert out.startswith("$") and out.endswith("$")
+    assert "x_{0}" in out and "x_{1}" in out  # real math, not the plain repr
+
+
+# ----------------------------------------------------------------------------- L1
+def test_l1_gdp_model_renders_without_crashing():
+    m = dm.Model("gdp")
+    z = m.continuous("z", lb=0, ub=10)
+    m.minimize(z)
+    m.subject_to(z >= 1, name="c1")
+    m.either_or([[z == 0], [z >= 5]], name="switch")
+    tex = model_to_latex(m)  # previously raised AttributeError
+    assert isinstance(tex, str)
+    assert r"\text{[" in tex  # the GDP constraint rendered as a placeholder
+
+
+def test_l1_indicator_constraint_renders_without_crashing():
+    m = dm.Model("ind")
+    a = m.binary("a")
+    z = m.continuous("z", lb=0, ub=10)
+    m.minimize(z)
+    m.if_then(a, [z >= 5], name="impl")
+    assert isinstance(model_to_latex(m), str)


### PR DESCRIPTION
## Summary

The display/rendering half of the display cluster: one multi-objective method bug and four LaTeX rendering defects (two of them crashes). All Tier 3 (visible-wrong, not certificate-affecting), isolated to `mo/nbi.py` and `modeling/latex.py`+`core.py`. Part of the parallel-track effort under issue #413.

**MO1 (mo/nbi.py).** The NBI quasi-normal was `-phi.sum(axis=1)`, summing the objective components *within* each anchor. Das–Dennis define `n̂ = −Φe` (the negated sum of the anchor payoff vectors), which in this row layout (`phi[i,j]` = objective `j` at anchor `i`) is `-phi.sum(axis=0)`. The two agree only when `phi` is symmetric (k=2, the only case the suite tested); for k≥3 the CHIM placement / uniform-spacing property the method exists to provide is broken (the review measured an 8.6° direction error). Extracted into a testable `_quasi_normal(phi)` helper and fixed to `axis=0`.

**LaTeX display (modeling/latex.py, core.py):**
- **L1 (crash)** — `_constraint_to_latex` read `.body`/`.sense` on GDP constraint types (`_IndicatorConstraint`/`_DisjunctiveConstraint`/`_SOSConstraint`/`_LogicalConstraint`), so merely displaying a model with `if_then`/`either_or`/`m.logical` in Jupyter raised `AttributeError`. Now renders a `\text{[Type: name]}` placeholder for non-arithmetic constraints.
- **L5** — an indexed digit-suffixed variable rendered an invalid double subscript (`y1[0]` → `y_{1}_{0}`, a MathJax error box). Now merges to `y_{1,0}`; other bases are brace-wrapped so their subscripts nest validly.
- **L6 (crash)** — `_fmt_num(inf)` raised `OverflowError` via `int(inf)`. Now returns `\infty` / `-\infty` / `\mathrm{nan}` for non-finite input.
- **L8** — `Expression._repr_latex_` wrapped the plain repr in `$...$` (broken Jupyter math); now renders the DAG via `expr_to_latex`.

## Tests

New `python/tests/test_display_cluster.py` (`smoke`): MO1 axis=0 equals the negated anchor-row sum + a k=2 unchanged control; L1 GDP and indicator models render without crashing; L5 single subscript; L6 non-finite formatting + unbounded-variable model; L8 real math. **The latex tests fail on the pre-fix code** — verified fails-before/passes-after by reverting `latex.py`/`core.py` to `main`; MO1's behavioral change (axis0 ≠ axis1 for an asymmetric k=3 payoff) shown directly.

**Verification run:** `test_display_cluster` (9) + the mo/scalarization/pareto/latex suites → **69 passed, 0 regressions**. `ruff check` / `format --check` clean.

## Not in this PR (follow-ups)

The **example-model** findings (E1 Haverly wrong optimum, E2 `example_logical_constraints` crash, E3 reactor infeasible + a test carve-out to remove) are gallery-model *correctness* work — a different flavor from these display/rendering fixes, and E3 involves re-deriving a model and restoring a loosened assertion — so they're best as their own focused PR. Also deferred: latex L2 (fast-path rows invisible — part of the X-1 builder-rows root), L3/L4/L7, and MO2/MO3/MO4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm)_