### PR TITLE
fix(correctness): #467 — never certify optimal on an unbranchable unbounded-below root (+ rigorous-infeasibility precedence)

### DIFF
--- a/crates/discopt-core/src/bnb/branching.rs
+++ b/crates/discopt-core/src/bnb/branching.rs
@@ -447,6 +447,18 @@ pub fn select_spatial_branch_variable(
             continue; // Fixed variable, skip.
         }
         let relative_width = width / global_width;
+        if !relative_width.is_finite() {
+            // An unbounded dimension (infinite node width, or an infinite global
+            // range) yields NaN/inf here. Such a dimension is NOT spatially
+            // branchable: bisecting an infinite interval never shrinks its
+            // normalized width. Skip it deterministically. Without this, a NaN
+            // relative width silently defeats both the `< SPATIAL_MIN_WIDTH`
+            // "too tight" filter (NaN < x is false) and the `> best_width`
+            // selection (NaN > x is false), so the variable is neither skipped
+            // as fixed nor selected — the root dead-ends unbranched and the
+            // tree falsely certifies (issue #467).
+            continue;
+        }
         if relative_width < SPATIAL_MIN_WIDTH {
             continue; // Domain already very tight.
         }
@@ -522,6 +534,12 @@ pub fn select_spatial_integer_branch_variable(
             continue; // Fixed at root, skip.
         }
         let relative_width = width / global_width;
+        if !relative_width.is_finite() {
+            // Unbounded integer dimension (infinite node or global width): not
+            // spatially branchable. Skip deterministically so a NaN/inf relative
+            // width cannot defeat the `> best_rel_width` selection (issue #467).
+            continue;
+        }
         if relative_width > best_rel_width {
             best_rel_width = relative_width;
             best_idx = Some(idx);
@@ -885,5 +903,65 @@ mod tests {
         // Right: x1 >= 5
         assert_eq!(right.lb[1], 5.0);
         assert_eq!(right.ub[1], 8.0); // unchanged
+    }
+
+    #[test]
+    fn test_spatial_branch_skips_unbounded_dimension() {
+        // Issue #467: an unbounded continuous dimension yields a NaN relative
+        // width (inf/inf) that silently defeats both filters; it must be skipped,
+        // and a coexisting FINITE dimension must still be selected.
+        // x0 = [-5, inf] (unbounded), x1 = [-5, 5] (finite).
+        let node_lb = vec![-5.0, -5.0];
+        let node_ub = vec![f64::INFINITY, 5.0];
+        let global_lb = vec![-5.0, -5.0];
+        let global_ub = vec![f64::INFINITY, 5.0];
+        let sel = select_spatial_branch_variable(
+            &node_lb,
+            &node_ub,
+            &global_lb,
+            &global_ub,
+            &[],
+            &[],
+            false,
+        );
+        assert!(sel.is_some(), "the finite dimension x1 must be branchable");
+        assert_eq!(
+            sel.unwrap().0.var_index,
+            1,
+            "must branch the finite dim, not the unbounded one"
+        );
+
+        // Both dimensions unbounded → no branchable dimension at all.
+        let none = select_spatial_branch_variable(
+            &[-5.0, f64::NEG_INFINITY],
+            &[f64::INFINITY, 5.0],
+            &[-5.0, f64::NEG_INFINITY],
+            &[f64::INFINITY, 5.0],
+            &[],
+            &[],
+            false,
+        );
+        assert!(
+            none.is_none(),
+            "an all-unbounded box has no spatial branch direction"
+        );
+    }
+
+    #[test]
+    fn test_spatial_integer_branch_skips_unbounded_dimension() {
+        // Issue #467: an unbounded integer dimension must not be selected via a
+        // NaN/inf relative width.
+        let cols = vec![true];
+        let none = select_spatial_integer_branch_variable(
+            &[0.0],
+            &[f64::INFINITY],
+            &[0.0],
+            &[f64::INFINITY],
+            &cols,
+        );
+        assert!(
+            none.is_none(),
+            "an unbounded integer dimension is not branchable"
+        );
     }
 }

--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -65,6 +65,11 @@ pub struct TreeStats {
     pub global_lower_bound: f64,
     /// Current optimality gap (relative).
     pub gap: f64,
+    /// True when a node was fathomed with no branching direction and no valid
+    /// finite dual bound (an unbounded-below / spatially-unbranchable root). The
+    /// tree bound is pinned at -inf and the search must NOT be certified optimal
+    /// even though `open_nodes == 0` (issue #467).
+    pub bound_unresolved: bool,
 }
 
 /// Internal buffer for results waiting to be processed.
