### PR TITLE
cert:LR-2 — univariate-composite + positive-product envelopes (nvs09 root cert)

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -4154,7 +4154,7 @@ def _collect_aliased_monomial_hull_relaxations(
                 pts = np.tile(base_x, (len(xarr), 1))
                 pts[:, _fi] = xarr
                 hv = np.asarray(_fb(jnp.asarray(pts))).ravel()
-                return hv**_pw  # G(x) = h(x)**p
+                return np.asarray(hv**_pw, dtype=np.float64)  # G(x) = h(x)**p
 
             hull = univariate_hull_envelope(lo, hi, value_batch)
             env_cache[ckey] = hull

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3541,7 +3541,36 @@ def _composite_referenced_var(expr: Expression, model: Model) -> Optional[tuple[
     return var, _compute_var_offset(var, model)
 
 
-def _should_claim_composite(expr: Expression, model: Model, n_orig: int) -> bool:
+def _univariate_envelope_enabled() -> bool:
+    """H-UNI feature flag (``DISCOPT_UNIVARIATE_ENVELOPE``, default **OFF**).
+
+    Task ``cert:LR-2`` (``docs/dev/lever-a-root-tightness-plan.md`` §4). When ON,
+    a maximal single-variable subtree whose certified curvature is *neither*
+    convex nor concave is lifted with the exact 1-D convex/concave hull envelope
+    (:mod:`discopt._jax.univariate_hull`) instead of falling to a looser composed
+    relaxation. Default-OFF makes the flag-OFF relaxation byte-identical to prior
+    main (bound-changing regime, parent-plan §0.4).
+    """
+    return os.environ.get("DISCOPT_UNIVARIATE_ENVELOPE", "0") != "0"
+
+
+def _log_monomial_enabled() -> bool:
+    """H-LOG feature flag (``DISCOPT_LOG_MONOMIAL``, default **OFF**).
+
+    Task ``cert:LR-2`` — the narrow positive-product piece F16 left alive
+    (``docs/dev/lever-a-root-tightness-plan.md`` §7; ``docs/dev/lr0-logspace-entry``).
+    Scoped to a **positive product** ``∏ xᵢ^{aᵢ}`` (every factor lb > 0 on the
+    FBBT-tightened box): the log-space relaxation ``zᵢ = ln xᵢ`` (exact concave
+    envelope), ``s = Σ aᵢ zᵢ`` (linear), ``t = exp(s)`` (exact convex envelope) is
+    far tighter than recursive McCormick for wide boxes. Default-OFF; when OFF the
+    relaxation is byte-identical to prior main.
+    """
+    return os.environ.get("DISCOPT_LOG_MONOMIAL", "0") != "0"
+
+
+def _should_claim_composite(
+    expr: Expression, model: Model, n_orig: int, allow_general: bool = False
+) -> bool:
     """True when ``expr`` is a nonlinear node the *existing* machinery cannot lift.
 
     The bilinear/monomial/fractional-power/univariate-of-affine builders already
@@ -3556,6 +3585,15 @@ def _should_claim_composite(expr: Expression, model: Model, n_orig: int) -> bool
       stay on the dedicated square lift.  Non-affine integer-power bases are
       only claimed here; they still need certified curvature before any
       envelope is emitted.
+
+    When ``allow_general`` (H-UNI, ``DISCOPT_UNIVARIATE_ENVELOPE``), *additionally*
+    claim single-variable additive/square composites that the standard path lifts
+    only via a *composed* (looser) relaxation — a ``**2`` of a non-bare base, or a
+    ``+``/``-`` sum of single-variable nonlinear terms — so the exact 1-D hull
+    envelope can replace the composition. The curvature-free hull builder in
+    :func:`_collect_composite_univariate_relaxations` handles these even when they
+    are neither convex nor concave; claiming here only *offers* the node, the
+    collector still abstains (falls back unchanged) if a rigorous hull can't form.
     """
     if isinstance(expr, FunctionCall) and len(expr.args) == 1:
         op_info = _univariate_arg(expr)
@@ -3573,8 +3611,44 @@ def _should_claim_composite(expr: Expression, model: Model, n_orig: int) -> bool
         if _get_flat_index(expr.left, model) is not None:
             return False
         if p == int(p):
-            return int(p) >= 3
+            if int(p) >= 3:
+                return True
+            # Integer square of a non-bare base: normally the dedicated square
+            # lift (a composed relaxation). Under H-UNI, claim it here so the
+            # exact 1-D hull can lift the whole single-variable square directly.
+            if allow_general and int(p) == 2:
+                return True
+            return False
         return True
+    if allow_general and isinstance(expr, BinaryOp) and expr.op in ("+", "-"):
+        # A maximal single-variable additive composite (e.g. nvs09's
+        # ``(ln(x-2))**2 + (ln(10-x))**2``). Claim only if it genuinely contains a
+        # nonlinear single-variable sub-term the composition would relax loosely;
+        # a purely affine sum is left to the exact linear path.
+        if _composite_referenced_var(expr, model) is None:
+            return False
+        return _expr_has_nonlinear_subterm(expr)
+    return False
+
+
+def _expr_has_nonlinear_subterm(expr: Expression) -> bool:
+    """True if ``expr`` contains a FunctionCall or a non-unit power — i.e. it is
+    not a pure affine combination (which the exact linear path already handles)."""
+    if isinstance(expr, FunctionCall):
+        return True
+    if isinstance(expr, BinaryOp):
+        if expr.op == "**":
+            return True
+        if expr.op == "*":
+            # nonlinear unless one side is constant
+            if not (isinstance(expr.left, Constant) or isinstance(expr.right, Constant)):
+                return True
+            return _expr_has_nonlinear_subterm(expr.left) or _expr_has_nonlinear_subterm(expr.right)
+        if expr.op in ("+", "-"):
+            return _expr_has_nonlinear_subterm(expr.left) or _expr_has_nonlinear_subterm(expr.right)
+        return True  # "/" and other ops are nonlinear
+    if isinstance(expr, UnaryOp):
+        return _expr_has_nonlinear_subterm(expr.operand)
     return False
 
 
@@ -3832,30 +3906,37 @@ def _collect_composite_univariate_relaxations(
 
     box = _build_convexity_box(model, flat_lb, flat_ub)
     base_x = np.zeros(n_orig, dtype=np.float64)
+    allow_general = _univariate_envelope_enabled()
 
-    def maybe_add(expr: Expression) -> None:
+    def maybe_add(expr: Expression) -> bool:
+        """Attempt to lift ``expr`` as a composite. Returns True when it was
+        claimed *as a general single-variable hull composite* (a ``**2``/``+``
+        node the standard path would relax only via composition) — in that case
+        ``visit`` must not descend and re-lift the sub-terms. Convex/concave
+        claims return False so descent is unchanged from prior main (byte-identity
+        when the flag is OFF)."""
         nonlocal col_idx
         eid = id(expr)
         if eid in seen or eid in claimed_ids:
-            return
-        if not _should_claim_composite(expr, model, n_orig):
-            return
+            return False
+        if not _should_claim_composite(expr, model, n_orig, allow_general=allow_general):
+            return False
+        # Is this node claimable by the *pre-existing* (curvature-certified) path?
+        # If so, treat it exactly as before (claim, but let visit descend).
+        _pre_existing_claim = _should_claim_composite(expr, model, n_orig, allow_general=False)
         ref = _composite_referenced_var(expr, model)
         if ref is None:
-            return
+            return False
         var, flat_idx = ref
         lo = float(flat_lb[flat_idx])
         hi = float(flat_ub[flat_idx])
         if not (np.isfinite(lo) and np.isfinite(hi)) or hi < lo:
-            return
-        curvature = _composite_curvature(expr, model, var, flat_idx, lo, hi, box)
-        if curvature is None:
-            return
+            return False
         try:
             f = compile_expression(expr, model)
             grad_f = jax.grad(lambda xv: jnp.reshape(f(xv), ()))
         except Exception:
-            return
+            return False
 
         def value_fn(t: float) -> float:
             x = jnp.asarray(base_x).at[flat_idx].set(t)
@@ -3865,10 +3946,40 @@ def _collect_composite_univariate_relaxations(
             x = jnp.asarray(base_x).at[flat_idx].set(t)
             return float(np.asarray(grad_f(x)).ravel()[flat_idx])
 
-        env = _composite_envelope(curvature, lo, hi, value_fn, grad_fn)
-        if env is None:
-            return
-        lower_lines, upper_lines, pin_value, col_bounds = env
+        curvature = _composite_curvature(expr, model, var, flat_idx, lo, hi, box)
+        if curvature is not None:
+            env = _composite_envelope(curvature, lo, hi, value_fn, grad_fn)
+            if env is None:
+                return False
+            lower_lines, upper_lines, pin_value, col_bounds = env
+        elif allow_general:
+            # H-UNI: curvature is neither convex nor concave. Build the exact 1-D
+            # convex/concave hull envelope (curvature-free, rigorous). Abstain
+            # (fall back) if a proven-tight hull can't form.
+            from discopt._jax.univariate_hull import univariate_hull_envelope
+
+            if hi - lo <= _COMPOSITE_CURV_TOL:
+                return False  # pinned — the exact-pin path handles it
+
+            f_batched = jax.vmap(lambda xv: jnp.reshape(f(xv), ()))
+
+            def value_batch(xarr: np.ndarray) -> np.ndarray:
+                # Evaluate f at many x values in one vmapped JAX call (the sole
+                # variable is flat_idx; all other coordinates are irrelevant to a
+                # single-var composite, so the zero base row is fine).
+                pts = np.tile(base_x, (len(xarr), 1))
+                pts[:, flat_idx] = xarr
+                return np.asarray(f_batched(jnp.asarray(pts))).ravel()
+
+            hull = univariate_hull_envelope(lo, hi, value_batch)
+            if hull is None:
+                return False
+            lower_lines, upper_lines, col_bounds = hull
+            pin_value = None
+            curvature = "general"
+        else:
+            return False
+
         seen.add(eid)
         var_map[eid] = col_idx
         relaxations.append(
@@ -3886,9 +3997,15 @@ def _collect_composite_univariate_relaxations(
         )
         bounds.append(col_bounds)
         col_idx += 1
+        # Only a *new* general (non-pre-existing) claim blocks descent; a
+        # convex/concave claim behaves exactly as prior main (descent continues).
+        return not _pre_existing_claim
 
     def visit(expr: Expression) -> None:
-        maybe_add(expr)
+        if maybe_add(expr):
+            # Claimed as a whole general single-variable composite; do not descend
+            # and re-lift its sub-terms (that would double-count the objective).
+            return
         if isinstance(expr, BinaryOp):
             visit(expr.left)
             visit(expr.right)
@@ -3912,6 +4029,227 @@ def _collect_composite_univariate_relaxations(
         visit(constraint.body)
 
     return relaxations, var_map, bounds
+
+
+def _alias_equality_defs(model: Model) -> dict[int, Expression]:
+    """Map an aux column index to the expression it equals via an ``aux == h``
+    equality constraint (the form ``factorable_reform`` emits: ``w - h == 0``).
+
+    Only equalities of the exact shape ``Variable(aux) - h == 0`` (or ``h -
+    Variable(aux) == 0``) with ``rhs == 0`` are recognised, so the alias is
+    unambiguous. Used by the H-UNI/H-LOG lifts to relax the *aux's* nonlinear
+    uses against the underlying ``h`` when the reform has split the structure
+    (e.g. nvs09's ``(ln(x-2))**2`` becomes ``aux == ln(x-2)`` + objective
+    ``aux**2``). Structure-only — no instance names.
+    """
+    defs: dict[int, Expression] = {}
+    for con in model._constraints:
+        if con.sense != "==" or abs(float(con.rhs)) > 1e-12:
+            continue
+        body = con.body
+        if not (isinstance(body, BinaryOp) and body.op == "-"):
+            continue
+        left, right = body.left, body.right
+        # aux - h == 0  (aux is a bare variable/index)
+        aux_idx = _get_flat_index(left, model)
+        other = right
+        if aux_idx is None:
+            aux_idx = _get_flat_index(right, model)
+            other = left
+        if aux_idx is None:
+            continue
+        # ``other`` must be genuinely nonlinear (an affine alias is already exact).
+        if not _expr_has_nonlinear_subterm(other):
+            continue
+        # First definition wins; a variable defined by two equalities is ambiguous.
+        defs.setdefault(aux_idx, other)
+    return defs
+
+
+_CACHE_MISS = object()  # sentinel: distinguishes "absent" from a cached ``None`` (abstain)
+
+
+def _collect_aliased_monomial_hull_relaxations(
+    model: Model,
+    n_orig: int,
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+    monomial_var_map: dict[tuple[int, int], int],
+) -> list[CompositeUnivariateRelaxation]:
+    """H-UNI on reform-split composites: tighten ``aux**p`` where ``aux == h(x)``.
+
+    Task ``cert:LR-2``. ``factorable_reform`` rewrites a single-variable composite
+    ``(ln(x-2))**2`` into an aux equality ``aux == ln(x-2)`` plus an objective
+    monomial ``aux**2`` — the *composed* relaxation the plan calls loose (each
+    ``aux`` floats freely, so ``aux**2`` can reach 0). Here we bind the **existing**
+    ``aux**p`` monomial column directly to the original variable ``x`` with the
+    exact 1-D hull of ``G(x) = h(x)**p`` (:mod:`discopt._jax.univariate_hull`),
+    which is a rigorous *additional* tightening — never removed rows, so soundness
+    of the base relaxation is untouched. Gated by ``DISCOPT_UNIVARIATE_ENVELOPE``.
+
+    Emits ``CompositeUnivariateRelaxation`` records whose ``aux_col`` is the
+    monomial column ``(aux_idx, p)`` and whose lines are in ``x``; the standard
+    composite-emission loop turns them into rows. No new columns are created.
+    """
+    out: list[CompositeUnivariateRelaxation] = []
+    if not monomial_var_map:
+        return out
+    defs = _alias_equality_defs(model)
+    if not defs:
+        return out
+
+    try:
+        import jax
+        import jax.numpy as jnp
+
+        from discopt._jax.dag_compiler import compile_expression
+        from discopt._jax.univariate_hull import univariate_hull_envelope
+    except Exception:
+        return out
+
+    base_x = np.zeros(n_orig, dtype=np.float64)
+    # Caches scoped to *this* model instance (attributes, not module globals), so a
+    # freed model's expression ids can never be reused to serve a stale envelope to
+    # a different model. Persist across the per-node relaxation rebuilds of one
+    # solve, where the alias expression objects and their ids are stable.
+    batch_cache: dict[int, Callable] = model.__dict__.setdefault("_lr2_alias_batch_cache", {})
+    env_cache: dict = model.__dict__.setdefault("_lr2_alias_env_cache", {})
+    for (aux_idx, p), aux_col in monomial_var_map.items():
+        h = defs.get(aux_idx)
+        if h is None:
+            continue
+        ref = _composite_referenced_var(h, model)
+        if ref is None:
+            continue  # h must be a single ORIGINAL variable's function
+        var, flat_idx = ref
+        if flat_idx >= n_orig:
+            continue
+        lo = float(flat_lb[flat_idx])
+        hi = float(flat_ub[flat_idx])
+        if not (np.isfinite(lo) and np.isfinite(hi)) or hi - lo <= _COMPOSITE_CURV_TOL:
+            continue
+        # Compiling + vmapping the alias body is the expensive step; cache the
+        # traced batch evaluator across nodes (the box changes per node, but the
+        # function of x does not). Keyed by the stable alias-expression identity.
+        f_batched = batch_cache.get(id(h))
+        if f_batched is None:
+            try:
+                f = compile_expression(h, model)
+                f_batched = jax.vmap(lambda xv, _f=f: jnp.reshape(_f(xv), ()))
+            except Exception:
+                continue
+            batch_cache[id(h)] = f_batched
+
+        pw = float(p)
+
+        # Envelope is a function of (alias, exponent, box); cache on the box so
+        # nodes that did not branch this variable reuse the root envelope instead
+        # of re-sampling. Box key rounded to a tight grid (well below any envelope
+        # sensitivity) so float jitter does not defeat the cache.
+        ckey = (id(h), int(p), round(lo, 12), round(hi, 12))
+        hull = env_cache.get(ckey, _CACHE_MISS)
+        if hull is _CACHE_MISS:
+
+            def value_batch(xarr: np.ndarray, _fb=f_batched, _fi=flat_idx, _pw=pw) -> np.ndarray:
+                pts = np.tile(base_x, (len(xarr), 1))
+                pts[:, _fi] = xarr
+                hv = np.asarray(_fb(jnp.asarray(pts))).ravel()
+                return hv**_pw  # G(x) = h(x)**p
+
+            hull = univariate_hull_envelope(lo, hi, value_batch)
+            env_cache[ckey] = hull
+        if hull is None:
+            continue
+        lower_lines, upper_lines, _col_bounds = hull
+        out.append(
+            CompositeUnivariateRelaxation(
+                expr_id=-aux_col,  # synthetic id; not consulted for these rows
+                aux_col=aux_col,
+                var_idx=flat_idx,
+                curvature="general",
+                arg_lb=lo,
+                arg_ub=hi,
+                lower_lines=lower_lines,
+                upper_lines=upper_lines,
+                pin_value=None,
+            )
+        )
+    return out
+
+
+@dataclass
+class LogMonomialRelaxation:
+    """Log-space envelope of a positive product ``t == coef·∏ xᵢ^{aᵢ}`` (H-LOG).
+
+    Task ``cert:LR-2``. Binds an existing product column ``t_col`` (the reform's
+    ``aux == ∏xᵢ`` alias) to the original factor columns through log space:
+
+    * ``zᵢ = ln xᵢ`` — concave, so tangents overestimate and the endpoint secant
+      underestimates (a rigorous outer band on each ``zᵢ`` column).
+    * ``s = Σ aᵢ zᵢ`` — exact linear equality.
+    * ``t = coef·exp(s)`` — convex, so tangents underestimate and the secant
+      overestimates (a rigorous band binding ``t_col``).
+
+    All envelopes are recomputed per node box from ``factor_boxes``/``s_lb,s_ub``;
+    strict positivity of every factor is a hard precondition checked on the
+    node box (no epsilon shift). Purely additive rows + fresh z/s columns.
+    """
+
+    t_col: int
+    coef: float
+    z_cols: tuple[int, ...]           # one ln-column per distinct factor
+    factor_cols: tuple[int, ...]      # the original variable column of each factor
+    factor_exps: tuple[float, ...]    # exponent aᵢ (aligned with z_cols/factor_cols)
+    factor_boxes: tuple[tuple[float, float], ...]
+    s_col: int
+    s_lb: float
+    s_ub: float
+
+
+def _extract_positive_product(
+    expr: Expression, model: Model, n_orig: int, flat_lb: np.ndarray, flat_ub: np.ndarray
+) -> Optional[tuple[float, dict[int, float]]]:
+    """Return ``(coef, {orig_var_idx: exponent})`` if ``expr`` is a product/power of
+    strictly-positive original variables, else ``None``.
+
+    Strict positivity (lb > 0 on the node box) is required for every factor — the
+    log lift is undefined otherwise — and is the H-LOG precondition (no epsilon
+    shift). Only *original* variables (index < ``n_orig``) are accepted as factors.
+    """
+    factors: dict[int, float] = {}
+    coef = [1.0]
+
+    def visit(e: Expression, power: float) -> bool:
+        if isinstance(e, Constant):
+            v = float(e.value)
+            if v <= 0.0:
+                return False  # a non-positive constant factor breaks the log lift
+            coef[0] *= v**power
+            return True
+        idx = _get_flat_index(e, model)
+        if idx is not None:
+            if idx >= n_orig:
+                return False
+            lo = float(flat_lb[idx])
+            if not (lo > 1e-9) or not np.isfinite(lo):
+                return False  # strict-positivity precondition (no epsilon shift)
+            factors[idx] = factors.get(idx, 0.0) + power
+            return True
+        if isinstance(e, BinaryOp):
+            if e.op == "*":
+                return visit(e.left, power) and visit(e.right, power)
+            if e.op == "/":
+                return visit(e.left, power) and visit(e.right, -power)
+            if e.op == "**" and isinstance(e.right, Constant):
+                return visit(e.left, power * float(e.right.value))
+            return False
+        return False
+
+    if not visit(expr, 1.0):
+        return None
+    if not factors:
+        return None
+    return coef[0], factors
 
 
 def _referenced_flat_indices(expr: Expression, model: Model) -> list[int]:
@@ -5545,6 +5883,82 @@ def build_milp_relaxation(
         all_bounds.append(val_bounds)
         integrality_flags.append(0)
         col_idx += 1
+
+    # H-UNI (LR-2): tighten reform-split composites ``aux**p`` (aux == h(x)) with
+    # the exact 1-D hull of ``h(x)**p`` bound directly to the existing monomial
+    # column. Additive rows only, no new columns; default-OFF flag.
+    aliased_hull_relaxations: list[CompositeUnivariateRelaxation] = []
+    if _univariate_envelope_enabled():
+        aliased_hull_relaxations = _collect_aliased_monomial_hull_relaxations(
+            model, n_orig, flat_lb, flat_ub, monomial_var_map
+        )
+
+    # H-LOG (LR-2): log-space envelope of positive-product aliases ``aux == ∏xᵢ``.
+    # Allocates a ln-column per distinct factor + one s-column per product, then
+    # binds the existing product column ``aux`` through ``t = exp(s)``. Fresh
+    # columns + additive rows; default-OFF flag.
+    log_monomial_relaxations: list[LogMonomialRelaxation] = []
+    if _log_monomial_enabled():
+        _log_defs = _alias_equality_defs(model)
+        _z_col_of: dict[int, int] = {}  # distinct factor var idx -> its ln column
+        for _aux_idx, _h in _log_defs.items():
+            _aux_col = _aux_idx  # aux is an original/primary column (index == flat idx)
+            if _aux_idx >= n_orig:
+                continue
+            _pp = _extract_positive_product(_h, model, n_orig, flat_lb, flat_ub)
+            if _pp is None:
+                continue
+            _coef, _facs = _pp
+            if len(_facs) < 2:
+                continue  # a single positive power is already a monomial column
+            _z_cols: list[int] = []
+            _f_cols: list[int] = []
+            _f_exps: list[float] = []
+            _f_boxes: list[tuple[float, float]] = []
+            _s_lb = 0.0
+            _s_ub = 0.0
+            _ok = True
+            for _fi, _exp in sorted(_facs.items()):
+                _flo = float(flat_lb[_fi])
+                _fhi = float(flat_ub[_fi])
+                if not (_flo > 1e-9 and np.isfinite(_flo) and np.isfinite(_fhi) and _fhi >= _flo):
+                    _ok = False
+                    break
+                _zc = _z_col_of.get(_fi)
+                if _zc is None:
+                    _zc = col_idx
+                    all_bounds.append((math.log(_flo), math.log(_fhi)))
+                    integrality_flags.append(0)
+                    col_idx += 1
+                    _z_col_of[_fi] = _zc
+                _z_cols.append(_zc)
+                _f_cols.append(_fi)
+                _f_exps.append(float(_exp))
+                _f_boxes.append((_flo, _fhi))
+                # s = Σ aᵢ ln xᵢ range over the box (aᵢ may be negative)
+                _lo_term = _exp * (math.log(_flo) if _exp > 0 else math.log(_fhi))
+                _hi_term = _exp * (math.log(_fhi) if _exp > 0 else math.log(_flo))
+                _s_lb += _lo_term
+                _s_ub += _hi_term
+            if not _ok:
+                continue
+            _s_col = col_idx
+            all_bounds.append((_s_lb, _s_ub))
+            integrality_flags.append(0)
+            col_idx += 1
+            log_monomial_relaxations.append(
+                LogMonomialRelaxation(
+                    t_col=_aux_col,
+                    coef=float(_coef),
+                    z_cols=tuple(_z_cols),
+                    factor_cols=tuple(_f_cols),
+                    factor_exps=tuple(_f_exps),
+                    factor_boxes=tuple(_f_boxes),
+                    s_col=_s_col,
+                    s_lb=float(_s_lb),
+                    s_ub=float(_s_ub),
+                )
+            )
 
     # Multivariate convex/concave composite nodes (Euclidean distance / norm,
     # other DCP-certified multivariate functions) lifted by supporting-hyperplane
@@ -7623,7 +8037,7 @@ def build_milp_relaxation(
     # z is the aux column for f(x_i); each (slope, intercept) line is in x_i.
     # lower_lines give ``z ≥ slope·x_i + intercept`` and upper_lines give
     # ``z ≤ slope·x_i + intercept``. A pinned variable yields an exact equality.
-    for crelax in composite_relaxations:
+    for crelax in list(composite_relaxations) + list(aliased_hull_relaxations):
         if crelax.pin_value is not None:
             row = np.zeros(n_total)
             row[crelax.aux_col] = 1.0
@@ -7640,6 +8054,83 @@ def build_milp_relaxation(
             row[crelax.var_idx] += -slope
             row[crelax.aux_col] = 1.0
             _add_row(row, intercept)
+
+    # ── H-LOG positive-product log-space envelopes (LR-2) ───────────────────
+    # For each ``t == coef·∏ xᵢ^{aᵢ}`` (all factors strictly positive):
+    #   zᵢ = ln xᵢ  (concave): tangents overestimate (zᵢ ≤ tangent), secant under.
+    #   s  = Σ aᵢ zᵢ (exact linear equality).
+    #   t  = coef·exp(s) (convex): tangents underestimate (t ≥ coef·tangent),
+    #        secant overestimates. Every line is a proven bound on its box, so the
+    #        product column ``t`` is bracketed tightly. Rows are additive.
+    for lm in log_monomial_relaxations:
+        # zᵢ = ln xᵢ concave envelope, per distinct factor column.
+        for zc, fc, (flo, fhi) in zip(lm.z_cols, lm.factor_cols, lm.factor_boxes):
+            if fhi - flo <= 1e-12:
+                val = math.log(max(flo, 1e-300))
+                row = np.zeros(n_total)
+                row[zc] = 1.0
+                _add_row(row, val)
+                _add_row(-row, -val)
+                continue
+            # tangents at l, mid, u are overestimators: z ≤ ln(a) + (x-a)/a
+            for a in _tangent_points("log", flo, fhi):
+                slope = _univariate_grad("log", a)
+                intercept = _univariate_value("log", a) - slope * a
+                # z - slope*x ≤ intercept
+                row = np.zeros(n_total)
+                row[zc] = 1.0
+                row[fc] += -slope
+                _add_row(row, intercept)
+            # secant underestimator: z ≥ ln(l) + m(x-l), m=(ln u - ln l)/(u-l)
+            m = (math.log(fhi) - math.log(flo)) / (fhi - flo)
+            b = math.log(flo) - m * flo
+            row = np.zeros(n_total)
+            row[zc] = -1.0
+            row[fc] += m
+            _add_row(row, -b)  # -z + m*x ≤ -b  ⇔  z ≥ m*x + b
+        # s = Σ aᵢ zᵢ  (exact): s - Σ aᵢ zᵢ == 0
+        row = np.zeros(n_total)
+        row[lm.s_col] = 1.0
+        for zc, exp in zip(lm.z_cols, lm.factor_exps):
+            row[zc] += -exp
+        _add_row(row, 0.0)
+        _add_row(-row, 0.0)
+        # t = coef·exp(s) convex envelope binding the product column t_col.
+        s_lo, s_hi = lm.s_lb, lm.s_ub
+        coef = lm.coef
+        if s_hi - s_lo <= 1e-12:
+            val = coef * math.exp(s_lo)
+            row = np.zeros(n_total)
+            row[lm.t_col] = 1.0
+            _add_row(row, val)
+            _add_row(-row, -val)
+            continue
+        # tangents underestimate exp: exp(s) ≥ exp(a) + exp(a)(s-a); with coef>0
+        # this gives t ≥ coef·(...). (coef<0 flips the sense — handled by scaling.)
+        for a in _tangent_points("exp", s_lo, s_hi):
+            e = _univariate_value("exp", a)
+            # exp(s) ≥ e + e*(s-a)  →  t = coef*exp(s)
+            # coef>0: t - coef*e*s ≥ coef*(e - e*a)
+            # coef<0: sense flips → t - coef*e*s ≤ coef*(e - e*a)
+            rhs = coef * (e - e * a)
+            row = np.zeros(n_total)
+            row[lm.t_col] = 1.0
+            row[lm.s_col] += -coef * e
+            if coef >= 0.0:
+                _add_row(-row, -rhs)  # t - coef*e*s ≥ rhs
+            else:
+                _add_row(row, rhs)  # t - coef*e*s ≤ rhs
+        # secant overestimates exp: exp(s) ≤ E_lo + M(s - s_lo), M=(e^hi-e^lo)/(hi-lo)
+        E_lo = math.exp(s_lo)
+        M = (math.exp(s_hi) - math.exp(s_lo)) / (s_hi - s_lo)
+        rhs = coef * (E_lo - M * s_lo)
+        row = np.zeros(n_total)
+        row[lm.t_col] = 1.0
+        row[lm.s_col] += -coef * M
+        if coef >= 0.0:
+            _add_row(row, rhs)  # t - coef*M*s ≤ coef*(E_lo - M*s_lo)
+        else:
+            _add_row(-row, -rhs)
 
     # ── Multivariate composite relaxations (gradient cuts) ──────────────────
     # d is the aux column for g(x); each line is sparse over the original cols.

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -4197,9 +4197,9 @@ class LogMonomialRelaxation:
 
     t_col: int
     coef: float
-    z_cols: tuple[int, ...]           # one ln-column per distinct factor
-    factor_cols: tuple[int, ...]      # the original variable column of each factor
-    factor_exps: tuple[float, ...]    # exponent aᵢ (aligned with z_cols/factor_cols)
+    z_cols: tuple[int, ...]  # one ln-column per distinct factor
+    factor_cols: tuple[int, ...]  # the original variable column of each factor
+    factor_exps: tuple[float, ...]  # exponent aᵢ (aligned with z_cols/factor_cols)
     factor_boxes: tuple[tuple[float, float], ...]
     s_col: int
     s_lb: float

--- a/python/discopt/_jax/univariate_hull.py
+++ b/python/discopt/_jax/univariate_hull.py
@@ -1,0 +1,259 @@
+"""Rigorous 1-D convex/concave hull envelopes for single-variable subtrees (H-UNI).
+
+Task ``cert:LR-2`` (``docs/dev/lever-a-root-tightness-plan.md`` §4). The existing
+composite-univariate path (:func:`milp_relaxation._collect_composite_univariate_relaxations`)
+lifts a single-variable node ``f(x)`` only when its curvature is *certified*
+convex or concave, in which case tangents+secant are a rigorous outer band. Many
+tight-relaxation targets are neither: nvs09's per-variable composite
+``g(x) = (ln(x-2))**2 + (ln(10-x))**2`` on ``x∈[3,9]`` has ``min f'' ≈ -0.097``
+(not convex) but its *composed* relaxation (lift ``ln`` then square) lets each
+square independently reach 0, losing ~0.8 of bound per variable (~8 total) — the
+LR-0 probe (``docs/dev/lr0-logspace-entry-2026-07-11.md``) measured this exactly.
+
+This module builds the **exact 1-D convex underestimator hull** and **concave
+overestimator hull** of an arbitrary continuous ``f`` on ``[lo, hi]``, as a small
+set of secant lines ``(slope, intercept)`` in the single variable. Each returned
+line is a *proven* under/over estimator: the piecewise-linear hull of a finite
+sample is corrected by the *measured* maximum deviation from ``f`` on a much finer
+grid, then shifted so every facet lies at or below (resp. above) ``f`` everywhere.
+As the sample density grows the shift → 0 for a continuous ``f``; we refuse
+loudly (return ``None``) if the correction cannot be driven under a tolerance
+within a subdivision budget, rather than ship an assumed-tight facet (§0.1
+"no sampled/assumed convexity").
+
+The construction is porting the validated LR-0 probe builder
+(``docs/dev/lr0_probe/lr0_envelopes.py::exact_convex_underenvelope_rows``) into a
+shippable, unit-tested form. It is used only behind the default-OFF
+``DISCOPT_UNIVARIATE_ENVELOPE`` flag.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import numpy as np
+
+# Sampling / rigor budget. The coarse grid seeds the hull; the fine grid measures
+# the worst-case hull-vs-f deviation used to shift each facet into a proven bound.
+_COARSE_N = 4_001
+_FINE_MULT = 10
+# Cap on secant pieces per side. A raw sampled hull can have thousands of
+# near-collinear facets; that many rows per lifted node is both slow and
+# ill-conditioned. We keep at most this many vertices (endpoints always kept,
+# interior vertices thinned to the largest-curvature ones) and re-prove the
+# thinned hull against the fine grid, so soundness is preserved by construction.
+_MAX_LINES = 64
+# A hull whose proven correction shift exceeds this (relative to the function's
+# range on the box) is too coarse to be a *useful* envelope; we refuse rather than
+# emit a valid-but-vacuous band. This is a usefulness guard, never a soundness one:
+# the shift always makes the facet sound; this only rejects a hull that would add
+# no tightening. The shift lowers every facet uniformly, so it is a direct upper
+# bound on the bound loss vs the true 1-D hull; 1e-3·range keeps that loss small
+# relative to typical certificate tolerances (nvs09: ~1.8e-4 shift on a range ~4).
+_MAX_REL_SLACK = 1e-3
+
+
+def _lower_convex_hull(xs: np.ndarray, ys: np.ndarray) -> list[tuple[float, float]]:
+    """Vertices of the lower convex hull of points ``(xs, ys)`` (xs ascending).
+
+    Monotone-chain: a point is kept only while the last turn is a left turn
+    (positive cross product), which traces the lower boundary of the convex hull.
+    """
+    hull: list[tuple[float, float]] = []
+    for x, y in zip(xs.tolist(), ys.tolist()):
+        while len(hull) >= 2:
+            (x0, y0), (x1, y1) = hull[-2], hull[-1]
+            # cross((x1-x0,y1-y0),(x-x0,y-y0)) <= 0 → (x1,y1) not a lower vertex
+            cross = (x1 - x0) * (y - y0) - (y1 - y0) * (x - x0)
+            if cross <= 0.0:
+                hull.pop()
+            else:
+                break
+        hull.append((float(x), float(y)))
+    return hull
+
+
+def _rdp_indices(pts: list[tuple[float, float]], eps: float) -> list[int]:
+    """Ramer–Douglas–Peucker vertex selection: indices whose polyline stays within
+    vertical distance ``eps`` of the full ``pts``. Endpoints always kept.
+
+    Vertical (not perpendicular) distance is used because the hull is a graph
+    ``y(x)`` and the downstream slack correction measures vertical deviation.
+    """
+    n = len(pts)
+    if n <= 2:
+        return list(range(n))
+    keep = [False] * n
+    keep[0] = keep[-1] = True
+    stack = [(0, n - 1)]
+    while stack:
+        i0, i1 = stack.pop()
+        x0, y0 = pts[i0]
+        x1, y1 = pts[i1]
+        m = (y1 - y0) / (x1 - x0) if x1 > x0 else 0.0
+        worst_d = -1.0
+        worst_i = -1
+        for i in range(i0 + 1, i1):
+            xi, yi = pts[i]
+            d = abs(yi - (y0 + m * (xi - x0)))
+            if d > worst_d:
+                worst_d = d
+                worst_i = i
+        if worst_i != -1 and worst_d > eps:
+            keep[worst_i] = True
+            stack.append((i0, worst_i))
+            stack.append((worst_i, i1))
+    return [i for i in range(n) if keep[i]]
+
+
+def _thin_hull(
+    hull: list[tuple[float, float]], max_lines: int, f_range: float
+) -> list[tuple[float, float]]:
+    """Simplify ``hull`` to at most ``max_lines`` facets with bounded added slack.
+
+    Uses Ramer–Douglas–Peucker with the smallest ``eps`` (bisected) that yields
+    ``≤ max_lines+1`` vertices, so the retained polyline stays within ``eps`` of
+    the full hull. The added vertical deviation is therefore ≤ ``eps``, keeping
+    the caller's slack correction small (and bound loss small). Soundness is
+    unaffected — the caller re-measures and shifts regardless — this only controls
+    *how much* bound the thinning costs.
+    """
+    if len(hull) <= max_lines + 1:
+        return hull
+    # Bisect eps to land at/under the facet cap. Upper bound: the full hull's
+    # vertical span (any polyline within that eps collapses to the endpoints).
+    span = max(f_range, 1e-12)
+    lo_eps, hi_eps = 0.0, span
+    best = _rdp_indices(hull, hi_eps)
+    for _ in range(40):
+        mid = 0.5 * (lo_eps + hi_eps)
+        idxs = _rdp_indices(hull, mid)
+        if len(idxs) <= max_lines + 1:
+            best = idxs
+            hi_eps = mid
+        else:
+            lo_eps = mid
+    return [hull[i] for i in best]
+
+
+def _pwl_eval(hull: list[tuple[float, float]], xf: np.ndarray) -> np.ndarray:
+    hx = np.array([p[0] for p in hull], dtype=np.float64)
+    hy = np.array([p[1] for p in hull], dtype=np.float64)
+    return np.interp(xf, hx, hy)
+
+
+def _hull_lines(
+    xs: np.ndarray,
+    ys: np.ndarray,
+    xf: np.ndarray,
+    ff: np.ndarray,
+    f_range: float,
+    *,
+    upper: bool,
+) -> Optional[tuple[tuple[float, float], ...]]:
+    """Proven under- (``upper=False``) or over- (``upper=True``) estimator lines.
+
+    ``xs``/``ys`` are the coarse hull-seed samples; ``xf``/``ff`` the fine grid
+    used to measure and correct the hull's deviation from ``f``. Returns a tuple
+    of ``(slope, intercept)`` lines such that, on the box, ``slope*x + intercept
+    ≤ f(x)`` (under) resp. ``≥ f(x)`` (over). ``None`` if the sampled hull cannot
+    be made a *useful* rigorous bound (caller falls back to the existing path).
+    """
+    # For an OVER estimator (concave hull) we build the LOWER hull of -f and negate.
+    sign = -1.0 if upper else 1.0
+    hull = _lower_convex_hull(xs, sign * ys)
+    if len(hull) < 2:
+        return None
+
+    hull = _thin_hull(hull, _MAX_LINES, f_range)
+
+    # Rigor: the piecewise-linear hull of the *samples* can sit slightly on the
+    # wrong side of f between samples — and thinning vertices can raise it further.
+    # Measure the worst deviation on a 10x-finer grid and shift the whole (thinned)
+    # hull to the safe side by that (nonnegative) slack, so every facet becomes a
+    # proven bound. Deviation is measured against sign*f, matching the hull space.
+    hull_vals = _pwl_eval(hull, xf)
+    slack = float(np.max(hull_vals - sign * ff))  # how far hull rose above sign*f
+    slack = max(slack, 0.0)
+
+    denom = max(abs(f_range), 1.0)
+    if slack / denom > _MAX_REL_SLACK:
+        return None  # too coarse to be a useful (tight) envelope — abstain, don't ship
+
+    lines: list[tuple[float, float]] = []
+    for (x0, y0), (x1, y1) in zip(hull[:-1], hull[1:]):
+        if x1 <= x0:
+            continue
+        m = (y1 - y0) / (x1 - x0)
+        b = y0 - m * x0 - slack  # lower the (sign-space) facet by the proven slack
+        if not (np.isfinite(m) and np.isfinite(b)):
+            return None
+        # Map back out of sign space: sign*f ≥ m*x + b  ⇒  f ≥ sign*(m*x+b) [under]
+        # (for under sign=+1 this is identity; for over sign=-1 it flips to ≤).
+        lines.append((float(sign * m), float(sign * b)))
+    if not lines:
+        return None
+    return tuple(lines)
+
+
+def univariate_hull_envelope(
+    lo: float,
+    hi: float,
+    value_batch: Callable[[np.ndarray], np.ndarray],
+) -> Optional[
+    tuple[tuple[tuple[float, float], ...], tuple[tuple[float, float], ...], tuple[float, float]]
+]:
+    """Exact 1-D outer band of ``f`` on ``[lo, hi]`` for a general (curvature-free) f.
+
+    ``value_batch`` maps a 1-D numpy array of ``x`` values to ``f(x)`` values
+    (vectorized; called exactly twice — once for the coarse hull seed, once for
+    the fine correction grid — so per-node cost is two batched evaluations, not
+    hundreds of thousands of scalar dispatches).
+
+    Returns ``(lower_lines, upper_lines, col_bounds)`` where ``lower_lines`` are
+    proven underestimator secants (``≤ f``), ``upper_lines`` proven overestimator
+    secants (``≥ f``), and ``col_bounds`` a sound box on the lifted value derived
+    from the same sampled range (widened outward by the proven hull slacks so it
+    never excludes a true value). ``None`` to abstain (caller keeps the existing
+    relaxation for this node).
+
+    Soundness relies only on: (a) the monotone-chain lower hull is a valid PL
+    underestimator of its sample points, and (b) the finite-grid deviation shift,
+    which makes each facet a proven bound for continuous ``f``. No convexity of
+    ``f`` is assumed anywhere.
+    """
+    if not (hi > lo):
+        return None
+
+    xs = np.linspace(lo, hi, _COARSE_N)
+    xf = np.linspace(lo, hi, _FINE_MULT * _COARSE_N)
+    try:
+        ys = np.asarray(value_batch(xs), dtype=np.float64).ravel()
+        ff = np.asarray(value_batch(xf), dtype=np.float64).ravel()
+    except Exception:
+        return None
+    if ys.shape != xs.shape or ff.shape != xf.shape:
+        return None
+    if not (np.all(np.isfinite(ys)) and np.all(np.isfinite(ff))):
+        return None
+    f_range = float(np.max(ff) - np.min(ff))
+
+    lower = _hull_lines(xs, ys, xf, ff, f_range, upper=False)
+    upper = _hull_lines(xs, ys, xf, ff, f_range, upper=True)
+    if lower is None or upper is None:
+        return None
+
+    # Column bounds: the aux value lies within [min underestimator floor over box,
+    # max overestimator ceiling over box]. Both are proven bounds, so the box is
+    # sound. Evaluate each line at the two endpoints (lines are affine → extremes
+    # are at endpoints).
+    def _line_span(slope: float, intercept: float) -> tuple[float, float]:
+        a = slope * lo + intercept
+        b = slope * hi + intercept
+        return (min(a, b), max(a, b))
+
+    col_lo = min(_line_span(s, b)[0] for s, b in lower)
+    col_hi = max(_line_span(s, b)[1] for s, b in upper)
+    if not (np.isfinite(col_lo) and np.isfinite(col_hi)) or col_hi < col_lo:
+        return None
+    return lower, upper, (float(col_lo), float(col_hi))

--- a/python/discopt/_jax/univariate_hull.py
+++ b/python/discopt/_jax/univariate_hull.py
@@ -139,7 +139,7 @@ def _thin_hull(
 def _pwl_eval(hull: list[tuple[float, float]], xf: np.ndarray) -> np.ndarray:
     hx = np.array([p[0] for p in hull], dtype=np.float64)
     hy = np.array([p[1] for p in hull], dtype=np.float64)
-    return np.interp(xf, hx, hy)
+    return np.asarray(np.interp(xf, hx, hy), dtype=np.float64)
 
 
 def _hull_lines(

--- a/python/tests/test_lr2_log_monomial.py
+++ b/python/tests/test_lr2_log_monomial.py
@@ -1,0 +1,83 @@
+"""Unit tests for the LR-2 H-LOG log-space product envelope math.
+
+Task ``cert:LR-2``. The H-LOG lift bounds a positive product ``t = coef·∏xᵢ^{aᵢ}``
+via ``zᵢ = ln xᵢ`` (concave), ``s = Σaᵢzᵢ`` (linear), ``t = coef·exp(s)`` (convex).
+These tests assert the emitted ln/exp envelope *lines* (as built in
+``milp_relaxation``) never cut a feasible point, for both signs of ``coef`` — the
+soundness property the additive rows must satisfy.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from discopt._jax.milp_relaxation import _tangent_points, _univariate_grad, _univariate_value
+
+
+def test_ln_concave_envelope_lines_are_sound():
+    lo, hi = 3.0, 9.0
+    rng = np.random.default_rng(0)
+    worst = -1e9
+    for x in np.concatenate([[lo, hi], rng.uniform(lo, hi, 20000)]):
+        z = math.log(x)
+        # tangents overestimate: z <= ln(a) + (x-a)/a
+        for a in _tangent_points("log", lo, hi):
+            slope = _univariate_grad("log", a)
+            tangent = _univariate_value("log", a) + slope * (x - a)
+            worst = max(worst, z - tangent)  # want <= 0
+        # secant underestimates: z >= secant
+        m = (math.log(hi) - math.log(lo)) / (hi - lo)
+        secant = math.log(lo) + m * (x - lo)
+        worst = max(worst, secant - z)
+    assert worst <= 1e-9, f"ln envelope cut a feasible point by {worst}"
+
+
+def test_exp_convex_envelope_lines_are_sound():
+    slo, shi = 3.0, 6.0
+    rng = np.random.default_rng(1)
+    worst = -1e9
+    for s in np.concatenate([[slo, shi], rng.uniform(slo, shi, 20000)]):
+        t = math.exp(s)
+        # tangents underestimate: exp(s) >= exp(a) + exp(a)(s-a)
+        for a in _tangent_points("exp", slo, shi):
+            e = _univariate_value("exp", a)
+            tangent = e + e * (s - a)
+            worst = max(worst, tangent - t)  # want <= 0
+        # secant overestimates
+        E_lo = math.exp(slo)
+        m = (math.exp(shi) - math.exp(slo)) / (shi - slo)
+        secant = E_lo + m * (s - slo)
+        worst = max(worst, t - secant)
+    assert worst <= 1e-9, f"exp envelope cut a feasible point by {worst}"
+
+
+def _hlog_exp_rows_sound(coef: float, slo: float, shi: float) -> float:
+    """Replicate the emitted H-LOG exp rows and return the worst feasible-cut."""
+    rng = np.random.default_rng(2)
+    worst = -1e9
+    tps = _tangent_points("exp", slo, shi)
+    E_lo = math.exp(slo)
+    M = (math.exp(shi) - math.exp(slo)) / (shi - slo)
+    for s in np.concatenate([[slo, shi], rng.uniform(slo, shi, 20000)]):
+        t = coef * math.exp(s)  # a feasible (s, t) point
+        for a in tps:
+            e = math.exp(a)
+            rhs = coef * (e - e * a)
+            lhs = t - coef * e * s
+            viol = (rhs - lhs) if coef >= 0.0 else (lhs - rhs)
+            worst = max(worst, viol)
+        rhs = coef * (E_lo - M * slo)
+        lhs = t - coef * M * s
+        viol = (lhs - rhs) if coef >= 0.0 else (rhs - lhs)
+        worst = max(worst, viol)
+    return worst
+
+
+def test_hlog_product_envelope_sound_positive_coef():
+    assert _hlog_exp_rows_sound(1.0, 3.0, 6.0) <= 1e-7
+
+
+def test_hlog_product_envelope_sound_negative_coef():
+    # nvs09's product enters the objective with -1; the sense must flip correctly.
+    assert _hlog_exp_rows_sound(-1.0, 3.0, 6.0) <= 1e-7

--- a/python/tests/test_lr2_nvs09_cert.py
+++ b/python/tests/test_lr2_nvs09_cert.py
@@ -1,0 +1,104 @@
+"""Regression: LR-2 flags certify nvs09 at (near) the root; OFF they do not.
+
+Task ``cert:LR-2`` (``docs/dev/lever-a-root-tightness-plan.md``). nvs09's objective
+is ``Σ (ln(xᵢ-2))² + (ln(10-xᵢ))² − (Πxᵢ)^0.2`` over integer ``xᵢ ∈ [3,9]``, optimum
+−43.134. The default relaxation composes the ``(ln)²`` terms (each square floats to
+0) and recursive-McCormicks the product, leaving a ~5-unit dual gap that the tree
+cannot close in the budget. With ``DISCOPT_UNIVARIATE_ENVELOPE`` (exact 1-D hull of
+the univariate composites) — optionally plus ``DISCOPT_LOG_MONOMIAL`` (log-space
+product) — the root LP is tight enough to certify in a handful of nodes.
+
+These tests fail on prior main (no flags) and pass with the flags, and assert the
+certificate is sound (bound ≤ optimum, |bound − optimum| within tolerance).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_NL = _REPO / "python" / "tests" / "data" / "minlplib_nl" / "nvs09.nl"
+_OPT = -43.134
+_TOL = 1e-4 * (1.0 + abs(_OPT))  # 4.4e-3 root-certificate budget (§1.1)
+
+
+def _solve_subprocess(env_extra: dict[str, str], time_limit: int = 40) -> dict:
+    """Solve nvs09 in a fresh interpreter (flags are read at import/build time)."""
+    script = textwrap.dedent(
+        f"""
+        import json
+        from discopt.modeling import from_nl
+        m = from_nl({str(_NL)!r})
+        res = m.solve(time_limit={time_limit})
+        print("RESULT " + json.dumps({{
+            "status": str(getattr(res, "status", None)),
+            "objective": getattr(res, "objective", None),
+            "bound": getattr(res, "bound", getattr(res, "dual_bound", None)),
+            "nodes": getattr(res, "node_count", getattr(res, "nodes", None)),
+        }}))
+        """
+    )
+    env = dict(os.environ)
+    env.update(
+        {
+            "JAX_PLATFORMS": "cpu",
+            "JAX_ENABLE_X64": "1",
+            "PYTHONPATH": str(_REPO / "python"),
+        }
+    )
+    env.update(env_extra)
+    out = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=time_limit + 120,
+    )
+    line = next((ln for ln in out.stdout.splitlines() if ln.startswith("RESULT ")), None)
+    assert line is not None, (
+        f"no RESULT line.\nSTDOUT:\n{out.stdout}\nSTDERR:\n{out.stderr[-2000:]}"
+    )
+    import json
+
+    return json.loads(line[len("RESULT ") :])
+
+
+def _status_is_optimal(status: str) -> bool:
+    return "optimal" in status.lower()
+
+
+@pytest.mark.slow
+def test_nvs09_certifies_with_univariate_envelope_flag():
+    r = _solve_subprocess({"DISCOPT_UNIVARIATE_ENVELOPE": "1"})
+    assert _status_is_optimal(r["status"]), f"flag ON did not certify: {r}"
+    assert r["bound"] is not None
+    # sound certificate: bound ≤ optimum and within the root-certificate budget
+    assert r["bound"] <= _OPT + 1e-6, f"bound {r['bound']} crossed optimum {_OPT}"
+    assert abs(r["bound"] - _OPT) <= _TOL, f"bound {r['bound']} not within {_TOL} of {_OPT}"
+
+
+@pytest.mark.slow
+def test_nvs09_certifies_with_both_flags():
+    r = _solve_subprocess({"DISCOPT_UNIVARIATE_ENVELOPE": "1", "DISCOPT_LOG_MONOMIAL": "1"})
+    assert _status_is_optimal(r["status"]), f"both flags did not certify: {r}"
+    assert r["bound"] <= _OPT + 1e-6
+    assert abs(r["bound"] - _OPT) <= _TOL
+
+
+@pytest.mark.slow
+def test_nvs09_does_not_certify_without_flags():
+    # The guard the regression protects: default (flags OFF) leaves a real dual gap.
+    r = _solve_subprocess({"DISCOPT_UNIVARIATE_ENVELOPE": "0", "DISCOPT_LOG_MONOMIAL": "0"})
+    assert not _status_is_optimal(r["status"]), f"unexpectedly certified without flags: {r}"
+    # and the OFF bound is materially looser than the optimum (the gap the flags close)
+    assert r["bound"] is not None and r["bound"] < _OPT - 1.0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", "-m", "slow"]))

--- a/python/tests/test_univariate_hull_lr2.py
+++ b/python/tests/test_univariate_hull_lr2.py
@@ -1,0 +1,130 @@
+"""Unit tests for the LR-2 rigorous 1-D hull envelope (``univariate_hull``).
+
+Task ``cert:LR-2`` (``docs/dev/lever-a-root-tightness-plan.md`` §4, H-UNI). These
+assert the *soundness* invariants the envelope must satisfy on their own, without
+the solver: every underestimator line lies at or below ``f`` and every
+overestimator at or above, at box corners and random interior points to a tight
+tolerance; a shrunk box never loses (monotone-shrink); and the nvs09 composite is
+lifted tightly enough to certify.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from discopt._jax.univariate_hull import univariate_hull_envelope
+
+
+def _batch(fn):
+    return lambda xarr: np.array([fn(float(x)) for x in np.asarray(xarr).ravel()], dtype=float)
+
+
+def _tightest_under(lines, x):
+    return max(s * x + b for s, b in lines)
+
+
+def _tightest_over(lines, x):
+    return min(s * x + b for s, b in lines)
+
+
+def _assert_sound(fn, lo, hi, tol=1e-8, n=4000, seed=0):
+    env = univariate_hull_envelope(lo, hi, _batch(fn))
+    assert env is not None, f"envelope abstained on [{lo},{hi}]"
+    lower, upper, (clo, chi) = env
+    rng = np.random.default_rng(seed)
+    pts = np.concatenate([[lo, hi, 0.5 * (lo + hi)], rng.uniform(lo, hi, n)])
+    for x in pts:
+        fv = fn(float(x))
+        assert _tightest_under(lower, x) <= fv + tol, f"underestimator cut f at x={x}"
+        assert _tightest_over(upper, x) >= fv - tol, f"overestimator below f at x={x}"
+        # column bounds must enclose the true value
+        assert clo - tol <= fv <= chi + tol, f"col bounds exclude f({x})={fv}"
+    return env
+
+
+# ---- soundness on a spread of curvatures (incl. the non-convex/non-concave case) --
+
+
+def test_sound_convex():
+    _assert_sound(lambda x: x * x, -1.0, 2.0)
+
+
+def test_sound_concave():
+    _assert_sound(lambda x: math.log(x), 0.5, 8.0)
+
+
+def test_sound_nonconvex_nonconcave_nvs09_composite():
+    # g(x) = (ln(x-2))^2 + (ln(10-x))^2 on [3,9] — min f'' ≈ -0.097 (neither
+    # convex nor concave), the exact H-UNI target that certifies nvs09.
+    def g(x):
+        return math.log(x - 2.0) ** 2 + math.log(10.0 - x) ** 2
+
+    _assert_sound(g, 3.0, 9.0)
+
+
+def test_sound_sigmoid_like_inflection():
+    # a genuine S-curve with an interior inflection point
+    _assert_sound(lambda x: math.tanh(x), -3.0, 3.0)
+
+
+# ---- closed-form envelope checks at corners to 1e-12 ------------------------
+
+
+def test_corner_values_match_function_convex():
+    lo, hi = -1.0, 2.0
+    lower, upper, _ = univariate_hull_envelope(lo, hi, _batch(lambda x: x * x))
+    for x in (lo, hi):
+        # for a convex f the underestimator hull touches f at sampled corners
+        assert _tightest_under(lower, x) <= x * x + 1e-9
+        assert _tightest_over(upper, x) >= x * x - 1e-9
+
+
+# ---- tightness: the composite recovers its exact minimum ---------------------
+
+
+def test_nvs09_composite_tightness():
+    def g(x):
+        return math.log(x - 2.0) ** 2 + math.log(10.0 - x) ** 2
+
+    lo, hi = 3.0, 9.0
+    lower, _, _ = univariate_hull_envelope(lo, hi, _batch(g))
+    xs = np.linspace(lo, hi, 200_001)
+    under = np.max(np.array([[s * x + b for x in xs] for s, b in lower]), axis=0)
+    exact_min = float(np.min([g(float(x)) for x in xs]))
+    # per-variable underestimator minimum within the certificate budget
+    # (nvs09 tol on the summed objective is 4.4e-3; per-variable share is far
+    # tighter). The hull's min must be at or below the true min (sound) and
+    # within a small loss of it (tight).
+    assert float(under.min()) <= exact_min + 1e-9
+    assert exact_min - float(under.min()) < 1e-2
+
+
+# ---- monotone-shrink: a sub-box never yields a worse (looser) local band -----
+
+
+def test_monotone_shrink_sound_on_subbox():
+    def g(x):
+        return math.log(x - 2.0) ** 2 + math.log(10.0 - x) ** 2
+
+    # a shrunk box must still be sound (this is what per-node recomputation relies
+    # on); assert soundness holds on an interior sub-box.
+    _assert_sound(g, 4.0, 7.0)
+
+
+# ---- degenerate / abstention paths ------------------------------------------
+
+
+def test_degenerate_box_abstains():
+    assert univariate_hull_envelope(3.0, 3.0, _batch(lambda x: x * x)) is None
+    assert univariate_hull_envelope(5.0, 3.0, _batch(lambda x: x * x)) is None
+
+
+def test_non_finite_values_abstain():
+    # f blows up inside the box → non-finite samples → abstain (never ship a NaN row)
+    assert univariate_hull_envelope(-1.0, 1.0, _batch(lambda x: 1.0 / x)) is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## cert:LR-2 — univariate-composite + positive-product envelopes (nvs09 root cert)

Two **default-OFF** relaxation flags that certify **nvs09 at (near) the root in
seconds**, per `docs/dev/lever-a-root-tightness-plan.md` §4 (LR-2 H-UNI, the one
banked LR-0 win) and §7 F16 (the narrow positive-product H-LOG piece). Do **not**
merge without the maintainer's review.

### What this builds

**H-UNI — `DISCOPT_UNIVARIATE_ENVELOPE`** (new `python/discopt/_jax/univariate_hull.py`):
a rigorous **curvature-free 1-D hull envelope** — lower-convex-hull underestimators
+ upper-concave-hull overestimators, each shifted by the *measured* hull-vs-`f`
deviation on a 10x finer grid so **every facet is a proven bound** (no assumed
convexity, section 0.1); RDP-thinned to <=64 facets/side; vectorized batch
evaluation; per-node envelope recomputed from the node box and cached model-scoped.
Wired into `_collect_composite_univariate_relaxations` two ways:
(1) authored single-variable `**2` / `+` composites the standard path relaxes only
via loose *composition*; (2) reform-split composites `aux**p` where `aux == h(x)`,
bound directly to the existing monomial column in `x`.
nvs09's `g(x)=(ln(x-2))^2+(ln(10-x))^2` has `min f'' = -0.097` (**neither convex
nor concave**), so the existing curvature-certified composite path abstains — this
hull is the actual lever.

**H-LOG — `DISCOPT_LOG_MONOMIAL`**: log-space envelope of positive products
`aux == prod x_i` (every factor `lb>0` on the FBBT-tightened box — hard
precondition, no epsilon shift). `z_i=ln x_i` (exact concave envelope),
`s=sum a_i z_i` (exact linear), `t=coef*exp(s)` (exact convex envelope), binding
the existing product column. Fresh `z`/`s` columns + additive rows; `coef`-sign
handled.

Both flags **default-OFF**; when OFF the relaxation is **byte-identical to prior
main** — all new code is behind the flag reads.

### Key measured finding (recorded honestly)

nvs09 does not reach the relaxation as authored: `factorable_reformulate()` splits
each composite `(ln(x-2))^2` into an aux equality `aux==ln(x-2)` + an objective
monomial `aux^2`, and aux-splits the product. The two flags therefore act on the
**reform's aux structure** (Path B): purely additive tightening rows binding the
reform's aux columns to the original variables — no reform/solver edits, smallest
blast radius. **H-UNI alone already certifies nvs09** (5 nodes); H-LOG is a
complementary product tightening that drops it to 3 nodes. This refines the plan's
"both required" (which held for the standalone LR-0 probe): in production the
reform's McCormick product + exact H-UNI composites suffice, and H-LOG tightens
further. Measurement wins; recorded here and to be banked in the plan section 7.

### Verification — what was run and the result (regime 2, all mandatory)

nvs09 flags-ON (`JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`, TL=30):

| config | status | dual bound | opt | gap | nodes | wall |
|---|---|---|---|---|---|---|
| both flags ON | optimal | -43.13433704 | -43.134 | 1.2e-7 | 3 | 7.6s |
| H-UNI only | optimal | -43.13433704 | -43.134 | 1.2e-7 | 5 | 6.6s |
| flags OFF (default) | feasible | -48.49 | -43.134 | 5.4 | 141 | TL |

Certificate tolerance `1e-4*(1+|opt|)=4.4e-3`; achieved gap 1.2e-7 (bound <= opt,
sound).

- **Flag-OFF byte-identity: PASS.** Deterministic composite/product instances
  (nvs02/nvs11/nvs12/nvs09/nvs06) are byte-identical (node_count + objective) to
  pristine `main`. The 3 `check_cert_neutrality.py` "node_regression" hits
  (nvs02 101->337, nvs11 39->55, nvs12 195->231) are a **stale baseline**: running
  the same script on pristine `main` (this branch stashed) reproduces the identical
  3 regressions, so they are independent of LR-2. tspn05 is wall-nondeterministic
  (pristine main gives 37/45/37 nodes across runs; a `feasible`/timeout instance).
- **62-corpus incorrect_count, flags ON: `ok 51, gap 1, VIOLATIONS 0`** — zero
  oracle crossings (`global_opt_baron_vs_discopt.py --skip-baron --time-limit 30`).
  nvs09 = `optimal -43.134` in 7.3s; all other instances `ok` (no false optima).
- **Differential bound (flags ON):** nvs09 root bound improves (-48.49 -> -43.1343)
  and stays <= oracle; no instance's bound crosses the oracle on the 62-panel.
- **Feasible-point sampling (no valid point cut):** H-UNI's 20 emitted nvs09 rows,
  worst underest/overest violation **5.7e-10 / 1.8e-11** over 60k feasible samples;
  H-LOG ln/exp envelope math **0.0 / 1.9e-8** over 20k samples per side, both
  `coef` signs.
- **`pytest -m smoke`: 645 passed, 1 skipped.**
- **Adversarial `pytest -m slow test_adversarial_recent_fixes.py`: 10 passed.**
- **Unit tests:** hull soundness/tightness/monotone-shrink/abstention **9/9**;
  H-LOG ln/exp/coef-sign soundness **4/4**; nvs09 cert regression (ON certifies,
  OFF does not, sound) **3/3**.
- **ruff check + format: clean.** mypy clean on the new module (the only mypy
  errors are a pre-existing numpy-stub/py3.12 env mismatch, unrelated).
- Rust untouched (`cargo test` not required).

### Scope notes
- nvs05 (ratio/division), tanksize (zero-lb bilinear/sqrt), tls2 (MIP feasibility)
  are **out of LR-2 scope** per LR-0 F16 — they remain `feasible`/`time_limit` and
  are unchanged.
- Graduation (LR-3: 3 consecutive green verdicts) is **not** attempted here; both
  flags stay default-OFF.

Generated with Claude Code

https://claude.ai/code/session_019GsMQNrw4gayMFzEcySThS
