### PR TITLE
perf(startup): F7 — opt-in eager imports + JAX compile cache (fixed-tax trims)

### DIFF
--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -220,3 +220,50 @@ def chat(llm_model: str | None = None, verbose: bool = True):
     from discopt.llm.chat import chat as _chat
 
     return _chat(llm_model=llm_model, verbose=verbose)
+
+
+# Opt-in eager imports (F7, perf-followup-plan §2). The first ``solve()`` in a
+# fresh process lazily loads ~0.4 s of solve-path modules (jax.numpy, scipy
+# sparse/linalg, and the discopt._jax / discopt.solvers relaxation+NLP stack);
+# measured lazy-import cumtime 0.41 s (m3) / 0.42 s (nvs13) on the first solve.
+# For batch/CLI/benchmark harnesses that pay import cost once and solve many
+# instances, moving that tax to ``import discopt`` time drops the first-solve
+# lazy-import tax to ~0.03 s (m3/nvs13). This is purely relocating import work
+# — it changes no solver math (bound-neutral: node_count and certified
+# objective are byte-identical with it on or off).
+#
+# Default OFF so a bare ``import discopt`` stays fast/lazy (jax-free code paths,
+# e.g. the GAMS LP/MILP link, must not pay the multi-second jax import). Opt in
+# with ``DISCOPT_EAGER_IMPORTS=1``. Every import is guarded: optional deps
+# (jax, scipy, pounce) may be absent, and a failure here must never break
+# ``import discopt`` — the eager path is a pure optimization whose absence only
+# costs the lazy re-import at first solve.
+def _eager_import_solve_path() -> None:
+    import importlib
+
+    # Ordered from the heaviest external deps (which dominate the lazy-import
+    # tax) to the discopt solve-path modules that pull them in.
+    for _name in (
+        "jax.numpy",
+        "scipy.sparse",
+        "scipy.linalg",
+        "scipy.sparse.linalg",
+        "discopt.solver",
+        "discopt._jax.milp_relaxation",
+        "discopt._jax.primal_heuristics",
+        "discopt._jax.nonlinear_bound_tightening",
+        "discopt._jax.convexity",
+        "discopt.solvers.nlp_pounce",
+        "discopt.solvers.lp_pounce",
+        "discopt.solvers.amp",
+    ):
+        try:
+            importlib.import_module(_name)
+        except Exception:
+            # Optional dependency missing or a submodule import error: skip
+            # silently. The lazy path will surface any real error at solve time.
+            pass
+
+
+if _os.environ.get("DISCOPT_EAGER_IMPORTS", "0") == "1":
+    _eager_import_solve_path()