@@ -127,6 +132,16 @@ pub struct TreeManager {
     /// all-false unless registered via [`Self::set_branch_deprioritized`].
     /// Fallback in [`select_spatial_branch_variable`] preserves completeness.
     branch_deprioritized: Vec<bool>,
+    /// Set true (and never cleared within a solve) when a node is fathomed with
+    /// no branching direction AND no validly-established finite dual bound (its
+    /// `local_lower_bound` is still `-inf`/sentinel — e.g. an unbounded-below,
+    /// spatially-unbranchable root). Such a subtree is genuinely UNRESOLVED: no
+    /// relaxation proved a lower bound and there is no finite dimension to branch
+    /// on, so the tree must NOT declare `global_lower_bound := incumbent` and
+    /// certify optimality. When set, [`Self::update_global_lower_bound`] forces
+    /// `global_lower_bound = -inf` so `gap() = ∞` and the search reports
+    /// feasible/unknown rather than a false optimal (issue #467).
+    bound_unresolved: bool,
 }
 
 impl TreeManager {
@@ -166,6 +181,7 @@ impl TreeManager {
             nonconvex: false,
             spatial_integer_cols,
             branch_deprioritized,
+            bound_unresolved: false,
         }
     }
 
@@ -508,7 +524,26 @@ impl TreeManager {
                         self.pool.add(right);
                         stats.branched += 1;
                     } else {
-                        // Every domain is tight; fathom.
+                        // No branching direction remains. Whether this fathom is
+                        // sound depends on the node's dual bound:
+                        //   * finite `local_lower_bound`: a valid relaxation bound
+                        //     WAS established and every domain is tight, so the node
+                        //     is genuinely resolved — fathom as before (this is the
+                        //     honest root-close case, e.g. `chance`/`st_miqp3`).
+                        //   * non-finite (`-inf`/sentinel): no relaxation ever proved
+                        //     a lower bound AND there is no finite dimension to branch
+                        //     on (an unbounded-below, spatially-unbranchable root).
+                        //     The subtree is UNRESOLVED; fathoming it and letting the
+                        //     global bound collapse to the incumbent would falsely
+                        //     certify a local/near-feasible point as the global
+                        //     optimum (issue #467). Mark the tree bound unresolved so
+                        //     `update_global_lower_bound` pins `global_lower_bound` at
+                        //     -inf (gap = ∞ → feasible/unknown, never optimal). Still
+                        //     fathom the node so the driver cannot infinite-loop on a
+                        //     node it can neither branch nor bound.
+                        if !self.pool.get(result.node_id).local_lower_bound.is_finite() {
+                            self.bound_unresolved = true;
+                        }
                         self.pool.get_mut(result.node_id).status = NodeStatus::Fathomed;
                         stats.fathomed += 1;
                     }
