### PR TITLE
fix(correctness): C-10 apply rhs safety margin to LP-spatial GMI cuts

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -103,7 +103,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-7 | P2 | .nl parser | defined variables (V segments) discarded → hard parse error | fixed |
 | C-8 | P2 | .nl parser | common opcodes unhandled (o76/o77/o78/o48/o11/o12/o35) | fixed |
 | C-9 | P2 | .nl parser | nlvo>nlvc integer-block classification unverified | fixed |
-| C-10 | P2 | lp_spatial cuts | GMI cuts appended without rhs safety margin (opt-in path) | open |
+| C-10 | P2 | lp_spatial cuts | GMI cuts appended without rhs safety margin (opt-in path) | fixed |
 | C-3 | P2 | solver.py incumbent | unrounded integer incumbent survives if terminal polish throws | fixed |
 | C-11 | P2 | modeling API | missing `__ne__` → `x != y` silently evaluates False | fixed |
 | C-22 | P3 | fbbt.rs interval | `interval_mul` NaN endpoints on 0·∞ (lost tightening, not unsound) | fixed |
@@ -1008,7 +1008,43 @@ for the ≤ form), matching `_augment_lpdata_with_gomory_cuts`.
 cut rounds enabled (enumerate feasible integer points in a small box; none
 violated); standing gates pass.
 
-**Log:** —
+**Log:**
+- 2026-07-03 — **CONFIRMED then FIXED.** Confirmed dynamically (not just by static
+  read): drove the incremental-McCormick node LP of a small all-integer bilinear
+  model (`a*b + c >= 10`, box `[0,6]×[0,5]×[0,4]`) through the actual
+  `_separate_node_cuts` GMI branch and reproduced the raw crossover-vertex GMI cut
+  independently. The emitted GMI cut's `<=` rhs was **byte-identical** to the raw
+  Rust GMI rhs (`-6.000000000000001`) — no safety margin, exactly as the card
+  predicts. Every other GMI consumer relaxes by `1e-7·(1+‖row‖₁)`; this path did
+  not, so a cut whose boundary passes through a feasible integer point could shave
+  it under the ~1e-12 float error the crossover vertex carries.
+- **Fix (per the card sketch).** `lp_spatial_bb.py:_separate_node_cuts` GMI branch
+  now adds `margin = 1e-7*(1+‖row‖₁)` to each cut's `<=` rhs before appending —
+  matching `solver.py:_augment_lpdata_with_gomory_cuts` / `cmir_cuts.py`. Sound by
+  construction: the margin only ever moves the cut *outward* (relaxes the
+  constraint), so it can never remove a feasible point; it only forgoes cutting an
+  ~1e-7-thin sliver. The cMIR/aggregation branches already carried their own
+  margins and were left untouched. No validity check weakened; no other path
+  changed.
+- **Regression tests** (`python/tests/test_lp_spatial_bb.py`, `@pytest.mark.smoke`,
+  sub-second, direct calls into `_separate_node_cuts` — no full solve; verified
+  RED-before/GREEN-after by stashing the fix):
+  `test_c10_lp_spatial_gmi_cut_carries_safety_margin` (reconstructs the raw GMI
+  cut and asserts the emitted rhs is relaxed outward by *exactly* the margin — RED
+  pre-fix: emitted == raw, no margin) and `test_c10_no_feasible_integer_point_is_cut`
+  (encodes the class invariant: enumerates every integer-feasible point of the
+  model and asserts no emitted node cut violates it). The first test pins the
+  emission contract so any future revert to a raw-rhs append trips CI immediately.
+- **Gates:** C-10 tests 2 passed (RED-before confirmed via `git stash`); cut suite
+  (`test_{cutting_planes,cover_cuts,conflict_cuts,clique_cuts,constraint_cuts,rlt_cuts,auto_cut_policy,cut_recognizer,lp_spatial_bb}`)
+  135 passed; `-k "mccormick or relax or spatial" -m "not slow"` 693 passed / 1
+  skipped; `pytest -m smoke` 480 passed / 1 skipped; adversarial
+  `test_adversarial_recent_fixes.py -m slow` 10 passed; `ruff check` +
+  `ruff format --check` clean; pre-commit `mypy` passed. No Rust touched (no
+  `cargo test`). `incorrect_count` unchanged (0 failures across all suites; no
+  correctness assertion weakened). PR: (pending).
+
+**Status:** open → fixed.
 
 ---
 

--- a/python/discopt/_jax/lp_spatial_bb.py
+++ b/python/discopt/_jax/lp_spatial_bb.py
@@ -131,7 +131,16 @@ def _separate_node_cuts(A, b, bounds, x, ncol, c, max_cuts=12):
         gc = _separate_gomory_cuts(lp, xv, ncol, list(range(ncol)), max_cuts=max_cuts)
         if gc is not None:
             for i in range(len(gc[1])):  # GMI returns coeffs·x >= rhs -> negate to <=
