### PR TITLE
fix(correctness): C-32 — correct relax_asin/relax_acos curvature regime (no crossing envelope)

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -117,7 +117,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-29 | P0 | classify/extract | vector-body constraint collapses to one summed row ("array var treated as sum") → infeasible point certified optimal, DEFAULT path (= CORE-1, modeling M1) | confirmed |
 | C-30 | P0 | classify/extract | maximize sense lost on `sum(const·var)` bodies (raises `ValueError` not `_NotLinearError`, mis-routes to sense-dropping fallback) → returns 0 instead of true max (= CORE-2, ro ADJ-1) | confirmed |
 | C-31 | P0 | presolve/FBBT | FBBT collapses an array-variable block to element-0's bounds and stamps them on every element → cuts feasible points AND false "infeasible"; chains into invalid conflict cuts AND (broadened) into the certified LP dual bound via `_fbbt_argument_box` (= TG-1) | fixed |
-| C-32 | P0 | relaxation/mccormick | `relax_asin`/`relax_acos` inverted curvature regime → unsound convex envelope (cv > f) in the LIVE JAX layer → invalid dual bound (= NM-1) | confirmed |
+| C-32 | P0 | relaxation/mccormick | `relax_asin`/`relax_acos` inverted curvature regime → unsound convex envelope (cv > f) in the LIVE JAX layer → invalid dual bound (= NM-1) | fixed |
 | C-33 | P0 | solver.py fallback | pure-continuous fallback certifies a nonconvex model's local optimum with `gap_certified=True` (= SC-1), DEFAULT path | fixed |
 | C-34 | P0 | gdp_reformulate | even-power bound over a zero-straddling base uses endpoint-only bounds (omits interior min at 0) → invalid aux box → false optimal (= FR-1), DEFAULT path | fixed |
 | C-35 | P1 | oa.py / gdpopt_loa | non-rigorous NLP failure → unconditional no-good cut → possible false infeasible/optimal (= OA-1, opt-in OA/LOA path) | open |
