### PR TITLE
fix(correctness): C-35 — OA/LOA no-good cut only on rigorous infeasibility

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -120,7 +120,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-32 | P0 | relaxation/mccormick | `relax_asin`/`relax_acos` inverted curvature regime → unsound convex envelope (cv > f) in the LIVE JAX layer → invalid dual bound (= NM-1) | fixed |
 | C-33 | P0 | solver.py fallback | pure-continuous fallback certifies a nonconvex model's local optimum with `gap_certified=True` (= SC-1), DEFAULT path | fixed |
 | C-34 | P0 | gdp_reformulate | even-power bound over a zero-straddling base uses endpoint-only bounds (omits interior min at 0) → invalid aux box → false optimal (= FR-1), DEFAULT path | fixed |
-| C-35 | P1 | oa.py / gdpopt_loa | non-rigorous NLP failure → unconditional no-good cut → possible false infeasible/optimal (= OA-1, opt-in OA/LOA path) | open |
+| C-35 | P1 | oa.py / gdpopt_loa | non-rigorous NLP failure → unconditional no-good cut → possible false infeasible/optimal (= OA-1, opt-in OA/LOA path) | fixed |
 
 ---
 
@@ -1995,8 +1995,9 @@ checks per §0.
 
 ---
 
-## C-35 (P1) — OA/LOA emits an unconditional no-good cut on non-rigorous NLP failure (opt-in)
+## C-35 (P1) — OA/LOA emits an unconditional no-good cut on non-rigorous NLP failure (opt-in) — **FIXED**
 
+**Status:** fixed (PR: see Log).
 **Origin:** solver-core review (OA-1).
 **Area:** `python/discopt/oa.py:209-236, 893-931, 916` and
 `python/discopt/gdpopt_loa.py:314-370, 225`.
@@ -2027,7 +2028,62 @@ sub-second GDP. Fails before, passes after.
 no-good cut is emitted without a rigorous infeasibility proof; existing OA/LOA tests
 unchanged; standing gates pass.
 
-**Log:** 2026-07-03 — new opt-in P1 (solver-core review §2).
+**Log:**
+- 2026-07-03 — new opt-in P1 (solver-core review §2).
+- 2026-07-03 — **CONFIRMED then FIXED.** Confirmed both false-certificate classes
+  on pre-fix code with a direct `solve_oa` repro (monkeypatching the fixed-integer
+  NLP subproblem to fail *non-rigorously*, as a diverged/iteration-limited local
+  NLP does):
+  * **False infeasible** — a feasible model `min (x-0.5)^2+3y s.t. x+y>=0.3` (true
+    opt x=0.5,y=0,obj=0) returned `status="infeasible", gap_certified=True` when
+    every NLP subproblem merely failed.
+  * **False optimal** — same model with only the *optimal* config's (y=0) NLP
+    failing returned `status="optimal", objective=3.0` (the suboptimal y=1),
+    certified, because the no-good cut excluded the optimal config.
+
+  Root cause was structural: `_solve_nlp_subproblem` collapses *every* non-optimal
+  outcome (diverged / iteration-limit-without-feasible / error / exception) to
+  `(None, None)`, and the loop's `else` branch treated that as "infeasible" and
+  emitted an **unconditional** no-good cut. The NLP layer never even produces a
+  rigorous infeasible verdict (`nlp_ipopt._IPOPT_STATUS_MAP` deliberately maps
+  IPOPT status 2 `Infeasible_Problem_Detected` → `ERROR`), so *every* no-good cut
+  in this branch was unsound.
+
+  **Fix** (`python/discopt/solvers/oa.py`, `python/discopt/solvers/gdpopt_loa.py`):
+  added `_fixed_subproblem_rigorously_infeasible(...)` — a *sufficient, rigorous*
+  infeasibility test (currently: no free continuous variables remaining ⇒ the
+  fixed point is the sole candidate, so a constraint violation there is a complete
+  proof). The no-good cut is now emitted **only** when that test passes;
+  certification is preserved for genuinely-provable exclusions (e.g. all-integer
+  models). On a non-rigorous failure the cut is **withheld**, the configuration is
+  recorded as unresolved (OA gradient cuts at the master point are still added —
+  those never cut a feasible point), the loop breaks soundly if the master
+  re-proposes an unresolved config (anti-cycling without exclusion), and the result
+  is downgraded: `gap_certified=False`, never a certified `optimal`, and never a
+  certified `infeasible` (a new `status="unknown"` is returned instead when there
+  is no incumbent). No rigorous check was weakened.
+
+  **Note (scope, per §0 rule 7):** the fix showed the bug is slightly *broader*
+  than the card framing — OA's `optimal` certification on ordinary MINLPs with an
+  infeasible integer config was also resting on the unsound no-good logic. The
+  rigorous no-continuous-freedom check preserves certification for those (the one
+  existing test that momentarily flipped `optimal`→`feasible`,
+  `test_oa_maximize_linear_objective_is_not_the_minimum`, is green again). Blast
+  radius was a single test; the OA convergence guarantee is not touched broadly, so
+  no escalation was needed. A future, more general rigorous infeasibility prover
+  (interval/FBBT over the fixed box; feasibility-restoration certificate) would let
+  the no-good cut fire in more cases — tracked as a follow-on, not required for
+  soundness (withholding is always sound).
+
+  **Regression test:** `python/tests/test_c35_oa_nogood_nlp_failure.py` (4 tests,
+  `@pytest.mark.smoke`, sub-second, calls `solve_oa`/`solve_gdpopt_loa` directly):
+  no false infeasible (OA + LOA), no false optimal (OA), AND certification IS
+  preserved when the infeasible config is rigorously provable (all-integer case).
+  Red before the fix (3 fail), green after (4 pass).
+
+  **Gates:** smoke 197 passed / 1 skipped; adversarial 10 passed; OA/LOA/gdpopt/
+  nogood/benders 165 passed / 2 skipped; ruff clean; mypy clean on changed files;
+  no Rust touched. PR: (filled at PR creation).
 
 ---
 

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -1997,7 +1997,7 @@ checks per §0.
 
 ## C-35 (P1) — OA/LOA emits an unconditional no-good cut on non-rigorous NLP failure (opt-in) — **FIXED**
 
