### PR TITLE
perf(cert-gap): route separation/strong-branch LPs to the warm in-house simplex (Phase D)

### DIFF
--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -138,6 +138,7 @@ experiment may run.
 | Phase 4 build 3 — Q-matrix extraction | **done — (A) bound-neutral, (B) flagged bound-changing** | (this PR) | Exact `extract_quadratic(expr,n,model)` in `quadratic_form.py` (exact-or-abstain, validated 1e-12 on 250 pts/inst + 14 non-quadratic rejections). Consumer: PSD-on-Q convexity certificate wired into `certify_convex` behind `DISCOPT_PSD_QFORM` (**default-OFF**); sound tightening, never mis-certifies (30 indefinite-Q seeds), strict refinement of the rigorous path. Flag-off is byte-identical → cert-neutral. See §8 "Phase 4 Q-extraction — build results" |
 | Phase 4 items 2 & 4 (V-segments, symmetry) | **locked / de-scoped** (§0.1.2) | — | V-segments de-prioritized (0 defvars in text `.nl`); symmetry DO-NOT-BUILD (0 orbits) per the re-profile. RLT/edge-concave rewire onto `extract_quadratic` scoped as bound-neutral follow-on |
 | Phase 5 | **locked** (§0.1.2) | — | requires post-Phase-1 re-profile |
+| Phase D — separation/strong-branch LP → warm in-house simplex (`perf-d1`) | **done — bound-neutral, default-ON** | (this PR) | Re-profile: **POUNCE subsolver is the #1 wall** (nvs17 ~239 cold POUNCE-LP solves / 6.3 s ≈ 40% of wall). Routed edge-concave separation + strong-branch LPs to `lp_simplex.solve_lp` under `DISCOPT_SEPARATION_LP_SIMPLEX` (default ON). Cert-baseline **NEUTRAL** (41/41 exact node_count, Δobj 0, incorrect 0); nvs17 equal-budget 93 nodes both flags. T0.4: 37 cuts / 14,800 checks, no invalid cut. Win: nvs17 POUNCE 848→0, wall 60.3 s (TL) → 38.1 s (optimal), s/node 0.826→0.409 (**2.02×**); nvs13 2.67×. See §8 "Phase D re-profile" |
 
 **Phase 0 — DONE & gated** (cert0 green: root_gap coverage 0.909 ≥ 0.90, incorrect 0).
 
