### PR TITLE
feat(mcbox): P1.2 — variable division via sign-definite reciprocal

### DIFF
--- a/python/discopt/_jax/mcbox.py
+++ b/python/discopt/_jax/mcbox.py
@@ -25,7 +25,9 @@ Design (validated by the P0.1 entry experiment):
   incoming subgradients. This avoids ``jax.grad`` over a possibly-nonconvex composite.
 
 Scope: affine arithmetic, general bilinear product (all sign regimes), integer powers
-via sign-agnostic repeated multiplication, constant division, the provably-convex-
+via sign-agnostic repeated multiplication, constant division and sign-definite
+variable division (x/y via the reciprocal; no-info bracket when y crosses 0), the
+provably-convex-
 envelope intrinsics exp/log/log2/log10/sqrt/softplus/abs (kernel-chain subgradient),
 and (P1.1) the S-shaped intrinsics tanh/atan/sigmoid/sinh — tight kernel-chain on a
 box that doesn't span the inflection, a sound constant-envelope fallback (jnp.where)
@@ -103,7 +105,7 @@ class MCBox:
 
     def __truediv__(self, o):
         if isinstance(o, MCBox):
-            raise UnsupportedMcboxOp("division by a non-constant (P1: sign-definite reciprocal)")
+            return _bilinear(self, _reciprocal(o))  # x/y = x * (1/y), sign-definite y
         c = jnp.asarray(o, dtype=jnp.float64)
         return _scalar_mul(self, 1.0 / c)
 
@@ -121,9 +123,8 @@ class MCBox:
             out = out * self
         return out
 
-    # -- univariate intrinsics: only envelopes whose cv is provably convex, so the
-    #    kernel-chain subgradient is valid. Regime/S-shaped ops (tanh/atan/sigmoid/
-    #    sinh) need per-regime subgradient selection -> P1.1 (refuse for now). --
+    # -- univariate intrinsics with provably-convex envelopes: the kernel-chain
+    #    subgradient is valid directly (see _univariate). --
     def exp(self):
         return _univariate(self, "exp", jnp.exp)
 
@@ -225,6 +226,53 @@ def _univariate(a, name, scalar_f, monotone_inc=True):
         e = (scalar_f(a.lo), scalar_f(a.hi))
         interval = (jnp.where((a.lo < 0) & (a.hi > 0), 0.0, jnp.minimum(*e)), jnp.maximum(*e))
     return _univariate_kernel(a, kernel, interval)
+
+
+def _recip_kernel(cvg, ccg, lb, ub):
+    """Composition kernel for 1/y over a SIGN-DEFINITE box (0 not in [lb, ub]).
+
+    y>0: 1/y is convex decreasing -> cv = 1/cc_g (value at the cc branch, the
+    argmin of the decreasing envelope), cc = secant at cv_g. y<0: 1/y is concave
+    decreasing -> cv = secant at cc_g, cc = 1/cv_g. The secant is the chord of 1/y
+    on [lb, ub]. Differentiable in (cv_g, cc_g), so the kernel-chain subgradient is
+    valid (cv is convex in both sign regimes)."""
+    # McCormick mid-rule clamp: the operand's relaxation values bracket the true y in
+    # [lb, ub], but a loose inner relaxation (e.g. y*y) can push cv_g below lb / cc_g
+    # above ub; clamp into the valid interval first (still valid bounds on y, and where
+    # 1/y is defined) so the reciprocal never extrapolates the secant / 1/(.) outside
+    # the domain. Preserves soundness; gradient saturates on the clamped region.
+    cvg = jnp.clip(cvg, lb, ub)
+    ccg = jnp.clip(ccg, lb, ub)
+    width = ub - lb
+    slope = (1.0 / ub - 1.0 / lb) / jnp.where(jnp.abs(width) > 1e-12, width, 1.0)
+
+    def sec(t):
+        return 1.0 / lb + slope * (t - lb)
+
+    pos = lb > 0.0
+    cv = jnp.where(pos, 1.0 / ccg, sec(ccg))
+    cc = jnp.where(pos, sec(cvg), 1.0 / cvg)
+    return cv, cc
+
+
+def _reciprocal(b):
+    """1/b as an MCBox. Sound-or-refuse: if the denominator interval crosses zero
+    the reciprocal is unbounded, so return a no-information bracket (-inf, +inf)
+    (any downstream consumer of a non-finite bracket refuses); jit-safe via
+    ``jnp.where``. Degenerate (lo==hi) reduces to the exact constant 1/lo."""
+    lo, hi = b.lo, b.hi
+    interval = (1.0 / hi, 1.0 / lo)  # 1/y is decreasing: min at hi, max at lo
+    r = _univariate_kernel(b, _recip_kernel, interval)
+    crosses = (lo <= 0.0) & (hi >= 0.0)
+    zero = jnp.zeros_like(b.sub_cv)
+    return MCBox(
+        jnp.where(crosses, -jnp.inf, r.cv),
+        jnp.where(crosses, jnp.inf, r.cc),
+        jnp.where(crosses, -jnp.inf, r.lo),
+        jnp.where(crosses, jnp.inf, r.hi),
+        jnp.where(crosses, zero, r.sub_cv),
+        jnp.where(crosses, zero, r.sub_cc),
+    )
 
 
 def _sigmoidal(a, name, scalar_f):

