### PR TITLE
perf(relaxation): F5 — composite even-power envelope for the pinning class (flagged, default-off)

### DIFF
--- a/docs/dev/bottleneck-profile-2026-07-05.md
+++ b/docs/dev/bottleneck-profile-2026-07-05.md
@@ -438,6 +438,67 @@ overwritten:
    the heuristic phase. This is a **distinct overrun site** outside F4's scope
    (F4 halves it as a side effect but cannot close it); it needs its own
    entry/streaming gate and is filed as F4 follow-up **#507**.
+10. **"F5: st_e36's root bound is pinned by a variable-box-independent
+    even-power composite envelope; thread the argument interval into
+    `relax_pow` to lift it"** (§3 st_e36 row; §7 F5; plan §2 F5).
+    *Correction — KILL CRITERION HIT (F5 entry experiment,
+    `perf-f5-composite-power-envelope`, pounce 0.7.0, M4 Pro; no code
+    shipped):* the F5 premise is **falsified on three independent grounds**;
+    the composite even-power envelope is *not* the defect and building the
+    flag would be a dead lever (CLAUDE.md §3).
+    (a) **The pinned bound is the objective's own true box-minimum, and the
+    objective has no `±(inner)²` composite at all.** st_e36's objective is a
+    plain polynomial `2·x0² + 0.008·x1³ − 3.2·x0·x1 − 2·x1`. Its true
+    minimum over the box (ignoring constraint C0), by dense sampling, is
+    **−304.5000 for x1 ∈ [15,25], [20,25], AND [24,25]** — bit-identical
+    because the minimizer is the shared corner `(x0=5.5, x1=25)` (obj
+    −304.5). The measured discopt root bound `−304.5000003055` matches this
+    to 7 digits, i.e. **the relaxation is already essentially exact for the
+    objective**; there is no envelope slack on the pinning term. The bound is
+    box-independent because the *objective's argmin-over-box* is
+    box-independent, not because any envelope discards interval information.
+    (b) **st_e36's only `(inner)²` composites live in constraint C0 and all
+    carry coefficient `+1` (convex), whose true convex under-envelope equals
+    the function itself.** C0 `= f1·(f2·f3·f4·f5)` with `f1 =
+    x0²−6x0−11+0.8x1` and `f2..f5 = (affine)² + (affine)²` (sums of squares,
+    strictly ≥ 0). A scipy convex-hull LP over the graph of a representative
+    factor `(−0.62·x1+3.25·x0)²` gives, at the box center, `true convex
+    under-envelope = f(center)` to machine precision on **both** [15,25]
+    (1.99516) and [24,25] (1.89751) — **gap 0**; the values differ only
+    because the query point moves. For a *convex* composite the convex
+    underestimator is exact and there is nothing to tighten. (The
+    box-dependent side is the *concave* over-envelope / secant, and only a
+    *negative*-coefficient square `−(inner)²` would have a box-dependent
+    *under*-envelope — which st_e36 does not contain: verified the −(inner)²
+    under-envelope does move, −53.30 → −21.02, but that structure is absent.)
+    Moreover `mccormick.py::relax_pow`'s even branch already returns
+    `cv = mid²` with `mid = ½(cv_l+cc_l)` — it **already threads the
+    composite argument's interval** `[cv_l, cc_l]` and reproduces the exact
+    convex-hull value; the "variable-box-independent fallback" the plan
+    posited does not exist on this path.
+    (c) **st_e36 never calls `relax_pow` and the pin survives a perfect
+    square envelope: C0's relaxed interval spans 0 on every box because f1
+    crosses 0.** Instrumenting `relax_pow` records **0 calls** on st_e36's
+    root solve — the default LP relaxer lifts each `(inner)²` to an aux and
+    separates it via `_separate_univariate_square` (interval-dependent
+    already), so the F5 target line (`mccormick.py:203`) is not even on
+    st_e36's path. Independently, `f1 = x0²−6x0−11+0.8x1` ranges over
+    `[−8.0,6.25]` / `[−4.0,6.25]` / `[−0.8,6.25]` on the three boxes — it
+    **spans 0 on all of them** — so `C0 = f1·(positive)` relaxes to an
+    interval spanning 0 regardless of how tight the `+(inner)²` factors are.
+    No even-power envelope can exclude the objective corner `(5.5,25)` (where
+    C0 = 374 442 ≠ 0, corner infeasible) while f1's own relaxation still
+    admits 0. The bound *does* respond to the box — but through the variables
+    that enter the objective/f1 **linearly/quadratically**: shrinking x0 to
+    [5,5.5] lifts −304.5 → **−246.0**, to [3,3.5] → −182.7; fixing x1 = 22 →
+    −278.9. That is branch-and-reduce on the *product/quadratic* structure
+    (cert-gap-plan territory), not a composite-power-envelope fix.
+    **Conclusion:** F5 as specified cannot help this class; the flag would be
+    inert. The real st_e36 lever is tightening the **product-of-factors /
+    f1-quadratic-crossing** relaxation of C0 (RLT/edge-concave on the lifted
+    product, or spatial branching on x0) — re-scope under the branch-and-
+    reduce roadmap (cert-gap-plan), not the relaxation-envelope catalog. No
+    feature flag added; no relaxation code changed.
 
 ---
 

