### PR TITLE
fix(correctness): C-13 — only trust converged-convex NLP objective as a node bound (abstain otherwise)

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -88,7 +88,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 |---|---|---|---|---|
 | C-16 | P0 | presolve/aggregate | positional bound resync after variable-removing pass fuses unrelated variables' bounds → false "infeasible" / silent optimum cut, DEFAULT path | fixed |
 | C-17 | P0 | alphaBB bound | node bound uses sampled (non-rigorous) α + center-only PSD check → false "optimal", default path for small nonconvex; deterministic repro confirms (spike width ≤ 0.006 → α=0, bound 0.0, true min −3.5) | fixed |
-| C-13 | P0 | solver.py bounds | serial convex path trusts under-converged NLP objective as node lower bound → false "optimal" | open |
+| C-13 | P0 | solver.py bounds | serial convex path trusts under-converged NLP objective as node lower bound → false "optimal" | fixed |
 | C-1 | P0 | solver.py status | false "infeasible" from non-rigorous NLP fathoms (solve_model path) | open |
 | C-4 | P1 | mir.rs cuts | integer-MIR applied with fractional integer lower bound → invalid cut | open |
 | C-2 | P1 | milp_driver status | false "Infeasible" when deadline orphans deferred nodes | open |
@@ -352,7 +352,38 @@ convex models can decertify too.
   if none exists).
 - Standing gates pass.
 
-**Log:** —
+**Log:** 2026-07-03 — **CONFIRMED then FIXED** (branch `fix-c13-convex-nlp-bound`).
+*Confirm (static):* the serial `solve_model` node loop seeds `nlp_lb = nlp_obj`
+whenever the node NLP status is `OPTIMAL` **or** `ITERATION_LIMIT`
+(`solver.py:5312-5317`), with no `_batch_trusted`-equivalent trust check; for a
+convex model that value flows into `result_lbs[i]` and thence `tree.import_results`
+as the rigorous node lower bound, and the only serial node-loop decertify block was
+gated `if not _model_is_convex` (`:5528`), so it never fired for convex models. The
+serial `_solve_node_nlp` was not even passed `convex=`, so the convex polish-retry
+in `_solve_node_nlp_pounce` never ran. The batch path (`:5016`) and `_solve_nlp_bb`
+(`:7411`) both already decertify this exact case — the serial `solve_model` path was
+the gap. *Confirm (dynamic):* forcing every convex serial node NLP to report
+`ITERATION_LIMIT` (non-KKT) on a convex MINLP solved with `nlp_bb=False, batch_size=1`
+returned `status="optimal", gap_certified=True` (false certificate) on pre-fix code.
+Reachability: a *nonlinear* convex MINLP normally auto-routes to `_solve_nlp_bb`
+(`:3843`), but `nlp_bb=False` (or `lazy_constraints`) forces the `solve_model` serial
+loop — user-reachable. *Fix:* (1) pass `convex=_model_is_convex` to the serial
+`_solve_node_nlp` so the existing convex polish-retry gets its chance to reach KKT;
+(2) for a convex node compute `_serial_nlp_trusted = (not convex) or status==OPTIMAL`
+— when untrusted, ABSTAIN from the NLP bound (`nlp_lb=-inf`, so the node imports at
+its inherited parent bound and fathoms nothing — no unsound prune) and decertify the
+gap after every bound source (mirrors the batch `_batch_trusted` guard and
+`_solve_nlp_bb`). Discards the bound rather than trusting it (option 1 of the Fix
+sketch); OPTIMAL convex nodes and all nonconvex nodes are untouched.
+*Regression test:* `python/tests/test_c13_serial_convex_nlp_bound.py`
+(`@pytest.mark.smoke`, sub-second): `test_serial_convex_iteration_limit_does_not_certify`
+is RED before the fix (asserts NOT `optimal`+`gap_certified`) / GREEN after;
+`test_serial_convex_inflated_bound_never_crosses_primal` pins the dual-≤-primal and
+dual-≤-true-optimum invariants under an above-optimum inflated objective;
+`test_serial_convex_converged_still_certifies` is the bound-neutral control (all-OPTIMAL
+convex solve still certifies, node_count unchanged 3→3). Existing
+`test_p03_trust_gate.py` (batch guard + `_solve_nlp_bb` serial) still green (10/10).
+Status: `open` → `fixed`. PR: #443.
 
 ---
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5382,16 +5382,41 @@ def solve_model(
                         _active_cb,
                         opts,
                         nlp_solver=nlp_solver,
+                        convex=_model_is_convex,
                     )
 
                 result_ids[i] = int(batch_ids[i])
