### PR TITLE
perf: graduate DISCOPT_ADAPTIVE_NLP to default-ON (baron-gap G2)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5647,7 +5647,8 @@ def solve_model(
     _deadline = t_start + time_limit
 
     # --- TX1: adaptive back-off for the strided in-tree node NLP -------------
-    # DISCOPT_ADAPTIVE_NLP (default OFF, flag-graduation). The strided node-NLP is
+    # DISCOPT_ADAPTIVE_NLP (default ON since G2, flag-graduation; =0 restores the
+    # fixed stride). The strided node-NLP is
     # a pure primal heuristic (fires only in the nonconvex + LP-relaxer regime,
     # where the LP gives the bound); TX0 measured it as idle waste on integer-heavy
     # models (nvs09 14.3 s, identical proof). When ON we grow the *effective*

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -323,11 +323,11 @@ class SolverTuning:
     """Solve the node NLP every k-th node (``DISCOPT_NODE_NLP_STRIDE``, default 4)."""
 
     adaptive_nlp: bool = field(
-        default_factory=lambda: _env_flag("DISCOPT_ADAPTIVE_NLP", default=False)
+        default_factory=lambda: _env_flag("DISCOPT_ADAPTIVE_NLP", default=True)
     )
     """Adaptive back-off for the *strided in-tree node NLP*
-    (``DISCOPT_ADAPTIVE_NLP``, **default OFF** — flag-graduation convention: ``=0``
-    restores today's fixed ``node_nlp_stride``).
+    (``DISCOPT_ADAPTIVE_NLP``, **default ON** since G2 — flag-graduation
+    convention: ``=0`` restores today's fixed ``node_nlp_stride``).
 
     TX1 (``docs/dev/tenx-plan.md`` §3). The strided node-NLP is a **pure primal
     heuristic** — it fires ONLY where the McCormick LP relaxer supplies the node

--- a/python/tests/test_tx1_adaptive_nlp.py
+++ b/python/tests/test_tx1_adaptive_nlp.py
@@ -8,8 +8,10 @@ change *incumbent arrival* (node counts, wall), never the certificate. TX0
 measured this bucket as idle waste on integer-heavy nonconvex models (nvs09:
 14.3 s skippable, identical proof/bound).
 
-``DISCOPT_ADAPTIVE_NLP`` graduates behind the flag convention: ``=0`` (default)
-restores today's fixed ``node_nlp_stride``.
+``DISCOPT_ADAPTIVE_NLP`` graduated to **default-ON** in G2
+(``docs/dev/baron-gap-plan.md`` §4). Flag-graduation convention: the adaptive
+back-off is now the default; ``DISCOPT_ADAPTIVE_NLP=0`` restores today's fixed
+``node_nlp_stride``.
 
 Soundness contract asserted here:
   * On a **convex** model the flag is inert — the gated regime requires
@@ -47,6 +49,29 @@ def _solve(name: str, *, adaptive: bool, tl: float, monkeypatch):
     monkeypatch.setenv("DISCOPT_ADAPTIVE_NLP", "1" if adaptive else "0")
     model = from_nl(os.path.join(_DATA, f"{name}.nl"))
     return model.solve(time_limit=tl)
+
+
+def test_adaptive_nlp_default_direction(monkeypatch):
+    """G2 flip: the adaptive back-off is now default-ON; ``=0`` restores fixed.
+
+    Fast, load-immune unit test on the tuning default itself (no solve).
+    ``docs/dev/baron-gap-plan.md`` §4 graduated ``DISCOPT_ADAPTIVE_NLP`` from
+    default-OFF to default-ON; the flag-graduation convention keeps ``=0`` as the
+    explicit escape hatch back to today's fixed ``node_nlp_stride``.
+    """
+    from discopt.solver_tuning import SolverTuning
+
+    # Unset env -> the new default is ON (adaptive back-off engaged).
+    monkeypatch.delenv("DISCOPT_ADAPTIVE_NLP", raising=False)
+    assert SolverTuning().adaptive_nlp is True
+
+    # =0 restores the fixed stride (explicit opt-out still honored).
+    monkeypatch.setenv("DISCOPT_ADAPTIVE_NLP", "0")
+    assert SolverTuning().adaptive_nlp is False
+
+    # =1 is still ON (idempotent with the default).
+    monkeypatch.setenv("DISCOPT_ADAPTIVE_NLP", "1")
+    assert SolverTuning().adaptive_nlp is True
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## G2 — graduate `DISCOPT_ADAPTIVE_NLP` to default-ON

Implements task **G2** of `docs/dev/baron-gap-plan.md` §4: flip TX1's adaptive
node-NLP back-off from opt-in to default.

### What changed
- `python/discopt/solver_tuning.py:325` — `adaptive_nlp` default flipped
  `False → True`; docstring updated to the flag-graduation convention
  (**default ON**, `DISCOPT_ADAPTIVE_NLP=0` restores the fixed
  `node_nlp_stride`).
- `python/discopt/solver.py` — the TX1 comment block updated to say default-ON
  (documentation only; **the `_eff_nlp_stride` adaptive-doubling mechanism is
  untouched**).
- `python/tests/test_tx1_adaptive_nlp.py` — module docstring flipped to
  default-ON; new fast, load-immune `test_adaptive_nlp_default_direction`
  asserts the tuning default is `True`, `=0` restores fixed, `=1` stays ON.

Why this can't touch the certificate: the strided node-NLP is a pure primal
heuristic, gated to the nonconvex + LP-relaxer regime where the **LP** is the
node dual bound. Throttling the heuristic changes only incumbent arrival, never
the bound. Soundness is unchanged from TX1 (landed 2026-07-14).

### Entry experiment (required; re-verifies TX1 survives on current `main` @`0f3ebd7d`)
Fresh subprocesses, `time_limit=30`, 2 repeats each (medians for wall;
bound/node/status are load-immune and are the real gate). All six vendored.

| instance | OFF status | OFF bound | OFF nodes | ON status | ON bound | ON nodes | wall OFF/ON |
|---|---|---|---|---|---|---|---|
| nvs09  | optimal  | -43.13433699 | 19 | optimal  | -43.13773713 | 17 | 3.8 / 3.7 |
| tspn05 | optimal  | 191.25508182 | 39 | optimal  | 191.25508182 | 39 | 8.0 / 8.5 |
| st_e36 | optimal  | -246.00000038 | 89 | optimal | -246.00000038 | 89 | 6.1 / 5.3 |
| fac2   | optimal  | 331837497.56 | 39 | optimal  | 331837497.56 | 39 | 5.4 / 5.3 |
| tls2   | feasible | 2.10..2.45 | 317..353 | feasible | 2.45..2.50 | 353..373 | ~30 / ~30 |
| nvs12  | optimal  | -481.20000000 | 231 | optimal | -481.20000000 | 231 | 1.4 / 1.4 |

**Gate PASS.** 0 proofs lost (every OFF-optimal instance stays optimal ON);
0 crossed certificates (every dual bound stays below the incumbent, min sense).

- **tls2 trap held:** adaptive-ON bound is equal-or-**tighter** than OFF
  (2.45 / 2.50 vs 2.10 / 2.45), never looser. The spread is pure timeout
  nondeterminism on a non-terminating instance; both stay well below the
  incumbent.
- **nvs09 improves** (17 vs 19 nodes, faster), matching TX1's recorded gain.
  Both prove optimal; ON's terminal dual bound differs within the
  optimality-gap tolerance while the optimality **proof is preserved**.

### New-default confirmation (the flip actually takes effect)
Edited code, **no env var** (`SolverTuning().adaptive_nlp == True` verified),
matches env=1 byte-for-byte on all deterministic instances: nvs09 nodes=17
bound=-43.13773713, tspn05 39/191.25508182, st_e36 89/-246.00000038,
fac2 39/331837497.56, nvs12 231/-481.20000000. tls2 (timeout-nondeterministic)
returned a valid bound below its incumbent.

### Verification run
- `python/tests/test_tx1_adaptive_nlp.py`: **3 passed** (the 2 slow soundness
  regressions + the new default-direction test).
- `pytest python/tests -m smoke`: **637 passed, 1 skipped, 0 failed** (29s).
- `ruff check` + `ruff format --check` on all changed files: clean.
- Pre-commit (ruff/ruff-format/mypy) passed at commit time.

Rust not touched → no `cargo test` required for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
