### PR TITLE
bench(graduation): G1.2 — per-flag graduation gate + protocol (nightly + CI subset)

### DIFF
--- a/.github/workflows/graduation-gate.yml
+++ b/.github/workflows/graduation-gate.yml
@@ -1,0 +1,61 @@
+name: Flag-graduation gate (CI subset)
+
+# G1.2 — the CI-runnable subset of the flag-graduation gate.
+#
+# The FULL gate (held-out per-flag arm + cert-neutrality + ledger append) needs
+# the ~4,800-instance MINLPLib corpus in ~/Dropbox/projects/discopt-minlp-benchmark,
+# which GitHub CI does NOT have. So CI runs only the cert-neutrality +
+# incorrect_count portion over the VENDORED cert panel (which IS in the repo) as a
+# regression guard: it proves that turning a parked flag ON does not change a
+# certified objective or lose an optimal status on the panel. It does NOT measure
+# held-out benefit and does NOT append a graduation verdict to the ledger — those
+# are nightly-only facts produced by `make graduation-gate` on a corpus machine.
+#
+# See docs/dev/flag-graduation-protocol.md for the local-full vs CI-subset split.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Mondays 07:42 UTC. Off the PR-fast path (the cert re-solve is minutes).
+    - cron: "42 7 * * 1"
+
+jobs:
+  graduation-gate-ci-subset:
+    name: cert-neutrality regression guard (vendored panel)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y coinor-libipopt-dev liblapack-dev libblas-dev gfortran
+      - name: Install Python dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install maturin
+          pip install numpy scipy "jax[cpu]" pytest pytest-timeout
+          pip install pounce-solver || echo "pounce-solver unavailable; cert panel may skip nonlinear instances"
+          maturin develop --release
+      - name: Run the graduation gate CI subset (cert-neutrality + incorrect_count)
+        run: |
+          source .venv/bin/activate
+          python discopt_benchmarks/scripts/graduation_gate.py \
+            --flags root_fixpoint,node_reduce,psd_cost_gate,lift_zero_spanning,lift_loose_products \
+            --ci-subset
+        env:
+          JAX_PLATFORMS: cpu
+          JAX_ENABLE_X64: "1"
+          PYTHONPATH: ${{ github.workspace }}/python
+      - name: Upload gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: graduation-gate-ci-subset
+          path: reports/graduation_gate_*.json
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ CUTEST_ENV      := $(CUTEST_PREFIX)/env.sh
         bench-cutest bench-cutest-smoke setup-cutest check-cutest \
         docs docs-open notebooks \
         gams-build gams-register gams-install gams-test gams-verify \
+        graduation-gate graduation-gate-ci \
         bench-lp-smoke bench-qp-smoke bench-milp-smoke bench-miqp-smoke bench-minlp-smoke bench-global-smoke \
         bench-lp-full bench-qp-full bench-milp-full bench-miqp-full bench-minlp-full bench-global-full \
         bench-smoke-all bench-full-all bench-all bench-global-baron bench-global-nlsolvers
@@ -789,6 +790,43 @@ gate-small: build
 		--workers $(BENCH_WORKERS) --mem-limit-mb 0 \
 		--scaled-out-dir $(BENCH_OUT_DIR)/small_gate_$(TS) \
 		--gate small
+
+# ── Flag-graduation gate (G1.2) ──────────────────────────────────────────────
+# The reusable per-flag validation instrument that lets parked default-OFF
+# capabilities flip to default-ON on evidence. Two invocations:
+#
+#   make graduation-gate      FULL gate — held-out per-flag arm + cert-neutrality
+#                             + ledger append. Needs the MINLPLib corpus in
+#                             ~/Dropbox/projects/discopt-minlp-benchmark (a corpus
+#                             machine only — GitHub CI does NOT have it). This is
+#                             the nightly graduation run. Schedule it via cron, e.g.
+#                             (a machine with the corpus, from the repo root):
+#                               17 4 * * *  cd /path/to/discopt && \
+#                                 PYTHONPATH=$PWD/python JAX_PLATFORMS=cpu \
+#                                 JAX_ENABLE_X64=1 make graduation-gate >> \
+#                                 reports/graduation-nightly.log 2>&1
+#
+#   make graduation-gate-ci   CI SUBSET — cert-neutrality + incorrect_count over
+#                             the VENDORED cert panel only (no corpus, no ledger).
+#                             Mirrors .github/workflows/graduation-gate.yml so it
+#                             can be reproduced locally.
+#
+# See docs/dev/flag-graduation-protocol.md for the protocol.
+
+GRAD_FLAGS ?= root_fixpoint,node_reduce,psd_cost_gate,lift_zero_spanning,lift_loose_products
+GRAD_N     ?= 100
+GRAD_SEED  ?= 0
+GRAD_TL    ?= 30
+
+graduation-gate: build
+	@echo "==> Flag-graduation gate (FULL): held-out arm + cert-neutrality + ledger"
+	PYTHONPATH=$(PROJECT_DIR)/python $(PYTHON) discopt_benchmarks/scripts/graduation_gate.py \
+		--flags $(GRAD_FLAGS) --n $(GRAD_N) --seed $(GRAD_SEED) --time-limit $(GRAD_TL)
+
+graduation-gate-ci: build
+	@echo "==> Flag-graduation gate (CI SUBSET): cert-neutrality over the vendored panel"
+	PYTHONPATH=$(PROJECT_DIR)/python $(PYTHON) discopt_benchmarks/scripts/graduation_gate.py \
+		--flags $(GRAD_FLAGS) --ci-subset
 
 # ── Dashboard (local web UI) ─────────────────────────────────────────────────
 

--- a/discopt_benchmarks/scripts/generality_sweep.py
+++ b/discopt_benchmarks/scripts/generality_sweep.py
@@ -102,6 +102,68 @@ FLAGS_ON = {
 }
 CAPABILITIES = ("branch_reduce", "psd_gate")
 
+# --------------------------------------------------------------------------- #
+# Per-flag ARMS (G1.2) — the isolation the N=20 pilot lacked.
+#
+# The pilot bundled ALL flags together (FLAGS_ON), so a benefit could not be
+# attributed to a single capability and its regression rate was contaminated by
+# its neighbours (e.g. the nvs13 19->49-node regression is PSD's, but the bundle
+# hid it inside branch-and-reduce's numbers). The flag-graduation gate needs each
+# capability's benefit-fraction / regression-rate / soundness measured in
+# ISOLATION: one arm per parked flag, each setting exactly that capability's env
+# flags (everything else at its default OFF), plus an ``off`` control and the
+# ``all`` bundle for a bundle-vs-isolated cross-check.
+#
+# Each arm names:
+#   - ``env``          the exact env flags it sets (empty for the OFF control);
+#   - ``struct_attr``  which ``Row`` structural-prevalence attribute gates it
+#                      (only structure-carrying instances score the arm), or None
+#                      for the whole-sample arms (off / all);
+#   - ``regime``       ``bound_neutral`` (must be cert byte-identical) or
+#                      ``bound_changing`` (may legitimately change nodes/bound; the
+#                      differential + oracle-bracket soundness check applies). This
+#                      selects which neutrality check the gate runs for the flag.
+ARMS: dict[str, dict] = {
+    "off": {"env": {}, "struct_attr": None, "regime": "control"},
+    "root_fixpoint": {
+        "env": {"DISCOPT_ROOT_FIXPOINT": "1"},
+        "struct_attr": "reduce_struct",
+        "regime": "bound_changing",
+    },
+    "node_reduce": {
+        "env": {"DISCOPT_NODE_REDUCE": "1"},
+        "struct_attr": "reduce_struct",
+        "regime": "bound_changing",
+    },
+    "psd_cost_gate": {
+        "env": {"DISCOPT_PSD_COST_GATE": "1"},
+        "struct_attr": "psd_struct",
+        "regime": "bound_changing",
+    },
+    "lift_zero_spanning": {
+        "env": {"DISCOPT_LIFT_ZERO_SPANNING_FACTORS": "1"},
+        "struct_attr": None,  # structure is a runtime property; no cheap static proxy
+        "regime": "bound_changing",
+    },
+    "lift_loose_products": {
+        "env": {"DISCOPT_LIFT_LOOSE_PRODUCTS": "1"},
+        "struct_attr": None,
+        "regime": "bound_changing",
+    },
+    "all": {"env": dict(FLAGS_ON), "struct_attr": None, "regime": "bound_changing"},
+}
+
+# The parked flags that graduation targets (excludes the ``off`` control and the
+# ``all`` bundle cross-check). These are the arms a graduation verdict is emitted
+# for.
+GRADUATION_ARMS = (
+    "root_fixpoint",
+    "node_reduce",
+    "psd_cost_gate",
+    "lift_zero_spanning",
+    "lift_loose_products",
+)
+
 # correctness tolerance (matches conftest abs=1e-6, rel=1e-4)
 ATOL, RTOL = 1e-6, 1e-4
 
