### PR TITLE
fix(#517): in-house numerical dual bound for hda-class no-bound nodes

### DIFF
--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -1658,6 +1658,25 @@ impl<'a> Simplex<'a> {
                     Vec::new()
                 }
             }
+            // #517: on a phase-2 `Numerical` breakdown also export the Optimal-style
+            // row-dual candidate `y = B⁻ᵀc_B` from the final basis. It is a *candidate*
+            // the caller verifies (a Neumaier–Shcherbina safe bound is valid for ANY
+            // `y`, so a drifted-basis dual only loosens it, never lifts it above the
+            // optimum) — it lets the hda-class no-bound nodes still contribute a sound
+            // lower bound. `IterLimit` and the `failed()` path keep the empty dual
+            // (no usable factorization to btran against).
+            LpStatus::Numerical => {
+                let mut y: Vec<f64> = self
+                    .basis
+                    .iter()
+                    .map(|&j| if j < self.n { self.c[j] } else { 0.0 })
+                    .collect();
+                if self.lu.btran(&mut y).is_ok() {
+                    y
+                } else {
+                    Vec::new()
+                }
+            }
             _ => Vec::new(),
         };
         let ray = std::mem::take(&mut self.unbounded_ray);

--- a/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
+++ b/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
@@ -85,7 +85,16 @@ certified `objective` **exactly unchanged** on the certifying panel + `cargo tes
 -p discopt-core`. Each is its own PR, not a rider on this investigation.
 
 **(A) Safe dual bound from the in-house basis (most tractable, additive) —
-VIABILITY CONFIRMED.** A valid *lower* bound needs only a dual point + directed
+IMPLEMENTED (flag `DISCOPT_NODE_NUMERICAL_DUAL_BOUND` /
+`SolverTuning.node_numerical_dual_bound`, default OFF).** `primal.rs` `assemble()`
+exports the Optimal-style dual candidate on a `Numerical` breakdown;
+`solve_lp_warm_std` computes the NS safe bound from it; `MilpRelaxationModel.solve`
+stashes it and attaches it as a last-resort floor when the whole in-house chain
+produced no bound; `MccormickLPRelaxer._solve_at_node_impl` reports it as a
+bound-only node. Measured: hda flag-ON → `bound = -1.80e10` (finite, `≤` optimum
+`-5964.53` — its first), flag-OFF → `bound=None` (baseline unchanged); clean
+certifying instances (alan, ex1221, nvs05) byte-identical. Tests:
+`python/tests/test_issue_517_numerical_dual_bound.py`. A valid *lower* bound needs only a dual point + directed
 rounding (Neumaier–Shcherbina), **not** a clean primal. When phase-2 drifts
 (audit `Bounds`/`Rows`) or breaks down, the engine still holds a basis and can
 export its dual `y = B⁻ᵀc_B`; feeding that through the in-repo NS certificate

--- a/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
+++ b/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
@@ -132,10 +132,26 @@ known oracle. *Perf caveat:* heatexch_gen3 flag-ON took 240 s vs 32 s OFF (the
 extra bounded nodes drive more per-node NS work) — default-OFF, so no CI impact;
 a reason the flag stays opt-in until (B) tightens the underlying solve.
 
+## 2b. Full verification (flag ON) — PR #662
+
+| suite | result |
+|---|---|
+| differential panel (16 inst, ON vs OFF) | `PASS` — all bounds ≤ oracle; 12 byte-identical |
+| adversarial recent-fixes (`-m slow`, ON) | 10 passed, 0 failed (hda oracle-checked to −5964.53) |
+| `test_issue_517_numerical_dual_bound.py` | 5 passed (hda first-bound, flag-off baseline, alan/ex1221 inert, default-off) |
+| smoke (`-m smoke`, ON) | 651 passed, 13 skipped, 0 failed |
+| `cargo test -p discopt-core` | 446 + 4 + 1 passed, 0 failed |
+
+Graduation: flag stays **default OFF** (bound-changing regime) until it accrues
+green runs and the perf caveat above is understood; a default-ON flip is a
+separate change.
+
 ## 3. Disposition
 
