### PR TITLE
fix(packaging): #433 — remove stale doe references from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,6 @@ learned = ["equinox>=0.13.8", "optax>=0.1"]
 # *code-generate* JAX relaxation closures offline; it is never imported on the
 # solver hot path. See docs/notebooks/symbolic_envelopes.ipynb.
 sympy = ["sympy>=1.12"]
-doe = ["openpyxl>=3.1"]
-doe-gui = ["discopt[doe]", "streamlit>=1.30", "pandas>=2.0"]
 dev = [
     "pytest",
     "pytest-timeout",
@@ -83,7 +81,7 @@ dev = [
     "onnx>=1.14",
     "onnxruntime>=1.16",
 ]
-all = ["discopt[pounce,ipopt,cutest,llm,gnn,nn,ml,doe,doe-gui,sympy,pyomo]"]
+all = ["discopt[pounce,ipopt,cutest,llm,gnn,nn,ml,sympy,pyomo]"]
 
 [project.scripts]
 discopt = "discopt.cli:main"
@@ -96,12 +94,6 @@ discopt-gams = "discopt.gams.link:main"
 [project.entry-points."pyomo.solvers"]
 discopt = "discopt.pyomo.solver"
 
-# CLI plugin subcommands (see the protocol in discopt/cli.py). The doe entry
-# will move to the standalone discopt-doe package when the module is extracted
-# (#389); registering the in-tree module here exercises the same mechanism.
-[project.entry-points."discopt.cli"]
-doe = "discopt.doe.cli"
-
 [tool.maturin]
 manifest-path = "crates/discopt-python/Cargo.toml"
 python-source = "python"
@@ -113,7 +105,6 @@ include = [
     "Cargo.lock",
     "crates/**/*.rs",
     "crates/**/*.toml",
-    "python/discopt/doe/gui/discopt-logo.png",
     "python/discopt/gams/data/*.gms",
     "python/discopt/gams/data/manifest.json",
 ]

--- a/python/tests/test_cli_plugins.py
+++ b/python/tests/test_cli_plugins.py
@@ -129,3 +129,26 @@ class TestLaziness:
         with pytest.raises(SystemExit) as exc:
             _main_with([FakeEntryPoint("fake", mod), never], ["fake"])
         assert exc.value.code == 0
+
+
+# Issue #433 regression: the DOE extraction (#410) left stale `doe` references in
+# pyproject.toml (extras, `all`, the `discopt.cli` entry point, a phantom maturin
+# include). They caused a spurious plugin-load warning on every `discopt help`.
+# Guard against them (and future extractions) reappearing.
+def test_pyproject_has_no_stale_doe_references():
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    pyproject = root / "pyproject.toml"
+    if not pyproject.exists():  # running from an installed wheel, not the repo
+        pytest.skip("pyproject.toml not present (installed context)")
+    text = pyproject.read_text()
+    stale = [
+        'doe = ["openpyxl',  # the `doe` extra
+        "doe-gui = ",  # the `doe-gui` extra
+        "doe,doe-gui",  # the `all` aggregate
+        "discopt.doe.cli",  # the core `discopt.cli` entry point (moved to discopt-doe)
+        "doe/gui/discopt-logo.png",  # the phantom maturin include (file removed by #410)
+    ]
+    found = [s for s in stale if s in text]
+    assert not found, f"stale DOE references survive in pyproject.toml (issue #433): {found}"


### PR DESCRIPTION
## fix(packaging): #433 — remove stale `doe` references from `pyproject.toml`

The #410 DOE extraction removed `python/discopt/doe/` (its commit message claimed the
packaging cleanup) but **never touched `pyproject.toml`**. Five dangling refs survived —
causing a spurious `discopt.cli` plugin-load warning on every `discopt help` and dragging
`streamlit`/`openpyxl`/`pandas` into `discopt[all]`.

**Removed all five:**
- `doe = ["openpyxl>=3.1"]` and `doe-gui = […]` extras
- `doe,doe-gui` inside the `all` aggregate
- the core `[project.entry-points."discopt.cli"] doe = "discopt.doe.cli"` entry point (+ comment) — moved to the standalone `discopt-doe` plugin
- the phantom maturin include `python/discopt/doe/gui/discopt-logo.png`

The `cli.py` docstring/comment examples mentioning `discopt.doe.cli` are **kept** — they now correctly describe the *external* plugin. `maturin develop` builds clean (confirms the include removal). The `discopt.cli` entry-points table is now empty; external plugins register their own.

**Regression test** `test_pyproject_has_no_stale_doe_references` (smoke) parses the repo `pyproject.toml` and asserts none of the five references reappear — **fail-before/pass-after verified** (re-adding `doe,doe-gui` fails it). Also a nudge for future extractions (#430/#431/#432): grep `pyproject.toml` for the module name as part of the extraction PR.

Gates: `test_cli_plugins.py` 11 passed; ruff clean; `maturin develop --release` builds clean.

Closes #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
