### PR TITLE
docs: zero-warning jupyter-book build (132 → 0)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,6 +2,12 @@ title: discopt
 author: John Kitchin
 copyright: "2026, John Kitchin"
 logo: discopt-logo.png
+# Internal planning/design notes live under dev/ and design/; they are not book
+# pages, so keep them out of the Sphinx source tree (otherwise every one warns
+# "document isn't included in any toctree").
+exclude_patterns:
+  - dev
+  - design
 execute:
   execute_notebooks: "off"
 repository:

--- a/docs/gams_solver_link.md
+++ b/docs/gams_solver_link.md
@@ -3,7 +3,7 @@
 discopt can act as a **solver inside GAMS**: once registered, a GAMS user solves
 a model with discopt the same way they would call BARON, SCIP, or CONOPT:
 
-```gams
+```text
 option minlp = discopt;
 solve m using minlp minimizing z;
 ```
@@ -52,7 +52,7 @@ discopt gams-register          # writes ~/.gams/gamsconfig.yaml + the launcher
 
 Then, in any GAMS model:
 
-```gams
+```text
 option minlp = discopt;        // and/or lp/mip/nlp/... = discopt
 solve m using minlp minimizing z;
 ```

--- a/docs/notebooks/benchmark_dashboard.ipynb
+++ b/docs/notebooks/benchmark_dashboard.ipynb
@@ -15,7 +15,8 @@
     "The benchmarking methodology follows the Dolan-Moré performance profile\n",
     "framework {cite:p}`DolanMore2002` with shifted geometric mean timing\n",
     "as recommended by {cite:t}`Mittelmann2023`."
