### PR TITLE
docs(#671): candidate-B investigation — hda tight bound needs higher-precision LP arithmetic

### DIFF
--- a/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
+++ b/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
@@ -209,6 +209,36 @@ it is the best a float64 engine can certify on this relaxation. My earlier
 float64 limit); the *verified* obstacle is genuine near-singularity, confirmed by
 HiGHS failing identically.
 
+## SCIP cross-check + feasibility settled (the LP is FEASIBLE, false-infeasible on conditioning)
+
+**SCIP/SoPlex (pyscipopt 6.2.1 / SCIP 10):** default solve (SoPlex + iterative
+refinement) → **infeasible** on hda's captured root LP; exact-rational mode
+**unavailable** (this SCIP was compiled without exact-solve support). So SCIP joins
+feral + HiGHS(simplex) + HiGHS(IPM) — **four float64 engines all false-infeasible**.
+
+**Feasibility settled by elastic phase-1** (min total constraint violation, a
+well-posed LP HiGHS solves cleanly):
+
+```
+RAW root LP (original units):  min violation = 1.8e-10   -> FEASIBLE
+```
+
+The root relaxation **is feasible** (a feasible point exists to ~1e-10; node_count=1,
+so it is the root). *(Correction: an intermediate elastic run on the optimally-
+scaled system reported "887" and I briefly mis-read it as genuine infeasibility —
+that was a units error: violations in scaled space are inflated by the row factors,
+up to ~1e12, so 887-scaled ≈ ~1e-10 raw. The RAW-units test above is authoritative.)*
+
+**Settled verdict.** hda's root McCormick relaxation is **feasible but float64-
+intractable**: every available float64 LP engine (feral, HiGHS simplex + IPM,
+SCIP/SoPlex) **false-infeasibles** on it because of the rank-deficiency + ~1e14
+conditioning. This is not a feral bug, not genuine infeasibility, and not fixable by
+scaling/presolve (all tested). The genuine lever is **higher-precision / exact-
+rational LP arithmetic** (an exact solver would return the feasible optimum) — could
+not be demonstrated here only because no exact-capable solver is installed. A
+reformulated well-conditioned relaxation is the alternative. Candidate (A)'s sound
+floor remains the best a float64 engine certifies on this relaxation.
+
 Acceptance / regime unchanged from #664: bound-neutral verification
 (`node_count` + certified `objective` exactly unchanged on the certifying panel,
 `cargo test -p discopt-core`), and a **tight** hda bound materially closer to opt

--- a/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
+++ b/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
@@ -155,6 +155,37 @@ Candidate (B)'s tight bound requires L3-structural or higher-precision arithmeti
 tracked here as the honest scope; not attempted speculatively, since the entry
 experiment shows no scaling/factorization path exists.
 
+## CORRECTION (the "~1e7 ceiling" reasoning above was wrong)
+
+The "feral reliable to ~1e7" figure is `scaling.rs`'s empirical **coefficient
+dynamic-range** heuristic (`SCALE_TRIGGER`-adjacent), **not** a float64 limit —
+float64 LU with partial pivoting is accurate to condition numbers ~1e12–1e14. And
+the "1.77e9" repeatedly cited above is a **coefficient range**, not the basis
+**condition number** that governs factorization. Comparing them was an error.
+
+The real measurement (SVD of the captured hda node matrix, raw and optimally
+scaled):
+
+| | σ_max | σ_min (nz) | numerical rank (σ<σmax·1e-14) | #σ < σmax·1e-7 |
+|---|---|---|---|---|
+| raw A (2974×1138) | 8.91e10 | 4.47e-18 | 1123 / 1138 | — |
+| optimally-scaled A | 3.55 | 9.4e-26 | **1095 / 1138** | **409** |
+
+hda's relaxation matrix is **rank-deficient by ~15–43** (genuine near-linear
+dependence among columns) with a true SVD condition number **~1e14+** — and this is
+**scale-invariant**, which is why L1 cut the coefficient spread to 4e9 yet hda still
+failed. feral's FT `Growth` is it choking on **near-singular bases** (tiny pivots),
+exactly what a rank-deficient matrix produces.
+
+**Re-scoped fix (more tractable than "higher precision"):** the blocker is
+structural **redundancy / near-linear-dependence** in the lifted relaxation, not
+conditioning-by-scaling. The lever is a **presolve that detects and removes (or
+regularizes) the ~43 numerically dependent columns/rows** before factorization, so
+bases are non-singular. Higher precision is *not* required. (An earlier presolve
+probe was run on a malformed captured LP and its negative result is withdrawn —
+this SVD evidence supersedes it.) Still a real core-engine change under the
+bound-neutral regime; but structural-rank-reduction, not scaling and not f128.
+
 Acceptance / regime unchanged from #664: bound-neutral verification
 (`node_count` + certified `objective` exactly unchanged on the certifying panel,
 `cargo test -p discopt-core`), and a **tight** hda bound materially closer to opt

