### PR TITLE
fix(mo): MO2/MO3/MO4 — dedupe Pareto filter, stable hypervolume reference, AUGMECON2 (#413)

### DIFF
--- a/docs/dev/mo-module-review.md
+++ b/docs/dev/mo-module-review.md
@@ -1,5 +1,11 @@
 # MO Module Review — Correctness, Thoroughness, Performance, and SOTA Assessment
 
+> STATUS: IN PROGRESS — 4/10 findings resolved (MO1–MO4). The correctness /
+> method-fidelity cluster is closed: MO1 (NBI axis, prior PR), MO2 (AUGMECON2 —
+> lexicographic payoff + bypass), MO3 (Pareto dedup), MO4 (stable hypervolume
+> reference). Remaining open: MO5 (sweep recompilation), MO6–MO10 (P2/P3
+> robustness/perf/API gaps).
+
 **Date:** 2026-07-03
 **Scope:** `python/discopt/mo/` (`scalarization.py`, `nbi.py`, `pareto.py`,
 `indicators.py`, `utils.py`, `__init__.py` — 1,783 lines) and its tests
@@ -30,9 +36,9 @@ and test blind spots.
 | # | Severity | Component | Finding |
 |---|----------|-----------|---------|
 | MO1 | **P1 method-correctness** — ✅ RESOLVED | `nbi.py:128` | NBI quasi-normal computed with the **wrong axis** (`phi.sum(axis=1)` instead of `axis=0`) — deviates from the cited Das–Dennis (1998) formula for k ≥ 3; invisible at k = 2 by symmetry [CONFIRMED] |
-| MO2 | P2 method-fidelity | `scalarization.py` | The `epsilon_constraint` implementation is **AUGMECON, not AUGMECON2**: the bypass/jump acceleration that defines AUGMECON2 is absent, and the payoff table is not built lexicographically as Mavrotas prescribes [BY INSPECTION] |
-| MO3 | P2 | `pareto.py` | `filtered()` keeps **duplicate points** (identical objective vectors from different scalarization parameters survive weak-dominance filtering) [CONFIRMED] |
-| MO4 | P2 (doc/API) | `indicators.py` | Default hypervolume reference is **front-dependent** — comparing two fronts via `front.hypervolume()` silently compares against different references [CONFIRMED: 2.16 vs 0.08 for nested fronts] |
+| MO2 | P2 method-fidelity — ✅ RESOLVED | `scalarization.py` | The `epsilon_constraint` implementation was **AUGMECON, not AUGMECON2**: the bypass/jump acceleration that defines AUGMECON2 was absent, and the payoff table was not built lexicographically as Mavrotas prescribes [BY INSPECTION]. **FIXED — both features implemented** (see §3). `test_mo_augmecon2.py` |
+| MO3 | P2 — ✅ RESOLVED | `pareto.py` | `filtered()` kept **duplicate points** (identical objective vectors from different scalarization parameters survived weak-dominance filtering) [CONFIRMED]. **FIXED — tolerance-aware dedup in `filtered()`.** `test_mo_pareto.py::TestFilteredDedup` |
+| MO4 | P2 (doc/API) — ✅ RESOLVED | `indicators.py` | Default hypervolume reference was **front-dependent** — comparing two fronts via `front.hypervolume()` silently compared against different references [CONFIRMED: 2.16 vs 0.08 for nested fronts]. **FIXED — `common_reference(*fronts)` helper + loud docstring warning.** `test_mo_indicators.py::TestCommonReference` |
 | MO5 | P2 perf | `utils.py`, sweep loops | `evaluate_expression` recompiles (JAX trace) each objective per call — k compilations per accepted point per sweep, plus k² for the payoff table, of the *same* k expressions |
 | MO6–MO10 | P2–P3 | various | Robustness/API gaps (§3) |
 
@@ -105,7 +111,30 @@ end-to-end tri-objective test (the suite currently has none — §5).
 
 ## 3. Methodological and robustness gaps
 
-### MO2. "AUGMECON2" is actually AUGMECON
+### MO2. "AUGMECON2" is actually AUGMECON — ✅ RESOLVED (`test_mo_augmecon2.py`)
+
+> **✅ RESOLVED — AUGMECON2 implemented (both features), not renamed.** The scope
+> check found this a *bounded* change, so the honest path was to make the code
+> match the name rather than rename to `augmecon`:
+> - **Lexicographic payoff table** — new `utils.lexicographic_payoff()` +
+>   `utils.nadir_from_payoff()`; `epsilon_constraint` uses it by default
+>   (`payoff="lexicographic"`, opt-out `"simple"`). For each objective as
+>   lexicographic primary it optimizes that objective, then pins it (tolerance
+>   constraint) and optimizes the rest in order — Pareto-optimal anchors, so the
+>   nadir is not inflated/truncated by alternative optima. Regression:
+>   `test_lexicographic_differs_from_simple_under_alternative_optima` — the
+>   simple payoff reports nadir(f2) ≈ 3 (alternative-optimum junk) where the
+>   lexicographic payoff reports the true Pareto-worst 2.0.
+> - **Bypass / jump acceleration** — new `bypass=True` (default; requires
+>   `augmented`). The innermost ε-axis is swept worst→best; a subproblem's
+>   innermost slack `s` skips `floor(s/step)` cells that provably reproduce the
+>   same optimum. Exact (only known-redundant cells are skipped). Regression:
+>   `test_bypass_skips_cells_same_front` — on a bi-objective binary knapsack
+>   step front, bypass does 6 solves vs 15 exhaustive and returns the **same**
+>   nondominated set.
+> The `"augmecon2"` front tag is now honest. `payoff="simple", bypass=False`
+> recovers the old AUGMECON behavior for A/B comparison. The full finding text
+> is preserved below.
 
 The front tag and docstring say AUGMECON2 [Mavrotas 2009/2013], and the augmented
 slack objective with range normalization is implemented correctly. But the two
@@ -129,7 +158,15 @@ Fix: either implement both (rename stays) or rename the tag/docs to `augmecon`
 valuable of the two for correctness of *coverage*; the bypass is the perf win.
 Both are well-specified in the cited papers.
 
-### MO3. Fronts accumulate duplicate points
+### MO3. Fronts accumulate duplicate points — ✅ RESOLVED (`test_mo_pareto.py::TestFilteredDedup`)
+
+> **✅ RESOLVED.** `ParetoFront.filtered()` now collapses tolerance-equal
+> duplicate objective vectors (via `np.allclose`, default `dedup_tol=1e-8`,
+> tunable) **before** the weak-dominance filter, keeping the first occurrence
+> and its `scalarization_params`. Repro before: the 3+1+1 front returned
+> `filtered().n == 4`; after: `== 2` (one representative of the triple + the
+> distinct point; the dominated point dropped). Genuinely-distinct near points
+> (differing by 1e-4) are preserved at the default tolerance. Full text below.
 
 `filtered()` removes only strictly dominated points; identical objective vectors
 (the same optimum found at several weights — routine for anchors and flat regions)
@@ -139,7 +176,19 @@ misleading summaries. Fix: tolerance-based dedup in `filtered()` (keep first
 occurrence; `np.allclose` on objective vectors with a documented tol), preserving
 `scalarization_params` of the kept representative.
 
-### MO4. Default hypervolume reference is front-dependent
+### MO4. Default hypervolume reference is front-dependent — ✅ RESOLVED (`test_mo_indicators.py::TestCommonReference`)
+
+> **✅ RESOLVED.** Two changes: (1) a new `indicators.common_reference(*fronts)`
+> helper (exported from `discopt.mo`) builds one shared reference from the union
+> of the fronts' points (per-objective union-worst + 1 % margin), so scoring
+> every front against it gives **comparable** numbers; (2) the `hypervolume()`
+> docstring (and the `ParetoFront.hypervolume` delegate) now carry a loud
+> `.. warning::` that the default `reference=None` is front-dependent and
+> **not** comparable across fronts — use `common_reference`. Regression
+> `test_default_reference_is_front_dependent` pins the pathology (the worse
+> front scores higher under defaults); `test_shared_reference_is_comparable`
+> shows the dominating front scores ≥ the dominated one under the shared
+> reference. Max- and min-sense both covered. Full text below.
 
 `front.hypervolume()` with no reference derives one from the front's own
 nadir/worst + 1 % margin. Two fronts for the *same problem* therefore get

--- a/docs/dev/review-execution-plan.md
+++ b/docs/dev/review-execution-plan.md
@@ -303,7 +303,7 @@ Legend: ⬜ open · ◧ in-progress · ✅ resolved · ◻︎ not-reproduced.
 | 2 | DC-S1 | decomposition | ⬜ |
 | 2 | OA-1=C-35 | solver-core | ⬜ |
 | 2 | M3 | modeling | ✅ `test_m3_cross_model_ownership` — validate() rejects index-incompatible cross-model leaves |
-| 3 | MO1–MO4 | mo | ⬜ |
+| 3 | MO1–MO4 ✅ · MO5–MO10 ⬜ | mo | ◧ — MO1 (NBI axis, prior PR) ✅; **MO2** (AUGMECON2: lexicographic payoff + bypass) ✅, **MO3** (Pareto dedup) ✅, **MO4** (stable HV reference `common_reference`) ✅ — `test_mo_augmecon2.py`, `test_mo_pareto.py::TestFilteredDedup`, `test_mo_indicators.py::TestCommonReference`; cert-baseline NEUTRAL (mo off the solve path). MO5–MO10 (perf/robustness) open. |
 | 3 | E1–E3, L1–L8, M4–M8 | modeling/examples/latex | ⬜ |
 | 4 | Rust-1 (dual/ray unscale), Rust-2 (numpy panic), P2/P3 across all | all | ⬜ |
 

--- a/python/discopt/mo/__init__.py
+++ b/python/discopt/mo/__init__.py
@@ -45,6 +45,7 @@ you intend to reuse it for other solves.
 """
 
 from discopt.mo.indicators import (
+    common_reference,
     epsilon_indicator,
     hypervolume,
     igd,
@@ -87,6 +88,7 @@ __all__ = [
     "normalized_normal_constraint",
     # Indicators
     "hypervolume",
+    "common_reference",
     "igd",
     "spread",
     "epsilon_indicator",

--- a/python/discopt/mo/indicators.py
+++ b/python/discopt/mo/indicators.py
@@ -35,6 +35,94 @@ def _flip_reference(reference: np.ndarray, senses: np.ndarray) -> np.ndarray:
     return np.asarray(senses * reference, dtype=np.float64)
 
 
+def _default_reference(front: ParetoFront, *, margin_frac: float = 0.01) -> np.ndarray:
+    """Front-dependent default hypervolume reference (original senses).
+
+    Uses the front's nadir (if available) or its per-objective worst value,
+    inflated by ``margin_frac`` of the per-objective range in the unfavorable
+    direction so every point strictly dominates the reference.
+
+    .. warning::
+
+       This reference is **derived from a single front** and is therefore
+       *front-dependent*: two fronts for the same problem generally get
+       different references, so their hypervolumes are **not comparable**. To
+       compare fronts, build one shared reference with
+       :func:`common_reference` and pass it explicitly.
+    """
+    senses = front._senses_array()
+    if front.nadir is not None:
+        ref_orig = np.asarray(front.nadir, dtype=np.float64).copy()
+    else:
+        objs = front.objectives()
+        ref_orig = np.array(
+            [objs[:, j].max() if senses[j] > 0 else objs[:, j].min() for j in range(front.k)],
+            dtype=np.float64,
+        )
+    objs = front.objectives()
+    obj_min = objs.min(axis=0)
+    obj_max = objs.max(axis=0)
+    margin = margin_frac * np.maximum(obj_max - obj_min, 1.0)
+    return np.asarray(ref_orig + senses * margin, dtype=np.float64)
+
+
+def common_reference(*fronts: ParetoFront, margin_frac: float = 0.01) -> np.ndarray:
+    """Build one shared hypervolume reference from several fronts.
+
+    The natural way to *compare* fronts (e.g. ``weighted_sum`` vs ``nbi`` on
+    the same problem) is to score every front against the **same** reference
+    point. This helper constructs such a reference from the union of the
+    fronts' points: the per-objective worst value seen across *all* fronts,
+    inflated by ``margin_frac`` of the union range in the unfavorable direction
+    so every point of every front strictly dominates it.
+
+    Pass the returned array as the ``reference=`` argument of
+    :func:`hypervolume` (or :meth:`ParetoFront.hypervolume`) for each front to
+    obtain comparable numbers.
+
+    Parameters
+    ----------
+    *fronts : ParetoFront
+        Fronts to compare. Must share the same number of objectives and the
+        same senses; at least one must be non-empty.
+    margin_frac : float, default 0.01
+        Fraction of the union per-objective range added as margin.
+
+    Returns
+    -------
+    numpy.ndarray
+        Shape ``(k,)`` reference point in the original senses of the fronts.
+
+    Raises
+    ------
+    ValueError
+        If no fronts are supplied, they disagree on ``k`` or ``senses``, or
+        every front is empty.
+    """
+    if not fronts:
+        raise ValueError("common_reference requires at least one front")
+    k = fronts[0].k
+    senses = fronts[0].senses
+    for f in fronts[1:]:
+        if f.k != k:
+            raise ValueError(f"fronts disagree on number of objectives: {k} vs {f.k}")
+        if f.senses != senses:
+            raise ValueError("fronts must have the same senses")
+    all_objs = [f.objectives() for f in fronts if f.n > 0]
+    if not all_objs:
+        raise ValueError("all fronts are empty; cannot build a reference")
+    stacked = np.vstack(all_objs)
+    senses_arr = fronts[0]._senses_array()
+    worst = np.array(
+        [stacked[:, j].max() if senses_arr[j] > 0 else stacked[:, j].min() for j in range(k)],
+        dtype=np.float64,
+    )
+    obj_min = stacked.min(axis=0)
+    obj_max = stacked.max(axis=0)
+    margin = margin_frac * np.maximum(obj_max - obj_min, 1.0)
+    return np.asarray(worst + senses_arr * margin, dtype=np.float64)
+
+
 def _hv_2d(points: np.ndarray, reference: np.ndarray) -> float:
     """Exact 2-D hypervolume for minimization.
 
@@ -157,6 +245,15 @@ def hypervolume(
         uses the nadir (if available) or the per-objective worst value of
         the front, inflated by 1 % of the range, so every returned
         hypervolume is positive.
+
+        .. warning::
+
+           The default (``reference=None``) reference is **front-dependent**:
+           it is derived from *this* front's own nadir/worst values, so two
+           fronts for the same problem get **different** references and their
+           default hypervolumes are **not comparable**. To compare fronts,
+           build one shared reference with :func:`common_reference` and pass it
+           as ``reference=`` to every front.
     method : {"auto", "exact", "mc"}, default "auto"
         ``"auto"`` uses exact HSO for ``k <= 3`` and Monte-Carlo otherwise.
     n_samples : int
@@ -176,23 +273,7 @@ def hypervolume(
     pts_min = _to_min_form(front)
 
     if reference is None:
-        if front.nadir is not None:
-            ref_orig = front.nadir.copy()
-        else:
-            ref_orig = np.array(
-                [
-                    front.objectives()[:, j].max()
-                    if senses[j] > 0
-                    else front.objectives()[:, j].min()
-                    for j in range(front.k)
-                ],
-                dtype=np.float64,
-            )
-        # Inflate by 1% of range in the unfavorable direction.
-        obj_min = front.objectives().min(axis=0)
-        obj_max = front.objectives().max(axis=0)
-        margin = 0.01 * np.maximum(obj_max - obj_min, 1.0)
-        ref_orig = ref_orig + senses * margin
+        ref_orig = _default_reference(front)
     else:
         ref_orig = np.asarray(reference, dtype=np.float64)
 

--- a/python/discopt/mo/pareto.py
+++ b/python/discopt/mo/pareto.py
@@ -163,8 +163,24 @@ class ParetoFront:
 
     # ── Filtering ──
 
-    def filtered(self) -> "ParetoFront":
-        """Return a new front containing only strictly nondominated points."""
+    def filtered(self, *, dedup_tol: float = 1e-8) -> "ParetoFront":
+        """Return a new front containing only strictly nondominated points.
+
+        Duplicate points -- identical objective vectors produced by different
+        scalarization parameters, routine at anchors and on flat front regions
+        -- are collapsed to a single representative before the weak-dominance
+        filter runs. Weak dominance keeps *all* copies of an equal objective
+        vector (no strict component distinguishes them), which inflates
+        ``self.n`` and distorts spacing metrics; the dedup fixes that.
+
+        Parameters
+        ----------
+        dedup_tol : float, default 1e-8
+            Absolute tolerance for treating two objective vectors as identical
+            (via :func:`numpy.allclose` with ``atol=rtol=dedup_tol``). The first
+            occurrence in point order is kept, preserving its
+            ``scalarization_params``.
+        """
         objs = self.objectives()
         if objs.size == 0:
             return ParetoFront(
@@ -175,8 +191,25 @@ class ParetoFront:
                 ideal=self.ideal,
                 nadir=self.nadir,
             )
+        # Collapse tolerance-equal duplicate objective vectors, keeping the
+        # first occurrence (and its scalarization_params). This is done before
+        # the dominance filter because weak dominance keeps every copy of an
+        # identical vector (equal points do not strictly dominate each other).
+        unique_points: list[ParetoPoint] = []
+        unique_objs: list[np.ndarray] = []
+        for p in self.points:
+            row = np.asarray(p.objectives, dtype=np.float64)
+            is_dup = any(
+                np.allclose(row, kept_row, rtol=dedup_tol, atol=dedup_tol)
+                for kept_row in unique_objs
+            )
+            if not is_dup:
+                unique_points.append(p)
+                unique_objs.append(row)
+
+        objs = np.vstack(unique_objs)
         mask = filter_nondominated(objs, senses=self._senses_array())
-        kept = [p for p, keep in zip(self.points, mask) if keep]
+        kept = [p for p, keep in zip(unique_points, mask) if keep]
         return ParetoFront(
             points=kept,
             method=self.method,

--- a/python/discopt/mo/scalarization.py
+++ b/python/discopt/mo/scalarization.py
@@ -25,6 +25,8 @@ from discopt.mo.utils import (
     _x_to_var_dict,
     evaluate_expression,
     ideal_point,
+    lexicographic_payoff,
+    nadir_from_payoff,
     nadir_point,
 )
 
@@ -283,13 +285,15 @@ def epsilon_constraint(
     delta: float = 1e-3,
     warm_start: bool = True,
     filter: bool = True,
+    payoff: str = "lexicographic",
+    bypass: bool = True,
     ideal: Optional[np.ndarray] = None,
     nadir: Optional[np.ndarray] = None,
     anchors: Optional[list[dict[str, np.ndarray]]] = None,
     slack_ub: float = 1e6,
     **solve_kwargs,
 ) -> ParetoFront:
-    """Epsilon-constraint sweep with optional AUGMECON2 augmentation.
+    """Epsilon-constraint sweep — AUGMECON2 [Mavrotas & Florios 2013].
 
     Minimizes the *primary* objective subject to
     ``f_i <= epsilon_i`` (for minimize-sense non-primary objectives;
@@ -298,10 +302,28 @@ def epsilon_constraint(
     ``-delta * sum(s_i / r_i)`` on them so every returned point is strictly
     Pareto-optimal [Mavrotas 2009].
 
+    The two features that make this AUGMECON2 rather than plain AUGMECON are
+    both on by default:
+
+    * **Lexicographic payoff table** (``payoff="lexicographic"``): the
+      ideal/nadir range is computed from a lexicographically-optimized payoff
+      table (:func:`~discopt.mo.utils.lexicographic_payoff`), whose rows are
+      Pareto-optimal, avoiding the inflated / truncated ε-grid a plain
+      single-objective payoff produces under alternative optima
+      [Miettinen 1999]. Pass ``payoff="simple"`` for the original
+      :func:`~discopt.mo.utils.ideal_point` / ``nadir_point`` behavior.
+    * **Bypass / jump acceleration** (``bypass=True``): after each solve, the
+      innermost objective's optimal slack is used to skip the ε-grid cells that
+      would provably reproduce the same solution, sweeping the innermost axis
+      from best to worst. This is exact — it only skips subproblems whose
+      optimum is already known — and yields fewer solves on flat front regions.
+      Requires ``augmented=True``. Pass ``bypass=False`` for the exhaustive
+      grid.
+
     Epsilon grids are uniform over ``[ideal_i, nadir_i]`` of the non-primary
-    objectives, using ``n_points`` divisions per axis (total
-    ``n_points ** (k - 1)`` subproblems for ``k`` objectives). For ``k = 2``,
-    this is simply ``n_points`` solves.
+    objectives, using ``n_points`` divisions per axis (up to
+    ``n_points ** (k - 1)`` subproblems for ``k`` objectives; fewer with
+    ``bypass``). For ``k = 2``, this is at most ``n_points`` solves.
 
     Parameters follow the same conventions as :func:`weighted_sum`.
     """
@@ -312,25 +334,48 @@ def epsilon_constraint(
         raise ValueError("Need at least 2 objectives")
     if not 0 <= primary < k:
         raise ValueError(f"primary={primary} not in range [0, {k})")
+    if payoff not in ("lexicographic", "simple"):
+        raise ValueError(f"payoff must be 'lexicographic' or 'simple', got {payoff!r}")
+    use_bypass = bool(bypass) and augmented
 
     saved_obj = model._objective
     saved_n_cons = len(model._constraints)
 
     try:
-        if ideal is None or anchors is None:
-            ideal_arr, anchors = ideal_point(
+        if ideal is not None and nadir is not None:
+            ideal_arr = np.asarray(ideal, dtype=np.float64)
+            nadir_arr = np.asarray(nadir, dtype=np.float64)
+        elif payoff == "lexicographic":
+            ideal_arr, payoff_mat, anchors = lexicographic_payoff(
                 model,
                 objectives,
                 senses=senses_list,
                 warm_start=warm_start,
                 **solve_kwargs,
             )
+            if ideal is not None:
+                ideal_arr = np.asarray(ideal, dtype=np.float64)
+            nadir_arr = (
+                np.asarray(nadir, dtype=np.float64)
+                if nadir is not None
+                else nadir_from_payoff(payoff_mat, senses=senses_list)
+            )
         else:
-            ideal_arr = np.asarray(ideal, dtype=np.float64)
-        if nadir is None:
-            nadir_arr = nadir_point(model, objectives, anchors, senses=senses_list)
-        else:
-            nadir_arr = np.asarray(nadir, dtype=np.float64)
+            if ideal is None or anchors is None:
+                ideal_arr, anchors = ideal_point(
+                    model,
+                    objectives,
+                    senses=senses_list,
+                    warm_start=warm_start,
+                    **solve_kwargs,
+                )
+            else:
+                ideal_arr = np.asarray(ideal, dtype=np.float64)
+            nadir_arr = (
+                np.asarray(nadir, dtype=np.float64)
+                if nadir is not None
+                else nadir_point(model, objectives, anchors, senses=senses_list)
+            )
 
         non_primary = [i for i in range(k) if i != primary]
         # Parameters for each non-primary epsilon.
@@ -373,53 +418,100 @@ def epsilon_constraint(
             if penalty is not None:
                 scalarized = scalarized - penalty
 
-        # Epsilon grid. For each non-primary objective, a grid of n_points
-        # values in [ideal_i, nadir_i] (in original sense).
-        grids = []
+        # Epsilon grid per non-primary axis, oriented from WORST to BEST value
+        # (nadir -> ideal in min-convention). AUGMECON2 sweeps the innermost
+        # axis in this direction so that a subproblem's slack tells us how many
+        # of the *next* (tighter) ε cells reproduce the same solution and can be
+        # skipped ("bypass"). Grid values are stored in min-convention units
+        # (sign_i * f_i) so step sizes are positive and comparable to slacks.
+        min_grids = []  # min-convention grid values, worst -> best
         for i in non_primary:
-            lo, hi = float(ideal_arr[i]), float(nadir_arr[i])
-            if senses_list[i] == "max":
-                lo, hi = hi, lo  # so that grid goes from worst to best
-            grid = np.linspace(lo, hi, n_points)
-            grids.append(grid)
-        if len(non_primary) == 1:
-            eps_grid = grids[0][:, None]
-        else:
-            mesh = np.meshgrid(*grids, indexing="ij")
-            eps_grid = np.column_stack([m.reshape(-1) for m in mesh])
+            lo_min = float(signs[i] * ideal_arr[i])
+            hi_min = float(signs[i] * nadir_arr[i])
+            # In min-convention, ideal <= nadir; worst is the larger value.
+            worst, best = max(lo_min, hi_min), min(lo_min, hi_min)
+            min_grids.append(np.linspace(worst, best, n_points))
+
+        # Step size of the innermost axis (last non-primary), in min-convention.
+        inner_axis = len(non_primary) - 1
+        inner_grid = min_grids[inner_axis]
+        inner_step = abs(float(inner_grid[0] - inner_grid[1])) if n_points > 1 else 0.0
 
         points: list[ParetoPoint] = []
         last_x: Optional[dict[str, np.ndarray]] = None
 
-        for eps_vec in eps_grid:
-            for idx, i in enumerate(non_primary):
-                eps_params[idx].value = np.asarray(float(eps_vec[idx]))
-            model.minimize(scalarized)
+        def _run_solve(min_eps_vec):
+            """Set ε parameters from min-convention values and solve.
 
+            Returns ``(result, wall, obj_vec, slack_inner)`` or
+            ``(None, wall, None, None)`` on infeasibility.
+            """
+            nonlocal last_x
+            for idx in range(len(non_primary)):
+                i = non_primary[idx]
+                # Convert min-convention grid value back to original sense.
+                eps_params[idx].value = np.asarray(float(signs[i] * min_eps_vec[idx]))
+            model.minimize(scalarized)
             kwargs = dict(solve_kwargs)
             if warm_start and last_x is not None and "initial_solution" not in kwargs:
                 kwargs["initial_solution"] = _x_to_var_dict(model, last_x)
-
             t0 = time.perf_counter()
             result = model.solve(**kwargs)
             wall = time.perf_counter() - t0
-
             if result.x is None:
-                continue
+                return None, wall, None, None
             obj_vec = _collect_objectives_at_x(objectives, model, result.x)
+            # Innermost slack (min-convention): eps_inner - sign*f_inner >= 0.
+            i_inner = non_primary[inner_axis]
+            slack_inner = float(min_eps_vec[inner_axis] - signs[i_inner] * obj_vec[i_inner])
+            last_x = result.x
+            return result, wall, obj_vec, slack_inner
+
+        def _record(result, wall, obj_vec, min_eps_vec):
             params_record = {
-                "epsilon": {f"f{i + 1}": float(e) for i, e in zip(non_primary, eps_vec)}
+                "epsilon": {
+                    f"f{i + 1}": float(signs[i] * min_eps_vec[idx])
+                    for idx, i in enumerate(non_primary)
+                }
             }
             points.append(
                 ParetoPoint(
-                    x={k: np.asarray(v).copy() for k, v in result.x.items()},
+                    x={kk: np.asarray(v).copy() for kk, v in result.x.items()},
                     objectives=obj_vec,
                     status=result.status,
                     wall_time=wall,
                     scalarization_params=params_record,
                 )
             )
-            last_x = result.x
+
+        # Iterate the outer axes exhaustively; sweep the innermost axis with the
+        # bypass jump when enabled.
+        from itertools import product
+
+        outer_axes = list(range(len(non_primary) - 1))
+        outer_ranges = [range(len(min_grids[a])) for a in outer_axes]
+        for outer_idx in product(*outer_ranges) if outer_axes else [()]:
+            inner_pos = 0
+            while inner_pos < len(inner_grid):
+                min_eps_vec = [0.0] * len(non_primary)
+                for a, gi in zip(outer_axes, outer_idx):
+                    min_eps_vec[a] = float(min_grids[a][gi])
+                min_eps_vec[inner_axis] = float(inner_grid[inner_pos])
+
+                result, wall, obj_vec, slack_inner = _run_solve(min_eps_vec)
+                if result is None:
+                    # Infeasible: tightening the innermost ε further stays
+                    # infeasible, so abandon the rest of this inner sweep.
+                    break
+                _record(result, wall, obj_vec, min_eps_vec)
+
+                if use_bypass and inner_step > 0 and slack_inner is not None:
+                    # The slack covers floor(slack/step) additional cells that
+                    # would reproduce this solution; jump past them.
+                    jump = int(np.floor(max(slack_inner, 0.0) / inner_step))
+                    inner_pos += max(jump, 0) + 1
+                else:
+                    inner_pos += 1
     finally:
         model._objective = saved_obj
         # Trim constraints we added (leaves aux vars and parameters in place).

--- a/python/discopt/mo/utils.py
+++ b/python/discopt/mo/utils.py
@@ -203,6 +203,138 @@ def nadir_point(
     return nadir
 
 
+def lexicographic_payoff(
+    model,
+    objectives: list,
+    *,
+    senses: Optional[Iterable[str]] = None,
+    warm_start: bool = True,
+    lex_tol: float = 1e-6,
+    **solve_kwargs,
+) -> tuple[np.ndarray, np.ndarray, list[dict[str, np.ndarray]]]:
+    r"""Lexicographic payoff table (AUGMECON2, Mavrotas & Florios 2013).
+
+    For each objective ``i`` taken as the lexicographic primary, this solves a
+    sequence of ``k`` optimizations: first optimize ``f_i``; then, holding
+    ``f_i`` fixed at its optimum (via a tolerance constraint), optimize the
+    remaining objectives in order, each time fixing the previous ones. The
+    resulting anchor is guaranteed Pareto-optimal, so the payoff-table rows do
+    not contain the alternative-optima "junk" that inflates (or, for ``k >= 3``,
+    can truncate) a plain single-objective payoff table [Miettinen 1999].
+
+    This is the AUGMECON2 replacement for :func:`ideal_point` +
+    :func:`nadir_point` (which build a *simple*, non-lexicographic payoff). It
+    returns the ideal vector, the ``(k, k)`` payoff matrix
+    (``payoff[i, j] = f_j`` at anchor ``i``), and the anchor solution dicts.
+
+    Parameters
+    ----------
+    model : discopt.modeling.Model
+        Model carrying the decision variables and constraints. Any existing
+        objective is restored before return; the tolerance constraints added
+        for the lexicographic passes are removed before return.
+    objectives : list of Expression
+        Length-``k`` list of objective expressions.
+    senses : iterable of {"min", "max"}, optional
+        One sense per objective; default is all ``"min"``.
+    warm_start : bool, default True
+        Warm-start each solve from the previous one.
+    lex_tol : float, default 1e-6
+        Absolute tolerance used to pin an already-optimized objective at its
+        optimum during the subsequent lexicographic passes.
+    \*\*solve_kwargs : dict
+        Forwarded to :meth:`discopt.modeling.Model.solve`.
+
+    Returns
+    -------
+    ideal : numpy.ndarray
+        Shape ``(k,)`` best per-objective value (the diagonal of the payoff
+        table), in original senses.
+    payoff : numpy.ndarray
+        Shape ``(k, k)`` payoff matrix, ``payoff[i, j] = f_j`` at anchor ``i``.
+    anchors : list of dict
+        ``anchors[i]`` is the (Pareto-optimal) anchor for lexicographic
+        primary ``i``.
+
+    Raises
+    ------
+    RuntimeError
+        If any lexicographic solve fails to return a feasible solution.
+    """
+    senses_list = _as_senses(senses, len(objectives))
+    k = len(objectives)
+    signs = [1.0 if s == "min" else -1.0 for s in senses_list]
+    saved_objective = model._objective
+    saved_n_cons = len(model._constraints)
+
+    payoff = np.zeros((k, k), dtype=np.float64)
+    anchors: list[Optional[dict[str, np.ndarray]]] = [None] * k
+    last_x: Optional[dict[str, np.ndarray]] = None
+
+    def _solve(expr, sense):
+        nonlocal last_x
+        if sense == "min":
+            model.minimize(expr)
+        else:
+            model.maximize(expr)
+        kwargs = dict(solve_kwargs)
+        if warm_start and last_x is not None and "initial_solution" not in kwargs:
+            kwargs["initial_solution"] = _x_to_var_dict(model, last_x)
+        result = model.solve(**kwargs)
+        if result.x is None or result.objective is None:
+            raise RuntimeError(f"lexicographic payoff solve failed: status={result.status}")
+        last_x = result.x
+        return result
+
+    try:
+        # Lexicographic order for primary i: [i, then the rest in index order].
+        for i in range(k):
+            order = [i] + [j for j in range(k) if j != i]
+            fixed_bounds: list[tuple[int, float]] = []
+            result = None
+            for pos, j in enumerate(order):
+                result = _solve(objectives[j], senses_list[j])
+                fj_opt = evaluate_expression(objectives[j], model, result.x)
+                # Pin f_j at its optimum for the subsequent passes, in the
+                # min-convention: sign_j * f_j <= sign_j * fj_opt + lex_tol.
+                if pos < len(order) - 1:
+                    con = signs[j] * objectives[j] <= signs[j] * fj_opt + lex_tol
+                    model.subject_to(con, name=f"_mo_lex_{i}_{j}")
+                    fixed_bounds.append((j, fj_opt))
+            # The inner loop always ran at least once (k >= 1) and _solve
+            # raises on failure, so result carries a feasible solution here.
+            assert result is not None and result.x is not None
+            # Record the payoff row from the final (fully-refined) anchor.
+            anchors[i] = {kk: np.asarray(v).copy() for kk, v in result.x.items()}
+            for j in range(k):
+                payoff[i, j] = evaluate_expression(objectives[j], model, result.x)
+            # Drop this primary's lexicographic tolerance constraints before
+            # the next primary.
+            del model._constraints[saved_n_cons:]
+    finally:
+        model._objective = saved_objective
+        del model._constraints[saved_n_cons:]
+
+    ideal = np.array([payoff[i, i] for i in range(k)], dtype=np.float64)
+    return ideal, payoff, [a for a in anchors if a is not None]
+
+
+def nadir_from_payoff(
+    payoff: np.ndarray,
+    *,
+    senses: Optional[Iterable[str]] = None,
+) -> np.ndarray:
+    """Nadir estimate from a payoff matrix (column-worst per objective)."""
+    payoff = np.asarray(payoff, dtype=np.float64)
+    k = payoff.shape[1]
+    senses_list = _as_senses(senses, k)
+    nadir = np.zeros(k, dtype=np.float64)
+    for j in range(k):
+        col = payoff[:, j]
+        nadir[j] = float(col.max() if senses_list[j] == "min" else col.min())
+    return nadir
+
+
 def normalize_objectives(
     objectives: np.ndarray,
     ideal: np.ndarray,

--- a/python/tests/test_mo_augmecon2.py
+++ b/python/tests/test_mo_augmecon2.py
@@ -1,0 +1,149 @@
+"""MO2 regression tests: AUGMECON2 fidelity.
+
+The ``epsilon_constraint`` scalarizer is AUGMECON2 [Mavrotas & Florios 2013],
+which adds two features over plain AUGMECON:
+
+1. a **lexicographic payoff table** whose rows are Pareto-optimal, so the
+   ideal/nadir range (and hence the epsilon grid) is not distorted by
+   alternative optima at an anchor [Miettinen 1999]; and
+2. a **bypass / jump acceleration** that uses a subproblem's slack to skip the
+   epsilon-grid cells that would reproduce the same solution.
+
+These tests are solve-backed but use tiny LP/IP models and run sub-second, so
+they are ``smoke`` (run on every PR), not ``slow``.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.mo import epsilon_constraint
+from discopt.mo.utils import (
+    ideal_point,
+    lexicographic_payoff,
+    nadir_from_payoff,
+    nadir_point,
+)
+
+
+def _alt_optimum_model():
+    """Bi-objective LP with alternative optima at the f1 anchor.
+
+    min f1 = x1, min f2 = x2 ; x1 in [0, 2], x2 in [0, 3], x1 + x2 >= 2.
+
+    The f1 anchor (x1 = 0) leaves x2 free in [2, 3] -- alternative optima. A
+    plain single-objective payoff can pick x2 = 3 (Pareto-worst), inflating the
+    nadir estimate of f2 to ~3; the lexicographic payoff pins x2 = 2, giving the
+    true Pareto-worst nadir(f2) = 2.
+    """
+    m = dm.Model("alt_opt")
+    x1 = m.continuous("x1", lb=0.0, ub=2.0)
+    x2 = m.continuous("x2", lb=0.0, ub=3.0)
+    m.subject_to(x1 + x2 >= 2.0)
+    return m, [x1, x2]
+
+
+def _knapsack_step_model():
+    """Bi-objective binary knapsack with a step Pareto front (flat regions)."""
+    m = dm.Model("knap")
+    x = m.binary("x", shape=(3,))
+    p = np.array([5.0, 4.0, 3.0])
+    q = np.array([2.0, 6.0, 4.0])
+    f1 = p[0] * x[0] + p[1] * x[1] + p[2] * x[2]
+    f2 = q[0] * x[0] + q[1] * x[1] + q[2] * x[2]
+    m.subject_to(x[0] + x[1] + x[2] <= 2)
+    return m, [f1, f2]
+
+
+class TestLexicographicPayoff:
+    @pytest.mark.smoke
+    def test_lexicographic_payoff_is_pareto_optimal(self):
+        # MO-2a: the lexicographic nadir matches the hand-computed Pareto-worst.
+        m, objs = _alt_optimum_model()
+        ideal, payoff, anchors = lexicographic_payoff(m, objs, senses=["min", "min"])
+        nadir = nadir_from_payoff(payoff, senses=["min", "min"])
+        # Values carry the LP tolerance and the lexicographic slack (lex_tol);
+        # 1e-3 is comfortably tighter than the alternative-optimum inflation
+        # (which pushes nadir(f2) to ~3) this test guards against.
+        np.testing.assert_allclose(ideal, [0.0, 0.0], atol=1e-3)
+        # Payoff must be the Pareto-optimal table [[0, 2], [2, 0]].
+        np.testing.assert_allclose(payoff, [[0.0, 2.0], [2.0, 0.0]], atol=1e-3)
+        np.testing.assert_allclose(nadir, [2.0, 2.0], atol=1e-3)
+
+    @pytest.mark.smoke
+    def test_lexicographic_differs_from_simple_under_alternative_optima(self):
+        # The simple payoff (ideal_point + nadir_point) inflates nadir(f2)
+        # because the f1 anchor sits on an alternative optimum; lexicographic
+        # does not. This pins the *distinction* that makes it AUGMECON2.
+        m_simple, objs_simple = _alt_optimum_model()
+        _, anchors = ideal_point(m_simple, objs_simple, senses=["min", "min"])
+        simple_nadir = nadir_point(m_simple, objs_simple, anchors, senses=["min", "min"])
+
+        m_lex, objs_lex = _alt_optimum_model()
+        _, payoff, _ = lexicographic_payoff(m_lex, objs_lex, senses=["min", "min"])
+        lex_nadir = nadir_from_payoff(payoff, senses=["min", "min"])
+
+        # Simple over-estimates the f2 nadir (alternative optimum x2 ~ 3);
+        # lexicographic reports the true Pareto-worst 2.0.
+        assert simple_nadir[1] > 2.0 + 1e-3
+        assert lex_nadir[1] == pytest.approx(2.0, abs=1e-4)
+
+    @pytest.mark.smoke
+    def test_lexicographic_restores_objective_and_constraints(self):
+        m, objs = _alt_optimum_model()
+        n_cons_before = len(m._constraints)
+        obj_before = m._objective
+        lexicographic_payoff(m, objs, senses=["min", "min"])
+        # No lexicographic tolerance constraints leak; objective restored.
+        assert len(m._constraints) == n_cons_before
+        assert m._objective is obj_before
+
+
+class TestAugmecon2Bypass:
+    @pytest.mark.smoke
+    def test_bypass_skips_cells_same_front(self):
+        # MO-2b: on a step front, bypass does strictly fewer solves than the
+        # exhaustive grid AND returns the same nondominated set.
+        def run(bypass):
+            m, objs = _knapsack_step_model()
+            calls = {"n": 0}
+            orig = m.solve
+
+            def counted(*a, **k):
+                calls["n"] += 1
+                return orig(*a, **k)
+
+            m.solve = counted
+            front = epsilon_constraint(
+                m, objs, senses=["max", "max"], n_points=11, bypass=bypass, filter=False
+            )
+            return front, calls["n"]
+
+        front_bypass, n_bypass = run(True)
+        front_full, n_full = run(False)
+
+        assert n_bypass < n_full, "bypass must reduce the solve count on a flat front"
+
+        def ndset(front):
+            filt = front.filtered()
+            return sorted(tuple(np.round(p.objectives, 6)) for p in filt.points)
+
+        assert ndset(front_bypass) == ndset(front_full)
+
+    @pytest.mark.smoke
+    def test_bypass_disabled_matches_full_grid(self):
+        # bypass=False must be the exhaustive n_points^(k-1) grid.
+        m, objs = _knapsack_step_model()
+        calls = {"n": 0}
+        orig = m.solve
+        m.solve = lambda *a, **k: (calls.__setitem__("n", calls["n"] + 1) or orig(*a, **k))
+        epsilon_constraint(m, objs, senses=["max", "max"], n_points=11, bypass=False, filter=False)
+        # k=2 => n_points grid solves + k lexicographic-payoff solves (>= n_points).
+        assert calls["n"] >= 11
+
+    @pytest.mark.smoke
+    def test_invalid_payoff_arg_raises(self):
+        m, objs = _knapsack_step_model()
+        with pytest.raises(ValueError):
+            epsilon_constraint(m, objs, senses=["max", "max"], payoff="bogus")

--- a/python/tests/test_mo_indicators.py
+++ b/python/tests/test_mo_indicators.py
@@ -7,6 +7,7 @@ import pytest
 from discopt.mo import (
     ParetoFront,
     ParetoPoint,
+    common_reference,
     epsilon_indicator,
     hypervolume,
     igd,
@@ -105,6 +106,70 @@ class TestHypervolumeSenses:
         f_max = _front([[3.0, 1.0], [2.0, 2.0], [1.0, 3.0]], senses=("max", "max"))
         hv_max = hypervolume(f_max, reference=np.array([0.0, 0.0]))
         assert hv_max == pytest.approx(6.0)
+
+
+class TestCommonReference:
+    """MO4: the default HV reference is front-dependent (incomparable across
+    fronts); ``common_reference`` builds one shared reference so two fronts for
+    the same problem are comparable.
+    """
+
+    @pytest.mark.smoke
+    def test_default_reference_is_front_dependent(self):
+        # Two nested fronts. Under the default (front-derived) reference their
+        # hypervolumes are computed against DIFFERENT references, so they are
+        # not comparable -- the better (dominating) front can score LOWER.
+        better = _front([[0.0, 2.0], [1.0, 1.0], [2.0, 0.0]])
+        worse = _front([[0.0, 4.0], [2.0, 2.0], [4.0, 0.0]])
+        hv_better_default = better.hypervolume()
+        hv_worse_default = worse.hypervolume()
+        # The pathology: the worse front scores strictly higher under defaults
+        # (its self-derived reference box is larger). This is the MO4 bug.
+        assert hv_worse_default > hv_better_default
+
+    @pytest.mark.smoke
+    def test_shared_reference_is_comparable(self):
+        better = _front([[0.0, 2.0], [1.0, 1.0], [2.0, 0.0]])
+        worse = _front([[0.0, 4.0], [2.0, 2.0], [4.0, 0.0]])
+        ref = common_reference(better, worse)
+        hv_better = better.hypervolume(reference=ref)
+        hv_worse = worse.hypervolume(reference=ref)
+        # Against a SHARED reference the dominating front scores at least as
+        # high, restoring comparability.
+        assert hv_better >= hv_worse
+
+    @pytest.mark.smoke
+    def test_reference_dominates_all_points(self):
+        f1 = _front([[0.0, 2.0], [2.0, 0.0]])
+        f2 = _front([[1.0, 3.0], [3.0, 1.0]])
+        ref = common_reference(f1, f2)
+        # Every point of every front must strictly dominate the reference so
+        # each contributes positive hypervolume.
+        for f in (f1, f2):
+            assert f.hypervolume(reference=ref) > 0.0
+            assert np.all(f.objectives() < ref[None, :])
+
+    @pytest.mark.smoke
+    def test_max_sense_shared_reference(self):
+        f1 = _front([[3.0, 1.0], [1.0, 3.0]], senses=("max", "max"))
+        f2 = _front([[2.0, 1.0], [1.0, 2.0]], senses=("max", "max"))
+        ref = common_reference(f1, f2)
+        # Max-sense: reference must be BELOW all points (worse in max sense).
+        for f in (f1, f2):
+            assert np.all(f.objectives() > ref[None, :])
+            assert f.hypervolume(reference=ref) > 0.0
+
+    @pytest.mark.smoke
+    def test_incompatible_fronts_raise(self):
+        f_min = _front([[0.0, 2.0]], senses=("min", "min"))
+        f_max = _front([[0.0, 2.0]], senses=("min", "max"))
+        with pytest.raises(ValueError):
+            common_reference(f_min, f_max)
+        with pytest.raises(ValueError):
+            common_reference()
+        empty = _front(np.zeros((0, 2)))
+        with pytest.raises(ValueError):
+            common_reference(empty)
 
 
 class TestIGD:

--- a/python/tests/test_mo_pareto.py
+++ b/python/tests/test_mo_pareto.py
@@ -95,3 +95,68 @@ class TestParetoFront:
     def test_senses_array(self):
         front = _make_front([[0, 2]], senses=("min", "max"))
         np.testing.assert_allclose(front._senses_array(), [1.0, -1.0])
+
+
+class TestFilteredDedup:
+    """MO3: filtered() must collapse tolerance-equal duplicate objective vectors.
+
+    Weak dominance keeps every copy of an identical objective vector (equal
+    points do not strictly dominate one another), so without an explicit dedup
+    a front with three identical anchors survives as three points -- inflating
+    ``n`` and distorting spacing metrics.
+    """
+
+    @pytest.mark.smoke
+    def test_exact_duplicates_collapsed(self):
+        # 3 identical + 1 distinct + 1 dominated (MO3 repro: 3+1+1).
+        objs = [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0], [0.0, 2.0], [3.0, 3.0]]
+        front = _make_front(objs)
+        kept = front.filtered()
+        # Want exactly 2: one representative of the triple + the distinct
+        # point; the dominated (3, 3) is dropped. (Pre-fix: 4.)
+        assert kept.n == 2
+        kept_objs = sorted(tuple(p.objectives) for p in kept.points)
+        assert kept_objs == [(0.0, 2.0), (1.0, 1.0)]
+
+    @pytest.mark.smoke
+    def test_dedup_keeps_first_occurrence_params(self):
+        pts = [
+            ParetoPoint(
+                x={},
+                objectives=np.array([1.0, 1.0]),
+                status="optimal",
+                wall_time=0.0,
+                scalarization_params={"weights": [0.2, 0.8]},
+            ),
+            ParetoPoint(
+                x={},
+                objectives=np.array([1.0, 1.0]),
+                status="optimal",
+                wall_time=0.0,
+                scalarization_params={"weights": [0.5, 0.5]},
+            ),
+        ]
+        front = ParetoFront(
+            points=pts, method="test", objective_names=["f1", "f2"], senses=["min", "min"]
+        )
+        kept = front.filtered()
+        assert kept.n == 1
+        # First occurrence's params are preserved.
+        assert kept.points[0].scalarization_params == {"weights": [0.2, 0.8]}
+
+    @pytest.mark.smoke
+    def test_genuinely_distinct_near_points_preserved(self):
+        # Two points differing by 1e-4 must NOT be merged at the default 1e-8 tol.
+        objs = [[1.0, 1.0], [1.0 + 1e-4, 1.0 - 1e-4], [0.0, 2.0]]
+        front = _make_front(objs)
+        kept = front.filtered()
+        assert kept.n == 3
+
+    @pytest.mark.smoke
+    def test_dedup_tol_is_tunable(self):
+        objs = [[1.0, 1.0], [1.0 + 1e-4, 1.0 - 1e-4]]
+        front = _make_front(objs)
+        # A looser tolerance collapses the near-duplicate pair.
+        assert front.filtered(dedup_tol=1e-3).n == 1
+        # The default keeps them distinct.
+        assert front.filtered().n == 2


### PR DESCRIPTION
Resolves the **MO2 / MO3 / MO4** mo-module Fable-review findings (issue #413,
Phase C P2). MO1 was resolved in a prior PR and is untouched. All three findings
were **confirmed on `origin/main`** before fixing. `discopt.mo` is a
post-processing layer off the B&B solve path, so cert-baseline neutrality is
exact by construction (no solver code changed).

## MO3 — `pareto.py` `filtered()` kept duplicate points ✅
Weak dominance keeps every copy of an identical objective vector (equal points
don't strictly dominate one another), so a front with 3 identical anchors
survived as 3 points. `filtered()` now collapses tolerance-equal duplicates
(`np.allclose`, default `dedup_tol=1e-8`, tunable) **before** the dominance
filter, keeping the first occurrence and its `scalarization_params`.
- Repro before: 3-identical + 1-distinct + 1-dominated → `filtered().n == 4`.
- After: `== 2`; genuinely-distinct near points (1e-4 apart) preserved.

## MO4 — `indicators.py` front-dependent hypervolume reference ✅
`front.hypervolume()` with no reference derived one from *that* front's own
nadir/worst, so two fronts for the same problem were scored against **different**
references (incomparable — the worse front could score higher). Added:
- `common_reference(*fronts)` (exported from `discopt.mo`): one shared reference
  from the union of the fronts' points (union-worst + 1 % margin);
- a loud `.. warning::` on `hypervolume()` / `ParetoFront.hypervolume` that the
  default `reference=None` is front-dependent and not comparable across fronts.

Under a shared reference the dominating front scores ≥ the dominated one
(comparability restored); min- and max-sense both tested.

## MO2 — `scalarization.py` was AUGMECON, not AUGMECON2 ✅ (implemented, not renamed)
**Scope decision:** the review's Phase-1 acceptance criteria (lexicographic
payoff behind `payoff="lexicographic"` default; bypass with a solve-count-drop
assertion) describe a **bounded** change, so the honest path was to make the
code match the `"augmecon2"` name rather than rename to `augmecon`. Both
distinguishing features are now implemented and on by default:
1. **Lexicographic payoff table** — new `utils.lexicographic_payoff()` +
   `utils.nadir_from_payoff()`; `epsilon_constraint(payoff="lexicographic")`
   (opt-out `"simple"`). Each objective as lexicographic primary is optimized,
   pinned by a tolerance constraint, then the rest optimized in order →
   Pareto-optimal anchors, so the nadir isn't inflated/truncated by alternative
   optima [Miettinen 1999]. Demonstrated: on an alternative-optimum LP the
   *simple* payoff reports nadir(f2) ≈ 3 (junk); lexicographic reports the true
   Pareto-worst 2.0.
2. **Bypass / jump acceleration** — `bypass=True` (default; requires
   `augmented`). The innermost ε-axis is swept worst→best; a subproblem's
   innermost slack skips `floor(slack/step)` cells that provably reproduce the
   same optimum (exact — only known-redundant cells skipped). Demonstrated on a
   bi-objective binary knapsack step front: **6 solves with bypass vs 15
   exhaustive, identical nondominated set**.

`payoff="simple", bypass=False` recovers plain AUGMECON for A/B comparison.

## Tests (fails-before verified by stashing the source; all `smoke`)
- `python/tests/test_mo_pareto.py::TestFilteredDedup` — MO3 (base: `4 != 2`).
- `python/tests/test_mo_indicators.py::TestCommonReference` — MO4 (base:
  `common_reference` absent → ImportError; default-front-dependence pinned).
- `python/tests/test_mo_augmecon2.py` — MO2 lexicographic-payoff + bypass
  (base: `lexicographic_payoff` absent → ImportError; solve-backed, sub-second).

## What was run
- Fast mo suite (`test_mo_pareto`, `test_mo_indicators`, `test_mo_augmecon2`):
  **45 passed**.
- Slow scalarization suite (`test_mo_scalarization.py -m slow`): **12 passed**.
- Adversarial (`-m slow test_adversarial_recent_fixes.py`): **10 passed**.
- `pytest python/tests/ -m smoke`: **520 passed, 1 skipped**.
- `ruff check` + `ruff format --check`: clean. `mypy` (numpy-stub-compatible
  run): clean — the `python_version=3.10` numpy-stub syntax error is a
  pre-existing environment issue that also trips untouched files.
- Cert-baseline neutrality (`JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`,
  `docs/dev/data/cert-baseline.jsonl`): **NEUTRAL** on the re-solved subset —
  nodes exact (21→21, 0→0, 165→165), `|Δobj|=0.00e+00`, `incorrect_count == 0`.
  Expected: mo is off the solve path, so the B&B code is byte-identical.

`test_mo_nbi.py -m slow` hangs on this machine both before and after this
change (pre-existing; nbi code untouched) — out of scope.

Docs updated: `mo-module-review.md` STATUS banner + MO2/MO3/MO4 `✅ RESOLVED`
markers; `review-execution-plan.md` §4 ledger MO row (MO1–MO4 resolved,
MO5–MO10 open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
