### PR TITLE
fix(bench): A3 — worker res.bound + dual-bound-vs-oracle violation check

### DIFF
--- a/discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py
+++ b/discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py
@@ -95,18 +95,45 @@ def _claims_global(status: str) -> bool:
 OK, GAP, VIOLATION, NA = "ok", "GAP", "VIOLATION", "n/a"
 
 
-def classify(status: str, obj: float | None, known: float | None, maximize: bool) -> str:
+def bound_violates_oracle(bound: float | None, known: float | None, maximize: bool) -> bool:
+    """Does the reported *dual bound* cross the known global optimum?
+
+    The certificate invariant (CLAUDE.md): a valid dual bound never crosses the
+    oracle — for a minimize problem the lower bound must satisfy ``bound <= opt``;
+    for maximize the upper bound must satisfy ``bound >= opt``. A bound on the
+    wrong side of the proven global (beyond tolerance) is an invalid bound — a
+    false certificate seed — regardless of whether the incumbent is correct.
+    None bound / no oracle → cannot judge → not a violation.
+    """
+    if bound is None or known is None or math.isnan(known):
+        return False
+    tol = RTOL * max(1.0, abs(known)) + ATOL
+    return (bound < known - tol) if maximize else (bound > known + tol)
+
+
+def classify(
+    status: str,
+    obj: float | None,
+    known: float | None,
+    maximize: bool,
+    bound: float | None = None,
+) -> str:
     """Honest correctness verdict against the proven global.
 
     - ``ok``        : incumbent matches the known global within tolerance.
-    - ``VIOLATION`` : the non-negotiable red line — either the solver *claimed*
-                      a certified global with the wrong value, or it returned an
-                      incumbent strictly *better* than the proven global (an
-                      impossible bound, i.e. a relaxation/incumbent bug).
+    - ``VIOLATION`` : the non-negotiable red line — the solver *claimed* a
+                      certified global with the wrong value, returned an incumbent
+                      strictly *better* than the proven global, or reported a
+                      *dual bound that crosses the oracle* (an impossible bound,
+                      i.e. a relaxation/incumbent/bound bug).
     - ``GAP``       : an honest feasible/uncertified incumbent that is *worse*
                       than the global — a convergence gap, not a correctness bug.
     - ``n/a``       : no oracle, or no incumbent returned.
     """
+    # An invalid dual bound is a VIOLATION even when the incumbent is fine or
+    # absent — it is the core certificate failure.
+    if bound_violates_oracle(bound, known, maximize):
+        return VIOLATION
     if obj is None or known is None or math.isnan(known):
         return NA
     if matches(obj, known):
@@ -151,7 +178,11 @@ try:
     model = from_nl(nl)
     res = model.solve(time_limit=tl, gap_tolerance=1e-4)
     dt = time.perf_counter() - t0
