### PR TITLE
fix(correctness): CUTOFF-SOUND-1 — R2 sound; gate cert-check over-strict (C-38 is the cause)

### DIFF
--- a/discopt_benchmarks/scripts/graduation_gate.py
+++ b/discopt_benchmarks/scripts/graduation_gate.py
@@ -147,25 +147,37 @@ def run_cert_neutrality(arm: str, env_on: dict[str, str]) -> CertResult:
     the committed ``cert-baseline.jsonl`` and exits non-zero on any violation. For
     a bound-changing flag, a *node_count* change on a cert instance carrying the
     flag's structure is expected and NOT a soundness fault, but a changed
-    *objective* or a lost *optimal* status is. Because the underlying check enforces
-    objective-to-tolerance and still-optimal unconditionally (its perf-class node
-    guard is separate), we run it as-is and classify: objective/status/missing
-    violations are hard fails; a lone node_regression is downgraded to a perf note
-    for a bound-changing flag."""
+    *objective* or a lost *optimal* status is.
+
+    The objective check is **regime-aware** (the CUTOFF-SOUND-1 fix). For a
+    *bound-neutral* flag the underlying ``check_neutrality`` demands byte-
+    reproducibility (~1e-8). For a *bound-changing* flag that would be a category
+    error: the flag legitimately alters the search, so its certified objective may
+    drift beyond 1e-8 while staying within *correctness* tolerance and not crossing
+    the true optimum (the ex1225 31.0 / st_e38 shape — a drift *toward* =opt=). We
+    therefore pass the ``bound_changing`` regime and the ``cert-optima.json`` oracle
+    down to ``check_neutrality``, which flags an objective only when it disagrees
+    with the TRUE optimum beyond correctness tolerance (a genuine false certificate).
+    node_regression is downgraded to a perf note for a bound-changing flag."""
     regime = gs.ARMS.get(arm, {}).get("regime", "bound_changing")
     env = dict(os.environ, JAX_PLATFORMS="cpu", JAX_ENABLE_X64="1")
     env.update(env_on)
     # Emit machine-readable violations by importing the util in the subprocess and
     # dumping JSON — reusing check_cert_neutrality's own runner + baseline so we do
-    # not fork its logic.
+    # not fork its logic. The oracle (cert-optima.json) lets the bound-changing
+    # objective check bracket against the TRUE optimum, not byte-identity.
     worker = (
         "import json, sys\n"
         f"sys.path.insert(0, {str(_BENCH_ROOT)!r}); sys.path.insert(0, {str(_REPO)!r})\n"
+        "from pathlib import Path\n"
         "from benchmarks.runner import BenchmarkConfig, BenchmarkRunner, SolverConfig\n"
-        "from scripts.gen_cert_baseline import _instance_budgets\n"
+        "from scripts.gen_cert_baseline import _instance_budgets, _CERT_OPTIMA\n"
         "from utils.cert_neutrality import check_neutrality, load_baseline\n"
         "from scripts.check_cert_neutrality import _CERT_BASELINE, _KNOWN_PERF_GATED\n"
         "baseline = load_baseline(_CERT_BASELINE)\n"
+        "_op = Path(_CERT_OPTIMA)\n"
+        "oracle = json.loads(_op.read_text()) if _op.exists() else {}\n"
+        f"regime = {regime!r}\n"
         "budgets = _instance_budgets(60.0)\n"
         "solver = SolverConfig(name='discopt', command='', solver_type='internal')\n"
         "new_rows = {}\n"
@@ -174,7 +186,8 @@ def run_cert_neutrality(arm: str, env_on: dict[str, str]) -> CertResult:
         "        time_limit=int(budgets.get(name, 60)), num_runs=1, solvers=[solver])\n"
         "    res = BenchmarkRunner(cfg)._run_discopt(solver, name, 0)\n"
         "    new_rows[name] = res.to_dict()\n"
-        "viol = check_neutrality(new_rows, baseline, known_perf_gated=_KNOWN_PERF_GATED)\n"
+        "viol = check_neutrality(new_rows, baseline, known_perf_gated=_KNOWN_PERF_GATED,\n"
+        "    regime=regime, oracle=oracle)\n"
         "print('CERTJSON:' + json.dumps([{'instance': v.instance, 'kind': v.kind,\n"
         "    'detail': v.detail} for v in viol]))\n"
     )

