### PR TITLE
fix(correctness): C-4 guard integer-MIR against fractional substitution bounds

### DIFF
--- a/crates/discopt-core/src/lp/mir.rs
+++ b/crates/discopt-core/src/lp/mir.rs
@@ -23,6 +23,13 @@
 //! - integer `j`: `γ_j = ⌊ã_j⌋ + max(0, f_j − f)/(1 − f)`;
 //! - continuous `j`: `γ_j = min(ã_j, 0)/(1 − f)`.
 //!
+//! The integer branch is valid only when the shifted `y_j` is integer-valued,
+//! which requires the *active substitution bound* to be integral (`l_j` for a
+//! lower shift, `u_j` for an upper complement). Presolve can leave an integer
+//! column with a fractional bound; there the integer branch would cut feasible
+//! points, so such a column falls back to the continuous coefficient (C-4) —
+//! the same premise the GMI separator guards in `super::gomory`.
+//!
 //! Single-row MIR is only as strong as the row's scaling, so each row is tried
 //! at several scalings `δ` (1, and `1/|a_j|` for each integer column) and — for
 //! both the all-lower substitution and the near-bound (per-column upper-vs-lower)
@@ -45,9 +52,15 @@ const FRAC_MIN: f64 = 1e-3;
 /// Absolute cap on a cut coefficient; larger ones are numerically unsafe.
 const MAX_ABS_COEFF: f64 = 1e7;
 
