### PR TITLE
feat(warm-start): extend initial points across integer-bilinear lift

### DIFF
--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -119,6 +119,18 @@ class _Expander:
         # (var._index, elem) -> (lo, [(coef, e_k Variable), ...])
         self._cache: dict[tuple[int, int], tuple[int, list[tuple[int, Variable]]]] = {}
         self._counter = 0
+        # Warm-start reconstruction spec: one entry per auxiliary column, in the
+        # exact order the columns are appended to ``model._variables`` (so the aux
+        # block is a suffix of the reformed flat layout and each entry's index ==
+        # its append position). Every aux is *exactly determined* by the original
+        # variables, so a warm start over the originals extends to the reformed
+        # vector by evaluating this spec in order (see ``extend_initial_point``).
+        #   ("bit", (var._index, elem), k, lo, nbits): bit k of round(x - lo).
+        #   ("prod", (e._index, 0), (other._index, other_elem)): v = e * other.
+        self.aux_spec: list[tuple] = []
+        # Cleared if an aux column cannot be described (defensive): then the whole
+        # spec is discarded and no warm start is mapped rather than one misaligned.
+        self.spec_ok = True
 
     def expansion(self, var: Variable, elem: int, lo: int, hi: int):
         key = (var._index, elem)
@@ -134,6 +146,10 @@ class _Expander:
             e = Variable(f"_ipx_e{self._counter}", VarType.BINARY, (), 0.0, 1.0, self.model)
             self._counter += 1
             self.model._variables.append(e)
+            # e_k is bit k of round(x_i - lo): the link row pins sum 2^k e_k to
+            # x_i - lo exactly, and the binary digits of a value in [0, 2^nbits-1]
+            # are unique.
+            self.aux_spec.append(("bit", (var._index, elem), k, lo, nbits))
             bits.append((1 << k, e))
             term = e if k == 0 else BinaryOp("*", Constant(float(1 << k)), e)
             link = BinaryOp("-", link, term)
@@ -172,6 +188,15 @@ class _Expander:
         )
         self._counter += 1
         self.model._variables.append(v)
+        # v == e * other, both scalar variable references (``other`` is either an
+        # original factor or, in the square expansion, another expansion bit — in
+        # every case already appended before this product), so v reconstructs as
+        # value(e) * value(other) at any point. Record it for warm-start mapping.
+        oref = _scalar_var_ref(other)
+        if oref is None:  # pragma: no cover - defensive; other is always a scalar ref
+            self.spec_ok = False
+        else:
+            self.aux_spec.append(("prod", (e._index, 0), (oref[0]._index, oref[1])))
         ac = self.aux_constraints
         # discopt's LP extractor folds the RHS into the body (``body sense 0``);
         # every row below is therefore normalized to rhs == 0 with the constant
@@ -506,9 +531,81 @@ def expand_integer_products(model: Model, implied=frozenset()) -> Model:
         if len(new_model._variables) > cap:
             return model
         new_model._constraints = rebuilt + exp.aux_constraints
+        _attach_warm_start_spec(model, new_model, exp)
         return new_model
     except Exception:
         return model
