### PR TITLE
fix(tests): #665 — restore batch-path coverage with wide-frontier models

### DIFF
--- a/python/tests/test_batch_sentinel_soundness.py
+++ b/python/tests/test_batch_sentinel_soundness.py
@@ -30,30 +30,34 @@ import pytest
 def _build_nonconvex_minlp() -> tuple[dm.Model, dict]:
     """Nonconvex MINLP that branches into a multi-node frontier.
 
-    The integer ``x`` makes the root relaxation fractional, so the tree opens
-    several nodes at once: ``export_batch`` returns >1 node and the POUNCE
-    batch path (``n_batch > 1``) runs. The ``sin`` term keeps the model
-    nonconvex and out of the MIQP class and — crucially — leaves it free of
-    bilinear products, so the spatial-BB McCormick LP relaxer is inactive.
-    That matters because the relaxer would otherwise rescue a failed node-NLP
-    solve with a valid LP bound; without it, the failure sentinel survives to
-    the decertification guard. The optimum is x=0, y≈3.665 (1.3*0 + sin≈-1.0 =
-    -1.0); the warm start (x=8, y=5) is feasible but far worse, so pruning the
-    whole tree off failure sentinels and certifying the gap would report a
-    badly wrong "optimal".
+    The integer ``x`` has a *fractional* root relaxation here: minimizing
+    ``-1.3 x`` drives ``x`` up against the linear cap ``2x + y <= 5``, and at the
+    relaxed optimum (``y = 0``) that pins ``x = 2.5``. The tree therefore
+    branches on ``x`` (children ``x <= 2`` and ``x >= 3``) and opens several
+    nodes at once: ``export_batch`` returns >1 node and the POUNCE batch path
+    (``n_batch > 1``) runs. (A root relaxation that is already integer-feasible
+    would converge at the root and never form a batch — that is exactly why the
+    earlier model here stopped exercising the batch path; see issue #665.) The
+    ``sin`` term keeps the model nonconvex and out of the MIQP class and —
+    crucially — leaves it free of bilinear products, so the spatial-BB McCormick
+    LP relaxer is inactive. That matters because the relaxer would otherwise
+    rescue a failed node-NLP solve with a valid LP bound; without it, the
+    failure sentinel survives to the decertification guard. The optimum is
+    x=2, y=0 (-1.3*2 + sin(0) = -2.6); the warm start (x=0, y=0 -> obj 0) is
+    feasible but far worse, so pruning the whole tree off failure sentinels and
+    certifying the gap would report a badly wrong "optimal".
     """
     m = dm.Model("sentinel_soundness")
     x = m.integer("x", lb=0, ub=8)
     y = m.continuous("y", lb=0, ub=5)
-    m.minimize(2 * x + dm.sin(3 * y) - 0.7 * x)
-    m.subject_to(3 * x + 2 * y >= 7)
-    m.subject_to(x - y <= 3)
-    warm = {x: 8, y: 5.0}
+    m.minimize(-1.3 * x + dm.sin(3 * y))
+    m.subject_to(2 * x + y <= 5)
+    warm = {x: 0, y: 0.0}
     return m, warm
 
 
-# Optimum of the model above: x=0, y≈3.665 -> 1.3*0 + sin(3y)≈-1.0.
-_OPT = -1.0
+# Optimum of the model above: x=2, y=0 -> -1.3*2 + sin(0) = -2.6.
+_OPT = -2.6
 
 
 def _all_sentinel_batch(evaluator, batch_lb, batch_ub, batch_ids, n_vars, *args, **kwargs):

--- a/python/tests/test_pounce_batch.py
+++ b/python/tests/test_pounce_batch.py
@@ -155,17 +155,47 @@ def test_batch_pounce_marks_infeasible_nodes():
     assert np.all(np.abs(rlb) >= _SENTINEL)
 
 
