### PR TITLE
ci: add codecov.yml — make coverage statuses informational (stop spurious PR alerts)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+# Codecov configuration.
+#
+# Coverage is REPORTED but is NOT a blocking PR gate in this repo. The real
+# coverage floor (>=65% now; #87 tracks restoring to 85%) is enforced by
+# `--cov-fail-under=65` inside the label-gated `python-coverage` CI job
+# (.github/workflows/ci.yml), which runs on `main` pushes and on PRs tagged
+# `coverage`.
+#
+# The codecov status checks, by contrast, fire on EVERY PR. Without an uploaded
+# `coverage.xml` (the coverage job is skipped on unlabeled PRs) they cannot
+# compute a real comparison and default to FAILURE — a spurious red check /
+# alert on docs-only, results-only, and every unlabeled PR. Marking them
+# `informational` makes codecov post the coverage delta as a non-failing status,
+# eliminating the noise while keeping the report. Enforcement remains in the
+# coverage job's `--cov-fail-under`.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# Keep the PR comment concise (it is not a failing check, just a summary).
+comment:
+  layout: "reach, diff, flags"
+  require_changes: true   # only comment when coverage actually changes


### PR DESCRIPTION
## What

Adds a `codecov.yml` that marks the `project` and `patch` coverage statuses **`informational`** (report-only, never failing).

## Why

There was **no codecov config**, so codecov used its default of failing the `project` status on any coverage delta. The `python-coverage` job is label-gated (runs only on `main` pushes or PRs tagged `coverage`), so on a normal PR **no `coverage.xml` is uploaded** → codecov can't compute a real comparison → `codecov/project` **fails on essentially every PR**. That's the recurring spurious "coverage" alert.

## What this does / doesn't change

- ✅ Codecov still **reports** the coverage delta on PRs (comment + status), now as a non-failing status → no more spurious alerts.
- ✅ The **real coverage floor is unchanged** — `--cov-fail-under=65` in the `python-coverage` job (main pushes + `coverage`-labeled PRs) still enforces it; #87 tracks restoring 85%.
- ✅ No solver/test code touched — config only.

After this merges, docs-only/results-only/unlabeled PRs won't throw the coverage check failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