@@ -612,6 +674,10 @@ def geomean(xs: Sequence[float | None]) -> float | None:
     return math.exp(statistics.fmean(math.log(x) for x in vals))
 
 
+def pct_or_dash(x: object) -> str:
+    return f"{x * 100:.0f}%" if isinstance(x, (int, float)) else "—"
+
+
 # --------------------------------------------------------------------------- #
 # orchestration + reporting
 # --------------------------------------------------------------------------- #
@@ -684,6 +750,127 @@ def per_capability_stats(rows: list[Row], structattr: str) -> CapStats:
         benefit_instances=[r.instance for r in scored if r.cmp.verdict == BENEFIT],
         regression_instances=[r.instance for r in scored if r.cmp.verdict == REGRESS],
     )
+
+
+# --------------------------------------------------------------------------- #
+# Per-flag ARMS runner (G1.2) — reusable by graduation_gate.py.
+#
+# Solves each selected instance once for the OFF control and once per requested
+# arm, then tallies per-arm CapStats (restricted to the arm's structure-carrying
+# instances when it has a static structural proxy; whole-sample otherwise). Also
+# collects soundness violations across ALL arms (any oracle crossing / false
+# optimal, in any config, is a P0 — the arm's env flags cannot excuse it).
+# --------------------------------------------------------------------------- #
+@dataclass
+class ArmRow:
+    """One instance solved under the OFF control + one arm's flags."""
+
+    instance: str
+    probtype: str
+    nvars: int
+    oracle: float
+    dual: float | None
+    maximize: bool
+    psd_struct: bool
+    reduce_struct: bool
+    off: SolveRun
+    on: SolveRun  # the arm's ON solve
+    cmp: Compare
+    violations: list[Violation]
+
+
+def _arm_struct_ok(arm: str, inst: Instance) -> bool:
+    """Does this instance carry the arm's target structure? Arms with no cheap
+    static proxy (lifts, all, off) score every instance."""
+    attr = ARMS[arm]["struct_attr"]
+    if attr is None:
+        return True
+    return bool(getattr(inst, attr))
+
+
+def arm_stats(rows: list[ArmRow], arm: str) -> CapStats:
+    """Benefit/regression/soundness tally for one arm, restricted to the arm's
+    structure-carrying instances (whole-sample when the arm has no static proxy).
+    Mirrors :func:`per_capability_stats` but over ArmRows."""
+    attr = ARMS[arm]["struct_attr"]
+    sub = [r for r in rows if (attr is None or getattr(r, attr))]
+    scored = [r for r in sub if not (r.off.error or r.on.error)]
+    n = len(scored)
+    benefit = sum(r.cmp.verdict == BENEFIT for r in scored)
+    regress = sum(r.cmp.verdict == REGRESS for r in scored)
+    node_ratios = [r.cmp.node_ratio for r in scored if r.cmp.node_ratio is not None]
+    wall_ratios = [r.cmp.wall_ratio for r in scored if r.cmp.wall_ratio is not None]
+    return CapStats(
+        structural_prevalence=len(sub),
+        scored=n,
+        benefit_count=benefit,
+        regression_count=regress,
+        benefit_fraction=(benefit / n) if n else None,
+        regression_rate=(regress / n) if n else None,
+        geomean_node_ratio=geomean(node_ratios),
+        geomean_wall_ratio=geomean(wall_ratios),
+        benefit_instances=[r.instance for r in scored if r.cmp.verdict == BENEFIT],
+        regression_instances=[r.instance for r in scored if r.cmp.verdict == REGRESS],
+    )
+
+
+def run_arm(
+    instances: list[Instance],
+    nl_dir: Path,
+    arm: str,
+    tl: float,
+    off_cache: dict[str, SolveRun] | None = None,
+    progress: bool = True,
+) -> list[ArmRow]:
+    """Solve every instance OFF (control) and ON (this arm's env flags).
+
+    ``off_cache`` lets callers reuse one OFF control solve across multiple arms
+    (the OFF solve is identical for every arm, so a per-flag sweep pays for it
+    once). Mutated in place with each computed control run.
+    """
+    env_on = ARMS[arm]["env"]
+    rows: list[ArmRow] = []
+    for idx, inst in enumerate(instances, 1):
+        nl_path = nl_dir / f"{inst.name}.nl"
+        maximize = nl_is_maximize(nl_path)
+        if off_cache is not None and inst.name in off_cache:
+            off = off_cache[inst.name]
+        else:
+            off = run_discopt(nl_path, tl, extra_env=None)
+            if off_cache is not None:
+                off_cache[inst.name] = off
+        on = run_discopt(nl_path, tl, extra_env=(env_on or None))
+        viol = check_soundness(inst, off, "off", maximize) + check_soundness(
+            inst, on, arm, maximize
+        )
+        cmp = compare(off, on, inst.name)
+        rows.append(
+            ArmRow(
+                instance=inst.name,
+                probtype=inst.probtype,
+                nvars=inst.nvars,
+                oracle=inst.oracle,
+                dual=inst.dual,
+                maximize=maximize,
+                psd_struct=inst.psd_struct,
+                reduce_struct=inst.reduce_struct,
+                off=off,
+                on=on,
+                cmp=cmp,
+                violations=viol,
+            )
+        )
+        if progress:
+            vtag = "  !!VIOL" if viol else ""
+            struct = "★" if _arm_struct_ok(arm, inst) else "·"
+            print(
+                f"[{arm}] [{idx:2}/{len(instances)}] {inst.name:22} {struct} "
+                f"OFF {off.status[:8]:8} {off.node_count:5}n {off.wall_time:5.1f}s | "
+                f"ON {on.status[:8]:8} {on.node_count:5}n {on.wall_time:5.1f}s "
+                f"-> {cmp.verdict}{vtag}",
+                flush=True,
+            )
+    return rows
 
 
 def verdict_line(name: str, stats: CapStats, total_n: int) -> str:
@@ -978,6 +1165,17 @@ def main() -> int:
         action="store_true",
         help="print the selected instance list and structural prevalence, then exit (no solves)",
     )
