### PR TITLE
fix(correctness): A1/C-37 — callback best_bound must not over-report the certified global bound (nvs05)

### DIFF
--- a/discopt_benchmarks/benchmarks/runner.py
+++ b/discopt_benchmarks/benchmarks/runner.py
@@ -285,7 +285,7 @@ class BenchmarkRunner:
                             [
                                 float(ctx.elapsed_time),
                                 int(ctx.node_count),
-                                float(ctx.best_bound),
+                                (None if ctx.best_bound is None else float(ctx.best_bound)),
                                 (None if ctx.incumbent_obj is None else float(ctx.incumbent_obj)),
                             ]
                         )

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -122,6 +122,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-34 | P0 | gdp_reformulate | even-power bound over a zero-straddling base uses endpoint-only bounds (omits interior min at 0) → invalid aux box → false optimal (= FR-1), DEFAULT path | fixed |
 | C-35 | P1 | oa.py / gdpopt_loa | non-rigorous NLP failure → unconditional no-good cut → possible false infeasible/optimal (= OA-1, opt-in OA/LOA path) | fixed |
 | C-36 | P3 | convexity/interval.py | Python `interval_mul` yields NaN on 0·∞ (`RuntimeWarning: invalid value encountered in multiply`), same 0·∞ class as C-22 but a SEPARATE Python code path (`python/discopt/_jax/convexity/interval.py:171`); lost tightening, not unsound | fixed |
+| C-37 | P2 | solver.py callback API | `CallbackContext.best_bound` surfaced the raw tree `global_lower_bound` with no sense-negation and no taint gate → **over-reported** the certified global bound on a non-rigorously-fathomed tree (nvs05: callback 5.32 vs the rigorous `SolveResult.bound` 1.35) and reported a wrong-signed bound for MAXIMIZE; API-surface soundness (the reported `SolveResult.bound` was already correct) | fixed (A1) |
 
 ---
 
@@ -2605,3 +2606,78 @@ it is a separate module with its own tests and consumers.
     adversarial suite 10 passed; ruff + ruff-format clean; `incorrect_count = 0`;
     the `RuntimeWarning: invalid value encountered in multiply` from `interval.py`
     is gone. No Rust touched.
