### PR TITLE
fix(examples): E1/E2/E3 — Haverly wrong optimum, logical-constraints crash, reactor infeasible

### DIFF
--- a/docs/dev/modeling-module-review.md
+++ b/docs/dev/modeling-module-review.md
@@ -32,7 +32,7 @@ unambiguous from control flow.
 | M7 | P2 perf | `core.py:3213` | `_check_name` rebuilds the full name set per declaration → **O(n²)** model build; measured 37→94→170 µs/var at n=1k/2k/4k [CONFIRMED] |
 | M8–M12 | P2 | various | Robustness/API gaps (§4) |
 | G1–G15 | **P0–P2** | `gams_parser.py` | Fifteen verified defect classes; the five worst silently build a *different model* than the GAMS source and let the solver certify it (§6.1) |
-| E1–E3 | **P0/P1** | `examples.py` | Haverly pooling example is mathematically wrong (certified optimum 1390 vs the classic 400); `example_logical_constraints` crashes (never built by any test); `example_reactor_design` is provably infeasible (§6.2) |
+| E1–E3 | **P0/P1** — ✅ RESOLVED | `examples.py` | Haverly pooling example is mathematically wrong (certified optimum 1390 vs the classic 400); `example_logical_constraints` crashes (never built by any test); `example_reactor_design` is provably infeasible (§6.2) |
 | L1–L8 | P1–P3 | `latex.py` | `to_latex`/Jupyter `_repr_` **crashes** on any model with `if_then`/`either_or`/`logical`; fast-path constraint families render as zero constraints; several precedence/escaping defects (§6.3) |
 | I1–I2 | P2 | `implicit.py` | Absolute-only Newton tolerance falsely NaN-fails well-posed scaled residuals; build-time probe uses wrong `u` length for vector inputs (§6.4) |
 
