### PR TITLE
fix(correctness): C-29/C-30 — per-element linear-body extraction + preserve maximize sense

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -114,8 +114,8 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-26 | P1 | nn/tree_ensemble | tree big-M invalid for out-of-box thresholds → cuts feasible points | in progress (nn-module-plan T-N0.3) |
 | C-27 | P2 | nn/readers/onnx | ONNX reader silently mis-reads Gemm attrs / residual Add / branched graphs | in progress (nn-module-plan T-N1.1) |
 | C-28 | P2 | nn/readers/sklearn | sklearn classifier semantics silently embed logits / wrong base_score | in progress (nn-module-plan T-N1.2) |
-| C-29 | P0 | classify/extract | vector-body constraint collapses to one summed row ("array var treated as sum") → infeasible point certified optimal, DEFAULT path (= CORE-1, modeling M1) | confirmed |
-| C-30 | P0 | classify/extract | maximize sense lost on `sum(const·var)` bodies (raises `ValueError` not `_NotLinearError`, mis-routes to sense-dropping fallback) → returns 0 instead of true max (= CORE-2, ro ADJ-1) | confirmed |
+| C-29 | P0 | classify/extract | vector-body constraint collapses to one summed row ("array var treated as sum") → infeasible point certified optimal, DEFAULT path (= CORE-1, modeling M1) | fixed |
+| C-30 | P0 | classify/extract | maximize sense lost on `sum(const·var)` bodies (raises `ValueError` not `_NotLinearError`, mis-routes to sense-dropping fallback) → returns 0 instead of true max (= CORE-2, ro ADJ-1) | fixed |
 | C-31 | P0 | presolve/FBBT | FBBT collapses an array-variable block to element-0's bounds and stamps them on every element → cuts feasible points AND false "infeasible"; chains into invalid conflict cuts AND (broadened) into the certified LP dual bound via `_fbbt_argument_box` (= TG-1) | fixed |
 | C-32 | P0 | relaxation/mccormick | `relax_asin`/`relax_acos` inverted curvature regime → unsound convex envelope (cv > f) in the LIVE JAX layer → invalid dual bound (= NM-1) | confirmed |
 | C-33 | P0 | solver.py fallback | pure-continuous fallback certifies a nonconvex model's local optimum with `gap_certified=True` (= SC-1), DEFAULT path | fixed |
@@ -1285,7 +1285,27 @@ points; algebraic-vs-autodiff extraction agree (rows, matrix, objective, sense) 
 property-test panel of vectorized affine models; `_eval_const` non-scalar → `_NotLinearError`;
 standing gates; `incorrect_count ≤ 0`.
 
-**Log:** —
+**Log:** 2026-07-03 **fixed** (branch `fix-c29-c30-linear-body-classify`, with C-30).
+Confirmed first: LP `min Σa+Σb s.t. a+b>=1` (shape (2,), box [0,1]) certified **1.0**
+at the elementwise-infeasible point `a=b=[0.25,0.25]` (`a+b=0.5<1`), true **2.0**; MILP
+set-cover `y+z>=1` (shape (3,) binaries) certified **1.0**, true **3.0**. Root cause:
+the algebraic walkers `_extract_linear_coefficients`/`_extract_quadratic_coefficients`
+collapsed a size>1 array variable in *scalar* position into one summed row, and the
+constraint loop appends exactly one row per `Constraint`, so a vector body `a+b>=1`
+became `Σa+Σb>=1`. **Fix (Stage 1, sound-minimal):** both `_walk`s now carry an
+`allow_array` flag — True only under a `SumExpression` (where element-collapse with a
+*uniform* scale is a legitimate reduction), False elsewhere; an array node in scalar
+position raises `_NotLinearError`/`_NotQuadraticError` so `extract_lp_data`'s dispatcher
+routes the body to the per-component autodiff extractor (one LP row per element). Also
+`_eval_const` now raises `_NotLinearError` (not `ValueError`) on a non-scalar array
+constant. Legit `sum(array_var)` bodies still take the fast algebraic single-row path
+(bound-neutral guard test). Post-fix: both repros certify 2.0 / 3.0 at elementwise-
+feasible points. Regression: `python/tests/test_c29_c30_linear_body_classify.py`
+(`test_c29_vector_body_not_collapsed_to_single_row`,
+`test_c29_solve_certifies_feasible_point`, `test_c29_milp_set_cover_vector_body`,
+`test_legit_sum_stays_on_fast_algebraic_path`), all `@pytest.mark.smoke`, red-before/
+green-after. Gates: smoke 297 passed (only the 3 pre-existing C-31 tests fail — separate
+Rust FBBT bug, out of scope), adversarial 10 passed, ruff clean. PR #___.
 
 ---
 