+    ap.add_argument(
+        "--arms",
+        type=str,
+        default=None,
+        help=(
+            "comma-separated per-flag arms to run in ISOLATION instead of the "
+            f"bundled OFF-vs-ON sweep (choices: {','.join(GRADUATION_ARMS)},all). "
+            "Each arm sets only its capability's env flags; the OFF control is "
+            "shared across arms. Emits a per-arm CapStats JSON."
+        ),
+    )
     args = ap.parse_args()
 
     corpus = Path(os.path.expanduser(args.corpus))
@@ -1014,6 +1212,70 @@ def main() -> int:
                 flush=True,
             )
         return 0
+
+    # --- Per-flag arms mode (G1.2) --------------------------------------- #
+    if args.arms:
+        requested = [a.strip() for a in args.arms.split(",") if a.strip()]
+        unknown = [a for a in requested if a not in ARMS or a == "off"]
+        if unknown:
+            print(f"# ERROR: unknown/invalid arm(s): {unknown}", file=sys.stderr)
+            return 2
+        off_cache: dict[str, SolveRun] = {}
+        arms_out: dict[str, dict] = {}
+        total_viol = 0
+        for arm in requested:
+            arm_rows = run_arm(instances, nl_dir, arm, args.time_limit, off_cache=off_cache)
+            stats = arm_stats(arm_rows, arm)
+            viol = [asdict(v) for r in arm_rows for v in r.violations]
+            total_viol += len(viol)
+            arms_out[arm] = {
+                "env": ARMS[arm]["env"],
+                "regime": ARMS[arm]["regime"],
+                "struct_attr": ARMS[arm]["struct_attr"],
+                "stats": asdict(stats),
+                "violations": viol,
+                "rows": [
+                    {
+                        "instance": r.instance,
+                        "probtype": r.probtype,
+                        "nvars": r.nvars,
+                        "off": asdict(r.off),
+                        "on": asdict(r.on),
+                        "verdict": r.cmp.verdict,
+                        "node_ratio": r.cmp.node_ratio,
+                        "wall_ratio": r.cmp.wall_ratio,
+                        "reasons": r.cmp.reasons,
+                    }
+                    for r in arm_rows
+                ],
+            }
+        payload = {
+            "timestamp": ts,
+            "mode": "arms",
+            "n_requested": args.n,
+            "n_selected": len(instances),
+            "seed": args.seed,
+            "time_limit": args.time_limit,
+            "max_vars": args.max_vars,
+            "selection_meta": selection_meta,
+            "instances": [i.name for i in instances],
+            "arms": arms_out,
+            "n_violations": total_viol,
+        }
+        js = out_dir / f"generality_arms_{ts}.json"
+        js.write_text(json.dumps(payload, indent=2))
+        print("", flush=True)
+        for arm in requested:
+            s = arms_out[arm]["stats"]
+            print(
+                f"# arm {arm:20} scored {s['scored']:3} "
+                f"benefit {pct_or_dash(s['benefit_fraction'])} "
+                f"regression {pct_or_dash(s['regression_rate'])} "
+                f"viol {len(arms_out[arm]['violations'])}",
+                flush=True,
+            )
+        print(f"# ARMS JSON: {js}", flush=True)
+        return 1 if total_viol else 0
 
     rows: list[Row] = []
     for idx, inst in enumerate(instances, 1):

