### PR TITLE
fix(correctness): C-11 add __ne__ guard so `x != y` refuses loudly

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -105,7 +105,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-9 | P2 | .nl parser | nlvo>nlvc integer-block classification unverified | fixed |
 | C-10 | P2 | lp_spatial cuts | GMI cuts appended without rhs safety margin (opt-in path) | open |
 | C-3 | P2 | solver.py incumbent | unrounded integer incumbent survives if terminal polish throws | fixed |
-| C-11 | P2 | modeling API | missing `__ne__` → `x != y` silently evaluates False | open |
+| C-11 | P2 | modeling API | missing `__ne__` → `x != y` silently evaluates False | fixed |
 | C-22 | P3 | fbbt.rs interval | `interval_mul` NaN endpoints on 0·∞ (lost tightening, not unsound) | open |
 | C-23 | P1 | mccormick.py | ESCALATED (was P3): `relax_div` produces an invalid convex underestimator (cv > f) for **nonlinear** denominators (`1/(x*y)` cv=1.334 > true 1.0) — the "harmless" label held only for variable/affine denominators; `_relax_reciprocal` also mislabels concavity for negative denominators (= DIV-1) | fixed |
 | C-24 | P3 | mccormick.py | secants produce NaN on infinite bounds; soundness leans on downstream filters | open |
@@ -1375,7 +1375,27 @@ error.
 **Done criteria:** test asserting the TypeError; standing gates pass (check no
 internal code relies on expression `!=`).
 
