### PR TITLE
fix(correctness): C-24 mccormick — ±inf no-info envelope on infinite bounds, never NaN

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -1586,7 +1586,7 @@ non-finite, at the `_secant`/envelope level rather than relying on callers.
 NaN; grep-audit that no caller special-cases NaN envelopes anymore; standing gates
 pass.
 
-**Log:** 2026-07-03 — CONFIRMED and FIXED (status open→fixed, PR #<pending>).
+**Log:** 2026-07-03 — CONFIRMED and FIXED (status open→fixed, PR #462).
 Repro (pre-fix): `_secant(x²,x=0,lb=−2,ub=+∞)=NaN`; `relax_square`/`relax_exp`/
 `relax_cosh` return `cc=NaN` on any half-infinite box; `relax_bilinear` with an
 ∞ factor bound returns `cv=NaN`; `relax_pow` odd on `[−2,+∞)` returns NaN. A NaN

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -108,7 +108,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-11 | P2 | modeling API | missing `__ne__` → `x != y` silently evaluates False | fixed |
 | C-22 | P3 | fbbt.rs interval | `interval_mul` NaN endpoints on 0·∞ (lost tightening, not unsound) | fixed |
 | C-23 | P1 | mccormick.py | ESCALATED (was P3): `relax_div` produces an invalid convex underestimator (cv > f) for **nonlinear** denominators (`1/(x*y)` cv=1.334 > true 1.0) — the "harmless" label held only for variable/affine denominators; `_relax_reciprocal` also mislabels concavity for negative denominators (= DIV-1) | fixed |
-| C-24 | P3 | mccormick.py | secants produce NaN on infinite bounds; soundness leans on downstream filters | open |
+| C-24 | P3 | mccormick.py | secants produce NaN on infinite bounds; soundness leans on downstream filters | fixed |
 | C-12 | P3 | .nl parser | range-split renumbers constraints vs source indices | fixed (documented) |
 | C-25 | P1 | nn/formulations | scaling + bound-propagation domain mismatch cuts the true optimum on scaled embedded NNs | in progress (nn-module-plan T-N0.2) |
 | C-26 | P1 | nn/tree_ensemble | tree big-M invalid for out-of-box thresholds → cuts feasible points | in progress (nn-module-plan T-N0.3) |
@@ -1586,7 +1586,34 @@ non-finite, at the `_secant`/envelope level rather than relying on callers.
 NaN; grep-audit that no caller special-cases NaN envelopes anymore; standing gates
 pass.
 
-**Log:** —
+**Log:** 2026-07-03 — CONFIRMED and FIXED (status open→fixed, PR #<pending>).
+Repro (pre-fix): `_secant(x²,x=0,lb=−2,ub=+∞)=NaN`; `relax_square`/`relax_exp`/
+`relax_cosh` return `cc=NaN` on any half-infinite box; `relax_bilinear` with an
+∞ factor bound returns `cv=NaN`; `relax_pow` odd on `[−2,+∞)` returns NaN. A NaN
+is not a valid envelope — every `cv≤f` / `f≤cc` soundness comparison is False for
+NaN, so an unguarded consumer silently gets an unsafe bound.
+Fix (envelope level, per the sketch): `_secant` gained a `fallback` arg and
+returns it (not NaN) whenever either bound is non-finite; every call site passes
+the sign matching its role (`+∞` for the concave-overestimator `cc`, `−∞` for the
+convex-underestimator `cv`), so the envelope degrades to the sound no-information
+bracket `−∞ ≤ f ≤ +∞`. `relax_bilinear` replaces its whole envelope with
+`(−∞,+∞)` when any factor bound is non-finite (its NaN came from `inf−inf` in the
+affine terms, not from `_secant`). `relax_div`/`_relax_reciprocal` inherit the
+fix through `relax_bilinear` and the reciprocal's finite `1/±∞→0` bounds; the
+sin/cos wide-interval path already returned `[−1,1]` and is unchanged. Curvature
+regimes (C-32) and division math (C-23) left untouched to avoid collision — only
+the ±∞-vs-NaN behaviour changed. Verified: finite random sub-box soundness for
+all univariate + bilinear + odd-power relaxations unchanged (0 crossings, 0 NaN);
+half-infinite boxes now bracket at all sampled interior points with 0 NaN.
+On the downstream filters: the `isfinite` guards in `mccormick_nlp.py`/
+`mccormick_lp.py` are NOT dead after this fix — they still (correctly) drop the
+distinct *singularity* NaN class (`1/(x³·sin x)` at wide bounds) that has nothing
+to do with infinite bounds; removing them would weaken a real safety guard
+(CLAUDE.md §1/§3), so they stay. Regression test:
+`python/tests/test_c24_infinite_bound_envelope.py` (5 `@pytest.mark.smoke` cases,
+sub-second, direct primitive calls) — fails-before (5 red on pre-fix) /
+passes-after. Encodes the class (every secant-using primitive + bilinear + power),
+not a named instance.
 
 ---
 

--- a/python/discopt/_jax/mccormick.py
+++ b/python/discopt/_jax/mccormick.py
@@ -20,10 +20,20 @@ import jax.numpy as jnp
 # ---------------------------------------------------------------------------
 
 
-def _secant(f, x, lb, ub):
+def _secant(f, x, lb, ub, fallback=jnp.inf):
     """Secant line of f between (lb, f(lb)) and (ub, f(ub)) evaluated at x.
 
-    When lb == ub, falls back to f(x) to avoid division by zero.
+    When ``lb == ub``, falls back to ``f(x)`` to avoid division by zero.
+
+    When either bound is non-finite the secant is undefined
+    (``slope = (f(ub) - f(lb)) / (ub - lb)`` becomes ``inf/inf`` = ``NaN``): a
+    secant is only a valid envelope over a *bounded* interval. Rather than leak a
+    NaN (which is not a valid over-/under-estimator and silently defeats every
+    downstream ``cv <= f`` / ``f <= cc`` soundness check), we return an explicit
+    *no-information* value ``fallback``. Callers pass ``+inf`` when the secant
+    plays the concave-overestimator (``cc``) role and ``-inf`` when it plays the
+    convex-underestimator (``cv``) role, so the resulting envelope still brackets
+    ``f`` (``-inf <= f <= +inf``) without fabricating a finite bound. See C-24.
     """
     f_lb = f(lb)
     f_ub = f(ub)
@@ -35,7 +45,10 @@ def _secant(f, x, lb, ub):
     slope = (f_ub - f_lb) / safe_width
     line = f_lb + slope * (x - lb)
     # Degenerate case: lb ≈ ub -> just return f(x)
-    return jnp.where(degenerate, f(x), line)
+    line = jnp.where(degenerate, f(x), line)
+    # Non-finite bound: the secant carries no information -> explicit fallback.
+    both_finite = jnp.isfinite(lb) & jnp.isfinite(ub)
+    return jnp.where(both_finite, line, fallback)
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +79,15 @@ def relax_bilinear(x, y, x_lb, x_ub, y_lb, y_ub):
     # bound at interior points; clamping tightens the relaxation.
     both_nonneg = (x_lb >= 0.0) & (y_lb >= 0.0)
     cv = jnp.where(both_nonneg, jnp.maximum(cv, x_lb * y_lb), cv)
+
+    # The McCormick envelope of x*y is only valid over a *bounded* box: with a
+    # non-finite factor bound the affine terms carry ``inf*·`` / ``inf - inf`` =
+    # ``NaN`` (an invalid, non-bracketing value). Replace the whole envelope with
+    # an explicit no-information bracket (cv=-inf, cc=+inf) rather than leaking a
+    # NaN a downstream consumer might use unguarded. See C-24.
+    all_finite = jnp.isfinite(x_lb) & jnp.isfinite(x_ub) & jnp.isfinite(y_lb) & jnp.isfinite(y_ub)
+    cv = jnp.where(all_finite, cv, -jnp.inf)
+    cc = jnp.where(all_finite, cc, jnp.inf)
 
     return cv, cc
 
@@ -209,7 +231,7 @@ def relax_pow(x, lb, ub, n):
     case1_cc = _secant(f, x, lb, ub)
 
     # Case 2: ub <= 0 -> fully concave: cv = secant, cc = f(x)
-    case2_cv = _secant(f, x, lb, ub)
+    case2_cv = _secant(f, x, lb, ub, fallback=-jnp.inf)
     case2_cc = f(x)
 
     # Case 3: lb < 0 < ub -> inflection at 0
@@ -217,8 +239,8 @@ def relax_pow(x, lb, ub, n):
     # - x >= 0: f is convex -> cv = f(x), cc = secant on [0, ub]
     # - x < 0:  f is concave -> cv = secant on [lb, 0], cc = f(x)
     zero = jnp.zeros_like(x)
-    sec_neg = _secant(f, x, lb, zero)
-    sec_pos = _secant(f, x, zero, ub)
+    sec_neg = _secant(f, x, lb, zero, fallback=-jnp.inf)  # concave-half cv role
+    sec_pos = _secant(f, x, zero, ub)  # convex-half cc role
     case3_cv = jnp.where(x >= 0, f(x), sec_neg)
     case3_cc = jnp.where(x >= 0, sec_pos, f(x))
 
@@ -292,7 +314,7 @@ def relax_sqrt(x, lb, ub):
     Returns (cv, cc).
     """
     cc = jnp.sqrt(x)
-    cv = _secant(jnp.sqrt, x, lb, ub)
+    cv = _secant(jnp.sqrt, x, lb, ub, fallback=-jnp.inf)
     return cv, cc
 
 
@@ -303,7 +325,7 @@ def relax_log(x, lb, ub):
     Returns (cv, cc).
     """
     cc = jnp.log(x)
-    cv = _secant(jnp.log, x, lb, ub)
+    cv = _secant(jnp.log, x, lb, ub, fallback=-jnp.inf)
     return cv, cc
 
 
@@ -314,7 +336,7 @@ def relax_log2(x, lb, ub):
     Returns (cv, cc).
     """
     cc = jnp.log2(x)
-    cv = _secant(jnp.log2, x, lb, ub)
+    cv = _secant(jnp.log2, x, lb, ub, fallback=-jnp.inf)
     return cv, cc
 
 
@@ -325,7 +347,7 @@ def relax_log10(x, lb, ub):
     Returns (cv, cc).
     """
     cc = jnp.log10(x)
-    cv = _secant(jnp.log10, x, lb, ub)
+    cv = _secant(jnp.log10, x, lb, ub, fallback=-jnp.inf)
     return cv, cc
 
 
@@ -474,12 +496,12 @@ def relax_tan(x, lb, ub):
     case1_cc = _secant(f, x, lb, ub)
 
     # Case 2: ub <= center -> concave half: cv = secant, cc = f(x)
-    case2_cv = _secant(f, x, lb, ub)
+    case2_cv = _secant(f, x, lb, ub, fallback=-jnp.inf)
     case2_cc = f(x)
 
     # Case 3: lb < center < ub -> piecewise
-    sec_neg = _secant(f, x, lb, center)
-    sec_pos = _secant(f, x, center, ub)
+    sec_neg = _secant(f, x, lb, center, fallback=-jnp.inf)  # concave-half cv role
+    sec_pos = _secant(f, x, center, ub)  # convex-half cc role
     case3_cv = jnp.where(x >= center, f(x), sec_neg)
     case3_cc = jnp.where(x >= center, sec_pos, f(x))
 
@@ -513,7 +535,7 @@ def relax_atan(x, lb, ub):
     f = jnp.arctan
 
     # Case 1: lb >= 0 -> concave: cv = secant, cc = f(x)
-    case1_cv = _secant(f, x, lb, ub)
+    case1_cv = _secant(f, x, lb, ub, fallback=-jnp.inf)
     case1_cc = f(x)
 
     # Case 2: ub <= 0 -> convex: cv = f(x), cc = secant
@@ -521,8 +543,8 @@ def relax_atan(x, lb, ub):
     case2_cc = _secant(f, x, lb, ub)
 
     # Case 3: lb < 0 < ub -> mixed
-    sec_neg = _secant(f, x, lb, 0.0)
-    sec_pos = _secant(f, x, 0.0, ub)
+    sec_neg = _secant(f, x, lb, 0.0)  # convex-half cc role (x < 0)
+    sec_pos = _secant(f, x, 0.0, ub, fallback=-jnp.inf)  # concave-half cv role (x >= 0)
     case3_cv = jnp.where(x >= 0, sec_pos, f(x))
     case3_cc = jnp.where(x >= 0, f(x), sec_neg)
 
@@ -546,19 +568,19 @@ def relax_asin(x, lb, ub):
     """
     f = jnp.arcsin
 
-    # Case 1: lb >= 0 -> convex: cv = f(x), cc = secant
+    # Case 1: lb >= 0 -> convex: cv = f(x), cc = secant (cc/overestimator role)
     case1_cv = f(x)
     case1_cc = _secant(f, x, lb, ub)
 
-    # Case 2: ub <= 0 -> concave: cv = secant, cc = f(x)
-    case2_cv = _secant(f, x, lb, ub)
+    # Case 2: ub <= 0 -> concave: cv = secant (cv/underestimator role), cc = f(x)
+    case2_cv = _secant(f, x, lb, ub, fallback=-jnp.inf)
     case2_cc = f(x)
 
     # Case 3: lb < 0 < ub -> straddles the inflection at 0. Split at 0:
     # positive (convex) side -> f(x)/sec_pos; negative (concave) side ->
     # sec_neg/f(x).
-    sec_neg = _secant(f, x, lb, 0.0)
-    sec_pos = _secant(f, x, 0.0, ub)
+    sec_neg = _secant(f, x, lb, 0.0, fallback=-jnp.inf)  # cv role (x < 0 concave half)
+    sec_pos = _secant(f, x, 0.0, ub)  # cc role (x >= 0 convex half)
     case3_cv = jnp.where(x >= 0, f(x), sec_neg)
     case3_cc = jnp.where(x >= 0, sec_pos, f(x))
 
@@ -584,19 +606,19 @@ def relax_acos(x, lb, ub):
     """
     f = jnp.arccos
 
-    # Case 1: lb >= 0 -> concave: cv = secant, cc = f(x)
-    case1_cv = _secant(f, x, lb, ub)
+    # Case 1: lb >= 0 -> concave: cv = secant (cv/underestimator role), cc = f(x)
+    case1_cv = _secant(f, x, lb, ub, fallback=-jnp.inf)
     case1_cc = f(x)
 
-    # Case 2: ub <= 0 -> convex: cv = f(x), cc = secant
+    # Case 2: ub <= 0 -> convex: cv = f(x), cc = secant (cc/overestimator role)
     case2_cv = f(x)
     case2_cc = _secant(f, x, lb, ub)
 
     # Case 3: lb < 0 < ub -> straddles the inflection at 0. Split at 0:
     # positive (concave) side -> sec_pos/f(x); negative (convex) side ->
     # f(x)/sec_neg.
-    sec_neg = _secant(f, x, lb, 0.0)
-    sec_pos = _secant(f, x, 0.0, ub)
+    sec_neg = _secant(f, x, lb, 0.0)  # cc role (x < 0 convex half)
+    sec_pos = _secant(f, x, 0.0, ub, fallback=-jnp.inf)  # cv role (x >= 0 concave half)
     case3_cv = jnp.where(x >= 0, sec_pos, f(x))
     case3_cc = jnp.where(x >= 0, f(x), sec_neg)
 
@@ -624,11 +646,11 @@ def relax_sinh(x, lb, ub):
     case1_cv = f(x)
     case1_cc = _secant(f, x, lb, ub)
 
-    case2_cv = _secant(f, x, lb, ub)
+    case2_cv = _secant(f, x, lb, ub, fallback=-jnp.inf)
     case2_cc = f(x)
 
-    sec_neg = _secant(f, x, lb, 0.0)
-    sec_pos = _secant(f, x, 0.0, ub)
+    sec_neg = _secant(f, x, lb, 0.0, fallback=-jnp.inf)  # concave-half cv role (x < 0)
+    sec_pos = _secant(f, x, 0.0, ub)  # convex-half cc role (x >= 0)
     case3_cv = jnp.where(x >= 0, f(x), sec_neg)
     case3_cc = jnp.where(x >= 0, sec_pos, f(x))
 
@@ -659,14 +681,14 @@ def relax_tanh(x, lb, ub):
     """
     f = jnp.tanh
 
-    case1_cv = _secant(f, x, lb, ub)
+    case1_cv = _secant(f, x, lb, ub, fallback=-jnp.inf)
     case1_cc = f(x)
 
     case2_cv = f(x)
     case2_cc = _secant(f, x, lb, ub)
 
-    sec_neg = _secant(f, x, lb, 0.0)
-    sec_pos = _secant(f, x, 0.0, ub)
+    sec_neg = _secant(f, x, lb, 0.0)  # convex-half cc role (x < 0)
+    sec_pos = _secant(f, x, 0.0, ub, fallback=-jnp.inf)  # concave-half cv role (x >= 0)
     case3_cv = jnp.where(x >= 0, sec_pos, f(x))
     case3_cc = jnp.where(x >= 0, f(x), sec_neg)
 
@@ -689,7 +711,7 @@ def relax_sigmoid(x, lb, ub):
     f = jnn.sigmoid
 
     # Case 1: lb >= 0 → concave region
-    case1_cv = _secant(f, x, lb, ub)
+    case1_cv = _secant(f, x, lb, ub, fallback=-jnp.inf)
     case1_cc = f(x)
 
     # Case 2: ub <= 0 → convex region
@@ -697,8 +719,8 @@ def relax_sigmoid(x, lb, ub):
     case2_cc = _secant(f, x, lb, ub)
 
     # Case 3: lb < 0 < ub → mixed
-    sec_neg = _secant(f, x, lb, 0.0)
-    sec_pos = _secant(f, x, 0.0, ub)
+    sec_neg = _secant(f, x, lb, 0.0)  # convex-half cc role (x < 0)
+    sec_pos = _secant(f, x, 0.0, ub, fallback=-jnp.inf)  # concave-half cv role (x >= 0)
     case3_cv = jnp.where(x >= 0, sec_pos, f(x))
     case3_cc = jnp.where(x >= 0, f(x), sec_neg)
 

--- a/python/tests/test_c24_infinite_bound_envelope.py
+++ b/python/tests/test_c24_infinite_bound_envelope.py
@@ -1,0 +1,127 @@
+"""C-24: McCormick secant envelopes must never return NaN on infinite bounds.
+
+`_secant` computes ``slope = (f(ub) - f(lb)) / (ub - lb)``. When either bound is
+non-finite this is ``inf/inf`` / ``inf - inf`` = ``NaN``, and the NaN propagates
+into ``cc`` (for convex relaxations) or ``cv`` (for concave relaxations) and into
+``relax_bilinear``. A NaN is not a valid over/under-estimator: it silently defeats
+downstream soundness comparisons (``cv <= f``, ``f <= cc``) which are all False for
+NaN, and any consumer that uses the value unguarded gets an unsafe bound.
+
+The sound behavior on a half-/fully-infinite box is a *no-information* envelope:
+the concave overestimator is ``+inf`` and the convex underestimator is ``-inf``.
+These tests pin that: on infinite bounds the primitives must return an envelope
+that (a) is never NaN and (b) still brackets the function ``cv <= f <= cc``.
+
+All calls hit the relaxation primitives directly, so this is a sub-second smoke
+test suitable for every-PR CI.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt._jax import mccormick as mc
+
+
+def _finite_and_brackets(cv, cc, fx):
+    """cv, cc must be non-NaN and bracket fx (allowing +/-inf as no-info)."""
+    cv = float(cv)
+    cc = float(cc)
+    fx = float(fx)
+    assert not np.isnan(cv), f"cv is NaN (fx={fx})"
+    assert not np.isnan(cc), f"cc is NaN (fx={fx})"
+    # Bracketing: cv <= f <= cc, with +/-inf permitted as no-information.
+    assert cv <= fx + 1e-9, f"cv={cv} > f={fx}"
+    assert cc >= fx - 1e-9, f"cc={cc} < f={fx}"
+
+
+@pytest.mark.smoke
+def test_secant_infinite_bounds_no_nan():
+    """`_secant` on an infinite bound returns the requested no-info fallback,
+    never NaN."""
+
+    def f(t):
+        return t**2
+
+    # Overestimator role -> fallback +inf; underestimator role -> fallback -inf.
+    for lb, ub in [(-2.0, np.inf), (-np.inf, 2.0), (-np.inf, np.inf), (1.0, np.inf)]:
+        cc = mc._secant(f, jnp.array(0.0), jnp.array(lb), jnp.array(ub), fallback=jnp.inf)
+        cv = mc._secant(f, jnp.array(0.0), jnp.array(lb), jnp.array(ub), fallback=-jnp.inf)
+        assert not np.isnan(float(cc)), f"cc NaN on [{lb},{ub}]"
+        assert not np.isnan(float(cv)), f"cv NaN on [{lb},{ub}]"
+        assert float(cc) == np.inf
+        assert float(cv) == -np.inf
+
+    # Finite bounds must be unaffected (regression guard on the sound path).
+    cc = mc._secant(f, jnp.array(0.0), jnp.array(-2.0), jnp.array(2.0), fallback=jnp.inf)
+    assert abs(float(cc) - 4.0) < 1e-9  # secant of x^2 over [-2,2] at 0 is 4
+
+
+@pytest.mark.smoke
+def test_convex_relaxations_infinite_bounds_no_nan():
+    """Convex univariate relaxations (cc = secant) must not emit a NaN cc when a
+    bound is infinite; cc must be a valid overestimator (+inf ok)."""
+    cases = [
+        (mc.relax_square, lambda x: x**2, 0.0),
+        (mc.relax_exp, lambda x: np.exp(x), 0.0),
+        (mc.relax_cosh, lambda x: np.cosh(x), 0.0),
+    ]
+    for relax_fn, f, x in cases:
+        for lb, ub in [(-2.0, np.inf), (-np.inf, 2.0), (-np.inf, np.inf)]:
+            cv, cc = relax_fn(jnp.array(x), jnp.array(lb), jnp.array(ub))
+            _finite_and_brackets(cv, cc, f(x))
+
+
+@pytest.mark.smoke
+def test_concave_relaxations_infinite_bounds_no_nan():
+    """Concave univariate relaxations (cv = secant) must not emit a NaN cv when
+    the upper bound is infinite; cv must be a valid underestimator (-inf ok)."""
+    # sqrt/log require lb finite & > 0; ub can be +inf.
+    cases = [
+        (mc.relax_sqrt, lambda x: np.sqrt(x), 1.0, 0.0),
+        (mc.relax_log, lambda x: np.log(x), 1.0, 0.5),
+    ]
+    for relax_fn, f, x, lb in cases:
+        cv, cc = relax_fn(jnp.array(x), jnp.array(lb), jnp.array(np.inf))
+        _finite_and_brackets(cv, cc, f(x))
+
+
+@pytest.mark.smoke
+def test_bilinear_infinite_bounds_no_nan():
+    """`relax_bilinear` must not emit NaN cv/cc when a factor bound is infinite.
+    The envelopes must still bracket the product at an interior point."""
+    x, y = 1.0, 1.0
+    for x_lb, x_ub, y_lb, y_ub in [
+        (-2.0, np.inf, -2.0, 2.0),
+        (-np.inf, 2.0, -2.0, 2.0),
+        (-2.0, 2.0, -np.inf, np.inf),
+        (0.0, np.inf, 0.0, np.inf),
+    ]:
+        cv, cc = mc.relax_bilinear(
+            jnp.array(x),
+            jnp.array(y),
+            jnp.array(x_lb),
+            jnp.array(x_ub),
+            jnp.array(y_lb),
+            jnp.array(y_ub),
+        )
+        _finite_and_brackets(cv, cc, x * y)
+
+
+@pytest.mark.smoke
+def test_pow_odd_infinite_bounds_no_nan():
+    """Odd-power relaxation (piecewise secants) must not emit NaN on inf bounds."""
+    n = 3
+    f = lambda t: t**n  # noqa: E731
+    for lb, ub, x in [(-2.0, np.inf, 0.5), (-np.inf, 2.0, -0.5), (-np.inf, np.inf, 0.0)]:
+        cv, cc = mc.relax_pow(jnp.array(x), jnp.array(lb), jnp.array(ub), n)
+        _finite_and_brackets(cv, cc, f(x))


### PR DESCRIPTION
## C-24 (P3) — McCormick secant envelopes return NaN on infinite bounds

### Confirmed
`_secant` divides by `ub - lb`; with a non-finite bound this is `inf/inf` /
`inf - inf` = **NaN**, which propagates into `cc` (convex relaxations), `cv`
(concave relaxations), and `relax_bilinear`. Direct repro on pre-fix code:

- `_secant(x², x=0, lb=-2, ub=+inf) = NaN`
- `relax_square` / `relax_exp` / `relax_cosh` return `cc = NaN` on any
  half-infinite box
- `relax_bilinear` with an `inf` factor bound returns `cv = NaN`
- `relax_pow(x, [-2, +inf), n=3)` returns `NaN`

A NaN is not a valid envelope: every `cv <= f` / `f <= cc` soundness comparison is
False for NaN, so an unguarded consumer silently gets an unsafe bound. Soundness
leaned entirely on the downstream inf/NaN filters — exactly the fragility the card
flags.

### Fix (envelope level, per the sketch)
- `_secant` gains a `fallback` arg and returns it (not NaN) whenever either bound
  is non-finite. Every call site passes the sign matching its role: `+inf` for the
  concave-overestimator (`cc`) role, `-inf` for the convex-underestimator (`cv`)
  role, so the envelope degrades to the sound no-information bracket
  `-inf <= f <= +inf` without fabricating a finite bound.
- `relax_bilinear` replaces its whole envelope with `(-inf, +inf)` when any factor
  bound is non-finite (its NaN came from `inf - inf` in the affine terms, not from
  `_secant`). `relax_div` / `_relax_reciprocal` inherit the fix through
  `relax_bilinear`.
- The `sin`/`cos` wide-interval path already returned `[-1, 1]` and is unchanged.

Scope discipline: curvature regimes (**C-32**) and division math (**C-23**) are
left untouched to avoid collision — only the ±inf-vs-NaN behaviour changed. The
`isfinite` filters in `mccormick_nlp.py` / `mccormick_lp.py` are **retained**: they
still (correctly) drop the distinct *singularity*-NaN class (`1/(x³·sin x)` at wide
bounds), and removing them would weaken a real safety guard (CLAUDE.md §1/§3).

### Regression test (fail-before / pass-after)
`python/tests/test_c24_infinite_bound_envelope.py` — 5 sub-second
`@pytest.mark.smoke` cases calling the primitives directly on half-/fully-infinite
boxes; asserts non-NaN and `cv <= f <= cc` across every secant-using primitive +
bilinear + odd power. **5 red on pre-fix, 5 green after.** Encodes the class, not a
named instance.

### Verification
- `pytest -m smoke` (worktree source): **198 passed, 1 skipped, 0 failed**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed**
- `pytest python/tests/ -k "mccormick or envelope or relax or convex"`:
  **1139 passed, 0 failed** (includes the 5 new tests and `test_amp`)
- Finite random sub-box soundness for all univariate + bilinear + odd-power
  relaxations unchanged: **0 crossings, 0 NaN**; half-infinite boxes now bracket at
  every sampled interior point with 0 NaN
- `ruff check` + `ruff format --check`: clean
- No Rust touched (pure Python/JAX), so no `cargo test` / `maturin develop` needed
- `incorrect_count`: unchanged — envelopes only got **wider** on infinite boxes,
  never tighter, so no certified bound can move

> `mypy python/discopt/` is blocked by a pre-existing numpy-stub / py3.12-venv vs
> py3.10-target artifact that halts before reaching this file (identical on `main`);
> no new mypy error is introduced.

Closes C-24 (status `open` → `fixed` in `docs/dev/correctness-issues.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
