### PR TITLE
feat(mcbox): P2.3 — wire DISCOPT_RELAX_SPACE=reduced (MAiNGO parity, default-OFF, sound on nvs22)

### DIFF
--- a/docs/dev/maingo-parity-plan.md
+++ b/docs/dev/maingo-parity-plan.md
@@ -415,7 +415,7 @@ remainder enclosure; kill if the enclosure blows up on the motivating model).
 | P1.3–P1.4 coverage | not started | P1.3 tight monomial hull (`x**n` via relax_pow, tighter than repeated-mult); P1.4 fractional powers/signomials. P1.1b: tight sigmoidal spanning envelope. |
 | P2.1 jit Kelley | not started | eager baseline: 12–23 s / 15 rounds (nvs19/24) |
 | P2.2 in-house LP | not started | de-risk: check `RefacFtTinyPivot` ≈ 0 on Kelley bases |
-| P2.3 mode wiring | not started | |
+| P2.3 mode wiring | **BLOCKED — NO-GO (2026-07-10)** | Wiring done on branch `feat/relax-space-p2.3` (`solver_tuning.relax_space` + env `DISCOPT_RELAX_SPACE`, reduced bound fed into both the batched and serial node loops, sound-or-refuse fallback). **Default byte-identical: PASS** (11-instance panel: node_count + certified objective identical for unset/lifted/auto). **Feasible-point soundness of the reduced bound: PASS** (74,015 samples, 0 cuts). **HARD GATE FAILURE — a FALSE OPTIMAL:** on `nvs22` (in-corpus MINLP, oracle 6.0582) reduced mode certifies **11.4393 as "optimal"**. Root cause is UPSTREAM, not the wiring: `reduced_mccormick_lp_bound` returns **false `infeasible`** on a node box that provably contains the feasible optimum (reproduced directly: box of half-width 1 around x\* → status `infeasible`), so the node holding the optimum is (correctly, per the status contract) fathomed. The reduced *bound* is sound on the boxes tested (≤ true box-min); the defect is the **infeasibility detection** for the equality-constrained division/sqrt intermediate class (nvs22 also has unbounded x4–x7 leaves the builder does NOT refuse). Reduced mode CANNOT be wired into the solver until the evaluator's soundness/scope guard is fixed (P0/P1 layer). nodes/s note: reduced is ~5× slower per node on st\_e36 (137 nodes @1.2 nps vs lifted 153 @5.8 nps) — speed was never the P2.3 justification (§0.1), but there is no speed win to offset the soundness break. |
 | P2.4 auto policy | blocked on P2.3 | |
 | P2.5 hybrid | deferred | |
 | P3.1 CustomCall relax | not started | prototype P3.3 first |
