### PR TITLE
fix(cert): B2-FIX (task #89) — report the strongest rigorous dual bound on tainted trees (per-node taint accounting)

### DIFF
--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -711,6 +711,26 @@ impl TreeManager {
         }
     }
 
+    /// A node's stored `local_lower_bound`, or `None` when the id was never
+    /// allocated in the pool.
+    ///
+    /// Read-only accessor for certification accounting (task #89 / B2-FIX):
+    /// between `export_batch` and `import_results` this is the node's
+    /// *pop-time* bound — the value inherited from its parent's rigorous
+    /// relaxation solve (children are floored at the parent bound on import).
+    /// When a node is later fathomed non-rigorously (failure sentinel with no
+    /// infeasibility proof), this pop-time bound is still a valid lower bound
+    /// for the node's entire subtree, so the driver can keep it as a floor in
+    /// the reported global dual bound instead of discarding the whole tree
+    /// bound.
+    pub fn node_lower_bound(&self, id: NodeId) -> Option<f64> {
+        if id.0 < self.pool.total_count() {
+            Some(self.pool.get(id).local_lower_bound)
+        } else {
+            None
+        }
+    }
+
     /// The warm-start basis stored on a node (cloned), for the Rust-internal
     /// simplex MILP driver. `None` if the node has no inherited basis (root).
     pub fn node_basis(&self, id: NodeId) -> Option<crate::lp::basis::Basis> {

--- a/crates/discopt-python/src/bnb_bindings.rs
+++ b/crates/discopt-python/src/bnb_bindings.rs
@@ -199,6 +199,36 @@ impl PyTreeManager {
         Ok(())
     }
 
+    /// Pop-time `local_lower_bound` for each of `node_ids` (task #89 / B2-FIX).
+    ///
+    /// Read-only. Called between `export_batch` and `import_results`, each
+    /// value is the bound the node carried when it was popped — inherited from
+    /// its parent's rigorous relaxation solve — which remains a valid lower
+    /// bound for that node's whole subtree even if the node is subsequently
+    /// fathomed non-rigorously (failure sentinel without an infeasibility
+    /// proof). Unknown / negative ids map to `-inf` (conservative: a `-inf`
+    /// floor makes the caller discard the tree bound, the pre-fix behavior).
+    fn node_lower_bounds<'py>(
+        &self,
+        py: Python<'py>,
+        node_ids: PyReadonlyArray1<i64>,
+    ) -> Bound<'py, PyArray1<f64>> {
+        let ids = node_ids.as_array();
+        let out: Vec<f64> = ids
+            .iter()
+            .map(|&i| {
+                if i < 0 {
+                    f64::NEG_INFINITY
+                } else {
+                    self.inner
+                        .node_lower_bound(NodeId(i as usize))
+                        .unwrap_or(f64::NEG_INFINITY)
+                }
+            })
+            .collect();
+        PyArray1::from_vec(py, out)
+    }
+
     /// Replace a node's structural variable bounds with reduction-tightened ones
     /// (cert:T2.4c), so its children inherit the contracted box.
     ///

--- a/docs/dev/gap-closing-execution-plan.md
+++ b/docs/dev/gap-closing-execution-plan.md
@@ -348,6 +348,7 @@ adversarial suite. Post the table to the tracking issue; update this §7.
 | F5 | OBBT-on-aux (`cascade_aux`) helps | neutral-to-regressive; nvs22 fails to certify | perf-plan §6 |
 | F6 | **LU condition estimate discriminates failing bases** | populations inverted (fail p50=16; healthy ≤1e16); growth no-signal; mechanism = 3× LP failure rate, not corruption | 2026-07-10, #77 |
 | F7 | gear4 is reducible by cutoff-OBBT/probing | stalls at 2.46M box; not a gate probe | plan §14 |
