### PR TITLE
perf(lp): #557 — density-aware dense/sparse LU route for wide-McCormick node bases (flag-gated)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,8 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "feral"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef91918cdb92a5ea18d2a40563014b84102ec41ebf621fe4a5c0d9d337d59326"
+version = "0.13.0"
+source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -96,8 +95,7 @@ dependencies = [
 [[package]]
 name = "feral-amd"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead2f064dbcef0e0d3110202e9d6d7c293c1dffe6da5964513a20c5967e4d560"
+source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -105,8 +103,7 @@ dependencies = [
 [[package]]
 name = "feral-amf"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ea6dacabfa085e7f40080c894da245d9db60e9211f1f8ab08d715d6d0f5a29"
+source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -114,8 +111,7 @@ dependencies = [
 [[package]]
 name = "feral-kahip"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ba0d001a63e777227de4565c7f4cd14062b9fbe83d3cadcb292be74410b4f4"
+source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -125,8 +121,7 @@ dependencies = [
 [[package]]
 name = "feral-metis"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b34963682eaf680479bfd6018a5570bfd1ed9c1f05d8bf085ab49f13b308cb"
+source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -135,14 +130,12 @@ dependencies = [
 [[package]]
 name = "feral-ordering-core"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca94ad929e23c0adaa6edda42474aa71b5b2bfb3930b1f6b202e4b37c8e9b763"
+source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
 
 [[package]]
 name = "feral-scotch"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51fe24bffbef76e88803e801c2d8977f5d304dd6af43f70c1e91fdfabd0b530"
+source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -19,13 +19,30 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # invisible on few-row knapsacks but catastrophic on 800–1500-row covering LPs.
 # `test_setcover_lp_regression.py` guards against a re-downgrade.
 #
-# 0.12.0 is the first crates.io release carrying the discopt#364 LU-hardening APIs
+# 0.12.0 was the first crates.io release carrying the discopt#364 LU-hardening APIs
 # (feral #93/#94/#95) the numeric-focus simplex consumes: the element-growth
 # getters (growth()/u_max0()), the unsymmetric-LU condition estimate
 # (condition_estimate_1), and the richer update() instability signal
 # (RefactorCause + last_refactor() + growth-aware/dense-parity should_refactor).
-# It replaces the temporary git-rev pin used while those APIs were unreleased.
-feral = "0.12.0"
+#
+# Pinned to a git rev PAST the v0.13.0 release (2026-07-02) for feral #112 / PR #113
+# (merge commit 660224dc9299): the sparse Forrest–Tomlin bump update now accumulates
+# its working row with an always-on Neumaier (Kahan–Babuška) compensated sum, which
+# keeps the sparse LU factor accurate on the wide dense-McCormick node bases.
+#
+# WHY THIS IS BUNDLED WITH THE #557 density-aware LU route (linsolve.rs): the route
+# sends the m∈(16,256] sparse-but-wide McCormick bases to feral's SPARSE LU instead
+# of the dense O(m³) path. On plain feral 0.12 that eliminates the RefacFtTinyPivot
+# refactor storm (storm-elimination IS feral-independent, 42337→~3200 on st_e36) —
+# BUT the plain-0.12 sparse factor is not accurate enough for the dual bound to keep
+# closing: st_e36 with the route ON drops optimal→feasible, its bound stuck at the
+# root value −304.5 (vs −246.02 that certifies optimal). #112's compensated sparse
+# accumulation restores the bound-closing, so route ON stays `optimal`. Bound-closing
+# is NOT feral-independent, hence the route change and this bump ship together.
+# No discopt API change (LuParams gains `update_pivot_search: bool`, default false,
+# covered by `..LuParams::default()`). Unreleased on crates.io as of the pin date,
+# hence the git rev; bump to the next tagged release when it cuts.
+feral = { git = "https://github.com/jkitchin/feral", rev = "660224dc929953072582603a15c7cb4c7bf0592c" }
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to
 # 1.10 to keep the crate's MSRV (1.75); 1.12+ requires rustc 1.80.

--- a/crates/discopt-core/src/lp/simplex/linsolve.rs
+++ b/crates/discopt-core/src/lp/simplex/linsolve.rs
@@ -137,6 +137,61 @@ enum Factored {
 /// also gates on sparsity, would not. Above it we defer to feral's heuristic.
 const FORCE_DENSE_M: usize = 256;
 
+/// Tiny-basis cutoff (mirrors feral's `M_TINY`): at or below this `m` a dense LU
+/// always wins and the density-aware route never diverts to sparse.
+const M_TINY: usize = 16;
+
+/// Choose the dense vs sparse LU route for an `m`×`m` basis with `nnz` stored
+/// entries — the discopt-side policy on top of feral's `should_use_dense_lu`.
+///
+/// **Default (OFF):** the historical policy — force dense for every `m ≤
+/// FORCE_DENSE_M`, else defer to feral's `should_use_dense_lu` (which itself is
+/// dense for `m ≤ 16`, dense if `m ≤ dense_threshold` and ≥ 25% dense, else
+/// sparse). Byte-identical to prior behavior.
+///
+/// **Density-aware route (`DISCOPT_LU_DENSITY_ROUTE=1`):** for the band
+/// `M_TINY < m ≤ FORCE_DENSE_M`, consult the *same* density gate feral uses
+/// (`nnz·4 ≥ m·m`, i.e. ≥ 25% dense) instead of forcing dense. Sparse-but-large
+/// bases (`nnz·4 < m·m`) then take feral's sparse LU. Motivation (#557): the
+/// wide lifted-McCormick node bases land at `m ≈ 200–256` but are only ~4% dense;
+/// forcing them dense pays an O(m³) refactor **and** triggers the dense FT
+/// update's `TinyPivot` refactor-every-pivot storm, whereas the sparse LU factors
+/// them ~13× faster and its FT update commits (measured on st_e36: a captured
+/// m=225 4.4%-dense node LP goes 62 ms → 4.6 ms, `RefacFtTinyPivot` 201/solve →
+/// ~0). Truly-dense small bases and `m ≤ M_TINY` still route dense (the density
+/// gate keeps them there), so the ~440 µs/iter sparse-symbolic overhead the
+/// dense cutoff was built to avoid is not paid on the bases that need dense.
+fn want_dense_route(m: usize, nnz: usize, params: &LuParams) -> bool {
+    route_dense_decision(m, nnz, params, density_route_enabled())
+}
+
+/// Pure routing decision (env flag passed in, so it is deterministically
+/// testable). See [`want_dense_route`] for the policy rationale.
+fn route_dense_decision(m: usize, nnz: usize, params: &LuParams, density_route: bool) -> bool {
+    // Off: preserve the exact historical routing.
+    if !density_route {
+        return m <= FORCE_DENSE_M || should_use_dense_lu(m, nnz, params);
+    }
+    // Density-aware: tiny always dense; the (M_TINY, FORCE_DENSE_M] band defers to
+    // the density gate; above FORCE_DENSE_M feral's heuristic decides (unchanged).
+    if m <= M_TINY {
+        return true;
+    }
+    if m <= FORCE_DENSE_M {
+        // feral's exact density criterion: dense iff at least a quarter dense.
+        // Saturating so a huge m can't overflow m·m / nnz·4.
+        return nnz.saturating_mul(4) >= m.saturating_mul(m);
+    }
+    should_use_dense_lu(m, nnz, params)
+}
+
+/// Whether the `DISCOPT_LU_DENSITY_ROUTE` density-aware LU route (#557) is on.
+/// Default off — the LU routing is byte-identical to the historical policy — so
+/// this is a real, opt-in performance knob, not a dead flag.
+fn density_route_enabled() -> bool {
+    std::env::var_os("DISCOPT_LU_DENSITY_ROUTE").is_some()
+}
+
 /// The retained basis matrix, in dense-column form, kept **in sync** with every
 /// [`update`](LinearSolver::update) so a refined solve or condition estimate can
 /// form the residual `r = b − B·x` against the matrix the factor *currently*
@@ -309,7 +364,7 @@ impl LinearSolver for FeralLU {
             .map(|c| c.iter().filter(|&&v| v != 0.0).count())
             .sum();
         self.lu = Some(
-            if m <= FORCE_DENSE_M || should_use_dense_lu(m, nnz, &params) {
+            if want_dense_route(m, nnz, &params) {
                 Factored::Dense(Box::new(
                     DenseLu::factor(cols, m, params).map_err(feral_err)?,
                 ))
@@ -335,7 +390,7 @@ impl LinearSolver for FeralLU {
         let nnz: usize = cols.iter().map(|c| c.len()).sum();
         // Densify once if either the dense LU branch needs it or numeric-focus
         // retention does; reuse the single dense copy for both.
-        let want_dense = m <= FORCE_DENSE_M || should_use_dense_lu(m, nnz, &params);
+        let want_dense = want_dense_route(m, nnz, &params);
         let dense = (want_dense || self.refine_enabled()).then(|| {
             let mut d = vec![vec![0.0; m]; m];
             for (slot, col) in cols.iter().enumerate() {
@@ -498,6 +553,40 @@ impl LinearSolver for DenseLU {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn route_default_off_is_historical() {
+        // Default (density_route=false) must reproduce the exact historical policy:
+        // dense for every m ≤ FORCE_DENSE_M regardless of density, else feral.
+        let p = LuParams::default();
+        // Wide, sparse McCormick-like band basis: historically forced dense.
+        assert!(route_dense_decision(225, 996 + 225, &p, false));
+        // A genuinely large sparse basis: feral routes it sparse either way.
+        assert!(!route_dense_decision(1000, 1000 * 4, &p, false));
+        // Tiny: dense.
+        assert!(route_dense_decision(8, 0, &p, false));
+    }
+
+    #[test]
+    fn route_density_on_diverts_sparse_band_only() {
+        let p = LuParams::default();
+        // The #557 target: m=225 at ~4.4% density → now SPARSE (was dense).
+        assert!(!route_dense_decision(225, 996 + 225, &p, true));
+        // A truly-dense small basis (≥25% dense) in the band → still DENSE.
+        let dense_nnz = 100 * 100 / 3; // ~33% dense
+        assert!(route_dense_decision(100, dense_nnz, &p, true));
+        // Exactly the 25% density boundary (nnz·4 == m·m) → dense (≥ gate).
+        assert!(route_dense_decision(100, 100 * 100 / 4, &p, true));
+        // Just below 25% → sparse.
+        assert!(!route_dense_decision(100, 100 * 100 / 4 - 1, &p, true));
+        // Tiny stays dense even at 0 nnz.
+        assert!(route_dense_decision(16, 0, &p, true));
+        // Above FORCE_DENSE_M: feral heuristic, unchanged by the flag.
+        assert_eq!(
+            route_dense_decision(300, 300, &p, true),
+            should_use_dense_lu(300, 300, &p)
+        );
+    }
 
     // Matrix-vector B·x with B[i][j] = cols[j][i].
     fn bmatvec(cols: &[Vec<f64>], x: &[f64]) -> Vec<f64> {


### PR DESCRIPTION
## Summary

Root-cause + fix for the Forrest–Tomlin refactor **storm** that dominated per-node LP cost on dense-McCormick spatial-B&B nodes (THRU-5: refactorization 55–66% of node-LP wall, `RefacFtFail` ~100%). Closes the engine core of #557. **Two commits that ship together:** the density-aware LU route (flag-gated) + the feral#112 bump it depends on for bound-closing.

**The storm is a dense/sparse routing artifact in discopt.** `FeralLU::factorize` forced feral's **dense** LU for every basis with `m ≤ 256`. The wide lifted-McCormick node bases land at `m ≈ 200–256` but are only ~4% dense; forcing them dense paid an O(m³) refactor **and** drove the dense FT update's `TinyPivot` refactor-every-pivot storm. feral's **sparse** LU factors them ~13× faster and its sparse FT update commits on ~every pivot. (This is why ENGINE-1/2 #570/#571 and the cadence experiment missed it — they profiled the *sparse* FT path while the runtime storm was in the *dense* path these bases were mis-routed to.)

## The change

1. **`8598a8f6`** — `crates/discopt-core/src/lp/simplex/linsolve.rs` (+91/−2): `route_dense_decision()`, flag-gated by `DISCOPT_LU_DENSITY_ROUTE`. **OFF (default): the exact historical expression — byte-identical routing.** ON: for `16 < m ≤ 256`, defer to feral's own density gate (`nnz·4 ≥ m·m`); tiny and truly-dense-small bases stay dense; `m > 256` unchanged. Two unit tests pin OFF=historical, ON=diverts-the-sparse-band-only.
2. **`5ce15161`** — feral bumped to git rev `660224dc` (the feral#112 compensated-accumulation fix). **Required, not optional:** a global50 gap-instance smoke showed that on plain feral 0.12, route-ON leaves st_e36's dual bound **stuck at the root value** (−304.5) → status drops `optimal → feasible`. The storm-elimination is feral-independent; the **bound-closing is not** — it needs #112's more accurate sparse factorization. With the bundle, st_e36 is `optimal` (bound −246.019) at **1.69×**.

## Measurements (route ON vs OFF, bundled build)

- **Storm:** st_e36 `RefacFtFail` 42337 → ~3–5k (**8–13×↓**); nvs24 2996 → 263 (**11×↓**). Residual fails are genuinely-dense small bases that correctly stay dense.
- **Wall:** st_e36 24.3s → **14.4s (1.69×, `optimal`, 153 nodes identical)**; st_e07 6.5s → **0.84s (7.75×)**; nvs06 1.55×; st_e13 neutral. Broad 35-instance sweep otherwise neutral, **no real regression** (sub-100ms "regressions" were jitter; neutral on min-of-5).
- **Honest scope note:** the fast June-18 global50 gap rows (st_e38, st_test1, st_miqp1/2/4) were already closed by other work since that baseline — the route is inert on them. The route's wins are the storm-bound class (st_e36, st_e07, nvs06, …).

## Correctness (bound-changing-numerics regime, CLAUDE.md §5)

A different factorization of the same LP ⇒ acceptance bar is **status-preserved + node-count-neutral + in-tolerance objective**, `incorrect_count = 0`:

- **10-instance deterministic cert panel (bundled build, OFF vs ON): all 10 `optimal → optimal` (zero certification losses), node_count byte-identical 10/10**, objectives 8/10 byte-identical + 2 last-bit drifts (ex1225 5.3e-12, st_e36 2.8e-14).
- Broad sweep: 0 node_count drift on all 27 optimal pairs; worst objective drift st_e07 (abs 5.96e-5, rel 1.4e-7 — well inside the abs 1e-4 / rel 1e-3 gate; present OFF and ON, unchanged in kind by the route).
- **Suites (bundled, route ON):** `cargo test -p discopt-core` 430/0 · `pytest -m smoke` 633/1skip/0 · adversarial 10/0 · clippy clean. Default-OFF byte-identity reconfirmed (st_e36: optimal/−246.0/153/storm 42337 — identical to baseline; the feral bump alone changes nothing without the route).

## Rollout

Ships **default-OFF** (`DISCOPT_LU_DENSITY_ROUTE=1` to enable). Graduation to default-ON is a separate step after consecutive-nightly soak, per the §5 bound-changing protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
