### PR TITLE
fix(correctness): C-3 round near-integral incumbent integers before certifying

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -104,7 +104,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-8 | P2 | .nl parser | common opcodes unhandled (o76/o77/o78/o48/o11/o12/o35) | open |
 | C-9 | P2 | .nl parser | nlvo>nlvc integer-block classification unverified | open |
 | C-10 | P2 | lp_spatial cuts | GMI cuts appended without rhs safety margin (opt-in path) | open |
-| C-3 | P2 | solver.py incumbent | unrounded integer incumbent survives if terminal polish throws | open |
+| C-3 | P2 | solver.py incumbent | unrounded integer incumbent survives if terminal polish throws | fixed |
 | C-11 | P2 | modeling API | missing `__ne__` → `x != y` silently evaluates False | open |
 | C-22 | P3 | fbbt.rs interval | `interval_mul` NaN endpoints on 0·∞ (lost tightening, not unsound) | open |
 | C-23 | P1 | mccormick.py | ESCALATED (was P3): `relax_div` produces an invalid convex underestimator (cv > f) for **nonlinear** denominators (`1/(x*y)` cv=1.334 > true 1.0) — the "harmless" label held only for variable/affine denominators; `_relax_reciprocal` also mislabels concavity for negative denominators (= DIV-1) | fixed |
@@ -1227,7 +1227,51 @@ minimum round-and-verify on the polish exception path before reporting.
 exactly-integral integer variables and passes feasibility at standard tol;
 standing gates pass.
 
-**Log:** —
+**Log:**
+- 2026-07-03 — **CONFIRMED then FIXED.** Static confirm: `tree.inject_incumbent`
+  (`tree_manager.rs:724`) stores the solution vector verbatim after only an
+  objective-improvement check — no integrality snap — and the warm-start /
+  node-injection gates accept any coordinate within `1e-5` of an integer. The
+  reported `x_dict` is built from that raw vector at each finalizer; the terminal
+  KKT polish rounds integers only *inside* its own accept branch, so if the polish
+  raises / returns non-OPTIMAL / is not adopted, the fractional coordinate is
+  certified. **Dynamic repro** (fails-before): a MIQP warm-started with
+  `n=2.999997`, terminal polish monkeypatched to raise → reported `n =
+  2.999999999997271` (residual 2.7e-12, NOT integral); with the fix → `n = 3.0`
+  exactly. Verified fail-before/pass-after by stashing the fix.
+- **Fix** (`solver.py`): new `_round_incumbent_integers(sol_flat, int_offsets,
+  int_sizes, evaluator=None, cl_list=None, cu_list=None)` helper snaps every
+  discrete coordinate *within the `1e-5` integrality tol* of an integer to that
+  integer (a perturbation no larger than the tol the point already satisfied),
+  leaves genuinely-fractional coordinates untouched (snapping them would fabricate
+  an unproven point), and — when an evaluator + constraint bounds are supplied —
+  re-verifies the rounded point at `1e-4`; it returns `(rounded, feasible)` and the
+  caller adopts the rounded point only when `feasible` (else keeps the
+  already-verified unrounded point, so no infeasible "integral" point is ever
+  certified). Wired into **all four** incumbent finalizers: `solve_model`,
+  `_solve_nlp_bb` (both with the constraint re-check), and `_solve_milp_bb` /
+  `_solve_miqp_bb` (integers are branch-fixed to `[k,k]` before each node solve, so
+  a stored `k±ε` is a numeric artifact and rounding to `k` cannot move a linear row
+  by more than the integrality tol — documented at each site). No safety mechanism
+  weakened; the round-and-verify is strictly additive over the existing polish.
+- **Regression test** (`python/tests/test_c3_incumbent_rounding.py`, all
+  `@pytest.mark.smoke`, fail-before/pass-after verified by stashing the fix):
+  `test_c3_round_incumbent_snaps_near_integral` (in-tol snap, input not mutated,
+  continuous untouched), `test_c3_round_incumbent_leaves_genuinely_fractional_untouched`
+  (a 2.4 is left alone — never fabricate an unproven point),
+  `test_c3_round_incumbent_rejects_when_rounding_breaks_feasibility` (rounding that
+  violates a constraint returns `feasible=False` so the caller must not adopt), and
+  the end-to-end `test_c3_fractional_integer_does_not_survive_polish_failure`
+  (polish forced to raise + near-integral incumbent injected → reported integer is
+  exactly integral). The first three encode the *class* (round-and-verify contract)
+  by calling the helper directly, sub-second.
+- **Gates:** `pytest -m smoke` 482 passed / 1 skipped / 0 failed; adversarial
+  `test_adversarial_recent_fixes.py -m slow` 10 passed; the incumbent/solver/
+  certif/gap/bound selection 727 passed / 2 xfailed / 0 failed;
+  `test_c3_incumbent_rounding.py` 4 passed. `ruff check` + `ruff format --check`
+  clean; `pre-commit run mypy` passed. No Rust touched. `incorrect_count`
+  unchanged (0 failures; no correctness assertion weakened). PR: __PR__.
+**Status:** open → fixed.
 
 ---
 

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -1270,7 +1270,7 @@ standing gates pass.
   certif/gap/bound selection 727 passed / 2 xfailed / 0 failed;
   `test_c3_incumbent_rounding.py` 4 passed. `ruff check` + `ruff format --check`
   clean; `pre-commit run mypy` passed. No Rust touched. `incorrect_count`
