### PR TITLE
bench(V): default-path re-measure vs BARON after G1+G2 (defaults-only)

### DIFF
--- a/docs/dev/v-baron-remeasure-2026-07-07.md
+++ b/docs/dev/v-baron-remeasure-2026-07-07.md
@@ -1,0 +1,97 @@
+# V — Default-path re-measure vs BARON after G1+G2 (defaults-only)
+
+**Date:** 2026-07-07
+**Branch:** `v-baron-remeasure` (from `origin/main` @ `0308a7d1`)
+**Panel:** 61 vendored MINLPLib `.nl` (`python/tests/data/minlplib_nl/`), 60 s time limit,
+`gap_tolerance=1e-4`, correctness tol abs=1e-6 rel=1e-4.
+**Build:** release (`maturin develop --release`); pounce `.so` = 4.73 MB (release, not debug).
+**Run:** discopt **defaults-only, no flags toggled** — measures what a real user gets.
+BARON numbers reused verbatim from the 2026-07-06 baseline (only discopt changed).
+
+## What is on the default path now (all merged to `main`, all default-ON)
+
+- ILS cap (#532)
+- PSD gate (#537)
+- zero-spanning lift (#538)
+- heuristic effort governor (#541)
+- C-38 false-optimal fix (#536)
+
+## Headline: before → after
+
+| metric | baseline 2026-07-06 | this run 2026-07-07 | delta |
+|---|---|---|---|
+| **discopt proved-optimal** | **42** | **43** | **+1** (no cert lost) |
+| discopt total wall (all 61) | 18.83 min (1130 s) | **18.18 min (1091 s)** | −0.65 min |
+| discopt shifted-geomean wall | 4.74 s | 4.63 s | −0.11 s |
+| **discopt VIOLATIONS** | **0** | **0** | — |
+
+**Cert change:** GAINED `st_e36` (feasible→optimal). LOST: none. No proved-optimal regression.
+
+## HARD CORRECTNESS GATE — result: PASS (0 violations)
+
+- **discopt VIOLATIONS = 0** on the 61-panel (harness verdict, oracle = MINLPLib `primalbound`).
+- **Independent `minlplib.solu` cross-check:** every discopt `status==optimal` objective
+  matches its `=best=`/`=opt=` value within tol. **CLEAN** — no C-38/C-40-shape false-optimal.
+- **Dual-bound cross-check:** no discopt dual bound crosses the `.solu` oracle. **CLEAN.**
+- **`util` reconciliation:** the known C-40 `util` false-optimal is **NOT in this 61-panel**
+  (it was caught on a different held-out set). 58/61 panel instances carry a `.solu`
+  primal oracle; the 3 without one are the `bchoco06/07/08` class (`known=null` in both
+  baseline and this run — n/a, not a cert). The baseline's "0 violations" needs no
+  reconciliation for this panel.
+
+## Per-instance wall deltas — where the capabilities moved the needle
+
+**The one real win — governor freeing search budget:**
+
+| instance | base | now | Δ | nodes | note |
+|---|---|---|---|---|---|
+| **st_e36** | 60.09 s (feasible) | **16.26 s (optimal)** | **−43.8 s** | 883→153 | **new cert** — proved within budget |
+
+**Integer instances — ILS cap (#532):**
+
+| instance | base | now | Δ | nodes |
+|---|---|---|---|---|
+| nvs06 | 4.07 s | 1.60 s | −2.46 s | 5→5 |
+| nvs01 | 5.50 s | 3.09 s | −2.41 s | 17→17 |
+| nvs08 | 2.76 s | 1.05 s | −1.71 s | 57→57 |
+| st_e38 | 1.22 s | 0.60 s | −0.62 s | 3→3 |
+
+Node counts unchanged on these — the ILS cap trims per-node heuristic work, not the tree.
+
+**Small regressions (noise / governor overhead where it doesn't pay):** m3 +0.86 s,
+fac2 +0.94 s, clay0303hfsg +2.70 s, casctanks +1.20 s, several `tspn*`/`heatexch*`
++0.5–1.5 s. All node-neutral or near it; none crosses a cert boundary. These are the
+governor/lift paying a small fixed tax on instances where its win does not land.
+
+**Panel-invisible wins (the instrument limitation).** The **PSD gate (#537)** and
+**zero-spanning lift (#538)** target the QCQP class. The QCQP probes named in the roadmap
+(`nvs17`, `nvs19`, `nvs24`) are **NOT in this 61-panel**, so those two capabilities are
+essentially invisible here. The panel-visible improvement is therefore small **by
+construction** — the wins concentrate off-panel. This is the known limitation of the
+BARON-vs-discopt 61-panel as an instrument for G1+G2, and it is why the headline gain is
++1 cert / −0.65 min rather than something larger.
+
+## The BARON gap
+
+- BARON proves **44**, discopt proves **43**; **40 jointly proved**.
+- **BARON proves but discopt does not (4):** `nvs05`, `nvs09`, `tanksize`, `tls2`
+  — discopt returns an honest feasible/time-limit incumbent (GAP), not a wrong answer.
+- **discopt proves but BARON does not (3):** `chance`, `dispatch` (BARON stops at
+  `2 Locally Optimal` — not certified global), `tspn05` (BARON `8 Integer Solution` at 60 s).
+- **Wall ratio on the 40 jointly-proved:** discopt/BARON geomean **14.4×** (median 14.6×,
+  min 1.40×, max 180.6×). discopt is correct but slower; closing this ratio is the
+  remaining performance work, and it lives mostly off this panel.
+
+## Verification
+
+- Release build; pounce `.so` = 4.73 MB (confirmed release, ~10× smaller than a debug build).
+- Bound-neutral spot check: `alan` optimal, obj 2.925, 21 nodes — identical to baseline.
+- Node counts unchanged on the bound-neutral instances (ILS cap trims work, not tree).
+- Raw discopt-only sweep JSON + the BARON-merged JSON under `reports/`.
+
+## Artifacts
+
+- `reports/global_opt_baron_vs_discopt_2026-07-07T11-06-06.json` — raw discopt-only sweep
+  (BARON = SKIPPED).
+- `reports/v_baron_remeasure_2026-07-07T11-06-06.json` — merged: this run's discopt +
+  baseline BARON, verdicts recomputed.

--- a/reports/global_opt_baron_vs_discopt_2026-07-07T11-06-06.json
+++ b/reports/global_opt_baron_vs_discopt_2026-07-07T11-06-06.json
@@ -1,0 +1,1531 @@
+{
+  "time_limit": 60.0,
+  "timestamp": "2026-07-07T11-06-06",
+  "rows": [
+    {
+      "instance": "4stufen",
+      "known": 116329.6706,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": 19020.498520801193,
+        "gap": null,
+        "node_count": 63,
+        "wall_time": 62.648355500306934,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "alan",
+      "known": 2.925,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.924999998301341,
+        "lower_bound": 2.924999998301341,
+        "gap": 0.0,
+        "node_count": 21,
+        "wall_time": 0.1687729163095355,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "bchoco06",
+      "known": null,
+      "maximize": true,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 31,
+        "wall_time": 62.28345879167318,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "bchoco07",
+      "known": null,
+      "maximize": true,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 7,
+        "wall_time": 62.845650541596115,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "bchoco08",
+      "known": null,
+      "maximize": true,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 15,
+        "wall_time": 65.60487295873463,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "beuster",
+      "known": 116329.6706,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": 6351.565076176493,
+        "gap": null,
+        "node_count": 31,
+        "wall_time": 61.05215129069984,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "casctanks",
+      "known": 9.163479388,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": -90.17862929102458,
+        "gap": null,
+        "node_count": 127,
+        "wall_time": 64.19884141720831,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "chance",
+      "known": 29.89437816,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 29.894378154271102,
+        "lower_bound": 29.894378154271102,
+        "gap": 0.0,
+        "node_count": 0,
+        "wall_time": 0.38776008412241936,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "clay0303hfsg",
+      "known": 26669.10957,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 26669.10955143382,
+        "lower_bound": 26669.109551433936,
+        "gap": 0.0,
+        "node_count": 229,
+        "wall_time": 25.249535416718572,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "contvar",
+      "known": 809149.8272,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 809149.8138136583,
+        "lower_bound": 174044.7144558017,
+        "gap": 0.7849042149123167,
+        "node_count": 63,
+        "wall_time": 60.80020304210484,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "cvxnonsep_nsig30",
+      "known": 130.6287126,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 130.62871116925294,
+        "lower_bound": 130.61841392487688,
+        "gap": 7.882808727819201e-05,
+        "node_count": 165,
+        "wall_time": 2.7570066670887172,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "cvxnonsep_psig30",
+      "known": 78.99885434,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 78.9988543529429,
+        "lower_bound": 78.99179874365787,
+        "gap": 8.9312555104815e-05,
+        "node_count": 89,
+        "wall_time": 1.3770153750665486,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "cvxnonsep_psig40r",
+      "known": 86.5451047,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 86.5452799516496,
+        "lower_bound": 86.53872191349262,
+        "gap": 7.423014759247372e-05,
+        "node_count": 95,
+        "wall_time": 4.151557791978121,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "dispatch",
+      "known": 3155.287927,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 3155.2879266989703,
+        "lower_bound": 3155.072917127798,
+        "gap": 6.814261523911746e-05,
+        "node_count": 3,
+        "wall_time": 0.4755614581517875,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "ex1221",
+      "known": 7.667180069,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 7.6671800711443945,
+        "lower_bound": 7.667180058272593,
+        "gap": 1.3747612131369656e-09,
+        "node_count": 5,
+        "wall_time": 0.613023541867733,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "ex1222",
+      "known": 1.076543083,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 1.0765430648177292,
+        "lower_bound": 1.0765430463031964,
+        "gap": 0.0,
+        "node_count": 1,
+        "wall_time": 0.41427725041285157,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "ex1224",
+      "known": -0.9434705,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -0.9434704910762214,
+        "lower_bound": -0.9435072710857,
+        "gap": 3.677330332119144e-05,
+        "node_count": 53,
+        "wall_time": 2.2723040408454835,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "ex1225",
+      "known": 31.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 30.999999951817372,
+        "lower_bound": 30.999999951817376,
+        "gap": 0.0,
+        "node_count": 7,
+        "wall_time": 1.2347830422222614,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "ex1226",
+      "known": -17.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -17.000000003900116,
+        "lower_bound": -17.000000023491527,
+        "gap": 1.1524359503259587e-09,
+        "node_count": 5,
+        "wall_time": 0.5385857499204576,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "fac2",
+      "known": 331837498.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 331837498.18201375,
+        "lower_bound": 331837497.8338103,
+        "gap": 0.0,
+        "node_count": 69,
+        "wall_time": 6.736725499853492,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "flay02m",
+      "known": 37.94733192,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 37.947331863834606,
+        "lower_bound": 37.94733180456952,
+        "gap": 0.0,
+        "node_count": 7,
+        "wall_time": 0.5538010410964489,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "flay03m",
+      "known": 48.98979486,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 48.98979479383545,
+        "lower_bound": 48.98979470823029,
+        "gap": 0.0,
+        "node_count": 111,
+        "wall_time": 7.32409125007689,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "gbd",
+      "known": 2.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.199999982504936,
+        "lower_bound": 2.199999982504936,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.14908312493935227,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "gkocis",
+      "known": -1.923098738,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -1.9230987798770212,
+        "lower_bound": -1.9230988280923489,
+        "gap": 0.0,
+        "node_count": 5,
+        "wall_time": 0.7370092500932515,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "hda",
+      "known": -5964.534084,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 7,
+        "wall_time": 65.17324233287945,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "heatexch_gen1",
+      "known": 154895.933,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": 100499.99999999991,
+        "gap": null,
+        "node_count": 63,
+        "wall_time": 62.16235316591337,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "heatexch_gen2",
+      "known": 635838.8464,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 676410.9816093397,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 147,
+        "wall_time": 61.208427666220814,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "GAP",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "heatexch_gen3",
+      "known": 64843.69761,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 15,
+        "wall_time": 61.435835250187665,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "m3",
+      "known": 37.8,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 37.79999966997884,
+        "lower_bound": 37.79999951039201,
+        "gap": 0.0,
+        "node_count": 61,
+        "wall_time": 4.174682250246406,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs01",
+      "known": 12.46966882,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 12.46966882156821,
+        "lower_bound": 12.46966880809854,
+        "gap": 1.080194672104233e-09,
+        "node_count": 17,
+        "wall_time": 3.0887217088602483,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs02",
+      "known": 5.964184523,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 5.96418452307,
+        "lower_bound": 5.96418452307,
+        "gap": 0.0,
+        "node_count": 101,
+        "wall_time": 0.13330275006592274,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs03",
+      "known": 16.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 16.0,
+        "lower_bound": 15.99999972676511,
+        "gap": 1.707718066956687e-08,
+        "node_count": 5,
+        "wall_time": 0.42135116597637534,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs04",
+      "known": 0.72,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 0.720000000000006,
+        "lower_bound": 0.7199999473599988,
+        "gap": 5.264000713101069e-08,
+        "node_count": 5,
+        "wall_time": 0.4876568750478327,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs05",
+      "known": 5.470934108,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 5.47093412640568,
+        "lower_bound": 1.348118846767416,
+        "gap": 0.7535852533371464,
+        "node_count": 733,
+        "wall_time": 60.22935925005004,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs06",
+      "known": 1.7703125,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 1.7703125002341187,
+        "lower_bound": 1.7703124984296874,
+        "gap": 8.870256221212425e-10,
+        "node_count": 5,
+        "wall_time": 1.6039277920499444,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs07",
+      "known": 4.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 4.0,
+        "lower_bound": 4.0,
+        "gap": 0.0,
+        "node_count": 5,
+        "wall_time": 0.041860208846628666,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs08",
+      "known": 23.44972735,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 23.449727353351044,
+        "lower_bound": 23.449382312131643,
+        "gap": 1.4713797977099544e-05,
+        "node_count": 57,
+        "wall_time": 1.0513565000146627,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs09",
+      "known": -43.13433692,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": -43.13433691803531,
+        "lower_bound": -57.680145993208754,
+        "gap": 0.337221112331312,
+        "node_count": 221,
+        "wall_time": 60.05631833290681,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs10",
+      "known": -310.8,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -310.79999999999995,
+        "lower_bound": -310.79999999999995,
+        "gap": 0.0,
+        "node_count": 5,
+        "wall_time": 0.0873126252554357,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs11",
+      "known": -431.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -431.0,
+        "lower_bound": -431.0,
+        "gap": 0.0,
+        "node_count": 39,
+        "wall_time": 0.42489937506616116,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs12",
+      "known": -481.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -481.20000000000016,
+        "lower_bound": -481.20000000000016,
+        "gap": 0.0,
+        "node_count": 195,
+        "wall_time": 1.6021957080811262,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs13",
+      "known": -585.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -585.2,
+        "lower_bound": -585.2000011714,
+        "gap": 2.0017087463537884e-09,
+        "node_count": 49,
+        "wall_time": 2.2692656670697033,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs14",
+      "known": -40358.15477,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -40358.1547693,
+        "lower_bound": -40358.1547693,
+        "gap": 0.0,
+        "node_count": 325,
+        "wall_time": 0.2861521663144231,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "nvs15",
+      "known": 1.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 1.0,
+        "lower_bound": 1.0,
+        "gap": 0.0,
+        "node_count": 7,
+        "wall_time": 0.06036358326673508,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "oaer",
+      "known": -1.923098514,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -1.9230983037453937,
+        "lower_bound": -1.923098601139822,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 1.1834212075918913,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_e13",
+      "known": 2.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.0,
+        "lower_bound": 1.9999999825187809,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.47115774964913726,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_e29",
+      "known": -0.9434705,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -0.9434704910762214,
+        "lower_bound": -0.9435072710857,
+        "gap": 3.677330332119144e-05,
+        "node_count": 53,
+        "wall_time": 3.0341386669315398,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_e36",
+      "known": -246.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -246.0,
+        "lower_bound": -246.01879639837531,
+        "gap": 7.640812347689022e-05,
+        "node_count": 153,
+        "wall_time": 16.2568882079795,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_e38",
+      "known": 7197.727149,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 7197.727116839705,
+        "lower_bound": 7197.727116826533,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.6030559591017663,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_miqp1",
+      "known": 281.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 280.9999999906497,
+        "lower_bound": 280.9999999906497,
+        "gap": 0.0,
+        "node_count": 15,
+        "wall_time": 0.1441669575870037,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_miqp2",
+      "known": 2.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.0,
+        "lower_bound": 2.0,
+        "gap": 0.0,
+        "node_count": 9,
+        "wall_time": 0.14680537534877658,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_miqp3",
+      "known": -6.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -6.0,
+        "lower_bound": -6.0,
+        "gap": 0.0,
+        "node_count": 1,
+        "wall_time": 0.13911199988797307,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_miqp4",
+      "known": -4574.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -4574.000004423649,
+        "lower_bound": -4574.000004423649,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.14930287515744567,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_test1",
+      "known": 0.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -1.6495994490692313e-08,
+        "lower_bound": -1.6495994490692313e-08,
+        "gap": 0.0,
+        "node_count": 15,
+        "wall_time": 0.15158516727387905,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "st_testgr3",
+      "known": -20.59,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -20.59,
+        "lower_bound": -20.59070709795548,
+        "gap": 3.434181425354089e-05,
+        "node_count": 549,
+        "wall_time": 0.21676962496712804,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "tanksize",
+      "known": 1.268643754,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 1.2686437480322943,
+        "lower_bound": 0.8680315476476382,
+        "gap": 0.31577990354346364,
+        "node_count": 451,
+        "wall_time": 60.087795750238,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "tls2",
+      "known": 5.3,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 1887,
+        "wall_time": 60.461395542137325,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "tspn05",
+      "known": 191.2552078,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 191.25520768494184,
+        "lower_bound": 191.25288274907072,
+        "gap": 1.215420076587872e-05,
+        "node_count": 39,
+        "wall_time": 19.530149083118886,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "tspn08",
+      "known": 290.5668539,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 290.5668537474048,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 1,
+        "wall_time": 17.909853290766478,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "tspn10",
+      "known": 225.1260716,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 225.1260713973292,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 1,
+        "wall_time": 15.630885958205909,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "tspn12",
+      "known": 262.6473957,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 262.64739525060224,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 1,
+        "wall_time": 14.332488667219877,
+        "error": null
+      },
+      "baron": {
+        "status": "SKIPPED",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "n/a"
+    }
+  ]
+}

--- a/reports/global_opt_baron_vs_discopt_2026-07-07T11-06-06.md
+++ b/reports/global_opt_baron_vs_discopt_2026-07-07T11-06-06.md
@@ -1,0 +1,94 @@
+# Global Optimization Benchmark — discopt vs BARON (GAMS, full license)
+
+- Instances: **61** vendored MINLPLib `.nl` (`python/tests/data/minlplib_nl/`)
+- Per-problem time limit: **60 s**; gap tolerance 1e-4; correctness tol abs=1e-6 rel=1e-4 vs MINLPLib `primalbound`
+- discopt: isolated subprocess `Model.solve(time_limit=60, gap_tolerance=1e-4)`
+- BARON: `gams <name>.gms minlp=baron optcr=0 optca=1e-9 reslim=60` (CMU full license)
+- Generated: 2026-07-07T11-06-06
+
+## Verdict vocabulary
+
+| verdict | meaning |
+|---|---|
+| `ok` | incumbent matches the proven global within tolerance |
+| `GAP` | honest feasible/uncertified incumbent **worse** than the global — a convergence gap in the time budget, *not* a correctness bug |
+| `VIOLATION` | **the non-negotiable red line**: solver claimed a certified global with the wrong value, returned an incumbent strictly *better* than the proven global, or reported a **dual bound crossing the oracle** (all impossible → bug) |
+| `n/a` | no oracle, or no incumbent returned (e.g. parser error) |
+
+## Correctness summary
+
+- Instances with a known optimum (oracle): **58/61**
+- **discopt — VIOLATIONS: 0**  ·  ok 50  ·  gap 1  ·  n/a 10
+- **BARON   — VIOLATIONS: 0**  ·  ok 0  ·  gap 0  ·  n/a 61
+
+> ✅ **Zero discopt correctness violations.**
+
+## Per-instance results
+
+| instance | known | discopt obj | d | d status | d time | BARON obj | b | b status | b time |
+|---|---|---|---|---|---|---|---|---|---|
+| 4stufen |   1.1633e+05 |            - | n/a | time_limit | 62.65 |            - | n/a | SKIPPED | 0.00 |
+| alan |        2.925 |        2.925 | ok | optimal | 0.17 |            - | n/a | SKIPPED | 0.00 |
+| bchoco06 |            - |            - | n/a | time_limit | 62.28 |            - | n/a | SKIPPED | 0.00 |
+| bchoco07 |            - |            - | n/a | time_limit | 62.85 |            - | n/a | SKIPPED | 0.00 |
+| bchoco08 |            - |            - | n/a | time_limit | 65.60 |            - | n/a | SKIPPED | 0.00 |
+| beuster |   1.1633e+05 |            - | n/a | time_limit | 61.05 |            - | n/a | SKIPPED | 0.00 |
+| casctanks |       9.1635 |            - | n/a | time_limit | 64.20 |            - | n/a | SKIPPED | 0.00 |
+| chance |       29.894 |       29.894 | ok | optimal | 0.39 |            - | n/a | SKIPPED | 0.00 |
+| clay0303hfsg |        26669 |        26669 | ok | optimal | 25.25 |            - | n/a | SKIPPED | 0.00 |
+| contvar |   8.0915e+05 |   8.0915e+05 | ok | feasible | 60.80 |            - | n/a | SKIPPED | 0.00 |
+| cvxnonsep_nsig30 |       130.63 |       130.63 | ok | optimal | 2.76 |            - | n/a | SKIPPED | 0.00 |
+| cvxnonsep_psig30 |       78.999 |       78.999 | ok | optimal | 1.38 |            - | n/a | SKIPPED | 0.00 |
+| cvxnonsep_psig40r |       86.545 |       86.545 | ok | optimal | 4.15 |            - | n/a | SKIPPED | 0.00 |
+| dispatch |       3155.3 |       3155.3 | ok | optimal | 0.48 |            - | n/a | SKIPPED | 0.00 |
+| ex1221 |       7.6672 |       7.6672 | ok | optimal | 0.61 |            - | n/a | SKIPPED | 0.00 |
+| ex1222 |       1.0765 |       1.0765 | ok | optimal | 0.41 |            - | n/a | SKIPPED | 0.00 |
+| ex1224 |     -0.94347 |     -0.94347 | ok | optimal | 2.27 |            - | n/a | SKIPPED | 0.00 |
+| ex1225 |           31 |           31 | ok | optimal | 1.23 |            - | n/a | SKIPPED | 0.00 |
+| ex1226 |          -17 |          -17 | ok | optimal | 0.54 |            - | n/a | SKIPPED | 0.00 |
+| fac2 |   3.3184e+08 |   3.3184e+08 | ok | optimal | 6.74 |            - | n/a | SKIPPED | 0.00 |
+| flay02m |       37.947 |       37.947 | ok | optimal | 0.55 |            - | n/a | SKIPPED | 0.00 |
+| flay03m |        48.99 |        48.99 | ok | optimal | 7.32 |            - | n/a | SKIPPED | 0.00 |
+| gbd |          2.2 |          2.2 | ok | optimal | 0.15 |            - | n/a | SKIPPED | 0.00 |
+| gkocis |      -1.9231 |      -1.9231 | ok | optimal | 0.74 |            - | n/a | SKIPPED | 0.00 |
+| hda |      -5964.5 |            - | n/a | time_limit | 65.17 |            - | n/a | SKIPPED | 0.00 |
+| heatexch_gen1 |    1.549e+05 |            - | n/a | time_limit | 62.16 |            - | n/a | SKIPPED | 0.00 |
+| heatexch_gen2 |   6.3584e+05 |   6.7641e+05 | GAP | feasible | 61.21 |            - | n/a | SKIPPED | 0.00 |
+| heatexch_gen3 |        64844 |            - | n/a | time_limit | 61.44 |            - | n/a | SKIPPED | 0.00 |
+| m3 |         37.8 |         37.8 | ok | optimal | 4.17 |            - | n/a | SKIPPED | 0.00 |
+| nvs01 |        12.47 |        12.47 | ok | optimal | 3.09 |            - | n/a | SKIPPED | 0.00 |
+| nvs02 |       5.9642 |       5.9642 | ok | optimal | 0.13 |            - | n/a | SKIPPED | 0.00 |
+| nvs03 |           16 |           16 | ok | optimal | 0.42 |            - | n/a | SKIPPED | 0.00 |
+| nvs04 |         0.72 |         0.72 | ok | optimal | 0.49 |            - | n/a | SKIPPED | 0.00 |
+| nvs05 |       5.4709 |       5.4709 | ok | feasible | 60.23 |            - | n/a | SKIPPED | 0.00 |
+| nvs06 |       1.7703 |       1.7703 | ok | optimal | 1.60 |            - | n/a | SKIPPED | 0.00 |
+| nvs07 |            4 |            4 | ok | optimal | 0.04 |            - | n/a | SKIPPED | 0.00 |
+| nvs08 |        23.45 |        23.45 | ok | optimal | 1.05 |            - | n/a | SKIPPED | 0.00 |
+| nvs09 |      -43.134 |      -43.134 | ok | feasible | 60.06 |            - | n/a | SKIPPED | 0.00 |
+| nvs10 |       -310.8 |       -310.8 | ok | optimal | 0.09 |            - | n/a | SKIPPED | 0.00 |
+| nvs11 |         -431 |         -431 | ok | optimal | 0.42 |            - | n/a | SKIPPED | 0.00 |
+| nvs12 |       -481.2 |       -481.2 | ok | optimal | 1.60 |            - | n/a | SKIPPED | 0.00 |
+| nvs13 |       -585.2 |       -585.2 | ok | optimal | 2.27 |            - | n/a | SKIPPED | 0.00 |
+| nvs14 |       -40358 |       -40358 | ok | optimal | 0.29 |            - | n/a | SKIPPED | 0.00 |
+| nvs15 |            1 |            1 | ok | optimal | 0.06 |            - | n/a | SKIPPED | 0.00 |
+| oaer |      -1.9231 |      -1.9231 | ok | optimal | 1.18 |            - | n/a | SKIPPED | 0.00 |
+| st_e13 |            2 |            2 | ok | optimal | 0.47 |            - | n/a | SKIPPED | 0.00 |
+| st_e29 |     -0.94347 |     -0.94347 | ok | optimal | 3.03 |            - | n/a | SKIPPED | 0.00 |
+| st_e36 |         -246 |         -246 | ok | optimal | 16.26 |            - | n/a | SKIPPED | 0.00 |
+| st_e38 |       7197.7 |       7197.7 | ok | optimal | 0.60 |            - | n/a | SKIPPED | 0.00 |
+| st_miqp1 |          281 |          281 | ok | optimal | 0.14 |            - | n/a | SKIPPED | 0.00 |
+| st_miqp2 |            2 |            2 | ok | optimal | 0.15 |            - | n/a | SKIPPED | 0.00 |
+| st_miqp3 |           -6 |           -6 | ok | optimal | 0.14 |            - | n/a | SKIPPED | 0.00 |
+| st_miqp4 |        -4574 |        -4574 | ok | optimal | 0.15 |            - | n/a | SKIPPED | 0.00 |
+| st_test1 |            0 |  -1.6496e-08 | ok | optimal | 0.15 |            - | n/a | SKIPPED | 0.00 |
+| st_testgr3 |       -20.59 |       -20.59 | ok | optimal | 0.22 |            - | n/a | SKIPPED | 0.00 |
+| tanksize |       1.2686 |       1.2686 | ok | feasible | 60.09 |            - | n/a | SKIPPED | 0.00 |
+| tls2 |          5.3 |            - | n/a | time_limit | 60.46 |            - | n/a | SKIPPED | 0.00 |
+| tspn05 |       191.26 |       191.26 | ok | optimal | 19.53 |            - | n/a | SKIPPED | 0.00 |
+| tspn08 |       290.57 |       290.57 | ok | feasible | 17.91 |            - | n/a | SKIPPED | 0.00 |
+| tspn10 |       225.13 |       225.13 | ok | feasible | 15.63 |            - | n/a | SKIPPED | 0.00 |
+| tspn12 |       262.65 |       262.65 | ok | feasible | 14.33 |            - | n/a | SKIPPED | 0.00 |
+
+## discopt convergence gaps (honest, suboptimal in budget)
+
+- **heatexch_gen2**: discopt 6.7641e+05 (`feasible`) vs global 6.3584e+05 — BARON - (also n/a)

--- a/reports/v_baron_remeasure_2026-07-07T11-06-06.json
+++ b/reports/v_baron_remeasure_2026-07-07T11-06-06.json
@@ -1,0 +1,1533 @@
+{
+  "time_limit": 60.0,
+  "timestamp": "2026-07-07T11-06-06",
+  "baseline_json": "global_opt_baron_vs_discopt_2026-07-06T03-25-20.json",
+  "note": "discopt re-run defaults-only on origin/main G1+G2; BARON reused from baseline",
+  "rows": [
+    {
+      "instance": "4stufen",
+      "known": 116329.6706,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": 19020.498520801193,
+        "gap": null,
+        "node_count": 63,
+        "wall_time": 62.648355500306934,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 116736.0469,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.43,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "GAP"
+    },
+    {
+      "instance": "alan",
+      "known": 2.925,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.924999998301341,
+        "lower_bound": 2.924999998301341,
+        "gap": 0.0,
+        "node_count": 21,
+        "wall_time": 0.1687729163095355,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 2.925,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.05,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "bchoco06",
+      "known": null,
+      "maximize": true,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 31,
+        "wall_time": 62.28345879167318,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 0.9628,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.99,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "bchoco07",
+      "known": null,
+      "maximize": true,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 7,
+        "wall_time": 62.845650541596115,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 0.963,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.1,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "bchoco08",
+      "known": null,
+      "maximize": true,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 15,
+        "wall_time": 65.60487295873463,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 0.9617,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.07,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "beuster",
+      "known": 116329.6706,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": 6351.565076176493,
+        "gap": null,
+        "node_count": 31,
+        "wall_time": 61.05215129069984,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 120733.0427,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.36,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "GAP"
+    },
+    {
+      "instance": "casctanks",
+      "known": 9.163479388,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": -90.17862929102458,
+        "gap": null,
+        "node_count": 127,
+        "wall_time": 64.19884141720831,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 9.1635,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 61.11,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "chance",
+      "known": 29.89437816,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 29.894378154271102,
+        "lower_bound": 29.894378154271102,
+        "gap": 0.0,
+        "node_count": 0,
+        "wall_time": 0.38776008412241936,
+        "error": null
+      },
+      "baron": {
+        "status": "2 Locally Optimal",
+        "objective": 29.8944,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.006,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "clay0303hfsg",
+      "known": 26669.10957,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 26669.10955143382,
+        "lower_bound": 26669.109551433936,
+        "gap": 0.0,
+        "node_count": 229,
+        "wall_time": 25.249535416718572,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 26669.1096,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 1.42,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "contvar",
+      "known": 809149.8272,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 809149.8138136583,
+        "lower_bound": 174044.7144558017,
+        "gap": 0.7849042149123167,
+        "node_count": 63,
+        "wall_time": 60.80020304210484,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 809149.8272,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.17,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "cvxnonsep_nsig30",
+      "known": 130.6287126,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 130.62871116925294,
+        "lower_bound": 130.61841392487688,
+        "gap": 7.882808727819201e-05,
+        "node_count": 165,
+        "wall_time": 2.7570066670887172,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 130.6287,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 1.79,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "cvxnonsep_psig30",
+      "known": 78.99885434,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 78.9988543529429,
+        "lower_bound": 78.99179874365787,
+        "gap": 8.9312555104815e-05,
+        "node_count": 89,
+        "wall_time": 1.3770153750665486,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 78.9989,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.76,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "cvxnonsep_psig40r",
+      "known": 86.5451047,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 86.5452799516496,
+        "lower_bound": 86.53872191349262,
+        "gap": 7.423014759247372e-05,
+        "node_count": 95,
+        "wall_time": 4.151557791978121,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 86.5451,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.37,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "dispatch",
+      "known": 3155.287927,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 3155.2879266989703,
+        "lower_bound": 3155.072917127798,
+        "gap": 6.814261523911746e-05,
+        "node_count": 3,
+        "wall_time": 0.4755614581517875,
+        "error": null
+      },
+      "baron": {
+        "status": "2 Locally Optimal",
+        "objective": 3155.2879,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.006,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1221",
+      "known": 7.667180069,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 7.6671800711443945,
+        "lower_bound": 7.667180058272593,
+        "gap": 1.3747612131369656e-09,
+        "node_count": 5,
+        "wall_time": 0.613023541867733,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 7.6672,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.01,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1222",
+      "known": 1.076543083,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 1.0765430648177292,
+        "lower_bound": 1.0765430463031964,
+        "gap": 0.0,
+        "node_count": 1,
+        "wall_time": 0.41427725041285157,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 1.0765,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.01,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1224",
+      "known": -0.9434705,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -0.9434704910762214,
+        "lower_bound": -0.9435072710857,
+        "gap": 3.677330332119144e-05,
+        "node_count": 53,
+        "wall_time": 2.2723040408454835,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -0.9435,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.05,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1225",
+      "known": 31.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 30.999999951817372,
+        "lower_bound": 30.999999951817376,
+        "gap": 0.0,
+        "node_count": 7,
+        "wall_time": 1.2347830422222614,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 31.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1226",
+      "known": -17.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -17.000000003900116,
+        "lower_bound": -17.000000023491527,
+        "gap": 1.1524359503259587e-09,
+        "node_count": 5,
+        "wall_time": 0.5385857499204576,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -17.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "fac2",
+      "known": 331837498.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 331837498.18201375,
+        "lower_bound": 331837497.8338103,
+        "gap": 0.0,
+        "node_count": 69,
+        "wall_time": 6.736725499853492,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 331837498.1768,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "flay02m",
+      "known": 37.94733192,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 37.947331863834606,
+        "lower_bound": 37.94733180456952,
+        "gap": 0.0,
+        "node_count": 7,
+        "wall_time": 0.5538010410964489,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 37.9473,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "flay03m",
+      "known": 48.98979486,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 48.98979479383545,
+        "lower_bound": 48.98979470823029,
+        "gap": 0.0,
+        "node_count": 111,
+        "wall_time": 7.32409125007689,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 48.9898,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.29,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "gbd",
+      "known": 2.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.199999982504936,
+        "lower_bound": 2.199999982504936,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.14908312493935227,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 2.2,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "gkocis",
+      "known": -1.923098738,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -1.9230987798770212,
+        "lower_bound": -1.9230988280923489,
+        "gap": 0.0,
+        "node_count": 5,
+        "wall_time": 0.7370092500932515,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -1.9231,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "hda",
+      "known": -5964.534084,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 7,
+        "wall_time": 65.17324233287945,
+        "error": null
+      },
+      "baron": {
+        "status": "19 Infeasible - No Solution",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.2,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "heatexch_gen1",
+      "known": 154895.933,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": 100499.99999999991,
+        "gap": null,
+        "node_count": 63,
+        "wall_time": 62.16235316591337,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 154895.933,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.82,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "heatexch_gen2",
+      "known": 635838.8464,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 676410.9816093397,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 147,
+        "wall_time": 61.208427666220814,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 635838.8465,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.3,
+        "error": null
+      },
+      "d_verdict": "GAP",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "heatexch_gen3",
+      "known": 64843.69761,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 15,
+        "wall_time": 61.435835250187665,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 64898.2283,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.33,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "GAP"
+    },
+    {
+      "instance": "m3",
+      "known": 37.8,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 37.79999966997884,
+        "lower_bound": 37.79999951039201,
+        "gap": 0.0,
+        "node_count": 61,
+        "wall_time": 4.174682250246406,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 37.8,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs01",
+      "known": 12.46966882,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 12.46966882156821,
+        "lower_bound": 12.46966880809854,
+        "gap": 1.080194672104233e-09,
+        "node_count": 17,
+        "wall_time": 3.0887217088602483,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 12.4697,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.05,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs02",
+      "known": 5.964184523,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 5.96418452307,
+        "lower_bound": 5.96418452307,
+        "gap": 0.0,
+        "node_count": 101,
+        "wall_time": 0.13330275006592274,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 5.9642,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs03",
+      "known": 16.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 16.0,
+        "lower_bound": 15.99999972676511,
+        "gap": 1.707718066956687e-08,
+        "node_count": 5,
+        "wall_time": 0.42135116597637534,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 16.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs04",
+      "known": 0.72,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 0.720000000000006,
+        "lower_bound": 0.7199999473599988,
+        "gap": 5.264000713101069e-08,
+        "node_count": 5,
+        "wall_time": 0.4876568750478327,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 0.72,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs05",
+      "known": 5.470934108,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 5.47093412640568,
+        "lower_bound": 1.348118846767416,
+        "gap": 0.7535852533371464,
+        "node_count": 733,
+        "wall_time": 60.22935925005004,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 5.4709,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.53,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs06",
+      "known": 1.7703125,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 1.7703125002341187,
+        "lower_bound": 1.7703124984296874,
+        "gap": 8.870256221212425e-10,
+        "node_count": 5,
+        "wall_time": 1.6039277920499444,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 1.7703,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs07",
+      "known": 4.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 4.0,
+        "lower_bound": 4.0,
+        "gap": 0.0,
+        "node_count": 5,
+        "wall_time": 0.041860208846628666,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 4.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs08",
+      "known": 23.44972735,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 23.449727353351044,
+        "lower_bound": 23.449382312131643,
+        "gap": 1.4713797977099544e-05,
+        "node_count": 57,
+        "wall_time": 1.0513565000146627,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 23.4497,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.05,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs09",
+      "known": -43.13433692,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": -43.13433691803531,
+        "lower_bound": -57.680145993208754,
+        "gap": 0.337221112331312,
+        "node_count": 221,
+        "wall_time": 60.05631833290681,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -43.1343,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs10",
+      "known": -310.8,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -310.79999999999995,
+        "lower_bound": -310.79999999999995,
+        "gap": 0.0,
+        "node_count": 5,
+        "wall_time": 0.0873126252554357,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -310.8,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs11",
+      "known": -431.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -431.0,
+        "lower_bound": -431.0,
+        "gap": 0.0,
+        "node_count": 39,
+        "wall_time": 0.42489937506616116,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -431.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs12",
+      "known": -481.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -481.20000000000016,
+        "lower_bound": -481.20000000000016,
+        "gap": 0.0,
+        "node_count": 195,
+        "wall_time": 1.6021957080811262,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -481.2,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs13",
+      "known": -585.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -585.2,
+        "lower_bound": -585.2000011714,
+        "gap": 2.0017087463537884e-09,
+        "node_count": 49,
+        "wall_time": 2.2692656670697033,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -585.2,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.15,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs14",
+      "known": -40358.15477,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -40358.1547693,
+        "lower_bound": -40358.1547693,
+        "gap": 0.0,
+        "node_count": 325,
+        "wall_time": 0.2861521663144231,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -40358.1548,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs15",
+      "known": 1.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 1.0,
+        "lower_bound": 1.0,
+        "gap": 0.0,
+        "node_count": 7,
+        "wall_time": 0.06036358326673508,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 1.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "oaer",
+      "known": -1.923098514,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -1.9230983037453937,
+        "lower_bound": -1.923098601139822,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 1.1834212075918913,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -1.9231,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_e13",
+      "known": 2.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.0,
+        "lower_bound": 1.9999999825187809,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.47115774964913726,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 2.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_e29",
+      "known": -0.9434705,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -0.9434704910762214,
+        "lower_bound": -0.9435072710857,
+        "gap": 3.677330332119144e-05,
+        "node_count": 53,
+        "wall_time": 3.0341386669315398,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -0.9435,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.05,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_e36",
+      "known": -246.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -246.0,
+        "lower_bound": -246.01879639837531,
+        "gap": 7.640812347689022e-05,
+        "node_count": 153,
+        "wall_time": 16.2568882079795,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -246.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.09,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_e38",
+      "known": 7197.727149,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 7197.727116839705,
+        "lower_bound": 7197.727116826533,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.6030559591017663,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 7197.7271,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_miqp1",
+      "known": 281.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 280.9999999906497,
+        "lower_bound": 280.9999999906497,
+        "gap": 0.0,
+        "node_count": 15,
+        "wall_time": 0.1441669575870037,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 281.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_miqp2",
+      "known": 2.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.0,
+        "lower_bound": 2.0,
+        "gap": 0.0,
+        "node_count": 9,
+        "wall_time": 0.14680537534877658,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 2.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_miqp3",
+      "known": -6.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -6.0,
+        "lower_bound": -6.0,
+        "gap": 0.0,
+        "node_count": 1,
+        "wall_time": 0.13911199988797307,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -6.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.01,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_miqp4",
+      "known": -4574.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -4574.000004423649,
+        "lower_bound": -4574.000004423649,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.14930287515744567,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -4574.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_test1",
+      "known": 0.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -1.6495994490692313e-08,
+        "lower_bound": -1.6495994490692313e-08,
+        "gap": 0.0,
+        "node_count": 15,
+        "wall_time": 0.15158516727387905,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 0.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_testgr3",
+      "known": -20.59,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -20.59,
+        "lower_bound": -20.59070709795548,
+        "gap": 3.434181425354089e-05,
+        "node_count": 549,
+        "wall_time": 0.21676962496712804,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -20.59,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "tanksize",
+      "known": 1.268643754,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 1.2686437480322943,
+        "lower_bound": 0.8680315476476382,
+        "gap": 0.31577990354346364,
+        "node_count": 451,
+        "wall_time": 60.087795750238,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 1.2686,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 2.65,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "tls2",
+      "known": 5.3,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 1887,
+        "wall_time": 60.461395542137325,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 5.3,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "tspn05",
+      "known": 191.2552078,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 191.25520768494184,
+        "lower_bound": 191.25288274907072,
+        "gap": 1.215420076587872e-05,
+        "node_count": 39,
+        "wall_time": 19.530149083118886,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 191.2552,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.06,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "tspn08",
+      "known": 290.5668539,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 290.5668537474048,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 1,
+        "wall_time": 17.909853290766478,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 290.5669,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "tspn10",
+      "known": 225.1260716,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 225.1260713973292,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 1,
+        "wall_time": 15.630885958205909,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 225.1261,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.11,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "tspn12",
+      "known": 262.6473957,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 262.64739525060224,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 1,
+        "wall_time": 14.332488667219877,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 262.6474,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.07,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    }
+  ]
+}


### PR DESCRIPTION
## V — default-path re-measure vs BARON after G1+G2 (defaults-only)

The roadmap's "V" milestone measurement. Re-ran **discopt defaults-only — no flags toggled** (what a real user gets) on the 61-instance MINLPLib panel at 60 s, on `origin/main` @ `0308a7d1`. The default path now carries: ILS cap (#532), PSD gate (#537), zero-spanning lift (#538), heuristic governor (#541), and the C-38 false-optimal fix (#536). BARON is reused verbatim from the 2026-07-06 baseline (only discopt changed). **Docs/results-only.**

### Headline vs baseline (42 proved-optimal, 18.83 min, 0 violations)

| metric | baseline | this run | delta |
|---|---|---|---|
| **discopt proved-optimal** | **42** | **43** | **+1** (no cert lost) |
| total wall (61) | 18.83 min | **18.18 min** | −0.65 min |
| shifted-geomean wall | 4.74 s | 4.63 s | −0.11 s |
| **VIOLATIONS** | **0** | **0** | — |

### Correctness gate — PASS (0 violations)

- discopt VIOLATIONS = 0 on the panel.
- Independent `minlplib.solu` cross-check: every `status==optimal` objective matches its `=best=`/`=opt=` oracle within tol — **no false-optimal**.
- No discopt dual bound crosses the `.solu` oracle.
- The C-40 `util` false-optimal is **not in this panel** (caught on a different held-out set); the baseline's "0 violations" needs no reconciliation here.

### Per-capability attribution (panel-visible vs invisible)

- **Real win:** `st_e36` feasible(60 s)→**optimal(16.3 s)**, 883→153 nodes — a **new cert** from the governor freeing search budget.
- **ILS cap (#532):** nvs06 −2.5 s, nvs01 −2.4 s, nvs08 −1.7 s (node-neutral — trims per-node work).
- **Panel-invisible:** the **PSD gate (#537)** and **zero-spanning lift (#538)** target the QCQP class; the QCQP probes `nvs17/19/24` are **not in this 61-panel**, so those two wins are invisible here. The small headline gain is by construction — the wins concentrate off-panel. This is the known instrument limitation.

### BARON gap

- BARON proves **44**, discopt **43**, **40 jointly**. discopt/BARON wall geomean **14.4×** on jointly-proved.
- BARON-only (4): `nvs05`, `nvs09`, `tanksize`, `tls2` (discopt returns honest GAP, not wrong).
- discopt-only (3): `chance`, `dispatch` (BARON `2 Locally Optimal`), `tspn05` (BARON `8 Integer Solution`).

### Artifacts

- `docs/dev/v-baron-remeasure-2026-07-07.md` — full before/after table + attribution.
- `reports/global_opt_baron_vs_discopt_2026-07-07T11-06-06.json` — raw discopt-only sweep.
- `reports/v_baron_remeasure_2026-07-07T11-06-06.json` — merged (this run's discopt + baseline BARON, verdicts recomputed).

### Run notes

- Release build; pounce `.so` = 4.73 MB (release, verified not debug).
- `PYTHONPATH=<wt>/python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`, harness `discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py --time-limit 60 --skip-baron`.
- No source or build files changed. Do **not** merge — numbers for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
