### PR TITLE
ci(amp): isolate slow tan/abs certification tests to a fresh-process step (#90, #606)

### DIFF
--- a/.github/workflows/amp-integration.yml
+++ b/.github/workflows/amp-integration.yml
@@ -46,29 +46,37 @@ jobs:
         run: |
           source .venv/bin/activate
           python -c "import cyipopt"
-      - name: Run opt-in AMP integration suite
+      # The AMP suite is split into two steps because two distinct failure modes
+      # share one root cause: the in-house MILP B&B is pathologically slow on the
+      # tan/abs cert instances (~24x nodes / 81% degenerate pivots vs HiGHS,
+      # tracked in #606), and JAX/XLA reserves address space that the per-test
+      # jax.clear_caches() fixture cannot return to the OS (only process death
+      # does). Packed into one long-lived worker, later tests run under
+      # accumulated XLA pressure that thrashes that already-slow B&B — a tan/abs
+      # cert that finishes in ~seconds in a fresh interpreter blew past the 300s
+      # harness timeout on the Linux runner (run 29126190059). So:
+      #
+      # STEP 1 (bulk, 186 tests): pytest-xdist -n 2 --dist=load. Spreading tests
+      # across worker processes bounds per-process XLA accumulation to ~1/N so no
+      # single interpreter degrades. -n 2 (not "auto") caps aggregate memory well
+      # under the 16 GB runner; --dist=load (not loadscope) spreads individual
+      # tests — the suite has no class/module/session-scoped fixtures, so per-test
+      # distribution is safe, whereas loadscope would keep a whole heavy class on
+      # one worker and re-accumulate. --forked (true per-test isolation) is NOT
+      # usable: it INTERNALERRORs with pytest-timeout when a test runs to the
+      # timeout, whereas xdist coordinates timeouts correctly.
+      #
+      # STEP 2 (cert, 4 tests, @pytest.mark.amp_cert_heavy): run SINGLE-PROCESS in
+      # a fresh interpreter with a generous --timeout=900. A fresh process has no
+      # accumulated XLA state, so the slow B&B runs at true speed (seconds, not
+      # 300s+). These stay real gating tests (unweakened assertions:
+      # status==optimal, gap_certified). This is deterministic — a fresh process
+      # removes the accumulation mechanism entirely, it does not merely widen a
+      # timeout budget and hope.
+      - name: Run AMP integration suite — bulk (xdist, process-distributed)
         run: |
           source .venv/bin/activate
-          # Distribute the ~190 tests across worker processes with pytest-xdist
-          # (--dist=load). Root cause of the historical CI flakiness: run
-          # single-process, the suite accumulates XLA address-space reservations
-          # across hundreds of JAX compilations, and later certification-sensitive
-          # tests (tan/abs nlp_004 gap certs, etc.) intermittently degrade to a
-          # feasible-not-optimal verdict or trip an XLA std::bad_alloc abort. The
-          # per-test jax.clear_caches() fixture reclaims compile caches but NOT the
-          # process's reserved address space, which only dies with the process.
-          # Splitting the run across N worker processes bounds per-process
-          # accumulation to ~1/N of the solves, so no single interpreter degrades.
-          # -n 2 is deliberate (not "auto"): each worker holds a full JAX/XLA
-          # runtime, so worker count is capped to keep aggregate memory well under
-          # the 16 GB runner. --dist=load spreads individual tests (the suite has
-          # no class/module/session-scoped fixtures, so per-test distribution is
-          # safe); loadscope would keep the 96-test heavy class on one worker and
-          # defeat the purpose. --forked (true per-test isolation) is NOT usable
-          # here: it deadlocks/INTERNALERRORs with pytest-timeout when a test runs
-          # to the timeout (the nlp3 xfail probe does), whereas xdist coordinates
-          # timeouts correctly.
-          scripts/run_memory_capped_pytest.sh pytest python/tests/test_amp_integration.py -v --timeout=300 -n 2 --dist=load -m "slow or integration or amp_benchmark or requires_cyipopt or memory_heavy"
+          scripts/run_memory_capped_pytest.sh pytest python/tests/test_amp_integration.py -v --timeout=300 -n 2 --dist=load -m "(slow or integration or amp_benchmark or requires_cyipopt or memory_heavy) and not amp_cert_heavy"
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
@@ -76,6 +84,15 @@ jobs:
           # address-space regions, so a virtual-memory cap produces flaky
           # std::bad_alloc aborts (exit 134) unrelated to real RAM use. The
           # runner's kernel OOM-killer remains the safety net against a genuine
-          # resident-memory runaway; per-worker distribution above is the primary
-          # guard against address-space accumulation.
+          # resident-memory runaway; per-worker distribution is the primary guard
+          # against address-space accumulation.
+          PYTEST_MEMORY_LIMIT_MB: "0"
+      - name: Run AMP integration suite — heavy certification tests (isolated)
+        if: always()
+        run: |
+          source .venv/bin/activate
+          scripts/run_memory_capped_pytest.sh pytest python/tests/test_amp_integration.py -v --timeout=900 -p no:cacheprovider -m "(slow or integration or amp_benchmark or requires_cyipopt or memory_heavy) and amp_cert_heavy"
+        env:
+          JAX_PLATFORMS: cpu
+          JAX_ENABLE_X64: "1"
           PYTEST_MEMORY_LIMIT_MB: "0"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -62,6 +62,14 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "relaxation: per-operator relaxation soundness/coverage audit"
     )
