### PR TITLE
feat(#187): exact binary-multilinear linearization routes autocorr-class models to MILP

### DIFF
--- a/design/issue-pattern-map.md
+++ b/design/issue-pattern-map.md
@@ -90,12 +90,21 @@ elsewhere), **new-pattern** (needs a pattern not yet implemented), **search/infr
   `w = 0` gives a valid relaxation, and the disjunction drives branching.
 - Recommendation: add an IR node (per the issue) + the `w=xy, w=0` cut; provable.
 
-### #187 — autocorr_bern: products of binaries — **new-pattern (exact)**
+### #187 — autocorr_bern: products of binaries — **new-pattern (exact)** — **done**
 - Structure: products of **binary** variables `∏ b_i` (Fortet/Glover).
 - Pattern: new **Fortet/Glover linearization** — *exact* (not a relaxation):
   `z = ∏_i b_i ⟺ z <= b_i ∀i, z >= Σ b_i − (n−1), z >= 0`.
 - Recommendation: highest-value clean win — exact, provable, and avoids the
   full-DAG Jacobian XLA blowup the issue flags. Implement first.
+- **Shipped** as the auto-firing presolve pass
+  `discopt._jax.binary_multilinear_reform` (`solve_model` adopts it under the
+  pure-MILP guard and routes to the MILP engine): per-monomial Fortet rows for
+  the general binary-multilinear case, plus an exact **integer-point secant
+  envelope** for objective-pressure squares of integer-valued forms
+  (`y == E`, `t >= (u+v)·y − u·v` over the attainable value grid — the
+  autocorr `Σ_k C_k²` structure), which keeps the MILP ~10x smaller than flat
+  expansion. `{0,1}`-bounded INTEGER columns count as binary (from_nl typing).
+  Certified in `python/tests/test_binary_multilinear_reform.py`.
 
 ### #219 — transcendental over unbounded/implied-bound domains — **search/infra (bounds)**
 - Structure: `exp/log/...` whose argument has no finite bound → dropped from LP.

--- a/design/relaxation-patterns.md
+++ b/design/relaxation-patterns.md
@@ -218,6 +218,13 @@ the envelope engine), **roadmap** (proof given here, implementation pending).
   For `n = 2` these are the bilinear hull on `[0,1]^2`. *Fortet (1960); Glover &
   Woolsey (1974).* Issue #187.
 - `patterns.binary_product_linearization`; certified in `test_patterns.py`.