-                cuts.append((-np.asarray(gc[0][i])[:ncol], -float(gc[1][i])))
+                row = -np.asarray(gc[0][i])[:ncol]
+                # GMI validity holds only up to machine precision (gomory.rs:31); the
+                # raw crossover vertex the cut separates carries ~1e-12 float error, so
+                # a cut whose boundary passes through a feasible integer point could
+                # shave it. Relax the <= rhs outward by the same safe margin every
+                # other GMI consumer uses (solver.py _augment_lpdata_with_gomory_cuts,
+                # cmir_cuts.py) — C-10. Sound: it only ever moves the cut AWAY from the
+                # feasible region, never removing a feasible point.
+                margin = 1e-7 * (1.0 + float(np.abs(row).sum()))
+                cuts.append((row, -float(gc[1][i]) + margin))
     except Exception:
         pass
     # complemented-MIR (multi-row aggregation)

--- a/python/tests/test_lp_spatial_bb.py
+++ b/python/tests/test_lp_spatial_bb.py
@@ -10,10 +10,105 @@ os.environ.setdefault("JAX_PLATFORMS", "cpu")
 os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
 import pytest  # noqa: E402
-from discopt._jax.lp_spatial_bb import solve_lp_spatial_bb  # noqa: E402
+from discopt._jax.lp_spatial_bb import _separate_node_cuts, solve_lp_spatial_bb  # noqa: E402
 
 _DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib")
+
+
+def _assemble_node_lp(ux=6, uy=5, uz=4):
+    """Build a small all-integer bilinear node LP that drives the incremental
+    McCormick path (``inc.ok``) and yields at least one GMI cut. Returns
+    ``(inc, A, b, bounds, x, ncol)`` for the root box."""
+    from discopt._jax.incremental_mccormick import IncrementalMcCormickLP
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    m = dm.Model("c10")
+    a = m.integer("a", lb=0, ub=ux)
+    b = m.integer("b", lb=0, ub=uy)
+    c = m.integer("c", lb=0, ub=uz)
+    m.minimize(a + b + c)
+    m.subject_to(a * b + c >= 10)
+    terms = classify_nonlinear_terms(m)
+    inc = IncrementalMcCormickLP(m, terms)
+    assert inc.ok, "incremental McCormick path required for the GMI cut branch"
+    lb = np.array([0.0, 0.0, 0.0])
+    ub = np.array([float(ux), float(uy), float(uz)])
+    A, b_, bounds = inc.assemble(lb, ub, [])
+    bd, x, _ = inc.solve_assembled(A, b_, bounds)
+    assert x is not None
+    return inc, A, b_, bounds, x, inc.ncol
+
+
+def _raw_gmi_cuts(inc, A, b, bounds, x, ncol):
+    """Reproduce the *unmargined* GMI cuts exactly as ``_separate_node_cuts``'s
+    GMI branch derives them (crossover vertex -> Rust GMI -> negate to <=), so a
+    test can assert the emitted cut carries the safety margin the raw cut lacks."""
+    from discopt._jax.crossover import crossover_to_vertex
+    from discopt._jax.problem_classifier import LPData
+    from discopt.solver import _separate_gomory_cuts
+
+    m_rows = A.shape[0]
+    A_eq = np.hstack([A, np.eye(m_rows)])
+    cc = np.concatenate([np.asarray(inc.c, dtype=np.float64)[:ncol], np.zeros(m_rows)])
+    xl = np.concatenate([bounds[:, 0], np.zeros(m_rows)])
+    xu = np.concatenate([bounds[:, 1], np.full(m_rows, 1e20)])
+    xv = crossover_to_vertex(np.concatenate([x, b - A @ x]), A_eq, b.copy(), cc, xl, xu)
+    gc = _separate_gomory_cuts(LPData(cc, A_eq, b.copy(), xl, xu, 0.0), xv, ncol, list(range(ncol)))
+    if gc is None:
+        return []
+    return [(-np.asarray(gc[0][i])[:ncol], -float(gc[1][i])) for i in range(len(gc[1]))]
+
+
+# --------------------------------------------------------------------------- #
+# C-10: LP-spatial GMI cuts must carry the machine-precision rhs safety margin #
+# every other GMI consumer applies, else a cut whose boundary passes through a #
+# feasible integer point can shave it (invalid cut -> false bound).            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.smoke
+def test_c10_lp_spatial_gmi_cut_carries_safety_margin():
+    """Fail-before/pass-after (C-10): each GMI cut ``_separate_node_cuts`` emits
+    must relax its ``<=`` rhs outward by exactly ``1e-7*(1+||row||_1)`` versus the
+    raw (unmargined) GMI cut. Pre-fix the emitted rhs equals the raw rhs (no
+    margin) and this fails; post-fix it is relaxed by the margin."""
+    inc, A, b, bounds, x, ncol = _assemble_node_lp()
+    raw = _raw_gmi_cuts(inc, A, b, bounds, x, ncol)
+    assert raw, "expected at least one raw GMI cut on this node"
+    emitted = _separate_node_cuts(A, b, bounds, x, ncol, inc.c)
+    # the GMI cuts are appended first, in order, so emitted[:len(raw)] are the GMI rows
+    assert len(emitted) >= len(raw)
+    for (row_raw, rhs_raw), (row_emit, rhs_emit) in zip(raw, emitted[: len(raw)]):
+        assert np.allclose(row_emit, row_raw)  # coefficients unchanged
+        margin = 1e-7 * (1.0 + float(np.abs(np.asarray(row_raw)).sum()))
+        # rhs is relaxed OUTWARD (>=) by the margin, never left raw and never tightened
+        assert rhs_emit == pytest.approx(rhs_raw + margin, abs=1e-15)
+        assert rhs_emit > rhs_raw
+
+
+@pytest.mark.smoke
+def test_c10_no_feasible_integer_point_is_cut():
+    """Property (C-10 class): no integer-feasible point of the model is violated by
+    any emitted node cut (GMI, MIR, ...). Encodes the invariant a valid cut must
+    satisfy — the margin guarantees float error can't shave a boundary point."""
+    ux, uy, uz = 6, 5, 4
+    inc, A, b, bounds, x, ncol = _assemble_node_lp(ux, uy, uz)
+    cuts = _separate_node_cuts(A, b, bounds, x, ncol, inc.c)
+    assert cuts, "expected node cuts to exercise the property"
+    # aux column layout for this model: [a, b, c, w=a*b]
+    for ai in range(ux + 1):
+        for bi in range(uy + 1):
+            for ci in range(uz + 1):
+                if ai * bi + ci < 10:
+                    continue  # infeasible for the original model
+                pt = np.array([ai, bi, ci, ai * bi], dtype=float)[:ncol]
+                for co, rhs in cuts:
+                    co = np.asarray(co, dtype=float)
+                    assert float(co @ pt) <= rhs + 1e-9, (
+                        f"cut {co}·x<= {rhs} shaves feasible point {(ai, bi, ci)}"
+                    )
 
 
 def _tiny(ux, uy, rhs, coef):


