### PR TITLE
fix(#654): gate optional spatial root-setup on the deadline (honor time_limit)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4972,6 +4972,84 @@ def solve_model(
     _root_lb_snapshot = np.asarray(lb, dtype=np.float64).copy()
     _root_ub_snapshot = np.asarray(ub, dtype=np.float64).copy()
 
+    # --- #654: deadline-exhausted short-circuit before the spatial search build ---
+    # Everything below (the per-node NLP evaluator's one-time XLA compile, the
+    # McCormick LP relaxer build, and the node loop) is *optional* search apparatus:
+    # it only tightens the dual bound or finds an incumbent. On the large sparse
+    # network-design / QAP / graph-partition class (sonet*, qap, super3t) that
+    # build+compile is a fixed multi-second uninterruptible cost that runs to
+    # completion *regardless of* ``time_limit`` — the residual #654 overrun: wall is
+    # ~constant no matter how small ``T`` is. When the whole budget is already spent
+    # before we reach it, decline to *start* the search and instead spend the same
+    # bounded slice the post-search path uses on the rigorous root-relaxation
+    # fallback (``_root_relaxation_lower_bound`` builds its OWN McCormick relaxation
+    # — it does not need ``evaluator`` — and is the designated last-ditch bound
+    # recovery, docs/dev/baron-gap-plan.md §8). This is sound: the fallback runs to
+    # completion (never truncated mid-flight, so casctanks-class keeps its dual
+    # bound), the reported status is ``time_limit`` (never a certified/optimal
+    # claim), and skipping the search only ever *weakens* a still-valid bound —
+    # never falsifies it. When budget remains, ``_deadline_exhausted()`` is False and
+    # this is byte-identical to the pre-fix path (the search runs as before).
+    if _deadline_exhausted():
+        from discopt.modeling.core import ObjectiveSense as _ObjSenseSC
+
+        _rr_bound: Optional[float] = None
+        if model._objective is not None:
+            _is_maximize = model._objective.sense == _ObjSenseSC.MAXIMIZE
+            # Same bounded budget the post-search fallback grants once the limit is
+            # spent: the ``_ROOT_FALLBACK_FLOOR_S`` floor recovers a bound instead of
+            # None while keeping the overrun to a single bounded op.
+            _rr_budget = max(_remaining_budget(), _ROOT_FALLBACK_FLOOR_S)
+            try:
+                _rr_val = _root_relaxation_lower_bound(
+                    model,
+                    _root_lb_snapshot,
+                    _root_ub_snapshot,
+                    _rr_budget,
+                    psd_cuts=psd_cuts,
+                )
+            except Exception as _rr_exc:  # pragma: no cover - defensive
+                logger.debug(
+                    "root-relaxation fallback (deadline short-circuit) failed: %s", _rr_exc
+                )
+                _rr_val = None
+            if _rr_val is not None and np.isfinite(_rr_val):
+                # A lower bound on the internally minimized objective: for a MINIMIZE
+                # it is the dual lower bound directly; for a MAXIMIZE the builder
+                # minimizes ``-obj`` so a lower bound ``L`` on ``-obj`` gives the
+                # valid upper bound ``-L`` (mirrors the post-search negation).
+                _rr_bound = -_rr_val if _is_maximize else _rr_val
+        logger.info(
+            "time_limit spent before spatial search build (#654) — declining the "
+            "search apparatus; reporting the rigorous root-relaxation bound"
+        )
+        wall_time = time.perf_counter() - t_start
+        # Interactive debugger: fire the terminal checkpoint on this early exit too,
+        # so ``debug="on-error"`` sessions observe the (non-"optimal") termination
+        # exactly as they would on the normal loop exit (line ~9020). The status is
+        # always the non-certified ``"time_limit"`` here, so ``error`` is set.
+        from discopt import debug as _debug_sc
+
+        _debug_sc.fire(
+            _debug_sc.Checkpoint.TERMINATED,
+            model=model,
+            iteration=0,
+            elapsed=wall_time,
+            error="time_limit",
+        )
+        return SolveResult(
+            status="time_limit",
+            objective=None,
+            bound=_rr_bound,
+            gap=None,
+            x=None,
+            wall_time=wall_time,
+            node_count=0,
+            rust_time=rust_time,
+            jax_time=jax_time,
+            python_time=wall_time - rust_time - jax_time,
+        )
+
     # --- Create PyTreeManager (Rust) ---
     t_rust_start = time.perf_counter()
     tree = PyTreeManager(
@@ -5469,14 +5547,30 @@ def solve_model(
                         # timeout — so a brief cap suffices and leaves the bulk of
                         # the budget for the actual B&B. Mirror the OBBT root-budget
                         # heuristic above, never exceeding the live remaining time.
-                        _probe_remaining = time_limit - (time.perf_counter() - t_start)
-                        _probe_budget = min(
-                            max(time_limit * 0.1, 2.0),
-                            max(_probe_remaining, _DEADLINE_NODE_FLOOR_S),
-                        )
-                        _probe = _mc_lp_relaxer.solve_at_node(
-                            _probe_lb, _probe_ub, time_limit=_probe_budget
-                        )
+                        if _deadline_exhausted():
+                            # #654: the probe's FIRST ``solve_at_node`` builds the
+                            # full McCormick LP (seconds on the large sparse
+                            # sonet/qap/eg_all_s class) — that build is NOT bounded by
+                            # the solve ``time_limit`` below, only the Rust MILP solve
+                            # is — solely to decide whether to keep the relaxer for a
+                            # search that, past the deadline, finalizes after <=1 node.
+                            # Once the budget is already spent, skip the probe: leaving
+                            # ``_probe=None`` drops the relaxer to the sound ``"none"``
+                            # bound source, the node loop exits immediately, and the
+                            # rigorous post-search root-relaxation fallback still
+                            # supplies the dual bound. Sound: the relaxer only ever
+                            # *tightens* a per-node bound the fallback also computes —
+                            # skipping it never changes the reported bound's validity.
+                            _probe = None
+                        else:
+                            _probe_remaining = time_limit - (time.perf_counter() - t_start)
+                            _probe_budget = min(
+                                max(time_limit * 0.1, 2.0),
+                                max(_probe_remaining, _DEADLINE_NODE_FLOOR_S),
+                            )
+                            _probe = _mc_lp_relaxer.solve_at_node(
+                                _probe_lb, _probe_ub, time_limit=_probe_budget
+                            )
                     except Exception as e:  # pragma: no cover - defensive
                         logger.debug("McCormick LP root probe failed: %s", e)
                         _probe = None

--- a/python/tests/test_issue654_deadline_root_setup.py
+++ b/python/tests/test_issue654_deadline_root_setup.py
@@ -1,0 +1,134 @@
+"""Issue #654 — the pre-B&B root-setup phase honors ``solve(time_limit=T)``.
+
+``Model.solve(time_limit=T)`` was violated on a class of large sparse
+network-design / QAP / graph-partition MINLPs (sonet*, qap, super3t, eg_all_s):
+wall time was roughly *constant* regardless of ``T`` because an uninterruptible
+pre-B&B "root setup" phase — the per-node NLP evaluator's one-time XLA compile,
+the McCormick LP relaxer build, and the root LP probe — ran to completion before
+the (already deadline-respecting) Rust B&B loop, none of it polling the deadline.
+
+The fix gates *entry* into that OPTIONAL search apparatus on the remaining
+budget (``solver._deadline_exhausted``): once ``time_limit`` is already spent the
+solver declines to build the search and instead spends the same bounded slice on
+the rigorous root-relaxation fallback (``_root_relaxation_lower_bound`` — the
+designated last-ditch dual bound, which builds its OWN relaxation and needs no
+evaluator). This never truncates a bound-producing op mid-flight
+(docs/dev/baron-gap-plan.md §8) and only ever *weakens* a still-valid bound, so
+``incorrect_count`` stays 0.
+
+These tests pin:
+  * the gate is INERT when the budget is ample — an ample-budget solve still runs
+    the search (node_count > 0) and certifies the true optimum unchanged
+    (bound-neutrality: the gated phases must not alter a certified result);
+  * the gate BITES when the budget is spent — a zero/tiny-budget solve skips the
+    search (node_count == 0), returns promptly with a sound (never false-optimal,
+    never oracle-crossing) result;
+  * (slow, big-corpus) on sonet22v4 the wall now *scales* with ``T`` instead of
+    being a fixed ~10 s floor.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import discopt as do
+import pytest
+
+
+def _spatial_model():
+    """A small nonconvex MINLP (transcendental + bilinear) that routes to the
+    spatial-McCormick B&B path guarded by the #654 root-setup gate."""
+    m = do.Model("issue654")
+    x = m.continuous("x", lb=0.1, ub=4.0)
+    y = m.continuous("y", lb=0.1, ub=4.0)
+    z = m.integer("z", lb=0, ub=3)
+    m.subject_to(x * y + z >= 3.0)
+    m.subject_to(y == do.exp(x) - 1.0)
+    m.minimize(x + 0.5 * y + 0.3 * z)
+    return m
+
+
+@pytest.mark.requires_pounce
+def test_ample_budget_gate_is_inert_and_bound_neutral():
+    """With budget to spare the gate never fires: the spatial search runs
+    (node_count > 0) and certifies the true optimum. This is the bound-neutrality
+    guard — the #654 entry gates must not change a certified result."""
+    r = _spatial_model().solve(time_limit=30.0)
+    assert r.status == "optimal", f"ample-budget solve did not certify: {r.status}"
+    assert r.objective is not None
+    # The search actually ran — the deadline short-circuit did NOT fire.
+    assert r.node_count > 0, "ample-budget solve unexpectedly skipped the search"
+    # Sound certificate: the dual bound sits at (or below) the incumbent.
+    assert r.bound is not None
+    assert r.bound <= r.objective + 1e-4
+
+
+@pytest.mark.requires_pounce
+def test_zero_budget_short_circuits_soundly():
+    """A zero budget spends the whole limit in presolve, so the root-setup gate
+    fires: the spatial search apparatus (evaluator compile + relaxer + probe +
+    node loop) is skipped (node_count == 0) and the solver returns promptly with a
+    sound result — never a false optimum, and any surfaced dual bound is a valid
+    lower bound (<= the true optimum)."""
+    # Reference optimum from an ample solve (self-consistent oracle).
+    ref = _spatial_model().solve(time_limit=30.0)
+    assert ref.status == "optimal" and ref.objective is not None
+    opt = ref.objective
+
+    t0 = time.perf_counter()
+    r = _spatial_model().solve(time_limit=0.0)
+    wall = time.perf_counter() - t0
+
+    # The gate fired: no node was processed (search apparatus declined).
+    assert r.node_count == 0, "zero-budget solve still ran the spatial search"
+    # Deadline honored: no dominant uninterruptible search build — bounded to at
+    # most the one designated root-relaxation fallback op.
+    assert wall < 20.0, f"zero-budget solve ran {wall:.1f}s — root setup not gated"
+    # Never a false optimum on a spent budget.
+    assert r.status != "optimal"
+    # Any surfaced dual bound must be a valid lower bound (MINIMIZE): never cross
+    # the true optimum. ``None`` (no bound proven) is also sound.
+    if r.bound is not None:
+        assert r.bound <= opt + 1e-4, f"unsound bound {r.bound} > opt {opt}"
+    # And it must never claim a feasible point strictly better than the optimum.
+    if r.objective is not None:
+        assert r.objective >= opt - 1e-4
+
+
+_BENCH = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+
+
+@pytest.mark.slow
+@pytest.mark.requires_pounce
+def test_sonet22v4_wall_scales_with_time_limit():
+    """On the triggering instance, wall must now *scale* with ``time_limit`` (the
+    #654 bug was that it did not — a fixed ~10 s root-setup floor dominated). The
+    dual bound must stay valid (never cross the sonet22v4 oracle dual bound
+    2311055.149; ``None`` is sound too)."""
+    path = os.path.join(_BENCH, "sonet22v4.nl")
+    if not os.path.exists(path):
+        pytest.skip("sonet22v4.nl not vendored (big corpus)")
+
+    from discopt.modeling.core import from_nl
+
+    def _run(tl):
+        t0 = time.perf_counter()
+        r = from_nl(path).solve(time_limit=tl)
+        return time.perf_counter() - t0, r
+
+    wall2, r2 = _run(2.0)
+    wall5, r5 = _run(5.0)
+
+    # Deadline honored to within one bounded uninterruptible fallback op (the
+    # documented root-relaxation floor), and — the crux of #654 — the T=2 wall is
+    # meaningfully below the T=5 wall: the budget now matters.
+    assert wall2 < 30.0, f"T=2 wall {wall2:.1f}s — root setup not gated"
+    assert wall2 < wall5 + 3.0, (
+        f"wall did not scale with time_limit (T=2 {wall2:.1f}s vs T=5 {wall5:.1f}s)"
+    )
+    # sonet22v4 is a MINIMIZE; a valid dual bound never exceeds the oracle optimum.
+    _ORACLE = 2373966.0
+    for r in (r2, r5):
+        if r.bound is not None:
+            assert r.bound <= _ORACLE + 1.0, f"unsound bound {r.bound} > oracle {_ORACLE}"


### PR DESCRIPTION
## Contributes to #654 — deadline-aware pre-B&B root setup

The residual #654 overrun: `solve(time_limit=T)` was ~constant regardless of `T` on
the large sparse network-design / QAP / graph-partition class (sonet*, qap, super3t,
eg_all_s), because an uninterruptible pre-B&B "root setup" phase ran to completion
before the (already deadline-respecting) Rust B&B loop. #507 (term-classifier) and
#187 (XLA Jacobian compile) closed two specific sites; this addresses the residual
general phase.

### Profile (where the residual went — sonet22v4, T=2s -> wall ~9.5s on `main`)

Instrumented phase wall-times (budget spent at 2s):

| phase | starts | cost | notes |
|---|---|---|---|
| Rust presolve + FBBT | 0s | ~1.4s | required, bound-producing (§8: don't truncate) |
| convexity classify | ~1.5s | ~0.5s | already budget-gated (honored) |
| `_make_evaluator` (XLA compile) | ~2.7s | **~2.4s** | atomic compile floor (#187), runs post-budget |
| McCormick relaxer build + **root LP probe** | ~5s | **~2.7s** | probe's first `solve_at_node` **builds the full McCormick LP** — that build is *not* bounded by its solve `time_limit`, only the Rust MILP solve is |
| `_root_relaxation_lower_bound` fallback | ~7.7s | ~1.5-5s+ | **bound-producing** (casctanks/super3t/sonet23v4's dual bound) |

All three middle phases execute **after** the budget is spent and are **optional**
search apparatus (they only tighten a bound or find an incumbent). For qap / eg_all_s
the probe's LP build is 5-7s — the issue's ">110s, 0 nodes" cases never finished the
root before the external cap.

### Fix (extends the existing `_deadline_exhausted()` entry-gate pattern)

The repo already gates root OBBT, the root cut pool, and F4 root heuristics on
`_deadline_exhausted()`. This adds two gates in the same style:

1. **Short-circuit before the spatial search build.** When the budget is already spent
   at the point we would build the evaluator + relaxer + node loop, decline them and
   spend the same bounded slice on the rigorous root-relaxation fallback
   (`_root_relaxation_lower_bound` builds its **own** McCormick relaxation — it does not
   need the evaluator — and is the designated last-ditch dual bound). Fires the
   `TERMINATED` debug checkpoint so `debug="on-error"` sessions still observe the exit.
2. **Gate the root LP probe's `solve_at_node` build.** Leaving `_probe=None` drops the
   relaxer to the sound `"none"` bound source; the node loop exits immediately and the
   post-search fallback still supplies the dual bound.

### Why it's sound (which phases are optional)

- Both gates only decline to **start** optional bound-tightening work; they **never
  truncate an in-flight bound-producing op** (CLAUDE.md §1, `docs/dev/baron-gap-plan.md`
  §8). The root-relaxation fallback — which *is* the dual bound for casctanks (5.698),
  super3t (-1.0), sonet23v4 (-53974.375) — always runs to completion.
- Skipping the search only ever **weakens** a still-valid bound (looser box / fewer
  cuts); it can never falsify one. Reported status is `time_limit`, never a
  certified/optimal claim, so no false-optimal is possible.
- **Bound-neutral when budget is ample:** `_deadline_exhausted()` is `False`, so both
  gates are inert and the path is byte-identical to before — a certified solve is
  unchanged.

### Before / after (back-to-back, same machine; bounds preserved exactly)

| instance | T | baseline wall | fixed wall | bound base -> fix |
|---|---|---|---|---|
| sonet22v4 | 2s | 10.4s | **6.6s** | None -> None |
| sonet22v4 | 5s | 10.8s | **9.7s** | None -> None |
| sonet23v4 | 2s | 48.9s | **24.4s** | -53974.375 -> **-53974.375** |
| qap / eg_all_s | 2s | >110s (external cap, 0 nodes) | **~12-13s** | None -> None |

Wall now **scales with `T`** (sonet22v4: 6.6s @ T=2 vs 9.7s @ T=5 — the budget matters),
where before it was a fixed ~10s floor.

### Remaining gap (why "Contributes to", not "Closes")

The single residual is the **root-relaxation fallback's own relaxation build**, which on
this class is 5-25s and, for casctanks/super3t/sonet23v4, **is the bound-producing op**
§8 forbids truncating (build cost and bound-yield don't separate cheaply — super3t
builds 4.4s and yields a bound; qap builds 5s and yields None, indistinguishable a
priori). This is the "one in-flight uninterruptible op" the DoD margin explicitly
allows. Making `build_milp_relaxation` itself deadline-aware without risking the
bound-producing cases is a larger, separately-scoped change.

### Verification (all run synchronously)

- `pytest -m smoke` — **653 passed**, 1 skipped
- adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`) — **10 passed**
- `pytest -m correctness` — **407 passed**, 7 skipped, 6 xfailed (no `incorrect_count`, no oracle-crossing bound)
- New regression test `python/tests/test_issue654_deadline_root_setup.py`: **fails before**
  the change (`node_count=1`, search ran) and **passes after** (`node_count=0`,
  short-circuit fired); also pins bound-neutrality on an ample budget and wall-scaling
  on sonet22v4.
- `ruff check` / `ruff format` clean; `mypy` clean (pre-commit passed). No Rust changed
  (`cargo test` not required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
