### PR TITLE
fix(correctness): INT-1 — NLP-BB lazy-constraint rejection no longer swallowed (#413)

### DIFF
--- a/docs/dev/infra-interop-review.md
+++ b/docs/dev/infra-interop-review.md
@@ -21,7 +21,7 @@ round-trip correctly).
 
 | # | Severity | Component | Finding |
 |---|----------|-----------|---------|
-| INT-1 | **P1 correctness** | `solver.py:7479` + `1461-1478` | On the **NLP-BB path**, `_invoke_pre_import_callbacks` is called with `_cut_pool=None` while forwarding a live `lazy_constraints` callback. `_cut_pool.add(...)` raises `AttributeError`, swallowed by the broad `except`; because `.add` precedes the node-rejection line inside the `try`, the rejection is **also lost** — the integer-feasible point the cut meant to exclude is **accepted as incumbent** [CONFIRMED: code path + agent end-to-end repro returns `y=0` instead of `y=1`] |
+| INT-1 | **P1 correctness** | `solver.py:7479` + `1461-1478` | On the **NLP-BB path**, `_invoke_pre_import_callbacks` is called with `_cut_pool=None` while forwarding a live `lazy_constraints` callback. `_cut_pool.add(...)` raises `AttributeError`, swallowed by the broad `except`; because `.add` precedes the node-rejection line inside the `try`, the rejection is **also lost** — the integer-feasible point the cut meant to exclude is **accepted as incumbent** [CONFIRMED: code path + agent end-to-end repro returns `y=0` instead of `y=1`]. **✅ RESOLVED (#413): the NLP-BB path cannot enforce a rejecting callback (no per-node cut application; its primal heuristics — feasibility pump, RENS, diving, sub-NLP — inject incumbents via `tree.inject_incumbent` without consulting the callback), so it now REFUSES `lazy_constraints`/`incumbent_callback` loudly (explicit `nlp_bb=True` raises `ValueError`; auto-select `nlp_bb=None` falls through to spatial B&B, which honors both). `_invoke_pre_import_callbacks` reordered to reject-before-add and its `except` narrowed to wrap only the user-callback call, so a programming error (e.g. a `None` cut pool) surfaces instead of silently dropping a rejection. Regression `TestInt1NlpBbLazyRejection` in `test_callbacks.py`. NOTE: a *separate* pre-existing defect surfaced during confirm — the feasibility-pump/RENS heuristics inject incumbents WITHOUT consulting the callbacks on BOTH paths, so a lazy/incumbent rejection is silently bypassed whenever a heuristic finds the excluded point at the root (reproduces on `origin/main`, spatial path included); tracked as a follow-up, not INT-1.** |
 | INT-2 | **P1 correctness** | `modeling/core.py:3629-3630` (`from_nl`) | Binary columns drop the `.nl`'s `lb/ub` (the integer branch keeps them). A `.nl` binary with `lb=ub=1` re-imports as free `[0,1]` → wrong optimum. **Hits the Pyomo `SolverFactory('discopt')` bridge and any `from_nl` of a MINLPLib instance with fixed binaries** [CONFIRMED; = modeling-review M2, here with corpus/bridge impact] **✅ RESOLVED (X-3, #413): `from_nl` now stamps the parsed lb/ub onto the binary column, clamped into `[0,1]`; closes M2 = INT-2 in one change. Regression `TestFromNlBinaryBoundsX3` in `test_nl_reconstruction.py`.** |
 | INT-3 | P2 | `pyomo/solver.py:164-171` | Pyomo bridge stores the **incumbent** in `problem.lower_bound` and the **dual bound** in `upper_bound` — swapped for minimize (incumbent is an *upper* bound). Only observable with a nonzero gap; misreports `SolverResults` bounds but does not corrupt the loaded primal [CONFIRMED by logic] |
 | INT-4 | P2 | `callbacks.py` + `solver.py:1470-1477` | The same swallow-before-reject ordering means **any** exception in `cut_result_to_dense` (e.g. a cut referencing an unknown variable) drops the cut *and* accepts the node — a malformed user cut yields silent acceptance rather than a loud error [CONFIRMED by inspection] |
@@ -68,6 +68,28 @@ guard. **Fix:** either build a real cut pool on the NLP-BB path, or **refuse
 loudly** when `lazy_constraints` is combined with `nlp_bb=True` (per the
 "refuse rather than silently approximate" rule); and move the node-rejection
 *before* the `.add` so a cut-construction error can never yield acceptance (INT-4).
+
+> **STATUS — ✅ RESOLVED (#413).** Chose the loud refusal: confirm-first showed the
+> NLP-BB path has NO way to honor a rejecting callback — it has no per-node cut
+> application (the augmented-evaluator cut pool is spatial-B&B-only) *and* its primal
+> heuristics (feasibility pump, RENS, fractional diving, sub-NLP) inject incumbents
+> directly via `tree.inject_incumbent` without ever consulting the callback. Building
+> a no-op cut pool would fix only the swallow while the heuristic bypass still returns
+> the excluded point, so per CLAUDE.md §3 the path now refuses: explicit
+> `nlp_bb=True` + `lazy_constraints`/`incumbent_callback` raises a clear `ValueError`;
+> auto-select (`nlp_bb=None`) skips NLP-BB when either callback is set and falls
+> through to spatial B&B (which honors them, verified on the nonlinear-knapsack
+> fixture). `_invoke_pre_import_callbacks` (shared with the spatial path) was
+> hardened: the node-rejection now precedes any fallible cut insertion, and the
+> `except` wraps ONLY the user-callback invocation, so a `None`-cut-pool
+> `AttributeError` (or any of our own errors after the callback) can no longer be
+> downgraded to a warning that also loses the rejection (closes INT-4's ordering
+> concern too). Regression `TestInt1NlpBbLazyRejection` in `test_callbacks.py`
+> (fails-before/passes-after verified by stashing). Cert-baseline: NEUTRAL, 41/41
+> `nodes N->N`, `|Δobj|=0`. **Follow-up (separate finding, reproduces on `origin/main`):
+> the feasibility-pump/RENS heuristics bypass the lazy/incumbent callbacks on the
+> spatial path too when they find the excluded point at the root — a broader
+> heuristic-vs-callback contract gap, out of scope for INT-1.**
 
 **INT-2** is modeling-review M2, but the infra pass adds the impact surface: it is
 inherited by the Pyomo `SolverFactory('discopt')` bridge and by any direct

--- a/docs/dev/review-execution-plan.md
+++ b/docs/dev/review-execution-plan.md
@@ -171,6 +171,11 @@ last.** "Default path" = a plain `m.solve()` on an idiomatic model.
 - **EX-1** (export) — `.nl` Jacobian non-conformant with ASL (breaks BARON/Couenne/
   SCIP comparisons).
 - **INT-1** (infra/solver.py) — `nlp_bb=True` + `lazy_constraints` swallow-and-accept.
+  ✅ RESOLVED (#413): the NLP-BB path cannot honor a rejecting callback (no per-node
+  cut application; primal heuristics inject incumbents without consulting it), so it
+  now refuses `lazy_constraints`/`incumbent_callback` loudly; auto-select routes them
+  to spatial B&B (which honors them). `_invoke_pre_import_callbacks` reordered
+  reject-before-add with a narrowed `except`.
 - **MP-1** (mpec) — `tighten_complementarity_bounds` overwrites a positive lb → hides
   infeasibility.
 - **DC-S1** (decomposition) — unbounded recourse populates an invalid `bound`.
@@ -289,7 +294,7 @@ Legend: ⬜ open · ◧ in-progress · ✅ resolved · ◻︎ not-reproduced.
 | 2 | RO-1, RO-2, RO-3 | ro | ⬜ |
 | 2 | C1, C2, C3 | dae | ⬜ |
 | 2 | EX-1 | export | ✅ — union-based J/G/k/header sparsity; nonlinear-only vars get a 0-coeff `J` entry; pure-constant bodies move to r-section rhs (`n0` body, no longer counted nonlinear). Byte-level structural parity with Pyomo's writer on a 4-case corpus; `TestNLWriterJacobianConformance` in `test_nl_writer.py`; #413 |
-| 2 | INT-1 | infra/solver | ⬜ |
+| 2 | INT-1 | infra/solver | ✅ — NLP-BB path now REFUSES `lazy_constraints`/`incumbent_callback` loudly (it cannot enforce a rejection: no per-node cut application + primal heuristics inject incumbents without consulting the callback), and auto-select routes them to spatial B&B which honors them; `_invoke_pre_import_callbacks` reordered to reject-before-add with a narrowed `except` so a programming error can no longer swallow a lost rejection. Tests `TestInt1NlpBbLazyRejection` in `test_callbacks.py`; #413 |
 | 2 | MP-1 | mpec | ⬜ |
 | 2 | DC-S1 | decomposition | ⬜ |
 | 2 | OA-1=C-35 | solver-core | ⬜ |

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1570,36 +1570,51 @@ def _invoke_pre_import_callbacks(
 
         # --- Lazy constraints ---
         if lazy_constraints is not None:
+            # Invoking the user's callback is the only step allowed to fail
+            # softly: a user-code error is logged and the node proceeds as
+            # normal (no cut, no rejection). Everything AFTER the callback —
+            # rejecting the node and inserting the cut — is our own code and
+            # must NOT be swallowed. INT-1/INT-4 (#413): the previous broad
+            # ``except`` wrapped the ``_cut_pool.add`` too, so an
+            # ``AttributeError`` (e.g. a ``None`` cut pool) was downgraded to a
+            # warning AND the rejection that followed it was lost, letting the
+            # excluded integer-feasible point become the incumbent.
             try:
                 cuts = lazy_constraints(ctx, model)
-                if cuts:
-                    for cut in cuts:
-                        coeffs, rhs, sense = cut_result_to_dense(cut, model)
-                        _cut_pool.add(LinearCut(coeffs=coeffs, rhs=rhs, sense=sense))
-                    # Mark as infeasible so it does not become incumbent.
-                    result_lbs[i] = _INFEASIBILITY_SENTINEL
-                    logger.info(
-                        "Lazy constraint callback added %d cut(s) at node %d",
-                        len(cuts),
-                        int(result_ids[i]),
-                    )
-                    continue  # skip incumbent callback for cut-separated nodes
             except Exception as e:
                 logger.warning("Lazy constraint callback raised an exception: %s", e)
+                cuts = None
+            if cuts:
+                # Reject the node FIRST: even if cut insertion below were to
+                # fail, the point the cuts exclude must never be accepted as an
+                # incumbent. This assignment precedes any fallible cut math.
+                result_lbs[i] = _INFEASIBILITY_SENTINEL
+                for cut in cuts:
+                    coeffs, rhs, sense = cut_result_to_dense(cut, model)
+                    _cut_pool.add(LinearCut(coeffs=coeffs, rhs=rhs, sense=sense))
+                logger.info(
+                    "Lazy constraint callback added %d cut(s) at node %d",
+                    len(cuts),
+                    int(result_ids[i]),
+                )
+                continue  # skip incumbent callback for cut-separated nodes
 
         # --- Incumbent callback ---
         if incumbent_callback is not None:
+            solution = _unpack_solution(model, result_sols[i])
+            # Only the user callback may fail softly; the rejection that acts on
+            # its verdict is our code and stays OUTSIDE the swallow (INT-1, #413).
             try:
-                solution = _unpack_solution(model, result_sols[i])
                 accept = incumbent_callback(ctx, model, solution)
-                if accept is False:
-                    result_lbs[i] = _INFEASIBILITY_SENTINEL
-                    logger.info(
-                        "Incumbent callback rejected solution at node %d",
-                        int(result_ids[i]),
-                    )
             except Exception as e:
                 logger.warning("Incumbent callback raised an exception: %s", e)
+                accept = None
+            if accept is False:
+                result_lbs[i] = _INFEASIBILITY_SENTINEL
+                logger.info(
+                    "Incumbent callback rejected solution at node %d",
+                    int(result_ids[i]),
+                )
 
 
 def _unpack_solution(model: Model, x_flat: np.ndarray):
@@ -3714,6 +3729,29 @@ def solve_model(
 
     # --- Explicit NLP-BB override: bypass specialized solvers ---
     if nlp_bb is True and not _pure_continuous:
+        # INT-1 (#413): the NLP-BB path cannot honor a callback that REJECTS an
+        # integer-feasible point. It has no per-node cut-application mechanism
+        # (the augmented-evaluator cut pool is spatial-B&B-only) and its primal
+        # heuristics (feasibility pump, RENS, diving, sub-NLP) inject incumbents
+        # directly via ``tree.inject_incumbent`` WITHOUT consulting the callback
+        # — so a lazy constraint's cut or an incumbent-callback's ``False`` would
+        # be silently dropped and the excluded point accepted as the optimum.
+        # Refuse loudly rather than return a wrong answer (CLAUDE.md §3); these
+        # callbacks are supported on the spatial-B&B path (``nlp_bb=False``).
+        if lazy_constraints is not None or incumbent_callback is not None:
+            _rejected = []
+            if lazy_constraints is not None:
+                _rejected.append("lazy_constraints")
+            if incumbent_callback is not None:
+                _rejected.append("incumbent_callback")
+            raise ValueError(
+                f"{' and '.join(_rejected)} cannot be used with nlp_bb=True: the "
+                "NLP-BB path cannot enforce a callback that rejects an integer-"
+                "feasible point (its primal heuristics inject incumbents without "
+                "consulting the callback, and it has no per-node cut application). "
+                "Use nlp_bb=False (spatial branch-and-bound) for these callbacks, "
+                "or omit nlp_bb to auto-select a path that honors them."
+            )
         return _solve_nlp_bb(
             model,
             time_limit,
@@ -3999,9 +4037,13 @@ def solve_model(
     # --- NLP-BB auto-select for convex MINLPs (nlp_bb=None) ---
     # Placed after problem classifier so MILP/MIQP use their specialized
     # (faster) solvers. Only genuinely nonlinear convex MINLPs reach here.
-    # Also skip when lazy constraints are provided (they need the cut pool
-    # infrastructure from the full spatial B&B loop).
-    if nlp_bb is None and lazy_constraints is None:
+    # Also skip when a rejecting user callback is provided: the NLP-BB path
+    # cannot honor a lazy constraint or an incumbent-callback rejection (no
+    # per-node cut application; its primal heuristics inject incumbents without
+    # consulting the callback — INT-1, #413). Fall through to the spatial-B&B
+    # loop, which enforces both correctly, rather than silently drop the
+    # rejection and accept the excluded point.
+    if nlp_bb is None and lazy_constraints is None and incumbent_callback is None:
         if not _root_convexity_known:
             _root_convexity_known, _root_is_convex, _root_constraint_mask = (
                 _classify_model_convexity(
@@ -7902,22 +7944,20 @@ def _solve_nlp_bb(
                         logger.debug("Fractional diving failed: %s", e)
 
         # --- User callbacks ---
+        # INT-1 (#413): the NLP-BB path cannot honor a callback that rejects an
+        # integer-feasible point — it has no per-node cut application and its
+        # primal heuristics inject incumbents without consulting the callback.
+        # ``solve_model`` refuses these callbacks before routing here (explicit
+        # ``nlp_bb=True`` raises; auto-select falls through to spatial B&B). This
+        # is a fail-loud backstop: if a rejecting callback ever reaches this path
+        # it is a routing bug, and we must NOT silently drop the rejection (which
+        # would accept the excluded point as the optimum) by calling
+        # ``_invoke_pre_import_callbacks`` with a ``None`` cut pool.
         if lazy_constraints is not None or incumbent_callback is not None:
-            _invoke_pre_import_callbacks(
-                model=model,
-                tree=tree,
-                t_start=t_start,
-                result_ids=result_ids,
-                result_lbs=result_lbs,
-                result_sols=result_sols,
-                result_feas=result_feas,
-                n_batch=n_batch,
-                int_offsets=int_offsets,
-                int_sizes=int_sizes,
-                n_vars=n_vars,
-                lazy_constraints=lazy_constraints,
-                incumbent_callback=incumbent_callback,
-                _cut_pool=None,
+            raise AssertionError(
+                "lazy_constraints/incumbent_callback reached the NLP-BB path, "
+                "which cannot enforce them (INT-1, #413). This is a routing bug: "
+                "solve_model should have refused or rerouted to spatial B&B."
             )
 
         # Import results back to Rust tree

--- a/python/tests/test_callbacks.py
+++ b/python/tests/test_callbacks.py
@@ -61,6 +61,42 @@ def _small_milp_with_continuous():
     return m, x, y, z
 
 
+def _nonlinear_knapsack():
+    """MINLP knapsack whose lazy callback actually fires at branch nodes.
+
+    max 4*x0 + 5*x1 + 6*x2 + 7*x3  s.t.  3*x0+4*x1+5*x2+6*x3 <= 9,  xi binary,
+    plus a genuine nonlinear term exp(z) (z>=0) to force the MINLP / NLP-BB
+    route. The LP relaxation is fractional, so B&B branches and integer-feasible
+    nodes reach the lazy-constraint callback (unlike a convex model whose primal
+    heuristics find the optimum at the root and never invoke the callback). The
+    unconstrained optimum is x=(0,1,1,0) (value 11); a lazy cut x1+x2<=1 excludes
+    it, making the true optimum x=(1,0,0,1) (value 11 as well but a distinct
+    point, so accepting the excluded (0,1,1,0) is observably wrong).
+    """
+    m = discopt.Model("nl_knap")
+    n = 4
+    xs = [m.binary(f"x{i}") for i in range(n)]
+    z = m.continuous("z", lb=0.0, ub=1.0)
+    v = [4, 5, 6, 7]
+    w = [3, 4, 5, 6]
+    m.minimize(-sum(v[i] * xs[i] for i in range(n)) + discopt.exp(z))
+    m.subject_to(sum(w[i] * xs[i] for i in range(n)) <= 9, name="cap")
+    m.subject_to(z >= 0.0, name="zpos")
+    return m, xs
+
+
+def _reject_0110_cut(xs):
+    """Lazy callback: exclude the integer point x=(0,1,1,0) via x1+x2<=1."""
+
+    def cb(ctx, model):
+        xr = [int(round(ctx.x_relaxation[i])) for i in range(4)]
+        if xr == [0, 1, 1, 0]:
+            return [CutResult(terms=[(xs[1], 1.0), (xs[2], 1.0)], sense="<=", rhs=1.0)]
+        return []
+
+    return cb
+
+
 # ── Unit tests for CutResult and cut_result_to_dense ──
 
 
@@ -171,27 +207,20 @@ class TestNodeCallback:
 @pytest.mark.integration
 class TestLazyConstraints:
     def test_lazy_cut_excludes_solution(self):
-        """Lazy constraints can exclude the otherwise-optimal solution.
+        """Lazy constraints exclude the otherwise-optimal integer point.
 
-        Without the cut, optimal is x=1, y=0 (obj=exp(0.7)~2.01).
-        The lazy constraint forces y=1, changing the optimal.
+        Uses the nonlinear-knapsack fixture whose LP relaxation is fractional so
+        B&B branches and the lazy callback actually fires at integer-feasible
+        nodes (a convex model's primal heuristics find the optimum at the root
+        and never invoke the callback). The cut x1+x2<=1 excludes (0,1,1,0), so
+        the returned solution must not be that point.
         """
-        m, x, y = _simple_milp()
-        cut_added = [False]
-
-        def lazy_cb(ctx, model):
-            sol = ctx.x_relaxation
-            # If y < 0.5 (y=0 in the integer solution), add cut y >= 1
-            if sol[1] < 0.5 and not cut_added[0]:
-                cut_added[0] = True
-                return [CutResult(terms=[(y, 1.0)], sense=">=", rhs=1.0)]
-            return []
-
-        result = m.solve(lazy_constraints=lazy_cb, time_limit=30)
-        # The cut forces y=1.
+        m, xs = _nonlinear_knapsack()
+        result = m.solve(lazy_constraints=_reject_0110_cut(xs), time_limit=30)
         if result.status in ("optimal", "feasible"):
             assert result.x is not None
-            assert result.x["y"] >= 0.5  # y should be 1
+            sol = [round(float(result.x[f"x{i}"])) for i in range(4)]
+            assert sol != [0, 1, 1, 0]  # the excluded point must not be accepted
 
     def test_empty_lazy_callback_is_noop(self):
         """An empty lazy callback should not change the optimal solution."""
@@ -207,24 +236,91 @@ class TestLazyConstraints:
 
 @pytest.mark.slow
 @needs_rust
+@pytest.mark.integration
+class TestInt1NlpBbLazyRejection:
+    """INT-1 (#413): on the NLP-BB path a lazy-constraint / incumbent-callback
+    rejection was silently swallowed (``_cut_pool`` was ``None``, so
+    ``_cut_pool.add`` raised an ``AttributeError`` caught by a broad ``except``
+    that ALSO dropped the node-rejection line that followed it), so the excluded
+    integer-feasible point was accepted as the incumbent — a wrong optimum.
+
+    The fix refuses these callbacks loudly on the NLP-BB path (the path cannot
+    enforce them: no per-node cut application and heuristics inject incumbents
+    without consulting the callback), and routes them to spatial B&B where the
+    rejection is honored. It also reorders ``_invoke_pre_import_callbacks`` so the
+    node-rejection precedes any fallible cut insertion and narrows the ``except``
+    so a programming error can no longer be swallowed.
+    """
+
+    def test_nlp_bb_true_with_lazy_constraints_refuses_loudly(self):
+        """Explicit ``nlp_bb=True`` + ``lazy_constraints`` must raise, not
+        silently drop the rejection and return the excluded point."""
+        m, xs = _nonlinear_knapsack()
+        with pytest.raises(ValueError, match="nlp_bb=True"):
+            m.solve(nlp_bb=True, lazy_constraints=_reject_0110_cut(xs), time_limit=30)
+
+    def test_nlp_bb_true_with_incumbent_callback_refuses_loudly(self):
+        """Explicit ``nlp_bb=True`` + ``incumbent_callback`` must raise: the
+        NLP-BB path cannot honor an incumbent rejection either."""
+        m, xs = _nonlinear_knapsack()
+        with pytest.raises(ValueError, match="nlp_bb=True"):
+            m.solve(
+                nlp_bb=True,
+                incumbent_callback=lambda ctx, model, sol: True,
+                time_limit=30,
+            )
+
+    def test_spatial_path_honors_lazy_rejection(self):
+        """``nlp_bb=False`` (spatial B&B) must EXCLUDE the rejected point — the
+        pre-fix NLP-BB bug returned exactly this excluded point."""
+        m, xs = _nonlinear_knapsack()
+        result = m.solve(nlp_bb=False, lazy_constraints=_reject_0110_cut(xs), time_limit=30)
+        assert result.status in ("optimal", "feasible")
+        sol = [round(float(result.x[f"x{i}"])) for i in range(4)]
+        assert sol != [0, 1, 1, 0], f"rejected point accepted as incumbent: {sol}"
+
+    def test_auto_select_with_lazy_routes_to_spatial_and_honors(self):
+        """Auto-select (no ``nlp_bb``) with a lazy callback must fall through to
+        spatial B&B (not the callback-blind NLP-BB auto path) and exclude the
+        rejected point."""
+        m, xs = _nonlinear_knapsack()
+        result = m.solve(lazy_constraints=_reject_0110_cut(xs), time_limit=30)
+        assert result.status in ("optimal", "feasible")
+        sol = [round(float(result.x[f"x{i}"])) for i in range(4)]
+        assert sol != [0, 1, 1, 0], f"rejected point accepted as incumbent: {sol}"
+
+    def test_nlp_bb_true_without_callbacks_still_works(self):
+        """The refusal must be narrow: ``nlp_bb=True`` without any rejecting
+        callback still solves normally."""
+        m, xs = _nonlinear_knapsack()
+        result = m.solve(nlp_bb=True, time_limit=30)
+        assert result.status in ("optimal", "feasible")
+        assert result.objective is not None
+
+
+@pytest.mark.slow
+@needs_rust
 @pytest.mark.slow
 @pytest.mark.integration
 class TestIncumbentCallback:
     def test_incumbent_rejection(self):
-        """Incumbent callback can reject solutions where y=0."""
-        m, x, y = _simple_milp()
+        """Incumbent callback can reject an integer-feasible point.
 
-        def reject_y0(ctx, model, solution):
-            # Reject solutions where y is 0
-            y_val = solution.get("y", np.array([0.0]))
-            if np.all(y_val < 0.5):
-                return False
-            return True
+        Uses the nonlinear-knapsack fixture (fractional relaxation → the callback
+        actually fires at branch nodes). Reject the point x=(0,1,1,0); the
+        returned solution must therefore differ from it.
+        """
+        m, xs = _nonlinear_knapsack()
 
-        result = m.solve(incumbent_callback=reject_y0, time_limit=30)
+        def reject_0110(ctx, model, solution):
+            xr = [round(float(np.ravel(solution[f"x{i}"])[0])) for i in range(4)]
+            return xr != [0, 1, 1, 0]
+
+        result = m.solve(incumbent_callback=reject_0110, time_limit=30)
         if result.status in ("optimal", "feasible"):
             assert result.x is not None
-            assert result.x["y"] >= 0.5
+            sol = [round(float(result.x[f"x{i}"])) for i in range(4)]
+            assert sol != [0, 1, 1, 0]
 
     def test_accept_all_is_noop(self):
         """Accepting all incumbents should behave identically to no callback."""


### PR DESCRIPTION
## INT-1 (#413) — NLP-BB lazy-constraint rejection no longer swallowed

**P1 correctness, CONFIRMED.** On the NLP-BB path, `_invoke_pre_import_callbacks`
was called with `_cut_pool=None` while forwarding a live `lazy_constraints`
callback. `_cut_pool.add(...)` raised `AttributeError`, swallowed by a broad
`except`; because `.add` **preceded** the node-rejection line inside the same
`try`, the rejection was **also lost** — the integer-feasible point the cut meant
to EXCLUDE was accepted as the incumbent.

### Confirm-first (repro)
Nonlinear-knapsack MINLP on `nlp_bb=True` with a lazy cut that rejects the
integer point `x=(0,1,1,0)`:

- **Pre-fix (origin/main):** `Lazy constraint callback raised an exception:
  'NoneType' object has no attribute 'add'` (the swallowed `AttributeError`) →
  solver returns the **excluded** point `[0,1,1,0]`.
- **Post-fix:** the path refuses loudly (`ValueError`), so no wrong answer.
- **Spatial path (`nlp_bb=False`) / auto-select:** the same cut is **honored** →
  returns `[1,0,0,1]` (the excluded point is not accepted).

### Root cause & fix (loud refusal, per CLAUDE.md §3)
Confirm-first established the NLP-BB path **cannot** honor a rejecting callback:
it has no per-node cut application (the augmented-evaluator cut pool is
spatial-B&B-only) **and** its primal heuristics (feasibility pump, RENS,
fractional diving, sub-NLP) inject incumbents via `tree.inject_incumbent`
**without ever consulting the callback**. A no-op cut pool would fix only the
swallow while the heuristic bypass still returned the excluded point, so the path
now refuses instead of silently approximating.

- `solve_model`: explicit `nlp_bb=True` + `lazy_constraints`/`incumbent_callback`
  raises a clear `ValueError`; auto-select (`nlp_bb=None`) skips NLP-BB when
  either callback is set and falls through to spatial B&B (which honors them).
- `_solve_nlp_bb`: the now-unreachable callback block is a fail-loud
  `AssertionError` backstop instead of calling `_invoke_pre_import_callbacks`
  with a `None` cut pool.
- `_invoke_pre_import_callbacks` (shared with the spatial path): **reject-before-add**
  — the node-rejection precedes any fallible cut insertion — and the `except` is
  **narrowed** to wrap ONLY the user-callback invocation, so a programming error
  (e.g. a `None` cut pool) surfaces instead of being downgraded to a warning that
  also drops the rejection (closes INT-4's ordering concern).

### Tests run
- **New regression** `TestInt1NlpBbLazyRejection` (`test_callbacks.py`), 5 cases —
  refusal on `nlp_bb=True` for both callbacks, spatial + auto-select honor the
  cut, `nlp_bb=True` without callbacks still solves. Fails-before/passes-after
  **verified by stashing** (`solver.py` reverted → the 2 refusal cases fail
  "DID NOT RAISE"; restored → all 5 pass). Two rotted `slow`/`integration`
  callback tests (`_simple_milp`, heuristic-preempted) re-pointed to the
  nonlinear-knapsack fixture where the callback actually fires.
- `test_callbacks.py` full file: **22 passed**.
- `pytest -m smoke` (worktree on path): **542 passed, 1 skipped, 0 failed**.
- Adversarial `pytest -m slow test_adversarial_recent_fixes.py`: **10 passed**.
- `pytest -k "lazy or callback or nlp_bb or cut_pool or incumbent or solver"`:
  **162 passed, 1 skipped**.
- **Cert-baseline neutrality** (`JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`): **NEUTRAL**,
  41/41 `nodes N->N`, `|Δobj|=0`, `incorrect_count == 0` — the normal path is
  unperturbed (cert-baseline instances use no callbacks).
- `ruff check` / `ruff format --check`: clean on touched files. `mypy`: no new
  errors on `solver.py` (pre-existing env/numpy-stub errors in unrelated files).

### Follow-up (separate finding, NOT INT-1)
Confirm surfaced a broader defect that **reproduces on `origin/main`**: the
feasibility-pump/RENS heuristics inject incumbents **without consulting the
lazy/incumbent callbacks on the spatial path too**, so a rejection is silently
bypassed whenever a heuristic finds the excluded point at the root. Documented in
`infra-interop-review.md` as a follow-up; out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