--- a/python/discopt/_jax/mccormick_subgradient.py
+++ b/python/discopt/_jax/mccormick_subgradient.py
@@ -78,7 +78,8 @@ def _to_mcbox(expr, leaves, model):
                 if c == 0.0:
                     raise UnsupportedRelaxation("division by zero constant")
                 return _to_mcbox(expr.left, leaves, model) * (1.0 / c)
-            raise UnsupportedRelaxation("division by a non-constant")
+            # variable division via the sign-definite reciprocal (P1.2)
+            return _to_mcbox(expr.left, leaves, model) / _to_mcbox(expr.right, leaves, model)
         if op == "**":
             if not isinstance(expr.right, (Constant, Parameter)):
                 raise UnsupportedRelaxation("non-constant exponent")

--- a/python/tests/test_mcbox.py
+++ b/python/tests/test_mcbox.py
@@ -168,14 +168,38 @@ def test_jit_and_vmap_over_boxes():
     assert bool(jnp.all(cv <= cc + 1e-9))
 
 
+# ---- variable division via sign-definite reciprocal (P1.2) ----
+def test_division_positive_denominator():
+    _check(lambda x, y: x / y, lambda v: v[0] / v[1], [0.5, 1.0], [3.0, 4.0])
+
+
+def test_division_negative_denominator():
+    _check(lambda x, y: x / y, lambda v: v[0] / v[1], [0.5, -4.0], [3.0, -1.0])
+
+
+def test_division_nonaffine_denominator():
+    # (x+1)/(y*y+1): non-affine MCBox denominator with a provably-positive interval
+    # (y non-spanning, so the y*y bilinear interval stays >= 0 and the reciprocal is
+    # well-defined; a spanning y would make the loose y*y interval cross 0 and the
+    # reciprocal correctly returns a no-information bracket instead of a wrong bound).
+    _check(
+        lambda x, y: (x + 1.0) / (y * y + 1.0),
+        lambda v: (v[0] + 1.0) / (v[1] * v[1] + 1.0),
+        [-1.0, 0.5],
+        [2.0, 2.0],
+    )
+
+
+def test_division_zero_crossing_denominator_noinfo():
+    # denominator interval spans 0 -> reciprocal is unbounded -> no-information
+    # bracket (non-finite cv/cc), jit-safe and never a wrong finite bound.
+    z = relax_through(
+        lambda x, y: x / y, jnp.array([1.0, 1.0]), jnp.array([1.0, -2.0]), jnp.array([2.0, 2.0])
+    )
+    assert not bool(jnp.isfinite(z.cv)) and not bool(jnp.isfinite(z.cc))
+
+
 # ---- sound-or-refuse ----
 def test_refuse_noninteger_power():
     with pytest.raises(UnsupportedMcboxOp):
         relax_through(lambda x: x**1.5, jnp.array([1.0]), jnp.array([0.5]), jnp.array([3.0]))
