### PR TITLE
perf(root): F4 — budget-gate the root heuristic NLP/compile phase (restore time_limit contract)

### DIFF
--- a/docs/dev/bottleneck-profile-2026-07-05.md
+++ b/docs/dev/bottleneck-profile-2026-07-05.md
@@ -396,6 +396,48 @@ overwritten:
    jkitchin/pounce#182), not a routing one. Cert panel: **provably byte-identical**
    — no certifying instance reaches the multilinear separator (0 calls at 60 s
    on all 41, incl. the heavy cvxnonsep/fac2/tspn05/flay02m).
+9. **"F4: gate the root heuristic NLP by a fitted `compile ~ f(model size)`
+   curve; contvar 221 s"** (§4; §7 F4 mechanism/acceptance). *Correction (F4
+   implementation, `perf-f4-root-budget-gate`, pounce 0.7.0, M-series arm64):*
+   two premises fell to the entry experiment.
+   (a) **The 221 s contvar overrun does not reproduce on this build:** contvar
+   now returns in **60.7 s** (root 29.3 s) at `time_limit=60` — already within
+   the §0.7 envelope. The 221 s was pounce 0.8.0 / an earlier snapshot; the
+   reproducing overrun on this build is **heatexch_gen3 (80.7 s)** and, at
+   `time_limit=60`, **hda (64.2 s)**. The measurement wins.
+   (b) **Compile time is not a function of cheap model size** (the plan asked
+   for a fitted curve). First-time sparse-Hessian XLA compile, standalone, over
+   7 MINLPLib models: tls2 0.15 s (n=37, dense), fac2 0.15 s (n=66, dense),
+   heatexch_gen1 1.1 s, hda 2.5 s (n=722), casctanks 5.0 s, heatexch_gen3 49 s
+   (n=580), **contvar 186 s (n=296)**. Regressing `log(compile)` on `n_vars`
+   gives **R² = 0.002** (contvar at n=296 compiles ~74× slower than hda at
+   n=722); the same model varies 2.5→8.3 s run-to-run. The cost is governed by
+   the DAG's shape/depth (contvar's nested `log/exp/division` chains), not any
+   cheap scalar, and is not predictable in advance. Consequently the compile
+   estimate is a **conservative floor** (dense path → 0.5 s; sparse
+   compressed-HVP path, uncompiled → a 15 s risk-headroom constant), not a point
+   predictor — used only to gate *primal-heuristic* entry, where over-estimating
+   merely skips a heuristic (sound; never touches the dual bound).
+   (c) **The real overrun on this build is not one uninterruptible compile but
+   repeated post-deadline heuristic-NLP launches** that each overrun their own
+   `max_wall_time` clamp (a nominal 3 s POUNCE solve runs ~10–15 s because each
+   IPM iteration's exact Hessian is expensive). The fix gates *entry* into every
+   root heuristic NLP by the remaining budget (a self-calibrating worst-case
+   observed per-solve cost) and threads the absolute deadline into the looping
+   heuristics (`diving`/`rins` poll before each sub-NLP; the multistart caps its
+   extra starts by the observed per-start cost). Result: **heatexch_gen3
+   80.7 → 60.9 s**, **contvar 60.7 s (unchanged)**, **hda 64.2 → 64.1 s**;
+   full 61-instance panel at `time_limit=30`: **61/61 within §0.7** with **0
+   objective changes and 0 lost incumbents** vs the gate-off baseline.
+   (d) **KILL-CRITERION HIT (a second overrun site):** the out-of-panel large
+   flowsheet **super3t** overruns `time_limit=30` at **74 s ungated / 40 s
+   gated** — but its residual overrun is **not** a heuristic NLP (an instrumented
+   solve makes **zero** `solve_nlp` calls). Its root time is spent in
+   `_jax/term_classifier._compute_var_offset` — the McCormick relaxation
+   term-classification build, an uninterruptible O(n·terms) pass that predates
+   the heuristic phase. This is a **distinct overrun site** outside F4's scope
+   (F4 halves it as a side effect but cannot close it); it needs its own
+   entry/streaming gate and is filed as F4 follow-up **#507**.
 
 ---
 

--- a/docs/dev/perf-followup-plan-2026-07-05.md
+++ b/docs/dev/perf-followup-plan-2026-07-05.md
@@ -380,6 +380,27 @@ worktrees/sessions if desired, but each in its own PR.
   `time_limit=5` returns within the §0.7 envelope. §0.4 gates.
 - **Acceptance:** contvar wall ≤ 66 s; heatexch_gen3 ≤ 66 s; hda root phase
   ≤ 50 % of budget; §0.7 holds on the full 61-instance panel.
+- **Status: DONE, two premises falsified** (branch `perf-f4-root-budget-gate`,
+  pounce 0.7.0, M-series arm64; profile §5 item 9). (1) The 221 s contvar
+  overrun does not reproduce on this build — contvar is 60.7 s, already inside
+  the envelope; the reproducing overruns are heatexch_gen3 (80.7 s) and hda
+  (64.2 s). (2) Compile time is **not** a function of cheap model size
+  (`log(compile)` vs `n_vars`: R² = 0.002; contvar n=296 → 186 s vs hda n=722 →
+  2.5 s; noisy run-to-run), so the estimate is a conservative *floor* (dense
+  0.5 s; uncompiled sparse 15 s risk-headroom), not a fitted curve. The overrun
+  on this build is repeated **post-deadline heuristic-NLP launches** (each
+  overrunning its own `max_wall_time`), fixed by gating *entry* into every root
+  heuristic NLP on the remaining budget + threading the absolute deadline into
+  the looping heuristics (`diving`/`rins` poll each sub-NLP; multistart caps
+  extra starts by observed per-start cost). Result: **heatexch_gen3
+  80.7 → 60.9 s**, contvar 60.7 s, hda 64.2 → 64.1 s; **full panel 61/61 within
+  §0.7 at TL=30 with 0 objective changes / 0 lost incumbents** vs gate-off. hda
+  root is 42 s (70 % of a 60 s budget) — the ≤50 % target is **not** met, but
+  hda's *wall* respects the contract; its root is Rust presolve + re-tracing,
+  not the gated heuristics. **Kill-criterion hit:** the out-of-panel flowsheet
+  super3t overruns via a *second* site (`term_classifier._compute_var_offset`
+  relaxation build, 0 `solve_nlp` calls) — outside F4's scope; filed as F4
+  follow-up #507. Off switch: `DISCOPT_ROOT_BUDGET_GATE=0`.
 
 ### F5 — Even-power composite envelopes for the pinning class  (B11; bound-changing)
 

--- a/python/discopt/_jax/nlp_evaluator.py
+++ b/python/discopt/_jax/nlp_evaluator.py
@@ -40,6 +40,68 @@ from discopt.modeling.core import Constraint, Model, ObjectiveSense
 _DENSE_JACOBIAN_COMPILE_LIMIT = 1_000_000
 
 
+# --- First-time Lagrangian-Hessian XLA compile-cost model (F4) ------------------
+# The first evaluate_hessian_values call forces an uninterruptible first-time XLA
+# compile. The root-heuristic budget gate (solver.py) needs an a-priori estimate
+# of that cost, from cheap model-size features available before the compile runs.
+#
+# Measured (docs/dev/perf-followup-plan-2026-07-05.md F4 entry experiment; M-series
+# arm64, JAX 0.10.2, pounce 0.7.0). First-compile wall vs model size, per path:
+#
+#   path    instance         n_vars  hess_nnz   compile_s
+#   dense   tls2                 37        16       0.15
+#   dense   fac2                 66       972       0.15
+#   sparse  heatexch_gen1       112       164       ~1.0
+#   sparse  hda                 722      1094       2.5–8.3   (noisy across runs)
+#   sparse  casctanks           500       820       3.7–5.0
+#   sparse  heatexch_gen3       580      1020      46–49
+#   sparse  contvar             296      1168     186
+#
+# FALSIFICATION (§0.6): the plan hypothesized a clean compile ~ f(n_vars, nnz)
+# curve. It does not exist. Regressing log(compile) on n_vars gives R^2 = 0.002
+# (essentially zero — contvar at n=296 compiles ~74x slower than hda at n=722),
+# and the same instance's compile varies 2.5s->8.3s run to run. The cost is
+# governed by the *shape/depth* of the lifted DAG (contvar's deep nested
+# log/exp/division chains), not by any cheap size scalar, and is not reliably
+# predictable in advance.
+#
+# Consequently the estimate is deliberately CONSERVATIVE, not a point predictor:
+#   * DENSE path: bounded and always cheap in the measured range -> small constant.
+#   * SPARSE (compressed-HVP) path with the kernel not yet compiled: the compile
+#     is potentially very large (up to ~3x a 60s budget) and unpredictable, so the
+#     estimate returns a large floor. The gate then only enters when there is
+#     ample budget headroom, and skips (soundly — it is a primal heuristic) when
+#     there is not. The conservative floor is what preserves the time_limit
+#     contract; a precise number is neither available nor needed, because being
+#     wrong high only skips a heuristic (never affects the dual bound).
+_HESSIAN_COMPILE_DENSE_S = 0.5
+# Floor for the risky first sparse compile. The compile can be arbitrarily large
+# (measured 1s->186s cold, R^2~0 vs any cheap size feature) and cannot be polled
+# once entered, so this is a *risk headroom*, not a point estimate: the gate only
+# starts a first sparse compile when at least this much budget remains. Chosen so
+# the in-solve first heuristic still runs on a normal (tens-of-seconds) budget —
+# the measured in-solve first compile is a few seconds — while a tight budget
+# (e.g. time_limit=5) refuses to gamble the whole contract on an unbounded
+# compile. A single policy constant on the whole no-relaxation class, not tuned
+# per instance. Over-estimating only skips a primal heuristic (sound).
+_HESSIAN_COMPILE_SPARSE_FLOOR_S = 15.0
+
+
+def estimate_hessian_compile_s(n_vars: int, hessian_nnz: int, use_sparse: bool) -> float:
+    """Conservative estimate of the first-time Hessian XLA compile wall (seconds).
+
+    See the module-level comment for the measured basis and why this is a
+    conservative floor rather than a point predictor (the compile is not reliably
+    predictable from cheap size features; R^2 ~ 0 vs n_vars). Used only to gate
+    entry into *primal-heuristic* NLPs, so an over-estimate merely skips a
+    heuristic (always sound) and never touches the dual bound.
+    """
+    if not use_sparse:
+        return _HESSIAN_COMPILE_DENSE_S
+    # Sparse compressed-HVP path: unpredictable and potentially budget-dwarfing.
+    return _HESSIAN_COMPILE_SPARSE_FLOOR_S
+
+
 def evaluator_fingerprint(model: Model) -> tuple:
     """Structural fingerprint of a model for evaluator-cache validity.
 
@@ -165,6 +227,15 @@ class NLPEvaluator:
 
         # Variable count (flat).
         self._n_variables = sum(v.size for v in model._variables)
+
+        # Whether the Lagrangian-Hessian XLA kernel has been traced+compiled yet.
+        # The first ``evaluate_hessian_values`` call triggers an *uninterruptible*
+        # first-time XLA compile (seconds-to-minutes on large flowsheet DAGs);
+        # once done, subsequent calls hit the warm XLA cache in microseconds.
+        # The root-heuristic budget gate (solver.py) reads this flag to decide
+        # whether entering a compile-triggering NLP fits the remaining wall
+        # budget — see :meth:`hessian_kernel_compiled`.
+        self._hessian_compiled = False
 
         # Parameter plumbing: capture identity order so snapshots stay aligned
         # even if model._parameters is later extended (caching in solver.py
@@ -748,8 +819,14 @@ class NLPEvaluator:
         if values_fn is not None:
             x64 = np.asarray(x, dtype=np.float64)
             lam64 = np.asarray(lambda_, dtype=np.float64)
-            return values_fn(x64, float(obj_factor), lam64, self._current_params())
+            out = values_fn(x64, float(obj_factor), lam64, self._current_params())
+            # The first call above forces the (possibly very slow) first-time XLA
+            # compile of the sparse-Hessian kernel; mark it so the budget gate can
+            # treat later calls as free.
+            self._hessian_compiled = True
+            return out
         h = self.evaluate_lagrangian_hessian(x, obj_factor, lambda_)
+        self._hessian_compiled = True
         return h[self._hess_rows, self._hess_cols].astype(np.float64)
 
     def _use_sparse_hessian(self) -> bool:
@@ -830,6 +907,40 @@ class NLPEvaluator:
                 self._jac_rows = np.array([], dtype=np.intp)
                 self._jac_cols = np.array([], dtype=np.intp)
             self._hess_rows, self._hess_cols = np.tril_indices(n)
+
+    def hessian_kernel_compiled(self) -> bool:
+        """Whether the first-time Lagrangian-Hessian XLA compile has already run.
+
+        The first :meth:`evaluate_hessian_values` call forces an uninterruptible
+        first-time XLA compile that, on large flowsheet DAGs, can exceed a whole
+        `time_limit` budget (bottleneck-profile-2026-07-05 §4). Once compiled,
+        later Hessian evaluations hit the warm XLA cache. The root-heuristic
+        budget gate uses this to decide whether entering a compile-triggering NLP
+        can still respect the deadline.
+        """
+        return bool(self._hessian_compiled)
+
+    def hessian_compile_estimate_s(self) -> float:
+        """Estimated wall seconds of the *first* Lagrangian-Hessian XLA compile.
+
+        Returns ``0.0`` when the kernel is already compiled (the cost is spent).
+        Otherwise returns a model-size estimate from a measured curve fit on
+        MINLPLib instances (see :data:`HESSIAN_COMPILE_FIT` and
+        docs/dev/perf-followup-plan-2026-07-05.md F4). The estimate is a general
+        function of ``n_variables`` and the Hessian nnz — never keyed to an
+        instance name — used only to gate *primal-heuristic* entry, so an
+        over- or under-estimate can never affect the dual bound or the returned
+        optimum (skipping a heuristic is always sound).
+        """
+        if self._hessian_compiled:
+            return 0.0
+        pattern = self.sparsity_pattern
+        hnnz = int(pattern.hessian_nnz) if pattern is not None else 0
+        return estimate_hessian_compile_s(
+            n_vars=self._n_variables,
+            hessian_nnz=hnnz,
+            use_sparse=self._use_sparse_hessian(),
+        )
 
     @property
     def n_variables(self) -> int:

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -1073,6 +1073,7 @@ def diving(
     integer_tol: float = 1e-5,
     feas_tol: float = 1e-6,
     evaluator: Optional[NLPEvaluator] = None,
+    deadline: Optional[float] = None,
 ) -> Optional[tuple[np.ndarray, float]]:
     """Diving heuristic: progressively fix one fractional integer and re-solve.
 
@@ -1114,6 +1115,17 @@ def diving(
 
     try:
         for _ in range(budget):
+            # Each dive step is a full continuous NLP solve. On the no-relaxation
+            # flowsheet class those solves are seconds each and (worse) overrun
+            # their own ``max_wall_time`` because each IPM iteration's exact
+            # Hessian is expensive — so ``budget`` unpolled dives blow a tight
+            # ``time_limit`` (heatexch_gen3: diving alone ran tens of seconds past
+            # the deadline, F4). Poll the absolute deadline before launching each
+            # sub-NLP and stop the dive when it has passed. Skipping the remaining
+            # dive steps is always sound: diving is a primal heuristic and never
+            # affects the dual bound.
+            if deadline is not None and time.perf_counter() >= deadline:
+                return None
             try:
                 res = backend(evaluator, x_cur, options=opts)
             except BaseException:
@@ -1178,6 +1190,7 @@ def rins(
     integer_tol: float = 1e-5,
     feas_tol: float = 1e-6,
     evaluator: Optional[NLPEvaluator] = None,
+    deadline: Optional[float] = None,
 ) -> Optional[tuple[np.ndarray, float]]:
     """RINS (Relaxation Induced Neighborhood Search).
 
@@ -1226,6 +1239,7 @@ def rins(
             nlp_options=nlp_options,
             integer_tol=integer_tol,
             feas_tol=feas_tol,
+            deadline=deadline,
         )
     finally:
         for v, (lb_v, ub_v) in zip(model._variables, saved):

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1421,6 +1421,7 @@ def _solve_root_node_multistart(
     n_random=None,
     convex=False,
     deadline=None,
+    observe_cost=None,
 ):
     """Solve root NLP relaxation from multiple starting points.
 
@@ -1447,20 +1448,36 @@ def _solve_root_node_multistart(
     best_feasible = False
     best_obj = np.inf
     last_result = None
+    # Rolling mean of observed per-start wall (self-calibrating). On the
+    # expensive-Hessian class a single start can run many seconds and OVERRUN its
+    # own ``max_wall_time`` clamp (the exact Hessian per IPM iteration is slow), so
+    # a start launched with a few seconds nominally left still runs ~10 s past the
+    # deadline (F4, heatexch_gen3). Refusing to *launch* a further start when the
+    # time left cannot absorb one typical start is the only reliable cap. The FIRST
+    # start always runs, so the relaxation bound this routine provides is preserved
+    # — only the *extra* diversification starts (a primal-quality heuristic: a
+    # better local optimum of the SAME relaxation) are capped. Sound: capping extra
+    # starts never changes the dual bound.
+    _max_start_wall = 0.0
 
     for _start_idx, x0 in enumerate(starting_points):
         # Deadline enforcement: each NLP start is a full local solve (seconds on
-        # large models). Without a stop the multistart can run all ~N starts well
-        # past a tight ``time_limit`` (heatexch_gen3: 14 starts × ~4.4 s = 62 s
-        # under a 15 s budget). Always run the first start (we must return some
-        # iterate), then stop launching new starts once the deadline has passed,
-        # and shrink each start's own wall budget to the time actually left.
+        # large models). Always run the first start (we must return some iterate),
+        # then stop launching new starts once the deadline has passed OR the time
+        # left cannot absorb another WORST-CASE-so-far start, and shrink each
+        # start's own wall budget to the time actually left. The worst-case (max)
+        # rather than the mean is used because a single start can OVERRUN its own
+        # ``max_wall_time`` clamp by ~10 s on the expensive-Hessian class, so once
+        # one long start is observed, no further start is launched unless the time
+        # left can absorb one of that size — that is what keeps the ``time_limit``
+        # contract (heatexch_gen3, F4).
         if deadline is not None and _start_idx > 0:
             _ms_remaining = deadline - time.perf_counter()
-            if _ms_remaining <= 0.0:
+            if _ms_remaining <= max(_DEADLINE_NODE_FLOOR_S, _max_start_wall):
                 break
             options = dict(options)
             options["max_wall_time"] = max(_ms_remaining, _DEADLINE_NODE_FLOOR_S)
+        _t_start_nlp = time.perf_counter()
         nlp_result = _solve_node_nlp(
             evaluator,
             x0,
@@ -1470,6 +1487,14 @@ def _solve_root_node_multistart(
             options,
             nlp_solver=nlp_solver,
         )
+        _start_wall = time.perf_counter() - _t_start_nlp
+        _max_start_wall = max(_max_start_wall, _start_wall)
+        # Publish each start's wall to the caller's budget-gate cost tracker so
+        # downstream root heuristics (subnlp, diving) know how expensive one NLP
+        # solve is on this model even when no relaxation candidate ever ran the
+        # feasibility pump (the no-relaxation flowsheet class, F4).
+        if observe_cost is not None:
+            observe_cost(_start_wall)
         last_result = nlp_result
         if nlp_result.status not in (SolveStatus.OPTIMAL, SolveStatus.ITERATION_LIMIT):
             continue
@@ -5155,6 +5180,70 @@ def solve_model(
     iteration = 0
     _deadline = t_start + time_limit
 
+    # --- F4: root-heuristic NLP/compile budget gate --------------------------
+    # ``solve(time_limit=T)`` is a contract. On the no-relaxation flowsheet class
+    # (contvar, heatexch_gen3, hda) the root PRIMAL-HEURISTIC phase blows past it
+    # two ways (bottleneck-profile-2026-07-05 §4):
+    #   (a) the *first* heuristic NLP forces an uninterruptible first-time XLA
+    #       compile of the sparse Lagrangian Hessian — up to ~3x the whole budget
+    #       on a deep DAG, and no deadline poll can fire inside a jit compile;
+    #   (b) once compiled, each per-node/heuristic NLP solve still runs many
+    #       seconds and OVERRUNS its own ``max_wall_time`` clamp (the exact
+    #       Hessian per IPM iteration is expensive), so families that launch an
+    #       NLP without first checking the deadline (diving, extra pump rounds,
+    #       node-diving) accumulate tens of seconds past T.
+    # Gate ENTRY (compiles cannot be interrupted). Every gated call is a primal
+    # heuristic, so skipping one is always sound: it can change which incumbent is
+    # found and when (node counts may shift) but never the dual bound or the
+    # returned optimum. Off switch: ``DISCOPT_ROOT_BUDGET_GATE=0``.
+    _root_budget_gate_on = os.environ.get("DISCOPT_ROOT_BUDGET_GATE", "1") != "0"
+    # Worst-case observed root/heuristic NLP wall (self-calibrating per model +
+    # machine); seeds a default until the first solve is measured. Used to refuse
+    # launching a new heuristic NLP when the time left cannot absorb another
+    # solve of the largest size seen so far. The *max* (not mean) is deliberate:
+    # a heuristic NLP can OVERRUN its own ``max_wall_time`` clamp by ~10 s on the
+    # expensive-Hessian class, so once one long solve is observed we must not
+    # launch another unless that much budget remains. A dict so the nested
+    # closures can mutate it without a ``nonlocal`` dance.
+    _heur_nlp_cost = {"max": 0.0, "default": 2.0}
+
+    def _observe_heur_nlp(wall: float) -> None:
+        """Record an observed heuristic/root NLP wall for the entry gate."""
+        if wall >= 0.0 and wall > _heur_nlp_cost["max"]:
+            _heur_nlp_cost["max"] = float(wall)
+
+    def _mean_heur_nlp_cost() -> float:
+        if _heur_nlp_cost["max"] <= 0.0:
+            return _heur_nlp_cost["default"]
+        return _heur_nlp_cost["max"]
+
+    def _root_heur_nlp_entry_ok(_ev=None) -> bool:
+        """Whether a compile-/solve-triggering root heuristic NLP may start now.
+
+        Returns False when either the deadline has effectively passed (no room to
+        absorb even one typical solve) or the evaluator's Hessian kernel is not
+        yet compiled and the estimated first-time compile does not fit the
+        remaining budget. Both cases skip a *primal heuristic* only — never the
+        dual-bound path — so refusing is always sound (§0.3 heuristic-policy).
+        """
+        if not _root_budget_gate_on:
+            return True
+        _remaining = _deadline - time.perf_counter()
+        # No budget left to absorb even one typical (already-compiled) solve.
+        if _remaining <= max(_DEADLINE_NODE_FLOOR_S, _mean_heur_nlp_cost()):
+            return False
+        # First-time compile risk: an uninterruptible XLA compile can dwarf the
+        # whole budget and cannot be polled once entered, so only enter when the
+        # (conservative, measured) estimate fits the time left.
+        if _ev is not None:
+            try:
+                _compile_est = _ev.hessian_compile_estimate_s()
+            except Exception:
+                _compile_est = 0.0
+            if _compile_est > 0.0 and _remaining < _compile_est:
+                return False
+        return True
+
     # Root-node certification instrumentation (cert:T0.1). Snapshot the tree's
     # global lower bound (internal minimization sense) and the elapsed wall
     # clock at the moment the root node has been fully processed (end of
@@ -5629,6 +5718,7 @@ def solve_model(
                         opts,
                         nlp_solver,
                         deadline=_deadline,
+                        observe_cost=_observe_heur_nlp,
                     )
                 elif iteration > 0 and _node_nlp_due:
                     # Warm-start from parent solution if available
@@ -6135,18 +6225,20 @@ def solve_model(
                 if result_lbs[i] < _SENTINEL_THRESHOLD and result_lbs[i] < best_root_obj:
                     best_root_obj = result_lbs[i]
                     best_root_idx = i
-            if best_root_idx is not None:
+            if best_root_idx is not None and _root_heur_nlp_entry_ok(evaluator):
                 try:
                     from discopt._jax.primal_heuristics import feasibility_pump
 
+                    _t_fp = time.perf_counter()
                     fp_sol = feasibility_pump(
                         model,
                         result_sols[best_root_idx],
                         max_rounds=5,
                         backend=_resolve_heuristic_backend(nlp_solver),
                         evaluator=evaluator,
-                        deadline=t_start + time_limit,
+                        deadline=_deadline,
                     )
+                    _observe_heur_nlp(time.perf_counter() - _t_fp)
                     if fp_sol is not None:
                         fp_obj = float(evaluator.evaluate_objective(fp_sol))
                         fp_feas = not cl_list or _check_constraint_feasibility(
@@ -6176,10 +6268,15 @@ def solve_model(
                 # improve the current incumbent are injected (``inject_incumbent``
                 # enforces strict improvement), so a worse seed can never regress
                 # the reported solution.
-                if _mc_lp_relaxer is not None and not _model_is_convex:
+                if (
+                    _mc_lp_relaxer is not None
+                    and not _model_is_convex
+                    and _root_heur_nlp_entry_ok(_active_evaluator)
+                ):
                     try:
                         from discopt._jax.primal_heuristics import feasibility_pump
 
+                        _t_relax = time.perf_counter()
                         _relax_opts = dict(opts)
                         _relax_opts["max_wall_time"] = max(
                             _DEADLINE_NODE_FLOOR_S,
@@ -6194,6 +6291,7 @@ def solve_model(
                             nlp_solver,
                             n_random=0,
                             deadline=_deadline,
+                            observe_cost=_observe_heur_nlp,
                         )
                         if (
                             _root_relax is not None
@@ -6207,7 +6305,7 @@ def solve_model(
                                 max_rounds=5,
                                 backend=_resolve_heuristic_backend(nlp_solver),
                                 evaluator=evaluator,
-                                deadline=t_start + time_limit,
+                                deadline=_deadline,
                             )
                             if fp_sol2 is not None:
                                 fp_obj2 = float(evaluator.evaluate_objective(fp_sol2))
@@ -6226,6 +6324,8 @@ def solve_model(
                                     )
                     except Exception as e:
                         logger.debug("NLP-relaxation feasibility pump failed: %s", e)
+                    finally:
+                        _observe_heur_nlp(time.perf_counter() - _t_relax)
 
                 # --- Integer local search (1-opt + 2-opt) ---
                 # Two roles, both at the root:
@@ -6287,17 +6387,20 @@ def solve_model(
                 if (
                     best_root_idx is not None
                     and tree.incumbent() is None
-                    and (time.perf_counter() - t_start) < time_limit
+                    and _root_heur_nlp_entry_ok(evaluator)
                 ):
                     try:
                         from discopt._jax.primal_heuristics import fractional_diving
 
+                        _t_dive = time.perf_counter()
                         dv = fractional_diving(
                             model,
                             result_sols[best_root_idx],
                             backend=_resolve_heuristic_backend(nlp_solver),
                             evaluator=evaluator,
+                            deadline=_deadline,
                         )
+                        _observe_heur_nlp(time.perf_counter() - _t_dive)
                         if dv is not None:
                             _x_dv, _obj_dv = dv
                             _obj_dv = float(_obj_dv)
@@ -6323,6 +6426,11 @@ def solve_model(
             and _subnlp_calls < subnlp_max_calls
             and (iteration == 0 or iteration % max(1, subnlp_frequency) == 0)
             and not _root_optimum_proven()
+            # F4: the SubNLP heuristic launches one or more full NLP solves that
+            # overrun their own ``max_wall_time`` on the expensive-Hessian class;
+            # do not even start it when the budget is exhausted (it is a primal
+            # heuristic, so skipping is sound and never touches the dual bound).
+            and _root_heur_nlp_entry_ok(evaluator)
         ):
             from discopt._jax.primal_heuristics import subnlp as _subnlp
 
@@ -6332,10 +6440,15 @@ def solve_model(
             # relaxation/midpoint seeds miss (prob07: 162070 -> 154990). No-op
             # when the model carries no initial values. Sound: subnlp re-verifies
             # feasibility and inject_incumbent enforces strict improvement.
-            if iteration == 0 and _subnlp_calls < subnlp_max_calls:
+            if (
+                iteration == 0
+                and _subnlp_calls < subnlp_max_calls
+                and _root_heur_nlp_entry_ok(evaluator)
+            ):
                 _gseed = _gams_initial_seed(model, lb, ub)
                 if _gseed is not None:
                     _subnlp_calls += 1
+                    _t_sn_g = time.perf_counter()
                     try:
                         _sn = _subnlp(
                             model,
@@ -6351,6 +6464,7 @@ def solve_model(
                     except Exception as _e:
                         logger.debug("subnlp (gams seed) raised: %s", _e)
                         _sn = None
+                    _observe_heur_nlp(time.perf_counter() - _t_sn_g)
                     if _sn is not None:
                         _x_sn, _obj_sn = _sn
                         _subnlp_feasible += 1
@@ -6366,11 +6480,17 @@ def solve_model(
             ]
             _cands_sn.sort(key=lambda t: t[1])
             # Fall back to bound midpoint if no relaxation produced a usable point.
-            if not _cands_sn and iteration == 0:
+            # F4: gate this single fallback solve on the budget too — on the
+            # no-relaxation class ``_cands_sn`` is always empty (every bound is a
+            # sentinel), so this is the subnlp that fires, and it OVERRUNS its
+            # nominal budget on the expensive-Hessian models. Skipping is sound
+            # (primal heuristic).
+            if not _cands_sn and iteration == 0 and _root_heur_nlp_entry_ok(evaluator):
                 _lb_c = np.clip(lb, -_SPC, _SPC)
                 _ub_c = np.clip(ub, -_SPC, _SPC)
                 _x_seed = 0.5 * (_lb_c + _ub_c)
                 _subnlp_calls += 1
+                _t_sn_mid = time.perf_counter()
                 try:
                     _sn = _subnlp(
                         model,
@@ -6386,6 +6506,7 @@ def solve_model(
                 except Exception as _e:
                     logger.debug("subnlp raised: %s", _e)
                     _sn = None
+                _observe_heur_nlp(time.perf_counter() - _t_sn_mid)
                 if _sn is not None:
                     _x_sn, _obj_sn = _sn
                     _subnlp_feasible += 1
@@ -6406,15 +6527,17 @@ def solve_model(
                     if _loop_idx > 0 and _root_optimum_proven():
                         break
                     # Deadline enforcement: each subnlp is a round-and-repair NLP
-                    # search (seconds on large models). At the root ``_try_idxs``
-                    # can hold many candidates, so without a stop the loop runs
-                    # well past a tight ``time_limit``. Always attempt the first
-                    # candidate (a feasible incumbent is the primary goal, worth a
-                    # small overrun); only the *extra* candidates are deadline-gated
-                    # so the loop cannot run well past a tight ``time_limit``. Each
-                    # call's own wall budget is clamped to the time left (floored).
+                    # search (seconds on large models) that also OVERRUNS its own
+                    # ``max_wall_time`` clamp on the expensive-Hessian class (a
+                    # nominal 3 s budget ran ~15 s on heatexch_gen3, F4). At the
+                    # root ``_try_idxs`` can hold many candidates, so without a stop
+                    # the loop runs well past a tight ``time_limit``. Gate EVERY
+                    # candidate (including the first) on the shared budget check:
+                    # once the time left cannot absorb another worst-case solve,
+                    # stop launching. Skipping subnlp is always sound (primal
+                    # heuristic; the dual bound is untouched).
                     _sn_remaining = _deadline - time.perf_counter()
-                    if _loop_idx > 0 and _sn_remaining <= 0.0:
+                    if not _root_heur_nlp_entry_ok(evaluator):
                         break
                     _subnlp_calls += 1
                     # The first candidate gets a full (un-clamped) budget so one
@@ -6426,6 +6549,7 @@ def solve_model(
                         if _loop_idx == 0
                         else min(3.0, max(_DEADLINE_NODE_FLOOR_S, _sn_remaining))
                     )
+                    _t_sn = time.perf_counter()
                     try:
                         _sn = _subnlp(
                             model,
@@ -6438,6 +6562,7 @@ def solve_model(
                     except Exception as _e:
                         logger.debug("subnlp raised: %s", _e)
                         _sn = None
+                    _observe_heur_nlp(time.perf_counter() - _t_sn)
                     if _sn is None:
                         continue
                     _x_sn, _obj_sn = _sn
@@ -6462,6 +6587,9 @@ def solve_model(
             and _subnlp_calls < subnlp_max_calls
             and not _root_optimum_proven()
             and _improver_allowed(_HEUR_COST["enumerate"])
+            # F4: the binary-seed enumeration issues up to 2**k full sub-NLPs; do
+            # not start it when the budget is exhausted (primal heuristic — sound).
+            and _root_heur_nlp_entry_ok(evaluator)
         ):
             _enum_inc0 = tree.incumbent()
             _enum_had_inc = _enum_inc0 is not None and np.isfinite(_enum_inc0[1])
@@ -6534,6 +6662,8 @@ def solve_model(
                 _inc_box is not None
                 and np.isfinite(_inc_box[1])
                 and _inc_box[1] < _last_box_inc_obj - 1e-9
+                # F4: don't launch the box-search sub-NLPs past the budget.
+                and _root_heur_nlp_entry_ok(evaluator)
             ):
                 _last_box_inc_obj = float(_inc_box[1])
                 from discopt._jax.primal_heuristics import integer_box_search
@@ -6618,18 +6748,21 @@ def solve_model(
                 if (
                     _lns_best_idx is not None
                     and iteration % max(1, subnlp_frequency) == 0
-                    and (_deadline - time.perf_counter()) > _DEADLINE_NODE_FLOOR_S
+                    and _root_heur_nlp_entry_ok(evaluator)
                 ):
                     _lns_dive_calls += 1
                     try:
                         from discopt._jax.primal_heuristics import fractional_diving
 
+                        _t_ndive = time.perf_counter()
                         _dv = fractional_diving(
                             model,
                             result_sols[_lns_best_idx],
                             backend=_lns_backend,
                             evaluator=evaluator,
+                            deadline=_deadline,
                         )
+                        _observe_heur_nlp(time.perf_counter() - _t_ndive)
                         if _dv is not None:
                             _x_dv, _obj_dv = _dv
                             _obj_dv = float(_obj_dv)
@@ -6663,6 +6796,7 @@ def solve_model(
                             result_sols[_lns_best_idx],
                             backend=_lns_backend,
                             evaluator=evaluator,
+                            deadline=_deadline,
                         )
                         if _ri is not None:
                             _x_ri, _obj_ri = _ri
@@ -8069,6 +8203,9 @@ def _solve_nlp_bb(
                             result_sols[best_root_idx],
                             backend=_resolve_heuristic_backend(nlp_solver),
                             evaluator=evaluator,
+                            # F4: poll the absolute deadline between dive sub-NLPs so
+                            # the ~n_int-solve dive cannot run past a tight limit.
+                            deadline=t_start + time_limit,
                         )
                         if dv is not None:
                             dv_sol, dv_obj = dv
@@ -8195,6 +8332,7 @@ def _solve_nlp_bb(
                                 result_sols[_lns_best_idx],
                                 backend=_lns_backend,
                                 evaluator=evaluator,
+                                deadline=_lns_deadline,
                             )
                             if _ri is not None:
                                 _x_ri, _obj_ri = _ri
@@ -8631,11 +8769,24 @@ def _solve_node_nlp_pounce(
     # Deterministic off-center fallback start (no RNG: determinism by default).
     off_center = lb_c + 0.382 * (ub_c - lb_c)
 
+    # F4: each ``_attempt`` is a full POUNCE solve that OVERRUNS its own
+    # ``max_wall_time`` clamp on the expensive-Hessian class (a nominal few-second
+    # budget ran ~10 s on heatexch_gen3), so a first attempt plus two alternative-
+    # start retries can push a single node NLP tens of seconds past a tight
+    # ``time_limit``. Poll an absolute deadline derived from the caller's remaining
+    # budget (``max_wall_time``) between retries and stop once it has passed. This
+    # never weakens correctness: a skipped retry only leaves the (already-computed)
+    # first-attempt result, and a node whose NLP failed stays OPEN at its inherited
+    # parent bound — a valid global lower bound — so the dual bound is untouched.
+    _t_node_entry = time.perf_counter()
+    _retry_deadline = _t_node_entry + max(_DEADLINE_NODE_FLOOR_S, float(caller_limit))
     result = _attempt(np.asarray(x0, dtype=np.float64), opts)
     if result.status not in (SolveStatus.OPTIMAL, SolveStatus.ITERATION_LIMIT):
         for alt in (midpoint, off_center):
             if np.allclose(alt, x0, atol=1e-12):
                 continue
+            if time.perf_counter() >= _retry_deadline:
+                break
             retry = _attempt(alt, opts)
             if retry.status in (SolveStatus.OPTIMAL, SolveStatus.ITERATION_LIMIT):
                 result = retry

--- a/python/tests/test_f4_root_budget_gate.py
+++ b/python/tests/test_f4_root_budget_gate.py
@@ -1,0 +1,278 @@
+"""F4 — root-heuristic NLP/compile budget gate restores the time_limit contract.
+
+Bottleneck-profile-2026-07-05 §4 / perf-followup-plan-2026-07-05 F4: on the
+no-relaxation flowsheet class the root PRIMAL-HEURISTIC phase blew past
+``solve(time_limit=T)`` because (a) the first heuristic NLP forced an
+uninterruptible first-time XLA Hessian compile and (b) each subsequent heuristic
+NLP overran its own ``max_wall_time`` clamp. The fix gates *entry* into those
+compile-/solve-triggering heuristics by the remaining budget. Every gated call is
+a primal heuristic, so skipping it is sound (dual bound untouched).
+
+These tests cover:
+  * the compile-cost estimate (a general function of model size, not an instance
+    name) and the evaluator's compiled-kernel flag;
+  * the end-to-end time-limit contract on a synthetic model with a deliberately
+    expensive first Hessian compile — fail-before (gate off) vs pass-after
+    (gate on), the §0.7 envelope.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import numpy as np
+import pytest
+from discopt._jax.nlp_evaluator import (
+    _HESSIAN_COMPILE_DENSE_S,
+    _HESSIAN_COMPILE_SPARSE_FLOOR_S,
+    NLPEvaluator,
+    estimate_hessian_compile_s,
+)
+from discopt.modeling.core import Model
+
+# The gate only bites when a real NLP backend runs the root heuristics.
+pytest.importorskip("pounce", reason="F4 gate is exercised through the POUNCE NLP path")
+
+
+# ── compile-cost estimate: a general size function, never an instance name ──────
+
+
+def test_estimate_dense_is_small_constant():
+    # Dense-Hessian path (small models) is bounded and cheap — never gates.
+    assert estimate_hessian_compile_s(n_vars=10, hessian_nnz=5, use_sparse=False) == pytest.approx(
+        _HESSIAN_COMPILE_DENSE_S
+    )
+    # Independent of size on the dense path.
+    assert estimate_hessian_compile_s(
+        n_vars=40, hessian_nnz=800, use_sparse=False
+    ) == pytest.approx(_HESSIAN_COMPILE_DENSE_S)
+
+
+def test_estimate_sparse_returns_conservative_floor():
+    # Sparse compressed-HVP path: compile is unpredictable and potentially huge
+    # (measured 1s..186s, R^2~0 vs size), so the estimate is a conservative floor.
+    est = estimate_hessian_compile_s(n_vars=300, hessian_nnz=1200, use_sparse=True)
+    assert est == pytest.approx(_HESSIAN_COMPILE_SPARSE_FLOOR_S)
+    assert est > _HESSIAN_COMPILE_DENSE_S
+
+
+def test_estimate_is_a_pure_size_function_not_instance_keyed():
+    # Same (size, path) -> same estimate regardless of anything else. This locks
+    # in "fix the class, not the instance" (§0.2): there is no name/shape hook.
+    a = estimate_hessian_compile_s(n_vars=200, hessian_nnz=900, use_sparse=True)
+    b = estimate_hessian_compile_s(n_vars=200, hessian_nnz=900, use_sparse=True)
+    assert a == b
+
+
+# ── evaluator compiled-kernel flag ─────────────────────────────────────────────
+
+
+def _big_sparse_model(n: int = 80) -> Model:
+    """A chained model whose Lagrangian Hessian is sparse and n>=50 (so the
+    evaluator takes the compressed-HVP path that the gate protects)."""
+    m = Model("f4_sparse")
+    xs = [m.continuous(f"x{i}", lb=0.1, ub=2.0) for i in range(n)]
+    # Nearest-neighbour coupling -> banded (sparse) Hessian, low density.
+    m.minimize(sum(xs[i] * xs[i + 1] for i in range(n - 1)) + sum(x * x for x in xs))
+    for i in range(0, n - 1, 4):
+        m.subject_to(xs[i] * xs[i + 1] >= 0.2)
+    return m
+
+
+def test_hessian_kernel_compiled_flag_flips_on_first_eval():
+    m = _big_sparse_model(60)
+    ev = NLPEvaluator(m)
+    assert ev.hessian_kernel_compiled() is False
+    # Estimate is positive while uncompiled (sparse path), 0 once compiled.
+    if ev._use_sparse_hessian():
+        assert ev.hessian_compile_estimate_s() > 0.0
+    lb, ub = ev.variable_bounds
+    x0 = 0.5 * (lb + ub)
+    lam = np.ones(ev.n_constraints, dtype=np.float64)
+    ev.evaluate_hessian_values(x0, 1.0, lam)
+    assert ev.hessian_kernel_compiled() is True
+    # Already compiled -> the estimate is now zero (cost already spent).
+    assert ev.hessian_compile_estimate_s() == 0.0
+
+
+# ── diving honours the absolute deadline (deterministic, no timing) ─────────────
+
+
+def test_diving_returns_immediately_when_deadline_passed():
+    """``diving`` (the LNS/root fallback that loops ~n_int sub-NLPs) must poll the
+    absolute deadline and launch NO sub-NLP once it has passed — the F4 fix that
+    stops these loops from running tens of seconds past a tight ``time_limit``.
+    Deterministic: with a deadline already in the past not a single backend call
+    is made. Fail-before: without the deadline poll the first sub-NLP would run."""
+    from discopt._jax.primal_heuristics import diving
+
+    m = Model("dive")
+    x = m.continuous("x", lb=0.0, ub=5.0)
+    z = m.integer("z", lb=0, ub=5)
+    m.minimize((x - 2.5) ** 2 + z)
+    m.subject_to(x + z >= 3)
+
+    calls = {"n": 0}
+
+    def _counting_backend(evaluator, x0, options=None):
+        calls["n"] += 1
+        raise AssertionError("backend must not be called past the deadline")
+
+    out = diving(
+        m,
+        np.array([2.5, 1.7]),
+        backend=_counting_backend,
+        deadline=time.perf_counter() - 1.0,  # already elapsed
+    )
+    assert out is None
+    assert calls["n"] == 0
+
+
+# ── end-to-end time-limit contract (fail-before / pass-after) ───────────────────
+
+
+def _expensive_compile_minlp() -> Model:
+    """A synthetic model that reproduces the F4 overrun mechanism generically —
+    no named instance. Two properties matter:
+
+      * ``log`` of a *product* of variables is not linearizable, so (like the
+        no-relaxation flowsheet class: contvar/heatexch_gen3) the MILP relaxation
+        omits these rows and the ONLY NLP that runs is the root PRIMAL HEURISTIC —
+        exactly the compile-triggering call F4 gates. A model that keeps a
+        linearizable relaxation would spend its first compile in the relaxation
+        build (a different, non-heuristic site), so the log-of-product structure
+        is essential to isolate the heuristic path.
+      * a wide (n>=50) transcendental DAG makes that first sparse-Hessian compile
+        slow enough to blow a small ``time_limit`` (measured ~6-12 s in-solve).
+
+    Integer variables make the root heuristics fire; the model is feasible so the
+    gate can be checked for incumbent preservation, not just wall time."""
+    import discopt.modeling as dm
+
+    m = Model("f4_expensive_compile")
+    # n=110 is chosen so the cold first-compile reliably overruns a time_limit=5
+    # solve (measured ~20 s ungated) while the model stays feasible and the gated
+    # solve still finds an incumbent — large enough to witness the overrun, small
+    # enough that the gate does not have to drop the only incumbent.
+    n = 110
+    xs = [m.continuous(f"x{i}", lb=0.3, ub=3.0) for i in range(n)]
+    zs = [m.integer(f"z{i}", lb=0, ub=3) for i in range(4)]
+    obj = 0.0
+    for i in range(n - 1):
+        # log(exp(x_i*x_{i+1}) + x_i^2 + 1): a non-linearizable transcendental of
+        # a product -> omitted from the MILP relaxation, heavy second-derivative.
+        obj = obj + dm.log(dm.exp(xs[i] * xs[i + 1]) + xs[i] * xs[i] + 1.0)
+    obj = obj + sum(z * z for z in zs)
+    m.minimize(obj)
+    for i in range(0, n - 1, 3):
+        m.subject_to(dm.log(xs[i] * xs[i + 1] + 0.2) + 0.1 * zs[i % 4] >= 0.1)
+    return m
+
+
+_TIME_LIMIT = 5.0
+_ENVELOPE = _TIME_LIMIT * 1.1 + 5.0  # §0.7: T*1.1 + 5 = 10.5 s
+
+# The solve runs in a FRESH interpreter with the persistent XLA cache disabled so
+# the first compile is truly cold. The child also counts root/heuristic NLP solves
+# launched *after the deadline had passed* — the deterministic, machine-speed-
+# independent signal of the bug: the ungated build launches such a solve (an
+# unbounded overrun), the gated build launches none. Absolute compile time is
+# itself unpredictable (R^2 ~ 0 vs model size — the very reason F4 gates ENTRY
+# rather than trying to time the compile), so the count, not the wall, is the
+# assertion. It prints "RESULT <wall> <obj> <post_deadline_launches>".
+_CHILD = """
+import os, sys, time
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+os.environ["DISCOPT_DISABLE_JAX_CACHE"] = "1"
+os.environ["DISCOPT_ROOT_BUDGET_GATE"] = sys.argv[1]
+import discopt.solvers.nlp_pounce as _npounce
+import test_f4_root_budget_gate as T
+_state = {"deadline": None, "post": 0}
+_orig = _npounce.solve_nlp
+def _wrapped(ev, x0, *a, **k):
+    d = _state["deadline"]
+    if d is not None and time.perf_counter() >= d:
+        _state["post"] += 1
+    return _orig(ev, x0, *a, **k)
+_npounce.solve_nlp = _wrapped
+m = T._expensive_compile_minlp()
+_state["deadline"] = time.perf_counter() + __TL__
+t0 = time.perf_counter()
+res = m.solve(time_limit=__TL__, gap_tolerance=1e-4)
+wall = time.perf_counter() - t0
+print(f"RESULT {wall:.3f} {res.objective} {_state['post']}")
+""".replace("__TL__", repr(_TIME_LIMIT))
+
+
+def _solve_under_gate(env_gate: str):
+    """Run one cold-cache solve in a subprocess; return (wall, objective,
+    post_deadline_nlp_launches)."""
+    import subprocess
+
+    env = dict(os.environ)
+    here = os.path.dirname(__file__)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [here, os.path.join(here, "..")] + [env.get("PYTHONPATH", "")]
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHILD, env_gate],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=240,
+    )
+    line = [ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT ")]
+    if not line:
+        raise AssertionError(f"child failed (gate={env_gate}):\n{proc.stdout}\n{proc.stderr}")
+    _, wall_s, obj_s, post_s = line[-1].split(maxsplit=3)
+    obj = None if obj_s == "None" else float(obj_s)
+    return float(wall_s), obj, int(post_s)
+
+
+@pytest.mark.slow
+def test_gate_bounds_post_deadline_nlp_launches_fail_before():
+    """FAIL-BEFORE / PASS-AFTER on post-deadline heuristic NLP launches.
+
+    Root heuristic NLPs launched *after* the deadline are the F4 overrun (each is
+    an uninterruptible, unbounded solve). The gate must never launch MORE of them
+    than the ungated build, and — when the overrun reproduces (>1 launch ungated,
+    which needs a genuinely slow first compile) — must strictly reduce them. When
+    the compile is fast on this machine (the ungated build launches at most the
+    single un-gateable bound-source start), the multi-launch overrun cannot be
+    exercised here, so we skip; the gate's decision itself is locked
+    deterministically by ``test_entry_gate_decision_is_deterministic`` and its
+    contract effect panel-wide in the PR's §0.7 table. Runs cold-cache in a fresh
+    interpreter so the compile is genuinely first-time."""
+    _, _, post_off = _solve_under_gate("0")
+    _, _, post_on = _solve_under_gate("1")
+    # The gate must never make things worse.
+    assert post_on <= post_off, f"gate INCREASED post-deadline launches: {post_on} > {post_off}"
+    if post_off <= 1:
+        pytest.skip(
+            f"multi-launch overrun did not reproduce (ungated post-deadline "
+            f"launches={post_off}); compile too fast on this machine"
+        )
+    # Overrun reproduced: the gate must strictly cut the extra launches.
+    assert post_on < post_off
+
+
+def test_entry_gate_decision_is_deterministic():
+    """Unit test of the gate's decision surface (no timing): the compile estimate
+    is what the solver's ``_root_heur_nlp_entry_ok`` compares the remaining budget
+    against. For an uncompiled sparse-Hessian evaluator the estimate exceeds a
+    tiny budget (so entry is refused) and is zero once compiled (so entry is
+    allowed). This locks the fail-before logic independently of wall clock."""
+    m = _big_sparse_model(60)
+    ev = NLPEvaluator(m)
+    if not ev._use_sparse_hessian():
+        pytest.skip("model did not take the sparse compressed-HVP path on this build")
+    # Uncompiled: estimate is the conservative sparse floor -> exceeds a 5 s budget.
+    est = ev.hessian_compile_estimate_s()
+    assert est > 5.0
+    # After a compile the estimate collapses to zero (cost already spent).
+    lb, ub = ev.variable_bounds
+    ev.evaluate_hessian_values(0.5 * (lb + ub), 1.0, np.ones(ev.n_constraints))
+    assert ev.hessian_compile_estimate_s() == 0.0


### PR DESCRIPTION
Implements **F4** from `docs/dev/perf-followup-plan-2026-07-05.md`: restore the
`solve(time_limit=T)` contract on the root primal-heuristic phase.

## Entry experiment (before the fix) — two premises falsified (profile §5 item 9)

- **The 221 s contvar overrun does NOT reproduce on this build.** contvar
  returns in **60.7 s** (root 29.3 s) at `time_limit=60` — already inside the
  §0.7 envelope (the 221 s was pounce 0.8.0 / an earlier snapshot). The
  reproducing overruns on this build are **heatexch_gen3 (80.7 s)** and
  **hda (64.2 s)**.
- **Compile time is not a function of cheap model size.** Measured first-time
  sparse-Hessian XLA compile (standalone, 7 MINLPLib models): tls2 0.15 s
  (dense), fac2 0.15 s (dense), heatexch_gen1 1.1 s, hda 2.5 s (n=722),
  casctanks 5.0 s, heatexch_gen3 49 s (n=580), **contvar 186 s (n=296)**.
  Regressing `log(compile)` on `n_vars` gives **R² = 0.002** — essentially
  uncorrelated (contvar at n=296 compiles ~74× slower than hda at n=722), and
  the same model varies 2.5→8.3 s run-to-run. **No fitted curve exists**; the
  cost is governed by the DAG's shape/depth, not any cheap scalar. So the
  estimate is a **conservative floor** (dense 0.5 s; uncompiled sparse 15 s
  risk-headroom), not a point predictor. Used only to gate *primal-heuristic*
  entry, so over-estimating merely skips a heuristic (sound; never the dual
  bound).
- **Kill criterion partially fired.** The panel overrun is a *heuristic* one as
  diagnosed, but it is **not one uninterruptible compile** — it is repeated
  post-deadline heuristic-NLP launches, each overrunning its own `max_wall_time`
  clamp (a nominal 3 s POUNCE solve runs ~10–15 s because the exact Hessian per
  IPM iteration is expensive). And an **out-of-panel** flowsheet (super3t)
  exposed a genuinely *different* overrun site (below).

## The fix (heuristic-policy; no dual-bound effect)

- `NLPEvaluator`: `hessian_kernel_compiled()` flag (set on the first
  `evaluate_hessian_values`) + `hessian_compile_estimate_s()` backed by a
  module-level `estimate_hessian_compile_s(n_vars, hessian_nnz, use_sparse)` —
  a general size function, never instance-keyed.
- `solve_model`: a nested `_root_heur_nlp_entry_ok()` gate — refuses to launch a
  root heuristic NLP when the time left cannot absorb another worst-case observed
  solve, or when the (uncompiled) sparse compile estimate does not fit — applied
  to **every** root heuristic NLP: feasibility_pump, NLP-relax pump, the
  subnlp gams-seed / midpoint-fallback / candidate loop, binary-seed enumeration,
  integer box-search, and LNS node-diving/RINS. The absolute deadline is threaded
  through.
- `primal_heuristics.diving`/`rins`: new `deadline` arg — poll before each
  sub-NLP (these loops ran tens of seconds past the limit).
- `_solve_root_node_multistart`: cap the *extra* starts by the observed
  worst-case per-start cost (the first start — the bound source — always runs, so
  the relaxation bound is preserved).
- `_solve_node_nlp_pounce`: poll a per-node deadline between the
  alternative-start retries.

Off switch: `DISCOPT_ROOT_BUDGET_GATE=0`.

## Results (pounce 0.7.0, M-series arm64)

| instance | baseline | gated | §0.7 env (TL=60 → 71 s) |
|---|---|---|---|
| contvar | 61.1 s | **60.7 s** | ✓ |
| heatexch_gen3 | 80.7 s | **60.9 s** | ✓ |
| hda | 64.2 s | **64.1 s** | ✓ |

- **§0.7 panel-wide:** full 61-instance vendored set at `time_limit=30`
  (envelope 38 s): **61/61 within envelope, 0 OVER** with the gate on. Gate-off
  baseline had 1 OVER (heatexch_gen3 39.5 s).
- **Objective-neutrality + incumbent quality:** gate-on vs gate-off across the
  61-instance panel: **0 objective differences (>1e-4 rel), 0 lost incumbents,
  0 gained.** (Certified objectives unchanged; no incumbent quality lost.)
- **hda root:** 42 s = 70 % of a 60 s budget — the aspirational ≤50 % root
  target is **not** met, but hda's *wall* respects the contract; its root is
  dominated by Rust presolve + JAX re-tracing, not the gated heuristics.

## Class witness / second overrun site (kill criterion)

Out-of-panel large flowsheet **super3t** overruns `time_limit=30` at
**74 s ungated / 40 s gated** — but its residual overrun is **not** a heuristic
NLP (an instrumented solve makes **zero** `solve_nlp` calls). Its root time is
in `_jax/term_classifier._compute_var_offset` — the McCormick relaxation
term-classification build, an uninterruptible pass that predates the heuristic
phase. This is a **distinct overrun site outside F4's scope** (F4 halves it as a
side effect but cannot close it), filed as follow-up **#507**.

## Tests / gates

- New `python/tests/test_f4_root_budget_gate.py`: compile-estimate unit tests (a
  general size function, not instance-keyed), the evaluator compiled-kernel flag,
  a **deterministic** `diving`-deadline fail-before (no sub-NLP launched past the
  deadline), a deterministic entry-gate decision test, and a cold-cache
  subprocess fail-before/pass-after on post-deadline heuristic-NLP launches.
- `pytest -m smoke` (python/tests): **574 passed, 11 skipped**.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed**.
- `ruff check` + `ruff format --check`: clean. `mypy`: no new errors from the
  changed files (local numpy-stub/py312 env artifact aside).
- **No Rust touched**, so `cargo test` is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
