### PR TITLE
perf: bottleneck profile 2026-07-05 — easy-instance per-node cost + dual-bound stall vs BARON

### DIFF
--- a/discopt_benchmarks/scripts/profile_instance.py
+++ b/discopt_benchmarks/scripts/profile_instance.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+"""Measurement-only per-phase profiler for a single MINLPLib .nl instance.
+
+Produces a JSON record attributing wall clock to solver phases:
+parse, root processing, per-node LP, POUNCE NLP subsolves, OBBT/FBBT,
+cut separation, relaxation (re)construction, lazy imports, and JAX tracing.
+
+Modes
+-----
+clean     : no profiler; wall-clock phases from result fields + a bound trace
+            sampled via ``node_callback`` (best_bound vs time/nodes).
+cprofile  : same solve under cProfile; dumps .pstats and extracts cumulative
+            times for a fixed set of attribution buckets. cProfile adds
+            measurable overhead (~10-50% on JAX-heavy code); use the clean
+            run's wall clock for totals and this run for *shares*.
+
+Usage
+-----
+  python profile_instance.py INST.nl --time-limit 60 --mode clean --json out.json
+  python profile_instance.py INST.nl --mode cprofile --pstats out.pstats --json out.json
+  python profile_instance.py INST.nl --mode clean --second-solve   # JIT/setup tax
+  python profile_instance.py INST.nl --mode clean --dump-stack-after 70  # deadline overrun
+
+This script never modifies solver behavior beyond attaching the (optional)
+``node_callback`` trace; ``--no-trace`` disables even that for a fully
+uninstrumented run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import faulthandler
+import json
+import pstats
+import sys
+import threading
+import time
+
+
+class StackSampler:
+    """In-process sampling profiler (py-spy needs root on macOS; this doesn't).
+
+    Samples the main thread's Python stack at ``hz`` from a daemon thread and
+    aggregates collapsed stacks (``a;b;c count`` lines, flamegraph-compatible).
+    Native (Rust/C) time is attributed to the Python frame that called it.
+    Overhead is a few percent at 100-200 Hz.
+    """
+
+    def __init__(self, hz: float = 100.0):
+        self.interval = 1.0 / hz
+        self.counts: dict[str, int] = {}
+        self.n_samples = 0
+        self._stop = threading.Event()
+        self._target = threading.current_thread().ident
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self):
+        while not self._stop.is_set():
+            frames = sys._current_frames()
+            f = frames.get(self._target)
+            stack = []
+            while f is not None:
+                code = f.f_code
+                fn = code.co_filename
+                # keep paths short: last two components
+                parts = fn.replace("\\", "/").split("/")
+                short = "/".join(parts[-2:])
+                stack.append(f"{short}:{code.co_name}")
+                f = f.f_back
+            if stack:
+                key = ";".join(reversed(stack))
+                self.counts[key] = self.counts.get(key, 0) + 1
+                self.n_samples += 1
+            time.sleep(self.interval)
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        self._thread.join(timeout=2.0)
+
+    def dump(self, path: str):
+        with open(path, "w") as fh:
+            for k, v in sorted(self.counts.items(), key=lambda kv: -kv[1]):
+                fh.write(f"{k} {v}\n")
+
+
+def run(args: argparse.Namespace) -> dict:
+    t0 = time.perf_counter()
+    from discopt.modeling.core import from_nl
+
+    t_import = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    model = from_nl(args.instance)
+    t_parse = time.perf_counter() - t0
+
+    trace: list[dict] = []
+
+    def node_cb(ctx, _model):
+        trace.append(
+            {
+                "t": ctx.elapsed_time,
+                "nodes": ctx.node_count,
+                "best_bound": _f(ctx.best_bound),
+                "incumbent": _f(ctx.incumbent_obj),
+                "gap": _f(ctx.gap),
+            }
+        )
+
+    kwargs: dict = {"time_limit": args.time_limit, "gap_tolerance": 1e-4}
+    if not args.no_trace:
+        kwargs["node_callback"] = node_cb
+
+    if args.dump_stack_after:
+        faulthandler.dump_traceback_later(args.dump_stack_after, repeat=True, exit=False)
+
+    prof = None
+    if args.mode == "cprofile":
+        prof = cProfile.Profile()
+        prof.enable()
+    sampler = None
+    if args.sample_hz:
+        sampler = StackSampler(hz=args.sample_hz)
+        sampler.start()
+    t0 = time.perf_counter()
+    result = model.solve(**kwargs)
+    t_solve = time.perf_counter() - t0
+    if sampler is not None:
+        sampler.stop()
+        if args.sample_out:
+            sampler.dump(args.sample_out)
+    if prof is not None:
+        prof.disable()
+    if args.dump_stack_after:
+        faulthandler.cancel_dump_traceback_later()
+
+    rec: dict = {
+        "instance": args.instance,
+        "mode": args.mode,
+        "time_limit": args.time_limit,
+        "import_s": t_import,
+        "parse_s": t_parse,
+        "solve_s": t_solve,
+        "status": str(result.status),
+        "objective": _f(result.objective),
+        "bound": _f(result.bound),
+        "gap": _f(result.gap),
+        "node_count": result.node_count,
+        "root_time_s": _f(result.root_time),
+        "root_bound": _f(result.root_bound),
+        "root_gap": _f(result.root_gap),
+        "rust_time": _f(result.rust_time),
+        "jax_time": _f(result.jax_time),
+        "python_time": _f(result.python_time),
+        "solver_stats": result.solver_stats,
+        "trace": trace if not args.no_trace else None,
+    }
+
+    if args.second_solve:
+        t0 = time.perf_counter()
+        r2 = model.solve(time_limit=args.time_limit, gap_tolerance=1e-4)
+        rec["second_solve_s"] = time.perf_counter() - t0
+        rec["second_solve_nodes"] = r2.node_count
+
+    if prof is not None:
+        if args.pstats:
+            prof.dump_stats(args.pstats)
+        rec["buckets"] = extract_buckets(prof)
+
+    return rec
+
+
+def _f(v):
+    """JSON-safe float (None for None/inf/nan kept as-is where representable)."""
+    if v is None:
+        return None
+    try:
+        v = float(v)
+    except (TypeError, ValueError):
+        return str(v)
+    return v if v == v and abs(v) != float("inf") else str(v)
+
+
+# Attribution buckets: (label, match on (filename, lineno, funcname), use_cumtime).
+# Builtin/C functions are keyed as ('~', 0, '<name>') by pstats. For C entries
+# cumtime includes Python callbacks re-entered from Rust (pounce evaluates
+# objective/jacobian via JAX callbacks), so both cum and tot are reported.
+BUCKETS = [
+    ("pounce_problem_solve", lambda f, n: f == "~" and "pounce" in n and "solve" in n),
+    ("pounce_module_fn", lambda f, n: f == "~" and "pounce._pounce" in n and "solve" not in n),
+    ("rust_lp_solve", lambda f, n: f == "~" and "discopt._rust.solve_lp" in n),
+    ("rust_other", lambda f, n: f == "~" and "discopt._rust" in n and "solve_lp" not in n),
+    ("build_milp_relaxation", lambda f, n: n == "build_milp_relaxation"),
+    ("solve_at_node", lambda f, n: n == "solve_at_node"),
+    ("lp_relaxer_solve", lambda f, n: "milp_relaxation" in f and n == "solve"),
+    ("obbt_root", lambda f, n: "obbt.py" in f and n == "obbt_tighten_root"),
+    ("obbt_node", lambda f, n: "obbt.py" in f and n in ("obbt_tighten_node", "obbt_tighten")),
+    ("feasibility_pump", lambda f, n: n == "feasibility_pump"),
+    ("primal_heuristics_mod", lambda f, n: "primal_heuristics" in f),
+    ("nlp_pounce_solve_nlp", lambda f, n: "nlp_pounce" in f and n == "solve_nlp"),
+    ("qp_pounce", lambda f, n: "qp_pounce" in f),
+    ("jax_trace", lambda f, n: "partial_eval" in f and n == "trace_to_jaxpr"),
+    ("jax_pjit_cache_miss", lambda f, n: "pjit" in f and n == "cache_miss"),
+    ("lazy_imports", lambda f, n: "importlib" in f and n == "_find_and_load"),
+    ("scipy_sparse", lambda f, n: "scipy/sparse" in f),
+]
+
+
+def extract_buckets(prof: cProfile.Profile) -> dict:
+    st = pstats.Stats(prof)
+    out: dict[str, dict] = {}
+    for (fname, _lineno, funcname), (_cc, nc, tt, ct, _callers) in st.stats.items():
+        for label, match in BUCKETS:
+            try:
+                hit = match(fname, funcname)
+            except Exception:
+                hit = False
+            if hit:
+                b = out.setdefault(label, {"ncalls": 0, "tottime": 0.0, "cumtime": 0.0})
+                b["ncalls"] += nc
+                b["tottime"] += tt
+                # cumtime across multiple matched frames of one bucket can
+                # double-count nesting within the bucket; still the best
+                # available upper estimate per bucket.
+                if label == "rust_lp_solve":
+                    b["cumtime"] += ct
+                else:
+                    b["cumtime"] = max(b["cumtime"], ct)
+    total = pstats.Stats(prof).total_tt
+    out["_total_profiled_s"] = total
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("instance")
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    ap.add_argument("--mode", choices=["clean", "cprofile"], default="clean")
+    ap.add_argument("--pstats", default=None, help="dump raw pstats here (cprofile mode)")
+    ap.add_argument("--json", dest="json_out", default=None)
+    ap.add_argument("--no-trace", action="store_true", help="do not attach node_callback")
+    ap.add_argument("--second-solve", action="store_true", help="solve twice; JIT/setup tax")
+    ap.add_argument("--sample-hz", type=float, default=None, help="in-process stack sampler rate")
+    ap.add_argument("--sample-out", default=None, help="collapsed-stack output file")
+    ap.add_argument(
+        "--dump-stack-after",
+        type=float,
+        default=None,
+        help="faulthandler stack dump every N seconds (deadline-overrun diagnosis)",
+    )
+    args = ap.parse_args()
+
+    rec = run(args)
+    text = json.dumps(rec, indent=1)
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            fh.write(text)
+    # Keep stdout terse: summary line only (trace can be thousands of entries).
+    summary = {k: v for k, v in rec.items() if k not in ("trace", "buckets")}
+    print(json.dumps(summary, indent=1))
+    if "buckets" in rec:
+        print(json.dumps(rec["buckets"], indent=1))
+    if rec.get("trace"):
+        tr = rec["trace"]
+        print(f"trace: {len(tr)} nodes; first={tr[0]} last={tr[-1]}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/bottleneck-profile-2026-07-05.md
+++ b/docs/dev/bottleneck-profile-2026-07-05.md
@@ -1,0 +1,448 @@
+# Bottleneck profile — 2026-07-05 (easy-instance per-node cost + dual-bound stall vs BARON)
+
+**Date:** 2026-07-05
+**Status:** measured (measurement-only; no production code changed)
+**Scope:** the two problem classes the 2026-07-05 BARON comparison
+(`reports/global_opt_baron_vs_discopt_2026-07-05T10-47-11.json`, 61 MINLPLib
+instances, 60 s) exposed: **Class A** (massive apparent per-node cost on
+instances BARON solves in <1 s: fac2, nvs01, m3, nvs13) and **Class B**
+(correct incumbent, dual bound doesn't close: flay03m, st_e36, tls2, nvs05,
+nvs09, hda, clay0303hfsg). Also: the budget-overrun mechanism (contvar,
+heatexch_gen3) and the fixed JIT/setup tax.
+**Referenced by:** follows `docs/dev/bottleneck-profile-2026-07-02.md` (B1–B6)
+and the Phase-D sections of `docs/dev/certification-gap-plan.md` (§8, dated
+2026-07-05). This pass explicitly tests the user challenge to the Phase-D
+conclusion: *"POUNCE is not that much slower than Ipopt, especially on smaller
+problems — there must be substantial room on the discopt side."*
+
+> **Method.** Branch `perf-profile-2026-07-05` at `origin/main` (31683a25).
+> Apple M4 Pro (14-core, arm64), Python 3.12.11, JAX 0.10.2 (`JAX_PLATFORMS=cpu`,
+> `JAX_ENABLE_X64=1`), pounce **0.7.0** (note: Phase-D used 0.8.0), numpy 2.5.1,
+> scipy 1.18.0, `maturin develop --release`. Instances from
+> `python/tests/data/minlplib_nl/`, `from_nl(path).solve(time_limit=60,
+> gap_tolerance=1e-4)`. Three independent measurement modes per instance via
+> `discopt_benchmarks/scripts/profile_instance.py` (new, reusable):
+> 1. **clean** — uninstrumented wall + `SolveResult` phase fields
+>    (`root_time`, `root_bound`, T0.3 `solver_stats` timers) + a
+>    `node_callback` bound/incumbent trace (verified node-count-neutral on
+>    nvs13: 19 nodes, identical objective, with and without the callback);
+> 2. **cprofile** — full cProfile with fixed attribution buckets (C-extension
+>    entries included, so POUNCE/Rust builtins are timed directly); overhead
+>    vs clean ≈ +10–85 % depending on Python-callback density — used for
+>    *shares*, never for totals;
+> 3. **sampled** — in-process 100 Hz stack sampler (py-spy needs root on
+>    macOS and was unusable; the sampler is `--sample-hz` in the same script).
+>    Native time is attributed to the calling Python frame.
+> `faulthandler.dump_traceback_later` (`--dump-stack-after`) gave mid-run
+> stacks for the deadline-overrun runs. Raw artifacts (JSON, pstats, collapsed
+> stacks) were produced in the session scratchpad; the durable numbers are
+> below.
+
+> **Reproducibility caveat (honesty).** On this machine two "Class B" probes
+> from the 07-05 report actually **certify inside the budget**: flay03m
+> `optimal` in 46.5 s / 111 nodes (report: time-limit, 18.4 % gap, 69 nodes)
+> and clay0303hfsg `optimal` in 25.6 s / 229 nodes (report: time-limit,
+> 19.1 % gap). The report run was evidently slower per unit work (load /
+> different machine); the *shape* of where time goes is stable across all
+> three measurement modes here, and the class conclusions do not depend on
+> whether the 60 s line is crossed. fac2/nvs01/m3/nvs13/st_e36/tls2/nvs05/
+> nvs09/hda reproduce the report's statuses.
+
+---
+
+## 1. Executive summary — ranked bottlenecks (measured)
+
+**The POUNCE-hypothesis verdict up front:** the user's challenge is
+**confirmed for Class A and for most of Class B**. On the profiled panel,
+POUNCE's *per-solve* latency is 10–64 ms — unremarkable for these problem
+sizes and nowhere near the 0.5–2.3 s/solve outliers of the Phase-D
+(ex1252a/heatexch_gen1) class. Where POUNCE seconds dominate the wall, the
+driver is **call volume commanded by discopt-side policy** (thousands of
+heuristic sub-NLPs), not subsolver speed. Two instances (nvs01, st_e36) are
+dominated by the **in-house Rust simplex**, with POUNCE at 15 %/22 %. The
+Phase-D claim "the POUNCE subsolver is the #1 wall lever" does **not**
+transfer to these classes (§5).
+
+Ranked bottlenecks:
+
+1. **B7 — Unbudgeted LNS `local_branching` enumeration** (Class A fac2;
+   Class B flay03m, and via RENS the root of tls2). `_lns_k_schedule =
+   (2, 5, 10)`; with 12 binaries the enumeration path of
+   `primal_heuristics.local_branching` issues `sum(C(12,r), r=0..k)` full
+   POUNCE sub-NLPs: **79 at k=2, 1586 at k=5**. Measured: fac2 = 1665 subnlp
+   calls (= exactly 79+1586) / **22.2 s of a 23.5 s solve (85.8 % of samples)**;
+   flay03m = 3330 calls (= 2×1665) / **48.9 s of 46.5–52.5 s (96.5 % of
+   samples)**. The caller passes a ≤2 s slice (`submip_time_limit=_lb_slice`)
+   but the ≤`max_binaries` enumeration branch **ignores any time budget and
+   never polls the deadline** — a k=5 call runs ~22 s against an intended 2 s
+   slice, even when the incumbent is already the known optimum (it was, on
+   both). Counterfactual `rens=False` does *not* fix it (fac2 27.3 s,
+   flay03m 91.7 s): the same enumeration migrates to the in-tree LNS call
+   site. The fix has to be at `local_branching` itself.
+2. **B8 — Rust dual-simplex warm-restart stall** (nvs01; also the st_e36
+   volume cost). nvs01: of 41 `solve_lp_warm_std` calls totalling 17.5 s,
+   **two warm re-solves take 8.71 s and 8.70 s each** on a 117×25 / 118×25
+   tangent-augmented LP (the other 39 calls: 4–6 ms). That is **79 % of
+   nvs01's 22.0 s wall**, inside `_separate_univariate_square`'s
+   append-rows-and-re-solve loop. st_e36: 2 398 warm-simplex calls at
+   13.3 ms mean = 31.9 s = **53 % of wall** on a 2-variable problem (85 % of
+   wall under `solve_at_node`, incl. relaxation rebuilds).
+3. **B9 — Separation re-solve volume, and one separator still on the POUNCE
+   LP IPM** (nvs09, st_e36, nvs01). nvs09: **92.6 % of 60 s** is
+   `_separate_multilinear` → **`lp_pounce._solve_core`** (99.5 % of that
+   separator's samples) — the multilinear separator's per-round re-solves go
+   through the POUNCE LP IPM on this path; the #484 Phase-D routing
+   (`DISCOPT_SEPARATION_LP_SIMPLEX`, default ON) covered edge-concave +
+   strong-branching only. This is the "if separation LPs STILL dominate,
+   that's news" case. st_e36/nvs01: same 8-round separate-and-re-solve
+   pattern through the warm simplex (B8).
+4. **B10 — Root-phase heuristic/NLP binge on the "no relaxation" flowsheet
+   class** (hda, contvar, heatexch_gen3; root = 66–100 % of wall). hda:
+   root 42–51 s of 64 s = Rust `PyModelRepr.presolve` **15.1 s in one
+   call** + 21 root multistart POUNCE NLPs at ~600–780 ms (12.6 s tottime,
+   20.4 s incl. JAX callbacks) + ~10.4 s JAX trace/dispatch (11 419 pjit
+   cache misses, 784 traces) — and the MILP relaxation **omits 23
+   constraints** ("cannot linearize log(...)/x**expr"), so there is **no
+   dual bound at all** (`best_bound = 1e30` sentinel for all 7 nodes).
+   contvar/heatexch_gen3 are the same class (§4: budget overrun).
+5. **B11 — Weak root relaxation on specific structures** (Class B bound
+   stalls; §3). st_e36's root bound (−304.5) is **bit-identical** for
+   x1 ∈ [15,25] and x1 ∈ [24,25] — the pinning term's envelope is independent
+   of the integer's box; only *fixing* x1 lifts it (fix x1=22 → certifies in
+   5 nodes; 897 unfixed nodes go nowhere). nvs05/tls2/nvs09 root gaps
+   87.7 % / 86.4 % / 69.0 % with slow-but-real climbs; clay0303hfsg root
+   bound pinned at ~0 (big-M gated objective) for ~100 nodes, then climbs
+   and certifies.
+6. **B12 — POUNCE as the per-node NLP bound engine** (nvs05, tls2 — the one
+   sub-class where the subsolver itself is the direct cost). nvs05: 834
+   node-NLP `_attempt` calls = 53.3 s ≈ **64 ms/solve, 91 % of wall**; tls2:
+   1497 node NLPs at 29 ms = 70 % of wall. Per Phase-D's own A/B (median
+   7–11× vs Ipopt), an Ipopt-class engine would cut this to roughly 5–9 s
+   (nvs05) — worth having — but the root gap (87.7 %) is what makes the node
+   count high in the first place.
+7. **Fixed setup tax** (visible only on trivial instances): `import discopt`
+   0.10–0.14 s + **lazy imports inside the first `solve()` 0.4–0.6 s** +
+   JIT/warmup ≈ 0.5 s (m3 second in-process solve: 3.41 s → 2.88 s, same 61
+   nodes). Net of tax, m3 is still ~2.7 s vs BARON 0.04 s — the gap is real
+   work (B7/B12-class), not tax.
+
+**Where the prior "per-node cost" framing was wrong:** fac2's benchmark line
+(32.5 s / 69 nodes ≈ 0.47 s/node) is a mis-attribution. Measured: root
+processing = **22.1 s (94 %)**, B&B loop = 1.4 s / 69 nodes = **20 ms/node**,
+already at the 0.018 s/node cert-gate target. Same for tls2 (root 25.5 s;
+tree 18 ms/node × 1903 nodes) and clay0303hfsg (root 12.2 s = 48 %). nvs01's
+"1.3 s/node" is actually two 8.7 s LP calls (B8).
+
+### POUNCE wall-share vs per-solve latency (the hypothesis test, per instance)
+
+| instance | POUNCE incl. callbacks (cum) | pure-Rust IPM (tottime) | calls | ms/solve | dominant caller | verdict |
+|---|---:|---:|---:|---:|---|---|
+| fac2 | 23.3 s (80 %) | 15.8 s (54 %) | 1 744 | 13.4 | LNS `subnlp` (1 665) | **volume, not speed** |
+| flay03m | 49.4 s (94 %) | 34.2 s (65 %) | 3 557 | 13.9 | LNS `subnlp` (3 330) | **volume, not speed** |
+| tls2 | 43.8 s (70 %) | 29.2 s (47 %) | 1 516 | 28.9 | node NLPs (1 497) | volume + engine |
+| nvs05 | 55.1 s (91 %) | 32.5 s (54 %) | 1 206 | 45.7 | node NLPs (834 @ 64 ms) | **engine (B12)** |
+| m3 | 2.8 s (60 %) | 1.6 s (35 %) | 258 | 10.7 | node NLPs (204) | volume, small |
+| hda | 20.4 s (30 %) | 12.6 s (19 %) | 21 | ~600–780 | root multistart | engine on 722 vars |
+| st_e36 | 13.4 s (22 %) | 11.5 s (19 %) | 1 928 | 7.0 | mixed | **not POUNCE (B8/B9)** |
+| nvs01 | 3.5 s (15 %) | 2.6 s (11 %) | 430 | 8.1 | heuristics | **not POUNCE (B8)** |
+| nvs13 | 0.48 s (19 %) | 0.13 s (5 %) | 44 | 10.9 | node NLPs | not POUNCE |
+| nvs09 | ~4.8 % of samples | — | — | — | — | **not POUNCE-NLP (B9: `lp_pounce` LP-IPM 92.6 %)** |
+
+(Shares are of the cProfile-profiled total; sampler cross-checks on fac2
+[88.6 % pounce frames], flay03m [98.0 %], st_e36 [24.0 %], nvs09 [4.8 %]
+agree within a few points.)
+
+**Verdict, stated plainly:** on Class A the prior "POUNCE is the residual
+bottleneck" conclusion is **falsified** — fac2/m3/nvs13 POUNCE per-solve is
+10–14 ms (near-Ipopt territory for these sizes) and nvs01 is a simplex
+pathology; the room is on the discopt side, as the user hypothesized. On
+Class B it is falsified for flay03m (heuristic volume), st_e36 (simplex +
+separation volume), and nvs09 (separation LP-IPM routing), and **survives
+only in a refined form** on nvs05/tls2 (per-node NLP engine, 29–64 ms/solve)
+and hda's 722-var root NLPs — the class where Phase-D's Ipopt A/B actually
+measured it.
+
+---
+
+## 2. Per-instance phase breakdown
+
+Wall/phase columns from the **clean** runs; attribution shares from
+cProfile + sampler. "tree ms/node" = (solve − root_time)/nodes.
+
+### Class A
+
+| phase | fac2 | nvs01 | m3 | nvs13 |
+|---|---:|---:|---:|---:|
+| total wall (clean) | 23.45 s | 21.97 s | 3.25 s | 1.51 s |
+| `from_nl` parse | 0.002 s | 0.002 s | 0.002 s | 0.007 s |
+| root processing (`root_time`) | 22.06 s (94 %) | 4.09 s (19 %) | 1.95 s (60 %) | 0.91 s (60 %) |
+| B&B loop | 1.39 s | 17.88 s | 1.30 s | 0.60 s |
+| nodes / tree ms-per-node | 69 / **20 ms** | 17 / 1 052 ms | 61 / 21 ms | 19 / 32 ms |
+| status / verdict | optimal, exact | optimal, exact | optimal, exact | optimal, exact |
+| BARON wall | 0.04 s | 0.1 s | 0.04 s | 0.1 s |
+
+Attribution (share of profiled wall):
+
+- **fac2** (convex-quadratic objective + quadratic constraints; routed through
+  the generic `_solve_nlp_bb`, *not* the convex-MIQP fast path, which gates on
+  `problem_class == MIQP` — fac2's nonlinear constraints exclude it):
+  POUNCE-cum 80 % — of which `rens` → nested `_solve_nlp_bb` → LNS
+  `local_branching` → 1 665 `subnlp` calls = 22.2 s. The *entire* Class-A
+  story is one root RENS call whose sub-solve runs two enumeration rounds
+  (k=2: 79, k=5: 1 586). Remainder: JIT 0.75 s, lazy imports 0.54 s.
+- **nvs01**: `rust_lp_solve` 17.5 s (75 %): 41 calls, **two at 8.7 s each**
+  (warm dual-simplex re-optimization after `_separate_univariate_square`
+  appended tangent rows; LP is 117–118 rows × 25 cols; all other calls
+  4–6 ms). T0.3 timer agrees: `separate/univariate_square` = 17.45 s.
+  POUNCE 15 %.
+- **m3**: POUNCE 60 % (204 node NLPs @ 11.6 ms + 49 diving); JIT 0.48 s;
+  lazy imports 0.43 s. Root 1.95 s = multistart + root separation; root
+  bound starts at ~0 (pinned, gear4-style) and climbs to optimal by node 61.
+- **nvs13**: `solve_at_node` 42 % (of which `build_milp_relaxation` 34 % —
+  30 calls @ 29 ms on a 5-var problem), rust LP 16 %, POUNCE 19 %, lazy
+  imports 17 %, JIT 18 %. At 1.5 s total, the fixed taxes are ~⅔ of the
+  BARON gap.
+
+### Class B
+
+| phase | flay03m | st_e36 | tls2 | nvs05 | hda |
+|---|---:|---:|---:|---:|---:|
+| total wall (clean) | 46.5 s | 60.1 s (TL) | 60.3 s (TL) | 60.1 s (TL) | 64.1 s (TL) |
+| root processing | 22.4 s (48 %) | 2.6 s (4 %) | 25.5 s (42 %) | 3.2 s (5 %) | 42.0 s (66 %) |
+| B&B loop | 24.1 s | 57.5 s | 34.8 s | 56.9 s | 22.1 s |
+| nodes / tree ms-per-node | 111 / 217 ms | 897 / 64 ms | 1 903 / **18 ms** | 821 / 69 ms | 7 / 5 525 ms |
+| dominant sink (share) | LNS subnlp 94 % | simplex 53 % + sep 28 % | POUNCE 70 % | node NLPs 91 % | presolve 22 % + POUNCE 30 % + JAX ~15 % |
+| status | optimal here | feasible, gap 23.8 % | feasible at 58.7 s | feasible, gap open | no incumbent, no bound |
+| BARON wall | 0.3 s | 0.1 s | 0.04 s | 0.6 s | 0.2 s |
+
+- **flay03m**: root 22.4 s = RENS (24.2 s cum) with the same LNS enumeration
+  inside; the 23.5 s mid-search "stall" (bound flat at 40.0, nodes 49→87) is
+  in-tree LNS calls, not bound trouble — the bound then climbs and
+  **certifies at node 111**. Root gap 36.8 % (root bound 30.98 vs 48.99) is
+  real but survivable: nodes are ~20 ms without the heuristic tax.
+- **st_e36** (2 vars, x1 integer [15,25]): 85 % under `solve_at_node`; rust
+  simplex 31.9 s tottime (2 398 calls) + `build_milp_relaxation` 9.2 s
+  (506 calls) + POUNCE 13.4 s. `separate/multilinear` = 11.65 s (T0.3).
+  Bound: see §3.
+- **tls2**: root 25.5 s (RENS/feasibility hunt: `primal_heuristics` 26.6 s
+  cum); tree itself runs at 18 ms/node and the bound climbs steadily
+  0.72 → 5.2 (opt 5.3) — with the root tax removed it would have closed at
+  roughly the same node count. `rens=False` counterfactual: 41.1 s.
+- **nvs05**: 91 % node NLPs (834 @ 64 ms, incl. retry-from-alternative-start
+  policy: ~1.6 NLP per node with `subnlp` extras). Root gap 87.7 %; bound
+  climbs 0.67 → 5.32 (trace) but the **reported** final bound is 1.35 (see
+  §6 anomaly).
+- **hda** (722 vars): root 42–51 s = 15.1 s Rust presolve (one call) +
+  21 multistart POUNCE NLPs (~600–780 ms each) + one 8.05 s `subnlp` +
+  ~10.4 s JAX pjit dispatch/trace (11 419 cache misses / 784 traces — this
+  class **does** re-trace; §5) + rust LP/MILP 10 s. 23 constraints omitted
+  from the relaxation → no dual bound ever (sentinel 1e30) → nothing can
+  fathom; 7 nodes at TL. Python churn is also visible (366 791
+  `np.asarray`, 32.2 M `core.py:size` calls = 3.3 s + 0.8 s).
+
+---
+
+## 3. Class B — root gap and the binding deficiency
+
+"Moves?" = does the global dual bound improve during the 60 s budget.
+
+| instance | root bound | known opt | root gap | bound at TL (trace) | moves? | binding deficiency (evidence) |
+|---|---:|---:|---:|---:|---|---|
+| flay03m | 30.984 | 48.9898 | 36.8 % | 48.99 (certified @111 nodes, 46.5 s) | yes | **(none — heuristic tax B7 masks a working search).** Root gap from big-M/McCormick-div is real but the tree closes it in ~1 s of actual node work. |
+| st_e36 | −304.500 | −246.0 | 23.8 % | −304.498 after 897 nodes | **no** | **(a) envelope pinning.** Root bound bit-identical (−304.5000003055) for x1 ∈ [15,25], [20,25], and [24,25]; only *fixing* lifts it: x1=22 → root −278.9, certifies in 5 nodes; box [5,5.5]×[20,22] → root = −246.0000 exactly. The pinning term's under-envelope (nested `pow(·,2)` composites with negative coefficients) is independent of the integer's interval, so no amount of interval branching moves the bound. |
+| tls2 | 0.718 | 5.3 | 86.4 % | 5.2 | yes, steadily | **(root-cost starvation + envelope).** 42 % of budget burned at root; tree itself climbs 0.72→5.2 at 18 ms/node. sqrt/mult structure; bound would close with ~2× more node budget. |
+| nvs05 | 0.674 | 5.4709 | 87.7 % | 5.32 (trace) / 1.35 (reported — §6) | yes, slowly | **(a)+(engine).** Loose product/power envelopes give an 87.7 % root gap; 64 ms/node POUNCE NLPs (B12) cap throughput at ~14 nodes/s. |
+| nvs09 | −72.900 | −43.134 | 69.0 % | −59.24 @159 nodes | yes, slowly | **(c) separation cost, not cut absence:** 92.6 % of wall is the multilinear separator's LP re-solves through `lp_pounce._solve_core` (B9) → ~2.6 nodes/s. The cuts work (bound climbs every trace sample); they are just catastrophically expensive to separate. |
+| hda | none (1e30) | −5964.5 | ∞ | none | n/a | **(a′) relaxation coverage:** 23 rows omitted ("cannot linearize `log(<general expr>)` / `x**expr`") → no dual bound exists; plus B10 root binge. BARON reports this instance infeasible in 0.2 s (its own issue); discopt neither bounds nor finds a point. |
+| clay0303hfsg | ≈ 0 (−1.2e−5) | 26 669.1 | ~100 % | 26 669.1 (certified @229 nodes, 25.6 s) | yes (after ~100 nodes flat) | **(d)-flavored:** big-M/disjunctive structure — objective gated by binaries, root bound structurally pinned at 0 (gear4-pattern per performance-plan §6); bound lifts only once enough binaries are branched. Root cost 12.2 s (48 %) on top. |
+
+Two structural sub-classes for the bound stalls:
+
+- **Pinned-at-a-constant** (st_e36, clay0303hfsg, m3's root, gear4 from the
+  06-24 record): the root relaxation value is a structural constant that
+  interval-shrinking cannot lift — only fixing (st_e36) or branching the
+  gating binaries (clay) moves it. For st_e36 this is an *envelope* defect
+  (fix class: even-power composite envelopes); for clay/gear4 it is the
+  known branch-and-reduce gap (cert-gap-plan C2).
+- **Loose-but-live** (nvs05, tls2, nvs09): the bound climbs monotonically;
+  wall per node (B8/B9/B12) is what prevents closure inside 60 s.
+
+FLay/CLay big-M check (asked in the brief): flay03m's nonlinearity is only 3
+`div` rows (area constraints); the rest is linear big-M rows. discopt's tree
+handles them adequately *once it gets CPU* (111/229 nodes to certify); the
+big-M weakness shows up as the pinned root bound (clay: 0; flay: 30.98), not
+as an unsolvable tree. BARON's <1 s comes from a tight root (its probing +
+big-M-aware bounds), but with B7 removed the discopt gap on flay03m is
+~5 s vs 0.3 s, not 64 s vs 0.3 s.
+
+---
+
+## 4. Budget overrun (contvar 221 s, heatexch_gen3 81.5 s vs a 60 s limit)
+
+Measured with `--dump-stack-after 70` (faulthandler, repeat):
+
+- **contvar**: `solve()` returned after **221.0 s** (root_time = 220.9 s).
+  All three dumps (t = 70/140/210 s) show the identical stack:
+  `solve_model` (solver.py:6068) → `feasibility_pump`
+  (primal_heuristics.py:290) → `nlp_pounce.solve_nlp` → POUNCE Hessian
+  callback → `sparse_hessian.sparse_hess_values` (line 162) → **XLA
+  `backend_compile_and_load`**. The overrun is a single, uninterruptible
+  first-time XLA compilation of the sparse Hessian for the root
+  feasibility-pump NLP (~150 s+ of compile on this 297-var/flowsheet model).
+  No deadline poll can fire inside `jit` compilation, and the POUNCE
+  `max_wall_time` option cannot help either — the time is spent inside one
+  Python callback, before the solver iterates.
+- **heatexch_gen3**: same class — 81.5 s, root_time = 81.1 s, the t = 70 s
+  dump is inside `nlp_pounce.solve_nlp:148` (jax_time = 58.8 s). No bound
+  (1e30 sentinel; AMP-style constraint omissions like contvar/hda).
+
+So the loop that "fails to poll the deadline" is not a loop: it is the root
+heuristic's NLP solve whose *first Hessian evaluation* compiles for longer
+than the whole budget. Any fix must gate *entering* the compile (estimate or
+budget-check before requesting the Hessian path / choose a Hessian-free
+fallback when the remaining budget is small), not poll inside it.
+
+---
+
+## 5. Falsifications & corrections of prior claims
+
+Per performance-plan §6 house style — superseded claims recorded, not
+overwritten:
+
+1. **"Phase D: the POUNCE subsolver is the #1 wall lever"**
+   (certification-gap-plan §8, 2026-07-05). *Correction:* true only for the
+   NLP-heavy class it was measured on (ex1252a/heatexch_gen1/casctanks) and,
+   in refined form, for nvs05/tls2/hda root NLPs. On the easy Class A and on
+   flay03m/st_e36/nvs09 the #1 levers are discopt-side: unbudgeted LNS
+   enumeration (B7), simplex warm-restart stall (B8), and separation
+   re-solve volume/routing (B9). POUNCE per-solve on these instances is
+   7–64 ms — the pooled "median ~7× vs Ipopt" does not make it the wall
+   driver when the calls are 13 ms and number in the thousands *by policy*.
+2. **"XLA compilation: resolved (≤1 % of wall), 0 recompiles across
+   boxes"** (bottleneck-profile-2026-07-02 §2). *Correction:* verified there
+   for the gear4/nvs17 class and still true for it — but it does **not
+   generalize**: hda re-traces per solve family (784 traces / 11 419 pjit
+   cache misses, ~10.4 s ≈ 15 %), and contvar spends >150 s (>68 % of its
+   run) inside a single `backend_compile_and_load` (§4). The compile-cache
+   win is class-local.
+3. **"OBBT inner loop is the dominant orchestration cost"**
+   (bottleneck-profile-2026-07-02 §1 item 1). *Not contradicted, but not
+   general:* on all 11 instances profiled here OBBT is ≤4 % (obbt_root
+   ≤1.0 s everywhere). The 07-02 statement holds for its spatial panel only.
+4. **The benchmark report's per-node framing for Class A** ("fac2 0.47 s/node,
+   nvs01 1.3 s/node"). *Correction:* fac2 tree = 20 ms/node (94 % of wall is
+   the root RENS/LNS binge); nvs01 = two 8.7 s LP calls, not uniform node
+   cost. "s/node = wall/nodes" is a misleading metric when root/heuristic
+   phases dominate; gates should use root-phase and tree-phase timers
+   (T0.3) separately.
+5. **"cold simplex ≈ 1 840 µs average"** (07-02 §1 item 2) as a
+   characterization of simplex cost. *Refinement:* the tail, not the mean,
+   is the problem — a warm dual-simplex re-optimization after row appends
+   can take **8.7 s** on a 118×25 LP (nvs01, twice). Averages hide the
+   pathology.
+6. **Phase-D LP routing "shipped default-ON" closing the separation-LP
+   story** (#484). *Correction:* the multilinear separator still drives
+   its re-solves through `lp_pounce._solve_core` on the nvs09 path
+   (92.6 % of that instance's wall). The flag covered edge-concave and
+   strong-branching call sites only.
+
+---
+
+## 6. Observations out of scope (flagged, not fixed)
+
+- **Reported bound ≪ tree bound on nvs05:** the `node_callback` trace ends
+  with `best_bound = 5.32`, but `SolveResult.bound = 1.348` (gap reported
+  75.4 % instead of ~2.7 %). Either the frontier bound is not being adopted
+  into the final result on this path, or the callback's `best_bound` is not
+  the certified global bound. Both readings matter for benchmark scoring —
+  worth a correctness-side look (docs/dev/correctness-issues.md candidate).
+- **`best_bound = 1e30` sentinel** leaks into the `node_callback` API on
+  the no-relaxation class (hda/heatexch_gen3) instead of `None`/`-inf`.
+- **hda Python churn:** 32.2 M `core.py:size` calls / 21 M `abs` calls in a
+  67 s solve (term_classifier / relaxation walk) — ~2 s, secondary to B10
+  but a sign of per-call DAG re-walks on big models.
+
+---
+
+## 7. Fix candidates, ranked by measured expected wall-clock win
+
+Ordered by (expected win on the measured panel) × (confidence). Regimes per
+CLAUDE.md: *bound-neutral* changes must keep node_count/objective exactly
+unchanged; heuristic-policy changes touch incumbent discovery (node counts
+may legitimately change) but never the dual bound — they still face the
+`incorrect_count ≤ 0` panel gate.
+
+1. **F1 — Give `local_branching`'s enumeration path a real budget** (B7).
+   Mechanism: poll `deadline`/slice inside the flip loop; when
+   `sum_r C(n_bin, r) × ~14 ms` exceeds the slice, truncate or dispatch to
+   the existing `_local_branching_submip` (which already takes
+   `time_limit`). Affects: fac2, flay03m, tls2 root, every ≤12-binary
+   instance with an early incumbent. Expected (from component arithmetic,
+   not vibes): fac2 23.5 s → ~2.5–5 s (root 1.0 s [measured with rens off] +
+   tree 1.4 s + capped heuristics ≤2 s/call); flay03m 46.5 s → ~7–12 s;
+   tls2 −20 s at root. Note the `rens=False` counterfactual (fac2 27.3 s,
+   flay03m 91.7 s) proves disabling callers just relocates the cost — the
+   budget must live in the enumeration itself. Risk: heuristic-policy
+   (primal-only); dual bound untouched; needs the cert-panel
+   incorrect-count gate + a wall-clock regression probe.
+2. **F2 — Simplex warm-restart stall guard** (B8). Mechanism: iteration or
+   time cap on the warm dual-simplex re-optimize; on trip, fall back to a
+   cold solve of the same LP (soundness unchanged — same optimum, different
+   path). Evidence: nvs01's 2×8.7 s calls vs 4–6 ms siblings on
+   near-identical LPs; a cold solve of these LPs costs ~5 ms. Expected:
+   nvs01 22.0 s → ~4.5 s. Bound-neutral regime (objective/node_count must
+   be exactly unchanged — the LP optimum is the same; only who computes it
+   changes). Rust-side; needs `cargo test -p discopt-core` + cert-panel
+   neutrality run.
+3. **F3 — Route the multilinear separator's re-solves to the warm simplex**
+   (B9), i.e. extend #484's `DISCOPT_SEPARATION_LP_SIMPLEX` to this call
+   site (`mccormick_lp._separate_multilinear` → `milp.solve(backend=…)`
+   resolution). Expected: nvs09 60 s (gap 39 %) → separation cost drops
+   ~10–50× per Phase-D's own measurements of the same swap elsewhere;
+   st_e36's 13.3 ms×2 398 volume also shrinks with F2's warm path.
+   Bound-neutral-with-caveat exactly as #484 documented (degenerate-LP dual
+   may differ; cut *validity* is intercept-recomputed): decide by the same
+   empirical neutrality protocol.
+4. **F4 — Budget-gate the root heuristic NLP/compile phase** (B10, §4).
+   Mechanism: before a root heuristic NLP that will trigger a first-time
+   Hessian compile, check remaining budget vs a measured compile-cost
+   estimate for the model size; skip or use the Hessian-free path when it
+   doesn't fit; cap root multistart count by remaining time. Expected:
+   restores the 60 s contract on contvar (221 s → ≤60 s) and
+   heatexch_gen3 (81.5 → ≤60), cuts hda's root 42 s substantially. Risk:
+   heuristic-policy; no dual-bound effect. (The hard alternative —
+   interruptible XLA compiles — does not exist.)
+5. **F5 — Even-power composite envelope for the st_e36 pinning class**
+   (B11). Mechanism: secant/tangent envelopes for `±(affine+quadratic)²`
+   composites that actually contract with the participating variables'
+   boxes (relaxation-catalog check first per its "do not rebuild" rule).
+   Evidence: fixing x1 certifies in 5 nodes; the current envelope is
+   interval-independent. Expected: st_e36 60 s/897 nodes → ~2 s/≤10 nodes.
+   **Bound-changing regime**: feature-flagged, differential bound test +
+   feasible-point sampling, default-off until nightly-green.
+6. **F6 — Per-node NLP engine cost on the nvs05/tls2 class** (B12): either
+   the Phase-D POUNCE performance filing (per-solve 7–11× vs Ipopt on
+   identical problems) or reducing attempts (retry policy adds ~1.6
+   NLP/node on nvs05). Expected: nvs05 55 s → ~8–15 s *of solver time* —
+   but without F5-class root-gap work it still won't certify in 60 s
+   (bound at 5.32/5.47 after 821 nodes). Pair with relaxation work.
+7. **F7 — Fixed-tax trims** (lazy-import hoisting; JIT warmup reuse):
+   ~0.9–1.1 s on every first solve; only matters for the sub-5 s class
+   (m3, nvs13, ex1224, nvs08). Low risk, low ceiling.
+
+Non-candidates (measured dead here): OBBT tuning (≤4 % everywhere on this
+panel); further CSE/Q-extraction-style DAG shrinking for Class A (the DAG
+walk is not where the seconds are, except hda's churn note in §6).
+
+---
+
+## 8. Artifacts
+
+- `discopt_benchmarks/scripts/profile_instance.py` — the reusable
+  measurement harness used for every number in this doc (clean/cprofile
+  modes, 100 Hz in-process sampler with collapsed-stack output, bound/node
+  `node_callback` trace, `--second-solve` JIT-tax probe,
+  `--dump-stack-after` overrun stack dumps).
+- Raw per-instance JSON/pstats/collapsed stacks were produced in the session
+  scratchpad (not committed; regenerate with the script above — every table
+  states its instance + mode).

--- a/docs/dev/perf-followup-plan-2026-07-05.md
+++ b/docs/dev/perf-followup-plan-2026-07-05.md
@@ -1,0 +1,445 @@
+# Performance follow-up plan — 2026-07-05 (executable task list for the B7–B12 bottlenecks)
+
+**Status:** planned (no task started)
+**Basis:** every task below is grounded in a measurement in
+`docs/dev/bottleneck-profile-2026-07-05.md` (same branch/PR). Do not re-derive
+those numbers; do re-run the per-task *entry experiment* before implementing —
+if it no longer reproduces, the measurement wins: record the falsification in
+the profile doc's §5 style and re-scope.
+**Executor:** a fresh Claude (Opus) session with no prior context. Everything
+needed is in this doc, the profile doc, and the canonical planning docs listed
+in CLAUDE.md.
+**Tracking:** file one GitHub issue per task on first pickup (title = the task
+ID + name below); this doc is the specification, the issue is the workflow
+handle.
+
+---
+
+## §0 Binding contract (do not reinterpret)
+
+0.1 **Correctness before performance.** `incorrect_count ≤ 0` on every panel is
+    a hard gate with zero slack. A task that can only hit its wall-clock target
+    by weakening a validation, fallback, tolerance, or safety guard **loses**;
+    stop and surface it. The A-tasks (correctness) merge before any F-task that
+    touches the same layer.
+
+0.2 **Fix the class, not the instance.** The named instances (fac2, nvs01,
+    flay03m, st_e36, nvs09, hda, contvar, …) are *probes*. No change may key on
+    an instance name, shape hash, or benchmark membership. Each task names its
+    *class* and at least one out-of-panel witness instance from
+    `~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/` to confirm the
+    fix generalizes (oracle: `minlplib.solu`).
+
+0.3 **Verification regimes** (CLAUDE.md §Development-Philosophy 5, applied per
+    task below):
+    - *bound-neutral*: `node_count` and certified `objective` **exactly
+      unchanged** on the certifying panel (`docs/dev/data/cert-baseline.jsonl`
+      protocol; regenerate the comparison with the same seeds/flags). Any
+      drift, including apparent improvement, means the change is wrong.
+    - *heuristic-policy*: may change incumbent discovery timing (node counts
+      may legitimately change) but must never touch the dual bound path. Gate:
+      certified `objective` values unchanged, `incorrect_count = 0`, and a
+      wall-clock regression probe (no instance on the 61-instance panel slows
+      by >10 % — heuristics that stop finding incumbents show up here).
+    - *bound-changing*: feature flag, default-OFF; differential bound test
+      (new bound ≥ old bound AND ≤ true box optimum on fixed boxes) +
+      feasible-point sampling (no valid point cut); flips default only after
+      green on consecutive nightly runs.
+
+0.4 **Per-PR gates** (all tasks): `pytest -m smoke`,
+    `pytest -m slow python/tests/test_adversarial_recent_fixes.py`,
+    `cargo test -p discopt-core` when Rust is touched, `ruff check` +
+    `ruff format --check`, `mypy python/discopt/`. New behavior requires a
+    regression test that fails before / passes after. One task per PR, task ID
+    in the title. **Watch CI fully green before merging** (standing lesson:
+    #490 merged on unstable → broken main).
+
+0.5 **Measurement tooling.** Use
+    `discopt_benchmarks/scripts/profile_instance.py` (added with the profile
+    doc) for every before/after number: `clean` mode for totals, `--cprofile`
+    for shares, `--second-solve` for tax, `--dump-stack-after` for overruns.
+    Perf claims in PRs quote instance, mode, and machine.
+
+0.6 **Falsification discipline.** If an entry experiment contradicts this
+    plan, the profile doc, or `docs/dev/performance-plan.md` §6, the
+    measurement wins. Record it (profile doc §5 house style) before
+    re-scoping. Do not silently skip a task.
+
+0.7 **Time-limit semantics.** `solve(time_limit=T)` is a *contract*: wall
+    time ≤ T + a small constant (target: +10 % or +5 s, whichever is larger).
+    F4 restores it; no other task may regress it.
+
+---
+
+## §1 Ordering and dependencies
+
+```
+A1 (nvs05 bound adoption)  ──┐
+A2 (1e30 sentinel)         ──┤  correctness pre-flight: merge first
+A3 (benchmark lb field)    ──┘  (A3 is script-only, trivial)
+        │
+F4 (root budget gate / time_limit contract)   — independent
+F1 (LNS enumeration budget)                   — independent
+F2 (simplex warm-restart stall guard)         — independent (Rust)
+F3 (multilinear separator LP routing)         — after F2 lands (shares the
+                                                 warm-simplex path; F2's cap
+                                                 protects F3's new call site)
+        │
+F5 (even-power composite envelope)            — bound-changing, after A1
+                                                 (needs trusted bound
+                                                 reporting to evaluate)
+F6 (node-NLP volume/engine, nvs05/tls2 class) — after F5 entry experiment
+                                                 (F5 may collapse the node
+                                                 count and change F6's value)
+F7 (fixed-tax trims)                          — anytime, lowest priority
+        │
+V1 (full BARON head-to-head re-run + gate)    — after F1–F4 merged
+```
+
+A1/A2/A3, F1, F2, F4 are mutually independent — parallelize across
+worktrees/sessions if desired, but each in its own PR.
+
+---
+
+## §2 Tasks
+
+### A1 — nvs05-class: final `SolveResult.bound` is far below the tree's best bound  (P1, correctness)
+
+- **Evidence** (profile §6): on nvs05 the `node_callback` trace ends with
+  `best_bound = 5.32`, but `SolveResult.bound = 1.348` → reported gap 75.4 %
+  where the tree achieved ~2.7 %. One of two things is true, and both matter:
+  (a) the frontier/global bound is not adopted into the final result on this
+  path (under-reporting — makes discopt look worse and mis-scores every
+  benchmark), or (b) the callback's `best_bound` is *not* a certified global
+  bound (over-reporting in the callback API — a soundness question).
+- **Hypothesis:** (a) — a result-assembly path on `time_limit` exit takes a
+  stale root/incumbent-era bound instead of the tree frontier minimum.
+- **Entry experiment:** run nvs05 60 s with the callback trace
+  (`profile_instance.py --trace`); dump both the final frontier
+  (min over open nodes of node lower bounds) and `SolveResult.bound`.
+  *Kill criterion:* if the frontier min at exit is actually 1.348 (i.e. the
+  callback's 5.32 was never a valid global bound), this becomes a **callback
+  API soundness bug** — re-file as (b), fix the callback, and add it to
+  `docs/dev/correctness-issues.md` as a new C-item instead.
+- **Implementation sketch:** find where `SolveResult.bound` is assembled on
+  the `time_limit`/`feasible` exit path of `_solve_nlp_bb`
+  (`python/discopt/solver.py`; grep `bound =` near the result construction
+  and the `1e30` sentinel handling). The certified global bound at exit is
+  `min(node.lower_bound for node in open_frontier)` (min sense), or the last
+  completed-node bound when the frontier is empty. Ensure maximize-sense
+  negation is handled (solver.py:853 pattern).
+- **Class witness:** any time-limited spatial instance with open nodes at
+  exit; check tls2 (bound trace 5.2 at TL) reports ≈5.2, not less.
+- **Regime/gates:** correctness fix; the reported bound may only become
+  *tighter and still valid* (never exceeds true optimum on the oracle panel).
+  Add a regression test: solve a small instance with a tiny node budget,
+  assert `result.bound == frontier_min` and `bound ≤ oracle optimum`.
+  Full §0.4 gates + the 61-instance panel: `incorrect_count = 0` and no
+  reported bound crossing its `minlplib.solu` oracle.
+- **Acceptance:** nvs05@60 s reports gap ≈ (5.47−5.32)/5.47 ≈ 3 %, not 75 %;
+  panel-wide reported gaps never loosen.
+
+### A2 — `best_bound = 1e30` sentinel leaks into the public callback API  (P2, correctness/API)
+
+- **Evidence** (profile §6): on the no-relaxation class (hda, heatexch_gen3)
+  `node_callback` receives `best_bound = 1e30` instead of "no bound".
+- **Implementation sketch:** at the callback marshaling site, map the
+  sentinel to `None` (preferred; matches `SolveResult.bound: Optional`) —
+  and audit every consumer of `best_bound` inside the repo (gap computation,
+  commentary, dashboard) for arithmetic on the sentinel. Do **not** change
+  the internal sentinel representation — only the API boundary.
+- **Regime/gates:** bound-neutral (representation-only). Regression test:
+  callback on an hda-like model (a model whose relaxation omits rows — build
+  synthetically with an unsupported operator, not named-instance) receives
+  `None`. §0.4 gates.
+- **Acceptance:** no `1e30` observable through any public API; gap fields
+  `None` when no bound exists.
+
+### A3 — benchmark worker reads a nonexistent `res.lower_bound`  (P3, benchmark-infra, trivial)
+
+- **Evidence:** `global_opt_baron_vs_discopt.py`'s `DISCOPT_WORKER` does
+  `lb = getattr(res, "lower_bound", None)` — `SolveResult` has `bound`
+  (modeling/core.py:1186), so `lower_bound` was `null` for all 61 rows of the
+  2026-07-05 report. `gap` was real; only the `lower_bound` column is dead.
+- **Implementation sketch:** in the worker string, read `res.bound` (keep the
+  JSON key `lower_bound` for report compatibility, or rename both — either,
+  consistently). Also add a `bound-vs-oracle` violation check to the report
+  verdicts now that the field is live (bound crossing the `.solu` dual bound
+  = a VIOLATION row, same as an objective violation).
+- **Regime/gates:** script-only; smoke gate. **Blocks V1** (V1's report should
+  carry live bounds).
+- **Acceptance:** a 2-instance `--instances` run emits non-null bounds.
+
+### F1 — Budget `local_branching`'s enumeration path  (B7; the #1 wall lever)
+
+- **Evidence** (profile §1.1, §2): `_lns_k_schedule = (2, 5, 10)`
+  (solver.py:4999, :7610; consumed at :6617/:8123 →
+  `_jax/primal_heuristics.py:1426 local_branching`). With 12 binaries the
+  ≤`max_binaries` enumeration branch issues `ΣC(12,r)` full POUNCE sub-NLPs
+  — 79 at k=2, 1 586 at k=5 — ignoring its ≤2 s slice
+  (`submip_time_limit=_lb_slice`) and never polling the deadline. fac2:
+  1 665 calls = 85.8 % of 23.5 s; flay03m: 3 330 calls = 96.5 % of wall;
+  runs even when the incumbent is already optimal. `rens=False`
+  counterfactual (fac2 27.3 s, flay03m 91.7 s) proves the budget must live
+  **inside `local_branching`**, not at call sites.
+- **Hypothesis:** polling the slice/deadline inside the flip-enumeration loop
+  (and skipping enumeration when its predicted cost exceeds the slice)
+  removes ≥80 % of fac2/flay03m wall with zero effect on certified
+  objectives.
+- **Entry experiment** (run before implementing): monkeypatch a counter into
+  `local_branching` to log (n_binaries, k, calls issued, wall) on fac2 and
+  flay03m; confirm the 79/1 586 arithmetic and the ≥20 s attribution.
+  *Kill criterion:* enumeration <50 % of wall on both ⇒ re-profile before
+  proceeding.
+- **Implementation sketch** (all inside `local_branching` +
+  its enumeration helper):
+  1. Accept/honor a hard `deadline` (absolute) in addition to the slice;
+     poll every sub-NLP (they are ~14 ms — per-iteration polling is free).
+  2. Before starting a k-round, predict cost = `ΣC(n_bin, r≤k)` × the
+     *measured* mean sub-NLP time from the previous round (or 15 ms prior);
+     if it exceeds the remaining slice, truncate k or dispatch to the
+     existing `_local_branching_submip` (which already takes `time_limit`).
+  3. Do not start any round when the incumbent already matches the node
+     relaxation bound within `gap_tolerance` (nothing to improve).
+  Keep the k-schedule policy itself; this task adds budget enforcement, not
+  new heuristics.
+- **Class witness:** any ≤12-binary MINLP with an early incumbent; pick one
+  from `problems_small.txt` outside the 61-panel (e.g. a small `flay`/`clay`
+  sibling or `st_` family member with binaries) and show the same call-count
+  collapse.
+- **Regime/gates:** heuristic-policy (§0.3). Panel run: certified objectives
+  unchanged, `incorrect_count = 0`, no instance >10 % slower, and the
+  primal-side check that incumbent *quality* at exit is not degraded on the
+  panel (same or better objective at TL on the time-limited instances).
+  Regression test: a synthetic 12-binary model with a deadline of 1 s
+  asserts `local_branching` returns within 1.2 s and issues fewer sub-NLPs
+  than the unbudgeted count.
+- **Acceptance** (profile §7 arithmetic): fac2 23.5 s → ≤5 s;
+  flay03m 46.5 s → ≤12 s (certifying); tls2 root −≥15 s. Measured with
+  `profile_instance.py` clean mode, same machine, quoted in the PR.
+
+### F2 — Warm dual-simplex stall guard  (B8; Rust)
+
+- **Evidence** (profile §1.2, §2): nvs01 — of 41 `solve_lp_warm_std` calls
+  totalling 17.5 s, two warm re-solves after `_separate_univariate_square`
+  row-appends take **8.71 s / 8.70 s** on 117–118×25 LPs whose siblings take
+  4–6 ms (79 % of wall). st_e36 — 2 398 warm calls @ 13.3 ms = 53 % of wall.
+  A cold solve of the same LPs costs ~5 ms.
+- **Hypothesis:** the warm dual simplex enters a degenerate cycling/stalling
+  regime from a stale basis after row appends; an iteration cap with
+  cold-restart fallback recovers the 4–6 ms cost with an identical optimum.
+- **Entry experiment:** instrument (or log at `debug!`) iteration counts in
+  `crates/discopt-core/src/lp/simplex/dual.rs::solve_lp_warm*`; re-run nvs01;
+  confirm the two 8.7 s calls have pathological iteration counts (≫ the
+  4–6 ms calls) rather than per-iteration cost. *Kill criterion:* iterations
+  are normal and time is per-iteration (e.g. dense refactorization cost) ⇒
+  different fix (factorization reuse), re-scope before writing the cap.
+- **Implementation sketch** (`dual.rs`, possibly `primal.rs`):
+  1. Add `max_iterations`/`max_time` to `SimplexOptions` (respect existing
+     option plumbing; no new global).
+  2. Default cap: `K × (rows+cols) + C` (pick K from the entry experiment's
+     healthy-call distribution, e.g. p99 × 10 — record the number).
+  3. On cap trip: discard the warm basis, cold-solve the same LP
+     (`solve_lp` path), return that result; count trips in the LP stats.
+  4. EXPAND/anti-degeneracy already exists (CLAUDE.md notes) — check first
+     whether the stalled calls bypass it; if the root cause is a bypass,
+     fix that instead of adding the cap (§0 band-aid rule), keeping the cap
+     as a backstop.
+- **Class witness:** st_e36's 2 398-call volume mean should drop; pick one
+  out-of-panel spatial instance with separation-heavy traffic (from
+  `problems_short.txt`) and show no regression.
+- **Regime/gates:** **bound-neutral** (same LP optimum, different path):
+  cert-baseline node_count/objective exactly unchanged. `cargo test -p
+  discopt-core` + a Rust regression test that constructs a stall-prone
+  warm-start (from the entry experiment's captured LP + basis — serialize
+  it) and asserts the guarded path returns the same optimum as cold within
+  the cap. §0.4 gates.
+- **Acceptance:** nvs01 22.0 s → ≤5 s; no cert-panel drift; trip counter > 0
+  on nvs01 and = 0 on the healthy majority.
+
+### F3 — Route the multilinear separator's LP re-solves to the warm simplex  (B9; extends #484)
+
+- **Evidence** (profile §1.3): nvs09 — 92.6 % of 60 s inside
+  `_separate_multilinear` (`_jax/mccormick_lp.py:994`, called at :759) →
+  `lp_pounce._solve_core` (the POUNCE LP IPM). #484's
+  `DISCOPT_SEPARATION_LP_SIMPLEX` (default ON) covered edge-concave
+  (`edge_concave.py:58`) and strong branching (`solver.py:1748`) only.
+- **Hypothesis:** the same swap that gave 10–50× on the other separators
+  applies; nvs09's separation cost collapses and its node throughput rises
+  from ~2.6 nodes/s to the panel-normal range.
+- **Entry experiment:** count LP solves and mean ms inside
+  `_separate_multilinear` on nvs09 (one `--cprofile` run isolates it).
+  Confirm ≥80 % of wall and that the LPs are re-solves of an augmented LP
+  (warm-startable). *Kill criterion:* the LPs are structurally fresh each
+  round (no basis to reuse) ⇒ the win is only cold-simplex vs IPM; re-check
+  the expected gain before implementing (still likely worth it, but state
+  the new number).
+- **Implementation sketch:** mirror #484's mechanism at this call site: honor
+  `DISCOPT_SEPARATION_LP_SIMPLEX` in `_separate_multilinear`'s LP
+  construction, reuse the warm-basis plumbing the edge-concave path uses,
+  and (as #484 did) recompute each cut's intercept to the exact validity
+  boundary so cut *validity* never depends on which engine produced the
+  duals. **Depends on F2** (this adds warm-simplex traffic; the stall guard
+  should land first).
+- **Class witness:** an out-of-panel multilinear-heavy instance
+  (`minlplib_types.csv` → pick a small signomial/multilinear one).
+- **Regime/gates:** same protocol as #484 — nominally bound-neutral with the
+  documented degenerate-dual caveat; decide by the empirical neutrality run
+  (cert-baseline exact-match; if a degenerate instance drifts, investigate
+  before shipping — do not widen the tolerance). §0.4 gates + off-switch
+  test (`DISCOPT_SEPARATION_LP_SIMPLEX=0` restores the old path).
+- **Acceptance:** nvs09 separation share <20 % of wall; nodes/s ≥ 10× prior;
+  bound at 60 s strictly better than −59.24 (it may now certify; fine).
+
+### F4 — Budget-gate the root heuristic NLP/compile phase  (B10 + §4; restores the `time_limit` contract)
+
+- **Evidence** (profile §4): contvar returns after **221 s** against
+  `time_limit=60` — all stack dumps inside `feasibility_pump`
+  (primal_heuristics) → POUNCE Hessian callback →
+  `sparse_hessian.sparse_hess_values:162` → one uninterruptible first-time
+  **XLA compile** (~150 s+). heatexch_gen3 81.5 s, same class. hda's root:
+  42 s of 64 s (15.1 s one-call Rust presolve + 21 multistart NLPs
+  @600–780 ms + ~10 s re-tracing).
+- **Hypothesis:** gating *entry* into compile-triggering root work by
+  remaining budget (compiles cannot be interrupted) restores the contract
+  with no dual-bound effect, because all gated work is primal-heuristic.
+- **Entry experiment:** re-run contvar with `--dump-stack-after 70`; confirm
+  the overrun stack. Measure hda's root multistart count/costs. *Kill
+  criterion:* overrun reproduces somewhere other than a heuristic-NLP first
+  compile ⇒ that site needs its own gate; enumerate before coding.
+- **Implementation sketch:**
+  1. Thread the absolute deadline into the root-heuristic phase (it exists in
+     the B&B loop; the root phase predates it on this path).
+  2. Before a heuristic NLP whose evaluator family is not yet compiled
+     (query the JAX compile cache — the evaluator knows), require
+     `remaining_budget ≥ compile_estimate(model_size)`; the estimate comes
+     from a measured curve (fit on ~5 sizes with `profile_instance.py`;
+     record the fit in the PR). Otherwise skip the heuristic or use its
+     Hessian-free/first-order path if one exists (check
+     `nlp_pounce.solve_nlp` options) — skipping a *primal heuristic* is
+     always sound.
+  3. Cap root multistart count by remaining time (measured per-start cost ×
+     starts ≤ a root-phase fraction, e.g. 50 % of budget — a policy constant,
+     documented, not tuned per instance).
+  4. Poll the deadline between multistarts and between heuristic families
+     (feasibility_pump, RENS, diving).
+- **Class witness:** any large flowsheet-class `.nl` from the full corpus
+  with `time_limit=30`; assert wall ≤ 33 s + report which phases were
+  skipped.
+- **Regime/gates:** heuristic-policy. Panel: certified objectives unchanged,
+  `incorrect_count = 0`; time-limited instances must not lose incumbent
+  quality (compare objective-at-TL vs baseline). Regression test: a model
+  with an artificially expensive compile (large sparse Hessian) +
+  `time_limit=5` returns within the §0.7 envelope. §0.4 gates.
+- **Acceptance:** contvar wall ≤ 66 s; heatexch_gen3 ≤ 66 s; hda root phase
+  ≤ 50 % of budget; §0.7 holds on the full 61-instance panel.
+
+### F5 — Even-power composite envelopes for the pinning class  (B11; bound-changing)
+
+- **Evidence** (profile §3): st_e36's root bound (−304.5000003055) is
+  bit-identical for x1 ∈ [15,25], [20,25], [24,25] — the under-envelope of
+  its nested `pow(·,2)` composites with negative coefficients is independent
+  of the integer's box; only fixing lifts it (x1=22 → certifies in 5 nodes;
+  897 unfixed nodes go nowhere). nvs05/nvs09 root gaps 87.7 %/69 % are the
+  same loose-product/power family (live but slow).
+- **Precondition (binding):** check `docs/design/relaxation-catalog.md` first
+  — do not rebuild anything it lists as done. C-34/FR-1 (even powers p≥4
+  straddle bounds) and C-17 (alphaBB rigorous-α) are adjacent; this task is
+  about *composite* `±(inner expr)²` envelopes that contract with the
+  participating variables' boxes, not the bare-power case.
+- **Hypothesis:** a secant/tangent envelope for `c·(affine+quadratic)²`
+  (c<0 concave side) that is a function of the *composite argument's*
+  interval — propagated from member boxes — lifts st_e36's root bound
+  strictly monotonically with box shrinking, collapsing its tree.
+- **Entry experiment:** extract st_e36's pinning term (2 vars — print the
+  DAG); compute by hand/numpy the convex under-envelope over x1 ∈ [15,25]
+  vs [24,25]; verify they *differ* (i.e. the information exists and the
+  current relaxation discards it). *Kill criterion:* the true envelope is
+  also interval-independent on this structure ⇒ the defect is elsewhere
+  (e.g. the argument's interval never tightens in FBBT); re-diagnose before
+  building anything.
+- **Implementation sketch:** in the relaxation compiler
+  (`python/discopt/_jax/mccormick.py::relax_pow` at :203 and the composite
+  path that feeds it), thread the composite argument's interval (already
+  computed by interval propagation) into the even-power envelope instead of
+  falling back to the variable-box-independent form. Flag:
+  `DISCOPT_COMPOSITE_POW_ENVELOPE` (default OFF until nightly-green).
+- **Class witness:** grep the full corpus for `o5`/pow-of-expression
+  structures (the `.nl` opcode scan tooling from C-5 work) — pick 2
+  out-of-panel instances; differential bound test on both.
+- **Regime/gates:** **bound-changing** (§0.3): differential bound test on
+  fixed boxes (new ≥ old, ≤ true box optimum via dense sampling) +
+  feasible-point sampling (no valid point cut) + the flag discipline.
+  Panel with flag ON in a manual run: `incorrect_count = 0`.
+- **Acceptance:** st_e36 root bound strictly improves when x1's box shrinks;
+  st_e36 certifies ≪897 nodes (profile predicts ~5–10). Default flip only
+  after two green nightlies.
+
+### F6 — Node-NLP volume/engine on the nvs05/tls2 class  (B12; paired with upstream)
+
+- **Evidence** (profile §1.6): nvs05 — 834 node NLPs @64 ms = 91 % of wall
+  (retry policy adds ~1.6 NLP/node); tls2 — 1 497 @29 ms = 70 %. The engine
+  gap itself is filed upstream (jkitchin/pounce#182; Phase-D A/B: median
+  7–11× vs Ipopt).
+- **Scope here (discopt-side only):** (1) audit the retry-from-alternative-
+  start policy — measure its incumbent hit-rate on the panel; if retries
+  find <5 % of incumbents, cap retries by a deadline-aware policy;
+  (2) re-measure after F5: if the root-gap work collapses node counts, this
+  task may be moot — **run the F5-dependent entry experiment before any
+  code**. *Kill criterion:* retry hit-rate is material (≥15 % of incumbents)
+  ⇒ leave the policy alone; only the upstream engine work remains, and this
+  task closes as "blocked-upstream".
+- **Regime/gates:** heuristic-policy; §0.4 gates + panel neutrality on
+  certified objectives.
+- **Acceptance:** stated after the entry experiment (record the numbers in
+  the PR); do not pre-commit a wall target for a task whose scope is
+  conditional.
+
+### F7 — Fixed-tax trims  (lowest priority)
+
+- **Evidence** (profile §1.7): `import discopt` 0.10–0.14 s; lazy imports
+  inside first `solve()` 0.4–0.6 s; JIT warmup ≈0.5 s. Only matters for the
+  sub-5 s class (m3, nvs13, ex1224, nvs08) — and net of tax m3 is still
+  ~2.7 s vs BARON 0.04 s, so this is polish, not strategy.
+- **Sketch:** hoist the lazy imports to module import time behind a
+  `DISCOPT_EAGER_IMPORTS=1` env (opt-in for benchmark/CLI runs); persistent
+  JAX compilation cache (`jax.config.compilation_cache_dir`) for the warmup
+  family. Measure with `--second-solve`.
+- **Regime/gates:** bound-neutral; §0.4 gates.
+- **Acceptance:** first-solve tax ≤0.3 s with the env set; zero panel drift.
+
+### V1 — Re-run the BARON head-to-head and gate the outcome  (after F1–F4)
+
+- **Procedure:** rebuild `main`, re-run
+  `discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py --time-limit 60`
+  (A3 must be merged so bounds are live). Same machine class as the
+  2026-07-05 baseline; note load conditions.
+- **Gates (hard):** `incorrect_count = 0` / zero violations (as before);
+  no instance that certified on 2026-07-05 loses certification; §0.7
+  time-limit contract panel-wide.
+- **Targets (measured expectations, not promises — from §7 arithmetic):**
+  discopt total wall 23.1 min → **≤ ~12 min**; "hit TL" count 18 → ≤ 12;
+  fac2/nvs01/flay03m/nvs09 leave the slow list; contvar/heatexch_gen3
+  respect the budget. Compare per-instance vs the 2026-07-05 JSON and
+  record the delta table in `docs/dev/` (this doc's §3 as a results
+  appendix, or a dated results note).
+- **If a target is missed:** that is data, not failure — record which
+  bottleneck's share did not move (per-task acceptance already measured
+  them individually) and re-profile the residual before adding new tasks.
+
+---
+
+## §3 What NOT to do (measured dead ends — binding per §0.6)
+
+- **OBBT tuning** for these classes: ≤4 % of wall on all 11 profiled
+  instances (profile §5.3). The 07-02 OBBT finding applies to its spatial
+  panel only.
+- **More CSE/DAG-shrinking for Class A**: the DAG walk is not where the
+  seconds are (except hda's churn note, profile §6 — secondary to B10).
+- **Blaming POUNCE per-solve latency on Class A / flay03m / st_e36 / nvs09**:
+  falsified (profile §1, verdict table). The POUNCE engine work is real but
+  lives upstream (jkitchin/pounce#182) and only governs the nvs05/tls2/hda
+  class (F6).
+- **`rens=False` or disabling heuristics as a "fix" for B7**: measured to
+  relocate the cost, not remove it (fac2 27.3 s, flay03m 91.7 s).
+- **Polling inside XLA compiles** (F4): not possible; gate entry instead.


### PR DESCRIPTION
## Summary

MEASUREMENT-ONLY deep profile of the two classes the 2026-07-05 BARON comparison (`reports/global_opt_baron_vs_discopt_2026-07-05T10-47-11.json`, 61 instances, 60 s) exposed. Deliverable is `docs/dev/bottleneck-profile-2026-07-05.md` plus a reusable harness `discopt_benchmarks/scripts/profile_instance.py`. **No production code changed.**

## The POUNCE-hypothesis verdict (the question this PR answers)

The prior Phase-D conclusion "the POUNCE subsolver is the #1 wall lever" is **falsified for Class A and most of Class B** — confirming the challenge that "there must be substantial room on the discopt side":

- POUNCE per-solve on this panel is **10–64 ms** (near-Ipopt for these sizes). Where POUNCE seconds dominate, the driver is **call volume commanded by discopt policy**, not subsolver speed.
- fac2: 80% of wall is POUNCE, but via **1,665 LNS `local_branching` subnlp calls at 13.4 ms** — exactly `C(12,<=2)=79 + C(12,<=5)=1,586` from `_lns_k_schedule=(2,5,10)`; the enumeration path ignores its 2 s slice and never polls the deadline. flay03m: 3,330 calls = 96.5% of samples.
- nvs01: **79% of wall is TWO Rust dual-simplex warm re-solves at 8.7 s each** on a 118x25 LP (siblings: 4–6 ms) — a warm-restart stall, not POUNCE (15%).
- nvs09: **92.6% of wall is the multilinear separator's LP re-solves through `lp_pounce._solve_core`** — the #484 separation-LP routing did not cover this call site ("if separation LPs STILL dominate, that's news").
- The refined POUNCE claim survives only on nvs05/tls2 (per-node NLP engine, 29–64 ms/solve, 70–91% of wall) and hda's 722-var root NLPs — the class Phase-D actually measured.

## Other headline measurements

- **Class A "per-node cost" was mis-attributed**: fac2 tree = 20 ms/node (at the cert-gate target); 94% of wall is the root RENS/LNS binge. tls2 root = 25.5 s, tree 18 ms/node.
- **Class B root-gap table + bound traces**: st_e36's root bound (−304.5000003055) is **bit-identical for x1 in [15,25] and [24,25]** — envelope pinning independent of the integer box; fixing x1 certifies in 5 nodes (vs 897 nodes going nowhere). clay0303hfsg root bound pinned at ~0 (big-M gated). nvs05/tls2/nvs09 bounds climb but are starved by per-node cost.
- **Budget overrun root cause** (contvar 221 s vs 60 s limit): all periodic stack dumps inside `feasibility_pump → solve_nlp(POUNCE) → sparse Hessian → XLA backend_compile` — one uninterruptible first-time JIT compile; heatexch_gen3 same site.
- **Falsification records** vs the 07-02 profile ("XLA compile <=1%": class-local, hda ~15%, contvar >68%) and vs the per-node framing of the benchmark report.
- Ranked fix candidates F1–F7 with measured expected wins and CLAUDE.md verification regimes (doc §7).

## Honesty notes

- On this machine flay03m and clay0303hfsg **certify inside the budget** (46.5 s / 25.6 s) vs time-limit in the report; the attribution shape is stable across all three measurement modes, and conclusions don't depend on the 60 s line.
- py-spy requires root on macOS; substituted a 100 Hz in-process sampler (cross-checks cProfile within a few points on every shared instance).
- The `node_callback` trace was verified node-count-neutral (nvs13: 19 nodes, identical objective, with/without).
- pounce here is 0.7.0 (Phase-D used 0.8.0) — noted in the doc.

## What was run

- Environment: worktree at origin/main (31683a25), Apple M4 Pro, Python 3.12.11, JAX 0.10.2 (`JAX_PLATFORMS=cpu`, `JAX_ENABLE_X64=1`), `maturin develop --release`.
- Instances profiled (clean + cProfile + sampler/trace as applicable): fac2, nvs01, m3, nvs13, flay03m, st_e36, hda, tls2, nvs05, nvs09, clay0303hfsg, contvar, heatexch_gen3.
- `ruff check` + `ruff format` clean on the new script; script smoke-tested end-to-end after final edits (nvs13, optimal/19 nodes).
- No solver code touched, so the smoke/adversarial suites are not affected by this PR's content; correctness invariants untouched (two reporting anomalies *flagged* for the correctness backlog in doc §6: nvs05 reported bound 1.35 vs tree bound 5.32; `best_bound=1e30` sentinel leaking into the callback API).

Do NOT merge without review; measurement doc + script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
