### PR TITLE
feat(obbt): #208 extend reverse-FBBT aux cascade (trilinear/multilinear/ratio) + measured A/B

### DIFF
--- a/design/ab_cascade_aux.py
+++ b/design/ab_cascade_aux.py
@@ -1,0 +1,144 @@
+"""#208 A/B panel: OBBT aux-cascade OFF vs ON over the vendored corpus.
+
+The reverse-FBBT aux cascade (``obbt_tighten_root(cascade_aux=True)``) is sound by
+construction but ships default-OFF because it was measured *not* net-positive on
+the integer-heavy corpus. This harness drives it through the *real* solve path via
+the ``DISCOPT_OBBT_CASCADE_AUX`` env gate (default ``0``) and reports the flag ON
+vs OFF differential the issue's acceptance criteria ask for:
+
+  * **net-positive?** total node_count / wall, and per-instance node deltas;
+  * **cert-clean?** ON vs the trusted OFF path (CLAUDE.md §5 bound-changing
+    regime) — no false-infeasible, no objective divergence on certified
+    instances, no dual bound above OFF's incumbent, and cert gains/regressions.
+
+It changes nothing on the default path (the gate defaults off). Pure measurement.
+
+Usage::
+
+    python design/ab_cascade_aux.py                 # full corpus, 8s budget/instance
+    AB_TL=15 AB_LIMIT=20 python design/ab_cascade_aux.py
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+
+CORPUS = os.path.join(os.path.dirname(__file__), "..", "python", "tests", "data", "minlplib_nl")
+TIME_LIMIT = float(os.environ.get("AB_TL", "8"))
+GAP = 1e-4
+ATOL, RTOL = 1e-4, 1e-3
+
+
+def solve_one(path: str, cascade: bool) -> dict:
+    """Solve one instance with the aux cascade forced on/off (fresh model)."""
+    os.environ["DISCOPT_OBBT_CASCADE_AUX"] = "1" if cascade else "0"
+    m = dm.from_nl(path)
+    t = time.perf_counter()
+    try:
+        r = m.solve(time_limit=TIME_LIMIT, gap_tolerance=GAP)
+    except Exception as e:  # noqa: BLE001 — report, don't crash the panel
+        return {"err": f"{type(e).__name__}: {e}"}
+    return {
+        "status": r.status,
+        "obj": None if r.objective is None else float(r.objective),
+        "bound": None if r.bound is None else float(r.bound),
+        "nodes": int(r.node_count) if r.node_count is not None else None,
+        "wall": time.perf_counter() - t,
+        "cert": bool(getattr(r, "gap_certified", False)),
+    }
+
+
+def differential_bad(off: dict, on: dict) -> str | None:
+    """Differential soundness of ON against the trusted OFF path (CLAUDE.md §5)."""
+    if off.get("err") or on.get("err"):
+        return None  # solver error reported separately, not a soundness verdict
+
+    def tol(v: float) -> float:
+        return ATOL + RTOL * abs(v)
+
+    if on["status"] == "infeasible" and off.get("obj") is not None:
+        return f"ON FALSE-INFEASIBLE (OFF obj={off['obj']:.6g})"
+    if off.get("cert") and on.get("cert") and off["obj"] is not None and on["obj"] is not None:
+        if abs(on["obj"] - off["obj"]) > tol(off["obj"]):
+            return f"OBJ DIVERGENCE on={on['obj']:.6g} off={off['obj']:.6g}"
+    if on.get("bound") is not None and off.get("obj") is not None:
+        if on["bound"] > off["obj"] + tol(off["obj"]):
+            return f"ON BOUND>OFF-INCUMBENT bound={on['bound']:.6g} inc={off['obj']:.6g}"
+    if on.get("obj") is not None and off.get("bound") is not None:
+        if on["obj"] < off["bound"] - tol(off["bound"]):
+            return f"ON OBJ<OFF-BOUND obj={on['obj']:.6g} bound={off['bound']:.6g}"
+    return None
+
+
+def main() -> None:
+    files = sorted(glob.glob(os.path.join(CORPUS, "*.nl")))
+    lim = int(os.environ.get("AB_LIMIT", "0"))
+    if lim:
+        files = files[:lim]
+    hdr = f"{'instance':24s}  {'nodes off/on':>14s} {'wall off/on':>15s}  cert  note"
+    print(hdr)
+    print("-" * len(hdr))
+    n_changed = n_viol = n_err = n_cert_gain = n_cert_reg = 0
+    tot_off = tot_on = twall_off = twall_on = 0.0
+    viols: list[str] = []
+    for path in files:
+        name = os.path.splitext(os.path.basename(path))[0]
+        off, on = solve_one(path, False), solve_one(path, True)
+        note = ""
+        if off.get("err") or on.get("err"):
+            n_err += 1
+            note = f"err off={off.get('err', '')} on={on.get('err', '')}"
+        v = differential_bad(off, on)
+        if v:
+            n_viol += 1
+            viols.append(f"{name}: {v}")
+            note = (note + " !!VIOLATION").strip()
+        co, cn = bool(off.get("cert")), bool(on.get("cert"))
+        if co and not cn:
+            n_cert_reg += 1
+            note = (note + " CERT-REGRESSION").strip()
+        elif cn and not co:
+            n_cert_gain += 1
+            note = (note + " CERT-GAIN").strip()
+        no, nn = off.get("nodes"), on.get("nodes")
+        wo, wn = off.get("wall"), on.get("wall")
+        if no is not None and nn is not None:
+            tot_off += no
+            tot_on += nn
+            if no != nn:
+                n_changed += 1
+                note = (note + " CASCADE-CHANGED").strip()
+        if wo and wn:
+            twall_off += wo
+            twall_on += wn
+        print(
+            f"{name:24s}  {f'{no}/{nn}':>14s} "
+            f"{(f'{wo:.2f}/{wn:.2f}' if wo and wn else '-'):>15s}  "
+            f"{(str(co)[0] + str(cn)[0]):>4s}  {note}"
+        )
+    print("-" * len(hdr))
+    print(f"instances: {len(files)}   solver errors: {n_err}   cascade changed nodes: {n_changed}")
+    print(
+        f"total nodes  OFF={tot_off:.0f}  ON={tot_on:.0f}  "
+        f"({tot_on - tot_off:+.0f}, {100 * (tot_on - tot_off) / max(1, tot_off):+.1f}%)"
+    )
+    wpct = 100 * (twall_on - twall_off) / max(1e-9, twall_off)
+    print(
+        f"total wall   OFF={twall_off:.1f}s  ON={twall_on:.1f}s  "
+        f"({twall_on - twall_off:+.1f}s, {wpct:+.1f}%)"
+    )
+    print(f"cert gains: {n_cert_gain}   cert regressions: {n_cert_reg}")
+    print(f"DIFFERENTIAL SOUNDNESS VIOLATIONS (ON vs OFF): {n_viol}")
+    for line in viols:
+        print("   ", line)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -2152,6 +2152,16 @@ def _interval_div(nl: float, nu: float, dl: float, du: float) -> Optional[tuple[
     return _interval_mul(nl, nu, 1.0 / du, 1.0 / dl)
 
 
+def _interval_prod(intervals: list[tuple[float, float]]) -> Optional[tuple[float, float]]:
+    """Interval product ``∏ [lo_k, hi_k]``; ``None`` if any bound is non-finite."""
+    lo, hi = 1.0, 1.0
+    for a, b in intervals:
+        if not (np.isfinite(a) and np.isfinite(b)):
+            return None
+        lo, hi = _interval_mul(lo, hi, a, b)
+    return lo, hi
+
+
 def reverse_fbbt_from_aux(
     lb: np.ndarray,
     ub: np.ndarray,
@@ -2175,11 +2185,19 @@ def reverse_fbbt_from_aux(
       gives ``a in [wl, wu] / [bl, bu]`` (interval division), and symmetrically
       for ``b``;
     * monomial ``w = a**p`` with ``w in [wl, wu]`` gives the ``p``-th-root box
-      (sign-aware for even ``p``).
+      (sign-aware for even ``p``);
+    * trilinear / multilinear ``w = ∏ x_c`` gives, for each factor,
+      ``x_c in [wl, wu] / ∏_{s≠c} x_s`` when that product-of-the-others does not
+      straddle zero — the same hyperbolic deduction as bilinear, generalized to
+      any arity (#208 follow-up);
+    * ratio-of-products ``w = (∏ x_a) / (∏ x_b)`` (the #185 / #309 quotient aux)
+      gives, for each numerator factor ``x_a = w·(∏ x_b) / ∏_{s≠a} x_num[s]`` and
+      each denominator factor ``x_b = (∏ x_num) / (w·∏_{s≠b} x_den[s])``, again
+      only when the relevant divisor does not straddle zero.
 
-    Every such deduction is a sound FBBT step (it only removes ``a`` values that
-    cannot satisfy the term equation for any admissible partner), so the box stays
-    a valid enclosure. Mutates ``lb`` / ``ub`` in place over the original columns
+    Every such deduction is a sound FBBT step (it only removes values that cannot
+    satisfy the term equation for any admissible partner), so the box stays a
+    valid enclosure. Mutates ``lb`` / ``ub`` in place over the original columns
     and returns the number of bounds tightened.
     """
     n_orig = len(lb)