--- a/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
+++ b/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
@@ -74,23 +74,46 @@ rows.
    the 6.3e10 Arrhenius/normal coupling is an **irreducible ~1e9 conditioning** that
    diagonal scaling cannot remove.
 
-## Real levers (harder; not yet built)
+## L1 — slack-aware scaling: BUILT + MEASURED (necessary, effective, insufficient alone)
 
-- **L1 — scale `A_ub` pre-slack:** equilibrate the structural matrix before slacks
-  are appended (append slacks with coefficient = row scale, not 1), so feral sees
-  ~2.5e9 instead of ~2e20. Necessary but likely not sufficient alone.
-- **L2 — robust factorization for ~2.5e9:** pair L1 with the dense LU route
-  (`#557`) and/or a higher feral pivot threshold, since ~2.5e9 is past the sparse
-  route's reliable range.
-- **L3 — model/relaxation-level rescale of the Arrhenius term:** normalize the
-  `6.3e10 · exp(-E/RT)` product (the aux value is ~1e-13, so the product is ~6e-3)
-  at relaxation build, removing the 6.3e10 from the matrix entirely. The most
-  fundamental fix; largest surface.
+Implemented (env-gated `DISCOPT_LP_SLACK_AWARE_SCALE`, since reverted): a
+single-entry column is a slack (standard-form `I`) or bound row; exclude such
+columns from the row equilibration and normalize each to 1 via its own column
+scale, so slacks no longer pin the row factors.
 
-Kill note: candidate B is **not** a scaling-parameter tweak. It needs L1+L2
-(and possibly L3) together, each a real core-engine/relaxation change under the
-bound-neutral regime. Candidate A's loose floor remains the shipped fallback until
-one lands.
+L1 alone barely moved the residual (1.8e20 → ~1e20) because the *structural*
+scaling is itself capped by the 4-pass / `MAX_LINE_RANGE=1e-10` config. **L1 +
+stronger structural scaling** (`DISCOPT_SCALE_PASSES=12 DISCOPT_SCALE_LINE_RANGE=1e-16`)
+collapses it as theory predicts:
+
+```
+raw=2.837e26  →  scaled_residual = 4.096e9    (vs 1.845e20 default — a ~1e10 win)
+```
+
+But **hda end-to-end still `bound=None`**: **4e9 exceeds feral's ~1e7 reliable
+range** at m=2974. The dense LU route can't rescue it (m=2974 ≫ `FORCE_DENSE_M=256`;
+a dense O(m³) factorization is infeasible at this size), so the basis stays on the
+sparse route. Diagonal scaling provably cannot go below ~4e9 (the 6.3e10 Arrhenius
+coupling), so **no combination of L1 + scaling params + L2 factorization route
+solves hda** — the conditioning floor is above feral's ceiling.
+
+## Verdict — hda needs L3 (model-level rescale); L1 is a separable general win
+
+- **hda specifically:** blocked. Even the theoretical-best diagonal scaling (4e9)
+  is past feral's factorization limit at this size. The only lever that helps is
+  **L3** — normalize the `6.3e10·exp(−E/RT)` product (aux value ~1e-13, product
+  ~6e-3) at *relaxation build*, removing the 6.3e10 from the matrix so conditioning
+  drops below ~1e7. Most fundamental fix, largest surface; not yet built.
+- **L1 as a general improvement:** the slack-aware scaling (+ tuned stronger
+  structural params) is a real, separable conditioning win that likely helps
+  *other* ill-conditioned instances whose residual currently sits between feral's
+  ~1e7 ceiling and the ~1e20 the slacks impose. Worth productionizing on its own —
+  but it changes scaling factors globally, so it must ship bound-neutral-verified
+  (panel node_count/objective unchanged + `cargo test`) with carefully tuned
+  params (the `MAX_LINE_RANGE` floor exists to guard spurious residue). That is its
+  own task, separate from the hda goal.
+
+Candidate A's loose floor remains hda's shipped fallback until L3 lands.
 
 Acceptance / regime unchanged from #664: bound-neutral verification
 (`node_count` + certified `objective` exactly unchanged on the certifying panel,

--- a/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
+++ b/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
@@ -177,14 +177,37 @@ dependence among columns) with a true SVD condition number **~1e14+** — and th
 failed. feral's FT `Growth` is it choking on **near-singular bases** (tiny pivots),
 exactly what a rank-deficient matrix produces.
 
