### PR TITLE
feat(gp): per-expression log-curvature lattice (issue #115)

### DIFF
--- a/python/discopt/_jax/convexity/__init__.py
+++ b/python/discopt/_jax/convexity/__init__.py
@@ -24,6 +24,14 @@ from __future__ import annotations
 
 from .certificate import certify_convex, refresh_convex_mask
 from .lattice import Curvature
+from .log_lattice import (
+    LogCurvature,
+    classify_log_curvature,
+    log_combine_product,
+    log_combine_sum,
+    log_negate,
+    log_scale_pow,
+)
 from .rules import (
     OACutConvexity,
     classify_constraint,
@@ -34,11 +42,17 @@ from .rules import (
 
 __all__ = [
     "Curvature",
+    "LogCurvature",
     "OACutConvexity",
     "certify_convex",
     "classify_constraint",
     "classify_expr",
+    "classify_log_curvature",
     "classify_model",
     "classify_oa_cut_convexity",
+    "log_combine_product",
+    "log_combine_sum",
+    "log_negate",
+    "log_scale_pow",
     "refresh_convex_mask",
 ]

--- a/python/discopt/_jax/convexity/log_lattice.py
+++ b/python/discopt/_jax/convexity/log_lattice.py
@@ -1,0 +1,407 @@
+"""Per-expression log-curvature lattice for geometric programming.
+
+This is the log-space analogue of the original-space :class:`Curvature`
+lattice in :mod:`discopt._jax.convexity.lattice`, propagated through the
+*same* :class:`~discopt.modeling.core.Expression` DAG. Where the x-space
+walker (:mod:`discopt._jax.convexity.rules`) answers "is this expression
+convex in ``x``?", this walker answers "is this expression **log-convex**
+in ``x``?" — i.e. is ``F(u) = log f(exp(u))`` convex/concave/affine after
+the geometric-programming change of variables ``u_j = log x_j``.
+
+The two lattices are kept **strictly separate** (a distinct enum, a
+distinct walker, no cross-contamination). This is deliberate and a
+soundness requirement: a genuine posynomial is log-convex but *not*
+convex in ``x`` (its Hessian is indefinite on the positive orthant), so
+folding a log-curvature verdict into the x-space verdict would mis-gate
+the x-space convex fast path — a soundness break. See
+:func:`discopt.gp.is_log_convex` for the same argument at whole-model
+scope.
+
+Why a lattice and not the whole-model verdict
+----------------------------------------------
+:func:`discopt.gp.classify_gp` returns a single verdict for an *entire*
+model. This walker instead tags **every sub-expression**, so
+log-curvature *composes*: a posynomial buried deep inside a constraint is
+tagged ``LOG_CONVEX`` and that verdict propagates upward through products,
+ratios, powers and sums. That unlocks reasoning about **partially**
+log-convex models — a model that is a GP in some variables and something
+else in others — which the whole-model verdict cannot express. This is the
+richer form requested in issue #115 (a follow-up to #111); it is additive
+and does not touch the shipped whole-model GP path.
+
+The lattice
+-----------
+For a strictly-positive function ``f`` write ``F(u) = log f(exp(u))``:
+
+* ``LOG_AFFINE``  — ``F`` is affine. Exactly the monomials
+  ``c * prod_j x_j**a_j`` (``c > 0``): ``F = log c + sum_j a_j u_j``.
+* ``LOG_CONVEX``  — ``F`` is convex. Posynomials (sums of monomials) are
+  the canonical example: ``F = log sum_k exp(affine_k)`` (log-sum-exp).
+* ``LOG_CONCAVE`` — ``F`` is concave. E.g. a reciprocal of a posynomial.
+* ``UNKNOWN``     — no proof; the conservative top element.
+
+Soundness invariant
+--------------------
+A non-``UNKNOWN`` label is a **proof**, and it certifies two things at
+once: the expression is strictly **positive** on the model's declared
+box, *and* it has the stated log-curvature. Positivity is carried
+implicitly — every leaf rule that emits a non-``UNKNOWN`` label requires a
+strictly-positive lower bound (variables) or value (constants), and every
+composition rule below preserves positivity — so an operation that cannot
+stay in the positive domain (negation, subtraction) abstains to
+``UNKNOWN``. When a precondition fails, the walker propagates ``UNKNOWN``
+rather than guess.
+
+Composition rules (all sound; references below)
+-----------------------------------------------
+* **product** ``f*g``: ``log(f g) = log f + log g`` — the sum of two
+  log-log-curvatures, so this mirrors :func:`lattice.combine_sum` exactly
+  (convex+convex→convex, concave+concave→concave, convex+concave→unknown,
+  affine is the identity).
+* **ratio** ``f/g``: ``log(f/g) = log f - log g`` — product against the
+  *reciprocal* log-curvature of ``g`` (:func:`log_negate`).
+* **power** ``f**a`` (constant ``a``): ``log(f**a) = a log f`` — scales the
+  log-curvature by ``sign(a)`` (:func:`log_scale_pow`).
+* **sum** ``f+g``: log-convexity is preserved under addition (Boyd &
+  Vandenberghe §3.5.2), so a sum of ``LOG_AFFINE``/``LOG_CONVEX`` terms is
+  ``LOG_CONVEX``; anything else abstains. (Log-*concavity* is **not**
+  preserved under addition — hence the asymmetry.)
+* **max / min**: ``max`` of log-convex is log-convex; ``min`` of
+  log-concave is log-concave (pointwise max/min of convex/concave).
+
+References
+----------
+Boyd, Kim, Vandenberghe, Hassibi (2007), "A tutorial on geometric
+  programming," *Optimization and Engineering* 8(1):67-127.
+Boyd, Vandenberghe (2004), *Convex Optimization*, §3.5 (log-concave /
+  log-convex functions), §4.5 (geometric programming).
+Agrawal, Diamond, Boyd (2019), "Disciplined Geometric Programming,"
+  *Optimization Letters* — the DGP composition calculus this mirrors.
+
+Issue #115 (follow-up to #111).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+import numpy as np
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Expression,
+    FunctionCall,
+    IndexExpression,
+    Model,
+    Parameter,
+    SumExpression,
+    SumOverExpression,
+    UnaryOp,
+    Variable,
+)
+
+# Treat a lower bound / value at or below this as non-positive (out of the
+# strictly-positive GP domain). Matches the posynomial recogniser's tolerance.
+_POS_TOL = 1e-12
+
+
+class LogCurvature(Enum):
+    """Log-space curvature of an expression over the positive orthant.
+
+    For strictly-positive ``f`` and ``F(u) = log f(exp(u))``:
+
+    ``LOG_AFFINE``  — ``F`` affine (a monomial); both log-convex and
+        log-concave.
+    ``LOG_CONVEX``  — ``F`` convex (a posynomial's log-sum-exp form).
+    ``LOG_CONCAVE`` — ``F`` concave.
+    ``UNKNOWN``     — no sound verdict; the conservative top element. Also
+        the verdict whenever strict positivity could not be proven.
+
+    Deliberately distinct from :class:`discopt._jax.convexity.Curvature`;
+    the two lattices must never be conflated (see the module docstring).
+    """
+
+    LOG_AFFINE = "log-affine"
+    LOG_CONVEX = "log-convex"
+    LOG_CONCAVE = "log-concave"
+    UNKNOWN = "unknown"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Lattice operators (the log-space analogues of lattice.py)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def log_negate(c: LogCurvature) -> LogCurvature:
+    """Log-curvature of the reciprocal ``1/f`` given that of ``f``.
+
+    ``log(1/f) = -log f``, so convexity and concavity swap while an affine
+    log stays affine (and ``UNKNOWN`` stays ``UNKNOWN``).
+    """
+    if c == LogCurvature.LOG_CONVEX:
+        return LogCurvature.LOG_CONCAVE
+    if c == LogCurvature.LOG_CONCAVE:
+        return LogCurvature.LOG_CONVEX
+    return c
+
+
+def log_combine_product(a: LogCurvature, b: LogCurvature) -> LogCurvature:
+    """Log-curvature of a product ``f*g``.
+
+    ``log(f g) = log f + log g`` is the *sum* of the two log-log
+    curvatures, so this is the log-space twin of
+    :func:`lattice.combine_sum`: ``LOG_AFFINE`` is the identity, like
+    curvatures reinforce, and convex-against-concave collapses to
+    ``UNKNOWN``.
+    """
+    if a == LogCurvature.UNKNOWN or b == LogCurvature.UNKNOWN:
+        return LogCurvature.UNKNOWN
+    if a == LogCurvature.LOG_AFFINE:
+        return b
+    if b == LogCurvature.LOG_AFFINE:
+        return a
+    if a == b:
+        return a
+    return LogCurvature.UNKNOWN
+
+
+def log_combine_sum(a: LogCurvature, b: LogCurvature) -> LogCurvature:
+    """Log-curvature of a sum ``f+g``.
+
+    Log-convexity is preserved under addition (Boyd & Vandenberghe
+    §3.5.2): a sum of ``LOG_AFFINE``/``LOG_CONVEX`` terms is ``LOG_CONVEX``
+    (a sum of two monomials is a posynomial — log-convex, not log-affine).
+    Log-*concavity* is **not** preserved under addition, so any
+    ``LOG_CONCAVE`` or ``UNKNOWN`` operand yields ``UNKNOWN``.
+    """
+    convexish = (LogCurvature.LOG_AFFINE, LogCurvature.LOG_CONVEX)
+    if a in convexish and b in convexish:
+        return LogCurvature.LOG_CONVEX
+    return LogCurvature.UNKNOWN
+
+
+def log_scale_pow(c: LogCurvature, exponent: float) -> LogCurvature:
+    """Log-curvature of a constant power ``f**exponent``.
+
+    ``log(f**a) = a * log f``: an affine log stays affine under any real
+    ``a``; ``a == 0`` gives the constant ``1`` (``LOG_AFFINE``); ``a > 0``
+    preserves the log-curvature; ``a < 0`` flips it (like
+    :func:`log_negate`).
+    """
+    if c == LogCurvature.UNKNOWN:
+        return LogCurvature.UNKNOWN
+    if c == LogCurvature.LOG_AFFINE:
+        return LogCurvature.LOG_AFFINE
+    if exponent == 0.0:
+        return LogCurvature.LOG_AFFINE
+    if exponent > 0.0:
+        return c
+    return log_negate(c)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Leaf positivity helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _all_positive(value: object) -> bool:
+    """True iff every entry of a numeric value is strictly positive."""
+    arr = np.asarray(value, dtype=np.float64)
+    return arr.size > 0 and bool(np.all(arr > _POS_TOL))
+
+
+def _const_scalar(expr: Expression) -> Optional[float]:
+    """Scalar value of a constant/parameter leaf, else ``None``."""
+    if isinstance(expr, (Constant, Parameter)):
+        val = np.asarray(expr.value)
+        if val.ndim == 0:
+            return float(val)
+    return None
+
+
+def _variable_is_positive(v: Variable) -> bool:
+    lb = np.asarray(v.lb, dtype=np.float64)
+    return lb.size > 0 and float(lb.min()) > _POS_TOL
+
+
+def _indexed_variable_is_positive(expr: IndexExpression) -> bool:
+    base = expr.base
+    if not isinstance(base, Variable):
+        return False
+    lb = np.asarray(base.lb, dtype=np.float64)
+    try:
+        idx_lb = float(np.asarray(lb[expr.index]).min())
+    except (IndexError, TypeError, ValueError):
+        return False
+    return idx_lb > _POS_TOL
+
+
+# ──────────────────────────────────────────────────────────────────────
+# The DAG walker
+# ──────────────────────────────────────────────────────────────────────
+
+
+def classify_log_curvature(
+    expr: Expression,
+    model: Optional[Model] = None,
+    _cache: Optional[dict] = None,
+) -> LogCurvature:
+    """Return the proven :class:`LogCurvature` of ``expr``.
+
+    Walks the expression DAG and propagates log-curvature bottom-up via
+    the sound composition rules in this module. ``LogCurvature.UNKNOWN``
+    is a conservative verdict (no proof / not provably positive), never a
+    claim that the expression is *not* log-convex; callers must treat it
+    as such.
+
+    ``model`` is accepted for signature parity with
+    :func:`discopt._jax.convexity.classify_expr`; leaf positivity is read
+    from each variable's own declared bounds, so it may be ``None``.
+    """
+    if _cache is None:
+        _cache = {}
+    eid = id(expr)
+    cached = _cache.get(eid)
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    result = _classify_impl(expr, model, _cache)
+    _cache[eid] = result
+    return result
+
+
+def _classify_impl(expr: Expression, model: Optional[Model], cache: dict) -> LogCurvature:
+    # --- Leaves -----------------------------------------------------
+    if isinstance(expr, (Constant, Parameter)):
+        # A strictly-positive constant has affine (constant) log.
+        return LogCurvature.LOG_AFFINE if _all_positive(expr.value) else LogCurvature.UNKNOWN
+
+    if isinstance(expr, Variable):
+        # x > 0  =>  log x = u  is affine in u.
+        return LogCurvature.LOG_AFFINE if _variable_is_positive(expr) else LogCurvature.UNKNOWN
+
+    if isinstance(expr, IndexExpression):
+        if isinstance(expr.base, Variable):
+            return (
+                LogCurvature.LOG_AFFINE
+                if _indexed_variable_is_positive(expr)
+                else LogCurvature.UNKNOWN
+            )
+        # Indexing a non-variable base preserves elementwise log-curvature.
+        return classify_log_curvature(expr.base, model, cache)
+
+    # --- Unary ops --------------------------------------------------
+    if isinstance(expr, UnaryOp):
+        if expr.op == "abs":
+            # On the positive domain |f| = f, so a proven label carries
+            # through; an UNKNOWN operand stays UNKNOWN.
+            return classify_log_curvature(expr.operand, model, cache)
+        # Negation leaves the positive orthant (`-f <= 0`), where log-space
+        # curvature is undefined — abstain.
+        return LogCurvature.UNKNOWN
+
+    # --- Binary ops -------------------------------------------------
+    if isinstance(expr, BinaryOp):
+        return _classify_binary(expr, model, cache)
+
+    # --- Function calls --------------------------------------------
+    if isinstance(expr, FunctionCall):
+        return _classify_function_call(expr, model, cache)
+
+    # --- Aggregations ----------------------------------------------
+    if isinstance(expr, SumExpression):
+        # A reduction ``sum(operand)`` is an additive fold; a sum over a
+        # log-convex operand is log-convex.
+        return classify_log_curvature(expr.operand, model, cache)
+
+    if isinstance(expr, SumOverExpression):
+        result: Optional[LogCurvature] = None
+        for t in expr.terms:
+            ti = classify_log_curvature(t, model, cache)
+            result = ti if result is None else log_combine_sum(result, ti)
+            if result == LogCurvature.UNKNOWN:
+                return LogCurvature.UNKNOWN
+        return result if result is not None else LogCurvature.UNKNOWN
+
+    # MatMulExpression and everything else: no sound log-curvature rule.
+    return LogCurvature.UNKNOWN
+
+
+def _classify_binary(expr: BinaryOp, model: Optional[Model], cache: dict) -> LogCurvature:
+    op = expr.op
+
+    if op == "+":
+        a = classify_log_curvature(expr.left, model, cache)
+        b = classify_log_curvature(expr.right, model, cache)
+        return log_combine_sum(a, b)
+
+    if op == "-":
+        # A difference of positive quantities need not be positive, so it
+        # leaves the log-space domain — abstain (mirrors ``neg``).
+        return LogCurvature.UNKNOWN
+
+    if op == "*":
+        a = classify_log_curvature(expr.left, model, cache)
+        b = classify_log_curvature(expr.right, model, cache)
+        return log_combine_product(a, b)
+
+    if op == "/":
+        a = classify_log_curvature(expr.left, model, cache)
+        b = classify_log_curvature(expr.right, model, cache)
+        return log_combine_product(a, log_negate(b))
+
+    if op == "**":
+        # Only a constant real exponent is GP-representable; a variable
+        # exponent has no sound log-curvature rule here.
+        exponent = _const_scalar(expr.right)
+        if exponent is None:
+            return LogCurvature.UNKNOWN
+        base = classify_log_curvature(expr.left, model, cache)
+        return log_scale_pow(base, exponent)
+
+    return LogCurvature.UNKNOWN
+
+
+def _classify_function_call(
+    expr: FunctionCall, model: Optional[Model], cache: dict
+) -> LogCurvature:
+    name = expr.func_name
+
+    if name == "sqrt" and len(expr.args) == 1:
+        # sqrt(f) = f**0.5.
+        return log_scale_pow(classify_log_curvature(expr.args[0], model, cache), 0.5)
+
+    if name == "max" and len(expr.args) >= 2:
+        # Pointwise max of log-convex (incl. log-affine) is log-convex.
+        for a in expr.args:
+            if classify_log_curvature(a, model, cache) not in (
+                LogCurvature.LOG_AFFINE,
+                LogCurvature.LOG_CONVEX,
+            ):
+                return LogCurvature.UNKNOWN
+        return LogCurvature.LOG_CONVEX
+
+    if name == "min" and len(expr.args) >= 2:
+        # Pointwise min of log-concave (incl. log-affine) is log-concave.
+        for a in expr.args:
+            if classify_log_curvature(a, model, cache) not in (
+                LogCurvature.LOG_AFFINE,
+                LogCurvature.LOG_CONCAVE,
+            ):
+                return LogCurvature.UNKNOWN
+        return LogCurvature.LOG_CONCAVE
+
+    # exp / log and other transcendentals bridge between x-space and
+    # log-space; no sound single-lattice rule — abstain.
+    return LogCurvature.UNKNOWN
+
+
+__all__ = [
+    "LogCurvature",
+    "classify_log_curvature",
+    "log_combine_product",
+    "log_combine_sum",
+    "log_negate",
+    "log_scale_pow",
+]

--- a/python/discopt/gp/__init__.py
+++ b/python/discopt/gp/__init__.py
@@ -41,6 +41,9 @@ import discopt.modeling as dm
 from discopt._jax.convexity.log_lattice import (
     LogCurvature,
     classify_log_curvature,
+    log_combine_product,
+    log_combine_sum,
+    log_negate,
 )
 from discopt._jax.convexity.posynomial import (
     Monomial,
@@ -48,12 +51,14 @@ from discopt._jax.convexity.posynomial import (
     is_posynomial,
 )
 from discopt.modeling.core import (
+    BinaryOp,
     Constant,
     Constraint,
     Expression,
     Model,
     ObjectiveSense,
     SolveResult,
+    UnaryOp,
     VarType,
 )
 
@@ -252,6 +257,204 @@ def classify_gp(model: Model) -> Optional[GPStructure]:
         gp_constraints.append(gp_c)
 
     return GPStructure(objective=obj_form, minimize=minimize, constraints=gp_constraints)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Per-row log-curvature report (consumer of the per-expression lattice)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ObjectiveLogCurvature:
+    """Log-curvature of the objective and whether it is convex in ``y``.
+
+    ``curvature`` is the :class:`LogCurvature` of the objective expression.
+    ``log_convex`` is ``True`` iff *optimising* it is a convex problem in
+    ``y = log x``: minimising a log-convex (or log-affine) objective, or
+    maximising a log-concave (or log-affine) one.
+    """
+
+    curvature: LogCurvature
+    minimize: bool
+    log_convex: bool
+
+
+@dataclass
+class ConstraintLogCurvature:
+    """Log-curvature of one constraint's two sides and its feasible set.
+
+    A constraint is normalised to ``body sense 0`` with ``body = lhs -
+    rhs``; ``lhs`` / ``rhs`` here are the :class:`LogCurvature` of the
+    positive / negative additive parts of ``body`` (each strictly positive
+    when not ``UNKNOWN``). ``log_convex`` is ``True`` iff the constraint's
+    feasible region is convex in ``y = log x`` under the sound rule in
+    :func:`model_log_curvature`.
+    """
+
+    source: Constraint
+    lhs: LogCurvature
+    rhs: LogCurvature
+    log_convex: bool
+
+
+@dataclass
+class ModelLogCurvature:
+    """Per-row log-curvature report for a model.
+
+    The whole-model :func:`is_log_convex` returns a single yes/no; this
+    report instead tags **each row** (objective + every constraint) via the
+    per-expression lattice, so a model that is convex-in-``y`` on some rows
+    and not others is legible — the *partially* log-convex case that
+    motivated issue #115.
+    """
+
+    objective: Optional[ObjectiveLogCurvature]
+    constraints: list[ConstraintLogCurvature]
+
+    @property
+    def is_log_convex_program(self) -> bool:
+        """True iff every row is convex in ``y`` (a full GP).
+
+        This is a per-row derivation of the same verdict as
+        :func:`is_log_convex`, and is *more* general: it certifies rows
+        built from nested posynomials / reciprocals (e.g.
+        ``sqrt(x + y) <= t``) that the monomial-splitting
+        :func:`classify_gp` rejects.
+        """
+        obj_ok = self.objective is None or self.objective.log_convex
+        return obj_ok and all(c.log_convex for c in self.constraints)
+
+    @property
+    def log_convex_rows(self) -> int:
+        """Number of constraint rows proven convex in ``y``."""
+        return sum(1 for c in self.constraints if c.log_convex)
+
+
+def _split_additive(
+    expr: Expression, sign: float, plus: list[Expression], minus: list[Expression]
+) -> None:
+    """Group ``expr`` into positive / negative parts at its *top-level* sum.
+
+    Walks only ``+`` / ``-`` / unary ``neg`` so sub-terms such as
+    ``sqrt(x + y)`` or ``1 / (x + y)`` stay intact for the log-curvature
+    walker to classify. ``sign`` tracks the running coefficient sign.
+    """
+    if isinstance(expr, BinaryOp) and expr.op == "+":
+        _split_additive(expr.left, sign, plus, minus)
+        _split_additive(expr.right, sign, plus, minus)
+        return
+    if isinstance(expr, BinaryOp) and expr.op == "-":
+        _split_additive(expr.left, sign, plus, minus)
+        _split_additive(expr.right, -sign, plus, minus)
+        return
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        _split_additive(expr.operand, -sign, plus, minus)
+        return
+    (plus if sign > 0 else minus).append(expr)
+
+
+def _side_log_curvature(terms: list[Expression], cache: dict) -> LogCurvature:
+    """Fold the log-curvature of a sum of terms via :func:`log_combine_sum`.
+
+    Returns ``UNKNOWN`` for an empty side (no positive quantity to reason
+    about). A positive-coefficient scalar factor inside a term is handled
+    by the walker itself (``c * f`` is ``log_combine_product`` of an affine
+    coefficient), so no coefficient bookkeeping is needed here.
+    """
+    result: Optional[LogCurvature] = None
+    for term in terms:
+        label = classify_log_curvature(term, None, cache)
+        result = label if result is None else log_combine_sum(result, label)
+        if result == LogCurvature.UNKNOWN:
+            return LogCurvature.UNKNOWN
+    return result if result is not None else LogCurvature.UNKNOWN
+
+
+def _constraint_log_curvature(constraint: Constraint, cache: dict) -> ConstraintLogCurvature:
+    """Classify a single constraint's feasible-set log-curvature.
+
+    With ``body = P - N`` (positive part ``P``, negative part ``N``) the
+    constraint means ``P <= N`` (``<=``), ``P >= N`` (``>=``), or ``P == N``
+    (``==``). Writing the ratio ``r = P / N`` (``log_combine_product`` of
+    ``P`` against the reciprocal log-curvature of ``N``):
+
+    * ``P <= N`` ⇔ ``log(P/N) <= 0`` is convex iff ``r`` is
+      log-convex/affine (a convex sublevel set);
+    * ``P >= N`` ⇔ ``log(N/P) <= 0`` is convex iff ``r`` is
+      log-concave/affine;
+    * ``P == N`` is an affine equality in ``y`` (convex) iff ``r`` is
+      log-affine — i.e. monomial == monomial.
+
+    A missing side or an ``UNKNOWN`` side yields ``log_convex=False`` (no
+    proof), never a false positive.
+    """
+    plus: list[Expression] = []
+    minus: list[Expression] = []
+    _split_additive(constraint.body, 1.0, plus, minus)
+
+    p = _side_log_curvature(plus, cache)
+    n = _side_log_curvature(minus, cache)
+
+    log_convex = False
+    if p != LogCurvature.UNKNOWN and n != LogCurvature.UNKNOWN:
+        ratio = log_combine_product(p, log_negate(n))
+        if constraint.sense == "==":
+            log_convex = ratio == LogCurvature.LOG_AFFINE
+        elif constraint.sense == "<=":
+            log_convex = ratio in (LogCurvature.LOG_AFFINE, LogCurvature.LOG_CONVEX)
+        elif constraint.sense == ">=":
+            log_convex = ratio in (LogCurvature.LOG_AFFINE, LogCurvature.LOG_CONCAVE)
+
+    return ConstraintLogCurvature(source=constraint, lhs=p, rhs=n, log_convex=log_convex)
+
+
+def model_log_curvature(model: Model) -> ModelLogCurvature:
+    """Report the per-row log-curvature of ``model`` (issue #115 consumer).
+
+    Runs the per-expression :func:`classify_log_curvature` lattice over the
+    objective and every constraint and derives, for each row, whether it is
+    convex in ``y = log x``. Unlike the whole-model :func:`is_log_convex`
+    (a single verdict) this exposes *which* rows are log-convex, making a
+    **partially** log-convex model legible.
+
+    Soundness: every ``log_convex=True`` is a proof (each side's label
+    certifies strict positivity and its log-curvature, and the per-sense
+    rule is a sound convex-representability test); a failed precondition
+    reports ``log_convex=False`` / ``UNKNOWN``, never a false verdict. This
+    is a pure structural analysis — it does not solve, reformulate, or
+    touch the x-space convex fast path.
+
+    Only plain algebraic :class:`Constraint` rows are classifiable;
+    non-algebraic rows (indicator, disjunctive, SOS, logical) are reported
+    ``UNKNOWN`` / not-log-convex rather than skipped.
+    """
+    cache: dict = {}
+
+    objective: Optional[ObjectiveLogCurvature] = None
+    if model._objective is not None:
+        minimize = model._objective.sense == ObjectiveSense.MINIMIZE
+        curv = classify_log_curvature(model._objective.expression, None, cache)
+        if minimize:
+            obj_ok = curv in (LogCurvature.LOG_AFFINE, LogCurvature.LOG_CONVEX)
+        else:
+            obj_ok = curv in (LogCurvature.LOG_AFFINE, LogCurvature.LOG_CONCAVE)
+        objective = ObjectiveLogCurvature(curvature=curv, minimize=minimize, log_convex=obj_ok)
+
+    constraints: list[ConstraintLogCurvature] = []
+    for constraint in model._constraints:
+        if not isinstance(constraint, Constraint):
+            constraints.append(
+                ConstraintLogCurvature(
+                    source=constraint,
+                    lhs=LogCurvature.UNKNOWN,
+                    rhs=LogCurvature.UNKNOWN,
+                    log_convex=False,
+                )
+            )
+            continue
+        constraints.append(_constraint_log_curvature(constraint, cache))
+
+    return ModelLogCurvature(objective=objective, constraints=constraints)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -489,13 +692,17 @@ def solve_gp(model: Model, **solve_kwargs) -> Optional[SolveResult]:
 
 
 __all__ = [
+    "ConstraintLogCurvature",
     "GPConstraint",
     "GPStructure",
     "GeometricProgram",
     "LogCurvature",
+    "ModelLogCurvature",
+    "ObjectiveLogCurvature",
     "as_geometric_program",
     "classify_gp",
     "classify_log_curvature",
     "is_log_convex",
+    "model_log_curvature",
     "solve_gp",
 ]

--- a/python/discopt/gp/__init__.py
+++ b/python/discopt/gp/__init__.py
@@ -38,6 +38,10 @@ from typing import Optional
 import numpy as np
 
 import discopt.modeling as dm
+from discopt._jax.convexity.log_lattice import (
+    LogCurvature,
+    classify_log_curvature,
+)
 from discopt._jax.convexity.posynomial import (
     Monomial,
     PosynomialForm,
@@ -193,11 +197,14 @@ def is_log_convex(model: Model) -> bool:
     mis-gate the ``x``-space convex fast path — a soundness break — so the
     two are exposed as independent predicates.
 
-    This is whole-model recognition (the model is a GP in standard form);
-    per-expression log-curvature lattice propagation is a future
-    extension. A ``True`` result is a proof: it is exactly the precondition
-    under which :func:`as_geometric_program` builds an equivalent convex
-    NLP in ``y``.
+    This is whole-model recognition (the model is a GP in standard form).
+    For the finer-grained, *per-expression* verdict — a log-curvature
+    lattice (``LOG_AFFINE``/``LOG_CONVEX``/``LOG_CONCAVE``) propagated
+    through the DAG so a sub-expression deep inside a constraint can be
+    tagged and composed upward — see :func:`classify_log_curvature`. A
+    ``True`` result here is a proof: it is exactly the precondition under
+    which :func:`as_geometric_program` builds an equivalent convex NLP in
+    ``y``.
     """
     return classify_gp(model) is not None
 
@@ -485,8 +492,10 @@ __all__ = [
     "GPConstraint",
     "GPStructure",
     "GeometricProgram",
+    "LogCurvature",
     "as_geometric_program",
     "classify_gp",
+    "classify_log_curvature",
     "is_log_convex",
     "solve_gp",
 ]

--- a/python/tests/test_log_lattice.py
+++ b/python/tests/test_log_lattice.py
@@ -1,0 +1,260 @@
+"""Tests for the per-expression log-curvature *lattice* (issue #115).
+
+These exercise :func:`discopt.gp.classify_log_curvature`, the DAG-propagating
+log-space analogue of the x-space :class:`~discopt._jax.convexity.Curvature`
+lattice. Distinct from ``test_log_curvature.py`` (the flat SymPy classifier):
+here the verdict must *compose* through products, ratios, powers, sums and
+max/min on the discopt :class:`Expression` DAG, and stay strictly separate from
+the x-space verdict.
+"""
+
+import discopt.modeling as dm
+import pytest
+from discopt import Model
+from discopt._jax.convexity import Curvature, classify_expr
+from discopt._jax.convexity.log_lattice import (
+    LogCurvature,
+    classify_log_curvature,
+    log_combine_product,
+    log_combine_sum,
+    log_negate,
+    log_scale_pow,
+)
+from discopt.modeling.core import Constant
+
+pytestmark = pytest.mark.relaxation
+
+AFF = LogCurvature.LOG_AFFINE
+CVX = LogCurvature.LOG_CONVEX
+CCV = LogCurvature.LOG_CONCAVE
+UNK = LogCurvature.UNKNOWN
+
+
+@pytest.fixture
+def pos_model():
+    """A model with two strictly-positive continuous variables."""
+    m = Model("pos")
+    x = m.continuous("x", lb=0.1, ub=10.0)
+    y = m.continuous("y", lb=0.5, ub=20.0)
+    return m, x, y
+
+
+def lc(expr) -> LogCurvature:
+    return classify_log_curvature(expr)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Lattice operators (unit-level, no DAG)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_log_negate_swaps_convex_concave():
+    assert log_negate(CVX) == CCV
+    assert log_negate(CCV) == CVX
+    assert log_negate(AFF) == AFF
+    assert log_negate(UNK) == UNK
+
+
+def test_log_combine_product_is_the_log_space_sum():
+    # log(f*g) = log f + log g: affine is identity, like reinforce, cross → UNK.
+    assert log_combine_product(AFF, AFF) == AFF
+    assert log_combine_product(AFF, CVX) == CVX
+    assert log_combine_product(AFF, CCV) == CCV
+    assert log_combine_product(CVX, CVX) == CVX
+    assert log_combine_product(CCV, CCV) == CCV
+    assert log_combine_product(CVX, CCV) == UNK
+    assert log_combine_product(CVX, UNK) == UNK
+
+
+def test_log_combine_sum_preserves_log_convexity_only():
+    # Sum of log-convex (incl. affine) is log-convex; concavity is NOT preserved.
+    assert log_combine_sum(AFF, AFF) == CVX
+    assert log_combine_sum(AFF, CVX) == CVX
+    assert log_combine_sum(CVX, CVX) == CVX
+    assert log_combine_sum(AFF, CCV) == UNK
+    assert log_combine_sum(CCV, CCV) == UNK
+    assert log_combine_sum(CVX, UNK) == UNK
+
+
+def test_log_scale_pow():
+    assert log_scale_pow(AFF, 2.0) == AFF
+    assert log_scale_pow(AFF, -3.0) == AFF
+    assert log_scale_pow(CVX, 2.0) == CVX
+    assert log_scale_pow(CVX, -1.0) == CCV
+    assert log_scale_pow(CCV, 0.5) == CCV
+    assert log_scale_pow(CCV, -2.0) == CVX
+    assert log_scale_pow(CVX, 0.0) == AFF  # f**0 == 1
+    assert log_scale_pow(UNK, 2.0) == UNK
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Leaves and positivity gating
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_positive_variable_is_log_affine(pos_model):
+    _, x, y = pos_model
+    assert lc(x) == AFF
+    assert lc(y) == AFF
+
+
+def test_positive_constant_is_log_affine():
+    assert lc(Constant(3.0)) == AFF
+
+
+def test_nonpositive_variable_abstains():
+    m = Model("m")
+    z = m.continuous("z", lb=-1.0, ub=10.0)  # lb <= 0 → not in GP domain
+    w = m.continuous("w", lb=0.0, ub=10.0)  # lb == 0 → not strictly positive
+    assert lc(z) == UNK
+    assert lc(w) == UNK
+    # A monomial built on a non-positive variable is not log-affine either.
+    assert lc(2 * z**2) == UNK
+
+
+def test_nonpositive_constant_abstains():
+    assert lc(Constant(-2.0)) == UNK
+    assert lc(Constant(0.0)) == UNK
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Monomials → log-affine
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_monomial_is_log_affine(pos_model):
+    _, x, y = pos_model
+    assert lc(3 * x**2 * y) == AFF
+    assert lc(x / y) == AFF
+    assert lc(x**-2) == AFF
+    assert lc(5 * x) == AFF
+    assert lc(x**0) == AFF
+
+
+def test_sqrt_of_monomial_is_log_affine(pos_model):
+    _, x, y = pos_model
+    assert lc(dm.sqrt(x * y)) == AFF
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Posynomials → log-convex (composition is the point)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_posynomial_is_log_convex(pos_model):
+    _, x, y = pos_model
+    assert lc(x * y + 2 * x**2 + 0.5 * y) == CVX
+    assert lc(x + 5) == CVX  # monomial + positive constant
+
+
+def test_product_of_posynomials_composes_to_log_convex(pos_model):
+    # The flat SymPy classifier misses this (a Mul of two Adds); the lattice
+    # composes LOG_CONVEX * LOG_CONVEX = LOG_CONVEX.
+    _, x, y = pos_model
+    assert lc((x + y) * (x + 1)) == CVX
+
+
+def test_sqrt_of_posynomial_is_log_convex(pos_model):
+    _, x, y = pos_model
+    assert lc(dm.sqrt(x + y)) == CVX
+
+
+def test_max_of_posynomials_is_log_convex(pos_model):
+    _, x, y = pos_model
+    assert lc(dm.maximum(x + y, 2 * x)) == CVX
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Log-concave sources
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_reciprocal_of_posynomial_is_log_concave(pos_model):
+    _, x, y = pos_model
+    assert lc(1 / (x + y)) == CCV
+    assert lc((x + y) ** -1) == CCV
+
+
+def test_monomial_over_posynomial_is_log_concave(pos_model):
+    _, x, y = pos_model
+    assert lc((x * y) / (x + y)) == CCV
+
+
+def test_min_of_monomials_is_log_concave(pos_model):
+    _, x, y = pos_model
+    assert lc(dm.minimum(x, y)) == CCV
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Abstention (soundness: unknown, never a false log-curvature tag)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_difference_abstains(pos_model):
+    _, x, y = pos_model
+    assert lc(x - y) == UNK
+
+
+def test_negation_abstains(pos_model):
+    _, x, _ = pos_model
+    assert lc(-x) == UNK
+
+
+def test_max_with_concave_arg_abstains(pos_model):
+    # max needs every arg log-convex; a log-concave arg kills the verdict.
+    _, x, y = pos_model
+    assert lc(dm.maximum(x + y, 1 / (x + y))) == UNK
+
+
+def test_min_with_convex_arg_abstains(pos_model):
+    _, x, y = pos_model
+    assert lc(dm.minimum(x, x + y)) == UNK
+
+
+def test_sum_of_log_convex_and_log_concave_abstains(pos_model):
+    # x*y (log-affine) + 1/(x+y) (log-concave) → not provably log-convex.
+    _, x, y = pos_model
+    assert lc(x * y + 1 / (x + y)) == UNK
+
+
+def test_transcendental_abstains(pos_model):
+    _, x, _ = pos_model
+    assert lc(dm.exp(x)) == UNK
+    assert lc(dm.log(x)) == UNK
+
+
+def test_variable_exponent_abstains(pos_model):
+    _, x, y = pos_model
+    assert lc(x**y) == UNK
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Strict separation from the x-space Curvature lattice (the soundness rule)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_posynomial_is_log_convex_but_not_x_space_convex(pos_model):
+    """A genuine posynomial is log-convex yet NOT convex in x.
+
+    Folding one verdict into the other would mis-gate the x-space convex
+    fast path — the invariant the two lattices exist to keep apart.
+    """
+    _, x, y = pos_model
+    posy = x * y + 2 * x**2
+    assert lc(posy) == CVX
+    # x-space: x*y is indefinite on the positive orthant → not convex.
+    assert classify_expr(posy, None) != Curvature.CONVEX
+
+
+def test_log_curvature_returns_its_own_enum(pos_model):
+    _, x, y = pos_model
+    result = lc(x + y)
+    assert isinstance(result, LogCurvature)
+    assert not isinstance(result, Curvature)
+
+
+def test_shared_subexpression_is_cached(pos_model):
+    # A DAG with a reused node must classify consistently (id-cache).
+    _, x, y = pos_model
+    p = x + y
+    assert lc(p * p) == CVX

--- a/python/tests/test_log_lattice.py
+++ b/python/tests/test_log_lattice.py
@@ -20,6 +20,7 @@ from discopt._jax.convexity.log_lattice import (
     log_negate,
     log_scale_pow,
 )
+from discopt.gp import is_log_convex, model_log_curvature
 from discopt.modeling.core import Constant
 
 pytestmark = pytest.mark.relaxation
@@ -258,3 +259,92 @@ def test_shared_subexpression_is_cached(pos_model):
     _, x, y = pos_model
     p = x + y
     assert lc(p * p) == CVX
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Whole-model consumer: model_log_curvature (the #115 payoff)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _gp_model():
+    m = Model("gp")
+    x = m.continuous("x", lb=0.1, ub=10.0)
+    y = m.continuous("y", lb=0.1, ub=10.0)
+    return m, x, y
+
+
+def test_model_log_curvature_full_gp():
+    m, x, y = _gp_model()
+    m.minimize(x * y + 0.5 / x)  # posynomial objective
+    m.subject_to(x + y <= 5)
+    m.subject_to(x * y == 2)
+    report = model_log_curvature(m)
+    assert report.objective is not None
+    assert report.objective.log_convex is True
+    assert all(c.log_convex for c in report.constraints)
+    assert report.is_log_convex_program is True
+    assert report.log_convex_rows == 2
+
+
+def test_model_log_curvature_certifies_row_that_classify_gp_rejects():
+    """`sqrt(x + y) <= t` is convex in y but not a monomial-splitter GP row.
+
+    The lattice consumer certifies it; the whole-model monomial recogniser
+    (`classify_gp` / `is_log_convex`) does not — the concrete payoff of a
+    composing per-expression lattice.
+    """
+    m, x, y = _gp_model()
+    t = m.continuous("t", lb=0.1, ub=10.0)
+    m.minimize(t)
+    m.subject_to(dm.sqrt(x + y) <= t)
+    report = model_log_curvature(m)
+    (row,) = report.constraints
+    assert row.lhs == CVX  # sqrt(posynomial) is log-convex
+    assert row.rhs == AFF  # t is a monomial
+    assert row.log_convex is True
+    assert report.is_log_convex_program is True
+    # The whole-model monomial recogniser cannot see this structure.
+    assert is_log_convex(m) is False
+
+
+def test_model_log_curvature_reports_partial_log_convexity():
+    m, x, y = _gp_model()
+    m.minimize(x * y)
+    m.subject_to(x + y <= 4)  # log-convex row
+    m.subject_to(x - y <= 1)  # difference on the positive side → not certifiable
+    report = model_log_curvature(m)
+    assert [c.log_convex for c in report.constraints] == [True, False]
+    assert report.log_convex_rows == 1
+    assert report.is_log_convex_program is False
+
+
+def test_model_log_curvature_equality_needs_both_sides_monomial():
+    # monomial == monomial → affine equality in y (convex); posynomial == monomial → not.
+    m, x, y = _gp_model()
+    m.minimize(x)
+    m.subject_to(x * y == 3)
+    assert model_log_curvature(m).constraints[0].log_convex is True
+
+    m2, a, b = _gp_model()
+    m2.minimize(a)
+    m2.subject_to(a + b == 3)
+    assert model_log_curvature(m2).constraints[0].log_convex is False
+
+
+def test_model_log_curvature_objective_sense_matters():
+    # Maximising a monomial is convex-in-y; maximising a posynomial is not.
+    m, x, y = _gp_model()
+    m.maximize(x * y)
+    assert model_log_curvature(m).objective.log_convex is True
+
+    m2, a, b = _gp_model()
+    m2.maximize(a + b)
+    assert model_log_curvature(m2).objective.log_convex is False
+
+
+def test_model_log_curvature_no_objective():
+    m, x, y = _gp_model()
+    m.subject_to(x + y <= 5)
+    report = model_log_curvature(m)
+    assert report.objective is None
+    assert report.is_log_convex_program is True  # objective-free: all rows decide it


### PR DESCRIPTION
## Summary

Closes #115.

Implements the **per-expression log-curvature lattice** (the richer form of component 2 of #111, beyond the shipped whole-model `is_log_convex` verdict) and a whole-model consumer that reports per-row log-curvature. The lattice is the log-space analogue of the x-space `Curvature` lattice, propagated through the *same* expression DAG, but kept **strictly separate** to preserve soundness: a posynomial is log-convex yet not convex in `x`, so conflating the two verdicts would mis-gate the x-space convex fast path.

## Key changes

- **New module `discopt._jax.convexity.log_lattice`** — the composing lattice:
  - `LogCurvature` enum (`LOG_AFFINE`, `LOG_CONVEX`, `LOG_CONCAVE`, `UNKNOWN`).
  - Composition operators `log_negate`, `log_combine_product`, `log_combine_sum`, `log_scale_pow`.
  - DAG walker `classify_log_curvature()` propagating verdicts bottom-up, so a posynomial buried inside a constraint is tagged and composes upward through products, ratios, powers, sums and max/min.
  - Positivity gating: a non-`UNKNOWN` label certifies strict positivity on the declared box; operations leaving the positive domain (negation, subtraction) abstain to `UNKNOWN`.

- **Whole-model consumer `discopt.gp.model_log_curvature(model)`** — the first reader of the lattice:
  - Classifies the objective and every constraint and derives, per row, whether it is convex in `y = log x` (`ModelLogCurvature` / `ConstraintLogCurvature` / `ObjectiveLogCurvature`).
  - Unlike the whole-model `is_log_convex` (one yes/no), it exposes *which* rows are log-convex — the **partially** log-convex case that motivated #115.
  - Strictly **more general** than the monomial-splitting `classify_gp`: it certifies rows built from nested posynomials/reciprocals such as `sqrt(x + y) <= t` that `classify_gp` rejects (covered by a test).

- **Public API exports** in `discopt._jax.convexity.__init__` and `discopt.gp.__init__`; `is_log_convex` docstring updated to point at the finer-grained lattice.

## Soundness

- A non-`UNKNOWN` label is a proof of both strict positivity *and* the stated log-curvature; positivity is carried through leaf rules and preserved by every composition rule.
- Per-row rule (constraint `body = P - N`, split only at the top-level sum so nested sub-terms stay intact): with the ratio label `r = log_combine_product(P, log_negate(N))` — the log-curvature of `P/N` — `<=` is convex-in-`y` iff `r` is log-convex/affine, `>=` iff log-concave/affine, `==` iff log-affine. Every `log_convex=True` is a proof; a failed precondition reports `False`/`UNKNOWN`, never a false positive.
- Kept strictly separate from the x-space `Curvature` lattice (distinct enum, distinct walker). Pure structural analysis — no solve, no reformulation, no x-space fast-path change.

Composition rules follow Boyd & Vandenberghe (2004) §3.5 / §4.5 and the DGP calculus (Agrawal et al. 2019).

## Tests / verification

- `python/tests/test_log_lattice.py` — 33 cases: lattice operators, leaf/positivity gating, monomial/posynomial/log-concave composition, abstention, x-space separation, and the `model_log_curvature` consumer (full GP, the `classify_gp`-rejected row, partial log-convexity, equality both-sides-monomial, objective sense, objective-free).
- `pytest -m smoke`: 658 passed, 8 skipped. GP suites (`test_gp`, `test_gp_corpus`, `test_log_curvature`) green. `ruff check`/`format` and `mypy` clean.

## Out of scope (per #115)

Signomial (mixed-sign) solver and y-space branching / bound-tightening remain separate issues; this PR is additive with no correctness dependency and no solve-path change.

https://claude.ai/code/session_01MePsrNeqTm72c9DduuoEzV