### PR TITLE
ci: don't re-run test_amp.py in python-fast (dedup the AMP suite)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
             -q --tb=short --timeout=120 \
             -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
             --ignore=python/tests/test_correctness.py \
+            --ignore=python/tests/test_amp.py \
             -n "${PYTEST_XDIST_WORKERS}" --dist loadgroup \
             --durations=20
         env:


### PR DESCRIPTION
## What

Ignore `python/tests/test_amp.py` in the **`python-fast`** job.

## Why

On a code PR, `test_amp.py`'s non-`correctness` tests ran **twice** — once in `python-fast` (fast tier) and once in `python-amp-coverage` (test_amp with coverage). Since `python-amp-coverage` already runs the *full* `test_amp` battery (it doesn't exclude `correctness`), it's the single home for AMP; `python-fast` doesn't need to re-run it. This removes a redundant ~20-min execution from every code PR and speeds up the fast job.

## Scope / safety

- Scoped to `python-fast` only. `python-coverage` (label/main-push) still runs the full suite, so its `--cov-fail-under=65` stays accurate; `python-amp-coverage` uploads `test_amp` coverage separately (merged at codecov). No coverage is lost.
- No solver/test code changed — CI config only.
- With the docs/results path filter (#561): a docs PR skips everything; a code PR now runs `test_amp` exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
