### PR TITLE
docs(#565): complete notebook nbformat normalization to 4.5

### DIFF
--- a/docs/notebooks/benchmark_dashboard.ipynb
+++ b/docs/notebooks/benchmark_dashboard.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "48eff1e34a88",
    "metadata": {},
    "source": [
     "# Benchmark Dashboard\n",
@@ -15,12 +16,12 @@
     "The benchmarking methodology follows the Dolan-Moré performance profile\n",
     "framework {cite:p}`DolanMore2002` with shifted geometric mean timing\n",
     "as recommended by {cite:t}`Mittelmann2023`."
-   ],
-   "id": "48eff1e34a88"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "ba84e5418b38",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:43:36.361442Z",
@@ -45,11 +46,11 @@
     "%matplotlib inline\n",
     "plt.rcParams[\"figure.figsize\"] = (10, 6)\n",
     "plt.rcParams[\"figure.dpi\"] = 100"
-   ],
-   "id": "ba84e5418b38"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c80533685c84",
    "metadata": {},
    "source": [
     "## Load Results\n",
@@ -57,12 +58,12 @@
     "Load the most recent JSON results from the `results/` directory.\n",
     "Each JSON file contains a `BenchmarkResults` serialization with\n",
     "per-solver, per-instance solve data."
-   ],
-   "id": "c80533685c84"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "b7df66e7c9d8",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:43:36.808508Z",
@@ -109,22 +110,22 @@
     "        print(f\"No results found for {cat}\")\n",
     "\n",
     "print(f\"\\nLoaded {len(all_data)} categories\")"
-   ],
-   "id": "b7df66e7c9d8"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d70f0e271a71",
    "metadata": {},
    "source": [
     "## Build DataFrames\n",
     "\n",
     "Convert JSON results into pandas DataFrames for analysis."
-   ],
-   "id": "d70f0e271a71"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "d9f11bb455b8",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:43:36.827710Z",
@@ -293,12 +294,12 @@
     "print(f\"Solvers: {df['solver'].unique().tolist()}\")\n",
     "print(f\"Categories: {df['category'].unique().tolist()}\")\n",
     "df.head()"
-   ],
-   "id": "d9f11bb455b8"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "e14f4e37b1c7",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:43:36.837522Z",
@@ -578,23 +579,23 @@
     ")\n",
     "summary[\"solve_rate\"] = summary[\"solved\"] / summary[\"total\"]\n",
     "summary"
-   ],
-   "id": "e14f4e37b1c7"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5dfdd4474159",
    "metadata": {},
    "source": [
     "## Performance Profiles\n",
     "\n",
     "Dolan-Moré performance profiles {cite:p}`DolanMore2002` show the fraction\n",
     "of problems solved within a factor $\\\\tau$ of the best solver's time."
-   ],
-   "id": "5dfdd4474159"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "5d59342792e3",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:43:36.871805Z",
@@ -684,11 +685,11 @@
     "    plt.show()\n",
     "else:\n",
     "    print(\"No data to plot\")"
-   ],
-   "id": "5d59342792e3"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b7901b2a2a1e",
    "metadata": {},
    "source": [
     "## Wall-Time Scatter Plots\n",
@@ -696,12 +697,12 @@
     "Pairwise solver comparison: each point is an instance,\n",
     "axes are log-scale solve times. Points below the diagonal\n",
     "indicate the x-axis solver is faster."
-   ],
-   "id": "b7901b2a2a1e"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "01376bebe32d",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:43:37.098234Z",
@@ -769,22 +770,22 @@
     "                pair_idx += 1\n",
     "        plt.tight_layout()\n",
     "        plt.show()"
-   ],
-   "id": "01376bebe32d"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "a5549080a376",
    "metadata": {},
    "source": [
     "## Iteration Count Comparison\n",
     "\n",
     "Bar chart comparing median iteration counts across solvers."
-   ],
-   "id": "a5549080a376"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "82d9daa7e9a0",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:43:37.420802Z",
@@ -838,23 +839,23 @@
     "    plt.show()\n",
     "else:\n",
     "    print(\"No iteration data available\")"
-   ],
-   "id": "82d9daa7e9a0"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "83ecd44b0eb9",
    "metadata": {},
    "source": [
     "## Gap Closure Analysis (Global Optimization)\n",
     "\n",
     "For global optimization instances, analyze the quality of bounds\n",
     "and the optimality gap at termination."
-   ],
-   "id": "83ecd44b0eb9"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "07a97c11730d",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:43:37.454041Z",
@@ -910,22 +911,22 @@
     "    plt.show()\n",
     "else:\n",
     "    print(\"No global_opt data available\")"
-   ],
-   "id": "07a97c11730d"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4334ba76f91a",
    "metadata": {},
    "source": [
     "## Historical Trends\n",
     "\n",
     "If JSONL history files are available, plot solved counts over time."
-   ],
-   "id": "4334ba76f91a"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "acc8f9546f55",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:43:37.457861Z",
@@ -995,8 +996,7 @@
     "        print(\"No history files found\")\n",
     "else:\n",
     "    print(\"No history directory found. Run benchmarks first.\")"