--- a/docs/dev/perf-followup-plan-2026-07-05.md
+++ b/docs/dev/perf-followup-plan-2026-07-05.md
@@ -442,6 +442,31 @@ worktrees/sessions if desired, but each in its own PR.
 - **Acceptance:** st_e36 root bound strictly improves when x1's box shrinks;
   st_e36 certifies ≪897 nodes (profile predicts ~5–10). Default flip only
   after two green nightlies.
+- **Status: KILLED at the entry experiment — premise falsified, nothing
+  shipped** (branch `perf-f5-composite-power-envelope`, pounce 0.7.0,
+  M4 Pro; profile §5 item 10). The composite even-power envelope is **not**
+  st_e36's defect, on three grounds: (a) the pinned root bound
+  `−304.5000003055` *is* the objective's own true box-minimum (a plain
+  polynomial `2x0²+0.008x1³−3.2x0x1−2x1` whose argmin is the shared corner
+  `(5.5,25)`; dense-sampled box-min = −304.5000 for all of [15,25]/[20,25]/
+  [24,25]) — the relaxation is already essentially exact for the objective,
+  so there is no envelope slack to recover; (b) every `(inner)²` in st_e36
+  (all in constraint C0) has coefficient **+1** (convex), whose true convex
+  under-envelope *equals the function* (scipy convex-hull LP: gap 0 on both
+  boxes) — and `relax_pow`'s even branch already threads the argument
+  interval and returns exactly that, so the "variable-box-independent
+  fallback" the task posited does not exist; (c) st_e36 makes **0**
+  `relax_pow` calls (the LP relaxer lifts squares to auxes) and, decisively,
+  `f1 = x0²−6x0−11+0.8x1` spans 0 on **every** box (`[−8,6.25]`/`[−4,6.25]`/
+  `[−0.8,6.25]`), so `C0 = f1·(positive)` relaxes to an interval spanning 0
+  regardless of the square factors' tightness — no even-power envelope can
+  cut the corner. The bound *does* move with the box, but via the objective/
+  f1 quadratic-bilinear structure (shrink x0→[5,5.5] lifts −304.5→−246.0;
+  fix x1=22→−278.9), i.e. a **branch-and-reduce / product-relaxation**
+  lever, not an envelope one. Per CLAUDE.md §3 (no dead flags) the
+  `DISCOPT_COMPOSITE_POW_ENVELOPE` flag was **not** added and no relaxation
+  code changed. Re-scope st_e36 under the branch-and-reduce roadmap
+  (cert-gap-plan): tighten C0's product-of-factors / f1-crossing relaxation.
 
 ### F6 — Node-NLP volume/engine on the nvs05/tls2 class  (B12; paired with upstream)
 


### PR DESCRIPTION
## F5 — Even-power composite envelope for the pinning class (st_e36)

**Task:** F5 from `docs/dev/perf-followup-plan-2026-07-05.md` (B11; bound-changing, strict regime).
**Outcome: KILLED at the entry experiment. The premise is falsified; nothing is shipped.** No feature flag, no relaxation-code change — this PR is docs-only (records the finding, per CLAUDE.md §4/§3 falsification discipline).

### What F5 assumed
That st_e36's box-independent root bound (−304.5000003055, bit-identical for x1 ∈ [15,25]/[20,25]/[24,25]) is caused by a *variable-box-independent even-power composite envelope* discarding the argument's interval — fixable by threading the composite argument's interval into `relax_pow` (`mccormick.py:203`), behind `DISCOPT_COMPOSITE_POW_ENVELOPE` (default OFF).

### Entry experiment (reproduced on this build: pounce 0.7.0, JAX 0.10.2, M4 Pro)

**1. The pinned bound is the objective's own true box-minimum, and the objective has no `±(inner)²` composite.**
st_e36's objective is a plain polynomial `2·x0² + 0.008·x1³ − 3.2·x0·x1 − 2·x1`. Its true minimum over the box (ignoring C0), by dense sampling, is **−304.5000 for all three x1 boxes** — bit-identical because the minimizer is the shared corner `(x0=5.5, x1=25)`. The measured discopt root bound `−304.5000003055` matches this to 7 digits → the relaxation is **already essentially exact for the objective**; there is no envelope slack on the "pinning term". The bound is box-independent because the objective's *argmin-over-box* is box-independent.

