### PR TITLE
fix(decomposition): #391 — advisor certificate post-condition, block_id map, override test, CC/SCC parity

### DIFF
--- a/docs/dev/decomposition-module-review.md
+++ b/docs/dev/decomposition-module-review.md
@@ -65,6 +65,35 @@ certificate.
   analysis-only — `Model.solve()` never silently applies a decomposition (opt-in
   `decomposition=`/`lagrangian_bound=` only); `assert_sound()` refuses `HEURISTIC`.
 
+## 2b. Advisor review follow-ups (#391 / from the #388 review — landed)
+
+Hardening/clarity items from the Decomposition Advisor review; none were
+correctness blockers (the advisor was already sound — the drivers +
+`SolveResult.__post_init__` self-police), these close the latent gaps:
+
+1. **Certificate is now a checked post-condition, not just advice.** `is_sound()`
+   stays permissive (`RELAXATION`/`UNKNOWN` may run; only `HEURISTIC` is refused),
+   but `SoundnessCertificate.check_result` — called by `DecomposedModel.solve()`
+   after the driver returns — **raises** if a `RELAXATION`/`UNKNOWN` certificate
+   comes back `gap_certified=True` without the finite dual `bound` a real proof
+   leaves (the failure mode of a future driver that did not self-police). The
+   docstring now states the certificate is *advisory* and the driver's
+   `status`/`bound`/`gap_certified` is the contract. `effective_level(result)` /
+   `summary()` surface the driver's `gap_certified` as authoritative, so GBD's
+   `UNKNOWN → exact` resolution no longer disagrees with the attached certificate.
+2. **`map_subproblems` keys results by `block_id`, not list position.** An explicit
+   `{block_id: position}` map replaces `self.subproblems[block_id]` (latent
+   `IndexError`/mis-map for non-contiguous block ids); duplicate ids are refused
+   loudly. Regression: non-contiguous/unordered block ids.
+3. **Learning override positively tested.** Added a case where the learner's voted
+   method is a *viable* candidate and the recommendation actually flips (the prior
+   test only covered the safe no-op fallback).
+4. **Rust CC/SCC kernels: parity test added (not dropped).** Kept — CC is a live
+   speed-path candidate for `structure.py` (which calls the Python CC today) and
+   SCC is the documented stage/dual-dependency kernel. Added pure-Python edge-list
+   CC and iterative-Tarjan SCC references and a Rust↔Python parity test (fixed +
+   randomized) mirroring `test_articulation_rust_matches_python_reference`.
+
 ## 3. SOTA
 
 At or above the correctness bar of commercial/open-source Benders. CPLEX/Gurobi

