### PR TITLE
perf(node): THRU-4 — root-cut-pool inheritance for square/PSD separation (36x ceiling)

### DIFF
--- a/docs/dev/thru4-cut-inheritance-2026-07-07.md
+++ b/docs/dev/thru4-cut-inheritance-2026-07-07.md
@@ -1,0 +1,191 @@
+# THRU-4 — root-cut-pool inheritance for square/PSD separation (2026-07-07)
+
+**Task.** THRU-3 (`docs/dev/thru3-node-decomp-2026-07-07.md`, PR #550) measured
+that the dominant per-node cost on the dense integer-QP class is the pair of
+per-node point-separation loops — `_separate_univariate_square` (73% of the
+nvs24 solve wall) and `_separate_psd` (12%) — each re-deriving its cut family
+via up to 8 full MILP re-solves at EVERY node; with both off, nvs24 runs 9→309
+nodes (36×) at essentially unchanged bound-at-TL. THRU-4 implements the lever
+(BARON's architecture): separate fully at the ROOT, pool the cuts, and INHERIT
+them at every node instead of re-separating — keeping the root tightness while
+approaching the 36× throughput ceiling.
+
+Base: branched from `origin/main` @ `3d736c9a` (PR #550 still OPEN at branch
+time — its default-OFF `DISCOPT_SQUARE_COST_GATE` prototype, measured
+throughput-inert, was absent, so the baseline behaviour equals THRU-3's
+baseline, reproduced below to the node). #550 merged mid-task; the branch was
+**rebased onto `2d4d1efa`** (post-#550 main) with both features kept
+side-by-side (the square-cost-gate remains default-OFF and orthogonal), and the
+flag-ON fire test re-run post-rebase reproduces the pre-rebase result exactly
+(nvs19: optimal, 367 nodes, 53.0 s, pool 70/357/357, root −1104.2400022094807).
+
+Build: release (`maturin develop --release`), pounce `_pounce.abi3.so` 4.73 MB.
+Env: `PYTHONPATH=<wt>/python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`, TL 60 s.
+Oracle (`minlplib.solu`): nvs24 = −1033.2, nvs19 = −1098.4, nvs17 = −1100.4,
+nvs23 = −1125.2, nvs10 = −310.8, nvs13 = −585.2.
+
+## Part 1 — per-family validity classification (the soundness crux)
+
+Every cut family the node separation chain can emit, classified for
+inheritance from a ROOT-box pool into descendant sub-boxes. The governing
+fact: a pool row is inherited soundly iff it is valid at every feasible lifted
+point of the *root* box — every child's feasible set is a subset of the
+root's, so root-box validity implies validity on every descendant. The hazard
+is the reverse direction only (a cut separated on a CHILD box need not hold on
+a sibling), which the design excludes by pooling **only rows captured at the
+root box**.
+
+| family | cut form | classification | inherit? |
+|---|---|---|---|
+| `_separate_univariate_square` | tangent `s ≥ 2·x0·x − x0²` at the LP point | **globally valid** — a tangent of the convex `x²` under-estimates it on all of ℝ; coefficients carry no box bound | yes, directly |
+| `_separate_psd` | eigencut `vᵀMv ≥ 0`, `M = [[1,xᵀ],[x,X]]`, linearized on `(x, X)` | **globally valid** — `vᵀMv = (v₀ + v_rᵀx)² ≥ 0` wherever the lifting relations `X = x xᵀ` hold; the eigenvector `v` fixes coefficients, no box bound enters (verified in `psd_cuts.py::psd_cut_from_submatrix`) | yes, directly |
+| `_separate_convex` (#358 composite lifts) | supporting tangent of a convex (resp. concave) claimed subexpression | **root-box valid** — the claimer certifies curvature over the root box; the tangent under/over-estimates `g` on that box, hence on every sub-box | yes (root capture only) |
+| `_separate_multilinear` | over-cap multilinear envelope facets built from `milp._bounds` | **box-dependent** — envelope of the *capture-time* box; valid on that box and all its sub-boxes, invalid on points outside it | yes (root capture only); NEVER from node solves |
+| `_separate_edge_concave` | vertex-polyhedral hull hyperplanes of the current box | **box-dependent** — same as above | yes (root capture only); NEVER from node solves |
+| `_separate_rlt` | `(b − aᵀx)(x_j − l) ≥ 0` linearized, `l`/`u` the capture-time bounds | **box-dependent** — the bound factor is nonnegative only inside the capture-time box | yes (root capture only); NEVER from node solves |
+| static child-box relaxation rows (e.g. secant `s ≤ (l+u)x − lu`) | not emitted by any separator, but the canonical counter-example | **box-dependent and NOT pooled** — the regression test demonstrates a child-box secant cutting a root-feasible point | excluded by construction |
+
+No family had to be excluded from *root-pool* inheritance: root-box validity
+is sufficient for descent, and both measured-dominant families (square, PSD)
+are in fact globally valid — box-independent — so their pooled rows are exact,
+not loosened, on every child. The kill criterion ("every material family
+box-dependent and un-inheritable") did not trigger.
+
+**Lazy re-separation not needed (measured).** The pool rows are appended to
+each node's relaxation before the solve, so the node LP optimum satisfies them
+by construction; the only "lazy" trigger available is *fresh point separation*
+at the node LP optimum, which is exactly the loop being removed. THRU-3's
+`both_off` control already measured the no-re-separation end point: bound-at-TL
+essentially unchanged (nvs24 −1035.66→−1035.38 with NO cuts at all; here the
+pool retains the root cuts so the flag-ON bound-at-TL is *identical*, see
+below). Re-separation is therefore skipped entirely at nodes, per that
+measurement.
+
+## Part 2 — design
+
+Default-OFF flag: `DISCOPT_CUT_INHERIT` / `SolverTuning(cut_inherit=True)`.
+
+* **Root (unchanged behaviour):** the existing general root-cut-pool capture
+  (cert:T1.3, `solve_at_node(..., out_cuts=...)`) runs the full default
+  separation chain once on the root box and captures every appended row. With
+  the flag on this capture is additionally performed when the incremental
+  engine is unavailable (the cold-path instances are exactly where THRU-3
+  measured the drag). Root separation rounds/parameters are untouched, so root
+  tightness is retained — verified: the reported root bound is byte-identical
+  flag-ON vs flag-OFF on both targets (nvs24 −1035.6600020723224,
+  nvs19 −1104.2400022094807).
+* **Nodes:** each node still receives `inherited_cuts=_root_cut_pool`
+  (pre-existing mechanism, column-layout-gated), and with the flag on passes
+  `skip_pool_separators=True` to `solve_at_node`, which skips ONLY the
+  univariate-square and PSD point-separation loops (the two measured, pooled
+  families). The rest of the chain (multilinear / edge-concave / convex / RLT)
+  is untouched — each was <1% of the node wall in THRU-3's decomposition.
+  Skipping separation only *loosens* a node's relaxation; it can never cut a
+  feasible point or raise a bound — sound by construction.
+* **Instrumentation** (`solver_stats`): `pool/size` (rows in the root pool),
+  `pool/inherited_nodes`, `pool/inherited_rows` (fast + cold paths),
+  `pool/skipped_separations` (node solves that skipped the square/PSD loops).
+
+## Measurements (TL 60 s, single runs, same machine)
+
+### Targets
+
+| instance | arm | status | nodes | nodes/s | bound@TL | incumbent | root bound | pool |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| nvs24 | OFF (default) | feasible | 9 | 0.14 | −1035.66 | −1031.80 | −1035.6600020723224 | — |
+| nvs24 | **ON** | feasible | **49** | **0.76 (5.3×)** | **−1035.66 (same)** | −1031.80 | −1035.6600020723224 (identical) | size 30, inherited 38, skipped 38 |
+| nvs19 | OFF (default) | feasible | 197 | 3.28 | −1102.10 | −1098.20 | −1104.2400022094807 | — |
+| nvs19 | **ON** | **optimal (CERTIFIED)** | **367** | **6.93 (2.1×)** | **−1098.40 = opt** | **−1098.40 = opt** | −1104.2400022094807 (identical) | size 70, inherited 357, skipped 357 |
+
+* **nvs19 now CERTIFIES at 60 s** (gap 0.0, wall 52.9 s) — the incumbent
+  reaches the oracle optimum −1098.4 and the dual bound closes on it. Baseline
+  times out at 0.35% gap.
+* **nvs24**: 5.3× node throughput at *identical* bound-at-TL and incumbent.
+  Not the 36× ceiling: THRU-3 already showed nvs24's residual floor is the
+  base per-node MILP simplex solve (48% of samples) plus the root separation
+  wall (~16 s of the 60 s TL is the flag-ON root probe + pool capture — the
+  retained root-tightness cost); `both_off`'s 309 nodes came from a
+  *structurally smaller* LP (no lifted aux columns), which inheritance
+  deliberately does not give up. 49 nodes at the same tight bound strictly
+  dominates the baseline 9.
+* Per-node separation wall collapses as designed: nvs24
+  `separate/univariate_square` 45.7 s → 16.1 s (all remaining time is the
+  root probe + root pool capture, i.e. unchanged root behaviour),
+  `separate/psd` 7.7 s → 0.0 s; nvs19 24.9 s → 0.2 s and 12.2 s → 0.04 s.
+
+### QCQP control set (root tightness + certificates retained)
+
+| instance | arm | status | nodes | wall (s) | bound@TL | incumbent | root bound | oracle |
+|---|---|---|---:|---:|---:|---:|---:|---:|
+| nvs17 | OFF | optimal | 173 | 23.3 | −1100.41 | −1100.4 | −1105.89 | −1100.4 |
+| nvs17 | **ON** | optimal | 213 | **14.1 (1.65× faster cert)** | −1100.40 | −1100.4 | −1105.89 (identical) | −1100.4 |
+| nvs23 | OFF | feasible | 69 | 60.1 | −1130.50 | −1125.2 | −1130.70 | −1125.2 |
+| nvs23 | **ON** | feasible | **147 (2.1×)** | 60.2 | **−1130.41 (tighter)** | −1125.2 | −1130.70 (identical) | −1125.2 |
+| nvs10 | OFF | optimal | 5 | 0.1 | −310.8 | −310.8 | −397.0 | −310.8 |
+| nvs10 | ON | optimal | 5 | 0.1 | −310.8 | −310.8 | −397.0 (identical; no pool — sub-second cert) | −310.8 |
+| nvs13 | OFF | optimal | 49 | 1.9 | −585.2 | −585.2 | −590.37 | −585.2 |
+| nvs13 | ON | optimal | 53 | 1.5 | −585.2 | −585.2 | −590.37 (identical) | −585.2 |
+
+No control regressed: every certificate is retained (nvs17 certifies 1.65×
+faster), every root bound is identical flag-ON vs flag-OFF, every dual bound
+stays ≤ the oracle optimum and ≤ its incumbent, and the two TL-bound instances
+gain nodes (nvs23 2.1×) at same-or-tighter bound-at-TL. Pool fire-proof on all
+pool-eligible controls: nvs17 size 59 / inherited 209 / skipped 209; nvs23
+size 82 / inherited 109 / skipped 109; nvs13 size 36 / inherited 53 /
+skipped 53. (nvs17/nvs13/nvs23 already built a pool flag-OFF via the
+pre-existing cert:T1.3 incremental-path capture — the flag adds the *skip*;
+on nvs19/nvs24, where the incremental engine declines, the flag adds the pool
+capture itself.)
+
+## Verification (bound-changing regime, CLAUDE.md §5)
+
+* **Differential:** on every arm of every instance above, the reported dual
+  bound is ≤ the oracle optimum (min sense) and ≤ the incumbent — no bound
+  crossed the optimum. The ROOT bound is byte-identical flag-ON vs flag-OFF on
+  nvs19/nvs24 (root behaviour unchanged).
+* **Feasible-point sampling:** the captured root pools on nvs19 (70 rows),
+  nvs24 (95 rows), nvs17 (59 rows) were evaluated at 2000 random integer
+  feasible points each (exact lifted vectors): max violation 4.9e−32 — no
+  pooled cut removes any feasible point, hence none can cut a point of any
+  child box.
+* **Regression tests** (`python/tests/test_cut_inherit_pool.py`, smoke-marked):
+  (1) every pooled root cut holds at EVERY feasible lifted point of a dense
+  integer-QP box (exhaustive); (2) the box-dependence hazard is pinned — a
+  CHILD-box relaxation row (sub-box secant/envelope) provably cuts a
+  root-feasible point, the shipped root pool does not, and the flag-ON solve
+  still certifies the brute-force optimum naive child-row inheritance would
+  have fathomed; (3) default-off runs perform no pool-skip.
+* **Cert-neutrality (default OFF):** `check_cert_neutrality.py` — **40/41
+  byte-identical** (`nodes n->n`, `|Δobj|=0.00e+00` on every row). The one
+  flagged row — `nvs13 node_count 19 -> 49` — is the SAME pre-existing
+  baseline drift on `main` that THRU-3 (#550) already root-caused: re-solving
+  nvs13 on the BARE branch point (this diff stashed) yields **49 nodes,
+  objective −585.2** — identical to this branch's default-OFF run (49 nodes,
+  −585.2, see the control table). The committed `cert-baseline.jsonl` (19
+  nodes) predates a since-merged main commit that moved nvs13; the default-OFF
+  path of THIS change is verifiably byte-identical (49 → 49, |Δobj| = 0).
+  Refreshing the stale baseline remains out of scope (unrelated main drift,
+  same disposition as #550).
+
+## Gates
+
+* `pytest -m smoke`: **620 passed, 14 skipped** (includes the 3 new
+  smoke-marked pool tests); re-run post-rebase.
+* Adversarial: `pytest -m slow python/tests/test_adversarial_recent_fixes.py`
+  — **10 passed**; re-run post-rebase.
+* `ruff check` + `ruff format --check`: clean (re-run post-rebase).
+* Pre-commit `mypy` (the actual hook, whole-package): **Passed** (re-run
+  post-rebase).
+* `cargo test -p discopt-core`: n/a — no Rust touched.
+* Fire-proof: `pool/size` 30–95, `pool/inherited_nodes` and
+  `pool/skipped_separations` fire on every pool-eligible instance (tables
+  above); `pool/skipped_separations == 0` on every default-OFF run.
+
+## Follow-on (recorded, not shipped here)
+
+* Differential nightly greening before any default-ON discussion (CLAUDE.md
+  §5 bound-changing regime).
+* nvs24's residual ceiling: the base per-node MILP simplex solve (THRU-3's
+  `solve_milp` 48% floor) and the ~16 s root separation wall. The next
+  throughput levers on this class are a cheaper base node LP (warm-start /
+  structure) and a root-separation budget — not more per-node cut work.

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -260,6 +260,18 @@ class MccormickLPRelaxer:
         # (budget or diminishing-returns early-exit). Pure instrumentation; used to
         # prove the default-OFF gate actually engages. Zero on the default path.
         self._square_gate_fires: int = 0
+        # Root-cut-pool inheritance counters (THRU-4, ``DISCOPT_CUT_INHERIT``).
+        # Pure instrumentation — never affects control flow or the emitted cuts:
+        #   * inherited_nodes / inherited_rows: node solves that appended the
+        #     root pool (and how many rows in total), across the cold AND fast
+        #     paths;
+        #   * skipped_separations: node solves where the square/PSD point
+        #     separators were skipped in favour of the inherited pool.
+        self._pool_stats: dict[str, int] = {
+            "inherited_nodes": 0,
+            "inherited_rows": 0,
+            "skipped_separations": 0,
+        }
         # Spatial-BB uses standard McCormick globally — no partitioning here.
         self._disc = DiscretizationState(partitions={})
         self._n_orig = sum(v.size for v in model._variables)
@@ -476,6 +488,8 @@ class MccormickLPRelaxer:
                         and len(b_rows) == a_rows.shape[0]
                     ):
                         cut_rows = list(zip(a_rows, b_rows))
+                        self._pool_stats["inherited_nodes"] += 1
+                        self._pool_stats["inherited_rows"] += len(cut_rows)
             A, b, bounds = inc.assemble(lb, ub, cut_rows=cut_rows)
             nrows = int(A.shape[0])
             # Densification guard (Issue #20), same cap as the cold path below.
@@ -663,6 +677,7 @@ class MccormickLPRelaxer:
         out_cuts: Optional[list] = None,
         psd_max_rounds: int = 8,
         want_marginals: bool = False,
+        skip_pool_separators: bool = False,
     ) -> MccormickLPResult:
         """Solve the McCormick LP relaxation restricted to the given bound box.
 
@@ -683,6 +698,17 @@ class MccormickLPRelaxer:
         * ``out_cuts``: when a list is supplied, the rows the separation chain
           appended at THIS call are pushed onto it as ``(A_rows, b_rows)`` — used
           to capture the root pool once and replay it at every node.
+        * ``skip_pool_separators``: skip ONLY the two point-separation loops the
+          root pool already covers — the univariate-square tangent loop and the
+          PSD (moment) loop — while keeping the rest of the chain. Set by the
+          driver at non-pool node solves under ``DISCOPT_CUT_INHERIT`` (THRU-4):
+          those loops each re-derive the pool's cut families via up to 8 full
+          MILP re-solves per node (73% + 12% of the nvs24 solve wall, THRU-3),
+          and every cut they emit is valid independent of the node box (a square
+          tangent under-estimates ``x**2`` everywhere; a PSD eigencut
+          ``vᵀMv ≥ 0`` holds wherever ``X = x xᵀ``), so the inherited root pool
+          already supplies the family and skipping re-separation only *loosens*
+          this node's relaxation — never cuts a feasible point.
         """
         # Phase-B fast path: incremental patch + warm-started solve, reusing the
         # structure built once at construction instead of a per-node cold rebuild +
@@ -844,6 +870,8 @@ class MccormickLPRelaxer:
             _ia, _ib = inherited_cuts
             if _ia is not None and _sparse_cols(_ia) == n_total:
                 _append_relax_rows(milp, _ia, _ib)
+                self._pool_stats["inherited_nodes"] += 1
+                self._pool_stats["inherited_rows"] += _sparse_rows(_ia)
         _n_base_rows = 0 if milp._A_ub is None else _sparse_rows(milp._A_ub)
 
         res = milp.solve(time_limit=_remaining(), backend=self._backend)
@@ -866,9 +894,17 @@ class MccormickLPRelaxer:
             # Univariate squares ``s = x**2``: the static envelope cuts only at the
             # box endpoints, so deep inside a wide box the convex underestimator is
             # slack. Add the exact supporting tangent at the LP point each round.
-            _t = time.perf_counter()
-            res = self._separate_univariate_square(milp, varmap, res, _deadline)
-            _st["univariate_square"] += time.perf_counter() - _t
+            # Under root-pool inheritance (THRU-4, ``skip_pool_separators``) the
+            # inherited pool already carries the root's tangents and this loop —
+            # up to 8 full MILP re-solves — is skipped; every tangent is a global
+            # underestimator of ``x**2``, so the pool rows stay valid on any
+            # sub-box and skipping only loosens the node bound (sound).
+            if skip_pool_separators:
+                self._pool_stats["skipped_separations"] += 1
+            else:
+                _t = time.perf_counter()
+                res = self._separate_univariate_square(milp, varmap, res, _deadline)
+                _st["univariate_square"] += time.perf_counter() - _t
             # Convex/concave composite lifts (#358): add the exact supporting
             # hyperplane at the LP point, closing the gap the fixed reference-point
             # gradient cuts leave. Inert unless the convex claimer lifted a node.
@@ -877,10 +913,14 @@ class MccormickLPRelaxer:
             _st["convex"] += time.perf_counter() - _t
             # PSD (moment) cuts: enforce M = [[1,x^T],[x,X]] >= 0 over fully-lifted
             # cliques. Each cut v^T M v >= 0 is valid for every feasible point
-            # (X = x x^T), so adding them only tightens the bound.
-            _t = time.perf_counter()
-            res = self._separate_psd(milp, varmap, res, _deadline, max_rounds=psd_max_rounds)
-            _st["psd"] += time.perf_counter() - _t
+            # (X = x x^T), so adding them only tightens the bound. Skipped under
+            # root-pool inheritance (THRU-4): the eigencuts are valid wherever the
+            # lifting relations hold — independent of the node box — so the
+            # inherited root pool already supplies the family.
+            if not skip_pool_separators:
+                _t = time.perf_counter()
+                res = self._separate_psd(milp, varmap, res, _deadline, max_rounds=psd_max_rounds)
+                _st["psd"] += time.perf_counter() - _t
             # Targeted RLT (constraint-factor x bound-factor) cuts.
             _t = time.perf_counter()
             res = self._separate_rlt(milp, varmap, res, _deadline)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4662,6 +4662,16 @@ def solve_model(
     # warm LP solve instead of re-separating the PSD/RLT cuts from scratch. Stays
     # None unless the relaxer carries PSD cuts (the nvs* / box-QP regime).
     _root_cut_pool = None
+    # Root-cut-pool inheritance (THRU-4, ``DISCOPT_CUT_INHERIT`` /
+    # ``SolverTuning.cut_inherit``, default OFF). When on: (a) the general root
+    # cut pool below is captured even when the incremental engine is unavailable
+    # (the cold-path instances are exactly where THRU-3 measured the per-node
+    # separation drag), and (b) every node solve passes
+    # ``skip_pool_separators=True`` so the square/PSD point-separation loops —
+    # up to 8 full MILP re-solves per node each, 73%+12% of the nvs24 solve wall
+    # — are replaced by the inherited pool. Root behaviour is unchanged: the
+    # pool is separated with the full default chain on the root box.
+    _cut_inherit = _tuning().cut_inherit
     # The dual bound the root cut-pool relaxation proves over the whole feasible
     # region (a valid global lower bound for a MINIMIZE). The pool is separated for
     # its CUT ROWS, but the strengthened relaxation also yields a far tighter root
@@ -4999,7 +5009,7 @@ def solve_model(
                         except Exception as _pool_exc:  # pragma: no cover - defensive
                             logger.debug("root cut pool separation skipped: %s", _pool_exc)
                             _root_cut_pool = None
-                    elif getattr(_mc_lp_relaxer, "_inc", None) is not None:
+                    elif getattr(_mc_lp_relaxer, "_inc", None) is not None or _cut_inherit:
                         # Root cut pool for the GENERAL spatial path (cert:T1.3).
                         # When the incremental engine is active but PSD cuts are
                         # off, the fast path (which skips per-node separation) would
@@ -5012,6 +5022,13 @@ def solve_model(
                         # node. Sound: a cut valid over the root box is valid over
                         # every sub-box, so an inherited row never removes a
                         # feasible point.
+                        #
+                        # THRU-4 (``_cut_inherit``): additionally capture this pool
+                        # when the incremental engine is unavailable — cold-path
+                        # nodes are exactly where the per-node square/PSD point
+                        # separators dominate (nvs24: 73%+12% of the solve wall) —
+                        # so the node call sites below can skip those loops in
+                        # favour of the inherited pool (``skip_pool_separators``).
                         try:
                             _pool_chunks = []
                             _root_remaining = time_limit - (time.perf_counter() - t_start)
@@ -5795,6 +5812,10 @@ def solve_model(
                             inherited_cuts=_root_cut_pool,
                             separate=True,
                             want_marginals=_node_reduce_enabled,
+                            # THRU-4: with the root pool inherited, skip the per-node
+                            # square/PSD point-separation loops (sound: their cut
+                            # families are box-independent and already in the pool).
+                            skip_pool_separators=(_cut_inherit and _root_cut_pool is not None),
                         )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", i, e)
@@ -6103,6 +6124,10 @@ def solve_model(
                             inherited_cuts=_root_cut_pool,
                             separate=True,
                             want_marginals=_node_reduce_enabled,
+                            # THRU-4: with the root pool inherited, skip the per-node
+                            # square/PSD point-separation loops (sound: their cut
+                            # families are box-independent and already in the pool).
+                            skip_pool_separators=(_cut_inherit and _root_cut_pool is not None),
                         )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", int(batch_ids[i]), e)
@@ -7940,6 +7965,15 @@ def solve_model(
         _sqf = int(getattr(_mc_lp_relaxer, "_square_gate_fires", 0))
         if _sqf > 0:
             _solver_stats["gate/square_fires"] = float(_sqf)
+    # Root-cut-pool inheritance counters (THRU-4). Surfaced whenever a pool was
+    # built or inherited so both the fire-proof (pool populates + inherits) and
+    # the skip lever are observable on the final result.
+    if _root_cut_pool is not None:
+        _solver_stats["pool/size"] = float(_root_cut_pool[0].shape[0])
+    if _mc_lp_relaxer is not None and getattr(_mc_lp_relaxer, "_pool_stats", None):
+        for _pfam, _pcount in _mc_lp_relaxer._pool_stats.items():
+            if _pcount > 0:
+                _solver_stats[f"pool/{_pfam}"] = float(_pcount)
 
     return SolveResult(
         status=status,

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -185,6 +185,28 @@ class SolverTuning:
     improvement ``Δ ≤ tau × (1 + |lb_before|)`` abandons the remaining rounds at
     that node. Only consulted when :attr:`square_cost_gate` is on."""
 
+    # --- root-cut-pool inheritance (THRU-4, default OFF) -----------------------
+    cut_inherit: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_CUT_INHERIT", default=False)
+    )
+    """Root-cut-pool inheritance for the per-node square/PSD separation loops
+    (``DISCOPT_CUT_INHERIT``, default **OFF**). THRU-3 measured that the two
+    per-node point separators — the univariate-square tangent loop and the PSD
+    (moment) loop — are the dominant per-node cost on dense integer QPs (nvs24:
+    73% + 12% of the solve wall), each re-deriving cuts via up to 8 full MILP
+    re-solves at EVERY node; with both off, nvs24 runs 9→309 nodes (36×) with
+    the dual bound at TL essentially unchanged. When on, the root separates the
+    full cut chain ONCE (unchanged root behaviour), the accepted rows are stored
+    in the root cut pool, and every node *inherits* the pool instead of
+    re-running the square/PSD separation loops. SOUND: the inherited square
+    tangents (``s ≥ 2·x0·x − x0²``) and PSD eigencuts (``vᵀMv ≥ 0``) are valid at
+    every feasible lifted point independent of the node box, and every other
+    captured family is valid over the ROOT box, hence over every descendant
+    sub-box; skipping per-node re-separation only *loosens* the node relaxation
+    (never cuts a feasible point). See
+    ``docs/dev/thru4-cut-inheritance-2026-07-07.md`` for the per-family validity
+    classification and measurements."""
+
     # --- branch-and-bound / bound levers --------------------------------------
     alphabb_with_lp: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_ALPHABB_WITH_LP", default=False)

--- a/python/tests/test_cut_inherit_pool.py
+++ b/python/tests/test_cut_inherit_pool.py
@@ -1,0 +1,209 @@
+"""Regression tests for root-cut-pool inheritance (THRU-4, ``DISCOPT_CUT_INHERIT``).
+
+The lever: THRU-3 measured the two per-node point separators — the
+univariate-square tangent loop and the PSD (moment) loop — as the dominant
+per-node cost on dense integer QPs (73% + 12% of the nvs24 solve wall), each
+re-deriving cuts via up to 8 full MILP re-solves at every node. Under
+``cut_inherit`` the root separates the full chain once, the rows are pooled, and
+nodes inherit the pool instead of re-separating.
+
+Soundness invariants pinned here:
+
+* **Root-pool validity on children** — every pooled row is satisfied by every
+  feasible lifted point of the ROOT box, hence of every descendant sub-box
+  (a child's feasible set is a subset of the root's). Square tangents
+  (``s >= 2 x0 x - x0**2``) and PSD eigencuts (``v^T M v >= 0``) are valid at
+  any lifted feasible point independent of the box.
+* **Box-dependent rows are NOT inheritable and are excluded by design** — the
+  static child-box relaxation carries rows (e.g. the secant overestimator of
+  ``x**2`` on a sub-box) that CUT feasible points outside that sub-box; the
+  implementation therefore pools rows captured at the ROOT box only, never from
+  node-level solves. A synthetic case demonstrates the hazard and asserts the
+  flag-ON solve still certifies the true optimum that naive child-row
+  inheritance would cut off.
+* **Default-off neutrality** — with the flag off, no pool-skip is performed.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling.core as dm
+import numpy as np
+import pytest
+from discopt.solver_tuning import SolverTuning
+
+# Dense indefinite Q over a small signed integer box — a miniature of the nvs24
+# class (dense integer QP, no linear constraints) where the root square/PSD
+# separation loop verifiably fires (17 cuts captured at the root box).
+_Q = np.array([[1.0, -2.0], [-2.0, 1.0]])
+_C = np.array([0.5, -0.5])
+_N = 2
+_LB, _UB = -3, 3
+
+
+def _build_dense_int_qp() -> dm.Model:
+    m = dm.Model("mini_nvs")
+    x = m.integer("x", shape=(_N,), lb=_LB, ub=_UB)
+    expr = None
+    for i in range(_N):
+        for j in range(_N):
+            if _Q[i, j] != 0.0:
+                term = _Q[i, j] * x[i] * x[j]
+                expr = term if expr is None else expr + term
+    for i in range(_N):
+        if _C[i] != 0.0:
+            expr = expr + _C[i] * x[i]
+    m.minimize(expr)
+    return m
+
+
+def _brute_force_opt() -> tuple[float, np.ndarray]:
+    best, best_x = np.inf, None
+    for pt in itertools.product(range(_LB, _UB + 1), repeat=_N):
+        v = np.asarray(pt, dtype=float)
+        val = float(v @ _Q @ v + _C @ v)
+        if val < best:
+            best, best_x = val, v
+    return best, best_x
+
+
+def _lifted_point(x: np.ndarray, varmap: dict, n_total: int) -> np.ndarray | None:
+    """Exact lifted vector z for an original point x: z carries x, the lifted
+    squares ``X_ii = x_i**2`` and products ``X_ij = x_i x_j``. Returns None if any
+    lifted column is not covered by a family this helper reproduces (test guard:
+    the model must stay simple enough that the exact lift is stateable)."""
+    z = np.zeros(n_total)
+    covered: set[int] = set()
+    for col in (varmap.get("original") or {}).values():
+        z[int(col)] = float(x[int(col)])
+        covered.add(int(col))
+    for fam in ("monomial", "univariate_square"):
+        for (i, p), col in (varmap.get(fam) or {}).items():
+            z[int(col)] = float(x[int(i)]) ** int(p)
+            covered.add(int(col))
+    for fam in ("bilinear", "trilinear", "multilinear"):
+        for key, col in (varmap.get(fam) or {}).items():
+            z[int(col)] = float(np.prod([x[int(i)] for i in key]))
+            covered.add(int(col))
+    if covered != set(range(n_total)):
+        return None
+    return z
+
+
+def _root_pool_and_varmap():
+    """Capture the root cut pool on the dense integer QP, plus the lifted layout."""
+    from discopt._jax.mccormick_lp import MccormickLPRelaxer
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+
+    model = _build_dense_int_qp()
+    relaxer = MccormickLPRelaxer(model, psd_cuts=True)
+    lb = np.full(_N, float(_LB))
+    ub = np.full(_N, float(_UB))
+    chunks: list = []
+    res = relaxer.solve_at_node(lb, ub, time_limit=30.0, out_cuts=chunks)
+    assert res.status == "optimal", f"root solve failed: {res.status}"
+    assert chunks, "root separation captured no cut pool"
+    A_pool, b_pool = chunks[0]
+    A_pool = np.asarray(
+        A_pool.todense() if hasattr(A_pool, "todense") else A_pool, dtype=np.float64
+    )
+    b_pool = np.asarray(b_pool, dtype=np.float64)
+    assert A_pool.shape[0] >= 1, "empty root cut pool"
+    milp, varmap = build_milp_relaxation(
+        model, relaxer._terms, relaxer._disc, bound_override=(lb, ub)
+    )
+    return A_pool, b_pool, varmap, len(milp._c)
+
+
+@pytest.mark.smoke
+def test_root_pool_cuts_valid_on_every_child_feasible_point():
+    """Feasible-point sampling: every pooled root cut must hold at EVERY feasible
+    lifted point of the root box — hence at every point of every child sub-box."""
+    A_pool, b_pool, varmap, n_total = _root_pool_and_varmap()
+    assert A_pool.shape[1] == n_total
+    checked = 0
+    for pt in itertools.product(range(_LB, _UB + 1), repeat=_N):
+        z = _lifted_point(np.asarray(pt, dtype=float), varmap, n_total)
+        assert z is not None, "test model triggered an unmodelled lifted family"
+        viol = A_pool @ z - b_pool
+        assert viol.max() <= 1e-6, (
+            f"root pool cut violated at feasible point {pt}: max violation {viol.max():.3e}"
+        )
+        checked += 1
+    assert checked == (_UB - _LB + 1) ** _N
+
+
+@pytest.mark.smoke
+def test_box_dependent_child_rows_would_be_invalid_and_are_excluded():
+    """The hazard THRU-4 must exclude: rows of a CHILD-box relaxation (e.g. the
+    secant of ``x**2`` on a sub-box) cut feasible points outside that sub-box, so
+    they must never be inherited. Demonstrate the hazard, then assert the shipped
+    root pool contains no such row and the flag-ON solve still certifies the true
+    optimum that naive child-row inheritance would have cut off."""
+    from discopt._jax.mccormick_lp import MccormickLPRelaxer
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+
+    model = _build_dense_int_qp()
+    relaxer = MccormickLPRelaxer(model, psd_cuts=True)
+
+    # Child box pinning x to the upper corner region [2, 3]^_N.
+    child_lb = np.full(_N, 2.0)
+    child_ub = np.full(_N, float(_UB))
+    milp_child, varmap_child = build_milp_relaxation(
+        model, relaxer._terms, relaxer._disc, bound_override=(child_lb, child_ub)
+    )
+    A_child = milp_child._A_ub
+    A_child = np.asarray(
+        A_child.todense() if hasattr(A_child, "todense") else A_child, dtype=np.float64
+    )
+    b_child = np.asarray(milp_child._b_ub, dtype=np.float64)
+    n_total = len(milp_child._c)
+
+    # A root-feasible point OUTSIDE the child box (the origin). At least one
+    # child-box row must cut it (e.g. a McCormick under/overestimator built from
+    # the child bounds), proving child rows are not globally inheritable.
+    z0 = _lifted_point(np.zeros(_N), varmap_child, n_total)
+    assert z0 is not None
+    child_viol = (A_child @ z0 - b_child).max()
+    assert child_viol > 1e-6, (
+        "expected the child-box relaxation to cut a root-feasible point; "
+        "the box-dependence hazard this test pins vanished"
+    )
+
+    # The shipped pool (captured at the ROOT box) must NOT cut that point.
+    A_pool, b_pool, varmap_root, n_root = _root_pool_and_varmap()
+    z0_root = _lifted_point(np.zeros(_N), varmap_root, n_root)
+    assert z0_root is not None
+    assert (A_pool @ z0_root - b_pool).max() <= 1e-6
+
+    # End-to-end guard: flag-ON must reproduce the brute-force optimum with a
+    # valid bound (bound <= optimum for min). Naive child-row inheritance would
+    # have fathomed the region holding the optimum.
+    opt, _ = _brute_force_opt()
+    res = model.solve(time_limit=60, tuning=SolverTuning(cut_inherit=True))
+    assert res.objective is not None
+    assert res.objective == pytest.approx(opt, abs=1e-5)
+    if res.bound is not None:
+        assert res.bound <= opt + 1e-6, f"dual bound {res.bound} crossed the optimum {opt}"
+    # Fire-proof: the pool populated and was inherited/skipped at node solves.
+    stats = res.solver_stats or {}
+    assert stats.get("pool/size", 0) >= 1, f"root pool did not populate: {stats}"
+    assert (
+        stats.get("pool/inherited_nodes", 0) >= 1 or stats.get("pool/skipped_separations", 0) >= 1
+    ), f"pool was never inherited at a node: {stats}"
+
+
+@pytest.mark.smoke
+def test_cut_inherit_default_off_no_skip():
+    """Default (flag off): the square/PSD separators run as before — no pool-skip."""
+    model = _build_dense_int_qp()
+    res = model.solve(time_limit=60)
+    opt, _ = _brute_force_opt()
+    assert res.objective == pytest.approx(opt, abs=1e-5)
+    stats = res.solver_stats or {}
+    assert stats.get("pool/skipped_separations", 0) == 0


### PR DESCRIPTION
# THRU-4 — root-cut-pool inheritance for square/PSD separation

**Task.** THRU-3 (#550) measured the dominant per-node cost on the dense
integer-QP class: the two per-node point-separation loops —
`_separate_univariate_square` (73% of the nvs24 solve wall) and `_separate_psd`
(12%) — each re-derive their cut family via up to 8 full MILP re-solves at
EVERY node; with both off, nvs24 runs 9→309 nodes (36×) at essentially
unchanged bound-at-TL. This PR implements the lever (BARON's architecture):
separate fully at the ROOT once, pool the cuts, and INHERIT them at every node
instead of re-separating — behind the default-OFF flag `DISCOPT_CUT_INHERIT` /
`SolverTuning(cut_inherit=True)`.

Base: `origin/main` @ 3d736c9a (#550 still open at branch time; its default-OFF
square-cost-gate is not on this base — baseline behaviour identical to THRU-3's,
reproduced to the node: nvs24 9 nodes/0.14 n/s, nvs19 197/3.28).

## Soundness analysis (the crux — full table in the findings doc)

- **Square tangents** `s >= 2*x0*x - x0^2`: **globally valid** (a tangent of the
  convex `x^2` under-estimates it on all of R; no box bound in the coefficients).
- **PSD eigencuts** `v'Mv >= 0`: **globally valid** wherever the lifting
  relations `X = x x'` hold (verified in `psd_cuts.py::psd_cut_from_submatrix`:
  coefficients come from the eigenvector only).
- Multilinear / edge-concave / RLT / convex-composite rows are **box-dependent**
  (valid on the capture-time box and its sub-boxes only) — sound to inherit
  *from the root capture only*; the design never pools node-level rows. A
  regression test pins the hazard (a child-box row provably cuts a root-feasible
  point) and asserts it is excluded.

## Design

- **Root unchanged:** the existing cert:T1.3 general root-pool capture runs the
  full default separation chain once on the root box; with the flag on it also
  runs when the incremental engine is unavailable (exactly the cold-path
  instances where THRU-3 measured the drag). Verified: reported root bound is
  byte-identical flag-ON vs flag-OFF on every instance measured.
- **Nodes:** inherit the pool (pre-existing mechanism, column-layout-gated) and
  pass the new `skip_pool_separators=True` to `solve_at_node`, which skips ONLY
  the square and PSD loops. Skipping separation only loosens a node's
  relaxation — never cuts a feasible point. Lazy re-separation was not needed:
  THRU-3's `both_off` arm already measured the no-re-separation endpoint
  (bound-at-TL essentially unchanged); here the pool retains the root cuts so
  the flag-ON bound-at-TL is *identical* on nvs24.
- **Instrumentation:** `solver_stats` gains `pool/size`, `pool/inherited_nodes`,
  `pool/inherited_rows`, `pool/skipped_separations`.

## Measurements (TL 60 s, release build, oracle `minlplib.solu`)

| instance | arm | status | nodes | nodes/s | bound@TL | incumbent | root bound |
|---|---|---|---:|---:|---:|---:|---|
| nvs24 | OFF | feasible | 9 | 0.14 | -1035.66 | -1031.80 | -1035.6600020723224 |
| nvs24 | **ON** | feasible | **49** | **0.76 (5.3x)** | **-1035.66 (identical)** | -1031.80 | identical |
| nvs19 | OFF | feasible | 197 | 3.28 | -1102.10 | -1098.20 | -1104.2400022094807 |
| nvs19 | **ON** | **optimal (CERTIFIED, 52.9 s)** | **367** | **6.93 (2.1x)** | **-1098.40 = opt** | **-1098.40 = opt** | identical |

**nvs19 now CERTIFIES at 60 s** (baseline times out at 0.35% gap). nvs24 gains
5.3x node throughput at identical bound and incumbent; its residual floor is
the base per-node MILP simplex solve + the (retained) root separation wall, per
THRU-3 — the 36x arm got there only by giving up the root tightness this PR
deliberately keeps. Per-node separation wall collapses: nvs19 square
24.9 -> 0.2 s, PSD 12.2 -> 0.04 s.

QCQP control set (no regression; root bounds identical everywhere; every dual
bound <= oracle and <= its incumbent): nvs17 certifies **1.65x faster**
(23.3 -> 14.1 s), nvs23 2.1x nodes at slightly tighter bound-at-TL, nvs10/nvs13
certs unchanged.

## Verification (bound-changing regime, CLAUDE.md section 5)

- **Differential:** no reported bound crossed the oracle optimum on any arm of
  any instance (nvs10/13/17/19/23/24); root bound byte-identical ON vs OFF.
- **Feasible-point sampling:** root pools on nvs19 (70 rows), nvs24 (95),
  nvs17 (59) evaluated at 2000 random integer feasible points each (exact
  lifted vectors): max violation 4.9e-32 — no pooled cut removes any feasible
  point.
- **Regression tests** (`python/tests/test_cut_inherit_pool.py`, smoke-marked):
  pool validity exhaustive on a dense integer-QP box; the naive-inheritance
  hazard pinned and excluded; default-off performs no pool-skip.
- **Cert-neutrality (default OFF):** `check_cert_neutrality.py` — **40/41
  byte-identical** (`nodes n->n`, `|dObj|=0.00e+00`). The one flagged row,
  `nvs13 node_count 19 -> 49`, is the SAME pre-existing baseline drift on
  `main` that #550 already root-caused: the BARE branch point (this diff
  stashed) solves nvs13 to 49 nodes / -585.2, identical to this branch's
  default-OFF run — the default-OFF path is verifiably byte-identical
  (49 -> 49, |dObj| = 0). Stale-baseline refresh remains out of scope
  (unrelated main drift, same disposition as #550).

## Gates

- `pytest -m smoke`: **620 passed, 14 skipped** (includes the 3 new smoke
  pool tests); re-run post-rebase onto 2d4d1efa.
- Adversarial (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`):
  **10 passed**; re-run post-rebase.
- `ruff check` + `ruff format --check`: clean.
- Pre-commit `mypy` (the actual hook): **Passed**.
- `cargo test -p discopt-core`: n/a (no Rust touched).
- Rebased onto post-#550 main; both features coexist (square-cost-gate stays
  default-OFF and orthogonal); the flag-ON fire test reproduces exactly
  post-rebase (nvs19 optimal, 367 nodes, identical pool counters + root bound).

Findings doc: `docs/dev/thru4-cut-inheritance-2026-07-07.md`.

Do NOT merge (differential nightly greening per CLAUDE.md section 5 before any
default-on discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