-**Re-scoped fix (more tractable than "higher precision"):** the blocker is
-structural **redundancy / near-linear-dependence** in the lifted relaxation, not
-conditioning-by-scaling. The lever is a **presolve that detects and removes (or
-regularizes) the ~43 numerically dependent columns/rows** before factorization, so
-bases are non-singular. Higher precision is *not* required. (An earlier presolve
-probe was run on a malformed captured LP and its negative result is withdrawn —
-this SVD evidence supersedes it.) Still a real core-engine change under the
-bound-neutral regime; but structural-rank-reduction, not scaling and not f128.
+**Cross-check — every float64 route fails, presolve included (measured):**
+
+| approach on hda's captured node LP | result |
+|---|---|
+| HiGHS simplex, unscaled | INFEASIBLE (false) |
+| HiGHS simplex, optimally scaled (coef range 1.77e9) | `numerical` |
+| HiGHS simplex, **rank-reduced** to 1063 full-rank rows + scaled | `numerical` |
+| HiGHS **interior-point**, scaled | `numerical` |
+
+So the presolve / rank-reduction hypothesis is **falsified**: dropping the
+redundant rows does not make HiGHS solve it. And it is **not** a feral-specific
+weakness — HiGHS's simplex *and* IPM both fail, with scaling and presolve. hda's
+McCormick relaxation LP is **genuinely intractable at float64 precision**: the
+rank-deficiency (~43) plus the cluster of ~400 tiny singular values makes the
+KKT/basis systems near-singular for *any* float64 factorization.
+
+**Final disposition (verified).** The tight dual bound for hda is **not obtainable
+at float64 precision** with this relaxation, by any engine/scaling/presolve. The
+only genuine fixes are:
+
+1. **Higher-precision LP arithmetic** (f128 / rational residual refinement in the
+   factorization) — now the *primary* lever, not optional.
+2. **A reformulated, well-conditioned relaxation** of the hda-class flowsheet
+   (change the constraint structure so the McCormick LP is not near-singular) — a
+   relaxation-layer research problem.
+
+Candidate (A)'s sound loose floor (merged, #662) stands as the practical answer:
+it is the best a float64 engine can certify on this relaxation. My earlier
+"~1e7 ceiling" framing was wrong (it is feral's coefficient-range heuristic, not a
+float64 limit); the *verified* obstacle is genuine near-singularity, confirmed by
+HiGHS failing identically.
 
 Acceptance / regime unchanged from #664: bound-neutral verification
 (`node_count` + certified `objective` exactly unchanged on the certifying panel,

--- a/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
+++ b/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
@@ -46,18 +46,51 @@ toward 1 makes those excluded tiny entries relatively even smaller, so the
 residual dynamic range balloons to ~1e20 — which feral's LU cannot factorize
 without runaway growth.
 
-## Fix hypothesis (to test next)
+## Tested fix hypotheses (both refined/falsified) — the conditioning is harder than a scaling tweak
 
-**Drop / fold the sub-tolerance coefficients before scaling.** They are provably
-near-zero (cancellation residue) or fold soundly into the RHS via their interval
-worst case (the candidate-A "fold", here repurposed as a *conditioning* fix). With
-them gone, the equilibration can bring the residual to ~O(1), feral factorizes
-cleanly, phase-2 converges, and hda gets a **tight** bound.
+**H1 — drop/fold sub-tolerance coefficients: WRONG.** Capturing the real node LP
+and tracing its entries showed the residual-driving small coefficients are **not**
+droppable cancellation residue. They are **crushed real coefficients**: hda's
+Arrhenius rows pair a huge pre-exponential (~6.3e10) with normal (~1) entries.
+Geometric-mean row scaling crushes the ~1 entries to ~1e-11 (they are below the
+`MAX_LINE_RANGE=1e-10` noise floor relative to 6.3e10, so the floor *excludes* them
+from the scale computation). Dropping them would corrupt real constraints — not a
+sound fix.
 
-Kill criterion: if removing sub-tolerance coefficients does **not** collapse the
-scaled residual range (or if a clean residual still leaves phase-1 grinding on
-degeneracy), scaling is not the whole story and the degeneracy (redundant envelope
-rows, rank ~1136 of 2974) is the next target.
+**H2 — stronger scaling (lower noise floor + more passes): FALSIFIED.** Env-gated
+`DISCOPT_SCALE_PASSES=12 DISCOPT_SCALE_LINE_RANGE=1e-14` made the in-engine residual
+**worse** (1.8e20 → 2.25e21), and hda still `bound=None`. Root cause of the limit:
+the Rust scaler runs on the **standard-form matrix `[A | I]` with slack columns**
+(n=4112 = 1138 structural + 2974 slacks). The identity slacks **pin** the row
+scales, so no diagonal scaling of the full standard form can balance the Arrhenius
+rows.
+
+**The two irreducible facts:**
+
+1. Scaling `A_ub` *alone* (no slacks; 8-pass geo-mean, no floor) reaches ~**2.5e9**
+   — vs ~2e20 for the slack-included standard form. So scaling *before* the
+   standard-form conversion is worth ~1e11.
+2. Even 2.5e9 exceeds feral's reliable range (~1e7, per this module's own header):
+   the 6.3e10 Arrhenius/normal coupling is an **irreducible ~1e9 conditioning** that
+   diagonal scaling cannot remove.
+
+## Real levers (harder; not yet built)
+
+- **L1 — scale `A_ub` pre-slack:** equilibrate the structural matrix before slacks
+  are appended (append slacks with coefficient = row scale, not 1), so feral sees
+  ~2.5e9 instead of ~2e20. Necessary but likely not sufficient alone.
+- **L2 — robust factorization for ~2.5e9:** pair L1 with the dense LU route
+  (`#557`) and/or a higher feral pivot threshold, since ~2.5e9 is past the sparse
+  route's reliable range.
+- **L3 — model/relaxation-level rescale of the Arrhenius term:** normalize the
+  `6.3e10 · exp(-E/RT)` product (the aux value is ~1e-13, so the product is ~6e-3)
+  at relaxation build, removing the 6.3e10 from the matrix entirely. The most
+  fundamental fix; largest surface.
+
+Kill note: candidate B is **not** a scaling-parameter tweak. It needs L1+L2
+(and possibly L3) together, each a real core-engine/relaxation change under the
+bound-neutral regime. Candidate A's loose floor remains the shipped fallback until
+one lands.
 
 Acceptance / regime unchanged from #664: bound-neutral verification
 (`node_count` + certified `objective` exactly unchanged on the certifying panel,

--- a/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
+++ b/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
@@ -115,6 +115,46 @@ solves hda** — the conditioning floor is above feral's ceiling.
 
 Candidate A's loose floor remains hda's shipped fallback until L3 lands.
 
+## L3 entry experiment — the conditioning is irreducible and structural (measured)
+
+Before building any reformulation, solved the **true optimal diagonal scaling** of
+hda's captured node matrix (the classic log-space min-max LP:
+`min (M−m)` s.t. `m ≤ log|a_ij| + r_i + c_j ≤ M`, via HiGHS):
+
+```
+OPTIMAL diagonal-scaling residual spread = 1.771e9
+```
+
+So the heuristic ~2–4e9 was near-optimal; **~1.8e9 is the rigorous floor** no
+scaling algorithm can beat. And it is **not** caused by residue: recomputing the
+optimum after dropping every entry below 1e-14 … 1e-8 leaves it **exactly 1.771e9**
+at all thresholds. Tracing the binding entries: they are **normal-magnitude
+coefficients** (|a|≈1) — e.g. column 722 (6 rows) is forced to *both* extremes
+(scaled `e^0` in some rows, `e^-21.3` in others) because its rows demand scales
+differing by 1.77e9. It is a genuine **non-diagonal structural coupling** among real
+coefficients (the Arrhenius `6.3e10` / `3.27e6` rate rows vs the ~1 mass-balance
+rows sharing variables), which diagonal scaling provably cannot resolve.
+
+**Conclusion — candidate B is blocked at the relaxation-conditioning level, not the
+engine level.** hda's LP relaxation is inherently ~1.8e9-conditioned; float64
+simplex (feral ~1e7; HiGHS also false-infeasibles on the unscaled form) cannot
+solve it cleanly regardless of scaling/factorization. The only genuine fixes are
+both major and uncertain:
+
+- **L3-structural** — a *general* relaxation-build reformulation that changes the
+  coefficient structure (variable substitution/elimination to break the coupling,
+  or a rate-term reformulation). A constant-scale variable split is **not** enough
+  (it is diagonal, already in the 1.77e9). Must be general (Dev-Philosophy #2 — no
+  hda-keyed special case) and sound, which is a substantial relaxation-layer
+  research effort with no guarantee it drops below ~1e7.
+- **Higher-precision LP arithmetic** (f128 / rational residuals in the factorization)
+  — a different engine capability.
+
+**Disposition:** candidate (A)'s sound loose floor is the practical answer for hda.
+Candidate (B)'s tight bound requires L3-structural or higher-precision arithmetic —
+tracked here as the honest scope; not attempted speculatively, since the entry
+experiment shows no scaling/factorization path exists.
+
 Acceptance / regime unchanged from #664: bound-neutral verification
 (`node_count` + certified `objective` exactly unchanged on the certifying panel,
 `cargo test -p discopt-core`), and a **tight** hda bound materially closer to opt

