### PR TITLE
docs(crucible): rescue at-risk MAiNGO knowledge base (task #66)

### DIFF
--- a/.crucible/references.bib
+++ b/.crucible/references.bib
@@ -2522,3 +2522,25 @@
   author = {Khajavirad, A.; Michalek, J. J.; Sahinidis, N. V.},
   year = {2012},
 }
+
+@techreport{bongartz2018maingo,
+  title = {MAiNGO -- McCormick-based Algorithm for mixed-integer Nonlinear Global Optimization},
+  author = {Bongartz, D. and Najman, J. and Sass, S. and Mitsos, A.},
+  institution = {Process Systems Engineering (AVT.SVT), RWTH Aachen University},
+  year = {2018},
+  type = {Technical Report},
+  url = {https://avt-svt.pages.rwth-aachen.de/public/maingo/},
+  note = {The MAiNGO solver technical report. Ingested 2026-07-09.},
+}
+
+@article{bongartz2022maingo_overview,
+  title = {{MAiNGO} -- A Global Optimizer for Process Engineering: Algorithm and Applications in Process Design and Machine Learning},
+  author = {Bongartz, D. and Najman, J. and Mitsos, A.},
+  journal = {Chemie Ingenieur Technik},
+  volume = {94},
+  number = {3},
+  pages = {324--331},
+  year = {2022},
+  url = {https://doi.org/10.1002/cite.202255033},
+  note = {Overview of MAiNGO's algorithm and application niches. Ingested 2026-07-09.},
+}

--- a/.crucible/wiki/comparisons/maingo-vs-discopt.org
+++ b/.crucible/wiki/comparisons/maingo-vs-discopt.org
@@ -1,0 +1,171 @@
+#+TITLE: MAiNGO vs discopt
+#+FILETAGS: :comparison:maingo:discopt:mccormick:global-optimization:minlp:reduced-space:
+
+
+* MAiNGO vs discopt
+:PROPERTIES:
+:ARTICLE_TYPE: comparison
+:SOURCE_KEYS: bongartz2018maingo bongartz2017reducedspace najman2021linearization tsoukalas2014 mitsos2009 bongartz2026
+:STATUS: active
+:CREATED: 2026-07-09
+:UPDATED: 2026-07-09
+:END:
+
+[[file:../concepts/maingo-solver.org][MAiNGO]] and discopt are both deterministic global solvers for nonconvex MINLP
+built on the same theoretical foundation — [[file:../methods/mccormick-relaxations.org][McCormick relaxations]] in a
+[[file:../methods/spatial-branch-and-bound.org][spatial branch-and-bound]] with [[file:../methods/bound-tightening.org][bound tightening]]. That shared foundation makes
+MAiNGO the single most instructive architectural mirror for discopt: they differ
+less in *what math* they use than in *where in the variable space they apply it*
+and *how they implement the per-node engine*. This article maps the correspondences
+and the divergences.
+
+** Shared foundation
+
+- **McCormick relaxations as the bounding primitive.** Both derive convex/concave
+  relaxations from McCormick's factorable composition rules citep:mccormick1976 and
+  the multivariate generalization citep:tsoukalas2014. discopt implements the exact
+  Tsoukalas–Mitsos 2014 tightened composition rule in
+  =python/discopt/_jax/multivariate_mccormick.py=; MAiNGO implements it in MC++.
+- **Spatial branch-and-bound with a rigorous certificate.** Both target a proven
+  global optimum (dual bound ≤ incumbent), not just a good feasible point.
+- **OBBT + DBBT + FBBT range reduction** at nodes.
+- **Surrogate-embedded optimization as a first-class niche.** MAiNGO embeds ANNs
+  citep:schweidtmann2019ann, Gaussian processes, and trees; discopt has a parallel
+  [[file:../concepts/neural-network-embedding.org][neural-network embedding]] module (NNs and tree ensembles as algebraic
+  constraints). Both are in the OMLT/Melon lineage.
+
+** The central divergence: reduced-space propagation vs auxiliary-variable lifting
+
+This is the defining difference. MAiNGO's signature is that it **propagates
+McCormick relaxations through the model in the original (reduced) variable space,
+adding no auxiliary variables** citep:bongartz2017reducedspace,bongartz2026: the
+branch-and-bound tree branches only on the degrees of freedom, and intermediate
+quantities are hidden inside functions that return relaxations.
+
+discopt's **default** global path does the opposite. In
+=python/discopt/_jax/mccormick_lp.py= — whose own docstring reads "bilinears lifted
+to aux columns" — nonlinear terms are lifted into auxiliary LP columns, building a
+polyhedral relaxation in an *extended* variable space, exactly the
+[[file:../methods/auxiliary-variable-reformulation.org][auxiliary-variable method]] used by [[file:../concepts/baron-solver.org][BARON]], [[file:../concepts/couenne-solver.org][Couenne]], and [[file:../concepts/scip-solver.org][SCIP]]. So on its default
+path discopt sits in the AVM camp, *not* alongside MAiNGO — despite sharing the
+McCormick math.
+
+Notably, discopt already carries the machinery for MAiNGO's approach: besides the
+lifted-LP path it has multivariate-McCormick propagation
+(=multivariate_mccormick.py=) and a McCormick-NLP path (=mccormick_nlp.py=) that
+relaxes in a reduced space. The reduced-space route exists in discopt; it is simply
+not the default per-node bounding engine. Najman, Bongartz and Mitsos
+citep:najman2021linearization frame MC (reduced-space) and AVM (lifted) as
+endpoints of a spectrum that can be hybridized — a framing that maps directly onto
+discopt's having both toolchains.
+
+*Trade-off.* Reduced-space McCormick relaxations (MAiNGO) branch over far fewer
+variables but are weaker per node, because composed envelopes are not the convex
+hull of the whole expression. Lifted AVM relaxations (discopt default, BARON,
+Couenne) are tighter per node but branch over the full lifted variable set and
+build larger LPs.
+
+** Lower-bounding engine
+
+Both ultimately solve an LP for the node lower bound, but assemble and solve it
+differently:
+
+- **MAiNGO:** evaluate the McCormick relaxation, take subgradients, and *linearize*
+  each relaxation into affine cuts (supporting hyperplanes) to form an LP
+  citep:najman2021linearization; solve with CPLEX or CLP. The nonlinear convex
+  relaxation is never handed to an NLP solver by default.
+- **discopt:** build the lifted McCormick/RLT polyhedral relaxation and solve it
+  with an **in-house Rust dual simplex** (=crates/discopt-core/src/lp/simplex/=),
+  not an external LP library — a deliberate architectural bet distinct from MAiNGO's
+  reliance on CPLEX.
+
+** Implementation and platform
+
+| Dimension | MAiNGO | discopt |
+|-----------+--------+---------|
+| Core language | C++ | Rust core + Python orchestration |
+| Relaxation math | MC++ (McCormick + subgradients) | JAX DAG compiler (=_jax/=), autodiff |
+| Default variable space | reduced / original (no aux vars) | lifted / auxiliary-variable LP |
+| Node LP solver | CPLEX or CLP | in-house Rust dual simplex |
+| Interval arithmetic | FILIB++ | Rust FBBT / interval in =discopt-core= |
+| Local NLP (upper bound) | Ipopt, NLopt/SLSQP | JAX/cyipopt NLP relaxations |
+| Subgradients / AD | MC++ forward subgradient propagation | JAX =grad=/=jit=/=vmap= |
+| Parallelism / GPU | MPI B&B; GPU interval arithmetic (research) | JAX GPU acceleration for relaxations |
+| Modeling front-ends | ALE, C++, Python, GAMS | Python =discopt.modeling=, .nl parser |
+| Bound tightening | OBBT, DBBT, FBBT | OBBT, FBBT/presolve, cut inheritance |
+
+** Envelope coverage
+
+"Coverage" splits into three questions that answer differently: how many operators
+have envelopes, how tight those envelopes are, and how general the class of
+relaxable expressions is.
+
+- *Univariate function library — rough parity.* discopt supplies envelopes for a
+  broad intrinsic set (=exp=, =log/log2/log10=, =sqrt=, =x²=, integer/fractional
+  powers, =abs=, =sin=, =cos=, =tan=, =atan=, =asin=, =acos=, =sinh=, =cosh=,
+  =tanh=, =sigmoid=, =softplus=, =sign=, =asinh=, =acosh=, =atanh=, =erf=,
+  =log1p=). MC++ covers a comparably broad intrinsic set plus MAiNGO's per-function
+  custom relaxations. Neither has a decisive library-size edge on the factorable
+  core.
+- *Bilinear/multilinear tightness — discopt's lifted path is tighter per node.*
+  Both have the exact McCormick bilinear envelope (the convex hull). discopt's LP
+  path carries lifted product columns and produces the **exact multilinear hull via
+  RLT**, matching [[file:../concepts/baron-solver.org][BARON]]; trilinear/multilinear are exact there. MAiNGO's
+  reduced-space multilinear relaxations are built by *composition* and are **not**
+  the convex hull — looser per node by design, which is exactly what the MC↔AVM
+  hybridization citep:najman2021linearization buys back by selective lifting.
+  discopt's relaxation catalog records tightness as "at SOTA parity for the
+  factorable/polynomial core."
+- *Generality — MAiNGO wins on arbitrary code.* MC++ propagates McCormick
+  relaxations and subgradients through arbitrary factorable C++ code, so it relaxes
+  expressions outside a fixed operator table: implicit functions, general
+  algorithms/loops citep:mitsos2009, and embedded surrogates natively. discopt's
+  coverage is bounded by its DAG operator set and JAX relaxation rules — very broad,
+  but an envelope exists only for operators the compiler knows; its answer to
+  surrogates is the dedicated [[file:../concepts/neural-network-embedding.org][neural-network embedding]] module rather than "any
+  code."
+- *Count of specialized relaxation families — discopt is broader.* Beyond the core,
+  discopt carries rigorous α-BB (interval-Gershgorin Hessian), PSD/SOC cuts,
+  edge-concave aggregation, learned ICNN relaxations, piecewise McCormick, and
+  Taylor/Chebyshev/ellipsoidal models — more distinct strategies than MC++'s core.
+
+Net: the two cover the factorable core comparably and differ *in kind, not in
+amount* — discopt tighter and richer on structured polynomial relaxations, MAiNGO
+more general on arbitrary-code and implicit-function relaxations. This is a
+capability comparison from the catalog and the MAiNGO literature, not a measured
+head-to-head of envelope tightness; the clean experiment is a root-node dual-bound
+comparison on a shared instance set (the entry experiment in discopt issue #572).
+
+** Why the comparison matters for discopt performance
+
+The divergence is not academic — it bears directly on discopt's measured
+performance gap. discopt's investigation of its ~13× wall-time gap versus BARON on
+jointly-proved instances root-caused the dominant per-node cost to the in-house
+simplex refactorizing on nearly every pivot: the fixed-pivot-order Forrest–Tomlin
+LU update hits spurious zero pivots on the **wide dense columns that McCormick
+lifting places in the basis** (discopt issue #557; feral issue #112). Those dense
+columns are a direct consequence of the **auxiliary-variable lifting** discopt uses
+by default.
+
+MAiNGO's reduced-space propagation **structurally avoids introducing those columns
+at all** — there are no auxiliary variables to lift, so the pathological dense-column
+bases never form. This makes the MAiNGO architecture a genuine structural
+alternative to the LU-engine fix, and it is one discopt is unusually well positioned
+to explore because the reduced-space McCormick machinery already exists in the
+codebase (=multivariate_mccormick.py=, =mccormick_nlp.py=). The linearize-to-LP
+strategy citep:najman2021linearization and the MC/AVM hybridization it proposes are
+concrete templates: keep AVM where its tightness pays (dense-integer QP), fall back
+to reduced-space MC where lifting is what breaks the engine. The trade-off to weigh
+is MAiNGO's known weakness — reduced-space relaxations are looser per node, so a
+switch trades tighter bounds (fewer nodes) for a cheaper, better-conditioned
+per-node solve (more nodes, faster each).
+
+** Bottom line
+
+MAiNGO and discopt are close cousins with the same McCormick DNA and the same
+surrogate-embedding ambitions, split by one architectural axis: MAiNGO relaxes in
+the reduced space and leans on CPLEX; discopt relaxes in a lifted space by default
+and runs its own Rust simplex. Each choice sets up its own dominant cost — MAiNGO
+pays in looser per-node bounds, discopt pays in dense-column LP bases that stress
+its factorization. The reduced-space path MAiNGO pioneered is the most promising
+structural lever discopt has not yet pulled by default.

--- a/.crucible/wiki/concepts/maingo-solver.org
+++ b/.crucible/wiki/concepts/maingo-solver.org
@@ -1,0 +1,113 @@
+#+TITLE: MAiNGO Solver
+#+FILETAGS: :concept:maingo:solver:global-optimization:minlp:mccormick:reduced-space:
+
+
+* MAiNGO Solver
+:PROPERTIES:
+:ARTICLE_TYPE: concept
+:SOURCE_KEYS: bongartz2018maingo bongartz2017reducedspace najman2021linearization tsoukalas2014 mitsos2009 schweidtmann2019ann bongartz2022maingo_overview bongartz2026
+:STATUS: active
+:CREATED: 2026-07-09
+:UPDATED: 2026-07-09
+:END:
+
+MAiNGO (McCormick-based Algorithm for mixed-integer Nonlinear Global
+Optimization) is an open-source deterministic global optimization solver for
+nonconvex mixed-integer nonlinear programs (MINLPs), written in C++ and developed
+by the Process Systems Engineering group (AVT.SVT) at RWTH Aachen University
+(Bongartz, Najman, Sass, Mitsos) citep:bongartz2018maingo. Like
+[[file:baron-solver.org][BARON]], [[file:couenne-solver.org][Couenne]], and
+[[file:scip-solver.org][SCIP]], it is a spatial branch-and-bound solver that
+produces a rigorous optimality certificate; its distinguishing feature is *where*
+and *how* it builds convex relaxations.
+
+** The defining idea: relaxations in the original variable space
+
+The state-of-the-art global solvers relax nonconvex models via the
+[[file:../methods/auxiliary-variable-reformulation.org][auxiliary-variable method]] (AVM): every factorable expression is decomposed into
+elementary operations, one auxiliary variable is introduced per intermediate node,
+and [[file:../methods/mccormick-relaxations.org][McCormick envelopes]] / RLT rows
+are written on those auxiliary variables in a *lifted* space. MAiNGO's central
+design choice is the opposite: it **propagates McCormick relaxations through the
+computational graph in the original (reduced) optimization variable space, adding
+no auxiliary variables to the problem** citep:bongartz2018maingo,bongartz2026.
+
+It does this with **multivariate McCormick relaxations** citep:tsoukalas2014 — a
+generalization of McCormick's 1976 composition rules citep:mccormick1976 — together
+with **subgradient propagation** citep:mitsos2009: as the code list is evaluated,
+convex/concave relaxation values *and* their subgradients are carried forward by
+the chain rule. The machinery is implemented in the open-source MC++ library,
+which uses FILIB++ interval arithmetic underneath.
+
+** Reduced-space formulation and hidden model parts
+
+Because relaxations propagate through the model rather than needing an auxiliary
+variable per intermediate, the branch-and-bound tree can branch over only the
+**degrees of freedom** — the true decision variables — while all intermediate
+quantities are computed inside externally-defined functions that return values and
+McCormick relaxations citep:bongartz2017reducedspace. For a process flowsheet the
+optimizer sees a handful of design variables and few equality constraints; stream
+states, unit calculations, and even implicit-equation solutions are "hidden." When
+the number of degrees of freedom is far smaller than the number of intermediate
+variables, MAiNGO branches on a dramatically smaller space than an AVM solver,
+which must branch over the full lifted set. This is the source of its computational
+advantage on reduced-space-amenable problems.
+
+The same mechanism makes MAiNGO a natural host for **surrogate-embedded**
+optimization: artificial neural networks citep:schweidtmann2019ann, Gaussian
+processes, and decision trees are written as functions returning McCormick
+relaxations, and MAiNGO branches only on their inputs — the same territory as the
+OMLT/Melon toolboxes and discopt's own [[file:neural-network-embedding.org][neural-network embedding]] module.
+
+The trade-off is bound tightness: relaxations built by composition are generally
+**weaker per node** than the tightest AVM/RLT relaxation of the same model, because
+composed McCormick envelopes are not the convex hull of the whole expression.
+MAiNGO trades per-node tightness for a much smaller branching space.
+
+** Lower bounding: linearize the McCormick relaxation into an LP
+
+At a node MAiNGO evaluates the McCormick relaxation of the objective and each
+constraint over the current box, obtaining convex underestimators and concave
+overestimators together with subgradients at a reference point. It then
+**linearizes** these relaxations using the subgradients — each subgradient yields a
+supporting hyperplane, i.e. one affine cut — to assemble a linear program that is
+solved once for a valid lower bound citep:najman2021linearization. MAiNGO does not,
+by default, hand the nonlinear convex relaxation to an NLP solver; it solves an LP
+built from subgradient linearizations, which is cheaper and globally solved in a
+single pass. The number and placement of linearization points is a tuning knob:
+one point gives a loose but cheap LP, several points per relaxation give a tighter
+LP with more rows. Najman, Bongartz and Mitsos citep:najman2021linearization show
+that the pure-McCormick (MC) and auxiliary-variable (AVM) approaches are endpoints
+of a spectrum and can be **hybridized** — selectively lifting some subexpressions
+to auxiliary variables to recover AVM tightness where it pays, while keeping the
+small MC variable space elsewhere. The LP is solved with CPLEX or COIN-OR CLP.
+
+** Bound tightening
+
+MAiNGO applies both flavors of [[file:../methods/bound-tightening.org][bound tightening]] at nodes:
+**OBBT** (optimization-based) solves auxiliary LPs that minimize/maximize each
+variable over the relaxation to contract the box, and **DBBT** (duality-based) uses
+the LP dual multipliers and reduced costs from the lower-bounding LP to tighten
+variable bounds cheaply, in the spirit of Ryoo–Sahinidis range reduction. Interval
+constraint propagation (FBBT) is also used.
+
+** Upper bounding, integers, and ecosystem
+
+Feasible incumbents come from multistart local NLP solves via Ipopt or NLopt/SLSQP.
+Integers are handled by relaxing integrality for the LP lower bound and branching
+on both discrete and continuous variables. MAiNGO exposes a C++ API, the ALE
+algebraic modeling language, a Python interface, and a GAMS interface; it
+parallelizes its branch-and-bound over MPI ranks, with recent work on GPU-parallel
+interval arithmetic for the bounding kernels citep:bongartz2022maingo_overview. Its
+strongest niches are process-systems flowsheet optimization and
+machine-learning-surrogate-embedded global optimization.
+
+** Relevance to discopt
+
+MAiNGO is the reference McCormick-based global solver, and discopt shares the same
+McCormick foundation — making it the most instructive architectural comparison in
+the field. The key difference is that discopt's default global path lifts nonlinear
+terms into auxiliary LP columns (the AVM family, like BARON/Couenne), whereas
+MAiNGO propagates McCormick in the reduced space. That single choice explains much
+of their differing performance behavior; see [[file:../comparisons/maingo-vs-discopt.org][MAiNGO vs discopt]] for the detailed
+comparison.

--- a/docs/dev/consolidation-2026-07-10.md
+++ b/docs/dev/consolidation-2026-07-10.md
@@ -1,0 +1,88 @@
+# Session Consolidation — 2026-07-10 (gap-closing campaign)
+
+Single source of truth for what the gap-closing campaign produced, what is merged,
+what is parked, and what is at risk. Created in response to "consolidate what we
+have and make sure it is not lost."
+
+## 1. Merged this session (all on `main`, CI-green)
+
+| PR | what |
+|---|---|
+| #582 | reduced-space evaluator refuses non-finite boxes (nvs22 root cause #1) |
+| #583 | P2.3 wire `DISCOPT_RELAX_SPACE=reduced` (MAiNGO parity, default-OFF, sound on nvs22) |
+| #584 | P2.4 entry experiment — reduced-space never beats lifted; auto-select KILLED |
+| #585 | gap-closing execution plan (`docs/dev/gap-closing-execution-plan.md`) |
+| #586 | STRUCT-1 — CSE verified already-on-main (median 25% DAG reduction) |
+| #587 | CUTS-1 — aggregation c-MIR NO-GO (separator already sound + root already tight) |
+| #588 | MAIN-HEALTH — cert:T0.3 `solver_stats` schema (restore green main) |
+| #589 | TAIL-1c — `root_gap_ratio_vs_baron` now evaluable (added BARON root ref; fails at 2.69×) |
+| #590 | TAIL-1a — certification-stall attribution (diagnostic) |
+| #591 | **A-2 — failure-triggered dense LP retry; CURES the nvs21 certificate loss** |
+| #592 | **OVERHEAD-1 — lazy-SymPy; −20% median / −37% p25 startup on the easy class, bound-neutral** |
+| #593 | TAIL-1b — binary `.nl` parsing (transcode-to-text; st_miqp5 readable; +1 coverage) |
+| #594 | rescue MAiNGO Crucible KB (task #66 — was uncommitted/at-risk) |
+
+## 2. Flag inventory (authoritative from `main` `solver_tuning.py`, 2026-07-10)
+
+**Graduated / default-ON** (on the hot path today):
+`RLT_QUAD`, `MULTILINEAR_SEPARATE`, `TRILINEAR_RLT`, `SQUARE_SEPARATE`,
+`EDGE_CONCAVE`, `PSD_COST_GATE`, `LP_WARMSTART`, cut-pool inheritance
+(structure-gated, #55/#61), root-heuristic governor/RENS (#44).
+
+**Parked / default-OFF** (implemented + wired, awaiting graduation or killed):
+| flag | status |
+|---|---|
+| `ROOT_FIXPOINT` | branch-and-reduce root loop (in main via #524). #581 gave a −14% verdict but it did **not reproduce** under re-test; graduation OPEN. |
+| `NODE_REDUCE` | per-node FBBT + reduced-cost DBBT (in main via #524). Blocked by an st_e36 cert loss (LP-failure class) — re-gate now that A-2/#591 is merged (BR-3). |
+| `LU_DENSITY_ROUTE` | density-aware sparse LU + **A-2 dense retry (#591) that cures nvs21**. Re-gate for default-ON (BR-3). |
+| `SQUARE_COST_GATE` | sound; nvs21 cert loss (LP-failure class) — re-gate post-A-2. |
+| `OBJ_BRANCH_PRIORITY` | sound; nvs21 cert loss — re-gate post-A-2. |
+| `LIFTED_FBBT` | sound; st_e30 cert loss. |
+| `ALPHABB_WITH_LP` | sound; no perf gain when LP relaxer active (KEEP-OPT-IN). |
+| `RLT` | default-OFF (RLT_QUAD is the graduated variant). |
+| `RELAX_SPACE=reduced` | MAiNGO reduced-space; sound, opt-in; auto-select KILLED (P2.4, #584). |
+
+Nothing here is lost — every flag is implemented in `main` and tracked. Several
+nvs21/st_e36 cert losses share ONE mechanism (sparse-route LP failures) that A-2
+(#591) now cures → BR-3 re-gates them together.
+
+## 3. Binding falsifications this session (do not relitigate)
+
+- Reduced-space McCormick never tightens the root bound vs lifted (P2.4, #584).
+- Aggregation c-MIR already exists + discopt root already at SCIP-with-cuts strength
+  (#587).
+- CSE/hash-consing already in main (#453); V-segments have 0 applicable instances
+  (#586).
+- LU condition estimate does NOT discriminate failing bases; the mechanism is LP
+  failure-rate; fix is failure-triggered retry (perf-plan §9, #591).
+- **`root_fixpoint` in isolation is ≈neutral** (re-tested 2026-07-10). Whether the
+  full branch-and-reduce STACK (root+node reduce + strengthen, run together) beats
+  baseline is UNDER INVESTIGATION — the correct experiment is combined, not
+  per-flag (see §4).
+
+## 4. Open threads
+
+- **Branch-and-reduce as a SYSTEM.** Per-flag testing shows each reduce flag is
+  marginal alone. Combined-stack experiment (root_fixpoint + node_reduce +
+  lifted_fbbt + density-retry + RLT/strengthen, all ON) vs baseline on the
+  tree-opening class is running. Early signal: the stack is NOT collapsing trees
+  the way BARON does → likely a genuinely missing capability (candidates:
+  per-node OBBT is class-gated to n≤100; OBBT candidate scoring is index-order
+  not width×|RC| (T2.5 unbuilt); OBBT budget ~10% TL). This is the real gap to
+  branch-and-reduce parity — BR-2 scope.
+- **BR-3** — re-gate the nvs21/st_e36-blocked flags (node_reduce, density route,
+  square_cost_gate, obj_branch_priority, TD-A/lift-loose-products for nvs09) now
+  that A-2 cures the LP-failure class.
+- **BR-2** — Phase-2 completion (per-node OBBT declass, T2.5 scoring, warm probes,
+  in-tree probing). Note: T2.4a node-LP duals ARE already exposed (main), contrary
+  to the plan's stale note.
+
+## 5. Workspace hygiene (needs the maintainer)
+
+The primary checkout `/Users/jkitchin/projects/discopt` is on
+`fix-467-unbounded-root` — **195 commits behind `main`** — with uncommitted work
+(the MAiNGO Crucible KB, now rescued in #594; plus benchmark result JSONs and a
+stray `tim.lst`). Recommendation: after #594 merges, reconcile this checkout onto
+`main` (stash/commit the remaining `.crucible` MANIFEST/index edits or regenerate
+them via the crucible CLI). No solver code is at risk — origin/main has all merged
+work; this is a local-branch hygiene item.


### PR DESCRIPTION
## Rescue at-risk MAiNGO Crucible knowledge base (task #66)

The MAiNGO research deliverable from task #66 was never committed anywhere — it existed only as **uncommitted files in a working checkout sitting on `fix-467-unbounded-root` (195 commits behind main)**. Surfaced during a consolidation audit; rescuing it to main so it can't be lost.

Contents:
- `.crucible/wiki/concepts/maingo-solver.org` (113 lines) — MAiNGO solver distillation
- `.crucible/wiki/comparisons/maingo-vs-discopt.org` (171 lines) — MAiNGO↔discopt capability comparison
- `.crucible/references.bib` — `bongartz2018maingo`, `bongartz2022maingo_overview` (additive; no existing entries touched)

Wiki graph registration (`MANIFEST.md`/`index.org`) is intentionally omitted — those are CLI-generated and hand-editing risks corruption; regenerate with `crucible` after merge. This PR preserves the irreplaceable prose + citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
