### PR TITLE
feat(heuristics): #188 continuous stratified multistart at the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ The release procedure that produces these entries is documented in
 
 ## [Unreleased]
 
+### Added
+
+- **Continuous stratified multistart at the root** (`feat`, #188). Pure-continuous
+  nonconvex models had zero basin diversification on the spatial McCormick-LP
+  path: the integer-centric primal heuristics (pump/ILS/diving/RINS/RENS) all
+  no-op without integers, the root multistart NLP is skipped there, and the
+  strided node NLP warm-starts from the parent point — so the incumbent stayed
+  locked in the first LP-vertex basin (kall_congruentcircles_c51: parked at the
+  1.5371 two-row packing vs the 1.0730 global). `solve_model` now runs a
+  budgeted, deadline-gated stratified multistart
+  (`primal_heuristics.continuous_multistart`) once at the root for nonconvex
+  models with no integer variables; the c51-class reconstruction reaches the
+  1.07301 global on the default path (siblings and the C-38 `kall_circles_c8a`
+  soundness lock unregressed). Primal-only (heuristic-policy regime): every
+  point is constraint-re-verified and `inject_incumbent` enforces strict
+  improvement, so dual bounds and certificates are untouched.
+  `DISCOPT_CONTINUOUS_MULTISTART=0` / `SolverTuning.continuous_multistart=False`
+  restores the prior behavior.
+
 ## [0.6.0] - 2026-07-12
 
 ### Removed

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -199,6 +199,22 @@ early incumbent + more budget for the bound).
 do — these are sound suboptimal points); nothing is certified optimal without the
 bound (`gap_certified` discipline). Low correctness risk.
 