-/// Apply the MIR function to one (scaled, lower-shifted) row, returning the
-/// cut over the shifted variables `x'` as `(coeffs', rhs')` or `None`.
-fn mir_row(a: &[f64], b: f64, integrality: &[bool]) -> Option<(Vec<f64>, f64)> {
+/// Apply the MIR function to one (scaled, bound-shifted) row, returning the
+/// cut over the shifted variables `y` as `(coeffs', rhs')` or `None`.
+///
+/// The integer-MIR rounding is only valid when the shifted variable `y_j` is a
+/// nonnegative *integer*, which requires the substitution bound to be integral.
+/// `int_shift[j]` records that premise (integer column AND integral active
+/// bound); when it is false the column takes the always-valid continuous
+/// coefficient instead — mirroring the `use_integer` guard in `gomory.rs`.
+fn mir_row(a: &[f64], b: f64, int_shift: &[bool]) -> Option<(Vec<f64>, f64)> {
     let f = b - b.floor();
     if !(FRAC_MIN..=1.0 - FRAC_MIN).contains(&f) {
         return None;
@@ -55,7 +68,7 @@ fn mir_row(a: &[f64], b: f64, integrality: &[bool]) -> Option<(Vec<f64>, f64)> {
     let n = a.len();
     let mut g = vec![0.0_f64; n];
     for j in 0..n {
-        if integrality[j] {
+        if int_shift[j] {
             let fj = a[j] - a[j].floor();
             g[j] = a[j].floor() + (fj - f).max(0.0) / (1.0 - f);
         } else {
@@ -65,9 +78,12 @@ fn mir_row(a: &[f64], b: f64, integrality: &[bool]) -> Option<(Vec<f64>, f64)> {
     Some((g, b.floor()))
 }
 
-/// Tolerance within which an integer column's upper bound must sit to an
-/// integer for its complement `u_j − x_j` to remain integer-valued.
-const INT_UB_TOL: f64 = 1e-6;
+/// Tolerance within which the active substitution bound of an integer column
+/// must sit to an integer for the shifted variable to remain integer-valued:
+/// the lower bound `l_j` for `y_j = x_j − l_j`, or the upper bound `u_j` for the
+/// complement `y_j = u_j − x_j`. When the bound is fractional the integer-MIR
+/// rounding is unsound and the column falls back to the continuous coefficient.
+const INT_BOUND_TOL: f64 = 1e-6;
 
 /// Whether the LP point is within `frac` of the way up the `[l, u]` box, i.e.
 /// close enough to the upper bound that complementing there is worth trying.
@@ -90,9 +106,12 @@ fn near_upper(xj: f64, lj: f64, uj: f64) -> bool {
 /// `ã_j = −a_j` (complemented) or `a_j`, and `b̃ = b − Σ_{comp} a_j u_j −
 /// Σ_{not comp} a_j l_j`. MIR is valid for this nonnegative row, and mapping the
 /// cut `Σ γ_j y_j ≤ r` back through the (affine, invertible) substitution yields
-/// a valid inequality in `x`. Any integer-feasible `x` maps to a feasible `y`
-/// (integer when `x_j` and, for complemented integer columns, `u_j` are), so the
-/// cut removes no integer-feasible point of the row.
+/// a valid inequality in `x`. Any integer-feasible `x` maps to a feasible `y`,
+/// but `y_j` is *integer-valued* only when the active substitution bound is
+/// integral (`l_j` for a lower shift, `u_j` for a complement). The integer-MIR
+/// rounding is therefore requested (`int_shift[j]`) only for integer columns
+/// whose active bound is integral; a fractional bound falls back to the
+/// continuous coefficient so the cut removes no integer-feasible point (C-4).
 #[allow(clippy::too_many_arguments)]
 fn mir_under_substitution(
     row: &[f64],
@@ -107,21 +126,32 @@ fn mir_under_substitution(
     max_dynamism: f64,
 ) -> Option<(Vec<f64>, f64, f64)> {
     let n = row.len();
-    // Reformulated coefficients ã_j and the shift folded into the rhs.
+    // Reformulated coefficients ã_j and the shift folded into the rhs. Also record
+    // per column whether the integer-MIR branch is admissible: the shifted
+    // `y_j = x_j − l_j` (or `u_j − x_j` when complemented) stays integer-valued
+    // only when the *active* substitution bound is itself integral. Presolve
+    // (coefficient strengthening / implied bounds) can leave an integer column
+    // with a fractional bound; applying the integer rounding there yields a cut
+    // that can exclude a feasible integer point (C-4). Mirrors the `use_integer`
+    // guard in `gomory.rs`.
     let mut a_ref = vec![0.0_f64; n];
+    let mut int_shift = vec![false; n];
     let mut b_ref = b;
     for j in 0..n {
-        if comp[j] {
+        let pinned = if comp[j] {
             a_ref[j] = -row[j];
             b_ref -= row[j] * u[j];
+            u[j]
         } else {
             a_ref[j] = row[j];
             b_ref -= row[j] * l[j];
-        }
+            l[j]
+        };
+        int_shift[j] = integrality[j] && (pinned - pinned.round()).abs() <= INT_BOUND_TOL;
     }
     // Scale, then apply the MIR function in the nonnegative y-space.
     let a_scaled: Vec<f64> = a_ref.iter().map(|&aj| aj * d).collect();
-    let (g, r) = mir_row(&a_scaled, b_ref * d, integrality)?;
+    let (g, r) = mir_row(&a_scaled, b_ref * d, &int_shift)?;
 
     // Point value of y_j and violation of `Σ g_j y_j ≤ r` at x.
     let yj = |j: usize| if comp[j] { u[j] - x[j] } else { x[j] - l[j] };
@@ -215,7 +245,7 @@ pub fn separate_mir(
             if !near_upper(x[j], l[j], u[j]) {
                 continue;
             }
-            if integrality[j] && (u[j] - u[j].round()).abs() > INT_UB_TOL {
+            if integrality[j] && (u[j] - u[j].round()).abs() > INT_BOUND_TOL {
                 continue;
             }
             comp_near[j] = true;
@@ -458,6 +488,96 @@ mod tests {
             comp_viol >= base_viol - 1e-9,
             "complemented cut ({comp_viol}) weaker than all-lower ({base_viol})"
         );
+    }
+
+    /// C-4 property test: random rows with integer columns carrying *fractional*
+    /// lower and/or upper bounds (the state presolve coefficient-strengthening can
+    /// produce). Every emitted cut must exclude no integer-feasible point of the
+    /// row over the integer box. This locks the class: if the fractional-bound
+    /// guard is removed, the buggy integer rounding cuts a feasible integer point
+    /// on some draw and the assertion trips. Fails before the fix.
+    #[test]
+    fn c4_mir_validity_random_fractional_int_bounds() {
+        let mut state: u64 = 0xc4c4_dead_beef_0004;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((state >> 11) as f64) / ((1u64 << 53) as f64)
+        };
+        let mut n_cuts_checked = 0usize;
+        for _ in 0..1000 {
+            let n = 3;
+            let a: Vec<f64> = (0..n)
+                .map(|_| (next() * 8.0 - 4.0).round() + (next() - 0.5))
+                .collect();
+            // Fractional offsets in (0,1) added to integer endpoints, so the
+            // active substitution bounds are often non-integral for integer cols.
+            let frac_l: Vec<f64> = (0..n)
+                .map(|_| if next() > 0.4 { next() } else { 0.0 })
+                .collect();
+            let frac_u: Vec<f64> = (0..n)
+                .map(|_| if next() > 0.4 { next() } else { 0.0 })
+                .collect();
+            let lo_i: Vec<i64> = (0..n).map(|_| (next() * 4.0).floor() as i64 - 2).collect();
+            let hi_i: Vec<i64> = (0..n)
+                .map(|k| lo_i[k] + 1 + (next() * 4.0).floor() as i64)
+                .collect();
+            let l: Vec<f64> = (0..n).map(|k| lo_i[k] as f64 + frac_l[k]).collect();
+            let u: Vec<f64> = (0..n).map(|k| hi_i[k] as f64 + frac_u[k]).collect();
+            let integ: Vec<bool> = (0..n).map(|_| next() > 0.3).collect();
+            let b = next() * 14.0 - 6.0;
+            let x: Vec<f64> = (0..n)
+                .map(|k| {
+                    let t = if next() > 0.25 { 0.6 + 0.4 * next() } else { next() };
+                    l[k] + t * (u[k] - l[k]).max(0.0)
+                })
+                .collect();
+            // Integer-feasible box: integers within [l, u] → [ceil(l), floor(u)].
+            let lo_feas: Vec<i64> = (0..n).map(|k| l[k].ceil() as i64).collect();
+            let hi_feas: Vec<i64> = (0..n).map(|k| u[k].floor() as i64).collect();
+            if (0..n).any(|k| lo_feas[k] > hi_feas[k]) {
+                continue;
+            }
+            for cut in separate_mir(&a, &[b], &l, &u, &integ, &x, 1e-7, 1e9) {
+                assert_valid_le_box(&cut.coeffs, cut.rhs, &a, b, &lo_feas, &hi_feas);
+                n_cuts_checked += 1;
+            }
+        }
+        assert!(
+            n_cuts_checked > 20,
+            "expected many cuts to validate, got {n_cuts_checked}"
+        );
+    }
+
+    /// C-4 regression: an integer column with a *fractional* lower bound (as
+    /// presolve coefficient-strengthening / implied bounds can produce) must NOT
+    /// receive the integer-MIR rounding, because the bound substitution
+    /// `y_j = x_j − l_j` is non-integer there and the integer γ can cut a feasible
+    /// integer point. Mirrors `gomory.rs`'s
+    /// `gmi_cut_valid_when_integer_var_has_fractional_bound`.
+    ///
+    /// Row `−x0 − 2·x1 ≤ −2`, x0 integer in [0.5, 4] (fractional lower bound),
+    /// x1 integer in [0, 2]. Feasible integer points include (2, 0)
+    /// (`−2 − 0 = −2 ≤ −2`). At the LP point (0.8, 0.1) the *buggy* integer-MIR
+    /// cut is `−x0 − 2·x1 ≤ −2.5`, which excludes (2, 0) (`−2 > −2.5`). With the
+    /// fractional-lower-bound guard, column 0 falls back to the continuous
+    /// coefficient and every emitted cut stays valid for the whole integer box.
+    #[test]
+    fn c4_mir_valid_when_integer_var_has_fractional_lower_bound() {
+        let a = [-1.0, -2.0];
+        let b = -2.0;
+        let l = [0.5, 0.0]; // x0 has a fractional lower bound
+        let u = [4.0, 2.0];
+        let integ = [true, true];
+        let x = [0.8, 0.1]; // LP point that selects the (buggy) integer-MIR cut
+
+        let cuts = separate_mir(&a, &[b], &l, &u, &integ, &x, 1e-7, 1e9);
+        // Every emitted cut must exclude no integer-feasible point of the row over
+        // the integer box x0 ∈ {1,2,3,4} (integer ≥ 0.5), x1 ∈ {0,1,2}.
+        for cut in &cuts {
+            assert_valid_le_box(&cut.coeffs, cut.rhs, &a, b, &[1, 0], &[4, 2]);
+        }
     }
 
     #[test]

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -90,7 +90,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-17 | P0 | alphaBB bound | node bound uses sampled (non-rigorous) α + center-only PSD check → false "optimal", default path for small nonconvex; deterministic repro confirms (spike width ≤ 0.006 → α=0, bound 0.0, true min −3.5) | fixed |
 | C-13 | P0 | solver.py bounds | serial convex path trusts under-converged NLP objective as node lower bound → false "optimal" | fixed |
 | C-1 | P0 | solver.py status | false "infeasible" from non-rigorous NLP fathoms (solve_model path) | fixed |
-| C-4 | P1 | mir.rs cuts | integer-MIR applied with fractional integer lower bound → invalid cut | open |
+| C-4 | P1 | mir.rs cuts | integer-MIR applied with fractional integer lower bound → invalid cut | fixed |
 | C-2 | P1 | milp_driver status | false "Infeasible" when deadline orphans deferred nodes | fixed |
 | C-19 | P1 | relax_tan | pole-straddling interval classified as one branch → secant across a pole, invalid envelope | open |
 | C-5 | P1 | .nl parser | floor/ceil/round/trunc→identity, intdiv→div, all silent | open |
@@ -520,7 +520,49 @@ only when `(l_j − l_j.round()).abs() <= tol`, else use the continuous coeffici
   known-good instance (no silent disable).
 - Standing gates pass.
 
-**Log:** —
+**Status:** open → fixed.
+
+**Log:**
+- 2026-07-03 — **CONFIRMED then FIXED.** Confirmed with a decisive repro ported to
+  the MIR separator: row `−x0 − 2·x1 ≤ −2`, x0 integer in **[0.5, 4]** (fractional
+  lower bound, exactly the presolve-produced state the GMI guard defends against),
+  x1 integer in [0, 2]; at LP point (0.8, 0.1) the pre-fix separator emits
+  `−x0 − 2·x1 ≤ −2.5`, which **excludes the feasible integer point (2, 0)**
+  (`−2 > −2.5`) — a cut that removes a feasible integer point of the row. Test
+  fails on the pre-fix code with exactly that message.
+- **Root cause.** `mir_row` applied the integer-MIR rounding
+  `γ_j = ⌊ã_j⌋ + max(0, f_j − f)/(1 − f)` whenever `integrality[j]`, with no check
+  on the *active substitution bound*. The bound substitution `y_j = x_j − l_j`
+  (lower shift) / `y_j = u_j − x_j` (upper complement) makes `y_j` integer-valued
+  only when that bound is integral; a fractional bound breaks the premise and the
+  integer γ can cut feasible integer points.
+- **Fix (mirrors `gomory.rs:294-295`'s `use_integer` guard).** `mir_under_substitution`
+  now computes `int_shift[j] = integrality[j] && (pinned − pinned.round()).abs() ≤
+  INT_BOUND_TOL`, where `pinned` is the active bound (`u[j]` when complemented, else
+  `l[j]`), and passes `int_shift` (not raw `integrality`) into `mir_row`. When the
+  premise fails the column falls back to the always-valid continuous coefficient
+  `min(ã_j, 0)/(1 − f)`. Reused/renamed the existing `INT_UB_TOL` (1e-6) as
+  `INT_BOUND_TOL` since it is the same integral-bound premise the near-bound
+  complementation eligibility check already used for `u_j`. Module + soundness
+  docstrings updated. Fix is confined to `crates/discopt-core/src/lp/mir.rs`
+  (`mir_row` signature + `mir_under_substitution` + one constant) — no wider than
+  the card; no other file touched.
+- **Regression tests** (`lp::mir::tests`, both **fail-before / pass-after**, verified
+  by temporarily reverting the guard — the 6 pre-existing MIR tests still pass on the
+  buggy code, so the new tests isolate specifically the fractional-bound class):
+  `c4_mir_valid_when_integer_var_has_fractional_lower_bound` (the deterministic repro
+  above; enumerates the integer box and asserts no feasible point is cut) and
+  `c4_mir_validity_random_fractional_int_bounds` (1000 random rows with integer
+  columns carrying fractional lower AND upper bounds, mixed integer/continuous,
+  LP points near bounds so complementation fires; every emitted cut validated over
+  the integer box, ≥20 cuts exercised). The pre-existing
+  `mir_validity_random_complemented_rows` / `mir_cut_*` tests still pass (no silent
+  disable; the root cut path still produces cuts on integral-bound rows).
+- **Gates:** `cargo test -p discopt-core` 383 lib + 4 determinism + 1 doctest green,
+  no warnings; `cargo clippy -p discopt-core --lib` clean; extension rebuilt via
+  `maturin develop --release`; `pytest -m smoke` 339 passed / 1 skipped / 0 failed;
+  adversarial `test_adversarial_recent_fixes.py -m slow` 10 passed. `incorrect_count`
+  unchanged (0 failures; no correctness assertion weakened). PR: #TBD.
 
 ---
 


### PR DESCRIPTION
## C-4 (P1) — invalid MIR cut with a fractional integer substitution bound

`crates/discopt-core/src/lp/mir.rs`'s `mir_row` applied the integer-MIR rounding
`γ_j = ⌊ã_j⌋ + max(0, f_j − f)/(1 − f)` for **any** integer column, with no check on
the bound it was substituted against. The reformulation `y_j = x_j − l_j` (lower
shift) / `y_j = u_j − x_j` (upper complement) makes `y_j` integer-valued **only when
that active bound is integral**. Presolve (coefficient strengthening / implied bounds)
can leave an integer column with a fractional bound — the GMI separator is explicitly
hardened against exactly this (`gomory.rs:294-295`) — but MIR was not, so the integer
rounding could emit a cut that **excludes a feasible integer point of the row** → false
bound / false certificate. Both separators are fed the same `lp_data` in the root
cover-cut loop, so the state the GMI guard defends against reaches MIR unguarded.

### Confirm (fails before)
Row `−x0 − 2·x1 ≤ −2`, `x0` integer in **[0.5, 4]** (fractional lower bound), `x1`
integer in [0, 2]. Feasible integer points include `(2, 0)` (`−2 ≤ −2`). At LP point
`(0.8, 0.1)` the pre-fix separator emits `−x0 − 2·x1 ≤ −2.5`, which excludes `(2, 0)`
(`−2 > −2.5`). The new test fails on the pre-fix code with exactly:
`cut [-1.0, -2.0] <= -2.5 excludes feasible [2.0, 0.0]`.

### Fix (minimal — mirrors the GMI `use_integer` guard)
`mir_under_substitution` computes `int_shift[j] = integrality[j] &&
(pinned − pinned.round()).abs() ≤ INT_BOUND_TOL`, where `pinned` is the active bound
(`u[j]` when complemented, else `l[j]`), and passes `int_shift` — not raw
`integrality` — into `mir_row`. When the premise fails, the column falls back to the
always-valid continuous coefficient `min(ã_j, 0)/(1 − f)`. The existing `INT_UB_TOL`
(same integral-bound premise, already used for the complementation eligibility check)
was renamed `INT_BOUND_TOL` and reused. Change is confined to `mir.rs`.

### After
Same instance now emits `−2·x0 − 2·x1 ≤ −3` (continuous fallback on column 0): still
separates the LP point, cuts no feasible integer point.

### Regression tests (fail-before / pass-after, `lp::mir::tests`)
- `c4_mir_valid_when_integer_var_has_fractional_lower_bound` — the deterministic repro.
- `c4_mir_validity_random_fractional_int_bounds` — 1000 random rows with integer
  columns carrying fractional lower AND upper bounds, mixed integer/continuous, LP
  points near bounds so complementation fires; every emitted cut validated over the
  integer box (≥20 cuts exercised).

Verified fail-before by temporarily reverting the guard: both new tests fail, the 6
pre-existing MIR tests still pass — so the new tests isolate specifically the
fractional-bound class (no silent disable of the separator).

### Gates
- `cargo test -p discopt-core` — 383 lib + 4 determinism + 1 doctest green, no warnings
- `cargo clippy -p discopt-core --lib` — clean
- `maturin develop --release` — built
- `pytest -m smoke` — 339 passed, 1 skipped, 0 failed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed
- `incorrect_count` unchanged (0); no correctness assertion weakened

Updates the C-4 card in `docs/dev/correctness-issues.md` (open → fixed, Log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
