### PR TITLE
perf(heuristics): F1 — budget local_branching enumeration (LNS wall sink)

### DIFF
--- a/docs/dev/bottleneck-profile-2026-07-05.md
+++ b/docs/dev/bottleneck-profile-2026-07-05.md
@@ -345,6 +345,22 @@ overwritten:
    its re-solves through `lp_pounce._solve_core` on the nvs09 path
    (92.6 % of that instance's wall). The flag covered edge-concave and
    strong-branching call sites only.
+7. **"F1 (LNS enumeration budget) removes tls2's ~15 s root cost"**
+   (§1.1 "via RENS the root of tls2"; §7 F1 acceptance "tls2 root −≥15 s").
+   *Correction (F1 implementation, `perf-f1-lns-enumeration-budget`, pounce
+   0.7.0, M4 Pro):* on this machine tls2 never enters the `local_branching`
+   enumeration path at its root — an instrumented solve records **0**
+   `subnlp` calls / **0** `local_branching` invocations, and the single
+   in-tree `local_branching` call costs 1.36 s. tls2's ~25 s root sink is
+   **`rens` itself (2 calls = 25.7 s)** — RENS's own nested `_solve_nlp_bb`
+   root/heuristic phase — which F1 does not own. Budgeting the enumeration
+   correctly bounds fac2 (1665→158 sub-NLPs, 23.5 s→5.8 s) and flay03m
+   (3330→395, 47.8 s→6.8 s), both still certifying with identical node
+   count/objective, but leaves tls2's root unchanged (25.6 s→25.1 s). The
+   tls2 root lever is **F4** (budget-gate the root heuristic NLP phase), not
+   F1; the §7 F1 tls2 line is reassigned to F4. F1's class win (the
+   `sum_r C(n,r)` enumeration blow-up on the ≤12-binary early-incumbent
+   class) is confirmed and delivered.
 
 ---
 

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -9,6 +9,7 @@ and re-solves the resulting NLP.
 from __future__ import annotations
 
 import itertools
+import math
 import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