@@ -434,6 +434,17 @@ Prior falsifications binding on this plan (§4 of CLAUDE.md — measurements win
   root bounds on QPs.
 - The FT-storm motivation for reduced space is **gone** (#573 density route);
   §0.1's capability framing is the binding rationale.
+- **The reduced-space evaluator is NOT yet sound on the full library** (P2.3
+  falsification, 2026-07-10): `reduced_mccormick_lp_bound` returns false
+  `infeasible` on `nvs22` (equality-constrained division/sqrt intermediates,
+  unbounded leaves), which fathoms the node holding the optimum → false optimal.
+  The `build_reduced_relaxation` scope guard is too permissive (accepts unbounded
+  leaves + this equality class it cannot soundly declare infeasible). P2.3 mode
+  wiring is BLOCKED on a P0/P1-layer fix: either (a) refuse this class at build
+  time (unbounded leaf / equality-of-nonconvex-intermediate) so the solver falls
+  back to lifted, and/or (b) fix the infeasibility test to never report empty on a
+  non-empty relaxed set. Do NOT re-enable reduced wiring until a corpus-wide
+  false-infeasible / false-optimal sweep is clean.
 
 ## 8. What "parity" means at the end
 

--- a/docs/dev/maingo-parity-plan.md
+++ b/docs/dev/maingo-parity-plan.md
@@ -411,11 +411,11 @@ remainder enclosure; kill if the enclosure blows up on the motivating model).
 | P0.2 MCBox module | **DONE (2026-07-11)** | `feat/mcbox-p0` commit `5d7fdf4f`: `_jax/mcbox.py` (MCBox pytree, arithmetic + bilinear + sign-agnostic repeated-mult powers + exp/log/log2/log10/sqrt/softplus/abs), `test_mcbox.py` **22/22**. **Finding (binding for P1.1):** the kernel-chain subgradient is valid **exactly for provably-convex envelopes** — the S-shaped ops (tanh/atan/sigmoid/sinh) have a non-convex cv over a sign-spanning box, so they *refuse* in P0.2 and move to P1.1 (per-regime subgradient selection). Powers are sound via repeated bilinear multiplication for all n≥1 and all signs (looser than the tight monomial hull → P1.3). Not merged (library-only; PR pending). |
 | P0.3 v1 port | **DONE — PR #575 (2026-07-11)** | `mccormick_subgradient.py` reimplemented on MCBox (`_to_mcbox` AST interpreter); 14/14. **Strictly more capable:** 12 core v1 tests unchanged (regression floor); 2 v1 refusal tests flipped to soundness (x**3 spanning, exp(x)*x now relax soundly). P0.2 (`5d7fdf4f`) merged in **#574**; density-route #557 fix merged in **#573**. |
 | P1.1 S-shaped ops | **DONE — PR #576 (2026-07-11)** | tanh/atan/sigmoid/sinh in MCBox: kernel-chain (tight) on non-spanning boxes, sound constant-envelope fallback (`jnp.where`, loose) on spanning boxes — jit/vmap-able. Diagnostic confirmed the sigmoidal cv is convex non-spanning, non-convex spanning (issue #51). test_mcbox 27/27. **P1.1b** follow-up: tight tangent envelope for the spanning case. P0.3 merged in **#575**. |
-| P1.2 division | **DONE — PR #577 (2026-07-11)** | Non-affine products already sound in `_bilinear` (P0.2). Added variable division `x/y` via sign-definite reciprocal (mid-rule clamp; no-info bracket when denom interval crosses 0). test_mcbox 30/30, reduced-space `min x/y`=exact 1/3. |
+| P1.2 division | **PARTIAL — reciprocal-of-affine only (2026-07-10)** | PR #577 added `x/y` via sign-definite reciprocal (mid-rule clamp; no-info bracket when denom crosses 0); sound for `1/(affine)`. **Correction (P2.3, nvs22):** the general **non-affine-denominator** case (`(A·x6)/((x2·x3)·(Σ-sq))`) produces an INVALID `cc` subgradient (numeric witness in §7 P2.3). `_to_mcbox` now REFUSES division by a non-affine denominator (sound-or-refuse); reciprocal-of-affine and non-affine *products* remain sound. FOLLOW-UP: a validated non-affine reciprocal subgradient to lift the refusal. test_mcbox 30/30, `min x/y`=exact 1/3 still hold. |
 | P1.3–P1.4 coverage | not started | P1.3 tight monomial hull (`x**n` via relax_pow, tighter than repeated-mult); P1.4 fractional powers/signomials. P1.1b: tight sigmoidal spanning envelope. |
 | P2.1 jit Kelley | not started | eager baseline: 12–23 s / 15 rounds (nvs19/24) |
 | P2.2 in-house LP | not started | de-risk: check `RefacFtTinyPivot` ≈ 0 on Kelley bases |
-| P2.3 mode wiring | **BLOCKED — NO-GO (2026-07-10)** | Wiring done on branch `feat/relax-space-p2.3` (`solver_tuning.relax_space` + env `DISCOPT_RELAX_SPACE`, reduced bound fed into both the batched and serial node loops, sound-or-refuse fallback). **Default byte-identical: PASS** (11-instance panel: node_count + certified objective identical for unset/lifted/auto). **Feasible-point soundness of the reduced bound: PASS** (74,015 samples, 0 cuts). **HARD GATE FAILURE — a FALSE OPTIMAL:** on `nvs22` (in-corpus MINLP, oracle 6.0582) reduced mode certifies **11.4393 as "optimal"**. Root cause is UPSTREAM, not the wiring: `reduced_mccormick_lp_bound` returns **false `infeasible`** on a node box that provably contains the feasible optimum (reproduced directly: box of half-width 1 around x\* → status `infeasible`), so the node holding the optimum is (correctly, per the status contract) fathomed. The reduced *bound* is sound on the boxes tested (≤ true box-min); the defect is the **infeasibility detection** for the equality-constrained division/sqrt intermediate class (nvs22 also has unbounded x4–x7 leaves the builder does NOT refuse). Reduced mode CANNOT be wired into the solver until the evaluator's soundness/scope guard is fixed (P0/P1 layer). nodes/s note: reduced is ~5× slower per node on st\_e36 (137 nodes @1.2 nps vs lifted 153 @5.8 nps) — speed was never the P2.3 justification (§0.1), but there is no speed win to offset the soundness break. |
+| P2.3 mode wiring | **SOUND, default-OFF (2026-07-10)** | Branch `feat/relax-space-p2.3`: `solver_tuning.relax_space` + env `DISCOPT_RELAX_SPACE` (default `lifted`), reduced bound fed into both the batched and serial node loops, sound-or-refuse fallback. **Default byte-identical: PASS** (11-instance panel unchanged). **Corpus soundness sweep: PASS, incorrect_count=0** across 21 MINLPLib instances (curated small + nvs19/24/st_e36/nvs22 + QPs) cross-checked vs `minlplib.solu` — no false-optimal, no invalid bound, no false-infeasible. **Feasible-point soundness: PASS** (74,015 samples, 0 cuts). **Adversarial suite with the flag ON: 10/10** (incl. nvs22). **nvs22 false-optimal FIXED** — three root causes: (1) unbounded leaves (#582 `_require_finite_box`); (2) the wiring fed the reduced evaluator the LIFTED node box (15 cols incl. ~1e8-bound factorable-reformulation aux vars) instead of the original DOF — fixed by building on `_prereform_model` and slicing node boxes to `_prereform_nvars`; (3) the deep defect — an **INVALID `cc` subgradient of the non-affine division** in nvs22 con2 (`(A·x6)/((x2·x3)·(Σ-of-squares))`), whose Kelley cut excluded the true optimum by ~1.7e5 (numeric witness: cut idx 20 at iterate `[1,1,1,1,42.2,1,1.12,0.064]`). Fixed sound-or-refuse: `_to_mcbox` now **refuses division by a non-affine denominator** (`UnsupportedRelaxation` → status `unsupported` → whole-solve lifted fallback); reciprocal-of-affine is still accepted. Defense-in-depth: an `infeasible` from the in-house simplex is cross-checked against scipy/HiGHS before it is trusted to fathom (never a single mis-solve). nvs22 now certifies 6.0582 (35 nodes, = lifted). nodes/s: reduced ~5× slower/node on st\_e36 where it applies — capability, not speed (§0.1); `auto` still never selects reduced (P2.4). NOT merged; wiring stays default-OFF pending the P2.4 graduation gate. |
 | P2.4 auto policy | blocked on P2.3 | |
 | P2.5 hybrid | deferred | |
 | P3.1 CustomCall relax | not started | prototype P3.3 first |
@@ -434,17 +434,19 @@ Prior falsifications binding on this plan (§4 of CLAUDE.md — measurements win
   root bounds on QPs.
 - The FT-storm motivation for reduced space is **gone** (#573 density route);
   §0.1's capability framing is the binding rationale.
-- **The reduced-space evaluator is NOT yet sound on the full library** (P2.3
-  falsification, 2026-07-10): `reduced_mccormick_lp_bound` returns false
-  `infeasible` on `nvs22` (equality-constrained division/sqrt intermediates,
-  unbounded leaves), which fathoms the node holding the optimum → false optimal.
-  The `build_reduced_relaxation` scope guard is too permissive (accepts unbounded
-  leaves + this equality class it cannot soundly declare infeasible). P2.3 mode
-  wiring is BLOCKED on a P0/P1-layer fix: either (a) refuse this class at build
-  time (unbounded leaf / equality-of-nonconvex-intermediate) so the solver falls
-  back to lifted, and/or (b) fix the infeasibility test to never report empty on a
-  non-empty relaxed set. Do NOT re-enable reduced wiring until a corpus-wide
-  false-infeasible / false-optimal sweep is clean.
+- **The reduced-space evaluator's non-affine-division subgradient was unsound**
+  (P2.3, found+fixed 2026-07-10): the general `x/y = x·(1/y)` composition produced
+  an INVALID `cc` subgradient on `nvs22` con2, cutting off the true optimum → false
+  `infeasible` → false optimal. RESOLUTION (sound-or-refuse, CLAUDE.md §3):
+  `_to_mcbox` refuses division by a **non-affine denominator** (reciprocal-of-affine
+  stays sound); the caller falls back to lifted. Two adjacent bugs fixed with it:
+  the solver must feed the reduced evaluator the **original-DOF box**
+  (`_prereform_model` / `_prereform_nvars` slice), NOT the factorable-lifted node box
+  (whose ~1e8 aux bounds also made the Kelley LP mis-solve); and the unbounded-leaf
+  refusal (#582). Corpus sweep now clean (incorrect_count=0, 21 instances) + adversarial
+  10/10 with the flag ON. FOLLOW-UP (P1.2): implement a *validated* non-affine
+  division/reciprocal subgradient to widen scope beyond reciprocal-of-affine; until
+  then the refusal is the correct, sound behavior.
 
 ## 8. What "parity" means at the end
 

--- a/python/discopt/_jax/mccormick_subgradient.py
+++ b/python/discopt/_jax/mccormick_subgradient.py
@@ -60,6 +60,48 @@ def _scalar_const(expr) -> float:
     return float(v.reshape(()))
 
 
+def _is_affine_ast(expr, model) -> bool:
+    """True iff ``expr`` is affine in the original variables over the whole box.
+
+    Static, structural check on the AST (constants/params/scalar-vars are affine;
+    ``+``/``-``/unary-neg preserve affine-ness; ``*``//``/`` are affine only when one
+    side is a constant; ``**`` only for exponent 1 over an affine base). Used to gate
+    division: ``a / b`` is SOUND when the denominator ``b`` is affine (then ``1/b`` is a
+    univariate reciprocal of an affine expression — the classic McCormick case). For a
+    NON-affine denominator the general reciprocal-then-product composition
+    (``x/y = x·(1/y)``) is NOT validated — it produced an INVALID ``cc`` subgradient on
+    nvs22 con2 (``(A·x6)/((x2·x3)·(sum-of-squares))``), a cut that excluded the true
+    feasible optimum by ~1.7e5 -> false-infeasible -> false optimal (task #69). Refuse
+    rather than emit an invalid bound (sound-or-refuse, CLAUDE.md §3)."""
+    if isinstance(expr, (Constant, Parameter)):
+        return True
+    if _resolve_scalar_var_offset(expr, model) is not None:
+        return True
+    if isinstance(expr, Variable):
+        return False
+    if isinstance(expr, UnaryOp):
+        return expr.op == "neg" and _is_affine_ast(expr.operand, model)
+    if isinstance(expr, BinaryOp):
+        lo_const = isinstance(expr.left, (Constant, Parameter))
+        ro_const = isinstance(expr.right, (Constant, Parameter))
+        if expr.op in ("+", "-"):
+            return _is_affine_ast(expr.left, model) and _is_affine_ast(expr.right, model)
+        if expr.op == "*":
+            if lo_const:
+                return _is_affine_ast(expr.right, model)
+            if ro_const:
+                return _is_affine_ast(expr.left, model)
+            return False
+        if expr.op == "/":
+            return ro_const and _is_affine_ast(expr.left, model)
+        if expr.op == "**":
+            return (
+                ro_const and _scalar_const(expr.right) == 1.0 and _is_affine_ast(expr.left, model)
+            )
+        return False
+    return False
+
+
 def _to_mcbox(expr, leaves, model):
     """Interpret a scalar model expression into an MCBox over the current leaves."""
     if isinstance(expr, (Constant, Parameter)):
@@ -91,7 +133,16 @@ def _to_mcbox(expr, leaves, model):
                 if c == 0.0:
                     raise UnsupportedRelaxation("division by zero constant")
                 return _to_mcbox(expr.left, leaves, model) * (1.0 / c)
-            # variable division via the sign-definite reciprocal (P1.2)
+            # Variable division via the sign-definite reciprocal (P1.2). SOUND only
+            # for an AFFINE denominator (1/affine is a univariate reciprocal of an
+            # affine arg — validated). A NON-affine denominator routes through the
+            # general reciprocal-then-bilinear composition whose cc subgradient is
+            # NOT validated and was shown INVALID on nvs22 con2 (task #69) -> refuse.
+            if not _is_affine_ast(expr.right, model):
+                raise UnsupportedRelaxation(
+                    "division by a non-affine denominator (unvalidated reduced-space "
+                    "reciprocal composition; P1.2 follow-up)"
+                )
             return _to_mcbox(expr.left, leaves, model) / _to_mcbox(expr.right, leaves, model)
         if op == "**":
             if not isinstance(expr.right, (Constant, Parameter)):
@@ -323,6 +374,37 @@ def reduced_mccormick_lp_bound(
                     status = "error"
 
         if status == "infeasible":
+            # SOUND-OR-REFUSE (task #69, P2.3 root cause #2): a reduced-space
+            # ``infeasible`` fathoms the node, so it MUST be a rigorous proof — not
+            # a numerical artifact. The Kelley LP (box + epigraph + valid cuts) can
+            # only be genuinely infeasible if the accumulated valid constraint cuts
+            # contradict; but the in-house simplex can spuriously report infeasible
+            # on a badly-scaled basis. Cross-check with scipy/HiGHS before trusting
+            # the fathom: if HiGHS finds the same LP feasible (or is itself
+            # inconclusive), DO NOT fathom — return no bound and let the caller keep
+            # any other (lifted) bound source. Only a two-solver agreement fathoms.
+            if backend == "simplex":
+                try:
+                    _vres = sopt.linprog(
+                        c,
+                        A_ub=np.asarray(A_all),
+                        b_ub=np.asarray(rhs_all),
+                        bounds=bounds,
+                        method="highs",
+                    )
+                except Exception:
+                    _vres = None
+                _confirmed = _vres is not None and (
+                    "infeasible" in (getattr(_vres, "message", "") or "").lower()
+                    or (not _vres.success and getattr(_vres, "status", None) == 2)
+                )
+                if not _confirmed:
+                    # Unconfirmed infeasible => suspected simplex mis-solve. Refuse to
+                    # fathom; report no usable reduced bound for this node (the caller
+                    # falls back to any other bound source; the node is NOT pruned).
+                    return ReducedBound(
+                        bound=-np.inf, status="unsupported", rounds=r, history=history
+                    )
             return ReducedBound(bound=np.inf, status="infeasible", rounds=r, history=history)
         if status == "unbounded":
             return ReducedBound(bound=-np.inf, status="unbounded", rounds=r, history=history)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5687,6 +5687,29 @@ def solve_model(
             "(default), 'auto', or 'reduced'."
         )
     _reduced_space_active = _relax_space == "reduced" and model._objective is not None
+    # The reduced-space evaluator relaxes over the ORIGINAL degrees of freedom only
+    # (its whole premise — no auxiliary columns). Two adjustments are REQUIRED for a
+    # sound bound (task #69, P2.3 root cause #2):
+    #
+    #   1. Build the relaxation on the PRE-REFORMULATION model. When
+    #      ``factorable_reformulate`` ran (line ~3864), ``model`` is already the
+    #      LIFTED model: its ``_variables`` include the added dependent aux columns
+    #      (e.g. nvs22: 8 originals -> 15 lifted) and its constraints include their
+    #      defining equalities. Relaxing THAT through MCBox rebuilds the lifted
+    #      formulation — defeating the reduced-space purpose AND feeding the aux
+    #      columns' huge bounds (~1e8 on nvs22) into the Kelley LP, whose resulting
+    #      ~1e9-scaled basis the in-house simplex can mis-solve as spuriously
+    #      "infeasible" -> wrong node fathom -> FALSE OPTIMAL. Use ``_prereform_model``
+    #      (the true DOF) when it exists.
+    #   2. Slice every node box to the original columns ``[:_reduced_n_orig]``. Aux
+    #      columns are appended after the originals (comment at the reformulation
+    #      site), so the first ``_reduced_n_orig`` flat entries of every tree-exported
+    #      node box are exactly the original-variable sub-box.
+    _reduced_model = _prereform_model if _prereform_model is not None else model
+    if _prereform_model is not None:
+        _reduced_n_orig = int(_prereform_nvars)
+    else:
+        _reduced_n_orig = int(sum(v.size for v in model._variables))
     _reduced_bound_fn: Any = None
     if _reduced_space_active:
         try:
@@ -5701,9 +5724,9 @@ def solve_model(
             # surfaces here (status "unsupported") and we fall back for the whole
             # solve rather than paying the probe cost at every node.
             _rs_probe = _reduced_bound_fn(
-                model,
-                np.asarray(lb, dtype=np.float64),
-                np.asarray(ub, dtype=np.float64),
+                _reduced_model,
+                np.asarray(lb, dtype=np.float64)[:_reduced_n_orig],
+                np.asarray(ub, dtype=np.float64)[:_reduced_n_orig],
                 max_rounds=1,
             )
             if _rs_probe.status == "unsupported":
@@ -5745,12 +5768,16 @@ def solve_model(
         Correctness (plan §0.3, CLAUDE.md §1): only ``optimal``/``infeasible`` are
         acted on; a non-finite ``optimal`` bound is dropped (never trusted). This
         can only raise a node bound toward — never above — the true box optimum.
+
+        The node box spans the lifted space; slice to the original variables
+        (``[:_reduced_n_orig]``) — the reduced evaluator is defined over the
+        original variables only (see the setup block's rationale).
         """
         try:
             rb = _reduced_bound_fn(
-                model,
-                np.asarray(_node_lb, dtype=np.float64),
-                np.asarray(_node_ub, dtype=np.float64),
+                _reduced_model,
+                np.asarray(_node_lb, dtype=np.float64)[:_reduced_n_orig],
+                np.asarray(_node_ub, dtype=np.float64)[:_reduced_n_orig],
             )
         except Exception as _rb_exc:  # pragma: no cover - defensive
             logger.debug("reduced-space bound failed at node %d: %s", _i, _rb_exc)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5665,6 +5665,102 @@ def solve_model(
             _node_reduce_enabled = False
             _node_reduce_fn = None
 
+    # --- Reduced-space McCormick per-node bounding (MAiNGO-parity §2 P2.3) ---
+    # ``DISCOPT_RELAX_SPACE=reduced`` swaps the lifted per-node LP for a Kelley
+    # cutting-plane bound over the ORIGINAL variables only (no auxiliary columns —
+    # the #557 dense-lifted FT storm is avoided by construction). The bound is
+    # certifying: an ``optimal`` status is a VALID node dual lower bound and an
+    # ``infeasible`` status is a rigorous fathom (the relaxed feasible set is
+    # empty). ``lifted``/``auto`` preserve today's path byte-for-byte.
+    #
+    # Sound-or-refuse (plan §0.3): the reduced evaluator is *probed* once here on
+    # the root box. If the model is outside the sound MCBox scope
+    # (``UnsupportedRelaxation``), the WHOLE solve silently falls back to the
+    # lifted path — never an error to the user. Per node, ``unsupported`` /
+    # ``unbounded`` yields no reduced bound (the lifted LP still runs as fallback,
+    # so no node is ever left without a bound source it would otherwise have had).
+    _relax_space = _tuning().relax_space
+    if _relax_space == "hybrid":
+        raise NotImplementedError(
+            "DISCOPT_RELAX_SPACE=hybrid is reserved for MAiNGO-parity plan P2.5 "
+            "(MC<->AVM per-term lift) and is not implemented yet. Use 'lifted' "
+            "(default), 'auto', or 'reduced'."
+        )
+    _reduced_space_active = _relax_space == "reduced" and model._objective is not None
+    _reduced_bound_fn: Any = None
+    if _reduced_space_active:
+        try:
+            from discopt._jax.mccormick_subgradient import (
+                UnsupportedRelaxation as _RSUnsupported,
+            )
+            from discopt._jax.mccormick_subgradient import (
+                reduced_mccormick_lp_bound as _reduced_bound_fn,
+            )
+
+            # Probe buildability once on the root box: a model out of MCBox scope
+            # surfaces here (status "unsupported") and we fall back for the whole
+            # solve rather than paying the probe cost at every node.
+            _rs_probe = _reduced_bound_fn(
+                model,
+                np.asarray(lb, dtype=np.float64),
+                np.asarray(ub, dtype=np.float64),
+                max_rounds=1,
+            )
+            if _rs_probe.status == "unsupported":
+                logger.info(
+                    "DISCOPT_RELAX_SPACE=reduced: model outside sound reduced-space "
+                    "(MCBox) scope; falling back to the lifted McCormick path for "
+                    "this solve."
+                )
+                _reduced_space_active = False
+                _reduced_bound_fn = None
+        except _RSUnsupported as _rs_exc:
+            logger.info(
+                "DISCOPT_RELAX_SPACE=reduced: reduced-space build refused (%s); "
+                "falling back to the lifted McCormick path for this solve.",
+                _rs_exc,
+            )
+            _reduced_space_active = False
+            _reduced_bound_fn = None
+        except Exception as _rs_exc:  # pragma: no cover - defensive
+            logger.warning(
+                "DISCOPT_RELAX_SPACE=reduced: reduced-space setup failed (%s); "
+                "falling back to the lifted McCormick path for this solve.",
+                _rs_exc,
+            )
+            _reduced_space_active = False
+            _reduced_bound_fn = None
+        if _reduced_space_active:
+            logger.debug("reduced-space McCormick per-node bounding active (P2.3)")
+
+    def _reduced_node_bound(_node_lb, _node_ub, _i):
+        """Compute the reduced-space node dual bound over the given node box.
+
+        Returns ``(kind, value)`` where ``kind`` is:
+          * ``"infeasible"`` — rigorous fathom (relaxed feasible set empty);
+          * ``"bound"`` — ``value`` is a VALID node dual lower bound (min sense);
+          * ``None`` — no reduced bound available (unsupported/unbounded/error);
+            the caller must not fathom and should keep any other bound source.
+
+        Correctness (plan §0.3, CLAUDE.md §1): only ``optimal``/``infeasible`` are
+        acted on; a non-finite ``optimal`` bound is dropped (never trusted). This
+        can only raise a node bound toward — never above — the true box optimum.
+        """
+        try:
+            rb = _reduced_bound_fn(
+                model,
+                np.asarray(_node_lb, dtype=np.float64),
+                np.asarray(_node_ub, dtype=np.float64),
+            )
+        except Exception as _rb_exc:  # pragma: no cover - defensive
+            logger.debug("reduced-space bound failed at node %d: %s", _i, _rb_exc)
+            return None, None
+        if rb.status == "infeasible":
+            return "infeasible", None
+        if rb.status == "optimal" and rb.bound is not None and np.isfinite(rb.bound):
+            return "bound", float(rb.bound)
+        return None, None
+
     from discopt import debug as _debug
 
     def _debug_validate_candidate(
@@ -6092,11 +6188,47 @@ def solve_model(
                                 result_lbs[i] = max(result_lbs[i], float(mc_lbs[i]))
                 except (ValueError, ArithmeticError, RuntimeError) as e:
                     logger.debug("Batch McCormick bound failed: %s", e)
+            # Reduced-space McCormick per-node bound (P2.3). Replaces the lifted
+            # LP for nodes where it applies; nodes it cannot bound (None) fall
+            # through to the lifted block below unchanged.
+            _reduced_done = np.zeros(n_batch, dtype=bool)
+            if _reduced_space_active:
+                for i in range(n_batch):
+                    if node_infeasible_mask[i]:
+                        continue
+                    if _deadline - time.perf_counter() <= 0.0:
+                        break
+                    _rk, _rv = _reduced_node_bound(batch_lb[i], batch_ub[i], i)
+                    if _rk == "infeasible":
+                        # Rigorous fathom: the reduced-space relaxation is a valid
+                        # outer relaxation, so an empty relaxed feasible set proves
+                        # the node's subtree infeasible (mirrors the lifted path).
+                        node_infeasible_mask[i] = True
+                        result_lbs[i] = _INFEASIBILITY_SENTINEL
+                        result_feas[i] = False
+                        _reduced_done[i] = True
+                    elif _rk == "bound":
+                        # Valid node dual lower bound. Combine soundly (max) with
+                        # any bound already present; reduced REPLACES the lifted
+                        # LP solve for this node (the storm-avoidance win).
+                        cur = result_lbs[i]
+                        if cur >= _SENTINEL_THRESHOLD or not np.isfinite(cur):
+                            result_lbs[i] = _rv
+                            result_feas[i] = False
+                        else:
+                            result_lbs[i] = max(cur, _rv)
+                        _reduced_done[i] = True
+                    # _rk is None: no reduced bound (unsupported/unbounded); leave
+                    # the node for the lifted LP fallback below.
+
             # LP-form McCormick: lift bilinears, solve as LP via HiGHS.
             # Per-node, ~20ms for problems with tens of bilinear terms.
             if _mc_lp_relaxer is not None:
                 for i in range(n_batch):
                     if node_infeasible_mask[i]:
+                        continue
+                    if _reduced_done[i]:
+                        # Reduced-space already produced this node's bound/fathom.
                         continue
                     # Deadline enforcement (time_limit overrun fix). A single
                     # McCormick LP solve has an irreducible ~1s floor on a large
@@ -6428,12 +6560,32 @@ def solve_model(
                     result_sols[i] = 0.5 * (lb_clipped + ub_clipped)
                     result_feas[i] = False
 
+                # Reduced-space McCormick per-node bound (P2.3, serial path).
+                # Replaces the lifted LP where it applies; a node it cannot bound
+                # (None) falls through to the lifted block unchanged.
+                _reduced_done_serial = False
+                if _reduced_space_active and not node_infeasible_mask[i]:
+                    _rk, _rv = _reduced_node_bound(node_lb, node_ub, i)
+                    if _rk == "infeasible":
+                        node_infeasible_mask[i] = True
+                        result_lbs[i] = _INFEASIBILITY_SENTINEL
+                        result_feas[i] = False
+                        _reduced_done_serial = True
+                    elif _rk == "bound":
+                        cur = result_lbs[i]
+                        if cur >= _SENTINEL_THRESHOLD or not np.isfinite(cur):
+                            result_lbs[i] = _rv
+                            result_feas[i] = False
+                        else:
+                            result_lbs[i] = max(cur, _rv)
+                        _reduced_done_serial = True
+
                 # LP-form McCormick bound (lifted bilinears, HiGHS LP).
                 # Runs independently of the NLP: provides a valid lower bound
                 # and a feasible LP point usable for spatial branching even
                 # when the NLP was skipped (root) or returned infeasible /
                 # iteration_limit (any node).
-                if _mc_lp_relaxer is not None:
+                if _mc_lp_relaxer is not None and not _reduced_done_serial:
                     try:
                         mc_lp_res = _mc_lp_relaxer.solve_at_node(
                             node_lb,

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -291,6 +291,34 @@ class SolverTuning:
     """Per-node dual bound: ``"lp"`` (default, lifted-McCormick LP) or ``"milp"``
     (legacy nested integer MILP node solve) — ``DISCOPT_NODE_BOUND_MODE``."""
 
+    relax_space: str = field(
+        default_factory=lambda: os.environ.get("DISCOPT_RELAX_SPACE", "lifted")
+    )
+    """Per-node relaxation *space* for the McCormick dual bound
+    (``DISCOPT_RELAX_SPACE``, MAiNGO-parity plan §2 P2.3). Values:
+
+    - ``"lifted"`` (**default**, byte-identical to pre-P2.3): today's lifted
+      McCormick LP with auxiliary columns (``MccormickLPRelaxer.solve_at_node``).
+    - ``"auto"``: currently an alias for ``"lifted"`` — no structural policy has
+      graduated yet (P2.4). Preserves today's behavior exactly.
+    - ``"reduced"``: MAiNGO-style **reduced-space** McCormick — a Kelley
+      cutting-plane bound over the *original* variables only (no lifted columns),
+      computed by ``reduced_mccormick_lp_bound``. The evaluator is built once per
+      solve; if the model is outside the sound MCBox scope
+      (``UnsupportedRelaxation`` at build time) the whole solve falls back to the
+      lifted path (logged once, never an error). Per-node, an ``"unsupported"`` /
+      ``"unbounded"`` status yields no reduced bound for that node (lifted-only);
+      ``"infeasible"`` fathoms the node; ``"optimal"`` is a **valid** node dual
+      lower bound and is combined soundly (max with any lifted bound).
+    - ``"hybrid"``: reserved for P2.5 (Najman-style MC↔AVM per-term lift); raises
+      ``NotImplementedError`` until then rather than silently degrading.
+
+    CORRECTNESS-CRITICAL: the reduced-space bound certifies the node dual bound.
+    A ``"reduced"`` bound is only ever used where its status is ``"optimal"``
+    (valid LB) or ``"infeasible"`` (empty relaxed set → fathom); it can only
+    *raise* a node bound up to (never above) the true box optimum, never cut a
+    feasible point."""
+
     node_nlp_stride: int = field(default_factory=lambda: _env_int("DISCOPT_NODE_NLP_STRIDE", 4))
     """Solve the node NLP every k-th node (``DISCOPT_NODE_NLP_STRIDE``, default 4)."""
 
@@ -357,6 +385,11 @@ class SolverTuning:
         if self.node_bound_mode not in ("lp", "milp"):
             raise ValueError(
                 f"node_bound_mode must be 'lp' or 'milp', got {self.node_bound_mode!r}"
+            )
+        if self.relax_space not in ("auto", "lifted", "reduced", "hybrid"):
+            raise ValueError(
+                "relax_space must be 'auto', 'lifted', 'reduced', or 'hybrid', "
+                f"got {self.relax_space!r}"
             )
         if self.psd_cost_gate_budget <= 0:
             raise ValueError(f"psd_cost_gate_budget must be > 0, got {self.psd_cost_gate_budget}")

--- a/python/tests/test_relax_space_reduced.py
+++ b/python/tests/test_relax_space_reduced.py
@@ -1,0 +1,149 @@
+"""End-to-end + soundness tests for the ``DISCOPT_RELAX_SPACE=reduced`` per-node
+bounding mode (MAiNGO-parity plan §2 P2.3).
+
+CORRECTNESS-CRITICAL: the reduced-space Kelley bound certifies the node dual
+bound (and hence global optimality). These tests pin:
+  * a small QP certifies its known optimum under ``reduced`` mode;
+  * ``reduced`` produces a VALID dual lower bound (<= true optimum) and a feasible
+    incumbent (>= true optimum) — never a false optimal;
+  * ``hybrid`` refuses loudly (reserved for P2.5);
+  * the default (``lifted``/``auto``) is byte-identical to unset on node_count +
+    certified objective (a pure add; the default path must not move at all).
+"""
+
+from __future__ import annotations
+
+import os
+
+import jax
+import numpy as np
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import discopt.modeling as dm  # noqa: E402
+from discopt import SolverTuning  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _small_qp():
+    """min x0*x1 - x0 + 2*x1 s.t. x0 + x1 <= 2, box [-1,3]x[-2,2].
+
+    A nonconvex bilinear QP with a unique global optimum reached by spatial
+    branching; small enough that the (slower) reduced-space Kelley bound still
+    solves it in a few seconds.
+    """
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=[-1.0, -2.0], ub=[3.0, 2.0])
+    m.minimize(x[0] * x[1] - x[0] + 2.0 * x[1])
+    m.subject_to(x[0] + x[1] <= 2.0)
+    return m
+
+
+def _oracle_qp():
+    """Brute-force global optimum of _small_qp over a fine grid (feasible only)."""
+    xs = np.linspace(-1.0, 3.0, 801)
+    ys = np.linspace(-2.0, 2.0, 801)
+    X, Y = np.meshgrid(xs, ys)
+    F = X * Y - X + 2.0 * Y
+    feas = (X + Y) <= 2.0 + 1e-9
+    return float(F[feas].min())
+
+
+@pytest.mark.smoke
+def test_reduced_mode_certifies_small_qp():
+    opt = _oracle_qp()
+    m = _small_qp()
+    res = m.solve(time_limit=60, tuning=SolverTuning(relax_space="reduced"))
+    assert res.status == "optimal", f"expected certified optimal, got {res.status}"
+    # incumbent matches the oracle
+    assert res.objective == pytest.approx(opt, abs=1e-3, rel=1e-4)
+    # dual bound is a VALID lower bound (never above the true optimum)
+    assert res.bound <= opt + 1e-4 * (abs(opt) + 1.0)
+    # certificate invariant: bound <= incumbent (min sense)
+    assert res.bound <= res.objective + 1e-6
+
+
+@pytest.mark.smoke
+def test_reduced_mode_bound_never_above_optimum_time_limited():
+    """Even when the reduced solve is cut off by a tight time limit, the reported
+    dual bound must remain a valid lower bound and the incumbent feasible."""
+    opt = _oracle_qp()
+    m = _small_qp()
+    res = m.solve(time_limit=5, tuning=SolverTuning(relax_space="reduced"))
+    if np.isfinite(res.bound):
+        assert res.bound <= opt + 1e-4 * (abs(opt) + 1.0), "dual bound above true optimum"
+    if res.objective is not None and np.isfinite(res.objective):
+        assert res.objective >= opt - 1e-4 * (abs(opt) + 1.0), "incumbent below true optimum"
+
+
+def test_hybrid_refuses_loudly():
+    m = _small_qp()
+    with pytest.raises(NotImplementedError, match="hybrid"):
+        m.solve(time_limit=5, tuning=SolverTuning(relax_space="hybrid"))
+
+
+@pytest.mark.parametrize("mode", ["lifted", "auto"])
+def test_default_paths_byte_identical(mode):
+    """``lifted`` and ``auto`` reproduce the unset-flag path exactly (node_count +
+    certified objective). P2.3 is a pure add; the default path must not move."""
+    m1 = _small_qp()
+    base = m1.solve(time_limit=60)  # unset -> "lifted"
+    m2 = _small_qp()
+    got = m2.solve(time_limit=60, tuning=SolverTuning(relax_space=mode))
+    assert got.node_count == base.node_count
+    assert got.objective == pytest.approx(base.objective, abs=0.0, rel=0.0)
+    assert got.status == base.status
+
+
+_NVS22 = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/nvs22.nl")
+
+
+@pytest.mark.xfail(
+    reason="P2.3 NO-GO: reduced_mccormick_lp_bound returns false-`infeasible` on a "
+    "node box that contains the feasible optimum of nvs22 (equality-constrained "
+    "division/sqrt intermediates + unbounded leaves the builder fails to refuse). "
+    "This fathoms the node holding the optimum -> false optimal (11.44 vs 6.06). "
+    "Reduced mode must NOT be wired into the solver until this UPSTREAM evaluator "
+    "soundness/scope bug is fixed (see docs/dev/maingo-parity-plan.md §7 P2.3).",
+    strict=True,
+)
+@pytest.mark.skipif(not os.path.exists(_NVS22), reason="MINLPLib corpus (nvs22.nl) not available")
+def test_reduced_bound_no_false_infeasible_nvs22():
+    """Regression pin for the P2.3 blocker: a valid outer relaxation must NEVER
+    report the relaxed feasible set empty on a box that contains a feasible point.
+    XFAIL(strict) until the reduced-space evaluator's infeasibility test / scope
+    guard is fixed; flip to a passing soundness test once it is."""
+    from discopt._jax.mccormick_subgradient import reduced_mccormick_lp_bound
+
+    m = dm.from_nl(_NVS22)
+    # x* is the (lifted-)certified global optimum; a box of half-width ~1 around it.
+    xstar = np.array([5, 1, 1, 2, 2121.6408, 10782.6705, 3.1623, 0.3162], dtype=float)
+    lb, ub = xstar.copy(), xstar.copy()
+    for i in range(4):
+        lb[i], ub[i] = max(1.0, xstar[i] - 1.0), xstar[i] + 1.0
+    for i in range(4, 8):
+        span = abs(xstar[i]) * 0.1 + 1.0
+        lb[i], ub[i] = xstar[i] - span, xstar[i] + span
+    assert np.all(lb <= xstar) and np.all(xstar <= ub)  # x* is inside the box
+    rb = reduced_mccormick_lp_bound(m, lb, ub)
+    # A sound relaxation of a non-empty set is never "infeasible".
+    assert rb.status != "infeasible", (
+        f"FALSE-INFEASIBLE on a box containing feasible x* (bound={rb.bound})"
+    )
+
+
+def test_reduced_falls_back_on_unsupported_model():
+    """A model outside the sound reduced-space (MCBox) scope must fall back to the
+    lifted path for the whole solve — never error to the user."""
+    # A ``/`` by a variable whose denominator interval spans 0 is out of MCBox
+    # scope at the root; the solve must still complete via the lifted fallback.
+    m = dm.Model()
+    x = m.continuous("x", 2, lb=[-1.0, -1.0], ub=[2.0, 2.0])
+    # sin is not in the sound reduced-space op set -> unsupported at build.
+    m.minimize(dm.sin(x[0]) + x[1] * x[1])
+    m.subject_to(x[0] + x[1] <= 1.0)
+    res = m.solve(time_limit=30, tuning=SolverTuning(relax_space="reduced"))
+    # Fallback path is the lifted solver; it must return a sound result, not raise.
+    assert res.status in ("optimal", "feasible", "infeasible")

--- a/python/tests/test_relax_space_reduced.py
+++ b/python/tests/test_relax_space_reduced.py
@@ -100,21 +100,17 @@ def test_default_paths_byte_identical(mode):
 _NVS22 = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/nvs22.nl")
 
 
-@pytest.mark.xfail(
-    reason="P2.3 NO-GO: reduced_mccormick_lp_bound returns false-`infeasible` on a "
-    "node box that contains the feasible optimum of nvs22 (equality-constrained "
-    "division/sqrt intermediates + unbounded leaves the builder fails to refuse). "
-    "This fathoms the node holding the optimum -> false optimal (11.44 vs 6.06). "
-    "Reduced mode must NOT be wired into the solver until this UPSTREAM evaluator "
-    "soundness/scope bug is fixed (see docs/dev/maingo-parity-plan.md §7 P2.3).",
-    strict=True,
-)
 @pytest.mark.skipif(not os.path.exists(_NVS22), reason="MINLPLib corpus (nvs22.nl) not available")
 def test_reduced_bound_no_false_infeasible_nvs22():
-    """Regression pin for the P2.3 blocker: a valid outer relaxation must NEVER
-    report the relaxed feasible set empty on a box that contains a feasible point.
-    XFAIL(strict) until the reduced-space evaluator's infeasibility test / scope
-    guard is fixed; flip to a passing soundness test once it is."""
+    """Regression for the P2.3 blocker (task #69): the reduced-space evaluator must
+    NEVER report a box that contains a feasible point as ``infeasible`` (which would
+    fathom the node holding the optimum -> false optimal, 11.44 vs true 6.06).
+
+    Root cause was an INVALID cc subgradient of nvs22 con2's non-affine division
+    ``(A·x6)/((x2·x3)·(sum-of-squares))`` — the Kelley cut excluded the true optimum
+    by ~1.7e5. The sound-or-refuse fix refuses division by a non-affine denominator
+    (``UnsupportedRelaxation`` -> status ``unsupported`` -> the solver falls back to
+    lifted for this class). So this box must NOT come back ``infeasible``."""
     from discopt._jax.mccormick_subgradient import reduced_mccormick_lp_bound
 
     m = dm.from_nl(_NVS22)
@@ -128,10 +124,54 @@ def test_reduced_bound_no_false_infeasible_nvs22():
         lb[i], ub[i] = xstar[i] - span, xstar[i] + span
     assert np.all(lb <= xstar) and np.all(xstar <= ub)  # x* is inside the box
     rb = reduced_mccormick_lp_bound(m, lb, ub)
-    # A sound relaxation of a non-empty set is never "infeasible".
+    # Sound-or-refuse: refuses (unsupported) rather than emitting a bogus infeasible.
     assert rb.status != "infeasible", (
         f"FALSE-INFEASIBLE on a box containing feasible x* (bound={rb.bound})"
     )
+    assert rb.status == "unsupported", (
+        f"expected refusal on the non-affine-division class, got {rb.status}"
+    )
+
+
+@pytest.mark.skipif(not os.path.exists(_NVS22), reason="MINLPLib corpus (nvs22.nl) not available")
+def test_reduced_mode_certifies_nvs22_via_fallback():
+    """End-to-end: nvs22 (oracle 6.0582) must certify the CORRECT optimum in reduced
+    mode. Because its division/sqrt-equality class is refused, the whole solve falls
+    back to the lifted path — the point is that reduced mode NEVER produces the old
+    false optimal (11.44)."""
+    r = dm.from_nl(_NVS22).solve(time_limit=90, tuning=SolverTuning(relax_space="reduced"))
+    opt = 6.05822
+    if r.status == "optimal":
+        assert r.objective == pytest.approx(opt, abs=1e-2, rel=1e-3), (
+            f"reduced-mode nvs22 certified {r.objective} != oracle {opt}"
+        )
+    # Dual bound must remain a valid lower bound regardless of termination status.
+    if r.bound is not None and np.isfinite(r.bound):
+        assert r.bound <= opt + 1e-2, f"reduced-mode nvs22 bound {r.bound} above optimum {opt}"
+
+
+def test_reduced_refuses_non_affine_division():
+    """Sound-or-refuse unit test (class-level, not instance-keyed): division by a
+    NON-affine denominator is refused by the reduced-space builder, while division by
+    an AFFINE denominator is accepted. This is the general rule that fixes nvs22."""
+    from discopt._jax.mccormick_subgradient import (
+        UnsupportedRelaxation,
+        build_reduced_relaxation,
+    )
+
+    # non-affine denominator (x1*x2) -> refuse
+    m = dm.Model()
+    x = m.continuous("x", 3, lb=[1.0, 1.0, 1.0], ub=[5.0, 5.0, 5.0])
+    m.minimize(x[0] / (x[1] * x[2]))
+    with pytest.raises(UnsupportedRelaxation, match="non-affine denominator"):
+        build_reduced_relaxation(m, np.array([1.0, 1.0, 1.0]), np.array([5.0, 5.0, 5.0]))
+
+    # affine denominator (2*x1 + 3) -> accepted (sound reciprocal-of-affine)
+    m2 = dm.Model()
+    y = m2.continuous("y", 2, lb=[1.0, 1.0], ub=[5.0, 5.0])
+    m2.minimize(y[0] / (2.0 * y[1] + 3.0))
+    R = build_reduced_relaxation(m2, np.array([1.0, 1.0]), np.array([5.0, 5.0]))
+    assert R.n == 2
 
 
 def test_reduced_falls_back_on_unsupported_model():

--- a/python/tests/test_solver_tuning.py
+++ b/python/tests/test_solver_tuning.py
@@ -31,6 +31,8 @@ def test_defaults_match_legacy_env_defaults():
     assert t.rlt_quad_max == 256
     assert t.multilinear_rlt_max == 4
     assert t.node_bound_mode == "lp"
+    # P2.3: reduced-space relaxation defaults to the lifted path (byte-identical).
+    assert t.relax_space == "lifted"
     assert t.node_nlp_stride == 4
     # ILS-DEFAULT: the integer_local_search sub-NLP solve cap is ON by default (2).
     assert t.ils_solve_cap == 2
@@ -59,6 +61,8 @@ def test_defaults_match_legacy_env_defaults():
         ("DISCOPT_RLT", "1", "rlt", True),
         ("DISCOPT_LIFTED_FBBT", "1", "lifted_fbbt", True),
         ("DISCOPT_NODE_BOUND_MODE", "milp", "node_bound_mode", "milp"),
+        ("DISCOPT_RELAX_SPACE", "reduced", "relax_space", "reduced"),
+        ("DISCOPT_RELAX_SPACE", "auto", "relax_space", "auto"),
         ("DISCOPT_NODE_NLP_STRIDE", "2", "node_nlp_stride", 2),
         ("DISCOPT_ILS_SOLVE_CAP", "5", "ils_solve_cap", 5),
         ("DISCOPT_ILS_SOLVE_CAP", "0", "ils_solve_cap", 0),  # escape hatch = uncapped
@@ -107,6 +111,7 @@ def test_explicit_field_overrides_env(monkeypatch):
         (dict(node_nlp_stride=0), "node_nlp_stride must be >= 1"),
         (dict(ils_solve_cap=-1), "ils_solve_cap must be >= 0"),
         (dict(node_bound_mode="bogus"), "node_bound_mode must be 'lp' or 'milp'"),
+        (dict(relax_space="bogus"), "relax_space must be"),
         (dict(psd_cost_gate_budget=0), "psd_cost_gate_budget must be > 0"),
         (dict(psd_cost_gate_budget=-1.0), "psd_cost_gate_budget must be > 0"),
         (dict(psd_cost_gate_tau=-1e-6), "psd_cost_gate_tau must be >= 0"),


### PR DESCRIPTION
## MAiNGO-parity P2.3 — wire `DISCOPT_RELAX_SPACE=reduced` (default-OFF, sound)

Wires the reduced-space McCormick evaluator (MCBox + Kelley reduced-space LP, built in P0–P2.2) into `Model.solve()` behind an opt-in `relax_space` knob, and hardens it to soundness on the equality-constrained division/sqrt class that the P2.3 gate exposed. This is the MAiNGO-parity capability: bound in the **reduced** McCormick space (genuine rule-based subgradients over the original DOF), not just the lifted space.

**Default path is byte-identical** — `relax_space="lifted"` is the default, `auto` never selects reduced (deferred to P2.4). Reduced mode is opt-in only.

### Correctness fixes (this is the substance)
The P2.3 gate caught a **false optimal on nvs22** (reduced certified 11.4393; true 6.0582). Root-caused to three distinct defects, all fixed sound-or-refuse per CLAUDE.md §3:

1. **Invalid `cc` subgradient of a non-affine division** (the real bug). On nvs22 con2 — `(A·x6)/((x2·x3)·(0.0833·x3² + (0.5·x0+0.5·x2)²))` — the general reciprocal-then-bilinear composition (`x/y = x·(1/y)`) produced an **invalid concave-overestimator subgradient**. Witness: at iterate `[1,1,1,1,42.2,1,1.12,0.064]`, the con2 `-cc` Kelley cut excludes the true feasible optimum by **~1.7e5** → node false-fathomed. Fix: `_to_mcbox` **refuses division by a non-affine denominator** (`_is_affine_ast` static AST check) → `UnsupportedRelaxation` → solver falls back to lifted. Reciprocal-of-**affine** (the P1.2 `x/y`, `1/(2y+3)` cases) stays sound. The unvalidated non-affine reciprocal subgradient math is left as a P1.2 follow-up; refusing is the correct behavior now.
2. **Lifted box fed to a reduced evaluator.** After `factorable_reformulate` the model grows to aux columns (bounds up to ~1.85e8); feeding the full lifted box built a ~1e9-scaled Kelley LP the in-house simplex mis-solved as spuriously infeasible. Fix: build over `_prereform_model` (true DOF) and slice every node box to the original columns `[:_prereform_nvars]`.
3. **Unbounded leaf** (merged separately as #582): reduced-space McCormick requires a finite box → `_require_finite_box` refuses non-finite boxes.

**Defense-in-depth:** a simplex `infeasible` verdict is now cross-checked against scipy/HiGHS before it is trusted to fathom a node — only a two-solver agreement prunes; otherwise the reduced bound is withheld (`unsupported`) and the node is **not** pruned. A single-solver artifact can never fathom.

### Gate results (all green)
- **nvs22 reduced now certifies 6.0582 (35 nodes, = lifted)** — false optimal eliminated.
- **Corpus sweep: `incorrect_count = 0`** over 21 MINLPLib instances cross-checked vs `minlplib.solu` (no false-optimal / invalid-bound / false-infeasible).
- Reduced path genuinely exercised where sound (st_e36: 114 reduced LP calls, valid bound −259.9 ≤ opt −246.0; nvs19: 11 calls, −1104.24 ≤ −1098.4), refuses+falls-back where not (nvs22, ex1221/1225/1226).
- **Adversarial suite with `DISCOPT_RELAX_SPACE=reduced`: 10/10** (the gate that caught the bug).
- **Feasible-point soundness: 74,015 samples, 0 invalid cuts.**
- **Default byte-identical: PASS** (11-instance node/objective panel unchanged).
- Unit floor: `test_mccormick_subgradient` + `test_mcbox` + `test_relax_space_reduced` + `test_solver_tuning` = **104 passed** locally; ruff + mypy (changed files) green.

### Scope / follow-ups
- Reduced mode stays **default-OFF and opt-in**; `auto` does not select it. Graduation (P2.4) — nodes/s measurement + the default-selection policy — is deliberately a separate PR.
- The nvs22 xfail is flipped to a **passing** soundness test; adds a class-level `test_reduced_refuses_non_affine_division`.
- P1.2 downgraded in the plan to "reciprocal-of-affine only," with the general non-affine reciprocal subgradient noted as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
