### PR TITLE
perf(separation): F3 — route multilinear separator LPs to the warm simplex (nvs09)

### DIFF
--- a/docs/dev/bottleneck-profile-2026-07-05.md
+++ b/docs/dev/bottleneck-profile-2026-07-05.md
@@ -361,6 +361,41 @@ overwritten:
    F1; the §7 F1 tls2 line is reassigned to F4. F1's class win (the
    `sum_r C(n,r)` enumeration blow-up on the ≤12-binary early-incumbent
    class) is confirmed and delivered.
+8. **"F3 collapses nvs09's separation cost ~10–50× (nodes/s ≥10×, share
+   <20 %)"** (§7 F3 acceptance; §1.3 "the same swap that gave 10–50× on the
+   other separators applies"). *Correction (F3 implementation,
+   `perf-f3-multilinear-separator-simplex`, pounce 0.7.0, M4 Pro):* the entry
+   experiment falsifies the uniform-10× premise for **this** LP class. The
+   multilinear hull LP is `min/max f(v)·λ s.t. Vᵀλ = x*, 1ᵀλ = 1, λ ≥ 0` with
+   `2^n` λ columns — **not** a row-augmented re-solve, so the "warm" in the
+   swap is cold-simplex-vs-IPM, exactly like #484's edge-concave routing (no
+   cross-call basis reuse; `lp_simplex.solve_lp` is documented cold). On
+   nvs09, `n`≈10 → **1024-column** hull LPs: a per-LP A/B shows the cold Rust
+   simplex is **bimodal** — it solves ~81 % of them in **≈1 ms (100× faster
+   than POUNCE's ~150 ms)** but on the remaining ~19 % (degenerate/
+   ill-conditioned widest LPs) it **stalls to its 100 000-pivot default
+   (~1.6 s)**, worse than POUNCE. (Bonus soundness note: the hull LP's
+   feasible set `{λ ≥ 0, Σλ = 1}` is a simplex — *provably bounded* — so
+   POUNCE's occasional `UNBOUNDED` verdict on the wide LP is a numerical
+   false-negative that **drops a valid cut**; the exact simplex recovers it,
+   and the intercept-recompute keeps every cut valid regardless of engine.)
+   The sound fix is F2's philosophy applied to the *cold* path: a size-derived
+   pivot cap → POUNCE per-LP fallback (F2's guard only covers the *warm* dual
+   re-solve, so the plan's "F2 protects the new traffic" holds only partially).
+   Result on nvs09 @60 s: simplex serves 564/698 hull LPs in 3.8 s (6.4 % of
+   wall), but the **128 POUNCE fallbacks cost 44.3 s (73 %)** — that hard
+   subset is *irreducible* (POUNCE is the better engine for it), so the
+   separation share stays ~89 % and the wall floor does not move 10×. Measured
+   deltas: **nodes/s 2.62 → 3.65 (1.4×)**, **bound@60 s −59.24 → −57.67
+   (strictly tighter, valid vs the −43.134 oracle)**, incumbent unchanged.
+   The `<20 %` share / `≥10×` nodes/s targets are **not met** and were premised
+   on separation being removable *overhead*; on nvs09 it is intrinsic bound
+   work whose hard tail is IPM-favourable. The class win (the ≤4-arity-cap
+   narrow hull LPs, ~81 % here, → ~100× per LP) is real and sound; the residual
+   nvs09 wall is the wide-LP IPM cost (a POUNCE-engine question, cf. F6/upstream
+   jkitchin/pounce#182), not a routing one. Cert panel: **provably byte-identical**
+   — no certifying instance reaches the multilinear separator (0 calls at 60 s
+   on all 41, incl. the heavy cvxnonsep/fac2/tspn05/flay02m).
 
 ---
 

--- a/docs/dev/perf-followup-plan-2026-07-05.md
+++ b/docs/dev/perf-followup-plan-2026-07-05.md
@@ -317,6 +317,26 @@ worktrees/sessions if desired, but each in its own PR.
   test (`DISCOPT_SEPARATION_LP_SIMPLEX=0` restores the old path).
 - **Acceptance:** nvs09 separation share <20 % of wall; nodes/s ≥ 10× prior;
   bound at 60 s strictly better than −59.24 (it may now certify; fine).
+- **Status: DONE with a falsified premise** (branch
+  `perf-f3-multilinear-separator-simplex`, pounce 0.7.0, M4 Pro; profile §5
+  item 8). The entry experiment falsified the uniform-10× assumption for this
+  LP class: the `2^n`-column hull LP is cold-simplex-vs-IPM (no warm re-use,
+  like #484), and on nvs09's 1024-column LPs the cold simplex is **bimodal** —
+  ~81 % solve in ≈1 ms (≈100× vs POUNCE's ~150 ms), ~19 % stall to the
+  100 000-pivot default. The kill-criterion "state the revised number" branch
+  applies. Implemented soundly: mirror #484's env
+  (`DISCOPT_SEPARATION_LP_SIMPLEX`, default ON) + intercept-recompute in
+  `multilinear_separation._solve_envelope`, plus a size-derived cold-simplex
+  pivot cap → POUNCE per-LP fallback (F2's warm-only guard does not cover the
+  cold hull LP). Measured nvs09 @60 s: **nodes/s 2.62 → 3.65 (1.4×, not 10×)**;
+  **bound −59.24 → −57.67 (strictly tighter, valid vs the −43.134 oracle)**;
+  separation share stays ~89 % because 128 wide-LP POUNCE fallbacks (44 s) are
+  IPM-favourable and irreducible by routing (a POUNCE-engine matter, cf. F6 /
+  jkitchin/pounce#182). The `<20 %`/`≥10×` targets are **not met**; the class
+  win (narrow hull LPs, ~81 % here → ~100× per LP) is real and sound. Cert
+  panel provably byte-identical (0 multilinear-separator calls at 60 s on all
+  41 certifying instances). Off-switch + soundness + fallback locked by
+  `python/tests/test_f3_multilinear_separation_lp_backend.py` (7 tests).
 
 ### F4 — Budget-gate the root heuristic NLP/compile phase  (B10 + §4; restores the `time_limit` contract)
 

--- a/python/discopt/_jax/multilinear_separation.py
+++ b/python/discopt/_jax/multilinear_separation.py
@@ -28,10 +28,41 @@ so the loop can stop at any round and the bound stays valid.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from itertools import product
 
 import numpy as np
+
+# Cold-simplex pivot cap for the multilinear vertex-hull LP. The hull LP has
+# ``2^n`` λ columns and ``n+1`` rows; on the widest ones (``n``≈10 → 1024
+# columns) the *cold* Rust simplex either converges in a few hundred pivots
+# (≈1 ms — ~100× faster than the POUNCE IPM's ~150 ms) or, on a degenerate/
+# ill-conditioned instance, spins to its 100 000-pivot default (≈1.6 s) — the
+# same stall class F2 guarded on the *warm* dual path, but the standalone hull
+# LP is solved cold. The two regimes are cleanly separated (hundreds vs 10⁵
+# pivots), so a small absolute cap detects a stall in ≈tens of ms; on a cap trip
+# (or any non-optimal exit) we fall back to POUNCE for that single LP, so no LP
+# is ever slower than the pre-F3 POUNCE baseline while the converging majority
+# gets the simplex win. The cap grows slowly with rows (``n+1``) for headroom.
+_HULL_SIMPLEX_STALL_K = 100
+_HULL_SIMPLEX_STALL_C = 500
+_HULL_SIMPLEX_STALL_MAX = 3000
+
+
+def _separation_lp_simplex_enabled() -> bool:
+    """Whether F3 routes the hull LP to the Rust simplex (env, default ON).
+
+    Honors the same ``DISCOPT_SEPARATION_LP_SIMPLEX`` flag as the edge-concave
+    separator (:func:`discopt._jax.edge_concave._separation_lp_solver`) and
+    strong branching; ``"0"`` restores the POUNCE-IPM-only path.
+    """
+    return os.environ.get("DISCOPT_SEPARATION_LP_SIMPLEX", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
 
 
 @dataclass(frozen=True)
@@ -52,39 +83,71 @@ def _solve_envelope(verts: np.ndarray, fv: np.ndarray, x_star: np.ndarray, maxim
     """Return ``(env_value, a, b)`` of the (concave if maximize) vertex envelope.
 
     The supporting-hyperplane LP ``min/max f(v)·λ s.t. Vᵀλ = x*, 1ᵀλ = 1, λ ≥ 0``
-    is solved with the pure-Rust POUNCE IPM (issue #356 — no SciPy/HiGHS). Only
-    the dual *slope* ``a`` (the marginals on the ``Vᵀλ = x*`` rows) is taken from
-    POUNCE; the intercept ``b`` is then recomputed to the exact validity boundary
-    over the box vertices — ``b = minᵥ(f(v) − a·v)`` (under) / ``maxᵥ`` (over).
-    Because a multilinear function attains its box extrema at vertices, the
-    resulting hyperplane ``a·x + b`` under/over-estimates ``f`` *everywhere*, so
-    the cut is rigorously valid for ANY slope — robust to POUNCE's analytic-center
-    dual on a degenerate LP (a different facet, still valid) or any dual sign/scale
-    convention. ``None`` if POUNCE is unavailable or the solve did not converge.
+    is solved with the in-house pure-Rust warm simplex by default (F3 lever;
+    ``DISCOPT_SEPARATION_LP_SIMPLEX=0`` restores the POUNCE IPM — see
+    :func:`_separation_lp_simplex_enabled`). The simplex is tried first with a
+    size-derived pivot cap; on a cap trip or any non-optimal exit it falls back
+    to POUNCE for that LP, so no single LP is slower than the pre-F3 POUNCE
+    baseline. Only the dual *slope* ``a`` (the marginals on the ``Vᵀλ = x*``
+    rows) is taken from whichever engine converged; the intercept ``b`` is then
+    recomputed to the exact validity boundary over the box vertices —
+    ``b = minᵥ(f(v) − a·v)`` (under) / ``maxᵥ`` (over). Because a multilinear
+    function attains its box extrema at vertices, the resulting hyperplane
+    ``a·x + b`` under/over-estimates ``f`` *everywhere*, so the cut is rigorously
+    valid for ANY slope — robust to the backend's analytic-center dual on a
+    degenerate LP (a different facet, still valid) or any dual sign/scale
+    convention. ``None`` if no backend is available or neither engine converged.
     """
     from discopt.solvers import SolveStatus
-    from discopt.solvers.lp_pounce import solve_lp
 
     n = verts.shape[1]
     m = verts.shape[0]
     a_eq = np.vstack([verts.T, np.ones(m)])
     b_eq = np.append(x_star, 1.0)
     c = -fv if maximize else fv
-    try:
-        res = solve_lp(c, A_eq=a_eq, b_eq=b_eq, bounds=[(0.0, np.inf)] * m)
-    except ImportError:  # pragma: no cover - POUNCE is a core dependency
-        return None
-    if res.status != SolveStatus.OPTIMAL or res.dual_values is None:
-        return None
-    duals = np.asarray(res.dual_values, dtype=np.float64)
-    if duals.shape[0] != n + 1 or not np.all(np.isfinite(duals)):
-        return None
+    bounds = [(0.0, np.inf)] * m
+
+    duals: np.ndarray | None = None
+    if _separation_lp_simplex_enabled():
+        try:
+            from discopt.solvers.lp_simplex import SIMPLEX_AVAILABLE
+            from discopt.solvers.lp_simplex import solve_lp as _simplex_solve_lp
+
+            if SIMPLEX_AVAILABLE:
+                cap = min(
+                    _HULL_SIMPLEX_STALL_K * (n + 1) + _HULL_SIMPLEX_STALL_C,
+                    _HULL_SIMPLEX_STALL_MAX,
+                )
+                res = _simplex_solve_lp(c, A_eq=a_eq, b_eq=b_eq, bounds=bounds, max_iter=int(cap))
+                if res.status == SolveStatus.OPTIMAL and res.dual_values is not None:
+                    _d = np.asarray(res.dual_values, dtype=np.float64)
+                    if _d.shape[0] == n + 1 and np.all(np.isfinite(_d)):
+                        duals = _d
+        except ImportError:
+            duals = None
+    if duals is None:
+        # POUNCE path: the off-switch, or the per-LP fallback when the capped
+        # simplex stalled / returned a non-usable dual (validity is unaffected —
+        # the intercept is recomputed from the vertices below for ANY slope).
+        from discopt.solvers.lp_pounce import solve_lp as _pounce_solve_lp
+
+        try:
+            res = _pounce_solve_lp(c, A_eq=a_eq, b_eq=b_eq, bounds=bounds)
+        except ImportError:  # pragma: no cover - POUNCE is a core dependency
+            return None
+        if res.status != SolveStatus.OPTIMAL or res.dual_values is None:
+            return None
+        _d = np.asarray(res.dual_values, dtype=np.float64)
+        if _d.shape[0] != n + 1 or not np.all(np.isfinite(_d)):
+            return None
+        duals = _d
+
     a = -duals[:n] if maximize else duals[:n]
     if not np.all(np.isfinite(a)):
         return None
     # Recompute the intercept to the exact validity boundary over the vertices,
     # so ``a·v + b`` bounds ``f(v)`` at every vertex (hence everywhere) — this is
-    # what makes the cut sound without trusting POUNCE's reported intercept/scale.
+    # what makes the cut sound without trusting the engine's reported intercept/scale.
     resid = fv - verts @ a  # f(v) − a·v
     if maximize:  # concave overestimator: a·v + b >= f(v)  ->  b = maxᵥ(f(v)−a·v)
         b = float(np.max(resid))

--- a/python/discopt/solvers/lp_simplex.py
+++ b/python/discopt/solvers/lp_simplex.py
@@ -63,6 +63,7 @@ def solve_lp(
     bounds: Optional[list[tuple[float, float]]] = None,
     time_limit: Optional[float] = None,
     warm_basis: Optional[object] = None,  # accepted for compatibility; ignored
+    max_iter: Optional[int] = None,
     **_kwargs: Any,
 ) -> LPResult:
     """Solve ``min c^T x  s.t.  A_ub x <= b_ub, A_eq x == b_eq, bounds`` exactly.
@@ -83,6 +84,14 @@ def solve_lp(
     equilibrates internally). The row duals come straight from the optimal basis
     (``y = B⁻ᵀ c_B``, exact at the vertex), and the reduced costs are
     ``c − A_ubᵀ y_ub − A_eqᵀ y_eq``.
+
+    ``max_iter`` caps the (cold) pivot count. It is *soundness-neutral*: within
+    the cap the returned optimum is exactly the vertex optimum (a rigorous
+    bound); if the cap is hit the status is ``ITERATION_LIMIT`` and no objective
+    is returned, so a caller that wants a robust result must fall back (never a
+    wrong bound). This lets a caller bound the rare cold-stall on a wide,
+    ill-conditioned LP (the F3 multilinear vertex-hull LP: ``2^n`` λ columns)
+    without waiting for the 100 000-pivot default.
     """
     from discopt._rust import solve_lp_warm_py
 
@@ -119,12 +128,16 @@ def solve_lp(
     lb_std = np.concatenate([lb, np.zeros(m)])
     ub_std = np.concatenate([ub, np.full(m_ub, 1e20), np.zeros(m_eq)])
 
+    _warm_kw: dict[str, Any] = {}
+    if max_iter is not None:
+        _warm_kw["max_iter"] = int(max_iter)
     status, x_full, obj, _iters, _cs, _bv, dual, _ray = solve_lp_warm_py(
         np.ascontiguousarray(c_std),
         np.ascontiguousarray(a_std),
         np.ascontiguousarray(b_vec),
         np.ascontiguousarray(lb_std),
         np.ascontiguousarray(ub_std),
+        **_warm_kw,
     )
 
     status_map = {

--- a/python/tests/test_f3_multilinear_separation_lp_backend.py
+++ b/python/tests/test_f3_multilinear_separation_lp_backend.py
@@ -1,0 +1,217 @@
+"""F3 (extends perf-d1/#484): the multilinear vertex-hull separation LP routes to
+the in-house warm simplex, not a cold POUNCE IPM per call, under the same
+``DISCOPT_SEPARATION_LP_SIMPLEX`` flag as the edge-concave separator.
+
+Regime: bound-neutral-with-caveat (a degenerate hull LP's dual may differ between
+the IPM and the simplex, so the derived cut can differ). The cut's *validity* is
+engine-independent — :func:`_solve_envelope` recomputes the intercept to the exact
+validity boundary over the box vertices, so ``a·x + b`` bounds the monomial
+everywhere for ANY slope. These tests lock the routing (flag honored + off-switch),
+the per-LP POUNCE fallback (so a cold-simplex stall never regresses), and cut
+soundness on both engine paths (feasible-point sampling removes no true point).
+
+Fails on the pre-F3 code, which hard-coded ``lp_pounce.solve_lp`` in
+``multilinear_separation._solve_envelope``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.filterwarnings("ignore")
+
+
+def test_multilinear_separation_lp_simplex_flag_honored(monkeypatch):
+    """The F3 env selector mirrors the edge-concave flag (default ON, '0' off)."""
+    from discopt._jax.multilinear_separation import _separation_lp_simplex_enabled
+
+    monkeypatch.delenv("DISCOPT_SEPARATION_LP_SIMPLEX", raising=False)
+    assert _separation_lp_simplex_enabled() is True  # default ON
+
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", "1")
+    assert _separation_lp_simplex_enabled() is True
+
+    for off in ("0", "false", "no", "off", "OFF"):
+        monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", off)
+        assert _separation_lp_simplex_enabled() is False
+
+
+def test_multilinear_separator_uses_simplex_when_on(monkeypatch):
+    """Flag ON (default): the hull LP is solved by the in-house simplex, and the
+    POUNCE LP solver is NOT called on a well-conditioned (simplex-converging) LP."""
+    import discopt.solvers.lp_pounce as lp_pounce
+    import discopt.solvers.lp_simplex as lp_simplex
+    from discopt._jax import multilinear_separation as ms
+
+    if not lp_simplex.SIMPLEX_AVAILABLE:
+        pytest.skip("in-house simplex binding not built")
+
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", "1")
+
+    pounce_calls = {"n": 0}
+    _orig_pounce = lp_pounce.solve_lp
+
+    def _count_pounce(*a, **k):
+        pounce_calls["n"] += 1
+        return _orig_pounce(*a, **k)
+
+    monkeypatch.setattr(lp_pounce, "solve_lp", _count_pounce)
+
+    simplex_calls = {"n": 0}
+    _orig_simplex = lp_simplex.solve_lp
+
+    def _count_simplex(*a, **k):
+        simplex_calls["n"] += 1
+        return _orig_simplex(*a, **k)
+
+    monkeypatch.setattr(lp_simplex, "solve_lp", _count_simplex)
+
+    # A trilinear product w = x0*x1*x2 over a box, with w* far below the hull ->
+    # both under/over hull LPs are solved.
+    lb = np.array([0.0, 0.0, 0.0])
+    ub = np.array([1.0, 1.0, 1.0])
+    xs = np.array([0.5, 0.5, 0.5])
+    cuts = ms.separate_multilinear_envelope(lb, ub, xs, w_star=-5.0)
+    assert cuts, "expected a violated multilinear hull cut"
+    assert simplex_calls["n"] >= 1, "flag ON must route the hull LP to the simplex"
+    assert pounce_calls["n"] == 0, "well-conditioned hull LP must not fall back to POUNCE"
+
+
+def test_multilinear_separator_off_switch_uses_pounce(monkeypatch):
+    """Off-switch ('0') restores the POUNCE-IPM path (the simplex is not called)."""
+    import discopt.solvers.lp_pounce as lp_pounce
+    import discopt.solvers.lp_simplex as lp_simplex
+    from discopt._jax import multilinear_separation as ms
+
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", "0")
+
+    pounce_calls = {"n": 0}
+    _orig_pounce = lp_pounce.solve_lp
+
+    def _count_pounce(*a, **k):
+        pounce_calls["n"] += 1
+        return _orig_pounce(*a, **k)
+
+    monkeypatch.setattr(lp_pounce, "solve_lp", _count_pounce)
+
+    simplex_calls = {"n": 0}
+    _orig_simplex = lp_simplex.solve_lp
+
+    def _count_simplex(*a, **k):
+        simplex_calls["n"] += 1
+        return _orig_simplex(*a, **k)
+
+    monkeypatch.setattr(lp_simplex, "solve_lp", _count_simplex)
+
+    lb = np.array([0.0, 0.0, 0.0])
+    ub = np.array([1.0, 1.0, 1.0])
+    xs = np.array([0.5, 0.5, 0.5])
+    cuts = ms.separate_multilinear_envelope(lb, ub, xs, w_star=-5.0)
+    assert cuts, "expected a violated multilinear hull cut on the POUNCE path"
+    assert pounce_calls["n"] >= 1, "off-switch must use POUNCE"
+    assert simplex_calls["n"] == 0, "off-switch must not call the simplex"
+
+
+def _sample_cut_valid(cut, lb, ub, seed=0, npts=2000):
+    """A hull cut removes no true (x, prod x) point over the box."""
+    rng = np.random.default_rng(seed)
+    n = lb.shape[0]
+    pts = lb + (ub - lb) * rng.random((npts, n))
+    w = np.prod(pts, axis=1)
+    est = pts @ cut.a + cut.b
+    if cut.sense == "under":  # w >= a.x + b  ->  est <= w everywhere
+        return bool(np.all(est <= w + 1e-6))
+    return bool(np.all(est >= w - 1e-6))  # over: est >= w
+
+
+@pytest.mark.parametrize("flag", ["1", "0"])
+def test_multilinear_cut_sound_on_both_engines(monkeypatch, flag):
+    """The separated cut is a valid under/over estimator over the whole box on
+    BOTH the simplex (flag ON) and POUNCE (flag OFF) paths — feasible-point
+    sampling removes no true point. Validity is engine-independent because the
+    intercept is recomputed to the exact boundary over the box vertices."""
+    import discopt.solvers.lp_simplex as lp_simplex
+    from discopt._jax import multilinear_separation as ms
+
+    if flag == "1" and not lp_simplex.SIMPLEX_AVAILABLE:
+        pytest.skip("in-house simplex binding not built")
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", flag)
+
+    cases = [
+        (np.array([-2.0, 0.5]), np.array([3.0, 4.0]), np.array([0.1, 2.0]), -50.0),
+        (np.array([-2.0, 0.5]), np.array([3.0, 4.0]), np.array([0.1, 2.0]), 50.0),
+        (np.array([0.0, 0.0, -1.0]), np.array([2.0, 2.0, 1.0]), np.array([1.0, 1.0, 0.0]), -20.0),
+    ]
+    got_any = False
+    for lb, ub, xs, w_star in cases:
+        cuts = ms.separate_multilinear_envelope(lb, ub, xs, float(w_star))
+        for cut in cuts:
+            got_any = True
+            assert _sample_cut_valid(cut, lb, ub), (
+                f"[flag={flag}] {cut.sense} cut removes a feasible point"
+            )
+    assert got_any, "expected at least one violated cut across the cases"
+
+
+def test_multilinear_capped_simplex_falls_back_to_pounce(monkeypatch):
+    """When the capped simplex returns non-optimal (simulated stall), the hull LP
+    falls back to POUNCE and still yields a valid cut — so a cold-simplex stall
+    never drops a cut the POUNCE path would have found."""
+    import discopt.solvers.lp_pounce as lp_pounce
+    import discopt.solvers.lp_simplex as lp_simplex
+    from discopt._jax import multilinear_separation as ms
+    from discopt.solvers import LPResult, SolveStatus
+
+    if not lp_simplex.SIMPLEX_AVAILABLE:
+        pytest.skip("in-house simplex binding not built")
+    monkeypatch.setenv("DISCOPT_SEPARATION_LP_SIMPLEX", "1")
+
+    # Force every simplex hull-LP solve to look like a stall (iteration limit).
+    monkeypatch.setattr(
+        lp_simplex, "solve_lp", lambda *a, **k: LPResult(status=SolveStatus.ITERATION_LIMIT)
+    )
+
+    pounce_calls = {"n": 0}
+    _orig_pounce = lp_pounce.solve_lp
+
+    def _count_pounce(*a, **k):
+        pounce_calls["n"] += 1
+        return _orig_pounce(*a, **k)
+
+    monkeypatch.setattr(lp_pounce, "solve_lp", _count_pounce)
+
+    lb = np.array([-2.0, 0.5])
+    ub = np.array([3.0, 4.0])
+    xs = np.array([0.1, 2.0])
+    cuts = ms.separate_multilinear_envelope(lb, ub, xs, w_star=-50.0)
+    assert cuts, "fallback must still separate a cut when the simplex stalls"
+    assert pounce_calls["n"] >= 1, "a simplex stall must fall back to POUNCE"
+    for cut in cuts:
+        assert _sample_cut_valid(cut, lb, ub), "fallback cut removes a feasible point"
+
+
+def test_lp_simplex_max_iter_passthrough_caps_pivots():
+    """``lp_simplex.solve_lp(max_iter=1)`` returns a non-optimal status rather than
+    a (possibly wrong) objective — the cap is soundness-neutral (never a bound)."""
+    import discopt.solvers.lp_simplex as lp_simplex
+    from discopt.solvers import SolveStatus
+
+    if not lp_simplex.SIMPLEX_AVAILABLE:
+        pytest.skip("in-house simplex binding not built")
+
+    # A small LP that needs >1 pivot; capping at 1 must NOT report OPTIMAL.
+    c = np.array([-1.0, -1.0])
+    A_ub = np.array([[1.0, 2.0], [2.0, 1.0]])
+    b_ub = np.array([4.0, 4.0])
+    bounds = [(0.0, 10.0), (0.0, 10.0)]
+    r_full = lp_simplex.solve_lp(c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+    assert r_full.status == SolveStatus.OPTIMAL
+    r_capped = lp_simplex.solve_lp(c, A_ub=A_ub, b_ub=b_ub, bounds=bounds, max_iter=1)
+    # Either it happened to converge in 1 pivot (still optimal + same obj) or it
+    # capped out (non-optimal, no bound) — never a wrong optimum.
+    if r_capped.status == SolveStatus.OPTIMAL:
+        assert abs(r_capped.objective - r_full.objective) < 1e-6
+    else:
+        assert r_capped.status == SolveStatus.ITERATION_LIMIT
+        assert r_capped.objective is None


### PR DESCRIPTION
## F3 — route the multilinear separator's LP re-solves to the warm simplex (B9)

Implements task **F3** from `docs/dev/perf-followup-plan-2026-07-05.md` (§2 F3),
extending #484's `DISCOPT_SEPARATION_LP_SIMPLEX` routing to the last separator
still hard-coded on the POUNCE LP IPM: the multilinear vertex-hull LP in
`multilinear_separation._solve_envelope`, measured at **92.6 % of nvs09's 60 s
wall** (`lp_pounce._solve_core`) by `bottleneck-profile-2026-07-05.md §1.3`.

### Entry experiment (before the fix) — the kill criterion fired, honestly
nvs09, pounce 0.7.0, M4 Pro: `_separate_multilinear` = **90.8 % of wall**; **280
POUNCE hull-LP solves = 90.6 % of wall at 195 ms/solve** (≥80 % confirmed).

The hull LP `min/max f(v)·λ s.t. Vᵀλ = x*, 1ᵀλ = 1, λ ≥ 0` (`2^n` λ columns) is
**not** a row-augmented re-solve — only the RHS `x*` changes, and
`lp_simplex.solve_lp` is documented **cold** (no cross-call basis reuse). So the
mechanism is **cold-simplex-vs-IPM**, exactly like #484's edge-concave path — the
kill-criterion's "state the revised number" branch applies. A per-LP A/B falsifies
the uniform-10× premise: on nvs09's **1024-column** LPs the cold simplex is
**bimodal** — ~81 % solve in **≈1 ms (≈100× vs POUNCE's ~150 ms)**, ~19 % (the
degenerate widest LPs) **stall to the 100 000-pivot default (~1.6 s)**, worse than
POUNCE. (Soundness bonus: the hull LP's feasible set is a simplex — provably
bounded — so POUNCE's occasional `UNBOUNDED` on the wide LP is a numerical
false-negative that **drops a valid cut**; the exact simplex recovers it.)

### The change (mirrors #484 exactly)
- `_separation_lp_simplex_enabled()` honors the **same** `DISCOPT_SEPARATION_LP_SIMPLEX`
  env (default ON); `"0"` restores the POUNCE-IPM-only path.
- `_solve_envelope` keeps only the dual **slope** and **recomputes the intercept**
  `b` to the exact validity boundary over the box vertices (`minᵥ`/`maxᵥ`), so cut
  *validity* never depends on which engine produced the duals (#484's critical
  soundness step; verified min-slack ≥ 0 at every vertex).
- Cold-stall handled soundly (F2's philosophy on the *cold* path — F2's warm-only
  guard does not cover this standalone hull LP): a size-derived pivot cap (new
  soundness-neutral `max_iter` passthrough on `lp_simplex.solve_lp`) → **POUNCE
  per-LP fallback** on any non-optimal exit, so no LP is ever slower than the
  pre-F3 POUNCE baseline.

### Results (nvs09 @60 s, revised numbers — honest)
| metric | baseline (SEP=0) | F3 (SEP=1) |
|---|---|---|
| nodes / (nodes/s) | 159 / 2.62 | **221 / 3.65 (1.4×)** |
| bound@60 s | −59.24 | **−57.67 (strictly tighter)** |
| incumbent | −43.1343369 | −43.1343369 (unchanged, ✓ vs −43.134 oracle) |
| separation share | ~92.6 % | ~88.9 % |
| hull-LP engine split | 100 % POUNCE | simplex serves 564/698 in 3.8 s (6.4 %); **128 POUNCE fallbacks = 44.3 s (73 %)** |

**The `<20 %` share / `≥10× nodes/s` acceptance targets are NOT met.** They rested
on separation being removable *overhead*; on nvs09 the hard tail (128 wide
degenerate LPs where the IPM beats the simplex) is **intrinsic bound work,
irreducible by routing** — a POUNCE-engine matter (cf. F6 / jkitchin/pounce#182).
The class win (narrow ≤cap hull LPs, ~81 % here → ~100× per LP) is real and sound,
and the bound-strictly-better criterion is met. Falsification recorded in
`bottleneck-profile-2026-07-05.md §5` (item 8) and the plan's F3 status per §0.6.

### Verification (regime: bound-neutral-with-caveat, #484 protocol)
- **Cert panel provably byte-identical** — instrumented all 41 certifying
  instances at 60 s: **0 multilinear-separator calls** (incl. heavy
  cvxnonsep_{n,p}sig*/fac2/tspn05/flay02m), so the changed path is never entered
  on any certifier → node_count + objective exactly unchanged by construction.
- **Feasible-point sampling** (cut-validity guard) on **both** engines — new tests
  sample points feasible for the original model and assert no separated
  under/over cut removes any (2000 pts × multiple boxes, flag ON and OFF).
- **Off-switch test** — `test_multilinear_separator_off_switch_uses_pounce`
  (`DISCOPT_SEPARATION_LP_SIMPLEX=0` restores POUNCE; simplex not called).
- **Out-of-panel witness** `ex14_1_5` (§0.2): identical result (optimal, 3 nodes,
  obj ≈ 0) with hull-LP POUNCE calls 4 → 0, bound valid vs the 0 oracle.
- New file `python/tests/test_f3_multilinear_separation_lp_backend.py` (7 tests);
  2 fail before the change / pass after.

### Gates run
- `pytest -m smoke` → **574 passed, 14 skipped**
- `pytest -m slow test_adversarial_recent_fixes.py` → **10 passed**
- edge-concave + univariate separation tests → **5 passed** (no #484 regression)
- `ruff check`, `ruff format --check`, `mypy` → **clean**
- No Rust touched (Python routing only) → `cargo test` not required per plan §0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
