### PR TITLE
fix(correctness): C-1 — require a rigorous proof to fathom infeasible (no NLP-failure infeasibility)

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -89,7 +89,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-16 | P0 | presolve/aggregate | positional bound resync after variable-removing pass fuses unrelated variables' bounds → false "infeasible" / silent optimum cut, DEFAULT path | fixed |
 | C-17 | P0 | alphaBB bound | node bound uses sampled (non-rigorous) α + center-only PSD check → false "optimal", default path for small nonconvex; deterministic repro confirms (spike width ≤ 0.006 → α=0, bound 0.0, true min −3.5) | fixed |
 | C-13 | P0 | solver.py bounds | serial convex path trusts under-converged NLP objective as node lower bound → false "optimal" | fixed |
-| C-1 | P0 | solver.py status | false "infeasible" from non-rigorous NLP fathoms (solve_model path) | open |
+| C-1 | P0 | solver.py status | false "infeasible" from non-rigorous NLP fathoms (solve_model path) | fixed |
 | C-4 | P1 | mir.rs cuts | integer-MIR applied with fractional integer lower bound → invalid cut | open |
 | C-2 | P1 | milp_driver status | false "Infeasible" when deadline orphans deferred nodes | open |
 | C-19 | P1 | relax_tan | pole-straddling interval classified as one branch → secant across a pole, invalid envelope | open |
@@ -428,7 +428,54 @@ else-branch return `status="unknown"` (bound=None, gap_certified=False) instead 
   still returns `"infeasible"` (add/keep a test asserting this).
 - Standing gates (§0.3) pass.
 