+> **Incumbent *quality* sub-gap closed (2026-07-16, #188).** CC4's latency framing
+> did not cover the basin-quality gap on pure-continuous nonconvex models: that
+> class had zero diversification end to end (pump/ILS/diving/RINS/RENS no-op with
+> no integers; root multistart skipped on the MC-LP path; node NLPs warm-start
+> from the parent point), so kall_congruentcircles_c51 parked at the 1.5371
+> two-row local packing forever. Fix: root stratified continuous multistart
+> (`primal_heuristics.continuous_multistart`, `DISCOPT_CONTINUOUS_MULTISTART`,
+> default ON) — c51 reconstruction now reaches the 1.07301 global (c41 sibling
+> and kall_circles_c8a C-38 lock unregressed).
+> **Falsified in passing:** #188's "random multistart is a confirmed dead end
+> (40/40 infeasible)" does not hold on the current POUNCE backend — 54/64
+> *stratified* starts converge to constraint-verified feasible KKT points
+> (~90 ms/solve), 3/32 in the global basin on every seed tried; the 4
+> deterministic anchors and LP-vertex seeds never leave 1.54–3.23. The dead end
+> was the sampling scheme + old backend, not multistart per se.
+
 ## 6. Stage 4 — Node-count reduction (CC3; highest leverage, strictest gate)
 
 > **Entry experiment (2026-06-24) — falsified the framing below; read this first.**

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -510,6 +510,124 @@ def subnlp(
     return x_out, obj
 
 
+def continuous_multistart(
+    model: Model,
+    n_starts: int = 32,
+    seed: int = 42,
+    backend: Optional[Callable] = None,
+    nlp_options: Optional[dict] = None,
+    evaluator: Optional[NLPEvaluator] = None,
+    deadline: Optional[float] = None,
+    feas_tol: float = 1e-6,
+    incumbent_obj: Optional[float] = None,
+) -> Optional[tuple[np.ndarray, float]]:
+    """Stratified continuous multistart for pure-continuous nonconvex models.
+
+    Basin diversification for the one model class the primal-heuristic suite
+    otherwise leaves bare (issue #188): with no integers to round, flip or dive
+    on, ``feasibility_pump``/``integer_local_search``/``fractional_diving``/
+    RINS/RENS all no-op, and on the McCormick-LP spatial path the node NLPs
+    warm-start from the parent point — so every local solve stays locked in the
+    first basin the relaxation vertex happens to fall into
+    (kall_congruentcircles_c51: parks at the two-row packing 1.5371 while the
+    single-row global basin at 1.0730 is reachable by 3/32 stratified starts,
+    every seed tried).
+
+    Draws ``n_starts`` stratified samples over the variable box (the
+    :func:`_generate_starts` Latin-hypercube-style sampler MultiStartNLP uses)
+    and runs one local NLP from each, keeping the best *constraint-verified*
+    point. Deadline-gated between starts; each solve is individually capped so
+    one pathological start cannot eat the remaining budget.
+
+    Scope guard: returns ``None`` untried when the model has any integer
+    variable — integer models have a full heuristic arsenal already, and a
+    relaxed-integer local optimum is useless as an incumbent there.
+
+    Sound (heuristic-policy regime, CLAUDE.md §5): a primal-side finder only.
+    Every returned point is re-verified with ``_check_constraint_feasibility``
+    and the caller's ``inject_incumbent`` enforces strict improvement, so the
+    dual bound and the certificate math are untouched by construction.
+
+    Args:
+        model: The optimization model (must be pure-continuous to act).
+        n_starts: Number of stratified starting points.
+        seed: RNG seed for the stratified sampler (fixed for determinism).
+        backend: ``solve_nlp(evaluator, x0, options=...)`` callable. If None,
+            uses :func:`discopt.solvers.nlp_backend.get_nlp_solver('auto')`.
+        nlp_options: Options dict forwarded to the NLP backend.
+        evaluator: Pre-built NLPEvaluator; one is constructed if omitted.
+        deadline: Absolute ``time.perf_counter()`` deadline. Starts are skipped
+            once it has passed; the loop never begins a solve it cannot fit.
+        feas_tol: Constraint-feasibility tolerance for accepting a point.
+        incumbent_obj: Current incumbent objective, if any. Purely
+            informational for early exit bookkeeping — points are kept only if
+            they beat it, but the caller's injection still re-checks.
+
+    Returns:
+        ``(x, obj)`` for the best constraint-feasible local optimum found that
+        beats ``incumbent_obj`` (when given), else ``None``.
+    """
+    int_mask = _get_integer_mask(model)
+    if np.any(int_mask):
+        return None
+    if n_starts <= 0:
+        return None
+
+    if backend is None:
+        from discopt.solvers.nlp_backend import get_nlp_solver
+
+        backend = get_nlp_solver("auto")
+    if evaluator is None:
+        evaluator = cached_evaluator(model)
+
+    lb, ub = _get_variable_bounds(model)
+    rng = np.random.default_rng(seed)
+    starts = _generate_starts(lb, ub, n_starts, rng)
+
+    opts = dict(nlp_options) if nlp_options else {}
+    opts.setdefault("print_level", 0)
+    opts.setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)
+
+    best_obj = float("inf") if incumbent_obj is None else float(incumbent_obj)
+    best_x: Optional[np.ndarray] = None
+
+    for i in range(n_starts):
+        remaining = np.inf if deadline is None else deadline - time.perf_counter()
+        if remaining <= 0.05:
+            break
+        solve_opts = dict(opts)
+        if np.isfinite(remaining):
+            # Cap the single solve so a stiff start cannot eat the whole budget,
+            # while still letting a typical (sub-second) local solve converge.
+            solve_opts.setdefault("max_wall_time", float(min(3.0, remaining)))
+        try:
+            res = backend(evaluator, starts[i], options=solve_opts)
+        except BaseException:
+            # PyO3 backends can raise PanicException (not an Exception subclass).
+            continue
+        # Accept OPTIMAL or ITERATION_LIMIT — the point is independently
+        # re-verified below, mirroring subnlp's acceptance set.
+        if res.status not in (SolveStatus.OPTIMAL, SolveStatus.ITERATION_LIMIT):
+            continue
+        if res.x is None or res.objective is None:
+            continue
+        obj = float(res.objective)
+        if not np.isfinite(obj) or obj >= best_obj:
+            continue
+        x_out = np.asarray(res.x, dtype=np.float64)
+        if not _check_constraint_feasibility(evaluator, x_out, tol=feas_tol):
+            continue
+        # Keep the verified objective consistent with the evaluator.
+        obj = float(evaluator.evaluate_objective(x_out))
+        if obj < best_obj:
+            best_obj = obj
+            best_x = x_out.copy()
+
+    if best_x is None:
+        return None
+    return best_x, best_obj
+
+
 def integer_local_search(
     model: Model,
     x_relax: np.ndarray,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7477,6 +7477,61 @@ def solve_model(
                     except Exception as e:
                         logger.debug("Fractional diving failed: %s", e)
 
+            # --- Continuous stratified multistart (issue #188) ---
+            # Pure-continuous nonconvex models are the one class the heuristic
+            # suite above leaves bare: with no integers to round/flip/dive on,
+            # pump, ILS and diving all no-op, the root multistart NLP is skipped
+            # on this (McCormick-LP) path, and the strided node NLP warm-starts
+            # from the parent point — so the incumbent stays locked in whatever
+            # basin the first LP-vertex-seeded local solve lands in
+            # (kall_congruentcircles_c51: 1.5371 two-row packing vs the 1.0730
+            # global row basin, reached by 3/32 stratified starts on every seed
+            # tried). Run one budgeted stratified multistart at the root.
+            # Sound (heuristic-policy regime, CLAUDE.md §5): a primal finder
+            # only — the point is constraint-re-verified here and
+            # ``inject_incumbent`` enforces strict improvement, so the dual
+            # bound and certificate math are untouched.
+            if (
+                _tuning().continuous_multistart
+                and _mc_lp_relaxer is not None
+                and not _model_is_convex
+                and not _lns_has_integers
+                and not _root_optimum_proven()
+                and _root_heur_nlp_entry_ok(evaluator)
+            ):
+                try:
+                    from discopt._jax.primal_heuristics import continuous_multistart
+
+                    _cms_inc = tree.incumbent()
+                    _cms_inc_obj = (
+                        float(_cms_inc[1])
+                        if _cms_inc is not None and _cms_inc[1] < _SENTINEL_THRESHOLD
+                        else None
+                    )
+                    _t_cms = time.perf_counter()
+                    _cms = continuous_multistart(
+                        model,
+                        n_starts=int(min(64, max(32, 2 * int(np.size(lb))))),
+                        backend=_resolve_heuristic_backend(nlp_solver),
+                        evaluator=evaluator,
+                        deadline=min(
+                            _deadline,
+                            time.perf_counter() + max(2.0, min(15.0, 0.2 * float(time_limit))),
+                        ),
+                        incumbent_obj=_cms_inc_obj,
+                    )
+                    _observe_heur_nlp(time.perf_counter() - _t_cms)
+                    if _cms is not None:
+                        _x_cms, _obj_cms = _cms
+                        _cms_feas = not cl_list or _check_constraint_feasibility(
+                            evaluator, _x_cms, cl_list, cu_list
+                        )
+                        if np.isfinite(_obj_cms) and _obj_cms < _SENTINEL_THRESHOLD and _cms_feas:
+                            tree.inject_incumbent(np.asarray(_x_cms).copy(), float(_obj_cms))
+                            logger.info("Continuous multistart found incumbent: obj=%.6g", _obj_cms)
+                except Exception as e:
+                    logger.debug("Continuous multistart failed: %s", e)
+
         # --- SubNLP primal heuristic ---
         # Fix integers in the best relaxation solution, then solve the
         # resulting continuous NLP. Useful for nonconvex problems whose

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -362,6 +362,31 @@ class SolverTuning:
     improvement, so the dual bound and gap certification are byte-identical to the
     fixed-stride run; only *which* nodes get a primal probe changes."""
 
+    continuous_multistart: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_CONTINUOUS_MULTISTART", default=True)
+    )
+    """Stratified continuous multistart at the root for pure-continuous
+    nonconvex models (``DISCOPT_CONTINUOUS_MULTISTART``, default ON; issue #188).
+
+    The primal-heuristic suite is integer-centric: on a model with no integer
+    variables, pump/ILS/diving/RINS/RENS all no-op, the root multistart NLP is
+    skipped on the McCormick-LP spatial path, and the strided node NLP
+    warm-starts from the parent point — zero basin diversification end to end.
+    Measured on the kall_congruentcircles_c51 class (#188): the default path
+    parks at the 1.5371 two-row local packing forever, while 32 stratified
+    starts (~2.8 s, ~90 ms/solve) reach the 1.0730 global basin on every seed
+    tried; the 4 deterministic anchors and the LP-vertex-seeded solves never do.
+
+    When ON, ``solve_model`` runs ``primal_heuristics.continuous_multistart``
+    once at the end of the root iteration on the spatial McCormick-LP path for
+    nonconvex models with no integer variables: ``min(64, max(32, 2·n))``
+    stratified starts, deadline-gated between starts and per-solve capped, seed
+    fixed for determinism. Sound (heuristic-policy regime, CLAUDE.md §5): a
+    primal finder only — every point is constraint-re-verified and
+    ``inject_incumbent`` enforces strict improvement; the dual bound and
+    certificate math are untouched. Set ``DISCOPT_CONTINUOUS_MULTISTART=0`` to
+    restore the prior behavior."""
+
     ils_solve_cap: int = field(default_factory=lambda: _env_int("DISCOPT_ILS_SOLVE_CAP", 2))
     """Sub-NLP solve cap for the ``integer_local_search`` objective-descent
     (``DISCOPT_ILS_SOLVE_CAP``, **default 2 = ON** since ILS-DEFAULT, #530-followup).

--- a/python/tests/test_issue_188_continuous_multistart.py
+++ b/python/tests/test_issue_188_continuous_multistart.py
@@ -1,0 +1,173 @@
+"""Regression lock for issue #188: continuous stratified multistart at the root.
+
+``kall_congruentcircles_c51`` (Kallrath circle packing; MINLPLib oracle
+``=best= 1.0730``) exposed a nonconvex global-search capability gap: the
+default spatial path returned the 1.5371 two-row-packing local optimum and
+never escaped its basin. Root cause: pure-continuous nonconvex models had
+ZERO basin diversification end to end — the integer-centric primal heuristics
+(pump/ILS/diving/RINS/RENS) all no-op with no integers to round or flip, the
+root multistart NLP is skipped on the McCormick-LP spatial path, and the
+strided node NLP warm-starts from the parent point, so every local solve
+stays locked in the basin of the first LP-vertex seed.
+
+The fix (general, class-level — no problem-name special cases): a budgeted
+stratified continuous multistart at the root
+(``primal_heuristics.continuous_multistart``), wired for nonconvex models with
+no integer variables on the McCormick-LP path, behind
+``SolverTuning.continuous_multistart`` (``DISCOPT_CONTINUOUS_MULTISTART``,
+default ON). Measured: 32 stratified starts reach the 1.0730 global basin on
+every seed tried (~2.8 s, ~90 ms/solve), while all 4 deterministic anchors and
+the LP-vertex seeds converge to 1.54-3.23 local optima.
+
+The MINLPLib instance is not vendored (#163) and the network-restricted CI
+cannot fetch it, so these tests run on a faithful reconstruction of the
+Kallrath generator (pattern extracted from the vendored
+``kall_circles_c8a.nl``): same variable/constraint structure (the .nl carries
+one extra defined objvar variable + defining row), same operator classes
+(bilinear area equality, reverse-convex pairwise separation, linear
+containment/ordering), and the same certified landscape — the single-row
+global at ``n - n*pi/4`` (c51: 1.07301, c41: 0.85841 — MINLPLib ``=best=``)
+and the two-row local basin at 1.5371 that #188 reported discopt parking in
+(reproduced to all published digits by this reconstruction pre-fix).
+
+Soundness: the heuristic is a primal finder only (heuristic-policy regime,
+CLAUDE.md §5) — every point is constraint-re-verified and
+``inject_incumbent`` enforces strict improvement, so dual bounds and
+certificates are untouched; the assertions below lock that too (bound must
+stay a valid underestimator, incumbent must never beat the true optimum).
+"""
+
+import math
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.solver_tuning import SolverTuning
+
+_R = 0.5
+
+# MINLPLib =best= oracles; analytically n - n*pi/4 (single-row packing, area n).
+_C51_GLOBAL = 5 - 5 * math.pi / 4  # 1.0730091830...
+_C41_GLOBAL = 4 - math.pi  # 0.8584073464...
+# The two-row local basin #188 reported the solver parking in (area 2(1+sqrt 3)).
+_C51_TWO_ROW_LOCAL = 2 * (1 + math.sqrt(3)) - 5 * math.pi / 4  # 1.5371107...
+
+# Feasibility tolerance (1e-6 on the separation rows) admits incumbents a hair
+# below the analytic optimum; keep the soundness guard just past that slack.
+_FEAS_SLACK = 1e-4
+
+
+def make_congruent_circles(n: int, a_max: float, b_max: float) -> "dm.Model":
+    """Kallrath congruent-circles generator (reconstruction, see module doc)."""
+    m = dm.Model(name=f"congruentcircles_c{n}1_recon")
+    xs = [m.continuous(f"x{i}", lb=_R, ub=a_max - _R) for i in range(n)]
+    ys = [m.continuous(f"y{i}", lb=_R, ub=b_max - _R) for i in range(n)]
+    a = m.continuous("a", lb=0.0, ub=a_max)
+    b = m.continuous("b", lb=0.0, ub=b_max)
+    t = m.continuous("t", lb=(2 * _R) ** 2 / 4.0, ub=a_max * b_max)
+
+    m.subject_to(t - a * b == 0.0)
+    for i in range(n):
+        for j in range(i + 1, n):
+            m.subject_to(
+                (xs[i] - xs[j]) * (xs[i] - xs[j]) + (ys[i] - ys[j]) * (ys[i] - ys[j])
+                >= (2 * _R) ** 2
+            )
+    for i in range(n):
+        m.subject_to(xs[i] - a <= -_R)
+        m.subject_to(ys[i] - b <= -_R)
+    m.subject_to(xs[0] <= a_max / 2.0)
+    m.subject_to(ys[0] <= b_max / 2.0)
+    for i in range(n):
+        for j in range(i + 1, n):
+            m.subject_to(xs[i] - xs[j] <= 0.0)
+
+    m.minimize(t - n * math.pi * _R * _R)
+    return m
+
+
+def _build_c51() -> "dm.Model":
+    # Variant-1 box: strip long enough for the single-row global optimum,
+    # width admitting the two-row local basin observed in #188.
+    return make_congruent_circles(5, a_max=5.0, b_max=2.1)
+
+
+def test_continuous_multistart_reaches_global_basin_unit():
+    """The heuristic itself must find the c51 global row basin (fast, no B&B)."""
+    from discopt._jax.primal_heuristics import continuous_multistart
+
+    model = _build_c51()
+    result = continuous_multistart(model, n_starts=32, seed=42)
+    assert result is not None, "continuous multistart found no feasible point at all"
+    x, obj = result
+    assert obj <= _C51_GLOBAL + 1e-3, (
+        f"multistart best {obj!r} did not reach the global basin {_C51_GLOBAL:.6f} "
+        f"(pre-#188 landscape: best reachable local was {_C51_TWO_ROW_LOCAL:.6f})"
+    )
+    # Soundness: a feasible point can undershoot the analytic optimum only by
+    # constraint-tolerance slack, never materially.
+    assert obj >= _C51_GLOBAL - _FEAS_SLACK
+    assert np.all(np.isfinite(x))
+
+
+def test_continuous_multistart_noops_on_integer_models():
+    """Scope guard: integer models keep their own heuristic arsenal; the
+    continuous multistart must decline them untried."""
+    from discopt._jax.primal_heuristics import continuous_multistart
+
+    m = dm.Model(name="int_scope_guard")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    z = m.integer("z", lb=0, ub=3)
+    m.subject_to(x * x + z >= 2.0)
+    m.minimize(x * x - z)
+    assert continuous_multistart(m, n_starts=4, seed=0) is None
+
+
+def test_flag_parses_and_defaults_on(monkeypatch):
+    monkeypatch.delenv("DISCOPT_CONTINUOUS_MULTISTART", raising=False)
+    assert SolverTuning().continuous_multistart is True
+    monkeypatch.setenv("DISCOPT_CONTINUOUS_MULTISTART", "0")
+    assert SolverTuning().continuous_multistart is False
+
+
+def test_solve_reaches_c51_global_on_default_path():
+    """End-to-end #188 lock: the DEFAULT path must reach the c51 global basin.
+
+    Pre-fix this fails with objective 1.5371107... (the two-row local packing,
+    reproduced from #188 to all published digits); post-fix the root multistart
+    lands the 1.07301 row packing. Also locks soundness: the dual bound stays a
+    valid underestimator and the incumbent never materially beats the analytic
+    optimum.
+    """
+    r = _build_c51().solve(time_limit=30, gap_tolerance=1e-4)
+
+    assert r.objective is not None, "expected a feasible incumbent"
+    assert r.objective <= _C51_GLOBAL + 1e-3, (
+        f"incumbent {r.objective!r} did not reach the global {_C51_GLOBAL:.6f} "
+        f"(#188 regression: parked in a local basin, e.g. {_C51_TWO_ROW_LOCAL:.6f}?)"
+    )
+    assert r.objective >= _C51_GLOBAL - _FEAS_SLACK, (
+        f"incumbent {r.objective!r} is below the true optimum {_C51_GLOBAL:.6f} "
+        f"beyond feasibility-tolerance slack — unsound incumbent"
+    )
+    if r.bound is not None and np.isfinite(r.bound):
+        assert r.bound <= r.objective + 1e-6, (
+            f"dual bound {r.bound!r} exceeds the incumbent {r.objective!r} — "
+            f"certificate invariant violated"
+        )
+
+
+@pytest.mark.slow
+def test_solve_sibling_c41_no_regress():
+    """#188 acceptance: the smaller sibling (already solved pre-fix) must keep
+    reaching its global 0.85841."""
+    r = make_congruent_circles(4, a_max=4.0, b_max=2.1).solve(time_limit=25, gap_tolerance=1e-4)
+    assert r.objective is not None
+    assert r.objective <= _C41_GLOBAL + 1e-3
+    assert r.objective >= _C41_GLOBAL - _FEAS_SLACK
+    if r.bound is not None and np.isfinite(r.bound):
+        assert r.bound <= r.objective + 1e-6


### PR DESCRIPTION
Pure-continuous nonconvex models had zero basin diversification on the
spatial McCormick-LP path: pump/ILS/diving/RINS/RENS all no-op with no
integers to round or flip, the root multistart NLP is skipped there, and
the strided node NLP warm-starts from the parent point — so the incumbent
stayed locked in whatever basin the first LP-vertex-seeded local solve
landed in. kall_congruentcircles_c51 (#188) parked at the 1.5371 two-row
packing while the 1.0730 single-row global basin is reachable by 3/32
stratified starts on every seed tried (~90 ms/solve, measured).

Fix (general, class-level — no problem-name special cases):
- primal_heuristics.continuous_multistart: budgeted stratified multistart
  (the _generate_starts LHS sampler), deadline-gated between starts,
  per-solve wall-capped, constraint-re-verified, integer models declined.
- solve_model wires it once at the end of the root iteration on the
  McCormick-LP path for nonconvex models with no integer variables, after
  the existing heuristic ladder; skipped when the root already proved
  optimality or the budget gate says no room.
- SolverTuning.continuous_multistart / DISCOPT_CONTINUOUS_MULTISTART,
  default ON; =0 restores the prior behavior exactly.

Sound (heuristic-policy regime, CLAUDE.md §5): primal finder only — every
point re-verified feasible, inject_incumbent enforces strict improvement;
dual bounds and certificate math untouched.

The MINLPLib kall instances are not vendored (#163), so the regression
lock runs on a faithful reconstruction of the Kallrath generator (pattern
extracted from the vendored kall_circles_c8a.nl) that reproduces the
1.5371107 parking to all published digits pre-fix and reaches the
1.0730091 global post-fix; sibling c41 (0.85841) locked too.

Verification: new tests fail pre-change (flag OFF reproduces 1.5371107)
and pass post-change; python/tests -m smoke 651 passed;
discopt_benchmarks/tests -m smoke 49 passed; adversarial suite 10/10;
test_c38_kall_circles_false_optimal (same class, heuristic fires) green;
ruff clean; mypy adds no new errors; Rust untouched.

Also records in docs/dev/performance-plan.md (CC4) the falsification of
#188's 'random multistart is a confirmed dead end': 54/64 stratified
starts converge to feasible KKT points on the current POUNCE backend —
the dead end was the sampling scheme + old backend, not multistart.

Closes #188.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PTqKe581RRVhpbHLsgzQRK