**2. Every `(inner)²` in st_e36 (all in constraint C0) carries coefficient +1 (convex), whose true convex under-envelope equals the function.**
C0 `= f1·(f2·f3·f4·f5)`, `f1 = x0²−6x0−11+0.8x1`, `f2..f5 = (affine)²+(affine)²` (sums of squares, ≥ 0). A scipy convex-hull LP over the graph of a representative factor `(−0.62·x1+3.25·x0)²` gives, at the box center, **true convex under-envelope = f(center) to machine precision on both [15,25] and [24,25] (gap 0)**; values differ only because the query point moves. A convex function's convex underestimator is exact. `relax_pow`'s even branch already returns `cv = mid²` with `mid = ½(cv_l+cc_l)` — it **already threads the argument interval** `[cv_l,cc_l]` and reproduces the exact hull value. The posited "variable-box-independent fallback" does not exist on this path. (Only a *negative*-coefficient square `−(inner)²` has a box-dependent *under*-envelope — verified it moves, −53.30 → −21.02 — but st_e36 contains none.)

**3. st_e36 makes 0 `relax_pow` calls, and the pin survives a perfect square envelope.**
Instrumenting `relax_pow` records **0 calls** on st_e36's root solve — the default LP relaxer lifts each `(inner)²` to an aux and separates it via `_separate_univariate_square`, so the F5 target line is not on st_e36's path. Independently, `f1` ranges over `[−8,6.25]` / `[−4,6.25]` / `[−0.8,6.25]` on the three boxes — it **spans 0 on all of them** — so `C0 = f1·(positive)` relaxes to an interval spanning 0 regardless of the square factors' tightness. No even-power envelope can exclude the objective corner `(5.5,25)` (where C0 = 374 442 ≠ 0) while f1's own relaxation still admits 0.

### Root-bound-vs-box (measured)

| x1 box | root bound | note |
|---|---:|---|
| [15,25] | −304.5000003055 | full box |
| [20,25] | −304.5000003055 | bit-identical |
| [24,25] | −304.4990978105 | negligible move |
| x1 fixed = 22 | −278.8752 | fixing lifts it |
| x0 → [5.0,5.5] | −246.0418 | quadratic/bilinear lever |
| x0 → [3.0,3.5] | −182.6550 | quadratic/bilinear lever |

The bound *does* respond to the box — through the variables that enter the objective/f1 **linearly/quadratically** (branch-and-reduce on the product/quadratic structure), **not** through any even-power composite envelope.

### What relaxation-catalog.md says about composite-power envelopes
The catalog (§1 `relax_pow`/`relax_power_int`; §3 "Repeated-factor lifting" / `factorable_reform.py`; §6.D exact bilinear→multilinear RLT hull; §6.F even-power `x**p` handled) treats even-power composites as **done**: the even branch is `cv = x^n` (exact convex underestimator) + secant over-estimator, and composite `(inner)²` is lifted and relaxed through the LP path's square/RLT machinery. It also states the layer is at "SOTA parity for the factorable/polynomial core" and the remaining distance is **bound-tightening orchestration (§7)** — i.e. branch-and-reduce, exactly the st_e36 lever. Per the catalog's "do not rebuild what it lists as done" rule, F5 would rebuild an already-exact envelope.

### Decision
Per CLAUDE.md §3 (no dead flags, no features that can't help), the `DISCOPT_COMPOSITE_POW_ENVELOPE` flag was **not** added and no relaxation code was changed. The st_e36 lever is the **product-of-factors / f1-quadratic-crossing** relaxation of C0 (RLT / edge-concave on the lifted product, or spatial branching on x0) — re-scope under the branch-and-reduce roadmap (`cert-gap-plan`), not the relaxation-envelope catalog.

### Changes (docs-only)
- `docs/dev/bottleneck-profile-2026-07-05.md` — §5 item 10: the F5 falsification, house style.
- `docs/dev/perf-followup-plan-2026-07-05.md` — F5 Status: KILLED, with the three-ground finding.

### Gates
Docs-only, no code touched → `pytest -m smoke`, adversarial suite, `cargo test -p discopt-core`, `ruff`, `mypy` are N/A (no source changed; pre-commit hooks ran clean on commit). The bound-changing verification regime (differential bound test + feasible-point sampling) is moot: no bound-changing code exists in this PR. Because nothing ships, the flag-OFF cert-baseline is trivially byte-identical to `main`.

Do not merge without maintainer review of the kill decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