--- a/python/discopt/decomposition/graph/kernels.py
+++ b/python/discopt/decomposition/graph/kernels.py
@@ -261,6 +261,77 @@ def _articulation_and_bridges_py(
     return articulation_points, bridges
 
 
+def _connected_components_edges_py(n: int, edges: list[tuple[int, int]]) -> tuple[list[int], int]:
+    """Pure-Python reference for the Rust ``decomp_connected_components`` kernel.
+
+    The public :func:`connected_components` above takes *clique* lists (the form
+    the structure layer produces); the Rust ``decomp_connected_components`` binding
+    takes an *edge* list. This is the edge-list oracle that mirrors it bit-for-bit
+    — union-find with union-by-size, then components relabelled in ascending
+    first-seen-vertex order (the same convention as the Rust kernel). It is the
+    reference the Rust↔Python CC parity test compares against (#391 item 4).
+    """
+    return connected_components(n, [[a, b] for a, b in edges])
+
+
+def _strongly_connected_components_py(n: int, arcs: list[tuple[int, int]]) -> tuple[list[int], int]:
+    """Pure-Python reference for the Rust ``decomp_strongly_connected_components``.
+
+    An iterative Tarjan that mirrors ``crates/discopt-core/src/decomp/components.rs``
+    exactly: SCC ids are assigned in the order roots are *finalized* (a reverse
+    topological order of the condensation), and the traversal is iterative so deep
+    graphs are safe. Bit-for-bit oracle for the Rust SCC kernel (#391 item 4).
+    """
+    adj: list[list[int]] = [[] for _ in range(n)]
+    for a, b in arcs:
+        adj[a].append(b)
+
+    UNSET = -1
+    index = [UNSET] * n
+    low = [0] * n
+    on_stack = [False] * n
+    comp = [UNSET] * n
+    scc_stack: list[int] = []
+    idx = 0
+    ncomp = 0
+
+    for s in range(n):
+        if index[s] != UNSET:
+            continue
+        work: list[list[int]] = [[s, 0]]  # [vertex, next-neighbor-index]
+        while work:
+            v, ci = work[-1]
+            if ci == 0:
+                index[v] = idx
+                low[v] = idx
+                idx += 1
+                scc_stack.append(v)
+                on_stack[v] = True
+            nbrs = adj[v]
+            if ci < len(nbrs):
+                work[-1][1] += 1
+                w = nbrs[ci]
+                if index[w] == UNSET:
+                    work.append([w, 0])
+                elif on_stack[w] and index[w] < low[v]:
+                    low[v] = index[w]
+            else:
+                if low[v] == index[v]:
+                    while True:
+                        w = scc_stack.pop()
+                        on_stack[w] = False
+                        comp[w] = ncomp
+                        if w == v:
+                            break
+                    ncomp += 1
+                work.pop()
+                if work:
+                    p = work[-1][0]
+                    if low[v] < low[p]:
+                        low[p] = low[v]
+    return comp, ncomp
+
+
 __all__ = [
     "articulation_and_bridges",
     "bearing_blocks",

--- a/python/discopt/decomposition/ir/certificate.py
+++ b/python/discopt/decomposition/ir/certificate.py
@@ -2,10 +2,26 @@
 
 The correctness spine of the reformulation IR (design §8.2). A
 :class:`SoundnessCertificate` records *why* a decomposition represents the
-original model — exactly, as a relaxation, or not at all — and refuses to run a
-decomposition that cannot be justified. A :class:`VariableMapping` records which
-original variables live in the master versus which subproblem block, so results
-come back in the user's variable space and the partition is inspectable.
+original model — exactly, as a relaxation, or property-dependent — and refuses
+outright to run a method that carries **no** guarantee (``HEURISTIC``). A
+:class:`VariableMapping` records which original variables live in the master
+versus which subproblem block, so results come back in the user's variable space
+and the partition is inspectable.
+
+**The certificate is advisory, not the contract.** ``is_sound()`` admits
+``RELAXATION`` and ``UNKNOWN`` (only ``HEURISTIC`` is refused), so the *authority*
+on whether a run actually certified optimality is the **driver's** returned
+``SolveResult`` (``status`` / ``bound`` / ``gap_certified``), which self-polices:
+GBD withholds its bound unless a convexity classifier *proves* the recourse
+convex, and Lagrangian certifies only when a recovered primal meets the dual
+bound. :meth:`SoundnessCertificate.check_result` turns that division of labour
+into a checked **post-condition** — after ``DecomposedModel.solve()`` it raises
+if a merely-``RELAXATION``/``UNKNOWN`` certificate returns ``gap_certified=True``
+*without* the finite dual ``bound`` that a real proof leaves behind (the only way
+a non-self-policing future driver could smuggle an unearned certificate past the
+gate), and it reports the driver's ``gap_certified`` as the authoritative signal
+so a GBD ``UNKNOWN`` certificate that the driver resolved to *exact* no longer
+disagrees with the run.
 """
 
 from __future__ import annotations
@@ -80,6 +96,76 @@ class SoundnessCertificate:
             raise ValueError(
                 f"refusing to build a {self.method.label} reformulation: {self.rationale}"
             )
+
+    def check_result(self, result) -> None:
+        """Post-condition: the driver's ``result`` must not out-claim this cert.
+
+        ``is_sound()`` is deliberately permissive (``RELAXATION`` / ``UNKNOWN``
+        are allowed to run), so the *driver* — not this certificate — is the
+        authority on whether a run certified optimality. This method enforces the
+        contract that ties the two together: a static ``RELAXATION`` / ``UNKNOWN``
+        certificate is allowed to return ``gap_certified=True`` **only** when the
+        driver actually proved it, and the proof always leaves a **finite dual
+        ``bound``** behind (a valid lower bound for a min-sense problem). A
+        ``gap_certified=True`` with no finite bound from such a certificate would
+        be an *unearned* certificate — exactly what a future driver that failed to
+        self-police would produce — so we raise rather than let it pass.
+
+        ``SolveResult.__post_init__`` already downgrades ``gap_certified`` when the
+        bound is absent/non-finite for a *non-infeasible* status; this is the
+        decomposition-layer backstop that also refuses the case
+        (``status="infeasible"``) that guard exempts, keeping the certificate a
+        real checked post-condition rather than documentation.
+
+        Raises
+        ------
+        AssertionError
+            If the result claims a certified gap the certificate cannot justify.
+        """
+        # PROVEN_EQUIVALENT may certify freely; HEURISTIC never reaches solve()
+        # (assert_sound refuses it). Only the permissive middle needs a backstop.
+        if self.level in (Soundness.PROVEN_EQUIVALENT, Soundness.HEURISTIC):
+            return
+        if not getattr(result, "gap_certified", False):
+            return
+        # An infeasibility certificate legitimately carries bound=None; a certified
+        # *optimality* gap from a relaxation/unknown method must show the finite
+        # dual bound the driver's proof produced.
+        if getattr(result, "status", None) == "infeasible":
+            return
+        bound = getattr(result, "bound", None)
+        try:
+            b = float(bound) if bound is not None else None
+            finite = b is not None and b == b and abs(b) < 1e300  # b == b filters NaN
+        except (TypeError, ValueError):
+            finite = False
+        if not finite:
+            raise AssertionError(
+                f"{self.method.label}: driver returned gap_certified=True from a "
+                f"{self.level.value} certificate without a finite dual bound — the "
+                "certificate cannot justify a certified optimality gap. The driver "
+                "must withhold gap_certified (report a valid bound) when it did not "
+                "prove optimality (see #391 item 1)."
+            )
+
+    def effective_level(self, result) -> Soundness:
+        """Authoritative soundness for *result*, driver-first (#391 item 1).
+
+        The stored ``level`` is the *static* estimate made before the solve; the
+        driver may resolve it. In particular GBD attaches an ``UNKNOWN``
+        certificate but, when its convexity gate proves the recourse convex,
+        returns ``gap_certified=True`` — a genuinely *exact* run. Surfacing the
+        driver's verdict avoids the user-facing disagreement where the run
+        certified optimality yet the attached certificate still reads ``UNKNOWN``.
+        Never *upgrades* past what the driver proved: a certified gap upgrades a
+        permissive certificate to ``PROVEN_EQUIVALENT``; otherwise the static
+        level stands.
+        """
+        if self.level in (Soundness.RELAXATION, Soundness.UNKNOWN) and getattr(
+            result, "gap_certified", False
+        ):
+            return Soundness.PROVEN_EQUIVALENT
+        return self.level
 
     def summary(self) -> str:
         """One-line human-readable certificate."""

--- a/python/discopt/decomposition/ir/reformulation.py
+++ b/python/discopt/decomposition/ir/reformulation.py
@@ -84,21 +84,18 @@ class DecomposedModel:
     var_map: VariableMapping
     certificate: SoundnessCertificate
     source_model: object = field(repr=False, default=None)
+    # Set by ``solve()`` to the driver's ``SolveResult`` so ``summary()`` can
+    # surface the *authoritative* soundness (the driver may resolve an UNKNOWN
+    # certificate to exact — #391 item 1). ``None`` until solved.
+    last_result: object = field(repr=False, default=None, compare=False)
 
     @property
     def num_blocks(self) -> int:
         """Number of subproblem blocks."""
         return len(self.subproblems)
 
-    def solve(self, **config):
-        """Run the coordinated solve, dispatching to the shipping driver.
-
-        Returns a ``SolveResult`` in the original variable space. ``NONE`` and
-        ``INDEPENDENT_BLOCKS`` fall back to the monolithic ``Model.solve`` (the
-        per-block *parallel* solve is Phase 6); Benders/GBD/Lagrangian dispatch to
-        their drivers with this decomposition's ``structure``.
-        """
-        self.certificate.assert_sound()
+    def _dispatch(self, **config):
+        """Run the coordinated solve and return the driver's ``SolveResult``."""
         model = self.source_model
         if self.method in (MethodKind.NONE, MethodKind.INDEPENDENT_BLOCKS):
             return model.solve(**config)
@@ -114,6 +111,29 @@ class DecomposedModel:
         if self.method is MethodKind.LAGRANGIAN:
             return solve_lagrangian(model, structure=self.structure, **config)
         raise NotImplementedError(f"no reformulation driver for {self.method.label}")
+
+    def solve(self, **config):
+        """Run the coordinated solve, dispatching to the shipping driver.
+
+        Returns a ``SolveResult`` in the original variable space. ``NONE`` and
+        ``INDEPENDENT_BLOCKS`` fall back to the monolithic ``Model.solve`` (the
+        per-block *parallel* solve is Phase 6); Benders/GBD/Lagrangian dispatch to
+        their drivers with this decomposition's ``structure``.
+
+        The soundness certificate is enforced as a **post-condition** (#391 item
+        1): after the driver returns, :meth:`SoundnessCertificate.check_result`
+        raises if a merely-``RELAXATION``/``UNKNOWN`` certificate came back
+        ``gap_certified=True`` without the finite dual bound a real proof leaves —
+        the failure mode of a future driver that did not self-police. The driver's
+        ``gap_certified`` is then the authoritative signal (see :meth:`summary`).
+        """
+        self.certificate.assert_sound()
+        result = self._dispatch(**config)
+        # Contract check: the advisory certificate must not be out-claimed by the
+        # driver. Raises on an unearned certified gap.
+        self.certificate.check_result(result)
+        self.last_result = result
+        return result
 
     def schedule(self):
         """Return the :class:`SchedulingGraph` over this decomposition's blocks."""
@@ -134,19 +154,46 @@ class DecomposedModel:
         from discopt.decomposition.parallel.comm import select_backend
 
         comm = select_backend(backend)
+        # ``execution_order()`` returns *block ids* (``ScheduledTask.block_id``),
+        # which are not guaranteed to equal list positions — only
+        # ``build_decomposition`` happens to assign ``block_id == enumerate
+        # index``. Resolve block id → position explicitly so a non-contiguous or
+        # reordered block-id set maps correctly instead of silently mis-indexing
+        # (or raising ``IndexError``). See #391 item 2.
+        pos_of_block = {sp.block_id: k for k, sp in enumerate(self.subproblems)}
+        if len(pos_of_block) != len(self.subproblems):
+            raise ValueError(
+                "map_subproblems: subproblem block_ids are not unique "
+                f"({[sp.block_id for sp in self.subproblems]}); cannot reduce "
+                "results back into block order."
+            )
         order = self.schedule().execution_order()
-        reordered = [self.subproblems[i] for i in order]
+        reordered = [self.subproblems[pos_of_block[b]] for b in order]
         exec_results = comm.map(reordered, solve_block)
         results: list = [None] * len(self.subproblems)
-        for k, i in enumerate(order):
-            results[i] = exec_results[k]
+        for k, b in enumerate(order):
+            results[pos_of_block[b]] = exec_results[k]
         return results
 
     def summary(self) -> str:
-        """Human-readable multi-line description of the decomposition."""
+        """Human-readable multi-line description of the decomposition.
+
+        Before a solve, the certificate's *static* level is shown. After a solve,
+        the driver's ``gap_certified`` is authoritative (#391 item 1): a GBD run
+        whose convexity gate resolved an ``UNKNOWN`` certificate to an exact solve
+        is reported as ``proven equivalent`` here, so the certificate no longer
+        disagrees with the run it certified.
+        """
+        cert_line = self.certificate.summary()
+        if self.last_result is not None:
+            effective = self.certificate.effective_level(self.last_result)
+            # effective_level only differs from the static level when the driver
+            # certified optimality, so this branch is exactly the driver-upgrade.
+            if effective is not self.certificate.level:
+                cert_line += f" [driver certified optimality → {effective.value}]"
         lines = [
             f"DecomposedModel: {self.method.label}",
-            f"  {self.certificate.summary()}",
+            f"  {cert_line}",
         ]
         if self.master is not None:
             lines.append(f"  {self.master.summary()}")

--- a/python/tests/test_decomposition_graph.py
+++ b/python/tests/test_decomposition_graph.py
@@ -130,6 +130,98 @@ def test_rust_kernels_reject_out_of_range_vertices():
             fn(3, [(0, 5)])  # vertex 5 is out of range for n=3
 
 
+def _normalize_scc_labels(comp):
+    """Canonicalize SCC labels to a partition signature (label-value independent).
+
+    Two labelings are equivalent iff they induce the same partition. We compare
+    the *partition* (which vertices share a component) rather than raw ids so a
+    genuine divergence is caught while a benign relabeling is not — but the Rust
+    and Python kernels also share the exact id-assignment convention, so the raw
+    lists match too (asserted separately).
+    """
+    canon: dict[int, int] = {}
+    out = []
+    for c in comp:
+        if c not in canon:
+            canon[c] = len(canon)
+        out.append(canon[c])
+    return out
+
+
+def test_cc_rust_matches_python_reference():
+    # The Rust ``decomp_connected_components`` (edge-list) must be bit-for-bit
+    # equivalent to the pure-Python edge-list reference. #391 item 4: the kernel
+    # is a future speed path for structure.py's block detection; a silent labeling
+    # divergence would change Benders/Lagrangian block detection.
+    rust = kernels._rust_kernels()
+    if rust is None:
+        pytest.skip("Rust extension not built")
+    graphs = [
+        (4, [(0, 1), (1, 2), (2, 3)]),  # single chain
+        (4, [(0, 1), (2, 3)]),  # two blocks
+        (3, []),  # all isolated
+        (5, [(0, 1), (1, 2), (2, 0), (3, 4)]),  # triangle + edge
+        (6, [(0, 1), (1, 0), (2, 3)]),  # duplicate edge + a block + isolated
+        (5, [(4, 0), (0, 2)]),  # first-seen ordering not vertex 0
+    ]
+    for n, edges in graphs:
+        got = [int(x) for x in rust.decomp_connected_components(n, edges)]
+        ref, _ = kernels._connected_components_edges_py(n, edges)
+        assert got == ref, f"CC divergence on n={n}, edges={edges}: {got} != {ref}"
+
+
+def test_scc_rust_matches_python_reference():
+    # The Rust ``decomp_strongly_connected_components`` must be bit-for-bit
+    # equivalent to the pure-Python Tarjan reference (same finalize-order id
+    # convention). #391 item 4: SCC underpins stage/dual-dependency ordering; a
+    # divergence would mis-detect mutually-dependent stages.
+    rust = kernels._rust_kernels()
+    if rust is None:
+        pytest.skip("Rust extension not built")
+    graphs = [
+        (3, [(0, 1), (1, 2), (2, 0)]),  # one cycle
+        (3, [(0, 1), (1, 2)]),  # DAG: three SCCs
+        (4, [(0, 1), (1, 0), (1, 2), (2, 3), (3, 2)]),  # two cycles, one-way link
+        (5, [(0, 1), (1, 2), (2, 0), (2, 3), (3, 4), (4, 3)]),  # nested cycles
+        (4, []),  # all singletons
+        (5, [(0, 0), (0, 1), (1, 2), (2, 1)]),  # self-loop + cycle
+    ]
+    for n, arcs in graphs:
+        got = [int(x) for x in rust.decomp_strongly_connected_components(n, arcs)]
+        ref, _ = kernels._strongly_connected_components_py(n, arcs)
+        # Same partition …
+        assert _normalize_scc_labels(got) == _normalize_scc_labels(ref), (
+            f"SCC partition divergence on n={n}, arcs={arcs}: {got} vs {ref}"
+        )
+        # … and the exact shared id convention (finalize order).
+        assert got == ref, f"SCC label divergence on n={n}, arcs={arcs}: {got} != {ref}"
+
+
+def test_cc_scc_rust_matches_python_reference_randomized():
+    # Randomized parity over many small graphs (mirrors the articulation parity
+    # test's intent for CC/SCC). #391 item 4.
+    import random
+
+    rust = kernels._rust_kernels()
+    if rust is None:
+        pytest.skip("Rust extension not built")
+    rng = random.Random(391)
+    for _ in range(200):
+        n = rng.randint(1, 9)
+        m = rng.randint(0, 2 * n)
+        undirected = [
+            (rng.randrange(n), rng.randrange(n)) for _ in range(m)
+        ]  # CC: undirected edges
+        cc_got = [int(x) for x in rust.decomp_connected_components(n, undirected)]
+        cc_ref, _ = kernels._connected_components_edges_py(n, undirected)
+        assert cc_got == cc_ref, f"CC divergence n={n}, edges={undirected}"
+
+        directed = [(rng.randrange(n), rng.randrange(n)) for _ in range(m)]  # SCC: arcs
+        scc_got = [int(x) for x in rust.decomp_strongly_connected_components(n, directed)]
+        scc_ref, _ = kernels._strongly_connected_components_py(n, directed)
+        assert scc_got == scc_ref, f"SCC divergence n={n}, arcs={directed}"
+
+
 def test_dependency_edges_star_expansion_for_wide_cliques():
     # a width-5 clique with max_clique_expand=3 becomes a star (4 edges),
     # not a full clique (10 edges).

--- a/python/tests/test_decomposition_learning.py
+++ b/python/tests/test_decomposition_learning.py
@@ -191,6 +191,45 @@ def test_instance_policy_promotes_viable_neighbor_winner():
     assert rec.candidate.method is MethodKind.BENDERS
 
 
+def test_instance_policy_flips_to_voted_viable_candidate():
+    # #391 item 3: the *positive* override — the learner's voted method IS a
+    # viable candidate (present, sound, score > 0), so the recommendation must
+    # actually FLIP from the rule-based pick to the voted one. Exercised at the
+    # policy seam with two synthetic viable candidates so the flip is deterministic
+    # and independent of what the generator cascade happens to produce.
+    from discopt.decomposition.advisor.scoring import ScoreVector
+    from discopt.decomposition.advisor.selection import RuleBasedPolicy, SelectionContext
+    from discopt.decomposition.advisor.types import Candidate, Soundness
+
+    report = StructureAnalyzer().analyze(_benders_model())
+    ctx = SelectionContext(report=report)
+
+    # Two viable candidates: BENDERS scores higher (the rule-based pick),
+    # LAGRANGIAN is viable but lower-scored.
+    benders = Candidate(MethodKind.BENDERS, None, "test", Soundness.PROVEN_EQUIVALENT)
+    lagr = Candidate(MethodKind.LAGRANGIAN, None, "test", Soundness.RELAXATION)
+    scored = [
+        (benders, ScoreVector(aggregate=1.5, confidence=1.0)),
+        (lagr, ScoreVector(aggregate=0.8, confidence=1.0)),
+    ]
+
+    # Baseline: the rule-based policy recommends BENDERS.
+    base_reco = next(r for r in RuleBasedPolicy().rank(scored, ctx) if r.recommended)
+    assert base_reco.candidate.method is MethodKind.BENDERS
+
+    # Seed the store with LAGRANGIAN winners on the identical instance → the
+    # learner votes LAGRANGIAN, which IS viable here → the pick flips.
+    store = RecordStore()
+    for i in range(4):
+        store.append(build_record([], report, MethodKind.LAGRANGIAN, timestamp=float(i)))
+    policy = InstanceBasedPolicy(store, min_records=3)
+    ranked = policy.rank(scored, ctx)
+    reco = next(r for r in ranked if r.recommended)
+    assert reco.candidate.method is MethodKind.LAGRANGIAN
+    # Exactly one candidate is recommended after the override.
+    assert sum(r.recommended for r in ranked) == 1
+
+
 # ── Phase 5 (T5.2): store auto-wires the learned policy ───────
 
 

--- a/python/tests/test_decomposition_parallel.py
+++ b/python/tests/test_decomposition_parallel.py
@@ -157,6 +157,42 @@ def test_map_subproblems_executes_big_first():
     assert order == [1, 2, 0]  # descending size
 
 
+def test_map_subproblems_handles_noncontiguous_block_ids():
+    # #391 item 2: map_subproblems must key results by block_id, not by list
+    # position. With non-contiguous/unordered block_ids, the old positional code
+    # (``self.subproblems[block_id]``) either IndexErrors or silently mis-maps.
+    from discopt.decomposition.ir.models import SubproblemModel
+
+    dcmp = analyze_decomposition(_independent_blocks_model()).decompose()
+    # Unordered, non-contiguous block ids (7 > len(subproblems)); big-first
+    # execution order will yield block ids, which must not be used as indices.
+    dcmp.subproblems = [
+        SubproblemModel(7, ("a",)),  # size 1
+        SubproblemModel(3, ("b", "c", "d")),  # size 3 → executes first
+        SubproblemModel(5, ("e", "f")),  # size 2
+    ]
+    # Each block reports its own id; results must come back in *block order*
+    # (the list order of subproblems), i.e. [7, 3, 5].
+    results = dcmp.map_subproblems(lambda sp: sp.block_id, backend="sequential")
+    assert results == [7, 3, 5]
+
+    # Execution order is still big-first (by size), independent of block id.
+    order = []
+    dcmp.map_subproblems(lambda sp: order.append(sp.block_id), backend="sequential")
+    assert order == [3, 5, 7]  # sizes 3, 2, 1
+
+
+def test_map_subproblems_rejects_duplicate_block_ids():
+    # #391 item 2: a duplicate block_id makes the block-order reduce ambiguous;
+    # refuse loudly rather than silently drop a result.
+    from discopt.decomposition.ir.models import SubproblemModel
+
+    dcmp = analyze_decomposition(_independent_blocks_model()).decompose()
+    dcmp.subproblems = [SubproblemModel(0, ("a",)), SubproblemModel(0, ("b",))]
+    with pytest.raises(ValueError, match="not unique"):
+        dcmp.map_subproblems(lambda sp: sp.block_id, backend="sequential")
+
+
 def test_map_subproblems_threads_and_sequential_agree():
     dcmp = analyze_decomposition(_independent_blocks_model()).decompose()
     seq = dcmp.map_subproblems(lambda sp: sp.size, backend="sequential")

--- a/python/tests/test_decomposition_reformulation.py
+++ b/python/tests/test_decomposition_reformulation.py
@@ -128,6 +128,103 @@ def test_certificate_relaxation_is_sound():
     cert.assert_sound()  # does not raise
 
 
+# ── #391 item 1: certificate post-condition + authoritative driver signal ──
+
+
+class _FakeResult:
+    """A driver result that *bypasses* ``SolveResult.__post_init__`` — the way a
+    non-self-policing future driver could smuggle an unearned certificate past the
+    permissive ``is_sound()`` gate."""
+
+    def __init__(self, status, gap_certified, bound):
+        self.status = status
+        self.gap_certified = gap_certified
+        self.bound = bound
+
+
+def test_check_result_raises_on_unearned_certified_gap():
+    # A RELAXATION certificate returning gap_certified=True with NO finite bound
+    # is an unearned certificate: check_result must refuse it (#391 item 1).
+    cert = SoundnessCertificate(MethodKind.LAGRANGIAN, Soundness.RELAXATION, "dual bound")
+    with pytest.raises(AssertionError, match="without a finite dual bound"):
+        cert.check_result(_FakeResult(status="optimal", gap_certified=True, bound=None))
+    with pytest.raises(AssertionError):
+        cert.check_result(_FakeResult(status="optimal", gap_certified=True, bound=float("-inf")))
+
+
+def test_check_result_accepts_proven_certified_gap():
+    # UNKNOWN certificate + driver-proved certified gap (finite bound) → allowed:
+    # this is exactly GBD's UNKNOWN→exact resolution.
+    cert = SoundnessCertificate(MethodKind.GENERALIZED_BENDERS, Soundness.UNKNOWN, "convex?")
+    cert.check_result(_FakeResult(status="optimal", gap_certified=True, bound=3.14))  # no raise
+
+
+def test_check_result_ignores_uncertified_and_infeasible():
+    cert = SoundnessCertificate(MethodKind.LAGRANGIAN, Soundness.RELAXATION, "dual bound")
+    # gap_certified=False → nothing to check.
+    cert.check_result(_FakeResult(status="feasible", gap_certified=False, bound=None))
+    # infeasibility certificate legitimately carries bound=None.
+    cert.check_result(_FakeResult(status="infeasible", gap_certified=True, bound=None))
+    # PROVEN_EQUIVALENT certificates may certify freely.
+    ok = SoundnessCertificate(MethodKind.BENDERS, Soundness.PROVEN_EQUIVALENT, "exact")
+    ok.check_result(_FakeResult(status="optimal", gap_certified=True, bound=None))
+
+
+def test_effective_level_surfaces_driver_verdict():
+    # UNKNOWN certificate whose driver certified optimality → authoritative
+    # PROVEN_EQUIVALENT (GBD UNKNOWN→exact disagreement fixed).
+    cert = SoundnessCertificate(MethodKind.GENERALIZED_BENDERS, Soundness.UNKNOWN, "convex?")
+    proved = _FakeResult(status="optimal", gap_certified=True, bound=1.0)
+    unproved = _FakeResult(status="time_limit", gap_certified=False, bound=None)
+    assert cert.effective_level(proved) is Soundness.PROVEN_EQUIVALENT
+    assert cert.effective_level(unproved) is Soundness.UNKNOWN
+    # A relaxation not certified stays a relaxation.
+    lag = SoundnessCertificate(MethodKind.LAGRANGIAN, Soundness.RELAXATION, "dual bound")
+    assert lag.effective_level(unproved) is Soundness.RELAXATION
+
+
+def test_solve_runs_postcondition_and_raises_on_bad_driver(monkeypatch):
+    # A driver that (wrongly) reports a certified gap without a bound must be
+    # caught by solve()'s post-condition, not silently trusted. Lagrangian is a
+    # RELAXATION certificate.
+    monkeypatch.setattr(
+        refmod,
+        "solve_lagrangian",
+        lambda model, **kw: _FakeResult(status="optimal", gap_certified=True, bound=None),
+    )
+    dcmp = analyze_decomposition(_coupled_model()).decompose()
+    assert dcmp.certificate.level is Soundness.RELAXATION
+    with pytest.raises(AssertionError, match="#391 item 1"):
+        dcmp.solve()
+
+
+def test_solve_records_last_result_and_summary_surfaces_verdict(monkeypatch):
+    # After a GBD solve that certified optimality, summary() must report the
+    # driver's authoritative verdict, not the stale UNKNOWN certificate.
+    monkeypatch.setattr(
+        refmod,
+        "solve_gbd",
+        lambda model, **kw: _FakeResult(status="optimal", gap_certified=True, bound=2.0),
+    )
+    m = _benders_model()
+    gbd_cand = Candidate(
+        MethodKind.GENERALIZED_BENDERS,
+        None,
+        "test",
+        Soundness.UNKNOWN,
+    )
+    dcmp = build_decomposition(m, gbd_cand)
+    # Force UNKNOWN (a nonconvex-ish path) so the driver-upgrade is observable.
+    dcmp.certificate = SoundnessCertificate(
+        MethodKind.GENERALIZED_BENDERS, Soundness.UNKNOWN, "recourse not verified convex"
+    )
+    res = dcmp.solve()
+    assert dcmp.last_result is res
+    s = dcmp.summary()
+    assert "driver certified optimality" in s
+    assert "proven_equivalent" in s
+
+
 # ── solve() dispatch (monkeypatched drivers) ───────────────────
 
 


### PR DESCRIPTION
Resolves #391 — the four Decomposition Advisor review follow-ups from #388. None
are correctness blockers: the advisor was already sound (the solve drivers +
`SolveResult.__post_init__` enforce it). These are hardening / clarity /
test-coverage items.

## Item 1 — certificate advisory-vs-docstring gap → real post-condition
**Decision: post-condition (the stronger fix), not just docstring.**
`is_sound()` stays permissive (`RELAXATION`/`UNKNOWN` may run; only `HEURISTIC`
is refused), but the certificate is now a *checked* post-condition:

- `SoundnessCertificate.check_result(result)` — called by
  `DecomposedModel.solve()` after the driver returns — **raises** if a
  `RELAXATION`/`UNKNOWN` certificate came back `gap_certified=True` without the
  finite dual `bound` a real proof leaves behind. That is exactly the false
  certificate a *future* driver that failed to self-police would emit; it now
  cannot pass silently.
- The module docstring is made honest: the certificate is *advisory*; the
  driver's `status`/`bound`/`gap_certified` is the contract.
- `effective_level(result)` + `summary()` surface the **driver's**
  `gap_certified` as authoritative, fixing the GBD `UNKNOWN → exact`
  disagreement (a GBD run whose convexity gate proved the recourse convex is now
  reported as `proven_equivalent` instead of a stale `UNKNOWN`).

Tests (`test_decomposition_reformulation.py`): unearned-certified-gap raises;
proven-certified-gap (finite bound) accepted; uncertified/infeasible exempt;
`effective_level` surfaces the driver verdict; `solve()` runs the post-condition
and raises on a bad driver; `summary()` surfaces the upgrade.

## Item 2 — `map_subproblems` block_id-as-position
Built an explicit `{block_id: position}` map; duplicate ids are refused loudly.
Regression (`test_decomposition_parallel.py`): non-contiguous/unordered block
ids reduce back into block order and execute big-first correctly (fails before
with `IndexError`/mis-map); duplicate-id rejection.

## Item 3 — learning override never positively tested
Added `test_instance_policy_flips_to_voted_viable_candidate`: two viable
candidates, rule-based picks BENDERS, the store votes LAGRANGIAN (viable here) →
the recommendation actually **flips** to LAGRANGIAN (exercises the
`_preferred_method` vote + `replace(r, recommended=...)` branch). Test-only add.

## Item 4 — Rust CC/SCC kernels unused + no parity test
**Decision: add the parity test (keep the exports), not drop.** Rationale: CC is
a live speed-path candidate for `structure.py` (which calls the *Python*
`connected_components` today), and SCC is the documented stage/dual-dependency
kernel. Added pure-Python edge-list CC (`_connected_components_edges_py`) and
iterative-Tarjan SCC (`_strongly_connected_components_py`) references as oracles,
plus a Rust↔Python parity test (fixed cases + 200 randomized graphs) mirroring
`test_articulation_rust_matches_python_reference`. Verified the parity test
actually catches a divergence (sanity-broke the Python SCC reference → test
failed). No Rust source changed.

## Verification
- `pytest -m smoke`: **565 passed, 1 skipped**
- adversarial (`-m slow test_adversarial_recent_fixes.py`): **10 passed**
- `pytest -k "decomp or benders or gbd or lagrang or advisor or learning or articulation or component"`: **217 passed, 1 skipped**
- certification suite (`-k "certification or certificate or optima_registry"`): **79 passed, 1 skipped**
- `cargo test -p discopt-core decomp`: **17 passed**
- Item-1/2 regressions confirmed fails-before / passes-after
- ruff + ruff format clean on all touched files; mypy clean on touched files
  (the only full-package mypy error is the pre-existing numpy-3.12-stub env
  artifact, unrelated)
- Cert-baseline neutrality (`JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`): all changes
  are in the opt-in `decomposition/` layer; the default `.nl` cert path is
  untouched; certification tests green → `incorrect_count == 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
