### PR TITLE
research(#677): falsify joint-correlation (degree-4 moment) coupling as the autocorr cert lever

### DIFF
--- a/discopt_benchmarks/pyproject.toml
+++ b/discopt_benchmarks/pyproject.toml
@@ -75,6 +75,9 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "C4", "SIM", "TCH"]
 # A/N/M/V are LP constraint matrices / moment matrices in the issue-673
 # z-polytope falsification (standard linear-algebra notation).
 "scripts/bqp673_zpolytope_falsification.py" = ["N803", "N806"]
+# B/M/K are the monomial basis / moment matrix / lag count in the issue-677
+# joint-correlation moment probe (standard linear-algebra notation).
+"scripts/joint_correlation_moment_probe.py" = ["N803", "N806"]
 
 [tool.coverage.run]
 source = ["benchmarks", "utils"]

--- a/discopt_benchmarks/scripts/joint_correlation_moment_probe.py
+++ b/discopt_benchmarks/scripts/joint_correlation_moment_probe.py
@@ -1,0 +1,153 @@
+"""Entry experiment for issue #677 — falsifying the joint-correlation
+(cross-square) lever for certifying the autocorr/LABS class.
+
+#673 showed that pairwise `z`-polytope cuts (triangle/PSD/RLT) leave the
+reformed-autocorr root bound at the parity floor. #677 re-scoped to the only
+remaining lever: coupling the *joint* realization of the correlation vector
+`(C_1,…,C_K)`, via the degree-4 moment (Lasserre level-2) relaxation.
+
+This probe solves the **combined** relaxation, which is the strongest form of the
+idea — the level-2 moment matrix ``M(y) ⪰ 0`` over ``s in {±1}`` (which sees the
+cross-square degree-4 couplings) PLUS the per-square parity secant cuts
+``t_k ≥ (u+v)y_k − uv`` (the integrality structure that gives the reformed model
+its floor). Pseudo-moments need not have ``(E[C_k], E[C_k²])`` inside the integer
+hull, so the secant cuts genuinely add to the SDP.
+
+  y_S     : moment of squarefree monomial  s_S = ∏_{i∈S} s_i  (|S| ≤ 4), y_∅ = 1
+  M[S,T]  = y_{S△T}  over degree-≤2 monomials S,T  (the level-2 moment matrix)
+  y_k = E[C_k]   = Σ_i y_{{i,i+k}}
+  t_k = E[C_k²]  = Σ_{i,i'} y_{{i,i+k}△{i',i'+k}}
+  minimize Σ_k t_k  s.t.  M ⪰ 0,  secant(t_k, y_k),  |y_S| ≤ 1
+
+Result (recorded in ``docs/dev/performance-plan.md`` §6, 2026-07-17): the bound
+moves above the floor only at small n and the movement **decays to zero by the
+target scale n=25** (11.9999 vs floor 12; optimum 36), while the dense SDP
+(326×326, ~2 min for a single root relaxation) is intractable in-solver. The
+LABS Fourier sum-rule (#677 direction 2) is a single ``vᵀMv ≥ 0`` cut subsumed by
+the level-1 PSD closure #673 already found inert.
+
+Requires ``cvxpy`` + an SDP solver (``pip install cvxpy clarabel``); prints a note
+and exits if unavailable. Small n solve in seconds; n≥20 take minutes (SCS).
+Run: ``python discopt_benchmarks/scripts/joint_correlation_moment_probe.py``
+"""
+
+from __future__ import annotations
+
+import itertools
+import time
+
+import numpy as np
+import scipy.sparse as sp
+
+
+def parity_floor(n: int, K: int) -> int:
+    """|C_k| ≥ 1 whenever (n-k) is odd; the floor is the count of such lags."""
+    return sum(1 for k in range(1, K + 1) if (n - k) % 2 == 1)
+
+
+def brute_optimum(n: int, K: int) -> int:
+    def energy(bits):
+        s = [2 * x - 1 for x in bits]
+        return sum(sum(s[i] * s[i + k] for i in range(n - k)) ** 2 for k in range(1, K + 1))
+
+    return min(energy(bits) for bits in itertools.product([0, 1], repeat=n))
+
+
+def combined_level2_secant(n: int, K: int, solver: str = "CLARABEL"):
+    """Combined level-2 moment SDP + parity secant cuts; returns (value, status,
+    solve_seconds, matrix_dim, n_moments) or a reason string if cvxpy absent."""
+    try:
+        import cvxpy as cp
+    except ImportError:
+        return None
+
+    # degree-≤2 squarefree monomials index the moment matrix
+    B = [frozenset()]
+    B += [frozenset((i,)) for i in range(n)]
+    B += [frozenset((i, j)) for i, j in itertools.combinations(range(n), 2)]
+    nb = len(B)
+
+    mom = sorted(
+        {B[a] ^ B[b] for a in range(nb) for b in range(nb)} - {frozenset()},
+        key=lambda s: (len(s), tuple(sorted(s))),
+    )
+    idx = {U: j for j, U in enumerate(mom)}
+    n_mom = len(mom)
+
+    # sparse moment -> matrix-entry map (empty diff -> identity constant)
+    rows, cols = [], []
+    for a in range(nb):
+        for b in range(nb):
+            U = B[a] ^ B[b]
+            if U:
+                rows.append(a * nb + b)
+                cols.append(idx[U])
+    amap = sp.csr_matrix((np.ones(len(rows)), (rows, cols)), shape=(nb * nb, n_mom))
+    i_flat = np.eye(nb).reshape(-1)
+
+    y = cp.Variable(n_mom)
+    matrix = cp.reshape(amap @ y + i_flat, (nb, nb), order="C")
+    cons = [matrix >> 0, y <= 1, y >= -1]
+
+    obj_coef = np.zeros(n_mom)
+    obj_const = 0.0
+    for k in range(1, K + 1):
+        yk = np.zeros(n_mom)
+        for i in range(n - k):
+            yk[idx[frozenset((i, i + k))]] += 1.0
+        tk = np.zeros(n_mom)
+        tk_const = 0.0
+        for i in range(n - k):
+            for ip in range(n - k):
+                U = frozenset((i, i + k)) ^ frozenset((ip, ip + k))
+                if U:
+                    tk[idx[U]] += 1.0
+                else:
+                    tk_const += 1.0
+        obj_coef += tk
+        obj_const += tk_const
+        rng = n - k
+        c0 = (n - k) % 2  # parity of the C_k value
+        g = 2
+        lo = -rng + ((c0 + rng) % g)
+        hi = rng - ((rng - c0) % g)
+        for u in range(lo, hi, g):
+            v = u + g
+            cons.append((tk - (u + v) * yk) @ y + (tk_const + u * v) >= 0)
+
+    prob = cp.Problem(cp.Minimize(obj_coef @ y + obj_const), cons)
+    t0 = time.time()
+    prob.solve(solver=getattr(cp, solver))
+    return prob.value, prob.status, time.time() - t0, nb, n_mom
+
+
+def main():
+    print("Combined level-2 moment + parity-secant bound vs parity floor (issue #677)\n")
+    # small n with the exact solver; larger n need SCS and are slow (documented).
+    plan = [(6, "CLARABEL"), (8, "CLARABEL"), (10, "CLARABEL"), (13, "CLARABEL"), (20, "SCS")]
+    for n, solver in plan:
+        K = n - 1
+        out = combined_level2_secant(n, K, solver)
+        if out is None:
+            print("cvxpy not installed — `pip install cvxpy clarabel` to run this probe.")
+            return
+        val, status, dt, nb, n_mom = out
+        pf = parity_floor(n, K)
+        opt = brute_optimum(n, K) if n <= 18 else None
+        moved = "MOVED" if val is not None and val > pf + 1e-3 else "flat"
+        shown = None if val is None else round(val, 3)
+        print(
+            f"n={n:2d}: parity_floor={pf:2d}  level2+secant={shown!s:>7}"
+            f"  opt={opt}  [{moved}]  ({status}, {nb}x{nb}, {dt:.1f}s, {solver})"
+        )
+    print(
+        "\nn=25 (the target, SCS eps=1e-6, ~2 min): "
+        "parity_floor=12, level2+secant=11.9999, opt=36.\n"
+        "The movement above the floor decays to zero by n≈13 and is nil at n=25, while the\n"
+        "dense 326x326 SDP is intractable in-solver. Both #677 directions fail the kill\n"
+        "criterion — see docs/dev/performance-plan.md §6 (2026-07-17)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -466,6 +466,46 @@ panel green for 3 consecutive nightlies before default-on.
 > lever for this class is cross-square/joint-correlation coupling, a distinct
 > higher-risk research direction — not `z`-polytope cuts.
 
+> **Falsified (2026-07-17, issue #677 — "joint-correlation / degree-4 moment
+> coupling certifies the autocorr class").** #673's re-scope pointed at the only
+> remaining lever: coupling the *joint* realization of `(C_1,…,C_K)` via the
+> degree-4 moment (Lasserre **level-2**) relaxation over `s ∈ {±1}`. Entry
+> experiment (before any engine integration, per #677's kill criterion): solve
+> the **combined** relaxation — the strongest form — the level-2 moment matrix
+> `M(y) ⪰ 0` (which *does* see the cross-square degree-4 couplings the pairwise
+> matrix misses) **plus** the per-square parity secant cuts `t_k ≥ (u+v)y_k−uv`
+> (pseudo-moments need not put `(E[C_k],E[C_k²])` in the integer hull, so the
+> secant cuts genuinely add to the SDP). Solved with CLARABEL/SCS:
+>
+> | n | parity floor | level-2+secant | movement | opt |
+> |---|---|---|---|---|
+> | 6 | 3 | 5.00 | **+2.0** | 7 |
+> | 8 | 4 | 4.76 | +0.76 | 8 |
+> | 10 | 5 | 5.77 | +0.77 | 13 |
+> | 13 | 6 | 6.00 | +0.0 (=opt) | 6 |
+> | 20 | 10 | 10.001 | ~0 | — |
+> | **25** (target) | **12** | **11.9999** | **~0** | 36 |
+>
+> The lever is **real but decays to zero by the target scale**: it moves the
+> bound above the floor only for small n (n=6 +2.0, n=8/10 ≈+0.76), the absolute
+> movement shrinks with n, and at n=25 the combined bound sits exactly at the
+> parity floor (11.9999, optimum 36). Worse, the mechanism is **intractable
+> in-solver**: the level-2 moment matrix is dense `326×326` at n=25 (15,275
+> moment vars), ~2 min for a *single* root relaxation at loose accuracy — hopeless
+> against the 60 s budget, before even considering per-node use. #677 direction 2
+> (the LABS Fourier sum-rule) is a single `vᵀM v ≥ 0` inequality **subsumed by
+> the level-1 PSD closure** #673 already found inert (12.0), so it is dead by
+> domination. Pure level-2 *without* the secant cuts is actually **weaker** than
+> the floor on most n (n=8 3.67<4, n=13 3.47<6) — it drops the per-square
+> integrality the reformed model exploits. **No code shipped.** This settles the
+> autocorr **dual-side** wall: no proposed relaxation lever (BQP/PSD `z`-polytope,
+> degree-4 moment, sum-rule) moves the n=25 bound off the parity floor tractably;
+> the LABS/merit-factor lower bound is genuinely hard (consistent with the weak
+> LP/SDP relaxations in that literature). The shipped practical state stands —
+> incumbent seeding returns the true optimum 36 in ~0.5 s; only certification is
+> open, and it is open on a hard-bound, not an engine, gap. Reproduction:
+> `discopt_benchmarks/scripts/joint_correlation_moment_probe.py`.
+
 ## 7. Sequencing & rationale (revised by the measurement)
 
 ```


### PR DESCRIPTION
## Summary

Investigation outcome for #677 (follow-up to #673). Per #677's own kill criterion — "measure whether the root bound moves materially above the parity floor **before** writing any engine integration" — I ran the entry experiment first.

I solved the **combined** relaxation (the strongest form of the idea): the level-2 moment matrix `M(y) ⪰ 0` over `s ∈ {±1}` — which *does* capture the cross-square degree-4 couplings the pairwise `z`-polytope missed — **plus** the per-square parity secant cuts (pseudo-moments need not put `(E[C_k], E[C_k²])` in the integer hull, so the secant cuts genuinely add to the SDP). CLARABEL / SCS:

| n | parity floor | level-2 + secant | movement | opt |
|---|---|---|---|---|
| 6 | 3 | 5.00 | **+2.0** | 7 |
| 8 | 4 | 4.76 | +0.76 | 8 |
| 10 | 5 | 5.77 | +0.77 | 13 |
| 13 | 6 | 6.00 | 0 (=opt) | 6 |
| 20 | 10 | 10.001 | ~0 | — |
| **25** (target) | **12** | **11.9999** | **~0** | 36 |

## Conclusion

The lever is **real but decays to zero by the target scale**: the movement above the floor shrinks with n and is nil at n=25, where the combined bound sits exactly at the parity floor (11.9999, optimum 36). The mechanism is also **intractable in-solver** — the level-2 moment matrix is dense `326×326` at n=25 (15,275 moment vars), ~2 min for a *single* root relaxation, against a 60 s budget. #677 direction 2 (the LABS Fourier sum-rule) is a single `vᵀM v ≥ 0` cut **subsumed by the level-1 PSD closure** #673 already found inert — dead by domination. (Pure level-2 *without* the secant cuts is actually *weaker* than the floor on most n — it drops the per-square integrality the reformed model exploits.)

**Both #677 directions fail the kill criterion.** This settles the autocorr **dual-side** wall: no proposed relaxation lever (BQP/PSD `z`-polytope, degree-4 moment, sum-rule) moves the n=25 bound off the parity floor tractably — it is a genuinely hard LABS/merit-factor bound. The shipped practical state stands: incumbent seeding returns the true optimum 36 in ~0.5 s; only certification is open, and it is open on a hard-bound gap, not an engine gap.

## Changes

- **`docs/dev/performance-plan.md` §6** — falsification record (house style: closure table, decay analysis, tractability, domination of the sum-rule).
- **`discopt_benchmarks/scripts/joint_correlation_moment_probe.py`** — reproduction (combined level-2 + secant SDP, cvxpy-optional; prints a note and exits if cvxpy absent).
- **`discopt_benchmarks/pyproject.toml`** — one per-file lint ignore (matrix notation), matching existing precedent.

## Testing

- `python discopt_benchmarks/scripts/joint_correlation_moment_probe.py` — reproduces the table (small n in seconds; n=25 documented, ~2 min under SCS).
- `ruff check` / `ruff format --check` — clean on the new script.

No production code paths changed (docs + reproduction script + lint config only), so there is no solver behavior to regress. No `pytest` pin added — the decisive n=25 datapoint needs a dense SDP and `cvxpy` (not a repo dependency); the reproduction script is the artifact, consistent with the other §6 falsification records.

Closes #677.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDMp6JoPUY29GRdyunzYJd)_