### PR TITLE
fix(correctness): C-22 interval_mul NaN endpoints on 0·∞ (lost tightening)

### DIFF
--- a/crates/discopt-core/src/presolve/fbbt.rs
+++ b/crates/discopt-core/src/presolve/fbbt.rs
@@ -115,11 +115,28 @@ pub fn interval_sub(a: &Interval, b: &Interval) -> Interval {
 }
 
 /// `[a,b] * [c,d]` using all four endpoint products.
+///
+/// A finite `0` endpoint multiplied by an infinite endpoint yields `0 * ±∞ =
+/// NaN` in IEEE-754. By the interval-multiplication convention the product of a
+/// zero factor with any interval (including an unbounded one) is `0`, so we map
+/// those NaN corner products to `0` (C-22). This keeps `interval_mul` a sound,
+/// finite outer enclosure — e.g. `[0,0] * [-∞,∞] = [0,0]` rather than the
+/// `[NaN,NaN]` that would silently discard downstream tightening. NaN can arise
+/// here *only* from `0 * ±∞`; every other operand pair is finite×finite (never
+/// NaN) or a genuine ±∞ product, so the substitution never masks a real value.
 pub fn interval_mul(a: &Interval, b: &Interval) -> Interval {
-    let p1 = a.lo * b.lo;
-    let p2 = a.lo * b.hi;
-    let p3 = a.hi * b.lo;
-    let p4 = a.hi * b.hi;
+    let prod = |x: f64, y: f64| {
+        let p = x * y;
+        if p.is_nan() {
+            0.0
+        } else {
+            p
+        }
+    };
+    let p1 = prod(a.lo, b.lo);
+    let p2 = prod(a.lo, b.hi);
+    let p3 = prod(a.hi, b.lo);
+    let p4 = prod(a.hi, b.hi);
     Interval::new(p1.min(p2).min(p3).min(p4), p1.max(p2).max(p3).max(p4))
 }
 