--- a/discopt_benchmarks/tests/test_cert_neutrality_regime.py
+++ b/discopt_benchmarks/tests/test_cert_neutrality_regime.py
@@ -1,0 +1,122 @@
+"""Regression: regime-aware certified-objective neutrality (CUTOFF-SOUND-1).
+
+The graduation gate's cert-neutrality check compares a flag-ON re-solve of the
+cert panel against ``cert-baseline.jsonl``. Its objective tolerance (``OBJ_TOL``
+1e-8) is a *byte-reproducibility* tolerance — correct for a **bound-neutral**
+change (refactor/cache), where any objective drift is a bug.
+
+For a **bound-changing** flag (a reduction/relaxation/cut behind a default-OFF env
+flag) that tolerance is a *category error*: the flag legitimately alters the search
+tree, so the certified objective may drift beyond 1e-8 while staying well within
+correctness tolerance and — crucially — landing *closer to or exactly on* the true
+optimum. The graduation gate flagged exactly this on the R2 cutoff-reduction:
+
+* ``ex1225`` node_reduce: 30.999999951817372 -> **31.0** (the true optimum),
+* ``st_e38`` root_fixpoint: 7197.727116839705 -> 7197.727148532429 (true optimum
+  7197.727148524341 — the ON value is ~1e-8 from the true optimum, the OFF baseline
+  was ~3e-5 *below* it).
+
+Both drifts are TOWARD the true optimum and inside correctness tolerance, yet the
+byte-reproducibility check flagged them as "objective" soundness violations — a
+gate false-positive. This test pins the fix: in the ``bound_changing`` regime the
+objective check brackets against the true optimum (``oracle``) with the correctness
+tolerance, so a benign toward-optimum drift is NOT a violation, while a genuine
+false certificate (a cross of the true optimum beyond correctness tolerance) STILL
+is. The default ``bound_neutral`` regime keeps byte-reproducibility unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BENCH_ROOT = Path(__file__).resolve().parents[1]
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from utils.cert_neutrality import check_neutrality  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.correctness]
+
+
+def _row(obj: float, *, status: str = "optimal", nodes: int = 7) -> dict:
+    return {"status": status, "objective": obj, "node_count": nodes}
+
+
+# The two instances the graduation gate flagged, with their exact numbers.
+EX1225_BASE = 30.999999951817372
+EX1225_ON = 31.0  # node_reduce drifts ONTO the true optimum
+EX1225_OPT = 31.0
+
+ST_E38_BASE = 7197.727116839705
+ST_E38_ON = 7197.727148532429  # root_fixpoint drifts toward opt
+ST_E38_OPT = 7197.727148524341
+
+
+def test_bound_neutral_still_byte_strict():
+    """A bound-neutral flag must reproduce the objective to ~1e-8 — the toward-opt
+    ex1225 drift (4.8e-8) IS a violation in this regime (unchanged behavior)."""
+    base = {"ex1225": _row(EX1225_BASE)}
+    new = {"ex1225": _row(EX1225_ON)}
+    viol = check_neutrality(new, base, regime="bound_neutral")
+    kinds = [v.kind for v in viol]
+    assert "objective" in kinds, "bound-neutral drift beyond 1e-8 must flag (byte-strict)"
+
+
+def test_bound_changing_toward_optimum_is_not_a_violation():
+    """The CUTOFF-SOUND-1 fix: in the bound-changing regime, a drift that lands ON
+    the true optimum (ex1225 -> 31.0) is NOT a soundness violation. This assertion
+    FAILS before the fix (the old check flagged it as 'objective')."""
+    base = {"ex1225": _row(EX1225_BASE)}
+    new = {"ex1225": _row(EX1225_ON)}
+    oracle = {"ex1225": EX1225_OPT}
+    viol = check_neutrality(new, base, regime="bound_changing", oracle=oracle)
+    assert viol == [], f"benign toward-optimum drift flagged as violation: {viol}"
+
+
+def test_bound_changing_st_e38_toward_optimum_is_not_a_violation():
+    """st_e38 root_fixpoint: ON is ~1e-8 from the true optimum, OFF baseline was
+    ~3e-5 below it. The ON value is MORE accurate — not a violation."""
+    base = {"st_e38": _row(ST_E38_BASE, nodes=3)}
+    new = {"st_e38": _row(ST_E38_ON, nodes=3)}
+    oracle = {"st_e38": ST_E38_OPT}
+    viol = check_neutrality(new, base, regime="bound_changing", oracle=oracle)
+    assert viol == [], f"toward-optimum st_e38 drift flagged as violation: {viol}"
+
+
+def test_bound_changing_still_catches_a_real_false_certificate():
+    """The fix must NOT weaken below true correctness: a certified objective that
+    crosses the true optimum by more than correctness tolerance is STILL flagged as
+    an 'objective' violation (a genuine false certificate)."""
+    # Claim optimal at 25.0 when the true optimum is 31.0 (min) — a gross wrong cert.
+    base = {"ex1225": _row(EX1225_BASE)}
+    new = {"ex1225": _row(25.0)}
+    oracle = {"ex1225": EX1225_OPT}
+    viol = check_neutrality(new, base, regime="bound_changing", oracle=oracle)
+    kinds = [v.kind for v in viol]
+    assert "objective" in kinds, "a real false certificate must still be flagged"
+
+
+def test_bound_changing_no_oracle_falls_back_to_correctness_drift():
+    """With no oracle for the instance, the bound-changing check falls back to a
+    correctness-tolerance drift bound vs baseline: a tiny drift passes, a gross one
+    is still caught."""
+    base = {"foo": _row(100.0)}
+    # tiny benign drift (within correctness tol) — not a violation
+    assert check_neutrality({"foo": _row(100.00001)}, base, regime="bound_changing") == []
+    # gross drift (well beyond correctness tol) — still a violation
+    viol = check_neutrality({"foo": _row(120.0)}, base, regime="bound_changing")
+    assert [v.kind for v in viol] == ["objective"]
+
+
+def test_bound_changing_status_and_missing_still_enforced():
+    """Regime-awareness only relaxes the *objective reproducibility* tolerance; a
+    lost optimal status or a missing instance is still a hard violation."""
+    base = {"a": _row(1.0), "b": _row(2.0)}
+    new = {"a": _row(1.0, status="feasible")}  # 'b' missing, 'a' not optimal
+    oracle = {"a": 1.0, "b": 2.0}
+    kinds = {v.kind for v in check_neutrality(new, base, regime="bound_changing", oracle=oracle)}
+    assert "status" in kinds
+    assert "missing" in kinds

--- a/discopt_benchmarks/utils/cert_neutrality.py
+++ b/discopt_benchmarks/utils/cert_neutrality.py
@@ -23,9 +23,26 @@ import json
 from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003
 
-# Objective reproducibility tolerance (matches gen_cert_baseline).
+# Objective reproducibility tolerance (matches gen_cert_baseline). This is a
+# *byte-reproducibility* tolerance: the baseline was produced by the same solver
+# math, so a bound-*neutral* change (refactor/cache/marshaling) must reproduce the
+# certified objective to ~1e-10. It is DELIBERATELY ~4 orders tighter than the
+# correctness tolerance below — for a bound-neutral change, any drift beyond it is
+# evidence the change altered the search, i.e. a bug (CLAUDE.md §5, bound-neutral
+# regime).
 OBJ_TOL = 1e-8
 OBJ_RTOL = 1e-9
+# Correctness tolerance (matches benchmarks.metrics.incorrect_count / conftest):
+# the objective disagrees with the *true optimum* only beyond this. A bound-CHANGING
+# flag (a relaxation/reduction/cut behind a default-OFF env flag) legitimately
+# changes the search tree, so its certified objective may drift beyond OBJ_TOL while
+# staying well within CORRECTNESS tolerance and (crucially) not crossing the true
+# optimum on the worsening side. Judging such a flag against OBJ_TOL is a category
+# error — it flags a *sound, more-accurate* result as a violation (the ex1225 /
+# st_e38 shape). For the bound-changing regime the objective check therefore uses
+# this correctness tolerance + an oracle-bracket guard (never cross =opt=).
+CORRECTNESS_ATOL = 1e-4
+CORRECTNESS_RTOL = 1e-3
 # Allowed node_count regression before it's a violation (one-directional guard).
 NODE_REGRESSION_FRAC = 0.05
 
@@ -48,6 +65,62 @@ def load_baseline(path: str | Path) -> dict[str, dict]:
     return out
 
 
+def _objective_violation(
+    inst: str,
+    nb: float,
+    no: float,
+    *,
+    regime: str,
+    oracle: dict[str, float] | None,
+    obj_tol: float,
+    obj_rtol: float,
+) -> NeutralityViolation | None:
+    """Decide whether the certified objective drift ``nb -> no`` is a violation.
+
+    - ``bound_neutral`` regime (default): byte-reproducibility. Any drift beyond
+      ``obj_tol + obj_rtol*|nb|`` is a violation — a bound-neutral change must
+      reproduce the certified objective exactly.
+    - ``bound_changing`` regime: the flag legitimately alters the search, so a drift
+      within *correctness* tolerance is expected and NOT a violation. It is a
+      violation only if the new objective is a **false certificate**: it disagrees
+      with the true optimum (``oracle``) by more than the correctness tolerance, OR
+      (when no oracle is available for the instance) it drifts from the baseline by
+      more than the correctness tolerance. This never masks a wrong answer — it only
+      stops flagging a sound, tolerance-accurate drift (e.g. one that lands closer to
+      or exactly on the true optimum) as a soundness fault.
+    """
+    if regime != "bound_changing":
+        if abs(no - nb) > obj_tol + obj_rtol * abs(nb):
+            return NeutralityViolation(
+                inst, "objective", f"|Δobj|={abs(no - nb):.3e} (obj {nb} -> {no})"
+            )
+        return None
+    ctol = CORRECTNESS_ATOL + CORRECTNESS_RTOL * abs(nb)
+    opt = (oracle or {}).get(inst)
+    if opt is not None:
+        # Genuine soundness: the certified value must agree with the TRUE optimum to
+        # correctness tolerance. A drift that crosses =opt= beyond tolerance is a
+        # real false certificate and is still flagged.
+        if abs(no - opt) > CORRECTNESS_ATOL + CORRECTNESS_RTOL * abs(opt):
+            return NeutralityViolation(
+                inst,
+                "objective",
+                f"certified obj {no} disagrees with true optimum {opt} "
+                f"(|Δ|={abs(no - opt):.3e} > correctness tol) — FALSE CERTIFICATE",
+            )
+        return None
+    # No oracle for this instance: fall back to a correctness-tolerance drift guard
+    # vs the baseline (still catches a gross wrong answer; tolerant of benign jitter).
+    if abs(no - nb) > ctol:
+        return NeutralityViolation(
+            inst,
+            "objective",
+            f"|Δobj|={abs(no - nb):.3e} exceeds correctness tol {ctol:.3e} "
+            f"(obj {nb} -> {no}; no oracle to bracket against)",
+        )
+    return None
+
+
 def check_neutrality(
     new_rows: dict[str, dict],
     baseline: dict[str, dict],
@@ -56,6 +129,8 @@ def check_neutrality(
     obj_rtol: float = OBJ_RTOL,
     node_regression_frac: float = NODE_REGRESSION_FRAC,
     known_perf_gated: dict[str, str] | None = None,
+    regime: str = "bound_neutral",
+    oracle: dict[str, float] | None = None,
 ) -> list[NeutralityViolation]:
     """Return the list of neutrality violations of ``new_rows`` vs ``baseline``.
 