-**Log:** —
+**Log:**
+- 2026-07-03 — **CONFIRMED then FIXED.** Static confirm: `solve_model`'s finalize
+  else-branch (now `solver.py:~6656-6672`) declared `status="infeasible"` whenever
+  the tree exhausted with no incumbent, checking only `max_nodes`/`time_limit` — it
+  consulted no rigor flag. `grep _unconverged_fathom` confirms that flag lives
+  ONLY in `_solve_nlp_bb` (5 occurrences, all in `7006..7960`), never in the
+  `solve_model` batch loop.
+- **Dynamic confirm (decisive).** A genuinely feasible nonconvex MINLP
+  (`x*y>=1`, feasible x=y=1; integer `z` to keep it on the spatial B&B batch path)
+  in which every node NLP fails non-rigorously (constraint-violating "optimal"
+  iterate → `_INFEASIBILITY_SENTINEL`) and no rigorous bound exists
+  (`mccormick_bounds="none"` + interval bound stubbed to −inf), with the tree
+  driven to `is_finished()` + no incumbent — the exact state the Rust
+  fathom-at-tight-box path (`tree_manager.rs:511/537`) produces when every leaf
+  carries a non-rigorous sentinel. Pre-fix: `status="infeasible"` on the feasible
+  model (the false certificate). This is the worst-class error. Note: reaching this
+  tree-state through the *full* end-to-end path is guarded in practice — a sentinel
+  node is not pruned without an incumbent (`tree_manager.rs:318`), so it keeps
+  branching → `node_limit`/`time_limit`, not `infeasible` — but the finalize LOGIC
+  itself was unsound and the state IS reachable via the Rust tight-box fathom, so
+  the fix hardens the logic regardless.
+- **Fix** (`solver.py`, per the card). Added a `_nonrigorous_fathom` flag
+  (initialized False alongside `_gap_certified`) with a single authoritative,
+  path-agnostic sweep after each batch's node loop, before `import_results`: any
+  node entering the tree with the failure sentinel but WITHOUT the rigorous
+  `node_infeasible_mask` (empty McCormick/LP relaxation over the finite box) sets
+  the flag. The finalize else-branch gains an `elif _nonrigorous_fathom:` arm that
+  returns `status="unknown"` (`_gap_certified=False`) instead of `"infeasible"`,
+  mirroring `_solve_nlp_bb`'s `_unconverged_fathom` semantics exactly. Covers
+  convex + nonconvex, batch + serial in one place. No rigorous check was weakened:
+  a node fathomed via `node_infeasible_mask` or a real `SolveStatus.INFEASIBLE`
+  still yields `"infeasible"`. `SolveResult.__post_init__` already handles
+  `"unknown"` (its `status != "infeasible"` finite-bound downgrade clears the
+  meaningless bound/gap).
+- **Regression tests** (`python/tests/test_c1_nlp_fathom_infeasible.py`,
+  `@pytest.mark.smoke`, sub-second, fail-before/pass-after verified by stashing the
+  fix): `test_nonrigorous_fathom_is_not_reported_infeasible` (the decisive repro —
+  pre-fix returns `"infeasible"`, post-fix `"unknown"`; asserts the class, not a
+  named instance) and `test_rigorous_infeasibility_is_preserved` (empty-box
+  `x>=5 ∧ x<=1` still returns `"infeasible"` — the fix must not downgrade a genuine
+  certificate).
+- **Gates:** ruff check + format clean; mypy (pre-commit) passed; `pytest -m smoke`
+  195 passed / 1 skipped / 0 failed (includes the 2 new tests); adversarial
+  `test_adversarial_recent_fixes.py -m slow` 10 passed. No Rust touched. No
+  correctness assertion weakened (`incorrect_count` unaffected; the change only
+  turns an unsound `"infeasible"` into a sound `"unknown"`). PR: TBD.
+
+**Status:** open → fixed.
 
 ---
 

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -473,7 +473,7 @@ else-branch return `status="unknown"` (bound=None, gap_certified=False) instead 
   195 passed / 1 skipped / 0 failed (includes the 2 new tests); adversarial
   `test_adversarial_recent_fixes.py -m slow` 10 passed. No Rust touched. No
   correctness assertion weakened (`incorrect_count` unaffected; the change only
-  turns an unsound `"infeasible"` into a sound `"unknown"`). PR: TBD.
+  turns an unsound `"infeasible"` into a sound `"unknown"`). PR: #444.
 
 **Status:** open → fixed.
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4191,6 +4191,21 @@ def solve_model(
         tree.set_nonconvex(True)
     _gap_certified = True
 
+    # --- Soundness (C-1): distinguish a PROVEN-infeasible fathom from a merely
+    # non-rigorous one, exactly as ``_solve_nlp_bb`` does with
+    # ``_unconverged_fathom``. A node fathomed on an empty McCormick/LP
+    # relaxation over a finite box (``node_infeasible_mask``) or on a
+    # ``SolveStatus.INFEASIBLE`` certificate is a valid infeasibility proof. A
+    # node that merely carries the failure sentinel because its local NLP failed
+    # / diverged / returned a constraint-violating iterate is NON-rigorous — it
+    # does not prove the subtree empty. If the tree later exhausts with no
+    # incumbent, an "infeasible" verdict is only sound when NO node was fathomed
+    # non-rigorously; otherwise feasibility is genuinely UNKNOWN and reporting
+    # "infeasible" would be a false certificate (the worst-class error). Set by a
+    # single authoritative per-batch sweep below (any sentinel-without-proof node)
+    # and consumed in the finalize else-branch.
+    _nonrigorous_fathom = False
+
     # Sense-derived negation flag for the internal (minimization) B&B. Unlike
     # ``_mc_negate`` below — which is only assigned correctly inside the
     # McCormick "nlp"/"midpoint" setup — this is valid in every relaxation
@@ -5631,6 +5646,21 @@ def solve_model(
                     _gap_certified = False
         jax_time += time.perf_counter() - t_jax_start
 
+        # C-1 (path-agnostic, covers convex + nonconvex, batch + serial): any node
+        # entering the tree with the failure sentinel but WITHOUT a rigorous
+        # infeasibility certificate (``node_infeasible_mask`` — an empty McCormick/
+        # LP relaxation over the finite box) is being fathomed non-rigorously. Its
+        # subtree is not proven empty, so if the tree later exhausts with no
+        # incumbent we must not declare the model "infeasible". The per-site flags
+        # above already cover the nonconvex decertify branches; this final sweep is
+        # the authoritative guard and also catches the convex path (whose local NLP
+        # objective is a valid bound but whose constraint-violating / failed nodes
+        # still get sentinelled with no proof).
+        for i in range(n_batch):
+            if result_lbs[i] >= _SENTINEL_THRESHOLD and not node_infeasible_mask[i]:
+                _nonrigorous_fathom = True
+                break
+
         if np.any(node_infeasible_mask):
             for idx in np.flatnonzero(node_infeasible_mask):
                 i = int(idx)
@@ -6752,9 +6782,24 @@ def solve_model(
         elif wall_time >= time_limit:
             status = "time_limit"
             _gap_certified = False
+        elif _nonrigorous_fathom:
+            # C-1: the tree exhausted with no incumbent, but at least one node was
+            # fathomed on a NON-rigorous failure (its local NLP failed / diverged /
+            # returned a constraint-violating iterate and it was sentinelled with no
+            # empty-relaxation or SolveStatus.INFEASIBLE certificate). A non-rigorous
+            # failure does NOT prove a subtree empty, so we cannot soundly claim the
+            # model is infeasible — its feasibility is genuinely UNDETERMINED.
+            # Reporting "infeasible" here would be a false certificate (the
+            # worst-class error: a feasible model declared infeasible). Report
+            # "unknown" instead, exactly as the _solve_nlp_bb path does with
+            # _unconverged_fathom. Conservative by design: soundness over capability.
+            status = "unknown"
+            _gap_certified = False
         else:
-            # Tree exhausted with no feasible node: infeasibility *is* a certified
-            # conclusion, so leave _gap_certified untouched.
+            # Tree exhausted with no feasible node and every fathom was a valid
+            # certificate (empty McCormick/LP relaxation over a finite box or
+            # SolveStatus.INFEASIBLE): infeasibility *is* a certified conclusion, so
+            # leave _gap_certified untouched.
             status = "infeasible"
 
     from discopt.modeling.core import ObjectiveSense

--- a/python/tests/test_c1_nlp_fathom_infeasible.py
+++ b/python/tests/test_c1_nlp_fathom_infeasible.py
@@ -1,0 +1,160 @@
+"""Soundness lock (C-1): a non-rigorous NLP fathom must never yield 'infeasible'.
+
+Declaring a model INFEASIBLE is a *certificate claim*: it asserts the feasible set
+is empty. That claim is only sound when every node that emptied the search tree was
+fathomed on a RIGOROUS proof — an empty McCormick/LP relaxation over a finite box,
+or a genuine ``SolveStatus.INFEASIBLE``. A node whose *local* NLP merely failed
+(diverged, hit an iteration limit, or returned a constraint-violating iterate) is
+sentinelled and pruned, but that is NOT a proof its subtree is empty: an
+interior-point method can stall at an infeasible point on a perfectly feasible
+nonconvex node.
+
+Before the C-1 fix, ``solve_model``'s finalize else-branch declared
+``status="infeasible"`` whenever the tree exhausted with no incumbent, checking only
+``max_nodes`` / ``time_limit`` — it never consulted whether the fathoms were
+rigorous. So a FEASIBLE model whose node NLPs all fail non-rigorously (and which has
+no rigorous relaxation bound) was reported INFEASIBLE — the worst-class error
+(a feasible problem told it has no solution).
+
+The fix tracks a ``_nonrigorous_fathom`` flag (mirroring ``_solve_nlp_bb``'s
+``_unconverged_fathom``) set whenever a node enters the tree with the failure
+sentinel but WITHOUT a rigorous infeasibility certificate, and downgrades the
+verdict to ``"unknown"`` (feasibility undetermined) instead of ``"infeasible"``.
+
+These tests are @pytest.mark.smoke: they run sub-second and lock the class in CI on
+every PR. ``test_nonrigorous_fathom_is_not_reported_infeasible`` reproduces the bug
+(it returned ``"infeasible"`` on the pre-fix code); the rigorous negative test
+confirms genuine infeasibility is preserved.
+"""
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.solver as S
+import numpy as np
+import pytest
+from discopt import Model
+from discopt.solvers import NLPResult, SolveStatus
+
+
+def _failing_node_nlp(
+    evaluator, x0, node_lb, node_ub, constraint_bounds, options, nlp_solver="ipopt", convex=False
+):
+    """A NON-rigorous NLP failure: return an 'optimal'-status point at the lower
+    corner, which violates the model constraints. This is NOT a proof of
+    infeasibility — the local solver simply failed to find a feasible point."""
+    xbad = np.clip(np.asarray(node_lb, dtype=float), -1e6, 1e6)
+    return NLPResult(
+        status=SolveStatus.OPTIMAL, x=xbad, objective=float(np.sum(xbad)), iterations=1
+    )
+
+
+def _failing_multistart(*a, **k):
+    node_lb = a[1] if len(a) > 1 else k["node_lb"]
+    xbad = np.clip(np.asarray(node_lb, dtype=float), -1e6, 1e6)
+    return NLPResult(
+        status=SolveStatus.OPTIMAL, x=xbad, objective=float(np.sum(xbad)), iterations=1
+    )
+
+
+def _build_feasible_nonconvex_minlp():
+    """A genuinely FEASIBLE nonconvex MINLP (integer var keeps it on the spatial
+    B&B batch path). Feasible point: x=y=1 (x*y=1>=1), z=1 -> objective 3."""
+    m = Model("c1_feasible")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=4.0)
+    z = m.integer("z", lb=1, ub=3)
+    m.subject_to(x * y >= 1.0)
+    m.minimize(x + y + z)
+    return m
+
+
+class _ExhaustNoIncumbentTree:
+    """Wraps the real B&B tree but reports the search finished with NO incumbent
+    after the first batch of results is imported. This is exactly the tree state
+    the Rust fathom-at-tight-box path produces when every leaf carries a
+    non-rigorous failure sentinel: ``open_count()==0`` and no feasible incumbent."""
+
+    def __init__(self, real_cls, *a, **k):
+        self._t = real_cls(*a, **k)
+        self._imported = 0
+
+    def inject_incumbent(self, *a, **k):
+        # No primal heuristic may smuggle in a feasible incumbent: we are
+        # exercising the case where the ONLY thing removing nodes is non-rigorous
+        # fathoming.
+        return None
+
+    def import_results(self, ids, lbs, sols, feas):
+        self._imported += 1
+        return self._t.import_results(ids, lbs, sols, feas)
+
+    def incumbent(self):
+        return None
+
+    def is_finished(self):
+        return self._imported >= 1
+
+    def __getattr__(self, name):
+        return getattr(self._t, name)
+
+
+@pytest.mark.smoke
+def test_nonrigorous_fathom_is_not_reported_infeasible(monkeypatch):
+    """A feasible model whose nodes are all fathomed non-rigorously must NOT be
+    reported infeasible. Pre-fix this returned ``status="infeasible"``."""
+    m = _build_feasible_nonconvex_minlp()
+    real_cls = S.PyTreeManager
+
+    monkeypatch.setattr(
+        S, "PyTreeManager", lambda *a, **k: _ExhaustNoIncumbentTree(real_cls, *a, **k)
+    )
+    monkeypatch.setattr(S, "_solve_node_nlp", _failing_node_nlp)
+    monkeypatch.setattr(S, "_solve_root_node_multistart", _failing_multistart)
+    # No rigorous relaxation bound available (mccormick 'none' + no interval save):
+    # the only thing that removes a node from the tree is the non-rigorous sentinel.
+    monkeypatch.setattr(S, "_compute_interval_bound", lambda *a, **k: -np.inf)
+
+    res = S.solve_model(
+        m,
+        time_limit=20.0,
+        max_nodes=5000,
+        mccormick_bounds="none",
+        nlp_solver="ipopt",
+        subnlp_enabled=False,
+        rens=False,
+        presolve=False,
+        skip_convex_check=True,
+    )
+
+    # Headline: the false certificate must be gone. A feasible model must never be
+    # declared infeasible off non-rigorous fathoms.
+    assert res.status != "infeasible", (
+        f"feasible model falsely reported infeasible via non-rigorous fathoms (status={res.status})"
+    )
+    # It should report the sound 'undetermined' verdict, with no certified gap.
+    assert res.status == "unknown", f"expected 'unknown', got {res.status!r}"
+    assert not getattr(res, "gap_certified", False)
+
+
+@pytest.mark.smoke
+def test_rigorous_infeasibility_is_preserved():
+    """A RIGOROUSLY infeasible model (empty box: x>=5 with x<=1) must still report
+    'infeasible' — the fix must not downgrade a genuine infeasibility certificate."""
+    m = Model("c1_rigorous_infeasible")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    z = m.integer("z", lb=0, ub=2)
+    m.subject_to(x >= 5.0)  # contradicts x <= 1 -> empty feasible set
+    m.subject_to(x * x + z >= 0.0)  # nonconvex term to reach the spatial path
+    m.minimize(x + z)
+
+    res = m.solve(time_limit=20.0, max_nodes=500)
+    assert res.status == "infeasible", (
+        f"rigorously infeasible model must stay infeasible, got {res.status!r}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## C-1 (P0) — false "infeasible" from non-rigorous NLP fathoms on the `solve_model` path

Declaring a model **infeasible** is a certificate claim: the feasible set is empty.
That is only sound when every node that emptied the B&B tree was fathomed on a
**rigorous** proof (an empty McCormick/LP relaxation over a finite box, or a genuine
`SolveStatus.INFEASIBLE`). A node whose *local* NLP merely failed — diverged, hit an
iteration limit, or returned a constraint-violating iterate — is sentinelled and
pruned, but that is **not** a proof its subtree is empty (an interior-point method
can stall at an infeasible point on a perfectly feasible nonconvex node).

`solve_model`'s finalize else-branch declared `status="infeasible"` whenever the tree
exhausted with no incumbent, checking only `max_nodes`/`time_limit` — it never
consulted whether the exhausting fathoms were rigorous. The equivalent guard
(`_unconverged_fathom`) already exists on the `_solve_nlp_bb` path but had **no
counterpart** in the `solve_model` batch loop.

### Confirmation (before fixing)
- **Static:** the finalize else-branch consults no rigor flag; `grep _unconverged_fathom`
  returns 5 hits, all inside `_solve_nlp_bb` (`solver.py:7006..7960`), none in the
  `solve_model` loop.
- **Dynamic (decisive):** a genuinely feasible nonconvex MINLP (`x*y>=1`, feasible
  x=y=1; integer `z` to stay on the spatial B&B batch path) where every node NLP
  fails non-rigorously (constraint-violating "optimal" iterate → `_INFEASIBILITY_SENTINEL`)
  and no rigorous bound exists (`mccormick_bounds="none"` + interval bound stubbed to
  −inf), with the tree driven to `is_finished()` + no incumbent — the exact state the
  Rust fathom-at-tight-box path (`tree_manager.rs:511/537`) produces when every leaf
  carries a non-rigorous sentinel. **Pre-fix: `status="infeasible"` on the feasible
  model.** Post-fix: `"unknown"`.

### Fix
Added a `_nonrigorous_fathom` flag (initialized False alongside `_gap_certified`) set
by a single authoritative, path-agnostic per-batch sweep before `import_results`: any
node entering the tree with the failure sentinel but **without** the rigorous
`node_infeasible_mask` sets it. The finalize else-branch gains an
`elif _nonrigorous_fathom: status="unknown"` arm (with `_gap_certified=False`) before
the `"infeasible"` branch — mirroring `_solve_nlp_bb`'s `_unconverged_fathom`
semantics. Covers convex + nonconvex, batch + serial in one place.

**No rigorous check was weakened.** A node fathomed via `node_infeasible_mask` (empty
relaxation over a finite box) or a real `SolveStatus.INFEASIBLE` still yields
`"infeasible"`. `SolveResult.__post_init__` already handles `"unknown"`. Conservative
by design (soundness over capability): a truly-infeasible model that happened to also
have a non-rigorous fathom is reported `"unknown"` rather than risk a false certificate
— it never reports a wrong answer.

### Tests (`python/tests/test_c1_nlp_fathom_infeasible.py`, `@pytest.mark.smoke`, sub-second)
- `test_nonrigorous_fathom_is_not_reported_infeasible` — the decisive repro; encodes
  the **class** (non-rigorous fathom → not "infeasible"), not a named instance.
  Verified **fail-before / pass-after** by stashing the fix (pre-fix: `"infeasible"`).
- `test_rigorous_infeasibility_is_preserved` — empty-box `x>=5 ∧ x<=1` still returns
  `"infeasible"`.

### Gates
- `ruff check` + `ruff format --check`: clean
- `mypy` (pre-commit): passed
- `pytest -m smoke` (python/tests): **195 passed, 1 skipped, 0 failed** (incl. the 2 new tests)
- adversarial `test_adversarial_recent_fixes.py -m slow`: **10 passed**
- No Rust touched; `incorrect_count` unaffected (an unsound `"infeasible"` becomes a sound `"unknown"`).

Updates `docs/dev/correctness-issues.md`: C-1 `open` → `fixed` with full Log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
