### PR TITLE
chore(release): open 0.6.1 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The release procedure that produces these entries is documented in
 [`RELEASE.md`](RELEASE.md).
 
+## [Unreleased]
+
 ## [0.6.0] - 2026-07-12
 
 ### Removed
@@ -507,6 +509,7 @@ git log v0.2.0..v0.2.1
 
 Going forward, every release will have a section above with curated entries.
 
+[Unreleased]: https://github.com/jkitchin/discopt/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/jkitchin/discopt/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/jkitchin/discopt/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jkitchin/discopt/compare/v0.3.0...v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "discopt"
-version = "0.6.0"
+version = "0.6.1.dev0"
 description = "Hybrid MINLP solver combining Rust and JAX"
 requires-python = ">=3.10"
 authors = [{name = "John Kitchin"}]

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -25,7 +25,7 @@ solvers
     NLP solver backends: POUNCE (pure-Rust Ipopt port), pure-JAX IPM (vmap batch), cyipopt (Ipopt).
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1.dev0"
 
 # Allow external distributions (e.g. the ``discopt-aggregation`` plugin) to
 # contribute submodules under the ``discopt`` namespace from a separate location


### PR DESCRIPTION
Post-release housekeeping for v0.6.0 (RELEASE.md §12).

- Bump `pyproject.toml` + `python/discopt/__init__.py` to **0.6.1.dev0** (opens the
  next dev cycle; `CITATION.cff` stays at 0.6.0 to match the released tag).
- Add a fresh `## [Unreleased]` section + compare link to `CHANGELOG.md`.

v0.6.0 is published: tag `v0.6.0`, PyPI (12 files: cp310–cp313 Linux/macOS/Windows
wheels + sdist), and the GitHub Release are all live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
