### PR TITLE
feat(#187): incumbent seeding for the binary-multilinear MILP route

### DIFF
--- a/crates/discopt-core/examples/milp_bench.rs
+++ b/crates/discopt-core/examples/milp_bench.rs
@@ -159,6 +159,7 @@ fn opts(n_struct: usize, integer_cols: Vec<usize>, tl: f64) -> MilpOptions {
         reduced_cost_fixing: false,
         sb_max_cands: 8,
         sb_node_budget: 128,
+        initial_incumbent: None,
         simplex: SimplexOptions {
             tol: 1e-9,
             max_iter: 100_000,

--- a/crates/discopt-core/examples/par_bench.rs
+++ b/crates/discopt-core/examples/par_bench.rs
@@ -123,6 +123,7 @@ fn opts(inst: &Instance) -> MilpOptions {
         reduced_cost_fixing: true,
         sb_max_cands: 8,
         sb_node_budget: 4096,
+        initial_incumbent: None,
         simplex: SimplexOptions {
             tol: 1e-9,
             max_iter: 100_000,

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -217,6 +217,15 @@ pub struct MilpOptions {
     /// early region where branching choices shape the whole search. Beyond it,
     /// matured pseudocosts decide (avoids probing overhead deep in large trees).
     pub sb_node_budget: usize,
+    /// Optional caller-supplied point over the structural columns (length
+    /// `n_struct`) to seed the incumbent before the search starts — e.g. a
+    /// warm start mapped through an exact reformulation, or a primal
+    /// heuristic's solution. The driver VALIDATES it (integrality, bounds,
+    /// original-row feasibility) and recomputes the objective from `c`; an
+    /// invalid seed is silently ignored. The caller's point is never trusted:
+    /// an infeasible incumbent would prune the true optimum — a false
+    /// certificate.
+    pub initial_incumbent: Option<Vec<f64>>,
     /// LP solver options.
     pub simplex: SimplexOptions,
 }
@@ -374,6 +383,20 @@ pub fn solve_milp_hooked(
     let mut u_w = base_u;
     let mut m_w = m;
     let mut n_w = n;
+
+    // --- Caller-seeded incumbent: validate, then inject before the search ---
+    // Runs on the pre-cut matrix (all rows are original rows here) with the
+    // presolve-tightened bounds (FBBT never cuts a feasible point, so a
+    // genuinely feasible seed survives the tightening). A seed that cannot be
+    // proven feasible is dropped silently — seeding is an optimization and
+    // must never be able to produce a false certificate.
+    if let Some(seed) = opts.initial_incumbent.as_ref() {
+        if let Some((sx, sobj)) =
+            validate_seed_incumbent(seed, ns, &is_int, &csc_w, &b_w, &c_w, &l_w, &u_w, m_w, n_w)
+        {
+            tm.inject_incumbent(sx, sobj + obj_const);
+        }
+    }
 
     let mut lp_iters = 0usize;
     let mut unbounded = false;
@@ -2166,6 +2189,100 @@ fn try_rounding_csc(
     best
 }
 
+/// Validate a caller-supplied structural seed point (see
+/// [`MilpOptions::initial_incumbent`]) and return `(x, cᵀx)` ready for
+/// `inject_incumbent`, or `None` when it cannot be *proven* feasible here.
+/// Mirrors [`try_rounding_csc`]'s feasibility test: integer columns must sit
+/// on integer values (within `1e-6`, then snapped exactly), every column must
+/// lie within its (presolve-tightened) bounds (within `1e-6`, then clamped),
+/// and each original row's residual must be coverable by its slack columns'
+/// bound range. The objective is recomputed from `c_w` — a caller-claimed
+/// value is never trusted. Rejection is silent: an unverifiable seed simply
+/// does not seed, so a bad caller point can never prune the true optimum.
+// The arguments ARE the standard-form LP slices, same shape as the sibling
+// heuristics (`try_rounding_csc`); a parameter struct would only obscure that.
+#[allow(clippy::too_many_arguments)]
+fn validate_seed_incumbent(
+    seed: &[f64],
+    ns: usize,
+    is_int: &[bool],
+    csc: &SparseCols,
+    b_w: &[f64],
+    c_w: &[f64],
+    l_w: &[f64],
+    u_w: &[f64],
+    n_orig_rows: usize,
+    n_w: usize,
+) -> Option<(Vec<f64>, f64)> {
+    const TOL: f64 = 1e-6;
+    if seed.len() != ns {
+        return None;
+    }
+    let mut x = Vec::with_capacity(ns);
+    for j in 0..ns {
+        let mut v = seed[j];
+        if !v.is_finite() {
+            return None;
+        }
+        if is_int[j] {
+            let r = v.round();
+            if (v - r).abs() > TOL {
+                return None;
+            }
+            v = r;
+        }
+        let (lo, hi) = if l_w[j] <= u_w[j] {
+            (l_w[j], u_w[j])
+        } else {
+            (u_w[j], l_w[j])
+        };
+        if v < lo - TOL || v > hi + TOL {
+            return None;
+        }
+        x.push(v.clamp(lo, hi));
+    }
+    let (col_ptr, row_idx, vals) = csc.raw();
+    let mut slack_lo = vec![0.0f64; n_orig_rows];
+    let mut slack_hi = vec![0.0f64; n_orig_rows];
+    for k in ns..n_w {
+        for idx in col_ptr[k]..col_ptr[k + 1] {
+            let i = row_idx[idx];
+            if i >= n_orig_rows {
+                continue;
+            }
+            let aik = vals[idx];
+            let (c1, c2) = (aik * l_w[k], aik * u_w[k]);
+            slack_lo[i] += c1.min(c2);
+            slack_hi[i] += c1.max(c2);
+        }
+    }
+    let mut act = vec![0.0f64; n_orig_rows];
+    for (j, &xj) in x.iter().enumerate() {
+        if xj == 0.0 {
+            continue;
+        }
+        for idx in col_ptr[j]..col_ptr[j + 1] {
+            let i = row_idx[idx];
+            if i >= n_orig_rows {
+                continue;
+            }
+            act[i] += vals[idx] * xj;
+        }
+    }
+    for i in 0..n_orig_rows {
+        let resid = b_w[i] - act[i];
+        if resid < slack_lo[i] - TOL || resid > slack_hi[i] + TOL {
+            return None;
+        }
+    }
+    let obj = x
+        .iter()
+        .zip(c_w.iter())
+        .map(|(xj, cj)| cj * xj)
+        .sum::<f64>();
+    Some((x, obj))
+}
+
 /// Fractional-diving primal heuristic with continuous repair: repeatedly fix the
 /// most-fractional unfixed integer to its nearest integer and **re-solve the LP**
 /// (warm-started — the bound-change case the dual simplex re-optimizes cheaply),
@@ -2565,6 +2682,7 @@ mod tests {
             reduced_cost_fixing: true,
             sb_max_cands: 8,
             sb_node_budget: 1024,
+            initial_incumbent: None,
             simplex: SimplexOptions::default(),
         }
     }
@@ -2586,6 +2704,65 @@ mod tests {
             u: &u,
         };
         let r = solve_milp(&lp, &[9.0], 0.0, &opts(4, vec![0, 1, 2, 3]));
+        assert_eq!(r.status, MilpStatus::Optimal);
+        assert!((r.obj - (-10.0)).abs() < 1e-6, "obj {}", r.obj);
+    }
+
+    /// Same knapsack, driven to a hard truncation (`max_nodes = 0`) so the only
+    /// possible incumbent is the seeded one: a valid seed must be adopted (and
+    /// reported), an infeasible / fractional / wrong-length one silently
+    /// rejected (never trusted — an infeasible incumbent would be a false
+    /// certificate). Root machinery (cuts/heuristics/presolve) is disabled so
+    /// no other incumbent source can mask the seeding behavior.
+    #[test]
+    fn seeded_incumbent_validated_then_adopted() {
+        let a = [5.0, 5.0, 5.0, 5.0, 1.0];
+        let c = [-10.0, -9.0, -8.0, -1.0, 0.0];
+        let l = [0.0; 5];
+        let u = [1.0, 1.0, 1.0, 1.0, INF];
+        let lp = LpView {
+            a: &a,
+            m: 1,
+            n: 5,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let bare = |seed: Option<Vec<f64>>| {
+            let mut o = opts(4, vec![0, 1, 2, 3]);
+            o.max_nodes = 0;
+            o.root_cuts = 0;
+            o.cut_rounds = 0;
+            o.gmi_cuts = false;
+            o.node_cuts = false;
+            o.heuristics = false;
+            o.presolve = false;
+            o.strong_branch = false;
+            o.initial_incumbent = seed;
+            solve_milp(&lp, &[9.0], 0.0, &o)
+        };
+        // Feasible seed (x1 = 1, others 0, obj -9): adopted and reported.
+        let r = bare(Some(vec![0.0, 1.0, 0.0, 0.0]));
+        assert_ne!(r.status, MilpStatus::Optimal, "truncated search");
+        assert!((r.obj - (-9.0)).abs() < 1e-9, "seed not adopted: {}", r.obj);
+        assert!((r.x[1] - 1.0).abs() < 1e-9);
+        // Row-infeasible seed (two items, 10 > 9): rejected, no incumbent.
+        let r = bare(Some(vec![1.0, 1.0, 0.0, 0.0]));
+        assert!(!r.obj.is_finite(), "infeasible seed adopted: {}", r.obj);
+        // Fractional integer column: rejected.
+        let r = bare(Some(vec![0.5, 0.0, 0.0, 0.0]));
+        assert!(!r.obj.is_finite(), "fractional seed adopted: {}", r.obj);
+        // Wrong length: rejected.
+        let r = bare(Some(vec![1.0, 0.0]));
+        assert!(!r.obj.is_finite(), "wrong-length seed adopted: {}", r.obj);
+        // Out-of-bounds value: rejected.
+        let r = bare(Some(vec![2.0, 0.0, 0.0, 0.0]));
+        assert!(!r.obj.is_finite(), "out-of-bounds seed adopted: {}", r.obj);
+        // A seeded search left to run must still certify the true optimum
+        // (seeding is monotone: it can only help pruning, never change math).
+        let mut o = opts(4, vec![0, 1, 2, 3]);
+        o.initial_incumbent = Some(vec![0.0, 1.0, 0.0, 0.0]);
+        let r = solve_milp(&lp, &[9.0], 0.0, &o);
         assert_eq!(r.status, MilpStatus::Optimal);
         assert!((r.obj - (-10.0)).abs() < 1e-6, "obj {}", r.obj);
     }
@@ -3083,6 +3260,7 @@ mod sparse_milp_diff {
                 reduced_cost_fixing: true,
                 sb_max_cands: 8,
                 sb_node_budget: 1024,
+                initial_incumbent: None,
                 simplex: SimplexOptions::default(),
             }
         }
@@ -3364,6 +3542,7 @@ mod sparse_milp_diff {
             reduced_cost_fixing: true,
             sb_max_cands: 8,
             sb_node_budget: 1024,
+            initial_incumbent: None,
             simplex: SimplexOptions::default(),
         };
         let r = solve_milp(&lp, &[10.0, 9.0], 0.0, &o);

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -748,7 +748,7 @@ impl MilpDebugHook for PyMilpHook {
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    time_limit_s=0.0, debug_hook=None))]
+                    initial_incumbent=None, time_limit_s=0.0, debug_hook=None))]
 pub fn solve_milp_py<'py>(
     py: Python<'py>,
     c: PyReadonlyArray1<'py, f64>,
