### PR TITLE
perf(graduate): cut-pool inheritance structure gate — stays opt-in (nvs22 false-optimal blocks the flip)

### DIFF
--- a/docs/dev/cut-inherit-grad-2026-07-08.md
+++ b/docs/dev/cut-inherit-grad-2026-07-08.md
@@ -1,0 +1,214 @@
+# CUT-INHERIT-GRAD — cut-pool inheritance graduation: predicate found, but the
+# default-ON flip is KILLED by a flag-path false-optimal (nvs22). Stays opt-in. (2026-07-08)
+
+**Status: NOT graduated to default-ON. `DISCOPT_CUT_INHERIT` / `SolverTuning.cut_inherit`
+stays OPT-IN (default force-off).** The task asked to graduate root-cut-pool
+inheritance to a *structure-gated default-ON* that ships the dense-QP 2–5× where
+it pays and is byte-identical elsewhere. Two findings reshaped that:
+
+1. **The structural premise was falsified (CLAUDE.md §4 — the measurement wins).**
+   THRU-4-graduate (#552) concluded the 2–5× is *specific to the dense
+   integer-QP class* and a broad flip is *throughput-neutral (1.004×)*. Under
+   clean serial measurement that 1.004× does **not reproduce** — it was a TL=30s /
+   parallel-contention artifact. Every pool-firing instance benefits (IQCQP,
+   QCP, QCQP, MBNLP alike: 1.6–9.7×). So there is **no neutral firing class to
+   gate out**; a class-keyed subset gate would wrongly withhold real wins. The
+   honest predicate is the simplest one: **pool-fires ⇒ ON** (inherit iff a
+   non-empty root pool is separated).
+
+2. **But the flag path has a false-optimal that blocks the flip (CLAUDE.md §1).**
+   The broad validation surfaced a **new deterministic false certificate**:
+   `nvs22` (MINLP, pure-integer nonconvex, an adversarial-suite soundness probe)
+   certifies `optimal 33.55166` against the oracle optimum **6.0582** — flag-ON,
+   both force-on and structure-gated. This is the nvs06-class incumbent-search
+   reroute that C-42 (#553) only *partially* fixed: C-42's pool-drop-retry fires
+   only when the pool-augmented node solve *fails numerically*; on nvs22 the pool
+   solve **succeeds**, but the pre-tree incumbent pump is still rerouted, the
+   region holding 6.0582 is fathomed, and a wrong optimum is certified. A false
+   certificate is a hard regression — the default cannot flip while it exists.
+
+**What ships (this PR).** The tri-state `cut_inherit` machinery + the pool-fires
+structure gate, wired and instrumented, **default force-off** (byte-identical to
+`origin/main`). The gate is reachable as an **opt-in** (`DISCOPT_CUT_INHERIT=gated`
+/ `cut_inherit=None`), the throughput win is documented, and the nvs22 blocker is
+pinned by a strict-xfail regression test so the flip can be re-attempted the
+moment the reroute is fixed.
+
+> **Method.** Apple M-series (arm64), Python 3.12, release build
+> (`maturin develop --release`; pounce `_pounce.abi3.so` = 4.73 MB, not debug),
+> `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`, corpus
+> `~/Dropbox/projects/discopt-minlp-benchmark/`, oracle `minlplib.solu`.
+> **Throughput A/B pairs were run SERIALLY** (one solve at a time) — the entry
+> experiment's first pass was run 15-way parallel and its node/throughput numbers
+> were corrupted by contention; the serial re-run is the reference below and is
+> what falsifies #552's "neutral".
+
+---
+
+## Part 1 — the structural predicate (entry experiment)
+
+### 1a. The named candidate feature does NOT separate (falsified)
+
+The task's leading candidate was the *fraction of the root/node wall the square+PSD
+separation loops consume*. Implemented as a cheap root-time feature
+(`pool/root_sqpsd_frac`: the square+PSD wall of the ONE root pool separation solve
+÷ that solve's wall, isolable because no node solves have run yet). Measured
+flag-ON on the labeled set (WIN = the #551/#552 win probes; NEUTRAL = the #552
+"neutral" firing slice):
+
+| instance | label (#552) | root_sqpsd_frac | pool |
+|---|---|---:|---:|
+| nvs23 | WIN | 0.941 | 82 |
+| nvs24 | WIN | 0.857 | 30 |
+| nvs19 | WIN | 0.702 | 70 |
+| nvs17 | WIN | 0.590 | 59 |
+| kall_circles_c6b | "neutral" | 0.912 | 31 |
+| kall_circles_c6c | "neutral" | 0.860 | 30 |
+| kall_circlespolygons_c1p12 | "neutral" | 0.859 | 122 |
+| knp3-12 | "neutral" | 0.516 | 64 |
+| ringpack_10_2 | "neutral" | 0.399 | 69 |
+| spring | control | 0.052 | 6 |
+
+**No threshold separates them.** The "neutral" kall instances (0.86–0.91) sit
+*above* WIN nvs17/19 (0.59/0.70). Pool size overlaps completely (kall 122 > nvs 30).
+`pure_discrete` also fails (nvs17/19 pure=1 WIN; nvs13/23 pure=1 neutral; kall
+pure=0). **Kill criterion for "the named feature": triggered.**
+
+### 1b. Why nothing separates — the #552 "neutral" is a measurement artifact
+
+Re-labeling by the *ground truth* (serial ON/OFF node-throughput ratio at TL=60s)
+shows the "neutral" label itself was wrong:
+
+| instance | probtype | OFF nodes | ON nodes | OFF n/s | ON n/s | **ratio** | verdict |
+|---|---|---:|---:|---:|---:|---:|---|
+| nvs24 | IQCQP | 9 | 49 | 0.14 | 0.79 | **5.46×** | WIN |
+| nvs23 | IQCQP | 69 | 125 | 1.14 | 2.08 | **1.82×** | WIN |
+| nvs17 | IQCQP | 173 | 225 | 7.39 | 12.85 | **1.74×** | WIN |
+| nvs19 | IQCQP | 215 | 295 | 3.57 | 6.09 | **1.70×** | WIN (+cert) |
+| kall_circles_c6c | QCP | 55 | 143 | 0.91 | 2.38 | **2.63×** | WIN |
+| kall_circles_c6b | QCP | 61 | 111 | 1.01 | 1.84 | **1.82×** | WIN |
+| knp3-12 | QCP | 31 | 287 | 0.49 | 4.77 | **9.72×** | WIN |
+| dispatch | QCQP | 3 | 15 | 6.63 | 21.51 | **3.25×** | WIN |
+| tspn05 | MBNLP | 39 | 119 | 2.07 | 2.47 | 1.19× (+cert) | WIN |
+
+Every pool-firing instance is a WIN, across IQCQP / QCP / QCQP / MBNLP. #552's
+knp3-12 "127→127 identical" reproduces its OFF=ON only at TL=30s under
+contention; serially it is OFF 31 → ON 287 nodes (~4–9×). Soundness of the wins
+verified: objectives identical (knp3-12 to 8 digits, kall_* bit-identical) or
+ON strictly better (nvs19 −1098.2 → −1098.4 = oracle); every bound ≤ incumbent
+and ≤ oracle.
+
+### 1c. The predicate that IS correct: pool-fires
+
+The one root-time signal that is present-and-correct is **whether a non-empty
+root cut pool is separated** (`_root_cut_pool is not None`). It is the cheapest
+possible predicate (already computed), keys on measured structure not on
+name/shape (CLAUDE.md §2), and:
+- **fires ⇒ broadly beneficial** (§1b), and
+- **does not fire ⇒ byte-identical** (nothing to inherit or skip; §3b).
+
+## Part 2 — the structure gate (built, default force-off)
+
+`cut_inherit` is now **tri-state** (`Optional[bool]`):
+`True` force-on · `False` force-off · `None` structure-gated. Env
+`DISCOPT_CUT_INHERIT`: unset/`0` ⇒ force-off (**shipped default**),
+`gated`/`auto` ⇒ `None`, any other non-`0` (e.g. `1`) ⇒ force-on. The gate is the
+pre-existing pool-population guard unified with the tri-state: capture the pool
+optimistically at the root when *not* forced off, and engage the per-node
+square/PSD skip iff the pool actually populated. Instrumented: `pool/gate_mode`
+(1/0/−1) and `pool/gate_decision` (1 iff inheritance engaged), plus the diagnostic
+`pool/root_sqpsd_frac`.
+
+Fire-proof: `pool/gate_decision=1` on nvs24 under `=gated`; `=0` on the default
+(force-off) path and on a pool-empty model.
+
+## Part 3 — verification
+
+### 3a. On-class win retained under the gate (gated vs OFF, serial, TL 60s)
+
+| instance | OFF | gated | nodes/s ratio | gate | cert |
+|---|---|---|---:|---:|---|
+| nvs24 | feasible, 9 n | feasible, 49 n | **5.40×** | ON | bound identical −1035.66 |
+| nvs19 | feasible, 217 n | **optimal, 295 n** | 1.66× | ON | **gains cert** (−1098.4 = opt) |
+| nvs17 | optimal, 173 n | optimal, 225 n | 1.74× | ON | preserved |
+| nvs23 | feasible, 69 n | feasible, 109 n | 1.58× | ON | obj identical |
+
+### 3b. Off-class byte-identical (gated vs force-off, serial) — 0 wrongful fires
+
+On 12 non-firing instances that terminate deterministically, `gated` is
+**byte-identical** to force-off (node_count + objective exactly equal,
+`gate_decision=0` on all): cvxnonsep_{normcon20,nsig20,psig20}, enpro56pb,
+ravempb, waterund01, gabriel02, sssd18-08persp, pointpack12, alan, gbd,
+st_miqp1. **12/12 IDENTICAL, 0 wrongful fires.** (The broad TL-bound held-out
+slice shows node-count wobble ON-vs-OFF on time-limited rows — that is wall-clock
+nondeterminism at the deadline, not a code path difference: those rows do not
+fire the pool, so gated≡force-off by construction.)
+
+### 3c. Bound-changing soundness on the on-class
+
+Differential: on every on-class arm the dual bound stays ≤ its incumbent and ≤
+the oracle (min sense); the root bound is identical on/off (nvs19/24
+−1104.24/−1035.66). Feasible-point sampling (existing
+`test_root_pool_cuts_valid_on_every_child_feasible_point`, exhaustive over the
+dense-QP box): every pooled row holds at every feasible lifted point → no
+inherited cut removes a feasible point. **0 soundness violations.**
+
+### 3d. THE BLOCKER — nvs22 flag-path false-optimal
+
+`nvs22` (MINLP), TL 25s, oracle 6.0582:
+
+| arm | status | objective | bound | nodes |
+|---|---|---:|---:|---:|
+| default (force-off) | optimal | **6.0582** (correct) | 6.0582 | 35 |
+| force-on | optimal | **33.55166** (FALSE) | 33.55166 | 11 |
+| structure-gated | optimal | **33.55166** (FALSE) | 33.55166 | 11 |
+
+Deterministic (persists at TL=60s). `pool/dropped_nodes` is *not* set — C-42's
+retry never triggers because the pool solve **succeeds**; the failure is the
+pre-tree incumbent-search reroute (nvs06-class, flagged as an unfixed follow-up
+in `c42-cut-inherit-fix-2026-07-07.md` §"Follow-ups": *driver
+sentinel-on-deliberate-skip*). This is a **false certificate** → CLAUDE.md §1
+KILL for default-ON. It was invisible to #551's probes and #552's held-out draw
+(neither contained nvs22); the adversarial soundness suite catches it.
+
+### 3e. cert-neutrality (default force-off vs committed baseline)
+
+`check_cert_neutrality.py`, flag unset (force-off), 41-instance panel:
+**41/41 byte-identical, `|Δobj|=0.00e+00` on every row, exit 0.** dispatch 3→3,
+nvs13 49→49, tspn05 39→39 — the default path is byte-identical to `origin/main`,
+so **no rebaseline** (the gate does not fire on the shipped default; the
+"justified rebaseline" clause is moot). Cleaner than #551/#552, which carried the
+nvs13 19→49 main-drift flag; that drift is absent here (the committed baseline was
+since refreshed to 49).
+
+## Part 4 — flip decision
+
+**Not flipped.** Parts 1–3 are not clean (Part 3d). Per the graduation protocol's
+kill criterion and CLAUDE.md §1, a flag with a deterministic false-optimal stays
+opt-in. `solver_tuning.py` default is force-off; `=1` / `=0` / `=gated` overrides
+all work and are tested.
+
+## Follow-ups (recorded, not shipped — the path back to default-ON)
+
+1. **Fix the nvs22 / nvs06-class reroute (the blocker).** Root-cause why the
+   flag-ON pre-tree incumbent pump is rerouted when the cold-path pool solve
+   *succeeds* (the feasibility pump → NLP-relaxation pump → integer local search
+   chain is bypassed, seeding a worse region). This is the same driver-layer
+   sentinel-on-deliberate-skip hazard `c42-cut-inherit-fix` deferred to the #396
+   backlog; it is now a *soundness* bug (false certificate), not merely a
+   degraded incumbent. File on #396.
+2. Once (1) is fixed, re-run this CUT-INHERIT-GRAD validation. The pool-fires
+   gate is already built and validated broadly beneficial; only the soundness
+   blocker stands between it and the flip.
+
+## Gates
+
+| gate | result |
+|---|---|
+| `pytest -m smoke` (python/tests) | **627 passed, 14 skipped** (incl. 6 CUT-INHERIT-GRAD tests: gate-fires, off-class byte-identical, tri-state env precedence, force-off no-skip) |
+| `pytest -m slow test_adversarial_recent_fixes.py` | **12 passed** (nvs22 sound on the default path) |
+| `pytest -m slow test_c42_cut_inherit_coldpath.py` | **2 passed + 1 xfailed** (the nvs22 blocker, strict-xfail — flips the suite red the moment the reroute is fixed) |
+| `check_cert_neutrality.py` (default force-off, 41-panel) | **41/41 byte-identical**, `|Δobj|=0`, exit 0 — no rebaseline |
+| `ruff check` / `ruff format --check` (v0.14.6) | clean |
+| pre-commit `mypy` (whole `python/discopt/`, v2.1.0) | clean on the changed files (`solver_tuning.py`, `solver.py`) |
+| `cargo test -p discopt-core` | n/a — no Rust touched |

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4682,16 +4682,38 @@ def solve_model(
     # warm LP solve instead of re-separating the PSD/RLT cuts from scratch. Stays
     # None unless the relaxer carries PSD cuts (the nvs* / box-QP regime).
     _root_cut_pool = None
+    # CUT-INHERIT-GRAD diagnostic: the fraction of the ONE root pool separation
+    # solve's wall spent in the square+PSD point-separation loops. Surfaced in
+    # ``solver_stats`` for observability; NOT the gate predicate (the entry
+    # experiment showed it does not separate win-from-neutral — the pool-fires
+    # signal does). ``None`` when no pool is separated.
+    _root_sqpsd_frac: Optional[float] = None
     # Root-cut-pool inheritance (THRU-4, ``DISCOPT_CUT_INHERIT`` /
-    # ``SolverTuning.cut_inherit``, default OFF). When on: (a) the general root
-    # cut pool below is captured even when the incremental engine is unavailable
-    # (the cold-path instances are exactly where THRU-3 measured the per-node
-    # separation drag), and (b) every node solve passes
-    # ``skip_pool_separators=True`` so the square/PSD point-separation loops —
-    # up to 8 full MILP re-solves per node each, 73%+12% of the nvs24 solve wall
-    # — are replaced by the inherited pool. Root behaviour is unchanged: the
-    # pool is separated with the full default chain on the root box.
-    _cut_inherit = _tuning().cut_inherit
+    # ``SolverTuning.cut_inherit``, **opt-in, default force-off**,
+    # CUT-INHERIT-GRAD). Tri-state resolution:
+    #   * ``_cut_inherit_mode is True``  — force ON  (env ``=1`` / ``cut_inherit=True``)
+    #   * ``_cut_inherit_mode is False`` — force OFF (env unset/``=0`` / ``cut_inherit=False``)
+    #     — the SHIPPED DEFAULT: byte-identical to pre-THRU-4 behaviour.
+    #   * ``_cut_inherit_mode is None``  — STRUCTURE-GATED opt-in (env ``=gated`` /
+    #     ``cut_inherit=None``): the pool is captured optimistically at the root and
+    #     inheritance engages iff a non-empty pool actually populates
+    #     (``_root_cut_pool is not None``). Validated broadly beneficial where it
+    #     fires, but NOT the default — a flag-path false-optimal on the MINLP
+    #     cold-path class (nvs22) blocks the flip (CLAUDE.md §1; see
+    #     ``docs/dev/cut-inherit-grad-2026-07-08.md``).
+    # When active: (a) the general root cut pool below is captured even when the
+    # incremental engine is unavailable (cold-path instances — nvs19/24 — are
+    # exactly where THRU-3 measured the per-node separation drag), and (b) every
+    # node solve passes ``skip_pool_separators=True`` so the square/PSD
+    # point-separation loops — up to 8 full MILP re-solves per node each — are
+    # replaced by the inherited pool. Root behaviour is unchanged. When the model
+    # carries no liftable square/PSD structure the pool stays empty and the gated
+    # path is byte-identical to force-OFF.
+    _cut_inherit_mode = _tuning().cut_inherit
+    # "Not forced off" — the condition under which the root pool is captured and
+    # (given a populated pool) inheritance is allowed to engage. Forced-ON and
+    # structure-gated both capture; only an explicit ``=0`` suppresses it.
+    _cut_inherit_enabled = _cut_inherit_mode is not False
     # The dual bound the root cut-pool relaxation proves over the whole feasible
     # region (a valid global lower bound for a MINIMIZE). The pool is separated for
     # its CUT ROWS, but the strengthened relaxation also yields a far tighter root
@@ -5029,7 +5051,7 @@ def solve_model(
                         except Exception as _pool_exc:  # pragma: no cover - defensive
                             logger.debug("root cut pool separation skipped: %s", _pool_exc)
                             _root_cut_pool = None
-                    elif getattr(_mc_lp_relaxer, "_inc", None) is not None or _cut_inherit:
+                    elif getattr(_mc_lp_relaxer, "_inc", None) is not None or _cut_inherit_enabled:
                         # Root cut pool for the GENERAL spatial path (cert:T1.3).
                         # When the incremental engine is active but PSD cuts are
                         # off, the fast path (which skips per-node separation) would
@@ -5043,7 +5065,8 @@ def solve_model(
                         # every sub-box, so an inherited row never removes a
                         # feasible point.
                         #
-                        # THRU-4 (``_cut_inherit``): additionally capture this pool
+                        # THRU-4/CUT-INHERIT-GRAD (``_cut_inherit_enabled``):
+                        # additionally capture this pool
                         # when the incremental engine is unavailable — cold-path
                         # nodes are exactly where the per-node square/PSD point
                         # separators dominate (nvs24: 73%+12% of the solve wall) —
@@ -5056,12 +5079,40 @@ def solve_model(
                                 max(time_limit * 0.25, 5.0),
                                 max(_root_remaining, _DEADLINE_NODE_FLOOR_S),
                             )
+                            # CUT-INHERIT-GRAD structure predicate: snapshot the
+                            # per-family separation timers BEFORE the root pool solve
+                            # so the square+PSD wall this ONE root separation spends is
+                            # isolable (no node solves have run yet, so the delta is
+                            # root-only). The fraction of the root pool solve's wall
+                            # consumed by the two point-separation loops is the
+                            # cheap, general, root-time feature that discriminates the
+                            # dense-integer-QP win class (loops dominate the node wall,
+                            # THRU-3: nvs24 73%+12%, nvs19 42%+20%) from the neutral
+                            # quadratic slice (loops fire but are not the bottleneck,
+                            # THRU-4-graduate wall ratio 1.004x). Keys on measured cost
+                            # only — never on instance name/shape (CLAUDE.md §2).
+                            _sep_before = dict(getattr(_mc_lp_relaxer, "_sep_timers", {}))
+                            _sqpsd_before = _sep_before.get("univariate_square", 0.0) + (
+                                _sep_before.get("psd", 0.0)
+                            )
+                            _pool_solve_t0 = time.perf_counter()
                             _pool_res = _mc_lp_relaxer.solve_at_node(
                                 _probe_lb,
                                 _probe_ub,
                                 time_limit=_pool_budget,
                                 out_cuts=_pool_chunks,
                             )
+                            _pool_solve_wall = time.perf_counter() - _pool_solve_t0
+                            _sep_after = getattr(_mc_lp_relaxer, "_sep_timers", {})
+                            _sqpsd_root_wall = (
+                                _sep_after.get("univariate_square", 0.0)
+                                + _sep_after.get("psd", 0.0)
+                                - _sqpsd_before
+                            )
+                            if _pool_solve_wall > 1e-9:
+                                _root_sqpsd_frac = max(0.0, _sqpsd_root_wall / _pool_solve_wall)
+                            else:
+                                _root_sqpsd_frac = 0.0
                             if _pool_chunks and _pool_chunks[0] is not None:
                                 _A_pool, _b_pool = _pool_chunks[0]
                                 _n_pool = _A_pool.shape[0]
@@ -5550,7 +5601,7 @@ def solve_model(
         # pool inheritance: the default path reads no extra state and is
         # byte-identical.
         _lazy_probing = False
-        if _cut_inherit and _root_cut_pool is not None:
+        if _cut_inherit_enabled and _root_cut_pool is not None:
             try:
                 _glb_now = float(tree.stats()["global_lower_bound"])
             except Exception:  # pragma: no cover - defensive
@@ -5914,7 +5965,9 @@ def solve_model(
                             # families are box-independent and already in the pool)
                             # — unless the global-stall governor is probing (C-42).
                             skip_pool_separators=(
-                                _cut_inherit and _root_cut_pool is not None and not _lazy_probing
+                                _cut_inherit_enabled
+                                and _root_cut_pool is not None
+                                and not _lazy_probing
                             ),
                         )
                     except Exception as e:
@@ -6229,7 +6282,9 @@ def solve_model(
                             # families are box-independent and already in the pool)
                             # — unless the global-stall governor is probing (C-42).
                             skip_pool_separators=(
-                                _cut_inherit and _root_cut_pool is not None and not _lazy_probing
+                                _cut_inherit_enabled
+                                and _root_cut_pool is not None
+                                and not _lazy_probing
                             ),
                         )
                     except Exception as e:
@@ -8073,6 +8128,23 @@ def solve_model(
     # the skip lever are observable on the final result.
     if _root_cut_pool is not None:
         _solver_stats["pool/size"] = float(_root_cut_pool[0].shape[0])
+    # CUT-INHERIT-GRAD: surface the structure predicate's root feature so the
+    # gate decision is verifiable from the outside (entry experiment + fire-proof).
+    if _root_sqpsd_frac is not None:
+        _solver_stats["pool/root_sqpsd_frac"] = float(_root_sqpsd_frac)
+    # CUT-INHERIT-GRAD gate decision (verifiable firing). ``mode``: 1 force-on,
+    # 0 force-off (env unset/``=0`` — the shipped default), -1 structure-gated
+    # opt-in (``=gated``/``cut_inherit=None``). ``gate_decision``: 1 iff
+    # inheritance actually engaged (not forced off AND a non-empty root pool was
+    # separated — the pool-fires predicate); the feature it keys on is the pool
+    # size, surfaced as ``pool/size`` above.
+    _gate_mode_code = (
+        1.0 if _cut_inherit_mode is True else (0.0 if _cut_inherit_mode is False else -1.0)
+    )
+    _solver_stats["pool/gate_mode"] = _gate_mode_code
+    _solver_stats["pool/gate_decision"] = (
+        1.0 if (_cut_inherit_enabled and _root_cut_pool is not None) else 0.0
+    )
     if _mc_lp_relaxer is not None and getattr(_mc_lp_relaxer, "_pool_stats", None):
         for _pfam, _pcount in _mc_lp_relaxer._pool_stats.items():
             if _pcount > 0:

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import os
 from contextvars import ContextVar
 from dataclasses import dataclass, field, fields
+from typing import Optional
 
 
 def _env_flag(name: str, *, default: bool) -> bool:
@@ -34,6 +35,30 @@ def _env_flag(name: str, *, default: bool) -> bool:
     raw = os.environ.get(name)
     if raw is None:
         return default
+    return raw != "0"
+
+
+def _env_cut_inherit(name: str) -> Optional[bool]:
+    """``DISCOPT_CUT_INHERIT`` as a tri-state:
+
+    * unset ⇒ ``False`` — **force-off is the shipped default** (opt-in flag).
+      CUT-INHERIT-GRAD validated the structure gate as broadly beneficial where
+      it fires and byte-identical where it does not, BUT surfaced a flag-path
+      false-optimal on the pure-integer / MINLP cold-path class (nvs22 certifies
+      33.55 vs the oracle 6.058; the nvs06-class reroute C-42 only partially
+      fixed). Per CLAUDE.md §1 a false certificate blocks any default-ON flip, so
+      the gated behaviour stays OPT-IN until that soundness bug is fixed.
+    * ``"0"`` ⇒ ``False`` (explicit force-off, identical to unset today);
+    * ``"gated"`` / ``"auto"`` ⇒ ``None`` (structure-gated opt-in: inherit iff a
+      non-empty root pool is separated — the pool-fires predicate);
+    * anything else (e.g. ``"1"``) ⇒ ``True`` (force-on).
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return False
+    low = raw.strip().lower()
+    if low in ("gated", "auto"):
+        return None
     return raw != "0"
 
 
@@ -185,25 +210,52 @@ class SolverTuning:
     improvement ``Δ ≤ tau × (1 + |lb_before|)`` abandons the remaining rounds at
     that node. Only consulted when :attr:`square_cost_gate` is on."""
 
-    # --- root-cut-pool inheritance (THRU-4, default OFF) -----------------------
-    cut_inherit: bool = field(
-        default_factory=lambda: _env_flag("DISCOPT_CUT_INHERIT", default=False)
+    # --- root-cut-pool inheritance (THRU-4, structure-gated default) -----------
+    cut_inherit: Optional[bool] = field(
+        default_factory=lambda: _env_cut_inherit("DISCOPT_CUT_INHERIT")
     )
-    """Root-cut-pool inheritance for the per-node square/PSD separation loops
-    (``DISCOPT_CUT_INHERIT``, default **OFF**). THRU-3 measured that the two
-    per-node point separators — the univariate-square tangent loop and the PSD
-    (moment) loop — are the dominant per-node cost on dense integer QPs (nvs24:
-    73% + 12% of the solve wall), each re-deriving cuts via up to 8 full MILP
-    re-solves at EVERY node; with both off, nvs24 runs 9→309 nodes (36×) with
-    the dual bound at TL essentially unchanged. When on, the root separates the
-    full cut chain ONCE (unchanged root behaviour), the accepted rows are stored
-    in the root cut pool, and every node *inherits* the pool instead of
-    re-running the square/PSD separation loops. SOUND: the inherited square
-    tangents (``s ≥ 2·x0·x − x0²``) and PSD eigencuts (``vᵀMv ≥ 0``) are valid at
-    every feasible lifted point independent of the node box, and every other
-    captured family is valid over the ROOT box, hence over every descendant
-    sub-box; skipping per-node re-separation only *loosens* the node relaxation
-    (never cuts a feasible point). See
+    """Root-cut-pool inheritance for the per-node square/PSD separation loops —
+    **tri-state, opt-in** (``DISCOPT_CUT_INHERIT``: unset / ``0`` ⇒ force-off = the
+    shipped default; ``gated``/``auto`` ⇒ structure-gated opt-in; ``1`` ⇒
+    force-on. Programmatically ``cut_inherit=None`` selects the structure gate.)
+
+    THRU-3 measured that the two per-node point separators — the univariate-square
+    tangent loop and the PSD (moment) loop — are the dominant per-node cost on the
+    cut-firing quadratic class (nvs24: 73% + 12% of the solve wall), each
+    re-deriving cuts via up to 8 full MILP re-solves at EVERY node. When active,
+    the root separates the full cut chain ONCE (unchanged root behaviour), the
+    accepted rows are stored in the root cut pool, and every node *inherits* the
+    pool instead of re-running the square/PSD separation loops.
+
+    **Structure gate (CUT-INHERIT-GRAD).** The activating predicate is *whether a
+    non-empty root cut pool is separated at the root* — a cheap, general,
+    root-time signal that keys on measured structure, never on instance
+    name/shape (CLAUDE.md §2). When the model carries the square/PSD-liftable
+    structure the pool populates and inheritance engages (measured broadly
+    beneficial: nvs17/19/23/24 1.6–5.4×, kall_circles 1.8–2.6×, knp3-12 ~4–9×,
+    dispatch 3.3×; nvs19 gains its certificate); when it does not, the pool is
+    empty, nothing is inherited or skipped, and the solve is **byte-identical to
+    the force-off path** (node_count + objective unchanged).
+
+    **Why still opt-in (default force-off).** The CUT-INHERIT-GRAD entry experiment
+    falsified THRU-4-graduate's "the 2–5× is specific to the dense integer-QP
+    class, broad flip is throughput-neutral" (that 1.004× was a TL=30s /
+    parallel-contention artifact; under clean serial measurement every pool-firing
+    instance benefits, so the honest gate is *pool-fires ⇒ ON*). BUT the same
+    validation surfaced a **flag-path false-optimal on the pure-integer / MINLP
+    cold-path class**: nvs22 certifies 33.55 against the oracle optimum 6.0582 —
+    an nvs06-class incumbent-search reroute that C-42 (#553) only partially fixed
+    (its pool-drop-retry does not trigger when the pool solve *succeeds* but the
+    pre-tree pump is rerouted). Per CLAUDE.md §1 a false certificate blocks any
+    default-ON flip, so the flag stays OPT-IN until that bug is fixed. See
+    ``docs/dev/cut-inherit-grad-2026-07-08.md``.
+
+    SOUND (where it fires cleanly): the inherited square tangents
+    (``s ≥ 2·x0·x − x0²``) and PSD eigencuts
+    (``vᵀMv ≥ 0``) are valid at every feasible lifted point independent of the
+    node box, and every other captured family is valid over the ROOT box, hence
+    over every descendant sub-box; skipping per-node re-separation only *loosens*
+    the node relaxation (never cuts a feasible point). See
     ``docs/dev/thru4-cut-inheritance-2026-07-07.md`` for the per-family validity
     classification and measurements."""
 

--- a/python/tests/test_c42_cut_inherit_coldpath.py
+++ b/python/tests/test_c42_cut_inherit_coldpath.py
@@ -146,6 +146,42 @@ def test_nvs06_cut_inherit_certifies_like_default():
     assert stats.get("pool/dropped_nodes", 0) >= 1, f"pool-drop retry never fired: {stats}"
 
 
+_CORPUS = Path.home() / "Dropbox" / "projects" / "discopt-minlp-benchmark" / "minlplib" / "nl"
+
+
+@pytest.mark.slow
+@pytest.mark.xfail(
+    reason="CUT-INHERIT-GRAD blocker: flag-ON false-optimal on the MINLP cold-path "
+    "class — nvs22 certifies 33.55 vs oracle 6.0582. The nvs06-class incumbent-"
+    "search reroute that C-42's pool-drop-retry does not cover (the pool solve "
+    "SUCCEEDS but the pre-tree pump is rerouted). Blocks the default-ON flip; the "
+    "flag stays opt-in until fixed. See docs/dev/cut-inherit-grad-2026-07-08.md.",
+    strict=True,
+)
+def test_nvs22_cut_inherit_no_false_optimal():
+    """Pins the CUT-INHERIT-GRAD graduation blocker. The DEFAULT (force-off) path
+    certifies nvs22's oracle optimum 6.0582 correctly; flag-ON currently returns a
+    FALSE-OPTIMAL 33.55. This xfail(strict) fails (i.e. flips to XPASS and the
+    suite goes red) the moment the flag-path reroute is fixed — the signal to
+    revisit the default-ON flip."""
+    nl = _CORPUS / "nvs22.nl"
+    if not nl.exists():
+        pytest.skip("nvs22 not in the local MINLPLib corpus")
+    # Sanity: the default (force-off) path is SOUND — this must always hold.
+    ref = from_nl(str(nl)).solve(time_limit=25, gap_tolerance=1e-4)
+    assert ref.objective == pytest.approx(6.0582200, rel=5e-3), (
+        f"default-path nvs22 regressed: {ref.objective}"
+    )
+    # Flag-ON currently produces a false certificate (this assertion is the xfail).
+    res = from_nl(str(nl)).solve(
+        time_limit=25, gap_tolerance=1e-4, tuning=SolverTuning(cut_inherit=True)
+    )
+    if str(res.status) == "optimal":
+        assert res.objective == pytest.approx(6.0582200, rel=5e-3), (
+            f"nvs22 flag-ON FALSE-OPTIMAL: certified {res.objective} vs oracle 6.0582"
+        )
+
+
 @pytest.mark.slow
 def test_tspn05_cut_inherit_certifies_via_lazy_reseparation():
     """The other #552 blocker: with inheritance-only, tspn05's bound stalls at

--- a/python/tests/test_cut_inherit_pool.py
+++ b/python/tests/test_cut_inherit_pool.py
@@ -21,7 +21,16 @@ Soundness invariants pinned here:
   node-level solves. A synthetic case demonstrates the hazard and asserts the
   flag-ON solve still certifies the true optimum that naive child-row
   inheritance would cut off.
-* **Default-off neutrality** — with the flag off, no pool-skip is performed.
+* **Force-off neutrality** — with ``cut_inherit=False`` (the shipped DEFAULT) no
+  pool-skip is performed.
+* **Structure gate (CUT-INHERIT-GRAD, OPT-IN)** — with ``cut_inherit=None`` (env
+  ``DISCOPT_CUT_INHERIT=gated``) the gate auto-engages iff a non-empty root pool is
+  separated (the pool-fires predicate): ON on a pool-firing dense QP, byte-identical
+  to force-off on a model that separates no square/PSD pool. The gate is validated
+  broadly beneficial where it fires but stays OPT-IN — the default-ON flip is
+  blocked by a flag-path false-optimal on the MINLP cold-path class (nvs22), see
+  ``docs/dev/cut-inherit-grad-2026-07-08.md``. Env precedence: unset/``0`` ⇒
+  force-off (default), ``gated``/``auto`` ⇒ structure-gated, ``1`` ⇒ force-on.
 """
 
 from __future__ import annotations
@@ -199,11 +208,83 @@ def test_box_dependent_child_rows_would_be_invalid_and_are_excluded():
 
 
 @pytest.mark.smoke
-def test_cut_inherit_default_off_no_skip():
-    """Default (flag off): the square/PSD separators run as before — no pool-skip."""
+def test_cut_inherit_force_off_no_skip():
+    """Force-off (``cut_inherit=False``): the square/PSD separators run as before —
+    no pool-skip, regardless of structure."""
     model = _build_dense_int_qp()
-    res = model.solve(time_limit=60)
+    res = model.solve(time_limit=60, tuning=SolverTuning(cut_inherit=False))
     opt, _ = _brute_force_opt()
     assert res.objective == pytest.approx(opt, abs=1e-5)
     stats = res.solver_stats or {}
     assert stats.get("pool/skipped_separations", 0) == 0
+    assert stats.get("pool/gate_decision", 0.0) == 0.0
+    assert stats.get("pool/gate_mode", 0.0) == 0.0  # forced off
+
+
+@pytest.mark.smoke
+def test_cut_inherit_structure_gated_fires_on_dense_qp():
+    """CUT-INHERIT-GRAD: the STRUCTURE-GATED opt-in (``cut_inherit=None``, env
+    ``DISCOPT_CUT_INHERIT=gated``) must auto-engage on a model that separates a
+    non-empty root pool — the pool-fires predicate. On the dense integer QP the
+    pool populates, so the gate decision is ON and the square/PSD separators are
+    skipped at nodes, while the certificate is preserved (bound <= optimum)."""
+    model = _build_dense_int_qp()
+    res = model.solve(time_limit=60, tuning=SolverTuning(cut_inherit=None))
+    opt, _ = _brute_force_opt()
+    assert res.objective == pytest.approx(opt, abs=1e-5)
+    if res.bound is not None:
+        assert res.bound <= opt + 1e-6, f"dual bound {res.bound} crossed the optimum {opt}"
+    stats = res.solver_stats or {}
+    assert stats.get("pool/size", 0) >= 1, f"root pool did not populate: {stats}"
+    assert stats.get("pool/gate_mode", 0.0) == -1.0, "expected structure-gated mode"
+    assert stats.get("pool/gate_decision", 0.0) == 1.0, (
+        f"structure gate did not engage on a pool-firing model: {stats}"
+    )
+    assert stats.get("pool/skipped_separations", 0) >= 1, (
+        f"gated-on solve did not skip any per-node separation: {stats}"
+    )
+
+
+def _build_linear_int() -> dm.Model:
+    m = dm.Model("linear_int")
+    x = m.integer("x", shape=(3,), lb=0, ub=5)
+    m.minimize(x[0] + 2 * x[1] + 3 * x[2])
+    m.subject_to(x[0] + x[1] + x[2] >= 4)
+    return m
+
+
+@pytest.mark.smoke
+def test_cut_inherit_structure_gated_inert_when_pool_empty():
+    """CUT-INHERIT-GRAD off-class: on a model with no liftable square/PSD structure
+    the root pool stays empty, so the structure gate does NOT engage and the solve
+    is byte-identical to force-off (same node_count + objective). A pure linear
+    integer model separates no square/PSD pool."""
+    res_gated = _build_linear_int().solve(time_limit=30, tuning=SolverTuning(cut_inherit=None))
+    res_off = _build_linear_int().solve(time_limit=30, tuning=SolverTuning(cut_inherit=False))
+    # Gate must not fire (empty/absent pool) and the two paths must be identical.
+    sg = res_gated.solver_stats or {}
+    assert sg.get("pool/gate_decision", 0.0) == 0.0, f"gate wrongly fired off-class: {sg}"
+    assert res_gated.node_count == res_off.node_count
+    assert res_gated.objective == pytest.approx(res_off.objective, abs=1e-9)
+
+
+@pytest.mark.smoke
+def test_cut_inherit_env_tristate_precedence(monkeypatch):
+    """The env override precedence (CUT-INHERIT-GRAD, opt-in default): unset ⇒
+    force-off (``False``, the shipped default — the gated flip is blocked by the
+    nvs22 flag-path false-optimal), ``=0`` ⇒ force-off, ``=gated``/``=auto`` ⇒
+    structure-gated opt-in (``None``), ``=1`` (any other non-``0``) ⇒ force-on."""
+    from discopt.solver_tuning import SolverTuning as ST
+
+    monkeypatch.delenv("DISCOPT_CUT_INHERIT", raising=False)
+    assert ST().cut_inherit is False  # default force-off (opt-in flag)
+    monkeypatch.setenv("DISCOPT_CUT_INHERIT", "0")
+    assert ST().cut_inherit is False  # explicit force-off
+    monkeypatch.setenv("DISCOPT_CUT_INHERIT", "gated")
+    assert ST().cut_inherit is None  # structure-gated opt-in
+    monkeypatch.setenv("DISCOPT_CUT_INHERIT", "auto")
+    assert ST().cut_inherit is None  # auto alias
+    monkeypatch.setenv("DISCOPT_CUT_INHERIT", "1")
+    assert ST().cut_inherit is True  # force-on
+    monkeypatch.setenv("DISCOPT_CUT_INHERIT", "yes")
+    assert ST().cut_inherit is True  # any other non-"0" ⇒ on


### PR DESCRIPTION
## CUT-INHERIT-GRAD — structure gate found, but default-ON flip is KILLED by a flag-path false-optimal

Graduating `DISCOPT_CUT_INHERIT` (root-cut-pool inheritance, #551/#553) to a
structure-gated default-ON. The entry experiment + broad validation produced two
findings that changed the outcome — the flag **stays opt-in** (default force-off).
Full record in `docs/dev/cut-inherit-grad-2026-07-08.md`.

### 1. The structural premise was falsified (the win is broad, not class-specific)

THRU-4-graduate (#552) concluded the 2-5x is *specific to the dense integer-QP
class* and a broad flip is *throughput-neutral (1.004x)*. Under **clean serial
measurement** (the entry experiment's first pass was 15-way parallel and its
numbers were contention-corrupted) that 1.004x does **not reproduce** — it was a
TL=30s / parallel-contention artifact. Every pool-firing instance benefits:

| instance | probtype | OFF->ON nodes/s | ratio |
|---|---|---|---:|
| nvs24 | IQCQP | 0.14->0.79 | **5.46x** |
| knp3-12 | QCP | 0.49->4.77 | **9.72x** |
| dispatch | QCQP | 6.63->21.51 | **3.25x** |
| kall_circles_c6c | QCP | 0.91->2.38 | **2.63x** |
| nvs17/19/23 | IQCQP | - | 1.7-1.8x |

So there is **no neutral firing class to gate out**. The task's named feature
(root square+PSD wall fraction) does NOT separate win-from-neutral (the "neutral"
kall instances 0.86-0.91 sit *above* win nvs17/19 at 0.59/0.70). The honest
predicate is the simplest one: **pool-fires => ON**.

### 2. But default-ON is a hard KILL (nvs22 false-optimal)

The broad validation surfaced a **new deterministic false certificate**: `nvs22`
(MINLP adversarial soundness probe) certifies `optimal 33.55` against the oracle
optimum **6.0582** — flag-ON (force-on and gated alike). This is the nvs06-class
incumbent-search reroute that C-42 (#553) only partially fixed: its pool-drop-retry
fires only when the pool solve *fails numerically*; on nvs22 the pool solve
**succeeds** but the pre-tree incumbent pump is rerouted and the region holding
6.0582 is fathomed. Per CLAUDE.md section 1 a false certificate blocks any default-ON flip.

### What ships

- Tri-state `cut_inherit` (`Optional[bool]`) + the pool-fires structure gate,
  wired and instrumented (`pool/gate_mode`, `pool/gate_decision`,
  `pool/root_sqpsd_frac`), **default force-off — byte-identical to `origin/main`**.
- Gate reachable **opt-in**: `DISCOPT_CUT_INHERIT=gated` / `cut_inherit=None`
  (fires + 2-5x where it pays; byte-identical where the pool is empty).
- Env precedence: unset/`0` => force-off, `gated`/`auto` => structure-gated, `1` => force-on.
- nvs22 blocker pinned by a **strict-xfail** regression (`test_c42_cut_inherit_coldpath.py`)
  so the suite flips red the moment the reroute is fixed — the signal to re-attempt the flip.

### Verification

- **On-class win under the gate** (gated vs OFF, serial, TL 60s): nvs24 5.40x,
  nvs19 1.66x **+gains its certificate**, nvs17 1.74x, nvs23 1.58x — gate fires on all.
- **Off-class byte-identical** (gated vs force-off, 12 terminating non-firing
  instances): **12/12 identical**, 0 wrongful fires.
- **Bound-changing soundness** (on-class): dual bound <= incumbent <= oracle;
  root bound identical on/off; exhaustive feasible-point sampling — 0 violations.
- **Blocker**: nvs22 false-optimal (Part 3d) -> flip killed.

### Gates run

- `pytest -m smoke`: **627 passed, 14 skipped** (6 new gate tests: gate-fires,
  off-class byte-identical, tri-state env precedence, force-off no-skip).
- `pytest -m slow test_adversarial_recent_fixes.py`: **12 passed** (nvs22 sound on default).
- `pytest -m slow test_c42_cut_inherit_coldpath.py`: **2 passed + 1 xfailed** (nvs22 blocker).
- `check_cert_neutrality.py` (default force-off, 41-panel): **41/41 byte-identical**,
  `|dobj|=0`, exit 0 — **no rebaseline** (the default doesn't fire the gate).
- `ruff check` / `ruff format --check` (v0.14.6): clean.
- pre-commit `mypy` (v2.1.0, whole package): clean on the changed files.
- `cargo test -p discopt-core`: n/a — no Rust touched.

### Follow-up (the path back to default-ON)

Fix the nvs22 / nvs06-class reroute (flag-ON pre-tree pump bypass when the
cold-path pool solve succeeds) — file on the #396 correctness backlog. Once fixed,
re-run this validation; the pool-fires gate is already built and validated
broadly beneficial, only the soundness blocker stands between it and the flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
