### PR TITLE
perf(cert-gap): V2 — [suites.global50]/[gates.cert2] wiring + flag-on BARON re-run (final tally)

### DIFF
--- a/discopt_benchmarks/benchmarks/metrics.py
+++ b/discopt_benchmarks/benchmarks/metrics.py
@@ -438,7 +438,23 @@ def root_gap_ratio(
     results_a: list[SolveResult],
     results_b: list[SolveResult],
 ) -> float:
-    """Mean ratio of root gaps: solver_a / solver_b on common instances."""
+    """Mean ratio of root gaps: solver_a / solver_b on common instances.
+
+    This is the metric behind ``root_gap_ratio_vs_baron`` (``[gates.cert2]``).
+    ``SolveResult.root_gap`` is ``(UB − LB_root)/|UB|`` at the root; A3 wired the
+    certified dual bound onto ``SolveResult.bound`` (null before A3), which makes
+    ``root_gap`` — and therefore this ratio — evaluable against a BARON reference.
+
+    Reference-bound caveat (cert-gap-plan §14 T2.6 item 3): many BARON rows carry
+    no usable root/dual bound (e.g. ``status="unknown"`` at ~20 ms), so their
+    ``root_gap`` is ``None``. Those rows are **excluded from both numerator and
+    denominator** by the ``root_gap is not None`` filter, so the ratio is never
+    divided by a non-bound. The ``gaps_b[inst] > 1e-10`` guard drops instances
+    where BARON's root gap is ~0 (division would blow up / is meaningless), and a
+    non-finite discopt gap is skipped defensively. Returns NaN when no instance
+    has a usable bound on both sides — the gate then reads NaN → fail (an honest
+    "not evaluable" rather than a spuriously-passing empty mean).
+    """
     gaps_a = {r.instance: r.root_gap for r in results_a if r.root_gap is not None}
     gaps_b = {r.instance: r.root_gap for r in results_b if r.root_gap is not None}
     common = set(gaps_a.keys()) & set(gaps_b.keys())
