### PR TITLE
cert:P4 — exact Q-matrix extraction (+ flagged PSD convexity path)

### DIFF
--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -135,7 +135,8 @@ experiment may run.
 | Phase 4 re-profile (entry experiment) | done — **rank recorded** | #442 | 8 run / 0 skipped. Ranked build order: **1) CSE (op-dup 31–37% on nvs17/clay), 2) Q-extraction (coupled to CSE), 3) V-segments DE-PRIORITIZED (0 defvars in all 1,558 text `.nl`; defined-var-heavy set is binary-`.nl` discopt can't parse), 4) symmetry DO-NOT-BUILD (0 orbits)**. CC5 FALSIFIED (XLA ≤1.2% of wall); dominant wall = separation. See §8 "Phase 4 — re-profile results" |
 | Phase 4 T-CSE/V-segments | **CSE unlocked; V-segments/symmetry de-scoped** (§0.1.2) | — | build order fixed by the re-profile above; CSE first (bound-neutral), Q-extraction second |
 | Phase 4 build 1 — CSE/hash-consing | **done — bound-neutral** | (this PR) | Content-addressed interning in `ExprArena` (`expr.rs`), wired into the `.nl` parser and Python `convert_expr`. DAG node count ↓ **68.9% nvs17, 64.8% clay0303hfsg, 34.2% ex1252, 34.0% casctanks, 0.0% gear4** (panel total −48.4%); gear4 0% confirms the re-profile prediction. Cert-neutrality **NEUTRAL** (42 certifying instances, node_count exactly unchanged, objective to tol). See §8 "Phase 4 CSE — build results" |
-| Phase 4 items 2–4 (V-segments, Q-extract, symmetry) | **locked** (§0.1.2) | — | independent; item 2 (V-segments) is the natural follow-on |
+| Phase 4 build 3 — Q-matrix extraction | **done — (A) bound-neutral, (B) flagged bound-changing** | (this PR) | Exact `extract_quadratic(expr,n,model)` in `quadratic_form.py` (exact-or-abstain, validated 1e-12 on 250 pts/inst + 14 non-quadratic rejections). Consumer: PSD-on-Q convexity certificate wired into `certify_convex` behind `DISCOPT_PSD_QFORM` (**default-OFF**); sound tightening, never mis-certifies (30 indefinite-Q seeds), strict refinement of the rigorous path. Flag-off is byte-identical → cert-neutral. See §8 "Phase 4 Q-extraction — build results" |
+| Phase 4 items 2 & 4 (V-segments, symmetry) | **locked / de-scoped** (§0.1.2) | — | V-segments de-prioritized (0 defvars in text `.nl`); symmetry DO-NOT-BUILD (0 orbits) per the re-profile. RLT/edge-concave rewire onto `extract_quadratic` scoped as bound-neutral follow-on |
 | Phase 5 | **locked** (§0.1.2) | — | requires post-Phase-1 re-profile |
 
 **Phase 0 — DONE & gated** (cert0 green: root_gap coverage 0.909 ≥ 0.90, incorrect 0).
