### PR TITLE
perf(lp): #85 — failure-triggered dense retry for the density-aware LU route (cures the nvs21 certificate loss)

### DIFF
--- a/crates/discopt-core/src/lp/simplex/linsolve.rs
+++ b/crates/discopt-core/src/lp/simplex/linsolve.rs
@@ -185,11 +185,57 @@ fn route_dense_decision(m: usize, nnz: usize, params: &LuParams, density_route: 
     should_use_dense_lu(m, nnz, params)
 }
 
-/// Whether the `DISCOPT_LU_DENSITY_ROUTE` density-aware LU route (#557) is on.
-/// Default off — the LU routing is byte-identical to the historical policy — so
-/// this is a real, opt-in performance knob, not a dead flag.
+/// Whether the `DISCOPT_LU_DENSITY_ROUTE` density-aware LU route (#557) is on
+/// for new factorizations: the env flag is set AND no dense-retry suppression is
+/// in effect (#85 — a failed solve is re-run once with the route suppressed; see
+/// [`with_density_route_suppressed`]). Default off — the LU routing is
+/// byte-identical to the historical policy — so this is a real, opt-in
+/// performance knob, not a dead flag.
 fn density_route_enabled() -> bool {
-    std::env::var_os("DISCOPT_LU_DENSITY_ROUTE").is_some()
+    !route_suppressed() && std::env::var_os("DISCOPT_LU_DENSITY_ROUTE").is_some()
+}
+
+std::thread_local! {
+    /// #85 failure-triggered dense retry: while `true`, [`want_dense_route`]
+    /// ignores the `DISCOPT_LU_DENSITY_ROUTE` flag and every factorization takes
+    /// the historical dense-preferring policy. Set only for the duration of a
+    /// retry re-solve (see `dense_retry_wanted` in `primal.rs`); thread-local
+    /// because the parallel B&B feature solves independent node LPs on rayon
+    /// workers.
+    static DENSITY_ROUTE_SUPPRESSED: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+/// Whether the density-route suppression (a dense retry in progress) is active
+/// on this thread.
+fn route_suppressed() -> bool {
+    DENSITY_ROUTE_SUPPRESSED.with(|s| s.get())
+}
+
+/// #85: whether a *failed* LP solve may be retried on the dense route — true iff
+/// the density route is currently active (so the failure may be
+/// sparse-route-specific) and we are not already inside a retry (a retry that
+/// fails again must fall through to the existing fallback chain, never recurse;
+/// [`density_route_enabled`] is false under suppression, which provides exactly
+/// that guarantee).
+pub(crate) fn density_route_retry_available() -> bool {
+    density_route_enabled()
+}
+
+/// Run `f` with the density-aware LU route suppressed: every factorization under
+/// `f` takes the historical dense-preferring routing (the robust path the
+/// default configuration uses). Restores the previous suppression state on exit,
+/// including on unwind (guard-based), so a panicking solve cannot leave the
+/// thread stuck in suppressed mode.
+pub(crate) fn with_density_route_suppressed<T>(f: impl FnOnce() -> T) -> T {
+    struct Restore(bool);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            DENSITY_ROUTE_SUPPRESSED.with(|s| s.set(self.0));
+        }
+    }
+    let _guard = Restore(DENSITY_ROUTE_SUPPRESSED.with(|s| s.replace(true)));
+    f()
 }
 
 /// The retained basis matrix, in dense-column form, kept **in sync** with every
