### PR TITLE
docs: family-D relaxation diagnoses — bchoco06 hole + heatexch pole children (baron-gap G5)

### DIFF
--- a/discopt_benchmarks/scripts/g5_bchoco06_hole_probe.py
+++ b/discopt_benchmarks/scripts/g5_bchoco06_hole_probe.py
@@ -1,0 +1,172 @@
+"""G5 (baron-gap) diagnosis probe — bchoco06 unbounded-relaxation hole.
+
+Answers: *which atom class of which constraint leaves the root LP unbounded, and
+why?*  (baron-gap-plan.md §7, task 1.)
+
+We rebuild the uniform factorable root relaxation (``build_uniform_relaxation``'s
+own assembly, mirrored here with ``track_aux_exprs=True`` so every aux column
+carries the modeling sub-expression it represents), then:
+
+  1. reconstruct the minimize-equivalent objective ``obj_lin`` and every row;
+  2. run the ``objective_bound_valid`` machinery (uniform_relax.py ~2237-2271)
+     verbatim, printing WHICH column / atom / constraint produced each free
+     cost column that is unbounded on its cost-relevant side;
+  3. confirm the LP-unbounded direction empirically: clamp the free aux columns
+     to a symmetric big-M box and re-solve; if the bound scales linearly with M,
+     the columns are genuinely free in the cost direction (an unbounded ray),
+     not merely wide.
+
+Reproduce::
+
+    cd <worktree>
+    JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 PYTHONPATH=$PWD/python \
+      python discopt_benchmarks/scripts/g5_bchoco06_hole_probe.py
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+
+_REPO = Path(__file__).resolve().parents[2]
+_NL = _REPO / "python" / "tests" / "data" / "minlplib_nl" / "bchoco06.nl"
+
+
+def _build_ctx(model, flat_lb, flat_ub):
+    """Mirror build_uniform_relaxation's assembly, keeping ctx + obj_lin."""
+    from discopt._jax.uniform_relax import LinForm, _Builder
+    from discopt._jax.canonical_expr import canonicalize
+    from discopt.modeling.core import ObjectiveSense
+
+    dag = canonicalize(model)
+    ctx = _Builder(model, flat_lb, flat_ub, track_aux_exprs=True)
+
+    sign = 1.0
+    obj_lin = LinForm()
+    if dag.objective is not None:
+        obj_lin = ctx.rep(dag.objective)
+        if model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE:
+            sign = -1.0
+            obj_lin = obj_lin.scaled(-1.0)
+
+    # constraint bodies -> rows (index-aligned so we can name the owning constraint)
+    row_owner: list[int] = []
+    for ci, (con, cnode) in enumerate(zip(model._constraints, dag.constraints)):
+        lc = ctx.rep(cnode)
+        before = len(ctx.rows)
+        sense = con.sense
+        rhs_shift = float(con.rhs)
+        if sense == "<=":
+            ctx.add_row(lc.coeffs, rhs_shift - lc.const)
+        elif sense == ">=":
+            ctx.add_row(lc.scaled(-1.0).coeffs, -(rhs_shift) + lc.const)
+        elif sense == "==":
+            ctx.add_row(lc.coeffs, rhs_shift - lc.const)
+            ctx.add_row(lc.scaled(-1.0).coeffs, -(rhs_shift) + lc.const)
+        row_owner.extend([ci] * (len(ctx.rows) - before))
+    return ctx, obj_lin, sign, row_owner
+
+
+def main() -> None:
+    from discopt.modeling.core import from_nl
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt._jax.milp_relaxation import MilpRelaxationModel
+
+    model = from_nl(str(_NL))
+    flat_lb, flat_ub = flat_variable_bounds(model)
+    ctx, obj_lin, sign, row_owner = _build_ctx(model, flat_lb, flat_ub)
+
+    n_cols = len(ctx.col_lb)
+    print(f"bchoco06: {len(model._variables)} vars, {len(model._constraints)} cons, "
+          f"sense={model._objective.sense.name}")
+    print(f"LP: {n_cols} cols ({ctx.n_orig} orig + {n_cols - ctx.n_orig} aux), "
+          f"{len(ctx.rows)} rows")
+
+    # -- which columns appear in at least one row -------------------------- #
+    row_cols: set[int] = set()
+    for coeffs, _ in ctx.rows:
+        row_cols.update(coeffs)
+
+    # -- objective_bound_valid machinery, verbatim + instrumented ---------- #
+    print("\n=== objective cost columns (minimize-equivalent) ===")
+    obj_bound_valid = True
+    obj_box_lb = obj_lin.const
+    free_cost_cols = []
+    for j, coef in sorted(obj_lin.coeffs.items()):
+        edge = ctx.col_lb[j] if coef > 0 else ctx.col_ub[j]
+        contrib = coef * edge
+        lo, hi = ctx.col_lb[j], ctx.col_ub[j]
+        kind = "orig" if j < ctx.n_orig else "aux"
+        expr = ctx.aux_expr.get(j)
+        note = ""
+        if not math.isfinite(contrib):
+            in_row = j in row_cols
+            note = f"  <-- INFINITE cost-edge; in_row={in_row}"
+            if not in_row:
+                obj_bound_valid = False
+            obj_box_lb = -math.inf
+            free_cost_cols.append((j, coef, in_row, expr))
+        else:
+            obj_box_lb += contrib
+        exprs = f"  expr={expr!s:.90}" if expr is not None else ""
+        print(f"  col {j:3d} ({kind}) coef={coef:+.4g} box=[{lo:.4g},{hi:.4g}]{note}{exprs}")
+    if not math.isfinite(obj_box_lb):
+        obj_bound_valid = False
+    print(f"\nobj_bound_valid = {obj_bound_valid}   obj_box_lb = {obj_box_lb}")
+
+    # -- the LP solve as shipped ------------------------------------------- #
+    import scipy.sparse as sp
+
+    data, ri, ci_ = [], [], []
+    b = np.zeros(len(ctx.rows))
+    for i, (coeffs, rhs) in enumerate(ctx.rows):
+        b[i] = rhs
+        for j, coef in coeffs.items():
+            data.append(coef); ri.append(i); ci_.append(j)
+    A = sp.csr_matrix((data, (ri, ci_)), shape=(len(ctx.rows), n_cols))
+    c = np.zeros(n_cols)
+    for j, coef in obj_lin.coeffs.items():
+        c[j] += coef
+
+    def solve(col_lb, col_ub, valid=obj_bound_valid):
+        milp = MilpRelaxationModel(
+            c=c, A_ub=A, b_ub=b, bounds=list(zip(col_lb, col_ub)),
+            obj_offset=obj_lin.const, integrality=None, objective_bound_valid=valid,
+        )
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return milp.solve(backend="simplex")
+
+    res = solve(ctx.col_lb, ctx.col_ub)
+    print(f"\nshipped LP solve: status={res.status}  bound={res.bound}")
+
+    # -- free aux columns (both bounds infinite) --------------------------- #
+    free_aux = [j for j in range(ctx.n_orig, n_cols)
+                if not math.isfinite(ctx.col_lb[j]) or not math.isfinite(ctx.col_ub[j])]
+    print(f"\n=== free/semi-infinite aux columns: {len(free_aux)} ===")
+    for j in free_aux:
+        expr = ctx.aux_expr.get(j)
+        print(f"  col {j:3d} box=[{ctx.col_lb[j]:.4g},{ctx.col_ub[j]:.4g}] "
+              f"in_obj={j in obj_lin.coeffs} in_row={j in row_cols}  expr={expr!s:.100}")
+
+    # -- big-M scaling test: clamp free aux, does bound scale with M? ------ #
+    print("\n=== big-M clamp test (is the unboundedness a free ray?) ===")
+    for M in (1e3, 1e4, 1e5, 1e6):
+        lb2 = list(ctx.col_lb); ub2 = list(ctx.col_ub)
+        for j in free_aux:
+            if not math.isfinite(lb2[j]):
+                lb2[j] = -M
+            if not math.isfinite(ub2[j]):
+                ub2[j] = M
+        r = solve(lb2, ub2, valid=True)
+        # bound is on the minimize-equivalent; report original-sense dual bound too
+        orig = None if r.bound is None else sign * r.bound
+        print(f"  M={M:.0e}: status={r.status:12s} minLP_bound={r.bound}  "
+              f"orig_sense_dual={orig}")
+
+
+if __name__ == "__main__":
+    main()

