### PR TITLE
fix(correctness): A2 — no 1e30 sentinel through any bound/gap API + non-rigorous-fathom decertification test

### DIFF
--- a/docs/dev/perf-followup-plan-2026-07-05.md
+++ b/docs/dev/perf-followup-plan-2026-07-05.md
@@ -141,6 +141,21 @@ worktrees/sessions if desired, but each in its own PR.
 
 ### A2 — `best_bound = 1e30` sentinel leaks into the public callback API  (P2, correctness/API)
 
+- **Status: DONE** (branch `fix-a2-sentinel-callback-audit`). The full audit found
+  the sentinel could still escape through `SolveResult.bound`/`.gap` and
+  `root_bound`/`root_gap` (the callback surface was already fixed by A1/#498): the
+  result-assembly paths (`solver.py` spatial ~7137, nlp_bb ~8380) set
+  `bound_val = stats["global_lower_bound"]` and only guarded with `np.isfinite`,
+  which passes the finite `1e30`. Fixed centrally in `SolveResult.__post_init__`
+  (`modeling/core.py`) — the single chokepoint every construction path funnels
+  through — by mapping any sentinel-magnitude `bound`/`root_bound` (either sense) to
+  `None` and clearing its gap. Callback `gap` is now gated on `best_bound is not
+  None` at all three `CallbackContext` sites. Bound-neutral: node_count and
+  certified objective exactly unchanged on the nonconvex cert subset; the one
+  intended output delta is the no-relaxation class now reporting `bound=None`
+  instead of `1e30`. Tests: `test_a2_sentinel_bound_api.py` (6),
+  `test_nonrigorous_fathom_decertifies_optimal.py` (5, incl. the previously-untested
+  false-*optimal* decertification lock).
 - **Evidence** (profile §6): on the no-relaxation class (hda, heatexch_gen3)
   `node_callback` receives `best_bound = 1e30` instead of "no bound".
 - **Implementation sketch:** at the callback marshaling site, map the

--- a/python/discopt/callbacks.py
+++ b/python/discopt/callbacks.py
@@ -54,7 +54,9 @@ class CallbackContext:
         omits rows so no dual bound exists. Never over-reports: this value never
         exceeds what the final ``SolveResult.bound`` would certify (A1).
     gap : float or None
-        Relative optimality gap, or None if no incumbent exists.
+        Relative optimality gap, or None if no incumbent exists — and also None
+        whenever ``best_bound`` is None, since a gap against a non-bound (a
+        tainted tree or the failure sentinel) is meaningless (A2).
     elapsed_time : float
         Wall-clock seconds since solve started.
     x_relaxation : numpy.ndarray

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -44,6 +44,8 @@ from typing import (
 
 import numpy as np
 
+from discopt.constants import SENTINEL_THRESHOLD as _SENTINEL_THRESHOLD
+
 if TYPE_CHECKING:
     from discopt.modeling.indexed import IndexedParam, IndexedVar
     from discopt.modeling.sets import _SetBase
@@ -1437,6 +1439,30 @@ class SolveResult:
     _sensitivity: Optional[np.ndarray] = None
 
     def __post_init__(self) -> None:
+        # A2 (correctness/API): the failure/no-relaxation sentinel must never
+        # escape through the public bound/gap surface. Internally the solver
+        # stores ``INFEASIBILITY_SENTINEL`` (``1e30``) as the "lower bound" of a
+        # node whose relaxation failed or was declared infeasible, and on the
+        # no-relaxation class (a model whose relaxation omits rows, so no dual
+        # bound is ever produced) the tree's ``global_lower_bound`` stays at that
+        # sentinel. It is *finite* (``np.isfinite(1e30)`` is True), so the
+        # existing non-finite guard below does not catch it, and a raw
+        # result-assembly path would surface ``bound=1e30`` — and a ``gap``
+        # computed from it — as if it were a real dual bound. Map any
+        # sentinel-magnitude bound (either sense, so ``-1e30`` from a MAXIMIZE
+        # negation too) to ``None`` at this single chokepoint that every
+        # ``SolveResult`` construction passes through, so no public consumer
+        # (``.bound``/``.gap``, the callback, commentary, the dashboard, the
+        # benchmark JSON) ever does arithmetic on it. This is a
+        # representation/reporting normalisation only — the internal sentinel is
+        # unchanged. ``root_bound``/``root_gap`` get the same treatment.
+        if self.bound is not None and abs(self.bound) >= _SENTINEL_THRESHOLD:
+            self.bound = None
+            self.gap = None
+        if self.root_bound is not None and abs(self.root_bound) >= _SENTINEL_THRESHOLD:
+            self.root_bound = None
+            self.root_gap = None
+
         # Soundness guard: a *certified* optimality gap requires a finite dual
         # bound. A non-finite bound (``±inf``) or an absent bound (``None``)
         # certifies nothing about optimality — e.g. a ``time_limit`` termination

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1502,6 +1502,31 @@ def _solve_root_node_multistart(
     return last_result
 
 
+def _nonrigorous_sentinel_fathom(node_lower_bound: float, node_infeasible: bool) -> bool:
+    """Whether a nonconvex node is being fathomed *non-rigorously* (issue #27a).
+
+    A node carrying the failure sentinel (``result_lbs[i] >= SENTINEL_THRESHOLD``)
+    but *without* a rigorous infeasibility proof (``node_infeasible`` False — no
+    empty McCormick/LP relaxation over the finite box, no
+    ``SolveStatus.INFEASIBLE``) is pruned without being proven suboptimal: its
+    local NLP merely failed / diverged, or its optimum violated the original
+    constraints, neither of which rules out a better point in the subtree. The
+    Rust tree still mechanically cuts that subtree by bound (``1e30 >=``
+    incumbent, ``tree_manager.rs``), so the *gap* it reports is not certified.
+    When this returns True the caller must set ``_gap_certified = False`` so the
+    terminal verdict downgrades from "optimal" to "feasible" — a non-rigorous
+    fathom can never certify global optimality.
+
+    A rigorously-infeasible node (``node_infeasible`` True) does NOT decertify:
+    an empty relaxation over the box is a valid emptiness proof, so pruning it is
+    sound. Extracted from the two twin call sites (serial + batch nonconvex
+    finalize) as a pure predicate so the decertification decision is unit
+    testable; the behaviour is byte-for-byte the previous inline logic
+    (bound-neutral).
+    """
+    return node_lower_bound >= _SENTINEL_THRESHOLD and not node_infeasible
+
+
 def _certified_callback_bound(
     global_lower_bound: Optional[float],
     tree_bound_valid: bool,
@@ -1607,7 +1632,11 @@ def _invoke_pre_import_callbacks(
             node_count=stats["total_nodes"],
             incumbent_obj=inc_obj,
             best_bound=_cb_bound,
-            gap=stats.get("gap"),
+            # A2: the gap is only meaningful against a certified dual bound. When
+            # ``best_bound`` is None (tainted tree / failure sentinel), the raw
+            # ``stats["gap"]`` was computed from that same non-bound, so surface
+            # None rather than a gap derived from the sentinel.
+            gap=(stats.get("gap") if _cb_bound is not None else None),
             elapsed_time=elapsed,
             x_relaxation=result_sols[i].copy(),
             node_bound=float(result_lbs[i]),
@@ -5529,7 +5558,7 @@ def solve_model(
                         pass
                     elif not np.isfinite(result_lbs[i]):
                         result_lbs[i] = _INFEASIBILITY_SENTINEL
-                    elif result_lbs[i] >= _SENTINEL_THRESHOLD and not node_infeasible_mask[i]:
+                    elif _nonrigorous_sentinel_fathom(result_lbs[i], node_infeasible_mask[i]):
                         # Soundness guard (issue #27a, batch parity with the
                         # serial path): a node carrying the failure sentinel
                         # without an FBBT infeasibility proof is pruned without
@@ -5855,7 +5884,7 @@ def solve_model(
                         pass
                     elif not np.isfinite(result_lbs[i]):
                         result_lbs[i] = _INFEASIBILITY_SENTINEL
-                    elif result_lbs[i] >= _SENTINEL_THRESHOLD:
+                    elif _nonrigorous_sentinel_fathom(result_lbs[i], node_infeasible_mask[i]):
                         _gap_certified = False
 
                 # C-13: convex node whose NLP objective was NOT a valid lower bound
@@ -6884,13 +6913,16 @@ def solve_model(
                 _cb_is_max = (
                     model._objective is not None and model._objective.sense == _ObjSense.MAXIMIZE
                 )
+                _cb_bound = _certified_callback_bound(
+                    stats_snap.get("global_lower_bound"), _gap_certified, _cb_is_max
+                )
                 ctx = CallbackContext(
                     node_count=stats_snap["total_nodes"],
                     incumbent_obj=inc_obj_cb,
-                    best_bound=_certified_callback_bound(
-                        stats_snap.get("global_lower_bound"), _gap_certified, _cb_is_max
-                    ),
-                    gap=stats_snap.get("gap"),
+                    best_bound=_cb_bound,
+                    # A2: no certified bound -> no meaningful gap (the raw gap was
+                    # derived from the same non-bound). See the pre-import site.
+                    gap=(stats_snap.get("gap") if _cb_bound is not None else None),
                     elapsed_time=time.perf_counter() - t_start,
                     x_relaxation=result_sols[best_idx].copy(),
                     node_bound=float(result_lbs[best_idx]),
@@ -8087,13 +8119,16 @@ def _solve_nlp_bb(
                 _cb_is_max = (
                     model._objective is not None and model._objective.sense == _ObjSense.MAXIMIZE
                 )
+                _cb_bound = _certified_callback_bound(
+                    stats_snap.get("global_lower_bound"), _gap_certified, _cb_is_max
+                )
                 ctx = CallbackContext(
                     node_count=stats_snap["total_nodes"],
                     incumbent_obj=inc_obj_cb,
-                    best_bound=_certified_callback_bound(
-                        stats_snap.get("global_lower_bound"), _gap_certified, _cb_is_max
-                    ),
-                    gap=stats_snap.get("gap"),
+                    best_bound=_cb_bound,
+                    # A2: no certified bound -> no meaningful gap (the raw gap was
+                    # derived from the same non-bound). See the pre-import site.
+                    gap=(stats_snap.get("gap") if _cb_bound is not None else None),
                     elapsed_time=time.perf_counter() - t_start,
                     x_relaxation=result_sols[best_idx].copy(),
                     node_bound=float(result_lbs[best_idx]),

--- a/python/tests/test_a2_sentinel_bound_api.py
+++ b/python/tests/test_a2_sentinel_bound_api.py
@@ -1,0 +1,147 @@
+"""A2 soundness lock: the 1e30 failure sentinel must never escape a bound/gap API.
+
+Internally the solver stores ``INFEASIBILITY_SENTINEL`` (1e30) as the "lower bound"
+of a node whose relaxation failed / was declared infeasible, and on the
+*no-relaxation* class (a model whose relaxation omits rows, so no dual bound is ever
+produced — e.g. hda / heatexch_gen3) the tree's ``global_lower_bound`` stays at that
+sentinel through to result assembly. It is *finite* (``np.isfinite(1e30)`` is True),
+so the pre-A2 non-finite guard did not catch it: a raw result-assembly path could
+surface ``SolveResult.bound = 1e30`` — and a ``gap`` computed from it — as if it were
+a real dual bound.
+
+A1 (#498) fixed only the callback ``best_bound`` dataclass surface. A2 establishes
+the *invariant* across every public bound/gap surface at the single chokepoint every
+``SolveResult`` construction passes through (``SolveResult.__post_init__``): a
+sentinel-magnitude ``bound``/``root_bound`` (either sense) is mapped to ``None`` and
+its gap cleared. Consumers (``SolveResult.bound``/``.gap``, the benchmark JSON via
+``runner``, the LLM serializer/diagnosis, the callback) then never do arithmetic on
+the sentinel. This is a representation/reporting normalisation only; the internal
+sentinel is unchanged.
+
+Fail-before: on pre-A2 code ``SolveResult(bound=1e30, ...)`` retained ``bound=1e30``
+(``np.isfinite`` passed it), and the callback ``gap`` was surfaced even when
+``best_bound`` was ``None``.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+import pytest
+from discopt.constants import INFEASIBILITY_SENTINEL, SENTINEL_THRESHOLD
+from discopt.modeling.core import SolveResult
+
+
+@pytest.mark.smoke
+def test_solveresult_bound_sentinel_scrubbed_to_none():
+    """A ``SolveResult`` built with the raw failure sentinel as its bound must
+    expose ``bound=None`` and ``gap=None`` — never 1e30."""
+    r = SolveResult(
+        status="feasible",
+        objective=10.0,
+        bound=INFEASIBILITY_SENTINEL,
+        gap=0.5,
+        gap_certified=False,
+    )
+    assert r.bound is None, f"sentinel leaked through SolveResult.bound: {r.bound}"
+    assert r.gap is None, f"gap computed from sentinel leaked: {r.gap}"
+
+
+@pytest.mark.smoke
+def test_solveresult_negated_sentinel_scrubbed():
+    """A MAXIMIZE model negates the internal minimization bound, so the sentinel can
+    arrive as ``-1e30``; that too must be scrubbed to ``None``."""
+    r = SolveResult(
+        status="feasible",
+        objective=10.0,
+        bound=-INFEASIBILITY_SENTINEL,
+        gap=0.5,
+        gap_certified=False,
+    )
+    assert r.bound is None
+    assert r.gap is None
+
+
+@pytest.mark.smoke
+def test_solveresult_root_bound_sentinel_scrubbed():
+    """The root-node instrumentation bound funnels through the same guard: a
+    sentinel ``root_bound`` -> ``None`` with ``root_gap`` cleared, and the real
+    primary ``bound`` is untouched."""
+    r = SolveResult(
+        status="feasible",
+        objective=10.0,
+        bound=5.0,
+        gap=0.5,
+        root_bound=INFEASIBILITY_SENTINEL,
+        root_gap=0.99,
+        gap_certified=False,
+    )
+    assert r.root_bound is None
+    assert r.root_gap is None
+    assert r.bound == 5.0, "a real primary bound must not be scrubbed"
+
+
+@pytest.mark.smoke
+def test_solveresult_real_bound_preserved():
+    """A genuine finite bound below the sentinel threshold must pass through
+    untouched — the guard must not over-scrub legitimate large objectives."""
+    r = SolveResult(status="optimal", objective=1e25, bound=1e25, gap=0.0, gap_certified=True)
+    assert r.bound == 1e25
+    assert r.gap == 0.0
+    # A value just under the threshold is still a real bound.
+    r2 = SolveResult(
+        status="feasible",
+        objective=SENTINEL_THRESHOLD * 0.9,
+        bound=SENTINEL_THRESHOLD * 0.9,
+        gap=0.1,
+        gap_certified=False,
+    )
+    assert r2.bound == SENTINEL_THRESHOLD * 0.9
+
+
+@pytest.mark.smoke
+def test_solveresult_non_finite_bound_still_scrubbed():
+    """Regression guard: the existing non-finite (+/-inf) scrub is preserved
+    alongside the new sentinel scrub."""
+    r = SolveResult(status="feasible", objective=1.0, bound=-np.inf, gap=0.5, gap_certified=True)
+    assert r.bound is None
+    assert r.gap is None
+    assert r.gap_certified is False
+
+
+@pytest.mark.smoke
+def test_callback_gap_none_when_best_bound_none():
+    """A2 callback-surface consistency: when the certified ``best_bound`` is ``None``
+    (tainted tree / failure sentinel), a real solve's callback must not hand out a
+    ``gap`` derived from that non-bound. Exercised end-to-end on a small model whose
+    node callback records every (best_bound, gap) pair."""
+    from discopt import Model
+    from discopt.callbacks import CallbackContext
+
+    m = Model("cb_gap_consistency")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=4.0)
+    z = m.integer("z", lb=0, ub=2)
+    m.subject_to(x * y >= 1.0)
+    m.minimize(x + y + z)
+
+    pairs: list[tuple[float | None, float | None]] = []
+
+    def _cb(ctx: CallbackContext, _model) -> None:
+        pairs.append((ctx.best_bound, ctx.gap))
+
+    m.solve(time_limit=10.0, node_callback=_cb)
+
+    # The invariant: no callback ever reports a gap while best_bound is None.
+    for bb, gap in pairs:
+        assert not (bb is None and gap is not None), (
+            f"callback surfaced gap={gap} with best_bound=None (gap from a non-bound)"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/tests/test_nonrigorous_fathom_decertifies_optimal.py
+++ b/python/tests/test_nonrigorous_fathom_decertifies_optimal.py
@@ -1,0 +1,214 @@
+"""Soundness lock: a non-rigorous NLP fathom must never yield a certified OPTIMAL.
+
+Companion to the C-1 test (``test_c1_nlp_fathom_infeasible.py``), which pins the
+false-*infeasible* verdict. This file pins the *other* false verdict off the same
+mechanism: false-*optimal*.
+
+Mechanism (confirmed SOUND by construction, previously UNtested):
+
+  * A node whose local NLP merely fails / diverges / returns a constraint-violating
+    iterate is sentinelled with ``result_lbs[i] = INFEASIBILITY_SENTINEL`` (1e30)
+    and *no* rigorous infeasibility proof (``node_infeasible_mask[i] == False``).
+  * The Rust tree still mechanically cuts that node's subtree by bound
+    (``1e30 >= incumbent`` -> fathom-by-bound, no children — ``tree_manager.rs``).
+    Nothing in the subtree is proven suboptimal; the search is only *mechanically*
+    closed, not *certifiably* closed.
+  * The Python guard (``solver.py`` nonconvex finalize, serial + batch twins) sets
+    ``_gap_certified = False`` for exactly this case (sentinel bound AND not
+    rigorously infeasible). The terminal verdict is
+    ``status = "optimal" if search_closed and _gap_certified else "feasible"``, so a
+    non-rigorous fathom forces "feasible", never "optimal".
+
+The guard is a one-line predicate now extracted to
+``solver._nonrigorous_sentinel_fathom`` so the *decision* is directly unit
+testable. ``test_guard_*`` pin that predicate (fail-before: stubbing it to
+always-True mislabels a sound rigorous prune; always-False mislabels a
+non-rigorous fathom). ``test_integration_*`` exercises the whole path: a feasible
+nonconvex model with a real incumbent whose one remaining node is fathomed
+non-rigorously must report "feasible", not "optimal".
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.solver as S
+import numpy as np
+import pytest
+from discopt import Model
+from discopt.constants import INFEASIBILITY_SENTINEL, SENTINEL_THRESHOLD
+from discopt.solvers import NLPResult, SolveStatus
+
+# ---------------------------------------------------------------------------
+# Focused guard unit tests (deterministic; the primary lock)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_guard_nonrigorous_sentinel_fathom_decertifies():
+    """A sentinel-bound node with NO rigorous infeasibility proof is a
+    non-rigorous fathom -> the predicate is True (caller sets _gap_certified=False,
+    downgrading the terminal verdict from 'optimal' to 'feasible')."""
+    # bound at the failure sentinel, node_infeasible_mask[i] == False
+    assert S._nonrigorous_sentinel_fathom(INFEASIBILITY_SENTINEL, False) is True
+    # any bound at/above the threshold, still not rigorously infeasible
+    assert S._nonrigorous_sentinel_fathom(SENTINEL_THRESHOLD, False) is True
+    assert S._nonrigorous_sentinel_fathom(1e30, False) is True
+
+
+@pytest.mark.smoke
+def test_guard_rigorous_infeasible_does_not_decertify():
+    """A RIGOROUSLY infeasible node (empty relaxation over the finite box ->
+    node_infeasible_mask[i] == True) is a SOUND prune: the predicate is False, so
+    the gap is NOT decertified. This is the branch that must never be swallowed by
+    an over-eager guard."""
+    assert S._nonrigorous_sentinel_fathom(INFEASIBILITY_SENTINEL, True) is False
+    assert S._nonrigorous_sentinel_fathom(1e30, True) is False
+
+
+@pytest.mark.smoke
+def test_guard_finite_bound_is_not_a_fathom():
+    """A node carrying a real finite relaxation bound is not being fathomed on the
+    failure sentinel at all -> the predicate is False regardless of the mask."""
+    assert S._nonrigorous_sentinel_fathom(5.0, False) is False
+    assert S._nonrigorous_sentinel_fathom(-1.0e6, False) is False
+    assert S._nonrigorous_sentinel_fathom(0.0, True) is False
+
+
+@pytest.mark.smoke
+def test_guard_fail_before_evidence_always_true_stub_is_wrong():
+    """Fail-before witness. If the guard were stubbed to ALWAYS return True (the
+    naive 'always decertify' over-guard), it would mislabel a sound rigorous prune
+    as a taint. Pin that the real predicate distinguishes the two cases, so such a
+    stub would flip this assertion."""
+
+    def _always_true(_lb, _infeasible):
+        return True
+
+    # The real predicate separates rigorous (False) from non-rigorous (True);
+    # an always-True stub collapses them and this assertion catches it.
+    assert S._nonrigorous_sentinel_fathom(1e30, True) != _always_true(1e30, True)
+    # Symmetric fail-before for an always-False stub (which would let a
+    # non-rigorous fathom certify a false optimum):
+    assert S._nonrigorous_sentinel_fathom(1e30, False) != (lambda *_: False)()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration: whole path from a model to the terminal verdict
+# ---------------------------------------------------------------------------
+
+
+def _build_feasible_nonconvex_minlp():
+    """A genuinely FEASIBLE nonconvex MINLP (integer var routes it onto the spatial
+    B&B batch path). Feasible point x=y=1 (x*y=1>=1), z=1 -> objective 3."""
+    m = Model("nonrigorous_optimal")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=4.0)
+    z = m.integer("z", lb=1, ub=3)
+    m.subject_to(x * y >= 1.0)
+    m.minimize(x + y + z)
+    return m
+
+
+class _IncumbentThenExhaustTree:
+    """Wraps the real B&B tree: holds a genuine feasible incumbent (so the terminal
+    path takes the WITH-incumbent branch), then reports the search finished after
+    the first batch import. This is the tree state produced when a real incumbent is
+    in hand but every *remaining* open node carries a non-rigorous failure sentinel
+    and is fathomed by bound — the false-optimal setup.
+
+    The incumbent (x=y=1, z=1, obj=3) is genuinely feasible for the model
+    (x*y=1>=1); it is not the certified global optimum, and it was NOT proven so
+    because the only thing that closed the tree was the non-rigorous sentinel
+    fathom. So the honest verdict is "feasible", never "optimal".
+    """
+
+    def __init__(self, real_cls, *a, **k):
+        self._t = real_cls(*a, **k)
+        self._imported = 0
+        # A genuinely feasible point for _build_feasible_nonconvex_minlp:
+        # x=1, y=1, z=1 (order matches variable creation) -> x*y=1>=1, obj=3.
+        self._inc = (np.array([1.0, 1.0, 1.0], dtype=float), 3.0)
+
+    def inject_incumbent(self, sol, obj):
+        # A better feasible incumbent may legitimately replace the seed, but never
+        # a bogus (sentinel) one.
+        if np.isfinite(obj) and obj < SENTINEL_THRESHOLD and obj < self._inc[1]:
+            self._inc = (np.asarray(sol, dtype=float).copy(), float(obj))
+        return None
+
+    def import_results(self, ids, lbs, sols, feas):
+        self._imported += 1
+        return self._t.import_results(ids, lbs, sols, feas)
+
+    def incumbent(self):
+        return self._inc
+
+    def is_finished(self):
+        return self._imported >= 1
+
+    def __getattr__(self, name):
+        return getattr(self._t, name)
+
+
+def _nonrigorous_failing_node_nlp(
+    evaluator, x0, node_lb, node_ub, constraint_bounds, options, nlp_solver="ipopt", convex=False
+):
+    """Non-rigorous failure: return an 'optimal'-status point at the lower corner
+    that violates the model's x*y>=1 constraint (lower corner has x*y=0). The node
+    is sentinelled with NO infeasibility proof — a classic non-rigorous fathom."""
+    xbad = np.clip(np.asarray(node_lb, dtype=float), -1e6, 1e6)
+    return NLPResult(
+        status=SolveStatus.OPTIMAL, x=xbad, objective=float(np.sum(xbad)), iterations=1
+    )
+
+
+@pytest.mark.smoke
+def test_integration_nonrigorous_fathom_reports_feasible_not_optimal(monkeypatch):
+    """A feasible nonconvex model with a real incumbent, whose remaining node is
+    fathomed non-rigorously (local NLP fails, no infeasibility proof, no rigorous
+    relaxation bound), must report status 'feasible' with gap NOT certified —
+    NEVER 'optimal'. A certified optimum here would be a false global-optimality
+    claim off an unproven subtree."""
+    m = _build_feasible_nonconvex_minlp()
+    real_cls = S.PyTreeManager
+
+    monkeypatch.setattr(
+        S, "PyTreeManager", lambda *a, **k: _IncumbentThenExhaustTree(real_cls, *a, **k)
+    )
+    monkeypatch.setattr(S, "_solve_node_nlp", _nonrigorous_failing_node_nlp)
+    # No rigorous relaxation bound available: the only thing removing a node from
+    # the tree is the non-rigorous sentinel.
+    monkeypatch.setattr(S, "_compute_interval_bound", lambda *a, **k: -np.inf)
+
+    res = S.solve_model(
+        m,
+        time_limit=20.0,
+        max_nodes=5000,
+        mccormick_bounds="none",
+        nlp_solver="ipopt",
+        subnlp_enabled=False,
+        rens=False,
+        presolve=False,
+        skip_convex_check=True,
+    )
+
+    # Headline soundness assertion: a non-rigorous fathom must NOT certify optimal.
+    assert res.status != "optimal", (
+        "non-rigorous fathom falsely certified global optimality "
+        f"(status={res.status!r}, gap_certified={getattr(res, 'gap_certified', None)})"
+    )
+    assert res.status == "feasible", f"expected 'feasible', got {res.status!r}"
+    assert not getattr(res, "gap_certified", False), (
+        "gap must not be certified when a node was fathomed non-rigorously"
+    )
+    # A2 corollary: no sentinel escapes through the public bound/gap surface.
+    if res.bound is not None:
+        assert abs(res.bound) < SENTINEL_THRESHOLD, f"sentinel leaked into bound: {res.bound}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Implements **A2** from `docs/dev/perf-followup-plan-2026-07-05.md` §2 — the full
sentinel audit A1/#498 explicitly deferred — plus a defense-in-depth soundness
regression test for the (previously untested) non-rigorous-fathom false-*optimal*
guard.

## The leak A2 fixes (A1 only touched the callback dataclass)

A1 made the callback `best_bound` None-correct. A2 audits the *consumers* and the
`SolveResult.bound`/`.gap` surface. The result-assembly paths
(`solver.py` spatial ~7137, nlp_bb ~8380) do
`bound_val = stats["global_lower_bound"]` and guard only with `np.isfinite` — which
**passes the finite `1e30`**. On the no-relaxation class (a model whose relaxation
omits rows so no dual bound is ever produced — hda / heatexch_gen3) that surfaced
`SolveResult.bound = 1e30` and a `gap` computed from it as a real dual bound.
`root_bound`/`root_gap` had the same hole.

## Fix (representation/reporting only — internal sentinel unchanged)

- **Central invariant in `SolveResult.__post_init__`** (`modeling/core.py`), the
  single chokepoint every construction path (spatial, nlp_bb, MILP, AMP, convex)
  funnels through: map any sentinel-magnitude `bound`/`root_bound` (either sense,
  so the MAXIMIZE-negated `-1e30` too) to `None` and clear its gap. Placed just
  before the existing non-finite (`±inf`) guard, which is preserved.
- **Callback `gap` consistency**: gate `gap` on `best_bound is not None` at all
  three `CallbackContext` sites (a gap against a non-bound is meaningless).

### Consumers audited
`llm/serializer`, `llm/diagnosis`, `result_io`, `benchmarks/runner` (JSON),
`solvers/{oa,gdpopt_loa,amp,milp_pounce}`, `_jax/*` — all read via
`SolveResult.bound`/`.gap` or already None-guard, so fixing the source makes them
sound automatically. The `SENTINEL_THRESHOLD` machinery inside `solver.py` is
untouched.

## PLUS: non-rigorous-fathom decertification test

A non-rigorous NLP-failure sentinel fathom mechanically cuts a node's subtree in
Rust (`1e30 >= incumbent`) but the Python guard forces `_gap_certified = False` so
the verdict is `"feasible"`, never a false `"optimal"`. The C-1 tests cover only
the false-*infeasible* flag; this pins the false-*optimal* guard. The one-line
predicate is extracted to `solver._nonrigorous_sentinel_fathom` (byte-for-byte
equivalent, wired into both twin call sites) so the decision is directly unit
testable.

## Regime + verification

**Bound-neutral** (representation/reporting only). `node_count` and certified
`objective` **exactly unchanged** on the nonconvex cert subset (alan, nvs01/02/06/08,
ex1221/1224, gbd): nodes `==`, `|Δobj| = 0.00e+00`. The **one intended output delta**:
the no-relaxation class now reports `bound=None` instead of `1e30`.

Fail-before / pass-after:
- `test_a2_sentinel_bound_api.py` (6): 3 assertions fail on pre-A2 code (`bound`/
  `-bound`/`root_bound` retained `1e30`), all pass after.
- `test_nonrigorous_fathom_decertifies_optimal.py` (5): disabling the guard flips
  the integration verdict to a certified `"optimal"` (`status='optimal'` observed);
  with the guard it reports `"feasible"`.

## Gates

- `pytest -m smoke` (python/tests): **576 passed, 1 skipped**
- adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`):
  **10 passed**
- `ruff check` + `ruff format --check`: pass
- `mypy python/discopt/`: clean on changed files (a pre-existing local numpy-stub /
  target mismatch is unrelated and identical on `main`; the pre-commit mypy hook runs
  its own pinned numpy and passed)
- Related regressions (`test_callbacks`, `test_c1_nlp_fathom_infeasible`,
  `test_tainted_tree_bound`, `test_batch_sentinel_soundness`): 17 passed
- No Rust touched, so `cargo test` N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
