### PR TITLE
fix(lint): annotate bounds_list in gdp_reformulate (un-red main, #490 mypy)

### DIFF
--- a/python/discopt/_jax/gdp_reformulate.py
+++ b/python/discopt/_jax/gdp_reformulate.py
@@ -326,7 +326,7 @@ def _compute_big_m_lp(
     # always appended *after* the originals, so the first ``n_vars`` scalar
     # columns are exactly the original variables that ``c_vec`` indexes — take
     # only those.
-    bounds_list = []
+    bounds_list: list[tuple[float, float]] = []
     for v in model._variables:
         if len(bounds_list) >= n_vars:
             break


### PR DESCRIPTION
#490 (GDP-1/GDP-2) merged on UNSTABLE and its `Lint + typecheck` job then failed on main with a single mypy error:
```
_jax/gdp_reformulate.py:329: error: Need type annotation for "bounds_list"  [var-annotated]
```
The GDP-2 fix added `bounds_list = []` (it collects `(lb_i, ub_i)` float pairs). Annotated as `list[tuple[float, float]]`. Ruff clean. Un-reds `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
