### PR TITLE
feat(mcbox): P0.3 — port the #572 reduced-space evaluator onto MCBox

### DIFF
--- a/python/discopt/_jax/mccormick_subgradient.py
+++ b/python/discopt/_jax/mccormick_subgradient.py
@@ -1,0 +1,230 @@
+"""Reduced-space McCormick relaxation + Kelley-cut LP bound, on the MCBox type.
+
+MAiNGO-parity plan P0.3: this reimplements the #572 reduced-space evaluator on top of
+:mod:`discopt._jax.mcbox`. Where the original walked the model AST into hand-rolled
+``(cv, cc)`` closures (affine / QP scope, ``jax.grad`` subgradients), this interprets
+the AST into :class:`~discopt._jax.mcbox.MCBox` operations — so the relaxation and its
+subgradients propagate by rule, and the scope widens to everything MCBox supports
+(general products, transcendental composition), still sound-or-refuse.
+
+Public API is unchanged from #572: :class:`UnsupportedRelaxation`,
+:func:`build_reduced_relaxation`, :func:`reduced_mccormick_lp_bound`,
+:class:`ReducedRelaxation`, :class:`ReducedBound`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from discopt._jax import mcbox as _mcbox
+from discopt._jax.mcbox import UnsupportedMcboxOp, mcbox_leaves
+from discopt._jax.relaxation_compiler import _resolve_scalar_var_offset
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Constraint,
+    FunctionCall,
+    ObjectiveSense,
+    Parameter,
+    UnaryOp,
+    Variable,
+)
+
+
+class UnsupportedRelaxation(Exception):
+    """Model is outside the sound reduced-space scope — caller falls back (α-BB/lifted)."""
+
+
+def _scalar_const(expr) -> float:
+    v = np.asarray(expr.value, dtype=float)
+    if v.size != 1:
+        raise UnsupportedRelaxation("non-scalar constant/parameter")
+    return float(v.reshape(()))
+
+
+def _to_mcbox(expr, leaves, model):
+    """Interpret a scalar model expression into an MCBox over the current leaves."""
+    if isinstance(expr, (Constant, Parameter)):
+        return _mcbox._const(_scalar_const(expr), len(leaves))
+
+    off = _resolve_scalar_var_offset(expr, model)
+    if off is not None:
+        return leaves[off]
+    if isinstance(expr, Variable):
+        raise UnsupportedRelaxation("non-scalar variable leaf in scalar expression")
+
+    if isinstance(expr, UnaryOp):
+        a = _to_mcbox(expr.operand, leaves, model)
+        if expr.op == "neg":
+            return -a
+        raise UnsupportedRelaxation(f"unary op '{expr.op}'")
+
+    if isinstance(expr, BinaryOp):
+        op = expr.op
+        if op == "+":
+            return _to_mcbox(expr.left, leaves, model) + _to_mcbox(expr.right, leaves, model)
+        if op == "-":
+            return _to_mcbox(expr.left, leaves, model) - _to_mcbox(expr.right, leaves, model)
+        if op == "*":
+            return _to_mcbox(expr.left, leaves, model) * _to_mcbox(expr.right, leaves, model)
+        if op == "/":
+            if isinstance(expr.right, (Constant, Parameter)):
+                c = _scalar_const(expr.right)
+                if c == 0.0:
+                    raise UnsupportedRelaxation("division by zero constant")
+                return _to_mcbox(expr.left, leaves, model) * (1.0 / c)
+            raise UnsupportedRelaxation("division by a non-constant")
+        if op == "**":
+            if not isinstance(expr.right, (Constant, Parameter)):
+                raise UnsupportedRelaxation("non-constant exponent")
+            p = _scalar_const(expr.right)
+            try:
+                return _to_mcbox(expr.left, leaves, model) ** p
+            except UnsupportedMcboxOp as e:
+                raise UnsupportedRelaxation(str(e)) from e
+        raise UnsupportedRelaxation(f"binary op '{op}'")
+
+    if isinstance(expr, FunctionCall):
+        if len(expr.args) != 1:
+            raise UnsupportedRelaxation(f"multi-arg function '{expr.func_name}'")
+        a = _to_mcbox(expr.args[0], leaves, model)
+        fn = getattr(_mcbox, expr.func_name, None)
+        if fn is None or not callable(fn):
+            raise UnsupportedRelaxation(f"function '{expr.func_name}'")
+        try:
+            return fn(a)
+        except UnsupportedMcboxOp as e:
+            raise UnsupportedRelaxation(str(e)) from e
+
+    raise UnsupportedRelaxation(f"node type {type(expr).__name__}")
+
+
+@dataclass
+class ReducedRelaxation:
+    obj_under: Callable  # convex underestimator of the objective (minimize form)
+    con_feas: list  # convex h_i(x) with h_i<=0 the relaxed feasibility
+    negate: bool
+    n: int
+
+
+def build_reduced_relaxation(model, node_lb, node_ub) -> ReducedRelaxation:
+    """Build the sound reduced-space McCormick relaxation (MCBox), or raise.
+
+    Raises :class:`UnsupportedRelaxation` if any part is outside MCBox scope. The
+    objective/constraint closures interpret the AST into MCBox at each point (jit-able);
+    a concrete trial build at the box midpoint surfaces unsupported structure eagerly.
+    """
+    lb = np.asarray(node_lb, dtype=float)
+    ub = np.asarray(node_ub, dtype=float)
+    n = int(lb.size)
+    negate = model._objective.sense == ObjectiveSense.MAXIMIZE
+    obj_expr = model._objective.expression
+
+    def obj_under(x):
+        z = _to_mcbox(obj_expr, mcbox_leaves(x, lb, ub), model)
+        return -z.cc if negate else z.cv
+
+    con_feas = []
+    for c in model._constraints:
+        if not isinstance(c, Constraint):
+            raise UnsupportedRelaxation(f"non-Constraint {type(c).__name__}")
+        body, sense = c.body, c.sense
+
+        if sense in ("<=", "=="):
+            con_feas.append(lambda x, b=body: _to_mcbox(b, mcbox_leaves(x, lb, ub), model).cv)
+        if sense in (">=", "=="):
+            con_feas.append(lambda x, b=body: -_to_mcbox(b, mcbox_leaves(x, lb, ub), model).cc)
+
+    # eager buildability check (concrete midpoint) so the caller can fall back
+    mid = jnp.asarray(0.5 * (lb + ub))
+    _ = float(obj_under(mid))
+    for h in con_feas:
+        _ = float(h(mid))
+    return ReducedRelaxation(obj_under=obj_under, con_feas=con_feas, negate=negate, n=n)
+
+
+def _np_grad(fn: Callable) -> Callable:
+    g = jax.grad(lambda z: fn(z))
+    return lambda x: np.asarray(g(jnp.asarray(x)), dtype=float)
+
+
+@dataclass
+class ReducedBound:
+    bound: float
+    status: str  # optimal | infeasible | unbounded | unsupported
+    rounds: int
+    history: list
+
+
+def reduced_mccormick_lp_bound(
+    model, node_lb, node_ub, *, max_rounds: int = 40, tol: float = 1e-7
+) -> ReducedBound:
+    """MAiNGO-style reduced-space lower bound: Kelley cutting planes on the MCBox
+    relaxation, solved as an LP over the original variables (no auxiliary columns).
+    scipy/HiGHS scaffold for the inner LP; P2 wires the in-house simplex."""
+    import scipy.optimize as sopt
+
+    try:
+        R = build_reduced_relaxation(model, node_lb, node_ub)
+    except UnsupportedRelaxation:
+        return ReducedBound(bound=-np.inf, status="unsupported", rounds=0, history=[])
+
+    lb = np.asarray(node_lb, dtype=float)
+    ub = np.asarray(node_ub, dtype=float)
+    n = R.n
+    gu = _np_grad(R.obj_under)
+    ghs = [_np_grad(h) for h in R.con_feas]
+
+    c = np.zeros(n + 1)
+    c[n] = 1.0
+    bounds = [(float(lb[i]), float(ub[i])) for i in range(n)] + [(None, None)]
+    A: list = []
+    rhs: list = []
+    xk = 0.5 * (lb + ub)
+    prev, bound = -np.inf, -np.inf
+    history: list = []
+
+    r = 0
+    for r in range(1, max_rounds + 1):
+        xj = jnp.asarray(xk)
+        u0 = float(R.obj_under(xj))
+        g = gu(xk)
+        if np.all(np.isfinite(g)) and np.isfinite(u0):
+            row = np.zeros(n + 1)
+            row[:n] = g
+            row[n] = -1.0
+            A.append(row)
+            rhs.append(float(g @ xk - u0))
+        for h, gh in zip(R.con_feas, ghs):
+            h0 = float(h(xj))
+            gg = gh(xk)
+            if np.all(np.isfinite(gg)) and np.isfinite(h0):
+                row = np.zeros(n + 1)
+                row[:n] = gg
+                A.append(row)
+                rhs.append(float(gg @ xk - h0))
+
+        res = sopt.linprog(
+            c, A_ub=np.asarray(A), b_ub=np.asarray(rhs), bounds=bounds, method="highs"
+        )
+        if not res.success:
+            msg = (res.message or "").lower()
+            if "infeasible" in msg:
+                return ReducedBound(bound=np.inf, status="infeasible", rounds=r, history=history)
+            if "unbounded" in msg:
+                return ReducedBound(bound=-np.inf, status="unbounded", rounds=r, history=history)
+            break
+        bound = float(res.fun)
+        history.append(bound)
+        xk = np.asarray(res.x[:n], dtype=float)
+        if bound - prev < tol * (abs(bound) + 1.0):
+            break
+        prev = bound
+
+    dual = -bound if R.negate else bound
+    return ReducedBound(bound=dual, status="optimal", rounds=r, history=history)

--- a/python/tests/test_mccormick_subgradient.py
+++ b/python/tests/test_mccormick_subgradient.py
@@ -145,8 +145,10 @@ def test_kelley_bound_indef_qp_valid_and_tight():
     m = dm.Model()
     x = m.continuous("x", 2, lb=0.0, ub=4.0)
     m.minimize(x[0] * x[1] - x[0] ** 2 + 2.0 * x[1])
+
     def f(z):
         return z[0] * z[1] - z[0] ** 2 + 2 * z[1]
+
     r = reduced_mccormick_lp_bound(m, [0.0, 0.0], [4.0, 4.0])
     tmin = _sampled_min(f, np.array([0.0, 0.0]), np.array([4.0, 4.0]), 2)
     assert r.status == "optimal"
@@ -159,8 +161,10 @@ def test_kelley_bound_valid_with_quadratic_constraint():
     x = m.continuous("x", 2, lb=-2.0, ub=3.0)
     m.minimize(x[0] ** 2 - 3.0 * x[0] * x[1])
     m.subject_to(x[0] * x[1] - 2.0 <= 0)
+
     def f(z):
         return z[0] ** 2 - 3 * z[0] * z[1]
+
     r = reduced_mccormick_lp_bound(m, [-2.0, -2.0], [3.0, 3.0])
     tmin = _sampled_min(
         f, np.array([-2.0, -2.0]), np.array([3.0, 3.0]), 2, feas=lambda z: z[0] * z[1] - 2.0 <= 0

--- a/python/tests/test_mccormick_subgradient.py
+++ b/python/tests/test_mccormick_subgradient.py
@@ -1,0 +1,202 @@
+"""Soundness of the reduced-space McCormick subgradient evaluator (#572).
+
+The reduced-space evaluator must produce a GENUINE McCormick underestimator over
+the original variables (not the collapse-to-exact-function that the compiled
+relaxation fns give at x_cv==x_cc), so that jax.grad yields a VALID subgradient
+usable for MAiNGO-style linearized lower-bounding cuts. These tests pin:
+  - envelope correctness (x*y at an interior point = the McCormick value, not x*y)
+  - validity (cv <= f on the box)
+  - convexity of cv
+  - subgradient validity (cv is above every tangent)
+  - bound validity (min cv <= min f)
+  - loud refusal outside the sound v1 scope (no silent invalid bound)
+"""
+
+import os
+
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+import discopt.modeling as dm
+import jax
+import jax.numpy as jnp
+import numpy as np
+from discopt._jax.mccormick_subgradient import (
+    build_reduced_relaxation,
+    reduced_mccormick_lp_bound,
+)
+
+RNG = np.random.default_rng(0)
+
+
+def _sound(model, lb, ub, f_true, n_samples=300):
+    R = build_reduced_relaxation(model, lb, ub)
+    u = R.obj_under
+    n = R.n
+    P = lb + RNG.random((n_samples, n)) * (ub - lb)
+    # validity: u(x) <= f(x)
+    for x in P:
+        assert float(u(jnp.asarray(x))) <= float(f_true(x)) + 1e-6 * (abs(float(f_true(x))) + 1)
+    # convexity + subgradient validity
+    gu = jax.grad(lambda z: u(z))
+    for _ in range(120):
+        a = lb + RNG.random(n) * (ub - lb)
+        b = lb + RNG.random(n) * (ub - lb)
+        mid = 0.5 * (a + b)
+        assert (
+            float(u(jnp.asarray(mid)))
+            <= 0.5 * (float(u(jnp.asarray(a))) + float(u(jnp.asarray(b)))) + 1e-6
+        )
+        u_a = float(u(jnp.asarray(a)))
+        g = np.asarray(gu(jnp.asarray(a)))
+        assert float(u(jnp.asarray(b))) >= u_a + g @ (b - a) - 1e-6 * (abs(u_a) + 1)
+    # bound validity: min cv <= min f (sampled)
+    min_u = min(float(u(jnp.asarray(x))) for x in P)
+    min_f = min(float(f_true(x)) for x in P)
+    assert min_u <= min_f + 1e-6 * (abs(min_f) + 1)
+
+
+def test_bilinear_envelope_not_collapse():
+    """x*y on [0,4]^2: cv at (1,1) is the McCormick envelope value 0, not 1."""
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=0.0, ub=4.0)
+    m.minimize(x[0] * x[1])
+    R = build_reduced_relaxation(m, np.array([0.0, 0.0]), np.array([4.0, 4.0]))
+    assert abs(float(R.obj_under(jnp.array([1.0, 1.0])))) < 1e-9
+
+
+def test_bilinear_sound():
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=0.0, ub=4.0)
+    m.minimize(x[0] * x[1])
+    _sound(m, np.array([0.0, 0.0]), np.array([4.0, 4.0]), lambda x: x[0] * x[1])
+
+
+def test_indefinite_qp_sound():
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=0.0, ub=4.0)
+    m.minimize(x[0] * x[1] - x[0] ** 2 + 2.0 * x[1])
+    _sound(
+        m, np.array([0.0, 0.0]), np.array([4.0, 4.0]), lambda x: x[0] * x[1] - x[0] ** 2 + 2 * x[1]
+    )
+
+
+def test_qp_with_quadratic_constraint_sound():
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=-2.0, ub=3.0)
+    m.minimize(x[0] ** 2 - 3.0 * x[0] * x[1])
+    m.subject_to(x[0] * x[1] - 2.0 <= 0)
+    _sound(m, np.array([-2.0, -2.0]), np.array([3.0, 3.0]), lambda x: x[0] ** 2 - 3 * x[0] * x[1])
+
+
+def test_even_power_sound():
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=-2.0, ub=3.0)
+    m.minimize(x[0] ** 4 - 2.0 * x[0] * x[1])
+    _sound(m, np.array([-2.0, -2.0]), np.array([3.0, 3.0]), lambda x: x[0] ** 4 - 2 * x[0] * x[1])
+
+
+def test_odd_power_positive_base_sound():
+    """x**3 over a positive-base box (like st_e36) is monotone convex -> sound."""
+    m = dm.Model()
+    x = m.continuous("x", 1, lb=1.0, ub=4.0)
+    m.minimize(x[0] ** 3)
+    _sound(m, np.array([1.0]), np.array([4.0]), lambda x: x[0] ** 3)
+
+
+def test_odd_power_spanning_zero_now_sound():
+    """P0.3: MCBox relaxes x**3 over a sign-spanning base soundly (repeated-mult),
+    where the v1 evaluator had to refuse it. The bound must be a valid lower bound."""
+    m = dm.Model()
+    x = m.continuous("x", 1, lb=-2.0, ub=2.0)
+    m.minimize(x[0] ** 3)
+    R = build_reduced_relaxation(m, np.array([-2.0]), np.array([2.0]))
+    P = -2.0 + RNG.random((300, 1)) * 4.0
+    for p in P:
+        assert float(R.obj_under(jnp.asarray(p))) <= float(p[0] ** 3) + 1e-6
+
+
+def test_transcendental_now_sound():
+    """P0.3: MCBox relaxes exp(x)*x soundly (exp + general product) where v1 refused."""
+    m = dm.Model()
+    x = m.continuous("x", 1, lb=0.1, ub=3.0)
+    m.minimize(dm.exp(x[0]) * x[0])
+    r = reduced_mccormick_lp_bound(m, [0.1], [3.0])
+    assert r.status == "optimal"
+    true_min = min(float(np.exp(p) * p) for p in np.linspace(0.1, 3.0, 2000))
+    assert r.bound <= true_min + 1e-4  # valid lower bound
+
+
+def _sampled_min(f, lb, ub, n, k=30000, feas=None):
+    P = lb + RNG.random((k, n)) * (ub - lb)
+    vals = [float(f(x)) for x in P if (feas is None or feas(x))]
+    return min(vals)
+
+
+def test_kelley_bound_bilinear_exact():
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=0.0, ub=4.0)
+    m.minimize(x[0] * x[1])
+    r = reduced_mccormick_lp_bound(m, [0.0, 0.0], [4.0, 4.0])
+    assert r.status == "optimal"
+    assert abs(r.bound) < 1e-6  # true min is 0
+    assert r.rounds <= 6  # converges in a few Kelley rounds
+
+
+def test_kelley_bound_indef_qp_valid_and_tight():
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=0.0, ub=4.0)
+    m.minimize(x[0] * x[1] - x[0] ** 2 + 2.0 * x[1])
+    def f(z):
+        return z[0] * z[1] - z[0] ** 2 + 2 * z[1]
+    r = reduced_mccormick_lp_bound(m, [0.0, 0.0], [4.0, 4.0])
+    tmin = _sampled_min(f, np.array([0.0, 0.0]), np.array([4.0, 4.0]), 2)
+    assert r.status == "optimal"
+    assert r.bound <= tmin + 1e-4  # valid lower bound
+    assert r.bound >= tmin - 2.0  # and tight (near-exact on this QP)
+
+
+def test_kelley_bound_valid_with_quadratic_constraint():
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=-2.0, ub=3.0)
+    m.minimize(x[0] ** 2 - 3.0 * x[0] * x[1])
+    m.subject_to(x[0] * x[1] - 2.0 <= 0)
+    def f(z):
+        return z[0] ** 2 - 3 * z[0] * z[1]
+    r = reduced_mccormick_lp_bound(m, [-2.0, -2.0], [3.0, 3.0])
+    tmin = _sampled_min(
+        f, np.array([-2.0, -2.0]), np.array([3.0, 3.0]), 2, feas=lambda z: z[0] * z[1] - 2.0 <= 0
+    )
+    assert r.status == "optimal"
+    assert r.bound <= tmin + 1e-4  # valid (looser: McCormick constraint relaxation)
+
+
+def test_kelley_bound_detects_infeasible_relaxation():
+    m = dm.Model()
+    x = m.continuous("x", 1, lb=0.0, ub=1.0)
+    m.minimize(x[0])
+    m.subject_to(x[0] >= 5.0)  # infeasible over the box
+    r = reduced_mccormick_lp_bound(m, [0.0], [1.0])
+    assert r.status == "infeasible"
+
+
+def test_kelley_bound_unsupported_returns_flag_not_crash():
+    # division by a variable is still outside MCBox scope -> clean fallback, no crash
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=1.0, ub=3.0)
+    m.minimize(x[0] / x[1])
+    r = reduced_mccormick_lp_bound(m, [1.0, 1.0], [3.0, 3.0])
+    assert r.status == "unsupported"  # falls back cleanly; no partial/invalid bound
+
+
+def test_maximize_sense_valid_lower_bound():
+    """For a maximize model the reduced bound (in min form) must stay valid."""
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=0.0, ub=4.0)
+    m.maximize(-(x[0] * x[1]))
+    R = build_reduced_relaxation(m, np.array([0.0, 0.0]), np.array([4.0, 4.0]))
+    # obj_under is in minimize form: minimizing -(-(x*y)) = minimizing x*y form.
+    P = np.array([0.0, 0.0]) + RNG.random((200, 2)) * 4.0
+    for x0 in P:
+        # obj_under underestimates the minimize-form objective (-f for maximize)
+        assert float(R.obj_under(jnp.asarray(x0))) <= -(-(x0[0] * x0[1])) + 1e-6 + 1e-6 * abs(
+            x0[0] * x0[1]
+        )


### PR DESCRIPTION
## Summary

MAiNGO-parity plan **P0.3**. Ports the #572 reduced-space McCormick evaluator + Kelley-cut LP bound onto the **MCBox** type (merged in #574). The model AST is now interpreted into `MCBox` operations (`_to_mcbox`) instead of hand-rolled `(cv, cc)` closures — so relaxation *and* subgradients propagate by rule, and the scope widens to everything MCBox supports.

**Library-only** — nothing on the default solve path (P2 wires the `DISCOPT_RELAX_SPACE=reduced` mode).

## Strictly more capable than the v1 evaluator

MCBox handles general (non-affine) products and transcendental composition, which the v1 QP-scope evaluator had to refuse. Concretely:
- The **12 core v1 tests** (bilinear/QP soundness, Kelley convergence, infeasible-relaxation detection, maximize sense) pass **unchanged** — the regression floor.
- Two v1 *refusal* tests flip to **soundness** tests, because MCBox now produces valid bounds where v1 refused: `x**3` over a sign-spanning base (via sound repeated-multiplication) and `exp(x)*x` (exp + general product).
- The unsupported-fallback test now uses variable division (`x/y`, still out of MCBox scope) to keep the sound-or-refuse guarantee covered.

Public API unchanged: `UnsupportedRelaxation`, `build_reduced_relaxation`, `reduced_mccormick_lp_bound`, `ReducedRelaxation`, `ReducedBound`. Inner LP is still the scipy/HiGHS scaffold; **P2** swaps in the in-house simplex.

## Tests

`python/tests/test_mccormick_subgradient.py` — **14/14**. Ran `pytest` (14/14), `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
