### PR TITLE
ci: skip heavy test jobs on docs/results/config-only PRs (conservative path filter)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decide whether this push/PR touches anything that could affect solver
+  # behavior. Docs-/results-/config-only changes skip the heavy test jobs
+  # (rust / python-fast / python-amp-coverage) below. Deliberately conservative:
+  # `code=true` unless EVERY changed file is in the docs/results allowlist, and
+  # `true` on any uncertainty (empty diff, missing base) — we never skip tests on
+  # doubt, because a core-solver change's blast radius is the whole corpus.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags --depth=200 origin "${{ github.base_ref }}" || true
+            base="$(git merge-base "origin/${{ github.base_ref }}" HEAD 2>/dev/null || true)"
+            changed="$(git diff --name-only "${base:-HEAD~1}" HEAD 2>/dev/null || true)"
+          else
+            changed="$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" 2>/dev/null \
+                      || git diff --name-only HEAD~1 HEAD 2>/dev/null || true)"
+          fi
+          echo "Changed files:"; printf '%s\n' "$changed"
+          # Allowlist of paths that can NOT affect solver behavior (safe to skip).
+          allow='^(docs/|reports/|discopt_benchmarks/results/|.*\.md$|codecov\.yml$|LICENSE$|\.gitignore$)'
+          if [ -z "$changed" ]; then
+            code=true                                   # unknown/empty -> run
+          elif printf '%s\n' "$changed" | grep -qvE "$allow"; then
+            code=true                                   # >=1 non-allowlisted file -> run
+          else
+            code=false                                  # every change is docs/results -> skip
+          fi
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "=> code=$code (heavy test jobs will $([ "$code" = true ] && echo RUN || echo SKIP))"
+
   rust:
     name: Rust
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -69,6 +111,8 @@ jobs:
   python-fast:
     name: Python fast (3.12, ubuntu)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -221,6 +265,8 @@ jobs:
   python-amp-coverage:
     name: Python AMP coverage (3.12, ubuntu)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## What

Skips the three expensive CI jobs (`rust`, `python-fast`, `python-amp-coverage`) on **docs-/results-/config-only** PRs, via a cheap `changes` job that classifies the diff. `lint` still runs on every PR (so there's always a green check).

## Why

Docs-only and results-only PRs currently run the full Rust + Python + ~20 min AMP suite for nothing.

## Safety (this is a solver — mis-classifying a code PR as docs would ship a regression)

The classifier is **conservative**: `code=true` (run the full suite) unless **every** changed file is in a docs/results/config allowlist, and it **defaults to `true` on any uncertainty** (empty diff, missing base). A core change has a corpus-wide blast radius — e.g. C-39 (a Rust simplex fix) broke a *Python AMP* test — so we never skip tests when a code/config file is touched. No `paths`-level trigger filtering (which can leave required checks stuck pending); this uses a real job that always reports.

Verified classification:

| changed files | decision |
|---|---|
| `docs/*.md` only | **skip** ✓ |
| `reports/*.json`, `codecov.yml` | **skip** ✓ |
| `docs/x.md` + `python/…/solver.py` | **run** ✓ |
| `docs/x.md` + `crates/…/simplex/primal.rs` (C-39 case) | **run** ✓ |
| single `.py` / `.rs` / `pyproject.toml` / workflow | **run** ✓ |
| empty / unknown | **run** ✓ (never skip on doubt) |

No required status checks are configured on `main`, so skipped jobs cannot leave PRs stuck "pending." This PR touches the workflow itself, so it runs the full suite (self-testing the run path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
