### PR TITLE
fix(correctness): M3 — reject cross-model expressions instead of aliasing by index (#413)

### DIFF
--- a/docs/dev/modeling-module-review.md
+++ b/docs/dev/modeling-module-review.md
@@ -154,6 +154,22 @@ Fails-before verified by stashing the core fix. Closes infra INT-2 (same root).
 
 ### M3. Cross-model expressions are silently accepted and alias by index
 
+> **✅ RESOLVED — `test_m3_cross_model_ownership.py`** (branch
+> `fix-m3-cross-model-ownership`, PR for #413/M3). `Model.validate()` (called by
+> `solve()`) now walks the objective + every constraint body (including the
+> indicator/disjunctive/SOS/logical families) via `_iter_owned_leaves` and rejects
+> any `Variable`/`Parameter` that is **index-incompatible** with the model being
+> solved. The invariant is *index-slot identity* — `self._variables[leaf._index]
+> is leaf` (or the leaf is one of this model's own objects) — **not** an
+> `owner is self` test: a legitimate model rebuild that *shares* the original
+> Variable objects (e.g. `reformulate_gdp`, which sets
+> `new_model._variables = list(model._variables)` then adds aux binaries) stays
+> index-compatible and must pass, while a genuinely foreign leaf is rejected loudly
+> with a `ValueError` naming the offending variable and both models. The cross-model
+> repro below now raises at solve time; single-model models (constants, scalars,
+> numpy broadcasts, parameters, matmuls, GDP reformulation) are unaffected
+> (cert-baseline neutral). Fails-before/passes-after verified by stashing the fix.
+
 No layer checks that variables in an objective/constraint belong to the model being
 solved. Variables carry a flat `_index` local to their own model, so a foreign
 variable **aliases whatever variable of the solved model has the same index**.

--- a/docs/dev/review-execution-plan.md
+++ b/docs/dev/review-execution-plan.md
@@ -293,7 +293,7 @@ Legend: ⬜ open · ◧ in-progress · ✅ resolved · ◻︎ not-reproduced.
 | 2 | MP-1 | mpec | ⬜ |
 | 2 | DC-S1 | decomposition | ⬜ |
 | 2 | OA-1=C-35 | solver-core | ⬜ |
-| 2 | M3 | modeling | ⬜ |
+| 2 | M3 | modeling | ✅ `test_m3_cross_model_ownership` — validate() rejects index-incompatible cross-model leaves |
 | 3 | MO1–MO4 | mo | ⬜ |
 | 3 | E1–E3, L1–L8, M4–M8 | modeling/examples/latex | ⬜ |
 | 4 | Rust-1 (dual/ray unscale), Rust-2 (numpy panic), P2/P3 across all | all | ⬜ |

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -761,6 +761,70 @@ def _find_owning_model(*exprs: Expression) -> Optional["Model"]:
     return None
 
 
+def _iter_model_leaves(*exprs: Expression):
+    """Yield every ``Variable`` / ``Parameter`` leaf reachable from *exprs*.
+
+    Walks the expression DAG(s) and surfaces the model-owning leaf nodes
+    (``Variable`` and ``Parameter``, both of which carry a ``.model`` back-
+    reference). ``Constant`` leaves — scalars, numpy arrays, broadcasts — carry
+    no model and are simply not yielded, so an ownership check built on this
+    walker never trips on legitimate constants. Used by the cross-model
+    ownership guard (finding M3) to detect a variable/parameter that belongs to
+    a different :class:`Model` than the one it is being solved in.
+    """
+    stack = list(exprs)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (Variable, Parameter)):
+            yield node
+        elif isinstance(node, IndexExpression):
+            stack.append(node.base)
+        elif isinstance(node, BinaryOp):
+            stack.extend((node.left, node.right))
+        elif isinstance(node, UnaryOp):
+            stack.append(node.operand)
+        elif isinstance(node, FunctionCall):
+            stack.extend(node.args)
+        elif isinstance(node, CustomCall):
+            stack.extend(node.args)
+        elif isinstance(node, MatMulExpression):
+            stack.extend((node.left, node.right))
+        elif isinstance(node, SumExpression):
+            stack.append(node.operand)
+        elif isinstance(node, SumOverExpression):
+            stack.extend(node.terms)
+        # Constant (and anything without children) contributes no owning leaf.
+
+
+def _logical_backing_vars(expr) -> list:
+    """Collect the backing ``Variable`` objects under a ``LogicalExpression`` tree.
+
+    ``BooleanVar`` wraps a binary ``Variable`` (``.variable``); the composite
+    logical nodes (``LogicalAnd``/``LogicalOr``/…) hold child logical
+    expressions. Returns the flat list of backing variables so the ownership
+    guard can check them too.
+    """
+    out: list = []
+    stack = [expr]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, BooleanVar):
+            if isinstance(node.variable, Variable):
+                out.append(node.variable)
+            else:
+                # Indexed BooleanVar wraps an IndexExpression over a Variable.
+                out.extend(_iter_model_leaves(node.variable))
+        elif isinstance(node, (LogicalAnd, LogicalOr, LogicalEquivalent)):
+            stack.extend((node.left, node.right))
+        elif isinstance(node, LogicalNot):
+            stack.append(node.operand)
+        elif isinstance(node, LogicalImplies):
+            stack.extend((node.antecedent, node.consequent))
+        elif isinstance(node, (LogicalAtLeast, LogicalAtMost, LogicalExactly)):
+            stack.extend(node.operands)
+    return out
+
+
 def if_else(
     condition: "Constraint",
     then_value: Union[Expression, float],
@@ -3138,6 +3202,94 @@ class Model:
 
     # ── Validation ──
 
+    def _iter_owned_leaves(self):
+        """Yield every ``Variable``/``Parameter`` leaf referenced by this model.
+
+        Walks the objective expression and every constraint body (including the
+        indicator/disjunctive/SOS/logical constraint families) so the ownership
+        guard (M3) sees the same leaves the solver will eventually lower to the
+        flat Rust variable vector.
+        """
+        if self._objective is not None:
+            yield from _iter_model_leaves(self._objective.expression)
+
+        def _from_constraint(c):
+            if isinstance(c, Constraint):
+                yield from _iter_model_leaves(c.body)
+            elif isinstance(c, _IndicatorConstraint):
+                yield from _iter_model_leaves(c.indicator)
+                yield from _from_constraint(c.constraint)
+            elif isinstance(c, _DisjunctiveConstraint):
+                for disjunct in c.disjuncts:
+                    for sub in disjunct:
+                        yield from _from_constraint(sub)
+            elif isinstance(c, _SOSConstraint):
+                yield from _iter_model_leaves(*c.variables)
+            elif isinstance(c, _LogicalConstraint):
+                yield from _iter_model_leaves(*_logical_backing_vars(c.expression))
+            elif hasattr(c, "body"):
+                # Unknown arithmetic-bodied constraint type: still walk its body.
+                yield from _iter_model_leaves(c.body)
+
+        for c in self._constraints:
+            yield from _from_constraint(c)
+
+    def _check_ownership(self):
+        """Reject expressions that reference a variable/parameter of another model.
+
+        A :class:`Variable` carries a flat ``_index`` into *its own* model's
+        variable vector. When the solver lowers this model it addresses each
+        leaf by that flat index, so the precise soundness invariant is:
+
+            ``self._variables[leaf._index] is leaf``
+
+        i.e. the leaf's flat index must address *that very object* in the model
+        being solved. A leaf from a foreign model has an index that addresses a
+        **different** object (or is out of range) → it would silently **alias by
+        flat index** onto this model's same-index variable, a wrong answer rather
+        than an error (review finding M3). Raise loudly instead (CLAUDE.md §3).
+
+        This index-slot identity is deliberately *not* an ``owner is self`` test:
+        legitimate model rebuilds (e.g. ``reformulate_gdp``) construct a new
+        ``Model`` that **shares** the original ``Variable`` objects in the same
+        order — index-compatible, so those must pass — while adding new aux
+        variables of their own. The identity check accepts both and rejects only
+        a genuinely foreign, index-incompatible leaf. One O(DAG) walk per solve.
+        """
+        # Object-identity membership sets for O(1) lookup. For variables, index
+        # equality is the real invariant; the identity set is the fast primary
+        # check, with the index-slot check as the precise diagnostic.
+        var_ids = {id(v) for v in self._variables}
+        param_ids = {id(p) for p in self._parameters}
+        n_vars = len(self._variables)
+        for leaf in self._iter_owned_leaves():
+            if isinstance(leaf, Parameter):
+                if id(leaf) in param_ids:
+                    continue
+            else:  # Variable
+                if id(leaf) in var_ids:
+                    continue
+                idx = getattr(leaf, "_index", None)
+                # An index that happens to address this very object is also fine
+                # (shared-object rebuilds), but that is already covered by the id
+                # set above; reaching here means the object is not in this model.
+                if idx is not None and 0 <= idx < n_vars and self._variables[idx] is leaf:
+                    continue
+            # Foreign leaf: index-incompatible with the model being solved.
+            owner = getattr(leaf, "model", None)
+            kind = "parameter" if isinstance(leaf, Parameter) else "variable"
+            own_name = getattr(owner, "name", None) or "<unknown>"
+            self_name = getattr(self, "name", None) or "<unnamed>"
+            raise ValueError(
+                f"Cross-model reference: {kind} '{leaf.name}' belongs to a "
+                f"different model ('{own_name}'), not to model '{self_name}' being "
+                f"solved. Variables/parameters carry a flat index local to their "
+                f"own model, so mixing them across models would silently alias by "
+                f"index and produce a wrong answer. Rebuild the offending "
+                f"expression using only variables/parameters declared on model "
+                f"'{self_name}'."
+            )
+
     def validate(self):
         """
         Validate model consistency.
@@ -3146,7 +3298,9 @@ class Model:
         ------
         ValueError
             If the objective is not set, variable names are not unique,
-            or variable bounds are inconsistent (lb > ub).
+            variable bounds are inconsistent (lb > ub), or any objective/
+            constraint references a variable/parameter owned by a *different*
+            model (which would silently alias by flat index — finding M3).
         """
         if self._objective is None:
             raise ValueError("No objective set. Call m.minimize() or m.maximize().")
@@ -3158,6 +3312,8 @@ class Model:
             names.add(var.name)
             if np.any(var.lb > var.ub):
                 raise ValueError(f"Variable '{var.name}' has lb > ub at some index")
+
+        self._check_ownership()
 
     # ── Model statistics ──
 

--- a/python/tests/test_m3_cross_model_ownership.py
+++ b/python/tests/test_m3_cross_model_ownership.py
@@ -1,0 +1,216 @@
+"""M3 (#413) — cross-model expressions must be rejected, never aliased by index.
+
+Finding M3 (``docs/dev/modeling-module-review.md``): a :class:`Variable` carries
+a flat ``_index`` into *its own* model's variable vector. Before this fix, mixing
+a variable from model B into model A's objective/constraint was silently
+accepted; the solver addressed the foreign variable by that flat index and it
+**aliased** whatever variable of the solved model had the same index → a
+plausible-looking **wrong answer** rather than an error.
+
+The guard is a single O(DAG) walk in ``Model.validate()`` (called by
+``solve()``): every ``Variable``/``Parameter`` reached from the objective and
+constraints must be *index-compatible* with the model being solved — i.e.
+``self._variables[leaf._index] is leaf`` (or the leaf is one of this model's own
+objects). This is deliberately an **index-slot identity** test, not an
+``owner is self`` test, so that legitimate model rebuilds that *share* the same
+Variable objects (e.g. ``reformulate_gdp``) are accepted while a genuinely
+foreign, index-incompatible leaf is rejected.
+
+These tests pin the *class* of the fix:
+
+* the guard fires at **solve time** for any cross-model reference reaching the
+  objective or a constraint, so the aliasing can never reach the Rust repr; and
+* legitimate single-model expressions — constants, Python scalars, numpy-array
+  constants, broadcasts, parameters, matmuls, and GDP models whose reformulation
+  shares variable objects across an internal model rebuild — do **not** raise
+  (no false positives).
+
+Fails-before / passes-after: on pre-fix code the cross-model ``solve()`` cases
+returned a silently wrong ``optimal`` result instead of raising.
+"""
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt import Model
+
+pytestmark = pytest.mark.smoke
+
+
+# ─────────────────────────── positive: must RAISE ───────────────────────────
+
+
+def test_cross_model_aliasing_would_be_wrong_answer():
+    """The headline M3 repro: min xa + xb with xb from another model.
+
+    If honored, xa∈[0,10], xb∈[5,10] gives optimum 5 (xa=0, xb=5). Pre-fix, xb
+    (index 0 in B) aliased xa (index 0 in A), collapsing the objective to
+    ``2*xa`` → optimum ~0. The guard now refuses at solve time instead.
+    """
+    ma = Model("A")
+    xa = ma.continuous("xa", lb=0, ub=10)
+    mb = Model("B")
+    xb = mb.continuous("xb", lb=5, ub=10)
+
+    ma.minimize(xa + xb)
+    with pytest.raises(ValueError, match="[Cc]ross-model"):
+        ma.solve()
+
+
+def test_cross_model_objective_various_operators_raise():
+    """The whole class of cross-model objective combinations is rejected."""
+    for build in (
+        lambda a, b: a - b,
+        lambda a, b: a * b,
+        lambda a, b: a / (b + 1.0),
+        lambda a, b: dm.exp(a) + dm.log(b + 1.0),
+    ):
+        ma = Model("A")
+        xa = ma.continuous("xa", lb=1, ub=10)
+        mb = Model("B")
+        xb = mb.continuous("xb", lb=1, ub=10)
+        ma.minimize(build(xa, xb))
+        with pytest.raises(ValueError, match="[Cc]ross-model"):
+            ma.solve()
+
+
+def test_cross_model_foreign_objective_raises_at_solve():
+    """A foreign var used as the *whole* objective (no combine) still raises."""
+    ma = Model("A")
+    ma.continuous("xa", lb=0, ub=10)  # index 0 in A
+    mb = Model("B")
+    xb = mb.continuous("xb", lb=5, ub=10)  # index 0 in B, aliases xa pre-fix
+
+    ma.minimize(xb)
+    with pytest.raises(ValueError, match="[Cc]ross-model"):
+        ma.solve()
+
+
+def test_cross_model_foreign_constraint_raises_at_solve():
+    """A foreign var reaching a constraint body is caught too."""
+    ma = Model("A")
+    xa = ma.continuous("xa", lb=0, ub=10)
+    mb = Model("B")
+    xb = mb.continuous("xb", lb=0, ub=10)
+
+    ma.minimize(xa)
+    ma.subject_to(xa + xb <= 3.0)  # xb foreign
+    with pytest.raises(ValueError, match="[Cc]ross-model"):
+        ma.solve()
+
+
+def test_cross_model_parameter_raises_at_solve():
+    """A foreign Parameter mixed into the objective is rejected."""
+    ma = Model("A")
+    xa = ma.continuous("xa", lb=1, ub=10)
+    mb = Model("B")
+    pb = mb.parameter("pb", value=2.0)
+
+    ma.minimize(pb * xa)
+    with pytest.raises(ValueError, match="[Cc]ross-model"):
+        ma.solve()
+
+
+def test_same_index_different_object_is_rejected():
+    """Two models with an identically-indexed but *different* var must not alias.
+
+    Both models declare a first variable (index 0). Referencing model B's var in
+    model A must raise, not silently address A's index-0 slot.
+    """
+    ma = Model("A")
+    ma.continuous("xa", lb=0, ub=10)
+    mb = Model("B")
+    xb = mb.continuous("xb", lb=0, ub=10)
+    assert xb._index == 0  # same flat index as A's xa
+
+    ma.minimize(xb)
+    with pytest.raises(ValueError, match="[Cc]ross-model"):
+        ma.solve()
+
+
+# ─────────────────────── negative: must NOT raise ───────────────────────────
+
+
+def test_single_model_with_constants_and_scalars_ok():
+    """Scalars and numeric constants must never trip the ownership guard."""
+    m = Model("legit")
+    x = m.continuous("x", lb=0, ub=10)
+    m.minimize(3.0 * x + 2 - 1.5)  # python scalars / constants
+    m.subject_to(x >= 1.0)
+    r = m.solve()
+    assert r.status == "optimal"
+    assert r.objective == pytest.approx(3.0 * 1.0 + 0.5, abs=1e-5)
+
+
+def test_single_model_with_numpy_broadcast_ok():
+    """numpy-array constants, broadcasts, and matmul on ONE model are fine."""
+    m = Model("legit2")
+    x = m.continuous("x", shape=(2,), lb=0, ub=10)
+    coef = np.array([1.0, 2.0])
+    m.minimize(dm.sum(x) + coef @ x + 3.0)
+    m.subject_to(x >= 1.0)
+    r = m.solve()
+    assert r.status == "optimal"
+    # x = [1, 1]: sum=2, coef@x=3, const=3 -> 8
+    assert r.objective == pytest.approx(8.0, abs=1e-5)
+
+
+def test_single_model_with_parameter_ok():
+    """A parameter and variable from the SAME model must not raise."""
+    m = Model("legit3")
+    x = m.continuous("x", lb=0, ub=10)
+    p = m.parameter("p", value=2.0)
+    m.minimize(p * x)
+    m.subject_to(x >= 1.0)
+    r = m.solve()
+    assert r.status == "optimal"
+    assert r.objective == pytest.approx(2.0, abs=1e-5)
+
+
+def test_same_model_two_variables_ok():
+    """Two variables from the same model combine freely."""
+    m = Model("legit4")
+    a = m.continuous("a", lb=0, ub=10)
+    b = m.continuous("b", lb=0, ub=10)
+    m.minimize(a + b)
+    m.subject_to(a + b >= 3.0)
+    r = m.solve()
+    assert r.status == "optimal"
+    assert r.objective == pytest.approx(3.0, abs=1e-5)
+
+
+def test_gdp_reformulation_shared_variables_not_false_positive():
+    """A GDP model whose reformulation builds a *new* Model sharing the original
+    Variable objects (and adding aux binaries) must pass the ownership check.
+
+    ``reformulate_gdp`` creates ``Model(model.name)`` and sets
+    ``new_model._variables = list(model._variables)`` — different Model object,
+    same shared, index-compatible Variable objects — then combines them with new
+    aux vars. An ``owner is self`` check would false-positive here; the index-
+    slot identity check must accept it.
+    """
+    m = dm.Model("gdp_share")
+    Y = m.boolean("y", shape=(3,))
+    m.logical(Y[0].implies(Y[1] & ~Y[2]))
+    m.subject_to(Y[0].variable == 1)
+    m.minimize(Y[1].variable + Y[2].variable)
+    r = m.solve(time_limit=30)
+    # Must reach a real result, not a cross-model ValueError.
+    assert r.status in ("optimal", "feasible")
+
+
+def test_validate_directly_accepts_index_shared_rebuild():
+    """Directly exercise the index-slot identity path: a second model sharing the
+    first's variable list (same objects, same order) validates clean."""
+    m = Model("orig")
+    x = m.continuous("x", lb=0, ub=5)
+    m.minimize(x)
+    m.subject_to(x >= 2.0)
+
+    rebuilt = Model("orig")
+    rebuilt._variables = list(m._variables)  # shared objects, index-compatible
+    rebuilt._parameters = list(m._parameters)
+    rebuilt._objective = m._objective
+    rebuilt._constraints = list(m._constraints)
+    # x.model is still the original `m`, but x._index addresses x in `rebuilt`.
+    rebuilt.validate()  # must not raise


### PR DESCRIPTION
## M3 (modeling review, #413) — cross-model expressions aliased by flat index

**P0 correctness.** A `Variable` carries a flat `_index` into *its own* model's
variable vector; the solver addresses each leaf by that index when it lowers the
model. Nothing checked that a variable/parameter in an objective/constraint
belonged to the model being solved, so mixing a variable from model B into model
A was silently accepted and the foreign leaf **aliased** whatever variable of the
solved model had the same flat index — a plausible-looking **wrong answer**, not
an error.

### Confirmed repro (origin/main)
`min xa + xb` with `xa ∈ [0,10]` (model A) and `xb ∈ [5,10]` (model B, index 0
in B). Honored optimum is **5** (xa=0, xb=5). Pre-fix `ma.solve()` returned
`optimal` objective **~0** because `xb` aliased `xa` (index 0 in A), collapsing
the objective to `2*xa`; `xb`'s bounds `[5,10]` were entirely ignored.

### Fix
`Model.validate()` (already called by `solve()`) now runs `_check_ownership()`, a
single O(DAG) walk over the objective + every constraint body (including the
indicator/disjunctive/SOS/logical families). Any `Variable`/`Parameter` that is
**index-incompatible** with the model being solved raises a clear `ValueError`
naming the offending leaf and both models — so the aliasing can never reach the
Rust repr.

The invariant is **index-slot identity** — `self._variables[leaf._index] is leaf`
(or the leaf is one of this model's own objects) — deliberately **not** an
`owner is self` test. A legitimate model rebuild that *shares* the original
`Variable` objects (e.g. `reformulate_gdp`, which sets
`new_model._variables = list(model._variables)` then adds aux binaries) stays
index-compatible and must pass; an owner-identity check false-positived on it
(6 GDP/reformulation/division tests). The identity check accepts the shared-object
rebuild and rejects only a genuinely foreign leaf. Constants (scalars, numpy
arrays, broadcasts) carry no owner and are never yielded, so single-model
expressions are unaffected. General to the whole class; no instance/shape special
cases; no guard weakened.

### Regression test
`python/tests/test_m3_cross_model_ownership.py` (12 smoke tests, sub-second):
- 6 **positive** (cross-model objective / various operators / whole-objective /
  constraint body / foreign parameter / same-index-different-object) — all raise.
- 6 **negative** (constants+scalars / numpy broadcast+matmul / parameter /
  two-var single model / GDP reformulation shared-variable rebuild / direct
  index-shared-rebuild `validate()`) — none raise.

Fails-before/passes-after verified by stashing the source fix: the 6 positive
tests go red pre-fix; all 6 negative pass on both.

### Verification (`JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`)
- New M3 tests: **12 passed**. Pre-fix: **6 failed / 6 passed**.
- `pytest -k "modeling or model or variable or expression or constraint or ownership"`:
  **760 passed, 1 skipped**.
- `pytest -m smoke`: **542 passed, 1 skipped**.
- Adversarial (`test_adversarial_recent_fixes.py -m slow`): **10 passed**.
- **Cert-baseline neutrality** (`docs/dev/data/cert-baseline.jsonl`): **NEUTRAL** —
  EXACT `nodes N->N` and `|Δobj|=0.00e+00` on all **41** certifying instances;
  `incorrect_count == 0`. (Cert-baseline models are single-model, so the guard is
  a no-op for them.)
- ruff/format clean on touched files. mypy is blocked by a pre-existing numpy-stub
  syntax error in this venv (identical before/after — not introduced here). No
  Rust touched (`cargo` N/A).

### Docs
`modeling-module-review.md` M3 → ✅ RESOLVED; `review-execution-plan.md` §4 M3 → ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