-   ]
+   ],
+   "id": "48eff1e34a88"
   },
   {
    "cell_type": "code",
@@ -44,7 +45,8 @@
     "%matplotlib inline\n",
     "plt.rcParams[\"figure.figsize\"] = (10, 6)\n",
     "plt.rcParams[\"figure.dpi\"] = 100"
-   ]
+   ],
+   "id": "ba84e5418b38"
   },
   {
    "cell_type": "markdown",
@@ -55,7 +57,8 @@
     "Load the most recent JSON results from the `results/` directory.\n",
     "Each JSON file contains a `BenchmarkResults` serialization with\n",
     "per-solver, per-instance solve data."
-   ]
+   ],
+   "id": "c80533685c84"
   },
   {
    "cell_type": "code",
@@ -106,7 +109,8 @@
     "        print(f\"No results found for {cat}\")\n",
     "\n",
     "print(f\"\\nLoaded {len(all_data)} categories\")"
-   ]
+   ],
+   "id": "b7df66e7c9d8"
   },
   {
    "cell_type": "markdown",
@@ -115,7 +119,8 @@
     "## Build DataFrames\n",
     "\n",
     "Convert JSON results into pandas DataFrames for analysis."
-   ]
+   ],
+   "id": "d70f0e271a71"
   },
   {
    "cell_type": "code",
@@ -288,7 +293,8 @@
     "print(f\"Solvers: {df['solver'].unique().tolist()}\")\n",
     "print(f\"Categories: {df['category'].unique().tolist()}\")\n",
     "df.head()"
-   ]
+   ],
+   "id": "d9f11bb455b8"
   },
   {
    "cell_type": "code",
@@ -572,7 +578,8 @@
     ")\n",
     "summary[\"solve_rate\"] = summary[\"solved\"] / summary[\"total\"]\n",
     "summary"
-   ]
+   ],
+   "id": "e14f4e37b1c7"
   },
   {
    "cell_type": "markdown",
@@ -582,7 +589,8 @@
     "\n",
     "Dolan-Moré performance profiles {cite:p}`DolanMore2002` show the fraction\n",
     "of problems solved within a factor $\\\\tau$ of the best solver's time."
-   ]
+   ],
+   "id": "5dfdd4474159"
   },
   {
    "cell_type": "code",
@@ -676,7 +684,8 @@
     "    plt.show()\n",
     "else:\n",
     "    print(\"No data to plot\")"
-   ]
+   ],
+   "id": "5d59342792e3"
   },
   {
    "cell_type": "markdown",
@@ -687,7 +696,8 @@
     "Pairwise solver comparison: each point is an instance,\n",
     "axes are log-scale solve times. Points below the diagonal\n",
     "indicate the x-axis solver is faster."
-   ]
+   ],
+   "id": "b7901b2a2a1e"
   },
   {
    "cell_type": "code",
@@ -759,7 +769,8 @@
     "                pair_idx += 1\n",
     "        plt.tight_layout()\n",
     "        plt.show()"
-   ]
+   ],
+   "id": "01376bebe32d"
   },
   {
    "cell_type": "markdown",
@@ -768,7 +779,8 @@
     "## Iteration Count Comparison\n",
     "\n",
     "Bar chart comparing median iteration counts across solvers."
-   ]
+   ],
+   "id": "a5549080a376"
   },
   {
    "cell_type": "code",
@@ -826,7 +838,8 @@
     "    plt.show()\n",
     "else:\n",
     "    print(\"No iteration data available\")"
-   ]
+   ],
+   "id": "82d9daa7e9a0"
   },
   {
    "cell_type": "markdown",
@@ -836,7 +849,8 @@
     "\n",
     "For global optimization instances, analyze the quality of bounds\n",
     "and the optimality gap at termination."
-   ]
+   ],
+   "id": "83ecd44b0eb9"
   },
   {
    "cell_type": "code",
@@ -896,7 +910,8 @@
     "    plt.show()\n",
     "else:\n",
     "    print(\"No global_opt data available\")"
-   ]
+   ],
+   "id": "07a97c11730d"
   },
   {
    "cell_type": "markdown",
@@ -905,7 +920,8 @@
     "## Historical Trends\n",
     "\n",
     "If JSONL history files are available, plot solved counts over time."
-   ]
+   ],
+   "id": "4334ba76f91a"
   },
   {
    "cell_type": "code",
@@ -979,7 +995,8 @@
     "        print(\"No history files found\")\n",
     "else:\n",
     "    print(\"No history directory found. Run benchmarks first.\")"
-   ]
+   ],
+   "id": "acc8f9546f55"
   }
  ],
  "metadata": {

--- a/docs/notebooks/bilevel.ipynb
+++ b/docs/notebooks/bilevel.ipynb
@@ -15,7 +15,8 @@
     "The leader picks $x$; the follower responds with the $y$ that is optimal for\n",
     "*its* problem. This models toll setting, network interdiction, pricing, and\n",
     "Stackelberg competition {cite:p}`Bard1998,Dempe2002,ColsonMarcotteSavard2007`.\n"
-   ]
+   ],
+   "id": "a30184abc295"
   },
   {
    "cell_type": "markdown",
@@ -38,7 +39,8 @@
     "be convex (LP or convex-QP) \u2014 nonconvex / integer-follower / pessimistic problems\n",
     "are refused loudly rather than silently mis-solved\n",
     "{cite:p}`KleinertLabbeLjubicSchmidt2021`.\n"
-   ]
+   ],
+   "id": "887b0ace5ef4"
   },
   {
    "cell_type": "markdown",
@@ -50,7 +52,8 @@
     "gradient must be an ordinary expression (not an opaque numeric callback). The\n",
     "`discopt.bilevel.symbolic_diff` engine provides `diff`/`grad` over the\n",
     "expression DAG:\n"
-   ]
+   ],
+   "id": "c73ea3fd77d2"
   },
   {
    "cell_type": "code",
@@ -65,7 +68,8 @@
     "x = m.continuous('x', lb=-5, ub=5)\n",
     "expr = x**2 + 3 * x\n",
     "print('d/dx (x^2 + 3x) =', diff(expr, x))   # simplifies to (x + x) + 3\n"
-   ]
+   ],
+   "id": "016107c4df64"
   },
   {
    "cell_type": "markdown",
@@ -79,7 +83,8 @@
     "in $f$, so `BilevelProblem` replaces it by its KKT conditions. We build the model\n",
     "and *formulate* it \u2014 turning it into a single-level MPEC \u2014 then inspect the\n",
     "emitted conditions (no solver needed for this step):\n"
-   ]
+   ],
+   "id": "1fbf87baa3e4"
   },
   {
    "cell_type": "code",
@@ -104,7 +109,8 @@
     "print('stationarity:', bl.kkt.stationarity[0].body)\n",
     "for p in bl.kkt.comp_pairs:\n",
     "    print('complementarity: 0 <=', p.f, 'perp', p.g, '>= 0')\n"
-   ]
+   ],
+   "id": "9bb77b084c7c"
   },
   {
    "cell_type": "markdown",
@@ -122,7 +128,8 @@
     "$t^\\* = 2.5$, $f^\\* = 2.5$ (revenue $6.25$). Because the complementarity is\n",
     "encoded exactly (GDP), the returned solution carries a global optimality\n",
     "certificate.\n"
-   ]
+   ],
+   "id": "2e42efe176f6"
   },
   {
    "cell_type": "markdown",
@@ -130,10 +137,9 @@
    "source": [
     "## References\n",
     "\n",
-    "```{bibliography}\n",
-    ":filter: docname in docnames\n",
-    "```\n"
-   ]
+    "See the [References](../references.md) page for full citations."
+   ],
+   "id": "f5e93dae8b31"
   }
  ],
  "metadata": {

--- a/docs/notebooks/decomposition_advisor.ipynb
+++ b/docs/notebooks/decomposition_advisor.ipynb
@@ -25,7 +25,8 @@
     "analysis \u2014 no solve is triggered \u2014 so it runs without the compiled solver\n",
     "backend; running the chosen decomposition is covered in the\n",
     "[Benders](tutorial_benders) and [Lagrangian](tutorial_lagrangian) tutorials."
-   ]
+   ],
+   "id": "b4cf0c14643d"
   },
   {
    "cell_type": "code",
@@ -41,7 +42,8 @@
     "import discopt.modeling as dm\n",
     "from discopt.decomposition import RecordStore, analyze_decomposition, record_outcome\n",
     "from discopt.decomposition.learning import ObservedPerformance, Outcome"
-   ]
+   ],
+   "id": "0ff6d9567fba"
   },
   {
    "cell_type": "markdown",
@@ -55,7 +57,8 @@
     "row **couples the binaries**, so the model is *not* already block-diagonal. But\n",
     "once the binaries are fixed, the recourse splits into three independent blocks:\n",
     "the textbook Benders structure."
-   ]
+   ],
+   "id": "87e57ed88946"
   },
   {
    "cell_type": "code",
@@ -74,7 +77,8 @@
     "m.subject_to(b[0] + b[1] + b[2] <= 2)                        # budget couples the binaries\n",
     "m.minimize((x[0] + x[1] + x[2]) - 3 * (b[0] + b[1] + b[2]))\n",
     "print(m)"
-   ]
+   ],
+   "id": "c1e6995a184c"
   },
   {
    "cell_type": "markdown",
@@ -86,7 +90,8 @@
     "`StructureReport` summarizes the exploitable structure in one pass \u2014 sizes,\n",
     "integer localization (how many recourse blocks appear once the integers are\n",
     "fixed), coupling density, and more."
-   ]
+   ],
+   "id": "fa66bec1ee48"
   },
   {
    "cell_type": "code",
@@ -96,7 +101,8 @@
    "source": [
     "adv = m.analyze_decomposition()\n",
     "print(adv.structure().summary())"
-   ]
+   ],
+   "id": "79bc8c47d570"
   },
   {
    "cell_type": "markdown",
@@ -108,7 +114,8 @@
     "generators. Each candidate reuses the existing `DecompositionStructure`, so it\n",
     "can drive the shipping solvers directly. The monolithic *no-decomposition*\n",
     "baseline is always included."
-   ]
+   ],
+   "id": "64dca2b2dce5"
   },
   {
    "cell_type": "code",
@@ -118,7 +125,8 @@
    "source": [
     "for c in adv.candidates():\n",
     "    print(\"-\", c.summary())"
-   ]
+   ],
+   "id": "4e0dc35b4004"
   },
   {
    "cell_type": "markdown",
@@ -130,7 +138,8 @@
     "(anchored at 0): a decomposition must *beat* solving the model as written. The\n",
     "score carries an analytic performance estimate (an Amdahl-style speedup capped by\n",
     "load balance) and a confidence. Unsound candidates are vetoed, not down-weighted."
-   ]
+   ],
+   "id": "7ef76838f1a4"
   },
   {
    "cell_type": "code",
@@ -140,7 +149,8 @@
    "source": [
     "for cand, sv in adv.scores():\n",
     "    print(f\"{cand.method.label:22s} {sv.summary()}\")"
-   ]
+   ],
+   "id": "60a3c4609c5c"
   },
   {
    "cell_type": "markdown",
@@ -151,7 +161,8 @@
     "Every recommendation is explainable \u2014 the reasons are backed by the same metrics\n",
     "the scorer used, with concerns and the runner-up alternatives. The explanation\n",
     "renders as text, markdown, or JSON (the JSON feeds tooling / the LLM layer)."
-   ]
+   ],
+   "id": "37e07ef55392"
   },
   {
    "cell_type": "code",
@@ -160,7 +171,8 @@
    "outputs": [],
    "source": [
     "print(adv.explain())"
-   ]
+   ],
+   "id": "3d4975b92828"
   },
   {
    "cell_type": "code",
@@ -169,7 +181,8 @@
    "outputs": [],
    "source": [
     "print(adv.explain(\"json\"))"
-   ]
+   ],
+   "id": "76e307cef31d"
   },
   {
    "cell_type": "markdown",
@@ -182,7 +195,8 @@
     "*not* already block-diagonal and an independent-block decomposition does not apply.\n",
     "(Lagrangian relaxation, by contrast, *is* a viable alternative \u2014 it appears as a\n",
     "runner-up above, since the budget row can be dualized.)"
-   ]
+   ],
+   "id": "efbc2628d99e"
   },
   {
    "cell_type": "code",
@@ -191,7 +205,8 @@
    "outputs": [],
    "source": [
     "print(adv.explain(method=\"independent_blocks\"))"
-   ]
+   ],
+   "id": "ede9728ff5b8"
   },
   {
    "cell_type": "markdown",
@@ -203,7 +218,8 @@
     "master/subproblem partition with a **soundness certificate** and an\n",
     "original-space **variable mapping**. Its `solve()` (not called here) dispatches to\n",
     "the shipping Benders / GBD / Lagrangian drivers."
-   ]
+   ],
+   "id": "e711db8fd4e4"
   },
   {
    "cell_type": "code",
@@ -217,7 +233,8 @@
     "print(\"variable roles:\")\n",
     "for name in [\"b0\", \"b1\", \"b2\", \"x0\", \"x1\", \"x2\"]:\n",
     "    print(f\"  {name}: {dcmp.var_map.role(name)}\")"
-   ]
+   ],
+   "id": "019a97260822"
   },
   {
    "cell_type": "markdown",
@@ -231,7 +248,8 @@
     "per-block function and reduces results **back into block order**, so the answer is\n",
     "deterministic regardless of backend. Here we map a trivial pure-Python function\n",
     "(the block size) rather than a real solve."
-   ]
+   ],
+   "id": "1a4227621edb"
   },
   {
    "cell_type": "code",
@@ -242,7 +260,8 @@
     "print(dcmp.schedule().summary())\n",
     "block_sizes = dcmp.map_subproblems(lambda sp: sp.size, backend=\"threads\")\n",
     "print(\"recourse block sizes (block order):\", block_sizes)"
-   ]
+   ],
+   "id": "93973edb16d9"
   },
   {
    "cell_type": "markdown",
@@ -255,7 +274,8 @@
     "measurable and future recommendations can improve. Records persist as local JSON\n",
     "lines; an `InstanceBasedPolicy` retrieves nearest past instances to bias\n",
     "selection (deferring safely to the rule-based policy until enough data accrues)."
-   ]
+   ],
+   "id": "f18f8339908f"
   },
   {
    "cell_type": "code",
@@ -275,7 +295,8 @@
     "print(\"chosen           :\", rec.chosen)\n",
     "print(\"predicted speedup:\", rec.predicted_speedup)\n",
     "print(\"features         :\", rec.features.to_dict())"
-   ]
+   ],
+   "id": "27e68b7d471d"
   },
   {
    "cell_type": "markdown",
@@ -292,7 +313,8 @@
     "Future directions (design spec \u00a714) include automatic hypergraph partitioning for\n",
     "block-angular models {cite:p}`KarypisKumar1998`, learned decomposition policies,\n",
     "and graph-neural-network structure prediction."
-   ]
+   ],
+   "id": "ea3fe8d9b812"
   }
  ],
  "metadata": {

--- a/docs/notebooks/differentiable_milp.ipynb
+++ b/docs/notebooks/differentiable_milp.ipynb
@@ -21,7 +21,8 @@
     "discopt handles integer models with **fix-and-differentiate**: solve the\n",
     "MILP/MIQP, *fix the integers at their optimal values*, and differentiate the\n",
     "resulting continuous restriction at the incumbent."
-   ]
+   ],
+   "id": "86458cc6a6de"
   },
   {
    "cell_type": "markdown",
@@ -47,7 +48,8 @@
     "objective has a kink and the gradient is one-sided \u2014 the value returned is that\n",
     "of the incumbent assignment's restriction, which is the right object when the\n",
     "discrete decision is being held fixed for learning."
-   ]
+   ],
+   "id": "1daf5f777e38"
   },
   {
    "cell_type": "code",
@@ -62,7 +64,8 @@
     "import numpy as np\n",
     "import discopt.modeling as dm\n",
     "from discopt._jax.differentiable import differentiable_solve"
-   ]
+   ],
+   "id": "2d79af89b61e"
   },
   {
    "cell_type": "markdown",
@@ -73,7 +76,8 @@
     "Minimize $p\\,y + x$ subject to $x \\ge 3 - y$, with $y\\in\\{0,1\\}$ and\n",
     "$x\\in[0,10]$. For a small fixed charge $p<1$ it pays to 'switch on' $y=1$,\n",
     "giving $x=2$ and objective $p+2$ \u2014 so $d\\,\\text{obj}^\\*/dp = 1$."
-   ]
+   ],
+   "id": "04b3d8850504"
   },
   {
    "cell_type": "code",
@@ -96,7 +100,8 @@
     "print('objective:', round(float(res.objective), 6))\n",
     "print('y*, x*   :', float(np.asarray(res.x['y'])), float(np.asarray(res.x['x'])))\n",
     "print('d(obj)/dp:', round(float(res.gradient(p)), 6))"
-   ]
+   ],
+   "id": "168414660c47"
   },
   {
    "cell_type": "markdown",
@@ -104,7 +109,8 @@
    "source": [
     "The analytic gradient matches a central finite difference of the *re-solved*\n",
     "objective \u2014 confirming it is the true sensitivity, not a relaxation surrogate."
-   ]
+   ],
+   "id": "08ed7dc94aa0"
   },
   {
    "cell_type": "code",
@@ -119,7 +125,8 @@
     "\n",
     "print('analytic:', round(float(res.gradient(p)), 6))\n",
     "print('finite-diff:', round(float(fd_gradient(fixed_charge, 0.5)), 6))"
-   ]
+   ],
+   "id": "64762526803e"
   },
   {
    "cell_type": "markdown",
@@ -131,7 +138,8 @@
     "$p>0.5$ the continuous optimum wants $x=p$ but the constraint binds at $x=0.5$\n",
     "with $y=0$, so the gradient flows through the active constraint:\n",
     "$d\\,\\text{obj}^\\*/dp = 2(p-0.5)$."
-   ]
+   ],
+   "id": "f9a818241024"
   },
   {
    "cell_type": "code",
@@ -153,7 +161,8 @@
     "print('objective:', round(float(r2.objective), 6), ' expected', (0.5 - 2.0) ** 2)\n",
     "print('analytic :', round(float(r2.gradient(p2)), 6), ' expected 2*(2-0.5) =', 2 * (2.0 - 0.5))\n",
     "print('finite-diff:', round(float(fd_gradient(miqp_binding, 2.0)), 6))"
-   ]
+   ],
+   "id": "b8f821e274b8"
   },
   {
    "cell_type": "markdown",
@@ -166,7 +175,8 @@
     "composition decision-focused learning needs {cite:p}`Elmachtoub2022`. Here we\n",
     "backpropagate a downstream squared loss on the optimal objective through the\n",
     "integer solve."
-   ]
+   ],
+   "id": "62bb459ec183"
   },
   {
    "cell_type": "code",
@@ -188,7 +198,8 @@
     "p_vec = jnp.array([0.5])\n",
     "print('obj       :', round(float(layer(p_vec)), 6))\n",
     "print('d loss/dp :', round(float(np.asarray(jax.grad(loss)(p_vec))[0]), 6))"
-   ]
+   ],
+   "id": "d6db6a5dac24"
   },
   {
    "cell_type": "markdown",
@@ -209,7 +220,8 @@
     "- `make_milp_objective_layer` exposes this as a `jax.custom_vjp` for use inside\n",
     "  `jax.grad` / `jax.jit` / `jax.vmap`, mirroring the LP/QP/NLP layers\n",
     "  {cite:p}`Amos2017,Agrawal2019`."
-   ]
+   ],
+   "id": "ca50952e3bff"
   }
  ],
  "metadata": {

--- a/docs/notebooks/infeasibility_iis.ipynb
+++ b/docs/notebooks/infeasibility_iis.ipynb
@@ -13,7 +13,8 @@
     "feasible if **any single member is removed** {cite:p}`Chinneck2008`. It is the\n",
     "smallest self-contained explanation of the conflict \u2014 the analogue of Gurobi's\n",
     "`computeIIS` and CPLEX's conflict refiner."
-   ]
+   ],
+   "id": "a2959f5db5f8"
   },
   {
    "cell_type": "markdown",
@@ -38,7 +39,8 @@
     "subsystem; it is *irreducible* exactly when every probe was conclusive \u2014 always\n",
     "the case for LP / MILP / convex models. `IISResult.proven_irreducible` reports\n",
     "which guarantee you have."
-   ]
+   ],
+   "id": "b3daf02d5e7b"
   },
   {
    "cell_type": "code",
@@ -51,7 +53,8 @@
     "os.environ.setdefault('JAX_ENABLE_X64', '1')\n",
     "\n",
     "import discopt.modeling as dm"
-   ]
+   ],
+   "id": "a6863be9a7e0"
   },
   {
    "cell_type": "markdown",
@@ -62,7 +65,8 @@
     "Here `x` is pushed above 5 and below 2 \u2014 a contradiction \u2014 while two other\n",
     "constraints are perfectly satisfiable. `solve()` only reports *infeasible*; the\n",
     "IIS pinpoints the two constraints that actually clash."
-   ]
+   ],
+   "id": "09d9b1902379"
   },
   {
    "cell_type": "code",
@@ -81,7 +85,8 @@
     "\n",
     "res = m.solve()\n",
     "print('solve status:', res.status)"
-   ]
+   ],
+   "id": "480596762eee"
   },
   {
    "cell_type": "code",
@@ -92,7 +97,8 @@
     "iis = m.compute_iis()\n",
     "print(iis.summary())\n",
     "print('\\nfeasibility solves used:', iis.n_solves)"
-   ]
+   ],
+   "id": "c8f5ad8d1b86"
   },
   {
    "cell_type": "markdown",
@@ -101,7 +107,8 @@
     "Out of four constraints, the IIS names exactly `demand_floor` and\n",
     "`capacity_cap` \u2014 the two you would edit to fix the model \u2014 and confirms the\n",
     "result is provably minimal."
-   ]
+   ],
+   "id": "660c2245aaeb"
   },
   {
    "cell_type": "markdown",
@@ -113,7 +120,8 @@
     "`compute_iis` also treats finite variable bounds as removable members, so it can\n",
     "surface a clash between a bound and a constraint. Here the lower bound `x >= 5`\n",
     "fights the constraint `x <= 2`:"
-   ]
+   ],
+   "id": "64309651444d"
   },
   {
    "cell_type": "code",
@@ -130,7 +138,8 @@
     "\n",
     "iis2 = m2.compute_iis()\n",
     "print(iis2.summary())"
-   ]
+   ],
+   "id": "7de38b36c58b"
   },
   {
    "cell_type": "markdown",
@@ -139,7 +148,8 @@
     "The IIS reports both the constraint `cap` **and** the variable bound `x >= 5`,\n",
     "while ignoring the unrelated variable `z`. Pass `include_bounds=False` to restrict\n",
     "the IIS to explicit constraints only."
-   ]
+   ],
+   "id": "f37160725530"
   },
   {
    "cell_type": "markdown",
@@ -150,7 +160,8 @@
     "Deletion filtering works for any class the solver can certify infeasible \u2014\n",
     "including integrality. Requiring an integer strictly between 3 and 4 is\n",
     "infeasible, and the IIS isolates the two bracketing constraints:"
-   ]
+   ],
+   "id": "be6fdc002064"
   },
   {
    "cell_type": "code",
@@ -166,7 +177,8 @@
     "\n",
     "print('status:', m3.solve().status)\n",
     "print(m3.compute_iis(include_bounds=False).summary())"
-   ]
+   ],
+   "id": "685388a75858"
   },
   {
    "cell_type": "markdown",
@@ -190,7 +202,8 @@
     "actionable list of the constraints and bounds that conflict \u2014 computed by sound\n",
     "deletion filtering {cite:p}`Chinneck1991` on discopt's own solver, with an\n",
     "explicit minimality guarantee."
-   ]
+   ],
+   "id": "3e42ff8bd5a6"
   }
  ],
  "metadata": {

--- a/docs/notebooks/llm_integration.ipynb
+++ b/docs/notebooks/llm_integration.ipynb
@@ -16,7 +16,8 @@
     "LLM features are **purely advisory** — they never affect solver correctness.\n",
     "All formulations pass through `model.validate()` before use.\n",
     "```"
-   ]
+   ],
+   "id": "efa5da7ff691"
   },
   {
    "cell_type": "markdown",
@@ -43,7 +44,8 @@
     "# Or use a local model (no API key needed):\n",
     "export DISCOPT_LLM_MODEL=\"ollama/llama3\"\n",
     "```"
-   ]
+   ],
+   "id": "c34f967a0301"
   },
   {
    "cell_type": "code",
@@ -71,7 +73,8 @@
     "from discopt.llm import is_available\n",
     "\n",
     "print(f\"LLM features available: {is_available()}\")"
-   ]
+   ],
+   "id": "687a2f58d3bb"
   },
   {
    "cell_type": "markdown",
@@ -81,7 +84,8 @@
     "\n",
     "The `serializer` module converts discopt models and results into structured text\n",
     "that LLMs can understand. This is used internally by all LLM features."
-   ]
+   ],
+   "id": "47d88e3eff9d"
   },
   {
    "cell_type": "code",
@@ -159,7 +163,8 @@
     "\n",
     "m.validate()\n",
     "print(serialize_model(m))"
-   ]
+   ],
+   "id": "561ac3a450fe"
   },
   {
    "cell_type": "markdown",
@@ -169,7 +174,8 @@
     "\n",
     "The advisor analyzes model structure and recommends solver parameters using\n",
     "rule-based heuristics. With `llm=True`, it augments suggestions with LLM analysis."
-   ]
+   ],
+   "id": "84d801a66099"
   },
   {
    "cell_type": "code",
@@ -206,7 +212,8 @@
     "print(\"Recommended solver parameters:\")\n",
     "for key, value in params.items():\n",
     "    print(f\"  {key}: {value}\")"
-   ]
+   ],
+   "id": "88d79324d863"
   },
   {
    "cell_type": "markdown",
@@ -216,7 +223,8 @@
     "\n",
     "Analyze a model for reformulation opportunities: big-M tightening,\n",
     "McCormick partitioning, symmetry breaking, bound tightening."
-   ]
+   ],
+   "id": "7e07c2fc2c31"
   },
   {
    "cell_type": "code",
@@ -250,7 +258,8 @@
     "for i, s in enumerate(suggestions, 1):\n",
     "    print(f\"{i}. [{s.category}] {s.description}\")\n",
     "    print(f\"   Impact: {s.impact}\\n\")"
-   ]
+   ],
+   "id": "c4a57bd0710a"
   },
   {
    "cell_type": "markdown",
@@ -265,7 +274,8 @@
     "result = m.solve()\n",
     "print(result.explain(llm=True))\n",
     "```"
-   ]
+   ],
+   "id": "bdb73755d939"
   },
   {
    "cell_type": "markdown",
@@ -290,7 +300,8 @@
     "if result.status == \"infeasible\":\n",
     "    print(diagnose_infeasibility(m_bad, result))\n",
     "```"
-   ]
+   ],
+   "id": "0c3bb95ea5ac"
   },
   {
    "cell_type": "markdown",
@@ -313,7 +324,8 @@
     "session.send(\"Solve it and explain the result\")\n",
     "session.close()\n",
     "```"
-   ]
+   ],
+   "id": "f2589b5e9fd7"
   },
   {
    "cell_type": "markdown",
@@ -336,7 +348,8 @@
     ")\n",
     "print(model.summary())\n",
     "```"
-   ]
+   ],
+   "id": "4abad3424849"
   },
   {
    "cell_type": "markdown",
@@ -361,7 +374,8 @@
     "import os\n",
     "os.environ[\"DISCOPT_LLM_MODEL\"] = \"ollama/llama3\"\n",
     "```"
-   ]
+   ],
+   "id": "fd8def186eb3"
   }
  ],
  "metadata": {

--- a/docs/notebooks/minlp_examples.ipynb
+++ b/docs/notebooks/minlp_examples.ipynb
@@ -13,7 +13,8 @@
     "3. **MINLPLib** instances loaded from `.nl` files\n",
     "\n",
     "For each example, we verify the solution against known optimal values."
-   ]
+   ],
+   "id": "fd3a72ccc1c8"
   },
   {
    "cell_type": "code",
@@ -45,7 +46,8 @@
     "import numpy as np\n",
     "\n",
     "print(\"discopt loaded successfully\")"
-   ]
+   ],
+   "id": "ea4d48fcecec"
   },
   {
    "cell_type": "markdown",
@@ -56,7 +58,8 @@
     "$$\\min_{x,y} \\; (x - 2)^2 + (y + 1)^2, \\quad x, y \\in [-5, 5]$$\n",
     "\n",
     "**Known optimal:** $x^* = 2, \\; y^* = -1, \\; f^* = 0$"
-   ]
+   ],
+   "id": "de47ff48c35b"
   },
   {
    "cell_type": "code",
@@ -95,7 +98,8 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 2.0)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: -1.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ]
+   ],
+   "id": "151cb6e5a463"
   },
   {
    "cell_type": "markdown",
@@ -106,7 +110,8 @@
     "$$\\min_{x,y} \\; (1 - x)^2 + 100(y - x^2)^2, \\quad x, y \\in [-5, 5]$$\n",
     "\n",
     "The classic banana-shaped valley. **Known optimal:** $x^* = 1, \\; y^* = 1, \\; f^* = 0$"
-   ]
+   ],
+   "id": "84862d8e8abe"
   },
   {
    "cell_type": "code",
@@ -152,7 +157,8 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 1.0)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: 1.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ]
+   ],
+   "id": "24ae8964d2da"
   },
   {
    "cell_type": "markdown",
@@ -163,7 +169,8 @@
     "$$\\min_{x,y} \\; x^2 + y^2 \\quad \\text{s.t.} \\quad x + y \\geq 1, \\quad x, y \\in [-5, 5]$$\n",
     "\n",
     "**Known optimal:** $x^* = y^* = 0.5, \\; f^* = 0.5$"
-   ]
+   ],
+   "id": "0d672bed0ff2"
   },
   {
    "cell_type": "code",
@@ -203,7 +210,8 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 0.5)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: 0.5)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ]
+   ],
+   "id": "669c913247eb"
   },
   {
    "cell_type": "markdown",
@@ -214,7 +222,8 @@
     "$$\\min_{x,y} \\; x^2 + y^2 \\quad \\text{s.t.} \\quad xy = 1, \\quad x, y \\in [0.1, 5]$$\n",
     "\n",
     "**Known optimal:** $x^* = y^* = 1, \\; f^* = 2$"
-   ]
+   ],
+   "id": "2aac29f2d784"
   },
   {
    "cell_type": "code",
@@ -254,7 +263,8 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 1.0)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: 1.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ]
+   ],
+   "id": "abe934dde8d4"
   },
   {
    "cell_type": "markdown",
@@ -265,7 +275,8 @@
     "$$\\min_{x,y} \\; e^x + y^2 \\quad \\text{s.t.} \\quad x + y \\geq 1, \\quad x, y \\in [-2, 2]$$\n",
     "\n",
     "From KKT conditions: $e^x = 2y$ and $x + y = 1$, giving $f^* \\approx 1.8395$."
-   ]
+   ],
+   "id": "e63575a7d40f"
   },
   {
    "cell_type": "code",
@@ -305,7 +316,8 @@
     "print(f\"x = {result.value(x):.6f}\")\n",
     "print(f\"y = {result.value(y):.6f}\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ]
+   ],
+   "id": "0e1462f52aae"
   },
   {
    "cell_type": "markdown",
@@ -318,7 +330,8 @@
     "The binary variable $x_3$ is minimized, so $x_3^* = 0$. The continuous part reduces to a constrained quadratic.\n",
     "\n",
     "**Known optimal:** $x_1^* = x_2^* = 0.5, \\; x_3^* = 0, \\; f^* = 0.5$"
-   ]
+   ],
+   "id": "766738e9ef38"
   },
   {
    "cell_type": "code",
@@ -362,7 +375,8 @@
     "print(f\"x2 = {result.value(x2):.6f}  (expected: 0.5)\")\n",
     "print(f\"x3 = {result.value(x3):.6f}  (expected: 0.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s | Nodes: {result.node_count}\")"
-   ]
+   ],
+   "id": "dd09574f2087"
   },
   {
    "cell_type": "markdown",
@@ -373,7 +387,8 @@
     "$$\\min_{x, y_1, y_2} \\; (x - 3)^2 + 2 y_1 + 3 y_2 \\quad \\text{s.t.} \\quad x \\leq 5 y_1, \\; x \\leq 4 y_2, \\; x \\in [0, 5], \\; y_1, y_2 \\in \\{0, 1\\}$$\n",
     "\n",
     "**Known optimal:** $x^* = 3, \\; y_1^* = 1, \\; y_2^* = 1, \\; f^* = 5.0$"
-   ]
+   ],
+   "id": "15d987c288b5"
   },
   {
    "cell_type": "code",
@@ -417,7 +432,8 @@
     "print(f\"y1 = {result.value(y1):.6f}  (expected: 1.0)\")\n",
     "print(f\"y2 = {result.value(y2):.6f}  (expected: 1.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s | Nodes: {result.node_count}\")"
-   ]
+   ],
+   "id": "4594f9e467ec"
   },
   {
    "cell_type": "markdown",
@@ -428,7 +444,8 @@
     "$$\\min_{n, x} \\; (x - 2.7)^2 + (n - 3)^2 \\quad \\text{s.t.} \\quad x + n \\leq 6, \\; x \\in [0, 5], \\; n \\in \\{0, 1, \\ldots, 5\\}$$\n",
     "\n",
     "**Known optimal:** $x^* = 2.7, \\; n^* = 3, \\; f^* = 0.0$"
-   ]
+   ],
+   "id": "2d5bdeda55fd"
   },
   {
    "cell_type": "code",
@@ -468,7 +485,8 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 2.7)\")\n",
     "print(f\"n = {result.value(n):.6f}  (expected: 3.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s | Nodes: {result.node_count}\")"
