### PR TITLE
docs(baron-gap G6): subnormal-flush hypothesis FALSIFIED — escalate in-house simplex non-convergence to Rust numerics (#649)

### DIFF
--- a/discopt_benchmarks/pyproject.toml
+++ b/discopt_benchmarks/pyproject.toml
@@ -70,6 +70,8 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "C4", "SIM", "TCH"]
 "bench_engine.py" = ["N806"]
 # A/A_new/A_ub are LP constraint matrices in the CUT-1 cut-injection harness.
 "scripts/cut1_cmir_oracle_injection.py" = ["N803", "N806"]
+# A/A_f/A_s are LP constraint matrices in the G6 conditioning diagnosis probe.
+"scripts/g6_bchoco06_conditioning_probe.py" = ["N803", "N806", "B905"]
 
 [tool.coverage.run]
 source = ["benchmarks", "utils"]

--- a/discopt_benchmarks/scripts/g6_bchoco06_conditioning_probe.py
+++ b/discopt_benchmarks/scripts/g6_bchoco06_conditioning_probe.py
@@ -1,0 +1,158 @@
+"""G6 (baron-gap §10) entry experiment — is bchoco06's LP non-convergence a
+subnormal-noise problem the cheap flush can fix, or a genuine Rust-simplex
+ill-conditioning defect?
+
+Falsifies the G6 hypothesis (see ``docs/dev/g5-family-d-diagnoses.md`` §"G6
+update"): flushing subnormal structural noise (``|v| < 1e-300 -> 0``) in the
+assembled ``(A_ub, b_ub, bounds)`` does NOT make the in-house simplex converge on
+the bchoco06 root relaxation. The genuine ``1e10`` coefficient spread survives full
+geometric-mean (Ruiz) equilibration as a residual ``~1.25e12`` condition, which the
+in-house Rust simplex stalls on (``iteration_limit``) while HiGHS solves it. The
+defect is Rust-layer linear-algebra robustness, not a Python cleanup pass -> the
+kill criterion fires; no flush is shipped.
+
+Reproduce::
+
+    JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 PYTHONPATH=$PWD/python \
+      python discopt_benchmarks/scripts/g6_bchoco06_conditioning_probe.py
+"""
+
+from __future__ import annotations
+
+import math
+
+# Reuse the G5 probe's assembly of the byte-identical uniform root relaxation.
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import scipy.sparse as sp
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO / "discopt_benchmarks" / "scripts"))
+from g5_bchoco06_hole_probe import _build_ctx  # noqa: E402
+
+_NL = _REPO / "python" / "tests" / "data" / "minlplib_nl" / "bchoco06.nl"
+
+# Structural-zero threshold the hypothesis proposed: ~288 orders of magnitude
+# below the 1e-12 factorization tolerance / 1e-6 abs tolerance in conftest.py.
+_STRUCTURAL_ZERO = 1e-300
+
+
+def _spread(data: np.ndarray) -> tuple[float, float, float]:
+    nz = np.abs(np.asarray(data))
+    nz = nz[(nz != 0.0) & np.isfinite(nz)]
+    if nz.size == 0:
+        return 0.0, 0.0, 1.0
+    return float(nz.min()), float(nz.max()), float(nz.max() / nz.min())
+
+
+def _flush(v: np.ndarray) -> np.ndarray:
+    v = np.array(v, dtype=np.float64, copy=True)
+    mask = np.isfinite(v) & (np.abs(v) < _STRUCTURAL_ZERO) & (v != 0.0)
+    v[mask] = 0.0
+    return v
+
+
+def main() -> None:
+    from discopt._jax.milp_relaxation import MilpRelaxationModel, equilibrate_relaxation_lp
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt.modeling.core import from_nl
+    from discopt.solvers.milp_simplex import solve_lp_warm_std
+
+    model = from_nl(str(_NL))
+    flat_lb, flat_ub = flat_variable_bounds(model)
+    ctx, obj_lin, sign, _ = _build_ctx(model, flat_lb, flat_ub)
+    n_cols = len(ctx.col_lb)
+
+    data, ri, ci_ = [], [], []
+    b = np.zeros(len(ctx.rows))
+    for i, (coeffs, rhs) in enumerate(ctx.rows):
+        b[i] = rhs
+        for j, coef in coeffs.items():
+            data.append(coef)
+            ri.append(i)
+            ci_.append(j)
+    A = sp.csr_matrix((data, (ri, ci_)), shape=(len(ctx.rows), n_cols))
+    c = np.zeros(n_cols)
+    for j, coef in obj_lin.coeffs.items():
+        c[j] += coef
+    col_lb = np.asarray(ctx.col_lb, dtype=np.float64)
+    col_ub = np.asarray(ctx.col_ub, dtype=np.float64)
+
+    def sub_count(v: np.ndarray) -> int:
+        v = np.asarray(v, dtype=np.float64)
+        fin = v[np.isfinite(v)]
+        return int(np.count_nonzero((fin != 0.0) & (np.abs(fin) < _STRUCTURAL_ZERO)))
+
+    print(f"subnormals < {_STRUCTURAL_ZERO:g}:  A.data={sub_count(A.data)}  "
+          f"b={sub_count(b)}  col_lb={sub_count(col_lb)}  col_ub={sub_count(col_ub)}")
+
+    A_f = A.copy()
+    A_f.data = _flush(A_f.data)
+    b_f = _flush(b)
+    lb_f = _flush(col_lb)
+    ub_f = _flush(col_ub)
+
+    def _show_spread(tag: str, data: np.ndarray) -> None:
+        mn, mx, ra = _spread(data)
+        print(f"{tag} A spread: min={mn:.3e} max={mx:.3e} ratio={ra:.3e}")
+
+    _show_spread("RAW     ", A.data)
+    _show_spread("FLUSHED ", A_f.data)
+    c_s, A_s, b_s, bnds_s, _ = equilibrate_relaxation_lp(c, A_f, b_f, list(zip(lb_f, ub_f)), None)
+    _show_spread("EQUILIB ", sp.csr_matrix(A_s).data)
+
+    def simplex(A_, b_, lb_, ub_) -> tuple[str, object]:
+        milp = MilpRelaxationModel(
+            c=c, A_ub=A_, b_ub=b_, bounds=list(zip(lb_, ub_)),
+            obj_offset=obj_lin.const, integrality=None, objective_bound_valid=True,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            r = milp.solve(backend="simplex")
+        return r.status, r.bound
+
+    def highs(A_, b_, lb_, ub_):
+        from scipy.optimize import linprog
+        bnds = list(zip(
+            [None if not math.isfinite(x) else x for x in lb_],
+            [None if not math.isfinite(x) else x for x in ub_],
+        ))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            hr = linprog(c, A_ub=A_, b_ub=b_, bounds=bnds, method="highs")
+        return hr.success, (None if not hr.success else sign * (hr.fun + obj_lin.const))
+
+    print("\n=== in-house simplex vs HiGHS (original-sense dual bound) ===")
+    for tag, (A_, b_, lb_, ub_) in {
+        "raw    ": (A, b, col_lb, col_ub),
+        "flushed": (A_f, b_f, lb_f, ub_f),
+    }.items():
+        st, bd = simplex(A_, b_, lb_, ub_)
+        hs, hb = highs(A_, b_, lb_, ub_)
+        obd = None if bd is None else sign * bd
+        print(f"  {tag}: simplex status={st:15s} dual={obd}   HiGHS ok={hs} dual={hb}")
+
+    # Direct raw-simplex probe on the equilibrated (flushed) matrix + safe bound.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res, _, cert = solve_lp_warm_std(
+            c_s, sp.csr_matrix(A_s), b_s, bnds_s, in_basis=None, return_cert=True
+        )
+    if res is None:
+        print(f"\nraw Rust simplex on EQUILIB(flushed): result=None (iter-limit)  "
+              f"safe_bound={cert.safe_bound}")
+    else:
+        print(f"\nraw Rust simplex on EQUILIB(flushed): status={res.status} "
+              f"bound={res.bound} safe_bound={cert.safe_bound}")
+
+    print("\nVERDICT: flushing subnormals does NOT make the in-house simplex "
+          "converge; residual post-Ruiz condition ~1.25e12 is genuine "
+          "ill-conditioning. Kill criterion MET -> Rust-layer numerics fix "
+          "(see docs/dev/g5-family-d-diagnoses.md 'G6 update').")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/baron-gap-plan.md
+++ b/docs/dev/baron-gap-plan.md
@@ -458,6 +458,16 @@ per §0.
 
 ### G6 — in-house LP simplex conditioning (from G5's bchoco06 re-attribution)
 
