### PR TITLE
perf(heuristics): VOLUME-1 — NLP-solve-volume attribution + cut (why nvs06 does 911 solves)

### DIFF
--- a/discopt_benchmarks/scripts/nlp_solve_volume.py
+++ b/discopt_benchmarks/scripts/nlp_solve_volume.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""VOLUME-1 — attribute POUNCE NLP-solve volume to its call-site SOURCES.
+
+Instruments the single shared POUNCE NLP entry point
+(``discopt.solvers.nlp_pounce.solve_nlp``) and buckets every NLP solve by the
+nearest identifying caller frame on the Python stack (root multistart,
+feasibility_pump, diving, rins, rens, subnlp, local_branching, per-node
+incumbent NLP, OBBT probe, ...).  For each bucket it records #solves and total
+wall.  It also wraps the primal-heuristic / multistart *entry* functions to
+measure the per-source **incumbent-improvement hit rate**: how often a call from
+that source returns a feasible candidate strictly better than the best-so-far.
+
+Pure monkeypatch — no production edit.  Measurement-only.
+
+Usage:
+    PYTHONPATH=<worktree>/python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 \
+        python nlp_solve_volume.py <instance.nl> [--time-limit 60] [--gap 1e-4]
+
+Env knobs for the prototype cut (all default-OFF, read by solver via env, not
+here) are echoed in the report so the caller can confirm the cut fired.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import inspect
+import json
+import time
+from collections import defaultdict
+
+import numpy as np
+
+# ---- source buckets: caller-frame function names we attribute solves to -----
+# Ordered by specificity; the *nearest* (deepest) match on the stack wins so a
+# subnlp launched from inside rens is charged to subnlp/rens correctly.
+HEURISTIC_SOURCES = [
+    "feasibility_pump",
+    "subnlp",
+    "diving",
+    "fractional_diving",
+    "objective_diving",
+    "rins",
+    "rens",
+    "local_branching",
+    "_local_branching_submip",
+    "integer_local_search",
+    "integer_box_search",
+    "enumerate_binary_seeds_subnlp",
+]
+# node / root engine sources
+ENGINE_SOURCES = [
+    "_solve_root_node_multistart",  # root multistart diversification
+    "_solve_node_nlp_pounce",  # per-node incumbent/bound NLP + _attempt retries
+    "_polish",  # OBBT / polishing probes (best-effort name match)
+    "obbt",
+]
+ALL_SOURCE_NAMES = HEURISTIC_SOURCES + ENGINE_SOURCES
+
+
+def _classify_stack() -> str:
+    """Walk the live stack and return the nearest identifying source label.
+
+    The deepest (closest to solve_nlp) matching frame wins.  When both a
+    heuristic frame and an engine frame are present (e.g. a diving call routes
+    through _solve_node_nlp_pounce), the HEURISTIC label wins because it is the
+    semantic source of the solve — the engine wrapper is shared plumbing.  We do
+    this by scanning outward and recording the first heuristic hit; if none,
+    fall back to the first engine hit; else 'other'.
+    """
+    # inner helpers whose true source is a heuristic further out on the stack
+    # (e.g. subnlp's inner _objective_improve loop actually belongs to
+    # integer_local_search).  Skip subnlp when a wider heuristic frame exists.
+    stack = inspect.stack()
+    engine_hit = None
+    outer_heuristic = None  # first (widest) heuristic that owns the solve
+    subnlp_seen = False
+    try:
+        for fr in stack:
+            name = fr.function
+            if name == "subnlp":
+                subnlp_seen = True
+            if name in HEURISTIC_SOURCES:
+                # remember the widest heuristic; but a direct subnlp with no
+                # wider heuristic is charged to subnlp itself
+                outer_heuristic = name
+            if engine_hit is None and name in ENGINE_SOURCES:
+                engine_hit = name
+    finally:
+        del stack
+    if outer_heuristic is not None:
+        # prefer the widest non-subnlp heuristic (integer_local_search etc.)
+        return outer_heuristic
+    if subnlp_seen:
+        return "subnlp"
+    if engine_hit is not None:
+        return engine_hit
+    return "other"
+
+
+class VolumeTracker:
+    def __init__(self):
+        self.count = defaultdict(int)  # source -> #solves
+        self.wall = defaultdict(float)  # source -> total wall (s)
+        self.iters = defaultdict(int)  # source -> total IPM iters
+        # hit-rate bookkeeping (per heuristic/multistart entry)
+        self.entry_calls = defaultdict(int)  # source -> #entry invocations
+        self.entry_hits = defaultdict(int)  # source -> #that improved best
+        self.best_obj = np.inf  # running best feasible incumbent (min sense)
+        self.total_solves = 0
+        self.total_wall = 0.0
+
+
+def install(tracker: VolumeTracker, sense_min: bool = True):
+    """Monkeypatch solve_nlp and the heuristic entry functions."""
+    import discopt._jax.primal_heuristics as ph
+    import discopt.solver as solver_mod
+    import discopt.solvers.nlp_pounce as npc
+
+    orig_solve_nlp = npc.solve_nlp
+
+    def wrapped_solve_nlp(*a, **k):
+        src = _classify_stack()
+        t0 = time.perf_counter()
+        res = orig_solve_nlp(*a, **k)
+        dt = time.perf_counter() - t0
+        tracker.count[src] += 1
+        tracker.wall[src] += dt
+        with contextlib.suppress(Exception):
+            tracker.iters[src] += int(getattr(res, "iterations", 0) or 0)
+        tracker.total_solves += 1
+        tracker.total_wall += dt
+        return res
+
+    npc.solve_nlp = wrapped_solve_nlp
+    # solver.py imports solve_nlp lazily as solve_nlp_pounce inside functions, so
+    # patching the module attribute is enough (the lazy `from ... import` runs at
+    # call time and picks up the patched attribute).
+
+    patched = [("nlp_pounce.solve_nlp", orig_solve_nlp)]
+
+    # ---- hit-rate wrappers on heuristic + multistart ENTRY functions --------
+    def _extract_obj(ret):
+        """Best-effort feasible objective from a heuristic return value.
+
+        Heuristics return (x, obj), or a candidate object, or None.  We only
+        need the objective (min sense) to test improvement.
+        """
+        if ret is None:
+            return None
+        if isinstance(ret, tuple) and len(ret) >= 2:
+            cand_x, cand_obj = ret[0], ret[1]
+            if cand_x is None:
+                return None
+            try:
+                return float(cand_obj)
+            except (TypeError, ValueError):
+                return None
+        # NLPResult-like
+        obj = getattr(ret, "objective", None)
+        status = getattr(ret, "status", None)
+        if obj is not None:
+            from discopt.solvers import SolveStatus
+
+            if status is not None and status not in (
+                SolveStatus.OPTIMAL,
+                SolveStatus.ITERATION_LIMIT,
+            ):
+                return None
+            try:
+                return float(obj)
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def make_hit_wrapper(name, orig):
+        def wrapper(*a, **k):
+            tracker.entry_calls[name] += 1
+            ret = orig(*a, **k)
+            obj = _extract_obj(ret)
+            if obj is not None and np.isfinite(obj):
+                # min sense: strictly better = smaller
+                better = obj < tracker.best_obj - 1e-9
+                if better:
+                    tracker.entry_hits[name] += 1
+                    tracker.best_obj = obj
+            return ret
+
+        return wrapper
+
+    for name in [
+        "feasibility_pump",
+        "subnlp",
+        "diving",
+        "fractional_diving",
+        "objective_diving",
+        "rins",
+        "rens",
+        "local_branching",
+        "integer_local_search",
+        "integer_box_search",
+        "enumerate_binary_seeds_subnlp",
+    ]:
+        if hasattr(ph, name):
+            o = getattr(ph, name)
+            patched.append((f"primal_heuristics.{name}", o))
+            setattr(ph, name, make_hit_wrapper(name, o))
+
+    # multistart entry: hit = did the root relaxation produce the FIRST feasible
+    # incumbent (best_obj was inf -> finite).  Wrap _solve_root_node_multistart.
+    if hasattr(solver_mod, "_solve_root_node_multistart"):
+        o = solver_mod._solve_root_node_multistart
+        patched.append(("solver._solve_root_node_multistart", o))
+
+        def ms_wrapper(*a, **k):
+            tracker.entry_calls["_solve_root_node_multistart"] += 1
+            ret = o(*a, **k)
+            obj = _extract_obj(ret)
+            if obj is not None and np.isfinite(obj) and obj < tracker.best_obj - 1e-9:
+                tracker.entry_hits["_solve_root_node_multistart"] += 1
+                tracker.best_obj = obj
+            return ret
+
+        solver_mod._solve_root_node_multistart = ms_wrapper
+
+    return patched
+
+
+def run(path: str, time_limit: float, gap: float) -> dict:
+    from discopt.modeling.core import from_nl
+
+    tracker = VolumeTracker()
+    model = from_nl(path)
+    install(tracker)
+
+    t0 = time.perf_counter()
+    result = model.solve(time_limit=time_limit, gap_tolerance=gap)
+    wall = time.perf_counter() - t0
+
+    # assemble report
+    rows = []
+    for src in sorted(tracker.count, key=lambda s: -tracker.wall[s]):
+        rows.append(
+            {
+                "source": src,
+                "solves": tracker.count[src],
+                "wall_s": round(tracker.wall[src], 3),
+                "iters": tracker.iters[src],
+            }
+        )
+    hit_rows = []
+    for src in sorted(tracker.entry_calls, key=lambda s: -tracker.entry_calls[s]):
+        calls = tracker.entry_calls[src]
+        hits = tracker.entry_hits[src]
+        hit_rows.append(
+            {
+                "source": src,
+                "entry_calls": calls,
+                "improved_incumbent": hits,
+                "hit_rate": round(hits / calls, 4) if calls else 0.0,
+            }
+        )
+
+    status = getattr(result, "status", None)
+    obj = getattr(result, "objective", None)
+    bound = getattr(result, "bound", None)
+    nodes = getattr(result, "node_count", getattr(result, "nodes", None))
+    return {
+        "instance": path.split("/")[-1],
+        "wall_s": round(wall, 3),
+        "status": str(status),
+        "objective": obj,
+        "bound": bound,
+        "nodes": nodes,
+        "total_nlp_solves": tracker.total_solves,
+        "total_nlp_wall_s": round(tracker.total_wall, 3),
+        "attribution": rows,
+        "hit_rates": hit_rows,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("instance")
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    ap.add_argument("--gap", type=float, default=1e-4)
+    ap.add_argument("--json-out", default=None)
+    args = ap.parse_args()
+    rep = run(args.instance, args.time_limit, args.gap)
+    print(json.dumps(rep, indent=2, default=str))
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump(rep, f, indent=2, default=str)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/nlp-solve-volume-2026-07-06.md
+++ b/docs/dev/nlp-solve-volume-2026-07-06.md
@@ -1,0 +1,287 @@
+# NLP-solve-volume attribution + cut — 2026-07-06 (VOLUME-1)
+
+**Date:** 2026-07-06
+**Status:** measured + prototype cut shipped behind a **default-OFF** env flag
+(`DISCOPT_ILS_SOLVE_CAP`). One production edit
+(`python/discopt/_jax/primal_heuristics.py`), one reusable script
+(`discopt_benchmarks/scripts/nlp_solve_volume.py`).
+**Scope:** the confirmed lever behind "discopt is seconds where BARON is
+sub-second" — the **volume** of POUNCE NLP subsolves. PYPROF-1 (#528,
+`docs/dev/python-residual-profile-2026-07-06.md`) established the wall is
+genuine NLP-solve + JAX-kernel VOLUME, not Python orchestration (~2 %
+removable), with the smoking gun **nvs06 = 911 POUNCE NLP solves for a 5-node
+problem**. VOLUME-1 is the *systematic accounting*: where do ALL the solves come
+from, what is each source's incumbent hit rate, and is the total cuttable
+without losing an incumbent or the certificate.
+**Builds on:** `docs/dev/bottleneck-profile-2026-07-05.md` §B4 (120 POUNCE NLP
+solves driven by diving/RINS on that panel), the F1 (#502, LNS-enumeration
+budget) and F4 (#508, root-heuristic budget) volume-control history.
+
+> **Method.** Branch `volume1-nlp-solve-volume` at `origin/main` (ed4b2265).
+> Apple M4 Pro (arm64), Python 3.12.11, JAX 0.10.2 (`JAX_PLATFORMS=cpu`,
+> `JAX_ENABLE_X64=1`), pounce **0.7.0** (release wheel `_pounce.abi3.so` =
+> **4.7 MB** — verified NOT a debug build), numpy 2.5.1, scipy 1.18.0,
+> `maturin develop --release`. Instances from `python/tests/data/minlplib_nl/`
+> (plus nvs23/nvs24 drawn from the MINLPLib snapshot),
+> `from_nl(path).solve(time_limit=60, gap_tolerance=1e-4)`, one at a time.
+> Attribution via `discopt_benchmarks/scripts/nlp_solve_volume.py` (new): a
+> pure monkeypatch that (1) wraps the single shared POUNCE entry point
+> `discopt.solvers.nlp_pounce.solve_nlp`, walks the live stack, and buckets
+> every solve by the nearest identifying caller frame; and (2) wraps each
+> heuristic / multistart *entry* function to record the per-source
+> incumbent-improvement HIT RATE (a call "hits" when it returns a feasible
+> candidate strictly better than the running best-so-far). Node-count and
+> objective for the cut A/B come from clean re-runs (no instrumentation).
+
+---
+
+## 0. Executive summary — the verdict
+
+**The NLP-solve volume is NOT load-bearing on this panel — the kill criterion
+did NOT fire — and it IS cuttable.** The single dominant source is the
+objective-improvement coordinate descent inside `integer_local_search`
+(`_objective_improve`, `primal_heuristics.py`), which on the integer-light
+panel instances issues **hundreds** of continuous-repair sub-NLPs at a
+**measured 0 % incumbent hit rate** — the incumbent is already found by the root
+multistart's *first* start. A default-OFF solve cap on that descent cuts the
+volume ~90 % with the certified objective, the node count, and the incumbent all
+**byte-unchanged** on every instance tested.
+
+1. **The 911 nvs06 solves decompose as: 888 `integer_local_search`, 15
+   `integer_box_search`, 5 per-node engine NLPs, 2 feasibility_pump, 1 subnlp.**
+   The 888 (97 % of the volume, 2.29 s of a 4.5 s wall) all come from
+   `_objective_improve`'s inner `int_idx × {±1,±2}` coordinate search, each move
+   a full continuous-repair `subnlp`. Its incumbent hit rate is **0/1 entry
+   calls** — it never improves the incumbent on nvs06.
+2. **The same source dominates nvs08 (779 solves, 0 % hit) and ex1224 (217, 0 %
+   hit).** For **fac2 (179 solves) and m3 (131 solves)** the dominant source is
+   instead **`rens`** (a nested B&B sub-solve) — a *different* structure, already
+   partly budgeted by F1/F4, and NOT the VOLUME-1 lever (see §3).
+3. **`integer_local_search` is dead weight even on its own cited class.** Its
+   docstring justifies itself on nvs23 ("-287 → -1125"); on the current build
+   nvs23's incumbent (-1124.8) also comes from the root multistart and ILS's hit
+   rate there is **0 %** too. The value it once delivered is now delivered
+   upstream by the root multistart.
+4. **The cut is viable, general, and certificate-safe.** A default-OFF cap
+   (`DISCOPT_ILS_SOLVE_CAP=k` ⇒ ≤ `k × n_int` sub-NLPs per descent) keyed on the
+   integer dimension (not any instance name) cuts nvs06 888→31 and nvs08 779→27
+   solves, wall **3.5 s→1.4 s (nvs06)** and **2.9 s→0.9 s (nvs08)**, with
+   objective, bound, and node count identical. Across all 18 panel instances
+   that fire ILS: **0 objective changes, 0 lost incumbents, 0 slowdowns > 10 %.**
+
+---
+
+## 1. Source-attribution table (where the solves come from)
+
+Per-instance, `time_limit=60`. "solves" = POUNCE NLP solves attributed to that
+source; "wall" = summed POUNCE solve wall for that source. Total wall is the
+whole `solve()` wall.
+
+### nvs06 — 911 solves, wall 4.5 s (5 nodes, optimal 1.7703125)
+
+| source | solves | wall (s) | IPM iters |
+|---|---:|---:|---:|
+| **integer_local_search** (`_objective_improve`) | **888** | **2.29** | 8841 |
+| integer_box_search | 15 | 0.05 | 158 |
+| `_solve_node_nlp_pounce` (per-node engine) | 5 | 0.04 | 157 |
+| feasibility_pump | 2 | 0.05 | 18 |
+| subnlp (direct) | 1 | 0.00 | 8 |
+
+### nvs08 — 828 solves, wall 4.3 s (57 nodes, optimal 23.4497)
+
+| source | solves | wall (s) |
+|---|---:|---:|
+| **integer_local_search** | **779** | **2.16** |
+| integer_box_search | 24 | 0.16 |
+| `_solve_node_nlp_pounce` | 18 | 0.06 |
+| feasibility_pump | 2 | 0.05 |
+| others (subnlp, fractional_diving) | 5 | 0.02 |
+
+### ex1224 — 254 solves, wall 2.2 s (53 nodes, optimal -0.94347)
+
+| source | solves | wall (s) |
+|---|---:|---:|
+| **integer_local_search** | **217** | **1.13** |
+| `_solve_node_nlp_pounce` | 23 | 0.09 |
+| feasibility_pump | 6 | 0.08 |
+| fractional_diving | 5 | 0.03 |
+| others | 3 | 0.01 |
+
+### fac2 — 198 solves, wall 5.8 s (69 nodes, optimal 3.3184e8)
+
+| source | solves | wall (s) |
+|---|---:|---:|
+| **rens** (nested B&B sub-solve) | **179** | **1.87** |
+| rins | 17 | 0.26 |
+| `_solve_node_nlp_pounce` | 2 | 0.29 |
+
+### m3 — 258 solves, wall 3.4 s (61 nodes, optimal 37.8)
+
+| source | solves | wall (s) |
+|---|---:|---:|
+| **rens** | **131** | **1.26** |
+| `_solve_node_nlp_pounce` | 102 | 1.12 |
+| rins | 25 | 0.18 |
+
+**The dominant 1–2 sources:** `integer_local_search` owns the 911 (nvs06), the
+828 (nvs08), and the 254 (ex1224). `rens` owns fac2/m3. `_objective_improve`
+(inside ILS) is the single largest NLP-solve source across the panel.
+
+---
+
+## 2. Per-source incumbent hit rate (the necessity question)
+
+"entry calls" = number of times that source function was *entered*; "hits" =
+number of those that returned a feasible candidate strictly better than the
+best-so-far incumbent. Measured on the same runs.
+
+| instance | source | entry calls | hits | hit rate |
+|---|---|---:|---:|---:|
+| nvs06 | `_solve_root_node_multistart` | 1 | **1** | **1.00** |
+| nvs06 | **integer_local_search** | 1 | **0** | **0.00** |
+| nvs06 | subnlp (all inner) | 903 | 0 | 0.00 |
+| nvs06 | feasibility_pump | 2 | 0 | 0.00 |
+| nvs08 | `_solve_root_node_multistart` | 1 | **1** | **1.00** |
+| nvs08 | **integer_local_search** | 1 | **0** | **0.00** |
+| ex1224 | `_solve_root_node_multistart` | 1 | **1** | **1.00** |
+| ex1224 | **integer_local_search** | 1 | **0** | **0.00** |
+| fac2 | `_solve_root_node_multistart` | 2 | 1 | 0.50 |
+| fac2 | rens / rins / diving / local_branching | — | 0 | 0.00 |
+| m3 | `_solve_root_node_multistart` | 2 | 1 | 0.50 |
+| nvs23 | `_solve_root_node_multistart` | 1 | **1** | **1.00** |
+| nvs23 | **integer_local_search** | 1 | **0** | **0.00** |
+
+**The crux:** on every instance the incumbent comes from
+`_solve_root_node_multistart` (start #1). `integer_local_search` — the source of
+the hundreds of solves — has a **0 % hit rate on every panel instance AND on its
+own docstring-cited nvs23**. The 888 nvs06 solves are load-*less*: they do the
+work and find nothing. This is exactly the "500 solves at a 1 % hit rate"
+lever the task asked for, here at **0 %**.
+
+The root multistart, by contrast, has a 100 % (or 50 %, when it runs twice) hit
+rate — it is the *load-bearing* source and is NOT touched.
+
+---
+
+## 3. Why `rens`/`_solve_node_nlp_pounce` are not the VOLUME-1 lever
+
+fac2/m3's dominant source is `rens`, whose 179/131 solves are the **nested
+`_solve_nlp_bb` B&B** over the RENS rounding neighbourhood — a single
+`sub_solver(model)` call that itself branches. That is a structurally different
+volume (real sub-problem search, and its incumbent can matter) and it is already
+under F1's LNS-enumeration budget and F4's root-heuristic budget. Cutting it is
+a re-scoped, higher-risk change (it can lose incumbents on the combinatorial
+class F1/F4 were built for) and is out of scope here. `_solve_node_nlp_pounce`
+is the per-node dual-bound engine — never cuttable without a certificate risk.
+VOLUME-1's clean, safe, high-yield lever is `integer_local_search`.
+
+---
+
+## 4. The cut — `DISCOPT_ILS_SOLVE_CAP` (default OFF)
+
+**Mechanism.** `integer_local_search._objective_improve` runs a first-improvement
+coordinate descent over `int_idx × {±1, ±2}`, calling `subnlp` (a full
+continuous-repair NLP) at each candidate, and re-sweeps until it hits a wall
+deadline (~9 s at `time_limit=60`). The genuine value of a first-improvement
+descent lands in the first sweep or two; the rest is the 0 %-hit plateau. The
+cut caps the number of sub-NLP solves a single descent may issue to
+`k × max(1, n_int)` where `k = DISCOPT_ILS_SOLVE_CAP` (default `0` ⇒ unlimited =
+today's behavior). Keyed on the integer dimension, not any instance name
+(CLAUDE.md §2). Sound: capping this descent only ever *weakens* the incumbent it
+might find (all its points are sub-NLP-verified and re-verified by
+`inject_incumbent`), and it never touches the dual bound or the certificate
+(heuristic-policy regime, CLAUDE.md §5).
+
+**The cut fires (verified via the source counter — the R2-didn't-fire lesson):**
+
+| instance | `DISCOPT_ILS_SOLVE_CAP` | ILS solves | total NLP | wall (s) | objective | nodes |
+|---|---:|---:|---:|---:|---|---:|
+| nvs06 | 0 (default) | 888 | 911 | 3.54 | 1.7703125002 | 5 |
+| nvs06 | **2** | **31** | **54** | **1.39** | 1.7703125002 | 5 |
+| nvs08 | 0 (default) | 779 | 828 | 2.89 | 23.449727353 | 57 |
+| nvs08 | **2** | **27** | **76** | **0.93** | 23.449727353 | 57 |
+
+`DISCOPT_ILS_SOLVE_CAP=0` reproduces the exact 888 solves of the unset default
+(byte-identical), confirming the flag is inert until armed.
+
+**Incumbent quality + certificate unchanged on the full ILS-firing panel.**
+A/B (cap 0 vs 2, `time_limit=60`) on all 18 panel instances that issue > 20 ILS
+solves — every objective identical, no incumbent lost, no slowdown:
+
+| instance | base obj | cut obj | base wall | cut wall | base/cut nodes |
+|---|---|---|---:|---:|---|
+| nvs08 | 23.449727353 | 23.449727353 | 2.89 | **0.93** | 57 / 57 |
+| nvs06 | 1.7703125002 | 1.7703125002 | 3.54 | **1.39** | 5 / 5 |
+| nvs01 | 12.469668822 | 12.469668822 | 5.87 | **2.82** | 17 / 17 |
+| st_e38 | 7197.7271168 | 7197.7271168 | 1.25 | **0.56** | 3 / 3 |
+| nvs09 | -43.13433692 | -43.13433692 | 60.03 | 60.11 | 221 / 221 |
+| nvs05 | 5.4709341264 | 5.4709341264 | 60.11 | 60.17 | 815 / 845 |
+| tspn05 | 191.25520768 | 191.25520768 | 18.92 | 19.30 | 39 / 39 |
+| st_e29 | -0.943470491 | -0.943470491 | 2.11 | 2.05 | 53 / 53 |
+| ex1224 | -0.943470491 | -0.943470491 | 2.06 | 2.10 | 53 / 53 |
+| tspn12 | 262.64739525 | 262.64739525 | 13.37 | 13.49 | 1 / 1 |
+| tspn08 | 290.56685375 | 290.56685375 | 16.64 | 16.71 | 1 / 1 |
+| ex1225 | 30.999999952 | 30.999999952 | 1.16 | 1.16 | 7 / 7 |
+| tspn10 | 225.12607140 | 225.12607140 | 15.01 | 14.43 | 1 / 1 |
+| gkocis | -1.923098780 | -1.923098780 | 0.70 | 0.69 | 5 / 5 |
+| ex1221 | 7.6671800711 | 7.6671800711 | 0.56 | 0.56 | 5 / 5 |
+| oaer | -1.923098304 | -1.923098304 | 0.65 | 0.65 | 3 / 3 |
+| ex1226 | -17.00000000 | -17.00000000 | 0.55 | 0.54 | 5 / 5 |
+| tanksize | 1.2686437480 | 1.2686437480 | 60.11 | 60.10 | 557 / 557 |
+
+Wall wins concentrate exactly where ILS was heavy (nvs06 2.5×, nvs08 3.1×,
+nvs01 2.1×, st_e38 2.2×). The time-limited instances (nvs05/nvs09/tanksize/tspn)
+are unchanged — ILS was not their bottleneck — and none regressed or lost its
+incumbent. nvs05's node count rose 815→845 (freed heuristic time buys more
+nodes) with the *same* objective: incumbent quality unchanged, as required.
+
+`ex1224`'s ILS solves (217) are spread across ~24 short restarts (n_int=8), so
+the per-descent cap of `2×8` does not bind there — the pathology (a *single*
+long descent re-sweeping to its wall deadline) is what the cap targets, and it
+binds precisely on the n_int-small, many-sweep instances (nvs06/nvs08) where the
+volume actually blows up. This is the correct, general behavior.
+
+---
+
+## 5. Kill criterion — NOT fired
+
+The kill criterion was: *if the volume is genuinely load-bearing (each source's
+solves have a material hit rate, cutting them loses incumbents or slows
+certification), the volume is irreducible and the gap is an algorithmic
+difference vs BARON.* It did **not** fire: the dominant source
+(`integer_local_search`) has a **0 % incumbent hit rate on every panel instance
+and on its own cited class**, and capping it loses **no** incumbent and slows
+**nothing**. The volume is reducible.
+
+(The residual gap vs BARON on the time-limited instances — nvs05, nvs09,
+tanksize, tspn — is genuinely a *bounding* problem, not a solve-volume one:
+their wall is unchanged by the cut because their bottleneck is the weak root
+relaxation / per-node bound work, i.e. the branch-and-reduce roadmap
+(cert-gap-plan), fewer-nodes not fewer-solves-per-node. That half of the panel
+points back to relaxation work, exactly as the kill-criterion's re-scope note
+anticipated — but the *solve-volume* half (nvs06/nvs08/nvs01/st_e38) is real,
+cuttable, and cut here.)
+
+---
+
+## 6. Verification run
+
+- `pytest -m smoke` (python/tests): **617 passed, 14 skipped**.
+- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed**.
+- `ruff check` + `ruff format --check` (v0.14.6): clean on the changed
+  production file and the script.
+- pre-commit `mypy` (whole `python/discopt/`): **Passed**.
+- No Rust touched (`cargo test` not required).
+- `DISCOPT_ILS_SOLVE_CAP=0` == unset default (888 solves, byte-identical) —
+  flag is default-OFF and inert until armed.
+
+---
+
+## 7. Artifacts
+
+- `discopt_benchmarks/scripts/nlp_solve_volume.py` — the source-attribution +
+  hit-rate profiler (monkeypatch of `nlp_pounce.solve_nlp` with stack-walk
+  bucketing and per-source incumbent-improvement hit rate). Reusable on any
+  `.nl` instance.
+- `python/discopt/_jax/primal_heuristics.py` — the `DISCOPT_ILS_SOLVE_CAP`
+  (default-OFF) sub-NLP solve cap inside `integer_local_search._objective_improve`.

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import itertools
 import math
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
@@ -31,6 +32,24 @@ from discopt.solvers import NLPResult, SolveStatus
 # capped, unconverged point simply fails the feasibility check and yields no
 # incumbent — it can never inject a wrong one (inject_incumbent re-verifies).
 _HEURISTIC_NLP_MAX_ITER = 300
+
+# VOLUME-1 (docs/dev/nlp-solve-volume-2026-07-06.md): the objective-improvement
+# coordinate descent inside ``integer_local_search`` (``_objective_improve``) is
+# the single dominant NLP-solve SOURCE on the easy-panel instances BARON solves
+# sub-second — nvs06 runs 888 sub-NLP solves there (of 911 total), nvs08 779,
+# ex1224 217 — and its measured incumbent-improvement HIT RATE is 0 % on every
+# one of them (the incumbent is already found by the root multistart's first
+# start). Left uncapped, the descent keeps re-sweeping ``int_idx × {±1,±2}``
+# until its wall deadline (~9 s), issuing hundreds of no-op sub-NLPs. This flag
+# caps the number of sub-NLP solves the descent may issue to
+# ``_ILS_SOLVE_CAP_MULT × n_int`` (a small multiple of the integer dimension —
+# enough for a full first-improvement sweep or two, which is where any real gain
+# lands, but not the hundreds-of-solves plateau). Default OFF (0 ⇒ unlimited =
+# current behavior); set ``DISCOPT_ILS_SOLVE_CAP`` to a positive integer to arm
+# it. Sound: capping this descent only ever *weakens* the incumbent it might
+# find (the descent injects sub-NLP-verified points that B&B still re-verifies),
+# and it never touches the dual bound or the certificate.
+_ILS_SOLVE_CAP_MULT = int(os.environ.get("DISCOPT_ILS_SOLVE_CAP", "0"))
 
 
 @dataclass
@@ -600,6 +619,14 @@ def integer_local_search(
         candidate and never affects the dual bound or certification."""
         bx = _round_clip(x_feas)
         best_x, best_obj = np.asarray(x_feas, dtype=np.float64).copy(), float(obj_feas)
+        # VOLUME-1 sub-NLP solve cap (default OFF). When armed, cap the number of
+        # continuous-repair sub-NLP solves this descent may issue to
+        # ``_ILS_SOLVE_CAP_MULT × n_int`` — a full first-improvement sweep or two
+        # — instead of re-sweeping until the wall deadline. Only the *extra*
+        # no-op solves past a couple of sweeps are cut (measured 0 % hit rate on
+        # the easy panel); the descent still injects any better point it finds.
+        _solve_cap = _ILS_SOLVE_CAP_MULT * max(1, n_int) if _ILS_SOLVE_CAP_MULT > 0 else None
+        _solves_used = 0
         improved = True
         while improved and time.perf_counter() < deadline:
             improved = False
@@ -607,12 +634,15 @@ def integer_local_search(
                 for d in (-1.0, 1.0, -2.0, 2.0):
                     if time.perf_counter() >= deadline:
                         break
+                    if _solve_cap is not None and _solves_used >= _solve_cap:
+                        return best_x, best_obj
                     nv = bx[j] + d
                     if nv < lb[j] - 1e-9 or nv > ub[j] + 1e-9:
                         continue
                     xt = bx.copy()
                     xt[j] = nv
                     if has_continuous:
+                        _solves_used += 1
                         cand = subnlp(
                             model,
                             xt,


### PR DESCRIPTION
## VOLUME-1 — NLP-solve-volume attribution + cut

Systematic accounting of the POUNCE NLP-solve **volume** that PYPROF-1 (#528)
identified as the wall behind "discopt is seconds where BARON is sub-second"
(the smoking gun: **nvs06 = 911 POUNCE solves for a 5-node problem**). Full
findings in `docs/dev/nlp-solve-volume-2026-07-06.md`.

### Where the 911 come from (source attribution)

New reusable profiler `discopt_benchmarks/scripts/nlp_solve_volume.py` wraps the
single shared entry point `nlp_pounce.solve_nlp`, walks the stack, and buckets
every solve by caller + records each source's incumbent-improvement hit rate.

| instance | dominant source | solves | source wall | hit rate |
|---|---|---:|---:|---:|
| nvs06 | `integer_local_search` (`_objective_improve`) | 888 / 911 | 2.29 s | **0 %** |
| nvs08 | `integer_local_search` | 779 / 828 | 2.16 s | **0 %** |
| ex1224 | `integer_local_search` | 217 / 254 | 1.13 s | **0 %** |
| fac2 | `rens` (nested B&B) | 179 / 198 | 1.87 s | 0 % (out of scope, F1/F4) |
| m3 | `rens` | 131 / 258 | 1.26 s | out of scope |

On **every** instance the incumbent comes from `_solve_root_node_multistart`
(start #1, 100 % hit). `integer_local_search`'s coordinate descent does hundreds
of continuous-repair sub-NLPs and improves the incumbent **0 %** of the time —
including on its own docstring-cited nvs23. **Kill criterion did NOT fire**: the
volume is not load-bearing and is cuttable.

### The cut (default-OFF `DISCOPT_ILS_SOLVE_CAP`)

Caps `_objective_improve`'s sub-NLP solves to `k × n_int` per descent (keyed on
the integer dimension, not any instance name). Default `0` ⇒ unlimited =
byte-identical to today.

Verified it **fires** (via the source counter — the R2-didn't-fire lesson):

| instance | cap | ILS solves | wall | objective | nodes |
|---|---:|---:|---:|---|---:|
| nvs06 | 0 | 888 | 3.54 s | 1.7703125002 | 5 |
| nvs06 | **2** | **31** | **1.39 s** | 1.7703125002 | 5 |
| nvs08 | 0 | 779 | 2.89 s | 23.449727353 | 57 |
| nvs08 | **2** | **27** | **0.93 s** | 23.449727353 | 57 |

A/B over **all 18 panel instances that fire ILS** (cap 0 vs 2, `time_limit=60`):
**0 objective changes, 0 lost incumbents, 0 slowdowns > 10 %.** Wall wins where
ILS was heavy (nvs06 2.5×, nvs08 3.1×, nvs01 2.1×, st_e38 2.2×); time-limited
instances (nvs05/nvs09/tanksize/tspn) unchanged and none regressed.
`DISCOPT_ILS_SOLVE_CAP=0` reproduces the exact 888 solves of the unset default.

### Regime + verification

Heuristic-policy (incumbent discovery only; dual bound / certificate untouched;
all ILS points are sub-NLP-verified and re-verified by `inject_incumbent`).

- `pytest -m smoke`: **617 passed, 14 skipped**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed**
- `ruff check` + `ruff format --check` (v0.14.6): clean
- pre-commit `mypy` (whole `python/discopt/`): **Passed**
- No Rust touched (`cargo test` not required)

Do not merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
