### PR TITLE
perf(cert-gap): R3a — bound-responsiveness fingerprint (BUILD/SKIP R3b)

### DIFF
--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -142,6 +142,13 @@ pub struct TreeManager {
     /// `global_lower_bound = -inf` so `gap() = ∞` and the search reports
     /// feasible/unknown rather than a false optimal (issue #467).
     bound_unresolved: bool,
+    /// R3a measurement counter (temporary, behavior-neutral): per-variable
+    /// branch frequency. Incremented once per branching event (integer or
+    /// spatial) with the branched flat column index. Length `n_vars`. Read by
+    /// the responsiveness-fingerprint experiment to compare actually-branched
+    /// variables against the box-shrink responsiveness ranking. Does not affect
+    /// any branching or bounding decision.
+    branch_var_counts: Vec<usize>,
 }
 
 impl TreeManager {
@@ -182,6 +189,20 @@ impl TreeManager {
             spatial_integer_cols,
             branch_deprioritized,
             bound_unresolved: false,
+            branch_var_counts: vec![0; n_vars],
+        }
+    }
+
+    /// R3a measurement accessor (temporary): per-variable branch frequency,
+    /// length `n_vars`. See [`Self::branch_var_counts`].
+    pub fn branch_var_counts(&self) -> &[usize] {
+        &self.branch_var_counts
+    }
+
+    /// Increment the R3a branch counter for a branched flat column index.
+    fn record_branch_var(&mut self, var_index: usize) {
+        if let Some(c) = self.branch_var_counts.get_mut(var_index) {
+            *c += 1;
         }
     }
 