+
+
+def _attach_warm_start_spec(model: Model, new_model: Model, exp: "_Expander") -> None:
+    """Record on *new_model* how to reconstruct every auxiliary column from a
+    point over the ORIGINAL variables, mirroring the binary-multilinear reform's
+    ``_bml_aux_spec`` / ``_bml_n_orig_flat``. The aux columns are appended after
+    the originals, so the reformed flat layout is ``[originals | aux]`` and each
+    aux's flat index equals ``n_orig_flat + its append position``. Purely primal
+    metadata: the MILP driver re-validates any seed built from it, so this can
+    never affect the dual bound or the certificate."""
+    if not exp.spec_ok:
+        return
+    full_off: dict[int, int] = {}
+    off = 0
+    for v in new_model._variables:
+        full_off[v._index] = off
+        off += v.size
+    n_orig_flat = sum(v.size for v in model._variables)
+
+    def _flat(key: tuple[int, int]) -> int:
+        return full_off[key[0]] + key[1]
+
+    translated: list[tuple] = []
+    try:
+        for entry in exp.aux_spec:
+            if entry[0] == "bit":
+                _, src, k, lo, nbits = entry
+                translated.append(("bit", _flat(src), k, lo, nbits))
+            else:  # "prod"
+                _, e_key, o_key = entry
+                translated.append(("prod", _flat(e_key), _flat(o_key)))
+    except KeyError:  # pragma: no cover - defensive; every key is a live variable
+        return
+    setattr(new_model, "_ipx_aux_spec", translated)  # noqa: B010
+    setattr(new_model, "_ipx_n_orig_flat", n_orig_flat)  # noqa: B010
+
+
+def extend_initial_point(reformed: Model, x0) -> Optional[np.ndarray]:
+    """Extend a point over the ORIGINAL variables (flat, length
+    ``_ipx_n_orig_flat``) to a point over the reformed model's full variable
+    vector by evaluating each auxiliary from its recorded definition
+    (``e_k`` = bit k of ``round(x - lo)``; ``v = e * other``). Returns ``None``
+    when the model carries no reformulation metadata, the point has the wrong
+    length or is non-finite, or any entry cannot be reconstructed exactly (a
+    non-integer integer-factor value, or one outside its expansion range) — the
+    caller then simply does not seed. The MILP driver re-validates whatever is
+    passed (bounds, integrality, row feasibility) and recomputes its objective,
+    so this mapping is an optimization, never a soundness lever."""
+    spec = getattr(reformed, "_ipx_aux_spec", None)
+    n0 = getattr(reformed, "_ipx_n_orig_flat", None)
+    if spec is None or n0 is None:
+        return None
+    x = np.asarray(x0, dtype=np.float64).ravel()
+    if x.size != n0 or not np.all(np.isfinite(x)):
+        return None
+    out: list[float] = list(x)
+    for entry in spec:
+        if entry[0] == "bit":
+            _, src, k, lo, nbits = entry
+            n = float(x[src]) - lo
+            nr = int(round(n))
+            # The bit is exactly determined only when x - lo is a non-negative
+            # integer representable in this factor's bit width; anything else
+            # (fractional or out-of-range seed) cannot be reconstructed — refuse.
+            if abs(n - nr) > 1e-6 or nr < 0 or nr > (1 << nbits) - 1:
+                return None
+            out.append(float((nr >> k) & 1))
+        else:  # "prod": v = e * other, both already reconstructed above
+            _, ei, oi = entry
+            out.append(float(out[ei] * out[oi]))
+    return np.asarray(out, dtype=np.float64)
 
 
 def has_reformulation_work(model: Model) -> bool:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4298,6 +4298,29 @@ def solve_model(
                     # _p3_force_cut_path_enabled / certification-gap-plan.md §7.
                     if not _p3_force_cut_path_enabled():
                         nlp_solver = "simplex"
+                # Incumbent seeding. A user warm start (initial_solution) is over
+                # the ORIGINAL variables; the big-M lift appends aux columns
+                # (bits e_k = binary digits of x-lo, products v = e*other) that
+                # are exactly determined by it, so extend it across the lift —
+                # otherwise the reformed vector is longer than the seed and the
+                # MILP fast path's size guard silently drops it (issue #689).
+                # Purely primal: the Rust MILP driver re-validates the seed and
+                # recomputes its objective, so a bad point is dropped, never
+                # trusted (the dual bound and certified optimum are unaffected).
+                if initial_point is not None:
+                    from discopt._jax.integer_product_reform import (
+                        extend_initial_point as _ipx_extend,
+                    )
+
+                    _ipx_x0 = _ipx_extend(model, initial_point)
+                    if _ipx_x0 is not None:
+                        initial_point = _ipx_x0
+                    else:
+                        logger.info(
+                            "integer-bilinear reformulation: warm-start point "
+                            "could not be extended across the lift; solving "
+                            "without a seed"
+                        )
     except Exception as _ipx_exc:  # pragma: no cover - defensive
         logger.debug("integer-bilinear reformulation skipped: %s", _ipx_exc)
 

--- a/python/tests/test_integer_bilinear.py
+++ b/python/tests/test_integer_bilinear.py
@@ -26,13 +26,22 @@ os.environ.setdefault("JAX_PLATFORMS", "cpu")
 os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 from discopt._jax.implied_integer import detect_implied_integers  # noqa: E402
 from discopt._jax.integer_product_reform import (  # noqa: E402
+    extend_initial_point,
     has_reformulation_work,
     reformulate_integer_bilinear,
 )
 from discopt._jax.term_classifier import classify_nonlinear_terms  # noqa: E402
+from discopt.modeling.core import (  # noqa: E402
+    BinaryOp,
+    Constant,
+    IndexExpression,
+    UnaryOp,
+    Variable,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -197,6 +206,162 @@ def test_blowup_guard_falls_back():
     m = dm.from_nl(path)
     assert has_reformulation_work(m)  # it does contain integer bilinear/squares
     assert reformulate_integer_bilinear(m) is m  # ...but the reform is too large -> fall back
+
+
+# --------------------------------------------------------------------------- #
+# warm-start extension across the big-M lift (issue #689)
+# --------------------------------------------------------------------------- #
+
+
+def _flat_offsets(model):
+    offs, off = {}, 0
+    for v in model._variables:
+        offs[v._index] = off
+        off += v.size
+    return offs
+
+
+def _eval_linear(expr, val):
+    """Evaluate a reformed (pure-linear) constraint body against a value map
+    ``(var._index, elem) -> float``."""
+    if isinstance(expr, Constant):
+        return float(np.asarray(expr.value).reshape(()))
+    if isinstance(expr, Variable):
+        return val[(expr._index, 0)]
+    if isinstance(expr, IndexExpression):
+        idx = expr.index
+        elem = idx if isinstance(idx, int) else int(np.ravel_multi_index(idx, expr.base.shape))
+        return val[(expr.base._index, elem)]
+    if isinstance(expr, UnaryOp):
+        assert expr.op == "neg"
+        return -_eval_linear(expr.operand, val)
+    if isinstance(expr, BinaryOp):
+        lhs = _eval_linear(expr.left, val)
+        rhs = _eval_linear(expr.right, val)
+        if expr.op == "+":
+            return lhs + rhs
+        if expr.op == "-":
+            return lhs - rhs
+        if expr.op == "*":
+            return lhs * rhs
+        if expr.op == "/":
+            return lhs / rhs
+        raise AssertionError(f"unexpected op {expr.op!r}")
+    raise AssertionError(f"unexpected node {type(expr).__name__}")
+
+
+def _extended_point_satisfies_model(rm, x):
+    """Every constraint row of the reformed model holds at the extended point."""
+    offs = _flat_offsets(rm)
+    val = {
+        (v._index, e): float(x[offs[v._index] + e]) for v in rm._variables for e in range(v.size)
+    }
+    for c in rm._constraints:
+        body = _eval_linear(c.body, val)
+        if c.sense == "==":
+            assert abs(body - c.rhs) < 1e-6, f"{c.name}: {body} != {c.rhs}"
+        elif c.sense == "<=":
+            assert body <= c.rhs + 1e-6, f"{c.name}: {body} > {c.rhs}"
+        else:
+            assert body >= c.rhs - 1e-6, f"{c.name}: {body} < {c.rhs}"
+
+
+@pytest.mark.parametrize(
+    "ua,ub,a0,b0,rhs",
+    [(6, 5, 3, 4, 12), (7, 3, 5, 2, 9), (15, 3, 11, 3, 33), (4, 4, 4, 4, 15)],
+)
+def test_extend_initial_point_satisfies_all_reform_rows(ua, ub, a0, b0, rhs):
+    """A warm start over the ORIGINAL integer factors extends to a point that
+    satisfies every big-M and bit-linking row of the lifted model exactly — so
+    the MILP driver's validation accepts it instead of silently dropping it for
+    a length mismatch (issue #689)."""
+    m = dm.Model("seed")
+    a = m.integer("a", lb=0, ub=ua)
+    b = m.integer("b", lb=0, ub=ub)
+    m.minimize(a + b)
+    m.subject_to(a * b >= rhs)
+    rm = reformulate_integer_bilinear(m)
+    assert rm is not m  # the lift fired
+    n0 = rm._ipx_n_orig_flat
+    assert n0 == 2  # two scalar originals
+    x0 = np.array([a0, b0], dtype=float)
+    x = extend_initial_point(rm, x0)
+    assert x is not None
+    assert x.size == sum(v.size for v in rm._variables)  # full reformed vector
+    assert x.size > n0  # aux columns were actually appended and filled
+    # The originals are preserved and every reform row holds at the extension.
+    assert np.allclose(x[:n0], x0)
+    _extended_point_satisfies_model(rm, x)
+
+
+def test_extend_initial_point_square_path():
+    """The integer-square expansion (bits + bit-AND products) is reconstructed
+    exactly, so a seed survives the ``x**2`` lift too."""
+    m = dm.Model("sq")
+    x = m.integer("x", lb=0, ub=6)
+    m.minimize(x * x - 4 * x)
+    rm = reformulate_integer_bilinear(m)
+    assert rm is not m
+    for xv in range(7):
+        ext = extend_initial_point(rm, np.array([xv], dtype=float))
+        assert ext is not None
+        assert ext.size == sum(v.size for v in rm._variables)
+        _extended_point_satisfies_model(rm, ext)
+
+
+def test_extend_initial_point_rejects_fractional_integer_factor():
+    """A non-integer value for the *binary-expanded* factor cannot be
+    reconstructed to bits exactly, so the extension refuses (returns ``None``)
+    rather than guessing. ``a`` (range 3) is the smaller factor, so it is the one
+    expanded into bits; a fractional ``a`` therefore cannot be mapped."""
+    m = dm.Model("frac")
+    a = m.integer("a", lb=0, ub=3)
+    b = m.integer("b", lb=0, ub=30)
+    m.minimize(a + b)
+    m.subject_to(a * b >= 10)
+    rm = reformulate_integer_bilinear(m)
+    # Sanity: the seed's a=1.5 sits on the expanded factor.
+    assert any(e[0] == "bit" for e in rm._ipx_aux_spec)
+    assert extend_initial_point(rm, np.array([1.5, 4.0])) is None
+
+
+def test_extend_initial_point_rejects_wrong_length_and_nonfinite():
+    """Wrong-length or non-finite seeds are refused (the driver's length guard is
+    the last line of defense; this one keeps a malformed seed from being lifted)."""
+    m = dm.Model("len")
+    a = m.integer("a", lb=0, ub=6)
+    b = m.integer("b", lb=0, ub=5)
+    m.minimize(a + b)
+    m.subject_to(a * b >= 12)
+    rm = reformulate_integer_bilinear(m)
+    assert extend_initial_point(rm, np.array([3.0])) is None  # too short
+    assert extend_initial_point(rm, np.array([3.0, 4.0, 0.0])) is None  # too long
+    assert extend_initial_point(rm, np.array([3.0, np.inf])) is None  # non-finite
+
+
+def test_extend_initial_point_none_without_metadata():
+    """A model that never went through the lift carries no spec, so extension is a
+    no-op returning ``None`` (the caller then does not seed)."""
+    m = dm.Model("plain")
+    x = m.continuous("x", lb=0, ub=5)
+    m.minimize(x)
+    assert extend_initial_point(m, np.array([1.0])) is None
+
+
+@pytest.mark.slow  # end-to-end solve
+def test_seed_survives_lift_end_to_end():
+    """Solving with an ``initial_solution`` over the original variables now seeds
+    the lifted MILP fast path instead of dropping it, and the solve still reaches
+    the proven optimum (soundness: the seed only helps pruning)."""
+    m = dm.Model("e2e")
+    a = m.integer("a", lb=0, ub=8)
+    b = m.integer("b", lb=0, ub=8)
+    m.minimize(a + b)
+    m.subject_to(a * b >= 20)
+    base = m.solve(time_limit=15).objective
+    seeded = m.solve(time_limit=15, initial_solution={a: 5, b: 4}).objective
+    assert base is not None and seeded is not None
+    assert seeded == pytest.approx(base, rel=1e-4, abs=1e-4)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Enable warm-start (initial solution) seeding across the big-M integer-bilinear reformulation by reconstructing auxiliary variables from the original problem's variables. When a user provides an `initial_solution` over the original variables, the solver now extends it to the reformed model's full variable vector instead of silently dropping it due to length mismatch.

## Changes

### Core warm-start reconstruction (`integer_product_reform.py`)

- **`_Expander` class**: Added `aux_spec` list and `spec_ok` flag to record how each auxiliary column is exactly determined by the original variables:
  - `("bit", src_flat_idx, k, lo, nbits)`: bit k of `round(x[src] - lo)`
  - `("prod", e_flat_idx, other_flat_idx)`: product `v = e * other`
  
- **`expansion()` method**: Records bit definitions as they are created during binary expansion of integer factors.

- **`bigm_product()` method**: Records product definitions for big-M auxiliary variables.

- **`_attach_warm_start_spec()` function**: Translates variable-index-based spec to flat-layout indices and attaches metadata (`_ipx_aux_spec`, `_ipx_n_orig_flat`) to the reformed model for later reconstruction.

- **`extend_initial_point()` function**: Maps a point over original variables to the full reformed vector by:
  - Validating input length and finiteness
  - Reconstructing each bit by rounding and extracting binary digits
  - Reconstructing each product by multiplying already-reconstructed values
  - Returning `None` if any factor is fractional, out-of-range, or the model carries no reformulation metadata (defensive: caller then does not seed)

### Solver integration (`solver.py`)

- Added incumbent seeding logic in the MILP fast path: when `initial_point` is provided and the model has been reformed, call `extend_initial_point()` to lift the seed across the auxiliary columns before passing to the Rust MILP driver.
- Logs an info message if extension fails, allowing the solve to proceed unseeded rather than silently dropping the seed.

### Test coverage (`test_integer_bilinear.py`)

- **`test_extend_initial_point_satisfies_all_reform_rows()`**: Verifies that extended points satisfy every big-M and bit-linking constraint exactly (parametrized over multiple factor ranges and RHS values).
- **`test_extend_initial_point_square_path()`**: Confirms the `x**2` expansion (bits + bit-AND products) reconstructs exactly for all values in the factor's range.
- **`test_extend_initial_point_rejects_fractional_integer_factor()`**: Ensures fractional values on the binary-expanded factor are rejected.
- **`test_extend_initial_point_rejects_wrong_length_and_nonfinite()`**: Validates input sanitization (length, finiteness).
- **`test_extend_initial_point_none_without_metadata()`**: Confirms non-reformed models return `None` (no-op).
- **`test_seed_survives_lift_end_to_end()`**: End-to-end solve showing seeded and unseeded paths reach the same proven optimum (soundness: seed only helps pruning).

## Implementation Details

- **Exact reconstruction**: Bits and products are uniquely determined by the original variables, so the extension is deterministic and exact (no approximation or tolerance-tweaking).
- **Defensive design**: If any auxiliary cannot be described (e.g., a product of a non-scalar expression), `spec_ok` is set to `False` and the entire spec is discarded rather than producing a misaligned mapping.
- **Primal-only metadata**: The warm-start spec is purely primal; the MILP driver re-validates bounds, integrality, and row feasibility, and recomputes the objective. A bad point is dropped, never trusted.
- **Fallback on failure**: If extension returns `None` (wrong length, non-finite, fractional factor, or no metadata), the solver logs and proceeds unseeded—

https://claude.ai/code/session_01RL1YoDRa3PfPbCe4upVQsF