### PR TITLE
feat(signomial): SGO canonicaliser + rigorous box lower bound (contributes to #114)

### DIFF
--- a/python/discopt/_jax/convexity/signomial.py
+++ b/python/discopt/_jax/convexity/signomial.py
@@ -1,0 +1,390 @@
+"""Signomial (mixed-sign) canonicaliser and a rigorous box lower bound.
+
+A *signomial* is a sum of signed monomials over strictly positive variables
+
+    S(x) = sum_k c_k * prod_j x_j^{a_kj},        x_j > 0,
+
+where — unlike a posynomial — some coefficients ``c_k`` may be **negative**.
+A signomial is generally non-convex and has **no** exact convex reformulation
+under ``y = log x`` (``log`` of a mixed-sign sum is not convex), so recognising
+one is *not* a proof of anything: it is only the structural precursor to a
+global scheme (issue #114, component 5 of #111).
+
+This module is the deliberately-conservative front end for that work:
+
+* :func:`is_signomial` — the *canonicaliser*. Parse an :class:`Expression` into
+  a :class:`SignomialForm` (a normalised list of signed :class:`Monomial`
+  terms over the model's flat scalar-variable indexing) when — and only when —
+  every term is a monomial on the strictly-positive box. Returns ``None``
+  otherwise. This reuses the exact same term-flattening / monomial-parsing as
+  the posynomial recogniser (:mod:`discopt._jax.convexity.posynomial`); the one
+  relaxation is that a term's coefficient may be negative.
+
+* :func:`signomial_box_lower_bound` — a **rigorous** closed-form lower bound on
+  ``min_x S(x)`` over the model's positive box, via interval arithmetic on each
+  monomial. Sound for a *minimisation* (the bound is ``<=`` the true global
+  optimum); it is a valid dual bound, never a certificate of optimality.
+
+* :func:`signomial_dc_terms` — bridge the canonical form to the log-domain
+  ``(sigma, log_c, exps)`` term list consumed by the certified DC convex/concave
+  envelope in :mod:`discopt._jax.symbolic.signed_signomial`.
+
+Soundness boundary (issue #114).
+--------------------------------
+Nothing here promotes a mixed-sign signomial to a *convex* or *global-optimal*
+verdict. The GP path (:func:`discopt.gp.is_log_convex` / ``classify_gp``)
+continues to abstain on any negative coefficient; this module adds only a valid
+*lower bound* plus an explicitly-uncertified status. No auto-routing: the
+default solve path is untouched.
+
+References
+----------
+* Lundell, A. & Westerlund, T. Signomial global optimization (SGO): the single /
+  positive-power transforms and the difference-of-convex underestimators of the
+  alpha-SGO framework.
+* Maranas, C. D. & Floudas, C. A. (1997). Global optimization in generalized
+  geometric programming. *Computers & Chemical Engineering* 21(4), 351-369.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+
+from discopt._jax.convexity.posynomial import (
+    Monomial,
+    _flatten_sum_terms,
+    _parse_monomial,
+)
+from discopt.modeling.core import Expression, Model, VarType
+
+# A coefficient with magnitude at or below this is treated as an exact zero and
+# dropped (a cancelled term contributes nothing and carries no log).
+_ZERO_TOL = 1e-12
+# Two exponent-vector entries closer than this are treated as equal when merging
+# like terms.
+_EXP_TOL = 1e-12
+
+
+@dataclass
+class SignomialForm:
+    """A signomial as a normalised list of signed :class:`Monomial` terms.
+
+    Each :class:`Monomial` here may have a **negative** ``coeff`` (that is the
+    whole point — a posynomial forbids it). ``exponents`` maps a flat
+    scalar-variable offset to its real exponent, exactly as in
+    :class:`~discopt._jax.convexity.posynomial.PosynomialForm`.
+    """
+
+    monomials: list[Monomial] = field(default_factory=list)
+
+    @property
+    def is_mixed_sign(self) -> bool:
+        """True iff there is at least one positive AND one negative coefficient.
+
+        A form with all-positive coefficients is really a posynomial; a form
+        with all-negative coefficients is ``-posynomial``. Only the mixed case
+        is non-trivially non-convex — and the case the GP path must not touch.
+        """
+        return any(m.coeff < -_ZERO_TOL for m in self.monomials) and any(
+            m.coeff > _ZERO_TOL for m in self.monomials
+        )
+
+    @property
+    def has_negative_term(self) -> bool:
+        """True iff any coefficient is negative (not GP-representable as-is)."""
+        return any(m.coeff < -_ZERO_TOL for m in self.monomials)
+
+    def variable_offsets(self) -> set[int]:
+        """Flat scalar offsets of every variable appearing with nonzero exponent."""
+        offsets: set[int] = set()
+        for mono in self.monomials:
+            for off, exp in mono.exponents.items():
+                if abs(exp) > _EXP_TOL:
+                    offsets.add(off)
+        return offsets
+
+    def evaluate(self, x_by_offset: dict[int, float]) -> float:
+        """Evaluate ``S(x)`` at a point given as ``{offset: value}`` (for tests)."""
+        total = 0.0
+        for mono in self.monomials:
+            term = mono.coeff
+            for off, exp in mono.exponents.items():
+                term *= float(x_by_offset[off]) ** exp
+            total += term
+        return total
+
+
+def _merge_like_terms(monomials: list[Monomial]) -> list[Monomial]:
+    """Combine monomials that share an exponent vector; drop cancelled terms.
+
+    Merging keeps the canonical form unique (so a round-trip is stable) and lets
+    ``x - x`` collapse to nothing rather than masquerade as a two-term
+    signomial. The exponent vector is keyed on the sorted ``(offset, rounded
+    exponent)`` pairs of its non-zero entries.
+    """
+    buckets: dict[tuple[tuple[int, float], ...], float] = {}
+    order: list[tuple[tuple[int, float], ...]] = []
+    exps_by_key: dict[tuple[tuple[int, float], ...], dict[int, float]] = {}
+    for mono in monomials:
+        nz = {off: e for off, e in mono.exponents.items() if abs(e) > _EXP_TOL}
+        key = tuple(sorted((off, round(e / _EXP_TOL) * _EXP_TOL) for off, e in nz.items()))
+        if key not in buckets:
+            buckets[key] = 0.0
+            order.append(key)
+            exps_by_key[key] = nz
+        buckets[key] += mono.coeff
+    merged: list[Monomial] = []
+    for key in order:
+        coeff = buckets[key]
+        if abs(coeff) <= _ZERO_TOL:
+            continue
+        merged.append(Monomial(coeff, dict(exps_by_key[key])))
+    return merged
+
+
+def is_signomial(expr: Expression, model: Model) -> Optional[SignomialForm]:
+    """Return a :class:`SignomialForm` if ``expr`` is a signomial, else ``None``.
+
+    Preconditions (any failure -> ``None``), mirroring the posynomial
+    recogniser except that a term's coefficient may be negative:
+
+    * ``expr`` flattens into a sum of monomials (constants, positive-lb
+      variable leaves, products, quotients, constant real/integer powers,
+      ``sqrt``).
+    * every variable leaf has a strictly positive declared lower bound
+      (``x_j > 0`` — required for the ``y = log x`` domain to exist).
+    * every exponent is a real *constant*, never another expression.
+
+    A non-``None`` return is a genuine signomial on the strictly-positive box.
+    It is **not** a convexity or global-optimality certificate.
+    """
+    terms: list[tuple[float, Expression]] = []
+    _flatten_sum_terms(expr, 1.0, terms)
+
+    monomials: list[Monomial] = []
+    for scale, term in terms:
+        mono = _parse_monomial(term, model)
+        if mono is None:
+            return None
+        coeff = mono.coeff * scale
+        if abs(coeff) <= _ZERO_TOL:
+            # Exact-zero term (e.g. ``0 * x`` or a cancellation); skip it.
+            continue
+        monomials.append(Monomial(coeff, mono.exponents))
+
+    monomials = _merge_like_terms(monomials)
+    if not monomials:
+        return None
+    return SignomialForm(monomials)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Box bounds over flat scalar offsets
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _offset_bounds(model: Model) -> dict[int, tuple[float, float]]:
+    """Map every flat scalar offset to its ``(lb, ub)`` in ``x``-space."""
+    bounds: dict[int, tuple[float, float]] = {}
+    offset = 0
+    for v in model._variables:
+        lb = np.asarray(v.lb, dtype=np.float64).reshape(-1)
+        ub = np.asarray(v.ub, dtype=np.float64).reshape(-1)
+        for k in range(v.size):
+            bounds[offset + k] = (float(lb[k]), float(ub[k]))
+        offset += v.size
+    return bounds
+
+
+def _monomial_extrema(
+    mono: Monomial, bounds: dict[int, tuple[float, float]]
+) -> Optional[tuple[float, float]]:
+    """Return ``(min, max)`` of ``|coeff| * prod x_j^{a_j}`` over the box.
+
+    The magnitude is handled here (always positive); the caller applies the
+    sign. For a single monomial ``c>0 * prod x_j^{a_j}`` over ``x_j in
+    [lb_j, ub_j]`` with ``lb_j > 0``, monotonicity in each coordinate is fixed
+    by the sign of the exponent: increasing when ``a_j > 0`` (use ``lb`` for the
+    min, ``ub`` for the max), decreasing when ``a_j < 0`` (the reverse). The box
+    extrema are therefore attained at closed-form corners — no search.
+
+    ``ub = +inf`` is handled soundly: a positive-exponent factor makes the box
+    max ``+inf`` and drives the min toward its ``lb`` corner; a negative-exponent
+    factor makes the box min ``0`` (as ``x -> inf``) and the max its ``lb``
+    corner. Returns ``None`` only if a lower bound is non-positive or non-finite
+    (violating the strict-positivity precondition), which :func:`is_signomial`
+    already forbids.
+    """
+    magnitude = abs(mono.coeff)
+    lo = magnitude
+    hi = magnitude
+    for off, exp in mono.exponents.items():
+        if abs(exp) <= _EXP_TOL:
+            continue
+        lb, ub = bounds[off]
+        if not math.isfinite(lb) or lb <= 0.0:
+            return None
+        if not math.isfinite(ub):
+            if exp > 0.0:
+                # x^exp is increasing and unbounded above; min at lb, max -> +inf.
+                lo *= lb**exp
+                hi = math.inf
+            else:
+                # x^exp is decreasing to 0 as x -> inf; min -> 0, max at lb.
+                lo = 0.0
+                hi *= lb**exp
+            continue
+        lo_pick = lb if exp > 0.0 else ub
+        hi_pick = ub if exp > 0.0 else lb
+        lo *= lo_pick**exp
+        hi *= hi_pick**exp
+    return lo, hi
+
+
+def signomial_box_lower_bound(form: SignomialForm, model: Model) -> float:
+    """Rigorous lower bound on ``min_x S(x)`` over the model's positive box.
+
+    Interval arithmetic on the signomial: writing
+    ``S = sum_{c_k>0} c_k m_k - sum_{c_k<0} |c_k| m_k`` (each ``m_k`` a positive
+    monomial), a valid lower bound is the sum of the positive terms' box minima
+    minus the sum of the negative terms' box maxima::
+
+        LB = sum_{+} min_box(c_k m_k) - sum_{-} max_box(|c_k| m_k).
+
+    This is sound because ``S(x) >= sum_+ min - sum_- max`` pointwise on the box
+    (each positive term is at least its minimum, each subtracted term at most its
+    maximum). It is a **dual bound only** — ``LB <= min_x S(x)`` — never a
+    proof of optimality, and it does not depend on any convexity of ``S``.
+
+    Returns ``-inf`` when the box is open in a direction that makes a subtracted
+    term unbounded above (an honest, sound "no useful bound"). Raises
+    ``ValueError`` if a variable bound is non-positive (violating the signomial
+    precondition; :func:`is_signomial` would already have refused such a model,
+    so this only guards direct misuse).
+    """
+    bounds = _offset_bounds(model)
+    lower = 0.0
+    for mono in form.monomials:
+        extrema = _monomial_extrema(mono, bounds)
+        if extrema is None:
+            raise ValueError(
+                "signomial_box_lower_bound requires strictly positive, finite "
+                "lower bounds on all variables"
+            )
+        lo, hi = extrema
+        if mono.coeff > 0.0:
+            lower += lo  # add the positive term's minimum
+        else:
+            lower -= hi  # subtract the negative term's maximum
+        if lower == -math.inf:
+            return -math.inf
+    return lower
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Bridge to the certified log-domain DC envelope
+# ──────────────────────────────────────────────────────────────────────
+
+
+def signomial_dc_terms(
+    form: SignomialForm,
+) -> tuple[list[tuple[float, float, np.ndarray]], list[int]]:
+    """Convert to ``(sigma, log_c, exps)`` terms for the DC envelope.
+
+    Produces the exact input format consumed by
+    :func:`discopt._jax.symbolic.signed_signomial.signed_signomial_dc_envelope`:
+    a dense exponent array over the sorted list of participating variable
+    offsets. Returns ``(terms, offsets)`` where ``offsets`` is the ordered list
+    of flat scalar offsets defining the ``u = log x`` coordinate order.
+
+    ``sigma = sign(coeff)``, ``log_c = log|coeff|`` (the envelope stores each
+    monomial with a positive coefficient and a separate sign, matching the
+    difference-of-convex split).
+    """
+    offsets = sorted(form.variable_offsets())
+    index = {off: j for j, off in enumerate(offsets)}
+    n = len(offsets)
+    terms: list[tuple[float, float, np.ndarray]] = []
+    for mono in form.monomials:
+        sigma = 1.0 if mono.coeff > 0.0 else -1.0
+        log_c = math.log(abs(mono.coeff))
+        exps = np.zeros(n, dtype=np.float64)
+        for off, e in mono.exponents.items():
+            if abs(e) > _EXP_TOL:
+                exps[index[off]] = e
+        terms.append((sigma, log_c, exps))
+    return terms, offsets
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Model-level uncertified relaxation (opt-in; never auto-routed)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SignomialRelaxation:
+    """An uncertified signomial relaxation of a minimisation model.
+
+    ``lower_bound`` is a rigorous dual bound on the global optimum (``<=`` it).
+    ``certified`` is **always** ``False`` — a mixed-sign signomial is non-convex
+    and this relaxation proves only a bound, not optimality. Consumers must
+    treat it as a bound, never a certificate.
+    """
+
+    form: SignomialForm
+    lower_bound: float
+    is_mixed_sign: bool
+    certified: bool = False
+
+
+def signomial_relaxation(model: Model) -> Optional[SignomialRelaxation]:
+    """Return an uncertified signomial relaxation of ``model``, or ``None``.
+
+    Recognises a single-objective *minimisation* whose objective is a signomial
+    over a strictly-positive continuous box and returns a rigorous lower bound
+    plus an explicitly-uncertified status. Returns ``None`` when the model is
+    not a minimisation signomial (e.g. no objective, maximisation, non-signomial
+    objective, or any non-positive / non-continuous variable) — leaving the
+    default solve path and the GP abstention entirely untouched.
+
+    This never certifies optimality and never auto-routes; it is an opt-in
+    analysis surface for the #114 SGO work.
+    """
+    if model._objective is None:
+        return None
+    from discopt.modeling.core import ObjectiveSense
+
+    if model._objective.sense != ObjectiveSense.MINIMIZE:
+        return None
+    for v in model._variables:
+        if v.var_type != VarType.CONTINUOUS:
+            return None
+        if float(np.asarray(v.lb).min()) <= 0.0:
+            return None
+    form = is_signomial(model._objective.expression, model)
+    if form is None:
+        return None
+    try:
+        lb = signomial_box_lower_bound(form, model)
+    except ValueError:
+        return None
+    return SignomialRelaxation(
+        form=form,
+        lower_bound=lb,
+        is_mixed_sign=form.is_mixed_sign,
+        certified=False,  # invariant: a signomial relaxation never certifies
+    )
+
+
+__all__ = [
+    "SignomialForm",
+    "SignomialRelaxation",
+    "is_signomial",
+    "signomial_box_lower_bound",
+    "signomial_dc_terms",
+    "signomial_relaxation",
+]

--- a/python/tests/test_signomial_canon.py
+++ b/python/tests/test_signomial_canon.py
@@ -1,0 +1,268 @@
+"""Signomial canonicaliser + rigorous box lower bound (issue #114).
+
+Covers:
+
+* Canonicaliser round-trip: an extracted :class:`SignomialForm` re-evaluates to
+  the same value as the model expression at sampled points; like terms merge.
+* Recognition boundary: non-signomial objectives and non-positive variables are
+  refused (``None``).
+* Soundness (the hard requirement): the interval lower bound is ``<=`` the true
+  global minimum on small signomials with brute-forced optima, for both
+  minimisation-relevant and unbounded-box cases.
+* Negative controls: genuinely non-convex mixed-sign signomials are NEVER
+  promoted to a convex / global-optimal verdict — ``certified`` stays ``False``,
+  and the GP path keeps abstaining (``is_log_convex`` False, ``classify_gp`` /
+  ``solve_gp`` None).
+* DC-envelope bridge: the ``(sigma, log_c, exps)`` terms feed the certified
+  log-domain envelope and reproduce ``cv <= s <= cc``.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+
+import numpy as np
+import pytest
+from discopt._jax.convexity.signomial import (
+    SignomialForm,
+    is_signomial,
+    signomial_box_lower_bound,
+    signomial_dc_terms,
+    signomial_relaxation,
+)
+from discopt._jax.symbolic.signed_signomial import signed_signomial_dc_envelope
+from discopt.gp import classify_gp, is_log_convex, solve_gp
+from discopt.modeling.core import Model
+
+pytestmark = pytest.mark.relaxation
+
+
+def _brute_min(form: SignomialForm, box: dict[int, tuple[float, float]], n: int = 121) -> float:
+    """Dense-grid global minimum of the signomial over the (finite) box."""
+    offsets = sorted(box)
+    grids = [np.linspace(box[o][0], box[o][1], n) for o in offsets]
+    best = math.inf
+    for pt in itertools.product(*grids):
+        x_by_off = {o: pt[j] for j, o in enumerate(offsets)}
+        best = min(best, form.evaluate(x_by_off))
+    return best
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Canonicaliser
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCanonicaliser:
+    def test_roundtrip_mixed_sign(self):
+        m = Model("sig")
+        x = m.continuous("x", lb=0.2, ub=3.0)
+        y = m.continuous("y", lb=0.3, ub=2.5)
+        expr = x * y - 2.0 * x / y + 0.5 * y**2
+        form = is_signomial(expr, m)
+        assert form is not None
+        assert form.is_mixed_sign
+        assert form.has_negative_term
+        rng = np.random.default_rng(0)
+        for _ in range(50):
+            xv = float(rng.uniform(0.2, 3.0))
+            yv = float(rng.uniform(0.3, 2.5))
+            expected = xv * yv - 2.0 * xv / yv + 0.5 * yv**2
+            assert form.evaluate({0: xv, 1: yv}) == pytest.approx(expected, rel=1e-12)
+
+    def test_like_terms_merge_and_cancel(self):
+        m = Model("merge")
+        x = m.continuous("x", lb=0.1, ub=5.0)
+        # 3x - x = 2x (merges to one term); x - x cancels to nothing.
+        form = is_signomial(3.0 * x - x, m)
+        assert form is not None
+        assert len(form.monomials) == 1
+        assert form.monomials[0].coeff == pytest.approx(2.0)
+        assert not form.has_negative_term  # 2x is a lone positive term
+        assert is_signomial(x - x, m) is None  # full cancellation -> not a signomial
+
+    def test_posynomial_is_signomial_but_not_mixed(self):
+        m = Model("posy")
+        x = m.continuous("x", lb=0.1, ub=5.0)
+        y = m.continuous("y", lb=0.1, ub=5.0)
+        form = is_signomial(x * y + x / y, m)
+        assert form is not None
+        assert not form.is_mixed_sign
+        assert not form.has_negative_term
+
+    def test_rejects_nonpositive_variable(self):
+        m = Model("neg_lb")
+        x = m.continuous("x", lb=-1.0, ub=5.0)  # lb <= 0: no log domain
+        assert is_signomial(x * x - x, m) is None
+
+    def test_rejects_non_monomial_term(self):
+        m = Model("nonmono")
+        x = m.continuous("x", lb=0.1, ub=5.0)
+        # exp(x) is not a monomial -> not a signomial.
+        import discopt.modeling as dm
+
+        assert is_signomial(dm.exp(x) - x, m) is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Rigorous lower bound (soundness)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestLowerBoundSoundness:
+    def test_bound_below_true_min_1d(self):
+        # S = x^2 - 3x on [0.2, 3]; true min = -2.25 at x = 1.5.
+        m = Model("s1")
+        x = m.continuous("x", lb=0.2, ub=3.0)
+        form = is_signomial(x**2 - 3.0 * x, m)
+        assert form is not None
+        lb = signomial_box_lower_bound(form, m)
+        true_min = _brute_min(form, {0: (0.2, 3.0)})
+        assert math.isfinite(lb)
+        assert lb <= true_min + 1e-9  # rigorous
+        assert lb > -1e6  # non-trivial (finite, not garbage)
+
+    def test_bound_below_true_min_2d(self):
+        # S = sqrt(x*y) - 1/x - 1/y on [0.3, 3]^2 (this bound is tight here).
+        m = Model("s2")
+        x = m.continuous("x", lb=0.3, ub=3.0)
+        y = m.continuous("y", lb=0.3, ub=3.0)
+        import discopt.modeling as dm
+
+        form = is_signomial(dm.sqrt(x * y) - 1.0 / x - 1.0 / y, m)
+        assert form is not None
+        assert form.is_mixed_sign
+        lb = signomial_box_lower_bound(form, m)
+        true_min = _brute_min(form, {0: (0.3, 3.0), 1: (0.3, 3.0)})
+        assert lb <= true_min + 1e-9
+
+    def test_bound_below_true_min_random_suite(self):
+        """Many random mixed-sign signomials: LB <= grid min, always."""
+        rng = np.random.default_rng(7)
+        for _ in range(40):
+            m = Model("rand")
+            x = m.continuous("x", lb=0.4, ub=2.5)
+            y = m.continuous("y", lb=0.4, ub=2.5)
+            ax, ay = rng.integers(-2, 3, size=2)
+            bx, by = rng.integers(-2, 3, size=2)
+            cpos = float(rng.uniform(0.5, 3.0))
+            cneg = float(rng.uniform(0.5, 3.0))
+            expr = cpos * x ** int(ax) * y ** int(ay) - cneg * x ** int(bx) * y ** int(by)
+            form = is_signomial(expr, m)
+            if form is None or not form.monomials:
+                continue
+            lb = signomial_box_lower_bound(form, m)
+            true_min = _brute_min(form, {0: (0.4, 2.5), 1: (0.4, 2.5)}, n=81)
+            assert lb <= true_min + 1e-6, (ax, ay, bx, by, cpos, cneg, lb, true_min)
+
+    def test_open_box_negative_term_gives_minus_inf(self):
+        # Subtracted term with positive exponent and ub = inf -> unbounded below.
+        m = Model("open")
+        x = m.continuous("x", lb=0.5, ub=np.inf)
+        form = is_signomial(1.0 / x - x, m)
+        assert form is not None
+        lb = signomial_box_lower_bound(form, m)
+        assert lb == -math.inf  # honest, sound "no useful bound"
+
+    def test_open_box_bounded_case_is_finite(self):
+        # Only a decaying negative term as x -> inf: bound stays finite.
+        m = Model("open2")
+        x = m.continuous("x", lb=0.5, ub=np.inf)
+        form = is_signomial(x - 1.0 / x, m)  # -1/x -> 0 as x->inf, +x min at 0.5
+        assert form is not None
+        lb = signomial_box_lower_bound(form, m)
+        assert math.isfinite(lb)
+        # true inf over [0.5, inf): at x=0.5, 0.5 - 2 = -1.5; bound must be <=.
+        assert lb <= -1.5 + 1e-9
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Negative controls: never a false certificate; GP abstention preserved
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestNegativeControls:
+    def _nonconvex_model(self):
+        # S = x - x^2 (concave, unbounded-below flavour) type non-convex signomial.
+        m = Model("nc")
+        x = m.continuous("x", lb=0.2, ub=4.0)
+        y = m.continuous("y", lb=0.2, ub=4.0)
+        # A genuinely non-convex signomial: negative bilinear + positive squares.
+        m.minimize(x**2 + y**2 - 4.0 * x * y)
+        return m
+
+    def test_relaxation_never_certifies(self):
+        m = self._nonconvex_model()
+        relax = signomial_relaxation(m)
+        assert relax is not None
+        assert relax.is_mixed_sign
+        assert relax.certified is False  # hard gate: never certified
+        # The reported bound is a valid lower bound on the true global min.
+        form = relax.form
+        true_min = _brute_min(form, {0: (0.2, 4.0), 1: (0.2, 4.0)})
+        assert relax.lower_bound <= true_min + 1e-6
+
+    def test_gp_path_still_abstains_on_signomial(self):
+        m = self._nonconvex_model()
+        # The GP recogniser must NOT touch a mixed-sign objective.
+        assert is_log_convex(m) is False
+        assert classify_gp(m) is None
+        assert solve_gp(m) is None
+
+    def test_maximisation_not_relaxed(self):
+        m = Model("maxi")
+        x = m.continuous("x", lb=0.2, ub=4.0)
+        m.maximize(x - x**2)
+        # signomial_relaxation only handles minimisation; must return None
+        # (no bound in the wrong direction).
+        assert signomial_relaxation(m) is None
+
+    def test_many_nonconvex_never_certified_and_bound_sound(self):
+        rng = np.random.default_rng(11)
+        for _ in range(30):
+            m = Model("ncr")
+            x = m.continuous("x", lb=0.3, ub=3.0)
+            y = m.continuous("y", lb=0.3, ub=3.0)
+            expr = (
+                float(rng.uniform(0.5, 2.0)) * x ** int(rng.integers(1, 3))
+                - float(rng.uniform(0.5, 2.0)) * x * y
+                + float(rng.uniform(0.5, 2.0)) * y ** int(rng.integers(1, 3))
+            )
+            m.minimize(expr)
+            relax = signomial_relaxation(m)
+            if relax is None:
+                continue
+            assert relax.certified is False
+            assert is_log_convex(m) is False
+            true_min = _brute_min(relax.form, {0: (0.3, 3.0), 1: (0.3, 3.0)}, n=81)
+            assert relax.lower_bound <= true_min + 1e-6
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Bridge to the certified DC envelope
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestDCBridge:
+    def test_dc_terms_reproduce_envelope_bounds(self):
+        m = Model("bridge")
+        x = m.continuous("x", lb=0.3, ub=4.0)
+        y = m.continuous("y", lb=0.3, ub=4.0)
+        import discopt.modeling as dm
+
+        form = is_signomial(x * y - 2.0 * dm.sqrt(x) / y + 1.5 / (x * y), m)
+        assert form is not None
+        terms, offsets = signomial_dc_terms(form)
+        assert offsets == [0, 1]
+        u_lb = np.array([math.log(0.3), math.log(0.3)])
+        u_ub = np.array([math.log(4.0), math.log(4.0)])
+        rng = np.random.default_rng(3)
+        for _ in range(60):
+            u = u_lb + rng.uniform(size=2) * (u_ub - u_lb)
+            cv, cc = signed_signomial_dc_envelope(u, terms, u_lb, u_ub)
+            # Reference: evaluate the signomial directly at x = exp(u).
+            x_by_off = {0: math.exp(u[0]), 1: math.exp(u[1])}
+            s = form.evaluate(x_by_off)
+            assert float(cv) <= s + 1e-9
+            assert float(cc) >= s - 1e-9


### PR DESCRIPTION
## Contributes to #114 — signomial (mixed-sign) global solver (SGO)

First **sound, self-contained** increment of the SGO work (component 5 of #111;
the exact GP path shipped in #105/#113 and correctly abstains on mixed-sign).
This ships the **canonicaliser + a rigorous box lower bound**, deliberately *not*
the full global loop.

### What shipped

New module `python/discopt/_jax/convexity/signomial.py`:

- **`is_signomial(expr, model) -> SignomialForm | None`** — the canonicaliser.
  Extracts a DAG expression into signed `(coeff, exponent-vector)` terms over the
  model's flat scalar-variable indexing, **reusing** the posynomial
  term-flattener/monomial-parser (`_flatten_sum_terms` / `_parse_monomial`).
  Requires strict positivity (`lb > 0`, so the `y = log x` domain exists), rejects
  non-monomial terms and non-constant exponents, and merges/cancels like terms.
  The one relaxation vs `is_posynomial` is that a coefficient may be negative.
- **`signomial_box_lower_bound(form, model) -> float`** — a **rigorous** closed-form
  interval lower bound over the positive box:
  `LB = sum_+ min_box(m_k) - sum_- max_box(m_k) <= min_x S(x)`. Each single
  monomial's box min/max is closed-form (monotone per coordinate by exponent sign).
  Sound for a *minimisation*, independent of any convexity of `S`. Returns `-inf`
  honestly when an open box (`ub = inf`) leaves a subtracted term unbounded above.
- **`signomial_dc_terms(form)`** — bridges the canonical form to the
  `(sigma, log_c, exps)` inputs of the existing certified DC convex/concave envelope
  (`_jax/symbolic/signed_signomial.py`), so that envelope is now reachable from a DAG.
- **`signomial_relaxation(model) -> SignomialRelaxation | None`** — opt-in,
  minimisation-only. Returns the bound with **`certified=False` always**. No
  auto-routing; nothing on the default solve path calls it.

### Soundness boundary preserved (#114 hard requirement)

Nothing here promotes a mixed-sign signomial to a convex / global-optimal verdict.
`is_log_convex` / `classify_gp` / `solve_gp` continue to return `False` / `None` on
any negative coefficient (regression-tested here). No dispatch changed, so no flag
was needed — the default path is unaffected.

### Entry experiment (run BEFORE implementing, per §4)

Interval bound vs brute-forced global min on 3 signomials over positive boxes:

| signomial | box | LB | true min | sound (LB <= min) |
|---|---|---|---|---|
| `x^2 - 3x` | `[0.2, 3]` | -8.960 | -2.250 | yes |
| `xy - 2*x^-1*y` | `[0.5, 2]^2` | -7.750 | -7.000 | yes |
| `sqrt(xy) - 1/x - 1/y` | `[0.3, 3]^2` | -6.367 | -6.367 | yes (tight) |

Rigorous (<= true optimum) and non-trivial (finite) in every case; case 3 is exact.

### Negative controls (never a false certificate)

Genuinely non-convex signomials (indefinite Hessian, e.g. `x^2+y^2-4xy`, eigenvalues
`{-2, 6}`) — plus 30 randomly-generated non-convex signomials — are **never**
certified (`certified` stays `False`), the reported `lower_bound` is verified
`<=` the brute-forced global min, and the GP path keeps abstaining. Maximisation
returns `None` (no bound in the wrong direction).

### Tests & verification

- New `python/tests/test_signomial_canon.py` (15 tests): canonicaliser
  round-trip/merge/cancel/reject, lower-bound soundness (known optima + a random
  40-case suite + open-box cases), negative controls, DC-envelope bridge.
- `pytest -m smoke` -> **663 passed**, 1 skipped.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` -> **10 passed**.
- GP / posynomial / signed-signomial regressions -> **77 passed**.
- `ruff check` / `ruff format` / pre-commit hooks clean. No Rust touched.

### Remaining for #114 (next phases)

- Tighten the bound via spatial / log-domain branch-and-reduce driving the DC
  envelope (this bound decouples the +/- terms, so it is loose when they share
  variables — case 1 above).
- Constraint-side signomials (this increment scopes the objective).
- The end-to-end global solve loop (SGO single/positive-power transforms).

Do NOT merge — research-phase increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
