### PR TITLE
docs(crucible): MAiNGO + parallel-tempering KB notes and references

### DIFF
--- a/.crucible/references.bib
+++ b/.crucible/references.bib
@@ -2533,6 +2533,41 @@
   note = {The MAiNGO solver technical report. Ingested 2026-07-09.},
 }
 
+@article{bongartz2017reducedspace,
+  title = {Deterministic global optimization of process flowsheets in a reduced space using {McCormick} relaxations},
+  author = {Bongartz, D. and Mitsos, A.},
+  journal = {Journal of Global Optimization},
+  volume = {69},
+  number = {4},
+  pages = {761--796},
+  year = {2017},
+  url = {https://doi.org/10.1007/s10898-017-0547-4},
+  note = {The reduced-space McCormick-propagation method underpinning MAiNGO. Ingested 2026-07-09.},
+}
+
+@article{najman2021linearization,
+  title = {Linearization of {McCormick} relaxations and hybridization with the auxiliary variable method},
+  author = {Najman, J. and Bongartz, D. and Mitsos, A.},
+  journal = {Journal of Global Optimization},
+  volume = {80},
+  pages = {731--756},
+  year = {2021},
+  url = {https://doi.org/10.1007/s10898-020-00977-x},
+  note = {How MAiNGO builds its lower-bounding LP by linearizing McCormick relaxations via subgradients, and hybridizes with AVM. Ingested 2026-07-09.},
+}
+
+@article{schweidtmann2019ann,
+  title = {Deterministic Global Optimization with Artificial Neural Networks Embedded},
+  author = {Schweidtmann, A. M. and Mitsos, A.},
+  journal = {Journal of Optimization Theory and Applications},
+  volume = {180},
+  number = {3},
+  pages = {925--948},
+  year = {2019},
+  url = {https://doi.org/10.1007/s10957-018-1396-0},
+  note = {Reduced-space McCormick optimization with ANNs embedded (MAiNGO); parallels discopt's nn/ module. Ingested 2026-07-09.},
+}
+
 @article{bongartz2022maingo_overview,
   title = {{MAiNGO} -- A Global Optimizer for Process Engineering: Algorithm and Applications in Process Design and Machine Learning},
   author = {Bongartz, D. and Najman, J. and Mitsos, A.},
@@ -2582,4 +2617,17 @@
   pages   = {100007},
   year    = {2021},
   doi     = {10.1016/j.ejco.2021.100007},
+}
+
+@misc{bongartz2026,
+  title = {MAiNGO — McCormick-based Algorithm for MINLP Global Optimization (research notes)},
+  author = {Bongartz, D. and Najman, J. and Sass, S. and Mitsos, A.},
+  year = {2026},
+  url = {https://avt-svt.pages.rwth-aachen.de/public/maingo/},
+}
+
+@article{kyuilsim2026,
+  title = {Solving Integer Linear Programming with Parallel Tempering},
+  author = {Kyuil Sim, Sanghyeok Choi, Jinkyoo Park},
+  year = {2026},
 }

--- a/.crucible/wiki/MANIFEST.md
+++ b/.crucible/wiki/MANIFEST.md
@@ -1,23 +1,23 @@
 # Crucible Knowledge Base
 
-Location: /Users/jkitchin/Dropbox/projects/discopt
-Updated: 2026-04-24
+Location: /Users/jkitchin/projects/discopt
+Updated: 2026-07-12
 
 ## Contents
 
-- 53 articles (concept, method, comparisons, summaries)
-- 169 concepts
-- 255 sources
-- 249 cross-links
+- 63 articles (1 comparison, 27 concept, 33 method, 2 summary)
+- 186 concepts
+- 279 sources (19 other, 168 pdf, 92 web)
+- 318 cross-links
 
 ## Topics
 
-minlp, global-optimization, solver, benchmark, convex-relaxation, optimization, branch-and-bound, convex-optimization, milp, disjunction, envelopes, classification, nlp-bb, outer-approximation, decomposition, cutting-planes, baron, big-m, formulation, rlt, convexity, dcp, couenne, coin-or, expression-dag, automatic-differentiation, jax, computational-graph, gdp, logic-based, highs, scip, primal-heuristic, presolve, feasibility-jump, rounding, diving, lns, rins, rens, dins, local-branching, crossover, probing, clique, fbbt, warp, rust, python, mpax, pdlp, cupdlp, first-order, gpu, gnn, neural-diving, neural-lns, predict-and-search, machine-learning, matheuristic, relax-and-fix, kernel-search, combinatorial-benders, cpsat, multiobjective, pareto, scalarization, epsilon-constraint, tchebycheff, nbi, normal-constraint, nsga, moead, spea, hypervolume, ehvi, nimbus, reference-point, ... (more)
+minlp, global-optimization, identifiability, solver, multiobjective, optimization, primal-heuristic, mip, convex-relaxation, jax, nlp, factorable, gpu, doe, baron, benchmark, big-m, milp, envelopes, convexity, couenne, mccormick, convex, pdlp, lp-free, matheuristic, generalized-convexity, sampling, mcmc, parallel-tempering, ... (156 more)
 
 ## How to Query
 
 ```bash
-cd /Users/jkitchin/Dropbox/projects/discopt
+cd /Users/jkitchin/projects/discopt
 crucible search "your query"     # full-text search
 crucible concepts                 # browse all topics
 crucible concept <name>           # articles on a topic

--- a/.crucible/wiki/concepts/parallel-tempering.org
+++ b/.crucible/wiki/concepts/parallel-tempering.org
@@ -1,0 +1,71 @@
+#+TITLE: Parallel Tempering
+#+FILETAGS: :concept:parallel-tempering:mcmc:simulated-annealing:sampling:replica-exchange:
+
+* Parallel Tempering
+:PROPERTIES:
+:ARTICLE_TYPE: concept
+:SOURCE_KEYS: kyuilsim2026
+:DERIVED_FROM: ../methods/sampling-based-ilp.org ../summaries/kyuilsim2026-ilp-parallel-tempering.org
+:STATUS: draft
+:CREATED: 2026-07-12
+:END:
+
+/Parallel Tempering/ (PT), also called /replica exchange/, is a Markov Chain
+Monte Carlo (MCMC) technique for sampling from rugged, multimodal
+distributions whose modes are separated by high-energy barriers that trap a
+single chain. Instead of one chain, PT runs $B$ chains in parallel, each
+targeting a /tempered/ version of the same distribution
+$\pi(x) \propto \exp(-\mathcal{E}(x)/\tau)$, and periodically proposes swaps of
+state between adjacent chains. Hot (weakly-tempered) chains flatten the energy
+surface and cross barriers freely to explore globally; cold chains keep the
+sharp target and refine within a basin. Swaps let a configuration discovered by
+a hot chain migrate down to a cold chain, giving the cold chain access to modes
+it could never reach by local moves alone.
+
+** Swap acceptance
+
+The joint distribution over all chains is the product of the per-chain tempered
+targets, $\pi(\mathbf{x}) = \prod_{i=1}^{B} \pi(x^i; \tau^i)$. A proposed swap
+between adjacent chains $i$ and $j$ is accepted under the Metropolis rule for
+this joint target, which for temperature tempering reduces to
+$\min(1, \exp(\Delta\beta_{i,j}\,\Delta\mathcal{E}_{i,j}))$ with
+$\Delta\beta = 1/\tau^i - 1/\tau^j$ and $\Delta\mathcal{E} = \mathcal{E}(x^i) - \mathcal{E}(x^j)$.
+Because each chain individually preserves its stationary distribution and the
+swap preserves the joint, the whole scheme leaves $\pi$ invariant. Mixing
+quality is commonly measured by the /round-trip rate/, how often a replica
+travels the full temperature ladder; non-reversible PT schemes (Syed et al.)
+improve this over naive random swaps.
+
+** Tempering axes
+
+The temperature $\tau$ is the classical thing to temper, but any parameter that
+controls the /sharpness/ or /shape/ of the target can define a ladder. In
+constrained problems the barrier is often set by a penalty weight $\lambda$
+rather than temperature; citet:kyuilsim2026 introduce *penalty tempering*
+($\lambda$-PT) for ILP, where a ladder of penalty levels
+$\lambda^1 > \cdots > \lambda^B$ lets low-$\lambda$ chains cross feasibility
+boundaries while the landscape over feasible solutions is preserved,
+complementary to standard temperature tempering ($\tau$-PT). See
+[[file:../methods/sampling-based-ilp.org][sampling-based ILP heuristics]] for the ILP application and
+[[file:../summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving ILP with Parallel Tempering]] for the full result.
+
+** Relation to simulated annealing
+
+Simulated annealing (SA) lowers a single chain's temperature on a schedule,
+$\tau(t) = \tau_0\gamma^t$, trading exploration for exploitation over time; it
+has one chain and no swaps. PT keeps the whole temperature ladder alive
+/simultaneously/ and exchanges between rungs, so it does not have to commit to a
+cooling schedule to retain barrier-crossing ability. The two compose: PT chains
+can each anneal, and citet:kyuilsim2026 find SA to be an indispensable
+component layered on top of PT for ILP.
+
+** Why it is relevant here
+
+PT is the global-exploration mechanism that makes MCMC competitive as a
+discrete-optimization heuristic: the $B$ chains are independent between swaps,
+so the scheme is embarrassingly parallel and maps naturally onto GPU
+throughput. That property is what makes sampling attractive as an LP-free,
+GPU-batchable primal heuristic for integer programs, a role developed for
+discopt in [[file:../methods/sampling-based-ilp.org][sampling-based ILP heuristics]] alongside [[file:../methods/feasibility-jump.org][Feasibility Jump]] and the
+[[file:../methods/first-order-mip-heuristics.org][first-order and GPU MIP heuristics]]. As a stochastic sampler it produces
+/primal/ points only, with no dual bound or optimality certificate.

--- a/.crucible/wiki/index.org
+++ b/.crucible/wiki/index.org
@@ -1,18 +1,19 @@
 #+TITLE: Crucible Wiki Index
-#+DATE: [2026-04-24 Fri]
+#+DATE: [2026-07-12 Sun]
 #+STARTUP: overview
 
 Auto-generated index of the Crucible knowledge base.
-56 articles, 177 concepts, 271 sources, 262 links.
+63 articles, 186 concepts, 279 sources, 318 links.
 
 * Articles by Type
 
-** Concepts (24)
+** Concepts (27)
 
 - [[file:concepts/baron-solver.org][BARON Solver]] /draft/
 - [[file:concepts/big-m-formulations.org][Big-M Formulations]] /draft/
 - [[file:concepts/convex-minlp-solvers.org][Convex MINLP Solvers]] /draft/
 - [[file:concepts/convex-relaxations.org][Convex Relaxations for Global Optimization]] /draft/
+- [[file:concepts/convex-transformable-functions.org][Convex-Transformable (G-convex) Functions]] /draft/
 - [[file:concepts/convexity-detection.org][Convexity Detection]] /draft/
 - [[file:concepts/couenne-solver.org][Couenne Solver]] /draft/
 - [[file:index.org][Crucible Wiki Index]] /draft/
@@ -22,19 +23,30 @@ Auto-generated index of the Crucible knowledge base.
 - [[file:concepts/highs-solver.org][HiGHS Solver]] /draft/
 - [[file:concepts/ipopt-solver.org][Ipopt: Interior Point Optimizer]] /draft/
 - [[file:concepts/llm-optimization.org][Large Language Models for Mathematical Optimization]] /draft/
+- [[file:concepts/maingo-solver.org][MAiNGO Solver]] /draft/
 - [[file:concepts/minlp-survey.org][MINLP Problem Class and Surveys]] /draft/
 - [[file:concepts/mpax-solver.org][MPAX Solver]] /draft/
 - [[file:concepts/model-based-doe.org][Model-Based Design of Experiments (MBDoE)]] /draft/
 - [[file:concepts/multiobjective-optimization.org][Multiobjective Optimization: Pareto Optimality and Problem Structure]] /draft/
 - [[file:concepts/neural-network-embedding.org][Neural Network Embedding in Optimization]] /draft/
 - [[file:concepts/nonlinear-programming.org][Nonlinear Programming Fundamentals]] /draft/
+- [[file:concepts/parallel-tempering.org][Parallel Tempering]] /draft/
 - [[file:concepts/identifiability-analysis.org][Parameter Identifiability Analysis]] /draft/
 - [[file:concepts/performance-indicators-mo.org][Performance Indicators for Pareto Front Approximations]] /draft/
 - [[file:concepts/robust-optimization.org][Robust Optimization: Decision-Making Under Set-Based Uncertainty]] /draft/
 - [[file:concepts/scip-solver.org][SCIP Solver]] /draft/
 - [[file:concepts/sloppy-models.org][Sloppy Models]] /draft/
 
-** Methods (32)
+** Source Summaries (2)
+
+- [[file:summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving Integer Linear Programming with Parallel Tempering]] /draft/
+- [[file:summaries/khajavirad-2012-convex-transformable.org][Summary — Relaxations of Factorable Functions with Convex-Transformable Intermediates (Khajavirad, Michalek, Sahinidis 2012)]] /draft/
+
+** Comparisons (1)
+
+- [[file:comparisons/maingo-vs-discopt.org][MAiNGO vs discopt]] /draft/
+
+** Methods (33)
 
 - [[file:methods/adaptive-multivariate-partitioning.org][Adaptive Multivariate Partitioning (AMP) for Global MINLP]] /draft/
 - [[file:methods/alphabb-underestimators.org][AlphaBB Underestimators]] /draft/
@@ -65,6 +77,7 @@ Auto-generated index of the Crucible knowledge base.
 - [[file:methods/outer-approximation.org][Outer Approximation for MINLP]] /draft/
 - [[file:methods/parameter-estimability.org][Parameter Estimability and Subset Selection]] /draft/
 - [[file:methods/profile-likelihood-identifiability.org][Profile Likelihood Identifiability Analysis]] /draft/
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] /draft/
 - [[file:methods/scalarization-methods.org][Scalarization Methods for Multiobjective Optimization]] /draft/
 - [[file:methods/spatial-branch-and-bound.org][Spatial Branch and Bound]] /draft/
 - [[file:methods/structural-identifiability.org][Structural Identifiability Methods]] /draft/
@@ -99,10 +112,11 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:methods/auxiliary-variable-reformulation.org][Auxiliary Variable Reformulation]] [method]
 
-** Baron (2)
+** Baron (3)
 
 - [[file:methods/auxiliary-variable-reformulation.org][Auxiliary Variable Reformulation]] [method]
 - [[file:concepts/baron-solver.org][BARON Solver]] [concept]
+- [[file:summaries/khajavirad-2012-convex-transformable.org][Summary — Relaxations of Factorable Functions with Convex-Transformable Intermediates (Khajavirad, Michalek, Sahinidis 2012)]] [summary]
 
 ** Barrier (1)
 
@@ -203,15 +217,19 @@ Auto-generated index of the Crucible knowledge base.
 - [[file:methods/nonlinear-branch-and-bound.org][Nonlinear Branch and Bound (NLP-BB)]] [method]
 - [[file:methods/outer-approximation.org][Outer Approximation for MINLP]] [method]
 
-** Convex-Relaxation (3)
+** Convex-Relaxation (5)
 
 - [[file:methods/alphabb-underestimators.org][AlphaBB Underestimators]] [method]
 - [[file:concepts/convex-relaxations.org][Convex Relaxations for Global Optimization]] [concept]
+- [[file:concepts/convex-transformable-functions.org][Convex-Transformable (G-convex) Functions]] [concept]
 - [[file:methods/mccormick-relaxations.org][McCormick Relaxations]] [method]
+- [[file:summaries/khajavirad-2012-convex-transformable.org][Summary — Relaxations of Factorable Functions with Convex-Transformable Intermediates (Khajavirad, Michalek, Sahinidis 2012)]] [summary]
 
-** Convexity (1)
+** Convexity (3)
 
+- [[file:concepts/convex-transformable-functions.org][Convex-Transformable (G-convex) Functions]] [concept]
 - [[file:concepts/convexity-detection.org][Convexity Detection]] [concept]
+- [[file:summaries/khajavirad-2012-convex-transformable.org][Summary — Relaxations of Factorable Functions with Convex-Transformable Intermediates (Khajavirad, Michalek, Sahinidis 2012)]] [summary]
 
 ** Couenne (3)
 
@@ -268,9 +286,10 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:methods/large-neighborhood-search.org][Large Neighborhood Search for MIP]] [method]
 
-** Discopt (1)
+** Discopt (2)
 
 - [[file:methods/debugging-discopt.org][Debugging and Troubleshooting discopt]] [method]
+- [[file:comparisons/maingo-vs-discopt.org][MAiNGO vs discopt]] [comparison]
 
 ** Discrimination (1)
 
@@ -304,9 +323,10 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:methods/bayesian-multiobjective.org][Bayesian Multiobjective Optimization]] [method]
 
-** Envelopes (2)
+** Envelopes (3)
 
 - [[file:concepts/convex-relaxations.org][Convex Relaxations for Global Optimization]] [concept]
+- [[file:concepts/convex-transformable-functions.org][Convex-Transformable (G-convex) Functions]] [concept]
 - [[file:methods/mccormick-relaxations.org][McCormick Relaxations]] [method]
 
 ** Epsilon-Constraint (1)
@@ -329,10 +349,12 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:concepts/expression-dag-and-ad.org][Expression DAG and Automatic Differentiation]] [concept]
 
-** Factorable (2)
+** Factorable (4)
 
 - [[file:methods/auxiliary-variable-reformulation.org][Auxiliary Variable Reformulation]] [method]
+- [[file:concepts/convex-transformable-functions.org][Convex-Transformable (G-convex) Functions]] [concept]
 - [[file:methods/mccormick-relaxations.org][McCormick Relaxations]] [method]
+- [[file:summaries/khajavirad-2012-convex-transformable.org][Summary — Relaxations of Factorable Functions with Convex-Transformable Intermediates (Khajavirad, Michalek, Sahinidis 2012)]] [summary]
 
 ** Fbbt (2)
 
@@ -369,6 +391,12 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:concepts/generalized-disjunctive-programming.org][Generalized Disjunctive Programming]] [concept]
 
+** Generalized-Convexity (3)
+
+- [[file:concepts/convex-transformable-functions.org][Convex-Transformable (G-convex) Functions]] [concept]
+- [[file:concepts/convexity-detection.org][Convexity Detection]] [concept]
+- [[file:summaries/khajavirad-2012-convex-transformable.org][Summary — Relaxations of Factorable Functions with Convex-Transformable Intermediates (Khajavirad, Michalek, Sahinidis 2012)]] [summary]
+
 ** Geometry (1)
 
 - [[file:concepts/sloppy-models.org][Sloppy Models]] [concept]
@@ -377,26 +405,32 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:methods/spatial-branch-and-bound.org][Spatial Branch and Bound]] [method]
 
-** Global-Optimization (8)
+** Global-Optimization (12)
 
 - [[file:methods/adaptive-multivariate-partitioning.org][Adaptive Multivariate Partitioning (AMP) for Global MINLP]] [method]
 - [[file:methods/alphabb-underestimators.org][AlphaBB Underestimators]] [method]
 - [[file:concepts/baron-solver.org][BARON Solver]] [concept]
 - [[file:methods/bound-tightening.org][Bound Tightening (FBBT and OBBT)]] [method]
 - [[file:concepts/convex-relaxations.org][Convex Relaxations for Global Optimization]] [concept]
+- [[file:concepts/convex-transformable-functions.org][Convex-Transformable (G-convex) Functions]] [concept]
 - [[file:concepts/couenne-solver.org][Couenne Solver]] [concept]
+- [[file:concepts/maingo-solver.org][MAiNGO Solver]] [concept]
+- [[file:comparisons/maingo-vs-discopt.org][MAiNGO vs discopt]] [comparison]
 - [[file:methods/mccormick-relaxations.org][McCormick Relaxations]] [method]
 - [[file:methods/spatial-branch-and-bound.org][Spatial Branch and Bound]] [method]
+- [[file:summaries/khajavirad-2012-convex-transformable.org][Summary — Relaxations of Factorable Functions with Convex-Transformable Intermediates (Khajavirad, Michalek, Sahinidis 2012)]] [summary]
 
 ** Gnn (2)
 
 - [[file:methods/branch-variable-selection.org][Branch Variable Selection]] [method]
 - [[file:methods/learning-based-mip-heuristics.org][Learning-Based MIP Heuristics]] [method]
 
-** Gpu (2)
+** Gpu (4)
 
 - [[file:methods/first-order-mip-heuristics.org][First-Order and GPU MIP Heuristics]] [method]
 - [[file:concepts/mpax-solver.org][MPAX Solver]] [concept]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
+- [[file:summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving Integer Linear Programming with Parallel Tempering]] [summary]
 
 ** Heuristic (1)
 
@@ -426,6 +460,11 @@ Auto-generated index of the Crucible knowledge base.
 ** Identification (1)
 
 - [[file:methods/model-discrimination.org][Model Discrimination: Rival-Model Experimental Design and Selection]] [method]
+
+** Ilp (2)
+
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
+- [[file:summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving Integer Linear Programming with Parallel Tempering]] [summary]
 
 ** Indicator (1)
 
@@ -461,11 +500,12 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:methods/algebraic-model-identifiability.org][Identifiability for Algebraic and Regression Models]] [method]
 
-** Jax (3)
+** Jax (4)
 
 - [[file:concepts/expression-dag-and-ad.org][Expression DAG and Automatic Differentiation]] [concept]
 - [[file:methods/feasibility-jump.org][Feasibility Jump]] [method]
 - [[file:concepts/mpax-solver.org][MPAX Solver]] [concept]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
 
 ** Kernel-Search (1)
 
@@ -500,27 +540,43 @@ Auto-generated index of the Crucible knowledge base.
 - [[file:concepts/highs-solver.org][HiGHS Solver]] [concept]
 - [[file:concepts/mpax-solver.org][MPAX Solver]] [concept]
 
-** Lp-Free (1)
+** Lp-Free (3)
 
 - [[file:methods/feasibility-jump.org][Feasibility Jump]] [method]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
+- [[file:summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving Integer Linear Programming with Parallel Tempering]] [summary]
 
 ** Machine-Learning (2)
 
 - [[file:methods/branch-variable-selection.org][Branch Variable Selection]] [method]
 - [[file:methods/learning-based-mip-heuristics.org][Learning-Based MIP Heuristics]] [method]
 
-** Matheuristic (2)
+** Maingo (2)
+
+- [[file:concepts/maingo-solver.org][MAiNGO Solver]] [concept]
+- [[file:comparisons/maingo-vs-discopt.org][MAiNGO vs discopt]] [comparison]
+
+** Matheuristic (3)
 
 - [[file:methods/first-order-mip-heuristics.org][First-Order and GPU MIP Heuristics]] [method]
 - [[file:methods/matheuristics.org][Matheuristics]] [method]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
 
 ** Mbdoe (1)
 
 - [[file:concepts/model-based-doe.org][Model-Based Design of Experiments (MBDoE)]] [concept]
 
-** Mccormick (1)
+** Mccormick (3)
 
+- [[file:concepts/maingo-solver.org][MAiNGO Solver]] [concept]
+- [[file:comparisons/maingo-vs-discopt.org][MAiNGO vs discopt]] [comparison]
 - [[file:methods/mccormick-relaxations.org][McCormick Relaxations]] [method]
+
+** Mcmc (3)
+
+- [[file:concepts/parallel-tempering.org][Parallel Tempering]] [concept]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
+- [[file:summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving Integer Linear Programming with Parallel Tempering]] [summary]
 
 ** Metric (1)
 
@@ -536,7 +592,7 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:methods/adaptive-multivariate-partitioning.org][Adaptive Multivariate Partitioning (AMP) for Global MINLP]] [method]
 
-** Minlp (14)
+** Minlp (16)
 
 - [[file:methods/adaptive-multivariate-partitioning.org][Adaptive Multivariate Partitioning (AMP) for Global MINLP]] [method]
 - [[file:methods/auxiliary-variable-reformulation.org][Auxiliary Variable Reformulation]] [method]
@@ -547,13 +603,15 @@ Auto-generated index of the Crucible knowledge base.
 - [[file:methods/exact-mo-integer-programming.org][Exact Multiobjective Integer and Mixed-Integer Programming]] [method]
 - [[file:methods/feasibility-pump.org][Feasibility Pump]] [method]
 - [[file:concepts/generalized-disjunctive-programming.org][Generalized Disjunctive Programming]] [concept]
+- [[file:concepts/maingo-solver.org][MAiNGO Solver]] [concept]
+- [[file:comparisons/maingo-vs-discopt.org][MAiNGO vs discopt]] [comparison]
 - [[file:concepts/minlp-survey.org][MINLP Problem Class and Surveys]] [concept]
 - [[file:methods/nonlinear-branch-and-bound.org][Nonlinear Branch and Bound (NLP-BB)]] [method]
 - [[file:methods/outer-approximation.org][Outer Approximation for MINLP]] [method]
 - [[file:concepts/scip-solver.org][SCIP Solver]] [concept]
 - [[file:methods/spatial-branch-and-bound.org][Spatial Branch and Bound]] [method]
 
-** Mip (6)
+** Mip (7)
 
 - [[file:methods/feasibility-jump.org][Feasibility Jump]] [method]
 - [[file:concepts/highs-solver.org][HiGHS Solver]] [concept]
@@ -561,6 +619,7 @@ Auto-generated index of the Crucible knowledge base.
 - [[file:methods/mip-presolve.org][MIP Presolve]] [method]
 - [[file:methods/mip-primal-heuristics.org][MIP Primal Heuristics]] [method]
 - [[file:methods/matheuristics.org][Matheuristics]] [method]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
 
 ** Model-Selection (1)
 
@@ -669,6 +728,12 @@ Auto-generated index of the Crucible knowledge base.
 - [[file:concepts/convex-minlp-solvers.org][Convex MINLP Solvers]] [concept]
 - [[file:methods/outer-approximation.org][Outer Approximation for MINLP]] [method]
 
+** Parallel-Tempering (3)
+
+- [[file:concepts/parallel-tempering.org][Parallel Tempering]] [concept]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
+- [[file:summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving Integer Linear Programming with Parallel Tempering]] [summary]
+
 ** Parameter-Estimation (1)
 
 - [[file:concepts/identifiability-analysis.org][Parameter Identifiability Analysis]] [concept]
@@ -707,13 +772,15 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:methods/interior-point-methods.org][Interior Point Methods for NLP]] [method]
 
-** Primal-Heuristic (5)
+** Primal-Heuristic (7)
 
 - [[file:methods/feasibility-jump.org][Feasibility Jump]] [method]
 - [[file:methods/feasibility-pump.org][Feasibility Pump]] [method]
 - [[file:methods/learning-based-mip-heuristics.org][Learning-Based MIP Heuristics]] [method]
 - [[file:methods/mip-primal-heuristics.org][MIP Primal Heuristics]] [method]
 - [[file:methods/matheuristics.org][Matheuristics]] [method]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
+- [[file:summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving Integer Linear Programming with Parallel Tempering]] [summary]
 
 ** Probing (1)
 
@@ -726,6 +793,11 @@ Auto-generated index of the Crucible knowledge base.
 ** Proximity (1)
 
 - [[file:methods/large-neighborhood-search.org][Large Neighborhood Search for MIP]] [method]
+
+** Reduced-Space (2)
+
+- [[file:concepts/maingo-solver.org][MAiNGO Solver]] [concept]
+- [[file:comparisons/maingo-vs-discopt.org][MAiNGO vs discopt]] [comparison]
 
 ** Reference-Point (1)
 
@@ -755,6 +827,10 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:methods/large-neighborhood-search.org][Large Neighborhood Search for MIP]] [method]
 
+** Replica-Exchange (1)
+
+- [[file:concepts/parallel-tempering.org][Parallel Tempering]] [concept]
+
 ** Rins (1)
 
 - [[file:methods/large-neighborhood-search.org][Large Neighborhood Search for MIP]] [method]
@@ -774,6 +850,12 @@ Auto-generated index of the Crucible knowledge base.
 ** Rounding (1)
 
 - [[file:methods/mip-primal-heuristics.org][MIP Primal Heuristics]] [method]
+
+** Sampling (3)
+
+- [[file:concepts/parallel-tempering.org][Parallel Tempering]] [concept]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
+- [[file:summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving Integer Linear Programming with Parallel Tempering]] [summary]
 
 ** Scalarization (1)
 
@@ -800,6 +882,12 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:concepts/highs-solver.org][HiGHS Solver]] [concept]
 
+** Simulated-Annealing (3)
+
+- [[file:concepts/parallel-tempering.org][Parallel Tempering]] [concept]
+- [[file:methods/sampling-based-ilp.org][Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)]] [method]
+- [[file:summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving Integer Linear Programming with Parallel Tempering]] [summary]
+
 ** Sloppy-Models (1)
 
 - [[file:concepts/sloppy-models.org][Sloppy Models]] [concept]
@@ -808,7 +896,7 @@ Auto-generated index of the Crucible knowledge base.
 
 - [[file:methods/identifiability-software.org][Identifiability Software Landscape]] [method]
 
-** Solver (7)
+** Solver (8)
 
 - [[file:concepts/baron-solver.org][BARON Solver]] [concept]
 - [[file:concepts/convex-minlp-solvers.org][Convex MINLP Solvers]] [concept]
@@ -816,6 +904,7 @@ Auto-generated index of the Crucible knowledge base.
 - [[file:methods/debugging-discopt.org][Debugging and Troubleshooting discopt]] [method]
 - [[file:concepts/highs-solver.org][HiGHS Solver]] [concept]
 - [[file:concepts/ipopt-solver.org][Ipopt: Interior Point Optimizer]] [concept]
+- [[file:concepts/maingo-solver.org][MAiNGO Solver]] [concept]
 - [[file:concepts/scip-solver.org][SCIP Solver]] [concept]
 
 ** Spatial-Branch-And-Bound (1)
@@ -885,6 +974,20 @@ Auto-generated index of the Crucible knowledge base.
 
 * Sources
 
+- [pdf] Solving Integer Linear Programming with Parallel Tempering (external)
+- [other] MAiNGO -- McCormick-based Algorithm for mixed-integer Nonlinear Global Optimization (shareable)
+  https://avt-svt.pages.rwth-aachen.de/public/maingo/
+- [pdf] Deterministic global optimization of process flowsheets in a reduced space using {McCormick} relaxations (shareable)
+  https://doi.org/10.1007/s10898-017-0547-4
+- [pdf] Linearization of {McCormick} relaxations and hybridization with the auxiliary variable method (shareable)
+  https://doi.org/10.1007/s10898-020-00977-x
+- [pdf] Deterministic Global Optimization with Artificial Neural Networks Embedded (shareable)
+  https://doi.org/10.1007/s10957-018-1396-0
+- [pdf] {MAiNGO} -- A Global Optimizer for Process Engineering: Algorithm and Applications in Process Design and Machine Learning (shareable)
+  https://doi.org/10.1002/cite.202255033
+- [web] MAiNGO — McCormick-based Algorithm for MINLP Global Optimization (research notes) (external)
+  https://avt-svt.pages.rwth-aachen.de/public/maingo/
+- [pdf] Relaxations of factorable functions with convex-transformable intermediates (external)
 - [pdf] Designs for discriminating between two rival models (shareable)
 - [pdf] A new sequential experimental design procedure for discriminating among rival models (shareable)
 - [pdf] Discrimination among mechanistic models (shareable)

--- a/.crucible/wiki/methods/auxiliary-variable-reformulation.org
+++ b/.crucible/wiki/methods/auxiliary-variable-reformulation.org
@@ -76,8 +76,20 @@ trilinear atoms when allocating auxiliaries for multilinear products.
   the polyhedron defined by the linear constraints plus the atomic
   envelopes.
 
+** The reduced-space alternative
+
+The auxiliary-variable method is not the only way to build a McCormick-based
+relaxation. [[file:../concepts/maingo-solver.org][MAiNGO]] instead *propagates* multivariate McCormick relaxations
+and their subgradients through the model in the original variable space, adding no
+auxiliary variables, and linearizes them into an LP only at the bounding step
+citep:bongartz2017reducedspace,najman2021linearization. This branches over far fewer
+variables (only the degrees of freedom) at the cost of looser per-node bounds, and
+the two approaches can be hybridized. [[file:../comparisons/maingo-vs-discopt.org][MAiNGO vs discopt]] contrasts the two along
+the lifting axis and its consequences for the per-node LP engine.
+
 ** See also
 
+- [[file:../concepts/maingo-solver.org][MAiNGO]] (reduced-space McCormick propagation)
 - [[file:../concepts/couenne-solver.org][Couenne]]
 - [[file:../concepts/baron-solver.org][BARON]]
 - [[file:../concepts/expression-dag-and-ad.org][expression DAG and AD]]

--- a/.crucible/wiki/methods/feasibility-jump.org
+++ b/.crucible/wiki/methods/feasibility-jump.org
@@ -27,7 +27,10 @@ citep:bolusani-scip9-2024 and =HighsFeasibilityJump.cpp= in [[file:../concepts/h
 For discopt, FJ is uniquely interesting: its inner loop maps cleanly onto
 JAX =vmap= or NVIDIA Warp kernels, giving discopt the opportunity to offer a
 GPU-batched feasibility engine that CPU-only implementations in SCIP and
-HiGHS structurally cannot match.
+HiGHS structurally cannot match. FJ's greedy single-variable descent has a
+stochastic, globally-exploring counterpart in [[file:sampling-based-ilp.org][sampling-based ILP heuristics]]
+(MCMC with parallel tempering), another LP-free, GPU-batchable primal engine
+in the same portfolio.
 
 ** The Algorithm
 

--- a/.crucible/wiki/methods/first-order-mip-heuristics.org
+++ b/.crucible/wiki/methods/first-order-mip-heuristics.org
@@ -19,7 +19,9 @@ architecturally very well suited to hosting MIP primal heuristics on a GPU,
 and combining it with NVIDIA Warp kernels (see [[file:feasibility-jump.org][feasibility jump]] and
 [[file:mip-presolve.org][MIP presolve]]) opens an entire class of heuristics that CPU-only solvers
 cannot easily match. This article surveys the landscape and records
-discopt's plan to take advantage.
+discopt's plan to take advantage. A non-projection sibling in the same
+GPU-batched, LP-free portfolio is [[file:sampling-based-ilp.org][sampling-based ILP heuristics]], which
+replaces first-order LP projections with MCMC and parallel tempering.
 
 ** Background: First-Order LP Solvers
 

--- a/.crucible/wiki/methods/sampling-based-ilp.org
+++ b/.crucible/wiki/methods/sampling-based-ilp.org
@@ -1,0 +1,139 @@
+#+TITLE: Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)
+#+FILETAGS: :method:sampling:mcmc:parallel-tempering:simulated-annealing:lp-free:primal-heuristic:matheuristic:ilp:mip:gpu:jax:
+
+* Sampling-Based ILP Heuristics (MCMC + Parallel Tempering)
+:PROPERTIES:
+:ARTICLE_TYPE: method
+:SOURCE_KEYS: kyuilsim2026
+:DERIVED_FROM: ../summaries/kyuilsim2026-ilp-parallel-tempering.org ./feasibility-jump.org ./first-order-mip-heuristics.org ./matheuristics.org
+:STATUS: draft
+:CREATED: 2026-07-12
+:END:
+
+/Sampling-based ILP/ treats an integer program not as a tree to be searched
+but as a probability distribution to be sampled. The objective and constraints
+are folded into a single Gibbs energy, and Markov Chain Monte Carlo (MCMC),
+accelerated by [[file:feasibility-jump.org][Lagrangian-style]] penalty weighting and Parallel Tempering,
+draws high-quality feasible integer points from it. It is *LP-free* (like
+[[file:feasibility-jump.org][Feasibility Jump]]), *GPU-batchable* (like the [[file:first-order-mip-heuristics.org][first-order and GPU MIP
+heuristics]]), and *training-free* (unlike learning-based methods). The
+canonical reference is citet:kyuilsim2026; the full result is distilled in
+the summary [[file:../summaries/kyuilsim2026-ilp-parallel-tempering.org][Solving ILP with Parallel Tempering]].
+
+The defining property, and the one that fixes its role in a global solver, is
+that a sampler returns a *primal* point with *no dual bound and no certificate
+of optimality*. It is therefore a [[file:matheuristics.org][primal heuristic]], a producer of good
+incumbents, not a replacement for certifying Branch-and-Bound.
+
+** The method in brief
+
+For $\min c^\top x$ s.t. $Ax \le b,\ x\in\{0,1\}^n$, sample from
+$\pi(x) \propto \exp(-\mathcal{E}(x;\lambda)/\tau)$ with the penalty energy
+
+$$\mathcal{E}(x;\lambda) = c^\top x + \lambda \sum_{k} \max(0,\ A_{k\cdot}x - b_k).$$
+
+Three moving parts:
+
+1. *Proposal (MLBP).* The exact Locally-Balanced Proposal over the 1-Hamming
+   sphere is computable in closed form because the energy is linear: the
+   single-flip objective and constraint changes are $c\odot(1-2x)$ and
+   $A\cdot\mathrm{diag}(1-2x)$. Multi-step LBP flips $L$ coordinates per move.
+2. *Temperature annealing.* An exponential simulated-annealing schedule
+   $\tau(t)=\tau_0\gamma^t$ moves from broad exploration to refinement.
+3. *[[file:../concepts/parallel-tempering.org][Parallel Tempering]].* A ladder of chains with periodic swaps escapes
+   local optima: $\tau$-PT tempers temperature; $\lambda$-PT tempers the penalty,
+   selectively lowering constraint barriers while preserving the landscape over
+   feasible points.
+
+** Why it fits discopt unusually well
+
+discopt already couples a Rust Branch-and-Bound core with a JAX/GPU numerics
+layer, and the wiki already records the thesis that *GPU-batched primal
+heuristics are a structural advantage CPU-only solvers (SCIP, HiGHS) cannot
+easily match* (see [[file:feasibility-jump.org][Feasibility Jump]] and [[file:first-order-mip-heuristics.org][first-order MIP heuristics]]).
+Sampling-based ILP slots into exactly that gap:
+
+- *The hot loop is two matrix products, per chain, per step.* MLBP's neighbor
+  energies are $c\odot(1-2x)$ and $A\cdot\mathrm{diag}(1-2x)$ (equations 6 in
+  citet:kyuilsim2026). Batched over $B$ tempering chains and $L$ candidate
+  flips, this is pure =jax.vmap= over sparse mat-vec, the same kernel style
+  discopt uses for McCormick relaxations. No LP solve, no factorization.
+- *Parallel Tempering is embarrassingly parallel.* The $B$ chains are
+  independent between swaps, matching a GPU's throughput profile; the swap step
+  is a cheap reduction.
+- *It reuses data discopt already marshals.* The B&B node already carries the
+  local $A$, $b$, $c$ and integer bounds; a sampling heuristic on the node's
+  fixings needs no new problem representation.
+
+** How discopt should (and should not) use it
+
+*Correctness-safe framing first.* Per the project's governing philosophy
+("the certificate is the product"), a sampling heuristic may *only* affect the
+/primal/ side. Concretely:
+
+- *Primary use, incumbent seeding.* Run the sampler at the root (or
+  periodically at nodes) as a GPU-batched primal heuristic. Any feasible
+  integer point it returns is re-validated by discopt's own feasibility check
+  and, if it improves the incumbent, tightens the upper bound, so B&B prunes
+  more aggressively and closes the gap faster. This is the identical role
+  [[file:feasibility-jump.org][Feasibility Jump]] and the [[file:first-order-mip-heuristics.org][first-order heuristics]] already occupy; sampling
+  adds a global-exploration flavor (PT escapes basins that a single-descent
+  heuristic like FJ cannot).
+- *$\lambda$-PT as a feasibility engine.* The penalty energy discopt would use
+  is exactly the constraint-violation form that feasibility heuristics already
+  minimize. $\lambda$-PT's ability to cross feasibility boundaries offers a
+  principled alternative to ad-hoc penalty schedules when the incumbent search
+  is stuck in an infeasible basin, complementary to the
+  [[file:feasibility-pump.org][feasibility pump]] / [[file:feasibility-jump.org][feasibility jump]] family.
+- *A hard guardrail.* Nothing the sampler emits may enter the dual bound, the
+  node selection certificate, or any pruning decision except through a
+  fully-validated improved incumbent. No sampled "bound", no early termination
+  on a sampled objective. A sampler has no soundness argument, so its output is
+  a candidate to be checked, never a fact to be trusted.
+
+*What does not transfer for free.*
+
+- *It is linear.* The exact-LBP trick and the closed-form neighbor energies
+  depend on $\mathcal{E}$ being linear (piecewise-linear with the penalty).
+  discopt's target class is MINLP: a nonconvex/bilinear energy has no
+  closed-form 1-Hamming-sphere update, and gradient-based discrete proposals
+  are exactly what citet:kyuilsim2026 show to be uninformative. A JAX evaluator
+  could supply nonlinear violation values per neighbor, but the per-step cost
+  and the loss of LBP optimality must be measured, not assumed. The honest
+  first target is therefore the *MILP / integer-linear substructure* (or ILP
+  subproblems), not general MINLP.
+- *Hyperparameters need tuning.* $\tau_0$, $\gamma$, $\lambda$, the ladder, and
+  the swap interval are grid-searched per problem class in the paper. A robust
+  default schedule keyed to the scales of $c$ and $A$ (which discopt can read
+  off the node) is a prerequisite for using this without per-instance babysitting.
+- *No convergence guarantee.* Discrete-PT mixing lacks theory, so the sampler
+  must run under a wall-clock/iteration budget as an /anytime/ incumbent
+  producer, never as a termination oracle.
+
+** A concrete falsifiable entry experiment
+
+Consistent with the repo's evidence-first protocol, the smallest test worth
+running before any implementation: on the MILP / integer-linear instances in
+the benchmark corpus, add a GPU-batched MLBP+$\tau$-PT root primal heuristic
+that only ever *proposes validated incumbents*, and measure (a) time-to-first
+incumbent and (b) time-to-close-gap versus the current primal heuristics, on a
+fixed panel, with =incorrect_count = 0= as a hard gate and =node_count= /
+certified objective required unchanged except through legitimately improved
+incumbents. Kill criterion: if it does not improve time-to-good-incumbent over
+the existing FJ/first-order heuristics on a majority of the panel, it does not
+earn a place in the portfolio.
+
+** Relationship to neighboring methods
+
+- [[file:feasibility-jump.org][Feasibility Jump]]: also LP-free and GPU-batchable, but a single
+  greedy-descent local search; sampling+PT adds stochastic global exploration
+  at higher per-step cost.
+- [[file:first-order-mip-heuristics.org][First-Order and GPU MIP Heuristics]]: same "GPU heuristics CPU solvers can't
+  match" thesis, but built on first-order LP (PDLP/MPAX) projections rather
+  than MCMC; the two are portfolio siblings, not competitors.
+- [[file:matheuristics.org][Matheuristics]]: sampling-based ILP is /solver-free/, so unlike classical
+  matheuristics it uses no MIP solver as a subroutine, it is closer in spirit
+  to Simulated Annealing for VLSI/TSP than to relax-and-fix.
+- [[file:learning-based-mip-heuristics.org][Learning-Based MIP Heuristics]]: the paper's main empirical foil; sampling
+  matches or beats them and, being training-free, does not collapse under
+  distribution shift.

--- a/.crucible/wiki/summaries/kyuilsim2026-ilp-parallel-tempering.org
+++ b/.crucible/wiki/summaries/kyuilsim2026-ilp-parallel-tempering.org
@@ -1,0 +1,114 @@
+#+TITLE: Solving Integer Linear Programming with Parallel Tempering
+#+FILETAGS: :summary:ilp:sampling:mcmc:parallel-tempering:simulated-annealing:lp-free:primal-heuristic:gpu:
+
+* Solving Integer Linear Programming with Parallel Tempering
+:PROPERTIES:
+:ARTICLE_TYPE: summary
+:SOURCE_KEYS: kyuilsim2026
+:STATUS: draft
+:CREATED: 2026-07-12
+:END:
+
+citet:kyuilsim2026 (Sim, Choi, and Park; KAIST and University of Edinburgh)
+propose a *training-free, solver-free, sampling-based* framework for Integer
+Linear Programming (ILP). Where learning-based ILP methods depend on external
+solvers and generalize poorly off their training distribution, and classical
+exact solvers rely on sophisticated Branch-and-Bound heuristics, this work
+casts the ILP itself as a discrete sampling problem and solves it with
+Markov Chain Monte Carlo (MCMC) enhanced by Parallel Tempering. It is a
+[[file:../methods/sampling-based-ilp.org][sampling-based ILP heuristic]]: it finds high-quality feasible integer points
+but produces no dual bound and no optimality certificate.
+
+** Formulation: ILP as a Gibbs sampling problem
+
+The canonical binary ILP $\min_x c^\top x$ s.t. $Ax \le b,\ x \in \{0,1\}^n$
+is reformulated as sampling from a Gibbs distribution
+$\pi(x;\lambda,\tau) = \exp(-\mathcal{E}(x;\lambda)/\tau) / Z(\lambda,\tau)$
+whose energy folds objective and constraints into one penalty function
+
+$$\mathcal{E}(x;\lambda) := c^\top x + \lambda \sum_{k=1}^{m} \max(0,\ A_{k\cdot} x - b_k).$$
+
+The paper stresses that this /inequality-penalty/ form is deliberately
+distinct from the standard Lagrangian formulation used in prior sampling-for-CO
+work, which handles only equality constraints and would introduce a slack
+variable per inequality, undesirable in a sampling setting. The temperature
+$\tau$ is annealed on an exponential schedule $\tau(t) = \tau_0 \gamma^t$
+(a simulated-annealing schedule), and $\lambda$ must be chosen large enough
+that $\arg\min_x \mathcal{E}(x;\lambda)$ recovers the true ILP optimum.
+
+** Multi-step Locally-Balanced Proposal (MLBP)
+
+The transition kernel uses the /Locally-Balanced Proposal/ (LBP) of Zanella,
+which is asymptotically optimal in the Peskun ordering. The key insight is
+that for ILP the LBP can be computed *exactly and cheaply* thanks to the
+linear energy, so no gradient approximation is needed (gradient-based
+discrete samplers are uninformative here because the piecewise-linear energy
+has a piecewise-constant gradient). For the 1-Hamming sphere around $x$, both
+$c^\top x^{-j}$ and $A x^{-j}$ over all single-flip neighbors follow from two
+matrix expressions,
+
+$$[c^\top x^{-1} \cdots c^\top x^{-n}] = c^\top x \cdot \mathbf{1}_n^\top + c \odot (1 - 2x^\top), \qquad
+[A x^{-1} \cdots A x^{-n}] = A x \cdot \mathbf{1}_n^\top + A \cdot \mathrm{diag}(1 - 2x),$$
+
+which yield the exact LBP over all single flips in a couple of matrix
+products. To move faster, /Multi-step LBP/ (MLBP-$L$) samples $L$ flip indices
+without replacement per step; the paper uses MLBP-3 ($L=3$) throughout.
+Ablations show plain LBP and MLBP dramatically outperform gradient-based
+discrete samplers (Gibbs-with-Gradients, Path Auxiliary Fast Sampler), which
+are often /infeasible/ on these problems, confirming that the linear structure
+is what makes exact LBP both possible and superior.
+
+** Two Parallel Tempering strategies
+
+ILP energy landscapes are rugged, multimodal, and fragmented by constraint
+barriers, so vanilla MCMC gets trapped. [[file:../concepts/parallel-tempering.org][Parallel Tempering]] (PT, a.k.a.
+replica exchange) runs $B$ chains at once and periodically proposes swaps between
+adjacent chains. The paper studies two axes:
+
+- *$\tau$-PT (temperature tempering)*, the classical scheme: chains sit at a
+  ladder of temperatures $\tau^1 < \cdots < \tau^B$. High-temperature chains
+  flatten the /entire/ surface and traverse steep barriers; low-temperature
+  chains refine. Swap acceptance is $\min(1, \exp(\Delta\beta_{i,j}\Delta\mathcal{E}_{i,j}))$.
+- *$\lambda$-PT (penalty tempering)*, the paper's novel contribution: chains
+  sit at a ladder of penalty levels $\lambda^1 > \cdots > \lambda^B$ at fixed
+  temperature. Lower $\lambda$ /selectively lowers the constraint barrier/,
+  letting a chain cross feasibility boundaries and traverse infeasible regions,
+  while the energy landscape over feasible solutions is preserved. This is a
+  parallel alternative to adaptive/online penalty schedules.
+
+Both use MLBP within chains and a non-reversible PT scheme (Syed et al.) for
+better round-trip mixing.
+
+** Empirical results
+
+- *Vs. classical solvers.* On four NP-hard ILP benchmarks (Minimum Vertex
+  Cover, Maximum Independent Set, Combinatorial Auction, Set Covering) under a
+  strict 200-second budget, the sampling methods consistently outperform SCIP
+  and match or exceed Gurobi on two of four tasks. $\tau$-PT helps most on
+  Combinatorial Auction (few constraints); $\lambda$-PT excels on MIS and Set
+  Covering (dense constraints), highlighting its constraint-handling.
+- *Out-of-distribution.* Learning-based baselines (IL-LNS, CL-LNS) degrade
+  sharply on OOD instances; the sampling framework, needing no training,
+  stays competitive across all OOD tasks: robustness is the headline
+  advantage over learned methods.
+- *Real-world.* On MIPLIB 2017 instances (<10,000 constraints, 1000s budget)
+  with only lightly-tuned hyperparameters, the framework is competitive with
+  classical solvers and beats learned methods that fail outside their training
+  set, though it still underperforms SCIP on some instances.
+- *Ablations.* Removing the simulated-annealing schedule degrades all four
+  benchmarks (SA is indispensable: broad exploration first, then concentration
+  on feasible regions). MLBP path length $L$ trades local accuracy for global
+  coverage; feasibility is robust to the choice.
+
+** Limitations (and why they matter for a certifying solver)
+
+The authors note: (1) convergence and mixing of discrete PT in
+high-dimensional spaces lack theory, so there are *no formal guarantees*;
+(2) the key hyperparameters $\tau$ and $\lambda$ are grid-searched on a small
+validation set and may need re-tuning per problem class; (3) the method relies
+on GPU-accelerated parallel computation. For discopt the decisive point is
+implicit in the design: a sampler yields a /primal/ (feasible) point but *no
+dual bound and no certificate of optimality*. It can therefore only complement
+a certifying global solver, never replace its Branch-and-Bound. The concrete
+integration path is developed in the method article
+[[file:../methods/sampling-based-ilp.org][sampling-based ILP heuristic]].


### PR DESCRIPTION
## Summary

Crucible knowledge-base / docs content only — **no solver or code changes**. The branch name refers to issue #467, but that correctness fix is already on `main` (PRs #471/#481); this branch carries only the KB/reference material that accumulated alongside it.

Two commits, rebased cleanly onto current `origin/main` (`b3c6021d`):

- **`cf66b0b0` updates** — new BibTeX entries in `.crucible/references.bib` (MAiNGO line: reduced-space McCormick, McCormick-linearization/AVM hybridization, ANN-embedded global opt; bilevel references; parallel-tempering ILP), plus wiki `MANIFEST`/`index` and method-article edits (auxiliary-variable reformulation, feasibility-jump, first-order MIP heuristics).
- **`d44a7b15` added notes** — new wiki articles: `concepts/parallel-tempering.org`, `methods/sampling-based-ilp.org`, and a paper summary `summaries/kyuilsim2026-ilp-parallel-tempering.org`.

## Conflict resolution notes

Rebasing surfaced two conflicts, both resolved conservatively:

- `.crucible/references.bib` — pure additive conflicts; resolved by **union** (all entries kept, no key collisions).
- `docs/dev/maingo-parity-plan.md` — `main`'s version was strictly more advanced (P2.3 merged #583, P2.4 KILLED with measurements, the non-affine-division unsoundness finding documented). Kept `main`'s content; the branch's stale ledger rows were dropped. Net result: this file is **unchanged vs `origin/main`** (the branch adds nothing to it).

## Verification

- Diff vs `origin/main` is docs-only (9 files, all under `.crucible/`); no `.rs`/`.py`/config changes, so no test surface is affected.
- No conflict markers remain in any file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