@@ -1315,7 +1335,26 @@ add a regression asserting `extract_lp_data(maximize_model).c` is negated.
 **Done criteria:** the maximize repro returns 4.0 and negated `c`; the sense-negation
 audit lands with a regression test; standing gates.
 
-**Log:** —
+**Log:** 2026-07-03 **fixed** (branch `fix-c29-c30-linear-body-classify`, with C-29).
+Confirmed first: `maximize dm.sum([1,1]·x) s.t. dm.sum([1,1]·x)<=4`, `x∈[0,10]²`
+certified **1.5e-08** at `x≈[0,0]`, true **4.0**; `extract_lp_data(m).c == [1,1,0]`
+un-negated. Two-part root cause: (1) `_eval_const` raised a raw `ValueError` on the
+size-2 array constant, aborting the algebraic walk; (2) the fallback it landed in —
+`_extract_lp_data_autodiff` — was the ONLY extractor that never applied the maximize
+negation (`extract_lp_data_algebraic:743`, `_extract_lp_data_from_repr:927`,
+`_extract_qp_data_autodiff:1375` all do), so it emitted `c=[1,1,0]` and the solver
+minimized a maximize model. **Fix:** `_eval_const` now raises `_NotLinearError` on a
+non-scalar array (C-29 change), AND `_extract_lp_data_autodiff` now negates `c`/
+`obj_const` for `ObjectiveSense.MAXIMIZE` — closing the sense-dropping gap for *every*
+body that routes to the autodiff LP fallback, not just this one. Audited all six
+sense-negation sites: the autodiff LP extractor was the sole omission. Post-fix: repro
+certifies **4.0** with `c=[-1,-1,0]`. Regression:
+`test_c30_eval_const_refuses_array_with_notlinear`,
+`test_c30_maximize_sense_preserved_in_extracted_c`,
+`test_c30_autodiff_extractor_applies_maximize_sense`,
+`test_c30_solve_maximize_returns_true_max` in
+`python/tests/test_c29_c30_linear_body_classify.py`, all `@pytest.mark.smoke`,
+red-before/green-after. Gates as for C-29. PR #___.
 
 ---
 

--- a/python/discopt/_jax/problem_classifier.py
+++ b/python/discopt/_jax/problem_classifier.py
@@ -205,13 +205,20 @@ def _extract_linear_coefficients(expr, model: Model, n: int):
     c = np.zeros(n, dtype=np.float64)
     const = 0.0
 
-    def _walk(node, scale=1.0):
+    def _walk(node, scale=1.0, allow_array=False):
+        # ``allow_array`` is True only inside a ``sum(...)`` reduction, where a
+        # size>1 (sub)expression contributes a single scalar row (its element sum
+        # with a *uniform* scale). Outside a sum, encountering a size>1 array node
+        # in scalar position means the whole body is vector-valued: the algebraic
+        # extractor would collapse it to one summed row (C-29), certifying an
+        # infeasible point. Refuse instead so extract_lp_data() routes the body to
+        # the per-component autodiff extractor (one LP row per element).
         nonlocal const
 
         if isinstance(node, Constant):
             val = node.value
-            if val.ndim == 0:
-                const += scale * float(val)
+            if val.ndim == 0 or val.size == 1:
+                const += scale * float(val.reshape(()))
             else:
                 raise _NotLinearError("Array constant in unexpected position")
             return
@@ -220,10 +227,15 @@ def _extract_linear_coefficients(expr, model: Model, n: int):
             offset = _compute_var_offset(node, model)
             if node.size == 1:
                 c[offset] += scale
-            else:
-                # Array variable treated as sum when used as scalar
+            elif allow_array:
+                # Inside sum(): sum(scale * x) = scale * Σ x_j (uniform scale).
                 for j in range(node.size):
                     c[offset + j] += scale
+            else:
+                raise _NotLinearError(
+                    "Array variable in scalar position (vector-valued body); "
+                    "routing to the per-component extractor"
+                )
             return
 
         if isinstance(node, IndexExpression):