+def _wide_bilinear_pool() -> dm.Model:
+    """A pooling-style bilinear (nonconvex) NLP with a genuinely wide B&B tree.
+
+    Two bilinear "blend" terms in the objective plus two bilinear capacity
+    constraints force the spatial branch-and-bound to open many nodes before it
+    closes the gap (the McCormick root relaxation does not converge at the
+    root), so the batch path fires repeatedly with ``n_batch > 1``. Contrast
+    with pooling-Haverly, whose root relaxation + NLP multistart nails the
+    global optimum in ~3 nodes, so the frontier never grows past a single node
+    and the batch path is never reached through ``solve()`` dispatch (issue
+    #665 — this is by-design solver behavior, not a batch-formation regression).
+
+    Certified global optimum obj = -12.8, established by discopt's own global
+    solver on both the ``ipm`` and ``pounce`` node engines (agreeing objective
+    and sound dual bound). It is used only as a known-correct fixed point here.
+    """
+    m = dm.Model("wide_bilinear_pool")
+    x = [m.continuous(f"x{i}", lb=0, ub=5) for i in range(4)]
+    m.minimize(-(x[0] * x[1]) - (x[2] * x[3]) + sum(xi * xi for xi in x) * 0.1)
+    m.subject_to(x[0] + x[1] + x[2] + x[3] <= 8)
+    m.subject_to(x[0] * x[2] <= 6)
+    m.subject_to(x[1] * x[3] <= 6)
+    return m
+
+
 @pytest.mark.correctness
 @pytest.mark.slow
-def test_pounce_batch_end_to_end_pooling(monkeypatch):
-    """A wide-tree nonconvex MINLP exercises the batch path and is correct.
+def test_pounce_batch_end_to_end_wide_bilinear(monkeypatch):
+    """A wide-tree nonconvex bilinear NLP exercises the batch path and is correct.
 
