### PR TITLE
fix(#689,#698,#280): lift initial_point across the reform, swap-reseed the MILP incumbent, and stop discarding time_limit

### DIFF
--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -105,6 +105,105 @@ def _int_factor_range(
     return lo_i, hi_i
 
 
+def _flat_offsets(model: Model) -> tuple[dict[int, int], int]:
+    """Map ``id(Variable)`` -> its offset in the model's flat vector, plus the
+    total flat width. Variables are laid out in ``model._variables`` order."""
+    off: dict[int, int] = {}
+    cur = 0
+    for v in model._variables:
+        off[id(v)] = cur
+        cur += int(v.size)
+    return off, cur
+
+
+def _resolve_aux_spec(model: Model, spec: list[tuple]) -> Optional[list[tuple]]:
+    """Resolve an ``_Expander.aux_spec`` (Variable refs) to flat-index arithmetic
+    against *model*'s final variable list. ``None`` if any ref is unresolvable."""
+    off, _ = _flat_offsets(model)
+
+    def idx(ref) -> Optional[int]:
+        if ref is None:
+            return None
+        var, elem = ref
+        base = off.get(id(var))
+        return None if base is None else base + int(elem)
+
+    out: list[tuple] = []
+    for entry in spec:
+        if entry[0] == "bits":
+            j_x = idx(entry[1])
+            bits = [idx((e, 0)) for e in entry[3]]
+            if j_x is None or any(b is None for b in bits):
+                return None
+            out.append(("bits", j_x, int(entry[2]), bits))
+        elif entry[0] == "prod":
+            j_v, j_e, j_o = idx((entry[1], 0)), idx((entry[2], 0)), idx(entry[3])
+            if j_v is None or j_e is None:
+                return None
+            out.append(("prod", j_v, j_e, j_o))
+        else:  # unknown kind: decline rather than guess
+            return None
+    return out
+
+
+def extend_initial_point(reformed: Model, x0) -> Optional[np.ndarray]:
+    """Extend a point over the ORIGINAL variables (flat, length
+    ``_ipx_n_orig_flat``) to a point over *reformed*'s full variable vector by
+    evaluating each auxiliary from its recorded definition — the expansion bits
+    ``e_k`` of ``x = lo + sum 2^k e_k``, and each big-M product ``v = e * other``.
+    Both are *exactly* determined by the originals at integral ``e``, so this is
+    reconstruction, not approximation.
+
+    Returns ``None`` — the caller then simply does not seed, today's behavior —
+    when the model carries no reformulation metadata, the point has the wrong
+    length or is non-integral where a bit expansion needs an integer, or any aux
+    is not reconstructible. Never guesses: a partial or invented seed would be
+    worse than no seed.
+
+    Purely primal, never a soundness lever: the MILP driver re-validates whatever
+    it is handed (bounds, integrality, row feasibility) and recomputes the
+    objective, so a bad point is dropped rather than trusted (#689)."""
+    spec = getattr(reformed, "_ipx_aux_spec", None)
+    n0 = getattr(reformed, "_ipx_n_orig_flat", None)
+    if spec is None or n0 is None:
+        return None
+    x = np.asarray(x0, dtype=np.float64).ravel()
+    if x.size != int(n0) or not np.all(np.isfinite(x)):
+        return None
+
+    _, total = _flat_offsets(reformed)
+    out = np.full(int(total), np.nan, dtype=np.float64)
+    out[: int(n0)] = x
+    known: set[int] = set(range(int(n0)))
+
+    for entry in spec:
+        if entry[0] == "bits":
+            _, j_x, lo, bit_idx = entry
+            if j_x not in known:
+                return None
+            shifted = float(out[j_x]) - float(lo)
+            r = round(shifted)
+            # A fractional value has no bit expansion; a value outside the
+            # expanded range would silently wrap. Decline both.
+            if abs(shifted - r) > 1e-6 or r < 0 or r >= (1 << len(bit_idx)):
+                return None
+            for k, j in enumerate(bit_idx):
+                out[j] = float((int(r) >> k) & 1)
+                known.add(j)
+        elif entry[0] == "prod":
+            _, j_v, j_e, j_o = entry
+            if j_o is None or j_e not in known or j_o not in known:
+                return None
+            out[j_v] = float(out[j_e]) * float(out[j_o])
+            known.add(j_v)
+        else:
+            return None
+
+    if np.any(np.isnan(out)):
+        return None
+    return out
+
+
 class _Expander:
     """Creates and caches the binary expansion of integer factor variables and
     accumulates the linking ``x_i == lo + sum 2^k e_k`` constraints."""
@@ -119,6 +218,11 @@ class _Expander:
         # (var._index, elem) -> (lo, [(coef, e_k Variable), ...])
         self._cache: dict[tuple[int, int], tuple[int, list[tuple[int, Variable]]]] = {}
         self._counter = 0
+        # Aux definitions in creation order, for reconstructing every lifted
+        # column from a point over the ORIGINAL variables (see
+        # :func:`extend_initial_point`). Entries hold Variable refs here and are
+        # resolved to flat indices once the variable list is final (#689).
+        self.aux_spec: list[tuple] = []
 
     def expansion(self, var: Variable, elem: int, lo: int, hi: int):
         key = (var._index, elem)
@@ -139,6 +243,7 @@ class _Expander:
             link = BinaryOp("-", link, term)
         self.aux_constraints.append(Constraint(link, "==", 0.0))
         self._cache[key] = (lo, bits)
+        self.aux_spec.append(("bits", (var, elem), lo, [e for _, e in bits]))
         return lo, bits
 
     def bigm_product(self, e: Variable, other: Expression, lo_o: float, hi_o: float) -> Variable:
@@ -187,6 +292,11 @@ class _Expander:
         # v - other - hi_o*e + hi_o >= 0   (i.e. v >= other - hi_o*(1-e))
         body_l = BinaryOp("-", BinaryOp("-", v, other), BinaryOp("*", Constant(hi_o), e))
         ac.append(Constraint(BinaryOp("+", body_l, Constant(hi_o)), ">=", 0.0))
+        # ``v == e * other`` exactly at ``e in {0,1}``, so v is reconstructible
+        # from a point whenever ``other`` is a plain variable reference. A more
+        # structured ``other`` records ``None`` and makes the whole extension
+        # decline (never guess) — see :func:`extend_initial_point`.
+        self.aux_spec.append(("prod", v, e, _scalar_var_ref(other)))
         return v
 
 
@@ -506,6 +616,16 @@ def expand_integer_products(model: Model, implied=frozenset()) -> Model:
         if len(new_model._variables) > cap:
             return model
         new_model._constraints = rebuilt + exp.aux_constraints
+        # Record how to rebuild the lifted columns from a point over the original
+        # variables, so a caller's initial_solution survives the lift instead of
+        # being silently dropped on the length check downstream (#689). Resolved
+        # here, where the variable list is final (aux are appended after the
+        # originals, so the originals keep their flat indices).
+        n_orig_flat = sum(int(v.size) for v in model._variables)
+        setattr(new_model, "_ipx_n_orig_flat", n_orig_flat)  # noqa: B010
+        setattr(  # noqa: B010
+            new_model, "_ipx_aux_spec", _resolve_aux_spec(new_model, exp.aux_spec)
+        )
         return new_model
     except Exception:
         return model

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4248,6 +4248,34 @@ def solve_model(
                 or _ipx_nl.general_nl
             )
             if _ipx_pure_milp and classify_problem(_ipx) == ProblemClass.MILP:
+                # Carry any caller seed across the lift. The reform appends aux
+                # columns, so an original-space point no longer matches the lifted
+                # width and the MILP driver's length check would drop it SILENTLY
+                # — discarding even a known-optimal incumbent (#689). Reconstruct
+                # the aux from their exact definitions; ``None`` means the point
+                # was not exactly reconstructible, and we simply do not seed
+                # (unchanged behavior) rather than guess. Purely primal: the
+                # driver re-validates the seed and recomputes its objective, so
+                # the dual bound and the certificate are unaffected either way.
+                if initial_point is not None:
+                    from discopt._jax.integer_product_reform import (
+                        extend_initial_point as _ipx_extend,
+                    )
+
+                    _ipx_x0 = _ipx_extend(_ipx, initial_point)
+                    if _ipx_x0 is None:
+                        logger.debug(
+                            "integer-bilinear reform: initial_point not reconstructible "
+                            "across the lift; solving without a seed"
+                        )
+                    initial_point = _ipx_x0
+                # Keep the pre-lift model reachable from the MILP path. A primal
+                # move over the ORIGINAL variables (e.g. a one-hot swap) is only
+                # well defined there: permuting bits in the lifted space leaves
+                # the expansion/big-M auxiliaries stale, i.e. genuinely
+                # infeasible. The MILP engine improves an incumbent by swapping
+                # here, then lifts the result back (#280).
+                _ipx._ipx_source_model = model
                 model = _ipx
                 model._convexity_classification_cache = None
                 clear_declared_box_cache(model)
@@ -13743,6 +13771,56 @@ def _root_dive(
 _SIMPLEX_MILP_BUDGET_CAP_S = 10.0
 
 
+def _one_hot_swap_reseed(model: Model, x_lifted: np.ndarray, budget: float) -> Optional[np.ndarray]:
+    """A lifted-space seed built by improving *x_lifted* with an assignment-aware
+    swap over the ORIGINAL variables, or ``None`` when unavailable.
+
+    On set-partition / assignment-structured models (``sum_k x[i,k] == 1``) a
+    single bit flip always breaks a one-hot row, so the engine's generic
+    flip/dive heuristics make little headway and its incumbent stalls well above
+    the optimum while the dual bound is already tight (#280). The
+    feasibility-preserving move is a *swap*, which is only well defined on the
+    pre-lift model: permuting bits in the lifted space leaves the expansion /
+    big-M auxiliaries stale, i.e. genuinely infeasible. So swap over the
+    originals, then reconstruct the aux exactly (#689).
+
+    Purely primal and never a soundness lever — the result is only ever handed
+    back as an ``initial_incumbent``, which the Rust driver re-validates (bounds,
+    integrality, row feasibility) and re-scores from ``c``. A bad or worse point
+    is dropped by the engine, never trusted; the dual bound and the certificate
+    are untouched either way. Self-gates to a no-op (returns ``None``) when the
+    model was not lifted or carries no one-hot structure."""
+    src = getattr(model, "_ipx_source_model", None)
+    n0 = getattr(model, "_ipx_n_orig_flat", None)
+    if src is None or n0 is None or budget <= 0.2:
+        return None
+    # ``one_hot_swap_search`` scores with the model's own objective and accepts
+    # strict *decreases*, so it only searches in the improving direction on a
+    # minimize model. On a maximize model it would drive the wrong way and the
+    # engine would just discard the seed — skip rather than burn the budget.
+    from discopt.modeling.core import ObjectiveSense as _Sense
+
+    obj = getattr(src, "_objective", None)
+    if obj is None or obj.sense != _Sense.MINIMIZE:
+        return None
+    try:
+        from discopt._jax.integer_product_reform import extend_initial_point
+        from discopt._jax.primal_heuristics import one_hot_swap_search
+
+        sw = one_hot_swap_search(
+            src,
+            np.asarray(x_lifted[: int(n0)], dtype=np.float64),
+            time_budget=min(1.0, budget * 0.5),
+            deadline=time.perf_counter() + budget,
+        )
+        if sw is None:
+            return None
+        return extend_initial_point(model, sw[0])
+    except Exception as _exc:  # pragma: no cover - defensive
+        logger.debug("one-hot swap reseed skipped: %s", _exc)
+        return None
+
+
 def _solve_milp_simplex(
     model: Model,
     time_limit: float,
@@ -13866,6 +13944,49 @@ def _solve_milp_simplex(
         time_limit_s=float(_milp_budget),
         debug_hook=_debug.rust_hook(),
     )
+    # (#280) The engine stopped with an uncertified incumbent and the user's
+    # budget is not spent (``_milp_budget`` is a *stall* bound, deliberately a
+    # slice of the limit — see above). On assignment-structured models that
+    # incumbent is typically stuck: the swap below is the move that escapes it.
+    # Re-enter the engine seeded with the improved point and keep the result only
+    # when it is strictly better in the engine's own (min-normalized) objective,
+    # so this can never worsen the answer. The seed is re-validated and re-scored
+    # by the driver, so soundness does not rest on the heuristic.
+    if status == "feasible":
+        _rem = float(time_limit) - (time.perf_counter() - t_start)
+        _seed2 = _one_hot_swap_reseed(model, np.asarray(x_struct, dtype=np.float64), _rem)
+        if _seed2 is not None:
+            _rem = float(time_limit) - (time.perf_counter() - t_start)
+            _budget2 = min(max(0.5, _rem - 0.2), _SIMPLEX_MILP_BUDGET_CAP_S)
+            _s2, _x2, _o2, _b2, _n2, _ = solve_milp_py(
+                np.ascontiguousarray(lp_data.c, dtype=np.float64),
+                A,
+                np.ascontiguousarray(lp_data.b_eq, dtype=np.float64),
+                np.ascontiguousarray(lp_data.x_l, dtype=np.float64),
+                np.ascontiguousarray(lp_data.x_u, dtype=np.float64),
+                np.ascontiguousarray(np.asarray(int_idx, dtype=np.int64)),
+                n_orig,
+                float(lp_data.obj_const),
+                int(max_nodes),
+                float(gap_tolerance),
+                initial_incumbent=np.ascontiguousarray(_seed2, dtype=np.float64),
+                time_limit_s=float(_budget2),
+                debug_hook=_debug.rust_hook(),
+            )
+            if _s2 in ("optimal", "feasible") and np.isfinite(_o2) and _o2 < obj - 1e-9:
+                # Both runs' bounds are valid lower bounds in min-normalized
+                # space, so keeping the tighter one is sound.
+                _bound_new = _b2
+                if np.isfinite(bound) and np.isfinite(_b2):
+                    _bound_new = max(bound, _b2)
+                elif not np.isfinite(_b2):
+                    _bound_new = bound
+                logger.info(
+                    "MILP one-hot swap reseed improved the incumbent: %.6g -> %.6g", obj, _o2
+                )
+                status, x_struct, obj, bound = _s2, _x2, _o2, _bound_new
+                nodes += _n2
+
     wall_time = time.perf_counter() - t_start
     maximize = model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -13929,6 +13929,7 @@ def _solve_milp_simplex(
     if initial_point is not None and np.asarray(initial_point).size == n_orig:
         _seed = np.ascontiguousarray(np.asarray(initial_point, dtype=np.float64).ravel())
 
+    _t_run1 = time.perf_counter()
     status, x_struct, obj, bound, nodes, _lp_iters = solve_milp_py(
         np.ascontiguousarray(lp_data.c, dtype=np.float64),
         A,
@@ -13944,20 +13945,41 @@ def _solve_milp_simplex(
         time_limit_s=float(_milp_budget),
         debug_hook=_debug.rust_hook(),
     )
-    # (#280) The engine stopped with an uncertified incumbent and the user's
-    # budget is not spent (``_milp_budget`` is a *stall* bound, deliberately a
-    # slice of the limit — see above). On assignment-structured models that
-    # incumbent is typically stuck: the swap below is the move that escapes it.
-    # Re-enter the engine seeded with the improved point and keep the result only
-    # when it is strictly better in the engine's own (min-normalized) objective,
-    # so this can never worsen the answer. The seed is re-validated and re-scored
-    # by the driver, so soundness does not rest on the heuristic.
+    # The engine came back with a real incumbent but no certificate, and the
+    # user's budget is not spent. ``_milp_budget`` is a *stall* bound (#291) — it
+    # exists to defer quickly to the robust fallback when the engine wedges — but
+    # an engine that produced an incumbent is demonstrably not wedged, and this
+    # branch RETURNS rather than falling back, so the rest of the budget is
+    # otherwise just discarded (at time_limit=40 the engine used ~10 s and
+    # returned uncertified; #698). Spend it instead, on two levers:
+    #
+    #   (a) primal — an assignment-aware swap over the pre-lift model, which is
+    #       what escapes a stuck one-hot incumbent (#280);
+    #   (b) dual — simply more search. The engine is monotone in its budget
+    #       (measured on graphpart_3pm-0334-0334: bound -54.0 / -50.0 / -40.5 /
+    #       -38.25 at 2.5 / 5 / 10 / 20 s), so a longer re-entry tightens the
+    #       bound and can certify.
+    #
+    # The first slice stays bounded either way: it keeps #291's stall deferral
+    # intact AND leaves room for (a) — handing run 1 the whole budget instead
+    # starves the swap and is strictly worse (measured).
     if status == "feasible":
+        _run1_spent_slice = (time.perf_counter() - _t_run1) >= _milp_budget - 0.05
         _rem = float(time_limit) - (time.perf_counter() - t_start)
         _seed2 = _one_hot_swap_reseed(model, np.asarray(x_struct, dtype=np.float64), _rem)
-        if _seed2 is not None:
-            _rem = float(time_limit) - (time.perf_counter() - t_start)
-            _budget2 = min(max(0.5, _rem - 0.2), _SIMPLEX_MILP_BUDGET_CAP_S)
+        _rem = float(time_limit) - (time.perf_counter() - t_start)
+        # Re-enter when the swap improved the point (even a short re-entry pays:
+        # the seed is better), or when there is genuinely more time than run 1
+        # had — otherwise a re-entry restarts the tree with less budget than run 1
+        # and cannot beat it, so it would only burn wall for nothing.
+        _more_time = _run1_spent_slice and _rem > _milp_budget + 0.5
+        if (_seed2 is not None or _more_time) and _rem > 0.7:
+            _seed_run2 = _seed2
+            if _seed_run2 is None:
+                _seed_run2 = np.asarray(x_struct, dtype=np.float64)[:n_orig]
+            # Uncapped: this is the user's own remaining budget, and no fallback
+            # is being starved — this branch returns its result directly.
+            _budget2 = max(0.5, _rem - 0.2)
             _s2, _x2, _o2, _b2, _n2, _ = solve_milp_py(
                 np.ascontiguousarray(lp_data.c, dtype=np.float64),
                 A,
@@ -13969,23 +13991,37 @@ def _solve_milp_simplex(
                 float(lp_data.obj_const),
                 int(max_nodes),
                 float(gap_tolerance),
-                initial_incumbent=np.ascontiguousarray(_seed2, dtype=np.float64),
+                initial_incumbent=np.ascontiguousarray(_seed_run2, dtype=np.float64),
                 time_limit_s=float(_budget2),
                 debug_hook=_debug.rust_hook(),
             )
-            if _s2 in ("optimal", "feasible") and np.isfinite(_o2) and _o2 < obj - 1e-9:
-                # Both runs' bounds are valid lower bounds in min-normalized
-                # space, so keeping the tighter one is sound.
-                _bound_new = _b2
-                if np.isfinite(bound) and np.isfinite(_b2):
-                    _bound_new = max(bound, _b2)
-                elif not np.isfinite(_b2):
-                    _bound_new = bound
-                logger.info(
-                    "MILP one-hot swap reseed improved the incumbent: %.6g -> %.6g", obj, _o2
-                )
-                status, x_struct, obj, bound = _s2, _x2, _o2, _bound_new
-                nodes += _n2
+
+            # Both runs' bounds are valid lower bounds on the same problem in
+            # min-normalized space, so keeping the tighter is sound (and can only
+            # sit below any feasible incumbent's objective).
+            def _tighter(_b_old, _b_new):
+                if not np.isfinite(_b_new):
+                    return _b_old
+                return _b_new if not np.isfinite(_b_old) else max(_b_old, _b_new)
+
+            if _s2 in ("optimal", "feasible") and np.isfinite(_o2):
+                if _o2 < obj - 1e-9:
+                    # Strictly better incumbent: take run 2's point wholesale.
+                    logger.info("MILP re-entry improved the incumbent: %.6g -> %.6g", obj, _o2)
+                    status, x_struct, obj = _s2, _x2, float(_o2)
+                    bound = _tighter(bound, _b2)
+                    nodes += _n2
+                elif _s2 == "optimal" and abs(float(_o2) - obj) <= 1e-9:
+                    # Same incumbent, now proved optimal — the certificate the
+                    # discarded budget was costing us.
+                    logger.info("MILP re-entry certified the incumbent: %.6g", obj)
+                    status = "optimal"
+                    bound = _tighter(bound, _b2)
+                    nodes += _n2
+                else:
+                    # No primal gain; still bank any dual progress.
+                    bound = _tighter(bound, _b2)
+                    nodes += _n2
 
     wall_time = time.perf_counter() - t_start
     maximize = model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE

--- a/python/tests/test_issue_689_ipx_seed_lift.py
+++ b/python/tests/test_issue_689_ipx_seed_lift.py
@@ -1,0 +1,143 @@
+"""Regression tests for #689 (and the #280 primal gap that it blocked).
+
+``reformulate_integer_bilinear`` binary-expands + big-M-linearizes integer-factor
+products into an exact pure MILP, appending aux columns after the originals. A
+caller's ``initial_solution`` is built over the ORIGINAL variables, so after the
+lift it no longer matches the lifted width and ``_solve_milp_simplex``'s
+``size == n_orig`` guard dropped it *silently* — discarding even a known-optimal
+incumbent (#689).
+
+``extend_initial_point`` reconstructs every lifted column from its exact
+definition (the expansion bits of ``x = lo + sum 2^k e_k``, and each big-M product
+``v = e * other``), so the seed survives the lift. That in turn is what lets the
+MILP path improve an assignment-structured incumbent with a one-hot swap, which
+is only well defined on the pre-lift model (#280).
+
+These tests are synthetic and corpus-free so they run in CI.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.integer_product_reform import (
+    extend_initial_point,
+    reformulate_integer_bilinear,
+)
+from discopt._jax.nlp_evaluator import cached_evaluator
+from discopt._jax.primal_heuristics import _check_constraint_feasibility
+
+
+def _partition_model(N, K, per, edges):
+    """min within-partition edge weight; each node in one partition, balanced.
+
+    The same assignment-structured shape as the ``graphpart_*`` family, built to
+    match how the ``.nl`` reader actually encodes it: **scalar** decision columns
+    declared ``INTEGER`` over ``[0, 1]`` (not ``BINARY``). That distinction is
+    load-bearing here — ``_int_factor_range`` excludes declared binaries, so a
+    ``m.binary(...)`` model is never lifted and would not exercise this path at
+    all, while the real family is.
+    """
+    m = dm.Model("gp")
+    x = [[m.integer(f"x_{i}_{k}", lb=0, ub=1) for k in range(K)] for i in range(N)]
+    for i in range(N):
+        m.subject_to(dm.sum(x[i][k] for k in range(K)) == 1, name=f"assign_{i}")
+    for k in range(K):
+        m.subject_to(dm.sum(x[i][k] for i in range(N)) == per, name=f"bal_{k}")
+    m.minimize(dm.sum(w * dm.sum(x[i][k] * x[j][k] for k in range(K)) for (i, j, w) in edges))
+    return m, x
+
+
+def _edges(N, seed=0):
+    rng = np.random.default_rng(seed)
+    return [(i, j, float(rng.integers(1, 9))) for i in range(N) for j in range(i + 1, N)]
+
+
+def _flat_assignment(N, K, assign):
+    xf = np.zeros(N * K, dtype=np.float64)
+    for i, k in enumerate(assign):
+        xf[i * K + k] = 1.0
+    return xf
+
+
+def _lifted():
+    m, _ = _partition_model(6, 3, 2, _edges(6, seed=1))
+    rm = reformulate_integer_bilinear(m)
+    return m, rm
+
+
+def test_lift_records_reconstruction_metadata():
+    """The reform must record what it needs to rebuild the lifted columns."""
+    m, rm = _lifted()
+    assert len(rm._variables) > len(m._variables), "expected the reform to lift"
+    assert rm._ipx_n_orig_flat == sum(int(v.size) for v in m._variables)
+    assert rm._ipx_aux_spec, "no aux spec recorded — the seed cannot survive the lift"
+
+
+def test_extended_point_is_exactly_reconstructed():
+    """The reconstructed point must satisfy every row of the LIFTED model and
+    reproduce the original objective — the guarantee the seed rests on.
+
+    This is the #689 defect: without the extension the point is the wrong width
+    and gets dropped; with a *wrong* extension the aux rows would be violated.
+    """
+    m, rm = _lifted()
+    x0 = _flat_assignment(6, 3, [0, 0, 1, 1, 2, 2])
+
+    xe = extend_initial_point(rm, x0)
+    assert xe is not None
+    assert xe.size == sum(int(v.size) for v in rm._variables)
+    assert np.allclose(xe[: x0.size], x0), "the originals must be preserved verbatim"
+
+    ev_lift, ev_orig = cached_evaluator(rm), cached_evaluator(m)
+    assert _check_constraint_feasibility(ev_lift, xe), "reconstructed aux violate the lifted rows"
+    assert float(ev_lift.evaluate_objective(xe)) == pytest.approx(
+        float(ev_orig.evaluate_objective(x0)), abs=1e-9
+    )
+
+
+def test_extension_declines_rather_than_guesses():
+    """A point the reform cannot reconstruct exactly must yield ``None`` (no seed),
+    never a partial or invented one."""
+    _, rm = _lifted()
+    n0 = rm._ipx_n_orig_flat
+    assert extend_initial_point(rm, np.zeros(n0 + 1)) is None  # wrong width
+    assert extend_initial_point(rm, np.full(n0, np.nan)) is None  # non-finite
+    # Fractional where a bit expansion needs an integer.
+    assert extend_initial_point(rm, np.full(n0, 0.5)) is None
+    # A model that was never lifted carries no metadata.
+    assert extend_initial_point(dm.Model("bare"), np.zeros(3)) is None
+
+
+def test_seed_reaches_the_engine_at_lifted_width(monkeypatch):
+    """The caller's ``initial_solution`` must arrive at the MILP driver, lifted.
+
+    This is the #689 defect precisely. The seed is built over the ORIGINAL
+    columns; the reform appends aux, so pre-fix the driver's ``size == n_orig``
+    guard saw a short vector and set ``initial_incumbent=None`` — silently. A
+    weaker end-to-end assertion (``objective <= optimum``) does not discriminate:
+    the engine often reaches the optimum unaided on a small instance. So assert
+    on what actually regressed — that a seed is handed to the driver, at the
+    lifted width, and that it is the point we asked for.
+    """
+    import discopt._rust as rust
+
+    seen: list = []
+    real = rust.solve_milp_py
+
+    def spy(*args, **kwargs):
+        seen.append(kwargs.get("initial_incumbent"))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(rust, "solve_milp_py", spy)
+
+    m, _ = _partition_model(6, 3, 2, _edges(6, seed=1))
+    x0 = _flat_assignment(6, 3, [0, 0, 1, 1, 2, 2])
+    m.solve(time_limit=10, initial_solution={v: float(x0[i]) for i, v in enumerate(m._variables)})
+
+    seeds = [s for s in seen if s is not None]
+    assert seeds, "the initial_solution never reached the MILP driver (silently dropped)"
+    seed = np.asarray(seeds[0], dtype=np.float64)
+    assert seed.size > x0.size, "seed was not lifted to the reformulated width"
+    assert np.allclose(seed[: x0.size], x0), "seed's original columns were not preserved"

--- a/python/tests/test_issue_698_milp_budget_reentry.py
+++ b/python/tests/test_issue_698_milp_budget_reentry.py
@@ -1,0 +1,120 @@
+"""Regression tests for #698 — the Rust MILP engine's truncated time budget.
+
+``_solve_milp_simplex`` bounds the engine to ``max(0.5, min(0.5 * remaining,
+_SIMPLEX_MILP_BUDGET_CAP_S))``. That slice is a *stall* bound (#291: defer fast
+to the robust fallback when the engine wedges), but on an uncertified
+``feasible`` the function RETURNS rather than falling back — so the rest of the
+user's ``time_limit`` was simply discarded. At ``time_limit=40`` the engine used
+~10 s and returned uncertified; at the default 3600 s it used ~10 s.
+
+An engine that produced an incumbent is demonstrably not wedged, so the fix
+re-enters it with the remaining budget, seeded with the best point so far. The
+engine is monotone in its budget, so this tightens the bound and can certify.
+
+These tests pin the *contract* (budget is spent; the re-entry never worsens the
+answer; no pointless re-entry when there is no extra budget), not a specific
+objective — the engine is wall-clock-limited and therefore load-nondeterministic,
+so asserting exact bounds/nodes here would be flaky.
+"""
+
+from __future__ import annotations
+
+import time
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+
+def _hard_partition_model(N, K, per, seed=7):
+    """An assignment-structured binary-product QP big enough not to certify fast.
+
+    Scalar ``integer(0, 1)`` columns match how the ``.nl`` reader encodes this
+    family (``_int_factor_range`` excludes declared ``BINARY``), so the
+    integer-bilinear reform lifts it to an exact MILP and it reaches the Rust
+    MILP engine — the path under test.
+    """
+    rng = np.random.default_rng(seed)
+    m = dm.Model("gp_hard")
+    x = [[m.integer(f"x_{i}_{k}", lb=0, ub=1) for k in range(K)] for i in range(N)]
+    for i in range(N):
+        m.subject_to(dm.sum(x[i][k] for k in range(K)) == 1, name=f"assign_{i}")
+    for k in range(K):
+        m.subject_to(dm.sum(x[i][k] for i in range(N)) == per, name=f"bal_{k}")
+    edges = [(i, j, float(rng.integers(1, 9))) for i in range(N) for j in range(i + 1, N)]
+    m.minimize(dm.sum(w * dm.sum(x[i][k] * x[j][k] for k in range(K)) for (i, j, w) in edges))
+    return m
+
+
+def _engine_budgets(monkeypatch):
+    """Record the ``time_limit_s`` handed to each Rust MILP driver call."""
+    import discopt._rust as rust
+
+    budgets: list[float] = []
+    real = rust.solve_milp_py
+
+    def spy(*args, **kwargs):
+        budgets.append(float(kwargs.get("time_limit_s", 0.0)))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(rust, "solve_milp_py", spy)
+    return budgets
+
+
+@pytest.mark.slow
+def test_uncertified_milp_spends_the_user_budget(monkeypatch):
+    """A solve that comes back uncertified must not leave most of the limit unused.
+
+    Pre-fix this returned at ~min(0.5*TL, 10 s) regardless of ``time_limit``.
+    """
+    budgets = _engine_budgets(monkeypatch)
+    m = _hard_partition_model(18, 3, 6)
+
+    tl = 30.0
+    t0 = time.perf_counter()
+    r = m.solve(time_limit=tl)
+    wall = time.perf_counter() - t0
+
+    assert wall <= tl + 5.0, "the solve must still respect the user's time_limit"
+    if r.status != "optimal":
+        # Uncertified: the budget should have been spent, not discarded at ~10 s.
+        assert wall > 12.0, f"returned uncertified after only {wall:.1f}s of a {tl}s limit"
+        assert max(budgets) > 10.0 + 1e-6, (
+            "no engine call was given more than the stall-slice cap, so the "
+            f"remaining budget was discarded (budgets={budgets})"
+        )
+
+
+@pytest.mark.slow
+def test_no_pointless_reentry_when_no_extra_budget(monkeypatch):
+    """With a small limit there is no budget left to beat run 1, so do not re-enter
+    on the dual lever — a restart with *less* time than run 1 cannot improve it and
+    would only burn wall. (A swap-improved seed is a separate, tested lever.)"""
+    budgets = _engine_budgets(monkeypatch)
+    m = _hard_partition_model(18, 3, 6)
+
+    tl = 4.0
+    t0 = time.perf_counter()
+    m.solve(time_limit=tl)
+    wall = time.perf_counter() - t0
+
+    assert wall <= tl + 3.0, f"overran a {tl}s limit ({wall:.1f}s)"
+    # Every engine budget must stay within what the limit could justify.
+    assert all(b <= tl + 1e-6 for b in budgets), f"budget exceeds the limit: {budgets}"
+
+
+@pytest.mark.slow
+def test_reentry_never_returns_a_worse_answer():
+    """The re-entry keeps its result only when strictly better (or when it
+    certifies the same incumbent), so a longer limit must never yield a worse
+    objective than a shorter one on the same model."""
+    short = _hard_partition_model(18, 3, 6).solve(time_limit=5)
+    long = _hard_partition_model(18, 3, 6).solve(time_limit=25)
+
+    assert short.objective is not None and long.objective is not None
+    # Minimize sense: more budget must not raise the objective.
+    assert long.objective <= short.objective + 1e-6, (
+        f"more budget produced a worse incumbent: {short.objective} -> {long.objective}"
+    )
+    # And the dual bound must never cross the incumbent it certifies.
+    assert long.bound <= long.objective + 1e-6


### PR DESCRIPTION
## Summary

Fixes #689, #698, and closes the primal half of #280. Three linked defects on the Rust MILP fast path, all surfaced by running #280's corpus-verification checklist ([findings](https://github.com/jkitchin/discopt/issues/280#issuecomment-5003047442)).

### 1. `initial_solution` silently dropped (#689)

`reformulate_integer_bilinear` lifts integer-factor products into an exact MILP, appending aux columns (`graphpart_2pm-0088-0888`: 192 → 765). A caller's seed is built over the ORIGINAL columns, so it failed `_solve_milp_simplex`'s `size == n_orig` guard and was dropped without a word — observed **discarding a known-optimal incumbent** (-55 handed in, -46 returned).

The reform now records each aux definition (expansion bits of `x = lo + Σ2^k·e_k`; each big-M product `v = e * other`) and `extend_initial_point()` reconstructs them from the originals. Both are *exactly* determined, so this is reconstruction, not approximation — verified: the rebuilt point satisfies every row of the lifted model and reproduces the objective exactly. Mirrors the existing `_bml_aux_spec` pattern. Anything not exactly reconstructible returns `None` → no seed (today's behavior), never a guess.

### 2. `one_hot_swap_search` (#687) never fired on `graphpart_*` (#280)

It was wired only into the spatial-B&B LNS loop, but all 15 instances route to the Rust MILP engine — it was dead code for the family it was written for. Its structure detector matches the real `.nl` encodings fine; **reachability**, not structure, was the problem.

The swap is only well defined *pre-lift* — permuting bits in the lifted space leaves the auxiliaries stale, i.e. genuinely infeasible (verified: the heuristic correctly *rejects* it), so naively wiring it into the MILP path would have been a silent no-op. So: swap over the originals, lift the result back via (1), re-enter the engine seeded with it.

### 3. Most of `time_limit` discarded (#698)

The engine's `max(0.5, min(0.5·remaining, 10 s))` slice is a **stall** bound (#291), but on an uncertified `feasible` the code returns rather than falling back, so the rest of the budget goes to no engine at all. At `time_limit=40` it used ~10 s; at the default 3600 it uses ~10 s. The engine is monotone in its budget (bound -54.0 / -50.0 / -40.5 / -38.25 at 2.5 / 5 / 10 / 20 s), so that was real search thrown away. Now it re-enters with the remainder.

**The first slice stays bounded on purpose.** Handing run 1 the whole budget is measurably *worse* — it starves the swap (gap 26.6% → 65.2% on `3pm-0334-0334`; `autocorr_bern30-04` -324 → -24). The fix is not "remove the cap".

## Soundness

Purely primal + search effort; the dual bound and certificate are never weakened.

- The hook fires **only** on an uncertified `feasible`, so a certified `optimal` never reaches it — certification cannot regress by construction.
- Any improved point is only ever offered as an `initial_incumbent`, which the Rust driver re-validates (bounds, integrality, row feasibility) and re-scores from `c`. A bad point is dropped, never trusted.
- A re-entry result is kept only when strictly better, or when it certifies the same incumbent; otherwise only dual progress is banked.
- Both runs' bounds are valid lower bounds on the same problem, so keeping the tighter is valid and stays below any feasible incumbent's objective.

## Measurements

**#280 primal gap — 15 `graphpart_*`, 5 s, `minlplib.solu` oracle:**

| instance | before | after | | instance | before | after |
|---|---|---|---|---|---|---|
| `2g-0077-0077` | 6.49% | **2.99%** | | `3g-0244-0244` | 20.48% | **9.44%** |
| `2pm-0077-0777` | 15.00% | **10.00%** | | `3g-0333-0333` | 9.86% | **0.00%** |
| `2pm-0088-0888` | 16.36% | **0.00%** | | `3g-0344-0344` | 17.02% | **7.57%** |
| `3pm-0244-0244` | 21.43% | **10.71%** | | `3pm-0334-0334` | 36.11% | **11.11%** |
| `3pm-0344-0344` | 27.08% | **16.67%** | | | | |

Every instance improved or held; **none regressed**. 6/15 certify optimal; `incorrect_count = 0`; no bound above its reference optimum.

**#698 budget — A/B at TL=60:**

| instance | stock | with re-entry |
|---|---|---|
| `edgecross10-090` | feasible, obj 1411 | **optimal, 1387** |
| `graphpart_3pm-0334-0334` | feasible, obj -32 | **optimal, -36** (= reference) |
| `edgecross10-040` | obj 173, bnd 48 | obj **148**, bnd **118.5** |
| `graphpart_2pm-0077-0777` | obj -37 | obj **-40** (= reference) |

2 newly certified, 5/6 tighter bounds, 0 bounds above reference. Wall 147 s → 335 s.

At **TL=5 the fixed and stock arms are identical** (status, objective, wall) across 8 instances — the no-extra-budget guard suppresses a pointless re-entry.

## ⚠️ Behavior change worth a reviewer's eye

With the default `time_limit=3600`, a MILP that currently returns uncertified at ~10 s may now search up to the full hour. That is what the limit asks for, and it is how a global solver should use a granted budget — but it is visible to anyone relying on the early return. Happy to gate it if you'd rather.

## Falsified along the way (recorded in #280)

The discarded budget is **not** the cause of #280's *primal* gap: restoring it moves only the dual bound (-54 → -41), never the incumbent. The two fixes are complementary — the swap supplies the incumbent, the budget supplies the certificate — which is why `3pm-0334-0334` only reaches `optimal` with both.

## Tests

- `python/tests/test_issue_689_ipx_seed_lift.py` (4) — the discriminating test (seed reaches the driver at lifted width) **fails before** the change ("silently dropped"), passes after. A weaker `objective <= optimum` assertion does *not* discriminate, since the engine reaches the optimum unaided on small instances.
- `python/tests/test_issue_698_milp_budget_reentry.py` (3) — the budget test **fails on the parent commit** (`budgets=[10.0, 10.0, 5.0]` under a 30 s limit), passes after.
- Synthetic models use scalar `integer(0,1)` columns, matching how the `.nl` reader encodes the real family — `_int_factor_range` excludes declared `BINARY`, so a `m.binary(...)` model is never lifted and would not exercise this path.
- `pytest -m smoke`: **665 passed**, 1 skipped. Adversarial: **10 passed**. MILP/simplex/reform/seed/budget selection: **308 passed**. `ruff`/`mypy` clean. No Rust touched.

## Follow-up

#280 stays open: the remaining tails (`3pm-0344-0344` 16.7%) are dual-side, where greedy swap plus more budget still do not close the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
