### PR TITLE
docs(decomp1): task #88 — certification-effort decomposition: Lever A dominates; fix two Lever-B plumbing defects first

### DIFF
--- a/docs/dev/certification-effort-decomposition-2026-07-10.md
+++ b/docs/dev/certification-effort-decomposition-2026-07-10.md
@@ -1,0 +1,234 @@
+# DECOMP-1 (task #88): certification-effort decomposition — which lever dominates?
+
+**Date:** 2026-07-10 · **Base:** `main` @ `16f25505` (includes root_gap/root_time #589,
+dense-retry counters #591, centropy relaxation #597) · **Measurement-only** — no solver
+changes in this PR.
+
+## 0. TL;DR
+
+The maintainer's directive was: *"we are still working way too hard to certify and not
+succeeding."* This diagnostic decomposes that effort on a 10-instance MINLPLib panel +
+the #598 AMP multi4N MILP, TL = 60 s, with per-node-LP status counting, Rust simplex
+profile counters, and a bound/incumbent trajectory tap on the B&B tree.
+
+**Verdict: Lever A (relaxation/dual-bound strength) dominates — 7 of 10 uncertified
+runs — but two narrow, cheap Lever-B certification-plumbing defects throw away dual
+bound the solver already proved, and should be fixed first.** Lever C (B&B machinery
+with a tight relaxation) appears on exactly one instance (nvs19). One instance (tls2)
+fails on the *primal* side — a lever the A/B/C taxonomy didn't anticipate.
+
+Headline numbers:
+
+- **10/11 runs found the exact oracle optimum; only 1/11 certified it** (st_e36).
+- **Node-LP numerical failure is a non-factor on the spatial path: 0 numerical /
+  iteration-limit / error exits in 711 McCormick node-LP solves** across the panel
+  (2 sound root-probe declines: one `optimal`-with-no-safe-bound, one `unbounded`).
+  The "node LPs take numerical exits → gap poisoned" hypothesis is **falsified as a
+  panel-wide driver** — it is real but *specific to the in-house MILP B&B* (#598),
+  and it reappears in a different guise as node-**NLP** taint (below).
+- **Root gap > 20 % on 7 of the 8 uncertified spatial runs that had an incumbent**
+  (clay0303hfsg 100 %, casctanks 1 084 %, nvs05 88 %, nvs09 69 %, tanksize 33 %,
+  ex6_2_5 39 179 %, ex6_2_9 33 205 %). The exception is nvs19 (0.53 %).
+- **The incumbent was already optimal for 52–96 % of the wall time** on those 7
+  instances (`stall_frac` column) — the entire tail is pure dual-bound effort.
+- **Two plumbing defects convert proved bound into reported failure:**
+  1. **#598 (in-house MILP B&B):** finds `obj == bound == −26.822045` (gap exactly 0,
+     HiGHS-verified optimum) in 0.8 s but exits `iteration_limit`, uncertified —
+     459 node LPs, 22 833 pivots, 81 % of dual pivots degenerate. scipy-HiGHS closes
+     the identical matrix (161 cols / 582 rows / 44 ints) in **one call, 0.24 s,
+     19 nodes**. `LpDenseRetries = 0` → confirmed **not** the #591 dense-route class.
+  2. **Decertify-and-discard (spatial path):** on nvs05 the tree *proved* a global
+     lower bound of **4.8746** (89 % of the 5.4709 optimum) but the run *reported*
+     **1.3481** — the `_nonrigorous_sentinel_fathom` taint sets
+     `_tree_bound_valid = False` and the whole tree bound is dropped for the root
+     pool fallback. Same on tanksize (proved 0.8811, reported 0.8680). The taint is
+     the correct soundness response to an unproven *fathom*; discarding the valid
+     *frontier bound* of the surviving tree is over-broad plumbing, not soundness.
+
+## 1. Method
+
+- Panel: clay0303hfsg, casctanks, tls2, nvs05, nvs09, tanksize, st_e36, nvs19,
+  ex6_2_5, ex6_2_9 (`~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/`,
+  oracle = `minlplib.solu`), plus the #598 AMP multi4N MILP relaxation
+  (`_make_alpine_multi4n(n=2, exprmode=1)` → `build_milp_relaxation`, `n_init=2`,
+  solved via the default in-house route; identical matrix cross-solved with
+  `scipy.optimize.milp` / HiGHS).
+- `Model.solve(time_limit=60)` per instance in a fresh subprocess with
+  `DISCOPT_PROFILE=1`; harness: `scripts/decomp1_cert_effort_run.py` (instance
+  runner), `scripts/decomp1_cert_effort_drive.py` (driver + profile-dump parser),
+  `scripts/decomp1_cert_effort_analyze.py` (attribution).
+- Instrumentation (monkeypatch, measurement-only): every
+  `MccormickLPRelaxer._solve_at_node_impl` call counted by terminal status
+  (including C-42/C-43 retries); `_compute_alphabb_bound` / `_compute_interval_bound`
+  / `solve_mccormick_batch` counted to identify each instance's actual node-bound
+  engine; `_pounce_recover_node_bound` counted (MILP-path decertify recovery);
+  `PyTreeManager` proxied so every `stats()` call records
+  `(t, global_lower_bound, incumbent)` — the bound/incumbent trajectory.
+- `t_inc*` = first time the incumbent matched the oracle (rel 1e-4);
+  `stall_frac` = fraction of wall time *after* that point;
+  `closed` = fraction of the root→oracle dual gap closed by the final tree bound.
+- Caveats: wall numbers from a shared laptop (sequential runs, but machine
+  contention possible); DISCOPT_PROFILE + the Python taps add small overhead —
+  node/LP/status counts and bounds are deterministic, wall times are indicative.
+
+## 2. Per-instance results (TL = 60 s)
+
+| instance | oracle | status | found opt? | root_gap | final gap | nodes | node-LP solves (failures) | node-bound engine | LP pivots | stall_frac | dual gap closed | attribution |
+|---|---:|---|:--:|---:|---:|---:|---:|---|---:|---:|---:|---|
+| clay0303hfsg | 26669.1 | feasible | yes | **1.00** | 0.268 | 305 | 0 (0) | NLP-BB (POUNCE) | 0 | 0.67 | 0.73 | **A** |
+| casctanks | 9.1635 | feasible | yes | **10.84** | 0.852 | 25 | 8 (0) | McCormick LP + interval | 28 576 | 0.52 | 0.92 | **A** |
+| tls2 | 5.3 | time_limit | **no incumbent** | n/a | n/a | 1663 | 0 (0) | NLP-BB | 0 | n/a | 0.91 (bound 4.90/5.3) | **primal** |
+| nvs05 | 5.4709 | feasible | yes | **0.88** | 0.754 | 533 | 2 (0)¹ | alphaBB + interval | 12 159 | **0.96** | 0.14 (reported)² | **A + B** |
+| nvs09 | −43.134 | feasible | yes | **0.69** | 0.540 | 31 | 10 (0) | LP + OBBT (~1.9 s/node) | 9 930 | **0.95** | 0.22 | **A** |
+| tanksize | 1.2686 | feasible | yes | **0.33** | 0.316 | 171 | 2 (0)¹ | alphaBB + interval | 55 097 | 0.84 | 0.05² | **A + B** |
+| st_e36 | −246.0 | **optimal** | yes | 0.24 | 7.6e-5 | 153 | 152 (0) | McCormick LP | 46 228 | — | 1.00 | certified |
+| nvs19 | −1098.4 | feasible | yes | **0.0053** | 0.0034 | 215 | 158 (0) | McCormick LP | 166 732 | 0.03³ | 0.37 | **C** |
+| ex6_2_5 | −70.752 | feasible | yes | **391.8** | 118.7 | 409 | 202 (0) | McCormick LP | 900 238 | **0.95** | 0.70 | **A** |
+| ex6_2_9 | −0.03407 | feasible | yes | **332.1** | 9.98 | 351 | 177 (0) | McCormick LP | 59 994 | **0.95** | 0.97⁴ | **A** |
+| amp_multi4n (#598) | −26.8220⁵ | iteration_limit | yes (gap = 0!) | n/a | 0 (uncertified) | 459⁶ | 459 (≥1 numerical)⁶ | in-house MILP B&B | 22 833 | n/a | n/a | **B** |
+
+¹ Root probes only: nvs05's LP declined a bound (`optimal`, no safe bound — sound
+refusal) and tanksize's returned `unbounded`, so both fell back to alphaBB/interval
+per-node bounding — the node engine that then stalls (lever A on *that* engine).
+² Reported bound after decertify-and-discard; the tree actually proved 4.8746 (nvs05,
+closed = 0.88) and 0.8811 (tanksize) — see §4.2.
+³ nvs19's exact incumbent −1098.4 only arrived at t = 58.3 s (a −1098.2 incumbent sat
+from t = 2.6 s); its bound was within 0.34 % at exit — a pure tail-closing failure.
+⁴ ex6_2_9 closed 97 % of an enormous root gap (−332 → −10.01) and still ends 294×
+away from the −0.0341 optimum in relative terms — the root gap is simply that large.
+⁵ Optimum of the lifted MILP itself, certified by HiGHS on the identical matrix
+(status 0, one `milp()` call, 0.24 s, 19 nodes, dual bound = objective).
+⁶ From `DISCOPT_PROFILE` phase counters: `NodeLpSolve = 459` (1.67 s total),
+`Phase1+Phase2 pivots = 22 833`, `DualWarmSolves = 761`, `DualColdFallbacks = 23`,
+`DualDegeneratePivots = 18 511` (81 % of dual pivots), `RefacCap = 443`,
+`LpDenseRetries = 0`. Exit after 0.85 s at `iteration_limit` with `obj == bound`.
+
+## 3. Lever attribution — the evidence
+
+### Lever A (relaxation/dual-bound strength) — DOMINANT, 7/10 uncertified
+
+Seven instances have root_gap ≥ 33 % (median root_gap across the 8 uncertified
+spatial runs with incumbents: **0.94**, i.e. ~94 % of the incumbent value), the
+incumbent in hand within seconds (t_inc* = 2.5–29.5 s), and then 30–58 s of pure
+dual-bound grinding that closes 5–97 % of the gap but never enough. Three distinct
+sub-classes — the lever is *not* one relaxation:
+
+- **alphaBB/interval-routed (nvs05, tanksize):** the McCormick LP declines at the
+  root (soundly), so nodes are bounded by interval arithmetic + alphaBB. That engine
+  closes 14 % (nvs05, tree bound) and 5 % (tanksize) of the gap in ~55 s over
+  533/171 nodes. The per-node relaxation, not the tree policy, is the binding
+  constraint.
+- **x·log(x) / Gibbs family (ex6_2_5, ex6_2_9):** root gaps of **392×** and
+  **332×** the unit scale. Measured *with* #597's centropy tangent underestimator
+  in the base commit — the root on these two is still orders of magnitude loose.
+  (ex6_2_9's bound moves −332 → −10.0, i.e. 97 % closed, and the residual is still
+  ~300× the optimum — no tree policy survives that starting point.)
+- **NLP-BB / root-bound-absent (clay0303hfsg; casctanks root):** clay is detected
+  convex → NLP-BB; its "root bound" is ≈ 0 vs an optimum of 26 669 (root_gap 1.0),
+  and 305 POUNCE NLP nodes close 73 % in 60 s. casctanks burns **29.4 s of 61 s in
+  the root** (fixpoint/OBBT — consistent with T1.6's finding that the OBBT LP loop
+  is the per-node lever) and starts the tree from root_gap 10.8.
+
+### Lever B (LP numerics / certification robustness) — REAL BUT NARROW; fix first
+
+The panel-wide form hypothesized in the directive — node LPs taking numerical exits
+— **does not occur on the spatial path**: 0 failures in 711 node-LP solves, and
+`LpDenseRetries = 0` everywhere. B is instead two specific plumbing defects:
+
+1. **#598, in-house MILP B&B:** gap **exactly 0** (obj = bound = HiGHS-verified
+   optimum) yet `iteration_limit`, because one lifted-McCormick node LP took an
+   uncertified exit and `decide_status` demands `gap_certified`. Cost of the miss:
+   an entire found-and-proved optimum reported as a limit exit. The engine also
+   burns 459 nodes / 22 833 pivots where HiGHS needs 19 nodes in one call — the
+   node-count ratio is ~24× *and* the exit label is wrong. (The pivot profile —
+   81 % degenerate dual pivots, RefacCap = 443 refactor-cap trips over 761 warm
+   solves — localizes the inefficiency to degeneracy handling + FT-update churn on
+   partitioned/lifted formulations.)
+2. **Decertify-and-discard on the spatial path:** `_nonrigorous_sentinel_fathom`
+   taint (a node NLP failed and was sentinel-pruned without proof) correctly blocks
+   an "optimal" label, but the result-build then treats the *entire tree bound* as
+   tainted (`_tree_bound_valid = False`) and reports the far weaker root-pool /
+   root-relaxation fallback: nvs05 reports 1.3481 where the tree proved 4.8746
+   (**3.6× weaker**, reported gap 75 % vs provable 11 %); tanksize reports 0.8680
+   vs proved 0.8811. A node pruned without proof taints *optimality*, and any
+   *ancestral* bound contribution of that node — but the frontier minimum over
+   surviving open nodes is a function of which nodes were (possibly wrongly)
+   *removed*; the sound fix is per-node (floor tainted nodes into the frontier at
+   their inherited parent bound) rather than discarding the frontier wholesale.
+   That is a certification-accounting fix, not a relaxation fix.
+
+### Lever C (B&B machinery with a tight relaxation) — 1/10
+
+Only **nvs19**: root_gap 0.53 % (consistent with #587 — the root is already
+SCIP-with-cuts-tight on the integer-product family, so A-via-cuts is dead there),
+final gap 0.34 %, 215 nodes at ~3.8 nodes/s with zero LP failures. The tree grinds
+the last half-percent and cannot finish. Note its *exact* incumbent only arrived at
+t = 58 s (a 0.02 %-off incumbent sat for 55 s) — tail-gap closing needs both the
+last bound sliver and the last incumbent sliver.
+
+### Unclassified by A/B/C: primal failure (tls2)
+
+tls2's *dual* side works: bound 0.718 → 4.90 vs optimum 5.3 (91 % closed, 1 663
+nodes). It never finds **any** incumbent in 60 s, so there is nothing to certify.
+The binding lever is primal heuristics on this structure, and no relaxation or
+certification work changes that.
+
+## 4. Counterfactual: "if the root bound were exact, how much would fathom?"
+
+Using the incumbent trajectory: with an oracle-exact root bound, the solve ends at
+t_inc\* (incumbent = optimum, bound = optimum → gap 0). Panel-wide that recovers
+**52–96 % of the wall time on 7 of the 9 uncertified runs with incumbents**
+(clay 67 %, casctanks 52 %, nvs05 96 %, nvs09 95 %, tanksize 84 %, ex6_2_5 95 %,
+ex6_2_9 95 %; nvs19 3 % — its bound is already near-exact; amp 100 % — its bound
+IS exact and only the label is withheld). The nvs05/nvs09/tanksize "finds the
+optimum instantly, stalls 60 s" pattern from the directive is confirmed and is a
+pure dual-bound stall, not incumbent search.
+
+## 5. Recommendation
+
+1. **Fix the two Lever-B plumbing defects first** (small, bounded, converts already-
+   proved results into certificates / honest gaps):
+   a. #598: harden the in-house node-LP so a zero-gap search can certify (iterative
+      refinement / anti-degeneracy on partitioned formulations — the profile points
+      at degenerate dual pivots + refactor-cap churn), or at minimum re-verify the
+      single poisoned node instead of withholding the label for the whole solve.
+   b. Replace decertify-and-**discard** with per-node taint accounting so the
+      reported bound is the tree's valid frontier bound (nvs05: 4.87 not 1.35).
+      This alone moves reported gaps on the taint-affected class from ~75 % to ~11 %
+      without touching any relaxation.
+2. **Then attack Lever A as the strategic thrust — but per sub-class, not
+   generically:** (i) the alphaBB/interval fallback engine that pure-integer /
+   LP-declined models route to (nvs05, tanksize) — these nodes close ≤ 14 % of the
+   gap in a minute; (ii) the x·log(x)/Gibbs root (ex6_2_5/9, root gaps 300–400×)
+   where #597's tangent planes are demonstrably not yet enough; (iii) the NLP-BB
+   root bound (clay: root_gap 1.0 — NLP-BB opens the tree with essentially no dual
+   bound). Do **not** spend A-effort on integer-product roots (#587: already
+   SCIP-tight; c-MIR NO-GO stands).
+3. **Lever C is not the panel's problem** (1/10). Revisit after A/B.
+4. Track the tls2-style primal gap separately — it is invisible to all three levers.
+
+## 6. Falsifications recorded
+
+- "Node-LP numerical exits poison certification panel-wide" — **falsified** on the
+  spatial path (0 failures / 711 node LPs, `LpDenseRetries = 0`). The failure class
+  is confined to the in-house MILP B&B on lifted/partitioned MILPs (#598) and to
+  node-*NLP* sentinel fathoms whose taint handling over-discards (§3, Lever B).
+- "The tree's reported bound reflects what the search proved" — **false** on the
+  taint-affected class (nvs05, tanksize): reporting discards up to 3.6× of proved
+  bound.
+- Binding negatives respected, not relitigated: per-node Python tax (T1.6 — the
+  OBBT LP loop is the per-node lever; casctanks' 29 s root is consistent),
+  reduced-space (no tightening), c-MIR on integer-product families (#587 NO-GO).
+
+## 7. Reproduction
+
+```bash
+DISCOPT_PROFILE=1 python scripts/decomp1_cert_effort_drive.py 60          # full panel
+python scripts/decomp1_cert_effort_drive.py 60 nvs05,amp_multi4n          # subset
+python scripts/decomp1_cert_effort_analyze.py <results-dir>               # attribution rows
+```
+
+Raw per-instance JSON (result fields, LP status counts, Rust profile counters,
+bound/incumbent trajectories) is written as `res_<name>.json`; this report's table
+is generated from those files by the analyze script. Runs for this report were on
+macOS arm64, sequential, 2026-07-10.

--- a/scripts/decomp1_cert_effort_analyze.py
+++ b/scripts/decomp1_cert_effort_analyze.py
@@ -1,0 +1,182 @@
+"""DECOMP-1 (task #88) analysis: per-instance attribution from res_*.json.
+
+Reads the res_<name>.json files produced by decomp1_cert_effort_drive.py (from
+the directory given as argv[1], default: alongside this script) and prints one
+JSON row per instance with the lever attribution (A/B/C/primal/certified).
+"""
+
+import glob
+import json
+import os
+import sys
+
+SCRATCH = sys.argv[1] if len(sys.argv) > 1 else os.path.dirname(os.path.abspath(__file__))
+
+ORACLE = {  # minlplib.solu (user sense); amp oracle from HiGHS on the identical matrix
+    "clay0303hfsg": 26669.10957,  # =opt=
+    "casctanks": 9.163479388,  # =best=
+    "tls2": 5.3,  # =opt=
+    "nvs05": 5.470934108,  # =opt=
+    "nvs09": -43.13433692,  # =opt=
+    "tanksize": 1.268643754,  # =opt=
+    "st_e36": -246.0,  # =opt=
+    "nvs19": -1098.4,  # =opt=
+    "ex6_2_5": -70.75207783,  # =best=
+    "ex6_2_9": -0.0340661841,  # =best=
+    "amp_multi4n": -26.822044702,  # HiGHS-certified optimum of the lifted MILP (min sense)
+}
+
+FAIL_KEYS = ("numerical", "error", "iteration_limit", "time_limit", "unbounded", "optimal_nobound")
+
+
+def relclose(a, b, tol=1e-4):
+    if a is None or b is None:
+        return False
+    return abs(a - b) <= tol * max(1.0, abs(a), abs(b))
+
+
+def analyze(rec):
+    name = rec["name"]
+    oracle = ORACLE.get(name)
+    obj = rec.get("objective")
+    bound = rec.get("bound")
+    root_bound = rec.get("root_bound")
+    root_gap = rec.get("root_gap")
+    wall = rec.get("wall_time") or rec.get("harness_wall")
+
+    lp = rec.get("mccormick_lp_impl_counts") or {}
+    lp_total = sum(lp.values())
+    lp_fail = sum(v for k, v in lp.items() if k in FAIL_KEYS)
+    fail_rate = (lp_fail / lp_total) if lp_total else None
+
+    found_opt = relclose(obj, oracle)
+    # dual-bound progress toward oracle, user sense (bound <= oracle for min;
+    # for max the reported bound is an upper bound >= oracle)
+    closed = None
+    if bound is not None and root_bound is not None and oracle is not None:
+        denom = oracle - root_bound
+        if abs(denom) > 1e-12:
+            closed = (bound - root_bound) / denom
+    stalled_at_root = (
+        bound is not None and root_bound is not None and relclose(bound, root_bound, 1e-6)
+    )
+
+    # incumbent timeline: first time the incumbent matched the oracle (internal sense)
+    t_first_opt = None
+    traj = rec.get("traj") or []
+    flip = False
+    if traj and obj is not None:
+        last_inc = traj[-1][2]
+        if last_inc is not None and abs(last_inc + obj) < 1e-6 * max(1.0, abs(obj)):
+            flip = True
+    tgt = None if oracle is None else (-oracle if flip else oracle)
+    if tgt is not None:
+        for t, _glb, inc in traj:
+            if inc is not None and relclose(inc, tgt):
+                t_first_opt = t
+                break
+    stall_frac = None
+    if t_first_opt is not None and wall:
+        stall_frac = max(0.0, (wall - t_first_opt) / wall)
+
+    ctrs = rec.get("rust_counters") or {}
+    pivots = ctrs.get("Phase1Pivots", 0) + ctrs.get("Phase2Pivots", 0)
+
+    # Certification taint: the reported bound is WEAKER than the tree's final
+    # global lower bound snapshot -> the tree bound was decertified (nonrigorous
+    # sentinel fathom / untrusted node solve) and discarded for a fallback bound.
+    tree_glb_final = None
+    if traj:
+        g = traj[-1][1]
+        if g is not None and g not in (float("inf"), float("-inf")):
+            tree_glb_final = -g if flip else g
+    tree_bound_dropped = False
+    if tree_glb_final is not None and bound is not None:
+        if flip:  # maximize: user-sense bound is an upper bound; dropped if bound > glb
+            tree_bound_dropped = bound - tree_glb_final > 1e-6 * max(1.0, abs(bound))
+        else:
+            tree_bound_dropped = tree_glb_final - bound > 1e-6 * max(1.0, abs(bound))
+
+    uncertified_zero_gap = (
+        rec.get("status") not in ("optimal",)
+        and not rec.get("gap_certified")
+        and rec.get("gap") is not None
+        and rec["gap"] <= 1e-6
+    ) or (rec.get("status") == "iteration_limit" and relclose(obj, bound) and obj is not None)
+
+    # --- attribution ---
+    reasons = []
+    certified = rec.get("status") == "optimal"
+    if not certified:
+        if obj is None and rec.get("status") in ("time_limit", "node_limit"):
+            reasons.append("primal")  # no incumbent at all: primal-heuristic gap
+        # A: root_gap > ~20%, or bound stalls at root value
+        if (root_gap is not None and root_gap > 0.2) or stalled_at_root:
+            reasons.append("A")
+        # B: node-LP failure rate > 1% (on a meaningful LP count), a
+        # found-but-uncertified zero-gap exit, or a tainted/dropped tree bound
+        if (
+            (fail_rate is not None and lp_total >= 20 and fail_rate > 0.01)
+            or uncertified_zero_gap
+            or tree_bound_dropped
+        ):
+            reasons.append("B")
+        # C: relaxation is fine (small root gap) yet the tree/machinery still
+        # cannot finish inside the budget
+        if (
+            (root_gap is not None and root_gap <= 0.2)
+            and not stalled_at_root
+            and "B" not in reasons
+            and obj is not None
+        ):
+            reasons.append("C")
+        if not reasons:
+            reasons.append("?")
+    attribution = "certified" if certified else "+".join(reasons)
+
+    return {
+        "name": name,
+        "oracle": oracle,
+        "status": rec.get("status"),
+        "objective": obj,
+        "found_opt": found_opt,
+        "bound": bound,
+        "root_bound": root_bound,
+        "root_gap": root_gap,
+        "root_time": rec.get("root_time"),
+        "gap": rec.get("gap"),
+        "gap_certified": rec.get("gap_certified"),
+        "nodes": rec.get("node_count"),
+        "wall": wall,
+        "lp_total": lp_total,
+        "lp_fail": lp_fail,
+        "lp_fail_rate": fail_rate,
+        "lp_status_counts": lp,
+        "engine_counts": rec.get("engine_counts"),
+        "pivots": pivots,
+        "dense_retries": ctrs.get("LpDenseRetries", 0),
+        "bound_closed_frac": closed,
+        "tree_glb_final": tree_glb_final,
+        "tree_bound_dropped": tree_bound_dropped,
+        "stalled_at_root": stalled_at_root,
+        "t_first_opt_incumbent": t_first_opt,
+        "stall_frac": stall_frac,
+        "uncertified_zero_gap": uncertified_zero_gap,
+        "attribution": attribution,
+    }
+
+
+def main():
+    rows = []
+    for path in sorted(glob.glob(os.path.join(SCRATCH, "res_*.json"))):
+        rec = json.load(open(path))
+        rows.append(analyze(rec))
+    order = list(ORACLE)
+    rows.sort(key=lambda r: order.index(r["name"]) if r["name"] in order else 99)
+    for r in rows:
+        print(json.dumps(r, indent=None, default=str))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/decomp1_cert_effort_drive.py
+++ b/scripts/decomp1_cert_effort_drive.py
@@ -1,0 +1,109 @@
+"""DECOMP-1 (task #88) driver: run the certification-effort panel sequentially.
+
+Runs each instance via decomp1_cert_effort_run.py in a fresh subprocess with
+DISCOPT_PROFILE=1, parses the Rust profile dumps from stderr, and writes one
+res_<name>.json per instance next to this script (or set DECOMP1_OUT).
+
+Usage: python scripts/decomp1_cert_effort_drive.py [time_limit] [name1,name2,...]
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+SCRATCH = os.path.dirname(os.path.abspath(__file__))
+OUT_DIR = os.environ.get("DECOMP1_OUT", SCRATCH)
+NL_DIR = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+RUNNER = os.path.join(SCRATCH, "decomp1_cert_effort_run.py")
+
+PANEL = [
+    "clay0303hfsg",
+    "casctanks",
+    "tls2",
+    "nvs05",
+    "nvs09",
+    "tanksize",
+    "st_e36",
+    "nvs19",
+    "ex6_2_5",
+    "ex6_2_9",
+]
+
+PHASE_RE = re.compile(r"^\s{2}(\w+)\s+(\d+) calls\s+([\d.]+) ms$")
+CTR_RE = re.compile(r"^\s{2}(\w+)\s+(\d+)$")
+
+
+def parse_profile(stderr_path):
+    """Sum phase counts/ms and counters across all DISCOPT_PROFILE dumps."""
+    phases: dict = {}
+    ctrs: dict = {}
+    with open(stderr_path, errors="replace") as fh:
+        for line in fh:
+            m = PHASE_RE.match(line.rstrip())
+            if m:
+                name, cnt, ms = m.group(1), int(m.group(2)), float(m.group(3))
+                c, t = phases.get(name, (0, 0.0))
+                phases[name] = (c + cnt, t + ms)
+                continue
+            m = CTR_RE.match(line.rstrip())
+            if m:
+                name, val = m.group(1), int(m.group(2))
+                ctrs[name] = ctrs.get(name, 0) + val
+    return (
+        {k: {"calls": v[0], "ms": round(v[1], 1)} for k, v in phases.items()},
+        {k: v for k, v in ctrs.items() if v},
+    )
+
+
+def run_one(name, extra_args, tl):
+    out_json = os.path.join(OUT_DIR, f"res_{name}.json")
+    err_path = os.path.join(OUT_DIR, f"err_{name}.txt")
+    env = dict(os.environ, DISCOPT_PROFILE="1")
+    cmd = [sys.executable, RUNNER, "--name", name, "--time-limit", str(tl)] + extra_args
+    print(f"=== {name} ===", flush=True)
+    with open(err_path, "w") as errf:
+        try:
+            proc = subprocess.run(
+                cmd, stdout=subprocess.PIPE, stderr=errf, timeout=tl * 4 + 120, text=True, env=env
+            )
+            stdout = proc.stdout
+            rc = proc.returncode
+        except subprocess.TimeoutExpired as e:
+            stdout = (e.stdout or b"").decode() if isinstance(e.stdout, bytes) else (e.stdout or "")
+            rc = "timeout"
+    rec = {"name": name, "returncode": rc}
+    for line in (stdout or "").splitlines():
+        if line.startswith("RESULT_JSON: "):
+            rec.update(json.loads(line[len("RESULT_JSON: ") :]))
+            break
+    else:
+        rec["error"] = "no RESULT_JSON"
+        rec["stdout_tail"] = (stdout or "")[-2000:]
+    phases, ctrs = parse_profile(err_path)
+    rec["rust_phases"] = phases
+    rec["rust_counters"] = ctrs
+    with open(out_json, "w") as f:
+        json.dump(rec, f, indent=1)
+    print(
+        f"  status={rec.get('status')} obj={rec.get('objective')} bound={rec.get('bound')} "
+        f"nodes={rec.get('node_count')} certified={rec.get('gap_certified')}",
+        flush=True,
+    )
+    return rec
+
+
+def main():
+    tl = float(sys.argv[1]) if len(sys.argv) > 1 else 60.0
+    only = sys.argv[2].split(",") if len(sys.argv) > 2 else None
+    for name in PANEL:
+        if only and name not in only:
+            continue
+        run_one(name, ["--nl", os.path.join(NL_DIR, f"{name}.nl")], tl)
+    if only is None or "amp_multi4n" in (only or []):
+        run_one("amp_multi4n", ["--amp-milp"], tl)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/decomp1_cert_effort_run.py
+++ b/scripts/decomp1_cert_effort_run.py
@@ -1,0 +1,283 @@
+"""DECOMP-1 measurement harness (task #88). Measurement-only: no solver changes.
+
+Runs one instance (a MINLPLib .nl file or the #598 AMP multi4N MILP relaxation)
+with instrumentation:
+  - counts every McCormick node-LP solve by terminal status (inner impl incl.
+    C-43 retries, and outer driver-visible verdicts),
+  - counts MILP-path POUNCE bound-recovery attempts/failures (gap decertify),
+  - records the (time, global_lower_bound, incumbent_obj) trajectory by
+    proxying PyTreeManager.stats(),
+  - emits a single RESULT_JSON line on stdout.
+
+Run with DISCOPT_PROFILE=1 in the env to additionally get the Rust simplex
+pivot/phase dumps on stderr (parsed by the parent).
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from collections import Counter
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--nl", default=None)
+    ap.add_argument("--amp-milp", action="store_true")
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    ap.add_argument("--name", default=None)
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        stream=sys.stderr,
+        format="LOG %(relativeCreated)d %(name)s %(message)s",
+    )
+
+    import discopt._jax.mccormick_lp as mlp
+    import discopt.solver as ds
+    import numpy as np  # noqa: F401
+
+    lp_counts: Counter = Counter()  # inner _solve_at_node_impl statuses
+    outer_counts: Counter = Counter()  # driver-visible solve_at_node verdicts
+
+    def _key(res):
+        k = res.status
+        if k == "optimal" and getattr(res, "lower_bound", None) is None:
+            k = "optimal_nobound"  # declined bound -> driver must branch
+        return k
+
+    _orig_impl = mlp.MccormickLPRelaxer._solve_at_node_impl
+
+    def _impl(self, *a, **k):
+        res = _orig_impl(self, *a, **k)
+        lp_counts[_key(res)] += 1
+        return res
+
+    mlp.MccormickLPRelaxer._solve_at_node_impl = _impl
+
+    _orig_outer = mlp.MccormickLPRelaxer.solve_at_node
+
+    def _outer(self, *a, **k):
+        res = _orig_outer(self, *a, **k)
+        outer_counts[_key(res)] += 1
+        return res
+
+    mlp.MccormickLPRelaxer.solve_at_node = _outer
+
+    # Non-LP node-bound engines: count calls so each instance's dominant
+    # per-node bounder is identified (pure-integer models route to
+    # alphaBB/interval, not the McCormick LP).
+    engine_counts: Counter = Counter()
+
+    _orig_ab = ds._compute_alphabb_bound
+
+    def _ab(*a, **k):
+        engine_counts["alphabb"] += 1
+        return _orig_ab(*a, **k)
+
+    ds._compute_alphabb_bound = _ab
+
+    _orig_iv = ds._compute_interval_bound
+
+    def _iv(*a, **k):
+        engine_counts["interval"] += 1
+        return _orig_iv(*a, **k)
+
+    ds._compute_interval_bound = _iv
+
+    try:
+        import discopt._jax.mccormick_nlp as mnlp
+
+        _orig_mcb = mnlp.solve_mccormick_batch
+
+        def _mcb(*a, **k):
+            r = _orig_mcb(*a, **k)
+            engine_counts["mccormick_nlp_batch_calls"] += 1
+            try:
+                engine_counts["mccormick_nlp_batch_nodes"] += int(len(r))
+            except Exception:
+                pass
+            return r
+
+        mnlp.solve_mccormick_batch = _mcb
+    except Exception:
+        pass
+
+    # MILP-path node-bound recovery (iteration-limit/numerical node LP exits):
+    # each attempt = one node whose LP bound was untrusted; a None return
+    # decertifies the gap (#598 failure class).
+    recover = {"attempts": 0, "failed": 0}
+    if hasattr(ds, "_pounce_recover_node_bound"):
+        _orig_rec = ds._pounce_recover_node_bound
+
+        def _rec(*a, **k):
+            recover["attempts"] += 1
+            r = _orig_rec(*a, **k)
+            if r is None:
+                recover["failed"] += 1
+            return r
+
+        ds._pounce_recover_node_bound = _rec
+
+    # Bound/incumbent trajectory via a PyTreeManager proxy. stats() is called
+    # once per driver batch iteration, so overhead is negligible vs node LPs.
+    traj: list = []
+    t0 = time.perf_counter()
+    _RealTree = ds.PyTreeManager
+
+    class TreeProxy:
+        def __init__(self, *a, **k):
+            object.__setattr__(self, "_t", _RealTree(*a, **k))
+
+        def __getattr__(self, name):
+            real = object.__getattribute__(self, "_t")
+            attr = getattr(real, name)
+            if name == "stats":
+
+                def stats(*a, **k):
+                    s = attr(*a, **k)
+                    try:
+                        inc = real.incumbent()
+                        inc_obj = None if inc is None else float(inc[1])
+                    except Exception:
+                        inc_obj = None
+                    glb = None
+                    try:
+                        glb = s.get("global_lower_bound")
+                        glb = None if glb is None else float(glb)
+                    except Exception:
+                        pass
+                    traj.append((time.perf_counter() - t0, glb, inc_obj))
+                    return s
+
+                return stats
+            return attr
+
+    ds.PyTreeManager = TreeProxy
+
+    scipy_contrast = None
+    if args.amp_milp:
+        from discopt import Model
+        from discopt._jax.discretization import initialize_partitions
+        from discopt._jax.milp_relaxation import build_milp_relaxation
+        from discopt._jax.model_utils import flat_variable_bounds
+        from discopt._jax.term_classifier import classify_nonlinear_terms
+
+        # Alpine examples/MINLPs/multi.jl:multi4N, n=2, exprmode=1 (issue #598).
+        m0 = Model("alpine_multi4N_2_1")
+        size = 7
+        x = m0.continuous("x", lb=0.1, ub=4.0, shape=(size,))
+        obj = None
+        for i in range(0, size - 1, 3):
+            term = x[i] * x[i + 1] * x[i + 2] * x[i + 3]
+            obj = term if obj is None else obj + term
+            m0.subject_to(x[i] + x[i + 1] + x[i + 2] + x[i + 3] <= 4.0)
+        m0.maximize(obj)
+
+        terms = classify_nonlinear_terms(m0)
+        flat_lb, flat_ub = flat_variable_bounds(m0)
+        state = initialize_partitions(
+            terms.partition_candidates,
+            lb=[flat_lb[i] for i in terms.partition_candidates],
+            ub=[flat_ub[i] for i in terms.partition_candidates],
+            n_init=2,
+        )
+        model, _varmap = build_milp_relaxation(m0, terms, state, incumbent=None)
+
+        # Identical matrix through scipy's HiGHS MILP for the node contrast.
+        # ``model`` is a MilpRelaxationModel wrapper: min c'x s.t. A_ub x <= b_ub,
+        # bounds, integrality (already in the internal min sense).
+        try:
+            import scipy.sparse as sp
+            from scipy.optimize import Bounds, LinearConstraint
+            from scipy.optimize import milp as scipy_milp
+
+            c = np.asarray(model._c, dtype=float)
+            A = sp.csr_matrix(model._A_ub) if model._A_ub is not None else None
+            b = np.asarray(model._b_ub, dtype=float) if model._b_ub is not None else None
+            xl = np.array([lo for lo, _ in model._bounds], dtype=float)
+            xu = np.array([hi for _, hi in model._bounds], dtype=float)
+            integrality = (
+                np.asarray(model._integrality, dtype=float)
+                if model._integrality is not None
+                else np.zeros(c.shape[0])
+            )
+            cons = [LinearConstraint(A, -np.inf, b)] if A is not None and A.shape[0] else []
+            t_h = time.perf_counter()
+            hres = scipy_milp(c=c, constraints=cons, bounds=Bounds(xl, xu), integrality=integrality)
+            scipy_contrast = {
+                "status": int(hres.status),
+                "message": str(hres.message),
+                "objective_min_sense": (
+                    None if hres.fun is None else float(hres.fun + model._obj_offset)
+                ),
+                "mip_node_count": int(getattr(hres, "mip_node_count", -1)),
+                "mip_dual_bound": (
+                    None
+                    if getattr(hres, "mip_dual_bound", None) is None
+                    else float(hres.mip_dual_bound)
+                ),
+                "wall": time.perf_counter() - t_h,
+                "n_cols": int(c.shape[0]),
+                "n_rows": 0 if A is None else int(A.shape[0]),
+                "n_int": int((integrality > 0).sum()),
+            }
+        except Exception as exc:  # measurement-only: record, don't die
+            scipy_contrast = {"error": repr(exc)}
+    else:
+        from discopt.modeling.core import from_nl
+
+        model = from_nl(args.nl)
+
+    t_solve = time.perf_counter()
+    result = model.solve(time_limit=args.time_limit)
+    wall = time.perf_counter() - t_solve
+
+    def _get(attr, default=None):
+        return getattr(result, attr, default)
+
+    # Compress trajectory: keep points where glb or incumbent changed.
+    slim = []
+    last = (object(), object())
+    for t, glb, inc in traj:
+        if (glb, inc) != last:
+            slim.append([round(t, 3), glb, inc])
+            last = (glb, inc)
+    if traj:
+        t, glb, inc = traj[-1]
+        if slim and slim[-1][0] != round(t, 3):
+            slim.append([round(t, 3), glb, inc])
+
+    out = {
+        "name": args.name or (args.nl or "amp_multi4n_milp"),
+        "status": result.status,
+        "objective": result.objective,
+        "bound": result.bound,
+        "gap": _get("gap"),
+        "gap_certified": bool(_get("gap_certified", False)),
+        "node_count": int(_get("node_count", -1) or -1),
+        "wall_time": float(_get("wall_time", wall) or wall),
+        "harness_wall": wall,
+        "root_bound": _get("root_bound"),
+        "root_gap": _get("root_gap"),
+        "root_time": _get("root_time"),
+        "safe_bound": _get("safe_bound"),
+        "farkas_certified": bool(_get("farkas_certified", False)),
+        "convex_fast_path": bool(_get("convex_fast_path", False)),
+        "nlp_bb": bool(_get("nlp_bb", False)),
+        "solver_stats": _get("solver_stats"),
+        "mccormick_lp_impl_counts": dict(lp_counts),
+        "mccormick_lp_outer_counts": dict(outer_counts),
+        "milp_recover": recover,
+        "engine_counts": dict(engine_counts),
+        "traj": slim,
+        "n_traj_snapshots": len(traj),
+        "scipy_highs": scipy_contrast,
+    }
+    print("RESULT_JSON: " + json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## DECOMP-1 (task #88): certification-effort decomposition — measurement only

Answers the directive *"we are still working way too hard to certify and not succeeding —
which lever?"* with a per-instance attribution on the 10-instance panel
(clay0303hfsg, casctanks, tls2, nvs05, nvs09, tanksize, st_e36, nvs19, ex6_2_5, ex6_2_9;
TL=60 s; oracle `minlplib.solu`) plus the #598 AMP multi4N MILP relaxation
cross-solved with scipy/HiGHS on the identical matrix. **No solver changes** — a docs
report + the reproduction harness only.

### Panel verdict (full table and evidence in `docs/dev/certification-effort-decomposition-2026-07-10.md`)

- **10/11 runs find the exact oracle optimum; 1/11 certifies** (st_e36).
- **Lever A (relaxation/dual-bound strength) dominates: 7/10 uncertified runs** —
  median root_gap 0.94 on uncertified spatial runs; incumbent already optimal for
  52–96 % of wall time. Three distinct sub-classes: alphaBB/interval-routed nodes
  (nvs05, tanksize — the McCormick LP soundly declines at root and the fallback engine
  closes ≤ 14 % of the gap), the x·log(x)/Gibbs roots (ex6_2_5/9 — root gaps 392×/332×
  *with* #597 centropy in the base), and NLP-BB with essentially no root bound (clay).
- **Lever B is real but narrow — two plumbing defects, recommended to fix FIRST:**
  1. **#598**: in-house MILP B&B reaches `obj == bound == −26.822045` (gap exactly 0,
     HiGHS-verified) in 0.85 s and still exits `iteration_limit` uncertified.
     459 node LPs / 22,833 pivots (81 % of dual pivots degenerate, RefacCap 443,
     `LpDenseRetries = 0` → not the #591 class) vs **one scipy-HiGHS call: 0.24 s,
     19 nodes, optimal**.
  2. **Decertify-and-discard**: on nvs05 the tree *proved* bound 4.8746 (89 % of the
     5.4709 optimum) but the run *reports* 1.3481 — the nonrigorous-sentinel-fathom
     taint drops the whole tree bound for the root fallback (3.6× weaker; reported
     gap 75 % vs provable 11 %). Same on tanksize (0.8811 → 0.8680).
- **The hypothesized panel-wide form of B is falsified**: 0 numerical/iteration-limit
  node-LP exits in 711 McCormick node-LP solves across the spatial panel.
- **Lever C: 1/10** (nvs19 — root_gap 0.53 %, consistent with #587's root-already-
  SCIP-tight NO-GO; final gap 0.34 % after 215 nodes).
- **tls2 is a pure primal failure** (no incumbent in 60 s while the dual bound closes
  91 %) — invisible to the A/B/C taxonomy, tracked separately.

### Recommendation (§5 of the report)

Fix the two B plumbing defects first (small, bounded, converts already-proved bound
into certificates/honest gaps), then attack A per sub-class (alphaBB/interval fallback
engine, Gibbs-family root, NLP-BB root bound) — explicitly NOT via more cuts on
integer-product roots (#587 NO-GO stands). C after A/B.

### What was run

- Harness: `scripts/decomp1_cert_effort_{run,drive,analyze}.py` (committed) — fresh
  subprocess per instance, `DISCOPT_PROFILE=1`, monkeypatch taps on
  `MccormickLPRelaxer._solve_at_node_impl` (per-status node-LP counts incl. C-42/C-43
  retries), `_compute_alphabb_bound` / `_compute_interval_bound` /
  `solve_mccormick_batch` (node-engine attribution), and a `PyTreeManager` proxy
  recording the bound/incumbent trajectory. Base `main@16f25505`; Rust ext rebuilt
  (`pip install -e .`), `import discopt._rust` verified.
- `ruff check` / `ruff format --check` clean on the three scripts.
- No pytest smoke / adversarial / cargo run: **no solver code changed** (docs +
  measurement scripts only; the harness never runs in CI).
- Wall-time caveat: sequential runs on a shared laptop; counts/bounds/statuses are
  deterministic, wall numbers indicative.

Do NOT merge without maintainer review — this sets the direction for the next
certification work package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
