### PR TITLE
feat: interactive branch-and-bound debugger ("pdb for B&B")

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -72,6 +72,65 @@ pub struct MilpResult {
     pub lp_iters: usize,
 }
 
+/// A node-lifecycle checkpoint fired to an attached [`MilpDebugHook`].
+///
+/// Mirrors the Python-side `discopt.debug.Checkpoint` so the pure-Rust MILP
+/// fast-path is inspectable by the same debugger that drives the spatial /
+/// MIQP / NLP-BB loops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MilpCheckpoint {
+    /// Top of a batch iteration.
+    IterStart,
+    /// After the batch's results were imported and prune/branch/fathom ran.
+    AfterProcess,
+    /// A strictly-better incumbent was just adopted.
+    IncumbentFound,
+    /// Once, after the search loop exits (final / limit / infeasible).
+    Terminated,
+}
+
+/// Aggregate solver state passed to a debug hook at a checkpoint. Read-only.
+#[derive(Debug, Clone, Copy)]
+pub struct MilpDebugState {
+    /// Which checkpoint fired.
+    pub checkpoint: MilpCheckpoint,
+    /// Batch-iteration counter (0-based), mirroring the Python loops.
+    pub iteration: usize,
+    /// Total B&B nodes created so far.
+    pub total_nodes: usize,
+    /// Open nodes remaining in the frontier.
+    pub open_nodes: usize,
+    /// Incumbent objective (internal min sense), or `None` if none yet.
+    pub incumbent: Option<f64>,
+    /// Global lower (dual) bound.
+    pub bound: f64,
+    /// Current relative optimality gap.
+    pub gap: f64,
+    /// Wall-clock seconds since the solve started.
+    pub elapsed: f64,
+}
+
+/// What a debug hook tells the search to do after a checkpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MilpDebugControl {
+    /// Keep searching.
+    Continue,
+    /// Stop the search now (graceful — a valid uncertified result is built).
+    Stop,
+}
+
+/// A debugger attached to the Rust MILP search. Implemented on the Python side
+/// by a GIL-reacquiring adapter over a Python callable. Must be `Sync` because
+/// the solve runs under `Python::allow_threads`.
+///
+/// **Zero effect when absent:** every fire-site is gated on `Option::is_some`,
+/// so a `None` hook leaves the search bit-for-bit identical (bound-neutral).
+pub trait MilpDebugHook: Sync {
+    /// Called at each fired checkpoint; return [`MilpDebugControl::Stop`] to
+    /// end the search gracefully.
+    fn checkpoint(&self, state: &MilpDebugState) -> MilpDebugControl;
+}
+
 /// Options for the MILP driver.
 pub struct MilpOptions {
     /// Number of structural (model) variables; columns `[n_struct, n)` are slacks.
@@ -186,6 +245,19 @@ fn decide_status(
 /// Solve `min cᵀx + obj_const s.t. A x = b, l ≤ x ≤ u` with `integer_cols`
 /// integer-constrained, by Rust-internal warm-started-simplex branch and bound.
 pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions) -> MilpResult {
+    solve_milp_hooked(lp, b, obj_const, opts, None)
+}
+
+/// [`solve_milp`] with an optional interactive-debugger hook. When `hook` is
+/// `None` this is bit-for-bit identical to a plain solve (all fire-sites
+/// short-circuit); the `solve_milp` wrapper above passes `None`.
+pub fn solve_milp_hooked(
+    lp: &LpView<'_>,
+    b: &[f64],
+    obj_const: f64,
+    opts: &MilpOptions,
+    hook: Option<&dyn MilpDebugHook>,
+) -> MilpResult {
     crate::profile::init_from_env();
     crate::profile::reset();
     let n = lp.n;
@@ -435,7 +507,40 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
     // change branching choice / cut tightness / early incumbents, never a
     // bound's validity.
     let _t_search = crate::profile::Timer::new(crate::profile::Phase::SearchLoop);
+
+    // Interactive debugger bookkeeping. `dbg_iter` mirrors the Python loops'
+    // iteration counter; `dbg_last_inc` tracks the incumbent so the
+    // `IncumbentFound` event fires exactly on a strict improvement. When `hook`
+    // is `None` the macro below expands to `false` and nothing is read.
+    let mut dbg_iter: usize = 0;
+    let mut dbg_last_inc: f64 = f64::INFINITY;
+    macro_rules! fire_dbg {
+        ($cp:expr) => {{
+            if let Some(h) = hook {
+                let s = tm.stats();
+                let inc = tm.incumbent().map(|(_, v)| v);
+                let state = MilpDebugState {
+                    checkpoint: $cp,
+                    iteration: dbg_iter,
+                    total_nodes: s.total_nodes,
+                    open_nodes: s.open_nodes,
+                    incumbent: inc,
+                    bound: s.global_lower_bound,
+                    gap: s.gap,
+                    elapsed: t_start.elapsed().as_secs_f64(),
+                };
+                matches!(h.checkpoint(&state), MilpDebugControl::Stop)
+            } else {
+                false
+            }
+        }};
+    }
+
     'search: loop {
+        if fire_dbg!(MilpCheckpoint::IterStart) {
+            gap_certified = false;
+            break;
+        }
         if tm.is_finished() || tm.gap() <= opts.gap_tol {
             break;
         }
@@ -622,6 +727,23 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
         tm.import_results(&results);
         tm.process_evaluated();
 
+        // Interactive debugger: post prune/branch/fathom, plus the new-incumbent
+        // event on a strict improvement (from any source this batch).
+        if let Some(v) = tm.incumbent().map(|(_, v)| v) {
+            if v < dbg_last_inc - 1e-9 {
+                dbg_last_inc = v;
+                if fire_dbg!(MilpCheckpoint::IncumbentFound) {
+                    gap_certified = false;
+                    break 'search;
+                }
+            }
+        }
+        if fire_dbg!(MilpCheckpoint::AfterProcess) {
+            gap_certified = false;
+            break 'search;
+        }
+        dbg_iter += 1;
+
         // Fold this batch's newly-found global cuts into the shared matrix.
         // Stored node bases are extended lazily on their next solve, so children
         // warm-start through the dual simplex from the cut-augmented basis.
@@ -643,6 +765,10 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
             slack_u = u_w[ns..].to_vec();
         }
     }
+
+    // Interactive debugger: terminal checkpoint (return value is advisory only —
+    // the solve is already over, so its control is ignored).
+    let _ = fire_dbg!(MilpCheckpoint::Terminated);
 
     let stats = tm.stats();
     let bound = stats.global_lower_bound;