-* #517 stays **open**, re-scoped to the phase-2/factorization robustness blocker
-  in §1, with candidate fix (A) (safe in-house dual bound) as the next step.
+* Candidate (A) is **implemented and shipped default-OFF** on this branch (PR
+  #662). #517's literal acceptance (a finite first dual bound for hda) is met.
+* #517 stays **open** for the *tight*-bound goal — the phase-2/factorization
+  robustness blocker in §1 (candidate B) — since (A)'s bound is loose.
 * The external-HiGHS rescue and the subtol-fold are **not shipped** (branch reset;
   no source change to the relaxation or solver was retained).
 * The root cause was measured with temporary `DISCOPT_LP_DEBUG` instrumentation in

--- a/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
+++ b/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
@@ -84,16 +84,24 @@ ship under the bound-neutral regime (Dev-Philosophy #5): `node_count` and
 certified `objective` **exactly unchanged** on the certifying panel + `cargo test
 -p discopt-core`. Each is its own PR, not a rider on this investigation.
 
-**(A) Safe dual bound from the in-house basis (most tractable, additive).**
-A valid *lower* bound needs only a dual point + directed rounding
-(Neumaier–Shcherbina), **not** a clean primal. When phase-2 drifts (audit
-`Bounds`/`Rows`) or breaks down, the engine still holds a basis and can export its
-dual `y = B⁻ᵀc_B`; feeding that through the in-repo NS certificate
-(`milp_simplex._safe_lp_lower_bound_std`, already used elsewhere) would attach a
-sound (if loose) bound where today there is none — architecture-respecting (own
-dual, no HiGHS). *Risk to test first:* from a fully broken phase-2 basis the dual
-may yield only `-inf`; viability needs one instrumented probe (export the dual on
-the `Numerical`/audit-fail path and check the NS bound is finite on hda).
+**(A) Safe dual bound from the in-house basis (most tractable, additive) —
+VIABILITY CONFIRMED.** A valid *lower* bound needs only a dual point + directed
+rounding (Neumaier–Shcherbina), **not** a clean primal. When phase-2 drifts
+(audit `Bounds`/`Rows`) or breaks down, the engine still holds a basis and can
+export its dual `y = B⁻ᵀc_B`; feeding that through the in-repo NS certificate
+(`milp_simplex._safe_lp_lower_bound_std`, already used elsewhere) attaches a sound
+bound where today there is none — architecture-respecting (own dual, no HiGHS).
+
+*Probe result (env-gated `DISCOPT_LP_NUMERICAL_DUAL`, since reverted):* on hda's
+`Numerical` root-LP solves the exported dual yields a **finite** NS safe bound —
+measured `-1.447e6` and `-2.650e8`, both valid (`≤` optimum `-5964.53`). So the
+in-house dual survives the phase-2 breakdown well enough to certify hda's **first
+finite dual bound**, with no HiGHS. *Caveat:* the bound is **loose** (the basis is
+drifted), so it lifts `best_bound` off the `1e30` sentinel and satisfies #517's
+literal acceptance but gives little fathoming power on its own — a tight, useful
+bound still needs (B). To ship, wire the numerical-path dual → NS bound behind a
+flag (bound-changing regime, default OFF) with the differential-bound +
+feasible-point + no-fathom gates.
 
 **(B) Phase-2 / factorization robustness (the deeper fix).** Keep phase-2 from
 drifting/breaking down on the ill-conditioned basis — more frequent

--- a/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
+++ b/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
@@ -32,62 +32,85 @@ problem, not a coverage or reformulation gap.
   bound-changing lever with no independently-demonstrated benefit (Dev-Philosophy
   #4).
 
-## 1. Root cause (measured, reproducible)
+## 1. Root cause (measured by in-engine instrumentation on the *real* solve)
 
-hda's root relaxation LP is **3054 rows × 1145 cols** — grossly redundant (2.7×
-more inequality rows than columns; the lifted McCormick / interval-floor
-envelopes emit many dependent rows). Its coefficient spread is **4.13e17**
-(Arrhenius pre-exponentials `~6.3e10` against `exp(-261.67/x)` envelope atoms in
-`[2e-13, 2.4e-12]`).
+hda's root relaxation LP is **2974 rows × ~1145 cols**, coefficient spread
+~1e26 (Arrhenius pre-exponentials `~6.3e10` against `exp(-261.67/x)` envelope
+atoms in `[2e-13, 2.4e-12]`, plus LinForm cancellation residue near machine
+epsilon). The blocker was pinned by temporary `DISCOPT_LP_DEBUG` `eprintln`
+tracing in `primal.rs` (scaling entry, phase-1 residual, phase-2 exit, and the
+`assemble()` feasibility audit), driving a real `Model.solve()` — **not** a
+captured/replayed LP (an earlier capture-and-replay pass was invalidated: the
+captured arrays were a malformed/infeasible subset — HiGHS agreed they were
+infeasible — so every replay conclusion from it, including "phase-1
+false-certifies infeasible" and "presolve/redundancy is the lever", is
+**withdrawn**).
 
-On this LP the in-house simplex fails at **0 pivots** — it never gets past
-phase-1 / initial factorization:
+On the *real* per-node LP the trace is unambiguous:
 
-| path | verdict on hda's folded root LP |
-|---|---|
-| bare cold simplex, un-equilibrated (`solve_lp_py`) | **false `infeasible`**, 0 pivots, 0.2 s |
-| bare cold simplex, geometric-mean equilibrated (spread → 1.9e4) | **`numerical`**, 0 pivots, ~14 s |
-| per-node path `milp.solve(backend="simplex")` | **false `infeasible`**, ~0.5 s |
-| `MilpRelaxationModel._solve_lp_warm_equilibrated()` (the repo's ill-conditioned handler, built for nvs21) | **None** (numerical/iter-limit) after ~55 s |
-| SciPy-HiGHS (has presolve) | `optimal` (collapses the redundancy first) |
+```
+phase1 done: m=2974 artificial_infeas_sum=3.5e-15      <- phase 1 CONVERGES (feasible)
+phase2 loop -> Numerical                                <- phase 2 breaks down
+assemble: audit=Bounds -> final=Numerical obj=1.6e10    <- drifted point rejected
+assemble: audit=Rows   -> final=Numerical obj=-2.1e4    <- Ax=b residual rejected
+```
 
-Equilibration *fixes the conditioning* (4.13e17 → 1.9e4) but the engine still
-returns `numerical` at 0 pivots — so conditioning is **not** the whole story.
-The distinguishing factor is HiGHS's **presolve**, which removes the redundant /
-dependent rows before factorizing; the in-house engine has no such LP presolve
-and its (already hardened) phase-1 cannot factor the raw redundant basis.
+So:
 
-The in-house phase-1 is already sophisticated for this exact class — Farkas-ray
-certification to distinguish genuine from numerical false-infeasible, plus the
-C-39 `drive_out_basic_artificials` degenerate-cleanup pass
-(`crates/discopt-core/src/lp/simplex/primal.rs:769–851`). hda defeats even that
-and hits the honest, non-fathoming `LpStatus::Numerical` return
-(`primal.rs:846`). No unsound fathom ever occurs — the failure mode is *no
-bound*, never a wrong one (the C-38 no-Farkas-no-prune guard holds). TD-B's
-"stock reform yields an infeasible root LP" observation is this same numerical
-false-infeasible, not an invalid relaxation.
+1. **Phase 1 succeeds** — the LP is feasible and the engine finds a feasible
+   basis (artificial infeasibility ≈ 3.5e-15). Coverage, the equilibration noise
+   floor, and row redundancy are all **not** the blocker (all three earlier
+   hypotheses falsified).
+2. **Phase 2 fails** — the objective-optimizing simplex loop returns
+   `LpStatus::Numerical` (a mid-solve `refactorize`/`basic_values` breakdown on
+   the ill-conditioned basis), or returns a point that the `assemble()`
+   feasibility audit rejects as `Bounds` (a Harris ratio-test excursion past a
+   variable bound) or `Rows` (accumulated `Ax=b` drift). The assembled objectives
+   are garbage-scale (1.6e10, 5.8e6, −3.6e7), confirming numerical drift.
+3. The audit **soundly** downgrades every such solve to `Numerical` — it refuses
+   to certify a drifted point (no unsound bound is ever produced; the failure
+   mode is strictly *no bound*). Because *every* root-LP solve fails this way,
+   the node contributes no dual bound and the tree never fathoms.
 
-## 2. The real fix (scoped, not yet implemented — core-engine work)
+The blocker is therefore **phase-2 simplex + factorization robustness on hda's
+ill-conditioned basis**, not relaxation coverage, conditioning-of-the-matrix, or
+row redundancy.
 
-Give the in-house LP layer a **presolve that removes redundant / linearly
-dependent inequality rows** (and empty/singleton rows) before the simplex
-factorizes — the step HiGHS uses to make this LP tractable. Candidate home:
-`crates/discopt-core/src/lp/` (a new `presolve` alongside `basis.rs`), applied on
-the relaxation-LP solve path.
+## 2. Candidate fixes (scoped, not yet implemented — core-engine work)
 
-This is a **certificate-critical core-engine change** and must ship under the
-bound-neutral verification regime (Dev-Philosophy #5): assert `node_count` and
-certified `objective` **exactly unchanged** on the certifying panel for every
-instance that already solves, plus `cargo test -p discopt-core`, before it can be
-trusted. It is therefore its own PR, not a rider on this investigation.
+Since phase-1 already reaches a feasible basis, two sound directions target the
+phase-2/audit failure. Both are certificate-critical core-engine changes and must
+ship under the bound-neutral regime (Dev-Philosophy #5): `node_count` and
+certified `objective` **exactly unchanged** on the certifying panel + `cargo test
+-p discopt-core`. Each is its own PR, not a rider on this investigation.
+
+**(A) Safe dual bound from the in-house basis (most tractable, additive).**
+A valid *lower* bound needs only a dual point + directed rounding
+(Neumaier–Shcherbina), **not** a clean primal. When phase-2 drifts (audit
+`Bounds`/`Rows`) or breaks down, the engine still holds a basis and can export its
+dual `y = B⁻ᵀc_B`; feeding that through the in-repo NS certificate
+(`milp_simplex._safe_lp_lower_bound_std`, already used elsewhere) would attach a
+sound (if loose) bound where today there is none — architecture-respecting (own
+dual, no HiGHS). *Risk to test first:* from a fully broken phase-2 basis the dual
+may yield only `-inf`; viability needs one instrumented probe (export the dual on
+the `Numerical`/audit-fail path and check the NS bound is finite on hda).
+
+**(B) Phase-2 / factorization robustness (the deeper fix).** Keep phase-2 from
+drifting/breaking down on the ill-conditioned basis — more frequent
+refactorization, tighter Harris ratio-test tolerances, or a better-conditioned
+basis factorization (the `#557` density-aware LU route, or basis scaling). Higher
+blast radius; only if (A) proves insufficient.
 
 Acceptance for #517 (unchanged): hda reports a **finite** dual bound (its first),
 `bound ≤ −5964.534084` (the published optimum), with no panel regression.
 
 ## 3. Disposition
 
-* #517 stays **open**, re-scoped to the in-house-simplex robustness blocker above.
+* #517 stays **open**, re-scoped to the phase-2/factorization robustness blocker
+  in §1, with candidate fix (A) (safe in-house dual bound) as the next step.
 * The external-HiGHS rescue and the subtol-fold are **not shipped** (branch reset;
   no source change to the relaxation or solver was retained).
-* Evidence for the rejection and the root cause is this document; the probes are
-  reproducible from the corpus instance `python/tests/data/minlplib_nl/hda.nl`.
+* The root cause was measured with temporary `DISCOPT_LP_DEBUG` instrumentation in
+  `primal.rs`, since reverted (no debug code retained). Reproducible from the
+  corpus instance `python/tests/data/minlplib_nl/hda.nl` via a real
+  `Model.solve()` — do **not** capture-and-replay the node LP (§1).

--- a/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
+++ b/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
@@ -1,0 +1,93 @@
+# #517 hda-class no-bound — root cause is in-house simplex robustness, not relaxation coverage (2026-07-16)
+
+**Issue:** #517 (re-scoped by TD-B,
+`uncertified-tail-plan-results-2026-07-06.md` §5). Goal: give the hda-class
+flowsheets a **first finite dual bound**.
+
+This record supersedes the original #517 framing ("lift `log()`/`x**expr` for
+relaxation coverage") *and* a rejected fix attempt ("subtol-fold + external-HiGHS
+node-LP rescue"). Both are wrong levers. The measured blocker is the **in-house
+Rust simplex failing to solve hda's root relaxation LP** — a core-engine numerics
+problem, not a coverage or reformulation gap.
+
+## 0. What went stale, and what was rejected
+
+* **Original framing (coverage):** the #632 cutover to the uniform factorable
+  engine (`uniform_relax.build_uniform_relaxation`) already covers every hda atom
+  (`log(<expr>)`, `x**expr`, divisions, fractional powers) with sound
+  interval-floor envelopes. hda's 23 formerly-omitted rows are gone. Coverage is
+  **not** the blocker.
+* **Rejected fix (external-HiGHS rescue):** a `DISCOPT_NODE_LP_RESCUE` flag that,
+  when the in-house node-LP chain returned no certified verdict, re-solved the
+  relaxation with SciPy-bundled HiGHS and kept only a Neumaier–Shcherbina safe
+  bound from its duals. **Rejected and not shipped.** It violates the stated
+  architecture (CLAUDE.md: "the default per-node LP engine is the in-house Rust
+  simplex … not HiGHS; do not plan work against a HiGHS backend"; highspy is
+  OA/GDP-only). It was also the *entire* cause of a measured 7× per-node
+  regression on heatexch_gen3 (37 s → 258 s, still no bound), and it produced
+  hda's bound *only* in combination with a subtol-fold, i.e. never through the
+  in-house engine. A companion `DISCOPT_RELAX_SUBTOL_FOLD` flag is likewise not
+  shipped: without the rescue it yields hda no bound, and its other measured
+  panel effects were entangled with the rescue, so shipping it alone would be a
+  bound-changing lever with no independently-demonstrated benefit (Dev-Philosophy
+  #4).
+
+## 1. Root cause (measured, reproducible)
+
+hda's root relaxation LP is **3054 rows × 1145 cols** — grossly redundant (2.7×
+more inequality rows than columns; the lifted McCormick / interval-floor
+envelopes emit many dependent rows). Its coefficient spread is **4.13e17**
+(Arrhenius pre-exponentials `~6.3e10` against `exp(-261.67/x)` envelope atoms in
+`[2e-13, 2.4e-12]`).
+
+On this LP the in-house simplex fails at **0 pivots** — it never gets past
+phase-1 / initial factorization:
+
+| path | verdict on hda's folded root LP |
+|---|---|
+| bare cold simplex, un-equilibrated (`solve_lp_py`) | **false `infeasible`**, 0 pivots, 0.2 s |
+| bare cold simplex, geometric-mean equilibrated (spread → 1.9e4) | **`numerical`**, 0 pivots, ~14 s |
+| per-node path `milp.solve(backend="simplex")` | **false `infeasible`**, ~0.5 s |
+| `MilpRelaxationModel._solve_lp_warm_equilibrated()` (the repo's ill-conditioned handler, built for nvs21) | **None** (numerical/iter-limit) after ~55 s |
+| SciPy-HiGHS (has presolve) | `optimal` (collapses the redundancy first) |
+
+Equilibration *fixes the conditioning* (4.13e17 → 1.9e4) but the engine still
+returns `numerical` at 0 pivots — so conditioning is **not** the whole story.
+The distinguishing factor is HiGHS's **presolve**, which removes the redundant /
+dependent rows before factorizing; the in-house engine has no such LP presolve
+and its (already hardened) phase-1 cannot factor the raw redundant basis.
+
+The in-house phase-1 is already sophisticated for this exact class — Farkas-ray
+certification to distinguish genuine from numerical false-infeasible, plus the
+C-39 `drive_out_basic_artificials` degenerate-cleanup pass
+(`crates/discopt-core/src/lp/simplex/primal.rs:769–851`). hda defeats even that
+and hits the honest, non-fathoming `LpStatus::Numerical` return
+(`primal.rs:846`). No unsound fathom ever occurs — the failure mode is *no
+bound*, never a wrong one (the C-38 no-Farkas-no-prune guard holds). TD-B's
+"stock reform yields an infeasible root LP" observation is this same numerical
+false-infeasible, not an invalid relaxation.
+
+## 2. The real fix (scoped, not yet implemented — core-engine work)
+
+Give the in-house LP layer a **presolve that removes redundant / linearly
+dependent inequality rows** (and empty/singleton rows) before the simplex
+factorizes — the step HiGHS uses to make this LP tractable. Candidate home:
+`crates/discopt-core/src/lp/` (a new `presolve` alongside `basis.rs`), applied on
+the relaxation-LP solve path.
+
+This is a **certificate-critical core-engine change** and must ship under the
+bound-neutral verification regime (Dev-Philosophy #5): assert `node_count` and
+certified `objective` **exactly unchanged** on the certifying panel for every
+instance that already solves, plus `cargo test -p discopt-core`, before it can be
+trusted. It is therefore its own PR, not a rider on this investigation.
+
+Acceptance for #517 (unchanged): hda reports a **finite** dual bound (its first),
+`bound ≤ −5964.534084` (the published optimum), with no panel regression.
+
+## 3. Disposition
+
+* #517 stays **open**, re-scoped to the in-house-simplex robustness blocker above.
+* The external-HiGHS rescue and the subtol-fold are **not shipped** (branch reset;
+  no source change to the relaxation or solver was retained).
+* Evidence for the rejection and the root cause is this document; the probes are
+  reproducible from the corpus instance `python/tests/data/minlplib_nl/hda.nl`.

--- a/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
+++ b/docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md
@@ -94,23 +94,19 @@ produced no bound; `MccormickLPRelaxer._solve_at_node_impl` reports it as a
 bound-only node. Measured: hda flag-ON → `bound = -1.80e10` (finite, `≤` optimum
 `-5964.53` — its first), flag-OFF → `bound=None` (baseline unchanged); clean
 certifying instances (alan, ex1221, nvs05) byte-identical. Tests:
-`python/tests/test_issue_517_numerical_dual_bound.py`. A valid *lower* bound needs only a dual point + directed
-rounding (Neumaier–Shcherbina), **not** a clean primal. When phase-2 drifts
-(audit `Bounds`/`Rows`) or breaks down, the engine still holds a basis and can
-export its dual `y = B⁻ᵀc_B`; feeding that through the in-repo NS certificate
-(`milp_simplex._safe_lp_lower_bound_std`, already used elsewhere) attaches a sound
-bound where today there is none — architecture-respecting (own dual, no HiGHS).
+`python/tests/test_issue_517_numerical_dual_bound.py`.
 
-*Probe result (env-gated `DISCOPT_LP_NUMERICAL_DUAL`, since reverted):* on hda's
-`Numerical` root-LP solves the exported dual yields a **finite** NS safe bound —
-measured `-1.447e6` and `-2.650e8`, both valid (`≤` optimum `-5964.53`). So the
-in-house dual survives the phase-2 breakdown well enough to certify hda's **first
-finite dual bound**, with no HiGHS. *Caveat:* the bound is **loose** (the basis is
-drifted), so it lifts `best_bound` off the `1e30` sentinel and satisfies #517's
-literal acceptance but gives little fathoming power on its own — a tight, useful
-bound still needs (B). To ship, wire the numerical-path dual → NS bound behind a
-flag (bound-changing regime, default OFF) with the differential-bound +
-feasible-point + no-fathom gates.
+The mechanism: a valid *lower* bound needs only a dual point + directed rounding
+(Neumaier–Shcherbina), **not** a clean primal. When phase-2 drifts (audit
+`Bounds`/`Rows`) or breaks down, the engine still holds a basis whose dual
+`y = B⁻ᵀc_B` through the in-repo NS certificate
+(`milp_simplex._safe_lp_lower_bound_std`) gives a sound bound where today there is
+none — architecture-respecting (own dual, no HiGHS). *Caveat:* the bound is
+**loose** (the basis is drifted): it lifts `best_bound` off the `1e30` sentinel
+and satisfies #517's literal acceptance but gives little fathoming power on its own
+— a tight, useful bound still needs (B). Env-gated probe measurements before wiring
+were `-1.447e6` / `-2.650e8` on the raw node LP; the end-to-end driver bound is
+looser (`-1.80e10`) as the frontier aggregates post-FBBT/OBBT node boxes.
 
 **(B) Phase-2 / factorization robustness (the deeper fix).** Keep phase-2 from
 drifting/breaking down on the ill-conditioned basis — more frequent
@@ -120,6 +116,21 @@ blast radius; only if (A) proves insufficient.
 
 Acceptance for #517 (unchanged): hda reports a **finite** dual bound (its first),
 `bound ≤ −5964.534084` (the published optimum), with no panel regression.
+
+## 2a. Verification of (A) — differential panel (flag ON vs OFF)
+
+16-instance in-repo panel, tl=25 s, oracle-checked against published optima:
+
+| class | instances | result |
+|---|---|---|
+| target | **hda** | `None → −1.80e10` (finite, ≤ opt −5964.53) — **first bound** |
+| tighter (still sound) | **4stufen** `19713 → 20282` (≤ opt 96908), **casctanks** `−90.182 → −90.179` (≤ opt 9.163) | flag explores a tighter frontier; every bound ≤ its true optimum |
+| byte-identical | nvs05, contvar, heatexch_gen1, beuster, tanksize, st_e36, nvs09, st_e11, gkocis, ex1221, alan, nvs21 | inert — the floor fires only on a numerically-failed node LP |
+
+`panel gate: PASS`; **no bound exceeds its true optimum** on any instance with a
+known oracle. *Perf caveat:* heatexch_gen3 flag-ON took 240 s vs 32 s OFF (the
+extra bounded nodes drive more per-node NS work) — default-OFF, so no CI impact;
+a reason the flag stays opt-in until (B) tightens the underlying solve.
 
 ## 3. Disposition
 

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -1523,6 +1523,18 @@ class MccormickLPRelaxer:
             floor = getattr(milp, "_objective_floor", None)
             if res.status == "unbounded" and floor is not None and np.isfinite(floor):
                 return MccormickLPResult(status="optimal", lower_bound=float(floor))
+            # #517 (flag-gated): the node LP broke down numerically but the in-house
+            # simplex's own dual yielded a rigorous Neumaier–Shcherbina safe lower
+            # bound (``milp.solve`` attached it to ``res.bound``). It is valid for ANY
+            # dual — so ``<=`` the true LP optimum ``<=`` this node's true optimum,
+            # sound even with unbounded nonlinear columns and no vertex ``x`` — which
+            # gives the hda-class no-bound nodes a dual bound instead of nothing.
+            if (
+                _tuning().node_numerical_dual_bound
+                and res.bound is not None
+                and np.isfinite(res.bound)
+            ):
+                return MccormickLPResult(status="optimal", lower_bound=float(res.bound))
             return MccormickLPResult(status=res.status)
 
         def _certify(r) -> Optional[float]:

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -282,6 +282,13 @@ class MilpRelaxationModel:
         from discopt.solvers import SolveStatus
         from discopt.solvers.lp_backend import get_milp_solver
 
+        # #517 last-resort dual floor (flag-gated, default OFF): reset per solve.
+        # A numerically-failed node LP may still yield a sound Neumaier–Shcherbina
+        # safe bound from the in-house simplex's own dual; the warm/equilibrated
+        # paths stash it here and it is attached below only if nothing else produced
+        # a bound (the hda-class no-bound nodes).
+        self._pending_numerical_bound: Optional[float] = None
+
         # Warm-startable pure-LP fast path: the spatial cut-separation loop
         # re-solves the SAME structural columns with only rows (cuts) appended, so
         # the previous optimal basis is an ideal dual-simplex warm start. Engage
@@ -421,6 +428,17 @@ class MilpRelaxationModel:
         ):
             bound = float(result.bound) + self._obj_offset
 
+        # #517 last-resort dual floor: if the whole in-house chain produced no
+        # bound but a numerically-failed node LP yielded a sound NS safe bound
+        # (from the engine's own dual), use it (flag-gated). Never overrides a real
+        # bound — it only fills a ``None`` — and never fathoms on its own.
+        if (
+            bound is None
+            and _tuning().node_numerical_dual_bound
+            and self._pending_numerical_bound is not None
+        ):
+            bound = self._pending_numerical_bound
+
         return MilpRelaxationResult(status=status_str, objective=obj, bound=bound, x=result.x)
 
     def _solve_lp_warm(self) -> Optional["MilpRelaxationResult"]:
@@ -461,6 +479,7 @@ class MilpRelaxationModel:
         if result is None:
             # iter_limit / numerical: let the generic path (with its HiGHS option)
             # handle it; drop the stale basis so the next round cold-starts.
+            self._stash_numerical_bound(cert)  # #517 last-resort floor (flag-gated)
             self._warm_basis = None
             return None
         if out_basis is not None:
@@ -530,6 +549,7 @@ class MilpRelaxationModel:
         except Exception:  # pragma: no cover - defensive
             return None
         if result is None:
+            self._stash_numerical_bound(cert)  # #517 last-resort floor (flag-gated)
             return None
         status_map = {
             SolveStatus.OPTIMAL: "optimal",
@@ -565,6 +585,27 @@ class MilpRelaxationModel:
             safe_bound=safe_bound,
             farkas_certified=bool(cert.farkas_certified),
         )
+
+    def _stash_numerical_bound(self, cert) -> None:
+        """Record a Neumaier–Shcherbina safe bound recovered from a numerically-
+        failed node LP as this solve's last-resort dual floor (#517, flag-gated).
+
+        The NS bound comes from the in-house simplex's *own* dual candidate on a
+        phase-2 breakdown and is valid for **any** multiplier vector, so it can
+        never exceed the true optimum — a drifted basis only loosens it. Attached
+        in :meth:`solve` only when nothing else produced a bound, so it never
+        overrides (or tightens away from) a real bound. Tracks the tightest (max)
+        floor seen across the warm/equilibrated attempts of one solve.
+        """
+        if not _tuning().node_numerical_dual_bound:
+            return
+        if cert is None or cert.safe_bound is None or not self._objective_bound_valid:
+            return
+        sb = float(cert.safe_bound) + self._obj_offset
+        if not math.isfinite(sb):
+            return
+        prev = getattr(self, "_pending_numerical_bound", None)
+        self._pending_numerical_bound = sb if prev is None else max(prev, sb)
 
 
 def sanitize_relaxation_for_conditioning(

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -82,6 +82,20 @@ class SolverTuning:
     it. All fields are validated on construction.
     """
 
+    # --- #517 hda-class last-resort dual bound --------------------------------
+    node_numerical_dual_bound: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_NODE_NUMERICAL_DUAL_BOUND", default=False)
+    )
+    """Attach a Neumaier–Shcherbina safe lower bound from the in-house simplex's
+    *own* dual candidate when the node LP solve breaks down numerically
+    (``DISCOPT_NODE_NUMERICAL_DUAL_BOUND``, default OFF — bound-changing regime,
+    #517). Fires only where the whole in-house chain (warm → equilibrated → cold)
+    produces NO bound today: the hda-class flowsheets whose ill-conditioned root
+    LP defeats phase-2 (see ``docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md``).
+    The NS bound is valid for ANY dual vector, so a drifted-basis dual only
+    loosens it, never lifts it above the optimum; never fathoms on its own. No
+    external solver (the removed #517 HiGHS rescue is NOT resurrected)."""
+
     # --- RLT (reformulation-linearization) families ---------------------------
     rlt: bool = field(default_factory=lambda: _env_flag("DISCOPT_RLT", default=False))
     """Legacy whole-relaxation RLT toggle (``DISCOPT_RLT``). The ``rlt=`` argument

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -531,8 +531,23 @@ def solve_lp_warm_std(
                 None,
                 LpWarmCert(safe_bound=None, farkas_certified=False),
             )
-        # iter_limit / numerical: signal the caller to fall back to the generic path.
-        return None, None, LpWarmCert(safe_bound=None, farkas_certified=False)
+        # iter_limit / numerical: no clean optimum — signal fallback (result None).
+        # But if the engine exported a dual candidate from the broken basis (#517),
+        # carry a Neumaier–Shcherbina safe lower bound in the cert. It is valid for
+        # ANY multiplier vector, so a drifted-basis dual only loosens it — never
+        # lifts it above the optimum. The caller (behind a default-OFF flag) uses it
+        # only as a last-resort floor when nothing else produced a bound.
+        safe = None
+        if dual is not None and np.size(dual):
+            safe = _safe_lp_lower_bound_std(dual, c_std, a_std, b_vec, lb_std, ub_std)
+        return (
+            None,
+            None,
+            LpWarmCert(
+                safe_bound=(None if safe is None else float(safe)),
+                farkas_certified=False,
+            ),
+        )
 
     result, out_basis, cert = _result_basis_cert()
     if return_cert:

--- a/python/tests/test_issue_517_numerical_dual_bound.py
+++ b/python/tests/test_issue_517_numerical_dual_bound.py
@@ -1,0 +1,84 @@
+"""Regression tests for #517 candidate (A): in-house numerical-dual safe bound.
+
+Root cause (``docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md``): on the
+hda-class ill-conditioned flowsheet relaxations the in-house simplex's phase 1
+finds a feasible basis but phase 2 drifts / breaks down (``Numerical``), so the
+node certifies no dual bound and the tree never fathoms — hda has *no* dual bound
+at all.
+
+Fix (flag ``DISCOPT_NODE_NUMERICAL_DUAL_BOUND`` /
+``SolverTuning.node_numerical_dual_bound``, default OFF — bound-changing regime):
+export the Optimal-style dual candidate ``y = B⁻ᵀc_B`` from the broken basis and
+attach the in-repo Neumaier–Shcherbina safe lower bound it yields. The NS bound is
+valid for ANY multiplier vector, so a drifted-basis dual only *loosens* it — never
+lifts it above the optimum — and it is reported as a bound-only node (no fabricated
+incumbent), so it never fathoms on its own. No external solver is used.
+"""
+
+import math
+import os
+
+import discopt.modeling as dm
+import pytest
+
+_NL_DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
+
+_FLAG = "DISCOPT_NODE_NUMERICAL_DUAL_BOUND"
+_HDA_OPT = -5964.534084  # published MINLPLib global optimum
+
+
+def _hda_path():
+    p = os.path.join(_NL_DATA, "hda.nl")
+    if not os.path.exists(p):
+        pytest.skip("hda.nl not vendored")
+    return p
+
+
+@pytest.mark.slow
+def test_hda_gets_first_finite_dual_bound(monkeypatch):
+    """With the flag ON, hda reports a *finite* dual bound (its first) that is a
+    sound lower bound (never above the published optimum)."""
+    monkeypatch.setenv(_FLAG, "1")
+    r = dm.from_nl(_hda_path()).solve(time_limit=25)
+    assert r.bound is not None, "hda should get its first finite dual bound with the flag ON"
+    assert math.isfinite(r.bound), f"bound must be finite, got {r.bound}"
+    # Soundness: a valid dual (lower) bound never crosses the true optimum.
+    assert r.bound <= _HDA_OPT + 1e-2, f"UNSOUND: bound {r.bound:.6g} > opt {_HDA_OPT}"
+    # Bound-only: the floor must not fabricate an incumbent or a false optimality.
+    assert r.status != "optimal", "a loose dual floor must not claim optimality"
+
+
+@pytest.mark.slow
+def test_hda_flag_off_is_the_unchanged_baseline(monkeypatch):
+    """Default (flag OFF): hda still has no dual bound — the fix is opt-in and the
+    baseline is untouched."""
+    monkeypatch.delenv(_FLAG, raising=False)
+    r = dm.from_nl(_hda_path()).solve(time_limit=25)
+    assert r.bound is None, f"flag OFF must be the no-bound baseline, got {r.bound}"
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", ["alan", "ex1221"])
+def test_inert_on_cleanly_certifying_instances(name, monkeypatch):
+    """Instances whose node LPs solve cleanly (no numerical breakdown) are
+    byte-identical with the flag ON: the floor fires only on a failed node LP, so
+    a well-conditioned certifying instance never triggers it."""
+    path = os.path.join(_NL_DATA, f"{name}.nl")
+    if not os.path.exists(path):
+        pytest.skip(f"{name}.nl not vendored")
+
+    monkeypatch.delenv(_FLAG, raising=False)
+    off = dm.from_nl(path).solve(time_limit=20)
+    monkeypatch.setenv(_FLAG, "1")
+    on = dm.from_nl(path).solve(time_limit=20)
+
+    assert off.status == on.status, f"{name}: status changed {off.status} -> {on.status}"
+    assert off.objective == on.objective, f"{name}: objective drifted with the flag"
+    assert off.bound == on.bound, f"{name}: bound drifted with the flag ({off.bound} -> {on.bound})"
+
+
+def test_flag_defaults_off():
+    """The tuning flag is default-OFF (opt-in, bound-changing regime)."""
+    from discopt.solver_tuning import SolverTuning
+
+    assert SolverTuning().node_numerical_dual_bound is False

--- a/python/tests/test_issue_517_numerical_dual_bound.py
+++ b/python/tests/test_issue_517_numerical_dual_bound.py
@@ -77,8 +77,12 @@ def test_inert_on_cleanly_certifying_instances(name, monkeypatch):
     assert off.bound == on.bound, f"{name}: bound drifted with the flag ({off.bound} -> {on.bound})"
 
 
-def test_flag_defaults_off():
-    """The tuning flag is default-OFF (opt-in, bound-changing regime)."""
+def test_flag_defaults_off(monkeypatch):
+    """The tuning flag is default-OFF (opt-in, bound-changing regime).
+
+    Check the *code* default in the absence of the env override (a CI shell that
+    exports the flag must not make the default look ON)."""
+    monkeypatch.delenv(_FLAG, raising=False)
     from discopt.solver_tuning import SolverTuning
 
     assert SolverTuning().node_numerical_dual_bound is False


### PR DESCRIPTION
## Summary

Implements candidate fix (A) from the #517 root-cause investigation (`docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md`): when the in-house simplex's phase-2 breaks down numerically on ill-conditioned node LPs (like hda's 2974×1145 root relaxation), export the Optimal-style dual candidate `y = B⁻ᵀc_B` from the final basis and compute a Neumaier–Shcherbina safe lower bound from it. This bound is valid for *any* multiplier vector, so a drifted-basis dual only loosens it—never lifts it above the true optimum—and it is attached as a last-resort floor only when the entire in-house chain (warm → equilibrated → cold) produces no bound.

**Result:** hda reports its first finite dual bound (`−1.80e10 ≤ opt −5964.53`) with no panel regression. The fix is flag-gated (`DISCOPT_NODE_NUMERICAL_DUAL_BOUND`, default OFF) and bound-changing regime (opt-in, no CI impact).

## Key Changes

- **`crates/discopt-core/src/lp/simplex/primal.rs`**: On `LpStatus::Numerical` (phase-2 breakdown), export the row-dual candidate from the final basis via `btran` of `c_B`. The dual is a *candidate* the caller verifies; it is empty if factorization fails.

- **`python/discopt/solvers/milp_simplex.py`**: In the `_result_basis_cert()` fallback path (iter_limit / numerical), compute the Neumaier–Shcherbina safe lower bound from the exported dual and carry it in `LpWarmCert.safe_bound`. The bound is valid for any dual, so a drifted basis only loosens it.

- **`python/discopt/_jax/milp_relaxation.py`**: 
  - Add `_pending_numerical_bound` field to track the tightest safe bound across warm/equilibrated attempts.
  - Implement `_stash_numerical_bound()` to record the NS bound from failed node LPs (flag-gated).
  - In `solve()`, attach the pending bound as a last-resort floor only if the whole in-house chain produced no bound and the flag is ON.

- **`python/discopt/_jax/mccormick_lp.py`**: In `_solve_at_node_impl()`, report the safe bound as a bound-only node (status "optimal", no fabricated incumbent) when the node LP broke down numerically but the in-house dual yielded a rigorous lower bound.

- **`python/discopt/solver_tuning.py`**: Add `node_numerical_dual_bound` boolean field (env `DISCOPT_NODE_NUMERICAL_DUAL_BOUND`, default OFF) to gate the feature.

- **`docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md`** (new): Full root-cause analysis, measurement methodology, and verification results. Documents why earlier hypotheses (coverage, presolve, row redundancy) were falsified and why (B) phase-2 robustness is the deeper fix.

- **`python/tests/test_issue_517_numerical_dual_bound.py`** (new): Regression tests verifying hda gets its first finite dual bound with the flag ON, the baseline (flag OFF) is unchanged, and cleanly-certifying instances (alan, ex1221) are byte-identical.

## Verification

- **Panel gate (16 instances, tl=25 s):** hda `None → −1.80e10` (finite, ≤ opt); 4stufen and casctanks tighter (still sound); 12 instances byte-identical. No bound exceeds its true optimum.
- **Perf caveat:** heatexch_gen3 flag-ON took 240 s vs 32 s OFF (extra bounded

https://claude.ai/code/session_01W6n8zSjqEhRVuNENRW9B5W