--- a/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
+++ b/docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md
@@ -1,0 +1,65 @@
+# Candidate (B) entry experiment — hda phase-2 blocked by post-scaling residual range (#664)
+
+Follow-up to #517 / #662 (candidate A, merged). Goal (B): make the in-house
+simplex converge on hda's ill-conditioned node LP so hda gets a **tight** dual
+bound, not the loose (A) floor. Per Dev-Philosophy #4, this is the entry
+experiment run **before** any implementation.
+
+## Diagnosis (built-in profiler, `DISCOPT_PROFILE`)
+
+hda's node LP (2974 rows × 4112 cols lifted):
+
+| metric | value |
+|---|---|
+| Phase1Pivots | 8 540 – 16 504 (degenerate grind) |
+| Phase2Pivots | 0 – 2 156 (starved) |
+| Refactorizations | 188 – 398 (mostly `RefacCap`, the 48-update cap) |
+| `RefacFtFail` cause | **`Growth` 18–26**, `TinyPivot` 2–6, **`Singular` 0** |
+
+At `time_limit=150 s` hda explores only **7 nodes** and never certifies a bound —
+a conditioning/speed wall, not a time budget. The FT failures are **numerical
+growth** in feral's eta factors (not singular bases, not tiny pivots).
+
+## Killed lever — feral iterative refinement (`with_numeric_focus`)
+
+Enabling feral's 2-step iterative refinement in the *main pivoting* factorization
+(`primal.rs` / `dual.rs`, env-gated `DISCOPT_LP_NUMERIC_FOCUS`) left the profile
+**byte-identical** (8540 / 0 / 20 / 18) and hda still `bound=None`. Refinement
+polishes solve *accuracy* but does not change the FT-update growth that forces the
+grind. **KILLED.**
+
+## Confirmed root cause — the scaler leaves a ~1e20 residual range
+
+Measured the coefficient spread feral actually factorizes, *after* the
+geometric-mean equilibration (`scaling.rs`, env-gated `DISCOPT_SCALE_DEBUG`):
+
+```
+m=2974 n=4112 raw_spread=2.837e26  scaled_residual_spread=1.845e20
+m=2974 n=4112 raw_spread=5.765e17  scaled_residual_spread=2.951e20   (scaling made it WORSE)
+```
+
+The equilibration barely dents the spread — and in one case *increases* it. The
+mechanism: the scaler's noise floor (`MAX_LINE_RANGE = 1e-10`) **excludes** tiny
+coefficients (cancellation residue ~1e-16, envelope slopes ~1e-9) from the scale
+computation but leaves them **in the matrix**. Scaling the structural entries
+toward 1 makes those excluded tiny entries relatively even smaller, so the
+residual dynamic range balloons to ~1e20 — which feral's LU cannot factorize
+without runaway growth.
+
+## Fix hypothesis (to test next)
+
+**Drop / fold the sub-tolerance coefficients before scaling.** They are provably
+near-zero (cancellation residue) or fold soundly into the RHS via their interval
+worst case (the candidate-A "fold", here repurposed as a *conditioning* fix). With
+them gone, the equilibration can bring the residual to ~O(1), feral factorizes
+cleanly, phase-2 converges, and hda gets a **tight** bound.
+
+Kill criterion: if removing sub-tolerance coefficients does **not** collapse the
+scaled residual range (or if a clean residual still leaves phase-1 grinding on
+degeneracy), scaling is not the whole story and the degeneracy (redundant envelope
+rows, rank ~1136 of 2974) is the next target.
+
+Acceptance / regime unchanged from #664: bound-neutral verification
+(`node_count` + certified `objective` exactly unchanged on the certifying panel,
+`cargo test -p discopt-core`), and a **tight** hda bound materially closer to opt
+`−5964.534084` than (A)'s `−1.80e10`.


