### PR TITLE
fix(correctness): C-5 .nl parser refuses floor/ceil/round/trunc/intdiv instead of silent misparse

### DIFF
--- a/crates/discopt-core/src/nl_parser.rs
+++ b/crates/discopt-core/src/nl_parser.rs
@@ -31,6 +31,17 @@ pub enum NlParseError {
     InvalidHeader(String),
     /// An expression opcode was not recognised.
     UnknownOpcode(i32),
+    /// A recognised opcode maps to an operator that has no sound representation
+    /// in the IR (e.g. floor/ceil/round/trunc/intdiv). Carries the operator name
+    /// and the numeric opcode. We refuse loudly rather than silently substituting
+    /// a different operator (identity / real division), which would solve a
+    /// different problem than the user posed. See correctness issue C-5.
+    UnsupportedOpcode {
+        /// Human-readable operator name (e.g. "floor").
+        name: &'static str,
+        /// The numeric .nl opcode (e.g. 13 for `o13`).
+        opcode: i32,
+    },
     /// The file uses the binary (`b`) .nl encoding, which is not supported.
     BinaryUnsupported,
     /// General parse error with a human-readable message.
@@ -43,6 +54,15 @@ impl fmt::Display for NlParseError {
             NlParseError::UnexpectedEof => write!(f, "unexpected end of .nl input"),
             NlParseError::InvalidHeader(msg) => write!(f, "invalid .nl header: {msg}"),
             NlParseError::UnknownOpcode(op) => write!(f, "unknown .nl opcode: o{op}"),
+            NlParseError::UnsupportedOpcode { name, opcode } => write!(
+                f,
+                "unsupported .nl operator '{name}' (opcode o{opcode}): this operator has no \
+                 sound representation in the solver IR. Parsing is refused rather than \
+                 silently substituting a different operator (e.g. identity or real division), \
+                 which would solve a different problem than the one posed. Reformulate the \
+                 model without '{name}', or file a feature request for real IR + relaxation \
+                 support for it."
+            ),
             NlParseError::BinaryUnsupported => write!(
                 f,
                 "binary .nl format not supported: file uses the binary ('b') encoding, \
@@ -575,40 +595,34 @@ fn parse_opcode(
             Ok(arena.add(ExprNode::SumOver { terms }))
         }
         // ── Binary operators (class 2) ──
-        55 => {
-            // o55: intdiv — approximate as Div
-            let left = parse_expr(reader, arena, var_nodes)?;
-            let right = parse_expr(reader, arena, var_nodes)?;
-            Ok(arena.add(ExprNode::BinaryOp {
-                op: BinOp::Div,
-                left,
-                right,
-            }))
-        }
-        57 => {
-            // o57: round (binary: round left to right decimal places)
-            // Approximate as identity (return left operand)
-            let left = parse_expr(reader, arena, var_nodes)?;
-            let _right = parse_expr(reader, arena, var_nodes)?;
-            Ok(left)
-        }
-        58 => {
-            // o58: trunc (binary: truncate left to right decimal places)
-            // Approximate as identity (return left operand)
-            let left = parse_expr(reader, arena, var_nodes)?;
-            let _right = parse_expr(reader, arena, var_nodes)?;
-            Ok(left)
-        }
-        13 => {
-            // o13: floor — not in IR, approximate as identity
-            let arg = parse_expr(reader, arena, var_nodes)?;
-            Ok(arg)
-        }
-        14 => {
-            // o14: ceil — not in IR, approximate as identity
-            let arg = parse_expr(reader, arena, var_nodes)?;
-            Ok(arg)
-        }
+        //
+        // C-5: floor/ceil/round/trunc/intdiv have NO sound representation in the IR.
+        // Previously each of these was silently rewritten to a *different* operator
+        // (identity for floor/ceil/round/trunc; real Div for intdiv), which makes the
+        // solver certify the optimum of a different problem than the user posed. We now
+        // refuse loudly (UnsupportedOpcode) so the solve errors instead of returning a
+        // false certificate. Real support would require IR + relaxation work (out of
+        // scope). The error aborts the parse, so we deliberately do NOT consume operands.
+        55 => Err(NlParseError::UnsupportedOpcode {
+            name: "intdiv",
+            opcode: 55,
+        }),
+        57 => Err(NlParseError::UnsupportedOpcode {
+            name: "round",
+            opcode: 57,
+        }),
+        58 => Err(NlParseError::UnsupportedOpcode {
+            name: "trunc",
+            opcode: 58,
+        }),
+        13 => Err(NlParseError::UnsupportedOpcode {
+            name: "floor",
+            opcode: 13,
+        }),
+        14 => Err(NlParseError::UnsupportedOpcode {
+            name: "ceil",
+            opcode: 14,
+        }),
         15 => {
             // o15: abs
             let arg = parse_expr(reader, arena, var_nodes)?;
@@ -2207,5 +2221,108 @@ mod tests {
         let model = parse_nl(&s).unwrap();
         let val = model.evaluate_objective(&[10.0, 3.0]);
         assert!((val - 7.0).abs() < 1e-12);
+    }
+
+    // ─── C-5: floor/ceil/round/trunc/intdiv must REFUSE, not silently misparse ───
+    //
+    // Before this fix each of these opcodes was silently rewritten to a different
+    // operator: floor/ceil/round/trunc → identity, intdiv → real division. That made
+    // the parser accept a *different* problem than the file encoded, and the solver
+    // then certified the wrong optimum. The sound behavior (no IR/relaxation support
+    // exists) is a loud refusal. These tests fail on the pre-fix code (parse_nl
+    // returns Ok with a wrong expression) and pass after (parse_nl returns the
+    // UnsupportedOpcode error naming the operator).
+
+    /// Build a single-objective .nl whose objective is `<unary-op>(v0)`.
+    fn nl_with_unary_obj(opcode_line: &str) -> String {
+        let mut s = String::new();
+        s.push_str("g3 1 1 0\n");
+        s.push_str(" 1 0 1 0 0\n");
+        s.push_str(" 0 1\n");
+        s.push_str(" 0 0\n");
+        s.push_str(" 0 1 0\n");
+        s.push_str(" 0 0 0 1\n");
+        s.push_str(" 0 0\n");
+        s.push_str(" 0 0\n");
+        s.push_str(" 0 0\n");
+        s.push_str(" 0 0 0 0 0\n");
+        s.push_str("O0 0\n");
+        s.push_str(opcode_line);
+        s.push_str("v0\n");
+        s.push_str("b\n");
+        s.push_str("3\n");
+        s
+    }
+
+    /// Build a single-objective .nl whose objective is `<binary-op>(v0, v1)`.
+    fn nl_with_binary_obj(opcode_line: &str) -> String {
+        let mut s = String::new();
+        s.push_str("g3 1 1 0\n");
+        s.push_str(" 2 0 1 0 0\n");
+        s.push_str(" 0 1\n");
+        s.push_str(" 0 0\n");
+        s.push_str(" 0 2 0\n");
+        s.push_str(" 0 0 0 1\n");
+        s.push_str(" 0 0\n");
+        s.push_str(" 0 0\n");
+        s.push_str(" 0 0\n");
+        s.push_str(" 0 0 0 0 0\n");
+        s.push_str("O0 0\n");
+        s.push_str(opcode_line);
+        s.push_str("v0\n");
+        s.push_str("v1\n");
+        s.push_str("b\n");
+        s.push_str("3\n");
+        s.push_str("3\n");
+        s
+    }
+
+    fn assert_unsupported(content: &str, expect_name: &str, expect_opcode: i32) {
+        let err = parse_nl(content)
+            .err()
+            .unwrap_or_else(|| panic!("expected UnsupportedOpcode for o{expect_opcode}, got Ok"));
+        match err {
+            NlParseError::UnsupportedOpcode { name, opcode } => {
+                assert_eq!(name, expect_name, "operator name");
+                assert_eq!(opcode, expect_opcode, "opcode number");
+            }
+            other => panic!("expected UnsupportedOpcode({expect_name}), got {other:?}"),
+        }
+        // The Display message must name the operator so the failure is actionable.
+        let msg = parse_nl(content).unwrap_err().to_string();
+        assert!(
+            msg.contains(expect_name) && msg.contains("unsupported"),
+            "message should name '{expect_name}' and say unsupported, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_floor_opcode_refused_not_identity() {
+        // o13 floor: pre-fix parsed to identity (floor(v0) == v0 == 1.7 at v0=1.7).
+        assert_unsupported(&nl_with_unary_obj("o13\n"), "floor", 13);
+    }
+
+    #[test]
+    fn test_ceil_opcode_refused_not_identity() {
+        // o14 ceil: pre-fix parsed to identity.
+        assert_unsupported(&nl_with_unary_obj("o14\n"), "ceil", 14);
+    }
+
+    #[test]
+    fn test_round_opcode_refused_not_identity() {
+        // o57 round (binary): pre-fix returned the left operand (identity).
+        assert_unsupported(&nl_with_binary_obj("o57\n"), "round", 57);
+    }
+
+    #[test]
+    fn test_trunc_opcode_refused_not_identity() {
+        // o58 trunc (binary): pre-fix returned the left operand (identity).
+        assert_unsupported(&nl_with_binary_obj("o58\n"), "trunc", 58);
+    }
+
+    #[test]
+    fn test_intdiv_opcode_refused_not_real_div() {
+        // o55 intdiv: pre-fix rewrote to real Div (7 intdiv 2 -> 3.5 instead of 3).
+        assert_unsupported(&nl_with_binary_obj("o55\n"), "intdiv", 55);
     }
 }

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -93,7 +93,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-4 | P1 | mir.rs cuts | integer-MIR applied with fractional integer lower bound → invalid cut | fixed |
 | C-2 | P1 | milp_driver status | false "Infeasible" when deadline orphans deferred nodes | fixed |
 | C-19 | P1 | relax_tan | pole-straddling interval classified as one branch → secant across a pole, invalid envelope | open |
-| C-5 | P1 | .nl parser | floor/ceil/round/trunc→identity, intdiv→div, all silent | open |
+| C-5 | P1 | .nl parser | floor/ceil/round/trunc→identity, intdiv→div, all silent | fixed |
 | C-6 | P1 | modeling API | integer vars silently clamped to [0, 1e6] | open |
 | C-18 | P1 | midpoint bound | `mccormick_bounds="midpoint"` returns u(mid), not a lower bound (opt-in mode) | open |
 | C-20 | P2 | fbbt_fp.rs | watch-list FBBT declares infeasibility with zero tolerance (opt-in engine) | fixed |
@@ -678,6 +678,8 @@ known optimum; standing gates pass.
 
 ## C-5 (P1) — `.nl` parser silently rewrites floor/ceil/round/trunc to identity and intdiv to real division
 
+**Status:** fixed (PR #447).
+
 **Area:** `crates/discopt-core/src/nl_parser.rs:578-611` (`parse_opcode`):
 `o13` floor → arg unchanged (`:602-606`); `o14` ceil → arg unchanged (`:607-611`);
 `o57` round → left operand (`:588-594`); `o58` trunc → left operand (`:595-601`);
@@ -707,7 +709,31 @@ would need IR + relaxation work — out of scope here; the fix is the refusal.)
 - The 61-file corpus still parses (confirms zero regression).
 - Standing gates pass.
 
-**Log:** —
+**Log:**
+- 2026-07-03 — **Confirmed** then **fixed**. Added five Rust unit tests
+  (`test_{floor,ceil,round,trunc,intdiv}_opcode_refused*` in `nl_parser.rs`) that
+  feed a hand-built text `.nl` whose objective is the bare opcode over `v0`/`v1`.
+  Fail-before: on the pre-fix silent-rewrite code all five return `Ok` with the wrong
+  expression (floor/ceil/round/trunc → identity, intdiv → real `Div`); proven red by
+  temporarily reverting only the five `parse_opcode` branches (5 failed, "got Ok").
+  Fix: added `NlParseError::UnsupportedOpcode { name, opcode }` with a Display message
+  that names the operator and states the parse is refused rather than substituting a
+  different operator; replaced the five silent branches (`o13`/`o14`/`o55`/`o57`/`o58`)
+  with that error (the error aborts the parse, so operands are deliberately not
+  consumed). No IR/relaxation support was added — the sound fix per CLAUDE.md §3 is the
+  loud refusal. Pass-after: all five tests green.
+- Verified end-to-end via the Python binding path (`discopt.modeling.core.from_nl` →
+  `_rust.parse_nl_file` → `parse_nl`): a floor `.nl` now raises
+  `ValueError: unsupported .nl operator 'floor' (opcode o13) …` instead of parsing
+  silently. (Note: the shared dev venv's `discopt.pth` resolves the package to a
+  different worktree; the Python gates were re-run with `PYTHONPATH` pinned to this
+  worktree so they exercise this fix's freshly-built `_rust.so`.)
+- Gates: `cargo test -p discopt-core` 386 lib + 4 integration + 1 doctest pass,
+  no warnings; `cargo clippy -p discopt-core --lib` clean; `maturin develop --release`
+  builds; `pytest -m smoke` 193 passed / 1 skipped; adversarial suite
+  (`test_adversarial_recent_fixes.py`) 10 passed; all 61 corpus files still parse.
+- Regression tests named above are committed and fast (sub-millisecond, direct
+  `parse_nl` calls; no `Model.solve()`).
 
 ---
 


### PR DESCRIPTION
## C-5 (P1) — `.nl` parser refuses floor/ceil/round/trunc/intdiv instead of silently misparsing

### Problem
`parse_opcode` in `crates/discopt-core/src/nl_parser.rs` silently rewrote five opcodes to a **different** operator, with no warning anywhere:

| opcode | operator | silent rewrite |
|---|---|---|
| o13 | floor | identity (`arg`) |
| o14 | ceil  | identity (`arg`) |
| o57 | round | identity (left operand) |
| o58 | trunc | identity (left operand) |
| o55 | intdiv | real `BinOp::Div` |

So `y = floor(x)` parsed as `y = x`, and `7 intdiv 2` became `3.5`. The solver then correctly solved the **wrong** problem and labelled the result optimal — a false certificate. P1: silent problem substitution (latent; the in-repo 61-file corpus uses none of these opcodes, so the phase gate could not catch it — it fires the moment a broader MINLPLib slice is ingested).

### Fix (loud refusal — CLAUDE.md §3)
These operators have no sound representation in the IR, so per §3 the correct fix is a **loud refusal**, not a cheap approximation. Added `NlParseError::UnsupportedOpcode { name, opcode }` with a Display message that names the operator and states the parse is refused rather than substituting a different operator; the five silent branches now return that error. The error aborts the parse (operands are deliberately not consumed). **No** IR/relaxation support was added — real floor/ceil/etc. support is out of scope and left as a follow-up.

### Confirm / fail-before / pass-after
Five fast Rust unit tests (`test_{floor,ceil,round,trunc,intdiv}_opcode_refused*`) feed a hand-built text `.nl` whose objective is the bare opcode over `v0`/`v1` and assert `parse_nl` returns `UnsupportedOpcode` naming the operator + a Display message containing that name.

- **Fail-before:** temporarily reverting only the five `parse_opcode` branches → all 5 tests fail with `expected UnsupportedOpcode …, got Ok` (the parser silently accepts the wrong problem).
- **Pass-after:** all 5 green.
- **End-to-end:** a floor `.nl` fed through `discopt.modeling.core.from_nl` → `_rust.parse_nl_file` now raises `ValueError: unsupported .nl operator 'floor' (opcode o13) …` instead of parsing silently.

### Gates (all green)
- `cargo test -p discopt-core` — 386 lib + 4 integration + 1 doctest pass, **no warnings**
- `cargo clippy -p discopt-core --lib` — clean
- `maturin develop --release` — builds
- `pytest -m smoke` — 193 passed, 1 skipped
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed
- All 61 files in `python/tests/data/minlplib_nl/` still parse (zero regression)

> Note: the shared dev venv's `discopt.pth` resolves the `discopt` package to a different worktree, so the Python gates were re-run with `PYTHONPATH` pinned to this worktree to exercise this fix's freshly-built `_rust.so`.

Closes the C-5 card in `docs/dev/correctness-issues.md` (updated `open → fixed` with Log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