+- **Auto-firing presolve pass** (issue #187): `discopt._jax.binary_multilinear_reform`
+  applies this per-monomial to any pure-binary multilinear model (`{0,1}` INTEGER
+  counts as binary), plus an exact integer-point **secant envelope**
+  `t >= (u+v)·y − u·v` over the attainable value grid for objective-pressure
+  squares of integer-valued forms (`Σ_k C_k²`, the autocorr structure) — the
+  whole model becomes an equivalent pure MILP and bypasses the spatial/JAX
+  path. Certified in `test_binary_multilinear_reform.py`.
 
 ### P12. Complementarity `x·y = 0`, `x,y >= 0` — **done**
 - **Fields:** MPEC/equilibrium, contact mechanics, KKT systems, disjunctive.

--- a/python/discopt/_jax/binary_multilinear_reform.py
+++ b/python/discopt/_jax/binary_multilinear_reform.py
@@ -1068,8 +1068,13 @@ def _reformulate(model: Model) -> Model:
     new_obj_expr = _rebuild(obj_body)
     rebuilt: list[Constraint] = []
     for c, pbody in zip(model._constraints, con_bodies):
-        has_work = pbody.squares or any(len(m) >= 2 for m in pbody.flat)
-        rebuilt.append(Constraint(_rebuild(pbody), c.sense, c.rhs, c.name) if has_work else c)
+        # Rebuild EVERY body from its expansion, not only those that gained
+        # aux terms: a body like ``b*b + x`` expands to the *linear* ``b + x``
+        # (no aux, so no "work"), but keeping the original nonlinear
+        # expression would make the pure-MILP adoption guard reject the whole
+        # reformulation. The rebuilt form is algebraically identical on the
+        # feasible set.
+        rebuilt.append(Constraint(_rebuild(pbody), c.sense, c.rhs, c.name))
 
     new_model._constraints = rebuilt + aux_rows
     new_model._objective = Objective(expression=new_obj_expr, sense=obj.sense)

--- a/python/discopt/_jax/binary_multilinear_reform.py
+++ b/python/discopt/_jax/binary_multilinear_reform.py
@@ -1,0 +1,1082 @@
+"""Pure-binary multilinear exact linearization (Fortet/Glover) — issue #187.
+
+A polynomial over binary-valued variables is *multilinear* on its feasible
+points (``b**2 == b`` for ``b in {0,1}``), so every monomial
+``coef * prod_i b_i`` can be replaced exactly by an auxiliary ``z`` with the
+Fortet/Glover linearization
+
+    z <= b_i          (for every factor i)
+    z >= sum_i b_i - (n - 1)
+    z >= 0
+
+which forces ``z == prod_i b_i`` at every binary vertex (Fortet 1960; Glover &
+Woolsey 1974; pattern P10 in ``design/relaxation-patterns.md``). Applying it to
+every monomial of degree >= 2 turns the model into an **equivalent pure MILP**
+whose optimum equals the original optimum — no spatial relaxation and no JAX
+Jacobian is ever needed.
+
+This is the architectural fix for the ``autocorr_bern*`` wall (issue #187): the
+Bernasconi autocorrelation objective ``sum_k (sum_i s_i s_{i+k})**2`` over
+``{0,1}``-valued variables expands to a ~3000-monomial quartic whose full-DAG
+JAX Jacobian compile and sparsity walk each exceed a 30 s budget on their own.
+All work here happens directly on the *factored* DAG with plain dict
+arithmetic over monomials (never materializing an expanded expression DAG and
+never touching sympy/JAX), and the reformulated model routes to the MILP
+branch-and-bound.
+
+Two exact encodings are combined:
+
+1. **Squared integer-valued forms** (the autocorr structure). An objective
+   addend ``c * E**2`` where ``E`` expands to a multilinear polynomial with
+   *integer* coefficients over *integer-valued* variables takes only integer
+   values, so ``E**2`` is described exactly at integer points by the secants of
+   the parabola between consecutive integers:
+
+       y == E_linearized,   t >= (2j+1)*y - j*(j+1)   for j = lo .. hi-1,
+
+   where ``[lo, hi]`` is an interval bound on ``E``. At every attainable
+   integer ``y`` the max of the secants equals ``y**2`` exactly, so every
+   original solution stays feasible at its original objective value (validity)
+   and the reformulated optimum is exact, *provided the optimization pressure
+   pushes ``t`` down onto the secant envelope* — guaranteed when the addend
+   sits in the objective with a min-effective positive coefficient (or the
+   equivalent condition in the objective variable's defining row, see below).
+   Between attainable points the chords of the convex parabola lie above it,
+   which only *tightens* the continuous relaxation. Compared to flat expansion
+   this needs O(range) rows per square instead of O(#monomials) rows total:
+   autocorr_bern25-25 drops from ~15k rows to ~1.2k.
+
+2. **Flat monomial linearization** (the general case). Everything not
+   expressible as (1) — constraint bodies, squares with the wrong sign, or an
+   objective already delivered in expanded form — is expanded to its
+   multilinear normal form and every degree>=2 monomial is Fortet-linearized
+   per the scheme above. Budgeted: a blow-up aborts and falls back.
+
+The `.nl` "objvar" convention (objective = a bare free variable ``tau`` whose
+value is pinned by one defining row ``a*tau + g(b) <sense> rhs``) is
+recognized so encoding (1) applies inside that row exactly when the sign/sense
+conditions make the row transmit the objective's minimization pressure to the
+squares (``mu * (-c/a) > 0`` with ``mu = +1`` for MIN / ``-1`` for MAX, and
+the row either an equality or the inequality that bounds ``tau`` on its
+objective-improving side, with ``tau`` free, scalar, continuous, and appearing
+nowhere else). Everything else falls back to (2).
+
+Scope and soundness rules:
+
+- ``{0,1}``-bounded ``INTEGER`` variables are recognized as binary-valued
+  (``from_nl`` types MINLPLib's 0/1 columns as ``INTEGER``, issue #187
+  correction 1) — the linearization only needs *values* in ``{0,1}``, which
+  integrality plus the bounds guarantees.
+- Every monomial of degree >= 2 must consist exclusively of binary-valued
+  factors; a continuous or general-integer variable may appear **linearly**
+  only. Anything else (transcendentals, fractional/negative powers, divisions
+  by non-constants, vector expressions) aborts the pass, which then returns
+  the model **unchanged** — the solver keeps its existing paths, so the pass
+  never regresses a model it cannot handle exactly.
+- The rewrite fires only when a term of total degree >= ``_MIN_DEGREE`` (3) is
+  present. Degree-2-only binary models are already handled exactly per-term by
+  McCormick on the existing paths; rerouting them wholesale is out of scope
+  here (and would change behavior on the whole binary-quadratic class).
+- Expansion and the emitted MILP are budgeted (``_MAX_MONOMIALS``,
+  ``_MAX_PRODUCT_OPS``, ``_MAX_ROWS``): a blow-up aborts and falls back
+  rather than emitting a MILP too large for the (dense-marshaling) in-house
+  MILP engines.
+
+The solver adopts the reformulation only under the same guard as the
+integer-bilinear pass (a genuinely pure MILP per both ``classify_problem`` and
+the DAG-walking ``classify_nonlinear_terms``), and routes it to the MILP
+engine.
+
+All DAG walks here are **iterative**: ``from_nl`` builds n-ary sums as
+left-associative ``BinaryOp`` chains, so a ~3000-term objective is a
+~3000-deep tree and any recursive walk would hit Python's recursion limit
+(silently disabling the pass on exactly the models it targets). For the same
+reason the rebuilt linear bodies use *balanced* sum trees, keeping downstream
+recursive walkers (term classifier, LP extractor) at O(log n) depth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Constraint,
+    Expression,
+    IndexExpression,
+    Model,
+    Objective,
+    ObjectiveSense,
+    Parameter,
+    SumExpression,
+    SumOverExpression,
+    UnaryOp,
+    Variable,
+    VarType,
+)
+
+# A monomial is a frozenset of scalar-variable keys ``(var._index, elem)``;
+# the empty frozenset is the constant term. Binary factors collapse via set
+# union (``b**2 == b``); the expansion aborts if a *non*-binary factor would
+# collapse (that would silently rewrite ``x**2 -> x``) or appears in a
+# degree>=2 monomial (not multilinear-reducible).
+_Mono = frozenset
+_EMPTY: frozenset = frozenset()
+
+# Fire only when a genuine degree>=3 term exists: n=2 products are already
+# exact per-term under McCormick on the existing paths (see module docstring),
+# and degree >= 3 is where the nested-bilinear relaxation is loose.
+_MIN_DEGREE = 3
+# Budget caps: abort (fall back to the existing paths) rather than emit an
+# intractable MILP. The row cap is calibrated to the in-house MILP engines'
+# dense LP marshaling (extract_lp_data materializes an (m, n+m) float64
+# matrix): autocorr_bern25-25 needs ~1.6k rows under the squared-form encoding
+# and fits comfortably; a 15k-row flat expansion of the same model would OOM.
+_MAX_MONOMIALS = 200_000
+_MAX_PRODUCT_OPS = 10_000_000
+_MAX_ROWS = 6_000
+# Largest constant integer exponent expanded by repeated multiplication.
+_MAX_POW = 16
+# Syntactic degree values in the cheap gate saturate here (avoids overflow on
+# deep power towers; anything at the cap is "large enough" for the witness).
+_DEG_CAP = 64
+# A variable bound at/above this magnitude counts as free (matches discopt's
+# effective-infinity sentinel).
+_FREE_BOUND = 1e19
+
+
+class _Unsupported(Exception):
+    """Structure this pass cannot linearize exactly — abort and fall back."""
+
+
+def _scalar_constant(node: Constant) -> float:
+    v = node.value
+    if v.ndim != 0 and v.size != 1:
+        raise _Unsupported("non-scalar constant")
+    return float(v.reshape(()))
+
+
+def _binary_like(var: Variable, elem: int) -> bool:
+    """True if ``var[elem]`` can only take values in ``{0, 1}``: declared
+    BINARY, or INTEGER with bounds inside ``(-1, 2)`` (so the only integers in
+    the box are 0/1). This is the {0,1}-integer recognition of issue #187."""
+    if var.var_type == VarType.BINARY:
+        return True
+    if var.var_type != VarType.INTEGER:
+        return False
+    lo = float(np.asarray(var.lb).flat[elem])
+    hi = float(np.asarray(var.ub).flat[elem])
+    return lo > -1.0 and hi < 2.0
+
+
+def _integer_valued(var: Variable) -> bool:
+    return var.var_type in (VarType.BINARY, VarType.INTEGER)
+
+
+def _leaf_ref(node: Expression) -> Optional[tuple[Variable, int, Expression]]:
+    """If *node* references one scalar variable element, return
+    ``(variable, flat_element, reference_expression)``, else ``None``."""
+    if isinstance(node, Variable):
+        if node.size == 1 and node.shape == ():
+            return node, 0, node
+        return None
+    if isinstance(node, IndexExpression):
+        base = node.base
+        if not isinstance(base, Variable):
+            return None
+        idx = node.index
+        if isinstance(idx, (int, np.integer)):
+            flat = int(idx)
+            if 0 <= flat < base.size and len(base.shape) <= 1:
+                return base, flat, node
+            return None
+        if isinstance(idx, tuple) and all(isinstance(i, (int, np.integer)) for i in idx):
+            try:
+                flat = int(np.ravel_multi_index(tuple(int(i) for i in idx), base.shape))
+            except ValueError:
+                return None
+            return base, flat, node
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cheap syntactic gate
+# ---------------------------------------------------------------------------
+
+
+def has_binary_multilinear_work(model: Model) -> bool:
+    """True if the objective or a constraint contains a product/power subterm
+    of syntactic degree >= ``_MIN_DEGREE`` whose variables are all
+    binary-valued — the witness that the exact Fortet/Glover linearization has
+    something to gain. Cheap (one iterative pass over each DAG, O(1) per node)
+    and safe: ``False`` means the pass is skipped, never that a model is
+    mis-rewritten. Returns ``False`` on any error."""
+    try:
+        if model._objective is None:
+            return False
+        bodies = [model._objective.expression]
+        for c in model._constraints:
+            if isinstance(c, Constraint):
+                bodies.append(c.body)
+        return any(_witness_scan(b) for b in bodies)
+    except Exception:
+        return False
+
+
+def _gate_children(node: Expression) -> Optional[list[Expression]]:
+    if isinstance(node, BinaryOp):
+        return [node.left, node.right]
+    if isinstance(node, UnaryOp):
+        return [node.operand]
+    if isinstance(node, SumExpression):
+        return [node.operand]
+    if isinstance(node, SumOverExpression):
+        return list(node.terms)
+    if isinstance(node, (Constant, Variable, IndexExpression, Parameter)):
+        return []
+    return None  # unsupported node type
+
+
+def _witness_scan(root: Expression) -> bool:
+    """Iterative post-order scan computing, per node, ``(degree, all_binary,
+    supported)`` — degree saturating at ``_DEG_CAP`` — and reporting whether
+    any ``*``/``**`` node reaches degree >= ``_MIN_DEGREE`` with all-binary
+    variables and fully supported structure underneath."""
+    # memo: id(node) -> (deg, all_bin, ok)
+    memo: dict[int, tuple[int, bool, bool]] = {}
+    stack: list[Expression] = [root]
+    while stack:
+        node = stack[-1]
+        if id(node) in memo:
+            stack.pop()
+            continue
+        children = _gate_children(node)
+        if children is None:
+            memo[id(node)] = (0, True, False)
+            stack.pop()
+            continue
+        pending = [c for c in children if id(c) not in memo]
+        if pending:
+            stack.extend(pending)
+            continue
+        stack.pop()
+        memo[id(node)] = _gate_eval(node, memo)
+        deg, all_bin, ok = memo[id(node)]
+        if (
+            ok
+            and all_bin
+            and deg >= _MIN_DEGREE
+            and isinstance(node, BinaryOp)
+            and node.op in ("*", "**")
+        ):
+            return True
+    return False
+
+
+def _gate_eval(node: Expression, memo: dict[int, tuple[int, bool, bool]]) -> tuple[int, bool, bool]:
+    if isinstance(node, (Constant, Parameter)):
+        return (0, True, True)
+    ref = _leaf_ref(node)
+    if ref is not None:
+        return (1, _binary_like(ref[0], ref[1]), True)
+    if isinstance(node, (IndexExpression, Variable)):
+        return (0, True, False)  # vector/opaque reference
+    if isinstance(node, UnaryOp):
+        d, b, ok = memo[id(node.operand)]
+        return (d, b, ok and node.op == "neg")
+    if isinstance(node, (SumExpression, SumOverExpression)):
+        children = _gate_children(node) or []
+        deg, all_bin, ok = 0, True, True
+        for c in children:
+            d, b, o = memo[id(c)]
+            deg, all_bin, ok = max(deg, d), all_bin and b, ok and o
+        return (deg, all_bin, ok)
+    if isinstance(node, BinaryOp):
+        dl, bl, okl = memo[id(node.left)]
+        dr, br, okr = memo[id(node.right)]
+        ok = okl and okr
+        all_bin = bl and br
+        if node.op in ("+", "-"):
+            return (max(dl, dr), all_bin, ok)
+        if node.op == "*":
+            return (min(dl + dr, _DEG_CAP), all_bin, ok)
+        if node.op == "/":
+            return (dl, all_bin, ok and dr == 0)
+        if node.op == "**":
+            if not (isinstance(node.right, Constant) and okl):
+                return (0, True, False)
+            try:
+                k = _scalar_constant(node.right)
+            except _Unsupported:
+                return (0, True, False)
+            if k != int(k) or not (0 <= k <= _MAX_POW):
+                return (0, True, False)
+            return (min(dl * int(k), _DEG_CAP), bl, okl)
+        return (0, True, False)
+    return (0, True, False)
+
+
+# ---------------------------------------------------------------------------
+# Exact multilinear expansion (dict arithmetic over monomials)
+# ---------------------------------------------------------------------------
+
+
+class _ExpandCtx:
+    """Shared state of one reformulation attempt: the (var, elem) -> reference
+    registry, the binary/integer-likeness caches, and the product-op budget."""
+
+    def __init__(self) -> None:
+        self.refs: dict[tuple[int, int], Expression] = {}
+        self.is_bin: dict[tuple[int, int], bool] = {}
+        self.is_int: dict[tuple[int, int], bool] = {}
+        self.ops = 0
+
+    def register(self, var: Variable, elem: int, ref: Expression) -> tuple[int, int]:
+        key = (var._index, elem)
+        if key not in self.refs:
+            self.refs[key] = ref
+            self.is_bin[key] = _binary_like(var, elem)
+            self.is_int[key] = _integer_valued(var)
+        return key
+
+
+def _poly_add(p: dict, q: dict, sign: float = 1.0) -> dict:
+    out = dict(p)
+    for m, c in q.items():
+        nc = out.get(m, 0.0) + sign * c
+        if nc == 0.0:
+            out.pop(m, None)
+        else:
+            out[m] = nc
+    if len(out) > _MAX_MONOMIALS:
+        raise _Unsupported("monomial budget exceeded")
+    return out
+
+
+def _poly_scale(p: dict, c: float) -> dict:
+    if c == 0.0:
+        return {}
+    return {m: v * c for m, v in p.items()}
+
+
+def _poly_mul(p: dict, q: dict, ctx: _ExpandCtx) -> dict:
+    ctx.ops += len(p) * len(q)
+    if ctx.ops > _MAX_PRODUCT_OPS:
+        raise _Unsupported("product-op budget exceeded")
+    out: dict = {}
+    for m1, c1 in p.items():
+        for m2, c2 in q.items():
+            dup = m1 & m2
+            if dup:
+                # Collapsing a repeated factor is ``b**2 == b`` — valid only
+                # for binary-valued factors. A repeated non-binary factor
+                # would be silently *rewritten* (x**2 -> x): abort instead.
+                for key in dup:
+                    if not ctx.is_bin[key]:
+                        raise _Unsupported("repeated non-binary factor")
+            m = m1 | m2
+            nc = out.get(m, 0.0) + c1 * c2
+            if nc == 0.0:
+                out.pop(m, None)
+            else:
+                out[m] = nc
+    if len(out) > _MAX_MONOMIALS:
+        raise _Unsupported("monomial budget exceeded")
+    return out
+
+
+def _poly_pow(p: dict, k: int, ctx: _ExpandCtx) -> dict:
+    if k == 0:
+        return {_EMPTY: 1.0}
+    out = p
+    for _ in range(k - 1):
+        out = _poly_mul(out, p, ctx)
+    return out
+
+
+def _expand_children(node: Expression) -> list[Expression]:
+    if isinstance(node, BinaryOp):
+        return [node.left, node.right]
+    if isinstance(node, UnaryOp):
+        if node.op != "neg":
+            raise _Unsupported(f"unary op {node.op!r}")
+        return [node.operand]
+    if isinstance(node, SumExpression):
+        return [node.operand]
+    if isinstance(node, SumOverExpression):
+        return list(node.terms)
+    if isinstance(node, (Constant, Parameter)):
+        return []
+    if _leaf_ref(node) is not None:
+        return []
+    raise _Unsupported(f"unsupported node {type(node).__name__}")
+
+
+def _expand_to_multilinear(root: Expression, ctx: _ExpandCtx) -> dict:
+    """Expand *root* into ``{monomial: coefficient}`` with binary squares
+    collapsed (``b**2 == b``), via an iterative post-order walk (see module
+    docstring for why recursion is forbidden here). Raises ``_Unsupported`` on
+    any structure the pass cannot linearize exactly."""
+    memo: dict[int, dict] = {}
+    stack: list[Expression] = [root]
+    while stack:
+        node = stack[-1]
+        if id(node) in memo:
+            stack.pop()
+            continue
+        children = _expand_children(node)
+        pending = [c for c in children if id(c) not in memo]
+        if pending:
+            stack.extend(pending)
+            continue
+        stack.pop()
+        memo[id(node)] = _expand_eval(node, memo, ctx)
+    return memo[id(root)]
+
+
+def _expand_eval(node: Expression, memo: dict[int, dict], ctx: _ExpandCtx) -> dict:
+    if isinstance(node, Constant):
+        v = _scalar_constant(node)
+        return {_EMPTY: v} if v != 0.0 else {}
+    if isinstance(node, Parameter):
+        pv = np.asarray(node.value)
+        if pv.ndim != 0 and pv.size != 1:
+            raise _Unsupported("non-scalar parameter")
+        v = float(pv.reshape(()))
+        return {_EMPTY: v} if v != 0.0 else {}
+    ref = _leaf_ref(node)
+    if ref is not None:
+        var, elem, ref_expr = ref
+        key = ctx.register(var, elem, ref_expr)
+        return {_Mono((key,)): 1.0}
+    if isinstance(node, UnaryOp):  # only "neg" reaches here
+        return _poly_scale(memo[id(node.operand)], -1.0)
+    if isinstance(node, SumExpression):
+        return memo[id(node.operand)]
+    if isinstance(node, SumOverExpression):
+        out: dict = {}
+        for t in node.terms:
+            out = _poly_add(out, memo[id(t)])
+        return out
+    if isinstance(node, BinaryOp):
+        left = memo[id(node.left)]
+        right = memo[id(node.right)]
+        if node.op == "+":
+            return _poly_add(left, right)
+        if node.op == "-":
+            return _poly_add(left, right, sign=-1.0)
+        if node.op == "*":
+            return _poly_mul(left, right, ctx)
+        if node.op == "/":
+            if set(right.keys()) - {_EMPTY}:
+                raise _Unsupported("division by a non-constant")
+            denom = right.get(_EMPTY, 0.0)
+            if denom == 0.0:
+                raise _Unsupported("division by zero")
+            return _poly_scale(left, 1.0 / denom)
+        if node.op == "**":
+            if not isinstance(node.right, Constant):
+                raise _Unsupported("non-constant exponent")
+            k = _scalar_constant(node.right)
+            if k != int(k) or not (0 <= k <= _MAX_POW):
+                raise _Unsupported(f"exponent {k!r} not a small non-negative integer")
+            return _poly_pow(left, int(k), ctx)
+        raise _Unsupported(f"binary op {node.op!r}")
+    raise _Unsupported(f"unsupported node {type(node).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Addend collection and squared-form detection
+# ---------------------------------------------------------------------------
+
+
+def _collect_addends(root: Expression) -> tuple[float, list[tuple[float, Expression]]]:
+    """Split *root* into ``(constant, [(coefficient, node), ...])`` by walking
+    the +/- spine iteratively, folding constant factors/divisors and unary
+    negations into the coefficients. Nodes below a non-additive operation are
+    returned whole (their internal structure is handled by expansion)."""
+    const = 0.0
+    addends: list[tuple[float, Expression]] = []
+    stack: list[tuple[float, Expression]] = [(1.0, root)]
+    while stack:
+        coef, node = stack.pop()
+        if isinstance(node, Constant):
+            const += coef * _scalar_constant(node)
+            continue
+        if isinstance(node, UnaryOp) and node.op == "neg":
+            stack.append((-coef, node.operand))
+            continue
+        if isinstance(node, SumExpression):
+            stack.append((coef, node.operand))
+            continue
+        if isinstance(node, SumOverExpression):
+            stack.extend((coef, t) for t in reversed(node.terms))
+            continue
+        if isinstance(node, BinaryOp):
+            if node.op == "+":
+                stack.append((coef, node.right))
+                stack.append((coef, node.left))
+                continue
+            if node.op == "-":
+                stack.append((-coef, node.right))
+                stack.append((coef, node.left))
+                continue
+            if node.op == "*":
+                if isinstance(node.left, Constant):
+                    stack.append((coef * _scalar_constant(node.left), node.right))
+                    continue
+                if isinstance(node.right, Constant):
+                    stack.append((coef * _scalar_constant(node.right), node.left))
+                    continue
+            if node.op == "/" and isinstance(node.right, Constant):
+                denom = _scalar_constant(node.right)
+                if denom == 0.0:
+                    raise _Unsupported("division by zero")
+                stack.append((coef / denom, node.left))
+                continue
+        addends.append((coef, node))
+    # The stack pops left-most last for '+' chains; addends were appended in
+    # traversal order already (left pushed last, popped first).
+    return const, addends
+
+
+def _square_base(node: Expression) -> Optional[Expression]:
+    """Return ``E`` when *node* is syntactically ``E**2`` or ``E*E`` (the same
+    object on both sides, as DAG-shared squares are), else ``None``."""
+    if isinstance(node, BinaryOp):
+        if node.op == "**" and isinstance(node.right, Constant):
+            try:
+                if _scalar_constant(node.right) == 2.0:
+                    return node.left
+            except _Unsupported:
+                return None
+        if node.op == "*" and node.left is node.right:
+            return node.left
+    return None
+
+
+@dataclass
+class _SquareTerm:
+    """One objective-pressure-encodable ``coef * E**2`` addend: ``poly`` is the
+    multilinear expansion of ``E`` (integer coefficients over integer-valued
+    variables), ``[lo, hi]`` its interval range snapped to the attainable
+    value grid, and ``step`` the grid spacing: when every non-constant
+    coefficient of ``E`` is divisible by ``g``, ``E`` only attains values
+    congruent to its constant term mod ``g``, so secants are only needed
+    between consecutive attainable points (autocorr's ``C_k`` has ``g = 2``,
+    halving the secant rows)."""
+
+    coef: float
+    poly: dict
+    lo: int
+    hi: int
+    step: int = 1
+
+    @property
+    def n_secants(self) -> int:
+        return (self.hi - self.lo) // self.step
+
+
+@dataclass
+class _ProcessedBody:
+    """A body split into a flat multilinear polynomial plus secant-encodable
+    squared terms (empty for plain constraint bodies)."""
+
+    flat: dict
+    squares: list[_SquareTerm] = field(default_factory=list)
+
+
+def _poly_int_range(poly: dict, ctx: _ExpandCtx) -> Optional[tuple[int, int]]:
+    """Integer interval bound of a multilinear *poly* whose every monomial is a
+    product of {0,1}-valued factors, when all coefficients (and the constant)
+    are integers and all participating variables are integer-valued. Returns
+    ``None`` when those conditions fail — the caller then falls back to flat
+    expansion of the square."""
+    lo = hi = 0.0
+    for m, c in poly.items():
+        if not float(c).is_integer():
+            return None
+        if not m:
+            lo += c
+            hi += c
+            continue
+        for key in m:
+            if not ctx.is_int[key]:
+                return None
+        if len(m) >= 2 and not all(ctx.is_bin[key] for key in m):
+            return None
+        if len(m) == 1:
+            key = next(iter(m))
+            vlo, vhi = (0.0, 1.0) if ctx.is_bin[key] else _var_bounds(ctx.refs[key])
+            if not (np.isfinite(vlo) and np.isfinite(vhi)):
+                return None
+            lo += min(c * vlo, c * vhi)
+            hi += max(c * vlo, c * vhi)
+        else:
+            lo += min(c, 0.0)
+            hi += max(c, 0.0)
+    if abs(lo) > 2**31 or abs(hi) > 2**31:
+        return None
+    return int(np.floor(lo)), int(np.ceil(hi))
+
+
+def _var_bounds(ref: Expression) -> tuple[float, float]:
+    leaf = _leaf_ref(ref)
+    assert leaf is not None
+    var, elem, _ = leaf
+    return (
+        float(np.asarray(var.lb).flat[elem]),
+        float(np.asarray(var.ub).flat[elem]),
+    )
+
+
+def _interval_of_dag(root: Expression) -> tuple[float, float]:
+    """Sound interval enclosure of *root* over the variable box, computed on
+    the *factored* DAG. On sum-of-products structure this is much tighter than
+    the per-monomial interval of the expanded polynomial (autocorr's
+    ``C_k = sum_i s_i s_{i+k}`` with ``s in [-1, 1]`` encloses to exactly
+    ``[-(n-k), n-k]``, ~4x tighter than the expanded-poly interval), which
+    directly cuts the number of secant rows. Unsupported structure yields
+    ``(-inf, inf)`` — the caller intersects with the expanded-poly interval,
+    so this is only ever a refinement."""
+    inf = float("inf")
+    memo: dict[int, tuple[float, float]] = {}
+    stack: list[Expression] = [root]
+    while stack:
+        node = stack[-1]
+        if id(node) in memo:
+            stack.pop()
+            continue
+        children = _gate_children(node)
+        if children is None:
+            memo[id(node)] = (-inf, inf)
+            stack.pop()
+            continue
+        pending = [c for c in children if id(c) not in memo]
+        if pending:
+            stack.extend(pending)
+            continue
+        stack.pop()
+        memo[id(node)] = _interval_eval(node, memo)
+    return memo[id(root)]
+
+
+def _interval_mul(a: tuple[float, float], b: tuple[float, float]) -> tuple[float, float]:
+    products = [a[0] * b[0], a[0] * b[1], a[1] * b[0], a[1] * b[1]]
+    products = [p for p in products if not np.isnan(p)]
+    if not products:
+        return (-float("inf"), float("inf"))
+    return (min(products), max(products))
+
+
+def _interval_eval(node: Expression, memo: dict[int, tuple[float, float]]) -> tuple[float, float]:
+    inf = float("inf")
+    top = (-inf, inf)
+    if isinstance(node, Constant):
+        try:
+            v = _scalar_constant(node)
+        except _Unsupported:
+            return top
+        return (v, v)
+    if isinstance(node, Parameter):
+        pv = np.asarray(node.value)
+        if pv.ndim != 0 and pv.size != 1:
+            return top
+        v = float(pv.reshape(()))
+        return (v, v)
+    ref = _leaf_ref(node)
+    if ref is not None:
+        var, elem, _ = ref
+        lo = float(np.asarray(var.lb).flat[elem])
+        hi = float(np.asarray(var.ub).flat[elem])
+        return (lo, hi)
+    if isinstance(node, UnaryOp):
+        lo, hi = memo[id(node.operand)]
+        return (-hi, -lo) if node.op == "neg" else top
+    if isinstance(node, SumExpression):
+        return memo[id(node.operand)]
+    if isinstance(node, SumOverExpression):
+        lo = hi = 0.0
+        for t in node.terms:
+            tl, th = memo[id(t)]
+            lo, hi = lo + tl, hi + th
+        return (lo, hi)
+    if isinstance(node, BinaryOp):
+        left = memo[id(node.left)]
+        right = memo[id(node.right)]
+        if node.op == "+":
+            return (left[0] + right[0], left[1] + right[1])
+        if node.op == "-":
+            return (left[0] - right[1], left[1] - right[0])
+        if node.op == "*":
+            return _interval_mul(left, right)
+        if node.op == "/":
+            if right[0] == right[1] and right[0] not in (0.0,):
+                d = right[0]
+                lo, hi = left[0] / d, left[1] / d
+                return (min(lo, hi), max(lo, hi))
+            return top
+        if node.op == "**":
+            if not isinstance(node.right, Constant):
+                return top
+            try:
+                k = _scalar_constant(node.right)
+            except _Unsupported:
+                return top
+            if k != int(k) or not (0 <= k <= _MAX_POW):
+                return top
+            out = (1.0, 1.0)
+            for _ in range(int(k)):
+                out = _interval_mul(out, left)
+            # Even powers are nonnegative regardless of the sign box.
+            if int(k) % 2 == 0:
+                out = (max(out[0], 0.0), out[1])
+            return out
+        return top
+    return top
+
+
+def _attainable_grid(poly: dict, lo: int, hi: int) -> Optional[tuple[int, int, int]]:
+    """Snap ``[lo, hi]`` to the value grid of the integer-coefficient form
+    *poly*: with ``g = gcd`` of the non-constant coefficients, every value is
+    congruent to the constant term mod ``g``, so the bounds tighten to the
+    outermost attainable points and secants only need spacing ``g``. Returns
+    ``(lo_a, hi_a, g)`` or ``None`` when the snapped interval is empty (a
+    numerically defensive impossibility — the true value is attainable and
+    inside every sound interval; the caller then falls back to flat)."""
+    c0 = int(round(poly.get(_EMPTY, 0.0)))
+    g = 0
+    for m, c in poly.items():
+        if m:
+            g = int(np.gcd(g, int(round(abs(c)))))
+    if g <= 1:
+        return (lo, hi, 1) if lo <= hi else None
+    lo_a = lo + (c0 - lo) % g
+    hi_a = hi - (hi - c0) % g
+    if lo_a > hi_a:
+        return None
+    return (lo_a, hi_a, g)
+
+
+def _process_body(root: Expression, ctx: _ExpandCtx, eff: Optional[float]) -> _ProcessedBody:
+    """Expand *root*, peeling off addends ``coef * E**2`` for the secant
+    encoding when ``eff`` (the objective-pressure multiplier of this body) is
+    set and ``eff * coef > 0`` and ``E`` is an integer-valued integer-
+    coefficient multilinear form. Everything else lands in the flat poly."""
+    const, addends = _collect_addends(root)
+    flat: dict = {_EMPTY: const} if const != 0.0 else {}
+    squares: list[_SquareTerm] = []
+    for coef, node in addends:
+        if coef == 0.0:
+            continue
+        base = _square_base(node)
+        if base is not None and eff is not None and eff * coef > 0.0:
+            inner = _expand_to_multilinear(base, ctx)
+            rng = _poly_int_range(inner, ctx)
+            if rng is not None:
+                # Refine with the factored-DAG interval (both are sound, so
+                # their intersection is): fewer secant rows, smaller MILP.
+                dlo, dhi = _interval_of_dag(base)
+                lo = max(rng[0], int(np.ceil(dlo)) if np.isfinite(dlo) else rng[0])
+                hi = min(rng[1], int(np.floor(dhi)) if np.isfinite(dhi) else rng[1])
+                grid = _attainable_grid(inner, lo, hi)
+            else:
+                grid = None
+            # A constant or affine-in-one-binary square is cheaper flat.
+            if grid is not None and grid[1] - grid[0] >= 2 and len(inner) >= 2:
+                squares.append(_SquareTerm(coef, inner, grid[0], grid[1], grid[2]))
+                continue
+        poly = _expand_to_multilinear(node, ctx)
+        flat = _poly_add(flat, _poly_scale(poly, coef))
+    return _ProcessedBody(flat=flat, squares=squares)
+
+
+# ---------------------------------------------------------------------------
+# Objective-variable ("objvar") defining-row detection
+# ---------------------------------------------------------------------------
+
+
+def _contains_node(root: Expression, target: Expression) -> bool:
+    """Iterative scan: does *root* reference *target* (by identity)?"""
+    seen: set[int] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        if node is target:
+            return True
+        for attr in ("left", "right", "operand", "base"):
+            child = getattr(node, attr, None)
+            if isinstance(child, Expression):
+                stack.append(child)
+        for attr in ("args", "terms"):
+            seq = getattr(node, attr, None)
+            if isinstance(seq, (list, tuple)):
+                stack.extend(c for c in seq if isinstance(c, Expression))
+    return False
+
+
+def _detect_objvar_row(model: Model, mu: float) -> Optional[tuple[int, float]]:
+    """Detect the `.nl` objvar convention: the objective is a bare free scalar
+    continuous variable ``tau`` pinned by exactly one row ``a*tau + g(x)
+    <sense> rhs`` that transmits the objective pressure to ``g`` (equality, or
+    the inequality bounding ``tau`` on its objective-improving side). Returns
+    ``(row_index, a)`` or ``None``. ``tau`` must be genuinely free: finite
+    bounds could clip the surrogate below the true objective value and break
+    exactness (see module docstring)."""
+    obj = model._objective
+    if obj is None or not isinstance(obj.expression, Variable):
+        return None
+    tau = obj.expression
+    if tau.var_type != VarType.CONTINUOUS or tau.size != 1 or tau.shape != ():
+        return None
+    lb = float(np.asarray(tau.lb).reshape(()))
+    ub = float(np.asarray(tau.ub).reshape(()))
+    if lb > -_FREE_BOUND or ub < _FREE_BOUND:
+        return None
+    rows = [i for i, c in enumerate(model._constraints) if _contains_node(c.body, tau)]
+    if len(rows) != 1:
+        return None
+    row = model._constraints[rows[0]]
+    # tau must enter the row as a plain linear addend with constant
+    # coefficient a, and appear in no other addend.
+    try:
+        _, addends = _collect_addends(row.body)
+    except _Unsupported:
+        return None
+    a = 0.0
+    for coef, node in addends:
+        if node is tau:
+            if a != 0.0:
+                return None
+            a = coef
+        elif _contains_node(node, tau):
+            return None
+    if a == 0.0:
+        return None
+    # Sense condition: '==' always transmits; an inequality only when it
+    # bounds tau on its objective-improving side (min: from below; max: from
+    # above). Constraint bodies are normalized against ``rhs``:
+    #   '>=' means body >= rhs  ->  a*tau >= rhs - g  (lower-bounds tau iff a>0)
+    #   '<=' means body <= rhs  ->  upper-bounds tau iff a>0.
+    if row.sense == "==":
+        return rows[0], a
+    if row.sense == ">=" and mu * a > 0:
+        return rows[0], a
+    if row.sense == "<=" and mu * a < 0:
+        return rows[0], a
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rebuild: Fortet aux variables, secant epigraphs, linear bodies
+# ---------------------------------------------------------------------------
+
+
+def _balanced_sum(terms: list[Expression]) -> Expression:
+    """Combine *terms* into a balanced ``+`` tree (depth O(log n)) so that
+    downstream recursive DAG walkers never see a linear-depth chain."""
+    if not terms:
+        return Constant(0.0)
+    while len(terms) > 1:
+        terms = [
+            BinaryOp("+", terms[i], terms[i + 1]) if i + 1 < len(terms) else terms[i]
+            for i in range(0, len(terms), 2)
+        ]
+    return terms[0]
+
+
+def _poly_terms(poly: dict, ctx: _ExpandCtx, aux: dict[frozenset, Variable]) -> list[Expression]:
+    terms: list[Expression] = []
+    const = poly.get(_EMPTY, 0.0)
+    for mono in sorted((m for m in poly if m), key=lambda m: tuple(sorted(m))):
+        c = poly[mono]
+        base: Expression = ctx.refs[next(iter(mono))] if len(mono) == 1 else aux[mono]
+        terms.append(base if c == 1.0 else BinaryOp("*", Constant(float(c)), base))
+    if const != 0.0 or not terms:
+        terms.append(Constant(float(const)))
+    return terms
+
+
+def _model_carries_unsupported_state(model: Model) -> bool:
+    """True when the model holds structure this pass does not copy into the
+    rebuilt model (SOS/indicator objects in ``_constraints``, complementarity
+    conditions, builder-side linear blocks/objectives). Firing on such a model
+    would silently drop that structure, so the pass abstains instead."""
+    if any(not isinstance(c, Constraint) for c in model._constraints):
+        return True
+    if getattr(model, "_complementarities", None):
+        return True
+    if getattr(model, "_builder_linear_blocks", None):
+        return True
+    if getattr(model, "_builder_linear_objective", None) is not None:
+        return True
+    if getattr(model, "_builder_quadratic_objective", None) is not None:
+        return True
+    return False
+
+
+def reformulate_binary_multilinear(model: Model) -> Model:
+    """Return an equivalent pure-MILP model with every binary multilinear
+    monomial exactly Fortet/Glover-linearized (and objective squares of
+    integer-valued forms secant-encoded), or *model* unchanged when the
+    structure is out of scope, a budget is exceeded, or anything errs — the
+    pass never regresses a model it cannot handle exactly."""
+    try:
+        return _reformulate(model)
+    except _Unsupported:
+        return model
+    except Exception:  # pragma: no cover - defensive
+        return model
+
+
+def _reformulate(model: Model) -> Model:
+    obj = model._objective
+    if obj is None:
+        return model
+    if _model_carries_unsupported_state(model):
+        return model
+
+    mu = 1.0 if obj.sense == ObjectiveSense.MINIMIZE else -1.0
+    objvar_row = _detect_objvar_row(model, mu)
+
+    ctx = _ExpandCtx()
+    if objvar_row is None:
+        obj_body = _process_body(obj.expression, ctx, eff=mu)
+    else:
+        obj_body = _process_body(obj.expression, ctx, eff=None)
+    con_bodies: list[_ProcessedBody] = []
+    for i, c in enumerate(model._constraints):
+        if objvar_row is not None and i == objvar_row[0]:
+            # The defining row transmits the objective pressure to its squares
+            # with multiplier -mu/a (min tau with a*tau + c*E**2 + ... pins
+            # tau to -(c/a)*E**2 + ..., so the min-effective coefficient of
+            # E**2 is -mu*c/a).
+            con_bodies.append(_process_body(c.body, ctx, eff=-mu / objvar_row[1]))
+        else:
+            con_bodies.append(_process_body(c.body, ctx, eff=None))
+
+    all_bodies = [obj_body, *con_bodies]
+
+    # Structural verdict: every degree>=2 flat monomial must be purely binary
+    # (a continuous / general-integer variable may only appear linearly), and
+    # a genuine degree>=_MIN_DEGREE term must exist for the rewrite to pay off
+    # (squares count as twice their inner degree).
+    max_degree = 0
+    monos: set = set()
+    n_secant_rows = 0
+    n_squares = 0
+    for pbody in all_bodies:
+        for m in pbody.flat:
+            if len(m) >= 2:
+                if not all(ctx.is_bin[k] for k in m):
+                    return model
+                monos.add(m)
+                max_degree = max(max_degree, len(m))
+        for sq in pbody.squares:
+            for m in sq.poly:
+                if len(m) >= 2:
+                    monos.add(m)
+            inner_deg = max((len(m) for m in sq.poly), default=0)
+            max_degree = max(max_degree, 2 * inner_deg)
+            n_secant_rows += sq.n_secants
+            n_squares += 1
+    if max_degree < _MIN_DEGREE:
+        return model
+    n_rows = (
+        len(model._constraints)
+        + sum(len(m) + 1 for m in monos)  # Fortet rows per monomial
+        + n_squares  # y == L linking rows
+        + n_secant_rows
+    )
+    if n_rows > _MAX_ROWS:
+        return model
+
+    new_model = Model(model.name)
+    new_model._variables = list(model._variables)
+    new_model._parameters = list(model._parameters)
+    new_model._rebuild_name_index()
+
+    # One aux + Fortet rows per distinct monomial, in deterministic order.
+    aux: dict[frozenset, Variable] = {}
+    aux_rows: list[Constraint] = []
+    for i, mono in enumerate(sorted(monos, key=lambda m: tuple(sorted(m)))):
+        z = Variable(f"_bml_z{i}", VarType.CONTINUOUS, (), 0.0, 1.0, new_model)
+        new_model._variables.append(z)
+        aux[mono] = z
+        refs = [ctx.refs[k] for k in sorted(mono)]
+        # z <= b_i for every factor (z >= 0 is the variable's lower bound).
+        for r in refs:
+            aux_rows.append(Constraint(BinaryOp("-", z, r), "<=", 0.0))
+        # z >= sum_i b_i - (n-1)  <=>  z - sum_i b_i + (n-1) >= 0. RHS kept at
+        # 0 with the constant folded into the body (the LP extractor folds the
+        # body against a zero RHS; see integer_product_reform's note).
+        lower: Expression = z
+        for r in refs:
+            lower = BinaryOp("-", lower, r)
+        lower = BinaryOp("+", lower, Constant(float(len(refs) - 1)))
+        aux_rows.append(Constraint(lower, ">=", 0.0))
+
+    # Secant epigraphs: per encodable square, y == linearized(E) plus the
+    # integer-point secants t >= (2j+1)*y - j*(j+1). At every integer y their
+    # max equals y**2 exactly; the objective pressure (eff*coef > 0, checked
+    # at collection) pins t to the envelope at the optimum.
+    sq_counter = 0
+
+    def _encode_square(sq: _SquareTerm) -> Variable:
+        nonlocal sq_counter
+        y = Variable(
+            f"_bml_y{sq_counter}",
+            VarType.CONTINUOUS,
+            (),
+            float(sq.lo),
+            float(sq.hi),
+            new_model,
+        )
+        new_model._variables.append(y)
+        t_lo = 0.0 if sq.lo <= 0 <= sq.hi else float(min(sq.lo**2, sq.hi**2))
+        t_hi = float(max(sq.lo**2, sq.hi**2))
+        t = Variable(f"_bml_t{sq_counter}", VarType.CONTINUOUS, (), t_lo, t_hi, new_model)
+        new_model._variables.append(t)
+        sq_counter += 1
+        link = _balanced_sum([y, *(_negate(term) for term in _poly_terms(sq.poly, ctx, aux))])
+        aux_rows.append(Constraint(link, "==", 0.0))
+        for u in range(sq.lo, sq.hi, sq.step):
+            # Secant of the parabola through (u, u^2) and (u+g, (u+g)^2):
+            # t >= (2u+g)*y - u*(u+g). Exact at both endpoints, so the max of
+            # all grid secants equals y**2 at every attainable y.
+            v = u + sq.step
+            row: Expression = BinaryOp("-", t, BinaryOp("*", Constant(float(u + v)), y))
+            row = BinaryOp("+", row, Constant(float(u * v)))
+            aux_rows.append(Constraint(row, ">=", 0.0))
+        return t
+
+    def _rebuild(pb: _ProcessedBody) -> Expression:
+        terms = _poly_terms(pb.flat, ctx, aux)
+        for sq in pb.squares:
+            t = _encode_square(sq)
+            terms.append(t if sq.coef == 1.0 else BinaryOp("*", Constant(float(sq.coef)), t))
+        return _balanced_sum(terms)
+
+    new_obj_expr = _rebuild(obj_body)
+    rebuilt: list[Constraint] = []
+    for c, pbody in zip(model._constraints, con_bodies):
+        has_work = pbody.squares or any(len(m) >= 2 for m in pbody.flat)
+        rebuilt.append(Constraint(_rebuild(pbody), c.sense, c.rhs, c.name) if has_work else c)
+
+    new_model._constraints = rebuilt + aux_rows
+    new_model._objective = Objective(expression=new_obj_expr, sense=obj.sense)
+    return new_model
+
+
+def _negate(term: Expression) -> Expression:
+    if isinstance(term, Constant):
+        return Constant(-float(term.value.reshape(())))
+    return UnaryOp("neg", term)

--- a/python/discopt/_jax/symbolic/cut_recognizer.py
+++ b/python/discopt/_jax/symbolic/cut_recognizer.py
@@ -197,11 +197,7 @@ def model_to_sympy(model) -> SympyModel:
                 # (.nl loading types MINLPLib's 0/1 columns as INTEGER, so
                 # keying on VarType.BINARY alone misses them — issue #187.)
                 if is_bin or (
-                    is_int
-                    and elb is not None
-                    and eub is not None
-                    and elb > -1.0
-                    and eub < 2.0
+                    is_int and elb is not None and eub is not None and elb > -1.0 and eub < 2.0
                 ):
                     binaries.add(syms[key])
     return SympyModel(

--- a/python/discopt/_jax/symbolic/cut_recognizer.py
+++ b/python/discopt/_jax/symbolic/cut_recognizer.py
@@ -184,12 +184,25 @@ def model_to_sympy(model) -> SympyModel:
         size = int(getattr(v, "size", 1) or 1)
         lb = getattr(v, "lb", None)
         ub = getattr(v, "ub", None)
-        is_bin = getattr(v, "var_type", None) == core.VarType.BINARY
+        vt = getattr(v, "var_type", None)
+        is_bin = vt == core.VarType.BINARY
+        is_int = vt == core.VarType.INTEGER
         for i in range(size):
             key = v.name if size == 1 else f"{v.name}[{i}]"
             if key in syms:
-                bounds[syms[key]] = (_elem(lb, i, size), _elem(ub, i, size))
-                if is_bin:
+                elb, eub = _elem(lb, i, size), _elem(ub, i, size)
+                bounds[syms[key]] = (elb, eub)
+                # A {0,1}-bounded INTEGER element is binary-VALUED — all the
+                # binary-keyed recognitions here only need values in {0,1}.
+                # (.nl loading types MINLPLib's 0/1 columns as INTEGER, so
+                # keying on VarType.BINARY alone misses them — issue #187.)
+                if is_bin or (
+                    is_int
+                    and elb is not None
+                    and eub is not None
+                    and elb > -1.0
+                    and eub < 2.0
+                ):
                     binaries.add(syms[key])
     return SympyModel(
         objective=obj,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3972,6 +3972,69 @@ def solve_model(
     except Exception as _dep_exc:  # pragma: no cover - defensive
         logger.debug("functional-dependency detection skipped: %s", _dep_exc)
 
+    # --- Pure-binary multilinear exact linearization (issue #187) ---
+    # A polynomial objective/constraint over binary-valued variables ({0,1}
+    # INTEGER counts — from_nl types MINLPLib's 0/1 columns as INTEGER) is
+    # multilinear on its feasible points, so every degree>=2 monomial can be
+    # replaced exactly by a Fortet/Glover-linearized auxiliary, and squares of
+    # integer-valued forms by their integer-point secant envelope. The result
+    # is an *equivalent pure MILP* that routes to the MILP branch-and-bound —
+    # bypassing the spatial/JAX path whose full-DAG Jacobian XLA compile and
+    # sparsity walk are the autocorr_bern* wall (issue #187). Runs BEFORE the
+    # factorable reform: that pass would lift the squared sums into continuous
+    # aux variables and destroy the pure-binary structure this one needs. The
+    # pass abstains (returns the model unchanged) on anything it cannot
+    # linearize exactly, so it is a no-op everywhere else.
+    try:
+        from discopt._jax.binary_multilinear_reform import (
+            has_binary_multilinear_work,
+            reformulate_binary_multilinear,
+        )
+
+        if has_binary_multilinear_work(model):
+            _bml = reformulate_binary_multilinear(model)
+            if _bml is not model:
+                from discopt._jax.problem_classifier import ProblemClass, classify_problem
+                from discopt._jax.term_classifier import classify_nonlinear_terms
+
+                # Same adoption guard as the integer-bilinear reform below:
+                # adopt ONLY a genuinely pure MILP, confirmed by BOTH the
+                # extract_lp_data-based classifier and the DAG-walking term
+                # classifier (see that block's rationale / issue #286).
+                _bml_nl = classify_nonlinear_terms(_bml)
+                _bml_pure_milp = not (
+                    _bml_nl.bilinear
+                    or _bml_nl.trilinear
+                    or _bml_nl.multilinear
+                    or _bml_nl.monomial
+                    or _bml_nl.fractional_power
+                    or _bml_nl.bilinear_with_fp
+                    or _bml_nl.ratio_of_products
+                    or _bml_nl.general_nl
+                )
+                if _bml_pure_milp and classify_problem(_bml) == ProblemClass.MILP:
+                    logger.info(
+                        "binary-multilinear linearization: exact pure-MILP "
+                        "reformulation adopted (%d -> %d vars, %d -> %d rows)",
+                        len(model._variables),
+                        len(_bml._variables),
+                        len(model._constraints),
+                        len(_bml._constraints),
+                    )
+                    model = _bml
+                    model._convexity_classification_cache = None
+                    model._convexity_time_budget = _convexity_time_budget
+                    # Route like the integer-bilinear reform: skip the (slow,
+                    # redundant) FBBT root presolve on the lifted rows and use
+                    # the monolithic Rust simplex MILP engine, unless the
+                    # cert:P3.1c cut-reachability experiment keeps the solve
+                    # on the cut-carrying _solve_milp_bb path.
+                    presolve = False
+                    if nlp_solver == "pounce" and not _p3_force_cut_path_enabled():
+                        nlp_solver = "simplex"
+    except Exception as _bml_exc:  # pragma: no cover - defensive
+        logger.debug("binary-multilinear reformulation skipped: %s", _bml_exc)
+
     # Pre-reform model + original variable count, set only when the factorable
     # lift actually fires (see below). Used by the per-node interval bound to
     # recover the un-distributed objective's tight enclosure over the original

--- a/python/tests/test_binary_multilinear_reform.py
+++ b/python/tests/test_binary_multilinear_reform.py
@@ -1,0 +1,323 @@
+"""Tests for the pure-binary multilinear exact linearization (issue #187).
+
+The pass turns a polynomial objective over binary-valued variables into an
+equivalent pure MILP (Fortet/Glover per-monomial linearization + integer-point
+secant envelopes for squared integer forms) so the solver routes to the MILP
+branch-and-bound instead of the spatial/JAX path whose full-DAG Jacobian XLA
+compile is the ``autocorr_bern*`` wall.
+
+Soundness gates from the issue:
+- Fortet linearization exact for 0/1 products — property-tested
+  ``aux == prod(binaries)`` at all integer points.
+- Secant envelope exact at every attainable integer point.
+- Clean fallback to the existing paths when not pure-binary-multilinear.
+- Value preservation: reformulated optimum == brute-force optimum.
+"""
+
+import itertools
+import os
+import time
+
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+import pytest
+from discopt import Model
+from discopt._jax import binary_multilinear_reform as B
+
+pytestmark = pytest.mark.relaxation
+
+
+# ---------------------------------------------------------------------------
+# Model builders
+# ---------------------------------------------------------------------------
+
+
+def build_autocorr(n, K, objvar_sense=None):
+    """Bernasconi low-autocorrelation instance: minimize
+    ``sum_{k=1..K} (sum_i s_i s_{i+k})**2`` with ``s = 2b - 1`` and ``b`` typed
+    as {0,1}-bounded INTEGER (matching ``from_nl``'s typing of MINLPLib's 0/1
+    columns — the issue #187 correction). ``objvar_sense`` switches to the
+    `.nl` objvar convention: ``min tau`` with ``tau <sense> E`` as a row."""
+    m = Model(name=f"autocorr{n}_{K}")
+    b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(n)]
+    s = [2 * bi - 1 for bi in b]
+    E = None
+    for k in range(1, K + 1):
+        Ck = None
+        for i in range(n - k):
+            t = s[i] * s[i + k]
+            Ck = t if Ck is None else Ck + t
+        term = Ck * Ck
+        E = term if E is None else E + term
+    if objvar_sense is None:
+        m.minimize(E)
+    else:
+        tau = m.continuous("objvar", lb=-1e20, ub=1e20)
+        if objvar_sense == "==":
+            m.subject_to(tau == E)
+        else:
+            m.subject_to(tau >= E)
+        m.minimize(tau)
+    return m, b
+
+
+def autocorr_energy(bits, K):
+    n = len(bits)
+    s = [2 * x - 1 for x in bits]
+    return sum(sum(s[i] * s[i + k] for i in range(n - k)) ** 2 for k in range(1, K + 1))
+
+
+def brute_force_autocorr(n, K):
+    return min(autocorr_energy(bits, K) for bits in itertools.product([0, 1], repeat=n))
+
+
+# ---------------------------------------------------------------------------
+# Property tests (issue soundness gates)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("deg", [2, 3, 4, 5])
+def test_fortet_aux_equals_product_at_all_integer_points(deg):
+    """The Fortet rows admit exactly ``z == prod(b)`` at every binary vertex:
+    the feasible z-interval [max(0, sum b - (n-1)), min b] is the singleton
+    ``prod b`` for every 0/1 assignment."""
+    for bits in itertools.product([0, 1], repeat=deg):
+        z_lo = max(0.0, sum(bits) - (deg - 1))
+        z_hi = min(bits)
+        prod = float(np.prod(bits))
+        assert z_lo == z_hi == prod
+
+
+@pytest.mark.parametrize("lo,hi,step", [(-3, 4, 1), (-6, 6, 2), (0, 9, 3), (-5, -1, 2)])
+def test_secant_envelope_exact_at_attainable_points(lo, hi, step):
+    """max over grid secants ``(u+v)*y - u*v`` equals ``y**2`` exactly at every
+    attainable grid point, and lies at/above the parabola in between (chords of
+    a convex function) — over-approximating only where no attainable value
+    exists, which tightens the relaxation without cutting any integer point."""
+    secants = [(u, u + step) for u in range(lo, hi, step)]
+    for y in range(lo, hi + 1, step):
+        env = max((u + v) * y - u * v for u, v in secants)
+        assert env == y * y
+    for y in np.linspace(lo, hi, 37):
+        env = max((u + v) * y - u * v for u, v in secants)
+        assert env >= y * y - 1e-9
+
+
+def test_expansion_matches_direct_evaluation_at_all_vertices():
+    """The multilinear expansion is exact at every binary vertex."""
+    n, K = 6, 5
+    m, b = build_autocorr(n, K)
+    ctx = B._ExpandCtx()
+    poly = B._expand_to_multilinear(m._objective.expression, ctx)
+    pos = {bv._index: i for i, bv in enumerate(b)}
+    for bits in itertools.product([0, 1], repeat=n):
+        val = sum(c * np.prod([bits[pos[vi]] for vi, _ in mono]) for mono, c in poly.items())
+        assert abs(val - autocorr_energy(bits, K)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Value preservation (reformulated MILP optimum == brute force)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n,K", [(6, 5), (8, 7)])
+def test_reformulated_optimum_matches_brute_force(n, K):
+    ref = brute_force_autocorr(n, K)
+    m, _ = build_autocorr(n, K)
+    m2 = B.reformulate_binary_multilinear(m)
+    assert m2 is not m
+    res = m2.solve(time_limit=120, nlp_solver="simplex", presolve=False)
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(ref, abs=1e-5)
+
+
+@pytest.mark.parametrize("row_sense", ["==", ">="])
+def test_objvar_defining_row_form(row_sense):
+    """The `.nl` objvar convention (objective = bare free var pinned by one
+    defining row) is recognized and secant-encoded through the row."""
+    n, K = 6, 5
+    ref = brute_force_autocorr(n, K)
+    m, _ = build_autocorr(n, K, objvar_sense=row_sense)
+    m2 = B.reformulate_binary_multilinear(m)
+    assert m2 is not m
+    assert any(v.name.startswith("_bml_t") for v in m2._variables), (
+        "expected the defining row's squares to be secant-encoded"
+    )
+    res = m2.solve(time_limit=120, nlp_solver="simplex", presolve=False)
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(ref, abs=1e-5)
+
+
+def test_maximize_sense_preserved():
+    m = Model()
+    b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(4)]
+    m.maximize(3 * b[0] * b[1] * b[2] - 2 * b[1] * b[2] * b[3] + b[0] - b[3])
+    ref = max(
+        3 * v[0] * v[1] * v[2] - 2 * v[1] * v[2] * v[3] + v[0] - v[3]
+        for v in itertools.product([0, 1], repeat=4)
+    )
+    m2 = B.reformulate_binary_multilinear(m)
+    assert m2 is not m
+    res = m2.solve(time_limit=60, nlp_solver="simplex", presolve=False)
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(ref, abs=1e-5)
+
+
+def test_wrong_direction_square_falls_back_to_flat_and_stays_exact():
+    """A square whose objective pressure points the wrong way (maximizing
+    ``+E**2`` / minimizing ``-E**2``) must NOT be secant-encoded (the epigraph
+    would be unsound) — it flat-expands and the optimum stays exact."""
+    for sense in ("min", "max"):
+        m = Model()
+        b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(4)]
+        s = [2 * bi - 1 for bi in b]
+        C = s[0] * s[1] + s[1] * s[2] + s[2] * s[3]
+        E = C * C
+        vals = [
+            (lambda sv: (sv[0] * sv[1] + sv[1] * sv[2] + sv[2] * sv[3]) ** 2)(
+                [2 * v[0] - 1, 2 * v[1] - 1, 2 * v[2] - 1, 2 * v[3] - 1]
+            )
+            for v in itertools.product([0, 1], repeat=4)
+        ]
+        if sense == "max":
+            m.maximize(E)
+            ref = max(vals)
+        else:
+            m.minimize(-E)
+            ref = -max(vals)
+        m2 = B.reformulate_binary_multilinear(m)
+        assert m2 is not m
+        assert not any(v.name.startswith("_bml_t") for v in m2._variables)
+        res = m2.solve(time_limit=60, nlp_solver="simplex", presolve=False)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(ref, abs=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Clean fallback (the pass must abstain, never mis-rewrite)
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_continuous_factor_not_fired():
+    m = Model()
+    b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(2)]
+    x = m.continuous("x", lb=0, ub=2)
+    m.minimize(b[0] * b[1] * x + x)
+    assert not B.has_binary_multilinear_work(m)
+    assert B.reformulate_binary_multilinear(m) is m
+
+
+def test_binary_quadratic_not_fired():
+    """Degree-2-only binary models keep their current path (McCormick is
+    already exact per bilinear term there)."""
+    m = Model()
+    b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(3)]
+    m.minimize(b[0] * b[1] + b[1] * b[2] - b[0])
+    assert not B.has_binary_multilinear_work(m)
+    assert B.reformulate_binary_multilinear(m) is m
+
+
+def test_general_integer_factor_not_fired():
+    m = Model()
+    b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(2)]
+    w = m.integer("w", lb=0, ub=3)
+    m.minimize(b[0] * b[1] * w)
+    assert B.reformulate_binary_multilinear(m) is m
+
+
+def test_transcendental_not_fired():
+    import discopt.modeling as dm
+
+    m = Model()
+    b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(3)]
+    m.minimize(dm.exp(b[0] * b[1] * b[2]))
+    assert not B.has_binary_multilinear_work(m)
+    assert B.reformulate_binary_multilinear(m) is m
+
+
+def test_mixed_model_with_binary_witness_still_abstains():
+    """Gate sees an all-binary cubic witness, but the model also carries a
+    continuous factor in another degree>=2 monomial — the whole pass must
+    abstain (partial rewrites are not exactness-preserving)."""
+    m = Model()
+    b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(3)]
+    x = m.continuous("x", lb=0, ub=2)
+    m.minimize(b[0] * b[1] * b[2] + b[0] * x)
+    assert B.has_binary_multilinear_work(m)
+    assert B.reformulate_binary_multilinear(m) is m
+
+
+def test_deterministic_rebuild():
+    m1, _ = build_autocorr(8, 7)
+    m2, _ = build_autocorr(8, 7)
+    r1 = B.reformulate_binary_multilinear(m1)
+    r2 = B.reformulate_binary_multilinear(m2)
+    assert [v.name for v in r1._variables] == [v.name for v in r2._variables]
+    assert len(r1._constraints) == len(r2._constraints)
+    assert repr(r1._objective.expression) == repr(r2._objective.expression)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: default solve() fires the pass and clears the wall (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_autocorr_end_to_end_certifies_within_budget(caplog):
+    """Issue #187 acceptance shape: an autocorr instance certifies quickly on
+    a default solve. Before the pass this model burned the whole budget on the
+    spatial/JAX path (n=8 dense: >60 s, no certificate); with it, the MILP
+    route certifies the brute-force optimum in seconds."""
+    import logging
+
+    n, K = 8, 7
+    ref = brute_force_autocorr(n, K)
+    m, _ = build_autocorr(n, K)
+    t0 = time.time()
+    with caplog.at_level(logging.INFO, logger="discopt.solver"):
+        res = m.solve(time_limit=120)
+    wall = time.time() - t0
+    assert any("binary-multilinear linearization" in r.message for r in caplog.records), (
+        "the exact linearization did not auto-fire on a default solve"
+    )
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(ref, abs=1e-5)
+    assert wall < 60, f"autocorr n=8 took {wall:.1f}s — the #187 wall is back"
+
+
+def test_from_nl_round_trip_fires_and_certifies(tmp_path):
+    """The real target path: a `.nl`-loaded model ({0,1} INTEGER typing,
+    left-associative sum chains from reconstruction) must pass the gate,
+    secant-encode its squares, and certify the brute-force optimum."""
+    n, K = 6, 5
+    from discopt.modeling.core import from_nl
+
+    ref = brute_force_autocorr(n, K)
+    m, _ = build_autocorr(n, K)
+    path = str(tmp_path / "autocorr.nl")
+    m.to_nl(path)
+    loaded = from_nl(path)
+    assert all(v.var_type.value == "integer" for v in loaded._variables)
+    assert B.has_binary_multilinear_work(loaded)
+    m2 = B.reformulate_binary_multilinear(loaded)
+    assert m2 is not loaded
+    assert any(v.name.startswith("_bml_t") for v in m2._variables)
+    res = loaded.solve(time_limit=120)
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(ref, abs=1e-5)
+
+
+def test_binary_valued_integer_recognized_in_model_to_sympy():
+    """{0,1}-bounded INTEGER columns count as binary in the symbolic
+    recognizer layer too (issue #187 correction 1)."""
+    pytest.importorskip("sympy")
+    from discopt._jax.symbolic.cut_recognizer import model_to_sympy
+
+    m = Model()
+    bi = m.integer("bi", lb=0, ub=1)
+    bb = m.binary("bb")
+    w = m.integer("w", lb=0, ub=3)
+    m.minimize(bi * bb * w)
+    sm = model_to_sympy(m)
+    names = {s.name for s in sm.binaries}
+    assert "bi" in names and "bb" in names and "w" not in names

--- a/python/tests/test_binary_multilinear_reform.py
+++ b/python/tests/test_binary_multilinear_reform.py
@@ -248,6 +248,34 @@ def test_mixed_model_with_binary_witness_still_abstains():
     assert B.reformulate_binary_multilinear(m) is m
 
 
+def test_binary_square_in_constraint_collapses_to_linear():
+    """``b*b`` in a constraint collapses to ``b`` (b**2 == b), so the rebuilt
+    model is genuinely pure-MILP and the optimum is preserved."""
+    m = Model()
+    b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(3)]
+    x = m.continuous("x", lb=0, ub=2)
+    m.subject_to(b[0] * b[0] + x <= 1.5)
+    m.minimize(b[0] * b[1] * b[2] - 2 * b[0] - x)
+    m2 = B.reformulate_binary_multilinear(m)
+    assert m2 is not m
+    from discopt._jax.problem_classifier import ProblemClass, classify_problem
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    nl = classify_nonlinear_terms(m2)
+    assert not (nl.bilinear or nl.trilinear or nl.multilinear or nl.monomial or nl.general_nl)
+    assert classify_problem(m2) == ProblemClass.MILP
+    # b0=1 forces x <= 0.5; with b1*b2 = 0 the objective is -2 - 0.5 = -2.5
+    # (b0=0 allows x=1.5 but only reaches -1.5). Verified by enumeration.
+    ref = min(
+        v0 * v1 * v2 - 2 * v0 - min(2.0, 1.5 - v0 * v0)
+        for v0, v1, v2 in itertools.product([0, 1], repeat=3)
+    )
+    res = m2.solve(time_limit=60, nlp_solver="simplex", presolve=False)
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(ref, abs=1e-5)
+    assert res.objective == pytest.approx(-2.5, abs=1e-5)
+
+
 def test_deterministic_rebuild():
     m1, _ = build_autocorr(8, 7)
     m2, _ = build_autocorr(8, 7)