@@ -246,46 +258,50 @@ def _extract_linear_coefficients(expr, model: Model, n: int):
 
         if isinstance(node, BinaryOp):
             if node.op == "+":
-                _walk(node.left, scale)
-                _walk(node.right, scale)
+                _walk(node.left, scale, allow_array)
+                _walk(node.right, scale, allow_array)
                 return
             if node.op == "-":
-                _walk(node.left, scale)
-                _walk(node.right, -scale)
+                _walk(node.left, scale, allow_array)
+                _walk(node.right, -scale, allow_array)
                 return
             if node.op == "*":
-                # One side must be constant for linearity
+                # One side must be a scalar constant for linearity. A size>1 array
+                # constant here raises _NotLinearError from _eval_const (the scale
+                # would differ per element), which routes to the per-component
+                # extractor rather than collapsing.
                 if _is_const_expr(node.left):
                     cval = _eval_const(node.left)
-                    _walk(node.right, scale * cval)
+                    _walk(node.right, scale * cval, allow_array)
                     return
                 if _is_const_expr(node.right):
                     cval = _eval_const(node.right)
-                    _walk(node.left, scale * cval)
+                    _walk(node.left, scale * cval, allow_array)
                     return
                 raise _NotLinearError("Product of two variable expressions")
             if node.op == "/":
                 if _is_const_expr(node.right):
                     cval = _eval_const(node.right)
-                    _walk(node.left, scale / cval)
+                    _walk(node.left, scale / cval, allow_array)
                     return
                 raise _NotLinearError("Division by variable expression")
             raise _NotLinearError(f"Non-linear operator: {node.op}")
 
         if isinstance(node, UnaryOp):
             if node.op == "neg":
-                _walk(node.operand, -scale)
+                _walk(node.operand, -scale, allow_array)
                 return
             raise _NotLinearError(f"Non-linear unary op: {node.op}")
 
         if isinstance(node, SumOverExpression):
             for term in node.terms:
-                _walk(term, scale)
+                _walk(term, scale, allow_array)
             return
 
         if isinstance(node, SumExpression):
-            # Sum of an array variable or expression
-            _walk(node.operand, scale)
+            # sum(expr) reduces expr to a scalar: element-collapse is legitimate
+            # here (uniform scale), so allow array nodes beneath this point.
+            _walk(node.operand, scale, allow_array=True)
             return
 
         if isinstance(node, MatMulExpression):
@@ -353,13 +369,18 @@ def _extract_quadratic_coefficients(expr, model: Model, n: int):
             return offset + int(flat_idx)
         return None
 
-    def _walk(node, scale=1.0):
+    def _walk(node, scale=1.0, allow_array=False):
+        # See _extract_linear_coefficients._walk: ``allow_array`` is True only
+        # inside a sum() reduction, where a size>1 array variable legitimately
+        # collapses to a single scalar term. Outside a sum, an array variable in
+        # scalar position means a vector-valued body that must NOT be collapsed to
+        # one row (C-29) — refuse so the caller routes to the autodiff extractor.
         nonlocal const
 
         if isinstance(node, Constant):
             val = node.value
-            if val.ndim == 0:
-                const += scale * float(val)
+            if val.ndim == 0 or val.size == 1:
+                const += scale * float(val.reshape(()))
             else:
                 raise _NotQuadraticError("Array constant in unexpected position")
             return
@@ -370,6 +391,11 @@ def _extract_quadratic_coefficients(expr, model: Model, n: int):
                 c[idx] += scale
                 return
             if isinstance(node, Variable) and node.size > 1:
+                if not allow_array:
+                    raise _NotQuadraticError(
+                        "Array variable in scalar position (vector-valued body); "
+                        "routing to the per-component extractor"
+                    )
                 offset = _compute_var_offset(node, model)
                 for j in range(node.size):
                     c[offset + j] += scale
@@ -378,22 +404,22 @@ def _extract_quadratic_coefficients(expr, model: Model, n: int):
 
         if isinstance(node, BinaryOp):
             if node.op == "+":
-                _walk(node.left, scale)
-                _walk(node.right, scale)
+                _walk(node.left, scale, allow_array)
+                _walk(node.right, scale, allow_array)
                 return
             if node.op == "-":