-  unchanged (0 failures; no correctness assertion weakened). PR: __PR__.
+  unchanged (0 failures; no correctness assertion weakened). PR: #456.
 **Status:** open → fixed.
 
 ---

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -945,6 +945,62 @@ def _is_integer_feasible_solution(x, int_offsets, int_sizes, tol=1e-5):
     return True
 
 
+def _round_incumbent_integers(
+    sol_flat,
+    int_offsets,
+    int_sizes,
+    evaluator=None,
+    cl_list=None,
+    cu_list=None,
+    integrality_tol=1e-5,
+    feas_tol=1e-4,
+):
+    """Snap near-integral discrete coordinates of a reported incumbent to exact
+    integers, verifying the rounded point stays feasible.
+
+    C-3: the batched JAX IPM leaves integer columns a few digits short of exact
+    (e.g. ``2.999997``); such a point still passes the ``1e-5`` integrality gate
+    at injection and is stored verbatim as the tree incumbent. The terminal KKT
+    polish / dual-recovery re-solve normally rounds and re-solves it, but that
+    step is *best-effort and guarded* — if it raises, is skipped, or returns a
+    non-adopted result, the raw near-integral coordinates are reported as-is,
+    yielding a certified "optimal" whose integer variables are fractional.
+
+    This rounds every discrete coordinate that is within ``integrality_tol`` of
+    an integer to that integer (a perturbation no larger than the integrality
+    tolerance the point already satisfied) and, when an evaluator + constraint
+    bounds are supplied, checks the rounded point against the constraints at
+    ``feas_tol``. A coordinate that is *not* within tolerance of any integer is
+    left untouched — snapping a genuinely fractional value would fabricate a
+    point the search never proved feasible.
+
+    Returns ``(rounded, feasible)``:
+      * ``rounded`` — a copy of ``sol_flat`` with in-tolerance integer columns
+        snapped exactly. ``sol_flat`` is never mutated.
+      * ``feasible`` — ``True`` if no evaluator was supplied (nothing to check)
+        or the rounded point satisfies the constraints within ``feas_tol``;
+        ``False`` if rounding broke feasibility. The caller must not certify a
+        rounded point that reports ``False``.
+    """
+    rounded = np.asarray(sol_flat, dtype=float).copy()
+    changed = False
+    for off, sz in zip(int_offsets, int_sizes):
+        for j in range(off, off + int(sz)):
+            xj = rounded[j]
+            if not np.isfinite(xj):
+                continue
+            nearest = round(float(xj))
+            if xj != nearest and abs(xj - nearest) <= integrality_tol:
+                rounded[j] = float(nearest)
+                changed = True
+    if not changed:
+        return rounded, True
+    if evaluator is None or not cl_list:
+        return rounded, True
+    feasible = _check_constraint_feasibility(evaluator, rounded, cl_list, cu_list, tol=feas_tol)
+    return rounded, feasible
+
+
 def _structural_linear_row_mask(model, sizes, m):
     """Boolean mask (length ``m``) of Jacobian rows whose body is structurally affine.
 
@@ -6693,6 +6749,18 @@ def solve_model(
 
     if incumbent is not None:
         sol_flat = np.array(sol_array)
+        # C-3: snap near-integral discrete coordinates to exact integers before
+        # reporting. The tree incumbent can carry a coordinate a few digits shy
+        # of integral (it passed the 1e-5 injection gate); the terminal polish
+        # below rounds+re-solves it, but is best-effort — if it raises or is not
+        # adopted the raw fractional value would be certified. Round up front so
+        # the reported point is exactly integral regardless of the polish
+        # outcome, only when the rounded point stays feasible.
+        _rounded_inc, _rounded_feas = _round_incumbent_integers(
+            sol_flat, int_offsets, int_sizes, evaluator, cl_list, cu_list
+        )
+        if _rounded_feas:
+            sol_flat = _rounded_inc
         x_dict = _unpack_solution(model, sol_flat)
 
         # Refine the incumbent's continuous variables with a KKT-accurate
@@ -7933,6 +8001,14 @@ def _solve_nlp_bb(
 
     if incumbent is not None:
         sol_flat = np.array(sol_array)
+        # C-3: snap near-integral discrete coordinates to exact integers before
+        # reporting; the dual-recovery re-solve below is best-effort and does
+        # not guarantee the reported primal is rounded (see helper docstring).
+        _rounded_inc, _rounded_feas = _round_incumbent_integers(
+            sol_flat, int_offsets, int_sizes, evaluator, cl_list, cu_list
+        )
+        if _rounded_feas:
+            sol_flat = _rounded_inc
         x_dict = _unpack_solution(model, sol_flat)
 
         # Recover relaxation duals at the incumbent by re-solving the NLP with
@@ -11569,6 +11645,15 @@ def _solve_milp_bb(
 
     if incumbent is not None:
         sol_flat = np.array(sol_array)
+        # C-3: snap near-integral discrete coordinates to exact integers. In the
+        # MILP path each integer was branch-fixed to [k, k] before the node LP
+        # solved, so a stored k±ε is a numeric artifact and rounding to k
+        # restores exactly the point the LP was solving — it cannot move a
+        # linear row by more than the integrality tol. The dual-recovery
+        # re-solve does not round the reported primal, so round here.
+        _rounded_inc, _rounded_feas = _round_incumbent_integers(sol_flat, int_offsets, int_sizes)
+        if _rounded_feas:
+            sol_flat = _rounded_inc
         x_dict = _unpack_solution(model, sol_flat)
 
         # Recover relaxation duals at the integer-feasible incumbent by
@@ -11966,6 +12051,13 @@ def _solve_miqp_bb(
 
     if incumbent is not None:
         sol_flat = np.array(sol_array)
+        # C-3: snap near-integral discrete coordinates to exact integers (see the
+        # MILP-BB path). Integers are branch-fixed before each node QP solve, so
+        # rounding a stored k±ε restores the fixed point; the dual-recovery
+        # re-solve does not round the reported primal.
+        _rounded_inc, _rounded_feas = _round_incumbent_integers(sol_flat, int_offsets, int_sizes)
+        if _rounded_feas:
+            sol_flat = _rounded_inc
         x_dict = _unpack_solution(model, sol_flat)
 
         # Recover relaxation duals at the integer-feasible incumbent by

--- a/python/tests/test_c3_incumbent_rounding.py
+++ b/python/tests/test_c3_incumbent_rounding.py
@@ -1,0 +1,123 @@
+"""C-3 (P2, solver.py incumbent) — a near-integral discrete coordinate must not
+survive unrounded into the reported incumbent when the terminal polish throws.
+
+Mechanism (from ``docs/dev/correctness-issues.md`` §C-3): the batched JAX IPM
+leaves an integer column a few digits shy of integral (e.g. ``2.999997``). Such a
+point still passes the ``1e-5`` integrality gate at ``tree.inject_incumbent`` and
+is stored verbatim as the tree incumbent. The terminal KKT polish / dual-recovery
+re-solve in the B&B finalizers normally rounds+re-solves it, but that step is
+best-effort and guarded — if it *raises* (or is skipped / not adopted) the raw
+fractional coordinate is reported as-is, yielding a certified "optimal" whose
+integer variable is fractional.
+
+Two layers, both fast:
+
+1. Direct unit test of ``_round_incumbent_integers`` — the extracted round-and-
+   verify helper wired into all four finalizers. Encodes the *class*: rounds
+   in-tolerance integers, leaves genuinely-fractional coords alone, and reports
+   ``feasible=False`` (so the caller must not adopt) when rounding breaks a
+   nonlinear constraint.
+
+2. End-to-end: force the terminal polish to raise and inject a near-integral
+   incumbent, then assert the reported solution's integer variable is *exactly*
+   integral. Fails-before / passes-after.
+"""
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import discopt.solver as S  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+
+class _FakeEvaluator:
+    """Minimal evaluator: constraint  x[1] <= 2.5  (violated once x[1] rounds to 3)."""
+
+    n_constraints = 1
+
+    def evaluate_constraints(self, x):
+        return np.array([x[1]], dtype=np.float64)
+
+
+@pytest.mark.smoke
+def test_c3_round_incumbent_snaps_near_integral():
+    # y = 2.999997 is within 1e-5 of 3; x = 1.2 is continuous (offset excluded).
+    sol = np.array([1.2, 2.999997])
+    rounded, feasible = S._round_incumbent_integers(sol, int_offsets=[1], int_sizes=[1])
+    assert feasible is True
+    assert rounded[1] == 3.0  # exactly integral
+    assert rounded[0] == 1.2  # continuous untouched
+    assert sol[1] == 2.999997  # input not mutated
+
+
+@pytest.mark.smoke
+def test_c3_round_incumbent_leaves_genuinely_fractional_untouched():
+    # 2.4 is NOT within 1e-5 of any integer: snapping it would fabricate a point
+    # the search never proved feasible, so it must be left alone.
+    sol = np.array([0.0, 2.4])
+    rounded, feasible = S._round_incumbent_integers(sol, int_offsets=[1], int_sizes=[1])
+    assert feasible is True
+    assert rounded[1] == 2.4
+
+
+@pytest.mark.smoke
+def test_c3_round_incumbent_rejects_when_rounding_breaks_feasibility():
+    # x[1] = 2.999997 -> rounds to 3.0, violating the fake constraint x[1] <= 2.5.
+    # The helper must report feasible=False so the caller keeps the unrounded
+    # point rather than certifying an infeasible "integral" solution.
+    sol = np.array([0.0, 2.999997])
+    rounded, feasible = S._round_incumbent_integers(
+        sol,
+        int_offsets=[1],
+        int_sizes=[1],
+        evaluator=_FakeEvaluator(),
+        cl_list=[-1e20],
+        cu_list=[2.5],
+    )
+    assert feasible is False
+    assert rounded[1] == 3.0  # still rounded, but flagged infeasible
+
+
+@pytest.mark.smoke
+def test_c3_fractional_integer_does_not_survive_polish_failure():
+    """End-to-end: terminal polish raises + near-integral incumbent injected ->
+    the reported integer variable must be exactly integral (fails before fix)."""
+    from discopt._rust import PyTreeManager
+
+    orig_polish = S._solve_node_nlp_kkt
+    orig_inc = PyTreeManager.incumbent
+
+    def _boom(*a, **k):
+        raise RuntimeError("forced terminal polish failure (C-3 repro)")
+
+    def _frac_inc(self):
+        inc = orig_inc(self)
+        if inc is None:
+            return inc
+        sol, obj = inc
+        sol = list(sol)
+        sol[1] = 2.999997  # y: near-integral but not exact
+        return (sol, obj)
+
+    S._solve_node_nlp_kkt = _boom
+    PyTreeManager.incumbent = _frac_inc
+    try:
+        m = dm.Model("c3_e2e")
+        x = m.continuous("x", lb=0.0, ub=5.0)
+        y = m.integer("y", lb=0, ub=5)
+        m.subject_to(x * x + y >= 3.0)
+        m.minimize((x - 1.2) ** 2 + (y - 2.7) ** 2)
+        res = m.solve(time_limit=20)
+    finally:
+        S._solve_node_nlp_kkt = orig_polish
+        PyTreeManager.incumbent = orig_inc
+
+    assert res.x is not None
+    yv = float(np.asarray(res.x["y"]))
+    assert abs(yv - round(yv)) < 1e-9, (
+        f"C-3: fractional integer {yv!r} survived into the reported incumbent"
+    )


### PR DESCRIPTION
## C-3 (P2) — fractional integer incumbent survives when the terminal polish throws

Fixes correctness backlog item **C-3** (`docs/dev/correctness-issues.md`).

### Confirmed (fails-before)
`tree.inject_incumbent` (`tree_manager.rs:724`) stores the solution vector verbatim after only an objective-improvement check — it never snaps integers. The warm-start and node-injection gates accept any coordinate within `1e-5` of an integer. Each B&B finalizer then builds the reported `x_dict` from that raw vector; the terminal KKT polish rounds integers only *inside its own accept branch*, so if the polish raises / returns non-OPTIMAL / is not adopted, the fractional coordinate is certified.

Dynamic repro (a MIQP warm-started with `n = 2.999997`, terminal polish monkeypatched to raise):
- **Before:** reported `n = 2.999999999997271` (residual 2.7e-12, **not** integral) — a certified "optimal" with a fractional integer.
- **After:** reported `n = 3.0` exactly.

Verified fail-before/pass-after by stashing the fix and re-running the repro and the regression test.

### Fix
New `_round_incumbent_integers(sol_flat, int_offsets, int_sizes, evaluator=None, cl_list=None, cu_list=None)` helper:
- snaps every discrete coordinate **within the `1e-5` integrality tol** of an integer to that integer (a perturbation no larger than the tol the point already satisfied);
- leaves genuinely-fractional coordinates untouched (snapping them would fabricate a point the search never proved feasible);
- when an evaluator + constraint bounds are supplied, re-verifies the rounded point at `1e-4` and returns `(rounded, feasible)`; the caller adopts the rounded point **only when `feasible`**, else keeps the already-verified unrounded point — so no infeasible "integral" point is ever certified.

Wired into **all four** incumbent finalizers: `solve_model`, `_solve_nlp_bb` (both with the constraint re-check), and `_solve_milp_bb` / `_solve_miqp_bb` (integers are branch-fixed to `[k,k]` before each node solve, so a stored `k±eps` is a numeric artifact — rounding to `k` cannot move a linear row by more than the integrality tol; documented at each site).

The round-and-verify is strictly additive over the existing polish. No validity check, fallback, or safety guard was weakened.

### Regression test
`python/tests/test_c3_incumbent_rounding.py` (all `@pytest.mark.smoke`, fail-before/pass-after verified):
- `test_c3_round_incumbent_snaps_near_integral` — in-tol snap; input not mutated; continuous untouched.
- `test_c3_round_incumbent_leaves_genuinely_fractional_untouched` — a `2.4` is left alone.
- `test_c3_round_incumbent_rejects_when_rounding_breaks_feasibility` — rounding that violates a constraint returns `feasible=False`.
- `test_c3_fractional_integer_does_not_survive_polish_failure` — end-to-end: polish forced to raise + near-integral incumbent injected -> reported integer is exactly integral.

The first three encode the *class* (the round-and-verify contract) by calling the helper directly, sub-second.

### Gates
- `pytest -m smoke` — **482 passed, 1 skipped, 0 failed**
- adversarial `test_adversarial_recent_fixes.py -m slow` — **10 passed**
- `pytest -k "incumbent or solver or certif or gap or bound"` — **727 passed, 2 xfailed, 0 failed**
- `test_c3_incumbent_rounding.py` — **4 passed**
- `ruff check` + `ruff format --check` clean; `pre-commit run mypy` passed
- No Rust touched. `incorrect_count` unchanged (0 failures; no correctness assertion weakened).

Generated with Claude Code

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
