### PR TITLE
perf(relaxation): TD-A — lift loose-product factors (nvs05/nvs09, flagged)

### DIFF
--- a/docs/dev/uncertified-tail-plan-results-2026-07-06.md
+++ b/docs/dev/uncertified-tail-plan-results-2026-07-06.md
@@ -300,3 +300,112 @@ to the true blockers (reform gating on large models + the reform's root-infeasib
 on hda). The `x**expr` (variable-exponent) rows are likewise out of scope: hda's
 `4^(0.0001+0.333·x0)` needs the `exp(expr·log x)` signomial path with `x_lb>0`, a
 separate treatment.
+## 6. TD-A — deeper-tail loose-product lift (nvs05/nvs09) · **BUILD (nvs09), KILL (nvs05)**
+
+**Track:** deeper-tail follow-on to §3 ("unchanged tail"): extend the factorable
+lift to the nvs05/nvs09 loose-product structure R4 does not tag. Bound-changing
+regime (§0.1). Flag `DISCOPT_LIFT_LOOSE_PRODUCTS`, **default OFF**.
+
+### Entry experiment (diagnose → hand-lift → measure) — the kill gate
+
+**Diagnosed structure (measurement beat the plan's characterisation):**
+
+- **nvs09** (all-integer, x0..x9 ∈ {3..9}): the objective is a *separable* sum of
+  **squared univariate logs** minus a signomial:
+  `Σ_i [ log(x_i−2)² + log(10−x_i)² ] − (∏_i x_i)^0.2`. It is **not** a "log·log
+  product" in the multivariate sense — each `log(·)²` is `pow(log(·), 2)`, an
+  *integer power of a univariate call*. `distribute_products` expands it to the
+  `log·log` product the MILP linearizer cannot decompose ("Cannot decompose
+  product: log·log"), so the whole objective is **dropped** → feasibility
+  objective, root bound from the fallback NLP/αBB path only (**69.0 %** root gap).
+- **nvs05** (welded-beam): a rational + sqrt signomial. Its objective
+  `1.10471·x0²·x1 + 0.04811·x2·x3·(14+x1)` is a monomial + trilinear the RLT hull
+  already relaxes; all constraints are already lifted (free auxes x4..x7 hold the
+  ratios/sqrts). No dropped/loose product remains in the objective.
+
+**Hand-lift + measurement (root bound; oracle nvs05 5.471, nvs09 −43.134):**
+
+| instance | native root bound | hand-lifted root bound | root gap native → lifted | rel. gap reduction | verdict |
+|---|---:|---:|---:|---:|---|
+| **nvs09** | −72.90 (69.0 %) | **−54.83 (27.1 %)** | 69.0 % → 27.1 % | **60.7 %** | **PASS** (≥ 25 %) |
+| **nvs05** | 0.674 (87.7 %) | 0.674 (unchanged) | — | **0 %** | **KILL** (criterion #2) |
+
+- **nvs09 hand-lift:** introduce `u_i == log(x_i−2)`, `v_i == log(10−x_i)` as
+  bounded auxes (`u,v ∈ [0, log 7]` on x ∈ [3,9] — strictly positive log args, no
+  sign change, so the nvs09 kill clause does *not* fire) and rewrite each squared
+  log as the exact univariate square `u²`/`v²`. Root bound −72.90 → −54.83, a
+  **60.7 % relative** gap reduction — well over the 25 % bar. Sound: −54.83 ≤
+  oracle −43.13 (no crossing).
+- **nvs05 KILL (criterion #2 — "already exactly relaxed; gap is elsewhere"):**
+  the *objective-only* relaxation over the native box equals **0.674 and is
+  certified optimal** — i.e. `min x0²·x1 + …` over the box is exactly 0.674,
+  achieved at the corner x0=x1=0.01. The objective envelope is not loose; the
+  87.7 % root gap is entirely that the **constraints do not push x0,x1,x2,x3 up
+  from the box corner at the root** (the true optimum is x0=0.68, x1=2.79). That
+  is a **bound-tightening / branch-and-reduce (OBBT)** problem — exactly R1's
+  "nvs05 = 32.5 % reduction-responsive" finding — **not** a lifting problem. No
+  product-factor lift moves it. Recorded and STOPPED for nvs05.
+
+### The general structure (not instance-keyed)
+
+The lift keys on **`g(x)**n`** where `g` is a *single-argument transcendental*
+(`log`/`log2`/`log10`/`exp`/`sqrt`/`sin`/`cos`/`tan`/`atan`/`tanh`/`log1p`) whose
+base is **not a bare variable** and `n` is a **positive integer ≥ 2**. It lifts
+`t == g(x)` (a bounded aux via the existing `_Lifter.expression`) and rewrites the
+node as the monomial `t**n` — relaxed exactly (even `n`, `relax_square`) or
+3-regime (odd `n`) by the existing monomial path. **Reuses the existing hull
+machinery; rebuilds nothing** (relaxation-catalog do-not-rebuild rule honoured).
+
+**Out-of-panel witnesses (corpus scan, 1226 `.nl` ≤ 150 KB, structurally
+distinct):** the same `pow(call, int≥2)` structure appears in **mathopt5_1**
+(`sin(x)**3`), **mathopt5_6** (`sin(x)**2`), **mathopt3** (`sin(x)**2`) — the
+lift fires on all three (`t == sin(x)`), confirming it is not log-specific. (Only
+nvs09 shows a *large* bound move; mathopt5_6 has an additional unrelated
+`sqrt(abs(x))` block that still drops its bound — that is a separate coverage gap,
+not a lift failure.)
+
+### Implementation (flagged, default OFF)
+
+`python/discopt/_jax/factorable_reform.py`:
+- `_lift_loose_products_enabled()` — env flag `DISCOPT_LIFT_LOOSE_PRODUCTS`
+  (default `"0"`).
+- `_liftable_call_power_base()` — the structural matcher (`call ** int≥2`,
+  non-atomic base).
+- `_prelift_call_powers()` — a pre-pass (runs *before* `distribute_products` so
+  the `**` node is intact) that lifts `g(x)**n → t**n`; a flag-gated identity
+  no-op when OFF.
+- `_scan_for_liftable_call_power()` + one gated line in
+  `_has_factorable_work_inner()` so the reform fires on instances whose *only*
+  liftable term is this structure.
+- Wired as the first step of both the constraint and objective reform paths.
+
+### Gates (BOUND-CHANGING, §0.1) — all green
+
+- **Differential bound (nvs09):** flag ON root bound (−54.83) ≥ OFF (−72.90) AND
+  ≤ oracle (−43.13); a ≥ 25 % relative reduction asserted (60.7 %).
+  `test_tda_nvs09_root_bound_tightens`.
+- **Feasible-point sampling (2000 pts):** the lift `t == g(x)` is an exact
+  identity — the lifted objective at `(x, t=g(x))` equals the original at `x`
+  (max err < 1e-6) and every aux equality holds (residual < 1e-6); cuts no
+  feasible point. `test_tda_lift_is_exact_identity_feasible_sampling`.
+- **Flag-OFF byte-identical:** `check_cert_neutrality.py` **NEUTRAL** — all 41
+  cert-panel instances `nodes X→X`, `|Δobj| = 0` (the new code is an identity
+  no-op when the flag is off).
+- **Suite:** `pytest -m smoke` 614 passed / 14 skipped; adversarial slow 10
+  passed; `test_factorable_reform.py` 65 (+5 TD-A) passed; ruff check + format
+  clean; mypy clean (numpy-stub env mismatch excepted). No Rust touched.
+
+### Acceptance
+
+**nvs09 root gap 69.0 % → 27.1 % (60.7 % relative reduction) with the flag ON —
+meets the ≥ 25 % bar.** At 60 s nvs09 is still `feasible` (per-node cost of the
+`(∏x_i)^0.2` 10-way signomial is the remaining limiter, 7 nodes) — the win is a
+*materially tighter dual bound*, not (yet) certification, which the acceptance
+allows ("a materially tighter bound is the bar; certifying is a bonus"). **nvs05
+is honestly KILLED** — its gap is OBBT/branch-and-reduce (R2 territory), not a
+lifting problem. Flag stays OFF pending 3 green nightlies per §0.1.
+
+**Ledger addition:** **TD-A** (loose-product / call-power lift) — **BUILD
+(nvs09, flagged default-OFF) / KILL (nvs05)**; nvs09 root gap 69.0 % → 27.1 %;
+witnesses mathopt5_1/5_6/mathopt3; PR — see title
+`perf(relaxation): TD-A — lift loose-product factors (nvs05/nvs09, flagged)`.

--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -93,6 +93,79 @@ def _lift_zero_spanning_factors_enabled() -> bool:
     return os.environ.get("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", "0") == "1"
 
 
+def _lift_loose_products_enabled() -> bool:
+    """TD-A feature flag (``DISCOPT_LIFT_LOOSE_PRODUCTS``, default OFF).
+
+    Extends the factorable lift to an integer power of a *non-atomic univariate
+    function call* — ``g(x)**n`` with ``g`` a transcendental (``log``, ``sin``,
+    …) whose argument is not a bare variable and ``n`` a positive integer ``≥ 2``.
+
+    The MILP objective/constraint linearizer bounds a power only when its base is
+    a bare variable index (the monomial path) or when the power is a *fractional*
+    power of a lifted composite (``_lift_objective_atoms``). An *integer* power of
+    a call falls through both: ``distribute_products`` expands ``g(x)**2`` into the
+    product ``g(x)·g(x)``, which ``_decompose_product`` cannot decompose (both
+    factors are transcendental), so the whole term is dropped and the model loses
+    its dual bound (nvs09: ``Cannot decompose product: log·log`` → feasibility
+    objective, 69 % root gap; mathopt5_6: ``sin·sin`` → no bound at all).
+
+    The lift introduces ``t == g(x)`` (a bounded aux via :meth:`_Lifter.expression`
+    — ``t`` inherits ``g``'s FBBT interval, e.g. ``log(x-2) ∈ [0, log 7]`` for
+    ``x ∈ [3, 9]``) and rewrites the node as the *monomial* ``t**n``, which the
+    existing monomial-secant / even-power envelope relaxes exactly (even ``n``) or
+    3-regime (odd ``n``). This is an exact identity substitution (``t == g(x)``),
+    so it cuts no feasible point; it only replaces a *dropped* term with a
+    relaxable one. Default OFF keeps the reform byte-identical.
+
+    Entry-experiment measurement (nvs09 hand-lift): root bound −72.90 → −54.83
+    (root gap 69.0 % → 27.1 %, a 60.7 % relative reduction, ≥ 25 % bar). nvs05 was
+    killed separately — its objective monomial is already exactly relaxed (the
+    box-minimum 0.674 equals the root bound), so its gap is constraint-driven box
+    reduction (OBBT/branch-and-reduce), not a lifting problem. See
+    ``docs/dev/uncertified-tail-plan-results-2026-07-06.md`` §TD-A.
+    """
+    import os
+
+    return os.environ.get("DISCOPT_LIFT_LOOSE_PRODUCTS", "0") == "1"
+
+
+# Transcendental univariate calls whose integer power TD-A lifts. Restricted to
+# single-argument functions with a monotone/bounded envelope so ``t == g(x)``
+# always yields a finite aux interval; excludes ``abs``/``sign`` (non-smooth) and
+# n-ary ``min``/``max``/``prod``/``norm`` (not univariate).
+_LIFTABLE_CALL_POWER_FUNCS = frozenset(
+    {"log", "log2", "log10", "exp", "sqrt", "sin", "cos", "tan", "atan", "tanh", "log1p"}
+)
+
+
+def _liftable_call_power_base(expr: Expression, model: Model) -> tuple[FunctionCall, int] | None:
+    """If *expr* is ``g(x)**n`` with ``g`` a single-argument transcendental over a
+    *non-atomic* argument (not a bare variable) and ``n`` a positive integer
+    ``≥ 2``, return ``(g_call, n)``; otherwise ``None``.
+
+    A bare-variable base (``x**n``) is already the monomial path and must not be
+    lifted; a fractional power is handled by ``_lift_objective_atoms`` directly.
+    """
+    if not isinstance(expr, BinaryOp) or expr.op != "**":
+        return None
+    if not isinstance(expr.right, Constant):
+        return None
+    exp_val = float(expr.right.value)
+    n = int(exp_val)
+    if exp_val != n or n < 2:
+        return None
+    base = expr.left
+    if not isinstance(base, FunctionCall):
+        return None
+    if base.func_name not in _LIFTABLE_CALL_POWER_FUNCS or len(base.args) != 1:
+        return None
+    # A univariate call over a bare variable (``sin(x)**2``) is still worth
+    # lifting: the linearizer drops it exactly the same way (the base is a call,
+    # not a variable index). Only require that the call is not itself trivially a
+    # constant.
+    return base, n
+
+
 # The factorable-reform walkers (``_find_clearable_denominator``, ``_lift_expr``,
 # the ``has_factorable_work`` scanners, ...) recurse one Python frame per
 # expression node.  ``from_nl`` rebuilds a sum/product of N terms as a left-deep
@@ -501,6 +574,60 @@ def _prelift_blowup_products(expr: Expression, model: Model, lifter: "_Lifter") 
     return expr
 
 
+def _prelift_call_powers(expr: Expression, model: Model, lifter: "_Lifter") -> Expression:
+    """TD-A pre-pass: lift an integer power of a univariate call ``g(x)**n`` (n >= 2)
+    to the monomial ``t**n`` with ``t == g(x)`` a bounded aux, *before*
+    ``distribute_products`` expands ``g(x)**2`` into the ``g(x)·g(x)`` product the
+    downstream ``_decompose_product`` cannot linearize (so the term is dropped and
+    the model loses its dual bound — nvs09 ``log·log``, mathopt5_6 ``sin·sin``).
+
+    Runs bottom-up so a call whose argument itself contains a power-of-call is
+    lifted inside out. Identity-preserving when nothing matches (returns the same
+    object), so a model without this structure is byte-for-byte unchanged; the
+    whole pass is a no-op unless ``DISCOPT_LIFT_LOOSE_PRODUCTS`` is set (the caller
+    gates it, but the walker also short-circuits on the flag for safety).
+
+    Sound: ``t == g(x)`` is an exact identity substitution over ``g``'s FBBT box,
+    so no feasible point is cut; the rewrite only replaces a *dropped* transcen-
+    dental power with a relaxable monomial.
+    """
+    if not _lift_loose_products_enabled():
+        return expr
+    if isinstance(expr, BinaryOp):
+        call_power = _liftable_call_power_base(expr, model)
+        if call_power is not None:
+            g_call, n = call_power
+            # Recurse into the call argument first (it may hide another such power).
+            inner_arg = _prelift_call_powers(g_call.args[0], model, lifter)
+            rebuilt_call = (
+                g_call if inner_arg is g_call.args[0] else FunctionCall(g_call.func_name, inner_arg)
+            )
+            t = lifter.expression(rebuilt_call)
+            if isinstance(t, Variable):
+                return BinaryOp("**", t, Constant(float(n)))
+            # Aux could not be bounded (unbounded argument): leave as-is (the term
+            # stays dropped exactly as before — never unsound).
+            if rebuilt_call is not g_call:
+                return BinaryOp("**", rebuilt_call, expr.right)
+            return expr
+        left = _prelift_call_powers(expr.left, model, lifter)
+        right = _prelift_call_powers(expr.right, model, lifter)
+        if left is expr.left and right is expr.right:
+            return expr
+        return BinaryOp(expr.op, left, right)
+    if isinstance(expr, UnaryOp):
+        operand = _prelift_call_powers(expr.operand, model, lifter)
+        if operand is expr.operand:
+            return expr
+        return UnaryOp(expr.op, operand)
+    if isinstance(expr, FunctionCall):
+        new_args = [_prelift_call_powers(a, model, lifter) for a in expr.args]
+        if all(na is oa for na, oa in zip(new_args, expr.args)):
+            return expr
+        return FunctionCall(expr.func_name, *new_args)
+    return expr
+
+
 # Univariate transcendentals whose argument may be lifted into an aux variable.
 # ``sqrt``/``exp`` are domain-safe to relax over a finite box once their argument
 # is a single variable (sqrt needs ``arg >= 0``, supplied by the lb floor below;
@@ -864,6 +991,10 @@ def _has_factorable_work_inner(model: Model) -> bool:
     def scan(expr: Expression) -> bool:
         if _find_clearable_denominator(expr, model) is not None:
             return True
+        # TD-A: scan for ``g(x)**n`` on the *pre-distribute* tree — distribution
+        # would collapse it into the ``g·g`` product that hides the structure.
+        if _lift_loose_products_enabled() and _scan_for_liftable_call_power(expr, model):
+            return True
         dist = distribute_products(expr)
         if _scan_for_mixed_product(dist, model):
             return True
@@ -931,6 +1062,24 @@ def _scan_for_liftable_call(expr: Expression, model: Model) -> bool:
         )
     if isinstance(expr, UnaryOp):
         return _scan_for_liftable_call(expr.operand, model)
+    return False
+
+
+def _scan_for_liftable_call_power(expr: Expression, model: Model) -> bool:
+    """True if *expr* contains an integer power ``g(x)**n`` (n >= 2) of a univariate
+    transcendental call — the TD-A lift target. Scans the *pre-distribute* tree
+    (``distribute_products`` would collapse ``g(x)**2`` into ``g·g`` and hide it).
+    """
+    if _liftable_call_power_base(expr, model) is not None:
+        return True
+    if isinstance(expr, BinaryOp):
+        return _scan_for_liftable_call_power(expr.left, model) or _scan_for_liftable_call_power(
+            expr.right, model
+        )
+    if isinstance(expr, UnaryOp):
+        return _scan_for_liftable_call_power(expr.operand, model)
+    if isinstance(expr, FunctionCall):
+        return any(_scan_for_liftable_call_power(a, model) for a in expr.args)
     return False
 
 
@@ -1454,6 +1603,7 @@ def _factorable_reformulate_inner(model: Model, *, clear_only: bool = False) -> 
                 else:
                     rebuilt.append(Constraint(distribute_products(body), sense, c.rhs, c.name))
                 continue
+            body = _prelift_call_powers(body, new_model, lifter)
             body = _prelift_blowup_products(body, new_model, lifter)
             body = distribute_products(body)
             body = _lift_objective_atoms(body, new_model, lifter)
@@ -1467,7 +1617,8 @@ def _factorable_reformulate_inner(model: Model, *, clear_only: bool = False) -> 
         # power of a polynomial base); division clearing is meaningless for an
         # objective so only the lifts apply.
         if not clear_only and new_model._objective is not None:
-            obj_expr = _prelift_blowup_products(new_model._objective.expression, new_model, lifter)
+            obj_expr = _prelift_call_powers(new_model._objective.expression, new_model, lifter)
+            obj_expr = _prelift_blowup_products(obj_expr, new_model, lifter)
             obj_expr = distribute_products(obj_expr)
             obj_expr = _lift_objective_atoms(obj_expr, new_model, lifter)
             lifted_obj = _lift_expr(obj_expr, new_model, lifter)

--- a/python/tests/test_factorable_reform.py
+++ b/python/tests/test_factorable_reform.py
@@ -31,6 +31,7 @@ from discopt._jax.term_classifier import classify_nonlinear_terms
 from discopt.modeling.core import FunctionCall, Variable
 
 _DATA = Path(__file__).parent / "data" / "minlplib"
+_NL_DATA = Path(__file__).parent / "data" / "minlplib_nl"
 
 
 def _aux_names(model):
@@ -916,3 +917,201 @@ def test_nvs01_certifies_with_sound_bound():
     assert r.objective == pytest.approx(12.4697, abs=1e-2)
     assert r.bound is not None
     assert r.bound <= r.objective + 1e-4  # sound dual bound
+
+
+# ---------------------------------------------------------------------------
+# TD-A: lift an integer power of a univariate call ``g(x)**n`` to ``t**n``
+# (t == g(x)), flag ``DISCOPT_LIFT_LOOSE_PRODUCTS`` (default OFF).
+# ---------------------------------------------------------------------------
+
+
+def _squared_log_model():
+    """An nvs09-shaped probe (not the named instance): a separable sum of squared
+    logs whose ``distribute_products`` form is the ``log·log`` product the MILP
+    linearizer drops. Two integer vars keep it small and certifiable."""
+    import math
+
+    m = dm.Model("sqlog")
+    xs = [m.integer(f"x{i}", lb=3, ub=9) for i in range(2)]
+    obj = 0
+    for x in xs:
+        obj = obj + dm.log(x - 2) ** 2 + dm.log(10 - x) ** 2
+    m.minimize(obj)
+    return m, xs, math
+
+
+def test_tda_flag_off_leaves_call_power_untouched(monkeypatch):
+    """Flag OFF: ``g(x)**n`` is NOT lifted (reform byte-identical to baseline)."""
+    monkeypatch.delenv("DISCOPT_LIFT_LOOSE_PRODUCTS", raising=False)
+    m, _xs, _ = _squared_log_model()
+    # The squared-log alone is not factorable work with the flag off.
+    assert not has_factorable_work(m)
+
+
+def test_tda_flag_on_lifts_call_power(monkeypatch):
+    """Flag ON: each ``log(·)**2`` is lifted to a ``t**2`` monomial with an aux
+    ``t == log(·)`` (bounded by the log's FBBT interval)."""
+    monkeypatch.setenv("DISCOPT_LIFT_LOOSE_PRODUCTS", "1")
+    m, _xs, _ = _squared_log_model()
+    assert has_factorable_work(m)
+    m2 = factorable_reformulate(m)
+    assert m2 is not m
+    auxes = _aux_names(m2)
+    # 2 vars * 2 logs each -> 4 lifted univariate-call auxes.
+    assert len(auxes) == 4, f"expected 4 call auxes, got {auxes}"
+
+    # Every aux is a bounded continuous var (t == log(arg)) with a finite box.
+    import numpy as np
+
+    for v in m2._variables:
+        if v.name in auxes:
+            lo, hi = float(np.min(v.lb)), float(np.max(v.ub))
+            assert np.isfinite(lo) and np.isfinite(hi)
+            assert lo <= hi
+
+
+def test_tda_lift_is_exact_identity_feasible_sampling(monkeypatch):
+    """Feasible-point sampling: the lift ``t == g(x)`` cuts no feasible point.
+
+    For random x in the box, the lifted objective evaluated at (x, t = g(x))
+    equals the original objective at x, and every aux-defining equality holds —
+    i.e. the reformulation is an exact identity substitution, never a relaxation
+    that could exclude a feasible point.
+    """
+    import numpy as np
+    from discopt._jax.dag_compiler import compile_expression
+
+    monkeypatch.setenv("DISCOPT_LIFT_LOOSE_PRODUCTS", "1")
+    m, _xs, math = _squared_log_model()
+    m2 = factorable_reformulate(m)
+
+    f_orig = compile_expression(m._objective.expression, m)
+    f_lift = compile_expression(m2._objective.expression, m2)
+    # aux-defining equalities: body == 0 for each ``t - g(x)``.
+    aux_bodies = [
+        (c.body, compile_expression(c.body, m2))
+        for c in m2._constraints
+        if any(vn in _aux_names(m2) for vn in _referenced_names(c.body))
+    ]
+
+    orig_vars = [v.name for v in m._variables]
+    lift_vars = [v.name for v in m2._variables]
+    aux_names = set(_aux_names(m2))
+
+    rng = np.random.default_rng(0)
+    max_obj_err = 0.0
+    max_aux_resid = 0.0
+    for _ in range(2000):
+        # sample the original (non-aux) variables over their integer box
+        xvals = {vn: float(rng.integers(3, 10)) for vn in orig_vars}
+        # derive the aux values t = log(arg) so the point is feasible in m2
+        full = dict(xvals)
+        # solve aux defs in order (they are t - log(arg) = 0, arg over base vars)
+        for v in m2._variables:
+            if v.name in aux_names:
+                full.setdefault(v.name, 0.0)
+        # fixpoint once: evaluate each aux body to recover t (t appears linearly)
+        for body, _fn in aux_bodies:
+            # body = t - g(x); set t = g(x)
+            t_name, g_val = _solve_aux_body(body, full, m2)
+            if t_name is not None:
+                full[t_name] = g_val
+        x_orig = np.array([xvals[vn] for vn in orig_vars], dtype=float)
+        x_lift = np.array([full[vn] for vn in lift_vars], dtype=float)
+        o0 = float(f_orig(x_orig))
+        o1 = float(f_lift(x_lift))
+        max_obj_err = max(max_obj_err, abs(o0 - o1))
+        for body, fn in aux_bodies:
+            max_aux_resid = max(max_aux_resid, abs(float(fn(x_lift))))
+    assert max_obj_err < 1e-6, f"lifted objective diverged from original: {max_obj_err}"
+    assert max_aux_resid < 1e-6, f"aux equality violated at t=g(x): {max_aux_resid}"
+
+
+@pytest.mark.correctness
+@pytest.mark.slow
+def test_tda_nvs09_root_bound_tightens(monkeypatch):
+    """nvs09: the flag ON tightens the root bound >= 25 % relative vs OFF, and the
+    ON bound never crosses the oracle (-43.134, min sense) — the TD-A acceptance.
+    """
+    nl = _NL_DATA / "nvs09.nl"
+    if not nl.exists():
+        pytest.skip("nvs09.nl not vendored")
+    oracle = -43.1343369200
+
+    monkeypatch.setenv("DISCOPT_LIFT_LOOSE_PRODUCTS", "1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r_on = dm.from_nl(str(nl)).solve(time_limit=8)
+    monkeypatch.setenv("DISCOPT_LIFT_LOOSE_PRODUCTS", "0")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r_off = dm.from_nl(str(nl)).solve(time_limit=8)
+
+    assert r_on.root_bound is not None and r_off.root_bound is not None
+    # Soundness: neither root bound crosses the oracle (min: bound <= optimum).
+    assert r_off.root_bound <= oracle + 1e-4
+    assert r_on.root_bound <= oracle + 1e-4
+    # ON is at least as tight (higher) as OFF.
+    assert r_on.root_bound >= r_off.root_bound - 1e-6
+    gap_off = abs(oracle - r_off.root_bound)
+    gap_on = abs(oracle - r_on.root_bound)
+    reduction = (gap_off - gap_on) / gap_off
+    assert reduction >= 0.25, (
+        f"flag ON must tighten nvs09 root gap >= 25 % "
+        f"(OFF {r_off.root_bound:.2f} -> ON {r_on.root_bound:.2f}, reduction {reduction:.1%})"
+    )
+
+
+def test_tda_generalizes_to_sin_power(monkeypatch):
+    """The lift keys on the *structure* (call ** int), not a named function: a
+    ``sin(x)**2`` term is lifted the same way ``log(x-2)**2`` is (mathopt witness
+    family). Demonstrates the rule is not log-specific."""
+    monkeypatch.setenv("DISCOPT_LIFT_LOOSE_PRODUCTS", "1")
+    m = dm.Model("sinpow")
+    x = m.continuous("x", lb=-1.0, ub=2.0)
+    m.minimize(dm.sin(x) ** 2 + 0.1 * x)
+    assert has_factorable_work(m)
+    m2 = factorable_reformulate(m)
+    assert m2 is not m
+    assert len(_aux_names(m2)) == 1, "sin(x)**2 must lift one aux t == sin(x)"
+
+
+def _referenced_names(expr):
+    names = set()
+
+    def walk(e):
+        if isinstance(e, Variable):
+            names.add(e.name)
+        for a in ("left", "right", "operand"):
+            if hasattr(e, a) and getattr(e, a) is not None:
+                walk(getattr(e, a))
+        if hasattr(e, "args") and getattr(e, "args", None):
+            try:
+                for k in e.args:
+                    walk(k)
+            except TypeError:
+                pass
+
+    walk(expr)
+    return names
+
+
+def _solve_aux_body(body, values, model):
+    """Given an aux-defining body ``t - g(x) == 0`` and a dict of base-var values,
+    return (t_name, g_value) by evaluating g at the base values."""
+    import numpy as np
+    from discopt._jax.dag_compiler import compile_expression
+    from discopt.modeling.core import BinaryOp
+
+    # body is ``t - g(x)`` (a subtraction with t the aux on the left leaf).
+    if not (isinstance(body, BinaryOp) and body.op == "-"):
+        return None, None
+    left = body.left
+    if not isinstance(left, Variable):
+        return None, None
+    t_name = left.name
+    g_expr = body.right
+    fn = compile_expression(g_expr, model)
+    lift_vars = [v.name for v in model._variables]
+    xv = np.array([values.get(vn, 0.0) for vn in lift_vars], dtype=float)
+    return t_name, float(fn(xv))


### PR DESCRIPTION
## TD-A — lift loose-product factors (nvs05/nvs09), flagged default-OFF

Deeper-tail follow-on to the uncertified-tail plan §3 ("unchanged tail"):
extend the factorable lift to the nvs05/nvs09 loose-product structure that R4's
zero-spanning-factor lift does not tag. **Bound-changing** regime; flag
`DISCOPT_LIFT_LOOSE_PRODUCTS`, **default OFF**. One task, one PR. **Do not merge**
(flag stays OFF pending 3 green nightlies per §0.1).

### Entry experiment — diagnosed structure and hand-lift (the kill gate)

The plan's characterisation was refined by measurement (measurement beats plan):

- **nvs09** (all-integer) is **not** a "log·log product". Its objective is a
  *separable* sum of **squared univariate logs** minus a signomial:
  `Σ_i [ log(x_i−2)² + log(10−x_i)² ] − (∏_i x_i)^0.2`. Each `log(·)²` is
  `pow(log(·), 2)`; `distribute_products` expands it to the `log·log` product the
  MILP linearizer cannot decompose ("Cannot decompose product: log·log"), so the
  **objective is dropped** → feasibility only, **69.0 %** root gap.
- **nvs05** (welded-beam) is a rational + sqrt signomial whose objective monomial
  is already relaxed and whose constraints already lift (free auxes x4..x7).

**Hand-lift root-bound measurement (oracle: nvs05 5.471, nvs09 −43.134):**

| instance | native root bound | lifted root bound | root gap | rel. reduction | verdict |
|---|---:|---:|---:|---:|---|
| **nvs09** | −72.90 (69.0 %) | **−54.83 (27.1 %)** | 69.0 → 27.1 % | **60.7 %** | **BUILD** (≥ 25 %) |
| **nvs05** | 0.674 (87.7 %) | 0.674 | — | **0 %** | **KILL** |

- **nvs09:** lift `u == log(x−2)`, `v == log(10−x)` (bounded, `∈ [0, log 7]`, no
  sign change), rewrite the squared logs as exact univariate squares `u²`/`v²`.
  Root bound −72.90 → −54.83 — a **60.7 % relative** gap reduction (≥ 25 % bar).
  Sound: −54.83 ≤ oracle −43.13.
- **nvs05 KILL (criterion #2):** the *objective-only* relaxation over the native
  box equals **0.674 and is certified optimal** — the monomial envelope is not
  loose. The 87.7 % gap is that the constraints do not push x0,x1 up from the box
  corner at the root (true optimum x0=0.68, x1=2.79). That is an
  **OBBT/branch-and-reduce** problem (R1: nvs05 = 32.5 % reduction-responsive),
  **not** a lifting problem. Recorded and stopped.

### The general structure (not instance-keyed)

Keys on **`g(x)**n`** where `g` is a single-argument transcendental
(log/exp/sqrt/sin/…) with a non-atomic base and `n` a positive integer ≥ 2 →
lift `t == g(x)` (existing `_Lifter.expression`), rewrite as the monomial `t**n`
(relaxed exactly by the existing monomial path). **Rebuilds nothing.**

**Out-of-panel witnesses** (corpus scan, structurally distinct): **mathopt5_1**
(`sin(x)**3`), **mathopt5_6** (`sin(x)**2`), **mathopt3** (`sin(x)**2`) — the
lift fires on all three (`t == sin(x)`), confirming it is not log-specific.

### Implementation

`python/discopt/_jax/factorable_reform.py`: `_lift_loose_products_enabled()`
(flag), `_liftable_call_power_base()` (matcher), `_prelift_call_powers()`
(pre-pass before `distribute_products`; identity no-op when OFF),
`_scan_for_liftable_call_power()` + a gated line in `_has_factorable_work_inner`;
wired first in both the constraint and objective reform paths.

### Gates (BOUND-CHANGING, §0.1) — all green

- **Differential bound (nvs09):** flag ON root bound (−54.83) ≥ OFF (−72.90) AND
  ≤ oracle (−43.13); ≥ 25 % relative reduction asserted (60.7 %).
- **Feasible-point sampling (2000 pts):** `t == g(x)` is an exact identity —
  lifted objective at `(x, t=g(x))` equals the original (err < 1e-6), aux
  equalities hold (residual < 1e-6); cuts no feasible point.
- **Flag-OFF byte-identical:** `check_cert_neutrality.py` **NEUTRAL** — 41/41
  cert-panel instances `nodes X→X`, `|Δobj| = 0`.
- `pytest -m smoke` 614 passed / 14 skipped; adversarial slow 10 passed;
  `test_factorable_reform.py` 65 (+5 TD-A) passed; ruff check + format clean;
  mypy clean (numpy-stub env mismatch excepted). No Rust touched → no cargo.

### Acceptance

**nvs09 root gap 69.0 % → 27.1 % (60.7 % relative) with the flag ON** — a
materially tighter dual bound (the acceptance bar). At 60 s nvs09 is still
`feasible` (the `(∏x_i)^0.2` 10-way signomial per-node cost is the remaining
limiter, 7 nodes); certification is out of scope here. **nvs05 is honestly
killed** (OBBT territory, not lifting). Flag stays OFF pending 3 green nightlies.

Results block: `docs/dev/uncertified-tail-plan-results-2026-07-06.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
