### PR TITLE
fix(correctness): C-36 Python interval_mul 0·∞ NaN leak (lost tightening)

### DIFF
--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -121,7 +121,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-33 | P0 | solver.py fallback | pure-continuous fallback certifies a nonconvex model's local optimum with `gap_certified=True` (= SC-1), DEFAULT path | fixed |
 | C-34 | P0 | gdp_reformulate | even-power bound over a zero-straddling base uses endpoint-only bounds (omits interior min at 0) → invalid aux box → false optimal (= FR-1), DEFAULT path | fixed |
 | C-35 | P1 | oa.py / gdpopt_loa | non-rigorous NLP failure → unconditional no-good cut → possible false infeasible/optimal (= OA-1, opt-in OA/LOA path) | fixed |
-| C-36 | P3 | convexity/interval.py | Python `interval_mul` yields NaN on 0·∞ (`RuntimeWarning: invalid value encountered in multiply`), same 0·∞ class as C-22 but a SEPARATE Python code path (`python/discopt/_jax/convexity/interval.py:171`); lost tightening, not unsound | open |
+| C-36 | P3 | convexity/interval.py | Python `interval_mul` yields NaN on 0·∞ (`RuntimeWarning: invalid value encountered in multiply`), same 0·∞ class as C-22 but a SEPARATE Python code path (`python/discopt/_jax/convexity/interval.py:171`); lost tightening, not unsound | fixed |
 
 ---
 
@@ -2473,7 +2473,7 @@ From the LP/dual-bound audit:
 
 ---
 
-## C-36 (P3) — Python `interval_mul` yields NaN on 0·∞ (separate path from C-22)
+## C-36 (P3, FIXED) — Python `interval_mul` yields NaN on 0·∞ (separate path from C-22)
 
 **Area:** `python/discopt/_jax/convexity/interval.py` (≈ line 171).
 **Class:** same `0·∞ → NaN` interval-arithmetic defect as C-22, but a **distinct
