### PR TITLE
fix(correctness): C-43 — nvs22 cut-inherit false-optimal fixed; graduation killed by #567

### DIFF
--- a/docs/dev/c43-nvs22-fix-graduate-2026-07-08.md
+++ b/docs/dev/c43-nvs22-fix-graduate-2026-07-08.md
@@ -1,0 +1,229 @@
+# C-43 — nvs22 cut-inherit false-optimal fixed (pool-infeasible re-verify);
+# broad graduation KILLED by an nvs19 cert loss the fix exposes. Flag stays opt-in. (2026-07-08)
+
+**Status.** Phase 1 (the soundness fix) SHIPS. Phase 2 (the default-ON flip) is
+**KILLED** and cut-inheritance stays **opt-in** (default force-off, byte-identical
+to `origin/main`). The nvs22 false-optimal (#564, the CUT-INHERIT-GRAD blocker)
+is fixed and nvs22 flag-ON now *certifies the oracle optimum*. But root-causing it
+showed the pre-fix flag path was resting on **unsound sub-box fathoms** across the
+class; making them sound costs `nvs19` its certificate (a Phase-2 gate failure),
+so the flip is killed and the deeper source fix is filed as #567.
+
+> **Method.** Apple M-series arm64, Python 3.12, release build
+> (`maturin develop --release`; pounce `_pounce.abi3.so` = 4.51 MB, not debug),
+> `PYTHONPATH=<wt>/python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`, corpus
+> `~/Dropbox/projects/discopt-minlp-benchmark/`, oracle `minlplib.solu`. Single
+> serial runs per arm, fresh interpreter per solve.
+
+---
+
+## Part 1 — root cause (file:line + mechanism)
+
+### 1a. Reproduce (confirmed)
+
+`nvs22` (MINLP, pure-integer nonconvex; oracle `6.0582200`), TL 25 s:
+
+| arm | status | objective | bound |
+|---|---|---:|---:|
+| default (force-off) | optimal | **6.0582** (correct) | 6.0582 |
+| `DISCOPT_CUT_INHERIT=1` (force-on) | optimal | **33.55166** (FALSE) | 33.55166 |
+| `=gated` (structure gate) | optimal | **33.55166** (FALSE) | 33.55166 |
+
+Deterministic at TL 25/60/120 s — the pre-fix tree *stably* (but falsely) closes
+at 33.55. `pool/dropped_nodes` is unset: C-42's cold-path drop-retry never fires.
+
+### 1b. The mechanism — a FALSE Farkas-infeasible fathom (not a "reroute")
+
+#564 framed this as an incumbent-search reroute on the pool-*success* path. The
+measurement (CLAUDE.md §4 — the measurement wins) found something more direct and
+more serious: a **false fathom**. Instrumenting node solves by whether the node
+box contains the true optimum integer assignment `(x0,x1,x2,x3)=(5,1,1,2)`:
+
+| arm | OPT-containing nodes | verdicts |
+|---|---:|---|
+| pool-inherited (`both`) | 3 | `optimal −4.37`, `optimal 1.84`, **`infeasible`** |
+| pool-free (`skip_only`) | 7 | all `optimal`, down to `6.058` |
+
+A node whose box **contains the feasible optimum 6.0582** is certified
+**Farkas-infeasible** once the inherited pool is appended, while the pool-free
+relaxation of the *same box* solves to `optimal`. The Farkas ray certifies the
+*pool-augmented* polytope empty — a real proof only if every pool row is valid on
+the box. Here a pool row is **not valid on that sub-box**, so it is a false
+fathom: the region holding 6.0582 is pruned, the tree closes around the
+suboptimal incumbent 33.55, and a false `optimal` is certified. The dual bound
+33.55 crosses the oracle 6.0582 — a false certificate (CLAUDE.md §1 hard stop).
+
+Isolation A/B (monkeypatched `solve_at_node`, TL 25 s):
+
+| config | inherited cuts | skip separators | result |
+|---|---|---|---|
+| `skip_only` | no | yes | **optimal 6.0582** (correct) |
+| `cuts_only` | yes | no | feasible 33.55, bound **−4.37** (valid, no cross) |
+| `both` | yes | yes | **optimal 33.55** (FALSE) |
+
+So the inherited **cuts** are the cause; the per-node separator *skip* is
+harmless. `cuts_only` keeps a valid bound (−4.37) but the wrong incumbent; `both`
+adds enough tightening that the false fathoms let the tree close falsely.
+
+### 1c. Why the pool row is invalid on the sub-box — column remapping
+
+The pool for nvs22 (10 rows) is separated on the general-spatial cold path
+(`solver.py:5217` region) and is dominated by the **`convex` + `univariate_square`**
+families (measured by per-family separation-timer delta during the root capture).
+Both are nominally *box-independent* (a square tangent `s ≥ 2x₀x − x₀²`
+under-estimates `x²` everywhere; a convex supporting hyperplane is global). So the
+invalidity is **not** cut invalidity — it is **column remapping**. The pool row is
+stated over the root's lifted column layout (`n_total` columns); the per-node
+incremental `assemble` / lifted-FBBT rebuild (`mccormick_lp.py:842`,
+`_try_incremental_node`:`545`) can produce the *same column count* with *different
+column semantics* (a re-lifted / pinned aux column), so the row addresses the
+wrong lifted variables and cuts a feasible point. The append guard
+(`mccormick_lp.py:537`, `:927`) checks only `sparse_cols == n_total` (count), not
+column identity — insufficient. The source fix is filed as **#567** (#396 backlog).
+
+## Part 2 — the fix (general, C-42-consistent)
+
+**The inherited pool is an accelerator, never a dependency — extended to the
+Farkas-infeasible branch, on both the fast and cold paths.** In `solve_at_node`
+(now a thin wrapper over `_solve_at_node_impl`, `mccormick_lp.py`): when a
+non-empty pool was on offer and the pool-augmented solve returns `infeasible`,
+**re-verify pool-free** before trusting the fathom:
+
+1. Cheap first — solve the **base** McCormick relaxation (no separators, no pool,
+   `separate=False`), the loosest valid outer approximation. If it is *also*
+   infeasible, the node's subtree is genuinely empty (a valid relaxation with an
+   empty feasible set is a rigorous fathom) — keep the `infeasible` verdict, one
+   loose LP. This is the hot path for a *sound* pool.
+2. Only if the base relaxation is **feasible** was the fathom pool-induced — pay
+   the full pool-free re-solve (byte-identical to the default path's node solve)
+   and adopt that valid result (recover the node on its sound bound). Counted as
+   `pool/dropped_nodes` (same role as C-42's).
+
+Soundness: re-solving pool-free only *loosens* the relaxation, so the guard can
+never introduce a false fathom of its own; it only forgoes a possible (and
+possibly-invalid) prune. C-42 (#553) covered the *no-certified-verdict* branch of
+the cold path; C-43 covers the *Farkas-infeasible* branch across the incremental
+fast path AND the cold path — the branch C-42's cold-path-only, verdict-gated
+retry did not reach.
+
+### 2a. The bug behind the bug — `len()` on a sparse pool
+
+The pool `A_rows` is a scipy CSR matrix, whose `len()` is *ambiguous and raises*.
+A naive `len(A_rows) > 0` row check throws on every pool node; the driver's
+node-solve `try/except` swallows it and silently *skips* the node — which happened
+to mask the false-optimal behind a crash instead of fixing it (and left
+`pool/dropped_nodes` at 0 while behaviour changed — a red flag we chased down).
+The fix uses a sparse-safe `_pool_has_rows` (`.shape[0]` via `_sparse_rows`).
+Regression-pinned by `test_pool_has_rows_is_sparse_safe`.
+
+### 2b. nvs22 before/after (flag-ON, TL 25 s)
+
+| arm | status | objective | bound | `dropped_nodes` |
+|---|---|---:|---:|---:|
+| before | optimal | **33.55166** (FALSE) | 33.55166 | 0 |
+| **after** | **optimal** | **6.05821994** (= oracle) | 6.0582 | **21** |
+
+Deterministic. The 21 recoveries are the false fathoms the guard catches.
+
+## Part 3 — verification
+
+### 3a. C-42 regression cases retained (flag-ON)
+
+| instance | status | objective | oracle | verdict |
+|---|---|---:|---:|---|
+| nvs06 (TL 20) | optimal | 1.7703125 | 1.7703125 | **retained** (`dropped=1`) |
+| tspn05 (TL 60) | optimal | 191.25521 | 191.25521 | **retained** |
+| nvs19 (TL 60) | *feasible* | −1098.4 (= oracle incumbent) | −1098.4 | cert LOST (see 3c) |
+
+nvs06 and tspn05 hold. `test_c42_cut_inherit_coldpath.py`: 3 slow + 4 smoke pass.
+
+### 3b. HiGHS/oracle battery — pool-firing instances, flag-ON (TL 40 s)
+
+Every certified `optimal` cross-checked against `minlplib.solu`; every bound
+checked against the oracle with the correct sense (min: bound ≤ opt; max: bound ≥
+opt):
+
+| instance | sense | status | obj | bound | oracle | sound? |
+|---|---|---|---:|---:|---:|---|
+| nvs17 | min | optimal | −1100.4 | −1100.40 | −1100.4 | ✓ |
+| nvs19 | min | feasible | −1098.4 | −1100.24 | −1098.4 | ✓ |
+| nvs22 | min | **optimal** | **6.0582** | 6.0582 | 6.0582 | ✓ |
+| nvs23 | min | feasible | −1124.8 | −1130.41 | −1125.2 | ✓ |
+| nvs24 | min | feasible | −1031.8 | −1035.66 | −1033.2 | ✓ |
+| knp3-12 | MAX | feasible | 1.1056 | 2.6444 | 1.1056 | ✓ (2.64 ≥ opt) |
+| dispatch | min | optimal | 3155.29 | 3155.01 | 3155.29 | ✓ |
+| kall_circles_c6a…c8a | min | feasible | — | ≤ opt | — | ✓ |
+
+**0 false-optima, 0 dual-bound-crosses-oracle.** Phase-1 hard gate MET.
+
+Broad held-out (20 instances: st_e31/e05, ex122x, nvs0x, alkyl, st_miqp1/2, gear,
+…), flag-ON TL 30 s: all sound, every `optimal` = oracle, and the guard is
+**inert** (`dropped=None` on all 20 — it fires only where a pool row is actually
+invalid). 0 violations.
+
+### 3c. Why the flip is KILLED — nvs19 (flag-ON, TL 60 s, serial)
+
+| instance | PRE-FIX | POST-FIX | Δ |
+|---|---|---|---|
+| nvs17 | optimal 17.1 s | optimal 17.2 s | identical |
+| **nvs19** | **optimal 48.5 s** | **feasible @ 60 s** | **cert LOST** |
+| nvs23 | feasible | feasible | identical |
+| nvs24 | feasible | feasible | identical |
+| dispatch | optimal 0.7 s | optimal 0.9 s | identical |
+| knp3-12 / kall_c6b / kall_c6c | feasible | feasible | identical |
+
+Only **nvs19 regresses**. Pre-fix nvs19 certified −1098.4 (the correct oracle) —
+but with `dropped=0`, i.e. by *trusting 5 unsound sub-box fathoms* that happened to
+prune only non-improving regions (sound-by-luck). Post-fix refuses them
+(`dropped=5`), re-opens those nodes, and the extra exploration pushes the cert past
+60 s. This is the **correct** behaviour (the fathoms were unsound), but it is a
+*lost certificate* on a documented win instance → the CUT-INHERIT-GRAD default-ON
+flip's "certs preserved-or-gained" gate FAILS. Per the graduation kill criterion,
+**the flip is killed; the flag stays opt-in.**
+
+A cheaper recovery (return the loose base relaxation instead of the full pool-free
+re-solve) was tried and *falsified*: it makes nvs22 fail to certify (bound stuck at
+−4.37) and does not recover nvs19 — the tight recovered bound is load-bearing.
+
+### 3d. Default path unchanged — cert-neutrality
+
+The fix is gated on `_pool_has_rows(inherited_cuts)`, which is empty on the
+default (force-off) path, so the default path is untouched. `solver_tuning.py`
+default is unchanged (force-off). `check_cert_neutrality.py` (41-instance panel,
+default): **NEUTRAL — 41/41, `|Δobj|=0` on every row, node counts unchanged**
+(tspn05 39→39, st_testgr3 549→549). No rebaseline (the gate does not fire on the
+shipped default; the "sanctioned bound-changing rebaseline" clause is moot because
+the flip is not made).
+
+## Part 4 — decision
+
+**Phase 1 ships. Phase 2 (default-ON flip) killed.** The nvs22 false certificate
+is fixed and nvs22 flag-ON certifies the oracle optimum; the fix is sound across
+the HiGHS/oracle battery and the broad held-out slice, and byte-identical on the
+default path. But the fix exposes that cut-inheritance's sub-box fathoms are
+**broadly unsound** (column remapping, #567) and making them sound costs nvs19 its
+certificate — a Phase-2 gate failure. The flag stays opt-in until #567 fixes the
+invalidity at the source (which would retire the runtime re-verify, restore
+nvs19's cert, and re-open the graduation).
+
+## Follow-ups
+
+1. **#567 — column-identity-safe pool inheritance.** Tag pool rows with the lifted
+   variables they reference and re-map/drop per node when the layout changes (or,
+   conservatively, refuse to append the pool unless the node's lifted layout is
+   provably identical to the root's). Removes the false fathoms → the C-43
+   re-verify goes inert → nvs19 re-certifies → re-attempt the flip. #396 backlog.
+
+## Gates
+
+| gate | result |
+|---|---|
+| nvs22 flag-ON (was xfail) | **optimal 6.0582** (= oracle); regression test flipped xfail→passing |
+| `pytest -m smoke` (python/tests) | **633 passed, 12 skipped** (incl. 2 new C-43 smoke tests) |
+| `pytest -m slow test_adversarial_recent_fixes.py` | **10 passed** |
+| `pytest -m slow test_c42_cut_inherit_coldpath.py` | **3 passed** (nvs06, tspn05, nvs22 sound) |
+| HiGHS/oracle battery (pool-firing + broad held-out) | **0 false-optima, 0 bound-crosses-oracle** |
+| `check_cert_neutrality.py` (default force-off, 41-panel) | **NEUTRAL**, `|Δobj|=0`, node counts unchanged |
+| `ruff check` / `ruff format --check` (v0.14.6) | clean |
+| pre-commit `mypy` (v2.1.0, whole package) | **Passed** |
+| `cargo test -p discopt-core` | n/a — no Rust touched |

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -57,6 +57,21 @@ def _sparse_cols(A) -> int:
     return int(_as_csr(A).shape[1]) if A is not None else 0
 
 
+def _pool_has_rows(inherited_cuts: Optional[tuple]) -> bool:
+    """True iff ``inherited_cuts`` is a non-empty ``(A_rows, b_rows)`` pool.
+
+    Sparse-safe row count: the pool ``A_rows`` is a scipy CSR matrix, whose
+    ``len()`` is *ambiguous and raises* — so a naive ``len(A_rows) > 0`` check
+    throws and (when swallowed by the caller's node-solve guard) silently skips
+    the node. Use ``.shape[0]`` via :func:`_sparse_rows` instead. Used to gate
+    the C-43 pool-infeasible re-verification (only re-verify when a pool that
+    could have been appended was actually on offer)."""
+    if inherited_cuts is None:
+        return False
+    a_rows = inherited_cuts[0]
+    return a_rows is not None and _sparse_rows(a_rows) > 0
+
+
 def _append_relax_rows(milp, A_rows, b_rows) -> None:
     """Append ``A_rows z <= b_rows`` to a relaxation model's inequality block."""
     import scipy.sparse as sp
@@ -733,6 +748,134 @@ class MccormickLPRelaxer:
     ) -> MccormickLPResult:
         """Solve the McCormick LP relaxation restricted to the given bound box.
 
+        Thin wrapper around :meth:`_solve_at_node_impl` that enforces the C-43
+        pool-soundness invariant: **an inherited pool row may only accelerate the
+        node solve; it may never be the sole reason a node is fathomed.** When a
+        non-empty pool was on offer (``inherited_cuts`` present) and the
+        pool-augmented solve returns ``infeasible``, the node is re-solved WITHOUT
+        the pool; the ``infeasible`` fathom is kept only if the pool-free
+        relaxation is *also* infeasible.
+
+        Why (C-43, nvs22): the code assumed a cut separated at the ROOT box is
+        valid on every sub-box (so an inherited row could only tighten, never cut
+        a feasible point). That premise is **false for at least one captured cut
+        family** — measured on nvs22: a node whose box contains the true optimum
+        ``(x0,x1,x2,x3)=(5,1,1,2)`` becomes *Farkas-certified infeasible* once the
+        pool is appended, though the pool-free relaxation of the same box solves
+        to ``optimal``. The Farkas ray certifies the *pool-augmented* polytope is
+        empty, which is a real proof only if every pool row is valid on the box;
+        when a pool row is invalid there, it is a **false fathom** that closes the
+        tree around a suboptimal incumbent and certifies a false optimum
+        (nvs22: ``optimal 33.55`` vs oracle ``6.0582``). C-42 (#553) extended the
+        same "pool is an accelerator, never a dependency" guarantee to the
+        *no-certified-verdict* branch of the cold path; C-43 (#564) extends it to
+        the *Farkas-infeasible* branch across BOTH the incremental fast path and
+        the cold path — the branch C-42's cold-path-only, verdict-gated retry did
+        not cover. Re-solving pool-free only *loosens* the relaxation, so this can
+        never introduce a false fathom of its own; it only forgoes a possible (and
+        possibly-invalid) prune, then keeps the node open on its valid parent
+        bound. See ``docs/dev/c43-nvs22-fix-graduate-2026-07-08.md``.
+
+        See :meth:`_solve_at_node_impl` for the full parameter contract.
+        """
+        res = self._solve_at_node_impl(
+            node_lb,
+            node_ub,
+            time_limit,
+            inherited_cuts=inherited_cuts,
+            separate=separate,
+            out_cuts=out_cuts,
+            psd_max_rounds=psd_max_rounds,
+            want_marginals=want_marginals,
+            skip_pool_separators=skip_pool_separators,
+        )
+        # C-43 pool-infeasible re-verification. Only relevant when (a) this was a
+        # regular node solve (not a root pool-capture call, which passes no pool),
+        # (b) inherited pool rows were on offer, and (c) the augmented solve
+        # fathomed the node as infeasible. Re-solve the IDENTICAL box with no pool
+        # (and no pool-separator skip — a pool-free node must see the full chain,
+        # exactly like the default path); trust the ``infeasible`` fathom only when
+        # the pool-free relaxation confirms it. A pool row that is genuinely valid
+        # on this box cannot flip a feasible relaxation to empty, so on the common
+        # (sound-pool) case the re-solve re-confirms ``infeasible`` and the verdict
+        # stands — the cost is one extra LP on the *rare* pool-infeasible node, not
+        # on the hot feasible path. Not pre-gated on the pool's column width: a
+        # column-mismatched pool that was never appended yields an identical
+        # pool-free re-solve, so at worst this spends one extra LP re-confirming a
+        # genuine infeasible — it can never *keep* a false fathom, which is the
+        # invariant that matters.
+        #
+        # This is a runtime GUARD, not a root fix: the underlying defect is that a
+        # pool row stated over the root's lifted column layout can be applied at a
+        # node whose re-lifted/pinned layout changed the columns' meaning (same
+        # count, different semantics — column remapping), so the row is no longer
+        # valid there. #567 tracks the source fix (column-identity-safe inheritance)
+        # that would make this guard inert; until then it keeps the certificate
+        # sound. Part of the #396 backlog.
+        if out_cuts is None and res.status == "infeasible" and _pool_has_rows(inherited_cuts):
+            # Cheap first: the BASE McCormick relaxation (no separators, no pool) is
+            # the loosest valid outer approximation. If IT is already infeasible, the
+            # node's subtree is genuinely empty (a valid relaxation with an empty
+            # feasible set is a rigorous fathom) and the pool did not cause it — keep
+            # the original ``infeasible`` verdict without a full re-separated re-solve.
+            # This is the hot path for a *sound* pool (its infeasibles re-confirm here
+            # in one loose LP), so inheritance keeps its throughput where the pool is
+            # valid. Only when the base relaxation is FEASIBLE was the fathom
+            # pool-induced (a pool row cut the non-empty node empty) — then pay the
+            # full pool-free re-solve to recover the node with the tightest valid
+            # bound the default path would have produced.
+            base_free = self._solve_at_node_impl(
+                node_lb,
+                node_ub,
+                time_limit,
+                inherited_cuts=None,
+                separate=False,
+                out_cuts=None,
+                psd_max_rounds=psd_max_rounds,
+                want_marginals=False,
+                skip_pool_separators=False,
+            )
+            if base_free.status != "infeasible":
+                # The pool row(s) caused a FALSE fathom of a non-empty node. Re-solve
+                # pool-free WITH the full separation chain (byte-identical to the
+                # default path's node solve) so the recovered node carries a bound as
+                # tight as the pool-free tree would give, then trust that valid
+                # relaxation. Count the recovery — same role as C-42's
+                # ``dropped_nodes``.
+                pool_free = self._solve_at_node_impl(
+                    node_lb,
+                    node_ub,
+                    time_limit,
+                    inherited_cuts=None,
+                    separate=separate,
+                    out_cuts=None,
+                    psd_max_rounds=psd_max_rounds,
+                    want_marginals=want_marginals,
+                    skip_pool_separators=False,
+                )
+                self._pool_stats["dropped_nodes"] += 1
+                # Adopt the pool-free result unconditionally: it is a valid relaxation
+                # of the identical box (optimal → recovered node with a sound bound;
+                # infeasible → the *default-path* separators tightened the loose base
+                # to empty, a rigorous fathom, since every separated cut is valid).
+                return pool_free
+        return res
+
+    def _solve_at_node_impl(
+        self,
+        node_lb: np.ndarray,
+        node_ub: np.ndarray,
+        time_limit: Optional[float] = None,
+        *,
+        inherited_cuts: Optional[tuple] = None,
+        separate: bool = True,
+        out_cuts: Optional[list] = None,
+        psd_max_rounds: int = 8,
+        want_marginals: bool = False,
+        skip_pool_separators: bool = False,
+    ) -> MccormickLPResult:
+        """Solve the McCormick LP relaxation restricted to the given bound box.
+
         Returns a :class:`MccormickLPResult`. ``lower_bound`` is a valid lower
         bound on the original problem within this box (for minimization).
         ``x`` is the LP solution projected to the original variable columns.
@@ -740,11 +883,13 @@ class MccormickLPRelaxer:
 
         Global cut pool (P1, see ``docs/design/global-cut-pool.md``):
 
-        * ``inherited_cuts``: ``(A_rows, b_rows)`` of globally-valid cut rows
-          separated once at the root, appended to this node's relaxation before
-          solving. Applied only when the lifted column layout matches the pool's
-          (a tightened child box can pin/fold columns); a mismatch skips them,
-          which is sound (fewer cuts only loosens the bound).
+        * ``inherited_cuts``: ``(A_rows, b_rows)`` of cut rows separated once at
+          the root, appended to this node's relaxation before solving. Applied
+          only when the lifted column layout matches the pool's (a tightened child
+          box can pin/fold columns); a mismatch skips them, which is sound (fewer
+          cuts only loosens the bound). NOTE: a pool row is NOT assumed valid on
+          every sub-box — see :meth:`solve_at_node`, which re-verifies any
+          pool-augmented ``infeasible`` against a pool-free solve (C-43).
         * ``separate``: when ``False`` skip the per-node cut-separation chain (use
           the inherited pool instead of re-deriving cuts every node).
         * ``out_cuts``: when a list is supplied, the rows the separation chain

--- a/python/tests/test_c42_cut_inherit_coldpath.py
+++ b/python/tests/test_c42_cut_inherit_coldpath.py
@@ -113,6 +113,73 @@ def test_pool_drop_retry_recovers_the_node_bound(monkeypatch):
 
 
 @pytest.mark.smoke
+def test_pool_has_rows_is_sparse_safe():
+    """C-43: the pool ``A_rows`` is a scipy CSR matrix whose ``len()`` is ambiguous
+    and *raises*. The re-verify gate must count rows via ``.shape[0]`` (through
+    ``_pool_has_rows``), not ``len()`` — otherwise it throws on every pool node,
+    the driver swallows the exception and silently skips the node, and the pool
+    infeasible is never re-verified (masking the bug behind a crash rather than
+    fixing it). This asserts the helper is sparse-safe and truthful."""
+    import scipy.sparse as sp
+    from discopt._jax.mccormick_lp import _pool_has_rows
+
+    A = sp.csr_matrix(np.array([[1.0, -1.0, 0.0], [0.0, 1.0, -1.0]]))
+    b = np.array([0.5, 0.5])
+    # A naive len(A) would raise here — the whole point of the helper:
+    with pytest.raises(TypeError):
+        len(A)
+    assert _pool_has_rows((A, b)) is True
+    assert _pool_has_rows(None) is False
+    assert _pool_has_rows((sp.csr_matrix((0, 3)), np.zeros(0))) is False
+
+
+@pytest.mark.smoke
+def test_pool_infeasible_reverify_recovers_false_fathom(monkeypatch):
+    """C-43 mechanism: when the pool-augmented node solve fathoms a node as
+    ``infeasible`` but the pool-free relaxation of the SAME box is feasible, the
+    inherited pool row cut off a non-empty node (invalid on this sub-box). The
+    re-verify must drop the pool and recover the node instead of trusting the false
+    fathom. Fails before the C-43 fix (the false ``infeasible`` propagates); passes
+    after (``pool/dropped_nodes`` fires and a valid bound is returned)."""
+    relaxer, lb, ub, pool = _mini_qp_relaxer_and_pool()
+
+    baseline = relaxer.solve_at_node(lb, ub, time_limit=30.0)
+    assert baseline.status == "optimal" and baseline.lower_bound is not None
+
+    # Poison the FIRST relaxation solve of the next node call (the pool-augmented
+    # one) with a *Farkas-certified* infeasible — reproducing what an
+    # invalid-on-sub-box pool row does: the pool-augmented polytope certifies empty
+    # though the pool-free box is feasible. The pool-free re-solve then delegates.
+    from discopt._jax import milp_relaxation as _mr
+
+    milp_cls = _mr.MilpRelaxationModel
+    real_solve = milp_cls.solve
+    state = {"fail_next": True}
+
+    def flaky(self, *args, **kwargs):
+        if state["fail_next"]:
+            state["fail_next"] = False
+            r = SimpleNamespace(
+                status="infeasible", x=None, objective=None, bound=None, farkas_certified=True
+            )
+            return r
+        return real_solve(self, *args, **kwargs)
+
+    monkeypatch.setattr(milp_cls, "solve", flaky)
+
+    res = relaxer.solve_at_node(
+        lb, ub, time_limit=30.0, inherited_cuts=pool, skip_pool_separators=True
+    )
+    assert res.status == "optimal", (
+        f"pool-induced false infeasible was trusted: {res.status} "
+        "(C-43: a pool-augmented infeasible must be re-verified pool-free)"
+    )
+    assert res.lower_bound is not None
+    assert res.lower_bound >= baseline.lower_bound - 1e-6
+    assert relaxer._pool_stats["dropped_nodes"] == 1
+
+
+@pytest.mark.smoke
 def test_lazy_reseparation_stride_net_fires():
     """The relaxer-side safety net: every ``_LAZY_RESEP_STRIDE``-th
     skip-eligible node solve runs the full separation pass regardless of the
@@ -150,20 +217,27 @@ _CORPUS = Path.home() / "Dropbox" / "projects" / "discopt-minlp-benchmark" / "mi
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="CUT-INHERIT-GRAD blocker: flag-ON false-optimal on the MINLP cold-path "
-    "class — nvs22 certifies 33.55 vs oracle 6.0582. The nvs06-class incumbent-"
-    "search reroute that C-42's pool-drop-retry does not cover (the pool solve "
-    "SUCCEEDS but the pre-tree pump is rerouted). Blocks the default-ON flip; the "
-    "flag stays opt-in until fixed. See docs/dev/cut-inherit-grad-2026-07-08.md.",
-    strict=True,
-)
 def test_nvs22_cut_inherit_no_false_optimal():
-    """Pins the CUT-INHERIT-GRAD graduation blocker. The DEFAULT (force-off) path
-    certifies nvs22's oracle optimum 6.0582 correctly; flag-ON currently returns a
-    FALSE-OPTIMAL 33.55. This xfail(strict) fails (i.e. flips to XPASS and the
-    suite goes red) the moment the flag-path reroute is fixed — the signal to
-    revisit the default-ON flip."""
+    """C-43 (#564) regression: the former CUT-INHERIT-GRAD graduation blocker.
+
+    Before this fix, flag-ON ``nvs22`` certified a FALSE-OPTIMAL ``33.55`` against
+    the oracle ``6.0582``: an inherited root cut-pool row is NOT valid on a
+    tightened sub-box (the "root-valid ⇒ globally-valid" premise is false for the
+    captured convex/square cut family here — a re-lifted child column changes what
+    the pool row addresses), so a node whose box contains the true optimum became
+    *Farkas-certified infeasible* once the pool was appended, falsely fathoming the
+    region and closing the tree around ``33.55``. C-42's pool-drop-retry did not
+    cover this: it fires only on the *no-certified-verdict* branch of the cold path,
+    but here the pool-augmented solve SUCCEEDS with a (false) ``infeasible``.
+
+    The fix re-verifies every pool-augmented ``infeasible`` against a pool-free
+    solve (``solve_at_node`` in ``mccormick_lp.py``): the fathom is kept only if the
+    pool-free relaxation is also infeasible; otherwise the node is recovered on its
+    valid pool-free bound. So flag-ON is now sound — and in fact certifies the
+    oracle optimum. This test was a strict-xfail (it went XPASS the moment the fix
+    landed); it is now a plain passing regression. See
+    ``docs/dev/c43-nvs22-fix-graduate-2026-07-08.md``.
+    """
     nl = _CORPUS / "nvs22.nl"
     if not nl.exists():
         pytest.skip("nvs22 not in the local MINLPLib corpus")
@@ -172,14 +246,26 @@ def test_nvs22_cut_inherit_no_false_optimal():
     assert ref.objective == pytest.approx(6.0582200, rel=5e-3), (
         f"default-path nvs22 regressed: {ref.objective}"
     )
-    # Flag-ON currently produces a false certificate (this assertion is the xfail).
+    # Flag-ON must be SOUND. The hard invariant (C-43): no false certificate — the
+    # dual bound is a valid lower bound (<= oracle + tol), and if the search
+    # certifies, the objective is the oracle optimum (never the old 33.55).
     res = from_nl(str(nl)).solve(
         time_limit=25, gap_tolerance=1e-4, tuning=SolverTuning(cut_inherit=True)
+    )
+    assert res.bound is None or res.bound <= 6.0582200 + 1e-3, (
+        f"nvs22 flag-ON dual bound {res.bound} crossed the oracle 6.0582 "
+        "(false bound — the C-43 pool-infeasible re-verify regressed)"
     )
     if str(res.status) == "optimal":
         assert res.objective == pytest.approx(6.0582200, rel=5e-3), (
             f"nvs22 flag-ON FALSE-OPTIMAL: certified {res.objective} vs oracle 6.0582"
         )
+    # The re-verify recovered at least one falsely-fathomed node (the mechanism
+    # under test); if it never fired, the guard is inert and the test is vacuous.
+    stats = res.solver_stats or {}
+    assert stats.get("pool/dropped_nodes", 0) >= 1, (
+        f"C-43 pool-infeasible re-verify never fired on nvs22: {stats}"
+    )
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## C-43 (#564) — nvs22 cut-inherit false-optimal fixed; broad graduation killed by an nvs19 cert loss the fix exposes

Fixes the CUT-INHERIT-GRAD blocker (#564). **Phase 1 (soundness) ships; Phase 2 (default-ON flip) is killed** — cut-inheritance stays **opt-in** (default force-off, byte-identical to `origin/main`).

### Root cause (measured, not #564's framing)

#564 framed nvs22's flag-ON false `optimal 33.55` (oracle `6.0582`) as an incumbent-search *reroute* on the pool-success path. The measurement found something more direct and more serious: a **false Farkas-infeasible fathom**. A node whose box contains the true optimum `(x0,x1,x2,x3)=(5,1,1,2)` is certified `infeasible` once the inherited pool is appended, though the pool-free relaxation of the same box solves to `optimal`. The Farkas ray certifies the *pool-augmented* polytope empty — a real proof only if every pool row is valid on the box. Here a pool row is **not valid on the sub-box** (column remapping: the row is stated over the root's lifted column layout, and a per-node re-lift/pin changes the columns' meaning at the same count), so the region holding 6.0582 is falsely pruned and the tree closes around 33.55 — a false certificate (dual bound 33.55 crosses the oracle 6.0582).

C-42 (#553) extended "the pool is an accelerator, never a dependency" to the *no-certified-verdict* branch of the cold path only. This is the **Farkas-infeasible** branch, on both the incremental fast path and the cold path — the branch C-42 did not cover.

### Fix

`solve_at_node` (now a thin wrapper over `_solve_at_node_impl`, `mccormick_lp.py`) re-verifies any pool-augmented `infeasible` **pool-free**: a cheap base-relaxation feasibility check first (keeps a genuine infeasible in one loose LP), and only on a real recovery a full pool-free re-solve (byte-identical to the default node solve). The `infeasible` fathom is kept only if the pool-free relaxation is also infeasible. Re-solving pool-free only *loosens*, so the guard can never introduce a false fathom of its own.

Also fixes a latent `len()`-on-scipy-sparse crash in the pool row check (was swallowed by the driver's node-solve `try/except`, masking the bug behind a skipped node) via a sparse-safe `_pool_has_rows`.

### Results

- **nvs22 flag-ON**: `optimal 33.55` (FALSE) → **`optimal 6.0582`** (= oracle), deterministic. Was strict-xfail → now a passing regression test.
- **C-42 cases retained** (flag-ON): nvs06 `optimal 1.7703125`, tspn05 `optimal 191.25521`.
- **HiGHS/oracle battery** (pool-firing: nvs17/19/22/23/24, knp3-12, dispatch, kall_circles_c6a…c8a) + broad held-out (20 instances): **0 false-optima, 0 dual-bound-crosses-oracle** (sense-correct: min bound ≤ opt, max bound ≥ opt). The guard is inert where the pool is valid (`dropped=None` on all 20 held-out).
- **Default (force-off) path untouched**: `check_cert_neutrality.py` **NEUTRAL** (41/41, `|Δobj|=0`, node counts unchanged). `solver_tuning.py` default unchanged.

### Graduation — KILLED (kept opt-in)

Root-causing showed the pre-fix flag path was resting on **broadly unsound sub-box fathoms** (not just nvs22). Making them sound costs **nvs19** its certificate (`optimal 48.5s` → `feasible @ 60s TL` — the 5 recovered false fathoms re-open nodes the pre-fix path unsoundly pruned). That is a Phase-2 "certs preserved-or-gained" gate failure, so per the graduation kill criterion the default-ON flip is killed. **#567** tracks the source fix (column-identity-safe inheritance) that would retire the runtime re-verify, restore nvs19's cert, and re-open the flip.

A cheaper recovery (return the loose base relaxation instead of the full re-solve) was tried and falsified: nvs22 then fails to certify.

### Gates run

- `pytest -m smoke` (python/tests): **633 passed, 12 skipped** (incl. 2 new C-43 smoke tests)
- `pytest -m slow test_adversarial_recent_fixes.py`: **10 passed**
- `pytest -m slow test_c42_cut_inherit_coldpath.py`: **3 passed** (nvs06, tspn05, nvs22 sound)
- `check_cert_neutrality.py` (default, 41-panel): **NEUTRAL**
- `ruff check` / `ruff format --check` (v0.14.6): clean
- pre-commit `mypy` (v2.1.0, whole package): **Passed**
- `cargo test -p discopt-core`: n/a — no Rust touched

Docs: `docs/dev/c43-nvs22-fix-graduate-2026-07-08.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