### PR DESCRIPTION
## Summary

Docs-only. Records the full measured investigation into a **tight** dual bound for the hda-class flowsheets — the follow-up to #517 (closed; first finite bound delivered by candidate A in #662). Adds `docs/dev/candidate-b-phase2-scaling-entry-2026-07-16.md` (245 lines). No source or behavior changes.

Forward tracking is **#671**; this branch is the primary evidence trail behind that issue's conclusion. Supersedes exploratory tracker #664 (closed).

## What the investigation established (verified)

hda's root McCormick relaxation LP (2974×1138) is **feasible** (elastic phase-1 min violation = 1.8e-10 in raw units) but **float64-intractable** — every available float64 LP engine false-infeasibles on it:

| engine | verdict |
|---|---|
| in-house feral simplex | `numerical` (FT `Growth` on near-singular bases) |
| HiGHS simplex | infeasible (false) |
| HiGHS interior-point | numerical |
| SCIP / SoPlex (SCIP 10, iterative refinement) | infeasible (false) |

Cause (scale-invariant): the relaxation is **rank-deficient** (SVD numerical rank 1095 / 1138 cols) with ~400 tiny singular values and condition ~1e14. Optimal diagonal scaling bottoms out at coefficient range 1.77e9 (rigorous floor, via a log min-max LP).

**Falsified levers** (documented so they aren't re-tried): better scaling / more passes / lower noise floor / slack-aware "L1" (cut spread 2.8e26→4.1e9 but conditioning is scale-invariant); presolve / rank-reduction; feral's existing double-precision iterative refinement.

**The lever** (tracked in #671): higher-precision LP arithmetic — a Gleixner-style iterative-refinement layer (mostly independent of feral; only the residual needs high precision) plus factorization robustness to near-singular bases.

## Honest record

The doc keeps the two mid-course corrections in the trail rather than hiding them: the initial "~1e7 float64 ceiling" framing was wrong (that is feral's coefficient-*range* heuristic, not a float64 limit), and an intermediate elastic run reported "887" in scaled units that was briefly mis-read as genuine infeasibility (a units artifact — the raw-units test settles feasibility). The final conclusion is consistent and evidence-backed.

## Testing

Docs-only — no code paths touched; no tests to run. The measurements referenced in the doc are reproducible from `python/tests/data/minlplib_nl/hda.nl` per the methods described (optimal-scaling LP, SVD spectrum, HiGHS/SCIP cross-checks, elastic phase-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6n8zSjqEhRVuNENRW9B5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6n8zSjqEhRVuNENRW9B5W)_