### PR DESCRIPTION
Closes #187 — the `autocorr_bern*` wall #2 (full-DAG Jacobian XLA compile / dense-DAG sparsity walk).

## What this does

New auto-firing presolve pass `discopt._jax.binary_multilinear_reform` + `solve_model` wiring: a polynomial model over **binary-valued** variables (`{0,1}`-bounded `INTEGER` counts — `from_nl` types MINLPLib's 0/1 columns as `INTEGER`, per the issue's correction 1) is rewritten into an **equivalent pure MILP** and routed to the MILP branch-and-bound, so the spatial/JAX path — whose full-DAG Jacobian XLA compile and sparsity walk are the wall — is never entered.

Two exact encodings, combined:

1. **Fortet/Glover per-monomial linearization** (pattern P10): every degree≥2 monomial `∏ bᵢ` becomes aux `z` with `z ≤ bᵢ ∀i`, `z ≥ Σbᵢ − (n−1)`, `z ≥ 0` — exact at every binary vertex, no pressure condition needed.
2. **Integer-point secant envelope** for squares of integer-coefficient multilinear forms (`Σₖ Cₖ²`, the autocorr structure): `y == Cₖ` linearized via the `z`'s, `t ≥ (u+v)·y − u·v` over the **attainable value grid** (gcd/parity of coefficients — autocorr's `Cₖ` has parity structure, halving the rows; ranges from the intersection of expanded-poly and factored-DAG interval arithmetic). Exact at every attainable point; chords of the convex parabola only tighten the relaxation in between. Gated to positions where the objective pressure pins `t` to the envelope (objective addends with min-effective positive coefficient, or the `.nl` objvar defining row under the matching sign/sense/free-bounds conditions). This keeps the MILP ~10× smaller than flat expansion (25-dense: ~1.2k rows vs ~15k, which OOMs the dense LP marshaling).