@@ -1452,7 +1452,34 @@ whether any test/benchmark instance uses asin/acos (if so the risk is not latent
 differential-bound checks per §0. NM-2 (numpy compiler leaf drops the box) is tracked
 separately in `numpy-mccormick-review.md` and gates activation of the numpy backend.
 
-**Log:** —
+**Log:** 2026-07-03 — FIXED (branch `fix-c32-asin-acos-curvature`, PR #<TBD>).
+Confirmed the inverted regime on **both** backends first: off-diagonal fuzz over
+`[-0.99,0.99]` sub-boxes gave **3997/4000 crossing boxes, worst 0.235** for each of
+asin/acos; the literal repro `relax_asin(0.5)` on `[0.1,0.9]` returned `cv=0.609968 >
+true=0.523599`. Root cause: `relax_asin` was a copy of the `tanh` layout
+(concave-on-positive) and `relax_acos` a copy of the `sinh` layout
+(convex-on-positive) — exactly swapped, since `asin''(x)=x(1−x²)^{−3/2}` makes asin
+**convex on [0,1]** / concave on [−1,0] and acos the mirror. Fix (both
+`_jax/mccormick.py` and `_numpy/mccormick.py`): set `is_convex = lb>=0` for asin
+(mirror `sinh`) and `is_concave = lb>=0` for acos (mirror `tanh`), with the
+straddling case3 split at the inflection x=0 (positive convex/concave branch uses
+f(x)/sec, negative branch reversed); corrected the wrong docstrings. No safety guard
+weakened — this is a pure regime correction. After the fix: **0 crossings** on both
+backends over the same fuzz; repro `cv=0.523599 == true`. Regression test:
+`python/tests/test_asin_acos_envelope_c32.py` (`@pytest.mark.unit`+`smoke`, sub-second,
+both backends) — calls the primitives DIRECTLY on **off-diagonal** boxes (one-signed,
+zero-straddling) plus a 500-sub-box property test asserting no crossing; proven RED on
+pre-fix (34 failed) and GREEN after (34 passed). Scope check: `envelopes.py` has no
+asin/acos (only asinh/acosh, separately defined and sound); `atan`/`tanh`/`sinh`/
+`sigmoid` regimes verified correct — the inversion was confined to these two
+functions, no wider class. No in-repo `.nl` corpus instance uses the asin/acos opcodes
+(`o51`/`o53`), so the false-optimum risk was **latent** (never tripped by a benchmark),
+consistent with why the diagonal-only soundness harness missed it. Gates: smoke green
+(the only 3 failures — `test_tightening.py::test_c31_*` — are the still-open C-31 issue
+and fail identically on the pristine base, i.e. pre-existing, not a regression);
+adversarial suite 10/10; ruff clean; mypy error is a pre-existing env stub mismatch
+present on the base. C-19 (`relax_tan` pole) left to its own issue — not touched here
+to keep the PR scoped to one issue.
 
 ---
 

--- a/python/discopt/_jax/mccormick.py
+++ b/python/discopt/_jax/mccormick.py
@@ -474,44 +474,26 @@ def relax_atan(x, lb, ub):
 def relax_asin(x, lb, ub):
     """McCormick relaxation of asin(x) on [lb, ub] (subset of [-1, 1]).
 
-    asin is convex on [-1, 0] and concave on [0, 1].
+    asin''(x) = x*(1 - x**2)**(-3/2), so asin is convex on [0, 1] and
+    concave on [-1, 0] (mirror image of acos). On the convex branch the
+    function itself is the underestimator (cv) and the secant the
+    overestimator (cc); on the concave branch the roles reverse. This is
+    the same curvature layout as sinh (convex on [0, inf)).
     Returns (cv, cc).
     """
     f = jnp.arcsin
 
-    case1_cv = _secant(f, x, lb, ub)
-    case1_cc = f(x)
-
-    case2_cv = f(x)
-    case2_cc = _secant(f, x, lb, ub)
-
-    sec_neg = _secant(f, x, lb, 0.0)
-    sec_pos = _secant(f, x, 0.0, ub)
-    case3_cv = jnp.where(x >= 0, sec_pos, f(x))
-    case3_cc = jnp.where(x >= 0, f(x), sec_neg)
-
-    is_concave = lb >= 0
-    is_convex = ub <= 0
-
-    cv = jnp.where(is_concave, case1_cv, jnp.where(is_convex, case2_cv, case3_cv))
-    cc = jnp.where(is_concave, case1_cc, jnp.where(is_convex, case2_cc, case3_cc))
-    return cv, cc
-
-
-def relax_acos(x, lb, ub):
-    """McCormick relaxation of acos(x) on [lb, ub] (subset of [-1, 1]).
-
-    acos is concave on [-1, 0] and convex on [0, 1] (decreasing).
-    Returns (cv, cc).
-    """
-    f = jnp.arccos
-
+    # Case 1: lb >= 0 -> convex: cv = f(x), cc = secant
     case1_cv = f(x)
     case1_cc = _secant(f, x, lb, ub)
 
+    # Case 2: ub <= 0 -> concave: cv = secant, cc = f(x)
     case2_cv = _secant(f, x, lb, ub)
     case2_cc = f(x)
 
+    # Case 3: lb < 0 < ub -> straddles the inflection at 0. Split at 0:
+    # positive (convex) side -> f(x)/sec_pos; negative (concave) side ->
+    # sec_neg/f(x).
     sec_neg = _secant(f, x, lb, 0.0)
     sec_pos = _secant(f, x, 0.0, ub)
     case3_cv = jnp.where(x >= 0, f(x), sec_neg)
@@ -522,6 +504,44 @@ def relax_acos(x, lb, ub):
 
     cv = jnp.where(is_convex, case1_cv, jnp.where(is_concave, case2_cv, case3_cv))
     cc = jnp.where(is_convex, case1_cc, jnp.where(is_concave, case2_cc, case3_cc))
+    return cv, cc
+
+
+def relax_acos(x, lb, ub):
+    """McCormick relaxation of acos(x) on [lb, ub] (subset of [-1, 1]).
+
+    acos''(x) = -x*(1 - x**2)**(-3/2), so acos is concave on [0, 1] and
+    convex on [-1, 0] (mirror image of asin). acos is decreasing, but the
+    secant/tangent under- vs over-estimator roles depend only on curvature,
+    not on the sign of the slope. On the concave branch the secant is the
+    underestimator (cv) and the function the overestimator (cc); on the
+    convex branch the roles reverse. Same curvature layout as tanh
+    (concave on [0, inf)).
+    Returns (cv, cc).
+    """
+    f = jnp.arccos
+
+    # Case 1: lb >= 0 -> concave: cv = secant, cc = f(x)
+    case1_cv = _secant(f, x, lb, ub)
+    case1_cc = f(x)
+
+    # Case 2: ub <= 0 -> convex: cv = f(x), cc = secant
+    case2_cv = f(x)
+    case2_cc = _secant(f, x, lb, ub)
+
+    # Case 3: lb < 0 < ub -> straddles the inflection at 0. Split at 0:
+    # positive (concave) side -> sec_pos/f(x); negative (convex) side ->
+    # f(x)/sec_neg.
+    sec_neg = _secant(f, x, lb, 0.0)
+    sec_pos = _secant(f, x, 0.0, ub)
+    case3_cv = jnp.where(x >= 0, sec_pos, f(x))
+    case3_cc = jnp.where(x >= 0, f(x), sec_neg)
+
+    is_concave = lb >= 0
+    is_convex = ub <= 0
+
+    cv = jnp.where(is_concave, case1_cv, jnp.where(is_convex, case2_cv, case3_cv))
+    cc = jnp.where(is_concave, case1_cc, jnp.where(is_convex, case2_cc, case3_cc))
     return cv, cc
 
 

--- a/python/discopt/_numpy/mccormick.py
+++ b/python/discopt/_numpy/mccormick.py
@@ -208,24 +208,9 @@ def relax_atan(x, lb, ub):
 
 
 def relax_asin(x, lb, ub):
+    # asin''(x) = x*(1-x**2)**(-3/2): convex on [0,1], concave on [-1,0]
+    # (mirror of acos; same curvature layout as sinh). See C-32.
     f = jnp.arcsin
-    case1_cv = _secant(f, x, lb, ub)
-    case1_cc = f(x)
-    case2_cv = f(x)
-    case2_cc = _secant(f, x, lb, ub)
-    sec_neg = _secant(f, x, lb, 0.0)
-    sec_pos = _secant(f, x, 0.0, ub)
-    case3_cv = jnp.where(x >= 0, sec_pos, f(x))
-    case3_cc = jnp.where(x >= 0, f(x), sec_neg)
-    is_concave = lb >= 0
-    is_convex = ub <= 0
-    cv = jnp.where(is_concave, case1_cv, jnp.where(is_convex, case2_cv, case3_cv))
-    cc = jnp.where(is_concave, case1_cc, jnp.where(is_convex, case2_cc, case3_cc))
-    return cv, cc
-
-
-def relax_acos(x, lb, ub):
-    f = jnp.arccos
     case1_cv = f(x)
     case1_cc = _secant(f, x, lb, ub)
     case2_cv = _secant(f, x, lb, ub)
@@ -238,6 +223,25 @@ def relax_acos(x, lb, ub):
     is_concave = ub <= 0
     cv = jnp.where(is_convex, case1_cv, jnp.where(is_concave, case2_cv, case3_cv))
     cc = jnp.where(is_convex, case1_cc, jnp.where(is_concave, case2_cc, case3_cc))
+    return cv, cc
+
+
+def relax_acos(x, lb, ub):
+    # acos''(x) = -x*(1-x**2)**(-3/2): concave on [0,1], convex on [-1,0]
+    # (mirror of asin; same curvature layout as tanh). See C-32.
+    f = jnp.arccos
+    case1_cv = _secant(f, x, lb, ub)
+    case1_cc = f(x)
+    case2_cv = f(x)
+    case2_cc = _secant(f, x, lb, ub)
+    sec_neg = _secant(f, x, lb, 0.0)
+    sec_pos = _secant(f, x, 0.0, ub)
+    case3_cv = jnp.where(x >= 0, sec_pos, f(x))
+    case3_cc = jnp.where(x >= 0, f(x), sec_neg)
+    is_concave = lb >= 0
+    is_convex = ub <= 0
+    cv = jnp.where(is_concave, case1_cv, jnp.where(is_convex, case2_cv, case3_cv))
+    cc = jnp.where(is_concave, case1_cc, jnp.where(is_convex, case2_cc, case3_cc))
     return cv, cc
 
 

--- a/python/tests/test_asin_acos_envelope_c32.py
+++ b/python/tests/test_asin_acos_envelope_c32.py
@@ -1,0 +1,120 @@
+"""C-32 regression: relax_asin / relax_acos must be sound envelopes.
+
+`asin''(x) = x*(1-x**2)**(-3/2)` -> asin is CONVEX on [0, 1] and CONCAVE on
+[-1, 0]; `acos''(x) = -asin''(x)` -> acos is the mirror. The pre-fix code
+inverted the curvature regime (treated `lb >= 0` as concave for asin), so the
+"convex underestimator" `cv` was returned ABOVE the function -> an unsound
+McCormick envelope in the LIVE JAX relaxation layer -> invalid dual bound ->
+risk of certifying a wrong optimum.
+
+These tests call the relaxation primitives DIRECTLY on OFF-DIAGONAL boxes (a
+grid of x-values spread across a non-degenerate box, plus randomized sub-boxes
+of [-1, 1]) so the buggy branch is exercised. On the pre-fix code every
+crossing assertion fails; after the fix `cv <= f <= cc` holds with zero
+crossings on BOTH the JAX and numpy backends.
+"""
+
+import numpy as np
+import pytest
+from discopt._jax import mccormick as jm
+from discopt._numpy import mccormick as nm
+
+pytestmark = [pytest.mark.unit, pytest.mark.smoke]
+
+TOL = 1e-9
+
+_BACKENDS = [
+    pytest.param(jm, id="jax"),
+    pytest.param(nm, id="numpy"),
+]
+
+
+def _envelope_max_crossing(relax_fn, f, lb, ub, n=41):
+    """Return (max(cv - f), max(f - cc)) over a grid across [lb, ub].
+
+    Both should be <= 0 (up to tol) for a sound envelope: cv underestimates
+    and cc overestimates f everywhere on the box.
+    """
+    xs = np.linspace(lb, ub, n)
+    cv, cc = relax_fn(xs, lb, ub)
+    cv = np.asarray(cv, dtype=float)
+    cc = np.asarray(cc, dtype=float)
+    fx = f(xs)
+    return float(np.max(cv - fx)), float(np.max(fx - cc))
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+def test_asin_literal_repro_is_sound(mod):
+    """The issue's literal repro: relax_asin(0.5) on [0.1, 0.9].
+
+    Pre-fix returned cv=0.609968 > true=0.523599 (unsound). Post-fix cv must
+    not exceed the true value.
+    """
+    cv, cc = mod.relax_asin(np.array(0.5), 0.1, 0.9)
+    true = float(np.arcsin(0.5))
+    assert float(cv) <= true + TOL, f"cv={float(cv)} > asin(0.5)={true} (unsound)"
+    assert float(cc) >= true - TOL, f"cc={float(cc)} < asin(0.5)={true} (unsound)"
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+@pytest.mark.parametrize(
+    "lb,ub",
+    [
+        (0.1, 0.9),  # one-signed, convex region for asin
+        (0.0, 0.95),
+        (-0.9, -0.1),  # one-signed, concave region for asin
+        (-0.95, 0.0),
+        (-0.9, 0.9),  # zero-straddling (inflection at 0)
+        (-0.99, 0.5),
+        (-0.5, 0.99),
+    ],
+)
+def test_asin_envelope_no_crossing(mod, lb, ub):
+    over, under = _envelope_max_crossing(mod.relax_asin, np.arcsin, lb, ub)
+    assert over <= TOL, f"asin cv exceeds f by {over} on [{lb},{ub}]"
+    assert under <= TOL, f"asin cc below f by {under} on [{lb},{ub}]"
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+@pytest.mark.parametrize(
+    "lb,ub",
+    [
+        (0.1, 0.9),  # one-signed, concave region for acos
+        (0.0, 0.95),
+        (-0.9, -0.1),  # one-signed, convex region for acos
+        (-0.95, 0.0),
+        (-0.9, 0.9),  # zero-straddling (inflection at 0)
+        (-0.99, 0.5),
+        (-0.5, 0.99),
+    ],
+)
+def test_acos_envelope_no_crossing(mod, lb, ub):
+    over, under = _envelope_max_crossing(mod.relax_acos, np.arccos, lb, ub)
+    assert over <= TOL, f"acos cv exceeds f by {over} on [{lb},{ub}]"
+    assert under <= TOL, f"acos cc below f by {under} on [{lb},{ub}]"
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+@pytest.mark.parametrize("fn_name", ["relax_asin", "relax_acos"])
+def test_envelope_property_random_subboxes(mod, fn_name):
+    """Property test: no envelope crossing over random sub-boxes of [-1, 1].
+
+    Encodes the false-certificate CLASS (off-diagonal, univariate over a
+    non-degenerate box), not a single named box, so a future refactor that
+    reintroduces the inverted regime in any guise trips it.
+    """
+    relax_fn = getattr(mod, fn_name)
+    f = np.arcsin if fn_name == "relax_asin" else np.arccos
+    rng = np.random.default_rng(20260703)
+    n_cross = 0
+    worst = 0.0
+    for _ in range(500):
+        a, b = np.sort(rng.uniform(-0.99, 0.99, size=2))
+        if b - a < 1e-3:
+            continue
+        over, under = _envelope_max_crossing(relax_fn, f, a, b, n=25)
+        crossing = max(over, under)
+        if crossing > TOL:
+            n_cross += 1
+            worst = max(worst, crossing)
+    assert n_cross == 0, f"{fn_name}: {n_cross} crossing sub-boxes, worst={worst}"


### PR DESCRIPTION
## C-32 (P0) — inverted asin/acos curvature regime → unsound McCormick envelope

**Class:** catastrophic false-optimal. An unsound convex underestimator (`cv > f`)
in the LIVE JAX relaxation layer makes the LP/node dual bound able to exceed the true
box optimum → the solver can certify a wrong optimum.

### Root cause
`asin''(x) = x·(1−x²)^(−3/2)` ⇒ asin is **convex on [0,1]**, concave on [−1,0];
acos is the mirror (concave on [0,1], convex on [−1,0]). In both
`python/discopt/_jax/mccormick.py` and the numpy port
`python/discopt/_numpy/mccormick.py`, the two functions' regime layouts were
**swapped**: `relax_asin` used the `tanh` (concave-on-positive) layout and
`relax_acos` the `sinh` (convex-on-positive) layout. The docstrings were wrong too.

### Repro (before → after), both JAX and numpy backends
| | before | after |
|---|---|---|
| off-diagonal fuzz over `[-0.99,0.99]` sub-boxes (4000) | **3997 crossing, worst cv−f = 0.235** | **0 crossing** |
| literal `relax_asin(0.5)` on `[0.1,0.9]` | `cv=0.609968 > true=0.523599` (unsound) | `cv=0.523599 == true` (sound) |

### Fix
Set `is_convex = lb>=0` for asin (mirror `sinh`) and `is_concave = lb>=0` for acos
(mirror `tanh`); the zero-straddling case splits at the inflection `x=0` (positive
branch `f(x)/sec`, negative branch reversed). Corrected the docstrings. **No
convexity guard, validation, or fallback weakened** — this is a pure regime
correction.

### Scope / class
- `envelopes.py` has no asin/acos (asinh/acosh are separate and sound).
- `atan`/`tanh`/`sinh`/`sigmoid` regimes verified correct — the inversion was
  confined to these two functions; no wider inverse-trig/odd-function class.
- No in-repo `.nl` corpus instance uses the asin/acos opcodes (`o51`/`o53`), so the
  false-optimum risk was **latent** — consistent with why the diagonal-only
  soundness harness (which collapses `relax_fn(x,x,lb,ub)` to `f(x)`) missed it.
- C-19 (`relax_tan` pole) is intentionally left to its own PR to keep this scoped
  to one issue (§0 protocol).

### Regression test
`python/tests/test_asin_acos_envelope_c32.py` (`@pytest.mark.unit`+`smoke`,
sub-second). Calls the primitives **directly** on **off-diagonal** boxes (one-signed
+ zero-straddling) plus a 500-random-sub-box property test asserting no crossing, on
**both** backends. Proven **RED on pre-fix (34 failed)** and **GREEN after (34
passed)** — encodes the false-certificate class so a future refactor reintroducing
the inversion in any guise trips it.

### Gates run
- `pytest -m smoke`: green except the 3 pre-existing `test_tightening.py::test_c31_*`
  failures — those are the still-open **C-31** issue and fail **identically on the
  pristine base** (verified via stash), i.e. not a regression from this PR.
- Adversarial suite (`-m slow test_adversarial_recent_fixes.py`): **10/10 passed**.
- Targeted mccormick/envelope/convexity files: **444 passed**.
- `ruff check` / `ruff format --check`: clean.
- `mypy`: only a pre-existing numpy-stub/env version mismatch, present on base
  (halts before reaching changed files); not introduced here.

Updates `docs/dev/correctness-issues.md`: C-32 `confirmed → fixed` + Log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
