### PR TITLE
chore(deps): require pounce-solver>=0.8 (+ adapt Schur/ordering tests to compiled Problem)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jaxlib>=0.4",
     "numpy>=1.24",
     "scipy>=1.10",
-    "pounce-solver>=0.7",
+    "pounce-solver>=0.8",
 ]
 
 [project.urls]
@@ -40,7 +40,7 @@ Issues = "https://github.com/jkitchin/discopt/issues"
 [project.optional-dependencies]
 # POUNCE is now a core dependency (the default NLP/IPM engine); this extra is
 # kept as a no-op alias for back-compat with `pip install discopt[pounce]`.
-pounce = ["pounce-solver>=0.7"]
+pounce = ["pounce-solver>=0.8"]
 ipopt = ["cyipopt>=1.4"]
 cutest = ["pycutest>=1.8.0"]
 # GAMS solver link: the expert-level GAMS Python API (GMO/GEV). Ships with a

--- a/python/tests/test_nlp_pounce.py
+++ b/python/tests/test_nlp_pounce.py
@@ -322,6 +322,39 @@ class TestMaximize:
 # ─────────────────────────────────────────────────────────────
 
 
+class _RecordingProblem:
+    """Delegating proxy around a ``pounce.Problem`` that records one method's arg.
+
+    pounce 0.8 makes ``Problem`` a compiled object (``pounce._pounce.Problem``)
+    whose attributes are **read-only**, so a call spy can no longer be installed via
+    ``monkeypatch.setattr(prob, "set_kkt_schur_block", ...)`` — it raises
+    ``AttributeError: ... is read-only``. discopt consumes the Problem purely by
+    method dispatch (``add_option`` / ``set_kkt_schur_block`` / ``set_ordering`` /
+    ``solve``), so wrapping the real object in a pure-Python proxy lets the test
+    observe the forwarded argument verbatim without mutating the compiled object.
+    Everything except the intercepted method delegates straight through."""
+
+    def __init__(self, real, record, method, key):
+        object.__setattr__(self, "_real", real)
+        object.__setattr__(self, "_record", record)
+        object.__setattr__(self, "_method", method)
+        object.__setattr__(self, "_key", key)
+
+    def __getattr__(self, name):
+        real = object.__getattribute__(self, "_real")
+        attr = getattr(real, name)  # raises AttributeError if absent (matches real)
+        if name == object.__getattribute__(self, "_method") and callable(attr):
+            record = object.__getattribute__(self, "_record")
+            key = object.__getattribute__(self, "_key")
+
+            def _spy(arg, *a, **k):
+                record[key] = list(arg)
+                return attr(arg, *a, **k)
+
+            return _spy
+        return attr
+
+
 class TestSchurPassthrough:
     def _eq_model(self):
         """min x^2 + y^2 s.t. x + y == 2 => optimal at (1, 1). n=2, m=1."""
@@ -340,15 +373,8 @@ class TestSchurPassthrough:
         def make_problem(*args, **kwargs):
             prob = original_problem(*args, **kwargs)
             if hasattr(prob, "set_kkt_schur_block"):
-                orig = prob.set_kkt_schur_block
-
-                def spy(block):
-                    captured["block"] = list(block)
-                    return orig(block)
-
-                monkeypatch.setattr(prob, "set_kkt_schur_block", spy, raising=False)
-            else:
-                captured["no_method"] = True
+                return _RecordingProblem(prob, captured, "set_kkt_schur_block", "block")
+            captured["no_method"] = True
             return prob
 
         monkeypatch.setattr(pounce, "Problem", make_problem)
@@ -398,15 +424,8 @@ class TestSchurPassthrough:
         def make_problem(*args, **kwargs):
             prob = original_problem(*args, **kwargs)
             if hasattr(prob, "set_ordering"):
-                orig = prob.set_ordering
-
-                def spy(order):
-                    captured["order"] = list(order)
-                    return orig(order)
-
-                monkeypatch.setattr(prob, "set_ordering", spy, raising=False)
-            else:
-                captured["no_method"] = True
+                return _RecordingProblem(prob, captured, "set_ordering", "order")
+            captured["no_method"] = True
             return prob
 
         monkeypatch.setattr(pounce, "Problem", make_problem)


### PR DESCRIPTION
## Summary

Bumps the `pounce-solver` dependency floor from **0.7 → 0.8** (0.8.0 released
2026-07-11) in `pyproject.toml` (core dep + the `[pounce]` extra alias).

## Why it isn't a one-liner

pounce 0.8 makes `pounce.Problem` a **compiled** object (`pounce._pounce.Problem`)
whose instance attributes are **read-only**.

- **Production is unaffected.** `discopt.solvers.nlp_pounce.solve_nlp` uses the
  Problem purely by method dispatch (`add_option` / `set_kkt_schur_block` /
  `set_ordering` / `solve`), each guarded by `hasattr` + `try/except`. KKT-Schur and
  ordering passthrough still work; unsupported methods degrade to the full-space
  solve. No production code changed.
- **Two tests broke.** `test_nlp_pounce.py::TestSchurPassthrough` installed a call
  spy via `monkeypatch.setattr(prob, "set_kkt_schur_block", …)`, which now raises
  `AttributeError: … is read-only`. Because that raised inside the
  `monkeypatch.setattr(pounce, "Problem", make_problem)` wrapper, it poisoned the
  whole class and leaked into `test_pounce_batch` / `test_pounce_bound_snap`
  (9 failures under the PR-fast ordering; green in isolation — classic order-masked
  pollution).

## Fix (test-only, no weakening)

A `_RecordingProblem` proxy wraps the real compiled Problem, records the forwarded
argument in `__getattr__`, and delegates every other method straight through
(discopt never type-checks the Problem, so the proxy is transparent). The spy tests
still assert the exact forwarded values (`block == [2]`, `order == [0, 1, 2]`).

## Heads-up

CI installs `pounce-solver` **unpinned**, so main CI would have hit this on its next
run once 0.8.0 became the latest release — independent of this floor bump.

## Verification

- Full pounce group green: **42 passed** (was 9 failed) run in the failing order.
- `pytest -m smoke`: **645 passed**, 1 skipped.
- Pre-commit (ruff / ruff-format / mypy) green. No production code, no Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
