### PR TITLE
perf(overhead1): task #83 — startup-floor profile + lazy SymPy in cut_recognizer

### DIFF
--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -472,6 +472,65 @@ Stage 0 (gate) ─► Stage 1 (kill recompilation — the dominant measured cost
 > Implemented in `lp/simplex/primal.rs` (`dense_retry`), counters
 > `LpDenseRetries`/`LpDenseRetryRescues`, still behind
 > `DISCOPT_LU_DENSITY_ROUTE` (default OFF).
+## Appendix B — per-solve fixed startup floor (OVERHEAD-1, task #83; 2026-07-10, `JAX_PLATFORMS=cpu`, x64)
+
+Decomposition of a fresh-process trivial solve (5× stable, ex1222/st_test1/gbd/alan/nvs01;
+timer convention of the global50 harness: starts **after** `import discopt`, so the
+measured window is `from_nl` + `solve()` and everything `solve()` lazily imports):
+
+| component | ms | in measured window? | class it hits |
+|---|---|---|---|
+| python+site+numpy+`import discopt` | ~110–130 | **no** (excluded by harness) | all |
+| `.nl` parse (`from_nl`) | 1–4 | yes | all |
+| `import jax` + devices + first tiny jit | ~240–300 | yes | nonlinear-relaxation class only — MILP/MIQP solves never import jax (measured) |
+| `import sympy` via `cut_recognizer` (solver.py structure-cut presolve) | ~100–120 | yes | **was: every solve**; now only models with a nonlinear `==` row (fixed this task) |
+| `import pounce` → `scipy.optimize` | ~125–150 | yes | every solve that reaches an NLP/QP relaxation or heuristic (incl. the MIQP node path `_pounce_qp_relaxation_nodes`) |
+| first-solve JAX trace/compile beyond imports | ~75 | yes | nonlinear class |
+| recurring engine work (trivial instance) | ~150 | yes | all (not floor) |
+
+Per-class in-window floor before the fix: MILP/MIQP ≈ 0.28–0.34 s (sympy 35–40%,
+pounce ~40%), nonlinear ≈ 0.55–0.65 s (jax ~40–45%, pounce ~25%, sympy ~18%).
+
+**Shipped (this task):** lazy SymPy in `cut_recognizer` behind its own sympy-free
+`has_square_difference_candidate` pre-check (the `symbolic/` package's lazy-SymPy
+invariant already mandated this). MILP/MIQP-class wall: st_test1 0.30→0.19 s,
+gbd 0.27→0.16 s, alan 0.34→0.23 s; ex1222 (no nonlinear `==` rows) 0.82→0.70 s.
+Verified **exactly bound-neutral** by a full differential over the 41-instance
+cert panel (pre-fix vs post-fix code, same machine, back-to-back): node_count,
+objective, and status bitwise-identical on all 41. (The committed
+`cert-baseline.jsonl` is stale vs current `main` on nvs02/nvs11/nvs12 —
+pre-existing at the branch base, confirmed by identical node counts with the
+fix reverted.)
+
+Easy-class panel (BARON-optimal-in-<1 s per the 2026-06-18 record → 30 local
+instances; TL=60, two back-to-back A/B interleaved runs each, loaded machine —
+load avg ~5–8 from sibling agents, identical conditions for A and B):
+
+| pass | median wall | p25 wall | geomean vs recorded BARON |
+|---|---|---|---|
+| before run 1 | 0.709 s | 0.273 s | 13.42× |
+| before run 2 | 0.770 s | 0.271 s | 13.75× |
+| after run 1 | 0.600 s | 0.163 s | 10.32× |
+| after run 2 | 0.570 s | 0.175 s | 10.42× |
+
+(−20% median, −37% p25, −23% geomean; every MIQP-class instance −32…−40%.)
+
+**Killed by the ≥20%-of-floor criterion (do not relitigate without new data):**
+- *Persistent JAX compilation cache* (`jax_compilation_cache_dir`): the cacheable
+  XLA-compile share of the floor is inside the ~75 ms trace+compile residue
+  (≈12% of the nonlinear-class floor; tracing, which dominates it, is not cached).
+- *Lazy-import surgery on `import discopt`* (scipy.sparse via `discopt.decomposition`
+  ≈63 ms): outside the harness window and ≈9% of the total user-facing floor.
+- *Deferring JAX init*: already the case — jax is imported only when a nonlinear
+  relaxation path runs; pure MILP/MIQP solves never touch it (measured).
+- *No-JAX fast path for linear/quadratic*: already exists (same measurement).
+
+**Out of repo (recorded, not actionable here):** (a) `import jax` ~240–300 ms is the
+single biggest remaining floor item on the nonlinear class — it is upstream cost
+(plugin discovery via `importlib.metadata` over the venv is a large slice);
+(b) `import pounce` spends ~90% of its ~140 ms importing `scipy.optimize` inside
+`pounce/_minimize.py` — a pounce-repo fix (defer scipy.optimize there) would cut
+~40% of the MILP/MIQP-class floor for every consumer.
 
 ## Appendix — raw measurement pass (2026-06-24, `JAX_PLATFORMS=cpu`, x64)
 

--- a/python/discopt/_jax/symbolic/cut_recognizer.py
+++ b/python/discopt/_jax/symbolic/cut_recognizer.py
@@ -60,18 +60,15 @@ def _ensure_sympy() -> None:
     module-level import failure).
     """
     global _SYMPY_LOADED, sp
-    global ChainCoupling, TermUnderestimator
     global eliminate_chain_coupling, power_term_underestimator, verify_cut
     if _SYMPY_LOADED:
         return
     import sympy as _sp
 
-    from discopt._jax.symbolic.constraint_cuts import (
-        ChainCoupling as _ChainCoupling,
-    )
-    from discopt._jax.symbolic.constraint_cuts import (
-        TermUnderestimator as _TermUnderestimator,
-    )
+    # ChainCoupling / TermUnderestimator are used only as annotations (evaluated
+    # never, under `from __future__ import annotations`) — they stay TYPE_CHECKING
+    # imports and are deliberately NOT rebound here (rebinding a class name trips
+    # mypy's "cannot assign to a type"). Only the runtime-called functions bind.
     from discopt._jax.symbolic.constraint_cuts import (
         eliminate_chain_coupling as _eliminate_chain_coupling,
     )
@@ -83,8 +80,6 @@ def _ensure_sympy() -> None:
     )
 
     sp = _sp
-    ChainCoupling = _ChainCoupling
-    TermUnderestimator = _TermUnderestimator
     eliminate_chain_coupling = _eliminate_chain_coupling
     power_term_underestimator = _power_term_underestimator
     verify_cut = _verify_cut

--- a/python/discopt/_jax/symbolic/cut_recognizer.py
+++ b/python/discopt/_jax/symbolic/cut_recognizer.py
@@ -30,17 +30,66 @@ cuts (the solver falls back to its normal relaxation). It is design-time
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-import sympy as sp
+if TYPE_CHECKING:
+    import sympy as sp
 
-from discopt._jax.symbolic.constraint_cuts import (
-    ChainCoupling,
-    TermUnderestimator,
-    eliminate_chain_coupling,
-    power_term_underestimator,
-    verify_cut,
-)
+    from discopt._jax.symbolic.constraint_cuts import (
+        ChainCoupling,
+        TermUnderestimator,
+        eliminate_chain_coupling,
+        power_term_underestimator,
+        verify_cut,
+    )
+
+_SYMPY_LOADED = False
+
+
+def _ensure_sympy() -> None:
+    """Bind SymPy and the SymPy-backed ``constraint_cuts`` toolkit into module globals.
+
+    Deferred (PEP 562 spirit, see ``symbolic/__init__``): ``solver.py`` imports this
+    module on *every* solve to reach the SymPy-free
+    :func:`has_square_difference_candidate` pre-check, so a module-level
+    ``import sympy`` would charge the ~0.1 s SymPy import to every solve — including
+    MILP/MIQP models that provably cannot match any pattern (OVERHEAD-1, task #83).
+    Every entry point that touches SymPy calls this first; raising
+    :class:`ImportError` here preserves the "optional ``[sympy]`` extra" contract
+    (``solver.py`` catches it at the call site exactly as it caught the old
+    module-level import failure).
+    """
+    global _SYMPY_LOADED, sp
+    global ChainCoupling, TermUnderestimator
+    global eliminate_chain_coupling, power_term_underestimator, verify_cut
+    if _SYMPY_LOADED:
+        return
+    import sympy as _sp
+
+    from discopt._jax.symbolic.constraint_cuts import (
+        ChainCoupling as _ChainCoupling,
+    )
+    from discopt._jax.symbolic.constraint_cuts import (
+        TermUnderestimator as _TermUnderestimator,
+    )
+    from discopt._jax.symbolic.constraint_cuts import (
+        eliminate_chain_coupling as _eliminate_chain_coupling,
+    )
+    from discopt._jax.symbolic.constraint_cuts import (
+        power_term_underestimator as _power_term_underestimator,
+    )
+    from discopt._jax.symbolic.constraint_cuts import (
+        verify_cut as _verify_cut,
+    )
+
+    sp = _sp
+    ChainCoupling = _ChainCoupling
+    TermUnderestimator = _TermUnderestimator
+    eliminate_chain_coupling = _eliminate_chain_coupling
+    power_term_underestimator = _power_term_underestimator
+    verify_cut = _verify_cut
+    _SYMPY_LOADED = True
+
 
 # ---------------------------------------------------------------------------
 # DAG -> SymPy
@@ -108,6 +157,7 @@ class SympyModel:
 
 def model_to_sympy(model) -> SympyModel:
     """Translate a model's objective, ``==`` and ``<=``/``>=`` constraints to SymPy."""
+    _ensure_sympy()
     from discopt.modeling import core
 
     syms: dict = {}
@@ -224,6 +274,7 @@ class ProductTerm:
 
 def find_product_terms(objective: sp.Expr) -> list[ProductTerm]:
     """Find additive terms ``coef * x * (y**k - 1)`` with x linear, y in a power."""
+    _ensure_sympy()
     out: list[ProductTerm] = []
     # Keep the objective factored so the (y**k - 1) factor stays intact.
     for term in sp.Add.make_args(objective):
@@ -387,8 +438,12 @@ def recognize_and_derive_cuts(model, *, verify: bool = True) -> list[RecognizedC
     # Cheap pre-check before the expensive SymPy translation: the pattern needs a
     # nonlinear equality constraint. Without one (e.g. a dense-objective MIQP) the
     # recognizer is a guaranteed no-op, so skip ``model_to_sympy`` outright.
+    # NOTE: keep this *above* ``_ensure_sympy()`` — the no-candidate exit must not
+    # even import SymPy (that ~0.1 s module import was a fixed per-solve tax on
+    # every MILP/MIQP; OVERHEAD-1, task #83).
     if not has_square_difference_candidate(model):
         return []
+    _ensure_sympy()
     sm = model_to_sympy(model)
     classes, fixed = _canonicalize(sm.equalities, sm.symbols)
     reverse = {sym: key for key, sym in sm.symbols.items()}
@@ -588,6 +643,7 @@ def inject_complementarity(model) -> int:
     (``c < 0``) and must be rejected — it makes the whole non-negative box
     feasible, so the cut would illegally remove feasible points.
     """
+    _ensure_sympy()
     sm = model_to_sympy(model)
     handles = _handle_map(model)
     reverse = {sym: key for key, sym in sm.symbols.items()}
@@ -632,6 +688,7 @@ def inject_binary_products(model, *, min_factors: int = 3) -> int:
     the product) but the relaxation uses the Fortet hull, which is tighter than the
     nested-bilinear McCormick relaxation for ``n >= 3``. Returns the count applied.
     """
+    _ensure_sympy()
     sm = model_to_sympy(model)
     handles = _handle_map(model)
     reverse = {sym: key for key, sym in sm.symbols.items()}
@@ -707,6 +764,8 @@ def inject_gp_cuts(model, *, samples: int = 6) -> int:
     import math
 
     import discopt.modeling as dm
+
+    _ensure_sympy()
     from discopt._jax.symbolic.log_curvature import is_monomial
 
     sm = model_to_sympy(model)
@@ -835,6 +894,7 @@ def inject_gp_constraint_cuts(model, *, samples: int = 5, max_cuts: int = 12) ->
 
     import discopt.modeling as dm
 
+    _ensure_sympy()
     sm = model_to_sympy(model)
     handles = _handle_map(model)
     reverse = {sym: key for key, sym in sm.symbols.items()}
@@ -1012,6 +1072,7 @@ def inject_signed_signomial_constraint_cuts(model, *, samples: int = 5, max_cuts
 
     import discopt.modeling as dm
 
+    _ensure_sympy()
     sm = model_to_sympy(model)
     handles = _handle_map(model)
     reverse = {sym: key for key, sym in sm.symbols.items()}


### PR DESCRIPTION
## OVERHEAD-1 (task #83): kill the fixed startup floor — profile + first remedy

### Phase 1 — profile (fresh-process trivial solves, 5x stable, JAX_PLATFORMS=cpu, x64)

Timer convention matches the global50 harness (starts after `import discopt`, so the
measured window is `from_nl` + `solve()` and everything `solve()` lazily imports):

| component | ms | in measured window? | class it hits |
|---|---|---|---|
| python+site+numpy+`import discopt` | ~110-130 | no (excluded by harness) | all |
| `.nl` parse (`from_nl`) | 1-4 | yes | all |
| `import jax` + devices + first tiny jit | ~240-300 | yes | nonlinear-relaxation class only; MILP/MIQP solves never import jax (measured) |
| `import sympy` via `cut_recognizer` (structure-cut presolve) | ~100-120 | yes | was: EVERY solve; now only models with a nonlinear `==` row |
| `import pounce` -> `scipy.optimize` | ~125-150 | yes | every solve reaching an NLP/QP relaxation (incl. the MIQP node path) |
| first-solve JAX trace/compile beyond imports | ~75 | yes | nonlinear class |
| recurring engine work (trivial instance) | ~150 | yes | all (engine, not floor) |

Per-class in-window floor before this PR: MILP/MIQP ~0.28-0.34 s (sympy 35-40%, pounce ~40%);
nonlinear ~0.55-0.65 s (jax ~40-45%, pounce ~25%, sympy ~18%). This decomposition explains the
easy-class shape (p25 ~= the no-jax class, median ~= the jax class).

### Phase 2 — remedy shipped (the one that clears the >=20%-of-floor bar and is in-repo)

`solver.py` imports `discopt._jax.symbolic.cut_recognizer` on every solve to reach its
SymPy-free `has_square_difference_candidate()` pre-check — but the module imported SymPy
(plus the SymPy-backed `constraint_cuts` names) eagerly at module level, violating the
`symbolic/` package's own documented lazy-SymPy invariant. This PR moves those imports into
`_ensure_sympy()`, called by every SymPy-touching entry point; the no-candidate exit of
`recognize_and_derive_cuts` returns before it. `ImportError` for a missing optional `[sympy]`
extra still surfaces at the `recognize_and_inject()` call site, where `solver.py` already
catches it — the contract is unchanged, and matching models run identical code after the
on-demand import.

Killed by the >=20% criterion (recorded in `docs/dev/performance-plan.md` Appendix B):
persistent JAX compilation cache (cacheable XLA share is inside the ~75 ms trace residue,
~12% of the nonlinear-class floor); lazy-import surgery on `import discopt` (~9% of total,
outside the harness window); deferring JAX init and a linear no-JAX path (both already
exist — measured: MILP/MIQP solves never import jax). Out-of-repo floor items recorded:
`import jax` itself, and `scipy.optimize` inside `pounce/_minimize` (~90% of the pounce
import; a pounce-repo fix would cut ~40% of the MILP/MIQP-class floor).

### Verification (bound-neutral regime)

- **Cert panel differential, pre-fix vs post-fix code, all 41 `cert-baseline.jsonl`
  instances, TL=60**: node_count, objective, and status **bitwise-identical on 41/41** —
  exactly bound-neutral.
- `check_cert_neutrality.py` flags nvs02/nvs11/nvs12 node regressions vs the *committed
  baseline file* — **pre-existing staleness at the branch base** (059165fc): with the fix
  reverted, the node counts are identical (nvs02 337, nvs11 55, nvs12 231, deterministic
  across repeats). The baseline JSONL predates recent main changes; not introduced here.
- `pytest python/tests -m smoke`: 635 passed, 1 skipped.
- Adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`): 10 passed.
- `pytest python/tests/test_cut_recognizer.py test_recognizer_adversarial.py`: 49 passed.
- `pytest discopt_benchmarks/tests -m smoke`: 49 passed, 1 failed —
  `test_cert_instrumentation.py::test_reduction_separation_timers_present_and_bounded`
  fails identically with the fix reverted (pre-existing on main, unrelated).
- `ruff check` + `ruff format`: clean. `mypy`: blocked by a pre-existing venv issue
  (numpy 
  stubs vs installed mypy, identical on the untouched tree).
- Rust untouched (no `cargo test` needed); the extension was rebuilt from this branch to run
  everything above.

### Measurement (easy class: BARON-optimal-in-<1 s per the recorded 2026-06-18 global50 run
-> 30 local instances; TL=60; two interleaved back-to-back A/B passes; load avg ~5-8 from
sibling agents — identical conditions for A and B, both runs reported)

| pass | median wall | p25 wall | geomean vs recorded BARON |
|---|---|---|---|
| before run 1 | 0.709 s | 0.273 s | 13.42x |
| before run 2 | 0.770 s | 0.271 s | 13.75x |
| after run 1 | 0.600 s | 0.163 s | 10.32x |
| after run 2 | 0.570 s | 0.175 s | 10.42x |

-20% median, -37% p25, -23% geomean; every MIQP-class instance -32% to -40%; objectives
identical across all four passes on all 30 instances. Honest notes: (a) the task brief cites
a 2026-07-10 40-instance/25.9x decomposition I could not locate locally — the class here is
derived from the recorded 2026-06-18 BARON times (30 instances qualify); (b) absolute walls
are inflated vs that record (machine shared with concurrent agents), so the relative A/B
comparison is the claim, not the absolute level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