@@ -446,9 +462,39 @@ def root_gap_ratio(
         return float("nan")
     ratios = []
     for inst in common:
-        if gaps_b[inst] > 1e-10:
+        if gaps_b[inst] > 1e-10 and math.isfinite(gaps_a[inst]):
             ratios.append(gaps_a[inst] / gaps_b[inst])
     return float(np.mean(ratios)) if ratios else float("nan")
+
+
+def closed_within_10_nodes_fraction(
+    results: list[SolveResult],
+    node_threshold: int = 10,
+) -> float:
+    """Fraction of *proved-optimal* rows that certified within ``node_threshold``
+    B&B nodes — the T2.6 metric for the Phase-2 exit criterion "≥ 30% of
+    currently-tree-opening instances close within 10 nodes" (cert-gap-plan §6/§14).
+
+    Rationale: BARON closes most of the global50 panel at 0–9 nodes; the branch-
+    and-reduce goal is for discopt to certify (prove optimality) at the root or in
+    a handful of nodes rather than opening a large tree. The denominator is every
+    row that reached a *proven optimum* (``status == OPTIMAL`` with a node count);
+    the numerator is the subset that did so in ``≤ node_threshold`` nodes. A row
+    that only found a feasible incumbent (uncertified tail) or errored is not in
+    the denominator — the metric measures *how tightly* the proofs close, not the
+    proof rate. Returns 0.0 for an empty set of proved rows.
+
+    ``node_count == 0`` rows are counted as closed (a convex fast-path / root
+    fathom proves optimality without opening a tree — the tightest possible close).
+    """
+    proved = [
+        r for r in results
+        if r.status == SolveStatus.OPTIMAL and r.node_count is not None
+    ]
+    if not proved:
+        return 0.0
+    closed = sum(1 for r in proved if r.node_count <= node_threshold)
+    return closed / len(proved)
 
 
 def node_count_reduction(
@@ -746,6 +792,8 @@ def evaluate_phase_gate(
                 actual = geometric_mean_ratio(discopt_results, reference_solvers[ref_solver])
         elif metric == "root_gap_populated_fraction":
             actual = root_gap_populated_fraction(discopt_results)
+        elif metric == "closed_within_10_nodes_fraction":
+            actual = closed_within_10_nodes_fraction(discopt_results)
         elif metric.startswith("root_gap_ratio_vs_"):
             ref_solver = metric.replace("root_gap_ratio_vs_", "")
             if reference_solvers and ref_solver in reference_solvers:

--- a/discopt_benchmarks/config/benchmarks.toml
+++ b/discopt_benchmarks/config/benchmarks.toml
@@ -79,6 +79,22 @@ sources = ["minlplib"]
 instance_list = "config/comparison_instances.txt"
 time_limit_seconds = 3600
 
+[suites.global50]
+# The certification panel every `[gates.cert*]` references (cert-gap-plan §11/§14
+# T2.6). Before this table existed, cert0/cert1/cert2 named `suite = "global50"`
+# with no suite to resolve it against — the recon flag in §11's "Wiring
+# corrections (2026-07-02)". The panel is the 50-instance BARON head-to-head set
+# vendored as `config/baron_global50.txt`. 49 of the 50 have a `.nl` in the local
+# corpus (`python/tests/data/minlplib_nl/`) and run out of the box with no
+# --fetch; st_miqp5 is listed but ships only as a binary `.nl` discopt cannot
+# parse (skipped by R1 for the same reason), so it resolves to 49 locally and to
+# all 50 with `--fetch`. 60 s per-instance cap matches the measurement of record
+# (`scripts/global_opt_baron_vs_discopt.py --time-limit 60`).
+description = "Certification panel: 50-instance BARON head-to-head set (cert-gap-plan §11)"
+sources = ["minlplib"]
+instance_list = "config/baron_global50.txt"
+time_limit_seconds = 60
+
 [suites.nightly]
 description = "Nightly CI regression suite"
 sources = ["minlplib"]
@@ -239,6 +255,31 @@ description = "Phase 1 gate: general node engine (cert:T1.x). Direction-(a) neut
   # Performance exit (§5) — pending the OBBT follow-on; informational until then.
   interop_overhead = { max = 0.10, suite = "global50", metric = "python_orchestration_fraction" }
   sec_per_node = { max = 0.018, suite = "global50", metric = "median_seconds_per_node" }
+
+[gates.cert2]
+description = "Phase 2 gate: branch-and-reduce (cert:T2.x). Root-gap vs BARON + tree closure."
+# Wiring per §11 with the 2026-07-02 recon corrections and the T2.6 additions
+# (cert-gap-plan §14 T2.6 items 1–2):
+#   * root_gap_vs_baron uses `root_gap_ratio_vs_baron`, which A3 made evaluable by
+#     wiring the certified dual bound onto `SolveResult.bound` (null before A3).
+#     The ratio counts ONLY BARON rows carrying a usable root/dual bound — many
+#     BARON rows are `status="unknown"` at ~20 ms with no bound to divide by; the
+#     metric fn skips a reference row whose `bound`/`root_gap` is None and floors
+#     the denominator, so it never divides by a non-bound (see metrics.py).
+#   * geomean_vs_baron uses the EXISTING `geomean_ratio_vs_baron` metric name
+#     (§11 correction 2 — `geomean_time_ratio_vs_baron` was never implemented).
+#   * closed_within_10_nodes_fraction is the new T2.6 metric for the §6 exit
+#     "≥ 30% of currently-tree-opening instances close within 10 nodes".
+# INFORMATIONAL until the R2/R3b/R4 flags are default-on (3 green nightlies, out
+# of V2 scope): T2.3–T2.5 are not built and R4 ships default-OFF, so the root-gap
+# and geomean criteria are not expected to pass on `main` yet. `zero_incorrect`
+# is the live zero-slack gate.
+
+  [gates.cert2.criteria]
+  zero_incorrect = { max = 0, suite = "global50", metric = "incorrect_count" }
+  root_gap_vs_baron = { max = 1.3, suite = "global50", metric = "root_gap_ratio_vs_baron" }
+  geomean_vs_baron = { max = 2.5, suite = "global50", metric = "geomean_ratio_vs_baron" }
+  tree_closed_fraction = { min = 0.30, suite = "global50", metric = "closed_within_10_nodes_fraction" }
 
 # ─────────────────────────────────────────────────────────────
 # SOLVER CONFIGURATIONS

--- a/discopt_benchmarks/tests/test_cert_instrumentation.py
+++ b/discopt_benchmarks/tests/test_cert_instrumentation.py
@@ -13,8 +13,10 @@ Pins the producers added to make the certification loop measurable:
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
+import tomllib
 
 os.environ.setdefault("JAX_PLATFORMS", "cpu")
 os.environ.setdefault("JAX_ENABLE_X64", "1")
@@ -23,6 +25,7 @@ from benchmarks.metrics import (  # noqa: E402
     BenchmarkResults,
     SolveResult,
     SolveStatus,
+    closed_within_10_nodes_fraction,
     evaluate_phase_gate,
     root_gap_populated_fraction,
     root_gap_ratio,
@@ -197,9 +200,6 @@ def test_root_gap_populated_fraction():
 
 
 def _load_cert0_gate_config():
-    import tomllib
-    from pathlib import Path
-
     toml = Path(__file__).resolve().parents[1] / "config" / "benchmarks.toml"
     with open(toml, "rb") as fh:
         return tomllib.load(fh)["gates"]["cert0"]
@@ -256,3 +256,97 @@ def test_cert0_gate_fails_on_incorrect():
     assert by["zero_incorrect"].actual >= 1
     assert not by["zero_incorrect"].passed
     assert not ok
+
+
+# ─────────────────────── T2.6: closed_within_10_nodes_fraction ───────────────────────
+
+def _opt(name: str, nodes: int) -> SolveResult:
+    """A proved-optimal discopt row with a given node count."""
+    return SolveResult(
+        instance=name, solver="discopt", status=SolveStatus.OPTIMAL,
+        objective=1.0, bound=1.0, node_count=nodes,
+    )
+
+
+def test_closed_within_10_nodes_fraction_known_counts():
+    """A fixture with known node counts yields the known fraction: of 4 proved
+    rows, 3 close in ≤ 10 nodes (0, 7, 10) and 1 does not (153) → 3/4 = 0.75."""
+    rows = [_opt("root_fathom", 0), _opt("cheap", 7), _opt("edge", 10), _opt("st_e36", 153)]
+    assert closed_within_10_nodes_fraction(rows) == pytest.approx(0.75)
+
+
+def test_closed_within_10_nodes_fraction_boundary_and_zero():
+    """node_count == threshold counts as closed; a run that opens 11 nodes does
+    not; node_count == 0 (root fathom / convex fast path) is the tightest close."""
+    assert closed_within_10_nodes_fraction([_opt("x", 10)]) == pytest.approx(1.0)
+    assert closed_within_10_nodes_fraction([_opt("x", 11)]) == pytest.approx(0.0)
+    assert closed_within_10_nodes_fraction([_opt("x", 0)]) == pytest.approx(1.0)
+
+
+def test_closed_within_10_nodes_fraction_denominator_is_proved_only():
+    """The denominator is *proved-optimal* rows only — feasible (uncertified
+    tail) and errored rows are excluded, so a large feasible tree does not dilute
+    the metric. Of the two OPTIMAL rows here (both ≤ 10 nodes) the fraction is
+    1.0 even though a feasible 900-node row is present."""
+    rows = [
+        _opt("a", 3),
+        _opt("b", 8),
+        SolveResult(instance="tail", solver="discopt", status=SolveStatus.FEASIBLE,
+                    objective=1.0, bound=0.0, node_count=900),
+        SolveResult(instance="err", solver="discopt", status=SolveStatus.ERROR),
+    ]
+    assert closed_within_10_nodes_fraction(rows) == pytest.approx(1.0)
+
+
+def test_closed_within_10_nodes_fraction_empty_is_zero():
+    """No proved-optimal rows → 0.0 (an honest 'nothing closed', not a NaN)."""
+    assert closed_within_10_nodes_fraction([]) == pytest.approx(0.0)
+    tail_only = [SolveResult(instance="t", solver="discopt", status=SolveStatus.FEASIBLE,
+                             objective=1.0, node_count=500)]
+    assert closed_within_10_nodes_fraction(tail_only) == pytest.approx(0.0)
+
+
+def _load_cert2_gate_config():
+    toml = Path(__file__).resolve().parents[1] / "config" / "benchmarks.toml"
+    with open(toml, "rb") as fh:
+        return tomllib.load(fh)["gates"]["cert2"]
+
+
+def test_cert2_suite_and_gate_wired():
+    """[suites.global50] resolves and [gates.cert2] wires the T2.6 metrics with
+    the recorded corrections (existing geomean_ratio_vs_baron name; new
+    closed_within_10_nodes_fraction; root_gap_ratio_vs_baron; zero-slack incorrect)."""
+    toml = Path(__file__).resolve().parents[1] / "config" / "benchmarks.toml"
+    with open(toml, "rb") as fh:
+        cfg = tomllib.load(fh)
+
+    # Every cert gate references suite "global50" — the suite table must exist.
+    assert "global50" in cfg["suites"]
+    assert cfg["suites"]["global50"]["instance_list"] == "config/baron_global50.txt"
+
+    crit = _load_cert2_gate_config()["criteria"]
+    assert crit["root_gap_vs_baron"]["metric"] == "root_gap_ratio_vs_baron"
+    assert crit["root_gap_vs_baron"]["max"] == 1.3
+    assert crit["geomean_vs_baron"]["metric"] == "geomean_ratio_vs_baron"
+    assert crit["tree_closed_fraction"]["metric"] == "closed_within_10_nodes_fraction"
+    assert crit["tree_closed_fraction"]["min"] == 0.30
+    assert crit["zero_incorrect"]["metric"] == "incorrect_count"
+    assert crit["zero_incorrect"]["max"] == 0
+
+
+def test_cert2_gate_dispatch_evaluates_new_metric():
+    """evaluate_phase_gate dispatches closed_within_10_nodes_fraction — a panel
+    where 3/4 proved rows close in ≤ 10 nodes reads 0.75 and passes the ≥ 0.30
+    criterion; the zero-slack correctness guard also passes on a correct panel."""
+    gate = _load_cert2_gate_config()
+    rows = [_opt("root_fathom", 0), _opt("cheap", 7), _opt("edge", 10), _opt("st_e36", 153)]
+    bench = BenchmarkResults(suite="cert2", timestamp="t")
+    for r in rows:
+        bench.add_result(r)
+    optima = {r.instance: 1.0 for r in rows}
+    ok, crits = evaluate_phase_gate("cert2", bench, gate, known_optima=optima)
+    by = {c.name: c for c in crits}
+    assert by["tree_closed_fraction"].actual == pytest.approx(0.75)
+    assert by["tree_closed_fraction"].passed
+    assert by["zero_incorrect"].actual == 0
+    assert by["zero_incorrect"].passed

--- a/docs/dev/uncertified-tail-plan-2026-07-06.md
+++ b/docs/dev/uncertified-tail-plan-2026-07-06.md
@@ -547,6 +547,34 @@ nightlies per §0.1.
 
 ### V2 — Gate wiring + the measurement of record
 
+**STATUS: DONE (2026-07-06). Honest target revised 42 → 43 (not the plan's ≥46,
+which assumed R2+R3b landed).** Full write-up:
+`docs/dev/uncertified-tail-plan-results-2026-07-06.md`. Summary:
+
+- **Gate wiring (Part 1) — landed.** `[suites.global50]` added to
+  `benchmarks.toml` (`instance_list = "config/baron_global50.txt"`, the panel
+  every cert gate named but had no table for); `[gates.cert2]` added per
+  cert-gap-plan §11 with the recorded corrections (`root_gap_ratio_vs_baron`
+  from A3's live `SolveResult.bound`; existing `geomean_ratio_vs_baron` name;
+  new `closed_within_10_nodes_fraction` metric fn + dispatch in `metrics.py`).
+  Reference-bound caveat handled: the root-gap ratio counts only BARON rows with
+  a usable bound (null-`root_gap` rows excluded both sides, `>1e-10` denominator
+  guard). 6 new tests (metric fn + gate wiring), all green. cert2 is
+  informational until the R-flags flip default-on (out of V2 scope).
+- **Measurement of record (Part 2) — flag-ON BARON re-run.** `proved-optimal
+  42 → 43` (**st_e36** only: feasible/TL → optimal, 153 nodes, ~17 s, with
+  `DISCOPT_LIFT_ZERO_SPANNING_FACTORS=1`). Correct-count and the four hard gates
+  (0 violations; no certification lost; time-limit contract; bound-vs-oracle
+  clean) all hold. R4 is the **only shipped tail win**; a single flag-ON full run
+  suffices because the corpus scan found the zero-spanning structure only in
+  st_e36 and flag-OFF is byte-identical to the V1 baseline on the 41-instance
+  cert panel.
+- **Why not ≥46:** R2 deferred (broad, non-tail); R3b killed by its own entry
+  experiment (the tail is relaxation-limited, not selection-limited); R5 not
+  built; F5/F6 killed. The plan's ≥46 assumed R2+R3b landed. tanksize/nvs05/
+  nvs09/tls2 and the hard no-bound tail (hda, casctanks, …) are unchanged —
+  deeper lifting / relaxation coverage (#517), out of scope.
+
 1. **Wire the long-missing suite/gate** (cert-gap-plan §14 T2.6 items 1–2):
    `[suites.global50]` in `benchmarks.toml` + `[gates.cert2]`
    (`root_gap_ratio_vs_baron ≤ 1.3` — computed from A3's now-live bound

--- a/docs/dev/uncertified-tail-plan-results-2026-07-06.md
+++ b/docs/dev/uncertified-tail-plan-results-2026-07-06.md
@@ -1,0 +1,196 @@
+# Uncertified-tail plan — V2 results (2026-07-06)
+
+**Status:** measured. The V2 gate-wiring + measurement-of-record task of
+`docs/dev/uncertified-tail-plan-2026-07-06.md` §3 V2 (and cert-gap-plan §11 /
+§14 T2.6 items 1–2). Two parts: (1) wire the long-missing
+`[suites.global50]` / `[gates.cert2]`; (2) the flag-ON BARON re-run that tallies
+what the tail plan's R-series actually shipped.
+
+**Headline (honest):** **R4 (#518) is the only shipped tail win.** With
+`DISCOPT_LIFT_ZERO_SPANNING_FACTORS=1` (default OFF), **st_e36** moves
+feasible/TL → **optimal** (153 nodes, ~17 s), lifting **proved-optimal 42 → 43**
+vs the 2026-07-06 V1 baseline. This is *not* the plan's original ≥46 target —
+that assumed R2 + R3b landed. R3b was killed by its own entry experiment (which
+also revealed R3a's fingerprint was measured on the wrong model — the
+factorable-only reform, not the integer-bilinear model the tree actually
+branches — so the tail is relaxation-limited, not selection-limited), R2 is
+deferred (broad, non-tail), R5 was not built, and F5/F6 were
+already killed. The hard branch-and-reduce / no-bound tail (nvs05, nvs09, hda,
+tanksize, casctanks, …) is **unchanged** — those need deeper lifting /
+relaxation coverage (#517), out of this plan's scope.
+
+**Method.** `discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py
+--time-limit 60 --out-dir reports`, 61 vendored MINLPLib `.nl`, discopt
+(isolated subprocess, **release** maturin build) vs full-license BARON via
+GAMS 53, MINLPLib `primalbound` oracle, abs=1e-6/rel=1e-4. **Release POUNCE**
+(4.7 MB `_pounce.abi3.so`) — the debug-build artifact (pounce#182) does not
+apply. The flag-ON run sets `DISCOPT_LIFT_ZERO_SPANNING_FACTORS=1` in the
+environment; it propagates to every discopt subprocess through the worker's
+`env=dict(os.environ, …)`. Reports:
+
+- flag-ON (this run): `reports/global_opt_baron_vs_discopt_2026-07-06T06-15-16.{json,md}`
+- V1 baseline (flag-OFF, on main): `reports/global_opt_baron_vs_discopt_2026-07-06T03-25-20.json`
+
+---
+
+## 1. Gate wiring (Part 1)
+
+Every `[gates.cert*]` in `benchmarks.toml` named `suite = "global50"`, but no
+`[suites.global50]` table existed (the recon flag in cert-gap-plan §11 "Wiring
+corrections 2026-07-02"). V2 closes that.
+
+**`[suites.global50]`** — points at the vendored `config/baron_global50.txt`
+(50 instances). 49 have a `.nl` in the local corpus
+(`python/tests/data/minlplib_nl/`) and run with no `--fetch`; st_miqp5 is listed
+but ships only as a binary `.nl` discopt cannot parse (R1 skipped it for the same
+reason), so the suite resolves to 49 locally / 50 with `--fetch`. 60 s
+per-instance cap matches the measurement of record.
+
+**`[gates.cert2]`** — wired per §11 with the recorded corrections:
+
+| criterion | metric | bound | notes |
+|---|---|---|---|
+| `zero_incorrect` | `incorrect_count` | max 0 | the zero-slack correctness gate (live) |
+| `root_gap_vs_baron` | `root_gap_ratio_vs_baron` | max 1.3 | computed from A3's now-live `SolveResult.bound` (null before A3) |
+| `geomean_vs_baron` | `geomean_ratio_vs_baron` | max 2.5 | **existing** metric name (§11 correction 2 — `geomean_time_ratio_vs_baron` was never implemented) |
+| `tree_closed_fraction` | `closed_within_10_nodes_fraction` | min 0.30 | new T2.6 metric + dispatch; the "≥ 30% close within 10 nodes" exit |
+
+**Reference-bound caveat (§14 T2.6 item 3).** Many BARON rows carry no usable
+root/dual bound (`status="unknown"` at ~20 ms), so their `root_gap` is `None`.
+`root_gap_ratio` excludes null-`root_gap` rows from **both** numerator and
+denominator, guards the denominator with `>1e-10`, and skips a non-finite
+discopt gap — it never divides by a non-bound. When no instance has a usable
+bound on both sides it returns NaN → the gate reads NaN → fail (an honest "not
+evaluable", never a spuriously-passing empty mean). Docstring records this.
+
+**New metric — `closed_within_10_nodes_fraction`.** Denominator = rows that
+reached a *proven* optimum (`status == OPTIMAL`); numerator = the subset that did
+so in ≤ 10 B&B nodes (`node_count == 0`, e.g. a root fathom / convex fast path,
+counts as the tightest close). A feasible-only (uncertified-tail) or errored row
+is not in the denominator — the metric measures how tightly the proofs close,
+not the proof rate.
+
+**Tests (all green, 6 new).** `discopt_benchmarks/tests/test_cert_instrumentation.py`:
+a fixture with known node counts (0, 7, 10, 153) → known fraction 0.75; the
+boundary (node_count == 10 closes, 11 does not, 0 is tightest); the
+denominator-is-proved-only guard (a 900-node *feasible* row does not dilute);
+empty/tail-only → 0.0; the `[suites.global50]` + `[gates.cert2]` config presence;
+and end-to-end `evaluate_phase_gate('cert2', …)` dispatch of the new metric
+(0.75 → passes ≥ 0.30) with the zero-slack correctness guard.
+
+**cert2 is informational until the R-flags flip default-on** (3 green nightlies,
+out of V2 scope): T2.3–T2.5 are not built and R4 ships default-OFF, so
+`root_gap_vs_baron` / `geomean_vs_baron` are not expected to pass on `main` yet.
+`zero_incorrect` is the live gate.
+
+---
+
+## 2. The measurement of record (Part 2) — flag-ON BARON re-run
+
+### 2.1 baseline (V1, flag-OFF) → V2 (flag-ON)
+
+| metric | V1 baseline (flag-OFF) | **V2 (flag-ON)** | Δ |
+|---|---:|---:|---:|
+| proved optimal | 42 | **43** | **+1** (st_e36) |
+| correct (`ok`) | 51 | 51 | — |
+| `GAP` (honest suboptimal) | 1 | 1 | — |
+| `n/a` (no oracle / no incumbent) | 9 | 9 | — |
+| **VIOLATIONS** | 0 | **0** | — (hard gate) |
+| uncertified tail (not proved-opt) | 19 | **18** | **−1** |
+| rows with a live dual bound | 51 / 61 | 51 / 61 | — (A3) |
+| total discopt wall | 1130.0 s (18.8 min) | **1094.8 s (18.2 min)** | −35 s (st_e36 faster) |
+
+Exactly **one** instance changed status — **st_e36** (feasible → optimal).
+Everything else is bit-for-bit the V1 baseline (same status, same verdict), as
+the single-instance thesis predicted (§2.4).
+
+### 2.2 Hard gates (all hold)
+
+- **0 correctness violations** — no run claimed a certified global at the wrong
+  value, returned an incumbent better than the proven global, or reported a dual
+  bound crossing its oracle. The A3 bound-vs-oracle check is live on **51/61**
+  rows and found **0 crossings**.
+- **No certification lost** — proved-optimal *increased* 42 → 43; the set of
+  baseline-proved instances is a subset of the flag-ON proved set (0 lost).
+- **`time_limit` contract holds** — cap = 60·1.1 + 5 = **71 s**; **0 instances
+  over cap** (slowest is bchoco08 at 66.7 s, a hard time_limit both ways).
+- **Bound-vs-oracle clean** — 0 dual bounds cross the oracle (checked above).
+
+### 2.3 The st_e36 row (the one instance that moves)
+
+In the full flag-ON run st_e36 is `optimal`, obj −246.0, bound −246.02, **153
+nodes, 15.8 s** (was `feasible`/TL, bound −304.49, 883 nodes, 60.1 s in the V1
+baseline). The cheap single-instance flag-OFF↔ON confirmation (same build, BARON
+skipped) reproduced the delta independently:
+
+| flag | status | bound | nodes | wall |
+|---|---|---:|---:|---:|
+| OFF | feasible (TL) | −304.49 | 883 | 60.2 s |
+| **ON** | **optimal** | **−246.0** | 153 | **17.3 s** |
+
+This is exactly the R4/#518 acceptance: branching the zero-spanning product
+factor `w = f1` (removed from the branch-deprioritized set only when the flag is
+on) un-pins the McCormick product bound. Relaxation math and feasible set are
+untouched — only branch *ordering* changes, always sound.
+
+### 2.4 Why one flag-ON full run is sufficient (no separate flag-OFF full run)
+
+R4 already proved flag-OFF is **byte-identical** to the V1 baseline on the
+41-instance cert panel (`check_cert_neutrality.py`: all `nodes X→X`, `|Δobj|=0`,
+NEUTRAL). The F5-style corpus scan (1610 MINLPLib `.nl` ≤ 200 KB) found the
+zero-spanning product-factor structure **only in st_e36**, so the flag tags an
+aux — and therefore changes behaviour — on **exactly one** instance. The V1
+baseline JSON is the flag-OFF full tally; the flag-ON run differs from it only at
+st_e36. The §2.3 single-instance flag-OFF↔ON delta confirms the difference is
+confined there.
+
+---
+
+## 3. What did NOT move — and why (honest scope)
+
+The uncertified tail shrank by exactly one (19 → 18: st_e36 left). The remaining
+**18** are unchanged vs the V1 baseline (same status, same bound):
+
+```
+4stufen  bchoco06  bchoco07  bchoco08  beuster  casctanks  contvar  hda
+heatexch_gen1  heatexch_gen2  heatexch_gen3  nvs05  nvs09  tanksize  tls2
+tspn08  tspn10  tspn12
+```
+
+The hard tail is unchanged by design:
+
+- **nvs05 / nvs09** — R4 tags **no** aux (bound identical ON/OFF). Their stall is
+  a different structure (nvs09: `log·log` product that can't be linearized;
+  nvs05: loose multilinear/signomial), not a zero-spanning product factor. R4's
+  lever is specific to the st_e36 class.
+- **hda** — no zero-spanning product factor to tag; its 23 omitted rows are a
+  `log(<general expr>)` / `x**expr` relaxation-coverage gap
+  (`_LIFTABLE_CALL_OUTER = {sqrt, exp}` deliberately excludes `log`). Filed as
+  **#517**; not forced into R4.
+- **tanksize, tls2** — reduction-responsive (T2.1/R1) but need R2's root fixpoint
+  loop, which is deferred (its generality arm passed but its value is broad
+  small-MINLP root closure, not the hard tail).
+- **casctanks, 4stufen, bchoco06/07/08, beuster, contvar, heatexch_gen1/2/3,
+  tspn08/10/12** — Class H (BARON-also-hard); this plan treats them as
+  beneficiaries, not gates. Unchanged.
+
+---
+
+## 4. Ledger of R-tasks (shipped / killed / deferred)
+
+| task | outcome | evidence |
+|---|---|---|
+| **R1** (T2.1 root-loop replay revisit) | **DONE → GO on R2** | full panel completes (19/20, loop-median 0.27 s); no P0 on 51 instances; generality arm 9/29=31%≥20% (cert-gap-plan §14 T2.1-revisit) |
+| **R2** (root fixpoint loop + reduce_node) | **DEFERRED** | unlocked by R1 but broad / non-tail; value is small-MINLP root closure, not the hard tail — not built in this arc |
+| **R3a** (responsiveness fingerprint) | **DONE — verdict BUILD R3b** | overlap 1/6 < 4 → BUILD; but the fingerprint was measured on the factorable-only reform (a methodology flaw R3b later caught); #515 |
+| **R3b** (responsiveness-aware branching) | **KILLED** (its own entry experiment) | force-branching the "responsive" var made it *worse* (nvs05 821→853, nvs09 bound worsened, tls2 unchanged); the branched model is 15-var integer-bilinear where R3a's columns don't exist → relaxation-limited, defer to R4; #516 |
+| **R4** (zero-spanning-factor lifting) | **SHIPPED (flagged, default-OFF)** | st_e36 feasible/TL → optimal (153 nodes, ~17 s); differential-bound + 20 000-pt feasible sampling + flag-OFF byte-identical all green; #518 |
+| **R5** (zerohalf pre-crossover) | **NOT BUILT** | optional / opportunistic; graphpart cut geometry (cert-gap-plan §7) — out of this arc |
+| **F5 / F6** | **KILLED (prior)** | envelope math / node-NLP warm-start are not the tail's levers (perf-followup-results-2026-07-06 §5) |
+| **V2** (this doc) | **DONE** | gate wiring + flag-ON tally: proved-optimal 42 → 43 |
+
+**Follow-ups filed:** **#517** (hda / `log`-argument relaxation-coverage gap);
+R2 remains available if the small-MINLP root-closure value is prioritized later.
+
+**Default flip (R4):** NOT in this arc — `DISCOPT_LIFT_ZERO_SPANNING_FACTORS`
+stays OFF until 3 consecutive green nightlies per §0.1.


### PR DESCRIPTION
## V2 — gate wiring + the measurement of record

Executes **task V2** of `docs/dev/uncertified-tail-plan-2026-07-06.md` §3 (and
cert-gap-plan §11 / §14 T2.6 items 1–2). Two parts.

### Part 1 — gate wiring (code)

- **`[suites.global50]`** added to `benchmarks.toml` — the certification panel
  every `[gates.cert*]` referenced but had no suite table for (the §11 recon
  flag). Points at the vendored `config/baron_global50.txt` (50 instances;
  resolves to 49 locally / 50 with `--fetch` — st_miqp5 is a binary `.nl`
  discopt can't parse).
- **`[gates.cert2]`** added per §11 with the recorded corrections:
  | criterion | metric | bound |
  |---|---|---|
  | `zero_incorrect` | `incorrect_count` | max 0 (zero-slack, live) |
  | `root_gap_vs_baron` | `root_gap_ratio_vs_baron` | max 1.3 (from A3's live `SolveResult.bound`) |
  | `geomean_vs_baron` | `geomean_ratio_vs_baron` | max 2.5 (existing metric name) |
  | `tree_closed_fraction` | `closed_within_10_nodes_fraction` | min 0.30 (new) |
- **New metric** `closed_within_10_nodes_fraction` + dispatch in `metrics.py`;
  `root_gap_ratio` docstring/guards sharpened for the **reference-bound caveat**
  (null-`root_gap` BARON rows excluded both sides; `>1e-10` denominator guard;
  non-finite discopt gap skipped; NaN → gate fails honestly, never a
  spuriously-passing empty mean).
- **cert2 is informational** until R2/R3b/R4 flip default-on (3 green nightlies,
  out of V2 scope). `zero_incorrect` is the live gate.

### Part 2 — measurement of record (flag-ON BARON re-run)

`scripts/global_opt_baron_vs_discopt.py --time-limit 60 --out-dir reports`, 61
vendored MINLPLib `.nl`, **release** maturin build + **release POUNCE**
(4.7 MB `_pounce.abi3.so`), GAMS-53 full-license BARON, with
`DISCOPT_LIFT_ZERO_SPANNING_FACTORS=1` in the environment.

| metric | V1 baseline (flag-OFF) | **V2 (flag-ON)** | Δ |
|---|---:|---:|---:|
| proved optimal | 42 | **43** | **+1** (st_e36) |
| correct (`ok`) | 51 | 51 | — |
| **VIOLATIONS** | 0 | **0** | — |
| uncertified tail | 19 | **18** | −1 |
| total discopt wall | 18.8 min | 18.2 min | −35 s |

**st_e36** is the one instance that moves: feasible/TL → **optimal** (883→153
nodes, 60.1→15.8 s) — exactly the R4/#518 acceptance (branch the zero-spanning
product factor; relaxation math untouched, only branch ordering changes).

**Four hard gates — all hold:** 0 correctness violations · 0 certification lost
(proved set strictly grows) · time-limit contract (cap 71 s, 0 over; slowest
bchoco08 66.7 s) · bound-vs-oracle clean (0 crossings on 51/61 live-bound rows).

**One flag-ON full run suffices** (no separate flag-OFF full run): R4 proved
flag-OFF byte-identical to baseline on the 41-instance cert panel, and the
corpus scan found the zero-spanning structure **only in st_e36**, so flag-ON
changes exactly one instance — independently confirmed by a single-instance
flag-OFF↔ON delta.

**Honest scope:** R4 is the **only** shipped tail win. R3b killed (relaxation-
limited, not selection-limited), R2 deferred, R5 not built; the hard no-bound
tail (nvs05, nvs09, hda, tanksize, casctanks, …) is unchanged — deeper lifting /
relaxation coverage (#517), out of scope. The plan's original ≥46 assumed R2+R3b
landed; the honest target is 42 → 43.

### Tests run

- `discopt_benchmarks/tests/test_cert_instrumentation.py` — **16/16 green**
  (6 new: metric fn known-count fixture → 0.75, boundary, denominator-is-proved-
  only, empty/tail → 0.0, `[suites.global50]`+`[gates.cert2]` config presence,
  `evaluate_phase_gate('cert2', …)` dispatch). `ruff check` clean on the touched
  test file; the `.toml` parses and the gate/suite resolve.
- **No `python/discopt/` or Rust changes** — Part 1 is confined to the benchmark
  layer (`discopt_benchmarks/`) + docs, so `mypy python/discopt/`, the
  adversarial suite, and `cargo test -p discopt-core` are unaffected by this PR.

### Docs / artifacts

- New results appendix `docs/dev/uncertified-tail-plan-results-2026-07-06.md`
  (before/after table, gate-wiring summary, hard-gate confirmation, unchanged-
  tail list, R-task ledger). Tail plan §3 V2 status → **DONE**.
- BARON report json/md persisted to `reports/` (gitignored per repo convention;
  referenced by path from the appendix).

Do **not** merge — R4's flag stays default-OFF until 3 green nightlies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
