### PR TITLE
docs(flag-grad): verdicts 2&3 — none graduate; density route regresses nvs22 (#602)

### DIFF
--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/gate.py
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/gate.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+"""Flag-graduation verdicts 2 & 3 driver (follow-on to BR-3 #602).
+
+Same house pattern as BR-3's gate.py: shared OFF baseline + per-flag ON arms,
+each ON arm composes the flag with DISCOPT_LU_DENSITY_ROUTE=1 (the #591 dense
+retry). Sequential solves, isolated subprocess per solve (fresh interpreter
+reads env flags at import). Resumable via jsonl.
+
+Usage: gate.py <verdict:v2|v3> [arm1,arm2,...]
+"""
+import json, os, subprocess, sys, time
+
+SP = os.path.dirname(os.path.abspath(__file__))
+PY = "/Users/jkitchin/projects/discopt/.claude/worktrees/agent-a045b99cdfea826ff/.venv-grad/bin/python"
+
+# Verdict 2: BR-3 panel, DIFFERENT draw. Blockers kept (nvs21/st_e36/nvs09/alkyl).
+# TL=40s.
+PANEL_V2 = [
+    # blockers
+    "nvs21", "st_e36", "nvs09", "alkyl", "tls2",
+    # integer NLP (fresh)
+    "nvs03", "nvs05", "nvs08", "nvs10", "nvs11", "nvs12", "nvs16", "nvs18",
+    # QP / MIQP (fresh)
+    "st_miqp1", "st_miqp4", "st_miqp5", "st_test2", "st_testgr1",
+    # spatial / bilinear (fresh)
+    "ex5_2_2_case2", "ex5_2_4", "ex7_2_2", "ex4_1_2", "ex4_1_8", "ex8_1_1", "st_bpaf1a",
+    # tree-opening (fresh)
+    "st_e29", "st_e31", "gbd",
+]
+
+# Verdict 3: LARGER (35) and LONGER (TL=60s). Blockers kept.
+PANEL_V3 = [
+    # blockers
+    "nvs21", "st_e36", "nvs09", "alkyl", "tls2",
+    # integer NLP
+    "nvs14", "nvs20", "nvs22", "nvs01", "nvs04", "nvs06", "nvs13", "nvs15", "nvs23",
+    # QP / MIQP
+    "st_miqp2", "st_miqp3", "st_miqp5", "st_test2", "meanvarx", "alan",
+    # spatial / bilinear
+    "ex5_2_2_case1", "ex5_2_4", "ex7_2_2", "ex7_2_3", "ex4_1_3", "ex4_1_8",
+    "ex4_1_9", "ex8_1_1", "ex8_1_6", "st_bpaf1a", "st_bpaf1b",
+    # tree / misc
+    "st_e29", "st_e31", "gbd", "gkocis",
+]
+
+PANELS = {"v2": (PANEL_V2, 40.0), "v3": (PANEL_V3, 60.0)}
+
+ARMS = {
+    "off": {},
+    "lu_density_route": {"DISCOPT_LU_DENSITY_ROUTE": "1"},
+    "obj_branch_priority": {"DISCOPT_OBJ_BRANCH_PRIORITY": "1", "DISCOPT_LU_DENSITY_ROUTE": "1"},
+    "lift_loose_products": {"DISCOPT_LIFT_LOOSE_PRODUCTS": "1", "DISCOPT_LU_DENSITY_ROUTE": "1"},
+}
+
+
+def run(inst, env_extra, tl):
+    env = dict(os.environ)
+    env["JAX_PLATFORMS"] = "cpu"
+    env["JAX_ENABLE_X64"] = "1"
+    env.update(env_extra)
+    try:
+        cp = subprocess.run(
+            [PY, os.path.join(SP, "solve_one.py"), inst, str(tl)],
+            capture_output=True, text=True, timeout=tl + 180, env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return {"instance": inst, "status": "OUTER_TIMEOUT"}
+    for ln in cp.stdout.splitlines():
+        if ln.startswith("RESULT "):
+            return json.loads(ln[7:])
+    return {"instance": inst, "status": "NO_RESULT", "stderr": cp.stderr[-300:]}
+
+
+def main():
+    verdict = sys.argv[1]
+    panel, tl = PANELS[verdict]
+    jsonl = os.path.join(SP, f"{verdict}_results.jsonl")
+    arms = sys.argv[2].split(",") if len(sys.argv) > 2 else list(ARMS)
+
+    done = {}
+    if os.path.exists(jsonl):
+        with open(jsonl) as f:
+            for ln in f:
+                try:
+                    d = json.loads(ln)
+                except json.JSONDecodeError:
+                    continue
+                done[(d["arm"], d["result"]["instance"])] = d["result"]
+
+    for arm in arms:
+        env_extra = ARMS[arm]
+        out = {}
+        for inst in panel:
+            if (arm, inst) in done:
+                out[inst] = done[(arm, inst)]
+                print(f"SKIP {arm} {inst} (cached)", flush=True)
+                continue
+            t0 = time.time()
+            r = run(inst, env_extra, tl)
+            out[inst] = r
+            with open(jsonl, "a") as f:
+                f.write(json.dumps({"arm": arm, "result": r}) + "\n")
+            print(f"[{time.time()-t0:6.1f}s] {verdict} {arm:20} {inst:16} "
+                  f"{str(r.get('status')):>12} obj={r.get('objective')} "
+                  f"bnd={r.get('bound')} n={r.get('node_count')} w={r.get('wall')}", flush=True)
+        with open(os.path.join(SP, f"{verdict}_{arm}.json"), "w") as f:
+            json.dump({"arm": arm, "env": env_extra, "tl": tl, "results": out}, f, indent=2)
+        print(f"WROTE {verdict}_{arm}.json", flush=True)
+    print(f"{verdict} ALL_ARMS_DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/liveness.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/liveness.json
@@ -1,0 +1,94 @@
+[
+  {
+    "flag": "DISCOPT_LU_DENSITY_ROUTE",
+    "instance": "nvs21",
+    "off": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.68521625604212,
+      "node_count": 195,
+      "wall": 9.255,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 10.439,
+      "sense": "min"
+    },
+    "changed": true
+  },
+  {
+    "flag": "DISCOPT_OBJ_BRANCH_PRIORITY",
+    "instance": "nvs01",
+    "off": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.46966880809854,
+      "node_count": 17,
+      "wall": 2.781,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668698257443,
+      "node_count": 11,
+      "wall": 1.753,
+      "sense": "min"
+    },
+    "changed": true
+  },
+  {
+    "flag": "DISCOPT_OBJ_BRANCH_PRIORITY",
+    "instance": "nvs13",
+    "off": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 45,
+      "wall": 1.988,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 35,
+      "wall": 1.793,
+      "sense": "min"
+    },
+    "changed": true
+  },
+  {
+    "flag": "DISCOPT_LIFT_LOOSE_PRODUCTS",
+    "instance": "nvs09",
+    "off": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -58.65050082502646,
+      "node_count": 191,
+      "wall": 40.407,
+      "sense": "min"
+    },
+    "on": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -47.059466396195894,
+      "node_count": 121,
+      "wall": 40.246,
+      "sense": "min"
+    },
+    "changed": true
+  }
+]

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/liveness.py
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/liveness.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""Flag-graduation verdicts 2&3 setup step 2: verify each flag is LIVE in THIS build.
+
+For each (flag, probe) pair, solve OFF then ON (flag alone) in isolated
+subprocesses and report node/bound/status deltas. A flag that changes nothing on
+its engaging instance => wrong build/panel => STOP.
+"""
+import json, os, subprocess, sys, time
+
+SP = os.path.dirname(os.path.abspath(__file__))
+PY = "/Users/jkitchin/projects/discopt/.claude/worktrees/agent-a045b99cdfea826ff/.venv-grad/bin/python"
+
+PROBES = [
+    ("DISCOPT_LU_DENSITY_ROUTE", "nvs21"),
+    ("DISCOPT_OBJ_BRANCH_PRIORITY", "nvs01"),
+    ("DISCOPT_OBJ_BRANCH_PRIORITY", "nvs13"),
+    ("DISCOPT_LIFT_LOOSE_PRODUCTS", "nvs09"),
+]
+TL = 40.0
+
+
+def run(inst, env_extra):
+    env = dict(os.environ)
+    env["JAX_PLATFORMS"] = "cpu"
+    env["JAX_ENABLE_X64"] = "1"
+    env.update(env_extra)
+    try:
+        cp = subprocess.run(
+            [PY, os.path.join(SP, "solve_one.py"), inst, str(TL)],
+            capture_output=True, text=True, timeout=TL + 120, env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return {"instance": inst, "status": "OUTER_TIMEOUT"}
+    for ln in cp.stdout.splitlines():
+        if ln.startswith("RESULT "):
+            return json.loads(ln[7:])
+    return {"instance": inst, "status": "NO_RESULT", "stderr": cp.stderr[-300:]}
+
+
+def main():
+    cache_off = {}
+    rows = []
+    for flag, inst in PROBES:
+        if inst not in cache_off:
+            t0 = time.time()
+            cache_off[inst] = run(inst, {})
+            r = cache_off[inst]
+            print(f"[{time.time()-t0:6.1f}s] OFF {inst:12} {r.get('status'):>10} "
+                  f"obj={r.get('objective')} bnd={r.get('bound')} n={r.get('node_count')}", flush=True)
+        t0 = time.time()
+        ron = run(inst, {flag: "1"})
+        roff = cache_off[inst]
+        changed = (ron.get("node_count") != roff.get("node_count")
+                   or ron.get("bound") != roff.get("bound")
+                   or ron.get("status") != roff.get("status"))
+        print(f"[{time.time()-t0:6.1f}s] ON  {inst:12} {ron.get('status'):>10} "
+              f"obj={ron.get('objective')} bnd={ron.get('bound')} n={ron.get('node_count')} "
+              f"flag={flag} LIVE={changed}", flush=True)
+        rows.append({"flag": flag, "instance": inst, "off": roff, "on": ron, "changed": changed})
+    with open(os.path.join(SP, "liveness.json"), "w") as f:
+        json.dump(rows, f, indent=2)
+    print("WROTE liveness.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/nvs22_rootcause.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/nvs22_rootcause.json
@@ -1,0 +1,42 @@
+{
+  "instance": "nvs22",
+  "finding": "DISCOPT_LU_DENSITY_ROUTE introduces an nvs22 certificate loss, NOT TL-sensitive",
+  "off": {
+    "TL40": {
+      "status": "optimal",
+      "node_count": 35,
+      "bound": 6.058219998999999,
+      "objective": 6.058219942618264
+    },
+    "TL60": {
+      "status": "optimal",
+      "node_count": 35,
+      "bound": 6.058219998999999,
+      "objective": 6.058219942618264
+    }
+  },
+  "route_only": {
+    "TL40": {
+      "status": "feasible",
+      "node_count": 37,
+      "bound": 6.0582199951512,
+      "objective": 6.0582199356118025
+    },
+    "TL60": {
+      "status": "feasible",
+      "node_count": 37,
+      "bound": 6.0582199951512,
+      "objective": 6.0582199356118025
+    }
+  },
+  "obj_branch_priority_plus_route": {
+    "TL60": {
+      "status": "feasible",
+      "node_count": 17,
+      "bound": 6.058219999999996,
+      "objective": 6.05821993806505
+    }
+  },
+  "oracle": 6.05822,
+  "note": "Both OFF and route are numerically correct to oracle (gap ~6e-8, within abs 1e-4). The route's 37-node tree never formally closes the gap (bound 6.0582199951512 vs incumbent 6.0582199356118, rel gap ~9.8e-9); OFF's 35-node tree does. Deterministic across TL=40 and TL=60 (byte-identical), so the loss is a hard cert loss, not a slower-certify."
+}

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/solve_one.py
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/solve_one.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""Solve ONE instance in an isolated process; print a RESULT json line.
+Env flags are read fresh at import (subprocess), so the parent sets e.g.
+DISCOPT_NODE_REDUCE=1 before invoking this."""
+import json, os, sys, time
+
+CORPUS = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+
+
+def main():
+    inst = sys.argv[1]
+    tl = float(sys.argv[2])
+    try:
+        from discopt.modeling.core import from_nl
+        m = from_nl(os.path.join(CORPUS, inst + ".nl"))
+        sense = "min"
+        try:
+            s = m._objective.sense
+            sense = "min" if str(s).lower().endswith("minimize") else "max"
+        except Exception:
+            pass
+        t = time.time()
+        r = m.solve(time_limit=tl, gap_tolerance=1e-4)
+        wall = time.time() - t
+        obj = getattr(r, "objective", None)
+        bnd = getattr(r, "bound", None)
+        out = {
+            "instance": inst,
+            "status": str(r.status),
+            "objective": None if obj is None else float(obj),
+            "bound": None if bnd is None else float(bnd),
+            "node_count": int(getattr(r, "node_count", -1) or -1),
+            "wall": round(wall, 3),
+            "sense": sense,
+        }
+    except Exception as e:
+        out = {"instance": inst, "status": "ERROR", "error": repr(e)[:400]}
+    print("RESULT " + json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v2_lift_loose_products.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v2_lift_loose_products.json
@@ -1,0 +1,262 @@
+{
+  "arm": "lift_loose_products",
+  "env": {
+    "DISCOPT_LIFT_LOOSE_PRODUCTS": "1",
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 9.733,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 153,
+      "wall": 7.999,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -45.780390825137985,
+      "node_count": 117,
+      "wall": 41.377,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.7651560833301083,
+      "node_count": 29,
+      "wall": 1.897,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 1375,
+      "wall": 40.038,
+      "sense": "min"
+    },
+    "nvs03": {
+      "instance": "nvs03",
+      "status": "optimal",
+      "objective": 16.0,
+      "bound": 15.99999972676511,
+      "node_count": 5,
+      "wall": 0.427,
+      "sense": "min"
+    },
+    "nvs05": {
+      "instance": "nvs05",
+      "status": "feasible",
+      "objective": 5.47093412640568,
+      "bound": 1.3520892806701879,
+      "node_count": 643,
+      "wall": 40.105,
+      "sense": "min"
+    },
+    "nvs08": {
+      "instance": "nvs08",
+      "status": "optimal",
+      "objective": 23.449727353351044,
+      "bound": 23.449382312131643,
+      "node_count": 57,
+      "wall": 0.938,
+      "sense": "min"
+    },
+    "nvs10": {
+      "instance": "nvs10",
+      "status": "optimal",
+      "objective": -310.7999999999999,
+      "bound": -310.7999999999999,
+      "node_count": 5,
+      "wall": 0.08,
+      "sense": "min"
+    },
+    "nvs11": {
+      "instance": "nvs11",
+      "status": "optimal",
+      "objective": -430.99999999999966,
+      "bound": -430.99999999999966,
+      "node_count": 55,
+      "wall": 0.444,
+      "sense": "min"
+    },
+    "nvs12": {
+      "instance": "nvs12",
+      "status": "optimal",
+      "objective": -481.20000000000005,
+      "bound": -481.20000000000005,
+      "node_count": 231,
+      "wall": 1.422,
+      "sense": "min"
+    },
+    "nvs16": {
+      "instance": "nvs16",
+      "status": "optimal",
+      "objective": 0.703125,
+      "bound": 0.7031248950084752,
+      "node_count": 7,
+      "wall": 0.75,
+      "sense": "min"
+    },
+    "nvs18": {
+      "instance": "nvs18",
+      "status": "optimal",
+      "objective": -778.4,
+      "bound": -778.4000015578,
+      "node_count": 105,
+      "wall": 6.546,
+      "sense": "min"
+    },
+    "st_miqp1": {
+      "instance": "st_miqp1",
+      "status": "optimal",
+      "objective": 280.9999999906497,
+      "bound": 280.9999999906497,
+      "node_count": 15,
+      "wall": 0.148,
+      "sense": "min"
+    },
+    "st_miqp4": {
+      "instance": "st_miqp4",
+      "status": "optimal",
+      "objective": -4574.000004423649,
+      "bound": -4574.000004423649,
+      "node_count": 3,
+      "wall": 0.137,
+      "sense": "min"
+    },
+    "st_miqp5": {
+      "instance": "st_miqp5",
+      "status": "optimal",
+      "objective": -333.8888902488547,
+      "bound": -333.8888902488547,
+      "node_count": 1,
+      "wall": 0.139,
+      "sense": "min"
+    },
+    "st_test2": {
+      "instance": "st_test2",
+      "status": "optimal",
+      "objective": -9.25,
+      "bound": -9.25,
+      "node_count": 5,
+      "wall": 0.132,
+      "sense": "min"
+    },
+    "st_testgr1": {
+      "instance": "st_testgr1",
+      "status": "optimal",
+      "objective": -12.811600000000002,
+      "bound": -12.811600000000002,
+      "node_count": 105,
+      "wall": 0.154,
+      "sense": "min"
+    },
+    "ex5_2_2_case2": {
+      "instance": "ex5_2_2_case2",
+      "status": "feasible",
+      "objective": -600.000006187781,
+      "bound": -1151.8851934692605,
+      "node_count": 3,
+      "wall": 0.625,
+      "sense": "min"
+    },
+    "ex5_2_4": {
+      "instance": "ex5_2_4",
+      "status": "optimal",
+      "objective": -450.0000011369069,
+      "bound": -450.00000209765136,
+      "node_count": 3,
+      "wall": 0.444,
+      "sense": "min"
+    },
+    "ex7_2_2": {
+      "instance": "ex7_2_2",
+      "status": "feasible",
+      "objective": -0.38881143010195207,
+      "bound": -0.39749234462710814,
+      "node_count": 75,
+      "wall": 5.79,
+      "sense": "min"
+    },
+    "ex4_1_2": {
+      "instance": "ex4_1_2",
+      "status": "optimal",
+      "objective": -663.5000966105001,
+      "bound": -663.5000966114999,
+      "node_count": 3,
+      "wall": 0.552,
+      "sense": "min"
+    },
+    "ex4_1_8": {
+      "instance": "ex4_1_8",
+      "status": "optimal",
+      "objective": -16.73889318443983,
+      "bound": -16.740521631557268,
+      "node_count": 7,
+      "wall": 0.366,
+      "sense": "min"
+    },
+    "ex8_1_1": {
+      "instance": "ex8_1_1",
+      "status": "optimal",
+      "objective": -2.021806795967722,
+      "bound": -2.021968747474246,
+      "node_count": 5,
+      "wall": 0.411,
+      "sense": "min"
+    },
+    "st_bpaf1a": {
+      "instance": "st_bpaf1a",
+      "status": "optimal",
+      "objective": -45.37971091253482,
+      "bound": -45.37971142671955,
+      "node_count": 5,
+      "wall": 0.497,
+      "sense": "min"
+    },
+    "st_e29": {
+      "instance": "st_e29",
+      "status": "optimal",
+      "objective": -0.9434704910762214,
+      "bound": -0.9435072710855771,
+      "node_count": 53,
+      "wall": 2.158,
+      "sense": "min"
+    },
+    "st_e31": {
+      "instance": "st_e31",
+      "status": "feasible",
+      "objective": -2.000000008986581,
+      "bound": -3.0,
+      "node_count": 609,
+      "wall": 40.64,
+      "sense": "min"
+    },
+    "gbd": {
+      "instance": "gbd",
+      "status": "optimal",
+      "objective": 2.199999982504936,
+      "bound": 2.199999982504936,
+      "node_count": 3,
+      "wall": 0.149,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v2_lu_density_route.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v2_lu_density_route.json
@@ -1,0 +1,261 @@
+{
+  "arm": "lu_density_route",
+  "env": {
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 10.28,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 153,
+      "wall": 7.659,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -58.727590275114444,
+      "node_count": 159,
+      "wall": 40.228,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.7651560833301083,
+      "node_count": 29,
+      "wall": 1.889,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 1215,
+      "wall": 40.35,
+      "sense": "min"
+    },
+    "nvs03": {
+      "instance": "nvs03",
+      "status": "optimal",
+      "objective": 16.0,
+      "bound": 15.99999972676511,
+      "node_count": 5,
+      "wall": 0.363,
+      "sense": "min"
+    },
+    "nvs05": {
+      "instance": "nvs05",
+      "status": "feasible",
+      "objective": 5.47093412640568,
+      "bound": 1.3520892806701879,
+      "node_count": 625,
+      "wall": 40.165,
+      "sense": "min"
+    },
+    "nvs08": {
+      "instance": "nvs08",
+      "status": "optimal",
+      "objective": 23.449727353351044,
+      "bound": 23.449382312131643,
+      "node_count": 57,
+      "wall": 0.872,
+      "sense": "min"
+    },
+    "nvs10": {
+      "instance": "nvs10",
+      "status": "optimal",
+      "objective": -310.7999999999999,
+      "bound": -310.7999999999999,
+      "node_count": 5,
+      "wall": 0.08,
+      "sense": "min"
+    },
+    "nvs11": {
+      "instance": "nvs11",
+      "status": "optimal",
+      "objective": -430.99999999999966,
+      "bound": -430.99999999999966,
+      "node_count": 55,
+      "wall": 0.438,
+      "sense": "min"
+    },
+    "nvs12": {
+      "instance": "nvs12",
+      "status": "optimal",
+      "objective": -481.20000000000005,
+      "bound": -481.20000000000005,
+      "node_count": 231,
+      "wall": 1.414,
+      "sense": "min"
+    },
+    "nvs16": {
+      "instance": "nvs16",
+      "status": "optimal",
+      "objective": 0.703125,
+      "bound": 0.7031248950084752,
+      "node_count": 7,
+      "wall": 0.767,
+      "sense": "min"
+    },
+    "nvs18": {
+      "instance": "nvs18",
+      "status": "optimal",
+      "objective": -778.4,
+      "bound": -778.4000015578,
+      "node_count": 105,
+      "wall": 6.476,
+      "sense": "min"
+    },
+    "st_miqp1": {
+      "instance": "st_miqp1",
+      "status": "optimal",
+      "objective": 280.9999999906497,
+      "bound": 280.9999999906497,
+      "node_count": 15,
+      "wall": 0.133,
+      "sense": "min"
+    },
+    "st_miqp4": {
+      "instance": "st_miqp4",
+      "status": "optimal",
+      "objective": -4574.000004423649,
+      "bound": -4574.000004423649,
+      "node_count": 3,
+      "wall": 0.137,
+      "sense": "min"
+    },
+    "st_miqp5": {
+      "instance": "st_miqp5",
+      "status": "optimal",
+      "objective": -333.8888902488547,
+      "bound": -333.8888902488547,
+      "node_count": 1,
+      "wall": 0.136,
+      "sense": "min"
+    },
+    "st_test2": {
+      "instance": "st_test2",
+      "status": "optimal",
+      "objective": -9.25,
+      "bound": -9.25,
+      "node_count": 5,
+      "wall": 0.133,
+      "sense": "min"
+    },
+    "st_testgr1": {
+      "instance": "st_testgr1",
+      "status": "optimal",
+      "objective": -12.811600000000002,
+      "bound": -12.811600000000002,
+      "node_count": 105,
+      "wall": 0.154,
+      "sense": "min"
+    },
+    "ex5_2_2_case2": {
+      "instance": "ex5_2_2_case2",
+      "status": "feasible",
+      "objective": -600.000006187781,
+      "bound": -1151.8851934692605,
+      "node_count": 3,
+      "wall": 0.6,
+      "sense": "min"
+    },
+    "ex5_2_4": {
+      "instance": "ex5_2_4",
+      "status": "optimal",
+      "objective": -450.0000011369069,
+      "bound": -450.00000209765136,
+      "node_count": 3,
+      "wall": 0.435,
+      "sense": "min"
+    },
+    "ex7_2_2": {
+      "instance": "ex7_2_2",
+      "status": "feasible",
+      "objective": -0.38881143010195207,
+      "bound": -0.39749234462710814,
+      "node_count": 75,
+      "wall": 5.736,
+      "sense": "min"
+    },
+    "ex4_1_2": {
+      "instance": "ex4_1_2",
+      "status": "optimal",
+      "objective": -663.5000966105001,
+      "bound": -663.5000966114999,
+      "node_count": 3,
+      "wall": 0.521,
+      "sense": "min"
+    },
+    "ex4_1_8": {
+      "instance": "ex4_1_8",
+      "status": "optimal",
+      "objective": -16.73889318443983,
+      "bound": -16.740521631557268,
+      "node_count": 7,
+      "wall": 0.358,
+      "sense": "min"
+    },
+    "ex8_1_1": {
+      "instance": "ex8_1_1",
+      "status": "optimal",
+      "objective": -2.021806795967722,
+      "bound": -2.021968747474246,
+      "node_count": 5,
+      "wall": 0.397,
+      "sense": "min"
+    },
+    "st_bpaf1a": {
+      "instance": "st_bpaf1a",
+      "status": "optimal",
+      "objective": -45.37971091253482,
+      "bound": -45.37971142671955,
+      "node_count": 5,
+      "wall": 0.487,
+      "sense": "min"
+    },
+    "st_e29": {
+      "instance": "st_e29",
+      "status": "optimal",
+      "objective": -0.9434704910762214,
+      "bound": -0.9435072710855771,
+      "node_count": 53,
+      "wall": 2.163,
+      "sense": "min"
+    },
+    "st_e31": {
+      "instance": "st_e31",
+      "status": "feasible",
+      "objective": -2.000000008986581,
+      "bound": -3.0,
+      "node_count": 577,
+      "wall": 40.555,
+      "sense": "min"
+    },
+    "gbd": {
+      "instance": "gbd",
+      "status": "optimal",
+      "objective": 2.199999982504936,
+      "bound": 2.199999982504936,
+      "node_count": 3,
+      "wall": 0.134,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v2_obj_branch_priority.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v2_obj_branch_priority.json
@@ -1,0 +1,262 @@
+{
+  "arm": "obj_branch_priority",
+  "env": {
+    "DISCOPT_OBJ_BRANCH_PRIORITY": "1",
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 11.019,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 153,
+      "wall": 7.991,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -58.727590275114444,
+      "node_count": 159,
+      "wall": 41.572,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.7651560833301083,
+      "node_count": 29,
+      "wall": 2.393,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 447,
+      "wall": 40.208,
+      "sense": "min"
+    },
+    "nvs03": {
+      "instance": "nvs03",
+      "status": "optimal",
+      "objective": 16.0,
+      "bound": 15.99999972676511,
+      "node_count": 5,
+      "wall": 0.41,
+      "sense": "min"
+    },
+    "nvs05": {
+      "instance": "nvs05",
+      "status": "feasible",
+      "objective": 5.47093412640568,
+      "bound": 1.3520892806701879,
+      "node_count": 583,
+      "wall": 40.154,
+      "sense": "min"
+    },
+    "nvs08": {
+      "instance": "nvs08",
+      "status": "optimal",
+      "objective": 23.449727353351044,
+      "bound": 23.449382312131643,
+      "node_count": 57,
+      "wall": 0.94,
+      "sense": "min"
+    },
+    "nvs10": {
+      "instance": "nvs10",
+      "status": "optimal",
+      "objective": -310.7999999999999,
+      "bound": -310.7999999999999,
+      "node_count": 5,
+      "wall": 0.082,
+      "sense": "min"
+    },
+    "nvs11": {
+      "instance": "nvs11",
+      "status": "optimal",
+      "objective": -430.99999999999966,
+      "bound": -430.99999999999966,
+      "node_count": 55,
+      "wall": 0.451,
+      "sense": "min"
+    },
+    "nvs12": {
+      "instance": "nvs12",
+      "status": "optimal",
+      "objective": -481.20000000000005,
+      "bound": -481.20000000000005,
+      "node_count": 231,
+      "wall": 1.432,
+      "sense": "min"
+    },
+    "nvs16": {
+      "instance": "nvs16",
+      "status": "optimal",
+      "objective": 0.703125,
+      "bound": 0.7031248950084752,
+      "node_count": 7,
+      "wall": 0.794,
+      "sense": "min"
+    },
+    "nvs18": {
+      "instance": "nvs18",
+      "status": "optimal",
+      "objective": -778.4,
+      "bound": -778.4000011455533,
+      "node_count": 97,
+      "wall": 6.481,
+      "sense": "min"
+    },
+    "st_miqp1": {
+      "instance": "st_miqp1",
+      "status": "optimal",
+      "objective": 280.9999999906497,
+      "bound": 280.9999999906497,
+      "node_count": 15,
+      "wall": 0.147,
+      "sense": "min"
+    },
+    "st_miqp4": {
+      "instance": "st_miqp4",
+      "status": "optimal",
+      "objective": -4574.000004423649,
+      "bound": -4574.000004423649,
+      "node_count": 3,
+      "wall": 0.143,
+      "sense": "min"
+    },
+    "st_miqp5": {
+      "instance": "st_miqp5",
+      "status": "optimal",
+      "objective": -333.8888902488547,
+      "bound": -333.8888902488547,
+      "node_count": 1,
+      "wall": 0.143,
+      "sense": "min"
+    },
+    "st_test2": {
+      "instance": "st_test2",
+      "status": "optimal",
+      "objective": -9.25,
+      "bound": -9.25,
+      "node_count": 5,
+      "wall": 0.138,
+      "sense": "min"
+    },
+    "st_testgr1": {
+      "instance": "st_testgr1",
+      "status": "optimal",
+      "objective": -12.811600000000002,
+      "bound": -12.811600000000002,
+      "node_count": 105,
+      "wall": 0.158,
+      "sense": "min"
+    },
+    "ex5_2_2_case2": {
+      "instance": "ex5_2_2_case2",
+      "status": "feasible",
+      "objective": -600.000006187781,
+      "bound": -1151.8851934692605,
+      "node_count": 3,
+      "wall": 0.646,
+      "sense": "min"
+    },
+    "ex5_2_4": {
+      "instance": "ex5_2_4",
+      "status": "optimal",
+      "objective": -450.0000011369069,
+      "bound": -450.00000209765136,
+      "node_count": 3,
+      "wall": 0.435,
+      "sense": "min"
+    },
+    "ex7_2_2": {
+      "instance": "ex7_2_2",
+      "status": "feasible",
+      "objective": -0.38881143010195207,
+      "bound": -0.39749234462710814,
+      "node_count": 75,
+      "wall": 5.739,
+      "sense": "min"
+    },
+    "ex4_1_2": {
+      "instance": "ex4_1_2",
+      "status": "optimal",
+      "objective": -663.5000966105001,
+      "bound": -663.5000966114999,
+      "node_count": 3,
+      "wall": 0.551,
+      "sense": "min"
+    },
+    "ex4_1_8": {
+      "instance": "ex4_1_8",
+      "status": "optimal",
+      "objective": -16.73889318443983,
+      "bound": -16.740521631557268,
+      "node_count": 7,
+      "wall": 0.361,
+      "sense": "min"
+    },
+    "ex8_1_1": {
+      "instance": "ex8_1_1",
+      "status": "optimal",
+      "objective": -2.021806795967722,
+      "bound": -2.021968747474246,
+      "node_count": 5,
+      "wall": 0.398,
+      "sense": "min"
+    },
+    "st_bpaf1a": {
+      "instance": "st_bpaf1a",
+      "status": "optimal",
+      "objective": -45.37971091253482,
+      "bound": -45.37971142671955,
+      "node_count": 5,
+      "wall": 0.481,
+      "sense": "min"
+    },
+    "st_e29": {
+      "instance": "st_e29",
+      "status": "optimal",
+      "objective": -0.9434704910762214,
+      "bound": -0.9435072710855771,
+      "node_count": 53,
+      "wall": 2.108,
+      "sense": "min"
+    },
+    "st_e31": {
+      "instance": "st_e31",
+      "status": "feasible",
+      "objective": -2.000000008986581,
+      "bound": -3.000000004,
+      "node_count": 609,
+      "wall": 40.051,
+      "sense": "min"
+    },
+    "gbd": {
+      "instance": "gbd",
+      "status": "optimal",
+      "objective": 2.199999982504936,
+      "bound": 2.199999982504936,
+      "node_count": 3,
+      "wall": 0.146,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v2_off.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v2_off.json
@@ -1,0 +1,259 @@
+{
+  "arm": "off",
+  "env": {},
+  "tl": 40.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.68521625604212,
+      "node_count": 195,
+      "wall": 8.801,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -246.0,
+      "bound": -246.01879639837531,
+      "node_count": 153,
+      "wall": 17.276,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -58.64520980040217,
+      "node_count": 191,
+      "wall": 40.626,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.764999879276536,
+      "bound": -1.7651560782283298,
+      "node_count": 29,
+      "wall": 2.906,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "time_limit",
+      "objective": null,
+      "bound": null,
+      "node_count": 1215,
+      "wall": 40.67,
+      "sense": "min"
+    },
+    "nvs03": {
+      "instance": "nvs03",
+      "status": "optimal",
+      "objective": 16.0,
+      "bound": 15.99999972676511,
+      "node_count": 5,
+      "wall": 0.402,
+      "sense": "min"
+    },
+    "nvs05": {
+      "instance": "nvs05",
+      "status": "feasible",
+      "objective": 5.47093412640568,
+      "bound": 1.3520892806701879,
+      "node_count": 613,
+      "wall": 40.153,
+      "sense": "min"
+    },
+    "nvs08": {
+      "instance": "nvs08",
+      "status": "optimal",
+      "objective": 23.449727353351044,
+      "bound": 23.449382312131643,
+      "node_count": 57,
+      "wall": 0.954,
+      "sense": "min"
+    },
+    "nvs10": {
+      "instance": "nvs10",
+      "status": "optimal",
+      "objective": -310.7999999999999,
+      "bound": -310.7999999999999,
+      "node_count": 5,
+      "wall": 0.081,
+      "sense": "min"
+    },
+    "nvs11": {
+      "instance": "nvs11",
+      "status": "optimal",
+      "objective": -430.99999999999966,
+      "bound": -430.99999999999966,
+      "node_count": 55,
+      "wall": 0.44,
+      "sense": "min"
+    },
+    "nvs12": {
+      "instance": "nvs12",
+      "status": "optimal",
+      "objective": -481.20000000000005,
+      "bound": -481.20000000000005,
+      "node_count": 231,
+      "wall": 1.414,
+      "sense": "min"
+    },
+    "nvs16": {
+      "instance": "nvs16",
+      "status": "optimal",
+      "objective": 0.703125,
+      "bound": 0.7031248950084752,
+      "node_count": 7,
+      "wall": 0.786,
+      "sense": "min"
+    },
+    "nvs18": {
+      "instance": "nvs18",
+      "status": "optimal",
+      "objective": -778.4,
+      "bound": -778.4000015578,
+      "node_count": 105,
+      "wall": 6.626,
+      "sense": "min"
+    },
+    "st_miqp1": {
+      "instance": "st_miqp1",
+      "status": "optimal",
+      "objective": 280.9999999906497,
+      "bound": 280.9999999906497,
+      "node_count": 15,
+      "wall": 0.139,
+      "sense": "min"
+    },
+    "st_miqp4": {
+      "instance": "st_miqp4",
+      "status": "optimal",
+      "objective": -4574.000004423649,
+      "bound": -4574.000004423649,
+      "node_count": 3,
+      "wall": 0.141,
+      "sense": "min"
+    },
+    "st_miqp5": {
+      "instance": "st_miqp5",
+      "status": "optimal",
+      "objective": -333.8888902488547,
+      "bound": -333.8888902488547,
+      "node_count": 1,
+      "wall": 0.141,
+      "sense": "min"
+    },
+    "st_test2": {
+      "instance": "st_test2",
+      "status": "optimal",
+      "objective": -9.25,
+      "bound": -9.25,
+      "node_count": 5,
+      "wall": 0.135,
+      "sense": "min"
+    },
+    "st_testgr1": {
+      "instance": "st_testgr1",
+      "status": "optimal",
+      "objective": -12.811600000000002,
+      "bound": -12.811600000000002,
+      "node_count": 105,
+      "wall": 0.157,
+      "sense": "min"
+    },
+    "ex5_2_2_case2": {
+      "instance": "ex5_2_2_case2",
+      "status": "feasible",
+      "objective": -600.000006187781,
+      "bound": -1151.885193468892,
+      "node_count": 3,
+      "wall": 0.566,
+      "sense": "min"
+    },
+    "ex5_2_4": {
+      "instance": "ex5_2_4",
+      "status": "optimal",
+      "objective": -450.0000011369072,
+      "bound": -450.00000209765136,
+      "node_count": 3,
+      "wall": 0.449,
+      "sense": "min"
+    },
+    "ex7_2_2": {
+      "instance": "ex7_2_2",
+      "status": "feasible",
+      "objective": -0.3888273979580534,
+      "bound": -0.3974923446270908,
+      "node_count": 61,
+      "wall": 12.986,
+      "sense": "min"
+    },
+    "ex4_1_2": {
+      "instance": "ex4_1_2",
+      "status": "optimal",
+      "objective": -663.5000966105001,
+      "bound": -663.5000966114999,
+      "node_count": 3,
+      "wall": 0.669,
+      "sense": "min"
+    },
+    "ex4_1_8": {
+      "instance": "ex4_1_8",
+      "status": "optimal",
+      "objective": -16.73889318443983,
+      "bound": -16.740521631557268,
+      "node_count": 7,
+      "wall": 0.448,
+      "sense": "min"
+    },
+    "ex8_1_1": {
+      "instance": "ex8_1_1",
+      "status": "optimal",
+      "objective": -2.021806795967722,
+      "bound": -2.021968747474239,
+      "node_count": 5,
+      "wall": 0.481,
+      "sense": "min"
+    },
+    "st_bpaf1a": {
+      "instance": "st_bpaf1a",
+      "status": "optimal",
+      "objective": -45.37971091253482,
+      "bound": -45.37971142671955,
+      "node_count": 5,
+      "wall": 0.58,
+      "sense": "min"
+    },
+    "st_e29": {
+      "instance": "st_e29",
+      "status": "optimal",
+      "objective": -0.9434704910762214,
+      "bound": -0.9435072710855771,
+      "node_count": 53,
+      "wall": 2.411,
+      "sense": "min"
+    },
+    "st_e31": {
+      "instance": "st_e31",
+      "status": "feasible",
+      "objective": -2.000000009009396,
+      "bound": -3.000000004,
+      "node_count": 203,
+      "wall": 40.065,
+      "sense": "min"
+    },
+    "gbd": {
+      "instance": "gbd",
+      "status": "optimal",
+      "objective": 2.199999982504936,
+      "bound": 2.199999982504936,
+      "node_count": 3,
+      "wall": 0.148,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v3_lift_loose_products.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v3_lift_loose_products.json
@@ -1,0 +1,325 @@
+{
+  "arm": "lift_loose_products",
+  "env": {
+    "DISCOPT_LIFT_LOOSE_PRODUCTS": "1",
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 60.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 9.684,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 153,
+      "wall": 7.779,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -44.51637303548111,
+      "node_count": 127,
+      "wall": 60.091,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.7651560833301083,
+      "node_count": 29,
+      "wall": 1.936,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "feasible",
+      "objective": 5.299999922109238,
+      "bound": null,
+      "node_count": 1921,
+      "wall": 60.102,
+      "sense": "min"
+    },
+    "nvs14": {
+      "instance": "nvs14",
+      "status": "optimal",
+      "objective": -40358.15476929996,
+      "bound": -40358.15476929999,
+      "node_count": 223,
+      "wall": 0.144,
+      "sense": "min"
+    },
+    "nvs20": {
+      "instance": "nvs20",
+      "status": "feasible",
+      "objective": 230.9221630055551,
+      "bound": 45.99999999999982,
+      "node_count": 739,
+      "wall": 60.088,
+      "sense": "min"
+    },
+    "nvs22": {
+      "instance": "nvs22",
+      "status": "feasible",
+      "objective": 6.0582199356118025,
+      "bound": 6.0582199951512,
+      "node_count": 37,
+      "wall": 8.132,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668808098541,
+      "node_count": 17,
+      "wall": 1.627,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.486,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 0.689,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 47,
+      "wall": 1.886,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.053,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1130.495879486534,
+      "node_count": 37,
+      "wall": 64.696,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.145,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.128,
+      "sense": "min"
+    },
+    "st_miqp5": {
+      "instance": "st_miqp5",
+      "status": "optimal",
+      "objective": -333.8888902488547,
+      "bound": -333.8888902488547,
+      "node_count": 1,
+      "wall": 0.136,
+      "sense": "min"
+    },
+    "st_test2": {
+      "instance": "st_test2",
+      "status": "optimal",
+      "objective": -9.25,
+      "bound": -9.25,
+      "node_count": 5,
+      "wall": 0.135,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.233,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.151,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.0000020422272,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.485,
+      "sense": "min"
+    },
+    "ex5_2_4": {
+      "instance": "ex5_2_4",
+      "status": "optimal",
+      "objective": -450.0000011369069,
+      "bound": -450.00000209765136,
+      "node_count": 3,
+      "wall": 0.455,
+      "sense": "min"
+    },
+    "ex7_2_2": {
+      "instance": "ex7_2_2",
+      "status": "feasible",
+      "objective": -0.38881143010195207,
+      "bound": -0.39749234462710814,
+      "node_count": 75,
+      "wall": 5.96,
+      "sense": "min"
+    },
+    "ex7_2_3": {
+      "instance": "ex7_2_3",
+      "status": "feasible",
+      "objective": 7049.247897736022,
+      "bound": 2675.941572579564,
+      "node_count": 1787,
+      "wall": 60.039,
+      "sense": "min"
+    },
+    "ex4_1_3": {
+      "instance": "ex4_1_3",
+      "status": "optimal",
+      "objective": -443.6717047411247,
+      "bound": -443.69325421340716,
+      "node_count": 49,
+      "wall": 0.401,
+      "sense": "min"
+    },
+    "ex4_1_8": {
+      "instance": "ex4_1_8",
+      "status": "optimal",
+      "objective": -16.73889318443983,
+      "bound": -16.740521631557268,
+      "node_count": 7,
+      "wall": 0.363,
+      "sense": "min"
+    },
+    "ex4_1_9": {
+      "instance": "ex4_1_9",
+      "status": "optimal",
+      "objective": -5.508013263411899,
+      "bound": -5.508237191656272,
+      "node_count": 187,
+      "wall": 0.898,
+      "sense": "min"
+    },
+    "ex8_1_1": {
+      "instance": "ex8_1_1",
+      "status": "optimal",
+      "objective": -2.021806795967722,
+      "bound": -2.021968747474246,
+      "node_count": 5,
+      "wall": 0.409,
+      "sense": "min"
+    },
+    "ex8_1_6": {
+      "instance": "ex8_1_6",
+      "status": "optimal",
+      "objective": -10.086001496222387,
+      "bound": -10.086001496222387,
+      "node_count": 1,
+      "wall": 0.368,
+      "sense": "min"
+    },
+    "st_bpaf1a": {
+      "instance": "st_bpaf1a",
+      "status": "optimal",
+      "objective": -45.37971091253482,
+      "bound": -45.37971142671955,
+      "node_count": 5,
+      "wall": 0.486,
+      "sense": "min"
+    },
+    "st_bpaf1b": {
+      "instance": "st_bpaf1b",
+      "status": "optimal",
+      "objective": -42.96255572024222,
+      "bound": -42.96255849515288,
+      "node_count": 3,
+      "wall": 0.486,
+      "sense": "min"
+    },
+    "st_e29": {
+      "instance": "st_e29",
+      "status": "optimal",
+      "objective": -0.9434704910762214,
+      "bound": -0.9435072710855771,
+      "node_count": 53,
+      "wall": 2.185,
+      "sense": "min"
+    },
+    "st_e31": {
+      "instance": "st_e31",
+      "status": "feasible",
+      "objective": -2.000000008986581,
+      "bound": -3.0,
+      "node_count": 985,
+      "wall": 60.126,
+      "sense": "min"
+    },
+    "gbd": {
+      "instance": "gbd",
+      "status": "optimal",
+      "objective": 2.199999982504936,
+      "bound": 2.199999982504936,
+      "node_count": 3,
+      "wall": 0.153,
+      "sense": "min"
+    },
+    "gkocis": {
+      "instance": "gkocis",
+      "status": "optimal",
+      "objective": -1.9230987798770212,
+      "bound": -1.9230988280923489,
+      "node_count": 5,
+      "wall": 0.774,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v3_lu_density_route.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v3_lu_density_route.json
@@ -1,0 +1,324 @@
+{
+  "arm": "lu_density_route",
+  "env": {
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 60.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 9.587,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 153,
+      "wall": 7.816,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -57.67146658173485,
+      "node_count": 221,
+      "wall": 60.621,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.7651560833301083,
+      "node_count": 29,
+      "wall": 1.949,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "feasible",
+      "objective": 5.299999922109238,
+      "bound": null,
+      "node_count": 1915,
+      "wall": 60.181,
+      "sense": "min"
+    },
+    "nvs14": {
+      "instance": "nvs14",
+      "status": "optimal",
+      "objective": -40358.15476929996,
+      "bound": -40358.15476929999,
+      "node_count": 223,
+      "wall": 0.153,
+      "sense": "min"
+    },
+    "nvs20": {
+      "instance": "nvs20",
+      "status": "feasible",
+      "objective": 230.9221630055551,
+      "bound": 45.99999999999982,
+      "node_count": 695,
+      "wall": 60.02,
+      "sense": "min"
+    },
+    "nvs22": {
+      "instance": "nvs22",
+      "status": "feasible",
+      "objective": 6.0582199356118025,
+      "bound": 6.0582199951512,
+      "node_count": 37,
+      "wall": 7.825,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668808098541,
+      "node_count": 17,
+      "wall": 1.566,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.46,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 0.678,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 47,
+      "wall": 1.887,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.054,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1130.495879486534,
+      "node_count": 37,
+      "wall": 60.188,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.161,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.138,
+      "sense": "min"
+    },
+    "st_miqp5": {
+      "instance": "st_miqp5",
+      "status": "optimal",
+      "objective": -333.8888902488547,
+      "bound": -333.8888902488547,
+      "node_count": 1,
+      "wall": 0.151,
+      "sense": "min"
+    },
+    "st_test2": {
+      "instance": "st_test2",
+      "status": "optimal",
+      "objective": -9.25,
+      "bound": -9.25,
+      "node_count": 5,
+      "wall": 0.142,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.251,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.166,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.0000020422272,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.511,
+      "sense": "min"
+    },
+    "ex5_2_4": {
+      "instance": "ex5_2_4",
+      "status": "optimal",
+      "objective": -450.0000011369069,
+      "bound": -450.00000209765136,
+      "node_count": 3,
+      "wall": 0.461,
+      "sense": "min"
+    },
+    "ex7_2_2": {
+      "instance": "ex7_2_2",
+      "status": "feasible",
+      "objective": -0.38881143010195207,
+      "bound": -0.39749234462710814,
+      "node_count": 75,
+      "wall": 5.766,
+      "sense": "min"
+    },
+    "ex7_2_3": {
+      "instance": "ex7_2_3",
+      "status": "feasible",
+      "objective": 7049.247897736022,
+      "bound": 2675.941572579564,
+      "node_count": 1783,
+      "wall": 60.025,
+      "sense": "min"
+    },
+    "ex4_1_3": {
+      "instance": "ex4_1_3",
+      "status": "optimal",
+      "objective": -443.6717047411247,
+      "bound": -443.69325421340716,
+      "node_count": 49,
+      "wall": 0.414,
+      "sense": "min"
+    },
+    "ex4_1_8": {
+      "instance": "ex4_1_8",
+      "status": "optimal",
+      "objective": -16.73889318443983,
+      "bound": -16.740521631557268,
+      "node_count": 7,
+      "wall": 0.373,
+      "sense": "min"
+    },
+    "ex4_1_9": {
+      "instance": "ex4_1_9",
+      "status": "optimal",
+      "objective": -5.508013263411899,
+      "bound": -5.508237191656272,
+      "node_count": 187,
+      "wall": 0.911,
+      "sense": "min"
+    },
+    "ex8_1_1": {
+      "instance": "ex8_1_1",
+      "status": "optimal",
+      "objective": -2.021806795967722,
+      "bound": -2.021968747474246,
+      "node_count": 5,
+      "wall": 0.418,
+      "sense": "min"
+    },
+    "ex8_1_6": {
+      "instance": "ex8_1_6",
+      "status": "optimal",
+      "objective": -10.086001496222387,
+      "bound": -10.086001496222387,
+      "node_count": 1,
+      "wall": 0.358,
+      "sense": "min"
+    },
+    "st_bpaf1a": {
+      "instance": "st_bpaf1a",
+      "status": "optimal",
+      "objective": -45.37971091253482,
+      "bound": -45.37971142671955,
+      "node_count": 5,
+      "wall": 0.486,
+      "sense": "min"
+    },
+    "st_bpaf1b": {
+      "instance": "st_bpaf1b",
+      "status": "optimal",
+      "objective": -42.96255572024222,
+      "bound": -42.96255849515288,
+      "node_count": 3,
+      "wall": 0.484,
+      "sense": "min"
+    },
+    "st_e29": {
+      "instance": "st_e29",
+      "status": "optimal",
+      "objective": -0.9434704910762214,
+      "bound": -0.9435072710855771,
+      "node_count": 53,
+      "wall": 2.143,
+      "sense": "min"
+    },
+    "st_e31": {
+      "instance": "st_e31",
+      "status": "feasible",
+      "objective": -2.000000008986581,
+      "bound": -3.0,
+      "node_count": 953,
+      "wall": 60.641,
+      "sense": "min"
+    },
+    "gbd": {
+      "instance": "gbd",
+      "status": "optimal",
+      "objective": 2.199999982504936,
+      "bound": 2.199999982504936,
+      "node_count": 3,
+      "wall": 0.151,
+      "sense": "min"
+    },
+    "gkocis": {
+      "instance": "gkocis",
+      "status": "optimal",
+      "objective": -1.9230987798770212,
+      "bound": -1.9230988280923489,
+      "node_count": 5,
+      "wall": 0.759,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v3_obj_branch_priority.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v3_obj_branch_priority.json
@@ -1,0 +1,325 @@
+{
+  "arm": "obj_branch_priority",
+  "env": {
+    "DISCOPT_OBJ_BRANCH_PRIORITY": "1",
+    "DISCOPT_LU_DENSITY_ROUTE": "1"
+  },
+  "tl": 60.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.685216256038941,
+      "node_count": 191,
+      "wall": 10.687,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -245.99999999999997,
+      "bound": -246.01879639837875,
+      "node_count": 153,
+      "wall": 7.995,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -57.68014599320852,
+      "node_count": 221,
+      "wall": 60.152,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.7649998792765358,
+      "bound": -1.7651560833301083,
+      "node_count": 29,
+      "wall": 1.872,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "feasible",
+      "objective": 5.299999922109238,
+      "bound": null,
+      "node_count": 1903,
+      "wall": 60.038,
+      "sense": "min"
+    },
+    "nvs14": {
+      "instance": "nvs14",
+      "status": "optimal",
+      "objective": -40358.15476929996,
+      "bound": -40358.15476929999,
+      "node_count": 223,
+      "wall": 0.146,
+      "sense": "min"
+    },
+    "nvs20": {
+      "instance": "nvs20",
+      "status": "feasible",
+      "objective": 230.9221630055551,
+      "bound": 45.99999999999982,
+      "node_count": 727,
+      "wall": 60.032,
+      "sense": "min"
+    },
+    "nvs22": {
+      "instance": "nvs22",
+      "status": "feasible",
+      "objective": 6.05821993806505,
+      "bound": 6.058219999999996,
+      "node_count": 17,
+      "wall": 4.796,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.469668698257443,
+      "node_count": 11,
+      "wall": 1.659,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.46,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 0.666,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 35,
+      "wall": 1.622,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.052,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1129.9909919878482,
+      "node_count": 179,
+      "wall": 60.073,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.146,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.133,
+      "sense": "min"
+    },
+    "st_miqp5": {
+      "instance": "st_miqp5",
+      "status": "optimal",
+      "objective": -333.8888902488547,
+      "bound": -333.8888902488547,
+      "node_count": 1,
+      "wall": 0.144,
+      "sense": "min"
+    },
+    "st_test2": {
+      "instance": "st_test2",
+      "status": "optimal",
+      "objective": -9.25,
+      "bound": -9.25,
+      "node_count": 5,
+      "wall": 0.142,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.243,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.159,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.0000020422272,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.496,
+      "sense": "min"
+    },
+    "ex5_2_4": {
+      "instance": "ex5_2_4",
+      "status": "optimal",
+      "objective": -450.0000011369069,
+      "bound": -450.00000209765136,
+      "node_count": 3,
+      "wall": 0.46,
+      "sense": "min"
+    },
+    "ex7_2_2": {
+      "instance": "ex7_2_2",
+      "status": "feasible",
+      "objective": -0.38881143010195207,
+      "bound": -0.39749234462710814,
+      "node_count": 75,
+      "wall": 5.952,
+      "sense": "min"
+    },
+    "ex7_2_3": {
+      "instance": "ex7_2_3",
+      "status": "feasible",
+      "objective": 7049.247897736022,
+      "bound": 2675.941572579564,
+      "node_count": 1811,
+      "wall": 60.052,
+      "sense": "min"
+    },
+    "ex4_1_3": {
+      "instance": "ex4_1_3",
+      "status": "optimal",
+      "objective": -443.6717047411247,
+      "bound": -443.69325421340716,
+      "node_count": 49,
+      "wall": 0.41,
+      "sense": "min"
+    },
+    "ex4_1_8": {
+      "instance": "ex4_1_8",
+      "status": "optimal",
+      "objective": -16.73889318443983,
+      "bound": -16.740521631557268,
+      "node_count": 7,
+      "wall": 0.359,
+      "sense": "min"
+    },
+    "ex4_1_9": {
+      "instance": "ex4_1_9",
+      "status": "optimal",
+      "objective": -5.508013263411899,
+      "bound": -5.508237191656272,
+      "node_count": 187,
+      "wall": 0.878,
+      "sense": "min"
+    },
+    "ex8_1_1": {
+      "instance": "ex8_1_1",
+      "status": "optimal",
+      "objective": -2.021806795967722,
+      "bound": -2.021968747474246,
+      "node_count": 5,
+      "wall": 0.405,
+      "sense": "min"
+    },
+    "ex8_1_6": {
+      "instance": "ex8_1_6",
+      "status": "optimal",
+      "objective": -10.086001496222387,
+      "bound": -10.086001496222387,
+      "node_count": 1,
+      "wall": 0.367,
+      "sense": "min"
+    },
+    "st_bpaf1a": {
+      "instance": "st_bpaf1a",
+      "status": "optimal",
+      "objective": -45.37971091253482,
+      "bound": -45.37971142671955,
+      "node_count": 5,
+      "wall": 0.492,
+      "sense": "min"
+    },
+    "st_bpaf1b": {
+      "instance": "st_bpaf1b",
+      "status": "optimal",
+      "objective": -42.96255572024222,
+      "bound": -42.96255849515288,
+      "node_count": 3,
+      "wall": 0.49,
+      "sense": "min"
+    },
+    "st_e29": {
+      "instance": "st_e29",
+      "status": "optimal",
+      "objective": -0.9434704910762214,
+      "bound": -0.9435072710855771,
+      "node_count": 53,
+      "wall": 2.111,
+      "sense": "min"
+    },
+    "st_e31": {
+      "instance": "st_e31",
+      "status": "feasible",
+      "objective": -2.000000008986581,
+      "bound": -3.0,
+      "node_count": 985,
+      "wall": 60.145,
+      "sense": "min"
+    },
+    "gbd": {
+      "instance": "gbd",
+      "status": "optimal",
+      "objective": 2.199999982504936,
+      "bound": 2.199999982504936,
+      "node_count": 3,
+      "wall": 0.159,
+      "sense": "min"
+    },
+    "gkocis": {
+      "instance": "gkocis",
+      "status": "optimal",
+      "objective": -1.9230987798770212,
+      "bound": -1.9230988280923489,
+      "node_count": 5,
+      "wall": 0.76,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v3_off.json
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/v3_off.json
@@ -1,0 +1,322 @@
+{
+  "arm": "off",
+  "env": {},
+  "tl": 60.0,
+  "results": {
+    "nvs21": {
+      "instance": "nvs21",
+      "status": "optimal",
+      "objective": -5.684782607923295,
+      "bound": -5.68521625604212,
+      "node_count": 195,
+      "wall": 8.028,
+      "sense": "min"
+    },
+    "st_e36": {
+      "instance": "st_e36",
+      "status": "optimal",
+      "objective": -246.0,
+      "bound": -246.01879639837531,
+      "node_count": 153,
+      "wall": 16.666,
+      "sense": "min"
+    },
+    "nvs09": {
+      "instance": "nvs09",
+      "status": "feasible",
+      "objective": -43.13433691803531,
+      "bound": -57.68014599320864,
+      "node_count": 221,
+      "wall": 60.263,
+      "sense": "min"
+    },
+    "alkyl": {
+      "instance": "alkyl",
+      "status": "optimal",
+      "objective": -1.764999879276536,
+      "bound": -1.7651560782283298,
+      "node_count": 29,
+      "wall": 2.943,
+      "sense": "min"
+    },
+    "tls2": {
+      "instance": "tls2",
+      "status": "feasible",
+      "objective": 5.299999922109238,
+      "bound": null,
+      "node_count": 1903,
+      "wall": 60.14,
+      "sense": "min"
+    },
+    "nvs14": {
+      "instance": "nvs14",
+      "status": "optimal",
+      "objective": -40358.15476929996,
+      "bound": -40358.15476929999,
+      "node_count": 223,
+      "wall": 0.147,
+      "sense": "min"
+    },
+    "nvs20": {
+      "instance": "nvs20",
+      "status": "feasible",
+      "objective": 230.9221630055551,
+      "bound": 45.99999999999982,
+      "node_count": 723,
+      "wall": 60.063,
+      "sense": "min"
+    },
+    "nvs22": {
+      "instance": "nvs22",
+      "status": "optimal",
+      "objective": 6.058219942618264,
+      "bound": 6.058219998999999,
+      "node_count": 35,
+      "wall": 8.116,
+      "sense": "min"
+    },
+    "nvs01": {
+      "instance": "nvs01",
+      "status": "optimal",
+      "objective": 12.46966882156821,
+      "bound": 12.46966880809854,
+      "node_count": 17,
+      "wall": 2.756,
+      "sense": "min"
+    },
+    "nvs04": {
+      "instance": "nvs04",
+      "status": "optimal",
+      "objective": 0.720000000000006,
+      "bound": 0.7199999473599988,
+      "node_count": 5,
+      "wall": 0.509,
+      "sense": "min"
+    },
+    "nvs06": {
+      "instance": "nvs06",
+      "status": "optimal",
+      "objective": 1.7703125002341187,
+      "bound": 1.7703124984296874,
+      "node_count": 5,
+      "wall": 0.73,
+      "sense": "min"
+    },
+    "nvs13": {
+      "instance": "nvs13",
+      "status": "optimal",
+      "objective": -585.2,
+      "bound": -585.2000011714,
+      "node_count": 45,
+      "wall": 1.963,
+      "sense": "min"
+    },
+    "nvs15": {
+      "instance": "nvs15",
+      "status": "optimal",
+      "objective": 1.0,
+      "bound": 1.0,
+      "node_count": 7,
+      "wall": 0.055,
+      "sense": "min"
+    },
+    "nvs23": {
+      "instance": "nvs23",
+      "status": "feasible",
+      "objective": -1124.8,
+      "bound": -1130.495879486534,
+      "node_count": 69,
+      "wall": 60.178,
+      "sense": "min"
+    },
+    "st_miqp2": {
+      "instance": "st_miqp2",
+      "status": "optimal",
+      "objective": 2.0,
+      "bound": 2.0,
+      "node_count": 9,
+      "wall": 0.159,
+      "sense": "min"
+    },
+    "st_miqp3": {
+      "instance": "st_miqp3",
+      "status": "optimal",
+      "objective": -6.0,
+      "bound": -6.0,
+      "node_count": 1,
+      "wall": 0.136,
+      "sense": "min"
+    },
+    "st_miqp5": {
+      "instance": "st_miqp5",
+      "status": "optimal",
+      "objective": -333.8888902488547,
+      "bound": -333.8888902488547,
+      "node_count": 1,
+      "wall": 0.148,
+      "sense": "min"
+    },
+    "st_test2": {
+      "instance": "st_test2",
+      "status": "optimal",
+      "objective": -9.25,
+      "bound": -9.25,
+      "node_count": 5,
+      "wall": 0.142,
+      "sense": "min"
+    },
+    "meanvarx": {
+      "instance": "meanvarx",
+      "status": "optimal",
+      "objective": 14.36923135631427,
+      "bound": 14.36923135631427,
+      "node_count": 17,
+      "wall": 0.245,
+      "sense": "min"
+    },
+    "alan": {
+      "instance": "alan",
+      "status": "optimal",
+      "objective": 2.924999998301341,
+      "bound": 2.924999998301341,
+      "node_count": 21,
+      "wall": 0.166,
+      "sense": "min"
+    },
+    "ex5_2_2_case1": {
+      "instance": "ex5_2_2_case1",
+      "status": "optimal",
+      "objective": -400.00000204222675,
+      "bound": -400.0000041260587,
+      "node_count": 3,
+      "wall": 0.525,
+      "sense": "min"
+    },
+    "ex5_2_4": {
+      "instance": "ex5_2_4",
+      "status": "optimal",
+      "objective": -450.0000011369072,
+      "bound": -450.00000209765136,
+      "node_count": 3,
+      "wall": 0.464,
+      "sense": "min"
+    },
+    "ex7_2_2": {
+      "instance": "ex7_2_2",
+      "status": "feasible",
+      "objective": -0.3888273979580534,
+      "bound": -0.3974923446270908,
+      "node_count": 61,
+      "wall": 12.2,
+      "sense": "min"
+    },
+    "ex7_2_3": {
+      "instance": "ex7_2_3",
+      "status": "feasible",
+      "objective": 7049.247897736024,
+      "bound": 2689.2981535278154,
+      "node_count": 1515,
+      "wall": 60.03,
+      "sense": "min"
+    },
+    "ex4_1_3": {
+      "instance": "ex4_1_3",
+      "status": "optimal",
+      "objective": -443.6717047411247,
+      "bound": -443.69325421340716,
+      "node_count": 49,
+      "wall": 0.483,
+      "sense": "min"
+    },
+    "ex4_1_8": {
+      "instance": "ex4_1_8",
+      "status": "optimal",
+      "objective": -16.73889318443983,
+      "bound": -16.740521631557268,
+      "node_count": 7,
+      "wall": 0.39,
+      "sense": "min"
+    },
+    "ex4_1_9": {
+      "instance": "ex4_1_9",
+      "status": "optimal",
+      "objective": -5.508013263411899,
+      "bound": -5.508237191656272,
+      "node_count": 187,
+      "wall": 0.965,
+      "sense": "min"
+    },
+    "ex8_1_1": {
+      "instance": "ex8_1_1",
+      "status": "optimal",
+      "objective": -2.021806795967722,
+      "bound": -2.021968747474239,
+      "node_count": 5,
+      "wall": 0.475,
+      "sense": "min"
+    },
+    "ex8_1_6": {
+      "instance": "ex8_1_6",
+      "status": "optimal",
+      "objective": -10.086001496222387,
+      "bound": -10.086001496222387,
+      "node_count": 1,
+      "wall": 0.393,
+      "sense": "min"
+    },
+    "st_bpaf1a": {
+      "instance": "st_bpaf1a",
+      "status": "optimal",
+      "objective": -45.37971091253482,
+      "bound": -45.37971142671955,
+      "node_count": 5,
+      "wall": 0.525,
+      "sense": "min"
+    },
+    "st_bpaf1b": {
+      "instance": "st_bpaf1b",
+      "status": "optimal",
+      "objective": -42.96255572024222,
+      "bound": -42.96255849515287,
+      "node_count": 3,
+      "wall": 0.534,
+      "sense": "min"
+    },
+    "st_e29": {
+      "instance": "st_e29",
+      "status": "optimal",
+      "objective": -0.9434704910762214,
+      "bound": -0.9435072710855771,
+      "node_count": 53,
+      "wall": 2.378,
+      "sense": "min"
+    },
+    "st_e31": {
+      "instance": "st_e31",
+      "status": "feasible",
+      "objective": -2.000000009009555,
+      "bound": -3.0,
+      "node_count": 479,
+      "wall": 60.2,
+      "sense": "min"
+    },
+    "gbd": {
+      "instance": "gbd",
+      "status": "optimal",
+      "objective": 2.199999982504936,
+      "bound": 2.199999982504936,
+      "node_count": 3,
+      "wall": 0.144,
+      "sense": "min"
+    },
+    "gkocis": {
+      "instance": "gkocis",
+      "status": "optimal",
+      "objective": -1.9230987798770212,
+      "bound": -1.9230988280923489,
+      "node_count": 5,
+      "wall": 0.736,
+      "sense": "min"
+    }
+  }
+}

--- a/docs/dev/data/flag-graduation-verdicts23-2026-07-10/verdict.py
+++ b/docs/dev/data/flag-graduation-verdicts23-2026-07-10/verdict.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+"""Flag-graduation verdicts 2 & 3 analysis (BR-3 / #581 house pattern).
+
+Criteria per flag per verdict:
+- incorrect_count = 0: certified-optimal objective matches oracle (=opt=, or the
+  [=bestdual=, =best=] bracket) within abs 1e-4 / rel 1e-3; zero slack.
+- oracle cross: dual bound must never cross the known optimum (sense-corrected).
+- ZERO certificate losses: OFF optimal -> ON non-optimal is a hard fail.
+- objective drift (both-certified) <= abs 1e-4 / rel 1e-3.
+- perf: node counts on both-certified instances.
+
+Usage: verdict.py <v2|v3>
+"""
+import json, math, os, sys
+
+SP = os.path.dirname(os.path.abspath(__file__))
+
+# (kind, best, bestdual)  kind: "opt" or "best"
+ORACLE = {
+    "nvs21": ("opt", -5.6847825, None),
+    "st_e36": ("opt", -246.0, None),
+    "nvs09": ("opt", -43.13433692, None),
+    "alkyl": ("best", -1.764999646, -1.765024983),
+    "tls2": ("opt", 5.3, None),
+    "nvs01": ("opt", 12.46966882, None),
+    "nvs03": ("opt", 16.0, None),
+    "nvs04": ("opt", 0.72, None),
+    "nvs05": ("opt", 5.470934108, None),
+    "nvs06": ("opt", 1.7703125, None),
+    "nvs08": ("opt", 23.44972735, None),
+    "nvs10": ("opt", -310.8, None),
+    "nvs11": ("opt", -431.0, None),
+    "nvs12": ("opt", -481.2, None),
+    "nvs13": ("opt", -585.2, None),
+    "nvs14": ("opt", -40358.15477, None),
+    "nvs15": ("opt", 1.0, None),
+    "nvs16": ("opt", 0.703125, None),
+    "nvs18": ("opt", -778.4, None),
+    "nvs20": ("opt", 230.9221652, None),
+    "nvs22": ("opt", 6.05822, None),
+    "nvs23": ("opt", -1125.2, None),
+    "st_miqp1": ("opt", 281.0, None),
+    "st_miqp2": ("opt", 2.0, None),
+    "st_miqp3": ("opt", -6.0, None),
+    "st_miqp4": ("opt", -4574.0, None),
+    "st_miqp5": ("opt", -333.8888889, None),
+    "st_test2": ("opt", -9.25, None),
+    "st_testgr1": ("opt", -12.8116, None),
+    "meanvarx": ("opt", 14.36923211, None),
+    "alan": ("opt", 2.925, None),
+    "ex5_2_2_case1": ("opt", -400.0, None),
+    "ex5_2_2_case2": ("opt", -600.0, None),
+    "ex5_2_4": ("opt", -450.0, None),
+    "ex7_2_2": ("opt", -0.3888114343, None),
+    "ex7_2_3": ("best", 7049.24802, 7049.227807),
+    "ex4_1_2": ("opt", -663.5000966, None),
+    "ex4_1_3": ("opt", -443.6717047, None),
+    "ex4_1_8": ("opt", -16.73889318, None),
+    "ex4_1_9": ("opt", -5.508013271, None),
+    "ex8_1_1": ("opt", -2.021806783, None),
+    "ex8_1_6": ("opt", -10.0860015, None),
+    "st_bpaf1a": ("opt", -45.37971014, None),
+    "st_bpaf1b": ("opt", -42.9625576, None),
+    "st_e29": ("opt", -0.9434705, None),
+    "st_e31": ("opt", -2.0, None),
+    "gbd": ("opt", 2.2, None),
+    "gkocis": ("opt", -1.923098738, None),
+}
+
+ABS_TOL, REL_TOL, CROSS_SLACK = 1e-4, 1e-3, 1e-4
+
+
+def load(verdict, arm):
+    with open(os.path.join(SP, f"{verdict}_{arm}.json")) as f:
+        return json.load(f)
+
+
+def within(a, b):
+    if a is None or b is None:
+        return False
+    return abs(a - b) <= max(ABS_TOL, REL_TOL * max(abs(a), abs(b)))
+
+
+def is_optimal(r):
+    return str(r.get("status", "")).lower().endswith("optimal")
+
+
+def sense_sign(r):
+    return 1.0 if r.get("sense", "min") == "min" else -1.0
+
+
+def check_arm(verdict, arm, base):
+    on = load(verdict, arm)["results"]
+    out = {"incorrect": [], "crosses": [], "cert_losses": [], "cert_gains": [],
+           "drifts": [], "node_rows": [], "errors": []}
+    for inst, r in on.items():
+        b = base[inst]
+        kind, best, bestdual = ORACLE[inst]
+        s = sense_sign(r) if r.get("sense") else sense_sign(b)
+        st = str(r.get("status", ""))
+        if st in ("ERROR", "NO_RESULT", "OUTER_TIMEOUT"):
+            out["errors"].append((inst, st, str(r.get("error", r.get("stderr", "")))[:150]))
+        if is_optimal(r) and r.get("objective") is not None:
+            obj = r["objective"]
+            if kind == "opt":
+                if not within(obj, best):
+                    out["incorrect"].append((inst, obj, best))
+            else:
+                lo, hi = sorted([best, bestdual])
+                pad = max(ABS_TOL, REL_TOL * max(abs(lo), abs(hi)))
+                if not (lo - pad <= obj <= hi + pad):
+                    out["incorrect"].append((inst, obj, (lo, hi)))
+        bnd = r.get("bound")
+        if bnd is not None and best is not None and math.isfinite(bnd):
+            ref = best if kind == "opt" else (bestdual if bestdual is not None else best)
+            pad = max(CROSS_SLACK, REL_TOL * abs(ref))
+            if s * bnd > s * ref + pad:
+                out["crosses"].append((inst, bnd, ref))
+        if is_optimal(b) and not is_optimal(r):
+            out["cert_losses"].append((inst, b.get("status"), st, b.get("bound"), bnd))
+        if not is_optimal(b) and is_optimal(r):
+            out["cert_gains"].append((inst, b.get("status"), st))
+        if is_optimal(b) and is_optimal(r):
+            if not within(r.get("objective"), b.get("objective")):
+                out["drifts"].append((inst, b.get("objective"), r.get("objective")))
+            out["node_rows"].append((inst, b.get("node_count"), r.get("node_count")))
+    return out
+
+
+def main():
+    verdict = sys.argv[1]
+    base = load(verdict, "off")["results"]
+    print(f"=== {verdict} OFF baseline ===")
+    for inst, r in base.items():
+        print(f"  {inst:18} {str(r.get('status')):>12} obj={r.get('objective')} "
+              f"bnd={r.get('bound')} n={r.get('node_count')} w={r.get('wall')}")
+    for arm in ["lu_density_route", "obj_branch_priority", "lift_loose_products"]:
+        path = os.path.join(SP, f"{verdict}_{arm}.json")
+        if not os.path.exists(path):
+            print(f"\n=== {arm}: MISSING ===")
+            continue
+        res = check_arm(verdict, arm, base)
+        print(f"\n=== {verdict} {arm} ===")
+        print(f"  errors:       {res['errors']}")
+        print(f"  incorrect:    {len(res['incorrect'])} {res['incorrect']}")
+        print(f"  oracle-cross: {len(res['crosses'])} {res['crosses']}")
+        print(f"  cert-losses:  {len(res['cert_losses'])} {res['cert_losses']}")
+        print(f"  cert-gains:   {len(res['cert_gains'])} {res['cert_gains']}")
+        print(f"  obj drift:    {len(res['drifts'])} {res['drifts']}")
+        tot_off = sum(n for _, n, _ in res["node_rows"] if n and n > 0)
+        tot_on = sum(n for _, _, n in res["node_rows"] if n and n > 0)
+        changed = [(i, a, c) for i, a, c in res["node_rows"] if a != c]
+        engaged = len(changed) > 0
+        print(f"  nodes (both-certified): OFF {tot_off} -> ON {tot_on}")
+        print(f"  node deltas: {changed}")
+        green = (not res["incorrect"] and not res["crosses"] and not res["cert_losses"]
+                 and not res["drifts"] and not res["errors"] and engaged)
+        print(f"  ENGAGED={engaged}  GREEN={green}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/flag-graduation-verdicts23-2026-07-10.md
+++ b/docs/dev/flag-graduation-verdicts23-2026-07-10.md
@@ -1,0 +1,176 @@
+# Flag graduation — verdicts 2 & 3 (follow-on to BR-3 #602, 2026-07-10)
+
+**Task:** run graduation **verdicts 2 and 3** (two independent held-out gate runs)
+for the three flags BR-3 (`docs/dev/br3-regate-2026-07-10.md`) found
+GRADUATE-ELIGIBLE at **verdict 1/3**. Per T2.6, a bound-changing flag needs **3
+consecutive green verdicts** before any default-ON flip. Each flag is composed
+with `DISCOPT_LU_DENSITY_ROUTE=1` (the #591 / A-2 dense retry), as BR-3
+established:
+
+1. `DISCOPT_LU_DENSITY_ROUTE` — the engine retry itself (#74 line).
+2. `DISCOPT_OBJ_BRANCH_PRIORITY` — BR-3: nvs21 cured, 1144→1102 nodes.
+3. `DISCOPT_LIFT_LOOSE_PRODUCTS` — TD-A; BR-3: nvs09 gap tightens.
+
+**This PR flips no defaults.** Outcome: **none of the three flags graduate** — a
+**new, deterministic certificate loss on `nvs22`, introduced by the density route
+itself**, surfaces at verdict 3 and fails all three arms (they all compose with the
+route). Details and root-cause below.
+
+## Build & method
+
+- **Build:** `maturin develop --release` in this worktree
+  (`agent-a045b99cdfea826ff`). Verified worktree-local:
+  `discopt.__file__ = …/agent-a045b99cdfea826ff/python/discopt/__init__.py`,
+  `discopt._rust.__file__ = …/python/discopt/_rust.cpython-312-darwin.so`.
+  `pounce-solver 0.7.0`, `jax 0.10.2`, `JAX_PLATFORMS=cpu`, `JAX_ENABLE_X64=1`.
+  Isolated subprocess per solve (env flags read fresh at import).
+- **Methodology:** the BR-3 / #581 house pattern. Shared all-OFF baseline; each
+  flag ON = *flag + `DISCOPT_LU_DENSITY_ROUTE=1`*. Two **independent** verdicts with
+  **different** held-out panels / conditions.
+- **Verdict 2:** 28-instance panel = BR-3's structure with a **different instance
+  draw**. Blocker probes kept (nvs21, st_e36, nvs09, alkyl, tls2); fresh
+  integer-NLP (nvs03/05/08/10/11/12/16/18), fresh QP/MIQP (st_miqp1/4/5, st_test2,
+  st_testgr1), fresh spatial/bilinear (ex5_2_2_case2, ex5_2_4, ex7_2_2, ex4_1_2,
+  ex4_1_8, ex8_1_1, st_bpaf1a), fresh tree (st_e29, st_e31, gbd). **TL = 40 s.**
+- **Verdict 3:** 35-instance **larger + longer** panel. Blockers kept; broader mix
+  including nvs14/20/22/01/04/06/13/15/23, st_miqp2/3/5, st_test2, meanvarx, alan,
+  ex5_2_2_case1, ex5_2_4, ex7_2_2/2_3, ex4_1_3/1_8/1_9, ex8_1_1/1_6, st_bpaf1a/1b,
+  st_e29/e31, gbd, gkocis. **TL = 60 s.**
+- **Criteria (per flag per verdict):** `incorrect_count = 0` (certified objective
+  vs oracle, abs 1e-4 / rel 1e-3, zero slack); **zero certificate losses** (OFF
+  optimal → ON non-optimal = hard fail); zero oracle crosses; objective drift ≤ abs
+  1e-4 / rel 1e-3; node-count delta (deterministic — the graded metric). A run that
+  never engages the flag is INCONCLUSIVE, not green.
+- **Oracle:** `~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu` (`=opt=`,
+  or the `[=bestdual=, =best=]` bracket). Full snapshot corpus
+  (`minlplib/nl/`, 4 830 instances) — not the in-repo 61-file subset.
+- **Concurrency hygiene (§0.7):** a co-tenant agent (arescue) shared the machine;
+  load avg ranged ≈ 3.5–11 during the runs. **All verdicts rest on deterministic
+  node counts / status / bound / objective, not wall time.** The nvs21 OFF baseline
+  reproduced byte-identically to BR-3 (195 n), and every liveness delta matched
+  BR-3 exactly (below), confirming the build and determinism. Wall times recorded
+  but used for **no** verdict.
+- **Artifacts:** `docs/dev/data/flag-graduation-verdicts23-2026-07-10/`
+  (per-arm JSON for v2 & v3, `liveness.json`, `nvs22_rootcause.json`, and the
+  harness `gate.py` / `verdict.py` / `liveness.py` / `solve_one.py`).
+
+## Flag-engagement proof (setup step 2 — each flag LIVE in THIS build)
+
+Every liveness delta matched BR-3's table exactly, confirming a correct,
+deterministic build before any measurement (`liveness.json`):
+
+| flag | probe | OFF | ON (flag alone) | engaged? |
+|---|---|---|---|---|
+| `DISCOPT_LU_DENSITY_ROUTE` | nvs21 | optimal 195 n | optimal **191 n** | **yes** |
+| `DISCOPT_OBJ_BRANCH_PRIORITY` | nvs01 | optimal 17 n | optimal **11 n** | **yes** |
+| `DISCOPT_OBJ_BRANCH_PRIORITY` | nvs13 | optimal 45 n | optimal **35 n** | **yes** |
+| `DISCOPT_LIFT_LOOSE_PRODUCTS` | nvs09 | feasible bnd −58.65 | feasible bnd **−47.06** | **yes** |
+
+Additional in-panel engagement proof for `lift_loose_products` (v2, nvs09): the
+route alone gives bound −58.73 / 159 n; **lift + route gives −45.78 / 117 n** — the
+tighter bound is the lift mechanism, not the route. TAIL-1 reproduces.
+
+## Verdict 2 (28 instances, TL = 40 s) — all three GREEN
+
+Shared OFF baseline: every certified objective matches the oracle; nvs21 195 n,
+st_e36 153 n, alkyl optimal 29 n (no square/route interaction here). nvs09, nvs05,
+tls2, ex5_2_2_case2, ex7_2_2, st_e31 are non-optimal at OFF (feasible/time_limit),
+so they cannot register a cert loss.
+
+| flag (ON = flag + route) | engaged? | incorrect | oracle-cross | cert-loss | node Δ (both-certified) | verdict |
+|---|:-:|:-:|:-:|:-:|---|---|
+| **lu_density_route** | yes | 0 | 0 | **0** | 1050 → 1046 (nvs21 195→191) | **GREEN** |
+| **obj_branch_priority** | yes | 0 | 0 | **0** (alkyl stays optimal 29 n) | 1050 → 1038 (nvs21 195→191, nvs18 105→97) | **GREEN** |
+| **lift_loose_products** | yes | 0 | 0 | **0** | 1050 → 1046 (nvs21 195→191); nvs09 bnd −58.65→−45.78, 191→117 n | **GREEN** |
+
+All three flags are green on verdict 2. No composition loss on this panel (the
+alkyl loss BR-3 saw was `square_cost_gate`×route, not tested here).
+
+## Verdict 3 (35 instances, TL = 60 s) — all three RED (nvs22 route cert loss)
+
+Shared OFF baseline: nvs22 solves **optimal, 35 n** (obj 6.05821994, bound
+6.058219999). All ON arms compose with the density route, and the route flips
+nvs22 to **feasible, 37 n**:
+
+| flag (ON = flag + route) | engaged? | incorrect | oracle-cross | cert-loss | node Δ (both-certified) | verdict |
+|---|:-:|:-:|:-:|---|---|---|
+| **lu_density_route** | yes | 0 | 0 | **1: nvs22** optimal→feasible | 1057 → 1055 (nvs21 195→191, nvs13 45→47) | **RED** |
+| **obj_branch_priority** | yes | 0 | 0 | **1: nvs22** optimal→feasible | 1057 → 1037 (nvs21 195→191, nvs01 17→11, nvs13 45→35) | **RED** |
+| **lift_loose_products** | yes | 0 | 0 | **1: nvs22** optimal→feasible | 1057 → 1055 (nvs21 195→191, nvs13 45→47) | **RED** |
+
+`incorrect_count = 0` and no oracle cross on every arm — the nvs22 answer is
+numerically correct. But **OFF optimal → ON non-optimal is a hard certificate loss
+(§0.1, zero slack)**, so all three arms fail verdict 3.
+
+Note the loss appears in the **`lu_density_route` (route-alone) arm** — it is the
+route's own behavior, inherited by the other two arms because they compose with the
+route. It is *distinct* from anything BR-3 saw: not the nvs21 loss the route
+**cured** (#591), not the `square_cost_gate`×route alkyl loss, not the
+`node_reduce` st_e36 loss.
+
+## Root-cause: the density route regresses nvs22 (new finding)
+
+Deterministic, isolated re-runs (`nvs22_rootcause.json`), 2–3 reps each,
+byte-identical:
+
+| nvs22 | route **OFF** | route **ON** |
+|---|---|---|
+| TL = 40 s | **optimal, 35 n**, bound 6.058219998999999 | **feasible, 37 n**, bound 6.0582199951512 |
+| TL = 60 s | **optimal, 35 n**, bound 6.058219998999999 | **feasible, 37 n**, bound 6.0582199951512 |
+
+**Not TL-sensitive** — route ON gives the identical `feasible, 37 n` result at both
+40 s and 60 s, so this is a **hard certificate loss, not a slower-certify** (which
+would *not* block graduation). The route changes the LU factorization path at nodes
+that qualify for the density-aware route (#557), which changes the node-LP
+solutions → a slightly different search tree (37 vs 35 nodes) whose **final dual
+bound never formally closes the gap**: route's bound 6.0582199951512 sits ~9.8e-9
+(relative) above its incumbent 6.0582199356118, so the solver terminates
+`feasible`; OFF's 35-node tree closes the same gap and terminates `optimal`. Both
+incumbents match the oracle 6.05822 to ~6e-8 (well within abs 1e-4). The certificate
+— not the answer — is lost.
+
+This is the same *class* as the nvs21 issue #591 targets (LU-route change perturbs
+the per-node LP and therefore the fathoming), but here the perturbation goes the
+**wrong** way: the retry that *rescued* nvs21's stuck bound *introduces* a
+non-closing tree on nvs22. It is a concrete, reproducible blocker that keeps the
+density route **opt-in**, and it blocks every flag that composes with the route.
+
+## Graduation outcome
+
+| flag | verdict 1 (BR-3) | verdict 2 | verdict 3 | consecutive greens | GRADUATE? |
+|---|:-:|:-:|:-:|:-:|:-:|
+| `DISCOPT_LU_DENSITY_ROUTE` | GREEN | GREEN | **RED (nvs22)** | 2 (broken) | **NO** |
+| `DISCOPT_OBJ_BRANCH_PRIORITY` | GREEN | GREEN | **RED (nvs22 via route)** | 2 (broken) | **NO** |
+| `DISCOPT_LIFT_LOOSE_PRODUCTS` | GREEN | GREEN | **RED (nvs22 via route)** | 2 (broken) | **NO** |
+
+**None of the three flags graduate.** Each reached 2 consecutive greens (BR-3
+verdict 1 + this verdict 2) but broke the streak at verdict 3 on the nvs22 route
+loss. T2.6 requires 3 **consecutive** greens; the count resets. **No default-ON
+flip is prepared or committed** — deliberately, because the shared composition
+(*flag + route*) is not clean on the verdict-3 panel.
+
+The obj_branch_priority and lift_loose_products flags are **not themselves** the
+cause of the verdict-3 failure (both are clean of new losses on their own; nvs22
+loses in the route-alone arm too). But because the graduation configuration under
+test is *flag + route* — and the route is the mechanism BR-3 required to cure the
+old blockers — a route regression blocks the composite. Any future re-gate of these
+two flags must either (a) first fix the density-route nvs22 regression, or (b)
+re-scope the composition.
+
+## Recommended next step (not done here)
+
+- **Entry experiment for the density-route nvs22 regression:** instrument which
+  nvs22 nodes take the density-aware route (#557) vs the historical dense-preferring
+  path, and why the route tree (37 n) fails to fathom the last open node that OFF
+  (35 n) fathoms. Kill criterion: if the route can be made to reproduce OFF's
+  fathoming on nvs22 without reintroducing the nvs21 stuck-bound (#591), the route
+  becomes a clean graduation candidate again and this verdict can be re-run. Until
+  then the density route — and therefore all three composed flags — stays opt-in.
+
+## Verification for the PR
+
+- `import discopt._rust` verified worktree-local (setup step 1).
+- Every flag proven LIVE against BR-3's exact liveness numbers (setup step 2).
+- Verdict data + oracle-checked analysis committed under
+  `docs/dev/data/flag-graduation-verdicts23-2026-07-10/`.
+- No solver math changed (docs + data only); no defaults flipped.


### PR DESCRIPTION
## Flag graduation — verdicts 2 & 3 (follow-on to BR-3 #602)

Ran graduation **verdicts 2 and 3** (two independent held-out gate runs) for the
three flags BR-3 (`docs/dev/br3-regate-2026-07-10.md`) found GRADUATE-ELIGIBLE at
**verdict 1/3**, each composed with `DISCOPT_LU_DENSITY_ROUTE=1` (the #591 dense
retry). Per T2.6, a bound-changing flag needs **3 consecutive green verdicts**
before any default-ON flip.

**Outcome: none of the three flags graduate.** A **new, deterministic certificate
loss on `nvs22`, introduced by the density route itself**, surfaces at verdict 3
and fails all three arms (they all compose with the route). No default-ON flip is
prepared — deliberately.

### Per-flag verdicts

| flag (ON = flag + route) | v1 (BR-3) | v2 (28-inst, 40s) | v3 (35-inst, 60s) | consecutive greens | GRADUATE? |
|---|:-:|:-:|:-:|:-:|:-:|
| `DISCOPT_LU_DENSITY_ROUTE` | GREEN | GREEN | **RED (nvs22)** | 2 (broken) | **NO** |
| `DISCOPT_OBJ_BRANCH_PRIORITY` | GREEN | GREEN | **RED (nvs22 via route)** | 2 (broken) | **NO** |
| `DISCOPT_LIFT_LOOSE_PRODUCTS` | GREEN | GREEN | **RED (nvs22 via route)** | 2 (broken) | **NO** |

- **Verdict 2 (all GREEN):** `incorrect_count=0`, 0 oracle-cross, **0 cert-loss** on
  every arm; each flag engaged (nvs21 195->191; obj_branch_priority also nvs18
  105->97; lift tightens nvs09 bound -58.65->-45.78 / 191->117 n — the lift
  mechanism, not the route). alkyl stayed optimal 29 n (no composition loss here).
- **Verdict 3 (all RED):** nvs22 OFF optimal (35 n) -> route feasible (37 n).
  `incorrect_count=0` and no oracle cross — the answer is correct — but OFF
  optimal -> ON non-optimal is a hard certificate loss (§0.1, zero slack).

### Root-cause: the density route regresses nvs22 (new finding)

Deterministic isolated re-runs (2-3 reps each, byte-identical):

| nvs22 | route **OFF** | route **ON** |
|---|---|---|
| TL = 40 s | **optimal, 35 n**, bound 6.058219998999999 | **feasible, 37 n**, bound 6.0582199951512 |
| TL = 60 s | **optimal, 35 n**, bound 6.058219998999999 | **feasible, 37 n**, bound 6.0582199951512 |

**Not TL-sensitive** (identical at 40 s and 60 s) -> a hard cert loss, not a
slower-certify. The route changes the LU factorization path -> different node-LP
solutions -> a 37-node tree whose final dual bound (6.0582199951512) never formally
closes the gap against its incumbent (6.0582199356118, rel gap ~9.8e-9); OFF's
35-node tree does close it. Both incumbents match the oracle 6.05822 to ~6e-8.

This is *distinct* from the nvs21 loss the route **cures** (#591), from BR-3's
`square_cost_gate`x route alkyl loss, and from `node_reduce`/st_e36. It appears in
the **route-alone** arm and is inherited by the other two arms via composition. It
is the concrete blocker that keeps the density route (and every flag composing with
it) **opt-in**.

### Recommended next step (not done here)

Entry experiment: instrument which nvs22 nodes take the density-aware route (#557)
and why the route tree fails to fathom the last open node OFF fathoms. Kill
criterion: if the route reproduces OFF's fathoming on nvs22 without reintroducing
the nvs21 stuck-bound (#591), it becomes a clean graduation candidate again.

### Verification

- `maturin develop --release` in this worktree; `import discopt._rust` verified
  worktree-local.
- Every flag proven LIVE against BR-3's exact liveness numbers before measuring.
- `pytest -m smoke` -> **641 passed, 13 skipped**; adversarial suite
  (`test_adversarial_recent_fixes.py -m slow`) -> **10 passed**.
- No solver math changed (docs + data only); **no defaults flipped**. No Rust
  touched, so `cargo test` not required (build compiled clean).
- Deterministic node counts / status / bound used for all verdicts; wall times
  recorded but used for none (co-tenant agent shared the machine, load ~3.5-11).

**Do not merge** — this is a measured verdict; the flags do not graduate.

Full writeup + per-arm JSON, liveness, nvs22 root-cause, and the harness:
`docs/dev/flag-graduation-verdicts23-2026-07-10.md` and
`docs/dev/data/flag-graduation-verdicts23-2026-07-10/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
