### PR TITLE
fix(mcbox): reduced-space evaluator refuses non-finite boxes (nvs22 false-optimal root cause #1)

### DIFF
--- a/python/discopt/_jax/mccormick_subgradient.py
+++ b/python/discopt/_jax/mccormick_subgradient.py
@@ -40,6 +40,19 @@ class UnsupportedRelaxation(Exception):
     """Model is outside the sound reduced-space scope — caller falls back (α-BB/lifted)."""
 
 
+def _require_finite_box(lb, ub) -> None:
+    """McCormick envelopes require a FINITE box: over an unbounded variable the
+    product/composition envelopes degrade to non-information ``(-inf, +inf)`` and the
+    linearized cuts carry NaN/inf, which can corrupt (or crash) the LP and, worse,
+    let a node be fathomed on a bogus bound. Refuse rather than approximate — the
+    caller falls back to the lifted path (which handles unbounded columns via its own
+    guards). This is the sound-or-refuse contract."""
+    lb = np.asarray(lb, dtype=float)
+    ub = np.asarray(ub, dtype=float)
+    if not (np.all(np.isfinite(lb)) and np.all(np.isfinite(ub))):
+        raise UnsupportedRelaxation("reduced-space McCormick requires a finite box")
+
+
 def _scalar_const(expr) -> float:
     v = np.asarray(expr.value, dtype=float)
     if v.size != 1:
@@ -122,6 +135,7 @@ def build_reduced_relaxation(model, node_lb, node_ub) -> ReducedRelaxation:
     """
     lb = np.asarray(node_lb, dtype=float)
     ub = np.asarray(node_ub, dtype=float)
+    _require_finite_box(lb, ub)
     n = int(lb.size)
     negate = model._objective.sense == ObjectiveSense.MAXIMIZE
     obj_expr = model._objective.expression
@@ -156,6 +170,7 @@ def _build_jit_evaluator(model, lb, ub):
     underestimator (minimize form) value/subgradient; ``h`` (m,) / ``gh`` (m, n) are the
     per-constraint feasibility values/subgradients (``h_i <= 0`` relaxed). Raises
     :class:`UnsupportedRelaxation` on first call (compile) if out of MCBox scope."""
+    _require_finite_box(lb, ub)
     lbj, ubj = jnp.asarray(lb), jnp.asarray(ub)
     n = int(lb.size)
     negate = model._objective.sense == ObjectiveSense.MAXIMIZE

--- a/python/tests/test_mccormick_subgradient.py
+++ b/python/tests/test_mccormick_subgradient.py
@@ -19,7 +19,9 @@ import discopt.modeling as dm
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from discopt._jax.mccormick_subgradient import (
+    UnsupportedRelaxation,
     build_reduced_relaxation,
     reduced_mccormick_lp_bound,
 )
@@ -215,3 +217,19 @@ def test_maximize_sense_valid_lower_bound():
         assert float(R.obj_under(jnp.asarray(x0))) <= -(-(x0[0] * x0[1])) + 1e-6 + 1e-6 * abs(
             x0[0] * x0[1]
         )
+
+
+def test_reduced_bound_refuses_unbounded_box():
+    # McCormick needs a finite box; an unbounded variable must refuse -> caller falls
+    # back to lifted (never a crash, never a bogus bound). Root cause of the nvs22
+    # unbounded-leaf class in the P2.3 gate.
+    import numpy as np
+
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=0.5, ub=4.0)
+    m.minimize(x[0])
+    m.subject_to(x[0] * x[1] - 4.0 == 0)
+    r = reduced_mccormick_lp_bound(m, [0.5, -np.inf], [4.0, np.inf])
+    assert r.status == "unsupported"
+    with pytest.raises(UnsupportedRelaxation):
+        build_reduced_relaxation(m, np.array([0.5, -np.inf]), np.array([4.0, np.inf]))


### PR DESCRIPTION
The P2.3 reduced-mode gate found a false optimal on **nvs22**: `reduced_mccormick_lp_bound` could crash / return a bogus bound on a model with **unbounded variables** — over an unbounded box the McCormick envelopes degrade to `(-inf,+inf)` and the Kelley cuts carry NaN/inf.

Add `_require_finite_box`: `build_reduced_relaxation` + the jitted evaluator RAISE `UnsupportedRelaxation` on any non-finite bound -> `reduced_mccormick_lp_bound` returns `unsupported` -> solver falls back to lifted. Sound-or-refuse; no crash, no bogus bound. **Fixes the nvs22 false-optimal in the solver** (its root box has unbounded x4-x7 -> reduced build refuses at root -> lifted fallback).

A separate nvs22-specific FINITE-box false-infeasible (relaxation inversion on the equality/division/sqrt class) remains under investigation. Library-only. 16/16 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)