-    Pooling-Haverly is below the default ``_POUNCE_BATCH_MIN_VARS`` size gate
-    (n_vars=6), so the threshold is lowered here to drive the integration; the
-    gate's own behavior is covered by ``test_pounce_size_gate_keeps_small_serial``.
+    The batch path fires only when the tree holds >1 open node at export time
+    (``n_batch > 1``). Small problems whose root relaxation already nails the
+    global optimum (pooling-Haverly, the old model here) converge at the root
+    and never form a multi-node frontier, so the batch path is never reached
+    through ``solve()`` — by design (issue #665). This model keeps the spatial
+    tree genuinely wide, so ``export_batch`` returns multi-node batches.
+
+    The model has 4 variables, below the default ``_POUNCE_BATCH_MIN_VARS`` size
+    gate, so the threshold is lowered here to drive the integration; the gate's
+    own behavior is covered by ``test_pounce_size_gate_keeps_small_serial``.
     """
-    from discopt.modeling.examples import example_pooling_haverly
-
     monkeypatch.setattr(S, "_POUNCE_BATCH_MIN_VARS", 0)
 
     sizes: list[int] = []
@@ -177,19 +207,12 @@ def test_pounce_batch_end_to_end_pooling(monkeypatch):
         return r
 
     monkeypatch.setattr(S, "_solve_batch_pounce", spy)
-    model = example_pooling_haverly()
+    model = _wide_bilinear_pool()
     res = model.solve(nlp_solver="pounce", batch_size=16, time_limit=120)
 
-    # Pooling-Haverly is nonconvex: the McCormick relaxation bounds do not
-    # rigorously close the gap, and spatial-branch nodes whose NLP relaxation
-    # fails carry no rigorous lower bound. Per the #27a soundness guard
-    # (applied on the serial path and, since the batch-sentinel fix, on the
-    # batch path too), such a search reports the correct incumbent as
-    # "feasible" rather than claiming a certificate it does not hold. Every
-    # solve path (pounce/ipm × batch/serial) agrees on "feasible" here.
     assert res.status in ("optimal", "feasible")
-    # Haverly pooling global optimum (this formulation): -400 profit => 1390 obj.
-    assert res.objective == pytest.approx(1390.0, abs=1.0, rel=1e-3)
+    # Certified global optimum (ipm and pounce agree; sound dual bound).
+    assert res.objective == pytest.approx(-12.8, abs=1e-2, rel=1e-3)
     # The batch path must have actually fired with more than one node.
     assert sizes, "pounce batch path never triggered"
     assert max(sizes) > 1, f"batch never exceeded one node: {sizes}"


### PR DESCRIPTION
Closes #665.

## Central question: by-design, not a regression

The two `correctness`-marked batch-soundness tests failed because `Model.solve()`
never dispatched to `_solve_batch_pounce`: the B&B never held `n_batch > 1` open
nodes at export time, so the `if _use_pounce_batch and n_batch > 1:` gate was
never satisfied. I investigated whether `tree.export_batch` / frontier batching
had regressed, and it has **not**:

- **`export_batch` is healthy.** It selects up to `batch_size` open nodes via
  `select_next()` and returns them. Instrumenting a genuinely wide nonconvex
  tree (a bilinear pooling-style NLP) through the *full* `solve()` dispatch
  produced multi-node batches (sizes up to 6) and fired `_solve_batch_pounce`
  23× with `n_batch > 1`. The passing `test_p03_trust_gate.py::test_batch_untrusted_node_decertifies`
  already relies on this same dispatch with a fractional-root convex MINLP.
- **The two failing models simply converge at/near the root.** The old sentinel
  model's integer root relaxation is already integer-feasible (`x=0`), so `x` is
  never branched — the tree finishes in 3 nodes with a single 1-node export.
  Pooling-Haverly's root McCormick relaxation + NLP multistart nails the global
  optimum (`400`) in ~3 nodes, so its frontier never grows past one node either.
  Finding and certifying the optimum at the root is correct, desirable solver
  behavior — not a batch-formation bug.

So this is the **by-design** branch of #665's central question. The fix reworks
the two tests to guard what they are meant to guard, using models that *provably*
form a ≥2-node batch through `solve()` dispatch. No solver code changed; no
soundness assertion was weakened.

## Changes

- **`test_batch_sentinel_soundness.py`** — new model `-1.3x + sin(3y)` s.t.
  `2x + y <= 5`. Minimizing `-1.3x` drives `x` against the linear cap, so the
  root relaxation pins `x = 2.5` (fractional) → the tree branches on `x` and
  opens a multi-node frontier. Kept nonconvex and **bilinear-free** (as the
  original intended) so the McCormick LP relaxer stays inactive and a failed
  node-NLP's `INFEASIBILITY_SENTINEL` survives to the decertification guard.
  The soundness assertions are **unchanged** (bound never above the optimum; any
  certification is of the *true* optimum). Optimum is now `x=2, y=0 → -2.6`; the
  warm start `(0,0) → 0` is feasible but far worse. With the all-fail batch
  monkeypatch the batch path now fires (20 calls) and the solver still keeps a
  sound bound and certifies only the true optimum.
- **`test_pounce_batch.py`** — replaced `test_pounce_batch_end_to_end_pooling`
  (pooling-Haverly, which converges at the root) with
  `test_pounce_batch_end_to_end_wide_bilinear`, a bilinear pooling-style NLP
  whose spatial tree stays genuinely wide (batch fires repeatedly, sizes > 1).
  Certified global optimum `-12.8` (both `ipm` and `pounce` node engines agree
  with a sound dual bound). This also retires the stale `1390.0` objective
  assertion the issue flagged. The size-gate control test
  (`test_pounce_size_gate_keeps_small_serial`) still uses pooling-Haverly and
  its correct `400.0` optimum, unchanged.

## Verification

- Target tests (`-m ''`): `test_batch_sentinel_soundness.py` +
  `test_pounce_batch.py` → **8 passed**.
- `pytest -m smoke` → **653 passed, 1 skipped**.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**.
- `ruff check` + `ruff format --check` on both files → clean.
- No Rust touched (tests-only change), so no `cargo test` / `maturin` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
