### PR TITLE
fix(mpec): implement elementwise vector/array complementarity

### DIFF
--- a/docs/notebooks/complementarity_mpec.ipynb
+++ b/docs/notebooks/complementarity_mpec.ipynb
@@ -299,6 +299,54 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Vectorized (elementwise) complementarity\n",
+    "\n",
+    "Equilibrium and KKT systems rarely have a single complementarity pair — they\n",
+    "have one per constraint or per commodity. `complementarity` accepts array\n",
+    "operands and treats them **elementwise** {cite:p}`LuoPangRalph1996`: for every\n",
+    "index $i$ independently,\n",
+    "\n",
+    "$$ 0 \\le x_i \\;\\perp\\; y_i \\ge 0 \\qquad (x_i\\,y_i = 0,\\; x_i,y_i \\ge 0). $$\n",
+    "\n",
+    "Each index becomes its own $(x_i=0)\\lor(y_i=0)$ disjunction, so the solver may\n",
+    "choose a *different* active side per index. This is strictly different from — and\n",
+    "not captured by — a single \"all $x=0$ or all $y=0$\" choice.\n",
+    "\n",
+    "The instance below makes the distinction observable. The objective wants\n",
+    "$y_0=5$ (forcing $x_0=0$) for the first pair but $x_1=5$ (forcing $y_1=0$) for\n",
+    "the second — a **mixed** selection. The elementwise optimum is $0$; an\n",
+    "all-or-nothing encoding would be stuck at $\\approx 25$.\n"
+   ],
+   "id": "vec-compl-md"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 2\n",
+    "mv = dm.Model(\"vector_mpec\")\n",
+    "xv = mv.continuous(\"x\", shape=n, lb=0, ub=10)\n",
+    "yv = mv.continuous(\"y\", shape=n, lb=0, ub=10)\n",
+    "# Pair 0 pulls y0 -> 5 (so x0 = 0); pair 1 pulls x1 -> 5 (so y1 = 0).\n",
+    "mv.minimize((yv[0] - 5) ** 2 + (xv[1] - 5) ** 2)\n",
+    "mv.complementarity(xv, yv)          # one call, n elementwise pairs\n",
+    "res = mv.solve()\n",
+    "\n",
+    "xs = np.asarray(res.x[\"x\"], dtype=float)\n",
+    "ys = np.asarray(res.x[\"y\"], dtype=float)\n",
+    "print(\"objective:\", round(float(res.objective), 6))\n",
+    "print(\"x:\", np.round(xs, 4))\n",
+    "print(\"y:\", np.round(ys, 4))\n",
+    "print(\"elementwise products x_i*y_i:\", np.round(xs * ys, 6))\n"
+   ],
+   "id": "vec-compl-code"
+  },
+  {
+   "cell_type": "markdown",
    "id": "6150e443",
    "metadata": {},
    "source": [

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2786,10 +2786,17 @@ class Model:
         ``Model._complementarities``) and immediately reformulated into ordinary
         constraints solved by :meth:`solve`.
 
+        Vector/array operands are complementarity **elementwise**: for every
+        index ``i`` independently, ``x_i · y_i == 0`` with ``x_i, y_i >= 0`` (a
+        separate disjunction per index — *not* a single "all ``x`` zero or all
+        ``y`` zero" choice). A scalar side broadcasts against a vector side;
+        incompatible shapes are rejected.
+
         Parameters
         ----------
         x, y : Expression
-            The complementary pair. Both are constrained non-negative.
+            The complementary pair. Both are constrained non-negative. May be
+            scalars or equally-shaped (or scalar-broadcastable) arrays.
         method : {"gdp", "sos1"}, default "gdp"
             Reformulation. ``"gdp"`` lowers to the exact disjunction
             ``(x == 0) ∨ (y == 0)`` (big-M with a selector binary), so

--- a/python/discopt/mpec.py
+++ b/python/discopt/mpec.py
@@ -71,6 +71,75 @@ def complementarity(f: Expression, g: Expression, name: Optional[str] = None) ->
     return Complementarity(f, g, name)
 
 
+# ─────────────────────────── scalarization ────────────────────────────
+
+
+def _elem_shape(model: Model, expr: Expression) -> tuple[int, ...]:
+    """Static element shape of ``expr`` (``()`` for a scalar) via interval eval."""
+    from discopt._jax.convexity.interval_eval import evaluate_interval
+
+    iv = evaluate_interval(expr, model)
+    return tuple(int(d) for d in np.asarray(iv.lo).shape)
+
+
+def _aux_upper_bound(model: Model, expr: Expression) -> float:
+    """Finite upper bound for an SOS1 aux mirroring a nonnegative operand.
+
+    Uses the static interval enclosure of ``expr``; returns ``+inf`` when the
+    enclosure is non-finite so the SOS1→big-M lowering can raise its clear
+    "add a finite upper bound" error instead of silently fabricating a huge M.
+    """
+    from discopt._jax.convexity.interval_eval import evaluate_interval
+
+    try:
+        hi = float(np.max(np.asarray(evaluate_interval(expr, model).hi)))
+    except Exception:
+        return np.inf
+    return hi if np.isfinite(hi) else np.inf
+
+
+def _index(expr: Expression, shape: tuple[int, ...], k: int) -> Expression:
+    """Return element ``k`` (row-major) of a vector/array expression."""
+    idx = tuple(int(v) for v in np.unravel_index(k, shape))
+    return expr[idx[0]] if len(idx) == 1 else expr[idx]
+
+
+def _scalarize_pairs(model: Model, pairs: list[Complementarity]) -> list[Complementarity]:
+    """Expand vector/array complementarity pairs into elementwise scalar pairs.
+
+    ``0 <= f ⊥ g >= 0`` over arrays is complementarity *elementwise*: for every
+    index ``i`` independently, ``f_i·g_i = 0`` with ``f_i, g_i >= 0``. A single
+    disjunction over the whole vector (``all f == 0`` ∨ ``all g == 0``) is a
+    strictly stronger, wrong condition, so every reformulation scalarizes first.
+
+    A scalar side is broadcast against a vector side (e.g. one ``f`` complementary
+    to each ``g_i``). Shapes that are neither equal nor scalar-broadcastable are
+    rejected loudly rather than silently mis-encoded.
+    """
+    out: list[Complementarity] = []
+    for i, p in enumerate(pairs):
+        tag = p.name or f"compl{i}"
+        fs = _elem_shape(model, p.f)
+        gs = _elem_shape(model, p.g)
+        nf = int(np.prod(fs, dtype=np.int64)) if fs else 1
+        ng = int(np.prod(gs, dtype=np.int64)) if gs else 1
+        n = max(nf, ng)
+        if n == 1:
+            out.append(Complementarity(p.f, p.g, tag))
+            continue
+        if nf not in (1, n) or ng not in (1, n):
+            raise ValueError(
+                f"complementarity {tag!r} has incompatible operand shapes "
+                f"{fs} ⊥ {gs}: sides must have equal element counts, or one side "
+                "must be scalar to broadcast."
+            )
+        for k in range(n):
+            fk = p.f if nf == 1 else _index(p.f, fs, k)
+            gk = p.g if ng == 1 else _index(p.g, gs, k)
+            out.append(Complementarity(fk, gk, f"{tag}_{k}"))
+    return out
+
+
 # ─────────────────────────── reformulations ───────────────────────────
 
 
@@ -79,10 +148,10 @@ def reformulate_scholtes(model: Model, pairs: list[Complementarity], t) -> None:
 
     ``t`` may be a float or a :class:`~discopt.modeling.core.Parameter`; using a
     parameter lets :func:`solve_mpec` drive the homotopy without rebuilding the
-    model.
+    model. Vector/array pairs are complementarity elementwise (each ``f_i·g_i <= t``).
     """
-    for i, p in enumerate(pairs):
-        tag = p.name or f"compl{i}"
+    for p in _scalarize_pairs(model, pairs):
+        tag = p.name
         model.subject_to(p.f >= 0, name=f"{tag}_f_nonneg")
         model.subject_to(p.g >= 0, name=f"{tag}_g_nonneg")
         model.subject_to(p.f * p.g <= t, name=f"{tag}_reg")
@@ -93,17 +162,23 @@ def reformulate_sos1(model: Model, pairs: list[Complementarity]) -> None:
 
     Requires ``f >= 0`` and ``g >= 0`` and that at most one is nonzero. When
     ``f``/``g`` are plain variables they enter the SOS1 set directly; otherwise
-    nonnegative auxiliary variables ``af == f``, ``ag == g`` are introduced.
+    nonnegative auxiliary variables ``af == f``, ``ag == g`` are introduced. Vector/
+    array pairs are complementarity elementwise (one SOS1 set per index).
     """
-    for i, p in enumerate(pairs):
-        tag = p.name or f"compl{i}"
+    for p in _scalarize_pairs(model, pairs):
+        tag = p.name
         members: list[Variable] = []
         for side, expr in (("f", p.f), ("g", p.g)):
             if isinstance(expr, Variable) and expr.size == 1:
                 model.subject_to(expr >= 0, name=f"{tag}_{side}_nonneg")
                 members.append(expr)
             else:
-                aux = model.continuous(f"{tag}_{side}_aux", lb=0.0, ub=np.inf)
+                # Finite ub (from interval enclosure) keeps the SOS1→big-M
+                # linking exact; left at inf only when genuinely unbounded, so
+                # the downstream check surfaces a clear "add a finite ub" error.
+                aux = model.continuous(
+                    f"{tag}_{side}_aux", lb=0.0, ub=_aux_upper_bound(model, expr)
+                )
                 model.subject_to(aux == expr, name=f"{tag}_{side}_link")
                 members.append(aux)
         model.sos1(members, name=f"{tag}_sos1")
@@ -119,16 +194,19 @@ def reformulate_gdp(model: Model, pairs: list[Complementarity]) -> None:
     side is zero when the other is bounded away from zero (the backward
     complementarity rule).
 
-    Nonlinear or vector operands are lifted into a scalar auxiliary variable
+    Nonlinear operands are lifted into a scalar auxiliary variable
     ``u == expr`` (with finite interval bounds) so the disjunct ``u == 0`` stays
     linear and big-M is exact; plain scalar variables enter the disjunction
     directly. Lifting also keeps the nonlinear part as an ordinary smooth
     equality handled natively by the NLP relaxation — avoiding the perspective
     of a nonlinear equality, whose big-M relaxation is bounded unreliably and
     whose hull form often cannot be linearized.
+
+    Vector/array pairs are complementarity elementwise: each index becomes its own
+    ``(f_i==0) ∨ (g_i==0)`` disjunction, not a single all-zero-vector disjunction.
     """
-    for i, p in enumerate(pairs):
-        tag = p.name or f"compl{i}"
+    for p in _scalarize_pairs(model, pairs):
+        tag = p.name
         fv = _gdp_operand(model, p.f, tag, "f")
         gv = _gdp_operand(model, p.g, tag, "g")
         model.subject_to(fv >= 0, name=f"{tag}_f_nonneg")

--- a/python/discopt/mpec.py
+++ b/python/discopt/mpec.py
@@ -36,7 +36,7 @@ Example
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, cast
 
 import numpy as np
 
@@ -94,14 +94,15 @@ def _aux_upper_bound(model: Model, expr: Expression) -> float:
     try:
         hi = float(np.max(np.asarray(evaluate_interval(expr, model).hi)))
     except Exception:
-        return np.inf
-    return hi if np.isfinite(hi) else np.inf
+        return float("inf")
+    return hi if np.isfinite(hi) else float("inf")
 
 
 def _index(expr: Expression, shape: tuple[int, ...], k: int) -> Expression:
     """Return element ``k`` (row-major) of a vector/array expression."""
     idx = tuple(int(v) for v in np.unravel_index(k, shape))
-    return expr[idx[0]] if len(idx) == 1 else expr[idx]
+    elem = expr[idx[0]] if len(idx) == 1 else expr[idx]
+    return cast(Expression, elem)
 
 
 def _scalarize_pairs(model: Model, pairs: list[Complementarity]) -> list[Complementarity]:
@@ -206,7 +207,8 @@ def reformulate_gdp(model: Model, pairs: list[Complementarity]) -> None:
     ``(f_i==0) ∨ (g_i==0)`` disjunction, not a single all-zero-vector disjunction.
     """
     for p in _scalarize_pairs(model, pairs):
-        tag = p.name
+        # _scalarize_pairs always assigns a name; narrow Optional[str] -> str.
+        tag = p.name or "compl"
         fv = _gdp_operand(model, p.f, tag, "f")
         gv = _gdp_operand(model, p.g, tag, "g")
         model.subject_to(fv >= 0, name=f"{tag}_f_nonneg")

--- a/python/tests/test_mpec.py
+++ b/python/tests/test_mpec.py
@@ -120,3 +120,85 @@ def test_unknown_method_raises():
     m, x, y = _distance_model()
     with pytest.raises(ValueError):
         solve_mpec(m, [complementarity(x, y)], method="bogus")
+
+
+# ─────────────────── vector / elementwise complementarity ───────────────────
+#
+# 0 <= f ⊥ g >= 0 over arrays is complementarity *elementwise*: each index is an
+# independent (f_i == 0) ∨ (g_i == 0) disjunction. A single all-zero-vector
+# disjunction is strictly wrong. The mixed-selection instance below is the
+# regression probe: pair 0 must pick x0 == 0 (y0 free) while pair 1 must pick
+# y1 == 0 (x1 free). The old "all x zero OR all y zero" encoding could not
+# select differently per index and returned obj ≈ 25 instead of 0.
+
+
+def _mixed_selection_model(name: str) -> tuple[dm.Model, dm.Variable, dm.Variable]:
+    m = dm.Model(name)
+    x = m.continuous("x", shape=2, lb=0, ub=10)
+    y = m.continuous("y", shape=2, lb=0, ub=10)
+    # Optimum needs y0 = 5 (=> x0 = 0) and x1 = 5 (=> y1 = 0): a mixed selection.
+    m.minimize((y[0] - 5) ** 2 + (x[1] - 5) ** 2)
+    return m, x, y
+
+
+def test_vector_gdp_elementwise_mixed_selection():
+    m, x, y = _mixed_selection_model("vec_gdp")
+    m.complementarity(x, y)  # default gdp
+    res = m.solve()
+    assert res.objective is not None
+    assert abs(float(res.objective)) < 1e-3  # was ≈ 25 with the all-or-nothing bug
+    xv = np.asarray(res.x["x"], dtype=float)
+    yv = np.asarray(res.x["y"], dtype=float)
+    assert np.allclose(xv * yv, 0.0, atol=1e-4)  # elementwise complementarity holds
+
+
+def test_vector_sos1_elementwise_mixed_selection():
+    m, x, y = _mixed_selection_model("vec_sos1")
+    res = solve_mpec(m, [complementarity(x, y)], method="sos1")
+    assert abs(float(res.objective)) < 1e-3
+    xv = np.asarray(res.x["x"], dtype=float)
+    yv = np.asarray(res.x["y"], dtype=float)
+    assert np.allclose(xv * yv, 0.0, atol=1e-4)
+
+
+def test_vector_scholtes_elementwise_mixed_selection():
+    m, x, y = _mixed_selection_model("vec_scholtes")
+    res = solve_mpec(m, [complementarity(x, y)], method="scholtes")
+    assert res is not None and res.objective is not None
+    assert abs(float(res.objective)) < 1e-3
+
+
+def test_matrix_complementarity_elementwise():
+    m = dm.Model("mat")
+    a = m.continuous("a", shape=(2, 2), lb=0, ub=10)
+    b = m.continuous("b", shape=(2, 2), lb=0, ub=10)
+    # Each pair: min (a-2)^2 + (b-3)^2 s.t. a·b = 0 -> (a=0,b=3)=4 beats (a=2,b=0)=9.
+    obj = sum((a[i, j] - 2) ** 2 for i in range(2) for j in range(2))
+    obj += sum((b[i, j] - 3) ** 2 for i in range(2) for j in range(2))
+    m.minimize(obj)
+    m.complementarity(a, b)
+    res = m.solve()
+    assert abs(float(res.objective) - 16.0) < 1e-2  # 4 per element × 4 elements
+    av = np.asarray(res.x["a"], dtype=float)
+    bv = np.asarray(res.x["b"], dtype=float)
+    assert np.allclose(av * bv, 0.0, atol=1e-4)
+
+
+def test_scalar_broadcasts_against_vector():
+    m = dm.Model("bcast")
+    xs = m.continuous("xs", lb=0, ub=10)
+    ys = m.continuous("ys", shape=2, lb=0, ub=10)
+    # Both y components want to be > 0, so the shared xs must be driven to 0.
+    m.minimize((xs - 1) ** 2 + (ys[0] - 2) ** 2 + (ys[1] - 3) ** 2)
+    m.complementarity(xs, ys)
+    res = m.solve()
+    assert abs(float(res.objective) - 1.0) < 1e-3
+    assert abs(float(np.asarray(res.x["xs"]))) < 1e-3
+
+
+def test_incompatible_vector_shapes_raise():
+    m = dm.Model("bad")
+    p = m.continuous("p", shape=2, lb=0)
+    q = m.continuous("q", shape=3, lb=0)
+    with pytest.raises(ValueError, match="incompatible operand shapes"):
+        m.complementarity(p, q)


### PR DESCRIPTION
## Summary

Implement proper elementwise complementarity for vector and array operands in MPEC reformulations. Previously, complementarity pairs with array operands were treated as a single all-or-nothing disjunction (all `f==0` OR all `g==0`), which is mathematically incorrect. The fix scalarizes vector/array pairs into independent elementwise complementarities, allowing the solver to choose different active sides per index.

## Key Changes

- **New scalarization infrastructure** (`_scalarize_pairs`, `_elem_shape`, `_index`, `_aux_upper_bound`):
  - `_scalarize_pairs()` expands vector/array complementarity pairs into scalar elementwise pairs
  - Validates shape compatibility (equal shapes or scalar-broadcastable)
  - Rejects incompatible shapes with clear error messages
  - Preserves pair names with index suffixes (e.g., `compl0_0`, `compl0_1`)

- **Updated reformulation methods** to use scalarization:
  - `reformulate_scholtes()`: applies scalarization before adding regularization constraints
  - `reformulate_sos1()`: applies scalarization; adds finite upper bound computation via interval evaluation to keep big-M linking exact
  - `reformulate_gdp()`: applies scalarization; updated docstring to clarify elementwise semantics

- **Improved auxiliary variable bounds** in SOS1:
  - `_aux_upper_bound()` computes finite upper bounds from interval enclosure
  - Returns `+inf` only when genuinely unbounded, allowing downstream big-M lowering to surface a clear "add a finite upper bound" error instead of silently fabricating huge M values

- **Documentation and tests**:
  - Updated docstrings in `complementarity()` and all reformulation methods to document elementwise semantics
  - Added comprehensive test suite covering mixed-selection instances (the regression probe that fails with all-or-nothing encoding)
  - Tests for vector/matrix complementarity, scalar-vector broadcasting, and shape validation
  - Added notebook section demonstrating vectorized complementarity with a mixed-selection example

## Implementation Details

The scalarization respects the mathematical definition: `0 ≤ f ⊥ g ≥ 0` over arrays means for every index `i` independently, `f_i·g_i = 0` with `f_i, g_i ≥ 0`. This is strictly different from a single disjunction over the whole vector.

Shape broadcasting follows NumPy semantics: a scalar side broadcasts against a vector side (e.g., one `f` complementary to each `g_i`). Shapes that are neither equal nor scalar-broadcastable are rejected loudly.

The interval-based upper bound computation for SOS1 auxiliaries ensures the big-M relaxation remains exact while avoiding fabricated huge bounds for genuinely unbounded expressions.

https://claude.ai/code/session_0153uDmN7NaXegQv9AxToLs8