@@ -534,7 +569,22 @@ impl TreeManager {
                     stats.branched += 1;
                 }
             } else {
-                // No fractional variable found — treat as fathomed.
+                // No fractional variable found — treat as fathomed. This branch
+                // is reached when the node produced no integer branch decision AND
+                // was not routed into the nonconvex spatial-branch block above —
+                // in particular when its bound is UNTRUSTED (`node_lb` non-finite),
+                // which forces `int_feasible = false`. An untrusted, unbranched
+                // node is not resolved: no relaxation proved a finite lower bound
+                // and (here) there was no branch direction, so fathoming it and
+                // letting `global_lower_bound` collapse to the incumbent would
+                // falsely certify a local/near-feasible incumbent as the global
+                // optimum on an unbounded-below / free-variable root (issue #467).
+                // Flag the tree bound unresolved so `update_global_lower_bound`
+                // pins the global bound at -inf (gap = ∞ → feasible/unknown). A
+                // trusted (finite-bound) node here IS resolved and stays certifiable.
+                if !trusted {
+                    self.bound_unresolved = true;
+                }
                 self.pool.get_mut(result.node_id).status = NodeStatus::Fathomed;
                 stats.fathomed += 1;
                 // Only a trusted (finite-bound, solver-verified) node may become
@@ -555,6 +605,16 @@ impl TreeManager {
 
     /// Recompute the global lower bound as the minimum over all open nodes.
     fn update_global_lower_bound(&mut self) {
+        // An unresolved subtree (a node fathomed with no branching direction and
+        // no valid finite bound) genuinely bounds the objective at -inf. Pin the
+        // global lower bound there and skip the min-over-open computation: neither
+        // the `min_lb == INFINITY → incumbent` collapse nor any finite open-node
+        // minimum may override an honest -inf, or the tree would certify a false
+        // optimal on an unbranchable, unbounded-below root (issue #467).
+        if self.bound_unresolved {
+            self.global_lower_bound = f64::NEG_INFINITY;
+            return;
+        }
         let mut min_lb = f64::INFINITY;
         for i in 0..self.pool.total_count() {
             let node = self.pool.get(NodeId(i));
@@ -621,6 +681,7 @@ impl TreeManager {
             incumbent_value: self.incumbent_value,
             global_lower_bound: self.global_lower_bound,
             gap: self.gap(),
+            bound_unresolved: self.bound_unresolved,
         }
     }
 
@@ -913,6 +974,78 @@ mod tests {
         );
         assert!((tm.global_lower_bound - 1.92).abs() < 1e-12);
         assert!(tm.gap() >= 0.0);
+    }
+
+    #[test]
+    fn test_unresolved_bound_not_collapsed_to_incumbent() {
+        // Issue #467: a node fathomed with no branching direction and no valid
+        // finite dual bound (an unbounded-below / spatially-unbranchable root)
+        // must NOT let the tree declare `global_lower_bound := incumbent`. The
+        // bound must stay -inf so the gap is infinite and the search reports
+        // feasible/unknown, never a false optimal.
+        let mut tm = TreeManager::new(
+            1,
+            vec![f64::NEG_INFINITY],
+            vec![f64::INFINITY],
+            vec![],
+            SelectionStrategy::BestFirst,
+        );
+        tm.initialize();
+        // An incumbent was injected (e.g. a local NLP / feasibility-pump point).
+        tm.incumbent_value = 0.2986;
+        tm.incumbent_solution = Some(vec![0.0]);
+        // The (only) node was fathomed with no valid bound: mark it Fathomed with
+        // a -inf local bound and flag the tree bound unresolved, mirroring the
+        // no-branch-candidate / untrusted-node fathom sites in `process_evaluated`.
+        {
+            let node = tm.pool.get_mut(NodeId(0));
+            node.local_lower_bound = f64::NEG_INFINITY;
+            node.status = NodeStatus::Fathomed;
+        }
+        tm.bound_unresolved = true;
+
+        tm.update_global_lower_bound();
+
+        assert_eq!(
+            tm.global_lower_bound,
+            f64::NEG_INFINITY,
+            "unresolved subtree must keep global_lower_bound at -inf, not the incumbent"
+        );
+        assert_eq!(
+            tm.gap(),
+            f64::INFINITY,
+            "an unresolved -inf bound must yield an infinite gap (never a certified 0)"
+        );
+    }
+
+    #[test]
+    fn test_resolved_root_close_still_collapses_to_incumbent() {
+        // Contrast to the #467 case: when the bound is NOT flagged unresolved (a
+        // node was closed with a valid finite bound), the standard
+        // "all nodes closed → global_lower_bound = incumbent" behaviour must be
+        // preserved (the honest root-close, e.g. `chance`/`st_miqp3`).
+        let mut tm = TreeManager::new(
+            1,
+            vec![0.0],
+            vec![1.0],
+            vec![VarBranchInfo {
+                offset: 0,
+                size: 1,
+                is_integer: true,
+            }],
+            SelectionStrategy::BestFirst,
+        );
+        tm.initialize();
+        tm.incumbent_value = -6.0;
+        {
+            let node = tm.pool.get_mut(NodeId(0));
+            node.local_lower_bound = -6.0;
+            node.status = NodeStatus::Fathomed;
+        }
+        // bound_unresolved stays false.
+        tm.update_global_lower_bound();
+        assert!((tm.global_lower_bound - (-6.0)).abs() < 1e-12);
+        assert!(tm.gap() < 1e-9);
     }
 
     #[test]

--- a/crates/discopt-python/src/bnb_bindings.rs
+++ b/crates/discopt-python/src/bnb_bindings.rs
@@ -231,7 +231,8 @@ impl PyTreeManager {
 
     /// Get aggregate tree statistics as a dict.
     ///
-    /// Returns {total_nodes, open_nodes, incumbent_value, global_lower_bound, gap}.
+    /// Returns {total_nodes, open_nodes, incumbent_value, global_lower_bound,
+    /// gap, bound_unresolved}.
     fn stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let s = self.inner.stats();
         let dict = PyDict::new(py);
@@ -240,6 +241,7 @@ impl PyTreeManager {
         dict.set_item("incumbent_value", s.incumbent_value)?;
         dict.set_item("global_lower_bound", s.global_lower_bound)?;
         dict.set_item("gap", s.gap)?;
+        dict.set_item("bound_unresolved", s.bound_unresolved)?;
         Ok(dict)
     }
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5673,10 +5673,21 @@ def solve_model(
                 # the chance to certify optimality before we decide to
                 # decertify the gap.
                 #   * -inf  : no bound source produced a finite lower bound this
-                #             round, so the node stays OPEN at -inf and is floored
-                #             at its inherited parent bound on import (still a valid
-                #             global lower bound). It fathoms nothing, so it does NOT
-                #             taint the tree — leave the gap certifiable (#138).
+                #             round. A NON-ROOT node stays OPEN at -inf and is
+                #             floored at its inherited parent bound on import (still
+                #             a valid global lower bound); it fathoms nothing, so it
+                #             does NOT taint the tree — leave the gap certifiable
+                #             (#138). The ROOT has no parent to floor against: if it
+                #             also has no finite spatial-branch direction (an
+                #             unbounded-below / free-variable root), the Rust tree
+                #             cannot branch it and would previously fathom it and
+                #             collapse `global_lower_bound` to the incumbent, falsely
+                #             certifying a local/near-feasible point as optimal. That
+                #             collapse is now blocked in the Rust tree
+                #             (`bound_unresolved` in `tree_manager.rs`, issue #467):
+                #             the global bound is pinned at -inf, so the gap is
+                #             infinite and the run downgrades to "feasible" via the
+                #             existing status logic. No Python change is needed here.
                 #   * non-finite (and not -inf): coerce to the infeasibility
                 #             sentinel so the Rust tree prunes it cleanly.
                 #   * >= sentinel (issue #27a): a node pruned with no rigorous
@@ -5691,7 +5702,11 @@ def solve_model(
                 #             downgrades to "feasible" instead of lying.
                 if not _model_is_convex and not node_infeasible_mask[i]:
                     if result_lbs[i] == -np.inf:
-                        pass  # open node, floored at parent bound — does not taint
+                        # Non-root: stays open, floored at the parent bound on
+                        # import — does not taint. Root with no branch direction:
+                        # the Rust tree pins the global bound at -inf instead of
+                        # collapsing to the incumbent (#467), so this remains sound.
+                        pass
                     elif not np.isfinite(result_lbs[i]):
                         result_lbs[i] = _INFEASIBILITY_SENTINEL
                     elif result_lbs[i] >= _SENTINEL_THRESHOLD:
@@ -6842,7 +6857,19 @@ def solve_model(
         if model._objective.sense == ObjectiveSense.MAXIMIZE:
             obj_val = -obj_val
 
-        search_closed = _gap_converged(tree, gap_tolerance) or tree.is_finished()
+        # An unresolved tree bound (a node fathomed with no branch direction and no
+        # valid finite dual bound — an unbounded-below / free-variable root) means
+        # the search cannot certify optimality even though `is_finished()` is True
+        # (no node can be branched further). The Rust tree pins `global_lower_bound`
+        # at -inf in that case (issue #467); do not let `is_finished()` alone
+        # certify. `_gap_converged` already returns False on the -inf bound, so
+        # require it (not the bare `is_finished()`) whenever the bound is unresolved.
+        _bound_unresolved = bool(tree.stats().get("bound_unresolved", False))
+        if _bound_unresolved:
+            _gap_certified = False
+        search_closed = _gap_converged(tree, gap_tolerance) or (
+            tree.is_finished() and not _bound_unresolved
+        )
         if search_closed and _gap_certified:
             status = "optimal"
         else:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4292,6 +4292,16 @@ def solve_model(
     # single authoritative per-batch sweep below (any sentinel-without-proof node)
     # and consumed in the finalize else-branch.
     _nonrigorous_fathom = False
+    # #467 sub-bug #3: set True when the ROOT batch (iteration 0 — the whole
+    # feasible region) is rigorously proven infeasible (every root node carries a
+    # ``node_infeasible_mask`` empty-box / empty-relaxation certificate — the same
+    # rigor the terminal ``infeasible`` verdict already trusts). A soft incumbent
+    # accepted only within tolerance that lies inside a region the search RIGOROUSLY
+    # proved infeasible must NOT be certified ``optimal``; the terminal logic
+    # discards such an incumbent (unless it is itself rigorously feasible, which
+    # would mean the root proof over-tightened — then the incumbent stands and no
+    # false ``infeasible`` is emitted).
+    _root_rigorously_infeasible = False
 
     # Sense-derived negation flag for the internal (minimization) B&B. Unlike
     # ``_mc_negate`` below — which is only assigned correctly inside the
@@ -5748,6 +5758,25 @@ def solve_model(
                 result_lbs[i] = _INFEASIBILITY_SENTINEL
                 result_feas[i] = False
 
+        # #467 sub-bug #3: the ROOT batch covers the whole feasible region. If
+        # EVERY root node is rigorously infeasible-masked (empty box / empty
+        # relaxation over a finite box — the rigorous certificate, not a soft
+        # failure sentinel), the model is rigorously proven infeasible at the root.
+        # A within-tolerance-only incumbent found by the primal heuristic then lies
+        # inside a region the search proved infeasible; the terminal logic must not
+        # certify it ``optimal`` (ex7_3_6: FBBT proves the root empty by ~2e-6 > the
+        # 1e-6 FBBT tolerance, yet a pump point at ~1.2e-4 residual was certified).
+        # Gated on iteration 0 and n_batch >= 1 so it reflects the root, not a deep
+        # subtree; ``_nonrigorous_fathom`` guarantees only rigorous certificates are
+        # trusted for the eventual ``infeasible`` verdict.
+        if (
+            iteration == 0
+            and n_batch >= 1
+            and bool(np.all(node_infeasible_mask[:n_batch]))
+            and not _nonrigorous_fathom
+        ):
+            _root_rigorously_infeasible = True
+
         # --- Objective-gating priority branching (issue #184) ---
         # The global dual bound is the minimum over the open frontier, so it stays
         # pinned at a structural 0 until *every* shallow node has had the binaries
@@ -6760,6 +6789,58 @@ def solve_model(
         sol_array, obj_val = incumbent
         # Filter out bogus incumbents from infeasible NLP relaxations
         if obj_val >= _SENTINEL_THRESHOLD:
+            incumbent = None
+
+    # #467 sub-bug #3: rigorous infeasibility proof wins over a soft incumbent.
+    # When the root (whole feasible region) was rigorously proven infeasible, an
+    # incumbent is only trustworthy if it is ITSELF rigorously feasible (at the
+    # solver's constraint-feasibility tolerance, evaluated over ALL constraints).
+    # If it is not, it is a spurious primal-heuristic point inside a region the
+    # search proved empty — discard it so control falls to the terminal
+    # infeasibility/unknown logic below (which reports ``infeasible`` for a
+    # rigorous proof, ``unknown`` for a non-rigorous one). If the incumbent IS
+    # rigorously feasible, the root proof must have over-tightened: keep the
+    # incumbent and NEVER report ``infeasible`` (guards the worst-class error, a
+    # false infeasible on a truly-feasible model).
+    if incumbent is not None and _root_rigorously_infeasible:
+        # Verify against the ORIGINAL (pre-reform) constraints. The factorable
+        # reform rewrites the model in terms of lifted aux variables; an incumbent
+        # can satisfy every reformed constraint (the aux defining equalities plus
+        # the rewritten bodies) while violating an ORIGINAL constraint by more than
+        # tolerance (ex7_3_6: reformed set feasible at 1e-4, but original C0 is
+        # violated by ~1.2e-4). Checking the reformed ``evaluator`` would mask that,
+        # so use the pre-reform model over the incumbent's original-variable slice
+        # (the first ``_prereform_nvars`` flat entries — aux columns are appended
+        # after the originals). When no reform ran, ``evaluator``/``cl_list`` ARE
+        # the original constraints, so fall back to them.
+        _inc_feasible = True
+        try:
+            if _prereform_model is not None:
+                _pf_eval = _make_evaluator(_prereform_model)
+                _pf_cl, _pf_cu = _infer_constraint_bounds(_prereform_model, _pf_eval)
+                if _pf_cl:
+                    _inc_feasible = _check_constraint_feasibility(
+                        _pf_eval,
+                        np.array(sol_array)[:_prereform_nvars],
+                        _pf_cl,
+                        _pf_cu,
+                    )
+            elif cl_list:
+                _inc_feasible = _check_constraint_feasibility(
+                    evaluator, np.array(sol_array), cl_list, cu_list
+                )
+        except Exception as _pf_exc:  # pragma: no cover - defensive
+            # If the original-model re-check cannot be built, be conservative and
+            # do NOT discard the incumbent (never risk a false infeasible).
+            logger.debug("prereform incumbent re-check skipped: %s", _pf_exc)
+            _inc_feasible = True
+        if not _inc_feasible:
+            logger.debug(
+                "Discarding within-tolerance-only incumbent (obj=%.6g): the root was "
+                "rigorously proven infeasible and this point violates the ORIGINAL "
+                "constraints beyond tolerance (#467 sub-bug #3).",
+                obj_val,
+            )
             incumbent = None
 
     if incumbent is not None:

--- a/python/tests/test_unbounded_relaxation_soundness.py
+++ b/python/tests/test_unbounded_relaxation_soundness.py
@@ -150,3 +150,80 @@ def _himmel16_model():
     m.subject_to(-(x[13] + x[14] + x[15] + x[16] + x[17] + x[18]) - objvar == 0.0)
     m.minimize(objvar)
     return m
+
+
+def _camel_semiinfinite(lb0, ub0, lb1, ub1, name):
+    """Six-hump-camel-style nonconvex objective (2*x0^2 - 1.05*x0^4 + x0^6/6
+    - x0*x1 + x1^2) over a box that may leave a variable one-sided-unbounded.
+
+    The true global minimum over the whole plane is 0.0 at the origin. On a
+    finite box the spatial B&B certifies it; on a semi-infinite box a
+    continuous variable has an unbounded side, so the ROOT cannot be spatially
+    branched (no finite branching direction) and no relaxation establishes a
+    finite dual bound. The tree must then NOT certify the local minimum 0.2986
+    (or any local point) as the global optimum.
+    """
+    m = discopt.Model(name)
+    x0 = m.continuous("x0", lb=lb0, ub=ub0)
+    x1 = m.continuous("x1", lb=lb1, ub=ub1)
+    m.minimize(2 * x0**2 - 1.05 * x0**4 + (1.0 / 6.0) * x0**6 - x0 * x1 + x1**2)
+    return m
+
+
+@pytest.mark.smoke
+def test_467_free_variable_root_not_falsely_optimal_nlp_route():
+    """#467: both continuous vars one-sided-unbounded (x0=[-5,inf], x1=[-inf,5]).
+
+    ``_origin_has_finite_continuous_var`` is False, so the McCormick-LP guard
+    falls the solve back to the NLP relaxation. The root cannot be spatially
+    branched and no valid dual bound is established. The Rust tree previously
+    fathomed the root and collapsed ``global_lower_bound`` to the local-minimum
+    incumbent (0.2986), certifying it ``optimal`` with gap 0 — a false optimal.
+    The honest verdict is NOT optimal (feasible/unknown).
+    """
+    r = _camel_semiinfinite(-5.0, float("inf"), float("-inf"), 5.0, "c467_nlp").solve(
+        time_limit=6.0, daemon=False
+    )
+    assert r.status != "optimal", (
+        f"free-variable root falsely certified optimal: status={r.status} "
+        f"obj={r.objective} bound={r.bound}"
+    )
+    assert not getattr(r, "gap_certified", False), (
+        f"free-variable root falsely reports gap_certified: bound={r.bound}"
+    )
+
+
+@pytest.mark.smoke
+def test_467_free_variable_root_not_falsely_optimal_lp_route():
+    """#467: one var finite (x1=[-5,5]), one semi-infinite (x0=[-5,inf]).
+
+    ``_origin_has_finite_continuous_var`` is True (x1 is finite), so the guard
+    does NOT fall back — the McCormick-LP spatial path runs. It still collapses:
+    the LP relaxer honestly abstains on the unbounded nonlinear column (x0), so
+    the root carries no finite bound and cannot be branched to a finite bound.
+    This exercises the second (LP) route into the same Rust fathom/collapse. The
+    verdict must NOT be a certified optimal.
+    """
+    r = _camel_semiinfinite(-5.0, float("inf"), -5.0, 5.0, "c467_lp").solve(
+        time_limit=6.0, daemon=False
+    )
+    assert r.status != "optimal", (
+        f"semi-infinite root falsely certified optimal (LP route): status={r.status} "
+        f"obj={r.objective} bound={r.bound}"
+    )
+    assert not getattr(r, "gap_certified", False), (
+        f"semi-infinite root falsely reports gap_certified (LP route): bound={r.bound}"
+    )
+
+
+@pytest.mark.smoke
+def test_467_finite_box_control_still_certifies_optimal():
+    """#467 control: the SAME objective over a finite box [-5,5]^2 must still
+    certify the true global optimum 0.0. This guards against the fix
+    over-firing and downgrading a validly-certified finite-box solve."""
+    r = _camel_semiinfinite(-5.0, 5.0, -5.0, 5.0, "c467_ctrl").solve(time_limit=10.0, daemon=False)
+    assert r.status == "optimal", f"finite-box control lost certification: status={r.status}"
+    assert r.objective is not None and abs(r.objective) <= 1e-3, (
+        f"finite-box control missed the true optimum 0.0: obj={r.objective}"
+    )
+    assert getattr(r, "gap_certified", False), "finite-box control lost gap_certified"

--- a/python/tests/test_unbounded_relaxation_soundness.py
+++ b/python/tests/test_unbounded_relaxation_soundness.py
@@ -227,3 +227,115 @@ def test_467_finite_box_control_still_certifies_optimal():
         f"finite-box control missed the true optimum 0.0: obj={r.objective}"
     )
     assert getattr(r, "gap_certified", False), "finite-box control lost gap_certified"
+
+
+# ---------------------------------------------------------------------------
+# #467 sub-bug #3: a rigorous infeasibility proof must win over a soft,
+# within-tolerance-only incumbent. Differential — BOTH directions:
+#   (a) genuinely INFEASIBLE + a near-boundary pump incumbent -> NOT optimal.
+#   (b) genuinely FEASIBLE with a within-tolerance boundary optimum -> stays
+#       optimal/feasible; the fix must NEVER flip it to infeasible (the
+#       worst-class error: a false infeasible on a truly-feasible model).
+# ---------------------------------------------------------------------------
+
+
+def _feasible_boundary_model():
+    """Feasible: minimize (x-1)^2+(y-1)^2 s.t. x+y<=2, x,y in [0,2]. The global
+    optimum (1,1) sits ON the constraint boundary, so the incumbent is accepted
+    only within tolerance — exactly the shape the fix must NOT reject."""
+    m = discopt.Model("feas_boundary")
+    x = m.continuous("x", lb=0.0, ub=2.0)
+    y = m.continuous("y", lb=0.0, ub=2.0)
+    m.subject_to(x + y <= 2.0)
+    m.minimize((x - 1.0) ** 2 + (y - 1.0) ** 2)
+    return m
+
+
+def _feasible_bilinear_boundary_model():
+    """Feasible bilinear: minimize x+y s.t. x*y>=4, x,y in [1,3]. Optimum on the
+    x*y=4 boundary (e.g. x=y=2). Guards against a false infeasible when a
+    nonlinear constraint is active at the optimum."""
+    m = discopt.Model("feas_bilinear")
+    x = m.continuous("x", lb=1.0, ub=3.0)
+    y = m.continuous("y", lb=1.0, ub=3.0)
+    m.subject_to(x * y >= 4.0)
+    m.minimize(x + y)
+    return m
+
+
+def _infeasible_bilinear_model():
+    """Infeasible: x*y<=1 with x,y in [2,3] (so x*y in [4,9] > 1). FBBT proves the
+    box empty; there is no feasible point."""
+    m = discopt.Model("infeas_bilinear")
+    x = m.continuous("x", lb=2.0, ub=3.0)
+    y = m.continuous("y", lb=2.0, ub=3.0)
+    m.subject_to(x * y <= 1.0)
+    m.minimize(x + y)
+    return m
+
+
+@pytest.mark.smoke
+def test_467sub3_feasible_boundary_not_flipped_to_infeasible():
+    """(b) false-infeasible guard: a feasible model with a within-tolerance
+    boundary optimum must stay optimal/feasible — NEVER infeasible."""
+    r = _feasible_boundary_model().solve(time_limit=6.0, daemon=False)
+    assert r.status != "infeasible", (
+        f"false infeasible on a truly-feasible model: status={r.status} obj={r.objective}"
+    )
+    assert r.objective is not None and abs(r.objective) <= 1e-3, (
+        f"feasible boundary model lost its optimum: status={r.status} obj={r.objective}"
+    )
+
+
+@pytest.mark.smoke
+def test_467sub3_feasible_bilinear_boundary_not_flipped_to_infeasible():
+    """(b) false-infeasible guard with an active NONLINEAR constraint at the
+    optimum. Must not be reported infeasible."""
+    r = _feasible_bilinear_boundary_model().solve(time_limit=6.0, daemon=False)
+    assert r.status != "infeasible", (
+        f"false infeasible on a truly-feasible bilinear model: status={r.status} obj={r.objective}"
+    )
+    assert r.objective is not None and r.objective <= 4.0 + 1e-2, (
+        f"feasible bilinear model lost its optimum (~4.0): status={r.status} obj={r.objective}"
+    )
+
+
+@pytest.mark.smoke
+def test_467sub3_infeasible_bilinear_never_optimal():
+    """(a) a rigorously infeasible model must NEVER be certified optimal. Either
+    infeasible (rigorous) or a resource-limited non-optimal status is acceptable;
+    a false optimal is not."""
+    r = _infeasible_bilinear_model().solve(time_limit=6.0, daemon=False)
+    assert r.status != "optimal", (
+        f"rigorously-infeasible model falsely certified optimal: status={r.status} "
+        f"obj={r.objective}"
+    )
+
+
+@pytest.mark.slow
+def test_467sub3_ex7_3_6_not_false_optimal():
+    """(a) the real repro (MINLPLib ex7_3_6, oracle =inf=): FBBT proves the root
+    empty by ~2e-6 while a feasibility-pump point at ~1.2e-4 original-constraint
+    residual was previously certified ``optimal``. The fix must make the verdict
+    NOT optimal (infeasible with enough budget; otherwise time_limit/unknown —
+    both acceptable). Skips if the instance is not cached locally."""
+    import os as _os
+
+    nl = _os.path.expanduser("~/.cache/discopt/minlplib/current/nl/ex7_3_6.nl")
+    if not _os.path.exists(nl):
+        pytest.skip("ex7_3_6.nl not cached locally")
+    from discopt.modeling.core import from_nl
+
+    r = from_nl(nl).solve(time_limit=20.0, daemon=False)
+    assert r.status != "optimal", (
+        f"ex7_3_6 (infeasible) falsely certified optimal: status={r.status} obj={r.objective}"
+    )
+    # The rigorous outcome is ``infeasible`` (a certified conclusion — for which
+    # gap_certified=True is correct). A resource-limited ``time_limit``/``unknown``
+    # is also acceptable (not a false optimal). What must never happen: an
+    # ``optimal``, or an ``infeasible`` verdict that still reports a feasible point.
+    assert r.status in ("infeasible", "time_limit", "unknown"), (
+        f"ex7_3_6 unexpected status {r.status} (obj={r.objective})"
+    )
+    if r.status == "infeasible":
+        assert r.objective is None, f"ex7_3_6 reported infeasible with an objective {r.objective}"


### PR DESCRIPTION
Fixes #467 — **false `optimal` certification** on two distinct mechanisms surfaced by the MINLPLib benchmark (2/448 wrong → **0**). Deep-dive per the issue's proposed work; two commits, one per root cause.

## Bug 1 — unbranchable unbounded-below root (the #467 headline)
When the root can't be spatially branched because a continuous variable is unbounded, a 3-site chain in the Rust B&B tree produced a false certificate:
1. `branching.rs` — an unbounded dim gives `relative_width = inf/inf = NaN`, which slips the "too-tight" filter *and* never wins "is-widest" → no branch direction.
2. `tree_manager.rs` — the node is then fathomed **unconditionally** (the only fathom site not gated on a finite bound), despite its dual bound still being `-inf`.
3. `tree_manager.rs` — the sole node fathomed, `min_lb` stays `∞` → **`global_lower_bound := incumbent`** → `is_finished()`, `gap==0` → `optimal`.

**Fix:** gate that fathom on `local_lower_bound.is_finite()`; add a `bound_unresolved` tree flag (set when a node closes with no branch direction *and* no valid finite bound, never cleared) that pins `global_lower_bound = -inf` so `gap = ∞` → `feasible`/`unknown`, never `optimal`. `branching.rs` now deterministically skips non-finite widths. This corrects the false-certificate **class** — not just `ex4_1_5` — across every unbounded/free-variable root.

## Bug 2 — soft incumbent overriding a rigorous infeasibility proof (`ex7_3_6`)
`ex7_3_6` is MINLPLib-infeasible, yet reported `optimal`: FBBT rigorously proves the root box empty (crossover ~2e-6 > the 1e-6 FBBT tol), but a feasibility-pump incumbent at ~1.2e-4 residual was accepted (`_check_constraint_feasibility` tol 1e-4) — and the **factorable reform masked it** (the point satisfies the *reformed* constraints while violating the *original* C0). With an incumbent present, the rigorous infeasibility proof never surfaced.

**Fix (solver.py only; no global tolerance change):** track `_root_rigorously_infeasible` (set at iteration 0 when every root node carries the rigorous `node_infeasible_mask` certificate and no non-rigorous fathom occurred). At the terminal, re-verify the incumbent against the **original (pre-reform)** constraints over its original-variable slice; if it violates them, discard it so the existing infeasibility/unknown logic surfaces. **False-infeasible guard:** if the incumbent *is* rigorously feasible (root proof over-tightened) it's kept and `infeasible` is never emitted; any exception keeps the incumbent. The fix never *manufactures* an infeasible verdict.

## Validation (both fixes, on current `main`)
- **Repros:** `ex4_1_5` → `feasible` (was `optimal 0.2986`); finite-box control → `optimal 0.0`; `ex7_3_6` → `infeasible` (≥16s) / `time_limit` at 5s — never `optimal`.
- `pytest -m smoke`: **505 passed, 1 skipped**; adversarial: **10 passed**; `cargo test -p discopt-core`: **418 passed**, clippy clean, touched files fmt/ruff-clean.
- **Cert-baseline neutrality: EXACT — 41/41, node_count unchanged, Δobj = 0, all still `optimal`** (nothing flipped to `infeasible`).
- **MINLPLib bench-short (448, the tier with both instances): wrong 2 → 1 → 0.** Verdicts `{correct: 249, feasible: 56, unknown: 143}`. **False-infeasible scan clean** — zero new `infeasible` verdicts vs the prior run; zero newly-wrong.
- New differential regression tests in `test_unbounded_relaxation_soundness.py`, both directions (false-optimal RED→GREEN; false-infeasible guards stay `optimal`).

## Scope note
The branching fix downgrades ~18 MINLPLib instances that were certifying via the identical single-node collapse from `optimal` to `feasible` — all verified unsound certificates on a pre-fix binary (`nodes=1, global_lower_bound==incumbent`); their verdicts stay `correct`, just no longer falsely "proved." None are in the cert-baseline (which is exactly neutral), so no *validly*-certified result regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