Everything happens in dict arithmetic on the **factored** DAG (`b² == b` collapse) — the expanded expression DAG the issue warns about is never materialized, and sympy/JAX are never touched. All walks are **iterative** (`from_nl` builds sum chains thousands of nodes deep; recursion would silently disable the pass on exactly the target models) and rebuilt bodies use balanced sum trees.

**Fallback:** the pass abstains — returns the model unchanged — on any structure it cannot linearize exactly (continuous/general-integer factor in a degree≥2 monomial, transcendentals, non-constant divisors/exponents, SOS/complementarity/builder-block state, expansion or row budgets exceeded, max degree < 3). Adoption in `solve_model` reuses the integer-bilinear pass's guard (pure MILP per **both** `classify_problem` and the DAG-walking `classify_nonlinear_terms`, issue #286 rationale) and its routing (`presolve=False`, monolithic Rust simplex engine unless the cert:P3.1c flag keeps the cut path).

Also: `model_to_sympy` now counts `{0,1}`-bounded `INTEGER` elements as binary (the recognizer-layer detector gap flagged in the issue).

## Evidence (synthetic Bernasconi instances)

The real `autocorr_bern*` `.nl` files are not vendored (#163) and minlplib.org is denied by this environment's network policy, so measurements use a generator of the mathematically identical class (`min Σₖ(Σᵢ sᵢsᵢ₊ₖ)²`, `s = 2b−1`, `{0,1}` INTEGER vars), including `to_nl`→`from_nl` round trips and the objvar defining-row convention.

| instance (dense, K=n−1) | before (this branch's base) | after |
|---|---|---|
| n=8 | 65 s, `feasible`, no certificate | **0.3 s, `optimal`** (= brute force) |
| n=10 | >60 s, no certificate | **0.9 s, `optimal`** (= brute force) |
| n=13 | — | **3.7 s, `optimal`** (= brute force) |
| n=25 (the 25-25 class) | no return in 120 s | **returns at 30 s** with valid dual bound 12.0 (+ incumbent in most runs), ~1 GB RSS |
| n=35 | no return | returns at ~30 s with valid dual bound 17.0 |

Optima verified against brute-force enumeration for all n ≤ 13; objvar `==`/`≥` forms and MAX-sense verified likewise. The residual gap at n=25/35 is the in-house MILP engine's LP throughput on ~1–3k-row instances (dense marshaling), not the reformulation — tracked separately if desired.

## Soundness gates (from the issue)

- [x] Fortet linearization exact for 0/1 products — property-tested `aux == prod(binaries)` at all integer points (`test_fortet_aux_equals_product_at_all_integer_points`), plus secant-grid exactness at every attainable point.
- [x] Clean fallback to the existing paths when not pure-binary-multilinear (5 abstention tests incl. mixed-witness models; corpus scan: the gate fires on **0 of 65** vendored `.nl` instances — the pass is a strict no-op on the entire in-repo corpus).
- [x] 0 SUSPECT / no certified problem regresses: `test_convexity_minlplib_suspect.py` 29 passed; full verification below.

## Verification run

- `pytest python/tests/test_binary_multilinear_reform.py` — **25 passed** (new; the end-to-end test fails before the change: n=8 burned >60 s on the spatial path without certificate)
- `pytest discopt_benchmarks/tests -m smoke` — passed
- `pytest python/tests -m smoke` — **651 passed, 7 skipped**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed** (a first run concurrent with the smoke suite flaked 2 wall-clock-margin tests — `hda`, `test_large_dense_jacobian_no_crash`; both pass standalone and neither model triggers the new gate)
- `pytest` on `test_cut_recognizer.py`, `test_recognizer_adversarial.py`, `test_patterns.py`, `test_integer_bilinear.py`, `test_issue_286_false_unbounded.py` — **84 passed**
- `ruff check` / `ruff format --check` clean; `mypy` — 0 errors in the new module

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgMKFo6dCDkmjquLuLTiwF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgMKFo6dCDkmjquLuLTiwF)_