### PR TITLE
cert(LR-3): H-UNI soundness hardening — kept default-OFF (graduation deferred to #632)

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3644,8 +3644,40 @@ def _should_claim_composite(
         # a purely affine sum is left to the exact linear path.
         if _composite_referenced_var(expr, model) is None:
             return False
-        return _expr_has_nonlinear_subterm(expr)
+        return _has_genuine_composite_subterm(expr, model, n_orig)
     return False
+
+
+def _has_genuine_composite_subterm(expr: Expression, model: Model, n_orig: int) -> bool:
+    """True if an additive single-variable ``expr`` contains a sub-term the standard
+    path relaxes only via a *looser composition* — the case H-UNI's exact 1-D hull
+    improves on.
+
+    A *bare monomial* ``x**p`` (base is a variable) is lifted exactly by the
+    dedicated monomial/fractional-power machinery, and the incremental McCormick
+    engine builds its rows directly; H-UNI adds no tightness there but would divert
+    the term into the composite path and break the engine's cold/patch agreement.
+    So ``_expr_has_nonlinear_subterm`` (which fires on *any* power) is too broad for
+    the additive claim. Here we walk ``+``/``-``/``neg``/const-scaling and claim only
+    when a leaf is a *genuine composite*: a univariate call of a non-affine argument
+    (``ln(x-2)``) or a power of a non-bare base (``(ln(x-2))**2``) — exactly the
+    non-additive cases :func:`_should_claim_composite` recognises with
+    ``allow_general=True``. nvs09's ``(ln(x-2))**2 + (ln(10-x))**2`` still qualifies;
+    ``x**p + x`` (bare monomial + linear) no longer does."""
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        return _has_genuine_composite_subterm(expr.operand, model, n_orig)
+    if isinstance(expr, BinaryOp) and expr.op in ("+", "-"):
+        return _has_genuine_composite_subterm(expr.left, model, n_orig) or (
+            _has_genuine_composite_subterm(expr.right, model, n_orig)
+        )
+    if isinstance(expr, BinaryOp) and expr.op == "*":
+        # A constant-scaled term contributes its non-constant factor's status.
+        if isinstance(expr.right, Constant):
+            return _has_genuine_composite_subterm(expr.left, model, n_orig)
+        if isinstance(expr.left, Constant):
+            return _has_genuine_composite_subterm(expr.right, model, n_orig)
+        return False
+    return _should_claim_composite(expr, model, n_orig, allow_general=True)
 
 
 def _is_tabulatable_trig_square(

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3621,11 +3621,20 @@ def _should_claim_composite(
         if p == int(p):
             if int(p) >= 3:
                 return True
-            # Integer square of a non-bare base: normally the dedicated square
-            # lift (a composed relaxation). Under H-UNI, claim it here so the
-            # exact 1-D hull can lift the whole single-variable square directly.
+            # Integer square of a non-bare base. Under H-UNI, claim it so the exact
+            # 1-D hull can lift the whole single-variable square directly — but NOT
+            # when the base is *affine*. A square of an affine (e.g. ``(x-3)**2``) is
+            # a convex quadratic the dedicated square lift already handles exactly;
+            # diverting it into the composite path changes the aux-column layout the
+            # incremental McCormick engine relies on and buys no tightness. Only a
+            # genuinely non-affine base (e.g. ``ln(x-2)``, whose square the standard
+            # path relaxes only via a looser composition) is claimed here.
             if allow_general and int(p) == 2:
-                return True
+                try:
+                    _linearize_affine_expr(expr.left, model, n_orig)
+                    return False  # affine base → dedicated square lift handles it
+                except ValueError:
+                    return True  # non-affine base → H-UNI hull is the right tool
             return False
         return True
     if allow_general and isinstance(expr, BinaryOp) and expr.op in ("+", "-"):

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3542,16 +3542,24 @@ def _composite_referenced_var(expr: Expression, model: Model) -> Optional[tuple[
 
 
 def _univariate_envelope_enabled() -> bool:
-    """H-UNI feature flag (``DISCOPT_UNIVARIATE_ENVELOPE``, default **OFF**).
+    """H-UNI feature flag (``DISCOPT_UNIVARIATE_ENVELOPE``, default **ON**).
 
-    Task ``cert:LR-2`` (``docs/dev/lever-a-root-tightness-plan.md`` §4). When ON,
-    a maximal single-variable subtree whose certified curvature is *neither*
-    convex nor concave is lifted with the exact 1-D convex/concave hull envelope
-    (:mod:`discopt._jax.univariate_hull`) instead of falling to a looser composed
-    relaxation. Default-OFF makes the flag-OFF relaxation byte-identical to prior
-    main (bound-changing regime, parent-plan §0.4).
+    Task ``cert:LR-2`` / ``cert:LR-3``. When ON, a maximal single-variable subtree
+    whose certified curvature is *neither* convex nor concave is lifted with the
+    exact 1-D convex/concave hull envelope (:mod:`discopt._jax.univariate_hull`)
+    instead of falling to a looser composed relaxation.
+
+    **Graduated default-ON (cert:LR-3).** Graduation gate (62-corpus + a MINLPLib
+    signomial/product draw): ``incorrect_count = 0``, zero certificate losses, and
+    it *adds* a certification (clay0303hfsg) while collapsing nvs09's tree
+    (215→3 nodes). Verified inert where it does not fire (byte-identical
+    status/objective/node_count on non-matching instances) and, post the LR-3
+    soundness fix, sound on the AMP path (no false-infeasible on unbounded boxes;
+    defers to exact trig-table / curvature handlers). Set
+    ``DISCOPT_UNIVARIATE_ENVELOPE=0`` to opt out (restores the prior composed
+    relaxation, byte-identical to pre-LR-2 main via the #630 fingerprint guard).
     """
-    return os.environ.get("DISCOPT_UNIVARIATE_ENVELOPE", "0") != "0"
+    return os.environ.get("DISCOPT_UNIVARIATE_ENVELOPE", "1") != "0"
 
 
 def _log_monomial_enabled() -> bool:

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3631,6 +3631,65 @@ def _should_claim_composite(
     return False
 
 
+def _is_tabulatable_trig_square(
+    expr: Expression,
+    model: Model,
+    n_orig: int,
+    flat_types: list[VarType],
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> bool:
+    """True when ``expr`` is exactly ``sin/cos(affine(x))**2`` for a small integer
+    domain ``x`` the finite-domain trig-square table covers exactly."""
+    if not (isinstance(expr, BinaryOp) and expr.op == "**" and isinstance(expr.right, Constant)):
+        return False
+    if float(expr.right.value) != 2.0:
+        return False
+    op = _univariate_arg(expr.left)
+    if op is None or op[0] not in {"sin", "cos"}:
+        return False
+    try:
+        arg_coeff, _arg_const = _linearize_affine_expr(op[1], model, n_orig)
+    except ValueError:
+        return False
+    nz = np.flatnonzero(np.abs(arg_coeff) > 1e-12)
+    if nz.size != 1:
+        return False
+    dom = _integer_domain_values(int(nz[0]), flat_types, flat_lb, flat_ub)
+    return dom is not None and 0 < len(dom) <= _MAX_FINITE_DOMAIN_TRIG_TABLE_VALUES
+
+
+def _defers_to_finite_domain_trig_table(
+    expr: Expression,
+    model: Model,
+    n_orig: int,
+    flat_types: list[VarType],
+    flat_lb: np.ndarray,
+    flat_ub: np.ndarray,
+) -> bool:
+    """True when every nonlinear part of ``expr`` is a tabulatable trig-square (a
+    ``sin/cos(affine(x))**2`` over a small integer domain).
+
+    H-UNI's ``allow_general`` claim otherwise grabs the whole composite — either
+    the bare ``trig(x)**2`` or an additive ``trig(x)**2 + c`` (the constraint RHS
+    form) — and relaxes it with a *continuous* 1-D hull, looser than the exact
+    per-integer-point table. Deferring lets the exact table
+    (:func:`_finite_domain_trig_square_table_values`) handle it. The recursion into
+    ``+``/``-`` keeps this from firing on genuinely non-tabulatable additive
+    composites (e.g. nvs09's ``(ln(x-2))**2 + (ln(10-x))**2`` — ``ln`` is not a
+    trig table), so the nvs09 win is preserved.
+    """
+
+    def all_nonlinear_tabulatable(e: Expression) -> bool:
+        if isinstance(e, BinaryOp) and e.op in ("+", "-"):
+            return all_nonlinear_tabulatable(e.left) and all_nonlinear_tabulatable(e.right)
+        if not _expr_has_nonlinear_subterm(e):
+            return True  # affine leaf: no nonlinear content to defer
+        return _is_tabulatable_trig_square(e, model, n_orig, flat_types, flat_lb, flat_ub)
+
+    return _expr_has_nonlinear_subterm(expr) and all_nonlinear_tabulatable(expr)
+
+
 def _expr_has_nonlinear_subterm(expr: Expression) -> bool:
     """True if ``expr`` contains a FunctionCall or a non-unit power — i.e. it is
     not a pure affine combination (which the exact linear path already handles)."""
@@ -3907,6 +3966,7 @@ def _collect_composite_univariate_relaxations(
     box = _build_convexity_box(model, flat_lb, flat_ub)
     base_x = np.zeros(n_orig, dtype=np.float64)
     allow_general = _univariate_envelope_enabled()
+    flat_types = _flat_variable_types(model)
 
     def maybe_add(expr: Expression) -> bool:
         """Attempt to lift ``expr`` as a composite. Returns True when it was
@@ -3921,6 +3981,12 @@ def _collect_composite_univariate_relaxations(
             return False
         if not _should_claim_composite(expr, model, n_orig, allow_general=allow_general):
             return False
+        # Defer to the exact finite-domain trig-square table (tighter than H-UNI's
+        # continuous hull) for sin/cos of a small integer domain.
+        if allow_general and _defers_to_finite_domain_trig_table(
+            expr, model, n_orig, flat_types, flat_lb, flat_ub
+        ):
+            return False
         # Is this node claimable by the *pre-existing* (curvature-certified) path?
         # If so, treat it exactly as before (claim, but let visit descend).
         _pre_existing_claim = _should_claim_composite(expr, model, n_orig, allow_general=False)
@@ -3930,7 +3996,14 @@ def _collect_composite_univariate_relaxations(
         var, flat_idx = ref
         lo = float(flat_lb[flat_idx])
         hi = float(flat_ub[flat_idx])
-        if not (np.isfinite(lo) and np.isfinite(hi)) or hi < lo:
+        # Use the solver-sense finiteness check (|bound| < 1e19), NOT raw
+        # np.isfinite: an *unbounded* variable carries a finite-but-astronomical
+        # default box (~±1e20), which np.isfinite accepts. Sampling a 1-D hull over
+        # a ~1e20-wide box is numerically meaningless (aux magnitudes reach ~1e60)
+        # and drives the LP to a false `infeasible`. Abstain → fall back to the
+        # sound composed relaxation. (Root cause of the H-UNI AMP min/max
+        # false-infeasible, cert:LR-3.)
+        if not (_is_effectively_finite(lo) and _is_effectively_finite(hi)) or hi < lo:
             return False
         try:
             f = compile_expression(expr, model)
@@ -3997,9 +4070,15 @@ def _collect_composite_univariate_relaxations(
         )
         bounds.append(col_bounds)
         col_idx += 1
-        # Only a *new* general (non-pre-existing) claim blocks descent; a
-        # convex/concave claim behaves exactly as prior main (descent continues).
-        return not _pre_existing_claim
+        # A *new* general (non-pre-existing) claim always blocks descent. When
+        # H-UNI is on, a pre-existing convex/concave composite ALSO blocks descent:
+        # the whole single-variable node is already relaxed as a composite in x, so
+        # descending would let H-UNI redundantly re-claim an inner sub-expression
+        # (e.g. the ``x**2 + 1`` inside a claimed ``sqrt(x**2 + 1)``) — sound but a
+        # duplicate column. When the flag is OFF, descent is unchanged from prior
+        # main (byte-identity: the general ``+``/``**2`` claims never fire, so
+        # descending into a convex composite claims nothing anyway).
+        return (not _pre_existing_claim) or allow_general
 
     def visit(expr: Expression) -> None:
         if maybe_add(expr):
@@ -4126,7 +4205,14 @@ def _collect_aliased_monomial_hull_relaxations(
             continue
         lo = float(flat_lb[flat_idx])
         hi = float(flat_ub[flat_idx])
-        if not (np.isfinite(lo) and np.isfinite(hi)) or hi - lo <= _COMPOSITE_CURV_TOL:
+        # Solver-sense finiteness (see the companion guard in
+        # _collect_composite_univariate_relaxations): reject the ~±1e20 default
+        # box of an unbounded variable, over which the sampled hull is numerically
+        # meaningless and yields a false `infeasible`.
+        if (
+            not (_is_effectively_finite(lo) and _is_effectively_finite(hi))
+            or hi - lo <= _COMPOSITE_CURV_TOL
+        ):
             continue
         # Compiling + vmapping the alias body is the expensive step; cache the
         # traced batch evaluator across nodes (the box changes per node, but the

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -3542,24 +3542,31 @@ def _composite_referenced_var(expr: Expression, model: Model) -> Optional[tuple[
 
 
 def _univariate_envelope_enabled() -> bool:
-    """H-UNI feature flag (``DISCOPT_UNIVARIATE_ENVELOPE``, default **ON**).
+    """H-UNI feature flag (``DISCOPT_UNIVARIATE_ENVELOPE``, default **OFF** — opt-in).
 
     Task ``cert:LR-2`` / ``cert:LR-3``. When ON, a maximal single-variable subtree
     whose certified curvature is *neither* convex nor concave is lifted with the
     exact 1-D convex/concave hull envelope (:mod:`discopt._jax.univariate_hull`)
-    instead of falling to a looser composed relaxation.
+    instead of falling to a looser composed relaxation. Set
+    ``DISCOPT_UNIVARIATE_ENVELOPE=1`` to opt in.
 
-    **Graduated default-ON (cert:LR-3).** Graduation gate (62-corpus + a MINLPLib
-    signomial/product draw): ``incorrect_count = 0``, zero certificate losses, and
-    it *adds* a certification (clay0303hfsg) while collapsing nvs09's tree
-    (215→3 nodes). Verified inert where it does not fire (byte-identical
-    status/objective/node_count on non-matching instances) and, post the LR-3
-    soundness fix, sound on the AMP path (no false-infeasible on unbounded boxes;
-    defers to exact trig-table / curvature handlers). Set
-    ``DISCOPT_UNIVARIATE_ENVELOPE=0`` to opt out (restores the prior composed
-    relaxation, byte-identical to pre-LR-2 main via the #630 fingerprint guard).
+    **Graduation deferred (kept default-OFF).** The gate result was sound (nvs09
+    certifies, tree 215→3, ``incorrect_count = 0``), but graduating H-UNI default-ON
+    surfaced a class of *claim-boundary collisions*: as an additional overlapping
+    "claimer" layered onto the federated lifted-relaxation path, H-UNI diverts terms
+    the dedicated exact machinery already handles (bare-monomial lifts, the square
+    lift, the issue-267 univariate-product path, the finite-domain trig table),
+    arbitrated by a hand-maintained defer-list in :func:`_should_claim_composite`.
+    Those collisions are order-masked under pytest-xdist, so a green parallel suite
+    is not proof of no silent divert. The principled home for graduating H-UNI is the
+    AVM/factorable-canonicalization work (``docs/dev/maingo-parity-plan.md``), where a
+    single canonical normal form gives one envelope per atom and the defer-list
+    disappears. Until then H-UNI ships as a sound opt-in flag; OFF is byte-identical
+    to prior main (the #630 fingerprint guard proves it), and the LR-3 soundness fixes
+    (no hull over effectively-unbounded boxes; the claim-boundary defers) still harden
+    the opt-in ON path.
     """
-    return os.environ.get("DISCOPT_UNIVARIATE_ENVELOPE", "1") != "0"
+    return os.environ.get("DISCOPT_UNIVARIATE_ENVELOPE", "0") != "0"
 
 
 def _log_monomial_enabled() -> bool:

--- a/python/tests/test_convex_fast_path.py
+++ b/python/tests/test_convex_fast_path.py
@@ -96,22 +96,12 @@ class TestNonconvexContinuousSpatialRegressions:
 
         result = m.solve(nlp_solver="ipm", time_limit=10.0, gap_tolerance=1e-6, max_nodes=1)
 
-        # Core invariants (the point of this regression): a nonconvex model must
-        # dispatch to spatial B&B, branch, and NOT falsely certify optimality at the
-        # node cap — with a bound that never crosses the true optimum (-1.0).
         assert result.convex_fast_path is False
         assert result.status != "optimal"
-        assert result.node_count > 1
         assert result.objective is not None
-        # cert:LR-3 graduated H-UNI (DISCOPT_UNIVARIATE_ENVELOPE) default-ON. Its exact
-        # 1-D hull of exp(-10000*(x-0.05)**2) tightens the root relaxation enough that
-        # the relaxed point steers the node NLP into the deep well, so the incumbent is
-        # now the true global min (-1.0) instead of a shallow local point. That is a
-        # sound improvement, not a regression: the incumbent is a real feasible point
-        # (>= the true optimum) and the bound stays a valid lower bound (<= incumbent).
-        assert result.objective >= -1.0 - 1e-6  # valid feasible point, never below true min
+        assert result.objective > -0.1
+        assert result.node_count > 1
         assert result.bound is None or result.bound < -0.5
-        assert result.bound is None or result.bound <= result.objective + 1e-6
 
     def test_nonconvex_continuous_qp_minimize_uses_spatial_bb(self):
         m = Model("nonconvex_qp_min")

--- a/python/tests/test_convex_fast_path.py
+++ b/python/tests/test_convex_fast_path.py
@@ -96,12 +96,22 @@ class TestNonconvexContinuousSpatialRegressions:
 
         result = m.solve(nlp_solver="ipm", time_limit=10.0, gap_tolerance=1e-6, max_nodes=1)
 
+        # Core invariants (the point of this regression): a nonconvex model must
+        # dispatch to spatial B&B, branch, and NOT falsely certify optimality at the
+        # node cap — with a bound that never crosses the true optimum (-1.0).
         assert result.convex_fast_path is False
         assert result.status != "optimal"
-        assert result.objective is not None
-        assert result.objective > -0.1
         assert result.node_count > 1
+        assert result.objective is not None
+        # cert:LR-3 graduated H-UNI (DISCOPT_UNIVARIATE_ENVELOPE) default-ON. Its exact
+        # 1-D hull of exp(-10000*(x-0.05)**2) tightens the root relaxation enough that
+        # the relaxed point steers the node NLP into the deep well, so the incumbent is
+        # now the true global min (-1.0) instead of a shallow local point. That is a
+        # sound improvement, not a regression: the incumbent is a real feasible point
+        # (>= the true optimum) and the bound stays a valid lower bound (<= incumbent).
+        assert result.objective >= -1.0 - 1e-6  # valid feasible point, never below true min
         assert result.bound is None or result.bound < -0.5
+        assert result.bound is None or result.bound <= result.objective + 1e-6
 
     def test_nonconvex_continuous_qp_minimize_uses_spatial_bb(self):
         m = Model("nonconvex_qp_min")

--- a/python/tests/test_lr2_huni_unbounded_guard.py
+++ b/python/tests/test_lr2_huni_unbounded_guard.py
@@ -1,0 +1,99 @@
+"""cert:LR-3 — H-UNI soundness/quality guards, exercised with the flag ON.
+
+The default-OFF tests elsewhere run the flag off, so they cannot catch a
+regression in the H-UNI (``DISCOPT_UNIVARIATE_ENVELOPE``) path. These tests set
+the flag ON explicitly and assert the three behaviours the LR-3 fix established:
+
+1. **No false-infeasible on unbounded variables.** H-UNI must not build a 1-D
+   hull over an *effectively unbounded* box (the ~±1e20 default of an unbounded
+   variable); the sampled hull is numerically meaningless (aux magnitudes reach
+   ~1e60) and drives the LP to a false ``infeasible``. The guard uses the
+   solver-sense ``is_effectively_finite`` (|bound| < 1e19), not raw ``np.isfinite``.
+2. **Defer to the exact finite-domain trig-square table.** ``sin/cos(int x)**2``
+   (and its additive ``... + c`` form) is covered exactly by the table; H-UNI's
+   continuous hull is looser, so it must defer.
+3. **No redundant sub-expression composite.** H-UNI must not re-claim an inner
+   composite of an already-claimed single-variable composite.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import pytest
+from discopt.modeling.core import Model
+
+pytestmark = [pytest.mark.correctness]
+
+
+def _build(model):
+    from discopt._jax.discretization import initialize_partitions
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    terms = classify_nonlinear_terms(model)
+    state = initialize_partitions([], lb=[], ub=[], n_init=2)
+    return build_milp_relaxation(model, terms, state, incumbent=None)
+
+
+def test_huni_unbounded_variable_not_false_infeasible(monkeypatch):
+    """Unbounded x + a min/max of polynomial branches: H-UNI must abstain on the
+    effectively-unbounded box and fall back to a sound relaxation (optimal), not
+    certify a false ``infeasible``."""
+    monkeypatch.setenv("DISCOPT_UNIVARIATE_ENVELOPE", "1")
+    m = Model("huni_unbounded")
+    x = m.continuous("x")  # unbounded → ~±1e20 default box
+    m.maximize(dm.minimum(0.75 + (x - 0.5) ** 3, 0.75 - (x - 0.5) ** 2))
+    milp_model, _ = _build(m)
+    result = milp_model.solve()
+    assert result.status != "infeasible", (
+        "H-UNI built a hull over an unbounded box → false infeasible"
+    )
+    assert result.status == "optimal"
+
+
+def test_huni_bounded_variable_still_fires(monkeypatch):
+    """The guard is targeted: on a *finite* box H-UNI still engages soundly."""
+    monkeypatch.setenv("DISCOPT_UNIVARIATE_ENVELOPE", "1")
+    m = Model("huni_bounded")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    m.maximize(dm.minimum(0.75 + (x - 0.5) ** 3, 0.75 - (x - 0.5) ** 2))
+    milp_model, _ = _build(m)
+    assert milp_model.solve().status == "optimal"
+
+
+def test_huni_defers_to_finite_domain_trig_table(monkeypatch):
+    """sin(int x)**2 in a constraint RHS must go to the exact table, not H-UNI's
+    looser hull: the relaxation bound must match the flag-OFF (exact-table) value."""
+    import numpy as np
+
+    def build_sin():
+        m = Model("huni_trig")
+        x = m.integer("x", lb=0, ub=4)
+        y = m.continuous("y", lb=0, ub=4)
+        m.maximize(10 * x + y)
+        m.subject_to(y <= dm.sin(x) ** 2 + 2)
+        return _build(m)[0].solve()
+
+    monkeypatch.setenv("DISCOPT_UNIVARIATE_ENVELOPE", "0")
+    off = build_sin()
+    monkeypatch.setenv("DISCOPT_UNIVARIATE_ENVELOPE", "1")
+    on = build_sin()
+    exact = -(40.0 + np.sin(4.0) ** 2 + 2.0)
+    assert on.status == "optimal" and off.status == "optimal"
+    # ON must not be looser than the exact table (which OFF uses).
+    assert on.objective == pytest.approx(off.objective, abs=1e-8)
+    assert on.objective == pytest.approx(exact, abs=1e-8)
+
+
+def test_huni_no_redundant_subexpression_composite(monkeypatch):
+    """sqrt(x**2 + 1): the convex composite is claimed once; H-UNI must not also
+    claim the inner x**2 + 1 (a redundant duplicate column)."""
+    monkeypatch.setenv("DISCOPT_UNIVARIATE_ENVELOPE", "1")
+    m = Model("huni_nested")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    m.minimize(dm.sqrt(x**2 + 1.0))
+    milp_model, varmap = _build(m)
+    result = milp_model.solve()
+    assert len(varmap["composite_relaxations"]) == 1
+    assert result.status == "optimal"
+    assert result.bound is not None and result.bound <= 1.0 + 1e-6

--- a/python/tests/test_lr2_offneutral_relaxation.py
+++ b/python/tests/test_lr2_offneutral_relaxation.py
@@ -85,8 +85,11 @@ def _clear_flags(monkeypatch):
     yield
 
 
-def test_flags_off_by_default():
-    assert mr._univariate_envelope_enabled() is False
+def test_flag_defaults_post_lr3_graduation():
+    # cert:LR-3 graduated H-UNI default-ON (sound + adds a certification + inert
+    # where it does not fire). H-LOG stays default-OFF (no binding target: nvs09
+    # closes without it, nvs05 was killed). ``=0`` opts out of H-UNI.
+    assert mr._univariate_envelope_enabled() is True
     assert mr._log_monomial_enabled() is False
 
 
@@ -110,6 +113,10 @@ def test_relaxation_off_byte_identical_corpus(name, monkeypatch):
     collectors. Because the flags are OFF, the real path already takes these
     branches — so equality proves the OFF path is a genuine no-op (no row leaks),
     byte-identical to prior main, on every corpus instance."""
+    # H-UNI is default-ON post cert:LR-3, so force the opt-out (=0) to exercise the
+    # genuine flag-OFF path this guardrail is about.
+    monkeypatch.setenv("DISCOPT_UNIVARIATE_ENVELOPE", "0")
+    monkeypatch.setenv("DISCOPT_LOG_MONOMIAL", "0")
     fp_real_off = _relaxation_fingerprint(name)
 
     # Force the additive Path-B entry points to their code-absent behavior.
@@ -127,6 +134,7 @@ def test_relaxation_off_byte_identical_corpus(name, monkeypatch):
 def test_flag_on_changes_nvs09_relaxation(monkeypatch):
     """Flag ON must add rows to nvs09's relaxation — proves the envelope lever is
     real, not an inert flag (CLAUDE.md §3)."""
+    monkeypatch.setenv("DISCOPT_UNIVARIATE_ENVELOPE", "0")
     fp_off = _relaxation_fingerprint("nvs09")
     monkeypatch.setenv("DISCOPT_UNIVARIATE_ENVELOPE", "1")
     fp_on = _relaxation_fingerprint("nvs09")

--- a/python/tests/test_lr2_offneutral_relaxation.py
+++ b/python/tests/test_lr2_offneutral_relaxation.py
@@ -85,11 +85,13 @@ def _clear_flags(monkeypatch):
     yield
 
 
-def test_flag_defaults_post_lr3_graduation():
-    # cert:LR-3 graduated H-UNI default-ON (sound + adds a certification + inert
-    # where it does not fire). H-LOG stays default-OFF (no binding target: nvs09
-    # closes without it, nvs05 was killed). ``=0`` opts out of H-UNI.
-    assert mr._univariate_envelope_enabled() is True
+def test_flags_default_off():
+    # cert:LR-3 graduation was DEFERRED: H-UNI stays default-OFF (opt-in) because
+    # graduating it default-ON surfaced order-masked claim-boundary collisions with
+    # the existing lifted-relaxation paths (see _univariate_envelope_enabled docstring
+    # and docs/dev/maingo-parity-plan.md). H-LOG is likewise default-OFF. Both remain
+    # sound opt-in flags; OFF is byte-identical to prior main (guarded below).
+    assert mr._univariate_envelope_enabled() is False
     assert mr._log_monomial_enabled() is False
 
 


### PR DESCRIPTION
## Summary

H-UNI (`DISCOPT_UNIVARIATE_ENVELOPE`) soundness hardening. Originally opened to
graduate H-UNI default-ON (cert:LR-3); **graduation is now deferred** and the flag
stays a sound **opt-in** (default-OFF). See #632 for the principled path to
graduating it (AVM/factorable canonicalization).

## Why graduation was deferred

Graduating H-UNI default-ON was sound (nvs09 certifies, tree 215→3,
`incorrect_count = 0`) but surfaced a class of **claim-boundary collisions**: as an
additional overlapping claimer on the federated lifted-relaxation path, H-UNI
diverts terms the dedicated exact machinery already handles (bare-monomial lift,
square lift, the issue-267 univariate-product path, the finite-domain trig table),
arbitrated only by a hand-maintained defer-list in `_should_claim_composite`. Those
collisions are **order-masked under pytest-xdist** (test_issue_267 passed under
`-n4`, failed serially / in CI), so a green parallel suite is not proof of no silent
divert. The whole measured gain is one certified instance (global50 43→44). Not
worth shipping on a claim boundary reverse-engineered from flaky tests.

## What this PR keeps (hardens the opt-in ON path; inert on the OFF default)

- **LR-3 soundness fix:** H-UNI no longer builds a 1-D hull over an *effectively
  unbounded* box (was a false-infeasible on the AMP path). Uses solver-sense
  `is_effectively_finite` (|bound| < 1e19), not raw `np.isfinite`.
- **Claim-boundary defers** (behind `allow_general`): affine-square → the exact
  square lift; a `_has_genuine_composite_subterm` gate on the additive claim so bare
  monomials (`x**p + x`) defer to the exact monomial lift. Keeps nvs09's
  `(ln(x-2))**2 + (ln(10-x))**2` claimed.
- Regression tests exercising the flag **ON** (`test_lr2_huni_unbounded_guard.py`).

## What this PR reverts to prior-main

- The default flip — `DISCOPT_UNIVARIATE_ENVELOPE` is default-**OFF** again.
- `test_lr2_offneutral_relaxation` flag-default test asserts OFF.
- `test_convex_fast_path` / `test_issue_267` restored to their default-path (OFF)
  assertions.

OFF is **byte-identical to prior main**, proven by the #630 relaxation-fingerprint
guard (`test_relaxation_off_byte_identical_corpus`).

## Verification

- Full PR-fast suite green **serially** (5351 passed, 0 failed) with the flag ON —
  the claim-boundary is internally consistent for covered tests.
- At the restored OFF default: #630 byte-identity + LR-3 ON-guards + nvs09 opt-in
  cert all pass (76/76 on the affected set).
- Pre-commit (ruff, ruff-format, mypy) green. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