@@ -1111,6 +1112,73 @@ collect_edge_concave_quadratics`, `rlt_cuts.py`), so rerouting them through
 coefficients, same verdict) and at worst risk a subtle drift; it is not shipped in
 this PR. The value there is a *faster path to the same relaxation*, which must be
 proven exactly bound-neutral (node_count/objective unchanged) — a separate task.
+
+### Phase D re-profile (2026-07-05) — the POUNCE subsolver is the #1 wall lever
+
+Re-profile on current `main` (post-CSE/Q-extraction/Rust-1). The §8 re-profile named
+"separation cost" as the dominant wall; this Phase-D pass attributes *where inside
+separation the time goes* — the **POUNCE subsolver**, called cold once per
+separation/strong-branch LP:
+
+- **nvs17**: `separate_edge_concave_quadratic → lp_pounce.solve_lp` = **85 calls /
+  4.86 s**; strong-branching → `lp_pounce.solve_lp` = **154 calls / 2.22 s**. Together
+  **~239 cold POUNCE-LP solves / 6.3 s ≈ 40% of nvs17 wall**, while the in-house Rust
+  simplex (`solve_lp_warm_py`) solves the same LPs at ~4–15 ms.
+- **Levers A/B/C status recorded:** CSE (Phase-4 lever 1) is **done and NOT a wall
+  lever by itself** (it shrinks the DAG the separators walk, but the separator's own
+  subsolver cost dominates); Q-extraction (lever 3) done/flagged; the earlier per-node
+  warm-start / Python-tax levers (T1.4/T1.6) were **measured dead**. The live lever is
+  the **separation/strong-branch subsolver backend**.
+
+**Lever taken (`perf-d1`): route the separation + strong-branch LPs to the warm
+in-house simplex.** The edge-concave separator hard-coded `lp_pounce.solve_lp`
+(`edge_concave.py`); strong branching used `get_lp_solver(prefer_pounce=nlp_solver==
+"pounce")`, i.e. POUNCE on the default `nlp_solver="pounce"`. Both now route to
+`lp_simplex.solve_lp` under `DISCOPT_SEPARATION_LP_SIMPLEX` (default **ON**; `"0"`
+restores POUNCE).
+
+**Confirm-first (does the routing preserve the derived output?).** Captured ≥50 of
+each LP on nvs17 + nvs11/12/13 during a live solve and solved each with *both*
+backends:
+- *Edge-concave (load-bearing output = the derived cut, not the vertex):* the two
+  backends **disagree on the dual slope** on the degenerate vertex-hull LP (|ΔA|∞ up to
+  1e10; IPM analytic-center dual vs simplex vertex dual) — but the separator recomputes
+  the intercept `B` to the exact validity boundary, so **both cuts are sound for any
+  slope**, and on the captured panel the **cut verdict matched 239/239** (every LP was
+  `noviol` for both — these instances produce no edge-concave cut). So the routing is
+  *not* byte-identical to POUNCE (different valid slope on a degenerate LP); its
+  neutrality is decided empirically, not by vertex identity.
+- *Strong-branch (load-bearing output = the objective bound used in the argmax score):*
+  objective agreement to LP tolerance (|Δobj| median 4.6e-6, max 1.1e-4 over 457 LPs);
+  the small wobble did not flip any branch argmax.
+
+**Result — strictly bound-neutral, measured:**
+- **Cert-baseline neutrality (`check_cert_neutrality.py`, `JAX_PLATFORMS=cpu`,
+  `JAX_ENABLE_X64=1`, flag ON): NEUTRAL.** All **41/41** certifying instances
+  `node_count` EXACTLY unchanged and `|Δobj| = 0.00e+00`, all `optimal` →
+  `incorrect_count = 0`. nvs17 (not in the baseline) verified separately: at a
+  generous budget both flag states finish `optimal` at **exactly 93 nodes, obj
+  −1100.4** — the branch decisions are identical.
+- **T0.4 soundness harness through the new path: PASS.** 37 real edge-concave cuts
+  derived via the simplex slope (nvs14/nvs11), **14,800 feasible-point validity checks,
+  no invalid cut** (the intercept-recompute keeps every cut sound regardless of slope).
+- **Measured win (POUNCE calls / wall / s-node), `nlp_solver="pounce"`, 60 s cap:**
+
+  | instance | POUNCE calls OFF→ON | wall OFF → ON | s/node OFF → ON | note |
+  |---|---:|---|---|---|
+  | nvs17 | 848 → **0** | 60.3 s (TL, feasible) → **38.1 s (optimal)** | 0.826 → **0.409 (2.02×)** | now certifies within budget |
+  | nvs13 | 164 → **0** | 3.86 s → **1.44 s** | 0.203 → **0.076 (2.67×)** | |
+  | nvs11/12/14 | 0 → 0 | unchanged | unchanged | no separation/SB POUNCE calls; neutral |
+
+  nvs17's 73→93 node difference at the 60 s cap is the *timeout truncating the slower
+  OFF run mid-search*, not a bound change (equal-budget node count is identical, above).
+
+**Shipped default-ON** (strictly bound-neutral: node_count + objective exactly
+unchanged on the cert panel and nvs17). A documented off-switch
+(`DISCOPT_SEPARATION_LP_SIMPLEX=0`) is retained because the edge-concave slope is not
+byte-identical across backends (degenerate-LP dual), so an operator can pin the legacy
+POUNCE path if a future instance ever shows a cut-selection difference; soundness holds
+either way.
 
 ---
 

--- a/python/discopt/_jax/edge_concave.py
+++ b/python/discopt/_jax/edge_concave.py
@@ -31,10 +31,47 @@ a vertex-hull "underestimator" that cuts off true points, so detection
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from itertools import product
 
 import numpy as np
+
+
+def _separation_lp_solver():
+    """Return the LP solver for the vertex-hull separation LP.
+
+    Phase-D lever (``perf-d1``): route the edge-concave separation LP through the
+    in-house pure-Rust warm simplex (``lp_simplex.solve_lp``) instead of a cold
+    POUNCE IPM solve per call, controlled by ``DISCOPT_SEPARATION_LP_SIMPLEX``
+    (default ``"1"`` — ON). The off-switch (``"0"``) restores the POUNCE path.
+
+    Soundness is independent of which backend is used: only the dual *slope* ``A``
+    is consumed and the intercept ``B`` is recomputed to the exact validity
+    boundary over the box vertices, so the derived cut bounds ``q`` everywhere for
+    ANY slope (see the module + :func:`separate_edge_concave_quadratic` docstrings).
+    The two backends can disagree on the slope on a *degenerate* vertex-hull LP
+    (the IPM returns an analytic-center dual, the simplex a vertex dual), so this
+    routing is not byte-for-byte identical to POUNCE — the derived cut can differ
+    (both sound). It is validated node-neutral on the cert baseline before shipping.
+    """
+    use_simplex = os.environ.get("DISCOPT_SEPARATION_LP_SIMPLEX", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+    if use_simplex:
+        try:
+            from discopt.solvers.lp_simplex import SIMPLEX_AVAILABLE, solve_lp
+
+            if SIMPLEX_AVAILABLE:
+                return solve_lp
+        except ImportError:
+            pass
+    from discopt.solvers.lp_pounce import solve_lp
+
+    return solve_lp
 
 
 @dataclass(frozen=True)
@@ -164,15 +201,18 @@ def separate_edge_concave_quadratic(
     edge-concavity), so the cut is sound; it is returned only when ``q_star``
     violates it.
 
-    The vertex-hull LP is solved with the pure-Rust POUNCE IPM (issue #356 — no
-    SciPy/HiGHS). Only the dual *slope* ``A`` is taken from POUNCE; the intercept
-    ``B`` is recomputed to the exact validity boundary over the vertices
-    (``minᵥ(q(v)−A·v)`` under / ``maxᵥ`` over), so by edge-concavity the cut
-    bounds ``q`` everywhere for ANY slope — robust to POUNCE's analytic-center
-    dual / sign / scale. ``None`` if POUNCE is unavailable or did not converge.
+    The vertex-hull LP is solved with the in-house pure-Rust warm simplex by
+    default (Phase-D lever ``perf-d1``; ``DISCOPT_SEPARATION_LP_SIMPLEX=0`` restores
+    the POUNCE IPM — see :func:`_separation_lp_solver`). Only the dual *slope* ``A``
+    is taken from the LP; the intercept ``B`` is recomputed to the exact validity
+    boundary over the vertices (``minᵥ(q(v)−A·v)`` under / ``maxᵥ`` over), so by
+    edge-concavity the cut bounds ``q`` everywhere for ANY slope — robust to the
+    backend's dual / sign / scale. ``None`` if no backend is available or the LP
+    did not converge.
     """
     from discopt.solvers import SolveStatus
-    from discopt.solvers.lp_pounce import solve_lp
+
+    solve_lp = _separation_lp_solver()
 
     n = len(block.var_idxs)
     if n < 2 or not (np.all(np.isfinite(lb[:n])) and np.all(np.isfinite(ub[:n]))):

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1737,7 +1737,21 @@ def _strong_branch_lp(
     try:
         from discopt.solvers.lp_backend import get_lp_solver
 
-        solve_lp = get_lp_solver(prefer_pounce)
+        # Phase-D lever (perf-d1): the strong-branch score reads only the child LP
+        # *objective* bound (never its vertex), so route these repeated LPs through
+        # the in-house warm simplex instead of a cold POUNCE IPM solve per call.
+        # Controlled by DISCOPT_SEPARATION_LP_SIMPLEX (default ON); the off-switch
+        # ("0") restores the caller-selected backend (POUNCE under nlp_solver=
+        # "pounce"). Node-neutrality is validated on the cert baseline: the simplex
+        # vertex optimum and the IPM analytic-center objective agree to LP
+        # tolerance, so the argmax branch decision is unchanged.
+        _sb_simplex = os.environ.get("DISCOPT_SEPARATION_LP_SIMPLEX", "1").strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+        )
+        solve_lp = get_lp_solver(prefer_pounce=prefer_pounce and not _sb_simplex)
     except ImportError:
         return None  # strong branching is optional; fall back to pseudocosts
 

--- a/python/tests/test_perf_d1_separation_lp_backend.py
+++ b/python/tests/test_perf_d1_separation_lp_backend.py
@@ -1,0 +1,133 @@
+"""Phase-D (perf-d1): the edge-concave separation LP and the strong-branch LP
+route to the in-house warm simplex, not a cold POUNCE IPM per call.
+
+Regression guard for the backend-routing lever (bound-neutral: only the LP
+*backend* changes; the separation math / branch rule are untouched). These tests
+fail on the pre-perf-d1 code (which hard-coded ``lp_pounce.solve_lp`` in the
+separator and let ``prefer_pounce`` reach the strong-branch solver on the default
+``nlp_solver="pounce"`` path).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.filterwarnings("ignore")
+
+
+def test_separation_lp_solver_defaults_to_simplex(monkeypatch):
+    """Default (flag unset / '1') -> the in-house simplex is the separation LP."""
+    import discopt.solvers.lp_pounce as lp_pounce
+    import discopt.solvers.lp_simplex as lp_simplex
+    from discopt._jax.edge_concave import _separation_lp_solver
+
+    if not lp_simplex.SIMPLEX_AVAILABLE:
+        pytest.skip("in-house simplex binding not built")
+
+    monkeypatch.delenv("DISCOPT_SEPARATION_LP_SIMPLEX", raising=False)
+    assert _separation_lp_solver() is lp_simplex.solve_lp
+
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", "1")
+    assert _separation_lp_solver() is lp_simplex.solve_lp
+
+    # off-switch restores POUNCE
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", "0")
+    assert _separation_lp_solver() is lp_pounce.solve_lp
+
+
+def test_edge_concave_cut_sound_via_simplex_path(monkeypatch):
+    """A cut derived through the simplex-backed separator is a valid under/over
+    estimator over the whole box (removes no true point)."""
+    import discopt.solvers.lp_simplex as lp_simplex
+    from discopt._jax.edge_concave import (
+        EdgeConcaveQuadratic,
+        separate_edge_concave_quadratic,
+    )
+
+    if not lp_simplex.SIMPLEX_AVAILABLE:
+        pytest.skip("in-house simplex binding not built")
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", "1")
+
+    # q(x0,x1) = -x0^2 - x1^2 + x0*x1  (edge-concave: both square coeffs < 0)
+    blk = EdgeConcaveQuadratic(
+        var_idxs=(0, 1),
+        sq={0: -1.0, 1: -1.0},
+        bilin={(0, 1): 1.0},
+        lin={},
+        const=0.0,
+        sense="under",
+    )
+    lb = np.array([-2.0, -2.0])
+    ub = np.array([2.0, 2.0])
+    xs = np.array([0.3, -0.4])
+    # q_star well below the vertex-hull underestimator value at xs -> violated,
+    # so the separator must emit a cut (which we then check is a valid estimator).
+    q_star = -100.0
+
+    cut = separate_edge_concave_quadratic(blk, lb, ub, xs, q_star)
+    assert cut is not None, "expected a violated edge-concave cut"
+    A, B = cut
+
+    # validity: A·x + B <= q(x) at every sampled box point (underestimator)
+    rng = np.random.default_rng(0)
+    pts = lb + (ub - lb) * rng.random((500, 2))
+    q = -(pts[:, 0] ** 2) - pts[:, 1] ** 2 + pts[:, 0] * pts[:, 1]
+    est = pts @ A + B
+    assert np.all(est <= q + 1e-6), "simplex-derived edge-concave cut removes a feasible point"
+
+
+def test_strong_branch_lp_routes_to_simplex_on_default(monkeypatch):
+    """On the default nlp_solver='pounce' path, strong branching's LP solver is
+    the in-house simplex (flag ON), not POUNCE."""
+    import discopt.solver as solvermod
+    import discopt.solvers.lp_pounce as lp_pounce
+    import discopt.solvers.lp_simplex as lp_simplex
+
+    if not lp_simplex.SIMPLEX_AVAILABLE:
+        pytest.skip("in-house simplex binding not built")
+
+    seen = {}
+
+    class _StubEvaluator:
+        n_constraints = 0
+
+        def evaluate_gradient(self, x):
+            return np.ones_like(np.asarray(x, dtype=float))
+
+    def _capture_get_lp_solver(prefer_pounce=False):
+        seen["prefer_pounce"] = prefer_pounce
+        return lp_pounce.solve_lp if prefer_pounce else lp_simplex.solve_lp
+
+    monkeypatch.setattr("discopt.solvers.lp_backend.get_lp_solver", _capture_get_lp_solver)
+
+    sol = np.array([0.5, 0.5])
+    lb = np.array([0.0, 0.0])
+    ub = np.array([1.0, 1.0])
+
+    # flag ON (default): even with prefer_pounce=True from the caller, the routing
+    # collapses prefer_pounce to False so the simplex is selected.
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", "1")
+    solvermod._strong_branch_lp(
+        _StubEvaluator(),
+        sol,
+        lb,
+        ub,
+        np.array([0, 1]),
+        parent_lb=0.0,
+        prefer_pounce=True,
+    )
+    assert seen["prefer_pounce"] is False, "flag ON should route strong-branch off POUNCE"
+
+    # off-switch restores the caller-selected POUNCE preference
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", "0")
+    solvermod._strong_branch_lp(
+        _StubEvaluator(),
+        sol,
+        lb,
+        ub,
+        np.array([0, 1]),
+        parent_lb=0.0,
+        prefer_pounce=True,
+    )
+    assert seen["prefer_pounce"] is True, "flag OFF should honor the caller's POUNCE choice"


### PR DESCRIPTION
## Phase D — the bound-neutral POUNCE-LP lever

**Re-profile finding (recorded in §8):** the **POUNCE subsolver is the #1 wall lever**.
On nvs17 the edge-concave separator (`separate_edge_concave_quadratic → lp_pounce.solve_lp`,
85 calls / 4.86s) and strong-branching (154 calls / 2.22s) issue **~239 cold POUNCE-LP
solves ≈ 40% of nvs17 wall**, while the in-house Rust warm simplex solves the same LPs at
~4–15ms. CSE (Phase-4 lever 1) is done but shrinks the DAG the separators walk — not a wall
lever by itself; the separator's *subsolver* dominates. Levers A/B/C (T1.4/T1.6 per-node
warm-start / Python-tax) were measured dead.

**Lever taken:** route the edge-concave separation LPs and strong-branch LPs to
`lp_simplex.solve_lp` under `DISCOPT_SEPARATION_LP_SIMPLEX` (default **ON**; `"0"` restores
POUNCE). The separation math and the branch rule are unchanged — only the LP backend.

- `edge_concave.py`: new `_separation_lp_solver()` selects the backend (was hard-coded
  `lp_pounce.solve_lp`). Only the dual *slope* `A` is consumed and the intercept `B` is
  recomputed to the exact validity boundary over the box vertices, so **any slope yields a
  sound cut**.
- `solver.py` `_strong_branch_lp`: collapse `prefer_pounce → False` under the flag, so the
  default `nlp_solver="pounce"` path uses the simplex. The score reads only the child LP
  *objective bound*, never its vertex.

## Confirm-first (solver agreement, ≥50 LPs/site, both backends)

- **Edge-concave** (load-bearing output = the derived cut): the two backends disagree on the
  dual slope on the *degenerate* vertex-hull LP (`|ΔA|∞` up to 1e10 — IPM analytic-center dual
  vs simplex vertex dual), but the recomputed `B` keeps every cut sound, and the **cut verdict
  matched 239/239** on the panel (all `noviol`). So the routing is *not* byte-identical to
  POUNCE — neutrality is decided empirically.
- **Strong-branch** (load-bearing output = the objective bound used in the argmax): objective
  agreed to LP tolerance (`|Δobj|` median 4.6e-6, max 1.1e-4 over 457 LPs); no branch argmax
  flipped.

## Validation — BOUND-NEUTRAL regime

- **Cert-baseline neutrality** (`check_cert_neutrality.py`, `JAX_PLATFORMS=cpu`,
  `JAX_ENABLE_X64=1`, flag ON): **NEUTRAL**. All **41/41** certifying instances `node_count`
  **EXACTLY unchanged**, `|Δobj| = 0.00e+00`, all `optimal` → **`incorrect_count = 0`**.
  nvs17 (not in the baseline) verified separately: at a generous budget both flag states finish
  `optimal` at **exactly 93 nodes, obj −1100.4** (branch decisions identical; the 73-vs-93 gap
  at the 60s cap is only the timeout truncating the slower OFF run).
- **T0.4 soundness harness** (`utils/soundness.py`) through the new path: **37 real edge-concave
  cuts** derived via the simplex slope (nvs14/nvs11), **14,800 feasible-point validity checks,
  no invalid cut**.
- **Tests:** new `test_perf_d1_separation_lp_backend.py` (fails pre-change on 2/3, passes after);
  targeted `-k "edge_concave or separat or strong or branch or lp or simplex or nvs17"` **229
  passed**; `pytest -m smoke` **520 passed**; adversarial suite (`test_adversarial_recent_fixes.py`)
  **10 passed**; `ruff check` + `ruff format --check` clean on all touched files. **Rust
  untouched** (no `cargo test` needed). mypy: pre-existing environment failure (venv numpy `.pyi`
  uses 3.12 `type` syntax under `python_version=3.10`; blocks at the numpy import on files not
  touched here) — unrelated to this change.

## Measured win (`nlp_solver="pounce"`, 60s cap)

| instance | POUNCE calls OFF→ON | wall OFF → ON | s/node OFF → ON |
|---|---:|---|---|
| **nvs17** | 848 → **0** | 60.3s (TL, feasible) → **38.1s (optimal)** | 0.826 → **0.409 (2.02×)** |
| **nvs13** | 164 → **0** | 3.86s → **1.44s** | 0.203 → **0.076 (2.67×)** |
| nvs11/12/14 | 0 → 0 | unchanged | unchanged (no separation/SB POUNCE calls) |

nvs17 now **certifies within budget** where the POUNCE path timed out.

## Flag

Shipped **default-ON** (strictly bound-neutral: node_count + objective exactly unchanged on the
cert panel and nvs17). A documented off-switch `DISCOPT_SEPARATION_LP_SIMPLEX=0` is retained
because the edge-concave slope is not byte-identical across backends on a degenerate LP, so an
operator can pin the legacy POUNCE path if a future instance ever shows a cut-selection
difference; soundness holds either way.

Docs: `certification-gap-plan.md` §8 (Phase D re-profile + build result) and §0.8 status table
updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