+
+---
+
+## C-37 (P2, FIXED — A1) — `CallbackContext.best_bound` over-reports the certified global dual bound on a tainted tree
+
+**Area:** `python/discopt/solver.py` — the three `CallbackContext(...)` construction
+sites (lazy-constraint helper `_invoke_pre_import_callbacks`, and the two
+`node_callback` sites in `solve_model` and `_solve_nlp_bb`).
+
+**Origin:** filed by the A1 entry experiment
+(`docs/dev/perf-followup-plan-2026-07-05.md` §2 A1) after its **kill criterion
+fired**. A1's evidence (profile §6) was that on nvs05@60 s the `node_callback`
+trace ends with `best_bound = 5.32` while `SolveResult.bound = 1.348` (reported
+gap 75.4 %). The plan named two possibilities: (a) the final result under-adopts
+the tree's frontier bound, or (b) the callback's `best_bound` was never a
+certified global bound (over-reporting). The entry experiment proved **(b)**.
+
+**Diagnosis (printed evidence):** on nvs05 (MINIMIZE, opt 5.470934) at the 60 s
+time-limit exit:
+- `SolveResult.bound = 1.3481188` (the rigorous root-relaxation fallback, #138) —
+  this is **correct and sound**: `1.348 ≤ 5.470934` (never crosses the oracle).
+- `stats["global_lower_bound"] = 5.32` = the minimum over the *surviving* open
+  frontier. But the run made **89 non-rigorous sentinel fathoms** (a node NLP that
+  merely failed/diverged, sentinel-pruned with no FBBT infeasibility proof —
+  `solver.py:5814`/`5842`; 7 such prunes already in a 20 s run). Each removes an
+  **unproven** subtree from the frontier. A pruned-but-unproven subtree is *not*
+  proven suboptimal, so the surviving-frontier minimum (5.32) may sit strictly
+  **above** the true certified global bound. Reporting it claims a dual bound the
+  search never proved.
+
+The final result-assembly path already handles this correctly: it drops the tree
+bound to `None` whenever the tree is tainted (`_tree_bound_valid = _gap_certified`,
+`solver.py:7107`/`8336`) and falls back to the rigorous root relaxation — hence the
+sound 1.348. The **callback API** did not: it surfaced the raw
+`stats["global_lower_bound"]` directly, with no taint gate and (a second, latent
+defect) **no maximize-sense negation** — for a MAXIMIZE the internal minimization
+tracks `-obj`, so the raw value is a lower bound on `-obj` (an *upper* bound on
+`obj` only after negating); the callback reported it un-negated, i.e. wrong-signed.
+
+**Severity (P2 — API-surface soundness, not a false certificate):** the reported
+`SolveResult.status`/`bound` were always correct, so no run ever *certified* a
+wrong answer. But `best_bound` is a public field (`CallbackContext`, used by the
+benchmark trajectory recorder and `profile_instance.py`); an over-reported /
+wrong-signed dual bound mis-scores gaps in monitoring and benchmark tooling and
+violates the invariant that a *global dual bound* never crosses the optimum.
+
+**Fix:** new helper `_certified_callback_bound(global_lower_bound,
+tree_bound_valid, is_maximize) -> Optional[float]` maps the raw tree bound to the
+value safe to surface: `None` when the tree is tainted (`tree_bound_valid` False),
+when the bound is the failure/`1e30` sentinel, or when it is non-finite (`-inf`
+root, #467); otherwise the sense-corrected bound (negated for MAXIMIZE). All three
+construction sites route through it (the lazy-constraint helper takes a new
+`tree_bound_valid=_gap_certified` kwarg; the two node_callback sites already have
+`_gap_certified` in scope). `CallbackContext.best_bound` is retyped
+`float | None`. Invariant established: **the callback's `best_bound` never exceeds
+what the final `SolveResult.bound` would certify.**
+
+**Verification:** nvs05@60 s — `SolveResult.bound` unchanged at 1.348 (the fix does
+not touch the reported bound, only the callback surface); callback trace now
+reports the honest climbing bound up to the first non-rigorous fathom (max 2.04),
+then `None` (no certified global bound), never 5.32.
+
+- **Regression tests** (`python/tests/test_callbacks.py`,
+  `TestCertifiedCallbackBound` + `TestCallbackBoundSoundness`): unit tests for the
+  helper (minimize passthrough, maximize negation, tainted→None, `-inf`→None,
+  sentinel→None) and two integration tests — a small NON-NAMED nonconvex MAXIMIZE
+  MINLP asserting every certified `best_bound` is a valid upper bound
+  (`>= objective`), and a tiny-budget minimize solve asserting the running
+  `best_bound` never exceeds the final `SolveResult.bound`. 6 of 7 fail on pre-fix
+  code (ImportError on the helper; the maximize wrong-sign assertion), all pass
+  after.
+- **Note for A2:** C-37 gates the *tainted-tree* and *sense* over-reporting. A2
+  (the `1e30` sentinel → `None` at the callback boundary) is complementary and
+  already partly covered here (the sentinel branch of the helper); A2 remains a
+  separate PR for the full no-relaxation-class audit of `best_bound` consumers.

--- a/python/discopt/callbacks.py
+++ b/python/discopt/callbacks.py
@@ -11,7 +11,8 @@ Example
 >>> from discopt.callbacks import CallbackContext, CutResult, NodeCallback
 >>>
 >>> def my_logger(ctx: CallbackContext, model: discopt.Model) -> None:
-...     print(f"Node {ctx.node_count}: bound={ctx.best_bound:.4f}")
+...     bb = "n/a" if ctx.best_bound is None else f"{ctx.best_bound:.4f}"
+...     print(f"Node {ctx.node_count}: bound={bb}")
 >>>
 >>> result = m.solve(node_callback=my_logger)
 """
@@ -43,8 +44,15 @@ class CallbackContext:
     incumbent_obj : float or None
         Best feasible objective value found so far, or None if no
         incumbent exists yet.
-    best_bound : float
-        Best (tightest) lower bound across all open nodes.
+    best_bound : float or None
+        The certified global dual bound of the search so far (a lower bound for
+        a MINIMIZE, an upper bound for a MAXIMIZE), or ``None`` when no such
+        bound has been certified yet. ``None`` is reported whenever the tree
+        bound is not (yet) a rigorous global bound — e.g. a node was fathomed
+        non-rigorously (an NLP failure with no infeasibility proof), an
+        unbounded/free root leaves the bound at ``-inf``, or the relaxation
+        omits rows so no dual bound exists. Never over-reports: this value never
+        exceeds what the final ``SolveResult.bound`` would certify (A1).
     gap : float or None
         Relative optimality gap, or None if no incumbent exists.
     elapsed_time : float
@@ -57,7 +65,7 @@ class CallbackContext:
 
     node_count: int
     incumbent_obj: float | None
-    best_bound: float
+    best_bound: float | None
     gap: float | None
     elapsed_time: float
     x_relaxation: np.ndarray

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1502,6 +1502,43 @@ def _solve_root_node_multistart(
     return last_result
 
 
+def _certified_callback_bound(
+    global_lower_bound: Optional[float],
+    tree_bound_valid: bool,
+    is_maximize: bool,
+) -> Optional[float]:
+    """The certified global dual bound to surface on the callback API.
+
+    A1 (correctness): the callback's ``best_bound`` must never exceed the bound
+    the final :class:`SolveResult` would certify. The Rust tree's raw
+    ``global_lower_bound`` is the minimum over the *surviving* open frontier, but
+    a non-rigorously-fathomed node (an NLP that merely failed/diverged and was
+    sentinel-pruned with no infeasibility proof — solver.py:5814/5842) removes an
+    unproven subtree from that frontier. Its subtree is not proven suboptimal, so
+    the surviving-frontier minimum may sit strictly *above* the true certified
+    global bound. Reporting it then over-reports a dual bound the search never
+    proved (nvs05: tree ``global_lower_bound = 5.32`` on a tainted tree whose
+    rigorous bound is 1.35 — reported bound must stay 1.35). The final
+    result-assembly path already drops the tree bound in exactly this case
+    (``_tree_bound_valid``); the callback must mirror it.
+
+    Returns the sense-corrected certified bound (for a MAXIMIZE the internal
+    minimization tracks ``-obj``, so a lower bound ``L`` on ``-obj`` is an upper
+    bound ``-L`` on ``obj``), or ``None`` when no certified bound exists: the
+    tree is tainted (``tree_bound_valid`` False), or the bound is the failure
+    sentinel / non-finite (``-inf`` root, or the ``1e30`` no-relaxation
+    sentinel). ``None`` matches the ``Optional`` convention already used by
+    ``incumbent_obj``/``gap``.
+    """
+    if not tree_bound_valid:
+        return None
+    if global_lower_bound is None or not np.isfinite(global_lower_bound):
+        return None
+    if abs(global_lower_bound) >= _SENTINEL_THRESHOLD:
+        return None
+    return -global_lower_bound if is_maximize else global_lower_bound
+
+
 def _invoke_pre_import_callbacks(
     *,
     model,
@@ -1518,6 +1555,7 @@ def _invoke_pre_import_callbacks(
     lazy_constraints,
     incumbent_callback,
     _cut_pool,
+    tree_bound_valid=True,
 ):
     """Check lazy constraints and incumbent callbacks before importing results.
 
@@ -1541,6 +1579,13 @@ def _invoke_pre_import_callbacks(
     stats = tree.stats()
     elapsed = time.perf_counter() - t_start
 
+    from discopt.modeling.core import ObjectiveSense as _ObjectiveSense
+
+    _cb_is_max = model._objective is not None and model._objective.sense == _ObjectiveSense.MAXIMIZE
+    _cb_bound = _certified_callback_bound(
+        stats.get("global_lower_bound"), tree_bound_valid, _cb_is_max
+    )
+
     for i in range(n_batch):
         if result_lbs[i] >= _SENTINEL_THRESHOLD:
             continue  # skip infeasible nodes
@@ -1561,7 +1606,7 @@ def _invoke_pre_import_callbacks(
         ctx = CallbackContext(
             node_count=stats["total_nodes"],
             incumbent_obj=inc_obj,
-            best_bound=stats.get("global_lower_bound", -np.inf),
+            best_bound=_cb_bound,
             gap=stats.get("gap"),
             elapsed_time=elapsed,
             x_relaxation=result_sols[i].copy(),
@@ -6667,6 +6712,7 @@ def solve_model(
                 lazy_constraints=lazy_constraints,
                 incumbent_callback=incumbent_callback,
                 _cut_pool=_cut_pool,
+                tree_bound_valid=_gap_certified,
             )
 
         # Convex-objective node bound (applied at the single point every node's
@@ -6833,11 +6879,17 @@ def solve_model(
                     if result_lbs[i] < result_lbs[best_idx]:
                         best_idx = i
                 from discopt.callbacks import CallbackContext
+                from discopt.modeling.core import ObjectiveSense as _ObjSense
 
+                _cb_is_max = (
+                    model._objective is not None and model._objective.sense == _ObjSense.MAXIMIZE
+                )
                 ctx = CallbackContext(
                     node_count=stats_snap["total_nodes"],
                     incumbent_obj=inc_obj_cb,
-                    best_bound=stats_snap.get("global_lower_bound", -np.inf),
+                    best_bound=_certified_callback_bound(
+                        stats_snap.get("global_lower_bound"), _gap_certified, _cb_is_max
+                    ),
                     gap=stats_snap.get("gap"),
                     elapsed_time=time.perf_counter() - t_start,
                     x_relaxation=result_sols[best_idx].copy(),
@@ -8030,11 +8082,17 @@ def _solve_nlp_bb(
                     if result_lbs[i] < result_lbs[best_idx]:
                         best_idx = i
                 from discopt.callbacks import CallbackContext
+                from discopt.modeling.core import ObjectiveSense as _ObjSense
 
+                _cb_is_max = (
+                    model._objective is not None and model._objective.sense == _ObjSense.MAXIMIZE
+                )
                 ctx = CallbackContext(
                     node_count=stats_snap["total_nodes"],
                     incumbent_obj=inc_obj_cb,
-                    best_bound=stats_snap.get("global_lower_bound", -np.inf),
+                    best_bound=_certified_callback_bound(
+                        stats_snap.get("global_lower_bound"), _gap_certified, _cb_is_max
+                    ),
                     gap=stats_snap.get("gap"),
                     elapsed_time=time.perf_counter() - t_start,
                     x_relaxation=result_sols[best_idx].copy(),

--- a/python/tests/test_callbacks.py
+++ b/python/tests/test_callbacks.py
@@ -442,3 +442,125 @@ class TestCallbackContext:
         )
         assert ctx.incumbent_obj is None
         assert ctx.gap is None
+
+    def test_none_best_bound(self):
+        # A1: best_bound is Optional — None when no certified global bound exists.
+        ctx = CallbackContext(
+            node_count=5,
+            incumbent_obj=3.0,
+            best_bound=None,
+            gap=None,
+            elapsed_time=0.1,
+            x_relaxation=np.zeros(2),
+            node_bound=1.0,
+        )
+        assert ctx.best_bound is None
+
+
+class TestCertifiedCallbackBound:
+    """A1: the callback's ``best_bound`` must never over-report the certified
+    global dual bound. ``_certified_callback_bound`` maps the Rust tree's raw
+    ``global_lower_bound`` to the value that is safe to surface.
+    """
+
+    def test_valid_minimize_passthrough(self):
+        from discopt.solver import _certified_callback_bound
+
+        assert _certified_callback_bound(5.32, True, False) == 5.32
+
+    def test_maximize_is_negated(self):
+        from discopt.solver import _certified_callback_bound
+
+        # Internal minimization tracks -obj: a lower bound L on -obj is an upper
+        # bound -L on obj. A raw min-sense bound must be negated for MAXIMIZE.
+        assert _certified_callback_bound(-52.89, True, True) == 52.89
+
+    def test_tainted_tree_reports_none(self):
+        from discopt.solver import _certified_callback_bound
+
+        # A non-rigorous fathom removed an unproven subtree; the surviving
+        # frontier minimum may sit above the true certified bound (nvs05:
+        # global_lower_bound = 5.32 on a tainted tree whose rigorous bound is
+        # 1.35). Never surface it.
+        assert _certified_callback_bound(5.32, False, False) is None
+        assert _certified_callback_bound(-52.89, False, True) is None
+
+    def test_neg_inf_root_reports_none(self):
+        from discopt.solver import _certified_callback_bound
+
+        # Unbounded / free-variable root (#467): the tree pins the bound at -inf.
+        assert _certified_callback_bound(-np.inf, True, False) is None
+
+    def test_failure_sentinel_reports_none(self):
+        from discopt.constants import SENTINEL_THRESHOLD
+        from discopt.solver import _certified_callback_bound
+
+        # The 1e30 no-relaxation sentinel (hda/heatexch class) is "no bound",
+        # not a numeric bound — must not leak through the API as a huge number.
+        assert _certified_callback_bound(SENTINEL_THRESHOLD, True, False) is None
+        assert _certified_callback_bound(None, True, False) is None
+
+
+class TestCallbackBoundSoundness:
+    """A1 regression: the callback's ``best_bound`` is a *certified* global dual
+    bound. It must (1) be on the correct side of the objective for the sense and
+    (2) never over-report relative to the final ``SolveResult.bound``. The
+    pre-fix code surfaced the raw internal min-sense ``global_lower_bound`` with
+    no sense negation and no taint gate, so both invariants failed.
+    """
+
+    def test_maximize_best_bound_is_a_valid_upper_bound(self):
+        # A small NON-NAMED nonconvex MAXIMIZE MINLP. For a maximize, every
+        # certified best_bound is an UPPER bound (>= the achievable objective).
+        # Pre-fix reported the un-negated internal bound (a lower bound on -obj,
+        # i.e. NEGATIVE here) and this assertion fails; post-fix it passes.
+        m = discopt.Model("cb_max_bound")
+        n = m.integer("n", lb=1, ub=6)
+        x = m.continuous("x", lb=0.0, ub=5.0)
+        m.maximize(x * n - (x - 2.0) ** 2 * n)  # nonconvex
+        m.subject_to(x + n <= 8.0)
+
+        bounds: list = []
+
+        def cb(ctx, _model):
+            bounds.append(ctx.best_bound)
+
+        res = m.solve(time_limit=15, gap_tolerance=1e-4, node_callback=cb)
+        assert res.status in ("optimal", "feasible")
+        assert res.objective is not None
+        finite = [b for b in bounds if b is not None and np.isfinite(b)]
+        assert finite, "expected at least one certified best_bound in the trace"
+        # Every certified upper bound must be >= the achievable objective.
+        for b in finite:
+            assert b >= res.objective - 1e-6, (
+                f"maximize best_bound {b} below objective {res.objective}: "
+                "callback under-/wrong-signed the certified bound"
+            )
+
+    def test_best_bound_never_exceeds_final_certified_bound(self):
+        # A tiny-budget spatial solve that exits feasible with an open frontier.
+        # The running certified best_bound must never exceed what the final
+        # SolveResult certifies (both are the same certified global bound; the
+        # callback is a snapshot of it). Over-reporting = the A1 bug.
+        m = discopt.Model("cb_min_bound")
+        n = m.integer("n", lb=1, ub=20)
+        x = m.continuous("x", lb=0.01, ub=20.0)
+        m.minimize((x - n) ** 2 * n - 10.0 * x / n)  # nonconvex product/reciprocal
+        m.subject_to(x * n >= 12.0)
+        m.subject_to(x + n <= 30.0)
+
+        bounds: list = []
+
+        def cb(ctx, _model):
+            bounds.append(ctx.best_bound)
+
+        res = m.solve(time_limit=5, gap_tolerance=1e-4, node_callback=cb)
+        assert res.status in ("optimal", "feasible")
+        finite = [b for b in bounds if b is not None and np.isfinite(b)]
+        if res.bound is not None and np.isfinite(res.bound):
+            for b in finite:
+                # MINIMIZE: a certified lower bound never exceeds the finally
+                # certified lower bound by more than solver tolerance.
+                assert b <= res.bound + 1e-4, (
+                    f"callback best_bound {b} over-reports the final certified bound {res.bound}"
+                )


### PR DESCRIPTION
## A1 — kill criterion fired: the callback over-reports, `SolveResult.bound` was already correct

Implements task **A1** from `docs/dev/perf-followup-plan-2026-07-05.md` §2. The A1
entry experiment proved **case (b)** (the callback-API soundness bug), not the
bound-adoption case (a), so per the plan's kill-criterion instructions this PR
fixes the callback and files a new correctness item instead of adopting the tree
frontier bound.

### Entry experiment (evidence, run before implementing)
nvs05 (`python/tests/data/minlplib_nl/nvs05.nl`, MINIMIZE, opt 5.470934),
`solve(time_limit=60, gap_tolerance=1e-4)` with a `node_callback` trace,
Apple M4 Pro, pounce 0.7.0, `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`, `maturin --release`:

| quantity | value | valid? |
|---|---:|---|
| `SolveResult.bound` (reported) | **1.348** | ✓ ≤ opt 5.470934 — sound (the rigorous root-relaxation fallback) |
| tree `global_lower_bound` = callback `best_bound` (last) | **5.32** | ✗ NOT a certified global bound |
| `root_bound` | 0.674 | |
| known optimum | 5.470934 | |

**Why 5.32 is not certified:** nvs05 makes **89 non-rigorous sentinel fathoms**
(a node NLP that merely failed/diverged, sentinel-pruned with **no** FBBT
infeasibility proof — `solver.py:5814`/`5842`; 7 such prunes already inside 20 s).
Each removes an *unproven* subtree from the open frontier. A pruned-but-unproven
subtree is not proven suboptimal, so the surviving-frontier minimum (5.32) may sit
strictly **above** the true certified global bound. The final result-assembly path
already knows this — it drops the tree bound whenever the tree is tainted
(`_tree_bound_valid = _gap_certified`, `solver.py:7107`/`8336`) and falls back to
the rigorous root relaxation, giving the correct 1.348. The **callback** did not:
it surfaced `stats["global_lower_bound"]` raw (and, latent, never negated it for
MAXIMIZE).

So (a) does **not** apply — the reported bound is already the tightest *valid*
bound. The defect is over-reporting on the public callback surface.

### Fix (file:line)
`python/discopt/solver.py`:
- New helper **`_certified_callback_bound(global_lower_bound, tree_bound_valid,
  is_maximize) -> Optional[float]`** (solver.py ~1505). Returns `None` on a tainted
  tree, on the failure/`1e30` sentinel, or on a non-finite (`-inf`) bound;
  otherwise the sense-corrected bound (negated for MAXIMIZE).
- All three `CallbackContext(...)` sites route through it: the lazy-constraint
  helper `_invoke_pre_import_callbacks` (new `tree_bound_valid=_gap_certified`
  kwarg, threaded from `solve_model`), and the two `node_callback` sites in
  `solve_model` and `_solve_nlp_bb` (both already have `_gap_certified` in scope).

`python/discopt/callbacks.py`: `CallbackContext.best_bound` retyped `float | None`;
docstring + example updated. `discopt_benchmarks/benchmarks/runner.py`: trajectory
recorder made `None`-safe.

**Invariant established:** the callback's `best_bound` never exceeds what the final
`SolveResult.bound` would certify.

Filed as **C-37** (P2) in `docs/dev/correctness-issues.md`.

### Before / after (nvs05 @ 60 s)
- `SolveResult.bound`: **1.348 → 1.348 (unchanged)** — the reported bound was
  correct; this PR does not touch it.
- callback `best_bound` trace: **max 5.32 → max 2.04, then `None`** — reports the
  honest climbing bound until the first non-rigorous fathom, then `None` (no
  certified global bound). No more 5.32 over-report.

The reported gap stays 75.4 % because that is the honest gap for a bound that is
only rigorously 1.348; closing it is the job of the relaxation/engine tasks (F5/F6),
not this correctness fix.

### Regime + gates
Correctness fix; **bound-neutral for the reported `SolveResult`** (callback surface
only). Verified on a 6-instance panel (nvs05, nvs13, m3, nvs01, st_e36, ex1224 @8 s):
`status`/`objective`/`bound` **identical** pre vs post; no reported bound crosses its
`minlplib.solu` oracle; reported gaps unchanged. (nvs05 `node_count` jitters 245↔247
across identical post-fix runs — pure wall-clock noise on a time-limited instance,
not this change; `bound` is byte-stable.)

- **Regression test** (`python/tests/test_callbacks.py`): `TestCertifiedCallbackBound`
  (5 unit — minimize passthrough, maximize negation, tainted→None, `-inf`→None,
  sentinel/None→None) + `TestCallbackBoundSoundness` (2 integration on small
  **non-named** nonconvex models — maximize `best_bound` is a valid upper bound;
  minimize `best_bound` never exceeds the final certified bound). **6/7 fail on
  pre-fix code** (helper ImportError; the maximize wrong-sign assertion); all pass
  after.
- `pytest -m smoke` (python/tests): **563 passed, 14 skipped**.
- adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`):
  **10 passed**.
- `test_callbacks.py` full: **30 passed**.
- `ruff check`, `ruff format --check`, `mypy python/discopt/` via the pinned
  pre-commit hooks: **pass**. No Rust touched (`cargo test` not required).

`incorrect_count = 0` on every panel run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