+> **Entry experiment run 2026-07-15 — subnormal-flush sub-hypothesis FALSIFIED,
+> kill criterion MET → escalated to issue #649.** Flushing subnormal structural
+> noise (`|v|<1e-300 → 0`) does NOT make the in-house simplex converge; the genuine
+> `1e10` spread survives geometric-mean equilibration as a residual `~1.25e12`
+> condition the Rust simplex stalls on while HiGHS solves the identical matrix. No
+> band-aid shipped. Full record: `g5-family-d-diagnoses.md` §"G6 update"; probe
+> `discopt_benchmarks/scripts/g6_bchoco06_conditioning_probe.py`. The Rust
+> linear-algebra/refactorization fix is now **issue #649** (its own plan, full
+> bound-changing gate + `cargo test -p discopt-core`).
+
 **Hypothesis (evidence-backed, from `g5-family-d-diagnoses.md`).** bchoco06's
 "missing dual bound" is **not** an unbounded-relaxation hole — the same root
 relaxation solved by HiGHS returns a finite bound ~1.0, while the in-house

--- a/docs/dev/g5-family-d-diagnoses.md
+++ b/docs/dev/g5-family-d-diagnoses.md
@@ -194,3 +194,69 @@ LP-conditioning/solver-robustness fix (Cause A), not a relaxation envelope;
 heatexch's LMTD AM/GM envelope is closed as a non-lever even on pole-excluded
 children. Both follow-ups, if taken, ship only through the CLAUDE.md §5
 bound-changing gate.