-   ],
-   "id": "acc8f9546f55"
+   ]
   }
  ],
  "metadata": {
@@ -1019,5 +1019,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/docs/notebooks/llm_integration.ipynb
+++ b/docs/notebooks/llm_integration.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "efa5da7ff691",
    "metadata": {},
    "source": [
     "# LLM Integration\n",
@@ -16,11 +17,11 @@
     "LLM features are **purely advisory** — they never affect solver correctness.\n",
     "All formulations pass through `model.validate()` before use.\n",
     "```"
-   ],
-   "id": "efa5da7ff691"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c34f967a0301",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -44,12 +45,12 @@
     "# Or use a local model (no API key needed):\n",
     "export DISCOPT_LLM_MODEL=\"ollama/llama3\"\n",
     "```"
-   ],
-   "id": "c34f967a0301"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "687a2f58d3bb",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:00.446286Z",
@@ -73,23 +74,23 @@
     "from discopt.llm import is_available\n",
     "\n",
     "print(f\"LLM features available: {is_available()}\")"
-   ],
-   "id": "687a2f58d3bb"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "47d88e3eff9d",
    "metadata": {},
    "source": [
     "## 1. Model Serialization\n",
     "\n",
     "The `serializer` module converts discopt models and results into structured text\n",
     "that LLMs can understand. This is used internally by all LLM features."
-   ],
-   "id": "47d88e3eff9d"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "561ac3a450fe",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:01.741754Z",
@@ -163,23 +164,23 @@
     "\n",
     "m.validate()\n",
     "print(serialize_model(m))"
-   ],
-   "id": "561ac3a450fe"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "84d801a66099",
    "metadata": {},
    "source": [
     "## 2. Solver Strategy Advisor\n",
     "\n",
     "The advisor analyzes model structure and recommends solver parameters using\n",
     "rule-based heuristics. With `llm=True`, it augments suggestions with LLM analysis."
-   ],
-   "id": "84d801a66099"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "88d79324d863",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:01.784932Z",
@@ -212,23 +213,23 @@
     "print(\"Recommended solver parameters:\")\n",
     "for key, value in params.items():\n",
     "    print(f\"  {key}: {value}\")"
-   ],
-   "id": "88d79324d863"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7e07c2fc2c31",
    "metadata": {},
    "source": [
     "## 3. Auto-Reformulation Analysis\n",
     "\n",
     "Analyze a model for reformulation opportunities: big-M tightening,\n",
     "McCormick partitioning, symmetry breaking, bound tightening."
-   ],
-   "id": "7e07c2fc2c31"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "c4a57bd0710a",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:01.790318Z",
@@ -258,11 +259,11 @@
     "for i, s in enumerate(suggestions, 1):\n",
     "    print(f\"{i}. [{s.category}] {s.description}\")\n",
     "    print(f\"   Impact: {s.impact}\\n\")"