-
-
-def test_refuse_var_division():
-    with pytest.raises(UnsupportedMcboxOp):
-        relax_through(
-            lambda x, y: x / y, jnp.array([1.0, 1.0]), jnp.array([0.0, 1.0]), jnp.array([2.0, 3.0])
-        )

--- a/python/tests/test_mccormick_subgradient.py
+++ b/python/tests/test_mccormick_subgradient.py
@@ -183,12 +183,23 @@ def test_kelley_bound_detects_infeasible_relaxation():
 
 
 def test_kelley_bound_unsupported_returns_flag_not_crash():
-    # division by a variable is still outside MCBox scope -> clean fallback, no crash
+    # a non-integer power is still outside MCBox scope -> clean fallback, no crash
+    # (variable division x/y is now supported via the sign-definite reciprocal, P1.2)
+    m = dm.Model()
+    x = m.continuous("x", 1, lb=0.5, ub=3.0)
+    m.minimize(x[0] ** 1.5)
+    r = reduced_mccormick_lp_bound(m, [0.5], [3.0])
+    assert r.status == "unsupported"  # falls back cleanly; no partial/invalid bound
+
+
+def test_kelley_bound_variable_division_sound():
+    # P1.2: min x/y over [1,3]x[1,3] -> reduced-space McCormick certifies the true min 1/3
     m = dm.Model()
     x = m.continuous("x", 2, lb=1.0, ub=3.0)
     m.minimize(x[0] / x[1])
     r = reduced_mccormick_lp_bound(m, [1.0, 1.0], [3.0, 3.0])
-    assert r.status == "unsupported"  # falls back cleanly; no partial/invalid bound
+    assert r.status == "optimal"
+    assert r.bound <= 1.0 / 3.0 + 1e-4  # valid lower bound on the true min 1/3
 
 
 def test_maximize_sense_valid_lower_bound():


### PR DESCRIPTION
## Summary

MAiNGO-parity plan **P1.2**. Adds **variable division** to the `MCBox` type via a sign-definite reciprocal, and confirms the general product rule was already complete.

Two findings:
1. **Non-affine products already relax soundly** through MCBox's `_bilinear` — the P0.2 product rule is the full multivariate McCormick product and never assumed affine operands (unlike the v1 evaluator). `exp(x)*log(y)` etc. bracket with valid subgradients. So P1.2's only real remaining content is division.
2. **`x/y = x·(1/y)`** via a new `_reciprocal` over a **sign-definite** denominator:
   - `y>0`: `1/y` convex decreasing → `cv = 1/cc_g`, `cc = secant`.
   - `y<0`: `1/y` concave decreasing → `cv = secant`, `cc = 1/cv_g`.
   - Kernel-chain subgradient valid (`cv` convex in both regimes).
   - **McCormick mid-rule clamp**: the operand's relaxation values are clipped into `[lo,hi]` before the reciprocal, so a loose inner relaxation (e.g. `y*y` dipping below its interval) never makes the secant / `1/(·)` extrapolate out of domain — a real soundness fix caught by the property tests.
   - If the denominator **interval crosses zero** the reciprocal is unbounded → a **no-information bracket** `(-inf,+inf)` via `jnp.where` (jit-safe; a consumer of a non-finite bracket refuses) — never a wrong finite bound.

`mccormick_subgradient._to_mcbox` now routes non-constant division through this; the reduced-space `min x/y` over `[1,3]²` certifies the exact `1/3`.

## Tests

- `test_mcbox.py` **30/30** — division (`+`/`−` denominators), non-affine positive denominator, zero-crossing no-info.
- `test_mccormick_subgradient.py` **15/15** — reduced-space `x/y` sound; the unsupported-fallback test moves to a non-integer power (still out of scope).

`ruff`/`format` clean. Library-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