@@ -1423,6 +1424,20 @@ def _local_branching_submip(
     return cand
 
 
+# Fallback estimate (seconds) for one enumeration sub-NLP before any round has
+# been measured. The profiled sub-NLP mean on the 12-binary flay/fac class is
+# ~14 ms (bottleneck-profile-2026-07-05 §1.1); 15 ms is the conservative prior
+# used to predict a round's cost when no measurement exists yet.
+_LB_SUBNLP_PRIOR_S = 0.015
+
+# Minimum remaining budget (seconds) before it is worth dispatching the truncated
+# neighbourhood to the bounded sub-MIP. A nested ``solve_model`` re-pays a fixed
+# setup/JIT/root tax measured at ~1.6-2 s on this class (F4 territory); launching
+# it with less than this is nearly all tax and no search, so below the threshold
+# we truncate the enumeration outright rather than blow the slice on startup cost.
+_LB_SUBMIP_MIN_BUDGET_S = 2.5
+
+
 def local_branching(
     model: Model,
     x_incumbent: np.ndarray,
@@ -1437,6 +1452,10 @@ def local_branching(
     submip_time_limit: float = 2.0,
     submip_max_nodes: int = 1000,
     submip_gap_tolerance: float = 1e-4,
+    deadline: Optional[float] = None,
+    node_bound: Optional[float] = None,
+    incumbent_obj: Optional[float] = None,
+    gap_tolerance: float = 1e-4,
 ) -> Optional[tuple[np.ndarray, float]]:
     """Local branching: search the Hamming-radius-``k`` neighbourhood of a binary
     incumbent for a better feasible point.
@@ -1453,8 +1472,28 @@ def local_branching(
     restricted problem with a bounded budget (with a recursion guard so the
     sub-solve never re-enters the LNS layer).
 
+    Budget enforcement (F1, bottleneck-profile-2026-07-05 §1.1). The enumeration
+    branch issues ``sum_r C(n_bin, r<=k)`` sub-NLPs — 79 at k=2, 1586 at k=5 for
+    12 binaries — which historically ignored its ``submip_time_limit`` slice and
+    the solver's absolute ``deadline`` entirely (fac2: 1665 sub-NLPs = 84 % of
+    wall; flay03m: 3330 = 96 %). It now:
+
+    1. honours a hard absolute ``deadline`` in addition to the per-call slice,
+       polling before every sub-NLP (~14 ms each — polling is free);
+    2. predicts each radius round's cost as ``C(n_bin, r) x measured_mean`` and,
+       when the round cannot fit the remaining budget, truncates the enumeration
+       rather than blowing past it — dispatching the *unexplored* neighbourhood
+       to the bounded :func:`_local_branching_submip` so the search is not simply
+       abandoned; and
+    3. skips the whole search when the incumbent already matches the node
+       relaxation ``node_bound`` within ``gap_tolerance`` (nothing to improve).
+
+    This is budget enforcement only: the neighbourhood, the k-schedule policy,
+    and the soundness of every proposed point are unchanged. Only proposes
+    incumbents — the dual bound is untouched.
+
     Returns the best feasible ``(x, obj)`` found in the neighbourhood, or
-    ``None``. Only proposes incumbents — the dual bound is untouched.
+    ``None``.
     """
     int_mask = _get_integer_mask(model)
     lb0, ub0 = _get_variable_bounds(model)
@@ -1466,10 +1505,33 @@ def local_branching(
 
     k = max(1, min(k, len(binary_idx)))
 
+    # (3) Nothing to improve: the incumbent already sits at the node relaxation
+    # bound within tolerance, so no point in the Hamming ball can beat it. Skip
+    # the whole search (heuristic-only; the dual bound is untouched either way).
+    if (
+        node_bound is not None
+        and incumbent_obj is not None
+        and np.isfinite(node_bound)
+        and np.isfinite(incumbent_obj)
+    ):
+        abs_gap = incumbent_obj - float(node_bound)
+        denom = max(abs(incumbent_obj), abs(float(node_bound)), 1e-10)
+        if abs_gap <= 1e-9 or abs_gap / denom <= gap_tolerance:
+            return None
+
+    # Absolute wall past which no further sub-NLP may start. The effective budget
+    # is the tighter of the caller's per-call slice and the solver's deadline.
+    slice_deadline = time.perf_counter() + max(0.0, float(submip_time_limit))
+    if deadline is not None and np.isfinite(deadline):
+        effective_deadline = min(slice_deadline, float(deadline))
+    else:
+        effective_deadline = slice_deadline
+
     # Scalable sub-MIP variant for large binary blocks.
     if len(binary_idx) > max_binaries:
         if evaluator is None:
             evaluator = cached_evaluator(model)
+        remaining = max(0.0, effective_deadline - time.perf_counter())
         return _local_branching_submip(
             model,
             x_incumbent,
@@ -1480,7 +1542,7 @@ def local_branching(
             integer_tol=integer_tol,
             feas_tol=feas_tol,
             evaluator=evaluator,
-            time_limit=submip_time_limit,
+            time_limit=min(float(submip_time_limit), remaining),
             max_nodes=submip_max_nodes,
             gap_tolerance=submip_gap_tolerance,
         )
@@ -1493,14 +1555,43 @@ def local_branching(
     k = max(1, min(k, len(binary_idx)))
 
     best: Optional[tuple[np.ndarray, float]] = None
+    # Rolling mean sub-NLP wall used to predict the next round's cost. Seeded with
+    # the profiled prior; refined from every measured sub-NLP.
+    mean_subnlp_s = _LB_SUBNLP_PRIOR_S
+    n_measured = 0
+    # Highest radius whose full enumeration we could afford. If the budget runs
+    # out mid-schedule we hand the *unexplored* radii to the bounded sub-MIP so
+    # the neighbourhood is still searched, just not by brute force.
+    truncated_at: Optional[int] = None
+
     # Enumerate flip sets of size 0..k (size 0 re-evaluates the incumbent itself).
     for radius in range(k + 1):
+        # (2) Predict this round's cost and stop enumerating if it cannot fit the
+        # remaining budget. C(n, 0)=1 (re-evaluate incumbent) is always cheap and
+        # always worth doing; larger radii are gated.
+        remaining = effective_deadline - time.perf_counter()
+        if remaining <= 0.0:
+            truncated_at = radius
+            break
+        round_calls = math.comb(len(binary_idx), radius)
+        predicted = round_calls * mean_subnlp_s
+        if radius >= 1 and predicted > remaining:
+            # Cannot afford the full round; hand the rest to the bounded sub-MIP.
+            truncated_at = radius
+            break
+
         for flip in itertools.combinations(binary_idx, radius):
+            # (1) Poll the deadline before every sub-NLP (they are ~14 ms, so
+            # per-iteration polling is free). Never start one past the budget.
+            if time.perf_counter() >= effective_deadline:
+                truncated_at = radius
+                break
             seed = x_inc.copy()
             for i in binary_idx:
                 seed[i] = incumbent_bits[i]
             for i in flip:
                 seed[i] = 1.0 - incumbent_bits[i]
+            _t0 = time.perf_counter()
             found = subnlp(
                 model,
                 seed,
@@ -1510,6 +1601,39 @@ def local_branching(
                 integer_tol=integer_tol,
                 feas_tol=feas_tol,
             )
+            # Refine the rolling mean from the measured sub-NLP wall.
+            n_measured += 1
+            mean_subnlp_s += (time.perf_counter() - _t0 - mean_subnlp_s) / n_measured
             if found is not None and (best is None or found[1] < best[1]):
                 best = found
+        else:
+            # Inner loop completed without a budget break; continue the schedule.
+            continue
+        # Inner loop broke on the deadline: stop the whole enumeration.
+        truncated_at = radius
+        break
+
+    # If the budget cut the enumeration short, search the unexplored Hamming
+    # ball (radius >= truncated_at, up to k) via the bounded sub-MIP, which adds
+    # the Hamming cut as one linear constraint instead of enumerating C(n, r)
+    # flips. This keeps the neighbourhood covered without blowing the deadline.
+    if truncated_at is not None and truncated_at <= k:
+        remaining = effective_deadline - time.perf_counter()
+        if remaining >= _LB_SUBMIP_MIN_BUDGET_S:
+            submip = _local_branching_submip(
+                model,
+                x_inc,
+                binary_idx,
+                k=k,
+                backend=backend,
+                nlp_options=nlp_options,
+                integer_tol=integer_tol,
+                feas_tol=feas_tol,
+                evaluator=evaluator,
+                time_limit=min(float(submip_time_limit), remaining),
+                max_nodes=submip_max_nodes,
+                gap_tolerance=submip_gap_tolerance,
+            )
+            if submip is not None and (best is None or submip[1] < best[1]):
+                best = submip
     return best

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -6705,6 +6705,12 @@ def solve_model(
                             submip_time_limit=_lb_slice,
                             submip_max_nodes=1000,
                             submip_gap_tolerance=gap_tolerance,
+                            # F1: hand the enumeration a hard budget (profile
+                            # §1.1) so it cannot blow past the slice/deadline.
+                            deadline=_deadline,
+                            node_bound=_lns_lb,
+                            incumbent_obj=float(_lns_inc[1]),
+                            gap_tolerance=gap_tolerance,
                         )
                         if _lb is not None:
                             _x_lb, _obj_lb = _lb
@@ -8230,6 +8236,12 @@ def _solve_nlp_bb(
                                 submip_time_limit=_lb_slice,
                                 submip_max_nodes=1000,
                                 submip_gap_tolerance=gap_tolerance,
+                                # F1: hand the enumeration a hard budget (profile
+                                # §1.1) so it cannot blow past the slice/deadline.
+                                deadline=_lns_deadline,
+                                node_bound=_lns_lb,
+                                incumbent_obj=float(_lns_inc[1]),
+                                gap_tolerance=gap_tolerance,
                             )
                             if _lb is not None:
                                 _x_lb, _obj_lb = _lb

--- a/python/tests/test_issue_267_lns.py
+++ b/python/tests/test_issue_267_lns.py
@@ -217,3 +217,98 @@ def test_local_branching_no_improvement_returns_none():
         submip_max_nodes=1000,
     )
     assert result is None
+
+
+# ─────────────────────────────────────────────────────────────
+# F1 — enumeration budget (bottleneck-profile-2026-07-05 §1.1)
+#
+# The ≤``max_binaries`` enumeration branch issues ``sum_r C(n_bin, r<=k)`` full
+# sub-NLPs — 79 at k=2, 1586 at k=5 for 12 binaries — and historically ignored
+# both its per-call slice and the solver's absolute deadline (fac2: 1665 sub-NLPs
+# = 84 % of wall). These tests lock in the budget enforcement: a hard deadline is
+# honoured, and the search is skipped when the incumbent already matches the node
+# bound. General (non-named) ≤12-binary models only.
+# ─────────────────────────────────────────────────────────────
+
+
+def test_local_branching_enumeration_honors_deadline(monkeypatch):
+    """A ≤12-binary model with an early incumbent + a 1 s deadline must return
+    within the budget and issue far fewer sub-NLPs than the unbudgeted count.
+
+    Fail-before: the unbudgeted enumeration issues ``sum_r C(12, r<=5)`` = 1586
+    sub-NLPs regardless of any deadline; at ~3 ms each that is ~4.8 s, blowing a
+    1 s deadline. After the F1 budget, the flip loop polls the deadline every
+    sub-NLP and truncates, so it returns in ~1 s with ≪1586 calls.
+    """
+    import math
+    import time
+
+    import discopt._jax.primal_heuristics as ph
+
+    n = 12  # exactly at the cap -> the enumeration path (not the sub-MIP)
+    m, _ = _knapsack_model(n)
+    ev = NLPEvaluator(m)
+    incumbent = np.zeros(n)
+    incumbent[:2] = 1.0  # a poor early incumbent -> the search has work to do
+
+    unbudgeted_k5 = sum(math.comb(n, r) for r in range(5 + 1))
+    assert unbudgeted_k5 == 1586  # the arithmetic the profile measured
+
+    calls = {"n": 0}
+    real_subnlp = ph.subnlp
+
+    def counting_slow_subnlp(*a, **k):
+        calls["n"] += 1
+        time.sleep(0.003)  # ~3 ms: 1586 of these would be ~4.8 s (> 1 s deadline)
+        return real_subnlp(*a, **k)
+
+    monkeypatch.setattr(ph, "subnlp", counting_slow_subnlp)
+
+    deadline = time.perf_counter() + 1.0
+    t0 = time.perf_counter()
+    local_branching(
+        m,
+        incumbent,
+        k=5,
+        evaluator=ev,
+        max_binaries=12,
+        # A slice large enough NOT to be the limiting factor; the deadline is.
+        submip_time_limit=10.0,
+        submip_max_nodes=500,
+        deadline=deadline,
+    )
+    elapsed = time.perf_counter() - t0
+
+    # Budget honoured: returned within the deadline envelope (§0.7 style: +~20 %).
+    assert elapsed <= 1.2, f"local_branching overran its 1 s deadline: {elapsed:.2f} s"
+    # And it issued strictly fewer sub-NLPs than the unbudgeted enumeration.
+    assert calls["n"] < unbudgeted_k5, (
+        f"enumeration was not truncated: {calls['n']} sub-NLPs "
+        f"(unbudgeted would be {unbudgeted_k5})"
+    )
+
+
+def test_local_branching_skips_when_incumbent_matches_node_bound():
+    """When the incumbent objective already equals the node relaxation bound
+    within ``gap_tolerance``, there is nothing to improve, so the search is
+    skipped entirely (zero sub-NLPs) and ``None`` is returned."""
+    n = 12
+    m, _ = _knapsack_model(n)
+    ev = NLPEvaluator(m)
+    optimum = np.ones(n)  # global optimum, obj = -n
+    inc_obj = float(ev.evaluate_objective(optimum))
+    assert inc_obj == pytest.approx(-float(n))
+
+    # Node bound equal to the incumbent objective -> gap closed -> skip.
+    result = local_branching(
+        m,
+        optimum,
+        k=5,
+        evaluator=ev,
+        max_binaries=12,
+        submip_time_limit=3.0,
+        node_bound=inc_obj,
+        incumbent_obj=inc_obj,
+        gap_tolerance=1e-4,
+    )
+    assert result is None


### PR DESCRIPTION
## F1 — Budget `local_branching`'s enumeration path (B7; the #1 wall lever)

Implements task **F1** from `docs/dev/perf-followup-plan-2026-07-05.md` §2.
Closes #501.

### The bottleneck (measured)
The `≤max_binaries` enumeration branch of
`python/discopt/_jax/primal_heuristics.py::local_branching` issues
`Σ_r C(n_bin, r≤k)` full POUNCE sub-NLPs — **79 at k=2, 1586 at k=5** for 12
binaries — ignoring both its `submip_time_limit` slice and the solver's absolute
deadline, and running even when the incumbent is already optimal.

**Entry experiment** (instrumented counter into `subnlp`/`local_branching`, pounce
0.7.0, M4 Pro) — confirmed the arithmetic; kill criterion (enumeration <50% of
wall) did **not** fire:

| instance | sub-NLP calls | enumeration wall | share |
|---|---:|---:|---:|
| fac2 | 1665 (79 + 1586) | 20.6 s | 84.2% of 23.5 s |
| flay03m | 3330 (2×[79+1586]) | 46.6 s | 96.5% of 48.3 s |

Both were already at the optimum yet ran the full enumeration.

### The fix (all inside `local_branching` + its helper; heuristic-policy regime)
Budget enforcement only — the neighbourhood, k-schedule policy, and every proposed
point's soundness are unchanged; the dual bound is untouched.

1. Honor a hard absolute `deadline` in addition to the per-call slice; poll before
   every sub-NLP (~14 ms each, so polling is free).
2. Predict each radius round's cost (`C(n_bin, r) × measured mean sub-NLP time`,
   seeded at 15 ms) and, when it cannot fit the remaining budget, truncate the
   enumeration and hand the *unexplored* Hamming ball to the existing bounded
   `_local_branching_submip` — but only when the remaining budget clears a nested
   `solve_model`'s measured fixed setup tax (~2 s; F4 territory), else truncate
   outright so a nested solve isn't launched all-tax/no-search.
3. Skip the search entirely when the incumbent already matches the node relaxation
   bound within `gap_tolerance` (nothing to improve).

Both call sites (`solve_model` spatial + `_solve_nlp_bb`) pass
`deadline`/`node_bound`/`incumbent_obj`/`gap_tolerance`.

### Acceptance — `profile_instance.py` clean mode, same machine (M4 Pro, pounce 0.7.0)

| instance | before | after | target | nodes | objective |
|---|---:|---:|---:|---:|---|
| fac2 | 23.51 s | **5.79 s** | ≤5 s | 69 → 69 | identical (3.31837498e8) |
| flay03m | 47.84 s | **6.75 s** | ≤12 s | 111 → 111 | identical (48.98979479) |
| tls2 root | 25.61 s | 25.08 s | −≥15 s | — | see below |

fac2 lands at 5.8 s (4.05×; marginally over the aggressive ≤5 s arithmetic target,
whose "root 1.0 s" term assumed `rens=False` — a §3 binding dead-end we must not
take; the ~0.8 s residual is the nested-RENS root tax owned by **F4**, not the
enumeration, which is fully eliminated: 1665 → 158 sub-NLPs). flay03m beats its
target and now **certifies within budget** (baseline: `feasible` at TL).

**tls2 — profile sub-prediction falsified (recorded, profile §5).** On this
machine tls2 never enters the enumeration path: an instrumented solve records **0**
`subnlp` calls / **0** `local_branching` invocations. Its ~25 s root sink is
**`rens` itself (2 calls = 25.7 s)** — RENS's own nested `_solve_nlp_bb` — which F1
does not own. The §7 F1 tls2 line is reassigned to **F4** (root-heuristic budget
gate). F1's class win is confirmed and delivered.

### Class witness (out of panel, plan §0.2)
`flay03h` (12 binaries; oracle `minlplib.solu` = 48.9897948600; **not** in the
61-instance panel): certifies obj 48.98983 / bound 48.98979 correctly; each k=5
round collapses **1586 → 13** sub-NLPs (52 total across 4 LB rounds). Confirms the
fix is keyed to the class (any ≤12-binary early-incumbent MINLP), not the probe
names.

### Regression tests (`python/tests/test_issue_267_lns.py`)
- `test_local_branching_enumeration_honors_deadline` — synthetic non-named
  12-binary knapsack MINLP + poor early incumbent + 1 s deadline; asserts return
  within 1.2 s AND `< 1586` sub-NLPs. **Fail-before:** the unbudgeted
  `local_branching` runs all 1586 sub-NLPs = **13.59 s** against the 1 s deadline
  (both assertions fail); pass-after.
- `test_local_branching_skips_when_incumbent_matches_node_bound` — item 3 gate:
  incumbent obj == node bound ⇒ zero sub-NLPs, returns `None`.

### Gates
- **Panel objective-neutrality** (20 certifying instances, baseline = origin/main
  same machine): **zero objective drift**; node counts unchanged where certifying.
- **No slowdown**: no instance slower by >10% AND >0.5 s (the two >1.10 ratios are
  sub-0.5 s instances, <0.05 s absolute — noise). Incumbent quality preserved.
- `incorrect_count = 0` (all panel statuses correct vs oracle).
- `pytest -m smoke`: **574 passed, 14 skipped**.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed**.
- LNS-layer suites (test_issue_267_lns, test_nlp_bb_lns_layer,
  test_improvement_heuristics, test_rens): **21 passed**.
- `ruff check` + `ruff format --check`: clean. `mypy python/discopt/` (pre-commit
  hook, CI-equivalent env): **Passed**.
- No Rust touched → `cargo test` N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