### PR DESCRIPTION
## C-10 (P2) — LP-spatial GMI cuts appended without the rhs safety margin

**Confirmed** (dynamically, not just static read) **then fixed.**

### Problem
The GMI branch of `_separate_node_cuts` (`python/discopt/_jax/lp_spatial_bb.py`)
appended the raw Rust GMI coefficients/rhs with **no safety margin**, unlike every
other GMI consumer in the codebase (`solver.py:_augment_lpdata_with_gomory_cuts`,
`cmir_cuts.py`), which relax the rhs by `1e-7·(1+‖row‖₁)`.

`gomory.rs` documents GMI validity as holding only "up to machine precision". The
crossover vertex the cut separates carries ~1e-12 floating-point error, so a GMI
cut whose boundary passes through a feasible integer point could shave it — an
invalid cut that can produce a false bound on the LP-spatial engine when cut
rounds are enabled.

**Confirmation:** driving the incremental-McCormick node LP of a small all-integer
bilinear model through the actual GMI branch, the emitted cut's `<=` rhs was
**byte-identical** to the raw Rust GMI rhs (`-6.000000000000001`) — no margin.

### Fix
Add `margin = 1e-7·(1+‖row‖₁)` to each emitted GMI cut's `<=` rhs before
appending, matching the other consumers. **Sound by construction:** the margin
only ever moves the cut *outward* (relaxes the constraint), so it can never remove
a feasible point; it only forgoes cutting an ~1e-7-thin sliver. The
cMIR/aggregation branches already carried their own margins and are untouched. No
validity check weakened.

### Tests (new, `@pytest.mark.smoke`, sub-second, RED-before/GREEN-after)
- `test_c10_lp_spatial_gmi_cut_carries_safety_margin` — reconstructs the raw GMI
  cut and asserts the emitted rhs is relaxed outward by *exactly* the margin. RED
  pre-fix (emitted == raw); pins the emission contract so any future revert to a
  raw-rhs append trips CI.
- `test_c10_no_feasible_integer_point_is_cut` — class invariant: enumerates every
  integer-feasible point of the model and asserts no emitted node cut violates it.

Verified fail-before/pass-after by stashing the fix.

### Gates run
- C-10 tests: **2 passed** (RED-before confirmed via `git stash`)
- Cut suite (`cutting_planes, cover_cuts, conflict_cuts, clique_cuts, constraint_cuts, rlt_cuts, auto_cut_policy, cut_recognizer, lp_spatial_bb`): **135 passed**
- `-k "mccormick or relax or spatial" -m "not slow"`: **693 passed / 1 skipped**
- `pytest -m smoke`: **480 passed / 1 skipped**
- adversarial (`test_adversarial_recent_fixes.py -m slow`): **10 passed**
- `ruff check` + `ruff format --check`: clean; pre-commit `mypy`: passed
- No Rust touched → no `cargo test`
- `incorrect_count` unchanged (0 failures across all suites; no correctness assertion weakened)

Card updated in `docs/dev/correctness-issues.md` (open → fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