-    lb = getattr(res, "lower_bound", None)
+    # A3: SolveResult exposes the certified dual bound as ``.bound`` (there is no
+    # ``.lower_bound`` attribute — the old name silently read None on every run).
+    # After A2, ``.bound`` is None on the no-relaxation class rather than a 1e30
+    # sentinel, so a None here means "no dual bound", not "read failed".
+    lb = getattr(res, "bound", None)
     print(json.dumps({
         "ok": True,
         "status": str(getattr(res, "status", "")),
@@ -317,8 +348,20 @@ def tri(v: bool | None) -> str:
 
 
 def finalize(row: Row) -> Row:
-    row.d_verdict = classify(row.discopt.status, row.discopt.objective, row.known, row.maximize)
-    row.b_verdict = classify(row.baron.status, row.baron.objective, row.known, row.maximize)
+    row.d_verdict = classify(
+        row.discopt.status,
+        row.discopt.objective,
+        row.known,
+        row.maximize,
+        row.discopt.lower_bound,
+    )
+    row.b_verdict = classify(
+        row.baron.status,
+        row.baron.objective,
+        row.known,
+        row.maximize,
+        row.baron.lower_bound,
+    )
     return row
 
 
@@ -355,8 +398,9 @@ def write_report(rows: list[Row], tl: float, out_dir: Path, ts: str) -> Path:
         "| `GAP` | honest feasible/uncertified incumbent **worse** than the "
         "global — a convergence gap in the time budget, *not* a correctness bug |",
         "| `VIOLATION` | **the non-negotiable red line**: solver claimed a "
-        "certified global with the wrong value, or returned an incumbent "
-        "strictly *better* than the proven global (impossible → bug) |",
+        "certified global with the wrong value, returned an incumbent "
+        "strictly *better* than the proven global, or reported a **dual bound "
+        "crossing the oracle** (all impossible → bug) |",
         "| `n/a` | no oracle, or no incumbent returned (e.g. parser error) |",
         "",
         "## Correctness summary",
@@ -391,10 +435,15 @@ def write_report(rows: list[Row], tl: float, out_dir: Path, ts: str) -> Path:
     if viol:
         lines += ["", "## ⚠️ discopt correctness VIOLATIONS", ""]
         for r in viol:
-            lines.append(
-                f"- **{r.instance}**: discopt {r.discopt.objective} "
-                f"(status {r.discopt.status}) vs proven global {r.known}"
+            bad_bound = bound_violates_oracle(r.discopt.lower_bound, r.known, r.maximize)
+            reason = (
+                f"dual bound {fmt(r.discopt.lower_bound).strip()} crosses the proven "
+                f"global {fmt(r.known).strip()} (invalid bound)"
+                if bad_bound
+                else f"incumbent {r.discopt.objective} (status {r.discopt.status}) "
+                f"vs proven global {r.known}"
             )
+            lines.append(f"- **{r.instance}**: {reason}")
 
     gaps = [r for r in rows if r.d_verdict == GAP]
     if gaps:

--- a/discopt_benchmarks/tests/test_nl_solvers_verdict.py
+++ b/discopt_benchmarks/tests/test_nl_solvers_verdict.py
@@ -21,7 +21,15 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.global_opt_baron_vs_discopt import GAP, NA, OK, VIOLATION, classify
+from scripts.global_opt_baron_vs_discopt import (
+    DISCOPT_WORKER,
+    GAP,
+    NA,
+    OK,
+    VIOLATION,
+    bound_violates_oracle,
+    classify,
+)
 from scripts.global_opt_nl_solvers import write_report
 
 pytestmark = pytest.mark.unit
@@ -48,6 +56,51 @@ def test_matching_optimum_is_ok_and_missing_oracle_is_na():
     assert classify("optimal", 5.4709, 5.4709, maximize=False) == OK
     assert classify("feasible", 5.4709, None, maximize=False) == NA
     assert classify("feasible", None, 5.4709, maximize=False) == NA
+
+
+# --------------------------------------------------------------------------- #
+# A3: the dual bound must never cross the oracle (certificate invariant)
+# --------------------------------------------------------------------------- #
+def test_dual_bound_crossing_oracle_is_violation():
+    # minimize: a lower bound ABOVE the true optimum is impossible (bound<=opt).
+    assert classify("feasible", 5.4709, 5.4709, maximize=False, bound=5.60) == VIOLATION
+    # maximize: an upper bound BELOW the true optimum is impossible (bound>=opt).
+    assert classify("feasible", 5.4709, 5.4709, maximize=True, bound=5.35) == VIOLATION
+
+
+def test_bound_violation_fires_even_without_incumbent():
+    # No incumbent (obj=None) but the reported dual bound crosses the oracle:
+    # still the red line, not n/a.
+    assert classify("time_limit", None, 5.4709, maximize=False, bound=6.0) == VIOLATION
+
+
+def test_valid_dual_bound_below_optimum_is_not_a_bound_violation():
+    # A lower bound at/under the optimum with a suboptimal incumbent is an
+    # honest GAP, never a bound violation.
+    assert classify("feasible", 6.9358, 5.4709, maximize=False, bound=1.348) == GAP
+    assert classify("optimal", 5.4709, 5.4709, maximize=False, bound=5.4709) == OK
+
+
+def test_none_bound_preserves_incumbent_verdict():
+    # bound=None (default) → classify falls through to the incumbent logic,
+    # exactly as before A3 (backward-compatible).
+    assert classify("feasible", 6.9358, 5.4709, maximize=False, bound=None) == GAP
+    assert classify("optimal", 6.9358, 5.4709, maximize=False, bound=None) == VIOLATION
+
+
+def test_bound_violates_oracle_predicate():
+    assert bound_violates_oracle(6.0, 5.4709, maximize=False) is True
+    assert bound_violates_oracle(5.0, 5.4709, maximize=False) is False  # valid LB
+    assert bound_violates_oracle(5.0, 5.4709, maximize=True) is True  # UB below opt
+    assert bound_violates_oracle(None, 5.4709, maximize=False) is False
+    assert bound_violates_oracle(6.0, None, maximize=False) is False
+
+
+def test_worker_reads_res_bound_not_lower_bound():
+    # Regression for the A3 bug: SolveResult has `.bound`, not `.lower_bound`
+    # (the old getattr silently read None on every one of the 61 rows).
+    assert 'getattr(res, "bound"' in DISCOPT_WORKER
+    assert 'getattr(res, "lower_bound"' not in DISCOPT_WORKER
 
 
 def test_report_distinguishes_gap_from_violation(tmp_path):

--- a/docs/dev/perf-followup-plan-2026-07-05.md
+++ b/docs/dev/perf-followup-plan-2026-07-05.md
@@ -184,6 +184,18 @@ worktrees/sessions if desired, but each in its own PR.
 - **Regime/gates:** script-only; smoke gate. **Blocks V1** (V1's report should
   carry live bounds).
 - **Acceptance:** a 2-instance `--instances` run emits non-null bounds.
+- **Status: DONE** (branch `fix-a3-benchmark-bound-oracle`). Worker reads
+  `getattr(res, "bound", None)` (the `.lower_bound` attr never existed; `None`
+  now means "no dual bound" post-A2, not "read failed"). Added
+  `bound_violates_oracle(bound, known, maximize)` and threaded the reported
+  bound into `classify()` — a dual bound crossing the oracle (`bound > opt` for
+  min, `bound < opt` for max, beyond tol) is now a `VIOLATION` even with a
+  correct/absent incumbent, and the violation report distinguishes a bad bound
+  from a bad incumbent. Tests in
+  `discopt_benchmarks/tests/test_nl_solvers_verdict.py` (6 new: bound-crossing
+  → VIOLATION both senses, fires without an incumbent, valid-LB-stays-GAP,
+  None-bound backward-compat, the predicate, and the worker-attr regression).
+  Script-only; ruff clean.
 
 ### F1 — Budget `local_branching`'s enumeration path  (B7; the #1 wall lever)
 


### PR DESCRIPTION
## A3 — benchmark worker `res.bound` + dual-bound-vs-oracle violation check

Third correctness pre-flight item of `docs/dev/perf-followup-plan-2026-07-05.md`. **Script + tests only.**

### The bug
`global_opt_baron_vs_discopt.py`'s `DISCOPT_WORKER` did `lb = getattr(res, "lower_bound", None)` — but `SolveResult` exposes the certified dual bound as `.bound` (there is no `.lower_bound`). So the `lower_bound` column was silently `null` for **all 61 rows** of the 2026-07-05 report. `gap` was real; only the bound column was dead.

### The fix
- Worker reads `getattr(res, "bound", None)`. After A2 (#499), `.bound` is `None` on the no-relaxation class rather than a `1e30` sentinel, so `None` here means "no dual bound", not "read failed".
- Now that the field is live, added `bound_violates_oracle(bound, known, maximize)` and threaded the reported bound into `classify()`: a **dual bound that crosses the proven global** (`bound > opt` for minimize, `bound < opt` for maximize, beyond `RTOL·|opt|+ATOL`) is a `VIOLATION` — the certificate invariant stated in CLAUDE.md ("dual bound never crossing the known oracle") — **even when the incumbent is correct or absent** (an invalid bound is the core certificate failure).
- The `⚠️ VIOLATIONS` report section now distinguishes an **invalid bound** from a **wrong incumbent**.

### Tests (`discopt_benchmarks/tests/test_nl_solvers_verdict.py`, +6)
- dual bound above opt (min) / below opt (max) → `VIOLATION`
- bound violation fires with **no incumbent** (`obj=None`)
- valid LB under the optimum with a suboptimal incumbent stays `GAP`; matching opt stays `ok`
- `bound=None` (default) preserves the pre-A3 incumbent verdict (backward-compatible)
- the `bound_violates_oracle` predicate directly
- regression: `DISCOPT_WORKER` reads `res.bound`, not `res.lower_bound`

### Gates
`pytest discopt_benchmarks/tests/test_nl_solvers_verdict.py` — **11 passed** (5 existing + 6 new). `ruff check` + `ruff format --check` — clean. No solver code touched (script + test only); no build/Rust/smoke-solver impact. **Blocks V1** (its report now carries live bounds + the bound-vs-oracle gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
