### PR TITLE
test(#309): verify + guard the graduated default path certifies gear4 in a handful of nodes

### DIFF
--- a/python/tests/test_integer_ratio_partition.py
+++ b/python/tests/test_integer_ratio_partition.py
@@ -246,3 +246,26 @@ def test_gear4_both_flags_with_witness_injection_near_root_solve(monkeypatch):
     assert res.bound <= res.objective + 1e-6
     assert res.gap_certified
     assert res.node_count <= 50
+
+
+@pytest.mark.slow
+def test_gear4_default_path_certifies_in_a_handful_of_nodes(monkeypatch):
+    """#309 acceptance guard on the GRADUATED DEFAULT path (both flags default-ON
+    since 2026-07-16, PR #676). The other slow gear4 solves force the flags on via
+    ``setenv(..., "1")``; this one asserts nothing about the environment and relies
+    solely on the shipped defaults, so a silent default flip (or a break in the
+    default wiring) that left the forced-on tests green would still fail here.
+
+    Measured on the default path: 3 nodes / <1 s certified (legacy path with both
+    flags OFF: 4281 nodes / ~35 s). The ceiling of 50 guards the graduated behavior
+    with generous headroom, not an exact count; a soundness-preserving change may
+    move the exact node count."""
+    # Make the default explicit: no override in the environment for either flag.
+    monkeypatch.delenv("DISCOPT_INTEGER_RATIO_PARTITION", raising=False)
+    monkeypatch.delenv("DISCOPT_NS_SHARP_MARGIN", raising=False)
+    m = _gear4()
+    res = m.solve(time_limit=150, gap_tolerance=1e-4)
+    assert res.objective == pytest.approx(GEAR4_OPT, abs=1e-4)
+    assert res.bound <= res.objective + 1e-6  # certificate invariant (min sense)
+    assert res.gap_certified
+    assert res.node_count <= 50


### PR DESCRIPTION
## Summary

Closes #309 (spatial-integer branching node-heavy on the gear4 ratio/bilinear-integer class).

The substantive lever for #309 landed and merged in **PR #676**, which graduated
two bound-changing flags to default-ON after a passing corpus-wide differential
panel (66 instances / 132 runs, `incorrect_count=0`, 0 certification regressions):

- `DISCOPT_INTEGER_RATIO_PARTITION` - the integer-ratio partition bound
  (`_jax/integer_ratio.py`): dives over the quotient's exactly-enumerable
  achievable rational set, unfreezing the gear4 root bound (baseline ~0) and
  injecting root witnesses.
- `DISCOPT_NS_SHARP_MARGIN` - the sharp Neumaier-Shcherbina safe-bound margin: a
  tighter (still rigorous) safe LP lower bound that additionally abstains on
  sign-uncertain unbounded columns.

Both keep the `=0` opt-out and the legacy path intact (CLAUDE.md regime 2).

This PR is the **#309-specific verification + regression guard**, re-measured on
current `main` (post-#676). It is **test-only - no solver behavior changes.**

## gear4 before / after (the acceptance metric)

| config | status | obj | oracle | nodes | wall |
|---|---|---|---|---|---|
| **legacy** (both flags `=0`) | optimal | 1.643428 | 1.6434284740 | **4281** | **~35 s** |
| **default** (graduated ON) | optimal | 1.643428 | 1.6434284740 | **3** | **~0.9 s** |

3 nodes / <1 s is within ~5x of BARON's ~0.18 s and a >1000x node reduction from
the issue's 5921-node baseline - the acceptance target ("within ~10x of BARON,
i.e. seconds") is met.

## The general lever (no instance-specific hacks)

Both flags are structural: `detect_integer_ratio_specs` keys on the *shape*
(quotient of products of sign-definite bounded integers), never a problem name;
the NS sharp margin is a general safe-bound tightening on the MILP-simplex path.
No gear4-keyed special-casing (CLAUDE.md section 2).

## Correctness - ratio/bilinear-integer cohort on current `main` (default flags)

`incorrect_count = 0`. Every `optimal` claim matches its `minlplib.solu` oracle
and satisfies the certificate invariant `bound <= incumbent` (min sense):

| instance | status | obj | oracle | nodes | wall | cert |
|---|---|---|---|---|---|---|
| gear4 | optimal | 1.643428 | 1.6434284740 | 3 | 1.1 s | yes |
| clay0303hfsg | optimal | 26669.109551 | 26669.1095700000 | 443 | 37 s | yes |
| ex1263a | optimal | 19.6 | 19.6 | 9483 | 0.5 s | yes |
| tln4 | time_limit | - | 8.3 | 52319 | 60 s | open |
| tln5 | time_limit | - | 10.3 | 29247 | 60 s | open |

tln4/tln5 do not certify within 60 s on this container, but this is **not a #309
regression**: with the graduated flags forced OFF (legacy path) they time out
identically (tln4 bound 1.7286, tln5 bound 2.1571 - the same open bounds and the
same non-certification in both configs). Their gap is orthogonal to the #309
flags; no false claim is ever made (status `time_limit`, sound bound below the
oracle).

## Regression guard added

`test_gear4_default_path_certifies_in_a_handful_of_nodes` (slow). Every existing
slow gear4 solve forces the flags on via `monkeypatch.setenv(..., "1")`, so none
guard the *shipped default*. The new test sets no environment override, relies
solely on the graduated defaults, and asserts gear4 certifies
(`gap_certified`, `bound <= objective`) in `<= 50` nodes. Fail-before/pass-after
verified: with the flag forced OFF the same solve takes 4295 nodes (> 50) and the
assertion trips.

## Tests run

- `pytest -m smoke` -> **653 passed, 1 skipped**.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` -> **10 passed** (2:27).
- New + existing gear4 partition tests (`-m slow`) -> **5 passed** (incl. the new
  default-path guard, 1.19 s).
- Cohort correctness harness above: `incorrect_count = 0`.

No Rust source changed (the extension was rebuilt only to match `main`'s existing
`initial_incumbent` binding for this multi-worktree checkout).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
