### PR TITLE
fix(tests): repair stale correctness tests (Lagrangian method wiring, pooling optimum)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2908,6 +2908,7 @@ def solve_model(
     record_decomposition: bool = False,
     lagrangian_bound: bool = False,
     lagrangian_frequency: int = 1,
+    lagrangian_method: str = "subgradient",
     initial_point: Optional[np.ndarray] = None,
     skip_convex_check: bool = False,
     nlp_bb: Optional[bool] = None,
@@ -3695,6 +3696,7 @@ def solve_model(
                 gap_tolerance=gap_tolerance,
                 max_iterations=max_nodes,
                 nlp_solver=nlp_solver,
+                method=lagrangian_method,
             )
         if decomposition == "auto":
             # Consult the advisor, log its reasoning, and dispatch its

--- a/python/tests/test_decomposition_benchmarks.py
+++ b/python/tests/test_decomposition_benchmarks.py
@@ -89,7 +89,7 @@ def test_benders_matches_known_optimum_and_monolithic(case):
 @pytest.mark.parametrize("method", ["subgradient", "bundle"])
 def test_lagrangian_matches_known_optimum(case, method):
     model, opt = case()
-    r = model.solve(decomposition="lagrangian", method=method, time_limit=60)
+    r = model.solve(decomposition="lagrangian", lagrangian_method=method, time_limit=60)
     assert r.status == "optimal"
     assert r.objective == pytest.approx(opt, abs=ABS_TOL)
     assert r.bound is not None and r.bound <= r.objective + 1e-4

--- a/python/tests/test_pounce_batch.py
+++ b/python/tests/test_pounce_batch.py
@@ -220,7 +220,7 @@ def test_pounce_size_gate_keeps_small_serial():
     finally:
         S._solve_batch_pounce = orig
 
-    assert res.objective == pytest.approx(1390.0, abs=1.0, rel=1e-3)  # still correct
+    assert res.objective == pytest.approx(400.0, abs=1.0, rel=1e-3)  # Haverly-I optimum (E1)
     assert not fired, "small problem should stay serial under the size gate"
 
 


### PR DESCRIPTION
## What & why

Repairs 3 `correctness`-marked tests that were red on `main`. They are excluded from
every PR CI job (`-m "not slow and not correctness and ..."`), so the rot accumulated
unnoticed. Surfaced while checking whether the sparse-MILP work (#663) impacted them —
it did not; these are independent, pre-existing failures (confirmed failing on clean
`main`).

## Fixes

1. **Lagrangian sub-method wiring** — `test_lagrangian_matches_known_optimum[{subgradient,bundle}-_block_conflict]`.
   The test calls `solve(decomposition="lagrangian", method=…)`, but `solve_model`
   neither accepted nor forwarded a Lagrangian method: `solve_lagrangian(method=…)`
   existed yet was called without it. Added `solve_model(lagrangian_method="subgradient")`
   (auto-accepted via the signature-derived kwarg allowlist) and forwarded it; updated
   the test to `lagrangian_method=`. Both cases now certify their known optimum.

2. **Stale pooling optimum** — `test_pounce_size_gate_keeps_small_serial` asserted the
   Haverly-I optimum was **1390**; the true optimum is **400** (max profit), certified
   by the default global spatial B&B (`obj == bound == 400`) and documented in the
   model's own E1 note (the concentration form fixed an earlier false-500 / stale-1390
   value). Default/serial/batch pounce all agree on 400. Updated the assertion.

## Not fixed here → #665

`test_batch_failure_sentinels_decertify_gap` and `test_pounce_batch_end_to_end_pooling`
still fail because `Model.solve()` no longer **dispatches** to `_solve_batch_pounce`
(the B&B never forms a multi-node batch on these small models), even though the batch
function itself is green (`test_p03_trust_gate` unit-tests it). The sentinel test is a
**soundness guard**, so neutering it to pass would be wrong — filed **#665** for a
maintainer decision (intended single-node export → rework the tests, vs. a
batch-formation regression → restore it).

## Tests run

- The 3 repaired tests pass (`-m ''`).
- `test_decomposition_benchmarks.py` + `test_pounce_batch.py` (minus the #665 batch-trigger
  test): 9 passed, 1 deselected.
- `solve()` still rejects unknown kwargs; `lagrangian_method` is in the accepted set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
