### PR TITLE
perf(graduate): G1.5 — lift_zero_spanning default-ON (gate-validated post-C-38)

### DIFF
--- a/python/discopt/_jax/factorable_reform.py
+++ b/python/discopt/_jax/factorable_reform.py
@@ -72,7 +72,8 @@ _INF_THRESH = 1e15
 
 
 def _lift_zero_spanning_factors_enabled() -> bool:
-    """R4 feature flag (``DISCOPT_LIFT_ZERO_SPANNING_FACTORS``, default OFF).
+    """R4 feature flag (``DISCOPT_LIFT_ZERO_SPANNING_FACTORS``, default **ON** since
+    G1.5; ``DISCOPT_LIFT_ZERO_SPANNING_FACTORS=0`` is the escape hatch).
 
     When a product ``f(x)·g(x)`` has a *non-atomic* factor ``f`` whose interval
     spans 0, the factorable reform already lifts ``w == f`` to a bounded aux (via
@@ -84,13 +85,23 @@ def _lift_zero_spanning_factors_enabled() -> bool:
     ``w·g`` (with ``g ≥ 0``) responds sharply — it is the only move that un-pins
     the bound (st_e36: root −304.5, pinned for every x-box, jumps to ≈ optimum
     once ``w`` is split at 0; see uncertified-tail-plan §3 R4). This flag marks
-    those specific auxes so the solver keeps them branchable. Default OFF keeps
-    the reform byte-identical (no tagging, so the deprioritization set is
-    unchanged).
+    those specific auxes so the solver keeps them branchable.
+
+    Structure-gated: where no product has a zero-spanning non-atomic factor, no aux
+    is tagged and the reform is byte-identical (inert) — so this flag is a free win
+    on-structure (st_e36 feasible→optimal) and invisible elsewhere. Graduated to
+    default-ON (G1.5-redo, post-C-38) on gate evidence: the isolated held-out arm
+    (N=40, seed 0, tl 25 s) verdicts eligible — 0 soundness violations, cert-neutral
+    (bound-changing regime), regression 3.8 % (1 off-structure timing artifact, ≪
+    the 10 % ceiling) — plus the bound-changing verification (differential dual
+    bound tighter but still ≤ =opt= on st_e36: −304.5 → −246.02 ≤ −246.0;
+    feasible-point sample recovers the identical incumbent ON vs OFF). See
+    ``docs/dev/flag-graduation-redo-2026-07-07.md``. ``=0`` restores the old
+    byte-identical (no-tagging) behavior.
     """
     import os
 
-    return os.environ.get("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", "0") == "1"
+    return os.environ.get("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", "1") != "0"
 
 
 def _lift_loose_products_enabled() -> bool:

--- a/python/tests/test_factorable_reform.py
+++ b/python/tests/test_factorable_reform.py
@@ -557,15 +557,25 @@ def _st_e36_shaped(name="zsf"):
     return m
 
 
-def test_r4_default_off_no_tagging(monkeypatch):
-    """Flag OFF (default): no aux is tagged, so the branching set is unchanged."""
+def test_r4_default_on_tags_and_escape_hatch(monkeypatch):
+    """G1.5 (post-C-38): the R4 zero-spanning-factor lift is ON by default, and
+    ``DISCOPT_LIFT_ZERO_SPANNING_FACTORS=0`` is the escape hatch that restores the
+    old byte-identical (no-tagging) branching set. The lift itself always happens
+    (the aux exists); only the *tagging* is what the flag gates."""
+    # Default (env absent): ON — the zero-spanning factor aux is tagged.
     monkeypatch.delenv("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", raising=False)
     m = _st_e36_shaped()
     assert has_factorable_work(m)
     m2 = factorable_reformulate(m)
-    # The lift still happens (the aux exists) — only the *tagging* is gated.
     assert _aux_names(m2), "the zero-spanning factor should still be lifted"
-    assert getattr(m2, "_zero_spanning_factor_auxes", set()) == set()
+    assert getattr(m2, "_zero_spanning_factor_auxes", set()), (
+        "default-ON must tag the zero-spanning product factor for branching"
+    )
+    # Escape hatch: "0" restores the old no-tagging behavior (aux still lifted).
+    monkeypatch.setenv("DISCOPT_LIFT_ZERO_SPANNING_FACTORS", "0")
+    m_off = factorable_reformulate(_st_e36_shaped())
+    assert _aux_names(m_off), "the aux is still lifted with the hatch on"
+    assert getattr(m_off, "_zero_spanning_factor_auxes", set()) == set()
 
 
 def test_r4_flag_on_tags_zero_spanning_factor(monkeypatch):


### PR DESCRIPTION
## G1.5 — graduate `lift_zero_spanning` to default-ON (gate-validated, post-C-38)

Flips the R4 zero-spanning product-factor lift (`DISCOPT_LIFT_ZERO_SPANNING_FACTORS`)
from default-OFF to **default-ON**, with `DISCOPT_LIFT_ZERO_SPANNING_FACTORS=0`
preserved as the escape hatch (restores the old byte-identical no-tagging behavior).
When a product `f(x)·g(x)` has a non-atomic factor `f` whose interval spans 0, the
reform lifts `f` to a bounded aux and (with this flag) keeps it branchable —
splitting `f`'s sign at 0 is the only move that un-pins the McCormick product bound.
**Structure-gated:** where no product has a zero-spanning non-atomic factor, nothing
is tagged and the reform is byte-identical (inert) — a free win on-structure,
invisible elsewhere.

### Why now
The first graduation run found this flag cert-neutral + fires + sound but
**INELIGIBLE**, blocked only by **C-38** (`kall_circles_c8a` false-optimal on the
default path contaminating the shared OFF control). **C-38 (#536)** + the
**regime-aware cert-neutrality fix (#535)** are now on `main`.

### Re-verdict (post-C-38), `graduation_gate.py --flags lift_zero_spanning --n 40 --seed 0 --time-limit 25`
| metric | first run | this run |
|---|---|---|
| eligible | no | **YES** |
| soundness_ok | N (C-38 in OFF control) | **Y** (0 violations) |
| cert_neutral | Y | **Y** (bound-changing regime) |
| regression_rate | 8% | **3.8%** (1/26, sonet22v5 — off-structure timing artifact) |

`kall_circles_c8a/c6b/c6c` all solved `feasible` with no VIOL this run. Ledger banks
**green #1** (streak 1/3).

### Bound-changing verification (CLAUDE.md §5), real `st_e36.nl`
- **Differential dual bound:** OFF `feasible, bound −304.49` (root pinned, cannot
  certify) → ON `optimal, bound −246.019` — **tighter** (ON ≥ OFF) AND still ≤
  `=opt= −246.0` (valid underestimator, never crosses opt).
- **Feasible-point sample:** ON incumbent `{x0=5, x1=20}` **identical** to OFF, both
  `−246.0 = =opt=` — no valid point cut.
- **Fire-check:** st_e36 `feasible→optimal` status upgrade is the fire signal.
- **Cert-neutrality** (standalone, bound_changing, 41-panel): **NEUTRAL** — 0 hard
  violations, **0 node-drift** (the panel carries no zero-spanning structure → the
  flag is fully inert there; structure-narrow inertness confirmed).

### Flip authority
Green #1 (streak 1/3). Flipped here under the plan's single-validation rule
(eligible, wide-margin: 3.8% regression ≪ 10% ceiling, 0 soundness violations,
cert-neutral + the differential/feasible-point verification), mirroring the ILS-cap
(#532) graduation. A structure-narrow but sound + cert-neutral flag is a valid
default-ON (inert where absent). The `=0` escape hatch keeps the flip reversible.

### Gates run (release build, `pounce-solver 0.7.0`)
- `ruff check` + `ruff format --check`: clean
- pre-commit **mypy**: Passed
- `pytest test_factorable_reform.py + test_factorable_lift_coverage.py`: 59 passed
  (incl. `test_r4_default_on_tags_and_escape_hatch`, which replaces the old
  `test_r4_default_off_no_tagging`)
- `pytest -m smoke`: 617 passed, 14 skipped
- `pytest -m slow test_adversarial_recent_fixes.py`: 10 passed
- No Rust touched (no `cargo test` needed)

### ⚠️ Pre-existing (flip-independent) failure surfaced — NOT introduced here
`test_r4_flag_on_unpins_pinned_product` (slow) fails on this machine/build: its
**synthetic** `_st_e36_shaped` probe stays pinned at −304.5 in *both* arms within
the 60s budget (a wall-clock race its docstring flags as machine-dependent), so the
≥25% un-pin **performance** claim fails. Its **soundness** asserts (bound never
crosses opt) PASS. **Confirmed the identical failure on `origin/main`** with the
source reverted — both arms set the env explicitly, so the default-flip cannot
affect it. The **real** `st_e36.nl` un-pins correctly (−304.5 → −246.02 optimal,
measured above). Left untouched (not weakened to pass); out of scope for this
graduation. Recommend a follow-up issue to make the synthetic probe budget-robust
or assert only soundness.

Findings: `docs/dev/flag-graduation-redo-2026-07-07.md` (added in the G1.3 PR #537).
Companion PR (G1.3): `psd_cost_gate` default-ON (#537). Closes G1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