+
+---
+
+## G6 update — subnormal-flush hypothesis FALSIFIED (2026-07-15)
+
+Follow-up on Diagnosis 1 / Cause A (baron-gap-plan.md §10 "G6"). The G6 entry
+experiment tested a specific, cheap hypothesis for the bchoco06 LP
+non-convergence before committing to a Rust-layer numerics fix. It is falsified;
+recording per the performance-plan.md §6 house style (hypothesis → the
+measurement that settled it → verdict vs kill criterion → scoped follow-up).
+
+**Environment.** Worktree of `discopt` @ `b7ed54c` (post-#647, on `main`'s line);
+`JAX_PLATFORMS=cpu JAX_ENABLE_X64=1`; `bchoco06.nl` from the in-repo corpus. Root
+uniform relaxation assembled exactly as `g5_bchoco06_hole_probe.py`, byte-identical
+matrix solved by the shipped in-house Rust simplex (`backend="simplex"`, which
+already retries via `_solve_lp_warm_equilibrated` / geometric-mean Ruiz
+equilibration) and cross-checked with HiGHS (scipy `linprog`).
+
+**Hypothesis (G6).** The `-4.941e-324` subnormal lower bounds on `x^2`/`x*y` aux
+columns (interval-arithmetic underflow of a true `0`) plus any subnormal matrix
+coefficients are the conditioning poison. Flushing structural noise `|v| < 1e-300`
+to `0` in `(A_ub, b_ub, bounds)` before the solve lets the existing equilibration
+compress the *real* 1e10 range, and the in-house simplex then converges to the
+HiGHS bound (≈ 1.0). **Kill criterion:** if the flush does NOT make the simplex
+converge (the 1e10 side alone still stalls it), STOP — it is a deeper Rust
+linear-algebra/refactorization problem, not a cleanup pass.
+
+**The measurement that settled it.** bchoco06 root LP, one stage at a time:
+
+| stage of the matrix | A nonzero spread (max / min) | in-house simplex | HiGHS |
+|---|---|---|---|
+| raw (as shipped) | 1.0e10 / 4.9e-324 = **inf** | `iteration_limit`, None | optimal, **0.99998** |
+| subnormals flushed (`|v|<1e-300 → 0`) | 1.0e10 / 1.0e-10 = **1e20** | **`iteration_limit`, None** | optimal, 0.99998 |
+| flushed + Ruiz equilibrated (20/50/100 sweeps) | 1.95 / 1.56e-12 = **1.25e12** | **`iteration_limit`, None** | optimal, ~1.0 |
+
+- Subnormal count: **20** nonzeros in `A.data`, **29** in `col_lb`, 0 in `b`/`col_ub`.
+  Flushing *all* of them to 0 leaves the simplex at `iteration_limit`, bound None.
+- The subnormals are **not** the poison. After the flush the smallest nonzero is a
+  *genuine* McCormick coefficient `1e-10` (not a subnormal), and the real spread is
+  `1e20`. Geometric-mean (Ruiz, power-of-two) equilibration compresses this only to
+  a **residual `1.25e12`** and cannot go lower — 50 and 100 sweeps give the identical
+  `1.25e12`. That residual is the intrinsic ill-conditioning of the recursive-
+  McCormick envelope over degree-5 multilinear products on the wide/unbounded box,
+  which a diagonal rescaling cannot remove.
+- The raw Rust warm simplex returns `None` (iter-limit at its 100k-pivot cap / stall
+  guard, `crates/discopt-core/src/lp/simplex/`) on the equilibrated matrix, flushed
+  or not; the Neumaier–Shcherbina `safe_bound` side channel is also `None` — no
+  salvageable bound. HiGHS solves the identical raw / flushed / equilibrated matrix
+  to optimal ≈ 1.0.
+
+**Verdict — kill criterion MET; hypothesis FALSIFIED.** Flushing subnormals does
+not make the in-house simplex converge. The `-4.941e-324` bounds are a real
+interval-underflow artifact, but they are **not** the conditioning poison — the
+poison is the genuine `≥1e12` ill-conditioning that *survives* full geometric-mean
+equilibration, a matrix HiGHS's dual simplex handles (LU refactorization + Harris
+ratio test + pivoting tolerances) and the in-house Rust simplex does not. This is a
+**Rust linear-algebra / refactorization robustness defect** in
+`crates/discopt-core/src/lp/simplex/`, exactly the escalation branch baron-gap §10
+G6 named ("scaling does not recover a finite bound → escalate to a linear-algebra
+(refactorization/tolerance) fix with its own plan"). No band-aid shipped: a subnormal
+flush is (a) a proven no-op for convergence on the target class and (b) would add a
+threshold with no measured beneficiary — rejected per CLAUDE.md §3. Tracked in
+**issue #649** for a Rust-layer numerics fix (refactorization cadence / Markowitz
+pivoting tolerances / Harris ratio test), which will carry the full bound-changing
+gate + `cargo test -p discopt-core`. Reproduce with
+`discopt_benchmarks/scripts/g6_bchoco06_conditioning_probe.py`.


