### PR TITLE
docs(cert): BR-3 (task #80) — re-gate nvs21/st_e36-blocked flags post dense-retry (verdict 1/3)

### DIFF
--- a/docs/dev/br3-regate-2026-07-10.md
+++ b/docs/dev/br3-regate-2026-07-10.md
@@ -1,0 +1,147 @@
+# BR-3 — Re-gate the nvs21/st_e36-blocked flags post dense-retry (task #80, 2026-07-10)
+
+**Task:** BR-3 of `docs/dev/gap-closing-execution-plan.md` §3. Re-run the #581
+graduation gates for the flags previously blocked by single-instance certificate
+losses, now that the **failure-triggered dense LP retry** (#591 / A-2, task #85,
+behind `DISCOPT_LU_DENSITY_ROUTE`) is merged on `main`. Hypothesis: those cert
+losses share one mechanism — sparse-route node-LP failures that abandon a node
+with its loose inherited bound, sticking the final dual bound — which the retry
+cures (nvs21). Each flag that goes green ×3 verdicts → default-ON PR; this run is
+**verdict 1 post-retry** (T2.6: 3 consecutive greens required before any flip).
+
+**This PR flips no defaults.** Every flag remains default-OFF. The deliverable is
+the measured re-gate + per-flag verdict.
+
+## Composition (binding, per task)
+
+Every ON arm composes the graduating flag **with `DISCOPT_LU_DENSITY_ROUTE=1`** —
+the A-2 dense retry is the mechanism hypothesized to cure the cert losses, so the
+"ON" configuration under test is *flag + route*, not the flag alone. The
+`lu_density_route` arm is the route alone (the #74 gate re-run: nvs21 must go
+optimal→optimal). Where a loss survives the route, the route is not its cause and
+the arm's verdict stands on the residual loss (root-caused below).
+
+## Build & method
+
+- **Build:** `maturin develop --release` from this worktree's crates
+  (`discopt._rust.cpython-312-darwin.so` local to the worktree, verified imported
+  from `…/agent-a6bfe943313e1b6a4/python/discopt`); `pounce-solver 0.7`,
+  `JAX_PLATFORMS=cpu`, `JAX_ENABLE_X64=1`. Isolated subprocess per solve (env flags
+  read fresh at import).
+- **Panel (28 instances):** the named blockers (nvs21, st_e36, nvs09, tls2) +
+  tree-opening (ringpack_10_1, kall_circles_c6b, st_e07, nvs06, nvs19, nvs24) +
+  integer-NLP (nvs01/02/04/07/13/15/17/23) + QP/MIQP (st_miqp2, st_miqp3, meanvarx,
+  alan) + spatial/bilinear (ex5_2_2_case1, ex5_3_2, ex7_2_1, ex4_1_1, alkyl,
+  st_e30). TL=40 s, gap 1e-4. Oracle = `minlplib.solu` (`=opt=`, or the
+  `[=bestdual=, =best=]` bracket).
+- **Criteria (#581 house pattern):** `incorrect_count=0` (certified objective vs
+  oracle, zero slack, abs 1e-4/rel 1e-3); **zero certificate losses** (OFF optimal
+  → ON non-optimal); objective drift ≤ abs 1e-4/rel 1e-3; no oracle cross (dual
+  bound never past `=opt=`); perf = node counts on both-certified instances.
+- **Concurrency hygiene (§0.7):** a second agent (decomp1) shared the machine
+  (load avg ≈ 8 during the run). All verdicts rest on **deterministic node
+  counts / status / objective**, which reproduced exactly across the two gate
+  runs (the first aborted on an unrelated venv-path error; the OFF baseline and
+  liveness numbers are byte-identical between runs — nvs21 195 n, st_e36 153 n,
+  and every node delta below reproduced). Wall times are **not** used for any
+  verdict.
+- **Artifacts:** `docs/dev/data/br3-regate-2026-07-10/` (per-arm JSON + liveness).
+
+## Flag-engagement proof (setup step 2 — each flag is LIVE in this build)
+
+A flag that changes nothing = a wrong panel/build (INCONCLUSIVE, not green). Each
+flag was flipped on an engaging instance and confirmed to move node count / bound
+/ status (`br3-regate-2026-07-10/liveness.json`):
+
+| flag | probe | OFF | ON (flag alone) | engaged? |
+|---|---|---|---|---|
+| `DISCOPT_LU_DENSITY_ROUTE` | nvs21 | optimal 195 n | optimal 191 n | **yes** (nodes 195→191) |
+| `DISCOPT_NODE_REDUCE` | nvs21 | optimal 195 n | optimal **29 n** | **yes** (nodes 195→29) |
+| `DISCOPT_NODE_REDUCE` | st_e36 | optimal 153 n | feasible 75 n | **yes** (status + nodes) |
+| `DISCOPT_SQUARE_COST_GATE` | nvs19 | feasible 161 n | feasible **131 n** | **yes** (nodes 161→131) |
+| `DISCOPT_OBJ_BRANCH_PRIORITY` | nvs01 | optimal 17 n | optimal **11 n** | **yes** (nodes 17→11) |
+| `DISCOPT_OBJ_BRANCH_PRIORITY` | nvs13 | optimal 45 n | optimal **35 n** | **yes** (nodes 45→35) |
+| `DISCOPT_LIFT_LOOSE_PRODUCTS` | nvs09 | feasible bnd −58.65 | feasible bnd **−47.06** | **yes** (bound tightens) |
+
+Flag name for TD-A verified in `python/discopt/_jax/factorable_reform.py`:
+`DISCOPT_LIFT_LOOSE_PRODUCTS` (`_lift_loose_products_enabled`, default OFF).
+
+## Per-flag verdict table
+
+All arms: **`incorrect_count=0`, 0 oracle crosses, 0 objective drift** (every
+certified objective matches the oracle to tolerance; every dual bound is a valid
+underestimator ≤ `=opt=`). The discriminator is the certificate-loss column.
+
+| flag (ON = flag + route) | engaged? | incorrect | cert-loss | node Δ (both-certified) | verdict |
+|---|:-:|:-:|---|---|---|
+| **lu_density_route** (#74 re-run) | yes | 0 | **0** — nvs21 optimal→optimal (195→191 n) | 1144→1142 (nvs21 −4) | **GRADUATE-ELIGIBLE** |
+| **obj_branch_priority** | yes | 0 | **0** (nvs21 cured: optimal 191 n) | 1144→**1102** (nvs01 17→11, nvs13 45→35, nvs17 173→151) | **GRADUATE-ELIGIBLE** |
+| **lift_loose_products** (TD-A) | yes | 0 | **0** (nvs09 gap tightens −58.65→−45.78) | 1144→1142 | **GRADUATE-ELIGIBLE** |
+| **node_reduce** | yes | 0 | **1: st_e36** optimal→feasible (bound pinned −304.5 vs −246) | 991→**817** (nvs21 195→35, st_e30 53→19, nvs01 17→9) | **KEEP-OPT-IN** |
+| **square_cost_gate** | yes | 0 | **1: alkyl** optimal→feasible (bound −2.409 vs −1.765) | 1115→1125 (neutral) | **KEEP-OPT-IN** |
+
+## Root-cause of the two residual cert losses (the retry did NOT cure them)
+
+The BR-3 hypothesis was that the blocked losses are the LP-failure class the retry
+fixes. **For nvs21 it holds** (route re-certifies nvs21 in every arm). But the two
+surviving losses are **not** that class — the route is irrelevant to both:
+
+- **node_reduce / st_e36** — loses **with OR without** the route (measured: route
+  OFF → `feasible 75 n bound −304.5`; route ON → same). The mechanism is *not* a
+  sparse-route LP failure: node_reduce's per-node DBBT/FBBT pins the box and a node
+  fathoms carrying the **loose inherited bound −304.5**, so the final dual bound
+  sticks at the pin (true `=opt= −246`). The incumbent is correct (−246); the bound
+  is a valid underestimator; but the certificate is lost. This is the
+  reduction-mechanism loss (the R4 `lift_zero_spanning` reform is what un-pins
+  st_e36 from −304.5 — a different flag), not the retry's domain. **Residual
+  blocker; needs its own entry experiment (interaction of node_reduce DBBT with the
+  −304.5 root pin), not a tweak.**
+
+- **square_cost_gate / alkyl** — a **composition** loss that exists *only* with the
+  route. Measured, deterministic 2/2: square alone → `optimal 29 n`; route alone →
+  `optimal 29 n`; **square + route → `feasible 29 n bound −2.409`** (incumbent
+  −1.765 correct in all three; identical 29-node tree). So the route does not cure
+  square_cost_gate's old nvs21 loss for free — it *introduces* a new alkyl loss when
+  the gated square-loop and the dense-retry path co-occur at a node, leaving that
+  node's bound loose. nvs21 itself is now clean under square+route (191 n optimal).
+  **Residual blocker is the square×route interaction; needs an entry experiment.**
+
+Both residual losses are sound (valid loose underestimator, correct incumbent, no
+oracle cross, `incorrect_count=0`) — a lost *certificate*, not a wrong answer — but
+a lost certificate blocks default-ON per §0.1.
+
+## Which flags are now graduate-eligible (this run = verdict 1 of 3, T2.6)
+
+- **`DISCOPT_LU_DENSITY_ROUTE`** — the #74 gate passes: nvs21 optimal→optimal,
+  0 cert-losses, 0 incorrect across the panel. This is the retry doing its job.
+  **GRADUATE-ELIGIBLE (verdict 1/3).**
+- **`DISCOPT_OBJ_BRANCH_PRIORITY`** (with route) — nvs21 cured, 0 cert-losses,
+  0 incorrect, and node counts now **improve broadly** (1144→1102; helps nvs01,
+  nvs13, nvs17; no both-certified regressions on the panel). Note vs #581: there
+  the nvs21 loss + a net node *increase* both blocked it; composed with the route
+  the loss is gone AND the node picture flipped positive on this panel.
+  **GRADUATE-ELIGIBLE (verdict 1/3).**
+- **`DISCOPT_LIFT_LOOSE_PRODUCTS`** (TD-A, with route) — 0 cert-losses, 0 incorrect;
+  the TAIL-1 win reproduces (nvs09 dual bound tightens −58.65→−45.78, closing the
+  root gap toward `=opt= −43.13`; per-node lift is inert/byte-identical where the
+  loose-product structure is absent). **GRADUATE-ELIGIBLE (verdict 1/3).**
+
+Each needs 2 more independent green verdicts (different instance draws / TLs) before
+a default-ON flip PR, per T2.6.
+
+**Still KEEP-OPT-IN (route did not cure the loss):**
+- **`DISCOPT_NODE_REDUCE`** — st_e36 loss survives the route (reduction-mechanism,
+  not LP-failure). Perf is genuinely positive (817 vs 991 nodes on both-certified;
+  nvs21 195→35), so the *only* blocker is the st_e36 certificate.
+- **`DISCOPT_SQUARE_COST_GATE`** — alkyl loss introduced by the square×route
+  composition; perf remains neutral (1115→1125 nodes) as in #581.
+
+## Verification run for the PR
+
+- `import discopt._rust` verified from the worktree build (setup step 1).
+- Every flag proven LIVE (setup step 2, table above) before measuring.
+- Gate data + oracle-checked verdicts committed under
+  `docs/dev/data/br3-regate-2026-07-10/`.
+- No solver math changed (docs + data only); no defaults flipped. `pytest -m
+  smoke` and the adversarial suite are unaffected by this doc-only change but were
+  run to confirm the worktree build is healthy (see PR body).

--- a/docs/dev/data/br3-regate-2026-07-10/br3_lift_loose_products.json
+++ b/docs/dev/data/br3-regate-2026-07-10/br3_lift_loose_products.json
@@ -1,0 +1,262 @@
+{
+  "arm": "lift_loose_products",
+  "env": {
+    "DISCOPT_LIFT_LOOSE_PRODUCTS": "1",
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 9.868,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 153,
+      "wall": 7.86,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -45.780390825137985,
+      "node_count": 117,
+      "wall": 41.218,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 1343,
+      "wall": 41.01,
+      "sense": "min"
+    },
+    "ringpack_10_1": {
+      "instance": "ringpack_10_1",
+      "status": "feasible",
+      "objective": -8.692986405129453,
+      "bound": -20.85821767761298,
+      "node_count": 113,
+      "wall": 41.454,
+      "sense": "min"
+    },
+    "kall_circles_c6b": {
+      "instance": "kall_circles_c6b",
+      "status": "feasible",
+      "objective": 2.575063259074003,
+      "bound": -1.000001381788337e-09,
+      "node_count": 31,
+      "wall": 50.102,
+      "sense": "min"
+    },
+    "st_e07": {
+      "instance": "st_e07",
+      "status": "optimal",
+      "objective": -400.0000040538907,
+      "bound": -400.0000040538907,
+      "node_count": 1,
+      "wall": 3.536,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 0.639,
+      "sense": "min"
+    },
+    "nvs19": {
+      "instance": "nvs19",
+      "status": "feasible",
+      "objective": -1098.2,
+      "bound": -1102.8385175019384,
+      "node_count": 163,
+      "wall": 40.073,
+      "sense": "min"
+    },
+    "nvs24": {
+      "instance": "nvs24",
+      "status": "feasible",
+      "objective": -1031.7999999999997,
+      "bound": -1035.6600020723224,
+      "node_count": 7,
+      "wall": 52.845,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668808098541,
+      "node_count": 17,
+      "wall": 1.674,
+      "sense": "min"
+    },
+    "nvs02": {
+      "instance": "nvs02",
+      "status": "optimal",
+      "objective": 5.96418452307,
+      "bound": 5.96418452307,
+      "node_count": 337,
+      "wall": 0.164,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.494,
+      "sense": "min"
+    },
+    "nvs07": {
+      "instance": "nvs07",
+      "status": "optimal",
+      "objective": 4.0,
+      "bound": 4.0,
+      "node_count": 5,
+      "wall": 0.038,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 47,
+      "wall": 1.957,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.055,
+      "sense": "min"
+    },
+    "nvs17": {
+      "instance": "nvs17",
+      "status": "optimal",
+      "objective": -1100.4000000000003,
+      "bound": -1100.4100022118205,
+      "node_count": 173,
+      "wall": 25.914,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1130.495879486534,
+      "node_count": 37,
+      "wall": 50.975,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.164,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.14,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.251,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.166,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.0000020422272,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.513,
+      "sense": "min"
+    },
+    "ex5_3_2": {
+      "instance": "ex5_3_2",
+      "status": "optimal",
+      "objective": 1.864159520848939,
+      "bound": 1.8641594407102666,
+      "node_count": 19,
+      "wall": 4.545,
+      "sense": "min"
+    },
+    "ex7_2_1": {
+      "instance": "ex7_2_1",
+      "status": "feasible",
+      "objective": 1227.22583657496,
+      "bound": 1111.0742602155763,
+      "node_count": 1071,
+      "wall": 40.07,
+      "sense": "min"
+    },
+    "ex4_1_1": {
+      "instance": "ex4_1_1",
+      "status": "optimal",
+      "objective": -7.487312364902362,
+      "bound": -7.4875244284025655,
+      "node_count": 49,
+      "wall": 0.477,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.7651560833301083,
+      "node_count": 29,
+      "wall": 2.486,
+      "sense": "min"
+    },
+    "st_e30": {
+      "instance": "st_e30",
+      "status": "optimal",
+      "objective": -1.5811388234782087,
+      "bound": -1.5811569835482764,
+      "node_count": 53,
+      "wall": 5.99,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/br3-regate-2026-07-10/br3_lu_density_route.json
+++ b/docs/dev/data/br3-regate-2026-07-10/br3_lu_density_route.json
@@ -1,0 +1,261 @@
+{
+  "arm": "lu_density_route",
+  "env": {
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 9.808,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 153,
+      "wall": 8.061,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -58.727590275114444,
+      "node_count": 159,
+      "wall": 40.335,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 1311,
+      "wall": 40.048,
+      "sense": "min"
+    },
+    "ringpack_10_1": {
+      "instance": "ringpack_10_1",
+      "status": "feasible",
+      "objective": -8.692986405129453,
+      "bound": -20.858217677612917,
+      "node_count": 127,
+      "wall": 40.945,
+      "sense": "min"
+    },
+    "kall_circles_c6b": {
+      "instance": "kall_circles_c6b",
+      "status": "feasible",
+      "objective": 2.575063259074003,
+      "bound": -1.000001381788337e-09,
+      "node_count": 31,
+      "wall": 50.168,
+      "sense": "min"
+    },
+    "st_e07": {
+      "instance": "st_e07",
+      "status": "optimal",
+      "objective": -400.0000040538907,
+      "bound": -400.0000040538907,
+      "node_count": 1,
+      "wall": 3.489,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 0.658,
+      "sense": "min"
+    },
+    "nvs19": {
+      "instance": "nvs19",
+      "status": "feasible",
+      "objective": -1098.2,
+      "bound": -1102.8385175019384,
+      "node_count": 163,
+      "wall": 40.048,
+      "sense": "min"
+    },
+    "nvs24": {
+      "instance": "nvs24",
+      "status": "feasible",
+      "objective": -1031.7999999999997,
+      "bound": -1035.6600020723224,
+      "node_count": 7,
+      "wall": 50.967,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668808098541,
+      "node_count": 17,
+      "wall": 1.588,
+      "sense": "min"
+    },
+    "nvs02": {
+      "instance": "nvs02",
+      "status": "optimal",
+      "objective": 5.96418452307,
+      "bound": 5.96418452307,
+      "node_count": 337,
+      "wall": 0.16,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.465,
+      "sense": "min"
+    },
+    "nvs07": {
+      "instance": "nvs07",
+      "status": "optimal",
+      "objective": 4.0,
+      "bound": 4.0,
+      "node_count": 5,
+      "wall": 0.038,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 47,
+      "wall": 1.866,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.053,
+      "sense": "min"
+    },
+    "nvs17": {
+      "instance": "nvs17",
+      "status": "optimal",
+      "objective": -1100.4000000000003,
+      "bound": -1100.4100022118205,
+      "node_count": 173,
+      "wall": 25.326,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1130.495879486534,
+      "node_count": 37,
+      "wall": 49.989,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.151,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.129,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.239,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.157,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.0000020422272,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.489,
+      "sense": "min"
+    },
+    "ex5_3_2": {
+      "instance": "ex5_3_2",
+      "status": "optimal",
+      "objective": 1.864159520848939,
+      "bound": 1.8641594407102666,
+      "node_count": 19,
+      "wall": 4.348,
+      "sense": "min"
+    },
+    "ex7_2_1": {
+      "instance": "ex7_2_1",
+      "status": "feasible",
+      "objective": 1227.22583657496,
+      "bound": 1111.0742602155763,
+      "node_count": 2065,
+      "wall": 40.043,
+      "sense": "min"
+    },
+    "ex4_1_1": {
+      "instance": "ex4_1_1",
+      "status": "optimal",
+      "objective": -7.487312364902362,
+      "bound": -7.4875244284025655,
+      "node_count": 49,
+      "wall": 0.441,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.7651560833301083,
+      "node_count": 29,
+      "wall": 1.86,
+      "sense": "min"
+    },
+    "st_e30": {
+      "instance": "st_e30",
+      "status": "optimal",
+      "objective": -1.5811388234782087,
+      "bound": -1.5811569835482764,
+      "node_count": 53,
+      "wall": 4.854,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/br3-regate-2026-07-10/br3_node_reduce.json
+++ b/docs/dev/data/br3-regate-2026-07-10/br3_node_reduce.json
@@ -1,0 +1,262 @@
+{
+  "arm": "node_reduce",
+  "env": {
+    "DISCOPT_NODE_REDUCE": "1",
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.684782627987372,
+      "node_count": 35,
+      "wall": 1.365,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "feasible",
+      "objective": -246.0,
+      "bound": -304.49999999999994,
+      "node_count": 75,
+      "wall": 4.952,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -54.131208381602605,
+      "node_count": 159,
+      "wall": 40.307,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 1343,
+      "wall": 40.94,
+      "sense": "min"
+    },
+    "ringpack_10_1": {
+      "instance": "ringpack_10_1",
+      "status": "feasible",
+      "objective": -8.692986405129453,
+      "bound": -20.858217677612917,
+      "node_count": 95,
+      "wall": 40.525,
+      "sense": "min"
+    },
+    "kall_circles_c6b": {
+      "instance": "kall_circles_c6b",
+      "status": "feasible",
+      "objective": 2.575063259074003,
+      "bound": -1.000001381788337e-09,
+      "node_count": 31,
+      "wall": 50.347,
+      "sense": "min"
+    },
+    "st_e07": {
+      "instance": "st_e07",
+      "status": "optimal",
+      "objective": -400.0000040538907,
+      "bound": -400.0000040538907,
+      "node_count": 1,
+      "wall": 3.763,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 0.706,
+      "sense": "min"
+    },
+    "nvs19": {
+      "instance": "nvs19",
+      "status": "feasible",
+      "objective": -1098.2,
+      "bound": -1103.0116448138926,
+      "node_count": 137,
+      "wall": 40.043,
+      "sense": "min"
+    },
+    "nvs24": {
+      "instance": "nvs24",
+      "status": "feasible",
+      "objective": -1031.7999999999997,
+      "bound": -1035.6600020723224,
+      "node_count": 7,
+      "wall": 51.608,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668808098536,
+      "node_count": 9,
+      "wall": 1.358,
+      "sense": "min"
+    },
+    "nvs02": {
+      "instance": "nvs02",
+      "status": "optimal",
+      "objective": 5.96418452307,
+      "bound": 5.96418452307,
+      "node_count": 337,
+      "wall": 0.158,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.457,
+      "sense": "min"
+    },
+    "nvs07": {
+      "instance": "nvs07",
+      "status": "optimal",
+      "objective": 4.0,
+      "bound": 4.0,
+      "node_count": 5,
+      "wall": 0.037,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 53,
+      "wall": 1.979,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.052,
+      "sense": "min"
+    },
+    "nvs17": {
+      "instance": "nvs17",
+      "status": "optimal",
+      "objective": -1100.4000000000003,
+      "bound": -1100.4000022018004,
+      "node_count": 193,
+      "wall": 27.134,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1130.495879486534,
+      "node_count": 37,
+      "wall": 50.619,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.226,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.127,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.237,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.152,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.0000020422272,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.471,
+      "sense": "min"
+    },
+    "ex5_3_2": {
+      "instance": "ex5_3_2",
+      "status": "optimal",
+      "objective": 1.864159520848939,
+      "bound": 1.8641594407102666,
+      "node_count": 19,
+      "wall": 4.289,
+      "sense": "min"
+    },
+    "ex7_2_1": {
+      "instance": "ex7_2_1",
+      "status": "feasible",
+      "objective": 1227.22583657496,
+      "bound": 1111.0742602155763,
+      "node_count": 2083,
+      "wall": 40.051,
+      "sense": "min"
+    },
+    "ex4_1_1": {
+      "instance": "ex4_1_1",
+      "status": "optimal",
+      "objective": -7.487312364902362,
+      "bound": -7.487671981669279,
+      "node_count": 39,
+      "wall": 0.425,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.765151210163065,
+      "node_count": 39,
+      "wall": 3.679,
+      "sense": "min"
+    },
+    "st_e30": {
+      "instance": "st_e30",
+      "status": "optimal",
+      "objective": -1.5811387973200657,
+      "bound": -1.5811388336444845,
+      "node_count": 19,
+      "wall": 2.54,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/br3-regate-2026-07-10/br3_obj_branch_priority.json
+++ b/docs/dev/data/br3-regate-2026-07-10/br3_obj_branch_priority.json
@@ -1,0 +1,262 @@
+{
+  "arm": "obj_branch_priority",
+  "env": {
+    "DISCOPT_OBJ_BRANCH_PRIORITY": "1",
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 9.672,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 153,
+      "wall": 7.578,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -58.727590275114444,
+      "node_count": 159,
+      "wall": 40.821,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 1247,
+      "wall": 40.091,
+      "sense": "min"
+    },
+    "ringpack_10_1": {
+      "instance": "ringpack_10_1",
+      "status": "feasible",
+      "objective": -8.692986405129453,
+      "bound": -20.858217677612917,
+      "node_count": 127,
+      "wall": 40.852,
+      "sense": "min"
+    },
+    "kall_circles_c6b": {
+      "instance": "kall_circles_c6b",
+      "status": "feasible",
+      "objective": 2.575063259074003,
+      "bound": -1.000001381788337e-09,
+      "node_count": 31,
+      "wall": 50.208,
+      "sense": "min"
+    },
+    "st_e07": {
+      "instance": "st_e07",
+      "status": "optimal",
+      "objective": -400.0000040538907,
+      "bound": -400.0000040538907,
+      "node_count": 1,
+      "wall": 3.669,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 0.699,
+      "sense": "min"
+    },
+    "nvs19": {
+      "instance": "nvs19",
+      "status": "feasible",
+      "objective": -1098.2,
+      "bound": -1103.6714939498638,
+      "node_count": 147,
+      "wall": 40.162,
+      "sense": "min"
+    },
+    "nvs24": {
+      "instance": "nvs24",
+      "status": "feasible",
+      "objective": -1031.7999999999997,
+      "bound": -1035.6600020723224,
+      "node_count": 7,
+      "wall": 50.789,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668698257443,
+      "node_count": 11,
+      "wall": 1.759,
+      "sense": "min"
+    },
+    "nvs02": {
+      "instance": "nvs02",
+      "status": "optimal",
+      "objective": 5.96418452307,
+      "bound": 5.96418452307,
+      "node_count": 337,
+      "wall": 0.165,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.494,
+      "sense": "min"
+    },
+    "nvs07": {
+      "instance": "nvs07",
+      "status": "optimal",
+      "objective": 4.0,
+      "bound": 4.0,
+      "node_count": 5,
+      "wall": 0.039,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 35,
+      "wall": 1.747,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.056,
+      "sense": "min"
+    },
+    "nvs17": {
+      "instance": "nvs17",
+      "status": "optimal",
+      "objective": -1100.4000000000003,
+      "bound": -1100.4100022118205,
+      "node_count": 151,
+      "wall": 21.821,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1130.495879486534,
+      "node_count": 95,
+      "wall": 40.148,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.158,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.136,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.247,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.16,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.0000020422272,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.496,
+      "sense": "min"
+    },
+    "ex5_3_2": {
+      "instance": "ex5_3_2",
+      "status": "optimal",
+      "objective": 1.864159520848939,
+      "bound": 1.8641594407102666,
+      "node_count": 19,
+      "wall": 4.394,
+      "sense": "min"
+    },
+    "ex7_2_1": {
+      "instance": "ex7_2_1",
+      "status": "feasible",
+      "objective": 1227.22583657496,
+      "bound": 1111.0742602155763,
+      "node_count": 2013,
+      "wall": 40.077,
+      "sense": "min"
+    },
+    "ex4_1_1": {
+      "instance": "ex4_1_1",
+      "status": "optimal",
+      "objective": -7.487312364902362,
+      "bound": -7.4875244284025655,
+      "node_count": 49,
+      "wall": 0.439,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.7651560833301083,
+      "node_count": 29,
+      "wall": 1.833,
+      "sense": "min"
+    },
+    "st_e30": {
+      "instance": "st_e30",
+      "status": "optimal",
+      "objective": -1.5811388234782087,
+      "bound": -1.5811569835482764,
+      "node_count": 53,
+      "wall": 4.789,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/br3-regate-2026-07-10/br3_off.json
+++ b/docs/dev/data/br3-regate-2026-07-10/br3_off.json
@@ -1,0 +1,259 @@
+{
+  "arm": "off",
+  "env": {},
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.68521625604212,
+      "node_count": 195,
+      "wall": 8.956,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -246.0,
+      "bound": -246.01879639837531,
+      "node_count": 153,
+      "wall": 17.23,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -58.65050082502646,
+      "node_count": 191,
+      "wall": 40.453,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 1311,
+      "wall": 40.237,
+      "sense": "min"
+    },
+    "ringpack_10_1": {
+      "instance": "ringpack_10_1",
+      "status": "feasible",
+      "objective": -8.692986405129453,
+      "bound": -20.858217677612917,
+      "node_count": 127,
+      "wall": 41.209,
+      "sense": "min"
+    },
+    "kall_circles_c6b": {
+      "instance": "kall_circles_c6b",
+      "status": "feasible",
+      "objective": 2.575063259074003,
+      "bound": -1.000001381788337e-09,
+      "node_count": 31,
+      "wall": 50.169,
+      "sense": "min"
+    },
+    "st_e07": {
+      "instance": "st_e07",
+      "status": "optimal",
+      "objective": -400.0000040538907,
+      "bound": -400.0000040538907,
+      "node_count": 1,
+      "wall": 2.421,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 1.334,
+      "sense": "min"
+    },
+    "nvs19": {
+      "instance": "nvs19",
+      "status": "feasible",
+      "objective": -1098.2,
+      "bound": -1102.8385175019384,
+      "node_count": 161,
+      "wall": 40.078,
+      "sense": "min"
+    },
+    "nvs24": {
+      "instance": "nvs24",
+      "status": "feasible",
+      "objective": -1031.7999999999997,
+      "bound": -1035.6600020723224,
+      "node_count": 7,
+      "wall": 53.192,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.46966880809854,
+      "node_count": 17,
+      "wall": 2.717,
+      "sense": "min"
+    },
+    "nvs02": {
+      "instance": "nvs02",
+      "status": "optimal",
+      "objective": 5.96418452307,
+      "bound": 5.96418452307,
+      "node_count": 337,
+      "wall": 0.163,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.463,
+      "sense": "min"
+    },
+    "nvs07": {
+      "instance": "nvs07",
+      "status": "optimal",
+      "objective": 4.0,
+      "bound": 4.0,
+      "node_count": 5,
+      "wall": 0.037,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 45,
+      "wall": 1.875,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.054,
+      "sense": "min"
+    },
+    "nvs17": {
+      "instance": "nvs17",
+      "status": "optimal",
+      "objective": -1100.4000000000003,
+      "bound": -1100.4100022118205,
+      "node_count": 173,
+      "wall": 25.175,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1130.495879486534,
+      "node_count": 37,
+      "wall": 41.206,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.152,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.129,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.236,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.152,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.00000204222675,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.508,
+      "sense": "min"
+    },
+    "ex5_3_2": {
+      "instance": "ex5_3_2",
+      "status": "optimal",
+      "objective": 1.864159520848939,
+      "bound": 1.8641594575931957,
+      "node_count": 19,
+      "wall": 3.232,
+      "sense": "min"
+    },
+    "ex7_2_1": {
+      "instance": "ex7_2_1",
+      "status": "feasible",
+      "objective": 1227.2258365749606,
+      "bound": 1111.0742597196686,
+      "node_count": 2065,
+      "wall": 40.074,
+      "sense": "min"
+    },
+    "ex4_1_1": {
+      "instance": "ex4_1_1",
+      "status": "optimal",
+      "objective": -7.487312364902362,
+      "bound": -7.4875244284025655,
+      "node_count": 49,
+      "wall": 0.44,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.764999879276536,
+      "bound": -1.7651560782283298,
+      "node_count": 29,
+      "wall": 2.901,
+      "sense": "min"
+    },
+    "st_e30": {
+      "instance": "st_e30",
+      "status": "optimal",
+      "objective": -1.5811388234321722,
+      "bound": -1.5811569828347167,
+      "node_count": 53,
+      "wall": 4.703,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/br3-regate-2026-07-10/br3_square_cost_gate.json
+++ b/docs/dev/data/br3-regate-2026-07-10/br3_square_cost_gate.json
@@ -1,0 +1,262 @@
+{
+  "arm": "square_cost_gate",
+  "env": {
+    "DISCOPT_SQUARE_COST_GATE": "1",
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 8.941,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 155,
+      "wall": 8.066,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -58.727590275114444,
+      "node_count": 159,
+      "wall": 41.241,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 1343,
+      "wall": 40.714,
+      "sense": "min"
+    },
+    "ringpack_10_1": {
+      "instance": "ringpack_10_1",
+      "status": "feasible",
+      "objective": -8.692986405129453,
+      "bound": -20.858217677613293,
+      "node_count": 77,
+      "wall": 41.441,
+      "sense": "min"
+    },
+    "kall_circles_c6b": {
+      "instance": "kall_circles_c6b",
+      "status": "feasible",
+      "objective": 2.2429209344637493,
+      "bound": -1.0006461531603387e-09,
+      "node_count": 81,
+      "wall": 45.239,
+      "sense": "min"
+    },
+    "st_e07": {
+      "instance": "st_e07",
+      "status": "optimal",
+      "objective": -400.0000040538907,
+      "bound": -400.0000040538907,
+      "node_count": 1,
+      "wall": 3.546,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 0.67,
+      "sense": "min"
+    },
+    "nvs19": {
+      "instance": "nvs19",
+      "status": "feasible",
+      "objective": -1097.6,
+      "bound": -1103.4380115915135,
+      "node_count": 131,
+      "wall": 40.17,
+      "sense": "min"
+    },
+    "nvs24": {
+      "instance": "nvs24",
+      "status": "time_limit",
+      "objective": null,
+      "bound": -430911.1834752736,
+      "node_count": 3,
+      "wall": 41.08,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668808098541,
+      "node_count": 17,
+      "wall": 1.598,
+      "sense": "min"
+    },
+    "nvs02": {
+      "instance": "nvs02",
+      "status": "optimal",
+      "objective": 5.96418452307,
+      "bound": 5.96418452307,
+      "node_count": 337,
+      "wall": 0.162,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.469,
+      "sense": "min"
+    },
+    "nvs07": {
+      "instance": "nvs07",
+      "status": "optimal",
+      "objective": 4.0,
+      "bound": 4.0,
+      "node_count": 5,
+      "wall": 0.037,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2,
+      "node_count": 51,
+      "wall": 1.788,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.052,
+      "sense": "min"
+    },
+    "nvs17": {
+      "instance": "nvs17",
+      "status": "optimal",
+      "objective": -1100.4000000000003,
+      "bound": -1100.410002388686,
+      "node_count": 179,
+      "wall": 19.22,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1130.7000022623997,
+      "node_count": 29,
+      "wall": 40.633,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.154,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.129,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.235,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.171,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.0000020422272,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.494,
+      "sense": "min"
+    },
+    "ex5_3_2": {
+      "instance": "ex5_3_2",
+      "status": "optimal",
+      "objective": 1.864159520848939,
+      "bound": 1.864159457593197,
+      "node_count": 19,
+      "wall": 2.212,
+      "sense": "min"
+    },
+    "ex7_2_1": {
+      "instance": "ex7_2_1",
+      "status": "feasible",
+      "objective": 1227.22583657496,
+      "bound": 1107.6205797955731,
+      "node_count": 2137,
+      "wall": 40.085,
+      "sense": "min"
+    },
+    "ex4_1_1": {
+      "instance": "ex4_1_1",
+      "status": "optimal",
+      "objective": -7.487312364902362,
+      "bound": -7.4875244284025655,
+      "node_count": 49,
+      "wall": 0.456,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "feasible",
+      "objective": -1.764999879276536,
+      "bound": -2.408984803783712,
+      "node_count": 29,
+      "wall": 1.806,
+      "sense": "min"
+    },
+    "st_e30": {
+      "instance": "st_e30",
+      "status": "optimal",
+      "objective": -1.5811388069127532,
+      "bound": -1.5811569835571342,
+      "node_count": 53,
+      "wall": 4.957,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/br3-regate-2026-07-10/liveness.json
+++ b/docs/dev/data/br3-regate-2026-07-10/liveness.json
@@ -1,0 +1,163 @@
+[
+  {
+    "flag": "DISCOPT_LU_DENSITY_ROUTE",
+    "instance": "nvs21",
+    "off": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.68521625604212,
+      "node_count": 195,
+      "wall": 9.984,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 9.709,
+      "sense": "min"
+    },
+    "changed": true
+  },
+  {
+    "flag": "DISCOPT_NODE_REDUCE",
+    "instance": "st_e36",
+    "off": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -246.0,
+      "bound": -246.01879639837531,
+      "node_count": 153,
+      "wall": 17.355,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "st_e36",
+      "status": "feasible",
+      "objective": -245.99999999999997,
+      "bound": -304.49999999999994,
+      "node_count": 75,
+      "wall": 8.97,
+      "sense": "min"
+    },
+    "changed": true
+  },
+  {
+    "flag": "DISCOPT_NODE_REDUCE",
+    "instance": "nvs21",
+    "off": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.68521625604212,
+      "node_count": 195,
+      "wall": 9.984,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.684782627987372,
+      "node_count": 29,
+      "wall": 1.324,
+      "sense": "min"
+    },
+    "changed": true
+  },
+  {
+    "flag": "DISCOPT_SQUARE_COST_GATE",
+    "instance": "nvs19",
+    "off": {
+      "instance": "nvs19",
+      "status": "feasible",
+      "objective": -1098.2,
+      "bound": -1102.8385175019384,
+      "node_count": 161,
+      "wall": 40.103,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs19",
+      "status": "feasible",
+      "objective": -1097.6,
+      "bound": -1103.4380115915135,
+      "node_count": 131,
+      "wall": 40.015,
+      "sense": "min"
+    },
+    "changed": true
+  },
+  {
+    "flag": "DISCOPT_OBJ_BRANCH_PRIORITY",
+    "instance": "nvs01",
+    "off": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.46966880809854,
+      "node_count": 17,
+      "wall": 2.801,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668698257443,
+      "node_count": 11,
+      "wall": 1.77,
+      "sense": "min"
+    },
+    "changed": true
+  },
+  {
+    "flag": "DISCOPT_OBJ_BRANCH_PRIORITY",
+    "instance": "nvs13",
+    "off": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 45,
+      "wall": 1.986,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 35,
+      "wall": 1.781,
+      "sense": "min"
+    },
+    "changed": true
+  },
+  {
+    "flag": "DISCOPT_LIFT_LOOSE_PRODUCTS",
+    "instance": "nvs09",
+    "off": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -58.65050082502646,
+      "node_count": 191,
+      "wall": 40.181,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -47.059466396195894,
+      "node_count": 121,
+      "wall": 41.657,
+      "sense": "min"
+    },
+    "changed": true
+  }
+]


### PR DESCRIPTION
## BR-3 (task #80) — re-gate the nvs21/st_e36-blocked flags post dense-retry

Re-runs the #581 graduation gates for the flags previously blocked by
single-instance certificate losses, now that the **failure-triggered dense LP
retry** (#591 / A-2, task #85, behind `DISCOPT_LU_DENSITY_ROUTE`) is on `main`.
Each ON arm composes the graduating flag **with `DISCOPT_LU_DENSITY_ROUTE=1`** —
the retry is the mechanism hypothesized to cure the cert losses, so the ON config
under test is *flag + route*. The `lu_density_route` arm is the route alone (the
#74 re-run). **This PR flips no defaults and changes no solver math** (docs + gate
data only).

### Method
- Build: `maturin develop --release` from this worktree's crates (`import
  discopt._rust` verified worktree-local); `pounce-solver 0.7`, `JAX_PLATFORMS=cpu`,
  x64; isolated subprocess per solve.
- Panel: 28 instances — blockers (nvs21, st_e36, nvs09, tls2) + tree-opening +
  integer-NLP + QP/MIQP + spatial/bilinear. TL=40s, gap 1e-4, oracle
  `minlplib.solu`.
- Criteria (#581 house pattern): `incorrect_count=0` (zero slack), zero cert
  losses (OFF optimal → ON non-optimal), drift ≤ abs1e-4/rel1e-3, no oracle cross;
  perf = node counts on both-certified instances.
- **Concurrency (§0.7):** decomp1 shared the machine (load ≈ 8). Verdicts rest on
  **deterministic node counts / status**, which reproduced byte-identically across
  two gate runs; wall not used.
- Each flag proven **LIVE** on an engaging instance before measuring (setup step 2).

### Per-flag verdict (all arms: incorrect=0, 0 oracle-cross, 0 drift)

| flag (ON = flag + route) | engaged? | cert-loss | node Δ | verdict |
|---|:-:|---|---|---|
| **lu_density_route** (#74) | yes | **0** — nvs21 optimal→optimal | 1144→1142 | **GRADUATE-ELIGIBLE (1/3)** |
| **obj_branch_priority** | yes | **0** (nvs21 cured) | 1144→**1102** | **GRADUATE-ELIGIBLE (1/3)** |
| **lift_loose_products** (TD-A) | yes | **0** (nvs09 gap tightens) | 1144→1142 | **GRADUATE-ELIGIBLE (1/3)** |
| **node_reduce** | yes | **1: st_e36** (survives route) | 991→**817** | **KEEP-OPT-IN** |
| **square_cost_gate** | yes | **1: alkyl** (square×route composition) | 1115→1125 | **KEEP-OPT-IN** |

### The retry cures nvs21 but NOT the two residual losses (root-caused)
- **node_reduce / st_e36** — loses *with or without* the route (measured):
  reduction-mechanism (node fathoms carrying the loose inherited bound −304.5 vs
  `=opt= −246`), not a sparse-route LP failure. Needs its own entry experiment.
- **square_cost_gate / alkyl** — a **composition** loss that exists *only* with the
  route (deterministic 2/2: square alone optimal, route alone optimal, square+route
  feasible with a loose −2.409 bound on the identical 29-node tree). nvs21 itself is
  now clean under square+route.

Both residual losses are **sound** — correct incumbent, valid loose underestimator,
no oracle cross, `incorrect_count=0` — a lost *certificate*, not a wrong answer, so
they block default-ON per §0.1.

### Graduate-eligible (this run = verdict 1 of 3, T2.6)
`DISCOPT_LU_DENSITY_ROUTE`, `DISCOPT_OBJ_BRANCH_PRIORITY`,
`DISCOPT_LIFT_LOOSE_PRODUCTS` — each needs 2 more independent green verdicts
(different draws/TLs) before a default-ON flip PR.

### Verification
- `pytest -m smoke` → **634 passed, 14 skipped** (worktree release build).
- Adversarial: `pytest -m slow python/tests/test_adversarial_recent_fixes.py` →
  **10 passed**.
- No Rust source changed; no `cargo test` needed. No defaults flipped.

Report: `docs/dev/br3-regate-2026-07-10.md`. Data:
`docs/dev/data/br3-regate-2026-07-10/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