-   ],
-   "id": "c4a57bd0710a"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "bdb73755d939",
    "metadata": {},
    "source": [
     "## 4. Result Explanation (requires API key)\n",
@@ -274,11 +275,11 @@
     "result = m.solve()\n",
     "print(result.explain(llm=True))\n",
     "```"
-   ],
-   "id": "bdb73755d939"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0c3bb95ea5ac",
    "metadata": {},
    "source": [
     "## 5. Infeasibility Diagnosis (requires API key)\n",
@@ -300,11 +301,11 @@
     "if result.status == \"infeasible\":\n",
     "    print(diagnose_infeasibility(m_bad, result))\n",
     "```"
-   ],
-   "id": "0c3bb95ea5ac"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f2589b5e9fd7",
    "metadata": {},
    "source": [
     "## 6. Conversational Model Building (requires API key)\n",
@@ -324,11 +325,11 @@
     "session.send(\"Solve it and explain the result\")\n",
     "session.close()\n",
     "```"
-   ],
-   "id": "f2589b5e9fd7"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4abad3424849",
    "metadata": {},
    "source": [
     "## 7. Natural Language Formulation (requires API key)\n",
@@ -348,11 +349,11 @@
     ")\n",
     "print(model.summary())\n",
     "```"
-   ],
-   "id": "4abad3424849"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "fd8def186eb3",
    "metadata": {},
    "source": [
     "## Provider Configuration\n",
@@ -374,8 +375,7 @@
     "import os\n",
     "os.environ[\"DISCOPT_LLM_MODEL\"] = \"ollama/llama3\"\n",
     "```"
-   ],
-   "id": "fd8def186eb3"
+   ]
   }
  ],
  "metadata": {
@@ -398,5 +398,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/docs/notebooks/minlp_examples.ipynb
+++ b/docs/notebooks/minlp_examples.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "fd3a72ccc1c8",
    "metadata": {},
    "source": [
     "# discopt MINLP Examples\n",
@@ -13,12 +14,12 @@
     "3. **MINLPLib** instances loaded from `.nl` files\n",
     "\n",
     "For each example, we verify the solution against known optimal values."
-   ],
-   "id": "fd3a72ccc1c8"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "ea4d48fcecec",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:03.916773Z",
@@ -46,11 +47,11 @@
     "import numpy as np\n",
     "\n",
     "print(\"discopt loaded successfully\")"
-   ],
-   "id": "ea4d48fcecec"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "de47ff48c35b",
    "metadata": {},
    "source": [
     "## 1. Unconstrained Quadratic (NLP)\n",
@@ -58,12 +59,12 @@
     "$$\\min_{x,y} \\; (x - 2)^2 + (y + 1)^2, \\quad x, y \\in [-5, 5]$$\n",
     "\n",
     "**Known optimal:** $x^* = 2, \\; y^* = -1, \\; f^* = 0$"
-   ],
-   "id": "de47ff48c35b"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "151cb6e5a463",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:04.116145Z",
@@ -98,11 +99,11 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 2.0)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: -1.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ],
-   "id": "151cb6e5a463"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "84862d8e8abe",
    "metadata": {},
    "source": [
     "## 2. Rosenbrock Function (NLP)\n",
@@ -110,12 +111,12 @@
     "$$\\min_{x,y} \\; (1 - x)^2 + 100(y - x^2)^2, \\quad x, y \\in [-5, 5]$$\n",
     "\n",
     "The classic banana-shaped valley. **Known optimal:** $x^* = 1, \\; y^* = 1, \\; f^* = 0$"
-   ],
-   "id": "84862d8e8abe"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "24ae8964d2da",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:04.761535Z",
@@ -157,11 +158,11 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 1.0)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: 1.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ],
-   "id": "24ae8964d2da"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0d672bed0ff2",
    "metadata": {},
    "source": [
     "## 3. Constrained Quadratic with Inequality (NLP)\n",
@@ -169,12 +170,12 @@
     "$$\\min_{x,y} \\; x^2 + y^2 \\quad \\text{s.t.} \\quad x + y \\geq 1, \\quad x, y \\in [-5, 5]$$\n",
     "\n",
     "**Known optimal:** $x^* = y^* = 0.5, \\; f^* = 0.5$"
-   ],
-   "id": "0d672bed0ff2"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "669c913247eb",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:04.846410Z",
@@ -210,11 +211,11 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 0.5)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: 0.5)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ],
-   "id": "669c913247eb"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "2aac29f2d784",
    "metadata": {},
    "source": [
     "## 4. Nonlinear Equality Constraint (NLP)\n",
@@ -222,12 +223,12 @@
     "$$\\min_{x,y} \\; x^2 + y^2 \\quad \\text{s.t.} \\quad xy = 1, \\quad x, y \\in [0.1, 5]$$\n",
     "\n",
     "**Known optimal:** $x^* = y^* = 1, \\; f^* = 2$"
-   ],
-   "id": "2aac29f2d784"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "abe934dde8d4",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:04.876286Z",
@@ -263,11 +264,11 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 1.0)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: 1.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ],
-   "id": "abe934dde8d4"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e63575a7d40f",
    "metadata": {},
    "source": [
     "## 5. Exponential NLP\n",
@@ -275,12 +276,12 @@
     "$$\\min_{x,y} \\; e^x + y^2 \\quad \\text{s.t.} \\quad x + y \\geq 1, \\quad x, y \\in [-2, 2]$$\n",
     "\n",
     "From KKT conditions: $e^x = 2y$ and $x + y = 1$, giving $f^* \\approx 1.8395$."
-   ],
-   "id": "e63575a7d40f"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "0e1462f52aae",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:04.970238Z",
@@ -316,11 +317,11 @@
     "print(f\"x = {result.value(x):.6f}\")\n",
     "print(f\"y = {result.value(y):.6f}\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ],
-   "id": "0e1462f52aae"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "766738e9ef38",
    "metadata": {},
    "source": [
     "## 6. Simple MINLP (Branch & Bound)\n",
@@ -330,12 +331,12 @@
     "The binary variable $x_3$ is minimized, so $x_3^* = 0$. The continuous part reduces to a constrained quadratic.\n",
     "\n",
     "**Known optimal:** $x_1^* = x_2^* = 0.5, \\; x_3^* = 0, \\; f^* = 0.5$"
-   ],
-   "id": "766738e9ef38"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "dd09574f2087",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:05.059307Z",
@@ -375,11 +376,11 @@
     "print(f\"x2 = {result.value(x2):.6f}  (expected: 0.5)\")\n",
     "print(f\"x3 = {result.value(x3):.6f}  (expected: 0.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s | Nodes: {result.node_count}\")"
-   ],
-   "id": "dd09574f2087"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "15d987c288b5",
    "metadata": {},
    "source": [
     "## 7. Binary Knapsack-like MINLP\n",
@@ -387,12 +388,12 @@
     "$$\\min_{x, y_1, y_2} \\; (x - 3)^2 + 2 y_1 + 3 y_2 \\quad \\text{s.t.} \\quad x \\leq 5 y_1, \\; x \\leq 4 y_2, \\; x \\in [0, 5], \\; y_1, y_2 \\in \\{0, 1\\}$$\n",
     "\n",
     "**Known optimal:** $x^* = 3, \\; y_1^* = 1, \\; y_2^* = 1, \\; f^* = 5.0$"
-   ],
-   "id": "15d987c288b5"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "4594f9e467ec",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:06.240917Z",
@@ -432,11 +433,11 @@
     "print(f\"y1 = {result.value(y1):.6f}  (expected: 1.0)\")\n",
     "print(f\"y2 = {result.value(y2):.6f}  (expected: 1.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s | Nodes: {result.node_count}\")"