-**Log:** —
+**Log:** 2026-07-03 — **CONFIRMED then FIXED** (PR: fix-c11-modeling-api).
+Repro before: `bool(x != 0)` returned `False` (a plain bool, no Constraint, no
+error) — verified `x != 0`, `x != y`, `(x+1) != 2`, `v[0] != 0` all silently
+yielded `False`. Root cause exactly as carded: `Expression.__eq__`
+(`core.py:157`) builds a Constraint, and with no `__ne__` Python's default
+`__ne__` computes `not <truthy Constraint>` → `False`. Fix: added
+`Expression.__ne__` raising `TypeError("'!=' is not a valid constraint
+operator …")` (loud refusal, per CLAUDE.md §3 — mirrors the C-6 "no silent
+transformation" pattern). Placed on the `Expression` base so every node type
+(Variable/BinaryOp/UnaryOp/IndexExpression/…) inherits it. Confirmed no internal
+code depends on `Expression`-level `!=` (all `!=` hits across `modeling/` and
+`_jax/` operate on scalars/str/enums/ndarrays, none on Expression objects).
+`__hash__` unaffected — defining `__ne__` (unlike `__eq__`) does not null
+`__hash__`; `Variable.__hash__` still works and a Variable remains dict/set-usable.
+Repro after: all four `!=` forms raise `TypeError`; `==` still returns a
+Constraint. Regression test: `python/tests/test_c11_ne_guard.py` (6 smoke tests,
+fail-before 4/6 → pass-after 6/6, sub-second, direct API calls). Gates: `pytest
+-m smoke` 484 passed / 1 skipped / 0 failed; adversarial suite 10 passed / 0
+failed; `pytest -k "modeling or api or variable or constraint or model"` 629
+passed / 1 skipped / 0 failed; ruff + ruff-format clean; mypy clean on core.py
+(pre-existing numpy-stub / unrelated-module errors only); incorrect_count 0.
 
 ---
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -171,6 +171,17 @@ class Expression:
     def __eq__(self, other):
         return Constraint(self - _wrap(other), sense="==", rhs=0.0)
 
+    def __ne__(self, other):
+        # ``!=`` is not a valid optimization-constraint operator. Because
+        # ``__eq__`` is overridden to build a Constraint, Python's default
+        # ``__ne__`` would evaluate ``not <truthy Constraint>`` → ``False``
+        # *silently*, mis-encoding the user's intent (correctness issue C-11).
+        # Refuse loudly instead of silently transforming the model (CLAUDE.md §3).
+        raise TypeError(
+            "'!=' is not a valid constraint operator on modeling expressions. "
+            "Use '==', '<=', or '>=' to build a constraint."
+        )
+
     # ── Indexing for array variables ──
 
     def __getitem__(self, idx):

--- a/python/tests/test_c11_ne_guard.py
+++ b/python/tests/test_c11_ne_guard.py
@@ -1,0 +1,76 @@
+"""Regression test for correctness issue C-11.
+
+The modeling API overrides ``Expression.__eq__`` to build an equality
+``Constraint`` (``x == y`` → a constraint, not a bool). It did **not** define
+``__ne__``. Python's default ``__ne__`` is ``not __eq__(...)``, so ``x != y``
+evaluated to ``not <truthy Constraint>`` → ``False`` *silently* — with no error
+and no ``Constraint`` object. User-side control flow such as ``if x != 0:`` then
+misbehaved with no diagnostic (CLAUDE.md §3: the modeling API must not silently
+mis-encode the user's intent; refuse loudly instead).
+
+``!=`` is not a valid optimization constraint operator, so the sound fix is a
+loud ``TypeError`` — not a silent ``False`` and not a fabricated constraint.
+
+These tests call the modeling API directly (sub-second, no ``Model.solve()``).
+"""
+
+import pytest
+from discopt import Model
+
+
+@pytest.mark.smoke
+def test_ne_against_constant_raises():
+    """``x != 0`` must raise, not silently evaluate to False (fail-before/pass-after)."""
+    m = Model()
+    x = m.continuous("x")
+    with pytest.raises(TypeError):
+        x != 0
+
+
+@pytest.mark.smoke
+def test_ne_between_expressions_raises():
+    """``x != y`` on two expressions must raise loudly."""
+    m = Model()
+    x = m.continuous("x")
+    y = m.continuous("y")
+    with pytest.raises(TypeError):
+        x != y
+
+
+@pytest.mark.smoke
+def test_ne_on_derived_expression_raises():
+    """The guard lives on the Expression base, so derived nodes are covered too."""
+    m = Model()
+    x = m.continuous("x")
+    with pytest.raises(TypeError):
+        (x + 1) != 2  # BinaryOp
+    with pytest.raises(TypeError):
+        (-x) != 0  # UnaryOp
+
+
+@pytest.mark.smoke
+def test_ne_on_indexed_expression_raises():
+    """Indexed array-variable expressions are guarded as well."""
+    m = Model()
+    v = m.continuous("v", shape=(3,))
+    with pytest.raises(TypeError):
+        v[0] != 0
+
+
+@pytest.mark.smoke
+def test_eq_still_builds_a_constraint():
+    """The fix must not disturb ``==``: it still yields an equality Constraint."""
+    m = Model()
+    x = m.continuous("x")
+    c = x == 0
+    assert type(c).__name__ == "Constraint"
+
+
+@pytest.mark.smoke
+def test_variable_remains_hashable():
+    """Defining ``__ne__`` must not break hashability (used in dicts/sets)."""
+    m = Model()
+    x = m.continuous("x")
+    # Should not raise; Variable defines __hash__ explicitly.
+    hash(x)
+    assert x in {x}


### PR DESCRIPTION
## Correctness fix: C-11 (P2, modeling API)

Fixes correctness issue **C-11** from `docs/dev/correctness-issues.md`: the modeling
API had no `__ne__` guard, so `x != y` silently evaluated to `False`.

### Confirmed (fail-before)
`Expression.__eq__` (`core.py:157`) builds an equality `Constraint`, but no `__ne__`
existed. Python's default `__ne__` is `not __eq__(...)` → `not <truthy Constraint>` →
`False`. Verified pre-fix: `bool(x != 0)`, `x != y`, `(x + 1) != 2`, and `v[0] != 0`
all returned a plain `False` — no error, no `Constraint`. A user writing `if x != 0:`
silently gets the wrong branch, i.e. the modeling API mis-encodes the user's intent
with no diagnostic. Same "no silent transformation" class as C-6 (silent integer-bound
clamp).

### Fix (loud refusal, per CLAUDE.md §3)
Added `Expression.__ne__` that raises `TypeError("'!=' is not a valid constraint
operator …")`. `!=` is not a valid optimization-constraint operator, so the sound
behavior is a loud error — never a silent `False` and never a fabricated constraint.

- Placed on the `Expression` base class so every node type
  (`Variable` / `BinaryOp` / `UnaryOp` / `IndexExpression` / …) inherits it.
- `__hash__` unaffected: defining `__ne__` (unlike `__eq__`) does not null `__hash__`;
  `Variable.__hash__` still works and a `Variable` remains dict/set-usable (test covers this).
- Verified no internal code relies on `Expression`-level `!=` — every `!=` across
  `modeling/` and `_jax/` operates on scalars / str / enums / ndarrays, none on
  `Expression` objects. `==` still returns a `Constraint`.

### Regression test
`python/tests/test_c11_ne_guard.py` — 6 sub-second `@pytest.mark.smoke` tests calling
the modeling API directly. **4/6 fail before the fix, 6/6 pass after.** Covers `x != 0`,
`x != y`, derived `BinaryOp`/`UnaryOp`, indexed array expr, `==`-still-a-Constraint, and
hashability.

### Gates run
- `pytest -m smoke` (python/tests): **484 passed, 1 skipped, 0 failed**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed, 0 failed**
- `pytest -k "modeling or api or variable or constraint or model"`: **629 passed, 1 skipped, 0 failed**
- `ruff check` + `ruff format --check`: clean
- `mypy` on `modeling/core.py`: clean (only pre-existing numpy-stub / unrelated-module errors)
- `incorrect_count = 0`; Rust untouched (no `cargo test` needed)

Card updated to `fixed` with a Log entry in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
