### PR TITLE
bench: baron_global50 head-to-head re-run (current main)

### DIFF
--- a/docs/dev/global50-rerun-2026-07-07.json
+++ b/docs/dev/global50-rerun-2026-07-07.json
@@ -1,0 +1,1256 @@
+{
+  "time_limit": 60.0,
+  "timestamp": "2026-07-07T16-38-24",
+  "rows": [
+    {
+      "instance": "alan",
+      "known": 2.925,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.924999998301341,
+        "lower_bound": 2.924999998301341,
+        "gap": 0.0,
+        "node_count": 21,
+        "wall_time": 0.16889974987134337,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 2.925,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.06,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "casctanks",
+      "known": 9.163479388,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": -90.17862929102458,
+        "gap": null,
+        "node_count": 159,
+        "wall_time": 67.0837340420112,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 9.1635,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 61.0,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "chance",
+      "known": 29.89437816,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 29.894378154271102,
+        "lower_bound": 29.894378154271102,
+        "gap": 0.0,
+        "node_count": 0,
+        "wall_time": 0.3695022091269493,
+        "error": null
+      },
+      "baron": {
+        "status": "2 Locally Optimal",
+        "objective": 29.8944,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.006,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "clay0303hfsg",
+      "known": 26669.10957,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 26669.10955143382,
+        "lower_bound": 26669.109551433936,
+        "gap": 0.0,
+        "node_count": 229,
+        "wall_time": 22.667318542022258,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 26669.1096,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 1.45,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "cvxnonsep_nsig30",
+      "known": 130.6287126,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 130.62871116925294,
+        "lower_bound": 130.61841392487688,
+        "gap": 7.882808727819201e-05,
+        "node_count": 165,
+        "wall_time": 2.6078048339113593,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 130.6287,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 1.85,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "cvxnonsep_psig30",
+      "known": 78.99885434,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 78.9988543529429,
+        "lower_bound": 78.99179874365787,
+        "gap": 8.9312555104815e-05,
+        "node_count": 89,
+        "wall_time": 1.2088319580070674,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 78.9989,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.78,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "cvxnonsep_psig40r",
+      "known": 86.5451047,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 86.5452799516496,
+        "lower_bound": 86.53872191349262,
+        "gap": 7.423014759247372e-05,
+        "node_count": 95,
+        "wall_time": 3.3855845420621336,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 86.5451,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.37,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "dispatch",
+      "known": 3155.287927,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 3155.2879266989703,
+        "lower_bound": 3155.072917127798,
+        "gap": 6.814261523911746e-05,
+        "node_count": 3,
+        "wall_time": 0.44479200011119246,
+        "error": null
+      },
+      "baron": {
+        "status": "2 Locally Optimal",
+        "objective": 3155.2879,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.007,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1221",
+      "known": 7.667180069,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 7.6671800711443945,
+        "lower_bound": 7.667180058272593,
+        "gap": 1.3747612131369656e-09,
+        "node_count": 5,
+        "wall_time": 0.548234208021313,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 7.6672,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.01,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1222",
+      "known": 1.076543083,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 1.0765430833322625,
+        "lower_bound": 1.0765430463031964,
+        "gap": 0.0,
+        "node_count": 1,
+        "wall_time": 0.3933427087031305,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 1.0765,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.01,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1224",
+      "known": -0.9434705,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -0.9434704910762214,
+        "lower_bound": -0.9435072710857,
+        "gap": 3.677330332119144e-05,
+        "node_count": 53,
+        "wall_time": 2.0769917089492083,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -0.9435,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.05,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1225",
+      "known": 31.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 30.999999951817372,
+        "lower_bound": 30.999999951817376,
+        "gap": 0.0,
+        "node_count": 7,
+        "wall_time": 1.0940775419585407,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 31.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "ex1226",
+      "known": -17.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -17.000000003900116,
+        "lower_bound": -17.000000023491527,
+        "gap": 1.1524359503259587e-09,
+        "node_count": 5,
+        "wall_time": 0.5464434996247292,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -17.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "fac2",
+      "known": 331837498.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 331837498.18201375,
+        "lower_bound": 331837497.8338103,
+        "gap": 0.0,
+        "node_count": 69,
+        "wall_time": 5.639428500086069,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 331837498.1768,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "flay02m",
+      "known": 37.94733192,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 37.947331863834606,
+        "lower_bound": 37.94733180456952,
+        "gap": 0.0,
+        "node_count": 7,
+        "wall_time": 0.5132738342508674,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 37.9473,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "flay03m",
+      "known": 48.98979486,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 48.98979479383545,
+        "lower_bound": 48.98979470823029,
+        "gap": 0.0,
+        "node_count": 111,
+        "wall_time": 6.592361166141927,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 48.9898,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.3,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "gbd",
+      "known": 2.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.199999982504936,
+        "lower_bound": 2.199999982504936,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.14881945820525289,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 2.2,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "gkocis",
+      "known": -1.923098738,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -1.9230987798770212,
+        "lower_bound": -1.9230988280923489,
+        "gap": 0.0,
+        "node_count": 5,
+        "wall_time": 0.7157849166542292,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -1.9231,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "hda",
+      "known": -5964.534084,
+      "maximize": false,
+      "discopt": {
+        "status": "time_limit",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 7,
+        "wall_time": 64.009048207663,
+        "error": null
+      },
+      "baron": {
+        "status": "19 Infeasible - No Solution",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.21,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "n/a"
+    },
+    {
+      "instance": "m3",
+      "known": 37.8,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 37.79999966997884,
+        "lower_bound": 37.79999951039201,
+        "gap": 0.0,
+        "node_count": 61,
+        "wall_time": 3.3243506252765656,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 37.8,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs01",
+      "known": 12.46966882,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 12.46966882156821,
+        "lower_bound": 12.46966880809854,
+        "gap": 1.080194672104233e-09,
+        "node_count": 17,
+        "wall_time": 2.8008102090097964,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 12.4697,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.05,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs02",
+      "known": 5.964184523,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 5.96418452307,
+        "lower_bound": 5.96418452307,
+        "gap": 0.0,
+        "node_count": 101,
+        "wall_time": 0.12717108288779855,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 5.9642,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs03",
+      "known": 16.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 16.0,
+        "lower_bound": 15.99999972676511,
+        "gap": 1.707718066956687e-08,
+        "node_count": 5,
+        "wall_time": 0.40900537511333823,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 16.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs04",
+      "known": 0.72,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 0.720000000000006,
+        "lower_bound": 0.7199999473599988,
+        "gap": 5.264000713101069e-08,
+        "node_count": 5,
+        "wall_time": 0.47938308399170637,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 0.72,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs05",
+      "known": 5.470934108,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 5.470934126405679,
+        "lower_bound": 1.348118846767416,
+        "gap": 0.7535852533371464,
+        "node_count": 827,
+        "wall_time": 60.107433250173926,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 5.4709,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.54,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs06",
+      "known": 1.7703125,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 1.7703125002341187,
+        "lower_bound": 1.7703124984296874,
+        "gap": 8.870256221212425e-10,
+        "node_count": 5,
+        "wall_time": 1.4129552501253784,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 1.7703,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs07",
+      "known": 4.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 4.0,
+        "lower_bound": 4.0,
+        "gap": 0.0,
+        "node_count": 5,
+        "wall_time": 0.03952800016850233,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 4.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs08",
+      "known": 23.44972735,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 23.449727353351044,
+        "lower_bound": 23.449382312131643,
+        "gap": 1.4713797977099544e-05,
+        "node_count": 57,
+        "wall_time": 0.9269533329643309,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 23.4497,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.05,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs09",
+      "known": -43.13433692,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": -43.13433691803531,
+        "lower_bound": -57.67146658173501,
+        "gap": 0.33701989418136724,
+        "node_count": 221,
+        "wall_time": 60.26939562475309,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -43.1343,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs10",
+      "known": -310.8,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -310.79999999999995,
+        "lower_bound": -310.79999999999995,
+        "gap": 0.0,
+        "node_count": 5,
+        "wall_time": 0.08730358304455876,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -310.8,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs11",
+      "known": -431.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -431.0,
+        "lower_bound": -431.0,
+        "gap": 0.0,
+        "node_count": 39,
+        "wall_time": 0.41423433274030685,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -431.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs12",
+      "known": -481.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -481.20000000000016,
+        "lower_bound": -481.20000000000016,
+        "gap": 0.0,
+        "node_count": 195,
+        "wall_time": 1.4885921250097454,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -481.2,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.05,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs13",
+      "known": -585.2,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -585.2,
+        "lower_bound": -585.2000011714,
+        "gap": 2.0017087463537884e-09,
+        "node_count": 49,
+        "wall_time": 1.9661892498843372,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -585.2,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.15,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs14",
+      "known": -40358.15477,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -40358.1547693,
+        "lower_bound": -40358.1547693,
+        "gap": 0.0,
+        "node_count": 325,
+        "wall_time": 0.2484681662172079,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -40358.1548,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "nvs15",
+      "known": 1.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 1.0,
+        "lower_bound": 1.0,
+        "gap": 0.0,
+        "node_count": 7,
+        "wall_time": 0.05538916680961847,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 1.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "oaer",
+      "known": -1.923098514,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -1.9230983037453937,
+        "lower_bound": -1.923098601139822,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.6601961660198867,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -1.9231,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_e13",
+      "known": 2.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.0,
+        "lower_bound": 1.9999999825187809,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.38301091734319925,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 2.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_e29",
+      "known": -0.9434705,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -0.9434704910762214,
+        "lower_bound": -0.9435072710857,
+        "gap": 3.677330332119144e-05,
+        "node_count": 53,
+        "wall_time": 2.0854089581407607,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -0.9435,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_e36",
+      "known": -246.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -246.0,
+        "lower_bound": -246.01879639837531,
+        "gap": 7.640812347689022e-05,
+        "node_count": 153,
+        "wall_time": 16.47204437525943,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -246.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.08,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_e38",
+      "known": 7197.727149,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 7197.727116839705,
+        "lower_bound": 7197.727116826533,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.5511546251364052,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 7197.7271,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_miqp1",
+      "known": 281.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 280.9999999906497,
+        "lower_bound": 280.9999999906497,
+        "gap": 0.0,
+        "node_count": 15,
+        "wall_time": 0.1337838745675981,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 281.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_miqp2",
+      "known": 2.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 2.0,
+        "lower_bound": 2.0,
+        "gap": 0.0,
+        "node_count": 9,
+        "wall_time": 0.1582299997098744,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 2.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_miqp3",
+      "known": -6.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -6.0,
+        "lower_bound": -6.0,
+        "gap": 0.0,
+        "node_count": 1,
+        "wall_time": 0.1332875001244247,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -6.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.01,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_miqp4",
+      "known": -4574.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -4574.000004423649,
+        "lower_bound": -4574.000004423649,
+        "gap": 0.0,
+        "node_count": 3,
+        "wall_time": 0.14122687466442585,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -4574.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.04,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_miqp5",
+      "known": -333.8888889,
+      "maximize": false,
+      "discopt": {
+        "status": "ERROR",
+        "objective": null,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.0013271667994558811,
+        "error": "ValueError: binary .nl format not supported: file uses the binary ('b') encoding, but only the text/ASCII ('g') format is supported. Re-export the model in text .nl format (e.g. AMPL `write g<stub>;` rather than `write b<stub>;`)"
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -333.8889,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "n/a",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_test1",
+      "known": 0.0,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -1.6495994490692313e-08,
+        "lower_bound": -1.6495994490692313e-08,
+        "gap": 0.0,
+        "node_count": 15,
+        "wall_time": 0.14912683377042413,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 0.0,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.02,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "st_testgr3",
+      "known": -20.59,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": -20.59,
+        "lower_bound": -20.59070709795548,
+        "gap": 3.434181425354089e-05,
+        "node_count": 549,
+        "wall_time": 0.21389745827764273,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": -20.59,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "tanksize",
+      "known": 1.268643754,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 1.2686437480322943,
+        "lower_bound": 0.8680315476476382,
+        "gap": 0.31577990354346364,
+        "node_count": 555,
+        "wall_time": 60.103311708197,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 1.2686,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 2.85,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "tls2",
+      "known": 5.3,
+      "maximize": false,
+      "discopt": {
+        "status": "feasible",
+        "objective": 5.299999922109238,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 1915,
+        "wall_time": 60.027052875142545,
+        "error": null
+      },
+      "baron": {
+        "status": "1 Optimal",
+        "objective": 5.3,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 0.03,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    },
+    {
+      "instance": "tspn05",
+      "known": 191.2552078,
+      "maximize": false,
+      "discopt": {
+        "status": "optimal",
+        "objective": 191.25520768494184,
+        "lower_bound": 191.25288274907072,
+        "gap": 1.215420076587872e-05,
+        "node_count": 39,
+        "wall_time": 21.042134707793593,
+        "error": null
+      },
+      "baron": {
+        "status": "8 Integer Solution",
+        "objective": 191.2552,
+        "lower_bound": null,
+        "gap": null,
+        "node_count": 0,
+        "wall_time": 60.08,
+        "error": null
+      },
+      "d_verdict": "ok",
+      "b_verdict": "ok"
+    }
+  ]
+}

--- a/docs/dev/global50-rerun-2026-07-07.md
+++ b/docs/dev/global50-rerun-2026-07-07.md
@@ -1,0 +1,134 @@
+# baron_global50 head-to-head re-run — current `main` (2026-07-07)
+
+Re-run of the 50-instance curated global-opt head-to-head (`discopt_benchmarks/config/baron_global50.txt`)
+against full-license BARON (via GAMS 53), on the current solver
+(`origin/main` @ `d1b09d3e`, all this session's wins default-ON: ILS cap, PSD
+gate, zero-spanning lift, effort governor, plus the C-38/C-40 correctness fixes).
+
+- **Solver build:** `maturin develop --release` (pounce `_pounce.abi3.so` = 4.5 MB,
+  confirmed a release build — debug timings would be meaningless).
+- **Harness:** `discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py`,
+  `--time-limit 60`, both solvers fresh (no reuse). BARON driven the established
+  way: `gams <name>.gms minlp=baron optcr=0 optca=1e-9 reslim=60`.
+- **Correctness tol:** abs=1e-6, rel=1e-4. Oracle: MINLPLib `primalbound`
+  (harness) **and** an independent cross-check against
+  `~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu`
+  (`=opt=`/`=best=` primal, `=bestdual=` dual).
+- **Raw JSON:** `docs/dev/global50-rerun-2026-07-07.json`.
+
+## HARD CORRECTNESS GATE — PASS (0 violations)
+
+Independent cross-check of every discopt certified-optimal incumbent and every
+discopt dual bound against `minlplib.solu`:
+
+- **discopt VIOLATIONS: 0** — no false-optimal, no incumbent strictly better than
+  the proven global, no dual bound crossing the oracle.
+- **BARON VIOLATIONS: 0.**
+
+This confirms the C-38/C-40 fixes hold on the global50 set specifically (the
+session's 250-instance sweep was clean; this is the confirmation on this panel).
+
+## Headline
+
+| metric | discopt (now) | discopt (prior 06-18) | BARON (fresh) |
+|---|---|---|---|
+| proved-optimal / 50 | **43** | 0 | 45 |
+| total wall (s) | 476.6 | — | 130.9 |
+| geomean wall (s, all 50) | 1.037 | — | 0.068 |
+
+The story is the **discopt delta: 0 → 43 proved-optimal / 50**. The prior 06-18
+run (baron 31/50, discopt 0/50) predates every relaxation/bounding/correctness
+change in this session; discopt now certifies global optimality on 43 of the 50.
+
+> "proved-optimal" = a *certified* global (discopt status `optimal`; BARON model
+> status `1 Optimal`). BARON's `2 Locally Optimal` and `8 Integer Solution` are
+> **not** certified global and do not count.
+
+## The gap vs BARON
+
+- **Jointly proved-optimal: 40.** On those 40, geomean wall: discopt 0.645 s vs
+  BARON 0.049 s → **discopt ≈ 13.3× slower** on the jointly-proved set. BARON is
+  still much faster per-instance; the gap is bounding/convergence speed, not
+  correctness.
+- **discopt-only proved (3):** `chance`, `dispatch`, `tspn05`. discopt certifies
+  the global here while BARON stops at a *locally* optimal / integer-solution
+  status (uncertified) within the 60 s budget.
+- **BARON-only proved (5):** `nvs05`, `nvs09`, `tanksize`, `tls2`, `st_miqp5`.
+  - `nvs05`, `nvs09`, `tanksize`, `tls2`: discopt found the **correct incumbent**
+    (matches the oracle) but exhausted the 60 s budget without closing the gap —
+    honest convergence gaps, not correctness failures. Dual bounds are valid
+    (never cross the oracle).
+  - `st_miqp5`: **data artifact, not a solver failure.** This instance is not in
+    the vendored `python/tests/data/minlplib_nl/` corpus; the copy drawn from the
+    full MINLPLib snapshot is in **binary `.nl`** format (`b` encoding), which the
+    parser correctly refuses with a loud error (only text/`g` `.nl` is supported).
+- **Two honest time-limits with no incumbent:** `casctanks`, `hda` — discopt
+  returned no feasible point in 60 s (BARON: `casctanks` `8 Integer Solution`
+  uncertified, `hda` `19 Infeasible` — an intermediate/relaxation status).
+  `casctanks`'s discopt dual bound (-90.18) does **not** cross the oracle (9.16) —
+  a valid lower bound.
+
+## Per-instance results
+
+| instance | solu best | discopt obj | discopt status | d wall (s) | BARON obj | BARON status | b wall (s) |
+|---|---|---|---|---|---|---|---|
+| alan | 2.925 | 2.925 | optimal | 0.2 | 2.925 | 1 Optimal | 0.1 |
+| casctanks | 9.1635 | — | time_limit | 67.1 | 9.1635 | 8 Integer Solution | 61.0 |
+| chance | 29.894 | 29.894 | optimal | 0.4 | 29.894 | 2 Locally Optimal | 0.0 |
+| clay0303hfsg | 26669 | 26669 | optimal | 22.7 | 26669 | 1 Optimal | 1.4 |
+| cvxnonsep_nsig30 | 130.63 | 130.63 | optimal | 2.6 | 130.63 | 1 Optimal | 1.9 |
+| cvxnonsep_psig30 | 78.999 | 78.999 | optimal | 1.2 | 78.999 | 1 Optimal | 0.8 |
+| cvxnonsep_psig40r | 86.545 | 86.545 | optimal | 3.4 | 86.545 | 1 Optimal | 0.4 |
+| dispatch | 3155.3 | 3155.3 | optimal | 0.4 | 3155.3 | 2 Locally Optimal | 0.0 |
+| ex1221 | 7.6672 | 7.6672 | optimal | 0.5 | 7.6672 | 1 Optimal | 0.0 |
+| ex1222 | 1.0765 | 1.0765 | optimal | 0.4 | 1.0765 | 1 Optimal | 0.0 |
+| ex1224 | -0.94347 | -0.94347 | optimal | 2.1 | -0.9435 | 1 Optimal | 0.1 |
+| ex1225 | 31 | 31 | optimal | 1.1 | 31 | 1 Optimal | 0.0 |
+| ex1226 | -17 | -17 | optimal | 0.5 | -17 | 1 Optimal | 0.0 |
+| fac2 | 3.3184e+08 | 3.3184e+08 | optimal | 5.6 | 3.3184e+08 | 1 Optimal | 0.0 |
+| flay02m | 37.947 | 37.947 | optimal | 0.5 | 37.947 | 1 Optimal | 0.0 |
+| flay03m | 48.99 | 48.99 | optimal | 6.6 | 48.99 | 1 Optimal | 0.3 |
+| gbd | 2.2 | 2.2 | optimal | 0.1 | 2.2 | 1 Optimal | 0.0 |
+| gkocis | -1.9231 | -1.9231 | optimal | 0.7 | -1.9231 | 1 Optimal | 0.0 |
+| hda | -5964.5 | — | time_limit | 64.0 | — | 19 Infeasible | 0.2 |
+| m3 | 37.8 | 37.8 | optimal | 3.3 | 37.8 | 1 Optimal | 0.0 |
+| nvs01 | 12.47 | 12.47 | optimal | 2.8 | 12.47 | 1 Optimal | 0.1 |
+| nvs02 | 5.9642 | 5.9642 | optimal | 0.1 | 5.9642 | 1 Optimal | 0.0 |
+| nvs03 | 16 | 16 | optimal | 0.4 | 16 | 1 Optimal | 0.0 |
+| nvs04 | 0.72 | 0.72 | optimal | 0.5 | 0.72 | 1 Optimal | 0.0 |
+| nvs05 | 5.4709 | 5.4709 | feasible | 60.1 | 5.4709 | 1 Optimal | 0.5 |
+| nvs06 | 1.7703 | 1.7703 | optimal | 1.4 | 1.7703 | 1 Optimal | 0.0 |
+| nvs07 | 4 | 4 | optimal | 0.0 | 4 | 1 Optimal | 0.0 |
+| nvs08 | 23.45 | 23.45 | optimal | 0.9 | 23.45 | 1 Optimal | 0.1 |
+| nvs09 | -43.134 | -43.134 | feasible | 60.3 | -43.134 | 1 Optimal | 0.0 |
+| nvs10 | -310.8 | -310.8 | optimal | 0.1 | -310.8 | 1 Optimal | 0.0 |
+| nvs11 | -431 | -431 | optimal | 0.4 | -431 | 1 Optimal | 0.0 |
+| nvs12 | -481.2 | -481.2 | optimal | 1.5 | -481.2 | 1 Optimal | 0.1 |
+| nvs13 | -585.2 | -585.2 | optimal | 2.0 | -585.2 | 1 Optimal | 0.1 |
+| nvs14 | -40358 | -40358 | optimal | 0.2 | -40358 | 1 Optimal | 0.0 |
+| nvs15 | 1 | 1 | optimal | 0.1 | 1 | 1 Optimal | 0.0 |
+| oaer | -1.9231 | -1.9231 | optimal | 0.7 | -1.9231 | 1 Optimal | 0.0 |
+| st_e13 | 2 | 2 | optimal | 0.4 | 2 | 1 Optimal | 0.0 |
+| st_e29 | -0.94347 | -0.94347 | optimal | 2.1 | -0.9435 | 1 Optimal | 0.0 |
+| st_e36 | -246 | -246 | optimal | 16.5 | -246 | 1 Optimal | 0.1 |
+| st_e38 | 7197.7 | 7197.7 | optimal | 0.6 | 7197.7 | 1 Optimal | 0.0 |
+| st_miqp1 | 281 | 281 | optimal | 0.1 | 281 | 1 Optimal | 0.0 |
+| st_miqp2 | 2 | 2 | optimal | 0.2 | 2 | 1 Optimal | 0.0 |
+| st_miqp3 | -6 | -6 | optimal | 0.1 | -6 | 1 Optimal | 0.0 |
+| st_miqp4 | -4574 | -4574 | optimal | 0.1 | -4574 | 1 Optimal | 0.0 |
+| st_miqp5 | -333.89 | ERROR (binary .nl) | ERROR | 0.0 | -333.89 | 1 Optimal | 0.0 |
+| st_test1 | 0 | -1.6496e-08 | optimal | 0.1 | 0 | 1 Optimal | 0.0 |
+| st_testgr3 | -20.59 | -20.59 | optimal | 0.2 | -20.59 | 1 Optimal | 0.0 |
+| tanksize | 1.2686 | 1.2686 | feasible | 60.1 | 1.2686 | 1 Optimal | 2.9 |
+| tls2 | 5.3 | 5.3 | feasible | 60.0 | 5.3 | 1 Optimal | 0.0 |
+| tspn05 | 191.26 | 191.26 | optimal | 21.0 | 191.26 | 8 Integer Solution | 60.1 |
+
+## Bottom line
+
+- **Correctness gate: 0 violations** (independent solu cross-check) — clean.
+- **discopt: 43/50 proved-optimal**, up from **0/50** at the 06-18 baseline —
+  the structural win of this session lands on the curated global set.
+- **Remaining gap to BARON** is convergence *speed* (≈13× geomean on jointly
+  proved, 4 honest gaps where discopt has the right incumbent but can't close the
+  bound in 60 s), plus one data-format artifact (`st_miqp5` binary `.nl`) and two
+  no-incumbent time-limits (`casctanks`, `hda`). No correctness debt.


### PR DESCRIPTION
Re-run of the 50-instance curated global-opt head-to-head
(`discopt_benchmarks/config/baron_global50.txt`) vs full-license BARON
(GAMS 53) on **current `main`** (`d1b09d3e`), with all of this session's
wins default-ON (ILS cap, PSD gate, zero-spanning lift, effort governor)
plus the C-38/C-40 correctness fixes. **Results-only PR.**

- Release build (pounce `_pounce.abi3.so` = 4.5 MB, confirmed not debug).
- `--time-limit 60`, both solvers fresh (no reuse).
- BARON: `gams <name>.gms minlp=baron optcr=0 optca=1e-9 reslim=60`.

## HARD CORRECTNESS GATE — PASS (0 violations)

Independent cross-check of every discopt certified-optimal incumbent and
every discopt dual bound against `minlplib.solu` (`=opt=`/`=best=` primal,
`=bestdual=` dual):

- **discopt VIOLATIONS: 0** — no false-optimal, no incumbent better than the
  proven global, no dual bound crossing the oracle.
- **BARON VIOLATIONS: 0.**

## Headline

| metric | discopt (now) | discopt (prior 06-18) | BARON (fresh) |
|---|---|---|---|
| proved-optimal / 50 | **43** | 0 | 45 |
| total wall (s) | 476.6 | — | 130.9 |
| geomean wall (s) | 1.037 | — | 0.068 |

The story is the **discopt delta: 0 -> 43 proved-optimal / 50**. The prior
06-18 run (baron 31/50, discopt 0/50) predates all the session's work.

("proved-optimal" = certified global: discopt `optimal`, BARON `1 Optimal`.
BARON's `2 Locally Optimal` / `8 Integer Solution` do not count.)

## The gap vs BARON

- **Jointly proved-optimal: 40.** Geomean wall on those: discopt 0.645 s vs
  BARON 0.049 s -> discopt ~13.3x slower. The gap is convergence *speed*, not
  correctness.
- **discopt-only proved (3):** `chance`, `dispatch`, `tspn05` (BARON stopped at
  a locally-optimal / integer-solution status, uncertified).
- **BARON-only proved (5):** `nvs05`, `nvs09`, `tanksize`, `tls2` (discopt has
  the correct incumbent but hit the 60 s budget -- honest gaps, valid bounds) +
  `st_miqp5` (**data artifact**: not in the vendored corpus; the snapshot copy is
  binary `.nl`, which the parser correctly refuses).
- **Two no-incumbent time-limits:** `casctanks`, `hda` (no feasible point in
  60 s; `casctanks` dual bound does not cross the oracle).

Full per-instance table + raw JSON in `docs/dev/global50-rerun-2026-07-07.md`
and `docs/dev/global50-rerun-2026-07-07.json`.

**Bottom line:** correctness gate clean; discopt 43/50 proved-optimal up from
0/50; remaining gap to BARON is speed + one data-format artifact. No
correctness debt.

Do not merge (results-only record).