-   ],
-   "id": "4594f9e467ec"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "2d5bdeda55fd",
    "metadata": {},
    "source": [
     "## 8. Integer Quadratic\n",
@@ -444,12 +445,12 @@
     "$$\\min_{n, x} \\; (x - 2.7)^2 + (n - 3)^2 \\quad \\text{s.t.} \\quad x + n \\leq 6, \\; x \\in [0, 5], \\; n \\in \\{0, 1, \\ldots, 5\\}$$\n",
     "\n",
     "**Known optimal:** $x^* = 2.7, \\; n^* = 3, \\; f^* = 0.0$"
-   ],
-   "id": "2d5bdeda55fd"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "707b3b82814d",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:07.232151Z",
@@ -485,11 +486,11 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 2.7)\")\n",
     "print(f\"n = {result.value(n):.6f}  (expected: 3.0)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s | Nodes: {result.node_count}\")"
-   ],
-   "id": "707b3b82814d"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ee99f21beb8c",
    "metadata": {},
    "source": [
     "## 9. Logarithmic NLP\n",
@@ -497,12 +498,12 @@
     "$$\\min_{x,y} \\; -\\log(x) - \\log(y) \\quad \\text{s.t.} \\quad x + y \\leq 1, \\; x, y \\in [0.01, 0.99]$$\n",
     "\n",
     "**Known optimal:** $x^* = y^* = 0.5, \\; f^* = 2 \\ln(2) \\approx 1.3863$"
-   ],
-   "id": "ee99f21beb8c"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "5bdaba889327",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:07.463202Z",
@@ -541,11 +542,11 @@
     "print(f\"x = {result.value(x):.6f}  (expected: 0.5)\")\n",
     "print(f\"y = {result.value(y):.6f}  (expected: 0.5)\")\n",
     "print(f\"Time:      {result.wall_time:.3f}s\")"
-   ],
-   "id": "5bdaba889327"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "17f3ec544e44",
    "metadata": {},
    "source": [
     "---\n",
@@ -555,12 +556,12 @@
     "discopt can also load standard `.nl` format files from the MINLPLib {cite:p}`Bussieck2003` benchmark library. These are parsed by the Rust backend and solved through the same B&B engine.\n",
     "\n",
     "Below we solve several MINLPLib instances and compare against published optimal values."
-   ],
-   "id": "17f3ec544e44"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "137c5367e26e",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:07.549640Z",
@@ -655,22 +656,22 @@
     "    )\n",
     "\n",
     "print(f\"\\nCorrect: {n_correct}/{n_total}\")"
-   ],
-   "id": "137c5367e26e"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "3a80e89b24c0",
    "metadata": {},
    "source": [
     "## 11. Direct Comparison: discopt vs. cyipopt\n",
     "\n",
     "For continuous NLP problems, we can compare discopt's solution against a raw cyipopt (Ipopt {cite:p}`Wachter2006`) solve to verify correctness."
-   ],
-   "id": "3a80e89b24c0"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "c738cd71edd3",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:49:07.554306Z",
@@ -786,11 +787,11 @@
     "print(f\"x difference:        {x_diff:.2e}\")\n",
     "print(f\"y difference:        {y_diff:.2e}\")\n",
     "print(f\"Match: {'YES' if obj_diff < 1e-6 else 'NO'}\")"
-   ],
-   "id": "c738cd71edd3"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "134d78097c5b",
    "metadata": {},
    "source": [
     "## 12. Summary of the discopt API\n",
@@ -829,8 +830,7 @@
     "Available nonlinear functions: `dm.exp`, `dm.log`, `dm.sqrt`, `dm.sin`, `dm.cos`, `dm.tan`, `dm.abs`\n",
     "\n",
     "Load from files: `dm.from_nl(\"problem.nl\")`"
-   ],
-   "id": "134d78097c5b"
+   ]
   }
  ],
  "metadata": {
@@ -853,5 +853,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/docs/notebooks/nn_embedding.ipynb
+++ b/docs/notebooks/nn_embedding.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "1af01718fa25",
    "metadata": {},
    "source": [
     "# Neural Network Embedding\n",
@@ -14,11 +15,11 @@
     "strong MIP formulations of {cite:p}`Anderson2020`, adapted to discopt's\n",
     "expression DAG, JAX automatic differentiation, and McCormick relaxations\n",
     "for spatial branch-and-bound."
-   ],
-   "id": "1af01718fa25"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "79c3cd373dda",
    "metadata": {},
    "source": [
     "## Overview\n",
@@ -32,23 +33,23 @@
     "  - `relu_bigm` — Big-M MILP formulation for ReLU networks using binary variables.\n",
     "  - `reduced_space` — Nested expressions with no intermediate variables (small networks).\n",
     "- **`load_onnx`**: Load trained models from ONNX format (covers scikit-learn, PyTorch, Keras exports)."
-   ],
-   "id": "79c3cd373dda"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "eaa5bdf011fe",
    "metadata": {},
    "source": [
     "## Example: Optimize over a trained neural network\n",
     "\n",
     "We'll train a small neural network to approximate a function,\n",
     "then find the input that minimizes the network's output subject to constraints."
-   ],
-   "id": "eaa5bdf011fe"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "9949ea878aab",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:50:04.418373Z",
@@ -67,11 +68,11 @@
     "    NetworkDefinition,\n",
     "    NNFormulation,\n",
     ")"
-   ],
-   "id": "9949ea878aab"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4aef39cc4ec8",
    "metadata": {},
    "source": [
     "### Step 1: Define a trained network\n",
@@ -79,12 +80,12 @@
     "Here we manually specify a small 2-layer ReLU network.\n",
     "In practice, you would train this with scikit-learn, PyTorch, etc.\n",
     "and load via `load_onnx()`."
-   ],
-   "id": "4aef39cc4ec8"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "bfdd973ed25e",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:50:04.595647Z",
@@ -121,11 +122,11 @@
     "\n",
     "print(f\"Network: {net.input_size} -> {net.layers[0].n_outputs} -> {net.output_size}\")\n",
     "print(f\"Forward pass at [0, 0]: {net.forward(np.array([0.0, 0.0]))}\")"
