### PR TITLE
fix(correctness): C-18 remove unsound mccormick_bounds="midpoint" mode

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -95,7 +95,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-19 | P1 | relax_tan | pole-straddling interval classified as one branch → secant across a pole, invalid envelope | open |
 | C-5 | P1 | .nl parser | floor/ceil/round/trunc→identity, intdiv→div, all silent | fixed |
 | C-6 | P1 | modeling API | integer vars silently clamped to [0, 1e6] | fixed |
-| C-18 | P1 | midpoint bound | `mccormick_bounds="midpoint"` returns u(mid), not a lower bound (opt-in mode) | open |
+| C-18 | P1 | midpoint bound | `mccormick_bounds="midpoint"` returns u(mid), not a lower bound (opt-in mode) | fixed |
 | C-20 | P2 | fbbt_fp.rs | watch-list FBBT declares infeasibility with zero tolerance (opt-in engine) | fixed |
 | C-15 | P2 | obbt.py | `run_obbt` variant tightens to raw LP vertex, no NS safe-bound clamp | fixed |
 | C-14 | P2 | milp_driver | LP-infeasible fathom trusts status alone; Farkas ray never verified | open |
@@ -939,7 +939,56 @@ must never return a non-bound.
 end-to-end model certifies the true optimum or refuses the mode; docs updated;
 standing gates pass.
 
-**Log:** —
+**Log:**
+- 2026-07-03 — **CONFIRMED then FIXED.** Confirmed the non-bound directly: for
+  objective `x²` on `[1,3]`, `evaluate_midpoint_bound(...)` returned **3.0**
+  (the compiled McCormick secant envelope's `cv` at the midpoint x=2), while the
+  true box minimum is **1.0** (at x=1). 3.0 > 1.0, so the returned value is NOT a
+  valid lower bound — it can fathom the node holding the true optimum → false
+  "optimal" for any user who selected the documented mode. (The card predicted 4.0
+  under the assumption `cv = x²`; the compiler's actual secant envelope gives 3.0,
+  but the class is identical: `u(mid) > min_box f`.) The value was consumed as a
+  bound at the two McCormick objective-bound seams (`solver.py` batch ~5136 and
+  serial ~5361) via `max()` into `result_lbs`/`convex_lb`/`nlp_lb`.
+- **Fix — option (c), remove the mode and refuse loudly.** The only sound cheap
+  way to turn the convex underestimator into a bound is to MINIMIZE it over the
+  box, which is exactly what `mccormick_bounds="nlp"` already does
+  (`solve_mccormick_relaxation_nlp`). A sound "midpoint" mode would just duplicate
+  "nlp", so the mode was removed rather than reimplemented:
+  - `solver.py` now validates `mccormick_bounds ∈ {auto, nlp, lp, none}` at the
+    top of `solve_model` (next to the `nlp_solver` check); `"midpoint"` raises a
+    `ValueError` naming C-18 and the worked counterexample, and any other unknown
+    value is also rejected (previously an unknown value silently fell through).
+  - `evaluate_midpoint_bound` / `evaluate_midpoint_bound_batch` (the non-bound
+    helpers) and the `_midpoint_batch_cache` were **deleted** from
+    `mccormick_nlp.py`; the two now-dead consumer branches in `solver.py` and the
+    `_mc_mode in ("midpoint","nlp")` guard were collapsed to `"nlp"`-only.
+  - Docstrings updated (`solve_model` `mccormick_bounds` param, `mccormick_nlp`
+    module header, `convex-relaxation-expert` skill doc).
+- **Regression tests** (`python/tests/test_mccormick_bounds.py::TestC18MidpointNotABound`,
+  fail-before/pass-after verified by stashing the fix — the rejection and
+  helpers-gone tests fail on pre-fix source): `test_midpoint_value_exceeds_true_box_minimum`
+  (reconstructs `u(mid)=3.0 > 1.0` for x² on [1,3] straight from the compiled
+  relaxation — the mechanism, fix-agnostic), `test_midpoint_mode_is_rejected_loudly`
+  (`solve(mccormick_bounds="midpoint")` raises `ValueError` matching "C-18"),
+  `test_unknown_mccormick_bounds_rejected` (typos rejected), and
+  `test_evaluate_midpoint_helpers_are_gone` (the unsound helpers are deleted, not
+  just unwired). The pre-existing `TestMidpointBounds` class (which exercised the
+  removed non-bound and even asserted an end-to-end "optimal") was removed; the
+  three integration tests that passed `"midpoint"` were repointed to the sound
+  `"nlp"`/`"none"` modes; `test_nlp_bound_finds_minimum_of_underestimator` now
+  derives its `cv(mid)` reference directly instead of via the deleted helper.
+- **Gates:** `test_mccormick_bounds.py` 15 passed; `pytest -m smoke` 193 passed /
+  1 skipped; adversarial `test_adversarial_recent_fixes.py -m slow` 10 passed; `ruff check` +
+  `ruff format --check` clean on all touched files; `pre-commit run mypy` passed.
+  No Rust touched (no `cargo test`). The broad `-k "midpoint or mccormick or bound
+  or nlp"` filter showed 39 failures that are **pre-existing and unrelated** —
+  `TestSchurPassthrough` (POUNCE Schur-block) fails identically with this fix
+  stashed, and the `test_relaxation_coverage`/`test_qp_pounce` cases pass in
+  isolation (test-ordering artifacts); `incorrect_count` unaffected (no correctness
+  assertion weakened — the fix strictly REMOVES a false-bound path). PR: <PR>.
+
+**Status:** open → fixed.
 
 ---
 

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -986,7 +986,7 @@ standing gates pass.
   `TestSchurPassthrough` (POUNCE Schur-block) fails identically with this fix
   stashed, and the `test_relaxation_coverage`/`test_qp_pounce` cases pass in
   isolation (test-ordering artifacts); `incorrect_count` unaffected (no correctness
-  assertion weakened — the fix strictly REMOVES a false-bound path). PR: <PR>.
+  assertion weakened — the fix strictly REMOVES a false-bound path). PR: #449.
 
 **Status:** open → fixed.
 