@@ -1045,6 +1046,71 @@ tolerance. `cargo test -p discopt-core` green (incl. `presolve_determinism`, 4/4
 `cargo clippy --lib` clean, the new CSE unit/property tests pass. Because the interner
 only merges structurally-identical nodes, the relaxation math is bit-for-bit the same
 — the smaller arena is a representation change, not a math change.
+
+### Phase 4 Q-extraction — build results (2026-07-03)
+
+Built **build item 3** (ranked #2 by the re-profile): exact Q-matrix coefficient
+extraction in the IR, plus the first sound consumer (the PSD-on-Q convexity
+certificate). Two clearly separated correctness regimes, per §3 / CLAUDE.md §5.
+
+**(A) Exact extraction — BOUND-NEUTRAL foundation.**
+`python/discopt/_jax/quadratic_form.py`: `extract_quadratic(expr, n, model) ->
+Optional[(Q, c, d)]` returns the symmetric `Q`, linear `c`, constant `d` with
+`expr == xᵀQx + cᵀx + d` **exactly, or `None`** (abstain). It layers on the
+existing trusted polynomial walker `milp_relaxation._expr_to_polynomial`
+(fed `term_classifier.distribute_products`) — the same machinery the edge-concave
+collector already uses — and additionally rejects any degree-≥3 monomial. Flat
+indexing is the identical prefix-sum layout the convexity certificate uses
+(`interval_ad._var_offset` == `term_classifier._compute_var_offset`), so a `Q`
+here is directly consistent with `certify_convex`'s coordinate system. Symmetric
+split: `Q_ij = Q_ji = ½·coeff` (i≠j), `Q_ii = coeff`. Helpers `quadratic_is_psd`
+/ `quadratic_is_nsd` do the exact `eigvalsh` test.
+
+*Validation (`test_quadratic_form.py`, 39 tests):* random quadratics reconstruct
+to **1e-12 on 250 points/instance** across 12 seeds; the symmetric-split, affine,
+and constant sub-cases are pinned; **14 non-quadratic shapes** (cube, quartic,
+trilinear, `x²·y`, exp/log/sin/sqrt, bilinear-with-transcendental, var-in-
+denominator, fractional power, `abs`, reciprocal) all return `None` — never a
+mis-extracted `Q`; out-of-range flat index abstains; PSD/NSD helpers match
+`eigvalsh` on 20 random symmetric matrices.
+
+**(B) Convexity certificate via PSD-on-Q — BOUND-CHANGING, flag default-OFF.**
+Wired into `convexity/certificate.py::certify_convex` behind
+**`DISCOPT_PSD_QFORM`** (default `0`). On a purely quadratic body the Hessian is
+the *constant* matrix `2·Q`, so `λ_min(Q) ≥ 0` is a rigorous, box-independent
+convexity proof — strictly tighter than the conservative interval-Hessian +
+Gershgorin row-sum enclosure (which abstains on tight-but-PSD matrices, e.g.
+`Q` with all off-diagonals 0.99, `λ_min≈0.01`). On any abstention (non-quadratic
+body, indefinite `Q`, non-finite `Q`) it returns `None` and **falls through to the
+existing rigorous path unchanged** — it never assumes convex. Because it can prove
+*more* bodies convex, it changes node relaxations/counts → shipped behind a flag
+per the bound-changing regime.
+
+*Differential/soundness result (`test_psd_qform_convexity.py`, 78 pass / 4 skip):*
+(1) **No mis-certification** — 30 random *indefinite* `Q` (both eigen-signs,
+away from 0) never read as CONVEX/CONCAVE with the flag ON. (2) **Strict
+refinement** — over 30 random PSD/NSD/indefinite cases the flag-ON verdict never
+flips a flag-OFF verdict; it only turns `None` into a verdict, and always agrees
+with a direct `eigvalsh` check (20 seeds). (3) **Non-quadratic bodies are
+identical on/off** (flag only touches the purely quadratic case). (4) Flag default
+reproduces the conservative abstention. Full `-k "convex or quadratic or rlt or
+edge_concave or qmatrix or psd"` suite: **786 pass / 5 skip / 2 xfail** with the
+flag default-off.
+
+**Bound-neutrality of the default (flag OFF):** the PSD path is behind
+`_psd_qform_enabled()` (only active when `DISCOPT_PSD_QFORM ∈ {1,true,yes,on}`), so
+with the flag unset `certify_convex` is byte-for-byte the prior function — the
+`check_cert_neutrality.py` panel is unaffected. Enabling and validating on nightlies
+(differential-bound + feasible-point + `incorrect_count=0`) is the follow-on before
+default-on.
+
+**Scoped as follow-on (proven partial > unproven whole, §8):** RLT and edge-concave
+already extract quadratic coefficients via `_expr_to_polynomial` (`edge_concave.py::
+collect_edge_concave_quadratics`, `rlt_cuts.py`), so rerouting them through
+`extract_quadratic` would at best be a bound-neutral refactor with no payoff (same
+coefficients, same verdict) and at worst risk a subtle drift; it is not shipped in
+this PR. The value there is a *faster path to the same relaxation*, which must be
+proven exactly bound-neutral (node_count/objective unchanged) — a separate task.
 
 ---
 

--- a/python/discopt/_jax/convexity/certificate.py
+++ b/python/discopt/_jax/convexity/certificate.py
@@ -29,6 +29,7 @@ Adjiman, Dallwig, Floudas, Neumaier (1998), "αBB — I. Theoretical
 
 from __future__ import annotations
 
+import os
 from typing import Optional
 
 import numpy as np
@@ -44,6 +45,70 @@ from .lattice import Curvature
 # interval Hessian already outward-rounds, so genuine zero eigenvalues
 # may appear as small negatives; a very tight tolerance suffices.
 _PSD_TOL = 1e-10
+
+
+def _psd_qform_enabled() -> bool:
+    """Whether the exact PSD-on-Q convexity fast path is active.
+
+    **Default OFF** (Phase 4 item 3, bound-changing regime — CLAUDE.md §5).
+    The path is a *sound tightening*: on a purely quadratic body the
+    Hessian is the constant matrix ``2·Q``, so an exact eigenvalue PSD
+    test on ``Q`` certifies convexity rigorously where the conservative
+    interval-Hessian + Gershgorin row-sum enclosure would abstain. It can
+    therefore prove *more* constraints/objectives convex, which changes
+    node relaxations and counts — hence it ships behind a flag,
+    default-off until validated on consecutive nightly runs.
+
+    Enable with ``DISCOPT_PSD_QFORM=1`` (also ``true``/``yes``/``on``).
+    """
+    return os.environ.get("DISCOPT_PSD_QFORM", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _certify_quadratic_psd(expr: Expression, model: Model) -> Optional[Curvature]:
+    """Exact convexity verdict for a *purely quadratic* body, or ``None``.
+
+    Returns ``Curvature.CONVEX`` when the body ``xᵀ Q x + cᵀ x + d`` has
+    ``Q ⪰ 0`` (Hessian ``2·Q ⪰ 0`` — convex everywhere, box-independent),
+    ``Curvature.CONCAVE`` when ``Q ⪯ 0``, and ``None`` in every other
+    case: the body is not purely quadratic (extraction abstained), ``Q``
+    is indefinite, or ``Q`` is not numerically usable. ``None`` means "I
+    cannot certify from Q" — the caller MUST then fall back to the
+    existing rigorous interval-Hessian path; it must never assume convex.
+
+    This is sound because extraction is exact-or-abstain: a returned
+    ``(Q, c, d)`` reproduces the body identically (verified to 1e-12 on
+    random points in ``test_quadratic_form.py``), so ``2·Q`` *is* the
+    body's Hessian — no enclosure, no looseness.
+    """
+    # Local import: keep the convexity package import-light and avoid any
+    # cycle with the broader _jax package that quadratic_form pulls in.
+    from discopt._jax.quadratic_form import (
+        extract_quadratic,
+        quadratic_is_nsd,
+        quadratic_is_psd,
+    )
+
+    n = sum(v.size for v in model._variables)
+    res = extract_quadratic(expr, n, model)
+    if res is None:
+        # Not purely quadratic — abstain; caller uses the rigorous path.
+        return None
+    Q, _c, _d = res
+
+    is_psd = quadratic_is_psd(Q, tol=_PSD_TOL)
+    if is_psd is True:
+        return Curvature.CONVEX
+    is_nsd = quadratic_is_nsd(Q, tol=_PSD_TOL)
+    if is_nsd is True:
+        return Curvature.CONCAVE
+    # Indefinite, or Q unusable (non-finite) — abstain to the rigorous
+    # path rather than claim anything.
+    return None
 
 
 def certify_convex(
@@ -70,6 +135,20 @@ def certify_convex(
           ``None`` is a deliberate abstention — the caller must treat
           the expression as non-convex.
     """
+    # Exact PSD-on-Q fast path (Phase 4 item 3, flag default-OFF). When a
+    # body is *purely quadratic*, its Hessian is the constant matrix
+    # ``2·Q`` and an exact eigenvalue test on ``Q`` certifies convexity
+    # rigorously — strictly tighter than (and never looser than) the
+    # interval-Hessian + Gershgorin enclosure below. On abstention
+    # (non-quadratic body, indefinite Q, or unusable Q) this returns
+    # ``None`` and we fall through to the rigorous path unchanged. The
+    # verdict is box-independent, so the ``box`` argument does not affect
+    # it (a global quadratic convexity proof holds on every sub-box).
+    if _psd_qform_enabled():
+        q_verdict = _certify_quadratic_psd(expr, model)
+        if q_verdict is not None:
+            return q_verdict
+
     try:
         ad = interval_hessian(expr, model, box=box)
     except ValueError:

--- a/python/discopt/_jax/quadratic_form.py
+++ b/python/discopt/_jax/quadratic_form.py
@@ -1,0 +1,220 @@
+"""Exact quadratic (Q-matrix) coefficient extraction from the expression IR.
+
+This module upgrades the notion of "quadratic" from a *degree check*
+(``ExprArena::is_quadratic`` in Rust — ``max_degree <= 2``, a yes/no
+predicate) to an *exact coefficient extraction*: given a scalar
+expression, recover the symmetric matrix ``Q``, the linear vector ``c``
+and the constant ``d`` such that
+
+    expr(x) == xᵀ Q x + cᵀ x + d      (exactly, for all x)
+
+or return ``None`` when the expression is not purely quadratic.
+
+Design rules (binding — see ``docs/dev/certification-gap-plan.md`` §8
+Phase 4 item 3, and CLAUDE.md §5 on the two verification regimes):
+
+* **Exact or abstain.** The extraction is a *recognition*. It either
+  returns coefficients that reproduce the expression bit-for-bit (up to
+  floating-point evaluation order), or it returns ``None``. It NEVER
+  returns an approximate ``Q``. A degree-3+ monomial, a transcendental,
+  a variable in a denominator, a fractional power, an unsupported atom
+  — any of these make the whole expression non-(purely-)quadratic and
+  the function abstains.
+
+* **Trusted foundation.** Extraction is layered on the existing,
+  tested polynomial walker
+  :func:`discopt._jax.milp_relaxation._expr_to_polynomial` (fed the
+  :func:`discopt._jax.term_classifier.distribute_products` normal form),
+  the same machinery the edge-concave collector already relies on. That
+  walker returns ``None`` on any non-polynomial leaf; we additionally
+  reject any monomial of degree > 2. The flat variable indexing is the
+  identical prefix-sum layout used by the convexity certificate
+  (``interval_ad._var_offset`` == ``term_classifier._compute_var_offset``),
+  so a ``Q`` produced here is directly consistent with the coordinate
+  system :func:`discopt._jax.convexity.certificate.certify_convex` works
+  in.
+
+* **Symmetric-split convention.** For a cross term ``b·x_i·x_j`` with
+  ``i != j`` we set ``Q[i,j] = Q[j,i] = b/2`` so that the quadratic form
+  ``xᵀ Q x`` reproduces ``b·x_i·x_j`` (the form contributes
+  ``Q[i,j]·x_i·x_j + Q[j,i]·x_j·x_i = 2·Q[i,j]·x_i·x_j``). For a square
+  ``a·x_i²`` we set ``Q[i,i] = a`` (``xᵀ Q x`` contributes
+  ``Q[i,i]·x_i²`` directly).
+
+The Hessian of ``xᵀ Q x + cᵀ x + d`` is the constant matrix ``2·Q``.
+That is the payoff for the convexity certificate: on a *purely
+quadratic* body the Hessian is constant, so an exact PSD test on ``Q``
+(``λ_min(Q) >= 0``) is a rigorous, box-independent convexity proof —
+strictly tighter than the conservative interval-Hessian + Gershgorin
+row-sum enclosure, which can abstain on an indefinite-looking but
+genuinely PSD matrix.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from discopt.modeling.core import Expression, Model
+
+
+def extract_quadratic(
+    expr: Expression, n: int, model: Model
+) -> Optional[tuple[np.ndarray, np.ndarray, float]]:
+    """Extract ``(Q, c, d)`` with ``expr == xᵀ Q x + cᵀ x + d``, or ``None``.
+
+    Args:
+        expr: A scalar :class:`~discopt.modeling.core.Expression`.
+        n: The flat variable count (dimension of ``x``). ``Q`` is
+            ``(n, n)`` and ``c`` is ``(n,)``; monomials must reference
+            flat indices in ``[0, n)``.
+        model: The model defining the flat variable layout (prefix-sum
+            over ``model._variables`` by declaration order — the same
+            layout the convexity certificate uses).
+
+    Returns:
+        A tuple ``(Q, c, d)`` where ``Q`` is a symmetric ``float64``
+        ``(n, n)`` array, ``c`` is a ``float64`` ``(n,)`` array and
+        ``d`` is a Python ``float``, such that
+        ``expr(x) == x @ Q @ x + c @ x + d`` for every ``x``. Returns
+        ``None`` if the expression is not purely quadratic in the model's
+        original variables (a degree-≥3 term, a transcendental, a
+        variable-in-denominator, a fractional power, an unsupported atom,
+        or an out-of-range flat index).
+
+    Notes:
+        This is *exact-or-abstain*. It never returns an approximate
+        ``Q``. The returned ``Q`` is symmetric by construction (the
+        cross-coefficient ``b`` is split evenly onto ``Q[i,j]`` and
+        ``Q[j,i]``).
+    """
+    if n < 0:
+        return None
+
+    # Local imports: keep module import cheap and avoid any import cycle
+    # with milp_relaxation (which imports broadly from the _jax package).
+    from discopt._jax.milp_relaxation import _expr_to_polynomial
+    from discopt._jax.term_classifier import distribute_products
+
+    try:
+        poly = _expr_to_polynomial(distribute_products(expr), model)
+    except Exception:
+        # The trusted walker abstains loudly on shapes it cannot reduce
+        # (array variables, etc.). Treat any failure as "not recognized"
+        # — abstain rather than guess.
+        return None
+
+    if poly is None:
+        return None
+
+    const, terms = poly
+
+    Q = np.zeros((n, n), dtype=np.float64)
+    c = np.zeros(n, dtype=np.float64)
+    d = float(const)
+
+    for coeff, monomial in terms:
+        degree = len(monomial)
+        if degree == 0:
+            # A degree-0 monomial (rare — constants normally fold into
+            # ``const``, but honor it if present).
+            d += float(coeff)
+        elif degree == 1:
+            i = int(monomial[0])
+            if not (0 <= i < n):
+                return None
+            c[i] += float(coeff)
+        elif degree == 2:
+            i, j = int(monomial[0]), int(monomial[1])
+            if not (0 <= i < n and 0 <= j < n):
+                return None
+            if i == j:
+                # a·x_i²  ->  Q[i,i] += a
+                Q[i, i] += float(coeff)
+            else:
+                # b·x_i·x_j (i != j)  ->  Q[i,j] = Q[j,i] += b/2
+                half = 0.5 * float(coeff)
+                Q[i, j] += half
+                Q[j, i] += half
+        else:
+            # Degree >= 3: not purely quadratic. Abstain — never
+            # mis-extract a higher-degree expression as quadratic.
+            return None
+
+    return Q, c, d
+
+
+def is_purely_quadratic(expr: Expression, n: int, model: Model) -> bool:
+    """Return ``True`` iff :func:`extract_quadratic` recognizes ``expr``.
+
+    A convenience predicate for callers that only need the yes/no verdict
+    (a *coefficient-backed* upgrade of the Rust degree check — this says
+    "quadratic AND exactly recoverable", where ``is_quadratic`` says only
+    "degree ≤ 2"). Purely quadratic includes the affine and constant
+    sub-cases (``Q == 0``).
+    """
+    return extract_quadratic(expr, n, model) is not None
+
+
+def quadratic_is_psd(Q: np.ndarray, tol: float = 1e-10) -> Optional[bool]:
+    """Exact PSD test on a symmetric ``Q``: ``True`` PSD, ``False`` not, ``None`` unusable.
+
+    Uses the symmetric eigenvalue decomposition (``numpy.linalg.eigvalsh``)
+    on ``½·(Q + Qᵀ)`` (the symmetric part; ``Q`` is already symmetric by
+    construction from :func:`extract_quadratic`, but symmetrizing is
+    defensive and free). A matrix is accepted as PSD when its minimum
+    eigenvalue is ``>= -tol``.
+
+    The ``tol`` slack absorbs floating-point round-off in the eigenvalue
+    routine only; it is a soundness *margin* the caller must reconcile
+    with its own certificate tolerance. Returns ``None`` if ``Q`` is not
+    finite (the eigen-decomposition would be meaningless), so the caller
+    can abstain to its existing rigorous path.
+
+    Args:
+        Q: A square, (approximately) symmetric matrix.
+        tol: Non-negative slack for accepting ``λ_min >= 0`` despite
+            round-off. Must match or be tighter than the caller's
+            certificate tolerance.
+
+    Returns:
+        ``True`` if ``Q`` is (numerically) PSD, ``False`` if it is
+        provably indefinite/negative, ``None`` if ``Q`` is not usable
+        (non-finite entries).
+    """
+    Qa = np.asarray(Q, dtype=np.float64)
+    if Qa.ndim != 2 or Qa.shape[0] != Qa.shape[1]:
+        return None
+    if not np.all(np.isfinite(Qa)):
+        return None
+    if Qa.shape[0] == 0:
+        # The zero-dimensional form xᵀ Q x with n == 0 is the constant 0,
+        # trivially PSD (convex).
+        return True
+    sym = 0.5 * (Qa + Qa.T)
+    lam_min = float(np.linalg.eigvalsh(sym)[0])
+    return lam_min >= -tol
+
+
+def quadratic_is_nsd(Q: np.ndarray, tol: float = 1e-10) -> Optional[bool]:
+    """Exact NSD (negative semidefinite) test — ``quadratic_is_psd(-Q)``.
+
+    ``True`` if ``Q`` is negative semidefinite (the form is concave),
+    ``False`` if not, ``None`` if unusable. Companion to
+    :func:`quadratic_is_psd` for certifying concavity.
+    """
+    Qa = np.asarray(Q, dtype=np.float64)
+    if Qa.ndim != 2 or Qa.shape[0] != Qa.shape[1]:
+        return None
+    if not np.all(np.isfinite(Qa)):
+        return None
+    return quadratic_is_psd(-Qa, tol=tol)
+
+
+__all__ = [
+    "extract_quadratic",
+    "is_purely_quadratic",
+    "quadratic_is_psd",
+    "quadratic_is_nsd",
+]

--- a/python/tests/test_psd_qform_convexity.py
+++ b/python/tests/test_psd_qform_convexity.py
@@ -1,0 +1,191 @@
+"""Soundness + differential tests for the flagged PSD-on-Q convexity path.
+
+This is the *bound-changing* regime gate (CLAUDE.md §5) for the Phase 4
+Q-extraction consumer wired into ``certify_convex``:
+
+``DISCOPT_PSD_QFORM=1`` enables an exact eigenvalue PSD test on the
+extracted ``Q`` of a purely quadratic body. Because the body's Hessian is
+the *constant* matrix ``2·Q``, this is a rigorous, box-independent
+convexity certificate that can prove convexity where the conservative
+interval-Hessian + Gershgorin row-sum enclosure abstains.
+
+The tests pin the two soundness obligations of a bound-changing flag:
+
+1. **No mis-certification.** For random *non-convex* (indefinite Q)
+   quadratics, the flagged path NEVER returns ``CONVEX`` (and never
+   ``CONCAVE`` for non-concave). This is the catastrophic failure mode
+   the flag must not have.
+2. **Strict tightening / never contradict.** For random quadratics, the
+   flag-ON verdict is (a) always a *refinement* of the flag-OFF verdict —
+   it only ever turns ``None`` into a verdict, never flips an existing
+   ``CONVEX``↔``CONCAVE`` — and (b) always agrees with a direct
+   ``numpy.linalg.eigvalsh`` check on the true Q.
+3. **Abstention on non-quadratic bodies is identical on/off** — the flag
+   only touches the purely quadratic case; everything else falls through
+   to the unchanged rigorous path.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.convexity.certificate import certify_convex
+from discopt._jax.convexity.lattice import Curvature
+
+
+@pytest.fixture
+def psd_qform_on(monkeypatch):
+    monkeypatch.setenv("DISCOPT_PSD_QFORM", "1")
+
+
+@pytest.fixture
+def psd_qform_off(monkeypatch):
+    monkeypatch.setenv("DISCOPT_PSD_QFORM", "0")
+
+
+def _quadratic_body_from_Q(x, Q: np.ndarray):
+    """Build the expression ``xᵀ Q x`` from a symmetric matrix ``Q``.
+
+    Uses squares for the diagonal and cross terms ``2·Q[i,j]·x_i·x_j``
+    for the strict upper triangle, so the resulting body's Hessian is
+    exactly ``2·Q``.
+    """
+    n = Q.shape[0]
+    body = 0.0 * x[0]
+    for i in range(n):
+        if Q[i, i] != 0.0:
+            body = body + float(Q[i, i]) * x[i] ** 2
+    for i in range(n):
+        for j in range(i + 1, n):
+            coeff = Q[i, j] + Q[j, i]  # = 2·Q[i,j] for symmetric Q
+            if coeff != 0.0:
+                body = body + float(coeff) * x[i] * x[j]
+    return body
+
+
+def _random_symmetric(rng, n, kind):
+    """Random symmetric Q of a requested definiteness ``kind``."""
+    A = rng.uniform(-2, 2, size=(n, n))
+    S = 0.5 * (A + A.T)
+    w, V = np.linalg.eigh(S)
+    if kind == "psd":
+        w = np.abs(w) + 1e-3
+    elif kind == "nsd":
+        w = -(np.abs(w) + 1e-3)
+    elif kind == "indef":
+        # Force at least one positive and one negative eigenvalue.
+        if n == 1:
+            return None  # cannot be indefinite in 1-D
+        w = np.abs(w) + 1e-2
+        w[0] = -(abs(w[0]) + 1e-2)
+    return (V * w) @ V.T
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("seed", range(30))
+def test_flag_on_never_miscertifies_indefinite(seed, psd_qform_on):
+    """The catastrophic case: an indefinite Q must never read as CONVEX/CONCAVE."""
+    rng = np.random.default_rng(4000 + seed)
+    n = int(rng.integers(2, 6))
+    Q = _random_symmetric(rng, n, "indef")
+    lam = np.linalg.eigvalsh(Q)
+    # Confirm genuinely indefinite (both signs present, away from zero).
+    assert lam.min() < -1e-6 and lam.max() > 1e-6
+
+    m = dm.Model("indef")
+    x = m.continuous("x", shape=(n,), lb=-1, ub=1)
+    body = _quadratic_body_from_Q(x, Q)
+
+    verdict = certify_convex(body, m)
+    assert verdict is None, f"indefinite Q (eig {lam}) must NOT be certified; got {verdict}"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("seed", range(20))
+def test_flag_on_agrees_with_eigvalsh(seed, psd_qform_on):
+    """PSD Q -> CONVEX, NSD Q -> CONCAVE, matching a direct eigen check."""
+    rng = np.random.default_rng(5000 + seed)
+    n = int(rng.integers(1, 6))
+
+    m = dm.Model("psd")
+    x = m.continuous("x", shape=(n,), lb=-1, ub=1)
+
+    Q_psd = _random_symmetric(rng, n, "psd")
+    body_psd = _quadratic_body_from_Q(x, Q_psd)
+    assert certify_convex(body_psd, m) == Curvature.CONVEX
+
+    Q_nsd = _random_symmetric(rng, n, "nsd")
+    body_nsd = _quadratic_body_from_Q(x, Q_nsd)
+    assert certify_convex(body_nsd, m) == Curvature.CONCAVE
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("seed", range(30))
+def test_flag_on_is_a_refinement_of_flag_off(seed, monkeypatch):
+    """ON verdict only ever turns OFF's ``None`` into a verdict; never flips one."""
+    rng = np.random.default_rng(6000 + seed)
+    n = int(rng.integers(1, 6))
+    kind = rng.choice(["psd", "nsd", "indef"])
+    Q = _random_symmetric(rng, n, kind)
+    if Q is None:
+        pytest.skip("1-D cannot be indefinite")
+
+    m = dm.Model("ref")
+    x = m.continuous("x", shape=(n,), lb=-1, ub=1)
+    body = _quadratic_body_from_Q(x, Q)
+
+    monkeypatch.setenv("DISCOPT_PSD_QFORM", "0")
+    off = certify_convex(body, m)
+    monkeypatch.setenv("DISCOPT_PSD_QFORM", "1")
+    on = certify_convex(body, m)
+
+    # A verdict under OFF must be preserved exactly under ON (never a flip).
+    if off is not None:
+        assert on == off, f"flag flipped a rigorous verdict {off} -> {on}"
+    # ON is at least as decisive as OFF (soundness of the tightening: it
+    # only adds verdicts, guaranteed by the eigen agreement test above).
+    lam = np.linalg.eigvalsh(Q)
+    if lam.min() >= -1e-10:
+        assert on == Curvature.CONVEX
+    elif lam.max() <= 1e-10:
+        assert on == Curvature.CONCAVE
+    else:
+        assert on is None
+
+
+@pytest.mark.unit
+def test_non_quadratic_body_identical_on_off(monkeypatch):
+    """Non-quadratic bodies fall through: verdict is unchanged by the flag."""
+    m = dm.Model("nq")
+    x = m.continuous("x", shape=(2,), lb=0.5, ub=3.0)
+    bodies = [
+        dm.exp(x[0]) + x[1] ** 2,  # convex (exp convex + convex sq)
+        dm.log(x[0]),  # concave
+        x[0] * x[1],  # bilinear, indefinite -> None
+        x[0] ** 3,  # cubic -> None
+        dm.sin(x[0]),  # neither
+    ]
+    for body in bodies:
+        monkeypatch.setenv("DISCOPT_PSD_QFORM", "0")
+        off = certify_convex(body, m)
+        monkeypatch.setenv("DISCOPT_PSD_QFORM", "1")
+        on = certify_convex(body, m)
+        assert off == on, f"flag changed a non-quadratic verdict: {off} -> {on}"
+
+
+@pytest.mark.unit
+def test_flag_default_off_is_conservative(monkeypatch):
+    """With no env override, the tight-but-Gershgorin-defeating PSD case abstains."""
+    monkeypatch.delenv("DISCOPT_PSD_QFORM", raising=False)
+    m = dm.Model("d")
+    x = m.continuous("x", shape=(3,), lb=-1, ub=1)
+    # Q with all off-diagonals 0.99: PSD (λ_min ≈ 0.01) but Gershgorin
+    # row-sum lower bound is negative, so the default path abstains.
+    body = (x[0] ** 2 + x[1] ** 2 + x[2] ** 2) + 2 * 0.99 * (
+        x[0] * x[1] + x[0] * x[2] + x[1] * x[2]
+    )
+    assert certify_convex(body, m) is None
+    # And ON certifies it.
+    monkeypatch.setenv("DISCOPT_PSD_QFORM", "1")
+    assert certify_convex(body, m) == Curvature.CONVEX

--- a/python/tests/test_quadratic_form.py
+++ b/python/tests/test_quadratic_form.py
@@ -1,0 +1,247 @@
+"""Property tests for exact Q-matrix extraction (``extract_quadratic``).
+
+The correctness contract (``docs/dev/certification-gap-plan.md`` §8 Phase 4
+item 3, CLAUDE.md §5): extraction is *exact or abstains*. These tests pin
+
+1. **Exactness.** For randomly generated quadratic expressions, the
+   reconstructed form ``xᵀ Q x + cᵀ x + d`` reproduces the original
+   expression identically on ≥ 200 random points to 1e-12.
+2. **Symmetric-split convention.** ``Q[i,j] == Q[j,i] == ½·coeff`` for a
+   cross term, ``Q[i,i] == coeff`` for a square.
+3. **Non-quadratic rejection.** Degree-3+ terms, transcendentals,
+   bilinear-with-transcendental, variable-in-denominator, fractional
+   powers, and `abs` all return ``None`` — never a mis-extracted ``Q``.
+4. **PSD / NSD helpers** agree with a direct eigenvalue computation.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.dag_compiler import compile_expression
+from discopt._jax.quadratic_form import (
+    extract_quadratic,
+    is_purely_quadratic,
+    quadratic_is_nsd,
+    quadratic_is_psd,
+)
+
+# Number of random evaluation points per expression (contract: >= 200).
+_N_POINTS = 250
+# Reconstruction tolerance (contract: 1e-12).
+_TOL = 1e-12
+
+
+def _reconstruct(Q: np.ndarray, c: np.ndarray, d: float, x: np.ndarray) -> float:
+    return float(x @ Q @ x + c @ x + d)
+
+
+def _random_quadratic_expr(rng: np.random.Generator, n: int):
+    """Build a random quadratic expression over ``n`` scalar variables.
+
+    Returns ``(model, var, expr, Q_true, c_true, d_true)`` where the
+    *_true arrays are the reference coefficients the expression encodes,
+    independent of ``extract_quadratic`` (so the test does not check the
+    function against itself).
+    """
+    m = dm.Model("q")
+    x = m.continuous("x", shape=(n,), lb=-3.0, ub=3.0)
+
+    Q_true = np.zeros((n, n))
+    c_true = np.zeros(n)
+    d_true = float(rng.uniform(-5, 5))
+
+    # Seed the sum with the first square so ``expr`` is an Expression from
+    # the start; fold the constant offset in afterwards (scalars wrap to a
+    # Constant via the operator overloads).
+    expr = 0.0 * x[0]
+
+    # Squares a_i x_i^2.
+    for i in range(n):
+        if rng.random() < 0.7:
+            a = float(rng.uniform(-4, 4))
+            Q_true[i, i] += a
+            expr = expr + a * x[i] ** 2
+
+    # Linear c_i x_i.
+    for i in range(n):
+        if rng.random() < 0.7:
+            b = float(rng.uniform(-4, 4))
+            c_true[i] += b
+            expr = expr + b * x[i]
+
+    # Cross terms b_ij x_i x_j (i < j).
+    for i in range(n):
+        for j in range(i + 1, n):
+            if rng.random() < 0.5:
+                b = float(rng.uniform(-4, 4))
+                Q_true[i, j] += 0.5 * b
+                Q_true[j, i] += 0.5 * b
+                expr = expr + b * x[i] * x[j]
+
+    expr = expr + d_true
+
+    return m, x, expr, Q_true, c_true, d_true
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("seed", range(12))
+def test_extract_quadratic_exact_reconstruction(seed):
+    """Random quadratics reconstruct to 1e-12 on >= 250 points."""
+    rng = np.random.default_rng(seed)
+    n = int(rng.integers(1, 6))
+    m, x, expr, Q_true, c_true, d_true = _random_quadratic_expr(rng, n)
+
+    res = extract_quadratic(expr, n, m)
+    assert res is not None, "purely quadratic expression must be recognized"
+    Q, c, d = res
+
+    # Q is symmetric by construction.
+    assert np.allclose(Q, Q.T, atol=0.0), "Q must be exactly symmetric"
+
+    # Coefficients match the independently-tracked reference.
+    assert np.allclose(Q, Q_true, atol=1e-12)
+    assert np.allclose(c, c_true, atol=1e-12)
+    assert abs(d - d_true) <= 1e-12
+
+    # Reconstruction identity on many random points, against the compiled
+    # DAG evaluator (the ground-truth evaluation of the original expr).
+    f = compile_expression(expr, m)
+    pts = rng.uniform(-3.0, 3.0, size=(_N_POINTS, n))
+    for k in range(_N_POINTS):
+        xv = pts[k]
+        original = float(f(xv))
+        recon = _reconstruct(Q, c, d, xv)
+        assert abs(original - recon) <= _TOL, f"seed={seed} pt={k}: |{original} - {recon}| > {_TOL}"
+
+
+@pytest.mark.unit
+def test_symmetric_split_convention():
+    """Cross term coeff b -> Q[i,j]=Q[j,i]=b/2; square a -> Q[i,i]=a."""
+    m = dm.Model("s")
+    x = m.continuous("x", shape=(3,), lb=-2, ub=2)
+    expr = 5.0 * x[0] * x[1] + 3.0 * x[2] ** 2 - 2.0 * x[0] * x[2]
+    Q, c, d = extract_quadratic(expr, 3, m)
+    assert Q[0, 1] == pytest.approx(2.5)
+    assert Q[1, 0] == pytest.approx(2.5)
+    assert Q[2, 2] == pytest.approx(3.0)
+    assert Q[0, 2] == pytest.approx(-1.0)
+    assert Q[2, 0] == pytest.approx(-1.0)
+    assert np.allclose(c, 0.0)
+    assert d == pytest.approx(0.0)
+
+
+@pytest.mark.unit
+def test_pure_square_and_bilinear_and_cross():
+    m = dm.Model("m")
+    x = m.continuous("x", shape=(2,), lb=-1, ub=1)
+    # (x0 - x1)^2 = x0^2 - 2 x0 x1 + x1^2
+    expr = (x[0] - x[1]) ** 2
+    Q, c, d = extract_quadratic(expr, 2, m)
+    assert np.allclose(Q, np.array([[1.0, -1.0], [-1.0, 1.0]]))
+    assert np.allclose(c, 0.0)
+    assert d == pytest.approx(0.0)
+    # This Q is PSD (the square is convex).
+    assert quadratic_is_psd(Q) is True
+
+
+@pytest.mark.unit
+def test_affine_and_constant_are_quadratic_with_zero_Q():
+    m = dm.Model("a")
+    x = m.continuous("x", shape=(2,), lb=0, ub=1)
+    aff = 3.0 * x[0] - 2.0 * x[1] + 4.0
+    Q, c, d = extract_quadratic(aff, 2, m)
+    assert np.allclose(Q, 0.0)
+    assert np.allclose(c, [3.0, -2.0])
+    assert d == pytest.approx(4.0)
+    # A constant offset folded onto a zeroed variable term.
+    cst = extract_quadratic(0.0 * x[0] + 7.0, 2, m)
+    assert cst is not None
+    Qc, cc, dc = cst
+    assert np.allclose(Qc, 0.0) and np.allclose(cc, 0.0) and dc == pytest.approx(7.0)
+
+
+@pytest.mark.unit
+def test_non_quadratic_expressions_return_none():
+    """Every non-(purely-)quadratic shape must abstain (return None)."""
+    m = dm.Model("n")
+    x = m.continuous("x", shape=(3,), lb=0.5, ub=3.0)
+
+    cases = {
+        "cube": x[0] ** 3,
+        "quartic": x[0] ** 4,
+        "trilinear": x[0] * x[1] * x[2],
+        "square_times_var": x[0] ** 2 * x[1],
+        "exp": dm.exp(x[0]),
+        "log": dm.log(x[0]),
+        "sin": dm.sin(x[0]),
+        "sqrt": dm.sqrt(x[0]),
+        "bilinear_with_transcendental": x[0] * dm.sin(x[1]),
+        "sum_with_transcendental": x[0] ** 2 + dm.exp(x[1]),
+        "var_in_denominator": x[0] / x[1],
+        "fractional_power": x[0] ** 0.5,
+        "abs": abs(x[0]),
+        "reciprocal": 1.0 / x[0],
+    }
+    for name, expr in cases.items():
+        assert extract_quadratic(expr, 3, m) is None, f"{name} must abstain"
+        assert not is_purely_quadratic(expr, 3, m), f"{name} is_purely_quadratic must be False"
+
+
+@pytest.mark.unit
+def test_non_quadratic_never_misextracted_on_points():
+    """A degree-3 expression must NOT be silently reduced to a wrong Q.
+
+    Belt-and-braces: even if some future refactor mistakenly returned a Q,
+    it could not reproduce a cubic on random points. We assert the
+    abstention directly, which is the sound behavior.
+    """
+    m = dm.Model("c")
+    x = m.continuous("x", shape=(2,), lb=-2, ub=2)
+    cubic = x[0] ** 3 + x[0] * x[1]
+    assert extract_quadratic(cubic, 2, m) is None
+
+
+@pytest.mark.unit
+def test_out_of_range_index_abstains():
+    m = dm.Model("r")
+    x = m.continuous("x", shape=(3,), lb=-1, ub=1)
+    expr = x[2] ** 2 + x[0] * x[1]
+    # n too small to hold index 2 -> must abstain rather than write OOB.
+    assert extract_quadratic(expr, 2, m) is None
+    # Correct n succeeds.
+    assert extract_quadratic(expr, 3, m) is not None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("seed", range(20))
+def test_psd_nsd_helpers_match_eigvalsh(seed):
+    rng = np.random.default_rng(1000 + seed)
+    n = int(rng.integers(1, 6))
+    A = rng.uniform(-2, 2, size=(n, n))
+    Q = 0.5 * (A + A.T)  # symmetric
+    lam = np.linalg.eigvalsh(Q)
+    expect_psd = bool(lam.min() >= -1e-10)
+    expect_nsd = bool(lam.max() <= 1e-10)
+    assert quadratic_is_psd(Q) is expect_psd
+    assert quadratic_is_nsd(Q) is expect_nsd
+
+
+@pytest.mark.unit
+def test_psd_helper_handles_degenerate_inputs():
+    # Non-finite -> None (unusable).
+    bad = np.array([[np.nan, 0.0], [0.0, 1.0]])
+    assert quadratic_is_psd(bad) is None
+    assert quadratic_is_nsd(bad) is None
+    # Non-square -> None.
+    assert quadratic_is_psd(np.zeros((2, 3))) is None
+    # Zero-dimensional form is trivially PSD.
+    assert quadratic_is_psd(np.zeros((0, 0))) is True
+    # A clearly-PSD identity, a clearly-NSD negative identity.
+    assert quadratic_is_psd(np.eye(3)) is True
+    assert quadratic_is_nsd(-np.eye(3)) is True
+    # Indefinite.
+    indef = np.array([[1.0, 0.0], [0.0, -1.0]])
+    assert quadratic_is_psd(indef) is False
+    assert quadratic_is_nsd(indef) is False


### PR DESCRIPTION
## cert:P4 — exact Q-matrix extraction (+ flagged PSD convexity path)

Phase 4 build item 3 (ranked #2 by the re-profile, coupled to the merged CSE work): upgrade "quadratic" from a *degree check* (`ExprArena::is_quadratic` = `max_degree ≤ 2`) to *exact coefficient extraction*, and wire the first sound consumer. Two clearly separated correctness regimes per CLAUDE.md §5.

### (A) Exact Q-matrix extraction — BOUND-NEUTRAL foundation

`python/discopt/_jax/quadratic_form.py`:
- `extract_quadratic(expr, n, model) -> Optional[(Q, c, d)]` returns the symmetric `Q`, linear `c`, constant `d` with `expr == xᵀQx + cᵀx + d` **exactly, or `None`** (abstain). Layered on the existing trusted polynomial walker `milp_relaxation._expr_to_polynomial` (fed `term_classifier.distribute_products`) — the same machinery the edge-concave collector already uses — plus a hard reject of any degree-≥3 monomial. Flat indexing matches the convexity certificate's layout (`interval_ad._var_offset` == `term_classifier._compute_var_offset`).
- Symmetric split: `Q_ij = Q_ji = ½·coeff` (i≠j), `Q_ii = coeff`.
- `quadratic_is_psd` / `quadratic_is_nsd`: exact `eigvalsh` definiteness tests.

**It is exact-or-abstain and NEVER returns an approximate `Q`.**

### (B) Convexity certificate via PSD-on-Q — BOUND-CHANGING, flag default-OFF

Wired into `convexity/certificate.py::certify_convex` behind **`DISCOPT_PSD_QFORM`** (default `0`). On a purely quadratic body the Hessian is the *constant* matrix `2·Q`, so `λ_min(Q) ≥ 0` is a rigorous, box-independent convexity proof — strictly tighter than the conservative interval-Hessian + Gershgorin row-sum enclosure (which abstains on tight-but-PSD matrices). On any abstention (non-quadratic body, indefinite `Q`, non-finite `Q`) it returns `None` and **falls through to the existing rigorous path unchanged — never assumes convex**. It can prove *more* bodies convex → node relaxations/counts change → shipped behind a flag per the bound-changing regime.

RLT and edge-concave already extract quadratic coefficients via `_expr_to_polynomial`; rerouting them through `extract_quadratic` would at best be a bound-neutral refactor with no payoff, so it is scoped as follow-on (proven partial > unproven whole). Recorded in `docs/dev/certification-gap-plan.md` §8.

## Validation

**(A) exact extraction (`test_quadratic_form.py`, 39 tests):** random quadratics reconstruct to **1e-12 on 250 points/instance** across 12 seeds; symmetric-split / affine / constant sub-cases pinned; **14 non-quadratic shapes** (cube, quartic, trilinear, `x²·y`, exp/log/sin/sqrt, bilinear-with-transcendental, var-in-denominator, fractional power, `abs`, reciprocal) all return `None`; out-of-range index abstains; PSD/NSD helpers match `eigvalsh` on 20 random matrices.

**(B) PSD-on-Q soundness/differential (`test_psd_qform_convexity.py`, 78 pass / 4 skip):**
- **No mis-certification** — 30 random *indefinite* `Q` never read as CONVEX/CONCAVE with the flag ON.
- **Strict refinement** — flag-ON never flips a flag-OFF verdict; only turns `None` into a verdict; always agrees with a direct `eigvalsh` check.
- **Non-quadratic bodies identical on/off**; default reproduces the conservative abstention.

## Gates run

- `pytest python/tests/ -k "convex or quadratic or rlt or edge_concave or qmatrix or psd"`: **786 passed, 5 skipped, 2 xfailed** (flag default-off).
- `pytest -m smoke`: **395 passed, 1 skipped, 3 failed** — the 3 failures are `test_tightening.py::test_c31_*`, **pre-existing on `origin/main`** (confirmed by stashing this PR's changes and re-running; they live in `_collect_univariate_relaxations` / FBBT-rescue, a path this PR never touches, and the flag is off).
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed**.
- `check_cert_neutrality.py` (flag OFF): reports 1 objective violation (`st_ph10`, |Δobj|=2.23e-08) + node deltas at `nvs13` (55→19) and `nvs17` (205→55). **All three are pre-existing `cert-baseline.jsonl`-vs-`main` drift, NOT from this PR** — verified by stashing this PR's changes and re-running the same three instances on the base tree: identical results (st_ph10 |Δobj|=2.226e-08 to the 6th sig-fig, nvs13 55→19, nvs17 205→55). This PR's PSD path is default-off, so `certify_convex` executes byte-identical code and cannot move any bound; the drift predates it and belongs to a separate baseline-refresh task.
- `ruff check` / `ruff format --check`: clean on all changed/new files.
- `mypy`: no errors introduced in the new files (the numpy-stub `python_version=3.10` vs numpy-3.12 error is pre-existing and environment-level, reproduces on unchanged files).
- No Rust touched (the `is_quadratic` degree check is left intact as the cheap predicate; extraction is Python where all consumers live).

## Safety

The PSD-on-Q path is a *sound tightening* gated by `DISCOPT_PSD_QFORM` (default `0`): with the flag unset, `certify_convex` is byte-for-byte the prior function, so no certified bound changes. Enabling + validating on nightlies (differential-bound + feasible-point + `incorrect_count=0`) is the follow-on before any default-on. No certified bound was changed in a way that could not be proven sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