@@ -2237,6 +2255,75 @@ def reverse_fbbt_from_aux(
             lo = -((-wl) ** (1.0 / p)) if wl < 0 else wl ** (1.0 / p)
             hi = -((-wu) ** (1.0 / p)) if wu < 0 else wu ** (1.0 / p)
             n_tight += _tighten(i, lo, hi)
+
+    def _aux_box(cw: int) -> Optional[tuple[float, float]]:
+        if not (0 <= cw < len(aux_lb)):
+            return None
+        wl, wu = float(aux_lb[cw]), float(aux_ub[cw])
+        if not (np.isfinite(wl) and np.isfinite(wu)):
+            return None
+        return wl, wu
+
+    # Higher-arity products ``w = ∏ x_c``: divide the aux box by the interval
+    # product of the *other* factors, exactly as bilinear does with its single
+    # partner. Distinct-original keys, so every factor is an original column.
+    for mapname in ("trilinear", "multilinear"):
+        for cols, cw in varmap.get(mapname, {}).items():
+            wb = _aux_box(cw)
+            if wb is None or len(cols) < 2:
+                continue
+            cols = tuple(int(c) for c in cols)
+            for t, ct in enumerate(cols):
+                if not (0 <= ct < n_orig):
+                    continue
+                others = _interval_prod(
+                    [(float(lb[cols[s]]), float(ub[cols[s]])) for s in range(len(cols)) if s != t]
+                )
+                if others is None:
+                    continue
+                d = _interval_div(wb[0], wb[1], others[0], others[1])
+                if d is not None:
+                    n_tight += _tighten(ct, d[0], d[1])
+
+    # Ratio-of-products ``w = (∏ x_num) / (∏ x_den)`` (#185 / #309 quotient aux).
+    # ``num`` / ``den`` are tuples of original columns (repeated per exponent), so
+    # "the other factors" is taken over occurrences to handle powers correctly.
+    for (num, den), cw in varmap.get("ratio", {}).items():
+        wb = _aux_box(cw)
+        if wb is None or not num or not den:
+            continue
+        num = tuple(int(c) for c in num)
+        den = tuple(int(c) for c in den)
+        num_box = _interval_prod([(float(lb[c]), float(ub[c])) for c in num])
+        den_box = _interval_prod([(float(lb[c]), float(ub[c])) for c in den])
+        if num_box is None or den_box is None:
+            continue
+        # Numerator factor:  x_a = w · (∏ x_den) / ∏_{s≠a} x_num[s]
+        for t, ca in enumerate(num):
+            if not (0 <= ca < n_orig):
+                continue
+            rhs = _interval_mul(wb[0], wb[1], den_box[0], den_box[1])
+            others = _interval_prod(
+                [(float(lb[num[s]]), float(ub[num[s]])) for s in range(len(num)) if s != t]
+            )
+            if others is None:
+                continue
+            d = _interval_div(rhs[0], rhs[1], others[0], others[1])
+            if d is not None:
+                n_tight += _tighten(ca, d[0], d[1])
+        # Denominator factor:  x_b = (∏ x_num) / (w · ∏_{s≠b} x_den[s])
+        for t, cb in enumerate(den):
+            if not (0 <= cb < n_orig):
+                continue
+            others = _interval_prod(
+                [(float(lb[den[s]]), float(ub[den[s]])) for s in range(len(den)) if s != t]
+            )
+            if others is None:
+                continue
+            divisor = _interval_mul(wb[0], wb[1], others[0], others[1])
+            d = _interval_div(num_box[0], num_box[1], divisor[0], divisor[1])
+            if d is not None:
+                n_tight += _tighten(cb, d[0], d[1])
     return n_tight
 
 

--- a/python/discopt/_jax/root_reduce.py
+++ b/python/discopt/_jax/root_reduce.py
@@ -39,6 +39,7 @@ flag-agnostic.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Optional
@@ -371,12 +372,16 @@ def _stage_obbt(
     reduce↔rebuild fixpoint, DBBT-first (one objective LP → reduced costs tighten all
     vars) then OBBT (2n min/max probes), all through the NS-safe vertex clamp. It is
     tighten-only and returns the input box on any failure. ``cascade_aux`` stays off
-    (measured-dead, §4/§14)."""
+    by default (measured-dead on the integer-heavy corpus, §4/§14); it is exposed
+    behind ``DISCOPT_OBBT_CASCADE_AUX`` (default ``0``) purely so the #208 A/B panel
+    can drive the reverse-FBBT cascade through the real solve path without changing
+    the default behavior."""
     try:
         from discopt._jax.obbt import obbt_tighten_root
     except Exception:
         return lb, ub, False, 0
 
+    cascade_aux = os.environ.get("DISCOPT_OBBT_CASCADE_AUX", "0") != "0"
     try:
         res = obbt_tighten_root(
             model,
@@ -387,7 +392,7 @@ def _stage_obbt(
             incumbent_cutoff=cutoff,
             superposition=superposition,
             prefer_pounce=prefer_pounce,
-            cascade_aux=False,
+            cascade_aux=cascade_aux,
         )
     except Exception:
         return lb, ub, False, 0

--- a/python/tests/test_obbt.py
+++ b/python/tests/test_obbt.py
@@ -758,6 +758,86 @@ class TestReverseFbbtFromAux:
         assert lb[0] >= 1.0 - 1e-12 and ub[0] <= 3.0 + 1e-12
         assert lb[1] >= 2.0 - 1e-12 and ub[1] <= 4.0 + 1e-12
 
+    def test_trilinear_product_of_others_bound(self):
+        # w = x*y*z, y in [2,4], z in [1,2] -> y*z in [2,8]; a tightened w <= 12
+        # implies x <= 12/2 = 6 (a hyperbolic bound the linear rows can't express).
+        from discopt._jax.obbt import reverse_fbbt_from_aux
+
+        lb = np.array([0.0, 2.0, 1.0])
+        ub = np.array([10.0, 4.0, 2.0])
+        varmap = {"trilinear": {(0, 1, 2): 3}}
+        aux_lb = np.array([0.0, 0.0, 0.0, 0.0])
+        aux_ub = np.array([0.0, 0.0, 0.0, 12.0])
+        n = reverse_fbbt_from_aux(lb, ub, aux_lb, aux_ub, varmap)
+        assert n >= 1
+        assert ub[0] <= 6.0 + 1e-9  # x <= w_ub / (y*z)_lb = 12/2
+
+    def test_multilinear_product_of_others_bound(self):
+        # w = x0*x1*x2*x3, partners in [1,2] -> product-of-others in [1,8];
+        # w <= 4 implies x0 <= 4/1 = 4.
+        from discopt._jax.obbt import reverse_fbbt_from_aux
+
+        lb = np.array([0.0, 1.0, 1.0, 1.0])
+        ub = np.array([10.0, 2.0, 2.0, 2.0])
+        varmap = {"multilinear": {(0, 1, 2, 3): 4}}
+        aux_lb = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+        aux_ub = np.array([0.0, 0.0, 0.0, 0.0, 4.0])
+        n = reverse_fbbt_from_aux(lb, ub, aux_lb, aux_ub, varmap)
+        assert n >= 1
+        assert ub[0] <= 4.0 + 1e-9
+
+    def test_ratio_numerator_and_denominator_bounds(self):
+        # w = x / y. y in [2,4], tightened w <= 1 implies x = w*y <= 4.
+        from discopt._jax.obbt import reverse_fbbt_from_aux
+
+        lb = np.array([0.0, 2.0])
+        ub = np.array([10.0, 4.0])
+        varmap = {"ratio": {((0,), (1,)): 2}}
+        aux_lb = np.array([0.0, 0.0, 0.0])
+        aux_ub = np.array([0.0, 0.0, 1.0])
+        n = reverse_fbbt_from_aux(lb, ub, aux_lb, aux_ub, varmap)
+        assert n >= 1
+        assert ub[0] <= 4.0 + 1e-9  # x <= w_ub * y_ub = 1*4
+
+    def test_ratio_denominator_tightens(self):
+        # w = x / y, x fixed at 4, w in [2,10] implies y = x/w in [0.4, 2].
+        from discopt._jax.obbt import reverse_fbbt_from_aux
+
+        lb = np.array([4.0, 0.1])
+        ub = np.array([4.0, 5.0])
+        varmap = {"ratio": {((0,), (1,)): 2}}
+        aux_lb = np.array([0.0, 0.0, 2.0])
+        aux_ub = np.array([0.0, 0.0, 10.0])
+        n = reverse_fbbt_from_aux(lb, ub, aux_lb, aux_ub, varmap)
+        assert n >= 1
+        assert lb[1] >= 0.4 - 1e-9  # y >= x_lb / w_ub = 4/10
+        assert ub[1] <= 2.0 + 1e-9  # y <= x_ub / w_lb = 4/2
+
+    def test_higher_arity_never_loosens_and_is_sound(self):
+        # Randomized soundness: every (x,y,z) whose product lands in the aux box
+        # must remain inside the tightened box (reverse FBBT only removes points
+        # that cannot satisfy w = x*y*z for the given aux bounds).
+        from discopt._jax.obbt import reverse_fbbt_from_aux
+
+        rng = np.random.default_rng(0)
+        for _ in range(200):
+            lb = np.array([rng.uniform(-3, 0), rng.uniform(0.5, 2), rng.uniform(1, 2)])
+            ub = np.array([rng.uniform(1, 4), rng.uniform(2, 4), rng.uniform(2, 3)])
+            wl, wu = sorted(rng.uniform(-20, 20, size=2))
+            varmap = {"trilinear": {(0, 1, 2): 3}}
+            aux_lb = np.array([0.0, 0.0, 0.0, wl])
+            aux_ub = np.array([0.0, 0.0, 0.0, wu])
+            tl, tu = lb.copy(), ub.copy()
+            reverse_fbbt_from_aux(tl, tu, aux_lb, aux_ub, varmap)
+            # Tightened box is a subset of the original.
+            assert np.all(tl >= lb - 1e-9) and np.all(tu <= ub + 1e-9)
+            # No feasible (in-box, in-aux) point is cut.
+            for _ in range(40):
+                p = np.array([rng.uniform(lb[k], ub[k]) for k in range(3)])
+                w = p[0] * p[1] * p[2]
+                if wl - 1e-12 <= w <= wu + 1e-12:
+                    assert np.all(p >= tl - 1e-9) and np.all(p <= tu + 1e-9)
+
     def test_cascade_preserves_box_subset_and_optimum(self):
         # End to end: cascade_aux must keep the box a subset and never remove the
         # bilinear optimum. min x+y s.t. x*y >= 4, x,y in [0.5,4].


### PR DESCRIPTION
Advances #208 (OBBT-on-auxiliaries). **Does not close it** — the cascade stays default-OFF because the corpus A/B does not meet the net-positive bar (below). This is a sound, tested coverage extension of the existing opt-in path plus the measurement infrastructure to graduate it later.

## What changed

1. **`reverse_fbbt_from_aux` coverage extension** (`python/discopt/_jax/obbt.py`)
   The #208 aux-bound cascade (`obbt_tighten_root(cascade_aux=True)`) previously propagated tightened auxiliary-column bounds back onto the original variables only for **bilinear** products and integer-power **monomials**. It now also handles the remaining product/ratio families the uniform relaxation engine actually lifts and that reach original columns:
   - **trilinear / multilinear** `w = ∏ x_c` — for each factor, divide the aux box by the interval product of the other factors (the arity-generalized bilinear hyperbolic deduction);
   - **ratio-of-products** `w = (∏ x_num)/(∏ x_den)` (the #185/#309 quotient aux) — solve each numerator/denominator factor from the term equation via interval products and division.

   Every deduction is a **sound FBBT step** (valid interval enclosures only remove values that cannot satisfy the term equation), so the box stays a valid enclosure. `fractional_power` was deliberately *not* added — that varmap family is empty on the uniform engine, so a handler would be dead code.

2. **Measurable gate + reproducible A/B harness** (`python/discopt/_jax/root_reduce.py`, `design/ab_cascade_aux.py`)
   `DISCOPT_OBBT_CASCADE_AUX` (default `0`) drives the cascade through the real `Model.solve()` path so the #208 acceptance-criteria A/B can run end-to-end. Gate off ⇒ `cascade_aux=False` (the existing measured-dead default); the OFF path is byte-identical to before. `design/ab_cascade_aux.py` is a flag OFF-vs-ON differential panel over the vendored 65-instance corpus.

## Measured A/B (in-repo corpus, 8 s/instance budget)

| metric | OFF | ON | delta |
|---|---|---|---|
| total node_count | 2322 | 2428 | **+4.6%** |
| total wall | 390.4 s | 317.5 s | −18.7% (−9.2% ex-`tspn12` outlier) |
| differential soundness violations | — | — | **0** |
| cert gains / regressions | — | — | +1 / −1 |

Node deltas split cleanly by structure: **continuous** spatial-branch instances reduce (`nvs01` 5→3, `tspn08/10/12` 3→1) while **integer/combinatorial** ones grow (`cvxnonsep_nsig30` +50, `tls2` +32). One cert gain (`cvxnonsep_nsig30` F→T), one cert regression under budget (`fac2` T→F).

**Verdict (measurement wins):** SOUND but **not net-positive** on this integer-heavy corpus, so `cascade_aux` correctly stays default-OFF — reconfirming the earlier finding. Graduating the flag needs a *continuous spatial-branching* suite (the MINLPLib snapshot, not vendored in this environment) plus the "budget the cascade" follow-up.

## Testing

- `pytest python/tests/test_obbt.py` — 53 passed (5 new: trilinear, multilinear, both ratio directions, randomized soundness check that no in-box/in-aux point is ever cut).
- `pytest python/tests/ -m smoke` — 658 passed, 13 skipped.
- `pytest python/tests/test_r2_branch_and_reduce.py python/tests/test_f4_root_budget_gate.py` — 14 passed (env-gate edit regression check).
- `ruff check` / `ruff format --check` clean; no new `mypy` errors in `obbt.py`. Rust untouched.
- Verified the trilinear `{(0,1,2):col}` and ratio `{((0,),(1,)):col}` varmap key formats against real `build_milp_relaxation` builds; confirmed `cascade_aux=True` stays a sound box subset (optimum preserved) end-to-end.

## Follow-ups (keep #208 open)

- A/B on a continuous spatial-branching suite (the class where the hyperbolic root bound prunes).
- Budget the cascade: only spend aux min/max LPs on columns whose `reverse_fbbt_from_aux` can reach an original variable — likely erases the +4.6% node regression and the `fac2` cert regression on integer-heavy instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012s63aECpwvUfzLnehcxM8E)_