-**Status:** fixed (PR: see Log).
+**Status:** fixed (PR #451).
 **Origin:** solver-core review (OA-1).
 **Area:** `python/discopt/oa.py:209-236, 893-931, 916` and
 `python/discopt/gdpopt_loa.py:314-370, 225`.
@@ -2083,7 +2083,7 @@ unchanged; standing gates pass.
 
   **Gates:** smoke 197 passed / 1 skipped; adversarial 10 passed; OA/LOA/gdpopt/
   nogood/benders 165 passed / 2 skipped; ruff clean; mypy clean on changed files;
-  no Rust touched. PR: (filled at PR creation).
+  no Rust touched. PR: #451.
 
 ---
 

--- a/python/discopt/solvers/gdpopt_loa.py
+++ b/python/discopt/solvers/gdpopt_loa.py
@@ -156,6 +156,13 @@ def solve_gdpopt_loa(
     incumbent = None
     incumbent_obj = None
 
+    # C-35: integer configurations whose fixed-integer NLP subproblem failed to
+    # resolve *non-rigorously* (diverged / iteration limit / error). A local NLP
+    # failure is NOT a proof of infeasibility, so we must NOT exclude such a
+    # configuration with a no-good cut. Tracked to refuse certification and to
+    # break the loop soundly if the master re-proposes an unresolved config.
+    unresolved_int_configs: set[tuple[int, ...]] = set()
+
     for iteration in range(max_iterations):
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -221,9 +228,16 @@ def solve_gdpopt_loa(
                 oa_convexity.objective_is_convex,
             )
         else:
-            # NLP infeasible → add no-good cut
-            _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars)
-            # Also try OA cuts at master point
+            # C-35: the fixed-integer NLP subproblem returned no feasible point.
+            # A no-good cut is only SOUND when this configuration is RIGOROUSLY
+            # infeasible/dominated. A local NLP that merely failed to converge is
+            # NOT such a proof (the NLP layer never emits a rigorous
+            # infeasibility verdict). Split on a rigorous check.
+            rigorously_infeasible = _fixed_subproblem_rigorously_infeasible(
+                evaluator, sub_lb, sub_ub
+            )
+
+            # OA cuts at master point (valid supporting linearizations either way).
             _add_oa_cuts(
                 evaluator,
                 x_master,
@@ -235,6 +249,27 @@ def solve_gdpopt_loa(
                 oa_convexity.constraint_mask,
                 oa_convexity.objective_is_convex,
             )
+
+            if rigorously_infeasible:
+                # Proven infeasible ⇒ the no-good cut is valid (and provides the
+                # anti-cycling exclusion). Certification is preserved.
+                _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars)
+            else:
+                # Non-rigorous failure ⇒ do NOT exclude this configuration.
+                # Record it as unresolved (result not certified) and break
+                # soundly if the master re-proposes it (avoids cycling without
+                # the anti-cycling no-good cut).
+                config_key = _int_config_key(x_master, int_indices)
+                already_seen = config_key in unresolved_int_configs
+                unresolved_int_configs.add(config_key)
+                if already_seen:
+                    logger.info(
+                        "LOA: integer configuration %s unresolved by NLP "
+                        "(non-rigorous failure) and re-proposed; stopping without "
+                        "a no-good cut (result not certified)",
+                        config_key,
+                    )
+                    break
 
         # d. Check convergence
         gap = _compute_gap(LB, UB)
@@ -256,8 +291,14 @@ def solve_gdpopt_loa(
     bound = LB if master_bound_valid and LB > -1e19 else None
     reported_gap = gap if bound is not None and UB < 1e19 else None
 
+    # C-35: unresolved configurations mean the search is incomplete — we did not
+    # exclude them, so neither optimality nor infeasibility is proved. Downgrade
+    # certification and never report a *certified* "infeasible" in this state.
+    has_unresolved = len(unresolved_int_configs) > 0
+
     if incumbent is not None:
-        status = "optimal" if gap <= gap_tolerance else "feasible"
+        certified = (gap <= gap_tolerance) and not has_unresolved
+        status = "optimal" if certified else "feasible"
         x_dict = _build_x_dict(incumbent, reformulated)
         return SolveResult(
             status=status,
@@ -266,6 +307,20 @@ def solve_gdpopt_loa(
             gap=reported_gap,
             x=x_dict,
             wall_time=wall_time,
+            gap_certified=not has_unresolved,
+        )
+
+    if has_unresolved:
+        # No feasible incumbent AND unresolved configurations: cannot certify
+        # infeasibility (a diverged subproblem is not a proof).
+        return SolveResult(
+            status="unknown",
+            objective=None,
+            bound=bound,
+            gap=None,
+            x={},
+            wall_time=wall_time,
+            gap_certified=False,
         )
 
     return SolveResult(
@@ -370,6 +425,36 @@ def _solve_nlp_subproblem(evaluator, sub_lb, sub_ub, nlp_solver: str) -> np.ndar
     return None
 
 
+def _fixed_subproblem_rigorously_infeasible(evaluator, sub_lb, sub_ub, tol: float = 1e-6) -> bool:
+    """RIGOROUSLY decide whether the fixed-integer subproblem is infeasible.
+
+    C-35: a no-good cut is only sound when the excluded configuration is proved
+    infeasible/dominated. A local NLP that merely failed to converge is not such
+    a proof. Sufficient rigorous condition: when there are NO free continuous
+    variables (every variable pinned, ``sub_lb == sub_ub``), the subproblem has
+    a single candidate point; a constraint violation there proves infeasibility.
+    Otherwise return False (do not claim rigorous infeasibility).
+    """
+    sub_lb = np.asarray(sub_lb, dtype=np.float64)
+    sub_ub = np.asarray(sub_ub, dtype=np.float64)
+    if not np.all(sub_lb >= sub_ub - 1e-12):
+        return False
+    if evaluator.n_constraints == 0:
+        return False
+    try:
+        from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+        model = getattr(evaluator, "_model", None)
+        c_lb, c_ub = _infer_constraint_bounds(model)
+        x_point = 0.5 * (sub_lb + sub_ub)
+        cons = np.asarray(evaluator.evaluate_constraints(x_point), dtype=np.float64)
+        if not np.all(np.isfinite(cons)):
+            return False
+        return bool(np.any(cons < c_lb - tol) or np.any(cons > c_ub + tol))
+    except Exception:
+        return False
+
+
 class _BoundsProxy:
     """Wraps an NLPEvaluator with overridden variable bounds."""
 
@@ -467,6 +552,11 @@ def _add_oa_cuts(
         # This cut is: coeffs @ x <= rhs (underestimates the objective)
         oa_A_rows.append(obj_cut.coeffs.copy())
         oa_b_rows.append(obj_cut.rhs)
+
+
+def _int_config_key(x_master, int_indices) -> tuple[int, ...]:
+    """Canonical hashable key for the integer part of a master solution."""
+    return tuple(int(round(x_master[idx])) for idx in int_indices)
 
 
 def _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars):

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -254,6 +254,58 @@ def _solve_nlp_subproblem(evaluator, lb, ub, int_indices, x_master, nlp_solver):
     return _solve_nlp(proxy, sub_lb, sub_ub, nlp_solver)
 
 
+def _fixed_subproblem_rigorously_infeasible(
+    evaluator, lb, ub, int_indices, x_master, tol: float = 1e-6
+) -> bool:
+    """RIGOROUSLY decide whether the fixed-integer subproblem is infeasible.
+
+    C-35: a no-good (integer-exclusion) cut is only sound when the excluded
+    configuration is *proved* infeasible/dominated. A local NLP that merely
+    failed to converge is NOT such a proof. This returns True only under a
+    *sufficient, rigorous* condition:
+
+    * **No free continuous variables.** When every variable is fixed (an
+      all-integer model with integers pinned to the master values), the
+      subproblem has a single candidate point ``x_master``. Evaluating the
+      constraints there is a complete feasibility test: if any constraint is
+      violated beyond ``tol`` the configuration is genuinely infeasible, so a
+      no-good cut is valid.
+
+    Any other situation (free continuous variables remaining) returns False —
+    we do NOT claim rigorous infeasibility and therefore withhold the cut.
+    """
+    sub_lb = lb.copy()
+    sub_ub = ub.copy()
+    for idx in int_indices:
+        val = round(x_master[idx])
+        sub_lb[idx] = val
+        sub_ub[idx] = val
+
+    # Rigorous only when there is no continuous freedom left: every variable is
+    # pinned (lb == ub). Otherwise a violation at one point proves nothing.
+    if not np.all(sub_lb >= sub_ub - 1e-12):
+        return False
+
+    if evaluator.n_constraints == 0:
+        return False  # no constraints ⇒ the fixed point is feasible, not infeasible
+
+    try:
+        from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+        cl, cu = _infer_constraint_bounds(evaluator._model)
+        x_point = np.array(
+            [0.5 * (sub_lb[i] + sub_ub[i]) for i in range(evaluator.n_variables)],
+            dtype=np.float64,
+        )
+        cons = np.asarray(evaluator.evaluate_constraints(x_point), dtype=np.float64)
+        if not np.all(np.isfinite(cons)):
+            return False  # cannot certify on non-finite constraint values
+        return bool(np.any(cons < cl - tol) or np.any(cons > cu + tol))
+    except Exception:
+        # Any failure to rigorously evaluate ⇒ do NOT claim infeasibility.
+        return False
+
+
 def _solve_feasibility_subproblem(evaluator, lb, ub, int_indices, x_master, nlp_solver):
     """Solve feasibility problem with fixed integers.
 
@@ -416,6 +468,11 @@ def _add_ecp_cuts(
         n_added += 1
 
     return n_added
+
+
+def _int_config_key(x_master, int_indices) -> tuple[int, ...]:
+    """Canonical hashable key for the integer part of a master solution."""
+    return tuple(int(round(x_master[idx])) for idx in int_indices)
 
 
 def _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars):
@@ -718,6 +775,15 @@ def solve_oa(
     incumbent = None
     incumbent_obj = None
 
+    # C-35: integer configurations whose fixed-integer NLP subproblem failed to
+    # resolve *non-rigorously* (diverged / iteration limit / error). A local NLP
+    # failure is NOT a proof of infeasibility, so we must NOT exclude such a
+    # configuration with a no-good cut. We track them to (a) refuse to certify the
+    # final result and (b) break the loop soundly if the master re-proposes an
+    # already-unresolved configuration (would otherwise cycle forever, since we no
+    # longer emit the anti-cycling no-good cut for it).
+    unresolved_int_configs: set[tuple[int, ...]] = set()
+
     if x_relax is not None:
         _add_oa_cuts(
             evaluator,
@@ -891,7 +957,18 @@ def solve_oa(
                 equality_relaxation=equality_relaxation,
             )
         else:
-            # NLP infeasible for this integer assignment
+            # C-35: the fixed-integer NLP subproblem returned no feasible point.
+            # A no-good (integer-exclusion) cut is only SOUND when this integer
+            # configuration is RIGOROUSLY infeasible/dominated. A local NLP that
+            # merely failed to converge (diverged / iteration limit / error) is
+            # NOT such a proof — the NLP layer never emits a rigorous
+            # infeasibility verdict (see nlp_ipopt._IPOPT_STATUS_MAP, which maps
+            # Infeasible_Problem_Detected to ERROR because IPOPT sees only
+            # *local* infeasibility). So we split on a rigorous check.
+            rigorously_infeasible = _fixed_subproblem_rigorously_infeasible(
+                evaluator, decomp.lb, decomp.ub, decomp.int_indices, x_master
+            )
+
             if feasibility_cuts:
                 x_feas = _solve_feasibility_subproblem(
                     evaluator,
@@ -912,10 +989,7 @@ def solve_oa(
                         decomp.oa_constraint_mask,
                     )
 
-            # Always add no-good cut as fallback to avoid cycling
-            _add_no_good_cut(x_master, decomp.int_indices, oa_A_rows, oa_b_rows, n_vars)
-
-            # Also add OA cuts at master point
+            # OA cuts at master point (valid supporting linearizations either way).
             _add_oa_cuts(
                 evaluator,
                 x_master,
@@ -929,6 +1003,28 @@ def solve_oa(
                 decomp.oa_objective_is_convex,
                 equality_relaxation=equality_relaxation,
             )
+
+            if rigorously_infeasible:
+                # Proven infeasible ⇒ the no-good cut is valid (and doubles as the
+                # anti-cycling exclusion). Certification is preserved.
+                _add_no_good_cut(x_master, decomp.int_indices, oa_A_rows, oa_b_rows, n_vars)
+            else:
+                # Non-rigorous failure ⇒ do NOT exclude this configuration (that
+                # could cut off a feasible/optimal assignment). Record it as
+                # unresolved so the result is not certified, and break soundly if
+                # the master re-proposes it (would otherwise cycle without the
+                # anti-cycling no-good cut).
+                config_key = _int_config_key(x_master, decomp.int_indices)
+                already_seen = config_key in unresolved_int_configs
+                unresolved_int_configs.add(config_key)
+                if already_seen:
+                    logger.info(
+                        "OA: integer configuration %s unresolved by NLP "
+                        "(non-rigorous failure) and re-proposed; stopping without "
+                        "a no-good cut (result not certified)",
+                        config_key,
+                    )
+                    break
 
         # d. Check convergence
         gap = _compute_gap(LB, UB)
@@ -950,8 +1046,16 @@ def solve_oa(
     bound = LB if decomp.master_bound_valid and LB > -1e19 else None
     reported_gap = gap if bound is not None and UB < 1e19 else None
 
+    # C-35: if any integer configuration was left unresolved by a non-rigorous
+    # NLP failure, the search is incomplete — we deliberately did NOT exclude
+    # those configurations, so neither optimality nor infeasibility is proved.
+    # Downgrade certification; never report a *certified* "infeasible" in this
+    # state (an unresolved configuration might be the feasible/optimal one).
+    has_unresolved = len(unresolved_int_configs) > 0
+
     if incumbent is not None and incumbent_obj is not None:
-        status = "optimal" if gap <= gap_tolerance else "feasible"
+        certified = (gap <= gap_tolerance) and not has_unresolved
+        status = "optimal" if certified else "feasible"
         return SolveResult(
             status=status,
             objective=_obj_sign * incumbent_obj,
@@ -959,6 +1063,21 @@ def solve_oa(
             gap=reported_gap,
             x=_build_x_dict(incumbent, model),
             wall_time=wall_time,
+            gap_certified=not has_unresolved,
+        )
+
+    if has_unresolved:
+        # No feasible incumbent AND unresolved configurations: we cannot certify
+        # infeasibility (a merely-diverged subproblem is not a proof). Report an
+        # uncertified, inconclusive status instead of a false "infeasible".
+        return SolveResult(
+            status="unknown",
+            objective=None,
+            bound=(_obj_sign * bound if bound is not None else None),
+            gap=None,
+            x={},
+            wall_time=wall_time,
+            gap_certified=False,
         )
 
     return SolveResult(

--- a/python/tests/test_c35_oa_nogood_nlp_failure.py
+++ b/python/tests/test_c35_oa_nogood_nlp_failure.py
@@ -1,0 +1,149 @@
+"""C-35 regression: OA/LOA must NOT emit an unconditional no-good cut on a
+*non-rigorous* NLP failure.
+
+A no-good (integer-exclusion) cut permanently removes an integer configuration.
+It is only sound when that configuration is *rigorously* proved
+infeasible/dominated. The fixed-integer NLP subproblem in the OA/LOA paths is a
+*local* solver that never returns a rigorous infeasibility verdict (see
+``nlp_ipopt._IPOPT_STATUS_MAP`` — ``Infeasible_Problem_Detected`` maps to
+``ERROR``, precisely because IPOPT sees only *local* infeasibility). Treating
+"the NLP failed to converge" as "this configuration is infeasible" can:
+
+  * exclude the optimal configuration -> a **false optimal** at a worse config, or
+  * exclude every feasible configuration -> a **false infeasible**.
+
+These tests drive the exact false-certificate class by monkeypatching the NLP
+subproblem to fail non-rigorously (as a diverged / iteration-limited local NLP
+would) and assert the OA/LOA path NEVER returns a *certified* optimal/infeasible
+that excluded a feasible/optimal integer assignment. They call ``solve_oa`` /
+``solve_gdpopt_loa`` directly (sub-second, no full B&B) and use the default
+``milp_solver="auto"`` (in-house Rust simplex), so they run in CI without highspy.
+
+Before the fix these assertions FAIL (status "infeasible"/"optimal", cert=True);
+after the fix the path abstains (uncertified) and never excludes the config.
+"""
+
+import discopt.modeling as dm
+import discopt.solvers.gdpopt_loa as loa_mod
+import discopt.solvers.oa as oa_mod
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def _feasible_binary_model():
+    """min (x-0.5)^2 + c*y,  x in [0,1], y in {0,1}, x + y >= 0.3.
+
+    Feasible for both y=0 (x>=0.3) and y=1. With c>0 the true optimum is
+    y=0, x=0.5, obj=0. A model that is unambiguously feasible.
+    """
+    m = dm.Model("c35")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    y = m.binary("y")
+    m.minimize((x - 0.5) ** 2 + 3.0 * y)
+    m.subject_to(x + y >= 0.3)
+    return m
+
+
+def test_oa_no_false_infeasible_on_nonrigorous_nlp_failure(monkeypatch):
+    """Every NLP fails non-rigorously -> OA must NOT certify infeasible.
+
+    The model is feasible. If the NLP relaxation and every fixed-integer NLP
+    subproblem merely *fail* (diverge), OA previously emitted no-good cuts that
+    excluded every configuration and returned a certified ``infeasible``. That
+    is a false infeasible.
+    """
+    # Simulate a global non-rigorous NLP failure (no rigorous infeasibility).
+    monkeypatch.setattr(oa_mod, "_solve_nlp_relaxation", lambda *a, **k: (None, None))
+    monkeypatch.setattr(oa_mod, "_solve_nlp_subproblem", lambda *a, **k: (None, None))
+
+    result = oa_mod.solve_oa(_feasible_binary_model(), time_limit=30, max_iterations=50)
+
+    # The model is feasible: OA must never claim CERTIFIED infeasibility here.
+    assert result.status != "infeasible", (
+        "OA reported a false 'infeasible' on a feasible model whose NLPs merely "
+        "failed non-rigorously (no-good cut excluded feasible configurations)"
+    )
+    # Whatever it reports, it must not be certified.
+    assert result.gap_certified is False
+
+
+def test_oa_no_false_optimal_when_optimal_config_nlp_fails(monkeypatch):
+    """Only the optimal config's NLP fails -> OA must NOT certify a worse optimum.
+
+    y=0 is optimal (obj 0); y=1 is feasible but suboptimal (obj ~3). If the NLP
+    for the optimal config y=0 fails non-rigorously, OA previously excluded y=0
+    with a no-good cut and certified the suboptimal y=1 as ``optimal`` -> a false
+    optimal. After the fix it must not certify optimality at the worse value.
+    """
+    orig_sub = oa_mod._solve_nlp_subproblem
+
+    def failing_sub(evaluator, lb, ub, int_indices, x_master, nlp_solver):
+        y_val = int(round(x_master[int_indices[0]]))
+        if y_val == 0:  # optimal configuration's NLP "diverges"
+            return None, None
+        return orig_sub(evaluator, lb, ub, int_indices, x_master, nlp_solver)
+
+    # No early integer-feasible incumbent from the relaxation.
+    monkeypatch.setattr(oa_mod, "_solve_nlp_relaxation", lambda *a, **k: (None, None))
+    monkeypatch.setattr(oa_mod, "_solve_nlp_subproblem", failing_sub)
+
+    result = oa_mod.solve_oa(_feasible_binary_model(), time_limit=30, max_iterations=50)
+
+    # Must not certify OPTIMAL at the suboptimal objective (~3) by excluding y=0.
+    if result.status == "optimal":
+        assert result.objective is not None and result.objective < 1.0, (
+            "OA certified 'optimal' at a suboptimal objective after excluding the "
+            f"true-optimal config y=0 via a no-good cut (obj={result.objective})"
+        )
+    # An uncertified/abstaining outcome is the correct behavior here.
+    assert not (result.status == "optimal" and result.gap_certified)
+
+
+def test_oa_certifies_when_infeasible_config_is_rigorous():
+    """All-integer model: an infeasible config IS rigorously provable.
+
+    ``max x+y s.t. x^2+y^2 <= 10``, x,y integers. The config (0,4) has
+    x^2+y^2=16 > 10 — infeasible — but with all variables fixed the constraint
+    check is a *complete*, rigorous feasibility test, so the no-good cut is
+    valid and OA may (and must be able to) certify optimality at the true max=4.
+    This locks the rigorous branch: the C-35 fix must NOT over-abstain when the
+    exclusion is genuinely provable.
+    """
+    m = dm.Model("oa_int_rigorous")
+    x = m.integer("x", lb=0, ub=5)
+    y = m.integer("y", lb=0, ub=5)
+    m.maximize(x + y)
+    m.subject_to(x**2 + y**2 <= 10)
+    result = oa_mod.solve_oa(m, time_limit=30, max_iterations=50)
+    assert result.status == "optimal", (
+        "OA over-abstained on an all-integer model where the infeasible "
+        "configuration is rigorously provable (certification lost)"
+    )
+    assert result.objective == pytest.approx(4.0, abs=1e-3)
+    assert result.gap_certified is True
+
+
+def _feasible_binary_loa_model():
+    m = dm.Model("c35_loa")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    y = m.binary("y")
+    m.minimize((x - 0.5) ** 2 + 3.0 * y)
+    m.subject_to(x + y >= 0.3)
+    return m
+
+
+def test_loa_no_false_infeasible_on_nonrigorous_nlp_failure(monkeypatch):
+    """LOA path: same class — a non-rigorous NLP failure must not certify infeasible."""
+    monkeypatch.setattr(loa_mod, "_solve_nlp_relaxation", lambda *a, **k: None)
+    monkeypatch.setattr(loa_mod, "_solve_nlp_subproblem", lambda *a, **k: None)
+
+    result = loa_mod.solve_gdpopt_loa(
+        _feasible_binary_loa_model(), time_limit=30, max_iterations=50
+    )
+
+    assert result.status != "infeasible", (
+        "LOA reported a false 'infeasible' on a feasible model whose NLPs merely "
+        "failed non-rigorously"
+    )
+    assert result.gap_certified is False


### PR DESCRIPTION
## C-35 (P1) — OA/LOA emits an unconditional no-good cut on non-rigorous NLP failure

Fixes correctness backlog item **C-35** (`docs/dev/correctness-issues.md`).
Opt-in OA/ECP/LOA solve paths only (not the default B&B).

### Bug (confirmed)

The OA/LOA loops emitted an **unconditional** integer no-good (exclusion) cut
whenever the fixed-integer NLP subproblem returned no feasible point. That branch
collapses *every* non-optimal outcome (diverged / iteration-limit-without-feasible
/ error / exception) to `(None, None)` and treated it as "this configuration is
infeasible".

A local NLP failure is not a proof of infeasibility. The NLP layer never even
produces a rigorous infeasible verdict — `nlp_ipopt._IPOPT_STATUS_MAP` maps IPOPT
status 2 `Infeasible_Problem_Detected` → `ERROR` because IPOPT sees only *local*
infeasibility — so **every** no-good cut in this branch was unsound.

Confirmed both false-certificate classes on a direct `solve_oa` repro
(monkeypatching the subproblem to fail non-rigorously, as a diverged NLP does):

| repro | pre-fix | post-fix |
|---|---|---|
| feasible model, all NLPs fail | `status="infeasible"`, `gap_certified=True` (**false infeasible**) | `status="unknown"`, `gap_certified=False` |
| only the optimal config's NLP fails | `status="optimal"`, `objective=3.0` (suboptimal, **false optimal**) | `status="unknown"`, `gap_certified=False` |

### Fix

`python/discopt/solvers/oa.py`, `python/discopt/solvers/gdpopt_loa.py`:

- Added `_fixed_subproblem_rigorously_infeasible(...)` — a **sufficient, rigorous**
  infeasibility test. Current rule: when there are no free continuous variables
  left (all vars pinned), the fixed point is the sole candidate, so a constraint
  violation there is a complete proof of infeasibility.
- The no-good cut is emitted **only** when that test passes → certification is
  preserved for genuinely-provable exclusions (e.g. all-integer models).
- On a non-rigorous failure the cut is **withheld**; the configuration is recorded
  as unresolved (OA gradient cuts at the master point are still added — those never
  cut off a feasible point); the loop breaks soundly if the master re-proposes an
  unresolved config (anti-cycling without exclusion); and the result is downgraded:
  `gap_certified=False`, never a certified `optimal`, and never a certified
  `infeasible` (returns `status="unknown"` when there is no incumbent).
- No rigorous check was weakened.

### Scope note

The fix showed the bug is slightly broader than the card framing: OA's `optimal`
certification on ordinary MINLPs with an infeasible integer config was also resting
on the unsound no-good logic. The rigorous no-continuous-freedom check preserves
certification for those — the one existing test that momentarily flipped
`optimal`→`feasible` (`test_oa_maximize_linear_objective_is_not_the_minimum`) is
green again. Blast radius was a single test; the OA convergence guarantee is not
touched broadly (no escalation needed). A more general rigorous infeasibility
prover (interval/FBBT over the fixed box; feasibility-restoration certificate) is a
follow-on that would let the no-good cut fire in more cases — not required for
soundness, since withholding is always sound.

### Tests / gates

- New: `python/tests/test_c35_oa_nogood_nlp_failure.py` — 4 `@pytest.mark.smoke`
  tests, sub-second, call `solve_oa` / `solve_gdpopt_loa` directly. **Red before**
  the fix (3 fail), **green after** (4 pass). Covers: no false infeasible (OA+LOA),
  no false optimal (OA), and certification preserved when the infeasible config is
  rigorously provable.
- `pytest -m smoke`: 197 passed, 1 skipped.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: 10 passed.
- `pytest -k "oa or loa or gdpopt or nogood or benders"`: 165 passed, 2 skipped.
- `ruff check` / `ruff format`: clean. `mypy` on changed files: clean.
- No Rust touched (pure Python) → `cargo test` not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
