### PR TITLE
cert:T2.5 — scored top-k OBBT + de-gate (flag default-OFF); entry experiment KILLs it as a bound lever

### DIFF
--- a/discopt_benchmarks/scripts/t25_obbt_topk_entry.py
+++ b/discopt_benchmarks/scripts/t25_obbt_topk_entry.py
@@ -1,0 +1,115 @@
+"""cert:T2.5 ENTRY EXPERIMENT — scored top-k per-node OBBT de-gate ON vs OFF.
+
+Measures, per instance (casctanks, tanksize, nvs05 + two mid-size spatial NLPs):
+whether per-node OBBT now RUNS on n>100 models with the ``DISCOPT_OBBT_TOPK``
+flag, and whether the certified dual bound climbs / node count drops. Distinguishes
+three outcomes the task asks us to separate:
+
+  * OBBT-ran?     -> solver_stats["reduce/obbt"] > 0 (per-node OBBT consumed wall)
+  * bound moved?  -> certified bound / root bound ON vs OFF
+  * net wall win? -> wall ON vs OFF (noisy on a shared box; reported, not gated)
+
+Run in the isolated worktree venv:
+    JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 \
+      python discopt_benchmarks/scripts/t25_obbt_topk_entry.py
+"""
+
+from __future__ import annotations
+
+import os
+import os.path as osp
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+
+SNAP = osp.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+TL = float(os.environ.get("T25_TL", "60"))
+
+# (stem, oracle) — oracle is =opt= where known, else =best= (primal) for a
+# sanity floor; the soundness check that matters is "certified bound <= oracle".
+INSTANCES = [
+    ("casctanks", 9.1634793880),
+    ("tanksize", 1.2686437540),
+    ("nvs05", 5.4709341080),
+    ("ex8_3_7", -1.2326191910),
+    ("ex8_3_13", -43.0894781500),
+]
+
+
+def _solve(stem: str, topk_on: bool):
+    if topk_on:
+        os.environ["DISCOPT_OBBT_TOPK"] = "1"
+    else:
+        os.environ.pop("DISCOPT_OBBT_TOPK", None)
+    m = dm.from_nl(osp.join(SNAP, f"{stem}.nl"))
+    nvars = sum(v.size for v in m._variables)
+    t0 = time.perf_counter()
+    r = m.solve(time_limit=TL)
+    wall = time.perf_counter() - t0
+    stats = getattr(r, "solver_stats", None) or {}
+    obbt_wall = float(stats.get("reduce/obbt", 0.0))
+    return {
+        "nvars": nvars,
+        "status": str(getattr(r, "status", "?")),
+        "obj": getattr(r, "objective", None),
+        "bound": getattr(r, "bound", None),
+        "root_bound": getattr(r, "root_bound", None),
+        "nodes": getattr(r, "node_count", None),
+        "obbt_ran": obbt_wall > 0.0,
+        "obbt_wall": obbt_wall,
+        "wall": wall,
+    }
+
+
+def _fmt(v, w=12, p=6):
+    if v is None:
+        return f"{'—':>{w}}"
+    if isinstance(v, bool):
+        return f"{('YES' if v else 'no'):>{w}}"
+    if isinstance(v, float):
+        return f"{v:>{w}.{p}f}"
+    return f"{str(v):>{w}}"
+
+
+def main() -> int:
+    print(f"T2.5 entry experiment — TL={TL}s, top_k per-node OBBT ON vs OFF\n")
+    rows = []
+    for stem, oracle in INSTANCES:
+        if not osp.isfile(osp.join(SNAP, f"{stem}.nl")):
+            print(f"[skip] {stem}: not in snapshot")
+            continue
+        off = _solve(stem, topk_on=False)
+        on = _solve(stem, topk_on=True)
+        rows.append((stem, oracle, off, on))
+        print(f"=== {stem} (n={off['nvars']}, oracle={oracle}) ===")
+        print(f"  {'':16s}{'OFF':>14s}{'ON':>14s}")
+        print(f"  {'obbt_ran':16s}{_fmt(off['obbt_ran'], 14)}{_fmt(on['obbt_ran'], 14)}")
+        print(
+            f"  {'obbt_wall(s)':16s}{_fmt(off['obbt_wall'], 14, 3)}{_fmt(on['obbt_wall'], 14, 3)}"
+        )
+        print(f"  {'cert_bound':16s}{_fmt(off['bound'], 14)}{_fmt(on['bound'], 14)}")
+        print(f"  {'root_bound':16s}{_fmt(off['root_bound'], 14)}{_fmt(on['root_bound'], 14)}")
+        print(f"  {'obj':16s}{_fmt(off['obj'], 14)}{_fmt(on['obj'], 14)}")
+        print(f"  {'nodes':16s}{_fmt(off['nodes'], 14)}{_fmt(on['nodes'], 14)}")
+        print(f"  {'status':16s}{_fmt(off['status'], 14)}{_fmt(on['status'], 14)}")
+        print(f"  {'wall(s)':16s}{_fmt(off['wall'], 14, 2)}{_fmt(on['wall'], 14, 2)}")
+        print()
+
+    # Soundness: certified bound must never cross the oracle (min sense: bound <= oracle+tol).
+    print("=== SOUNDNESS (certified bound must be <= oracle for min sense) ===")
+    bad = 0
+    for stem, oracle, off, on in rows:
+        for label, res in (("OFF", off), ("ON", on)):
+            b = res["bound"]
+            if b is not None and b > oracle + 1e-4 * (1 + abs(oracle)):
+                print(f"  VIOLATION {stem} {label}: bound {b} > oracle {oracle}")
+                bad += 1
+    print(f"  bound-crossing violations: {bad}")
+    return 0 if bad == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -126,7 +126,7 @@ experiment may run.
 | T2.2 OBBT persistent LP + warm probes | (a)+(b) done; (c) skipped | #406 | Per-sweep CSC built once + warm-primal probes (t14 patch applied). Differential **NEUTRAL** (warm==cold ≤4.3e-12, tightenings identical, cert-neutrality NEUTRAL). Root-OBBT umbrella: ex1252a 1.54×, ex1252 1.89×, st_e38 1.92×. ex1252a < 2× → residual is the JAX envelope rebuild (Phase 4/5), not the LP loop. See the T2.2-DONE block below |
 | T2.3 root fixpoint loop | **built — flagged default-OFF** (R2) | (this PR) | `_jax/root_reduce.py::run_root_fixpoint` {S2 cutoff-FBBT, S3 cutoff-OBBT}, integrated at end of iteration 0 (solver.py); tighten-only intersection, ≤2 rounds, ≈10% budget; `root_fixpoint`/`DISCOPT_ROOT_FIXPOINT` OFF. No-offtarget gate + cut-pool re-capture opt-in only. Flag-OFF cert-baseline **NEUTRAL** (41/41 node_count exact, Δobj 0). Node A/B: wastewater04m2 479→159 (root). See §14 "R2 build-results" |
 | T2.4 per-node `reduce_node()` | **built — flagged default-OFF** (R2) | (this PR) | T2.4a marginals on `MccormickLPResult` (bound-neutral, additive `dual`/`col_status`/`safe_bound`/`reduced_costs`); T2.4b `_jax/node_reduce.py::reduce_node` (cutoff-FBBT + free DBBT z=safe_bound + integer RC-fixing); T2.4c `PyTreeManager.set_node_bounds` feeds child boxes. `node_reduce`/`DISCOPT_NODE_REDUCE` OFF. 200-box property test green. See §14 "R2 build-results" |