--- a/python/discopt/_jax/mccormick_nlp.py
+++ b/python/discopt/_jax/mccormick_nlp.py
@@ -7,11 +7,16 @@ convex relaxation is a valid lower bound on the original nonconvex problem over 
 node's domain. (The JAX IPM previously used here is retired; the relaxation
 *functions* remain JAX-built.)
 
-Two modes:
-  - **midpoint**: Evaluate the McCormick convex underestimator at the midpoint
-    of the node bounds. Nearly free but provides a weak bound.
+Mode:
   - **nlp**: Solve a convex NLP minimizing the McCormick underestimator subject
-    to McCormick-relaxed constraints. Tighter but costs one IPM solve per node.
+    to McCormick-relaxed constraints. Its optimum is a valid lower bound.
+
+The former **midpoint** mode — evaluate the underestimator at the box midpoint
+and return that value — was removed (correctness issue C-18): ``u(midpoint)`` is
+not a valid lower bound on ``min_box u`` (e.g. for ``x**2`` on ``[1, 3]`` it
+returns 3.0 while the true minimum is 1.0), so it could certify a wrong optimum.
+The only sound cheap bound is the minimum of the (convex) underestimator over the
+box, which is precisely what the ``nlp`` mode computes.
 """
 
 from __future__ import annotations
@@ -19,7 +24,6 @@ from __future__ import annotations
 import time
 from typing import Callable, Optional
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -28,69 +32,11 @@ import numpy as np
 # XLA cache instead of recompiling. Without these caches each call built
 # fresh closures over (lb, ub), forcing JAX to retrace+recompile per node
 # (the dominant cost on small instances).
-_midpoint_batch_cache: dict = {}
 _pounce_evaluator_cache: dict = {}
 
 
 def _deadline_expired(deadline: float | None) -> bool:
     return deadline is not None and time.perf_counter() >= deadline
-
-
-def evaluate_midpoint_bound(
-    obj_relax_fn: Callable,
-    node_lb: jnp.ndarray,
-    node_ub: jnp.ndarray,
-    negate: bool = False,
-) -> float:
-    """Evaluate McCormick objective relaxation at the node midpoint.
-
-    Args:
-        obj_relax_fn: Compiled relaxation fn(x_cv, x_cc, lb, ub) -> (cv, cc).
-        node_lb: Lower bounds for this B&B node, shape (n,).
-        node_ub: Upper bounds for this B&B node, shape (n,).
-        negate: If True, the original problem is maximization.
-            Return -cc as the lower bound on the negated objective.
-
-    Returns:
-        A valid lower bound (float), or -inf on failure.
-    """
-    try:
-        mid = 0.5 * (node_lb + node_ub)
-        cv, cc = obj_relax_fn(mid, mid, node_lb, node_ub)
-        if negate:
-            return -float(cc)
-        return float(cv)
-    except Exception:
-        return -np.inf
-
-
-def evaluate_midpoint_bound_batch(
-    obj_relax_fn: Callable,
-    lb_batch: jnp.ndarray,
-    ub_batch: jnp.ndarray,
-    negate: bool = False,
-) -> jnp.ndarray:
-    """Evaluate McCormick midpoint bounds for a batch of nodes.
-
-    Args:
-        obj_relax_fn: Compiled relaxation fn(x_cv, x_cc, lb, ub) -> (cv, cc).
-        lb_batch: Lower bounds, shape (N, n_vars).
-        ub_batch: Upper bounds, shape (N, n_vars).
-        negate: If True, maximization problem.
-
-    Returns:
-        Array of lower bounds, shape (N,).
-    """
-    key = id(obj_relax_fn)
-    vmapped_fn = _midpoint_batch_cache.get(key)
-    if vmapped_fn is None:
-        vmapped_fn = jax.jit(jax.vmap(obj_relax_fn))
-        _midpoint_batch_cache[key] = vmapped_fn
-    mid = 0.5 * (lb_batch + ub_batch)
-    cv_batch, cc_batch = vmapped_fn(mid, mid, lb_batch, ub_batch)
-    if negate:
-        return jnp.asarray(-cc_batch)
-    return jnp.asarray(cv_batch)
 
 
 def _filter_well_behaved_constraints(

--- a/python/discopt/skills/agents/convex-relaxation-expert.md
+++ b/python/discopt/skills/agents/convex-relaxation-expert.md
@@ -23,7 +23,7 @@ You are an expert on the convex-relaxation machinery in discopt. You help users 
 - `python/discopt/_jax/mccormick.py` — bilinear and univariate envelopes. Functions: `relax_bilinear`, `relax_add`, `relax_mul`, `relax_div`, `relax_pow`, `relax_exp`, `relax_log`, `relax_sqrt`, `relax_abs`, `relax_square`, `relax_neg`. Each returns `(cv, cc)` = (convex under, concave over) pair.
 - `python/discopt/_jax/alphabb.py` — `estimate_alpha(f, lb, ub, method=...)` with `"eigenvalue"` (exact, expensive) and `"gershgorin"` (cheap, loose) methods. `alphabb_underestimator`, `make_alphabb_relaxation`.
 - `python/discopt/_jax/envelopes.py` — higher-order and special-case envelopes.
-- `python/discopt/_jax/mccormick_nlp.py` — `evaluate_midpoint_bound` and the spatial B&B relaxation evaluator.
+- `python/discopt/_jax/mccormick_nlp.py` — `solve_mccormick_relaxation_nlp` (minimizes the convex underestimator over the box for a valid lower bound) and the spatial B&B relaxation evaluator. (The old `evaluate_midpoint_bound` "midpoint" mode was removed — correctness issue C-18: `u(mid)` is not a valid lower bound.)
 - `python/discopt/_jax/relaxation_compiler.py` — DAG-walking compiler for the convex relaxation. `compile_objective_relaxation`, `compile_constraint_relaxation`.
 - `python/discopt/_jax/cutting_planes.py` — RLT and OA cut generators.
 - `python/discopt/_jax/discretization.py`, `milp_relaxation.py` — piecewise McCormick machinery.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2515,9 +2515,11 @@ def solve_model(
         Requires at least one continuous variable; falls back to
         ``"none"`` for pure-integer nonconvex models (the ``"nlp"`` fallback
         would be unsound — issue #120),
-        ``"midpoint"`` evaluates the convex underestimator at midpoint
-        (heuristic, not a valid global lower bound — use with caution),
         ``"none"`` disables.
+        (The former ``"midpoint"`` mode was removed in correctness issue C-18:
+        it returned the underestimator's value at the box midpoint, which is not
+        a valid lower bound on the box minimum, so it could certify a wrong
+        optimum. Selecting it now raises ``ValueError``.)
     gdp_method : str, default "big-m"
         Reformulation method for disjunctive constraints:
         ``"big-m"`` (default) or ``"hull"`` (convex hull).
@@ -2602,6 +2604,35 @@ def solve_model(
             f"Unknown nlp_solver={nlp_solver!r}. Choose one of "
             f"{sorted(_valid_nlp_solvers)}. (The 'ripopt' backend was replaced "
             "by 'pounce', a pure-Rust port of Ipopt.)"
+        )
+
+    # C-18: the "midpoint" mode returned the McCormick underestimator's VALUE at
+    # the box midpoint, u(mid), and fed it into the node lower bound as if it were
+    # a bound. But u(mid) <= f(mid) does NOT imply u(mid) <= min_box f: for x**2
+    # on [1, 3] the mode returns 3.0 while the true box minimum is 1.0, so it can
+    # fathom the node holding the true optimum -> false "optimal". The only sound
+    # cheap way to turn the convex underestimator into a bound is to *minimize* it
+    # over the box, which is exactly what mccormick_bounds="nlp" already does.
+    # Rather than ship a non-bound that claims to be a bound, the mode is removed
+    # and rejected loudly. Use "lp" for a valid global spatial bound on nonconvex
+    # models, or "nlp" for the convex-model relaxation bound. See
+    # docs/dev/correctness-issues.md (C-18).
+    _valid_mccormick_bounds = {"auto", "nlp", "lp", "none"}
+    if mccormick_bounds not in _valid_mccormick_bounds:
+        if mccormick_bounds == "midpoint":
+            raise ValueError(
+                "mccormick_bounds='midpoint' has been removed (correctness issue "
+                "C-18): it evaluated the convex underestimator at the box midpoint "
+                "and returned that value as a lower bound, but u(midpoint) is NOT a "
+                "valid lower bound on the box minimum (e.g. for x**2 on [1, 3] it "
+                "returns 3.0 while the true minimum is 1.0), so it could certify a "
+                "wrong optimum. Use mccormick_bounds='lp' for a valid global "
+                "spatial bound on nonconvex models with continuous variables, or "
+                "'nlp' for the convex-model relaxation bound."
+            )
+        raise ValueError(
+            f"Unknown mccormick_bounds={mccormick_bounds!r}. Choose one of "
+            f"{sorted(_valid_mccormick_bounds)}."
         )
 
     # Root PSD cut-pool levers: resolve the explicit kwargs against the env-var
@@ -4253,7 +4284,7 @@ def solve_model(
         logger.debug("convex-objective node bound enabled (n_vars=%d)", n_vars)
 
     # --- McCormick relaxation bounds ---
-    _mc_obj_eval = None  # BatchRelaxationEvaluator for midpoint bounds
+    _mc_obj_eval = None  # BatchRelaxationEvaluator for the McCormick "nlp" bound
     _mc_obj_relax_fn = None  # raw relaxation fn for NLP bounds
     _mc_con_relax_fns: list[Callable] | None = None
     _mc_obj_relax_fn_np = None  # numpy-backed relaxation, when supported
@@ -4672,7 +4703,7 @@ def solve_model(
         )
         _mc_mode = "none"
 
-    if _mc_mode in ("midpoint", "nlp") and model._objective is not None:
+    if _mc_mode == "nlp" and model._objective is not None:
         from discopt._jax.batch_evaluator import BatchRelaxationEvaluator
         from discopt._jax.relaxation_compiler import (
             compile_constraint_relaxation,
@@ -5194,8 +5225,9 @@ def solve_model(
                     lb_jax = jnp.array(batch_lb, dtype=jnp.float64)
                     ub_jax = jnp.array(batch_ub, dtype=jnp.float64)
                     # Use NLP mode only periodically to avoid per-node IPM overhead.
-                    # Midpoint mode is NOT a valid lower bound (cv(mid) >= min f(x)
-                    # is not guaranteed), so skip McCormick on non-NLP iterations.
+                    # (The removed "midpoint" mode returned cv(mid), which is NOT a
+                    # valid lower bound on the box minimum — correctness issue C-18;
+                    # "nlp" is now the only McCormick objective-bound mode here.)
                     _use_mc_nlp = (
                         _mc_mode == "nlp"
                         and _mc_obj_relax_fn is not None
@@ -5216,20 +5248,6 @@ def solve_model(
                                 deadline=t_start + time_limit,
                                 obj_relax_fn_numpy=_mc_obj_relax_fn_np,
                                 con_relax_fns_numpy=_mc_con_relax_fns_np,
-                            )
-                        )
-                    elif _mc_mode != "nlp":
-                        from discopt._jax.mccormick_nlp import (
-                            evaluate_midpoint_bound_batch,
-                        )
-
-                        assert _mc_obj_relax_fn is not None
-                        mc_lbs = np.asarray(
-                            evaluate_midpoint_bound_batch(
-                                _mc_obj_relax_fn,
-                                lb_jax,
-                                ub_jax,
-                                negate=_mc_negate,
                             )
                         )
                     else:
@@ -5470,18 +5488,10 @@ def solve_model(
                                     obj_relax_fn_numpy=_mc_obj_relax_fn_np,
                                     con_relax_fns_numpy=_mc_con_relax_fns_np,
                                 )
-                            elif _mc_mode != "nlp":
-                                from discopt._jax.mccormick_nlp import (
-                                    evaluate_midpoint_bound,
-                                )
-
-                                mc_lb = evaluate_midpoint_bound(
-                                    _mc_obj_relax_fn,
-                                    lb_j,
-                                    ub_j,
-                                    negate=_mc_negate,
-                                )
                             else:
+                                # The removed "midpoint" mode returned cv(mid),
+                                # which is NOT a valid lower bound (C-18); "nlp" is
+                                # the only McCormick objective-bound mode.
                                 mc_lb = -np.inf
                             if np.isfinite(mc_lb):
                                 if _model_is_convex:

--- a/python/tests/test_mccormick_bounds.py
+++ b/python/tests/test_mccormick_bounds.py
@@ -32,14 +32,6 @@ def _simple_minimize_model():
     return m
 
 
-def _maximize_model():
-    """max -(x^2)  s.t. x in [0,4], x integer => optimal x=0, obj=0."""
-    m = Model()
-    x = m.integer("x", lb=0, ub=4)
-    m.maximize(-(x**2))
-    return m
-
-
 def _convex_quadratic_model():
     """min (x-1)^2 + (y-2)^2  s.t. x in [0,3], y in [0,3], x integer."""
     m = Model()
@@ -70,102 +62,68 @@ def _eq_constrained_model():
 
 
 # ===========================================================================
-# Option A: Midpoint bounds
+# C-18: the removed "midpoint" mode returned a non-bound
 # ===========================================================================
 
 
-class TestMidpointBounds:
-    """Tests for McCormick midpoint evaluation (Option A)."""
+class TestC18MidpointNotABound:
+    """Correctness issue C-18.
 