-   ]
+   ],
+   "id": "707b3b82814d"
   },
   {
    "cell_type": "markdown",
@@ -479,7 +497,8 @@
     "$$\\min_{x,y} \\; -\\log(x) - \\log(y) \\quad \\text{s.t.} \\quad x + y \\leq 1, \\; x, y \\in [0.01, 0.99]$$\n",
     "\n",
     "**Known optimal:** $x^* = y^* = 0.5, \\; f^* = 2 \\ln(2) \\approx 1.3863$"
-   ]
+   ],
+   "id": "ee99f21beb8c"
   },
   {
    "cell_type": "code",
@@ -522,7 +541,8 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 0.5)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: 0.5)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ]
+   ],
+   "id": "5bdaba889327"
   },
   {
    "cell_type": "markdown",
@@ -535,7 +555,8 @@
     "discopt can also load standard `.nl` format files from the MINLPLib {cite:p}`Bussieck2003` benchmark library. These are parsed by the Rust backend and solved through the same B&B engine.\n",
     "\n",
     "Below we solve several MINLPLib instances and compare against published optimal values."
-   ]
+   ],
+   "id": "17f3ec544e44"
   },
   {
    "cell_type": "code",
@@ -634,7 +655,8 @@
     "    )\n",
     "\n",
     "print(f\"\\nCorrect: {n_correct}/{n_total}\")"
-   ]
+   ],
+   "id": "137c5367e26e"
   },
   {
    "cell_type": "markdown",
@@ -643,7 +665,8 @@
     "## 11. Direct Comparison: discopt vs. cyipopt\n",
     "\n",
     "For continuous NLP problems, we can compare discopt's solution against a raw cyipopt (Ipopt {cite:p}`Wachter2006`) solve to verify correctness."
-   ]
+   ],
+   "id": "3a80e89b24c0"
   },
   {
    "cell_type": "code",
@@ -763,7 +786,8 @@
     "print(f\"x difference:        {x_diff:.2e}\")\n",
     "print(f\"y difference:        {y_diff:.2e}\")\n",
     "print(f\"Match: {'YES' if obj_diff < 1e-6 else 'NO'}\")"
-   ]
+   ],
+   "id": "c738cd71edd3"
   },
   {
    "cell_type": "markdown",
@@ -805,7 +829,8 @@
     "Available nonlinear functions: `dm.exp`, `dm.log`, `dm.sqrt`, `dm.sin`, `dm.cos`, `dm.tan`, `dm.abs`\n",
     "\n",
     "Load from files: `dm.from_nl(\"problem.nl\")`"
-   ]
+   ],
+   "id": "134d78097c5b"
   }
  ],
  "metadata": {

--- a/docs/notebooks/nn_embedding.ipynb
+++ b/docs/notebooks/nn_embedding.ipynb
@@ -14,7 +14,8 @@
     "strong MIP formulations of {cite:p}`Anderson2020`, adapted to discopt's\n",
     "expression DAG, JAX automatic differentiation, and McCormick relaxations\n",
     "for spatial branch-and-bound."
-   ]
+   ],
+   "id": "1af01718fa25"
   },
   {
    "cell_type": "markdown",
@@ -31,7 +32,8 @@
     "  - `relu_bigm` — Big-M MILP formulation for ReLU networks using binary variables.\n",
     "  - `reduced_space` — Nested expressions with no intermediate variables (small networks).\n",
     "- **`load_onnx`**: Load trained models from ONNX format (covers scikit-learn, PyTorch, Keras exports)."
-   ]
+   ],
+   "id": "79c3cd373dda"
   },
   {
    "cell_type": "markdown",
@@ -41,7 +43,8 @@
     "\n",
     "We'll train a small neural network to approximate a function,\n",
     "then find the input that minimizes the network's output subject to constraints."
-   ]
+   ],
+   "id": "eaa5bdf011fe"
   },
   {
    "cell_type": "code",
@@ -64,7 +67,8 @@
     "    NetworkDefinition,\n",
     "    NNFormulation,\n",
     ")"
-   ]
+   ],
+   "id": "9949ea878aab"
   },
   {
    "cell_type": "markdown",
@@ -75,7 +79,8 @@
     "Here we manually specify a small 2-layer ReLU network.\n",
     "In practice, you would train this with scikit-learn, PyTorch, etc.\n",
     "and load via `load_onnx()`."
-   ]
+   ],
+   "id": "4aef39cc4ec8"
   },
   {
    "cell_type": "code",
@@ -116,7 +121,8 @@
     "\n",
     "print(f\"Network: {net.input_size} -> {net.layers[0].n_outputs} -> {net.output_size}\")\n",
     "print(f\"Forward pass at [0, 0]: {net.forward(np.array([0.0, 0.0]))}\")"
-   ]
+   ],
+   "id": "bfdd973ed25e"
   },
   {
    "cell_type": "markdown",
@@ -127,7 +133,8 @@
     "The `relu_bigm` strategy introduces binary variables for each ReLU neuron\n",
     "where the pre-activation value can be positive or negative.\n",
     "Interval arithmetic bound propagation computes tight big-M constants."
-   ]
+   ],
+   "id": "11e401970a32"
   },
   {
    "cell_type": "code",
@@ -166,7 +173,8 @@
     "m.subject_to(nn.inputs[0] + nn.inputs[1] >= -1.0, name=\"sum_lb\")\n",
     "\n",
     "print(m.summary())"
-   ]
+   ],
+   "id": "410ef8853eca"
   },
   {
    "cell_type": "code",
@@ -203,7 +211,8 @@
     "x_opt = result.value(nn.inputs)\n",
     "nn_check = net.forward(x_opt)\n",
     "print(f\"NumPy forward check: {nn_check}\")"
-   ]
+   ],
+   "id": "9919e5214892"
   },
   {
    "cell_type": "markdown",
@@ -214,7 +223,8 @@
     "For networks with smooth activations (sigmoid, tanh, softplus),\n",
     "the `full_space` strategy creates nonlinear constraints that get\n",
     "McCormick relaxations and JAX automatic differentiation."
-   ]
+   ],
+   "id": "3d856c143c04"
   },
   {
    "cell_type": "code",
@@ -264,7 +274,8 @@
     "print(f\"Status: {result2.status}\")\n",
     "print(f\"Optimal objective: {result2.objective:.6f}\")\n",
     "print(f\"Optimal inputs: {result2.value(nn2.inputs)}\")"
-   ]
+   ],
+   "id": "f7ff7b71fbcf"
   },
   {
    "cell_type": "markdown",
@@ -282,7 +293,8 @@
     "Choose `full_space` for smooth networks when you want tight McCormick\n",
     "relaxations for global optimization. Choose `reduced_space` for very\n",
     "small networks where compilation overhead matters."
-   ]
+   ],
+   "id": "640cba7e2047"
   }
  ],
  "metadata": {

--- a/docs/notebooks/robust_adjustable.ipynb
+++ b/docs/notebooks/robust_adjustable.ipynb
@@ -52,7 +52,8 @@
     "                        ↓\n",
     "                  Deterministic model: optimize over (x, y₀, Y_cols)\n",
     "```"
-   ]
+   ],
+   "id": "68db47573f34"
   },
   {
    "cell_type": "code",
@@ -74,7 +75,8 @@
     "\n",
     "import discopt.modeling as dm\n",
     "from discopt.ro import AffineDecisionRule, BoxUncertaintySet, RobustCounterpart"
-   ]
+   ],
+   "id": "5c7aba482253"
   },
   {
    "cell_type": "markdown",
@@ -90,7 +92,8 @@
     "$$\n",
     "\n",
     "We compare three approaches: nominal (ignore uncertainty), static robust (worst-case $d=100$), and adjustable robust (recourse adapts to realized demand)."
-   ]
+   ],
+   "id": "bf8ca5c83f66"
   },
   {
    "cell_type": "code",
@@ -154,7 +157,8 @@
     "print(f\"\\nADR policy: Y0 = {r_adj.x['adr_Y0']:.4f}\")\n",
     "print(\"  Y0~0 means no adaptation (same as static)\")\n",
     "print(\"  Y0~1 would mean full adaptation to demand\")"
-   ]
+   ],
+   "id": "7c24b14ccc54"
   },
   {
    "cell_type": "markdown",
@@ -163,7 +167,8 @@
     "In this example, the here-and-now order $x$ is cheap (\\$2) while the emergency recourse $y$ is expensive (\\$8). The ADR recovers the static robust solution because the optimal strategy is to order everything upfront at the cheap price rather than wait. The ADR correctly sets $Y_0 \\approx 0$ (no adaptation), confirming that recourse has no value when the first-stage option dominates on cost.\n",
     "\n",
     "For ADR to strictly outperform static robust, the uncertainty must enter constraints in **opposing directions** so that static must over-hedge while the adaptive policy can compensate. The next example demonstrates this."
-   ]
+   ],
+   "id": "146b70c82216"
   },
   {
    "cell_type": "markdown",
@@ -178,7 +183,8 @@
     "$$\n",
     "\n",
     "The static solution must simultaneously hedge against $z = +1$ (constraint 1) and $z = -1$ (constraint 2), requiring $x = 2$. The ADR sets $y(z) = z$, which perfectly counteracts the uncertainty in both constraints, needing only $x = 1$. This is a 50% reduction in cost."
-   ]
+   ],
+   "id": "ce2dfa17d78c"
   },
   {
    "cell_type": "code",
@@ -247,7 +253,8 @@
     "    c1 = r_a.x[\"x\"] + y_val - (1 + z_val)\n",
     "    c2 = r_a.x[\"x\"] - y_val - (1 - z_val)\n",
     "    print(f\"  z={z_val:+.0f}: y={y_val:+.2f}, c1={c1:.2f}, c2={c2:.2f}\")"
-   ]
+   ],
+   "id": "9f049f5d593c"
   },
   {
    "cell_type": "markdown",
@@ -299,7 +306,8 @@
     "- The policy matrix scales as $\\dim(y) \\times n_\\xi$ new scalar variables,\n",
     "  which can be large for high-dimensional problems.\n",
     "- Non-affine recourse (polynomial, piecewise-linear) is not yet supported."
-   ]
+   ],
+   "id": "04e5bdcda144"
   }
  ],
  "metadata": {

--- a/docs/notebooks/sets_and_indexing.ipynb
+++ b/docs/notebooks/sets_and_indexing.ipynb
@@ -15,7 +15,8 @@
     "The whole layer is **pure-Python sugar**: a named set is the authoritative index\n",
     "for variables/parameters/constraints, and everything desugars to the same flat\n",
     "model the solver already consumes. No solver or backend changes are involved."
-   ]
+   ],
+   "id": "50e877f4a961"
   },
   {
    "cell_type": "markdown",
@@ -25,7 +26,8 @@
     "\n",
     "A `Set` holds an order-stable, de-duplicated collection of **hashable** members.\n",
     "Members may be scalars (`dimen == 1`) or fixed-arity tuples (`dimen == N`)."
-   ]
+   ],
+   "id": "4bea867ce70c"
   },
   {
    "cell_type": "code",
@@ -39,7 +41,8 @@
     "plants = m.set(\"plants\", [\"pitt\", \"sf\", \"nyc\"])\n",
     "markets = m.set(\"markets\", [\"a\", \"b\", \"c\", \"d\"])\n",
     "print(plants, \"| dimen =\", plants.dimen, \"| len =\", len(plants))"
-   ]
+   ],
+   "id": "aeaa0bd990e5"
   },
   {
    "cell_type": "markdown",
@@ -52,7 +55,8 @@
     "and JuMP {cite:p}`Dunning2017` use to express sparse index structure. Cross\n",
     "products are **lazy**, and filtering a product materializes only the members\n",
     "that pass the predicate (JuMP's `SparseAxisArray`-via-condition)."
-   ]
+   ],
+   "id": "a99d694eb1bf"
   },
   {
    "cell_type": "code",
@@ -65,7 +69,8 @@
     "print(\"dense grid :\", len(plants * markets))\n",
     "print(\"sparse links:\", len(links))\n",
     "print((\"nyc\", \"a\") in links, (\"pitt\", \"a\") in links)"
-   ]
+   ],
+   "id": "2efaefea3835"
   },
   {
    "cell_type": "markdown",
@@ -77,7 +82,8 @@
     "variable, so `ship[\"pitt\", \"a\"]` desugars to the ordinary indexing the solver\n",
     "already understands. Bounds may be a scalar, a `dict` keyed by member, or a\n",
     "callable `fn(member)`."
-   ]
+   ],
+   "id": "9faab57869eb"
   },
   {
    "cell_type": "code",
@@ -90,7 +96,8 @@
     "cap = m.continuous(\"cap\", over=plants, lb=0, ub=supply)  # dict bounds\n",
     "print(ship)\n",
     "print(\"ship[pitt, a] ->\", ship[\"pitt\", \"a\"])  # an indexing expression"
-   ]
+   ],
+   "id": "03ff182a746b"
   },
   {
    "cell_type": "markdown",
@@ -102,7 +109,8 @@
     "`name[key]`. Tuple members are unpacked into the rule's arguments, and a rule\n",
     "may return `dm.Skip` to omit a member (Pyomo's `Constraint.Skip`\n",
     "{cite:p}`Hart2017`)."
-   ]
+   ],
+   "id": "f4a05a64da05"
   },
   {
    "cell_type": "code",
@@ -121,7 +129,8 @@
     "             lambda k: dm.sum(ship[p, k] for p in plants if (p, k) in links) >= demand[k],\n",
     "             name=\"demand\")\n",
     "print(\"variables:\", len(m._variables), \" sets:\", len(m._sets))"
-   ]
+   ],
+   "id": "38b99611799b"
   },
   {
    "cell_type": "markdown",
@@ -131,7 +140,8 @@
     "\n",
     "`dm.sum` and `dm.prod` accept generators over sets, or a callable plus `over=`.\n",
     "For `dimen > 1` sets, tuple members are unpacked: `dm.sum(lambda p, k: ..., over=links)`."
-   ]
+   ],
+   "id": "b060a5ecfcc0"
   },
   {
    "cell_type": "code",
@@ -141,7 +151,8 @@
    "source": [
     "total_out = dm.sum(lambda p, k: ship[p, k], over=links)\n",
     "print(total_out)"
-   ]
+   ],
+   "id": "dbbef849d38a"
   },
   {
    "cell_type": "markdown",
@@ -151,7 +162,8 @@
     "\n",
     "A complete transportation model {cite:p}`Fourer2003` built from named sets, then\n",
     "solved. Values come back keyed by set member via `IndexedVar.value`."
-   ]
+   ],
+   "id": "cbb8fa25cafd"
   },
   {
    "cell_type": "code",
@@ -173,7 +185,8 @@
     "res = t.solve()\n",
     "print(res.status, round(res.objective, 3))\n",
     "print(x.value(res))"
-   ]
+   ],
+   "id": "a37d5c316626"
   },
   {
    "cell_type": "markdown",
@@ -193,7 +206,8 @@
     "call into the Rust builder instead of thousands of expression objects. This is a\n",
     "pure performance path \u2014 the resulting model and solution are identical, and any\n",
     "family that isn't single-variable-affine transparently falls back."
-   ]
+   ],
+   "id": "d276a86f4ddc"
   },
   {
    "cell_type": "markdown",
@@ -210,7 +224,8 @@
     "\n",
     "Both produce the *same* flat model \u2014 named sets add labels, sparsity, and set\n",
     "algebra without changing the math."
-   ]
+   ],
+   "id": "5e318de3dceb"
   }
  ],
  "metadata": {

--- a/docs/notebooks/stochastic_programming.ipynb
+++ b/docs/notebooks/stochastic_programming.ipynb
@@ -18,7 +18,8 @@
     "protects the *worst case* over an uncertainty set, stochastic programming optimizes\n",
     "the *average* over a distribution {cite:p}`ShapiroDentchevaRuszczynski2021`. With a\n",
     "finite scenario set $\\{\\xi_s, p_s\\}$ the expectation is $\\sum_s p_s Q(x,\\xi_s)$.\n"
-   ]
+   ],
+   "id": "628047c4c050"
   },
   {
    "cell_type": "markdown",
@@ -30,7 +31,8 @@
     "equivalent* \u2014 via a **scenario-creator callback** that constructs each scenario's\n",
     "recourse. Here is the classic **newsvendor**: order $q$ at cost $c$, then in each\n",
     "demand scenario sell $\\min(q, d_s)$ at price $r$ (revenue = negative cost).\n"
-   ]
+   ],
+   "id": "0153031eccfd"
   },
   {
    "cell_type": "code",
@@ -59,7 +61,8 @@
     "                          first_stage_cost=Constant(2.0) * q,  # cost 2/unit\n",
     "                          risk=Expectation())\n",
     "print('scenarios:', len(scen), '| expected-value objective built')\n"
-   ]
+   ],
+   "id": "d92446be87dc"
   },
   {
    "cell_type": "markdown",
@@ -69,7 +72,8 @@
     "`m.solve()` would return the certified order quantity (the classic critical-fractile\n",
     "solution). The Birge\u2013Louveaux **farmer** problem {cite:p}`BirgeLouveaux2011` is built\n",
     "the same way, with per-scenario planting/selling recourse.\n"
-   ]
+   ],
+   "id": "de5bc4623bd1"
   },
   {
    "cell_type": "markdown",
@@ -80,7 +84,8 @@
     "Beyond the risk-neutral expectation, `discopt.stochastic` provides **CVaR**\n",
     "(Conditional Value-at-Risk) via the Rockafellar\u2013Uryasev formulation\n",
     "{cite:p}`RockafellarUryasev2000`, which penalizes the worst-tail scenarios:\n"
-   ]
+   ],
+   "id": "7aa2f112e3f8"
   },
   {
    "cell_type": "code",
@@ -97,7 +102,8 @@
     "                               risk=CVaR(alpha=0.9))   # penalize worst 10%\n",
     "aux = [v.name for v in mc._variables if v.name.startswith('cvar')]\n",
     "print('CVaR auxiliaries (VaR + per-scenario shortfalls):', aux)\n"
-   ]
+   ],
+   "id": "a96de27c227a"
   },
   {
    "cell_type": "markdown",
@@ -105,7 +111,8 @@
    "source": [
     "A **chance constraint** $P(g(x,\\xi)\\le 0)\\ge 1-\\varepsilon$ is imposed (under SAA)\n",
     "with a per-scenario indicator and a coverage budget:\n"
-   ]
+   ],
+   "id": "267fa08d082b"
   },
   {
    "cell_type": "code",
@@ -120,7 +127,8 @@
     "z = chance_constraint(mch, [x - Constant(d) for d in demands],\n",
     "                      probs=[0.25]*4, epsilon=0.25, big_m=1000.0)\n",
     "print('indicator binaries:', len(z), '(\u03a3 p_s z_s \u2264 \u03b5 caps the violation prob.)')\n"
-   ]
+   ],
+   "id": "fc045741af78"
   },
   {
    "cell_type": "markdown",
@@ -133,7 +141,8 @@
     "master, each scenario a subproblem, and cuts approximate the expected recourse. The\n",
     "probability weighting rides in the objective, so the decomposition engine is reused\n",
     "unchanged. `solve_lshaped(..., solve=False)` builds the model and its structure:\n"
-   ]
+   ],
+   "id": "37bbb0d19e5f"
   },
   {
    "cell_type": "code",
@@ -151,7 +160,8 @@
     "recourse_blocks = [b for b in res.structure.blocks if 'q' not in b]\n",
     "print('first-stage (complicating):', res.structure.complicating_vars)\n",
     "print('separable recourse blocks:', len(recourse_blocks))\n"
-   ]
+   ],
+   "id": "216b8d8efdd4"
   },
   {
    "cell_type": "markdown",
@@ -164,7 +174,8 @@
     "the copies to a common *nonanticipative* value $\\bar x = \\sum_s p_s x_s$. The driver\n",
     "takes an injected subproblem solver; here a closed-form quadratic illustrates that PH\n",
     "converges to the expected-value decision:\n"
-   ]
+   ],
+   "id": "86fc30fd1e6e"
   },
   {
    "cell_type": "code",
@@ -180,7 +191,8 @@
     "                         subproblem_solver=quadratic_subproblem_solver(targets),\n",
     "                         rho=1.0)\n",
     "print('x_bar =', float(ph.x_bar[0]), '(= \u03a3 p_s a_s = 58) | converged:', ph.converged)\n"
-   ]
+   ],
+   "id": "fc722d4c5f6f"
   },
   {
    "cell_type": "markdown",
@@ -192,7 +204,8 @@
     "true optimum. Averaging independent batches gives a statistical **lower** bound, and\n",
     "evaluating a candidate on a fresh sample gives an **upper** bound \u2014 together an\n",
     "optimality-gap estimate {cite:p}`MakMortonWood1999`:\n"
-   ]
+   ],
+   "id": "f14efb495f7f"
   },
   {
    "cell_type": "code",
@@ -208,23 +221,18 @@
     "gap = optimality_gap_estimate(lower, upper)\n",
     "print('point gap:', round(gap['point_gap'], 2),\n",
     "      '| conservative gap:', round(gap['conservative_gap'], 2))\n"
-   ]
+   ],
+   "id": "d8f27a8a72d9"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For a *worst-case-over-distributions* view (distributionally robust optimization),\n",
-    "`discopt.stochastic.dro` computes the worst-case distribution over an ambiguity ball \u2014\n",
-    "the bridge to `discopt.ro`. Multistage (nested Benders) and integer-recourse L-shaped\n",
-    "are reserved.\n",
-    "\n",
     "## References\n",
     "\n",