-| T2.5 OBBT escalation policy | **UNLOCKED** (T2.1-revisit GO) → R2 | — | build per §14 spec (width×\|RC\| top-k scoring) |
+| T2.5 OBBT escalation policy | **BUILT → KILL** (2026-07-11; mechanism sound, flag-gated default-OFF) | `p2/obbt-topk-scoring` | width×\|RC\| top-k scoring + `DISCOPT_OBBT_TOPK` de-gate: OBBT now RUNS on casctanks (n=500)/ex8_3_13, but bound is flat/WORSE and net wall is negative (kill-crit b). Mechanism kept for a targeted-budget revisit; do NOT flip default. See "T2.5 — RESULTS / VERDICT (2026-07-11)" |
 | T2.6 cert2 gate wiring + default-on | **moot** (T2.3–T2.5 not built) | — | residual gap re-scoped to Phases 3–4 |
 | Phase 3 entry experiment (0b) | done — GO on c-MIR **(SUPERSEDED by CUT-1, 2026-07-06 → NO-GO)** | (prior) | SCIP root-bound *proxy* (`scripts/p3_0b_scip_rootbound.py`): median root gap closed discopt 0.0 vs SCIP 1.0 over 8 (graphpart/ex1263/fac). CUT-1 replaced the proxy with a direct injection of SCIP's actual c-MIR cut coefficients into discopt's LP + a real-relaxation measurement; on nvs17/19/24 discopt's *default* root already closes 99.9% (≥ SCIP's cut-root), and injected cuts close ≤1.8%. See §7 "0b RESULTS / VERDICT (2026-07-03)" and "CUT-1 …(2026-07-06)" |
 | Phase 3 1c reachability entry experiment | done — **NO-GO / re-scope** | #(prior) | Cuts made reachable+armed close ~0% (median gap-closed 0.000, best +0.55% on ex1263a) vs SCIP ~1.0. Residual is separator DEPTH, not plumbing. Do NOT build the Rust cut-callback seam yet. See §7 "Phase 3 1c" |