+| F8 | **The tainted tree "proved" its final frontier bound** (DECOMP-1 §3: nvs05 4.87, tanksize 0.881) | per-node accounting (B2-FIX, task #89): the rigorous bound of a tainted tree is min(frontier, tainted nodes' pop-time bounds); on nvs05 the earliest taint (iteration 2) floors it at **1.3521** and on tanksize at 0.8473 — the frontier value is NOT rigorous once those subtrees were removed unproven. The recoverable headroom is marginal (nvs05 1.3481→1.3521), not 3.6×. The real lever is preventing the unsound removal (bound sentinel-fathomed NLP-failure nodes with the always-valid interval bound so they branch instead — the McCormick-LP path already does this rescue), which is bound-changing and separately gated. | 2026-07-10, #89 |
 
 ## §7 Progress ledger (update per task; falsifications also to perf-plan §6)
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4761,6 +4761,30 @@ def solve_model(
         tree.set_nonconvex(True)
     _gap_certified = True
 
+    # --- B2-FIX (task #89): per-node taint accounting for the reported dual bound.
+    # A non-rigorous sentinel fathom (a node whose local NLP merely failed and that
+    # was pruned with no infeasibility proof) rightly decertifies *optimality*
+    # (issue #27a) — but the node's POP-TIME lower bound (inherited from its
+    # parent's rigorous relaxation solve; the Rust import floors every child at
+    # its parent's bound) remains a valid lower bound for that node's whole
+    # subtree forever. The rigorous global dual bound of a tainted tree is
+    # therefore  min(surviving-frontier bound, min over tainted nodes of their
+    # pop-time bound)  — NOT the bare frontier minimum (which may over-report:
+    # the unproven subtree was removed from it), and NOT nothing (discarding the
+    # whole tree bound under-reports: nvs05 reported 1.348 where the search had
+    # proven 4.87 — DECOMP-1 §3, "decertify-and-discard").
+    #   _taint_floor_internal: running min (internal minimization sense) of the
+    #     pop-time bounds of every node fathomed without a rigorous proof. +inf
+    #     while no such node exists. A -inf floor (root fathomed non-rigorously,
+    #     or a node never bounded) makes the recovery below discard the tree
+    #     bound — exactly the pre-fix conservative behavior.
+    #   _tree_bound_poisoned: True when a possibly-INVALID bound value entered
+    #     the tree itself (convex batch node whose non-KKT objective was kept as
+    #     its bound, roadmap P0.3). Then no frontier arithmetic is trustworthy
+    #     and the tree bound is discarded wholesale, as before.
+    _taint_floor_internal = np.inf
+    _tree_bound_poisoned = False
+
     # --- Soundness (C-1): distinguish a PROVEN-infeasible fathom from a merely
     # non-rigorous one, exactly as ``_solve_nlp_bb`` does with
     # ``_unconverged_fathom``. A node fathomed on an empty McCormick/LP
@@ -6095,8 +6119,13 @@ def solve_model(
             # A convex node whose relaxation objective is not KKT-valid (and
             # could not be polished) is not a valid lower bound; decertify the
             # gap rather than trust it (roadmap P0.3). Bounds are left as-is.
+            # B2-FIX (task #89): the possibly-invalid value stays in result_lbs
+            # and enters the tree as the node's bound, so the frontier minimum
+            # itself is no longer trustworthy — poison the tree bound (full
+            # discard at result build; the taint-floor recovery must not apply).
             if _model_is_convex and not bool(np.all(_batch_trusted)):
                 _gap_certified = False
+                _tree_bound_poisoned = True
             # Constraint feasibility post-check for batch IPM results.
             # When the IPM solution violates constraints (e.g. due to hitting
             # the iteration limit), mark the node as infeasible (SENTINEL).
@@ -6762,10 +6791,33 @@ def solve_model(
         # the authoritative guard and also catches the convex path (whose local NLP
         # objective is a valid bound but whose constraint-violating / failed nodes
         # still get sentinelled with no proof).
+        #
+        # B2-FIX (task #89): every such node also contributes its POP-TIME lower
+        # bound (still stored in the Rust pool — import_results has not run yet
+        # for this batch, so ``node_lower_bounds`` returns the bound the node was
+        # popped with, proved at its parent) to ``_taint_floor_internal``. That
+        # floor keeps the unproven subtree represented in the reported global
+        # dual bound after the sentinel import removes it from the frontier,
+        # instead of discarding the entire tree bound (DECOMP-1
+        # "decertify-and-discard"). Fetched lazily — zero Rust calls on a clean
+        # batch — and read-only, so node processing is byte-identical.
+        _taint_pop_lbs = None
         for i in range(n_batch):
             if result_lbs[i] >= _SENTINEL_THRESHOLD and not node_infeasible_mask[i]:
                 _nonrigorous_fathom = True
-                break
+                if _taint_pop_lbs is None:
+                    _taint_pop_lbs = np.asarray(
+                        tree.node_lower_bounds(np.asarray(result_ids, dtype=np.int64)),
+                        dtype=np.float64,
+                    )
+                _taint_floor_internal = min(_taint_floor_internal, float(_taint_pop_lbs[i]))
+                logger.debug(
+                    "Non-rigorous sentinel fathom at node %d (iteration %d): "
+                    "pop-time bound %.6g kept as a floor of the reported global bound",
+                    int(result_ids[i]),
+                    iteration,
+                    float(_taint_pop_lbs[i]),
+                )
 
         if np.any(node_infeasible_mask):
             for idx in np.flatnonzero(node_infeasible_mask):
@@ -8335,6 +8387,7 @@ def solve_model(
     if status == "feasible":
         _gap_certified = False
 
+    _bound_from_taint_recovery = False
     if not _gap_certified:
         gap_val = None
         # Keep the untainted tree bound on a feasible exit; recompute its gap. Only
@@ -8346,6 +8399,41 @@ def solve_model(
                 gap_val = abs(obj_val - bound_val) / max(1.0, abs(obj_val))
         else:
             bound_val = None
+            # B2-FIX (task #89): decertify-and-discard repair. The tree bound was
+            # decertified, but unless a possibly-invalid bound VALUE entered the
+            # tree (``_tree_bound_poisoned``), every number in the frontier is
+            # still a rigorous per-subtree bound — the only unsound step was
+            # *removing* sentinel-fathomed nodes without proof. Those subtrees
+            # are re-represented by ``_taint_floor_internal`` (the min of their
+            # pop-time bounds, each proved at the node's parent), so
+            #   min(frontier bound, taint floor)
+            # is a rigorous global dual bound: the frontier term covers every
+            # surviving open node, the floor covers every unproven removed
+            # subtree, and rigorously-fathomed regions need no term (their
+            # proofs stand). Report it instead of discarding the search's proof
+            # wholesale (DECOMP-1: nvs05 reported 1.348 where the tree had
+            # proved ~4.87). Stays UNCERTIFIED: the gap is recomputed for
+            # honesty but ``_gap_certified`` remains False and the
+            # re-certification block below is gated off for this bound — a
+            # tainted tree never upgrades to "optimal" via its own recovered
+            # bound (issue #27a's contract), only via an independently rigorous
+            # bound (root pool / root relaxation), exactly as before.
+            # The frontier term must itself be finite: a -inf frontier (e.g. the
+            # Rust tree pinned ``global_lower_bound`` at -inf because a node was
+            # fathomed unresolved WITHOUT passing through the sentinel sweep —
+            # issue #467's ``bound_unresolved``) means an unproven subtree has
+            # no floor entry, so the floor alone would over-report. -inf is then
+            # the honest frontier value and the recovery must stand down.
+            _glb_int = stats["global_lower_bound"]
+            if not _tree_bound_poisoned and _glb_int is not None and np.isfinite(_glb_int):
+                _rig_int = min(_taint_floor_internal, float(_glb_int))
+                if np.isfinite(_rig_int) and abs(_rig_int) < _SENTINEL_THRESHOLD:
+                    bound_val = (
+                        -_rig_int if model._objective.sense == ObjectiveSense.MAXIMIZE else _rig_int
+                    )
+                    _bound_from_taint_recovery = True
+                    if obj_val is not None and np.isfinite(obj_val):
+                        gap_val = abs(obj_val - bound_val) / max(1.0, abs(obj_val))
 
     # Root cut-pool bound: a rigorous global lower bound the strengthened root
     # relaxation already proved during setup (nvs19: -1156 vs the cut-less tree's
@@ -8362,6 +8450,9 @@ def solve_model(
         and (bound_val is None or not np.isfinite(bound_val) or _root_pool_bound > bound_val)
     ):
         bound_val = _root_pool_bound
+        # The pool bound is rigorous independently of the tree's taint, so it
+        # may re-certify below exactly as before (B2-FIX gate does not apply).
+        _bound_from_taint_recovery = False
         if obj_val is not None and np.isfinite(obj_val):
             gap_val = max(0.0, obj_val - bound_val) / max(1.0, abs(obj_val))
 
@@ -8378,15 +8469,21 @@ def solve_model(
     # *upper* bound, surfaced by negating (issue #267: inscribedsquare02, whose
     # objective square is finite only after FBBT bounds the free auxiliaries, used
     # to report ``bound=None`` because no maximize-side fallback existed).
+    # B2-FIX (task #89): a taint-recovered tree bound must not SHORT-CIRCUIT this
+    # fallback — pre-fix, every tainted exit reached it (the tree bound had been
+    # discarded to None) and could report a root-relaxation bound STRONGER than
+    # the taint floor (tanksize: floor 0.847 vs root relaxation 0.868). Run it in
+    # that case too and keep the tighter of the two rigorous bounds.
+    _rr_needed = bound_val is None or not np.isfinite(bound_val) or _bound_from_taint_recovery
     _rr_remaining = time_limit - (time.perf_counter() - t_start)
-    if (bound_val is None or not np.isfinite(bound_val)) and _rr_remaining <= 0.0:
+    if _rr_needed and _rr_remaining <= 0.0:
         # B&B consumed the whole limit and surfaced no bound. Spend a small bounded
         # slice on the rigorous root-relaxation fallback anyway so an uncertified
         # exit reports a sound dual bound instead of None (issue #138). Only ever
         # reached when the search produced nothing usable; the floor's own ~10%
         # internal budget keeps the wall-time overrun small.
         _rr_remaining = _ROOT_FALLBACK_FLOOR_S
-    if (bound_val is None or not np.isfinite(bound_val)) and _rr_remaining > 0.0:
+    if _rr_needed and _rr_remaining > 0.0:
         _is_maximize = model._objective.sense == ObjectiveSense.MAXIMIZE
         # Budget the fallback to the time actually left: it runs *after* the B&B
         # loop already consumed the limit, so passing the full ``time_limit`` here
@@ -8399,7 +8496,17 @@ def solve_model(
             # ``obj``. The relaxation is a valid outer approximation either way, so
             # the surfaced bound is rigorous and on the correct side of the
             # incumbent (a maximize upper bound is ``>= obj``).
-            bound_val = -_rr if _is_maximize else _rr
+            _rr_signed = -_rr if _is_maximize else _rr
+            # Keep the tighter rigorous bound (a MINIMIZE wants the larger lower
+            # bound, a MAXIMIZE the smaller upper bound). When the independently
+            # rigorous fallback wins, the taint-recovery gate lifts (it may
+            # re-certify below, exactly the pre-fix behavior).
+            if bound_val is None or not np.isfinite(bound_val):
+                bound_val = _rr_signed
+                _bound_from_taint_recovery = False
+            elif (_rr_signed <= bound_val) if _is_maximize else (_rr_signed >= bound_val):
+                bound_val = _rr_signed
+                _bound_from_taint_recovery = False
             if obj_val is not None and np.isfinite(obj_val):
                 gap_val = abs(bound_val - obj_val) / max(1.0, abs(obj_val))
 
@@ -8425,6 +8532,12 @@ def solve_model(
         and _bound_on_correct_side
         and gap_val is not None
         and gap_val <= gap_tolerance
+        # B2-FIX (task #89): a bound recovered from a TAINTED tree (frontier
+        # min floored by the tainted nodes' pop-time bounds) is reported but
+        # never re-certifies: #27a's contract is that a non-rigorous fathom
+        # can never upgrade the exit to "optimal". Independently rigorous
+        # bounds (root pool / root relaxation) still re-certify as before.
+        and not _bound_from_taint_recovery
     ):
         _gap_certified = True
         status = "optimal"

--- a/python/tests/test_b2fix_taint_floor_bound.py
+++ b/python/tests/test_b2fix_taint_floor_bound.py
@@ -1,0 +1,113 @@
+"""B2-FIX (task #89): tainted trees report the strongest RIGOROUS dual bound.
+
+DECOMP-1 (docs/dev/certification-effort-decomposition-2026-07-10.md §3, Lever B)
+measured that a single ``_nonrigorous_sentinel_fathom`` taint made the result
+build discard the ENTIRE tree bound and fall back to the much weaker root
+bound (nvs05: reported 1.3481 while the frontier had reached 4.87).
+
+The sound repair is per-node accounting, not taint removal: a node fathomed via
+the failure sentinel *without* an infeasibility proof was removed from the
+frontier unsoundly, but its POP-TIME bound (inherited from its parent's rigorous
+relaxation solve — the Rust import floors every child at the parent bound) is
+still a valid lower bound for its whole subtree. The rigorous global dual bound
+of a tainted tree is therefore::
+
+    min(surviving-frontier bound, min over tainted nodes of pop-time bound)
+
+On nvs05 the earliest taint (node 3, iteration 2) carries pop-time bound
+1.35209, so the honest rigorous bound is ~1.3521 — NOT the 4.87 frontier value
+(that removed subtree was never re-proven; DECOMP-1's "the tree proved 4.8746"
+is falsified by this per-node accounting). The regression under test is that
+the reported bound is exactly this floored value (strictly stronger than the
+pre-fix 1.3481 root fallback), stays on the sound side of the oracle optimum
+5.4709, and the taint still blocks an "optimal" upgrade (issue #27a contract).
+"""
+
+import math
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.solver import PyTreeManager
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+
+_NVS05_OPT = 5.4709  # MINLPLib reference optimum (minimize)
+# Pre-fix reported bound: root-relaxation fallback after the tree bound was
+# discarded wholesale (decertify-and-discard).
+_NVS05_PREFIX_BOUND = 1.3481188467674154
+# Post-fix rigorous bound: the taint floor — the pop-time bound of the earliest
+# non-rigorously fathomed node (node 3, iteration 2), which caps the reported
+# bound for the rest of the run. Deterministic: it derives from the root
+# FBBT/OBBT box and the first two batch iterations, not from the time limit.
+_NVS05_TAINT_FLOOR = 1.3520892806701879
+
+
+@pytest.mark.slow
+def test_nvs05_tainted_tree_reports_rigorous_floored_bound():
+    """nvs05's tainted exit reports the floored rigorous bound, not the weak
+    root fallback (fails before B2-FIX: reported 1.3481 < floor 1.3521)."""
+    m = dm.from_nl(str(_DATA / "nvs05.nl"))
+    # The earliest taint fires by iteration 2 (~4 s in); 20 s leaves margin
+    # without paying the full 60 s DECOMP-1 budget.
+    r = m.solve(time_limit=20)
+
+    assert r.objective is not None and abs(r.objective - _NVS05_OPT) < 1e-2
+    assert r.bound is not None and math.isfinite(r.bound)
+    # Soundness: never report past the oracle optimum (minimize).
+    assert r.bound <= _NVS05_OPT + 1e-3, f"bound {r.bound} crosses the optimum"
+    # Certificate invariant: bound <= incumbent.
+    assert r.bound <= r.objective + 1e-9
+    # The regression: the reported bound must be the rigorous taint-floored
+    # value, strictly stronger than the pre-fix discarded-tree fallback.
+    assert r.bound >= _NVS05_TAINT_FLOOR - 1e-6, (
+        f"reported bound {r.bound} is weaker than the rigorous taint floor "
+        f"{_NVS05_TAINT_FLOOR} (decertify-and-discard regression)"
+    )
+    # ... and it must NEVER exceed what the taint floor allows: the frontier
+    # value (~4.87 at 60 s) is NOT rigorous once a subtree floored at 1.3521
+    # was removed without proof. Reporting materially past the floor would be
+    # a false certificate.
+    assert r.bound <= _NVS05_TAINT_FLOOR + 1e-6, (
+        f"reported bound {r.bound} exceeds the rigorous taint floor "
+        f"{_NVS05_TAINT_FLOOR}: an unsoundly-fathomed subtree's bound was dropped"
+    )
+    # #27a contract: a tainted tree never upgrades to "optimal" via its own
+    # recovered bound.
+    assert r.status != "optimal"
+
+
+@pytest.mark.smoke
+def test_node_lower_bounds_returns_pop_time_bounds():
+    """The Rust tree exposes pop-time node bounds; unknown ids map to -inf."""
+    t = PyTreeManager(2, [0.0, 0.0], [1.0, 1.0], [0], [2], "best_first")
+    t.initialize()
+    lb, ub, ids, _psols = t.export_batch(4)
+    assert len(ids) == 1  # root only
+    pop = np.asarray(t.node_lower_bounds(np.asarray(ids, dtype=np.int64)))
+    # Root has no parent bound: -inf (a -inf floor keeps the conservative
+    # discard behavior in the driver).
+    assert pop[0] == -np.inf
+
+    # Import a finite bound and branch; children inherit >= the parent bound.
+    t.import_results(
+        np.asarray(ids, dtype=np.int64),
+        np.array([3.5]),
+        np.array([[0.5, 0.5]]),
+        np.array([False]),
+    )
+    t.process_evaluated()
+    lb2, ub2, ids2, _ = t.export_batch(4)
+    assert len(ids2) >= 1
+    pop2 = np.asarray(t.node_lower_bounds(np.asarray(ids2, dtype=np.int64)))
+    assert np.all(pop2 >= 3.5 - 1e-12), f"children lost the parent floor: {pop2}"
+
+    # Out-of-range / negative ids are conservative (-inf), never an exception.
+    bad = np.asarray(t.node_lower_bounds(np.array([999, -1], dtype=np.int64)))
+    assert bad[0] == -np.inf and bad[1] == -np.inf


### PR DESCRIPTION
# fix(cert): B2-FIX (task #89) — report the strongest RIGOROUS dual bound on tainted trees (per-node taint accounting, not decertify-and-discard)

## The defect (DECOMP-1 §3, Lever B.2)

On a `_nonrigorous_sentinel_fathom` taint (a node whose local NLP failed and was
sentinel-pruned with **no** infeasibility proof), the result build set
`_tree_bound_valid = False` and discarded the **entire** tree bound, reporting the
far weaker root fallback (nvs05: reported **1.3481**, gap 75%, while the frontier
showed 4.87).

## Root cause (file:line)

- `python/discopt/solver.py` result assembly (`_tree_bound_valid = _gap_certified`
  → `bound_val = None` in the `if not _gap_certified` else-branch): one taint
  event anywhere in the tree discarded every bound the search proved.
- Taint producers (spatial path `solve_model`):
  1. **Non-rigorous sentinel fathom** (batch finalize, serial finalize, and the
     authoritative C-1 sweep): node imported at the failure sentinel without an
     empty-relaxation / `SolveStatus.INFEASIBLE` proof → Rust prunes its subtree
     unproven. On the nvs05/tanksize path (`_mc_lp_relaxer is None`, alphaBB +
     interval bounding) a failed node NLP has **no rescue** — the alphaBB/interval
     blocks skip sentinel nodes — so the node is unsoundly removed. (The
     McCormick-LP path already rescues these nodes with the LP bound.)
  2. **Convex batch untrusted bound** (roadmap P0.3): a non-KKT objective is left
     in `result_lbs` and enters the tree — the frontier *values* themselves are
     suspect.

## Soundness analysis per fathom class

| class | node's own pop-time bound still rigorous for its subtree? | treatment |
|---|---|---|
| sentinel fathom w/o proof (NLP failed/diverged/violating) | **yes** — the pop-time `local_lower_bound` was inherited from the parent's rigorous relaxation solve (Rust import floors every child at the parent bound); a bound over a fixed box stays valid forever | floor it into the reported bound |
| rigorous infeasibility fathom (empty relaxation / FBBT proof) | subtree proven empty | no term needed (unchanged) |
| cutoff fathom vs incumbent (valid LP/alphaBB/interval bound) | rigorous | unchanged |
| deadline-skipped / `-inf` nodes | stay OPEN at inherited bound (no removal) | unchanged (#138) |
| convex untrusted bound kept in `result_lbs` | **no** — the frontier value itself may be invalid | new `_tree_bound_poisoned` flag → full discard (pre-fix behavior) |

The rigorous global dual bound of a tainted (non-poisoned) tree is

```
min( surviving-frontier bound , min over tainted nodes of pop-time bound )
```

frontier term covers every open node; the floor covers every unproven removed
subtree; rigorously-fathomed regions need no term. This is exactly "floor tainted
nodes into the frontier" from DECOMP-1 §3.

## The fix

- **Rust** (`tree_manager.rs`, `bnb_bindings.rs`): read-only
  `PyTreeManager.node_lower_bounds(ids)` — pop-time `local_lower_bound` per node
  (unknown/negative ids → `-inf`, i.e. conservative discard).
- **Python** (`solver.py`, spatial path):
  - `_taint_floor_internal`: running min of tainted nodes' pop-time bounds,
    accumulated in the authoritative C-1 sweep (lazily fetched — zero Rust calls
    on a clean batch; node processing byte-identical).
  - `_tree_bound_poisoned`: set where an untrusted bound VALUE entered the tree
    (convex batch P0.3) → keeps the wholesale discard.
  - Result assembly: where the tainted tree bound was dropped to `None`, report
    `min(frontier, taint_floor)` when finite and non-poisoned, **combined
    (sense-aware max) with the root cut-pool bound and the root-relaxation
    fallback** — the reported bound is never weaker than pre-fix.
  - **Never re-certifies**: a taint-recovered bound is gated out of the
    feasible→optimal upgrade (#27a contract: a non-rigorous fathom can never
    certify optimality). Independently rigorous bounds (root pool / root
    relaxation) still re-certify exactly as before.

## Measured finding — DECOMP-1's headline number is falsified (recorded in gap-closing-execution-plan §6 F8)

Per-node accounting shows the "proved 4.8746" claim was wrong: taint events fire
**throughout** the solve (16 tainted batches in 60 s), and the earliest
(node 3, iteration 2, t≈3.4 s) carries pop-time bound **1.35209** — that subtree
was never re-proven, so no bound above 1.35209 is rigorous. The frontier's 4.87
is exactly the over-report the taint exists to prevent.

| instance | pre-fix reported | post-fix reported (rigorous) | DECOMP-1 projected | oracle |
|---|---|---|---|---|
| nvs05 (TL 60) | 1.3481188 (root fallback) | **1.3520893** (taint floor) | ~4.87 (falsified) | 5.4709 |
| tanksize (TL 60) | 0.8680315 (root-relax fallback) | **0.8680315** (max(floor 0.8473, fallback)) | ~0.881 (falsified) | 1.2686 |

The recoverable headroom on this class is marginal, not 3.6×. The *real* lever is
preventing the unsound removal: bound sentinel-fathomed NLP-failure nodes with the
always-valid interval bound so they **branch** instead of being pruned (the
McCormick-LP path already does this rescue at its `nlp_failed` branch). That is a
bound-changing search modification (node counts change) and needs its own
flag-gated task per §0.4 — follow-on filed in the PR discussion.

## Verification

- **Regression test** `python/tests/test_b2fix_taint_floor_bound.py`:
  - nvs05 (TL 20): reported bound == taint floor 1.3520893 ± 1e-6 (fails pre-fix:
    1.3481 < floor), bound ≤ oracle, bound ≤ incumbent, status never "optimal".
    Verified fail-before / pass-after.
  - smoke test for `node_lower_bounds` semantics (pop-time value, parent-floor
    inheritance, conservative -inf on unknown ids).
- **Cert-neutrality** (`check_cert_neutrality.py`, 41 certifying instances):
  objectives Δ=0 on all 41; node counts identical on 38; the 3 flagged
  (nvs02 101→337, nvs11 39→55, nvs12 195→231) reproduce **byte-identically with
  the fix stashed** (pre-existing baseline drift on origin/main, not this change).
- **Panel sweep** (18 MINLPLib instances, TL 30, oracle = `minlplib.solu`):
  `incorrect_count = 0`; no reported bound crosses the oracle; `bound ≤ incumbent`
  everywhere. Panel: nvs05, nvs09, tanksize, casctanks, st_e36, nvs19, ex6_2_5,
  ex6_2_9, clay0303hfsg, tls2, gear4, nvs17, nvs21, nvs23, nvs24, chance, ex1225,
  ex1226. Side effect of the same repair on untainted-but-uncertified exits:
  nvs24 (time_limit, no incumbent) now reports its rigorous frontier bound
  (−389098, loose but honest and ≤ oracle) instead of discarding it.
- `pytest -m smoke`: 637 passed, 1 skipped (+ the new smoke test).
- Adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`): green.
- `cargo test -p discopt-core`: 433 passed.
- `ruff check` / `ruff format --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