+    config.addinivalue_line(
+        "markers",
+        "amp_cert_heavy: AMP end-to-end certification tests whose in-house MILP "
+        "B&B is pathologically slow (#606) and thrashes under accumulated XLA "
+        "memory when packed into a shared multi-solve worker; the CI workflow "
+        "runs these in a separate single-process step (fresh interpreter, no "
+        "accumulation) so they execute at true speed as real gating tests",
+    )
 
 
 def _cyipopt_available() -> bool:

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -1788,6 +1788,7 @@ class TestAmpEndToEnd:
         assert abs(result.objective - MULTI2_OPTIMUM) <= 1e-3
 
     @pytest.mark.slow
+    @pytest.mark.amp_cert_heavy
     @pytest.mark.timeout(300)
     @pytest.mark.xfail(
         reason="nlp3 MILP exceeds test budget; tracked in #24",
@@ -2909,6 +2910,7 @@ class TestCurrentCodeWeaknesses:
         tol = 1e-6 + 1e-4 * abs(instance.expected_obj)
         assert abs(result.objective - instance.expected_obj) <= tol
 
+    @pytest.mark.amp_cert_heavy
     def test_amp_certifies_tan_abs_nlp_004_010_at_issue_gap(self):
         """The continuous tan/abs nlp_004 case should certify the issue-89 gap."""
         instance = MINLPTESTS_NLP_BY_ID["nlp_004_010"]
@@ -3114,6 +3116,7 @@ class TestCurrentCodeWeaknesses:
         tol = 1e-6 + 1e-4 * abs(instance.expected_obj)
         assert abs(result.objective - instance.expected_obj) <= tol
 
+    @pytest.mark.amp_cert_heavy
     @pytest.mark.parametrize("problem_id", ["nlp_mi_004_010", "nlp_mi_004_011"])
     def test_amp_certifies_tan_abs_integer_nlp_004_cases_at_issue_gap(self, problem_id):
         """The mixed-integer tan/abs nlp_004 cases should certify the issue-79 gap."""


### PR DESCRIPTION
## Task #90 (AMP-STABILIZE), part 2: isolate the slow tan/abs cert tests

Follow-up to #607. The `xdist -n 2` fix stopped the `std::bad_alloc` aborts, but the **post-merge run on main revealed a second failure mode with the same root cause** (run 29126190059):

```
[gw1] FAILED test_amp_certifies_tan_abs_nlp_004_010_at_issue_gap - Failed: Timeout (>300.0s)
[gw1] FAILED test_amp_certifies_tan_abs_integer_nlp_004_cases_at_issue_gap[nlp_mi_004_011] - Failed: Timeout (>300.0s)
= 2 failed, 185 passed, 1 xfailed, 2 xpassed in 865.69s =
```

My prior "green on macOS, no capability gap" conclusion **was wrong** and is retracted: macOS can't impose the runner's address-space cap and has more RAM, so it never saw the thrash.

### Root cause (the real one)

The in-house MILP B&B is **pathologically slow** on these tan/abs instances (~24x nodes / 81% degenerate pivots vs HiGHS — tracked in **#606**). Packed into a long-lived xdist worker, later tests run under accumulated XLA address-space pressure (which `jax.clear_caches()` cannot return to the OS — only process death does) that thrashes that already-slow B&B. A cert that finishes in **~5.5s in a fresh interpreter** blew past the 300s harness timeout on Linux.

### Fix — Option A (isolation; keeps them as real gating tests)

New marker `@pytest.mark.amp_cert_heavy` on the **4 at-risk** end-to-end cert tests, registered in `conftest.py`:

| test | why marked |
|------|-----------|
| `test_amp_certifies_tan_abs_nlp_004_010_at_issue_gap` | timed out on Linux |
| `test_amp_certifies_tan_abs_integer_nlp_004_cases_at_issue_gap[nlp_mi_004_010]` | sibling param, same instance family |
| `test_amp_certifies_tan_abs_integer_nlp_004_cases_at_issue_gap[nlp_mi_004_011]` | timed out on Linux |
| `test_nlp3_multilinear_global_optimum` | internal `time_limit=300` == harness timeout; latent same-mechanism hard-timeout risk |

Enumerated by grepping the suite for every `_at_issue_gap` / `certifies` test **and** every solve with `time_limit>=300` that could race the harness timeout — **no third one is left to fail next week**. (Checked and cleared: `time_limit_respected` (3s), `alpine_multi2` (30s/8 iters), `max_iter_respected` (bounded by max_iter=3) — none can hard-timeout.)

The workflow now runs **two steps**:
- **STEP 1 (bulk, 186 tests):** `xdist -n 2 --dist=load` with `... and not amp_cert_heavy`
- **STEP 2 (cert, 4 tests):** **single-process fresh interpreter**, `--timeout=900`, `... and amp_cert_heavy`, `if: always()`

Coverage is identical (186 + 4 = 190). **No assertion weakened** — the cert tests keep `status == "optimal"` + `gap_certified is True`.

### Why this holds on Linux (reasoned from the mechanism, NOT "green on macOS")

A fresh process has **zero accumulated XLA state**, so the slow B&B runs at its true speed. This removes the accumulation mechanism *entirely* rather than merely widening a timeout and hoping. Measured on this branch, fresh single process:

- the 3 tan/abs certs run in **5.58 / 5.49 / 5.41 s** — vs the >300s they hit under accumulation — 3 passed in 16.8s. **Repeated 4×, all green.**
- Bulk step (186 tests, xdist -n2): **184 passed, 2 xpassed, 0 failed** (317s).

`pytest -m smoke`: **643 passed, 9 skipped, 0 failed**. `ruff check` / `ruff format --check` / `actionlint`: clean.

### Not fixed here (by design)

The underlying reason these tests need isolation — the slow B&B — stays tracked in **#606**. This PR is the durable CI stabilization; #606 is the real perf fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