-                _walk(node.left, scale)
-                _walk(node.right, -scale)
+                _walk(node.left, scale, allow_array)
+                _walk(node.right, -scale, allow_array)
                 return
             if node.op == "*":
                 # Check: const * expr, expr * const, or var * var
                 if _is_const_expr(node.left):
                     cval = _eval_const(node.left)
-                    _walk(node.right, scale * cval)
+                    _walk(node.right, scale * cval, allow_array)
                     return
                 if _is_const_expr(node.right):
                     cval = _eval_const(node.right)
-                    _walk(node.left, scale * cval)
+                    _walk(node.left, scale * cval, allow_array)
                     return
                 # var * var => quadratic term
                 # Q is the Hessian: f = 0.5 x'Qx, so d²(c*xi*xj)/dxi dxj = c,
@@ -431,7 +457,7 @@ def _extract_quadratic_coefficients(expr, model: Model, n: int):
             if node.op == "/":
                 if _is_const_expr(node.right):
                     cval = _eval_const(node.right)
-                    _walk(node.left, scale / cval)
+                    _walk(node.left, scale / cval, allow_array)
                     return
                 raise _NotQuadraticError("Division by variable expression")
             if node.op == "**":
@@ -444,7 +470,7 @@ def _extract_quadratic_coefficients(expr, model: Model, n: int):
                             Q[idx, idx] += 2.0 * scale  # x^2 = 0.5 * 2 * x^2
                             return
                     if abs(pval - 1.0) < 1e-12:
-                        _walk(node.left, scale)
+                        _walk(node.left, scale, allow_array)
                         return
                     if abs(pval) < 1e-12:
                         const += scale
@@ -454,17 +480,18 @@ def _extract_quadratic_coefficients(expr, model: Model, n: int):
 
         if isinstance(node, UnaryOp):
             if node.op == "neg":
-                _walk(node.operand, -scale)
+                _walk(node.operand, -scale, allow_array)
                 return
             raise _NotQuadraticError(f"Non-linear unary op: {node.op}")
 
         if isinstance(node, SumOverExpression):
             for term in node.terms:
-                _walk(term, scale)
+                _walk(term, scale, allow_array)
             return
 
         if isinstance(node, SumExpression):
-            _walk(node.operand, scale)
+            # sum(expr) reduces to a scalar: array collapse legitimate below here.
+            _walk(node.operand, scale, allow_array=True)
             return
 
         if isinstance(node, MatMulExpression):
@@ -563,10 +590,23 @@ def _is_const_expr(expr) -> bool:
 
 
 def _eval_const(expr) -> float:  # type: ignore[return-value]
-    """Evaluate a constant expression to a float scalar."""
+    """Evaluate a constant expression to a float scalar.
+
+    Raises ``_NotLinearError`` (NOT ``ValueError``) on a non-scalar array
+    constant. C-30: a raw ``ValueError`` from ``float(v.item())`` on a size>1
+    array (e.g. ``sum(np.array([1,1]) * x)``) used to abort the algebraic walk
+    and mis-route to a fallback that dropped the objective sense. Refusing with
+    ``_NotLinearError`` routes such bodies to the row- and sense-correct autodiff
+    extractor instead.
+    """
     if isinstance(expr, Constant):
         v = expr.value
-        return float(v) if v.ndim == 0 else float(v.item())
+        if v.ndim == 0 or v.size == 1:
+            return float(v.reshape(()))
+        raise _NotLinearError(
+            "Non-scalar array constant cannot be evaluated as a scalar coefficient; "
+            "routing to the per-component extractor"
+        )
     if isinstance(expr, BinaryOp):
         lv = _eval_const(expr.left)
         r = _eval_const(expr.right)
@@ -1204,6 +1244,7 @@ def _extract_lp_data_autodiff(model: Model) -> LPData:
     import jax.numpy as jnp
 
     from discopt._jax.dag_compiler import compile_constraint, compile_objective
+    from discopt.modeling.core import ObjectiveSense
 
     n_orig = sum(v.size for v in model._variables)
     obj_fn = compile_objective(model)
@@ -1273,6 +1314,17 @@ def _extract_lp_data_autodiff(model: Model) -> LPData:
     c_full = jnp.concatenate([c, jnp.zeros(n_slack)])
     x_l = jnp.concatenate([x_l_orig, jnp.zeros(n_slack)])
     x_u = jnp.concatenate([x_u_orig, jnp.full(n_slack, jnp.inf)])