-   ],
-   "id": "bfdd973ed25e"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "11e401970a32",
    "metadata": {},
    "source": [
     "### Step 2: Embed in a discopt model with big-M formulation\n",
@@ -133,12 +134,12 @@
     "The `relu_bigm` strategy introduces binary variables for each ReLU neuron\n",
     "where the pre-activation value can be positive or negative.\n",
     "Interval arithmetic bound propagation computes tight big-M constants."
-   ],
-   "id": "11e401970a32"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "410ef8853eca",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:50:04.611035Z",
@@ -173,12 +174,12 @@
     "m.subject_to(nn.inputs[0] + nn.inputs[1] >= -1.0, name=\"sum_lb\")\n",
     "\n",
     "print(m.summary())"
-   ],
-   "id": "410ef8853eca"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "9919e5214892",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:50:04.613932Z",
@@ -211,11 +212,11 @@
     "x_opt = result.value(nn.inputs)\n",
     "nn_check = net.forward(x_opt)\n",
     "print(f\"NumPy forward check: {nn_check}\")"
-   ],
-   "id": "9919e5214892"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "3d856c143c04",
    "metadata": {},
    "source": [
     "### Step 3: Compare with smooth formulation\n",
@@ -223,12 +224,12 @@
     "For networks with smooth activations (sigmoid, tanh, softplus),\n",
     "the `full_space` strategy creates nonlinear constraints that get\n",
     "McCormick relaxations and JAX automatic differentiation."
-   ],
-   "id": "3d856c143c04"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "f7ff7b71fbcf",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:50:04.821514Z",
@@ -274,11 +275,11 @@
     "print(f\"Status: {result2.status}\")\n",
     "print(f\"Optimal objective: {result2.objective:.6f}\")\n",
     "print(f\"Optimal inputs: {result2.value(nn2.inputs)}\")"
-   ],
-   "id": "f7ff7b71fbcf"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "640cba7e2047",
    "metadata": {},
    "source": [
     "## Formulation strategies\n",
@@ -293,8 +294,7 @@
     "Choose `full_space` for smooth networks when you want tight McCormick\n",
     "relaxations for global optimization. Choose `reduced_space` for very\n",
     "small networks where compilation overhead matters."
-   ],
-   "id": "640cba7e2047"
+   ]
   }
  ],
  "metadata": {
@@ -317,5 +317,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/docs/notebooks/robust_adjustable.ipynb
+++ b/docs/notebooks/robust_adjustable.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "68db47573f34",
    "metadata": {},
    "source": [
     "# Adjustable Robust Optimization\n",
@@ -52,12 +53,12 @@
     "                        ↓\n",
     "                  Deterministic model: optimize over (x, y₀, Y_cols)\n",
     "```"
-   ],
-   "id": "68db47573f34"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "5c7aba482253",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:50:24.129239Z",
@@ -75,11 +76,11 @@
     "\n",
     "import discopt.modeling as dm\n",
     "from discopt.ro import AffineDecisionRule, BoxUncertaintySet, RobustCounterpart"
-   ],
-   "id": "5c7aba482253"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "bf8ca5c83f66",
    "metadata": {},
    "source": [
     "## Example 1 — Two-Stage Inventory Management\n",
@@ -92,12 +93,12 @@
     "$$\n",
     "\n",
     "We compare three approaches: nominal (ignore uncertainty), static robust (worst-case $d=100$), and adjustable robust (recourse adapts to realized demand)."
-   ],
-   "id": "bf8ca5c83f66"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "7c24b14ccc54",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:50:24.328968Z",
@@ -157,21 +158,21 @@
     "print(f\"\\nADR policy: Y0 = {r_adj.x['adr_Y0']:.4f}\")\n",
     "print(\"  Y0~0 means no adaptation (same as static)\")\n",
     "print(\"  Y0~1 would mean full adaptation to demand\")"
-   ],
-   "id": "7c24b14ccc54"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "146b70c82216",
    "metadata": {},
    "source": [
     "In this example, the here-and-now order $x$ is cheap (\\$2) while the emergency recourse $y$ is expensive (\\$8). The ADR recovers the static robust solution because the optimal strategy is to order everything upfront at the cheap price rather than wait. The ADR correctly sets $Y_0 \\approx 0$ (no adaptation), confirming that recourse has no value when the first-stage option dominates on cost.\n",
     "\n",
     "For ADR to strictly outperform static robust, the uncertainty must enter constraints in **opposing directions** so that static must over-hedge while the adaptive policy can compensate. The next example demonstrates this."
-   ],
-   "id": "146b70c82216"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ce2dfa17d78c",
    "metadata": {},
    "source": [
     "## Example 2 — ADR Beats Static: Opposing Uncertainty (Ben-Tal et al. 2004)\n",
@@ -183,12 +184,12 @@
     "$$\n",
     "\n",
     "The static solution must simultaneously hedge against $z = +1$ (constraint 1) and $z = -1$ (constraint 2), requiring $x = 2$. The ADR sets $y(z) = z$, which perfectly counteracts the uncertainty in both constraints, needing only $x = 1$. This is a 50% reduction in cost."
-   ],
-   "id": "ce2dfa17d78c"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "9f049f5d593c",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:50:24.742147Z",
@@ -253,11 +254,11 @@
     "    c1 = r_a.x[\"x\"] + y_val - (1 + z_val)\n",
     "    c2 = r_a.x[\"x\"] - y_val - (1 - z_val)\n",
     "    print(f\"  z={z_val:+.0f}: y={y_val:+.2f}, c1={c1:.2f}, c2={c2:.2f}\")"