-    "```{bibliography}\n",
-    ":filter: docname in docnames\n",
-    "```\n"
-   ]
+    "See the [References](../references.md) page for full citations."
+   ],
+   "id": "91f3a697ec11"
   }
  ],
  "metadata": {

--- a/docs/notebooks/tutorial_lagrangian.ipynb
+++ b/docs/notebooks/tutorial_lagrangian.ipynb
@@ -11,7 +11,8 @@
     "$$L(\\lambda) = \\min_z\\; c^\\top z + \\lambda^\\top (A_c z - r_c) \\quad\\text{s.t. block constraints},\\; z \\in \\text{bounds}.$$\n",
     "\n",
     "Because the dualized term is $\\le 0$ at any feasible point, $L(\\lambda) \\le z^\\star$ always. The **Lagrangian dual** $\\max_{\\lambda \\ge 0} L(\\lambda)$ tightens this bound; for problems whose blocks lack the integrality property it can dominate the LP relaxation {cite:p}`Fisher2004`. discopt maximizes the dual by a **subgradient** method or a **bundle** (cutting-plane) method, and recovers a feasible primal incumbent with a Lagrangian heuristic {cite:p}`Barahona2000`."
-   ]
+   ],
+   "id": "4f83c74fa971"
   },
   {
    "cell_type": "code",
@@ -25,7 +26,8 @@
     "os.environ[\"JAX_ENABLE_X64\"] = \"1\"\n",
     "\n",
     "import discopt.modeling as dm"
-   ]
+   ],
+   "id": "469d84d1c2e2"
   },
   {
    "cell_type": "markdown",
@@ -36,7 +38,8 @@
     "Two independent blocks each must select one item; a *coupling* constraint forbids selecting item 0 and item 2 together. Marking that constraint with `mark_coupling` tells the solver which row to dualize.\n",
     "\n",
     "Without the coupling the cheapest picks are items 0 and 2 (cost $2 + 2 = 4$); the conflict forces a swap, and the optimum is $3 + 2 = 5$ (items 1 and 2)."
-   ]
+   ],
+   "id": "5bac58fadcaf"
   },
   {
    "cell_type": "code",
@@ -59,14 +62,16 @@
     "print(\"objective:\", round(result.objective, 4))\n",
     "print(\"bound    :\", round(result.bound, 4))\n",
     "print(\"x =\", result.x[\"x\"])"
-   ]
+   ],
+   "id": "9c825b090bd2"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "The dual `bound` is a rigorous lower bound on the optimum; here it meets the recovered incumbent, so the gap is certified. The auto-detector also identifies the linking row, which `detect_decomposition` reports:"
-   ]
+   ],
+   "id": "83f0c3b285c1"
   },
   {
    "cell_type": "code",
@@ -77,7 +82,8 @@
     "import discopt\n",
     "\n",
     "print(discopt.detect_decomposition(m).summary())"
-   ]
+   ],
+   "id": "7bbe54346f8b"
   },
   {
    "cell_type": "markdown",
@@ -86,7 +92,8 @@
     "## Subgradient vs bundle\n",
     "\n",
     "The dual can be maximized two ways. The **subgradient** method (default) takes a Polyak step along the constraint residual; the **bundle** method builds a piecewise-linear model of the concave dual and maximizes it over a trust box, typically converging in fewer iterations on harder duals. Both return the same rigorous bound."
-   ]
+   ],
+   "id": "f72d235b7a85"
   },
   {
    "cell_type": "code",
@@ -97,7 +104,8 @@
     "for method in (\"subgradient\", \"bundle\"):\n",
     "    r = m.solve(decomposition=\"lagrangian\", method=method)\n",
     "    print(f\"{method:12s} -> objective {round(r.objective, 4)}, bound {round(r.bound, 4)}\")"
-   ]
+   ],
+   "id": "c1b6a666f840"
   },
   {
    "cell_type": "markdown",
@@ -120,7 +128,8 @@
     "## When to use Lagrangian relaxation\n",
     "\n",
     "Reach for it when a handful of constraints couple otherwise-separable blocks (shared resources, budgets, network flow balance) — dualizing them yields strong bounds and independent, parallelizable subproblems. The v1 implementation targets linear (mixed-integer) models; the reported `bound` is always a valid lower bound. Dantzig-Wolfe / column generation / branch-and-price are on the roadmap."
-   ]
+   ],
+   "id": "c9dce0c85276"
   }
  ],
  "metadata": {

--- a/docs/notebooks/tutorial_oa.ipynb
+++ b/docs/notebooks/tutorial_oa.ipynb
@@ -31,7 +31,8 @@
     "   - Generate OA cuts (tangent hyperplanes) at NLP solution\n",
     "   - If NLP infeasible: add feasibility cuts {cite:p}`Fletcher1994` or no-good cuts\n",
     "3. **Terminate** when gap converges or master becomes infeasible"
-   ]
+   ],
+   "id": "ec621c28825d"
   },
   {
    "cell_type": "code",
@@ -52,7 +53,8 @@
     "os.environ[\"JAX_ENABLE_X64\"] = \"1\"\n",
     "\n",
     "import discopt.modeling as dm"
-   ]
+   ],
+   "id": "2158283e5108"
   },
   {
    "cell_type": "markdown",
@@ -64,7 +66,8 @@
     "$$\\text{s.t.} \\quad x_1 + x_2 \\geq 1, \\quad x_1^2 + x_2 \\leq 3, \\quad x_3 \\in \\{0,1\\}$$\n",
     "\n",
     "The optimal solution is $x_1 = x_2 = 0.5$, $x_3 = 0$, with objective 0.5."
-   ]
+   ],
+   "id": "d5360b017967"
   },
   {
    "cell_type": "code",
@@ -110,7 +113,8 @@
     "print(f\"Objective: {result.objective:.4f}\")\n",
     "print(f\"Solution: {result.x}\")\n",
     "print(f\"Wall time: {result.wall_time:.2f}s\")"
-   ]
+   ],
+   "id": "b93f8c3bde45"
   },
   {
    "cell_type": "markdown",
@@ -123,7 +127,8 @@
     "\n",
     "$$\\min \\quad (x - 3)^2 + 2y_1 + 3y_2$$\n",
     "$$\\text{s.t.} \\quad y_1 + y_2 \\leq 1, \\quad x \\leq 2y_1 + 4y_2, \\quad x \\in [0, 5],\\; y_i \\in \\{0,1\\}$$"
-   ]
+   ],
+   "id": "0fe3d57db4bb"
   },
   {
    "cell_type": "code",
@@ -159,7 +164,8 @@
     "result = m.solve(gdp_method=\"oa\", time_limit=60)\n",
     "print(f\"Status: {result.status}, Objective: {result.objective:.4f}\")\n",
     "print(f\"x={result.x['x']:.3f}, y1={result.x['y1']:.0f}, y2={result.x['y2']:.0f}\")"
-   ]
+   ],
+   "id": "8a4e9131cda0"
   },
   {
    "cell_type": "markdown",
@@ -169,7 +175,8 @@
     "\n",
     "Both solvers find the same optimum for convex MINLP, but OA is typically\n",
     "faster when the integer structure dominates."
-   ]
+   ],
+   "id": "626b0e7be898"
   },
   {
    "cell_type": "code",
@@ -228,7 +235,8 @@
     "bb_t = result_bb.wall_time\n",
     "print(f\"OA:  obj={oa_obj:.4f}, time={oa_t:.2f}s, status={result_oa.status}\")\n",
     "print(f\"B&B: obj={bb_obj:.4f}, time={bb_t:.2f}s, status={result_bb.status}\")"
-   ]
+   ],
+   "id": "643c820ea588"
   },
   {
    "cell_type": "markdown",
@@ -240,7 +248,8 @@
     "subproblem solves entirely. Instead, it generates OA cuts at the MILP\n",
     "master solution for violated nonlinear constraints. This is simpler but\n",
     "converges more slowly."
-   ]
+   ],
+   "id": "cd5fb5d5bbe9"
   },
   {
    "cell_type": "code",
@@ -280,7 +289,8 @@
     "\n",
     "print(f\"ECP Status: {result_ecp.status}\")\n",
     "print(f\"ECP Objective: {result_ecp.objective}\")"
-   ]
+   ],
+   "id": "2047b1acd5e3"
   },
   {
    "cell_type": "markdown",
@@ -292,7 +302,8 @@
     "can make the MILP master infeasible. The **Equality Relaxation** strategy\n",
     "{cite:p}`Viswanathan1990` relaxes these to inequalities in the OA cuts,\n",
     "restoring master feasibility."
-   ]
+   ],
+   "id": "970c1102d058"
   },
   {
    "cell_type": "code",
@@ -330,7 +341,8 @@
     "\n",
     "result_er = m.solve(gdp_method=\"oa\", equality_relaxation=True, time_limit=60)\n",
     "print(f\"Status: {result_er.status}, Objective: {result_er.objective}\")"
-   ]
+   ],
+   "id": "690c16f29e28"
   },
   {
    "cell_type": "markdown",
@@ -348,7 +360,8 @@
     "| `equality_relaxation` | False | Relax nonlinear equalities |\n",
     "| `feasibility_cuts` | True | Gradient-based feasibility cuts |\n",
     "| `nlp_solver` | \"ipm\" | NLP backend: \"ipm\", \"ipopt\", \"pounce\" |"
-   ]
+   ],
+   "id": "4c5cb8ef706b"
   },
   {
    "cell_type": "markdown",
@@ -367,7 +380,8 @@
     "For a comprehensive review and comparison of convex MINLP solvers, see\n",
     "{cite:p}`Kronqvist2019`. The Bonmin solver {cite:p}`Bonami2009` provides\n",
     "multiple algorithmic variants including OA, NLP-BB, and hybrid approaches."
-   ]
+   ],
+   "id": "6d7011ddabf2"
   }
  ],
  "metadata": {

--- a/docs/notebooks/tutorial_robust.ipynb
+++ b/docs/notebooks/tutorial_robust.ipynb
@@ -33,7 +33,8 @@
     "| **Box** | $\\lvert p_j - \\bar{p}_j \\rvert \\le \\delta_j$ | Substitute worst-case bound per component |\n",
     "| **Ellipsoidal** | $\\lVert \\Sigma^{-1/2}(p-\\bar{p}) \\rVert_2 \\le \\rho$ | Add SOC norm penalty {cite:p}`BenTal1999` |\n",
     "| **Polyhedral** | $A\\xi \\le b,\\; \\xi = p - \\bar{p}$ | LP dual auxiliary variables {cite:p}`BertsimasSim2004` |"
-   ]
+   ],
+   "id": "5ea299b28e69"
   },
   {
    "cell_type": "code",
@@ -56,7 +57,8 @@
     "import discopt.modeling as dm\n",
     "import numpy as np\n",
     "from discopt.ro import BoxUncertaintySet, RobustCounterpart"
-   ]
+   ],
+   "id": "71c3667e6920"
   },
   {
    "cell_type": "markdown",
@@ -72,7 +74,8 @@
     "$$\n",
     "\n",
     "Both costs $c$ and demand $d$ are uncertain: $c \\in [\\bar{c} - \\delta_c, \\bar{c} + \\delta_c]$ and $d \\in [\\bar{d} - \\delta_d, \\bar{d} + \\delta_d]$. We solve the nominal problem first, then compare with the robust counterpart."
-   ]
+   ],
+   "id": "1e219ef46c0e"
   },
   {
    "cell_type": "code",
@@ -138,7 +141,8 @@
     "    f\"\\nPrice of robustness: {r_rob.objective - r_nom.objective:.2f} \"\n",
     "    f\"({(r_rob.objective / r_nom.objective - 1) * 100:.1f}% increase)\"\n",
     ")"
-   ]
+   ],
+   "id": "9a2b8cbb8896"
   },
   {
    "cell_type": "markdown",
@@ -154,7 +158,8 @@
     "$$\n",
     "\n",
     "With demand $d$ uncertain within $[40, 60]$ (nominal $\\bar{d} = 50$, $\\delta = 10$), the robust counterpart must ensure feasibility at $d = 60$."
-   ]
+   ],
+   "id": "a8d4a97d1cdd"
   },
   {
    "cell_type": "code",
@@ -208,7 +213,8 @@
     "\n",
     "print(\"\\nThe robust solution orders 10 more units of the expensive product\")\n",
     "print(\"to guarantee feasibility if demand reaches 60.\")"
-   ]
+   ],
+   "id": "c5acb81b2c59"
   },
   {
    "cell_type": "markdown",
@@ -224,7 +230,8 @@
     "$$\n",
     "\n",
     "where returns $\\mu$ lie in an ellipsoidal set $\\{\\mu: \\lVert \\mu - \\bar{\\mu} \\rVert_2 \\le \\rho\\}$. The robust counterpart adds a norm penalty: $\\max_x\\; \\bar{\\mu}^\\top x - \\rho \\lVert x \\rVert_2$."
-   ]
+   ],
+   "id": "5fa182bd963a"
   },
   {
    "cell_type": "code",
@@ -312,7 +319,8 @@
     "print(f\"\\nRobust:   return = {-r_rob.objective:.4f}\")\n",
     "print(f\"          x = {np.round(x_r, 4)}\")\n",
     "print(\"          (Diversified to hedge against return uncertainty)\")"
-   ]
+   ],
+   "id": "52b1996cc7ba"
   },
   {
    "cell_type": "markdown",
@@ -321,7 +329,8 @@
     "## Multiple Uncertain Parameters\n",
     "\n",
     "Multiple parameters from the same uncertainty family can be passed as a list:"
-   ]
+   ],
+   "id": "e3c45d5513de"
   },
   {
    "cell_type": "code",
@@ -372,7 +381,8 @@
     "print(\"\\nRobust constraints (worst-case constants substituted):\")\n",
     "for con in m_multi._constraints:\n",
     "    print(f\"  [{con.name}]  {con.body} {con.sense} {con.rhs}\")"
-   ]
+   ],
+   "id": "77fa4f3f8e0e"
   },
   {
    "cell_type": "markdown",
@@ -395,7 +405,8 @@
     "$$\n",
     "\n",
     "The uncertain concentrations are $a_1 = 0.01 \\pm 0.5\\%$ and $a_2 = 0.02 \\pm 2\\%$. The published solutions are: nominal profit = \\$8,819.66 (using only RawII), robust profit = \\$8,294.57 (switching to the more reliable RawI), a 5.95% price of robustness."
-   ]
+   ],
+   "id": "0ab26cfbf26c"
   },
   {
    "cell_type": "code",
@@ -482,7 +493,8 @@
     "    \"\\ntighter uncertainty (0.5% vs 2%), making it more reliable despite\"\n",
     "    \"\\nhigher cost per gram.\"\n",
     ")"
-   ]
+   ],
+   "id": "a2d4657ad686"
   },
   {
    "cell_type": "markdown",
@@ -535,7 +547,8 @@
     "\n",
     "For a full adjustable RO tutorial including multi-parameter recourse and vector recourse variables,\n",
     "see {doc}`robust_adjustable`."
-   ]
+   ],
+   "id": "b24621797dfd"
   }
  ],
  "metadata": {

--- a/python/discopt/daemon.py
+++ b/python/discopt/daemon.py
@@ -141,7 +141,7 @@ def solve_via_daemon(
     run.
 
     ``hard_deadline`` (seconds, default ``None`` = no limit) additionally asks the
-    *daemon* to fork a watchdog that ``SIGKILL``s itself if this solve overruns,
+    *daemon* to fork a watchdog that ``SIGKILL``-s itself if this solve overruns,
     enforcing the limit even with no client waiting (orphaned worker) and even for
     a solver wedged in a C extension.
     """

--- a/python/discopt/decomposition/benders/gbd.py
+++ b/python/discopt/decomposition/benders/gbd.py
@@ -9,7 +9,7 @@ models.
 
 Where classical Benders (``solver.py``) handles a *linear* recourse LP, GBD
 handles a **convex nonlinear** recourse subproblem. The two-stage problem
-(internally minimizing) is
+(internally minimizing) is::
 
     min  f(x, y)
     s.t. g(x, y) <= 0            (coupling / recourse constraints)

--- a/python/discopt/decomposition/benders/solver.py
+++ b/python/discopt/decomposition/benders/solver.py
@@ -1,6 +1,6 @@
 """Classical Benders decomposition solver (v1: linear (MI)LP recourse).
 
-Algorithm (minimization, internally):
+Algorithm (minimization, internally)::
 
     min  c_x^T x + c_y^T y
     s.t. master-only rows           A_m x <= r_m

--- a/python/discopt/gams/daemon.py
+++ b/python/discopt/gams/daemon.py
@@ -88,9 +88,12 @@ def default_socket_path() -> Path:
 
 
 class DaemonServer(_CoreDaemonServer):
-    """Warm GAMS solver server. Wraps the historical ``(control_file, sysdir) ->
-    int`` solve callback into the core's ``request -> reply`` contract so the GAMS
-    link and its tests keep their signature."""
+    """Warm GAMS solver server.
+
+    Wraps the historical ``(control_file, sysdir) -> int`` solve callback into the
+    core's ``request -> reply`` contract so the GAMS link and its tests keep their
+    signature.
+    """
 
     def __init__(
         self,

--- a/python/discopt/gp/__init__.py
+++ b/python/discopt/gp/__init__.py
@@ -1,6 +1,6 @@
 """Geometric programming: detection, log-space reformulation, and solve.
 
-A *geometric program* (GP) in standard form is
+A *geometric program* (GP) in standard form is::
 
     minimize    f_0(x)
     subject to  f_i(x) <= 1,    i = 1..m   (posynomial inequalities)

--- a/python/discopt/heuristic_governor.py
+++ b/python/discopt/heuristic_governor.py
@@ -7,12 +7,12 @@ largely *non-load-bearing*. On a pooled panel + held-out replay (27 instances,
 #1) on **every** instance, while the expensive nested-B&B heuristics never
 improved it:
 
-============================  ======  ========  ===========
-source                        solves  wall%     incumbent hit-rate
-============================  ======  ========  ===========
-rens (nested B&B)                805     14.3 %   0 / 13   (0.0 %)
-rins (LNS dive)                  440     10.4 %   0 / 143  (0.0 %)
-============================  ======  ========  ===========
+=================  ======  ======  ==================
+source             solves  wall%   incumbent hit-rate
+=================  ======  ======  ==================
+rens (nested B&B)  805     14.3 %  0 / 13   (0.0 %)
+rins (LNS dive)    440     10.4 %  0 / 143  (0.0 %)
+=================  ======  ======  ==================
 
 On the 21 *finished* easy instances RENS alone is **33 % of total solve wall**
 at a 0 % hit rate. SCIP/BARON track per-heuristic success and throttle the

--- a/python/discopt/mo/indicators.py
+++ b/python/discopt/mo/indicators.py
@@ -82,7 +82,7 @@ def common_reference(*fronts: ParetoFront, margin_frac: float = 0.01) -> np.ndar
 
     Parameters
     ----------
-    *fronts : ParetoFront
+    \\*fronts : ParetoFront
         Fronts to compare. Must share the same number of objectives and the
         same senses; at least one must be non-empty.
     margin_frac : float, default 0.01

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1176,6 +1176,8 @@ def norm(x: Expression, ord: Union[int, float, str] = 2) -> Expression:
 
 
 class ConstraintSense(Enum):
+    """Relational sense of a constraint (``<=``, ``>=``, or ``==``)."""
+
     LE = "<="
     GE = ">="
     EQ = "=="
@@ -1252,6 +1254,8 @@ class ConstraintList:
 
 
 class ObjectiveSense(Enum):
+    """Optimization direction of the objective (minimize or maximize)."""
+
     MINIMIZE = "minimize"
     MAXIMIZE = "maximize"
 

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -8,6 +8,8 @@ import numpy as np
 
 
 class SolveStatus(Enum):
+    """Terminal status of a solve (optimal, infeasible, unbounded, ...)."""
+
     OPTIMAL = "optimal"
     INFEASIBLE = "infeasible"
     UNBOUNDED = "unbounded"

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -4725,9 +4725,10 @@ def solve_oa(
         MindtPy FP controls that are explicitly unsupported in discopt's current
         FP implementation unless set to their no-op defaults. Non-default values
         raise ``ValueError`` rather than being silently ignored.
-    add_regularization : {None, "level_L1", "level_L2", "level_L_infinity",
-            "grad_lag", "hess_lag", "hess_only_lag", "sqp_lag"}
+    add_regularization : str or None
         Optional level-set regularized OA master before fixed-integer NLP solves.
+        One of ``None``, ``"level_L1"``, ``"level_L2"``, ``"level_L_infinity"``,
+        ``"grad_lag"``, ``"hess_lag"``, ``"hess_only_lag"``, or ``"sqp_lag"``.
         L1, L-infinity, and ``grad_lag`` are solved as MILPs; quadratic modes
         require a MIQP-capable QP backend. Derivative modes require NLP duals,
         and Hessian modes require Lagrangian Hessian access.
@@ -4756,13 +4757,18 @@ def solve_oa(
         generated binary variables. Unbounded or impractically bounded general
         integers raise a diagnostic when this option is combined with
         ``add_no_good_cuts``.
-    external_primal_candidate_hook, external_hyperplane_hook, external_dual_bound_hook,
+    external_primal_candidate_hook : callable, optional
+        Opt-in event hook for the multi-tree OA loop (see notes below).
+    external_hyperplane_hook : callable, optional
+        Opt-in event hook for the multi-tree OA loop (see notes below).
+    external_dual_bound_hook : callable, optional
+        Opt-in event hook for the multi-tree OA loop (see notes below).
     termination_hook : callable, optional
-        Opt-in event hooks for the multi-tree OA loop. Hooks receive a read-only
-        context dictionary with iteration, elapsed time, current bound/incumbent
-        data, and candidate points where relevant. Returned payloads are
-        validated before they can add external fixed-NLP candidates, master cuts,
-        dual-bound updates, or request user termination.
+        Opt-in event hook for the multi-tree OA loop. All four hooks receive a
+        read-only context dictionary with iteration, elapsed time, current
+        bound/incumbent data, and candidate points where relevant. Returned
+        payloads are validated before they can add external fixed-NLP candidates,
+        master cuts, dual-bound updates, or request user termination.
 
     Returns
     -------

--- a/python/discopt/solvers/qp_pounce.py
+++ b/python/discopt/solvers/qp_pounce.py
@@ -111,8 +111,7 @@ def solve_qp(
 
     Raises:
         ImportError: If POUNCE is not installed.
-        ValueError: If dimensions are inconsistent, or ``integrality`` marks
-            any variable integer (POUNCE has no MIQP support).
+        ValueError: On inconsistent dimensions, or any integer-marked variable (no MIQP support).
     """
     if not POUNCE_AVAILABLE:
         raise ImportError(


### PR DESCRIPTION
## What this does

Makes `jupyter-book build docs/` build with **zero warnings and zero errors**
(down from 132). One self-contained commit.

> **Stacked on #595.** This targets `claude/lucid-newton-0cz50i`, not `main`,
> because two of the fixes it relies on — the duplicate `Dempe2002` bibtex-entry
> removal and the `nlp_pounce` docstring rewrite — live in #595 (a standalone
> build on `main` regresses without them). When #595 merges, GitHub retargets
> this PR to `main` automatically. Review/merge #595 first.

## Categories fixed

- **90 "document isn't included in any toctree"** — internal `dev/` and
  `design/` planning notes were globbed by Sphinx but aren't book pages; excluded
  via `exclude_patterns` in `_config.yml`.
- **11 "duplicate citation for key"** — `bilevel.ipynb` and
  `stochastic_programming.ipynb` each carried a local `{bibliography}` directive
  overlapping the global `references.md`; replaced with a pointer to the
  References page (consistent with every other notebook).
- **7 "cell is missing an id field"** — stable ids added to all notebook cells
  that lacked them, preserving each file's existing serialization/unicode style
  so the diff is pure id additions.
- **3 Pygments lexer warnings** — `gams` → `text` fences in
  `gams_solver_link.md`; the `cron` one was under `dev/` (now excluded).
- **autoapi RST warnings/errors from source docstrings** — undocumented enums
  (`ConstraintSense`, `ObjectiveSense`, `SolveStatus`) were falling back to the
  malformed stdlib `enum.Enum` docstring (one-line docstrings added); pluralized
  inline literals (`` ``SIGKILL``s ``); a numpydoc `*fronts` emphasis; wrapped
  param type/name lists in `oa.py`; missing `::` before math blocks in
  `benders/gbd`, `benders/solver`, `gp`; a mis-sized simple-table in
  `heuristic_governor`; a multi-line `Raises:` in `qp_pounce`; and a
  line-spanning summary literal in `gams/daemon`.

## Scope note

Most of this is docstring-only edits across ~10 modules (`daemon`,
`mo/indicators`, `oa`, `qp_pounce`, `gp`, `heuristic_governor`, `benders/*`, plus
the three enums). No logic changes; `ruff` clean; all touched modules
import-verified.

## Testing

- `jupyter-book build docs/` → `build succeeded.` (no warning/error count).
- `ruff check python/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkFD6xSzPgnVbxrK9Lfdam

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkFD6xSzPgnVbxrK9Lfdam)_