### PR TITLE
perf(sparse-milp): fully-sparse per-node McCormick path — qap 30 GB → <1 GB, 14.7×/node

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -3247,6 +3247,58 @@ mod sparse_milp_diff {
         }
     }
 
+    /// T3b6 branching integration golden. The panel solves at the root (nodes=1) so
+    /// it never runs the per-node engine. This instance FORCES a 13-node tree
+    /// (heuristics off, no root GMI) while keeping node cover separation, strong
+    /// branching, and FBBT propagation ON — so `separate_cover`, `strong_branch`,
+    /// and `tighten_bounds` (and their CSC ports wired in at T3b5) are exercised
+    /// end-to-end. The rewire must leave status/obj/node-count/`lp_iters` EXACTLY
+    /// unchanged; any drift is a per-node-engine regression the panel would miss.
+    #[test]
+    fn branching_golden() {
+        let a = [
+            3.0, 4.0, 5.0, 2.0, 6.0, 1.0, 1.0, 0.0, //
+            2.0, 3.0, 1.0, 5.0, 2.0, 4.0, 0.0, 1.0,
+        ];
+        let c = [-5.0, -6.0, -7.0, -4.0, -8.0, -3.0, 0.0, 0.0];
+        let l = [0.0; 8];
+        let u = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, INF, INF];
+        let lp = LpView {
+            a: &a,
+            m: 2,
+            n: 8,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let o = MilpOptions {
+            n_struct: 6,
+            integer_cols: vec![0, 1, 2, 3, 4, 5],
+            max_nodes: 100_000,
+            time_limit_s: None,
+            gap_tol: 1e-9,
+            root_cuts: 0,
+            cut_rounds: 3,
+            gmi_cuts: false,
+            cut_select: true,
+            node_cuts: true,
+            max_pool_cuts: 500,
+            heuristics: false,
+            presolve: true,
+            strong_branch: true,
+            node_propagation: true,
+            reduced_cost_fixing: true,
+            sb_max_cands: 8,
+            sb_node_budget: 1024,
+            simplex: SimplexOptions::default(),
+        };
+        let r = solve_milp(&lp, &[10.0, 9.0], 0.0, &o);
+        assert_eq!(r.status, MilpStatus::Optimal, "status");
+        assert!((r.obj - (-16.0)).abs() < 1e-9, "obj {}", r.obj);
+        assert_eq!(r.nodes, 13, "node-count drift (per-node engine)");
+        assert_eq!(r.lp_iters, 39, "lp_iters drift (per-node engine)");
+    }
+
     /// Determinism: re-solving is bit-identical. This is exactly the property the
     /// CSC path must satisfy against the dense path at T1, so the harness proves the
     /// gate is meaningful (the dense driver itself is reproducible).

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -2932,6 +2932,61 @@ mod sparse_milp_diff {
         }
     }
 