@@ -325,6 +325,28 @@ bug above is untested** (all fixtures use `model /all/`, dense positive alphabet
 tables, comma'd data, unquoted labels, lowercase-consistent names).
 
 ### 6.2 `examples.py` — the gallery contains wrong and broken models
+
+> **✅ RESOLVED E1, E2, E3** — `python/tests/test_examples_gallery.py` (this PR).
+> - **E1**: reformulated `example_pooling_haverly` with the pool **concentration**
+>   `p` (not sulfur mass) so the product specs bind even at zero pool flow. The
+>   review's suggested "scale `2z` by `(y0+y1)`" was itself wrong — multiplying the
+>   spec through by the pool flow makes it vacuous (`0 ≤ 0`) when the pool is
+>   bypassed, and the model then certified 500 shipping 2 %-sulfur product against
+>   the 1.5 % spec. The concentration form certifies the classic Haverly-I optimum
+>   **400** with the product-1 spec binding at exactly 1.5 %.
+> - **E2**: `example_logical_constraints` now uses `m.logical()` (not `subject_to`)
+>   for the propositional constraints, `m.make_disjunct()` (not `m.disjunct`), and
+>   encodes "project 3 requires project 0" as the implication `lor(~a3, a0)` (not the
+>   `land` conjunction that forced both). Also fixed `Disjunct`'s docstring
+>   (`Model.make_disjunct`). Builds and `validate()`s.
+> - **E3**: `example_reactor_design`'s heat balance dropped the needless `F/(Cp·F)`
+>   and reduced the exotherm so the adiabatic cascade stays within the 750 K limit
+>   (`T=[400,520,640]`); the model is now feasible (was provably infeasible). The
+>   `test_nlp_ipopt.py` "hard example" carve-out that accepted `INFEASIBLE` is
+>   removed — reactor takes the real `OPTIMAL/ITERATION_LIMIT` check.
+>
+> A whole-gallery smoke test now builds and `validate()`s every pure-modeling
+> `example_*`. Verified fails-before/passes-after. The full finding text is below.
 
 | ID | Loc | Finding |
 |----|-----|---------|

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -3420,7 +3420,7 @@ def exactly(k: int, *args: LogicalExpression) -> LogicalExactly:
 class Disjunct:
     """A named block of constraints activated by a boolean indicator.
 
-    Created via :meth:`Model.disjunct`, not directly.
+    Created via :meth:`Model.make_disjunct`, not directly.
 
     Parameters
     ----------

--- a/python/discopt/modeling/examples.py
+++ b/python/discopt/modeling/examples.py
@@ -59,10 +59,11 @@ def example_pooling_haverly():
     # z = direct flow from source 2 to product 1
     z = m.continuous("z_direct", lb=0, ub=100)
 
-    # Pool quality (bilinear: this is what makes it nonconvex)
-    # q = quality in pool = (quality_A * y[0] + quality_B * y[1]) / (y[0] + y[1])
-    # We reformulate using the p-formulation: p = q * total_flow
-    p = m.continuous("pool_quality_flow", lb=0, ub=300)
+    # Pool quality (bilinear: this is what makes it nonconvex). p is the pool
+    # sulfur CONCENTRATION (quality), bounded by the source qualities [1, 3].
+    # Modelling p as the concentration (not the sulfur *mass*) is what keeps the
+    # product specs from vanishing when the pool is bypassed — see below (E1).
+    p = m.continuous("pool_sulfur_concentration", lb=0.0, ub=3.0)
 
     # Source qualities
     quality = np.array([3.0, 1.0, 2.0])  # sulfur content
@@ -81,14 +82,23 @@ def example_pooling_haverly():
     # Pool mass balance
     m.subject_to(y[0] + y[1] == x[0] + x[1], name="pool_mass_balance")
 
-    # Pool quality balance (bilinear: p = quality[0]*y[0] + quality[1]*y[1])
-    m.subject_to(p == quality[0] * y[0] + quality[1] * y[1], name="pool_quality_balance")
-
-    # Product quality specs (bilinear: p * fraction <= spec * flow)
-    m.subject_to(p * x[0] <= 2.5 * x[0] * (y[0] + y[1]), name="product0_sulfur_spec")
+    # Pool quality balance (bilinear): concentration * pool inflow = sulfur mass in.
     m.subject_to(
-        p * x[1] + quality[2] * z <= 1.5 * (x[1] + z) * (y[0] + y[1]), name="product1_sulfur_spec"
+        p * (y[0] + y[1]) == quality[0] * y[0] + quality[1] * y[1],
+        name="pool_quality_balance",
     )
+
+    # Product quality specs: sulfur delivered <= spec * total flow to the product.
+    # Product 0 draws only pool flow (at concentration p); product 1 draws the pool
+    # stream x1 (at concentration p) plus the direct source-2 stream z (concentration
+    # quality[2]). Using the concentration p directly — rather than clearing a
+    # 1/(y0+y1) denominator by multiplying the spec through by the pool flow — keeps
+    # both constraints binding even when the pool is bypassed (pool flow -> 0). The
+    # original mass form multiplied through by (y0+y1), so an all-direct solution
+    # satisfied the spec vacuously (0 <= 0) and shipped 2 %-sulfur product against a
+    # 1.5 % spec, certifying a false optimum of 500 (true Haverly-I optimum 400) (E1).
+    m.subject_to(p * x[0] <= 2.5 * x[0], name="product0_sulfur_spec")
+    m.subject_to(p * x[1] + quality[2] * z <= 1.5 * (x[1] + z), name="product1_sulfur_spec")
 
     # Product demand
     m.subject_to(x[0] <= 100, name="product0_demand")
@@ -262,9 +272,16 @@ def example_reactor_design():
             name=f"conversion_stage{i}",
         )
 
-    # Heat balance: adiabatic temperature rise
+    # Heat balance: adiabatic temperature rise per stage.
+    # ΔT = -dH·X/Cp is intensive (independent of the feed rate F), so the original
+    # `F/(Cp*F)` was a needless division-by-variable that merely cancels to 1/Cp.
+    # With the original dH=-80000 the rise is 320 K/stage, which forces
+    # T[2] >= 940 K against the 750 K material limit below — the model was provably
+    # infeasible. A moderate exotherm keeps the 3-stage cascade within limits (E3).
     Cp = 75.0  # J/(mol·K)
-    dH = -80000.0  # J/mol (exothermic)
+    dH = -30000.0  # J/mol (exothermic)
+    conversion = 0.3  # fractional conversion per stage
+    delta_T = -dH * conversion / Cp  # adiabatic rise per stage, K (= 120 K)
     for i in range(3):
         if i == 0:
             m.subject_to(
@@ -272,8 +289,8 @@ def example_reactor_design():
                 name="feed_temp",
             )
         else:
-            # Temperature rises due to reaction
-            m.subject_to(T[i] == T[i - 1] - dH * 0.3 * F / (Cp * F), name=f"heat_balance_stage{i}")
+            # Temperature rises due to reaction (constant adiabatic increment).
+            m.subject_to(T[i] == T[i - 1] + delta_T, name=f"heat_balance_stage{i}")
 
     # Material limit on temperature
     m.subject_to([T[i] <= 750 for i in range(3)], name="max_temperature")
@@ -427,23 +444,29 @@ def example_logical_constraints():
     returns = np.array([12.0, 8.0, 15.0, 6.0])
     m.maximize(dm.sum(lambda i: returns[i] * invest[i], over=range(4)))
 
-    # Budget constraint (at most 3 projects active)
-    m.subject_to(dm.atmost(3, active), name="budget")
+    # Budget constraint (at most 3 projects active). Propositional-logic
+    # constraints go through m.logical(), not m.subject_to() (which takes
+    # algebraic Constraints only) (E2).
+    m.logical(dm.atmost(3, active), name="budget")
 
-    # Project 3 requires project 0 (precedence)
-    m.subject_to(dm.land(~active[3], active[0]), name="precedence")
+    # Project 3 requires project 0 (precedence): the implication a3 -> a0, i.e.
+    # lor(~a3, a0). The original land(~a3, a0) instead *asserts* both ~a3 and a0
+    # unconditionally (forcing project 3 off and project 0 on), not the
+    # requirement being modelled (E2).
+    m.logical(dm.lor(~active[3], active[0]), name="precedence")
 
     # At least one of projects 0 or 1 must be active
-    m.subject_to(dm.lor(active[0], active[1]), name="require_one")
+    m.logical(dm.lor(active[0], active[1]), name="require_one")
 
     # Investment only allowed if project is active (indicator constraints)
     for i in range(4):
         m.if_then(active[i].variable, [invest[i] >= 10, invest[i] <= 80])
 
-    # Disjunction: project 2 is either high-intensity (≥50) or low-intensity (≤20)
-    d_high = m.disjunct("project2_high")
+    # Disjunction: project 2 is either high-intensity (≥50) or low-intensity (≤20).
+    # Disjunct blocks are created with make_disjunct() (E2).
+    d_high = m.make_disjunct("project2_high")
     d_high.subject_to(invest[2] >= 50)
-    d_low = m.disjunct("project2_low")
+    d_low = m.make_disjunct("project2_low")
     d_low.subject_to(invest[2] <= 20)
     m.add_disjunction([d_high, d_low], name="project2_mode")
 

--- a/python/tests/test_examples_gallery.py
+++ b/python/tests/test_examples_gallery.py
@@ -1,0 +1,93 @@
+"""Regression tests for the examples-gallery fixes E1, E2, E3.
+
+- **E1** (`example_pooling_haverly`): the product-1 sulfur spec was dimensionally
+  inconsistent and, once "cleared" by multiplying through by the pool flow, went
+  vacuous when the pool was bypassed — certifying a false optimum of 500 that ships
+  2 %-sulfur product against a 1.5 % spec. Reformulated with the pool *concentration*
+  so the spec binds even at zero pool flow; the classic Haverly-I optimum is 400.
+- **E2** (`example_logical_constraints`): used non-existent API (`subject_to` on a
+  logical expression, `m.disjunct`) and encoded the precedence "3 requires 0" as a
+  conjunction that forces both values. Now builds and validates.
+- **E3** (`example_reactor_design`): the heat balance drove `T[2] >= 940 K` against a
+  750 K limit — provably infeasible. Fixed to a feasible adiabatic cascade.
+
+The whole-gallery build/validate test is `smoke`; the two global/feasibility solves
+carry time limits.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+import numpy as np
+import pytest
+from discopt.modeling import examples
+
+
+def _build(factory):
+    """Construct an example model, swallowing its illustrative print(m)."""
+    with contextlib.redirect_stdout(io.StringIO()):
+        return factory()
+
+
+# Pure-modeling examples (no external deps: nn / pyomo / a .nl file / litellm).
+_GALLERY = [
+    "example_simple_minlp",
+    "example_pooling_haverly",
+    "example_process_synthesis",
+    "example_portfolio",
+    "example_reactor_design",
+    "example_facility_location",
+    "example_parametric",
+    "example_logical_constraints",
+    "example_transportation",
+    "example_assignment",
+    "example_multicommodity_flow",
+]
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("fname", _GALLERY)
+def test_every_gallery_example_builds_and_validates(fname):
+    """Every gallery example constructs and passes validate() (E2 crashed here)."""
+    m = _build(getattr(examples, fname))
+    m.validate()  # must not raise
+
+
+@pytest.mark.smoke
+def test_e2_logical_constraints_precedence_is_an_implication():
+    """The precedence constraint must be the implication ~a3 | a0, not a conjunction."""
+    m = _build(examples.example_logical_constraints)
+    # A conjunction would have forced active[3]=0 and active[0]=1; as an
+    # implication the model just constrains them. Sanity: it builds with the
+    # expected logical + disjunction constraints present.
+    names = {getattr(c, "name", None) for c in m._constraints}
+    assert {"budget", "precedence", "require_one"} <= names
+
+
+def test_e1_haverly_certifies_classic_optimum_400():
+    """The fixed Haverly-I model certifies the textbook optimum of 400."""
+    m = _build(examples.example_pooling_haverly)
+    r = m.solve(time_limit=120)
+    assert r.objective is not None
+    assert float(r.objective) == pytest.approx(400.0, abs=1.0)
+    # The certified point must actually respect the 1.5 % product-1 spec.
+    val = {v.name: np.array(r.value(v)) for v in m._variables}
+    x = val["x_pool_to_product"]
+    z = float(val["z_direct"])
+    p = float(val["pool_sulfur_concentration"])
+    flow1 = float(x[1]) + z
+    if flow1 > 1e-6:
+        conc1 = (p * float(x[1]) + 2.0 * z) / flow1
+        assert conc1 <= 1.5 + 1e-4
+
+
+def test_e3_reactor_is_feasible_not_infeasible():
+    """The fixed reactor model is feasible (was provably infeasible)."""
+    m = _build(examples.example_reactor_design)
+    r = m.solve(time_limit=90)
+    assert r.status in ("optimal", "feasible"), f"reactor status {r.status}"
+    T = np.array(r.value(next(v for v in m._variables if v.name == "temperature")))
+    assert np.all(T <= 750.0 + 1e-3)  # material limit respected
+    assert float(T[0]) <= 400.0 + 1e-3  # feed temperature limit

--- a/python/tests/test_nlp_ipopt.py
+++ b/python/tests/test_nlp_ipopt.py
@@ -122,12 +122,11 @@ class TestConstrainedNLP:
 _SOLVABLE_EXAMPLES = [
     ("simple_minlp", examples.example_simple_minlp),
     ("pooling_haverly", examples.example_pooling_haverly),
-]
-
-# Reactor design is highly nonlinear (Arrhenius kinetics) and may converge
-# to local infeasibility from an arbitrary midpoint start.  We test it
-# separately with a looser status assertion.
-_HARD_EXAMPLES = [
+    # reactor_design used to be quarantined as a "hard example" with a loosened
+    # assertion that accepted INFEASIBLE — masking the fact that its heat balance
+    # was provably infeasible (T[2] >= 940 K vs a 750 K limit). With that fixed
+    # (E3) the model is feasible, so it takes the real OPTIMAL/ITERATION_LIMIT
+    # check like the others.
     ("reactor_design", examples.example_reactor_design),
 ]
 
@@ -157,21 +156,6 @@ class TestExampleModels:
         result = solve_nlp_from_model(m, options={"max_iter": 3000})
         if result.status == SolveStatus.OPTIMAL:
             assert np.isfinite(result.objective)
-
-    @pytest.mark.parametrize("name,factory", _HARD_EXAMPLES, ids=[e[0] for e in _HARD_EXAMPLES])
-    def test_hard_example_runs_without_error(self, name, factory):
-        """Hard nonlinear models run without crashing; any terminal status is OK."""
-        m = factory()
-        result = solve_nlp_from_model(m, options={"max_iter": 3000})
-        assert result.status in (
-            SolveStatus.OPTIMAL,
-            SolveStatus.ITERATION_LIMIT,
-            SolveStatus.INFEASIBLE,
-            SolveStatus.ERROR,  # some cyipopt versions return ERROR for hard problems
-        )
-        assert result.x is not None
-        if result.status != SolveStatus.ERROR:
-            assert np.all(np.isfinite(result.x))
 
 
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the three gallery-model findings from modeling-review §6.2 — the example-model correctness half of the display cluster. These are illustrative models users copy, and two of them shipped a *wrong certified answer* or a *crash*. Isolated to `modeling/examples.py` (+ one docstring and one test-carve-out). Part of the parallel-track effort under issue #413.

**E1 — Haverly pooling certifies a false optimum.** The product-1 sulfur spec was dimensionally inconsistent. Notably, **the review's own suggested fix (scale the `2z` term by `(y0+y1)`) is itself wrong**: multiplying the spec through by the pool flow makes it vacuous (`0 ≤ 0`) when the pool is bypassed, so an all-direct solution ships 2 %-sulfur product against a 1.5 % spec and certifies **500**. I reformulated with the pool **concentration** `p` (not sulfur mass) so the specs bind even at zero pool flow. The model now certifies the classic **Haverly-I optimum 400**, with the product-1 spec binding at exactly 1.5 % — matching the independently-correct `pooling.py` (`gap_certified=True`).

**E2 — `example_logical_constraints` crashes.** It used non-existent API and wrong logic: `m.subject_to()` on `LogicalExpression`s (should be `m.logical()`), `m.disjunct()` (should be `m.make_disjunct()`), and encoded "project 3 requires project 0" as `land(~a3, a0)` — which *asserts both* unconditionally rather than the implication `lor(~a3, a0)`. Fixed all three; also corrected `Disjunct`'s docstring (`Model.make_disjunct`). Builds and `validate()`s.

**E3 — `example_reactor_design` is provably infeasible.** The heat balance `T[i] = T[i-1] − dH·0.3·F/(Cp·F)` has a needless `F/F` division and, with `dH=−80000`, a 320 K/stage rise that forces `T[2] ≥ 940 K` against a 750 K material limit. Removed the `F/F` (the adiabatic rise is intensive) and reduced the exotherm to a feasible cascade (`T=[400,520,640]`). **Removed the "hard example" carve-out in `test_nlp_ipopt.py`** that accepted `INFEASIBLE`, restoring the real `OPTIMAL/ITERATION_LIMIT` check — this carve-out was exactly the "workaround masking a real bug" the development philosophy forbids.

## Tests

New `python/tests/test_examples_gallery.py`: a whole-gallery `smoke` test builds and `validate()`s **every** pure-modeling `example_*` (E2 crashed here); E1 certifies 400 with the spec respected; E3 is feasible with `T` within limits. **E2's crash is verified fails-before/passes-after**; E1 (500→400) and E3 (infeasible→feasible) behavioral changes verified directly against the solver.

**Verification run:** `test_examples_gallery` → **14 passed**. `ruff check` / `format --check` clean. cyipopt isn't installed in my environment, so the restored `test_nlp_ipopt.py` reactor check runs in CI rather than locally; the model's feasibility is verified via the main global solver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmFoJ1AcPtAWdaWK2tz4fm)_