### PR TITLE
fix(#654): poll the deadline between root-fallback bound candidates

### DIFF
--- a/docs/dev/baron-gap-plan.md
+++ b/docs/dev/baron-gap-plan.md
@@ -435,6 +435,32 @@ elsewhere.
 5. **Do not trust single-layer profiler labels** (June's "jax=97.7%"): always
    aggregate cProfile across binding boundaries (pounce/_rust/jax/python) as
    in §1.3, or use the fresh-subprocess phase decomposition of §1.1.
+6. **Do not drop or reorder the root-relaxation fallback's bound candidates to
+   cut its wall** (#654 residual, measured 2026-07-17). `_root_relaxation_lower_bound`
+   computes independent candidates (static-envelope `plain`, separated `sep`,
+   opt-in PSD/RLT) and returns the `max`. Two tempting cuts are both **falsified**
+   over the 65-instance in-repo corpus at the real 3.0s grant:
+   - *"`sep` dominates `plain`, so drop the 5–8s `build_milp_relaxation`"* —
+     **false**. Neither dominates: `plain` is the SOLE producer on 2 (st_miqp2
+     −13.0625, st_miqp4 −6254.0) and strictly tighter on 14; `sep` is sole on 6
+     (hda, heatexch_gen1–3, nvs05, clay0303hfsg) and strictly tighter on 15. The
+     `max` is load-bearing.
+   - *"`plain` is cheap and enough, so skip `sep` once the budget is spent"* —
+     **false, and it drops exactly the §8.1 bounds**. On the whole #654 class
+     `plain` is `None` (its budgeted solve hits the iteration limit) and `sep` is
+     the sole producer: sonet23v4 −53974.375, super3t −1.0.
+
+   Also corrects PR #682's stated residual: the fallback's dominant cost is **not**
+   `build_milp_relaxation` in general — on sonet23v4 it is `sep`'s own LP build
+   (16.8s against a 1.0s solve budget; the build is not bounded by the solve's
+   `time_limit`), and that op *is* the bound producer. Hence the **documented
+   floor** for the class (T=2s walls: sonet22v4 6.7s / graphpart_clique-70 5.5s /
+   qap 11.4s / eg_all_s 18.0s / sonet23v4 24.5s) is irreducible under §8.1, and
+   #654's bar is "wall SCALES with `T`" (pinned by
+   `python/tests/test_issue654_deadline_root_setup.py`), not "wall ≤ T + 2s".
+   Admissible (landed): a checkpoint poll *between* whole candidates that declines
+   to START another only when a valid bound is already in hand and the fallback's
+   own grant is spent — corpus-measured bound-neutral (0/65 bounds changed).
 
 ---
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2610,6 +2610,46 @@ def _root_relaxation_lower_bound(
     )
     from discopt._jax.term_classifier import classify_nonlinear_terms
 
+    # Issue #654 checkpoint poll. This routine computes several INDEPENDENT bound
+    # candidates (plain / separated / PSD / RLT) and returns the tightest; each is
+    # an unbudgeted *build* plus a budgeted solve, so pre-fix they all ran to
+    # completion unconditionally and the fallback could overrun its own granted
+    # ``time_limit`` several-fold (measured: sonet23v4 22.3s against a 3.0s grant,
+    # eg_all_s 11.0s — the residual #654 overrun after PR #682 gated *entry* into
+    # the search apparatus). ``_fb_stop`` lets each phase poll at a safe checkpoint
+    # — between whole candidates, never inside one — so the overrun is bounded to
+    # at most one in-flight op and we return the best valid bound accumulated so
+    # far (the issue's fix direction 1).
+    #
+    # Two rules make this sound under docs/dev/baron-gap-plan.md §8 ("do not
+    # truncate bound-producing native solves"):
+    #
+    #   1. **Never skip while no valid bound is in hand.** A phase is only
+    #      "optional tightening" once some candidate has already landed; until
+    #      then it is the last remaining chance at a dual bound and MUST run to
+    #      completion. This is load-bearing, not defensive: measured on the #654
+    #      class, ``plain`` is ``None`` on *every* instance (its budgeted solve
+    #      hits the iteration limit), and the bound comes solely from the later
+    #      separated candidate — sonet23v4 (-53974.375), super3t (-1.0). A poll
+    #      without this rule would drop exactly the bounds §8 protects.
+    #   2. **Anchor on the fallback's OWN grant, not the global deadline.** The
+    #      caller only reaches here once the global budget is spent, so polling
+    #      the global deadline would fire on the first checkpoint every time and
+    #      trade large amounts of bound quality for nothing (nvs11: reports the
+    #      static -9600 instead of the separated -439 to save a 0.06s phase).
+    #
+    # Skipping a started-nothing phase only ever *weakens* a still-valid bound
+    # (fewer cuts), never falsifies one, so ``incorrect_count`` is unaffected.
+    # Corpus-measured bound-neutral: no in-repo instance both spends the whole
+    # grant before a checkpoint and has a candidate in hand, so no bound changes.
+    _fb_t0 = time.perf_counter()
+
+    def _fb_stop(have: "list[float]") -> bool:
+        """True when this phase should decline to *start* another optional
+        tightening: the fallback's own grant is spent AND a valid bound is
+        already in hand (rules 1 and 2 above)."""
+        return bool(have) and (time.perf_counter() - _fb_t0) >= max(0.0, float(time_limit))
+
     try:
         terms = classify_nonlinear_terms(model)
         relax, _relax_info = build_milp_relaxation(
@@ -2622,6 +2662,11 @@ def _root_relaxation_lower_bound(
             return None
         relax = sanitize_relaxation_for_conditioning(relax)
 
+        # Candidates accumulate here in completion order; every entry is an
+        # independently valid lower bound on the internally minimized objective,
+        # so ``max`` at the bottom keeps the tightest and any prefix is sound.
+        _have: list[float] = []
+
         # PSD (moment) cuts strengthen the McCormick relaxation toward the SDP
         # bound on nonconvex QCQP. `sanitize_*` only drops rows, so the column
         # map `_relax_info` still matches `relax`. Each cut is valid for the whole
@@ -2629,7 +2674,7 @@ def _root_relaxation_lower_bound(
         # (>= the plain bound); it joins the candidates below and `max` keeps the
         # tightest. Opt-in via `psd_cuts=True`; any failure is a sound no-op.
         psd_bound: Optional[float] = None
-        if psd_cuts:
+        if psd_cuts and not _fb_stop(_have):
             try:
                 from discopt._jax.model_utils import binary_flat_cols
                 from discopt._jax.psd_cuts import psd_strengthen_relaxation_bound
@@ -2643,6 +2688,7 @@ def _root_relaxation_lower_bound(
                 )
                 if _nc and _za is not None and np.isfinite(_za):
                     psd_bound = float(_za)
+                    _have.append(psd_bound)
             except Exception as psd_exc:  # pragma: no cover - defensive
                 logger.debug("root PSD-strengthened bound skipped: %s", psd_exc)
 
@@ -2657,7 +2703,7 @@ def _root_relaxation_lower_bound(
         # sound no-op.
         rlt_bound: Optional[float] = None
         _tun = _tuning()
-        if getattr(_tun, "rlt1_root_bound", False):
+        if getattr(_tun, "rlt1_root_bound", False) and not _fb_stop(_have):
             try:
                 from discopt._jax.model_utils import binary_flat_cols as _bfc
                 from discopt._jax.rlt import rlt1_lower_bound
@@ -2672,6 +2718,7 @@ def _root_relaxation_lower_bound(
                 )
                 if _nrows and _rb is not None and np.isfinite(_rb):
                     rlt_bound = float(_rb)
+                    _have.append(rlt_bound)
             except Exception as rlt_exc:  # pragma: no cover - defensive
                 logger.debug("root RLT-1 bound skipped: %s", rlt_exc)
 
@@ -2682,7 +2729,7 @@ def _root_relaxation_lower_bound(
         # route that beats the exact simplex's scaling wall at qap scale. Opt-in
         # (`DISCOPT_RLT1_LAGRANGIAN`, default off); any failure is a sound no-op.
         rlt_lag_bound: Optional[float] = None
-        if getattr(_tun, "rlt1_lagrangian", False):
+        if getattr(_tun, "rlt1_lagrangian", False) and not _fb_stop(_have):
             try:
                 from discopt._jax.model_utils import binary_flat_cols as _bfc
                 from discopt._jax.rlt import rlt1_lagrangian_lower_bound
@@ -2698,11 +2745,16 @@ def _root_relaxation_lower_bound(
                 )
                 if _nc and _lb is not None and np.isfinite(_lb):
                     rlt_lag_bound = float(_lb)
+                    _have.append(rlt_lag_bound)
             except Exception as lag_exc:  # pragma: no cover - defensive
                 logger.debug("root RLT-1 Lagrangian bound skipped: %s", lag_exc)
 
         budget = min(10.0, max(1.0, time_limit * 0.1))
-        result = relax.solve(time_limit=budget, gap_tolerance=1e-6)
+        # Checkpoint: the static-envelope solve is optional tightening only once a
+        # strengthened candidate (PSD/RLT) already landed; with those default-off
+        # ``_have`` is empty here, so this gate is inert on the default path and
+        # the plain solve always runs (rule 1 — it is then the first candidate).
+        result = None if _fb_stop(_have) else relax.solve(time_limit=budget, gap_tolerance=1e-6)
         # Only an OPTIMAL relaxation solve yields a valid lower bound. An
         # "unbounded" verdict means the relaxation (e.g. a McCormick envelope over
         # a box where a nonlinear-term variable is still unbounded) has no finite
@@ -2712,8 +2764,14 @@ def _root_relaxation_lower_bound(
         # fallback bound would publish an invalid (above-incumbent) dual bound.
         # Gate on optimality so an unbounded/limit solve returns no bound instead.
         plain_bound: Optional[float] = None
-        if result.status == "optimal" and result.bound is not None and np.isfinite(result.bound):
+        if (
+            result is not None
+            and result.status == "optimal"
+            and result.bound is not None
+            and np.isfinite(result.bound)
+        ):
             plain_bound = float(result.bound)
+            _have.append(plain_bound)
 
         # The raw ``relax.solve`` above carries only the static envelope cuts; the
         # per-node spatial relaxation additionally separates the multilinear hull,
@@ -2727,15 +2785,24 @@ def _root_relaxation_lower_bound(
         # unbounded cross-check, infeasible/limit re-verify) return no bound on
         # any unsound solve. ``_objective_bound_valid`` above already certified
         # the objective is fully linearized, the precondition both paths share.
+        # Checkpoint (#654): this candidate's LP build is NOT bounded by its solve
+        # ``time_limit`` — measured 16.8s on sonet23v4 against a 1.0s solve budget —
+        # so it is the fallback's dominant overrun. It is nonetheless the sole
+        # bound producer on the whole #654 class (``plain`` is None there), hence
+        # rule 1: it is declined only when a valid bound is ALREADY in hand, in
+        # which case it could merely tighten one we can still soundly report.
         sep_bound: Optional[float] = None
-        try:
-            from discopt._jax.mccormick_lp import MccormickLPRelaxer
+        if not _fb_stop(_have):
+            try:
+                from discopt._jax.mccormick_lp import MccormickLPRelaxer
 
-            node_res = MccormickLPRelaxer(model).solve_at_node(root_lb, root_ub, time_limit=budget)
-            if node_res.lower_bound is not None and np.isfinite(node_res.lower_bound):
-                sep_bound = float(node_res.lower_bound)
-        except Exception as sep_exc:  # pragma: no cover - defensive
-            logger.debug("root separated-relaxation bound skipped: %s", sep_exc)
+                node_res = MccormickLPRelaxer(model).solve_at_node(
+                    root_lb, root_ub, time_limit=budget
+                )
+                if node_res.lower_bound is not None and np.isfinite(node_res.lower_bound):
+                    sep_bound = float(node_res.lower_bound)
+            except Exception as sep_exc:  # pragma: no cover - defensive
+                logger.debug("root separated-relaxation bound skipped: %s", sep_exc)
 
         # Both values are valid lower bounds for a minimization, so the larger
         # (tighter) one is the better rigorous bound.

--- a/python/tests/test_issue654_deadline_root_setup.py
+++ b/python/tests/test_issue654_deadline_root_setup.py
@@ -96,6 +96,64 @@ def test_zero_budget_short_circuits_soundly():
         assert r.objective >= opt - 1e-4
 
 
+_CORPUS = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
+
+
+def _root_box(model):
+    import numpy as np
+
+    lb = np.array([v.lb if v.lb is not None else -1e20 for v in model._variables], float)
+    ub = np.array([v.ub if v.ub is not None else 1e20 for v in model._variables], float)
+    return lb, ub
+
+
+def test_root_fallback_checkpoint_poll_fires_and_stays_sound():
+    """The root-relaxation fallback polls its own grant *between* bound candidates.
+
+    ``_root_relaxation_lower_bound`` computes several independent candidates (the
+    static-envelope "plain" LP and the separated ``solve_at_node`` LP, plus the
+    opt-in PSD/RLT ones) and returns the tightest. Each is an unbudgeted *build*
+    plus a budgeted solve, so pre-fix they all ran unconditionally and the routine
+    could overrun its own grant several-fold (#654's residual).
+
+    nvs11 pins both halves of the contract on one instance:
+      * ``grant=0`` — the budget is spent the moment the first candidate lands, so
+        the *separated* candidate is declined and we report the plain bound. This
+        is the poll FIRING (without it, both candidates always run).
+      * ``grant=3`` — the default caller grant (``_ROOT_FALLBACK_FLOOR_S``) leaves
+        room, so the separated candidate runs and tightens -9600 -> -439.1.
+
+    Crucially both are *valid* lower bounds (<= the -431.0 oracle): declining to
+    start an optional tightening only ever weakens a sound bound, never falsifies
+    one (docs/dev/baron-gap-plan.md §8), so ``incorrect_count`` is untouched.
+    """
+    path = os.path.join(_CORPUS, "nvs11.nl")
+    if not os.path.exists(path):
+        pytest.skip("nvs11.nl not in the in-repo corpus")
+
+    from discopt.modeling.core import from_nl
+    from discopt.solver import _root_relaxation_lower_bound
+
+    model = from_nl(path)
+    lb, ub = _root_box(model)
+
+    spent = _root_relaxation_lower_bound(model, lb, ub, 0.0)
+    ample = _root_relaxation_lower_bound(model, lb, ub, 3.0)
+
+    assert spent is not None and ample is not None, "fallback lost its bound entirely"
+    # The poll bit: a spent grant declines the (optional) separated candidate, so
+    # the surfaced bound is the looser plain one. If this ever ties, the gate has
+    # gone inert and the test no longer pins anything.
+    assert spent < ample, (
+        f"checkpoint poll did not fire: spent-grant bound {spent} == ample-grant {ample}"
+    )
+    # Rule 1 (§8): a spent grant must still never return None — the first candidate
+    # is the last-hope bound producer and always runs to completion.
+    _ORACLE = -431.0  # nvs11 =opt= (minlplib.solu); MINIMIZE -> dual bound <= opt
+    for b in (spent, ample):
+        assert b <= _ORACLE + 1e-6, f"unsound bound {b} > oracle {_ORACLE}"
+
+
 _BENCH = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
 
 
@@ -132,3 +190,94 @@ def test_sonet22v4_wall_scales_with_time_limit():
     for r in (r2, r5):
         if r.bound is not None:
             assert r.bound <= _ORACLE + 1.0, f"unsound bound {r.bound} > oracle {_ORACLE}"
+
+
+# The #654 "definition of done" panel: the instances whose wall was ~constant
+# regardless of ``time_limit``. Each entry is (instance, oracle optimum), the
+# oracle being the ``=best=`` value from ``minlplib.solu``; all are MINIMIZE, so a
+# valid dual bound never exceeds it.
+#
+# MEASURED FLOOR (2026-07-17, this machine, T=2s) — the documented, unavoidable
+# cost of the *one in-flight uninterruptible op* the DoD margin allows. It is the
+# rigorous root-relaxation fallback, and on this class it is genuinely
+# irreducible: profiling shows every phase either IS the sole dual-bound producer
+# (sonet23v4's -53974.375 costs a single 16.8s separated build+solve; super3t's
+# -1.0 costs 2.4s) or is the last remaining chance at one, and §8 forbids
+# truncating those. So the bar below is NOT "wall <= T + 2s" — it is the DoD's
+# actual crux: **wall must SCALE with T** (the bug was that it did not), and the
+# bound must stay valid.
+#
+#   instance             T=2 wall   fallback   dual bound
+#   sonet22v4              6.7s       3.9s     None
+#   graphpart_clique-70    5.5s       2.6s     None
+#   qap                   11.4s       7.7s     None
+#   eg_all_s              18.0s      11.0s     None
+#   sonet23v4             24.5s      22.3s     -53974.375
+_DOD_PANEL = [
+    ("sonet22v4", 2373966.0),
+    ("sonet23v4", -22747.5),
+    ("graphpart_clique-70", 6348.0),
+    ("qap", 388214.0),
+    ("eg_all_s", 7.657752093),
+]
+
+
+@pytest.mark.slow
+@pytest.mark.requires_pounce
+@pytest.mark.parametrize("inst,oracle", _DOD_PANEL)
+def test_issue654_dod_panel_honors_and_scales_with_time_limit(inst, oracle):
+    """#654 definition of done, per instance: the budget must *matter*, and the
+    dual bound must stay sound.
+
+    Pre-fix these ran a fixed ~26-110s regardless of ``T`` (``T=2`` vs ``T=5``
+    walls were indistinguishable — the budget was effectively ignored, and the
+    0-node cases never finished the root before an external 110s kill).
+    """
+    path = os.path.join(_BENCH, inst + ".nl")
+    if not os.path.exists(path):
+        pytest.skip(f"{inst}.nl not vendored (big corpus)")
+
+    from discopt.modeling.core import from_nl
+
+    def _run(tl):
+        t0 = time.perf_counter()
+        r = from_nl(path).solve(time_limit=tl)
+        return time.perf_counter() - t0, r
+
+    wall2, r2 = _run(2.0)
+    wall8, r8 = _run(8.0)
+
+    # 1. The budget is honored to within the documented floor: no instance may
+    #    regress to the pre-fix "runs until an external cap" behavior.
+    assert wall2 < 60.0, f"{inst}: T=2 wall {wall2:.1f}s — root setup not gated (#654)"
+    # 2. THE CRUX: wall scales with T. A larger budget must buy strictly more
+    #    time in the engine; pre-fix both walls sat on the same fixed floor.
+    assert wall2 < wall8, f"{inst}: wall did not scale (T=2 {wall2:.1f}s vs T=8 {wall8:.1f}s)"
+    # 3. The deadline gating never truncated a bound-producing op into an unsound
+    #    bound: a MINIMIZE dual bound never crosses the oracle optimum (``None``
+    #    is sound — merely weaker). This is the clause that would fail if a poll
+    #    ever hard-killed a bound mid-flight (§8).
+    for tl, r in ((2.0, r2), (8.0, r8)):
+        assert r.status != "optimal" or r.objective is not None
+        if r.bound is not None:
+            assert r.bound <= oracle + 1e-4 * max(1.0, abs(oracle)), (
+                f"{inst} T={tl}: unsound dual bound {r.bound} > oracle {oracle}"
+            )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_pounce
+def test_sonet23v4_bound_survives_the_deadline_gating():
+    """§8 guard: sonet23v4's dual bound is produced by a single ~17s uninterruptible
+    op inside the root-relaxation fallback (its LP *build* is not bounded by the
+    solve's ``time_limit``). The deadline work must never cost us that bound — the
+    casctanks-class regression (-99.09 -> +5.70) this pins against."""
+    path = os.path.join(_BENCH, "sonet23v4.nl")
+    if not os.path.exists(path):
+        pytest.skip("sonet23v4.nl not vendored (big corpus)")
+
+    from discopt.modeling.core import from_nl
+
+    r = from_nl(path).solve(time_limit=2.0)
+    assert r.bound is not None, "sonet23v4 lost its dual bound — a §8 truncation regression"
+    assert r.bound <= -22747.5 + 1e-4, f"unsound bound {r.bound}"


### PR DESCRIPTION
## Closes #654 — the root-relaxation fallback now polls the deadline between bound candidates

PR #682 gated *entry* into the optional spatial search apparatus and left one documented residual: the rigorous root-relaxation fallback (`_root_relaxation_lower_bound`), which overran its own grant several-fold (**sonet23v4 22.3s against a 3.0s grant**, eg_all_s 11.0s).

Profiling that residual **falsifies #682's framing of it**, in two ways. Both are recorded in `docs/dev/baron-gap-plan.md` §8.6 as binding.

### Falsification 1 — the build is not the residual

#682 stated the residual was `build_milp_relaxation`. Measured per-phase (T=2s, this machine):

| instance | wall | fallback | `build_milp_relaxation` | `sep` (`solve_at_node`) | dual bound |
|---|---|---|---|---|---|
| sonet22v4 | 6.7s | 3.9s | 2.5s | 0.2s | None |
| graphpart_clique-70 | 5.5s | 2.6s | 1.8s | 0.3s | None |
| qap | 11.4s | 7.7s | 5.2s | 1.1s | None |
| eg_all_s | 18.0s | 11.0s | 8.4s | 0.7s | None |
| **sonet23v4** | **24.5s** | **22.3s** | 4.2s | **16.8s** | **-53974.375** |

On sonet23v4 the dominant cost is the **separated** candidate's own LP build — 16.8s against a **1.0s** solve budget, because the build is not bounded by the solve's `time_limit` — and **that op is the bound producer**.

### Falsification 2 — neither candidate dominates, so nothing can be dropped

The fallback computes independent candidates and returns the `max`. Over the **65-instance in-repo corpus** at the real 3.0s grant:

| | count | examples |
|---|---|---|
| `plain` is the **sole** producer | 2 | st_miqp2 (-13.0625), st_miqp4 (-6254.0) |
| `sep` is the **sole** producer | 6 | hda, heatexch_gen1–3, nvs05, clay0303hfsg |
| `plain` strictly tighter | 14 | ex1225, nvs01, st_miqp1, tspn05, … |
| `sep` strictly tighter | 15 | nvs11 (-439.1 vs -9600), flay02m, nvs14, … |

The `max` is load-bearing. And on the whole #654 class `plain` is `None` (its budgeted solve hits `iteration_limit`), so **`sep` is the sole producer** — skipping it drops exactly the bounds §8.1 protects (the casctanks `-99.09 -> +5.70` class).

### Consequence: the floor is irreducible, so the DoD's real bar is wall-scaling

Every phase of the fallback on this class is either the sole dual-bound producer or the last remaining chance at one, and §8.1 forbids truncating those. **`wall ≤ T + 2s` is therefore unreachable here without losing bounds.** The per-class floor is now measured and documented, and #654's bar is the DoD's actual crux — **wall must SCALE with `T`** (the bug was that it did not) — which is what the new panel pins. Scope confirmed with the owner before implementing.

### What lands

A checkpoint poll **between whole candidates** (never inside one), sound under two rules the measurements forced:

1. **Never skip while no valid bound is in hand.** Until then the phase is the last-hope producer, not optional tightening. This is what preserves sonet23v4 / super3t.
2. **Anchor on the fallback's OWN grant, not the global deadline.** The caller only reaches here once the global budget is spent, so a global-deadline poll would fire on every first checkpoint and trade large bound quality for nothing (nvs11: -439.1 → -9600 to save a 0.06s phase).

Skipping a not-yet-started phase only ever *weakens* a still-valid bound (fewer cuts), never falsifies one, so `incorrect_count` is untouched.

**Corpus-measured bound-neutral: 0/65 bounds changed** vs baseline (49 produce a bound); fallback wall 22.8s → 22.6s. The gate is inert today and bounds candidate *stacking* as the opt-in PSD/RLT candidates graduate on — it is pinned live (not dead code) by a test that shows it firing.

### Verification (all run synchronously)

- `pytest -m smoke` — **660 passed**, 1 skipped
- adversarial (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`) — **10 passed**
- `pytest -m correctness` — **407 passed**, 7 skipped, 6 xfailed (no `incorrect_count`, no oracle-crossing bound)
- `test_issue654_deadline_root_setup.py` incl. the slow DoD panel — **10 passed**
- New `test_root_fallback_checkpoint_poll_fires_and_stays_sound` (nvs11, in-repo corpus): **fails before / passes after**; asserts both grants stay ≤ the -431.0 oracle.
- New DoD panel over `{sonet22v4, sonet23v4, graphpart_clique-70, qap, eg_all_s}`: wall scales with `T`, dual bound never crosses the `minlplib.solu` oracle; plus a sonet23v4 §8 bound-survival guard.
- `ruff check`/`format` clean; `mypy` unchanged vs baseline (only a pre-existing numpy-stub error). No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