@@ -2511,3 +2511,47 @@ it is a separate module with its own tests and consumers.
 **Log:**
 - (filed) — surfaced during C-22 (#460) verification; carded P3 as the same 0·∞
   class on the Python interval path. Status `open`.
+- 2026-07-03 — CONFIRMED then FIXED (PR #465). Status `open` → `fixed`.
+  - **Repro (RED):** `Interval.point(0.0) * Interval.from_bounds(-inf, inf)` →
+    `[nan, nan]` with four `RuntimeWarning: invalid value encountered in multiply`
+    at `interval.py:171-174`; `[0,5]·[-inf,inf]` also `[nan,nan]` (should be
+    `[-inf,inf]`).
+  - **STEP 0 — consumer semantics (verdict: sound-but-weak, P3 HOLDS; no
+    escalation).** Audited every reachable convexity/certificate consumer of
+    `Interval`; each gates on `np.isfinite`, and `np.isfinite(NaN) is False`
+    *identically* to `±inf`, so a NaN Hessian endpoint forces abstention exactly
+    as an unbounded one does — no consumer treats NaN as finite/definite:
+    - `certificate.py:81` — `if not (np.all(np.isfinite(hess.lo)) and
+      np.all(np.isfinite(hess.hi))): return None` (abstain → treated non-convex).
+      The rank-1 fast path (`:90`) and 2×2 PSD path likewise guard on finiteness.
+    - `eigenvalue.py:101-102` `gershgorin_lambda_min` returns `-inf` on any
+      non-finite entry (`-inf >= -PSD_TOL` is False → never certifies convex);
+      `:124-125` `gershgorin_lambda_max` returns `+inf` (never certifies concave);
+      `psd_2x2_sufficient` `:156` guards on `isfinite` too.
+    Verdict: NaN and `±inf` are handled the same (UNKNOWN/abstain); the bug is
+    *lost tightening* (a consumer keeps its looser prior interval), never a wrong
+    verdict. P3 confirmed; no unsound path exists on this module.
+  - **Fix:** `interval.py::__mul__` now maps NaN corner products to `0` via a new
+    `_nan_corner_to_zero` helper (`np.nan_to_num(x, nan=0.0, posinf=inf,
+    neginf=-inf)` — replaces NaN only, leaves genuine ±∞ corners untouched) before
+    the min/max, under `np.errstate(invalid="ignore")`. NaN there can arise ONLY
+    from `0·±∞` (interval-convention value `0`); all other pairs are finite×finite
+    or genuine ±∞. `[0,0]·[-∞,∞] → [0,0]` (up to the module's ±1-ULP outward
+    round), `[0,5]·[-∞,∞] → [-∞,∞]`. Existing `_round_down`/`_round_up` kept.
+    `__truediv__`/`__pow__` inherit the fix (both route through `__mul__`; `__pow__`
+    n==2 special-case was already NaN-safe via its `zero_in` clamp — no change).
+  - **Regression test (RED→GREEN):** `TestC36MulZeroTimesInfinity` in
+    `python/tests/test_convexity_interval.py` (4 `@pytest.mark.smoke` sub-second
+    unit tests calling `__mul__` directly): the `[0,0]·entire → [0,0]` repro; the
+    `[0,5]·entire → [-∞,∞]` non-clamp case; a `warnings.simplefilter("error")`
+    guard proving the `RuntimeWarning` is GONE; and a grid property test over ±∞
+    endpoints / zero-width factors asserting never-NaN, `lo ≤ hi`, and rigorous
+    product containment (mirrors Rust `c22_interval_mul_never_nan_and_encloses…`).
+    All 4 fail on pre-fix code, pass after.
+  - **Gates:** `pytest -k "interval or convex or certif or curvature"` 771
+    passed / 5 skipped; `pytest -m smoke` 496 passed / 1 skipped (the 3
+    `test_c31_*` fails are a stale prebuilt `_rust.so` in the shared venv — those
+    tests hit the Rust FBBT path, not this Python module, and are green on `main`);
+    adversarial suite 10 passed; ruff + ruff-format clean; `incorrect_count = 0`;
+    the `RuntimeWarning: invalid value encountered in multiply` from `interval.py`
+    is gone. No Rust touched.

--- a/python/discopt/_jax/convexity/interval.py
+++ b/python/discopt/_jax/convexity/interval.py
@@ -55,6 +55,16 @@ def _round_up(x: Number) -> np.ndarray:
     return np.nextafter(x, np.float64(np.inf))
 
 
+def _nan_corner_to_zero(x: Number) -> np.ndarray:
+    """Replace ``NaN`` corner products with ``0``, preserving ±inf (C-36).
+
+    Used by :meth:`Interval.__mul__`, where a NaN corner can arise *only*
+    from ``0 * ±∞``, whose interval-convention value is ``0``. ``±inf`` is
+    left untouched so genuine unbounded corners still dominate the min/max.
+    """
+    return np.nan_to_num(x, nan=0.0, posinf=np.inf, neginf=-np.inf)
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Interval
 # ──────────────────────────────────────────────────────────────────────
@@ -168,10 +178,25 @@ class Interval:
         other = _as_interval(other)
         # The four corner products enclose the result on any sign
         # combination; pick element-wise min/max to handle all cases.
-        a = self.lo * other.lo
-        b = self.lo * other.hi
-        c = self.hi * other.lo
-        d = self.hi * other.hi
+        #
+        # A finite ``0`` endpoint times an infinite endpoint gives
+        # ``0 * ±∞ = NaN`` in IEEE-754, and ``np.minimum``/``np.maximum``
+        # then propagate that NaN, collapsing the interval to ``[NaN, NaN]``
+        # (C-36). By the interval-multiplication convention the product of a
+        # zero factor with any interval — including an unbounded one — is
+        # ``0``, so we map those NaN corners to ``0`` before the min/max.
+        # NaN can arise here *only* from ``0 * ±∞``; every other operand pair
+        # is finite×finite (never NaN) or a genuine ±∞ product, so the
+        # substitution never masks a real value. The result stays a rigorous
+        # outer enclosure that never excludes a point: ``[0,0]·[−∞,∞] = [0,0]``
+        # (correct) while ``[0,5]·[−∞,∞] = [−∞,∞]`` (the ±∞ corners still
+        # dominate). Genuine ±∞ corners are left untouched — only NaN is
+        # replaced.
+        with np.errstate(invalid="ignore"):
+            a = _nan_corner_to_zero(self.lo * other.lo)
+            b = _nan_corner_to_zero(self.lo * other.hi)
+            c = _nan_corner_to_zero(self.hi * other.lo)
+            d = _nan_corner_to_zero(self.hi * other.hi)
         lo = np.minimum(np.minimum(a, b), np.minimum(c, d))
         hi = np.maximum(np.maximum(a, b), np.maximum(c, d))
         return Interval(_round_down(lo), _round_up(hi))

--- a/python/tests/test_convexity_interval.py
+++ b/python/tests/test_convexity_interval.py
@@ -105,6 +105,91 @@ class TestArithmetic:
         assert neg.lo == -3.0 and neg.hi == 2.0
 
 
+class TestC36MulZeroTimesInfinity:
+    """C-36: ``Interval.__mul__`` must not leak NaN on ``0 · ±∞``.
+
+    A finite zero endpoint times an infinite endpoint is ``0 * ±∞ = NaN`` in
+    IEEE-754. Before the fix, ``np.minimum``/``np.maximum`` propagated that NaN
+    and the interval collapsed to ``[NaN, NaN]`` — every downstream comparison
+    against NaN is False, so the convexity certificate's ``np.isfinite`` gate
+    abstains (sound but weak: lost tightening). The interval convention makes
+    ``0 · [anything] = 0``, so the fix maps NaN corners to ``0`` while leaving
+    genuine ±∞ corners intact. These are the Python siblings of the Rust C-22
+    tests (PR #460).
+    """
+
+    @pytest.mark.smoke
+    def test_zero_point_times_entire_is_zero(self):
+        # The exact repro: [0,0] · [-inf, inf]. Every corner is 0 * (±inf) = NaN.
+        # Sound, informative enclosure is [0, 0] (up to one ULP of outward
+        # rounding), NOT [NaN, NaN].
+        a = Interval.point(0.0)
+        b = Interval.from_bounds(-np.inf, np.inf)
+        r = a * b
+        assert not np.isnan(r.lo) and not np.isnan(r.hi), "must not be NaN"
+        assert r.lo <= 0.0 <= r.hi, "must enclose 0"
+        # Tightest representable enclosure of the point 0: within one ULP.
+        assert abs(float(r.lo)) <= 1e-300 and abs(float(r.hi)) <= 1e-300
+
+    @pytest.mark.smoke
+    def test_zero_touching_times_entire_is_unbounded(self):
+        # [0,5] · [-inf, inf]: the 0-corners are NaN→0, but the genuine ±inf
+        # corners (5 * ±inf) still dominate → [-inf, +inf]. The fix must NOT
+        # clamp those infinities.
+        a = Interval.from_bounds(0.0, 5.0)
+        b = Interval.from_bounds(-np.inf, np.inf)
+        r = a * b
+        assert not np.isnan(r.lo) and not np.isnan(r.hi)
+        assert r.lo == -np.inf and r.hi == np.inf
+
+    @pytest.mark.smoke
+    def test_no_runtime_warning_on_zero_times_inf(self):
+        # The `RuntimeWarning: invalid value encountered in multiply` that the
+        # unguarded corner products raised must be gone.
+        a = Interval.point(0.0)
+        b = Interval.from_bounds(-np.inf, np.inf)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            a * b  # no RuntimeWarning
+
+    @pytest.mark.smoke
+    def test_mul_never_nan_and_encloses_true_product(self):
+        # Grid over ±∞ endpoints and zero-width / zero-touching factors. For
+        # every valid pair the product must (a) never be NaN, (b) satisfy
+        # lo <= hi, and (c) rigorously enclose the true product of every pair of
+        # representative points drawn from the two intervals. A NaN endpoint
+        # would fail containment silently, so both are checked explicitly.
+        ninf, pinf = -np.inf, np.inf
+        bounds = [ninf, -3.0, -1.0, 0.0, 1.0, 2.5, pinf]
+        for alo in bounds:
+            for ahi in bounds:
+                if alo > ahi:
+                    continue
+                for blo in bounds:
+                    for bhi in bounds:
+                        if blo > bhi:
+                            continue
+                        a = Interval.from_bounds(alo, ahi)
+                        b = Interval.from_bounds(blo, bhi)
+                        r = a * b
+                        assert not np.isnan(r.lo) and not np.isnan(r.hi), (
+                            f"NaN endpoint for [{alo},{ahi}]*[{blo},{bhi}]"
+                        )
+                        assert r.lo <= r.hi, f"lo>hi for [{alo},{ahi}]*[{blo},{bhi}]"
+                        # True product set at the (finite) representative points.
+                        for x in (alo, ahi):
+                            for y in (blo, bhi):
+                                if not (np.isfinite(x) and np.isfinite(y)):
+                                    continue
+                                p = x * y
+                                assert r.lo <= p + 1e-9, (
+                                    f"{p} < lo {r.lo} for [{alo},{ahi}]*[{blo},{bhi}]"
+                                )
+                                assert p - 1e-9 <= r.hi, (
+                                    f"{p} > hi {r.hi} for [{alo},{ahi}]*[{blo},{bhi}]"
+                                )
+
+
 class TestPower:
     def test_square_nonneg_is_nonneg(self):
         a = Interval.from_bounds(1.0, 3.0)


### PR DESCRIPTION
## C-36 (P3) — Python `interval_mul` yields NaN on `0·∞`

Fixes the Python-path sibling of C-22 (Rust `interval_mul`, #460). `Interval.__mul__`
in `python/discopt/_jax/convexity/interval.py` formed four corner products; a finite
`0` endpoint times an infinite endpoint gives `0 * ±∞ = NaN` in IEEE-754, and
`np.minimum`/`np.maximum` propagated it, collapsing the interval to `[NaN, NaN]`
(with `RuntimeWarning: invalid value encountered in multiply`). Separate module and
consumers from C-22, so #460 did not cover it.

### Repro (RED)
```
Interval.point(0.0) * Interval.from_bounds(-inf, inf)  -> [nan, nan]   (4x RuntimeWarning)
Interval.from_bounds(0,5) * Interval.from_bounds(-inf, inf) -> [nan, nan]  (should be [-inf, inf])
```

### STEP 0 — consumer-semantics verdict: **sound-but-weak, P3 holds (no escalation)**
Every reachable convexity/certificate consumer of `Interval` gates on `np.isfinite`,
and `np.isfinite(NaN)` is `False` **identically** to `±inf`, so a NaN Hessian endpoint
forces the same abstention an unbounded one does — no consumer treats NaN as
finite/definite:
- `certificate.py:81` — `if not (np.all(np.isfinite(hess.lo)) and np.all(np.isfinite(hess.hi))): return None`; the rank-1 fast path and 2×2 PSD path also guard on finiteness.
- `eigenvalue.py:101` `gershgorin_lambda_min` returns `-inf` on any non-finite entry (`-inf >= -PSD_TOL` is False → never certifies convex); `:124` `gershgorin_lambda_max` returns `+inf` (never certifies concave); `psd_2x2_sufficient` `:156` guards on `isfinite`.

Verdict: NaN and `±inf` are handled the same (UNKNOWN/abstain); the bug is *lost
tightening*, never a wrong verdict. P3 confirmed.

### Fix (mirror C-22, minimal, sound)
`__mul__` maps NaN corner products to `0` via a new `_nan_corner_to_zero` helper
(`np.nan_to_num(x, nan=0.0, posinf=inf, neginf=-inf)` — replaces NaN only, leaves
genuine `±∞` corners intact) before the min/max, under `np.errstate(invalid="ignore")`.
NaN there can arise **only** from `0·±∞` (interval-convention value `0`); all other
pairs are finite×finite or a genuine `±∞` product. Result: `[0,0]·[−∞,∞] → [0,0]`
(up to the module's ±1-ULP outward round), `[0,5]·[−∞,∞] → [−∞,∞]`. Existing
`_round_down`/`_round_up` kept. `__truediv__`/`__pow__` inherit the fix via `__mul__`;
`__pow__` n==2 was already NaN-safe (its `zero_in` clamp) — untouched.

### Regression test (RED → GREEN)
`TestC36MulZeroTimesInfinity` in `python/tests/test_convexity_interval.py` — 4
sub-second `@pytest.mark.smoke` unit tests calling `__mul__` directly: the
`[0,0]·entire → [0,0]` repro; the `[0,5]·entire → [−∞,∞]` non-clamp case; a
`warnings.simplefilter("error")` guard proving the `RuntimeWarning` is gone; and a
grid property test over `±∞` endpoints / zero-width factors asserting never-NaN,
`lo ≤ hi`, and rigorous product containment (mirrors Rust
`c22_interval_mul_never_nan_and_encloses_true_product`). All 4 fail before, pass after.

### Gates
- `pytest -k "interval or convex or certif or curvature"` — **771 passed, 5 skipped**
- `pytest -m smoke` — **496 passed, 1 skipped**; the 3 `test_c31_*` fails are a stale
  prebuilt `_rust.so` in the shared venv (those tests hit the **Rust FBBT** path, not
  this Python module; green on `main`)
- adversarial suite (`test_adversarial_recent_fixes.py -m slow`) — **10 passed**
- `ruff check` + `ruff format --check` — clean; `incorrect_count = 0`
- `interval.py` `RuntimeWarning: invalid value encountered in multiply` — **gone**
- No Rust touched (pure-Python module).

Updates the `## C-36` card (open→fixed, Log with the consumer-semantics finding) and
flips the status-board row to `fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
