### PR TITLE
fix(interop): EX-1 — ASL-conformant .nl Jacobian structure (#413)

### DIFF
--- a/docs/dev/export-module-review.md
+++ b/docs/dev/export-module-review.md
@@ -19,7 +19,7 @@ comparison this repository exists to make.
 
 | # | Severity | Component | Finding |
 |---|----------|-----------|---------|
-| EX-1 | **P0 interop** | `nl.py` | `.nl` Jacobian structure is **non-conformant with the ASL convention**: variables appearing only nonlinearly in a constraint get no zero-coefficient J entry, so the header nonzero count, the k section, and the J sections mutually disagree (4 vs 1 vs 3 on a 2-var model). Pyomo's writer on the same model emits `J0 2 / 0 0 / 1 1` and consistent counts [CONFIRMED by direct diff] |
+| EX-1 ✅ RESOLVED | **P0 interop** | `nl.py` | `.nl` Jacobian structure is **non-conformant with the ASL convention**: variables appearing only nonlinearly in a constraint get no zero-coefficient J entry, so the header nonzero count, the k section, and the J sections mutually disagree (4 vs 1 vs 3 on a 2-var model). Pyomo's writer on the same model emits `J0 2 / 0 0 / 1 1` and consistent counts [CONFIRMED by direct diff]. **FIXED (#413):** the header nnz, the `k` section, and every `J` block are now built from one union sparsity per constraint (`_jac_cols` = `linear vars ∪ nonlinear vars`), so a nonlinear-only var gets a 0-coeff `J` entry and all three agree; the objective gradient (`G`) uses the same union. Pure-constant bodies are peeled to the r-section rhs (body becomes `n0`, no longer counted nonlinear — ASL requires nonlinear cons to be the first `n_nl_cons`). EX-9 folded in: `k` section is now a single-pass per-column tally. Byte-level structural parity with Pyomo's writer on a 4-case corpus (linear-only / nonlinear-only-var / mixed-lin+nl / objective-nonlinear); in-house round-trip + solve unchanged. Regression: `TestNLWriterJacobianConformance` in `python/tests/test_nl_writer.py`. |
 | EX-2 ✅ RESOLVED 1dc3278 | **P0 silent-wrong** | `mps.py`, `lp.py`, `gams.py` | **Builder-resident models export as empty/zero models**: fast-API constraint rows and `add_linear_objective` are invisible — MPS emits a ROWS section with only OBJ, LP emits `obj: 0`, GAMS emits `obj_var =e= 0`. Only `nl.py` handles builder blocks [CONFIRMED]. **FIXED (X-1):** MPS/LP/GAMS now emit builder rows via `export._common.iter_builder_linear_rows` and recover a builder-resident linear/quadratic objective via `export._common.builder_objective` (was `obj: 0`). Exported MPS round-trips through HiGHS to the true optimum (3.0). Regression: `test_x1_builder_resident_rows.py::test_ex2_*`. |
 | EX-3 | **P0 silent-wrong** | `mps.py:158`, `lp.py:127`, `gams.py:163` | **Fixed binaries lose their fixing** in all three formats (the binary branch ignores `lb`/`ub` entirely: `BV BND`, implicit LP binary, no GAMS bounds). Writer-side sibling of the `from_nl` import bug (modeling-review M2); `.nl`'s b-section is correct [CONFIRMED] |
 | EX-4 | ✅ RESOLVED (X-2 residual) | `gams.py:176-191` | **Heterogeneous per-element array bounds are silently dropped entirely** (written only when uniform) — a DAE-style model with `u[0]` pinned to 1 via bounds exports with **no bounds at all**; the `.nl` control correctly writes `4 1.0` [CONFIRMED]. **FIXED**: `to_gams` now emits per-element `.lo('k')`/`.up('k')` at 1-based labels (uniform still compacted to one domain-wide line); `from_gams` parses concrete-label bounds so heterogeneous bounds round-trip. Tests `test_gams_export_preserves_heterogeneous_array_bounds` + `test_gams_roundtrip_preserves_per_element_bounds` (`test_x2_residual_array_bounds.py`). |
@@ -27,7 +27,7 @@ comparison this repository exists to make.
 | EX-6 | P1 | `gams.py` | No scalarization pass: vector/broadcast constraint bodies and `SumExpression`/`MatMul` render as scalar-syntax garbage (`(x)` for `sum(x)`, `(A * x)` for `A@x`), and unknown nodes are written **into the file** as `<unsupported:…>` instead of raising — export "succeeds", GAMS compile fails later (or worse) [BY INSPECTION] |
 | EX-7 | P2 | `_extract.py:153,475` | Array-valued `Constant` in a scalar position silently collapses to its **first element** (`value.flat[0]`); `sum(constant_vector)` likewise returns the first element rather than the sum [BY INSPECTION] |
 | EX-8 | P2 | `mps.py`/`lp.py`/`gams.py` | Constraint-name hygiene: duplicates never checked (duals/rows silently collide), `_sanitize_name` handles only space/dash — indexed-family names like `cap[pitt]` corrupt LP files (brackets delimit quadratic sections) and break GAMS |
-| EX-9 | P3 | `nl.py:912-924` | k-section built by an O(n_vars × n_cons) nested scan — quadratic build time on large models (also wrong per EX-1; fix together) |
+| EX-9 ✅ RESOLVED (with EX-1) | P3 | `nl.py` | k-section built by an O(n_vars × n_cons) nested scan — quadratic build time on large models (also wrong per EX-1; fix together). **FIXED (#413):** `_write_k_section` now accumulates a per-column nonzero tally in a single pass over the constraint rows (O(nnz)); shares the union sparsity with the header/`J` fix. |
 
 Checked and found **correct** (worth as much as the findings):
 
@@ -57,7 +57,18 @@ Checked and found **correct** (worth as much as the findings):
 
 ---
 
-## 2. The `.nl` conformance bug (EX-1) in detail
+## 2. The `.nl` conformance bug (EX-1) in detail — ✅ RESOLVED (#413)
+
+> **STATUS: RESOLVED.** Implemented as described below, with one refinement:
+> rather than "keep constants in the C body", a *pure-constant* nonlinear body
+> is peeled into the r-section rhs (body → `n0`), matching Pyomo exactly and
+> keeping the ASL requirement that nonlinear constraints are the first
+> `n_nl_cons` rows and carry the only non-`n0` bodies. A body that *does*
+> reference a variable keeps its constant folded via the rhs the same way.
+> Byte-level structural parity with Pyomo verified on the acceptance corpus;
+> in-house round-trip + solve unchanged. Regression:
+> `TestNLWriterJacobianConformance` in `python/tests/test_nl_writer.py`.
+
 
 Reproduction (2 variables, `exp(x) + y <= 5` and `x + y <= 3`):
 

--- a/docs/dev/review-execution-plan.md
+++ b/docs/dev/review-execution-plan.md
@@ -288,7 +288,7 @@ Legend: ⬜ open · ◧ in-progress · ✅ resolved · ◻︎ not-reproduced.
 | 1 | NM-1=C-32 (live JAX + numpy), NM-2 | _numpy/_jax McCormick | ⬜ |
 | 2 | RO-1, RO-2, RO-3 | ro | ⬜ |
 | 2 | C1, C2, C3 | dae | ⬜ |
-| 2 | EX-1 | export | ⬜ |
+| 2 | EX-1 | export | ✅ — union-based J/G/k/header sparsity; nonlinear-only vars get a 0-coeff `J` entry; pure-constant bodies move to r-section rhs (`n0` body, no longer counted nonlinear). Byte-level structural parity with Pyomo's writer on a 4-case corpus; `TestNLWriterJacobianConformance` in `test_nl_writer.py`; #413 |
 | 2 | INT-1 | infra/solver | ⬜ |
 | 2 | MP-1 | mpec | ⬜ |
 | 2 | DC-S1 | decomposition | ⬜ |

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -140,6 +140,12 @@ class _NLWriter:
         self._obj_nonlinear: Expression | None = None
         self._con_linear: list[dict[int, float]] = []  # per constraint
         self._con_nonlinear: list[Expression | None] = []
+        # Variables referenced by each constraint's nonlinear body (excluding
+        # pure constants). The Jacobian sparsity of a constraint is the UNION of
+        # its linear vars and these; a nonlinear-only var gets a 0-coefficient
+        # J entry (ASL convention). Filled by _decompose_expressions.
+        self._con_nl_vars: list[set[int]] = []
+        self._obj_nl_vars: set[int] = set()  # vars in the objective nonlinear body
         self._con_bounds: list[tuple[int, float, float]] = []  # (type, lb, ub)
         # Header discrete/nonlinear counts, filled by _reorder_vars_canonical.
         self._nlvc_total = 0  # total nonlinear vars in constraints (incl. both)
@@ -155,6 +161,7 @@ class _NLWriter:
         self._build_var_map()
         self._decompose_expressions()
         self._reorder_vars_canonical()
+        self._compute_nl_vars()
         buf = io.StringIO()
         self._write_header(buf)
         self._write_C_sections(buf)
@@ -296,29 +303,79 @@ class _NLWriter:
         self._nbv = len(lin_bin)
         self._niv = len(lin_int)
 
+    # ── Jacobian sparsity (union of linear + nonlinear vars per constraint) ──
+
+    def _compute_nl_vars(self):
+        """Resolve each constraint's nonlinear-body variable indices.
+
+        Must run *after* :meth:`_reorder_vars_canonical` so ``_var_index`` is
+        final (nonlinear expressions resolve their variable indices lazily
+        through it). Stored in ``_con_nl_vars`` and used by the header, ``k``,
+        and ``J`` writers so all three agree on one sparsity pattern.
+        """
+        self._con_nl_vars = []
+        for nl in self._con_nonlinear:
+            vs: set[int] = set()
+            if nl is not None:
+                self._collect_var_indices(nl, vs)
+            self._con_nl_vars.append(vs)
+        obj_vs: set[int] = set()
+        if self._obj_nonlinear is not None:
+            self._collect_var_indices(self._obj_nonlinear, obj_vs)
+        self._obj_nl_vars = obj_vs
+
+    def _jac_cols(self, i: int) -> dict[int, float]:
+        """Full Jacobian row for constraint ``i``: ``{var_idx: coeff}``.
+
+        The ASL convention: every variable appearing in the constraint —
+        linearly *or* nonlinearly — gets an entry carrying its linear
+        coefficient (``0.0`` for a variable that appears only nonlinearly).
+        This single union map is the source of truth for the header nonzero
+        count, the ``k`` cumulative-column-count section, and the ``J`` block,
+        so all three are guaranteed to agree.
+        """
+        cols = dict(self._con_linear[i])
+        for vi in self._con_nl_vars[i]:
+            cols.setdefault(vi, 0.0)
+        return cols
+
+    def _obj_grad_cols(self) -> dict[int, float]:
+        """Full objective gradient: ``{var_idx: coeff}`` (0.0 for nonlinear-only).
+
+        The ``G`` section and the header gradient-nonzero count are both built
+        from this union of the objective's linear vars and its nonlinear-body
+        vars, so they agree.
+        """
+        cols = dict(self._obj_linear)
+        for vi in self._obj_nl_vars:
+            cols.setdefault(vi, 0.0)
+        return cols
+
     # ── Decompose expressions into linear + nonlinear parts ──
 
     def _decompose_expressions(self):
         """Split objective and constraints into linear and nonlinear parts."""
         obj = self.model._objective
         if obj is not None:
-            linear, nonlinear = self._split_expr(obj.expression)
+            # Objectives have no r-section rhs, so the constant offset stays in
+            # the O body (re-attached as an additive node).
+            linear, nonlinear, const_offset = self._split_expr(obj.expression)
             self._obj_linear = linear
-            self._obj_nonlinear = nonlinear
+            self._obj_nonlinear = self._attach_const(nonlinear, const_offset)
         self._decompose_builder_objective()
 
         for con in self.model._constraints:
             # Determine constraint bound type (shared by every scalar row this
             # constraint expands into).
-            rhs = con.rhs
+            rhs = float(con.rhs)
             if con.sense == "<=":
-                bnd = (1, 0.0, float(rhs))  # body <= rhs
+                base_bnd = (1, 0.0, rhs)  # body <= rhs
             elif con.sense == ">=":
-                bnd = (2, float(rhs), 0.0)  # body >= rhs (stored as <=)
+                base_bnd = (2, rhs, 0.0)  # body >= rhs
             elif con.sense == "==":
-                bnd = (4, float(rhs), float(rhs))
+                base_bnd = (4, rhs, rhs)
             else:
-                bnd = (3, 0.0, 0.0)  # free (unreachable in practice)
+                base_bnd = (3, 0.0, 0.0)  # free (unreachable in practice)
 
             # Vectorized constraints (e.g. DAE/collocation bodies built from
             # matrix products and broadcasting) carry an array-valued body that
@@ -326,12 +383,47 @@ class _NLWriter:
             # expression per output element before linear/nonlinear splitting.
             bodies = self._scalarize_body(con.body)
             for body in bodies:
-                linear, nonlinear = self._split_expr(body)
+                linear, nonlinear, const_offset = self._split_expr(body)
                 self._con_linear.append(linear)
                 self._con_nonlinear.append(nonlinear)
-                self._con_bounds.append(bnd)
+                self._con_bounds.append(self._offset_bound(base_bnd, const_offset))
 
         self._decompose_builder_blocks()
+
+    @staticmethod
+    def _attach_const(nl: Expression | None, const_offset: float) -> Expression | None:
+        """Re-attach a constant offset to a nonlinear body (for objectives).
+
+        Constraints carry the constant in the r-section rhs, but the objective
+        has no rhs — so its constant offset is added back as an ``x + const``
+        node (or a bare ``Constant`` when there is no variable part).
+        """
+        if const_offset == 0.0:
+            return nl
+        if nl is None:
+            return Constant(const_offset)
+        return BinaryOp("+", nl, Constant(const_offset))
+
+    @staticmethod
+    def _offset_bound(
+        bnd: tuple[int, float, float], const_offset: float
+    ) -> tuple[int, float, float]:
+        """Move a body constant offset into the constraint bound.
+
+        The split peels the constant out of the body, so ``body <sense> rhs``
+        becomes ``(body - const) <sense> (rhs - const)``. Subtract the offset
+        from whichever numeric bound(s) the sense uses.
+        """
+        if const_offset == 0.0:
+            return bnd
+        btype, lb, ub = bnd
+        if btype == 1:  # <= ub
+            return (btype, lb, ub - const_offset)
+        if btype == 2:  # >= lb
+            return (btype, lb - const_offset, ub)
+        if btype in (0, 4):  # range / equality: both bounds carry rhs
+            return (btype, lb - const_offset, ub - const_offset)
+        return bnd  # free: nothing to shift
 
     def _decompose_builder_objective(self):
         """Recover a linear or quadratic objective that lives only in the builder.
@@ -627,11 +719,30 @@ class _NLWriter:
         # Opaque scalar leaf (e.g. Parameter): leave intact.
         return self._obj0(expr)
 
-    def _split_expr(self, expr: Expression) -> tuple[dict[int, float], Expression | None]:
-        """Split an expression into linear terms {var_idx: coeff} and nonlinear remainder."""
+    def _split_expr(self, expr: Expression) -> tuple[dict[int, float], Expression | None, float]:
+        """Split an expression into linear, variable-referencing nonlinear, and constant.
+
+        Returns ``(linear, nonlinear, const_offset)`` where:
+
+        - ``linear`` is ``{var_idx: coeff}`` for the linear terms,
+        - ``nonlinear`` is the variable-referencing nonlinear remainder (or
+          ``None`` if there is none), and
+        - ``const_offset`` is the accumulated constant contribution.
+
+        The constant is peeled out separately (rather than folded into the
+        nonlinear body) so callers can carry it in the ``r``-section rhs
+        instead of an ``n<const>`` node in the constraint body. Keeping the
+        nonlinear body free of a pure constant is what lets a constraint like
+        ``x + y <= 3`` (which discopt normalizes to ``x + y - 3 <= 0``) be
+        emitted as a genuinely *linear* constraint with an ``n0`` body — the
+        ASL convention (nonlinear constraints must be the first ``n_nl_cons``
+        and carry the only non-``n0`` bodies).
+        """
         linear: dict[int, float] = {}
         nonlinear_terms: list[Expression] = []
-        self._collect_linear(expr, 1.0, linear, nonlinear_terms)
+        const_acc: list[float] = [0.0]
+        self._collect_linear(expr, 1.0, linear, nonlinear_terms, const_acc)
+        const_offset = const_acc[0]
         if nonlinear_terms:
             if len(nonlinear_terms) == 1:
                 nl_expr = nonlinear_terms[0]
@@ -639,8 +750,8 @@ class _NLWriter:
                 nl_expr = nonlinear_terms[0]
                 for t in nonlinear_terms[1:]:
                     nl_expr = BinaryOp("+", nl_expr, t)
-            return linear, nl_expr
-        return linear, None
+            return linear, nl_expr, const_offset
+        return linear, None, const_offset
 
     def _collect_linear(
         self,
@@ -648,8 +759,14 @@ class _NLWriter:
         coeff: float,
         linear: dict[int, float],
         nonlinear: list[Expression],
+        const_acc: list[float],
     ):
         """Collect linear terms ``{var_idx: coeff}`` and segregate nonlinear ones.
+
+        Constant contributions accumulate into ``const_acc[0]`` (a 1-element
+        list used as a mutable float cell) rather than the ``nonlinear`` list,
+        so a pure constant never lands in the emitted nonlinear body — the
+        caller folds it into the r-section rhs instead.
 
         Driven by an explicit ``(expr, coeff)`` work stack rather than recursion:
         a body built with ``sum()`` of many terms is a deeply left-nested chain
@@ -665,8 +782,10 @@ class _NLWriter:
             if isinstance(node, Constant):
                 val = float(node.value)
                 if val != 0.0:
-                    # A nonzero constant contributes a constant offset.
-                    nonlinear.append(Constant(val * c))
+                    # A nonzero constant contributes a constant offset. Keep it
+                    # out of the nonlinear body: callers fold it into the
+                    # r-section rhs so a constant-only body stays ``n0``.
+                    const_acc[0] += val * c
                 continue
 
             if isinstance(node, Variable):
@@ -761,25 +880,24 @@ class _NLWriter:
         n_cons = len(self._con_linear)
         n_objs = 1 if self.model._objective else 0
 
-        # Count nonlinear constraints and objectives
-        n_nl_cons = sum(1 for nl in self._con_nonlinear if nl is not None)
+        # A constraint counts as nonlinear only when its nonlinear body
+        # references at least one variable. Since _split_expr peels pure
+        # constants out into the r-section rhs, a constant-only body leaves
+        # _con_nonlinear[i] is None (and _con_nl_vars[i] empty), so it is
+        # correctly counted as linear (ASL requires nonlinear constraints to be
+        # the first n_nl_cons rows and carry the only non-n0 bodies).
+        n_nl_cons = sum(1 for vs in self._con_nl_vars if vs)
         n_nl_objs = 1 if self._obj_nonlinear is not None else 0
 
-        # Count Jacobian nonzeros (linear + nonlinear vars in each constraint)
-        n_jac_nz = sum(len(lin) for lin in self._con_linear)
-        # Add nonlinear variable references in constraints
-        for nl in self._con_nonlinear:
-            if nl is not None:
-                vs: set[int] = set()
-                self._collect_var_indices(nl, vs)
-                n_jac_nz += len(vs)
+        # Count Jacobian nonzeros from the SAME union sparsity the k and J
+        # sections use: for each constraint, |union(linear vars, nonlinear
+        # vars)|. A variable appearing both linearly and nonlinearly is counted
+        # once; a nonlinear-only variable is counted (with a 0 coefficient in J).
+        n_jac_nz = sum(len(self._jac_cols(i)) for i in range(len(self._con_linear)))
 
-        # Count objective gradient nonzeros
-        n_grad_nz = len(self._obj_linear)
-        if self._obj_nonlinear is not None:
-            vs2: set[int] = set()
-            self._collect_var_indices(self._obj_nonlinear, vs2)
-            n_grad_nz += len(vs2)
+        # Objective gradient nonzeros: union of the objective's linear vars and
+        # its nonlinear-body vars (same de-duplication).
+        n_grad_nz = len(self._obj_grad_cols())
 
         # Line 0: format marker
         buf.write(f"g3 1 1 0\t# problem {self.model.name}\n")
@@ -910,37 +1028,55 @@ class _NLWriter:
     # ── k section (Jacobian column counts) ──
 
     def _write_k_section(self, buf: io.StringIO):
+        """Cumulative per-column Jacobian nonzero counts.
+
+        Built from the SAME union sparsity (:meth:`_jac_cols`) the ``J`` blocks
+        and the header nonzero count use, so all three agree. A single pass over
+        the constraint rows accumulates a per-column tally (fixes EX-9's former
+        ``O(n_vars x n_cons)`` nested scan). ASL reads the ``k`` section as the
+        cumulative count of nonzeros in columns ``0 .. n_vars-2``; the final
+        (``n_vars-1``-th) column total is implied by the header nonzero count.
+        """
         if self._n_total <= 1:
             buf.write("k0\n")
             return
+        per_col = [0] * self._n_total
+        for i in range(len(self._con_linear)):
+            for col in self._jac_cols(i):
+                per_col[col] += 1
         buf.write(f"k{self._n_total - 1}\n")
         cumulative = 0
         for col in range(self._n_total - 1):
-            count = 0
-            for lin in self._con_linear:
-                if col in lin:
-                    count += 1
-            cumulative += count
+            cumulative += per_col[col]
             buf.write(f"{cumulative}\n")
 
     # ── J sections (linear Jacobian terms) ──
 
     def _write_J_sections(self, buf: io.StringIO):
-        for i, lin in enumerate(self._con_linear):
-            if not lin:
+        """Per-constraint Jacobian blocks (ASL convention).
+
+        Each block lists *every* variable appearing in the constraint —
+        linearly or nonlinearly — with its linear coefficient (``0`` for a
+        variable that appears only nonlinearly). This is the union sparsity the
+        header and ``k`` section are computed from.
+        """
+        for i in range(len(self._con_linear)):
+            cols = self._jac_cols(i)
+            if not cols:
                 continue
-            buf.write(f"J{i} {len(lin)}\n")
-            for var_idx in sorted(lin.keys()):
-                buf.write(f"{var_idx} {lin[var_idx]}\n")
+            buf.write(f"J{i} {len(cols)}\n")
+            for var_idx in sorted(cols.keys()):
+                buf.write(f"{var_idx} {cols[var_idx]}\n")
 
     # ── G section (linear objective gradient) ──
 
     def _write_G_section(self, buf: io.StringIO):
-        if not self._obj_linear:
+        cols = self._obj_grad_cols()
+        if not cols:
             return
-        buf.write(f"G0 {len(self._obj_linear)}\n")
-        for var_idx in sorted(self._obj_linear.keys()):
-            buf.write(f"{var_idx} {self._obj_linear[var_idx]}\n")
+        buf.write(f"G0 {len(cols)}\n")
+        for var_idx in sorted(cols.keys()):
+            buf.write(f"{var_idx} {cols[var_idx]}\n")
 
     # ── Expression → .nl opcode encoding ──
 

--- a/python/tests/test_nl_writer.py
+++ b/python/tests/test_nl_writer.py
@@ -55,10 +55,15 @@ class TestNLWriterLinear:
 
         nl = m.to_nl()
         assert "r\n" in nl
-        # <= 10 -> type 1, >= 1 -> type 2, == 5 -> type 4
+        # The body constant is carried in the r-section rhs (ASL convention),
+        # NOT baked into the C body with rhs 0.  Discopt normalizes:
+        #   x <= 10  -> (x - 10) <= 0        -> type 1, rhs 10
+        #   x >= 1   -> (1 - x) <= 0         -> type 1, rhs -1  (i.e. -x <= -1)
+        #   x == 5   -> (x - 5) == 0         -> type 4, rhs 5
         r_section = nl[nl.index("r\n") :]
-        assert "1 0.0" in r_section  # <= 0 (normalized: x - 10 <= 0)
-        assert "4 0.0" in r_section  # == 0 (normalized: x - 5 == 0)
+        assert "1 10.0" in r_section  # x <= 10
+        assert "1 -1.0" in r_section  # -x <= -1  (x >= 1)
+        assert "4 5.0" in r_section  # x == 5
 
 
 class TestNLWriterNonlinear:
@@ -351,6 +356,185 @@ class TestNLWriterFile:
         assert outpath.exists()
         content = outpath.read_text()
         assert content.startswith("g3")
+
+
+def _nl_structure(nl: str) -> dict:
+    """Extract the header/k/J/G structural counts from a .nl text.
+
+    Returns a dict with:
+      - ``header_jac_nz``  : header line-7 Jacobian nonzero count
+      - ``header_nl_cons`` : header line-2 nonlinear-constraint count
+      - ``j_lengths``      : {con_idx: declared J-block length}
+      - ``j_entries``      : {con_idx: [(var_idx, coeff), ...]}  actual rows
+      - ``k_cumulative``   : the k-section cumulative per-column counts
+      - ``g_length``       : declared G0 length (or 0 if absent)
+    """
+    lines = [ln.split("#")[0].split("\t")[0].strip() for ln in nl.split("\n")]
+    out: dict = {"j_lengths": {}, "j_entries": {}, "k_cumulative": [], "g_length": 0}
+    out["header_nl_cons"] = int(lines[2].split()[0])
+    out["header_jac_nz"] = int(lines[7].split()[0])
+    i = 0
+    while i < len(lines):
+        ln = lines[i]
+        if ln.startswith("k") and ln[1:].isdigit():
+            n = int(ln[1:])
+            for j in range(n):
+                out["k_cumulative"].append(int(lines[i + 1 + j]))
+            i += n + 1
+            continue
+        if ln[:1] == "J" and len(ln) > 1 and ln[1].isdigit():
+            ci, cnt = ln[1:].split()
+            ci, cnt = int(ci), int(cnt)
+            out["j_lengths"][ci] = cnt
+            rows = []
+            for j in range(cnt):
+                vi, co = lines[i + 1 + j].split()
+                rows.append((int(vi), float(co)))
+            out["j_entries"][ci] = rows
+            i += cnt + 1
+            continue
+        if ln[:1] == "G" and len(ln) > 1 and ln[1].isdigit():
+            out["g_length"] = int(ln.split()[1])
+        i += 1
+    return out
+
+
+class TestNLWriterJacobianConformance:
+    """EX-1 (#413): ASL-conformant Jacobian structure.
+
+    A variable appearing ONLY nonlinearly in a constraint must still get a
+    (zero-coefficient) J entry, and the header nonzero count, the k
+    cumulative-column-count section, and the J blocks must all be computed
+    from that same union sparsity so they agree.
+    """
+
+    def _ex1_model(self):
+        # exp(x) + y <= 5  (x appears ONLY nonlinearly);  x + y <= 3
+        m = dm.Model("ex1")
+        x = m.continuous("x", lb=0, ub=5)
+        y = m.continuous("y", lb=0, ub=5)
+        m.minimize(x + y)
+        m.subject_to(dm.exp(x) + y <= 5)
+        m.subject_to(x + y <= 3)
+        return m
+
+    def test_nonlinear_only_var_gets_zero_j_entry(self):
+        nl = self._ex1_model().to_nl()
+        s = _nl_structure(nl)
+        # C0 = exp(x)+y<=5: J block must list BOTH x (var 0, coeff 0) and y.
+        assert 0 in s["j_entries"]
+        c0 = dict(s["j_entries"][0])
+        assert c0.get(0) == 0.0, f"x (var 0) missing its 0-coeff J entry: {s['j_entries'][0]}"
+        assert 1 in c0  # y appears linearly
+        assert s["j_lengths"][0] == 2
+
+    def test_header_k_j_counts_agree(self):
+        nl = self._ex1_model().to_nl()
+        s = _nl_structure(nl)
+        sum_j = sum(s["j_lengths"].values())
+        # header nnz == total J entries emitted
+        assert s["header_jac_nz"] == sum_j, (s["header_jac_nz"], sum_j)
+        assert s["header_jac_nz"] == 4  # 2 (C0: x,y) + 2 (C1: x,y)
+        # k-section: cumulative col-0 count == number of constraints touching x.
+        # Both C0 (nonlinear x) and C1 (linear x) touch col 0 => 2.
+        assert s["k_cumulative"][0] == 2, s["k_cumulative"]
+        # Final implied column total (header) equals sum(J) — full agreement.
+        assert s["k_cumulative"][-1] <= s["header_jac_nz"]
+
+    def test_pure_linear_constraint_not_counted_nonlinear(self):
+        # C1 (x+y<=3) is linear; only C0 is nonlinear.
+        nl = self._ex1_model().to_nl()
+        s = _nl_structure(nl)
+        assert s["header_nl_cons"] == 1
+
+    def test_constant_moves_to_rhs_body_is_n0(self):
+        # The pure-constant body of x+y<=3 becomes an n0 body with rhs 3.
+        nl = self._ex1_model().to_nl()
+        assert "C1\nn0\n" in nl
+        r_section = nl[nl.index("r\n") :]
+        assert "1 5.0" in r_section  # exp(x)+y <= 5
+        assert "1 3.0" in r_section  # x + y   <= 3
+
+    def test_no_double_count_var_linear_and_nonlinear(self):
+        # x appears both linearly and nonlinearly in the same constraint;
+        # it must be counted ONCE in the header/J/k.
+        m = dm.Model("mixed")
+        x = m.continuous("x", lb=0, ub=5)
+        y = m.continuous("y", lb=0, ub=5)
+        m.minimize(x + y)
+        m.subject_to(x * x + x + y <= 5)  # x nonlinear (x*x) AND linear (+x)
+        s = _nl_structure(m.to_nl())
+        assert s["j_lengths"][0] == 2  # {x, y}, not 3
+        assert s["header_jac_nz"] == 2
+
+    def test_roundtrip_solve_matches(self, tmp_path):
+        m = self._ex1_model()
+        nl_path = tmp_path / "ex1.nl"
+        m.to_nl(str(nl_path))
+        m2 = dm.from_nl(str(nl_path))
+        r1 = m.solve()
+        r2 = m2.solve()
+        assert r1.status == r2.status == "optimal"
+        assert abs(r1.objective - r2.objective) < 1e-6
+
+    @pytest.mark.parametrize(
+        "kind",
+        ["linear-only", "nl-only-var", "mixed-lin-nl", "obj-nonlinear"],
+    )
+    def test_structural_match_pyomo(self, kind):
+        pyo = pytest.importorskip("pyomo.environ")
+        import tempfile
+
+        def build_discopt():
+            m = dm.Model("t")
+            x = m.continuous("x", lb=0.1, ub=5)
+            y = m.continuous("y", lb=0, ub=5)
+            if kind == "linear-only":
+                m.minimize(x + 2 * y)
+                m.subject_to(x + y <= 3)
+            elif kind == "nl-only-var":
+                m.minimize(x + y)
+                m.subject_to(dm.exp(x) + y <= 5)
+                m.subject_to(x + y <= 3)
+            elif kind == "mixed-lin-nl":
+                m.minimize(x + y)
+                m.subject_to(x * x + x + y <= 5)
+            else:  # obj-nonlinear
+                m.minimize(dm.log(x) + y)
+                m.subject_to(x + y <= 4)
+            return m.to_nl()
+
+        def build_pyomo():
+            m = pyo.ConcreteModel()
+            m.x = pyo.Var(bounds=(0.1, 5))
+            m.y = pyo.Var(bounds=(0, 5))
+            if kind == "linear-only":
+                m.o = pyo.Objective(expr=m.x + 2 * m.y)
+                m.c = pyo.Constraint(expr=m.x + m.y <= 3)
+            elif kind == "nl-only-var":
+                m.o = pyo.Objective(expr=m.x + m.y)
+                m.c0 = pyo.Constraint(expr=pyo.exp(m.x) + m.y <= 5)
+                m.c1 = pyo.Constraint(expr=m.x + m.y <= 3)
+            elif kind == "mixed-lin-nl":
+                m.o = pyo.Objective(expr=m.x + m.y)
+                m.c = pyo.Constraint(expr=m.x * m.x + m.x + m.y <= 5)
+            else:
+                m.o = pyo.Objective(expr=pyo.log(m.x) + m.y)
+                m.c = pyo.Constraint(expr=m.x + m.y <= 4)
+            f = tempfile.mktemp(suffix=".nl")
+            m.write(f, format="nl", io_options={"symbolic_solver_labels": False})
+            return open(f).read()
+
+        ds = _nl_structure(build_discopt())
+        ps = _nl_structure(build_pyomo())
+        assert ds["header_jac_nz"] == ps["header_jac_nz"]
+        assert ds["header_nl_cons"] == ps["header_nl_cons"]
+        assert ds["j_lengths"] == ps["j_lengths"]
+        assert ds["k_cumulative"] == ps["k_cumulative"]
+        assert ds["g_length"] == ps["g_length"]
+        # J entries: same (var, coeff) sets per constraint.
+        for ci in ds["j_entries"]:
+            assert set(ds["j_entries"][ci]) == set(ps["j_entries"][ci]), ci
 
 
 class TestNLWriterRoundTrip:


### PR DESCRIPTION
## EX-1 (#413, Phase B): ASL-conformant `.nl` Jacobian structure

**P0 interop.** The `.nl` writer emitted a Jacobian sparsity that mutually
disagreed across the header nonzero count, the `k` (cumulative column-count)
section, and the per-constraint `J` blocks. A variable appearing **only
nonlinearly** in a constraint got no `J` entry, so any ASL consumer (Ipopt,
BARON, Couenne, SCIP) — which rebuilds its column-wise Jacobian from
header+`k`+`J` — silently mis-reads the file.

### Reproduced (review's 2-var model: `exp(x)+y<=5`, `x+y<=3`)

| Quantity | before (buggy) | after (this PR) | Pyomo reference |
|---|---|---|---|
| Header Jacobian nonzeros | 4 | **4** | 4 |
| Σ `J`-block entries | 3 | **4** | 4 |
| `k` col-0 cumulative | 1 | **2** | 2 |
| Header nonlinear constraints | 2 | **1** | 1 |
| `J0` (constraint 0) | `J0 1 / 1 1.0` (x missing) | `J0 2 / 0 0.0 / 1 1.0` | `J0 2 / 0 0 / 1 1` |
| `C1` body / rhs | `n-3.0` / `1 0.0` | `n0` / `1 3.0` | `n0` / `1 3` |

Before: header (4) ≠ Σ`J` (3) ≠ `k` (1). After: header == Σ`J` == final `k` == 4.

### Fix
- Build **one union sparsity** per constraint (`_jac_cols` = linear vars ∪
  nonlinear-body vars) and drive the header nnz, the `k` section, and every `J`
  block from it. A nonlinear-only var gets a `0`-coefficient `J` entry; a var
  that is both linear and nonlinear is counted **once** (no double count).
- Objective gradient (`G`) uses the same union.
- **Pure-constant bodies** are peeled into the r-section rhs (body → `n0`), so a
  constraint like `x+y<=3` is emitted as genuinely linear — honoring the ASL
  rule that nonlinear constraints are the first `n_nl_cons` rows and carry the
  only non-`n0` bodies. Matches Pyomo exactly.
- **EX-9 folded in**: the `k` section is now a single O(nnz) per-column pass
  (was O(n_vars × n_cons)).

Byte-level structural parity with Pyomo's `NLv2Writer` (dims, nl-con count,
header nnz, `k`, `J`, `G`) verified on a 4-case corpus (linear-only /
nonlinear-only-var / mixed-lin+nl / objective-nonlinear). In-house round-trip
(`to_nl → from_nl → solve`) unchanged.

### Verification (numbers)
- **New regression** `TestNLWriterJacobianConformance` (`test_nl_writer.py`):
  fails-before / passes-after — verified by stashing `nl.py` (9 fail → 10 pass).
- `test_nl_writer` / `test_nl_reconstruction` / `test_export`: **116 passed**.
- `pytest -m smoke`: **542 passed, 1 skipped**.
- Adversarial (`test_adversarial_recent_fixes.py -m slow`): **10 passed**.
- **Cert-baseline neutrality**: the `.nl` **writer** is not on the solve path
  (cert instances are `.nl` **inputs** parsed by the Rust parser; `to_nl` is
  never called). Only `nl.py` + its test changed — `node_count` / certified
  objective / `incorrect_count == 0` are unchanged by construction. **No Rust
  touched** (no `cargo test` needed).
- ruff + format clean on touched files; no new mypy errors (the 6 pre-existing
  numpy-object-array errors in `_scalarize` are identical on base).

### Docs
- `docs/dev/review-execution-plan.md` §4: EX-1 ✅
- `docs/dev/export-module-review.md`: EX-1 STATUS ✅ (and EX-9 ✅, folded in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
