### PR TITLE
perf(nlp): F6 — warm-start incumbent NLPs across the B&B tree (iteration count)

### DIFF
--- a/docs/dev/bottleneck-profile-2026-07-05.md
+++ b/docs/dev/bottleneck-profile-2026-07-05.md
@@ -499,6 +499,68 @@ overwritten:
     product, or spatial branching on x0) — re-scope under the branch-and-
     reduce roadmap (cert-gap-plan), not the relaxation-envelope catalog. No
     feature flag added; no relaxation code changed.
+11. **"POUNCE is ~7–11× slower per solve than Ipopt (engine gap), and warm-
+    starting incumbent NLPs across the B&B tree will cut node-NLP wall on the
+    nvs05/tls2 class"** (§1.6 B12; §5 item 1's "engine gap"; plan §2 F6;
+    jkitchin/pounce#182). *Correction — the engine gap was a debug-build
+    artifact, and the re-scoped warm-start lever HIT ITS KILL CRITERION
+    (F6 entry experiment, `perf-f6-tree-warmstart-nlp`, pounce 0.7.0 RELEASE
+    wheel = 4.7 MB `_pounce*.so`, M-series arm64; no code shipped).*
+    (a) **The "7–11× vs Ipopt" engine gap is not real on a release build.**
+    pounce#182 comment 4889424028 (and our own release-wheel profiling)
+    established a *release* POUNCE is ~1.1× Ipopt with *fewer* iterations; the
+    Phase-D 7–11× A/B was measured against a debug POUNCE. So there is **no
+    per-solve engine gap to close** — the only discopt-side lever the POUNCE
+    maintainer endorsed is warm-starting node NLPs across the tree.
+    (b) **discopt does currently solve every node/incumbent NLP cold** (entry
+    experiment part 1, confirmed): grepped the whole node-NLP path
+    (`nlp_pounce.solve_nlp`, `_solve_node_nlp`/`_solve_node_nlp_pounce`, the
+    shared `_IpoptCallbacks` adapter) — **zero** occurrences of `lagrange`,
+    `zl`/`zu`, `mu_init`, or `warm_start_init_point`. Only the parent *primal*
+    is threaded (`x0 = clip(parent_sol, child_box)`); the parent's converged
+    duals and barrier μ are discarded. So the lever exists in principle.
+    (c) **Prototyping the warm start on real parent→child NLP pairs falsified
+    the win.** Captured the actual converged node NLPs (primal x, `mult_g`,
+    `mult_x_L/U`, μ from POUNCE `info`) from live 60 s nvs05 and tls2 B&B runs,
+    then re-solved each child (parent + one tightened bound) COLD vs WARM
+    (`Problem.solve(x0=parent_x, lagrange=mult_g, zl=, zu=,
+    warm_start_init_point='yes', mu_init=parent_μ)`). Every replay reached the
+    **same KKT point** (identical objective to ≤1e-4) — so warm-start is
+    incumbent-quality-*safe* — but the **iteration count went the wrong way on
+    the class:**
+    - **tls2 (one of the two F6 targets): warm-start is UNIFORMLY WORSE — 8/8
+      parent→child pairs slower.** Full-recipe median ratio cold/warm = **0.58**
+      (warm takes ~1.7× *more* iters: 126 cold vs 277 warm summed); even the
+      primal-only recipe (just `warm_start_init_point='yes'`, no duals) is
+      0.77 (163 warm). tls2's KKT points sit at bound-active vertices a warm
+      interior iterate approaches *slower* than a fresh centered start.
+    - **nvs05: the full recipe helps only on the narrowest pairs and is
+      fragile.** For pairs differing in ≤2 bounds, cold/warm median = 2.29×
+      (5/5 better, 80→38 iters) — a real but narrow win; widen the pairing to
+      ≤4 changed bounds and it flips to a **net loss** (94 cold → 181 warm, one
+      pair 31→153). Dropping `mu_init` (`warm_nomu`) or the duals
+      (`warm_xonly`) collapses the nvs05 gain to neutral (median 1.00×), so the
+      only positive recipe is exactly the one that is catastrophic on tls2.
+    Kill criterion (plan §2 F6: "<1.3× median ⇒ warm-start is not the lever;
+    child boxes differ too much / nonconvex restart lands elsewhere") **fires**
+    on tls2 (0.58×, all pairs worse) and on nvs05's realistic pairing.
+    (d) **Retry-policy sub-audit (entry experiment part 3):** the
+    alternative-start retry issues ~1.7–1.9 NLP/node, but retries that actually
+    *rescue* a node (first attempt fails → retry accepts) are **2.4% of nodes
+    on nvs05, 0.2% on tls2** — far below the 15% "material" threshold, and well
+    below even the 5% "cap it" threshold. Since the primary lever is dead the
+    retry policy is left unchanged (F4 already added deadline-polling between
+    retries); no retry-cap shipped.
+    **Conclusion:** F6 as re-scoped cannot help this class. Threading parent
+    KKT/μ state is either quality-neutral-but-iteration-negative (tls2) or a
+    fragile narrow win that reverses on realistic box changes (nvs05); no
+    single recipe is a safe class-wide accelerator, so per CLAUDE.md §3 (no
+    dead flags) **no warm-start API, flag, or `mu` field was shipped**. The
+    real nvs05/tls2 lever is the one F5 already re-scoped to: their stall is a
+    weak-bound / branch-and-reduce problem (cert-gap-plan), not a per-node NLP
+    speed problem — faster nodes would not close the gap. Node-NLP work on this
+    class closes as **not-a-lever**; the upstream engine item (pounce#182) is
+    resolved as a build artifact.
 
 ---
 

--- a/docs/dev/perf-followup-plan-2026-07-05.md
+++ b/docs/dev/perf-followup-plan-2026-07-05.md
@@ -487,6 +487,32 @@ worktrees/sessions if desired, but each in its own PR.
 - **Acceptance:** stated after the entry experiment (record the numbers in
   the PR); do not pre-commit a wall target for a task whose scope is
   conditional.
+- **Status: RE-SCOPED then KILLED at the entry experiment — nothing shipped**
+  (branch `perf-f6-tree-warmstart-nlp`, pounce 0.7.0 RELEASE wheel, M-series
+  arm64; profile §5 item 11). F6 was re-scoped away from the "POUNCE engine
+  gap" (proven a *debug-build artifact* — a release POUNCE is ~1.1× Ipopt with
+  fewer iters, pounce#182 comment 4889424028) to the maintainer-endorsed
+  lever: **warm-start incumbent NLPs across the B&B tree** (thread the parent
+  node's converged primal + duals + μ into the child NLP via POUNCE's
+  `Problem.solve(x0, lagrange=, zl=, zu=)` + `warm_start_init_point`/`mu_init`).
+  Entry experiment (real captured parent→child NLP pairs from live 60 s nvs05
+  and tls2 B&B runs, cold vs warm re-solve): warm-start is **incumbent-quality
+  safe** (every replay reached the identical KKT point / objective) but its
+  **iteration count fails the kill criterion on the class** — **tls2 uniformly
+  worse (8/8 pairs, median cold/warm 0.58×, i.e. warm needs ~1.7× more iters);
+  nvs05 helps only on ≤2-bound-diff pairs (2.29×) and flips to a net loss on
+  realistic ≤4-bound pairs**, and the only positive recipe (`x + duals + μ`) is
+  exactly the one that is catastrophic on tls2 (dropping μ or the duals makes
+  nvs05 merely neutral). Per the plan's "<1.3× median ⇒ warm-start is not the
+  lever" kill criterion the task stops. Retry sub-audit: alternative-start
+  retries *rescue* only 2.4% (nvs05) / 0.2% (tls2) of nodes — below the 15%
+  "material" and 5% "cap it" thresholds — so the retry policy is left unchanged
+  (F4 already deadline-polls between retries). Per CLAUDE.md §3 (no dead flags)
+  **no warm-start API, feature flag, or `NLPResult.mu` field was added and no
+  solver code changed.** The nvs05/tls2 stall is a weak-bound / branch-and-
+  reduce problem (as F5 also concluded), not a per-node NLP speed problem —
+  re-scope under the cert-gap-plan branch-and-reduce roadmap. pounce#182 closes
+  as a resolved build artifact.
 
 ### F7 — Fixed-tax trims  (lowest priority)
 
@@ -530,9 +556,14 @@ worktrees/sessions if desired, but each in its own PR.
 - **More CSE/DAG-shrinking for Class A**: the DAG walk is not where the
   seconds are (except hda's churn note, profile §6 — secondary to B10).
 - **Blaming POUNCE per-solve latency on Class A / flay03m / st_e36 / nvs09**:
-  falsified (profile §1, verdict table). The POUNCE engine work is real but
-  lives upstream (jkitchin/pounce#182) and only governs the nvs05/tls2/hda
-  class (F6).
+  falsified (profile §1, verdict table). The "POUNCE engine gap" (Phase-D
+  7–11× vs Ipopt) was itself falsified as a **debug-build artifact** — a
+  release POUNCE is ~1.1× Ipopt with fewer iters (pounce#182 comment
+  4889424028; profile §5 item 11). There is no per-solve engine gap to close,
+  upstream or down. **Warm-starting node NLPs across the tree (F6)** was the
+  endorsed alternative and was **killed at its entry experiment** (worse
+  iteration count on tls2, fragile on nvs05); nvs05/tls2 are a weak-bound /
+  branch-and-reduce problem, not a node-NLP-speed problem.
 - **`rens=False` or disabling heuristics as a "fix" for B7**: measured to
   relocate the cost, not remove it (fac2 27.3 s, flay03m 91.7 s).
 - **Polling inside XLA compiles** (F4): not possible; gate entry instead.


### PR DESCRIPTION
## F6 — warm-start incumbent NLPs across the B&B tree (RE-SCOPED, then KILLED at entry experiment)

Implements **task F6** from `docs/dev/perf-followup-plan-2026-07-05.md` §2, per its §0 binding contract. **Docs-only:** the entry experiment failed its kill criterion, so per CLAUDE.md §3 (no dead flags) **no code shipped**.

### Re-scope
The plan's F6 framed the nvs05/tls2 node-NLP cost as a POUNCE "engine gap" (~7–11× vs Ipopt, jkitchin/pounce#182). That gap is a **debug-build artifact** — a *release* POUNCE is ~1.1× Ipopt with fewer iterations (pounce#182 comment 4889424028; our release-wheel profiling agreed). So there is no per-solve engine gap to close. The re-scoped, maintainer-endorsed lever: **warm-start incumbent NLPs across the tree** — thread the parent node's converged primal + duals + μ into the child NLP (`Problem.solve(x0, lagrange=, zl=, zu=)` + `warm_start_init_point`/`mu_init`). discopt currently solves every node NLP **cold** (confirmed: zero `lagrange`/`zl`/`zu`/`mu_init`/`warm_start_init_point` in the node-NLP path; only the parent *primal* is threaded via `x0`).

### Entry experiment (release pounce 0.7.0, verified 4.7 MB `_pounce*.so` = release; nvs05 + tls2, 60 s)
Captured the real converged node NLPs (primal x, `mult_g`, `mult_x_L/U`, μ from POUNCE `info`) from live B&B runs; replayed each child (parent + one tightened bound) COLD vs WARM.

**Every warm re-solve reached the identical KKT point / objective as cold** (warm-start is incumbent-quality *safe*), but the **iteration count fails the class:**

| instance | pairing | recipe | cold iters (sum) | warm iters (sum) | median cold/warm | verdict |
|---|---|---|---|---|---|---|
| **tls2** | ≤2-bound-diff | full (x+duals+μ) | 126 | 277 | **0.58×** | 8/8 pairs WORSE |
| tls2 | ≤2 | primal-only | 126 | 163 | 0.77× | 8/8 WORSE |
| **nvs05** | ≤2-bound-diff | full | 80 | 38 | **2.29×** | 5/5 better (narrow win) |
| nvs05 | ≤4-bound-diff | full | 94 | 181 | 2.67× median but **net loss** | 1 pair 31→153 |
| nvs05 | any | no-μ / primal-only | 80 | 76 | 1.00× | neutral |

The only positive recipe (x + duals + μ) is exactly the one that is catastrophic on tls2; dropping μ or the duals makes nvs05 merely neutral. tls2's KKT points are bound-active vertices a warm interior iterate approaches *slower* than a fresh centered start.

**Kill criterion** (plan §2 F6: "<1.3× median ⇒ warm-start is not the lever; child boxes differ too much / nonconvex restart lands elsewhere") **fires** on tls2 (0.58×, all pairs worse) and nvs05's realistic pairing.

**Retry sub-audit:** the alternative-start retry issues ~1.7–1.9 NLP/node, but retries that *rescue* a node (first attempt fails → retry accepts) are **2.4% (nvs05) / 0.2% (tls2)** of nodes — below the 15% "material" and 5% "cap it" thresholds. Retry policy left unchanged (F4 already deadline-polls between retries).

### Outcome
- **No warm-start API, feature flag, or `NLPResult.mu` field added; no solver code changed.** The scaffolding built to run the experiment was reverted; baseline byte-restored (`solve_nlp` has no `warm_start` param, `NLPResult` has no `mu` field).
- Docs updated in the same PR: profile doc §5 **item 11** (pounce#182 build-artifact resolution + the F6 kill), plan F6 **Status**, and plan §3.
- nvs05/tls2 are a **weak-bound / branch-and-reduce** problem (as F5 also concluded), not a per-node NLP speed problem — re-scoped under the cert-gap-plan branch-and-reduce roadmap. pounce#182 closes as a resolved build artifact.

### Gates
Docs-only, no behavior change ⇒ **bound-neutral by construction** (baseline byte-identical; verified `solve_nlp` signature and `NLPResult` fields restored). No regression test required — the deliverable is the documented kill, not a shipped feature. Pre-commit hooks passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