--- a/python/tests/test_eager_imports_optin.py
+++ b/python/tests/test_eager_imports_optin.py
@@ -1,0 +1,76 @@
+"""Guard: ``DISCOPT_EAGER_IMPORTS`` is opt-in and never changes default startup.
+
+F7 (perf-followup-plan §2, fixed-tax trims). The first ``solve()`` in a fresh
+process lazily loads ~0.4 s of solve-path modules (jax.numpy, scipy
+sparse/linalg, the discopt._jax / discopt.solvers stack). Batch/CLI/benchmark
+harnesses that pay import cost once can opt in to move that tax to
+``import discopt`` time via ``DISCOPT_EAGER_IMPORTS=1``.
+
+This is bound-neutral plumbing: it must never change what a *default*
+``import discopt`` does. In particular the default import must stay JAX-free
+(the pure LP/MILP/QP paths must not pay the multi-second JAX cold start —
+see ``test_lazy_jax_linear_path.py``). These guards pin:
+
+* default (env unset / ``=0``): ``import discopt`` succeeds and does **not**
+  eager-load jax or the solve orchestrator (startup stays lazy/fast);
+* opt-in (env ``=1``): ``import discopt`` succeeds and the solve-path modules
+  (jax, ``discopt.solver``) are preloaded.
+
+Each case runs in a *fresh subprocess* so ``sys.modules`` reflects only what
+importing discopt did, and a regression that eager-loads on the default path
+(or fails to on the opt-in path) fails here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+# Assert against sys.modules right after ``import discopt`` in a clean process.
+_DRIVER = """
+import sys
+import discopt  # noqa: F401
+jax_loaded = 'jax' in sys.modules
+solver_loaded = 'discopt.solver' in sys.modules
+print('JAX_LOADED' if jax_loaded else 'JAX_FREE')
+print('SOLVER_LOADED' if solver_loaded else 'SOLVER_LAZY')
+"""
+
+
+def _run(env_value: str | None) -> list[str]:
+    import os
+
+    env = dict(os.environ)
+    env.pop("DISCOPT_EAGER_IMPORTS", None)
+    if env_value is not None:
+        env["DISCOPT_EAGER_IMPORTS"] = env_value
+    out = subprocess.run(
+        [sys.executable, "-c", _DRIVER],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=env,
+    )
+    assert out.returncode == 0, f"import discopt failed:\n{out.stderr}"
+    return out.stdout.strip().splitlines()
+
+
+@pytest.mark.parametrize("env_value", [None, "0"])
+def test_default_import_stays_lazy(env_value):
+    """Default (env unset or =0): import succeeds and stays JAX-free/lazy."""
+    lines = _run(env_value)
+    assert lines[0] == "JAX_FREE", (
+        f"default import eager-loaded JAX (cold-start regression): {lines}"
+    )
+    assert lines[1] == "SOLVER_LAZY", f"default import eager-loaded the solve orchestrator: {lines}"
+
+
+def test_eager_optin_preloads_solve_path():
+    """Opt-in (env =1): import succeeds and preloads jax + the orchestrator."""
+    lines = _run("1")
+    assert lines[0] == "JAX_LOADED", f"DISCOPT_EAGER_IMPORTS=1 did not eager-load JAX: {lines}"
+    assert lines[1] == "SOLVER_LOADED", (
+        f"DISCOPT_EAGER_IMPORTS=1 did not eager-load discopt.solver: {lines}"
+    )


### PR DESCRIPTION
## F7 — Fixed-tax trims (opt-in eager imports)

Implements **F7** from `docs/dev/perf-followup-plan-2026-07-05.md` §2 (lowest
priority, explicitly low-ceiling). Evidence: profile
`docs/dev/bottleneck-profile-2026-07-05.md` §1.7 — the fixed setup tax visible
only on the sub-5 s class (m3, nvs13, ex1224, nvs08).

### Entry experiment (before the fix)
Measured on the clean `origin/main` build (F1–F6), `JAX_PLATFORMS=cpu`,
`JAX_ENABLE_X64=1`:

| component | measurement |
|---|---|
| `import discopt` wall | ~0.095 s (warm), 0.10–0.14 s cold — matches §1.7 |
| lazy-import tax inside first `solve()` (`_find_and_load` cumtime) | **m3 0.443 s / nvs13 0.440 s** |
| JIT/warmup delta (first − second in-process solve, same nodes) | m3 0.71 s / nvs13 0.52 s |

**Kill criterion** (STOP if lazy-import + warmup tax < 0.3 s): **did not fire** —
the lazy-import tax alone is ~0.44 s, well above the 0.3 s floor.

Note: **lever 2 (persistent JAX compilation cache) is already shipped on
`origin/main`** (`python/discopt/__init__.py` sets
`JAX_COMPILATION_CACHE_DIR` + min-compile/min-entry = 0, opt-out via
`DISCOPT_DISABLE_JAX_CACHE`). Nothing to add there. This PR ships **only
lever 1**.

### What shipped
Lever 1 only — **opt-in eager imports**, gated behind `DISCOPT_EAGER_IMPORTS=1`
(env, **default OFF**). When set, `import discopt` eagerly imports the
solve-path modules (`jax.numpy`, `scipy.sparse/linalg`, and the
`discopt._jax` / `discopt.solvers` relaxation+NLP stack) so batch/CLI/benchmark
harnesses pay that tax once at import instead of on the first `solve()`. Every
import is guarded (optional deps may be absent; a failure never breaks
`import discopt`).

**Default behavior is unchanged**: a bare `import discopt` stays JAX-free and
fast (the pure LP/MILP/QP and GAMS-link paths must not pay the multi-second JAX
import). Verified with the env both set and unset — no import cycle.

### Result (env set)
| instance | first-solve lazy-import tax OFF → ON | first-solve wall OFF → ON |
|---|---|---|
| m3    | 0.443 s → **0.027 s** | ~3.64 s → ~3.41 s (−0.23 s) |
| nvs13 | 0.440 s → **0.031 s** | ~1.53 s → ~1.25 s (−0.28 s) |

First-solve lazy-import tax with the env set is **≤ 0.03 s** (acceptance target
≤ 0.3 s, profile §7 F7). This is polish, not strategy: net of tax m3 is still
~2.7 s vs BARON 0.04 s.

### Regime + gates (bound-neutral, plan §0.3/§0.4)
- **Cert-baseline byte-identical**: the 41-instance cert panel
  (`docs/dev/data/cert-baseline.jsonl` protocol) re-solved with the feature
  **OFF and ON** — **0 drift rows** (node_count + objective + status identical),
  and the OFF run matches the committed baseline node_counts exactly (0
  mismatches). Pure import plumbing changes no solver math.
- **Import regression test**: `python/tests/test_eager_imports_optin.py`
  (fresh-subprocess) asserts the default import stays JAX-free/lazy and the
  opt-in import preloads the solve path. Fails before the change (opt-in was a
  no-op), passes after.
- `pytest -m smoke`: **574 passed, 14 skipped**.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed**.
- `ruff check` + `ruff format --check`: pass on both files.
- `mypy python/discopt/__init__.py`: clean (no issues). The full-tree
  `mypy python/discopt/` fails on a numpy stub (`numpy/__init__.pyi:737` uses a
  3.12 `type` statement under the pinned 3.10 target) — reproduces identically
  on pristine `origin/main`, so it is a pre-existing local-env artifact, not
  from this change.
- No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
