### PR TITLE
chore(deps): bump feral to crates.io 0.14.0 (retire the #112 git-rev pin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,8 +77,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "feral"
-version = "0.13.0"
-source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd098b55d4d14e0807addbfdba87efccbe699f72f58acf8aa78d622933af3144"
 dependencies = [
  "feral-amd",
  "feral-amf",
@@ -95,7 +96,8 @@ dependencies = [
 [[package]]
 name = "feral-amd"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead2f064dbcef0e0d3110202e9d6d7c293c1dffe6da5964513a20c5967e4d560"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -103,7 +105,8 @@ dependencies = [
 [[package]]
 name = "feral-amf"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ea6dacabfa085e7f40080c894da245d9db60e9211f1f8ab08d715d6d0f5a29"
 dependencies = [
  "feral-ordering-core",
 ]
@@ -111,7 +114,8 @@ dependencies = [
 [[package]]
 name = "feral-kahip"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ba0d001a63e777227de4565c7f4cd14062b9fbe83d3cadcb292be74410b4f4"
 dependencies = [
  "feral-amd",
  "feral-metis",
@@ -121,7 +125,8 @@ dependencies = [
 [[package]]
 name = "feral-metis"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b34963682eaf680479bfd6018a5570bfd1ed9c1f05d8bf085ab49f13b308cb"
 dependencies = [
  "feral-amd",
  "feral-ordering-core",
@@ -130,12 +135,14 @@ dependencies = [
 [[package]]
 name = "feral-ordering-core"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca94ad929e23c0adaa6edda42474aa71b5b2bfb3930b1f6b202e4b37c8e9b763"
 
 [[package]]
 name = "feral-scotch"
 version = "0.2.1"
-source = "git+https://github.com/jkitchin/feral?rev=660224dc929953072582603a15c7cb4c7bf0592c#660224dc929953072582603a15c7cb4c7bf0592c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51fe24bffbef76e88803e801c2d8977f5d304dd6af43f70c1e91fdfabd0b530"
 dependencies = [
  "feral-amd",
  "feral-metis",

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -25,24 +25,25 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # (condition_estimate_1), and the richer update() instability signal
 # (RefactorCause + last_refactor() + growth-aware/dense-parity should_refactor).
 #
-# Pinned to a git rev PAST the v0.13.0 release (2026-07-02) for feral #112 / PR #113
-# (merge commit 660224dc9299): the sparse Forrest–Tomlin bump update now accumulates
-# its working row with an always-on Neumaier (Kahan–Babuška) compensated sum, which
-# keeps the sparse LU factor accurate on the wide dense-McCormick node bases.
+# 0.14.0 is the first crates.io release carrying feral #112 / PR #113 (previously
+# git-rev-pinned at merge commit 660224dc9299, unreleased at the time): the sparse
+# Forrest–Tomlin bump update now accumulates its working row with an always-on
+# Neumaier (Kahan–Babuška) compensated sum, which keeps the sparse LU factor
+# accurate on the wide dense-McCormick node bases. This bump replaces that temporary
+# git rev with the tagged release, as the pin comment instructed.
 #
-# WHY THIS IS BUNDLED WITH THE #557 density-aware LU route (linsolve.rs): the route
+# WHY THIS MATTERS FOR THE #557 density-aware LU route (linsolve.rs): the route
 # sends the m∈(16,256] sparse-but-wide McCormick bases to feral's SPARSE LU instead
 # of the dense O(m³) path. On plain feral 0.12 that eliminates the RefacFtTinyPivot
 # refactor storm (storm-elimination IS feral-independent, 42337→~3200 on st_e36) —
 # BUT the plain-0.12 sparse factor is not accurate enough for the dual bound to keep
 # closing: st_e36 with the route ON drops optimal→feasible, its bound stuck at the
 # root value −304.5 (vs −246.02 that certifies optimal). #112's compensated sparse
-# accumulation restores the bound-closing, so route ON stays `optimal`. Bound-closing
-# is NOT feral-independent, hence the route change and this bump ship together.
-# No discopt API change (LuParams gains `update_pivot_search: bool`, default false,
-# covered by `..LuParams::default()`). Unreleased on crates.io as of the pin date,
-# hence the git rev; bump to the next tagged release when it cuts.
-feral = { git = "https://github.com/jkitchin/feral", rev = "660224dc929953072582603a15c7cb4c7bf0592c" }
+# accumulation (carried by 0.14.0) restores the bound-closing, so route ON stays
+# `optimal` — this is the acceptance test for the bump. No discopt API change
+# (LuParams gains `update_pivot_search: bool`, default false, covered by
+# `..LuParams::default()`).
+feral = "0.14"
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to
 # 1.10 to keep the crate's MSRV (1.75); 1.12+ requires rustc 1.80.


### PR DESCRIPTION
## Bump feral 0.13.0 git-rev pin → crates.io 0.14.0

The `feral` LU-engine dependency was git-rev-pinned at `jkitchin/feral@660224dc`
(past v0.13.0) because **feral #112 / PR #113** — the always-on Neumaier
(Kahan–Babuška) compensated sum in the sparse Forrest–Tomlin bump update — was
unreleased on crates.io. The pin comment said *"bump to the next tagged release
when it cuts."* **0.14.0 is that release** (published on crates.io); this replaces
the git rev with the clean versioned dependency.

### Why the compensated sum matters (unchanged rationale)
The #557 density-aware LU route sends `m∈(16,256]` sparse-but-wide McCormick bases
to feral's sparse LU. Without #112's compensated accumulation the sparse factor
isn't accurate enough to keep the dual bound closing — `st_e36` drops
optimal→feasible with its bound stuck at the root value −304.5 (vs −246.02 that
certifies optimal). 0.14.0 carries #112, so bound-closing is preserved.

### Verification (all on feral 0.14.0)
- `cargo check -p discopt-core`: compiles, **no API breakage** (growth / u_max0 /
  condition_estimate_1 / RefactorCause / last_refactor / should_refactor /
  `LuParams.update_pivot_search` all present).
- `cargo test -p discopt-core`: **439 + 4 (determinism) + 1 (doctest) passed, 0 failed**.
- **Acceptance** (`st_e36`, density route ON by default #616): **status=optimal,
  bound −246.019, 153 nodes, 7.4s** — the exact bound-closing #112 protects.
- `test_setcover_lp_regression.py`: **passed** (guards the 0.11 O(m³) cliff).
- `pytest -m smoke`: **645 passed, 1 skipped**.

Dependency + lockfile only; no discopt source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