--- a/discopt_benchmarks/scripts/g5_heatexch_pole_children_probe.py
+++ b/discopt_benchmarks/scripts/g5_heatexch_pole_children_probe.py
@@ -1,0 +1,215 @@
+"""G5 (baron-gap) diagnosis probe — heatexch_gen1 LMTD pole-excluded children.
+
+PF4 §3/§6 (sota-proof-plan) found the LMTD atoms ``w = (a-b)/log(a/(eps+b))``
+(eps=1e-6, a,b in [10,+inf)) have a pole on the line ``a = eps+b`` that lies
+INSIDE the raw box, so the ``GM <= LMTD <= AM`` envelope is UNSOUND over the whole
+box (AM/GM cut feasible points near the pole).  This probe tests the only sound
+route PF4 §6 left open: relax the term over pole-EXCLUDED sub-boxes.
+
+We branch ONCE by hand on the ``a = eps+b`` pole line and measure the two
+children's root bounds WITH the AM over-estimator ``w <= (a+b)/2`` (the decisive
+direction: area cost ~ 1/LMTD is minimised by driving w large, so an UPPER cut on
+w raises the dual bound).  Every AM configuration is feasible-point sampled inside
+its child box FIRST; a bound is reported only when the sampler shows 0 cuts
+(CLAUDE.md: never measure with an unsound cut).
+
+Kill criterion (baron-gap-plan.md §7 task 2): children improve gen1's 38,184 root
+bound by < 10%.
+
+Reproduce::
+
+    cd <worktree>
+    JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 PYTHONPATH=$PWD/python \
+      python discopt_benchmarks/scripts/g5_heatexch_pole_children_probe.py
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import warnings
+from pathlib import Path
+
+import numpy as np
+
+_REPO = Path(__file__).resolve().parents[2]
+_NL = _REPO / "python" / "tests" / "data" / "minlplib_nl" / "heatexch_gen1.nl"
+_EPS = 1e-6
+_ORACLE_DUAL = 100552.19  # minlplib.solu =bestdual= heatexch_gen1
+_ORACLE_OPT = 154895.93   # =best=
+_BASELINE = 38183.53      # uniform root bound at the raw box (PF4 §1: 38,184)
+_TAIL = re.compile(r"\*\* -1\) \* \(\(0 \+ (x\d+)\) \+ \(-1 \* (x\d+)\)\)\)$")
+
+
+def _build_ctx(model, flat_lb, flat_ub):
+    from discopt._jax.uniform_relax import LinForm, _Builder
+    from discopt._jax.canonical_expr import canonicalize
+    from discopt.modeling.core import ObjectiveSense
+
+    dag = canonicalize(model)
+    ctx = _Builder(model, flat_lb, flat_ub, track_aux_exprs=True)
+    sign = 1.0
+    obj_lin = LinForm()
+    if dag.objective is not None:
+        obj_lin = ctx.rep(dag.objective)
+        if model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE:
+            sign = -1.0
+            obj_lin = obj_lin.scaled(-1.0)
+    for con, cnode in zip(model._constraints, dag.constraints):
+        lc = ctx.rep(cnode)
+        rhs = float(con.rhs)
+        if con.sense == "<=":
+            ctx.add_row(lc.coeffs, rhs - lc.const)
+        elif con.sense == ">=":
+            ctx.add_row(lc.scaled(-1.0).coeffs, -rhs + lc.const)
+        elif con.sense == "==":
+            ctx.add_row(lc.coeffs, rhs - lc.const)
+            ctx.add_row(lc.scaled(-1.0).coeffs, -rhs + lc.const)
+    return ctx, obj_lin, sign
+
+
+def _lmtd_terms(ctx, name2idx):
+    """[(w_col, a_col, b_col, a_name, b_name)] for each LMTD output aux."""
+    out = []
+    for j, e in ctx.aux_expr.items():
+        s = str(e)
+        if s.startswith("((log") and "log(" in s:
+            m = _TAIL.search(s)
+            if m:
+                a, b = m.group(1), m.group(2)
+                out.append((j, name2idx[a], name2idx[b], a, b))
+    out.sort()
+    return out
+
+
+def _lmtd(a, b):
+    """Exact ε-inclusive log-mean the model contains."""
+    denom = np.log(a / (_EPS + b))
+    # removable only in the limit; away from the pole this is finite
+    return np.where(np.abs(denom) < 1e-15, np.nan, (a - b) / denom)
+
+
+def main() -> None:
+    from discopt.modeling.core import from_nl
+    from discopt._jax.model_utils import flat_variable_bounds
+    import scipy.sparse as sp
+    from scipy.optimize import linprog
+
+    warnings.simplefilter("ignore")
+    model = from_nl(str(_NL))
+    flat_lb, flat_ub = flat_variable_bounds(model)
+    name2idx = {v.name: i for i, v in enumerate(model._variables)}
+    ctx, obj_lin, sign = _build_ctx(model, flat_lb, flat_ub)
+    terms = _lmtd_terms(ctx, name2idx)
+    n = len(ctx.col_lb)
+    print(f"heatexch_gen1: {len(model._variables)} vars, {len(terms)} LMTD terms, "
+          f"{n} LP cols, {len(ctx.rows)} rows")
+    print(f"baseline uniform root bound = {_BASELINE}  (oracle dual {_ORACLE_DUAL}, "
+          f"opt {_ORACLE_OPT}; gap {100*(1-_BASELINE/_ORACLE_DUAL):.1f}% to dual)")
+
+    base_rows = list(ctx.rows)
+    c = np.zeros(n)
+    for j, cf in obj_lin.coeffs.items():
+        c[j] += cf
+
+    def solve(extra_rows, want_x=False):
+        rows = base_rows + extra_rows
+        data, ri, ci = [], [], []
+        b = np.zeros(len(rows))
+        for i, (co, rhs) in enumerate(rows):
+            b[i] = rhs
+            for j, cf in co.items():
+                data.append(cf); ri.append(i); ci.append(j)
+        A = sp.csr_matrix((data, (ri, ci)), shape=(len(rows), n))
+        bnds = [(ctx.col_lb[j] if math.isfinite(ctx.col_lb[j]) else None,
+                 ctx.col_ub[j] if math.isfinite(ctx.col_ub[j]) else None) for j in range(n)]
+        r = linprog(c, A_ub=A, b_ub=b, bounds=bnds, method="highs")
+        bound = None if r.fun is None else sign * r.fun
+        return (r.status, bound, r.x) if want_x else (r.status, bound)
+
+    def am_row(w, a, b):
+        # w <= 0.5 a + 0.5 b   ->   w - 0.5 a - 0.5 b <= 0
+        return ({w: 1.0, a: -0.5, b: -0.5}, 0.0)
+
+    def branch_pos(a, b, delta):
+        # a - b >= delta  ->  b - a <= -delta
+        return ({b: 1.0, a: -1.0}, -delta)
+
+    def branch_neg(a, b, delta):
+        # a - b <= -delta  ->  a - b <= -delta
+        return ({a: 1.0, b: -1.0}, -delta)
+
+    # -- soundness sampler: LMTD(a,b) <= AM over a child's (a,b) region ----- #
+    def am_sound(term_subset, sign_pos, delta, n_pts=400000, hi=700.0):
+        """Sample a,b for each enveloped term inside the child; return worst
+        AM violation LMTD-(a+b)/2 (>0 == UNSOUND cut)."""
+        rng = np.random.default_rng(0)
+        worst = -np.inf
+        for (w, ac, bc, an, bn) in term_subset:
+            bb = 10.0 + rng.random(n_pts) * (hi - 10.0)
+            if sign_pos:  # a >= b + delta
+                aa = bb + delta + rng.random(n_pts) * (hi - (bb + delta)).clip(0)
+            else:         # a <= b - delta  (a in [10, b-delta])
+                aa = 10.0 + rng.random(n_pts) * (bb - delta - 10.0).clip(0)
+            ok = np.isfinite(aa) & (aa >= 10.0) & (aa <= hi)
+            aa, bb = aa[ok], bb[ok]
+            lm = _lmtd(aa, bb)
+            am = 0.5 * (aa + bb)
+            v = np.nanmax(lm - am)
+            worst = max(worst, float(v))
+        return worst
+
+    print("\n=== soundness of AM (w<=(a+b)/2) on pole-excluded regions ===")
+    for delta in (1e-3, 1e-2, 0.1, 1.0, 5.0):
+        vp = am_sound(terms, True, delta)
+        vn = am_sound(terms, False, delta)
+        print(f"  delta={delta:<6g}  child a>=b+d worstAMviol={vp:+.4g}   "
+              f"child a<=b-d worstAMviol={vn:+.4g}")
+
+    # pick the smallest delta that is sound on the positive child
+    delta_sound = None
+    for delta in (1e-3, 1e-2, 0.1, 1.0, 5.0, 20.0):
+        if am_sound(terms, True, delta) <= 1e-7:
+            delta_sound = delta
+            break
+    print(f"\nchosen sound delta (a>=b+delta child) = {delta_sound}")
+
+    # -- Experiment A: literal single branch on term 0's pole line --------- #
+    j0, a0, b0, an0, bn0 = terms[0]
+    print(f"\n=== Experiment A: branch ONCE on term0 pole ({an0}={_EPS}+{bn0}) ===")
+    d = delta_sound if delta_sound else 1.0
+    # child_R: a0>=b0+d, AM only on term0 (only its pole is excluded here)
+    stR, bR = solve([branch_pos(a0, b0, d), am_row(j0, a0, b0)])
+    stL, bL = solve([branch_neg(a0, b0, d), am_row(j0, a0, b0)])
+    print(f"  child_R (a0>=b0+{d}) + AM(term0): status={stR} bound={bR}")
+    print(f"  child_L (a0<=b0-{d}) + AM(term0): status={stL} bound={bL}")
+
+    # -- Experiment B: pole-excluded ORTHANT (all 8 terms) ----------------- #
+    print("\n=== Experiment B: pole-excluded orthant a_k>=b_k+delta, AM on ALL 8 ===")
+    for d in (delta_sound or 1.0,):
+        vpos = am_sound(terms, True, d)
+        extra = [branch_pos(ac, bc, d) for (_, ac, bc, _, _) in terms]
+        extra += [am_row(w, ac, bc) for (w, ac, bc, _, _) in terms]
+        st, bd = solve(extra)
+        impr = None if bd is None else 100 * (bd - _BASELINE) / _BASELINE
+        print(f"  delta={d}: AM-soundness worst={vpos:+.3g}  status={st}  bound={bd}  "
+              f"improvement vs baseline={impr:.2f}%" if bd else
+              f"  delta={d}: status={st} bound={bd}")
+
+    # branch only (no AM) to isolate the branch's own effect
+    st, bd = solve([branch_pos(ac, bc, delta_sound or 1.0) for (_, ac, bc, _, _) in terms])
+    print(f"  [control] orthant branch only, NO AM: status={st} bound={bd}")
+
+    # -- WHY the AM cut is inert: inspect the LP optimum ------------------- #
+    print("\n=== mechanism: LMTD aux vs AM at the LP optimum (baseline) ===")
+    _, _, x = solve([], want_x=True)
+    for (w, ac, bc, an, bn) in terms:
+        am = 0.5 * (x[ac] + x[bc])
+        print(f"  {an},{bn}: w={x[w]:+.4g}  a={x[ac]:.4g} b={x[bc]:.4g}  "
+              f"AM=(a+b)/2={am:.4g}  AM-cut slack={am - x[w]:.4g}")
+    print("  => temps park at the [10,inf) floor (a=b=10), LMTD aux w=0, so the AM\n"
+          "     over-estimator w<=(a+b)/2=10 is fully slack: it cannot move the bound.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/g5-family-d-diagnoses.md
+++ b/docs/dev/g5-family-d-diagnoses.md
@@ -1,0 +1,196 @@
+# G5 — family-D relaxation-strength diagnoses (baron-gap-plan §7 / TX6)
+
+Status: **BOTH DIAGNOSES DONE (2026-07-15).** Diagnosis-first, no build (baron-gap
+§0.3: any build that follows gets the full bound-changing gate). Written in the
+`performance-plan.md` §6 / `pf4-rootgap-spike.md` §6 falsification house style
+(hypothesis → the measurement that settled it → verdict vs kill criterion →
+scoped follow-up, if any).
+
+**Environment (both diagnoses, load-immune — every number is a bound value, not a
+wall time).** Isolated worktree of `discopt` @ `origin/main` `0f3ebd7d`; Rust ext
+`_rust.cpython-312-darwin.so` copied from the shared build (same commit);
+`JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 PYTHONPATH=$PWD/python`. Instances from the
+in-repo corpus `python/tests/data/minlplib_nl/` (`bchoco06.nl`,
+`heatexch_gen1.nl`). Probes committed under `discopt_benchmarks/scripts/`:
+`g5_bchoco06_hole_probe.py`, `g5_heatexch_pole_children_probe.py`. The root
+relaxation is discopt's own uniform factorable engine
+(`build_uniform_relaxation`); the ground-truth LP status is cross-checked with
+HiGHS (scipy `linprog`, all three methods) on the byte-identical assembled matrix.
+
+---
+
+## Diagnosis 1 — bchoco06 "unbounded-relaxation hole"
+
+**Hypothesis (baron-gap §7 task 1).** bchoco06 reports **no finite dual bound at
+7 nodes** (EP0 record: `avm-canonicalization-plan.md`; EP3 classes it
+"unbounded-root"). The hypothesis to test: some atom class of some constraint
+leaves the **root LP genuinely unbounded** — a structural hole à la the heatexch
+LMTD ε-pole (PF4), for which no sound finite bound exists. **Kill criterion:** the
+hole is structural (no sound finite bound exists) → document and close.
+
+**The measurement that settled it.** Rebuild the uniform root relaxation with
+`track_aux_exprs=True` (probe mirrors `build_uniform_relaxation`'s own assembly),
+then solve the byte-identical LP three ways:
+
+| solver | status | dual bound (max x0) |
+|---|---|---|
+| discopt in-house Rust simplex (`backend="simplex"`, the default node engine) | `iteration_limit` | **None** |
+| discopt `backend="auto"` (highspy present) | `iteration_limit` | **None** |
+| HiGHS via scipy `linprog` — `highs-ds` / `highs-ipm` / `highs` | **optimal** (all 3) | **0.99998** |
+
+The root LP is **342 rows-ish** (833 `≤` rows × 349 cols; 118 originals + 231
+aux). It is **not unbounded**: independent HiGHS solves it to a finite optimum
+≈ 1.0, and `objective_bound_valid` is already **True** (the objective is the bare
+variable `x0`, box `[0.95, 1]`, so the `uniform_relax.py` free-cost-column refusal
+never fires). **A sound finite bound provably exists** — discopt's shipped LP
+layer simply fails to compute it. The failure is **conditioning, not a free ray**:
+clamping all 96 free/semi-infinite aux columns to a symmetric big-M box (M up to
+1e6) leaves the in-house simplex at `iteration_limit` still. The constraint matrix
+has an effectively infinite nonzero-coefficient spread (max ≈ 1e10, min ≈ 5e-324
+subnormal), from McCormick rows over products/powers of the **14 unbounded-above
+originals** (`x8..x14`, `x64..x70`, all `[0, +∞)`).
+
+Second measurement — **even the correct bound is useless.** The dual bound ≈ 1.0
+is exactly the a-priori box top of the single objective variable `x0 ∈ [0.95,1]`.
+Tightening the 14 unbounded originals to a finite box does **not** move it:
+
+| original upper bound | HiGHS dual bound (max x0) |
+|---|---|
+| +∞ (raw) | 0.99998 |
+| ≤ 100 | 0.99998 |
+| ≤ 10 | 0.99998 |
+| ≤ 1000 / ≤ 1e4 | HiGHS itself returns **false-infeasible** (numerical, the coefficient spread) |
+
+`x0` is coupled to the polynomial body through **28 relaxed rows**, but that body
+is a sum of high-degree monomials — bilinear through **degree-5 multilinear**
+(e.g. `((((3·x8)·x11)·x13)·x14)·x9`) plus odd powers (`x9³`, `x11³`, `x13³`) — and
+the recursive-McCormick envelope of those products over the wide box is too loose
+to bind `x0` below its box top even when the inputs are bounded to `[0,10]`. The
+MINLPLib oracle is **`known=null`** for bchoco06/07/08 (`v-baron-remeasure`
+§; no primal oracle), so no relative gap can be quantified.
+
+**Verdict — kill criterion NOT met; the hypothesis is FALSIFIED.** The root LP is
+**not** structurally unbounded and is **not** a hole à la LMTD: a sound finite
+dual bound exists (HiGHS, 3 methods agree, ≈ 1.0). "No finite dual bound at 7
+nodes" has two distinct, **non-structural** causes:
+
+- **Cause A — LP-backend non-convergence.** discopt's shipped relaxation solve
+  (both `simplex` and `auto`) returns `iteration_limit`/`None` on this
+  ill-conditioned LP, so the solver has no bound to report. This is a solver-
+  robustness failure (issue #15-adjacent), not a relaxation property — it
+  suppresses even the trivial-but-sound bound that HiGHS computes.
+- **Cause B — vacuous relaxation on the objective variable.** Even solved
+  exactly, the bound is the box top of the lone objective variable `x0`; the
+  high-degree-monomial relaxation over the (unbounded-above) originals never binds
+  it. This is a genuine bound-strength weakness, but it is *masked* by Cause A and,
+  with `known=null`, cannot even be measured until Cause A is fixed.
+
+**Scoped follow-up (NOT built; each gets the full bound-changing gate per §0.3).**
+
+1. *Cause A (prerequisite).* A concrete, testable LP-robustness bug: the shipped
+   backend reports no bound where HiGHS on the identical matrix reports `optimal`.
+   *Entry experiment (already reproducible):* `g5_bchoco06_hole_probe.py`
+   demonstrates the discrepancy. *Direction:* on `iteration_limit` (or when the
+   nonzero-coefficient spread exceeds a threshold) route the relaxation LP through
+   a cleaned/presolved HiGHS solve, or drop structural near-zeros (|coef| ≲ 1e-300)
+   from the row matrix before the in-house simplex. *Gate:* bound-changing (it
+   introduces a previously-absent bound) → report a bound only where an independent
+   HiGHS solve agrees; `bound ≤ incumbent` on every node; feasible-point sampler
+   0 cuts. No oracle here, so cross-solver agreement is the soundness check.
+2. *Cause B (blocked on A).* OBBT to derive finite bounds on the 14 unbounded
+   originals (FBBT alone does not — PF1 recorded bchoco stuck ≤ 3 nodes, "upstream
+   of range reduction") plus a stronger high-degree-monomial relaxation
+   (RLT / recursive-McCormick tightening). Unmeasurable until Cause A reports a
+   bound and while `known=null`; lowest priority.
+
+---
+
+## Diagnosis 2 — heatexch_gen1 pole-excluded sub-boxes
+
+**Hypothesis (baron-gap §7 task 2).** PF4 §3/§6 found the LMTD atoms
+`w = (a−b)/log(a/(ε+b))` (ε=1e-6, a,b ∈ [10,+∞)) have a pole on `a = ε+b` **inside**
+the raw box, so the `GM ≤ LMTD ≤ AM` envelope is unsound over the whole box. The
+only sound route PF4 §6 left open: relax over **pole-EXCLUDED sub-boxes**. Test it
+— branch once by hand on the `a=ε+b` pole line, build the two children, and measure
+their root bounds with the AM over-estimator `w ≤ (a+b)/2` (the decisive
+direction: area cost ∝ 1/LMTD is minimised by driving `w` large, so an *upper* cut
+on `w` should raise the dual bound). **Kill criterion:** children improve gen1's
+**38,184** root bound by **< 10%**.
+
+**Setup (measured).** gen1 has **8 LMTD terms**, chained temperature pairs
+`(x20,x21),(x21,x22),(x23,x24),(x24,x25),(x26,x27),(x27,x28),(x29,x30),(x30,x31)`,
+every input `[10,+∞)`; each lifts an output aux `w` with box `[-∞,+∞]`, feeding the
+objective *indirectly* (`w ∉ objective` directly — it enters via the downstream
+area = Q/(U·w) ratio). Baseline uniform root bound = **38,183.53** (matches PF4
+§1's 38,184; HiGHS agrees to 38,183.53; the in-house simplex **converges** here,
+unlike bchoco06). Oracle: `=bestdual= 100552.19`, `=best= 154895.93` — the baseline
+sits 62% below the dual bound.
+
+**AM soundness on the pole-excluded children (feasible-point sampled, 4×10⁵ pts /
+term, a,b ∈ [10,700]).** A single clean split at `a=ε+b` still leaves each child's
+closure touching the pole, so AM needs a *margin* δ (PF4 §6's point). Measured
+worst AM violation `LMTD − (a+b)/2` (>0 = unsound cut):
+
+| δ (margin) | child `a ≥ b+δ` | child `a ≤ b−δ` |
+|---|---|---|
+| 1e-3 | **+0.696** (unsound) | −1.8e-4 (sound) |
+| 0.1 | +0.007 (unsound) | −1.8e-4 (sound) |
+| 1.0 | +5.8e-4 (unsound) | −1.8e-4 (sound) |
+| **5.0** | **−0.0028 (sound)** | −1.8e-4 (sound) |
+
+The `a<b` child is sound at any δ (the pole is approached from the `a>b` side, where
+the denominator → 0⁺); the `a>b` child needs δ ≈ 5 to be sound — corroborating PF4
+§6 that the AM margin is quantitative and non-trivial.
+
+**The measurement that settled it.** With a sound δ=5, add the AM cut and re-solve
+the children's root LP (HiGHS on the assembled matrix):
+
+| configuration | AM sound? | root bound | improvement vs 38,184 |
+|---|---|---|---|
+| baseline (raw box, no AM) | — | 38,183.53 | — |
+| **Exp A:** branch once on term-0 pole, child `a≥b+5`, AM on term-0 | yes | 38,183.53 | **0.00%** |
+| **Exp A:** child `a≤b−5`, AM on term-0 | yes | 38,183.53 | **0.00%** |
+| **Exp B:** pole-excluded ORTHANT `a_k ≥ b_k+5 ∀k`, AM on **all 8** terms | yes (worst −0.003) | 38,183.53 | **0.00%** |
+| control: orthant branch only, **no AM** | — | 38,183.53 | 0.00% |
+
+**Why (mechanism, measured at the LP optimum).** At the baseline LP optimum **all
+8 temperature pairs park at the floor `a=b=10`**, the LMTD aux **`w = 0`**, and the
+AM cut `w ≤ (a+b)/2 = 10` is therefore **fully slack (slack = 10)**. The LMTD
+*upper* envelope is not the binding looseness. The relaxation reaches 38,184 by
+setting every approach to zero (LMTD → 0), and the dual bound is capped by the
+**downstream area = Q/(U·w) ratio** relaxation near `w → 0` (loose reciprocal),
+*not* by the value of `w` from above. Bounding `w` above (AM) cannot move a bound
+that is already achieved at `w = 0`. This holds in the best case — all 8 poles
+excluded, AM sound on every term.
+
+**Verdict — kill criterion MET (0.00% ≪ 10%).** Pole-excluded sub-box branching +
+the AM/GM envelope does **not** tighten gen1's root bound, even in its strongest
+form (full pole-excluded orthant, AM sound on all 8 LMTD terms). This **confirms
+and extends PF4 §6** from a new angle: the LMTD envelope is not merely unsound on
+the raw box — where it is *made* sound (pole excluded), it is **inert at the root**,
+because the LMTD *upper* bound is not the constraint that caps the dual. Close the
+"pole-excluded LMTD envelope" as a **non-lever** for gen1's root gap.
+
+**Scoped follow-up (a different lever, NOT built).** The measured binding looseness
+is the **downstream area = Q/(U·LMTD) reciprocal** near LMTD→0, together with the
+[10,+∞) temperature domains that let the relaxation drive every approach to zero.
+Any future family-D root-strength work should target (a) OBBT/FBBT tightening of the
+temperature bounds so LMTD cannot collapse to 0, and (b) the reciprocal/ratio
+envelope on area, *not* the LMTD AM/GM envelope — with the full bound-changing gate
+(differential per-box bound never lower/crossed + feasible-point 0-cuts). This is a
+distinct, unmeasured direction, explicitly out of this diagnosis's scope.
+
+---
+
+## Summary
+
+| diagnosis | kill criterion | verdict | key numbers |
+|---|---|---|---|
+| bchoco06 hole | structural à la LMTD (no sound finite bound) → close | **NOT met — FALSIFIED**: a sound finite bound exists (HiGHS 3-way ≈ 1.0); "no bound" = in-house LP non-convergence (Cause A) over a vacuous high-degree-monomial relaxation (Cause B); `known=null` | discopt LP: `iteration_limit`/None; HiGHS: optimal 0.99998; coeff spread 1e10..5e-324; 14 unbounded-above originals |
+| heatexch pole children | children improve 38,184 by < 10% | **MET — 0.00%** | baseline 38,183.53; AM sound at δ=5; Exp A & B both 38,183.53; at optimum a=b=10, w=0, AM slack=10 |
+
+Neither diagnosis authorises a build. bchoco06's actionable item is an
+LP-conditioning/solver-robustness fix (Cause A), not a relaxation envelope;
+heatexch's LMTD AM/GM envelope is closed as a non-lever even on pole-excluded
+children. Both follow-ups, if taken, ship only through the CLAUDE.md §5
+bound-changing gate.


### PR DESCRIPTION
## G5 / TX6 — family-D relaxation-strength diagnoses (baron-gap-plan §7)

Two **diagnosis-first, no-build** records for family D (stuck on bound strength, not
speed). Per baron-gap §0.3, any build that follows either gets the full
bound-changing gate. Everything here is **load-immune** (bound values, not wall
times) — concurrent agents don't affect it. Deliverable:
`docs/dev/g5-family-d-diagnoses.md` (falsification house style). Probes committed
under `discopt_benchmarks/scripts/` (outside the `^python/` ruff CI scope).

### Diagnosis 1 — bchoco06 "unbounded-relaxation hole" → FALSIFIED (kill NOT met)

The root LP is **not** structurally unbounded (not a hole à la LMTD). On the
byte-identical assembled root LP:

| solver | status | dual bound (max x0) |
|---|---|---|
| discopt in-house simplex (`backend="simplex"`) | `iteration_limit` | **None** |
| discopt `backend="auto"` (highspy present) | `iteration_limit` | **None** |
| HiGHS via scipy (`highs-ds`/`highs-ipm`/`highs`) | **optimal** (all 3) | **0.99998** |

A sound finite bound **provably exists** (HiGHS ≈ 1.0); `objective_bound_valid` is
already True. "No finite dual bound at 7 nodes" has two **non-structural** causes:

- **Cause A — LP-backend non-convergence** on an ill-conditioned matrix
  (nonzero-coefficient spread ≈ 1e10 … 5e-324, from McCormick rows over 14
  **unbounded-above** originals). Clamping all free aux to ±1e6 does **not** help
  the in-house simplex → conditioning, not a free ray. This suppresses even the
  trivial-but-sound bound HiGHS computes.
- **Cause B — vacuous relaxation:** the objective is the lone variable
  `x0 ∈ [0.95,1]`; the bound ≈ 1.0 is just its box top. Tightening the 14 originals
  to `[0,10]`/`[0,100]` leaves it at 1.0 — the degree-≤5 monomial relaxation never
  binds `x0`. MINLPLib oracle `known=null`.

**Actionable follow-up = an LP-conditioning/robustness fix (Cause A), not a
relaxation envelope** (route `iteration_limit`/ill-conditioned relaxation LPs
through a cleaned HiGHS solve; report a bound only where HiGHS agrees).
Bound-changing gate applies. Cause B is masked by A and unmeasurable while
`known=null`.

### Diagnosis 2 — heatexch_gen1 pole-excluded children → kill MET (0.00%)

Baseline uniform root bound **38,183.53** (= PF4's 38,184; HiGHS agrees; in-house
simplex converges here). 8 LMTD terms, inputs `[10,+∞)`. AM over-estimator
`w ≤ (a+b)/2` made **sound** on pole-excluded children (δ=5 verified by 4×10⁵-pt
sampling/term; the `a<b` child is sound at any δ):

| configuration | root bound | Δ vs 38,184 |
|---|---|---|
| baseline (raw box) | 38,183.53 | — |
| branch once on term-0 pole (`a≥b+5`), AM on term-0 | 38,183.53 | **0.00%** |
| pole-excluded **orthant** (`a_k≥b_k+5 ∀k`), AM on **all 8** | 38,183.53 | **0.00%** |

**Mechanism (measured at the LP optimum):** all temps park at floor `a=b=10`, LMTD
aux `w=0`, so the AM cut `w≤10` is **fully slack** — the LMTD *upper* envelope is
not the binding looseness (the downstream `area=Q/(U·LMTD)` reciprocal near
`LMTD→0` is). Even where AM is *made* sound (pole excluded), it is **inert at the
root**. Confirms + extends PF4 §6; closes the "pole-excluded LMTD envelope" as a
non-lever for gen1's root gap. Any future lever should target the temperature
bounds (OBBT) + the area reciprocal, not the LMTD AM/GM envelope.

### Testing / verification
No solver code changed (docs + two diagnostic probes only). Both probes reproduce
their tables:
```
JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 PYTHONPATH=$PWD/python \
  python discopt_benchmarks/scripts/g5_bchoco06_hole_probe.py
  python discopt_benchmarks/scripts/g5_heatexch_pole_children_probe.py
```
No merge intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