@@ -71,6 +146,12 @@ def check_neutrality(
     non-violations; the **soundness-class** checks (``objective``, ``missing``) are
     *always* enforced. This keeps a known, tracked perf issue from blocking a
     sound, node-improving change while never masking a wrong answer.
+
+    ``regime`` selects the objective check (see :func:`_objective_violation`):
+    ``bound_neutral`` (default) demands byte-reproducibility; ``bound_changing``
+    demands agreement with the true optimum ``oracle`` (or a correctness-tolerance
+    drift bound when no oracle is present). Node-regression stays a one-directional
+    perf guard in both regimes; the caller decides whether to treat it as fatal.
     """
     perf_gated = known_perf_gated or {}
     violations: list[NeutralityViolation] = []
@@ -88,18 +169,18 @@ def check_neutrality(
                     inst, "status", f"status={new.get('status')} (baseline optimal)"
                 )
             )
-        # certified objective to tolerance (soundness-class — ALWAYS enforced).
+        # certified objective (soundness-class — ALWAYS enforced, regime-aware tol).
         nb, no = base.get("objective"), new.get("objective")
         if no is None and gated:
             pass  # a perf-gated instance that didn't certify has no objective to check
         elif nb is None or no is None:
             violations.append(NeutralityViolation(inst, "objective", f"objective {nb!r} -> {no!r}"))
-        elif abs(no - nb) > obj_tol + obj_rtol * abs(nb):
-            violations.append(
-                NeutralityViolation(
-                    inst, "objective", f"|Δobj|={abs(no - nb):.3e} (obj {nb} -> {no})"
-                )
+        else:
+            ov = _objective_violation(
+                inst, nb, no, regime=regime, oracle=oracle, obj_tol=obj_tol, obj_rtol=obj_rtol
             )
+            if ov is not None:
+                violations.append(ov)
         # node_count one-directional guard (perf-class — suppressed if perf-gated).
         base_nc, new_nc = base.get("node_count", 0), new.get("node_count", 0)
         if base_nc > 0 and new_nc > base_nc * (1.0 + node_regression_frac) and not gated:

--- a/docs/dev/cutoff-sound-1-2026-07-07.md
+++ b/docs/dev/cutoff-sound-1-2026-07-07.md
@@ -1,0 +1,200 @@
+# CUTOFF-SOUND-1 — R2 cutoff-reduction soundness triage (2026-07-07)
+
+**Verdict: R2 (root_fixpoint + node_reduce) is SOUND. The two flagged signals split
+into two distinct causes, and NEITHER is an R2 bug:**
+
+1. **Held-out arm `n_soundness_violations` (2 / 4)** — a **single genuinely
+   false-optimal instance, `kall_circles_c8a`, on the DEFAULT (all-flags-OFF)
+   path**, inherited by every arm through the shared OFF-control baseline. This is a
+   **core relaxation/branching soundness bug (C-38, P0)**, NOT caused by the R2
+   flags (flag-ON reproduces the identical wrong certificate). Filed/handed off as
+   C-38; it is out of CUTOFF-SOUND-1's scope (R2 cutoff-reduction) and belongs in a
+   separate, focused correctness PR.
+2. **Cert-panel drift (st_e38 / ex1225)** — a benign, tolerance-accurate certified
+   objective drift *toward the true optimum*, flagged only because the gate's
+   cert-neutrality objective check used a **byte-reproducibility** tolerance (~1e-8)
+   on a **bound-changing** flag. **This IS a gate false-positive (bucket B)**; this
+   PR fixes it with a regime-aware objective check (below).
+
+**The gate's held-out bracket check is NOT weakened** — it correctly caught the real
+C-38 false-optimal. Only the cert-panel *byte-reproducibility* objective tolerance
+is corrected, and only for the bound-changing regime, and it still catches a genuine
+false certificate (a cross of the true optimum beyond correctness tolerance).
+
+Branch `cutoff-sound-1` from `origin/main`. Build: `maturin develop --release`
+(pounce present). Run env `PYTHONPATH=<worktree>/python JAX_PLATFORMS=cpu
+JAX_ENABLE_X64=1`.
+
+## Part 1 — Triage (the entry experiment)
+
+### The two evidence streams the gate produces
+
+The graduation gate reports two *independent* soundness signals per flag, and the
+prompt's evidence mixes them:
+
+1. **Held-out arm `n_soundness_violations`** — `generality_sweep.check_soundness`
+   over a seeded, held-out MINLPLib sample (seed 0, N=40, tl 25s). It uses the
+   `[=bestdual=, =best=]` **bracket** from `minlplib.solu`: a dual bound crossing
+   `=best=`, or a certified-optimal objective outside the bracket, is a violation.
+   This check is already bracket-based (not byte-identity) and is correctly
+   designed.
+2. **Cert-panel drift** — `run_cert_neutrality` re-solves the 41-instance vendored
+   cert panel with the flag ON and compares the certified objective against
+   `cert-baseline.jsonl` via `utils.cert_neutrality.check_neutrality`, whose
+   objective tolerance is `OBJ_TOL=1e-8 / OBJ_RTOL=1e-9` — a **byte-reproducibility**
+   tolerance. The prompt's "cert drift on st_e38 / ex1225" are this signal.
+
+The prompt's `n_soundness_violations=2` (root_fixpoint) / `=4` (node_reduce) and the
+named "cert drift" instances (st_e38, ex1225) are the same underlying phenomenon
+surfaced through the two signals: a legitimate, tolerance-accurate objective drift
+under a bound-changing flag.
+
+### The named cert-panel drifts (reproduced exactly on this build)
+
+`minlplib.solu` gives the **exact** optimum for both instances as `=opt=` (NOT
+`=best=` — note `load_solu` only parses `=best=`/`=bestdual=`, so these two never
+even enter the held-out selection; they are cert-panel instances). `cert-optima.json`
+carries the true optima for the panel.
+
+| instance | flag | OFF obj | ON obj | true opt (`=opt=`/cert-optima) | \|ON−opt\| | correct (abs 1e-4 / rel 1e-3)? | dual bound (ON) | bound ≤ opt? | drift direction |
+|---|---|---|---|---|---:|:-:|---|:-:|---|
+| st_e38 | root_fixpoint | 7197.727116839705 | 7197.727148532429 | 7197.727148524341 | 8.1e-09 | **yes** | 7197.727116826533 | yes | **toward opt** (OFF was 3.2e-5 *below* opt; ON is ~1e-8 from it) |
+| ex1225 | node_reduce | 30.999999951817372 | **31.0** | 31.0 | 0.0 | **yes** | 31.0 | yes | **onto opt** (exact) |
+| ex1225 | root_fixpoint | 30.999999951817372 | 30.999999968717816 | 31.0 | 3.1e-08 | **yes** | 30.999999968717820 | yes | toward opt |
+
+In every case: (a) the flag-ON objective agrees with the TRUE optimum to
+**correctness** tolerance (`incorrect_count` = 0), (b) the ON objective is **closer
+to** (st_e38, ex1225-root) or **exactly on** (ex1225-node) the true optimum than the
+OFF baseline, and (c) the dual bound never crosses the true optimum. Node counts are
+identical (st_e38 3→3, ex1225 7→7) — this is not even a search-tree divergence; the
+tighter root box lands the incumbent on a slightly different, more-accurate vertex.
+
+The cert-neutrality check flags these because the drift exceeds the **1e-8
+byte-reproducibility** threshold (`|Δobj|=3.17e-5 > 8.2e-6` for st_e38;
+`4.82e-8 > 4.1e-8` for ex1225) — roughly **four orders of magnitude tighter** than
+the actual correctness gate (`benchmarks.metrics.incorrect_count`, abs 1e-4 / rel
+1e-3). That tolerance is right for a **bound-neutral** change (a refactor must
+reproduce the objective exactly) but a **category error** for a **bound-changing**
+flag (a reduction that, by design, changes the search).
+
+### Held-out arm (seed 0, N=40, tl 25s) — the `n_soundness_violations` source
+
+The graduation gate's `n_soundness_violations` come from `generality_sweep.run_arm`
+→ `check_soundness` on the held-out sample, using the `[=bestdual=, =best=]`
+bracket. Critically, `run_arm` computes `check_soundness` for **both** the OFF
+control and the arm's ON solve, and the OFF control is **shared (cached) across all
+arms**. So an OFF-control violation is counted in *every* arm — which is exactly the
+pattern the graduation gate saw: **all five parked flags reported the same base
+count** (node_reduce 4, psd_cost_gate 4, lift_zero_spanning 4, lift_loose_products
+4; root_fixpoint 2 — root_fixpoint's tightening changes the count on 2 of the OFF
+violations).
+
+The offending instance is **`kall_circles_c8a`** (a circle-packing QCQP). On the
+DEFAULT (flags-OFF) path, discopt certifies (reproduced on this branch's build):
+
+```
+status=optimal  obj=3.6142347590019357  bound=3.6142347419851370  nodes=3  gap=0.0
+```
+
+but the MINLPLib oracle is `=best=`=**2.5409191380**, `=bestdual=`=2.5409129340.
+For a **minimize** problem (`.nl` `O0 0`) the certified dual **lower** bound
+3.6142 **exceeds a feasible objective 2.5409** — an impossible bound, a genuine
+FALSE CERTIFICATE. It reproduces **byte-identically flag-ON** (node_reduce ON:
+`obj=3.6142…, bound=3.6142…, 3 nodes`), proving it is a **core** bug, not an R2
+effect.
+
+Localization lead (for C-38): the **root McCormick LP bound is valid** (`-1e-9`,
+≤ 2.5409) — so the root relaxation is sound. The bound then **climbs to 3.6142 over
+3 nodes**, crossing the true optimum. The invalid bound is introduced during
+**branching / per-node processing** (a presolve/FBBT or spatial reduction that
+over-tightens a node box on the non-overlap `(xi−xj)²+(yi−yj)² ≥ (ri+rj)²`
+structure, removing the region containing the 2.5409 optimum, so the surviving
+nodes' bounds exceed the true optimum). Core layer, flags OFF — `crates/discopt-core`
+presolve/FBBT or the spatial-branch node reduction, not `_jax/{root,node}_reduce.py`.
+
+## Part 2 — Bucket classification
+
+| flagged signal | instance(s) | bucket | why |
+|---|---|---|---|
+| cert-panel drift | st_e38 (root_fixpoint) | **B** (gate false-positive) | ON obj within correctness tol of, and closer to, true opt 7197.7271490; bound ≤ opt; flagged only by the 1e-8 byte-repro tolerance |
+| cert-panel drift | ex1225 (node_reduce) | **B** (gate false-positive) | ON obj is **exactly** true opt 31.0; the drift *fixes* a 4.8e-8 baseline inaccuracy; flagged only by the 4.1e-8 byte-repro tolerance |
+| held-out arm | `kall_circles_c8a` | **A** (GENUINE), but **core / flag-independent** | default-path dual bound 3.6142 > feasible 2.5409 (min) — a real false certificate; inherited by every arm via the shared OFF baseline; **not caused by R2** → C-38 |
+
+**R2 itself introduces zero soundness violations.** Every R2-attributable signal is
+either the shared-baseline C-38 (a core bug) or a bucket-B cert-panel drift. R2's
+design invariants hold (tighten-only intersection; `objective <= cutoff` is a
+non-strict inequality so the optimum is never removed; NS-safe bounds only).
+
+## The fix (gate soundness-check correction, not solver math)
+
+The over-strict check is `utils.cert_neutrality.check_neutrality`'s objective
+tolerance applied to a bound-changing flag. The fix makes that check **regime-aware**:
+
+- `check_neutrality(..., regime="bound_neutral")` (**default, unchanged**) keeps the
+  1e-8 byte-reproducibility tolerance. `check_cert_neutrality.py` (the default-OFF
+  main / CI 41-panel guard) uses this default, so the vendored-panel regression
+  guard is untouched.
+- `check_neutrality(..., regime="bound_changing", oracle=<cert-optima>)` judges the
+  certified objective against the **true optimum** with the **correctness**
+  tolerance (abs 1e-4 / rel 1e-3, matching `incorrect_count`). An objective is a
+  violation only when it disagrees with `=opt=` beyond correctness tolerance (a
+  genuine false certificate) — a benign toward-optimum drift is not. When no oracle
+  exists for an instance, it falls back to a correctness-tolerance drift bound vs
+  the baseline (still catches a gross wrong answer).
+
+`graduation_gate.py::run_cert_neutrality` passes the flag's `regime`
+(`gs.ARMS[flag]["regime"]`) and loads `cert-optima.json` as the oracle into the
+worker. Node-regression stays a downgraded perf note for bound-changing flags
+(pre-existing behavior). Status / missing-instance violations stay hard fails.
+
+**The gate is NOT weakened below true correctness:** a certified objective crossing
+the true optimum beyond correctness tolerance is still an `objective` hard fail
+(unit test `test_bound_changing_still_catches_a_real_false_certificate`), and the
+held-out arm's `[=bestdual=, =best=]` bracket check is unchanged.
+
+### Before / after on the flagged instances
+
+- **Pre-fix** (byte-strict default): ex1225 31.0 drift flags
+  `objective |Δobj|=4.818e-08`; st_e38 flags `objective |Δobj|=3.169e-05`.
+- **Post-fix** (`bound_changing` + oracle): both clear (0 objective violations) —
+  the certified value agrees with `=opt=` to correctness tolerance.
+
+Reproduced directly:
+```
+pre-fix (byte-strict default): flags = [('objective', '|Δobj|=4.818e-08 ...31.0')]
+post-fix (bound_changing+oracle): flags = []
+```
+
+## R2's corrected verdict
+
+With the cert-panel objective check corrected and C-38 identified as the true owner
+of the held-out violations, **R2 has 0 R2-attributable soundness violations**. Its
+graduation blocker is **performance** (held-out `regression_rate` 0.20 > the 0.10
+threshold), not soundness — a perf concern, out of scope for this correctness task.
+
+R2 still FIRES and helps (seed 0, N=40, tl 25s, this build): root_fixpoint benefits
+`spring` (49→27 nodes), `tln12` (639→607); node_reduce benefits `sonet22v5` (7→3),
+`tln12` (607→575), `spring` (49→45). The gate fix does not disable the reduction.
+
+## C-38 (handoff) — default-path false-optimal on `kall_circles_c8a`
+
+A genuine core P0, discovered during this triage but **separate from CUTOFF-SOUND-1's
+scope** (R2 cutoff-reduction). Reproduce (flags OFF): `from_nl(kall_circles_c8a.nl)
+.solve(time_limit=60)` → `optimal obj=3.6142 bound=3.6142 3 nodes`, true min 2.5409.
+Root McCormick bound is valid (≈0); the invalid bound appears during branching. Fix
+belongs in `crates/discopt-core` presolve/FBBT or the spatial-branch node reduction.
+Handed to a fresh agent (own PR `fix(correctness): C-38 …`) per one-task-per-PR.
+
+## Gates run
+
+- `pytest discopt_benchmarks/tests/test_cert_neutrality_regime.py` — 6 passed
+  (the two toward-optimum tests FAIL on `origin/main` / byte-strict default, pass
+  after the fix; a real false certificate still flags).
+- `ruff check` + `ruff format --check` on the three changed files — clean.
+- `mypy --ignore-missing-imports` on the two changed modules (strict config) — clean.
+- `pytest -m smoke` (benchmark + repo) — see PR body.
+- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — see PR body.
+- No `python/discopt/` files touched → the pre-commit mypy hook
+  (scoped to `python/discopt/`) and the default-OFF 41-panel cert guard
+  (`check_cert_neutrality.py`, which calls `check_neutrality` with the unchanged
+  `bound_neutral` default) are unaffected. No Rust touched → no `cargo test`.


### PR DESCRIPTION
## CUTOFF-SOUND-1 — triage: R2 cutoff-reduction is SOUND; the gate's cert-panel check was over-strict; C-38 is the real bug

**Triage-first** per the task. The graduation gate flagged apparent soundness
violations on R2 (`root_fixpoint`, `node_reduce`). Reproduced at the gate's exact
config (seed 0, N=40, tl 25s) on a release build. The signals split into two
distinct causes, **neither an R2 bug**:

### (A) Held-out `n_soundness_violations` → a real, CORE, flag-independent bug (C-38)

The gate's `n_soundness_violations` (root_fixpoint 2, node_reduce 4 — and psd 4,
lift_zero_spanning 4, lift_loose_products 4) trace to a **single** genuinely
false-optimal instance, **`kall_circles_c8a`**, on the **DEFAULT (all-flags-OFF)**
path:

```
status=optimal  obj=3.6142347590  bound=3.6142347420  nodes=3   (minimize)
oracle: =best= 2.5409191380   =bestdual= 2.5409129340
```

The certified dual **lower** bound 3.6142 **exceeds a feasible objective 2.5409** —
an impossible bound, a genuine false certificate. It reproduces **byte-identically
flag-ON** (node_reduce ON: `obj=3.6142, bound=3.6142, 3 nodes`), so it is a **core**
relaxation/branching bug, **not** caused by R2. It contaminates every arm because
`generality_sweep.run_arm` checks soundness on the **shared, cached OFF control**,
so one OFF-baseline violation is counted in all five arms.

Lead for C-38: the **root McCormick LP bound is valid** (~0 ≤ 2.5409); the bound
climbs to 3.6142 over 3 nodes → the invalid bound is introduced during
**branching / per-node presolve**, in `crates/discopt-core` (flags OFF), not
`_jax/{root,node}_reduce.py`. **Handed off as its own `fix(correctness): C-38 …`
PR** per one-task-per-PR.

### (B) Cert-panel drift (st_e38, ex1225) → a gate FALSE-POSITIVE — fixed here

| instance | flag | OFF obj | ON obj | true opt | \|ON−opt\| | correct? | drift |
|---|---|---|---|---|---:|:-:|---|
| ex1225 | node_reduce | 30.999999951817372 | **31.0** | 31.0 | 0.0 | yes | onto opt |
| st_e38 | root_fixpoint | 7197.727116839705 | 7197.727148532429 | 7197.727148524341 | 8.1e-9 | yes | toward opt (OFF was 3.2e-5 *below* opt) |

Both are tolerance-accurate certified-objective drifts **toward the true optimum**,
flagged only because the cert-neutrality objective check used a **1e-8
byte-reproducibility** tolerance on a **bound-changing** flag — ~4 orders tighter
than the actual correctness gate (`incorrect_count`, abs 1e-4 / rel 1e-3). A
category error.

## The fix (gate infra only — no solver math)

`utils.cert_neutrality.check_neutrality` gains a **regime-aware** objective check:

- `regime="bound_neutral"` (**default, unchanged**): byte-reproducibility (~1e-8).
  `check_cert_neutrality.py` (the default-OFF 41-panel CI guard) uses this default,
  so the vendored-panel regression guard is untouched.
- `regime="bound_changing"` + `oracle` (cert-optima.json): the certified objective
  is a violation only if it disagrees with the **true optimum** beyond correctness
  tolerance (a genuine false certificate), or — with no oracle — drifts from the
  baseline beyond correctness tolerance. A benign toward-optimum drift is not.

`graduation_gate.run_cert_neutrality` passes the flag's `regime` and loads
`cert-optima.json` as the oracle. **The held-out bracket check is NOT weakened** —
it correctly caught the real C-38 false-optimal; only the cert-panel
byte-reproducibility tolerance is corrected, and it still catches a genuine false
certificate.

## R2's corrected verdict

R2 introduces **0 R2-attributable soundness violations**. Its graduation blocker is
**performance** (held-out `regression_rate` 0.20 > 0.10), not soundness — out of
scope for this correctness task. R2 still fires and helps (root_fixpoint: spring
49→27, tln12 639→607; node_reduce: sonet22v5 7→3, tln12 607→575).

## Tests / gates

- **New** `discopt_benchmarks/tests/test_cert_neutrality_regime.py` (6 tests) — the
  ex1225 / st_e38 toward-optimum cases **fail on `origin/main`** (no `regime` kwarg
  / byte-strict) and **pass after**; a real false certificate (obj 25 vs true opt
  31) still flags; status/missing still enforced.
- `pytest discopt_benchmarks/tests/ -m smoke` — **49 passed, 1 skipped**.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**.
- `ruff check` + `ruff format --check` (v0.14.6) on the 3 changed files — clean.
- `mypy --ignore-missing-imports` (strict) on the 2 changed modules — clean.
- No `python/discopt/` or Rust touched → pre-commit mypy hook (scoped to
  `python/discopt/`) and `cargo test` unaffected; committed WITHOUT `--no-verify`.

Findings doc: `docs/dev/cutoff-sound-1-2026-07-07.md` (per-instance triage table,
bucket split, C-38 root-cause lead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