-   ],
-   "id": "9f049f5d593c"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "04e5bdcda144",
    "metadata": {},
    "source": [
     "## API Summary\n",
@@ -306,8 +307,7 @@
     "- The policy matrix scales as $\\dim(y) \\times n_\\xi$ new scalar variables,\n",
     "  which can be large for high-dimensional problems.\n",
     "- Non-affine recourse (polynomial, piecewise-linear) is not yet supported."
-   ],
-   "id": "04e5bdcda144"
+   ]
   }
  ],
  "metadata": {
@@ -330,5 +330,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/docs/notebooks/tutorial_oa.ipynb
+++ b/docs/notebooks/tutorial_oa.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "ec621c28825d",
    "metadata": {},
    "source": [
     "# Outer Approximation Solver\n",
@@ -31,12 +32,12 @@
     "   - Generate OA cuts (tangent hyperplanes) at NLP solution\n",
     "   - If NLP infeasible: add feasibility cuts {cite:p}`Fletcher1994` or no-good cuts\n",
     "3. **Terminate** when gap converges or master becomes infeasible"
-   ],
-   "id": "ec621c28825d"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "2158283e5108",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:53:53.672712Z",
@@ -53,11 +54,11 @@
     "os.environ[\"JAX_ENABLE_X64\"] = \"1\"\n",
     "\n",
     "import discopt.modeling as dm"
-   ],
-   "id": "2158283e5108"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d5360b017967",
    "metadata": {},
    "source": [
     "## Example 1: Simple Convex MINLP\n",
@@ -66,12 +67,12 @@
     "$$\\text{s.t.} \\quad x_1 + x_2 \\geq 1, \\quad x_1^2 + x_2 \\leq 3, \\quad x_3 \\in \\{0,1\\}$$\n",
     "\n",
     "The optimal solution is $x_1 = x_2 = 0.5$, $x_3 = 0$, with objective 0.5."
-   ],
-   "id": "d5360b017967"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "b93f8c3bde45",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:53:53.842974Z",
@@ -113,11 +114,11 @@
     "print(f\"Objective: {result.objective:.4f}\")\n",
     "print(f\"Solution: {result.x}\")\n",
     "print(f\"Wall time: {result.wall_time:.2f}s\")"
-   ],
-   "id": "b93f8c3bde45"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0fe3d57db4bb",
    "metadata": {},
    "source": [
     "## Example 2: Quadratic Objective with Binary Activation\n",
@@ -127,12 +128,12 @@
     "\n",
     "$$\\min \\quad (x - 3)^2 + 2y_1 + 3y_2$$\n",
     "$$\\text{s.t.} \\quad y_1 + y_2 \\leq 1, \\quad x \\leq 2y_1 + 4y_2, \\quad x \\in [0, 5],\\; y_i \\in \\{0,1\\}$$"
-   ],
-   "id": "0fe3d57db4bb"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "8a4e9131cda0",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:53:55.195450Z",
@@ -164,23 +165,23 @@
     "result = m.solve(gdp_method=\"oa\", time_limit=60)\n",
     "print(f\"Status: {result.status}, Objective: {result.objective:.4f}\")\n",
     "print(f\"x={result.x['x']:.3f}, y1={result.x['y1']:.0f}, y2={result.x['y2']:.0f}\")"
-   ],
-   "id": "8a4e9131cda0"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "626b0e7be898",
    "metadata": {},
    "source": [
     "## Comparing OA with Branch & Bound\n",
     "\n",
     "Both solvers find the same optimum for convex MINLP, but OA is typically\n",
     "faster when the integer structure dominates."
-   ],
-   "id": "626b0e7be898"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "643c820ea588",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:54:55.451369Z",
@@ -235,11 +236,11 @@
     "bb_t = result_bb.wall_time\n",
     "print(f\"OA:  obj={oa_obj:.4f}, time={oa_t:.2f}s, status={result_oa.status}\")\n",
     "print(f\"B&B: obj={bb_obj:.4f}, time={bb_t:.2f}s, status={result_bb.status}\")"
-   ],
-   "id": "643c820ea588"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cd5fb5d5bbe9",
    "metadata": {},
    "source": [
     "## Extended Cutting Plane (ECP) Mode\n",
@@ -248,12 +249,12 @@
     "subproblem solves entirely. Instead, it generates OA cuts at the MILP\n",
     "master solution for violated nonlinear constraints. This is simpler but\n",
     "converges more slowly."
-   ],
-   "id": "cd5fb5d5bbe9"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "2047b1acd5e3",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:54:57.426075Z",
@@ -289,11 +290,11 @@
     "\n",
     "print(f\"ECP Status: {result_ecp.status}\")\n",
     "print(f\"ECP Objective: {result_ecp.objective}\")"
