### PR TITLE
chore(#581): wire 4 untracked flags into the graduation-gate ARM registry

### DIFF
--- a/discopt_benchmarks/scripts/generality_sweep.py
+++ b/discopt_benchmarks/scripts/generality_sweep.py
@@ -150,6 +150,42 @@ ARMS: dict[str, dict] = {
         "struct_attr": None,
         "regime": "bound_changing",
     },
+    # --- #581 flags wired in 2026-07-15 (previously untracked by the gate) ------ #
+    # LU density route (#557): a factorization *route*. A ``bound_neutral`` guess was
+    # FALSIFIED by the gate — the alternate route reorders pivots, so it is NOT
+    # byte-identical: node_count drifts (nvs02 101->337) and the objective drifts by
+    # ~1e-7 (oaer 1.96e-7, st_e13 3.46e-7), both from floating-point roundoff, well
+    # within the 1e-6 abs / 1e-4 rel tolerance. So it is ``bound_changing`` (certified
+    # objective enforced TO TOLERANCE + oracle bracket; node drift a perf note the
+    # graduation PR must weigh — the nvs02 +234% node case is a real trade-off). No
+    # cheap static structure proxy (density is a runtime property).
+    "lu_density_route": {
+        "env": {"DISCOPT_LU_DENSITY_ROUTE": "1"},
+        "struct_attr": None,
+        "regime": "bound_changing",
+    },
+    # Square-cost gate (THRU-3): when ON it *shortens* the per-node x**2 tangent
+    # loop, dropping cuts → a legitimately looser relaxation (more nodes, same valid
+    # bound) → ``bound_changing`` (objective + oracle-bracket enforced; node drift a
+    # perf note).
+    "square_cost_gate": {
+        "env": {"DISCOPT_SQUARE_COST_GATE": "1"},
+        "struct_attr": None,
+        "regime": "bound_changing",
+    },
+    # Lifted-FBBT: adds an FBBT sweep + conditional relaxation rebuild per node →
+    # tighter boxes / stronger bound (wins ex1252) → ``bound_changing``.
+    "lifted_fbbt": {
+        "env": {"DISCOPT_LIFTED_FBBT": "1"},
+        "struct_attr": None,
+        "regime": "bound_changing",
+    },
+    # alpha-BB alongside the LP: adds an extra (valid) dual bound → ``bound_changing``.
+    "alphabb_with_lp": {
+        "env": {"DISCOPT_ALPHABB_WITH_LP": "1"},
+        "struct_attr": None,
+        "regime": "bound_changing",
+    },
     "all": {"env": dict(FLAGS_ON), "struct_attr": None, "regime": "bound_changing"},
 }
 
@@ -162,6 +198,11 @@ GRADUATION_ARMS = (
     "psd_cost_gate",
     "lift_zero_spanning",
     "lift_loose_products",
+    # #581 flags wired in 2026-07-15
+    "lu_density_route",
+    "square_cost_gate",
+    "lifted_fbbt",
+    "alphabb_with_lp",
 )
 
 # correctness tolerance (matches conftest abs=1e-6, rel=1e-4)


### PR DESCRIPTION
Wires the 4 live-but-untracked `#581` flags into the flag-graduation harness so the gate can score them.

## Why
`#581` tracks 7 default-OFF flags; the graduation instrument (`discopt_benchmarks/scripts/graduation_gate.py` + `generality_sweep.GRADUATION_ARMS`) only registered 5 arms — and only **2** overlapped `#581`. Four of `#581`'s flags had no ARM, so the gate could not run them. (Confirmed during the `#581` reconciliation: all 7 flags are live post-#636; the issue body is now updated.)

## Change (harness-only, no solver math)
Add 4 ARMs to `generality_sweep.ARMS` + `GRADUATION_ARMS`:

| arm | env flag | regime |
|---|---|---|
| `lu_density_route` | `DISCOPT_LU_DENSITY_ROUTE` | bound_changing |
| `square_cost_gate` | `DISCOPT_SQUARE_COST_GATE` | bound_changing |
| `lifted_fbbt` | `DISCOPT_LIFTED_FBBT` | bound_changing |
| `alphabb_with_lp` | `DISCOPT_ALPHABB_WITH_LP` | bound_changing |

**Regime note (measurement over guess):** `square_cost_gate`/`lifted_fbbt`/`alphabb_with_lp` genuinely change the relaxation → `bound_changing`. `lu_density_route` I initially guessed `bound_neutral` (a factorization route "should" be exact-equivalent) — the gate **falsified** that: the alternate route reorders pivots, so node_count drifts (nvs02 101→337) and the objective drifts ~1e-7 (oaer 1.96e-7, st_e13 3.46e-7), both within the 1e-6 abs / 1e-4 rel tolerance. So it's `bound_changing` (objective enforced *to tolerance* + oracle bracket; node drift a perf note the eventual flip PR must weigh — the nvs02 +234% node case is a real trade-off).

## Verification
All 4 arms execute end-to-end and emit verdicts:
```
graduation_gate.py --flags lu_density_route,square_cost_gate,lifted_fbbt,alphabb_with_lp --n 3 --time-limit 10 --no-ledger
  → lu_density_route  eligible=YES  cert=neutral  (after regime fix)
  → square_cost_gate  eligible=YES  cert=neutral
  → lifted_fbbt       eligible=YES  cert=neutral
  → alphabb_with_lp   eligible=YES  cert=neutral
```
(N=3 on trivial instances just proves the mechanism runs — **not** a graduation signal. Real verdicts need the nightly N=100 on structure-carrying instances.)

## Follow-up (not in this PR)
Per the reconciled `#581`: run each gate at N=100 → verdict, then a flip PR per eligible flag (+ cert-baseline regen + 3-green streak). `DISCOPT_OBJ_BRANCH_PRIORITY` is already default-ON (GRADUATED). The 3 harness arms not in `#581` (`psd_cost_gate`, `lift_zero_spanning`, `lift_loose_products`) should be added to the issue table or a sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