@@ -2001,6 +2127,56 @@ mod tests {
         let r = solve_milp(&lp, &[9.0], 0.0, &opts(4, vec![0, 1, 2, 3]));
         assert_eq!(r.status, MilpStatus::Optimal);
         assert!((r.obj - (-10.0)).abs() < 1e-6, "obj {}", r.obj);
+    }
+
+    /// A no-op debug hook must be bound-neutral: identical status / obj / nodes
+    /// vs. no hook (CLAUDE.md §5), while still firing at least one checkpoint.
+    #[test]
+    fn debug_hook_is_bound_neutral() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct Counter(AtomicUsize);
+        impl MilpDebugHook for Counter {
+            fn checkpoint(&self, _s: &MilpDebugState) -> MilpDebugControl {
+                self.0.fetch_add(1, Ordering::Relaxed);
+                MilpDebugControl::Continue
+            }
+        }
+
+        // A knapsack big enough to branch (multiple nodes, an incumbent event).
+        let a = [5.0, 3.0, 2.0, 4.0, 3.0, 5.0, 1.0];
+        let c = [-8.0, -5.0, -3.0, -6.0, -4.0, -7.0, 0.0];
+        let l = [0.0; 7];
+        let u = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, INF];
+        let lp = LpView {
+            a: &a,
+            m: 1,
+            n: 7,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let base = solve_milp(&lp, &[10.0], 0.0, &opts(6, vec![0, 1, 2, 3, 4, 5]));
+
+        let hook = Counter(AtomicUsize::new(0));
+        let hooked = solve_milp_hooked(
+            &lp,
+            &[10.0],
+            0.0,
+            &opts(6, vec![0, 1, 2, 3, 4, 5]),
+            Some(&hook),
+        );
+
+        assert_eq!(base.status, hooked.status);
+        assert_eq!(base.nodes, hooked.nodes, "node count drifted with hook");
+        assert!(
+            (base.obj - hooked.obj).abs() < 1e-12,
+            "obj drifted with hook"
+        );
+        assert!(
+            hook.0.load(Ordering::Relaxed) > 0,
+            "hook never fired — checkpoints not wired"
+        );
     }
 
     #[test]

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -81,6 +81,8 @@ pub struct MilpResult {
 pub enum MilpCheckpoint {
     /// Top of a batch iteration.
     IterStart,
+    /// The batch of open nodes was just exported — their boxes are available.
+    AfterSelect,
     /// After the batch's results were imported and prune/branch/fathom ran.
     AfterProcess,
     /// A strictly-better incumbent was just adopted.
@@ -90,8 +92,12 @@ pub enum MilpCheckpoint {
 }
 
 /// Aggregate solver state passed to a debug hook at a checkpoint. Read-only.
+///
+/// The `batch_*` fields are populated only at [`MilpCheckpoint::AfterSelect`],
+/// where the current batch of open-node boxes is in scope; they are `None`
+/// elsewhere. The lifetime `'a` borrows those boxes from the export batch.
 #[derive(Debug, Clone, Copy)]
-pub struct MilpDebugState {
+pub struct MilpDebugState<'a> {
     /// Which checkpoint fired.
     pub checkpoint: MilpCheckpoint,
     /// Batch-iteration counter (0-based), mirroring the Python loops.
@@ -108,6 +114,14 @@ pub struct MilpDebugState {
     pub gap: f64,
     /// Wall-clock seconds since the solve started.
     pub elapsed: f64,
+    /// Number of structural variables (box length reference).
+    pub n_vars: usize,
+    /// Per-node lower-bound boxes of the exported batch (AfterSelect only).
+    pub batch_lb: Option<&'a [Vec<f64>]>,
+    /// Per-node upper-bound boxes of the exported batch (AfterSelect only).
+    pub batch_ub: Option<&'a [Vec<f64>]>,
+    /// Node ids of the exported batch (AfterSelect only).
+    pub batch_ids: Option<&'a [NodeId]>,
 }
 
 /// What a debug hook tells the search to do after a checkpoint.
@@ -128,7 +142,7 @@ pub enum MilpDebugControl {
 pub trait MilpDebugHook: Sync {
     /// Called at each fired checkpoint; return [`MilpDebugControl::Stop`] to
     /// end the search gracefully.
-    fn checkpoint(&self, state: &MilpDebugState) -> MilpDebugControl;
+    fn checkpoint(&self, state: &MilpDebugState<'_>) -> MilpDebugControl;
 }
 
 /// Options for the MILP driver.
@@ -528,6 +542,10 @@ pub fn solve_milp_hooked(
                     bound: s.global_lower_bound,
                     gap: s.gap,
                     elapsed: t_start.elapsed().as_secs_f64(),
+                    n_vars: ns,
+                    batch_lb: None,
+                    batch_ub: None,
+                    batch_ids: None,
                 };
                 matches!(h.checkpoint(&state), MilpDebugControl::Stop)
             } else {
@@ -557,6 +575,31 @@ pub fn solve_milp_hooked(
         let batch = tm.export_batch(64);
         if batch.node_ids.is_empty() {
             break;
+        }
+
+        // Interactive debugger: nodes selected — expose the batch's boxes/ids so
+        // `print node <i>` works on this pure-Rust path too. Gated on the hook.
+        if let Some(h) = hook {
+            let s = tm.stats();
+            let inc = tm.incumbent().map(|(_, v)| v);
+            let state = MilpDebugState {
+                checkpoint: MilpCheckpoint::AfterSelect,
+                iteration: dbg_iter,
+                total_nodes: s.total_nodes,
+                open_nodes: s.open_nodes,
+                incumbent: inc,
+                bound: s.global_lower_bound,
+                gap: s.gap,
+                elapsed: t_start.elapsed().as_secs_f64(),
+                n_vars: ns,
+                batch_lb: Some(&batch.lb),
+                batch_ub: Some(&batch.ub),
+                batch_ids: Some(&batch.node_ids),
+            };
+            if matches!(h.checkpoint(&state), MilpDebugControl::Stop) {
+                gap_certified = false;
+                break 'search;
+            }
         }
 
         // Equilibration scaling for the working matrix, computed once per batch
@@ -2137,7 +2180,7 @@ mod tests {
 
         struct Counter(AtomicUsize);
         impl MilpDebugHook for Counter {
-            fn checkpoint(&self, _s: &MilpDebugState) -> MilpDebugControl {
+            fn checkpoint(&self, _s: &MilpDebugState<'_>) -> MilpDebugControl {
                 self.0.fetch_add(1, Ordering::Relaxed);
                 MilpDebugControl::Continue
             }

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -29,7 +29,7 @@ use numpy::{
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyList};
 
 /// Push an interior LP optimum `x` to a vertex of the optimal face.
 ///
@@ -653,10 +653,11 @@ struct PyMilpHook {
 }
 
 impl MilpDebugHook for PyMilpHook {
-    fn checkpoint(&self, state: &MilpDebugState) -> MilpDebugControl {
+    fn checkpoint(&self, state: &MilpDebugState<'_>) -> MilpDebugControl {
         Python::with_gil(|py| {
             let cp = match state.checkpoint {
                 MilpCheckpoint::IterStart => "iter_start",
+                MilpCheckpoint::AfterSelect => "after_select",
                 MilpCheckpoint::AfterProcess => "after_process",
                 MilpCheckpoint::IncumbentFound => "incumbent_found",
                 MilpCheckpoint::Terminated => "terminated",
@@ -670,6 +671,29 @@ impl MilpDebugHook for PyMilpHook {
             let _ = d.set_item("bound", state.bound);
             let _ = d.set_item("gap", state.gap);
             let _ = d.set_item("elapsed", state.elapsed);
+            // Node-box inspection at AfterSelect: marshal the batch's boxes/ids
+            // as plain nested lists (best-effort; skipped on any conversion
+            // error since inspection is non-critical).
+            if let (Some(lbs), Some(ubs), Some(ids)) =
+                (state.batch_lb, state.batch_ub, state.batch_ids)
+            {
+                let rows = |boxes: &[Vec<f64>]| -> Option<Bound<'_, PyList>> {
+                    let r: Vec<Bound<'_, PyList>> = boxes
+                        .iter()
+                        .map(|row| PyList::new(py, row.iter().copied()).ok())
+                        .collect::<Option<Vec<_>>>()?;
+                    PyList::new(py, r).ok()
+                };
+                if let (Some(py_lb), Some(py_ub)) = (rows(lbs), rows(ubs)) {
+                    let _ = d.set_item("batch_lb", py_lb);
+                    let _ = d.set_item("batch_ub", py_ub);
+                    let id_vec: Vec<usize> = ids.iter().map(|n| n.0).collect();
+                    if let Ok(id_list) = PyList::new(py, id_vec) {
+                        let _ = d.set_item("batch_ids", id_list);
+                    }
+                    let _ = d.set_item("n_vars", state.n_vars);
+                }
+            }
             match self.callback.bind(py).call1((d,)) {
                 Ok(ret) => {
                     if ret.is_truthy().unwrap_or(false) {

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -11,7 +11,10 @@
 // type-complexity lints don't meaningfully apply to these binding shims.
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 
-use discopt_core::bnb::milp_driver::{solve_milp as core_solve_milp, MilpOptions, MilpStatus};
+use discopt_core::bnb::milp_driver::{
+    solve_milp_hooked as core_solve_milp_hooked, MilpCheckpoint, MilpDebugControl, MilpDebugHook,
+    MilpDebugState, MilpOptions, MilpStatus,
+};
 use discopt_core::lp::aggregation::separate_aggregation_mir;
 use discopt_core::lp::basis::{recover_basis, Basis, BASIC};
 use discopt_core::lp::crossover::{crossover_to_vertex, LpView};
@@ -26,6 +29,7 @@ use numpy::{
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
 /// Push an interior LP optimum `x` to a vertex of the optimal face.
 ///
@@ -633,6 +637,53 @@ pub fn solve_lp_batch_py<'py>(
 /// form (structural columns `[0, n_struct)`, slacks after). Returns
 /// `(status, x[n_struct], obj, bound, nodes, lp_iters)` where status is one of
 /// `optimal`, `feasible`, `infeasible`, `unbounded`, `node_limit`.
+/// Adapter that lets an attached Python debugger drive the Rust MILP search.
+///
+/// Holds a GIL-independent handle (`Py<PyAny>`, which is `Send + Sync`) to a
+/// Python callable. `checkpoint` re-acquires the GIL — the solve runs under
+/// `py.allow_threads`, so the search thread does not hold it — builds a plain
+/// state dict, calls the callable, and maps a truthy return to `Stop`. A hook
+/// that raises is reported and treated as `Continue`, so a buggy debugger can
+/// never corrupt the solve.
+struct PyMilpHook {
+    callback: Py<PyAny>,
+}
+
+impl MilpDebugHook for PyMilpHook {
+    fn checkpoint(&self, state: &MilpDebugState) -> MilpDebugControl {
+        Python::with_gil(|py| {
+            let cp = match state.checkpoint {
+                MilpCheckpoint::IterStart => "iter_start",
+                MilpCheckpoint::AfterProcess => "after_process",
+                MilpCheckpoint::IncumbentFound => "incumbent_found",
+                MilpCheckpoint::Terminated => "terminated",
+            };
+            let d = PyDict::new(py);
+            let _ = d.set_item("checkpoint", cp);
+            let _ = d.set_item("iteration", state.iteration);
+            let _ = d.set_item("nodes", state.total_nodes);
+            let _ = d.set_item("open_nodes", state.open_nodes);
+            let _ = d.set_item("incumbent", state.incumbent);
+            let _ = d.set_item("bound", state.bound);
+            let _ = d.set_item("gap", state.gap);
+            let _ = d.set_item("elapsed", state.elapsed);
+            match self.callback.bind(py).call1((d,)) {
+                Ok(ret) => {
+                    if ret.is_truthy().unwrap_or(false) {
+                        MilpDebugControl::Stop
+                    } else {
+                        MilpDebugControl::Continue
+                    }
+                }
+                Err(e) => {
+                    e.print(py);
+                    MilpDebugControl::Continue
+                }
+            }
+        })
+    }
+}
+
 #[pyfunction]
 #[pyo3(signature = (c, a, b, lb, ub, integer_cols, n_struct, obj_const=0.0,
                     max_nodes=1_000_000, gap_tol=1e-6, tol=1e-9, root_cuts=16,
@@ -640,7 +691,7 @@ pub fn solve_lp_batch_py<'py>(
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    time_limit_s=0.0))]
+                    time_limit_s=0.0, debug_hook=None))]
 pub fn solve_milp_py<'py>(
     py: Python<'py>,
     c: PyReadonlyArray1<'py, f64>,
@@ -668,6 +719,7 @@ pub fn solve_milp_py<'py>(
     sb_max_cands: usize,
     sb_node_budget: usize,
     time_limit_s: f64,
+    debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let dims = a.shape();
     let (m, n) = (dims[0], dims[1]);
@@ -721,6 +773,11 @@ pub fn solve_milp_py<'py>(
             deadline: None,
         },
     };
+    // Wrap an attached Python debugger (if any) as a core hook. It is created
+    // before releasing the GIL and re-acquires it per checkpoint; when absent,
+    // the search runs the untouched (bound-neutral) path.
+    let hook = debug_hook.map(|cb| PyMilpHook { callback: cb });
+    let hook_ref: Option<&dyn MilpDebugHook> = hook.as_ref().map(|h| h as &dyn MilpDebugHook);
     let res = py.allow_threads(|| {
         let lp = LpView {
             a: &a_owned,
@@ -730,7 +787,7 @@ pub fn solve_milp_py<'py>(
             l: &l_owned,
             u: &u_owned,
         };
-        let r = core_solve_milp(&lp, &b_owned, obj_const, &opts);
+        let r = core_solve_milp_hooked(&lp, &b_owned, obj_const, &opts, hook_ref);
         // Emit the per-phase / pivot profile to stderr when DISCOPT_PROFILE is set
         // (no-op otherwise). solve_milp has returned, so its function-scoped phase
         // timers have recorded. Engine perf work (issue #332) reads this.

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -644,9 +644,12 @@ pub fn solve_lp_batch_py<'py>(
 /// `py.allow_threads`, so the search thread does not hold it — builds a plain
 /// state dict, calls the callable, and maps a truthy return to `Stop`. A hook
 /// that raises is reported and treated as `Continue`, so a buggy debugger can
-/// never corrupt the solve.
+/// never corrupt the solve — EXCEPT `KeyboardInterrupt`, which stops the
+/// search and is stashed in `pending` so `solve_milp_py` re-raises it after
+/// the solve returns (Ctrl-C must abort the solve, not be swallowed).
 struct PyMilpHook {
     callback: Py<PyAny>,
+    pending: std::sync::Mutex<Option<PyErr>>,
 }
 
 impl MilpDebugHook for PyMilpHook {
@@ -676,8 +679,13 @@ impl MilpDebugHook for PyMilpHook {
                     }
                 }
                 Err(e) => {
-                    e.print(py);
-                    MilpDebugControl::Continue
+                    if e.is_instance_of::<pyo3::exceptions::PyKeyboardInterrupt>(py) {
+                        *self.pending.lock().unwrap() = Some(e);
+                        MilpDebugControl::Stop
+                    } else {
+                        e.print(py);
+                        MilpDebugControl::Continue
+                    }
                 }
             }
         })
@@ -776,7 +784,10 @@ pub fn solve_milp_py<'py>(
     // Wrap an attached Python debugger (if any) as a core hook. It is created
     // before releasing the GIL and re-acquires it per checkpoint; when absent,
     // the search runs the untouched (bound-neutral) path.
-    let hook = debug_hook.map(|cb| PyMilpHook { callback: cb });
+    let hook = debug_hook.map(|cb| PyMilpHook {
+        callback: cb,
+        pending: std::sync::Mutex::new(None),
+    });
     let hook_ref: Option<&dyn MilpDebugHook> = hook.as_ref().map(|h| h as &dyn MilpDebugHook);
     let res = py.allow_threads(|| {
         let lp = LpView {
@@ -794,6 +805,15 @@ pub fn solve_milp_py<'py>(
         discopt_core::profile::dump();
         r
     });
+    // Re-raise a KeyboardInterrupt captured by the debug hook: Ctrl-C during an
+    // attached debug session aborts the solve (graceful search stop above) and
+    // then propagates as the exception the caller expects, instead of being
+    // silently converted into a normal-looking partial result.
+    if let Some(h) = hook.as_ref() {
+        if let Some(err) = h.pending.lock().unwrap().take() {
+            return Err(err);
+        }
+    }
     let status = match res.status {
         MilpStatus::Optimal => "optimal",
         MilpStatus::Feasible => "feasible",

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -66,6 +66,7 @@ parts:
       - file: notebooks/pyomo_solver
       - file: pyomo_solver
       - file: notebooks/callbacks
+      - file: notebooks/interactive_debugger
   - caption: Solver Backends
     chapters:
       - file: notebooks/qp_solver

--- a/docs/notebooks/interactive_debugger.ipynb
+++ b/docs/notebooks/interactive_debugger.ipynb
@@ -1,0 +1,898 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8ccc5e77",
+   "metadata": {},
+   "source": [
+    "# Interactive Branch-and-Bound Debugger\n",
+    "\n",
+    "discopt ships an interactive debugger for its branch-and-bound search: a \"pdb for B&B\".\n",
+    "It pauses a solve at well-defined *node-lifecycle checkpoints*, lets you inspect the tree,\n",
+    "incumbent, bounds, and per-node relaxations, set breakpoints (by iteration, by condition,\n",
+    "or on solver events), and *safely* steer the search. It drives the same batch B&B loops\n",
+    "that power discopt's spatial-McCormick search for nonconvex MINLP\n",
+    "{cite:p}`McCormick1976,Belotti2009` and its LP/NLP-based integer searches in the\n",
+    "tradition of {cite:t}`Land1960` and {cite:t}`Dakin1965`.\n",
+    "\n",
+    "Two design rules shape everything below:\n",
+    "\n",
+    "1. **Zero effect when detached.** Every fire-site in the solver is a single `None` check,\n",
+    "   so a solve without a debugger attached is bit-for-bit identical to one built without\n",
+    "   the debugger at all. This is enforced by exact-equality regression tests (identical\n",
+    "   node counts and objectives).\n",
+    "2. **The certificate is untouchable.** A global solver's product is its optimality\n",
+    "   certificate. Steering can reorder work (branching hints) or offer *validated*\n",
+    "   incumbents, but no debugger action can loosen a bound, fabricate an incumbent, or\n",
+    "   turn a correct verdict into an incorrect one.\n",
+    "\n",
+    "There are three ways in:\n",
+    "\n",
+    "| Entry point | Use case |\n",
+    "|---|---|\n",
+    "| `m.solve(debug=True)` or `debug=\"repl\"` | human REPL on a TTY |\n",
+    "| `m.solve(debug=\"on-error\")` | enter only when the solve fails to certify |\n",
+    "| `m.solve(debug=\"json\")` / `JsonFrontend` | newline-delimited JSON protocol for agents, scripts, GUIs |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "747b7b14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:10:14.534797Z",
+     "iopub.status.busy": "2026-07-06T07:10:14.534455Z",
+     "iopub.status.idle": "2026-07-06T07:10:14.746839Z",
+     "shell.execute_reply": "2026-07-06T07:10:14.746215Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+    "os.environ[\"JAX_ENABLE_X64\"] = \"1\"\n",
+    "\n",
+    "import discopt as do\n",
+    "from discopt import debug\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a65e2935",
+   "metadata": {},
+   "source": [
+    "## A model worth debugging\n",
+    "\n",
+    "A small nonconvex MINLP (a bilinear constraint plus a transcendental equality) that\n",
+    "routes to the spatial-McCormick branch-and-bound loop and needs a handful of\n",
+    "iterations to certify.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "94db2446",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:10:14.748752Z",
+     "iopub.status.busy": "2026-07-06T07:10:14.748596Z",
+     "iopub.status.idle": "2026-07-06T07:10:16.050534Z",
+     "shell.execute_reply": "2026-07-06T07:10:16.049924Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "optimal 1.0525854590378239\n"
+     ]
+    }
+   ],
+   "source": [
+    "def make_model():\n",
+    "    m = do.Model(\"debug_demo\")\n",
+    "    x = m.continuous(\"x\", lb=0.1, ub=4.0)\n",
+    "    y = m.continuous(\"y\", lb=0.1, ub=4.0)\n",
+    "    z = m.integer(\"z\", lb=0, ub=3)\n",
+    "    m.subject_to(x * y + z >= 3.0)\n",
+    "    m.subject_to(y == do.exp(x) - 1.0)\n",
+    "    m.minimize(x + 0.5 * y + 0.3 * z)\n",
+    "    return m\n",
+    "\n",
+    "\n",
+    "baseline = make_model().solve(time_limit=30.0)\n",
+    "print(baseline.status, baseline.objective)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "904b359a",
+   "metadata": {},
+   "source": [
+    "## Scripted REPL sessions\n",
+    "\n",
+    "On a TTY, `m.solve(debug=True)` drops you into the REPL at the first pause. In a\n",
+    "notebook (or a test) there is no TTY, so we feed the same REPL a *script* of commands.\n",
+    "The session pauses at the first checkpoint, executes commands until a resume verb, and\n",
+    "detaches automatically when the script is exhausted. REPL output goes to stderr.\n",
+    "\n",
+    "The command language in one screen: flow control (`step`, `stepi`, `continue`,\n",
+    "`run N`, `stop-at <checkpoint>`, `detach`, `quit`), breakpoints (`break N`, `tbreak N`,\n",
+    "`break if <metric op value [&& ...]>`, `break on <event>`), inspection (`info`,\n",
+    "`print incumbent|bound|gap|stats|nodes|node <i>|relax <i>`, `watch <target>`), and\n",
+    "steering (`inject <i>`, `hint <node_id> <var>`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e1dfef15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:10:16.052257Z",
+     "iopub.status.busy": "2026-07-06T07:10:16.052099Z",
+     "iopub.status.idle": "2026-07-06T07:10:16.288259Z",
+     "shell.execute_reply": "2026-07-06T07:10:16.287629Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "discopt debugger — 'help' for commands, 'c' to continue\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "── paused at iter_start  (step)  iter=0 nodes=1 incumbent=none bound=-inf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) help\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "flow:   step(s/n) stepi(si) continue(c) run N stop-at <cp> detach quit(q)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "breaks: break N | tbreak N | break if <m op v [&& ...]> | break on <event>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "        break (list) | break del N | break clear [cond|events]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "watch:  watch <target> | watch | watch clear\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "look:   info(i) | print(p) incumbent|bound|gap|stats|nodes|node <i>|relax <i>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "steer:  inject <i>   (validate relax sol of batch node i; adopt if feasible)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "        hint <node_id> <var>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "metrics: bound, elapsed, gap, incumbent, iter, nodes, open\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "checkpoints: iter_start, after_select, before_import, after_process, incumbent_found, terminated\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) info\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[iter_start] iter=0 nodes=1 open=1 incumbent=none bound=-inf gap=none t=0.01s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) break if gap<0.5 && nodes>=2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "break if gap<0.5 && nodes>=2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) continue\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "── paused at iter_start  (condition: gap<0.5 && nodes>=2)  iter=1 nodes=3 incumbent=1.05259 bound=1.04943\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) print bound\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "bound = 1.04943\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) print nodes\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "no batch live at this checkpoint\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) continue\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "── paused at terminated  (stop-at terminated)  iter=2 nodes=3 incumbent=1.05259 bound=1.05259\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "detached; solve runs to completion\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "optimal 1.0525854590378239\n"
+     ]
+    }
+   ],
+   "source": [
+    "script = [\n",
+    "    \"help\",\n",
+    "    \"info\",\n",
+    "    \"break if gap<0.5 && nodes>=2\",   # conditional breakpoint (AND-only)\n",
+    "    \"continue\",\n",
+    "    \"print bound\",\n",
+    "    \"print nodes\",\n",
+    "    \"continue\",\n",
+    "]\n",
+    "debug.attach(debug.make_session(script=script))\n",
+    "try:\n",
+    "    res = make_model().solve(time_limit=30.0)\n",
+    "finally:\n",
+    "    debug.detach()\n",
+    "print(res.status, res.objective)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7864388c",
+   "metadata": {},
+   "source": [
+    "## Checkpoints\n",
+    "\n",
+    "Checkpoints mirror the lifecycle of one batch iteration of the B&B loop. Every name\n",
+    "below has at least one live fire-site; the JSON handshake never advertises a pause\n",
+    "point that cannot fire.\n",
+    "\n",
+    "| Checkpoint | Fires |\n",
+    "|---|---|\n",
+    "| `iter_start` | top of a batch iteration |\n",
+    "| `after_select` | open-node boxes/ids exported from the tree |\n",
+    "| `before_import` | relaxations solved, results not yet imported — the *steer point* |\n",
+    "| `after_process` | prune/branch/fathom applied by the tree |\n",
+    "| `incumbent_found` | event: a strictly better incumbent was adopted |\n",
+    "| `terminated` | once, after the search ends (with the final status) |\n",
+    "\n",
+    "`step` resumes to the next `iter_start`; `stepi` to the next checkpoint of any kind;\n",
+    "`stop-at <name>` adds a checkpoint to the always-pause set (aliases: `start`, `select`,\n",
+    "`steer`, `import`, `process`, `branch`, `incumbent`, `end`).\n",
+    "\n",
+    "For programmatic control you can skip the REPL entirely and hand the session a custom\n",
+    "*frontend*: any object with an `interact(ctx, session)` method. The context exposes the\n",
+    "aggregate tree state (`node_count`, `open_nodes`, `incumbent_obj`, `best_bound`, `gap`)\n",
+    "plus, at batch checkpoints, the per-node boxes and relaxation results.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c1ec1da2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:10:16.289748Z",
+     "iopub.status.busy": "2026-07-06T07:10:16.289643Z",
+     "iopub.status.idle": "2026-07-06T07:10:16.511159Z",
+     "shell.execute_reply": "2026-07-06T07:10:16.510594Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iter  0  iter_start       bound=     -inf  incumbent=None\n",
+      "iter  0  after_select     bound=     -inf  incumbent=None\n",
+      "iter  0  before_import    bound=     -inf  incumbent=1.05258544550726\n",
+      "iter  0  after_process    bound=  1.04943  incumbent=1.05258544550726\n",
+      "iter  0  incumbent_found  bound=  1.04943  incumbent=1.05258544550726\n",
+      "iter  1  iter_start       bound=  1.04943  incumbent=1.05258544550726\n",
+      "iter  1  after_select     bound=  1.04943  incumbent=1.05258544550726\n",
+      "iter  1  before_import    bound=  1.04943  incumbent=1.05258544550726\n",
+      "... 10 checkpoints total; final status: optimal\n"
+     ]
+    }
+   ],
+   "source": [
+    "from discopt.debug.engine import Control\n",
+    "from discopt.debug.session import DebugSession\n",
+    "\n",
+    "\n",
+    "class TraceFrontend:\n",
+    "    \"\"\"Walk every checkpoint and record the certificate state at each pause.\"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self.trace = []\n",
+    "\n",
+    "    def interact(self, ctx, session):\n",
+    "        self.trace.append((ctx.checkpoint.value, ctx.iteration, ctx.best_bound, ctx.incumbent_obj))\n",
+    "        return Control.CONTINUE if ctx.checkpoint.value == \"terminated\" else Control.STEPI\n",
+    "\n",
+    "\n",
+    "fe = TraceFrontend()\n",
+    "debug.attach(DebugSession(fe))\n",
+    "try:\n",
+    "    res = make_model().solve(time_limit=30.0)\n",
+    "finally:\n",
+    "    debug.detach()\n",
+    "\n",
+    "for cp, it, bound, inc in fe.trace[:8]:\n",
+    "    print(f\"iter {it:2d}  {cp:16s} bound={bound:9.5f}  incumbent={inc}\")\n",
+    "print(f\"... {len(fe.trace)} checkpoints total; final status: {res.status}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c9e8d9f",
+   "metadata": {},
+   "source": [
+    "The trace shows the two halves of the certificate converging: the dual bound only ever\n",
+    "rises and the incumbent only ever falls, at *every* checkpoint, until they meet. That\n",
+    "invariant is part of the debugger's adversarial test suite.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d269930b",
+   "metadata": {},
+   "source": [
+    "## Safe steering\n",
+    "\n",
+    "At the `before_import` steer point you can influence the search — within strict limits:\n",
+    "\n",
+    "- **`inject <i>`** offers batch node `i`'s relaxation solution as a candidate incumbent.\n",
+    "  The point is first *validated against the original problem* with the solver's own\n",
+    "  machinery (integrality check and snap, constraint feasibility, true-objective\n",
+    "  evaluation), exactly like the solver's internal primal heuristics\n",
+    "  {cite:p}`Berthold2006`. Only a feasible point with its *evaluated* objective is\n",
+    "  offered to the tree, which additionally requires strict improvement. An infeasible\n",
+    "  point is rejected; on solve paths that wire no validator, `inject` refuses outright\n",
+    "  rather than trust the caller.\n",
+    "- **`hint <node_id> <var>`** suggests the branching variable for a node — reordering\n",
+    "  only, in the spirit of branching-rule engineering {cite:p}`Achterberg2005`. A hint can\n",
+    "  never prune a region, and hostile hints (unknown nodes, out-of-range variables) are\n",
+    "  ignored by the tree.\n",
+    "\n",
+    "Arbitrary edits of node boxes or bounds are deliberately *not* offered.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8ab4336e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:10:16.512957Z",
+     "iopub.status.busy": "2026-07-06T07:10:16.512843Z",
+     "iopub.status.idle": "2026-07-06T07:10:16.738938Z",
+     "shell.execute_reply": "2026-07-06T07:10:16.738460Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "discopt debugger — 'help' for commands, 'c' to continue\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "── paused at iter_start  (step)  iter=0 nodes=1 incumbent=none bound=-inf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) stop-at steer\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "will stop at before_import\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) continue\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "── paused at before_import  (stop-at before_import)  iter=0 nodes=1 incumbent=1.05259 bound=-inf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) print relax 0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "relax[0] bound=1.04943 feasible=False\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  x = [0.1    0.1052 2.9895]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) inject 0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "inject node[0]: rejected: infeasible for the original problem\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) hint 999999 0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "branch hint: node 999999 -> var 0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) continue\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "── paused at before_import  (stop-at before_import)  iter=1 nodes=3 incumbent=1.05259 bound=1.04943\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "detached; solve runs to completion\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "optimal 1.0525854590378239\n"
+     ]
+    }
+   ],
+   "source": [
+    "steer_script = [\n",
+    "    \"stop-at steer\",\n",
+    "    \"continue\",\n",
+    "    \"print relax 0\",\n",
+    "    \"inject 0\",       # validated: adopted only if genuinely feasible + improving\n",
+    "    \"hint 999999 0\",  # hostile hint: harmless, ignored by the tree\n",
+    "    \"continue\",\n",
+    "]\n",
+    "debug.attach(debug.make_session(script=steer_script))\n",
+    "try:\n",
+    "    res = make_model().solve(time_limit=30.0)\n",
+    "finally:\n",
+    "    debug.detach()\n",
+    "print(res.status, res.objective)\n",
+    "assert abs(res.objective - baseline.objective) < 1e-6  # certificate unchanged\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d71da105",
+   "metadata": {},
+   "source": [
+    "## `on-error`: a post-mortem debugger\n",
+    "\n",
+    "`debug=\"on-error\"` stays silent unless the solve terminates without a certified\n",
+    "optimum (a limit was hit, the search was interrupted, the outcome is `unknown`, or\n",
+    "infeasibility was certified). It then pauses exactly once, at `terminated`, with the\n",
+    "final status as the reason — useful as an always-on safety net in long experiments.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "723e904c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:10:16.740571Z",
+     "iopub.status.busy": "2026-07-06T07:10:16.740463Z",
+     "iopub.status.idle": "2026-07-06T07:10:16.761079Z",
+     "shell.execute_reply": "2026-07-06T07:10:16.760568Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "discopt debugger — 'help' for commands, 'c' to continue\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "── paused at terminated  (on-error: time_limit)  iter=0 nodes=1 incumbent=none bound=-inf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) info\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[terminated] iter=0 nodes=1 open=1 incumbent=none bound=-inf gap=none t=0.01s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(discopt-dbg) continue\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "time_limit\n"
+     ]
+    }
+   ],
+   "source": [
+    "# A zero time limit forces a failed termination deterministically.\n",
+    "debug.attach(debug.make_session(\"on-error\", script=[\"info\", \"continue\"]))\n",
+    "try:\n",
+    "    res = make_model().solve(time_limit=0.0)\n",
+    "finally:\n",
+    "    debug.detach()\n",
+    "print(res.status)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e33f2814",
+   "metadata": {},
+   "source": [
+    "## The JSON protocol for agents\n",
+    "\n",
+    "The second frontend speaks newline-delimited JSON and shares the *same* command engine\n",
+    "as the REPL, so an LLM agent, script, or GUI gets identical semantics. The first output\n",
+    "is a `hello` handshake advertising every checkpoint, event, command, metric, and\n",
+    "capability — clients feature-detect from it and need no out-of-band docs. Each command\n",
+    "yields a `result` event echoing the request `id`, with `ok: false` when the command\n",
+    "failed (unknown verb, raised, or unavailable at this checkpoint). Non-finite floats are\n",
+    "coerced to `null` so the stream is always strict JSON.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4d86f2f5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:10:16.762544Z",
+     "iopub.status.busy": "2026-07-06T07:10:16.762457Z",
+     "iopub.status.idle": "2026-07-06T07:10:16.991871Z",
+     "shell.execute_reply": "2026-07-06T07:10:16.991233Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "handshake capabilities: {\n",
+      "  \"inspect\": true,\n",
+      "  \"safe_steer\": true,\n",
+      "  \"mutate_iterate\": false,\n",
+      "  \"conditional_breakpoints\": \"compound_and\",\n",
+      "  \"event_breakpoints\": true,\n",
+      "  \"request_ids\": true,\n",
+      "  \"rewind\": false,\n",
+      "  \"resolve\": false,\n",
+      "  \"progress_events\": false,\n",
+      "  \"terminal_checkpoint\": true\n",
+      "}\n",
+      "pause       checkpoint=iter_start bound=None\n",
+      "result id=1 ok=True: ['[iter_start] iter=0 nodes=1 open=1 incumbent=none bound=-inf gap=none t=0.01s']\n",
+      "result id=2 ok=True: ['break if nodes>=2']\n",
+      "result id=None ok=True: []\n",
+      "pause       checkpoint=iter_start bound=1.049430329446123\n",
+      "result id=3 ok=True: ['bound = 1.04943']\n",
+      "result id=None ok=True: []\n",
+      "terminated  checkpoint=terminated bound=1.05258544550726\n",
+      "result id=None ok=True: []\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "from discopt.debug.jsonproto import JsonFrontend\n",
+    "\n",
+    "commands = iter(\n",
+    "    [\n",
+    "        json.dumps({\"cmd\": \"info\", \"id\": 1}),\n",
+    "        json.dumps({\"cmd\": \"break if nodes>=2\", \"id\": 2}),\n",
+    "        \"continue\",\n",
+    "        json.dumps({\"cmd\": \"print\", \"args\": [\"bound\"], \"id\": 3}),\n",
+    "        \"continue\",\n",
+    "        \"continue\",\n",
+    "    ]\n",
+    ")\n",
+    "events = []\n",
+    "fe = JsonFrontend(read_fn=lambda: next(commands, None), write_fn=events.append)\n",
+    "debug.attach(DebugSession(fe))\n",
+    "try:\n",
+    "    res = make_model().solve(time_limit=30.0)\n",
+    "finally:\n",
+    "    debug.detach()\n",
+    "\n",
+    "print(\"handshake capabilities:\", json.dumps(events[0][\"capabilities\"], indent=2))\n",
+    "for e in events[1:]:\n",
+    "    if e[\"event\"] == \"result\":\n",
+    "        print(f\"result id={e['request_id']} ok={e['ok']}: {e['output'][:1]}\")\n",
+    "    else:\n",
+    "        print(f\"{e['event']:11s} checkpoint={e.get('checkpoint')} bound={e.get('bound')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3db3543",
+   "metadata": {},
+   "source": [
+    "## The pure-Rust MILP fast-path\n",
+    "\n",
+    "Pure MILPs can route to a search loop that runs entirely inside the Rust extension.\n",
+    "The same debugger drives it through a checkpoint hook across the PyO3 boundary, with\n",
+    "two differences: only the aggregate checkpoints fire (`iter_start`, `after_process`,\n",
+    "`incumbent_found`, `terminated` — no per-node batch arrays), and steering is\n",
+    "unavailable (inspection and flow control only, including `quit`). When no debugger is\n",
+    "attached, no hook is installed and the Rust search runs its untouched, bound-neutral\n",
+    "path.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8a91f349",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T07:10:16.993512Z",
+     "iopub.status.busy": "2026-07-06T07:10:16.993402Z",
+     "iopub.status.idle": "2026-07-06T07:10:17.000924Z",
+     "shell.execute_reply": "2026-07-06T07:10:17.000401Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['after_process', 'incumbent_found', 'iter_start', 'terminated']\n",
+      "optimal 24.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "def knapsack():\n",
+    "    m = do.Model(\"dbg_milp\")\n",
+    "    xs = [m.integer(f\"x{i}\", lb=0, ub=1) for i in range(10)]\n",
+    "    vals = [8, 5, 3, 6, 4, 7, 9, 2, 5, 6]\n",
+    "    wts = [5, 3, 2, 4, 3, 5, 6, 1, 2, 4]\n",
+    "    m.subject_to(sum(w * xi for w, xi in zip(wts, xs)) <= 14)\n",
+    "    m.maximize(sum(v * xi for v, xi in zip(vals, xs)))\n",
+    "    return m\n",
+    "\n",
+    "\n",
+    "fe = TraceFrontend()\n",
+    "debug.attach(DebugSession(fe))\n",
+    "try:\n",
+    "    res = knapsack().solve(time_limit=15.0, nlp_solver=\"simplex\")\n",
+    "finally:\n",
+    "    debug.detach()\n",
+    "print(sorted({cp for cp, *_ in fe.trace}))\n",
+    "print(res.status, res.objective)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed5639de",
+   "metadata": {},
+   "source": [
+    "## Guarantees and caveats\n",
+    "\n",
+    "- **Bound-neutral when detached** (and under pure inspection): attaching a no-op\n",
+    "  debugger, or stepping through every checkpoint with read-only commands, leaves the\n",
+    "  node count and certified objective *exactly* unchanged.\n",
+    "- **Certificate-safe steering**: `inject` validates against the original problem before\n",
+    "  the tree sees a point; `quit` produces a valid, *uncertified* partial result\n",
+    "  (`unknown` when nothing was proven — never a false `optimal` or `infeasible`), and no\n",
+    "  fallback engine silently resumes a solve you stopped.\n",
+    "- **Thread-local**: `debug.attach()` affects only solves started on the attaching\n",
+    "  thread, so concurrent solves can each carry their own debugger.\n",
+    "- **Outermost solve only**: the solver runs nested `solve_model` calls internally\n",
+    "  (restricted sub-MINLP heuristics, warm starts); those never fire checkpoints into\n",
+    "  your session.\n",
+    "- **Not instrumented**: purely continuous NLPs route around the B&B loops entirely, so\n",
+    "  an attached debugger simply never fires there. `on-error` does not trigger on the\n",
+    "  pure-Rust MILP fast-path (its hook carries no final status).\n",
+    "- **Ctrl-C** at a REPL prompt resumes the solve; Ctrl-C while a JSON frontend is\n",
+    "  blocked on input aborts the solve and re-raises `KeyboardInterrupt`, on the Rust\n",
+    "  path included.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/discopt/debug/__init__.py
+++ b/python/discopt/debug/__init__.py
@@ -23,7 +23,7 @@ certificate — see :mod:`discopt.debug.steer`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from .checkpoints import Checkpoint
 from .context import DebugContext
@@ -42,6 +42,8 @@ __all__ = [
     "current",
     "is_attached",
     "fire",
+    "fire_rust",
+    "rust_hook",
     "make_session",
 ]
 
@@ -148,6 +150,30 @@ def fire(
     if error is not None:
         ctx.extra["error"] = error
     return session.on_checkpoint(ctx)
+
+
+def fire_rust(state: dict) -> bool:
+    """Checkpoint entry for the pure-Rust MILP hook (see ``lp_bindings.rs``).
+
+    Called across the PyO3 boundary with an aggregate state dict. Returns
+    ``True`` to stop the search (``quit``). A no-op / detached debugger returns
+    ``False`` — matching the Rust guard that only installs a hook when attached.
+    """
+    session = _ACTIVE
+    if session is None:
+        return False
+    return session.on_checkpoint(DebugContext.from_rust(state))
+
+
+def rust_hook() -> "Optional[Callable[[dict], bool]]":
+    """Return the callable to pass as ``solve_milp_py(debug_hook=…)``, or None.
+
+    A debugger must be attached *now* for a hook to be installed, so the Rust
+    search stays bound-neutral whenever no debugger is present.
+    """
+    if _ACTIVE is None:
+        return None
+    return fire_rust
 
 
 class _AttachGuard:

--- a/python/discopt/debug/__init__.py
+++ b/python/discopt/debug/__init__.py
@@ -1,0 +1,157 @@
+"""Interactive branch-and-bound debugger for discopt — a "pdb for B&B".
+
+Pause a solve at well-defined node-lifecycle checkpoints, inspect the tree /
+nodes / incumbent / relaxations, set breakpoints by iteration / condition /
+event, and *safely* steer (inject an incumbent, hint a branch). It has **zero
+effect on the solve when not attached**: every fire-site is a single ``None``
+check, and the state context is built lazily only once a debugger is attached.
+
+Typical use::
+
+    result = m.solve(debug=True)          # drop into the REPL at the first pause
+    result = m.solve(debug="on-error")    # enter only if the solve fails/limits
+
+Programmatic / notebook use::
+
+    from discopt import debug
+    with debug.attach():
+        result = m.solve()
+
+Correctness note: debugger steering can never invalidate the solver's
+certificate — see :mod:`discopt.debug.steer`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from .checkpoints import Checkpoint
+from .context import DebugContext
+from .session import DebugQuit, DebugSession
+
+if TYPE_CHECKING:
+    from .session import Frontend
+
+__all__ = [
+    "Checkpoint",
+    "DebugContext",
+    "DebugQuit",
+    "DebugSession",
+    "attach",
+    "detach",
+    "current",
+    "is_attached",
+    "fire",
+    "make_session",
+]
+
+# Module-global active session. ``None`` => detached => fire() is a no-op.
+_ACTIVE: Optional[DebugSession] = None
+
+
+def attach(session: Optional[DebugSession] = None, **kwargs: Any) -> "_AttachGuard":
+    """Attach a debugger session for the duration of a ``with`` block (or until
+    :func:`detach`). With no argument, builds a default REPL session.
+    """
+    global _ACTIVE
+    if session is None:
+        session = make_session(**kwargs)
+    _ACTIVE = session
+    return _AttachGuard(session)
+
+
+def detach() -> None:
+    """Remove the active debugger; subsequent ``fire`` calls are no-ops."""
+    global _ACTIVE
+    _ACTIVE = None
+
+
+def current() -> Optional[DebugSession]:
+    return _ACTIVE
+
+
+def is_attached() -> bool:
+    return _ACTIVE is not None
+
+
+def make_session(
+    kind: Any = True,
+    *,
+    frontend: "Optional[Frontend]" = None,
+    script: Any = None,
+) -> DebugSession:
+    """Build a :class:`DebugSession` from a ``debug=`` argument.
+
+    ``kind`` may be ``True`` / ``"repl"`` (human REPL), ``"on-error"``, or a
+    ready-made :class:`DebugSession` (returned as-is).
+    """
+    if isinstance(kind, DebugSession):
+        return kind
+    enter_on_error = kind == "on-error"
+    if frontend is None:
+        from .repl import ReplFrontend
+
+        frontend = ReplFrontend(script=script)
+    return DebugSession(frontend, enter_on_error=enter_on_error)
+
+
+def fire(
+    checkpoint: Checkpoint,
+    *,
+    tree: Any = None,
+    model: Any = None,
+    iteration: int = 0,
+    elapsed: float = 0.0,
+    batch_lb: Any = None,
+    batch_ub: Any = None,
+    batch_ids: Any = None,
+    result_lbs: Any = None,
+    result_sols: Any = None,
+    result_feas: Any = None,
+    event: Optional[str] = None,
+    error: Any = None,
+) -> bool:
+    """Fire a checkpoint. **Hot path** — returns immediately when detached.
+
+    Arguments are passed as already-existing loop locals, so a detached solve
+    incurs only the attribute read and one ``is None`` test.
+
+    Returns
+    -------
+    bool
+        ``True`` if the user requested the solve stop (``quit``); the loop
+        should ``break`` promptly. Always ``False`` when detached.
+    """
+    session = _ACTIVE
+    if session is None:
+        return False
+    ctx = DebugContext.build(
+        checkpoint,
+        tree=tree,
+        model=model,
+        iteration=iteration,
+        elapsed=elapsed,
+        batch_lb=batch_lb,
+        batch_ub=batch_ub,
+        batch_ids=batch_ids,
+        result_lbs=result_lbs,
+        result_sols=result_sols,
+        result_feas=result_feas,
+        event=event,
+    )
+    if error is not None:
+        ctx.extra["error"] = error
+    return session.on_checkpoint(ctx)
+
+
+class _AttachGuard:
+    """Context manager returned by :func:`attach`; detaches on exit."""
+
+    def __init__(self, session: DebugSession) -> None:
+        self.session = session
+
+    def __enter__(self) -> DebugSession:
+        return self.session
+
+    def __exit__(self, *exc: Any) -> None:
+        detach()

--- a/python/discopt/debug/__init__.py
+++ b/python/discopt/debug/__init__.py
@@ -118,6 +118,7 @@ def fire(
     result_feas: Any = None,
     event: Optional[str] = None,
     error: Any = None,
+    validator: Any = None,
 ) -> bool:
     """Fire a checkpoint. **Hot path** — returns immediately when detached.
 
@@ -146,6 +147,7 @@ def fire(
         result_sols=result_sols,
         result_feas=result_feas,
         event=event,
+        validator=validator,
     )
     if error is not None:
         ctx.extra["error"] = error

--- a/python/discopt/debug/__init__.py
+++ b/python/discopt/debug/__init__.py
@@ -23,10 +23,17 @@ certificate — see :mod:`discopt.debug.steer`.
 The active session is **thread-local**: attaching in one thread never affects
 solves running in other threads, so concurrent solves can each carry their own
 debugger (or none). Attach in the same thread that calls ``solve()``.
+
+Only the **outermost** solve is instrumented: the solver runs nested
+``solve_model`` calls internally (restricted sub-MINLP heuristics, warm-start
+solves), and letting those fire into the user's session would interleave two
+solves' checkpoints, collide breakpoint state, and make ``quit`` kill a
+heuristic instead of the user's solve. See :func:`outermost_solve`.
 """
 
 from __future__ import annotations
 
+import functools
 import threading
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
@@ -50,6 +57,7 @@ __all__ = [
     "fire_rust",
     "rust_hook",
     "make_session",
+    "outermost_solve",
 ]
 
 # Thread-local active session. ``None`` => detached => fire() is a no-op.
@@ -60,6 +68,34 @@ _TLS = threading.local()
 
 def _active() -> Optional[DebugSession]:
     return getattr(_TLS, "session", None)
+
+
+def _suppressed() -> bool:
+    """True inside a NESTED solve (depth > 1): checkpoints stay silent there."""
+    return getattr(_TLS, "depth", 0) > 1
+
+
+def outermost_solve(fn: Callable) -> Callable:
+    """Decorator for ``solve_model``: instrument only the outermost solve.
+
+    The solver calls ``solve_model`` recursively for heuristic sub-solves
+    (restricted sub-MINLPs, warm starts). Without this guard those inner
+    solves fire checkpoints into the user's session — interleaved pauses from
+    a solve the user did not start, colliding iteration breakpoints, and a
+    ``quit`` that kills a heuristic while the real solve keeps running.
+    ``fire``/``fire_rust``/``rust_hook`` no-op whenever the depth exceeds 1.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        depth = getattr(_TLS, "depth", 0)
+        _TLS.depth = depth + 1
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            _TLS.depth = depth
+
+    return wrapper
 
 
 def attach(session: Optional[DebugSession] = None, **kwargs: Any) -> "_AttachGuard":
@@ -150,6 +186,8 @@ def fire(
     session = _active()
     if session is None:
         return False
+    if _suppressed():  # nested heuristic sub-solve: stay silent
+        return False
     ctx = DebugContext.build(
         checkpoint,
         tree=tree,
@@ -178,7 +216,7 @@ def fire_rust(state: dict) -> bool:
     ``False`` — matching the Rust guard that only installs a hook when attached.
     """
     session = _active()
-    if session is None:
+    if session is None or _suppressed():
         return False
     return session.on_checkpoint(DebugContext.from_rust(state))
 
@@ -187,9 +225,10 @@ def rust_hook() -> "Optional[Callable[[dict], bool]]":
     """Return the callable to pass as ``solve_milp_py(debug_hook=…)``, or None.
 
     A debugger must be attached *now* for a hook to be installed, so the Rust
-    search stays bound-neutral whenever no debugger is present.
+    search stays bound-neutral whenever no debugger is present. Nested
+    heuristic sub-solves get no hook either (outermost-solve rule).
     """
-    if _active() is None:
+    if _active() is None or _suppressed():
         return None
     return fire_rust
 

--- a/python/discopt/debug/__init__.py
+++ b/python/discopt/debug/__init__.py
@@ -19,10 +19,15 @@ Programmatic / notebook use::
 
 Correctness note: debugger steering can never invalidate the solver's
 certificate — see :mod:`discopt.debug.steer`.
+
+The active session is **thread-local**: attaching in one thread never affects
+solves running in other threads, so concurrent solves can each carry their own
+debugger (or none). Attach in the same thread that calls ``solve()``.
 """
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from .checkpoints import Checkpoint
@@ -47,33 +52,38 @@ __all__ = [
     "make_session",
 ]
 
-# Module-global active session. ``None`` => detached => fire() is a no-op.
-_ACTIVE: Optional[DebugSession] = None
+# Thread-local active session. ``None`` => detached => fire() is a no-op.
+# Thread-local (not module-global) so concurrent solves in different threads
+# never share a frontend or stop each other.
+_TLS = threading.local()
+
+
+def _active() -> Optional[DebugSession]:
+    return getattr(_TLS, "session", None)
 
 
 def attach(session: Optional[DebugSession] = None, **kwargs: Any) -> "_AttachGuard":
     """Attach a debugger session for the duration of a ``with`` block (or until
-    :func:`detach`). With no argument, builds a default REPL session.
+    :func:`detach`). With no argument, builds a default REPL session. The
+    attachment is thread-local: only solves on this thread see the debugger.
     """
-    global _ACTIVE
     if session is None:
         session = make_session(**kwargs)
-    _ACTIVE = session
+    _TLS.session = session
     return _AttachGuard(session)
 
 
 def detach() -> None:
-    """Remove the active debugger; subsequent ``fire`` calls are no-ops."""
-    global _ACTIVE
-    _ACTIVE = None
+    """Remove this thread's active debugger; subsequent ``fire`` calls are no-ops."""
+    _TLS.session = None
 
 
 def current() -> Optional[DebugSession]:
-    return _ACTIVE
+    return _active()
 
 
 def is_attached() -> bool:
-    return _ACTIVE is not None
+    return _active() is not None
 
 
 def make_session(
@@ -86,10 +96,16 @@ def make_session(
 
     ``kind`` may be ``True`` / ``"repl"`` (human REPL), ``"json"`` (agent
     protocol on stdin/stdout), ``"on-error"``, or a ready-made
-    :class:`DebugSession` (returned as-is).
+    :class:`DebugSession` (returned as-is). Anything else raises ``ValueError``
+    — a typo like ``debug="jsn"`` must not silently fall back to the REPL.
     """
     if isinstance(kind, DebugSession):
         return kind
+    if kind is not True and kind not in ("repl", "json", "on-error"):
+        raise ValueError(
+            f"debug: unknown mode {kind!r} (expected True, 'repl', 'json', "
+            "'on-error', or a DebugSession)"
+        )
     enter_on_error = kind == "on-error"
     if frontend is None:
         if kind == "json":
@@ -131,7 +147,7 @@ def fire(
         ``True`` if the user requested the solve stop (``quit``); the loop
         should ``break`` promptly. Always ``False`` when detached.
     """
-    session = _ACTIVE
+    session = _active()
     if session is None:
         return False
     ctx = DebugContext.build(
@@ -161,7 +177,7 @@ def fire_rust(state: dict) -> bool:
     ``True`` to stop the search (``quit``). A no-op / detached debugger returns
     ``False`` — matching the Rust guard that only installs a hook when attached.
     """
-    session = _ACTIVE
+    session = _active()
     if session is None:
         return False
     return session.on_checkpoint(DebugContext.from_rust(state))
@@ -173,7 +189,7 @@ def rust_hook() -> "Optional[Callable[[dict], bool]]":
     A debugger must be attached *now* for a hook to be installed, so the Rust
     search stays bound-neutral whenever no debugger is present.
     """
-    if _ACTIVE is None:
+    if _active() is None:
         return None
     return fire_rust
 

--- a/python/discopt/debug/__init__.py
+++ b/python/discopt/debug/__init__.py
@@ -82,16 +82,22 @@ def make_session(
 ) -> DebugSession:
     """Build a :class:`DebugSession` from a ``debug=`` argument.
 
-    ``kind`` may be ``True`` / ``"repl"`` (human REPL), ``"on-error"``, or a
-    ready-made :class:`DebugSession` (returned as-is).
+    ``kind`` may be ``True`` / ``"repl"`` (human REPL), ``"json"`` (agent
+    protocol on stdin/stdout), ``"on-error"``, or a ready-made
+    :class:`DebugSession` (returned as-is).
     """
     if isinstance(kind, DebugSession):
         return kind
     enter_on_error = kind == "on-error"
     if frontend is None:
-        from .repl import ReplFrontend
+        if kind == "json":
+            from .jsonproto import JsonFrontend
 
-        frontend = ReplFrontend(script=script)
+            frontend = JsonFrontend()
+        else:
+            from .repl import ReplFrontend
+
+            frontend = ReplFrontend(script=script)
     return DebugSession(frontend, enter_on_error=enter_on_error)
 
 

--- a/python/discopt/debug/__init__.py
+++ b/python/discopt/debug/__init__.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import functools
 import threading
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, ParamSpec, TypeVar
 
 from .checkpoints import Checkpoint
 from .context import DebugContext
@@ -75,7 +75,11 @@ def _suppressed() -> bool:
     return getattr(_TLS, "depth", 0) > 1
 
 
-def outermost_solve(fn: Callable) -> Callable:
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def outermost_solve(fn: Callable[_P, _R]) -> Callable[_P, _R]:
     """Decorator for ``solve_model``: instrument only the outermost solve.
 
     The solver calls ``solve_model`` recursively for heuristic sub-solves
@@ -87,7 +91,7 @@ def outermost_solve(fn: Callable) -> Callable:
     """
 
     @functools.wraps(fn)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         depth = getattr(_TLS, "depth", 0)
         _TLS.depth = depth + 1
         try:

--- a/python/discopt/debug/__main__.py
+++ b/python/discopt/debug/__main__.py
@@ -1,0 +1,137 @@
+"""Command-line entry point for the interactive branch-and-bound debugger.
+
+Lets an external agent, GUI, or human spawn a debugged solve of an AMPL ``.nl``
+model as a standalone process — the counterpart to pounce's ``--debug`` /
+``--debug-json`` CLI. The three modes mirror ``Model.solve(debug=...)``::
+
+    python -m discopt.debug model.nl              # human REPL
+    python -m discopt.debug model.nl --json       # JSON agent protocol (stdin/stdout)
+    python -m discopt.debug model.nl --on-error   # enter only if the solve fails
+    python -m discopt.debug model.nl --script cmds.pdbg   # scripted REPL
+
+In ``--json`` mode the debugger's protocol owns **stdout** (newline-delimited
+JSON); the solver banner and the final result summary go to **stderr** so the
+stream stays machine-parseable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import IO, TYPE_CHECKING, Optional, Sequence, cast
+
+if TYPE_CHECKING:
+    from discopt.modeling.core import SolveResult
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m discopt.debug",
+        description="Interactively debug a branch-and-bound solve of an AMPL .nl model.",
+    )
+    p.add_argument("model", help="path to an AMPL .nl model file")
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--json",
+        action="store_true",
+        help="drive via the self-describing JSON agent protocol on stdin/stdout",
+    )
+    mode.add_argument(
+        "--on-error",
+        action="store_true",
+        help="run freely; enter the debugger only if the solve fails or hits a limit",
+    )
+    p.add_argument(
+        "--script",
+        metavar="FILE",
+        help="run debugger commands from FILE at each pause (human REPL mode only)",
+    )
+    p.add_argument(
+        "--time-limit",
+        type=float,
+        default=3600.0,
+        metavar="SECONDS",
+        help="solve wall-clock time limit (default: 3600)",
+    )
+    p.add_argument(
+        "--nlp-solver",
+        default=None,
+        metavar="NAME",
+        help="override the node solver, e.g. 'simplex' for the pure-Rust MILP path",
+    )
+    return p
+
+
+def _resolve_kind(args: argparse.Namespace):
+    """Map parsed flags to the ``debug=`` argument understood by ``Model.solve``."""
+    if args.json:
+        return "json"
+    if args.on_error:
+        return "on-error"
+    return True  # human REPL
+
+
+def _read_script(path: Optional[str]) -> Optional[list[str]]:
+    if not path:
+        return None
+    with open(path, encoding="utf-8") as fh:
+        # One command per line; skip blanks and '#' / '//' comments (pounce style).
+        out: list[str] = []
+        for line in fh:
+            s = line.strip()
+            if not s or s.startswith("#") or s.startswith("//"):
+                continue
+            out.append(s)
+        return out
+
+
+def main(argv: Optional[Sequence[str]] = None, *, err: Optional[IO[str]] = None) -> int:
+    """Run a debugged solve. Returns a process exit code (0 = solved)."""
+    err = err or sys.stderr
+    args = build_parser().parse_args(argv)
+
+    if args.script and (args.json or args.on_error):
+        print("error: --script applies to the human REPL only", file=err)
+        return 2
+
+    from discopt import debug as _debug
+    from discopt.modeling import from_nl
+
+    try:
+        model = from_nl(args.model)
+    except FileNotFoundError:
+        print(f"error: no such model file: {args.model}", file=err)
+        return 2
+    except Exception as exc:  # malformed .nl, parser error, etc.
+        print(f"error: could not load {args.model}: {exc}", file=err)
+        return 2
+
+    kind = _resolve_kind(args)
+    if kind == "json":
+        session = _debug.make_session("json")
+    else:
+        # Route the REPL onto the same ``err`` stream as the summary, so the
+        # whole human-facing session is one stream (and testable via a buffer).
+        from discopt.debug.repl import ReplFrontend
+
+        frontend = ReplFrontend(script=_read_script(args.script), out=err)
+        session = _debug.make_session(kind, frontend=frontend)
+
+    solve_kwargs = {"time_limit": args.time_limit, "debug": session}
+    if args.nlp_solver:
+        solve_kwargs["nlp_solver"] = args.nlp_solver
+
+    # A non-streaming solve always returns a SolveResult (not an update iterator).
+    result = cast("SolveResult", model.solve(**solve_kwargs))
+
+    # Result summary always to stderr so --json keeps stdout pure.
+    obj = "n/a" if result.objective is None else f"{result.objective:.6g}"
+    print(
+        f"[discopt.debug] status={result.status} objective={obj} nodes={result.node_count}",
+        file=err,
+    )
+    return 0 if result.status in ("optimal", "feasible") else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - process entry
+    sys.exit(main())

--- a/python/discopt/debug/checkpoints.py
+++ b/python/discopt/debug/checkpoints.py
@@ -1,8 +1,11 @@
 """Checkpoint vocabulary for the interactive branch-and-bound debugger.
 
 The debugger reframes pounce's IPM-iteration phases as a B&B *node lifecycle*.
-Each solve loop fires the subset of checkpoints it actually reaches; the JSON
-``hello`` handshake advertises which are live for the active path.
+Every member below is fired by at least one instrumented solve loop, so the
+JSON ``hello`` handshake (which advertises all members) never promises a pause
+point that cannot fire. Candidate future checkpoints (e.g. after per-node
+FBBT/OBBT tightening, after the per-node relaxation solve) are added here only
+together with their fire-sites — no dead vocabulary.
 """
 
 from __future__ import annotations
@@ -18,8 +21,6 @@ class Checkpoint(str, Enum):
 
     ITER_START = "iter_start"  # top of a batch iteration
     AFTER_SELECT = "after_select"  # open-node boxes/ids exported from the tree
-    AFTER_TIGHTEN = "after_tighten"  # per-node FBBT/OBBT applied to boxes
-    AFTER_BOUND = "after_bound"  # per-node relaxation solved (sols/bounds/feas)
     BEFORE_IMPORT = "before_import"  # steer point: inject incumbent / branch hint
     AFTER_PROCESS = "after_process"  # prune/branch/fathom applied by the tree
     INCUMBENT_FOUND = "incumbent_found"  # event: a strictly better incumbent
@@ -39,9 +40,6 @@ ALIASES: dict[str, Checkpoint] = {
     "start": Checkpoint.ITER_START,
     "sel": Checkpoint.AFTER_SELECT,
     "select": Checkpoint.AFTER_SELECT,
-    "tighten": Checkpoint.AFTER_TIGHTEN,
-    "bound": Checkpoint.AFTER_BOUND,
-    "relax": Checkpoint.AFTER_BOUND,
     "steer": Checkpoint.BEFORE_IMPORT,
     "import": Checkpoint.BEFORE_IMPORT,
     "process": Checkpoint.AFTER_PROCESS,

--- a/python/discopt/debug/checkpoints.py
+++ b/python/discopt/debug/checkpoints.py
@@ -1,0 +1,64 @@
+"""Checkpoint vocabulary for the interactive branch-and-bound debugger.
+
+The debugger reframes pounce's IPM-iteration phases as a B&B *node lifecycle*.
+Each solve loop fires the subset of checkpoints it actually reaches; the JSON
+``hello`` handshake advertises which are live for the active path.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Checkpoint(str, Enum):
+    """A well-defined pause point in the branch-and-bound search.
+
+    Ordered by their position within a single batch iteration.
+    """
+
+    ITER_START = "iter_start"  # top of a batch iteration
+    AFTER_SELECT = "after_select"  # open-node boxes/ids exported from the tree
+    AFTER_TIGHTEN = "after_tighten"  # per-node FBBT/OBBT applied to boxes
+    AFTER_BOUND = "after_bound"  # per-node relaxation solved (sols/bounds/feas)
+    BEFORE_IMPORT = "before_import"  # steer point: inject incumbent / branch hint
+    AFTER_PROCESS = "after_process"  # prune/branch/fathom applied by the tree
+    INCUMBENT_FOUND = "incumbent_found"  # event: a strictly better incumbent
+    TERMINATED = "terminated"  # final / limit / infeasible
+
+    def __str__(self) -> str:  # nicer REPL/JSON output
+        return self.value
+
+
+#: Checkpoints the debugger stops at by default. Others fire every iteration but
+#: resume immediately unless a breakpoint or ``stop-at`` requests them (matches
+#: pounce's default of stopping only at ``iter_start`` and ``terminated``).
+DEFAULT_STOP: frozenset[Checkpoint] = frozenset({Checkpoint.ITER_START, Checkpoint.TERMINATED})
+
+#: Friendly aliases accepted by ``stop-at``.
+ALIASES: dict[str, Checkpoint] = {
+    "start": Checkpoint.ITER_START,
+    "sel": Checkpoint.AFTER_SELECT,
+    "select": Checkpoint.AFTER_SELECT,
+    "tighten": Checkpoint.AFTER_TIGHTEN,
+    "bound": Checkpoint.AFTER_BOUND,
+    "relax": Checkpoint.AFTER_BOUND,
+    "steer": Checkpoint.BEFORE_IMPORT,
+    "import": Checkpoint.BEFORE_IMPORT,
+    "process": Checkpoint.AFTER_PROCESS,
+    "branch": Checkpoint.AFTER_PROCESS,
+    "incumbent": Checkpoint.INCUMBENT_FOUND,
+    "end": Checkpoint.TERMINATED,
+    "done": Checkpoint.TERMINATED,
+}
+
+
+def resolve_checkpoint(name: str) -> Checkpoint:
+    """Resolve a checkpoint name or alias, raising ``KeyError`` if unknown."""
+    key = name.strip().lower()
+    if key in ALIASES:
+        return ALIASES[key]
+    return Checkpoint(key)  # raises ValueError -> caller reports it
+
+
+#: Solver events a breakpoint can fire on. Extended in later phases.
+EVENTS: frozenset[str] = frozenset({"new_incumbent"})

--- a/python/discopt/debug/context.py
+++ b/python/discopt/debug/context.py
@@ -137,11 +137,12 @@ class DebugContext:
 
     @classmethod
     def from_rust(cls, state: dict) -> "DebugContext":
-        """Build a context from the pure-Rust MILP hook's aggregate state dict.
+        """Build a context from the pure-Rust MILP hook's state dict.
 
-        The Rust ``solve_milp`` fast-path has no ``PyTreeManager``, so this path
-        carries aggregate scalars only (no per-node batch arrays, no steer
-        handle — inspection and flow control only). The Rust hook also carries
+        The Rust ``solve_milp`` fast-path has no ``PyTreeManager`` (so no steer
+        handle — inspection and flow control only), but at the ``after_select``
+        checkpoint the hook marshals the batch's per-node boxes/ids, so
+        ``print node <i>`` / ``print nodes`` work here too. The Rust hook carries
         no final status, so ``extra["error"]`` is never set and ``"on-error"``
         sessions do not trigger on this path (documented in ``Model.solve``).
         """
@@ -154,6 +155,15 @@ class DebugContext:
         )
         gap = state.get("gap")
         gap = float(gap) if gap is not None and np.isfinite(gap) else None
+
+        # Batch boxes are present only at after_select (nested lists from Rust).
+        b_lb = state.get("batch_lb")
+        b_ub = state.get("batch_ub")
+        b_ids = state.get("batch_ids")
+        batch_lb = np.asarray(b_lb, dtype=np.float64) if b_lb is not None else None
+        batch_ub = np.asarray(b_ub, dtype=np.float64) if b_ub is not None else None
+        batch_ids = np.asarray(b_ids, dtype=np.int64) if b_ids is not None else None
+
         return cls(
             checkpoint=cp,
             iteration=int(state.get("iteration", 0)),
@@ -163,4 +173,7 @@ class DebugContext:
             incumbent_obj=inc_obj,
             best_bound=float(state.get("bound", -np.inf)),
             gap=gap,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
         )

--- a/python/discopt/debug/context.py
+++ b/python/discopt/debug/context.py
@@ -91,12 +91,15 @@ class DebugContext:
         result_sols: Any = None,
         result_feas: Any = None,
         event: Optional[str] = None,
+        validator: Any = None,
     ) -> "DebugContext":
         """Construct a context by reading aggregate state from the Rust tree.
 
         Only pure reads (``tree.stats()`` / ``tree.incumbent()``) are performed,
         so building a context never perturbs the search — a no-op debugger is
-        bound-neutral.
+        bound-neutral. ``validator`` is the solve loop's candidate-validation
+        closure (see :data:`discopt.debug.steer.Validator`); the ``inject``
+        steer is available only at checkpoints that wire one.
         """
         from .steer import DebugSteer
 
@@ -128,7 +131,7 @@ class DebugContext:
             result_sols=result_sols,
             result_feas=result_feas,
             event=event,
-            steer=DebugSteer(tree, model) if tree is not None else None,
+            steer=DebugSteer(tree, model, validator=validator) if tree is not None else None,
             model=model,
         )
 

--- a/python/discopt/debug/context.py
+++ b/python/discopt/debug/context.py
@@ -141,7 +141,9 @@ class DebugContext:
 
         The Rust ``solve_milp`` fast-path has no ``PyTreeManager``, so this path
         carries aggregate scalars only (no per-node batch arrays, no steer
-        handle — inspection and flow control only).
+        handle — inspection and flow control only). The Rust hook also carries
+        no final status, so ``extra["error"]`` is never set and ``"on-error"``
+        sessions do not trigger on this path (documented in ``Model.solve``).
         """
         cp = Checkpoint(str(state["checkpoint"]))
         inc = state.get("incumbent")

--- a/python/discopt/debug/context.py
+++ b/python/discopt/debug/context.py
@@ -131,3 +131,31 @@ class DebugContext:
             steer=DebugSteer(tree, model) if tree is not None else None,
             model=model,
         )
+
+    @classmethod
+    def from_rust(cls, state: dict) -> "DebugContext":
+        """Build a context from the pure-Rust MILP hook's aggregate state dict.
+
+        The Rust ``solve_milp`` fast-path has no ``PyTreeManager``, so this path
+        carries aggregate scalars only (no per-node batch arrays, no steer
+        handle — inspection and flow control only).
+        """
+        cp = Checkpoint(str(state["checkpoint"]))
+        inc = state.get("incumbent")
+        inc_obj = (
+            float(inc)
+            if inc is not None and np.isfinite(inc) and float(inc) < _SENTINEL_THRESHOLD
+            else None
+        )
+        gap = state.get("gap")
+        gap = float(gap) if gap is not None and np.isfinite(gap) else None
+        return cls(
+            checkpoint=cp,
+            iteration=int(state.get("iteration", 0)),
+            elapsed=float(state.get("elapsed", 0.0)),
+            node_count=int(state.get("nodes", 0)),
+            open_nodes=int(state.get("open_nodes", 0)),
+            incumbent_obj=inc_obj,
+            best_bound=float(state.get("bound", -np.inf)),
+            gap=gap,
+        )

--- a/python/discopt/debug/context.py
+++ b/python/discopt/debug/context.py
@@ -1,0 +1,133 @@
+"""The state snapshot handed to the debugger at each checkpoint.
+
+``DebugContext`` is a superset of :class:`discopt.callbacks.CallbackContext`:
+it carries the aggregate tree state that is always available, plus the
+per-node batch arrays that exist only at the batch-level checkpoints. It is
+built lazily — only when a debugger is actually attached — so a detached solve
+pays nothing (see :func:`discopt.debug.fire`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+import numpy as np
+
+from .checkpoints import Checkpoint
+
+if TYPE_CHECKING:
+    from .steer import DebugSteer
+
+# Bounds sentinel used by the solver for infeasible / failed relaxations. Kept
+# in sync with solver._SENTINEL_THRESHOLD; values at/above this are "no bound".
+_SENTINEL_THRESHOLD = 1e19
+
+
+@dataclass
+class DebugContext:
+    """Read-mostly view of solver state at a checkpoint.
+
+    Aggregate fields are always populated. Batch fields (``batch_*`` and
+    ``result_*``) are present only at ``AFTER_SELECT`` and later within an
+    iteration; they are ``None`` at ``ITER_START`` and ``TERMINATED``.
+    """
+
+    checkpoint: Checkpoint
+    iteration: int
+    elapsed: float
+
+    # Aggregate tree state (always available).
+    node_count: int
+    open_nodes: int
+    incumbent_obj: Optional[float]
+    best_bound: float
+    gap: Optional[float]
+
+    # Per-node batch state (available at AFTER_SELECT .. AFTER_PROCESS).
+    batch_lb: Optional[np.ndarray] = None
+    batch_ub: Optional[np.ndarray] = None
+    batch_ids: Optional[np.ndarray] = None
+    result_lbs: Optional[np.ndarray] = None
+    result_sols: Optional[np.ndarray] = None
+    result_feas: Optional[np.ndarray] = None
+
+    # Optional event tag (e.g. "new_incumbent") and safe-steer handle.
+    event: Optional[str] = None
+    steer: Optional["DebugSteer"] = None
+    model: Any = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def n_batch(self) -> int:
+        """Number of nodes in the current batch (0 if no batch is live)."""
+        return 0 if self.batch_ids is None else len(self.batch_ids)
+
+    def metrics(self) -> dict[str, float]:
+        """Scalar metrics addressable by conditional breakpoints and ``print``."""
+        return {
+            "nodes": float(self.node_count),
+            "open": float(self.open_nodes),
+            "incumbent": (float(self.incumbent_obj) if self.incumbent_obj is not None else np.inf),
+            "bound": float(self.best_bound),
+            "gap": float(self.gap) if self.gap is not None else np.inf,
+            "iter": float(self.iteration),
+            "elapsed": float(self.elapsed),
+        }
+
+    @classmethod
+    def build(
+        cls,
+        checkpoint: Checkpoint,
+        *,
+        tree: Any,
+        model: Any = None,
+        iteration: int = 0,
+        elapsed: float = 0.0,
+        batch_lb: Any = None,
+        batch_ub: Any = None,
+        batch_ids: Any = None,
+        result_lbs: Any = None,
+        result_sols: Any = None,
+        result_feas: Any = None,
+        event: Optional[str] = None,
+    ) -> "DebugContext":
+        """Construct a context by reading aggregate state from the Rust tree.
+
+        Only pure reads (``tree.stats()`` / ``tree.incumbent()``) are performed,
+        so building a context never perturbs the search — a no-op debugger is
+        bound-neutral.
+        """
+        from .steer import DebugSteer
+
+        stats = tree.stats() if tree is not None else {}
+        inc = tree.incumbent() if tree is not None else None
+        inc_obj: Optional[float] = None
+        if inc is not None:
+            _, obj = inc
+            if np.isfinite(obj) and obj < _SENTINEL_THRESHOLD:
+                inc_obj = float(obj)
+
+        gap = stats.get("gap")
+        if gap is not None and not np.isfinite(gap):
+            gap = None
+
+        return cls(
+            checkpoint=checkpoint,
+            iteration=iteration,
+            elapsed=elapsed,
+            node_count=int(stats.get("total_nodes", 0)),
+            open_nodes=int(stats.get("open_nodes", 0)),
+            incumbent_obj=inc_obj,
+            best_bound=float(stats.get("global_lower_bound", -np.inf)),
+            gap=gap,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
+            result_lbs=result_lbs,
+            result_sols=result_sols,
+            result_feas=result_feas,
+            event=event,
+            steer=DebugSteer(tree, model) if tree is not None else None,
+            model=model,
+        )

--- a/python/discopt/debug/engine.py
+++ b/python/discopt/debug/engine.py
@@ -39,6 +39,7 @@ class CommandResult:
     output: list[str] = field(default_factory=list)
     control: Control = Control.NONE
     data: Optional[dict] = None  # structured payload for the JSON frontend
+    ok: bool = True  # False when the command failed (unknown / raised / unavailable)
 
     def line(self, text: str) -> "CommandResult":
         self.output.append(text)
@@ -136,11 +137,11 @@ class DebugCommandEngine:
 
         handler = _DISPATCH.get(cmd)
         if handler is None:
-            return CommandResult([f"unknown command: {cmd!r} (try 'help')"])
+            return CommandResult([f"unknown command: {cmd!r} (try 'help')"], ok=False)
         try:
             return handler(self, args, ctx, session)
         except Exception as exc:  # keep the prompt alive on user error
-            return CommandResult([f"error: {exc}"])
+            return CommandResult([f"error: {exc}"], ok=False)
 
 
 # ── individual command handlers ────────────────────────────────────────────
@@ -329,14 +330,15 @@ def _cmd_watch(engine, args, ctx, session):
 
 def _cmd_inject(engine, args, ctx, session):
     if ctx.steer is None or ctx.result_sols is None:
-        return CommandResult(["inject unavailable at this checkpoint"])
+        return CommandResult(["inject unavailable at this checkpoint"], ok=False)
     if not ctx.steer.can_inject:
         return CommandResult(
             [
                 "inject unavailable: this solve path wires no candidate validator, "
                 "so a point's true feasibility/objective cannot be verified "
                 "(refusing — certificate safety)"
-            ]
+            ],
+            ok=False,
         )
     i = int(args[0])
     sol = np.asarray(ctx.result_sols[i], dtype=np.float64)
@@ -350,7 +352,7 @@ def _cmd_inject(engine, args, ctx, session):
 
 def _cmd_hint(engine, args, ctx, session):
     if ctx.steer is None:
-        return CommandResult(["hint unavailable at this checkpoint"])
+        return CommandResult(["hint unavailable at this checkpoint"], ok=False)
     node_id, var = int(args[0]), int(args[1])
     ctx.steer.hint([node_id], [var])
     return CommandResult([f"branch hint: node {node_id} -> var {var}"])

--- a/python/discopt/debug/engine.py
+++ b/python/discopt/debug/engine.py
@@ -195,8 +195,10 @@ def _cmd_detach(engine, args, ctx, session):
 
 def _cmd_run(engine, args, ctx, session):
     if not args:
-        return CommandResult(["usage: run N"])
-    engine.iter_breaks.add(int(args[0]))
+        return CommandResult(["usage: run N"], ok=False)
+    # One-shot (temp) break: `run N` means "pause once at iteration N", not
+    # "leave a breakpoint at N behind".
+    engine.temp_breaks.add(int(args[0]))
     return CommandResult([f"running to iteration {int(args[0])}"], control=Control.CONTINUE)
 
 
@@ -231,6 +233,7 @@ def _cmd_break(engine, args, ctx, session):
         return CommandResult([f"break on {args[1]}"])
     if head == "del":
         engine.iter_breaks.discard(int(args[1]))
+        engine.temp_breaks.discard(int(args[1]))
         return CommandResult([f"removed break {int(args[1])}"])
     if head == "clear":
         what = args[1] if len(args) > 1 else "all"

--- a/python/discopt/debug/engine.py
+++ b/python/discopt/debug/engine.py
@@ -163,7 +163,7 @@ def _cmd_help(engine, args, ctx, session):
             "        break (list) | break del N | break clear [cond|events]",
             "watch:  watch <target> | watch | watch clear",
             "look:   info(i) | print(p) incumbent|bound|gap|stats|nodes|node <i>|relax <i>",
-            "steer:  inject <i>   (adopt relax sol of batch node i as incumbent)",
+            "steer:  inject <i>   (validate relax sol of batch node i; adopt if feasible)",
             "        hint <node_id> <var>",
             f"metrics: {', '.join(sorted(ctx.metrics()))}",
             f"checkpoints: {', '.join(c.value for c in Checkpoint)}",
@@ -330,13 +330,22 @@ def _cmd_watch(engine, args, ctx, session):
 def _cmd_inject(engine, args, ctx, session):
     if ctx.steer is None or ctx.result_sols is None:
         return CommandResult(["inject unavailable at this checkpoint"])
+    if not ctx.steer.can_inject:
+        return CommandResult(
+            [
+                "inject unavailable: this solve path wires no candidate validator, "
+                "so a point's true feasibility/objective cannot be verified "
+                "(refusing — certificate safety)"
+            ]
+        )
     i = int(args[0])
     sol = np.asarray(ctx.result_sols[i], dtype=np.float64)
-    obj = float(ctx.result_lbs[i])
-    adopted = ctx.steer.inject(sol, obj)
-    return CommandResult(
-        [f"inject node[{i}] obj={_fmt(obj)}: {'adopted' if adopted else 'rejected by tree'}"]
-    )
+    # The candidate is validated against the ORIGINAL problem (integrality,
+    # constraints, true objective) — never trusted with its relaxation bound.
+    adopted, obj, reason = ctx.steer.inject(sol)
+    if obj is None:
+        return CommandResult([f"inject node[{i}]: {reason}"])
+    return CommandResult([f"inject node[{i}] obj={_fmt(obj)}: {reason}"])
 
 
 def _cmd_hint(engine, args, ctx, session):

--- a/python/discopt/debug/engine.py
+++ b/python/discopt/debug/engine.py
@@ -1,0 +1,379 @@
+"""Frontend-agnostic command engine for the interactive debugger.
+
+Pounce's design is "one command engine, two frontends". The engine owns all
+breakpoint state and command semantics; the REPL and the JSON protocol are thin
+adapters that feed it command strings and render its results. This keeps human
+and agent debugging behaviourally identical.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Callable, Optional
+
+import numpy as np
+
+from .checkpoints import EVENTS, Checkpoint, resolve_checkpoint
+
+if TYPE_CHECKING:
+    from .context import DebugContext
+    from .session import DebugSession
+
+
+class Control(Enum):
+    """What a command tells the debugger to do after it runs."""
+
+    NONE = auto()  # stay at the prompt (inspection command)
+    STEP = auto()  # resume until next ITER_START
+    STEPI = auto()  # resume until next checkpoint of any kind
+    CONTINUE = auto()  # resume until next breakpoint / termination
+    QUIT = auto()  # abort the solve
+
+
+@dataclass
+class CommandResult:
+    """Outcome of one command: rendered text plus a control decision."""
+
+    output: list[str] = field(default_factory=list)
+    control: Control = Control.NONE
+    data: Optional[dict] = None  # structured payload for the JSON frontend
+
+    def line(self, text: str) -> "CommandResult":
+        self.output.append(text)
+        return self
+
+
+_COND_RE = re.compile(r"^\s*([a-z_]+)\s*(<=|>=|==|<|>)\s*([-+0-9.eE]+)\s*$")
+
+
+@dataclass
+class _Condition:
+    raw: str
+    clauses: list[tuple[str, str, float]]  # AND-joined (metric, op, value)
+
+    def eval(self, metrics: dict[str, float]) -> bool:
+        for metric, op, val in self.clauses:
+            m = metrics.get(metric)
+            if m is None:
+                return False
+            if not _apply(m, op, val):
+                return False
+        return True
+
+
+def _apply(lhs: float, op: str, rhs: float) -> bool:
+    if op == "<":
+        return lhs < rhs
+    if op == "<=":
+        return lhs <= rhs
+    if op == ">":
+        return lhs > rhs
+    if op == ">=":
+        return lhs >= rhs
+    # float-tolerant equality (pounce semantics)
+    return abs(lhs - rhs) <= 1e-9 * max(1.0, abs(rhs))
+
+
+def _parse_condition(expr: str) -> _Condition:
+    """Parse a ``&&``-joined conjunction of ``metric OP value`` atoms.
+
+    ``||`` and grouping are not supported in v1 (register multiple conditions,
+    as pounce recommends). Parentheses are stripped.
+    """
+    cleaned = expr.replace("(", " ").replace(")", " ")
+    if "||" in cleaned:
+        raise ValueError("'||' not supported; register separate 'break if' conditions")
+    clauses: list[tuple[str, str, float]] = []
+    for atom in cleaned.split("&&"):
+        m = _COND_RE.match(atom)
+        if not m:
+            raise ValueError(f"cannot parse condition atom: {atom.strip()!r}")
+        clauses.append((m.group(1), m.group(2), float(m.group(3))))
+    return _Condition(raw=expr.strip(), clauses=clauses)
+
+
+class DebugCommandEngine:
+    """Holds breakpoint state and interprets debugger commands."""
+
+    def __init__(self) -> None:
+        self.iter_breaks: set[int] = set()
+        self.temp_breaks: set[int] = set()
+        self.conditions: list[_Condition] = []
+        self.events: set[str] = set()
+        self.watches: list[str] = []
+
+    # ── breakpoint predicate (consulted by the session at each checkpoint) ──
+
+    def hit_reason(self, ctx: "DebugContext") -> Optional[str]:
+        """Return a human reason if a breakpoint fires at ``ctx``, else None.
+
+        Iteration / conditional breakpoints are evaluated at ITER_START only;
+        event breakpoints fire wherever the event surfaces.
+        """
+        if ctx.event and ctx.event in self.events:
+            return f"event: {ctx.event}"
+        if ctx.checkpoint is Checkpoint.ITER_START:
+            it = ctx.iteration
+            if it in self.iter_breaks or it in self.temp_breaks:
+                self.temp_breaks.discard(it)
+                return f"iteration {it}"
+            metrics = ctx.metrics()
+            for cond in self.conditions:
+                if cond.eval(metrics):
+                    return f"condition: {cond.raw}"
+        return None
+
+    # ── command dispatch ──
+
+    def execute(self, raw: str, ctx: "DebugContext", session: "DebugSession") -> CommandResult:
+        raw = raw.strip()
+        if not raw:
+            return CommandResult()
+        parts = raw.split()
+        cmd, args = parts[0].lower(), parts[1:]
+
+        handler = _DISPATCH.get(cmd)
+        if handler is None:
+            return CommandResult([f"unknown command: {cmd!r} (try 'help')"])
+        try:
+            return handler(self, args, ctx, session)
+        except Exception as exc:  # keep the prompt alive on user error
+            return CommandResult([f"error: {exc}"])
+
+
+# ── individual command handlers ────────────────────────────────────────────
+# Each takes (engine, args, ctx, session) and returns a CommandResult.
+
+
+def _fmt(x) -> str:
+    if x is None:
+        return "none"
+    if isinstance(x, float) and not np.isfinite(x):
+        return "inf" if x > 0 else "-inf"
+    return f"{x:.6g}" if isinstance(x, float) else str(x)
+
+
+def _cmd_help(engine, args, ctx, session):
+    return CommandResult(
+        [
+            "flow:   step(s/n) stepi(si) continue(c) run N stop-at <cp> detach quit(q)",
+            "breaks: break N | tbreak N | break if <m op v [&& ...]> | break on <event>",
+            "        break (list) | break del N | break clear [cond|events]",
+            "watch:  watch <target> | watch | watch clear",
+            "look:   info(i) | print(p) incumbent|bound|gap|stats|nodes|node <i>|relax <i>",
+            "steer:  inject <i>   (adopt relax sol of batch node i as incumbent)",
+            "        hint <node_id> <var>",
+            f"metrics: {', '.join(sorted(ctx.metrics()))}",
+            f"checkpoints: {', '.join(c.value for c in Checkpoint)}",
+        ]
+    )
+
+
+def _cmd_step(engine, args, ctx, session):
+    return CommandResult(control=Control.STEP)
+
+
+def _cmd_stepi(engine, args, ctx, session):
+    return CommandResult(control=Control.STEPI)
+
+
+def _cmd_continue(engine, args, ctx, session):
+    return CommandResult(control=Control.CONTINUE)
+
+
+def _cmd_quit(engine, args, ctx, session):
+    return CommandResult(["quitting solve"], control=Control.QUIT)
+
+
+def _cmd_detach(engine, args, ctx, session):
+    session.detach()
+    return CommandResult(["detached; solve runs to completion"], control=Control.CONTINUE)
+
+
+def _cmd_run(engine, args, ctx, session):
+    if not args:
+        return CommandResult(["usage: run N"])
+    engine.iter_breaks.add(int(args[0]))
+    return CommandResult([f"running to iteration {int(args[0])}"], control=Control.CONTINUE)
+
+
+def _cmd_stop_at(engine, args, ctx, session):
+    if not args:
+        names = ", ".join(c.value for c in sorted(session.stop_checkpoints, key=lambda c: c.value))
+        return CommandResult([f"stopping at: {names or '(none)'}"])
+    if args[0] == "clear":
+        session.stop_checkpoints = set()
+        return CommandResult(["stop-at cleared"])
+    cp = resolve_checkpoint(args[0])
+    session.stop_checkpoints.add(cp)
+    return CommandResult([f"will stop at {cp.value}"])
+
+
+def _cmd_break(engine, args, ctx, session):
+    if not args:  # list
+        out = [f"iter breaks: {sorted(engine.iter_breaks) or '(none)'}"]
+        out += [f"temp breaks: {sorted(engine.temp_breaks) or '(none)'}"]
+        out += [f"conditions:  {[c.raw for c in engine.conditions] or '(none)'}"]
+        out += [f"events:      {sorted(engine.events) or '(none)'}"]
+        return CommandResult(out)
+    head = args[0]
+    if head == "if":
+        cond = _parse_condition(" ".join(args[1:]))
+        engine.conditions.append(cond)
+        return CommandResult([f"break if {cond.raw}"])
+    if head == "on":
+        if not args[1:] or args[1] not in EVENTS:
+            return CommandResult([f"events: {', '.join(sorted(EVENTS))}"])
+        engine.events.add(args[1])
+        return CommandResult([f"break on {args[1]}"])
+    if head == "del":
+        engine.iter_breaks.discard(int(args[1]))
+        return CommandResult([f"removed break {int(args[1])}"])
+    if head == "clear":
+        what = args[1] if len(args) > 1 else "all"
+        if what in ("cond", "conditions"):
+            engine.conditions.clear()
+        elif what == "events":
+            engine.events.clear()
+        else:
+            engine.iter_breaks.clear()
+            engine.temp_breaks.clear()
+            engine.conditions.clear()
+            engine.events.clear()
+        return CommandResult([f"cleared {what} breakpoints"])
+    engine.iter_breaks.add(int(head))
+    return CommandResult([f"break at iteration {int(head)}"])
+
+
+def _cmd_tbreak(engine, args, ctx, session):
+    engine.temp_breaks.add(int(args[0]))
+    return CommandResult([f"one-shot break at iteration {int(args[0])}"])
+
+
+def _cmd_info(engine, args, ctx, session):
+    m = ctx.metrics()
+    return CommandResult(
+        [
+            f"[{ctx.checkpoint.value}] iter={ctx.iteration} "
+            f"nodes={ctx.node_count} open={ctx.open_nodes} "
+            f"incumbent={_fmt(ctx.incumbent_obj)} bound={_fmt(ctx.best_bound)} "
+            f"gap={_fmt(ctx.gap)} t={m['elapsed']:.2f}s"
+        ],
+        data={"metrics": m, "checkpoint": ctx.checkpoint.value},
+    )
+
+
+def _cmd_print(engine, args, ctx, session):
+    if not args:
+        return CommandResult(["usage: print <target>"])
+    target = args[0].lower()
+    if target in ("incumbent", "inc"):
+        return CommandResult(
+            [f"incumbent = {_fmt(ctx.incumbent_obj)}"],
+            data={"incumbent": ctx.incumbent_obj},
+        )
+    if target in ("bound", "lb"):
+        return CommandResult([f"bound = {_fmt(ctx.best_bound)}"], data={"bound": ctx.best_bound})
+    if target == "gap":
+        return CommandResult([f"gap = {_fmt(ctx.gap)}"], data={"gap": ctx.gap})
+    if target == "stats":
+        return _cmd_info(engine, args, ctx, session)
+    if target == "nodes":
+        if ctx.batch_ids is None:
+            return CommandResult(["no batch live at this checkpoint"])
+        lines = [f"{ctx.n_batch} open node(s) in batch:"]
+        for i in range(min(ctx.n_batch, 20)):
+            lines.append(f"  [{i}] id={int(ctx.batch_ids[i])}")
+        return CommandResult(lines, data={"node_ids": [int(x) for x in ctx.batch_ids]})
+    if target == "node":
+        i = int(args[1])
+        if ctx.batch_lb is None:
+            return CommandResult(["no batch live at this checkpoint"])
+        lb = np.asarray(ctx.batch_lb[i])
+        ub = np.asarray(ctx.batch_ub[i])
+        return CommandResult(
+            [
+                f"node[{i}] id={int(ctx.batch_ids[i])} box:",
+                f"  lb = {np.array2string(lb, precision=4, threshold=20)}",
+                f"  ub = {np.array2string(ub, precision=4, threshold=20)}",
+            ],
+            data={"lb": lb.tolist(), "ub": ub.tolist()},
+        )
+    if target == "relax":
+        i = int(args[1])
+        if ctx.result_sols is None:
+            return CommandResult(["no relaxation results live at this checkpoint"])
+        sol = np.asarray(ctx.result_sols[i])
+        return CommandResult(
+            [
+                f"relax[{i}] bound={_fmt(float(ctx.result_lbs[i]))} "
+                f"feasible={bool(ctx.result_feas[i]) if ctx.result_feas is not None else '?'}",
+                f"  x = {np.array2string(sol, precision=4, threshold=20)}",
+            ],
+            data={"bound": float(ctx.result_lbs[i]), "x": sol.tolist()},
+        )
+    return CommandResult([f"unknown print target: {target!r}"])
+
+
+def _cmd_watch(engine, args, ctx, session):
+    if not args:
+        return CommandResult([f"watches: {engine.watches or '(none)'}"])
+    if args[0] == "clear":
+        engine.watches.clear()
+        return CommandResult(["watches cleared"])
+    engine.watches.append(" ".join(args))
+    return CommandResult([f"watching: {' '.join(args)}"])
+
+
+def _cmd_inject(engine, args, ctx, session):
+    if ctx.steer is None or ctx.result_sols is None:
+        return CommandResult(["inject unavailable at this checkpoint"])
+    i = int(args[0])
+    sol = np.asarray(ctx.result_sols[i], dtype=np.float64)
+    obj = float(ctx.result_lbs[i])
+    adopted = ctx.steer.inject(sol, obj)
+    return CommandResult(
+        [f"inject node[{i}] obj={_fmt(obj)}: {'adopted' if adopted else 'rejected by tree'}"]
+    )
+
+
+def _cmd_hint(engine, args, ctx, session):
+    if ctx.steer is None:
+        return CommandResult(["hint unavailable at this checkpoint"])
+    node_id, var = int(args[0]), int(args[1])
+    ctx.steer.hint([node_id], [var])
+    return CommandResult([f"branch hint: node {node_id} -> var {var}"])
+
+
+_DISPATCH: dict[str, Callable[..., CommandResult]] = {
+    "help": _cmd_help,
+    "h": _cmd_help,
+    "?": _cmd_help,
+    "step": _cmd_step,
+    "s": _cmd_step,
+    "n": _cmd_step,
+    "stepi": _cmd_stepi,
+    "si": _cmd_stepi,
+    "continue": _cmd_continue,
+    "c": _cmd_continue,
+    "quit": _cmd_quit,
+    "q": _cmd_quit,
+    "exit": _cmd_quit,
+    "detach": _cmd_detach,
+    "run": _cmd_run,
+    "r": _cmd_run,
+    "stop-at": _cmd_stop_at,
+    "break": _cmd_break,
+    "b": _cmd_break,
+    "tbreak": _cmd_tbreak,
+    "tb": _cmd_tbreak,
+    "info": _cmd_info,
+    "i": _cmd_info,
+    "print": _cmd_print,
+    "p": _cmd_print,
+    "watch": _cmd_watch,
+    "inject": _cmd_inject,
+    "hint": _cmd_hint,
+}

--- a/python/discopt/debug/jsonproto.py
+++ b/python/discopt/debug/jsonproto.py
@@ -13,7 +13,8 @@ Wire format (all newline-delimited JSON on a single stream):
 * at each pause the frontend emits a ``pause`` event (or a ``terminated`` event
   at the final checkpoint), then reads command objects until one resumes;
 * each command yields a ``result`` event echoing the client's ``id`` as
-  ``request_id``.
+  ``request_id``; ``ok`` is ``false`` when the command failed (unknown verb,
+  raised, or unavailable at this checkpoint), so agents can branch on it.
 
 Input commands are either a bare string (``"continue"``) or an object
 (``{"cmd": "print", "args": ["node", "0"], "id": 7}``); ``{"cmd": "break if
@@ -128,7 +129,7 @@ class JsonFrontend:
             "event": "result",
             "request_id": req_id,
             "command": command,
-            "ok": True,
+            "ok": res.ok,
             "output": res.output,
             "data": res.data,
         }

--- a/python/discopt/debug/jsonproto.py
+++ b/python/discopt/debug/jsonproto.py
@@ -62,7 +62,7 @@ def _capabilities() -> dict[str, Any]:
     """What this debugger build can do — clients branch on these, not version."""
     return {
         "inspect": True,
-        "safe_steer": True,  # inject (tree-validated) + branch hint
+        "safe_steer": True,  # inject (validated vs original problem) + branch hint
         "mutate_iterate": False,  # certificate-safe: no node-box/bound edits
         "conditional_breakpoints": "compound_and",  # '&&' only; no '||'/grouping
         "event_breakpoints": True,

--- a/python/discopt/debug/jsonproto.py
+++ b/python/discopt/debug/jsonproto.py
@@ -1,0 +1,221 @@
+"""Newline-delimited JSON protocol frontend for the debugger.
+
+This is the agent-facing twin of the human REPL: it shares the exact same
+:class:`~discopt.debug.engine.DebugCommandEngine`, so an LLM agent, script, or
+GUI drives the solver with identical semantics. Modeled on pounce's
+``pounce-dbg/1`` protocol.
+
+Wire format (all newline-delimited JSON on a single stream):
+
+* first output line is a ``hello`` handshake advertising every checkpoint,
+  event, command, metric, and capability — clients feature-detect off it and
+  never need out-of-band docs;
+* at each pause the frontend emits a ``pause`` event (or a ``terminated`` event
+  at the final checkpoint), then reads command objects until one resumes;
+* each command yields a ``result`` event echoing the client's ``id`` as
+  ``request_id``.
+
+Input commands are either a bare string (``"continue"``) or an object
+(``{"cmd": "print", "args": ["node", "0"], "id": 7}``); ``{"cmd": "break if
+gap<0.2", "id": 8}`` (whole command in ``cmd``) is also accepted.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from .checkpoints import EVENTS, Checkpoint
+from .engine import Control
+
+if TYPE_CHECKING:
+    from .context import DebugContext
+    from .session import DebugSession
+
+PROTOCOL = "discopt-dbg/1"
+
+# Canonical command verbs advertised in the handshake (aliases omitted).
+_COMMANDS = [
+    "step",
+    "stepi",
+    "continue",
+    "run",
+    "stop-at",
+    "detach",
+    "quit",
+    "break",
+    "tbreak",
+    "info",
+    "print",
+    "watch",
+    "inject",
+    "hint",
+    "help",
+]
+
+_METRICS = ["nodes", "open", "incumbent", "bound", "gap", "iter", "elapsed"]
+
+
+def _capabilities() -> dict[str, Any]:
+    """What this debugger build can do — clients branch on these, not version."""
+    return {
+        "inspect": True,
+        "safe_steer": True,  # inject (tree-validated) + branch hint
+        "mutate_iterate": False,  # certificate-safe: no node-box/bound edits
+        "conditional_breakpoints": "compound_and",  # '&&' only; no '||'/grouping
+        "event_breakpoints": True,
+        "request_ids": True,
+        "rewind": False,
+        "resolve": False,
+        "progress_events": False,
+        "terminal_checkpoint": True,
+    }
+
+
+class JsonFrontend:
+    """Drives the command engine over a newline-delimited JSON stream."""
+
+    def __init__(
+        self,
+        *,
+        read_fn: Optional[Callable[[], Optional[str]]] = None,
+        write_fn: Optional[Callable[[dict], None]] = None,
+    ) -> None:
+        self._read = read_fn or _stdin_reader()
+        self._write = write_fn or _stdout_writer()
+        self._hello_sent = False
+
+    # ── event emitters ──
+
+    def _emit(self, obj: dict) -> None:
+        # Non-finite floats (inf/nan) are not valid JSON; strict agent parsers
+        # reject them. Coerce to null so the stream is always RFC-8259 clean.
+        self._write(_json_safe(obj))
+
+    def _hello(self) -> dict:
+        return {
+            "event": "hello",
+            "protocol": PROTOCOL,
+            "checkpoints": [c.value for c in Checkpoint],
+            "events": sorted(EVENTS),
+            "commands": _COMMANDS,
+            "metrics": _METRICS,
+            "capabilities": _capabilities(),
+        }
+
+    def _pause_event(self, ctx: "DebugContext") -> dict:
+        m = ctx.metrics()
+        event = "terminated" if ctx.checkpoint is Checkpoint.TERMINATED else "pause"
+        payload = {
+            "event": event,
+            "checkpoint": ctx.checkpoint.value,
+            "iter": ctx.iteration,
+            "nodes": ctx.node_count,
+            "open_nodes": ctx.open_nodes,
+            "incumbent": ctx.incumbent_obj,
+            "bound": ctx.best_bound if ctx.best_bound not in (float("-inf"),) else None,
+            "gap": ctx.gap,
+            "elapsed": m["elapsed"],
+            "n_batch": ctx.n_batch,
+            "reason": ctx.extra.get("reason"),
+        }
+        return payload
+
+    def _result_event(self, res, command: str, req_id: Any) -> dict:
+        return {
+            "event": "result",
+            "request_id": req_id,
+            "command": command,
+            "ok": True,
+            "output": res.output,
+            "data": res.data,
+        }
+
+    # ── the Frontend protocol ──
+
+    def interact(self, ctx: "DebugContext", session: "DebugSession") -> Control:
+        if not self._hello_sent:
+            self._emit(self._hello())
+            self._hello_sent = True
+
+        self._emit(self._pause_event(ctx))
+
+        while True:
+            line = self._read()
+            if line is None:  # EOF: client hung up -> run to completion
+                return Control.CONTINUE
+            line = line.strip()
+            if not line:
+                continue
+            command, req_id = _parse_command(line)
+            if command is None:
+                self._emit(
+                    {
+                        "event": "result",
+                        "request_id": req_id,
+                        "ok": False,
+                        "output": [f"malformed command: {line!r}"],
+                        "data": None,
+                    }
+                )
+                continue
+            res = session.engine.execute(command, ctx, session)
+            self._emit(self._result_event(res, command, req_id))
+            if res.control is not Control.NONE:
+                return res.control
+
+
+def _json_safe(value: Any) -> Any:
+    """Recursively replace non-finite floats with ``None`` for strict JSON."""
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+def _parse_command(line: str) -> tuple[Optional[str], Any]:
+    """Return ``(command_string, request_id)`` from one input line.
+
+    Accepts a bare string, a bare JSON string literal, or an object with
+    ``cmd`` (+ optional ``args`` list and ``id``).
+    """
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        # Treat a raw, unquoted line as the command itself.
+        return line, None
+
+    if isinstance(obj, str):
+        return obj, None
+    if isinstance(obj, dict):
+        cmd = obj.get("cmd")
+        if not isinstance(cmd, str):
+            return None, obj.get("id")
+        args = obj.get("args") or []
+        if args:
+            cmd = cmd + " " + " ".join(str(a) for a in args)
+        return cmd, obj.get("id")
+    return None, None
+
+
+def _stdin_reader() -> Callable[[], Optional[str]]:
+    def read() -> Optional[str]:
+        line = sys.stdin.readline()
+        return None if line == "" else line
+
+    return read
+
+
+def _stdout_writer() -> Callable[[dict], None]:
+    def write(obj: dict) -> None:
+        # default=str is a safety net for any stray numpy scalar; _json_safe has
+        # already handled non-finite floats upstream.
+        sys.stdout.write(json.dumps(obj, default=str) + "\n")
+        sys.stdout.flush()
+
+    return write

--- a/python/discopt/debug/repl.py
+++ b/python/discopt/debug/repl.py
@@ -1,0 +1,85 @@
+"""Human REPL frontend for the interactive debugger.
+
+Prints a pause banner and reads commands until the user issues a resume verb
+(``step``/``continue``/…). Uses ``readline`` for history and tab-completion
+when a TTY is available, and falls back to a plain line reader on a pipe so the
+same command stream can drive scripted tests (as pounce does).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Callable, Iterable, Optional
+
+from .engine import Control
+
+if TYPE_CHECKING:
+    from .context import DebugContext
+    from .session import DebugSession
+
+
+class ReplFrontend:
+    """Interactive stdin/stderr REPL sharing the session's command engine."""
+
+    def __init__(
+        self,
+        *,
+        input_fn: Optional[Callable[[str], str]] = None,
+        out=None,
+        script: Optional[Iterable[str]] = None,
+    ) -> None:
+        # ``script`` lets tests / ``--debug-script`` feed commands without a TTY.
+        self._script = iter(script) if script is not None else None
+        self._input_fn = input_fn or input
+        self._out = out or sys.stderr
+        self._banner_shown = False
+
+    def _emit(self, text: str = "") -> None:
+        print(text, file=self._out, flush=True)
+
+    def _read(self, prompt: str) -> str:
+        if self._script is not None:
+            try:
+                line = next(self._script)
+                self._emit(f"{prompt}{line}")
+                return line
+            except StopIteration:
+                # Script exhausted: detach and run to completion.
+                return "detach"
+        return self._input_fn(prompt)
+
+    def interact(self, ctx: "DebugContext", session: "DebugSession") -> Control:
+        if not self._banner_shown:
+            self._emit("discopt debugger — 'help' for commands, 'c' to continue")
+            self._banner_shown = True
+
+        reason = ctx.extra.get("reason", "")
+        self._emit(
+            f"\n── paused at {ctx.checkpoint.value}"
+            + (f"  ({reason})" if reason else "")
+            + f"  iter={ctx.iteration} nodes={ctx.node_count} "
+            f"incumbent={_fmt(ctx.incumbent_obj)} bound={_fmt(ctx.best_bound)}"
+        )
+        # Auto-print watches.
+        for target in session.engine.watches:
+            res = session.engine.execute(f"print {target}", ctx, session)
+            for ln in res.output:
+                self._emit(f"  {ln}")
+
+        while True:
+            try:
+                raw = self._read("(discopt-dbg) ")
+            except (EOFError, KeyboardInterrupt):
+                self._emit("")
+                return Control.CONTINUE
+            res = session.engine.execute(raw, ctx, session)
+            for ln in res.output:
+                self._emit(ln)
+            if res.control is not Control.NONE:
+                return res.control
+
+
+def _fmt(x) -> str:
+    if x is None:
+        return "none"
+    return f"{x:.6g}" if isinstance(x, float) else str(x)

--- a/python/discopt/debug/session.py
+++ b/python/discopt/debug/session.py
@@ -63,7 +63,12 @@ class DebugSession:
     def on_checkpoint(self, ctx: "DebugContext") -> bool:
         """Handle a checkpoint; return True if the solve should stop now."""
         if self._detached:
-            return self._stop_requested
+            # A detached session is inert. Returning _stop_requested here would
+            # let a stale session (quit during an earlier solve, then reused)
+            # kill every future solve at its first checkpoint — the quit that
+            # triggered the stop already propagated True through the non-
+            # detached path below.
+            return False
         # Derive the new_incumbent event for event breakpoints.
         if ctx.checkpoint is Checkpoint.INCUMBENT_FOUND:
             ctx.event = "new_incumbent"

--- a/python/discopt/debug/session.py
+++ b/python/discopt/debug/session.py
@@ -79,9 +79,15 @@ class DebugSession:
         return self._stop_requested
 
     def _should_pause(self, ctx: "DebugContext") -> bool:
-        # on-error sessions only ever pause at a failed termination.
+        # on-error sessions only ever pause at a failed termination. The solve
+        # loops pass ``error=<non-"optimal" status>`` at their TERMINATED fire
+        # (None on a certified optimum), so this triggers on limit hits,
+        # debugger interrupts, "unknown", and certified infeasibility.
         if self.enter_on_error:
-            return ctx.checkpoint is Checkpoint.TERMINATED and bool(ctx.extra.get("error"))
+            if ctx.checkpoint is Checkpoint.TERMINATED and ctx.extra.get("error"):
+                ctx.extra["reason"] = f"on-error: {ctx.extra['error']}"
+                return True
+            return False
 
         # Explicit breakpoint hit always pauses (and records the reason).
         reason = self.engine.hit_reason(ctx)

--- a/python/discopt/debug/session.py
+++ b/python/discopt/debug/session.py
@@ -1,0 +1,118 @@
+"""The debugger session: pause-decision state machine over the command engine.
+
+A ``DebugSession`` decides *whether* to pause at each checkpoint (based on the
+current step mode plus the engine's breakpoints) and, when it pauses, hands the
+context to the active frontend (REPL or JSON) to interact. It is deliberately
+frontend-agnostic; ``frontend.interact(ctx, session)`` drives the engine.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Protocol
+
+from .checkpoints import DEFAULT_STOP, Checkpoint
+from .engine import Control, DebugCommandEngine
+
+if TYPE_CHECKING:
+    from .context import DebugContext
+
+
+class DebugQuit(Exception):
+    """Reserved for a future hard-abort path. ``quit`` currently requests a
+    graceful stop via :attr:`DebugSession.stop_requested` so the solver still
+    builds a valid "stopped early" result from the partial tree state.
+    """
+
+
+class Frontend(Protocol):
+    def interact(self, ctx: "DebugContext", session: "DebugSession") -> Control:
+        """Drive the prompt until the user resumes; return the resume control."""
+        ...
+
+
+class DebugSession:
+    """Owns step mode + breakpoints and mediates checkpoint pauses."""
+
+    def __init__(self, frontend: "Frontend", *, enter_on_error: bool = False) -> None:
+        self.engine = DebugCommandEngine()
+        self.frontend = frontend
+        self.stop_checkpoints: set[Checkpoint] = set(DEFAULT_STOP)
+        self.enter_on_error = enter_on_error
+        # Step mode: None means "continue" (only breakpoints/stop-set pause).
+        self._mode: Optional[Control] = Control.STEP  # first checkpoint pauses
+        self._detached = False
+        self._stop_requested = False
+        self._last_incumbent: Optional[float] = None
+
+    # ── attachment lifecycle ──
+
+    def detach(self) -> None:
+        self._detached = True
+
+    @property
+    def detached(self) -> bool:
+        return self._detached
+
+    @property
+    def stop_requested(self) -> bool:
+        """True once the user issued ``quit``; the loop should break promptly."""
+        return self._stop_requested
+
+    # ── the hot path: called at every fired checkpoint ──
+
+    def on_checkpoint(self, ctx: "DebugContext") -> bool:
+        """Handle a checkpoint; return True if the solve should stop now."""
+        if self._detached:
+            return self._stop_requested
+        # Derive the new_incumbent event for event breakpoints.
+        if ctx.checkpoint is Checkpoint.INCUMBENT_FOUND:
+            ctx.event = "new_incumbent"
+
+        if self._should_pause(ctx):
+            control = self.frontend.interact(ctx, self)
+            self._apply_control(control)
+        return self._stop_requested
+
+    def _should_pause(self, ctx: "DebugContext") -> bool:
+        # on-error sessions only ever pause at a failed termination.
+        if self.enter_on_error:
+            return ctx.checkpoint is Checkpoint.TERMINATED and bool(ctx.extra.get("error"))
+
+        # Explicit breakpoint hit always pauses (and records the reason).
+        reason = self.engine.hit_reason(ctx)
+        if reason is not None:
+            ctx.extra["reason"] = reason
+            return True
+
+        # Step modes.
+        if self._mode is Control.STEPI:
+            ctx.extra["reason"] = "stepi"
+            return True
+        if self._mode is Control.STEP:
+            if ctx.checkpoint is Checkpoint.ITER_START or ctx.checkpoint is Checkpoint.TERMINATED:
+                ctx.extra["reason"] = "step"
+                return True
+            return False
+
+        # Continue mode: pause only at requested checkpoints.
+        if ctx.checkpoint in self.stop_checkpoints and self._mode is None:
+            # Honor stop-at only when the user explicitly added a checkpoint
+            # beyond the defaults; defaults are for step mode.
+            if ctx.checkpoint not in DEFAULT_STOP or ctx.checkpoint is Checkpoint.TERMINATED:
+                ctx.extra["reason"] = f"stop-at {ctx.checkpoint.value}"
+                return True
+        return False
+
+    def _apply_control(self, control: Control) -> None:
+        if control is Control.QUIT:
+            # Graceful stop: detach so no further pauses, and signal the loop.
+            self._stop_requested = True
+            self._detached = True
+            return
+        if control is Control.STEP:
+            self._mode = Control.STEP
+        elif control is Control.STEPI:
+            self._mode = Control.STEPI
+        elif control is Control.CONTINUE:
+            self._mode = None
+        # NONE never returns here (interact loops until a resume control).

--- a/python/discopt/debug/steer.py
+++ b/python/discopt/debug/steer.py
@@ -1,0 +1,77 @@
+"""Safe steering operations for the interactive debugger.
+
+discopt is a global solver whose product is its correctness *certificate*
+(CLAUDE.md §1). Unlike pounce, the debugger therefore refuses to mutate live
+search state that could invalidate that certificate. The only levers exposed
+here are ones the solver already trusts:
+
+* ``inject`` -> ``PyTreeManager.inject_incumbent``: the tree re-validates the
+  point (it is only accepted if genuinely feasible and improving), so a bad
+  injection is rejected rather than believed.
+* ``hint`` -> ``PyTreeManager.set_branch_hints``: reorders branching only; it
+  cannot change which region is explored, only the order.
+
+Neither can loosen a bound or fabricate an incumbent, so no debugger action can
+turn a correct verdict into an incorrect one. Arbitrary node-box/bound edits
+are intentionally *not* offered.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+class DebugSteer:
+    """Validated, certificate-safe steering handle over the Rust B&B tree."""
+
+    def __init__(self, tree: Any, model: Any = None):
+        self._tree = tree
+        self._model = model
+
+    def inject(self, solution: Any, obj: float) -> bool:
+        """Offer a candidate incumbent; the tree accepts it only if valid.
+
+        Parameters
+        ----------
+        solution : array-like
+            Full primal vector in the solver's flat variable order.
+        obj : float
+            Objective value of ``solution``.
+
+        Returns
+        -------
+        bool
+            ``True`` if the tree adopted it as the new incumbent.
+        """
+        sol = np.asarray(solution, dtype=np.float64).ravel()
+        if not np.all(np.isfinite(sol)):
+            raise ValueError("inject: solution contains non-finite entries")
+        if not np.isfinite(obj):
+            raise ValueError("inject: objective is not finite")
+        before = self._tree.incumbent()
+        self._tree.inject_incumbent(sol, float(obj))
+        after = self._tree.incumbent()
+        # Adopted iff the incumbent objective strictly improved.
+        if after is None:
+            return False
+        if before is None:
+            return True
+        return float(after[1]) < float(before[1]) - 1e-12
+
+    def hint(self, node_ids: Any, var_indices: Any) -> None:
+        """Suggest a branching variable per node (reorders only, never prunes).
+
+        Parameters
+        ----------
+        node_ids : array-like of int
+            Node ids (as exported by ``export_batch``).
+        var_indices : array-like of int
+            The variable index to branch on for each corresponding node.
+        """
+        ids = np.asarray(node_ids, dtype=np.int64).ravel()
+        vhint = np.asarray(var_indices, dtype=np.int64).ravel()
+        if ids.shape != vhint.shape:
+            raise ValueError("hint: node_ids and var_indices must have equal length")
+        self._tree.set_branch_hints(ids, vhint)

--- a/python/discopt/debug/steer.py
+++ b/python/discopt/debug/steer.py
@@ -3,11 +3,18 @@
 discopt is a global solver whose product is its correctness *certificate*
 (CLAUDE.md §1). Unlike pounce, the debugger therefore refuses to mutate live
 search state that could invalidate that certificate. The only levers exposed
-here are ones the solver already trusts:
+here are validated before they touch the tree:
 
-* ``inject`` -> ``PyTreeManager.inject_incumbent``: the tree re-validates the
-  point (it is only accepted if genuinely feasible and improving), so a bad
-  injection is rejected rather than believed.
+* ``inject``: the debugger first validates the candidate against the
+  **original** problem using the solver's own machinery (integrality check,
+  integer rounding, constraint feasibility, true-objective evaluation via the
+  ``validator`` wired in by the solve loop), and only then offers the point to
+  ``PyTreeManager.inject_incumbent``, which additionally enforces strict
+  improvement. ``inject_incumbent`` itself *trusts its caller* — it does NOT
+  re-validate feasibility — so the validation step here is mandatory, and
+  checkpoints that cannot wire a validator refuse to inject at all. The
+  objective handed to the tree is always the evaluated objective at the point,
+  never a relaxation bound.
 * ``hint`` -> ``PyTreeManager.set_branch_hints``: reorders branching only; it
   cannot change which region is explored, only the order.
 
@@ -18,47 +25,72 @@ are intentionally *not* offered.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable, Optional
 
 import numpy as np
+
+#: Validator contract: ``validator(x) -> (feasible, x_validated, obj)`` where
+#: ``x_validated`` has near-integral discrete coordinates snapped to integers
+#: and ``obj`` is the true internal (min-sense) objective evaluated at the
+#: point. ``obj`` is meaningless when ``feasible`` is False.
+Validator = Callable[[np.ndarray], tuple[bool, np.ndarray, float]]
 
 
 class DebugSteer:
     """Validated, certificate-safe steering handle over the Rust B&B tree."""
 
-    def __init__(self, tree: Any, model: Any = None):
+    def __init__(self, tree: Any, model: Any = None, validator: Optional[Validator] = None):
         self._tree = tree
         self._model = model
+        self._validator = validator
 
-    def inject(self, solution: Any, obj: float) -> bool:
-        """Offer a candidate incumbent; the tree accepts it only if valid.
+    @property
+    def can_inject(self) -> bool:
+        """True when this checkpoint wired a candidate validator."""
+        return self._validator is not None
+
+    def inject(self, solution: Any) -> tuple[bool, Optional[float], str]:
+        """Validate a candidate point and offer it as an incumbent.
 
         Parameters
         ----------
         solution : array-like
             Full primal vector in the solver's flat variable order.
-        obj : float
-            Objective value of ``solution``.
 
         Returns
         -------
-        bool
-            ``True`` if the tree adopted it as the new incumbent.
+        (adopted, obj, reason) : tuple[bool, Optional[float], str]
+            ``adopted`` is True iff the tree took the point as its new
+            incumbent. ``obj`` is the validated true objective (internal min
+            sense) when the point passed validation, else ``None``. ``reason``
+            is a human-readable outcome.
+
+        Raises
+        ------
+        ValueError
+            If the candidate contains non-finite entries.
+        RuntimeError
+            If no validator is wired at this checkpoint — the point's true
+            feasibility and objective cannot be verified, so injecting would
+            risk fabricating an incumbent (refused, per CLAUDE.md §1/§3).
         """
         sol = np.asarray(solution, dtype=np.float64).ravel()
         if not np.all(np.isfinite(sol)):
             raise ValueError("inject: solution contains non-finite entries")
-        if not np.isfinite(obj):
-            raise ValueError("inject: objective is not finite")
-        before = self._tree.incumbent()
-        self._tree.inject_incumbent(sol, float(obj))
-        after = self._tree.incumbent()
-        # Adopted iff the incumbent objective strictly improved.
-        if after is None:
-            return False
-        if before is None:
-            return True
-        return float(after[1]) < float(before[1]) - 1e-12
+        if self._validator is None:
+            raise RuntimeError(
+                "inject: no candidate validator is wired at this checkpoint, so "
+                "the point's feasibility and true objective cannot be verified; "
+                "refusing to inject an unvalidated incumbent"
+            )
+        feasible, x_val, obj = self._validator(sol)
+        if not feasible:
+            return False, None, "rejected: infeasible for the original problem"
+        obj = float(obj)
+        adopted = bool(self._tree.inject_incumbent(np.ascontiguousarray(x_val), obj))
+        if adopted:
+            return True, obj, "adopted"
+        return False, obj, "validated but not strictly improving on the incumbent"
 
     def hint(self, node_ids: Any, var_indices: Any) -> None:
         """Suggest a branching variable per node (reorders only, never prunes).

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -3249,9 +3249,12 @@ class Model:
         debug : bool, str, or DebugSession, optional
             Attach the interactive branch-and-bound debugger (a "pdb for B&B").
             ``True`` / ``"repl"`` drops into a human REPL at the first
-            checkpoint; ``"on-error"`` enters only if the solve fails or hits a
-            limit; a ready-made :class:`discopt.debug.DebugSession` uses a
-            custom frontend. ``None`` (default) leaves the solve untouched —
+            checkpoint; ``"on-error"`` enters only at termination when the
+            outcome is not a certified optimum (limit hit, interrupted,
+            "unknown", or certified infeasible) — not supported on the
+            pure-Rust MILP fast-path, whose hook carries no final status; a
+            ready-made :class:`discopt.debug.DebugSession` uses a custom
+            frontend. ``None`` (default) leaves the solve untouched —
             fire-sites short-circuit on a module-global check, so a detached
             solve is bound-neutral. Currently instruments the spatial-McCormick
             B&B path (nonconvex MINLP / continuous). See :mod:`discopt.debug`.

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -3122,6 +3122,7 @@ class Model:
         validate: bool = False,
         gauss_newton: bool = False,
         tuning: Optional["SolverTuning"] = None,
+        debug: Any = None,
         **kwargs,
     ) -> Union[SolveResult, Iterator["SolveUpdate"]]:
         r"""
@@ -3245,6 +3246,15 @@ class Model:
             step (iteration path) without changing the KKT point converged to.
             Silently falls back to the exact dense Hessian when the objective
             is not a recognized sum of squares (or the model maximizes).
+        debug : bool, str, or DebugSession, optional
+            Attach the interactive branch-and-bound debugger (a "pdb for B&B").
+            ``True`` / ``"repl"`` drops into a human REPL at the first
+            checkpoint; ``"on-error"`` enters only if the solve fails or hits a
+            limit; a ready-made :class:`discopt.debug.DebugSession` uses a
+            custom frontend. ``None`` (default) leaves the solve untouched —
+            fire-sites short-circuit on a module-global check, so a detached
+            solve is bound-neutral. Currently instruments the spatial-McCormick
+            B&B path (nonconvex MINLP / continuous). See :mod:`discopt.debug`.
         \*\*kwargs
             Additional keyword arguments passed to the solver backend.
 
@@ -3321,29 +3331,43 @@ class Model:
         from discopt._jax.deadline import deadline_scope
         from discopt.solver import solve_model
 
+        # Attach the interactive B&B debugger if requested. The fire-sites in
+        # the solve loop short-circuit on a module-global ``None`` check, so a
+        # detached solve (``debug=None``) is unaffected. ``debug`` may be True,
+        # "repl", "on-error", or a ready-made ``DebugSession``.
+        _debug_guard = None
+        if debug is not None and debug is not False:
+            from discopt import debug as _dbg
+
+            _debug_guard = _dbg.attach(_dbg.make_session(debug))
+
         # Install a process-global wall-clock deadline that JAX-compiled
         # while_loops (LP/QP/NLP IPM) can poll via host callback so they
         # self-terminate within ``time_limit + ε`` instead of running to
         # XLA convergence after Python's budget is gone (issue #80).
-        with deadline_scope(time_limit):
-            result = solve_model(
-                self,
-                time_limit=time_limit,
-                gap_tolerance=gap_tolerance,
-                threads=threads,
-                deterministic=deterministic,
-                partitions=partitions,
-                branching_policy=branching_policy,
-                initial_point=_x0_flat,
-                skip_convex_check=skip_convex_check,
-                nlp_bb=nlp_bb,
-                lazy_constraints=lazy_constraints,
-                incumbent_callback=incumbent_callback,
-                node_callback=node_callback,
-                solver=solver,
-                tuning=tuning,
-                **kwargs,
-            )
+        try:
+            with deadline_scope(time_limit):
+                result = solve_model(
+                    self,
+                    time_limit=time_limit,
+                    gap_tolerance=gap_tolerance,
+                    threads=threads,
+                    deterministic=deterministic,
+                    partitions=partitions,
+                    branching_policy=branching_policy,
+                    initial_point=_x0_flat,
+                    skip_convex_check=skip_convex_check,
+                    nlp_bb=nlp_bb,
+                    lazy_constraints=lazy_constraints,
+                    incumbent_callback=incumbent_callback,
+                    node_callback=node_callback,
+                    solver=solver,
+                    tuning=tuning,
+                    **kwargs,
+                )
+        finally:
+            if _debug_guard is not None:
+                _debug_guard.__exit__(None, None, None)
 
         # Attach model reference and auto-generate LLM explanation
         result._model = self

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5188,6 +5188,34 @@ def solve_model(
 
     from discopt import debug as _debug
 
+    def _debug_validate_candidate(
+        x,
+        _ev=evaluator,
+        _cl=cl_list,
+        _cu=cu_list,
+        _ioff=int_offsets,
+        _isz=int_sizes,
+    ):
+        """Validate a debugger-injected candidate against the ORIGINAL problem.
+
+        ``inject_incumbent`` trusts its caller (no feasibility re-check), so
+        the debugger's ``inject`` steer must verify integrality + constraint
+        feasibility here and hand the tree the point's true evaluated
+        objective — never a relaxation bound (CLAUDE.md §1). Returns
+        ``(feasible, x_validated, obj)``; pure reads only.
+        """
+        xv = np.asarray(x, dtype=np.float64).copy()
+        if _ioff and not _is_integer_feasible_solution(xv, _ioff, _isz):
+            return False, xv, float("nan")
+        for _o, _s in zip(_ioff, _isz):
+            xv[_o : _o + _s] = np.round(xv[_o : _o + _s])
+        if _cl and not _check_constraint_feasibility(_ev, xv, _cl, _cu):
+            return False, xv, float("nan")
+        _obj = float(_ev.evaluate_objective(xv))
+        if not np.isfinite(_obj) or _obj >= _SENTINEL_THRESHOLD:
+            return False, xv, float("nan")
+        return True, xv, _obj
+
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -6788,7 +6816,8 @@ def solve_model(
                     tree.inject_incumbent(xr, _obj_i)
 
         # Interactive debugger: steer point — relaxations solved, results not
-        # yet imported. Safe-steer (inject incumbent / branch hint) applies here.
+        # yet imported. Safe-steer (inject incumbent / branch hint) applies here;
+        # `inject` candidates are validated by _debug_validate_candidate.
         if _debug.fire(
             _debug.Checkpoint.BEFORE_IMPORT,
             tree=tree,
@@ -6801,6 +6830,7 @@ def solve_model(
             result_lbs=result_lbs,
             result_sols=result_sols,
             result_feas=result_feas,
+            validator=_debug_validate_candidate,
         ):
             break
 
@@ -7771,6 +7801,34 @@ def _solve_nlp_bb(
 
     from discopt import debug as _debug
 
+    def _debug_validate_candidate(
+        x,
+        _ev=evaluator,
+        _cl=cl_list,
+        _cu=cu_list,
+        _ioff=int_offsets,
+        _isz=int_sizes,
+    ):
+        """Validate a debugger-injected candidate against the ORIGINAL problem.
+
+        ``inject_incumbent`` trusts its caller (no feasibility re-check), so
+        the debugger's ``inject`` steer must verify integrality + constraint
+        feasibility here and hand the tree the point's true evaluated
+        objective — never a relaxation bound (CLAUDE.md §1). Returns
+        ``(feasible, x_validated, obj)``; pure reads only.
+        """
+        xv = np.asarray(x, dtype=np.float64).copy()
+        if _ioff and not _is_integer_feasible_solution(xv, _ioff, _isz):
+            return False, xv, float("nan")
+        for _o, _s in zip(_ioff, _isz):
+            xv[_o : _o + _s] = np.round(xv[_o : _o + _s])
+        if _cl and not _check_constraint_feasibility(_ev, xv, _cl, _cu):
+            return False, xv, float("nan")
+        _obj = float(_ev.evaluate_objective(xv))
+        if not np.isfinite(_obj) or _obj >= _SENTINEL_THRESHOLD:
+            return False, xv, float("nan")
+        return True, xv, _obj
+
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -8157,6 +8215,7 @@ def _solve_nlp_bb(
             )
 
         # Interactive debugger: steer point — relaxations solved, not imported.
+        # `inject` candidates are validated by _debug_validate_candidate.
         if _debug.fire(
             _debug.Checkpoint.BEFORE_IMPORT,
             tree=tree,
@@ -8169,6 +8228,7 @@ def _solve_nlp_bb(
             result_lbs=result_lbs,
             result_sols=result_sols,
             result_feas=result_feas,
+            validator=_debug_validate_candidate,
         ):
             break
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5216,6 +5216,10 @@ def solve_model(
             return False, xv, float("nan")
         return True, xv, _obj
 
+    # Set when the interactive debugger's `quit` breaks the search loop: a
+    # user-interrupted exit proves nothing, so the status decision below must
+    # not fall through to a certified "infeasible"/"optimal".
+    _debug_quit = False
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -5229,6 +5233,7 @@ def solve_model(
             iteration=iteration,
             elapsed=elapsed,
         ):
+            _debug_quit = True
             break
 
         # Update per-iteration time budget for NLP subproblem solves (issue #5).
@@ -5255,6 +5260,7 @@ def solve_model(
             batch_ub=batch_ub,
             batch_ids=batch_ids,
         ):
+            _debug_quit = True
             break
 
         node_infeasible_mask = np.zeros(n_batch, dtype=bool)
@@ -6832,6 +6838,7 @@ def solve_model(
             result_feas=result_feas,
             validator=_debug_validate_candidate,
         ):
+            _debug_quit = True
             break
 
         # Import results back to Rust tree
@@ -6848,6 +6855,7 @@ def solve_model(
             iteration=iteration,
             elapsed=time.perf_counter() - t_start,
         ):
+            _debug_quit = True
             break
 
         # Did the incumbent strictly improve this iteration, from ANY source?
@@ -6874,6 +6882,7 @@ def solve_model(
                 iteration=iteration,
                 elapsed=time.perf_counter() - t_start,
             ):
+                _debug_quit = True
                 break
 
         # --- Periodic OBBT with incumbent cutoff (Phase C) ---
@@ -7222,6 +7231,13 @@ def solve_model(
             # worst-class error: a feasible model declared infeasible). Report
             # "unknown" instead, exactly as the _solve_nlp_bb path does with
             # _unconverged_fathom. Conservative by design: soundness over capability.
+            status = "unknown"
+            _gap_certified = False
+        elif _debug_quit:
+            # Interactive debugger `quit`: the user interrupted the search, so
+            # the tree is NOT exhausted and neither infeasibility nor optimality
+            # was proven (a false "infeasible" here is the worst-class error).
+            # Report "unknown", uncertified.
             status = "unknown"
             _gap_certified = False
         else:
@@ -7829,6 +7845,10 @@ def _solve_nlp_bb(
             return False, xv, float("nan")
         return True, xv, _obj
 
+    # Set when the interactive debugger's `quit` breaks the search loop: a
+    # user-interrupted exit proves nothing, so the status decision below must
+    # not fall through to a certified "infeasible"/"optimal".
+    _debug_quit = False
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -7842,6 +7862,7 @@ def _solve_nlp_bb(
             iteration=iteration,
             elapsed=elapsed,
         ):
+            _debug_quit = True
             break
 
         # Update per-iteration time budget for NLP subproblem solves (issue #5).
@@ -7868,6 +7889,7 @@ def _solve_nlp_bb(
             batch_ub=batch_ub,
             batch_ids=batch_ids,
         ):
+            _debug_quit = True
             break
 
         # Tighten node bounds via constraint propagation (FBBT).
@@ -8230,6 +8252,7 @@ def _solve_nlp_bb(
             result_feas=result_feas,
             validator=_debug_validate_candidate,
         ):
+            _debug_quit = True
             break
 
         # Import results back to Rust tree
@@ -8246,6 +8269,7 @@ def _solve_nlp_bb(
             iteration=iteration,
             elapsed=time.perf_counter() - t_start,
         ):
+            _debug_quit = True
             break
 
         # --- Node callback ---
@@ -8558,6 +8582,13 @@ def _solve_nlp_bb(
             # declared infeasible). Conservative by design: if any fathom was
             # unconverged we forgo certifying infeasibility we might otherwise have
             # proven — soundness over capability.
+            status = "unknown"
+            _gap_certified = False
+        elif _debug_quit:
+            # Interactive debugger `quit`: the user interrupted the search, so
+            # the tree is NOT exhausted and neither infeasibility nor optimality
+            # was proven (a false "infeasible" here is the worst-class error).
+            # Report "unknown", uncertified.
             status = "unknown"
             _gap_certified = False
         else:
@@ -11613,6 +11644,26 @@ def _solve_milp_simplex(
     wall_time = time.perf_counter() - t_start
     maximize = model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE
 
+    def _debug_stopped_result() -> Optional[SolveResult]:
+        """Partial, uncertified result when the interactive debugger's `quit`
+        stopped the Rust search. Returned at the defer sites below instead of
+        ``None`` so the caller does NOT fall back to another engine — the user
+        asked the solve to stop, not to restart elsewhere. ``None`` (the normal
+        case) preserves the plain defer-to-fallback behavior."""
+        _sess = _debug.current()
+        if _sess is None or not _sess.stop_requested:
+            return None
+        _bv = None
+        if np.isfinite(bound):
+            _bv = -bound if maximize else bound
+        return SolveResult(
+            status="unknown",
+            bound=_bv,
+            wall_time=wall_time,
+            node_count=nodes,
+            gap_certified=False,
+        )
+
     if status in ("optimal", "feasible"):
         x_arr = np.asarray(x_struct, dtype=np.float64)
         xo = x_arr[:n_orig]
@@ -11650,7 +11701,7 @@ def _solve_milp_simplex(
                 "deferring to a sound engine",
                 status,
             )
-            return None
+            return _debug_stopped_result()
         x_dict = _unpack_solution(model, x_arr)
         obj_val = -obj if maximize else obj
         bound_val = None
@@ -11717,8 +11768,10 @@ def _solve_milp_simplex(
         # back to the robust spatial / POUNCE path — which, e.g., solves nvs12's
         # integer-bilinear reformulation in ~0.4 s where this engine stalls
         # (issue #291). A genuine incumbent is returned via the optimal/feasible
-        # branch above, so deferral only discards a no-solution result.
-        return None
+        # branch above, so deferral only discards a no-solution result. On a
+        # debugger `quit` this instead surfaces the uncertified partial state
+        # (no fallback engine resumes a solve the user stopped).
+        return _debug_stopped_result()
     return SolveResult(status="infeasible", wall_time=wall_time, node_count=nodes)
 
 
@@ -11995,6 +12048,10 @@ def _solve_milp_bb(
     _root_glb_internal: Optional[float] = None
     from discopt import debug as _debug
 
+    # Set when the interactive debugger's `quit` breaks the search loop: a
+    # user-interrupted exit proves nothing, so the status decision below must
+    # not fall through to a certified "infeasible"/"optimal".
+    _debug_quit = False
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -12008,6 +12065,7 @@ def _solve_milp_bb(
             iteration=iteration,
             elapsed=elapsed,
         ):
+            _debug_quit = True
             break
 
         t_rust_start = time.perf_counter()
@@ -12029,6 +12087,7 @@ def _solve_milp_bb(
             batch_ub=batch_ub,
             batch_ids=batch_ids,
         ):
+            _debug_quit = True
             break
 
         t_jax_start = time.perf_counter()
@@ -12099,6 +12158,7 @@ def _solve_milp_bb(
             result_sols=result_sols,
             result_feas=result_feas,
         ):
+            _debug_quit = True
             break
 
         t_rust_start = time.perf_counter()
@@ -12114,6 +12174,7 @@ def _solve_milp_bb(
             iteration=iteration,
             elapsed=time.perf_counter() - t_start,
         ):
+            _debug_quit = True
             break
 
         # Root-node certification snapshot (cert:T0.1).
@@ -12215,6 +12276,13 @@ def _solve_milp_bb(
             _gap_certified = False
         elif wall_time >= time_limit:
             status = "time_limit"
+            _gap_certified = False
+        elif _debug_quit:
+            # Interactive debugger `quit`: the user interrupted the search, so
+            # the tree is NOT exhausted and neither infeasibility nor optimality
+            # was proven (a false "infeasible" here is the worst-class error).
+            # Report "unknown", uncertified.
+            status = "unknown"
             _gap_certified = False
         else:
             # Tree exhausted with no feasible node: infeasibility *is* a certified
@@ -12477,6 +12545,10 @@ def _solve_miqp_bb(
     _root_glb_internal: Optional[float] = None
     from discopt import debug as _debug
 
+    # Set when the interactive debugger's `quit` breaks the search loop: a
+    # user-interrupted exit proves nothing, so the status decision below must
+    # not fall through to a certified "infeasible"/"optimal".
+    _debug_quit = False
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
@@ -12490,6 +12562,7 @@ def _solve_miqp_bb(
             iteration=iteration,
             elapsed=elapsed,
         ):
+            _debug_quit = True
             break
 
         t_rust_start = time.perf_counter()
@@ -12511,6 +12584,7 @@ def _solve_miqp_bb(
             batch_ub=batch_ub,
             batch_ids=batch_ids,
         ):
+            _debug_quit = True
             break
 
         t_jax_start = time.perf_counter()
@@ -12566,6 +12640,7 @@ def _solve_miqp_bb(
             result_sols=result_sols,
             result_feas=result_feas,
         ):
+            _debug_quit = True
             break
 
         t_rust_start = time.perf_counter()
@@ -12581,6 +12656,7 @@ def _solve_miqp_bb(
             iteration=iteration,
             elapsed=time.perf_counter() - t_start,
         ):
+            _debug_quit = True
             break
 
         # Root-node certification snapshot (cert:T0.1).
@@ -12687,6 +12763,13 @@ def _solve_miqp_bb(
             _gap_certified = False
         elif wall_time >= time_limit:
             status = "time_limit"
+            _gap_certified = False
+        elif _debug_quit:
+            # Interactive debugger `quit`: the user interrupted the search, so
+            # the tree is NOT exhausted and neither infeasibility nor optimality
+            # was proven (a false "infeasible" here is the worst-class error).
+            # Report "unknown", uncertified.
+            status = "unknown"
             _gap_certified = False
         else:
             # Tree exhausted with no feasible node: infeasibility *is* a certified

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -11530,6 +11530,12 @@ def _solve_milp_simplex(
     # bounding the wasted time before fallback to a few seconds.
     _remaining = float(time_limit) - (time.perf_counter() - t_start)
     _milp_budget = max(0.5, min(0.5 * _remaining, _SIMPLEX_MILP_BUDGET_CAP_S))
+    # Interactive debugger: install the Rust checkpoint hook only when a debugger
+    # is attached now (bound-neutral otherwise). This is the pure-Rust MILP
+    # fast-path — the hook fires the same node-lifecycle checkpoints as the
+    # Python-driven loops, across the PyO3 boundary.
+    from discopt import debug as _debug
+
     status, x_struct, obj, bound, nodes, _lp_iters = solve_milp_py(
         np.ascontiguousarray(lp_data.c, dtype=np.float64),
         A,
@@ -11542,6 +11548,7 @@ def _solve_milp_simplex(
         int(max_nodes),
         float(gap_tolerance),
         time_limit_s=float(_milp_budget),
+        debug_hook=_debug.rust_hook(),
     )
     wall_time = time.perf_counter() - t_start
     maximize = model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5186,9 +5186,21 @@ def solve_model(
             _pn_obbt_budget_total,
         )
 
+    from discopt import debug as _debug
+
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
+            break
+
+        # Interactive debugger: top-of-iteration checkpoint (no-op when detached).
+        if _debug.fire(
+            _debug.Checkpoint.ITER_START,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=elapsed,
+        ):
             break
 
         # Update per-iteration time budget for NLP subproblem solves (issue #5).
@@ -5202,6 +5214,19 @@ def solve_model(
 
         n_batch = len(batch_ids)
         if n_batch == 0:
+            break
+
+        # Interactive debugger: nodes selected — boxes/ids now available.
+        if _debug.fire(
+            _debug.Checkpoint.AFTER_SELECT,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=elapsed,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
+        ):
             break
 
         node_infeasible_mask = np.zeros(n_batch, dtype=bool)
@@ -6762,11 +6787,38 @@ def solve_model(
                 if np.isfinite(_obj_i) and _obj_i < _SENTINEL_THRESHOLD:
                     tree.inject_incumbent(xr, _obj_i)
 
+        # Interactive debugger: steer point — relaxations solved, results not
+        # yet imported. Safe-steer (inject incumbent / branch hint) applies here.
+        if _debug.fire(
+            _debug.Checkpoint.BEFORE_IMPORT,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=time.perf_counter() - t_start,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
+            result_lbs=result_lbs,
+            result_sols=result_sols,
+            result_feas=result_feas,
+        ):
+            break
+
         # Import results back to Rust tree
         t_rust_start = time.perf_counter()
         tree.import_results(result_ids, result_lbs, result_sols, result_feas)
         tree.process_evaluated()
         rust_time += time.perf_counter() - t_rust_start
+
+        # Interactive debugger: prune/branch/fathom applied by the tree.
+        if _debug.fire(
+            _debug.Checkpoint.AFTER_PROCESS,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=time.perf_counter() - t_start,
+        ):
+            break
 
         # Did the incumbent strictly improve this iteration, from ANY source?
         # proc_stats["incumbent_updates"] counts only incumbents found in the
@@ -6784,6 +6836,15 @@ def solve_model(
         _incumbent_improved = _inc_obj_now < _last_tighten_inc - 1e-9
         if _incumbent_improved:
             _last_tighten_inc = _inc_obj_now
+            # Interactive debugger: new-incumbent event checkpoint.
+            if _debug.fire(
+                _debug.Checkpoint.INCUMBENT_FOUND,
+                tree=tree,
+                model=model,
+                iteration=iteration,
+                elapsed=time.perf_counter() - t_start,
+            ):
+                break
 
         # --- Periodic OBBT with incumbent cutoff (Phase C) ---
         # When a new incumbent is found and bounds are still wide,
@@ -6924,6 +6985,15 @@ def solve_model(
     # --- Build result ---
     wall_time = time.perf_counter() - t_start
     python_time = wall_time - rust_time - jax_time
+
+    # Interactive debugger: terminal checkpoint (final/limit/infeasible state).
+    _debug.fire(
+        _debug.Checkpoint.TERMINATED,
+        tree=tree,
+        model=model,
+        iteration=iteration,
+        elapsed=wall_time,
+    )
 
     stats = tree.stats()
     incumbent = tree.incumbent()

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7769,9 +7769,21 @@ def _solve_nlp_bb(
         if improved:
             _heur_state["found"] += 1
 
+    from discopt import debug as _debug
+
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
+            break
+
+        # Interactive debugger: top-of-iteration checkpoint (no-op when detached).
+        if _debug.fire(
+            _debug.Checkpoint.ITER_START,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=elapsed,
+        ):
             break
 
         # Update per-iteration time budget for NLP subproblem solves (issue #5).
@@ -7785,6 +7797,19 @@ def _solve_nlp_bb(
 
         n_batch = len(batch_ids)
         if n_batch == 0:
+            break
+
+        # Interactive debugger: nodes selected — boxes/ids now available.
+        if _debug.fire(
+            _debug.Checkpoint.AFTER_SELECT,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=elapsed,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
+        ):
             break
 
         # Tighten node bounds via constraint propagation (FBBT).
@@ -8131,11 +8156,37 @@ def _solve_nlp_bb(
                 "solve_model should have refused or rerouted to spatial B&B."
             )
 
+        # Interactive debugger: steer point — relaxations solved, not imported.
+        if _debug.fire(
+            _debug.Checkpoint.BEFORE_IMPORT,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=time.perf_counter() - t_start,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
+            result_lbs=result_lbs,
+            result_sols=result_sols,
+            result_feas=result_feas,
+        ):
+            break
+
         # Import results back to Rust tree
         t_rust_start = time.perf_counter()
         tree.import_results(result_ids, result_lbs, result_sols, result_feas)
         tree.process_evaluated()
         rust_time += time.perf_counter() - t_rust_start
+
+        # Interactive debugger: prune/branch/fathom applied by the tree.
+        if _debug.fire(
+            _debug.Checkpoint.AFTER_PROCESS,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=time.perf_counter() - t_start,
+        ):
+            break
 
         # --- Node callback ---
         if node_callback is not None:
@@ -8311,6 +8362,15 @@ def _solve_nlp_bb(
     # --- Build result ---
     wall_time = time.perf_counter() - t_start
     python_time = wall_time - rust_time - jax_time
+
+    # Interactive debugger: terminal checkpoint (final/limit/infeasible state).
+    _debug.fire(
+        _debug.Checkpoint.TERMINATED,
+        tree=tree,
+        model=model,
+        iteration=iteration,
+        elapsed=wall_time,
+    )
 
     stats = tree.stats()
     incumbent = tree.incumbent()
@@ -11866,9 +11926,21 @@ def _solve_milp_bb(
     # Root-node certification instrumentation (cert:T0.1).
     _root_time: Optional[float] = None
     _root_glb_internal: Optional[float] = None
+    from discopt import debug as _debug
+
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
+            break
+
+        # Interactive debugger: top-of-iteration checkpoint (no-op when detached).
+        if _debug.fire(
+            _debug.Checkpoint.ITER_START,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=elapsed,
+        ):
             break
 
         t_rust_start = time.perf_counter()
@@ -11877,6 +11949,19 @@ def _solve_milp_bb(
 
         n_batch = len(batch_ids)
         if n_batch == 0:
+            break
+
+        # Interactive debugger: nodes selected — boxes/ids now available.
+        if _debug.fire(
+            _debug.Checkpoint.AFTER_SELECT,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=elapsed,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
+        ):
             break
 
         t_jax_start = time.perf_counter()
@@ -11933,10 +12018,36 @@ def _solve_milp_bb(
 
         jax_time += time.perf_counter() - t_jax_start
 
+        # Interactive debugger: steer point — relaxations solved, not imported.
+        if _debug.fire(
+            _debug.Checkpoint.BEFORE_IMPORT,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=time.perf_counter() - t_start,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
+            result_lbs=result_lbs,
+            result_sols=result_sols,
+            result_feas=result_feas,
+        ):
+            break
+
         t_rust_start = time.perf_counter()
         tree.import_results(result_ids, result_lbs, result_sols, result_feas)
         tree.process_evaluated()
         rust_time += time.perf_counter() - t_rust_start
+
+        # Interactive debugger: prune/branch/fathom applied by the tree.
+        if _debug.fire(
+            _debug.Checkpoint.AFTER_PROCESS,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=time.perf_counter() - t_start,
+        ):
+            break
 
         # Root-node certification snapshot (cert:T0.1).
         if iteration == 0:
@@ -11956,6 +12067,16 @@ def _solve_milp_bb(
 
     wall_time = time.perf_counter() - t_start
     python_time = wall_time - rust_time - jax_time
+
+    # Interactive debugger: terminal checkpoint (final/limit/infeasible state).
+    _debug.fire(
+        _debug.Checkpoint.TERMINATED,
+        tree=tree,
+        model=model,
+        iteration=iteration,
+        elapsed=wall_time,
+    )
+
     stats = tree.stats()
     incumbent = tree.incumbent()
 
@@ -12287,9 +12408,21 @@ def _solve_miqp_bb(
     # Root-node certification instrumentation (cert:T0.1).
     _root_time: Optional[float] = None
     _root_glb_internal: Optional[float] = None
+    from discopt import debug as _debug
+
     while True:
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
+            break
+
+        # Interactive debugger: top-of-iteration checkpoint (no-op when detached).
+        if _debug.fire(
+            _debug.Checkpoint.ITER_START,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=elapsed,
+        ):
             break
 
         t_rust_start = time.perf_counter()
@@ -12298,6 +12431,19 @@ def _solve_miqp_bb(
 
         n_batch = len(batch_ids)
         if n_batch == 0:
+            break
+
+        # Interactive debugger: nodes selected — boxes/ids now available.
+        if _debug.fire(
+            _debug.Checkpoint.AFTER_SELECT,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=elapsed,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
+        ):
             break
 
         t_jax_start = time.perf_counter()
@@ -12339,10 +12485,36 @@ def _solve_miqp_bb(
 
         jax_time += time.perf_counter() - t_jax_start
 
+        # Interactive debugger: steer point — relaxations solved, not imported.
+        if _debug.fire(
+            _debug.Checkpoint.BEFORE_IMPORT,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=time.perf_counter() - t_start,
+            batch_lb=batch_lb,
+            batch_ub=batch_ub,
+            batch_ids=batch_ids,
+            result_lbs=result_lbs,
+            result_sols=result_sols,
+            result_feas=result_feas,
+        ):
+            break
+
         t_rust_start = time.perf_counter()
         tree.import_results(result_ids, result_lbs, result_sols, result_feas)
         tree.process_evaluated()
         rust_time += time.perf_counter() - t_rust_start
+
+        # Interactive debugger: prune/branch/fathom applied by the tree.
+        if _debug.fire(
+            _debug.Checkpoint.AFTER_PROCESS,
+            tree=tree,
+            model=model,
+            iteration=iteration,
+            elapsed=time.perf_counter() - t_start,
+        ):
+            break
 
         # Root-node certification snapshot (cert:T0.1).
         if iteration == 0:
@@ -12362,6 +12534,16 @@ def _solve_miqp_bb(
 
     wall_time = time.perf_counter() - t_start
     python_time = wall_time - rust_time - jax_time
+
+    # Interactive debugger: terminal checkpoint (final/limit/infeasible state).
+    _debug.fire(
+        _debug.Checkpoint.TERMINATED,
+        tree=tree,
+        model=model,
+        iteration=iteration,
+        elapsed=wall_time,
+    )
+
     stats = tree.stats()
     incumbent = tree.incumbent()
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -30,6 +30,7 @@ from discopt._rust import PyTreeManager
 from discopt.constants import INFEASIBILITY_SENTINEL as _INFEASIBILITY_SENTINEL
 from discopt.constants import SENTINEL_THRESHOLD as _SENTINEL_THRESHOLD
 from discopt.constants import STARTING_POINT_CLIP as _SPC
+from discopt.debug import outermost_solve as _debug_outermost_solve
 from discopt.modeling.core import (
     Constraint,
     CustomCall,
@@ -2565,6 +2566,7 @@ def solve_model_accepted_kwargs() -> frozenset[str]:
 
 @_scoped_deep_recursion
 @_scoped_tuning
+@_debug_outermost_solve
 def solve_model(
     model: Model,
     time_limit: float = 3600.0,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7025,15 +7025,6 @@ def solve_model(
     wall_time = time.perf_counter() - t_start
     python_time = wall_time - rust_time - jax_time
 
-    # Interactive debugger: terminal checkpoint (final/limit/infeasible state).
-    _debug.fire(
-        _debug.Checkpoint.TERMINATED,
-        tree=tree,
-        model=model,
-        iteration=iteration,
-        elapsed=wall_time,
-    )
-
     stats = tree.stats()
     incumbent = tree.incumbent()
 
@@ -7246,6 +7237,19 @@ def solve_model(
             # SolveStatus.INFEASIBLE): infeasibility *is* a certified conclusion, so
             # leave _gap_certified untouched.
             status = "infeasible"
+
+    # Interactive debugger: terminal checkpoint. Fired after the status
+    # decision so ``debug="on-error"`` sessions can key on the outcome:
+    # ``error`` is the non-"optimal" status ("time_limit", "unknown",
+    # "infeasible", ...), or None on a certified optimum.
+    _debug.fire(
+        _debug.Checkpoint.TERMINATED,
+        tree=tree,
+        model=model,
+        iteration=iteration,
+        elapsed=wall_time,
+        error=None if status == "optimal" else status,
+    )
 
     from discopt.modeling.core import ObjectiveSense
 
@@ -8447,15 +8451,6 @@ def _solve_nlp_bb(
     wall_time = time.perf_counter() - t_start
     python_time = wall_time - rust_time - jax_time
 
-    # Interactive debugger: terminal checkpoint (final/limit/infeasible state).
-    _debug.fire(
-        _debug.Checkpoint.TERMINATED,
-        tree=tree,
-        model=model,
-        iteration=iteration,
-        elapsed=wall_time,
-    )
-
     stats = tree.stats()
     incumbent = tree.incumbent()
 
@@ -8596,6 +8591,19 @@ def _solve_nlp_bb(
             # certificate (FBBT-empty box or SolveStatus.INFEASIBLE): infeasibility
             # *is* a certified conclusion, so leave _gap_certified untouched.
             status = "infeasible"
+
+    # Interactive debugger: terminal checkpoint. Fired after the status
+    # decision so ``debug="on-error"`` sessions can key on the outcome:
+    # ``error`` is the non-"optimal" status ("time_limit", "unknown",
+    # "infeasible", ...), or None on a certified optimum.
+    _debug.fire(
+        _debug.Checkpoint.TERMINATED,
+        tree=tree,
+        model=model,
+        iteration=iteration,
+        elapsed=wall_time,
+        error=None if status == "optimal" else status,
+    )
 
     # Negate bound back for maximization
     bound_val = stats["global_lower_bound"]
@@ -12196,15 +12204,6 @@ def _solve_milp_bb(
     wall_time = time.perf_counter() - t_start
     python_time = wall_time - rust_time - jax_time
 
-    # Interactive debugger: terminal checkpoint (final/limit/infeasible state).
-    _debug.fire(
-        _debug.Checkpoint.TERMINATED,
-        tree=tree,
-        model=model,
-        iteration=iteration,
-        elapsed=wall_time,
-    )
-
     stats = tree.stats()
     incumbent = tree.incumbent()
 
@@ -12288,6 +12287,19 @@ def _solve_milp_bb(
             # Tree exhausted with no feasible node: infeasibility *is* a certified
             # conclusion, so leave _gap_certified untouched.
             status = "infeasible"
+
+    # Interactive debugger: terminal checkpoint. Fired after the status
+    # decision so ``debug="on-error"`` sessions can key on the outcome:
+    # ``error`` is the non-"optimal" status ("time_limit", "unknown",
+    # "infeasible", ...), or None on a certified optimum.
+    _debug.fire(
+        _debug.Checkpoint.TERMINATED,
+        tree=tree,
+        model=model,
+        iteration=iteration,
+        elapsed=wall_time,
+        error=None if status == "optimal" else status,
+    )
 
     from discopt.modeling.core import ObjectiveSense
 
@@ -12678,15 +12690,6 @@ def _solve_miqp_bb(
     wall_time = time.perf_counter() - t_start
     python_time = wall_time - rust_time - jax_time
 
-    # Interactive debugger: terminal checkpoint (final/limit/infeasible state).
-    _debug.fire(
-        _debug.Checkpoint.TERMINATED,
-        tree=tree,
-        model=model,
-        iteration=iteration,
-        elapsed=wall_time,
-    )
-
     stats = tree.stats()
     incumbent = tree.incumbent()
 
@@ -12775,6 +12778,19 @@ def _solve_miqp_bb(
             # Tree exhausted with no feasible node: infeasibility *is* a certified
             # conclusion, so leave _gap_certified untouched.
             status = "infeasible"
+
+    # Interactive debugger: terminal checkpoint. Fired after the status
+    # decision so ``debug="on-error"`` sessions can key on the outcome:
+    # ``error`` is the non-"optimal" status ("time_limit", "unknown",
+    # "infeasible", ...), or None on a certified optimum.
+    _debug.fire(
+        _debug.Checkpoint.TERMINATED,
+        tree=tree,
+        model=model,
+        iteration=iteration,
+        elapsed=wall_time,
+        error=None if status == "optimal" else status,
+    )
 
     from discopt.modeling.core import ObjectiveSense
 

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -315,6 +315,10 @@ def solve_milp(
     else:
         int_cols = np.zeros(0, dtype=np.int64)
 
+    # Interactive debugger: install the Rust checkpoint hook only when a debugger
+    # is attached now, so the pure-Rust search stays bound-neutral otherwise.
+    from discopt import debug as _debug
+
     status, x_full, obj, bound, nodes, _iters = solve_milp_py(
         np.ascontiguousarray(c_std),
         np.ascontiguousarray(a_std),
@@ -327,6 +331,7 @@ def solve_milp(
         int(max_nodes),
         float(gap_tolerance),
         time_limit_s=0.0 if time_limit is None else max(0.0, float(time_limit)),
+        debug_hook=_debug.rust_hook(),
     )
 
     if status == "infeasible":

--- a/python/tests/test_debug_adversarial.py
+++ b/python/tests/test_debug_adversarial.py
@@ -1,0 +1,455 @@
+"""Adversarial tests for the interactive B&B debugger (``discopt.debug``).
+
+Attacks the debugger the way a hostile (or merely clumsy) user/agent would:
+
+* command-engine fuzzing — garbage commands must never escape ``execute``;
+* JSON-protocol fuzzing — malformed frames must never kill the stream;
+* steering abuse — bad indices, hostile branch hints, maximize-sense inject;
+* lifecycle abuse — ``quit`` before any incumbent exists must not corrupt the
+  reported status (the certificate: never a false "infeasible"/"optimal");
+* hostile frontends — a hook that raises on the Rust path is contained;
+* active-stepping bound-neutrality — pausing at every checkpoint must leave
+  the certified search bit-for-bit identical (CLAUDE.md §5).
+"""
+
+from __future__ import annotations
+
+import discopt as do
+import numpy as np
+import pytest
+from discopt import debug
+from discopt.debug.context import DebugContext
+from discopt.debug.engine import Control, DebugCommandEngine
+from discopt.debug.session import DebugSession
+
+# ── fakes ───────────────────────────────────────────────────────────────────
+
+
+class FakeTree:
+    def __init__(self, inc=None):
+        self._inc = inc
+        self.hint = None
+
+    def stats(self):
+        return {"total_nodes": 7, "open_nodes": 3, "global_lower_bound": 4.2, "gap": 0.12}
+
+    def incumbent(self):
+        return self._inc
+
+    def inject_incumbent(self, sol, obj):
+        if self._inc is None or obj < self._inc[1]:
+            self._inc = (np.asarray(sol, dtype=float), float(obj))
+            return True
+        return False
+
+    def set_branch_hints(self, ids, vhint):
+        self.hint = (list(ids), list(vhint))
+
+
+def _ok_validator(x):
+    xv = np.asarray(x, dtype=np.float64).copy()
+    return True, xv, float(np.sum(xv)) + 2.9
+
+
+def _batch_ctx(tree, validator=None, n_nodes=2):
+    return DebugContext.build(
+        debug.Checkpoint.BEFORE_IMPORT,
+        tree=tree,
+        iteration=0,
+        elapsed=0.1,
+        batch_lb=np.zeros((n_nodes, 2)),
+        batch_ub=np.ones((n_nodes, 2)),
+        batch_ids=np.arange(11, 11 + n_nodes),
+        result_lbs=np.linspace(3.5, 3.6, n_nodes),
+        result_sols=np.full((n_nodes, 2), 0.5),
+        result_feas=np.ones(n_nodes, dtype=bool),
+        validator=validator,
+    )
+
+
+class QuitFrontend:
+    def interact(self, ctx, session):
+        return Control.QUIT
+
+
+class WalkFrontend:
+    """Pauses at every checkpoint (stepi) — maximally invasive inspection."""
+
+    def __init__(self):
+        self.hits = []
+
+    def interact(self, ctx, session):
+        self.hits.append(ctx.checkpoint.value)
+        # Exercise read-only commands at every pause, then keep stepping.
+        session.engine.execute("info", ctx, session)
+        session.engine.execute("print nodes", ctx, session)
+        if ctx.checkpoint.value == "terminated":
+            return Control.CONTINUE
+        return Control.STEPI
+
+
+# ── command-engine fuzzing (unit) ────────────────────────────────────────────
+
+GARBAGE_COMMANDS = [
+    "",
+    "   ",
+    "bogus",
+    "béak 3",
+    "\x00\x01\x02",
+    "break if",
+    "break if garbage",
+    "break if gap<<3",
+    "break if gap<abc",
+    "break if nodes>1e999 && gap<-1e999",
+    "break if gap==0.1||nodes>2",
+    "break on",
+    "break on not_an_event",
+    "break del",
+    "break del xyz",
+    "tbreak",
+    "tbreak abc",
+    "run",
+    "run -5",
+    "run notanumber",
+    "stop-at nonsense",
+    "print",
+    "print node",
+    "print node 99",
+    "print node -99",
+    "print relax 99",
+    "print wat",
+    "inject",
+    "inject 99",
+    "inject abc",
+    "hint",
+    "hint 1",
+    "hint a b",
+    "watch " + "x" * 10_000,
+    "b " * 2000,
+    "info extra args ignored",
+]
+
+
+@pytest.mark.unit
+def test_engine_never_raises_on_garbage():
+    """Every garbage command yields a CommandResult; nothing escapes execute."""
+    sess = DebugSession(QuitFrontend())
+    for validator in (None, _ok_validator):
+        eng = DebugCommandEngine()
+        ctx = _batch_ctx(FakeTree(), validator=validator)
+        for cmd in GARBAGE_COMMANDS:
+            res = eng.execute(cmd, ctx, sess)
+            assert res is not None, cmd
+            assert res.control in (Control.NONE, Control.CONTINUE, Control.QUIT), cmd
+    # No-batch context (ITER_START): batch-dependent commands must degrade.
+    eng = DebugCommandEngine()
+    ctx0 = DebugContext.build(debug.Checkpoint.ITER_START, tree=FakeTree(), iteration=0)
+    for cmd in ("print nodes", "print node 0", "print relax 0", "inject 0", "hint 1 1"):
+        res = eng.execute(cmd, ctx0, sess)
+        assert res.output, cmd
+
+
+@pytest.mark.unit
+def test_inject_out_of_range_is_error_and_tree_untouched():
+    tree = FakeTree()
+    eng = DebugCommandEngine()
+    sess = DebugSession(QuitFrontend())
+    ctx = _batch_ctx(tree, validator=_ok_validator, n_nodes=2)
+    res = eng.execute("inject 99", ctx, sess)
+    assert any("error" in line for line in res.output)
+    assert tree.incumbent() is None
+
+
+@pytest.mark.unit
+def test_inject_negative_index_does_not_crash():
+    """numpy would resolve -1 to the last node; document that it stays safe
+    (validated like any candidate) and does not crash."""
+    tree = FakeTree()
+    eng = DebugCommandEngine()
+    sess = DebugSession(QuitFrontend())
+    ctx = _batch_ctx(tree, validator=_ok_validator, n_nodes=2)
+    res = eng.execute("inject -1", ctx, sess)
+    assert res.output  # some outcome reported, no exception
+    inc = tree.incumbent()
+    if inc is not None:  # if adopted, it must carry the validated objective
+        assert inc[1] == pytest.approx(3.9)
+
+
+# ── JSON protocol fuzzing (unit) ─────────────────────────────────────────────
+
+MALFORMED_FRAMES = [
+    "@@@@",
+    "123",
+    "[1, 2, 3]",
+    '{"cmd": 5}',
+    '{"nope": true}',
+    '{"cmd": null, "id": 9}',
+    "{invalid json",
+    '"unterminated',
+    "NaN",
+    '{"cmd": "print", "args": {"k": "v"}}',
+    '{"cmd": "break if gap<0.2 || nodes>1"}',
+    " ",
+]
+
+
+@pytest.mark.unit
+def test_json_frontend_survives_malformed_stream():
+    from discopt.debug.jsonproto import JsonFrontend
+
+    frames = MALFORMED_FRAMES + ["continue"]
+    it = iter(frames)
+
+    def read():
+        try:
+            return next(it)
+        except StopIteration:
+            return None
+
+    events = []
+    fe = JsonFrontend(read_fn=read, write_fn=events.append)
+    sess = DebugSession(fe)
+    ctx = _batch_ctx(FakeTree())
+    control = fe.interact(ctx, sess)
+    assert control is Control.CONTINUE
+    # Every frame produced exactly one result/malformed event; stream stayed up.
+    results = [e for e in events if e["event"] == "result"]
+    assert len(results) == len([f for f in frames if f.strip()])
+    # And the whole stream stayed strict-JSON serializable.
+    import json as _json
+
+    for e in events:
+        _json.loads(_json.dumps(e, allow_nan=False))
+
+
+@pytest.mark.unit
+def test_json_string_args_do_not_crash():
+    """args as a bare string (agent bug) must not crash the frontend."""
+    from discopt.debug.jsonproto import _parse_command
+
+    cmd, _ = _parse_command('{"cmd": "print", "args": "bound"}')
+    assert isinstance(cmd, str)  # mangled is tolerable; crashing is not
+
+
+# ── lifecycle abuse: quit-early status validity (e2e) ────────────────────────
+
+
+def _spatial_model():
+    m = do.Model("adv_dbg")
+    x = m.continuous("x", lb=0.1, ub=4.0)
+    y = m.continuous("y", lb=0.1, ub=4.0)
+    z = m.integer("z", lb=0, ub=3)
+    m.subject_to(x * y + z >= 3.0)
+    m.subject_to(y == do.exp(x) - 1.0)
+    m.minimize(x + 0.5 * y + 0.3 * z)
+    return m
+
+
+def _spatial_model_max():
+    """Same feasible set, maximize sense — probes internal sign handling."""
+    m = do.Model("adv_dbg_max")
+    x = m.continuous("x", lb=0.1, ub=4.0)
+    y = m.continuous("y", lb=0.1, ub=4.0)
+    z = m.integer("z", lb=0, ub=3)
+    m.subject_to(x * y + z >= 3.0)
+    m.subject_to(y == do.exp(x) - 1.0)
+    m.maximize(-(x + 0.5 * y + 0.3 * z))
+    return m
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_quit_before_any_incumbent_is_not_false_infeasible():
+    """CERTIFICATE: quitting at the very first checkpoint (no incumbent, tree
+    not exhausted, no limits hit) proves nothing about the model. The status
+    must not be "infeasible" (worst-class false verdict on a feasible model)
+    and must not be "optimal" (nothing was certified)."""
+    debug.attach(DebugSession(QuitFrontend()))
+    try:
+        res = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status not in ("infeasible", "optimal"), (
+        f"quit-before-incumbent produced a false '{res.status}' verdict"
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_quit_early_keeps_bound_below_incumbent():
+    """Quit as soon as an incumbent exists: the partial result must still obey
+    bound <= objective (min sense) — the certificate invariant."""
+
+    class QuitOnIncumbent:
+        def interact(self, ctx, session):
+            if ctx.incumbent_obj is not None:
+                return Control.QUIT
+            return Control.STEPI
+
+    debug.attach(DebugSession(QuitOnIncumbent()))
+    try:
+        res = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status != "optimal" or res.gap is not None
+    if res.objective is not None and res.bound is not None:
+        assert res.bound <= res.objective + 1e-6, "UNSOUND: bound crossed incumbent"
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_session_reuse_after_quit_is_inert_but_sound():
+    """Reusing a quit session leaves it detached: the second solve never
+    pauses, and — critically — is not stopped early by the stale session."""
+    sess = DebugSession(QuitFrontend())
+    debug.attach(sess)
+    try:
+        _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+
+    baseline = _spatial_model().solve(time_limit=20.0)
+    debug.attach(sess)  # stale, already-quit session
+    try:
+        res = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status == baseline.status == "optimal"
+    assert res.objective == baseline.objective
+
+
+# ── active stepping must be bound-neutral (e2e) ──────────────────────────────
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_step_through_every_checkpoint_is_bound_neutral():
+    """CLAUDE.md §5: pausing at EVERY checkpoint and running read-only
+    inspection commands at each pause must leave node_count and the certified
+    objective exactly unchanged."""
+    base = _spatial_model().solve(time_limit=20.0)
+
+    fe = WalkFrontend()
+    debug.attach(DebugSession(fe))
+    try:
+        dbg = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+
+    assert len(fe.hits) > 4, "walk frontend never engaged"
+    assert dbg.node_count == base.node_count, "node count drifted under stepping"
+    assert dbg.objective == base.objective, "objective drifted under stepping"
+
+
+# ── steering abuse on a real solve (e2e) ─────────────────────────────────────
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_garbage_hints_cannot_corrupt_certificate():
+    """Hostile branch hints (bogus node ids, out-of-range/negative variable
+    indices) may at most reorder the search; the certified optimum must be
+    unchanged and the commands must not crash the REPL."""
+    base = _spatial_model().solve(time_limit=20.0)
+
+    script = [
+        "stop-at steer",
+        "continue",
+        "hint 999999 999999",
+        "hint 0 -5",
+        "hint -1 0",
+        "continue",
+    ]
+    debug.attach(debug.make_session(script=script))
+    try:
+        res = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(base.objective, rel=1e-6, abs=1e-6)
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_inject_on_maximize_model_keeps_certificate():
+    """Sign-flip probe: `inject` on a MAXIMIZE model must validate in the
+    internal min sense; the certified optimum must match the baseline."""
+    base = _spatial_model_max().solve(time_limit=20.0)
+    assert base.status == "optimal"
+
+    script = ["stop-at steer", "continue", "inject 0", "inject 1", "continue"]
+    debug.attach(debug.make_session(script=script))
+    try:
+        res = _spatial_model_max().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(base.objective, rel=1e-6, abs=1e-6)
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_repl_survives_garbage_mid_solve():
+    """A REPL script full of garbage must not derail the solve."""
+    base = _spatial_model().solve(time_limit=20.0)
+    script = list(GARBAGE_COMMANDS[:20]) + ["continue"]
+    debug.attach(debug.make_session(script=script))
+    try:
+        res = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(base.objective, rel=1e-6, abs=1e-6)
+
+
+# ── hostile frontends (e2e) ──────────────────────────────────────────────────
+
+
+def _pure_milp_model():
+    m = do.Model("adv_milp")
+    xs = [m.integer(f"x{i}", lb=0, ub=1) for i in range(10)]
+    vals = [8, 5, 3, 6, 4, 7, 9, 2, 5, 6]
+    wts = [5, 3, 2, 4, 3, 5, 6, 1, 2, 4]
+    m.subject_to(sum(w * xi for w, xi in zip(wts, xs)) <= 14)
+    m.maximize(sum(v * xi for v, xi in zip(vals, xs)))
+    return m
+
+
+@pytest.mark.smoke
+def test_raising_hook_on_rust_path_is_contained(capsys):
+    """A frontend that raises at every checkpoint on the pure-Rust MILP path
+    must be contained (printed + Continue): the solve completes and certifies
+    the same optimum as the baseline."""
+    base = _pure_milp_model().solve(time_limit=15.0, nlp_solver="simplex")
+    assert base.status == "optimal"
+
+    class BombFrontend:
+        def interact(self, ctx, session):
+            raise RuntimeError("hostile frontend")
+
+    debug.attach(DebugSession(BombFrontend()))
+    try:
+        res = _pure_milp_model().solve(time_limit=15.0, nlp_solver="simplex")
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(base.objective)
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_raising_frontend_on_python_path_detaches_cleanly():
+    """On the Python-driven path a raising frontend propagates (loud failure,
+    no silent swallowing) — but it must not poison the NEXT solve: the guard
+    in Model.solve() detaches, and a follow-up solve certifies normally."""
+
+    class BombFrontend:
+        def interact(self, ctx, session):
+            raise RuntimeError("hostile frontend")
+
+    with pytest.raises(RuntimeError, match="hostile frontend"):
+        _spatial_model().solve(time_limit=20.0, debug=DebugSession(BombFrontend()))
+    assert not debug.is_attached(), "solve() failed to detach after the crash"
+
+    res = _spatial_model().solve(time_limit=20.0)
+    assert res.status == "optimal"

--- a/python/tests/test_debug_adversarial.py
+++ b/python/tests/test_debug_adversarial.py
@@ -14,6 +14,8 @@ Attacks the debugger the way a hostile (or merely clumsy) user/agent would:
 
 from __future__ import annotations
 
+import time as _time
+
 import discopt as do
 import numpy as np
 import pytest
@@ -21,6 +23,7 @@ from discopt import debug
 from discopt.debug.context import DebugContext
 from discopt.debug.engine import Control, DebugCommandEngine
 from discopt.debug.session import DebugSession
+from discopt.solver import _solve_milp_bb
 
 # ── fakes ───────────────────────────────────────────────────────────────────
 
@@ -453,3 +456,410 @@ def test_raising_frontend_on_python_path_detaches_cleanly():
 
     res = _spatial_model().solve(time_limit=20.0)
     assert res.status == "optimal"
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Sweep 2 — orthogonal axes: trace invariants at every checkpoint, coverage of
+# ALL four instrumented loops (spatial / NLP-BB / MILP-BB / MIQP-BB) plus the
+# Rust fast-path, stateful chaos fuzzing during live solves, and odd model
+# classes (continuous-only, infeasible, maximize).
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+class TraceFrontend:
+    """Walks every checkpoint (stepi) recording (cp, bound, incumbent, iter)."""
+
+    def __init__(self):
+        self.trace = []
+
+    def interact(self, ctx, session):
+        self.trace.append((ctx.checkpoint.value, ctx.best_bound, ctx.incumbent_obj, ctx.iteration))
+        if ctx.checkpoint.value == "terminated":
+            return Control.CONTINUE
+        return Control.STEPI
+
+
+def _assert_trace_invariants(trace):
+    """Certificate + lifecycle invariants that must hold at EVERY checkpoint,
+    not just at the end of the solve (internal min sense throughout):
+    bound never crosses the incumbent, the dual bound never regresses, the
+    incumbent never worsens, iterations are monotone, TERMINATED fires exactly
+    once and last, INCUMBENT_FOUND always carries an incumbent."""
+    assert trace, "no checkpoints fired"
+    cps = [t[0] for t in trace]
+    assert cps[-1] == "terminated", f"trace did not end at terminated: {cps[-5:]}"
+    assert cps.count("terminated") == 1
+    prev_bound = -np.inf
+    prev_inc = np.inf
+    prev_iter = 0
+    for cp, bound, inc, it in trace:
+        if inc is not None and np.isfinite(bound):
+            assert bound <= inc + 1e-6 * max(1.0, abs(inc)), (
+                f"UNSOUND at {cp}: bound {bound} crossed incumbent {inc}"
+            )
+        if np.isfinite(bound):
+            assert bound >= prev_bound - 1e-9, f"dual bound regressed at {cp}"
+            prev_bound = max(prev_bound, bound)
+        if inc is not None:
+            assert inc <= prev_inc + 1e-9, f"incumbent worsened at {cp}"
+            prev_inc = min(prev_inc, inc)
+        if cp == "incumbent_found":
+            assert inc is not None, "incumbent_found fired without an incumbent"
+        assert it >= prev_iter or cp == "terminated"
+        prev_iter = max(prev_iter, it)
+
+
+def _traced_solve(model, **solve_kwargs):
+    fe = TraceFrontend()
+    debug.attach(DebugSession(fe))
+    try:
+        res = model.solve(time_limit=20.0, **solve_kwargs)
+    finally:
+        debug.detach()
+    return res, fe.trace
+
+
+# ── models routing to each instrumented loop ─────────────────────────────────
+
+
+def _convex_minlp():
+    """Convex MINLP for the NLP-BB loop (loop 2, via nlp_bb=True). The
+    (z - 1.5)^2 term makes the root NLP relaxation fractional in z, so the
+    loop must branch (a root-integral model would fathom immediately and
+    never reach the BEFORE_IMPORT steer point)."""
+    m = do.Model("adv2_nlpbb")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=4.0)
+    z = m.integer("z", lb=0, ub=3)
+    m.subject_to(x + y + z <= 4.0)
+    m.minimize((x - 1.5) ** 2 + (y - 2.5) ** 2 + (z - 1.5) ** 2)
+    return m
+
+
+def _nested_heuristic_minlp():
+    """Convex MINLP whose NLP-BB run launches a nested solve_model heuristic
+    (restricted sub-MINLP): the regression probe for outermost-solve
+    suppression. Root-integral in z, so the outer loop is short and the
+    nested solve dominates the trace if suppression is broken."""
+    m = do.Model("adv2_nested")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=4.0)
+    z = m.integer("z", lb=0, ub=3)
+    m.subject_to(x + y + z <= 4.0)
+    m.minimize((x - 1.5) ** 2 + (y - 2.5) ** 2 + 0.5 * z)
+    return m
+
+
+def _miqp_model():
+    """Convex MIQP routing to the MIQP-BB loop (loop 4)."""
+    m = do.Model("adv2_miqp")
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    y = m.continuous("y", lb=-5.0, ub=5.0)
+    z = m.integer("z", lb=0, ub=4)
+    m.subject_to(x + y + z >= 2.0)
+    m.minimize(x * x + y * y + 0.3 * z)
+    return m
+
+
+def _run_milp_bb(model):
+    """Drive the fallback-only Python MILP-BB loop (loop 3) directly."""
+    return _solve_milp_bb(model, 20.0, 1e-6, 8, "best_first", 100_000, _time.perf_counter())
+
+
+def _milp_model():
+    """Small MILP for driving the Python MILP-BB loop (loop 3) directly."""
+    m = do.Model("adv2_milp")
+    xs = [m.integer(f"x{i}", lb=0, ub=1) for i in range(8)]
+    vals = [7, 5, 4, 6, 3, 5, 8, 2]
+    wts = [4, 3, 3, 4, 2, 3, 5, 1]
+    m.subject_to(sum(w * xi for w, xi in zip(wts, xs)) <= 11)
+    m.maximize(sum(v * xi for v, xi in zip(vals, xs)))
+    return m
+
+
+def _infeasible_bilinear():
+    """Infeasible only after branching (FBBT alone cannot prove it): needs
+    x*y >= 0.5 with x + y <= 1 on [0,1]^2 (max of x*y is 0.25)."""
+    m = do.Model("adv2_infeas")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    y = m.continuous("y", lb=0.0, ub=1.0)
+    m.subject_to(x * y >= 0.5)
+    m.subject_to(x + y <= 1.0)
+    m.minimize(x + y)
+    return m
+
+
+# ── trace invariants across every loop ───────────────────────────────────────
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_trace_invariants_spatial_loop():
+    res, trace = _traced_solve(_spatial_model())
+    assert res.status == "optimal"
+    _assert_trace_invariants(trace)
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_trace_invariants_spatial_maximize():
+    res, trace = _traced_solve(_spatial_model_max())
+    assert res.status == "optimal"
+    _assert_trace_invariants(trace)
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_trace_invariants_nlp_bb_loop():
+    res, trace = _traced_solve(_convex_minlp(), nlp_bb=True)
+    assert res.status == "optimal"
+    _assert_trace_invariants(trace)
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_trace_invariants_miqp_loop():
+    res, trace = _traced_solve(_miqp_model())
+    assert res.status == "optimal"
+    _assert_trace_invariants(trace)
+
+
+@pytest.mark.smoke
+def test_trace_invariants_rust_fast_path():
+    res, trace = _traced_solve(_pure_milp_model(), nlp_solver="simplex")
+    assert res.status == "optimal"
+    _assert_trace_invariants(trace)
+
+
+@pytest.mark.smoke
+def test_trace_invariants_milp_bb_loop_direct():
+    """Loop 3 (_solve_milp_bb) is fallback-only, so drive it directly."""
+    fe = TraceFrontend()
+    debug.attach(DebugSession(fe))
+    try:
+        res = _run_milp_bb(_milp_model())
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    _assert_trace_invariants(fe.trace)
+
+
+# ── per-loop: no-op neutrality, quit statuses, inject wiring ─────────────────
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_nlp_bb_no_op_debugger_is_bound_neutral():
+    base = _convex_minlp().solve(time_limit=20.0, nlp_bb=True)
+    debug.attach(DebugSession(WalkFrontend()))
+    try:
+        dbg = _convex_minlp().solve(time_limit=20.0, nlp_bb=True)
+    finally:
+        debug.detach()
+    assert dbg.node_count == base.node_count
+    assert dbg.objective == base.objective
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_miqp_no_op_debugger_is_bound_neutral():
+    base = _miqp_model().solve(time_limit=20.0)
+    debug.attach(DebugSession(WalkFrontend()))
+    try:
+        dbg = _miqp_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert dbg.node_count == base.node_count
+    assert dbg.objective == base.objective
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_quit_early_not_false_infeasible_nlp_bb():
+    debug.attach(DebugSession(QuitFrontend()))
+    try:
+        res = _convex_minlp().solve(time_limit=20.0, nlp_bb=True)
+    finally:
+        debug.detach()
+    assert res.status not in ("infeasible", "optimal"), (
+        f"NLP-BB quit produced a false '{res.status}'"
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_quit_early_not_false_infeasible_miqp():
+    debug.attach(DebugSession(QuitFrontend()))
+    try:
+        res = _miqp_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status not in ("infeasible", "optimal"), (
+        f"MIQP-BB quit produced a false '{res.status}'"
+    )
+
+
+@pytest.mark.smoke
+def test_quit_early_not_false_infeasible_milp_bb_direct():
+    debug.attach(DebugSession(QuitFrontend()))
+    try:
+        res = _run_milp_bb(_milp_model())
+    finally:
+        debug.detach()
+    assert res.status not in ("infeasible", "optimal"), (
+        f"MILP-BB quit produced a false '{res.status}'"
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_inject_on_nlp_bb_keeps_certificate(capsys):
+    """Loop 2 wires a validator: inject validates and cannot corrupt."""
+    base = _convex_minlp().solve(time_limit=20.0, nlp_bb=True)
+    script = ["stop-at steer", "continue", "inject 0", "continue"]
+    debug.attach(debug.make_session(script=script))
+    try:
+        res = _convex_minlp().solve(time_limit=20.0, nlp_bb=True)
+    finally:
+        debug.detach()
+    err = capsys.readouterr().err
+    assert "inject node[0]" in err
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(base.objective, rel=1e-6, abs=1e-6)
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_inject_refused_on_miqp_loop(capsys):
+    """Loop 4 wires NO validator: inject must refuse loudly, not trust."""
+    base = _miqp_model().solve(time_limit=20.0)
+    script = ["stop-at steer", "continue", "inject 0", "continue"]
+    debug.attach(debug.make_session(script=script))
+    try:
+        res = _miqp_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    err = capsys.readouterr().err
+    assert "no candidate validator" in err, "MIQP inject did not refuse"
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(base.objective, rel=1e-6, abs=1e-6)
+
+
+# ── chaos: deterministic command storm during a live solve ──────────────────
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_chaos_command_storm_keeps_certificate():
+    """Rotate through the full command surface (inspection, breakpoints,
+    watches, steering, garbage) at every checkpoint of a live solve. The
+    certificate must survive and every command must return."""
+    base = _spatial_model().solve(time_limit=20.0)
+
+    commands = [
+        "info",
+        "print incumbent",
+        "print bound",
+        "print gap",
+        "print nodes",
+        "print node 0",
+        "print relax 0",
+        "break if gap<0.3",
+        "tbreak 2",
+        "watch bound",
+        "hint 0 0",
+        "inject 0",
+        "break",
+        "print node -1",
+        "break del 2",
+        "stop-at process",
+        "help",
+        "notacommand",
+        "break if x||y",
+    ]
+
+    class ChaosFrontend:
+        def __init__(self):
+            self.n = 0
+            self.executed = 0
+
+        def interact(self, ctx, session):
+            for _ in range(3):
+                cmd = commands[self.n % len(commands)]
+                self.n += 1
+                res = session.engine.execute(cmd, ctx, session)
+                assert res is not None, cmd
+                self.executed += 1
+            if ctx.checkpoint.value == "terminated":
+                return Control.CONTINUE
+            return Control.STEPI
+
+    fe = ChaosFrontend()
+    debug.attach(DebugSession(fe))
+    try:
+        res = _spatial_model().solve(time_limit=30.0)
+    finally:
+        debug.detach()
+    assert fe.executed >= 15, "chaos frontend barely engaged"
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(base.objective, rel=1e-6, abs=1e-6)
+    if res.bound is not None and res.objective is not None:
+        assert res.bound <= res.objective + 1e-6
+
+
+# ── odd model classes ────────────────────────────────────────────────────────
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_debugger_silent_on_continuous_path():
+    """A continuous NLP routes around all instrumented loops: an attached
+    debugger must simply never fire (documented gap), not crash the solve."""
+    m = do.Model("adv2_cont")
+    x = m.continuous("x", lb=0.0, ub=3.0)
+    m.minimize((x - 1.0) ** 2)
+    fe = TraceFrontend()
+    debug.attach(DebugSession(fe))
+    try:
+        res = m.solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    assert fe.trace == [], "continuous path unexpectedly fired checkpoints"
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_infeasible_model_traced_and_on_error():
+    """Certified infeasibility under full stepping: trace invariants hold,
+    the verdict survives the debugger, and on-error pauses with the reason."""
+    res, trace = _traced_solve(_infeasible_bilinear())
+    assert res.status in ("infeasible", "unknown")
+    if trace:
+        _assert_trace_invariants(trace)
+
+    fe = TraceFrontend()
+    debug.attach(DebugSession(fe, enter_on_error=True))
+    try:
+        res2 = _infeasible_bilinear().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res2.status == res.status
+    if trace:  # the loop ran, so TERMINATED fired with a non-optimal status
+        assert [t[0] for t in fe.trace] == ["terminated"]
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_nested_heuristic_solves_are_suppressed():
+    """The NLP-BB path launches nested solve_model heuristics (restricted
+    sub-MINLPs). Only the OUTERMOST solve may fire checkpoints: nested solves
+    interleaving into the session would collide breakpoints, break trace
+    monotonicity, and let `quit` kill a heuristic instead of the solve.
+    Regression: this model produced TWO `terminated` events before the
+    outermost-solve guard."""
+    res, trace = _traced_solve(_nested_heuristic_minlp(), nlp_bb=True)
+    assert res.status == "optimal"
+    cps = [t[0] for t in trace]
+    assert cps.count("terminated") == 1, f"nested solve leaked checkpoints: {cps}"
+    _assert_trace_invariants(trace)

--- a/python/tests/test_debug_bnb.py
+++ b/python/tests/test_debug_bnb.py
@@ -261,3 +261,88 @@ def test_scripted_repl_end_to_end(capsys):
     err = capsys.readouterr().err
     assert "paused at" in err
     assert "discopt-dbg" in err
+
+
+# ── JSON agent protocol ──────────────────────────────────────────────────────
+
+
+def _drive_json(model, commands):
+    """Run ``model`` under the JSON frontend fed ``commands``; return events."""
+    import json as _json
+
+    from discopt.debug.jsonproto import JsonFrontend
+
+    it = iter(commands)
+
+    def read():
+        try:
+            c = next(it)
+        except StopIteration:
+            return None
+        return c if isinstance(c, str) else _json.dumps(c)
+
+    events: list[dict] = []
+    fe = JsonFrontend(read_fn=read, write_fn=events.append)
+    debug.attach(DebugSession(fe))
+    try:
+        res = model.solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    return res, events
+
+
+@pytest.mark.unit
+def test_json_command_parsing_forms():
+    from discopt.debug.jsonproto import _parse_command
+
+    assert _parse_command("continue") == ("continue", None)
+    assert _parse_command('"continue"') == ("continue", None)
+    assert _parse_command('{"cmd": "print", "args": ["node", "0"], "id": 7}') == (
+        "print node 0",
+        7,
+    )
+    assert _parse_command('{"cmd": "break if gap<0.2", "id": 8}') == (
+        "break if gap<0.2",
+        8,
+    )
+    cmd, rid = _parse_command('{"nope": 1, "id": 3}')
+    assert cmd is None and rid == 3
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_json_protocol_handshake_and_events():
+    import json as _json
+
+    res, events = _drive_json(
+        _spatial_model(),
+        [
+            {"cmd": "info", "id": 1},
+            {"cmd": "break", "args": ["if", "nodes>=2"], "id": 2},
+            "continue",
+            {"cmd": "print", "args": ["bound"], "id": 3},
+            "continue",
+            "continue",
+        ],
+    )
+    assert res.status == "optimal"
+
+    # hello handshake is first and self-describing.
+    hello = events[0]
+    assert hello["event"] == "hello"
+    assert hello["protocol"] == "discopt-dbg/1"
+    assert "iter_start" in hello["checkpoints"]
+    assert "new_incumbent" in hello["events"]
+    assert hello["capabilities"]["mutate_iterate"] is False
+    assert hello["capabilities"]["safe_steer"] is True
+
+    kinds = [e["event"] for e in events]
+    assert "pause" in kinds
+    assert "terminated" in kinds
+    # request_id is echoed on results.
+    results = {e["request_id"]: e for e in events if e["event"] == "result"}
+    assert results[1]["command"] == "info"
+    assert results[3]["output"] == ["bound = 1.04943"]
+    # the whole stream is strict-JSON clean (no Infinity/NaN).
+    for e in events:
+        _json.loads(_json.dumps(e, allow_nan=False))

--- a/python/tests/test_debug_bnb.py
+++ b/python/tests/test_debug_bnb.py
@@ -571,3 +571,91 @@ def test_json_result_ok_flag():
     assert results[1]["ok"] is False
     assert results[2]["ok"] is False
     assert results[3]["ok"] is True
+
+
+# ── nits: run-N one-shot, strict make_session ────────────────────────────────
+
+
+@pytest.mark.unit
+def test_run_is_one_shot_and_break_del_clears_temp():
+    """`run N` pauses once at iteration N without leaving a breakpoint behind,
+    and `break del N` clears one-shot breaks too."""
+    eng = DebugCommandEngine()
+    sess = DebugSession(RecordingFrontend())
+    ctx0 = DebugContext.build(debug.Checkpoint.ITER_START, tree=FakeTree(), iteration=0)
+    res = eng.execute("run 3", ctx0, sess)
+    assert res.control is Control.CONTINUE
+    assert 3 in eng.temp_breaks and 3 not in eng.iter_breaks
+    ctx3 = DebugContext.build(debug.Checkpoint.ITER_START, tree=FakeTree(), iteration=3)
+    assert eng.hit_reason(ctx3) == "iteration 3"
+    assert eng.hit_reason(ctx3) is None  # consumed: nothing left behind
+    # break del also clears a pending one-shot
+    eng.execute("run 7", ctx0, sess)
+    eng.execute("break del 7", ctx0, sess)
+    ctx7 = DebugContext.build(debug.Checkpoint.ITER_START, tree=FakeTree(), iteration=7)
+    assert eng.hit_reason(ctx7) is None
+
+
+@pytest.mark.unit
+def test_make_session_rejects_unknown_mode():
+    """A typo'd debug= string raises instead of silently opening the REPL."""
+    with pytest.raises(ValueError, match="unknown mode"):
+        debug.make_session("jsn")
+    with pytest.raises(ValueError, match="unknown mode"):
+        debug.make_session("onerror")
+    # The documented forms still work.
+    assert debug.make_session(True) is not None
+    assert debug.make_session("on-error").enter_on_error is True
+
+
+# ── nits: thread-local attachment ────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_attachment_is_thread_local():
+    """Attaching in one thread must not leak into another: each thread's solves
+    see only its own session."""
+    import threading
+
+    sess = DebugSession(RecordingFrontend())
+    debug.attach(sess)
+    try:
+        seen_in_thread = []
+
+        def worker():
+            seen_in_thread.append(debug.current())
+            # Attaching in the worker must not clobber the main thread either.
+            debug.attach(DebugSession(RecordingFrontend()))
+            debug.detach()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert seen_in_thread == [None], "main-thread session leaked into worker"
+        assert debug.current() is sess, "worker attach/detach clobbered main thread"
+    finally:
+        debug.detach()
+
+
+# ── nits: Ctrl-C on the pure-Rust path aborts, not swallowed ─────────────────
+
+
+@pytest.mark.smoke
+def test_rust_milp_keyboard_interrupt_aborts():
+    """KeyboardInterrupt raised by the frontend on the pure-Rust MILP path
+    stops the search and re-raises — it must not be swallowed into a
+    normal-looking result."""
+
+    class InterruptFrontend:
+        def interact(self, ctx, session):
+            raise KeyboardInterrupt
+
+    debug.attach(DebugSession(InterruptFrontend()))
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            _pure_milp_model().solve(time_limit=15.0, nlp_solver="simplex")
+    finally:
+        debug.detach()
+    # The debugger machinery is still healthy afterward.
+    res = _pure_milp_model().solve(time_limit=15.0, nlp_solver="simplex")
+    assert res.status == "optimal"

--- a/python/tests/test_debug_bnb.py
+++ b/python/tests/test_debug_bnb.py
@@ -43,6 +43,8 @@ class FakeTree:
     def inject_incumbent(self, sol, obj):
         if self._inc is None or obj < self._inc[1]:
             self._inc = (np.asarray(sol, dtype=float), float(obj))
+            return True
+        return False
 
     def set_branch_hints(self, ids, vhint):
         self.hint = (list(ids), list(vhint))
@@ -63,7 +65,26 @@ class RecordingFrontend:
         return self._control
 
 
-def _batch_ctx(tree, checkpoint):
+def _true_obj(x):
+    """The 'true objective' the fake validator evaluates: sum + 2.9."""
+    return float(np.sum(x)) + 2.9
+
+
+def _fake_validator(feasible=True):
+    """Validator double matching discopt.debug.steer.Validator: the candidate
+    is 'feasible' iff requested, and its true objective is _true_obj(x) — which
+    deliberately differs from the relaxation bound in result_lbs."""
+
+    def validate(x):
+        xv = np.asarray(x, dtype=np.float64).copy()
+        if not feasible:
+            return False, xv, float("nan")
+        return True, xv, _true_obj(xv)
+
+    return validate
+
+
+def _batch_ctx(tree, checkpoint, validator=None):
     return DebugContext.build(
         checkpoint,
         tree=tree,
@@ -72,9 +93,10 @@ def _batch_ctx(tree, checkpoint):
         batch_lb=np.array([[0.0, 0.0]]),
         batch_ub=np.array([[1.0, 1.0]]),
         batch_ids=np.array([11]),
-        result_lbs=np.array([3.9]),
+        result_lbs=np.array([3.5]),
         result_sols=np.array([[0.5, 0.5]]),
         result_feas=np.array([True]),
+        validator=validator,
     )
 
 
@@ -123,29 +145,67 @@ def test_iteration_breakpoint_and_tbreak_one_shot():
 
 
 @pytest.mark.unit
-def test_inject_adopts_improving_incumbent():
+def test_inject_adopts_validated_true_objective_not_relax_bound():
+    """An adopted incumbent carries the validator's TRUE objective, never the
+    relaxation bound in result_lbs (which would fabricate an incumbent)."""
     tree = FakeTree(inc=(np.array([1.0, 2.0]), 5.05))
-    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT)
-    adopted = ctx.steer.inject(ctx.result_sols[0], float(ctx.result_lbs[0]))
+    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT, validator=_fake_validator())
+    adopted, obj, reason = ctx.steer.inject(ctx.result_sols[0])
     assert adopted is True
+    assert reason == "adopted"
+    # true objective 3.9 = _true_obj([0.5, 0.5]); relax bound is 3.5.
+    assert obj == pytest.approx(3.9)
     assert tree.incumbent()[1] == pytest.approx(3.9)
+    assert tree.incumbent()[1] != pytest.approx(float(ctx.result_lbs[0]))
 
 
 @pytest.mark.unit
-def test_inject_rejects_worse_incumbent():
+def test_inject_rejects_non_improving_candidate():
     tree = FakeTree(inc=(np.array([1.0, 2.0]), 1.0))
-    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT)
-    adopted = ctx.steer.inject(ctx.result_sols[0], 9.9)
+    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT, validator=_fake_validator())
+    adopted, obj, reason = ctx.steer.inject(ctx.result_sols[0])
     assert adopted is False
+    assert obj == pytest.approx(3.9)
+    assert "not strictly improving" in reason
     assert tree.incumbent()[1] == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_inject_rejects_infeasible_candidate():
+    """A candidate the validator rules infeasible never reaches the tree."""
+    tree = FakeTree(inc=(np.array([1.0, 2.0]), 5.05))
+    validator = _fake_validator(feasible=False)
+    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT, validator=validator)
+    adopted, obj, reason = ctx.steer.inject(ctx.result_sols[0])
+    assert adopted is False
+    assert obj is None
+    assert "infeasible" in reason
+    assert tree.incumbent()[1] == pytest.approx(5.05)  # untouched
+
+
+@pytest.mark.unit
+def test_inject_refuses_without_validator():
+    """No validator wired => inject refuses loudly rather than trusting the
+    caller (certificate safety, CLAUDE.md §1)."""
+    tree = FakeTree()
+    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT)  # validator=None
+    assert ctx.steer.can_inject is False
+    with pytest.raises(RuntimeError, match="no candidate validator"):
+        ctx.steer.inject(ctx.result_sols[0])
+    # The engine command reports it as unavailable instead of raising.
+    eng = DebugCommandEngine()
+    sess = DebugSession(RecordingFrontend())
+    res = eng.execute("inject 0", ctx, sess)
+    assert any("inject unavailable" in line for line in res.output)
+    assert tree.incumbent() is None  # nothing was injected
 
 
 @pytest.mark.unit
 def test_inject_refuses_nonfinite():
     tree = FakeTree()
-    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT)
+    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT, validator=_fake_validator())
     with pytest.raises(ValueError):
-        ctx.steer.inject(np.array([np.nan, 0.0]), 1.0)
+        ctx.steer.inject(np.array([np.nan, 0.0]))
 
 
 @pytest.mark.unit
@@ -238,6 +298,32 @@ def test_no_op_debugger_is_bound_neutral():
 
     assert dbg.node_count == base.node_count
     assert dbg.objective == base.objective  # exact, not approx
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_inject_cannot_corrupt_certificate(capsys):
+    """Regression for the unvalidated-inject hole: steering ``inject`` at the
+    BEFORE_IMPORT checkpoint must never change the certified optimum. The
+    candidate (a relaxation solution) is validated against the original
+    problem; an infeasible point is rejected outright, and a feasible one is
+    injected with its true evaluated objective — so the certificate is
+    identical either way. Before the fix, the relaxation *bound* was adopted
+    as the incumbent objective and the solve certified a wrong optimum."""
+    base = _spatial_model().solve(time_limit=20.0)
+    assert base.status == "optimal"
+
+    script = ["stop-at steer", "continue", "inject 0", "continue"]
+    debug.attach(debug.make_session(script=script))
+    try:
+        res = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+
+    err = capsys.readouterr().err
+    assert "inject node[0]" in err, "the inject command never ran"
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(base.objective, rel=1e-6, abs=1e-6)
 
 
 @pytest.mark.smoke

--- a/python/tests/test_debug_bnb.py
+++ b/python/tests/test_debug_bnb.py
@@ -346,3 +346,64 @@ def test_json_protocol_handshake_and_events():
     # the whole stream is strict-JSON clean (no Infinity/NaN).
     for e in events:
         _json.loads(_json.dumps(e, allow_nan=False))
+
+
+# ── pure-Rust MILP fast-path (PyO3 checkpoint hook) ──────────────────────────
+
+
+def _pure_milp_model():
+    """A pure binary knapsack that routes to the Rust ``solve_milp`` fast-path
+    (``nlp_solver='simplex'``) — the loop that runs entirely in Rust."""
+    m = do.Model("dbg_milp")
+    xs = [m.integer(f"x{i}", lb=0, ub=1) for i in range(10)]
+    vals = [8, 5, 3, 6, 4, 7, 9, 2, 5, 6]
+    wts = [5, 3, 2, 4, 3, 5, 6, 1, 2, 4]
+    m.subject_to(sum(w * xi for w, xi in zip(wts, xs)) <= 14)
+    m.maximize(sum(v * xi for v, xi in zip(vals, xs)))
+    return m
+
+
+@pytest.mark.smoke
+def test_rust_milp_hook_fires_across_pyo3():
+    fe = RecordingFrontend(walk=True)
+    debug.attach(DebugSession(fe))
+    try:
+        res = _pure_milp_model().solve(time_limit=15.0, nlp_solver="simplex")
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    seen = set(fe.hits)
+    # the Rust hook fires the aggregate checkpoints (no per-node batch on this path)
+    assert "iter_start" in seen
+    assert "after_process" in seen
+    assert "terminated" in seen
+
+
+@pytest.mark.smoke
+def test_rust_milp_hook_is_bound_neutral():
+    """A no-op debugger must not perturb the pure-Rust MILP search."""
+    base = _pure_milp_model().solve(time_limit=15.0, nlp_solver="simplex")
+
+    debug.attach(DebugSession(RecordingFrontend(control=Control.CONTINUE)))
+    try:
+        dbg = _pure_milp_model().solve(time_limit=15.0, nlp_solver="simplex")
+    finally:
+        debug.detach()
+
+    assert dbg.node_count == base.node_count
+    assert dbg.objective == base.objective
+
+
+@pytest.mark.smoke
+def test_rust_milp_quit_stops_early():
+    class QuitFrontend:
+        def interact(self, ctx, session):
+            return Control.QUIT
+
+    debug.attach(DebugSession(QuitFrontend()))
+    try:
+        res = _pure_milp_model().solve(time_limit=15.0, nlp_solver="simplex")
+    finally:
+        debug.detach()
+    # Aborted before proving optimality -> a valid, non-"optimal" partial result.
+    assert res.status in ("feasible", "node_limit", "time_limit")

--- a/python/tests/test_debug_bnb.py
+++ b/python/tests/test_debug_bnb.py
@@ -491,5 +491,7 @@ def test_rust_milp_quit_stops_early():
         res = _pure_milp_model().solve(time_limit=15.0, nlp_solver="simplex")
     finally:
         debug.detach()
-    # Aborted before proving optimality -> a valid, non-"optimal" partial result.
-    assert res.status in ("feasible", "node_limit", "time_limit")
+    # Aborted before proving optimality -> a valid, uncertified partial result:
+    # never a false "optimal"/"infeasible", and no fallback engine silently
+    # resumes a solve the user quit.
+    assert res.status in ("feasible", "node_limit", "time_limit", "unknown")

--- a/python/tests/test_debug_bnb.py
+++ b/python/tests/test_debug_bnb.py
@@ -495,3 +495,79 @@ def test_rust_milp_quit_stops_early():
     # never a false "optimal"/"infeasible", and no fallback engine silently
     # resumes a solve the user quit.
     assert res.status in ("feasible", "node_limit", "time_limit", "unknown")
+
+
+# ── on-error mode & protocol honesty ─────────────────────────────────────────
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_on_error_pauses_only_on_failure():
+    """``debug="on-error"``: no pause on a certified optimum; exactly one
+    pause at TERMINATED when the solve fails (error = the final status)."""
+    ok = RecordingFrontend()
+    debug.attach(DebugSession(ok, enter_on_error=True))
+    try:
+        res = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    assert ok.hits == [], "on-error session paused on a successful solve"
+
+    fail = RecordingFrontend()
+    debug.attach(DebugSession(fail, enter_on_error=True))
+    try:
+        res = _spatial_model().solve(time_limit=0.05)
+    finally:
+        debug.detach()
+    assert res.status != "optimal"
+    assert fail.hits == ["terminated"], f"expected one terminated pause, got {fail.hits}"
+
+
+@pytest.mark.unit
+def test_handshake_advertises_only_wired_checkpoints():
+    """Every checkpoint in the hello handshake has a live fire-site — no dead
+    vocabulary a client could wait on forever."""
+    from discopt.debug.jsonproto import JsonFrontend
+
+    hello = JsonFrontend()._hello()
+    assert hello["checkpoints"] == [
+        "iter_start",
+        "after_select",
+        "before_import",
+        "after_process",
+        "incumbent_found",
+        "terminated",
+    ]
+
+
+@pytest.mark.unit
+def test_stop_at_unwired_checkpoint_errors_cleanly():
+    eng = DebugCommandEngine()
+    sess = DebugSession(RecordingFrontend())
+    ctx = DebugContext.build(debug.Checkpoint.ITER_START, tree=FakeTree(), iteration=0)
+    res = eng.execute("stop-at tighten", ctx, sess)
+    assert res.ok is False
+    assert any("error" in line for line in res.output)
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_json_result_ok_flag():
+    """Agents can branch on ``ok``: False for unknown/unavailable commands,
+    True for successful ones."""
+    res, events = _drive_json(
+        _spatial_model(),
+        [
+            {"cmd": "bogus", "id": 1},
+            {"cmd": "inject", "args": ["0"], "id": 2},  # no batch at iter_start
+            {"cmd": "info", "id": 3},
+            "continue",
+            "continue",
+        ],
+    )
+    assert res.status == "optimal"
+    results = {e["request_id"]: e for e in events if e["event"] == "result"}
+    assert results[1]["ok"] is False
+    assert results[2]["ok"] is False
+    assert results[3]["ok"] is True

--- a/python/tests/test_debug_bnb.py
+++ b/python/tests/test_debug_bnb.py
@@ -1,0 +1,263 @@
+"""Tests for the interactive branch-and-bound debugger (``discopt.debug``).
+
+Covers three things:
+  * pure-logic units (command engine, condition parsing, safe-steer) with a
+    fake tree, no solver — marked ``unit``;
+  * end-to-end checkpoint firing on a real spatial-McCormick solve;
+  * the correctness gate: a no-op debugger is **bound-neutral** (identical
+    ``node_count`` and objective vs. no debugger), per CLAUDE.md §5.
+"""
+
+from __future__ import annotations
+
+import discopt as do
+import numpy as np
+import pytest
+from discopt import debug
+from discopt.debug.context import DebugContext
+from discopt.debug.engine import Control, DebugCommandEngine
+from discopt.debug.session import DebugSession
+
+# ── fakes ───────────────────────────────────────────────────────────────────
+
+
+class FakeTree:
+    """Minimal stand-in for PyTreeManager used by the unit tests."""
+
+    def __init__(self, inc=None, stats=None):
+        self._inc = inc
+        self._stats = stats or {
+            "total_nodes": 7,
+            "open_nodes": 3,
+            "global_lower_bound": 4.2,
+            "gap": 0.12,
+        }
+        self.hint = None
+
+    def stats(self):
+        return self._stats
+
+    def incumbent(self):
+        return self._inc
+
+    def inject_incumbent(self, sol, obj):
+        if self._inc is None or obj < self._inc[1]:
+            self._inc = (np.asarray(sol, dtype=float), float(obj))
+
+    def set_branch_hints(self, ids, vhint):
+        self.hint = (list(ids), list(vhint))
+
+
+class RecordingFrontend:
+    """Records every checkpoint it is asked to interact at, then resumes."""
+
+    def __init__(self, control=Control.CONTINUE, walk=False):
+        self.hits: list[str] = []
+        self._control = control
+        self._walk = walk
+
+    def interact(self, ctx, session):
+        self.hits.append(ctx.checkpoint.value)
+        if self._walk and ctx.checkpoint.value != "terminated":
+            return Control.STEPI
+        return self._control
+
+
+def _batch_ctx(tree, checkpoint):
+    return DebugContext.build(
+        checkpoint,
+        tree=tree,
+        iteration=0,
+        elapsed=0.1,
+        batch_lb=np.array([[0.0, 0.0]]),
+        batch_ub=np.array([[1.0, 1.0]]),
+        batch_ids=np.array([11]),
+        result_lbs=np.array([3.9]),
+        result_sols=np.array([[0.5, 0.5]]),
+        result_feas=np.array([True]),
+    )
+
+
+# ── unit: command engine ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_conditional_breakpoint_fires_on_metric():
+    eng = DebugCommandEngine()
+    tree = FakeTree()
+    sess = DebugSession(RecordingFrontend())
+    ctx = DebugContext.build(debug.Checkpoint.ITER_START, tree=tree, iteration=0)
+    eng.execute("break if gap<0.2", ctx, sess)
+    assert eng.hit_reason(ctx) == "condition: gap<0.2"
+    # A condition that does not hold does not fire.
+    eng2 = DebugCommandEngine()
+    eng2.execute("break if gap<0.05", ctx, sess)
+    assert eng2.hit_reason(ctx) is None
+
+
+@pytest.mark.unit
+def test_compound_condition_and_rejects_or():
+    eng = DebugCommandEngine()
+    sess = DebugSession(RecordingFrontend())
+    ctx = DebugContext.build(
+        debug.Checkpoint.ITER_START, tree=FakeTree(inc=(np.zeros(2), 5.0)), iteration=12
+    )
+    eng.execute("break if iter>10 && gap<0.2", ctx, sess)
+    assert eng.hit_reason(ctx) is not None
+    res = eng.execute("break if gap<0.2 || iter>3", ctx, sess)
+    assert any("||" in line for line in res.output)
+
+
+@pytest.mark.unit
+def test_iteration_breakpoint_and_tbreak_one_shot():
+    eng = DebugCommandEngine()
+    sess = DebugSession(RecordingFrontend())
+    ctx5 = DebugContext.build(debug.Checkpoint.ITER_START, tree=FakeTree(), iteration=5)
+    eng.execute("tbreak 5", ctx5, sess)
+    assert eng.hit_reason(ctx5) == "iteration 5"
+    # one-shot: does not fire a second time
+    assert eng.hit_reason(ctx5) is None
+
+
+# ── unit: safe steer ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_inject_adopts_improving_incumbent():
+    tree = FakeTree(inc=(np.array([1.0, 2.0]), 5.05))
+    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT)
+    adopted = ctx.steer.inject(ctx.result_sols[0], float(ctx.result_lbs[0]))
+    assert adopted is True
+    assert tree.incumbent()[1] == pytest.approx(3.9)
+
+
+@pytest.mark.unit
+def test_inject_rejects_worse_incumbent():
+    tree = FakeTree(inc=(np.array([1.0, 2.0]), 1.0))
+    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT)
+    adopted = ctx.steer.inject(ctx.result_sols[0], 9.9)
+    assert adopted is False
+    assert tree.incumbent()[1] == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_inject_refuses_nonfinite():
+    tree = FakeTree()
+    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT)
+    with pytest.raises(ValueError):
+        ctx.steer.inject(np.array([np.nan, 0.0]), 1.0)
+
+
+@pytest.mark.unit
+def test_hint_records_reordering():
+    tree = FakeTree()
+    ctx = _batch_ctx(tree, debug.Checkpoint.BEFORE_IMPORT)
+    ctx.steer.hint([11], [1])
+    assert tree.hint == ([11], [1])
+
+
+# ── unit: fire hot-path ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_fire_is_noop_when_detached():
+    debug.detach()
+    assert debug.fire(debug.Checkpoint.ITER_START, tree=FakeTree()) is False
+    assert not debug.is_attached()
+
+
+@pytest.mark.unit
+def test_quit_requests_stop():
+    class QuitFrontend:
+        def interact(self, ctx, session):
+            return Control.QUIT
+
+    sess = DebugSession(QuitFrontend())
+    debug.attach(sess)
+    try:
+        stop = debug.fire(debug.Checkpoint.ITER_START, tree=FakeTree(), iteration=0)
+        assert stop is True
+        assert sess.stop_requested
+    finally:
+        debug.detach()
+
+
+# ── end-to-end on a real spatial-McCormick solve ─────────────────────────────
+
+
+def _spatial_model():
+    """A nonconvex MINLP (transcendental + bilinear) that routes to the
+    spatial-McCormick B&B loop instrumented by the debugger."""
+    m = do.Model("dbg_e2e")
+    x = m.continuous("x", lb=0.1, ub=4.0)
+    y = m.continuous("y", lb=0.1, ub=4.0)
+    z = m.integer("z", lb=0, ub=3)
+    m.subject_to(x * y + z >= 3.0)
+    m.subject_to(y == do.exp(x) - 1.0)
+    m.minimize(x + 0.5 * y + 0.3 * z)
+    return m
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_checkpoints_fire_in_lifecycle_order():
+    fe = RecordingFrontend(walk=True)
+    debug.attach(DebugSession(fe))
+    try:
+        res = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    seen = set(fe.hits)
+    # every wired checkpoint is reached
+    for cp in (
+        "iter_start",
+        "after_select",
+        "before_import",
+        "after_process",
+        "terminated",
+    ):
+        assert cp in seen, f"{cp} never fired; saw {seen}"
+    # order within an iteration is select -> import -> process
+    i_sel = fe.hits.index("after_select")
+    assert fe.hits.index("before_import") > i_sel
+    assert fe.hits.index("after_process") > fe.hits.index("before_import")
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_no_op_debugger_is_bound_neutral():
+    """CLAUDE.md §5: an attached no-op debugger must not perturb the search."""
+    base = _spatial_model().solve(time_limit=20.0)
+
+    debug.attach(DebugSession(RecordingFrontend(control=Control.CONTINUE)))
+    try:
+        dbg = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+
+    assert dbg.node_count == base.node_count
+    assert dbg.objective == base.objective  # exact, not approx
+
+
+@pytest.mark.smoke
+@pytest.mark.requires_pounce
+def test_scripted_repl_end_to_end(capsys):
+    """Drive the human REPL with a scripted command stream (no TTY)."""
+    script = [
+        "info",
+        "break if nodes>=2",
+        "continue",
+        "print bound",
+        "continue",
+    ]
+    sess = debug.make_session(script=script)
+    debug.attach(sess)
+    try:
+        res = _spatial_model().solve(time_limit=20.0)
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    err = capsys.readouterr().err
+    assert "paused at" in err
+    assert "discopt-dbg" in err