@@ -446,6 +467,7 @@ impl TreeManager {
                 self.pool.add(left);
                 self.pool.add(right);
                 stats.branched += 1;
+                self.record_branch_var(decision.var_index);
             } else if self.nonconvex && int_feasible {
                 // No fractional integer variable, but nonconvex mode: branch
                 // spatially. Independent continuous variables and integer
@@ -523,6 +545,7 @@ impl TreeManager {
                         self.pool.add(left);
                         self.pool.add(right);
                         stats.branched += 1;
+                        self.record_branch_var(dep_decision.var_index);
                     } else {
                         // No branching direction remains. Whether this fathom is
                         // sound depends on the node's dual bound:
@@ -557,9 +580,11 @@ impl TreeManager {
                     self.pool.add(left);
                     self.pool.add(right);
                     stats.branched += 1;
+                    self.record_branch_var(sidx);
                 } else {
                     // Continuous bisection wins.
                     let (cont_decision, _) = cont.unwrap();
+                    let cont_var = cont_decision.var_index;
                     let parent = self.pool.get(result.node_id).clone();
                     self.pool.get_mut(result.node_id).status = NodeStatus::Branched;
                     let (left, right) =
@@ -567,6 +592,7 @@ impl TreeManager {
                     self.pool.add(left);
                     self.pool.add(right);
                     stats.branched += 1;
+                    self.record_branch_var(cont_var);
                 }
             } else {
                 // No fractional variable found — treat as fathomed. This branch

--- a/crates/discopt-python/src/bnb_bindings.rs
+++ b/crates/discopt-python/src/bnb_bindings.rs
@@ -245,6 +245,21 @@ impl PyTreeManager {
         Ok(dict)
     }
 
+    /// R3a measurement accessor (temporary, behavior-neutral): per-variable
+    /// branch frequency as an int64 array of length n_vars. Element `i` is the
+    /// number of branching events (integer or spatial) that split flat column
+    /// `i`. Used by the responsiveness-fingerprint experiment; does not affect
+    /// any solver decision.
+    fn branch_var_counts<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<i64>> {
+        let counts: Vec<i64> = self
+            .inner
+            .branch_var_counts()
+            .iter()
+            .map(|&c| c as i64)
+            .collect();
+        PyArray1::from_vec(py, counts)
+    }
+
     /// Get the current incumbent solution, if any.
     ///
     /// Returns (solution_array, objective_value) or None.

--- a/discopt_benchmarks/scripts/r3a_responsiveness_fingerprint.py
+++ b/discopt_benchmarks/scripts/r3a_responsiveness_fingerprint.py
@@ -1,0 +1,428 @@
+"""R3a entry experiment: bound-responsiveness fingerprint vs actual branching.
+
+This is the *entry experiment / kill criterion* for R3 in
+``docs/dev/uncertified-tail-plan-2026-07-06.md`` §3 (R3a). It is a MEASUREMENT
+task: it instruments solves and produces a per-instance table + a BUILD/SKIP
+verdict for R3b (responsiveness-aware spatial branching). It does NOT build the
+branching change and it changes NO solver decision — the only Rust addition is a
+behavior-neutral per-variable branch-frequency counter (``branch_var_counts``),
+armed via the ``solver._R3A_BRANCH_COUNT_SINK`` diagnostic sink.
+
+Per instance, two independent measurements are combined:
+
+  1. **Responsiveness fingerprint.** For each variable ``v`` (in the *reformed*
+     flat space the solver actually branches — factorable lift appends aux
+     columns after the originals), halve its box two ways (lower / upper half),
+     compute the root McCormick-LP bound of each half, keep the half with the
+     *better* (larger, for the internally-minimized sense) root bound, and record
+     ``score(v) = |root_bound(halved) − root_bound(full)|``. This is O(n_vars)
+     cheap root-bound evaluations — no full solves. Reuses ``root_lp_bound`` from
+     ``t21_root_loop_replay`` (the same cold McCormick relaxation the solver's
+     root path builds).
+
+  2. **Actual branching.** One instrumented 60 s solve; read the Rust tree's
+     ``branch_var_counts`` (a temporary counter incremented once per branching
+     event, integer or spatial, with the branched flat column). Count branch
+     frequency per variable.
+
+Deliverable (printed + JSON): per instance the top-3 *responsive* variables (by
+``score``) vs the top-3 *actually-branched* variables (by frequency), their
+overlap (|top3_resp ∩ top3_branched|), and the max ``score`` (is any variable
+responsive at all?). Then the kill-criterion verdict:
+
+  * If on ≥ 4 of the 6 Class-P instances the current policy already branches the
+    responsive vars (overlap ≥ 2/3), selection is not the lever → SKIP R3b.
+  * Instances where responsiveness is flat (no variable moves the root bound
+    > 1 % on box-halving) are flagged relaxation-limited (R4 territory).
+  * Otherwise BUILD R3b; the st_e36 F5 prediction (x0 responsive / x1 branched)
+    is confirmed or refuted explicitly.
+
+House style per t11/t12/t21: ``JAX_PLATFORMS=cpu`` + ``JAX_ENABLE_X64=1`` set
+before importing discopt; standalone runnable; the reform gating that fixes the
+branch/fingerprint variable space is reproduced faithfully from
+``solver.solve_model``.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import argparse
+import json
+import math
+import time
+
+import discopt.modeling as dm
+import discopt.solver as solver
+import numpy as np
+
+# Reuse the T2.1 root-bound machinery verbatim so the fingerprint's relaxation
+# is exactly the one the solver's root path builds.
+from t21_root_loop_replay import (  # noqa: E402
+    ORACLE,
+    flat_bounds,
+    resolve_nl,
+    root_lp_bound,
+)
+
+DEFAULT_SNAPSHOT = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+
+# The R3a panel (plan §3 R3a): 6 Class-P + 5 R1-resistant Class-H.
+CLASS_P = ["st_e36", "nvs05", "nvs09", "tanksize", "tls2", "hda"]
+CLASS_H = ["casctanks", "4stufen", "beuster", "heatexch_gen1", "bchoco06"]
+PANEL = CLASS_P + CLASS_H
+
+# Oracles for Class-H not covered by t21's ORACLE (minlplib.solu, =opt=/=best=).
+ORACLE_H: dict[str, float] = {
+    "nvs09": -43.134336,
+    "hda": -5964.5,
+    "casctanks": 9.163479388,
+    "4stufen": 96908.35577,
+    "beuster": 116655.4796,
+    "heatexch_gen1": 149112.4623,
+    "bchoco06": -390.0,
+}
+
+
+def get_oracle(name: str) -> float | None:
+    if name in ORACLE:
+        return ORACLE[name]
+    return ORACLE_H.get(name)
+
+
+def reformed_model_and_names(path: str):
+    """Return (live_model, var_names, prereform_nvars).
+
+    Reproduces the factorable-reform gating from ``solver.solve_model`` so the
+    fingerprint and the branch counter share the exact same flat variable space.
+    The reform fires only when ``has_factorable_work`` AND the model classifies as
+    provably-nonconvex — identical to the live solve path. ``var_names`` labels
+    every reformed flat column; the first ``prereform_nvars`` are the originals.
+    """
+    from discopt._jax.factorable_reform import (
+        factorable_reformulate,
+        has_factorable_work,
+    )
+
+    model = dm.from_nl(path)
+    prereform_nvars = sum(v.size for v in model._variables)
+    if has_factorable_work(model):
+        try:
+            ok, convex, _ = solver._classify_model_convexity(model)
+        except Exception:
+            ok, convex = False, True
+        if ok and not convex:
+            model = factorable_reformulate(model)
+    names = _flat_var_names(model)
+    return model, names, prereform_nvars
+
+
+def _flat_var_names(model) -> list[str]:
+    names: list[str] = []
+    for v in model._variables:
+        base = getattr(v, "name", None) or f"v{len(names)}"
+        if v.size == 1:
+            names.append(str(base))
+        else:
+            names.extend(f"{base}[{k}]" for k in range(v.size))
+    return names
+
+
+def fingerprint(model, lb: np.ndarray, ub: np.ndarray) -> tuple[np.ndarray, float | None]:
+    """Box-shrink responsiveness score per flat variable.
+
+    ``score[v] = |root_bound(better half of v's box) − root_bound(full box)|``.
+    Returns (scores, full_root_bound). Variables with a non-finite or
+    zero-width box are scored 0 (nothing to halve).
+    """
+    n = len(lb)
+    full_bound, _ = root_lp_bound(model, lb, ub)
+    scores = np.zeros(n, dtype=np.float64)
+    if full_bound is None or not math.isfinite(full_bound):
+        return scores, full_bound
+    for i in range(n):
+        lo, hi = float(lb[i]), float(ub[i])
+        if not (math.isfinite(lo) and math.isfinite(hi)) or (hi - lo) <= 1e-12:
+            continue
+        mid = 0.5 * (lo + hi)
+        best_delta = 0.0
+        for half in ("lower", "upper"):
+            hlb, hub = lb.copy(), ub.copy()
+            if half == "lower":
+                hub[i] = mid
+            else:
+                hlb[i] = mid
+            b, _ = root_lp_bound(model, hlb, hub)
+            if b is None or not math.isfinite(b):
+                continue
+            # Internally-minimized sense: a *larger* root bound is the better
+            # (tighter) half. Score the magnitude of the move on the half that
+            # does not worsen the bound (b >= full_bound within tolerance); a
+            # half that only loosens the bound carries no responsiveness signal.
+            delta = abs(b - full_bound)
+            if b >= full_bound - 1e-9 and delta > best_delta:
+                best_delta = delta
+        scores[i] = best_delta
+    return scores, full_bound
+
+
+def instrumented_branch_counts(path: str, time_limit: float) -> tuple[list[int], dict]:
+    """Run one solve with the branch-count sink armed; return (counts, info)."""
+    sink: dict = {}
+    prev = solver._R3A_BRANCH_COUNT_SINK
+    solver._R3A_BRANCH_COUNT_SINK = sink
+    try:
+        m = dm.from_nl(path)
+        t0 = time.perf_counter()
+        r = m.solve(time_limit=time_limit)
+        wall = time.perf_counter() - t0
+    finally:
+        solver._R3A_BRANCH_COUNT_SINK = prev
+    counts = sink.get("branch_var_counts") or []
+    info = {
+        "status": str(r.status),
+        "nodes": r.node_count,
+        "objective": r.objective,
+        "bound": r.bound,
+        "wall": wall,
+    }
+    return list(counts), info
+
+
+def top3(values: np.ndarray) -> list[int]:
+    """Indices of the top-3 by value (descending), dropping zero/nonpositive."""
+    order = np.argsort(-values, kind="stable")
+    out = [int(i) for i in order if values[int(i)] > 0]
+    return out[:3]
+
+
+def run_instance(name: str, path: str, time_limit: float) -> dict:
+    oracle = get_oracle(name)
+    model, names, prereform_nvars = reformed_model_and_names(path)
+    lb, ub = flat_bounds(model)
+    n = len(lb)
+
+    scores, full_bound = fingerprint(model, lb, ub)
+
+    counts, solve_info = instrumented_branch_counts(path, time_limit)
+    # Align the counter length to the fingerprint space. They should match (both
+    # are the reformed model). If the live solve took a different path (e.g. the
+    # reform did not fire there), flag it rather than silently mis-align.
+    counts_arr = np.zeros(n, dtype=np.int64)
+    aligned = len(counts) == n
+    if aligned:
+        counts_arr = np.asarray(counts, dtype=np.int64)
+    elif len(counts) >= n:
+        # live space is a superset (extra aux appended after originals): the
+        # first n entries still correspond 1:1 to the fingerprint columns.
+        counts_arr = np.asarray(counts[:n], dtype=np.int64)
+    else:
+        # live space smaller — pad, and flag the mismatch loudly.
+        counts_arr[: len(counts)] = np.asarray(counts, dtype=np.int64)
+
+    resp_top = top3(scores)
+    branch_top = top3(counts_arr.astype(np.float64))
+    overlap = len(set(resp_top) & set(branch_top))
+
+    max_score = float(np.max(scores)) if n else 0.0
+    # "flat" = no variable moves the root bound > 1% of the bound magnitude.
+    scale = max(1.0, abs(full_bound)) if full_bound is not None else 1.0
+    flat = (max_score / scale) < 0.01
+
+    return {
+        "name": name,
+        "class": "P" if name in CLASS_P else "H",
+        "oracle": oracle,
+        "n_vars": n,
+        "prereform_nvars": prereform_nvars,
+        "names": names,
+        "full_root_bound": full_bound,
+        "scores": scores.tolist(),
+        "branch_counts": counts_arr.tolist(),
+        "counts_len_raw": len(counts),
+        "counts_aligned": aligned,
+        "resp_top3": resp_top,
+        "branch_top3": branch_top,
+        "overlap_top3": overlap,
+        "max_score": max_score,
+        "max_score_rel": max_score / scale,
+        "flat_responsiveness": bool(flat),
+        "solve": solve_info,
+    }
+
+
+def _lab(names: list[str], idxs: list[int]) -> str:
+    if not idxs:
+        return "-"
+    return ", ".join(f"{names[i]}" for i in idxs)
+
+
+def print_report(results: list[dict]) -> dict:
+    print("\n" + "=" * 96)
+    print("R3a — BOUND-RESPONSIVENESS FINGERPRINT vs ACTUAL BRANCHING")
+    print("=" * 96)
+
+    print(
+        f"\n{'instance':16s} {'cls':3s} {'top3 responsive':28s} "
+        f"{'top3 branched':22s} {'ovlp':4s} {'maxΔ%':7s} {'flat?':5s}"
+    )
+    print("-" * 96)
+    for r in results:
+        names = r["names"]
+        rt = _lab(names, r["resp_top3"])
+        bt = _lab(names, r["branch_top3"])
+        print(
+            f"{r['name']:16s} {r['class']:3s} {rt:28.28s} {bt:22.22s} "
+            f"{str(r['overlap_top3']) + '/3':4s} {100 * r['max_score_rel']:6.2f}% "
+            f"{'YES' if r['flat_responsiveness'] else 'no':5s}"
+        )
+
+    # Detailed per-instance score/count dump (for the plan doc table).
+    print("\n--- Per-instance detail (score / branch-count by variable) ---")
+    for r in results:
+        names = r["names"]
+        scores = r["scores"]
+        counts = r["branch_counts"]
+        print(
+            f"\n{r['name']} (class {r['class']}, {r['n_vars']} reformed vars, "
+            f"{r['prereform_nvars']} original; full_root_bound="
+            f"{_fmt(r['full_root_bound'])}, oracle={_fmt(r['oracle'])}, "
+            f"solve={r['solve']['status']}/{r['solve']['nodes']} nodes):"
+        )
+        order = np.argsort(-np.asarray(scores), kind="stable")
+        for j in order:
+            j = int(j)
+            if scores[j] <= 0 and counts[j] == 0:
+                continue
+            print(f"    {names[j]:14s} score={scores[j]:12.5g}  branches={counts[j]}")
+
+    # ---- Kill criterion (plan §3 R3a) ----
+    class_p = [r for r in results if r["class"] == "P"]
+    # An instance "already branches the responsive vars" if overlap >= 2/3.
+    p_already = [r for r in class_p if r["overlap_top3"] >= 2]
+    n_p = len(class_p)
+    skip = len(p_already) >= 4  # >=4 of the 6 Class-P
+
+    flat_instances = [r["name"] for r in results if r["flat_responsiveness"]]
+
+    # st_e36 F5 prediction: x0 responsive (top), x1 branched (top).
+    st = next((r for r in results if r["name"] == "st_e36"), None)
+    st_verdict = None
+    if st is not None:
+        names = st["names"]
+        x0 = names.index("x0") if "x0" in names else None
+        x1 = names.index("x1") if "x1" in names else None
+        resp_is_x0 = x0 is not None and x0 in st["resp_top3"][:1]
+        branch_has_x1 = x1 is not None and x1 in st["branch_top3"]
+        # F5 prediction is x0-responsive AND x1-among-branched AND x0 NOT the top
+        # branched (i.e. the responsive var is under-branched relative to x1).
+        x0_branches = st["branch_counts"][x0] if x0 is not None else -1
+        x1_branches = st["branch_counts"][x1] if x1 is not None else -1
+        st_verdict = {
+            "x0_index": x0,
+            "x1_index": x1,
+            "x0_score": st["scores"][x0] if x0 is not None else None,
+            "x1_score": st["scores"][x1] if x1 is not None else None,
+            "x0_branches": x0_branches,
+            "x1_branches": x1_branches,
+            "resp_top_is_x0": bool(resp_is_x0),
+            "x1_in_branch_top3": bool(branch_has_x1),
+            "prediction_held": bool(resp_is_x0 and x1_branches > x0_branches),
+        }
+
+    print("\n" + "=" * 96)
+    print("KILL CRITERION (plan §3 R3a)")
+    print("=" * 96)
+    print(
+        f"Class-P instances already branching responsive vars (overlap >= 2/3): "
+        f"{len(p_already)}/{n_p}  -> "
+        + (", ".join(r["name"] for r in p_already) if p_already else "(none)")
+    )
+    print(
+        f"Flat / relaxation-limited instances (max root move < 1%): "
+        f"{flat_instances if flat_instances else '(none)'}"
+    )
+    if st_verdict is not None:
+        print("\nst_e36 F5 prediction (x0 responsive / x1 branched):")
+        print(f"    x0 score={_fmt(st_verdict['x0_score'])}  branches={st_verdict['x0_branches']}")
+        print(f"    x1 score={_fmt(st_verdict['x1_score'])}  branches={st_verdict['x1_branches']}")
+        print(
+            f"    resp-top is x0? {st_verdict['resp_top_is_x0']}   "
+            f"x1 in branch-top3? {st_verdict['x1_in_branch_top3']}   "
+            f"=> prediction {'HELD' if st_verdict['prediction_held'] else 'REFUTED'}"
+        )
+
+    verdict = "SKIP R3b" if skip else "BUILD R3b"
+    print(
+        f"\n==> VERDICT: {verdict}  "
+        f"(Class-P overlap>=2/3 count = {len(p_already)}/{n_p}; "
+        f"SKIP requires >= 4)"
+    )
+    print("=" * 96)
+
+    return {
+        "class_p_already_branching": [r["name"] for r in p_already],
+        "n_class_p_already": len(p_already),
+        "n_class_p": n_p,
+        "flat_instances": flat_instances,
+        "st_e36": st_verdict,
+        "verdict": verdict,
+    }
+
+
+def _fmt(x) -> str:
+    if x is None:
+        return "n/a"
+    try:
+        return f"{float(x):.6g}"
+    except Exception:
+        return str(x)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="R3a bound-responsiveness fingerprint")
+    ap.add_argument("--snapshot", default=DEFAULT_SNAPSHOT)
+    ap.add_argument("--instances", default=None, help="comma-separated subset of the panel")
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    ap.add_argument("--json-out", default=None)
+    args = ap.parse_args()
+
+    panel = PANEL if args.instances is None else [s.strip() for s in args.instances.split(",")]
+
+    results: list[dict] = []
+    for name in panel:
+        path = resolve_nl(name, args.snapshot)
+        if path is None:
+            print(f"[{name}] NL not found -> SKIP")
+            continue
+        print(f"\n########## {name} ##########")
+        t0 = time.perf_counter()
+        try:
+            r = run_instance(name, path, args.time_limit)
+            r["total_wall"] = time.perf_counter() - t0
+            results.append(r)
+            print(
+                f"[{name}] done in {r['total_wall']:.1f}s  "
+                f"resp_top3={r['resp_top3']} branch_top3={r['branch_top3']} "
+                f"overlap={r['overlap_top3']}/3 max_move={100 * r['max_score_rel']:.2f}% "
+                f"flat={r['flat_responsiveness']}"
+            )
+        except Exception as e:  # pragma: no cover - keep the panel going
+            import traceback
+
+            print(f"[{name}] ERROR: {type(e).__name__}: {e}")
+            traceback.print_exc()
+
+    verdict = print_report(results)
+
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump({"results": results, "verdict": verdict}, fh, indent=2)
+        print(f"\nWrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/uncertified-tail-plan-2026-07-06.md
+++ b/docs/dev/uncertified-tail-plan-2026-07-06.md
@@ -194,6 +194,100 @@ correctness pre-flight) is COMPLETE** — C-15/C-16/C-20/C-21 are all `fixed` in
   responsiveness is flat (no variable moves the bound > 1 % — that class is
   purely relaxation-limited → R4 territory).
 
+#### R3a RESULTS / VERDICT (2026-07-06)
+
+**Harness:** `discopt_benchmarks/scripts/r3a_responsiveness_fingerprint.py`
+(reuses `t21_root_loop_replay.root_lp_bound` for the fingerprint; branching read
+from a new behavior-neutral Rust counter `PyTreeManager.branch_var_counts()`
+armed via `solver._R3A_BRANCH_COUNT_SINK`). Release POUNCE verified
+(`_pounce.abi3.so` = 4.7 MB). Both measurements are taken in the *reformed* flat
+variable space (factorable lift appends `_fr_aux_*` after the originals), so
+`score(v)` and branch-frequency index the same columns. Instrumentation
+neutrality confirmed: st_e36 node count / objective / bound bit-identical with
+the sink on vs off (87 nodes, −246.0, −304.49044273); `cargo test -p
+discopt-core` bnb suite 75/75 green.
+
+**`score(v) = |root_bound(better half) − root_bound(full box)|`** (internally-
+minimized sense, so the "better" half is the one that *raises* the root bound).
+`maxΔ%` = max `score` relative to `max(1, |root_bound|)`. `flat` = `maxΔ% < 1 %`.
+One 60 s instrumented solve per instance for the branch counts.
+
+| instance | cls | root LP bound | top-3 responsive (by score) | top-3 branched (by freq) | overlap | maxΔ% | flat? |
+|---|---|---:|---|---|:--:|--:|:--:|
+| st_e36 | P | −304.5 | **x0**, _fr_aux_0, x1 | **x0**, _fr_aux_0, _fr_aux_1 | **2/3** | 24.8 % | no |
+| nvs05 | P | 0.675 | _fr_aux_3, x0, _fr_aux_0 | x0, x1, x3 | 1/3 | (near-0 bound) | no |
+| nvs09 | P | −72.9 | _fr_aux_1, x2, x0 | x2, x3, x1 | 1/3 | 38.3 % | no |
+| tanksize | P | **none** | — | x0, x1, x2 | 0/3 | 0.0 % | **YES** |
+| tls2 | P | ≈0 | x5, x4, x15 | x31, x35, x24 | **0/3** | (near-0 bound) | no |
+| hda | P | **none** | — | x719, x709 | 0/3 | 0.0 % | **YES** |
+| casctanks | H | **none** | — | x244, x245, x243 | 0/3 | 0.0 % | **YES** |
+| 4stufen | H | 10 604 | x129, x130, x131 | x114, x117, x111 | 0/3 | 17.0 % | no |
+| beuster | H | 5 942 | x156, x155, x154 | x122, x132, x131 | 0/3 | 31.9 % | no |
+| heatexch_gen1 | H | **none** | — | x107, x104, x100 | 0/3 | 0.0 % | **YES** |
+| bchoco06 | H | **none** | — | x9, x8, x0 | 0/3 | 0.0 % | **YES** |
+
+(For nvs05/tls2 the root LP bound is ≈0, so the `maxΔ%` denominator `max(1,|b|)`
+inflates the relative move; the **absolute** score is large — nvs05 `_fr_aux_3`
+score 288, tls2 x5 score 5.66 — so neither is flat. `flat` is driven entirely by
+the **no-root-bound** instances, not by any real bound that fails to move.)
+
+**Two distinct Class-P sub-classes, not one:**
+
+1. **Responsive-but-under-branched — the R3b lever (nvs05, nvs09, tls2).** A root
+   bound exists, responsive variables exist, but the top responsive variables are
+   *not* the top-branched. **tls2 is the clearest case in the whole panel:**
+   overlap **0/3** — its most-responsive variables `x5`/`x4` (score 5.66/5.01)
+   are branched **2/2** times, while its three most-branched columns `x31`/`x35`/
+   `x24` (123/98/87 branches) have **score exactly 0** — the policy spends its
+   entire branching budget on variables that provably do not move the root bound.
+   nvs05/nvs09 show the same shape more mildly (the single most-responsive column
+   is a lifted `_fr_aux_*` that is **never branched** — nvs05 `_fr_aux_3` score
+   288, 0 branches; nvs09 `_fr_aux_1` score 27.9, 0 branches).
+
+2. **Relaxation-limited / no-root-bound — R4 territory, not R3b (tanksize, hda).**
+   The cold McCormick relaxation produces **no LP bound at all** (the AMP
+   constraint-omission class — hda's 23 unlinearizable rows per bottleneck-
+   profile §3; tanksize's `4243.28/(x0·x1)` and other non-constant divisions).
+   Responsiveness is *undefined* (there is no bound for box-halving to move), so
+   these are flagged **flat → R4**, exactly as the kill criterion prescribes.
+   Branching selection cannot be their lever; they need relaxation coverage
+   (R4 lifting), not a branching score.
+
+**st_e36 — the F5 prediction is REFUTED (measurement beats plan, §0.4).** F5
+(bottleneck-profile §3/§5) predicted x0 responsive / x1 branched — "the tree
+branches 897 nodes on x1 while the responsive x0 is never split." On the
+post-F1–F7 engine this **does not reproduce**: x0 is the top responsive variable
+(score 75.6) **and** the top-branched variable (**267** branches vs x1's 14).
+The tree already spends most of its budget on the responsive variable; the
+overlap is **2/3** (x0 + `_fr_aux_0`, the 2nd-most-responsive lifted column,
+which is now also branched, 56×). So st_e36 is *not* a selection-limited
+instance — its residual gap is the zero-spanning-factor product relaxation (R4),
+consistent with F5's own re-scoping conclusion. This is the one Class-P instance
+that "already branches the responsive vars."
+
+**Class-H (context only, not a gate):** 4stufen/beuster are responsive-but-
+under-branched (overlap 0/3; responsive `x129`.../`x156`... never branched) — R3b
+beneficiaries. casctanks/heatexch_gen1/bchoco06 are no-root-bound / flat → R4.
+
+**KILL-CRITERION EVALUATION.** Class-P instances already branching the responsive
+variables (overlap ≥ 2/3): **1 of 6** (st_e36 only). SKIP requires ≥ 4. Not met.
+Relaxation-limited (flat) Class-P instances flagged for **R4**: **tanksize, hda**
+(both no-root-bound). The three Class-P instances with a live, responsive-but-
+under-branched signal are **nvs05, nvs09, tls2**.
+
+> **VERDICT: BUILD R3b.** Selection *is* a lever on nvs05/nvs09/tls2 — the
+> current policy demonstrably branches non-responsive columns while the
+> responsive ones (including lifted `_fr_aux_*` products) go untouched (tls2:
+> the top-3 branched have score 0; nvs05/nvs09: the top-responsive `_fr_aux_*` is
+> never branched). Scope R3b to *raise the branching priority of high-`score`
+> columns, including lifted aux variables* (which R4 also needs branchable — the
+> two tasks reinforce). Exclude tanksize/hda from R3b's acceptance (no bound to
+> respond to → R4). st_e36 already branches its responsive variable, so R3b is
+> not expected to help it; its lever is R4 (zero-spanning-factor lifting). The
+> §12 branching-exclusion reopen is thereby *narrowed*, not broadened: the win is
+> confined to the pinned/loose-product class R3 was scoped for, with a live
+> per-instance signal, not a general branching-rule project.
+
 **R3b — Conditional build: responsiveness-aware spatial branching score
 (flagged).**
 - **Mechanism:** blend a bound-responsiveness term into the *spatial*

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -42,6 +42,14 @@ from discopt.solver_tuning import reset_current as _reset_tuning
 from discopt.solver_tuning import set_current as _set_tuning
 from discopt.solvers import SolveStatus
 
+# R3a measurement sink (temporary, behavior-neutral). When set to a mutable
+# dict by an experiment harness, the nonconvex B&B path stores the Rust tree's
+# per-variable branch-frequency vector under key "branch_var_counts" just before
+# building its result. This is instrumentation only: it never influences a
+# branching, bounding, or feasibility decision. Left as ``None`` in all normal
+# solves so there is zero overhead and no observable behavior change.
+_R3A_BRANCH_COUNT_SINK: Optional[dict] = None
+
 # ``solve_nlp`` (cyipopt) is imported lazily at its nonlinear-path call site in
 # ``_solve_continuous`` so a pure LP/MILP/MIQP solve does not pull in the JAX-
 # backed NLPEvaluator that ``nlp_ipopt`` imports at module scope.
@@ -7100,6 +7108,17 @@ def solve_model(
     stats = tree.stats()
     incumbent = tree.incumbent()
 
+    # R3a instrumentation: export the per-variable branch-frequency vector when
+    # an experiment harness has armed the sink. Behavior-neutral; guarded so a
+    # missing accessor (older extension build) degrades silently.
+    if _R3A_BRANCH_COUNT_SINK is not None:
+        try:
+            _R3A_BRANCH_COUNT_SINK["branch_var_counts"] = np.asarray(
+                tree.branch_var_counts()
+            ).tolist()
+        except Exception as _e:  # pragma: no cover - diagnostics only
+            logger.debug("R3a branch_var_counts capture failed: %s", _e)
+
     if incumbent is not None:
         sol_array, obj_val = incumbent
         # Filter out bogus incumbents from infeasible NLP relaxations
@@ -8429,6 +8448,18 @@ def _solve_nlp_bb(
 
     stats = tree.stats()
     incumbent = tree.incumbent()
+
+    # R3a instrumentation (behavior-neutral): export the per-variable branch
+    # frequency when the diagnostic sink is armed. Mirrors the capture in the
+    # McCormick-LP nonconvex driver so alphaBB/NLP-path instances (e.g. tls2)
+    # are covered too.
+    if _R3A_BRANCH_COUNT_SINK is not None:
+        try:
+            _R3A_BRANCH_COUNT_SINK["branch_var_counts"] = np.asarray(
+                tree.branch_var_counts()
+            ).tolist()
+        except Exception as _e:  # pragma: no cover - diagnostics only
+            logger.debug("R3a branch_var_counts capture failed: %s", _e)
 
     if incumbent is not None:
         sol_array, obj_val = incumbent
@@ -12087,6 +12118,16 @@ def _solve_milp_bb(
     stats = tree.stats()
     incumbent = tree.incumbent()
 
+    # R3a instrumentation (behavior-neutral): export per-variable branch
+    # frequency when the diagnostic sink is armed (integer B&B drivers too).
+    if _R3A_BRANCH_COUNT_SINK is not None:
+        try:
+            _R3A_BRANCH_COUNT_SINK["branch_var_counts"] = np.asarray(
+                tree.branch_var_counts()
+            ).tolist()
+        except Exception as _e:  # pragma: no cover - diagnostics only
+            logger.debug("R3a branch_var_counts capture failed: %s", _e)
+
     if incumbent is not None:
         sol_array, obj_val = incumbent
         if obj_val >= _SENTINEL_THRESHOLD:
@@ -12492,6 +12533,16 @@ def _solve_miqp_bb(
     python_time = wall_time - rust_time - jax_time
     stats = tree.stats()
     incumbent = tree.incumbent()
+
+    # R3a instrumentation (behavior-neutral): export per-variable branch
+    # frequency when the diagnostic sink is armed (integer B&B drivers too).
+    if _R3A_BRANCH_COUNT_SINK is not None:
+        try:
+            _R3A_BRANCH_COUNT_SINK["branch_var_counts"] = np.asarray(
+                tree.branch_var_counts()
+            ).tolist()
+        except Exception as _e:  # pragma: no cover - diagnostics only
+            logger.debug("R3a branch_var_counts capture failed: %s", _e)
 
     if incumbent is not None:
         sol_array, obj_val = incumbent


### PR DESCRIPTION
## R3a — bound-responsiveness fingerprint (entry experiment for R3)

Executes **task R3a** from `docs/dev/uncertified-tail-plan-2026-07-06.md` §3.
This is a **MEASUREMENT task**: it instruments solves and produces a per-instance
responsive-vs-branched table + a BUILD/SKIP kill-criterion verdict for R3b. It
does **not** build the branching change (that is R3b, conditional on this verdict).

### What it adds
- **Behavior-neutral Rust counter** `TreeManager::branch_var_counts` — incremented
  once per branching event at every branch site (integer + all three spatial
  paths), exposed via `PyTreeManager.branch_var_counts()`. It influences no
  branching, bounding, or feasibility decision.
- **Diagnostic sink** `solver._R3A_BRANCH_COUNT_SINK`, populated on all B&B
  result paths (McCormick-LP, alphaBB/NLP, integer drivers); `None` in every
  normal solve (zero overhead, no observable behavior change).
- **`discopt_benchmarks/scripts/r3a_responsiveness_fingerprint.py`** — the
  fingerprint (`score(v) = |root_bound(better half of v's box) − root_bound(full)|`,
  reusing `t21_root_loop_replay.root_lp_bound`) plus one instrumented 60 s solve,
  both taken in the **reformed** flat space (factorable lift appends `_fr_aux_*`
  after the originals) so `score(v)` and branch-frequency index the same columns.

### Results (60 s, release POUNCE 4.7 MB, 6 Class-P + 5 Class-H)

| instance | cls | root LP bound | top-3 responsive | top-3 branched | overlap | flat? |
|---|---|---:|---|---|:--:|:--:|
| st_e36 | P | −304.5 | **x0**, _fr_aux_0, x1 | **x0**, _fr_aux_0, _fr_aux_1 | 2/3 | no |
| nvs05 | P | 0.675 | _fr_aux_3, x0, _fr_aux_0 | x0, x1, x3 | 1/3 | no |
| nvs09 | P | −72.9 | _fr_aux_1, x2, x0 | x2, x3, x1 | 1/3 | no |
| tanksize | P | **none** | — | x0, x1, x2 | 0/3 | **YES** |
| tls2 | P | ≈0 | x5, x4, x15 | x31, x35, x24 | **0/3** | no |
| hda | P | **none** | — | x719, x709 | 0/3 | **YES** |
| casctanks | H | none | — | x244, x245, x243 | 0/3 | YES |
| 4stufen | H | 10 604 | x129, x130, x131 | x114, x117, x111 | 0/3 | no |
| beuster | H | 5 942 | x156, x155, x154 | x122, x132, x131 | 0/3 | no |
| heatexch_gen1 | H | none | — | x107, x104, x100 | 0/3 | YES |
| bchoco06 | H | none | — | x9, x8, x0 | 0/3 | YES |

### Verdict: **BUILD R3b**
- Class-P instances already branching the responsive vars (overlap ≥ 2/3):
  **1/6** (st_e36 only). SKIP requires ≥ 4 → not met.
- Selection **is** a lever on **nvs05 / nvs09 / tls2** — the policy branches
  non-responsive columns while the responsive ones (incl. lifted `_fr_aux_*`
  products) go untouched. **tls2** is the sharpest signal in the panel: its three
  most-branched columns (x31/x35/x24, 123/98/87 branches) have responsiveness
  score **0**, while the responsive x4/x5 (score 5.0/5.66) are branched **2×** each.
- **st_e36 F5 prediction REFUTED**: F5 predicted x0-responsive / x1-branched
  ("897 nodes on x1, x0 never split"). On the post-F1–F7 engine x0 is **both**
  the top responsive (75.6) **and** top-branched (**267** vs x1's 14). st_e36
  already branches its responsive variable; its residual gap is the
  zero-spanning-factor product relaxation → **R4**, consistent with F5's own
  re-scoping.
- **Relaxation-limited (flat) → R4**: **tanksize, hda** (Class-P) plus
  casctanks/heatexch_gen1/bchoco06 (Class-H) have **no root LP bound at all**
  (AMP constraint omissions), so responsiveness is undefined — branching
  selection cannot be their lever.

### Verification
- `cargo test -p discopt-core` — 423 passed
- `pytest -m smoke` — 574 passed, 14 skipped
- adversarial suite `test_adversarial_recent_fixes.py -m slow` — 10 passed
- `ruff check` / `ruff format` — clean
- Instrumentation neutrality: st_e36 node count / objective / bound
  bit-identical with the counter sink on vs off (87 nodes, −246.0, −304.49044273)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