@@ -2532,6 +2532,60 @@ calibration table here; no per-class forks, no named-instance tuning.
   regression ≤ 1.05; the previously-gated class (`_dependent_var_names`
   instances) must not regress in node_count when the class gate is removed;
   `incorrect = 0`.
+
+**T2.5 — RESULTS / VERDICT (2026-07-11): KILL the de-gate as a bound lever
+(the scoring + de-gate MECHANISM is built, sound, and flag-gated default-OFF;
+it does NOT pay off).** Branch `p2/obbt-topk-scoring` (PR pending). Built the
+`width × |reduced cost|` top-k scoring (`run_obbt_on_relaxation(top_k=…)`,
+`obbt_tighten_root(top_k=…)`) and the `DISCOPT_OBBT_TOPK` de-gate that lets
+per-node OBBT run above the `_PER_NODE_OBBT_MAX_VARS=100` cap on the
+`_dependent_var_names` structural class. Reduced costs come from one extra
+objective LP (the DBBT LP); selection changes *which* vars are probed, never the
+NS-safe soundness of each tightening.
+
+- **Entry experiment** (casctanks n=500, tanksize n=47, nvs05 n=8, ex8_3_7 n=126,
+  ex8_3_13 n=115; TL=60 then 120; isolated release build):
+
+  | instance | OBBT-ran OFF→ON | cert bound OFF→ON | nodes OFF→ON | obbt wall ON | net |
+  |---|---|---|---|---|---|
+  | casctanks (TL60) | no→**YES** | 1.3523→1.3523 (=) | 103→25 | 36.9 s | bound flat |
+  | casctanks (TL120)| no→**YES** | **1.8023→1.3523 (WORSE)** | 211→75 | 73.8 s | **net-negative** |
+  | ex8_3_13 (TL120) | no→**YES** | −100.0→−100.0 (=) | 757→443 | 44.9 s | flat, wasted cost |
+  | tanksize | no→no | 0.8680 (=) | 551→555 | 0 | flag inert (no dep-vars) |
+  | nvs05 | no→no | 1.3521 (=) | 781→771 | 0 | flag inert (small+no dep) |
+  | ex8_3_7 | no→no | — (no LP bound; x0/x1 obj) | 1→1 | 0 | n/a |
+
+  Distinguishing the three outcomes the kill criterion demands:
+  **(1) OBBT now RUNS** on the de-gated large instances (casctanks/ex8_3_13
+  YES) — F12's size-gate disabler is genuinely cleared and top-k+budget bounds the
+  cost (casctanks 359 s/node uncapped → ≤37–74 s total). **(2) The bound does NOT
+  improve** — byte-identical on every de-gated instance, and on casctanks TL=120
+  it is *weaker* (1.352 vs 1.802) because ≥60 % of the budget goes to per-node
+  OBBT instead of the tree exploration that actually lifts the global frontier
+  bound. Node count drops (local fathoming) but the weakest open node — which sets
+  the dual bound — is not lifted faster. **(3) Net wall is negative.** Leaning the
+  config (k=8/frac=0.2 → still 1.352; k=5/frac=0.15 → matches 1.802 but wastes
+  19 s) does not flip it — best case is bound-neutral with pure overhead.
+
+- **KILL criterion (b) FIRES:** "the per-node cost even with top-k+budget is
+  net-negative on wall." Consistent with the T2.1-revisit record — casctanks is in
+  the OBBT-resistant/marginal class (8 % root-gap reduction; "does not crack the
+  hard uncertified tail"). Per-node OBBT's local box-tightening does not translate
+  into a better *global* dual bound on this class, and the budget it consumes would
+  raise the bound faster if spent on B&B.
+
+- **Soundness:** entry panel + 4 new correctness unit tests
+  (`test_obbt_topk_scoring.py`) + smoke (642 passed) + adversarial (10 passed) all
+  green; **0 bound-crossing violations**, no oracle cross. `top_k=None` /
+  flag-OFF is byte-identical to the legacy all-columns sweep (locked by
+  `test_topk_none_is_byte_identical_to_legacy`), so the machinery is inert at rest.
+
+- **Disposition:** the scoring + de-gate machinery ships flag-gated **default-OFF**
+  (mechanism is correct and cheap to keep for a future *targeted-budget* revisit —
+  e.g. a bound-conditioned trigger that only spends OBBT when it demonstrably lifts
+  the frontier). **T2.5 is NOT a bound win; do not flip the default.** The residual
+  large-model certification gap is re-scoped to Phases 3–4 (cuts/structure), which
+  the T2.1-revisit already flagged as the levers for the hard tail.
 
 **T2.6 — Gate wiring, nightlies, default-on (last).**
 1. `benchmarks.toml`: add `[suites.global50]`

--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -951,6 +951,7 @@ def run_obbt_on_relaxation(
     deadline: Optional[float] = None,
     prefer_pounce: bool = False,
     full_result: bool = False,
+    top_k: Optional[int] = None,
 ) -> ObbtResult:
     """OBBT over the LP relaxation of a MILP relaxation envelope.
 
@@ -989,6 +990,19 @@ def run_obbt_on_relaxation(
         Used by the OBBT-on-aux diagnostic (#208) to *capture* the tightening of
         the lifted (product/ratio) aux columns that the default path discards.
         Does not change the default (``False``) behavior for solve-path callers.
+    top_k : int, optional
+        When set, run OBBT only on the ``top_k`` most promising candidate
+        columns instead of every candidate in index order (T2.5). Candidates are
+        ranked by the standard ``bound-width × |reduced cost|`` heuristic: a wide
+        variable with a large marginal is where a min/max probe pays. Reduced
+        costs come from a single extra objective LP over the same relaxation
+        polytope (the DBBT LP); if no dual-exposing oracle is available the score
+        degrades to width alone. Selecting *which* variables to tighten never
+        changes the soundness of each tightening (every probe is still NS-safe),
+        only the number of probes — so this is a pure affordability lever that
+        lets per-node OBBT engage on large (n > 100) spatial models that the
+        all-columns sweep made too expensive to run. ``None`` (default) keeps the
+        legacy all-candidates-in-index-order behavior byte-for-byte.
     """
     import time as _time
 
@@ -1086,6 +1100,54 @@ def run_obbt_on_relaxation(
     n_tightened = 0
     total_lp_time = 0.0
     warm_basis = None
+
+    # T2.5 candidate scoring: when ``top_k`` is set, rank candidates by the
+    # standard ``width × |reduced cost|`` heuristic and probe only the top-k. A
+    # single objective LP over the (equilibrated) polytope yields the reduced
+    # costs; the marginal |d_i| says how strongly the relaxation objective pushes
+    # x_i against a bound, and width says how much room there is to shrink — their
+    # product is where a min/max probe pays. This selects *which* variables to
+    # tighten, never *how* (each surviving probe is still NS-safe below), so the
+    # subset is a pure affordability lever with no soundness effect. Without a
+    # dual-exposing oracle the score degrades to width alone (still far better
+    # than index order for the same budget). The scoring LP time is folded into
+    # ``total_lp_time`` so the budget accounting stays honest.
+    if top_k is not None and 0 <= top_k < len(candidate_idxs):
+        width_arr = ub_arr - lb_arr
+        rc = None
+        if c_obj is not None:
+            try:
+                _score_res = _lp(
+                    c=np.asarray(c_obj, dtype=np.float64),
+                    A_ub=A_ub,
+                    b_ub=b_ub,
+                    bounds=[(float(lb_arr[i]), float(ub_arr[i])) for i in range(n_total)],
+                    time_limit=time_limit_per_lp,
+                )
+                total_lp_time += getattr(_score_res, "wall_time", 0.0) or 0.0
+                n_lp_solves += 1
+                if _score_res.status == SolveStatus.OPTIMAL:
+                    _rc = getattr(_score_res, "reduced_costs", None)
+                    if _rc is not None:
+                        rc = np.asarray(_rc, dtype=np.float64)
+            except Exception:
+                rc = None
+
+        def _score(i: int) -> float:
+            w = float(width_arr[i]) if np.isfinite(width_arr[i]) else 0.0
+            if w <= min_width:
+                return 0.0
+            if rc is not None and i < rc.shape[0] and np.isfinite(rc[i]):
+                return w * abs(float(rc[i]))
+            # No reduced cost for this column: fall back to width, but rank it
+            # below any RC-scored candidate of comparable width so scored ones win
+            # the budget. Width alone is still a sound, sensible ordering.
+            return w if rc is None else 0.0
+
+        # Stable top-k: sort by descending score, keep index order among ties so
+        # the selection is deterministic (byte-reproducible verdicts).
+        ranked = sorted(candidate_idxs, key=lambda i: (-_score(i), i))
+        candidate_idxs = ranked[:top_k]
 
     def _bounds_list() -> list[tuple[float, float]]:
         return [(float(lb_arr[i]), float(ub_arr[i])) for i in range(n_total)]
@@ -1779,6 +1841,7 @@ def obbt_tighten_root(
     superposition: bool = False,
     prefer_pounce: bool = False,
     cascade_aux: bool = False,
+    top_k: Optional[int] = None,
 ) -> RootObbtResult:
     """Structural root OBBT over the LP-form McCormick relaxation.
 
@@ -1828,6 +1891,12 @@ def obbt_tighten_root(
         reduction and slightly regressed one instance (nvs13 39→53 nodes), so it
         does not meet #208's "the extra OBBT cost must pay for itself" bar yet. It
         is kept available behind this flag for a future targeted-budget A/B.
+    top_k : int, optional
+        Forwarded to :func:`run_obbt_on_relaxation` — probe only the ``top_k``
+        highest ``width × |reduced cost|`` variables per sweep instead of all
+        original columns (T2.5). This bounds the per-sweep probe count so per-node
+        OBBT stays affordable on large spatial models; soundness of each surviving
+        tightening is unchanged. ``None`` keeps the all-columns behavior.
     """
     from discopt.modeling.core import VarType
 
@@ -2007,6 +2076,10 @@ def obbt_tighten_root(
                 deadline=deadline,
                 prefer_pounce=prefer_pounce,
                 full_result=cascade_aux,
+                # T2.5: probe only the top-k width×|RC| candidates when requested.
+                # Not combined with the aux-cascade candidate set (all columns) —
+                # cascade is a diagnostic path with its own full-column contract.
+                top_k=None if cascade_aux else top_k,
             )
             total_lp_time += res.total_lp_time
             n_rounds += 1

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -235,6 +235,25 @@ _PER_NODE_OBBT_BUDGET_FRAC = 0.6
 _PER_NODE_OBBT_PER_NODE_S = 3.0
 _PER_NODE_OBBT_PER_LP_S = 0.3
 _PER_NODE_OBBT_ROUNDS = 3
+# T2.5 (flag-gated, default OFF): scored top-k OBBT de-gate. BARON/SCIP reduce at
+# every node but affordably, by scoring variables and probing only the most
+# promising ones. discopt's per-node OBBT probes all columns in index order —
+# O(n) LPs/node — so it is size-gated off at n>_PER_NODE_OBBT_MAX_VARS, which
+# skips large stall-class spatial models entirely (casctanks n=560 never runs
+# per-node OBBT; F12). With ``DISCOPT_OBBT_TOPK=1`` the gate instead runs OBBT on
+# the top-k ``width × |reduced cost|`` variables for models above the size cap,
+# bounding the per-sweep probe count so the existing per-node/cumulative budgets
+# can hold. Selecting *which* variables to tighten is a pure affordability lever;
+# every surviving tightening is still NS-safe (soundness unchanged). Default OFF
+# until the differential + panel gates are green on consecutive nightlies.
+_PER_NODE_OBBT_TOPK = 20
+
+
+def _obbt_topk_enabled() -> bool:
+    """Whether the T2.5 scored top-k OBBT de-gate is on (env flag, default OFF)."""
+    return os.environ.get("DISCOPT_OBBT_TOPK", "").strip().lower() in ("1", "true", "yes", "on")
+
+
 # Root branch-and-reduce fixpoint (cert:T2.3) no-offtarget gate: skip the loop when
 # the relative gap between the root dual bound and the incumbent cutoff is at/below
 # this — an already-tight root has nothing to close, so running it would only add
@@ -5687,21 +5706,31 @@ def solve_model(
     # certifies the welded-beam (nvs05) class; together they do (~23 nodes).
     # A cumulative time budget caps total cost so a deep tree can never let
     # per-node OBBT dominate wall clock.
-    _per_node_obbt_enabled = (
-        _mc_lp_relaxer is not None
-        and bool(_dependent_var_names)
-        and n_vars <= _PER_NODE_OBBT_MAX_VARS
+    _pn_obbt_structural = _mc_lp_relaxer is not None and bool(_dependent_var_names)
+    _pn_obbt_small = _pn_obbt_structural and n_vars <= _PER_NODE_OBBT_MAX_VARS
+    # T2.5 de-gate: with the scored top-k flag on, the same structural class runs
+    # per-node OBBT above the size cap too — but only on the top-k
+    # ``width × |reduced cost|`` variables, so the per-sweep probe count is bounded
+    # (O(top_k) LPs/node instead of O(n_vars)) and the existing per-node /
+    # cumulative budgets can cap wall. Below the cap we keep the legacy
+    # all-columns behavior byte-for-byte (top_k stays None) so the flag is inert
+    # on the already-certifying small class.
+    _pn_obbt_degated = (
+        _pn_obbt_structural and n_vars > _PER_NODE_OBBT_MAX_VARS and _obbt_topk_enabled()
     )
+    _per_node_obbt_enabled = _pn_obbt_small or _pn_obbt_degated
+    _pn_obbt_topk = _PER_NODE_OBBT_TOPK if _pn_obbt_degated else None
     _pn_obbt_spent = 0.0
     _pn_obbt_budget_total = time_limit * _PER_NODE_OBBT_BUDGET_FRAC
     if _per_node_obbt_enabled:
         from discopt._jax.obbt import obbt_tighten_root
 
         logger.debug(
-            "per-node OBBT enabled (n_vars=%d, dependent=%d, budget=%.1fs)",
+            "per-node OBBT enabled (n_vars=%d, dependent=%d, budget=%.1fs, top_k=%s)",
             n_vars,
             len(_dependent_var_names),
             _pn_obbt_budget_total,
+            _pn_obbt_topk,
         )
 
     # --- Per-node cheap reduction (cert:T2.4b, flag default OFF) ---
@@ -6104,6 +6133,7 @@ def solve_model(
                         deadline=_t_pn + _PER_NODE_OBBT_PER_NODE_S,
                         time_limit_per_lp=_PER_NODE_OBBT_PER_LP_S,
                         prefer_pounce=nlp_solver == "pounce",
+                        top_k=_pn_obbt_topk,
                     )
                 except Exception as _pn_exc:  # pragma: no cover - defensive
                     logger.debug("per-node OBBT failed: %s", _pn_exc)

--- a/python/tests/test_obbt_topk_scoring.py
+++ b/python/tests/test_obbt_topk_scoring.py
@@ -1,0 +1,174 @@
+"""cert:T2.5 — scored top-k OBBT candidate selection (flag-gated de-gate).
+
+The T2.5 lever ranks OBBT candidate variables by ``width × |reduced cost|`` and
+probes only the top-k, so per-node OBBT stays affordable on large spatial models
+that the all-columns-index-order sweep made too expensive (F12: casctanks n=560
+was size-gated off entirely). This is a *selection* lever: it changes WHICH
+variables get a min/max probe, never the soundness of each tightening (every
+surviving probe is still clamped to the Neumaier–Shcherbina safe bound).
+
+These tests lock the two properties that make it safe:
+
+  1. **Subset soundness / differential** — the tightening top-k produces on a
+     given column is identical to what the full sweep produces on that column
+     (same LP oracle, same box), and the top-k box is always a superset-or-equal
+     of the full box (top-k tightens a subset of variables, so it can only be
+     looser, never tighter — hence it can never cut a point the full sweep kept).
+  2. **No valid point cut (feasible-point sampling)** — a point feasible for the
+     original model, inside the input box, is never excluded by the top-k box.
+  3. **Cert-neutrality** — ``top_k=None`` (and, on the solve path, the flag OFF)
+     reproduces the legacy all-columns behavior bit-for-bit.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+import pytest
+from discopt._jax.obbt import run_obbt_on_relaxation
+from discopt.modeling.core import Model
+
+
+def _build_relaxation(model: Model):
+    from discopt._jax.discretization import initialize_partitions
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    terms = classify_nonlinear_terms(model)
+    state = initialize_partitions([], lb=[], ub=[], n_init=2)
+    milp, _ = build_milp_relaxation(model, terms, state, incumbent=None)
+    return milp
+
+
+def _spatial_model() -> Model:
+    """A small nonconvex spatial model with several bilinear terms.
+
+    Enough columns (originals + lifted aux) that top-k < n is a real subset, and
+    a linear objective so the scoring LP yields non-trivial reduced costs.
+    """
+    m = Model("topk_spatial")
+    xs = [m.continuous(f"x{i}", lb=-2.0, ub=3.0) for i in range(5)]
+    m.subject_to(xs[0] * xs[1] + xs[2] * xs[3] <= 4.0)
+    m.subject_to(xs[1] * xs[4] >= -3.0)
+    m.subject_to(xs[0] * xs[4] + xs[2] <= 5.0)
+    m.subject_to(sum(xs) <= 6.0)
+    m.subject_to(sum(xs) >= -6.0)
+    m.minimize(xs[0] - xs[3] + xs[4])
+    return m
+
+
+def _n_orig(model: Model) -> int:
+    return sum(v.size for v in model._variables)
+
+
+@pytest.mark.correctness
+def test_topk_none_is_byte_identical_to_legacy():
+    """``top_k=None`` reproduces the all-columns sweep exactly (cert-neutral)."""
+    m = _spatial_model()
+    n = _n_orig(m)
+    for cutoff in (None, 10.0, 2.0):
+        legacy = run_obbt_on_relaxation(
+            _build_relaxation(m), n_orig=n, incumbent_cutoff=cutoff, time_limit_per_lp=5.0
+        )
+        again = run_obbt_on_relaxation(
+            _build_relaxation(m),
+            n_orig=n,
+            incumbent_cutoff=cutoff,
+            time_limit_per_lp=5.0,
+            top_k=None,
+        )
+        assert np.array_equal(legacy.tightened_lb, again.tightened_lb)
+        assert np.array_equal(legacy.tightened_ub, again.tightened_ub)
+        assert legacy.n_tightened == again.n_tightened
+
+
+@pytest.mark.correctness
+def test_topk_box_is_superset_of_full_box():
+    """Top-k tightens a subset of columns → its box contains the full-sweep box.
+
+    A looser box can never exclude a point the tighter (full) box kept, so this
+    is the differential 'no worse than full' guarantee for the selection lever.
+    """
+    m = _spatial_model()
+    n = _n_orig(m)
+    for cutoff in (None, 10.0):
+        full = run_obbt_on_relaxation(
+            _build_relaxation(m), n_orig=n, incumbent_cutoff=cutoff, time_limit_per_lp=5.0
+        )
+        for k in (1, 2, 3):
+            topk = run_obbt_on_relaxation(
+                _build_relaxation(m),
+                n_orig=n,
+                incumbent_cutoff=cutoff,
+                time_limit_per_lp=5.0,
+                top_k=k,
+            )
+            # top-k box ⊇ full box: lb never above full's lb, ub never below.
+            assert np.all(topk.tightened_lb <= full.tightened_lb + 1e-9)
+            assert np.all(topk.tightened_ub >= full.tightened_ub - 1e-9)
+            # And top-k never tightens more variables than the full sweep.
+            assert topk.n_tightened <= full.n_tightened
+
+
+@pytest.mark.correctness
+def test_topk_does_not_cut_a_feasible_point():
+    """A model-feasible point inside the input box survives the top-k box."""
+    m = _spatial_model()
+    n = _n_orig(m)
+    # Sample feasible points by rejection over the input box.
+    rng = np.random.default_rng(0)
+    lb0 = np.array([-2.0] * 5)
+    ub0 = np.array([3.0] * 5)
+
+    def _feasible(x):
+        return (
+            x[0] * x[1] + x[2] * x[3] <= 4.0 + 1e-9
+            and x[1] * x[4] >= -3.0 - 1e-9
+            and x[0] * x[4] + x[2] <= 5.0 + 1e-9
+            and -6.0 - 1e-9 <= x.sum() <= 6.0 + 1e-9
+        )
+
+    pts = []
+    while len(pts) < 200 and len(pts) < 100000:
+        x = rng.uniform(lb0, ub0)
+        if _feasible(x):
+            pts.append(x)
+        if len(pts) == 0 and rng.random() < 1e-6:
+            break
+    assert pts, "no feasible sample drawn"
+
+    for k in (1, 2, 3):
+        res = run_obbt_on_relaxation(
+            _build_relaxation(m), n_orig=n, incumbent_cutoff=None, time_limit_per_lp=5.0, top_k=k
+        )
+        for x in pts:
+            assert np.all(x >= res.tightened_lb[:5] - 1e-6)
+            assert np.all(x <= res.tightened_ub[:5] + 1e-6)
+
+
+@pytest.mark.correctness
+def test_topk_zero_and_oversize_are_safe():
+    """``top_k=0`` probes nothing (no tightening); ``top_k>=n`` == full sweep."""
+    m = _spatial_model()
+    n = _n_orig(m)
+    z = run_obbt_on_relaxation(
+        _build_relaxation(m), n_orig=n, incumbent_cutoff=None, time_limit_per_lp=5.0, top_k=0
+    )
+    assert z.n_tightened == 0
+    full = run_obbt_on_relaxation(
+        _build_relaxation(m), n_orig=n, incumbent_cutoff=None, time_limit_per_lp=5.0
+    )
+    big = run_obbt_on_relaxation(
+        _build_relaxation(m),
+        n_orig=n,
+        incumbent_cutoff=None,
+        time_limit_per_lp=5.0,
+        top_k=10_000,
+    )
+    # top_k >= number of candidates falls through to the full candidate set.
+    assert np.array_equal(big.tightened_lb, full.tightened_lb)
+    assert np.array_equal(big.tightened_ub, full.tightened_ub)


### PR DESCRIPTION
## cert:T2.5 — scored top-k OBBT + de-gate (flag default-OFF). Entry experiment: **KILL** as a bound lever.

Builds the T2.5 spec (`docs/dev/certification-gap-plan.md §14`): rank per-node OBBT candidates by `width × |reduced cost|` and probe only the top-k, and add a `DISCOPT_OBBT_TOPK` flag (default **OFF**) that de-gates per-node OBBT above the `_PER_NODE_OBBT_MAX_VARS=100` size cap for the `_dependent_var_names` structural class. This targets the F12 disabler: casctanks (n=560/500) was size-gated **off** entirely because the all-columns-index-order sweep was too expensive (359 s/node uncapped).

### What was built
- `run_obbt_on_relaxation(top_k=…)` — one extra objective LP (the DBBT LP) yields reduced costs; candidates ranked by `width × |RC|`, only the top-k probed. Selecting *which* variables to tighten never changes the NS-safe soundness of each tightening. `top_k=None` is byte-identical to the legacy sweep.
- `obbt_tighten_root(top_k=…)` forwards it; `solver.py` de-gate passes `_PER_NODE_OBBT_TOPK=20` only when the flag is on and `n > cap`.

### Entry experiment (casctanks, tanksize, nvs05, ex8_3_7, ex8_3_13; TL=60/120; isolated release build)

| instance | OBBT-ran OFF→ON | cert bound OFF→ON | nodes OFF→ON | obbt wall ON | net |
|---|---|---|---|---|---|
| casctanks (TL60) | no→**YES** | 1.3523→1.3523 (=) | 103→25 | 36.9 s | bound flat |
| casctanks (TL120)| no→**YES** | **1.8023→1.3523 (WORSE)** | 211→75 | 73.8 s | **net-negative** |
| ex8_3_13 (TL120) | no→**YES** | −100.0→−100.0 (=) | 757→443 | 44.9 s | flat, wasted cost |
| tanksize | no→no | 0.8680 (=) | 551→555 | 0 | flag inert (no dep-vars) |
| nvs05 | no→no | 1.3521 (=) | 781→771 | 0 | flag inert (small+no dep) |
| ex8_3_7 | no→no | — (no LP bound) | 1→1 | 0 | n/a |

**Distinguishing the three outcomes (as the kill criterion requires):**
1. **OBBT now RUNS** on the de-gated large instances (casctanks/ex8_3_13 YES) — F12's size-gate disabler is genuinely cleared and top-k+budget bounds the cost (359 s/node → ≤37–74 s total).
2. **The bound does NOT improve** — byte-identical on every de-gated instance, and on casctanks TL=120 it is *weaker* (1.352 vs 1.802) because ≥60 % of the budget goes to per-node OBBT instead of the tree exploration that actually lifts the global frontier bound. Node count drops (local fathoming) but the weakest open node — which sets the dual bound — is not lifted faster.
3. **Net wall is negative.** Leaning the config (k=8/frac=0.2 → still 1.352; k=5/frac=0.15 → matches 1.802 but wastes 19 s) does not flip it.

**KILL criterion (b) fires:** the per-node cost even with top-k+budget is net-negative. Consistent with the T2.1-revisit record — casctanks is OBBT-resistant/marginal (8 % root-gap reduction; "does not crack the hard uncertified tail").

### Disposition
The scoring + de-gate machinery ships **flag-gated, default-OFF** (correct and cheap to keep for a future *targeted-budget* revisit — a bound-conditioned trigger that only spends OBBT when it demonstrably lifts the frontier). **Do NOT flip the default.** Residual large-model gap re-scoped to Phases 3–4. Falsification recorded in gap-plan §14 T2.5.

### Gates (all green)
- `test_obbt_topk_scoring.py` — 4 new correctness tests (subset-soundness/differential, feasible-point sampling, top_k=None byte-identity, zero/oversize) pass.
- `pytest -m smoke` — **642 passed**, 14 skipped.
- `pytest -m slow test_adversarial_recent_fixes.py` — **10 passed**.
- OBBT/cert soundness suite flag-ON — **68 passed**.
- 21-instance panel flag-ON — **incorrect_count = 0**, no oracle cross.
- Cert-neutrality: flag-OFF / `top_k=None` byte-identical (locked by `test_topk_none_is_byte_identical_to_legacy`).
- No Rust touched (`cargo test` N/A). Wall numbers on a shared box (#616 CI + concurrent work) — deterministic metrics (bound/nodes/obbt-ran) drive the verdict, not wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
