### PR TITLE
fix+perf: C-44 — column-identity-safe cut inheritance (#567); sound but no net speedup, stays opt-in

### DIFF
--- a/docs/dev/c44-column-identity-inherit-2026-07-08.md
+++ b/docs/dev/c44-column-identity-inherit-2026-07-08.md
@@ -1,0 +1,209 @@
+# C-44 (#567) — column-identity-safe cut-pool inheritance:
+# the C-43 false-fathom fixed AT THE SOURCE; #568 re-verify now inert. Sound —
+# but the broad default-ON flip stays KILLED (flag-ON regresses several
+# pool-firing instances >10%). Cut-inheritance stays OPT-IN. (2026-07-08)
+
+**Status.** The soundness fix SHIPS. The nvs22 column-remapping false-fathom
+class (C-43, #564) is fixed **at the source**: the inherited pool is remapped by
+lifted-column *identity*, so no node is falsely Farkas-fathomed and the C-43/#568
+runtime re-verify goes **inert** on nvs22 (`pool/dropped_nodes: 21 → 0`). The
+default (force-off) path is **byte-identical** to `origin/main` (cert-neutrality
+41/41, `|Δobj|=0`, node counts unchanged). The broad **default-ON graduation is
+KILLED** by measurement (CLAUDE.md §4): the *sound* flag-ON path regresses several
+pool-firing instances >10% on wall time (dispatch, nvs18, nvs08), which fails the
+graduation gate "no instance >10% slower." `DISCOPT_CUT_INHERIT` / `cut_inherit`
+stays **opt-in** (default force-off).
+
+> **Method.** Apple M-series arm64, Python 3.12, release build
+> (`maturin develop --release`; pounce `_pounce.abi3.so` = 4.73 MB, not debug),
+> `PYTHONPATH=<wt>/python JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`, corpus
+> `~/Dropbox/projects/discopt-minlp-benchmark/`, oracle `minlplib.solu`. A/B wall
+> pairs run **SERIALLY** (fresh interpreter per solve, one solve at a time), per
+> the #552/CUT-INHERIT-GRAD lesson (the TL=30s parallel artifact).
+
+---
+
+## Part 1 — the column-remap mechanism (nailed down, file:line)
+
+A root cut-pool row is stated by **column position** over the ROOT build's lifted
+column layout (`solver.py:5165`/`:5238` root-pool capture via
+`solve_at_node(..., out_cuts=...)`). Each lifted aux column has a **stable
+structural identity** — the term key that created it, available in
+`build_milp_relaxation`'s returned `varmap` (`milp_relaxation.py:8423`):
+`bilinear (i,j)→col`, `monomial (i,p)→col`, `trilinear`/`multilinear` tuple→col,
+`fractional_power (i,p)→col`, `univariate_square (base_col, 2)→col`. Original
+variables occupy the fixed first `n_orig` columns.
+
+Per node the relaxation is re-built (`mccormick_lp.py:934` cold build) and/or
+re-lifted by lifted-FBBT (`:987`–`:995`, which **swaps `milp, varmap` together**).
+This can produce the **same column count with different column semantics**: a
+tightened/degenerated box drops or re-orders lifted terms, so a position that was
+`x_2·x_5·x_8` at the root becomes `x_3·x_4` (or an unrelated aux) at the node.
+The pre-C-44 gate checked only the *count* (`_sparse_cols(_ia) == n_total`,
+`mccormick_lp.py`, and `a_rows.shape[1] == inc.ncol` on the incremental path), so
+it appended a root row by position onto the **wrong lifted variables** → an
+invalid cut → a node whose box contains the true optimum can be **falsely
+Farkas-fathomed** (the C-43 nvs22 mechanism; the #568 runtime re-verify catches it
+but pays the recovery and, on the numerical class, costs a certificate).
+
+**Measured on nvs22 (flag-ON), instrumenting `build_milp_relaxation` per node:**
+the root layout has 69 columns; node builds recur with the **same 69-column count
+but 16–24 columns remapped** (e.g. root col 26 = `trilinear (2,5,8)`; at a node
+col 26 = `bilinear (3,4)` or `opaque`). 21 such nodes were being false-fathomed
+(recovered by #568's re-verify: `pool/dropped_nodes = 21`).
+
+## Part 2 — the fix: remap by column identity, skip if unmappable
+
+`column_identities(varmap, n_total, n_orig)` (`mccormick_lp.py`) returns a
+per-column identity tuple: `("orig", k)` for originals (always stable),
+`(mapname, term_key)` for structurally-keyed aux (bilinear/monomial/trilinear/
+multilinear/fractional_power), `("univariate_square", (base_identity, 2))` with
+the base resolved *recursively* to its own identity, and `("opaque", k)` for any
+unclaimed aux (position-locked — never remaps).
+
+`_remap_pool_rows(a_rows, b_rows, root_idents, node_idents, ncol)` remaps each
+pool row from root-column positions → the node position carrying the SAME
+identity. **A row that references (with a nonzero coefficient) a column whose
+identity is absent at the node is SKIPPED** — never appended over the wrong
+columns (skipping an optional cut is always sound; fewer cuts only loosen).
+
+Capture side: `solve_at_node`'s `out_cuts` chunk is now
+`(A, b, col_idents)` (`mccormick_lp.py`, the capture tags the SAME `varmap` the
+separated rows are stated over, post-FBBT-rebuild if it fired); `_root_cut_pool`
+carries the identities (`solver.py`, three capture sites). Consume side:
+
+* **Cold path** (`mccormick_lp.py` `_solve_at_node_impl`): build the node
+  identities from the node `varmap` and remap, gated by the *same* equal-count
+  precondition the legacy gate used (`_sparse_cols(_ia) == n_total`) so C-44 only
+  *remaps* at equal count — exactly where the false-fathom lived — and is
+  behaviour-neutral on the layouts the legacy gate rejected.
+* **Incremental path** (`_try_incremental_node`, node identities =
+  `inc.col_identities`, fixed across nodes because `_patch` never rebuilds
+  columns): when the pool's column count does not match the incremental structure
+  (`a_rows.shape[1] != inc.ncol`, e.g. dispatch: pool 23 cols vs incremental 10),
+  **decline the incremental path (`return None`)** so the cold build — which
+  re-lifts to the pool's own layout — inherits it there. This reproduces the
+  pre-C-44 routing exactly (which relied incidentally on a sparse-`np.asarray`
+  exception to decline) and is required for default-path byte-identity (dispatch:
+  3 nodes; without it, 12 623 nodes — a bound-neutrality violation).
+
+The #568 pool-infeasible re-verify is **kept as defense-in-depth** (per the task:
+do not remove the soundness guarantee); it is now a **no-op on the remapping
+class** — the appended cuts are valid, so no false fathom occurs.
+
+## Part 3 — soundness (hard gates, CLAUDE.md §1)
+
+### 3a. nvs22 — false-fathom removed at the source
+
+| arm | status | objective | bound | `pool/dropped_nodes` |
+|---|---|---:|---:|---:|
+| default (force-off) | optimal | 6.05822 (oracle) | 6.05822 | — |
+| flag-ON, `origin/main` (#568 re-verify) | optimal | 6.05822 | 6.05822 | **21** |
+| **flag-ON, C-44** | **optimal** | **6.05822** | 6.05822 | **0** |
+
+The remap is genuinely load-bearing: of 55 node remap calls, **44 had a reordered
+node layout** (columns at different positions than root) — the exact cases that
+were false-fathomed; **0 rows skipped** (every referenced lifted term existed at
+each node, just at a different position, so the remap recovered the correct cut).
+Direct anti-C43 probe: **12 opt-containing node solves, 0 falsely infeasible**
+(pre-fix: 1 of 3 opt-containing nodes went falsely `infeasible`).
+
+### 3b. HiGHS/oracle battery — 0 false-optima, 0 bound-crosses-oracle
+
+Flag-ON, sense-aware oracle cross-check (min: bound ≤ opt; max: bound ≥ opt),
+pool-firing + broad held-out (25 instances incl. nvs17/19/22/23/24, nvs06,
+knp3-12, dispatch, tspn05, kall_circles_c6a–c8a, st_e05/e07, ex1223a, alkyl,
+st_miqp1/2, nvs02/03/08/14/18): **VIOLATIONS: 0.** Every certified `optimal`
+equals the oracle; every dual bound is a valid bound. A separate 24-instance
+held-out slice (kall_circles skip 134–2635 rows, st_e07 skips 12) also
+**0 violations** — the skip branch is exercised and sound.
+
+### 3c. Feasible-point sampling of the REMAPPED cuts — no valid point cut
+
+Reconstructing the exact lifted vector (originals + every aux synthesized from its
+identity: bilinear→`z_i·z_j`, monomial→`z_i**p`, trilinear/multilinear→product,
+usq→base², recursively) at random integer-feasible points inside each node box,
+and checking `A_remapped @ z ≤ b + tol` on **every appended remapped row**:
+across nvs22/nvs19/nvs17/nvs24, **max violation 0.0 over ~1.8 M row-checks**,
+`unsynth = 0` (no opaque column ever leaks into an appended cut). No remapped cut
+removes a feasible point.
+
+### 3d. default-path cert-neutrality — byte-identical
+
+`check_cert_neutrality.py` (default force-off, 41-instance panel): **41/41
+byte-identical, `|Δobj| = 0.00e+00` on every row, node counts unchanged
+(dispatch 3→3, nvs13 49→49, tspn05 39→39), exit 0.** No rebaseline (the gate does
+not fire on the shipped default). The identity remap runs on the default path too
+(the pre-existing cert:T1.3 inheritance) and is verified inert there.
+
+## Part 4 — the empirical decision: SOUND, but no broad net speedup → KILL the flip
+
+Serial A/B, force-off vs flag-ON, per the graduation criteria (material sound
+speedup AND certs preserved-or-gained AND 0 false-optima AND no instance >10%
+slower):
+
+| instance | OFF | ON | verdict |
+|---|---|---|---|
+| nvs17 (TL30) | optimal 23.9 s, 173 n | optimal **17.3 s**, 225 n | **1.4× faster cert** (win) |
+| nvs13 (TL30) | optimal 1.91 s, 49 n | optimal 1.58 s, 53 n | faster (win) |
+| nvs24 (TL40) | feasible 9 n | feasible **31 n** (3.4×), same bnd | node win (TL-bound) |
+| knp3-12 (TL40) | feasible 31 n | feasible **159 n** (5×), same bnd | node win (TL-bound) |
+| nvs19 (TL90) | feasible @ 90 s (bnd −1098.96) | **optimal 63.3 s** (−1098.4=opt) | **cert GAINED** (sound tightening; the `dropped` nodes are the C-38 *numerical* class, recovered soundly — NOT remapping) |
+| st_e07 (TL30) | optimal 2.24 s | optimal 2.20 s | neutral |
+| nvs08 (TL30) | optimal 0.89 s | optimal 1.01 s | **+13% slower** |
+| nvs18 (TL40) | optimal 6.23 s | optimal 7.37 s | **+18% slower** |
+| dispatch (TL40) | optimal 0.47 s, 3 n | optimal 0.88 s, 23 n | **+87% slower** (cert preserved) |
+
+**The wins are real and sound** on the dense-integer-QP subclass (nvs24 3.4×,
+knp3-12 5×, nvs17 1.4×; nvs19 gains its cert at TL≥~63 s). **But flag-ON regresses
+wall time >10% on several pool-firing instances** (dispatch +87%, nvs18 +18%,
+nvs08 +13%) where the per-node square/PSD skip widens the tree more than the
+inherited pool tightens it. Per the graduation kill criterion "no instance >10%
+slower," a **broad default-ON flip is not justified**. The flip is **KILLED**; the
+flag stays **opt-in** with C-44's soundness fix shipped.
+
+### Note on the #567 nvs19 hypothesis (falsified — CLAUDE.md §4)
+
+#567 predicted the source fix would restore nvs19's flag-ON certificate by
+removing false fathoms. **Measurement:** on nvs19 the remap is a *no-op*
+(root↔node columns are positionally identical — 0 reorders across 51 node remap
+calls; the pool references 44 nonzero columns, 0 opaque). nvs19's `dropped` nodes
+are therefore **not** column-remapping false-fathoms — they are the **C-38
+numerical class** (a *valid* cut destabilizes the warm simplex, same family as
+nvs06's `dropped=1`), which C-44 neither introduces nor can remove. nvs19 is a
+**cert at the ~60 s budget edge**: force-OFF times out at 90 s while flag-ON
+certifies at ~63 s (a sound ~1.4× convergence win), so the flag is
+certs-preserved-or-gained on nvs19 — but that does not rescue the broad flip,
+which the >10% regressions above kill.
+
+## Cert-baseline disposition
+
+No rebaseline. The shipped default is byte-identical to `origin/main`
+(cert-neutrality 41/41, `|Δobj|=0`, node counts unchanged), so the
+"sanctioned bound-changing rebaseline" clause is moot (the flip is not made).
+
+## Gates
+
+| gate | result |
+|---|---|
+| `pytest -m smoke` (python/tests) | **633 passed, 12 skipped** |
+| `pytest -m slow test_adversarial_recent_fixes.py` | **10 passed** |
+| `pytest test_c42_cut_inherit_coldpath.py` (slow+smoke) | **7 passed** (nvs22 now asserts `dropped_nodes==0`; nvs06/tspn05 hold) |
+| `pytest test_c44_column_identity_inherit.py` | **5 passed** (remap-moves-coeff, skip-unmappable, naive-would-cut-feasible-point, usq-identity, tag-orig/aux) |
+| `pytest test_cut_inherit_pool.py` | **passed** (3-tuple chunk fixup) |
+| `test_amp.py` (AMP coverage set) | **135 passed** |
+| `check_cert_neutrality.py` (default force-off, 41-panel) | **41/41 byte-identical**, `|Δobj|=0`, node counts unchanged, exit 0 |
+| HiGHS/oracle battery + broad held-out (flag-ON) | **0 false-optima, 0 bound-crosses-oracle**; feasible-point sampling of remapped cuts: **max violation 0.0** |
+| `ruff check` / `ruff format --check` (v0.14.6) | clean |
+| pre-commit `mypy` (v2.1.0, whole package) | **Passed** |
+| `cargo test -p discopt-core` | n/a — no Rust touched |
+
+## Follow-ups (recorded, not shipped)
+
+1. The >10% flag-ON regressions on dispatch/nvs18/nvs08 are the per-node
+   square/PSD *skip* widening the tree, not the inheritance itself. A cost-aware
+   skip (skip only when the inherited pool measurably reproduces the node's
+   separation gain) could recover those and re-open the flip. #396 backlog.
+2. nvs19's flag-ON `dropped` nodes are the C-38 numerical class (valid cut
+   destabilizes the warm simplex); a conditioning-robust warm re-solve on the
+   pool-augmented system would retire the last `dropped` recoveries. #396 backlog.

--- a/python/discopt/_jax/incremental_mccormick.py
+++ b/python/discopt/_jax/incremental_mccormick.py
@@ -162,6 +162,19 @@ class IncrementalMcCormickLP:
         self.bilinear = dict(info.get("bilinear", {}))
         self.monomial = dict(info.get("monomial", {}))  # any integer power p >= 2
 
+        # C-44: per-column identity vector for this fixed lifted layout. The
+        # incremental structure never rebuilds columns (``_patch`` only rewrites
+        # coefficients of existing rows), so this identity vector is stable across
+        # every node — a root cut pool (captured on the cold path over its own
+        # varmap) is remapped onto these positions by matching identity. Built
+        # from the same ``info`` (full varmap) the cold path returns.
+        try:
+            from discopt._jax.mccormick_lp import column_identities
+
+            self.col_identities = column_identities(info, self.ncol, self.n)
+        except Exception:
+            self.col_identities = None
+
         # map each product to its row indices (support subset of {factors, aux})
         supp = [set(np.nonzero(np.abs(A[k]) > _TOL)[0]) for k in range(A.shape[0])]
         self.bilin_rows = {}

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -58,7 +58,7 @@ def _sparse_cols(A) -> int:
 
 
 def _pool_has_rows(inherited_cuts: Optional[tuple]) -> bool:
-    """True iff ``inherited_cuts`` is a non-empty ``(A_rows, b_rows)`` pool.
+    """True iff ``inherited_cuts`` is a non-empty ``(A_rows, b_rows[, idents])`` pool.
 
     Sparse-safe row count: the pool ``A_rows`` is a scipy CSR matrix, whose
     ``len()`` is *ambiguous and raises* — so a naive ``len(A_rows) > 0`` check
@@ -70,6 +70,140 @@ def _pool_has_rows(inherited_cuts: Optional[tuple]) -> bool:
         return False
     a_rows = inherited_cuts[0]
     return a_rows is not None and _sparse_rows(a_rows) > 0
+
+
+# ── Column-identity-safe cut inheritance (C-44 / #567) ──────────────────────
+#
+# A root-pool row is stated by *column position* over the ROOT build's lifted
+# column layout. Per node the relaxation is re-built (cold path) or re-lifted by
+# lifted-FBBT, which can produce the *same column count* with *different column
+# semantics* — a given position that was ``x_2·x_5·x_8`` at the root can become
+# ``x_3·x_4`` at a node (measured on nvs22: 16–24 of 69 columns remap while the
+# count is unchanged). Appending a pool row by position onto such a node then
+# constrains the WRONG lifted variables → an invalid cut → a node holding the
+# true optimum can be falsely Farkas-fathomed (the C-43 mechanism). The
+# count-only guard (``sparse_cols == n_total``) cannot see this.
+#
+# The fix tags every pool row with the *identities* of the lifted columns it
+# references (the structural term key — the ``(i,j)`` bilinear pair, the
+# ``(i,p)`` monomial, the trilinear/multilinear tuple, the fractional power, the
+# univariate-square base) and, per node, remaps each row's coefficients from
+# root-column-identity → the node's current position for that SAME identity. A
+# row that references a column whose identity is absent or changed at the node is
+# INAPPLICABLE and is skipped (skipping an optional cut is always sound).
+
+
+def column_identities(varmap: dict, n_total: int, n_orig: int) -> tuple:
+    """Stable per-column identity keys for a lifted McCormick column layout.
+
+    Returns a tuple of length ``n_total``. Position ``k`` carries a hashable
+    identity that is *stable across builds* iff the column is either an original
+    model variable (``("orig", k)``, always fixed) or an aux lifted by a
+    structurally-keyed term map (bilinear ``(i,j)``, monomial ``(i,p)``,
+    trilinear/multilinear tuple, fractional power, or univariate square). Any
+    aux column not so claimed is tagged ``("opaque", k)`` — an identity that is
+    only ever equal to itself at the *same* position, so a pool row that
+    references it never remaps across a re-lifted layout and is skipped (sound).
+
+    The univariate-square key ``(base_col, 2)`` is resolved through the *base*
+    column's own identity, so a square of a lifted aux carries the aux's
+    structural identity rather than a raw (unstable) column index.
+    """
+    ident: list = [("orig", k) if k < n_orig else None for k in range(n_total)]
+    # Structurally-keyed aux maps: value is a column index, key is a stable
+    # structural term identity (independent of build order / Python ``id``).
+    for mapname in (
+        "bilinear",
+        "monomial",
+        "trilinear",
+        "multilinear",
+        "fractional_power",
+    ):
+        m = varmap.get(mapname) or {}
+        for key, col in m.items():
+            if isinstance(col, (int, np.integer)) and 0 <= int(col) < n_total:
+                ident[int(col)] = (mapname, key)
+    # Univariate square: key ``(base_col, 2)``; resolve the base to its identity
+    # (which may itself be a lifted aux) so the square is stably identified.
+    usq = varmap.get("univariate_square") or {}
+    for key, col in usq.items():
+        if not (isinstance(col, (int, np.integer)) and 0 <= int(col) < n_total):
+            continue
+        base = key[0] if isinstance(key, tuple) and key else None
+        base_id: object
+        if isinstance(base, (int, np.integer)) and 0 <= int(base) < n_total:
+            base_id = ident[int(base)]  # nested identity of the squared column
+        else:
+            base_id = base
+        ident[int(col)] = ("univariate_square", (base_id, key[1] if len(key) > 1 else 2))
+    # Any aux column left unclaimed: opaque, position-locked (never remaps).
+    for k in range(n_total):
+        if ident[k] is None:
+            ident[k] = ("opaque", k)
+    return tuple(ident)
+
+
+def _remap_pool_rows(a_rows, b_rows, root_idents, node_idents, ncol: int):
+    """Remap root-pool rows onto a node's column layout by column identity.
+
+    ``a_rows`` (dense 2-D array, one row per pooled cut over the ROOT layout) and
+    ``b_rows`` are remapped so each root column position is moved to the node
+    position that carries the SAME identity (``root_idents``/``node_idents`` are
+    the identity tuples from :func:`column_identities`). A row is emitted only if
+    EVERY column it references with a nonzero coefficient has its identity present
+    at the node; otherwise the row is inapplicable and is dropped (sound — fewer
+    cuts only loosen the relaxation).
+
+    Returns ``(A_remapped, b_remapped, n_kept, n_skipped)`` where ``A_remapped``
+    is an ``(n_kept, ncol)`` dense array in the NODE column space (or ``None`` if
+    no row survives)."""
+    a = np.atleast_2d(np.asarray(a_rows, dtype=np.float64))
+    b = np.asarray(b_rows, dtype=np.float64).ravel()
+    if a.size == 0 or a.shape[0] == 0:
+        return None, None, 0, 0
+    # node identity -> node column position (first wins; identities are unique
+    # per build by construction — orig cols are unique, structural keys unique,
+    # opaque keys carry their own position).
+    node_pos: dict = {}
+    for pos, key in enumerate(node_idents):
+        if key not in node_pos:
+            node_pos[key] = pos
+    n_root_cols = len(root_idents)
+    out_rows = []
+    out_b = []
+    n_skipped = 0
+    for r in range(a.shape[0]):
+        row = a[r]
+        nz = np.nonzero(np.abs(row) > 0.0)[0]
+        new_row = np.zeros(ncol, dtype=np.float64)
+        ok = True
+        for c in nz:
+            if c >= n_root_cols:
+                ok = False  # references a column absent from the root identity map
+                break
+            rid = root_idents[c]
+            # An opaque root column has no verifiable stable identity across builds
+            # (only its own position), so a nonzero coefficient on one cannot be
+            # soundly remapped — refuse the row. (In practice pool rows never touch
+            # opaque columns; this is defense-in-depth.)
+            if isinstance(rid, tuple) and rid and rid[0] == "opaque":
+                ok = False
+                break
+            tgt = node_pos.get(rid)
+            if tgt is None:
+                ok = False  # this lifted term is not present at the node → skip row
+                break
+            new_row[tgt] += row[c]
+        if ok:
+            out_rows.append(new_row)
+            out_b.append(b[r])
+        else:
+            n_skipped += 1
+    if not out_rows:
+        return None, None, 0, n_skipped
+    A_out = np.array(out_rows, dtype=np.float64)
+    b_out = np.array(out_b, dtype=np.float64)
+    return A_out, b_out, len(out_rows), n_skipped
 
 
 def _append_relax_rows(milp, A_rows, b_rows) -> None:
@@ -332,6 +466,9 @@ class MccormickLPRelaxer:
         self._pool_stats: dict[str, int] = {
             "inherited_nodes": 0,
             "inherited_rows": 0,
+            # C-44: pool rows dropped at a node because a lifted term they
+            # reference is absent/remapped there (column-identity skip — sound).
+            "inherited_rows_skipped": 0,
             "skipped_separations": 0,
             "dropped_nodes": 0,
             "lazy_reseparations": 0,
@@ -542,18 +679,49 @@ class MccormickLPRelaxer:
         try:
             cut_rows = None
             if inherited_cuts is not None:
-                a_rows, b_rows = inherited_cuts
-                if a_rows is not None and len(a_rows) > 0:
-                    a_rows = np.asarray(a_rows, dtype=np.float64)
+                a_rows = inherited_cuts[0]
+                b_rows = inherited_cuts[1]
+                root_idents = inherited_cuts[2] if len(inherited_cuts) > 2 else None
+                if a_rows is not None and _sparse_rows(a_rows) > 0:
+                    a_rows = _as_csr(a_rows).toarray()
                     b_rows = np.asarray(b_rows, dtype=np.float64).ravel()
-                    # Apply the root cut pool only when its column layout matches the
-                    # incremental structure exactly; a mismatch would address the
-                    # wrong columns (skipping is sound — fewer cuts only loosen).
-                    if (
+                    node_idents = getattr(inc, "col_identities", None)
+                    # A pool captured over a WIDER column layout than this incremental
+                    # structure carries (``a_rows.shape[1] != inc.ncol``) cannot be
+                    # applied here — decline the incremental path (fall to the cold
+                    # build, which re-lifts to the pool's own layout and can inherit
+                    # it there). This preserves the pre-C-44 routing (the count check
+                    # gated inheritance to the cold path on such models, e.g.
+                    # dispatch: pool 23 cols vs incremental 10 cols) while C-44 makes
+                    # the equal-count case IDENTITY-safe below.
+                    _count_ok = (
                         a_rows.ndim == 2
                         and a_rows.shape[1] == inc.ncol
                         and len(b_rows) == a_rows.shape[0]
-                    ):
+                    )
+                    if not _count_ok:
+                        return None
+                    # C-44: at the SAME column count, remap the root pool from its
+                    # ROOT column identities onto this structure's layout by matching
+                    # identity — the old count-only gate appended a row by position
+                    # even when a re-lift remapped which lifted variable each position
+                    # means (same count, different semantics → the C-43 false-fathom).
+                    # A row referencing a lifted term this layout does not carry at
+                    # that count is skipped (sound — fewer cuts only loosen).
+                    if root_idents is not None and node_idents is not None:
+                        A_rm, b_rm, n_kept, n_skip = _remap_pool_rows(
+                            a_rows, b_rows, root_idents, node_idents, inc.ncol
+                        )
+                        self._pool_stats["inherited_rows_skipped"] += n_skip
+                        if A_rm is not None and n_kept > 0:
+                            cut_rows = list(zip(A_rm, b_rm))
+                            self._pool_stats["inherited_nodes"] += 1
+                            self._pool_stats["inherited_rows"] += n_kept
+                    elif root_idents is None or node_idents is None:
+                        # Untagged pool or unavailable node identities (defensive
+                        # fallback): legacy count-gated positional append (we already
+                        # passed the equal-count precondition). Should not occur once
+                        # every capture tags idents and the structure builds them.
                         cut_rows = list(zip(a_rows, b_rows))
                         self._pool_stats["inherited_nodes"] += 1
                         self._pool_stats["inherited_rows"] += len(cut_rows)
@@ -1059,21 +1227,55 @@ class MccormickLPRelaxer:
                 return None
             return max(_deadline - time.perf_counter(), _SOLVE_DEADLINE_FLOOR_S)
 
-        # Root cut-pool inheritance (P1): append globally-valid cut rows separated
-        # once at the root instead of re-separating them every node. Sound — each
-        # pool row is a valid inequality at every feasible point regardless of the
-        # node box — but only column-aligned when the lifted layout is unchanged
-        # (a pinned child variable can pin/fold columns), so gate on a matching
-        # ``n_total`` and otherwise skip (fewer cuts only loosens the bound).
+        # Root cut-pool inheritance (P1 + C-44): append globally-valid cut rows
+        # separated once at the root instead of re-separating them every node.
+        # Each pool row is a valid inequality at every feasible point regardless
+        # of the node box — but it is stated over the ROOT's lifted column
+        # positions, and this node's re-built / re-lifted layout can carry
+        # *different* lifted variables at the same positions (same count,
+        # different semantics — the C-43 remapping). So instead of the old
+        # count-only gate (which appended a positionally-wrong row), remap each
+        # row from its ROOT column identities onto THIS build's column positions
+        # by :func:`column_identities`; a row referencing a lifted term this node
+        # does not carry is skipped (sound — fewer cuts only loosen the bound).
         _n_pre_pool_rows = 0 if milp._A_ub is None else _sparse_rows(milp._A_ub)
         _pool_rows_appended = 0
         if inherited_cuts is not None:
-            _ia, _ib = inherited_cuts
-            if _ia is not None and _sparse_cols(_ia) == n_total:
-                _append_relax_rows(milp, _ia, _ib)
-                _pool_rows_appended = _sparse_rows(_ia)
-                self._pool_stats["inherited_nodes"] += 1
-                self._pool_stats["inherited_rows"] += _pool_rows_appended
+            _ia = inherited_cuts[0]
+            _ib = inherited_cuts[1]
+            _root_idents = inherited_cuts[2] if len(inherited_cuts) > 2 else None
+            if _ia is not None and _sparse_rows(_ia) > 0:
+                _node_idents = None
+                try:
+                    _node_idents = column_identities(varmap, n_total, self._n_orig)
+                except Exception:
+                    logger.debug("node column-identity build failed; skipping pool", exc_info=True)
+                # Equal-count precondition (matches the legacy ``sparse_cols ==
+                # n_total`` gate): only inherit when the pool was captured over the
+                # same column count as this build, so C-44 stays behaviour-neutral on
+                # the layouts the legacy gate rejected and only *remaps* (never newly
+                # inherits) at equal count — exactly where the C-43 false-fathom lived.
+                _count_ok = _sparse_cols(_ia) == n_total
+                if _root_idents is not None and _node_idents is not None and _count_ok:
+                    _ia_dense = _as_csr(_ia).toarray()
+                    _A_rm, _b_rm, _n_kept, _n_skip = _remap_pool_rows(
+                        _ia_dense, _ib, _root_idents, _node_idents, n_total
+                    )
+                    self._pool_stats["inherited_rows_skipped"] += _n_skip
+                    if _A_rm is not None and _n_kept > 0:
+                        _append_relax_rows(milp, _A_rm, _b_rm)
+                        _pool_rows_appended = _n_kept
+                        self._pool_stats["inherited_nodes"] += 1
+                        self._pool_stats["inherited_rows"] += _pool_rows_appended
+                elif (_root_idents is None or _node_idents is None) and _count_ok:
+                    # Untagged pool or unavailable node identities (defensive
+                    # fallback): legacy count-gated positional append. Should not
+                    # occur once every capture site tags identities and the node
+                    # build produces them; kept so it degrades safely.
+                    _append_relax_rows(milp, _ia, _ib)
+                    _pool_rows_appended = _sparse_rows(_ia)
+                    self._pool_stats["inherited_nodes"] += 1
+                    self._pool_stats["inherited_rows"] += _pool_rows_appended
         _n_base_rows = 0 if milp._A_ub is None else _sparse_rows(milp._A_ub)
 
         res = milp.solve(time_limit=_remaining(), backend=self._backend)
@@ -1176,11 +1378,30 @@ class MccormickLPRelaxer:
 
         # Capture the rows the separation chain just appended, for the root cut
         # pool. Stated over this node's lifted column space (``n_total`` columns).
+        # C-44: tag the chunk with the per-column IDENTITIES of this build's
+        # layout (``column_identities``), so a node inheriting the pool can remap
+        # each row from these root-column identities onto its own (possibly
+        # re-lifted) column positions — or skip a row whose lifted term the node
+        # does not carry. The identity vector is captured from the SAME
+        # ``varmap`` the separated rows are stated over (post-FBBT-rebuild if that
+        # fired, since ``milp``/``varmap`` are swapped together above).
         if out_cuts is not None and milp._A_ub is not None:
             _A = _as_csr(milp._A_ub)
             if _A.shape[0] > _n_base_rows:
+                _n_total_cap = int(np.size(milp._c))
+                try:
+                    _idents = column_identities(varmap, _n_total_cap, self._n_orig)
+                except Exception:
+                    logger.debug(
+                        "column-identity capture failed; pool chunk untagged", exc_info=True
+                    )
+                    _idents = None
                 out_cuts.append(
-                    (_A[_n_base_rows:].copy(), np.asarray(milp._b_ub)[_n_base_rows:].copy())
+                    (
+                        _A[_n_base_rows:].copy(),
+                        np.asarray(milp._b_ub)[_n_base_rows:].copy(),
+                        _idents,
+                    )
                 )
 
         # Rigorous bound / fathom from pure-Rust certificates (issue #356) — no

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5177,10 +5177,12 @@ def solve_model(
                             )
                             if _pool_chunks and _pool_chunks[0] is not None:
                                 # solve_at_node captures each separated chunk as a
-                                # (A, b) pair of upper-bound rows ``A x <= b`` over
-                                # the node's lifted column space; inherited_cuts
-                                # takes the same (A, b) form.
-                                _A_pool, _b_pool = _pool_chunks[0]
+                                # (A, b, col_idents) triple of upper-bound rows
+                                # ``A x <= b`` over the root's lifted column space
+                                # plus the per-column identity vector (C-44); a
+                                # node remaps the rows onto its own layout by those
+                                # identities. inherited_cuts takes the same form.
+                                _A_pool, _b_pool, _idents_pool = _pool_chunks[0]
                                 _n_pool = _A_pool.shape[0]
                                 if _n_pool > _root_cut_max:
                                     # Keep the last (most-recently separated, i.e.
@@ -5189,7 +5191,7 @@ def solve_model(
                                     # size so inheritance stays cheap.
                                     _A_pool = _A_pool[-_root_cut_max:]
                                     _b_pool = _b_pool[-_root_cut_max:]
-                                _root_cut_pool = (_A_pool, _b_pool)
+                                _root_cut_pool = (_A_pool, _b_pool, _idents_pool)
                                 # Keep the strengthened root bound: it is a valid
                                 # global lower bound (the pool relaxation holds over
                                 # the whole feasible region) and is far tighter than
@@ -5277,12 +5279,12 @@ def solve_model(
                             else:
                                 _root_sqpsd_frac = 0.0
                             if _pool_chunks and _pool_chunks[0] is not None:
-                                _A_pool, _b_pool = _pool_chunks[0]
+                                _A_pool, _b_pool, _idents_pool = _pool_chunks[0]
                                 _n_pool = _A_pool.shape[0]
                                 if _n_pool > _root_cut_max:
                                     _A_pool = _A_pool[-_root_cut_max:]
                                     _b_pool = _b_pool[-_root_cut_max:]
-                                _root_cut_pool = (_A_pool, _b_pool)
+                                _root_cut_pool = (_A_pool, _b_pool, _idents_pool)
                                 if (
                                     _pool_res is not None
                                     and _pool_res.lower_bound is not None
@@ -7858,12 +7860,12 @@ def solve_model(
                                     out_cuts=_rf_chunks,
                                 )
                                 if _rf_chunks and _rf_chunks[0] is not None:
-                                    _A_rf, _b_rf = _rf_chunks[0]
+                                    _A_rf, _b_rf, _idents_rf = _rf_chunks[0]
                                     if _A_rf is not None and _A_rf.shape[0] > 0:
                                         if _A_rf.shape[0] > _root_cut_max:
                                             _A_rf = _A_rf[-_root_cut_max:]
                                             _b_rf = _b_rf[-_root_cut_max:]
-                                        _root_cut_pool = (_A_rf, _b_rf)
+                                        _root_cut_pool = (_A_rf, _b_rf, _idents_rf)
                             except Exception as _rf_pool_exc:  # pragma: no cover
                                 logger.debug(
                                     "root-fixpoint cut-pool refresh skipped: %s",

--- a/python/tests/test_c42_cut_inherit_coldpath.py
+++ b/python/tests/test_c42_cut_inherit_coldpath.py
@@ -230,13 +230,16 @@ def test_nvs22_cut_inherit_no_false_optimal():
     cover this: it fires only on the *no-certified-verdict* branch of the cold path,
     but here the pool-augmented solve SUCCEEDS with a (false) ``infeasible``.
 
-    The fix re-verifies every pool-augmented ``infeasible`` against a pool-free
-    solve (``solve_at_node`` in ``mccormick_lp.py``): the fathom is kept only if the
-    pool-free relaxation is also infeasible; otherwise the node is recovered on its
-    valid pool-free bound. So flag-ON is now sound — and in fact certifies the
-    oracle optimum. This test was a strict-xfail (it went XPASS the moment the fix
-    landed); it is now a plain passing regression. See
-    ``docs/dev/c43-nvs22-fix-graduate-2026-07-08.md``.
+    C-43 shipped a runtime *re-verify* guard (drop the pool and re-solve pool-free
+    when a pool-augmented ``infeasible`` is not also pool-free infeasible), which
+    made nvs22 sound but only by *catching* the false fathoms at runtime
+    (``pool/dropped_nodes`` fired ~21×). C-44 (#567) fixes the invalidity at the
+    SOURCE: the pool row is remapped from its root column identities onto each
+    node's re-lifted layout (``column_identities`` / ``_remap_pool_rows`` in
+    ``mccormick_lp.py``), so the row constrains the correct lifted variables and no
+    false fathom occurs. The re-verify is now INERT on nvs22
+    (``pool/dropped_nodes == 0``) — kept only as defense-in-depth. See
+    ``docs/dev/c44-column-identity-inherit-2026-07-08.md``.
     """
     nl = _CORPUS / "nvs22.nl"
     if not nl.exists():
@@ -246,25 +249,28 @@ def test_nvs22_cut_inherit_no_false_optimal():
     assert ref.objective == pytest.approx(6.0582200, rel=5e-3), (
         f"default-path nvs22 regressed: {ref.objective}"
     )
-    # Flag-ON must be SOUND. The hard invariant (C-43): no false certificate — the
-    # dual bound is a valid lower bound (<= oracle + tol), and if the search
+    # Flag-ON must be SOUND. The hard invariant (C-43/C-44): no false certificate —
+    # the dual bound is a valid lower bound (<= oracle + tol), and if the search
     # certifies, the objective is the oracle optimum (never the old 33.55).
     res = from_nl(str(nl)).solve(
         time_limit=25, gap_tolerance=1e-4, tuning=SolverTuning(cut_inherit=True)
     )
     assert res.bound is None or res.bound <= 6.0582200 + 1e-3, (
         f"nvs22 flag-ON dual bound {res.bound} crossed the oracle 6.0582 "
-        "(false bound — the C-43 pool-infeasible re-verify regressed)"
+        "(false bound — column-identity remap regressed)"
     )
-    if str(res.status) == "optimal":
-        assert res.objective == pytest.approx(6.0582200, rel=5e-3), (
-            f"nvs22 flag-ON FALSE-OPTIMAL: certified {res.objective} vs oracle 6.0582"
-        )
-    # The re-verify recovered at least one falsely-fathomed node (the mechanism
-    # under test); if it never fired, the guard is inert and the test is vacuous.
+    assert str(res.status) == "optimal", (
+        f"nvs22 flag-ON no longer certifies (C-44 should certify like default): {res.status}"
+    )
+    assert res.objective == pytest.approx(6.0582200, rel=5e-3), (
+        f"nvs22 flag-ON FALSE-OPTIMAL: certified {res.objective} vs oracle 6.0582"
+    )
+    # C-44: the source fix means the runtime re-verify is now INERT — the pool rows
+    # are valid on every sub-box after remap, so no node is ever falsely fathomed.
     stats = res.solver_stats or {}
-    assert stats.get("pool/dropped_nodes", 0) >= 1, (
-        f"C-43 pool-infeasible re-verify never fired on nvs22: {stats}"
+    assert stats.get("pool/dropped_nodes", 0) == 0, (
+        f"C-44: the pool-infeasible re-verify should be inert on nvs22 (source fix "
+        f"removes the false fathoms), but it fired: {stats}"
     )
 
 

--- a/python/tests/test_c44_column_identity_inherit.py
+++ b/python/tests/test_c44_column_identity_inherit.py
@@ -1,0 +1,147 @@
+"""Regression tests for C-44 (#567): column-identity-safe cut-pool inheritance.
+
+A root cut-pool row is stated by *column position* over the ROOT build's lifted
+column layout. Per node the relaxation is re-built / re-lifted, which can produce
+the SAME column count with DIFFERENT column semantics — a given position that was
+``x_2·x_5·x_8`` at the root can become ``x_3·x_4`` at a node (measured on nvs22:
+16–24 of 69 columns remap while the count is unchanged). The pre-C-44 gate
+(``sparse_cols == n_total`` — a count check) then appended the pool row onto the
+WRONG lifted variables → an invalid cut → a node holding the true optimum could
+be falsely Farkas-fathomed (the C-43 nvs22 mechanism).
+
+C-44 tags each pool row with the *identities* of the lifted columns it references
+(``column_identities``) and, per node, remaps each row's coefficients from
+root-column-identity → the node's current position for the SAME identity
+(``_remap_pool_rows``); a row referencing a lifted term the node does not carry
+is skipped (sound — fewer cuts only loosen). These tests pin the mechanism.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+import pytest
+from discopt._jax.mccormick_lp import _remap_pool_rows, column_identities
+
+
+def test_column_identities_tags_orig_and_structural_aux():
+    """The identity vector labels original columns ``("orig", k)`` (always
+    stable) and structurally-keyed aux columns by their term key; unclaimed aux
+    columns are ``("opaque", k)`` (position-locked, never remaps)."""
+    # n_orig = 3 originals; cols 3,4 are aux (bilinear (0,1) and monomial (2,2));
+    # col 5 is an unclaimed aux.
+    varmap = {
+        "original": {0: 0, 1: 1, 2: 2},
+        "bilinear": {(0, 1): 3},
+        "monomial": {(2, 2): 4},
+    }
+    idents = column_identities(varmap, n_total=6, n_orig=3)
+    assert idents[0] == ("orig", 0)
+    assert idents[1] == ("orig", 1)
+    assert idents[2] == ("orig", 2)
+    assert idents[3] == ("bilinear", (0, 1))
+    assert idents[4] == ("monomial", (2, 2))
+    assert idents[5] == ("opaque", 5)  # unclaimed aux → opaque, position-locked
+
+
+def test_remap_moves_coefficients_to_the_matching_node_column():
+    """A pool row stated over the ROOT layout must be remapped so each column's
+    coefficient lands on the NODE position carrying the SAME identity — not the
+    same index. Here the bilinear ``(0,1)`` aux sits at root col 3 but node col 4:
+    the remapped row must put the aux coefficient at col 4, else it would
+    constrain whatever the node lifted into col 3 (an invalid cut)."""
+    # root layout: [orig0, orig1, orig2, bilinear(0,1)@3]
+    root_idents = (("orig", 0), ("orig", 1), ("orig", 2), ("bilinear", (0, 1)))
+    # node layout (re-lifted): the SAME bilinear now sits at col 4; col 3 is a
+    # DIFFERENT lifted term (bilinear (1,2)).
+    node_idents = (
+        ("orig", 0),
+        ("orig", 1),
+        ("orig", 2),
+        ("bilinear", (1, 2)),  # position 3 means something else now
+        ("bilinear", (0, 1)),  # the identity the row references, remapped here
+    )
+    # pool row: 1.0*x0 - 2.0*aux(0,1) <= 5   (aux coeff at root position 3)
+    a = np.array([[1.0, 0.0, 0.0, -2.0]])
+    b = np.array([5.0])
+    A_rm, b_rm, n_kept, n_skip = _remap_pool_rows(a, b, root_idents, node_idents, ncol=5)
+    assert n_kept == 1 and n_skip == 0
+    # The aux coefficient must move to node col 4 (its identity), NOT stay at col 3.
+    assert A_rm[0, 3] == 0.0, "coefficient left on the WRONG (remapped) node column"
+    assert A_rm[0, 4] == pytest.approx(-2.0)
+    assert A_rm[0, 0] == pytest.approx(1.0)
+    assert b_rm[0] == pytest.approx(5.0)
+
+
+def test_remap_skips_a_row_whose_lifted_term_is_absent_at_the_node():
+    """If a pool row references a lifted term the node does not carry, the row is
+    inapplicable and must be SKIPPED (never appended over the wrong columns).
+    Skipping an optional cut is always sound."""
+    root_idents = (("orig", 0), ("orig", 1), ("bilinear", (0, 1)))
+    # node lifted a DIFFERENT product; the (0,1) product is absent here.
+    node_idents = (("orig", 0), ("orig", 1), ("bilinear", (0, 1) + (99,)))
+    a = np.array([[1.0, 0.0, -2.0]])  # references bilinear(0,1) at col 2
+    b = np.array([5.0])
+    A_rm, b_rm, n_kept, n_skip = _remap_pool_rows(a, b, root_idents, node_idents, ncol=3)
+    assert n_kept == 0 and n_skip == 1
+    assert A_rm is None
+
+
+def test_naive_positional_inheritance_would_cut_a_feasible_point_but_remap_does_not():
+    """The soundness crux, concretely: a root pool row that is VALID over the root
+    layout becomes an INVALID cut if appended by position onto a node whose columns
+    remapped — it cuts a feasible lifted point. The identity remap must fix this.
+
+    Root layout: col 2 = ``aux = x0*x1``. Row ``aux <= 6`` is valid when the box
+    admits ``x0*x1 <= 6``. At the node, position 2 instead holds ``aux2 = x0*x0``
+    (a re-lift), while ``x0*x1`` moved to col 3. The feasible node point
+    ``x0=3, x1=1`` gives ``x0*x1 = 3 (<= 6, ok)`` but ``x0*x0 = 9 (> 6)``. So the
+    NAIVE positional row ``z[2] <= 6`` cuts this feasible point; the REMAPPED row
+    ``z[3] <= 6`` (the real ``x0*x1``) does not."""
+    root_idents = (("orig", 0), ("orig", 1), ("bilinear", (0, 1)))
+    node_idents = (
+        ("orig", 0),
+        ("orig", 1),
+        ("monomial", (0, 2)),  # position 2 is now x0**2, NOT x0*x1
+        ("bilinear", (0, 1)),  # x0*x1 moved to position 3
+    )
+    a = np.array([[0.0, 0.0, 1.0]])  # aux(0,1) <= 6, over the ROOT layout
+    b = np.array([6.0])
+
+    # The feasible lifted point at the node: x0=3, x1=1, x0**2=9, x0*x1=3.
+    z = np.array([3.0, 1.0, 9.0, 3.0])
+
+    # Naive positional inheritance (the pre-C-44 bug) would append the row as-is:
+    naive_lhs = float(a[0] @ z[:3])  # uses z[2] = x0**2 = 9
+    assert naive_lhs > b[0] + 1e-9, "the naive positional row must cut this feasible point"
+
+    # C-44 remap: the row lands on the node's real x0*x1 column (3), value 3 <= 6.
+    A_rm, b_rm, n_kept, n_skip = _remap_pool_rows(a, b, root_idents, node_idents, ncol=4)
+    assert n_kept == 1 and n_skip == 0
+    remapped_lhs = float(A_rm[0] @ z)
+    assert remapped_lhs <= b_rm[0] + 1e-9, (
+        "the REMAPPED row must NOT cut the feasible point (it now addresses x0*x1)"
+    )
+    assert A_rm[0, 2] == 0.0 and A_rm[0, 3] == pytest.approx(1.0)
+
+
+def test_univariate_square_identity_resolves_through_its_base():
+    """A ``univariate_square`` key is ``(base_col, 2)``; the identity must resolve
+    the base column to ITS identity so a square of a lifted aux is stably tagged
+    (a raw base index would be unstable across re-lifts)."""
+    varmap = {
+        "original": {0: 0, 1: 1},
+        "bilinear": {(0, 1): 2},
+        # square of the bilinear aux (col 2): key (2, 2), lifted to col 3.
+        "univariate_square": {(2, 2): 3},
+    }
+    idents = column_identities(varmap, n_total=4, n_orig=2)
+    # col 3's identity must nest the bilinear identity of its base col 2.
+    assert idents[3][0] == "univariate_square"
+    base_id, power = idents[3][1]
+    assert base_id == ("bilinear", (0, 1))
+    assert power == 2

--- a/python/tests/test_cut_inherit_pool.py
+++ b/python/tests/test_cut_inherit_pool.py
@@ -117,7 +117,9 @@ def _root_pool_and_varmap():
     res = relaxer.solve_at_node(lb, ub, time_limit=30.0, out_cuts=chunks)
     assert res.status == "optimal", f"root solve failed: {res.status}"
     assert chunks, "root separation captured no cut pool"
-    A_pool, b_pool = chunks[0]
+    # C-44: solve_at_node now captures each chunk as (A, b, col_idents); the pool
+    # rows / rhs are the first two elements (identities are the remap tag).
+    A_pool, b_pool = chunks[0][0], chunks[0][1]
     A_pool = np.asarray(
         A_pool.todense() if hasattr(A_pool, "todense") else A_pool, dtype=np.float64
     )


### PR DESCRIPTION
## Summary

Source fix for the C-43 (#564) false-fathom class exposed by #567: inherited root
cut-pool rows are stated by **column position** over the root's lifted layout, but
a node's re-built / lifted-FBBT-rebuilt relaxation can carry the **same column
count with different column semantics** — a position that was `x_2·x_5·x_8` at the
root becomes `x_3·x_4` at a node (measured on nvs22: **16–24 of 69 columns remap**
while the count is unchanged). The count-only gate (`sparse_cols == n_total`)
appended a row onto the **wrong lifted variables** → an invalid cut → a node
holding the true optimum was falsely Farkas-fathomed. #568's runtime re-verify
*caught* this but paid the recovery (and on the numerical class cost a cert).

**Fix** (`mccormick_lp.py`): tag each pool row with the **identities** of the
lifted columns it references (`column_identities` — the structural term key, not
the positional index) and **remap** per node onto the position carrying the SAME
identity (`_remap_pool_rows`); **skip** a row whose lifted term is absent/opaque
at the node (sound — fewer cuts only loosen). The #568 re-verify is **kept as
defense-in-depth** and is now **inert on the remapping class** (nvs22
`pool/dropped_nodes 21 → 0`). The incremental path declines to the cold build on a
column-count mismatch so the pool inherits at its own layout (preserves
default-path routing).

## Soundness (hard gates)

- **nvs22 flag-ON: `optimal 6.05822` (oracle), `dropped_nodes = 0`** — the false
  fathom is removed at the source (44 of 55 node remaps genuinely reordered; 0
  skipped). Direct probe: **12 opt-containing node solves, 0 falsely infeasible**.
- **HiGHS/oracle battery + broad held-out (flag-ON, 49 instances): 0 false-optima,
  0 dual-bound-crosses-oracle.** The skip branch is exercised (kall_circles skip
  134–2635 rows) and sound.
- **Feasible-point sampling of every appended remapped cut: max violation 0.0**
  over ~1.8 M row-checks (nvs22/19/17/24); no valid point cut.
- **Default (force-off) path byte-identical**: `check_cert_neutrality.py` 41/41,
  `|Δobj| = 0`, node counts unchanged (dispatch 3→3, nvs13 49→49), exit 0.

## Empirical decision — stays OPT-IN (measurement wins, CLAUDE.md §4)

Serial A/B, sound flag-ON vs force-off:

| instance | verdict |
|---|---|
| nvs17 | optimal 1.4× faster |
| nvs24 / knp3-12 | 3.4× / 5× node throughput (TL-bound), same bound |
| nvs19 | **cert gained** — optimal ~63 s vs OFF timeout at 90 s |
| dispatch | **+87% slower** (cert preserved) |
| nvs18 / nvs08 | **+18% / +13% slower** |

The wins are real and sound on the dense-integer-QP subclass, but flag-ON
regresses several pool-firing instances **>10%** on wall time. Per the graduation
kill criterion "no instance >10% slower," the **broad default-ON flip stays
KILLED** — cut-inheritance remains **opt-in** (`DISCOPT_CUT_INHERIT` default
force-off; `=1`/`=gated` overrides tested). #567's nvs19 hypothesis is falsified:
nvs19's remap is a no-op (columns positionally identical); its `dropped` nodes are
the C-38 numerical class, not column remapping.

Full analysis + tables: `docs/dev/c44-column-identity-inherit-2026-07-08.md`.

## Tests run

- `pytest -m smoke` (python/tests): **633 passed, 12 skipped**
- `pytest -m slow test_adversarial_recent_fixes.py`: **10 passed**
- `pytest test_c42_cut_inherit_coldpath.py` (slow+smoke): **7 passed** (nvs22 now
  asserts `dropped_nodes == 0`; nvs06/tspn05 hold)
- `pytest test_c44_column_identity_inherit.py`: **5 passed** (incl. a synthetic
  node where naive positional inheritance *would* cut a feasible point, asserting
  the remap does not)
- `pytest test_cut_inherit_pool.py`: **passed** (3-tuple chunk fixup)
- `test_amp.py` (AMP coverage set): **135 passed**
- `check_cert_neutrality.py` (default force-off, 41-panel): **41/41 byte-identical, exit 0**
- `ruff check` / `ruff format --check` (v0.14.6): clean
- pre-commit `mypy` (v2.1.0, whole package): **Passed**
- `cargo test -p discopt-core`: n/a — no Rust touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
