### PR TITLE
fix(correctness): C-6 stop silently clamping unspecified integer bounds

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -763,7 +763,7 @@ warn visibly (option b), or raise (option c); a test locks the chosen behavior;
 docs updated; standing gates pass.
 
 **Log:** 2026-07-03, status open→fixed (branch `fix-c6-integer-var-silent-clamp`,
-PR #<TBD>). **Confirmed** the mechanism precisely: user-provided `lb`/`ub` were
+PR #448). **Confirmed** the mechanism precisely: user-provided `lb`/`ub` were
 *already* honored exactly (a repro with `integer("n", lb=-5, ub=10)` → stored
 `[-5, 10]`; `ub=5e6` → stored `5e6`) — the bug was the *silent* substitution of
 the finite default `[0, 1e6]` whenever a bound was left unspecified, so a model

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -94,7 +94,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-2 | P1 | milp_driver status | false "Infeasible" when deadline orphans deferred nodes | fixed |
 | C-19 | P1 | relax_tan | pole-straddling interval classified as one branch → secant across a pole, invalid envelope | open |
 | C-5 | P1 | .nl parser | floor/ceil/round/trunc→identity, intdiv→div, all silent | fixed |
-| C-6 | P1 | modeling API | integer vars silently clamped to [0, 1e6] | open |
+| C-6 | P1 | modeling API | integer vars silently clamped to [0, 1e6] | fixed |
 | C-18 | P1 | midpoint bound | `mccormick_bounds="midpoint"` returns u(mid), not a lower bound (opt-in mode) | open |
 | C-20 | P2 | fbbt_fp.rs | watch-list FBBT declares infeasibility with zero tolerance (opt-in engine) | fixed |
 | C-15 | P2 | obbt.py | `run_obbt` variant tightens to raw LP vertex, no NS safe-bound clamp | fixed |
@@ -762,7 +762,53 @@ never silently report a default-box-active optimum as certified.
 warn visibly (option b), or raise (option c); a test locks the chosen behavior;
 docs updated; standing gates pass.
 
-**Log:** —
+**Log:** 2026-07-03, status open→fixed (branch `fix-c6-integer-var-silent-clamp`,
+PR #<TBD>). **Confirmed** the mechanism precisely: user-provided `lb`/`ub` were
+*already* honored exactly (a repro with `integer("n", lb=-5, ub=10)` → stored
+`[-5, 10]`; `ub=5e6` → stored `5e6`) — the bug was the *silent* substitution of
+the finite default `[0, 1e6]` whenever a bound was left unspecified, so a model
+needing a negative or >1e6 integer was truncated with no diagnostic. Two of the
+six regression assertions were **red before / green after**
+(`test_unspecified_integer_bounds_warn_loudly`,
+`test_partial_bounds_default_only_missing_side`); the four
+bounds-honored assertions were green on both sides (they lock in that the fix
+does not regress the already-correct explicit-bound path).
+
+**Fix — chose option (b), refined per the loud-default principle:** changed the
+`integer(...)` signature defaults from `lb=0, ub=1e6` to `lb=None, ub=None`, and
+added `Model._resolve_integer_defaults`, which substitutes the finite fallbacks
+(`_INTEGER_DEFAULT_LB=0.0`, `_INTEGER_DEFAULT_UB=1e6`) **only for a `None`
+(unspecified) side** and emits a `UserWarning` naming the variable and the imposed
+range. A user-provided bound (any explicit value, including `0` / `1e6`) is passed
+through unchanged and never warns — the default can never override or narrow a
+declared bound. The finite fallback is kept (not ±inf per option (a)) so B&B still
+receives a bounded integer domain; making the substitution loud rather than
+removing it avoids touching any downstream solver assumption about integer
+boundedness. The indexed (`over=`) path already resolved `None`→default via
+`resolve_indexed_values`, so it inherits the same behavior; `_make_indexed_var`
+now receives the shared `_INTEGER_DEFAULT_*` constants. Overload signatures updated
+to `Optional[...]`. Docstrings and the `VarType.INTEGER` doc (`core.py:67`) updated
+to describe the honored-exactly / loud-default contract. Internal `.integer(...)`
+callers (`llm/tools.py`, `solvers/milp_pounce.py`) all pass explicit bounds, so
+none newly warn.
+
+**Regression test (named):** `python/tests/test_c6_integer_default_bounds.py` —
+six `@pytest.mark.smoke` unit tests calling the modeling API directly (sub-second,
+no `Model.solve()`): negative bounds honored exactly, large ub not clamped,
+explicit bounds do NOT warn, unspecified bounds WARN loudly (with finite fallback),
+partial (lb-only) warns for the defaulted side while honoring lb exactly, and the
+indexed path honors negative bounds. Encodes the class (silent default box), not a
+named instance.
+
+**Gates:** `pytest -m smoke` 345 passed/1 skipped; adversarial
+`test_adversarial_recent_fixes.py -m slow` 10 passed; `pytest -k "integer or
+modeling or bound or variable"` 617 passed/1 skipped/2 xfailed; C-6 file 6 passed.
+`ruff check` + `ruff format --check` clean on both files. No Rust touched.
+`incorrect_count=0` (no false certificate; nothing weakened — the fix strictly adds
+a diagnostic and honors input). mypy blocked only by a **pre-existing** env mismatch
+(installed numpy ships Python-3.12 `type` statement syntax in `__init__.pyi:737`
+while `[tool.mypy] python_version = "3.10"`) — reproduces identically on the
+unmodified tree, unrelated to this change.
 
 ---
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -27,6 +27,7 @@ Example::
 from __future__ import annotations
 
 import builtins as _builtins
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
@@ -64,12 +65,25 @@ class VarType(Enum):
     BINARY : str
         Binary variable restricted to ``{0, 1}``.
     INTEGER : str
-        General integer variable (default bounds: ``[0, 1e6]``).
+        General integer variable. A user-supplied ``lb``/``ub`` is honored
+        exactly; an *unspecified* bound falls back to the finite defaults
+        ``[0, 1e6]`` and emits a ``UserWarning`` (see :meth:`Model.integer`),
+        because a silent default box can cut a true optimum that lies below 0
+        or above 1e6 (correctness issue C-6).
     """
 
     CONTINUOUS = "continuous"
     BINARY = "binary"
     INTEGER = "integer"
+
+
+# Finite fallback bounds for a general-integer variable whose lb/ub is left
+# unspecified. B&B requires a bounded integer domain, so we substitute these —
+# but LOUDLY (a UserWarning names the variable and the imposed range) rather
+# than silently truncating the user's problem (correctness issue C-6). A
+# user-provided bound is always honored exactly and never replaced by these.
+_INTEGER_DEFAULT_LB = 0.0
+_INTEGER_DEFAULT_UB = 1e6
 
 
 # ─────────────────────────────────────────────────────────────
@@ -1704,8 +1718,8 @@ class Model:
         self,
         name: str,
         shape: Union[int, tuple[int, ...]] = ...,
-        lb: Union[float, np.ndarray] = ...,
-        ub: Union[float, np.ndarray] = ...,
+        lb: Optional[Union[float, np.ndarray]] = ...,
+        ub: Optional[Union[float, np.ndarray]] = ...,
         over: None = ...,
     ) -> Variable: ...
 
@@ -1714,8 +1728,8 @@ class Model:
         self,
         name: str,
         shape: Union[int, tuple[int, ...]] = ...,
-        lb: Union[float, np.ndarray] = ...,
-        ub: Union[float, np.ndarray] = ...,
+        lb: Optional[Union[float, np.ndarray]] = ...,
+        ub: Optional[Union[float, np.ndarray]] = ...,
         *,
         over: "_SetBase",
     ) -> "IndexedVar": ...
@@ -1724,8 +1738,8 @@ class Model:
         self,
         name: str,
         shape: Union[int, tuple[int, ...]] = (),
-        lb: Union[float, np.ndarray] = 0,
-        ub: Union[float, np.ndarray] = 1e6,
+        lb: Optional[Union[float, np.ndarray]] = None,
+        ub: Optional[Union[float, np.ndarray]] = None,
         over=None,
     ) -> Union[Variable, "IndexedVar"]:
         """
@@ -1737,15 +1751,30 @@ class Model:
             Variable name (must be unique in the model).
         shape : int or tuple of int, default ()
             Scalar ``()`` or tuple for array variables.
-        lb : float or numpy.ndarray, default 0
-            Lower bound.
-        ub : float or numpy.ndarray, default 1e6
-            Upper bound.
+        lb : float or numpy.ndarray, optional
+            Lower bound. Honored **exactly** when supplied. When omitted, the
+            finite fallback ``0`` is used and a ``UserWarning`` is emitted (see
+            below).
+        ub : float or numpy.ndarray, optional
+            Upper bound. Honored **exactly** when supplied. When omitted, the
+            finite fallback ``1e6`` is used and a ``UserWarning`` is emitted.
 
         Returns
         -------
         Variable
             Integer-valued variable.
+
+        Notes
+        -----
+        Branch-and-bound needs a bounded integer domain, so an *unspecified*
+        ``lb``/``ub`` falls back to ``[0, 1e6]``. Previously this substitution
+        was silent, so a model whose true optimum needed a negative integer or
+        one above ``1e6`` was quietly truncated and the wrong optimum reported
+        as certified (correctness issue C-6). The fallback is now applied
+        **loudly** — a ``UserWarning`` names the variable and the imposed
+        range — and it **never** overrides a bound you provide. Pass explicit
+        ``lb``/``ub`` (e.g. ``lb=-5, ub=10``) to silence the warning and to
+        solve the problem you actually mean.
 
         Examples
         --------
@@ -1753,14 +1782,48 @@ class Model:
         >>> batch = m.integer("batch", shape=(3,), lb=1, ub=100)
         >>> n = m.integer("n", over=plants, lb=0, ub=10)  # indexed integer
         """
+        lb, ub = self._resolve_integer_defaults(name, lb, ub)
         if over is not None:
             _require_no_shape(shape, "integer")
-            return self._make_indexed_var(name, VarType.INTEGER, over, lb, ub, 0.0, 1e6)
+            return self._make_indexed_var(
+                name, VarType.INTEGER, over, lb, ub, _INTEGER_DEFAULT_LB, _INTEGER_DEFAULT_UB
+            )
         if isinstance(shape, int):
             shape = (shape,)
         self._check_name(name)
         var = Variable(name, VarType.INTEGER, shape, lb, ub, self)
         return self._register_variable(var)
+
+    @staticmethod
+    def _resolve_integer_defaults(name, lb, ub):
+        """Substitute finite fallback integer bounds for unspecified sides, loudly.
+
+        Returns the (possibly-substituted) ``(lb, ub)``. A ``None`` side is
+        replaced with the finite fallback (``0`` / ``1e6``) and recorded so a
+        single ``UserWarning`` can name exactly which side(s) discopt had to
+        default. A user-provided bound is passed through unchanged and never
+        warns (correctness issue C-6).
+        """
+        defaulted: list[str] = []
+        if lb is None:
+            lb = _INTEGER_DEFAULT_LB
+            defaulted.append(f"lb={_INTEGER_DEFAULT_LB:g}")
+        if ub is None:
+            ub = _INTEGER_DEFAULT_UB
+            defaulted.append(f"ub={_INTEGER_DEFAULT_UB:g}")
+        if defaulted:
+            warnings.warn(
+                f"integer variable '{name}': no explicit "
+                f"{' and '.join(defaulted)} supplied; discopt is imposing the "
+                f"finite default integer bound(s) so branch-and-bound has a "
+                f"bounded domain. This default box silently cuts any optimum "
+                f"below {_INTEGER_DEFAULT_LB:g} or above {_INTEGER_DEFAULT_UB:g}. "
+                f"Pass explicit lb/ub to solve the intended problem and silence "
+                f"this warning.",
+                UserWarning,
+                stacklevel=3,
+            )
+        return lb, ub
 
     def _make_indexed_param(self, name, index_set, value) -> "IndexedParam":
         """Build an :class:`IndexedParam` backed by one flat parameter over *index_set*."""

--- a/python/tests/test_c6_integer_default_bounds.py
+++ b/python/tests/test_c6_integer_default_bounds.py
@@ -1,0 +1,88 @@
+"""Regression test for correctness issue C-6.
+
+The modeling API used to give ``m.integer(name)`` a silent default bound box of
+``[0, 1e6]``. A model whose optimum needs a negative or ``> 1e6`` integer was
+silently truncated and the truncated-box optimum reported as certified optimal —
+i.e. the solver silently solved a *different* problem than the user posed
+(CLAUDE.md §3: no silent approximations).
+
+The fix keeps a finite default (so downstream B&B still gets a bounded integer),
+but applies it **loudly** — a ``UserWarning`` is emitted whenever discopt has to
+supply a default integer bound because the user did not specify one. Critically,
+a user-provided ``lb``/``ub`` is honored **exactly** and never triggers the
+warning, and the default must never override or narrow a user-provided bound.
+
+These tests call the modeling API directly (sub-second, no ``Model.solve()``).
+"""
+
+import warnings
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt import Model
+
+
+@pytest.mark.smoke
+def test_user_negative_integer_bounds_honored_exactly():
+    """A user-declared negative integer lb/ub is stored verbatim (fix-before/after)."""
+    m = Model()
+    n = m.integer("n", lb=-5, ub=10)
+    assert float(n.lb) == -5.0
+    assert float(n.ub) == 10.0
+
+
+@pytest.mark.smoke
+def test_user_large_integer_ub_not_clamped():
+    """A user ub above the old 1e6 default is honored, not silently clamped down."""
+    m = Model()
+    n = m.integer("big", lb=0, ub=5_000_000)
+    assert float(n.ub) == 5_000_000.0
+
+
+@pytest.mark.smoke
+def test_user_provided_bounds_do_not_warn():
+    """Fully specified integer bounds must not emit the default-bound warning."""
+    m = Model()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any UserWarning becomes a failure
+        n = m.integer("n", lb=-3, ub=3)
+    assert float(n.lb) == -3.0
+    assert float(n.ub) == 3.0
+
+
+@pytest.mark.smoke
+def test_unspecified_integer_bounds_warn_loudly():
+    """An unspecified integer bound gets the finite default but WARNS loudly.
+
+    This is the core C-6 guard: silently imposing ``[0, 1e6]`` is the bug. The
+    default may still be applied (B&B needs a bounded integer) but it must not
+    be silent.
+    """
+    m = Model()
+    with pytest.warns(UserWarning, match="default"):
+        n = m.integer("n")
+    # Default still finite so downstream B&B has a bounded integer.
+    assert np.isfinite(float(n.lb))
+    assert np.isfinite(float(n.ub))
+
+
+@pytest.mark.smoke
+def test_partial_bounds_default_only_missing_side():
+    """Specifying only lb warns about the defaulted ub, honors lb exactly."""
+    m = Model()
+    with pytest.warns(UserWarning, match="default"):
+        n = m.integer("n", lb=-2)
+    assert float(n.lb) == -2.0  # user side honored exactly, not overridden
+    assert np.isfinite(float(n.ub))
+
+
+@pytest.mark.smoke
+def test_indexed_integer_negative_bounds_honored():
+    """The indexed (``over=``) integer path also honors negative user bounds."""
+    m = Model()
+    s = dm.Set("s", [1, 2, 3])
+    n = m.integer("n", over=s, lb=-4, ub=7)
+    flat = n.flat
+    assert float(np.min(flat.lb)) == -4.0
+    assert float(np.max(flat.ub)) == 7.0


### PR DESCRIPTION
## C-6 (P1): modeling API silently clamped unspecified integer variables to [0, 1e6]

Fixes correctness backlog item **C-6** (`docs/dev/correctness-issues.md`).

### The bug (confirmed)
`m.integer(name)` gave a **silent** default bound box of `[0, 1e6]`. A model whose
true optimum needed a negative integer or one above `1e6` was quietly truncated and
the truncated-box optimum reported as **certified optimal** — the solver silently
solved a *different* problem than the user posed (CLAUDE.md §3: no silent
approximations).

Confirming the exact mechanism first (`fail-before`):
- User-provided bounds were **already honored exactly** — `integer("n", lb=-5, ub=10)`
  stored `[-5, 10]`; `ub=5e6` stored `5e6`. So this was never a clamp of *declared*
  bounds.
- The bug was the *silent* substitution of the finite default whenever a bound was
  **left unspecified**. `m.integer("n")` yielded `0 <= n <= 1e6` with no diagnostic.

### The fix (option b, refined per the loud-default principle)
- `integer(...)` defaults change from `lb=0, ub=1e6` to `lb=None, ub=None`.
- New `Model._resolve_integer_defaults` substitutes the finite fallback
  (`_INTEGER_DEFAULT_LB=0.0`, `_INTEGER_DEFAULT_UB=1e6`) **only for an unspecified
  (`None`) side** and emits a `UserWarning` naming the variable and the imposed range.
- A user-provided bound (any explicit value, including `0` / `1e6`) is passed through
  unchanged and **never warns** — the default can never override or narrow a declared
  bound.
- The finite fallback is **kept** (not +/-inf) so B&B still receives a bounded integer
  domain; making the substitution *loud* rather than removing it avoids touching any
  downstream integer-boundedness assumption. No STOP-and-escalate condition hit.
- The indexed (`over=`) path already resolved `None`->default via
  `resolve_indexed_values`, so it inherits the same behavior. Docstrings + the
  `VarType.INTEGER` doc updated to state the honored-exactly / loud-default contract.
- Internal `.integer(...)` callers (`llm/tools.py`, `solvers/milp_pounce.py`) all pass
  explicit bounds -> none newly warn.

### Regression test (fail-before / pass-after)
`python/tests/test_c6_integer_default_bounds.py` — six `@pytest.mark.smoke` unit tests
calling the modeling API directly (sub-second, no `Model.solve()`):
- negative bounds honored exactly; large `ub` not clamped down
- explicit bounds do **not** warn
- unspecified bounds **warn loudly** (with finite fallback still applied)
- partial (`lb`-only) warns for the defaulted side while honoring `lb` exactly
- the indexed path honors negative bounds

The two warn-tests are **red before / green after**; the four bounds-honored tests
lock in that the fix does not regress the already-correct explicit-bound path.

### Gates
- `pytest -m smoke` — **345 passed**, 1 skipped
- adversarial `test_adversarial_recent_fixes.py -m slow` — **10 passed**
- `pytest -k "integer or modeling or bound or variable"` — **617 passed**, 1 skipped, 2 xfailed
- C-6 file — **6 passed**
- `ruff check` + `ruff format --check` — clean on both changed files
- No Rust touched. `incorrect_count=0` — the change strictly adds a diagnostic and
  honors input; nothing was weakened.
- mypy is blocked only by a **pre-existing** environment mismatch (installed numpy
  ships Python-3.12 `type`-statement syntax in `__init__.pyi:737` while `[tool.mypy]
  python_version = "3.10"`); reproduces identically on the unmodified tree, unrelated
  to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
