### PR TITLE
cert:P4 — re-profile: rank the four structure-loss levers

### DIFF
--- a/discopt_benchmarks/results/p4_reprofile_structure_loss_20260703T210635.json
+++ b/discopt_benchmarks/results/p4_reprofile_structure_loss_20260703T210635.json
@@ -1,0 +1,438 @@
+{
+  "experiment": "phase4_reprofile_structure_loss",
+  "generated_utc": "20260703T210635",
+  "time_cap_seconds": 90.0,
+  "panel": [
+    "nvs17",
+    "ex1252",
+    "ex1252a",
+    "gear4",
+    "st_e38",
+    "clay0303hfsg",
+    "casctanks",
+    "heatexch_gen1"
+  ],
+  "n_run": 8,
+  "n_skipped": 0,
+  "skipped": [],
+  "rows": [
+    {
+      "instance": "nvs17",
+      "nl_path": "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/nvs17.nl",
+      "defined_vars_discarded": 0,
+      "load_seconds": 0.0019,
+      "load_status": "ok",
+      "dag_nodes": 753,
+      "n_vars": 7,
+      "n_constraints": 7,
+      "cse_duplicate_nodes": 519,
+      "cse_duplicate_frac": 0.6892,
+      "cse_duplicate_by_type": {
+        "constant": 239,
+        "binary_op": 249,
+        "unary_op": 31
+      },
+      "quadratic": {
+        "obj_quadratic": true,
+        "obj_bilinear": false,
+        "constraints_quadratic": 7,
+        "term_classes": {
+          "bilinear": 21,
+          "trilinear": 0,
+          "multilinear": 0,
+          "monomial": 7,
+          "general_nl": 0
+        }
+      },
+      "symmetry": {
+        "orbits_found": 0,
+        "total_orbit_members": 0,
+        "variables_examined": 7,
+        "detect_seconds": 0.0002
+      },
+      "fbbt_one_sweep_seconds": "err:TypeError",
+      "wall_seconds": 79.111,
+      "solve_status": "optimal",
+      "node_count": 93,
+      "objective": -1100.4000000000003,
+      "bound": -1100.4000022018004,
+      "xla_compile_count": null,
+      "xla_compile_seconds": null,
+      "seconds_per_node": 0.85066,
+      "solver_stats": {
+        "reduce/fbbt": 0.12463533505797386,
+        "separate/multilinear": 0.0010295403189957142,
+        "separate/edge_concave": 32.931821294594556,
+        "separate/univariate_square": 7.954982667695731,
+        "separate/convex": 0.0001330026425421238,
+        "separate/psd": 21.502866834867746,
+        "separate/rlt": 6.007589399814606e-05
+      },
+      "bound_le_oracle": true
+    },
+    {
+      "instance": "ex1252",
+      "nl_path": "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/ex1252.nl",
+      "defined_vars_discarded": 0,
+      "load_seconds": 0.0004,
+      "load_status": "ok",
+      "dag_nodes": 336,
+      "n_vars": 39,
+      "n_constraints": 43,
+      "cse_duplicate_nodes": 115,
+      "cse_duplicate_frac": 0.3423,
+      "cse_duplicate_by_type": {
+        "constant": 76,
+        "binary_op": 24,
+        "unary_op": 15
+      },
+      "quadratic": {
+        "obj_quadratic": false,
+        "obj_bilinear": false,
+        "constraints_quadratic": 40,
+        "term_classes": {
+          "bilinear": 9,
+          "trilinear": 0,
+          "multilinear": 0,
+          "monomial": 3,
+          "general_nl": 0
+        }
+      },
+      "symmetry": {
+        "orbits_found": 0,
+        "total_orbit_members": 0,
+        "variables_examined": 39,
+        "detect_seconds": 7e-05
+      },
+      "fbbt_one_sweep_seconds": "err:TypeError",
+      "wall_seconds": 98.856,
+      "solve_status": "feasible",
+      "node_count": 71,
+      "objective": 141443.2429448267,
+      "bound": null,
+      "xla_compile_count": null,
+      "xla_compile_seconds": null,
+      "seconds_per_node": 1.39234,
+      "solver_stats": {
+        "reduce/fbbt": 0.3975185011513531,
+        "reduce/obbt": 6.965244290418923,
+        "separate/multilinear": 0.00037687644362449646,
+        "separate/edge_concave": 0.00040825363248586655,
+        "separate/univariate_square": 27.634101461153477,
+        "separate/convex": 5.216524004936218e-05,
+        "separate/psd": 2.0668376237154007e-05,
+        "separate/rlt": 1.046154648065567e-05
+      }
+    },
+    {
+      "instance": "ex1252a",
+      "nl_path": "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/ex1252a.nl",
+      "defined_vars_discarded": 0,
+      "load_seconds": 0.0003,
+      "load_status": "ok",
+      "dag_nodes": 282,
+      "n_vars": 24,
+      "n_constraints": 34,
+      "cse_duplicate_nodes": 101,
+      "cse_duplicate_frac": 0.3582,
+      "cse_duplicate_by_type": {
+        "constant": 62,
+        "binary_op": 24,
+        "unary_op": 15
+      },
+      "quadratic": {
+        "obj_quadratic": false,
+        "obj_bilinear": false,
+        "constraints_quadratic": 31,
+        "term_classes": {
+          "bilinear": 9,
+          "trilinear": 0,
+          "multilinear": 0,
+          "monomial": 3,
+          "general_nl": 0
+        }
+      },
+      "symmetry": {
+        "orbits_found": 0,
+        "total_orbit_members": 0,
+        "variables_examined": 24,
+        "detect_seconds": 7e-05
+      },
+      "fbbt_one_sweep_seconds": "err:TypeError",
+      "wall_seconds": 66.85,
+      "solve_status": "feasible",
+      "node_count": 15,
+      "objective": 138694.63057019692,
+      "bound": null,
+      "xla_compile_count": null,
+      "xla_compile_seconds": null,
+      "seconds_per_node": 4.45668,
+      "solver_stats": {
+        "reduce/fbbt": 0.17756870994344354,
+        "reduce/obbt": 1.9323918744921684,
+        "separate/multilinear": 8.633174002170563e-05,
+        "separate/edge_concave": 0.00030695507302880287,
+        "separate/univariate_square": 10.510151043068618,
+        "separate/convex": 2.4835579097270966e-05,
+        "separate/psd": 1.0041985660791397e-05,
+        "separate/rlt": 0.005949749145656824
+      }
+    },
+    {
+      "instance": "gear4",
+      "nl_path": "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/gear4.nl",
+      "defined_vars_discarded": 0,
+      "load_seconds": 0.0001,
+      "load_status": "ok",
+      "dag_nodes": 17,
+      "n_vars": 6,
+      "n_constraints": 1,
+      "cse_duplicate_nodes": 0,
+      "cse_duplicate_frac": 0.0,
+      "cse_duplicate_by_type": {},
+      "quadratic": {
+        "obj_quadratic": true,
+        "obj_bilinear": false,
+        "constraints_quadratic": 0,
+        "term_classes": {
+          "bilinear": 0,
+          "trilinear": 0,
+          "multilinear": 0,
+          "monomial": 0,
+          "general_nl": 0
+        }
+      },
+      "symmetry": {
+        "orbits_found": 0,
+        "total_orbit_members": 0,
+        "variables_examined": 6,
+        "detect_seconds": 0.0
+      },
+      "fbbt_one_sweep_seconds": "err:TypeError",
+      "wall_seconds": 49.84,
+      "solve_status": "optimal",
+      "node_count": 6045,
+      "objective": 1.6434284641344497,
+      "bound": 1.6434284564686623,
+      "xla_compile_count": null,
+      "xla_compile_seconds": null,
+      "seconds_per_node": 0.00824,
+      "solver_stats": {
+        "reduce/fbbt": 1.3231522319838405,
+        "reduce/obbt": 14.079789684619755,
+        "separate/multilinear": 0.009803989436477423,
+        "separate/edge_concave": 0.005300300195813179,
+        "separate/univariate_square": 0.0030903285369277,
+        "separate/convex": 0.0033112233504652977,
+        "separate/psd": 0.023861555382609367,
+        "separate/rlt": 0.0013328823260962963
+      },
+      "bound_le_oracle": true
+    },
+    {
+      "instance": "st_e38",
+      "nl_path": "/Users/jkitchin/projects/discopt/.claude/worktrees/agent-a3853b934670ff950/python/tests/data/minlplib_nl/st_e38.nl",
+      "defined_vars_discarded": 0,
+      "load_seconds": 0.0001,
+      "load_status": "ok",
+      "dag_nodes": 46,
+      "n_vars": 4,
+      "n_constraints": 3,
+      "cse_duplicate_nodes": 7,
+      "cse_duplicate_frac": 0.1522,
+      "cse_duplicate_by_type": {
+        "constant": 5,
+        "binary_op": 2
+      },
+      "quadratic": {
+        "obj_quadratic": false,
+        "obj_bilinear": false,
+        "constraints_quadratic": 2,
+        "term_classes": {
+          "bilinear": 0,
+          "trilinear": 1,
+          "multilinear": 0,
+          "monomial": 3,
+          "general_nl": 0
+        }
+      },
+      "symmetry": {
+        "orbits_found": 0,
+        "total_orbit_members": 0,
+        "variables_examined": 4,
+        "detect_seconds": 2e-05
+      },
+      "fbbt_one_sweep_seconds": "err:TypeError",
+      "wall_seconds": 2.326,
+      "solve_status": "optimal",
+      "node_count": 3,
+      "objective": 7197.727116839705,
+      "bound": 7197.727116826533,
+      "xla_compile_count": null,
+      "xla_compile_seconds": null,
+      "seconds_per_node": 0.77539,
+      "solver_stats": {
+        "reduce/fbbt": 0.022282582707703114,
+        "separate/multilinear": 2.3749656975269318e-05,
+        "separate/edge_concave": 5.512591451406479e-05,
+        "separate/univariate_square": 0.003271416760981083,
+        "separate/convex": 3.6261044442653656e-06,
+        "separate/psd": 2.2086314857006073e-06,
+        "separate/rlt": 0.0001897485926747322
+      },
+      "bound_le_oracle": true
+    },
+    {
+      "instance": "clay0303hfsg",
+      "nl_path": "/Users/jkitchin/projects/discopt/.claude/worktrees/agent-a3853b934670ff950/python/tests/data/minlplib_nl/clay0303hfsg.nl",
+      "defined_vars_discarded": 0,
+      "load_seconds": 0.0016,
+      "load_status": "ok",
+      "dag_nodes": 2135,
+      "n_vars": 99,
+      "n_constraints": 150,
+      "cse_duplicate_nodes": 1383,
+      "cse_duplicate_frac": 0.6478,
+      "cse_duplicate_by_type": {
+        "constant": 720,
+        "binary_op": 609,
+        "unary_op": 54
+      },
+      "quadratic": {
+        "obj_quadratic": true,
+        "obj_bilinear": false,
+        "constraints_quadratic": 114,
+        "term_classes": {
+          "bilinear": 0,
+          "trilinear": 0,
+          "multilinear": 0,
+          "monomial": 0,
+          "general_nl": 0
+        }
+      },
+      "symmetry": {
+        "orbits_found": 0,
+        "total_orbit_members": 0,
+        "variables_examined": 99,
+        "detect_seconds": 1e-05
+      },
+      "fbbt_one_sweep_seconds": "err:TypeError",
+      "wall_seconds": 73.856,
+      "solve_status": "optimal",
+      "node_count": 325,
+      "objective": 26669.109551433856,
+      "bound": 26669.109551433798,
+      "xla_compile_count": null,
+      "xla_compile_seconds": null,
+      "seconds_per_node": 0.22725,
+      "solver_stats": {}
+    },
+    {
+      "instance": "casctanks",
+      "nl_path": "/Users/jkitchin/projects/discopt/.claude/worktrees/agent-a3853b934670ff950/python/tests/data/minlplib_nl/casctanks.nl",
+      "defined_vars_discarded": 0,
+      "load_seconds": 0.0068,
+      "load_status": "ok",
+      "dag_nodes": 3124,
+      "n_vars": 500,
+      "n_constraints": 517,
+      "cse_duplicate_nodes": 1062,
+      "cse_duplicate_frac": 0.3399,
+      "cse_duplicate_by_type": {
+        "constant": 653,
+        "binary_op": 57,
+        "unary_op": 272,
+        "sum_over": 80
+      },
+      "quadratic": {
+        "obj_quadratic": false,
+        "obj_bilinear": false,
+        "constraints_quadratic": 457,
+        "term_classes": {
+          "bilinear": 60,
+          "trilinear": 0,
+          "multilinear": 0,
+          "monomial": 0,
+          "general_nl": 0
+        }
+      },
+      "symmetry": {
+        "orbits_found": 0,
+        "total_orbit_members": 0,
+        "variables_examined": 500,
+        "detect_seconds": 7e-05
+      },
+      "fbbt_one_sweep_seconds": "err:TypeError",
+      "wall_seconds": 97.416,
+      "solve_status": "time_limit",
+      "node_count": 31,
+      "objective": null,
+      "bound": -90.17862929102458,
+      "xla_compile_count": null,
+      "xla_compile_seconds": null,
+      "seconds_per_node": 3.14244,
+      "solver_stats": {
+        "reduce/fbbt": 3.993171749636531,
+        "separate/multilinear": 7.091788575053215e-05,
+        "separate/edge_concave": 0.012665625661611557,
+        "separate/univariate_square": 1.0109580419957638,
+        "separate/convex": 2.3708678781986237e-05,
+        "separate/psd": 1.0329298675060272e-05,
+        "separate/rlt": 9.87248495221138e-06
+      }
+    },
+    {
+      "instance": "heatexch_gen1",
+      "nl_path": "/Users/jkitchin/projects/discopt/.claude/worktrees/agent-a3853b934670ff950/python/tests/data/minlplib_nl/heatexch_gen1.nl",
+      "defined_vars_discarded": 0,
+      "load_seconds": 0.0012,
+      "load_status": "ok",
+      "dag_nodes": 798,
+      "n_vars": 112,
+      "n_constraints": 120,
+      "cse_duplicate_nodes": 237,
+      "cse_duplicate_frac": 0.297,
+      "cse_duplicate_by_type": {
+        "constant": 173,
+        "binary_op": 16,
+        "unary_op": 48
+      },
+      "quadratic": {
+        "obj_quadratic": true,
+        "obj_bilinear": false,
+        "constraints_quadratic": 96,
+        "term_classes": {
+          "bilinear": 16,
+          "trilinear": 0,
+          "multilinear": 0,
+          "monomial": 0,
+          "general_nl": 0
+        }
+      },
+      "symmetry": {
+        "orbits_found": 0,
+        "total_orbit_members": 0,
+        "variables_examined": 112,
+        "detect_seconds": 3e-05
+      },
+      "fbbt_one_sweep_seconds": "err:TypeError",
+      "wall_seconds": 171.042,
+      "solve_status": "time_limit",
+      "node_count": 3,
+      "objective": null,
+      "bound": 100499.99999999991,
+      "xla_compile_count": null,
+      "xla_compile_seconds": null,
+      "seconds_per_node": 57.01398,
+      "solver_stats": {
+        "reduce/fbbt": 0.559395540971309,
+        "separate/multilinear": 8.206814527511597e-06,
+        "separate/edge_concave": 0.0010400009341537952,
+        "separate/univariate_square": 3.541354089975357e-06,
+        "separate/convex": 1.4593824744224548e-06,
+        "separate/psd": 1.2079253792762756e-06,
+        "separate/rlt": 5.830079317092896e-07
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/results/p4_xla_compiles_probe.json
+++ b/discopt_benchmarks/results/p4_xla_compiles_probe.json
@@ -1,0 +1,34 @@
+{
+  "ex1252": {
+    "compiles": 7,
+    "compile_seconds": 0.025,
+    "wall": 36.491,
+    "nodes": 3,
+    "compile_frac_wall": 0.001,
+    "compiles_per_node": 2.333
+  },
+  "ex1252a": {
+    "compiles": 5,
+    "compile_seconds": 0.021,
+    "wall": 34.023,
+    "nodes": 3,
+    "compile_frac_wall": 0.001,
+    "compiles_per_node": 1.667
+  },
+  "clay0303hfsg": {
+    "compiles": 17,
+    "compile_seconds": 0.408,
+    "wall": 33.176,
+    "nodes": 253,
+    "compile_frac_wall": 0.012,
+    "compiles_per_node": 0.067
+  },
+  "casctanks": {
+    "compiles": 6,
+    "compile_seconds": 0.226,
+    "wall": 49.32,
+    "nodes": 3,
+    "compile_frac_wall": 0.005,
+    "compiles_per_node": 2.0
+  }
+}

--- a/discopt_benchmarks/scripts/p4_reprofile_structure_loss.py
+++ b/discopt_benchmarks/scripts/p4_reprofile_structure_loss.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Phase 4 re-profile entry experiment — rank the four structure-loss levers.
+
+Measurement-only (no solver math changed). For each panel instance we measure:
+  - DAG node count (arena_len) — the thing CSE/V-segments would shrink
+  - CSE duplicate-node potential (lever 1): fraction of arena nodes that are
+    content-identical to an earlier node -> hash-consing would dedup them
+  - defined-variable count discarded by nl_parser (lever 2): read from the .nl
+    "common exprs" header line (b,c,o,c1,o1); >0 means the parser drops sharing
+  - unrecognized-quadratic flag (lever 3): objective/constraint has degree-2
+    structure that is_quadratic sees but no Q-matrix is extracted
+  - nontrivial-orbit flag (lever 4): detect_symmetries finds orbits of size >= 2
+  - JAX relaxation compile count + seconds (perf-plan CC5) via solver_stats /
+    xla_compile_count, per-node eval time, FBBT sweep time, wall clock
+
+Guardrails: per-instance hard cap ~90 s, panel <= 8, results persisted to
+discopt_benchmarks/results/. Run synchronously. JAX_PLATFORMS/x64 set by caller.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import sys
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+import discopt.modeling as dm
+
+SNAP = Path.home() / "Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"
+REPO_CORPUS = Path(__file__).resolve().parents[2] / "python/tests/data/minlplib_nl"
+RESULTS = Path(__file__).resolve().parents[1] / "results"
+TIME_CAP = 90.0
+
+
+def find_nl(name: str) -> Path | None:
+    for base in (REPO_CORPUS, SNAP):
+        p = base / f"{name}.nl"
+        if p.exists():
+            return p
+    return None
+
+
+def attr(obj, name):
+    a = getattr(obj, name)
+    return a() if callable(a) else a
+
+
+def defined_var_count(nl_path: Path) -> int:
+    """Sum of the 'common exprs: b,c,o,c1,o1' header field (defined vars).
+
+    Returns -1 for a binary ('b') .nl (discopt cannot parse it at all)."""
+    try:
+        with open(nl_path, "rb") as fh:
+            if fh.read(1) != b"g":
+                return -1
+        with open(nl_path, errors="replace") as fh:
+            for _ in range(14):
+                line = fh.readline()
+                if not line:
+                    break
+                if "common exprs" in line:
+                    nums = line.split("#")[0].split()
+                    return sum(int(x) for x in nums)
+    except Exception:
+        return -2
+    return 0
+
+
+def content_hash_walk(repr_):
+    """Bottom-up content hashing over the arena to estimate CSE dedup potential.
+
+    The arena is topologically ordered (children have lower ids). Each node gets a
+    canonical content key built from its op and its children's *content* hashes
+    (not their ids); a node whose key was already seen is a duplicate that a
+    content-addressed intern (hash-consing) would collapse.
+    Returns (n_nodes, n_duplicate, {type: dup_count})."""
+    alen = attr(repr_, "arena_len")
+    content = [0] * alen
+    seen: dict = {}
+    dup = 0
+    dup_by_type: Counter = Counter()
+    for i in range(alen):
+        n = repr_.get_node(i)
+        t = n.get("type")
+        if t == "variable":
+            key = ("var", n["index"])
+        elif t == "constant":
+            key = ("const", repr(n["value"]))
+        elif t == "unary_op":
+            key = ("un", n["op"], content[n["arg"]])
+        elif t == "binary_op":
+            lo, ro = content[n["left"]], content[n["right"]]
+            if n["op"] in ("*", "+"):  # commutative -> order-independent key
+                lo, ro = sorted((lo, ro))
+            key = ("bin", n["op"], lo, ro)
+        elif t == "sum_over":
+            key = ("sum", tuple(sorted(content[c] for c in n["terms"])))
+        else:
+            key = ("other", i)  # never dedup unknown node types
+        h = hash(key)
+        content[i] = h
+        if h in seen:
+            dup += 1
+            dup_by_type[t] += 1
+        else:
+            seen[h] = i
+    return alen, dup, dict(dup_by_type)
+
+
+def quadratic_status(repr_):
+    """Lever 3: degree-check recognition of quadratic structure (no Q extraction)."""
+    n_con = attr(repr_, "n_constraints")
+    con_q = 0
+    for ci in range(n_con):
+        try:
+            if repr_.is_constraint_quadratic(ci):
+                con_q += 1
+        except Exception:
+            pass
+    cls = {}
+    try:
+        c = repr_.classify_nonlinear_terms()
+        for k in ("bilinear", "trilinear", "multilinear", "monomial"):
+            cls[k] = len(c.get(k, []))
+        cls["general_nl"] = len(c.get("general_nl", c.get("general", [])))
+    except Exception:
+        pass
+    return {
+        "obj_quadratic": bool(repr_.is_objective_quadratic()),
+        "obj_bilinear": bool(repr_.is_objective_bilinear()),
+        "constraints_quadratic": con_q,
+        "term_classes": cls,
+    }
+
+
+def measure_static(name: str, nl_path: Path):
+    out = {"instance": name, "nl_path": str(nl_path)}
+    dv = defined_var_count(nl_path)
+    out["defined_vars_discarded"] = dv
+    if dv == -1:
+        out["load_status"] = "binary_nl_unreadable"
+        return out, None
+    t0 = time.perf_counter()
+    try:
+        model = dm.from_nl(str(nl_path))
+    except Exception as e:
+        out["load_status"] = f"load_error:{type(e).__name__}:{str(e)[:80]}"
+        return out, None
+    out["load_seconds"] = round(time.perf_counter() - t0, 4)
+    r = model._nl_repr
+    alen, dup, dup_by_type = content_hash_walk(r)
+    out["load_status"] = "ok"
+    out["dag_nodes"] = alen
+    out["n_vars"] = attr(r, "n_vars")
+    out["n_constraints"] = attr(r, "n_constraints")
+    out["cse_duplicate_nodes"] = dup
+    out["cse_duplicate_frac"] = round(dup / alen, 4) if alen else 0.0
+    out["cse_duplicate_by_type"] = dup_by_type
+    out["quadratic"] = quadratic_status(r)
+    t0 = time.perf_counter()
+    try:
+        sym = r.detect_symmetries()
+        out["symmetry"] = {
+            "orbits_found": sym.get("orbits_found", 0),
+            "total_orbit_members": sym.get("total_orbit_members", 0),
+            "variables_examined": sym.get("variables_examined", 0),
+            "detect_seconds": round(time.perf_counter() - t0, 5),
+        }
+    except Exception as e:
+        out["symmetry"] = {"error": f"{type(e).__name__}:{str(e)[:60]}"}
+    try:
+        t0 = time.perf_counter()
+        r.fbbt()
+        out["fbbt_one_sweep_seconds"] = round(time.perf_counter() - t0, 5)
+    except Exception as e:
+        out["fbbt_one_sweep_seconds"] = f"err:{type(e).__name__}"
+    return out, model
+
+
+def measure_solve(model, oracle):
+    out = {}
+    t0 = time.perf_counter()
+    try:
+        res = model.solve(time_limit=TIME_CAP, gap=1e-4)
+    except Exception as e:
+        out["solve_status"] = f"solve_error:{type(e).__name__}:{str(e)[:80]}"
+        out["wall_seconds"] = round(time.perf_counter() - t0, 3)
+        return out
+    wall = time.perf_counter() - t0
+    out["wall_seconds"] = round(wall, 3)
+    out["solve_status"] = str(getattr(res, "status", "?"))
+    nodes = getattr(res, "node_count", None) or getattr(res, "nodes", None)
+    out["node_count"] = nodes
+    out["objective"] = getattr(res, "objective", None)
+    out["bound"] = getattr(res, "bound", None) or getattr(res, "best_bound", None)
+    xc = getattr(res, "xla_compile_count", None)
+    xs = getattr(res, "xla_compile_seconds", None)
+    out["xla_compile_count"] = xc
+    out["xla_compile_seconds"] = xs
+    if xs is not None and wall:
+        out["xla_compile_frac_of_wall"] = round(xs / wall, 3)
+    if nodes:
+        out["seconds_per_node"] = round(wall / nodes, 5)
+    stats = getattr(res, "solver_stats", None) or {}
+    out["solver_stats"] = {
+        k: v
+        for k, v in stats.items()
+        if any(k.startswith(p) for p in ("reduce/", "separate/", "cuts/", "compile"))
+    }
+    if oracle is not None and out["bound"] is not None:
+        with contextlib.suppress(Exception):
+            out["bound_le_oracle"] = bool(out["bound"] <= oracle + 1e-4 * (1 + abs(oracle)))
+    return out
+
+
+ORACLE = {
+    "nvs17": -1100.4,
+    "ex1252": 128893.8,
+    "ex1252a": 128893.8,
+    "gear4": 1.6434,
+    "st_e38": 7197.727,
+}
+
+
+def main(panel):
+    RESULTS.mkdir(exist_ok=True)
+    rows = []
+    skipped = []
+    for name in panel:
+        nl = find_nl(name)
+        if nl is None:
+            skipped.append({"instance": name, "reason": "nl_not_found"})
+            print(f"[SKIP] {name}: .nl not found", flush=True)
+            continue
+        print(f"[RUN ] {name}  ({nl})", flush=True)
+        static, model = measure_static(name, nl)
+        if static.get("load_status") != "ok":
+            static["skipped_solve"] = static.get("load_status")
+            rows.append(static)
+            skipped.append({"instance": name, "reason": static.get("load_status")})
+            print(f"       load_status={static.get('load_status')} (solve skipped)", flush=True)
+            continue
+        dupf = static["cse_duplicate_frac"] * 100
+        print(
+            f"       nodes={static['dag_nodes']} dup={static['cse_duplicate_nodes']}"
+            f" ({dupf:.1f}%) defvars={static['defined_vars_discarded']}"
+            f" obj_quad={static['quadratic']['obj_quadratic']}"
+            f" orbits={static['symmetry'].get('orbits_found')}",
+            flush=True,
+        )
+        solve = measure_solve(model, ORACLE.get(name))
+        static.update(solve)
+        xfrac = solve.get("xla_compile_frac_of_wall")
+        print(
+            f"       wall={solve.get('wall_seconds')}s nodes={solve.get('node_count')}"
+            f" s/node={solve.get('seconds_per_node')} xla={solve.get('xla_compile_count')}"
+            f"x/{solve.get('xla_compile_seconds')}s ({xfrac} of wall)",
+            flush=True,
+        )
+        rows.append(static)
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    outpath = RESULTS / f"p4_reprofile_structure_loss_{stamp}.json"
+    payload = {
+        "experiment": "phase4_reprofile_structure_loss",
+        "generated_utc": stamp,
+        "time_cap_seconds": TIME_CAP,
+        "panel": panel,
+        "n_run": len([r for r in rows if r.get("load_status") == "ok"]),
+        "n_skipped": len(skipped),
+        "skipped": skipped,
+        "rows": rows,
+    }
+    outpath.write_text(json.dumps(payload, indent=2, default=str))
+    print(f"\nWROTE {outpath}", flush=True)
+    print(f"n_run(ok)={payload['n_run']} n_skipped={payload['n_skipped']}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    default_panel = ["nvs17", "ex1252", "ex1252a", "gear4", "st_e38"]
+    panel = sys.argv[1:] or default_panel
+    sys.exit(main(panel))

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -132,7 +132,8 @@ experiment may run.
 | Phase 3 1c reachability entry experiment | done — **NO-GO / re-scope** | #(prior) | Cuts made reachable+armed close ~0% (median gap-closed 0.000, best +0.55% on ex1263a) vs SCIP ~1.0. Residual is separator DEPTH, not plumbing. Do NOT build the Rust cut-callback seam yet. See §7 "Phase 3 1c" |
 | Phase 3 1d separator-family attribution | done — **build zerohalf** | #420 | SCIP per-separator attribution (`scripts/p3_1d_separator_attribution.py`): on graphpart `zerohalf` alone closes 60–86% of the reachable root gap and is the sole load-bearing family (leave-one-out 15–53%); every other cut family (flowcover/aggregation/cmir/clique/…) closes 0. Build target = native zero-half separator; expected ~0.6–0.9 root-gap close. See §7 "Phase 3 1d" |
 | Phase 3 zerohalf build (native {0,½}-CG separator) | done — **sound; lever INERT on graphpart (measured)**; code parked on branch `cert-p3-zerohalf` (PR #427 closed unmerged), NOT on main | finding only | A validity-GREEN heuristic zero-half separator was built (400-system + binary-dense property tests: no feasible point cut). ON/OFF on graphpart: **gap_closed 0.000, `incorrect_count=0`** — the predicted 0.6–0.9 did NOT land: discopt's root LP optimum is a ⅓-partition vertex where every {0,½} combo is *tight, not violated* (exhaustive GF(2) nullspace search: viol=0.0000), and `root_off` already sits at SCIP's separators-off floor. Root cause = **LP vertex geometry (½-cuttable vs ⅓), not cut depth**. Follow-on = separate at a ½-valued/pre-crossover point. The inert separator is NOT merged (no dead flag on main); preserved on the branch for the follow-on. See §7 "Phase 3 zerohalf — build results" |
-| Phase 4 T-CSE/V-segments | **locked** (§0.1.2) | — | may parallel Phase 1 once specced |
+| Phase 4 re-profile (entry experiment) | done — **rank recorded** | #442 | 8 run / 0 skipped. Ranked build order: **1) CSE (op-dup 31–37% on nvs17/clay), 2) Q-extraction (coupled to CSE), 3) V-segments DE-PRIORITIZED (0 defvars in all 1,558 text `.nl`; defined-var-heavy set is binary-`.nl` discopt can't parse), 4) symmetry DO-NOT-BUILD (0 orbits)**. CC5 FALSIFIED (XLA ≤1.2% of wall); dominant wall = separation. See §8 "Phase 4 — re-profile results" |
+| Phase 4 T-CSE/V-segments | **CSE unlocked; V-segments/symmetry de-scoped** (§0.1.2) | — | build order fixed by the re-profile above; CSE first (bound-neutral), Q-extraction second |
 | Phase 5 | **locked** (§0.1.2) | — | requires post-Phase-1 re-profile |
 
 **Phase 0 — DONE & gated** (cert0 green: root_gap coverage 0.909 ≥ 0.90, incorrect 0).
@@ -862,6 +863,127 @@ change otherwise.
 **Correctness gate:** CSE and V-segment preservation are bound-neutral — exact
 node_count/objective equality vs baseline; Q-extraction validated by evaluating both
 forms on random points to 1e-12; symmetry fixing under the differential-bound test.
+
+### Phase 4 — re-profile results (2026-07-03)
+
+The §9 note ("the profile changes after Phases 1–2 — re-profile before committing")
+demanded this before building any Phase 4 item. Measurement-only harness
+`discopt_benchmarks/scripts/p4_reprofile_structure_loss.py` (arena introspection via
+`PyModelRepr.get_node`/`arena_len`/`detect_symmetries`/`is_*_quadratic`;
+`SolveResult.solver_stats` reduce/*+separate/* timers; XLA compiles via the existing
+`perf/measure.count_xla_compiles`). Panel = 8 text-`.nl` instances (5 named probes +
+3 larger-DAG general/quadratic). Per-instance 90 s solve cap, `JAX_PLATFORMS=cpu`,
+x64. **8 run, 0 skipped.** Raw JSON:
+`discopt_benchmarks/results/p4_reprofile_structure_loss_20260703T210635.json` and
+`results/p4_xla_compiles_probe.json`.
+
+**Cost breakdown + per-lever potential:**
+
+| instance | DAG nodes | dup% (all) | **op-dup%** (lever 1, actionable) | defvars (lever 2) | quad? (lever 3) | orbits (lever 4) | wall (s) | s/node | XLA % of wall | where the wall goes (solver_stats) |
+|---|---:|---:|---:|---:|:--:|---:|---:|---:|---:|---|
+| nvs17 | 753 | 68.9 | **37.2** | 0 | deg-2 obj | 0 | 79.1 | 0.85 | 0.1% | separate: edge_concave 32.9 + psd 21.5 + univar_sq 8.0 |
+| ex1252 | 336 | 34.2 | 11.6 | 0 | deg-2 (40 con) | 0 | 98.9 | 1.39 | 0.1% | separate/univar_sq 27.6 + reduce/obbt 7.0 |
+| ex1252a | 282 | 35.8 | 13.8 | 0 | deg-2 (31 con) | 0 | 66.9 | 4.46 | 0.1% | separate/univar_sq 10.5 + reduce/obbt 1.9 |
+| gear4 | 17 | 0.0 | **0.0** | 0 | deg-2 obj | 0 | 49.8 | 0.008 | ~0 | reduce/obbt 14.1 + fbbt 1.3 (6045 nodes — CC3) |
+| st_e38 | 46 | 15.2 | 4.3 | 0 | deg-3 | 0 | 2.3 | 0.78 | ~0 | tiny (3 nodes) |
+| clay0303hfsg | 2135 | 64.8 | **31.1** | 0 | deg-2 obj | 0 | 73.9 | 0.23 | 1.2% | (no separate timers; MILP path) |
+| casctanks | 3124 | 34.0 | 13.1 | 0 | bilinear | 0 | 97.4* | 3.14 | 0.5% | reduce/fbbt 4.0 + univar_sq 1.0 (*hit cap) |
+| heatexch_gen1 | 798 | 29.7 | 8.0 | 0 | deg-2 obj | 0 | 171* | 57 | ~0 | reduce/fbbt 0.6 (*hit cap) |
+
+("op-dup%" = duplicate **operator** nodes as a fraction of the DAG, i.e. duplicates
+excluding constant literals; the all-in dup% is inflated by repeated constants —
+e.g. nvs17's `2.0` literal appears 112× — which CSE would collapse but which cost
+~nothing to evaluate. The op-dup fraction is the actionable per-node/relaxation-cost
+lever.)
+
+**Per-lever verdict (measured potential):**
+
+- **Lever 1 — CSE/hash-consing: REAL and the only broadly-present structure loss.**
+  Operator-node duplication is **31–37% of the DAG on the general-nonconvex class**
+  (nvs17 37.2%, clay0303hfsg 31.1%) and 8–14% elsewhere; **0% on gear4** (its DAG is
+  already tiny — gear4 is a node-count/CC3 instance, not a structure-loss one). The
+  arena's `add` never dedups (`expr.rs`), confirmed by direct walk. This dedup would
+  shrink every downstream consumer (JAX trace, lifted LP rows, FBBT sweep, and the
+  **separation** work that dominates wall — see below).
+- **Lever 2 — `.nl` defined variables (V segments): NO APPLICABLE INSTANCE + a
+  separate parse blocker. Premise does not hold on the readable corpus.** Every one
+  of the 8 panel instances (and **all 1,558 text-`g` `.nl` files in the MINLPLib
+  snapshot**, verified by scanning the "common exprs: b,c,o,c1,o1" header field)
+  reports **0 defined variables** — the MINLPLib text export emits none. The
+  defined-variable-heavy instances (ACOPF, densitymod, milinfract, portfol_*, …) are
+  **all binary-`b`-encoded**, which `nl_parser.rs` rejects outright ("binary .nl
+  format not supported") — discopt cannot even *load* them. And when a `g`-format
+  file *did* carry a defined-var reference, `nl_parser.rs:347-352` would raise
+  "variable index out of range" (the parser drops the V body and cannot resolve a
+  reference to `n_vars + j`). So lever 2 has **zero measurable payoff on anything
+  discopt can read today**; the prerequisite is binary-`.nl` support, not V-segment
+  preservation.
+- **Lever 3 — Q-matrix extraction: structure is present but NOT the bottleneck.**
+  6 of 8 instances carry recognized degree-2 structure (`is_*_quadratic` True; nvs17
+  21 bilinear + 7 monomial terms, casctanks 60 bilinear, clay/ex1252 many quadratic
+  constraints) with no coefficient extraction. This *is* real unrecognized structure
+  — but the wall it would save is the convexity/PSD + edge-concave separation, which
+  is already the dominant cost (nvs17 `separate/psd` 21.5 s + `edge_concave` 32.9 s).
+  Q-extraction is a **strength/quality lever bundled with lever 1**, not an
+  independent win: it only pays once the DAG it reads is deduped.
+- **Lever 4 — symmetry/orbit fixing: NO PANEL SIGNAL.** `detect_symmetries` finds
+  **0 nontrivial orbits on all 8 instances** (variables examined 2–500). No
+  exploitable orbits on this panel → lowest priority; do not build speculatively.
+
+**Premise check — Phase 4's headline premise is PARTLY FALSIFIED, and one sub-premise
+(CC5, from §9) is FULLY FALSIFIED:**
+
+1. **CC5 / "the ex1252 class spends ~14 compiles × ~1 s ≈ the whole solve" is
+   FALSIFIED (per §0.4).** Measured exact XLA compiles: nvs17 **8 @ 0.029 s
+   (0.1% of wall)**, ex1252 **7 @ 0.025 s (0.1%)**, ex1252a **5 @ 0.021 s (0.1%)**,
+   clay0303hfsg 17 @ 0.408 s (1.2%), casctanks 6 @ 0.226 s (0.5%). JAX compilation is
+   **≤1.2% of wall everywhere** — the evaluator-cache fix (perf-plan §1 correction)
+   already amortized it; §1's "compile resolved" note is confirmed at the solve level.
+   **The ex1252 per-node cost (1.4–4.5 s/node) is per-node relaxation/separation
+   work, not compile.** Phase 5's compile item and any "compile-once" framing keyed
+   to ex1252 are moot.
+2. **The dominant wall cost is SEPARATION, not raw DAG-walk/compile.** `solver_stats`
+   attributes nvs17's 79 s almost entirely to `separate/edge_concave` (32.9 s) +
+   `separate/psd` (21.5 s) + `separate/univariate_square` (8.0 s); ex1252's 99 s to
+   `separate/univariate_square` (27.6 s) + `reduce/obbt` (7.0 s). CSE (lever 1) helps
+   *because* it shrinks the DAG those separators walk per node — so its payoff is a
+   multiplier on the separation cost, exactly the C4-as-multiplier framing — but the
+   deduplication itself is not the headline; the separation loop is.
+
+**RANKED build order (with evidence):**
+
+1. **Lever 1 — CSE / hash-consing in the Rust arena. BUILD FIRST.** It is the only
+   Phase-4 lever with broad, measured potential: **31–37% duplicate operator nodes on
+   the general-nonconvex class** (nvs17, clay0303hfsg), 8–14% on the rest. It is
+   bound-neutral by construction (semantic-preserving dedup), so it lands under the
+   exact-equality gate with no relaxation risk, and it shrinks the per-node
+   separation/FBBT/lift work that the profile shows *is* the wall. Ship it with the
+   op-dup metric (not the const-inflated all-dup number) as the exit gauge.
+2. **Lever 3 — Q-matrix extraction. BUILD SECOND, coupled to lever 1.** Real
+   unrecognized degree-2 structure on 6/8 instances, but its payoff (cheaper
+   convexity/PSD + RLT) only materializes on a deduped DAG and feeds the same
+   separation loop lever 1 shrinks. Not an independent win; sequence after CSE.
+3. **Lever 2 — `.nl` defined variables (V segments). DE-PRIORITIZE / re-scope.**
+   **Zero applicable instances** in the entire readable corpus (0 defined vars in all
+   1,558 text `.nl`); the defined-var-heavy set is binary-`.nl` that discopt cannot
+   parse at all. The real prerequisite is **binary-`.nl` reader support** (a parser
+   gap, tracked separately), not V-segment preservation. Building V-segment handling
+   now optimizes a code path no readable instance exercises.
+4. **Lever 4 — symmetry/orbit fixing. DO NOT BUILD (no panel signal).** 0 nontrivial
+   orbits on all 8 instances. Revisit only if a symmetry-bearing class enters the
+   gate panel.
+
+**Net:** Phase 4 is **not** the multiplier §8 assumed across the board — its premise
+holds *only* for lever 1 (CSE), is bundled-secondary for lever 3, and is falsified
+for levers 2 and 4 on the readable corpus. The largest wall lever exposed by this
+re-profile is **separation cost** (edge_concave/psd/univariate_square), which is
+Phase 3 / relaxation-strength territory, not structure preservation; CSE's value is
+as a per-node multiplier on that cost. Recommend scoping Phase 4 down to **CSE
+(+ coupled Q-extraction)** and moving binary-`.nl` support to the parser backlog.
+
+This experiment measures only (no solver math changed; the harness reads existing
+introspection hooks) — bound-neutral by construction; the sound solves on the panel
+(nvs17, gear4, st_e38 optimal) all satisfy `bound ≤ oracle`. No correctness gate applies.
 
 ---
 


### PR DESCRIPTION
## cert:P4 — re-profile: rank the four structure-loss levers

Runs the Phase 4 entry experiment the plan requires before building anything
(§8 + §9's "the profile changes after Phases 1–2 — re-profile before committing").
**Measurement-only**: a new read-only harness reads existing arena/solver_stats/XLA
introspection hooks; no solver math changed (bound-neutral by construction). Results
recorded as a "Phase 4 — re-profile results (2026-07-03)" block in §8 of
`docs/dev/certification-gap-plan.md` and in the §0.8 status table.

**8 instances run, 0 skipped.** Panel = 5 named probes (nvs17, ex1252, ex1252a,
gear4, st_e38) + 3 larger-DAG general/quadratic (clay0303hfsg, casctanks,
heatexch_gen1). 90 s per-instance solve cap, JAX_PLATFORMS=cpu, x64.

### Cost breakdown + per-lever potential

| instance | DAG nodes | op-dup% (lever 1) | defvars (lever 2) | quad (lever 3) | orbits (lever 4) | wall (s) | s/node | XLA % wall |
|---|---:|---:|---:|:--:|---:|---:|---:|---:|
| nvs17 | 753 | **37.2** | 0 | deg-2 | 0 | 79.1 | 0.85 | 0.1% |
| ex1252 | 336 | 11.6 | 0 | deg-2 | 0 | 98.9 | 1.39 | 0.1% |
| ex1252a | 282 | 13.8 | 0 | deg-2 | 0 | 66.9 | 4.46 | 0.1% |
| gear4 | 17 | **0.0** | 0 | deg-2 | 0 | 49.8 | 0.008 | ~0 |
| st_e38 | 46 | 4.3 | 0 | deg-3 | 0 | 2.3 | 0.78 | ~0 |
| clay0303hfsg | 2135 | **31.1** | 0 | deg-2 | 0 | 73.9 | 0.23 | 1.2% |
| casctanks | 3124 | 13.1 | 0 | bilinear | 0 | 97.4* | 3.14 | 0.5% |
| heatexch_gen1 | 798 | 8.0 | 0 | deg-2 | 0 | 171* | 57 | ~0 |

(* hit the 90 s cap. "op-dup%" = duplicate *operator* nodes / DAG — the all-in dup%
is inflated by repeated constant literals, e.g. nvs17's `2.0` appears 112x, which CSE
collapses but which cost ~nothing to evaluate.)

### Ranked build order (evidence)

1. **CSE / hash-consing — BUILD FIRST.** Only broadly-present lever: **31–37%
   duplicate operator nodes** on the general-nonconvex class, 8–14% elsewhere, 0% on
   gear4 (a node-count/CC3 instance, not structure-loss). Bound-neutral by
   construction, lands under the exact-equality gate with no relaxation risk.
2. **Q-matrix extraction — BUILD SECOND, coupled to CSE.** Real degree-2 structure on
   6/8, but its payoff (cheaper convexity/PSD + RLT) only materializes on a deduped
   DAG. Not an independent win.
3. **V-segments — DE-PRIORITIZE / re-scope.** **0 defined vars in all 1,558 text `.nl`
   in the MINLPLib snapshot** (verified via the "common exprs" header field). The
   defined-var-heavy set (ACOPF, densitymod, portfol_*, ...) is **binary-`.nl` that
   `nl_parser.rs` rejects outright** — discopt cannot even load it. Prerequisite is
   binary-`.nl` reader support, not V-segment preservation.
4. **Symmetry/orbit fixing — DO NOT BUILD.** 0 nontrivial orbits on all 8.

### Falsifications (per §0.4)

- **CC5 FALSIFIED.** "ex1252 spends ~14 compiles x ~1 s ~= the whole solve" is stale:
  measured XLA compile is **<=1.2% of wall everywhere** (ex1252 7 compiles / 0.025 s /
  0.1%; nvs17 8 / 0.029 s / 0.1%). The evaluator-cache fix already amortized it.
- **Dominant wall = SEPARATION**, not DAG-walk/compile: `solver_stats` attributes
  nvs17's 79 s to `separate/edge_concave` (32.9 s) + `psd` (21.5 s) +
  `univariate_square` (8.0 s); ex1252's 99 s to `univariate_square` (27.6 s) +
  `reduce/obbt` (7.0 s). That is Phase 3 / relaxation-strength territory; CSE's value
  is as a per-node **multiplier** on the separation cost, not the headline.

**Net:** Phase 4's multiplier premise holds *only* for CSE (+ coupled Q-extraction);
V-segments and symmetry are falsified for the readable corpus. Recommend scoping
Phase 4 to CSE + Q-extraction and moving binary-`.nl` support to the parser backlog.

### Verification

- `ruff check` / `ruff format --check` on the new harness: clean.
- `pytest -m smoke`: **193 passed, 1 skipped**.
- Measurement-only; no solver math touched, bound-neutral by construction. Sound
  solves on the panel (nvs17, gear4, st_e38 optimal) satisfy `bound <= oracle`.

Raw JSON: `discopt_benchmarks/results/p4_reprofile_structure_loss_20260703T210635.json`,
`results/p4_xla_compiles_probe.json`. Do NOT merge — this is a recorded entry
experiment; the maintainer decides the Phase 4 scope from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
