### PR TITLE
perf(relaxation): R4 — lift zero-spanning product factors to bounded auxiliaries (flagged, default-off)

### DIFF
--- a/docs/dev/uncertified-tail-plan-2026-07-06.md
+++ b/docs/dev/uncertified-tail-plan-2026-07-06.md
@@ -368,6 +368,88 @@ under-branched signal are **nvs05, nvs09, tls2**.
   them — that would give hda its first dual bound. If not, file the
   relaxation-coverage gap as its own issue; do not force it into R4.
 
+#### R4 RESULTS / VERDICT (2026-07-06) — SHIPPED (flagged, default-OFF)
+
+**Verdict: GO — st_e36 certifies at 60 s with the flag ON. Root cause refined
+vs the plan (measurement beat plan, CLAUDE.md §0.4).**
+
+*Relaxation-catalog precondition (§0.4):* the zero-spanning-factor lift **already
+exists** — `_prelift_blowup_products` (relaxation-catalog §3 "repeated-factor
+lifting") lifts every multi-term factor of a blow-up product to a bounded aux
+`w == f`. On st_e36 it already produces `_fr_aux_0 == f1` (box `[-23, 21.25]`,
+spans 0) and rewrites C0 as the multilinear product
+`_fr_aux_0·_fr_aux_1·…·_fr_aux_4 == 0`. So R4 is **not** "build a lift" and **not**
+new envelope math (F5 kill stands). It is **one branch-policy line**.
+
+*Entry experiment (hand-lift, then the real path):* KILL CRITERION **not** fired.
+Hand-lifting `f1` and splitting `w` at 0: the `w ≤ 0` child's root bound jumps
+**−304.50 → −247.91 (≈ optimum −246.0) and certifies in 5 nodes / 1.0 s**; the pin
+does not survive lifting. Then the decisive diagnostic on the *real* solver path:
+the **exact reformed model** (`_fr_aux_0` already present) solved standalone
+certifies in **7 nodes**, but inside `from_nl(...).solve()` it stalls at −304.49.
+Same model, same aux bounds — the only difference is `solver.py`'s
+`set_branch_deprioritized`, which deprioritizes **every** lifted aux column from
+spatial branching (rationale: a product aux `w = x_i·x_j` can't shrink its own
+envelope). That rationale is **inverted for a zero-spanning FACTOR**: branching
+`w` at 0 flips the factor's sign and sharply tightens the `w·g` McCormick
+envelope — the one move that un-pins the bound. FBBT/OBBT do *not* recover it
+(interval arithmetic decorrelates `x0²` from `−6x0`; naive `[-23,21.25]`,
+root-OBBT `[-8,6.25]`, but the pin is a branching problem, not a bound problem).
+
+*The change (exact, minimal — one lever):*
+`factorable_reform.py` tags the zero-spanning product-factor auxes
+(`_lift_zero_spanning_factors_enabled()`, env `DISCOPT_LIFT_ZERO_SPANNING_FACTORS`,
+**default OFF**) and surfaces them as `Model._zero_spanning_factor_auxes`;
+`solver.py` removes those columns from the branch-deprioritized set so they stay
+spatial-branching candidates. Relaxation math and feasible set are **untouched** —
+the lift is present flag on OR off; only branch *ordering* changes (always sound).
+
+*st_e36 flag ON, root-bound-vs-box (why it un-pins):*
+
+| box (x0 × x1) | reform root bound | note |
+|---|---:|---|
+| full `[3,5.5]×[15,25]`, `w∈[-8,6.25]` | −304.50 | pinned (w not yet split) |
+| after 1 w-split, child `w∈[-8,0]` | **−247.91** | ≈ optimum; certifies 5 nodes |
+| child `w∈[0,6.25]` | −304.50 | loose half; optimum on w=0 boundary |
+
+*st_e36 acceptance:* flag **ON → `optimal`, bound −246.02, 153 nodes, ~16–18 s**
+(≤ 60 s ✓); flag **OFF → `feasible`, bound −304.49, pinned** (baseline, 23.8 % gap).
+
+*Gates (all green):*
+- **Differential bound** (st_e36 + 2 witnesses): root bound identical ON/OFF
+  (relaxation unchanged); certified bound ON ≥ OFF **and** ≤ oracle every box —
+  st_e36 −304.50→−246.18 (≤ −246.0); synthA −32.69→−31.12 (≤ −16.44);
+  synthB −39.80→−21.54 (≤ −20.31). No false certificate.
+- **Feasible-point sampling** (20 000 pts): the lift `w == f(x)` is an exact
+  identity substitution — `C0(orig) − C0(lifted) ≡ 0`; cuts no feasible point.
+- **Flag OFF byte-identical:** `check_cert_neutrality.py` — all 41 certifying
+  instances `nodes X→X`, `|Δobj| = 0` → **NEUTRAL**.
+- **Out-of-panel witnesses:** the F5-style corpus scan (1610 MINLPLib `.nl`,
+  ≤200 KB) finds the zero-spanning *product-factor* structure **only in st_e36** —
+  it is genuinely rare (needs the blow-up prelift). Generality is therefore shown
+  on **2 structurally-distinct synthetic witnesses** (synthA: quadratic factor;
+  synthB: bilinear factor), each un-pinned hugely and sound (above). No
+  instance-keyed code; the tag is purely structural (any lifted product factor
+  whose box spans 0).
+- pytest `test_factorable_reform.py::*r4*` (4 tests), ruff, mypy (touched files):
+  clean.
+
+*Acceptance not met (honest):* **nvs05/nvs09 root gap unchanged** — the flag tags
+**no** aux for them (identical bound ON/OFF). Their stall is a *different*
+structure (nvs09's objective is a `log·log` product that can't even be
+linearized; nvs05 a loose multilinear/signomial), **not** a zero-spanning product
+factor. R4's lever is specific to the st_e36 class; nvs05/nvs09 fall outside it
+and remain for R2/R3b or a separate relaxation-coverage item.
+
+*hda:* out of R4 scope — hda tags no zero-spanning product factor; its 23 omitted
+rows are a `log(<general expr>)`/`x**expr` **relaxation-coverage** gap
+(`_LIFTABLE_CALL_OUTER = {sqrt, exp}` deliberately excludes `log`, which needs a
+certified positive argument lower bound). Filed as its own issue (#517); not
+forced.
+
+*Default flip:* NOT in this PR — flag stays OFF until 3 consecutive green
+nightlies per §0.1.
+
 ### R5 — Zerohalf at a pre-crossover point (optional, parallel; targets #280 graphpart)
 
 - **Basis:** cert-gap-plan §7/§0.8 — a validity-GREEN native {0,½}-CG

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -71,6 +71,28 @@ _ZERO_MARGIN = 1e-9
 _INF_THRESH = 1e15
 
 
+def _lift_zero_spanning_factors_enabled() -> bool:
+    """R4 feature flag (``DISCOPT_LIFT_ZERO_SPANNING_FACTORS``, default OFF).
+
+    When a product ``f(x)·g(x)`` has a *non-atomic* factor ``f`` whose interval
+    spans 0, the factorable reform already lifts ``w == f`` to a bounded aux (via
+    :func:`_prelift_blowup_products`). But the default spatial-branching policy
+    then *deprioritizes* every lifted aux column (``solver.py`` — a product aux
+    ``w = x_i·x_j`` cannot shrink its own envelope, so bisecting it is wasteful).
+    For a zero-*spanning* factor that reasoning is inverted: branching ``w`` at 0
+    splits the sign of the factor, and the McCormick envelope of the product
+    ``w·g`` (with ``g ≥ 0``) responds sharply — it is the only move that un-pins
+    the bound (st_e36: root −304.5, pinned for every x-box, jumps to ≈ optimum
+    once ``w`` is split at 0; see uncertified-tail-plan §3 R4). This flag marks
+    those specific auxes so the solver keeps them branchable. Default OFF keeps
+    the reform byte-identical (no tagging, so the deprioritization set is
+    unchanged).
+    """
+    import os
+
+    return os.environ.get("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", "0") == "1"
+
+
 # The factorable-reform walkers (``_find_clearable_denominator``, ``_lift_expr``,
 # the ``has_factorable_work`` scanners, ...) recurse one Python frame per
 # expression node.  ``from_nl`` rebuilds a sum/product of N terms as a left-deep
@@ -242,6 +264,11 @@ class _Lifter:
         self._expr_cache: dict[tuple[str, float | None], Variable] = {}
         self.aux_constraints: list[Constraint] = []
         self._counter = 0
+        # R4: names of lifted product-factor auxes whose interval spans 0. These
+        # are the only auxes worth keeping as spatial-branching candidates (see
+        # ``_lift_zero_spanning_factors_enabled``). Populated only when the flag
+        # is on, so the default reform is byte-identical.
+        self.zero_spanning_factor_auxes: set[str] = set()
 
     def monomial(self, leaf: Expression, flat_index: int, exp: int) -> Variable | None:
         """Return an aux variable equal to ``leaf**exp`` (creating it on first
@@ -441,6 +468,17 @@ def _prelift_blowup_products(expr: Expression, model: Model, lifter: "_Lifter") 
                     if w is not None:
                         new_factors.append(w)
                         changed = True
+                        # R4: a *product factor* whose lifted aux interval spans 0
+                        # is the branch-responsive one (splitting w at 0 flips the
+                        # factor's sign, tightening the product envelope). Tag it so
+                        # the solver keeps it a spatial-branching candidate instead
+                        # of deprioritizing it with the pure-product auxes. Flag-
+                        # gated: no tagging when off, so the reform is unchanged.
+                        if _lift_zero_spanning_factors_enabled():
+                            w_lo = float(np.min(w.lb))
+                            w_hi = float(np.max(w.ub))
+                            if w_lo < 0.0 < w_hi:
+                                lifter.zero_spanning_factor_auxes.add(w.name)
                         continue
                     new_factors.append(f_lifted)
                 else:
@@ -1441,6 +1479,10 @@ def _factorable_reformulate_inner(model: Model, *, clear_only: bool = False) -> 
         # Defining equalities for the aux variables come first so downstream
         # bound propagation sees them early.
         new_model._constraints = lifter.aux_constraints + rebuilt
+        # R4: surface the zero-spanning product-factor auxes (if any were tagged
+        # under the flag) so the solver can keep them branchable. Always set the
+        # attribute (empty by default) for a stable, easy-to-read contract.
+        new_model._zero_spanning_factor_auxes = set(lifter.zero_spanning_factor_auxes)
         return new_model
     except Exception:  # pragma: no cover - defensive: never break a solve
         return model

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1670,6 +1670,12 @@ class Model:
         self._names: set[str] = set()
         self._constraints: list[Constraint] = []
         self._objective: Optional[Objective] = None
+        # R4: names of lifted product-factor auxes whose interval spans 0, set by
+        # the factorable reform under ``DISCOPT_LIFT_ZERO_SPANNING_FACTORS`` so the
+        # solver keeps them as spatial-branching candidates (see
+        # ``factorable_reform._lift_zero_spanning_factors_enabled``). Empty by
+        # default, so it never changes behaviour with the flag off.
+        self._zero_spanning_factor_auxes: set[str] = set()
         self._builder = None  # Optional PyModelBuilder, lazy-initialized
         self._aux_counter = 0  # monotonic suffix for if_else auxiliary names
         # Complementarity conditions added via ``complementarity()``; recorded

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4793,6 +4793,25 @@ def solve_model(
                         _dep_cols_set: set = set()
                         if _prereform_model is not None and n_vars > _prereform_nvars:
                             _dep_cols_set.update(range(_prereform_nvars, n_vars))
+                        # R4 (DISCOPT_LIFT_ZERO_SPANNING_FACTORS): a lifted aux
+                        # ``w = f(x)`` for a *product factor* whose interval spans 0
+                        # is branch-responsive — splitting w at 0 flips the factor's
+                        # sign and tightens the product's McCormick envelope, the one
+                        # move that un-pins the bound (st_e36). Keep those columns
+                        # branchable by removing them from the deprioritized set. The
+                        # flag gates the reform's tagging, so this set is empty (no
+                        # behaviour change) unless the flag is on.
+                        _zsf_names = getattr(model, "_zero_spanning_factor_auxes", None)
+                        if _zsf_names:
+                            _name_to_col = {}
+                            _col = 0
+                            for _v in model._variables:
+                                _name_to_col[_v.name] = _col
+                                _col += _v.size
+                            _zsf_cols = {
+                                _name_to_col[_nm] for _nm in _zsf_names if _nm in _name_to_col
+                            }
+                            _dep_cols_set.difference_update(_zsf_cols)
                         if _dependent_var_names:
                             from discopt._jax.dependent_vars import (
                                 dependent_columns_for_model,

--- a/python/tests/test_factorable_reform.py
+++ b/python/tests/test_factorable_reform.py
@@ -518,6 +518,137 @@ def test_entropy_domain_guard_rejects_negative_lb():
     assert not _has_entropy(out._objective.expression)
 
 
+# --------------------------------------------------------------------------- #
+# R4 — zero-spanning product-factor lift (DISCOPT_LIFT_ZERO_SPANNING_FACTORS)  #
+# --------------------------------------------------------------------------- #
+#
+# A product ``f(x)·g(x)`` whose non-atomic factor ``f`` has an interval spanning
+# 0 already gets ``f`` lifted to a bounded aux ``w == f`` (via the blow-up
+# prelift). The default spatial-branching policy deprioritizes every lifted aux
+# (a product aux ``w = x_i·x_j`` cannot shrink its own envelope). For a
+# zero-spanning FACTOR that reasoning is inverted: branching ``w`` at 0 splits
+# the factor's sign and tightens the ``w·g`` McCormick envelope — the only move
+# that un-pins the bound. The flag tags those auxes so the solver keeps them
+# branchable. Default OFF => no tagging => byte-identical branching set.
+
+
+def _st_e36_shaped(name="zsf"):
+    """A 2-var st_e36-shaped model: a product of a zero-spanning quadratic factor
+    ``f = x^2 - 6x - 11 + 0.8y`` (∋ 0 on the box) and a strictly-positive
+    sum-of-squares product ``g``, constrained ``f·g == 0``. Since ``g > 0`` the
+    feasible set is exactly ``f == 0``; the objective's box-min off the manifold
+    pins the McCormick product bound until ``f``'s lifted aux is split at 0.
+    NOT the named instance — built here so the test is a class probe, not an
+    instance hack."""
+    m = dm.Model(name)
+    x = m.continuous("x", lb=3.0, ub=5.5)
+    y = m.continuous("y", lb=15.0, ub=25.0)
+    m.minimize(2 * x**2 + 0.008 * y**3 - 3.2 * x * y - 2 * y)
+    f = x**2 - 6 * x - 11 + 0.8 * y
+    g = (
+        ((-0.62 * y + 3.25 * x) ** 2 + (-6.35 + 0.2 * y + x) ** 2)
+        * ((-0.66 * y + 3.55 * x) ** 2 + (-6.85 + 0.2 * y + x) ** 2)
+        * ((-0.7 * y + 3.6 * x) ** 2 + (-7.1 + 0.2 * y + x) ** 2)
+        * ((-0.82 * y + 3.8 * x) ** 2 + (-7.9 + 0.2 * y + x) ** 2)
+    )
+    m.subject_to(f * g == 0)
+    m.subject_to(-0.2 * x * y + 0.6 * y + dm.exp(x - 3) - 1 <= 0)
+    return m
+
+
+def test_r4_default_off_no_tagging(monkeypatch):
+    """Flag OFF (default): no aux is tagged, so the branching set is unchanged."""
+    monkeypatch.delenv("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", raising=False)
+    m = _st_e36_shaped()
+    assert has_factorable_work(m)
+    m2 = factorable_reformulate(m)
+    # The lift still happens (the aux exists) — only the *tagging* is gated.
+    assert _aux_names(m2), "the zero-spanning factor should still be lifted"
+    assert getattr(m2, "_zero_spanning_factor_auxes", set()) == set()
+
+
+def test_r4_flag_on_tags_zero_spanning_factor(monkeypatch):
+    """Flag ON: the zero-spanning product-factor aux is tagged for branching."""
+    monkeypatch.setenv("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", "1")
+    m = _st_e36_shaped()
+    m2 = factorable_reformulate(m)
+    tagged = getattr(m2, "_zero_spanning_factor_auxes", set())
+    assert tagged, "a zero-spanning product factor must be tagged when the flag is on"
+    # Every tagged aux really spans 0 over its lifted box.
+    for v in m2._variables:
+        if v.name in tagged:
+            import numpy as np
+
+            lo, hi = float(np.min(v.lb)), float(np.max(v.ub))
+            assert lo < 0.0 < hi, f"tagged aux {v.name} box [{lo},{hi}] must span 0"
+
+
+def test_r4_positive_factor_not_tagged(monkeypatch):
+    """A product whose lifted factors are all strictly one-signed (never span 0)
+    tags nothing — the flag must not indiscriminately mark every product aux."""
+    monkeypatch.setenv("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", "1")
+    m = dm.Model("pos_factors")
+    x = m.continuous("x", lb=1.0, ub=3.0)
+    y = m.continuous("y", lb=1.0, ub=3.0)
+    # Both factors are sums of squares plus a positive constant => strictly > 0.
+    f = (x + y) ** 2 + (x - 0.5 * y) ** 2 + 1.0
+    g = (
+        ((0.5 * x + y) ** 2 + (x + 0.3 * y) ** 2 + 1.0)
+        * ((0.4 * x + y) ** 2 + (x + 0.2 * y) ** 2 + 1.0)
+        * ((0.3 * x + y) ** 2 + (x + 0.1 * y) ** 2 + 1.0)
+    )
+    m.minimize(x + y)
+    m.subject_to(f * g <= 5000.0)
+    if has_factorable_work(m):
+        m2 = factorable_reformulate(m)
+        for v in m2._variables:
+            if v.name in getattr(m2, "_zero_spanning_factor_auxes", set()):
+                import numpy as np
+
+                lo, hi = float(np.min(v.lb)), float(np.max(v.ub))
+                assert lo < 0.0 < hi  # any tagged aux must genuinely span 0
+
+
+@pytest.mark.correctness
+@pytest.mark.slow
+def test_r4_flag_on_unpins_pinned_product(monkeypatch):
+    """The st_e36-shaped pinned-product model: with the flag OFF the product's
+    McCormick bound is pinned at a box-min constant far below the optimum; with
+    it ON the zero-spanning factor aux becomes branchable and the bound climbs to
+    (essentially) the optimum. Asserts the *lever* (bound un-pinning) and
+    soundness — not a wall-clock certification race, which is machine-dependent.
+
+    The pin (OFF) is ≈ -304.5; the optimum is ≈ -246.0. A ≥ 25 % relative gap
+    reduction (the R4 acceptance threshold) is the falsifiable claim.
+    """
+    monkeypatch.setenv("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", "1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r_on = _st_e36_shaped().solve(time_limit=60, gap_tolerance=1e-4)
+    monkeypatch.setenv("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", "0")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r_off = _st_e36_shaped().solve(time_limit=20, gap_tolerance=1e-4)
+
+    assert r_on.bound is not None and r_off.bound is not None
+    assert r_on.objective is not None and r_off.objective is not None
+    opt = r_on.objective  # both reach the same incumbent (the true optimum)
+    # Soundness (both paths): the dual bound never crosses the optimum (min).
+    assert r_on.bound <= opt + 1e-4, "ON bound must not exceed the optimum (false cert)"
+    assert r_off.bound <= opt + 1e-4, "OFF bound must not exceed the optimum"
+    # Non-regression: ON is at least as tight as OFF.
+    assert r_on.bound >= r_off.bound - 1e-4, "ON bound must not regress vs OFF"
+    # The lever: ON reduces the root/OFF gap to the optimum by >= 25 %.
+    gap_off = abs(opt - r_off.bound)
+    gap_on = abs(opt - r_on.bound)
+    assert gap_off > 1e-3, "probe must actually be pinned with the flag OFF"
+    reduction = (gap_off - gap_on) / gap_off
+    assert reduction >= 0.25, (
+        f"flag ON must un-pin the bound >= 25 % "
+        f"(OFF gap {gap_off:.3f} -> ON gap {gap_on:.3f}, reduction {reduction:.1%})"
+    )
+
+
 def test_entropy_canonicalized_in_constraint_body():
     """The rewrite fires in constraint bodies too, not just the objective."""
     m = dm.Model("entcon")


### PR DESCRIPTION
## R4 — Zero-spanning-factor lifting (uncertified-tail-plan §3)

**Bound-changing task, strict regime. Flag `DISCOPT_LIFT_ZERO_SPANNING_FACTORS`, default OFF. Do NOT merge to flip the default — flag stays OFF until nightly-green (§0.1).**

### Relaxation-catalog precondition (§0.4): BUILD, but a one-line lever
The zero-spanning-factor lift **already exists** — `_prelift_blowup_products` (relaxation-catalog §3 "repeated-factor lifting") lifts every multi-term factor of a blow-up product to a bounded aux `w == f`. On st_e36 it already yields `_fr_aux_0 == f1` (box `[-23, 21.25]`, spans 0) and rewrites `C0` as the multilinear product `_fr_aux_0·_fr_aux_1·…·_fr_aux_4 == 0`. So R4 is **not** a new lift and **not** new envelope math (F5 kill stands).

### Entry experiment (ran before building; KILL CRITERION not fired)
Hand-lifting `f1` and splitting `w` at 0: the `w ≤ 0` child's root bound jumps **−304.50 → −247.91 (≈ optimum −246.0), certifies in 5 nodes**. The pin does not survive lifting. Decisive diagnostic on the real path: the **exact reformed model** (with `_fr_aux_0` present) solved *standalone* certifies in **7 nodes**, but inside `from_nl(...).solve()` it stalls at −304.49. Same model, same aux bounds.

**Root cause refined vs the plan (measurement beat plan, CLAUDE.md §0.4):** the difference is `solver.py`'s `set_branch_deprioritized`, which deprioritizes **every** lifted aux from spatial branching (a product aux `w = x_i·x_j` can't shrink its own envelope). That reasoning is **inverted for a zero-spanning FACTOR**: branching `w` at 0 flips the factor's sign and sharply tightens the `w·g` McCormick envelope — the only move that un-pins the bound. FBBT/OBBT do not recover it (interval arithmetic decorrelates `x0²` from `−6x0`); it is a branching problem, not a bound problem.

### The change (exact, minimal — one lever)
- `python/discopt/_jax/factorable_reform.py` — `_lift_zero_spanning_factors_enabled()` (env flag, default OFF); tag lifted product-factor auxes whose box spans 0; surface as `Model._zero_spanning_factor_auxes`.
- `python/discopt/modeling/core.py` — declare `Model._zero_spanning_factor_auxes` (empty default).
- `python/discopt/solver.py` — remove tagged columns from the branch-deprioritized set (keep them branchable). Flag gates the tagging, so the set is empty (no behaviour change) when OFF.

Relaxation math and feasible set are untouched — the lift is present flag on OR off; only branch *ordering* changes (always sound).

### st_e36 acceptance
| flag | status | bound | nodes | wall |
|---|---|---:|---:|---:|
| ON | **optimal** | −246.02 | 153 | ~17 s (≤ 60 s ✓) |
| OFF | feasible | −304.49 (pinned) | — | baseline unchanged |

Root-bound-vs-box (why it un-pins): full box `w∈[-8,6.25]` → −304.50 (pinned); after 1 `w`-split, child `w∈[-8,0]` → **−247.91** (≈ optimum, certifies 5 nodes); child `w∈[0,6.25]` → −304.50 (loose half; optimum on the `w=0` boundary).

### Gates (all green)
- **Differential bound** (st_e36 + 2 witnesses): root bound identical ON/OFF (relaxation unchanged); certified bound ON ≥ OFF **and** ≤ oracle every box — st_e36 −304.50→−246.18 (≤ −246.0); synthA −32.69→−31.12 (≤ −16.44); synthB −39.80→−21.54 (≤ −20.31). No false certificate.
- **Feasible-point sampling** (20 000 pts): the lift `w == f(x)` is an exact identity substitution; `C0(orig) − C0(lifted) ≡ 0`; cuts no point.
- **Flag-OFF byte-identical:** `check_cert_neutrality.py` → **NEUTRAL** (41/41 certifying instances `nodes X→X`, `|Δobj| = 0`).
- **Out-of-panel witnesses:** F5-style corpus scan (1610 MINLPLib `.nl`, ≤200 KB) finds the zero-spanning *product-factor* structure **only in st_e36** — genuinely rare (needs the blow-up prelift). Generality shown on **2 structurally-distinct synthetic witnesses** (synthA quadratic factor, synthB bilinear factor), each un-pinned and sound. No instance-keyed code — the tag is purely structural.
- Tests: `pytest test_factorable_reform.py` = **63 passed** (incl. 4 new R4 tests); adversarial recent-fixes = **10 passed**; smoke = **614 passed, 14 skipped**. `ruff check`/`ruff format --check`/`mypy` on touched files = clean. **No Rust touched** (cargo test not required).

### Acceptance not met (honest)
- **nvs05/nvs09 root gap unchanged** — the flag tags **no** aux for them (identical bound ON/OFF). Their stall is a *different* structure (nvs09's objective is a `log·log` product that can't be linearized; nvs05 a loose multilinear/signomial), not a zero-spanning product factor. R4's lever is specific to the st_e36 class.
- **hda** — out of R4 scope (tags no zero-spanning product factor; its 23 omitted rows are a `log(<general expr>)`/`x**expr` relaxation-coverage gap). Filed as **#517**.

### What was run
`pytest test_factorable_reform.py` (63), `pytest -m slow test_adversarial_recent_fixes.py` (10), `pytest -m smoke python/tests/` (614), `check_cert_neutrality.py` (NEUTRAL), differential + feasible-point harness (st_e36 + 2 witnesses), F5-style corpus scan (1610 `.nl`). Release POUNCE verified (`_pounce.abi3.so`, 4.7 MB). Machine: M4-class arm64, pounce 0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