@@ -775,6 +775,7 @@ pub fn solve_milp_py<'py>(
     reduced_cost_fixing: bool,
     sb_max_cands: usize,
     sb_node_budget: usize,
+    initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: f64,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
@@ -830,6 +831,7 @@ pub fn solve_milp_py<'py>(
         reduced_cost_fixing,
         sb_max_cands,
         sb_node_budget,
+        initial_incumbent,
         time_limit_s,
         debug_hook,
     )
@@ -847,7 +849,7 @@ pub fn solve_milp_py<'py>(
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    time_limit_s=0.0, debug_hook=None))]
+                    initial_incumbent=None, time_limit_s=0.0, debug_hook=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn solve_milp_csc_py<'py>(
     py: Python<'py>,
@@ -879,6 +881,7 @@ pub fn solve_milp_csc_py<'py>(
     reduced_cost_fixing: bool,
     sb_max_cands: usize,
     sb_node_budget: usize,
+    initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: f64,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
@@ -923,6 +926,7 @@ pub fn solve_milp_csc_py<'py>(
         reduced_cost_fixing,
         sb_max_cands,
         sb_node_budget,
+        initial_incumbent,
         time_limit_s,
         debug_hook,
     )
@@ -961,6 +965,7 @@ fn run_milp_hooked<'py>(
     reduced_cost_fixing: bool,
     sb_max_cands: usize,
     sb_node_budget: usize,
