### PR TITLE
fix(correctness): P0 false-optimal in LP-node engine + record TX4 routing falsification (baron-gap G3)

### DIFF
--- a/docs/dev/scip-gap-nvs-diagnosis.md
+++ b/docs/dev/scip-gap-nvs-diagnosis.md
@@ -149,3 +149,56 @@ SCIP), **not** cuts. Cuts (a future c-MIR/aggregation separator) are a node-coun
 optimization (6,796 → 70), valuable later but neither necessary nor currently
 attainable. **Step 2 is therefore the real next step; Step 3 is deferred** until a
 proper aggregation-MIR separator exists.
+
+## G3 / TX4 update (2026-07-15) — routing FALSIFIED; false-optimal fixed instead
+
+Entry experiments for baron-gap-plan G3 (route family C to the LP-node engine by
+default) measured on `main` @`0f3ebd7d` (post-#636 uniform engine). Two findings
+overrode the plan.
+
+**1. The default NLP path already solves the family (#636 superseded the freeze).**
+The frozen-bound pathology this diagnosis documented (nvs17 stuck at −65,842) is
+gone on the default path — the uniform engine + already-un-gated root OBBT
+(`solver.py:4711`, `_obbt_has_nonlinear and n_vars <= 50`) close it:
+
+| instance | default path (60 s budget) | true opt |
+|---|---|---|
+| nvs17 | **optimal −1100.4**, 131 nodes, 10.5 s | −1100.4 |
+| nvs19 | **optimal −1098.4**, 277 nodes, 30.2 s | −1098.4 |
+| nvs24 | feasible −1031.8, bound −1034.55, gap 0.27 %, 517 nodes, 60 s | −1033.2 |
+
+Root OBBT probe (EE3): post-#636 the root McCormick bound is −395,450 over [0,200]
+→ −34,715 after OBBT (box → ~[0,49..65]). The Phase-1 prediction (−65,842 →
+−6,790) was against the *pre-#636* relaxation and does not reproduce; the number
+changed but the default path solves regardless, so OBBT un-gating (plan part b) is
+already effective on `main`.
+
+**2. The opt-in LP-node engine returns CERTIFIED FALSE OPTIMA at `main`** — a P0
+regression, not just a throughput gap:
+
+| instance | `solve(lp_spatial=True)` at `main` | true opt |
+|---|---|---|
+| nvs17 | status=**optimal** obj=**−1836.2**, gap_certified=True (infeasible point) | −1100.4 |
+| nvs19 | status=**optimal** obj=**−2520.4** | −1098.4 |
+
+Cause: #636 lifts bilinear `x_i*x_j` via **univariate squares**, so
+`build_milp_relaxation`'s `info["bilinear"]` is empty for nvs17-class models. The
+engine's `_worst_product_var` then never sees the (loose) products, declares "all
+products tight", and accepted the loose McCormick node bound as the incumbent's
+true objective. `IncrementalMcCormickLP.ok` is also False (cuts + pump disabled),
+and the collapsed-box `verify()` returned None (`_objective_bound_valid` False).
+The existing `test_nvs17_dual_bound_is_valid_and_tight` catches this but is
+`slow`+`requires_pounce`, so CI smoke never ran it.
+
+**Action taken (this PR).** Routing (part c) is NOT landed — it would inject false
+optima into the default path, and the engine cannot beat the default even once made
+sound (inc.ok broken → no throughput; McCormick bound too loose). Instead the
+engine's **soundness** was fixed generally (exact ground-truth incumbent
+verification; a valid dual-bound floor for nodes it cannot branch; "optimal" only
+on a genuine gap closure). Post-fix the engine is sound on the family (nvs17
+feasible −1092.4 / valid bound −1836.2 / honest `time_limit`, no false optimum).
+
+**Kill criterion (met):** the engine, even with OBBT + soundness fixes, does not
+beat the default path on its own family. Full engine restoration to the #636
+relaxation (repopulate the product map so `inc.ok`/product-branching/cuts work
+again) is a separate, larger effort and the prerequisite for any future routing.

--- a/python/discopt/_jax/lp_spatial_bb.py
+++ b/python/discopt/_jax/lp_spatial_bb.py
@@ -12,12 +12,17 @@ LP relaxation** (``build_milp_relaxation`` — one LP, no NLP, globally valid lo
 bound for a minimize), and branches either on a fractional integer variable or, when
 the integer assignment is integral but a lifted product ``w_ij`` disagrees with
 ``x_i*x_j``, spatially on the worst-violated product's variable. A rounding
-heuristic produces incumbents, verified *exactly* by collapsing the integer box to
-the rounded point (where McCormick is exact).
+heuristic produces incumbents, verified *exactly* against a ground-truth point
+evaluator (true objective + constraint feasibility) — never the relaxation bound.
 
-**Scope (this step).** Pure-integer models with a MINIMIZE objective. With every
-variable integer, fixing the integers at a leaf determines every nonlinear term, so
-the collapsed-box LP value is the true objective and fathoming is exact. Cuts
+**Scope (this step).** Pure-integer models with a MINIMIZE objective. The frontier
+McCormick bound is always a valid lower bound; every incumbent is a genuinely
+feasible point whose reported objective is its true objective, so ``bound <=
+incumbent`` holds unconditionally. Optimality is declared only when the valid dual
+bound (frontier + a floor for nodes the engine cannot branch — see
+``unresolved_lb``) closes the gap: a node whose products are lifted outside this
+engine's ``info`` map (e.g. univariate-square bilinear post-#636) is *not* treated
+as an exact leaf, so a loose relaxation can never masquerade as a proof. Cuts
 (Gomory/MIR) and warm-started incremental LPs are added in later steps;
 ``build_milp_relaxation`` is currently rebuilt per node. Returns ``None`` (caller
 falls back to the default path) whenever the model is out of scope or anything
@@ -210,6 +215,30 @@ def solve_lp_spatial_bb(
 
     t0 = time.perf_counter()
 
+    # Ground-truth point evaluator for exact incumbent verification. An incumbent's
+    # objective MUST be the true objective at a verified-feasible integer point,
+    # never a McCormick relaxation value: post-uniform-relaxation (#636) a bilinear
+    # product ``x_i*x_j`` is lifted via univariate squares, so it no longer appears
+    # in this engine's ``info`` product map -- the "collapsed box is exact" argument
+    # (and ``_worst_product_var``'s "all products tight" check) silently fail, and
+    # trusting the relaxation bound as a primal produced *certified false optima*
+    # (nvs17: reported optimal -1836.2 vs true -1100.4, at an infeasible point).
+    # Verifying against the evaluator restores ``bound <= incumbent`` unconditionally.
+    # If we cannot build a verifier we cannot safely accept any incumbent, so bail to
+    # the sound default path (return None) rather than risk an unverified certificate.
+    try:
+        from discopt._jax.nlp_evaluator import NLPEvaluator
+        from discopt.solver import _check_constraint_feasibility, _infer_constraint_bounds
+
+        _ev = NLPEvaluator(model)
+        _cl, _cu = _infer_constraint_bounds(model, _ev)
+    except Exception:
+        return None
+    _FEAS_TOL = 1e-6
+
+    def _pt_feasible(xr: np.ndarray) -> bool:
+        return bool(_check_constraint_feasibility(_ev, xr, _cl, _cu, tol=_FEAS_TOL))
+
     if use_obbt:
         try:
             from discopt._jax.obbt import obbt_tighten_root
@@ -335,11 +364,21 @@ def solve_lp_spatial_bb(
             cnt_u[i] += 1
 
     def verify(xhat):
-        """True objective at integer point xhat (products fixed -> McCormick exact),
-        or None if xhat is infeasible."""
+        """Exact objective at the rounded integer point, or None if infeasible.
+
+        Ground truth only: evaluates the true objective and checks constraint
+        feasibility with the point evaluator (never the McCormick relaxation bound,
+        which is not exact once a product is lifted outside ``info`` -- see the
+        verifier note above). Guarantees any accepted incumbent is a genuinely
+        feasible point whose reported objective is its true objective, so the
+        frontier's valid lower bound can never exceed it."""
         xr = np.minimum(np.maximum(np.round(xhat), lb0), ub0)
-        b_, _x, _bas = relax(xr, xr, None)
-        return (b_, xr) if b_ is not None else None
+        if not _pt_feasible(xr):
+            return None
+        try:
+            return float(_ev.evaluate_objective(xr)), xr
+        except Exception:
+            return None
 
     def dive(lb_d, ub_d):
         """Fix-and-dive: repeatedly fix the most-fractional free integer to its
@@ -411,6 +450,12 @@ def solve_lp_spatial_bb(
     consider(dive(lb0, ub0))
     consider(feasibility_pump(lb0, ub0, root_x))
 
+    # Valid global lower bound floor from nodes the engine popped but could NOT
+    # branch or fathom exactly (see the unbranchable-node handling below). The true
+    # global lower bound is min(best frontier bound, this floor); optimality may be
+    # declared only when that closes the gap to the verified incumbent.
+    unresolved_lb = float("inf")
+
     status = "infeasible"
     while heap:
         if (time.perf_counter() - t0) >= time_limit or nodes >= max_nodes:
@@ -418,9 +463,14 @@ def solve_lp_spatial_bb(
             break
         bound, _, lb, ub, x, basis, ncuts = heapq.heappop(heap)
         nodes += 1
+        # Global lower bound = smallest frontier bound (this popped node, best-first)
+        # capped by any unresolved-node floor. Fathoming/gap tests use this, never the
+        # popped node's bound alone, so an unresolved node below the incumbent keeps
+        # the gap open instead of yielding a false optimality proof.
+        glb = min(bound, unresolved_lb)
         if bound >= inc_val - 1e-9 * (1 + abs(inc_val)):
             continue
-        if inc_x is not None and abs(inc_val - bound) <= gap_tolerance * (1 + abs(inc_val)):
+        if inc_x is not None and abs(inc_val - glb) <= gap_tolerance * (1 + abs(inc_val)):
             status = "optimal"
             break
         # primal: cheap one-shot rounding every node; dive / pump rate-limited so
@@ -445,19 +495,49 @@ def solve_lp_spatial_bb(
             _update_pc(bi, "d", bound, bd, fd)
             _update_pc(bi, "u", bound, bu, fu)
             continue
-        # integral assignment: spatial-bisect the worst-violated product variable
+        # Integral assignment: spatial-bisect the worst-violated product variable.
+        # ``_worst_product_var`` can only see products present in ``info``; once a
+        # product is lifted elsewhere (univariate-square bilinear post-#636) it
+        # returns None even though the relaxation is NOT tight, so "no branchable
+        # product" is NOT a proof that ``bound`` is exact here. Record a verified
+        # incumbent (exact objective, never the loose ``bound``); the node is a true,
+        # fathomable leaf only when the integer box is fully fixed (a single point,
+        # where every nonlinear term is determined). Otherwise it is unresolved: keep
+        # its valid lower bound as a global-bound floor so optimality is never claimed
+        # over branching the engine could not perform.
         bv = _worst_product_var(x, info, ub - lb)
         if bv is None:
-            consider((bound, x[:n].copy()))  # all products tight -> true solution
+            consider(verify(x[:n]))
+            if not bool(np.all(ub[:n] - lb[:n] <= 1e-9)):
+                unresolved_lb = min(unresolved_lb, bound)
             continue
         mid = np.floor((lb[bv] + ub[bv]) / 2)
         child(lb, _set(ub, bv, mid), basis, ncuts, _rounds)
         child(_set(lb, bv, mid + 1.0), ub, basis, ncuts, _rounds)
     else:
-        status = "optimal" if inc_x is not None else "infeasible"
+        # Heap exhausted. Optimal only if the unresolved-node floor does not sit below
+        # the incumbent (else there is space the engine could not rule out -> feasible
+        # with an honest gap, never a false optimality certificate).
+        if inc_x is not None and (
+            not np.isfinite(unresolved_lb)
+            or abs(inc_val - unresolved_lb) <= gap_tolerance * (1 + abs(inc_val))
+        ):
+            status = "optimal"
+        elif inc_x is not None:
+            status = "feasible"
+        elif np.isfinite(unresolved_lb):
+            # Nodes the engine could neither branch nor find a feasible point in were
+            # left unresolved: cannot certify infeasibility.
+            status = "time_limit"
+        else:
+            status = "infeasible"
 
-    gbound = min([h[0] for h in heap], default=inc_val)
-    gbound = min(gbound, inc_val) if inc_x is not None else gbound
+    gbound = min([h[0] for h in heap], default=float("inf"))
+    gbound = min(gbound, unresolved_lb)
+    if inc_x is not None:
+        gbound = min(gbound, inc_val)
+    if not np.isfinite(gbound):
+        gbound = inc_val if inc_x is not None else None
     obj = inc_val if inc_x is not None else None
     gap = None
     if obj is not None and gbound is not None and np.isfinite(gbound):
@@ -467,7 +547,7 @@ def solve_lp_spatial_bb(
     return LpSpatialResult(
         status=status,
         objective=obj,
-        bound=(gbound if np.isfinite(gbound) else None),
+        bound=(gbound if (gbound is not None and np.isfinite(gbound)) else None),
         gap=gap,
         x=inc_x,
         node_count=nodes,

--- a/python/tests/test_lp_spatial_bb.py
+++ b/python/tests/test_lp_spatial_bb.py
@@ -127,6 +127,48 @@ def _brute(ux, uy, rhs, coef):
     )
 
 
+@pytest.mark.smoke
+def test_no_false_optimum_on_dense_integer_quadratic():
+    """Soundness invariant (fail-before/pass-after for the #636 univariate-square
+    regression): on a dense all-integer quadratic the engine must never report an
+    objective *below* the true optimum, never a dual bound *above* it, and never
+    declare ``optimal`` at a suboptimal point.
+
+    The engine's incumbent objective used to be the McCormick relaxation value at a
+    collapsed box; once a bilinear product is lifted outside ``info`` (univariate-
+    square post-#636) that value is loose, and ``_worst_product_var`` cannot see the
+    product to branch it, so the loose bound was accepted as a certified optimum
+    (nvs17: -1836.2 vs true -1100.4). This small dense model drives the same
+    fallback path (``inc.ok`` is False), so the exact-verify + unresolved-bound
+    invariant is exercised without the slow nvs17 solve."""
+    n, ub = 3, 5
+    m = dm.Model("dq")
+    xs = [m.integer(f"x{i}", lb=0, ub=ub) for i in range(n)]
+    obj = 0
+    for i in range(n):
+        obj = obj - xs[i] * xs[i]
+        for j in range(i + 1, n):
+            obj = obj - xs[i] * xs[j]
+    m.minimize(obj)
+    m.subject_to(sum(xs) <= 2 * n)
+
+    brute = min(
+        -(a * a + b * b + c * c + a * b + a * c + b * c)
+        for a in range(ub + 1)
+        for b in range(ub + 1)
+        for c in range(ub + 1)
+        if a + b + c <= 2 * n
+    )
+    r = solve_lp_spatial_bb(m, time_limit=20, gap_tolerance=1e-6)
+    assert r is not None
+    if r.objective is not None:
+        assert r.objective >= brute - 1e-6  # incumbent can never beat the true optimum
+    if r.bound is not None:
+        assert r.bound <= brute + 1e-6  # dual bound is a valid lower bound
+    if r.status == "optimal":  # a claimed proof must be a real one
+        assert r.objective == pytest.approx(brute, abs=1e-6)
+
+
 # --------------------------------------------------------------------------- #
 # scope gate (pure logic, fast)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Task **G3 / TX4** of the baron-gap plan: route family C (integer-product models —
nvs17/19/24, graphpart_*) to the opt-in LP-node engine. The mandatory entry
experiments **falsified the routing plan** and surfaced a **P0 false-optimal
regression** in the engine itself. Per the kill criterion and CLAUDE.md
(correctness before performance, measurement wins), this PR lands the **safe
subpart**: it makes the LP-node engine sound, and does **not** route.

## Entry experiments (measured on `main` @`0f3ebd7d`, post-#636)

**1. The opt-in engine returns CERTIFIED FALSE OPTIMA on its own family.**

| instance | `solve(lp_spatial=True)` at `main` | true opt |
|---|---|---|
| nvs17 | status=**optimal** obj=**−1836.2**, `gap_certified=True` (point is infeasible: constraint 0 residual +131) | **−1100.4** |
| nvs19 | status=**optimal** obj=**−2520.4** | −1098.4 |
| nvs24 | time_limit, no incumbent, valid bound −32,045 | −1033.2 |

**Root cause:** #636 lifts bilinear `x_i*x_j` via **univariate squares**, so
`build_milp_relaxation`'s `info["bilinear"]` is empty for nvs17-class models
(classifier finds 21 bilinear terms; `info["bilinear"]` = 0). The engine's
`_worst_product_var` then never sees the (still-loose) products, wrongly declares
"all products tight", and accepted the **loose McCormick node bound** as the
incumbent's true objective. Compounding: `IncrementalMcCormickLP.ok=False` (cuts +
pump off) and the collapsed-box `verify()` returned None (`_objective_bound_valid`
False). The existing `test_nvs17_dual_bound_is_valid_and_tight` catches this
(`objective >= true_opt`) but is `slow`+`requires_pounce`, so CI smoke never ran it.

**2. The default NLP path already solves the family** (the #636 uniform engine +
already-un-gated root OBBT superseded the frozen-bound pathology this family was
named for):

| instance | default path | true opt |
|---|---|---|
| nvs17 | optimal −1100.4, 131 nodes, 10.5 s | −1100.4 |
| nvs19 | optimal −1098.4, 277 nodes, 30.2 s | −1098.4 |
| nvs24 | feasible −1031.8, bound −1034.55, gap 0.27 %, 60 s | −1033.2 |

**3. Root OBBT (part b) is already un-gated for pure-integer nonlinear models**
(`solver.py:4711`, `_obbt_has_nonlinear and n_vars <= 50`). EE3: nvs17 root bound
−395,450 → −34,715 with OBBT (box [0,200] → ~[0,49..65]). The Phase-1 prediction
(−65,842 → −6,790) was against the *pre-#636* relaxation and does not reproduce,
but the default path solves regardless. Nothing to implement for part b.

## What this PR changes (correctness fix — the safe subpart)

`python/discopt/_jax/lp_spatial_bb.py` — make the engine sound **regardless of how
a product is lifted**:

1. **Exact incumbent verification.** `verify()` now evaluates the true objective
   and constraint feasibility via the ground-truth `NLPEvaluator` (reusing
   `solver.py`'s `_infer_constraint_bounds` / `_check_constraint_feasibility`),
   never the relaxation bound. If a verifier can't be built → return None (fall
   back to the sound default path). Guarantees `bound <= incumbent` unconditionally.
2. **Sound optimality.** A node the engine cannot branch (because its products are
   invisible in `info`) is no longer treated as an exact leaf: its valid McCormick
   lower bound feeds a global floor (`unresolved_lb`), and `optimal` is declared
   only when the frontier bound (capped by that floor) closes the gap to a
   verified incumbent. Heap-exhaust with an open floor now reports `feasible`.

Post-fix the engine is sound on the family (nvs17 feasible −1092.4 / valid bound
−1836.2 / honest `time_limit`, **no false optimum**).

## What this PR does NOT do (falsified / deferred)

- **No routing (part c).** Routing would inject false optima into the default
  path, and even once sound the engine cannot close the family (`inc.ok` broken →
  no throughput; McCormick bound too loose), while the default path already solves
  it. Kill criterion met.
- **No latency fix (part a).** #287's repro instance (`kall_congruentcircles_c72`,
  18 continuous vars) is out of the engine's pure-integer scope; a latency fix on
  an engine we don't route to has no shippable effect.

**Follow-up (should be tracked as an issue):** restore the engine's product map to
the #636 univariate-square lifting (repopulate `info`/`inc.ok` so cuts + spatial
branching work again) — the prerequisite for any future routing. Plan recorded in
`docs/dev/scip-gap-nvs-diagnosis.md` (G3/TX4 update).

## Verification

- `python/tests/test_lp_spatial_bb.py`: **9 passed** — incl. the previously-FAILING
  slow `test_nvs17_dual_bound_is_valid_and_tight` (fail-before/pass-after) and the
  brute-force optimality tests (still prove optimality on small models where
  products are visible).
- New smoke guard `test_no_false_optimum_on_dense_integer_quadratic` exercises the
  `inc.ok=False` fallback path with a brute-force soundness check.
- `pytest -m smoke` (python/tests): **638 passed**, 1 skipped.
- Adversarial suite (`-m slow test_adversarial_recent_fixes.py`): **10 passed**.
- `test_issue_286_false_unbounded.py`: **9 passed**.
- `ruff` + `ruff format` + `mypy` (pre-commit): clean.
- **Off-family byte-identity:** the diff is confined to `lp_spatial_bb.py` + its
  test; the engine's only call site (`solver.py:3209`) is guarded by the opt-in
  `lp_spatial=True` flag, so every default solve is byte-identical by construction
  (spot-checked: alan optimal 21 nodes, ex1221 optimal 5 nodes, nvs05 feasible 355
  nodes — unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
