### PR TITLE
fix(cert): B1-FIX #598 — certify gap-closed MILP solves despite node-LP failures (per-node sound accounting)

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -43,7 +43,9 @@ const CUT_MAX_PARALLEL: f64 = 0.99;
 /// Terminal status of a MILP solve.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MilpStatus {
-    /// Proven optimal (gap closed, no uncertified node bounds).
+    /// Proven optimal: the final frontier gap (which folds in every valid
+    /// inherited bound, including the unresolved-fathom floor; #598) closed
+    /// within tolerance, with no search truncation.
     Optimal,
     /// A feasible incumbent found but optimality not proven (limit / numerical).
     Feasible,
@@ -224,17 +226,33 @@ pub struct MilpOptions {
 /// full solve.
 ///
 /// The C-2 invariant lives here: `Infeasible` is returned **only** on a rigorous
-/// empty-tree proof — `tree_finished && !search_incomplete`. `search_incomplete`
-/// is true whenever a node was deferred un-solved (deadline), which leaves it
-/// popped off the heap and `Evaluated`, invisible to the tree's `open_count()`.
-/// In that case `tree_finished` can read `true` over a subtree that was never
-/// searched, so the honest terminus is a limit status, never a false
+/// empty-tree proof — `tree_finished && !search_incomplete && !tree_unresolved`.
+/// `search_incomplete` is true whenever a node was deferred un-solved (deadline),
+/// which leaves it popped off the heap and `Evaluated`, invisible to the tree's
+/// `open_count()`. `tree_unresolved` is true whenever the tree fathomed a node
+/// without a proof (a failed relaxation with no branch direction left — the
+/// `bound_unresolved` pin of #467 or the `unresolved_floor` of #598): its
+/// subtree was never searched, so an empty tree is not an emptiness proof. In
+/// either case the honest terminus is a limit status, never a false
 /// "infeasible".
+///
+/// `Optimal` requires the final gap to actually be closed (`gap_closed` is
+/// computed from the tree's frontier bound, which already folds in the #598
+/// unresolved floor) with no search truncation (`gap_certified`). A finished
+/// tree does NOT imply a closed gap: an unresolved-floor fathom can drain the
+/// open set while the bound honestly stays below the incumbent, and that must
+/// exit `Feasible`, not `Optimal`. (Conversely, a rigorously drained tree with
+/// an incumbent always collapses the bound to the incumbent — gap 0 — so
+/// dropping the old `tree_finished ||` disjunct loses no true certificate.)
+// Eight orthogonal terminal-state bits; a parameter struct would only obscure
+// the truth table this function IS.
+#[allow(clippy::too_many_arguments)]
 fn decide_status(
     unbounded: bool,
     has_inc: bool,
     tree_finished: bool,
     search_incomplete: bool,
+    tree_unresolved: bool,
     gap_closed: bool,
     gap_certified: bool,
     node_limit_hit: bool,
@@ -242,12 +260,12 @@ fn decide_status(
     if unbounded {
         MilpStatus::Unbounded
     } else if !has_inc {
-        if tree_finished && !search_incomplete {
+        if tree_finished && !search_incomplete && !tree_unresolved {
             MilpStatus::Infeasible
         } else {
             MilpStatus::NodeLimit
         }
-    } else if (tree_finished || gap_closed) && gap_certified {
+    } else if gap_closed && gap_certified {
         MilpStatus::Optimal
     } else if node_limit_hit {
         MilpStatus::NodeLimit
@@ -340,6 +358,12 @@ pub fn solve_milp_hooked(
 
     let mut lp_iters = 0usize;
     let mut unbounded = false;
+    // False once the SEARCH was truncated (deadline deferral, node/time limit,
+    // debugger stop): the driver then reports a limit/feasible status, never
+    // `Optimal`. A node LP *failure* does NOT clear this (#598): the tree keeps
+    // failed nodes soundly accounted (parent-bound floor + branch, or the
+    // permanent `unresolved_floor`), so a closed gap stays a rigorous
+    // certificate — see the IterLimit/Numerical arm of `solve_node`.
     let mut gap_certified = true;
     // C-2: set whenever a node is dropped un-solved (deadline deferral). A
     // deferred node was already popped off the heap and left `Evaluated`, so it
@@ -712,9 +736,10 @@ pub fn solve_milp_hooked(
             if out.deferred {
                 // Deadline hit before this node's LP solve. Skip it entirely: do
                 // not import a result, so the node keeps its parent-inherited
-                // bound. The gap cannot be certified once any node went unsolved,
-                // and the loop-top deadline check breaks the search on the next
-                // iteration.
+                // bound. This is a search TRUNCATION (unlike a node-LP failure,
+                // which stays certifiable — see below), so the gap is not
+                // certified; the loop-top deadline check breaks the search on
+                // the next iteration.
                 //
                 // C-2: the node was popped off the heap by `export_batch` and is
                 // now stuck `Evaluated`, so `open_count()` no longer sees it. If
@@ -731,11 +756,19 @@ pub fn solve_milp_hooked(
                 hit_unbounded = true;
                 break;
             }
-            if out.uncertified {
-                // An untrusted (iter-limit/numerical) node bound: never claim
-                // optimality from this search.
-                gap_certified = false;
-            }
+            // An iter-limit/numerical node LP exit does NOT decertify the gap
+            // (#598). Such a node is handed back with a raw -inf bound and an
+            // untrusted midpoint solution; the tree keeps it SOUND end to end:
+            // `import_results` floors the -inf at the node's parent-inherited
+            // bound (valid over the child box), and `process_evaluated` only
+            // ever (a) prunes it against the incumbent using that valid bound,
+            // (b) branches it — its children re-solve fresh LPs, so the subtree
+            // stays searched and its bounds stay in the frontier minimum — or
+            // (c) when no branch direction remains, fathoms it into the
+            // tree's permanent `unresolved_floor`, which participates in
+            // `tm.gap()`. Every removal is therefore proof-backed or floored,
+            // so a closed gap is a rigorous certificate even after node-LP
+            // failures; withholding `Optimal` here was pure over-conservatism.
             if let Some(basis) = out.basis {
                 tm.set_node_basis(id, Some(basis));
             }
@@ -827,6 +860,10 @@ pub fn solve_milp_hooked(
         has_inc,
         tm.is_finished(),
         search_incomplete,
+        // A subtree was removed without proof (#467 -inf pin or #598 floor):
+        // an empty tree is then not an emptiness proof. The Optimal arm needs
+        // no such flag — the floor already participates in `tm.gap()`.
+        stats.bound_unresolved || stats.unresolved_floor.is_finite(),
         tm.gap() <= opts.gap_tol,
         gap_certified,
         stats.total_nodes >= opts.max_nodes,
@@ -942,8 +979,6 @@ struct NodeOutput {
     iters: usize,
     /// Relaxation was unbounded — the whole search terminates.
     unbounded: bool,
-    /// LP hit iter-limit / numerical breakdown — gap can't be certified.
-    uncertified: bool,
     /// The wall-clock deadline had already passed when this node was dequeued, so
     /// its (expensive) LP solve was skipped entirely. The reduce drops it without
     /// importing a result, leaving the node Evaluated with its parent-inherited
@@ -985,7 +1020,6 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             tightened: None,
             iters: 0,
             unbounded: false,
-            uncertified: true,
             deferred: true,
         };
     }
@@ -1035,7 +1069,6 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
                 tightened: None,
                 iters: 0,
                 unbounded: false,
-                uncertified: false,
                 deferred: false,
             };
         }
@@ -1159,7 +1192,6 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
         tightened,
         iters: sol.iters,
         unbounded: false,
-        uncertified: false,
         deferred: false,
     };
 
@@ -1294,10 +1326,12 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             // before pruning. The safe-bound identity is invariant under
             // equilibration (`scaling.rs`), so the scaled-space verdict equals the
             // original-space one. On verification failure the box is NOT provably
-            // empty: never fathom — hand the node back uncertified (non-pruning
-            // bound, midpoint) so it is branched/re-solved and the optimum can never
-            // be silently cut. A sound infeasible LP always exports a verifiable
-            // ray, so this costs one mat-vec and never changes a correct fathom.
+            // empty: never fathom — hand the node back with a raw -inf (non-pruning)
+            // bound and midpoint so it is branched/re-solved and the optimum can
+            // never be silently cut (same sound handling as the IterLimit /
+            // Numerical arm below). A sound infeasible LP always exports a
+            // verifiable ray, so this costs one mat-vec and never changes a
+            // correct fathom.
             if verify_farkas_infeasible(&sol.dual, ctx.sa, ctx.sb, &sl, &su, ctx.m_w, ctx.n_w) {
                 out.result = NodeResult {
                     node_id: id,
@@ -1306,7 +1340,6 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
                     is_feasible: false,
                 };
             } else {
-                out.uncertified = true;
                 out.result = NodeResult {
                     node_id: id,
                     lower_bound: f64::NEG_INFINITY,
@@ -1319,10 +1352,19 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             out.unbounded = true;
         }
         LpStatus::IterLimit | LpStatus::Numerical => {
-            // Cannot trust a bound: never prune (could drop the optimum). Give a
-            // non-pruning bound and leave the node to be branched; the reduce
-            // marks the gap uncertified so we never claim optimality.
-            out.uncertified = true;
+            // Cannot trust this LP's bound: never prune off it (could drop the
+            // optimum). Hand the node back with a raw -inf (non-pruning) bound
+            // and the box midpoint. This stays fully SOUND without decertifying
+            // the whole search (#598): `import_results` floors the -inf at the
+            // node's parent-inherited bound — a valid bound over this child box,
+            // proved at the ancestor's LP solve — and `process_evaluated` then
+            // only prunes it against the incumbent on that valid bound, branches
+            // it (children re-solve fresh LPs, so the subtree stays searched), or
+            // — when nothing is left to branch — folds the valid bound into the
+            // tree's permanent `unresolved_floor`. The untrusted midpoint can
+            // never fathom the node as integer-feasible or become the incumbent
+            // (`PendingResult::bound_trusted` gates both), so a closed gap
+            // remains a rigorous optimality certificate.
             out.result = NodeResult {
                 node_id: id,
                 lower_bound: f64::NEG_INFINITY,
@@ -2279,7 +2321,7 @@ mod tests {
             /*unbounded=*/ false, /*has_inc=*/ false,
             /*tree_finished=*/ true, // open_count()==0 because the orphan is Evaluated
             /*search_incomplete=*/ true, // a node was deferred un-solved
-            /*gap_closed=*/ false,
+            /*tree_unresolved=*/ false, /*gap_closed=*/ false,
             /*gap_certified=*/ false, // gap is correctly decertified on defer
             /*node_limit_hit=*/ false,
         );
@@ -2298,6 +2340,7 @@ mod tests {
         let status = decide_status(
             /*unbounded=*/ false, /*has_inc=*/ false, /*tree_finished=*/ true,
             /*search_incomplete=*/ false, // no node was ever dropped un-solved
+            /*tree_unresolved=*/ false, // every removal was proof-backed
             /*gap_closed=*/ false, /*gap_certified=*/ true,
             /*node_limit_hit=*/ false,
         );
@@ -2336,10 +2379,60 @@ mod tests {
         // `has_inc==true`, but pin it so a future refactor can't regress it).
         let status = decide_status(
             /*unbounded=*/ false, /*has_inc=*/ true, /*tree_finished=*/ false,
-            /*search_incomplete=*/ true, /*gap_closed=*/ false,
-            /*gap_certified=*/ false, /*node_limit_hit=*/ false,
+            /*search_incomplete=*/ true, /*tree_unresolved=*/ false,
+            /*gap_closed=*/ false, /*gap_certified=*/ false,
+            /*node_limit_hit=*/ false,
         );
         assert_eq!(status, MilpStatus::Feasible);
+    }
+
+    // ---- #598 (B1-FIX): certification semantics of decide_status ----
+
+    #[test]
+    fn b1_gap_closed_certifies_optimal_without_tree_finished() {
+        // The certification criterion is the CLOSED FRONTIER GAP (which folds in
+        // every valid inherited bound and the unresolved floor), not tree
+        // exhaustion: a search that closed the gap mid-tree — even one whose
+        // node LPs failed along the way, since those nodes stay soundly
+        // accounted (parent-bound floor + branch / unresolved_floor) — is a
+        // rigorous optimum.
+        let status = decide_status(
+            /*unbounded=*/ false, /*has_inc=*/ true, /*tree_finished=*/ false,
+            /*search_incomplete=*/ false, /*tree_unresolved=*/ false,
+            /*gap_closed=*/ true, /*gap_certified=*/ true,
+            /*node_limit_hit=*/ false,
+        );
+        assert_eq!(status, MilpStatus::Optimal);
+    }
+
+    #[test]
+    fn b1_finished_tree_with_open_gap_is_feasible_not_optimal() {
+        // A drained tree whose gap did NOT close (an unresolved-floor fathom
+        // kept the honest bound below the incumbent) must exit Feasible. The
+        // pre-fix `(tree_finished || gap_closed)` disjunct would have stamped
+        // this Optimal — a false certificate.
+        let status = decide_status(
+            /*unbounded=*/ false, /*has_inc=*/ true, /*tree_finished=*/ true,
+            /*search_incomplete=*/ false, /*tree_unresolved=*/ true,
+            /*gap_closed=*/ false, /*gap_certified=*/ true,
+            /*node_limit_hit=*/ false,
+        );
+        assert_eq!(status, MilpStatus::Feasible);
+    }
+
+    #[test]
+    fn b1_unresolved_fathom_blocks_false_infeasible() {
+        // No incumbent and the tree drained, but a subtree was removed without
+        // proof (failed relaxation, nothing left to branch): the empty tree is
+        // NOT an emptiness proof — a limit status, never Infeasible.
+        let status = decide_status(
+            /*unbounded=*/ false, /*has_inc=*/ false, /*tree_finished=*/ true,
+            /*search_incomplete=*/ false, /*tree_unresolved=*/ true,
+            /*gap_closed=*/ false, /*gap_certified=*/ true,
+            /*node_limit_hit=*/ false,
+        );
+        assert_ne!(status, MilpStatus::Infeasible);
+        assert_eq!(status, MilpStatus::NodeLimit);
     }
 
     #[test]

--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -70,6 +70,12 @@ pub struct TreeStats {
     /// tree bound is pinned at -inf and the search must NOT be certified optimal
     /// even though `open_nodes == 0` (issue #467).
     pub bound_unresolved: bool,
+    /// Minimum valid inherited bound over subtrees removed without proof (a
+    /// failed-relaxation node with no branch direction left; #598). `+inf` when
+    /// none. Already folded into `global_lower_bound`; exposed so drivers can
+    /// tell "tree drained rigorously" (may certify `Infeasible` on an empty
+    /// tree) from "tree drained with unproven removals" (may not).
+    pub unresolved_floor: f64,
 }
 
 /// Internal buffer for results waiting to be processed.
@@ -78,6 +84,17 @@ struct PendingResult {
     node_id: NodeId,
     solution: Vec<f64>,
     is_feasible: bool,
+    /// Whether the imported result carried its **own** finite relaxation bound
+    /// (recorded from the RAW `NodeResult::lower_bound`, before
+    /// [`TreeManager::import_results`] floors it at the parent-inherited bound).
+    /// `false` means the node's relaxation FAILED (LP iter-limit / numerical
+    /// breakdown, or the orchestrator could not bound it and imported `-inf`):
+    /// the node's `local_lower_bound` is then only the parent's floor — still a
+    /// valid bound for pruning and for the global frontier minimum, but the
+    /// attached `solution` is an untrusted placeholder (e.g. the bound-box
+    /// midpoint) that must never fathom the node as integer-feasible or become
+    /// the incumbent (#598).
+    bound_trusted: bool,
 }
 
 /// Record of a branching decision at a node, used for retroactive
@@ -142,6 +159,19 @@ pub struct TreeManager {
     /// `global_lower_bound = -inf` so `gap() = ∞` and the search reports
     /// feasible/unknown rather than a false optimal (issue #467).
     bound_unresolved: bool,
+    /// Running minimum over the *valid inherited bounds* of nodes that were
+    /// fathomed with an UNTRUSTED result and no branching direction left (#598):
+    /// the node's own relaxation failed (raw import `-inf`, floored at the
+    /// parent's bound by [`Self::import_results`]) and its box had no remaining
+    /// branchable dimension, so its subtree was removed without a proof. Unlike
+    /// the [`Self::bound_unresolved`] case, a finite valid bound for that subtree
+    /// *was* established (at an ancestor), so the honest global dual bound is the
+    /// frontier minimum floored at this value — not a wholesale `-inf` pin.
+    /// `+inf` when no such fathom occurred. Folded into
+    /// [`Self::update_global_lower_bound`]; the gap can then only close (and the
+    /// search only certify) if every such removed subtree is provably within
+    /// tolerance of the incumbent — which is exactly the rigorous criterion.
+    unresolved_floor: f64,
     /// R3a measurement counter (temporary, behavior-neutral): per-variable
     /// branch frequency. Incremented once per branching event (integer or
     /// spatial) with the branched flat column index. Length `n_vars`. Read by
@@ -189,6 +219,7 @@ impl TreeManager {
             spatial_integer_cols,
             branch_deprioritized,
             bound_unresolved: false,
+            unresolved_floor: f64::INFINITY,
             branch_var_counts: vec![0; n_vars],
         }
     }
@@ -314,6 +345,12 @@ impl TreeManager {
                 node_id: r.node_id,
                 solution: r.solution.clone(),
                 is_feasible: r.is_feasible,
+                // Recorded from the RAW imported bound, before the floor above:
+                // a non-finite raw bound means the node's own relaxation failed
+                // and the floored `local_lower_bound` is only the inherited
+                // parent bound (valid for pruning, but the solution is an
+                // untrusted placeholder). See `PendingResult::bound_trusted`.
+                bound_trusted: r.lower_bound.is_finite(),
             }));
     }
 
@@ -359,13 +396,20 @@ impl TreeManager {
             }
 
             // 2. Check if solution is integer-feasible. A node whose LP failed
-            // (iteration limit / numerical) carries a non-finite bound and an
-            // untrusted solution (the bound-box midpoint); it must never be
-            // fathomed or promoted to the incumbent off that point — only
-            // branched, so its subtree is still explored. (The driver already
-            // decertifies the gap for such nodes.) is_integer_feasible(midpoint)
-            // can spuriously be true when bounds are integral, so gate on a
-            // finite, trusted bound first.
+            // (iteration limit / numerical) carries an untrusted solution (the
+            // bound-box midpoint); it must never be fathomed or promoted to the
+            // incumbent off that point — only branched, so its subtree is still
+            // explored. is_integer_feasible(midpoint) can spuriously be true
+            // when bounds are integral, so the fathom/promote arm below gates on
+            // `bound_trusted` — the RAW imported bound was finite, i.e. the
+            // node's own relaxation actually produced this bound and solution.
+            // (`node_lb` alone cannot detect a failed node: import_results
+            // floors the raw `-inf` at the parent-inherited bound, so a failed
+            // node below a solved ancestor carries a finite — valid, but
+            // inherited — bound. Fathoming on it would remove an unexplored
+            // subtree, and promoting it would inject a FALSE incumbent whose
+            // "objective" is the parent's lower bound at an unverified point;
+            // #598.)
             let trusted = node_lb.is_finite();
             let int_feasible = trusted
                 && (result.is_feasible
@@ -380,7 +424,7 @@ impl TreeManager {
                     // incumbent from node_lb here.
                     // Fall through to branching (step 3) to spatially branch
                     // on continuous variables.
-                } else {
+                } else if result.bound_trusted {
                     // Convex mode: NLP local optimum = global optimum for the
                     // continuous subproblem.  Fathom the node.
                     self.pool.get_mut(result.node_id).status = NodeStatus::Fathomed;
@@ -392,6 +436,15 @@ impl TreeManager {
                         stats.incumbent_updates += 1;
                     }
                     continue;
+                } else {
+                    // Failed-relaxation node whose box MIDPOINT happens to be
+                    // integral (typically: branching already fixed every integer
+                    // variable). `node_lb` is the parent's inherited bound, not
+                    // this box's objective, and the midpoint is not verified
+                    // feasible — fathoming/promoting here is the false-incumbent
+                    // path described above. Fall through to branching; if no
+                    // branch direction remains, the no-decision arm below
+                    // fathoms it into `unresolved_floor` (#598).
                 }
             }
 
@@ -610,13 +663,25 @@ impl TreeManager {
                 // trusted (finite-bound) node here IS resolved and stays certifiable.
                 if !trusted {
                     self.bound_unresolved = true;
+                } else if !result.bound_trusted {
+                    // The node's own relaxation FAILED (raw import -inf) but a
+                    // valid finite bound for its box was inherited from an
+                    // ancestor (`import_results` floor), and no branch direction
+                    // remains — its subtree is removed UNPROVEN. Keep the global
+                    // dual bound honest by flooring it permanently at this
+                    // node's valid inherited bound (#598): the gap can then only
+                    // close if this removed subtree is provably within tolerance
+                    // of the incumbent, which keeps a gap-closed exit rigorous
+                    // without pinning the whole tree bound at -inf.
+                    self.unresolved_floor = self.unresolved_floor.min(node_lb);
                 }
                 self.pool.get_mut(result.node_id).status = NodeStatus::Fathomed;
                 stats.fathomed += 1;
-                // Only a trusted (finite-bound, solver-verified) node may become
-                // the incumbent. A failed LP's untrusted bound-box midpoint must
-                // not — it would corrupt the incumbent with a -inf objective.
-                if trusted && node_lb < self.incumbent_value {
+                // Only a node that produced its OWN trusted bound may become the
+                // incumbent. A failed relaxation's untrusted bound-box midpoint
+                // must not — its floored `node_lb` is the parent's lower bound,
+                // not an objective achieved at a verified-feasible point (#598).
+                if result.bound_trusted && trusted && node_lb < self.incumbent_value {
                     self.incumbent_value = node_lb;
                     self.incumbent_solution = Some(result.solution.clone());
                     stats.incumbent_updates += 1;
@@ -641,7 +706,11 @@ impl TreeManager {
             self.global_lower_bound = f64::NEG_INFINITY;
             return;
         }
-        let mut min_lb = f64::INFINITY;
+        // Seed the frontier minimum with the unresolved-fathom floor (#598): a
+        // subtree removed without proof still constrains the global dual bound
+        // at its valid inherited bound, permanently. `+inf` (no such fathom)
+        // leaves the computation unchanged.
+        let mut min_lb = self.unresolved_floor;
         for i in 0..self.pool.total_count() {
             let node = self.pool.get(NodeId(i));
             match node.status {
@@ -708,6 +777,7 @@ impl TreeManager {
             global_lower_bound: self.global_lower_bound,
             gap: self.gap(),
             bound_unresolved: self.bound_unresolved,
+            unresolved_floor: self.unresolved_floor,
         }
     }
 
@@ -1356,5 +1426,208 @@ mod tests {
 
         assert!(tm.is_finished());
         assert!(tm.incumbent().is_some());
+    }
+
+    // ---- #598 (B1-FIX): failed-relaxation results must stay soundly accounted ----
+    //
+    // A node whose relaxation FAILED is imported with a raw -inf bound and an
+    // untrusted placeholder solution (the box midpoint). `import_results` floors
+    // the bound at the parent-inherited value, which is finite below a solved
+    // ancestor — so `node_lb.is_finite()` can NOT detect the failure. Pre-fix,
+    // such a node whose midpoint happened to be integral (e.g. branching had
+    // fixed every integer variable) was fathomed as "integer feasible" in convex
+    // mode and PROMOTED TO THE INCUMBENT at the parent's lower bound — a false
+    // incumbent at an unverified point, and an unproven subtree removal.
+
+    fn two_int_vars() -> Vec<VarBranchInfo> {
+        vec![
+            VarBranchInfo {
+                offset: 0,
+                size: 1,
+                is_integer: true,
+            },
+            VarBranchInfo {
+                offset: 1,
+                size: 1,
+                is_integer: true,
+            },
+        ]
+    }
+
+    /// Box midpoint — exactly what `milp_driver::solve_node` hands back as the
+    /// untrusted placeholder solution on an IterLimit/Numerical LP exit.
+    fn mid(lb: &[f64], ub: &[f64]) -> Vec<f64> {
+        lb.iter().zip(ub).map(|(l, u)| 0.5 * (l + u)).collect()
+    }
+
+    /// Drive the tree so one child of the root solves fine and becomes the
+    /// incumbent (obj 5.0), the other branches; then FAIL one of its children
+    /// (raw -inf import, midpoint solution). Returns the tree post-processing.
+    fn tm_after_grandchild_lp_failure() -> TreeManager {
+        let mut tm = TreeManager::new(
+            2,
+            vec![0.0, 0.0],
+            vec![1.0, 1.0],
+            two_int_vars(),
+            SelectionStrategy::BestFirst,
+        );
+        tm.initialize();
+        // Root: lb=1.0, fractional at var 0 -> branch var 0.
+        let batch = tm.export_batch(1);
+        tm.import_results(&[NodeResult {
+            node_id: batch.node_ids[0],
+            lower_bound: 1.0,
+            solution: vec![0.5, 0.0],
+            is_feasible: false,
+        }]);
+        tm.process_evaluated();
+        // Children c1, c2 (x0 fixed to 0 / 1). c1: good LP, lb=2.0, fractional
+        // at var 1 -> branch var 1 (grandchildren have BOTH integers fixed).
+        // c2: good LP, integral solution, obj 5.0 -> fathom + incumbent.
+        let batch = tm.export_batch(2);
+        assert_eq!(batch.node_ids.len(), 2);
+        tm.import_results(&[
+            NodeResult {
+                node_id: batch.node_ids[0],
+                lower_bound: 2.0,
+                solution: {
+                    let mut s = mid(&batch.lb[0], &batch.ub[0]);
+                    s[1] = 0.5;
+                    s
+                },
+                is_feasible: false,
+            },
+            NodeResult {
+                node_id: batch.node_ids[1],
+                lower_bound: 5.0,
+                solution: batch.lb[1].clone(),
+                is_feasible: true,
+            },
+        ]);
+        tm.process_evaluated();
+        assert_eq!(tm.incumbent().map(|(_, v)| v), Some(5.0));
+        // Grandchildren g1, g2 (every integer variable fixed; inherited lb 2.0).
+        // g1's LP FAILS: raw -inf, box-midpoint solution — which is INTEGRAL
+        // here, the exact spurious-int-feasibility trap. g2 solves fine at 6.0
+        // (>= incumbent -> rigorously pruned).
+        let batch = tm.export_batch(2);
+        assert_eq!(batch.node_ids.len(), 2);
+        tm.import_results(&[
+            NodeResult {
+                node_id: batch.node_ids[0],
+                lower_bound: f64::NEG_INFINITY,
+                solution: mid(&batch.lb[0], &batch.ub[0]),
+                is_feasible: false,
+            },
+            NodeResult {
+                node_id: batch.node_ids[1],
+                lower_bound: 6.0,
+                solution: mid(&batch.lb[1], &batch.ub[1]),
+                is_feasible: false,
+            },
+        ]);
+        tm.process_evaluated();
+        tm
+    }
+
+    #[test]
+    fn failed_node_with_integral_midpoint_never_becomes_incumbent() {
+        // Pre-fix: the failed grandchild's floored bound (2.0, the PARENT's
+        // bound) is finite and its box midpoint is integral, so it was fathomed
+        // as "integer feasible" and PROMOTED to the incumbent (2.0 at an
+        // unverified point), silently replacing the true incumbent 5.0.
+        let tm = tm_after_grandchild_lp_failure();
+        assert_eq!(
+            tm.incumbent().map(|(_, v)| v),
+            Some(5.0),
+            "a failed relaxation's floored parent bound must never become the incumbent"
+        );
+        // The unproven removal is floored into the global bound permanently:
+        // the removed subtree (bounded below by the inherited 2.0) still
+        // constrains it, so the gap honestly stays open.
+        let stats = tm.stats();
+        assert_eq!(stats.unresolved_floor, 2.0);
+        assert_eq!(stats.global_lower_bound, 2.0);
+        assert!(
+            !stats.bound_unresolved,
+            "a finite floor must not -inf-pin the tree"
+        );
+        // The tree has drained (open_nodes == 0) but the gap honestly stays
+        // open: (5.0 - 2.0)/5.0. The driver's `decide_status` refuses both
+        // `Optimal` (gap not closed) and `Infeasible` (tree_unresolved) here.
+        assert!(
+            tm.gap() > 0.5,
+            "gap {} must stay open across an unproven subtree removal",
+            tm.gap()
+        );
+    }
+
+    #[test]
+    fn failed_node_with_fractional_midpoint_is_branched_not_fathomed() {
+        // A failed node whose box still has a branchable integer: it must be
+        // BRANCHED (children re-solve fresh relaxations; subtree stays in the
+        // frontier), never fathomed or promoted.
+        let mut tm = TreeManager::new(
+            2,
+            vec![0.0, 0.0],
+            vec![1.0, 1.0],
+            two_int_vars(),
+            SelectionStrategy::BestFirst,
+        );
+        tm.initialize();
+        let batch = tm.export_batch(1);
+        tm.import_results(&[NodeResult {
+            node_id: batch.node_ids[0],
+            lower_bound: 1.5,
+            solution: vec![0.5, 0.0],
+            is_feasible: false,
+        }]);
+        tm.process_evaluated();
+        // One child's LP fails; its box midpoint is fractional at var 1.
+        let batch = tm.export_batch(1);
+        assert_eq!(batch.node_ids.len(), 1);
+        tm.import_results(&[NodeResult {
+            node_id: batch.node_ids[0],
+            lower_bound: f64::NEG_INFINITY,
+            solution: mid(&batch.lb[0], &batch.ub[0]),
+            is_feasible: false,
+        }]);
+        let stats = tm.process_evaluated();
+        assert_eq!(
+            stats.branched, 1,
+            "failed node must be branched, not fathomed"
+        );
+        assert!(tm.incumbent().is_none());
+        let ts = tm.stats();
+        // No unproven removal happened: the floor stays disengaged and the
+        // frontier (failed node's children at the inherited 1.5 + the sibling)
+        // carries the bound.
+        assert_eq!(ts.unresolved_floor, f64::INFINITY);
+        assert!(ts.open_nodes >= 2, "failed node's children must be open");
+        assert_eq!(ts.global_lower_bound, 1.5);
+    }
+
+    #[test]
+    fn trusted_integral_result_still_fathoms_and_promotes() {
+        // Control: a node that produced its OWN finite bound with an integral
+        // solution still fathoms and becomes the incumbent (unchanged behavior).
+        let mut tm = TreeManager::new(
+            2,
+            vec![0.0, 0.0],
+            vec![1.0, 1.0],
+            simple_integer_vars(),
+            SelectionStrategy::BestFirst,
+        );
+        tm.initialize();
+        let batch = tm.export_batch(1);
+        tm.import_results(&[NodeResult {
+            node_id: batch.node_ids[0],
+            lower_bound: 2.0,
+            solution: vec![1.0, 0.0],
+            is_feasible: true,
+        }]);
+        tm.process_evaluated();
+        assert_eq!(tm.incumbent().map(|(_, v)| v), Some(2.0));
+        assert!(tm.is_finished());
     }
 }

--- a/crates/discopt-python/src/bnb_bindings.rs
+++ b/crates/discopt-python/src/bnb_bindings.rs
@@ -253,7 +253,7 @@ impl PyTreeManager {
     /// Get aggregate tree statistics as a dict.
     ///
     /// Returns {total_nodes, open_nodes, incumbent_value, global_lower_bound,
-    /// gap, bound_unresolved}.
+    /// gap, bound_unresolved, unresolved_floor}.
     fn stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let s = self.inner.stats();
         let dict = PyDict::new(py);
@@ -263,6 +263,7 @@ impl PyTreeManager {
         dict.set_item("global_lower_bound", s.global_lower_bound)?;
         dict.set_item("gap", s.gap)?;
         dict.set_item("bound_unresolved", s.bound_unresolved)?;
+        dict.set_item("unresolved_floor", s.unresolved_floor)?;
         Ok(dict)
     }
 

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -1564,17 +1564,17 @@ class TestAmpPhase4Coverage:
         milp_model, _ = self.build_milp(m, terms, state, incumbent=None)
         result = milp_model.solve()
 
-        # The in-house B&B finds and matches the true relaxation optimum
+        # The in-house B&B finds and CERTIFIES the true relaxation optimum
         # (-26.822045, cross-checked against HiGHS: incumbent == dual bound, gap
-        # closed). It conservatively labels the result "iteration_limit" rather
-        # than "optimal" because one lifted-McCormick node LP took an uncertified
-        # (numerical) exit, which clears ``gap_certified`` in the driver
-        # (milp_driver.rs::decide_status) -- a deliberate SOUNDNESS guard, not a
-        # wrong answer. Assert the property this test's name/docstring actually
-        # promises -- a real, VALID objective bound -- not the label the solver
-        # soundly withholds. Certifying these multi4N node LPs (so the label can
-        # be "optimal") is tracked in issue #598.
-        assert result.status in ("optimal", "iteration_limit")
+        # closed). Regression guard for issue #598: a lifted-McCormick node LP
+        # takes a numerical/iter-limit exit during this search, which used to
+        # clear ``gap_certified`` in the driver and withhold the "optimal" label
+        # (the interim #599 relaxation accepted "iteration_limit" here). Fixed by
+        # per-node sound accounting: a failed node LP keeps its parent-inherited
+        # bound (import floor) and is branched -- its subtree stays in the
+        # frontier minimum -- so the closed gap IS a rigorous certificate and
+        # the driver now labels it "optimal" (milp_driver.rs::decide_status).
+        assert result.status == "optimal"
         assert result.objective is not None
         assert result.objective == pytest.approx(-26.822045, abs=1e-4)
 


### PR DESCRIPTION
# fix(cert): B1-FIX (#598) — certify gap-closed MILP solves despite node-LP failures (per-node sound accounting)

## The defect (issue #598, DECOMP-1 §3 Lever B.1)

The in-house MILP B&B on the AMP multi4N lifted relaxation
(`_make_alpine_multi4n(n=2, exprmode=1)` → `build_milp_relaxation` → `MilpRelaxationModel.solve()`)
**finds and closes the gap** — `obj == bound == -26.82204470195638`, HiGHS-verified true optimum,
gap exactly 0 at 459 nodes / 22,833 pivots — but returns `status='feasible'`
(wrapper: `iteration_limit`) because one lifted-McCormick node LP took an
IterLimit/Numerical exit during the search and the driver cleared `gap_certified`
for the whole solve (`decide_status` demanded `(tree_finished || gap_closed) && gap_certified`).

## The soundness analysis (the whole task — done before touching code)

**Which case holds when a node LP fails?** Traced code path:

1. `milp_driver.rs::solve_node`, `LpStatus::IterLimit | Numerical` arm: the node is
   handed back with **raw `-inf` bound** and the **box midpoint** as a placeholder
   solution (`is_feasible: false`). It is *not* removed.
2. `tree_manager.rs::import_results` (the floor): `node.local_lower_bound =
   result.lower_bound.max(node.local_lower_bound)` — the `-inf` is floored at the
   **parent-inherited bound**, which is a valid lower bound over the child box
   (proved at the ancestor's LP solve; a bound over a fixed box stays valid forever).
3. `tree_manager.rs::process_evaluated`: the failed node is either **pruned against
   the incumbent using that valid floored bound** (a sound cutoff fathom), or
   **branched** — its children re-solve fresh LPs, so the subtree stays searched.
4. `update_global_lower_bound`: every open/Evaluated node's `local_lower_bound`
   (own LP bound or inherited floor) participates in the frontier minimum, capped
   at the incumbent.

So **case (a) holds on the main path**: the failed node REMAINS in the tree carrying
its parent-inherited valid bound; `best_bound` includes it; when
`incumbent − best_bound ≤ tol` the gap **is** rigorously closed, and clearing
`gap_certified` was pure over-conservatism. This is also exactly the task's
preferred structural fix ("keep the node OPEN with its inherited bound and branch
it") — already the tree's behavior; only the certification accounting refused to
admit it.

**But the audit found a case-(b) leak** (and a live false-incumbent bug): the guard
that was supposed to keep a failed node from being fathomed off its placeholder
solution was `trusted = node_lb.is_finite()` (`process_evaluated` step 2, with a
comment asserting "a node whose LP failed carries a non-finite bound"). The
`import_results` floor **defeats that gate** — below any solved ancestor the failed
node's floored bound is finite. Consequence: a failed node whose box **midpoint is
integral** (typically: branching had already fixed every integer variable) was
fathomed as "integer feasible" in convex mode and **promoted to the incumbent at
the parent's lower bound** — a false incumbent at an unverified point (wrong value
*and* unverified feasibility), plus an unproven subtree removal. The same defeated
gate guarded the no-branch-direction arm's incumbent promotion.

## The fix (per-node accounting, #603's rigor)

`crates/discopt-core/src/bnb/tree_manager.rs`:
- `PendingResult.bound_trusted`: recorded from the **raw** imported bound (before
  the floor). Untrusted results can never int-feasible-fathom or become the
  incumbent — they are branched; when no branch direction remains they are fathomed
  into a new permanent **`unresolved_floor`** (running min of the valid inherited
  bounds of unproven removals), which **seeds the frontier minimum** in
  `update_global_lower_bound`. The gap can then only close if every removed subtree
  is provably within tolerance of the incumbent — exactly the rigorous criterion —
  without the wholesale `-inf` pin of #467 (which is preserved for the
  no-valid-bound-at-all case).
- Pruning vs the incumbent still uses the floored bound (valid); routing on the
  nonconvex/spatial path is **untouched** (that path's taint accounting is #603,
  Python-side).

`crates/discopt-core/src/bnb/milp_driver.rs`:
- The reduce no longer clears `gap_certified` on an uncertified node result;
  `gap_certified` now means "no search truncation" (deadline deferral, node/time
  limit, debugger stop — all still clear it).
- `decide_status`: `Optimal` requires **`gap_closed && gap_certified`** (the final
  `tm.gap() ≤ gap_tol`, whose bound already folds in the unresolved floor). The old
  `tree_finished ||` disjunct is dropped: a drained tree with a floor-held open gap
  must exit `Feasible` (pre-fix that disjunct would have stamped it `Optimal`); a
  rigorously drained tree always collapses the bound to the incumbent (gap 0), so
  no true certificate is lost. `Infeasible` additionally requires no unproven
  removal (`bound_unresolved || unresolved_floor.is_finite()`) — an empty tree with
  an unproven removal is not an emptiness proof (closes a latent false-Infeasible
  corner: a root-LP failure with an all-fixed integer box).
- **Never flips feasible→optimal without proof**: certification is granted only by
  the closed frontier gap, every term of which is a proved bound.

`crates/discopt-python/src/bnb_bindings.rs`: expose `unresolved_floor` in
`PyTreeManager.stats()` (additive).

`python/tests/test_amp_integration.py`: revert the #599 interim relaxation — the
multi4N test asserts `result.status == "optimal"` again (kept the
`pytest.approx(-26.822045)` bound assertion; comment now documents the fix).

**On the #591 dense retry** (task checklist): `solve_milp`'s node LPs *do* route
through the failure-triggered dense retry hook (`solve_lp_warm_scaled_csc` →
`dense_retry_wanted`, primal.rs/dual.rs), but it is `DISCOPT_LU_DENSITY_ROUTE`-gated
(default off) and #598 measured it does **not** rescue this failure mode
(`LpDenseRetries = 0` on this instance). No new retry wired: the structural
keep-open-and-branch path is already taken and is now certifiable.

## Before / after on the multi4n repro (fails-before/passes-after gate)

| | baseline (origin/main) | this branch |
|---|---|---|
| status | `iteration_limit` | **`optimal`** |
| objective | -26.82204470195638 | -26.82204470195638 (byte-equal) |
| bound | -26.82204470195638 | -26.82204470195638 (byte-equal) |
| NodeLpSolve | 459 | 459 (byte-identical search) |
| Phase1+Phase2 pivots | 21,471 + 1,362 | identical |

The search itself is untouched on this instance — the fix is label-only here
(certification accounting, not node processing).

## Gates run

- **Regression test**: `test_alpine_multi4n_milp_relaxation_solves_with_objective_bound`
  **fails on the baseline wheel, passes on the fix wheel** (verified both ways in the
  same env).
- **Cert-neutrality (41-instance certifying panel, ≥18 required)**: ran
  `check_cert_neutrality.py` with the **baseline wheel and the fix wheel in the same
  environment**: all 41 rows (status, node_count, |Δobj|) **byte-identical between
  the two wheels**. The 3 violations the script reports vs the *committed*
  `cert-baseline.jsonl` (nvs02 101→337, nvs11 39→55, nvs12 195→231; also
  unflagged improvements nvs13 49→45, nvs14 325→223) **reproduce identically on
  untouched origin/main** — they pre-exist this PR (stale committed baseline or
  environment sensitivity on the nvs spatial family) and are not caused by it.
  `incorrect_count = 0`: every panel objective matches the baseline (worst |Δobj|
  4.4e-11 on nvs14, within tolerance), all 41 report `optimal`, no bound crosses
  the oracle.
- `cargo test -p discopt-core`: **444 passed, 0 failed** (6 new tests: 3
  tree-manager — false-incumbent guard, branch-not-fathom, trusted-control; 3
  `decide_status` — gap-closed certifies, floor-held gap refuses Optimal,
  unresolved fathom blocks false Infeasible). `cargo clippy -p discopt-core`
  clean with and without default features; rustfmt clean.
- `pytest -m smoke`: **634 passed, 14 skipped**.
- Adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`):
  **10 passed**.
- MILP backend slices (`test_amp_milp_backend_failure_recovery`,
  `test_amp_simplex_backend`, `test_debug_rust_milp`, `test_differentiable_milp`):
  **23 passed**.
- AMP integration suite (`test_amp_integration.py -m "slow or integration or
  amp_benchmark or requires_cyipopt or memory_heavy"`): **176 passed, 11 skipped,
  1 xfailed, 3 xpassed** (the 3 xpasses are pre-existing `strict=False`
  environment-dependent probes documented as stable on macOS — not this change).
- Concurrency note: the AMP-STABILIZE agent shared this machine; all gate verdicts
  above use deterministic metrics (status/node counts/objectives), not wall clock.

## Efficiency follow-on (report-only, NOT addressed here)

The engine still burns **459 nodes / 22,833 pivots** where HiGHS closes this MILP
in **19 nodes, one call** (~24× node ratio). Fresh profile on this branch:
`DualDegeneratePivots = 18,511` (**81%** of dual pivots), `RefacCap = 443`
refactor-cap trips over 761 warm solves, `DualColdFallbacks = 23`,
`LpDenseRetries = 0`. The inefficiency localizes to degeneracy handling + FT-update
churn on partitioned/lifted formulations — that is the remaining (efficiency) half
of #598 and is deliberately out of scope for this certification fix.

Closes the certification defect of #598; the node-count/degeneracy efficiency work
tracked there remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
