### PR TITLE
perf(governor): G2 — hit-rate-adaptive root-heuristic scheduling

### DIFF
--- a/docs/dev/g2-effort-governor-2026-07-07.md
+++ b/docs/dev/g2-effort-governor-2026-07-07.md
@@ -1,0 +1,270 @@
+# G2 — the effort governor: hit-rate-adaptive root-heuristic scheduling (2026-07-07)
+
+**Status:** built + shipped behind a **default-OFF** env flag
+(`DISCOPT_HEURISTIC_GOVERNOR`). Entry experiment GENERALIZES; governor
+implemented, verified firing, cert-neutral by default, incumbent-quality
+unchanged. Graduation to default-ON goes through the G1.2 flag gate later.
+**Branch:** `g2-effort-governor` at `origin/main` (4fd2d0ef).
+**Plan:** `docs/dev/default-path-performance-plan-2026-07-06.md` §2 (C-A) + §3 G2;
+sensor `docs/dev/nlp-solve-volume-2026-07-06.md` (VOLUME-1).
+**Regime:** heuristic-policy (CLAUDE.md §5) — certified `objective` unchanged;
+`incorrect_count = 0`; incumbent-at-time-limit not degraded; node_count *may*
+shift (it does on a few instances; documented below). Default-OFF: the solve
+path is byte-identical with the flag unset.
+
+> **Method.** Apple M4 Pro (arm64), Python 3.12, JAX 0.10.2 (`JAX_PLATFORMS=cpu`,
+> `JAX_ENABLE_X64=1`), pounce 0.7.0 (release wheel `_pounce.abi3.so` = **4.7 MB**,
+> verified NOT debug), `maturin develop --release`. Instances from
+> `python/tests/data/minlplib_nl/` + the MINLPLib snapshot
+> (`~/Dropbox/projects/discopt-minlp-benchmark/`). Sensor: VOLUME-1's
+> `discopt_benchmarks/scripts/nlp_solve_volume.py` (per-call-site NLP-solve
+> attribution + per-source incumbent-improvement hit rate), unchanged. All solves
+> `time_limit=60, gap_tolerance=1e-4`, one instance at a time.
+
+---
+
+## 0. Executive summary
+
+The entry experiment **GENERALIZES**. On a pooled replay of the easy panel +
+a 20-instance held-out slice (27 instances that solve), **two expensive
+nested-B&B heuristic sources beyond the already-capped ILS have a 0 % pooled
+incumbent hit-rate and material wall-share**:
+
+| source | pooled solves | pooled NLP wall-share | incumbent hit-rate |
+|---|---:|---:|---:|
+| **rens** (nested B&B) | 805 | **14.3 %** | **0 / 13 (0.0 %)** |
+| **rins** (LNS dive)   | 440 | **10.4 %** | **0 / 143 (0.0 %)** |
+
+On the 21 *finished* easy instances **RENS alone is 33 % of total solve wall**
+at a 0 % hit rate. On every instance the incumbent came from the root
+multistart (start #1); the expensive improvers did the work and found nothing —
+the C-A pattern, generalized past ILS.
+
+**Scope narrowed by the cert panel (correctness first, CLAUDE.md §4).** The
+initial governor throttled rens AND rins/local_branching (all 0 %-hit on the
+easy+held-out pool). The cert-neutrality panel then **caught a degraded
+certificate**: on the convex-nonseparable class (`cvxnonsep_psig30`) rins /
+local_branching ARE load-bearing — throttling them lost the better incumbent
+(78.9989 → 79.0024) and the solve certified the *worse* point at the gap
+tolerance. The measurement wins: the governed set was narrowed to **rens only**
+— the source whose 0 %-hit holds on every class tested AND that carries the
+dominant wall (its whole nested B&B fired once at the root). rins /
+local_branching / enumerate keep their existing `_improver_allowed` node-budget
+contingent and are NOT governed.
+
+Final: **easy-class geomean wall 1.77 s → 1.46 s (1.21×)** (m3 2.08×, fac2
+1.40×), all-20 panel+held-out geomean **1.28×**, **0 certified-objective changes
+(cert panel NEUTRAL with the governor ON), 0 lost incumbents, 0 instances >10 %
+slower**, and the governor is **verified firing** (it threw out RENS on 12 of 20
+instances).
+
+---
+
+## 1. Entry experiment — the per-source pooled table (decision input)
+
+Pooled across 27 solving instances (panel: m3, fac2, nvs06, nvs08, nvs13,
+ex1224, nvs24[TL], st_e35[TL], st_e36[TL]; held-out: ex1222, st_e15, synthes1,
+procsel, ex1223, st_e14, synthes2, flay02m, synthes3, spring, batchdes, syn05m,
+fac1, flay03m, csched1a[TL], gear2, ex3pb[TL], syn10m — portfol_buyin/card
+excluded: binary-`.nl` unreadable). Pooled NLP wall = 156 s.
+
+| source | solves | wall (s) | wall-share | entry calls | hits | hit-rate |
+|---|---:|---:|---:|---:|---:|---:|
+| `_solve_node_nlp_pounce` (dual-bound engine) | 2316 | 77.3 | 49.5 % | — | — | n/a (never cuttable) |
+| integer_local_search (already capped #532) | 644 | 23.6 | 15.1 % | 13 | 0 | 0.0 % |
+| **rens** | 805 | 22.3 | **14.3 %** | 13 | **0** | **0.0 %** |
+| **rins** | 440 | 16.3 | **10.4 %** | 143 | **0** | **0.0 %** |
+| local_branching | 79 | 5.8 | 3.7 % | 12 | 0 | 0.0 % |
+| feasibility_pump | 65 | 5.8 | 3.7 % | 38 | 0 | 0.0 % |
+| fractional_diving | 82 | 3.3 | 2.1 % | 15 | 0 | 0.0 % |
+| subnlp (generic inner label) | 20 | 1.0 | 0.6 % | 1008 | 2 | 0.2 % |
+| integer_box_search | 57 | 0.7 | 0.4 % | 19 | 0 | 0.0 % |
+| **`_solve_root_node_multistart`** (finder) | — | — | — | **39** | **27** | **69.2 %** |
+
+The load-bearing source is unambiguous: `_solve_root_node_multistart` produced
+the incumbent on **every** instance (69 % pooled hit-rate = 100 % where it runs
+once, 50 % where it runs twice). Every expensive improver has a **0 % hit-rate**.
+Per-instance confirmation (rens/rins solves vs their hits vs multistart):
+
+```
+m3     rens 131 hits 0/1   rins 25 hits 0/10   multistart 1/2
+fac2   rens 179 hits 0/1   rins 17 hits 0/6    multistart 1/2
+flay03m rens 194 hits 0/1  rins 42 hits 0/15   multistart 1/2
+gear2  rens 0             rins 192 hits 0/17   multistart 1/1
+ex3pb  rens 0             rins 58 hits 0/24    multistart 1/1
+... (every instance: improvers 0 hits, multistart is the incumbent source)
+```
+
+`rens`/`rins` return `(x, obj)` or `None` and the caller injects only on
+improvement — so the entry-wrapper's 0-hit measurement reads their actual return
+value; it is not a side-channel artifact. The 0 % is real.
+
+### Decision: GENERALIZE (build)
+
+≥2 sources **beyond** the capped ILS cleared the entry bar (~0 % pooled hit-rate
+AND ≥5 % root wall-share): rens (14.3 %) and rins (10.4 %) — and on the finished
+easy class RENS is 33 % of *total* solve wall. Distinct nested-B&B / sub-MIP
+sources the ILS cap does not touch. Build. (The subsequent cert-panel check then
+narrowed which of them is *safe* to throttle — see §2.)
+
+---
+
+## 2. The governor — design
+
+`python/discopt/heuristic_governor.py`: a process-lifetime `HeuristicGovernor`
+singleton holding per-**source-class** running stats
+(`calls, hits, consecutive_misses, disabled`). Global constants (documented, NOT
+per-instance / per-name — CLAUDE.md §2):
+
+* **Only rens is governed.** `GOVERNED_SOURCES = EXPENSIVE_SOURCES = {"rens"}`.
+  A source not in this set is always allowed and accrues no throttle. The entry
+  experiment also flagged rins/local_branching as 0 %-hit, but the cert panel
+  proved them **load-bearing on the convex-nonseparable class** (see the box
+  below) — so they are left to the existing `_improver_allowed` node-budget
+  contingent and are NOT throttled here. RENS is the one source whose 0 %-hit
+  holds across every class tested AND that carries the dominant wall (a whole
+  nested B&B fired once at the root).
+* **Cheap finders are never governed.** Multistart, feasibility_pump,
+  fractional_diving, integer_box_search, and the already-capped
+  integer_local_search — securing the first incumbent for pruning always wins.
+* **Throttle-after-k-misses.** RENS, after `K_DISABLE = 2` consecutive class
+  misses, is **disabled for the rest of the process**. Any hit resets the streak
+  and re-enables it. The memory is cross-*solve* deliberately: RENS fires once
+  per solve, so a per-solve counter could never throttle it — remembering it lost
+  on the last solves is exactly how SCIP/BARON throttle losers across a run.
+* **Gap-gated.** RENS runs only while the primal-dual gap is open.
+
+> **Correctness-first narrowing (CLAUDE.md §4 — the measurement wins).** The first
+> cut governed rens + rins + local_branching (all 0 %-hit on the easy+held-out
+> pool). Running `check_cert_neutrality.py` with the governor **ON** then caught a
+> **degraded certificate**: on `cvxnonsep_psig30` (convex, `rens` actually *hits*)
+> throttling the ungoverned-in-principle rins/local_branching lost the better
+> incumbent — certified **79.0024** vs the true **78.9989** (oracle 78.99885434),
+> reported "optimal" at the gap tolerance. That is a lost incumbent, forbidden by
+> the acceptance criterion. Root cause: the entry pool lacked the convex-nonsep
+> class, where those improvers ARE load-bearing. The set was narrowed to rens; the
+> degradation is gone (cvxnonsep_psig30 OFF/ON both 78.99885435, match). This is
+> the cert panel doing its job, exactly as the plan anticipated
+> ("a governor that throttles a load-bearing source shows up in
+> incumbent-quality-at-TL").
+
+**Routing.** Each governed call site adds `governor().allowed("rens", gap_open=…)`
+to its guard and `governor().record("rens", improved)` after (RENS at the root
+primary in `_solve_nlp_bb`). The RINS / local_branching / enumerate call sites
+carry `allowed`/`record` calls too, but with those names ungoverned the calls are
+no-ops (always allowed, no stats) — wired so a future re-scoping needs no new call
+sites. The existing `_improver_allowed`/`_record_improver` node-budget contingent
+is preserved throughout.
+
+**Soundness (heuristic-policy).** Throttling a primal heuristic can only cost
+B&B *nodes* — never a wrong optimum, bound, or lost certificate; B&B stays
+exhaustive and every injected point is re-verified downstream. The lone way it
+can hurt is *incumbent quality* (throttling a load-bearing improver), which is
+why the cert panel + incumbent-at-TL checks are the real gate — and why the set
+was narrowed to rens. Default-OFF: with the flag unset `allowed()` returns `True`
+and `record()` is a no-op — byte-identical behaviour.
+
+---
+
+## 3. Acceptance — before/after, firing proof, verification
+
+All A/B numbers are governor OFF vs ON, warm governor (RENS's miss streak primed
+so its single root call is throttled on the target instance — models steady
+state mid-benchmark; on a cold first solve RENS runs once before it can be
+throttled, so the benefit accrues from the 2nd RENS-heavy instance onward, which
+is the realistic benchmark case).
+
+### 3.1 Easy-class wall
+
+| instance | OFF wall | ON wall | speedup | obj OFF | obj ON | rens throttled |
+|---|---:|---:|---:|---|---|---|
+| m3    | 3.44 | **1.65** | **2.08×** | 37.79999967 | 37.79999967 | yes |
+| fac2  | 5.63 | **4.01** | **1.40×** | 331837498.182 | 331837498.182 | yes |
+| nvs06 | 1.08 | 1.07 | 1.00× | 1.7703125002 | 1.7703125002 | no |
+| nvs08 | 0.63 | 0.61 | 1.03× | 23.449727353 | 23.449727353 | no |
+| nvs13 | 1.24 | 1.21 | 1.02× | -585.2 | -585.2 | no |
+| ex1224| 1.89 | 1.85 | 1.02× | -0.9434704911 | -0.9434704911 | no |
+
+**Easy-class geomean wall: 1.769 s → 1.461 s = 1.21×.** The wins concentrate on
+the RENS-heavy instances (m3 2.08×, fac2 1.40×); the RINS-only / ILS-capped
+instances are correctly neutral (RENS not their lever, and RINS is no longer
+governed).
+
+### 3.2 Held-out generality (14-instance slice)
+
+Every finished held-out instance is same-or-faster, objective identical (Δ within
+1e-9 relative): synthes1 **1.76×**, flay03m **1.71×**, syn05m **1.69×**,
+batchdes 1.50×, ex1223 1.48×, synthes2 1.41×, fac1 1.34×, st_e14 1.19×,
+synthes3 1.17×, flay02m 1.15×, procsel 1.12×, spring 1.05×.
+
+**All-20 (easy + held-out) geomean wall: 0.728 s → 0.571 s = 1.28×; 0 objective
+mismatches; 0 instances >10 % slower; 0 lost incumbents. RENS throttled on 12 of
+20.** Incumbent-quality-at-TL confirmed unchanged on the earlier (wider-governor)
+time-limited run and re-confirmed neutral on the cert panel here.
+
+### 3.3 Firing proof (the R2-didn't-fire lesson)
+
+The governor's `snapshot()` shows RENS actually refused on the target instances:
+RENS `throttled_events ≥ 1` on m3, fac2, synthes1, synthes3, syn05m, flay02m,
+ex1223, st_e14, synthes2, batchdes, fac1, flay03m (12 instances). Example
+(m3): `rens {calls:…, hits:0, disabled:True, throttled_events:1}` — RENS's single
+root nested-B&B eliminated, obj identical, 2.08× faster.
+
+### 3.4 Cert-neutrality + gates
+
+* **`check_cert_neutrality.py` governor-OFF (default): NEUTRAL** — all 41
+  certifying instances byte-identical (`nodes X→X`, `|Δobj|=0.00e+00`). Inert by
+  default.
+* **`check_cert_neutrality.py` governor-ON (narrowed): NEUTRAL** — 0 violations,
+  0 nonzero Δobj (the earlier cvxnonsep_psig30 degradation is fixed; node counts
+  also identical since RENS is not load-bearing on the cert panel). This is the
+  decisive incumbent-quality gate, passing with the governor actually ON.
+* `pytest -m smoke`: **617 passed, 14 skipped**.
+* `pytest -m slow test_adversarial_recent_fixes.py`: **10 passed**.
+* `python/tests/test_heuristic_governor.py`: **8 passed** (policy state machine,
+  default-OFF inertness, ungoverned-sources-never-throttled, fac2 end-to-end
+  cert-neutral).
+* `ruff check` + `ruff format --check` (v0.14.6): clean on all changed files.
+* pre-commit `mypy` (whole `python/discopt/`, `--python-version 3.12`): the
+  change adds **0 new errors**; the 12 pre-existing errors (incl. solver.py
+  `RootObbtResult`) are identical on `origin/main` (verified by stash A/B).
+* No Rust touched → `cargo test` not required.
+
+---
+
+## 4. Kill criteria — none fired (but the cert panel narrowed the scope)
+
+The entry kill criterion ("every non-ILS source is load-bearing → governor
+reduces to the ILS cap") did not fire: rens is 0 %-hit at 14.3 % pooled wall /
+33 % finished-easy wall — a genuine, ILS-distinct lever. The build kill criterion
+("throttling doesn't reduce wall, or degrades any incumbent") did not fire for
+rens: throttling it cut m3 2.08×, fac2 1.40×, held-out to 1.76× with **no**
+incumbent lost or degraded. It **did** fire for rins/local_branching (they
+degraded cvxnonsep_psig30's incumbent) — so those were removed from the governed
+set. The governor ships throttling **rens only**.
+
+---
+
+## 5. Artifacts
+
+* `python/discopt/heuristic_governor.py` — the `HeuristicGovernor`, the policy
+  constants (`K_DISABLE`, `GOVERNED_SOURCES = EXPENSIVE_SOURCES = {"rens"}`), and
+  the process-lifetime singleton.
+* `python/discopt/solver.py` — governed call sites (RENS, and the inert-by-scope
+  RINS / local_branching / enumerate hooks) route through
+  `governor().allowed/record`; `_get_heuristic_governor` helper. Default-OFF via
+  `DISCOPT_HEURISTIC_GOVERNOR`.
+* `python/tests/test_heuristic_governor.py` — 8 regression tests.
+* Entry-experiment + A/B drivers (reproducible): the VOLUME-1 sensor
+  (`discopt_benchmarks/scripts/nlp_solve_volume.py`) pooled across the panel +
+  held-out, and the governor OFF/ON A/B.
+
+## 6. Follow-ups
+
+* **Graduation.** Default-ON only via the G1.2 flag gate (three green nightlies)
+  — not in this PR.
+* **rins/local_branching (parked, not killed).** They are 0 %-hit on the
+  integer-MINLP class but load-bearing on the convex-nonseparable class. A future,
+  *class-aware* governor could throttle them only where the model is nonconvex
+  (RENS's class-general 0 %-hit is the safe subset shipped now). Needs its own
+  entry experiment spanning the convex class before any throttle.

--- a/python/discopt/heuristic_governor.py
+++ b/python/discopt/heuristic_governor.py
@@ -1,0 +1,199 @@
+"""G2 — the effort governor: hit-rate-adaptive root-heuristic scheduling.
+
+Motivation (measured, ``docs/dev/g2-effort-governor-2026-07-07.md``): the root
+primal-heuristic phase is 60-97 % of easy-instance wall, and the volume is
+largely *non-load-bearing*. On a pooled panel + held-out replay (27 instances,
+60 s, gap 1e-4) the incumbent came from ``_solve_root_node_multistart`` (start
+#1) on **every** instance, while the expensive nested-B&B heuristics never
+improved it:
+
+============================  ======  ========  ===========
+source                        solves  wall%     incumbent hit-rate
+============================  ======  ========  ===========
+rens (nested B&B)                805     14.3 %   0 / 13   (0.0 %)
+rins (LNS dive)                  440     10.4 %   0 / 143  (0.0 %)
+============================  ======  ========  ===========
+
+On the 21 *finished* easy instances RENS alone is **33 % of total solve wall**
+at a 0 % hit rate. SCIP/BARON track per-heuristic success and throttle the
+losers; discopt fires the full suite unconditionally at every root. This module
+is the missing conductor.
+
+Policy (global constants, documented, NOT keyed on instance name or shape —
+CLAUDE.md §2):
+
+* Cheap *finder* heuristics (multistart, pump, diving) are **never** governed:
+  securing the first incumbent for pruning always wins, and they are cheap.
+* Each governed (expensive) source is tracked by a **process-lifetime class
+  hit-rate** (``rens``, ``rins``, ``lbranch``, ``enumerate`` are *classes*, not
+  instances). A source that fails to improve the incumbent ``K_DISABLE``
+  consecutive times is disabled for the rest of the process. The cross-*solve*
+  memory is deliberate: RENS fires once per solve, so a per-solve counter could
+  never throttle it — the only way to throttle a loser that fires once per solve
+  is to remember it lost on the last solves, which is exactly how SCIP/BARON
+  behave across a run.
+* Expensive sources additionally run **only while the primal-dual gap is open**
+  (a closed gap means the certificate is essentially done — no improver can
+  help).
+
+Soundness (heuristic-policy regime, CLAUDE.md §5): throttling a primal heuristic
+can only ever cost B&B *nodes* — never a wrong optimum, bound, or lost
+certificate. B&B stays exhaustive; the governor only decides whether to *spend*
+effort looking for a better incumbent, and every injected point is re-verified
+downstream. The dual bound is never touched.
+
+Default-**OFF**: the governor is inert unless ``DISCOPT_HEURISTIC_GOVERNOR`` is
+set to a truthy value (``1``/``true``/``on``). With it off, :meth:`allowed`
+returns ``True`` for every source and the solve path is byte-identical to the
+pre-governor behaviour. Graduation to default-ON goes through the G1.2 flag
+gate, not this module.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass, field
+
+# ---- global policy constants (NOT per-instance / per-name) -------------------
+
+#: A governed source disabled after this many *consecutive* class misses
+#: (calls that did not strictly improve the incumbent). Small: the measured
+#: hit rate of the governed sources is 0 %, so one or two misses is already
+#: conclusive, and a load-bearing source that hits resets its miss streak.
+K_DISABLE = 2
+
+#: Sources the governor treats as *expensive* — they additionally require the
+#: primal-dual gap to be open.
+#:
+#: SCOPE (measurement-bounded, CLAUDE.md §4 — the measurement wins). The entry
+#: experiment found rens AND rins at a 0 % pooled incumbent hit-rate on the
+#: easy panel + held-out MINLP slice, but the cert panel then showed **rins /
+#: local-branching are load-bearing on the convex-nonseparable class**
+#: (cvxnonsep_psig30: throttling them lost the better incumbent, 78.9989 ->
+#: 79.0024, degrading the certified objective at the gap tolerance). So the
+#: governed set is narrowed to the source whose 0 %-hit generalizes across every
+#: class tested AND that carries the dominant wall: **rens** (33 % of finished
+#: easy-class solve wall; a whole nested B&B fired once at the root, at a 0 % hit
+#: rate on every instance INCLUDING the convex ones, where multistart already
+#: has the incumbent). RINS, local-branching and the binary-seed enumeration are
+#: left to the existing ``_improver_allowed`` node-budget contingent — they are
+#: NOT governed here, precisely because the evidence for throttling them does not
+#: hold on the convex class.
+EXPENSIVE_SOURCES = frozenset({"rens"})
+
+#: The sources the governor throttles at all. A source not listed here is always
+#: allowed and never accrues a throttle (``record`` still tracks its stats for
+#: observability, but never disables it). Currently identical to
+#: :data:`EXPENSIVE_SOURCES`; kept separate so a future cheap-but-losing source
+#: could be governed without the gap gate.
+GOVERNED_SOURCES = frozenset({"rens"})
+
+
+def _governor_enabled() -> bool:
+    return os.environ.get("DISCOPT_HEURISTIC_GOVERNOR", "0").lower() in ("1", "true", "on", "yes")
+
+
+@dataclass
+class _SourceStats:
+    calls: int = 0
+    hits: int = 0
+    consecutive_misses: int = 0
+    disabled: bool = False
+    throttled_events: int = 0  # times :meth:`allowed` refused this source
+
+
+@dataclass
+class HeuristicGovernor:
+    """Per-source running stats + the throttle policy.
+
+    Thread-safe (a single :data:`_LOCK` guards the mutable stats) so it can be a
+    process-lifetime singleton shared across solves. Cheap: two dict lookups per
+    heuristic call site.
+    """
+
+    stats: dict[str, _SourceStats] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def _get(self, source: str) -> _SourceStats:
+        st = self.stats.get(source)
+        if st is None:
+            st = _SourceStats()
+            self.stats[source] = st
+        return st
+
+    def allowed(self, source: str, *, gap_open: bool = True) -> bool:
+        """Whether a governed heuristic ``source`` may run now.
+
+        ``gap_open`` is honoured only for :data:`EXPENSIVE_SOURCES`. Returns
+        ``True`` unconditionally when the governor is disabled (default) so the
+        caller's behaviour is unchanged.
+        """
+        if not _governor_enabled() or source not in GOVERNED_SOURCES:
+            return True
+        with self._lock:
+            st = self._get(source)
+            if st.disabled:
+                st.throttled_events += 1
+                return False
+            if source in EXPENSIVE_SOURCES and not gap_open:
+                st.throttled_events += 1
+                return False
+            return True
+
+    def record(self, source: str, improved: bool) -> None:
+        """Charge a governed run against the class hit-rate.
+
+        ``improved`` is ``True`` iff the run strictly improved the incumbent.
+        A miss streak of :data:`K_DISABLE` disables the source for the rest of
+        the process; any hit resets the streak (a source that starts paying off
+        again is re-enabled by :meth:`record` clearing ``disabled``).
+        """
+        if not _governor_enabled() or source not in GOVERNED_SOURCES:
+            return
+        with self._lock:
+            st = self._get(source)
+            st.calls += 1
+            if improved:
+                st.hits += 1
+                st.consecutive_misses = 0
+                st.disabled = False
+            else:
+                st.consecutive_misses += 1
+                if st.consecutive_misses >= K_DISABLE:
+                    st.disabled = True
+
+    # -- introspection (the firing proof / instrumentation) -------------------
+
+    def snapshot(self) -> dict[str, dict[str, object]]:
+        """A JSON-friendly copy of the per-source stats (for the firing proof)."""
+        with self._lock:
+            return {
+                src: {
+                    "calls": st.calls,
+                    "hits": st.hits,
+                    "consecutive_misses": st.consecutive_misses,
+                    "disabled": st.disabled,
+                    "throttled_events": st.throttled_events,
+                }
+                for src, st in self.stats.items()
+            }
+
+    def any_throttled(self) -> bool:
+        """True iff the governor refused at least one governed source."""
+        with self._lock:
+            return any(st.throttled_events > 0 for st in self.stats.values())
+
+    def reset(self) -> None:
+        """Clear all class stats (test isolation / a fresh benchmark run)."""
+        with self._lock:
+            self.stats.clear()
+
+
+#: Process-lifetime singleton. Governed call sites route through this.
+_GOVERNOR = HeuristicGovernor()
+
+
+def governor() -> HeuristicGovernor:
+    """Return the process-lifetime governor singleton."""
+    return _GOVERNOR

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -58,6 +58,19 @@ _R3A_BRANCH_COUNT_SINK: Optional[dict] = None
 logger = logging.getLogger(__name__)
 
 
+def _get_heuristic_governor():
+    """Return the process-lifetime heuristic governor (G2).
+
+    Lazy-imported so the module has no import-time coupling to the governor and
+    so ``heuristic_governor`` (a small leaf module) stays independently testable.
+    The governor is inert unless ``DISCOPT_HEURISTIC_GOVERNOR`` is set (default
+    behaviour byte-identical).
+    """
+    from discopt.heuristic_governor import governor
+
+    return governor()
+
+
 def _branch_priority_integer_vars(model: Model) -> frozenset[int]:
     """Integer/binary flat indices that *gate* the model's nonlinear terms.
 
@@ -5215,6 +5228,8 @@ def solve_model(
     # the (improver-role) heuristics; ``found`` counts those that strictly
     # improved the incumbent — the success signal in the contingent.
     _heur_state = {"calls": 0, "found": 0, "cost": 0.0}
+    # G2: the hit-rate-adaptive governor (default-OFF; see heuristic_governor.py).
+    _heuristic_governor = _get_heuristic_governor()
 
     def _improver_allowed(cost: float) -> bool:
         """Whether an *improver*-role heuristic costing ``cost`` may run now.
@@ -6805,6 +6820,12 @@ def solve_model(
             and _subnlp_calls < subnlp_max_calls
             and not _root_optimum_proven()
             and _improver_allowed(_HEUR_COST["enumerate"])
+            # G2 governor: gate the enumeration only in its improver role (an
+            # incumbent already exists); as a finder (no incumbent) gap is open
+            # so allowed() lets it through — securing the first incumbent wins.
+            and _heuristic_governor.allowed(
+                "enumerate", gap_open=tree.incumbent() is None or not _root_optimum_proven()
+            )
             # F4: the binary-seed enumeration issues up to 2**k full sub-NLPs; do
             # not start it when the budget is exhausted (primal heuristic — sound).
             and _root_heur_nlp_entry_ok(evaluator)
@@ -6853,6 +6874,7 @@ def solve_model(
                 _enum_inc1 = tree.incumbent()
                 _enum_improved = _enum_inc1 is not None and float(_enum_inc1[1]) < _enum_obj0 - 1e-9
                 _record_improver(_HEUR_COST["enumerate"], _enum_improved)
+                _heuristic_governor.record("enumerate", _enum_improved)
 
         # --- Incumbent integer-neighbourhood search (general-integer LB) ---
         # A feasible incumbent of a nonconvex general-integer model can sit next
@@ -7002,6 +7024,7 @@ def solve_model(
                     and _lns_best_idx is not None
                     and (_deadline - time.perf_counter()) > _DEADLINE_NODE_FLOOR_S
                     and _improver_allowed(_HEUR_COST["rins"])
+                    and _heuristic_governor.allowed("rins", gap_open=_lns_gap_open)
                 ):
                     _rins_obj0 = float(_lns_inc[1])
                     _rins_improved = False
@@ -7029,6 +7052,7 @@ def solve_model(
                     except Exception as _e:
                         logger.debug("LNS RINS failed: %s", _e)
                     _record_improver(_HEUR_COST["rins"], _rins_improved)
+                    _heuristic_governor.record("rins", _rins_improved)
 
                 # (3) Local branching (improve). Scalable Hamming-ball sub-MIP
                 # around the incumbent, escalating k across calls. Bounded by a
@@ -7039,6 +7063,7 @@ def solve_model(
                     and _lns_gap_open
                     and (_deadline - time.perf_counter()) > 1.0
                     and _improver_allowed(_HEUR_COST["lbranch"])
+                    and _heuristic_governor.allowed("lbranch", gap_open=_lns_gap_open)
                 ):
                     _lb_k = _lns_k_schedule[min(_lns_lb_calls, len(_lns_k_schedule) - 1)]
                     _lns_lb_calls += 1
@@ -7081,6 +7106,7 @@ def solve_model(
                     except Exception as _e:
                         logger.debug("LNS local-branching failed: %s", _e)
                     _record_improver(_HEUR_COST["lbranch"], _lb_improved)
+                    _heuristic_governor.record("lbranch", _lb_improved)
 
         # --- User callbacks: lazy constraints and incumbent filtering ---
         if lazy_constraints is not None or incumbent_callback is not None:
@@ -8272,6 +8298,8 @@ def _solve_nlp_bb(
     _HEUR_SUCCESS_GAIN = 3.0
     _HEUR_COST = {"rins": 5.0, "lbranch": 10.0}
     _heur_state = {"calls": 0, "found": 0, "cost": 0.0}
+    # G2: the hit-rate-adaptive governor (default-OFF; see heuristic_governor.py).
+    _heuristic_governor = _get_heuristic_governor()
 
     def _improver_allowed(cost: float) -> bool:
         """Whether an improver-role LNS heuristic costing ``cost`` may run now.
@@ -8585,7 +8613,23 @@ def _solve_nlp_bb(
                 # smallinvDAX 0.4004 -> 0.3988). It returns cheaply when too many
                 # integers are fractional, so the pump/diving fallback below still
                 # covers set-partitioning-style relaxations parked at 0.5.
-                if rens_enabled:
+                #
+                # G2 governor: RENS is the single largest NLP-solve source on the
+                # easy class (33 % of solve wall) at a measured 0 % incumbent
+                # hit-rate — the incumbent already came from the root multistart.
+                # The governor throttles it once its class miss-streak proves it is
+                # not paying off (default-OFF; heuristic-policy — soundness is
+                # untouched since B&B stays exhaustive).
+                _rens_gap_open = tree.incumbent() is None or (
+                    best_root_obj < _SENTINEL_THRESHOLD
+                    and float(tree.incumbent()[1]) - float(best_root_obj)
+                    > gap_tolerance * (abs(float(tree.incumbent()[1])) + 1e-10)
+                )
+                if rens_enabled and _heuristic_governor.allowed("rens", gap_open=_rens_gap_open):
+                    _rens_improved = False
+                    _rens_obj0 = (
+                        float(tree.incumbent()[1]) if tree.incumbent() is not None else float("inf")
+                    )
                     try:
                         from discopt._jax.primal_heuristics import rens as _rens_heuristic
 
@@ -8633,9 +8677,11 @@ def _solve_nlp_bb(
                             ):
                                 tree.inject_incumbent(rens_sol, rens_obj)
                                 _root_incumbent = True
+                                _rens_improved = rens_obj < _rens_obj0 - 1e-9
                                 logger.info("NLP-BB RENS incumbent: obj=%.6g", rens_obj)
                     except Exception as e:
                         logger.debug("RENS failed: %s", e)
+                    _heuristic_governor.record("rens", _rens_improved)
 
                 # --- Feasibility pump (fallback when RENS does not apply) ---
                 if not _root_incumbent:
@@ -8831,6 +8877,7 @@ def _solve_nlp_bb(
                         _lns_best_idx is not None
                         and (_lns_deadline - time.perf_counter()) > _DEADLINE_NODE_FLOOR_S
                         and _improver_allowed(_HEUR_COST["rins"])
+                        and _heuristic_governor.allowed("rins", gap_open=True)
                     ):
                         _rins_obj0 = float(_lns_inc[1])
                         _rins_improved = False
@@ -8864,9 +8911,12 @@ def _solve_nlp_bb(
                         except Exception as _e:
                             logger.debug("NLP-BB LNS RINS failed: %s", _e)
                         _record_improver(_HEUR_COST["rins"], _rins_improved)
+                        _heuristic_governor.record("rins", _rins_improved)
                     # (2) Local branching — Hamming-ball sub-MIP, escalating k.
-                    if (_lns_deadline - time.perf_counter()) > 1.0 and _improver_allowed(
-                        _HEUR_COST["lbranch"]
+                    if (
+                        (_lns_deadline - time.perf_counter()) > 1.0
+                        and _improver_allowed(_HEUR_COST["lbranch"])
+                        and _heuristic_governor.allowed("lbranch", gap_open=True)
                     ):
                         _lb_k = _lns_k_schedule[min(_lns_lb_calls, len(_lns_k_schedule) - 1)]
                         _lns_lb_calls += 1
@@ -8915,6 +8965,7 @@ def _solve_nlp_bb(
                         except Exception as _e:
                             logger.debug("NLP-BB LNS local-branching failed: %s", _e)
                         _record_improver(_HEUR_COST["lbranch"], _lb_improved)
+                        _heuristic_governor.record("lbranch", _lb_improved)
 
         # Root-node certification snapshot (cert:T0.1).
         if iteration == 0:

--- a/python/tests/test_heuristic_governor.py
+++ b/python/tests/test_heuristic_governor.py
@@ -1,0 +1,145 @@
+"""G2 — the effort governor: unit + integration tests.
+
+Covers the policy state machine (throttle-after-k-misses, gap gating,
+hit-resets-streak, default-OFF inertness) and one end-to-end assertion that
+turning the governor on does not change the certified objective on a
+RENS-heavy easy instance (fac2) — the heuristic-policy regime (certified
+objective unchanged; node_count may shift).
+"""
+
+from __future__ import annotations
+
+import pytest
+from discopt.heuristic_governor import (
+    EXPENSIVE_SOURCES,
+    K_DISABLE,
+    HeuristicGovernor,
+    governor,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("DISCOPT_HEURISTIC_GOVERNOR", raising=False)
+    yield
+
+
+def test_default_off_is_inert(monkeypatch):
+    """With the flag unset, every source is allowed and record() is a no-op."""
+    monkeypatch.delenv("DISCOPT_HEURISTIC_GOVERNOR", raising=False)
+    g = HeuristicGovernor()
+    # even a closed gap on an expensive source is allowed when OFF
+    assert g.allowed("rens", gap_open=False) is True
+    # record() does nothing when OFF
+    for _ in range(10):
+        g.record("rens", improved=False)
+    assert g.allowed("rens", gap_open=True) is True
+    assert g.snapshot() == {}  # no stats accumulated while OFF
+
+
+def test_throttle_after_k_consecutive_misses(monkeypatch):
+    monkeypatch.setenv("DISCOPT_HEURISTIC_GOVERNOR", "1")
+    g = HeuristicGovernor()
+    assert g.allowed("rens", gap_open=True) is True
+    for _ in range(K_DISABLE):
+        g.record("rens", improved=False)
+    # disabled for the rest of the process after K consecutive misses
+    assert g.allowed("rens", gap_open=True) is False
+    snap = g.snapshot()["rens"]
+    assert snap["disabled"] is True
+    assert snap["consecutive_misses"] == K_DISABLE
+    assert snap["throttled_events"] >= 1
+
+
+def test_hit_resets_miss_streak_and_reenables(monkeypatch):
+    monkeypatch.setenv("DISCOPT_HEURISTIC_GOVERNOR", "1")
+    g = HeuristicGovernor()
+    for _ in range(K_DISABLE):
+        g.record("rens", improved=False)
+    assert g.allowed("rens", gap_open=True) is False
+    # a genuine improvement clears the streak and re-enables the source
+    g.record("rens", improved=True)
+    assert g.allowed("rens", gap_open=True) is True
+    assert g.snapshot()["rens"]["consecutive_misses"] == 0
+
+
+def test_expensive_source_requires_open_gap(monkeypatch):
+    monkeypatch.setenv("DISCOPT_HEURISTIC_GOVERNOR", "1")
+    g = HeuristicGovernor()
+    for src in EXPENSIVE_SOURCES:
+        assert g.allowed(src, gap_open=True) is True
+        assert g.allowed(src, gap_open=False) is False
+
+
+def test_ungoverned_sources_are_never_throttled(monkeypatch):
+    """rins / local_branching are load-bearing on the convex class (cvxnonsep):
+    the governor must never throttle them, no matter how many misses accrue."""
+    monkeypatch.setenv("DISCOPT_HEURISTIC_GOVERNOR", "1")
+    g = HeuristicGovernor()
+    for src in ("rins", "lbranch", "enumerate", "feasibility_pump"):
+        for _ in range(K_DISABLE + 5):
+            g.record(src, improved=False)
+        # never disabled, never gap-gated, never a throttle event
+        assert g.allowed(src, gap_open=False) is True
+        assert g.snapshot() == {}  # ungoverned sources accrue no stats
+
+
+def test_non_expensive_source_ignores_gap(monkeypatch):
+    monkeypatch.setenv("DISCOPT_HEURISTIC_GOVERNOR", "1")
+    g = HeuristicGovernor()
+    # a source not governed is never gap-gated
+    assert g.allowed("feasibility_pump", gap_open=False) is True
+
+
+def test_singleton_is_shared():
+    assert governor() is governor()
+
+
+@pytest.mark.slow
+def test_governor_cert_neutral_on_fac2(monkeypatch):
+    """End-to-end: the governor does not change the certified objective.
+
+    fac2 is RENS-heavy (RENS is 33 % of its solve wall at a 0 % incumbent hit
+    rate); it is exactly where the governor throttles. Heuristic-policy regime:
+    the certified objective must be identical OFF vs ON (node_count may shift).
+    """
+    from pathlib import Path
+
+    from discopt.modeling.core import from_nl
+
+    data = Path(__file__).parent / "data" / "minlplib_nl" / "fac2.nl"
+    if not data.exists():
+        pytest.skip("fac2.nl not in the vendored corpus")
+
+    monkeypatch.delenv("DISCOPT_HEURISTIC_GOVERNOR", raising=False)
+    governor().reset()
+    off = from_nl(str(data)).solve(time_limit=60, gap_tolerance=1e-4)
+
+    monkeypatch.setenv("DISCOPT_HEURISTIC_GOVERNOR", "1")
+    governor().reset()
+    # prime the miss streak so the once-per-solve RENS call is throttled on this
+    # instance (models a warm governor mid-benchmark; RENS has a 0% hit rate)
+    for _ in range(K_DISABLE):
+        governor().record("rens", improved=False)
+    on = from_nl(str(data)).solve(time_limit=60, gap_tolerance=1e-4)
+
+    assert off.objective is not None and on.objective is not None
+    assert abs(off.objective - on.objective) <= 1e-6 * (abs(off.objective) + 1.0)
+    # the governor must have actually throttled something (the firing proof)
+    assert governor().any_throttled()
+
+    monkeypatch.delenv("DISCOPT_HEURISTIC_GOVERNOR", raising=False)
+    governor().reset()
+
+
+def test_env_truthy_parsing(monkeypatch):
+    from discopt.heuristic_governor import _governor_enabled
+
+    for v in ("1", "true", "on", "YES", "True"):
+        monkeypatch.setenv("DISCOPT_HEURISTIC_GOVERNOR", v)
+        assert _governor_enabled() is True
+    for v in ("0", "off", "false", "", "no"):
+        monkeypatch.setenv("DISCOPT_HEURISTIC_GOVERNOR", v)
+        assert _governor_enabled() is False
+    monkeypatch.delenv("DISCOPT_HEURISTIC_GOVERNOR", raising=False)
+    assert _governor_enabled() is False


### PR DESCRIPTION
## G2 — the effort governor: hit-rate-adaptive root-heuristic scheduling

Roadmap: `docs/dev/default-path-performance-plan-2026-07-06.md` §2 (cause C-A) + §3 G2. Sensor: VOLUME-1 (`docs/dev/nlp-solve-volume-2026-07-06.md`). Findings: `docs/dev/g2-effort-governor-2026-07-07.md`.

### Entry experiment → GENERALIZE (build)

VOLUME-1 sensor pooled across the easy panel + a 20-instance held-out MINLP slice (27 solving instances, 60s, gap 1e-4). On **every** instance the incumbent came from the root multistart (start #1); the expensive nested-B&B improvers never improved it:

| source | pooled solves | pooled NLP wall-share | incumbent hit-rate |
|---|---:|---:|---:|
| `_solve_node_nlp_pounce` (dual-bound engine) | 2316 | 49.5% | n/a — never cuttable |
| integer_local_search (capped, #532) | 644 | 15.1% | 0/13 (0.0%) |
| **rens** | 805 | **14.3%** | **0/13 (0.0%)** |
| **rins** | 440 | **10.4%** | **0/143 (0.0%)** |
| `_solve_root_node_multistart` (finder) | — | — | **27/39 (69.2%)** |

≥2 sources beyond the capped ILS have ~0% pooled hit-rate AND ≥5% root wall-share (rens, rins). On the finished easy class **RENS alone is 33% of total solve wall**. Distinct from the ILS cap → build.

### The governor

`python/discopt/heuristic_governor.py` — a process-lifetime `HeuristicGovernor` singleton with per-source-class stats and a global policy: throttle a governed source after `K_DISABLE=2` consecutive class misses (cross-solve, since RENS fires once per solve — how SCIP/BARON throttle losers), gap-gated. Routed through the root/LNS heuristic dispatch in `solver.py`. **Default-OFF** behind `DISCOPT_HEURISTIC_GOVERNOR`; inert (byte-identical) when unset.

### Correctness-first narrowing (the cert panel did its job)

The initial cut governed rens + rins + local_branching (all 0%-hit on the easy+held-out pool). Running `check_cert_neutrality.py` **with the governor ON** caught a **degraded certificate**: on the convex-nonseparable class (`cvxnonsep_psig30`) rins/local_branching are load-bearing — throttling them lost the better incumbent (78.9989 → 79.0024, certified "optimal" at the gap tolerance; oracle 78.99885434). The entry pool lacked that class. The measurement wins: `GOVERNED_SOURCES` narrowed to **`{"rens"}`** — the source whose 0%-hit holds across every class tested AND that carries the dominant wall. rins/lbranch/enumerate keep their existing `_improver_allowed` node-budget contingent, ungoverned. cvxnonsep degradation gone.

### Results (governor OFF vs ON, warm)

- **Easy-class geomean wall 1.77s → 1.46s = 1.21×** (m3 2.08×, fac2 1.40×).
- **All-20 panel+held-out geomean 1.28×**; held-out wins persist (synthes1 1.76×, syn05m 1.69×, flay03m 1.71×, batchdes 1.50×, …).
- **Firing proof:** RENS throttled on 12 of 20 instances (`throttled_events ≥ 1`), eliminating its root nested B&B.
- **0 certified-objective changes, 0 lost incumbents, 0 instances >10% slower.**

### Verification

- `check_cert_neutrality.py` governor-**OFF** (default): **NEUTRAL** — 41 instances byte-identical (`nodes X→X`, `|Δobj|=0`).
- `check_cert_neutrality.py` governor-**ON** (narrowed): **NEUTRAL**, 0 violations — the decisive incumbent-quality gate, passing with the governor active.
- `pytest -m smoke`: **617 passed, 14 skipped**.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **10 passed**.
- `python/tests/test_heuristic_governor.py`: **8 passed** (+1 slow fac2 end-to-end cert-neutral).
- `ruff check` + `ruff format --check` (v0.14.6): clean. mypy: **0 new errors** (12 pre-existing on origin/main, verified by stash A/B). No Rust touched → `cargo test` not required.

**Regime:** heuristic-policy (CLAUDE.md §5) — certified objective unchanged; node_count may shift (it does on a few instances; documented). **Default-OFF**; graduation to default-ON via the G1.2 flag gate later. Do not merge without that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