-    def test_cv_at_midpoint_underestimates_f(self):
-        """cv(midpoint) <= f(midpoint) by McCormick validity."""
-        from discopt._jax.mccormick_nlp import evaluate_midpoint_bound
+    ``mccormick_bounds="midpoint"`` returned the convex underestimator's VALUE
+    at the box midpoint, ``u(mid)``, and fed it into the node lower bound. But
+    ``u(mid) <= f(mid)`` does NOT imply ``u(mid) <= min_box f``: the value can sit
+    ABOVE the true box minimum, so it is not a valid lower bound and could fathom
+    the node holding the true optimum -> false "optimal". The mode is removed and
+    now rejected loudly.
+    """
+
+    def test_midpoint_value_exceeds_true_box_minimum(self):
+        """Documents the non-bound: for x**2 on [1,3], u(mid=2) > min_box x**2 = 1.
+
+        This is the mechanism that made the old ``evaluate_midpoint_bound`` return
+        an invalid lower bound. We reconstruct the exact value the removed helper
+        produced (cv at the midpoint) directly from the compiled relaxation and
+        show it exceeds the true box minimum.
+        """
         from discopt._jax.relaxation_compiler import compile_objective_relaxation
 
-        model = _simple_minimize_model()
-        relax_fn = compile_objective_relaxation(model)
+        m = Model()
+        x = m.continuous("x", lb=1.0, ub=3.0)
+        m.minimize(x * x)
 
-        lb = jnp.array([0.0, 0.0])
-        ub = jnp.array([4.0, 4.0])
-        mc_lb = evaluate_midpoint_bound(relax_fn, lb, ub, negate=False)
+        relax_fn = compile_objective_relaxation(m)
+        lb = jnp.array([1.0])
+        ub = jnp.array([3.0])
+        mid = 0.5 * (lb + ub)
+        cv, _cc = relax_fn(mid, mid, lb, ub)
+        u_mid = float(cv)  # exactly what evaluate_midpoint_bound(...) returned
 
-        # Midpoint = [2, 2], f(2,2) = 4 + 4 = 8
-        # cv(midpoint) should be <= f(midpoint)
-        assert mc_lb <= 8.0 + 1e-6
-        assert np.isfinite(mc_lb)
+        true_box_min = 1.0  # min of x**2 on [1, 3] at x=1
+        # The old "bound" is strictly ABOVE the true minimum -> NOT a valid bound.
+        assert u_mid > true_box_min + 1e-6
 
-    def test_narrower_bounds_tighter_cv(self):
-        """Narrower bounds should give tighter (higher) cv."""
-        from discopt._jax.mccormick_nlp import evaluate_midpoint_bound
-        from discopt._jax.relaxation_compiler import compile_objective_relaxation
-
-        model = _simple_minimize_model()
-        relax_fn = compile_objective_relaxation(model)
-
-        lb_wide = jnp.array([0.0, 0.0])
-        ub_wide = jnp.array([4.0, 4.0])
-        lb_narrow = jnp.array([1.0, 1.0])
-        ub_narrow = jnp.array([3.0, 3.0])
-
-        cv_wide = evaluate_midpoint_bound(relax_fn, lb_wide, ub_wide)
-        cv_narrow = evaluate_midpoint_bound(relax_fn, lb_narrow, ub_narrow)
-
-        # Both evaluate at their respective midpoints
-        # Wide: mid=[2,2], Narrow: mid=[2,2] (same midpoint!)
-        # But McCormick relaxation quality improves with narrower bounds
-        # cv_narrow should be >= cv_wide (tighter underestimator)
-        assert cv_narrow >= cv_wide - 1e-8
-
-    def test_batch_evaluation(self):
-        """Batch midpoint evaluation matches serial."""
-        from discopt._jax.mccormick_nlp import (
-            evaluate_midpoint_bound,
-            evaluate_midpoint_bound_batch,
-        )
-        from discopt._jax.relaxation_compiler import compile_objective_relaxation
+    def test_midpoint_mode_is_rejected_loudly(self):
+        """Selecting the removed mode raises ValueError (never returns a non-bound)."""
+        import pytest
 
         model = _simple_minimize_model()
-        relax_fn = compile_objective_relaxation(model)
+        with pytest.raises(ValueError, match="C-18"):
+            model.solve(mccormick_bounds="midpoint", max_nodes=1000)
 
-        lb_batch = jnp.array([[0.0, 0.0], [0.0, 0.0], [1.0, 1.0]])
-        ub_batch = jnp.array([[4.0, 4.0], [2.0, 2.0], [3.0, 3.0]])
+    def test_unknown_mccormick_bounds_rejected(self):
+        """A typo/unknown value is rejected rather than silently ignored."""
+        import pytest
 
-        batch_result = np.asarray(evaluate_midpoint_bound_batch(relax_fn, lb_batch, ub_batch))
-
-        for i in range(3):
-            serial = evaluate_midpoint_bound(relax_fn, lb_batch[i], ub_batch[i])
-            np.testing.assert_allclose(batch_result[i], serial, atol=1e-10)
-
-    def test_maximize_sign_handling(self):
-        """For maximize, lower bound uses -cc."""
-        from discopt._jax.mccormick_nlp import evaluate_midpoint_bound
-        from discopt._jax.relaxation_compiler import compile_objective_relaxation
-
-        model = _maximize_model()
-        relax_fn = compile_objective_relaxation(model)
-
-        lb = jnp.array([0.0])
-        ub = jnp.array([4.0])
-
-        # For max -(x^2), the objective expression is -(x^2).
-        # negate=True means we want bound for minimizing the negated obj.
-        mc_lb = evaluate_midpoint_bound(relax_fn, lb, ub, negate=True)
-        assert np.isfinite(mc_lb)
-
-        # Without negate, we get cv of -(x^2) at midpoint
-        mc_cv = evaluate_midpoint_bound(relax_fn, lb, ub, negate=False)
-        # cv of -(x^2) at midpoint=2 should be <= -(2^2) = -4
-        assert mc_cv <= -4.0 + 1e-6
-
-    def test_end_to_end_minlp_midpoint(self):
-        """Full solve with mccormick_bounds='midpoint'."""
         model = _simple_minimize_model()
-        result = model.solve(mccormick_bounds="midpoint", max_nodes=1000)
-        assert result.status in ("optimal", "feasible")
-        if result.status == "optimal":
-            # x integer in [0,4], y continuous [0,4]: optimal at x=0, y=0
-            assert result.objective is not None
-            assert result.objective <= 0.0 + 1e-4
+        with pytest.raises(ValueError, match="Unknown mccormick_bounds"):
+            model.solve(mccormick_bounds="bogus", max_nodes=1000)
+
+    def test_evaluate_midpoint_helpers_are_gone(self):
+        """The unsound helpers were deleted, not just left unwired."""
+        import discopt._jax.mccormick_nlp as mn
+
+        assert not hasattr(mn, "evaluate_midpoint_bound")
+        assert not hasattr(mn, "evaluate_midpoint_bound_batch")
 
 
 # ===========================================================================
@@ -194,11 +152,14 @@ class TestNLPBounds:
         assert nlp_lb <= 0.0 + 1e-4
 
     def test_nlp_bound_finds_minimum_of_underestimator(self):
-        """NLP solving finds the global min of the convex underestimator."""
-        from discopt._jax.mccormick_nlp import (
-            evaluate_midpoint_bound,
-            solve_mccormick_relaxation_nlp,
-        )
+        """NLP solving finds the global min of the convex underestimator.
+
+        The NLP mode minimizes cv over the box, so its bound must be <= the value
+        of cv at any interior point (here the box midpoint). This is exactly why
+        it is sound where the removed "midpoint" mode was not: it returns
+        ``min_box cv`` rather than ``cv(mid)``.
+        """
+        from discopt._jax.mccormick_nlp import solve_mccormick_relaxation_nlp
         from discopt._jax.relaxation_compiler import compile_objective_relaxation
 
         model = _simple_minimize_model()
@@ -207,11 +168,15 @@ class TestNLPBounds:
         lb = jnp.array([0.0, 0.0])
         ub = jnp.array([4.0, 4.0])
 
-        mp_lb = evaluate_midpoint_bound(relax_fn, lb, ub)
+        # cv evaluated at the box midpoint (what the removed midpoint mode used).
+        mid = 0.5 * (lb + ub)
+        cv_mid, _cc = relax_fn(mid, mid, lb, ub)
+        cv_mid = float(cv_mid)
+
         nlp_lb = solve_mccormick_relaxation_nlp(relax_fn, None, None, lb, ub)
 
         # NLP minimizes cv over the domain, should give <= cv(midpoint)
-        assert nlp_lb <= mp_lb + 1e-6
+        assert nlp_lb <= cv_mid + 1e-6
 
     def test_handles_ge_constraint(self):
         """NLP relaxation with >= constraints (binding)."""
@@ -331,11 +296,11 @@ class TestIntegration:
     def test_coexists_with_alphabb(self):
         """McCormick bounds + alphaBB both active, takes max."""
         model = _simple_nonconvex_model()
-        result = model.solve(mccormick_bounds="midpoint", max_nodes=500)
+        result = model.solve(mccormick_bounds="nlp", max_nodes=500)
         assert result.status in ("optimal", "feasible", "node_limit")
 
     def test_auto_activates_for_dag_models(self):
-        """'auto' mode should activate midpoint for DAG models."""
+        """'auto' mode should activate a valid bound path for DAG models."""
         model = _simple_minimize_model()
         result = model.solve(mccormick_bounds="auto", max_nodes=100)
         assert result.status in ("optimal", "feasible", "node_limit")
@@ -349,7 +314,7 @@ class TestIntegration:
     def test_global_optimality_with_bounds(self):
         """McCormick bounds should help prove global optimality."""
         model = _convex_quadratic_model()
-        result = model.solve(mccormick_bounds="midpoint", max_nodes=500)
+        result = model.solve(mccormick_bounds="nlp", max_nodes=500)
         assert result.status in ("optimal", "feasible")
         if result.status == "optimal":
             # (x-1)^2 + (y-2)^2, x integer: optimal x=1, y=2, obj=0


### PR DESCRIPTION
## C-18 (P1) — `mccormick_bounds="midpoint"` returned a non-bound

Correctness backlog item **C-18** (`docs/dev/correctness-issues.md`). The opt-in
`mccormick_bounds="midpoint"` mode evaluated the McCormick convex underestimator
at the box midpoint and returned that value, `u(mid)`, as a node lower bound. But
`u(mid) ≤ f(mid)` does **not** imply `u(mid) ≤ min_box f` — the value can sit
**above** the true box minimum, so it is not a valid lower bound and could fathom
the node holding the true optimum → **false "optimal"** for any user who selected
the documented mode.

### Repro (confirmed)

For objective `x²` on `[1,3]`, the compiled relaxation's `cv` at the midpoint
(`x=2`) is **3.0**, while the true box minimum is **1.0** (at `x=1`):

```
evaluate_midpoint_bound(...) -> 3.0   # returned as a "lower bound"
min_box x²                    = 1.0   # true box minimum
3.0 > 1.0  → NOT a valid bound
```

(The card predicted 4.0 assuming `cv = x²`; the compiler emits the secant envelope
so `cv(2)=3.0`, but the class is identical: `u(mid) > min_box f`.)

### Fix — remove the mode, refuse loudly (option c)

The only sound cheap way to turn the convex underestimator into a bound is to
**minimize** it over the box, which is exactly what `mccormick_bounds="nlp"`
already does (`solve_mccormick_relaxation_nlp`). A sound "midpoint" mode would just
duplicate "nlp", so the mode is removed rather than reimplemented — per the
backlog's minimum-acceptable option (c): *a documented bound mode must never
return a non-bound.*

- `solve_model` now validates `mccormick_bounds ∈ {auto, nlp, lp, none}` next to
  the existing `nlp_solver` check. `"midpoint"` raises a `ValueError` naming C-18
  and the `x²`/`[1,3]` counterexample; any other unknown value is also rejected
  (previously an unknown value silently fell through to near-`"none"` behavior).
- Deleted `evaluate_midpoint_bound` / `evaluate_midpoint_bound_batch` and the
  `_midpoint_batch_cache` from `mccormick_nlp.py`; collapsed the two now-dead
  consumer branches and the `("midpoint","nlp")` guard in `solver.py` to
  `"nlp"`-only.
- Updated docstrings (`solve_model` param, `mccormick_nlp` module header,
  `convex-relaxation-expert` skill doc).

### Regression tests (`TestC18MidpointNotABound`, fail-before/pass-after verified)

- `test_midpoint_value_exceeds_true_box_minimum` — reconstructs `u(mid)=3.0 > 1.0`
  straight from the compiled relaxation (the mechanism; fix-agnostic).
- `test_midpoint_mode_is_rejected_loudly` — `solve(mccormick_bounds="midpoint")`
  raises `ValueError` matching "C-18". **(fails before the fix)**
- `test_unknown_mccormick_bounds_rejected` — typos rejected. **(fails before)**
- `test_evaluate_midpoint_helpers_are_gone` — the unsound helpers are deleted, not
  just unwired. **(fails before)**

Removed the pre-existing `TestMidpointBounds` class (it exercised the removed
non-bound and even asserted an end-to-end "optimal"); the three integration tests
that passed `"midpoint"` were repointed to the sound `"nlp"`/`"none"` modes;
`test_nlp_bound_finds_minimum_of_underestimator` now derives its `cv(mid)`
reference directly instead of via the deleted helper.

### Gates

- `test_mccormick_bounds.py` — **15 passed**
- `pytest -m smoke` — **193 passed / 1 skipped**
- adversarial `test_adversarial_recent_fixes.py -m slow` — **10 passed**
- `ruff check` + `ruff format --check` clean; `pre-commit run mypy` passed
- No Rust touched (no `cargo test`)

The broad `-k "midpoint or mccormick or bound or nlp"` filter showed 39 failures
that are **pre-existing and unrelated**: `TestSchurPassthrough` (POUNCE Schur-block)
fails identically with this fix stashed, and the `test_relaxation_coverage` /
`test_qp_pounce` cases pass in isolation (test-ordering artifacts). The fix
strictly **removes** a false-bound path, so `incorrect_count` is unaffected and no
correctness assertion was weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