+    /// Golden lock on the CURRENT driver's per-instance solve — status, objective,
+    /// bound, node count, and simplex pivot count. This is the **driver-wide**
+    /// bit-identity gate for the sparse conversion: T2/T3 change the driver internals
+    /// for BOTH the dense and CSC entry points, so `csc_entry_matches_dense_on_panel`
+    /// (dense-vs-CSC) alone can no longer catch a regression against the *original*
+    /// behavior — after conversion both sides move together. `lp_iters` is the
+    /// sensitive discriminator: a different root-solve pivot path drifts it even when
+    /// the B&B tree is a single node. A change to any value here is a red flag — the
+    /// sparse path is a pure representation change and must reproduce these exactly.
+    #[test]
+    fn driver_matches_golden() {
+        for case in panel() {
+            let r = case.solve_dense();
+            let (status, obj, bound, nodes, iters): (MilpStatus, f64, f64, usize, usize) =
+                match case.name {
+                    "pure_lp" => (MilpStatus::Optimal, -1.0, -1.0, 1, 0),
+                    "binary_knapsack" => (MilpStatus::Optimal, -10.0, -10.0, 1, 1),
+                    "general_integer" => (MilpStatus::Optimal, -3.0, -3.0, 1, 1),
+                    "infeasible" => (MilpStatus::Infeasible, f64::INFINITY, f64::INFINITY, 0, 0),
+                    "unbounded" => (
+                        MilpStatus::Unbounded,
+                        f64::INFINITY,
+                        f64::NEG_INFINITY,
+                        1,
+                        0,
+                    ),
+                    "cuts_firing_knapsack" => (MilpStatus::Optimal, -16.0, -16.0, 1, 1),
+                    other => panic!("unhandled case {other}"),
+                };
+            assert_eq!(r.status, status, "{}: status", case.name);
+            assert_eq!(r.nodes, nodes, "{}: nodes", case.name);
+            assert_eq!(r.lp_iters, iters, "{}: lp_iters", case.name);
+            if obj.is_finite() {
+                assert!(
+                    (r.obj - obj).abs() < 1e-9,
+                    "{}: obj {} != {obj}",
+                    case.name,
+                    r.obj
+                );
+            } else {
+                assert_eq!(r.obj, obj, "{}: obj", case.name);
+            }
+            if bound.is_finite() {
+                assert!(
+                    (r.bound - bound).abs() < 1e-9,
+                    "{}: bound {} != {bound}",
+                    case.name,
+                    r.bound
+                );
+            } else {
+                assert_eq!(r.bound, bound, "{}: bound", case.name);
+            }
+        }
+    }
+
     /// Determinism: re-solving is bit-identical. This is exactly the property the
     /// CSC path must satisfy against the dense path at T1, so the harness proves the
     /// gate is meaningful (the dense driver itself is reproducible).

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -1616,7 +1616,10 @@ fn strong_branch(
     // Reference scaled bounds (the node's own) at which the basis is dual-feasible.
     let (ref_l, ref_u) = scale_bounds(orig_l, orig_u);
     let prep_view = LpView {
-        a: ctx.sa,
+        // T3b3: strong branching solves only through `PreparedDual`/`solve_lp_warm_scaled_csc`,
+        // which read the matrix from `ctx.csc`, never `LpView.a`. The `.a` is vestigial —
+        // pass an empty slice so this path carries no dense-matrix dependency.
+        a: &[],
         m: ctx.m_w,
         n: ctx.n_w,
         c: ctx.sc,
@@ -1630,7 +1633,7 @@ fn strong_branch(
             Some(p) => p.reoptimize(&sl, &su, ctx.sb, simplex),
             None => {
                 let view = LpView {
-                    a: ctx.sa,
+                    a: &[], // T3b3: matrix comes from `ctx.csc`; `.a` unused here.
                     m: ctx.m_w,
                     n: ctx.n_w,
                     c: ctx.sc,

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -1767,6 +1767,51 @@ fn augment_with_cuts(
     (m_new, n_new)
 }
 
+/// CSC analogue of [`augment_with_cuts`]'s MATRIX augmentation (docs/dev/sparse-milp-plan.md,
+/// T3): append `k` cut rows and `k` surplus-slack columns to a column-major matrix,
+/// producing EXACTLY the nonzeros `from_dense(augment_with_cuts(dense,..))` would.
+/// Bit-identical by construction and `O(nnz + cut_nnz)` — never materializes the dense
+/// `m×n` matrix, which is what lets the driver drop the dense `a_w` at T3b. The caller
+/// appends to `b/c/l/u/is_int` itself (those are independent of the matrix layout).
+#[allow(dead_code)] // wired into the driver at T3b (replaces the dense a_w path)
+fn augment_cols_with_cuts(sp: &SparseCols, m: usize, n: usize, cuts: &[GomoryCut]) -> SparseCols {
+    let k = cuts.len();
+    if k == 0 {
+        return sp.clone();
+    }
+    let (col_ptr, row_idx, vals) = sp.raw();
+    let mut new_col_ptr: Vec<usize> = Vec::with_capacity(n + k + 1);
+    let mut new_row_idx: Vec<usize> = Vec::with_capacity(row_idx.len() + n * k + k);
+    let mut new_vals: Vec<f64> = Vec::with_capacity(vals.len() + n * k + k);
+    new_col_ptr.push(0);
+    for j in 0..n {
+        // Existing entries (rows 0..m, already sorted ascending) …
+        for idx in col_ptr[j]..col_ptr[j + 1] {
+            new_row_idx.push(row_idx[idx]);
+            new_vals.push(vals[idx]);
+        }
+        // … then this column's coefficient in each cut row (rows m..m+k, strictly
+        // greater, so the column stays row-sorted). Matches the dense path's
+        // `coeffs[..min(len, n)]`: columns j >= cut.coeffs.len() contribute nothing.
+        for (ci, cut) in cuts.iter().enumerate() {
+            if let Some(&v) = cut.coeffs.get(j) {
+                if v != 0.0 {
+                    new_row_idx.push(m + ci);
+                    new_vals.push(v);
+                }
+            }
+        }
+        new_col_ptr.push(new_row_idx.len());
+    }
+    // Surplus slack columns n..n+k: a singleton `-1.0` at the cut's row.
+    for ci in 0..k {
+        new_row_idx.push(m + ci);
+        new_vals.push(-1.0);
+        new_col_ptr.push(new_row_idx.len());
+    }
+    SparseCols::from_csc(new_col_ptr, new_row_idx, new_vals)
+}
+
 /// Sparse signature of a cut for pool deduplication: its nonzero `(col, coeff)`
 /// pairs (quantized) plus the rhs, so an identical cut found at many nodes is
 /// added to the pool only once.
@@ -3154,6 +3199,50 @@ mod sparse_milp_diff {
                 csc.obj
             );
         }
+    }
+
+    /// T3 gate: the CSC cut augmentation reproduces the dense `augment_with_cuts`
+    /// matrix exactly — `augment_cols_with_cuts(from_dense(A))` equals `from_dense`
+    /// of the dense-augmented A, nonzero-for-nonzero (same col_ptr/row_idx/vals).
+    /// This is what lets T3b append cuts to the CSC and drop `a_w` without perturbing
+    /// a single coefficient.
+    #[test]
+    fn csc_augment_matches_dense_augment() {
+        use crate::lp::gomory::GomoryCut;
+        // 2×3 base with a structural zero; two cuts, one carrying a zero coeff.
+        let a = vec![1.0, 0.0, 2.0, 0.0, 3.0, 4.0];
+        let (m, n) = (2usize, 3usize);
+        let cuts = vec![
+            GomoryCut {
+                coeffs: vec![1.0, 0.0, -2.0],
+                rhs: 1.0,
+            },
+            GomoryCut {
+                coeffs: vec![0.0, 5.0, 0.0],
+                rhs: 2.0,
+            },
+        ];
+        // Reference: dense augment, then to CSC.
+        let mut a_w = a.clone();
+        let mut b = vec![0.0; m];
+        let mut c = vec![0.0; n];
+        let mut l = vec![0.0; n];
+        let mut u = vec![INF; n];
+        let mut ii = vec![false; n];
+        let (mn, nn) = augment_with_cuts(
+            &mut a_w, &mut b, &mut c, &mut l, &mut u, &mut ii, m, n, &cuts,
+        );
+        let csc_ref = SparseCols::from_dense(&a_w, mn, nn);
+        // CSC augment of the CSC of A.
+        let csc_test = augment_cols_with_cuts(&SparseCols::from_dense(&a, m, n), m, n, &cuts);
+        assert_eq!(
+            csc_ref.raw(),
+            csc_test.raw(),
+            "csc augment != from_dense(dense augment)"
+        );
+        // b/c/l/u/is_int side-effects (independent of the matrix layout) match the k
+        // appended surplus rows/cols.
+        assert_eq!((mn, nn), (m + cuts.len(), n + cuts.len()));
     }
 
     /// The CSC of each instance round-trips the dense matrix's exact nonzeros

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -2439,6 +2439,7 @@ fn solve_lp_root(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> crate::lp
 /// the root relaxation of a large sparse binary QP solves from CSC without the dense
 /// blow-up. `cols` is the (unscaled) CSC of the working matrix; `c/l/u/b` and the
 /// slack layout match the dense root LP.
+#[allow(clippy::too_many_arguments)] // inherent LP signature: cols + m,n,c,l,u,b,opts
 fn solve_lp_root_csc(
     cols: &SparseCols,
     m: usize,
@@ -2516,6 +2517,7 @@ fn csc_to_dense(csc: &SparseCols, m: usize, n: usize) -> Vec<f64> {
 /// [`csc_to_dense`]; the differential harness gates it bit-identical to
 /// [`solve_milp`] on the panel, and T2/T3 remove the internal densification so the
 /// sparse matrix flows through untouched.
+#[allow(clippy::too_many_arguments)] // inherent LP signature: csc + m,n,c,l,u,b,obj_const,opts
 pub fn solve_milp_csc(
     csc: &SparseCols,
     m: usize,

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -277,14 +277,35 @@ fn decide_status(
 /// Solve `min cᵀx + obj_const s.t. A x = b, l ≤ x ≤ u` with `integer_cols`
 /// integer-constrained, by Rust-internal warm-started-simplex branch and bound.
 pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions) -> MilpResult {
-    solve_milp_hooked(lp, b, obj_const, opts, None)
+    // Dense entry: build the working CSC from `lp.a` once and hand it to the fully
+    // sparse driver core. The CSC entry (`solve_milp_csc`) skips this densify.
+    solve_milp_hooked(
+        SparseCols::from_dense(lp.a, lp.m, lp.n),
+        lp.m,
+        lp.n,
+        lp.c,
+        lp.l,
+        lp.u,
+        b,
+        obj_const,
+        opts,
+        None,
+    )
 }
 
-/// [`solve_milp`] with an optional interactive-debugger hook. When `hook` is
-/// `None` this is bit-for-bit identical to a plain solve (all fire-sites
-/// short-circuit); the `solve_milp` wrapper above passes `None`.
+/// The MILP branch-and-bound driver core, taking the constraint matrix as a
+/// column-major [`SparseCols`] (`m` rows, `n` cols) — **no dense `m×n` matrix is ever
+/// materialized** (docs/dev/sparse-milp-plan.md T3b5/T4). `hook` is an optional
+/// interactive-debugger hook; when `None` this is bit-for-bit identical to a plain
+/// solve (all fire-sites short-circuit).
+#[allow(clippy::too_many_arguments)]
 pub fn solve_milp_hooked(
-    lp: &LpView<'_>,
+    mut csc_w: SparseCols,
+    m: usize,
+    n: usize,
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
     b: &[f64],
     obj_const: f64,
     opts: &MilpOptions,
@@ -292,7 +313,6 @@ pub fn solve_milp_hooked(
 ) -> MilpResult {
     crate::profile::init_from_env();
     crate::profile::reset();
-    let n = lp.n;
     let ns = opts.n_struct;
     let is_int = {
         let mut v = vec![false; ns];
@@ -315,11 +335,6 @@ pub fn solve_milp_hooked(
     let mut is_int_full = vec![false; n];
     is_int_full[..ns].copy_from_slice(&is_int);
 
-    // Working matrix as CSC — the MILP driver is fully sparse (no dense `m×n` working
-    // matrix is ever materialized). For the dense entry `lp.a` is read once here to
-    // build the CSC; the CSC entry (`solve_milp_csc`) feeds a `SparseCols` directly.
-    let mut csc_w = SparseCols::from_dense(lp.a, lp.m, n);
-
     // --- presolve: sound, dimension-preserving root bound tightening ---
     // Only narrows bounds (interval/FBBT contraction), so it never cuts a
     // feasible solution and needs no postsolve; the tightened bounds seed both
@@ -328,16 +343,7 @@ pub fn solve_milp_hooked(
         // cert:T0.3 — time root presolve bound reduction.
         let pr = {
             let _t = crate::profile::Timer::new(crate::profile::Phase::NodeReduce);
-            tighten_bounds_csc(
-                &csc_w,
-                lp.m,
-                n,
-                lp.l,
-                lp.u,
-                b,
-                &is_int_full,
-                opts.simplex.tol,
-            )
+            tighten_bounds_csc(&csc_w, m, n, l, u, b, &is_int_full, opts.simplex.tol)
         };
         if pr.infeasible {
             return MilpResult {
@@ -351,7 +357,7 @@ pub fn solve_milp_hooked(
         }
         (pr.l, pr.u)
     } else {
-        (lp.l.to_vec(), lp.u.to_vec())
+        (l.to_vec(), u.to_vec())
     };
 
     let glb = base_l[..ns].to_vec();
@@ -363,10 +369,10 @@ pub fn solve_milp_hooked(
     // columns; structural columns [0, ns) are untouched, so the tree's
     // structural bounds still apply unchanged.
     let mut b_w = b.to_vec();
-    let mut c_w = lp.c.to_vec();
+    let mut c_w = c.to_vec();
     let mut l_w = base_l;
     let mut u_w = base_u;
-    let mut m_w = lp.m;
+    let mut m_w = m;
     let mut n_w = n;
 
     let mut lp_iters = 0usize;
@@ -2613,7 +2619,12 @@ mod tests {
 
         let hook = Counter(AtomicUsize::new(0));
         let hooked = solve_milp_hooked(
-            &lp,
+            SparseCols::from_dense(&a, 1, 7),
+            1,
+            7,
+            &c,
+            &l,
+            &u,
             &[10.0],
             0.0,
             &opts(6, vec![0, 1, 2, 3, 4, 5]),

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -2652,3 +2652,251 @@ mod tests {
         );
     }
 }
+
+/// T0 (docs/dev/sparse-milp-plan.md): differential harness for the sparse-MILP
+/// conversion. A fixed panel of small MILPs solved through the reference dense
+/// [`solve_milp`]. Today it pins the dense results and their determinism; at T1 the
+/// CSC entry point plugs into [`Case::solve_csc`] and [`assert_same`] gates it
+/// bit-identical to the dense path (same status / obj / bound / node count) — the
+/// invariant that keeps the representation change from perturbing any dual bound.
+#[cfg(test)]
+mod sparse_milp_diff {
+    use super::*;
+    use crate::lp::simplex::sparse::SparseCols;
+
+    /// One MILP in the panel. Owns its data so the borrowing [`LpView`] can be
+    /// rebuilt per solve.
+    struct Case {
+        name: &'static str,
+        a: Vec<f64>, // row-major, m*n
+        m: usize,
+        n: usize,
+        c: Vec<f64>,
+        l: Vec<f64>,
+        u: Vec<f64>,
+        b: Vec<f64>,
+        ns: usize,
+        int_cols: Vec<usize>,
+    }
+
+    impl Case {
+        fn opts(&self) -> MilpOptions {
+            MilpOptions {
+                n_struct: self.ns,
+                integer_cols: self.int_cols.clone(),
+                max_nodes: 100_000,
+                time_limit_s: None,
+                gap_tol: 1e-9,
+                root_cuts: 16,
+                cut_rounds: 3,
+                gmi_cuts: true,
+                cut_select: true,
+                node_cuts: true,
+                max_pool_cuts: 500,
+                heuristics: true,
+                presolve: true,
+                strong_branch: true,
+                node_propagation: true,
+                reduced_cost_fixing: true,
+                sb_max_cands: 8,
+                sb_node_budget: 1024,
+                simplex: SimplexOptions::default(),
+            }
+        }
+
+        fn dense_view(&self) -> LpView<'_> {
+            LpView {
+                a: &self.a,
+                m: self.m,
+                n: self.n,
+                c: &self.c,
+                l: &self.l,
+                u: &self.u,
+            }
+        }
+
+        /// Reference solve through the dense driver.
+        fn solve_dense(&self) -> MilpResult {
+            solve_milp(&self.dense_view(), &self.b, 0.0, &self.opts())
+        }
+
+        /// CSC view of this instance's matrix. T1 will feed this to the CSC driver
+        /// entry; kept here so the harness already exercises `from_dense`/`from_csc`
+        /// round-tripping the same nonzeros the dense path sees.
+        #[allow(dead_code)]
+        fn csc(&self) -> SparseCols {
+            SparseCols::from_dense(&self.a, self.m, self.n)
+        }
+    }
+
+    /// Panel: pure-LP, small binary knapsack, general integer, infeasible,
+    /// unbounded, and a cuts-firing knapsack (branches + fires GMI cuts).
+    fn panel() -> Vec<Case> {
+        vec![
+            // pure LP: min -x0 s.t. x0 + s = 1, x0 in [0,1] continuous -> -1.
+            Case {
+                name: "pure_lp",
+                a: vec![1.0, 1.0],
+                m: 1,
+                n: 2,
+                c: vec![-1.0, 0.0],
+                l: vec![0.0, 0.0],
+                u: vec![1.0, INF],
+                b: vec![1.0],
+                ns: 1,
+                int_cols: vec![],
+            },
+            // binary knapsack: max 10x0+9x1+8x2+x3 s.t. 5*sum <= 9, binary -> -10.
+            Case {
+                name: "binary_knapsack",
+                a: vec![5.0, 5.0, 5.0, 5.0, 1.0],
+                m: 1,
+                n: 5,
+                c: vec![-10.0, -9.0, -8.0, -1.0, 0.0],
+                l: vec![0.0; 5],
+                u: vec![1.0, 1.0, 1.0, 1.0, INF],
+                b: vec![9.0],
+                ns: 4,
+                int_cols: vec![0, 1, 2, 3],
+            },
+            // general integer: min -x0-x1 s.t. x0+x1+s=3, x in [0,2] int -> -3.
+            Case {
+                name: "general_integer",
+                a: vec![1.0, 1.0, 1.0],
+                m: 1,
+                n: 3,
+                c: vec![-1.0, -1.0, 0.0],
+                l: vec![0.0, 0.0, 0.0],
+                u: vec![2.0, 2.0, INF],
+                b: vec![3.0],
+                ns: 2,
+                int_cols: vec![0, 1],
+            },
+            // infeasible: x0 + s = 1, x0 in [2,5] int -> infeasible.
+            Case {
+                name: "infeasible",
+                a: vec![1.0, 1.0],
+                m: 1,
+                n: 2,
+                c: vec![1.0, 0.0],
+                l: vec![2.0, 0.0],
+                u: vec![5.0, INF],
+                b: vec![1.0],
+                ns: 1,
+                int_cols: vec![0],
+            },
+            // unbounded: min -x0 s.t. 0*x0 + s = 1, x0 in [0,INF) -> unbounded.
+            Case {
+                name: "unbounded",
+                a: vec![0.0, 1.0],
+                m: 1,
+                n: 2,
+                c: vec![-1.0, 0.0],
+                l: vec![0.0, 0.0],
+                u: vec![INF, INF],
+                b: vec![1.0],
+                ns: 1,
+                int_cols: vec![0],
+            },
+            // cuts-firing knapsack: 6 binaries, branches and fires GMI cuts.
+            Case {
+                name: "cuts_firing_knapsack",
+                a: vec![5.0, 3.0, 2.0, 4.0, 3.0, 5.0, 1.0],
+                m: 1,
+                n: 7,
+                c: vec![-8.0, -5.0, -3.0, -6.0, -4.0, -7.0, 0.0],
+                l: vec![0.0; 7],
+                u: vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0, INF],
+                b: vec![10.0],
+                ns: 6,
+                int_cols: vec![0, 1, 2, 3, 4, 5],
+            },
+        ]
+    }
+
+    /// Bit-identical gate used by the dense-vs-dense determinism check now and by
+    /// the dense-vs-CSC check at T1. Status and node count must match exactly;
+    /// obj/bound match to a tight tolerance (finite cases only).
+    fn assert_same(name: &str, a: &MilpResult, b: &MilpResult) {
+        assert_eq!(a.status, b.status, "{name}: status drift");
+        assert_eq!(a.nodes, b.nodes, "{name}: node-count drift");
+        if a.obj.is_finite() && b.obj.is_finite() {
+            assert!(
+                (a.obj - b.obj).abs() < 1e-9,
+                "{name}: obj drift {} {}",
+                a.obj,
+                b.obj
+            );
+        }
+        if a.bound.is_finite() && b.bound.is_finite() {
+            assert!(
+                (a.bound - b.bound).abs() < 1e-9,
+                "{name}: bound drift {} {}",
+                a.bound,
+                b.bound
+            );
+        }
+    }
+
+    #[test]
+    fn dense_panel_reference_values() {
+        for case in panel() {
+            let r = case.solve_dense();
+            match case.name {
+                "pure_lp" => {
+                    assert_eq!(r.status, MilpStatus::Optimal, "pure_lp");
+                    assert!((r.obj - (-1.0)).abs() < 1e-6, "pure_lp obj {}", r.obj);
+                }
+                "binary_knapsack" => {
+                    assert_eq!(r.status, MilpStatus::Optimal, "binary_knapsack");
+                    assert!((r.obj - (-10.0)).abs() < 1e-6, "knapsack obj {}", r.obj);
+                }
+                "general_integer" => {
+                    assert_eq!(r.status, MilpStatus::Optimal, "general_integer");
+                    assert!((r.obj - (-3.0)).abs() < 1e-6, "genint obj {}", r.obj);
+                }
+                "infeasible" => assert_eq!(r.status, MilpStatus::Infeasible, "infeasible"),
+                "unbounded" => assert_eq!(r.status, MilpStatus::Unbounded, "unbounded"),
+                "cuts_firing_knapsack" => {
+                    assert_eq!(r.status, MilpStatus::Optimal, "cuts_firing");
+                    assert!(
+                        r.obj.is_finite() && r.obj < 0.0,
+                        "cuts_firing obj {}",
+                        r.obj
+                    );
+                }
+                other => panic!("unhandled case {other}"),
+            }
+        }
+    }
+
+    /// Determinism: re-solving is bit-identical. This is exactly the property the
+    /// CSC path must satisfy against the dense path at T1, so the harness proves the
+    /// gate is meaningful (the dense driver itself is reproducible).
+    #[test]
+    fn dense_panel_is_deterministic() {
+        for case in panel() {
+            let r1 = case.solve_dense();
+            let r2 = case.solve_dense();
+            assert_same(case.name, &r1, &r2);
+            assert_eq!(r1.lp_iters, r2.lp_iters, "{}: lp_iters drift", case.name);
+        }
+    }
+
+    /// The CSC of each instance round-trips the dense matrix's exact nonzeros
+    /// (T1 relies on this equivalence). Sanity-checks `from_dense` on the panel.
+    #[test]
+    fn csc_roundtrips_dense_nonzeros() {
+        for case in panel() {
+            let sp = case.csc();
+            let mut dense_nnz = 0usize;
+            for &v in &case.a {
+                if v != 0.0 {
+                    dense_nnz += 1;
+                }
+            }
+            let (_col_ptr, _row_idx, vals) = sp.raw();
+            assert_eq!(vals.len(), dense_nnz, "{}: csc nnz != dense nnz", case.name);
+        }
+    }
+}

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -25,8 +25,8 @@ use crate::lp::gomory::{separate_gomory, GomoryCut};
 use crate::lp::simplex::linsolve::{FeralLU, LinearSolver};
 use crate::lp::simplex::sparse::SparseCols;
 use crate::lp::simplex::{
-    solve_lp, solve_lp_scaled, solve_lp_warm, solve_lp_warm_scaled_csc, tighten_bounds, LpStatus,
-    PreparedDual, Scaling, SimplexOptions,
+    solve_lp, solve_lp_cols_scaled, solve_lp_scaled, solve_lp_warm, solve_lp_warm_scaled_csc,
+    tighten_bounds, LpStatus, PreparedDual, Scaling, SimplexOptions,
 };
 
 const INF: f64 = 1e20;
@@ -447,7 +447,13 @@ pub fn solve_milp_hooked(
             };
             let root = {
                 let _t = crate::profile::Timer::new(crate::profile::Phase::RootSolve);
-                solve_lp_root(&root_lp, &b_w, &node_simplex)
+                // T2 (docs/dev/sparse-milp-plan.md): solve the root relaxation from
+                // CSC via the bit-identical `solve_lp_root_csc`. The CSC is derived
+                // from `a_w` here only until T3 removes the dense working matrix; the
+                // node solves already run on CSC, so this makes the WHOLE per-round
+                // solve path sparse, gated bit-identical by `driver_matches_golden`.
+                let root_csc = SparseCols::from_dense(&a_w, m_w, n_w);
+                solve_lp_root_csc(&root_csc, m_w, n_w, &c_w, &l_w, &u_w, &b_w, &node_simplex)
             };
             lp_iters += root.iters;
             if root.status != LpStatus::Optimal {
@@ -1139,7 +1145,10 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
                 solve_lp_warm_scaled_csc(&solve_lp_view, ctx.sb, &basis, ctx.simplex, ctx.csc)
             } else {
                 match dual_slack_basis(
-                    ctx.a_w,
+                    // The unscaled CSC of the working matrix (== `from_dense(a_w)`);
+                    // dual_slack_basis reads only singleton structure + `c`, both
+                    // scale-invariant, so this is bit-identical to the old dense arg.
+                    ctx.csc_rc,
                     ctx.m_w,
                     ctx.n_w,
                     ctx.c_w,
@@ -2058,7 +2067,7 @@ fn midpoint(lb: &[f64], ub: &[f64]) -> Vec<f64> {
 // loop reads clearer than zipping four slices (matches the simplex modules).
 #[allow(clippy::needless_range_loop)]
 fn dual_slack_basis(
-    a: &[f64],
+    sp: &SparseCols,
     m: usize,
     n: usize,
     c: &[f64],
@@ -2066,7 +2075,6 @@ fn dual_slack_basis(
     u: &[f64],
     tol: f64,
 ) -> Option<Basis> {
-    let sp = SparseCols::from_dense(a, m, n);
     // Assign each row a distinct zero-cost singleton column (a slack).
     let mut row_basic: Vec<i64> = vec![-1; m];
     for j in 0..n {
@@ -2120,8 +2128,21 @@ fn dual_slack_basis(
 /// degenerate phase-2 pivots). `solve_lp_warm` falls back to the cold primal when
 /// the slack basis is unavailable or not actually dual-feasible, so the result is
 /// always the same optimum — only the path differs.
+///
+/// Superseded in the driver by [`solve_lp_root_csc`] (T2); retained as the
+/// differential ORACLE the `sparse_milp_diff` tests check the CSC root solve against
+/// bit-for-bit. Removed with the dense driver at T5.
+#[allow(dead_code)]
 fn solve_lp_root(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> crate::lp::simplex::LpSolve {
-    match dual_slack_basis(lp.a, lp.m, lp.n, lp.c, lp.l, lp.u, opts.tol) {
+    match dual_slack_basis(
+        &SparseCols::from_dense(lp.a, lp.m, lp.n),
+        lp.m,
+        lp.n,
+        lp.c,
+        lp.l,
+        lp.u,
+        opts.tol,
+    ) {
         Some(basis) => {
             // The dual-slack warm start is an *optimization*, not a requirement: on
             // covering/packing relaxations the dual simplex reaches the optimum in a
@@ -2141,6 +2162,47 @@ fn solve_lp_root(lp: &LpView<'_>, b: &[f64], opts: &SimplexOptions) -> crate::lp
             }
         }
         None => solve_lp(lp, b, opts),
+    }
+}
+
+/// Sparse-native equivalent of [`solve_lp_root`] (docs/dev/sparse-milp-plan.md, T2).
+/// Bit-identical to `solve_lp_root` on the same LP — the dual-slack warm start reads
+/// only singleton structure + `c` (scale-invariant), the warm re-solve uses the same
+/// `solve_lp_warm_scaled_csc` the node solves already trust with the same pivot cap,
+/// and the cold fallback uses [`solve_lp_cols_scaled`] which reproduces `solve_lp`'s
+/// `ScaledLp` equilibration exactly. It NEVER materializes the dense `m×n` matrix, so
+/// the root relaxation of a large sparse binary QP solves from CSC without the dense
+/// blow-up. `cols` is the (unscaled) CSC of the working matrix; `c/l/u/b` and the
+/// slack layout match the dense root LP.
+fn solve_lp_root_csc(
+    cols: &SparseCols,
+    m: usize,
+    n: usize,
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    opts: &SimplexOptions,
+) -> crate::lp::simplex::LpSolve {
+    match dual_slack_basis(cols, m, n, c, l, u, opts.tol) {
+        Some(basis) => {
+            let lp = LpView {
+                a: &[],
+                m,
+                n,
+                c,
+                l,
+                u,
+            };
+            let warm = solve_lp_warm_scaled_csc(&lp, b, &basis, &warm_root_opts(opts, m, n), cols);
+            match warm.status {
+                LpStatus::IterLimit | LpStatus::Numerical => {
+                    solve_lp_cols_scaled(cols.clone(), m, n, c, l, u, b, opts)
+                }
+                _ => warm,
+            }
+        }
+        None => solve_lp_cols_scaled(cols.clone(), m, n, c, l, u, b, opts),
     }
 }
 
@@ -3025,6 +3087,72 @@ mod sparse_milp_diff {
                     );
                 }
             }
+        }
+    }
+
+    /// T2 direct gate: [`solve_lp_root_csc`] reproduces the dense [`solve_lp_root`]
+    /// pivot-for-pivot (status, objective, and **iteration count**) on both a
+    /// well-conditioned LP and an ILL-conditioned one whose 1e8 dynamic range trips
+    /// the `ScaledLp`/`Scaling::from_sparse` equilibration — the exact path whose
+    /// dense-vs-CSC equivalence option A rests on. `iters` drift here would mean the
+    /// CSC root solve takes a different pivot path and is NOT bit-identical.
+    #[test]
+    fn solve_lp_root_csc_matches_dense() {
+        // (name, a row-major m*n, m, n, c, l, u, b)
+        let cases: Vec<(
+            &str,
+            Vec<f64>,
+            usize,
+            usize,
+            Vec<f64>,
+            Vec<f64>,
+            Vec<f64>,
+            Vec<f64>,
+        )> = vec![
+            (
+                "well_conditioned",
+                vec![1.0, 1.0],
+                1,
+                2,
+                vec![-1.0, 0.0],
+                vec![0.0, 0.0],
+                vec![1.0, INF],
+                vec![1.0],
+            ),
+            (
+                // 1e8*x0 + 1.0*s = 1e8, x0 in [0,1] -> x0=1, obj -1. Range 1e8 > 1e6
+                // SCALE_TRIGGER, so both paths equilibrate.
+                "ill_conditioned",
+                vec![1e8, 1.0],
+                1,
+                2,
+                vec![-1.0, 0.0],
+                vec![0.0, 0.0],
+                vec![1.0, INF],
+                vec![1e8],
+            ),
+        ];
+        let opts = SimplexOptions::default();
+        for (name, a, m, n, c, l, u, b) in cases {
+            let lp = LpView {
+                a: &a,
+                m,
+                n,
+                c: &c,
+                l: &l,
+                u: &u,
+            };
+            let dense = solve_lp_root(&lp, &b, &opts);
+            let sp = SparseCols::from_dense(&a, m, n);
+            let csc = solve_lp_root_csc(&sp, m, n, &c, &l, &u, &b, &opts);
+            assert_eq!(dense.status, csc.status, "{name}: status");
+            assert_eq!(dense.iters, csc.iters, "{name}: iters (pivot-path) drift");
+            assert!(
+                (dense.obj - csc.obj).abs() < 1e-6 * (1.0 + dense.obj.abs()),
+                "{name}: obj {} vs {}",
+                dense.obj,
+                csc.obj
+            );
         }
     }
 

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -18,15 +18,15 @@ use crate::bnb::node::NodeId;
 use crate::bnb::pool::SelectionStrategy;
 use crate::bnb::tree_manager::{NodeResult, TreeManager};
 use crate::lp::basis::{Basis, AT_LOWER, AT_UPPER, BASIC};
-use crate::lp::cover::separate_cover;
+use crate::lp::cover::separate_cover_csc;
 use crate::lp::crossover::LpView;
 use crate::lp::cut_select::select_cuts;
-use crate::lp::gomory::{separate_gomory, GomoryCut};
+use crate::lp::gomory::{separate_gomory_cols, GomoryCut};
 use crate::lp::simplex::linsolve::{FeralLU, LinearSolver};
 use crate::lp::simplex::sparse::SparseCols;
 use crate::lp::simplex::{
-    solve_lp, solve_lp_cols_scaled, solve_lp_scaled, solve_lp_warm, solve_lp_warm_scaled_csc,
-    tighten_bounds, LpStatus, PreparedDual, Scaling, SimplexOptions,
+    solve_lp, solve_lp_cols, solve_lp_cols_scaled, solve_lp_warm, solve_lp_warm_scaled_csc,
+    tighten_bounds_csc, LpStatus, PreparedDual, Scaling, SimplexOptions,
 };
 
 const INF: f64 = 1e20;
@@ -315,6 +315,11 @@ pub fn solve_milp_hooked(
     let mut is_int_full = vec![false; n];
     is_int_full[..ns].copy_from_slice(&is_int);
 
+    // Working matrix as CSC — the MILP driver is fully sparse (no dense `m×n` working
+    // matrix is ever materialized). For the dense entry `lp.a` is read once here to
+    // build the CSC; the CSC entry (`solve_milp_csc`) feeds a `SparseCols` directly.
+    let mut csc_w = SparseCols::from_dense(lp.a, lp.m, n);
+
     // --- presolve: sound, dimension-preserving root bound tightening ---
     // Only narrows bounds (interval/FBBT contraction), so it never cuts a
     // feasible solution and needs no postsolve; the tightened bounds seed both
@@ -323,7 +328,16 @@ pub fn solve_milp_hooked(
         // cert:T0.3 — time root presolve bound reduction.
         let pr = {
             let _t = crate::profile::Timer::new(crate::profile::Phase::NodeReduce);
-            tighten_bounds(lp, b, &is_int_full, opts.simplex.tol)
+            tighten_bounds_csc(
+                &csc_w,
+                lp.m,
+                n,
+                lp.l,
+                lp.u,
+                b,
+                &is_int_full,
+                opts.simplex.tol,
+            )
         };
         if pr.infeasible {
             return MilpResult {
@@ -348,7 +362,6 @@ pub fn solve_milp_hooked(
     // Working LP, possibly augmented with root cuts. Cuts add rows + slack
     // columns; structural columns [0, ns) are untouched, so the tree's
     // structural bounds still apply unchanged.
-    let mut a_w = lp.a.to_vec();
     let mut b_w = b.to_vec();
     let mut c_w = lp.c.to_vec();
     let mut l_w = base_l;
@@ -395,9 +408,9 @@ pub fn solve_milp_hooked(
     //     set; loose caps (≈8×) drive the per-node LP cost up and erase it. Cuts
     //     are kept globally valid and never removed, so a tight cap is the cheap
     //     stand-in for SCIP-style aging.
-    let struct_nnz: usize = (0..m_w)
-        .map(|i| (0..ns).filter(|&j| a_w[i * n_w + j] != 0.0).count())
-        .sum();
+    // Nonzeros in the structural columns [0, ns): the CSC's column pointer at `ns`
+    // (columns are stored contiguously) — identical to the dense per-row count.
+    let struct_nnz: usize = csc_w.raw().0[ns];
     let row_density = struct_nnz as f64 / (m_w.max(1) * ns.max(1)) as f64;
     const NODE_CUT_MAX_DENSITY: f64 = 0.5;
     let node_cuts_on = opts.node_cuts && row_density < NODE_CUT_MAX_DENSITY;
@@ -437,23 +450,12 @@ pub fn solve_milp_hooked(
             if total_cuts >= opts.root_cuts {
                 break;
             }
-            let root_lp = LpView {
-                a: &a_w,
-                m: m_w,
-                n: n_w,
-                c: &c_w,
-                l: &l_w,
-                u: &u_w,
-            };
             let root = {
                 let _t = crate::profile::Timer::new(crate::profile::Phase::RootSolve);
-                // T2 (docs/dev/sparse-milp-plan.md): solve the root relaxation from
-                // CSC via the bit-identical `solve_lp_root_csc`. The CSC is derived
-                // from `a_w` here only until T3 removes the dense working matrix; the
-                // node solves already run on CSC, so this makes the WHOLE per-round
-                // solve path sparse, gated bit-identical by `driver_matches_golden`.
-                let root_csc = SparseCols::from_dense(&a_w, m_w, n_w);
-                solve_lp_root_csc(&root_csc, m_w, n_w, &c_w, &l_w, &u_w, &b_w, &node_simplex)
+                // Solve the root relaxation directly from the working CSC (T3b5: no
+                // dense matrix). Bit-identical to `solve_lp_root` (gated by
+                // `driver_matches_golden`).
+                solve_lp_root_csc(&csc_w, m_w, n_w, &c_w, &l_w, &u_w, &b_w, &node_simplex)
             };
             lp_iters += root.iters;
             if root.status != LpStatus::Optimal {
@@ -475,8 +477,12 @@ pub fn solve_milp_hooked(
             // Gomory mixed-integer cuts off the native basis.
             let mut cuts = {
                 let _t = crate::profile::Timer::new(crate::profile::Phase::SepCover);
-                separate_cover(
-                    &root_lp,
+                separate_cover_csc(
+                    &csc_w,
+                    n_w,
+                    m_w,
+                    &l_w,
+                    &u_w,
                     &b_w,
                     &root.x,
                     ns,
@@ -487,8 +493,12 @@ pub fn solve_milp_hooked(
             };
             if opts.gmi_cuts {
                 let _t = crate::profile::Timer::new(crate::profile::Phase::SepGomory);
-                cuts.extend(separate_gomory(
-                    &root_lp,
+                cuts.extend(separate_gomory_cols(
+                    &csc_w,
+                    m_w,
+                    n_w,
+                    &l_w,
+                    &u_w,
                     &b_w,
                     &root.basis,
                     &is_int_full,
@@ -510,8 +520,8 @@ pub fn solve_milp_hooked(
                 break;
             }
             total_cuts += new_cuts.len();
-            let (nm, nn) = augment_with_cuts(
-                &mut a_w,
+            let (nw_csc, nm, nn) = augment_csc_with_cuts(
+                &csc_w,
                 &mut b_w,
                 &mut c_w,
                 &mut l_w,
@@ -521,6 +531,7 @@ pub fn solve_milp_hooked(
                 n_w,
                 &new_cuts,
             );
+            csc_w = nw_csc;
             m_w = nm;
             n_w = nn;
         }
@@ -639,28 +650,32 @@ pub fn solve_milp_hooked(
         // ill-scaled lifted LP this is the dominant per-node cost; sharing it lets
         // the 64 nodes pay one equilibration. When the matrix is well-conditioned
         // (`None`) the nodes solve the original LP unchanged.
-        let scaling = Scaling::from_matrix(&a_w, m_w, n_w);
-        let (a_s, c_s, b_s) = match &scaling {
-            Some(s) => (s.scale_matrix(&a_w), s.scale_c(&c_w), s.scale_b(&b_w)),
-            None => (Vec::new(), Vec::new(), Vec::new()),
+        let scaling = Scaling::from_sparse(&csc_w, m_w, n_w);
+        let (c_s, b_s) = match &scaling {
+            Some(s) => (s.scale_c(&c_w), s.scale_b(&b_w)),
+            None => (Vec::new(), Vec::new()),
         };
-        // Solve-space matrix/objective/rhs: the scaled copies when scaling, else
-        // the originals (borrowed). Node bounds are scaled per node (cheap).
-        let (sa, sc, sb): (&[f64], &[f64], &[f64]) = match &scaling {
-            Some(_) => (&a_s, &c_s, &b_s),
-            None => (&a_w, &c_w, &b_w),
+        // Solve-space objective/rhs: the scaled copies when scaling, else the
+        // originals (borrowed). Node bounds are scaled per node (cheap).
+        let (sc, sb): (&[f64], &[f64]) = match &scaling {
+            Some(_) => (&c_s, &b_s),
+            None => (&c_w, &b_w),
         };
-        // CSC of the solve-space matrix, built once and shared by every node solve
-        // in this batch (the matrix is constant within a batch). This lifts the
-        // per-node `SparseCols::from_dense` O(m·n) rebuild out of the warm solve.
-        let csc_batch = SparseCols::from_dense(sa, m_w, n_w);
-        // Reduced-cost fixing needs the *unscaled* duals/reduced costs (the integer
-        // bound fixing reasons in true objective units), so it gets the CSC of the
-        // unscaled working matrix. When the matrix isn't scaled this is exactly
-        // `csc_batch` (no second build); otherwise build it once for the batch.
-        let csc_unscaled_owned = scaling
-            .as_ref()
-            .map(|_| SparseCols::from_dense(&a_w, m_w, n_w));
+        // Solve-space CSC of the working matrix, built once and shared by every node
+        // solve in this batch (the matrix is constant within a batch): scale the
+        // working CSC by the batch factors, or reuse it unscaled. Never densified.
+        let csc_batch = match &scaling {
+            Some(s) => {
+                let mut c = csc_w.clone();
+                s.scale_cols(&mut c);
+                c
+            }
+            None => csc_w.clone(),
+        };
+        // Reduced-cost fixing (and the unscaled per-node consumers) reason in true
+        // objective units, so they use the CSC of the *unscaled* working matrix. When
+        // the matrix isn't scaled this is exactly `csc_batch` (no second build).
+        let csc_unscaled_owned = scaling.as_ref().map(|_| csc_w.clone());
         let csc_rc: &SparseCols = csc_unscaled_owned.as_ref().unwrap_or(&csc_batch);
         let sb_active = opts.strong_branch && tm.stats().total_nodes < opts.sb_node_budget;
         let mut results = Vec::with_capacity(batch.node_ids.len());
@@ -679,13 +694,11 @@ pub fn solve_milp_hooked(
         // the mutable reduce below.
         let outputs: Vec<NodeOutput> = {
             let ctx = NodeCtx {
-                a_w: &a_w,
                 b_w: &b_w,
                 c_w: &c_w,
                 l_w: &l_w,
                 u_w: &u_w,
                 scaling: scaling.as_ref(),
-                sa,
                 sc,
                 sb,
                 csc: &csc_batch,
@@ -830,8 +843,8 @@ pub fn solve_milp_hooked(
         // Stored node bases are extended lazily on their next solve, so children
         // warm-start through the dual simplex from the cut-augmented basis.
         if !pending_cuts.is_empty() {
-            let (nm, nn) = augment_with_cuts(
-                &mut a_w,
+            let (nw_csc, nm, nn) = augment_csc_with_cuts(
+                &csc_w,
                 &mut b_w,
                 &mut c_w,
                 &mut l_w,
@@ -841,6 +854,7 @@ pub fn solve_milp_hooked(
                 n_w,
                 &pending_cuts,
             );
+            csc_w = nw_csc;
             m_w = nm;
             n_w = nn;
             slack_l = l_w[ns..].to_vec();
@@ -890,26 +904,23 @@ pub fn solve_milp_hooked(
 /// tree's read-only state. All fields are `Sync`, so `solve_node` runs under
 /// `rayon`'s `into_par_iter` over the batch.
 struct NodeCtx<'a> {
-    a_w: &'a [f64],
     b_w: &'a [f64],
     c_w: &'a [f64],
     l_w: &'a [f64],
     u_w: &'a [f64],
     /// Equilibration for the working matrix (shared across the batch), or `None`
     /// when it is well-conditioned. When `Some`, the node LP is solved on the
-    /// pre-scaled `sa`/`sc`/`sb` and the solution is unscaled before use.
+    /// pre-scaled `csc`/`sc`/`sb` and the solution is unscaled before use.
     scaling: Option<&'a Scaling>,
-    /// Solve-space matrix / objective / rhs: scaled copies when `scaling` is
-    /// `Some`, else the originals (`a_w`/`c_w`/`b_w`).
-    sa: &'a [f64],
+    /// Solve-space objective / rhs: scaled copies when `scaling` is `Some`, else the
+    /// originals (`c_w`/`b_w`).
     sc: &'a [f64],
     sb: &'a [f64],
-    /// CSC view of the solve-space matrix `sa`, built **once per batch** and
-    /// shared by every node/strong-branch/dive LP solve in the batch. The working
-    /// matrix is constant within a batch (cuts fold in only between batches), so
-    /// this removes the per-node `SparseCols::from_dense` rebuild from the warm
-    /// solve. Built from `sa`, so it matches whichever (scaled or raw) matrix the
-    /// node solves see.
+    /// CSC view of the solve-space (scaled when `scaling` is `Some`) working matrix,
+    /// built **once per batch** and shared by every node/strong-branch/dive LP solve
+    /// in the batch. The working matrix is constant within a batch (cuts fold in only
+    /// between batches). The MILP driver is fully sparse: no dense `m×n` working
+    /// matrix is ever materialized, so a large sparse relaxation never blows up.
     csc: &'a SparseCols,
     /// CSC view of the **unscaled** working matrix `a_w`, for reduced-cost fixing
     /// (which reasons in true objective units, so it needs unscaled duals/reduced
@@ -1044,18 +1055,21 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
     // (including cut rows) with the node's local bounds.
     let mut tightened: Option<(Vec<f64>, Vec<f64>)> = None;
     if ctx.opts.node_propagation {
-        let prop_lp = LpView {
-            a: ctx.a_w,
-            m: ctx.m_w,
-            n: ctx.n_w,
-            c: ctx.c_w,
-            l: &full_l,
-            u: &full_u,
-        };
         let pr = {
-            // cert:T0.3 — time per-node FBBT/constraint propagation.
+            // cert:T0.3 — time per-node FBBT/constraint propagation. T3b5: FBBT on
+            // the UNSCALED working CSC (`ctx.csc_rc`; the dense `prop_lp.a` was
+            // `ctx.a_w`, unscaled), bit-identical to the dense `tighten_bounds`.
             let _t = crate::profile::Timer::new(crate::profile::Phase::Fbbt);
-            tighten_bounds(&prop_lp, ctx.b_w, ctx.is_int_full, ctx.opts.simplex.tol)
+            tighten_bounds_csc(
+                ctx.csc_rc,
+                ctx.m_w,
+                ctx.n_w,
+                &full_l,
+                &full_u,
+                ctx.b_w,
+                ctx.is_int_full,
+                ctx.opts.simplex.tol,
+            )
         };
         if pr.infeasible {
             // Proven-empty box ⇒ prune this node (a valid fathom, like an
@@ -1086,17 +1100,6 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
         full_l = pr.l;
         full_u = pr.u;
     }
-    // Original-space LP, used by the cut separators, rounding, and strong
-    // branching (which all reason about the model's true coefficients/values).
-    let node_lp = LpView {
-        a: ctx.a_w,
-        m: ctx.m_w,
-        n: ctx.n_w,
-        c: ctx.c_w,
-        l: &full_l,
-        u: &full_u,
-    };
-
     // Solve on the batch's shared (pre-scaled, when ill-conditioned) matrix. Only
     // the per-node bounds are scaled here; the matrix/objective/rhs were scaled
     // once for the whole batch. The basis is scaling-invariant, so a warm start
@@ -1110,7 +1113,7 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
         None => (full_l.clone(), full_u.clone()),
     };
     let solve_lp_view = LpView {
-        a: ctx.sa,
+        a: &[], // T3b5: matrix comes from `ctx.csc`; `.a` unused by the CSC solvers.
         m: ctx.m_w,
         n: ctx.n_w,
         c: ctx.sc,
@@ -1169,13 +1172,29 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
                             ctx.csc,
                         );
                         match warm.status {
-                            LpStatus::IterLimit | LpStatus::Numerical => {
-                                solve_lp_scaled(&solve_lp_view, ctx.sb, ctx.simplex)
-                            }
+                            LpStatus::IterLimit | LpStatus::Numerical => solve_lp_cols(
+                                ctx.csc.clone(),
+                                ctx.m_w,
+                                ctx.n_w,
+                                ctx.sc,
+                                &sl,
+                                &su,
+                                ctx.sb,
+                                ctx.simplex,
+                            ),
                             _ => warm,
                         }
                     }
-                    None => solve_lp_scaled(&solve_lp_view, ctx.sb, ctx.simplex),
+                    None => solve_lp_cols(
+                        ctx.csc.clone(),
+                        ctx.m_w,
+                        ctx.n_w,
+                        ctx.sc,
+                        &sl,
+                        &su,
+                        ctx.sb,
+                        ctx.simplex,
+                    ),
                 }
             }
         }
@@ -1254,11 +1273,11 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             // Primal heuristic: round this fractional point so the reduce can
             // inject a feasible incumbent early and prune more of the tree.
             if ctx.opts.heuristics && !feasible && !time_up {
-                out.incumbent = try_rounding(
+                out.incumbent = try_rounding_csc(
                     &sol.x,
                     ctx.ns,
                     ctx.is_int,
-                    ctx.a_w,
+                    ctx.csc_rc, // T3b5: unscaled working CSC (was ctx.a_w)
                     ctx.b_w,
                     ctx.c_w,
                     ctx.l_w,
@@ -1286,8 +1305,12 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             // dedups them into the shared pool to tighten the whole tree.
             if !feasible && ctx.pool_room && !time_up {
                 let _t = crate::profile::Timer::new(crate::profile::Phase::SepCover);
-                out.found_cuts = separate_cover(
-                    &node_lp,
+                out.found_cuts = separate_cover_csc(
+                    ctx.csc_rc, // T3b5: unscaled working CSC (was node_lp.a = ctx.a_w)
+                    ctx.n_w,
+                    ctx.m_w,
+                    ctx.l_w,
+                    ctx.u_w,
                     ctx.b_w,
                     &sol.x,
                     ctx.ns,
@@ -1341,7 +1364,10 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
             // Numerical arm below). A sound infeasible LP always exports a
             // verifiable ray, so this costs one mat-vec and never changes a
             // correct fathom.
-            if verify_farkas_infeasible(&sol.dual, ctx.sa, ctx.sb, &sl, &su, ctx.m_w, ctx.n_w) {
+            // T3b5: farkas check on the SCALED working CSC (`ctx.csc`; the dual/ray
+            // and `sl`/`su`/`ctx.sb` are all in scaled space, as `ctx.sa` was).
+            if verify_farkas_infeasible_csc(&sol.dual, ctx.csc, ctx.sb, &sl, &su, ctx.m_w, ctx.n_w)
+            {
                 out.result = NodeResult {
                     node_id: id,
                     lower_bound: INFEAS_SENTINEL, // pruned
@@ -1412,6 +1438,7 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
 /// certify. Runs on the scaled solve-space data (`sa`, `sb`, scaled `l`/`u`), where
 /// the returned ray lives; the safe-bound identity is invariant under
 /// equilibration, so the verdict matches the original space.
+#[allow(dead_code)] // retained as the differential oracle for the CSC port (tests)
 fn verify_farkas_infeasible(
     y: &[f64],
     a: &[f64],
@@ -1441,6 +1468,7 @@ fn verify_farkas_infeasible(
 /// `1e-18` dribble would send `g0` to `−∞` and reject a valid certificate). A reduced
 /// cost genuinely past that tolerance toward an infinite bound does push `g0` to
 /// `−∞`: this ray cannot certify emptiness and the caller keeps the node.
+#[allow(dead_code)] // retained as the differential oracle for the CSC port (tests)
 fn farkas_safe_bound(
     y: &[f64],
     a: &[f64],
@@ -1801,6 +1829,7 @@ fn reduced_cost_fix(
 /// as `coeffs·x − s = rhs` surplus rows (`s ≥ 0`), growing the dense matrix and
 /// the bound/cost/integrality vectors. Returns the new `(m, n)`.
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)] // retained as the differential oracle for the CSC port (tests)
 fn augment_with_cuts(
     a_w: &mut Vec<f64>,
     b_w: &mut Vec<f64>,
@@ -1883,6 +1912,37 @@ fn augment_cols_with_cuts(sp: &SparseCols, m: usize, n: usize, cuts: &[GomoryCut
     SparseCols::from_csc(new_col_ptr, new_row_idx, new_vals)
 }
 
+/// Full CSC analogue of [`augment_with_cuts`] (T3b5): augment the matrix via
+/// [`augment_cols_with_cuts`] AND append the `k` surplus rows/cols to
+/// `b/c/l/u/is_int` exactly as the dense version does. Returns the grown CSC and new
+/// `(m, n)`.
+#[allow(clippy::too_many_arguments)]
+fn augment_csc_with_cuts(
+    csc: &SparseCols,
+    b_w: &mut Vec<f64>,
+    c_w: &mut Vec<f64>,
+    l_w: &mut Vec<f64>,
+    u_w: &mut Vec<f64>,
+    is_int_full: &mut Vec<bool>,
+    m_w: usize,
+    n_w: usize,
+    cuts: &[GomoryCut],
+) -> (SparseCols, usize, usize) {
+    let k = cuts.len();
+    if k == 0 {
+        return (csc.clone(), m_w, n_w);
+    }
+    let new_csc = augment_cols_with_cuts(csc, m_w, n_w, cuts);
+    for cut in cuts {
+        b_w.push(cut.rhs);
+        c_w.push(0.0);
+        l_w.push(0.0);
+        u_w.push(INF);
+        is_int_full.push(false);
+    }
+    (new_csc, m_w + k, n_w + k)
+}
+
 /// Sparse signature of a cut for pool deduplication: its nonzero `(col, coeff)`
 /// pairs (quantized) plus the rhs, so an identical cut found at many nodes is
 /// added to the pool only once.
@@ -1936,6 +1996,7 @@ fn extend_basis(mut basis: Basis, n_w: usize) -> Basis {
 /// it is feasible for knapsack-like rows). Returns the better feasible candidate.
 /// Cheap (`O(ns · n_orig_rows)`); an early incumbent prunes the whole tree.
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)] // retained as the differential oracle for the CSC port (tests)
 fn try_rounding(
     x: &[f64],
     ns: usize,
@@ -2210,7 +2271,7 @@ fn try_dive_repair(
                 None => (full_l.clone(), full_u.clone()),
             };
             let view = LpView {
-                a: ctx.sa,
+                a: &[], // T3b5: matrix comes from `ctx.csc`; `.a` unused by CSC solve.
                 m: ctx.m_w,
                 n: ctx.n_w,
                 c: ctx.sc,

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -1491,6 +1491,74 @@ fn farkas_safe_bound(
     g > margin
 }
 
+/// CSC port of [`farkas_safe_bound`] (docs/dev/sparse-milp-plan.md T3b1). Bit-identical:
+/// the only matrix use is `(Aᵀy)ⱼ`, which `csc.dot(j, y)` computes as the same sum of
+/// the same nonzero products (multiplication commutes; structural zeros add `0.0`
+/// exactly; CSC preserves ascending row order). Never materializes the dense matrix.
+#[allow(dead_code)] // wired into the driver at T3b5
+fn farkas_safe_bound_csc(
+    y: &[f64],
+    csc: &SparseCols,
+    b: &[f64],
+    l: &[f64],
+    u: &[f64],
+    m: usize,
+    n: usize,
+) -> bool {
+    let ynorm = y.iter().fold(0.0f64, |acc, &v| acc.max(v.abs()));
+    let rc_tol = 1e-7 * ynorm.max(1.0);
+    let mut g = 0.0f64;
+    let mut scale = 0.0f64;
+    for i in 0..m {
+        g += b[i] * y[i];
+        scale = scale.max((b[i] * y[i]).abs());
+    }
+    for j in 0..n {
+        let aty = csc.dot(j, y);
+        let mut rc = -aty;
+        if rc.abs() <= rc_tol {
+            rc = 0.0;
+        }
+        let term = if rc > 0.0 {
+            if l[j] <= -INF {
+                return false;
+            }
+            rc * l[j]
+        } else if rc < 0.0 {
+            if u[j] >= INF {
+                return false;
+            }
+            rc * u[j]
+        } else {
+            0.0
+        };
+        g += term;
+        scale = scale.max(term.abs());
+    }
+    let margin = 1e-9 * scale.max(1.0);
+    g > margin
+}
+
+/// CSC port of [`verify_farkas_infeasible`].
+#[allow(dead_code)] // wired into the driver at T3b5
+fn verify_farkas_infeasible_csc(
+    y: &[f64],
+    csc: &SparseCols,
+    b: &[f64],
+    l: &[f64],
+    u: &[f64],
+    m: usize,
+    n: usize,
+) -> bool {
+    if y.len() != m || m == 0 {
+        return false;
+    }
+    farkas_safe_bound_csc(y, csc, b, l, u, m, n) || {
+        let neg: Vec<f64> = y.iter().map(|v| -v).collect();
+        farkas_safe_bound_csc(&neg, csc, b, l, u, m, n)
+    }
+}
+
 /// Limited strong branching. For the *unreliable* fractional candidates (those
 /// whose pseudocosts aren't trusted yet), probe both child bounds with a warm
 /// dual re-solve from the node's basis and pick the variable with the best
@@ -1932,6 +2000,88 @@ fn try_rounding(
             .collect()
     };
 
+    let mut best: Option<(Vec<f64>, f64)> = None;
+    let mut consider = |xc: Vec<f64>| {
+        if feasible(&xc) {
+            let o = obj(&xc);
+            if best.as_ref().map(|(_, bo)| o < *bo).unwrap_or(true) {
+                best = Some((xc, o));
+            }
+        }
+    };
+    consider(make(&|v: f64| v.round()));
+    consider(make(&|v: f64| v.floor()));
+    best
+}
+
+/// CSC port of [`try_rounding`] (docs/dev/sparse-milp-plan.md T3b1). Bit-identical:
+/// the slack range (`slack_lo/hi`, xc-independent) and the per-row activity `act` are
+/// accumulated by CSC column iteration in the SAME ascending order as the dense
+/// per-row loops, and a structural `0.0` adds exactly, so every row sum matches
+/// term-for-term. Never materializes the dense matrix.
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)] // wired into the driver at T3b5
+fn try_rounding_csc(
+    x: &[f64],
+    ns: usize,
+    is_int: &[bool],
+    csc: &SparseCols,
+    b_w: &[f64],
+    c_w: &[f64],
+    l_w: &[f64],
+    u_w: &[f64],
+    n_orig_rows: usize,
+    n_w: usize,
+    obj_const: f64,
+) -> Option<(Vec<f64>, f64)> {
+    let (col_ptr, row_idx, vals) = csc.raw();
+    let mut slack_lo = vec![0.0f64; n_orig_rows];
+    let mut slack_hi = vec![0.0f64; n_orig_rows];
+    for k in ns..n_w {
+        for idx in col_ptr[k]..col_ptr[k + 1] {
+            let i = row_idx[idx];
+            if i >= n_orig_rows {
+                continue;
+            }
+            let aik = vals[idx];
+            let (c1, c2) = (aik * l_w[k], aik * u_w[k]);
+            slack_lo[i] += c1.min(c2);
+            slack_hi[i] += c1.max(c2);
+        }
+    }
+    let feasible = |xc: &[f64]| -> bool {
+        let mut act = vec![0.0f64; n_orig_rows];
+        for j in 0..ns {
+            for idx in col_ptr[j]..col_ptr[j + 1] {
+                let i = row_idx[idx];
+                if i >= n_orig_rows {
+                    continue;
+                }
+                act[i] += vals[idx] * xc[j];
+            }
+        }
+        for i in 0..n_orig_rows {
+            let resid = b_w[i] - act[i];
+            if resid < slack_lo[i] - 1e-6 || resid > slack_hi[i] + 1e-6 {
+                return false;
+            }
+        }
+        true
+    };
+    let obj = |xc: &[f64]| -> f64 { (0..ns).map(|j| c_w[j] * xc[j]).sum::<f64>() + obj_const };
+    let make = |round: &dyn Fn(f64) -> f64| -> Vec<f64> {
+        (0..ns)
+            .map(|j| {
+                let v = if is_int[j] { round(x[j]) } else { x[j] };
+                let (lo, hi) = if l_w[j] <= u_w[j] {
+                    (l_w[j], u_w[j])
+                } else {
+                    (u_w[j], l_w[j])
+                };
+                v.clamp(lo, hi)
+            })
+            .collect()
+    };
     let mut best: Option<(Vec<f64>, f64)> = None;
     let mut consider = |xc: Vec<f64>| {
         if feasible(&xc) {
@@ -3243,6 +3393,54 @@ mod sparse_milp_diff {
         // b/c/l/u/is_int side-effects (independent of the matrix layout) match the k
         // appended surplus rows/cols.
         assert_eq!((mn, nn), (m + cuts.len(), n + cuts.len()));
+    }
+
+    /// T3b1 gate: `farkas_safe_bound_csc`/`verify_farkas_infeasible_csc` give the
+    /// identical verdict to their dense oracles across several rays.
+    #[test]
+    fn farkas_csc_matches_dense() {
+        let a = vec![2.0, 0.0, -1.0, 0.0, 3.0, 1.0, 1.0, -2.0, 0.0]; // 3×3
+        let (m, n) = (3usize, 3usize);
+        let b = vec![1.0, -2.0, 0.5];
+        let l = vec![0.0, 0.0, 0.0];
+        let u = vec![INF, INF, INF];
+        let csc = SparseCols::from_dense(&a, m, n);
+        for y in [
+            vec![1.0, -1.0, 2.0],
+            vec![0.5, 0.5, 0.5],
+            vec![-3.0, 1.0, 0.0],
+            vec![0.0, 0.0, 0.0],
+        ] {
+            assert_eq!(
+                farkas_safe_bound(&y, &a, &b, &l, &u, m, n),
+                farkas_safe_bound_csc(&y, &csc, &b, &l, &u, m, n),
+                "farkas verdict drift for y={y:?}"
+            );
+            assert_eq!(
+                verify_farkas_infeasible(&y, &a, &b, &l, &u, m, n),
+                verify_farkas_infeasible_csc(&y, &csc, &b, &l, &u, m, n),
+            );
+        }
+    }
+
+    /// T3b1 gate: `try_rounding_csc` returns the identical incumbent (or `None`) as
+    /// the dense oracle across fractional/integral start points.
+    #[test]
+    fn try_rounding_csc_matches_dense() {
+        let a = vec![1.0, 1.0, 1.0]; // 1×3: x0 + x1 + s = b
+        let (ns, n_orig_rows, n_w) = (2usize, 1usize, 3usize);
+        let b = vec![1.0];
+        let c = vec![-1.0, -1.0, 0.0];
+        let l = vec![0.0, 0.0, 0.0];
+        let u = vec![1.0, 1.0, INF];
+        let is_int = vec![true, true, false];
+        let csc = SparseCols::from_dense(&a, n_orig_rows, n_w);
+        for x in [vec![0.6, 0.3], vec![1.0, 1.0], vec![0.0, 0.0]] {
+            let dense = try_rounding(&x, ns, &is_int, &a, &b, &c, &l, &u, n_orig_rows, n_w, 0.0);
+            let cscr =
+                try_rounding_csc(&x, ns, &is_int, &csc, &b, &c, &l, &u, n_orig_rows, n_w, 0.0);
+            assert_eq!(dense, cscr, "try_rounding drift for x={x:?}");
+        }
     }
 
     /// The CSC of each instance round-trips the dense matrix's exact nonzeros

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -2163,6 +2163,55 @@ fn warm_root_opts(opts: &SimplexOptions, m: usize, n: usize) -> SimplexOptions {
     o
 }
 
+/// Reconstruct the dense row-major `m×n` matrix from a column-major
+/// [`SparseCols`]. **Temporary T1 bridge** (docs/dev/sparse-milp-plan.md): the CSC
+/// entry densifies here and calls the reference dense driver so the CSC path is
+/// provably bit-identical to the dense path, while T2/T3 sparsify the driver
+/// internals (root solve, scaling, cut appends) and remove this densification. It
+/// therefore does NOT yet fix the memory blow-up on a large sparse relaxation —
+/// that is T3's job — it only establishes the entry point and its differential gate.
+fn csc_to_dense(csc: &SparseCols, m: usize, n: usize) -> Vec<f64> {
+    let mut a = vec![0.0; m * n];
+    for j in 0..n {
+        let (rows, vals) = csc.col(j);
+        for (&i, &v) in rows.iter().zip(vals) {
+            a[i * n + j] = v;
+        }
+    }
+    a
+}
+
+/// CSC-input entry to the MILP branch-and-bound driver
+/// (docs/dev/sparse-milp-plan.md, T1). Identical contract and result to
+/// [`solve_milp`], but the equality-constraint matrix arrives column-major as a
+/// [`SparseCols`] (`m` rows, `n` columns) so a large *sparse* relaxation need not be
+/// densified by the caller / Python boundary. T1 bridges to the dense driver via
+/// [`csc_to_dense`]; the differential harness gates it bit-identical to
+/// [`solve_milp`] on the panel, and T2/T3 remove the internal densification so the
+/// sparse matrix flows through untouched.
+pub fn solve_milp_csc(
+    csc: &SparseCols,
+    m: usize,
+    n: usize,
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    obj_const: f64,
+    opts: &MilpOptions,
+) -> MilpResult {
+    let a = csc_to_dense(csc, m, n);
+    let lp = LpView {
+        a: &a,
+        m,
+        n,
+        c,
+        l,
+        u,
+    };
+    solve_milp(&lp, b, obj_const, opts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2720,12 +2769,25 @@ mod sparse_milp_diff {
             solve_milp(&self.dense_view(), &self.b, 0.0, &self.opts())
         }
 
-        /// CSC view of this instance's matrix. T1 will feed this to the CSC driver
-        /// entry; kept here so the harness already exercises `from_dense`/`from_csc`
-        /// round-tripping the same nonzeros the dense path sees.
-        #[allow(dead_code)]
+        /// CSC view of this instance's matrix, fed to the CSC driver entry.
         fn csc(&self) -> SparseCols {
             SparseCols::from_dense(&self.a, self.m, self.n)
+        }
+
+        /// Solve through the T1 CSC entry point [`solve_milp_csc`].
+        fn solve_csc(&self) -> MilpResult {
+            let sp = self.csc();
+            solve_milp_csc(
+                &sp,
+                self.m,
+                self.n,
+                &self.c,
+                &self.l,
+                &self.u,
+                &self.b,
+                0.0,
+                &self.opts(),
+            )
         }
     }
 
@@ -2880,6 +2942,34 @@ mod sparse_milp_diff {
             let r2 = case.solve_dense();
             assert_same(case.name, &r1, &r2);
             assert_eq!(r1.lp_iters, r2.lp_iters, "{}: lp_iters drift", case.name);
+        }
+    }
+
+    /// T1 gate: the CSC entry point [`solve_milp_csc`] is bit-identical to the
+    /// dense [`solve_milp`] on every panel case — same status, node count, objective,
+    /// bound, and incumbent length. Any drift means the CSC path perturbed the
+    /// solve, which would corrupt a dual bound (the whole point of the gate).
+    #[test]
+    fn csc_entry_matches_dense_on_panel() {
+        for case in panel() {
+            let dense = case.solve_dense();
+            let csc = case.solve_csc();
+            assert_same(case.name, &dense, &csc);
+            assert_eq!(
+                dense.x.len(),
+                csc.x.len(),
+                "{}: incumbent length",
+                case.name
+            );
+            if dense.status == MilpStatus::Optimal {
+                for (k, (xd, xc)) in dense.x.iter().zip(csc.x.iter()).enumerate() {
+                    assert!(
+                        (xd - xc).abs() < 1e-9,
+                        "{}: incumbent[{k}] drift {xd} {xc}",
+                        case.name
+                    );
+                }
+            }
         }
     }
 

--- a/crates/discopt-core/src/lp/cover.rs
+++ b/crates/discopt-core/src/lp/cover.rs
@@ -19,6 +19,7 @@
 
 use crate::lp::crossover::LpView;
 use crate::lp::gomory::GomoryCut;
+use crate::lp::simplex::sparse::SparseCols;
 
 /// Capacity ceiling for the integer lifting DP; above it we emit the basic cover.
 const MAX_CAP_DP: f64 = 100_000.0;
@@ -42,157 +43,203 @@ pub fn separate_cover(
 ) -> Vec<GomoryCut> {
     let (a, n) = (lp.a, lp.n);
     let mut cuts = Vec::new();
-
+    let mut row_nz: Vec<(usize, f64)> = Vec::new();
     for i in 0..n_orig_rows.min(lp.m) {
         let row = &a[i * n..(i + 1) * n];
-
-        // Require exactly one slack column (≥ ns) with coefficient +1 and
-        // bounds [0, ∞): i.e. a genuine `≤` row.
-        let mut slack: Option<usize> = None;
-        let mut ok = true;
-        for j in ns..n {
-            if row[j].abs() > tol {
-                if slack.is_some() || (row[j] - 1.0).abs() > tol {
-                    ok = false;
-                    break;
-                }
-                slack = Some(j);
+        row_nz.clear();
+        for (j, &v) in row.iter().enumerate() {
+            if v != 0.0 {
+                row_nz.push((j, v));
             }
         }
-        let s = match (ok, slack) {
-            (true, Some(s)) => s,
-            _ => continue,
-        };
-        // The slack must be a `≤` surplus (lower bound 0); its upper bound is
-        // irrelevant to cover validity (presolve may have tightened it to ≤ cap).
-        if lp.l[s].abs() > tol {
+        if let Some(cut) = cover_cut_for_row(&row_nz, ns, n, lp.l, lp.u, is_int, x, b[i], tol) {
+            cuts.push(cut);
+        }
+    }
+    cuts
+}
+
+/// CSC port of [`separate_cover`] (docs/dev/sparse-milp-plan.md T3b2). Bit-identical:
+/// per-row nonzeros are gathered from the CSC by a single `O(nnz)` column sweep,
+/// landing column-ascending per row exactly as the dense row scan produces them, and
+/// the shared [`cover_cut_for_row`] runs the same code. Never materializes the dense
+/// matrix.
+#[allow(clippy::too_many_arguments)]
+pub fn separate_cover_csc(
+    csc: &SparseCols,
+    n: usize,
+    m: usize,
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    x: &[f64],
+    ns: usize,
+    is_int: &[bool],
+    n_orig_rows: usize,
+    tol: f64,
+) -> Vec<GomoryCut> {
+    let rows = n_orig_rows.min(m);
+    let mut row_nz: Vec<Vec<(usize, f64)>> = vec![Vec::new(); rows];
+    let (col_ptr, row_idx, vals) = csc.raw();
+    for j in 0..n {
+        for idx in col_ptr[j]..col_ptr[j + 1] {
+            let i = row_idx[idx];
+            if i < rows {
+                row_nz[i].push((j, vals[idx]));
+            }
+        }
+    }
+    let mut cuts = Vec::new();
+    for (i, nz) in row_nz.iter().enumerate() {
+        if let Some(cut) = cover_cut_for_row(nz, ns, n, l, u, is_int, x, b[i], tol) {
+            cuts.push(cut);
+        }
+    }
+    cuts
+}
+
+/// Shared cover-cut construction for a single `≤` row, given its nonzeros
+/// `(col, coeff)` in ascending-column order. Returns a violated lifted-minimal-cover
+/// cut or `None`. Representation-independent: the dense and CSC entries differ ONLY
+/// in how they gather `row_nz`, so both emit byte-identical cuts.
+#[allow(clippy::too_many_arguments)]
+fn cover_cut_for_row(
+    row_nz: &[(usize, f64)],
+    ns: usize,
+    n: usize,
+    l: &[f64],
+    u: &[f64],
+    is_int: &[bool],
+    x: &[f64],
+    cap: f64,
+    tol: f64,
+) -> Option<GomoryCut> {
+    // Require exactly one slack column (≥ ns) with coefficient +1 and l=0: a `≤` row.
+    let mut slack: Option<usize> = None;
+    for &(j, v) in row_nz {
+        if j >= ns && v.abs() > tol {
+            if slack.is_some() || (v - 1.0).abs() > tol {
+                return None;
+            }
+            slack = Some(j);
+        }
+    }
+    let s = slack?;
+    if l[s].abs() > tol {
+        return None;
+    }
+    // Structural items must be binary with nonnegative weights.
+    let mut items: Vec<(usize, f64, f64)> = Vec::new();
+    for &(j, w) in row_nz {
+        if j >= ns || w.abs() <= tol {
             continue;
         }
+        if w < -tol || !is_int[j] || l[j] < -tol || u[j] > 1.0 + tol {
+            return None;
+        }
+        items.push((j, w, x[j]));
+    }
+    if items.is_empty() {
+        return None;
+    }
 
-        // Structural items must be binary with nonnegative weights.
-        let cap = b[i];
-        let mut items: Vec<(usize, f64, f64)> = Vec::new(); // (col, weight, x*)
-        let mut knap = true;
-        for j in 0..ns {
-            let w = row[j];
-            if w.abs() <= tol {
+    // Greedy cover: add items by x* descending until the weight exceeds cap.
+    items.sort_by(|p, q| q.2.partial_cmp(&p.2).unwrap_or(std::cmp::Ordering::Equal));
+    let mut cover: Vec<(usize, f64, f64)> = Vec::new();
+    let mut wsum = 0.0;
+    let mut xsum = 0.0;
+    for &it in &items {
+        cover.push(it);
+        wsum += it.1;
+        xsum += it.2;
+        if wsum > cap + tol {
+            break;
+        }
+    }
+    if wsum <= cap + tol {
+        return None; // never exceeded cap → not a cover
+    }
+
+    // Reduce to a minimal cover: drop the largest-weight element that keeps it a
+    // cover, repeatedly. Each removal raises the violation (by 1 − x*).
+    loop {
+        cover.sort_by(|p, q| q.1.partial_cmp(&p.1).unwrap_or(std::cmp::Ordering::Equal));
+        let mut removed = false;
+        for idx in 0..cover.len() {
+            if wsum - cover[idx].1 > cap + tol {
+                wsum -= cover[idx].1;
+                xsum -= cover[idx].2;
+                cover.remove(idx);
+                removed = true;
+                break;
+            }
+        }
+        if !removed {
+            break;
+        }
+    }
+
+    // Violated when Σ_C x* > |C| − 1.
+    let rhs_le = cover.len() as f64 - 1.0;
+    if !(xsum > rhs_le + 1e-4 && cover.len() >= 2) {
+        return None;
+    }
+    let rhs_i = cover.len() as i64 - 1; // |C| − 1
+
+    // Cover variables keep coefficient 1; non-cover variables are lifted.
+    let mut coeffs = vec![0.0; n];
+    for &(j, _, _) in &cover {
+        coeffs[j] = -1.0;
+    }
+
+    // Sequential up-lifting via an integer-capacity knapsack DP.
+    let cap_int = cap.round();
+    let integral =
+        (cap - cap_int).abs() < 1e-6 && items.iter().all(|&(_, w, _)| (w - w.round()).abs() < 1e-6);
+    if integral && (0.0..=MAX_CAP_DP).contains(&cap_int) {
+        let capn = cap_int as usize;
+        let mut f = vec![0i64; capn + 1];
+        for &(_, w, _) in &cover {
+            let wi = w.round() as usize;
+            if wi == 0 || wi > capn {
                 continue;
             }
-            if w < -tol || !is_int[j] || lp.l[j] < -tol || lp.u[j] > 1.0 + tol {
-                knap = false;
-                break;
-            }
-            items.push((j, w, x[j]));
-        }
-        if !knap || items.is_empty() {
-            continue;
-        }
-
-        // Greedy cover: add items by x* descending until the weight exceeds cap.
-        items.sort_by(|p, q| q.2.partial_cmp(&p.2).unwrap_or(std::cmp::Ordering::Equal));
-        let mut cover: Vec<(usize, f64, f64)> = Vec::new();
-        let mut wsum = 0.0;
-        let mut xsum = 0.0;
-        for &it in &items {
-            cover.push(it);
-            wsum += it.1;
-            xsum += it.2;
-            if wsum > cap + tol {
-                break;
-            }
-        }
-        if wsum <= cap + tol {
-            continue; // never exceeded cap → not a cover
-        }
-
-        // Reduce to a minimal cover: drop the largest-weight element that keeps
-        // it a cover, repeatedly. Each removal raises the violation (by 1 − x*).
-        loop {
-            cover.sort_by(|p, q| q.1.partial_cmp(&p.1).unwrap_or(std::cmp::Ordering::Equal));
-            let mut removed = false;
-            for idx in 0..cover.len() {
-                if wsum - cover[idx].1 > cap + tol {
-                    wsum -= cover[idx].1;
-                    xsum -= cover[idx].2;
-                    cover.remove(idx);
-                    removed = true;
-                    break;
+            for b in (wi..=capn).rev() {
+                let cand = f[b - wi] + 1;
+                if cand > f[b] {
+                    f[b] = cand;
                 }
             }
-            if !removed {
-                break;
-            }
         }
-
-        // Violated when Σ_C x* > |C| − 1.
-        let rhs_le = cover.len() as f64 - 1.0;
-        if !(xsum > rhs_le + 1e-4 && cover.len() >= 2) {
-            continue;
-        }
-        let rhs_i = cover.len() as i64 - 1; // |C| − 1
-
-        // Cover variables keep coefficient 1; non-cover variables are lifted.
-        let mut coeffs = vec![0.0; n];
-        for &(j, _, _) in &cover {
-            coeffs[j] = -1.0;
-        }
-
-        // Sequential up-lifting via an integer-capacity knapsack DP. Needs
-        // integral weights and a modest capacity; otherwise the basic minimal
-        // cover above is emitted unchanged.
-        let cap_int = cap.round();
-        let integral = (cap - cap_int).abs() < 1e-6
-            && items.iter().all(|&(_, w, _)| (w - w.round()).abs() < 1e-6);
-        if integral && (0.0..=MAX_CAP_DP).contains(&cap_int) {
-            let capn = cap_int as usize;
-            // f[b] = max LHS achievable within capacity b. Seed with the cover
-            // variables (each coefficient 1).
-            let mut f = vec![0i64; capn + 1];
-            for &(_, w, _) in &cover {
-                let wi = w.round() as usize;
-                if wi == 0 || wi > capn {
-                    continue;
-                }
-                for b in (wi..=capn).rev() {
-                    let cand = f[b - wi] + 1;
-                    if cand > f[b] {
-                        f[b] = cand;
-                    }
-                }
-            }
-            // Lift non-cover variables, heaviest first, folding each into f so
-            // later coefficients account for it (true sequential lifting).
-            let mut noncover: Vec<(usize, usize)> = items
-                .iter()
-                .filter(|&&(j, _, _)| !cover.iter().any(|&(cj, _, _)| cj == j))
-                .map(|&(j, w, _)| (j, w.round() as usize))
-                .collect();
-            noncover.sort_by_key(|b| std::cmp::Reverse(b.1));
-            for (j, wi) in noncover {
-                let alpha = if wi > capn {
-                    rhs_i // never fits alongside anything → maximal coefficient
-                } else {
-                    rhs_i - f[capn - wi]
-                };
-                if alpha > 0 {
-                    coeffs[j] = -(alpha as f64);
-                    if (1..=capn).contains(&wi) {
-                        for b in (wi..=capn).rev() {
-                            let cand = f[b - wi] + alpha;
-                            if cand > f[b] {
-                                f[b] = cand;
-                            }
+        let mut noncover: Vec<(usize, usize)> = items
+            .iter()
+            .filter(|&&(j, _, _)| !cover.iter().any(|&(cj, _, _)| cj == j))
+            .map(|&(j, w, _)| (j, w.round() as usize))
+            .collect();
+        noncover.sort_by_key(|b| std::cmp::Reverse(b.1));
+        for (j, wi) in noncover {
+            let alpha = if wi > capn {
+                rhs_i
+            } else {
+                rhs_i - f[capn - wi]
+            };
+            if alpha > 0 {
+                coeffs[j] = -(alpha as f64);
+                if (1..=capn).contains(&wi) {
+                    for b in (wi..=capn).rev() {
+                        let cand = f[b - wi] + alpha;
+                        if cand > f[b] {
+                            f[b] = cand;
                         }
                     }
                 }
             }
         }
-        cuts.push(GomoryCut {
-            coeffs,
-            rhs: -(rhs_i as f64),
-        });
     }
-    cuts
+    Some(GomoryCut {
+        coeffs,
+        rhs: -(rhs_i as f64),
+    })
 }
 
 #[cfg(test)]
@@ -257,5 +304,47 @@ mod tests {
         let is_int = [true, true, false];
         let cuts = separate_cover(&lp, &[9.0], &x, 2, &is_int, 1, 1e-9);
         assert!(cuts.is_empty());
+    }
+
+    /// T3b2 gate: `separate_cover_csc` emits byte-identical cuts to the dense
+    /// `separate_cover` on the violated-cover instance (a multi-item knapsack row
+    /// that fires the greedy cover, minimal-cover reduction, and lifting DP).
+    #[test]
+    fn csc_matches_dense_on_cover() {
+        let a = [5.0, 5.0, 5.0, 1.0];
+        let c = [0.0; 4];
+        let l = [0.0; 4];
+        let u = [1.0, 1.0, 1.0, 1e20];
+        let x = [0.6, 0.6, 0.6, 0.0];
+        let is_int = [true, true, true, false];
+        let (m, n) = (1usize, 4usize);
+        let lp = LpView {
+            a: &a,
+            m,
+            n,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let dense = separate_cover(&lp, &[9.0], &x, 3, &is_int, 1, 1e-9);
+        let csc = separate_cover_csc(
+            &SparseCols::from_dense(&a, m, n),
+            n,
+            m,
+            &l,
+            &u,
+            &[9.0],
+            &x,
+            3,
+            &is_int,
+            1,
+            1e-9,
+        );
+        assert_eq!(dense.len(), csc.len(), "cut count drift");
+        assert!(!dense.is_empty(), "expected a cover cut (sanity)");
+        for (d, s) in dense.iter().zip(csc.iter()) {
+            assert_eq!(d.coeffs, s.coeffs, "cover cut coeffs drift");
+            assert_eq!(d.rhs, s.rhs, "cover cut rhs drift");
+        }
     }
 }

--- a/crates/discopt-core/src/lp/gomory.rs
+++ b/crates/discopt-core/src/lp/gomory.rs
@@ -189,7 +189,40 @@ pub fn separate_gomory(
     tol: f64,
     max_dynamism: f64,
 ) -> Vec<GomoryCut> {
-    let (a, m, n, l, u) = (lp.a, lp.m, lp.n, lp.l, lp.u);
+    // Dense-entry wrapper (used by tests): build the CSC once and delegate. The
+    // driver calls `separate_gomory_cols` directly with its working CSC (no dense
+    // matrix) — see docs/dev/sparse-milp-plan.md T3b5.
+    let sp = SparseCols::from_dense(lp.a, lp.m, lp.n);
+    separate_gomory_cols(
+        &sp,
+        lp.m,
+        lp.n,
+        lp.l,
+        lp.u,
+        b,
+        basis,
+        integrality,
+        tol,
+        max_dynamism,
+    )
+}
+
+/// CSC-input GMI separation (the body of [`separate_gomory`]). Bit-identical: the
+/// function already worked entirely through a `SparseCols` (`sp.col(j)` + a sparse
+/// LU factorization); it just took the dense matrix and rebuilt the CSC internally.
+#[allow(clippy::too_many_arguments)]
+pub fn separate_gomory_cols(
+    sp: &SparseCols,
+    m: usize,
+    n: usize,
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    basis: &Basis,
+    integrality: &[bool],
+    tol: f64,
+    max_dynamism: f64,
+) -> Vec<GomoryCut> {
     let mut cuts = Vec::new();
     if m == 0 {
         return cuts;
@@ -201,15 +234,6 @@ pub fn separate_gomory(
         return cuts;
     }
 
-    // CSC view of the constraint matrix: column access `A[:,j]` in O(nnz_j),
-    // replacing the dense O(m·n) scans the bmat/bt build and the ā_j dot used to
-    // pay per cut. The basis factorization comes from feral's sparse LU
-    // (`B = A[:, basic_vars]`), so `x_B = B⁻¹(b − A_N x_N)` and each tableau row
-    // `B⁻ᵀ e_i` are a single ftran/btran instead of an O(m³) dense Gaussian
-    // solve — the dense `solve_dense`/`solve_refined` path was the dominant root
-    // cost on sparse models. Iterative refinement (the GMI soundness measure) is
-    // preserved exactly, now driven by sparse matvecs against the same factor.
-    let sp = SparseCols::from_dense(a, m, n);
     let mut lu = FeralLU::new();
     let bcols: Vec<Vec<(usize, f64)>> = basis
         .basic_vars

--- a/crates/discopt-core/src/lp/gomory.rs
+++ b/crates/discopt-core/src/lp/gomory.rs
@@ -265,7 +265,7 @@ pub fn separate_gomory_cols(
             }
         }
     }
-    let xb = match ftran_refined(&mut lu, &sp, &basis.basic_vars, &rhs_b, tol) {
+    let xb = match ftran_refined(&mut lu, sp, &basis.basic_vars, &rhs_b, tol) {
         Some(xb) => xb,
         None => return cuts,
     };
@@ -282,7 +282,7 @@ pub fn separate_gomory_cols(
         // Row i of B⁻¹: refined solve of Bᵀ w = e_i (one btran + refinement).
         let mut e_i = vec![0.0_f64; m];
         e_i[i] = 1.0;
-        let w = match btran_refined(&mut lu, &sp, &basis.basic_vars, &e_i, tol) {
+        let w = match btran_refined(&mut lu, sp, &basis.basic_vars, &e_i, tol) {
             Some(w) => w,
             None => continue,
         };

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -29,7 +29,7 @@ pub use dual::{
     solve_lp_warm, solve_lp_warm_csc, solve_lp_warm_scaled, solve_lp_warm_scaled_csc, PreparedDual,
 };
 pub use presolve::tighten_bounds;
-pub use primal::{solve_lp, solve_lp_cols, solve_lp_scaled};
+pub use primal::{solve_lp, solve_lp_cols, solve_lp_cols_scaled, solve_lp_scaled};
 pub use scaling::Scaling;
 pub use sparse::SparseCols;
 

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -28,7 +28,7 @@ pub use batch::{solve_lp_batch, solve_lp_multi_rhs, LpInstance};
 pub use dual::{
     solve_lp_warm, solve_lp_warm_csc, solve_lp_warm_scaled, solve_lp_warm_scaled_csc, PreparedDual,
 };
-pub use presolve::tighten_bounds;
+pub use presolve::{tighten_bounds, tighten_bounds_csc};
 pub use primal::{solve_lp, solve_lp_cols, solve_lp_cols_scaled, solve_lp_scaled};
 pub use scaling::Scaling;
 pub use sparse::SparseCols;

--- a/crates/discopt-core/src/lp/simplex/presolve.rs
+++ b/crates/discopt-core/src/lp/simplex/presolve.rs
@@ -14,6 +14,7 @@
 //! harmless (a no-op) on problems with no propagation, e.g. a lone knapsack row.
 
 use crate::lp::crossover::LpView;
+use crate::lp::simplex::sparse::SparseCols;
 
 const INF: f64 = 1e20;
 
@@ -41,106 +42,26 @@ pub fn tighten_bounds(lp: &LpView<'_>, b: &[f64], is_int: &[bool], tol: f64) -> 
     let max_rounds = 8;
     let round_tol = 1e-6;
 
+    let mut row_nz: Vec<(usize, f64)> = Vec::new();
     for _round in 0..max_rounds {
         let mut changed = false;
         for i in 0..m {
             let row = &a[i * n..(i + 1) * n];
-            // Row activity range with infinity bookkeeping. For column j the
-            // contribution interval is [cmin_j, cmax_j]; track the finite sums
-            // and how many terms are ±infinite so a single-column residual can
-            // tell whether *its* residual bound is finite.
-            let mut sum_min_finite = 0.0;
-            let mut sum_max_finite = 0.0;
-            let mut n_min_inf = 0usize; // terms contributing −∞ to the lower activity
-            let mut n_max_inf = 0usize; // terms contributing +∞ to the upper activity
-            for j in 0..n {
-                let aij = row[j];
-                if aij == 0.0 {
-                    continue;
-                }
-                let (cmin, cmax) = if aij > 0.0 {
-                    (aij * lo[j], aij * hi[j])
-                } else {
-                    (aij * hi[j], aij * lo[j])
-                };
-                if cmin <= -INF {
-                    n_min_inf += 1;
-                } else {
-                    sum_min_finite += cmin;
-                }
-                if cmax >= INF {
-                    n_max_inf += 1;
-                } else {
-                    sum_max_finite += cmax;
+            row_nz.clear();
+            for (j, &v) in row.iter().enumerate() {
+                if v != 0.0 {
+                    row_nz.push((j, v));
                 }
             }
-
-            for k in 0..n {
-                let aik = row[k];
-                if aik == 0.0 {
-                    continue;
-                }
-                let (ck_min, ck_max) = if aik > 0.0 {
-                    (aik * lo[k], aik * hi[k])
-                } else {
-                    (aik * hi[k], aik * lo[k])
-                };
-                let k_min_inf = ck_min <= -INF;
-                let k_max_inf = ck_max >= INF;
-
-                // Residual (over j≠k) bounds, finite only when no *other* term is
-                // infinite on that side.
-                let res_min_finite = n_min_inf - (k_min_inf as usize) == 0;
-                let res_max_finite = n_max_inf - (k_max_inf as usize) == 0;
-
-                // a_ik x_k ≤ b_i − res_min  (upper on the term)
-                let mut term_ub = INF;
-                if res_min_finite {
-                    let res_min = sum_min_finite - if k_min_inf { 0.0 } else { ck_min };
-                    term_ub = b[i] - res_min;
-                }
-                // a_ik x_k ≥ b_i − res_max  (lower on the term)
-                let mut term_lb = -INF;
-                if res_max_finite {
-                    let res_max = sum_max_finite - if k_max_inf { 0.0 } else { ck_max };
-                    term_lb = b[i] - res_max;
-                }
-
-                // Translate term bounds to x_k bounds (flip if a_ik < 0).
-                let (mut new_lo, mut new_hi) = if aik > 0.0 {
-                    (
-                        if term_lb <= -INF { -INF } else { term_lb / aik },
-                        if term_ub >= INF { INF } else { term_ub / aik },
-                    )
-                } else {
-                    (
-                        if term_ub >= INF { -INF } else { term_ub / aik },
-                        if term_lb <= -INF { INF } else { term_lb / aik },
-                    )
-                };
-                if is_int[k] {
-                    if new_lo > -INF {
-                        new_lo = (new_lo - round_tol).ceil();
-                    }
-                    if new_hi < INF {
-                        new_hi = (new_hi + round_tol).floor();
-                    }
-                }
-                if new_lo > lo[k] + tol {
-                    lo[k] = new_lo;
-                    changed = true;
-                }
-                if new_hi < hi[k] - tol {
-                    hi[k] = new_hi;
-                    changed = true;
-                }
-                if lo[k] > hi[k] + tol {
+            match fbbt_row(&row_nz, b[i], &mut lo, &mut hi, is_int, tol, round_tol) {
+                None => {
                     return PresolveResult {
                         l: lo,
                         u: hi,
                         infeasible: true,
-                    };
+                    }
                 }
+                Some(c) => changed |= c,
             }
         }
         if !changed {
@@ -153,6 +74,165 @@ pub fn tighten_bounds(lp: &LpView<'_>, b: &[f64], is_int: &[bool], tol: f64) -> 
         u: hi,
         infeasible: false,
     }
+}
+
+/// CSC port of [`tighten_bounds`] (docs/dev/sparse-milp-plan.md T3b4). Bit-identical:
+/// per-row nonzeros are gathered from the CSC once (a single `O(nnz)` column sweep,
+/// column-ascending per row exactly as the dense row scan produces them, reused
+/// across rounds), and the shared [`fbbt_row`] runs the same code. FBBT's row loops
+/// already skip structural zeros and the per-column tightening is independent of
+/// column order within a row (the activity sums are fixed from the first loop), so
+/// the CSC order yields the identical result. Never materializes the dense matrix.
+#[allow(clippy::too_many_arguments)]
+pub fn tighten_bounds_csc(
+    csc: &SparseCols,
+    m: usize,
+    n: usize,
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    is_int: &[bool],
+    tol: f64,
+) -> PresolveResult {
+    let mut lo = l.to_vec();
+    let mut hi = u.to_vec();
+    let max_rounds = 8;
+    let round_tol = 1e-6;
+
+    // Per-row nonzeros (CSR), built once and reused each round (the matrix is
+    // constant; only lo/hi change).
+    let mut row_nz: Vec<Vec<(usize, f64)>> = vec![Vec::new(); m];
+    let (col_ptr, row_idx, vals) = csc.raw();
+    for j in 0..n {
+        for idx in col_ptr[j]..col_ptr[j + 1] {
+            row_nz[row_idx[idx]].push((j, vals[idx]));
+        }
+    }
+
+    for _round in 0..max_rounds {
+        let mut changed = false;
+        for i in 0..m {
+            match fbbt_row(&row_nz[i], b[i], &mut lo, &mut hi, is_int, tol, round_tol) {
+                None => {
+                    return PresolveResult {
+                        l: lo,
+                        u: hi,
+                        infeasible: true,
+                    }
+                }
+                Some(c) => changed |= c,
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    PresolveResult {
+        l: lo,
+        u: hi,
+        infeasible: false,
+    }
+}
+
+/// One FBBT round over a single row, given its nonzeros `(col, coeff)`. Mutates
+/// `lo`/`hi` in place; returns `Some(changed)` or `None` if the box was proven empty.
+/// Matrix-representation-independent — the dense and CSC entries differ ONLY in how
+/// they gather `row_nz`, so both produce byte-identical tightenings.
+fn fbbt_row(
+    row_nz: &[(usize, f64)],
+    b_i: f64,
+    lo: &mut [f64],
+    hi: &mut [f64],
+    is_int: &[bool],
+    tol: f64,
+    round_tol: f64,
+) -> Option<bool> {
+    let mut changed = false;
+    // Row activity range with infinity bookkeeping.
+    let mut sum_min_finite = 0.0;
+    let mut sum_max_finite = 0.0;
+    let mut n_min_inf = 0usize;
+    let mut n_max_inf = 0usize;
+    for &(j, aij) in row_nz {
+        if aij == 0.0 {
+            continue;
+        }
+        let (cmin, cmax) = if aij > 0.0 {
+            (aij * lo[j], aij * hi[j])
+        } else {
+            (aij * hi[j], aij * lo[j])
+        };
+        if cmin <= -INF {
+            n_min_inf += 1;
+        } else {
+            sum_min_finite += cmin;
+        }
+        if cmax >= INF {
+            n_max_inf += 1;
+        } else {
+            sum_max_finite += cmax;
+        }
+    }
+
+    for &(k, aik) in row_nz {
+        if aik == 0.0 {
+            continue;
+        }
+        let (ck_min, ck_max) = if aik > 0.0 {
+            (aik * lo[k], aik * hi[k])
+        } else {
+            (aik * hi[k], aik * lo[k])
+        };
+        let k_min_inf = ck_min <= -INF;
+        let k_max_inf = ck_max >= INF;
+
+        let res_min_finite = n_min_inf - (k_min_inf as usize) == 0;
+        let res_max_finite = n_max_inf - (k_max_inf as usize) == 0;
+
+        let mut term_ub = INF;
+        if res_min_finite {
+            let res_min = sum_min_finite - if k_min_inf { 0.0 } else { ck_min };
+            term_ub = b_i - res_min;
+        }
+        let mut term_lb = -INF;
+        if res_max_finite {
+            let res_max = sum_max_finite - if k_max_inf { 0.0 } else { ck_max };
+            term_lb = b_i - res_max;
+        }
+
+        let (mut new_lo, mut new_hi) = if aik > 0.0 {
+            (
+                if term_lb <= -INF { -INF } else { term_lb / aik },
+                if term_ub >= INF { INF } else { term_ub / aik },
+            )
+        } else {
+            (
+                if term_ub >= INF { -INF } else { term_ub / aik },
+                if term_lb <= -INF { INF } else { term_lb / aik },
+            )
+        };
+        if is_int[k] {
+            if new_lo > -INF {
+                new_lo = (new_lo - round_tol).ceil();
+            }
+            if new_hi < INF {
+                new_hi = (new_hi + round_tol).floor();
+            }
+        }
+        if new_lo > lo[k] + tol {
+            lo[k] = new_lo;
+            changed = true;
+        }
+        if new_hi < hi[k] - tol {
+            hi[k] = new_hi;
+            changed = true;
+        }
+        if lo[k] > hi[k] + tol {
+            return None;
+        }
+    }
+    Some(changed)
 }
 
 #[cfg(test)]
@@ -232,5 +312,58 @@ mod tests {
         assert!(!r.infeasible);
         assert!((r.u[0] - 2.0).abs() < 1e-9, "x0 upper {}", r.u[0]);
         assert!((r.l[0] - 1.0).abs() < 1e-9, "x0 lower {}", r.l[0]);
+    }
+
+    /// T3b4 gate: `tighten_bounds_csc` produces byte-identical tightened bounds to
+    /// the dense `tighten_bounds` on a multi-row system that fires activity-range
+    /// propagation and integer rounding (u[0]→3, u[1]→2), and on an infeasible box.
+    #[test]
+    fn csc_matches_dense_fbbt() {
+        // 2x0 + 3x1 + s0 = 6 ; x0 − x1 + s1 = 1 ; x0,x1 binary→general int ≥ 0.
+        let a = [2.0, 3.0, 1.0, 0.0, 1.0, -1.0, 0.0, 1.0]; // 2×4
+        let (m, n) = (2usize, 4usize);
+        let c = [0.0; 4];
+        let l = [0.0, 0.0, 0.0, 0.0];
+        let u = [1e20, 1e20, 1e20, 1e20];
+        let b = [6.0, 1.0];
+        let is_int = [true, true, false, false];
+        let dense = tighten_bounds(&view(&a, m, n, &c, &l, &u), &b, &is_int, 1e-9);
+        let csc = tighten_bounds_csc(
+            &SparseCols::from_dense(&a, m, n),
+            m,
+            n,
+            &l,
+            &u,
+            &b,
+            &is_int,
+            1e-9,
+        );
+        assert_eq!(dense.infeasible, csc.infeasible, "infeasible verdict drift");
+        assert_eq!(dense.l, csc.l, "lower bounds drift");
+        assert_eq!(dense.u, csc.u, "upper bounds drift");
+        assert!(
+            dense.u[0] < 1e20 && dense.u[1] < 1e20,
+            "sanity: expected tightening"
+        );
+
+        // Infeasible box: x0 ≥ 5 but the same 2x0 ≤ 6 forces x0 ≤ 3.
+        let l2 = [5.0, 0.0, 0.0, 0.0];
+        let d2 = tighten_bounds(&view(&a, m, n, &c, &l2, &u), &b, &is_int, 1e-9);
+        let c2 = tighten_bounds_csc(
+            &SparseCols::from_dense(&a, m, n),
+            m,
+            n,
+            &l2,
+            &u,
+            &b,
+            &is_int,
+            1e-9,
+        );
+        assert!(
+            d2.infeasible && c2.infeasible,
+            "expected infeasible both paths"
+        );
+        assert_eq!(d2.l, c2.l);
+        assert_eq!(d2.u, c2.u);
     }
 }

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -16,7 +16,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use super::linsolve::{FeralLU, LinearSolver};
-use super::scaling::ScaledLp;
+use super::scaling::{ScaledLp, Scaling};
 use super::sparse::SparseCols;
 use super::{LpSolve, LpStatus, SimplexOptions};
 use crate::lp::basis::{Basis, AT_LOWER, AT_UPPER, BASIC};
@@ -135,6 +135,50 @@ pub fn solve_lp_cols(
         }
     }
     sol
+}
+
+/// Sparse-native equivalent of [`solve_lp`]: a cold CSC solve with the SAME
+/// geometric-mean equilibration [`solve_lp`] applies via [`ScaledLp`]. It is
+/// bit-identical to `solve_lp` on the same matrix — [`Scaling::from_sparse`] yields
+/// the identical factors as `Scaling::from_matrix` (equilibration is sparse-native;
+/// zeros never affect a line's min/max), [`Scaling::scale_cols`] produces the same
+/// `R A C` entries as `scale_matrix`, [`solve_lp_cols`] runs the same `Simplex` the
+/// node solves already trust, and the certificate vectors are unscaled back to the
+/// original space exactly as `solve_lp` does. The point: it NEVER materializes the
+/// dense `m×n` matrix, so a large sparse relaxation (docs/dev/sparse-milp-plan.md,
+/// T2) is solved from CSC without the dense blow-up while staying pivot-for-pivot
+/// identical to the dense root solve.
+#[allow(clippy::too_many_arguments)]
+pub fn solve_lp_cols_scaled(
+    mut cols: SparseCols,
+    m: usize,
+    n: usize,
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    opts: &SimplexOptions,
+) -> LpSolve {
+    match Scaling::from_sparse(&cols, m, n) {
+        Some(scaling) => {
+            scaling.scale_cols(&mut cols);
+            let cs = scaling.scale_c(c);
+            let ls = scaling.scale_lower(l);
+            let us = scaling.scale_upper(u);
+            let bs = scaling.scale_b(b);
+            let mut sol = solve_lp_cols(cols, m, n, &cs, &ls, &us, &bs, opts);
+            // Map the certificate vectors back to the original space (mirrors
+            // `solve_lp`), so a caller's safe-bound / Farkas check sees them against
+            // the ORIGINAL A/b/bounds rather than the scaled system.
+            scaling.unscale_x(&mut sol.x);
+            scaling.unscale_dual(&mut sol.dual);
+            scaling.unscale_ray(&mut sol.ray);
+            sol
+        }
+        // Well-conditioned: solve unscaled — bit-identical to `solve_lp`'s `None`
+        // branch (`solve_lp_scaled` on the raw view).
+        None => solve_lp_cols(cols, m, n, c, l, u, b, opts),
+    }
 }
 
 /// Warm-started primal solve from an inherited `start` basis (cert:T1.4).

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -42,6 +42,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_csc_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_batch_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_py, m)?)?;
+    m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_csc_py, m)?)?;
     m.add_function(wrap_pyfunction!(
         decomp_bindings::decomp_connected_components,
         m

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -799,6 +799,171 @@ pub fn solve_milp_py<'py>(
         .iter()
         .map(|&v| v as usize)
         .collect();
+    // Fully sparse driver (T3b5): build the working CSC from the dense numpy matrix
+    // once and delegate. The CSC entry `solve_milp_csc_py` skips this densify.
+    let csc = SparseCols::from_dense(&a_owned, m, n);
+    run_milp_hooked(
+        py,
+        csc,
+        m,
+        n,
+        c_owned,
+        l_owned,
+        u_owned,
+        b_owned,
+        int_cols,
+        n_struct,
+        obj_const,
+        max_nodes,
+        gap_tol,
+        tol,
+        root_cuts,
+        cut_rounds,
+        gmi_cuts,
+        cut_select,
+        node_cuts,
+        max_pool_cuts,
+        heuristics,
+        presolve,
+        strong_branch,
+        node_propagation,
+        reduced_cost_fixing,
+        sb_max_cands,
+        sb_node_budget,
+        time_limit_s,
+        debug_hook,
+    )
+}
+
+/// CSC-input MILP entry (docs/dev/sparse-milp-plan.md T4): the constraint matrix is
+/// passed column-major (`col_ptr`/`row_idx`/`vals`, `m` rows × `n` cols) so a large
+/// sparse relaxation is NEVER densified — not on the Python side (no `A.toarray()`)
+/// and not in Rust (the driver is fully sparse). Same options and return tuple as
+/// [`solve_milp_py`].
+#[pyfunction]
+#[pyo3(signature = (c, m, n, col_ptr, row_idx, vals, b, lb, ub, integer_cols, n_struct,
+                    obj_const=0.0, max_nodes=1_000_000, gap_tol=1e-6, tol=1e-9, root_cuts=16,
+                    cut_rounds=1, gmi_cuts=true, cut_select=false, node_cuts=false,
+                    max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
+                    node_propagation=false, reduced_cost_fixing=true,
+                    sb_max_cands=6, sb_node_budget=48,
+                    time_limit_s=0.0, debug_hook=None))]
+#[allow(clippy::too_many_arguments)]
+pub fn solve_milp_csc_py<'py>(
+    py: Python<'py>,
+    c: PyReadonlyArray1<'py, f64>,
+    m: usize,
+    n: usize,
+    col_ptr: PyReadonlyArray1<'py, i64>,
+    row_idx: PyReadonlyArray1<'py, i64>,
+    vals: PyReadonlyArray1<'py, f64>,
+    b: PyReadonlyArray1<'py, f64>,
+    lb: PyReadonlyArray1<'py, f64>,
+    ub: PyReadonlyArray1<'py, f64>,
+    integer_cols: PyReadonlyArray1<'py, i64>,
+    n_struct: usize,
+    obj_const: f64,
+    max_nodes: usize,
+    gap_tol: f64,
+    tol: f64,
+    root_cuts: usize,
+    cut_rounds: usize,
+    gmi_cuts: bool,
+    cut_select: bool,
+    node_cuts: bool,
+    max_pool_cuts: usize,
+    heuristics: bool,
+    presolve: bool,
+    strong_branch: bool,
+    node_propagation: bool,
+    reduced_cost_fixing: bool,
+    sb_max_cands: usize,
+    sb_node_budget: usize,
+    time_limit_s: f64,
+    debug_hook: Option<Py<PyAny>>,
+) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
+    let col_ptr_v: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
+    let row_idx_v: Vec<usize> = row_idx.as_slice()?.iter().map(|&x| x as usize).collect();
+    let vals_v: Vec<f64> = vals.as_slice()?.to_vec();
+    let c_owned: Vec<f64> = c.as_slice()?.to_vec();
+    let b_owned: Vec<f64> = b.as_slice()?.to_vec();
+    let l_owned: Vec<f64> = lb.as_slice()?.to_vec();
+    let u_owned: Vec<f64> = ub.as_slice()?.to_vec();
+    let int_cols: Vec<usize> = integer_cols
+        .as_slice()?
+        .iter()
+        .map(|&v| v as usize)
+        .collect();
+    let csc = SparseCols::from_csc(col_ptr_v, row_idx_v, vals_v);
+    run_milp_hooked(
+        py,
+        csc,
+        m,
+        n,
+        c_owned,
+        l_owned,
+        u_owned,
+        b_owned,
+        int_cols,
+        n_struct,
+        obj_const,
+        max_nodes,
+        gap_tol,
+        tol,
+        root_cuts,
+        cut_rounds,
+        gmi_cuts,
+        cut_select,
+        node_cuts,
+        max_pool_cuts,
+        heuristics,
+        presolve,
+        strong_branch,
+        node_propagation,
+        reduced_cost_fixing,
+        sb_max_cands,
+        sb_node_budget,
+        time_limit_s,
+        debug_hook,
+    )
+}
+
+/// Shared MILP solve: builds `MilpOptions`, wraps an optional debug hook, runs the
+/// fully sparse driver under `allow_threads`, and marshals the result back. Both the
+/// dense entry (`solve_milp_py`) and the CSC entry (`solve_milp_csc_py`) funnel here
+/// after producing the working `SparseCols`.
+#[allow(clippy::too_many_arguments)]
+fn run_milp_hooked<'py>(
+    py: Python<'py>,
+    csc: SparseCols,
+    m: usize,
+    n: usize,
+    c_owned: Vec<f64>,
+    l_owned: Vec<f64>,
+    u_owned: Vec<f64>,
+    b_owned: Vec<f64>,
+    int_cols: Vec<usize>,
+    n_struct: usize,
+    obj_const: f64,
+    max_nodes: usize,
+    gap_tol: f64,
+    tol: f64,
+    root_cuts: usize,
+    cut_rounds: usize,
+    gmi_cuts: bool,
+    cut_select: bool,
+    node_cuts: bool,
+    max_pool_cuts: usize,
+    heuristics: bool,
+    presolve: bool,
+    strong_branch: bool,
+    node_propagation: bool,
+    reduced_cost_fixing: bool,
+    sb_max_cands: usize,
+    sb_node_budget: usize,
+    time_limit_s: f64,
+    debug_hook: Option<Py<PyAny>>,
+) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let opts = MilpOptions {
         n_struct,
         integer_cols: int_cols,
@@ -842,15 +1007,9 @@ pub fn solve_milp_py<'py>(
     });
     let hook_ref: Option<&dyn MilpDebugHook> = hook.as_ref().map(|h| h as &dyn MilpDebugHook);
     let res = py.allow_threads(|| {
-        let lp = LpView {
-            a: &a_owned,
-            m,
-            n,
-            c: &c_owned,
-            l: &l_owned,
-            u: &u_owned,
-        };
-        let r = core_solve_milp_hooked(&lp, &b_owned, obj_const, &opts, hook_ref);
+        let r = core_solve_milp_hooked(
+            csc, m, n, &c_owned, &l_owned, &u_owned, &b_owned, obj_const, &opts, hook_ref,
+        );
         // Emit the per-phase / pivot profile to stderr when DISCOPT_PROFILE is set
         // (no-op otherwise). solve_milp has returned, so its function-scoped phase
         // timers have recorded. Engine perf work (issue #332) reads this.

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -107,8 +107,14 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
 - [x] **T3b2 — `separate_cover` → CSC** (+ its dense oracle + differential test on a
   crafted fractional node).
 - [x] **T3b3 — `strong_branch` → CSC.** Finding (mini-falsification): `strong_branch` is ALREADY CSC-based — it solves only via `PreparedDual::prepare`/`solve_lp_warm_scaled_csc`, which take `ctx.csc` and never read `LpView.a`, and it has no other matrix access. So no port is needed; its two `a: ctx.sa` fields were vestigial → set to `&[]` (removing its dense dependency). **Done ✓** — full `cargo test -p discopt-core` (456) green with the empty `.a` (runtime proof it's unread); the integration gate where `strong_branch` actually fires is T3b6.
-- [ ] **T3b4 — node propagation / FBBT (`prop_lp`) → CSC** (+ oracle + differential
-  test).
+- [x] **T3b4 — FBBT `tighten_bounds` → CSC.** Refactored FBBT so the matrix touch
+  (gather a row's nonzeros) is split from the shared per-row propagation `fbbt_row`
+  (activity ranges + infinity bookkeeping + integer rounding). Dense scans the row;
+  new `tighten_bounds_csc` builds per-row nonzeros once from the CSC (reused across
+  rounds). Bit-identical (zeros skipped; per-column tightening order-independent as
+  the sums are fixed from loop 1). **Done ✓** — 191 existing presolve tests gate the
+  dense refactor; new `csc_matches_dense_fbbt` (tightening + infeasible box) gates the
+  port; 457 core tests green.
 - [ ] **T3b5 — driver rewire + remove `a_w`.** Carry the working matrix as
   `SparseCols` through `solve_milp_hooked`: build base CSC, append cuts via
   `augment_cols_with_cuts` (+ the `b/c/l/u/is_int` appends), scaling via

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -35,11 +35,17 @@ assembly, never a new relaxation. Stop and root-cause.
   reference-values, determinism (dense re-solve bit-identical incl. lp_iters), and
   CSC-nnz-round-trips-dense. **Done ✓** — 3 tests green; full `cargo test
   -p discopt-core` 449+ pass.
-- [ ] **T1 — CSC-carrying driver core.** `solve_milp_csc(csc: SparseCols, m, n, c,
-  l, u, b, obj_const, opts)` that threads `csc` where `SparseCols::from_dense(&a_w)`
-  is today and passes zero-length `.a` to node `LpView`s. Root solve / cuts /
-  scaling may still build a dense `a_w` from the CSC *internally* for now (correct,
-  not yet memory-fixed). **Done:** T0 panel bit-identical dense vs CSC path.
+- [x] **T1 — CSC-carrying driver core.** Added `pub fn solve_milp_csc(csc, m, n, c,
+  l, u, b, obj_const, opts) -> MilpResult` (the entry the Python binding calls at T4)
+  + a `csc_to_dense` bridge. **T1 keeps a dense `a_w` internally** by reconstructing
+  the matrix at entry and calling the reference `solve_milp` — so it is provably
+  bit-identical but does NOT yet fix the memory blow-up (that is T2/T3, which remove
+  the densification). Note: threading the CSC *through* the batched-cuts loop is
+  entangled with per-batch scaling (`Scaling::from_matrix(&a_w)` →
+  `SparseCols::from_dense(scaled a_w)`) and cut-row appends, so it is correctly
+  deferred to T2/T3 rather than forced here. **Done ✓** — new gate
+  `csc_entry_matches_dense_on_panel` (status/nodes/obj/bound/incumbent all identical)
+  green; full `cargo test -p discopt-core` 450 pass; `discopt-python` builds.
 - [ ] **T2 — sparse root cold solve.** Replace `solve_lp_root`'s
   `dual_slack_basis(lp.a,..)`+`solve_lp` with a CSC cold two-phase (adapt the
   `solve_lp_cols_*` warm-fallback family to a cold entry). **Done:** root bound

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -100,7 +100,7 @@ matrices + fractional points). All ports are bit-identical by the same argument:
 structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
 (`csc.dot`) and row activities match the dense sums term-for-term.
 
-- [ ] **T3b1 — trivial ports.** `struct_nnz` → `col_ptr[ns]`; `try_rounding` and
+- [x] **T3b1 — trivial ports.** `struct_nnz` → `col_ptr[ns]`; `try_rounding` and
   `farkas_safe_bound` → `&SparseCols` (column-iteration into `act/lo/hi`;
   `csc.dot(j,y)`). Keep dense versions as oracles. **Done:** differential unit tests
   (dense == csc) green.

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -135,22 +135,42 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
   that genuinely branches (source from the `.nl` corpus or craft with cuts/heuristics
   off) so `driver_matches_golden` exercises `separate_cover`/`strong_branch`/
   propagation end-to-end, not just nodes=1. Capture status/obj/nodes/`lp_iters`.
-- [~] **T4 — Python binding + routing.** RUST HALF DONE: `solve_milp_hooked` now takes a
+- [x] **T4 — Python binding + routing.** RUST HALF: `solve_milp_hooked` takes a
   `SparseCols` (dense `solve_milp`/`solve_milp_py` build it from `lp.a`; no internal dense
   copy). Added `solve_milp_csc_py` (col_ptr/row_idx/vals input → `from_csc` → the sparse
   driver, NEVER densified) + a shared `run_milp_hooked`, registered in lib.rs. core 458
-  tests green; discopt-python builds. REMAINING (with T5, needs a rebuilt extension):
-  route `solvers/milp_simplex.py` + the `MilpRelaxationModel` MILP path to the CSC binding,
-  deleting `A.toarray()`/the dense `a_std`. `solve_milp_csc_py(col_ptr, row_idx, vals,
-  m, n, c, l, u, int_cols, ...)`; route `solvers/milp_simplex.py` and the
-  `MilpRelaxationModel` MILP path to pass the relaxation's existing scipy CSC
-  through — delete the `A.toarray()`/dense `a_std` assembly. **Done:** a small
-  binary-QP solves end-to-end via the CSC binding, bit-identical bound to dense.
-- [ ] **T5 — end-to-end + certificate gate.** `_root_relaxation_lower_bound(qap)`
-  and a full `solve_model(qap)` honor `time_limit` (no 73 GB, no overrun);
-  `incorrect_count == 0` on the global50 panel; node counts bit-identical to dense
-  on the T0 panel. **Done:** qap honors a real budget; certifying panels green;
-  retire the dense path only after consecutive nightly greens (separate task).
+  tests green. PYTHON HALF (this iter): `solvers/milp_simplex.py::solve_milp` now builds
+  the standard-form `[A_ub | I]` as a **scipy CSC** (`sp.hstack`, `sort_indices`) and calls
+  `solve_milp_csc_py` — the dense `a_std = np.zeros((m, n+m))` + `np.eye(m)` + `A.toarray()`
+  assembly is deleted. `MilpRelaxationModel.solve(backend="simplex")` already passes its
+  sparse `_A_ub` straight through (it is a CSR, ~2 MB for qap — verified). **Done:** all 39
+  `test_milp_simplex.py` tests green (incl. the pure-LP-machinery-off gate, respied on the
+  CSC binding); `pytest -m smoke` 653 green; adversarial suite 10 green — the routing is
+  bound-neutral (no node-count / objective drift on the certifying panels).
+- [x] **T5 — end-to-end measurement + FALSIFICATION (re-scope).** The MILP driver is now
+  fully sparse and materializes no dense `m×(n+m)` matrix (T0–T4 done, MILP path
+  bit-identical). **But the plan's premise — "making the Rust MILP driver sparse stops
+  qap's ~73 GB densification" — is FALSIFIED by measurement.** Entry experiment (qap.nl,
+  RSS watchdog, `/usr/bin/time -l`):
+  - qap's `MilpRelaxationModel._A_ub` is **already a sparse CSR** (85756×21649, ~2 MB) — not
+    dense. The 73 GB figure was the *hypothetical* dense driver footprint, never actually
+    allocated (the `_MAX_RELAX_DENSE_CELLS = 1e8` guard in `mccormick_lp.py` declines qap's
+    node LP at `(n_cols+n_rows)·n_rows = 9.2e9 > 1e8` **before** any solve).
+  - Measured peak RSS on a full `solve(time_limit=25s)` is **~28–30 GB** — and it is the
+    **same ~30 GB whether the guard is ON (every node LP declined, no simplex solve) or
+    OFF**. So qap's real memory ceiling is **independent of the LP solve and of the Rust
+    driver**: it is the **Python McCormick relaxation build** for the 85,756-row lift
+    (21,424 bilinear envelopes), a transient the sparse driver does not touch.
+  - **Consequences / re-scope:** (1) The sparse-driver work is correct and necessary but does
+    **not** by itself make qap tractable. (2) The `_MAX_RELAX_DENSE_CELLS` guard is left
+    **intact** — its dense-driver rationale is now obsolete, but even on the sparse path
+    solving qap's node LP still incurs the ~28 GB build blowup **and** an unquantified
+    85756×85756 basis-LU fill-in risk, so relaxing it would make qap *worse*, not better. Do
+    not open it without first solving the build-memory problem. (3) **Next task (new plan
+    doc):** profile and cap the Python McCormick relaxation *build* memory for large lifts
+    (the ~30 GB transient), independent of this driver work. The certificate gate
+    (`incorrect_count == 0` on global50) is unaffected by this iteration — the routing is
+    bound-neutral. Retire the dense oracles only after that follow-up + nightly greens.
 
 ## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
 

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -71,16 +71,19 @@ mechanisms — de-risked below, they're all bit-identical ports, not rewrites:
 - A CSC `ScaledLp` mirror: `Scaling::from_cols` → `scale_cols` + scale c/l/u/b →
   `solve_lp_cols` → unscale x/dual/ray (exactly what dense `solve_lp` does).
 
-- [ ] **T2 — bit-identical CSC root solve.** (a) `dual_slack_basis` → `&SparseCols`;
-  (b) add `Scaling::from_cols` (+ unit test: identical factors to `from_matrix` on
-  the panel); (c) a CSC-scaled cold solve mirroring `solve_lp`'s `ScaledLp` path;
-  (d) `solve_lp_root_csc` mirroring `solve_lp_root` (dual-slack warm via
-  `solve_lp_warm_scaled_csc`, CSC cold fallback), wired into the root-cuts loop from
-  a CSC derived once per round. **Coupling note:** cut rows still append to dense
-  `a_w` until T3, so a_w isn't gone yet — T2 proves the *root solve* is CSC and
-  bit-identical; T3 removes a_w. **Done:** `driver_matches_golden` green (incl.
-  `lp_iters`); a unit test confirms `solve_lp_root_csc` == `solve_lp_root` on the
-  panel.
+- [x] **T2 — bit-identical CSC root solve.** (a) `dual_slack_basis` → `&SparseCols`
+  (it already built one internally); (b) reused the existing `Scaling::from_sparse`
+  (identical factors to `from_matrix`); (c) added `solve_lp_cols_scaled` — a
+  sparse-native cold solve that mirrors `solve_lp`'s `ScaledLp` (from_sparse →
+  scale_cols + scale c/l/u/b → `solve_lp_cols` → unscale x/dual/ray); (d) added
+  `solve_lp_root_csc` (dual-slack warm via `solve_lp_warm_scaled_csc`, `solve_lp_cols_scaled`
+  cold fallback) and **wired it into the root-cuts loop** (CSC from `from_dense(a_w)`
+  per round for now). `solve_lp_root` retained as `#[allow(dead_code)]` differential
+  oracle. **Coupling:** dense `a_w` still built (cuts append to it; the loop derives
+  the CSC from it) — a_w removal is T3. **Done ✓** — `driver_matches_golden` green
+  incl. `lp_iters`; `solve_lp_root_csc_matches_dense` confirms bit-identity on a
+  well-conditioned AND an ill-conditioned (1e8-range, equilibration-firing) LP; full
+  `cargo test -p discopt-core` 452 pass; `discopt-python` builds.
 - [ ] **T3 — sparse scaling + cut-row append.** `Scaling::from_matrix` CSC variant;
   GMI cut rows appended to the CSC (grow col_ptr/row_idx/vals) instead of `a_w`.
   **Done:** cuts-firing panel instance bit-identical; `a_w` no longer constructed.

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -191,6 +191,28 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
     change per §5: needs the differential-bound test + feature flag + nightly greens, a
     separate task). Certificate gate unaffected. Retire dense oracles only after nightly-green.
 
+- [ ] **T7 — relax `_MAX_RELAX_DENSE_CELLS` for the sparse backend: ENTRY EXPERIMENT KILLED
+  IT (§4).** Before implementing the flag, measured the payoff on qap's root box (guard lifted,
+  `backend="simplex"`):
+  - **McCormick LP is now cheap and memory-safe:** `solve_at_node(root)` → **optimal in ~2 s,
+    0.6 GB** (all three of budget=10/30/60 s converge to the same vertex). The sparse work
+    (T0–T4) + the T6 incremental fix delivered a working large-lift LP path.
+  - **…but the bound is useless.** McCormick-LP root bound = **−1e-9 ≈ 0** vs the oracle DUAL
+    bound **149106**. Expected: McCormick envelopes on an indefinite binary `x'Qx`
+    (eig ∈ [−330k, +953k], x ∈ [0,1]) are trivially loose — each lifted product drops to its
+    independent lower envelope, so the LP minimum is ~0 and fathoms nothing.
+  - **PSD strengthening does not rescue it AND re-densifies.** `_root_relaxation_lower_bound(
+    …, psd_cuts=True)` → bound still **−1e-9**, **wall 64 s, RSS 46 GB** (vs 17 s / 0.6 GB
+    without PSD). So the moment/clique path (`psd_strengthen_relaxation_bound`) has its own
+    dense blowup, same class as T6 — and even so it buys no bound here.
+  - **Verdict:** relaxing the guard **by default is a regression** for qap (≥2 s/node LP for a
+    ~0 bound, no fathoming) and **helps no measured instance**, so shipping a default-off flag
+    would be a near-dead flag (§3). NOT implemented. The guard stays as-is. qap's real dual
+    bound (→149106) needs a fundamentally stronger relaxation (RLT-2 / tailored QAP / SDP),
+    not a McCormick-LP guard flip. **Two concrete follow-ups surfaced, neither a guard flip:**
+    (a) the PSD path's 46 GB densification (a real memory bug, T6-style fix); (b) per-node LP
+    time on large lifts (profiling target from T6). Awaiting direction on which to pursue.
+
 ## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
 
 `solve_milp_py` (the Rust MILP entry) takes a **dense** `a: PyReadonlyArray2`, and

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -104,7 +104,7 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
   `farkas_safe_bound` → `&SparseCols` (column-iteration into `act/lo/hi`;
   `csc.dot(j,y)`). Keep dense versions as oracles. **Done:** differential unit tests
   (dense == csc) green.
-- [ ] **T3b2 — `separate_cover` → CSC** (+ its dense oracle + differential test on a
+- [x] **T3b2 — `separate_cover` → CSC** (+ its dense oracle + differential test on a
   crafted fractional node).
 - [ ] **T3b3 — `strong_branch` → CSC** (+ oracle + differential test).
 - [ ] **T3b4 — node propagation / FBBT (`prop_lp`) → CSC** (+ oracle + differential

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -115,7 +115,15 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
   the sums are fixed from loop 1). **Done ✓** — 191 existing presolve tests gate the
   dense refactor; new `csc_matches_dense_fbbt` (tightening + infeasible box) gates the
   port; 457 core tests green.
-- [ ] **T3b5 — driver rewire + remove `a_w`.** Carry the working matrix as
+- [x] **T3b5 — driver rewire + remove `a_w`.** DONE — the MILP driver is fully sparse.
+  Built csc_w before presolve; presolve→tighten_bounds_csc; root-cuts loop→solve_lp_root_csc
+  + separate_cover_csc + separate_gomory_cols + augment_csc_with_cuts; per-batch scaling via
+  Scaling::from_sparse + scale_cols (csc_batch scaled, csc_rc unscaled); NodeCtx drops a_w/sa;
+  per-node consumers → CSC ports (FBBT/rounding/cover→csc_rc, farkas→csc); dense cold
+  fallbacks solve_lp_scaled→solve_lp_cols(ctx.csc). refactored separate_gomory→separate_gomory_cols.
+  **Done ✓** — driver_matches_golden AND branching_golden (nodes=13) green; 458 core tests +
+  discopt-python build. Dense oracles retained (allow(dead_code)) for the differential tests.
+  ORIGINAL: Carry the working matrix as
   `SparseCols` through `solve_milp_hooked`: build base CSC, append cuts via
   `augment_cols_with_cuts` (+ the `b/c/l/u/is_int` appends), scaling via
   `Scaling::from_sparse`+`scale_cols`, `NodeCtx` carries `csc`/`csc_rc` (drop `a_w`,

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -123,7 +123,7 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
   Delete `a_w = lp.a.to_vec()` and every dense-matrix site. **Done:**
   `driver_matches_golden` green (incl. `lp_iters`); all T3b differential tests green;
   `a_w` no longer constructed; dense-entry path bit-identical.
-- [ ] **T3b6 (gate strengthening) — branching integration golden.** Add ≥1 small MILP
+- [x] **T3b6 (gate strengthening) — branching integration golden.** DONE FIRST (gate-first, before T3b5). Small 6-binary knapsack solved with heuristics off + no root GMI (forces a 13-node tree) but node cover separation + strong branching + FBBT propagation ON — so `separate_cover`/`strong_branch`/`tighten_bounds` (and their CSC ports) run end-to-end. Golden: Optimal, obj −16, **nodes=13, lp_iters=39**. This gates the T3b5 rewire (the nodes=1 panel can't). **Original T3b6 note:** Add ≥1 small MILP
   that genuinely branches (source from the `.nl` corpus or craft with cuts/heuristics
   off) so `driver_matches_golden` exercises `separate_cover`/`strong_branch`/
   propagation end-to-end, not just nodes=1. Capture status/obj/nodes/`lp_iters`.

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -229,7 +229,33 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
   0.69 GB** (64 s → 15 s). Regression tests: `test_solve_lp_routes_through_sparse_csc_binding`
   (spies that the dense binding is never called) + `test_solve_lp_does_not_densify_large_sparse_lp`
   (tracemalloc peak ≪ the dense `m×(n+m)`). NB: PSD still buys qap no bound (−1e-9) — that is a
-  separate *effectiveness* question, untouched here; only the memory blowup is fixed.
+  separate *effectiveness* question, resolved in T9 below.
+
+- [x] **T9 — PSD effectiveness: root-caused the "no bound" AND fixed a real inertness bug.**
+  Diagnosed why `psd_strengthen_relaxation_bound` never tightens qap (two layers):
+  - **Primary bug (FIXED):** the moment separator's `_diag_col`/`_lifted_cliques` required a
+    lifted **square** column `X_ii = x_i²` (`monomial`/`univariate_square`), which pure products
+    of *distinct* binaries (the whole QAP objective) never create → **0 cliques → 0 cuts → PSD
+    completely inert** on every binary-product model, not just qap. But for a **binary** `x_i`,
+    `x_i² = x_i` at every feasible point, so the moment diagonal `X_ii` *is* the original `x_i`
+    column. Fix: `discopt/_jax/model_utils.py::binary_flat_cols` (integer-typed vars on `[0,1]`)
+    threaded as `binary_vars` through `_diag_col`→`_moment_blocks_for_set`→`_lifted_cliques`→
+    `separate_psd_cuts_on_relaxation`→`psd_strengthen_relaxation_bound`, and wired at both
+    callers (`solver.py` root bound, `mccormick_lp.py` per-node). Sound only for binaries
+    (continuous `X_ii = x_i² ≠ x_i` still requires the real square lift — preserved, see
+    `test_no_op_on_model_without_lifted_squares`). On qap: cliques go 0 → 223 (k=2) / 219 (k=4)
+    / 215 (k=6).
+  - **Deeper limitation (measured, not a bug):** even with cliques, **0 of qap's 223 pairwise
+    moment minors are violated** at the McCormick vertex (λ_min = 0) — pairwise binary moment
+    cuts are redundant with McCormick, and qap's vertex also satisfies the k≤6 minors, so the
+    bound stays ~0. Closing qap needs the **global** (full 226×226) moment/Shor SDP, which local
+    clique separation cannot supply — a separate, larger effort.
+  - **The fix is verified effective + sound on the class it targets** via a constructed binary
+    QP (`min x0x1+x0x2+x1x2 s.t. Σx ≥ 1.5`, true min 1): the k=3 moment matrix at `x=(½,½,½),
+    X=0` has eigenvalue −¼, so **PSD strengthening lifts the bound 0 → 0.356** (was 0 cuts before
+    the fix), staying valid (≤ 1); feasible-point sampling confirms no cut removes an integer
+    point (`test_binary_products_get_moment_cuts_via_diagonal_shortcut`). 158 PSD, 653 smoke, 10
+    adversarial green; continuous QCQP PSD path unchanged (reaches −1.0 exactly).
 
 ## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
 

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -84,9 +84,22 @@ mechanisms — de-risked below, they're all bit-identical ports, not rewrites:
   incl. `lp_iters`; `solve_lp_root_csc_matches_dense` confirms bit-identity on a
   well-conditioned AND an ill-conditioned (1e8-range, equilibration-firing) LP; full
   `cargo test -p discopt-core` 452 pass; `discopt-python` builds.
-- [ ] **T3 — sparse scaling + cut-row append.** `Scaling::from_matrix` CSC variant;
-  GMI cut rows appended to the CSC (grow col_ptr/row_idx/vals) instead of `a_w`.
-  **Done:** cuts-firing panel instance bit-identical; `a_w` no longer constructed.
+- [x] **T3a — CSC cut-augmentation primitive.** Added `augment_cols_with_cuts`
+  (CSC analogue of `augment_with_cuts`: append `k` cut rows + `k` surplus-slack
+  columns, O(nnz+cut_nnz), no dense). `Scaling::from_matrix`'s CSC form already
+  exists (`Scaling::from_sparse`, used in T2). **Done ✓** — `csc_augment_matches_dense_augment`
+  proves it's nonzero-for-nonzero identical to `from_dense(augment_with_cuts(..))`;
+  453 core tests green.
+- [ ] **T3b — remove dense `a_w` (driver rewire).** Carry the working matrix as a
+  `SparseCols` through `solve_milp_hooked`: build the base CSC (from the entry;
+  `from_dense(lp.a)` for the dense entry until T4), append cuts via
+  `augment_cols_with_cuts`, drive scaling with `Scaling::from_sparse` + `scale_cols`,
+  and build the node `ctx` (`csc`/`csc_rc`) directly. Remove `a_w = lp.a.to_vec()`,
+  the per-round `from_dense(a_w)`, the `Scaling::from_matrix(&a_w)` /
+  `from_dense(sa)` / `from_dense(&a_w)` sites, and the `NodeCtx.a_w`/`sa` dense
+  fields (rewire their few consumers — cuts, reduced-cost fixing — to the CSC).
+  **Done:** `driver_matches_golden` green (incl. `lp_iters`); `a_w` no longer
+  constructed anywhere; the dense-entry path still bit-identical.
 - [ ] **T4 — Python binding + routing.** `solve_milp_csc_py(col_ptr, row_idx, vals,
   m, n, c, l, u, int_cols, ...)`; route `solvers/milp_simplex.py` and the
   `MilpRelaxationModel` MILP path to pass the relaxation's existing scipy CSC

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -90,16 +90,37 @@ mechanisms — de-risked below, they're all bit-identical ports, not rewrites:
   exists (`Scaling::from_sparse`, used in T2). **Done ✓** — `csc_augment_matches_dense_augment`
   proves it's nonzero-for-nonzero identical to `from_dense(augment_with_cuts(..))`;
   453 core tests green.
-- [ ] **T3b — remove dense `a_w` (driver rewire).** Carry the working matrix as a
-  `SparseCols` through `solve_milp_hooked`: build the base CSC (from the entry;
-  `from_dense(lp.a)` for the dense entry until T4), append cuts via
-  `augment_cols_with_cuts`, drive scaling with `Scaling::from_sparse` + `scale_cols`,
-  and build the node `ctx` (`csc`/`csc_rc`) directly. Remove `a_w = lp.a.to_vec()`,
-  the per-round `from_dense(a_w)`, the `Scaling::from_matrix(&a_w)` /
-  `from_dense(sa)` / `from_dense(&a_w)` sites, and the `NodeCtx.a_w`/`sa` dense
-  fields (rewire their few consumers — cuts, reduced-cost fixing — to the CSC).
-  **Done:** `driver_matches_golden` green (incl. `lp_iters`); `a_w` no longer
-  constructed anywhere; the dense-entry path still bit-identical.
+**T3b scope correction (user: full per-node CSC port).** `a_w` (dense) is read by
+the WHOLE per-node engine via `node_lp.a`/`prop_lp.a`/`ctx.sa`, not "a few
+consumers": `struct_nnz`, `try_rounding`, `farkas_safe_bound`, `separate_cover`,
+`strong_branch`, and node propagation (FBBT). The panel solves at the root (nodes=1)
+so it can't gate these — instead **keep each dense function as the oracle and add a
+DIRECT differential unit test** (`fn_dense(dense,..) == fn_csc(csc,..)` on crafted
+matrices + fractional points). All ports are bit-identical by the same argument: a
+structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
+(`csc.dot`) and row activities match the dense sums term-for-term.
+
+- [ ] **T3b1 — trivial ports.** `struct_nnz` → `col_ptr[ns]`; `try_rounding` and
+  `farkas_safe_bound` → `&SparseCols` (column-iteration into `act/lo/hi`;
+  `csc.dot(j,y)`). Keep dense versions as oracles. **Done:** differential unit tests
+  (dense == csc) green.
+- [ ] **T3b2 — `separate_cover` → CSC** (+ its dense oracle + differential test on a
+  crafted fractional node).
+- [ ] **T3b3 — `strong_branch` → CSC** (+ oracle + differential test).
+- [ ] **T3b4 — node propagation / FBBT (`prop_lp`) → CSC** (+ oracle + differential
+  test).
+- [ ] **T3b5 — driver rewire + remove `a_w`.** Carry the working matrix as
+  `SparseCols` through `solve_milp_hooked`: build base CSC, append cuts via
+  `augment_cols_with_cuts` (+ the `b/c/l/u/is_int` appends), scaling via
+  `Scaling::from_sparse`+`scale_cols`, `NodeCtx` carries `csc`/`csc_rc` (drop `a_w`,
+  `sa`; ignored `LpView.a` fields → `&[]`), switch all consumers to the CSC ports.
+  Delete `a_w = lp.a.to_vec()` and every dense-matrix site. **Done:**
+  `driver_matches_golden` green (incl. `lp_iters`); all T3b differential tests green;
+  `a_w` no longer constructed; dense-entry path bit-identical.
+- [ ] **T3b6 (gate strengthening) — branching integration golden.** Add ≥1 small MILP
+  that genuinely branches (source from the `.nl` corpus or craft with cuts/heuristics
+  off) so `driver_matches_golden` exercises `separate_cover`/`strong_branch`/
+  propagation end-to-end, not just nodes=1. Capture status/obj/nodes/`lp_iters`.
 - [ ] **T4 — Python binding + routing.** `solve_milp_csc_py(col_ptr, row_idx, vals,
   m, n, c, l, u, int_cols, ...)`; route `solvers/milp_simplex.py` and the
   `MilpRelaxationModel` MILP path to pass the relaxation's existing scipy CSC

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -1,5 +1,60 @@
 # Sparse MILP path for the Rust B&B driver
 
+## §0 Loop protocol (binding — this doc is loop-executable)
+
+Execute the checklist in **§Tasks** strictly in order, one task per loop iteration.
+Each iteration:
+
+1. Pick the **first unchecked** `[ ]` task in §Tasks. Do only that task.
+2. Implement it. Touch only what the task names; keep the dense `solve_milp` intact
+   as the reference oracle (do NOT delete it) until T5 is green.
+3. **Verify before committing** — a task is not done until:
+   - `cargo build -p discopt-core` and `cargo build -p discopt-python` succeed;
+   - `cargo test -p discopt-core` passes (and the differential harness from T0 once
+     it exists);
+   - the task's own **Done** criterion below holds.
+   If verification fails, fix it in the same iteration; do not advance.
+4. Commit with `feat(sparse-milp): Tn <title>` (or `test:`/`docs:`), then check the
+   box `[x]` in this file **in the same commit** and record the one-line result.
+5. **Kill criterion:** if a task reveals the plan is wrong (e.g. a node solve DOES
+   read `LpView.a`, or `from_csc` can't represent a needed op), STOP, write the
+   falsification under the task, and re-scope §Tasks before continuing — the
+   measurement wins (CLAUDE.md §4).
+
+**Never advance on red.** The invariant (§Invariants) is bit-identical-to-dense;
+any node-count or certified-objective drift on the T0 panel is a bug in the CSC
+assembly, never a new relaxation. Stop and root-cause.
+
+## Tasks
+
+- [ ] **T0 — differential harness.** Rust test `bnb::milp_driver` (or a new
+  `sparse_milp_diff` test module): a panel of small MILPs — pure-LP, 1–3 binaries,
+  infeasible, unbounded, a cuts-firing instance — each solved via dense `solve_milp`
+  and (stubbed for now) asserted against itself; wire the CSC path in at T1.
+  **Done:** panel builds + passes against the dense path; committed.
+- [ ] **T1 — CSC-carrying driver core.** `solve_milp_csc(csc: SparseCols, m, n, c,
+  l, u, b, obj_const, opts)` that threads `csc` where `SparseCols::from_dense(&a_w)`
+  is today and passes zero-length `.a` to node `LpView`s. Root solve / cuts /
+  scaling may still build a dense `a_w` from the CSC *internally* for now (correct,
+  not yet memory-fixed). **Done:** T0 panel bit-identical dense vs CSC path.
+- [ ] **T2 — sparse root cold solve.** Replace `solve_lp_root`'s
+  `dual_slack_basis(lp.a,..)`+`solve_lp` with a CSC cold two-phase (adapt the
+  `solve_lp_cols_*` warm-fallback family to a cold entry). **Done:** root bound
+  unchanged on the T0 panel; no dense `a_w` touched on the root path.
+- [ ] **T3 — sparse scaling + cut-row append.** `Scaling::from_matrix` CSC variant;
+  GMI cut rows appended to the CSC (grow col_ptr/row_idx/vals) instead of `a_w`.
+  **Done:** cuts-firing panel instance bit-identical; `a_w` no longer constructed.
+- [ ] **T4 — Python binding + routing.** `solve_milp_csc_py(col_ptr, row_idx, vals,
+  m, n, c, l, u, int_cols, ...)`; route `solvers/milp_simplex.py` and the
+  `MilpRelaxationModel` MILP path to pass the relaxation's existing scipy CSC
+  through — delete the `A.toarray()`/dense `a_std` assembly. **Done:** a small
+  binary-QP solves end-to-end via the CSC binding, bit-identical bound to dense.
+- [ ] **T5 — end-to-end + certificate gate.** `_root_relaxation_lower_bound(qap)`
+  and a full `solve_model(qap)` honor `time_limit` (no 73 GB, no overrun);
+  `incorrect_count == 0` on the global50 panel; node counts bit-identical to dense
+  on the T0 panel. **Done:** qap honors a real budget; certifying panels green;
+  retire the dense path only after consecutive nightly greens (separate task).
+
 ## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
 
 `solve_milp_py` (the Rust MILP entry) takes a **dense** `a: PyReadonlyArray2`, and

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -257,6 +257,26 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
     point (`test_binary_products_get_moment_cuts_via_diagonal_shortcut`). 158 PSD, 653 smoke, 10
     adversarial green; continuous QCQP PSD path unchanged (reaches −1.0 exactly).
 
+- [x] **T10 — per-node LP-time profiling: the LP is NOT the bottleneck; the cold rebuild is.**
+  cProfile of `MccormickLPRelaxer.solve_at_node` on qap (guard lifted, 4 node solves, warm):
+  **3.66 s/node**, split — **cold `build_milp_relaxation` 3.16 s (86%)** vs the sparse LP solve
+  `solve_lp_warm_csc_py` **0.49 s (13%)**. The "per-node LP time" is small; the cost is
+  **rebuilding the 85 756-row McCormick relaxation from scratch every node** (qap can't use the
+  incremental fast path — its dense `base_A` is declined in T6). Inside the build, the top Python
+  cost was **1.54 M `BinaryOp` constructions per 4 nodes**, each calling
+  `numpy.broadcast_shapes` on (almost always) scalar `()` shapes — ~2.5 s of the 12.6 s 4-node
+  build spent on shape bookkeeping alone.
+  - **Fix (bound-neutral, committed):** scalar/equal-shape fast path in `core._broadcast_shapes`
+    (equal shapes → themselves; scalar → the other operand; differing shapes still defer to numpy,
+    which also validates). Verified identical output to numpy on a broadcast panel (incl. the
+    mismatch-raises case). **Per-node 3.66 s → 3.05 s (−17%)**, build 3.16 → 2.55 s/node; 653
+    smoke + 96 shape/broadcast tests green.
+  - **The remaining bottleneck (biggest lever, not yet taken):** the 2.55 s/node cold rebuild
+    itself. `distribute_products` (0.64 s/node) + `_build_product`/`_emit_mccormick` dominate. The
+    real win is to **make `IncrementalMcCormickLP` sparse** (the T6 follow-up) so qap can patch
+    coefficients per node instead of rebuilding — that would collapse the ~2.5 s build to a patch,
+    leaving mostly the 0.49 s LP solve. Larger change (bit-identity contract vs the cold build).
+
 ## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
 
 `solve_milp_py` (the Rust MILP entry) takes a **dense** `a: PyReadonlyArray2`, and

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -1,0 +1,74 @@
+# Sparse MILP path for the Rust B&B driver
+
+## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
+
+`solve_milp_py` (the Rust MILP entry) takes a **dense** `a: PyReadonlyArray2`, and
+`bnb::milp_driver::solve_milp` carries a **dense** working matrix
+`a_w = lp.a.to_vec()` (milp_driver.rs:351). qap's McCormick relaxation LP is
+`85 756 × 21 649` with **172 292 nonzeros** (~2/row), but the dense form is
+`a_std = zeros(85 756, 107 405)` ≈ **73 GB**. Consequences:
+
+* Python side (`solvers/milp_simplex.py:solve_milp`): `A.toarray()` + `np.eye(m)`
+  build the dense `a_std` — the ~12.9 s "marshaling".
+* Rust side: `a_w = lp.a.to_vec()` copies it; `SparseCols::from_dense(&a_w)`
+  (milp_driver.rs:650) iterates the whole dense matrix; the solve overruns its
+  `time_limit_s` (measured `_root_relaxation_lower_bound(qap, tl=5)` > 120 s for a
+  ~1 s budget).
+
+The sparse LP path (`solve_lp_warm_csc_py`) is fine (qap LP relaxation solves in
+0.5 s) but is **LP-only**; there is no sparse MILP.
+
+## Key facts that make this bounded (verified in source)
+
+1. `SparseCols::from_csc(col_ptr, row_idx, vals)` exists (lp/simplex/sparse.rs:69)
+   — build the driver's matrix directly from CSC, no dense intermediate.
+2. The **per-node** solver `solve_lp_warm_scaled_csc` (lp/simplex/dual.rs:172) uses
+   only the `SparseCols` for the matrix and `LpView` for `c/l/u/b` — it never reads
+   `LpView.a`. So node LP solves are ALREADY fully sparse; the driver just also
+   keeps a redundant dense `a_w`.
+
+So the ONLY blocker is the dense `a_w`. Its consumers in `milp_driver.rs`:
+
+| line(s) | use of dense `a_w` | sparse replacement |
+|---|---|---|
+| 351 | `a_w = lp.a.to_vec()` working matrix | carry a `SparseCols` (from `from_csc`) |
+| 399 | per-row structural-nnz counts | CSC column/row counts |
+| 441, 1042, 1086 | `LpView{ a: &a_w, .. }` for solves | node solves ignore `.a`; pass `&[]`/dummy; root needs a CSC root solve |
+| 508, 828 | GMI cut rows appended to `a_w` | append rows to the CSC (grow col_ptr/row_idx/vals) |
+| 636–650, 657 | `Scaling::from_matrix(&a_w)`, `SparseCols::from_dense(&a_w)` | scaling from CSC; drop `from_dense` |
+| 2124 (`solve_lp_root`) | cold root solve via `dual_slack_basis(lp.a,..)` + `solve_lp` | CSC cold root solve |
+| 1142, 1252 | reduced-cost fixing reads `a_w` | already has `csc_rc`; use it |
+
+## Plan (incremental; each step compiles + `cargo test -p discopt-core` green)
+
+0. **Harness first.** Add a Rust test: a small sparse MILP solved via the current
+   dense `solve_milp` AND the new CSC path must return the identical status /
+   objective / bound / node count on a panel (pure-LP, a few binaries, infeasible,
+   cuts-firing). This is the bit-identical gate — the CSC path is a *representation*
+   change, not an algorithm change, so any drift is a bug.
+1. **CSC-carrying driver.** Introduce `solve_milp_csc(csc: SparseCols, m, n, c, l,
+   u, b, obj_const, opts)`. Internally keep today's dense `solve_milp` as the
+   reference; the CSC one threads `csc` where `from_dense(&a_w)` was and passes a
+   zero-length `.a` to the node `LpView`s (verified unused).
+2. **Sparsify the root cold solve** (`solve_lp_root`): a CSC cold two-phase (the
+   `solve_lp_cols_*` family already exists as the warm fallback — expose/adapt a
+   cold entry).
+3. **Sparsify scaling + cut-row appends** (CSC row append; `Scaling::from_matrix`
+   CSC variant).
+4. **Python binding** `solve_milp_csc_py(col_ptr, row_idx, vals, m, n, c, l, u,
+   int_cols, ...)` + route `solvers/milp_simplex.py` (and the `MilpRelaxationModel`
+   MILP path) to pass the relaxation's existing `scipy.sparse` CSC straight through
+   — deleting the `A.toarray()` / dense `a_std` assembly.
+5. **End-to-end**: `_root_relaxation_lower_bound(qap)` and a full `solve_model(qap)`
+   honor `time_limit`; `incorrect_count == 0` on the global50 panel (certificate
+   invariant) and node counts bit-identical to the dense path on the step-0 panel.
+
+## Invariants (CLAUDE.md §5, §1)
+
+* Bit-identical to the dense path on every certifying instance — this is a pure
+  representation change (same pivots, same B&B tree, same cuts). Node count and
+  certified objective must be EXACTLY unchanged; any drift means the CSC assembly
+  diverged and is a bug.
+* Never weaken a validation to make it pass. The dense path stays as the reference
+  oracle in the test harness (not deleted) until the CSC path is green on
+  consecutive nightlies.

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -58,16 +58,29 @@ it even at a single B&B node). Panel note: the current cases all solve at the RO
 (nodes=1), so `lp_iters` is the real bit-identity signal for T2; consider adding a
 genuinely-branching instance before/with T3.
 
-- [ ] **T2 — sparse root cold solve.** Replace `solve_lp_root`'s
-  `dual_slack_basis(lp.a,..)`+`solve_lp` with a CSC path. **RE-SCOPED (risk):** it is
-  NOT a clean swap — `solve_lp` (dense) does internal `ScaledLp` equilibration + a
-  dual-slack warm start; `solve_lp_cols` (CSC) may take a different pivot path →
-  different basis → `lp_iters`/tree drift. To stay bit-identical, mirror the dense
-  logic in CSC (CSC dual-slack warm start where it qualifies, then a CSC cold
-  two-phase) OR confirm `solve_lp_cols` reproduces `solve_lp`'s basis exactly. If
-  neither holds, this is a falsification: stop and re-scope the invariant (bound-only
-  vs bit-identical) before proceeding. **Done:** `driver_matches_golden` still green
-  with no dense `a_w` on the root path.
+**Invariant decision (user, option A): STRICT bit-identical.** Reproduce
+`solve_lp_root` pivot-for-pivot in CSC (keep the `lp_iters`/node-count golden). The
+falsification (`solve_lp_cols` skips `ScaledLp`) is resolved by *porting* the dense
+mechanisms — de-risked below, they're all bit-identical ports, not rewrites:
+- `dual_slack_basis` ALREADY does `SparseCols::from_dense(a)` at its top then uses
+  only `sp.col(j)`; switch its signature to `&SparseCols` and drop the densify —
+  identical result.
+- `Scaling::from_matrix` ALREADY delegates to `equilibrate(&SparseCols,..)`; add
+  `Scaling::from_cols(&SparseCols,m,n)` (same min/max trigger over `vals`, same
+  `equilibrate`) — identical factors. `Scaling::scale_cols(&mut SparseCols)` exists.
+- A CSC `ScaledLp` mirror: `Scaling::from_cols` → `scale_cols` + scale c/l/u/b →
+  `solve_lp_cols` → unscale x/dual/ray (exactly what dense `solve_lp` does).
+
+- [ ] **T2 — bit-identical CSC root solve.** (a) `dual_slack_basis` → `&SparseCols`;
+  (b) add `Scaling::from_cols` (+ unit test: identical factors to `from_matrix` on
+  the panel); (c) a CSC-scaled cold solve mirroring `solve_lp`'s `ScaledLp` path;
+  (d) `solve_lp_root_csc` mirroring `solve_lp_root` (dual-slack warm via
+  `solve_lp_warm_scaled_csc`, CSC cold fallback), wired into the root-cuts loop from
+  a CSC derived once per round. **Coupling note:** cut rows still append to dense
+  `a_w` until T3, so a_w isn't gone yet — T2 proves the *root solve* is CSC and
+  bit-identical; T3 removes a_w. **Done:** `driver_matches_golden` green (incl.
+  `lp_iters`); a unit test confirms `solve_lp_root_csc` == `solve_lp_root` on the
+  panel.
 - [ ] **T3 — sparse scaling + cut-row append.** `Scaling::from_matrix` CSC variant;
   GMI cut rows appended to the CSC (grow col_ptr/row_idx/vals) instead of `a_w`.
   **Done:** cuts-firing panel instance bit-identical; `a_w` no longer constructed.

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -205,13 +205,13 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
     …, psd_cuts=True)` → bound still **−1e-9**, **wall 64 s, RSS 46 GB** (vs 17 s / 0.6 GB
     without PSD). So the moment/clique path (`psd_strengthen_relaxation_bound`) has its own
     dense blowup, same class as T6 — and even so it buys no bound here.
-  - **Verdict:** relaxing the guard **by default is a regression** for qap (≥2 s/node LP for a
-    ~0 bound, no fathoming) and **helps no measured instance**, so shipping a default-off flag
-    would be a near-dead flag (§3). NOT implemented. The guard stays as-is. qap's real dual
-    bound (→149106) needs a fundamentally stronger relaxation (RLT-2 / tailored QAP / SDP),
-    not a McCormick-LP guard flip. **Two concrete follow-ups surfaced, neither a guard flip:**
-    (a) the PSD path's 46 GB densification (a real memory bug, T6-style fix) — **FIXED in T8
-    below**; (b) per-node LP time on large lifts (profiling target from T6).
+  - **Verdict (revised in T12):** relaxing the guard **by default is a regression** for qap
+    (≥2 s/node LP for a ~0 bound, no fathoming) and **helps no measured instance**, so it is
+    **NOT default-on**. qap's real dual bound (→149106) needs a fundamentally stronger relaxation
+    (RLT-2 / tailored QAP / SDP), not a McCormick-LP guard flip. **Two follow-ups surfaced:**
+    (a) the PSD path's 46 GB densification — **FIXED in T8**; (b) per-node LP time — **profiled
+    in T10, fixed in T11**. The guard relaxation itself is shipped as a **default-off flag in
+    T12** (the now-safe capability), not defaulted on.
 
 - [x] **T8 — FIXED the PSD/OBBT exact-LP oracle 46 GB densification.** Root cause: the exact-LP
   oracle `solvers/lp_simplex.py::solve_lp` (returned by `get_exact_lp_solver`, called by
@@ -304,6 +304,29 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
     (T7: qap's McCormick bound is ~0, so lifting it is a separate flagged, bound-changing
     decision). This change removes the memory blowup and makes the fast path *available* for
     large lifts — the enabler that lifting that guard would need.
+
+- [x] **T12 — the guard relaxation, shipped as a default-off flag (§5 bound-changing).** With the
+  whole per-node path now sparse (T0–T11), the `_MAX_RELAX_DENSE_CELLS` dense-cell guard blocks
+  large-lift LPs for a "would force a multi-GB dense allocation" reason that no longer exists.
+  Added `SolverTuning.sparse_large_lp` (`DISCOPT_SPARSE_LARGE_LP`, **default off**): when set, both
+  guard sites (`mccormick_lp.py` fast + cold paths, via `_lp_lift_too_large`) switch from the
+  dense-cell test to a **nonzero** ceiling (`_MAX_SPARSE_LP_NNZ = 5e7`), so a large *sparse* lift
+  earns its rigorous McCormick LP bound instead of being declined — relevant because for
+  `n_vars > 50` alpha-BB is ineligible, so a declined node has **no** per-node relaxation at all.
+  - **Sound (§5):** the McCormick LP bound is a valid lower bound and the B&B keeps the parent
+    bound as a floor, so enabling it never loosens a node — only adds a bound. Regression test
+    `test_sparse_large_lp_flag_solves_declined_node_soundly`: guard tripped + flag on solves the
+    node with the **same** bound as the below-cap solve (the flag gates only *declining*, not the
+    math) and ≤ every sampled feasible objective; flag off is unchanged (declined). qap (guard
+    tripped): off → `skipped_oversize`; on → optimal, bound −3e-9 ≤ oracle, 0.64 GB. 653 smoke +
+    10 adversarial green (default-off ⇒ no behavior change).
+  - **Why default-off (not a dead flag, §3):** the survey found **no benchmark instance that
+    benefits** — the guard only trips at qap-scale lifts (>1e8 dense cells), and qap's indefinite-
+    QP McCormick bound is ~0; every other tested lift is compact (< 1e8 cells) and already solves
+    (autocorr_bern20-03's root McCormick LP is *exact*, −72.0 = oracle). The flag is the opt-in
+    escape hatch for a large-*sparse*-lift-with-tight-McCormick problem (the culmination the whole
+    sparse thread enables); it stays off until such an instance measurably benefits on consecutive
+    nightlies, per §5.
 
 ## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
 

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -106,7 +106,7 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
   (dense == csc) green.
 - [x] **T3b2 — `separate_cover` → CSC** (+ its dense oracle + differential test on a
   crafted fractional node).
-- [ ] **T3b3 — `strong_branch` → CSC** (+ oracle + differential test).
+- [x] **T3b3 — `strong_branch` → CSC.** Finding (mini-falsification): `strong_branch` is ALREADY CSC-based — it solves only via `PreparedDual::prepare`/`solve_lp_warm_scaled_csc`, which take `ctx.csc` and never read `LpView.a`, and it has no other matrix access. So no port is needed; its two `a: ctx.sa` fields were vestigial → set to `&[]` (removing its dense dependency). **Done ✓** — full `cargo test -p discopt-core` (456) green with the empty `.a` (runtime proof it's unread); the integration gate where `strong_branch` actually fires is T3b6.
 - [ ] **T3b4 — node propagation / FBBT (`prop_lp`) → CSC** (+ oracle + differential
   test).
 - [ ] **T3b5 — driver rewire + remove `a_w`.** Carry the working matrix as

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -46,10 +46,28 @@ assembly, never a new relaxation. Stop and root-cause.
   deferred to T2/T3 rather than forced here. **Done ✓** — new gate
   `csc_entry_matches_dense_on_panel` (status/nodes/obj/bound/incumbent all identical)
   green; full `cargo test -p discopt-core` 450 pass; `discopt-python` builds.
+### Gate strengthening (done during T2 setup — §0 kill/re-scope)
+
+The T1 dense-vs-CSC test (`csc_entry_matches_dense_on_panel`) is insufficient as the
+driver-wide gate: T2/T3 change the driver internals for BOTH entry points, so after
+conversion "dense" and "CSC" move together and that test can't catch a regression
+vs the *original* behavior. Added **`driver_matches_golden`** — golden status / obj /
+bound / **node count** / **lp_iters** captured from the pre-conversion driver.
+`lp_iters` is the sensitive discriminator (a different root-solve pivot path drifts
+it even at a single B&B node). Panel note: the current cases all solve at the ROOT
+(nodes=1), so `lp_iters` is the real bit-identity signal for T2; consider adding a
+genuinely-branching instance before/with T3.
+
 - [ ] **T2 — sparse root cold solve.** Replace `solve_lp_root`'s
-  `dual_slack_basis(lp.a,..)`+`solve_lp` with a CSC cold two-phase (adapt the
-  `solve_lp_cols_*` warm-fallback family to a cold entry). **Done:** root bound
-  unchanged on the T0 panel; no dense `a_w` touched on the root path.
+  `dual_slack_basis(lp.a,..)`+`solve_lp` with a CSC path. **RE-SCOPED (risk):** it is
+  NOT a clean swap — `solve_lp` (dense) does internal `ScaledLp` equilibration + a
+  dual-slack warm start; `solve_lp_cols` (CSC) may take a different pivot path →
+  different basis → `lp_iters`/tree drift. To stay bit-identical, mirror the dense
+  logic in CSC (CSC dual-slack warm start where it qualifies, then a CSC cold
+  two-phase) OR confirm `solve_lp_cols` reproduces `solve_lp`'s basis exactly. If
+  neither holds, this is a falsification: stop and re-scope the invariant (bound-only
+  vs bit-identical) before proceeding. **Done:** `driver_matches_golden` still green
+  with no dense `a_w` on the root path.
 - [ ] **T3 — sparse scaling + cut-row append.** `Scaling::from_matrix` CSC variant;
   GMI cut rows appended to the CSC (grow col_ptr/row_idx/vals) instead of `a_w`.
   **Done:** cuts-firing panel instance bit-identical; `a_w` no longer constructed.

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -162,15 +162,34 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
     driver**: it is the **Python McCormick relaxation build** for the 85,756-row lift
     (21,424 bilinear envelopes), a transient the sparse driver does not touch.
   - **Consequences / re-scope:** (1) The sparse-driver work is correct and necessary but does
-    **not** by itself make qap tractable. (2) The `_MAX_RELAX_DENSE_CELLS` guard is left
-    **intact** — its dense-driver rationale is now obsolete, but even on the sparse path
-    solving qap's node LP still incurs the ~28 GB build blowup **and** an unquantified
-    85756×85756 basis-LU fill-in risk, so relaxing it would make qap *worse*, not better. Do
-    not open it without first solving the build-memory problem. (3) **Next task (new plan
-    doc):** profile and cap the Python McCormick relaxation *build* memory for large lifts
-    (the ~30 GB transient), independent of this driver work. The certificate gate
-    (`incorrect_count == 0` on global50) is unaffected by this iteration — the routing is
-    bound-neutral. Retire the dense oracles only after that follow-up + nightly greens.
+    **not** by itself make qap tractable. (2) **Next task:** root-cause and fix the Python
+    McCormick relaxation build memory for large lifts (the ~30 GB transient).
+
+- [x] **T6 — ROOT-CAUSED + FIXED the ~30 GB (commit `fad92ab6`).** Stack-sampling the relaxer
+  build (`faulthandler.dump_traceback` triggered by an RSS watchdog) placed the entire blowup
+  in `IncrementalMcCormickLP._build_structure`, **not** the cold build and **not** `_A_ub`:
+  - The incremental per-node fast path stores **`base_A` DENSE** (`rows×cols`): qap's
+    85756×21649 lift is `.todense()` → **14.85 GB**, then `self.base_A = A.copy()` holds a
+    **second 14.85 GB**, and `_patch()` does `A = self.base_A.copy()` — a **fresh 14.85 GB
+    dense array on every node**. The fast path is `O(rows·cols)` memory, per node.
+  - **Fix:** guard the incremental structure by dense-cell budget
+    (`_MAX_INCREMENTAL_DENSE_CELLS = 1e8`, ~0.8 GB) **before** the `.todense()`; above it,
+    raise → caught by the existing `__init__` fallback (`ok=False`) → `solve_at_node` uses the
+    sparse per-node cold build. Sound: the fast path is only an accelerator whose rows are
+    `_validate`d bit-identical to the cold build, so declining it changes speed, never the
+    bound. General (mirrors `_MAX_RELAX_DENSE_CELLS`), not instance-keyed. Regression test
+    `test_incremental_declined_when_lift_too_large_for_dense`; 230 mccormick/incremental +
+    653 smoke green.
+  - **Measured (peak RSS):** relaxer construction 30 GB → **0.38 GB**; full solve with
+    production guards 30 GB → **0.86 GB**; full solve with `_MAX_RELAX_DENSE_CELLS` lifted so
+    the sparse simplex actually solves qap's 85756-row node LP → **0.88 GB, bound sound**
+    (−1e-9 ≤ oracle 388214). **The basis-LU does NOT blow memory** — falsifying the T5
+    "unquantified fill-in risk" worry. The remaining issue is per-node LP **time** (8 s budget
+    → ~20 s wall on the 85k-row McCormick LP), now a **profiling target**, not a memory
+    blocker. The `_MAX_RELAX_DENSE_CELLS` guard is still left intact by default (relaxing it —
+    to let qap earn a real McCormick LP bound instead of alphaBB — is a **bound-changing**
+    change per §5: needs the differential-bound test + feature flag + nightly greens, a
+    separate task). Certificate gate unaffected. Retire dense oracles only after nightly-green.
 
 ## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
 

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -135,7 +135,13 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
   that genuinely branches (source from the `.nl` corpus or craft with cuts/heuristics
   off) so `driver_matches_golden` exercises `separate_cover`/`strong_branch`/
   propagation end-to-end, not just nodes=1. Capture status/obj/nodes/`lp_iters`.
-- [ ] **T4 — Python binding + routing.** `solve_milp_csc_py(col_ptr, row_idx, vals,
+- [~] **T4 — Python binding + routing.** RUST HALF DONE: `solve_milp_hooked` now takes a
+  `SparseCols` (dense `solve_milp`/`solve_milp_py` build it from `lp.a`; no internal dense
+  copy). Added `solve_milp_csc_py` (col_ptr/row_idx/vals input → `from_csc` → the sparse
+  driver, NEVER densified) + a shared `run_milp_hooked`, registered in lib.rs. core 458
+  tests green; discopt-python builds. REMAINING (with T5, needs a rebuilt extension):
+  route `solvers/milp_simplex.py` + the `MilpRelaxationModel` MILP path to the CSC binding,
+  deleting `A.toarray()`/the dense `a_std`. `solve_milp_csc_py(col_ptr, row_idx, vals,
   m, n, c, l, u, int_cols, ...)`; route `solvers/milp_simplex.py` and the
   `MilpRelaxationModel` MILP path to pass the relaxation's existing scipy CSC
   through — delete the `A.toarray()`/dense `a_std` assembly. **Done:** a small

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -277,6 +277,34 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
     coefficients per node instead of rebuilding — that would collapse the ~2.5 s build to a patch,
     leaving mostly the 0.49 s LP solve. Larger change (bit-identity contract vs the cold build).
 
+- [x] **T11 — sparse `IncrementalMcCormickLP`: 14.7× per-node on qap, 30 GB → 0.76 GB.** Made the
+  incremental fast path fully sparse so large-lift models patch coefficients per node instead of
+  rebuilding:
+  - `base_A` is now **CSR** (was `.todense()`d, ~14.85 GB/copy on qap). The McCormick product
+    rows have a **stable sparsity pattern** (columns fixed at `{factors, aux}`, only the box-
+    dependent *values* change), so `_build_structure` precomputes each product row's data-index
+    span + target-column positions, and `_patch` copies the base `.data` (~nnz floats) and
+    overwrites only those entries — O(nnz)/node, not O(rows·cols). `_full_build` keeps the matrix
+    sparse; the row-mapping loop is now O(nnz) via a CSC aux-column lookup (was O(rows·products)
+    ~1.8e9 on qap); `_rowset` compares sparse row-sets order-free without densifying; `assemble`
+    uses sparse vstack. Guard is now **nnz-based** (`_MAX_INCREMENTAL_NNZ = 5e7`), replacing the
+    T6 dense-cell decline.
+  - **Bit-identical:** the built-in `_validate` gate (patched vs cold-built row-set on 6 sign-
+    diverse boxes) still passes — 231 mccormick/incremental + 653 smoke + 10 adversarial green.
+    New `test_incremental_structure_is_sparse_and_patch_matches_dense` asserts `base_A` is sparse
+    and the sparse patch equals an independent dense patch.
+  - **Measured (qap, guard lifted so the LP solves):** per-node **1.566 s (cold rebuild) → 0.107 s
+    (sparse patch)**, **14.7×**, same bound (−1e-9), RSS **0.76 GB** (was ~30 GB). Construction
+    (incl. `_validate`'s 6 cold builds) ~13 s, one-time.
+  - **Fixup:** `lp_spatial_bb._separate_node_cuts` (a dense-only GMI/crossover cut separator that
+    always received a dense `A`) now densifies its `A` at entry — this bounded per-node cut path
+    was never viable for a large lift; the node LP solve stays sparse.
+  - **Production note:** the 14.7× is *realized* only where the node LP actually solves. For qap
+    the `_MAX_RELAX_DENSE_CELLS` fast-path guard (`mccormick_lp.py:766`) still declines the solve
+    (T7: qap's McCormick bound is ~0, so lifting it is a separate flagged, bound-changing
+    decision). This change removes the memory blowup and makes the fast path *available* for
+    large lifts — the enabler that lifting that guard would need.
+
 ## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
 
 `solve_milp_py` (the Rust MILP entry) takes a **dense** `a: PyReadonlyArray2`, and

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -210,8 +210,26 @@ structural `0.0` adds exactly, and CSC preserves ascending row order, so `Aᵀy`
     would be a near-dead flag (§3). NOT implemented. The guard stays as-is. qap's real dual
     bound (→149106) needs a fundamentally stronger relaxation (RLT-2 / tailored QAP / SDP),
     not a McCormick-LP guard flip. **Two concrete follow-ups surfaced, neither a guard flip:**
-    (a) the PSD path's 46 GB densification (a real memory bug, T6-style fix); (b) per-node LP
-    time on large lifts (profiling target from T6). Awaiting direction on which to pursue.
+    (a) the PSD path's 46 GB densification (a real memory bug, T6-style fix) — **FIXED in T8
+    below**; (b) per-node LP time on large lifts (profiling target from T6).
+
+- [x] **T8 — FIXED the PSD/OBBT exact-LP oracle 46 GB densification.** Root cause: the exact-LP
+  oracle `solvers/lp_simplex.py::solve_lp` (returned by `get_exact_lp_solver`, called by
+  `psd_strengthen_relaxation_bound`, OBBT, DBBT, Benders) is a **separate** dense entry from the
+  T4b `solve_milp` — it did `A_ub.toarray()` **and** built `a_std = np.zeros((m, n+m))`; for
+  qap's 85756-row PSD-strengthened relaxation that standard form is `85756 x 107405 ~ 9.2e9
+  cells ~ 73 GB` (observed ~46 GB peak before the OS killed/partial-committed it). **Fix:**
+  rewrote `solve_lp` to assemble the standard form `[A_ub | I_ub | 0 ; A_eq | 0 | I_eq]`
+  **sparsely** (`sp.vstack`/`sp.hstack` + `sort_indices`) and call the CSC-native
+  `solve_lp_warm_csc_py` (which already returns the row duals), reconstructing reduced costs
+  with sparse `Aᵀy`. Bound-neutral marshaling (§5): objective matches HiGHS to 3e-16 and
+  dense-input == sparse-input on a 40-LP panel; row-dual/reduced-cost KKT identities preserved
+  (`test_simplex_lp.py` +2 tests, 344 LP/OBBT/DBBT/PSD tests, 653 smoke, 10 adversarial green).
+  **Measured (qap root, peak RSS):** `_root_relaxation_lower_bound(psd_cuts=True)` **46 GB →
+  0.69 GB** (64 s → 15 s). Regression tests: `test_solve_lp_routes_through_sparse_csc_binding`
+  (spies that the dense binding is never called) + `test_solve_lp_does_not_densify_large_sparse_lp`
+  (tracemalloc peak ≪ the dense `m×(n+m)`). NB: PSD still buys qap no bound (−1e-9) — that is a
+  separate *effectiveness* question, untouched here; only the memory blowup is fixed.
 
 ## Problem (measured on qap — a 225-binary Quadratic Assignment Problem)
 

--- a/docs/dev/sparse-milp-plan.md
+++ b/docs/dev/sparse-milp-plan.md
@@ -27,11 +27,14 @@ assembly, never a new relaxation. Stop and root-cause.
 
 ## Tasks
 
-- [ ] **T0 — differential harness.** Rust test `bnb::milp_driver` (or a new
-  `sparse_milp_diff` test module): a panel of small MILPs — pure-LP, 1–3 binaries,
-  infeasible, unbounded, a cuts-firing instance — each solved via dense `solve_milp`
-  and (stubbed for now) asserted against itself; wire the CSC path in at T1.
-  **Done:** panel builds + passes against the dense path; committed.
+- [x] **T0 — differential harness.** `#[cfg(test)] mod sparse_milp_diff` in
+  `milp_driver.rs`: a 6-case panel (pure-LP, binary knapsack, general integer,
+  infeasible, unbounded, cuts-firing knapsack) with a `Case` owning its data, a
+  dense-oracle runner, a `Case::csc()` (from_dense) for T1, and an `assert_same`
+  bit-identical gate (status + node-count exact, obj/bound tight). Tests:
+  reference-values, determinism (dense re-solve bit-identical incl. lp_iters), and
+  CSC-nnz-round-trips-dense. **Done ✓** — 3 tests green; full `cargo test
+  -p discopt-core` 449+ pass.
 - [ ] **T1 — CSC-carrying driver core.** `solve_milp_csc(csc: SparseCols, m, n, c,
   l, u, b, obj_const, opts)` that threads `csc` where `SparseCols::from_dense(&a_w)`
   is today and passes zero-length `.a` to node `LpView`s. Root solve / cuts /

--- a/python/discopt/_jax/convexity/patterns.py
+++ b/python/discopt/_jax/convexity/patterns.py
@@ -71,7 +71,38 @@ from .lattice import Curvature
 # ──────────────────────────────────────────────────────────────────────
 
 
+# Per-model cache of the declared-box arrays + scalar count (issue: qap-class
+# convexity classification). ``_box_bounds`` / ``_total_scalar_variables`` are pure
+# functions of the model's DECLARED variable bounds, yet the syntactic convexity
+# recognizers call them once per product term (``_affine_strictly_positive`` ->
+# ``_affine_lower_bound``) — 66k times on qap's 21,424-term objective, each an
+# O(n_vars) rebuild (10s of pure recomputation). Declared bounds are static within a
+# single classification pass, so we memoize the result on the model and invalidate it
+# exactly where the solver resets ``_convexity_classification_cache`` (see
+# :func:`clear_declared_box_cache`, called from ``solver.solve_model``), so a
+# post-presolve re-classification with tightened bounds recomputes. Bound-neutral: the
+# returned arrays/count are identical, only recomputation is removed.
+_DECLARED_BOX_CACHE_ATTR = "_patterns_declared_box_cache"
+
+
+def clear_declared_box_cache(model: Model) -> None:
+    """Invalidate the per-model declared-box cache (call when declared bounds change).
+
+    Idempotent and safe on a model that was never cached. The solver calls this at
+    every point it resets its convexity-classification cache, so a re-classification
+    after presolve/reformulation tightens the declared bounds sees fresh values.
+    """
+    try:
+        if hasattr(model, _DECLARED_BOX_CACHE_ATTR):
+            delattr(model, _DECLARED_BOX_CACHE_ATTR)
+    except Exception:
+        pass
+
+
 def _total_scalar_variables(model: Model) -> int:
+    cached = getattr(model, _DECLARED_BOX_CACHE_ATTR, None)
+    if cached is not None:
+        return int(cached[0])
     return sum(v.size for v in model._variables)
 
 
@@ -219,7 +250,16 @@ def _affine_range_1d(alpha: float, beta: float, lb: float, ub: float) -> tuple[f
 
 
 def _box_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
-    """Per-scalar-slot lower/upper bound vectors over all model variables."""
+    """Per-scalar-slot lower/upper bound vectors over all model variables.
+
+    Memoized per model (see :data:`_DECLARED_BOX_CACHE_ATTR`): pure function of the
+    DECLARED bounds, called once per objective term by the syntactic convexity
+    recognizers. The cache stores ``(n_scalar, lo, hi)`` so ``_total_scalar_variables``
+    shares it, and is invalidated by :func:`clear_declared_box_cache`.
+    """
+    cached = getattr(model, _DECLARED_BOX_CACHE_ATTR, None)
+    if cached is not None:
+        return cached[1], cached[2]
     los: list[np.ndarray] = []
     his: list[np.ndarray] = []
     for v in model._variables:
@@ -232,8 +272,14 @@ def _box_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
         los.append(lb)
         his.append(ub)
     if not los:
-        return np.zeros(0), np.zeros(0)
-    return np.concatenate(los), np.concatenate(his)
+        lo_arr, hi_arr = np.zeros(0), np.zeros(0)
+    else:
+        lo_arr, hi_arr = np.concatenate(los), np.concatenate(his)
+    try:
+        setattr(model, _DECLARED_BOX_CACHE_ATTR, (int(lo_arr.size), lo_arr, hi_arr))
+    except Exception:
+        pass
+    return lo_arr, hi_arr
 
 
 def _affine_lower_bound(expr: Expression, model: Model) -> Optional[float]:

--- a/python/discopt/_jax/incremental_mccormick.py
+++ b/python/discopt/_jax/incremental_mccormick.py
@@ -35,20 +35,18 @@ logger = logging.getLogger(__name__)
 
 _TOL = 1e-7
 
-# Dense-footprint budget for the incremental structure. Unlike the cold build
-# (which keeps ``_A_ub`` SPARSE, ~nnz cells), the incremental fast path stores
-# ``base_A`` as a DENSE ``rows x cols`` array and, worse, ``_patch`` copies that
-# whole dense array on EVERY node solve — so its footprint is ``O(rows*cols)``
-# per node, not per solve. A large lift makes this ruinous: qap's 85756 x 21649
-# lift is ~1.86e9 cells ~ 14.85 GB for base_A alone, plus another 14.85 GB per
-# node copy (measured ~30 GB peak just constructing the relaxer). Above this cell
-# budget the incremental path is declined (``ok=False``) and ``solve_at_node``
-# falls back to the trusted per-node SPARSE cold build. Sound: the incremental
-# structure is only an accelerator whose result is validated bit-identical to the
-# cold build (see the class docstring / ``_validate``), so skipping it changes
-# speed, never the bound. ~1e8 cells ~ 0.8 GB dense: comfortably covers every
-# small/medium lift the fast path targets, far below the multi-GB blowup.
-_MAX_INCREMENTAL_DENSE_CELLS = 1.0e8
+# Nonzero-footprint budget for the incremental structure. The fast path now holds
+# ``base_A`` SPARSE (CSR) and ``_patch`` copies only its ``.data`` array (~nnz
+# floats) per node, so the footprint is ``O(nnz)``, not ``O(rows*cols)`` — the
+# earlier dense ``base_A`` (~14.85 GB on qap, ~30 GB peak) is gone. This cap only
+# guards a pathologically dense lift whose per-node ``.data`` copy would itself be
+# large; above it the incremental path is declined (``ok=False``) and
+# ``solve_at_node`` uses the per-node SPARSE cold build. Sound either way: the
+# structure is only an accelerator whose rows are validated bit-identical to the
+# cold build (``_validate``), so declining changes speed, never the bound. 5e7
+# nonzeros ~ 0.4 GB of f64 data — far above qap's ~172k nnz and any well-posed
+# lift, far below a memory-thrashing structure.
+_MAX_INCREMENTAL_NNZ = 50_000_000
 
 # Warn-once keys for oversize declines, so a large model logs a single line
 # rather than one per relaxer construction.
@@ -218,28 +216,14 @@ class IncrementalMcCormickLP:
         )
         if not relax._objective_bound_valid or relax._A_ub is None:
             raise ValueError("relaxation has no valid bound / no rows")
-        # Decline the dense incremental structure for a large lift BEFORE
-        # densifying (``.todense()`` below would allocate the full ``rows*cols``
-        # array). This keeps the ~30 GB dense ``base_A`` (and its per-node copy in
-        # ``_patch``) off large-lift problems like qap; ``solve_at_node`` then uses
-        # the sparse cold build per node. See ``_MAX_INCREMENTAL_DENSE_CELLS``.
-        _rows, _cols = relax._A_ub.shape
-        if _rows * _cols > _MAX_INCREMENTAL_DENSE_CELLS:
-            key = (_rows, _cols)
-            if key not in _incremental_oversize_warned:
-                _incremental_oversize_warned.add(key)
-                logger.info(
-                    "Incremental McCormick structure declined: lift %dx%d ~ %.1e dense "
-                    "cells > cap %.0e; using the per-node sparse cold build instead.",
-                    _rows,
-                    _cols,
-                    float(_rows * _cols),
-                    _MAX_INCREMENTAL_DENSE_CELLS,
-                )
-            raise _IncrementalStructureTooLarge(
-                f"lift {_rows}x{_cols} exceeds the dense incremental budget"
-            )
-        A = np.asarray(sp.csr_matrix(relax._A_ub).todense(), dtype=np.float64)
+        # SPARSE: keep the lifted constraint matrix as CSR — never densify. The
+        # structure holds it sparse (``_build_structure``) and ``_patch`` rewrites
+        # only the box-dependent product-row *values* in place (fixed sparsity
+        # pattern), so the footprint is O(nnz), not O(rows*cols). (Before this the
+        # matrix was ``.todense()``'d, ~14.85 GB per copy on qap's 85756x21649 lift,
+        # which forced the whole structure to be declined for large lifts — T6/T10.)
+        A = sp.csr_matrix(relax._A_ub, dtype=np.float64)
+        A.sort_indices()
         b = np.asarray(relax._b_ub, dtype=np.float64).ravel()
         bnds = np.asarray(relax._bounds, dtype=np.float64)
         c = np.asarray(relax._c, dtype=np.float64).ravel()
@@ -266,11 +250,25 @@ class IncrementalMcCormickLP:
                 lb_p[k], ub_p[k] = -(7.0 + k), -1.0
             else:
                 lb_p[k], ub_p[k] = 1.0, 7.0 + k
-        A, b, bnds, c, info, _ = self._full_build(lb_p, ub_p)
+        A, b, bnds, c, info, _ = self._full_build(lb_p, ub_p)  # A is CSR (sparse)
+        # Decline only genuinely huge structures — now measured by NONZEROS (the
+        # sparse footprint), not dense cells. qap's lift is ~172k nnz (trivial);
+        # this guards a pathological lift whose sparse `.data` copy per node would
+        # itself be large. Above it, fall back to the per-node cold build.
+        if A.nnz > _MAX_INCREMENTAL_NNZ:
+            if A.nnz not in _incremental_oversize_warned:
+                _incremental_oversize_warned.add(A.nnz)
+                logger.info(
+                    "Incremental McCormick structure declined: lift has %d nonzeros "
+                    "> cap %d; using the per-node sparse cold build instead.",
+                    A.nnz,
+                    _MAX_INCREMENTAL_NNZ,
+                )
+            raise _IncrementalStructureTooLarge(f"lift nnz {A.nnz} exceeds budget")
         self.n = n
         self.ncol = A.shape[1]
         self.c = c
-        self.base_A = A.copy()
+        self.base_A = A  # CSR, sorted indices; product-row VALUES rewritten per node
         self.base_b = b.copy()
         self.base_bounds = bnds.copy()
         self.bilinear = dict(info.get("bilinear", {}))
@@ -290,11 +288,24 @@ class IncrementalMcCormickLP:
         except Exception:
             self.col_identities = None
 
-        # map each product to its row indices (support subset of {factors, aux})
-        supp = [set(np.nonzero(np.abs(A[k]) > _TOL)[0]) for k in range(A.shape[0])]
+        # Map each product to its row indices. SPARSE + efficient: each product row
+        # contains its aux column, so a product's rows are found among the rows that
+        # touch that aux (a CSC lookup) — not by scanning all rows for every product
+        # (the old dense ``supp <= {...}`` loop was O(rows*products) ~1.8e9 on qap).
+        indptr, indices, data = A.indptr, A.indices, A.data
+        csc = A.tocsc()
+        col_ptr, col_rows = csc.indptr, csc.indices
+
+        def _rows_with_col(c):
+            return col_rows[col_ptr[c] : col_ptr[c + 1]]
+
+        def _support(k):
+            lo, hi = indptr[k], indptr[k + 1]
+            return {int(indices[t]) for t in range(lo, hi) if abs(data[t]) > _TOL}
+
         self.bilin_rows = {}
         for (i, j), a in self.bilinear.items():
-            rows = [k for k in range(A.shape[0]) if a in supp[k] and supp[k] <= {i, j, a}]
+            rows = [int(k) for k in _rows_with_col(a) if _support(k) <= {i, j, a}]
             if len(rows) != 4:
                 raise ValueError(f"bilinear ({i},{j}) -> {len(rows)} rows, expected 4")
             self.bilin_rows[(i, j, a)] = rows
@@ -303,14 +314,14 @@ class IncrementalMcCormickLP:
         for (i, p), a in self.monomial.items():
             if self._root_sign[i] == 0:
                 raise ValueError(f"monomial x_{i}^{p}: root box spans zero (unmappable)")
-            rows = [k for k in range(A.shape[0]) if a in supp[k] and supp[k] <= {i, a}]
+            rows = [int(k) for k in _rows_with_col(a) if _support(k) <= {i, a}]
             if len(rows) != 4:
                 raise ValueError(f"monomial x_{i}^{p} -> {len(rows)} rows, expected 4")
             self.mono_rows[(i, a, p)] = rows
         # affine square (c*x_j + d)**2 -> aux: 4 secant/tangent rows over {j, aux}.
         self.affsq_rows = {}
         for (j, a), (coeff, const) in self.affine_square.items():
-            rows = [k for k in range(A.shape[0]) if a in supp[k] and supp[k] <= {j, a}]
+            rows = [int(k) for k in _rows_with_col(a) if _support(k) <= {j, a}]
             if len(rows) != 4:
                 raise ValueError(f"affine square ({j},{a}) -> {len(rows)} rows, expected 4")
             self.affsq_rows[(j, a, coeff, const)] = rows
@@ -323,49 +334,120 @@ class IncrementalMcCormickLP:
         for rs in self.affsq_rows.values():
             self._prod_rows |= set(rs)
 
+        # Fixed-pattern rewrite maps for the sparse ``_patch`` hot path: the base
+        # CSR ``.data`` template, each product row's data-index span (to zero it,
+        # matching the dense ``A[k]=0.0``), and the data index of each target column
+        # ``(row, col)``. The sparsity pattern never changes across nodes — only the
+        # product-row coefficient *values* do — so a node solve copies ``.data`` and
+        # overwrites a few hundred entries instead of rebuilding the whole matrix.
+        self._base_data = np.asarray(data, dtype=np.float64).copy()
+        self._base_indices = np.asarray(indices)
+        self._base_indptr = np.asarray(indptr)
+        self._base_shape = A.shape
+        self._row_span = {k: (int(indptr[k]), int(indptr[k + 1])) for k in self._prod_rows}
+        self._pos: dict[tuple[int, int], int] = {}
+
+        def _index_of(k, col):
+            lo, hi = indptr[k], indptr[k + 1]
+            for t in range(lo, hi):
+                if int(indices[t]) == col:
+                    return int(t)
+            # Probe box is built so every McCormick coefficient is nonzero, so each
+            # target column is present. A miss means the pattern can't represent a
+            # box where this coefficient is nonzero -> refuse (ok=False -> cold path).
+            raise ValueError(f"incremental pattern missing entry ({k},{col})")
+
+        for (i, j, a), rows in self.bilin_rows.items():
+            for k in rows:
+                for col in (i, j, a):
+                    self._pos[(k, col)] = _index_of(k, col)
+        for (i, a, p), rows in self.mono_rows.items():
+            for k in rows:
+                for col in (i, a):
+                    self._pos[(k, col)] = _index_of(k, col)
+        for (j, a, coeff, const), rows in self.affsq_rows.items():
+            for k in rows:
+                for col in (j, a):
+                    self._pos[(k, col)] = _index_of(k, col)
+
     # -- per-node patch ---------------------------------------------------- #
 
     def _patch(self, lb, ub):
-        """Return (A, b, bounds) for the McCormick LP over [lb,ub]."""
-        A = self.base_A.copy()
+        """Return (A, b, bounds) for the McCormick LP over [lb,ub].
+
+        SPARSE hot path: copy the base CSR ``.data`` template and overwrite only the
+        box-dependent product-row entries at their precomputed positions (fixed
+        pattern), then wrap it back into a CSR sharing the immutable indptr/indices.
+        Equivalent, row for row, to the dense ``A[k]=0; A[k,col]=coef`` it replaces
+        (each product row's stored support is exactly its target columns, so zeroing
+        the row's data span then setting the targets reproduces it) — bit-identity is
+        gated by :meth:`_validate`.
+        """
+        data = self._base_data.copy()
         b = self.base_b.copy()
         bounds = self.base_bounds.copy()
         bounds[: self.n, 0] = lb
         bounds[: self.n, 1] = ub
+        pos = self._pos
+        span = self._row_span
         for (i, j, a), rows in self.bilin_rows.items():
             li, ui, lj, uj = lb[i], ub[i], lb[j], ub[j]
             for k, (ci, cj, cw, rhs) in zip(rows, _bilinear_rows(i, j, a, li, ui, lj, uj)):
-                A[k] = 0.0
-                A[k, i] += ci
-                A[k, j] += cj
-                A[k, a] = cw
+                lo, hi = span[k]
+                data[lo:hi] = 0.0  # zero the whole row (matches dense A[k]=0.0)
+                data[pos[(k, i)]] = ci
+                data[pos[(k, j)]] = cj
+                data[pos[(k, a)]] = cw
                 b[k] = rhs
             bounds[a, 0], bounds[a, 1] = _bilinear_aux_bounds(li, ui, lj, uj)
         for (i, a, p), rows in self.mono_rows.items():
             li, ui = lb[i], ub[i]
             for k, (ci, cs, rhs) in zip(rows, _monomial_rows(li, ui, p)):
-                A[k] = 0.0
-                A[k, i] = ci
-                A[k, a] = cs
+                lo, hi = span[k]
+                data[lo:hi] = 0.0
+                data[pos[(k, i)]] = ci
+                data[pos[(k, a)]] = cs
                 b[k] = rhs
             bounds[a, 0], bounds[a, 1] = _monomial_aux_bounds(li, ui, p)
         for (j, a, coeff, const), rows in self.affsq_rows.items():
             li, ui = lb[j], ub[j]
             for k, (cx, cw, rhs) in zip(rows, _affine_square_rows(coeff, const, li, ui)):
-                A[k] = 0.0
-                A[k, j] = cx
-                A[k, a] = cw
+                lo, hi = span[k]
+                data[lo:hi] = 0.0
+                data[pos[(k, j)]] = cx
+                data[pos[(k, a)]] = cw
                 b[k] = rhs
             bounds[a, 0], bounds[a, 1] = _affine_square_aux_bounds(coeff, const, li, ui)
+        A = sp.csr_matrix(
+            (data, self._base_indices, self._base_indptr), shape=self._base_shape, copy=False
+        )
         return A, b, bounds
 
     # -- soundness gate ---------------------------------------------------- #
 
     @staticmethod
     def _rowset(A, b):
-        """Canonical hashable representation of the polytope's rows (order-free)."""
-        rows = np.hstack([np.round(A, 6), np.round(b, 6).reshape(-1, 1)])
-        return sorted(map(tuple, rows.tolist()))
+        """Canonical hashable representation of the polytope's rows (order-free).
+
+        Sparse-native (O(nnz), never densified): each row is the sorted tuple of its
+        nonzero ``(col, round(val,6))`` pairs plus ``round(rhs,6)``. Entries rounding
+        to 0 are dropped, so an explicit structural zero (the fixed-pattern ``_patch``
+        can leave a zeroed target entry) compares equal to its absence in the cold
+        build — the two matrices match iff they encode the same polytope.
+        """
+        M = sp.csr_matrix(A)
+        M.sort_indices()
+        indptr, indices, data = M.indptr, M.indices, M.data
+        b = np.asarray(b, dtype=np.float64).ravel()
+        out = []
+        for k in range(M.shape[0]):
+            entries = tuple(
+                (int(indices[t]), rv)
+                for t in range(indptr[k], indptr[k + 1])
+                if (rv := round(float(data[t]), 6)) != 0.0
+            )
+            out.append((entries, round(float(b[k]), 6)))
+        return sorted(out)
 
     @staticmethod
     def _box_sign_regime(lo, hi):
@@ -479,13 +561,13 @@ class IncrementalMcCormickLP:
         ``cut_rows`` is a list of ``(coeffs, rhs)`` inequalities ``coeffs·x <= rhs``
         over the structural+aux columns (length ``ncol``). Returns ``(A, b, bounds)``.
         """
-        A, b, bounds = self._patch(lb, ub)
+        A, b, bounds = self._patch(lb, ub)  # A is CSR (sparse)
         if cut_rows:
-            extra_A = np.array(
-                [np.asarray(co, dtype=np.float64)[: self.ncol] for co, _ in cut_rows]
+            extra_A = sp.csr_matrix(
+                np.array([np.asarray(co, dtype=np.float64)[: self.ncol] for co, _ in cut_rows])
             )
             extra_b = np.array([float(r) for _, r in cut_rows])
-            A = np.vstack([A, extra_A])
+            A = sp.vstack([A, extra_A], format="csr")
             b = np.concatenate([b, extra_b])
         return A, b, bounds
 

--- a/python/discopt/_jax/incremental_mccormick.py
+++ b/python/discopt/_jax/incremental_mccormick.py
@@ -25,12 +25,39 @@ univariate, fractional power, piecewise) makes validation fail -> fallback.
 
 from __future__ import annotations
 
+import logging
 import time
 
 import numpy as np
 import scipy.sparse as sp
 
+logger = logging.getLogger(__name__)
+
 _TOL = 1e-7
+
+# Dense-footprint budget for the incremental structure. Unlike the cold build
+# (which keeps ``_A_ub`` SPARSE, ~nnz cells), the incremental fast path stores
+# ``base_A`` as a DENSE ``rows x cols`` array and, worse, ``_patch`` copies that
+# whole dense array on EVERY node solve — so its footprint is ``O(rows*cols)``
+# per node, not per solve. A large lift makes this ruinous: qap's 85756 x 21649
+# lift is ~1.86e9 cells ~ 14.85 GB for base_A alone, plus another 14.85 GB per
+# node copy (measured ~30 GB peak just constructing the relaxer). Above this cell
+# budget the incremental path is declined (``ok=False``) and ``solve_at_node``
+# falls back to the trusted per-node SPARSE cold build. Sound: the incremental
+# structure is only an accelerator whose result is validated bit-identical to the
+# cold build (see the class docstring / ``_validate``), so skipping it changes
+# speed, never the bound. ~1e8 cells ~ 0.8 GB dense: comfortably covers every
+# small/medium lift the fast path targets, far below the multi-GB blowup.
+_MAX_INCREMENTAL_DENSE_CELLS = 1.0e8
+
+# Warn-once keys for oversize declines, so a large model logs a single line
+# rather than one per relaxer construction.
+_incremental_oversize_warned: set = set()
+
+
+class _IncrementalStructureTooLarge(Exception):
+    """The lifted relaxation is too large to hold densely in the incremental
+    fast path; the caller falls back to the sparse per-node cold build."""
 
 
 def _bilinear_rows(i, j, a, li, ui, lj, uj):
@@ -191,6 +218,27 @@ class IncrementalMcCormickLP:
         )
         if not relax._objective_bound_valid or relax._A_ub is None:
             raise ValueError("relaxation has no valid bound / no rows")
+        # Decline the dense incremental structure for a large lift BEFORE
+        # densifying (``.todense()`` below would allocate the full ``rows*cols``
+        # array). This keeps the ~30 GB dense ``base_A`` (and its per-node copy in
+        # ``_patch``) off large-lift problems like qap; ``solve_at_node`` then uses
+        # the sparse cold build per node. See ``_MAX_INCREMENTAL_DENSE_CELLS``.
+        _rows, _cols = relax._A_ub.shape
+        if _rows * _cols > _MAX_INCREMENTAL_DENSE_CELLS:
+            key = (_rows, _cols)
+            if key not in _incremental_oversize_warned:
+                _incremental_oversize_warned.add(key)
+                logger.info(
+                    "Incremental McCormick structure declined: lift %dx%d ~ %.1e dense "
+                    "cells > cap %.0e; using the per-node sparse cold build instead.",
+                    _rows,
+                    _cols,
+                    float(_rows * _cols),
+                    _MAX_INCREMENTAL_DENSE_CELLS,
+                )
+            raise _IncrementalStructureTooLarge(
+                f"lift {_rows}x{_cols} exceeds the dense incremental budget"
+            )
         A = np.asarray(sp.csr_matrix(relax._A_ub).todense(), dtype=np.float64)
         b = np.asarray(relax._b_ub, dtype=np.float64).ravel()
         bnds = np.asarray(relax._bounds, dtype=np.float64)

--- a/python/discopt/_jax/lp_spatial_bb.py
+++ b/python/discopt/_jax/lp_spatial_bb.py
@@ -119,6 +119,17 @@ def _separate_node_cuts(A, b, bounds, x, ncol, c, max_cuts=12):
     except Exception:
         return cuts
 
+    # This GMI/crossover cut separator is dense by construction (``np.hstack([A,
+    # np.eye])``, ``LPData``, the crossover vertex solve), and its dense ``A_eq`` is
+    # ``m x (ncol+m)`` regardless — it was never viable for a large lift. ``inc.assemble``
+    # now returns a SPARSE ``A``, so densify once here to preserve the exact prior
+    # contract (only this bounded per-node cut path densifies; the node LP solve stays
+    # sparse).
+    import scipy.sparse as sp
+
+    if sp.issparse(A):
+        A = A.toarray()
+
     lb = bounds[:, 0]
     ub = bounds[:, 1]
     is_int = np.ones(ncol, dtype=bool)  # original + product aux are integer-valued

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -241,6 +241,29 @@ _SOLVE_DEADLINE_FLOOR_S = 0.05
 # (typical MINLP lifts are < 1e6 cells) and far below the multi-GB blowup.
 _MAX_RELAX_DENSE_CELLS = 1.0e8
 
+# Nonzero ceiling for the per-node McCormick LP under the opt-in
+# ``SolverTuning.sparse_large_lp`` flag. The whole per-node path is sparse now, so
+# the dense-cell guard above is the wrong cost model — memory is O(nnz), not
+# O(rows*cols). With the flag set the guard becomes nnz-based against this cap
+# (~0.4 GB of f64 data), so a large *sparse* lift earns its rigorous McCormick LP
+# bound instead of being declined. Matches ``incremental_mccormick._MAX_INCREMENTAL_NNZ``.
+_MAX_SPARSE_LP_NNZ = 50_000_000
+
+
+def _lp_lift_too_large(n_cols: int, n_rows: int, nnz: int) -> bool:
+    """Whether a per-node lift should be declined (``skipped_oversize``).
+
+    Default: the legacy dense-cell guard ``(n_cols+n_rows)*n_rows > cap`` — a proxy
+    for the matrix-form backend's dense allocation. Under the opt-in
+    ``sparse_large_lp`` flag the path is fully sparse, so switch to a nonzero-based
+    ceiling: a large sparse lift is memory-safe and its LP is a valid (rigorous)
+    bound, so decline only a pathologically dense structure. Sound either way — a
+    decline only forgoes a node's LP bound, never fathoms."""
+    if _tuning().sparse_large_lp:
+        return nnz > _MAX_SPARSE_LP_NNZ
+    return (n_cols + n_rows) * n_rows > _MAX_RELAX_DENSE_CELLS
+
+
 # Lifted-LP FBBT (issue #184): number of feasibility-propagation sweeps over the
 # relaxation rows, and the width left around a factor that propagation pins to a
 # point so the build path keeps the multilinear term at full arity (see
@@ -762,8 +785,13 @@ class MccormickLPRelaxer:
             # a multi-GB dense solve. Sound: no bound is returned, so the caller
             # keeps the rigorous alphaBB/interval underestimator (identical to the
             # cold-path decline). Falling back to the cold build would only hit the
-            # same guard, so return the oversize verdict directly.
-            if (inc.ncol + nrows) * nrows > _MAX_RELAX_DENSE_CELLS:
+            # same guard, so return the oversize verdict directly. Under the opt-in
+            # ``sparse_large_lp`` flag the check is nnz-based (the path is sparse; see
+            # ``_lp_lift_too_large``), so a large sparse lift is solved, not declined.
+            import scipy.sparse as sp
+
+            _nnz = int(A.nnz) if sp.issparse(A) else int(np.count_nonzero(A))
+            if _lp_lift_too_large(inc.ncol, nrows, _nnz):
                 return MccormickLPResult(status="skipped_oversize")
             in_basis = (
                 self._inc_warm_basis
@@ -1169,10 +1197,15 @@ class MccormickLPRelaxer:
         # forgoes this node's LP underestimator; the caller keeps the rigorous
         # alphaBB/interval bound and the incumbent search, so the solve respects
         # its time limit instead of hanging on the dense solve.
+        import scipy.sparse as sp
+
         n_cols = int(np.size(milp._c))
         _a_ub = milp._A_ub
         n_rows = 0 if _a_ub is None else int(_a_ub.shape[0])
-        if (n_cols + n_rows) * n_rows > _MAX_RELAX_DENSE_CELLS:
+        _nnz = 0 if _a_ub is None else int(sp.csr_matrix(_a_ub).nnz)
+        # Under the opt-in ``sparse_large_lp`` flag this is nnz-based (the path is
+        # sparse — no dense allocation); by default the legacy dense-cell guard.
+        if _lp_lift_too_large(n_cols, n_rows, _nnz):
             key = (n_cols, n_rows).__hash__()
             if key not in _oversize_warned:
                 _oversize_warned.add(key)

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -825,10 +825,15 @@ class MccormickLPRelaxer:
                 try:
                     y = np.asarray(cert.dual, dtype=np.float64)
                     n0 = self._n_orig
-                    A_arr = np.asarray(A, dtype=np.float64)
-                    if A_arr.ndim == 2 and A_arr.shape[0] == y.shape[0] and A_arr.shape[1] >= n0:
+                    # ``A`` is the assembled node matrix — SPARSE CSR since the
+                    # incremental structure went sparse (T11). Compute the structural
+                    # reduced costs ``d_j = c_j - (Aᵀy)_j`` with a sparse matvec on the
+                    # first ``n0`` columns; never densify ``A`` (would reintroduce the
+                    # O(rows*cols) blow-up on a large lift).
+                    A_sp = A if sp.issparse(A) else sp.csr_matrix(np.asarray(A, dtype=np.float64))
+                    if A_sp.shape[0] == y.shape[0] and A_sp.shape[1] >= n0:
                         c_full = np.asarray(inc.c, dtype=np.float64)
-                        rc = c_full[:n0] - (A_arr[:, :n0].T @ y)
+                        rc = c_full[:n0] - np.asarray(A_sp[:, :n0].T @ y, dtype=np.float64).ravel()
                         res.reduced_costs = rc
                         res.dual = y
                         res.col_status = cert.col_status

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -608,6 +608,9 @@ class MccormickLPRelaxer:
         # nodes, non-separating solves) never trigger it, so the extra cold build it
         # costs stays off their hot path.
         self._has_composite_lift_cache: Optional[bool] = None
+        # Binary-variable columns (moment diagonal X_ii = x_i) for the PSD moment
+        # separator; computed once, only when the opt-in PSD path first fires.
+        self._binary_cols_cache: Optional[frozenset] = None
 
     def _model_has_composite_lift(self) -> bool:
         """Whether the model carries a composite convex/concave OA lift whose
@@ -2193,8 +2196,15 @@ class MccormickLPRelaxer:
                 ):
                     # Per-node PSD wall budget spent — stop feeding the search.
                     break
+                if self._binary_cols_cache is None:
+                    from discopt._jax.model_utils import binary_flat_cols
+
+                    self._binary_cols_cache = binary_flat_cols(self._model)
                 cuts = separate_psd_cuts_on_relaxation(
-                    varmap, np.asarray(res.x, dtype=np.float64), n_total
+                    varmap,
+                    np.asarray(res.x, dtype=np.float64),
+                    n_total,
+                    binary_vars=self._binary_cols_cache,
                 )
                 if not cuts:
                     break

--- a/python/discopt/_jax/model_utils.py
+++ b/python/discopt/_jax/model_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from discopt.modeling.core import Model
+from discopt.modeling.core import Model, VarType
 
 
 def flat_variable_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
@@ -15,3 +15,25 @@ def flat_variable_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
         lbs.extend(np.asarray(v.lb, dtype=np.float64).ravel().tolist())
         ubs.extend(np.asarray(v.ub, dtype=np.float64).ravel().tolist())
     return np.array(lbs, dtype=np.float64), np.array(ubs, dtype=np.float64)
+
+
+def binary_flat_cols(model: Model) -> frozenset[int]:
+    """Flat column indices of the model's **binary** variables — integer-typed with
+    bounds ``[0, 1]``.
+
+    A binary variable satisfies ``x**2 == x`` at every feasible (integer) point, so
+    the moment-matrix diagonal ``X_ii`` equals ``x_i`` there: the PSD/moment-cut
+    separator can use the original ``x_i`` column as ``X_ii`` for these variables
+    even when no explicit lifted square column exists (the common case for pure
+    products of distinct binaries, e.g. QAP). Only binary variables qualify — for a
+    continuous ``x_i`` in ``[0,1]`` the relation ``X_ii == x_i`` is false and the
+    substitution would be unsound.
+    """
+    lb, ub = flat_variable_bounds(model)
+    is_int: list[np.ndarray] = []
+    for v in model._variables:
+        integral = v.var_type in (VarType.BINARY, VarType.INTEGER)
+        is_int.append(np.full(int(v.size), integral, dtype=bool))
+    int_mask = np.concatenate(is_int) if is_int else np.zeros(0, dtype=bool)
+    binary = int_mask & np.isclose(lb, 0.0) & np.isclose(ub, 1.0)
+    return frozenset(int(i) for i in np.flatnonzero(binary))

--- a/python/discopt/_jax/psd_cuts.py
+++ b/python/discopt/_jax/psd_cuts.py
@@ -120,18 +120,29 @@ def psd_cut_from_submatrix(
     return LinearCut(coeffs=coeffs, rhs=float(rhs), sense=">=")
 
 
-def _diag_col(info: dict, i: int) -> Optional[int]:
-    """Relaxation column holding the lifted square ``X_ii = x_i**2`` (or None)."""
+def _diag_col(info: dict, i: int, binary_vars: Optional[frozenset] = None) -> Optional[int]:
+    """Relaxation column standing for the moment-matrix diagonal ``X_ii`` (or None).
+
+    Normally this is a lifted square column ``X_ii = x_i**2``. For a **binary**
+    variable (``binary_vars``) ``x_i**2 = x_i`` at every feasible point, so the
+    original ``x_i`` column *is* ``X_ii`` — this is what lets the moment/PSD cut fire
+    on pure products of distinct binaries (QAP) where no square column is lifted.
+    Sound only for binaries; a continuous ``x_i`` has ``X_ii = x_i**2 != x_i``.
+    """
     mono = info.get("monomial", {})
     usq = info.get("univariate_square", {})
     if (i, 2) in mono:
         return int(mono[(i, 2)])
     if (i, 2) in usq:
         return int(usq[(i, 2)])
+    if binary_vars is not None and i in binary_vars:
+        orig = info.get("original", {})
+        if i in orig:
+            return int(orig[i])
     return None
 
 
-def _moment_blocks_for_set(info: dict, S: Sequence[int]):
+def _moment_blocks_for_set(info: dict, S: Sequence[int], binary_vars: Optional[frozenset] = None):
     """Column indices needed for the moment submatrix over variables ``S``.
 
     Returns ``(orig_cols, diag_cols, off_cols)`` or ``None`` if any required
@@ -144,7 +155,7 @@ def _moment_blocks_for_set(info: dict, S: Sequence[int]):
         return None
     diag_cols = []
     for i in S:
-        di = _diag_col(info, i)
+        di = _diag_col(info, i, binary_vars)
         if di is None:
             return None
         diag_cols.append(di)
@@ -160,10 +171,16 @@ def _moment_blocks_for_set(info: dict, S: Sequence[int]):
 
 
 def _moment_clique_cut(
-    info: dict, x_full: np.ndarray, S: Sequence[int], n_total: int, *, tol: float
+    info: dict,
+    x_full: np.ndarray,
+    S: Sequence[int],
+    n_total: int,
+    *,
+    tol: float,
+    binary_vars: Optional[frozenset] = None,
 ) -> Optional[LinearCut]:
     """Separate a single moment cut over the variable clique ``S`` (size >= 2)."""
-    blocks = _moment_blocks_for_set(info, S)
+    blocks = _moment_blocks_for_set(info, S, binary_vars)
     if blocks is None:
         return None
     orig_cols, diag_cols, off = blocks
@@ -180,15 +197,20 @@ def _moment_clique_cut(
     return psd_cut_from_submatrix(x_vals, X_vals, orig_cols, prod_cols, n_total, tol=tol)
 
 
-def _lifted_cliques(info: dict, max_dim: int) -> list[tuple[int, ...]]:
+def _lifted_cliques(
+    info: dict, max_dim: int, binary_vars: Optional[frozenset] = None
+) -> list[tuple[int, ...]]:
     """Greedy cliques of variables whose pairwise products + squares are all lifted.
 
-    A clique ``S`` (all pairs in ``bilinear``, all squares lifted) is exactly the
-    set over which a dense moment submatrix can be formed. Dense ``k>=3`` cliques
-    capture multi-variable moment coupling that pairwise 2x2 minors miss.
+    A clique ``S`` (all pairs in ``bilinear``, all diagonals available) is exactly
+    the set over which a dense moment submatrix can be formed. Dense ``k>=3`` cliques
+    capture multi-variable moment coupling that pairwise 2x2 minors miss. A binary
+    variable's diagonal ``X_ii = x_i`` needs no lifted square (see ``_diag_col``), so
+    passing ``binary_vars`` lets cliques form over pure products of distinct binaries
+    (QAP) that would otherwise yield no moment cut at all.
     """
     bil = info.get("bilinear", {})
-    verts = [i for i in info.get("original", {}) if _diag_col(info, i) is not None]
+    verts = [i for i in info.get("original", {}) if _diag_col(info, i, binary_vars) is not None]
     adj: dict[int, set] = {i: set() for i in verts}
     for i, j in bil:
         if i in adj and j in adj:
@@ -217,6 +239,7 @@ def separate_psd_cuts_on_relaxation(
     tol: float = 1e-7,
     max_cuts: int = 64,
     max_dim: int = 6,
+    binary_vars: Optional[frozenset] = None,
 ) -> list[LinearCut]:
     """Separate moment (PSD) cuts from a McCormick relaxation point.
 
@@ -236,10 +259,10 @@ def separate_psd_cuts_on_relaxation(
     cuts: list[LinearCut] = []
     seen_pairs: set[tuple[int, int]] = set()
     # Dense cliques first (strongest), then any remaining pairwise products.
-    for S in _lifted_cliques(info, max_dim):
+    for S in _lifted_cliques(info, max_dim, binary_vars):
         if len(cuts) >= max_cuts:
             break
-        cut = _moment_clique_cut(info, x_full, S, n_total, tol=tol)
+        cut = _moment_clique_cut(info, x_full, S, n_total, tol=tol, binary_vars=binary_vars)
         if cut is not None:
             cuts.append(cut)
         for a in range(len(S)):
@@ -253,11 +276,11 @@ def separate_psd_cuts_on_relaxation(
             break
         if (min(i, j), max(i, j)) in seen_pairs:
             continue
-        di = _diag_col(info, i)
-        dj = _diag_col(info, j)
+        di = _diag_col(info, i, binary_vars)
+        dj = _diag_col(info, j, binary_vars)
         if di is None or dj is None or i not in orig or j not in orig:
             continue
-        cut = _moment_clique_cut(info, x_full, (i, j), n_total, tol=tol)
+        cut = _moment_clique_cut(info, x_full, (i, j), n_total, tol=tol, binary_vars=binary_vars)
         if cut is not None:
             cuts.append(cut)
     return cuts
@@ -270,6 +293,7 @@ def psd_strengthen_relaxation_bound(
     max_rounds: int = 5,
     tol: float = 1e-7,
     time_limit_per_lp: Optional[float] = 1.0,
+    binary_vars: Optional[frozenset] = None,
 ):
     """Iteratively add PSD cuts to a McCormick relaxation LP and re-solve.
 
@@ -312,7 +336,9 @@ def psd_strengthen_relaxation_bound(
     A_cur = sp.csr_matrix(A_ub)
     b_cur = np.asarray(b_ub, dtype=np.float64)
     for _ in range(max(1, max_rounds)):
-        cuts = separate_psd_cuts_on_relaxation(info, np.asarray(res.x), n_total, tol=tol)
+        cuts = separate_psd_cuts_on_relaxation(
+            info, np.asarray(res.x), n_total, tol=tol, binary_vars=binary_vars
+        )
         if not cuts:
             break
         # Cut is coeffs.z >= rhs  ==>  (-coeffs).z <= -rhs for the A_ub<=b_ub form.

--- a/python/discopt/_jax/uniform_relax.py
+++ b/python/discopt/_jax/uniform_relax.py
@@ -1109,10 +1109,20 @@ class _Builder:
             return LinForm.constant(node.payload)
         if node.kind == "sum":
             coeffs, const = node.payload
-            acc = LinForm.constant(const)
+            # Accumulate into ONE dict rather than chaining ``acc = acc + rep(child)``:
+            # ``LinForm.__add__`` copies the growing accumulator each time, so a sum of
+            # N children (e.g. a 21k-term quadratic objective, qap) was O(N^2). Folding
+            # in place is O(N + total nnz) and produces the byte-identical LinForm (same
+            # per-column coefficient sum, zeros dropped), so the relaxation is unchanged.
+            acc_coeffs: dict[int, float] = {}
+            acc_const = float(const)
             for coef, child in zip(coeffs, node.children):
-                acc = acc + self.rep(child).scaled(float(coef))
-            return acc
+                s = float(coef)
+                lf = self.rep(child)
+                acc_const += lf.const * s
+                for j, c in lf.coeffs.items():
+                    acc_coeffs[j] = acc_coeffs.get(j, 0.0) + c * s
+            return LinForm({j: c for j, c in acc_coeffs.items() if c != 0.0}, acc_const)
         # Every remaining kind is a nonlinear atom: allocate an aux with the sound
         # interval floor, then let its builder add tighter sound rows.
         lo, hi = self.bounds(node)

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -371,6 +371,18 @@ def _broadcast_shapes(
     NLPEvaluator with an opaque traceback, or (worse) be silently mis-extracted —
     so raise here with both operand shapes named.
     """
+    # Hot path: building a large McCormick relaxation constructs millions of
+    # element-wise ``BinaryOp`` nodes (~1.5M for a single qap node), the vast
+    # majority on identical shapes — scalars ``() op ()`` or matched arrays. Equal
+    # shapes broadcast to themselves, and a scalar broadcasts to the other operand;
+    # both are exact and skip the ~10x-slower ``numpy.broadcast_shapes`` machinery
+    # (profiled ~2.5s of a 12.6s 4-node build). Result is identical to the numpy
+    # path, so this is bound-neutral. Differing non-scalar shapes still defer to
+    # numpy, which additionally validates broadcast-compatibility.
+    if s_left == s_right or s_right == ():
+        return s_left
+    if s_left == ():
+        return s_right
     try:
         return tuple(int(d) for d in np.broadcast_shapes(s_left, s_right))
     except ValueError:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3251,6 +3251,12 @@ def solve_model(
     # cannot, on its own, overrun ``time_limit`` (issue: tens of seconds of
     # eigenvalue work on large quadratic models before search even starts).
     model._convexity_classification_cache = None
+    # The syntactic convexity recognizers memoize the declared-box arrays on the
+    # model; invalidate that cache in lockstep with the classification cache so a
+    # post-presolve re-classification with tightened bounds recomputes them.
+    from discopt._jax.convexity.patterns import clear_declared_box_cache
+
+    clear_declared_box_cache(model)
     _convexity_time_budget = min(max(0.2 * float(time_limit), 0.5), 20.0)
     model._convexity_time_budget = _convexity_time_budget
     # #654: absolute solve deadline, anchored at ``_solve_t0`` (before all
@@ -4023,6 +4029,7 @@ def solve_model(
             # on the (larger) lifted model — heatexch_gen3: 12 s classify under a
             # 15 s solve budget. Re-assert the budget (and clear any stale cache).
             model._convexity_classification_cache = None
+            clear_declared_box_cache(model)
             model._convexity_time_budget = _convexity_time_budget
             model._solve_deadline = _solve_t0 + float(time_limit)  # #654 (see above)
         # A *convex* model with a clearable denominator is deliberately left
@@ -4089,6 +4096,7 @@ def solve_model(
             if _ipx_pure_milp and classify_problem(_ipx) == ProblemClass.MILP:
                 model = _ipx
                 model._convexity_classification_cache = None
+                clear_declared_box_cache(model)
                 model._convexity_time_budget = _convexity_time_budget
                 model._solve_deadline = _solve_t0 + float(time_limit)  # #654 (see above)
                 # The reformulated big-M MILP is best handled by a real MILP

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2631,9 +2631,16 @@ def _root_relaxation_lower_bound(
         psd_bound: Optional[float] = None
         if psd_cuts:
             try:
+                from discopt._jax.model_utils import binary_flat_cols
                 from discopt._jax.psd_cuts import psd_strengthen_relaxation_bound
 
-                _zb, _za, _nc = psd_strengthen_relaxation_bound(relax, _relax_info)
+                # Binary variables have moment diagonal X_ii = x_i, so the moment
+                # separator can form cliques over pure products of distinct binaries
+                # (QAP-class) that carry no lifted square column — otherwise it finds
+                # no clique and emits no cut (a no-op strengthening).
+                _zb, _za, _nc = psd_strengthen_relaxation_bound(
+                    relax, _relax_info, binary_vars=binary_flat_cols(model)
+                )
                 if _nc and _za is not None and np.isfinite(_za):
                     psd_bound = float(_za)
             except Exception as psd_exc:  # pragma: no cover - defensive

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -299,6 +299,23 @@ class SolverTuning:
     """Feasibility-based bound tightening on lifted columns
     (``DISCOPT_LIFTED_FBBT``, default off)."""
 
+    sparse_large_lp: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_SPARSE_LARGE_LP", default=False)
+    )
+    """Solve the per-node McCormick LP even when its lift exceeds the
+    ``_MAX_RELAX_DENSE_CELLS`` dense-cell guard (``DISCOPT_SPARSE_LARGE_LP``, default
+    off). The whole per-node path is now sparse — relaxation build (CSR), incremental
+    patch (T11), simplex (CSC), exact-LP oracle (T8) — so the guard's "would force a
+    multi-GB dense allocation" premise is obsolete: a huge lift (e.g. qap's 85756-row
+    McCormick relaxation) solves in ~0.1 s at <1 GB. On this flag the guard becomes
+    nonzero-based (``_MAX_INCREMENTAL_NNZ``) instead of dense-cell-based, so a large
+    *sparse* lift earns its rigorous McCormick LP bound instead of being declined
+    (no per-node relaxation at all when ``n_vars > 50``, where alpha-BB is
+    ineligible). Sound: the LP bound is a valid lower bound and the B&B keeps the
+    parent bound as a floor, so enabling it never loosens a node — only adds a bound.
+    Default off pending a benchmark instance that measurably benefits (qap's
+    indefinite-QP McCormick bound is ~0; see docs/dev/sparse-milp-plan.md T7/T12)."""
+
     node_bound_mode: str = field(
         default_factory=lambda: os.environ.get("DISCOPT_NODE_BOUND_MODE", "lp")
     )

--- a/python/discopt/solvers/lp_simplex.py
+++ b/python/discopt/solvers/lp_simplex.py
@@ -54,6 +54,21 @@ def _dense_rows(A: Optional[Union[np.ndarray, sp.spmatrix]], n: int) -> np.ndarr
     return dense.reshape(-1, n)
 
 
+def _sparse_rows(A: Optional[Union[np.ndarray, sp.spmatrix]], n: int) -> "sp.csr_matrix":
+    """Sparse CSR ``(m, n)`` view of a constraint block, or an empty ``(0, n)``.
+
+    Never densifies a sparse input — the whole point of the sparse marshaling in
+    :func:`solve_lp`. A dense ndarray input is reshaped to ``(-1, n)`` (matching
+    :func:`_dense_rows`) then converted to CSR.
+    """
+    if A is None:
+        return sp.csr_matrix((0, n), dtype=np.float64)
+    if sp.issparse(A):
+        M = sp.csr_matrix(A)
+        return M if M.shape[1] == n else M.reshape((-1, n))
+    return sp.csr_matrix(np.asarray(A, dtype=np.float64).reshape(-1, n))
+
+
 def solve_lp(
     c: np.ndarray,
     A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
@@ -93,13 +108,20 @@ def solve_lp(
     ill-conditioned LP (the F3 multilinear vertex-hull LP: ``2^n`` λ columns)
     without waiting for the 100 000-pivot default.
     """
-    from discopt._rust import solve_lp_warm_py
+    from discopt._rust import solve_lp_warm_csc_py
 
     c_arr = np.asarray(c, dtype=np.float64).ravel()
     n = c_arr.shape[0]
 
-    a_ub = _dense_rows(A_ub if (b_ub is not None and np.size(b_ub)) else None, n)
-    a_eq = _dense_rows(A_eq if (b_eq is not None and np.size(b_eq)) else None, n)
+    # Constraint blocks kept SPARSE. A dense standard form ``a_std`` here is
+    # ``O(m*(n+m))`` — for a large lifted relaxation (qap's 85756-row McCormick LP:
+    # ``a_std`` = 85756 x 107405 ~ 9.2e9 cells ~ 73 GB) it blows memory before the
+    # solve. This oracle is the exact-LP seam the PSD/OBBT/DBBT paths call, so the
+    # blowup surfaced there (~46 GB, issue: sparse-milp-plan T7). The CSC-native
+    # ``solve_lp_warm_csc_py`` consumes the standard form directly with the slack
+    # identity left implicit-sparse.
+    a_ub = _sparse_rows(A_ub if (b_ub is not None and np.size(b_ub)) else None, n)
+    a_eq = _sparse_rows(A_eq if (b_eq is not None and np.size(b_eq)) else None, n)
     m_ub, m_eq = a_ub.shape[0], a_eq.shape[0]
     m = m_ub + m_eq
     b_vec = np.concatenate(
@@ -109,15 +131,18 @@ def solve_lp(
         ]
     )
 
-    # Standard form [A_ub | I_ub | 0 ; A_eq | 0 | I_eq] z = b, with slacks in
-    # [0, +inf) for the inequality rows and pinned to [0, 0] for the equality rows.
-    a_std = np.zeros((m, n + m), dtype=np.float64)
-    if m_ub:
-        a_std[:m_ub, :n] = a_ub
-        a_std[:m_ub, n : n + m_ub] = np.eye(m_ub)
-    if m_eq:
-        a_std[m_ub:, :n] = a_eq
-        a_std[m_ub:, n + m_ub :] = np.eye(m_eq)
+    # Standard form [A_ub | I_ub | 0 ; A_eq | 0 | I_eq] z = b, built directly as
+    # CSC. Structural columns first, then one slack per row: [0, +inf) for the
+    # inequality rows and pinned to [0, 0] for the equality rows. ``sort_indices``
+    # gives ascending row order per column, which the CSC-native simplex requires.
+    a_struct = sp.vstack([a_ub, a_eq], format="csr") if m else sp.csr_matrix((0, n))
+    if m > 0:
+        a_std = sp.hstack(
+            [a_struct, sp.identity(m, format="csc", dtype=np.float64)], format="csc"
+        ).tocsc()
+        a_std.sort_indices()
+    else:
+        a_std = sp.csc_matrix((0, n), dtype=np.float64)
     c_std = np.concatenate([c_arr, np.zeros(m)])
     if bounds is not None:
         lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
@@ -131,12 +156,18 @@ def solve_lp(
     _warm_kw: dict[str, Any] = {}
     if max_iter is not None:
         _warm_kw["max_iter"] = int(max_iter)
-    status, x_full, obj, _iters, _cs, _bv, dual, _ray = solve_lp_warm_py(
+    status, x_full, obj, _iters, _cs, _bv, dual, _ray = solve_lp_warm_csc_py(
         np.ascontiguousarray(c_std),
-        np.ascontiguousarray(a_std),
+        m,
+        n + m,
+        np.ascontiguousarray(a_std.indptr, dtype=np.int64),
+        np.ascontiguousarray(a_std.indices, dtype=np.int64),
+        np.ascontiguousarray(a_std.data, dtype=np.float64),
         np.ascontiguousarray(b_vec),
         np.ascontiguousarray(lb_std),
         np.ascontiguousarray(ub_std),
+        None,  # no warm basis (cold solve)
+        None,
         **_warm_kw,
     )
 
@@ -181,9 +212,9 @@ def solve_lp(
     if dual_values is not None:
         rc = c_arr.copy()
         if m_ub:
-            rc = rc - a_ub.T @ y[:m_ub]
+            rc = rc - np.asarray(a_ub.T @ y[:m_ub]).ravel()
         if m_eq:
-            rc = rc - a_eq.T @ y[m_ub:]
+            rc = rc - np.asarray(a_eq.T @ y[m_ub:]).ravel()
         if np.all(np.isfinite(rc)):
             reduced_costs = rc
 

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -263,51 +263,58 @@ def solve_milp(
     ``objective`` is the engine's dual lower bound (see module docstring).
     """
     try:
-        from discopt._rust import solve_milp_py
+        from discopt._rust import solve_milp_csc_py
     except ImportError as err:  # pragma: no cover - exercised via the selector
         raise SimplexBackendUnavailable(
-            "discopt._rust.solve_milp_py is unavailable; build the Rust extension"
+            "discopt._rust.solve_milp_csc_py is unavailable; build the Rust extension"
         ) from err
 
     c_arr = np.asarray(c, dtype=np.float64).ravel()
     n = c_arr.shape[0]
 
     # Assemble all rows as `<=` (A_eq becomes a pair of `<=` rows) then slack.
-    rows: list[np.ndarray] = []
+    # SPARSE throughout: a dense `[A_ub | I]` would materialize an m×(n+m) matrix
+    # (~73 GB for qap's 85k×21k McCormick relaxation) that the Rust driver never
+    # needs — it consumes CSC. We keep every block sparse and hand the driver the
+    # CSC triplets of the standard-form matrix; nothing is ever densified here.
+    blocks: list[sp.spmatrix] = []
     rhs: list[float] = []
     if A_ub is not None and b_ub is not None and np.size(b_ub) > 0:
-        a = (
-            cast("sp.spmatrix", A_ub).toarray()
+        au = (
+            sp.csr_matrix(cast("sp.spmatrix", A_ub))
             if sp.issparse(A_ub)
-            else np.asarray(A_ub, dtype=np.float64)
+            else sp.csr_matrix(np.asarray(A_ub, dtype=np.float64).reshape(-1, n))
         )
-        rows.append(a.reshape(-1, n))
+        blocks.append(au)
         rhs.extend(np.asarray(b_ub, dtype=np.float64).ravel().tolist())
     if A_eq is not None and b_eq is not None and np.size(b_eq) > 0:
-        a = (
-            cast("sp.spmatrix", A_eq).toarray()
+        ae = (
+            sp.csr_matrix(cast("sp.spmatrix", A_eq))
             if sp.issparse(A_eq)
-            else np.asarray(A_eq, dtype=np.float64)
+            else sp.csr_matrix(np.asarray(A_eq, dtype=np.float64).reshape(-1, n))
         )
-        a = a.reshape(-1, n)
         be = np.asarray(b_eq, dtype=np.float64).ravel()
-        rows.append(a)
+        blocks.append(ae)
         rhs.extend(be.tolist())
-        rows.append(-a)
+        blocks.append(-ae)
         rhs.extend((-be).tolist())
 
-    if rows:
-        a_ub = np.vstack(rows)
+    if blocks:
+        a_ub_sp = sp.vstack(blocks, format="csr")
     else:
-        a_ub = np.zeros((0, n), dtype=np.float64)
+        a_ub_sp = sp.csr_matrix((0, n), dtype=np.float64)
     b_vec = np.asarray(rhs, dtype=np.float64)
-    m = a_ub.shape[0]
+    m = a_ub_sp.shape[0]
 
-    # Standard form A_eq z = b with one slack per row: [A_ub | I] z = b_ub.
-    a_std = np.zeros((m, n + m), dtype=np.float64)
-    if m > 0:
-        a_std[:, :n] = a_ub
-        a_std[:, n:] = np.eye(m)
+    # Standard form A_eq z = b with one slack per row: [A_ub | I] z = b_ub, built
+    # directly as CSC (never densified). ``sort_indices`` gives ascending row
+    # order within each column, which ``SparseCols::from_csc`` requires.
+    a_std_sp = sp.hstack([a_ub_sp, sp.identity(m, dtype=np.float64, format="csr")], format="csc")
+    a_std_sp.sum_duplicates()
+    a_std_sp.sort_indices()
+    csc_col_ptr = np.ascontiguousarray(a_std_sp.indptr, dtype=np.int64)
+    csc_row_idx = np.ascontiguousarray(a_std_sp.indices, dtype=np.int64)
+    csc_vals = np.ascontiguousarray(a_std_sp.data, dtype=np.float64)
 
     if bounds is not None:
         lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
@@ -356,9 +363,13 @@ def solve_milp(
         else {}
     )
 
-    status, x_full, obj, bound, nodes, _iters = solve_milp_py(
+    status, x_full, obj, bound, nodes, _iters = solve_milp_csc_py(
         np.ascontiguousarray(c_std),
-        np.ascontiguousarray(a_std),
+        m,
+        n + m,  # total columns: structural + one slack per row
+        csc_col_ptr,
+        csc_row_idx,
+        csc_vals,
         np.ascontiguousarray(b_vec),
         np.ascontiguousarray(lb_std),
         np.ascontiguousarray(ub_std),

--- a/python/tests/test_incremental_mccormick_node.py
+++ b/python/tests/test_incremental_mccormick_node.py
@@ -54,6 +54,43 @@ def test_incremental_active_for_integer_qcqp():
     assert MccormickLPRelaxer(_int_qcqp())._inc is not None
 
 
+def test_incremental_declined_when_lift_too_large_for_dense(monkeypatch):
+    """A lift whose dense ``base_A`` would exceed the cell budget declines the
+    incremental structure and falls back to the sparse per-node cold build with an
+    UNCHANGED (never looser) bound.
+
+    Regression for the qap ~30 GB blowup: ``IncrementalMcCormickLP`` stores
+    ``base_A`` DENSE (``rows x cols``) and ``_patch`` copies that whole array on
+    EVERY node — ~14.85 GB each for qap's 85756x21649 lift, ~30 GB peak just
+    constructing the relaxer. The size guard declines the dense structure above
+    ``_MAX_INCREMENTAL_DENSE_CELLS`` so large-lift models use the sparse cold path.
+    Before the guard, ``_inc`` was built regardless of lift size (this test's
+    ``_inc is None`` assertion fails); after, it is declined.
+    """
+    import discopt._jax.incremental_mccormick as inc
+
+    m = _int_qcqp()
+    lb = np.array([float(v.lb) for v in m._variables], dtype=np.float64)
+    ub = np.array([float(v.ub) for v in m._variables], dtype=np.float64)
+
+    # Reference bound WITH the fast path (normal cap): structure engages.
+    relaxer_fast = MccormickLPRelaxer(m)
+    assert relaxer_fast._inc is not None
+    ref = relaxer_fast.solve_at_node(lb, ub)
+    assert ref.status == "optimal"
+
+    # Tiny cap forces the oversize decline even on this small QCQP lift.
+    monkeypatch.setattr(inc, "_MAX_INCREMENTAL_DENSE_CELLS", 1.0)
+    relaxer_cold = MccormickLPRelaxer(m)
+    assert relaxer_cold._inc is None  # dense structure declined -> cold fallback
+    got = relaxer_cold.solve_at_node(lb, ub)
+    assert got.status == "optimal"
+    # Sound + never looser: the cold path keeps every cut the fast path may drop,
+    # so its lower bound is >= the fast-path bound (bound-neutral to slightly
+    # tighter), never a regression.
+    assert got.lower_bound >= ref.lower_bound - 1e-6
+
+
 def test_validate_exercises_at_least_four_sign_regimes():
     """C-21: the soundness gate must probe negative-lb / zero-spanning / mixed-sign
     / degenerate boxes, not just ``lb>=0``. On a model with zero-spanning root

--- a/python/tests/test_incremental_mccormick_node.py
+++ b/python/tests/test_incremental_mccormick_node.py
@@ -54,18 +54,68 @@ def test_incremental_active_for_integer_qcqp():
     assert MccormickLPRelaxer(_int_qcqp())._inc is not None
 
 
-def test_incremental_declined_when_lift_too_large_for_dense(monkeypatch):
-    """A lift whose dense ``base_A`` would exceed the cell budget declines the
-    incremental structure and falls back to the sparse per-node cold build with an
-    UNCHANGED (never looser) bound.
+def test_incremental_structure_is_sparse_and_patch_matches_dense():
+    """The incremental structure holds ``base_A`` SPARSE and ``_patch`` returns a
+    sparse CSR whose dense form equals a from-scratch dense patch — the fixed-pattern
+    ``.data`` rewrite is bit-identical to the old dense ``A[k]=0; A[k,col]=coef``.
 
-    Regression for the qap ~30 GB blowup: ``IncrementalMcCormickLP`` stores
-    ``base_A`` DENSE (``rows x cols``) and ``_patch`` copies that whole array on
-    EVERY node — ~14.85 GB each for qap's 85756x21649 lift, ~30 GB peak just
-    constructing the relaxer. The size guard declines the dense structure above
-    ``_MAX_INCREMENTAL_DENSE_CELLS`` so large-lift models use the sparse cold path.
-    Before the guard, ``_inc`` was built regardless of lift size (this test's
-    ``_inc is None`` assertion fails); after, it is declined.
+    Regression for the sparse-incremental rewrite: before it ``base_A`` was a dense
+    ``rows x cols`` array (``.todense()``, ~14.85 GB per copy on qap). Here we assert
+    the representation is sparse AND the patched values are unchanged.
+    """
+    import numpy as np
+    import scipy.sparse as sp
+    from discopt._jax.incremental_mccormick import (
+        IncrementalMcCormickLP,
+        _affine_square_rows,
+        _bilinear_rows,
+        _monomial_rows,
+    )
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    m = _int_qcqp()  # (x-3)^2 + (y-2)^2 + x*y : bilinear + affine squares
+    inc = IncrementalMcCormickLP(m, classify_nonlinear_terms(m))
+    assert inc.ok
+    # base_A is sparse, not a dense ndarray.
+    assert sp.issparse(inc.base_A)
+
+    lb = np.array([1.0, 0.0])
+    ub = np.array([5.0, 4.0])
+    A_sp, b_sp, bd_sp = inc._patch(lb, ub)
+    assert sp.issparse(A_sp)  # patched matrix is sparse
+
+    # Independent dense reference of the same patch (zero the product rows, set the
+    # McCormick/monomial/affine-square coefficients) — must match the sparse patch.
+    A_ref = inc.base_A.toarray().copy()
+    for (i, j, a), rows in inc.bilin_rows.items():
+        for k, (ci, cj, cw, rhs) in zip(rows, _bilinear_rows(i, j, a, lb[i], ub[i], lb[j], ub[j])):
+            A_ref[k] = 0.0
+            A_ref[k, i] += ci
+            A_ref[k, j] += cj
+            A_ref[k, a] = cw
+    for (i, a, p), rows in inc.mono_rows.items():
+        for k, (ci, cs, rhs) in zip(rows, _monomial_rows(lb[i], ub[i], p)):
+            A_ref[k] = 0.0
+            A_ref[k, i] = ci
+            A_ref[k, a] = cs
+    for (j, a, coeff, const), rows in inc.affsq_rows.items():
+        for k, (cx, cw, rhs) in zip(rows, _affine_square_rows(coeff, const, lb[j], ub[j])):
+            A_ref[k] = 0.0
+            A_ref[k, j] = cx
+            A_ref[k, a] = cw
+    assert np.allclose(A_sp.toarray(), A_ref, atol=1e-12)
+
+
+def test_incremental_declined_when_lift_exceeds_nnz_budget(monkeypatch):
+    """A lift whose nonzero count exceeds the budget declines the incremental
+    structure and falls back to the sparse per-node cold build with an UNCHANGED
+    (never looser) bound.
+
+    The structure now holds ``base_A`` SPARSE and ``_patch`` copies only its
+    ``.data`` (~nnz floats) per node, so the guard is by NONZEROS
+    (``_MAX_INCREMENTAL_NNZ``), not the old dense ``rows*cols`` cells. Above it the
+    fast path is declined (``_inc is None``) and ``solve_at_node`` uses the cold
+    build; declining only forgoes the speedup, never soundness.
     """
     import discopt._jax.incremental_mccormick as inc
 
@@ -73,16 +123,16 @@ def test_incremental_declined_when_lift_too_large_for_dense(monkeypatch):
     lb = np.array([float(v.lb) for v in m._variables], dtype=np.float64)
     ub = np.array([float(v.ub) for v in m._variables], dtype=np.float64)
 
-    # Reference bound WITH the fast path (normal cap): structure engages.
+    # Reference bound WITH the fast path (normal budget): structure engages.
     relaxer_fast = MccormickLPRelaxer(m)
     assert relaxer_fast._inc is not None
     ref = relaxer_fast.solve_at_node(lb, ub)
     assert ref.status == "optimal"
 
-    # Tiny cap forces the oversize decline even on this small QCQP lift.
-    monkeypatch.setattr(inc, "_MAX_INCREMENTAL_DENSE_CELLS", 1.0)
+    # Tiny nnz budget forces the decline even on this small QCQP lift.
+    monkeypatch.setattr(inc, "_MAX_INCREMENTAL_NNZ", 1)
     relaxer_cold = MccormickLPRelaxer(m)
-    assert relaxer_cold._inc is None  # dense structure declined -> cold fallback
+    assert relaxer_cold._inc is None  # structure declined -> cold fallback
     got = relaxer_cold.solve_at_node(lb, ub)
     assert got.status == "optimal"
     # Sound + never looser: the cold path keeps every cut the fast path may drop,

--- a/python/tests/test_lp_spatial_bb.py
+++ b/python/tests/test_lp_spatial_bb.py
@@ -36,6 +36,13 @@ def _assemble_node_lp(ux=6, uy=5, uz=4):
     lb = np.array([0.0, 0.0, 0.0])
     ub = np.array([float(ux), float(uy), float(uz)])
     A, b_, bounds = inc.assemble(lb, ub, [])
+    # ``inc.assemble`` now returns a sparse CSR ``A``; this test's dense GMI reference
+    # (``_raw_gmi_cuts``: ``np.hstack([A, np.eye])`` etc.) needs a dense array, so
+    # densify here (small node LP) to reproduce the pre-sparse-incremental contract.
+    import scipy.sparse as sp
+
+    if sp.issparse(A):
+        A = A.toarray()
     bd, x, _ = inc.solve_assembled(A, b_, bounds)
     assert x is not None
     return inc, A, b_, bounds, x, inc.ncol

--- a/python/tests/test_mccormick_lp_densify_guard.py
+++ b/python/tests/test_mccormick_lp_densify_guard.py
@@ -75,3 +75,50 @@ def test_solve_at_node_declines_oversize(monkeypatch):
     assert gated.status == "skipped_oversize"
     assert gated.lower_bound is None
     assert gated.status != "infeasible"  # a declined node must never be fathomed
+
+
+def test_sparse_large_lp_flag_solves_declined_node_soundly(monkeypatch):
+    """Opt-in ``DISCOPT_SPARSE_LARGE_LP``: a node the dense-cell guard would decline
+    is instead solved (the whole path is sparse now), yielding the SAME rigorous LP
+    bound as the normal below-cap solve — the flag only gates *declining*, not the
+    math. Sound: the bound is a valid lower bound (<= every feasible objective).
+
+    §5 bound-changing regime: default off (no behavior change), and when on the new
+    bound equals the old below-cap bound and never exceeds the true optimum.
+    """
+    from discopt.solver_tuning import current
+
+    m = _small_bilinear()
+    lb = np.array([-2.0, -2.0], dtype=np.float64)
+    ub = np.array([2.0, 2.0], dtype=np.float64)
+
+    # Real McCormick bound below the cap (guard inactive).
+    relaxer = mc.MccormickLPRelaxer(m)
+    normal = relaxer.solve_at_node(lb, ub, time_limit=5.0)
+    assert normal.status == "optimal" and normal.lower_bound is not None
+    b_normal = float(normal.lower_bound)
+
+    # Force the guard to trip on this small lift.
+    monkeypatch.setattr(mc, "_MAX_RELAX_DENSE_CELLS", 1.0)
+
+    # Flag OFF (default): declined.
+    monkeypatch.delenv("DISCOPT_SPARSE_LARGE_LP", raising=False)
+    assert current().sparse_large_lp is False
+    off = mc.MccormickLPRelaxer(m).solve_at_node(lb, ub, time_limit=5.0)
+    assert off.status == "skipped_oversize"
+
+    # Flag ON: the same node now solves, with the SAME bound as the below-cap solve.
+    monkeypatch.setenv("DISCOPT_SPARSE_LARGE_LP", "1")
+    assert current().sparse_large_lp is True
+    on = mc.MccormickLPRelaxer(m).solve_at_node(lb, ub, time_limit=5.0)
+    assert on.status == "optimal"
+    assert on.lower_bound is not None
+    assert on.lower_bound == pytest.approx(b_normal, rel=1e-9, abs=1e-9)
+
+    # Feasible-point sampling: the bound never exceeds any feasible objective
+    # (min x*y - x - y over x+y>=0.5, x,y in [-2,2]).
+    feas = [(2.0, 2.0), (0.5, 0.0), (0.25, 0.25), (2.0, -1.5), (-2.0, 2.5), (1.0, 1.0)]
+    for x, y in feas:
+        if x + y >= 0.5 - 1e-9 and -2.0 <= x <= 2.0 and -2.0 <= y <= 2.0:
+            obj = x * y - x - y
+            assert on.lower_bound <= obj + 1e-6, (x, y, obj, on.lower_bound)

--- a/python/tests/test_milp_simplex.py
+++ b/python/tests/test_milp_simplex.py
@@ -215,22 +215,22 @@ class TestPureLpShortCircuit:
     verdict is unchanged; only the wasted integer-side work is skipped."""
 
     def test_pure_lp_runs_with_machinery_off(self, monkeypatch):
-        """A no-integer solve routes ``solve_milp_py`` with the MILP machinery
+        """A no-integer solve routes the sparse CSC driver with the MILP machinery
         off; a solve WITH integers keeps it on. Fails before THRU-2b (the old
         code always passed the machinery-on defaults)."""
         import discopt._rust as _rust
         from discopt.solvers import milp_simplex
 
         captured: list[dict] = []
-        _orig = _rust.solve_milp_py
+        _orig = _rust.solve_milp_csc_py
 
         def _spy(*args, **kwargs):
             captured.append(dict(kwargs))
             return _orig(*args, **kwargs)
 
-        # ``solve_milp`` does ``from discopt._rust import solve_milp_py`` at call
-        # time, so patch the source module attribute (not ``milp_simplex``).
-        monkeypatch.setattr(_rust, "solve_milp_py", _spy)
+        # ``solve_milp`` does ``from discopt._rust import solve_milp_csc_py`` at
+        # call time, so patch the source module attribute (not ``milp_simplex``).
+        monkeypatch.setattr(_rust, "solve_milp_csc_py", _spy)
 
         c = np.array([-1.0, -1.0])
         A = np.array([[2.0, 1.0], [1.0, 2.0]])

--- a/python/tests/test_patterns_declared_box_cache.py
+++ b/python/tests/test_patterns_declared_box_cache.py
@@ -1,0 +1,71 @@
+"""Per-model declared-box cache for the syntactic convexity recognizers.
+
+``convexity.patterns._box_bounds`` / ``_total_scalar_variables`` are pure functions
+of the model's DECLARED variable bounds, yet the recognizers call them once per
+objective term (66k times on a 21k-term quadratic). Memoizing them on the model —
+safe because declared ``Variable`` bounds are immutable ``np.broadcast_to`` views
+for a model's life, with tightening flowing through node boxes, never mutation —
+removes ~10s of pure recomputation. This test pins the cache's correctness and its
+explicit invalidation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt import Model
+from discopt._jax.convexity.patterns import (
+    _DECLARED_BOX_CACHE_ATTR,
+    _box_bounds,
+    _total_scalar_variables,
+    clear_declared_box_cache,
+)
+
+
+@pytest.mark.unit
+def test_box_bounds_values_correct_and_cached():
+    m = Model()
+    m.continuous("x", lb=-1.0, ub=2.0)
+    m.continuous("y", lb=0.0, ub=5.0)
+
+    lo, hi = _box_bounds(m)
+    assert np.allclose(lo, [-1.0, 0.0])
+    assert np.allclose(hi, [2.0, 5.0])
+    assert _total_scalar_variables(m) == 2
+
+    # Second call returns the SAME cached arrays (identity), proving no rebuild.
+    lo2, hi2 = _box_bounds(m)
+    assert lo2 is lo and hi2 is hi
+    assert hasattr(m, _DECLARED_BOX_CACHE_ATTR)
+
+
+@pytest.mark.unit
+def test_clear_declared_box_cache_invalidates():
+    m = Model()
+    m.continuous("x", lb=0.0, ub=1.0)
+    lo, _ = _box_bounds(m)
+    assert hasattr(m, _DECLARED_BOX_CACHE_ATTR)
+
+    clear_declared_box_cache(m)
+    assert not hasattr(m, _DECLARED_BOX_CACHE_ATTR)
+
+    # Recomputes fresh (equal values, new object) after invalidation.
+    lo2, _ = _box_bounds(m)
+    assert lo2 is not lo
+    assert np.allclose(lo2, lo)
+
+    # Idempotent / safe on an un-cached model.
+    clear_declared_box_cache(m)
+    clear_declared_box_cache(Model())
+
+
+@pytest.mark.unit
+def test_total_scalar_variables_matches_box_size_for_array_vars():
+    """The cached scalar count must equal the flattened box length, including
+    array variables (size > 1)."""
+    m = Model()
+    m.continuous("s", lb=0.0, ub=1.0)
+    m.continuous("v", lb=np.zeros(4), ub=np.ones(4), shape=(4,))
+    lo, hi = _box_bounds(m)
+    assert lo.size == hi.size == 5
+    assert _total_scalar_variables(m) == 5

--- a/python/tests/test_psd_cuts_relaxation.py
+++ b/python/tests/test_psd_cuts_relaxation.py
@@ -83,7 +83,12 @@ def test_separator_emits_no_cut_at_a_consistent_moment_point():
 
 
 def test_no_op_on_model_without_lifted_squares():
-    """A purely bilinear model with no lifted squares yields no PSD cuts (sound no-op)."""
+    """A purely bilinear model with no lifted squares yields no PSD cuts (sound no-op).
+
+    The variables here are CONTINUOUS, so ``X_ii = x_i**2 != x_i`` and the moment
+    diagonal genuinely needs a lifted square (absent) — the separator correctly finds
+    nothing. This is the soundness boundary of the binary-diagonal shortcut below.
+    """
     m = dm.Model("bilin")
     x = m.continuous("x", shape=(2,), lb=0, ub=1)
     m.minimize(x[0] * x[1])  # only the cross term; no x_i^2 lifted
@@ -92,3 +97,57 @@ def test_no_op_on_model_without_lifted_squares():
     assert n_cuts == 0
     if z_before is not None:
         assert z_after == pytest.approx(z_before)
+
+
+def test_binary_products_get_moment_cuts_via_diagonal_shortcut():
+    """Pure products of DISTINCT binaries (QAP-class) carry no lifted square column,
+    yet ``X_ii = x_i`` holds for a binary — so the moment separator must still fire.
+
+    Before the binary-diagonal fix ``_diag_col`` returned ``None`` for every variable
+    (no ``monomial``/``univariate_square`` lift), so ``_lifted_cliques`` was empty and
+    PSD strengthening was a silent no-op on all such models (the qap ``-1e-9`` bound).
+
+    Model: min x0x1 + x0x2 + x1x2 s.t. x0+x1+x2 >= 1.5, xi in {0,1}. Binary-feasible
+    sums are {2,3} so the true minimum is 1; the McCormick relaxation reaches 0 at
+    x=(.5,.5,.5), X_ij=0, whose 4x4 moment matrix has eigenvalue -1/4. The k=3 moment
+    cut is violated there and tightens the bound, staying valid (<= 1).
+    """
+    from discopt._jax.model_utils import binary_flat_cols
+
+    m = dm.Model("tri")
+    x = [m.integer(f"x{i}", lb=0, ub=1) for i in range(3)]
+    m.minimize(x[0] * x[1] + x[0] * x[2] + x[1] * x[2])
+    m.subject_to(x[0] + x[1] + x[2] >= 1.5)
+    bvars = binary_flat_cols(m)
+    assert bvars == frozenset({0, 1, 2})
+
+    # Old behavior (no binary_vars): still a no-op — gates the fix (fails after if the
+    # shortcut leaked into the default path).
+    milp0, info0 = _relax(m)
+    zb0, za0, nc0 = psd_strengthen_relaxation_bound(milp0, info0, max_rounds=10, binary_vars=None)
+    assert nc0 == 0
+
+    # With binary diagonals: cuts fire and tighten the bound toward the true min 1.
+    milp1, info1 = _relax(m)
+    zb1, za1, nc1 = psd_strengthen_relaxation_bound(milp1, info1, max_rounds=10, binary_vars=bvars)
+    assert nc1 >= 1
+    assert za1 > zb1 + 1e-3  # genuine tightening (McCormick 0 -> ~0.36)
+    assert za1 <= 1.0 + 1e-6  # SOUND: never above the true minimum
+
+    # Soundness / feasible-point sampling (CLAUDE.md §5): every separated cut must
+    # hold at every feasible integer point (X_ij = x_i x_j, X_ii = x_i there).
+    x_at_pt = np.asarray(milp1._c, dtype=np.float64)  # length = #relaxation columns
+    n_total = x_at_pt.shape[0]
+    cuts = separate_psd_cuts_on_relaxation(info1, np.zeros(n_total), n_total, binary_vars=bvars)
+    orig = info1["original"]
+    bil = info1["bilinear"]
+    feas = [p for p in [(1, 1, 0), (1, 0, 1), (0, 1, 1), (1, 1, 1)] if sum(p) >= 1.5]
+    for pt in feas:
+        z = np.zeros(n_total)
+        for i in range(3):
+            z[orig[i]] = pt[i]
+        for (i, j), col in bil.items():
+            z[col] = pt[i] * pt[j]  # X_ij = x_i x_j exactly at an integer point
+        for c in cuts:
+            # coeffs . z >= rhs must hold at every feasible integer point.
+            assert float(c.coeffs @ z) >= c.rhs - 1e-7, (pt, "cut removes a feasible point")

--- a/python/tests/test_simplex_lp.py
+++ b/python/tests/test_simplex_lp.py
@@ -249,3 +249,79 @@ class TestSimplexLpDuals:
             assert len(rc) == n
             checked += 1
         assert checked >= 20
+
+
+def test_solve_lp_routes_through_sparse_csc_binding(monkeypatch):
+    """The exact-LP oracle (``solvers.lp_simplex.solve_lp``) must marshal through
+    the CSC-native ``solve_lp_warm_csc_py``, NEVER the dense ``solve_lp_warm_py``
+    whose ``a_std = np.zeros((m, n+m))`` standard form blew memory on a large
+    lifted LP — qap's 85756-row McCormick relaxation densifies to
+    ``85756 x 107405 ~ 73 GB`` (surfaced as the PSD/OBBT ~46 GB blowup; see
+    docs/dev/sparse-milp-plan.md T7). Fails before the sparse rewrite (which
+    called the dense binding).
+    """
+    import discopt._rust as _rust
+    from discopt.solvers import SolveStatus as _SS
+    from discopt.solvers.lp_simplex import solve_lp as _solve_lp
+
+    calls = {"csc": 0, "dense": 0}
+    _orig_csc = _rust.solve_lp_warm_csc_py
+
+    def _csc_spy(*a, **k):
+        calls["csc"] += 1
+        return _orig_csc(*a, **k)
+
+    monkeypatch.setattr(_rust, "solve_lp_warm_csc_py", _csc_spy)
+    if hasattr(_rust, "solve_lp_warm_py"):
+        _orig_dense = _rust.solve_lp_warm_py
+
+        def _dense_spy(*a, **k):
+            calls["dense"] += 1
+            return _orig_dense(*a, **k)
+
+        monkeypatch.setattr(_rust, "solve_lp_warm_py", _dense_spy)
+
+    A = np.array([[2.0, 1.0], [1.0, 3.0]])
+    b = np.array([4.0, 6.0])
+    c = np.array([-1.0, -1.0])
+    r = _solve_lp(c=c, A_ub=A, b_ub=b, bounds=[(0.0, 10.0), (0.0, 10.0)])
+    assert r.status == _SS.OPTIMAL
+    assert calls["csc"] >= 1  # routed through the sparse CSC binding
+    assert calls["dense"] == 0  # never the dense standard-form binding
+
+
+def test_solve_lp_does_not_densify_large_sparse_lp():
+    """A large, very sparse LP must not allocate anything near the dense standard
+    form ``[A | I]`` of shape ``m x (n+m)``. Regression for the exact-LP oracle
+    densification (docs/dev/sparse-milp-plan.md T7)."""
+    import gc
+    import tracemalloc
+
+    import scipy.sparse as sp
+    from discopt.solvers import SolveStatus as _SS
+    from discopt.solvers.lp_simplex import solve_lp as _solve_lp
+
+    n = 1500
+    rng = np.random.default_rng(0)
+    rows, cols, data, b = [], [], [], []
+    for i in range(n):
+        j = int(rng.integers(0, n))
+        rows += [i, i]
+        cols += [j, (j + 1) % n]
+        data += [1.0, 1.0]
+        b.append(2.0)
+    A = sp.csr_matrix((data, (rows, cols)), shape=(n, n), dtype=np.float64)
+    c = np.ones(n)
+    bounds = [(0.0, 1.0)] * n
+    dense_std_bytes = n * (2 * n) * 8  # m x (n+m) f64 the old path allocated
+
+    gc.collect()
+    tracemalloc.start()
+    r = _solve_lp(c=c, A_ub=A, b_ub=np.array(b, dtype=np.float64), bounds=bounds)
+    _cur, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert r.status == _SS.OPTIMAL
+    # The sparse marshaling peaks far below the dense standard form (which would be
+    # ~36 MB here, ~73 GB on qap). Half of it is a generous, deterministic ceiling.
+    assert peak < dense_std_bytes * 0.5, f"peak={peak} vs dense={dense_std_bytes}"

--- a/python/tests/test_uniform_relax.py
+++ b/python/tests/test_uniform_relax.py
@@ -448,3 +448,48 @@ def test_ep5_hash_consing_shares_one_compiled_fn():
     assert len(keys) == len(set(keys))
     for key, node in dag._intern.items():
         assert dag._intern[key] is node  # stable identity per structural key
+
+
+@pytest.mark.unit
+def test_sum_accumulation_bound_neutral_multiterm_quadratic():
+    """The ``sum`` rep folds children into one dict in O(N) (not the old
+    O(N^2) chained ``LinForm.__add__``). This must be BYTE-IDENTICAL to the
+    per-child accumulation: each product/linear column keeps its exact summed
+    coefficient. A multi-term quadratic whose McCormick envelope is exact at the
+    box corner pins the bound, so a dropped/mis-scaled objective coefficient would
+    move it.
+
+    ``min x*y + x*z`` over ``x,y,z in [1,2]`` — McCormick is exact at the corner
+    ``(1,1,1)`` where the true minimum ``1*1 + 1*1 = 2`` is attained, so the root
+    LP bound is exactly 2. If the sum accumulation mis-summed either bilinear aux's
+    objective coefficient the bound would not be 2.
+    """
+    m = Model()
+    x = m.continuous("x", lb=1.0, ub=2.0)
+    y = m.continuous("y", lb=1.0, ub=2.0)
+    z = m.continuous("z", lb=1.0, ub=2.0)
+    m.minimize(x * y + x * z)
+    bound, status, _ = _root_bound(m)
+    assert status == "optimal"
+    assert bound is not None
+    assert bound == pytest.approx(2.0, abs=1e-6)  # exact at the corner (1,1,1)
+    assert bound <= 2.0 + 1e-9  # sound: never above the true box minimum
+
+
+@pytest.mark.unit
+def test_sum_accumulation_repeated_column_coefficients_sum():
+    """A column appearing in several summed children must accumulate its
+    coefficients (not overwrite). ``min 3*x + x*y + x*y`` over ``x in [1,2],
+    y in [1,2]``: the linear ``x`` carries coeff 3 and the bilinear ``x*y``
+    carries coeff 2. McCormick is exact at ``(1,1)`` giving ``3*1 + 2*(1*1) = 5``.
+    A broken accumulation (overwrite instead of add) would drop to ``3 + 1 = 4``
+    or ``3`` and change the bound."""
+    m = Model()
+    x = m.continuous("x", lb=1.0, ub=2.0)
+    y = m.continuous("y", lb=1.0, ub=2.0)
+    m.minimize(3.0 * x + x * y + x * y)
+    bound, status, _ = _root_bound(m)
+    assert status == "optimal"
+    assert bound is not None
+    assert bound == pytest.approx(5.0, abs=1e-6)
+    assert bound <= 5.0 + 1e-9


### PR DESCRIPTION
## What & why

Make the Rust MILP branch-and-bound driver **and the whole per-node McCormick path fully
sparse**, so a large sparse binary QP (qap: 225 binaries, an 85,756×21,649 McCormick lift)
is no longer densified. Along the way this fixes four distinct densification/inertness bugs
on the qap path, each with a regression test, and lands one bound-changing capability behind
a default-off flag. Work log: `docs/dev/sparse-milp-plan.md` (T0–T12).

The motivating symptom was ~73 GB of *hypothetical* densification. Measurement repeatedly
corrected the plan (recorded as falsifications, per the repo's evidence-first protocol): the
real blowups were **~30 GB** (dense incremental `base_A`) and **~46 GB** (the exact-LP
oracle), not the driver — and qap's own dual bound turns out to need a global SDP, not
McCormick (tracked separately in #661).

## The changes

| Task | Change | Result |
|---|---|---|
| T0–T4 | Rust MILP driver → CSC end to end (`solve_milp_csc_py`, sparse `solve_milp_hooked`; Python routing) | no dense `m×(n+m)`; bit-identical |
| T6 | Decline the dense incremental `base_A` for large lifts | relaxer build 30 GB → 0.9 GB |
| T8 | Sparse exact-LP oracle (`lp_simplex.solve_lp` → CSC `solve_lp_warm_csc_py`) | PSD/OBBT/DBBT 46 GB → 0.69 GB |
| T9 | Recognize binary moment diagonals `X_ii = x_i` | PSD moment cuts un-inerted for binary-product (QAP-class) models |
| T10 | Scalar/equal-shape fast path in `core._broadcast_shapes` | −17%/node build |
| T11 | Sparse `IncrementalMcCormickLP` (fixed-pattern `.data` patch) | **14.7×**/node, 30 GB → 0.76 GB |
| T12 | `DISCOPT_SPARSE_LARGE_LP` flag (default off) to solve large-lift LPs | large sparse lift solvable, sound |

## Correctness (the product is the certificate)

- **Bit-identity where required (§5 bound-neutral):** the CSC driver ports were gated by
  per-function differential tests + two integration goldens (node counts / certified objective
  exactly unchanged). The sparse incremental structure is gated by its built-in `_validate`
  (patched vs cold-built row-set on 6 sign-diverse boxes) and a new sparse-vs-dense patch test.
  The sparse exact-LP oracle matches HiGHS to 3e-16 and dense-input == sparse-input on a 40-LP
  panel, preserving the row-dual / reduced-cost KKT identities.
- **Bound-changing changes (§5) behind flags:** T9 (PSD) is verified effective + sound on a
  constructed binary QP (bound 0 → 0.356, ≤ true min, feasible-point sampling — no integer point
  cut). T12 is default-off; when on it produces the *same* bound as the below-cap solve (the flag
  gates only *declining*, not the math) and never loosens a node (B&B keeps the parent floor).
- Every densification/inertness fix ships with a regression test that fails before and passes
  after.

## Tests run

- `pytest -m smoke` — 653 passed
- adversarial suite (`-m slow python/tests/test_adversarial_recent_fixes.py`) — 10 passed
- `pytest -k "increment or mccormick"` — 231 passed; `-k psd` — 158 passed; LP/OBBT/DBBT — 344 passed
- `cargo test -p discopt-core` — 458 passed (from the T0–T4 CSC work)

## Measured (qap, peak RSS via `/usr/bin/time -l`)

- Relaxer construction: **~30 GB → 0.38 GB**; full solve (production guards): **~30 GB → 0.86 GB**.
- Per-node (guard lifted so the LP solves): **1.566 s cold rebuild → 0.107 s sparse patch = 14.7×**,
  same bound, 0.76 GB. The basis-LU does *not* blow memory (falsifying an earlier worry).

## Honest boundary → #661

qap's own McCormick bound is **~0** (indefinite `x'Qx`); the sparse work makes that LP solvable
and memory-safe but cannot make it *tight*. Closing qap's gap needs a **global SDP (Shor / RLT-2)**
relaxation — filed as **#661**, out of scope here. The `DISCOPT_SPARSE_LARGE_LP` flag stays
default-off until a large-sparse-lift-with-tight-McCormick instance measurably benefits (none in
the current corpus; the guard only trips at qap-scale, and qap doesn't benefit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