### PR DESCRIPTION
## What this is

The G6 entry experiment (baron-gap-plan.md §10), run **before** any shipped code
per CLAUDE.md §4. The G6 subnormal-flush hypothesis is **FALSIFIED** — the kill
criterion the task defined fires — so **no solver code ships**. This PR records the
falsification and escalates the real fix to a Rust-layer numerics issue. Docs +
reproduction probe only; the LP layer is untouched.

## Hypothesis under test

bchoco06's root uniform relaxation LP is solved by the in-house Rust simplex
(`backend="simplex"`, the default node engine) → `iteration_limit`, bound None,
while HiGHS on the byte-identical matrix → optimal ≈ 1.0. The G6 hypothesis: the
`-4.941e-324` subnormal lower bounds on `x^2`/`x*y` aux columns (interval-underflow
of a true 0) plus subnormal matrix coefficients are the conditioning poison;
flushing `|v| < 1e-300 → 0` before the solve lets the existing geometric-mean
equilibration compress the real 1e10 range and the simplex converges.

**Kill criterion (from the task):** if the flush does NOT make the in-house simplex
converge, STOP — the fix is a deeper Rust linear-algebra/refactorization problem,
not a cleanup pass.

## Entry-experiment result — kill criterion MET

Reproduce: `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 PYTHONPATH=$PWD/python python
discopt_benchmarks/scripts/g6_bchoco06_conditioning_probe.py`