+    initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: f64,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
@@ -987,6 +992,9 @@ fn run_milp_hooked<'py>(
         reduced_cost_fixing,
         sb_max_cands,
         sb_node_budget,
+        initial_incumbent: initial_incumbent
+            .map(|arr| arr.as_slice().map(|s| s.to_vec()))
+            .transpose()?,
         simplex: SimplexOptions {
             tol,
             max_iter: 100_000,

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -376,6 +376,33 @@ panel green for 3 consecutive nightlies before default-on.
 
 **Risk**: high (correctness-sensitive). Flag-gated, A/B'd, default-off until green.
 
+> **Binary-multilinear MILP route follow-up (2026-07-16) — "sparse-MILP LP
+> throughput ⇒ autocorr 25-25 certifies" FALSIFIED.** After #187's exact
+> linearization (PR #667) routed the autocorr class to the MILP engine and #663's
+> sparse CSC engine landed, the hypothesis was that node-LP throughput was the
+> remaining blocker to *certifying* autocorr_bern25-25 in budget. Measured on the
+> reformed 1,224-row MILP (synthetic Bernasconi n=25 dense):
+>
+> | lever | result |
+> |---|---|
+> | sparse engine, 600 s | 8,415 nodes, **dual bound frozen at 12.0** (= the parity floor: one per odd-length lag) — no visible progress toward the optimum 36 |
+> | generic root cuts (cover/clique/GMI/MIR via `DISCOPT_P3_FORCE_CUT_PATH`) | bound unchanged at 12.0; root ~10× slower |
+> | perfect incumbent (36) | frontier bound stays ~12 → pruning threshold barely matters for tree size |
+>
+> The LP relaxation sits at the parity floor because the LP can hold every
+> ``y_k`` at its parity-nearest-zero value with fractional ``b = 1/2`` and
+> loose Fortet ``z``; branching individual bits barely moves it until deep in
+> the tree. This is the **same bound-pinned phenomenon as gear4 above**, now on
+> the lifted binary-product (Boolean-quadric) polytope: certification needs
+> BQP/PSD-class strengthening of the ``z``-polytope (triangle inequalities,
+> PSD moment cuts à la #663's `X_ii = x_i` recognition — currently only on the
+> spatial path), a scoped research effort, not an engine or throughput fix.
+> **What DID pay** (shipped in the follow-up PR): incumbent seeding — the
+> class-gated 1-flip local search finds the true optimum 36 in ~0.5 s, and with
+> it the 30 s answer improves from `feasible 84 / bound 12` to `incumbent 36 /
+> bound 12`; n=13 dense *certification* drops 3.7 s → 0.4 s (the seed collapses
+> the proving phase where the bound does move).
+
 ## 7. Sequencing & rationale (revised by the measurement)
 
 ```

--- a/python/discopt/_jax/binary_multilinear_reform.py
+++ b/python/discopt/_jax/binary_multilinear_reform.py
@@ -880,6 +880,11 @@ def _detect_objvar_row(model: Model, mu: float) -> Optional[tuple[int, float]]:
 # ---------------------------------------------------------------------------
 
 
+def _mono_order(poly: dict) -> list[frozenset]:
+    """Non-constant monomials of *poly* in the deterministic canonical order."""
+    return sorted((m for m in poly if m), key=lambda m: tuple(sorted(m)))
+
+
 def _balanced_sum(terms: list[Expression]) -> Expression:
     """Combine *terms* into a balanced ``+`` tree (depth O(log n)) so that
     downstream recursive DAG walkers never see a linear-depth chain."""
@@ -1004,6 +1009,23 @@ def _reformulate(model: Model) -> Model:
     new_model._parameters = list(model._parameters)
     new_model._rebuild_name_index()
 
+    # Flat positions of the original variables (the aux columns are appended
+    # after them, so the original flat layout is a prefix of the reformed one).
+    # Recorded per aux variable — in exact append order — so a warm start /
+    # heuristic point over the ORIGINAL variables can be extended to a feasible
+    # point of the reformed MILP (see ``extend_initial_point``).
+    _flat_off: dict[int, int] = {}
+    _off = 0
+    for v in model._variables:
+        _flat_off[v._index] = _off
+        _off += v.size
+    n_orig_flat = _off
+
+    def _flat(key: tuple[int, int]) -> int:
+        return _flat_off[key[0]] + key[1]
+
+    aux_spec: list[tuple] = []
+
     # One aux + Fortet rows per distinct monomial, in deterministic order.
     aux: dict[frozenset, Variable] = {}
     aux_rows: list[Constraint] = []
@@ -1011,6 +1033,7 @@ def _reformulate(model: Model) -> Model:
         z = Variable(f"_bml_z{i}", VarType.CONTINUOUS, (), 0.0, 1.0, new_model)
         new_model._variables.append(z)
         aux[mono] = z
+        aux_spec.append(("z", tuple(_flat(k) for k in sorted(mono))))
         refs = [ctx.refs[k] for k in sorted(mono)]
         # z <= b_i for every factor (z >= 0 is the variable's lower bound).
         for r in refs:
@@ -1046,6 +1069,11 @@ def _reformulate(model: Model) -> Model:
         t = Variable(f"_bml_t{sq_counter}", VarType.CONTINUOUS, (), t_lo, t_hi, new_model)
         new_model._variables.append(t)
         sq_counter += 1
+        y_terms = tuple(
+            (sq.poly[m], tuple(_flat(k) for k in sorted(m))) for m in _mono_order(sq.poly)
+        )
+        aux_spec.append(("y", y_terms, float(sq.poly.get(_EMPTY, 0.0))))
+        aux_spec.append(("t",))
         link = _balanced_sum([y, *(_negate(term) for term in _poly_terms(sq.poly, ctx, aux))])
         aux_rows.append(Constraint(link, "==", 0.0))
         for u in range(sq.lo, sq.hi, sq.step):
@@ -1078,10 +1106,311 @@ def _reformulate(model: Model) -> Model:
 
     new_model._constraints = rebuilt + aux_rows
     new_model._objective = Objective(expression=new_obj_expr, sense=obj.sense)
+
+    # --- Warm-start / heuristic metadata (incumbent seeding) ---
+    # Dynamic attributes (Model does not declare them): consumed only through
+    # getattr by extend_initial_point / heuristic_incumbent.
+    setattr(new_model, "_bml_aux_spec", aux_spec)  # noqa: B010
+    setattr(new_model, "_bml_n_orig_flat", n_orig_flat)  # noqa: B010
+    setattr(  # noqa: B010
+        new_model,
+        "_bml_binary_flat",
+        frozenset(_flat(k) for k, is_b in ctx.is_bin.items() if is_b),
+    )
+    setattr(  # noqa: B010
+        new_model,
+        "_bml_heuristic",
+        _heuristic_meta(model, ctx, mu, objvar_row, obj_body, con_bodies, _flat_off, n_orig_flat),
+    )
     return new_model
+
+
+def _heuristic_meta(
+    model: Model,
+    ctx: _ExpandCtx,
+    mu: float,
+    objvar_row: Optional[tuple[int, float]],
+    obj_body: _ProcessedBody,
+    con_bodies: list[_ProcessedBody],
+    flat_off: dict[int, int],
+    n_orig_flat: int,
+) -> Optional[dict]:
+    """Build the primal local-search description of the model, or ``None`` when
+    the class-level feasibility argument does not apply. The heuristic needs
+    "every 0/1 assignment of the binary variables is feasible", which holds
+    exactly when the only constraint is the objective variable's defining row
+    (or there are none) and every variable is binary-valued — except the free
+    objective variable itself, whose value is *determined* by the bits."""
+    n_extra_rows = 1 if objvar_row is not None else 0
+    if len(model._constraints) != n_extra_rows:
+        return None
+
+    def _flat(key: tuple[int, int]) -> int:
+        return flat_off[key[0]] + key[1]
+
+    tau_key: Optional[tuple[int, int]] = None
+    if objvar_row is not None:
+        assert model._objective is not None
+        tau = model._objective.expression
+        assert isinstance(tau, Variable)
+        tau_key = (tau._index, 0)
+
+    bits: list[int] = []
+    fixed: list[tuple[int, float]] = []
+    for v in model._variables:
+        for elem in range(v.size):
+            key = (v._index, elem)
+            if tau_key is not None and key == tau_key:
+                continue
+            if not _binary_like(v, elem):
+                return None
+            lo = float(np.asarray(v.lb).flat[elem])
+            hi = float(np.asarray(v.ub).flat[elem])
+            flo, fhi = max(0.0, np.ceil(lo)), min(1.0, np.floor(hi))
+            if flo > fhi:
+                return None
+            if flo == fhi:
+                fixed.append((_flat(key), flo))
+            else:
+                bits.append(_flat(key))
+
+    def _poly_terms_flat(poly: dict, scale: float, skip: Optional[tuple[int, int]] = None):
+        terms = []
+        for m in _mono_order(poly):
+            if skip is not None and m == frozenset((skip,)):
+                continue
+            terms.append((scale * poly[m], tuple(_flat(k) for k in sorted(m))))
+        return terms, scale * poly.get(_EMPTY, 0.0)
+
+    squares: list[tuple[float, list, float]] = []
+    if objvar_row is None:
+        body = obj_body
+        flat_terms, const = _poly_terms_flat(body.flat, 1.0)
+        for sq in body.squares:
+            iterms, iconst = _poly_terms_flat(sq.poly, 1.0)
+            squares.append((sq.coef, iterms, iconst))
+        tau_spec = None
+    else:
+        # Row a*tau + R(b) + sum c_q*E_q**2 <sense> rhs pins the objective to
+        # tau*(b) = (rhs - R(b) - sum c_q E_q(b)**2) / a on its binding side.
+        row_idx, a = objvar_row
+        c = model._constraints[row_idx]
+        body = con_bodies[row_idx]
+        assert tau_key is not None
+        flat_terms, const = _poly_terms_flat(body.flat, -1.0 / a, skip=tau_key)
+        const += float(c.rhs) / a
+        for sq in body.squares:
+            iterms, iconst = _poly_terms_flat(sq.poly, 1.0)
+            squares.append((-sq.coef / a, iterms, iconst))
+        tau_spec = _flat(tau_key)
+
+    return {
+        "bits": bits,
+        "fixed": fixed,
+        "tau": tau_spec,
+        "flat_terms": flat_terms,
+        "flat_const": const,
+        "squares": squares,
+        "sense_mul": mu,
+        "n_orig_flat": n_orig_flat,
+    }
 
 
 def _negate(term: Expression) -> Expression:
     if isinstance(term, Constant):
         return Constant(-float(term.value.reshape(())))
     return UnaryOp("neg", term)
+
+
+# ---------------------------------------------------------------------------
+# Incumbent seeding: warm-start mapping + primal local search
+# ---------------------------------------------------------------------------
+
+
+def extend_initial_point(reformed: Model, x0) -> Optional[np.ndarray]:
+    """Extend a point over the ORIGINAL variables (flat, length
+    ``_bml_n_orig_flat``) to a point over the reformed model's full variable
+    vector by evaluating each auxiliary from its recorded definition
+    (``z = prod b``, ``y = E(b)``, ``t = y**2``). Binary-valued entries are
+    snapped to their nearest integer first so the aux values satisfy the
+    Fortet/secant rows exactly. Returns ``None`` when the model carries no
+    reformulation metadata or the point has the wrong length — the caller then
+    simply does not seed (the MILP driver re-validates whatever is passed, so
+    this mapping is an optimization, never a soundness lever)."""
+    spec = getattr(reformed, "_bml_aux_spec", None)
+    n0 = getattr(reformed, "_bml_n_orig_flat", None)
+    if spec is None or n0 is None:
+        return None
+    x = np.asarray(x0, dtype=np.float64).ravel()
+    if x.size != n0 or not np.all(np.isfinite(x)):
+        return None
+    x = x.copy()
+    for j in getattr(reformed, "_bml_binary_flat", frozenset()):
+        r = round(float(x[j]))
+        if abs(x[j] - r) > 1e-6:
+            return None
+        x[j] = float(r)
+    out = list(x)
+    last_y = 0.0
+    for entry in spec:
+        kind = entry[0]
+        if kind == "z":
+            v = 1.0
+            for j in entry[1]:
+                v *= x[j]
+        elif kind == "y":
+            v = entry[2]
+            for coef, idxs in entry[1]:
+                term = coef
+                for j in idxs:
+                    term *= x[j]
+                v += term
+            last_y = v
+        else:  # "t"
+            v = last_y * last_y
+        out.append(float(v))
+    return np.asarray(out, dtype=np.float64)
+
+
+def _heuristic_value(meta: dict, xb: dict[int, float]) -> float:
+    """Objective value (model sense's raw value, not min-normalized) of the
+    bit assignment *xb* (flat index -> 0/1) under the recorded description."""
+    val = meta["flat_const"]
+    for coef, idxs in meta["flat_terms"]:
+        term = coef
+        for j in idxs:
+            term *= xb[j]
+        val += term
+    for coef, iterms, iconst in meta["squares"]:
+        e = iconst
+        for c2, idxs in iterms:
+            term = c2
+            for j in idxs:
+                term *= xb[j]
+            e += term
+        val += coef * e * e
+    return float(val)
+
+
+class _FlipSearch:
+    """1-flip steepest-descent machinery over the recorded objective
+    description, with incremental deltas: flipping bit ``j`` changes each
+    multilinear part by ``(1 - 2*b_j) * (sum of its j-monomials evaluated on
+    the other factors)``, and each square by ``coef*(2*E*dE + dE**2)`` — so a
+    flip probe costs O(terms containing j), not O(all terms)."""
+
+    def __init__(self, meta: dict):
+        self.meta = meta
+        self.bits: list[int] = meta["bits"]
+        # Per bit: flat-part monomials containing it, and per-square monomials
+        # containing it (square index, coefficient, remaining factors).
+        self.flat_by_bit: dict[int, list] = {j: [] for j in self.bits}
+        self.sq_by_bit: dict[int, list] = {j: [] for j in self.bits}
+        bitset = set(self.bits)
+        for coef, idxs in meta["flat_terms"]:
+            for j in set(idxs) & bitset:
+                others = tuple(k for k in idxs if k != j)
+                self.flat_by_bit[j].append((coef, others))
+        for q, (_, iterms, _) in enumerate(meta["squares"]):
+            for c2, idxs in iterms:
+                for j in set(idxs) & bitset:
+                    others = tuple(k for k in idxs if k != j)
+                    self.sq_by_bit[j].append((q, c2, others))
+
+    def descend(self, xb: dict[int, float], budget: list) -> float:
+        """Steepest-descend *xb* in place; returns the raw objective value.
+        ``budget`` is a single-element mutable flip-probe countdown shared
+        across restarts (deterministic work cap)."""
+        meta = self.meta
+        e_vals = []
+        for _, iterms, iconst in meta["squares"]:
+            e = iconst
+            for c2, idxs in iterms:
+                term = c2
+                for j in idxs:
+                    term *= xb[j]
+                e += term
+            e_vals.append(e)
+        mu = meta["sense_mul"]
+        while budget[0] > 0:
+            best_j, best_d, best_des = None, -1e-9, None
+            for j in self.bits:
+                budget[0] -= 1
+                f = 1.0 - 2.0 * xb[j]
+                d_flat = 0.0
+                for coef, others in self.flat_by_bit[j]:
+                    term = coef
+                    for k in others:
+                        term *= xb[k]
+                    d_flat += f * term
+                des: dict[int, float] = {}
+                d_val = d_flat
+                for q, c2, others in self.sq_by_bit[j]:
+                    term = c2
+                    for k in others:
+                        term *= xb[k]
+                    des[q] = des.get(q, 0.0) + f * term
+                for q, de in des.items():
+                    d_val += meta["squares"][q][0] * (2.0 * e_vals[q] * de + de * de)
+                if mu * d_val < best_d:
+                    best_j, best_d, best_des = j, mu * d_val, des
+            if best_j is None:
+                break
+            xb[best_j] = 1.0 - xb[best_j]
+            for q, de in (best_des or {}).items():
+                e_vals[q] += de
+        # Exact value of the terminal point (the incremental E_q caches only
+        # steer the descent; the reported value is recomputed from scratch).
+        return _heuristic_value(meta, xb)
+
+    def run(self, restarts: int, max_flip_probes: int, seed: int):
+        import random
+
+        rng = random.Random(seed)
+        mu = self.meta["sense_mul"]
+        starts: list[dict[int, float]] = [
+            {j: 0.0 for j in self.bits},
+            {j: 1.0 for j in self.bits},
+        ]
+        while len(starts) < restarts:
+            starts.append({j: float(rng.getrandbits(1)) for j in self.bits})
+        budget = [max_flip_probes]
+        best_val, best_bits = None, None
+        for xb in starts:
+            if budget[0] <= 0:
+                break
+            for jf, vf in self.meta["fixed"]:
+                xb[jf] = vf
+            v = self.descend(xb, budget)
+            if best_val is None or mu * v < mu * best_val:
+                best_val, best_bits = v, dict(xb)
+        return best_val, best_bits
+
+
+def heuristic_incumbent(
+    reformed: Model, *, restarts: int = 512, max_flip_probes: int = 2_000_000, seed: int = 0
+) -> Optional[np.ndarray]:
+    """Deterministic 1-flip steepest-descent local search over the binary
+    variables of a reformed model whose recorded structure proves EVERY bit
+    assignment feasible (no constraints beyond the objvar defining row; all
+    non-objvar variables binary-valued). Returns the best point found,
+    extended over the reformed variable vector, or ``None`` when the class
+    argument does not apply. Purely a primal seed: the MILP driver re-validates
+    it, and a better incumbent only prunes — it never changes the certified
+    optimum. Fixed ``seed``/``restarts``/``max_flip_probes`` keep the search
+    deterministic (``deterministic=True`` default)."""
+    meta = getattr(reformed, "_bml_heuristic", None)
+    if not meta:
+        return None
+    bits: list[int] = meta["bits"]
+    if not bits or len(bits) > 1024:
+        return None
+    best_val, best_bits = _FlipSearch(meta).run(restarts, max_flip_probes, seed)
+    if best_bits is None:
+        return None
+    x0 = np.zeros(meta["n_orig_flat"], dtype=np.float64)
+    for j, v in best_bits.items():
+        x0[j] = v
+    if meta["tau"] is not None:
+        x0[meta["tau"]] = _heuristic_value(meta, best_bits)
+    return extend_initial_point(reformed, x0)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4034,6 +4034,28 @@ def solve_model(
                     presolve = False
                     if nlp_solver == "pounce" and not _p3_force_cut_path_enabled():
                         nlp_solver = "simplex"
+                    # Incumbent seeding. A user warm start is over the ORIGINAL
+                    # variables; the aux columns (z = prod b, y = E(b),
+                    # t = y**2) are determined by it, so extend it to the
+                    # reformed vector. Without one, run the class-gated
+                    # deterministic local search (any bit assignment is
+                    # feasible on this class, so its best point is a valid
+                    # incumbent). Purely primal: the Rust MILP driver
+                    # re-validates the seed and recomputes its objective, so a
+                    # bad point is dropped, never trusted (the dual bound and
+                    # the certified optimum are unaffected either way).
+                    from discopt._jax.binary_multilinear_reform import (
+                        extend_initial_point,
+                        heuristic_incumbent,
+                    )
+
+                    _bml_x0 = None
+                    if initial_point is not None:
+                        _bml_x0 = extend_initial_point(model, initial_point)
+                    if _bml_x0 is None:
+                        _bml_x0 = heuristic_incumbent(model)
+                    if _bml_x0 is not None:
+                        initial_point = _bml_x0
     except Exception as _bml_exc:  # pragma: no cover - defensive
         logger.debug("binary-multilinear reformulation skipped: %s", _bml_exc)
 
@@ -4524,7 +4546,12 @@ def solve_model(
                         "default nlp_solver='pounce' MILP path to enable it."
                     )
                 _simplex_res = _solve_milp_simplex(
-                    model, time_limit, gap_tolerance, max_nodes, t_start
+                    model,
+                    time_limit,
+                    gap_tolerance,
+                    max_nodes,
+                    t_start,
+                    initial_point=initial_point,
                 )
                 if _simplex_res is not None:
                     return _simplex_res
@@ -13360,6 +13387,7 @@ def _solve_milp_simplex(
     gap_tolerance: float,
     max_nodes: int,
     t_start: float,
+    initial_point: Optional[np.ndarray] = None,
 ) -> Optional[SolveResult]:
     """Solve a pure MILP with the Rust-internal warm-started-simplex B&B
     (``nlp_solver="simplex"`` and the POUNCE-only default MILP path).
@@ -13454,6 +13482,13 @@ def _solve_milp_simplex(
     # Python-driven loops, across the PyO3 boundary.
     from discopt import debug as _debug
 
+    # Optional incumbent seed over the structural columns. The Rust driver
+    # validates it (bounds, integrality, row feasibility) and recomputes its
+    # objective from c, so a bad point is silently ignored — never trusted.
+    _seed = None
+    if initial_point is not None and np.asarray(initial_point).size == n_orig:
+        _seed = np.ascontiguousarray(np.asarray(initial_point, dtype=np.float64).ravel())
+
     status, x_struct, obj, bound, nodes, _lp_iters = solve_milp_py(
         np.ascontiguousarray(lp_data.c, dtype=np.float64),
         A,
@@ -13465,6 +13500,7 @@ def _solve_milp_simplex(
         float(lp_data.obj_const),
         int(max_nodes),
         float(gap_tolerance),
+        initial_incumbent=_seed,
         time_limit_s=float(_milp_budget),
         debug_hook=_debug.rust_hook(),
     )

--- a/python/tests/test_binary_multilinear_reform.py
+++ b/python/tests/test_binary_multilinear_reform.py
@@ -335,6 +335,136 @@ def test_from_nl_round_trip_fires_and_certifies(tmp_path):
     assert res.objective == pytest.approx(ref, abs=1e-5)
 
 
+# ---------------------------------------------------------------------------
+# Incumbent seeding: warm-start mapping + local-search heuristic
+# ---------------------------------------------------------------------------
+
+
+def _flat_point_satisfies_model(m2, x):
+    """Every constraint row of the reformed model holds at the extended point."""
+    from discopt._jax.binary_multilinear_reform import _ExpandCtx
+
+    offs = {}
+    off = 0
+    for v in m2._variables:
+        offs[v._index] = off
+        off += v.size
+    for c in m2._constraints:
+        ctx = _ExpandCtx()
+        poly = B._expand_to_multilinear(c.body, ctx)
+        val = 0.0
+        for mono, coef in poly.items():
+            term = coef
+            for vi, el in mono:
+                term *= x[offs[vi] + el]
+            val += term
+        if c.sense == "==":
+            assert abs(val - c.rhs) < 1e-9, f"{c.name}: {val} != {c.rhs}"
+        elif c.sense == "<=":
+            assert val <= c.rhs + 1e-9
+        else:
+            assert val >= c.rhs - 1e-9
+
+
+@pytest.mark.parametrize("objvar_sense", [None, "=="])
+def test_extend_initial_point_satisfies_all_reform_rows(objvar_sense):
+    """The aux extension of any binary point (z = prod b, y = E(b), t = y**2,
+    tau = E) satisfies every Fortet, link, and secant row exactly — so the
+    Rust driver's validation accepts it and the seed's objective equals the
+    original objective at that point."""
+    n, K = 6, 5
+    m, _ = build_autocorr(n, K, objvar_sense=objvar_sense)
+    m2 = B.reformulate_binary_multilinear(m)
+    n0 = m2._bml_n_orig_flat
+    rng = np.random.RandomState(7)
+    for _ in range(10):
+        bits = rng.randint(0, 2, size=n).astype(float)
+        x0 = np.zeros(n0)
+        x0[:n] = bits
+        if objvar_sense is not None:
+            x0[n] = autocorr_energy([int(v) for v in bits], K)  # tau = E(b)
+        x = B.extend_initial_point(m2, x0)
+        assert x is not None and x.size == sum(v.size for v in m2._variables)
+        _flat_point_satisfies_model(m2, x)
+
+
+def test_extend_initial_point_rejects_fractional_binary():
+    m, _ = build_autocorr(5, 4)
+    m2 = B.reformulate_binary_multilinear(m)
+    x0 = np.full(m2._bml_n_orig_flat, 0.5)
+    assert B.extend_initial_point(m2, x0) is None
+
+
+def test_heuristic_incumbent_finds_good_point_deterministically():
+    n, K = 10, 9
+    ref = brute_force_autocorr(n, K)
+    m, _ = build_autocorr(n, K)
+    m2 = B.reformulate_binary_multilinear(m)
+    x1 = B.heuristic_incumbent(m2)
+    x2 = B.heuristic_incumbent(m2)
+    assert x1 is not None
+    np.testing.assert_array_equal(x1, x2)  # deterministic
+    _flat_point_satisfies_model(m2, x1)
+    meta = m2._bml_heuristic
+    xb = {j: x1[j] for j in meta["bits"]}
+    for jf, vf in meta["fixed"]:
+        xb[jf] = vf
+    val = B._heuristic_value(meta, xb)
+    assert val == pytest.approx(ref, abs=1e-9), "local search should nail n=10"
+
+
+def test_heuristic_gated_off_with_extra_constraints():
+    """An extra constraint on the bits breaks the every-assignment-feasible
+    argument — the heuristic must not run on such a model."""
+    m = Model()
+    b = [m.integer(f"b{i}", lb=0, ub=1) for i in range(4)]
+    s = [2 * bi - 1 for bi in b]
+    C = s[0] * s[1] + s[1] * s[2] + s[2] * s[3]
+    m.subject_to(b[0] + b[1] <= 1)
+    m.minimize(C * C)
+    m2 = B.reformulate_binary_multilinear(m)
+    assert m2 is not m
+    assert m2._bml_heuristic is None
+    assert B.heuristic_incumbent(m2) is None
+
+
+def test_warm_start_reaches_milp_engine_end_to_end():
+    """A user initial_solution must survive the reformulation: the reported
+    objective can never be worse than the (feasible) warm start's value, even
+    under a truncated search."""
+    n, K = 10, 9
+    ref = brute_force_autocorr(n, K)
+    m, b = build_autocorr(n, K)
+    # brute-force the optimal bits for the warm start
+    best_bits = None
+    best = None
+    for mask in range(1 << n):
+        bits = [(mask >> i) & 1 for i in range(n)]
+        e = autocorr_energy(bits, K)
+        if best is None or e < best:
+            best, best_bits = e, bits
+    x0 = {bv: float(v) for bv, v in zip(b, best_bits)}
+    res = m.solve(time_limit=60, initial_solution=x0)
+    assert res.objective is not None
+    assert res.objective <= ref + 1e-6
+    assert res.status in ("optimal", "feasible")
+
+
+def test_seeded_solve_certifies_faster_regression():
+    """n=13 dense: heuristic seeding collapses the proving phase (measured
+    3.7 s -> 0.4 s). Keep a loose ceiling so a silent loss of seeding (the
+    regression this guards) is caught without making the test timing-flaky."""
+    n, K = 13, 12
+    ref = brute_force_autocorr(n, K)
+    m, _ = build_autocorr(n, K)
+    t0 = time.time()
+    res = m.solve(time_limit=120)
+    wall = time.time() - t0
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(ref, abs=1e-5)
+    assert wall < 30, f"n=13 took {wall:.1f}s — incumbent seeding regressed"
+
+
 def test_binary_valued_integer_recognized_in_model_to_sympy():
     """{0,1}-bounded INTEGER columns count as binary in the symbolic
     recognizer layer too (issue #187 correction 1)."""


### PR DESCRIPTION
Follow-up to #187 / PR #667, targeting "autocorr 25-25 should certify". The entry experiment **falsified the throughput framing** and re-scoped the work; this PR ships the lever that measurably pays (primal seeding), and #673 tracks the certification lever (relaxation strengthening).

## Entry experiment (recorded in `docs/dev/performance-plan.md` §6)

On the reformed 1,224-row MILP for synthetic Bernasconi n=25 dense, with #663's sparse engine landed:

| lever | result |
|---|---|
| sparse engine, 600 s | 8,415 nodes; **dual bound frozen at 12.0** — exactly the parity floor (one per odd-length lag) |
| generic root cuts (cover/clique/GMI/MIR via `DISCOPT_P3_FORCE_CUT_PATH`) | bound unchanged; root ~10× slower |
| perfect incumbent | could not even be injected — the in-house MILP paths had no incumbent plumbing, and warm starts were silently dropped on the reformed model (25-var point vs 373-var model) |

So certification is blocked on the **strength of the lifted binary-product relaxation**, not LP speed — BQP/PSD-class cuts, filed with evidence and gates as #673. The incumbent side, however, is both a real bug (silent warm-start drop) and a big practical win.

## What this PR does

**Rust** (`milp_driver.rs`): `MilpOptions.initial_incumbent` — a caller-supplied structural point, **validated in-driver** (integer columns snapped within 1e-6, bounds within 1e-6 then clamped, original-row residuals coverable by slack ranges — mirroring `try_rounding_csc` — and the objective recomputed from `c`; a caller-claimed value is never trusted). An unverifiable seed is silently dropped, so a bad point can never prune the true optimum (no false-certificate channel). Injected via `tm.inject_incumbent` before the search, on the pre-cut matrix with presolve-tightened bounds (FBBT never cuts a feasible point).

**Bindings**: optional `initial_incumbent=None` on `solve_milp_py` / `solve_milp_csc_py`.

**Solver**: `_solve_milp_simplex(..., initial_point=None)` passes the seed; the MILP dispatch threads `initial_point` through.

**Reformulation** (`binary_multilinear_reform`):
- Records per-aux definitions in append order (`z = ∏b`, `y = E(b)`, `t = y²`), so `extend_initial_point()` maps a warm start over the ORIGINAL variables to a feasible point of the reformed MILP. Previously `initial_solution` was validated against the original model and then silently lost on this route.
- `heuristic_incumbent()`: deterministic 1-flip steepest-descent local search with incremental deltas (a flip probe costs O(terms containing the bit)), **gated to the class where every bit assignment is provably feasible** (no constraints beyond the recognized objvar defining row; every non-objvar variable binary-valued). Auto-runs at reform adoption when no user warm start is given; fixed seed/restarts/probe-budget keep it deterministic.

Purely primal throughout: the driver re-validates every seed, and a better incumbent only prunes — the dual bound and the certified optimum are unchanged by construction.

## Measured (synthetic Bernasconi; oracle = brute force ≤ n=13, local-search-confirmed 36 at n=25)

| case | before | after |
|---|---|---|
| n=25 dense, default solve, 30 s | `feasible 84 / bound 12` (sometimes no incumbent) | **`incumbent 36 (true optimum) / bound 12`**, returns ~11 s |
| n=25 with user `initial_solution` | warm start silently ignored | reported objective 36 |
| n=13 dense certification | 3.7 s | **0.4 s** (the seed collapses the proving phase) |
| heuristic alone (n=25, 512 restarts) | — | finds 36 in ~0.5 s |

## Verification

- `cargo test -p discopt-core` — **461 passed**, including new `seeded_incumbent_validated_then_adopted` (adopt on a valid seed under a truncated search; reject row-infeasible / fractional / wrong-length / out-of-bounds seeds; seeded full search still certifies the true optimum).
- `pytest python/tests/test_binary_multilinear_reform.py` — **32 passed** (extension satisfies every reform row at random binary points, property-tested for both direct and objvar forms; heuristic determinism + quality (nails n=10 brute-force optimum); gating negatives; end-to-end warm start; n=13 seeding-regression ceiling).
- `pytest python/tests -m smoke` — **651 passed, 7 skipped**; `pytest discopt_benchmarks/tests -m smoke` — passed; `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**.
- `ruff check` / `ruff format --check` / `mypy` (0 errors in touched module) / `cargo fmt --check` / `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgMKFo6dCDkmjquLuLTiwF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgMKFo6dCDkmjquLuLTiwF)_