### PR TITLE
fix(node): C-42 — cut-inherit cold-path probe must not truncate the B&B loop

### DIFF
--- a/docs/dev/c42-cut-inherit-fix-2026-07-07.md
+++ b/docs/dev/c42-cut-inherit-fix-2026-07-07.md
@@ -1,0 +1,184 @@
+# C-42 — cut-inherit cold-path probe must not truncate the B&B loop (2026-07-07)
+
+**Task.** THRU-4's graduation validation (#552,
+`docs/dev/thru4-graduate-2026-07-07.md` on the `thru4-graduate` branch) found
+two deterministic flag-ON certificate losses that keep `DISCOPT_CUT_INHERIT`
+(#551) default-OFF: **nvs06** exits after 1 node at 1.5 s with 8.5 s of budget
+unused (`feasible 231.70` instead of the certified `1.7703125`), and **tspn05**
+loses its certificate because per-node re-separation is load-bearing there.
+This change root-causes and fixes the nvs06-class truncation (Part 1) and ships
+the lazy re-separation trigger for the tspn05 class (Part 2). The flag default
+stays **OFF** — no default-path change in this PR.
+
+Build: release (`maturin develop --release`, pounce `_pounce.abi3.so` 4.73 MB).
+Env: `PYTHONPATH=<wt>/python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`, corpus
+`~/Dropbox/projects/discopt-minlp-benchmark/`, oracle `minlplib.solu`
+(nvs06 = 1.7703125, tspn05 = 191.25521, nvs19 = −1098.4, nvs24 = −1033.2).
+Single runs per arm, same machine, fresh interpreter per solve.
+
+## Part 1 — root cause of the nvs06 truncation (file:line)
+
+Reproduced deterministically: flag-ON nvs06 → `feasible 231.70004, 1 node,
+1.5 s`; flag-OFF → `optimal 1.7703125, 5 nodes, 1.4 s`. The failure chain has
+four links:
+
+1. **The cold-path pool probe captures a VALID cut.** With the flag on, the
+   `elif ... or _cut_inherit` branch (`python/discopt/solver.py:5012`, pre-fix
+   numbering) runs the general root-pool capture on nvs06 (where the
+   incremental engine declines). The captured pool is ONE row — verified by
+   hand to be a legitimate PSD eigencut `vᵀMv ≥ 0` over the lifted clique
+   `(aux0, aux1)` with `v = (0.2332, 0.7392, −0.6318)`, `b = v₀²`; it holds at
+   every exactly-lifted feasible point (checked at integer feasible points).
+   The cut is NOT the bug.
+2. **Appending that one row makes the cold node solve fail numerically.**
+   At the root node solve, `solve_at_node`
+   (`python/discopt/_jax/mccormick_lp.py:877`, pre-fix) appends the row and the
+   warm-simplex integer-aware relaxation solve flips from `optimal 1.10` to an
+   **uncertified `infeasible`** (or `iteration_limit`, depending on warm
+   state) — the C-38 numerical-false-infeasible class, triggered here by the
+   extra row instead of a stale basis. Isolated A/B on the identical box:
+   `inherit-only → numerical`, `skip-only → optimal 1.10`,
+   `inherit+skip → numerical`, `neither → optimal 1.10` — the inherited row
+   alone is necessary and sufficient. The existing guard
+   (`mccormick_lp.py:967–993`) correctly refuses to fathom on an uncertified
+   infeasible and returns `status="numerical"` **with no bound**.
+3. **The driver turns "no bound" into a failure sentinel at the root.** On the
+   LP-relaxer path the root's node NLP is deliberately skipped, so
+   `result_lbs[i]` is pre-set to `_INFEASIBILITY_SENTINEL`
+   (`solver.py:6107`, pre-fix) on the expectation that the LP block overwrites
+   it. With the LP solve failed, the sentinel survives;
+   `_nonrigorous_sentinel_fathom` (`solver.py:6235`) decertifies the gap and
+   the root is imported as pruned.
+4. **Loop truncation + pre-tree incumbent-search reroute.** With the root
+   pruned, `tree.export_batch` returns 0 nodes and the `while True` loop breaks
+   (`solver.py:5493`) after ONE node with 8.5 s unused. The pre-tree pump chain
+   (feasibility pump → NLP-relaxation pump → integer local search,
+   `solver.py:6486` gate `best_root_idx is not None`) never runs because no
+   root relaxation bound landed in `result_lbs` — this is the "reroute": only
+   the SubNLP/box-search heuristics (different gates) fire, seeding 251.3 →
+   231.7. Exit: `feasible 231.70`, dual bound 1.10 (valid — not a false
+   certificate, but a lost certificate + 130× degraded incumbent).
+
+### The fix (general, not keyed to nvs06)
+
+**The inherited pool is an accelerator, never a dependency.** In
+`solve_at_node` (`mccormick_lp.py`, after the initial cold solve): when pool
+rows were appended and the solve produced no certified verdict — not
+`optimal` and not a Farkas-certified `infeasible` — the pool rows are stripped
+and the node re-solved. The retry is byte-identical to the no-pool solve the
+default path performs, so a destabilizing pool can perturb neither the
+incumbent search nor loop termination at any node. The per-node square/PSD
+skip is lifted for that node too (its justification — "the pool already
+supplies the family" — no longer holds once the pool is dropped).
+Soundness: dropping valid rows only loosens the relaxation; a Farkas-certified
+infeasible on the pool-augmented system is still a rigorous fathom (valid cuts
+preserve all feasible points) and is kept. Instrumented as
+`pool/dropped_nodes`.
+
+The driver-layer hazard behind link 3 — a *deliberately skipped* node NLP
+sharing the failure sentinel with a *failed* one, so any node whose LP yields
+no bound is pruned non-rigorously — is pre-existing, flag-independent, and
+NOT changed here (changing it would alter default-path node accounting and
+break cert-neutrality in this PR). Recorded as a follow-up for the
+correctness backlog (#396): `solver.py` sentinel-on-skip at the line noted
+above.
+
+### nvs06 before/after (flag-ON, TL 10 s)
+
+| arm | status | objective | bound | nodes | wall | pool |
+|---|---|---|---:|---:|---:|---|
+| before (main @ cd6e199d) | feasible | 231.70004 | 1.1000150 | 1 | 1.5 s | size 1, inherited 1, skipped 1 |
+| **after** | **optimal** | **1.7703125** | 1.7703125 | 5 | 2.0 s | size 1, inherited 3, skipped 2, **dropped 1** |
+| flag-OFF (reference, unchanged) | optimal | 1.7703125 | 1.7703125 | 5 | 1.4 s | — |
+
+Flag-ON now reproduces the flag-OFF certificate exactly (same 5 nodes, same
+objective/bound to the last digit); `pool/dropped_nodes = 1` fires at the
+root, confirming the mechanism.
+
+## Part 2 — lazy re-separation trigger (the tspn05 blocker)
+
+Design shipped: a **driver-side global-bound-stall governor** plus a
+**relaxer-side stride safety net** (all constants global, never
+per-instance):
+
+* Governor (`solver.py`, `_LAZY_RESEP_STALL_WINDOW = 24`,
+  `_LAZY_RESEP_PROBE_BUDGET = 8`, `_LAZY_RESEP_GLB_EPS = 1e-9`): watch the
+  tree's global lower bound each iteration (only under active pool
+  inheritance — the default path reads no extra state). The governor is
+  ARMED by the first genuine in-tree bound improvement — a bound that has
+  never moved since the root is the pool-at-fixed-point signature (nvs24:
+  root pool separated to convergence; per-node re-separation measured
+  bound-inert), where a probe only burns the most expensive separation wall
+  in the corpus. Once armed: a stall of a full window of node solves
+  re-enables the full square/PSD separation pass (`probing`); an improvement
+  while probing REFRESHES the probe (separation is demonstrably productive —
+  this is what lets tspn05 lock separation in and close instead of rationing
+  it to an 8-in-32 duty cycle); a probe that spends its whole budget with no
+  improvement mutes until the bound next moves. Stats:
+  `pool/stall_reseparations`.
+* Stride net (`mccormick_lp.py`, `_LAZY_RESEP_STRIDE = 64`): every 64th
+  skip-eligible node solve separates regardless, so inheritance can never
+  fully starve a class the governor misjudges (including the never-armed
+  shape). Stats: `pool/lazy_reseparations`.
+
+### Falsified designs (recorded per CLAUDE.md §4; measurements this branch)
+
+The task sketch's per-NODE stall test — "re-separate when the node's LP bound
+improvement vs its parent is below a small threshold" — was implemented first
+(via a Rust `node_lower_bounds` getter; children inherit
+`parent.local_lower_bound` at branch time) and **falsified**: on the dense
+integer-QP class the node LP sitting at the parent's bound is the NORMAL state
+(closure comes from branching depth), so the arm fired on **185/191 nvs19
+nodes** and destroyed #551's win (nvs19: optimal 52.8 s → feasible at TL with
+a worse incumbent; nvs24: 49 → 13 nodes). A per-fire LP-GAIN productivity
+mute (BARON-style) was tried next and also **falsified**: the per-fire gain
+does not discriminate — nvs19's fires gain a LOT of LP value (median relative
+gain 0.117) yet are worthless for the 60 s certificate, while tspn05's
+load-bearing fires gain little (median relative gain 1.3e-3); any threshold
+keeps the wrong class firing. The discriminating signal is the GLOBAL bound's
+progress, which only the driver sees — hence the shipped governor. Three
+supporting measurements shaped the final knobs: (i) a 1-in-16 stride net costs
+nvs24 49 → 29 nodes (one separation pass there is seconds — THRU-3's 73%+12%
+wall share), 1-in-64 is within noise; (ii) without probe-refresh-on-improvement
+the governor rations tspn05's load-bearing separation to an 8-in-32 duty cycle
+and the certificate lands at 60.15 s — at the budget's edge (with refresh:
+48.8 s); (iii) without the arming rule the governor's very first probe fires
+on nvs24 (whose bound never moves from the root) and costs 49 → 31 nodes.
+
+### Results (TL 60 s except nvs06 at 10 s; flag-ON, single runs, this build)
+
+| instance | flag-ON on main @ cd6e199d (the #552 blockers) | flag-ON, this change | flag-OFF reference (this build) | verdict |
+|---|---|---|---|---|
+| tspn05 | feasible 191.2552, bound STALLS at 190.2786, 199 nodes @ TL — **cert lost** | **optimal 191.25521**, bound 191.2478 (gap 3.9e-5 ≤ 1e-4), 119 nodes, **48.8 s**; 26 stall + 1 stride fires | optimal 191.25521, 39 nodes, 19.2 s | **cert regained** |
+| nvs19 | optimal −1098.4, 367 nodes, 52.8 s (the #551 win) | **optimal −1098.4, 295 nodes, 49.3 s**; 48 stall + 3 stride fires | feasible @ TL, 197 nodes, 0.35 % gap | **win retained** (certifies, slightly faster) |
+| nvs24 | feasible, 49 nodes @ TL, bound −1035.6600 (5.3× nodes/s vs OFF's 9 nodes) | feasible, **49 nodes @ TL, bound −1035.6600** — governor never arms (bound never moves from the root), 38 skips, 0 fires: byte-matches the #551 flag-ON baseline | feasible, 9 nodes @ TL, same bound | **win retained** (identical) |
+| nvs06 | **feasible 231.70, 1 node, 1.5 s — cert lost** (Part 1) | **optimal 1.7703125, 5 nodes, 2.0 s**, `pool/dropped_nodes` = 1 | optimal 1.7703125, 5 nodes, 1.4 s | **cert regained** |
+
+Every dual bound above stays ≤ its incumbent and ≤ the oracle optimum (min
+sense) — the certificate invariant holds on every arm.
+
+## Gates
+
+| gate | result |
+|---|---|
+| regression tests (`python/tests/test_c42_cut_inherit_coldpath.py`) | 2 smoke (pool-drop retry mechanism — verified to FAIL on the pre-fix code and pass after; stride net) + 2 slow (nvs06 flag-ON certifies 1.7703125; tspn05 flag-ON certifies 191.25521) — all pass |
+| `check_cert_neutrality.py` (default OFF, 41-instance panel) | **40/41 byte-identical** (`|Δobj| = 0.00e+00` on every row, `nodes n->n`). The one flagged row — `nvs13 node_count 19 -> 49` — is the SAME pre-existing stale-baseline drift #550/#551/#552 already recorded: re-verified here by solving nvs13 default-OFF on the BARE branch point (this diff stashed) → **49 nodes, −585.2, bound −585.2000011714 — byte-identical to this branch's default-OFF run**. No rebaseline (same disposition as #550/#551/#552: main-drift, not this branch's). |
+| `pytest -m smoke` (python/tests) | 622 passed, 14 skipped (includes the 2 new smoke tests) |
+| `pytest -m slow python/tests/test_adversarial_recent_fixes.py` | 10 passed |
+| `cargo test -p discopt-core` | 424 passed (run during development; the final diff touches NO Rust — the `node_lower_bounds` getter added for the falsified per-node arm was removed again) |
+| `ruff check` / `ruff format --check` (v0.14.6) | clean |
+| pre-commit `mypy` (the actual hook, whole package) | Passed |
+
+Flag default stays **OFF** (`SolverTuning.cut_inherit=False`); no default-path
+behaviour change in this PR.
+
+## Follow-ups (recorded, not shipped)
+
+* Driver sentinel-on-deliberate-skip (Part 1 link 3): a node whose NLP was
+  deliberately skipped shares the failure sentinel with a genuinely failed
+  one, so ANY node whose LP yields no bound is pruned non-rigorously
+  (decertified, but still pruned). Flag-independent and pre-existing; file on
+  the #396 backlog.
+* Re-attempt THRU-4 graduation (#552's protocol) now that both panel losses
+  are fixed: the cert-panel arm should be re-run flag-ON against
+  `cert-baseline.jsonl` plus a fresh held-out draw before any flip discussion.

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -100,6 +100,46 @@ _LIFTED_FBBT_ROUNDS = 30
 _LIFTED_FBBT_TOL = 1e-9
 _LIFTED_FBBT_UNPIN_EPS = 1e-6
 
+# Lazy re-separation, relaxer-side arm (C-42, the THRU-4 follow-on). Under
+# root-pool inheritance (``skip_pool_separators``) a node normally skips the
+# per-node square/PSD point-separation loops — sound (skipping only loosens)
+# but not free on every class: on tspn05-shape spatial models the inherited
+# pool alone leaves each node too loose to fathom, the tree's bound stalls,
+# and the certificate is lost at budget (THRU-4 graduation, #552). The full
+# trigger is split between two layers:
+#   (a) the DRIVER's global-bound-stall governor (``solver.py``,
+#       ``_LAZY_RESEP_STALL_WINDOW`` there): when the tree's global lower
+#       bound stagnates, it stops passing ``skip_pool_separators`` for a
+#       bounded probe of node solves, and mutes again if the probe does not
+#       move the bound;
+#   (b) this module's stride safety net: every ``_LAZY_RESEP_STRIDE``-th
+#       skip-eligible node solve runs the full separation pass regardless, so
+#       inheritance can never fully starve a class the governor misjudges.
+#
+# Two per-NODE signals were tried first and FALSIFIED by measurement
+# (2026-07-07, this branch — kept as a negative result per CLAUDE.md §4):
+#   * "node LP value fails to improve on the parent's bound" fires on 185/191
+#     nvs19 nodes — on the dense integer-QP class the node LP sitting at the
+#     parent bound is the NORMAL state (closure comes from branching depth),
+#     and the resulting re-separation destroys the 2–5× throughput win of
+#     #551 (nvs19 loses its 53 s certificate again);
+#   * "LP-value gain of the re-separation pass below a threshold" does not
+#     discriminate either: on nvs19 the per-fire LP gain is LARGE (median
+#     rel. gain 0.117) yet worthless for the 60 s certificate — separation
+#     there is bound-productive but wall-unproductive.
+# The discriminating signal is the GLOBAL bound's progress per wall spent,
+# which only the driver can see — hence the split above.
+#
+# The stride is GLOBAL — never tuned per instance. Firing more only tightens
+# a node's relaxation (every emitted cut is valid) and firing less only
+# loosens it, so the net affects performance, never soundness. Sized by
+# measurement: one separation pass on the dense integer-QP class costs
+# seconds (THRU-3: the loops are 73%+12% of the nvs24 solve wall), and a
+# 1-in-16 net measurably degraded nvs24's node throughput (49 -> 29 nodes at
+# the same 60 s budget); 1-in-64 keeps the starvation guarantee at a bounded
+# ~1.5 % worst-case node overhead.
+_LAZY_RESEP_STRIDE = 64
+
 
 def _lifted_lp_fbbt(
     A_ub: "object",
@@ -266,12 +306,24 @@ class MccormickLPRelaxer:
         #     root pool (and how many rows in total), across the cold AND fast
         #     paths;
         #   * skipped_separations: node solves where the square/PSD point
-        #     separators were skipped in favour of the inherited pool.
+        #     separators were skipped in favour of the inherited pool;
+        #   * dropped_nodes: cold node solves where the pool-augmented system
+        #     produced no certified verdict and the pool rows were stripped for
+        #     a no-pool retry (C-42 — the pool is an accelerator, never a
+        #     dependency).
+        #   * lazy_reseparations: skip-eligible node solves where the lazy
+        #     trigger (bound stall vs the parent, or the stride safety net)
+        #     re-enabled the square/PSD separation pass (C-42 Part 2).
         self._pool_stats: dict[str, int] = {
             "inherited_nodes": 0,
             "inherited_rows": 0,
             "skipped_separations": 0,
+            "dropped_nodes": 0,
+            "lazy_reseparations": 0,
         }
+        # Skip-eligible node-solve counter for the lazy-trigger stride net
+        # (see the module-level ``_LAZY_RESEP_STRIDE`` rationale).
+        self._lazy_skip_ctr: int = 0
         # Spatial-BB uses standard McCormick globally — no partitioning here.
         self._disc = DiscretizationState(partitions={})
         self._n_orig = sum(v.size for v in model._variables)
@@ -708,7 +760,9 @@ class MccormickLPRelaxer:
           tangent under-estimates ``x**2`` everywhere; a PSD eigencut
           ``vᵀMv ≥ 0`` holds wherever ``X = x xᵀ``), so the inherited root pool
           already supplies the family and skipping re-separation only *loosens*
-          this node's relaxation — never cuts a feasible point.
+          this node's relaxation — never cuts a feasible point. The driver's
+          global-stall governor and this module's stride net (C-42, see
+          ``_LAZY_RESEP_STRIDE``) selectively re-enable the pass.
         """
         # Phase-B fast path: incremental patch + warm-started solve, reusing the
         # structure built once at construction instead of a per-node cold rebuild +
@@ -864,17 +918,66 @@ class MccormickLPRelaxer:
         # once at the root instead of re-separating them every node. Sound — each
         # pool row is a valid inequality at every feasible point regardless of the
         # node box — but only column-aligned when the lifted layout is unchanged
-        # (a pinned child variable can fold columns), so gate on a matching
+        # (a pinned child variable can pin/fold columns), so gate on a matching
         # ``n_total`` and otherwise skip (fewer cuts only loosens the bound).
+        _n_pre_pool_rows = 0 if milp._A_ub is None else _sparse_rows(milp._A_ub)
+        _pool_rows_appended = 0
         if inherited_cuts is not None:
             _ia, _ib = inherited_cuts
             if _ia is not None and _sparse_cols(_ia) == n_total:
                 _append_relax_rows(milp, _ia, _ib)
+                _pool_rows_appended = _sparse_rows(_ia)
                 self._pool_stats["inherited_nodes"] += 1
-                self._pool_stats["inherited_rows"] += _sparse_rows(_ia)
+                self._pool_stats["inherited_rows"] += _pool_rows_appended
         _n_base_rows = 0 if milp._A_ub is None else _sparse_rows(milp._A_ub)
 
         res = milp.solve(time_limit=_remaining(), backend=self._backend)
+
+        # C-42: the inherited pool is an ACCELERATOR, never a dependency — a node
+        # solve must be no worse with it than without it. The warm/equilibrated
+        # in-house simplex can fail numerically on the pool-augmented system even
+        # though the pool rows are valid (nvs06: one valid root PSD eigencut flips
+        # the root node's integer-aware relaxation solve from ``optimal`` to an
+        # uncertified ``infeasible``/``iteration_limit`` — the C-38 failure class,
+        # now triggered by the extra row instead of a stale basis). Losing the
+        # node bound is what truncated the flag-ON B&B loop at the root (the
+        # driver's deliberately-skipped node NLP leaves the failure sentinel in
+        # place, the sentinel prunes the root non-rigorously, and the tree
+        # exhausts after one node). So: when pool rows were appended and the
+        # solve produced no certified verdict — not ``optimal`` and not a
+        # Farkas-certified ``infeasible`` — strip the pool rows and re-solve.
+        # Dropping valid rows only loosens the relaxation (sound), and the retry
+        # is byte-identical to the no-pool solve the default path performs, so
+        # the pool can perturb neither the incumbent search nor loop termination.
+        # The per-node square/PSD skip is likewise lifted for this node: its
+        # justification ("the pool already supplies the family") no longer holds
+        # once the pool is dropped here.
+        if _pool_rows_appended and not (
+            res.status == "optimal"
+            or (res.status == "infeasible" and getattr(res, "farkas_certified", False))
+        ):
+            _a_ub_cur = milp._A_ub
+            if _n_pre_pool_rows == 0 or _a_ub_cur is None:
+                milp._A_ub, milp._b_ub = None, None
+            else:
+                milp._A_ub = _a_ub_cur[:_n_pre_pool_rows]
+                milp._b_ub = np.asarray(milp._b_ub)[:_n_pre_pool_rows]
+            _n_base_rows = _n_pre_pool_rows
+            skip_pool_separators = False
+            self._pool_stats["dropped_nodes"] += 1
+            res = milp.solve(time_limit=_remaining(), backend=self._backend)
+
+        # Lazy re-separation, stride safety net (C-42): every
+        # ``_LAZY_RESEP_STRIDE``-th skip-eligible node solve runs the full
+        # square/PSD separation pass regardless of the driver's global-stall
+        # governor, so pool inheritance can never fully starve a class the
+        # governor misjudges. Separating more only tightens (each emitted cut
+        # is valid), so the net is performance-only — see the constants above.
+        if skip_pool_separators and separate:
+            self._lazy_skip_ctr += 1
+            if self._lazy_skip_ctr % _LAZY_RESEP_STRIDE == 0:
+                skip_pool_separators = False
+                self._pool_stats["lazy_reseparations"] += 1
 
         if separate:
             _st = self._sep_timers  # cert:T0.3 per-family separation timers

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -254,6 +254,26 @@ _AUTO_RLT_LEVEL1_MAX_VARS = 50
 # with this margin, so the convexity verdict (hence bound soundness) is never
 # borderline.
 _CONVEX_OBJ_PSD_TOL = 1e-6
+# Lazy re-separation, global-bound-stall governor (C-42 Part 2, THRU-4
+# follow-on; the relaxer-side stride net is ``_LAZY_RESEP_STRIDE`` in
+# ``mccormick_lp.py``). Active only under pool inheritance
+# (``DISCOPT_CUT_INHERIT`` with a captured root pool). All three constants are
+# GLOBAL — never tuned per instance:
+#   * ``_LAZY_RESEP_STALL_WINDOW``: node solves without any global-lower-bound
+#     improvement before re-separation is probed. Small enough to catch the
+#     tspn05-class freeze well inside its budget, large enough that the
+#     steadily-closing nvs19-class (bound moves every few nodes) never probes.
+#   * ``_LAZY_RESEP_PROBE_BUDGET``: node solves the probe may re-separate
+#     before concluding separation is bound-inert here (the nvs24 signature)
+#     and muting until the bound next moves — this caps the throughput cost of
+#     a wrong probe at ``budget / window`` of the node solves.
+#   * ``_LAZY_RESEP_GLB_EPS``: relative improvement that counts as progress;
+#     near-zero because the stall signature is an EXACTLY frozen bound.
+# Per-node alternatives (parent-bound stall, LP-gain productivity) were tried
+# and falsified by measurement — see ``docs/dev/c42-cut-inherit-fix-2026-07-07.md``.
+_LAZY_RESEP_STALL_WINDOW = 24
+_LAZY_RESEP_PROBE_BUDGET = 8
+_LAZY_RESEP_GLB_EPS = 1e-9
 # Floor on the time budget handed to the end-of-solve root-relaxation fallback
 # bound (issue #138). On a hard nonconvex minimize the B&B loop can consume the
 # entire `time_limit` and exit uncertified, leaving no time for the rigorous
@@ -5459,6 +5479,15 @@ def solve_model(
             return False, xv, float("nan")
         return True, xv, _obj
 
+    # Lazy re-separation governor state (C-42 Part 2; see the module-level
+    # ``_LAZY_RESEP_*`` constants). Touched only under active pool inheritance.
+    _lazy_glb_ref: Optional[float] = None
+    _lazy_armed = False
+    _lazy_stagnant_solves = 0
+    _lazy_probe_spent = 0
+    _lazy_mode = "idle"
+    _lazy_resep_fires = 0
+
     # Set when the interactive debugger's `quit` breaks the search loop: a
     # user-interrupted exit proves nothing, so the status decision below must
     # not fall through to a certified "infeasible"/"optimal".
@@ -5491,6 +5520,74 @@ def solve_model(
         n_batch = len(batch_ids)
         if n_batch == 0:
             break
+
+        # C-42 Part 2 — lazy re-separation, global-bound-stall governor. Under
+        # pool inheritance the square/PSD point separators are skipped at
+        # nodes; on the tspn05 class that skip is load-bearing for closure
+        # (#552: the tree's bound freezes and the certificate is lost at
+        # budget). The governor watches the tree's GLOBAL lower bound:
+        #   * ``idle``    — the bound improved within the last
+        #     ``_LAZY_RESEP_STALL_WINDOW`` node solves: keep the cheap
+        #     pool-only path (this is what preserves #551's 2–5× throughput
+        #     win on nvs19/nvs24);
+        #   * ``probing`` — the bound had been moving (the governor is ARMED
+        #     by a genuine in-tree improvement) and then stagnated for a full
+        #     window: re-enable the full separation pass for up to
+        #     ``_LAZY_RESEP_PROBE_BUDGET`` node solves;
+        #   * ``muted``   — the probe did not move the bound either (the
+        #     nvs24 signature: separation is measured bound-inert there):
+        #     return to pool-only until the bound next improves, which resets
+        #     the cycle (self-healing on phase changes).
+        # An improvement while ``probing`` REFRESHES the probe (separation is
+        # demonstrably moving the bound right now, so keep it engaged — this
+        # is what lets tspn05 close instead of rationing separation to an
+        # 8-in-32 duty cycle); a probe still exits after a full budget of
+        # improvement-free separated solves, which caps the cost of a
+        # misjudged lock-in. An improvement in any other mode resets to
+        # ``idle``. Enabling separation only ever TIGHTENS a node's relaxation
+        # (every cut is valid), so the governor is performance-only —
+        # soundness is unaffected in every state. Evaluated only under active
+        # pool inheritance: the default path reads no extra state and is
+        # byte-identical.
+        _lazy_probing = False
+        if _cut_inherit and _root_cut_pool is not None:
+            try:
+                _glb_now = float(tree.stats()["global_lower_bound"])
+            except Exception:  # pragma: no cover - defensive
+                _glb_now = -np.inf
+            if np.isfinite(_glb_now) and (
+                _lazy_glb_ref is None
+                or _glb_now > _lazy_glb_ref + _LAZY_RESEP_GLB_EPS * max(1.0, abs(_lazy_glb_ref))
+            ):
+                if _lazy_glb_ref is not None:
+                    # A genuine in-tree improvement (not the first finite
+                    # reference) ARMS the governor: a stall is only a
+                    # meaningful signal once the bound has demonstrably been
+                    # moving. A bound that has never moved since the root is
+                    # the pool-at-fixed-point signature (nvs24: the root pool
+                    # is separated to convergence and per-node re-separation
+                    # is measured bound-inert), where a probe only burns the
+                    # most expensive separation wall in the corpus; the
+                    # stride net remains the unconditional prober there.
+                    _lazy_armed = True
+                _lazy_glb_ref = _glb_now
+                _lazy_stagnant_solves = 0
+                _lazy_probe_spent = 0
+                if _lazy_mode != "probing":
+                    _lazy_mode = "idle"
+            if (
+                _lazy_mode == "idle"
+                and _lazy_armed
+                and _lazy_stagnant_solves >= _LAZY_RESEP_STALL_WINDOW
+            ):
+                _lazy_mode = "probing"
+            elif _lazy_mode == "probing" and _lazy_probe_spent >= _LAZY_RESEP_PROBE_BUDGET:
+                _lazy_mode = "muted"
+            _lazy_probing = _lazy_mode == "probing"
+            _lazy_stagnant_solves += n_batch
+            if _lazy_probing:
+                _lazy_probe_spent += n_batch
+                _lazy_resep_fires += n_batch
 
         # Interactive debugger: nodes selected — boxes/ids now available.
         if _debug.fire(
@@ -5814,8 +5911,11 @@ def solve_model(
                             want_marginals=_node_reduce_enabled,
                             # THRU-4: with the root pool inherited, skip the per-node
                             # square/PSD point-separation loops (sound: their cut
-                            # families are box-independent and already in the pool).
-                            skip_pool_separators=(_cut_inherit and _root_cut_pool is not None),
+                            # families are box-independent and already in the pool)
+                            # — unless the global-stall governor is probing (C-42).
+                            skip_pool_separators=(
+                                _cut_inherit and _root_cut_pool is not None and not _lazy_probing
+                            ),
                         )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", i, e)
@@ -6126,8 +6226,11 @@ def solve_model(
                             want_marginals=_node_reduce_enabled,
                             # THRU-4: with the root pool inherited, skip the per-node
                             # square/PSD point-separation loops (sound: their cut
-                            # families are box-independent and already in the pool).
-                            skip_pool_separators=(_cut_inherit and _root_cut_pool is not None),
+                            # families are box-independent and already in the pool)
+                            # — unless the global-stall governor is probing (C-42).
+                            skip_pool_separators=(
+                                _cut_inherit and _root_cut_pool is not None and not _lazy_probing
+                            ),
                         )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", int(batch_ids[i]), e)
@@ -7974,6 +8077,10 @@ def solve_model(
         for _pfam, _pcount in _mc_lp_relaxer._pool_stats.items():
             if _pcount > 0:
                 _solver_stats[f"pool/{_pfam}"] = float(_pcount)
+    # C-42 Part 2: node solves the global-bound-stall governor re-separated
+    # (driver-side; the relaxer's ``lazy_reseparations`` counts the stride net).
+    if _lazy_resep_fires > 0:
+        _solver_stats["pool/stall_reseparations"] = float(_lazy_resep_fires)
 
     return SolveResult(
         status=status,

--- a/python/tests/test_c42_cut_inherit_coldpath.py
+++ b/python/tests/test_c42_cut_inherit_coldpath.py
@@ -1,0 +1,164 @@
+"""Regression tests for C-42: the cut-inherit cold-path pool must never
+truncate the B&B loop, and the lazy re-separation trigger.
+
+Root cause pinned here (THRU-4 graduation blocker #552, fix in this change):
+under ``DISCOPT_CUT_INHERIT`` the cold-path root pool probe (#551) captures a
+valid root cut (nvs06: one PSD eigencut), but appending that row to a node's
+relaxation can make the in-house warm-simplex solve fail *numerically*
+(uncertified ``infeasible`` / ``iteration_limit`` — the C-38 failure class,
+triggered by the extra row instead of a stale basis). The node then produced NO
+bound; with the node NLP deliberately skipped on the LP-relaxer path, the
+driver's failure sentinel pruned the ROOT non-rigorously, the pre-tree pump
+chain never ran (its gate needs a root relaxation bound), and the B&B loop
+exhausted after one node — nvs06 exited ``feasible 231.70`` at 1.5 s with 8.5 s
+of budget unused instead of certifying ``optimal 1.7703125``.
+
+The fix: the inherited pool is an ACCELERATOR, never a dependency. When the
+pool-augmented cold solve yields no certified verdict, the pool rows are
+stripped and the node re-solved without them — byte-identical to the no-pool
+solve the default path performs — so the pool can perturb neither the incumbent
+search nor loop termination (``solve_at_node`` in ``mccormick_lp.py``).
+
+Part 2 (the tspn05-class blocker): lazy re-separation. Inheritance-only leaves
+tspn05's nodes too loose to fathom (the tree's bound freezes, cert lost at
+budget). The trigger is a driver-side GLOBAL-bound-stall governor (``solver.py``
+``_LAZY_RESEP_*`` constants: stagnation window -> bounded re-separation probe ->
+mute if the probe is bound-inert, reset on any improvement) plus a relaxer-side
+stride safety net (``_LAZY_RESEP_STRIDE`` in ``mccormick_lp.py``). Per-node
+signals (parent-bound stall, LP-gain productivity) were tried first and
+falsified by measurement — see ``docs/dev/c42-cut-inherit-fix-2026-07-07.md``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+import pytest
+from discopt.modeling.core import from_nl
+from discopt.solver_tuning import SolverTuning
+
+_DATA = Path(__file__).parent / "data" / "minlplib_nl"
+
+
+def _mini_qp_relaxer_and_pool():
+    """A dense integer QP whose root separation verifiably pools cuts, with the
+    incremental engine disabled so node solves take the COLD path (the C-42
+    surface — nvs06/nvs19/nvs24 are cold-path instances)."""
+    import discopt.modeling.core as dm
+    from discopt._jax.mccormick_lp import MccormickLPRelaxer
+
+    m = dm.Model("mini_c42")
+    x = m.integer("x", shape=(2,), lb=-3, ub=3)
+    m.minimize(x[0] * x[0] + x[1] * x[1] - 2 * x[0] * x[1] + 0.5 * x[0] - 0.5 * x[1])
+    relaxer = MccormickLPRelaxer(m, psd_cuts=True)
+    lb = np.full(2, -3.0)
+    ub = np.full(2, 3.0)
+    chunks: list = []
+    res = relaxer.solve_at_node(lb, ub, time_limit=30.0, out_cuts=chunks)
+    assert res.status == "optimal" and chunks, "root pool capture failed"
+    relaxer._inc = None  # force the cold path at node solves
+    return relaxer, lb, ub, chunks[0]
+
+
+@pytest.mark.smoke
+def test_pool_drop_retry_recovers_the_node_bound(monkeypatch):
+    """The mechanism test: when the pool-augmented cold solve fails with no
+    certified verdict, the pool rows must be stripped and the node re-solved —
+    the node keeps a valid bound instead of losing it (which is what truncated
+    nvs06's loop at the root). Fails before the C-42 fix (no bound), passes
+    after (bound recovered, ``pool/dropped_nodes`` fires)."""
+    relaxer, lb, ub, pool = _mini_qp_relaxer_and_pool()
+
+    baseline = relaxer.solve_at_node(lb, ub, time_limit=30.0)
+    assert baseline.status == "optimal" and baseline.lower_bound is not None
+
+    # Poison exactly the FIRST relaxation solve of the next node call (the
+    # pool-augmented one) with an uncertified failure; delegate afterwards.
+    # This reproduces deterministically what the nvs06 PSD pool row does to the
+    # warm simplex numerically.
+    from discopt._jax import milp_relaxation as _mr
+
+    milp_cls = _mr.MilpRelaxationModel
+    real_solve = milp_cls.solve
+    state = {"fail_next": True}
+
+    def flaky(self, *args, **kwargs):
+        if state["fail_next"]:
+            state["fail_next"] = False
+            return SimpleNamespace(
+                status="numerical", x=None, objective=None, bound=None, farkas_certified=False
+            )
+        return real_solve(self, *args, **kwargs)
+
+    monkeypatch.setattr(milp_cls, "solve", flaky)
+
+    res = relaxer.solve_at_node(
+        lb, ub, time_limit=30.0, inherited_cuts=pool, skip_pool_separators=True
+    )
+    assert res.status == "optimal", (
+        f"node lost its bound after a failed pool-augmented solve: {res.status} "
+        "(C-42: the pool must be dropped and the node re-solved)"
+    )
+    assert res.lower_bound is not None
+    # Sound and no worse than the no-pool baseline (the retry IS the no-pool
+    # solve; the lifted skip lets separation tighten it further).
+    assert res.lower_bound >= baseline.lower_bound - 1e-6
+    assert relaxer._pool_stats["dropped_nodes"] == 1
+
+
+@pytest.mark.smoke
+def test_lazy_reseparation_stride_net_fires():
+    """The relaxer-side safety net: every ``_LAZY_RESEP_STRIDE``-th
+    skip-eligible node solve runs the full separation pass regardless of the
+    driver's governor, so inheritance can never fully starve a class."""
+    from discopt._jax.mccormick_lp import _LAZY_RESEP_STRIDE
+
+    relaxer, lb, ub, pool = _mini_qp_relaxer_and_pool()
+    for _ in range(_LAZY_RESEP_STRIDE):
+        relaxer.solve_at_node(
+            lb, ub, time_limit=30.0, inherited_cuts=pool, skip_pool_separators=True
+        )
+    assert relaxer._pool_stats["lazy_reseparations"] == 1
+    assert relaxer._pool_stats["skipped_separations"] == _LAZY_RESEP_STRIDE - 1
+
+
+@pytest.mark.slow
+def test_nvs06_cut_inherit_certifies_like_default():
+    """The #552 graduation blocker, end-to-end: nvs06 flag-ON must certify the
+    oracle optimum 1.7703125 exactly like flag-OFF, instead of exiting after one
+    node with ``feasible 231.70`` and most of the budget unused. Fails before
+    the C-42 fix, passes after."""
+    model = from_nl(str(_DATA / "nvs06.nl"))
+    res = model.solve(time_limit=20, gap_tolerance=1e-4, tuning=SolverTuning(cut_inherit=True))
+    assert str(res.status) == "optimal", f"nvs06 flag-ON lost its certificate: {res.status}"
+    assert res.objective == pytest.approx(1.7703125, abs=1e-5)
+    assert res.bound is not None and res.bound <= res.objective + 1e-6
+    stats = res.solver_stats or {}
+    # The cold-path pool populated (the #551 extension under test)...
+    assert stats.get("pool/size", 0) >= 1, f"cold-path pool did not populate: {stats}"
+    # ...and the destabilized root solve recovered by dropping it (the fix).
+    assert stats.get("pool/dropped_nodes", 0) >= 1, f"pool-drop retry never fired: {stats}"
+
+
+@pytest.mark.slow
+def test_tspn05_cut_inherit_certifies_via_lazy_reseparation():
+    """The other #552 blocker: with inheritance-only, tspn05's bound stalls at
+    190.28 and the certificate is lost at budget. The lazy re-separation
+    trigger must break the stall so flag-ON certifies the oracle optimum
+    191.25521 within the flag-OFF-class budget."""
+    model = from_nl(str(_DATA / "tspn05.nl"))
+    res = model.solve(time_limit=60, gap_tolerance=1e-4, tuning=SolverTuning(cut_inherit=True))
+    assert str(res.status) == "optimal", f"tspn05 flag-ON lost its certificate: {res.status}"
+    assert res.objective == pytest.approx(191.25521, rel=1e-5)
+    assert res.bound is not None and res.bound <= res.objective + 1e-6
+    stats = res.solver_stats or {}
+    assert (
+        stats.get("pool/stall_reseparations", 0) >= 1
+        or stats.get("pool/lazy_reseparations", 0) >= 1
+    ), f"no re-separation trigger fired on the stalling class: {stats}"


### PR DESCRIPTION
Fixes the two `DISCOPT_CUT_INHERIT` graduation blockers found by the THRU-4 validation (#552): the nvs06-class B&B-loop truncation (#551's cold-path pool probe) and the tspn05-class lost certificate (per-node re-separation is load-bearing there). Flag default stays **OFF** — no default-path change. Full record: `docs/dev/c42-cut-inherit-fix-2026-07-07.md`.

## Part 1 — root cause + fix (nvs06 truncation)

The failure chain (file:line in the doc):

1. The cold-path pool probe captures ONE root cut on nvs06 — verified by hand to be a **valid** PSD eigencut (`v = (0.2332, 0.7392, −0.6318)`, `b = v0²`; holds at every exactly-lifted feasible point). The cut is not the bug.
2. Appending that row flips the warm-simplex node solve from `optimal 1.10` to an **uncertified `infeasible`/`iteration_limit`** (the C-38 numerical class, triggered by the extra row instead of a stale basis). Isolated A/B on the identical box: inherit-only → numerical; skip-only → optimal; inherit+skip → numerical; neither → optimal.
3. The guard correctly refuses to fathom on an uncertified infeasible — but the node then has **no bound**, and the driver's deliberately-skipped node NLP leaves the failure sentinel in place (`solver.py`), so the ROOT is pruned non-rigorously.
4. `export_batch` returns 0 → the loop breaks after ONE node with 8.5 s of budget unused; the pre-tree pump chain (feasibility pump → NLP-relax pump → integer local search) never runs because its gate needs a root relaxation bound — that is the "reroute" to SubNLP/box-search (251.3 → 231.7).

**Fix (general, `mccormick_lp.py::solve_at_node`):** the inherited pool is an accelerator, never a dependency. When pool rows were appended and the solve yields no certified verdict (not `optimal`, not Farkas-certified `infeasible`), strip the pool rows and re-solve — byte-identical to the no-pool solve the default path performs. A destabilizing pool can no longer perturb the incumbent search or loop termination at any node. Instrumented as `pool/dropped_nodes`.

| nvs06, flag-ON (TL 10 s) | status | objective | nodes | wall |
|---|---|---|---:|---:|
| before (main) | feasible | 231.70004 | 1 | 1.5 s |
| **after** | **optimal** | **1.7703125** | 5 | 2.0 s |
| flag-OFF reference | optimal | 1.7703125 | 5 | 1.4 s |

## Part 2 — lazy re-separation trigger (tspn05)

Shipped: a **driver-side global-bound-stall governor** + a **relaxer-side 1-in-64 stride net** (all constants global, documented in the doc/code):

- Governor (`solver.py`, `_LAZY_RESEP_STALL_WINDOW=24`, `_LAZY_RESEP_PROBE_BUDGET=8`, `_LAZY_RESEP_GLB_EPS=1e-9`): armed by the first genuine in-tree bound improvement; once armed, a stall of a full window re-enables the full square/PSD separation pass; an improvement while probing refreshes the probe (what lets tspn05 lock separation in and close); a budget-exhausted improvement-free probe mutes until the bound next moves (the nvs24 signature).
- Two per-node designs were tried first and **falsified by measurement** (recorded in the doc per CLAUDE.md §4): the parent-bound stall test fires on 185/191 nvs19 nodes (the stall signature is the NORMAL state on dense integer QPs) and destroys the #551 win; an LP-gain productivity mute doesn't discriminate either (nvs19 fires gain median rel 0.117 yet are wall-useless; tspn05's load-bearing fires gain median rel 1.3e-3).

| instance (TL 60 s, flag-ON) | main (#552 blockers) | this PR | verdict |
|---|---|---|---|
| tspn05 | bound STALLS 190.279, cert lost at TL | **optimal 191.25521, 119 nodes, 48.8 s** | cert regained |
| nvs19 | optimal 52.8 s (the #551 win) | **optimal −1098.4, 49.3 s** | win retained |
| nvs24 | 49 nodes @ TL, bound −1035.66 (5.3× nodes/s) | **49 nodes @ TL, same bound — governor never arms; byte-identical** | win retained |

Every dual bound stays ≤ incumbent and ≤ the oracle optimum on every arm.

## Gates (all run on this branch, release build)

- **Regression tests** (`python/tests/test_c42_cut_inherit_coldpath.py`): 2 smoke (pool-drop retry mechanism — verified to FAIL on pre-fix code; stride net) + 2 slow (nvs06 flag-ON certifies 1.7703125; tspn05 flag-ON certifies 191.25521). All pass.
- **`check_cert_neutrality.py`** (default OFF, 41-panel): **40/41 byte-identical** (`|Δobj|=0.00e+00`, `nodes n->n` everywhere). The single flagged row (`nvs13` 19→49) is the known pre-existing stale-baseline drift recorded by #550/#551/#552 — re-verified here: nvs13 default-OFF on the BARE branch point (diff stashed) gives 49 nodes / −585.2 / bound −585.2000011714, byte-identical to this branch. No rebaseline (same disposition as #550–#552).
- `pytest -m smoke`: 622 passed, 14 skipped.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: 10 passed.
- `cargo test -p discopt-core`: 424 passed (run during development; the final diff touches **no Rust** — the getter added for the falsified per-node arm was removed again).
- `ruff check` + `ruff format --check`: clean. Pre-commit `mypy` (the actual hook, whole package): Passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