-   ],
-   "id": "2047b1acd5e3"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "970c1102d058",
    "metadata": {},
    "source": [
     "## Equality Relaxation\n",
@@ -302,12 +303,12 @@
     "can make the MILP master infeasible. The **Equality Relaxation** strategy\n",
     "{cite:p}`Viswanathan1990` relaxes these to inequalities in the OA cuts,\n",
     "restoring master feasibility."
-   ],
-   "id": "970c1102d058"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "690c16f29e28",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:54:58.066240Z",
@@ -341,11 +342,11 @@
     "\n",
     "result_er = m.solve(gdp_method=\"oa\", equality_relaxation=True, time_limit=60)\n",
     "print(f\"Status: {result_er.status}, Objective: {result_er.objective}\")"
-   ],
-   "id": "690c16f29e28"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4c5cb8ef706b",
    "metadata": {},
    "source": [
     "## Configuration Options\n",
@@ -360,11 +361,11 @@
     "| `equality_relaxation` | False | Relax nonlinear equalities |\n",
     "| `feasibility_cuts` | True | Gradient-based feasibility cuts |\n",
     "| `nlp_solver` | \"ipm\" | NLP backend: \"ipm\", \"ipopt\", \"pounce\" |"
-   ],
-   "id": "4c5cb8ef706b"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "6d7011ddabf2",
    "metadata": {},
    "source": [
     "## Limitations\n",
@@ -380,8 +381,7 @@
     "For a comprehensive review and comparison of convex MINLP solvers, see\n",
     "{cite:p}`Kronqvist2019`. The Bonmin solver {cite:p}`Bonami2009` provides\n",
     "multiple algorithmic variants including OA, NLP-BB, and hybrid approaches."
-   ],
-   "id": "6d7011ddabf2"
+   ]
   }
  ],
  "metadata": {
@@ -404,5 +404,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/docs/notebooks/tutorial_robust.ipynb
+++ b/docs/notebooks/tutorial_robust.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "5ea299b28e69",
    "metadata": {},
    "source": [
     "# Robust Optimization\n",
@@ -33,12 +34,12 @@
     "| **Box** | $\\lvert p_j - \\bar{p}_j \\rvert \\le \\delta_j$ | Substitute worst-case bound per component |\n",
     "| **Ellipsoidal** | $\\lVert \\Sigma^{-1/2}(p-\\bar{p}) \\rVert_2 \\le \\rho$ | Add SOC norm penalty {cite:p}`BenTal1999` |\n",
     "| **Polyhedral** | $A\\xi \\le b,\\; \\xi = p - \\bar{p}$ | LP dual auxiliary variables {cite:p}`BertsimasSim2004` |"
-   ],
-   "id": "5ea299b28e69"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "71c3667e6920",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:56:48.227715Z",
@@ -57,11 +58,11 @@
     "import discopt.modeling as dm\n",
     "import numpy as np\n",
     "from discopt.ro import BoxUncertaintySet, RobustCounterpart"
-   ],
-   "id": "71c3667e6920"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1e219ef46c0e",
    "metadata": {},
    "source": [
     "## Example 1 — Production Planning with Box Uncertainty\n",
@@ -74,12 +75,12 @@
     "$$\n",
     "\n",
     "Both costs $c$ and demand $d$ are uncertain: $c \\in [\\bar{c} - \\delta_c, \\bar{c} + \\delta_c]$ and $d \\in [\\bar{d} - \\delta_d, \\bar{d} + \\delta_d]$. We solve the nominal problem first, then compare with the robust counterpart."
-   ],
-   "id": "1e219ef46c0e"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "9a2b8cbb8896",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:56:48.436944Z",
@@ -141,11 +142,11 @@
     "    f\"\\nPrice of robustness: {r_rob.objective - r_nom.objective:.2f} \"\n",
     "    f\"({(r_rob.objective / r_nom.objective - 1) * 100:.1f}% increase)\"\n",
     ")"
-   ],
-   "id": "9a2b8cbb8896"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "a8d4a97d1cdd",
    "metadata": {},
    "source": [
     "## Example 2 — Robust Demand with Capacity Constraints\n",
@@ -158,12 +159,12 @@
     "$$\n",
     "\n",
     "With demand $d$ uncertain within $[40, 60]$ (nominal $\\bar{d} = 50$, $\\delta = 10$), the robust counterpart must ensure feasibility at $d = 60$."
-   ],
-   "id": "a8d4a97d1cdd"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "c5acb81b2c59",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:56:48.801141Z",
@@ -213,11 +214,11 @@
     "\n",
     "print(\"\\nThe robust solution orders 10 more units of the expensive product\")\n",
     "print(\"to guarantee feasibility if demand reaches 60.\")"
