### PR TITLE
fix(correctness): bilevel P0 false-optimal (GDP big-M sentinel) + certified/convex-NLP followers

### DIFF
--- a/.crucible/references.bib
+++ b/.crucible/references.bib
@@ -2544,3 +2544,42 @@
   url = {https://doi.org/10.1002/cite.202255033},
   note = {Overview of MAiNGO's algorithm and application niches. Ingested 2026-07-09.},
 }
+
+@book{dempe2002,
+  author    = {Dempe, Stephan},
+  title     = {Foundations of Bilevel Programming},
+  publisher = {Kluwer Academic},
+  year      = {2002},
+  doi       = {10.1007/b101970},
+}
+
+@book{bard1998,
+  author    = {Bard, Jonathan F.},
+  title     = {Practical Bilevel Optimization: Algorithms and Applications},
+  publisher = {Springer US},
+  series    = {Nonconvex Optimization and Its Applications},
+  volume    = {30},
+  year      = {1998},
+  doi       = {10.1007/978-1-4757-2836-1},
+}
+
+@article{colson-marcotte-savard-2007,
+  author  = {Colson, Beno{\^\i}t and Marcotte, Patrice and Savard, Gilles},
+  title   = {An overview of bilevel optimization},
+  journal = {Annals of Operations Research},
+  volume  = {153},
+  number  = {1},
+  pages   = {235--256},
+  year    = {2007},
+  doi     = {10.1007/s10479-007-0176-2},
+}
+
+@article{kleinert-labbe-ljubic-schmidt-2021,
+  author  = {Kleinert, Thomas and Labb{\'e}, Martine and Ljubi{\'c}, Ivana and Schmidt, Martin},
+  title   = {A survey on mixed-integer programming techniques in bilevel optimization},
+  journal = {EURO Journal on Computational Optimization},
+  volume  = {9},
+  pages   = {100007},
+  year    = {2021},
+  doi     = {10.1016/j.ejco.2021.100007},
+}

--- a/.crucible/wiki/concepts/bilevel-programming.org
+++ b/.crucible/wiki/concepts/bilevel-programming.org
@@ -1,0 +1,122 @@
+#+TITLE: Bilevel Programming
+#+FILETAGS: :concept:bilevel:stackelberg:kkt:mpec:complementarity:big-m:
+bibliography:../../references.bib
+
+* Bilevel Programming
+:PROPERTIES:
+:ARTICLE_TYPE: concept
+:SOURCE_KEYS: bard1998 dempe2002 colson-marcotte-savard-2007 kleinert-labbe-ljubic-schmidt-2021
+:STATUS: new
+:CREATED: 2026-07-14
+:UPDATED: 2026-07-14
+:END:
+
+A bilevel program is an optimization problem in which one problem is nested inside
+another: a /leader/ optimizes an objective subject to constraints, one of which
+requires a /follower/ to be optimal for its own problem, parameterized by the
+leader's decision. It is the mathematical form of a Stackelberg game, where the
+leader commits to a decision and the follower responds by best-replying
+citep:bard1998,dempe2002. Writing the leader's variables as $x$ and the follower's
+as $y$, the problem is
+
+\[
+\min_{x,y}\; F(x,y) \quad\text{s.t.}\quad G(x,y) \le 0,\quad
+y \in \arg\min_{y'}\{\, f(x,y') : g(x,y') \le 0 \,\}.
+\]
+
+The argmin constraint is the whole difficulty: it is an /optimization problem
+embedded inside a constraint/, so the feasible set of the leader is defined
+implicitly by the follower's optimality rather than by ordinary algebraic
+inequalities. Even when all data are linear, the resulting problem is nonconvex and
+NP-hard citep:colson-marcotte-savard-2007.
+
+** Optimistic versus pessimistic
+
+When the follower's optimal response is not unique, the bilevel problem is
+ill-posed until one specifies how ties are broken. The /optimistic/ formulation
+lets the leader choose, among all follower optima, the one most favorable to the
+leader; the /pessimistic/ formulation makes the leader hedge against the least
+favorable response. The optimistic case is the standard, well-posed, and tractable
+one and is what the KKT reduction below produces; the pessimistic case has a
+min--max structure that is genuinely harder and is treated separately in the
+literature citep:dempe2002,colson-marcotte-savard-2007.
+
+** The KKT reduction to a single level
+
+The canonical exact reduction applies when the follower's problem is /convex in
+$y$/ for each fixed $x$. Then the follower's Karush--Kuhn--Tucker (KKT) conditions
+are necessary /and sufficient/ for its optimality, so the argmin constraint can be
+replaced by the KKT system, collapsing the two levels into one:
+
+- stationarity $\nabla_y L = 0$ with the Lagrangian $L = f + \sum_i \mu_i g_i$,
+- primal feasibility $g_i(x,y) \le 0$,
+- dual feasibility $\mu_i \ge 0$,
+- complementarity $0 \le \mu_i \perp -g_i(x,y) \ge 0$.
+
+The result is a single-level Mathematical Program with Equilibrium Constraints
+(MPEC): an ordinary nonlinear program plus complementarity conditions. The
+convexity precondition is not advice but a soundness requirement — for a nonconvex
+follower the KKT conditions are only /necessary/, so the reduction would admit
+points that are stationary but not follower-optimal, silently changing the problem.
+
+The strong-duality reduction is an alternative for a linear (or convex) follower:
+replace the follower by primal feasibility, dual feasibility, and the single
+equality $c^\top y = b^\top \lambda$ equating primal and dual objectives. It trades
+the disjunctive complementarity for one bilinear equality, which the global
+spatial-branching solver handles directly; it is often convenient because it avoids
+discrete complementarity branching, at the cost of a nonconvex equality that is not
+gap-certifiable.
+
+** The big-M multiplier-bound pitfall
+
+Reducing complementarity to a solvable form is where bilevel programs are most
+easily mis-solved. Each condition $0 \le \mu_i \perp -g_i \ge 0$ is a disjunction
+(either $\mu_i = 0$ or $g_i = 0$), and the two standard encodings —
+[[file:generalized-disjunctive-programming.org][GDP]] big-M and SOS1 — both need a
+/finite bound/ on every participating variable to build a valid
+[[file:big-m-formulations.org][big-M]] linking constraint. The subtlety is that KKT
+multipliers $\mu_i$ have /no a priori upper bound/: the leader can, in general, drive
+the follower's dual arbitrarily large, and the multiplier is pinned only by
+complementarity itself, not by the linear KKT relaxation.
+
+This creates a trap that is easy to miss. If a multiplier is left at a solver's
+"unbounded" sentinel and that sentinel value is used as the big-M $M$, the
+disjunction link $\mu_i \le M\,b$ (with binary selector $b$) is satisfiable with $b$
+far below the integrality tolerance while $\mu_i$ is large — the disjunction becomes
+/numerically vacuous/, complementarity is never enforced, and the solver returns a
+follower-infeasible point with a spurious optimality certificate. The failure is a
+false /optimal/, not a false infeasible, and is invisible unless the returned $y$ is
+independently checked against the follower's own optimum. The lesson is that a big-M
+must be a genuinely usable finite bound, and a sentinel-magnitude value must be
+refused rather than used — treating it as "large but finite" is unsound.
+
+Deriving /valid/ finite multiplier bounds automatically is the crux of certified
+bilevel optimization, and it is NP-hard in general: there is no free lunch, and
+constant-factor or heuristic big-Ms can cut off the true optimum
+citep:kleinert-labbe-ljubic-schmidt-2021. Bound-tightening over the linear KKT
+relaxation does not help, because the multiplier's unboundedness there is exactly
+the recession direction that complementarity would remove. Practical certified
+solves therefore rely on problem-specific valid bounds — supplied by the modeler, or
+derived from structure the solver can exploit.
+
+** Realization in discopt
+
+discopt implements the optimistic KKT reduction in =discopt.bilevel=. A symbolic
+differentiator over the [[file:expression-dag-and-ad.org][expression DAG]] emits the
+stationarity condition $\nabla_y L = 0$ as ordinary algebraic constraints, keeping
+the reformulation inside the certified global path rather than behind an opaque
+numeric-gradient node. Complementarity is handed to the MPEC layer (GDP / SOS1 /
+Scholtes). A convexity gate certifies the follower is convex in $y$ — a
+constant-Hessian PSD test for LP/QP followers, and an interval-Hessian Gershgorin
+test over the variable box for convex-NLP followers, which accepts the natural
+linearly-coupled form such as $e^{y} - x\,y$ (convex in $y$ though not jointly convex
+in $(x,y)$). Nonconvex, integer-follower, and pessimistic problems are refused
+loudly.
+
+Consistent with the big-M pitfall above, discopt /refuses/ the certified GDP/SOS1
+path when the follower multipliers are unbounded, rather than emit a vacuous big-M.
+The modeler can supply a valid finite multiplier bound to obtain a gap-certified
+solve, or use the strong-duality reduction for an exact but uncertified solve. This
+is the honest position the survey literature recommends: expose the certificate
+faithfully, and never manufacture one from an unproven bound
+citep:kleinert-labbe-ljubic-schmidt-2021.

--- a/docs/dev/bilevel-audit-2026-07-13.md
+++ b/docs/dev/bilevel-audit-2026-07-13.md
@@ -1,0 +1,88 @@
+# Audit report — `discopt.bilevel` (2026-07-13)
+
+**Scope.** Verify the existing (Phases 0–3) bilevel module: does it run green, are
+its soundness gates correct, and does the design doc match the code. Environment:
+`pip install -e ".[dev]"` + pounce, Rust extension built; JAX + scipy present.
+
+## Summary
+
+The reformulation *math* is correct and the convexity gate is sound, but the
+module's headline capability — a **certified global bilevel solve** — was
+**untested and, on its default path, unsound**. A P0 false-optimal was found and
+fixed; coverage and doc drift were closed.
+
+| Workstream | Result |
+|---|---|
+| A. Baseline suite | ✅ 64 bilevel/mpec tests passed; ruff clean |
+| B. `symbolic_diff` engine | ✅ correct vs `jax.grad`; **coverage gap closed** (structural nodes were untested) |
+| C. Convexity gate | ✅ sound & conservative on every edge case (incl. max-follower sign-flip); **edge cases now tested** |
+| D. KKT / strong-duality emission | ✅ signs, free multipliers, follower-bound fold all correct |
+| E. End-to-end certified solve | ❌→✅ **P0 false-optimal found & fixed**; first end-to-end solve tests added |
+| F. Doc/code drift | ✅ reconciled (`convexity_gate.py`, false "certified → CI" claims) |
+
+## E — the P0 false optimal (headline)
+
+No test anywhere called `model.solve()` on a `BilevelProblem`. Running one:
+
+- **`kkt` + `gdp`** (the module default, used by `example_bilevel_toll`) on a linear
+  Bard-style follower returned `status=optimal, gap_certified=True, x=5, y=10`,
+  while the independent scipy follower oracle gives `y=0`. Complementarity was
+  violated by `μ·(−g)=953` (must be 0) — **a certified follower-infeasible point.**
+- **`kkt` + `sos1`** refused loudly (correct).
+- **`strong_duality`** returned the correct optimum (`x=1, y=2, obj=−7`).
+
+**Root cause.** KKT multipliers have no a-priori upper bound, so `kkt.build_kkt`
+creates them at discopt's `ub≈9.999e19` unbounded sentinel. `_compute_big_m`
+(`_jax/gdp_reformulate.py`, the GDP-1/#413 contract) treated that sentinel as a
+*finite, valid* big-M (`np.isfinite(9.999e19)` is True) → `M≈1e20`. That `M` is
+numerically vacuous: `M · integrality_tol = 1e20 · 1e-5 = 1e15`, so the disjunction
+selector binary rounds to "integer" while the big-M term stays huge, and
+complementarity is never enforced. #413 guarded "`M` too *small* cuts feasible
+points → false infeasible"; it missed "`M` too *large* → disjunction vacuous →
+false optimal." `_compute_big_m_lp` and SOS1 already rejected `≥1e15`; only the
+`_compute_big_m` fallback re-admitted the sentinel.
+
+**Fix (shared GDP layer + bilevel front-end).**
+1. `_compute_big_m` now refuses a bound `|b| ≥ _BIGM_SENTINEL (1e15)` as it already
+   did for `±inf` — a sentinel is not a usable big-M. Real finite bounds below the
+   sentinel still use the true bound (the #413 fix for genuine bounds is preserved).
+2. `BilevelProblem.formulate(method="kkt", mpec_method="gdp"|"sos1")` refuses loudly
+   when follower multipliers are unbounded, pointing at `strong_duality`.
+3. `example_bilevel_toll` switched to `strong_duality` (the sound path).
+4. Blast-radius check: the change reverses one #413 sub-decision (sentinel → refuse,
+   not `M=1e20`); the two tests encoding it were updated to the corrected behavior
+   (real finite bound → use it; sentinel/inf → refuse). All other GDP / indicator /
+   SOS / MPEC / GDPopt / pattern / gallery suites stay green.
+
+## What is and isn't certified now
+
+`strong_duality` solves linear and convex-QP bilevel to the true optimistic
+optimum, but its solve is **not gap-certified** (its strong-duality equality is
+nonconvex/bilinear) — an honest state. A genuinely gap-certified KKT path needs
+valid finite multiplier bounds; that is future work, not a big-M over the sentinel.
+Deferred features (convex-NLP lower level, integer/pessimistic lower level) remain
+**refused loudly**, per CLAUDE.md §3.
+
+## Tests added / changed
+
+- `python/tests/test_bilevel_phase3.py` (new): the missing end-to-end coverage —
+  `kkt`+`gdp`/`sos1` refuse unbounded multipliers; `strong_duality` solves the
+  linear bilevel to `x=1,y=2,obj=−7` with the returned `y` confirmed as the
+  follower argmin (scipy oracle).
+- `test_bilevel_symbolic_diff.py`: added differential-test cases for the structural
+  nodes (`UnaryOp neg`, `SumExpression`, `SumOverExpression`, `IndexExpression`,
+  `MatMulExpression`) — documented-supported but previously unexercised.
+- `test_bilevel_phase2.py`: added convexity-gate edge cases (non-diagonal PSD QP
+  accepted, indefinite sibling refused, max-follower sign-flip both directions,
+  concave inequality body refused).
+- `test_bilevel_phase1.py` / `phase2.py`: KKT-math checks now build via the new
+  `BilevelProblem.build_kkt_system()` (sound KKT construction, independent of the
+  now-refused big-M encoding).
+- `test_gdp.py`, `test_gdp1_gdp2_bigm_soundness.py`: updated the #413 sentinel tests
+  to the corrected behavior.
+
+## Known limitations (out of scope, documented)
+
+- Scalar-only lower variables (arrays passed component-wise).
+- No `.crucible/` wiki concept page on bilevel programming.
+- No gap-certified KKT path (needs valid multiplier bounds).

--- a/docs/dev/bilevel-audit-2026-07-13.md
+++ b/docs/dev/bilevel-audit-2026-07-13.md
@@ -56,12 +56,27 @@ false optimal." `_compute_big_m_lp` and SOS1 already rejected `≥1e15`; only th
 
 ## What is and isn't certified now
 
-`strong_duality` solves linear and convex-QP bilevel to the true optimistic
-optimum, but its solve is **not gap-certified** (its strong-duality equality is
-nonconvex/bilinear) — an honest state. A genuinely gap-certified KKT path needs
-valid finite multiplier bounds; that is future work, not a big-M over the sentinel.
-Deferred features (convex-NLP lower level, integer/pessimistic lower level) remain
-**refused loudly**, per CLAUDE.md §3.
+`strong_duality` solves linear, convex-QP, and convex-NLP bilevel to the true
+optimistic optimum, but its solve is **not gap-certified** (its strong-duality
+equality is nonconvex/bilinear) — an honest state. Integer/pessimistic lower levels
+remain **refused loudly**, per CLAUDE.md §3.
+
+## Follow-on capabilities (2026-07-14)
+
+- **Certified path via user-supplied multiplier bounds.** Auto-deriving valid
+  multiplier bounds was investigated and **falsified** (entry experiment: `run_obbt`
+  leaves every KKT multiplier at the sentinel — boundedness comes from
+  complementarity, not the linear KKT relaxation; valid bilevel big-Ms are NP-hard,
+  Kleinert et al. 2021). Instead `BilevelProblem(..., multiplier_ub=M)` lets the user
+  assert a valid finite bound on the follower duals (like any big-M), making
+  `kkt`+`gdp` gap-certified (verified on Bard: `optimal, obj=−7, gap_certified=True`).
+  `solve()` best-effort-warns if a multiplier sits at its bound. `strong_duality`
+  stays the default for users who cannot bound their duals.
+- **Convex-NLP followers.** The convexity gate now certifies convexity *in `y`* for a
+  nonlinear body via a symbolic follower Hessian + interval-Gershgorin PSD test over
+  the box (`problem.py::_y_convex_on_box`) — tight enough to accept the natural
+  linearly-coupled form (`exp(y) − x·y`), refusing nonconvex/concave bodies. This
+  removes the "convex-NLP deferred" limitation.
 
 ## Tests added / changed
 

--- a/docs/dev/bilevel-module-plan.md
+++ b/docs/dev/bilevel-module-plan.md
@@ -231,13 +231,31 @@ enforced. Fixes:
 - **Bilevel front-end**: `formulate(method="kkt", mpec_method="gdp"|"sos1")` now
   **refuses loudly** when the follower multipliers are unbounded (the common case),
   pointing at `method="strong_duality"`.
-- **The working certified-ish path is `strong_duality`** (a single bilinear
-  equality, no big-M): it solves the linear/convex-QP bilevel to the true
-  optimistic optimum (the new `test_bilevel_phase3.py` pins this end-to-end and
-  checks follower optimality against a scipy oracle). Its solve is *not*
-  gap-certified because the strong-duality equality is nonconvex — an honest state,
-  not the "certified" the table claimed. A genuinely gap-certified KKT path needs
-  valid finite multiplier bounds (future work), not a big-M over the sentinel.
+- **The default working path is `strong_duality`** (a single bilinear equality, no
+  big-M): it solves the linear/convex-QP/convex-NLP bilevel to the true optimistic
+  optimum (the new `test_bilevel_phase3.py` pins this end-to-end and checks follower
+  optimality against a scipy oracle). Its solve is *not* gap-certified because the
+  strong-duality equality is nonconvex — an honest state, not the "certified" the
+  table claimed.
+
+**Follow-on (2026-07-14) — certified path + convex-NLP followers.**
+- **Auto-derived multiplier bounds: FALSIFIED.** An entry experiment confirmed
+  `run_obbt` cannot bound the KKT multipliers (they are unbounded in the linear KKT
+  relaxation — boundedness comes from complementarity, and valid bilevel big-Ms are
+  NP-hard, Kleinert et al. 2021). Dropped.
+- **Certified via user-supplied bounds (delivered).** `BilevelProblem(...,
+  multiplier_ub=M)` applies a user-asserted valid finite bound to the follower duals
+  (like any user-supplied big-M), making `kkt`+`gdp` gap-certified (verified on Bard:
+  `optimal, obj=−7, gap_certified=True`, follower-optimal). Soundness is the user's
+  responsibility (a too-small `M` cuts the true optimum); `solve()` best-effort-warns
+  when a multiplier sits at its bound. `sos1` additionally needs the `−g` operand
+  bounded (an `mpec.reformulate_sos1` gap), so use `gdp`.
+- **Convex-NLP followers (delivered).** The convexity gate now proves convexity *in
+  `y`* for a nonlinear body via a symbolic follower Hessian + interval-Gershgorin PSD
+  test over the box (`problem.py::_y_convex_on_box`). Tight enough to accept the
+  natural linearly-coupled form (`exp(y) − x·y`, `y**4 − x·y`) while refusing
+  nonconvex/concave bodies; solves end-to-end via `strong_duality`. This supersedes
+  the Phase-2 "convex-NLP deferred / gate refuses" note.
 
 **Re-scope note (2026-07-03, after Phase 0 landed).** The original plan put LP
 strong-duality in Phase 1 and the KKT reformulation in Phase 2. With Phase 0's

--- a/docs/dev/bilevel-module-plan.md
+++ b/docs/dev/bilevel-module-plan.md
@@ -1,7 +1,9 @@
 # Bilevel Optimization Module — Design & Implementation Plan
 
-**Date:** 2026-07-03
-**Status:** design plan for a new `python/discopt/bilevel/` module.
+**Date:** 2026-07-03 (audited & corrected 2026-07-13)
+**Status:** implemented (`python/discopt/bilevel/`), Phases 0–3 landed. A 2026-07-13
+audit found and fixed a P0 false-optimal in the certified KKT path — see the
+"Audit correction" block in §6. The sound end-to-end path is `strong_duality`.
 **Thesis:** a bilevel program is solved by replacing the *follower's* optimization
 with its optimality conditions, collapsing the two levels into one. discopt already
 has the two hardest ingredients — the **complementarity/MPEC machinery**
@@ -89,12 +91,20 @@ for cuts, teaching).
 ```
 python/discopt/bilevel/
   __init__.py            # BilevelProblem, exports
-  problem.py             # BilevelProblem: the user-facing front-end + .formulate()
+  problem.py             # BilevelProblem: front-end + .formulate()/.build_kkt_system()
+                         #   AND the convexity gate (folded in; no separate file)
   symbolic_diff.py       # ∂Expression/∂Variable -> Expression  (the new engine piece)
   kkt.py                 # KKT reformulation: stationarity + feas + complementarity
-  strong_duality.py      # LP strong-duality reformulation
-  convexity_gate.py      # lower-level-convex-in-y check (wraps the certifier)
+  strong_duality.py      # LP/QP strong-duality reformulation
 ```
+
+> **As-built note (audit 2026-07-13):** there is no separate `convexity_gate.py`;
+> the lower-level-convex-in-y check lives in `problem.py` (`_convexity_status` /
+> `_hessian_in_y` / `_gate_convexity`), a constant-Hessian PSD test covering LP and
+> convex-QP. The general convexity certifier is not yet wired in (non-quadratic
+> convex lower levels are refused loudly). `problem.py` also exposes
+> `build_kkt_system()` — the sound KKT-math construction, separate from the
+> encoding choice in `formulate()`.
 
 Optional dep: none beyond the core (mpec + _jax are already core). Mirrors the flat,
 builder-pattern shape of `ro/`.
@@ -202,6 +212,32 @@ already uses.
 | **1 ✅ DONE** | `BilevelProblem` (`problem.py`) + `kkt.py` — the **KKT reformulation** for an LP-in-`y` lower level; integer/nonconvex/pessimistic gates | the emitted stationarity + primal + dual + complementarity conditions exactly characterize follower optimality — validated against an independent **scipy follower-LP oracle** (min & max followers, several leader `x`), stationarity shown to bind, all gates enforced — **11 tests pass, ruff clean**. End-to-end *certified* solve of Bard's instances → CI (needs Rust+pounce). | module/API docstrings with a worked toll example (the seed for the notebook) |
 | **2 ✅ DONE** | `strong_duality.py` (aggregate-complementarity / strong-duality reformulation) + convexity gate **lifted to convex-QP** (PSD constant Hessian in y) | KKT ≡ strong-duality verified equivalent at the follower optimum (scipy LP oracle); convex-QP lower level accepted with KKT correct (QP oracle); nonconvex / non-quadratic / nonlinear-equality lower levels refused — **8 tests pass, ruff clean**. Convex-**NLP** (non-quadratic) via the full convexity certifier is deferred (gate refuses loudly, names it). End-to-end certified solve → CI. | module/API docstrings; worked LP + convex-QP examples seed the notebook |
 | **3 ✅ DONE** | `example_bilevel_toll` gallery model (convex-QP toll setting) + **follower-variable-bound correctness fix** (finite bounds folded into the KKT); `docs/notebooks/bilevel.ipynb`; `references.bib` + `_toc.yml` | the gallery example builds + `validate()`s in the whole-gallery smoke test; notebook code cells execute solver-free (formulate is pure-Python); bound-active regression test (a follower optimum on a bound is excluded without the fix) — **bilevel suite + gallery green (ruff clean)**. `jupyter-book build` zero-warning check → CI (not installed locally). Advisor hook deferred (bilevel does not map onto the decomposition advisor). | notebook with `{cite:p}` citations (Bard/Dempe/Colson–Marcotte–Savard/Kleinert et al.); gallery example; TOC + bib entries |
+
+**Audit correction (2026-07-13) — the certified KKT solve never actually worked.**
+The Phase-1/3 "End-to-end *certified* solve → CI" line was aspirational: **no test
+ever called `model.solve()` on a `BilevelProblem`** (the phase suites validate the
+`formulate()` output against a scipy oracle; the gallery example is only
+`validate()`d). An end-to-end solve exposed a **P0 false optimal**: the module
+default `method="kkt", mpec_method="gdp"` on a linear-follower bilevel certified a
+follower-*infeasible* point (`gap_certified=True`) because the KKT multipliers are
+unbounded and the GDP big-M treated discopt's ±1e20 unbounded sentinel as a valid
+(but numerically vacuous) `M`, so the complementarity disjunction was never
+enforced. Fixes:
+- **Shared GDP layer** (`_jax/gdp_reformulate.py`): `_compute_big_m` now refuses a
+  sentinel-magnitude bound (`|bound| ≥ _BIGM_SENTINEL = 1e15`) as it already did for
+  ±inf and as SOS1 / `_compute_big_m_lp` already did — a sentinel `M` is not a
+  usable big-M. (Real finite bounds below the sentinel still use the true bound,
+  preserving the #413 "don't shrink a valid `M`" fix.)
+- **Bilevel front-end**: `formulate(method="kkt", mpec_method="gdp"|"sos1")` now
+  **refuses loudly** when the follower multipliers are unbounded (the common case),
+  pointing at `method="strong_duality"`.
+- **The working certified-ish path is `strong_duality`** (a single bilinear
+  equality, no big-M): it solves the linear/convex-QP bilevel to the true
+  optimistic optimum (the new `test_bilevel_phase3.py` pins this end-to-end and
+  checks follower optimality against a scipy oracle). Its solve is *not*
+  gap-certified because the strong-duality equality is nonconvex — an honest state,
+  not the "certified" the table claimed. A genuinely gap-certified KKT path needs
+  valid finite multiplier bounds (future work), not a big-M over the sentinel.
 
 **Re-scope note (2026-07-03, after Phase 0 landed).** The original plan put LP
 strong-duality in Phase 1 and the KKT reformulation in Phase 2. With Phase 0's

--- a/docs/notebooks/bilevel.ipynb
+++ b/docs/notebooks/bilevel.ipynb
@@ -21,25 +21,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## The KKT reduction\n",
-    "\n",
-    "When the lower level is **convex in $y$** (for each fixed $x$), the follower's\n",
-    "**KKT conditions** are necessary *and sufficient* for its optimality, so we can\n",
-    "replace `y ∈ argmin{…}` by\n",
-    "\n",
-    "- **stationarity** $\\nabla_y L = 0$ with $L = f + \\sum_i \\mu_i g_i$,\n",
-    "- **primal feasibility** $g_i \\le 0$,\n",
-    "- **dual feasibility** $\\mu_i \\ge 0$,\n",
-    "- **complementarity** $0 \\le \\mu_i \\perp -g_i \\ge 0$.\n",
-    "\n",
-    "The result is a single-level **MPEC**, which discopt already solves\n",
-    "(`discopt.mpec`: GDP / SOS1 / Scholtes). discopt's `BilevelProblem` builds this\n",
-    "reduction automatically. It handles the **optimistic** case; the lower level must\n",
-    "be convex (LP or convex-QP) — nonconvex / integer-follower / pessimistic problems\n",
-    "are refused loudly rather than silently mis-solved\n",
-    "{cite:p}`KleinertLabbeLjubicSchmidt2021`.\n"
-   ],
+   "source": "## The KKT reduction\n\nWhen the lower level is **convex in $y$** (for each fixed $x$), the follower's\n**KKT conditions** are necessary *and sufficient* for its optimality, so we can\nreplace `y ∈ argmin{…}` by\n\n- **stationarity** $\\nabla_y L = 0$ with $L = f + \\sum_i \\mu_i g_i$,\n- **primal feasibility** $g_i \\le 0$,\n- **dual feasibility** $\\mu_i \\ge 0$,\n- **complementarity** $0 \\le \\mu_i \\perp -g_i \\ge 0$.\n\nThe result is a single-level **MPEC**, which discopt already solves\n(`discopt.mpec`: GDP / SOS1 / Scholtes). discopt's `BilevelProblem` builds this\nreduction automatically. It handles the **optimistic** case; the lower level must\nbe convex in $y$ — an LP, a convex-QP, or a **convex-NLP** proved convex by an\ninterval-Hessian test over the box (so the natural linearly-coupled form such as\n$e^{y} - x\\,y$ is accepted). Nonconvex / integer-follower / pessimistic problems\nare refused loudly rather than silently mis-solved\n{cite:p}`KleinertLabbeLjubicSchmidt2021`.\n",
    "id": "887b0ace5ef4"
   },
   {
@@ -88,7 +70,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "The follower's finite bounds ($0 \\le f \\le 8$) are folded into the KKT system\nautomatically — they are genuine follower constraints, so omitting them would be\nwrong whenever the follower optimum sits on a bound.\n\n## Solving and the optimum\n\nTo solve, call `bl.formulate(method='strong_duality')` and then `m.solve()`.\nThe strong-duality reduction keeps stationarity, primal and dual feasibility, and\nreplaces the per-row complementarity with the single aggregate equality\n$\\sum_i \\mu_i g_i = 0$ (one bilinear equality, no disjunction). Here the\nfollower's unconstrained optimum is $f = 5 - t$, so revenue is $t(5-t)$,\nmaximized at $t^\\* = 2.5$, $f^\\* = 2.5$ (revenue $6.25$).\n\nWhy not the big-M KKT encodings (`mpec_method='gdp'`/`'sos1'`)? A follower's KKT\nmultipliers have no a-priori upper bound, and a big-M complementarity encoding\nneeds a *finite* bound on each multiplier — a sentinel-sized big-M is numerically\nvacuous and would let the solver certify a follower-infeasible point (a false\noptimum). So `BilevelProblem` **refuses those methods loudly** for unbounded\nmultipliers and points here. Strong duality is exact for this convex lower level;\nits solve is a valid bilevel optimum but is *not* gap-certified, because the\nstrong-duality equality is itself nonconvex.\n",
+   "source": "The follower's finite bounds ($0 \\le f \\le 8$) are folded into the KKT system\nautomatically — they are genuine follower constraints, so omitting them would be\nwrong whenever the follower optimum sits on a bound.\n\n## Solving and the optimum\n\n**Default (uncertified).** Call `bl.formulate(method='strong_duality')` then\n`m.solve()`. Strong duality keeps stationarity, primal and dual feasibility, and\nreplaces the per-row complementarity with the single aggregate equality\n$\\sum_i \\mu_i g_i = 0$ (one bilinear equality, no disjunction). Here the follower's\nunconstrained optimum is $f = 5 - t$, so revenue is $t(5-t)$, maximized at\n$t^\\* = 2.5$, $f^\\* = 2.5$ (revenue $6.25$). This is a valid bilevel optimum but is\n*not* gap-certified, because the strong-duality equality is itself nonconvex.\n\n**Certified (`gap_certified=True`).** The big-M KKT encodings\n(`mpec_method='gdp'`/`'sos1'`) *can* be certified, but only with a **finite bound on\neach follower multiplier**: a KKT multiplier has no a-priori upper bound, and a\nsentinel-sized big-M is numerically vacuous — it would let the solver certify a\nfollower-infeasible point (a false optimum), so `BilevelProblem` **refuses the big-M\nmethods loudly** for unbounded multipliers. Deriving a valid bound automatically is\nNP-hard in general {cite:p}`KleinertLabbeLjubicSchmidt2021`, so if you can assert one\nfor your problem, pass it explicitly:\n\n```python\nbl = BilevelProblem(..., multiplier_ub=50.0)   # a *valid* upper bound on the duals\nbl.formulate(method='kkt', mpec_method='gdp')\nresult = m.solve()                              # gap_certified=True\n```\n\nThe bound is a modeling assertion, exactly like a user-supplied big-M: it must be\n$\\ge$ the largest multiplier at the true follower optimum for every leader decision,\nor it silently cuts the true response. `solve()` warns if a multiplier ends up *at*\nits supplied bound.\n",
    "id": "2e42efe176f6"
   },
   {

--- a/docs/notebooks/bilevel.ipynb
+++ b/docs/notebooks/bilevel.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "When the lower level is **convex in $y$** (for each fixed $x$), the follower's\n",
     "**KKT conditions** are necessary *and sufficient* for its optimality, so we can\n",
-    "replace `y \u2208 argmin{\u2026}` by\n",
+    "replace `y ∈ argmin{…}` by\n",
     "\n",
     "- **stationarity** $\\nabla_y L = 0$ with $L = f + \\sum_i \\mu_i g_i$,\n",
     "- **primal feasibility** $g_i \\le 0$,\n",
@@ -36,7 +36,7 @@
     "The result is a single-level **MPEC**, which discopt already solves\n",
     "(`discopt.mpec`: GDP / SOS1 / Scholtes). discopt's `BilevelProblem` builds this\n",
     "reduction automatically. It handles the **optimistic** case; the lower level must\n",
-    "be convex (LP or convex-QP) \u2014 nonconvex / integer-follower / pessimistic problems\n",
+    "be convex (LP or convex-QP) — nonconvex / integer-follower / pessimistic problems\n",
     "are refused loudly rather than silently mis-solved\n",
     "{cite:p}`KleinertLabbeLjubicSchmidt2021`.\n"
    ],
@@ -74,16 +74,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Worked example: toll setting\n",
-    "\n",
-    "A road authority (**leader**) sets a toll $t$ on an arc to maximize revenue\n",
-    "$t\\,f$. Drivers (**follower**) choose the flow $f$ to minimize a convex\n",
-    "congestion-plus-toll cost $\\tfrac12 f^2 - 5f + t f$. The follower is a convex QP\n",
-    "in $f$, so `BilevelProblem` replaces it by its KKT conditions. We build the model\n",
-    "and *formulate* it \u2014 turning it into a single-level MPEC \u2014 then inspect the\n",
-    "emitted conditions (no solver needed for this step):\n"
-   ],
+   "source": "## Worked example: toll setting\n\nA road authority (**leader**) sets a toll $t$ on an arc to maximize revenue\n$t\\,f$. Drivers (**follower**) choose the flow $f$ to minimize a convex\ncongestion-plus-toll cost $\\tfrac12 f^2 - 5f + t f$. The follower is a convex QP\nin $f$, so `BilevelProblem` replaces it by its KKT conditions. We build the\nfollower's KKT system with `build_kkt_system()` and inspect the emitted\nconditions (pure Python — no solver needed for this step):\n",
    "id": "1fbf87baa3e4"
   },
   {
@@ -91,44 +82,13 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": [
-    "from discopt.bilevel import BilevelProblem\n",
-    "\n",
-    "m = dm.Model('toll')\n",
-    "t = m.continuous('toll', lb=0, ub=5)   # leader: toll\n",
-    "f = m.continuous('flow', lb=0, ub=8)   # follower: flow\n",
-    "m.minimize(-(t * f))                    # maximize revenue t*f\n",
-    "\n",
-    "bl = BilevelProblem(\n",
-    "    m, upper_vars=[t], lower_vars=[f],\n",
-    "    lower_objective=0.5 * f * f - 5 * f + t * f,  # convex QP in f\n",
-    "    lower_constraints=[],                          # only the flow bounds (folded in)\n",
-    ")\n",
-    "bl.formulate(method='kkt', mpec_method='gdp')\n",
-    "\n",
-    "print('stationarity:', bl.kkt.stationarity[0].body)\n",
-    "for p in bl.kkt.comp_pairs:\n",
-    "    print('complementarity: 0 <=', p.f, 'perp', p.g, '>= 0')\n"
-   ],
+   "source": "from discopt.bilevel import BilevelProblem\n\nm = dm.Model('toll')\nt = m.continuous('toll', lb=0, ub=5)   # leader: toll\nf = m.continuous('flow', lb=0, ub=8)   # follower: flow\nm.minimize(-(t * f))                    # maximize revenue t*f\n\nbl = BilevelProblem(\n    m, upper_vars=[t], lower_vars=[f],\n    lower_objective=0.5 * f * f - 5 * f + t * f,  # convex QP in f\n    lower_constraints=[],                          # only the flow bounds (folded in)\n)\n\n# build_kkt_system() emits the follower's KKT conditions (sound math) and returns\n# them for inspection, independent of how the complementarity is later encoded.\nbl.build_kkt_system()\n\nprint('stationarity:', bl.kkt.stationarity[0].body)\nfor p in bl.kkt.comp_pairs:\n    print('complementarity: 0 <=', p.f, 'perp', p.g, '>= 0')\n",
    "id": "9bb77b084c7c"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "The follower's finite bounds ($0 \\le f \\le 8$) are folded into the KKT system\n",
-    "automatically \u2014 they are genuine follower constraints, so omitting them would be\n",
-    "wrong whenever the follower optimum sits on a bound.\n",
-    "\n",
-    "## Solving and the optimum\n",
-    "\n",
-    "Calling `m.solve()` (or `bl.solve()`) runs the global MINLP solver on the\n",
-    "resulting MPEC, whose certificate is the bilevel solution. Here the follower's\n",
-    "unconstrained optimum is $f = 5 - t$, so revenue is $t(5-t)$, maximized at\n",
-    "$t^\\* = 2.5$, $f^\\* = 2.5$ (revenue $6.25$). Because the complementarity is\n",
-    "encoded exactly (GDP), the returned solution carries a global optimality\n",
-    "certificate.\n"
-   ],
+   "source": "The follower's finite bounds ($0 \\le f \\le 8$) are folded into the KKT system\nautomatically — they are genuine follower constraints, so omitting them would be\nwrong whenever the follower optimum sits on a bound.\n\n## Solving and the optimum\n\nTo solve, call `bl.formulate(method='strong_duality')` and then `m.solve()`.\nThe strong-duality reduction keeps stationarity, primal and dual feasibility, and\nreplaces the per-row complementarity with the single aggregate equality\n$\\sum_i \\mu_i g_i = 0$ (one bilinear equality, no disjunction). Here the\nfollower's unconstrained optimum is $f = 5 - t$, so revenue is $t(5-t)$,\nmaximized at $t^\\* = 2.5$, $f^\\* = 2.5$ (revenue $6.25$).\n\nWhy not the big-M KKT encodings (`mpec_method='gdp'`/`'sos1'`)? A follower's KKT\nmultipliers have no a-priori upper bound, and a big-M complementarity encoding\nneeds a *finite* bound on each multiplier — a sentinel-sized big-M is numerically\nvacuous and would let the solver certify a follower-infeasible point (a false\noptimum). So `BilevelProblem` **refuses those methods loudly** for unbounded\nmultipliers and points here. Strong duality is exact for this convex lower level;\nits solve is a valid bilevel optimum but is *not* gap-certified, because the\nstrong-duality equality is itself nonconvex.\n",
    "id": "2e42efe176f6"
   },
   {

--- a/python/discopt/_jax/gdp_reformulate.py
+++ b/python/discopt/_jax/gdp_reformulate.py
@@ -42,6 +42,15 @@ from discopt.modeling.core import (
 
 _DEFAULT_BIG_M = 1e4
 
+# A bound at or above this magnitude is treated as the "unbounded" sentinel, not a
+# real finite bound: discopt's unbounded sentinel is 9.999e19 and the NLP path warns
+# above ~1e15, so any |bound| >= this is meaningless as a big-M. Using such a value
+# as M makes the disjunction link ``operand <= M * b`` satisfiable with the selector
+# ``b`` far below the integrality tolerance, silently defeating the disjunction (a
+# false optimal). Both big-M paths refuse rather than emit a vacuous M. This is
+# orthogonal to the GDP-1/#413 "M too small cuts feasible points" guard.
+_BIGM_SENTINEL = 1e15
+
 
 def reformulate_gdp(
     model: Model,
@@ -177,15 +186,20 @@ def _compute_big_m(
     constraint and can cut feasible points of the *active* disjunct, producing
     a false-infeasible / wrong-optimum certificate. Therefore:
 
-    - When the relevant body bound is **finite** (even if very large, e.g. a
-      variable left at the default ±1e20), that finite bound *is* a valid M and
-      is used as-is. A large M weakens the LP relaxation (a *performance* cost),
-      but correctness comes first — we never shrink a valid finite M to a
-      smaller ``default`` just because it exceeds a "looks infinite" threshold.
-    - When the relevant body bound is **truly non-finite** (``±inf``), no valid
-      finite M exists, so we **refuse loudly** rather than silently substitute
-      ``default`` (which is not a valid over-estimate and would cut feasible
-      points). The caller must supply a finite bound on the offending variable.
+    - When the relevant body bound is **finite and below the ``_BIGM_SENTINEL``
+      magnitude**, that bound *is* a valid M and is used as-is. A large M weakens
+      the LP relaxation (a *performance* cost), but correctness comes first — we
+      never shrink such a valid finite M to a smaller ``default``.
+    - When the relevant body bound is **non-finite (``±inf``) or at/above the
+      ``_BIGM_SENTINEL`` "unbounded" magnitude** (e.g. a variable left at the
+      default ±9.999e19 sentinel), no *usable* finite M exists, so we **refuse
+      loudly** rather than emit a vacuous M. A sentinel-sized M is not merely weak:
+      it makes the disjunction link ``operand <= M * selector`` hold with the
+      selector binary far below the integrality tolerance, so the disjunction is
+      never enforced and the solver can certify a point that violates it (a false
+      optimal — see GDP-2). The caller must supply a finite bound on the offending
+      variable, or use ``method='hull'`` (no big-M). This is *orthogonal* to the
+      GDP-1/#413 "M too small cuts feasible points" guard, which still holds.
 
     Parameters
     ----------
@@ -214,15 +228,16 @@ def _compute_big_m(
 
     def _require_finite_upper() -> float:
         # Valid M for a ``body <= 0`` disjunct: any value >= max body. The
-        # interval upper bound ``hi`` is exactly that. Finite (even if huge) ⇒
-        # valid; non-finite ⇒ no valid finite M exists.
-        if np.isfinite(hi):
+        # interval upper bound ``hi`` is exactly that. Finite AND below the
+        # unbounded sentinel ⇒ valid; non-finite or sentinel-sized ⇒ no *usable*
+        # finite M exists (a sentinel-sized M makes the disjunction vacuous).
+        if np.isfinite(hi) and abs(hi) < _BIGM_SENTINEL:
             return abs(hi)
         raise _unbounded_big_m_error(constraint, "above")
 
     def _require_finite_lower() -> float:
         # Valid M for a ``body >= 0`` disjunct: any value >= -min(body) = |lo|.
-        if np.isfinite(lo):
+        if np.isfinite(lo) and abs(lo) < _BIGM_SENTINEL:
             return abs(lo)
         raise _unbounded_big_m_error(constraint, "below")
 
@@ -340,7 +355,7 @@ def _compute_big_m_lp(
             ub_i = float(ub_flat[i]) if ub_flat.size == v.size else float(ub_flat.flat[0])
             bounds_list.append((lb_i, ub_i))
 
-    _INF_THRESH = 1e15
+    _INF_THRESH = _BIGM_SENTINEL  # shared "unbounded" magnitude; see _compute_big_m
 
     def _solve_bound(maximize: bool) -> float | None:
         """Solve LP to get bound. Returns None if LP fails."""

--- a/python/discopt/bilevel/problem.py
+++ b/python/discopt/bilevel/problem.py
@@ -200,6 +200,43 @@ class BilevelProblem:
                 f"makes the lower feasible set nonconvex); got curvature '{status}'."
             )
 
+    # ── big-M feasibility gate for the KKT complementarity path ────────
+
+    # A KKT multiplier left at discopt's ±sentinel bound is "unbounded above" for
+    # the purpose of the big-M complementarity encoding: the GDP/SOS1 reformulation
+    # needs a finite bound on μ to build the disjunction link, and a sentinel-sized
+    # big-M is numerically vacuous (it would let the selector binary sit below the
+    # integrality tolerance while μ > 0, silently defeating complementarity — a
+    # false optimal). Match the GDP layer's threshold (gdp_reformulate._BIGM_SENTINEL).
+    _MU_UNBOUNDED = 1e15
+
+    def _require_bounded_multipliers(self, mpec_method: str) -> None:
+        """Refuse loudly when a complementarity multiplier is unbounded above.
+
+        KKT multipliers have no a-priori upper bound, so :func:`kkt.build_kkt`
+        creates them unbounded. The big-M complementarity encodings (``gdp``,
+        ``sos1``) cannot certify such a system — the linking big-M would be the
+        ±sentinel and the disjunction becomes vacuous. Rather than emit an unsound
+        (false-optimal) reformulation, refuse and point at the sound alternative.
+        """
+        unbounded = [
+            pair.f.name
+            for pair in self.kkt.comp_pairs
+            if isinstance(pair.f, Variable) and float(pair.f.ub) >= self._MU_UNBOUNDED
+        ]
+        if unbounded:
+            raise NotImplementedError(
+                f"the KKT complementarity multiplier(s) {unbounded} are unbounded "
+                f"above, so the '{mpec_method}' big-M reformulation cannot build a "
+                f"finite, non-vacuous complementarity encoding — it would certify a "
+                f"follower-infeasible point (a false optimum). KKT multipliers have "
+                f"no a-priori bound. Use method='strong_duality' (a single bilinear "
+                f"equality, no big-M; exact for a convex lower level, though its "
+                f"nonconvex equality means the solve is not gap-certified), or supply "
+                f"finite upper bounds on the follower's dual multipliers if the "
+                f"problem admits them."
+            )
+
     # ── follower variable bounds are follower constraints ──────────────
 
     _BIG = 1e19  # discopt's "unbounded" sentinel is 9.999e19; treat |b| >= 1e19 as ∞
@@ -232,6 +269,35 @@ class BilevelProblem:
 
     # ── build ─────────────────────────────────────────────────────────
 
+    def build_kkt_system(self) -> _kkt.KKTSystem:
+        """Emit the follower's KKT system onto the model and return it (sound math).
+
+        Runs the convexity gate, folds finite follower-variable bounds into the
+        lower constraint set, and builds the KKT stationarity + primal-feasibility
+        constraints and multipliers via :func:`discopt.bilevel.kkt.build_kkt`. It
+        does **not** encode the complementarity pairs (that is :meth:`formulate`'s
+        big-M / strong-duality step) and does not mark the problem formulated, so it
+        is the way to inspect or validate the KKT characterization independently of
+        the encoding. Idempotent: repeated calls return the already-built system;
+        :meth:`formulate` reuses it.
+        """
+        if self.kkt is None:
+            self._gate_convexity()
+            # Follower variable bounds are follower constraints: fold finite ones in
+            # so the KKT system is complete (user constraints first, so
+            # multipliers[0:k] stay aligned with the user's lower_constraints).
+            extra = self._follower_bound_constraints() if self.include_follower_bounds else []
+            self.lower_constraints_full = list(self.lower_constraints) + extra
+            self.kkt = _kkt.build_kkt(
+                self.model,
+                lower_vars=self.lower_vars,
+                lower_objective=self.lower_objective,
+                lower_constraints=self.lower_constraints_full,
+                lower_sense=self.lower_sense,
+                prefix=self.prefix,
+            )
+        return self.kkt
+
     def formulate(self, *, method: str = "kkt", mpec_method: str = "gdp") -> None:
         """Rewrite the model in place into a single-level MPEC.
 
@@ -261,14 +327,6 @@ class BilevelProblem:
         if method not in ("kkt", "strong_duality"):
             raise ValueError(f"unknown method {method!r}; use 'kkt' or 'strong_duality'")
 
-        self._gate_convexity()
-
-        # Follower variable bounds are follower constraints: fold finite ones in so
-        # the KKT system is complete (user constraints first, so multipliers[0:k]
-        # remain aligned with the user's lower_constraints).
-        extra = self._follower_bound_constraints() if self.include_follower_bounds else []
-        self.lower_constraints_full = list(self.lower_constraints) + extra
-
         if method == "kkt":
             if mpec_method not in ("gdp", "sos1"):
                 raise ValueError(
@@ -276,20 +334,20 @@ class BilevelProblem:
                     f"{mpec_method!r}. (For the local Scholtes homotopy, call "
                     f"discopt.mpec.solve_mpec on the formulated pairs.)"
                 )
-            self.kkt = _kkt.build_kkt(
-                self.model,
-                lower_vars=self.lower_vars,
-                lower_objective=self.lower_objective,
-                lower_constraints=self.lower_constraints_full,
-                lower_sense=self.lower_sense,
-                prefix=self.prefix,
-            )
+            # Gate + fold follower bounds + build the KKT stationarity/primal system.
+            self.build_kkt_system()
             if self.kkt.comp_pairs:
+                # The big-M complementarity encodings cannot certify an unbounded
+                # multiplier without a vacuous big-M — refuse before emitting it.
+                self._require_bounded_multipliers(mpec_method)
                 if mpec_method == "gdp":
                     reformulate_gdp(self.model, self.kkt.comp_pairs)
                 else:
                     reformulate_sos1(self.model, self.kkt.comp_pairs)
         else:  # strong_duality
+            self._gate_convexity()
+            extra = self._follower_bound_constraints() if self.include_follower_bounds else []
+            self.lower_constraints_full = list(self.lower_constraints) + extra
             self.strong_duality = _sd.build_strong_duality(
                 self.model,
                 lower_vars=self.lower_vars,

--- a/python/discopt/bilevel/problem.py
+++ b/python/discopt/bilevel/problem.py
@@ -7,17 +7,20 @@ calls :meth:`~BilevelProblem.formulate`, which rewrites the model in place into 
 single-level MPEC that ``model.solve()`` handles.
 
 Scope (``docs/dev/bilevel-module-plan.md`` §1): **optimistic** bilevel with a lower
-level that is **convex in the follower variables** (an LP or convex-QP in ``y``), via
-either the KKT reformulation (:mod:`~discopt.bilevel.kkt`, ``method="kkt"``) or the
-strong-duality reformulation (:mod:`~discopt.bilevel.strong_duality`,
-``method="strong_duality"``). Finite follower-variable bounds are folded into the
-KKT system automatically. Everything the reduction is unsound for is refused loudly
-rather than silently approximated:
+level that is **convex in the follower variables** — an LP, a convex-QP, or a
+certified convex-NLP in ``y`` — via either the KKT reformulation
+(:mod:`~discopt.bilevel.kkt`, ``method="kkt"``) or the strong-duality reformulation
+(:mod:`~discopt.bilevel.strong_duality`, ``method="strong_duality"``). LP/QP curvature
+is proved by a constant-Hessian PSD test; a nonlinear follower is proved convex in
+``y`` by an interval-Hessian Gershgorin test over the box (leader variables enter as a
+bounded interval, so the natural linearly-coupled form such as ``exp(y) - x*y`` is
+accepted). Finite follower-variable bounds are folded into the KKT system
+automatically. Everything the reduction is unsound for is refused loudly rather than
+silently approximated:
 
 * integer follower variables — KKT does not characterize integer optima;
-* a lower level that is **nonconvex in** ``y`` — refused outright; a non-quadratic
-  (variable-dependent curvature) lower level is refused pending the full convexity
-  certifier (the gate names the offending expression);
+* a lower level the certifier cannot prove **convex in** ``y`` (indefinite/concave
+  curvature, or an unsupported nonlinear atom) — refused (the gate names the witness);
 * pessimistic semantics.
 
 Example
@@ -39,6 +42,7 @@ Example
 
 from __future__ import annotations
 
+import warnings
 from typing import TypeGuard
 
 import numpy as np
@@ -94,7 +98,7 @@ def _convexity_status(expr: Expression, ys: list[Variable]):
 
 
 class BilevelProblem:
-    """Optimistic bilevel program with a convex lower level (LP or convex-QP)."""
+    """Optimistic bilevel program with a convex lower level (LP, convex-QP, or convex-NLP)."""
 
     def __init__(
         self,
@@ -107,6 +111,7 @@ class BilevelProblem:
         lower_sense: str = "min",
         prefix: str = "bl",
         include_follower_bounds: bool = True,
+        multiplier_ub: float | None = None,
     ):
         self.model = model
         self.upper_vars = list(upper_vars)
@@ -116,6 +121,10 @@ class BilevelProblem:
         self.lower_sense = lower_sense
         self.prefix = prefix
         self.include_follower_bounds = include_follower_bounds
+        # A user-asserted valid finite upper bound on every follower KKT multiplier,
+        # enabling the certified big-M (gdp/sos1) path. See _apply_multiplier_ub for
+        # the soundness contract (a too-small bound silently cuts the true optimum).
+        self.multiplier_ub = multiplier_ub
         self._formulated = False
         self.kkt: _kkt.KKTSystem | None = None
         self.strong_duality: _sd.StrongDualitySystem | None = None
@@ -155,15 +164,16 @@ class BilevelProblem:
                 raise ValueError(f"variable '{v.name}' is in both upper_vars and lower_vars")
 
     def _gate_convexity(self) -> None:
-        """Gate: the lower level must be **convex in y** (LP or convex-QP).
+        """Gate: the lower level must be **convex in y** (LP, convex-QP, or convex-NLP).
 
         KKT / strong-duality characterize follower optimality only when the lower
         problem is convex in the follower variables. We require the (sign-adjusted)
-        objective and every inequality body to be convex in ``y`` (PSD constant
-        Hessian), and every equality body to be affine in ``y`` (a nonlinear equality
-        makes the lower feasible set nonconvex). A nonconvex lower level is refused
-        outright; a non-quadratic curvature is refused pending the convexity
-        certifier (rather than assuming convexity).
+        objective and every inequality body to be convex in ``y`` — proved by a
+        constant-Hessian PSD test for LP/QP curvature, falling through to an
+        interval-Hessian Gershgorin test over the box for a nonlinear body — and every
+        equality body to be affine in ``y`` (a nonlinear equality makes the lower
+        feasible set nonconvex). Anything the certifier cannot prove convex in ``y`` is
+        refused (rather than assuming convexity).
         """
         # Follower minimizes f (or maximizes f == minimizes -f): the *minimized*
         # objective must be convex in y.
@@ -180,12 +190,20 @@ class BilevelProblem:
         if status in ("affine", "convex"):
             return
         if status == "nonquadratic":
+            # The constant-Hessian (LP/QP) test can't classify a nonlinear body.
+            # Certify convexity in y directly: enclose the symbolic y-Hessian over the
+            # box and run an interval-Gershgorin PSD test (sound sufficient condition).
+            # This is convexity *in the follower variables* (leader vars enter as a
+            # bounded interval), so it accepts the natural bilevel form where the
+            # leader couples linearly, e.g. exp(y) − x·y (∂²/∂y² = exp(y) > 0).
+            if self._y_convex_on_box(expr):
+                return
             raise NotImplementedError(
-                f"{what} is nonlinear-but-not-quadratic in the follower variables "
-                f"(witness '{info.name}'); the KKT reduction needs a certified-convex "
-                f"lower level. LP and convex-QP lower levels are supported; general "
-                f"convex-NLP lower levels await the convexity-certifier hook. Refusing "
-                f"rather than assuming convexity."
+                f"{what} is nonlinear in the follower variables and the convexity "
+                f"certifier could not prove it convex in y over the box (witness "
+                f"'{info.name}'); the KKT reduction needs a certified-convex lower "
+                f"level. LP, convex-QP, and certified convex-NLP lower levels are "
+                f"supported. Refusing rather than assuming convexity."
             )
         raise NotImplementedError(  # nonconvex
             f"{what} is nonconvex in the follower variables (indefinite Hessian in y). "
@@ -199,6 +217,40 @@ class BilevelProblem:
                 f"{what} must be affine in the follower variables (a nonlinear equality "
                 f"makes the lower feasible set nonconvex); got curvature '{status}'."
             )
+
+    def _y_convex_on_box(self, expr: Expression) -> bool:
+        """Sound check that ``expr`` is convex in the follower variables over the box.
+
+        Builds the symbolic follower Hessian ``H[j][k] = ∂²expr/∂y_j∂y_k`` (reusing the
+        symbolic differentiator), encloses each entry in an interval over the declared
+        leader×follower box (:func:`evaluate_interval`), then applies an interval
+        Gershgorin test: a symmetric matrix whose every row has
+        ``min(diag) − max(off-diagonal abs row sum) ≥ 0`` is PSD, hence the function is
+        convex in ``y`` for every leader decision in the box. Sound (sufficient): it
+        returns ``False`` (abstains) whenever it cannot prove PSD — including when an
+        entry's enclosure is non-finite (unsupported atom) — so the caller refuses
+        rather than assume convexity.
+        """
+        from discopt._jax.convexity.interval_eval import evaluate_interval
+
+        ys = self.lower_vars
+        n = len(ys)
+        grads = [diff(expr, yk) for yk in ys]
+        ent: dict[tuple[int, int], tuple[float, float]] = {}
+        for k in range(n):
+            for j in range(k, n):
+                iv = evaluate_interval(diff(grads[k], ys[j]), self.model)
+                lo, hi = float(np.asarray(iv.lo)), float(np.asarray(iv.hi))
+                if not (np.isfinite(lo) and np.isfinite(hi)):
+                    return False  # unsupported atom -> cannot certify
+                ent[(k, j)] = ent[(j, k)] = (lo, hi)
+        tol = 1e-9
+        for i in range(n):
+            diag_min = ent[(i, i)][0]
+            radius = sum(max(abs(ent[(i, j)][0]), abs(ent[(i, j)][1])) for j in range(n) if j != i)
+            if diag_min - radius < -tol:
+                return False
+        return True
 
     # ── big-M feasibility gate for the KKT complementarity path ────────
 
@@ -232,10 +284,37 @@ class BilevelProblem:
                 f"follower-infeasible point (a false optimum). KKT multipliers have "
                 f"no a-priori bound. Use method='strong_duality' (a single bilinear "
                 f"equality, no big-M; exact for a convex lower level, though its "
-                f"nonconvex equality means the solve is not gap-certified), or supply "
-                f"finite upper bounds on the follower's dual multipliers if the "
-                f"problem admits them."
+                f"nonconvex equality means the solve is not gap-certified), or pass "
+                f"BilevelProblem(..., multiplier_ub=<M>) with a valid finite upper "
+                f"bound on the follower's dual multipliers to get a gap-certified solve."
             )
+
+    def _apply_multiplier_ub(self) -> None:
+        """Apply the user-supplied ``multiplier_ub`` to the complementarity multipliers.
+
+        ``multiplier_ub`` is a **user-asserted valid** finite upper bound on every
+        follower KKT multiplier (exactly like a user-supplied big-M in any MILP). With
+        it, the ``gdp`` complementarity encoding is finite and the solve is
+        gap-certified. (``sos1`` additionally needs the *other* complementarity operand
+        ``-g_i`` bounded, which :func:`discopt.mpec.reformulate_sos1` does not do, so
+        it may still refuse — use ``mpec_method="gdp"`` for the certified path.)
+        **Soundness contract:** the bound must be ``>=`` the largest
+        multiplier at the true follower optimum for *every* leader decision in the
+        upper box; a too-small bound silently excludes the true follower response and
+        yields a wrong certificate. :meth:`solve` warns if a multiplier ends up at its
+        supplied bound (a sign the bound may be cutting). Free equality multipliers
+        (no complementarity) are untouched.
+        """
+        if self.multiplier_ub is None:
+            return
+        m = float(self.multiplier_ub)
+        if not np.isfinite(m) or m <= 0.0:
+            raise ValueError(
+                f"multiplier_ub must be a finite positive number, got {self.multiplier_ub!r}"
+            )
+        for pair in self.kkt.comp_pairs:
+            if isinstance(pair.f, Variable):
+                pair.f.ub = np.asarray(m, dtype=float)
 
     # ── follower variable bounds are follower constraints ──────────────
 
@@ -337,6 +416,9 @@ class BilevelProblem:
             # Gate + fold follower bounds + build the KKT stationarity/primal system.
             self.build_kkt_system()
             if self.kkt.comp_pairs:
+                # A user-supplied multiplier bound (if any) makes the big-M encoding
+                # certifiable; apply it before the unbounded-multiplier gate.
+                self._apply_multiplier_ub()
                 # The big-M complementarity encodings cannot certify an unbounded
                 # multiplier without a vacuous big-M — refuse before emitting it.
                 self._require_bounded_multipliers(mpec_method)
@@ -363,8 +445,37 @@ class BilevelProblem:
         """Formulate (if needed) and solve the resulting single-level MPEC.
 
         Thin wrapper over :meth:`Model.solve`; the global optimality certificate is
-        the MPEC's (see :mod:`discopt.mpec`).
+        the MPEC's (see :mod:`discopt.mpec`). When a ``multiplier_ub`` was supplied,
+        this best-effort-warns if any complementarity multiplier ends up *at* its
+        supplied bound in the returned solution — a sign the bound may be binding and
+        thus cutting the true follower response (raise ``multiplier_ub`` and re-solve).
         """
         if not self._formulated:
             self.formulate()
-        return self.model.solve(**kwargs)
+        result = self.model.solve(**kwargs)
+        self._warn_if_multiplier_bound_active(result)
+        return result
+
+    def _warn_if_multiplier_bound_active(self, result) -> None:
+        """Warn if a comp-pair multiplier sits at its user-supplied ``multiplier_ub``."""
+        if self.multiplier_ub is None or self.kkt is None or not self.kkt.comp_pairs:
+            return
+        m = float(self.multiplier_ub)
+        tol = 1e-6 * max(1.0, m)
+        for pair in self.kkt.comp_pairs:
+            mu = pair.f
+            if not isinstance(mu, Variable):
+                continue
+            try:
+                val = float(np.max(np.abs(np.asarray(result.value(mu)))))
+            except Exception:
+                continue
+            if val >= m - tol:
+                warnings.warn(
+                    f"bilevel multiplier '{mu.name}' is at its supplied multiplier_ub="
+                    f"{m:g} in the returned solution; the bound may be binding and "
+                    f"cutting the true follower response, so the certificate may be "
+                    f"invalid. Raise multiplier_ub and re-solve to confirm.",
+                    stacklevel=2,
+                )
+                return

--- a/python/discopt/bilevel/problem.py
+++ b/python/discopt/bilevel/problem.py
@@ -271,6 +271,7 @@ class BilevelProblem:
         ±sentinel and the disjunction becomes vacuous. Rather than emit an unsound
         (false-optimal) reformulation, refuse and point at the sound alternative.
         """
+        assert self.kkt is not None  # only called after build_kkt_system()
         unbounded = [
             pair.f.name
             for pair in self.kkt.comp_pairs
@@ -312,6 +313,7 @@ class BilevelProblem:
             raise ValueError(
                 f"multiplier_ub must be a finite positive number, got {self.multiplier_ub!r}"
             )
+        assert self.kkt is not None  # only called after build_kkt_system()
         for pair in self.kkt.comp_pairs:
             if isinstance(pair.f, Variable):
                 pair.f.ub = np.asarray(m, dtype=float)
@@ -414,8 +416,8 @@ class BilevelProblem:
                     f"discopt.mpec.solve_mpec on the formulated pairs.)"
                 )
             # Gate + fold follower bounds + build the KKT stationarity/primal system.
-            self.build_kkt_system()
-            if self.kkt.comp_pairs:
+            kkt = self.build_kkt_system()
+            if kkt.comp_pairs:
                 # A user-supplied multiplier bound (if any) makes the big-M encoding
                 # certifiable; apply it before the unbounded-multiplier gate.
                 self._apply_multiplier_ub()
@@ -423,9 +425,9 @@ class BilevelProblem:
                 # multiplier without a vacuous big-M — refuse before emitting it.
                 self._require_bounded_multipliers(mpec_method)
                 if mpec_method == "gdp":
-                    reformulate_gdp(self.model, self.kkt.comp_pairs)
+                    reformulate_gdp(self.model, kkt.comp_pairs)
                 else:
-                    reformulate_sos1(self.model, self.kkt.comp_pairs)
+                    reformulate_sos1(self.model, kkt.comp_pairs)
         else:  # strong_duality
             self._gate_convexity()
             extra = self._follower_bound_constraints() if self.include_follower_bounds else []

--- a/python/discopt/modeling/examples.py
+++ b/python/discopt/modeling/examples.py
@@ -832,7 +832,11 @@ def example_bilevel_toll():
         lower_objective=0.5 * f * f - 5 * f + t * f,
         lower_constraints=[],  # only the follower's flow bounds (folded in as KKT)
     )
-    bl.formulate(method="kkt", mpec_method="gdp")
+    # Strong-duality reduction (a single bilinear equality) rather than the KKT
+    # big-M path: the follower's KKT multipliers are unbounded, and a big-M
+    # (gdp/sos1) complementarity encoding cannot certify an unbounded multiplier
+    # without a vacuous big-M. Strong duality is exact for this convex lower level.
+    bl.formulate(method="strong_duality")
 
     print(m)
     return m

--- a/python/tests/test_bilevel_phase1.py
+++ b/python/tests/test_bilevel_phase1.py
@@ -84,7 +84,7 @@ def _build_instance_min():
         lower_constraints=[x + y >= 3, y <= 2 * x],
         lower_sense="min",
     )
-    bl.formulate(method="kkt", mpec_method="gdp")
+    bl.build_kkt_system()  # sound KKT math; the big-M encoding is tested separately
     # signed objective gradient d, and (A, b(x)) for the follower LP in y.
     #   g0: 3 - x - y <= 0  ->  -y <= x - 3
     #   g1: y - 2x   <= 0  ->   y <= 2x
@@ -108,7 +108,7 @@ def _build_instance_max():
         lower_constraints=[y <= 2 * x, y <= 5],
         lower_sense="max",
     )
-    bl.formulate(method="kkt", mpec_method="gdp")
+    bl.build_kkt_system()  # sound KKT math; the big-M encoding is tested separately
     # signed objective = -y (max y == min -y) -> d = [-1]
     d = [-1.0]
     A = [[1.0], [1.0]]
@@ -181,7 +181,7 @@ def test_structure_and_leader_objective_preserved():
         lower_objective=y,
         lower_constraints=[x + y >= 3, y <= 2 * x],
     )
-    bl.formulate(method="kkt", mpec_method="gdp")
+    bl.build_kkt_system()
     # one multiplier per lower constraint (2 user + 2 finite follower bounds y in
     # [0,10]); one stationarity row per lower var; all four are inequalities.
     assert len(bl.lower_constraints_full) == 4
@@ -220,9 +220,11 @@ def test_double_formulate_refused():
     bl = BilevelProblem(
         m, upper_vars=[x], lower_vars=[y], lower_objective=y, lower_constraints=[x + y >= 3]
     )
-    bl.formulate()
+    # strong_duality has no big-M multiplier gate, so it formulates in place; the
+    # double-call guard must then refuse a second formulate.
+    bl.formulate(method="strong_duality")
     with pytest.raises(RuntimeError, match="already been called"):
-        bl.formulate()
+        bl.formulate(method="strong_duality")
 
 
 # ---------------------------------------------------------------------------
@@ -272,8 +274,8 @@ def test_bilinear_xy_is_allowed_affine_in_y():
         lower_objective=x * y,  # affine in y (x is the coefficient)
         lower_constraints=[x + y >= 3],
     )
-    bl.formulate(method="kkt")  # must not raise
-    assert bl._formulated
+    bl.build_kkt_system()  # convexity gate must accept affine-in-y and build the KKT
+    assert bl.kkt is not None and len(bl.kkt.stationarity) == 1
 
 
 def test_pessimistic_refused():

--- a/python/tests/test_bilevel_phase2.py
+++ b/python/tests/test_bilevel_phase2.py
@@ -238,20 +238,73 @@ def test_nonconvex_qp_refused():
         bl.formulate(method="kkt")
 
 
-def test_nonquadratic_lower_refused_pending_certifier():
+def test_convex_nlp_lower_accepted():
+    """A genuinely convex non-quadratic follower is certified convex in y and accepted.
+
+    ``exp(y) - x*y`` is convex in y (∂²/∂y² = exp(y) > 0) for every leader x, even
+    though it is not jointly convex in (x, y). The interval-Hessian-in-y certifier
+    must accept it (the natural bilevel form couples the leader linearly).
+    """
     m = Model("nq")
+    x = m.continuous("x", lb=0.5, ub=8)
+    y = m.continuous("y", lb=-2, ub=2)
+    m.minimize((y - 1) * (y - 1))
+    bl = BilevelProblem(
+        m,
+        upper_vars=[x],
+        lower_vars=[y],
+        lower_objective=FunctionCall("exp", y) - x * y,
+        lower_constraints=[],
+    )
+    bl.build_kkt_system()  # must not raise
+    assert bl.kkt is not None and len(bl.kkt.stationarity) == 1
+
+
+def test_convex_nlp_with_power_accepted():
+    """y**4 - x*y: convex in y (∂²/∂y² = 12 y² >= 0), leader coupling linear."""
+    m = Model("pw")
+    x = m.continuous("x", lb=0, ub=5)
+    y = m.continuous("y", lb=-3, ub=3)
+    m.minimize(x - y)
+    bl = BilevelProblem(
+        m, upper_vars=[x], lower_vars=[y], lower_objective=y**4 - x * y, lower_constraints=[]
+    )
+    bl.build_kkt_system()
+    assert bl.kkt is not None
+
+
+def test_nonconvex_nlp_lower_refused():
+    """sin(y) has an indefinite second derivative over the box → refused."""
+    m = Model("ncx_nl")
     x = m.continuous("x", lb=0, ub=10)
-    y = m.continuous("y", lb=0.1, ub=10)
+    y = m.continuous("y", lb=-2, ub=2)
     m.minimize(x - y)
     bl = BilevelProblem(
         m,
         upper_vars=[x],
         lower_vars=[y],
-        lower_objective=FunctionCall("exp", y),  # exp(y): convex but non-quadratic
-        lower_constraints=[y <= 5],
+        lower_objective=FunctionCall("sin", y),  # ∂²/∂y² = -sin(y): sign-indefinite
+        lower_constraints=[],
     )
-    with pytest.raises(NotImplementedError, match="not-quadratic|certifier"):
-        bl.formulate(method="kkt")
+    with pytest.raises(NotImplementedError, match="convex"):
+        bl.build_kkt_system()
+
+
+def test_concave_nlp_min_follower_refused():
+    """-exp(y) for a *minimizing* follower is concave → nonconvex lower level, refused."""
+    m = Model("cc_nl")
+    x = m.continuous("x", lb=0, ub=10)
+    y = m.continuous("y", lb=-2, ub=2)
+    m.minimize(x - y)
+    bl = BilevelProblem(
+        m,
+        upper_vars=[x],
+        lower_vars=[y],
+        lower_objective=-FunctionCall("exp", y),
+        lower_constraints=[],
+    )
+    with pytest.raises(NotImplementedError, match="convex"):
+        bl.build_kkt_system()
 
 
 def test_nondiagonal_psd_qp_accepted():

--- a/python/tests/test_bilevel_phase2.py
+++ b/python/tests/test_bilevel_phase2.py
@@ -59,7 +59,12 @@ def _lp_instance(method):
         lower_objective=y,
         lower_constraints=[x + y >= 3, y <= 2 * x],
     )
-    bl.formulate(method=method)
+    # KKT multipliers here are unbounded, so the big-M encoding (formulate kkt) is
+    # correctly refused; build the sound KKT system directly to validate its math.
+    if method == "kkt":
+        bl.build_kkt_system()
+    else:
+        bl.formulate(method=method)
     d, A = [1.0], [[-1.0], [1.0]]
     b_of_x = lambda xv: [xv - 3.0, 2.0 * xv]  # noqa: E731
     return m, x, y, bl, d, A, b_of_x
@@ -128,7 +133,7 @@ def test_convex_qp_lower_level_accepted_and_kkt_correct():
         lower_objective=y * y - 2 * x * y,  # convex in y (Hessian = 2)
         lower_constraints=[y <= 1],
     )
-    bl.formulate(method="kkt")  # gate must accept convex-QP
+    bl.build_kkt_system()  # gate must accept convex-QP; validate the KKT math
     assert bl.kkt is not None and len(bl.kkt.stationarity) == 1
 
     for xv in [1.5, 2.0, 3.0]:
@@ -175,7 +180,7 @@ def test_active_follower_bound_gets_its_multiplier():
     bl = BilevelProblem(
         m, upper_vars=[x], lower_vars=[y], lower_objective=y, lower_constraints=[y <= 8]
     )
-    bl.formulate(method="kkt")
+    bl.build_kkt_system()
     # constraints: [y<=8 (user), 2-y<=0 (lb), y-10<=0 (ub)]
     assert len(bl.lower_constraints_full) == 3
     # at y*=2 the lower bound is active: μ_lb = 1, others 0 -> stationarity 1+μ0-μ_lb+μ_ub = 0
@@ -202,7 +207,7 @@ def test_without_bound_handling_active_bound_optimum_is_excluded():
         lower_constraints=[y <= 8],
         include_follower_bounds=False,
     )
-    bl.formulate(method="kkt")
+    bl.build_kkt_system()
     assert len(bl.lower_constraints_full) == 1
     # stationarity is 1 + μ0; with the only multiplier μ0 >= 0 it can never be 0.
     for mu0 in (0.0, 5.0):
@@ -247,6 +252,87 @@ def test_nonquadratic_lower_refused_pending_certifier():
     )
     with pytest.raises(NotImplementedError, match="not-quadratic|certifier"):
         bl.formulate(method="kkt")
+
+
+def test_nondiagonal_psd_qp_accepted():
+    # min_{y1,y2} y1^2 + y1*y2 + y2^2 : Hessian [[2,1],[1,2]], eigenvalues 1,3 > 0
+    # -> convex (non-diagonal). The gate must accept it (not just diagonal QPs).
+    m = Model("psd")
+    x = m.continuous("x", lb=0, ub=10)
+    y1 = m.continuous("y1", lb=-5, ub=5)
+    y2 = m.continuous("y2", lb=-5, ub=5)
+    m.minimize(x - y1 - y2)
+    bl = BilevelProblem(
+        m,
+        upper_vars=[x],
+        lower_vars=[y1, y2],
+        lower_objective=y1 * y1 + y1 * y2 + y2 * y2,
+        lower_constraints=[y1 + y2 <= 4],
+    )
+    bl.build_kkt_system()  # gate accepts; would raise if it mis-classified
+    assert bl.kkt is not None and len(bl.kkt.stationarity) == 2
+
+
+def test_nondiagonal_indefinite_qp_refused():
+    # y1^2 + 3*y1*y2 + y2^2 : Hessian [[2,3],[3,2]], eigenvalues -1,5 -> indefinite.
+    m = Model("indef")
+    x = m.continuous("x", lb=0, ub=10)
+    y1 = m.continuous("y1", lb=-5, ub=5)
+    y2 = m.continuous("y2", lb=-5, ub=5)
+    m.minimize(x - y1 - y2)
+    bl = BilevelProblem(
+        m,
+        upper_vars=[x],
+        lower_vars=[y1, y2],
+        lower_objective=y1 * y1 + 3 * y1 * y2 + y2 * y2,
+        lower_constraints=[y1 + y2 <= 4],
+    )
+    with pytest.raises(NotImplementedError, match="nonconvex"):
+        bl.build_kkt_system()
+
+
+def test_max_follower_sign_flip_in_convexity_gate():
+    # The gate signs the objective by lower_sense: a *max* follower minimises -f, so
+    # a **convex** objective under max is a *concave* minimand -> must be refused,
+    # while a **concave** objective under max is convex -> accepted. A gate that
+    # forgot the sign flip would wrongly accept the convex-max case.
+    def _mk(obj_fn):
+        m = Model("maxg")
+        x = m.continuous("x", lb=0, ub=10)
+        y = m.continuous("y", lb=-5, ub=5)
+        m.minimize(x - y)
+        return BilevelProblem(
+            m,
+            upper_vars=[x],
+            lower_vars=[y],
+            lower_objective=obj_fn(y),
+            lower_constraints=[y <= 4],
+            lower_sense="max",
+        )
+
+    # max of a concave objective -> convex minimand -> accepted.
+    _mk(lambda y: -(y * y)).build_kkt_system()
+    # max of a convex objective -> concave minimand -> refused.
+    with pytest.raises(NotImplementedError, match="nonconvex"):
+        _mk(lambda y: y * y).build_kkt_system()
+
+
+def test_concave_inequality_body_refused():
+    # A '<=' body that is concave in y makes the gate refuse: KKT/strong-duality
+    # need each inequality body convex (convex feasible set). Conservative refusal.
+    m = Model("concave")
+    x = m.continuous("x", lb=0, ub=10)
+    y = m.continuous("y", lb=-5, ub=5)
+    m.minimize(x - y)
+    bl = BilevelProblem(
+        m,
+        upper_vars=[x],
+        lower_vars=[y],
+        lower_objective=y,
+        lower_constraints=[-(y * y) <= 0],  # concave body
+    )
+    with pytest.raises(NotImplementedError, match="nonconvex"):
+        bl.build_kkt_system()
 
 
 def test_nonlinear_equality_refused():

--- a/python/tests/test_bilevel_phase3.py
+++ b/python/tests/test_bilevel_phase3.py
@@ -1,0 +1,101 @@
+"""Bilevel Phase 3: end-to-end solve behavior (the audit's missing coverage).
+
+The phase-1/2 suites validate the KKT/strong-duality *reformulation* against a
+scipy oracle but never call ``model.solve()`` — so a false optimal in the actual
+global solve went uncaught. This file closes that gap and pins the audit fix:
+
+* The KKT ``gdp``/``sos1`` big-M encodings **refuse loudly** when the follower's
+  multipliers are unbounded (the common case) — a sentinel-sized big-M is
+  numerically vacuous and would certify a follower-infeasible point (a false
+  optimum). This is the regression for the shared GDP big-M fix
+  (``_jax/gdp_reformulate._BIGM_SENTINEL``).
+* The ``strong_duality`` reduction (a single bilinear equality, no big-M) **solves**
+  a linear bilevel to the true optimistic optimum, and the returned follower ``y``
+  is genuinely the follower's argmin at the returned leader ``x`` (scipy oracle).
+
+The solve needs the Rust extension + an NLP backend; the refusal tests are
+solver-free.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+scipy_opt = pytest.importorskip("scipy.optimize")
+from discopt.bilevel import BilevelProblem  # noqa: E402
+from discopt.modeling.core import Model  # noqa: E402
+
+
+def _bard_lp():
+    """Linear bilevel with a known optimistic optimum.
+
+    Leader:   min_{x,y} x - 4y
+    Follower: min_y  y   s.t.  x + y >= 3,  y <= 2x,  y in [0, 10],  x in [0, 10].
+
+    The follower minimises y, so at leader x it picks y = max(0, 3 - x) subject to
+    y <= 2x (feasible only for x >= 1). Leader objective x - 4y over x in [1, 3] is
+    5x - 12, minimised at x = 1 (y = 2) → obj = -7. (For x > 3 the follower gives
+    y = 0 and the leader objective only grows.)
+    """
+    m = Model("bard")
+    x = m.continuous("x", lb=0, ub=10)
+    y = m.continuous("y", lb=0, ub=10)
+    m.minimize(x - 4 * y)
+    bl = BilevelProblem(
+        m,
+        upper_vars=[x],
+        lower_vars=[y],
+        lower_objective=y,
+        lower_constraints=[x + y >= 3, y <= 2 * x],
+        lower_sense="min",
+    )
+    return m, x, y, bl
+
+
+def _follower_argmin(xv: float) -> float:
+    res = scipy_opt.linprog(
+        c=[1.0],
+        A_ub=[[-1.0], [1.0]],
+        b_ub=[xv - 3.0, 2.0 * xv],
+        bounds=[(0.0, 10.0)],
+        method="highs",
+    )
+    assert res.success, res.message
+    return float(res.x[0])
+
+
+# ---------------------------------------------------------------------------
+# 1. Unbounded KKT multipliers → the big-M encodings refuse loudly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("mpec_method", ["gdp", "sos1"])
+def test_kkt_bigm_refuses_unbounded_multipliers(mpec_method):
+    """Certifying an unbounded KKT multiplier via big-M would be a false optimum."""
+    _m, _x, _y, bl = _bard_lp()
+    with pytest.raises(NotImplementedError, match="unbounded|strong_duality"):
+        bl.formulate(method="kkt", mpec_method=mpec_method)
+
+
+# ---------------------------------------------------------------------------
+# 2. strong_duality solves the linear bilevel to the true optimum.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(120)
+def test_strong_duality_solves_linear_bilevel_to_true_optimum():
+    pytest.importorskip("discopt._rust")
+    m, x, y, bl = _bard_lp()
+    bl.formulate(method="strong_duality")
+    r = m.solve(time_limit=90)
+    assert r.status in ("optimal", "feasible"), f"unexpected status {r.status}"
+    assert r.objective is not None, "no incumbent returned"
+    xv, yv = float(r.value(x)), float(r.value(y))
+    # True optimistic optimum.
+    assert r.objective == pytest.approx(-7.0, abs=1e-3)
+    assert xv == pytest.approx(1.0, abs=1e-2)
+    assert yv == pytest.approx(2.0, abs=1e-2)
+    # The returned y is genuinely the follower's argmin at the returned x
+    # (guards against certifying a follower-infeasible point).
+    assert yv == pytest.approx(_follower_argmin(xv), abs=1e-2)

--- a/python/tests/test_bilevel_phase3.py
+++ b/python/tests/test_bilevel_phase3.py
@@ -19,6 +19,8 @@ solver-free.
 
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 scipy_opt = pytest.importorskip("scipy.optimize")
@@ -26,7 +28,7 @@ from discopt.bilevel import BilevelProblem  # noqa: E402
 from discopt.modeling.core import Model  # noqa: E402
 
 
-def _bard_lp():
+def _bard_lp(**kw):
     """Linear bilevel with a known optimistic optimum.
 
     Leader:   min_{x,y} x - 4y
@@ -48,6 +50,7 @@ def _bard_lp():
         lower_objective=y,
         lower_constraints=[x + y >= 3, y <= 2 * x],
         lower_sense="min",
+        **kw,
     )
     return m, x, y, bl
 
@@ -99,3 +102,110 @@ def test_strong_duality_solves_linear_bilevel_to_true_optimum():
     # The returned y is genuinely the follower's argmin at the returned x
     # (guards against certifying a follower-infeasible point).
     assert yv == pytest.approx(_follower_argmin(xv), abs=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# 3. Certified solve via a user-supplied multiplier bound.
+# ---------------------------------------------------------------------------
+
+
+def test_default_still_refuses_without_multiplier_ub():
+    """No multiplier_ub → the big-M path still refuses (unbounded multipliers)."""
+    _m, _x, _y, bl = _bard_lp()
+    with pytest.raises(NotImplementedError, match="unbounded|multiplier_ub"):
+        bl.formulate(method="kkt", mpec_method="gdp")
+
+
+@pytest.mark.parametrize("bad", [0.0, -5.0, float("inf")])
+def test_invalid_multiplier_ub_raises(bad):
+    _m, _x, _y, bl = _bard_lp(multiplier_ub=bad)
+    with pytest.raises(ValueError, match="finite positive"):
+        bl.formulate(method="kkt", mpec_method="gdp")
+
+
+@pytest.mark.timeout(120)
+def test_user_multiplier_ub_gives_certified_solve():
+    """A valid user-supplied multiplier bound makes kkt+gdp gap-certified (LP follower).
+
+    True follower duals here are O(1), so multiplier_ub=50 is valid. The solve must
+    reach the true optimum with gap_certified=True and a follower-optimal y.
+    """
+    pytest.importorskip("discopt._rust")
+    m, x, y, bl = _bard_lp(multiplier_ub=50.0)
+    bl.formulate(method="kkt", mpec_method="gdp")
+    r = m.solve(time_limit=90)
+    assert r.status == "optimal", f"unexpected status {r.status}"
+    assert r.objective == pytest.approx(-7.0, abs=1e-3)
+    xv, yv = float(r.value(x)), float(r.value(y))
+    assert xv == pytest.approx(1.0, abs=1e-2)
+    assert yv == pytest.approx(2.0, abs=1e-2)
+    assert yv == pytest.approx(_follower_argmin(xv), abs=1e-2)
+    assert getattr(r, "gap_certified", False) is True
+
+
+def test_multiplier_bound_active_warning_is_best_effort():
+    """The solve() guard warns when a multiplier sits at its supplied bound.
+
+    Driven with a stub result (deterministic, solver-free): the guard is a
+    best-effort signal that a too-small multiplier_ub may be cutting the true
+    follower response. It does not catch every unsound bound, only the at-bound case.
+    """
+    import numpy as np
+
+    m, _x, _y, bl = _bard_lp(multiplier_ub=10.0)
+    bl.build_kkt_system()
+    bl._apply_multiplier_ub()
+    mu0 = bl.kkt.comp_pairs[0].f
+
+    class _Stub:
+        def __init__(self, at_bound):
+            self._at = at_bound
+
+        def value(self, v):
+            return np.asarray(10.0 if (v is mu0 and self._at) else 0.0)
+
+    with pytest.warns(UserWarning, match="multiplier_ub"):
+        bl._warn_if_multiplier_bound_active(_Stub(at_bound=True))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning expected when well below the bound
+        bl._warn_if_multiplier_bound_active(_Stub(at_bound=False))
+
+
+# ---------------------------------------------------------------------------
+# 4. Convex-NLP follower solves end-to-end via strong_duality.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(180)
+def test_convex_nlp_follower_solves_via_strong_duality():
+    """Follower min exp(y) - x*y (convex in y) → y* = ln(x); leader min (y-1)^2.
+
+    The optimistic optimum is y=1, x=e (obj 0). Confirms the convex-NLP lower level
+    (accepted by the interval-Hessian-in-y certifier) reduces and solves end-to-end,
+    with the returned y satisfying the follower's first-order condition exp(y) = x.
+    """
+    import numpy as np
+    from discopt.modeling.core import FunctionCall, Model
+
+    pytest.importorskip("discopt._rust")
+    m = Model("nlp_bilevel")
+    x = m.continuous("x", lb=0.5, ub=8.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    m.minimize((y - 1.0) * (y - 1.0))
+    bl = BilevelProblem(
+        m,
+        upper_vars=[x],
+        lower_vars=[y],
+        lower_objective=FunctionCall("exp", y) - x * y,
+        lower_constraints=[],
+    )
+    bl.formulate(method="strong_duality")
+    r = m.solve(time_limit=150)
+    assert r.status in ("optimal", "feasible"), f"unexpected status {r.status}"
+    assert r.objective is not None
+    xv, yv = float(r.value(x)), float(r.value(y))
+    assert yv == pytest.approx(1.0, abs=2e-2)
+    assert xv == pytest.approx(np.e, abs=5e-2)
+    # Follower first-order optimality: exp(y) - x == 0.
+    assert abs(np.exp(yv) - xv) < 5e-2

--- a/python/tests/test_bilevel_symbolic_diff.py
+++ b/python/tests/test_bilevel_symbolic_diff.py
@@ -18,6 +18,7 @@ import math
 import pytest
 
 jax = pytest.importorskip("jax")
+import discopt.modeling as dm  # noqa: E402
 import jax.numpy as jnp  # noqa: E402
 from discopt._jax.dag_compiler import compile_expression_params  # noqa: E402
 from discopt.bilevel.symbolic_diff import diff, grad  # noqa: E402
@@ -225,6 +226,47 @@ def test_grad_returns_component_list():
     dy = float(compile_expression_params(g[1], m)(xv, _NO_PARAMS))  # 3x
     assert abs(dx - (2 * 1.1 + 3 * 0.4)) <= 1e-9
     assert abs(dy - (3 * 1.1)) <= 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 4b. Aggregation / structural nodes (the module documents these as supported;
+# the random fuzz above only builds arithmetic + univariate-function nodes, so
+# pin them explicitly against jax.grad).
+# ---------------------------------------------------------------------------
+
+
+def test_unary_neg_node():
+    m = Model("neg")
+    x = m.continuous("x", lb=-3, ub=3)
+    y = m.continuous("y", lb=-3, ub=3)
+    # -(x*y): UnaryOp('neg') around a product.
+    assert _assert_grad_matches(-(x * y), m, [x, y], jnp.asarray([1.1, -0.7]))
+
+
+def test_sum_over_expression_node():
+    m = Model("sumover")
+    xs = [m.continuous(f"x{i}", lb=-3, ub=3) for i in range(3)]
+    # dm.sum over a list of expressions -> SumOverExpression.
+    expr = dm.sum([xs[0] * xs[0], xs[1], xs[2] * Constant(3.0)])
+    assert _assert_grad_matches(expr, m, xs, jnp.asarray([1.1, -0.7, 0.5]))
+
+
+def test_sum_and_index_over_array_variable():
+    m = Model("sumidx")
+    s = m.continuous("s", lb=-3, ub=3)  # scalar we differentiate against
+    a = m.continuous("a", shape=(3,), lb=-3, ub=3)  # array var
+    # dm.sum(a) -> SumExpression (reduction); a[1] -> IndexExpression. Multiply by
+    # the scalar so ∂/∂s is nonzero and structural nodes are on the diff path.
+    for expr in (dm.sum(a) * s, a[1] * s):
+        assert _assert_grad_matches(expr, m, [s], jnp.asarray([1.1, 0.2, 0.3, 0.4]))
+
+
+def test_matmul_node():
+    m = Model("matmul")
+    s = m.continuous("s", lb=-3, ub=3)
+    a = m.continuous("a", shape=(3,), lb=-3, ub=3)
+    # (a @ a) is a scalar (dot product); times s exercises the matmul product rule.
+    assert _assert_grad_matches((a @ a) * s, m, [s], jnp.asarray([1.1, 0.2, 0.3, 0.4]))
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_gdp.py
+++ b/python/tests/test_gdp.py
@@ -127,20 +127,31 @@ class TestComputeBigM:
         # Lower bound of body = 0 - 3 = -3, so M = -(-3) * 1.01 = 3.03
         assert M == pytest.approx(3.0 * 1.01)
 
-    def test_large_finite_bounds_use_true_bound(self):
-        # GDP-1 (#413): a variable left at the large-but-FINITE default bounds
-        # (±~1e20) has a valid (large) big-M equal to that finite bound. The old
-        # behavior shrank it to _DEFAULT_BIG_M (1e4), which is NOT a valid
-        # over-estimate and cut feasible points of the active disjunct → a
-        # false-infeasible certificate. Correctness first: use the true finite
-        # bound, even though a huge M weakens the LP relaxation.
+    def test_large_but_real_finite_bounds_use_true_bound(self):
+        # GDP-1 (#413), preserved: a variable with a large-but-*real* finite bound
+        # (below the unbounded sentinel) has a valid big-M equal to that bound. We
+        # must NOT shrink it to _DEFAULT_BIG_M (1e4) — that would cut feasible
+        # points of the active disjunct (a false-infeasible certificate).
         m = dm.Model("t")
-        x = m.continuous("x")  # lb≈-1e20, ub≈1e20 (finite defaults)
-        ub = float(np.max(x.ub))
+        x = m.continuous("x", lb=-1e6, ub=1e6)  # real bounds, < _BIGM_SENTINEL
         con = Constraint(body=x, sense="<=", rhs=0.0)
         M = _compute_big_m(con, m)
-        assert M == pytest.approx(ub * 1.01)
-        assert M >= ub  # M must over-estimate the body's reachable max
+        assert M == pytest.approx(1e6 * 1.01)
+        assert M >= 1e6  # M must over-estimate the body's reachable max
+
+    def test_sentinel_bounds_refuse_loudly(self):
+        # Audit correction to GDP-1: a variable left at discopt's unbounded
+        # *sentinel* bounds (±~1e20) has NO usable big-M. #413 used that sentinel
+        # as M to avoid a false-infeasible, but a sentinel-sized M is numerically
+        # vacuous (M·integrality_tol ≫ operand scale), so the disjunction/
+        # complementarity is not enforced and the solver can certify a point that
+        # violates it (a false *optimal* — see the bilevel KKT complementarity
+        # case). A sentinel bound is not a real bound: refuse, exactly as for ±inf.
+        m = dm.Model("t")
+        x = m.continuous("x")  # lb≈-1e20, ub≈1e20 (unbounded sentinel)
+        con = Constraint(body=x, sense="<=", rhs=0.0)
+        with pytest.raises(ValueError, match="unbounded|finite"):
+            _compute_big_m(con, m)
 
     def test_truly_infinite_bounds_refuse_loudly(self):
         # GDP-1 (#413): a genuinely unbounded body has NO valid finite big-M.

--- a/python/tests/test_gdp1_gdp2_bigm_soundness.py
+++ b/python/tests/test_gdp1_gdp2_bigm_soundness.py
@@ -2,14 +2,21 @@
 
 GDP-1 — *too-small* big-M cuts feasible points of the active disjunct.
     ``_compute_big_m`` treated any variable bound ≥ 1e15 as "effectively
-    infinite" and substituted ``_DEFAULT_BIG_M = 1e4``. For a variable left at
-    the large-but-*finite* default bounds (±~1e20), that shrank a *valid* big-M
-    (the true finite bound) down to 1e4, which is NOT a valid over-estimate of
-    the body: the inactive disjunct's relaxed constraint stayed binding and cut
-    off the whole active disjunct → a false-**infeasible** certificate on the
-    default ``gdp_method="big-m"`` path. The sound behavior: use the true finite
-    bound (a large valid M), and for a *truly* infinite bound refuse loudly
-    (no valid finite M exists). The same defect lived in the SOS linking big-M.
+    infinite" and substituted ``_DEFAULT_BIG_M = 1e4``. For a variable with a
+    large-but-*real* finite bound, that shrank a *valid* big-M (the true finite
+    bound) down to 1e4, which is NOT a valid over-estimate of the body: the
+    inactive disjunct's relaxed constraint stayed binding and cut off the whole
+    active disjunct → a false-**infeasible** certificate. The sound behavior for a
+    *real* finite bound: use the true bound (a large valid M).
+
+    Audit correction (bilevel KKT complementarity): a variable left at discopt's
+    unbounded *sentinel* bounds (±~1e20) is a different case — a sentinel-sized M
+    is numerically vacuous (``M·integrality_tol ≫`` operand scale), so on an
+    objective that exploits the slack the disjunction is not enforced and the
+    solver certifies a violating point (a false-**optimal**). So the sentinel
+    range (``|bound| ≥ _BIGM_SENTINEL``) and a *truly* infinite bound both **refuse
+    loudly** — only real finite bounds below the sentinel yield a big-M. The same
+    rule holds for the SOS linking big-M.
 
 GDP-2 — mbigm crashes on any disjunction that adds a selector.
     ``_compute_big_m_lp`` built the LP ``bounds`` list from the *mutated* model
@@ -39,10 +46,28 @@ def _optx(result) -> float:
     return float(np.ravel(x)[0]) if x is not None else float("nan")
 
 
-def test_gdp1_large_finite_bounds_no_false_infeasible():
-    """Default (large-finite) bounds must NOT yield a false-infeasible cert."""
+def test_gdp1_sentinel_bounds_refuse_loudly():
+    """Sentinel (unbounded-default) bounds in a big-M disjunct must refuse loudly.
+
+    Audit correction to GDP-1: #413 used the ±~1e20 sentinel as the big-M to avoid
+    a false-infeasible, but a sentinel-sized M is numerically vacuous
+    (``M·integrality_tol ≫`` operand scale), so on an objective that *exploits* the
+    slack the disjunction is not enforced and the solver certifies a violating
+    point (a false optimal — the bilevel KKT complementarity case). A sentinel
+    bound is not a usable big-M: refuse and tell the user to add finite bounds.
+    """
     m = dm.Model("gdp1")
-    x = m.continuous("x")  # default ±~1e20 (finite)
+    x = m.continuous("x")  # default ±~1e20 (unbounded sentinel)
+    m.minimize((x - 25000.0) * (x - 25000.0))
+    m.either_or([[x <= 2], [x >= 20000]])
+    with pytest.raises(ValueError, match="unbounded|finite"):
+        m.solve(gdp_method="big-m")
+
+
+def test_gdp1_finite_bounds_no_false_infeasible():
+    """With real finite bounds the big-M path solves (no false-infeasible)."""
+    m = dm.Model("gdp1")
+    x = m.continuous("x", lb=0.0, ub=1e5)  # real bounds < _BIGM_SENTINEL
     m.minimize((x - 25000.0) * (x - 25000.0))
     # Feasible region: x<=2 OR x>=20000. True optimum: x=25000, obj=0.
     m.either_or([[x <= 2], [x >= 20000]])


### PR DESCRIPTION
## Summary

An audit of the existing `discopt.bilevel` module uncovered a **P0 false-optimal** in the certified solve path, plus missing end-to-end test coverage. This PR fixes the correctness bug, hardens the shared GDP layer, and adds two capabilities (a certified path and convex-NLP followers). Correctness first — unsound cases are refused loudly, never approximated.

## The P0 bug (correctness)

No test ever called `model.solve()` on a `BilevelProblem`. Running one exposed a false optimal: the module default `kkt` + `mpec_method="gdp"` on a linear-follower bilevel returned `status=optimal, gap_certified=True` at a **follower-infeasible** point (complementarity violated by ~950; the returned `y` was the follower's *worst* response, not its optimum).

**Root cause:** KKT multipliers have no a-priori upper bound, so they sit at discopt's `~1e20` "unbounded" sentinel. `_compute_big_m` treated that sentinel as a valid finite big-M → `M≈1e20`, which is numerically vacuous (`M·integrality_tol = 1e15`): the disjunction selector rounds to "integer" while the multiplier stays large, so complementarity is never enforced. The `#413` fix guarded "M too *small* → false infeasible"; it missed "M too *large* → vacuous → false optimal."

## Changes (4 commits)

**1. Shared GDP layer** (`_jax/gdp_reformulate.py`) — `_compute_big_m` now refuses a sentinel-magnitude bound (`|bound| ≥ _BIGM_SENTINEL = 1e15`), consistent with `±inf`, SOS1, and the LP path's existing `_INF_THRESH`. Real finite bounds below the sentinel still use the true bound, preserving `#413`. This reverses one `#413` sub-decision (sentinel → refuse, not `M=1e20`); the two tests encoding it were updated.

**2. Bilevel front-end** (`bilevel/problem.py`) — refuses the big-M path loudly for unbounded multipliers with an actionable message; `example_bilevel_toll` switched to the sound `strong_duality` path; added `build_kkt_system()` to separate the sound KKT-math construction from the encoding choice.

**3. Certified path via user-supplied multiplier bounds** — auto-deriving valid multiplier bounds was investigated and **falsified** (OBBT can't bound them — boundedness comes from complementarity, and valid bilevel big-Ms are NP-hard, Kleinert et al. 2021). Instead, `BilevelProblem(..., multiplier_ub=M)` lets the user assert a valid finite bound (like any big-M), making `kkt+gdp` gap-certified. A best-effort `solve()` guard warns if a multiplier sits at its bound. `strong_duality` stays the default uncertified path.

**4. Convex-NLP followers** — the convexity gate now certifies convexity *in `y`* for a nonlinear body via a symbolic follower Hessian + interval-Gershgorin PSD test over the box, accepting the natural linearly-coupled form (`exp(y) − x·y`) while refusing nonconvex/concave bodies. Solves end-to-end via `strong_duality`.

**5. Docs** — corrected the false "certified solve → CI" claims and the non-existent `convexity_gate.py` reference in the design doc; added `docs/dev/bilevel-audit-2026-07-13.md`, updated the notebook, and added a `.crucible/` bilevel concept page.

## Tests

- **`python/tests/test_bilevel_phase3.py`** (new) — the missing end-to-end coverage: big-M methods refuse unbounded multipliers; `strong_duality` solves the linear bilevel to `x=1, y=2, obj=−7` with follower optimality checked against a scipy oracle; `multiplier_ub` certified solve (`gap_certified=True`); convex-NLP follower solves (`min exp(y)−x·y → y=ln(x)`).
- **`test_bilevel_phase2.py`** — convexity-gate edge cases (non-diagonal PSD, max-follower sign-flip, concave body) + convex-NLP acceptance / nonconvex refusals.
- **`test_bilevel_symbolic_diff.py`** — coverage for previously-untested structural nodes.
- **`test_gdp.py` / `test_gdp1_gdp2_bigm_soundness.py`** — updated to the corrected sentinel behavior.

## Verification

- `pytest python/tests -m smoke` — **654 passed**, 13 skipped.
- Adversarial suite (`-m slow test_adversarial_recent_fixes.py`) — **10 passed** (one transient wall-clock flake on a batch run, green in isolation; the test has no GDP constructs).
- Bilevel + GDP + MPEC + indicator + GDPopt + gallery suites — **green** (209 in the final combined run; 71 bilevel).
- `ruff check` + `ruff format --check` on all touched files — clean.
- `docs/notebooks/bilevel.ipynb` re-executes clean via `nbclient`.

Note: this branch carries three logically-distinct changes (P0 correctness fix, certified-bilevel feature, convex-NLP feature) that would normally be separate PRs; they share one branch here. Commits are separated so they can be reviewed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)