### PR TITLE
fix(correctness): C-19 + C-23 — sound McCormick envelopes for tan poles and nonlinear-denominator division

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -645,7 +645,7 @@ via `solve_milp`. Gates: `cargo test -p discopt-core` 390 passed / 0 failed;
 
 ---
 
-## C-19 (P1) — `relax_tan` classifies pole-straddling intervals as a single convex/concave branch → secant across a pole
+## C-19 (P1, FIXED) — `relax_tan` classifies pole-straddling intervals as a single convex/concave branch → secant across a pole
 
 **Area:** `python/discopt/_jax/mccormick.py:393-436`. Centers on the nearest
 inflection `center = round(mid/π)·π` and classifies via `lb ≥ center` /
@@ -672,7 +672,27 @@ not), `cv ≤ tan ≤ cc` holds wherever tan is defined and finite envelopes are
 returned; a tan-containing MINLP with pole-straddling initial bounds solves to the
 known optimum; standing gates pass.
 
-**Log:** —
+**Log:** 2026-07-03 — CONFIRMED then FIXED (status open→fixed). Direct-call repro
+on the pre-fix code: `relax_tan` on `[1.4,1.8]` (straddles π/2≈1.5708) draws a
+secant through `tan(1.4)=+5.8` and `tan(1.8)=−4.3` across the pole → `max(cv−f) ≈
++2.7e5` on the branch (invalid underestimator); the mirror `[−1.8,−1.4]` gives
+`max(f−cc) ≈ +2.7e5`. **Fix:** detect the branch spanning the box (nearest
+inflection `center=k·π`, bounding poles `center±π/2`) and abstain — return the
+no-information envelope `(−inf,+inf)` — whenever an endpoint reaches or crosses a
+pole (`pole_free = (lb > center−π/2) & (ub < center+π/2)`). Pole-free boxes keep
+the tight branch envelope. Also hardened `_secant` so the degenerate `lb==ub`
+branch never evaluates `0/0` (was only guarded *after* the division). Applied to
+BOTH backends — the JAX `_jax/mccormick.py` (in scope) and the ported
+`_numpy/mccormick.py` (the NM-4 twin noted in the 2026-07-03 reconciliation) — so
+the class is closed on both. **After:** every pole-straddling box abstains (no
+finite crossing envelope); all pole-free branches (incl. k=±1 at `[3.3,4.6]`,
+`[−4.6,−3.3]`) remain sound to 1e-7. **Regression test:**
+`python/tests/test_tan_pole_envelope_c19.py` (`@pytest.mark.smoke`, sub-second,
+both backends): literal `[1.4,1.8]` repro, pole-straddling never-crosses,
+pole-free stays-tight, and a random-sub-box property test over `[−5,5]` — 14 red
+before, all green after. **Gates:** targeted `-k "tan or div or envelope or relax
+or mccormick or convex"` 1366 passed / 0 failed; ruff + format clean; mypy clean
+on the changed modules. PR: (pending).
 
 ---
 
@@ -1248,7 +1268,7 @@ product range and is never NaN; standing gates pass.
 
 ---
 