-   ],
-   "id": "c5acb81b2c59"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5fa182bd963a",
    "metadata": {},
    "source": [
     "## Example 3 — Portfolio with Ellipsoidal Uncertainty\n",
@@ -230,12 +231,12 @@
     "$$\n",
     "\n",
     "where returns $\\mu$ lie in an ellipsoidal set $\\{\\mu: \\lVert \\mu - \\bar{\\mu} \\rVert_2 \\le \\rho\\}$. The robust counterpart adds a norm penalty: $\\max_x\\; \\bar{\\mu}^\\top x - \\rho \\lVert x \\rVert_2$."
-   ],
-   "id": "5fa182bd963a"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "52b1996cc7ba",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:56:48.975702Z",
@@ -319,22 +320,22 @@
     "print(f\"\\nRobust:   return = {-r_rob.objective:.4f}\")\n",
     "print(f\"          x = {np.round(x_r, 4)}\")\n",
     "print(\"          (Diversified to hedge against return uncertainty)\")"
-   ],
-   "id": "52b1996cc7ba"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e3c45d5513de",
    "metadata": {},
    "source": [
     "## Multiple Uncertain Parameters\n",
     "\n",
     "Multiple parameters from the same uncertainty family can be passed as a list:"
-   ],
-   "id": "e3c45d5513de"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "77fa4f3f8e0e",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:56:49.213733Z",
@@ -381,11 +382,11 @@
     "print(\"\\nRobust constraints (worst-case constants substituted):\")\n",
     "for con in m_multi._constraints:\n",
     "    print(f\"  [{con.name}]  {con.body} {con.sense} {con.rhs}\")"
-   ],
-   "id": "77fa4f3f8e0e"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0ab26cfbf26c",
    "metadata": {},
    "source": [
     "## Example 4 — Drug Production (Ben-Tal et al. 2009, Example 1.1.1)\n",
@@ -405,12 +406,12 @@
     "$$\n",
     "\n",
     "The uncertain concentrations are $a_1 = 0.01 \\pm 0.5\\%$ and $a_2 = 0.02 \\pm 2\\%$. The published solutions are: nominal profit = \\$8,819.66 (using only RawII), robust profit = \\$8,294.57 (switching to the more reliable RawI), a 5.95% price of robustness."
-   ],
-   "id": "0ab26cfbf26c"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "a2d4657ad686",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-25T11:56:49.292162Z",
@@ -493,11 +494,11 @@
     "    \"\\ntighter uncertainty (0.5% vs 2%), making it more reliable despite\"\n",
     "    \"\\nhigher cost per gram.\"\n",
     ")"
-   ],
-   "id": "a2d4657ad686"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b24621797dfd",
    "metadata": {},
    "source": [
     "## API Summary\n",
@@ -547,8 +548,7 @@
     "\n",
     "For a full adjustable RO tutorial including multi-parameter recourse and vector recourse variables,\n",
     "see {doc}`robust_adjustable`."
-   ],
-   "id": "b24621797dfd"
+   ]
   }
  ],
  "metadata": {
@@ -571,5 +571,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

Closes #565.

The 110-warning docs build described in #565 was already fixed on `main` by PR #605 (`c2a0caf`, "docs: zero-warning jupyter-book build (132 → 0)") — verified here with a from-scratch `jupyter-book build docs/` on current `main`: **`build succeeded.` with zero warnings**.

This PR fixes the one residual item left behind by #605: it added cell `id`s to seven notebooks but left `nbformat_minor` at 4, where `id` is not a legal cell field. Those notebooks failed strict `nbformat.validate` with "Additional properties are not allowed ('id' was unexpected)" and are the remaining source of the `MissingIDFieldWarning`-class noise the issue mentions. The seven notebooks are bumped to nbformat 4.5 via nbformat's canonical writer:

- `docs/notebooks/benchmark_dashboard.ipynb`
- `docs/notebooks/llm_integration.ipynb`
- `docs/notebooks/minlp_examples.ipynb`
- `docs/notebooks/nn_embedding.ipynb`
- `docs/notebooks/robust_adjustable.ipynb`
- `docs/notebooks/tutorial_oa.ipynb`
- `docs/notebooks/tutorial_robust.ipynb`

Cell sources, outputs, ids, and execution counts are byte-identical before/after (verified programmatically) — the diff is only `nbformat_minor: 4 → 5` plus nbformat's canonical key ordering.

## Acceptance criteria from #565

- `make docs` (`jupyter-book build docs/`) succeeds — **zero warnings**, verified on a clean `docs/_build`.
- AutoAPI warnings — fixed in Python docstrings by #605 (`daemon.py`, `decomposition/benders/gbd.py`, `gp/__init__.py`, `heuristic_governor.py`, `solvers/oa.py`, `solvers/qp_pounce.py`, …).
- Standalone dev/design notes — excluded from the Sphinx source tree in `docs/_config.yml` (with a documented reason), which also removes the `cron` Pygments-lexer warning from `docs/dev/flag-graduation-protocol.md`.
- Citations — no duplicate keys in `references.bib`; every notebook citation key (including `BirgeLouveaux2011`) resolves.
- Notebook nbformat warnings — resolved by this PR; all 65 docs + manuscript notebooks now pass strict `nbformat.validate`.

## Testing

- Two full `jupyter-book build docs/` runs (including one from-scratch after `rm -rf docs/_build`): `build succeeded.` with zero warnings, both before and after the notebook change.
- Programmatic check that all 65 notebooks pass `nbformat.validate` and that the seven edited notebooks are content-identical to `HEAD`.
- No Python/Rust code touched, so `pytest -m smoke` / `cargo test` are not applicable to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiKLnn5SGqzen9bf7zj2jU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiKLnn5SGqzen9bf7zj2jU)_