@@ -553,6 +599,29 @@ impl LinearSolver for DenseLU {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dense_retry_suppression_scopes_and_restores() {
+        // #85: the suppression guard must (a) suppress inside the closure —
+        // which also makes density_route_retry_available() false, preventing
+        // retry recursion; (b) restore on exit; (c) restore on unwind.
+        assert!(!route_suppressed());
+        with_density_route_suppressed(|| {
+            assert!(route_suppressed());
+            // No recursion: inside a retry, a further retry is unavailable even
+            // if the env flag were set (density_route_enabled() is false here).
+            assert!(!density_route_retry_available());
+            // Nesting is harmless and restores to the outer (suppressed) state.
+            with_density_route_suppressed(|| assert!(route_suppressed()));
+            assert!(route_suppressed());
+        });
+        assert!(!route_suppressed());
+        // Unwind safety: a panicking solve must not leave the thread suppressed.
+        let _ = std::panic::catch_unwind(|| {
+            with_density_route_suppressed(|| panic!("simulated solve panic"))
+        });
+        assert!(!route_suppressed());
+    }
 
     #[test]
     fn route_default_off_is_historical() {

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -50,13 +50,61 @@ pub fn solve_lp(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpSolve {
     }
 }
 
+/// #85 failure-triggered dense retry (with the #557 density-aware LU route): is
+/// this solve a *failure* that may be sparse-route-specific?
+///
+/// Entry experiment (docs/dev/performance-plan.md §6, 2026-07-10): with the
+/// route ON, a small class of node LPs exits `Numerical`/`IterLimit` on the
+/// sparse route where the historical dense-preferring route succeeds (nvs21: 39
+/// vs 12 failing solves; the failing node keeps its inherited loose relaxation
+/// bound, the final dual bound sticks at that value, and the `optimal`
+/// certificate is lost — `feasible`, bound −1.59e7 vs true −5.685). A
+/// factorization-time conditioning gate was falsified as the discriminator
+/// (inverted populations), so the fix is failure-triggered: detect the failure
+/// the solve already reports and re-solve once on the robust path.
+fn dense_retry_wanted(sol: &LpSolve) -> bool {
+    matches!(sol.status, LpStatus::Numerical | LpStatus::IterLimit)
+        && super::linsolve::density_route_retry_available()
+}
+
+/// Re-solve a failed LP once, cold, with the density-aware LU route suppressed
+/// (every factorization takes the historical dense-preferring policy — the exact
+/// robust path the default configuration uses).
+///
+/// **Soundness invariant:** this only ever *replaces a failure* — a
+/// `Numerical`/`IterLimit` exit carries no certificate to preserve — with the
+/// robust path's result; a suspect fast-path result is never accepted or
+/// blended. A retry that also fails is returned as that failure and falls
+/// through to the existing fallback chain exactly as before the retry existed.
+/// The retry is **cold**, not warm from the failed run's state: that state
+/// (basis, factor, iterate) is precisely what is in doubt after a numerical
+/// breakdown (sound-or-refuse). Recursion is impossible: under suppression,
+/// `density_route_retry_available()` is false.
+fn dense_retry(failed: LpSolve, re_solve: impl FnOnce() -> LpSolve) -> LpSolve {
+    debug_assert!(matches!(
+        failed.status,
+        LpStatus::Numerical | LpStatus::IterLimit
+    ));
+    drop(failed); // no certificate to keep — the retry result replaces it wholesale
+    crate::profile::incr(crate::profile::Ctr::LpDenseRetries);
+    let sol = super::linsolve::with_density_route_suppressed(re_solve);
+    if !matches!(sol.status, LpStatus::Numerical | LpStatus::IterLimit) {
+        crate::profile::incr(crate::profile::Ctr::LpDenseRetryRescues);
+    }
+    sol
+}
+
 /// Two-phase primal simplex on an already-equilibrated (or known well-scaled) LP.
 /// The warm dual path's cold fallback and the B&B driver (which equilibrates the
 /// working matrix once and shares it across all node solves) call this directly
 /// so the matrix is not scaled twice; the caller owns the [`scaling::Scaling`]
 /// and unscales the returned `x` itself.
 pub fn solve_lp_scaled(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> LpSolve {
-    Simplex::new(lp, b, opts).run()
+    let sol = Simplex::new(lp, b, opts).run();
+    if dense_retry_wanted(&sol) {
+        return dense_retry(sol, || Simplex::new(lp, b, opts).run());
+    }
+    sol
 }
 
 /// Cold primal solve from an owned CSC matrix (already scaled by the caller, if at
@@ -73,7 +121,20 @@ pub fn solve_lp_cols(
     b: &[f64],
     opts: &SimplexOptions,
 ) -> LpSolve {
-    Simplex::new_from_cols(cols, m, n, c, l, u, b, opts).run()
+    // #85: `cols` is consumed by the solve, so a possible dense retry needs its
+    // own copy up front. O(nnz), paid only with the density route ON (the warm
+    // dual path already clones the CSC per solve — see dual.rs — so this is
+    // in-family), and nothing extra with the route OFF (default).
+    let retry_cols = super::linsolve::density_route_retry_available().then(|| cols.clone());
+    let sol = Simplex::new_from_cols(cols, m, n, c, l, u, b, opts).run();
+    if let Some(cols2) = retry_cols {
+        if dense_retry_wanted(&sol) {
+            return dense_retry(sol, || {
+                Simplex::new_from_cols(cols2, m, n, c, l, u, b, opts).run()
+            });
+        }
+    }
+    sol
 }
 
 /// Warm-started primal solve from an inherited `start` basis (cert:T1.4).
@@ -102,13 +163,25 @@ pub fn solve_lp_cols_warm(
     start: &Basis,
     opts: &SimplexOptions,
 ) -> LpSolve {
+    // #85: cloned up front for a possible dense retry (see solve_lp_cols).
+    let retry_cols = super::linsolve::density_route_retry_available().then(|| cols.clone());
     let s = Simplex::new_from_cols(cols, m, n, c, l, u, b, opts);
-    match s.run_warm(start) {
+    let sol = match s.run_warm(start) {
         Ok(sol) => sol,
         // Unusable warm basis → the genuine cold two-phase solve on the same
         // matrix (handed back so no clone / no stale state is reused).
         Err(cols_back) => Simplex::new_from_cols(cols_back, m, n, c, l, u, b, opts).run(),
+    };
+    if let Some(cols2) = retry_cols {
+        if dense_retry_wanted(&sol) {
+            // Cold, never warm from `start`-derived state: after a numerical
+            // failure the warm trajectory is exactly what is in doubt.
+            return dense_retry(sol, || {
+                Simplex::new_from_cols(cols2, m, n, c, l, u, b, opts).run()
+            });
+        }
     }
+    sol
 }
 
 /// Whether `x` satisfies the box `l ≤ x ≤ u` and the equalities `A x = b` to a

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -156,6 +156,14 @@ counters!(
     RefacFtGrowth,
     RefacFtTinyPivot,
     RefacFtSingular,
+    // #85 failure-triggered dense retry (density-aware LU route, #557): a node LP
+    // that failed (Numerical/IterLimit) on the sparse route was re-solved once,
+    // cold, with the route suppressed (Retries), and how many of those retries
+    // reached a terminal certificate — Optimal/Infeasible/Unbounded — instead of
+    // failing again (Rescues). The gap Retries − Rescues falls through to the
+    // existing fallback chain exactly as before the retry existed.
+    LpDenseRetries,
+    LpDenseRetryRescues,
 );
 
 #[inline(always)]

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -416,6 +416,63 @@ Stage 0 (gate) ─► Stage 1 (kill recompilation — the dominant measured cost
   above names the experiment that must confirm its premise *before* code, and the
   metric + correctness gate that must move *after* it.
 
+## 9. Engine layer — density-aware LU route (#557): the nvs21 certificate loss
+
+> **Entry experiment (2026-07-10, task #77) — the conditioning-gate hypothesis is
+> falsified; the mechanism is the LP failure rate, and the fix is
+> failure-triggered (task #85).**
+>
+> Context: the `DISCOPT_LU_DENSITY_ROUTE` route (routes m∈(16,256] sparse
+> McCormick bases to feral's sparse LU; #573) failed its graduation gate on one
+> instance: **nvs21** goes `optimal` → `feasible` with the route ON — same
+> correct incumbent (−5.68478…), but the final dual bound sticks at
+> **−15 901 749** (vs −5.68522 OFF). Hypothesis under test: the offending bases
+> are ill-conditioned, so a factorization-time condition estimate can divert
+> them to the dense LU.
+>
+> Instrumented every sparse factorization (feral `condition_estimate_1`
+> Hager–Higham κ₁ + `growth()`, incl. mid-solve refactorizations) and attributed
+> them to their LP solve's outcome:
+>
+> | population (route ON) | n(fact) | κ₁ p50 | p90 | p99 | max |
+> |---|---|---|---|---|---|
+> | nvs21, factorizations in FAILING LP solves (`Numerical`/`IterLimit`) | 59 | **1.6e1** | 1.5e9 | 7.6e18 | 7.6e18 |
+> | nvs21, factorizations in OPTIMAL LP solves | 391 | 2.1e5 | 3.1e7 | 2.4e9 | 1.0e10 |
+> | st_e36 (certifies optimal), OPTIMAL solves | 832 | 2.8e6 | **7.9e10** | 3.3e12 | **3.2e13** |
+> | nvs06 (certifies optimal), OPTIMAL solves | 72 | 5.0e8 | 7.5e12 | — | **1.2e16** |
+>
+> 1. **The populations are inverted, not merely overlapping**: most failing
+>    solves factorize *beautifully conditioned* bases (κ₁ p50 = 16), while
+>    healthy instances routinely succeed at κ₁ 10¹⁰–10¹⁶. No threshold — let
+>    alone one with the required ≥2-orders margin — separates them. A gate tight
+>    enough to catch nvs21's failures diverts essentially everything (killing
+>    the st_e36-class win); a gate loose enough to spare the healthy population
+>    catches 2 of 39 failures. `growth()` is 1.0 uniformly — zero signal.
+>    **Conditioning-gate: KILLED.** The failures develop during the *iteration*
+>    (a κ₁=8 basis factorizes cleanly, then the solve breaks), invisible at
+>    factorization time.
+> 2. **The −1.6e7 values are not corrupted LP optima.** They appear in the
+>    route-OFF run too — they are legitimately loose early lifted-McCormick
+>    relaxation bounds. The pathology is that the node carrying one never gets
+>    closed.
+> 3. **The real ON-vs-OFF delta is the LP failure rate**: `Numerical`/`IterLimit`
+>    exits 39 ON vs 12 OFF (3.25×). A node whose LP fails is abandoned with its
+>    inherited loose bound → final bound stuck → certificate lost. Sound (the
+>    bound stays valid) but uncertified.
+>
+> **Consequence (task #85):** the fix is **failure-triggered, not predictive** —
+> when a solve fails with the route ON, re-solve that LP once, cold, with the
+> route suppressed (the robust dense-preferring path). It uses the failure
+> signal the solve already reports, needs no tunable threshold, and is sound by
+> construction (only ever replaces a *failure*; never accepts or blends a
+> suspect fast-path result; cold because the failed run's warm state is exactly
+> what is in doubt). Validated: nvs21 ON → `optimal`, bound −5.68522, 30
+> retries / 27 rescues; st_e36 win preserved at 1.65× (24.8 s → 15.0 s);
+> panel: 10/10 `optimal→optimal`, node counts identical, incorrect_count 0.
+> Implemented in `lp/simplex/primal.rs` (`dense_retry`), counters
+> `LpDenseRetries`/`LpDenseRetryRescues`, still behind
+> `DISCOPT_LU_DENSITY_ROUTE` (default OFF).
+
 ## Appendix — raw measurement pass (2026-06-24, `JAX_PLATFORMS=cpu`, x64)
 
 Built-in split (first pass):

--- a/python/tests/data/minlplib_nl/nvs21.nl
+++ b/python/tests/data/minlplib_nl/nvs21.nl
@@ -1,0 +1,65 @@
+g3 0 1 0	# problem nvs21
+ 3 2 1 0 0	# vars, constraints, objectives, ranges, eqns
+ 2 1	# nonlinear constraints, objectives
+ 0 0	# network constraints: nonlinear, linear
+ 3 3 3	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 2 0 0	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 3	# nonzeros in Jacobian, gradients
+ 3 2	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+b
+0 0 .2
+0 0 200
+0 0 200
+x3
+0 .1
+1 1
+2 1
+r
+2 -675
+2 -.419
+C0
+o16
+o2
+o5
+v1
+n2
+v2
+C1
+o16
+o2
+o2
+n.1
+o5
+v1
+n2
+o5
+v0
+n2
+O0 0
+o16
+o2
+o2
+o2
+n2.01e-3
+o5
+v1
+n4
+v2
+o5
+v0
+n2
+k2
+1
+3
+J0 2
+1 0
+2 0
+J1 2
+0 0
+1 0
+G0 3
+0 0
+1 0
+2 0

--- a/python/tests/test_lu_density_route_dense_retry.py
+++ b/python/tests/test_lu_density_route_dense_retry.py
@@ -1,0 +1,75 @@
+"""#85 regression: the failure-triggered dense retry keeps the certificate when
+the density-aware LU route is ON (gate probe: nvs21).
+
+Before #85, ``DISCOPT_LU_DENSITY_ROUTE=1`` lost the ``optimal`` certificate on
+nvs21: a small class of node LPs fails (``Numerical``/``IterLimit``) on the
+sparse route where the historical dense-preferring route succeeds (39 vs 12
+failing solves); the failing node keeps its inherited loose lifted-McCormick
+relaxation bound, the final dual bound sticks at that value (−15 901 749 vs the
+true −5.68522), and the solve returns ``feasible`` — sound (the bound stays
+valid) but uncertified. A factorization-time conditioning gate was falsified as
+the discriminator (docs/dev/performance-plan.md §9: inverted populations — the
+failing solves factorize κ₁≈16 bases while healthy instances succeed at
+κ₁ 1e10–1e16), so the fix is failure-triggered: on such a failure the LP is
+re-solved once, cold, with the route suppressed (``dense_retry`` in
+``crates/discopt-core/src/lp/simplex/primal.rs``).
+
+This test asserts the certificate is retained with the flag ON. It fails before
+the #85 change (status ``feasible``, bound −1.59e7) and passes after (status
+``optimal``, bound ≈ −5.68522). nvs21 is a gate probe for the failure *class*
+(sparse-route LP failure → abandoned node → stuck bound); the class-level
+mechanics are unit-tested in Rust (``dense_retry_suppression_scopes_and_restores``
+and the ``route_dense_decision`` tests in ``linsolve.rs``).
+
+Marked ``slow`` (a full ~25 s B&B solve); run with ``-m slow``.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import pytest  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+
+_NL = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl", "nvs21.nl")
+
+# BARON-confirmed optimum (minlplib.solu =opt=). Minimization.
+_NVS21_OPT = -5.6847825
+# Solver-native tolerances (conftest house values).
+_ABS = 1e-4
+_REL = 1e-3
+
+
+@pytest.mark.slow
+def test_nvs21_density_route_keeps_certificate(monkeypatch):
+    """Route ON: nvs21 must certify ``optimal`` with a closed dual bound."""
+    monkeypatch.setenv("DISCOPT_LU_DENSITY_ROUTE", "1")
+    result = from_nl(_NL).solve(deterministic=True, max_nodes=200_000)
+
+    # The pre-#85 failure mode: status "feasible" with the dual bound stuck at
+    # the root relaxation value (−1.59e7). The certificate must be retained.
+    assert result.status == "optimal", (
+        f"certificate lost with DISCOPT_LU_DENSITY_ROUTE=1: status={result.status!r}, "
+        f"bound={getattr(result, 'bound', None)!r} (pre-#85 signature: feasible / −1.59e7)"
+    )
+
+    # The certified optimum must sit at the true optimum (no false-optimal).
+    assert result.objective is not None
+    err = abs(result.objective - _NVS21_OPT)
+    assert err <= _ABS or err <= _REL * abs(_NVS21_OPT), (
+        f"objective {result.objective!r} vs oracle {_NVS21_OPT}"
+    )
+
+    # The dual bound must have closed to the optimum, not merely be valid-but-
+    # loose: bound ≤ objective (min sense, validity) AND bound within tolerance
+    # of the optimum (certification). A stuck −1.59e7 bound fails the second.
+    bound = getattr(result, "bound", None)
+    assert bound is not None
+    assert bound <= result.objective + 1e-9, "certificate invariant: bound ≤ incumbent (min)"
+    assert abs(bound - _NVS21_OPT) <= 1e-2, (
+        f"dual bound {bound!r} did not close to the optimum {_NVS21_OPT} "
+        f"(pre-#85 signature: −15901749)"
+    )


### PR DESCRIPTION
## Summary

Cures the **nvs21 certificate loss** that blocked graduation of the density-aware LU route (`DISCOPT_LU_DENSITY_ROUTE`, #557/#573): with the route ON, nvs21 dropped `optimal` -> `feasible` — correct incumbent, but the dual bound stuck at the root relaxation value (−15,901,749 vs the true −5.68522). The same fragility blocked the #581 flag gates (square_cost_gate, obj_branch_priority).

**Fix: failure-triggered dense retry.** When an LP solve fails (`Numerical`/`IterLimit`) while the density route is active, re-solve that LP once, **cold**, with the route suppressed (thread-local guard) — the retry takes the exact robust dense-preferring path the default configuration uses. Flag stays **default OFF**.

## Why failure-triggered, not a conditioning gate (entry experiment #77, recorded in `docs/dev/performance-plan.md` §9)

The "ill-conditioned bases -> divert to dense" hypothesis was **falsified before implementation**. Instrumenting every sparse factorization (feral `condition_estimate_1` + `growth()`, incl. mid-solve refactorizations), attributed to the owning LP solve's outcome:

| population (route ON) | n(fact) | k1 p50 | p90 | max |
|---|---|---|---|---|
| nvs21, factorizations in FAILING solves | 59 | **1.6e1** | 1.5e9 | 7.6e18 |
| nvs21, factorizations in OPTIMAL solves | 391 | 2.1e5 | 3.1e7 | 1.0e10 |
| st_e36 (certifies optimal), OPTIMAL solves | 832 | 2.8e6 | 7.9e10 | **3.2e13** |
| nvs06 (certifies optimal), OPTIMAL solves | 72 | 5.0e8 | 7.5e12 | **1.2e16** |

The populations are **inverted**: failing solves mostly factorize beautifully conditioned bases (k1 p50 = 16); healthy instances routinely succeed at k1 1e10–1e16. `growth()` = 1.0 uniformly. No threshold exists — the failures develop during the *iteration*, invisible at factorization time. The measured mechanism is the **LP failure rate** (`Numerical`/`IterLimit` exits: 39 ON vs 12 OFF on nvs21); a failing node is abandoned with its inherited loose relaxation bound (the −1.6e7 values appear in the OFF run too — legitimately loose early lifted-McCormick bounds, not corruption).

## Implementation

- **Layer: Rust, at the three terminal LP entry points** (`solve_lp_scaled`, `solve_lp_cols`, `solve_lp_cols_warm` in `lp/simplex/primal.rs`). The dual warm path already cold-falls-back into these, so coverage is transparent to all callers (node LPs, OBBT, batch, fallback chains). Chosen over the Python `_solve_lp_warm` None-branch because it skips the re-marshal (leaner) and covers call sites the Python hook cannot see (measured: st_e07 has 10 deep retries the Python prototype never saw).
- **Soundness invariant:** the retry only ever **replaces a failure** (a `Numerical`/`IterLimit` exit carries no certificate) with the robust path's result; a suspect fast-path result is never accepted or blended; a retry that also fails falls through to the existing fallback chain exactly as before. **Cold, never warm** from the failed run's state — that state is precisely what is in doubt (sound-or-refuse). Recursion impossible: retry availability is false under suppression (unit-tested, incl. unwind safety).
- Observability: `LpDenseRetries` / `LpDenseRetryRescues` profile counters.

## Measurements

(Machine shared with concurrent benchmark agents: status/node verdicts are authoritative; walls are back-to-back min-of-2.)

**nvs21 (the blocker) — cured:**
| config | status | bound | nodes | retries/rescues |
|---|---|---|---|---|
| route ON, before | feasible | **−15,901,749 (stuck)** | 163–191 | — |
| route ON, after | **optimal** | **−5.685216 (closes)** | 191 | 30 / 27 |

**Cert panel (10 deterministic-optimal instances), OFF vs ON:** 10/10 `optimal->optimal`, node counts identical, obj drift ≤ 5.3e-12 (ex1225) / 2.8e-14 (st_e36), `incorrect_count = 0` vs minlplib.solu.

**Flag OFF (default): byte-identical** to the pre-change baseline (status+nodes+obj on all 10).

**Wins preserved (leaner than the #77 Python prototype):**
| instance | OFF | ON (this PR) | ratio | note |
|---|---|---|---|---|
| st_e36 | 24.82 s | 15.02 s | **1.65×** | prototype eroded this to 1.33× |
| nvs06 | 1.41 s | 0.72 s | **1.96×** | |
| st_e07 | 6.34 s | 5.69 s | 1.11× | earlier 7.75× partly came from silently *skipped* failing OBBT LPs; the retry now completes them honestly (obj now equals OFF exactly) |
| ex4 | optimal 461 nodes | optimal 461 nodes | — | node- and obj-identical |

## Tests / gates run

- `cargo test -p discopt-core`: **431 passed / 0 failed** (incl. new `dense_retry_suppression_scopes_and_restores`)
- `pytest -m smoke` flag OFF: **635/0**; flag ON: **635/0**
- Adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`) flag ON: **10/0**
- Regression test `python/tests/test_lu_density_route_dense_retry.py` (slow; nvs21.nl vendored, 694 B): **fails before** the change (feasible/stuck bound, or >120 s grind on current main), **passes after** (23.7 s)
- `ruff check` / `ruff format --check` clean on the new test

## Default-ON eligibility

With this fix, the #74 graduation gate's only blocker (nvs21) is cured and the panel is fully green. The flag is **default-ON eligible pending T2.6-style consecutive nightly verdicts** — not flipped in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