+
+                # C-13: default a convex node to "trusted" (valid NLP lower bound);
+                # the ITERATION_LIMIT branch below clears it when the node NLP did
+                # not converge to a KKT point, which decertifies the gap after every
+                # bound source has had its chance (mirrors the nonconvex finalize).
+                _serial_nlp_trusted = True
 
                 if nlp_result is not None and nlp_result.status in (
                     SolveStatus.OPTIMAL,
                     SolveStatus.ITERATION_LIMIT,
                 ):
                     nlp_obj = float(nlp_result.objective)
-                    nlp_lb = nlp_obj
+                    # C-13: for a CONVEX model the node NLP objective is used as a
+                    # rigorous lower bound — but that is legitimate only when the
+                    # solve actually converged to a KKT point (SolveStatus.OPTIMAL).
+                    # An interior-point iterate stopped at ITERATION_LIMIT can sit
+                    # strictly ABOVE the true node minimum (non-KKT, unconverged
+                    # duals), so its objective is NOT a valid lower bound; trusting
+                    # it can fathom the subtree holding the optimum while the gap
+                    # stays certified → false "optimal". The polish-retry inside
+                    # _solve_node_nlp (convex=True above) already tried to reach KKT;
+                    # if it still returned ITERATION_LIMIT, ABSTAIN from the NLP
+                    # bound (fall back to the valid relaxation/interval bounds
+                    # accumulated in convex_lb, or -inf → node stays open at its
+                    # inherited parent bound, fathoming nothing) and decertify the
+                    # gap. This mirrors the batch path's _batch_trusted guard
+                    # (roadmap P0.3) and _solve_nlp_bb's ITERATION_LIMIT decertify.
+                    _serial_nlp_trusted = (not _model_is_convex) or (
+                        nlp_result.status == SolveStatus.OPTIMAL
+                    )
+                    nlp_lb = nlp_obj if _serial_nlp_trusted else -np.inf
                     convex_lb = -np.inf  # accumulate valid convex lower bound
 
                     if _use_alphabb:
@@ -5590,6 +5615,20 @@ def solve_model(
                         result_lbs[i] = _INFEASIBILITY_SENTINEL
                     elif result_lbs[i] >= _SENTINEL_THRESHOLD:
                         _gap_certified = False
+
+                # C-13: convex node whose NLP objective was NOT a valid lower bound
+                # (non-KKT ITERATION_LIMIT, unrescued by the polish-retry).  The
+                # bound was already abstained above (nlp_lb=-inf, so the node imports
+                # at its inherited parent bound — no unsound fathom), but the gap can
+                # no longer be certified optimal: an under-converged relaxation
+                # objective proves nothing about the subtree, and for a convex model
+                # the NLP objective is typically the ONLY bound source (alphaBB is
+                # nonconvex-only; McCormick/LP relaxers are usually absent).
+                # Decertify unconditionally on any untrusted convex node — the same
+                # conservative guard the batch path applies via _batch_trusted
+                # (roadmap P0.3) and that _solve_nlp_bb applies on ITERATION_LIMIT.
+                if _model_is_convex and not node_infeasible_mask[i] and not _serial_nlp_trusted:
+                    _gap_certified = False
         jax_time += time.perf_counter() - t_jax_start
 
         if np.any(node_infeasible_mask):

--- a/python/tests/test_c13_serial_convex_nlp_bound.py
+++ b/python/tests/test_c13_serial_convex_nlp_bound.py
@@ -1,0 +1,126 @@
+"""C-13 (P0): the serial convex B&B path must not trust an under-converged NLP
+objective as a rigorous node lower bound.
+
+For a **convex** model the node NLP's objective is a valid lower bound *only* when
+the solve converged to a KKT point (``SolveStatus.OPTIMAL``). An interior-point
+iterate that stops at ``ITERATION_LIMIT`` can sit strictly ABOVE the true node
+minimum (non-KKT, unconverged duals), so its objective is NOT a valid lower bound.
+Trusting it can fathom the subtree holding the optimum while the optimality gap
+stays certified — a false "optimal" certificate, the worst failure class.
+
+The batch path already guards this via the ``_batch_trusted`` mask (roadmap P0.3),
+and ``_solve_nlp_bb`` decertifies on ITERATION_LIMIT. This locks the same guarantee
+onto the serial ``solve_model`` path (reached e.g. with ``nlp_bb=False``, or with
+lazy constraints), which previously accepted ITERATION_LIMIT objectives as rigorous
+bounds with no trust check and never decertified for convex models.
+
+Contract under test (the false-certificate CLASS, not a named instance):
+
+  * A convex serial node whose NLP returns ITERATION_LIMIT (non-KKT) must NOT
+    produce ``status == "optimal"`` with ``gap_certified is True``. Either the true
+    optimum is proven some other (rigorous) way, or the run decertifies to
+    "feasible" — but it never *certifies* on the under-converged objective.
+  * The reported dual bound is always a valid lower bound (``bound <= objective``
+    for a minimize) — the dual never crosses the primal.
+  * A normally-converging convex solve (all nodes OPTIMAL) is unaffected: it still
+    certifies optimality with the correct objective (no regression, bound-neutral).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import discopt.solver as S
+import numpy as np
+import pytest
+from discopt.solvers import SolveStatus
+
+# Convex MINLP (exp keeps it nonlinear, out of the MIQP class). The continuous
+# relaxation optimum is fractional (x -> 4.5), so B&B genuinely branches on the
+# serial path. True integer optimum: x=4, y=0.7 -> exp(0.6)+0.25+0 ~ 2.0721.
+_OPT = float(np.exp(0.15 * 4) + (4 - 4.5) ** 2 + (0.7 - 0.7) ** 2)
+
+
+def _convex_minlp():
+    m = dm.Model("c13_cvx")
+    x = m.integer("x", lb=0, ub=8)
+    y = m.continuous("y", lb=-5, ub=5)
+    m.minimize(dm.exp(0.15 * x) + (x - 4.5) ** 2 + (y - 0.7) ** 2)
+    m.subject_to(x + y >= 0)
+    return m
+
+
+def _force_iteration_limit(monkeypatch, inflate: float = 0.0):
+    """Make every serial node/root NLP report ITERATION_LIMIT (non-KKT).
+
+    ``inflate`` optionally pushes the objective ABOVE the true node minimum,
+    emulating an interior-point iterate that stalled above the optimum — the
+    precise condition under which the objective is not a valid lower bound.
+    """
+    orig_node = S._solve_node_nlp
+    orig_root = S._solve_root_node_multistart
+
+    def _degrade(res):
+        if res is not None and res.status == SolveStatus.OPTIMAL:
+            res.status = SolveStatus.ITERATION_LIMIT
+            if inflate:
+                res.objective = float(res.objective) + inflate
+        return res
+
+    monkeypatch.setattr(S, "_solve_node_nlp", lambda *a, **k: _degrade(orig_node(*a, **k)))
+    monkeypatch.setattr(
+        S, "_solve_root_node_multistart", lambda *a, **k: _degrade(orig_root(*a, **k))
+    )
+
+
+@pytest.mark.smoke
+def test_serial_convex_iteration_limit_does_not_certify(monkeypatch):
+    """Non-KKT convex serial nodes must not yield a certified optimal."""
+    _force_iteration_limit(monkeypatch, inflate=0.0)
+    # nlp_bb=False forces the solve_model serial loop (bypasses the convex NLP-BB
+    # auto-select); batch_size=1 forces the serial per-node path (n_batch == 1).
+    r = _convex_minlp().solve(nlp_solver="ipm", time_limit=60, batch_size=1, nlp_bb=False)
+
+    # The core certificate contract: never "optimal + certified" off an
+    # under-converged NLP objective.
+    assert not (r.status == "optimal" and r.gap_certified is True)
+
+
+@pytest.mark.smoke
+def test_serial_convex_inflated_bound_never_crosses_primal(monkeypatch):
+    """An inflated (above-optimum) non-KKT node objective must not fathom the
+    optimum nor be reported as a certified dual bound above the true optimum."""
+    _force_iteration_limit(monkeypatch, inflate=50.0)
+    r = _convex_minlp().solve(nlp_solver="ipm", time_limit=60, batch_size=1, nlp_bb=False)
+
+    # No false optimal on the objective.
+    if r.status == "optimal" and r.gap_certified:
+        assert r.objective is not None and abs(r.objective - _OPT) < 1e-2, (
+            f"false optimal: certified obj={r.objective} vs true {_OPT}"
+        )
+
+    # Certificate invariant: the reported dual bound never crosses the incumbent
+    # (bound <= objective for a minimize), and never exceeds the true optimum.
+    if r.bound is not None and np.isfinite(r.bound):
+        if r.objective is not None and np.isfinite(r.objective):
+            assert r.bound <= r.objective + 1e-6, (
+                f"dual bound {r.bound} crossed primal {r.objective}"
+            )
+        assert r.bound <= _OPT + 1e-6, f"dual bound {r.bound} exceeds true optimum {_OPT}"
+
+
+@pytest.mark.smoke
+def test_serial_convex_converged_still_certifies():
+    """Control: a normally-converging convex serial solve is unaffected — it still
+    certifies optimality with the correct objective (fix is bound-neutral on the
+    KKT-converged path)."""
+    r = _convex_minlp().solve(nlp_solver="ipm", time_limit=60, batch_size=1, nlp_bb=False)
+    assert r.status == "optimal"
+    assert r.gap_certified is True
+    assert r.objective is not None and abs(r.objective - _OPT) < 1e-3
+    # Valid dual bound meeting the incumbent.
+    assert r.bound is not None and r.bound <= r.objective + 1e-6


### PR DESCRIPTION
## C-13 (P0) — serial convex path trusted an under-converged NLP objective as a rigorous node lower bound → false "optimal"

Fixes correctness backlog item **C-13** (tracking issue #396), a P0 false-optimality
certificate on the default serial `solve_model` branch-and-bound path.

### The bug (confirmed)

For a **convex** model the node NLP's objective is used as a rigorous node lower
bound — legitimate only when the solve actually converged to a KKT point
(`SolveStatus.OPTIMAL`). An interior-point iterate stopped at `ITERATION_LIMIT`
can sit strictly **above** the true node minimum (non-KKT, unconverged duals), so
its objective is **not** a valid lower bound. Trusting it can fathom the subtree
holding the optimum while the optimality gap stays certified → **false "optimal"**.

The serial `solve_model` node loop seeded `nlp_lb = nlp_obj` whenever the status
was `OPTIMAL` **or** `ITERATION_LIMIT`, with **no** trust check, and the only
serial-node decertify block was gated `if not _model_is_convex` — so it never
fired for convex models. The serial `_solve_node_nlp` was not even passed
`convex=`, so the convex polish-retry never ran. The **batch** path already guards
this via `_batch_trusted`, and `_solve_nlp_bb` decertifies on `ITERATION_LIMIT` —
the serial `solve_model` path was the gap.

**Reachability:** a nonlinear convex MINLP normally auto-routes to `_solve_nlp_bb`,
but `nlp_bb=False` (or `lazy_constraints`) forces the `solve_model` serial loop —
user-reachable.

**Confirmation (dynamic):** forcing every convex serial node NLP to report
`ITERATION_LIMIT` on a convex MINLP solved with `nlp_bb=False, batch_size=1`
returned `status="optimal", gap_certified=True` on pre-fix code (false
certificate). After the fix it correctly reports `feasible, gap_certified=False`
with the correct incumbent and a valid dual bound (`bound <= objective`).

### The fix (sound; abstain, never trust the under-converged bound)

1. Pass `convex=_model_is_convex` to the serial `_solve_node_nlp` so the existing
   convex polish-retry in `_solve_node_nlp_pounce` gets its chance to reach KKT.
2. Compute `_serial_nlp_trusted = (not convex) or status == OPTIMAL`. When a convex
   node is **untrusted**, **abstain** from the NLP bound (`nlp_lb = -inf`, so the
   node imports at its inherited parent bound and fathoms nothing — no unsound
   prune) and **decertify** the gap after every bound source has had its chance.
   This mirrors the batch `_batch_trusted` guard (roadmap P0.3) and `_solve_nlp_bb`.

`OPTIMAL` convex nodes and all nonconvex nodes are untouched. No safety mechanism
was weakened — the convergence gate is made **stricter** (ITERATION_LIMIT is no
longer accepted as a valid convex bound). Python-only; no Rust changed.

### Tests

New fast regression test `python/tests/test_c13_serial_convex_nlp_bound.py`
(`@pytest.mark.smoke`, sub-second):

- `test_serial_convex_iteration_limit_does_not_certify` — **RED before the fix**
  (asserts the run is never `optimal` + `gap_certified`), **GREEN after**. Encodes
  the false-certificate class, not a named instance.
- `test_serial_convex_inflated_bound_never_crosses_primal` — pins the certificate
  invariants (`bound <= objective`, `bound <= true optimum`) under an
  above-optimum inflated objective.
- `test_serial_convex_converged_still_certifies` — bound-neutral control: an
  all-`OPTIMAL` convex solve still certifies optimality with the correct objective,
  node count unchanged.

### Gates run

- `pytest python/tests/test_c13_serial_convex_nlp_bound.py python/tests/test_p03_trust_gate.py` — **13 passed** (new C-13 + existing batch/serial trust-gate guard).
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**.
- Targeted certification/bound/NLP sweep (11 files, `-m "not slow"`) — **82 passed, 0 failed**.
- `pytest -m smoke` — see PR run.
- `ruff check` + `ruff format --check` on changed files — clean.
- No Rust touched → `cargo test` / `maturin develop` not required.

Docs: `docs/dev/correctness-issues.md` C-13 updated `open` → `fixed` with a full Log entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
