### PR TITLE
fix(amp): size per-iteration MILP budget by expected horizon, not max_iter cap

### DIFF
--- a/python/discopt/solvers/amp.py
+++ b/python/discopt/solvers/amp.py
@@ -1047,13 +1047,41 @@ def _check_constraints_with_evaluator(
         return False
 
 
+# Realistic horizon for how many AMP refinement rounds remain, used to size the
+# per-iteration MILP budget. AMP converges in a handful of rounds (single digits
+# to low tens on the MINLPTESTS/adversarial corpus), so the MILP budget should be
+# an even split of the remaining wall over *that* horizon — not over the rarely
+# reached ``max_iter`` cap. Splitting by a large cap (e.g. ``max_iter=1000``)
+# starves every early iteration to a fraction of a second, below the fixed cost of
+# building and XLA-compiling one refined relaxation on a cold interpreter, so the
+# loop makes no progress and the solve burns its whole wall without certifying.
+_AMP_EXPECTED_ITER_HORIZON = 32
+
+
 def _default_milp_time_limit(
     remaining: float,
     iteration: int,
     max_iter: int,
 ) -> float:
-    """Allocate a bounded MILP budget from the remaining AMP wall time."""
-    iter_budget = remaining / max(1, max_iter - iteration + 1)
+    """Allocate a bounded MILP budget from the remaining AMP wall time.
+
+    The budget is an even split of the wall still available over the number of
+    iterations we actually *expect* to run (``_AMP_EXPECTED_ITER_HORIZON``),
+    capped by the true iterations-left when that is smaller. Dividing by the full
+    ``max_iter`` cap instead under-budgets early iterations pathologically: with
+    ``max_iter=1000`` and 300 s remaining each MILP would get ~0.9 s, which on a
+    cold/slow interpreter is less than the one-time cost of building and compiling
+    the refined MILP envelope. Each iteration then accomplishes nothing and the
+    AMP solve returns ``feasible`` instead of ``optimal`` despite having ample
+    wall left (observed on the 2-core CI runner: nlp_004_010, time_limit=300,
+    max_iter=1000). This is a pure *time-allocation* ceiling — ``remaining`` is
+    recomputed every iteration and the outer AMP deadline still hard-caps total
+    spend, so raising it never changes a certificate, only lets a slow MILP solve
+    finish (yielding an equal-or-tighter valid lower bound) instead of being cut
+    off mid-compile.
+    """
+    horizon = min(max(1, max_iter - iteration + 1), _AMP_EXPECTED_ITER_HORIZON)
+    iter_budget = remaining / horizon
     return min(iter_budget * 3, remaining * 0.8, 60.0)
 
 

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -801,6 +801,43 @@ def test_amp_small_helpers_cover_aliases_gaps_and_pruning():
     assert cuts == ["keep1", "keep2"]
 
 
+def test_default_milp_time_limit_not_starved_by_large_max_iter():
+    """Regression: a large ``max_iter`` must not starve early MILP budgets.
+
+    AMP converges in a handful of refinement rounds, but ``max_iter`` is a large
+    safety cap (callers routinely pass 1000). The per-iteration MILP budget must
+    be split over the *expected* iteration horizon, not the full cap — otherwise
+    each early MILP is handed a fraction of a second, below the fixed cost of
+    building and XLA-compiling one refined relaxation on a cold interpreter, and
+    the solve burns its whole wall without certifying (returns ``feasible``
+    instead of ``optimal`` on the 2-core CI runner: nlp_004_010, time_limit=300).
+
+    The old code (`remaining / (max_iter - iteration + 1)` then `* 3`) gave
+    ``min(0.9, ...) == 0.9`` s here; the fix must hand out a workable budget.
+    """
+    from discopt.solvers import amp as amp_mod
+
+    # Large max_iter, plenty of wall left → budget must reflect the ~tens of
+    # iterations we actually expect, not the 1000 cap. Old behaviour was 0.9 s.
+    budget = amp_mod._default_milp_time_limit(remaining=300.0, iteration=1, max_iter=1000)
+    assert budget >= 5.0, f"per-iter MILP budget starved to {budget}s by large max_iter"
+
+    # Horizon-bounded: never exceeds the remaining*0.8 and 60 s ceilings.
+    assert budget <= 60.0
+    assert budget <= 300.0 * 0.8
+
+    # Backward-compatible for small caps (unchanged pre-fix contract, line 783).
+    assert amp_mod._default_milp_time_limit(remaining=10.0, iteration=1, max_iter=5) == 6.0
+
+    # When the true iterations-left is smaller than the horizon, it governs:
+    # near the cap the remaining wall is split over the few rounds that remain.
+    near_end = amp_mod._default_milp_time_limit(remaining=100.0, iteration=999, max_iter=1000)
+    assert near_end == pytest.approx(min(100.0 / 2 * 3, 100.0 * 0.8, 60.0))
+
+    # Tiny remaining wall is still respected (never budgets more than 80% of it).
+    assert amp_mod._default_milp_time_limit(remaining=0.5, iteration=1, max_iter=1000) <= 0.5 * 0.8
+
+
 def test_amp_constraint_helpers_cover_success_and_failure(caplog):
     """Constraint helper failures should reject points instead of accepting them."""
     from discopt.solvers import amp as amp_mod


### PR DESCRIPTION
## The recurring AMP-integration failure, root-caused

On every push to `main` the AMP integration workflow fails on
`test_amp_certifies_tan_abs_nlp_004_010_at_issue_gap` with
`AssertionError: assert 'feasible' == 'optimal'`. We've fixed the *symptoms*
several times (memory, timeouts) and it kept coming back. This PR fixes the
actual cause.

### Root cause: per-iteration MILP budget starved by the `max_iter` cap

The AMP loop sizes each iteration's MILP-relaxation solve with
`_default_milp_time_limit(remaining, iteration, max_iter)`:

```
iter_budget = remaining / (max_iter - iteration + 1)   # then *3, capped at min(remaining*0.8, 60)
```

The cert tests pass **`max_iter=1000`**. So at iteration 1 with 300 s of wall
left, each MILP got `min(0.9, 240, 60) = 0.9 s` — even though AMP converges in
**~7 rounds** and the whole 300 s is available. The divisor is the rarely-reached
safety cap, not the handful of iterations actually run.

- **Warm dev machine:** 0.9 s is plenty. `nlp_004_010` certifies `optimal` in 0.75 s.
- **Cold 2-core CI runner:** building + XLA-compiling one refined MILP envelope
  costs **more than 0.9 s**. Every iteration is starved below its own fixed
  compile cost → no progress → the solve burns its whole 300 s wall and returns
  `feasible`.

The tell that this is variance around a marginal budget, not a code regression:
`c2493bad` **passed** and `242dd0b` **failed** on this exact test with identical
AMP-path code (only #618 — a flag-default-OFF OBBT change that never touches the
AMP driver — merged between them). The two integer variants that ran right after
it in the same single-process step *passed* — because the first test had already
warmed XLA; they reused the compiled kernels while the first test ate the cold
cost.

Prior de-flake work (#607 xdist, #608 isolation + `--timeout=900`) fixed the
memory/timeout crash mode but never touched the thing that is actually marginal:
**the per-MILP solve budget.** This is that fix.

### The fix

Split the remaining wall over the iteration horizon we actually expect
(`_AMP_EXPECTED_ITER_HORIZON = 32`), capped by the true iterations-left when
smaller:

| call | old | new |
|---|---|---|
| iter 1, `max_iter=1000`, 300 s left | **0.9 s** | **28.1 s** |
| iter 1, `max_iter=5`, 10 s left | 6.0 s | 6.0 s (unchanged) |
| near cap (iters-left=2), 100 s left | 60 s | 60 s (true iters-left governs) |
| tiny wall 0.5 s | ≤0.4 s | ≤0.4 s (`remaining*0.8` still caps) |

This is a pure time-**allocation** ceiling. `remaining` is recomputed every
iteration and the outer AMP deadline still hard-caps total spend, so it **never
changes a certificate** — it only lets a slow MILP finish (yielding an
equal-or-tighter *valid* lower bound) instead of being cut off mid-compile. On
warm hardware the ceiling never binds: same 7 iterations, same objective, 0.94 s.
No soundness surface is touched.

### Verification
- **New regression test** `test_default_milp_time_limit_not_starved_by_large_max_iter`
  — fails on old code (0.9 < 5.0), passes on new (28.1).
- The **exact CI-failing** cert test + integer variants + full `test_amp.py`: **136 passed**.
- `pytest -m smoke`: **645 passed, 1 skipped**.
- Adversarial `test_adversarial_recent_fixes.py -m slow`: **10 passed**.
- `ruff check` / `ruff format --check`: clean. No Rust touched.
- The AMP integration workflow runs on this PR (labeled `amp-integration`) — the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