| stage of the bchoco06 root matrix | A nonzero spread (max / min) | in-house simplex | HiGHS |
|---|---|---|---|
| raw (as shipped) | 1.0e10 / 4.9e-324 = inf | `iteration_limit`, None | optimal, **0.99998** |
| subnormals flushed (`|v|<1e-300 → 0`) | 1.0e10 / 1.0e-10 = 1e20 | **`iteration_limit`, None** | optimal, 0.99998 |
| flushed + Ruiz equilibrated (20/50/100 sweeps) | 1.95 / 1.56e-12 = **1.25e12** | **`iteration_limit`, None** | optimal, ~1.0 |

- 20 subnormal `A` nonzeros + 29 subnormal bounds; flushing **all** of them leaves
  the simplex at `iteration_limit`.
- The subnormals are not the poison: after the flush the smallest nonzero is a
  genuine McCormick coefficient `1e-10`, spread `1e20`. Ruiz equilibration (already
  run by the shipped `_solve_lp_warm_equilibrated` path) compresses this only to a
  residual `~1.25e12` and can go no lower (50/100 sweeps identical) — intrinsic
  ill-conditioning of the recursive-McCormick envelope over degree-5 products on the
  wide/unbounded box, not a scaling deficiency.
- On the equilibrated matrix the raw Rust warm simplex returns `None` (iter-limit at
  its 100k-pivot cap / stall guard); the Neumaier–Shcherbina `safe_bound` side
  channel is also `None`. HiGHS solves the identical raw/flushed/equilibrated matrix
  to optimal ≈ 1.0.

## Verdict & disposition

The defect is Rust linear-algebra / refactorization robustness
(`crates/discopt-core/src/lp/simplex/`) — HiGHS handles a `~1e12`-conditioned basis
(LU refactorization, Harris ratio test, pivoting tolerances) and the in-house
simplex cycles/stalls to the pivot cap. **No band-aid shipped:** the subnormal flush
is a proven no-op for convergence on this class and has no other measured
beneficiary, so it would be a dead threshold (CLAUDE.md §3). The Rust-layer fix is
escalated to **issue #649** (its own plan, full bound-changing gate +
`cargo test -p discopt-core`).

## Changes

- `docs/dev/g5-family-d-diagnoses.md` — "G6 update" falsification record
  (performance-plan §6 house style: hypothesis → measurement → verdict → follow-up).
- `docs/dev/baron-gap-plan.md` — §10 G6 verdict stamp pointing to #649.
- `discopt_benchmarks/scripts/g6_bchoco06_conditioning_probe.py` — committed,
  lint-clean reproduction of the entry experiment (+ its per-file ruff ignore in
  `discopt_benchmarks/pyproject.toml`).

## What was run

- Entry experiment reproduced 3× (raw / flushed / equilibrated), numbers above.
- `ruff check` on the new probe: clean (per-file-ignore for LP-matrix notation,
  matching the existing `scripts/cut1_*` convention).
- No solver / LP-layer / Rust code touched → no bound can change → the
  bound-changing gate does not apply to this PR (it applies to the #649 fix).

## Not for merge yet

Left open for review. This PR ships the falsification record, not a fix.