--- a/python/tests/test_debug_bnb.py
+++ b/python/tests/test_debug_bnb.py
@@ -514,10 +514,13 @@ def test_on_error_pauses_only_on_failure():
     assert res.status == "optimal"
     assert ok.hits == [], "on-error session paused on a successful solve"
 
+    # time_limit=0.0 fails deterministically: the loop's first elapsed check
+    # breaks immediately, so even a fully warm solve cannot certify (a small
+    # positive limit races the JAX cache and flakes on fast machines).
     fail = RecordingFrontend()
     debug.attach(DebugSession(fail, enter_on_error=True))
     try:
-        res = _spatial_model().solve(time_limit=0.05)
+        res = _spatial_model().solve(time_limit=0.0)
     finally:
         debug.detach()
     assert res.status != "optimal"

--- a/python/tests/test_debug_cli.py
+++ b/python/tests/test_debug_cli.py
@@ -1,0 +1,72 @@
+"""Tests for the ``python -m discopt.debug`` CLI entry point.
+
+Kept in a separate module from ``test_debug_bnb.py`` so the CLI surface can grow
+without churning the core debugger tests.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from discopt.debug import __main__ as cli
+
+_TINY_NL = Path(__file__).parent / "data" / "minlplib_nl" / "st_miqp3.nl"
+
+
+# ── unit: argument parsing and helpers (no solve) ────────────────────────────
+
+
+@pytest.mark.unit
+def test_resolve_kind_maps_flags():
+    parse = cli.build_parser().parse_args
+    assert cli._resolve_kind(parse(["m.nl"])) is True  # REPL
+    assert cli._resolve_kind(parse(["m.nl", "--json"])) == "json"
+    assert cli._resolve_kind(parse(["m.nl", "--on-error"])) == "on-error"
+
+
+@pytest.mark.unit
+def test_json_and_on_error_are_mutually_exclusive():
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args(["m.nl", "--json", "--on-error"])
+
+
+@pytest.mark.unit
+def test_read_script_strips_comments_and_blanks(tmp_path):
+    f = tmp_path / "cmds.pdbg"
+    f.write_text("# a comment\n\ninfo\n// slash comment\ncontinue\n")
+    assert cli._read_script(str(f)) == ["info", "continue"]
+    assert cli._read_script(None) is None
+
+
+@pytest.mark.unit
+def test_missing_model_file_returns_error_code():
+    err = io.StringIO()
+    rc = cli.main(["/no/such/model.nl"], err=err)
+    assert rc == 2
+    assert "could not load" in err.getvalue() or "no such model" in err.getvalue()
+
+
+@pytest.mark.unit
+def test_script_with_json_is_rejected():
+    err = io.StringIO()
+    rc = cli.main(["m.nl", "--json", "--script", "x"], err=err)
+    assert rc == 2
+    assert "--script applies to the human REPL only" in err.getvalue()
+
+
+# ── integration: a real scripted solve through the CLI ───────────────────────
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not _TINY_NL.exists(), reason="minlplib_nl test corpus absent")
+def test_cli_runs_scripted_repl_solve(tmp_path):
+    script = tmp_path / "cmds.pdbg"
+    script.write_text("info\nbreak if nodes>=1\ncontinue\nprint bound\ncontinue\n")
+    err = io.StringIO()
+    rc = cli.main([str(_TINY_NL), "--script", str(script), "--time-limit", "20"], err=err)
+    assert rc == 0
+    out = err.getvalue()
+    assert "status=optimal" in out
+    assert "paused at" in out  # the scripted debugger actually ran

--- a/python/tests/test_debug_rust_milp.py
+++ b/python/tests/test_debug_rust_milp.py
@@ -1,0 +1,130 @@
+"""Tests for the pure-Rust MILP debugger hook and its node-box inspection.
+
+Kept separate from ``test_debug_bnb.py`` so the Rust-fast-path surface can evolve
+without churning the core debugger tests. Exercises the ``after_select``
+checkpoint that marshals per-node boxes across the PyO3 boundary.
+"""
+
+from __future__ import annotations
+
+import discopt as do
+import pytest
+from discopt import debug
+from discopt.debug.context import DebugContext
+from discopt.debug.engine import Control
+from discopt.debug.session import DebugSession
+
+# ── unit: DebugContext.from_rust batch marshaling ────────────────────────────
+
+
+@pytest.mark.unit
+def test_from_rust_populates_batch_boxes():
+    ctx = DebugContext.from_rust(
+        {
+            "checkpoint": "after_select",
+            "iteration": 2,
+            "nodes": 5,
+            "open_nodes": 2,
+            "incumbent": None,
+            "bound": 3.0,
+            "gap": 0.5,
+            "elapsed": 0.4,
+            "batch_lb": [[0.0, 0.0], [0.0, 1.0]],
+            "batch_ub": [[1.0, 1.0], [1.0, 1.0]],
+            "batch_ids": [7, 8],
+            "n_vars": 2,
+        }
+    )
+    assert ctx.checkpoint is debug.Checkpoint.AFTER_SELECT
+    assert ctx.n_batch == 2
+    assert ctx.batch_lb.shape == (2, 2)
+    assert int(ctx.batch_ids[1]) == 8
+    assert ctx.steer is None  # no tree on the Rust path
+
+
+@pytest.mark.unit
+def test_from_rust_without_batch_is_aggregate_only():
+    ctx = DebugContext.from_rust({"checkpoint": "iter_start", "nodes": 3})
+    assert ctx.n_batch == 0
+    assert ctx.batch_lb is None
+
+
+# ── unit: print node <i> renders a Rust-path box ─────────────────────────────
+
+
+@pytest.mark.unit
+def test_print_node_on_rust_context():
+    ctx = DebugContext.from_rust(
+        {
+            "checkpoint": "after_select",
+            "batch_lb": [[0.0, 2.0]],
+            "batch_ub": [[1.0, 5.0]],
+            "batch_ids": [42],
+            "n_vars": 2,
+        }
+    )
+    sess = DebugSession(_NullFrontend())
+    res = sess.engine.execute("print node 0", ctx, sess)
+    assert "id=42" in res.output[0]
+    assert res.data["lb"] == [0.0, 2.0]
+    assert res.data["ub"] == [1.0, 5.0]
+
+
+class _NullFrontend:
+    def interact(self, ctx, session):
+        return Control.CONTINUE
+
+
+# ── integration: real pure-Rust MILP solve ──────────────────────────────────
+
+
+def _knapsack():
+    m = do.Model("dbg_rust_milp")
+    xs = [m.integer(f"x{i}", lb=0, ub=1) for i in range(10)]
+    vals = [8, 5, 3, 6, 4, 7, 9, 2, 5, 6]
+    wts = [5, 3, 2, 4, 3, 5, 6, 1, 2, 4]
+    m.subject_to(sum(w * xi for w, xi in zip(wts, xs)) <= 14)
+    m.maximize(sum(v * xi for v, xi in zip(vals, xs)))
+    return m
+
+
+@pytest.mark.smoke
+def test_rust_milp_after_select_exposes_node_boxes():
+    captured: dict = {}
+
+    class Inspect:
+        def interact(self, ctx, session):
+            if ctx.checkpoint.value == "after_select" and "box" not in captured:
+                captured["n_batch"] = ctx.n_batch
+                captured["box"] = session.engine.execute("print node 0", ctx, session)
+            if ctx.checkpoint.value == "terminated":
+                return Control.CONTINUE
+            return Control.STEPI
+
+    debug.attach(DebugSession(Inspect()))
+    try:
+        res = _knapsack().solve(time_limit=15.0, nlp_solver="simplex")
+    finally:
+        debug.detach()
+    assert res.status == "optimal"
+    assert captured["n_batch"] >= 1
+    assert "id=" in captured["box"].output[0]
+    assert captured["box"].data is not None  # real box data crossed PyO3
+
+
+@pytest.mark.smoke
+def test_rust_milp_after_select_bound_neutral():
+    """The added after_select fire-site must not perturb the search."""
+    base = _knapsack().solve(time_limit=15.0, nlp_solver="simplex")
+
+    class Noop:
+        def interact(self, ctx, session):
+            return Control.CONTINUE
+
+    debug.attach(DebugSession(Noop()))
+    try:
+        dbg = _knapsack().solve(time_limit=15.0, nlp_solver="simplex")
+    finally:
+        debug.detach()
+    assert dbg.node_count == base.node_count
+    assert dbg.objective == base.objective


### PR DESCRIPTION
## Summary

Adds an interactive branch-and-bound debugger (`discopt.debug`) that pauses a solve at well-defined node-lifecycle checkpoints, allowing inspection of tree state, incumbent, relaxations, and safe steering (inject incumbent, branch hints). The debugger is **bound-neutral when detached** — every fire-site is a single `None` check with lazy context building, so an unattached solve is bit-for-bit identical.

## Key Changes

### Python Debugger Infrastructure (`python/discopt/debug/`)
- **`__init__.py`**: Module-level API (`attach()`, `detach()`, `fire()`, `make_session()`) with global session state. Fire-sites short-circuit when detached.
- **`checkpoints.py`**: Checkpoint vocabulary (ITER_START, AFTER_SELECT, BEFORE_IMPORT, AFTER_PROCESS, INCUMBENT_FOUND, TERMINATED) mirroring B&B node lifecycle.
- **`context.py`**: `DebugContext` — read-mostly snapshot of solver state (aggregate tree stats + per-node batch arrays) built lazily only when debugger is attached.
- **`engine.py`**: `DebugCommandEngine` — frontend-agnostic command interpreter owning breakpoint state (iteration, conditional, event breakpoints) and command dispatch. Supports:
  - Iteration breakpoints (`break N`, `tbreak N`)
  - Conditional breakpoints (`break if gap<0.2 && nodes>10`) with AND-only logic
  - Event breakpoints (`break on incumbent_found`)
  - Inspection commands (`info`, `print`, `watch`)
  - Safe steering (`inject`, `hint`)
- **`session.py`**: `DebugSession` — pause-decision state machine over the engine. Decides whether to pause at each checkpoint (based on step mode + breakpoints) and mediates frontend interaction.
- **`steer.py`**: `DebugSteer` — certificate-safe steering handle. `inject()` offers a candidate incumbent (tree re-validates); `hint()` reorders branching. Neither can loosen bounds or fabricate incumbents.
- **`repl.py`**: Human REPL frontend with readline support (TTY) and fallback plain reader (pipes/scripts). Prints pause banner and reads commands until resume verb.
- **`jsonproto.py`**: Newline-delimited JSON protocol frontend for agent/LLM/GUI control. Mirrors REPL semantics exactly via shared `DebugCommandEngine`. Emits `hello` handshake advertising checkpoints/events/commands/metrics, then `pause`/`terminated` events with state, reads command objects until resume.

### Solver Integration (`python/discopt/solver.py`)
- Inserted 5 checkpoint fire-sites in the spatial-McCormick B&B loop:
  - `ITER_START`: top of batch iteration
  - `AFTER_SELECT`: after nodes selected from tree (batch_lb/ub/ids available)
  - `BEFORE_IMPORT`: steer point (relaxations solved, results not yet imported to tree)
  - `AFTER_PROCESS`: after prune/branch/fathom applied by tree
  - `INCUMBENT_FOUND`: event checkpoint when new incumbent adopted
  - `TERMINATED`: final checkpoint (optimal/limit/infeasible)
- Each fire-site passes relevant loop locals (tree, model, iteration, elapsed, batch arrays, result arrays) to `debug.fire()`.
- Added `debug` parameter to `Model.solve()` accepting `True`/`"repl"`/`"on-error"`/`DebugSession`.

### Rust MILP Fast-Path (`crates/discopt-core/src/bnb/milp_driver.rs`)
- Added `MilpCheckpoint` enum (IterStart, AfterProcess, IncumbentFound, Terminated).
- Added `MilpDebugState` struct (checkpoint, iteration, node counts, incumbent, bound, gap, elapsed).
- Added `MilpDebugControl` enum (Continue, Stop).
- Added `MilpDebugHook` trait (Sync,

https://claude.ai/code/session_01VLfKfSoPkx5wbN1rRFc3or