@@ -1323,6 +1340,106 @@ mod tests {
         let r = interval_mul(&a, &b);
         assert!((r.lo - (-8.0)).abs() < 1e-15);
         assert!((r.hi - 12.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn c22_interval_mul_zero_times_entire_is_zero() {
+        // C-22: [0,0] * [-inf, inf]. Each corner product is 0 * (±inf) = NaN.
+        // Before the fix, f64::min/max propagate NaN and the result is [NaN, NaN]
+        // — a "lost tightening" bug (any variable intersected with a NaN interval
+        // keeps its stale bound). By the interval convention 0 * anything = 0, so
+        // the sound, informative enclosure is [0, 0].
+        let a = Interval::point(0.0);
+        let b = Interval::entire();
+        let r = interval_mul(&a, &b);
+        assert!(!r.lo.is_nan() && !r.hi.is_nan(), "result must not be NaN");
+        assert_eq!(r.lo, 0.0);
+        assert_eq!(r.hi, 0.0);
+    }
+
+    #[test]
+    fn c22_interval_mul_never_nan_and_encloses_true_product() {
+        // C-22 property test: over a grid of intervals including infinite
+        // endpoints and zero-width [0,0] factors, interval_mul must (a) never
+        // produce NaN endpoints and (b) contain the true product of every pair
+        // of representative points drawn from the two intervals (rigorous
+        // outer enclosure). A NaN endpoint fails containment silently, so we
+        // check both explicitly.
+        let ninf = f64::NEG_INFINITY;
+        let pinf = f64::INFINITY;
+        let bounds = [ninf, -3.0, -1.0, 0.0, 1.0, 2.5, pinf];
+        for &alo in &bounds {
+            for &ahi in &bounds {
+                if alo > ahi {
+                    continue;
+                }
+                for &blo in &bounds {
+                    for &bhi in &bounds {
+                        if blo > bhi {
+                            continue;
+                        }
+                        let a = Interval::new(alo, ahi);
+                        let b = Interval::new(blo, bhi);
+                        let r = interval_mul(&a, &b);
+                        assert!(
+                            !r.lo.is_nan() && !r.hi.is_nan(),
+                            "interval_mul({a:?}, {b:?}) produced NaN: {r:?}"
+                        );
+                        assert!(r.lo <= r.hi, "interval_mul({a:?}, {b:?}) => {r:?}");
+                        // Containment: probe *finite* points from each factor and
+                        // require the product lies within the result interval.
+                        // A finite point drawn from an unbounded factor is still
+                        // a member of that interval, so its product must be
+                        // enclosed. (Degenerate point-at-infinity intervals like
+                        // [-inf,-inf] have no finite members and are excluded by
+                        // finite_probes returning empty.)
+                        let a_pts = finite_probes(alo, ahi);
+                        let b_pts = finite_probes(blo, bhi);
+                        for &x in &a_pts {
+                            for &y in &b_pts {
+                                let p = x * y;
+                                assert!(
+                                    p >= r.lo - 1e-6 && p <= r.hi + 1e-6,
+                                    "product {p} of {x}*{y} escaped {r:?} \
+                                     for a={a:?} b={b:?}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Genuine finite members of `[lo, hi]` used as containment witnesses in
+    /// the C-22 property test. Every returned value satisfies `lo <= v <= hi`.
+    /// Unbounded sides are probed with a large finite magnitude (still a member);
+    /// a degenerate point-at-infinity interval (e.g. `[-inf,-inf]`) has no finite
+    /// members and returns empty.
+    fn finite_probes(lo: f64, hi: f64) -> Vec<f64> {
+        let mut pts = Vec::new();
+        if lo.is_finite() {
+            pts.push(lo);
+        } else if lo == f64::NEG_INFINITY && hi > f64::NEG_INFINITY {
+            // A large-magnitude negative member, but never above hi.
+            let cap = if hi.is_finite() { hi } else { 1e6 };
+            pts.push((-1e6_f64).min(cap));
+        }
+        if hi.is_finite() {
+            pts.push(hi);
+        } else if hi == f64::INFINITY && lo < f64::INFINITY {
+            // A large-magnitude positive member, but never below lo.
+            let floor = if lo.is_finite() { lo } else { -1e6 };
+            pts.push((1e6_f64).max(floor));
+        }
+        if lo.is_finite() && hi.is_finite() && (hi - lo).abs() > 1e-15 {
+            pts.push(lo + (hi - lo) * 0.5);
+        }
+        // Include 0 when it is a member — exercises the 0 * ±∞ corner.
+        if lo <= 0.0 && hi >= 0.0 {
+            pts.push(0.0);
+        }
+        pts
     }
 
     #[test]

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -106,7 +106,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-10 | P2 | lp_spatial cuts | GMI cuts appended without rhs safety margin (opt-in path) | open |
 | C-3 | P2 | solver.py incumbent | unrounded integer incumbent survives if terminal polish throws | fixed |
 | C-11 | P2 | modeling API | missing `__ne__` → `x != y` silently evaluates False | fixed |
-| C-22 | P3 | fbbt.rs interval | `interval_mul` NaN endpoints on 0·∞ (lost tightening, not unsound) | open |
+| C-22 | P3 | fbbt.rs interval | `interval_mul` NaN endpoints on 0·∞ (lost tightening, not unsound) | fixed |
 | C-23 | P1 | mccormick.py | ESCALATED (was P3): `relax_div` produces an invalid convex underestimator (cv > f) for **nonlinear** denominators (`1/(x*y)` cv=1.334 > true 1.0) — the "harmless" label held only for variable/affine denominators; `_relax_reciprocal` also mislabels concavity for negative denominators (= DIV-1) | fixed |
 | C-24 | P3 | mccormick.py | secants produce NaN on infinite bounds; soundness leans on downstream filters | open |
 | C-12 | P3 | .nl parser | range-split renumbers constraints vs source indices | fixed (documented) |
@@ -1412,7 +1412,33 @@ convention).
 test over random intervals incl. infinite endpoints: result contains the true
 product range and is never NaN; standing gates pass.
 
-**Log:** —
+**Log:**
+- 2026-07-03 — **CONFIRMED then FIXED** (`open`→`fixed`). Confirmed via a new
+  Rust unit test: `interval_mul([0,0], entire())` returned `[NaN, NaN]` on the
+  pre-fix code (each corner is `0 * ±∞ = NaN`; `f64::min/max` then propagate NaN),
+  and a grid property test over infinite-endpoint intervals hit NaN endpoints.
+  Verified fail-before (both tests red on pre-fix) / pass-after by reverting the
+  guard. As the card predicted the defect is *lost tightening* (a variable
+  intersected with a `[NaN,NaN]` interval keeps its stale bound — sound but weak),
+  not an unsound bound; the fix restores the tightening.
+- **Fix** (`presolve/fbbt.rs`, `interval_mul`): map NaN corner products to `0`.
+  NaN here can arise *only* from `0 * ±∞`, whose interval-convention value is `0`;
+  every other operand pair is finite×finite or a genuine ±∞ product, so the
+  substitution never masks a real value. Result: `[0,0]·[−∞,∞] = [0,0]`. Minimal,
+  local; no other operator touched (`interval_div`'s `inv_b` path routes through
+  `interval_mul`, so it inherits the fix). Comment documents the convention.
+- **Regression tests** (`presolve::fbbt::tests`, sub-second, call `interval_mul`
+  directly): `c22_interval_mul_zero_times_entire_is_zero` (the exact `[0,0]·entire`
+  repro) and `c22_interval_mul_never_nan_and_encloses_true_product` (grid over
+  intervals incl. ±∞ endpoints and zero-width factors — asserts never-NaN,
+  `lo ≤ hi`, and rigorous containment of the true product at finite witness
+  points). Both fail before / pass after.
+- **Gates:** `cargo test -p discopt-core` 383 lib + 4 integration + 1 doctest
+  green, no warnings; `cargo clippy -p discopt-core --lib` clean; my added code is
+  `cargo fmt`-clean (the single pre-existing fmt drift at `fbbt.rs:2597` is in the
+  C-31 test block, on `main`, untouched — out of scope). `maturin develop
+  --release` OK; `pytest -m smoke` 193 passed/1 skipped; adversarial suite 10
+  passed; `incorrect_count = 0`. PR: (pending).
 
 ---
 

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -1438,7 +1438,7 @@ product range and is never NaN; standing gates pass.
   `cargo fmt`-clean (the single pre-existing fmt drift at `fbbt.rs:2597` is in the
   C-31 test block, on `main`, untouched — out of scope). `maturin develop
   --release` OK; `pytest -m smoke` 193 passed/1 skipped; adversarial suite 10
-  passed; `incorrect_count = 0`. PR: (pending).
+  passed; `incorrect_count = 0`. PR: #460.
 
 ---
 


### PR DESCRIPTION
## C-22 (P3) — `interval_mul` NaN endpoints on 0·∞

Fixes correctness backlog item **C-22** (`docs/dev/correctness-issues.md`).
One issue, one PR. **CONFIRMED** then fixed; do not merge until reviewed.

### The defect
`crates/discopt-core/src/presolve/fbbt.rs::interval_mul` computed all four corner
products directly. For a factor with a `0` endpoint against an infinite endpoint,
`0 * ±∞ = NaN` (IEEE-754), and `f64::min/max` then propagated NaN, so
`interval_mul([0,0], entire())` returned `[NaN, NaN]`.

A variable later intersected with a `[NaN,NaN]` interval keeps its stale bound
(all comparisons vs NaN are false) — **lost FBBT tightening**. This is *sound but
weak*: the audit found no unsound path, hence P3. Confirmed exactly as the card
described.

### Confirmation (fail-before)
Two new Rust unit tests were written first and shown **red** on the pre-fix code
(verified by reverting only the guard):
- `interval_mul([0,0], entire())` returned `[NaN, NaN]` (expected `[0,0]`).
- A grid property test over infinite-endpoint / zero-width intervals hit NaN
  endpoints.

### The fix (minimal, sound)
In `interval_mul`, map NaN corner products to `0`. NaN here can arise **only**
from `0 * ±∞`, whose interval-multiplication-convention value is `0`; every other
operand pair is finite×finite (never NaN) or a genuine ±∞ product, so the
substitution never masks a real value. `[0,0]·[−∞,∞]` now returns `[0,0]` — a
sound, informative outer enclosure. The result is a strictly *tighter* (never
looser) enclosure than before, so it can only recover tightening, never exclude a
feasible point. `interval_div` inherits the fix via its `inv_b → interval_mul`
path. No other operator touched.

### Regression tests (fast, sub-second, direct calls)
`crates/discopt-core/src/presolve/fbbt.rs` (`presolve::fbbt::tests`):
- `c22_interval_mul_zero_times_entire_is_zero` — the exact `[0,0]·entire` repro.
- `c22_interval_mul_never_nan_and_encloses_true_product` — grid over intervals
  incl. ±∞ endpoints and zero-width `[0,0]` factors: asserts never-NaN, `lo ≤ hi`,
  and rigorous containment of the true product at finite witness points (encodes
  the false-certificate class, not just the one repro).

Both **fail before / pass after**.

### Verification
- `cargo test -p discopt-core` — 383 lib + 4 integration + 1 doctest green, no warnings
- `cargo clippy -p discopt-core --lib` — clean
- Added code is `cargo fmt`-clean (the single pre-existing fmt drift at
  `fbbt.rs:2597` is in the C-31 test block, already on `main`, left untouched — out
  of scope for C-22)
- `maturin develop --release` — OK
- `pytest -m smoke` — 193 passed, 1 skipped
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed
- `incorrect_count = 0`

Card updated (`open` → `fixed`, Log, PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