-## C-23 (P1) — `relax_div` produces an invalid convex underestimator for nonlinear denominators (ESCALATED from P3)
+## C-23 (P1, FIXED) — `relax_div` produces an invalid convex underestimator for nonlinear denominators (ESCALATED from P3)
 
 **Area:** `python/discopt/_jax/mccormick.py:119-135` (`relax_div`), wired at
 `relaxation_compiler.py:719-726`. Also `:102-116` (`_relax_reciprocal` sets
@@ -1302,6 +1322,37 @@ unchanged; standing gates pass.
 variable/affine-only test coverage masked the nonlinear-denominator defect; the
 diagonal-vs-composite blind spot is the same one that hid C-32/NM-1
 (solver-core review, `docs/dev/solver-core-review.md` §1).
+
+2026-07-03 — FIXED (status confirmed→fixed). **Confirmed** via the full compiler
+(the `relaxation_harness`): pre-fix worst `cv−f` = **+0.80** on `1/(x*y)`, **+1.15**
+on `1/(x*x)`, **+0.71** on `x/(y*z)`, plus `1/sqrt(x*y)`, `(x+1)/(x*y)`,
+`1/(x*y+1)` all `cv>f`; controls `1/x`, `x/y`, `1/(x+y)` sound. **Fix chosen:** the
+tight bilinear composition `x·(1/y)` is retained **only where the denominator
+relaxation collapses to a point** (`|y_ub−y_lb|<1e-12` — constant / variable /
+affine denominator, where `1/y` is exact and the composition is sound & tight).
+For a **non-degenerate (nonlinear) denominator interval** the midpoint-reciprocal
+crosses the function, so we abstain to the **sound interval enclosure**
+`[x_lb,x_ub] · [1/y_ub, 1/y_lb]` (a constant `[cv,cc]` that brackets `x/y` at every
+point, both denominator signs) — the "sound construction / fall back to interval
+bounds" the card sanctions. This is looser than a perfect composite envelope but
+never emits `cv>f`; spatial branching shrinks the denominator interval → the
+enclosure tightens. (The by-hand bivariate-McCormick composite was prototyped and
+**rejected** — brute-force truth sampling showed it still crossed by up to +11, so
+it was not shipped; the enclosure is provably sound to machine-epsilon.) Applied to
+BOTH `_jax/mccormick.py` (in scope) and the ported `_numpy/mccormick.py`. Also
+hardened `_secant` against `0/0` on the degenerate branch. **After:** every listed
+nonlinear-denominator case is sound to ≤3.6e-15 (`cv≤f≤cc`); the `1/(x*y)` repro
+flips from `cv=1.334>1.0` to sound; controls stay exactly tight; point-denominator
+`3/2` stays `cv=cc=1.5`. **Regression test:**
+`python/tests/test_div_nonlinear_denominator_c23.py` (`@pytest.mark.smoke`,
+sub-second, both backends): literal repro, non-degenerate never-crosses (pos & neg
+denom), point-denominator tightness, random-sub-box property test, plus a
+full-compiler containment layer over `1/(x*y)`, `x/(y*z)`, `1/(x*x)`,
+`1/sqrt(x*y)`, `(x+1)/(x*y)`, `1/(x*y+1)` + the `1/x`/`x/y`/`1/(x+y)` controls —
+the reciprocal-/division-of-nonlinear-inner case the harness previously omitted.
+36 assertions red before, all green after. **Gates:** targeted `-k` suite 1366
+passed / 0 failed; ruff + format clean; mypy clean on the changed modules. PR:
+(pending).
 
 ---
 

--- a/python/discopt/_jax/mccormick.py
+++ b/python/discopt/_jax/mccormick.py
@@ -27,10 +27,15 @@ def _secant(f, x, lb, ub):
     """
     f_lb = f(lb)
     f_ub = f(ub)
-    slope = (f_ub - f_lb) / (ub - lb)
+    width = ub - lb
+    degenerate = jnp.abs(width) < 1e-15
+    # Guard the divisor so the degenerate branch never evaluates 0/0 (which is a
+    # ZeroDivisionError on Python-float scalars and a NaN on arrays).
+    safe_width = jnp.where(degenerate, 1.0, width)
+    slope = (f_ub - f_lb) / safe_width
     line = f_lb + slope * (x - lb)
     # Degenerate case: lb ≈ ub -> just return f(x)
-    return jnp.where(jnp.abs(ub - lb) < 1e-15, f(x), line)
+    return jnp.where(degenerate, f(x), line)
 
 
 # ---------------------------------------------------------------------------
@@ -117,22 +122,55 @@ def _relax_reciprocal(y, y_lb, y_ub):
 
 
 def relax_div(x, y, x_lb, x_ub, y_lb, y_ub):
-    """McCormick relaxation of x/y given bounds.
+    """McCormick relaxation of x/y given bounds on the numerator and denominator.
 
-    Requires 0 not in [y_lb, y_ub].
-    Uses the composition: x/y = x * (1/y) with bilinear relaxation.
+    In the compiler, ``[x_lb, x_ub] = [cv_num, cc_num]`` and
+    ``[y_lb, y_ub] = [cv_den, cc_den]`` are the *relaxation intervals* of the
+    numerator and denominator at the evaluation point, and ``x``/``y`` are points
+    inside them. Requires ``0`` not in ``[y_lb, y_ub]``.
 
-    Returns (cv, cc).
+    Two regimes (C-23):
+
+    - **Point/linear denominator** (``y_lb == y_ub``): the denominator relaxation
+      collapses to a point, so ``1/y`` is exact and the classic bilinear
+      composition ``x*(1/y)`` is sound and tight. This covers a constant, a bare
+      variable, or an affine denominator.
+    - **Nonlinear denominator** (``y_lb != y_ub``): the bilinear composition
+      reciprocated at the *midpoint* of the denominator interval is **not** a
+      valid envelope — ``1/mid`` sits above the true ``1/(.)`` on a curved
+      denominator, so the "convex underestimator" can exceed ``f`` (``cv > f``),
+      an invalid dual bound. We instead return the sound **interval enclosure**
+      of ``x/y`` over the box (``[x_lb,x_ub] * [1/y_ub, 1/y_lb]``): a constant
+      ``[cv, cc]`` with ``cv <= x/y <= cc`` at every point. This is looser but
+      never crosses the function; spatial branching tightens the box (and the
+      denominator interval) so the enclosure shrinks.
     """
-    # First get relaxation of 1/y
-    recip_cv, recip_cc = _relax_reciprocal(y, y_lb, y_ub)
-    recip_lb = 1.0 / y_ub  # min of 1/y when y > 0 (note swap)
+    # Sound reciprocal bounds over the denominator interval (0 excluded, so the
+    # two endpoints share a sign): 1/y is monotone-decreasing, hence the range is
+    # [1/y_ub, 1/y_lb] up to ordering.
+    recip_lb = 1.0 / y_ub
     recip_ub = 1.0 / y_lb
-    # Ensure correct ordering
     recip_lb_sorted = jnp.minimum(recip_lb, recip_ub)
     recip_ub_sorted = jnp.maximum(recip_lb, recip_ub)
-    # Use bilinear relaxation of x * recip
-    return relax_bilinear(x, recip_cv, x_lb, x_ub, recip_lb_sorted, recip_ub_sorted)
+
+    # Tight bilinear composition, valid only where the denominator relaxation
+    # collapses to a point (1/y exact).
+    recip_cv, _recip_cc = _relax_reciprocal(y, y_lb, y_ub)
+    tight_cv, tight_cc = relax_bilinear(x, recip_cv, x_lb, x_ub, recip_lb_sorted, recip_ub_sorted)
+
+    # Sound interval enclosure of x/y = [x_lb,x_ub] * [recip_lb,recip_ub],
+    # valid for a nonlinear (non-degenerate) denominator interval.
+    p1 = x_lb * recip_lb_sorted
+    p2 = x_lb * recip_ub_sorted
+    p3 = x_ub * recip_lb_sorted
+    p4 = x_ub * recip_ub_sorted
+    encl_cv = jnp.minimum(jnp.minimum(p1, p2), jnp.minimum(p3, p4))
+    encl_cc = jnp.maximum(jnp.maximum(p1, p2), jnp.maximum(p3, p4))
+
+    denom_is_point = jnp.abs(y_ub - y_lb) < 1e-12
+    cv = jnp.where(denom_is_point, tight_cv, encl_cv)
+    cc = jnp.where(denom_is_point, tight_cc, encl_cc)
+    return cv, cc
 
 
 # ---------------------------------------------------------------------------
@@ -393,11 +431,18 @@ def relax_cos(x, lb, ub):
 def relax_tan(x, lb, ub):
     """McCormick relaxation of tan(x) on [lb, ub].
 
-    Requires [lb, ub] within a single period (-pi/2, pi/2) + k*pi.
-    tan has an inflection point at k*pi: convex on [k*pi, pi/2+k*pi),
-    concave on (-pi/2+k*pi, k*pi].
+    ``tan`` is only continuous on an open branch ``(-pi/2 + k*pi, pi/2 + k*pi)``;
+    it diverges at each pole ``pi/2 + k*pi``. Within one branch it has an
+    inflection point at ``k*pi`` (convex on ``[k*pi, pi/2+k*pi)``, concave on
+    ``(-pi/2+k*pi, k*pi]``) and a valid convex/concave envelope can be drawn.
 
-    For the principal period (-pi/2, pi/2):
+    If ``[lb, ub]`` **straddles a pole** the branch classification below is not
+    applicable — a secant drawn across the pole is not a valid under/over
+    estimator (C-19). In that case we *abstain*, returning the no-information
+    envelope ``(-inf, +inf)`` (matching how other relaxations abstain), leaving
+    FBBT / spatial branching to shrink the box below the pole spacing.
+
+    For a pole-free interval within the principal period ``(-pi/2, pi/2)``:
     - lb >= 0: convex -> cv = tan(x), cc = secant
     - ub <= 0: concave -> cv = secant, cc = tan(x)
     - lb < 0 < ub: piecewise with separate secants per half
@@ -407,11 +452,22 @@ def relax_tan(x, lb, ub):
     f = jnp.tan
 
     # Shift to principal period by finding the nearest inflection point
-    # For simplicity, assume the interval is within one period.
-    # Determine the inflection point center = k*pi nearest to midpoint
+    # (center = k*pi nearest to the midpoint); the continuous branch spanning
+    # the box is (center - pi/2, center + pi/2).
     mid = 0.5 * (lb + ub)
     k = jnp.round(mid / jnp.pi)
     center = k * jnp.pi
+
+    # --- Pole detection (C-19) -------------------------------------------
+    # tan is finite and single-branch on the box iff both endpoints lie
+    # strictly inside the branch centered at ``center``, whose bounding poles
+    # are at ``center +/- pi/2``. Any box that reaches or crosses either pole
+    # (equivalently spans >= a full period, so it would contain a pole for some
+    # k) is not classifiable by the branch logic below and must abstain — a
+    # secant across a pole is neither a valid under- nor over-estimator.
+    lo_pole = center - 0.5 * jnp.pi
+    hi_pole = center + 0.5 * jnp.pi
+    pole_free = (lb > lo_pole) & (ub < hi_pole)
 
     # Case 1: lb >= center -> convex half: cv = f(x), cc = secant
     case1_cv = f(x)
@@ -432,6 +488,13 @@ def relax_tan(x, lb, ub):
 
     cv = jnp.where(is_convex_half, case1_cv, jnp.where(is_concave_half, case2_cv, case3_cv))
     cc = jnp.where(is_convex_half, case1_cc, jnp.where(is_concave_half, case2_cc, case3_cc))
+
+    # Abstain across a pole: emit the no-information envelope (-inf, +inf)
+    # rather than a secant drawn through the singularity.
+    neg_inf = -jnp.inf * jnp.ones_like(cv)
+    pos_inf = jnp.inf * jnp.ones_like(cc)
+    cv = jnp.where(pole_free, cv, neg_inf)
+    cc = jnp.where(pole_free, cc, pos_inf)
 
     return cv, cc
 

--- a/python/discopt/_numpy/mccormick.py
+++ b/python/discopt/_numpy/mccormick.py
@@ -13,9 +13,13 @@ import numpy as jnp
 def _secant(f, x, lb, ub):
     f_lb = f(lb)
     f_ub = f(ub)
-    slope = (f_ub - f_lb) / (ub - lb)
+    width = ub - lb
+    degenerate = jnp.abs(width) < 1e-15
+    # Guard the divisor so the degenerate branch never evaluates 0/0.
+    safe_width = jnp.where(degenerate, 1.0, width)
+    slope = (f_ub - f_lb) / safe_width
     line = f_lb + slope * (x - lb)
-    return jnp.where(jnp.abs(ub - lb) < 1e-15, f(x), line)
+    return jnp.where(degenerate, f(x), line)
 
 
 def relax_bilinear(x, y, x_lb, x_ub, y_lb, y_ub):
@@ -52,12 +56,30 @@ def _relax_reciprocal(y, y_lb, y_ub):
 
 
 def relax_div(x, y, x_lb, x_ub, y_lb, y_ub):
-    recip_cv, _recip_cc = _relax_reciprocal(y, y_lb, y_ub)
+    # C-23: the bilinear composition x*(1/y) is only sound when the denominator
+    # relaxation collapses to a point (y_lb == y_ub -> 1/y exact: constant,
+    # variable, or affine denominator). For a nonlinear denominator (y_lb != y_ub)
+    # reciprocating the midpoint yields cv > f, an invalid underestimator; fall
+    # back to the sound interval enclosure [x_lb,x_ub] * [1/y_ub, 1/y_lb].
     recip_lb = 1.0 / y_ub
     recip_ub = 1.0 / y_lb
     recip_lb_sorted = jnp.minimum(recip_lb, recip_ub)
     recip_ub_sorted = jnp.maximum(recip_lb, recip_ub)
-    return relax_bilinear(x, recip_cv, x_lb, x_ub, recip_lb_sorted, recip_ub_sorted)
+
+    recip_cv, _recip_cc = _relax_reciprocal(y, y_lb, y_ub)
+    tight_cv, tight_cc = relax_bilinear(x, recip_cv, x_lb, x_ub, recip_lb_sorted, recip_ub_sorted)
+
+    p1 = x_lb * recip_lb_sorted
+    p2 = x_lb * recip_ub_sorted
+    p3 = x_ub * recip_lb_sorted
+    p4 = x_ub * recip_ub_sorted
+    encl_cv = jnp.minimum(jnp.minimum(p1, p2), jnp.minimum(p3, p4))
+    encl_cc = jnp.maximum(jnp.maximum(p1, p2), jnp.maximum(p3, p4))
+
+    denom_is_point = jnp.abs(y_ub - y_lb) < 1e-12
+    cv = jnp.where(denom_is_point, tight_cv, encl_cv)
+    cc = jnp.where(denom_is_point, tight_cc, encl_cc)
+    return cv, cc
 
 
 def relax_pow(x, lb, ub, n):
@@ -171,10 +193,15 @@ def relax_cos(x, lb, ub):
 
 
 def relax_tan(x, lb, ub):
+    # C-19: abstain (return the no-information envelope) when [lb, ub] straddles
+    # a tan pole at pi/2 + k*pi; a secant across a pole is not a valid envelope.
     f = jnp.tan
     mid = 0.5 * (lb + ub)
     k = jnp.round(mid / jnp.pi)
     center = k * jnp.pi
+    lo_pole = center - 0.5 * jnp.pi
+    hi_pole = center + 0.5 * jnp.pi
+    pole_free = (lb > lo_pole) & (ub < hi_pole)
     case1_cv = f(x)
     case1_cc = _secant(f, x, lb, ub)
     case2_cv = _secant(f, x, lb, ub)
@@ -187,6 +214,10 @@ def relax_tan(x, lb, ub):
     is_concave_half = ub <= center
     cv = jnp.where(is_convex_half, case1_cv, jnp.where(is_concave_half, case2_cv, case3_cv))
     cc = jnp.where(is_convex_half, case1_cc, jnp.where(is_concave_half, case2_cc, case3_cc))
+    neg_inf = -jnp.inf * jnp.ones_like(cv)
+    pos_inf = jnp.inf * jnp.ones_like(cc)
+    cv = jnp.where(pole_free, cv, neg_inf)
+    cc = jnp.where(pole_free, cc, pos_inf)
     return cv, cc
 
 

--- a/python/tests/test_div_nonlinear_denominator_c23.py
+++ b/python/tests/test_div_nonlinear_denominator_c23.py
@@ -1,0 +1,164 @@
+"""C-23 regression: relax_div must be a sound envelope for NONLINEAR denominators.
+
+``relax_div`` composes ``x/y = x * (1/y)`` and (pre-fix) reciprocated the
+denominator at the MIDPOINT of its relaxation interval. When the denominator is a
+bare variable or affine, that interval point-collapses so ``1/mid`` is exact and
+the composition is sound. When the denominator is NONLINEAR (``x*y``, ``x*x``,
+``sqrt(x*y)``, ``x*y+1``, ...) the interval is non-degenerate, ``1/mid`` sits
+ABOVE the true ``1/(.)``, and the "convex underestimator" ``cv`` exceeds ``f``
+(e.g. ``1/(x*y)`` on ``[0.3,2]x[0.4,1.8]`` gave ``cv=1.334 > 1.0``) -> invalid
+dual bound -> risk of a wrong certificate.
+
+The fix keeps the tight bilinear composition where the denominator relaxation
+collapses to a point, and falls back to the SOUND interval enclosure
+``[x_lb,x_ub] * [1/y_ub, 1/y_lb]`` when the denominator interval is
+non-degenerate — never emitting ``cv > f``.
+
+Two layers of coverage:
+  1. Direct primitive test on ``relax_div`` with a non-degenerate denominator
+     interval (JAX and numpy backends).
+  2. Full-compiler containment on ``1/(x*y)``, ``x/(y*z)``, ``1/(x*x)``,
+     ``1/sqrt(x*y)`` plus the sound ``1/x`` / ``x/y`` controls — the
+     reciprocal-/division-of-nonlinear-inner case the harness previously omitted.
+"""
+
+import numpy as np
+import pytest
+from discopt._jax import mccormick as jm
+from discopt._numpy import mccormick as nm
+from relaxation_harness import build_relaxation, evaluate
+
+pytestmark = [pytest.mark.unit, pytest.mark.smoke]
+
+TOL = 1e-7
+
+_BACKENDS = [
+    pytest.param(jm, id="jax"),
+    pytest.param(nm, id="numpy"),
+]
+
+
+# --------------------------------------------------------------------------
+# Layer 1: direct primitive test on relax_div with a non-degenerate denominator
+# --------------------------------------------------------------------------
+
+
+def _div_max_crossing(relax_fn, x_lb, x_ub, y_lb, y_ub, n=21):
+    """Max (cv - x/y) and (x/y - cc) over the numerator x denominator box.
+
+    ``relax_div`` returns a scalar (cv, cc) that must bracket x/y for EVERY
+    (x_true, y_true) in [x_lb,x_ub] x [y_lb,y_ub]. The compiler evaluates it at
+    the interval midpoints, so we call it the same way and check containment over
+    the whole box.
+    """
+    x = 0.5 * (x_lb + x_ub)
+    y = 0.5 * (y_lb + y_ub)
+    cv, cc = relax_fn(np.array(x), np.array(y), x_lb, x_ub, y_lb, y_ub)
+    cv = float(cv)
+    cc = float(cc)
+    xs = np.linspace(x_lb, x_ub, n)
+    ys = np.linspace(y_lb, y_ub, n)
+    XX, YY = np.meshgrid(xs, ys)
+    fx = XX / YY
+    return float(np.max(cv - fx)), float(np.max(fx - cc))
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+def test_div_nonlinear_denominator_literal_repro(mod):
+    """1/(x*y) style: numerator collapsed to 1, denominator interval [0.58, 1.56].
+
+    Pre-fix cv=1.334 > true 1.0. Post-fix the enclosure must bracket every point.
+    """
+    # numerator '1' -> x_lb == x_ub == 1 ; denominator relax interval [0.58, 1.56]
+    over, under = _div_max_crossing(mod.relax_div, 1.0, 1.0, 0.58, 1.56)
+    assert over <= TOL, f"div cv exceeds f by {over} (nonlinear-denominator underestimator)"
+    assert under <= TOL, f"div cc below f by {under}"
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+@pytest.mark.parametrize(
+    "x_lb,x_ub,y_lb,y_ub",
+    [
+        (1.0, 1.0, 0.58, 1.56),  # 1 / nonlinear positive denom
+        (0.3, 2.0, 0.5, 1.5),  # numerator interval too, positive denom
+        (-2.0, 2.0, 0.5, 1.5),  # numerator straddles 0, positive denom
+        (1.0, 1.0, -1.56, -0.58),  # nonlinear NEGATIVE denom
+        (-2.0, 1.0, -1.5, -0.5),  # both straddle / negative denom
+    ],
+)
+def test_div_nondegenerate_denominator_never_crosses(mod, x_lb, x_ub, y_lb, y_ub):
+    over, under = _div_max_crossing(mod.relax_div, x_lb, x_ub, y_lb, y_ub)
+    assert over <= TOL, f"div cv exceeds f by {over} on [{x_lb},{x_ub}]/[{y_lb},{y_ub}]"
+    assert under <= TOL, f"div cc below f by {under} on [{x_lb},{x_ub}]/[{y_lb},{y_ub}]"
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+def test_div_point_denominator_stays_tight(mod):
+    """Collapsed (linear/constant) denominator keeps the exact bilinear value."""
+    # y_lb == y_ub -> 1/y exact; cv == cc == x/y at the point.
+    cv, cc = mod.relax_div(np.array(3.0), np.array(2.0), 3.0, 3.0, 2.0, 2.0)
+    assert abs(float(cv) - 1.5) <= TOL and abs(float(cc) - 1.5) <= TOL
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+def test_div_random_subboxes_no_crossing(mod):
+    """Property test over random positive/negative denominator sub-boxes."""
+    rng = np.random.default_rng(20260703)
+    n_cross = 0
+    worst = 0.0
+    for _ in range(600):
+        # positive or negative denominator (0 excluded)
+        if rng.random() < 0.5:
+            y_lb = rng.uniform(0.2, 3.0)
+            y_ub = y_lb + rng.uniform(0.0, 3.0)
+        else:
+            y_ub = rng.uniform(-3.0, -0.2)
+            y_lb = y_ub - rng.uniform(0.0, 3.0)
+        x_lb = rng.uniform(-3.0, 3.0)
+        x_ub = x_lb + rng.uniform(0.0, 3.0)
+        over, under = _div_max_crossing(mod.relax_div, x_lb, x_ub, y_lb, y_ub, n=13)
+        crossing = max(over, under)
+        if crossing > TOL:
+            n_cross += 1
+            worst = max(worst, crossing)
+    assert n_cross == 0, f"relax_div: {n_cross} crossing sub-boxes, worst={worst}"
+
+
+# --------------------------------------------------------------------------
+# Layer 2: full-compiler containment (the harness's missing nonlinear-inner case)
+# --------------------------------------------------------------------------
+
+
+def _compiler_worst_crossing(expr_fn, bounds, n=4000, seed=0):
+    relax_fn, true_fn, lb, ub = build_relaxation(expr_fn, bounds)
+    rng = np.random.default_rng(seed)
+    w = np.asarray(ub) - np.asarray(lb)
+    xs = np.asarray(lb) + rng.uniform(0.0, 1.0, size=(n, len(bounds))) * w
+    import jax.numpy as jnp
+
+    cv, cc, f = evaluate(relax_fn, true_fn, lb, ub, jnp.array(xs, dtype=jnp.float64))
+    fin = np.isfinite(cv) & np.isfinite(cc) & np.isfinite(f)
+    over = float(np.max((cv - f)[fin])) if fin.any() else 0.0
+    under = float(np.max((f - cc)[fin])) if fin.any() else 0.0
+    return over, under
+
+
+@pytest.mark.parametrize(
+    "expr_fn,bounds,label",
+    [
+        (lambda x, y: 1 / (x * y), [(0.3, 2.0), (0.4, 1.8)], "1/(x*y)"),
+        (lambda x, y, z: x / (y * z), [(0.5, 2.0), (0.4, 1.8), (0.5, 1.5)], "x/(y*z)"),
+        (lambda x: 1 / (x * x), [(0.3, 2.0)], "1/(x*x)"),
+        (lambda x, y: 1 / (x * y) ** 0.5, [(0.3, 2.0), (0.4, 1.8)], "1/sqrt(x*y)"),
+        (lambda x, y: (x + 1) / (x * y), [(0.3, 2.0), (0.4, 1.8)], "(x+1)/(x*y)"),
+        (lambda x, y: 1 / (x * y + 1), [(0.3, 2.0), (0.4, 1.8)], "1/(x*y+1)"),
+        # sound controls (linear/point denominators) must remain sound.
+        (lambda x: 1 / x, [(0.3, 2.0)], "1/x"),
+        (lambda x, y: x / y, [(0.3, 2.0), (0.4, 1.8)], "x/y"),
+        (lambda x, y: 1 / (x + y), [(0.3, 2.0), (0.4, 1.8)], "1/(x+y)"),
+    ],
+)
+def test_compiler_division_containment(expr_fn, bounds, label):
+    over, under = _compiler_worst_crossing(expr_fn, bounds)
+    assert over <= 1e-6, f"[{label}] cv exceeds f by {over} (invalid underestimator)"
+    assert under <= 1e-6, f"[{label}] cc below f by {under} (invalid overestimator)"

--- a/python/tests/test_tan_pole_envelope_c19.py
+++ b/python/tests/test_tan_pole_envelope_c19.py
@@ -1,0 +1,140 @@
+"""C-19 regression: relax_tan must not draw a secant across a tan pole.
+
+``tan`` diverges at each pole ``pi/2 + k*pi``. The pre-fix code centered on the
+nearest inflection ``k*pi`` and classified the box as a single convex/concave
+branch via ``lb >= center`` / ``ub <= center`` without checking that ``[lb, ub]``
+stays inside one continuous branch ``(-pi/2 + k*pi, pi/2 + k*pi)``. For a
+pole-straddling box (e.g. ``[1.4, 1.8]`` straddling ``pi/2 ~= 1.5708``) it drew a
+secant ACROSS the pole -> the "convex underestimator" ``cv`` exceeded ``tan`` by
+hundreds of thousands on part of the branch (invalid envelope -> invalid dual
+bound -> risk of a wrong certificate).
+
+The fix *abstains* on any pole-straddling box: it emits the no-information
+envelope ``(-inf, +inf)`` (never a crossing finite envelope), leaving FBBT /
+spatial branching to shrink the box below the pole spacing. Pole-free boxes keep
+the tight branch envelope.
+
+These tests call ``relax_tan`` DIRECTLY on straddling and pole-free boxes so the
+buggy branch is exercised, on BOTH the JAX and numpy backends. The property test
+encodes the false-certificate CLASS (a finite envelope that crosses ``tan`` on a
+pole-straddling box), not a single named box.
+"""
+
+import numpy as np
+import pytest
+from discopt._jax import mccormick as jm
+from discopt._numpy import mccormick as nm
+
+pytestmark = [pytest.mark.unit, pytest.mark.smoke]
+
+TOL = 1e-7
+# Stay away from the pole itself where tan -> +-inf and float values are useless.
+_POLE_GUARD = 5e-3
+
+_BACKENDS = [
+    pytest.param(jm, id="jax"),
+    pytest.param(nm, id="numpy"),
+]
+
+
+def _pole_distance(xs):
+    """Distance from each x to the nearest tan pole pi/2 + k*pi."""
+    return np.abs(((xs + np.pi / 2) % np.pi) - np.pi / 2)
+
+
+def _finite_max_crossing(relax_fn, lb, ub, n=401):
+    """Max (cv - tan) and (tan - cc) over FINITE envelope points on [lb, ub].
+
+    Abstained points (cv=-inf, cc=+inf) carry no information and are excluded;
+    what must never happen is a *finite* envelope that crosses tan.
+    """
+    xs = np.linspace(lb, ub, n)
+    keep = _pole_distance(xs) > _POLE_GUARD
+    xs = xs[keep]
+    cv, cc = relax_fn(xs, lb, ub)
+    cv = np.asarray(cv, dtype=float)
+    cc = np.asarray(cc, dtype=float)
+    fx = np.tan(xs)
+    finite = np.isfinite(cv) & np.isfinite(cc) & np.isfinite(fx)
+    if not finite.any():
+        return -np.inf, -np.inf, 0
+    over = float(np.max(cv[finite] - fx[finite]))
+    under = float(np.max(fx[finite] - cc[finite]))
+    return over, under, int(finite.sum())
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+def test_tan_straddling_pole_literal_repro_is_sound(mod):
+    """The card's literal repro: relax_tan on [1.4, 1.8] evaluated at x=1.5.
+
+    Pre-fix ``cv`` (secant across the pole) massively exceeds tan(1.5)~=14.10.
+    Post-fix the box straddles a pole so the envelope must abstain (cv=-inf).
+    """
+    cv, cc = mod.relax_tan(np.array(1.5), 1.4, 1.8)
+    cv = float(cv)
+    cc = float(cc)
+    true = float(np.tan(1.5))
+    # Sound either way: abstain (-inf/+inf) or a non-crossing finite envelope.
+    assert cv <= true + TOL, f"cv={cv} > tan(1.5)={true} (secant across pole)"
+    assert cc >= true - TOL, f"cc={cc} < tan(1.5)={true} (secant across pole)"
+    # The fix's chosen behavior is to abstain across the pole.
+    assert cv == -np.inf and cc == np.inf, "straddling box must abstain, not emit a finite envelope"
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+@pytest.mark.parametrize(
+    "lb,ub",
+    [
+        (1.4, 1.8),  # straddles +pi/2
+        (-1.8, -1.4),  # straddles -pi/2
+        (1.0, 2.2),  # wide straddle of +pi/2
+        (1.5, 4.8),  # spans more than one full period (contains a pole)
+        (4.4, 4.9),  # straddles 3*pi/2 ~= 4.712
+    ],
+)
+def test_tan_pole_straddling_never_crosses(mod, lb, ub):
+    """A finite tan envelope must never cross the function across a pole."""
+    over, under, _ = _finite_max_crossing(mod.relax_tan, lb, ub)
+    assert over <= TOL, f"tan cv exceeds f by {over} on straddling [{lb},{ub}]"
+    assert under <= TOL, f"tan cc below f by {under} on straddling [{lb},{ub}]"
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+@pytest.mark.parametrize(
+    "lb,ub",
+    [
+        (0.1, 1.4),  # pole-free, convex half of principal branch
+        (-1.4, -0.1),  # pole-free, concave half
+        (-1.4, 1.4),  # pole-free, spans the inflection at 0
+        (3.3, 4.6),  # pole-free branch centered at pi (k=1)
+        (-4.6, -3.3),  # pole-free branch centered at -pi
+    ],
+)
+def test_tan_pole_free_stays_tight_and_sound(mod, lb, ub):
+    """Pole-free boxes must keep a finite, sound (non-crossing) envelope."""
+    over, under, n_finite = _finite_max_crossing(mod.relax_tan, lb, ub)
+    assert n_finite > 0, f"pole-free [{lb},{ub}] unexpectedly abstained everywhere"
+    assert over <= TOL, f"tan cv exceeds f by {over} on pole-free [{lb},{ub}]"
+    assert under <= TOL, f"tan cc below f by {under} on pole-free [{lb},{ub}]"
+
+
+@pytest.mark.parametrize("mod", _BACKENDS)
+def test_tan_envelope_property_random_subboxes(mod):
+    """Property test: no FINITE envelope crossing over random sub-boxes.
+
+    Draws random boxes across several branches (some pole-straddling, some not).
+    Whatever the box, a returned finite envelope must satisfy cv <= tan <= cc.
+    """
+    rng = np.random.default_rng(20260703)
+    n_cross = 0
+    worst = 0.0
+    for _ in range(600):
+        a, b = np.sort(rng.uniform(-5.0, 5.0, size=2))
+        if b - a < 1e-3:
+            continue
+        over, under, _ = _finite_max_crossing(mod.relax_tan, a, b, n=61)
+        crossing = max(over, under)
+        if crossing > TOL:
+            n_cross += 1
+            worst = max(worst, crossing)
+    assert n_cross == 0, f"relax_tan: {n_cross} crossing sub-boxes, worst={worst}"


### PR DESCRIPTION
## Summary

Fixes two P1 correctness bugs (`docs/dev/correctness-issues.md`) — invalid McCormick envelopes in the live JAX relaxation layer (`python/discopt/_jax/mccormick.py`). An envelope whose convex underestimator `cv > f` (or concave `cc < f`) is an invalid relaxation → invalid dual bound → risk of a false optimal. Both fixes guarantee `cv ≤ f ≤ cc` over the whole box or **abstain**. Mirrored into the ported numpy backend (`python/discopt/_numpy/mccormick.py`) so each class is closed on both backends (C-19 was flagged on the numpy backend too, = NM-4).

## C-19 — `relax_tan` secant across a tan pole

`tan` diverges at each pole `π/2 + kπ`. A box straddling a pole (e.g. `[1.4, 1.8]`, pole at `π/2≈1.5708`) was classified as a single convex/concave branch, drawing a secant **across** the pole.

- **Repro (before):** direct `relax_tan` on `[1.4,1.8]` → `max(cv − tan) ≈ +2.7e5` (invalid underestimator). Mirror `[−1.8,−1.4]` → `max(tan − cc) ≈ +2.7e5`.
- **Fix:** detect the branch spanning the box (nearest inflection `center=k·π`, bounding poles `center ± π/2`) and **abstain** — return the no-information envelope `(−inf, +inf)` — whenever an endpoint reaches or crosses a pole. Pole-free boxes keep the tight branch envelope.
- **After:** every pole-straddling box abstains; all pole-free branches (incl. `k=±1`) sound to 1e-7.

## C-23 — `relax_div` invalid underestimator for nonlinear denominators

`x/y = x·(1/y)` reciprocated the denominator at the **midpoint** of its relaxation interval. For a nonlinear denominator the interval is non-degenerate, so `1/mid` sits above the true `1/(·)` and `cv > f`.

- **Repro (before), via the full compiler:** worst `cv − f` = **+0.80** on `1/(x*y)`, **+1.15** on `1/(x*x)`, **+0.71** on `x/(y*z)`; `1/sqrt(x*y)`, `(x+1)/(x*y)`, `1/(x*y+1)` also crossing. Controls `1/x`, `x/y`, `1/(x+y)` sound.
- **Fix:** keep the tight bilinear composition **only** where the denominator relaxation collapses to a point (`|y_ub−y_lb| < 1e-12` — constant/variable/affine, `1/y` exact); otherwise abstain to the **sound interval enclosure** `[x_lb,x_ub] · [1/y_ub, 1/y_lb]` (brackets `x/y` at every point, both denominator signs). Looser but never crossing; spatial branching shrinks the denominator interval → the enclosure tightens. (A by-hand bivariate-McCormick composite was prototyped and rejected — brute-force truth sampling showed it still crossed by up to +11.)
- **After:** every listed nonlinear-denominator case sound to ≤3.6e-15; the `1/(x*y)` repro flips from `cv=1.334>1.0` to sound; controls stay exactly tight; point-denominator `3/2` stays `cv=cc=1.5`.

Also hardened `_secant` (both backends) so the degenerate `lb==ub` branch never evaluates `0/0` (the guard previously ran only *after* the division).

## Tests (new, required, red-before / green-after)

- `python/tests/test_tan_pole_envelope_c19.py` — literal `[1.4,1.8]` repro, pole-straddling never-crosses, pole-free stays-tight, random-sub-box property test. 14 red before, green after.
- `python/tests/test_div_nonlinear_denominator_c23.py` — literal repro, non-degenerate never-crosses (pos & neg denom), point-denominator tightness, random-sub-box property test, plus a **full-compiler containment layer** over `1/(x*y)`, `x/(y*z)`, `1/(x*x)`, `1/sqrt(x*y)`, `(x+1)/(x*y)`, `1/(x*y+1)` + `1/x`/`x/y`/`1/(x+y)` controls — the reciprocal-/division-of-nonlinear-inner case the harness previously omitted. 36 assertions red before, green after.

Both are `@pytest.mark.smoke`, sub-second, parametrized over JAX and numpy backends, calling the primitives directly.

## Gates

- Targeted `pytest python/tests/ -k "tan or div or envelope or relax or mccormick or convex"` — **1366 passed, 1 skipped, 2 xfailed, 0 failed**
- `pytest -m smoke` — **388 passed, 1 skipped, 0 failed**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed, 0 failed**
- `ruff check` + `ruff format --check` clean; `mypy` clean on the changed modules
- No Rust touched (`cargo test` not required). No safety guard weakened — `incorrect_count` unaffected; the change only turns previously-crossing envelopes into sound/abstaining ones.

## Docs

`docs/dev/correctness-issues.md` — C-19 and C-23 cards updated (open/confirmed → fixed) with the before/after numbers, fix rationale, and the regression-test filenames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
