### PR TITLE
fix(correctness): C-2 MILP driver false "Infeasible" on deadline-orphaned nodes

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -146,6 +146,43 @@ pub struct MilpOptions {
     pub simplex: SimplexOptions,
 }
 
+/// Map the search's terminal state to a [`MilpStatus`]. Pure so it can be
+/// unit-tested against the exact orphaned-node scenario (C-2) without driving a
+/// full solve.
+///
+/// The C-2 invariant lives here: `Infeasible` is returned **only** on a rigorous
+/// empty-tree proof — `tree_finished && !search_incomplete`. `search_incomplete`
+/// is true whenever a node was deferred un-solved (deadline), which leaves it
+/// popped off the heap and `Evaluated`, invisible to the tree's `open_count()`.
+/// In that case `tree_finished` can read `true` over a subtree that was never
+/// searched, so the honest terminus is a limit status, never a false
+/// "infeasible".
+fn decide_status(
+    unbounded: bool,
+    has_inc: bool,
+    tree_finished: bool,
+    search_incomplete: bool,
+    gap_closed: bool,
+    gap_certified: bool,
+    node_limit_hit: bool,
+) -> MilpStatus {
+    if unbounded {
+        MilpStatus::Unbounded
+    } else if !has_inc {
+        if tree_finished && !search_incomplete {
+            MilpStatus::Infeasible
+        } else {
+            MilpStatus::NodeLimit
+        }
+    } else if (tree_finished || gap_closed) && gap_certified {
+        MilpStatus::Optimal
+    } else if node_limit_hit {
+        MilpStatus::NodeLimit
+    } else {
+        MilpStatus::Feasible
+    }
+}
+
 /// Solve `min cᵀx + obj_const s.t. A x = b, l ≤ x ≤ u` with `integer_cols`
 /// integer-constrained, by Rust-internal warm-started-simplex branch and bound.
 pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions) -> MilpResult {
@@ -218,6 +255,14 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
     let mut lp_iters = 0usize;
     let mut unbounded = false;
     let mut gap_certified = true;
+    // C-2: set whenever a node is dropped un-solved (deadline deferral). A
+    // deferred node was already popped off the heap and left `Evaluated`, so it
+    // is invisible to `open_count()` — `is_finished()` can then read `true` even
+    // though that node's subtree was never searched. Without this flag, an empty
+    // tree with no incumbent is mislabeled `Infeasible` (a false certificate)
+    // when the real terminus is a time-limit cut-off. The no-incumbent status
+    // branch gates on this so a deadline yields a limit status, not `Infeasible`.
+    let mut search_incomplete = false;
 
     // Original constraint rows (before any cuts) are the knapsack candidates for
     // cover separation; later rows are themselves cuts.
@@ -519,10 +564,19 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
             if out.deferred {
                 // Deadline hit before this node's LP solve. Skip it entirely: do
                 // not import a result, so the node keeps its parent-inherited
-                // bound and stays a valid open node. The gap cannot be certified
-                // once any node went unsolved, and the loop-top deadline check
-                // breaks the search on the next iteration.
+                // bound. The gap cannot be certified once any node went unsolved,
+                // and the loop-top deadline check breaks the search on the next
+                // iteration.
+                //
+                // C-2: the node was popped off the heap by `export_batch` and is
+                // now stuck `Evaluated`, so `open_count()` no longer sees it. If
+                // the rest of this final batch fathoms rigorously and no incumbent
+                // exists, `is_finished()` would read `true` and the driver would
+                // return `Infeasible` — a false certificate, since this node's
+                // subtree was never searched. Record that the search was cut short
+                // so the no-incumbent status resolves to a limit status instead.
                 gap_certified = false;
+                search_incomplete = true;
                 continue;
             }
             if out.unbounded {
@@ -599,21 +653,15 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
         Some((xi, oi)) if oi < INFEAS_SENTINEL - 1.0 => (xi.to_vec(), oi, true),
         _ => (vec![0.0; ns], f64::INFINITY, false),
     };
-    let status = if unbounded {
-        MilpStatus::Unbounded
-    } else if !has_inc {
-        if tm.is_finished() {
-            MilpStatus::Infeasible
-        } else {
-            MilpStatus::NodeLimit
-        }
-    } else if (tm.is_finished() || tm.gap() <= opts.gap_tol) && gap_certified {
-        MilpStatus::Optimal
-    } else if stats.total_nodes >= opts.max_nodes {
-        MilpStatus::NodeLimit
-    } else {
-        MilpStatus::Feasible
-    };
+    let status = decide_status(
+        unbounded,
+        has_inc,
+        tm.is_finished(),
+        search_incomplete,
+        tm.gap() <= opts.gap_tol,
+        gap_certified,
+        stats.total_nodes >= opts.max_nodes,
+    );
 
     MilpResult {
         status,
@@ -1863,6 +1911,88 @@ mod tests {
         };
         let r = solve_milp(&lp, &[1.0], 0.0, &opts(1, vec![0]));
         assert_eq!(r.status, MilpStatus::Infeasible);
+    }
+
+    // ---- C-2: deadline that orphans a deferred node must NOT report Infeasible ----
+    //
+    // These drive the terminal-status logic (`decide_status`) directly, which is
+    // where the false certificate lived: when the last batch fathoms rigorously
+    // and no incumbent exists, a deferred (un-solved) node has been popped off the
+    // heap and left `Evaluated`, so the tree reads `is_finished() == true`. The
+    // pre-fix code returned `Infeasible` unconditionally on that branch — a false
+    // "infeasible" on a time-limit termination whose orphaned subtree may contain
+    // the optimum. The fix gates `Infeasible` on `!search_incomplete`.
+
+    #[test]
+    fn c2_deferred_node_orphaned_by_deadline_is_not_infeasible() {
+        // Empty tree, no incumbent, but a node was deferred un-solved: the search
+        // was cut short by the deadline, so the honest status is a limit status,
+        // NEVER Infeasible. This is the exact scenario the C-2 card describes.
+        let status = decide_status(
+            /*unbounded=*/ false, /*has_inc=*/ false,
+            /*tree_finished=*/ true, // open_count()==0 because the orphan is Evaluated
+            /*search_incomplete=*/ true, // a node was deferred un-solved
+            /*gap_closed=*/ false,
+            /*gap_certified=*/ false, // gap is correctly decertified on defer
+            /*node_limit_hit=*/ false,
+        );
+        assert_ne!(
+            status,
+            MilpStatus::Infeasible,
+            "deferred-node orphaning must not yield a false Infeasible certificate"
+        );
+        assert_eq!(status, MilpStatus::NodeLimit);
+    }
+
+    #[test]
+    fn c2_genuine_infeasible_still_reported_when_search_complete() {
+        // Rigorous empty-tree proof: every node fathomed, nothing deferred. The
+        // Infeasible certificate must survive the fix — do not weaken it.
+        let status = decide_status(
+            /*unbounded=*/ false, /*has_inc=*/ false, /*tree_finished=*/ true,
+            /*search_incomplete=*/ false, // no node was ever dropped un-solved
+            /*gap_closed=*/ false, /*gap_certified=*/ true,
+            /*node_limit_hit=*/ false,
+        );
+        assert_eq!(
+            status,
+            MilpStatus::Infeasible,
+            "a rigorously drained empty tree must still certify Infeasible"
+        );
+    }
+
+    #[test]
+    fn c2_end_to_end_genuine_infeasible_unaffected() {
+        // The full-driver infeasible path (no deferral) is unchanged: x0 ∈ [2,5]
+        // integer with x0 ≤ 1 is genuinely infeasible and no deadline is set, so
+        // `search_incomplete` stays false and the status is Infeasible.
+        let a = [1.0, 1.0];
+        let c = [1.0, 0.0];
+        let l = [2.0, 0.0];
+        let u = [5.0, INF];
+        let lp = LpView {
+            a: &a,
+            m: 1,
+            n: 2,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let r = solve_milp(&lp, &[1.0], 0.0, &opts(1, vec![0]));
+        assert_eq!(r.status, MilpStatus::Infeasible);
+    }
+
+    #[test]
+    fn c2_deferred_with_incumbent_reports_feasible_not_infeasible() {
+        // Orthogonal guard: a deferred node with an incumbent present is a
+        // time-limited feasible solve, not Infeasible (that branch never touched
+        // `has_inc==true`, but pin it so a future refactor can't regress it).
+        let status = decide_status(
+            /*unbounded=*/ false, /*has_inc=*/ true, /*tree_finished=*/ false,
+            /*search_incomplete=*/ true, /*gap_closed=*/ false,
+            /*gap_certified=*/ false, /*node_limit_hit=*/ false,
+        );
+        assert_eq!(status, MilpStatus::Feasible);
     }
 
     #[test]

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -91,7 +91,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-13 | P0 | solver.py bounds | serial convex path trusts under-converged NLP objective as node lower bound → false "optimal" | open |
 | C-1 | P0 | solver.py status | false "infeasible" from non-rigorous NLP fathoms (solve_model path) | open |
 | C-4 | P1 | mir.rs cuts | integer-MIR applied with fractional integer lower bound → invalid cut | open |
-| C-2 | P1 | milp_driver status | false "Infeasible" when deadline orphans deferred nodes | open |
+| C-2 | P1 | milp_driver status | false "Infeasible" when deadline orphans deferred nodes | fixed |
 | C-19 | P1 | relax_tan | pole-straddling interval classified as one branch → secant across a pole, invalid envelope | open |
 | C-5 | P1 | .nl parser | floor/ceil/round/trunc→identity, intdiv→div, all silent | open |
 | C-6 | P1 | modeling API | integer vars silently clamped to [0, 1e6] | open |
@@ -442,7 +442,43 @@ popped, so `open_count` would still miss it.)
 - `gap_certified` remains false in the deferred case.
 - Standing gates pass.
 
-**Log:** —
+**Status:** fixed.
+
+**Log:** 2026-07-03 — CONFIRMED statically at all three code sites: `export_batch`
+(`tree_manager.rs:233`) marks a dispatched node `Evaluated` and pops its heap
+entry; the deferral path (`milp_driver.rs`, `out.deferred`) drops the node's
+result without re-import, so it is stranded `Evaluated`; `open_count()`
+(`pool.rs`) counts only `Pending`, so the orphan is invisible and `is_finished()`
+reads `true`; the `!has_inc` status branch returned `Infeasible` unconditionally —
+a false certificate on a time-limit termination. (Confirmed the *real* damage is
+scoped to the Infeasible label, not a false Optimal: `gap_certified` is already
+correctly false on the deferral path.) A deferred-node time-out is inconclusive,
+not proven-infeasible; `python/discopt/infeasibility.py` treats `status ==
+"infeasible"` as a *proof*, so the false label propagates.
+
+FIX (minimal, per the card sketch): added `search_incomplete: bool` on the driver,
+set alongside the existing `gap_certified = false` whenever a node is deferred
+un-solved. The terminal-status decision was extracted into a pure `decide_status`
+helper so it is unit-testable in isolation; its no-incumbent branch now returns
+`Infeasible` **only** on `tree_finished && !search_incomplete` (a rigorous
+empty-tree proof), else a limit status (`NodeLimit`, mapped to `"node_limit"` at
+`lp_bindings.rs`, which the Python layer treats as inconclusive). Reused the
+existing `NodeLimit` variant rather than adding a `TimeLimit` arm — no new enum
+arm, no Python-mapping churn; the card permits either. The rigorous-infeasible
+path (`search_incomplete == false`) is untouched. `gap_certified` still goes false
+on defer.
+
+Regression tests (`crates/discopt-core/src/bnb/milp_driver.rs`, module `tests`,
+sub-second, direct calls into `decide_status`): `c2_deferred_node_orphaned_by_
+deadline_is_not_infeasible` (RED before fix: returned `Infeasible`; GREEN after:
+`NodeLimit` — verified by temporarily reverting the `&& !search_incomplete` gate),
+`c2_genuine_infeasible_still_reported_when_search_complete` (the rigorous path is
+not weakened), `c2_deferred_with_incumbent_reports_feasible_not_infeasible`
+(orthogonal guard), and end-to-end `c2_end_to_end_genuine_infeasible_unaffected`
+via `solve_milp`. Gates: `cargo test -p discopt-core` 390 passed / 0 failed;
+`cargo clippy -p discopt-core --lib` 0 warnings; `maturin develop --release` built;
+`pytest -m smoke` 193 passed / 1 skipped; adversarial suite 10 passed;
+`incorrect_count = 0`. PR: (fix-c2-milp-driver-deadline-infeasible).
 
 ---
 


### PR DESCRIPTION
## C-2 (P1) — MILP driver reports false "Infeasible" when the deadline orphans deferred nodes

Fixes correctness backlog item **C-2** (`docs/dev/correctness-issues.md`).

### Bug
The Rust MILP driver (`crates/discopt-core/src/bnb/milp_driver.rs`) returned `MilpStatus::Infeasible` on the `!has_inc && is_finished()` branch. But a node whose LP solve is deferred past the wall-clock deadline was already popped off the heap by `export_batch` (marked `Evaluated`) and its result is dropped without re-import — so it is stranded `Evaluated`, invisible to `open_count()` (which counts only `Pending`). `is_finished()` then reads `true` over a subtree that was **never searched**, and the driver stamped `Infeasible` on it.

That is a false certificate on a time-limit termination — the orphaned subtree may contain the optimum. It is not merely cosmetic: `python/discopt/infeasibility.py` treats `status == "infeasible"` as a *proof* of infeasibility, so the false label propagates into caller logic. (`gap_certified` was already correctly `false` on this path, so no false *Optimal* was ever possible — the damage is confined to the Infeasible label.)

### Fix (minimal, per the C-2 card sketch)
- Add a `search_incomplete: bool` on the driver, set alongside the existing `gap_certified = false` whenever a node is deferred un-solved.
- Extract the terminal-status decision into a pure `decide_status` helper (unit-testable in isolation), and gate its no-incumbent branch: `Infeasible` **only** on `tree_finished && !search_incomplete` (a rigorous empty-tree proof), else a limit status.
- Reused the existing `NodeLimit` variant (→ `"node_limit"`, which the Python layer treats as inconclusive) rather than adding a new `TimeLimit` enum arm — the card permits either, and this avoids churn across the exhaustive `MilpStatus` match sites.

The rigorous-infeasible path (`search_incomplete == false`) is untouched. No safety guard was weakened.

### Tests (new, `crates/discopt-core/src/bnb/milp_driver.rs`, sub-second, direct calls)
- `c2_deferred_node_orphaned_by_deadline_is_not_infeasible` — **RED before** the fix (returned `Infeasible`), **GREEN after** (`NodeLimit`); proven red by temporarily reverting the `&& !search_incomplete` gate.
- `c2_genuine_infeasible_still_reported_when_search_complete` — the rigorous path is not weakened.
- `c2_deferred_with_incumbent_reports_feasible_not_infeasible` — orthogonal guard.
- `c2_end_to_end_genuine_infeasible_unaffected` — full `solve_milp` infeasible check (no deferral).

### Gates run
- `cargo test -p discopt-core` — 390 passed, 0 failed
- `cargo clippy -p discopt-core --lib` — 0 warnings
- `maturin develop --release` — built
- `pytest -m smoke` — 193 passed, 1 skipped
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed
- `incorrect_count = 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