+
+    # Handle objective sense: negate for maximization (solvers always minimize).
+    # C-30: this autodiff fallback previously dropped the maximize negation that
+    # every other extractor applies (extract_lp_data_algebraic:743,
+    # _extract_lp_data_from_repr:927, _extract_qp_data_autodiff:1375), so a
+    # `maximize` model routed here (e.g. a vector `sum(const*var)` body that the
+    # algebraic walk refuses) was silently minimized and returned 0.
+    assert model._objective is not None
+    if model._objective.sense == ObjectiveSense.MAXIMIZE:
+        c_full = -c_full
+        obj_const = -obj_const
 
     return LPData(
         c=c_full,

--- a/python/tests/test_c29_c30_linear_body_classify.py
+++ b/python/tests/test_c29_c30_linear_body_classify.py
@@ -1,0 +1,174 @@
+"""Regression tests for C-29 and C-30 (false certified answers on the DEFAULT
+linear-body classify/extract path in ``discopt._jax.problem_classifier``).
+
+Both bugs certified a *wrong* answer on ``m.solve()`` with no flags:
+
+* **C-29** — a vector-valued constraint body (``a + b >= 1`` with ``a, b`` shape
+  ``(2,)``) is one ``Constraint`` whose body is array-valued. The algebraic
+  extractor summed every element into a single row, so ``a + b >= 1`` became
+  ``Σa + Σb >= 1`` and a point infeasible by the model's own semantics was
+  certified optimal (objective 1.0 for a problem whose true optimum is 2.0).
+
+* **C-30** — ``maximize sum(const * var)`` raised a raw ``ValueError`` from
+  ``_eval_const`` (``float(v.item())`` on a size>1 array), aborting the algebraic
+  walk and falling over to the autodiff extractor, which — unlike every other
+  extractor — never applied the maximize sense negation. The solver then
+  *minimized* a maximize model and returned 0 instead of the true max.
+
+The fix makes both algebraic walkers refuse to collapse an array node in scalar
+position (``_NotLinearError``) so the body routes to the per-component autodiff
+extractor, and makes that autodiff extractor apply the maximize negation. These
+tests call the extractor directly (sub-second) plus one end-to-end solve to lock
+the certificate.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt import Model
+from discopt._jax import problem_classifier as pc
+
+
+@pytest.mark.smoke
+def test_c29_vector_body_not_collapsed_to_single_row():
+    """A per-element constraint ``a + b >= 1`` (shape (2,)) must extract as two
+    rows, not one summed row. Pre-fix the algebraic walk produced one collapsed
+    row; the fix refuses (``_NotLinearError``) so the per-component autodiff
+    extractor produces one row per element.
+    """
+    m = Model()
+    a = m.continuous("a", shape=(2,), lb=0.0, ub=1.0)
+    b = m.continuous("b", shape=(2,), lb=0.0, ub=1.0)
+    m.minimize(dm.sum(a) + dm.sum(b))
+    m.subject_to(a + b >= 1)
+
+    n_orig = 4  # a[0], a[1], b[0], b[1]
+
+    # The algebraic walker must NOT silently collapse the vector body to one row.
+    with pytest.raises(pc._NotLinearError):
+        pc._extract_linear_coefficients((a + b >= 1).body, m, n_orig)
+
+    # The full dispatcher routes to the per-component extractor: two rows, one per
+    # element (each with a distinct slack), never a single summed row.
+    lp = pc.extract_lp_data(m)
+    A = np.asarray(lp.A_eq)
+    # 2 constraint rows (one per element), n_orig + 2 slack columns.
+    assert A.shape == (2, n_orig + 2)
+    # Row r couples exactly a[r] and b[r] (plus its own slack), never both elements.
+    assert np.count_nonzero(A[0, :n_orig]) == 2
+    assert np.count_nonzero(A[1, :n_orig]) == 2
+    # a[0]/b[0] appear only in row 0; a[1]/b[1] only in row 1.
+    assert A[0, 1] == 0.0 and A[0, 3] == 0.0  # a[1], b[1] absent from row 0
+    assert A[1, 0] == 0.0 and A[1, 2] == 0.0  # a[0], b[0] absent from row 1
+
+
+@pytest.mark.smoke
+def test_c29_solve_certifies_feasible_point():
+    """End-to-end: the certified optimum is 2.0 and the returned point is
+    feasible per element (pre-fix: objective 1.0 at an infeasible point)."""
+    m = Model()
+    a = m.continuous("a", shape=(2,), lb=0.0, ub=1.0)
+    b = m.continuous("b", shape=(2,), lb=0.0, ub=1.0)
+    m.minimize(dm.sum(a) + dm.sum(b))
+    m.subject_to(a + b >= 1)
+
+    res = m.solve()
+    assert res.objective == pytest.approx(2.0, abs=1e-4)
+    xa = np.asarray(res.value(a))
+    xb = np.asarray(res.value(b))
+    # No per-element constraint is violated — the false-certified point had
+    # a + b == 0.5 < 1 element-wise.
+    assert np.all(xa + xb >= 1.0 - 1e-5)
+
+
+@pytest.mark.smoke
+def test_c29_milp_set_cover_vector_body():
+    """MILP set-cover with a vector body: ``y + z >= 1`` (shape (3,) binaries)
+    must certify 3.0 (pre-fix: 1.0)."""
+    m = Model()
+    y = m.binary("y", shape=(3,))
+    z = m.binary("z", shape=(3,))
+    m.minimize(dm.sum(y) + dm.sum(z))
+    m.subject_to(y + z >= 1)
+    res = m.solve()
+    assert res.objective == pytest.approx(3.0, abs=1e-4)
+
+
+@pytest.mark.smoke
+def test_c30_eval_const_refuses_array_with_notlinear():
+    """``_eval_const`` on a non-scalar array constant must raise ``_NotLinearError``
+    (not a raw ``ValueError``), so the algebraic walk routes to a sense-aware path
+    instead of the old sense-dropping fallback."""
+    from discopt.modeling.core import Constant
+
+    arr = Constant(np.array([1.0, 1.0]))
+    with pytest.raises(pc._NotLinearError):
+        pc._eval_const(arr)
+
+    # A scalar / size-1 array constant still evaluates fine.
+    assert pc._eval_const(Constant(np.array(3.0))) == 3.0
+    assert pc._eval_const(Constant(np.array([2.5]))) == 2.5
+
+
+@pytest.mark.smoke
+def test_c30_maximize_sense_preserved_in_extracted_c():
+    """``extract_lp_data`` on ``maximize sum(const * var)`` must return a negated
+    ``c`` (solvers minimize). Pre-fix it returned the un-negated ``[1, 1, 0]``."""
+    m = Model()
+    x = m.continuous("x", shape=(2,), lb=0.0, ub=10.0)
+    m.maximize(dm.sum(np.array([1.0, 1.0]) * x))
+    m.subject_to(dm.sum(np.array([1.0, 1.0]) * x) <= 4)
+
+    lp = pc.extract_lp_data(m)
+    c = np.asarray(lp.c)
+    # Original variable coefficients negated for the maximize sense.
+    assert c[0] == pytest.approx(-1.0)
+    assert c[1] == pytest.approx(-1.0)
+
+
+@pytest.mark.smoke
+def test_c30_autodiff_extractor_applies_maximize_sense():
+    """The autodiff LP fallback itself (the sense-dropping culprit) must now
+    negate ``c`` for a maximize model."""
+    m = Model()
+    x = m.continuous("x", shape=(2,), lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.maximize(x[0] + x[1] + y)
+    m.subject_to(x[0] + x[1] + y <= 4)
+
+    lp = pc._extract_lp_data_autodiff(m)
+    c = np.asarray(lp.c)
+    assert np.all(c[:3] == pytest.approx(-1.0))
+
+
+@pytest.mark.smoke
+def test_c30_solve_maximize_returns_true_max():
+    """End-to-end: ``maximize sum(const * var) s.t. sum(const * var) <= 4``
+    certifies 4.0 (pre-fix: ~0)."""
+    m = Model()
+    x = m.continuous("x", shape=(2,), lb=0.0, ub=10.0)
+    m.maximize(dm.sum(np.array([1.0, 1.0]) * x))
+    m.subject_to(dm.sum(np.array([1.0, 1.0]) * x) <= 4)
+    res = m.solve()
+    assert res.objective == pytest.approx(4.0, abs=1e-4)
+
+
+@pytest.mark.smoke
+def test_legit_sum_stays_on_fast_algebraic_path():
+    """Bound-neutral guard: a genuine ``sum(array_var)`` (scalar body) must still
+    extract on the fast algebraic path as ONE row — the fix must not over-refuse
+    legitimate reductions."""
+    m = Model()
+    a = m.continuous("a", shape=(3,), lb=0.0, ub=5.0)
+    m.minimize(dm.sum(a))
+    m.subject_to(dm.sum(a) >= 6)
+
+    # Algebraic extraction succeeds (does not raise) and yields a single row.
+    lp = pc.extract_lp_data_algebraic(m)
+    A = np.asarray(lp.A_eq)
+    assert A.shape[0] == 1
+    # All three components carry the same (uniform) coefficient in the summed row.
+    assert np.count_nonzero(A[0, :3]) == 3
+    assert m.solve().objective == pytest.approx(6.0, abs=1e-4)


### PR DESCRIPTION
## Summary

Fixes two P0 (catastrophic-class) DEFAULT-path false certified answers in the
linear-body classify/extract path (`python/discopt/_jax/problem_classifier.py`),
tracked as **C-29** and **C-30** in `docs/dev/correctness-issues.md`. They live
in the same module and interleave, so they are fixed together (one commit).

### C-29 — vector-body constraint collapsed to one summed row

A vector-valued constraint body (e.g. `a + b >= 1` with `a, b` shape `(2,)`) is a
single `Constraint` whose body is array-valued. The algebraic walkers collapsed a
size>1 array variable in scalar position into one summed row, so `a + b >= 1` was
extracted as `Σa + Σb >= 1` — an **elementwise-infeasible point was certified
optimal** on the default `m.solve()` path.

- Repro before: `min Σa+Σb s.t. a+b>=1` (shape (2,), box [0,1]) → **1.0** at
  `a=b=[0.25,0.25]` (`a+b=0.5<1`, infeasible), true **2.0**.
- MILP set-cover `y+z>=1` (shape (3,) binaries) → **1.0**, true **3.0**.
- After: both certify **2.0** / **3.0** at elementwise-feasible points.

**Fix:** both `_walk`s carry an `allow_array` flag, True only beneath a
`SumExpression` (where element-collapse with a uniform scale is a legitimate
reduction). An array node in scalar position raises `_NotLinearError` /
`_NotQuadraticError`, so `extract_lp_data` routes the body to the per-component
autodiff extractor (one LP row per element). `_eval_const` now raises
`_NotLinearError` (not `ValueError`) on a non-scalar array constant. Legit
`sum(array_var)` bodies still take the fast algebraic single-row path (guarded).

### C-30 — maximize sense lost on `sum(const*var)` bodies

`maximize sum(const*var)` raised a raw `ValueError` from `_eval_const` and fell
over to `_extract_lp_data_autodiff` — the only extractor that never applied the
maximize negation — so the solver **minimized a maximize model and returned 0**.

- Repro before: `maximize sum([1,1]·x) s.t. sum([1,1]·x)<=4`, `x∈[0,10]²` →
  **~0** at `x≈[0,0]`, `c=[1,1,0]` un-negated; true **4.0**.
- After: certifies **4.0** with `c=[-1,-1,0]`.

**Fix:** `_extract_lp_data_autodiff` now negates `c`/`obj_const` for
`ObjectiveSense.MAXIMIZE`, closing the sense-dropping gap for *every* body routed
to the autodiff LP fallback. Audited all six sense-negation sites; the autodiff
LP extractor was the sole omission.

## Soundness

No validation, fallback, or guard was weakened. Both bugs are resolved by a
**sound refusal** (`_NotLinearError` → the row-correct autodiff extractor) plus
restoring the missing sense negation — never a silent collapse. `incorrect_count = 0`
on the affected models.

## Tests run

- `python/tests/test_c29_c30_linear_body_classify.py` — 8 new `@pytest.mark.smoke`
  tests, proven **red-before / green-after** (7 of 8 fail on pre-fix HEAD; the 8th
  is the bound-neutral guard that must pass both ways).
- `pytest -m smoke` — **297 passed**, 1 skipped. The only failures are the 3
  pre-existing `test_c31_*` tests (a separate, out-of-scope Rust FBBT bug; verified
  failing identically on pristine HEAD).
- `pytest -m slow test_adversarial_recent_fixes.py` — **10 passed**.
- `test_lp_qp_solvers`, `test_qp_solve`, `test_differentiable_vector_constraints`
  — all green (guards the quadratic-walker change).
- `ruff check` / `ruff format --check` — clean. (`mypy` aborts on a pre-existing
  numpy-stub / Python-version mismatch on HEAD, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