--- a/discopt_benchmarks/scripts/graduation_gate.py
+++ b/discopt_benchmarks/scripts/graduation_gate.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Flag-graduation gate (G1.2) — the per-flag validation instrument + ledger.
+
+**The process gap this closes (cause C-B).** discopt's bound-changing regime
+(CLAUDE.md §5) correctly parks each new capability behind a default-OFF env flag
+"pending 3 green nightlies". But no nightly pipeline exists, so **nothing ever
+graduates** — five sound, class-validated capabilities are inert on main. This
+script is the missing instrument: it runs, *per parked flag*, the evidence a
+graduation PR needs, emits a machine-readable verdict, and appends it to a
+durable ledger so "3 consecutive green" is checkable. The flip itself stays a
+separate, reviewed PR — this gate produces the evidence, it does not automate the
+decision.
+
+**Per flag it runs three checks** (all infra; NO solver-math change):
+
+1. **Held-out per-flag arm** — via :mod:`generality_sweep` ARMS: solve a seeded,
+   held-out sample (excludes the 61-panel + named probes) OFF vs the flag ON *in
+   isolation* (every other capability at its default OFF — the isolation the N=20
+   pilot lacked). Yields ``benefit_fraction`` / ``regression_rate`` /
+   structural-prevalence and any soundness violation (oracle-bracket crossing /
+   false-optimal in either config).
+
+2. **Cert-panel neutrality** — re-runs :mod:`check_cert_neutrality` **in a fresh
+   subprocess with the flag ON** (so the fresh interpreter reads the env flag at
+   import). For a *bound-neutral* flag this must be byte-identical (node_count +
+   objective) vs ``cert-baseline.jsonl``; for a *bound-changing / heuristic-policy*
+   flag the certified **objective is always enforced** (soundness) while node
+   drift on the cert panel is a documented, non-fatal perf note (it is expected
+   where the flag's structure is present). Either way, a changed *objective* or a
+   lost *optimal status* is a hard fail.
+
+3. **incorrect_count = 0 + no oracle cross** — folded into checks (1) and (2):
+   the arm's soundness bracket ( ``[=bestdual=, =best=]`` ) is the held-out
+   incorrect-count guard; the cert panel's objective-to-tolerance is the panel
+   incorrect-count guard.
+
+**Eligibility.** A flag's verdict is ``eligible`` iff:
+
+  * **0** soundness violations in the held-out arm (either config), AND
+  * cert-neutral (objective unchanged + still optimal; node byte-identical too for
+    a bound-neutral flag), AND
+  * ``regression_rate`` at/below the documented threshold
+    (:data:`MAX_REGRESSION_RATE`).
+
+A flag is **graduation-eligible** (ready for its flip PR) only after
+:data:`GREEN_STREAK_REQUIRED` *consecutive* eligible verdicts in the ledger — the
+"3 green nightlies" rule made checkable.
+
+**Corpus honesty (read §4 of the plan doc).** The held-out arm needs the full
+~4,800-instance MINLPLib corpus in ``~/Dropbox/projects/discopt-minlp-benchmark``,
+which **GitHub CI does not have**. So:
+
+  * **local / nightly** (a machine with the corpus): run the *full* gate — the
+    held-out arm + cert-neutrality + ledger append. ``make graduation-gate`` or
+    the documented cron line drives this.
+  * **CI subset** (``.github/workflows/graduation-gate.yml``): runs only the
+    **cert-neutrality + incorrect_count** portion over the **vendored** cert panel
+    (which IS in the repo) as a regression guard — ``--ci-subset``. It skips the
+    held-out arm (no corpus) and does NOT append a ledger verdict (a nightly-only
+    fact).
+
+Usage (full, one flag, tiny smoke):
+    PYTHONPATH=<worktree>/python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 \
+      python discopt_benchmarks/scripts/graduation_gate.py \
+        --flags psd_cost_gate --n 8 --time-limit 15
+
+Usage (CI subset — cert-neutrality only, vendored panel, no corpus):
+    python discopt_benchmarks/scripts/graduation_gate.py \
+        --flags all --ci-subset
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+_BENCH_ROOT = _SCRIPTS.parent
+_REPO = _BENCH_ROOT.parent
+sys.path.insert(0, str(_BENCH_ROOT))
+sys.path.insert(0, str(_SCRIPTS))
+
+import generality_sweep as gs  # noqa: E402
+
+DEFAULT_CORPUS = Path(os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark"))
+CERT_NEUTRALITY_SCRIPT = _SCRIPTS / "check_cert_neutrality.py"
+LEDGER_PATH = _REPO / "docs" / "dev" / "data" / "graduation-ledger.jsonl"
+
+# --------------------------------------------------------------------------- #
+# Documented thresholds (global, not per-instance — CLAUDE.md §2). A flip PR must
+# cite these; changing them is a reviewed decision, recorded in the protocol doc.
+# --------------------------------------------------------------------------- #
+# Max held-out regression-rate for eligibility. The pilot measured branch-and-
+# reduce at 8 % and PSD at 10 % (bundled); the isolated arms must land at/below
+# this. 0.10 is the documented ceiling — a flag regressing >10 % of its
+# structure-carrying held-out instances is not ready to be a default.
+MAX_REGRESSION_RATE = 0.10
+# Consecutive green verdicts required before a flag is graduation-eligible (the
+# "3 green nightlies" rule).
+GREEN_STREAK_REQUIRED = 3
+
+
+# --------------------------------------------------------------------------- #
+# verdict record
+# --------------------------------------------------------------------------- #
+@dataclass
+class Verdict:
+    flag: str
+    eligible: bool
+    benefit_fraction: float | None
+    regression_rate: float | None
+    soundness_ok: bool
+    cert_neutral: bool
+    # context / provenance
+    regime: str = ""
+    structural_prevalence: int = 0
+    scored: int = 0
+    n_soundness_violations: int = 0
+    cert_kind: str = ""  # "byte_identical" | "objective_only" | "skipped"
+    cert_violations: list[dict] = field(default_factory=list)
+    benefit_instances: list[str] = field(default_factory=list)
+    regression_instances: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# cert-panel neutrality — fresh subprocess so the env flag is read at import
+# --------------------------------------------------------------------------- #
+@dataclass
+class CertResult:
+    neutral: bool
+    kind: str  # "byte_identical" | "objective_only" | "skipped"
+    violations: list[dict]
+    note: str
+
+
+def run_cert_neutrality(arm: str, env_on: dict[str, str]) -> CertResult:
+    """Run ``check_cert_neutrality.py`` in a fresh subprocess with the flag ON.
+
+    The check compares the flagged re-solve of the 41-instance cert panel against
+    the committed ``cert-baseline.jsonl`` and exits non-zero on any violation. For
+    a bound-changing flag, a *node_count* change on a cert instance carrying the
+    flag's structure is expected and NOT a soundness fault, but a changed
+    *objective* or a lost *optimal* status is. Because the underlying check enforces
+    objective-to-tolerance and still-optimal unconditionally (its perf-class node
+    guard is separate), we run it as-is and classify: objective/status/missing
+    violations are hard fails; a lone node_regression is downgraded to a perf note
+    for a bound-changing flag."""
+    regime = gs.ARMS.get(arm, {}).get("regime", "bound_changing")
+    env = dict(os.environ, JAX_PLATFORMS="cpu", JAX_ENABLE_X64="1")
+    env.update(env_on)
+    # Emit machine-readable violations by importing the util in the subprocess and
+    # dumping JSON — reusing check_cert_neutrality's own runner + baseline so we do
+    # not fork its logic.
+    worker = (
+        "import json, sys\n"
+        f"sys.path.insert(0, {str(_BENCH_ROOT)!r}); sys.path.insert(0, {str(_REPO)!r})\n"
+        "from benchmarks.runner import BenchmarkConfig, BenchmarkRunner, SolverConfig\n"
+        "from scripts.gen_cert_baseline import _instance_budgets\n"
+        "from utils.cert_neutrality import check_neutrality, load_baseline\n"
+        "from scripts.check_cert_neutrality import _CERT_BASELINE, _KNOWN_PERF_GATED\n"
+        "baseline = load_baseline(_CERT_BASELINE)\n"
+        "budgets = _instance_budgets(60.0)\n"
+        "solver = SolverConfig(name='discopt', command='', solver_type='internal')\n"
+        "new_rows = {}\n"
+        "for name in sorted(baseline):\n"
+        "    cfg = BenchmarkConfig(suite_name='cert-neutral',\n"
+        "        time_limit=int(budgets.get(name, 60)), num_runs=1, solvers=[solver])\n"
+        "    res = BenchmarkRunner(cfg)._run_discopt(solver, name, 0)\n"
+        "    new_rows[name] = res.to_dict()\n"
+        "viol = check_neutrality(new_rows, baseline, known_perf_gated=_KNOWN_PERF_GATED)\n"
+        "print('CERTJSON:' + json.dumps([{'instance': v.instance, 'kind': v.kind,\n"
+        "    'detail': v.detail} for v in viol]))\n"
+    )
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", worker],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=3600,
+        )
+    except subprocess.TimeoutExpired:
+        return CertResult(False, "skipped", [], "cert-neutrality subprocess timed out (1h)")
+    line = next(
+        (ln for ln in proc.stdout.splitlines() if ln.startswith("CERTJSON:")),
+        None,
+    )
+    if line is None:
+        return CertResult(
+            False,
+            "skipped",
+            [],
+            f"cert-neutrality produced no JSON (stderr tail: {proc.stderr.strip()[-300:]!r})",
+        )
+    viol = json.loads(line[len("CERTJSON:") :])
+    # Soundness-class violations (objective / status / missing) are hard fails in
+    # every regime. node_regression is perf-class: fatal for a bound-neutral flag,
+    # a documented note for a bound-changing / heuristic-policy flag.
+    hard = [v for v in viol if v["kind"] in ("objective", "status", "missing")]
+    node_only = [v for v in viol if v["kind"] == "node_regression"]
+    if regime == "bound_neutral":
+        neutral = not viol
+        kind = "byte_identical"
+        note = "byte-identical required (bound-neutral flag)"
+        return CertResult(neutral, kind, viol, note)
+    # bound-changing / control: objective must hold; node drift is a perf note.
+    neutral = not hard
+    kind = "objective_only"
+    note = "certified objective + optimal-status enforced; node drift is a perf note"
+    if node_only:
+        note += (
+            f" ({len(node_only)} instance(s) changed node_count — expected where structure present)"
+        )
+    return CertResult(neutral, kind, hard, note)
+
+
+# --------------------------------------------------------------------------- #
+# ledger (durable, append-only) + consecutive-green streak
+# --------------------------------------------------------------------------- #
+def append_ledger(verdict: Verdict, ts: str, meta: dict) -> None:
+    LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
+    row = {"timestamp": ts, **meta, **asdict(verdict)}
+    with open(LEDGER_PATH, "a") as fh:
+        fh.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def read_ledger() -> list[dict]:
+    if not LEDGER_PATH.exists():
+        return []
+    return [json.loads(ln) for ln in LEDGER_PATH.read_text().splitlines() if ln.strip()]
+
+
+def green_streak(flag: str, ledger: list[dict]) -> int:
+    """Count trailing consecutive eligible verdicts for ``flag`` (most-recent-last
+    order). Any non-eligible verdict resets the streak."""
+    streak = 0
+    for row in ledger:
+        if row.get("flag") != flag:
+            continue
+        if row.get("eligible"):
+            streak += 1
+        else:
+            streak = 0
+    return streak
+
+
+# --------------------------------------------------------------------------- #
+# the gate, per flag
+# --------------------------------------------------------------------------- #
+def evaluate_flag(
+    flag: str,
+    instances: list,
+    nl_dir: Path,
+    tl: float,
+    off_cache: dict,
+    ci_subset: bool,
+) -> Verdict:
+    env_on = gs.ARMS[flag]["env"]
+    regime = gs.ARMS[flag]["regime"]
+    notes: list[str] = []
+
+    # (2/3) cert-panel neutrality + incorrect_count (both regimes run this).
+    cert = run_cert_neutrality(flag, env_on)
+    notes.append(f"cert: {cert.note}")
+
+    if ci_subset:
+        # CI has no corpus → skip the held-out arm; verdict reports cert-only.
+        # NOT ledger-appended (a nightly-only fact). eligible here means "cert
+        # regression guard passed" — the CI signal, not graduation-eligibility.
+        notes.append(
+            "CI-SUBSET: held-out arm SKIPPED (no corpus in CI); this verdict is a "
+            "cert regression guard only, NOT a graduation verdict (not ledgered)."
+        )
+        return Verdict(
+            flag=flag,
+            eligible=cert.neutral,
+            benefit_fraction=None,
+            regression_rate=None,
+            soundness_ok=cert.neutral,
+            cert_neutral=cert.neutral,
+            regime=regime,
+            cert_kind=cert.kind,
+            cert_violations=cert.violations,
+            notes=notes,
+        )
+
+    # (1) held-out per-flag arm (isolated).
+    arm_rows = gs.run_arm(instances, nl_dir, flag, tl, off_cache=off_cache)
+    stats = gs.arm_stats(arm_rows, flag)
+    n_viol = sum(len(r.violations) for r in arm_rows)
+    soundness_ok = n_viol == 0
+    rr = stats.regression_rate
+    regression_ok = (rr is None) or (rr <= MAX_REGRESSION_RATE)
+    if stats.structural_prevalence == 0:
+        notes.append(
+            "held-out arm: 0 structure-carrying instances at this N — benefit/"
+            "regression UNMEASURED; grow N or target the stratum to get signal."
+        )
+    if not regression_ok:
+        notes.append(
+            f"regression_rate {rr:.2f} > threshold {MAX_REGRESSION_RATE:.2f} — not eligible."
+        )
+    if not soundness_ok:
+        notes.append(f"{n_viol} SOUNDNESS violation(s) in held-out arm — P0, not eligible.")
+
+    eligible = soundness_ok and cert.neutral and regression_ok
+    return Verdict(
+        flag=flag,
+        eligible=eligible,
+        benefit_fraction=stats.benefit_fraction,
+        regression_rate=rr,
+        soundness_ok=soundness_ok,
+        cert_neutral=cert.neutral,
+        regime=regime,
+        structural_prevalence=stats.structural_prevalence,
+        scored=stats.scored,
+        n_soundness_violations=n_viol,
+        cert_kind=cert.kind,
+        cert_violations=cert.violations,
+        benefit_instances=stats.benefit_instances,
+        regression_instances=stats.regression_instances,
+        notes=notes,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# reporting
+# --------------------------------------------------------------------------- #
+def write_reports(
+    verdicts: list[Verdict], args: argparse.Namespace, ts: str, out_dir: Path, ledger: list[dict]
+) -> tuple[Path, Path]:
+    def pct(x: object) -> str:
+        return f"{x * 100:.0f}%" if isinstance(x, (int, float)) else "—"
+
+    payload = {
+        "timestamp": ts,
+        "mode": "ci_subset" if args.ci_subset else "full",
+        "n": args.n,
+        "seed": args.seed,
+        "time_limit": args.time_limit,
+        "max_vars": args.max_vars,
+        "max_regression_rate": MAX_REGRESSION_RATE,
+        "green_streak_required": GREEN_STREAK_REQUIRED,
+        "verdicts": [asdict(v) for v in verdicts],
+        "streaks": {v.flag: green_streak(v.flag, ledger) for v in verdicts if not args.ci_subset},
+    }
+    js = out_dir / f"graduation_gate_{ts}.json"
+    js.write_text(json.dumps(payload, indent=2))
+
+    lines = [
+        f"# Flag-graduation gate — {'CI-subset (cert-only)' if args.ci_subset else 'full'} run",
+        "",
+        f"- Generated: {ts}",
+        f"- Mode: **{'CI-subset' if args.ci_subset else 'full (held-out arm + cert panel)'}**",
+        f"- Eligibility: 0 soundness violations AND cert-neutral AND "
+        f"regression_rate ≤ **{MAX_REGRESSION_RATE:.0%}**; graduation-eligible after "
+        f"**{GREEN_STREAK_REQUIRED}** consecutive green verdicts.",
+        "",
+        "| flag | regime | benefit | regression | soundness | cert-neutral | eligible | "
+        + ("streak |" if not args.ci_subset else "|"),
+        "|---|---|---|---|:-:|:-:|:-:|" + ("---|" if not args.ci_subset else ""),
+    ]
+    for v in verdicts:
+        streak_cell = (
+            f" {green_streak(v.flag, ledger)}/{GREEN_STREAK_REQUIRED} |"
+            if not args.ci_subset
+            else ""
+        )
+        lines.append(
+            f"| {v.flag} | {v.regime} | {pct(v.benefit_fraction)} | {pct(v.regression_rate)} | "
+            f"{'Y' if v.soundness_ok else 'N'} | {'Y' if v.cert_neutral else 'N'} | "
+            f"{'YES' if v.eligible else 'no'} |{streak_cell}"
+        )
+    for v in verdicts:
+        lines += ["", f"### {v.flag}", ""]
+        if not args.ci_subset:
+            lines.append(
+                f"- structural prevalence {v.structural_prevalence}, scored {v.scored}, "
+                f"soundness violations {v.n_soundness_violations}"
+            )
+            if v.benefit_instances:
+                lines.append(f"- benefit: {', '.join(v.benefit_instances)}")
+            if v.regression_instances:
+                lines.append(f"- regression: {', '.join(v.regression_instances)}")
+        if v.cert_violations:
+            lines.append(f"- cert violations: {v.cert_violations}")
+        for note in v.notes:
+            lines.append(f"- {note}")
+
+    md = out_dir / f"graduation_gate_{ts}.md"
+    md.write_text("\n".join(lines) + "\n")
+    return js, md
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--flags",
+        type=str,
+        default=",".join(gs.GRADUATION_ARMS),
+        help=(
+            "comma-separated parked flags to gate "
+            f"(choices: {','.join(gs.GRADUATION_ARMS)}; or 'all' for the bundle "
+            "cross-check). Default: all parked flags."
+        ),
+    )
+    ap.add_argument("--n", type=int, default=100, help="held-out sample size (nightly default 100)")
+    ap.add_argument("--seed", type=int, default=0, help="selection seed (reproducibility)")
+    ap.add_argument("--time-limit", type=float, default=30.0, help="seconds per held-out solve")
+    ap.add_argument("--max-vars", type=int, default=500, help="cap on variable count per instance")
+    ap.add_argument("--corpus", type=str, default=str(DEFAULT_CORPUS))
+    ap.add_argument("--out-dir", type=str, default=str(_REPO / "reports"))
+    ap.add_argument(
+        "--ci-subset",
+        action="store_true",
+        help=(
+            "CI-runnable subset: cert-neutrality + incorrect_count over the VENDORED "
+            "cert panel only; skips the held-out corpus arm and does NOT append to "
+            "the ledger. For .github CI where the ~4,800-instance corpus is absent."
+        ),
+    )
+    ap.add_argument(
+        "--no-ledger",
+        action="store_true",
+        help="do not append verdicts to the ledger (dry run of a full gate).",
+    )
+    args = ap.parse_args()
+
+    requested = [f.strip() for f in args.flags.split(",") if f.strip()]
+    valid = set(gs.GRADUATION_ARMS) | {"all"}
+    unknown = [f for f in requested if f not in valid]
+    if unknown:
+        print(f"# ERROR: unknown flag(s): {unknown}; choices: {sorted(valid)}", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y-%m-%dT%H-%M-%S")
+
+    instances: list = []
+    nl_dir = Path()
+    selection_meta: dict = {}
+    if not args.ci_subset:
+        corpus = Path(os.path.expanduser(args.corpus))
+        if not (corpus / "minlplib" / "nl").is_dir():
+            print(
+                f"# ERROR: corpus not found at {corpus}. The full gate needs the "
+                "MINLPLib snapshot; use --ci-subset on a machine without it.",
+                file=sys.stderr,
+            )
+            return 2
+        instances, selection_meta = gs.select_instances(corpus, args.n, args.seed, args.max_vars)
+        nl_dir = corpus / "minlplib" / "nl"
+        print(
+            f"# graduation gate (full): {len(instances)}/{args.n} held-out instances, "
+            f"seed {args.seed}, tl {int(args.time_limit)}s; flags {requested}",
+            flush=True,
+        )
+    else:
+        print(
+            f"# graduation gate (CI-subset): cert-neutrality over the vendored cert "
+            f"panel for flags {requested} (held-out arm skipped — no corpus)",
+            flush=True,
+        )
+
+    off_cache: dict = {}
+    verdicts: list[Verdict] = []
+    meta = {
+        "mode": "ci_subset" if args.ci_subset else "full",
+        "n": args.n,
+        "seed": args.seed,
+        "time_limit": args.time_limit,
+        "max_vars": args.max_vars,
+        "selection_meta": selection_meta,
+    }
+    for flag in requested:
+        print(f"\n=== gating flag: {flag} ===", flush=True)
+        v = evaluate_flag(flag, instances, nl_dir, args.time_limit, off_cache, args.ci_subset)
+        verdicts.append(v)
+        if not args.ci_subset and not args.no_ledger:
+            append_ledger(v, ts, meta)
+
+    ledger = read_ledger()
+    js, md = write_reports(verdicts, args, ts, out_dir, ledger)
+
+    print("\n─── verdicts ───", flush=True)
+    any_hard_fail = False
+    for v in verdicts:
+        streak = green_streak(v.flag, ledger) if not args.ci_subset else None
+        streak_s = f" streak {streak}/{GREEN_STREAK_REQUIRED}" if streak is not None else ""
+        grad = (
+            " → GRADUATION-ELIGIBLE"
+            if streak is not None and streak >= GREEN_STREAK_REQUIRED
+            else ""
+        )
+        print(
+            f"  {v.flag:20} eligible={'YES' if v.eligible else 'no ':3} "
+            f"benefit={_p(v.benefit_fraction)} regression={_p(v.regression_rate)} "
+            f"soundness={'ok' if v.soundness_ok else 'FAIL'} "
+            f"cert={'neutral' if v.cert_neutral else 'FAIL'}{streak_s}{grad}",
+            flush=True,
+        )
+        # A soundness or cert-objective failure is a hard, non-zero exit (P0 / CI red).
+        if not v.soundness_ok or not v.cert_neutral:
+            any_hard_fail = True
+    print(f"# JSON: {js}\n# MD:   {md}", flush=True)
+    if not args.ci_subset and not args.no_ledger:
+        print(f"# LEDGER: appended {len(verdicts)} verdict(s) to {LEDGER_PATH}", flush=True)
+    return 1 if any_hard_fail else 0
+
+
+def _p(x: object) -> str:
+    return f"{x * 100:.0f}%" if isinstance(x, (int, float)) else "—"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/dev/default-path-performance-plan-2026-07-06.md
+++ b/docs/dev/default-path-performance-plan-2026-07-06.md
@@ -117,11 +117,22 @@ structural proofs, not tuning failures). No heuristic work reaches them.
      (~60–80 integer instances, cap-off vs cap-on) flips
      `DISCOPT_ILS_SOLVE_CAP` default if **0 incumbents lost**; keep `=0` as
      the escape hatch. Expected: integer class 2.5–3× by default.
-  2. **G1.2 stand up the nightly graduation gate**: a scheduled run of
-     `generality_sweep.py` (N≈100 held-out, seeded) + the cert panel +
-     `incorrect_count = 0`, with per-flag ON arms. Three consecutive green →
-     a flag is *eligible*; flips happen in reviewed PRs. Without this, stop
-     shipping default-OFF flags at all.
+  2. **G1.2 stand up the nightly graduation gate** — **DONE** (see
+     `docs/dev/flag-graduation-protocol.md`). `generality_sweep.py` now has
+     per-flag `ARMS` (each parked flag isolated, everything else default-OFF —
+     the isolation the N=20 pilot lacked) + `run_arm`/`arm_stats`;
+     `graduation_gate.py` is the wrapper: per flag it runs the held-out arm +
+     the cert-panel neutrality check (fresh subprocess with the flag ON) +
+     `incorrect_count = 0`/no-oracle-cross, emits a machine-readable verdict
+     (`{flag, eligible, benefit_fraction, regression_rate, soundness_ok,
+     cert_neutral, notes}`), and appends it to
+     `docs/dev/data/graduation-ledger.jsonl` so 3-consecutive-green is
+     checkable. Corpus honesty (§4): the full held-out gate runs locally on a
+     corpus machine (`make graduation-gate` / documented cron); GitHub CI runs
+     only the cert-neutrality + `incorrect_count` subset over the vendored 61
+     panel (`.github/workflows/graduation-gate.yml`, `--ci-subset`). Three
+     consecutive green → a flag is *eligible*; flips happen in reviewed PRs.
+     Without this, stop shipping default-OFF flags at all.
   3. **G1.3 PSD gate → default-ON** after its single-flag arm is clean
      (its 10 % regression rate must be re-measured in isolation — the pilot
      bundled it with R2; nvs13 19→49-node regression is the known cost).

--- a/docs/dev/flag-graduation-protocol.md
+++ b/docs/dev/flag-graduation-protocol.md
@@ -1,0 +1,191 @@
+# Flag-graduation protocol (G1.2)
+
+**Status:** active instrument. Roadmap task G1.2 of
+`docs/dev/default-path-performance-plan-2026-07-06.md` (§3 G1, cause C-B).
+**What it is:** the reusable, per-flag validation gate + ledger that lets
+discopt's parked default-OFF capabilities flip to default-ON on *evidence*, not by
+hand. It is benchmark-infra + docs only — it changes **no solver math**.
+
+## Why this exists (the process gap)
+
+discopt's bound-changing regime (CLAUDE.md §5) correctly parks each new capability
+behind a default-OFF env flag "pending 3 green nightlies". But no nightly pipeline
+existed, so **nothing ever graduated** — five sound, class-validated capabilities
+sit inert on `main` (the plan's §1 table). Every future bound-changing win would
+suffer the same fate. This gate is the missing pipeline: it produces, per flag,
+the evidence a graduation PR needs, and records it durably so "3 consecutive
+green" is a checkable fact rather than a manual claim.
+
+The template is already on `main`: **ILS-cap (#532)** graduated to default-ON
+after its held-out validation. Every other flag follows the same path through this
+gate.
+
+## The parked flags
+
+| arm (this gate) | env flag(s) | regime | target structure |
+|---|---|---|---|
+| `root_fixpoint` | `DISCOPT_ROOT_FIXPOINT=1` | bound-changing | reduce-responsive box (≥1 var, ≥1 con) |
+| `node_reduce` | `DISCOPT_NODE_REDUCE=1` | bound-changing | reduce-responsive box |
+| `psd_cost_gate` | `DISCOPT_PSD_COST_GATE=1` | bound-changing | QCQP (any Q[C]P family) |
+| `lift_zero_spanning` | `DISCOPT_LIFT_ZERO_SPANNING_FACTORS=1` | bound-changing | products of zero-spanning factors (R4) |
+| `lift_loose_products` | `DISCOPT_LIFT_LOOSE_PRODUCTS=1` | bound-changing | loose composite products (TD-A) |
+
+The `off` control and the `all` bundle are also defined as arms for cross-checks
+(`all` reproduces the pre-G1.2 bundled sweep). The escape-hatch convention holds
+for every graduated flag: **`DISCOPT_X=0` restores the old behavior** — a graduated
+flag is never a dead flag, it is a default that a user can turn off.
+
+## The arms — isolation the pilot lacked
+
+The N=20 pilot ran **all** flags together (`FLAGS_ON`), so a benefit could not be
+attributed to a single capability and each flag's regression-rate was contaminated
+by its neighbours (the nvs13 19→49-node regression is PSD's, but the bundle hid it
+inside branch-and-reduce's numbers). The gate runs each parked flag as an
+**isolated arm**: it sets exactly that capability's env flags, with every other
+capability at its default OFF, against a shared `off` control. One run yields, per
+flag, its own benefit-fraction / regression-rate / soundness / structural
+prevalence.
+
+Arms live in `discopt_benchmarks/scripts/generality_sweep.py` (`ARMS`,
+`GRADUATION_ARMS`, `run_arm`, `arm_stats`). Run the sweep alone in arms mode with:
+
+```bash
+PYTHONPATH=<worktree>/python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 \
+  python discopt_benchmarks/scripts/generality_sweep.py \
+    --arms psd_cost_gate,root_fixpoint --n 100 --seed 0 --time-limit 30
+```
+
+## The gate — what it runs per flag
+
+`discopt_benchmarks/scripts/graduation_gate.py` runs, per requested flag:
+
+1. **Held-out per-flag arm** — a seeded, stratified held-out sample (excludes the
+   61 vendored panel instances + the named tuning probes), solved OFF vs the flag
+   ON in isolation. Yields `benefit_fraction`, `regression_rate`,
+   `structural_prevalence`, and any **soundness** violation (a dual bound crossing
+   the best-known primal, or a certified-optimal outside the
+   `[=bestdual=, =best=]` oracle bracket, in *either* config). The OFF control
+   solve is shared across arms, so an N-flag sweep pays for it once.
+
+2. **Cert-panel neutrality** — re-runs the cert-neutrality check
+   (`check_cert_neutrality.py`'s logic) **in a fresh subprocess with the flag ON**
+   (so the fresh interpreter reads the env flag at import) against the committed
+   41-instance `docs/dev/data/cert-baseline.jsonl`:
+   - a **bound-neutral** flag must be **byte-identical** (node_count + objective);
+   - a **bound-changing / heuristic-policy** flag must keep the certified
+     **objective** unchanged and the **optimal status** (soundness), while a
+     node_count change on a cert instance carrying the flag's structure is an
+     *expected, documented perf note*, not a fault.
+
+3. **`incorrect_count = 0` + no oracle cross** — folded into (1) and (2): the
+   held-out arm's oracle bracket is the held-out incorrect-count guard; the cert
+   panel's objective-to-tolerance is the panel incorrect-count guard. A changed
+   certified objective or a lost optimal status is a hard, non-zero-exit fail.
+
+### Eligibility thresholds (documented; global, not per-instance)
+
+A flag's verdict is `eligible` **iff**:
+
+- **0** soundness violations in the held-out arm (either config), **AND**
+- cert-neutral (objective unchanged + still optimal; node byte-identical too for a
+  bound-neutral flag), **AND**
+- `regression_rate` ≤ **`MAX_REGRESSION_RATE = 0.10`** (the documented ceiling; the
+  pilot measured branch-and-reduce at 8 % and PSD at 10 % *bundled* — the isolated
+  arms must land at or below 10 %).
+
+Changing a threshold is a reviewed decision, recorded here and in the script
+constant. These constants live at the top of `graduation_gate.py`
+(`MAX_REGRESSION_RATE`, `GREEN_STREAK_REQUIRED`).
+
+## The ledger — 3 consecutive green
+
+Every full-gate run appends one verdict per flag to
+`docs/dev/data/graduation-ledger.jsonl` (append-only, one JSON object per line).
+The verdict shape:
+
+```json
+{"timestamp": "...", "flag": "psd_cost_gate", "eligible": true,
+ "benefit_fraction": 0.33, "regression_rate": 0.0, "soundness_ok": true,
+ "cert_neutral": true, "regime": "bound_changing", "structural_prevalence": 12,
+ "scored": 11, "n_soundness_violations": 0, "cert_kind": "objective_only",
+ "cert_violations": [], "benefit_instances": ["..."], "notes": ["..."]}
+```
+
+A flag is **graduation-eligible** (ready for its flip PR) only after
+**`GREEN_STREAK_REQUIRED = 3` consecutive `eligible` verdicts** for that flag in
+the ledger — the "3 green nightlies" rule made checkable. Any non-eligible verdict
+resets the streak (`green_streak()` in the script). The gate prints the current
+streak and flags `→ GRADUATION-ELIGIBLE` when it reaches 3.
+
+## The flip is a separate, reviewed PR (never automated)
+
+The gate produces evidence; it does **not** flip a default. Graduating a flag
+(G1.3 PSD, G1.4 R2, G1.5 R4/TD-A) is a separate, reviewed PR that:
+
+1. changes the flag's default in `solver_tuning.py` / the relevant reader
+   (default OFF → default ON), keeping `DISCOPT_X=0` as the escape hatch;
+2. cites the ledger's 3 green verdicts + the held-out benefit table + the
+   cert-panel proof in the PR body;
+3. re-runs the measurement of record (`global_opt_baron_vs_discopt.py`, 60 s, 61
+   instances) with the new default and reports defaults-only numbers.
+
+**Kill criterion.** Any lost incumbent / soundness violation in an arm → that flag
+stays OFF with the instance recorded. That is the gate doing its job, not a plan
+failure (plan §3 G1 "Kill").
+
+## Local-full vs CI-subset (the honest corpus constraint)
+
+The held-out arm needs the full ~4,800-instance MINLPLib snapshot in
+`~/Dropbox/projects/discopt-minlp-benchmark/`, which **GitHub CI does not have**.
+So a corpus-wide nightly **cannot** run in GitHub Actions. The split:
+
+- **Local / nightly (corpus machine)** — the *full* gate: held-out arm +
+  cert-neutrality + ledger append. Run it with:
+
+  ```bash
+  make graduation-gate           # all parked flags, N=100, seed 0, 30 s/solve
+  # or one flag:
+  make graduation-gate GRAD_FLAGS=psd_cost_gate GRAD_N=100
+  ```
+
+  Schedule it via cron on a machine with the corpus (from the repo root):
+
+  ```cron
+  17 4 * * *  cd /path/to/discopt && PYTHONPATH=$PWD/python JAX_PLATFORMS=cpu \
+    JAX_ENABLE_X64=1 make graduation-gate >> reports/graduation-nightly.log 2>&1
+  ```
+
+  Only the full gate appends to the ledger, so only the full gate accrues the
+  3-green streak.
+
+- **CI subset (GitHub Actions)** — `.github/workflows/graduation-gate.yml`
+  (scheduled `cron:` + `workflow_dispatch`) runs **only the cert-neutrality +
+  `incorrect_count`** portion over the **vendored** cert panel (the 41 instances
+  that ARE in the repo), via `graduation_gate.py --ci-subset`. It:
+  - proves that turning a parked flag ON does not change a certified objective or
+    lose an optimal status on the panel (a regression guard);
+  - **skips** the held-out arm (no corpus) and **does not** append a ledger
+    verdict (a nightly-only fact).
+
+  Reproduce the CI subset locally with `make graduation-gate-ci`.
+
+## Determinism
+
+Selection is seeded (`--seed`, default 0): the same seed draws the same held-out
+sample and the same solve order, so a verdict is reproducible. The ledger records
+the seed + N + time-limit with each verdict.
+
+## Files
+
+- `discopt_benchmarks/scripts/generality_sweep.py` — held-out selection + the
+  per-flag `ARMS` + `run_arm`/`arm_stats` (arms mode via `--arms`).
+- `discopt_benchmarks/scripts/graduation_gate.py` — the gate wrapper (verdict +
+  ledger + CI subset).
+- `discopt_benchmarks/scripts/check_cert_neutrality.py` +
+  `discopt_benchmarks/utils/cert_neutrality.py` — the cert-baseline neutrality
+  check the gate reuses.
+- `docs/dev/data/cert-baseline.jsonl` — the 41-instance cert baseline (the
+  neutrality reference).
+- `docs/dev/data/graduation-ledger.jsonl` — the append-only verdict ledger.
+- `.github/workflows/graduation-gate.yml` — the CI subset workflow.
+- `Makefile` targets `graduation-gate` (full) and `graduation-gate-ci` (subset).


### PR DESCRIPTION
## G1.2 — flag-graduation gate + protocol

Stands up the flag-graduation gate (roadmap task G1.2 of
`docs/dev/default-path-performance-plan-2026-07-06.md`, §3 G1 / cause **C-B**):
the reusable, per-flag validation instrument + ledger that lets discopt's parked
default-OFF capabilities flip to default-ON on **evidence**, not by hand.

**Benchmark-infra + docs only — NO solver-math change.** `git diff origin/main --
python/discopt crates` is empty.

### The gap this closes
The bound-changing regime (CLAUDE.md §5) parks each new capability behind a
default-OFF flag "pending 3 green nightlies", but no nightly existed — so five
sound, class-validated capabilities are inert on `main`. This gate produces, per
flag, the evidence a graduation PR needs, and records it durably so
"3 consecutive green" is checkable. ILS-cap (#532) is the template; every other
flag now follows the same path.

### What's here
- **Per-flag arms** (`generality_sweep.py`): `ARMS` + `run_arm`/`arm_stats` +
  `--arms` mode. Each parked flag (`root_fixpoint`, `node_reduce`,
  `psd_cost_gate`, `lift_zero_spanning`, `lift_loose_products`) runs in
  **isolation** — everything else at default OFF — the isolation the N=20 pilot
  (which bundled R2+PSD) lacked.
- **The gate wrapper** (`graduation_gate.py`): per flag, runs (a) the held-out
  per-flag arm (benefit / regression / soundness bracket), (b) the cert-panel
  neutrality check in a **fresh subprocess with the flag ON** (byte-identical for
  bound-neutral flags; certified-objective-unchanged + still-optimal for
  bound-changing flags, with node drift a documented perf note), (c)
  `incorrect_count = 0` / no-oracle-cross. Emits a machine-readable verdict
  `{flag, eligible, benefit_fraction, regression_rate, soundness_ok,
  cert_neutral, notes}` + markdown.
- **Consecutive-green ledger** (`docs/dev/data/graduation-ledger.jsonl`,
  append-only): a flag is **graduation-eligible** only after **3 consecutive
  green** verdicts; the flip itself is a separate, reviewed PR.
- **CI workflow** (`.github/workflows/graduation-gate.yml`, scheduled `cron:` +
  `workflow_dispatch`): the **CI subset** — cert-neutrality + `incorrect_count`
  over the **vendored** cert panel only (`--ci-subset`), a regression guard. No
  held-out arm, no ledger append.
- **Local invocation** (`make graduation-gate` full / `make graduation-gate-ci`
  subset) + a documented cron line.
- **Protocol doc** (`docs/dev/flag-graduation-protocol.md`): arms, thresholds
  (`MAX_REGRESSION_RATE=0.10`, `GREEN_STREAK_REQUIRED=3`), the 3-green ledger,
  the reviewed-flip-PR step, the `DISCOPT_X=0` escape-hatch convention, and the
  local-full vs CI-subset split.

### The honest corpus constraint
The held-out arm needs the ~4,800-instance MINLPLib corpus in
`~/Dropbox/projects/discopt-minlp-benchmark/`, which **GitHub CI does not have**.
So a corpus-wide nightly cannot run in GitHub Actions. Split:
- **local / nightly** (corpus machine): the *full* gate (held-out arm +
  cert-neutrality + ledger) — `make graduation-gate` / the documented cron. Only
  the full gate accrues the 3-green streak.
- **CI** (GitHub Actions): only the cert-neutrality + `incorrect_count` subset
  over the vendored panel (which IS in the repo).

### Smoke test (proving the harness runs)
`graduation_gate.py --flags psd_cost_gate --n 8 --time-limit 15` ran end-to-end:

```
psd_cost_gate  eligible=no  benefit=0%  regression=25%  soundness=ok  cert=neutral  streak 0/3
```

Verdict JSON (shape): `{"flag": "psd_cost_gate", "eligible": false,
"benefit_fraction": 0.0, "regression_rate": 0.25, "soundness_ok": true,
"cert_neutral": true, "regime": "bound_changing", "structural_prevalence": 5,
"scored": 4, "cert_kind": "objective_only", "regression_instances":
["crudeoil_pooling_ct1"], "notes": [...]}` — appended to the ledger, cert-panel
neutrality portion ran (certified objective + optimal-status held; node drift a
perf note). The gate **correctly refused** to graduate psd_cost_gate (regression
25% > the 10% threshold) — the gate doing its job. Isolated, it surfaces PSD's
own cost (crudeoil_pooling_ct1 31→63 nodes) that the bundle hid. The ledger was
reset to empty for `main` (the N=8 smoke verdict is not a real nightly). This is
the harness proof, NOT a graduation run.

### Tests / checks run
- `ruff check` + `ruff format --check` clean on the new/changed scripts.
- CI workflow YAML parses (pyyaml `safe_load`).
- `graduation_gate.py --ci-subset` confirmed to enter the cert path with **no**
  corpus dependency.
- `git diff origin/main -- python/discopt crates` empty (infra-only).

Do NOT merge yet. This unblocks G1.3/G1.4/G1.5 (running the gate per flag to
graduate PSD / R2 / R4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
