### PR TITLE
feat(#694): anytime/incremental root-relaxation build (DISCOPT_ANYTIME_ROOT_BUILD, default off)

### DIFF
--- a/discopt_benchmarks/pyproject.toml
+++ b/discopt_benchmarks/pyproject.toml
@@ -78,6 +78,8 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "C4", "SIM", "TCH"]
 # B/M/K are the monomial basis / moment matrix / lag count in the issue-677
 # joint-correlation moment probe (standard linear-algebra notation).
 "scripts/joint_correlation_moment_probe.py" = ["N803", "N806"]
+# A/Acsr/Ap are LP constraint matrices in the issue-694 anytime-build probe.
+"scripts/issue694_anytime_build_probe.py" = ["N806"]
 
 [tool.coverage.run]
 source = ["benchmarks", "utils"]

--- a/discopt_benchmarks/scripts/issue694_anytime_build_probe.py
+++ b/discopt_benchmarks/scripts/issue694_anytime_build_probe.py
@@ -1,0 +1,232 @@
+"""Issue #694 entry experiment — bound-vs-build-time curve for the root McCormick
+relaxation build.
+
+Measurement-only (no library change; mirrors ``pf_panel.py`` #632). The hypothesis
+(#694) is that the monolithic ``build_uniform_relaxation`` produces its dual bound
+only at the *end* of the build, so truncating the build (to honor ``time_limit``)
+loses the bound (baron-gap-plan.md §8.1). If instead a *finite* LP bound exists
+early in the build, an interrupted build still yields a valid (weaker) bound and the
+§8 fork dissolves.
+
+What this probe does, per instance:
+
+1. Instrument ``_Builder.add_row`` to timestamp every row as it is appended during a
+   single full ``build_uniform_relaxation`` — this gives ``elapsed(row_i)``, the
+   build wall-clock at which row ``i`` first existed, with **zero** checkpoint-solve
+   perturbation (the build runs once, uninterrupted).
+2. Post-hoc, at each build decile ``k`` (10%, 20%, …, 100% of the final rows), solve
+   the *prefix* LP ``A_ub[:n_k] x <= b[:n_k]`` over the full column set and the real
+   objective, and record ``(elapsed(n_k), n_k, status, bound, finite?)``. A prefix
+   relaxation has FEWER rows, so it is still a valid outer approximation — its LP min
+   is a valid (weaker) lower bound whenever it is finite (bounded). This is exactly
+   the "weaken but never falsify" property the hypothesis rests on.
+3. Also record the always-available sound interval floor (``milp._objective_floor``,
+   the ``obj_box_lb`` computed from cost-column bounds alone), which needs zero rows.
+
+Kill criterion (#694): the approach dies if, on the #654 class, the partial-build
+bound is ``-inf``/``None`` until ≳90% of build time — no useful anytime curve.
+
+Usage::
+
+    python discopt_benchmarks/scripts/issue694_anytime_build_probe.py \
+        casctanks hda heatexch_gen1 nvs05 --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import time
+
+import numpy as np
+
+_CORPUS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "python",
+    "tests",
+    "data",
+    "minlplib_nl",
+)
+_BENCH = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+
+
+def _resolve(inst: str) -> str | None:
+    for root in (_CORPUS, _BENCH):
+        p = os.path.join(root, inst + ".nl")
+        if os.path.exists(p):
+            return p
+    return None
+
+
+def _root_box(model):
+    lb = np.array([v.lb if v.lb is not None else -1e20 for v in model._variables], float)
+    ub = np.array([v.ub if v.ub is not None else 1e20 for v in model._variables], float)
+    return lb, ub
+
+
+def probe_instance(inst: str, solve_tl: float = 20.0) -> dict:
+    from discopt.modeling.core import from_nl
+
+    path = _resolve(inst)
+    if path is None:
+        return {"instance": inst, "status": "missing"}
+
+    model = from_nl(path)
+    lb, ub = _root_box(model)
+    return probe_model(model, inst, lb, ub, solve_tl=solve_tl)
+
+
+def probe_model(model, inst, lb, ub, solve_tl: float = 20.0) -> dict:
+    from discopt._jax import uniform_relax as ur
+    from discopt._jax.milp_relaxation import MilpRelaxationModel
+
+    # --- 1. instrument add_row with timestamps, run ONE uninterrupted build -----
+    row_stamps: list[float] = []
+    orig_add_row = ur._Builder.add_row
+    build_t0 = [0.0]
+
+    def timed_add_row(self, coeffs, rhs):
+        orig_add_row(self, coeffs, rhs)
+        # record only when a row is actually appended (add_row drops all-zero rows)
+        if len(row_stamps) < len(self.rows):
+            row_stamps.append(time.perf_counter() - build_t0[0])
+
+    ur._Builder.add_row = timed_add_row
+    try:
+        build_t0[0] = time.perf_counter()
+        rel = ur.build_uniform_relaxation(model, (lb, ub))
+        build_wall = time.perf_counter() - build_t0[0]
+    finally:
+        ur._Builder.add_row = orig_add_row
+
+    milp = rel.model
+    c = np.asarray(milp._c, dtype=np.float64)
+    obj_offset = float(milp._obj_offset) if hasattr(milp, "_obj_offset") else 0.0
+    # MilpRelaxationModel stores obj_offset; read via the attribute the class uses.
+    obj_offset = float(getattr(milp, "_obj_offset", getattr(milp, "obj_offset", 0.0)))
+    bounds = list(milp._bounds) if getattr(milp, "_bounds", None) is not None else None
+    A = milp._A_ub
+    b = milp._b_ub
+    n_rows = 0 if A is None else int(A.shape[0])
+    obj_floor = milp._objective_floor
+    obj_valid = bool(milp._objective_bound_valid)
+
+    # Align stamp count with the assembled matrix (add_row may append the separable
+    # floor row after the constraint loop; both are part of the build).
+    while len(row_stamps) < n_rows:
+        row_stamps.append(build_wall)
+    row_stamps = row_stamps[:n_rows]
+
+    import scipy.sparse as sp
+
+    Acsr = None if A is None else sp.csr_matrix(A)
+
+    def solve_prefix(nk: int) -> dict:
+        if Acsr is None or nk <= 0:
+            Ap, bp = None, None
+        else:
+            Ap = Acsr[:nk]
+            bp = b[:nk]
+        m = MilpRelaxationModel(
+            c=c,
+            A_ub=Ap,
+            b_ub=bp,
+            bounds=bounds,
+            obj_offset=obj_offset,
+            integrality=None,
+            objective_bound_valid=obj_valid,
+        )
+        t0 = time.perf_counter()
+        res = m.solve(backend="simplex", time_limit=solve_tl, gap_tolerance=1e-6)
+        solve_wall = time.perf_counter() - t0
+        bound = res.bound
+        finite = (
+            res.status == "optimal" and bound is not None and math.isfinite(float(bound))
+        )
+        return {
+            "n_rows": nk,
+            "frac_rows": (nk / n_rows) if n_rows else 1.0,
+            "build_elapsed": row_stamps[nk - 1] if nk > 0 else 0.0,
+            "build_frac": (
+                (row_stamps[nk - 1] / build_wall) if (nk > 0 and build_wall > 0) else 0.0
+            ),
+            "status": res.status,
+            "bound": None if bound is None else float(bound),
+            "finite": bool(finite),
+            "solve_wall": solve_wall,
+        }
+
+    # --- 2. checkpoints at every 10% of rows -----------------------------------
+    checkpoints = []
+    for k in range(1, 11):
+        nk = int(math.ceil(k / 10.0 * n_rows))
+        nk = max(1, min(nk, n_rows))
+        checkpoints.append(solve_prefix(nk))
+
+    # first build-decile at which a finite bound appears (build_frac of that row)
+    first_finite = next((cp for cp in checkpoints if cp["finite"]), None)
+
+    return {
+        "instance": inst,
+        "status": "ok",
+        "n_vars": len(model._variables),
+        "n_cons": len(model._constraints),
+        "n_rows": n_rows,
+        "n_cols": int(c.size),
+        "build_wall": build_wall,
+        "obj_floor": None if obj_floor is None else float(obj_floor),
+        "obj_bound_valid": obj_valid,
+        "full_bound": checkpoints[-1]["bound"] if checkpoints else None,
+        "first_finite_build_frac": None if first_finite is None else first_finite["build_frac"],
+        "first_finite_row_frac": None if first_finite is None else first_finite["frac_rows"],
+        "checkpoints": checkpoints,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("instances", nargs="+")
+    ap.add_argument("--json", default=None)
+    ap.add_argument("--solve-tl", type=float, default=20.0)
+    args = ap.parse_args()
+
+    results = []
+    for inst in args.instances:
+        print(f"\n=== {inst} ===", flush=True)
+        r = probe_instance(inst, solve_tl=args.solve_tl)
+        results.append(r)
+        if r["status"] != "ok":
+            print(f"  {r['status']}", flush=True)
+            continue
+        print(
+            f"  vars={r['n_vars']} cons={r['n_cons']} rows={r['n_rows']} cols={r['n_cols']} "
+            f"build_wall={r['build_wall']:.3f}s obj_floor={r['obj_floor']} "
+            f"full_bound={r['full_bound']}",
+            flush=True,
+        )
+        print("  build%  row%   elapsed   status     bound         finite", flush=True)
+        for cp in r["checkpoints"]:
+            bstr = "None" if cp["bound"] is None else f"{cp['bound']:.6g}"
+            print(
+                f"  {cp['build_frac']*100:5.1f}  {cp['frac_rows']*100:5.1f}  "
+                f"{cp['build_elapsed']:7.3f}  {cp['status']:>10}  "
+                f"{bstr:>12}  {cp['finite']}",
+                flush=True,
+            )
+        ff = r["first_finite_build_frac"]
+        print(
+            f"  --> first finite bound at build_frac="
+            f"{'never' if ff is None else f'{ff*100:.1f}%'}",
+            flush=True,
+        )
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nwrote {args.json}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/discopt_benchmarks/scripts/issue694_synthetic_proxy.py
+++ b/discopt_benchmarks/scripts/issue694_synthetic_proxy.py
@@ -1,0 +1,183 @@
+"""Issue #694 — synthetic proxy for the #654 class (sonet*/qap/graphpart).
+
+The decisive #654-class instances (sonet23v4, super3t, qap, eg_all_s, sonet22v4)
+live only in the big Dropbox corpus and are absent from CI / this environment, and
+MINLPLib is network-blocked. To exercise the *slow-build* regime the #694
+hypothesis targets, we synthesize models with the same structural signature: a
+dense quadratic over binaries (QAP / max-clique / network-design-like), which lifts
+O(n^2) bilinear products -> O(n^2) McCormick envelope rows, so the
+``build_uniform_relaxation`` cost grows into the multi-second range that dominates
+sonet23v4 (16.8s).
+
+Two families:
+  * ``clique`` — max-weight-clique-style dense quadratic over ``n`` binaries with a
+    cardinality band; objective is the quadratic form (products carry the cost, so
+    the interval floor is loose and the bound must come from the envelopes — the
+    ``plain``-is-None signature of the #654 class).
+  * ``qap`` — a small quadratic assignment (n facilities) with assignment
+    constraints and a sum-of-products objective.
+
+Run::
+
+    python discopt_benchmarks/scripts/issue694_synthetic_proxy.py --family clique --n 60
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import numpy as np
+from issue694_anytime_build_probe import probe_model  # type: ignore
+
+
+def _balanced_sum(terms: list):
+    """Sum a list of expressions via pairwise reduction so the expression tree is
+    O(log n) deep, not O(n) — a chained ``sum()`` builds a left-nested tree that
+    overflows the canonicalizer's recursion on dense quadratics."""
+    if not terms:
+        return 0.0
+    while len(terms) > 1:
+        nxt = []
+        for i in range(0, len(terms) - 1, 2):
+            nxt.append(terms[i] + terms[i + 1])
+        if len(terms) % 2 == 1:
+            nxt.append(terms[-1])
+        terms = nxt
+    return terms[0]
+
+
+def _seeded_matrix(n: int, seed: int) -> np.ndarray:
+    # Deterministic pseudo-random symmetric weights in [-1, 1] (no Math.random ban
+    # here — plain numpy — but keep it seeded for reproducibility).
+    rng = np.random.default_rng(seed)
+    a = rng.uniform(-1.0, 1.0, size=(n, n))
+    return (a + a.T) * 0.5
+
+
+def build_clique(n: int, seed: int = 7):
+    import discopt as do
+
+    m = do.Model(f"synth_clique_{n}")
+    x = [m.binary(f"x{i}") for i in range(n)]
+    q = _seeded_matrix(n, seed)
+    # dense quadratic objective over binaries: sum_{i<j} q_ij x_i x_j  (MINIMIZE)
+    terms = [float(q[i, j]) * x[i] * x[j] for i in range(n) for j in range(i + 1, n)]
+    m.minimize(_balanced_sum(terms))
+    # a cardinality band so the LP is non-trivial
+    k = n // 3
+    m.subject_to(_balanced_sum(list(x)) >= k)
+    m.subject_to(_balanced_sum(list(x)) <= 2 * k)
+    lb = np.zeros(n)
+    ub = np.ones(n)
+    return m, lb, ub
+
+
+def build_qap(n: int, seed: int = 11):
+    import discopt as do
+
+    m = do.Model(f"synth_qap_{n}")
+    f = _seeded_matrix(n, seed) + 1.0  # flows >= 0-ish
+    d = _seeded_matrix(n, seed + 1) + 1.0  # distances
+    x = {(i, j): m.binary(f"x_{i}_{j}") for i in range(n) for j in range(n)}
+    # assignment constraints
+    for i in range(n):
+        m.subject_to(_balanced_sum([x[(i, j)] for j in range(n)]) == 1)
+    for j in range(n):
+        m.subject_to(_balanced_sum([x[(i, j)] for i in range(n)]) == 1)
+    # quadratic cost sum_{i,k,j,l} f_ik d_jl x_ij x_kl  (thin it to keep it buildable)
+    terms = []
+    for i in range(n):
+        for k in range(i + 1, n):
+            for j in range(n):
+                for ll in range(n):
+                    if ll == j:
+                        continue
+                    c = float(f[i, k] * d[j, ll])
+                    if abs(c) < 1e-9:
+                        continue
+                    terms.append(c * x[(i, j)] * x[(k, ll)])
+    m.minimize(_balanced_sum(terms))
+    lb = np.zeros(n * n)
+    ub = np.ones(n * n)
+    return m, lb, ub
+
+
+def build_netdesign(n: int, seed: int = 17):
+    """Network-design proxy (sonet* signature): a LINEAR objective (minimize design
+    cost) coupled to bilinear *constraints* (capacity = design * flow). Here the
+    interval floor on the linear objective is finite from row 0 (trivially), but the
+    USEFUL bound comes from the bilinear constraint envelopes — so the anytime
+    question is whether the bound *tightens* continuously as envelope rows accrue."""
+    import discopt as do
+
+    m = do.Model(f"synth_netdesign_{n}")
+    rng = np.random.default_rng(seed)
+    # continuous design vars y_i in [0,1], flow vars f_i in [0,1]
+    y = [m.continuous(f"y{i}", lb=0.0, ub=1.0) for i in range(n)]
+    fl = [m.continuous(f"f{i}", lb=0.0, ub=1.0) for i in range(n)]
+    cost = [float(rng.uniform(0.5, 2.0)) for i in range(n)]
+    m.minimize(_balanced_sum([cost[i] * y[i] for i in range(n)]))
+    # bilinear coupling: sum over a random neighborhood of y_i*f_j >= demand
+    dem = rng.uniform(0.1, 0.4, size=n)
+    for i in range(n):
+        nbrs = [(i + t) % n for t in range(1, max(2, n // 4))]
+        terms = [y[i] * fl[j] for j in nbrs]
+        m.subject_to(_balanced_sum(terms) >= float(dem[i]) * len(nbrs))
+    lb = np.zeros(2 * n)
+    ub = np.ones(2 * n)
+    return m, lb, ub
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--family", choices=["clique", "qap", "netdesign"], default="clique")
+    ap.add_argument("--n", type=int, nargs="+", default=[40, 60, 80])
+    ap.add_argument("--solve-tl", type=float, default=20.0)
+    ap.add_argument("--json", default=None)
+    args = ap.parse_args()
+
+    results = []
+    for n in args.n:
+        name = f"synth_{args.family}_{n}"
+        print(f"\n=== {name} ===", flush=True)
+        if args.family == "clique":
+            model, lb, ub = build_clique(n)
+        elif args.family == "qap":
+            model, lb, ub = build_qap(n)
+        else:
+            model, lb, ub = build_netdesign(n)
+        r = probe_model(model, name, lb, ub, solve_tl=args.solve_tl)
+        results.append(r)
+        if r["status"] != "ok":
+            print(f"  {r['status']}", flush=True)
+            continue
+        print(
+            f"  vars={r['n_vars']} cons={r['n_cons']} rows={r['n_rows']} cols={r['n_cols']} "
+            f"build_wall={r['build_wall']:.3f}s obj_floor={r['obj_floor']} "
+            f"full_bound={r['full_bound']}",
+            flush=True,
+        )
+        print("  build%  row%   elapsed   status     bound         finite", flush=True)
+        for cp in r["checkpoints"]:
+            bstr = "None" if cp["bound"] is None else f"{cp['bound']:.6g}"
+            print(
+                f"  {cp['build_frac']*100:5.1f}  {cp['frac_rows']*100:5.1f}  "
+                f"{cp['build_elapsed']:7.3f}  {cp['status']:>14}  {bstr:>12}  {cp['finite']}",
+                flush=True,
+            )
+        ff = r["first_finite_build_frac"]
+        print(
+            f"  --> first finite bound at build_frac="
+            f"{'never' if ff is None else f'{ff*100:.1f}%'}",
+            flush=True,
+        )
+
+    if args.json:
+        with open(args.json, "w") as fp:
+            json.dump(results, fp, indent=2)
+        print(f"\nwrote {args.json}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/baron-gap-plan.md
+++ b/docs/dev/baron-gap-plan.md
@@ -483,11 +483,22 @@ elsewhere.
    product-envelopes must precede other rows, else −∞ until ~40 %); (b) a truncated
    (smaller) relaxation is often *more* solvable within budget — hda's full LP
    `iteration_limit`s while every prefix solves `optimal`, the exact "`plain` is
-   None" mode. **Not implemented this session** (bound-changing → default-off flag +
-   §5 corpus panel to graduate; super3t/sonet23v4 are big-corpus-only and absent
-   here, so the gate is a run-on-owner's-machine step). §8.1/§8.2 remain
-   un-circumvented: this changes the build's *precondition*, it does not truncate a
-   native solve or add a Rust LP deadline.
+   None" mode. **Implementation landed default-OFF** (`DISCOPT_ANYTIME_ROOT_BUILD`):
+   `build_uniform_relaxation` gained a `build_deadline` that stops the constraint-row
+   loop when spent (a valid weaker relaxation), threaded through
+   `build_milp_relaxation` and `solve_at_node`; `_root_relaxation_lower_bound`
+   applies it to the `sep` build only (the base build stays whole — truncating it can
+   trip `objective_bound_valid=False → return None` and LOSE the bound, the rule-1
+   case). OFF is byte-identical (smoke 661 + #654 suite green); tests in
+   `test_issue694_anytime_root_build.py`. **§5 graduation is a run-on-owner's-machine
+   step** (super3t/sonet23v4 are big-corpus-only): flag ON-vs-OFF panel, must-not-
+   regress casctanks 5.698 / super3t −1.0 / sonet23v4 −53974.375, cert-clean +
+   net-positive. Measured caveat: on hda (wide/unbounded cost columns) flag ON returns
+   `None` (sound, honors grant) rather than a weaker bound — the benefit is
+   structure-dependent (retained on clean finite-box #654 structure per the proxies;
+   the constraint row-ordering refinement is the follow-up if the class needs it).
+   §8.1/§8.2 remain un-circumvented: this changes the build's *precondition*, it does
+   not truncate a native solve or add a Rust LP deadline.
 
 ---
 

--- a/docs/dev/baron-gap-plan.md
+++ b/docs/dev/baron-gap-plan.md
@@ -462,6 +462,33 @@ elsewhere.
    to START another only when a valid bound is already in hand and the fallback's
    own grant is spent — corpus-measured bound-neutral (0/65 bounds changed).
 
+   **UPDATE (2026-07-17, #694 entry experiment — the "floor is irreducible" claim
+   above is now qualified, not overturned).** #694 asks whether the floor is
+   *fundamental* or an *artifact of a monolithic build*: SOTA solvers don't face the
+   fork because their bound accrues continuously (a truncated build still hands back
+   a valid weaker bound). The entry experiment
+   (`issue694-anytime-build-entry-2026-07-17.md`; probes
+   `discopt_benchmarks/scripts/issue694_anytime_build_probe.py` +
+   `issue694_synthetic_proxy.py`) instruments `_Builder.add_row` and solves every
+   10 %-of-rows build **prefix**. **Verdict: the kill criterion is NOT met** — on all
+   6 named controls a finite bound exists by 8 %–21 % of build time (casctanks
+   69 %), and on synthetic proxies matching the class's structure (sonet\*:
+   linear-obj + bilinear-constraint `netdesign`, finite at **11.7 %** then monotone;
+   qap/graphpart: dense-quadratic `clique`, finite at ~40 % then monotone to 28 k
+   rows) the bound **accrues continuously** across deciles. So a build interrupted at
+   a checkpoint *does* yield a valid weaker bound: the §8.1 fork is **dissolvable in
+   principle** for this class, and the "irreducible floor" holds only for the
+   *current* end-of-build materialization, not fundamentally. Two subtleties recorded
+   there: (a) build **order** decides how early the bound turns finite (objective
+   product-envelopes must precede other rows, else −∞ until ~40 %); (b) a truncated
+   (smaller) relaxation is often *more* solvable within budget — hda's full LP
+   `iteration_limit`s while every prefix solves `optimal`, the exact "`plain` is
+   None" mode. **Not implemented this session** (bound-changing → default-off flag +
+   §5 corpus panel to graduate; super3t/sonet23v4 are big-corpus-only and absent
+   here, so the gate is a run-on-owner's-machine step). §8.1/§8.2 remain
+   un-circumvented: this changes the build's *precondition*, it does not truncate a
+   native solve or add a Rust LP deadline.
+
 ---
 
 ## §9. Task table (verdicts land here)

--- a/docs/dev/data/issue694-anytime-controls.json
+++ b/docs/dev/data/issue694-anytime-controls.json
@@ -1,0 +1,698 @@
+[
+  {
+    "instance": "casctanks",
+    "status": "ok",
+    "n_vars": 500,
+    "n_cons": 517,
+    "n_rows": 1742,
+    "n_cols": 840,
+    "build_wall": 0.2267378850000341,
+    "obj_floor": -3.557e-321,
+    "obj_bound_valid": true,
+    "full_bound": 3.887999999999999,
+    "first_finite_build_frac": 0.6941895837124976,
+    "first_finite_row_frac": 0.10045924225028703,
+    "checkpoints": [
+      {
+        "n_rows": 175,
+        "frac_rows": 0.10045924225028703,
+        "build_elapsed": 0.15739907800002584,
+        "build_frac": 0.6941895837124976,
+        "status": "optimal",
+        "bound": -3.557e-321,
+        "finite": true,
+        "solve_wall": 0.008563309999999547
+      },
+      {
+        "n_rows": 349,
+        "frac_rows": 0.20034443168771526,
+        "build_elapsed": 0.1643146500000512,
+        "build_frac": 0.7246898770358843,
+        "status": "optimal",
+        "bound": -3.557e-321,
+        "finite": true,
+        "solve_wall": 0.006871406999948704
+      },
+      {
+        "n_rows": 523,
+        "frac_rows": 0.3002296211251435,
+        "build_elapsed": 0.17189243400002852,
+        "build_frac": 0.7581107762383982,
+        "status": "optimal",
+        "bound": -3.557e-321,
+        "finite": true,
+        "solve_wall": 0.010946285999921201
+      },
+      {
+        "n_rows": 697,
+        "frac_rows": 0.40011481056257175,
+        "build_elapsed": 0.18198013900007481,
+        "build_frac": 0.8026013782392274,
+        "status": "optimal",
+        "bound": -3.557e-321,
+        "finite": true,
+        "solve_wall": 0.014871953000010762
+      },
+      {
+        "n_rows": 871,
+        "frac_rows": 0.5,
+        "build_elapsed": 0.19454834200007554,
+        "build_frac": 0.8580319164573943,
+        "status": "optimal",
+        "bound": -3.557e-321,
+        "finite": true,
+        "solve_wall": 0.017381418000013582
+      },
+      {
+        "n_rows": 1046,
+        "frac_rows": 0.600459242250287,
+        "build_elapsed": 0.203150570000048,
+        "build_frac": 0.8959710019347558,
+        "status": "optimal",
+        "bound": -3.557e-321,
+        "finite": true,
+        "solve_wall": 0.03241936500000975
+      },
+      {
+        "n_rows": 1220,
+        "frac_rows": 0.7003444316877153,
+        "build_elapsed": 0.21130879300005745,
+        "build_frac": 0.9319518570971307,
+        "status": "optimal",
+        "bound": -3.557e-321,
+        "finite": true,
+        "solve_wall": 0.043303359999981694
+      },
+      {
+        "n_rows": 1394,
+        "frac_rows": 0.8002296211251435,
+        "build_elapsed": 0.21553519400004006,
+        "build_frac": 0.9505918871917132,
+        "status": "optimal",
+        "bound": -3.557e-321,
+        "finite": true,
+        "solve_wall": 0.053139338000050884
+      },
+      {
+        "n_rows": 1568,
+        "frac_rows": 0.9001148105625718,
+        "build_elapsed": 0.21750583400000778,
+        "build_frac": 0.9592831564075631,
+        "status": "optimal",
+        "bound": 3.8879999999950416,
+        "finite": true,
+        "solve_wall": 0.07248473100003139
+      },
+      {
+        "n_rows": 1742,
+        "frac_rows": 1.0,
+        "build_elapsed": 0.22007063000000926,
+        "build_frac": 0.9705948787516305,
+        "status": "optimal",
+        "bound": 3.887999999999999,
+        "finite": true,
+        "solve_wall": 0.08922342999994726
+      }
+    ]
+  },
+  {
+    "instance": "hda",
+    "status": "ok",
+    "n_vars": 722,
+    "n_cons": 718,
+    "n_rows": 3022,
+    "n_cols": 1147,
+    "build_wall": 5.413830994000023,
+    "obj_floor": -172201.82,
+    "obj_bound_valid": true,
+    "full_bound": -28100067.375443634,
+    "first_finite_build_frac": 0.12089940371714257,
+    "first_finite_row_frac": 0.10026472534745202,
+    "checkpoints": [
+      {
+        "n_rows": 303,
+        "frac_rows": 0.10026472534745202,
+        "build_elapsed": 0.654528938999988,
+        "build_frac": 0.12089940371714257,
+        "status": "optimal",
+        "bound": -172201.8200000297,
+        "finite": true,
+        "solve_wall": 0.005744996999965224
+      },
+      {
+        "n_rows": 605,
+        "frac_rows": 0.200198544010589,
+        "build_elapsed": 1.1049064710000494,
+        "build_frac": 0.20408957579661835,
+        "status": "optimal",
+        "bound": -180818.52710928576,
+        "finite": true,
+        "solve_wall": 0.014141657999971358
+      },
+      {
+        "n_rows": 907,
+        "frac_rows": 0.300132362673726,
+        "build_elapsed": 2.7384832950000373,
+        "build_frac": 0.5058309537248229,
+        "status": "optimal",
+        "bound": -180818.5271092922,
+        "finite": true,
+        "solve_wall": 0.025349744999971335
+      },
+      {
+        "n_rows": 1209,
+        "frac_rows": 0.400066181336863,
+        "build_elapsed": 3.6869235560000106,
+        "build_frac": 0.68101932995066,
+        "status": "optimal",
+        "bound": -180818.52710938037,
+        "finite": true,
+        "solve_wall": 0.04418704099998649
+      },
+      {
+        "n_rows": 1511,
+        "frac_rows": 0.5,
+        "build_elapsed": 4.209886917000063,
+        "build_frac": 0.7776169817021896,
+        "status": "optimal",
+        "bound": -180818.53631322025,
+        "finite": true,
+        "solve_wall": 0.06688257799999064
+      },
+      {
+        "n_rows": 1814,
+        "frac_rows": 0.600264725347452,
+        "build_elapsed": 5.34677298400004,
+        "build_frac": 0.9876135752899747,
+        "status": "optimal",
+        "bound": -172201.8548736482,
+        "finite": true,
+        "solve_wall": 0.08862754100005077
+      },
+      {
+        "n_rows": 2116,
+        "frac_rows": 0.700198544010589,
+        "build_elapsed": 5.400943853000058,
+        "build_frac": 0.9976195893417716,
+        "status": "optimal",
+        "bound": -167220.08788492077,
+        "finite": true,
+        "solve_wall": 0.1298505259999274
+      },
+      {
+        "n_rows": 2418,
+        "frac_rows": 0.800132362673726,
+        "build_elapsed": 5.402976248000073,
+        "build_frac": 0.9979949972557363,
+        "status": "optimal",
+        "bound": -164466.0923233029,
+        "finite": true,
+        "solve_wall": 0.1615089330000501
+      },
+      {
+        "n_rows": 2720,
+        "frac_rows": 0.900066181336863,
+        "build_elapsed": 5.405157469000073,
+        "build_frac": 0.9983978951301653,
+        "status": "optimal",
+        "bound": -147934.03872376433,
+        "finite": true,
+        "solve_wall": 0.30337859999997363
+      },
+      {
+        "n_rows": 3022,
+        "frac_rows": 1.0,
+        "build_elapsed": 5.407424712000079,
+        "build_frac": 0.9988166823074005,
+        "status": "iteration_limit",
+        "bound": -28100067.375443634,
+        "finite": false,
+        "solve_wall": 5.38387862400009
+      }
+    ]
+  },
+  {
+    "instance": "heatexch_gen1",
+    "status": "ok",
+    "n_vars": 112,
+    "n_cons": 120,
+    "n_rows": 364,
+    "n_cols": 220,
+    "build_wall": 0.07457688500005588,
+    "obj_floor": 0.0,
+    "obj_bound_valid": true,
+    "full_bound": 38183.531745992055,
+    "first_finite_build_frac": 0.16517352528282953,
+    "first_finite_row_frac": 0.10164835164835165,
+    "checkpoints": [
+      {
+        "n_rows": 37,
+        "frac_rows": 0.10164835164835165,
+        "build_elapsed": 0.0123181270000714,
+        "build_frac": 0.16517352528282953,
+        "status": "optimal",
+        "bound": 0.0,
+        "finite": true,
+        "solve_wall": 0.0013161350000245875
+      },
+      {
+        "n_rows": 73,
+        "frac_rows": 0.20054945054945056,
+        "build_elapsed": 0.014692876000026445,
+        "build_frac": 0.19701648842017785,
+        "status": "optimal",
+        "bound": 0.0,
+        "finite": true,
+        "solve_wall": 0.0012363230000573822
+      },
+      {
+        "n_rows": 110,
+        "frac_rows": 0.3021978021978022,
+        "build_elapsed": 0.025410272000044642,
+        "build_frac": 0.3407258428670707,
+        "status": "optimal",
+        "bound": 0.0,
+        "finite": true,
+        "solve_wall": 0.0015137679999952525
+      },
+      {
+        "n_rows": 146,
+        "frac_rows": 0.4010989010989011,
+        "build_elapsed": 0.039736726999990424,
+        "build_frac": 0.5328289992262435,
+        "status": "optimal",
+        "bound": 0.0,
+        "finite": true,
+        "solve_wall": 0.002180146999990029
+      },
+      {
+        "n_rows": 182,
+        "frac_rows": 0.5,
+        "build_elapsed": 0.056114090000050965,
+        "build_frac": 0.7524327410565474,
+        "status": "optimal",
+        "bound": 0.0,
+        "finite": true,
+        "solve_wall": 0.0025827650000564972
+      },
+      {
+        "n_rows": 219,
+        "frac_rows": 0.6016483516483516,
+        "build_elapsed": 0.06546193799999855,
+        "build_frac": 0.8777778530163803,
+        "status": "optimal",
+        "bound": 0.0,
+        "finite": true,
+        "solve_wall": 0.0026568739999675017
+      },
+      {
+        "n_rows": 255,
+        "frac_rows": 0.7005494505494505,
+        "build_elapsed": 0.07117364300006557,
+        "build_frac": 0.9543659942355093,
+        "status": "optimal",
+        "bound": 0.0,
+        "finite": true,
+        "solve_wall": 0.0027884930000254826
+      },
+      {
+        "n_rows": 292,
+        "frac_rows": 0.8021978021978022,
+        "build_elapsed": 0.07215894199998729,
+        "build_frac": 0.9675778493555104,
+        "status": "optimal",
+        "bound": 24749.99999997575,
+        "finite": true,
+        "solve_wall": 0.004599883999958365
+      },
+      {
+        "n_rows": 328,
+        "frac_rows": 0.9010989010989011,
+        "build_elapsed": 0.07243689500000983,
+        "build_frac": 0.9713049157249669,
+        "status": "optimal",
+        "bound": 24749.99999996031,
+        "finite": true,
+        "solve_wall": 0.005772750000005544
+      },
+      {
+        "n_rows": 364,
+        "frac_rows": 1.0,
+        "build_elapsed": 0.07276340700002493,
+        "build_frac": 0.9756831087805612,
+        "status": "optimal",
+        "bound": 38183.531745992055,
+        "finite": true,
+        "solve_wall": 0.008430232000023352
+      }
+    ]
+  },
+  {
+    "instance": "heatexch_gen2",
+    "status": "ok",
+    "n_vars": 148,
+    "n_cons": 166,
+    "n_rows": 484,
+    "n_cols": 309,
+    "build_wall": 0.11796289799997339,
+    "obj_floor": 1590.0125080900855,
+    "obj_bound_valid": true,
+    "full_bound": 543496.0185139069,
+    "first_finite_build_frac": 0.1648114816573306,
+    "first_finite_row_frac": 0.1012396694214876,
+    "checkpoints": [
+      {
+        "n_rows": 49,
+        "frac_rows": 0.1012396694214876,
+        "build_elapsed": 0.019441639999968174,
+        "build_frac": 0.1648114816573306,
+        "status": "optimal",
+        "bound": 1590.012508090016,
+        "finite": true,
+        "solve_wall": 0.0018960250000645829
+      },
+      {
+        "n_rows": 97,
+        "frac_rows": 0.20041322314049587,
+        "build_elapsed": 0.02255687299998499,
+        "build_frac": 0.19122006480368156,
+        "status": "optimal",
+        "bound": 1590.012508090007,
+        "finite": true,
+        "solve_wall": 0.0021555529999659484
+      },
+      {
+        "n_rows": 146,
+        "frac_rows": 0.30165289256198347,
+        "build_elapsed": 0.050389670999948066,
+        "build_frac": 0.4271654211136745,
+        "status": "optimal",
+        "bound": 1590.0125080899977,
+        "finite": true,
+        "solve_wall": 0.002940345999945748
+      },
+      {
+        "n_rows": 194,
+        "frac_rows": 0.40082644628099173,
+        "build_elapsed": 0.08354450199999519,
+        "build_frac": 0.708226937591971,
+        "status": "optimal",
+        "bound": 1590.0125080899888,
+        "finite": true,
+        "solve_wall": 0.004207272000030571
+      },
+      {
+        "n_rows": 242,
+        "frac_rows": 0.5,
+        "build_elapsed": 0.09706590099995083,
+        "build_frac": 0.8228511052684779,
+        "status": "optimal",
+        "bound": 1590.0125080899797,
+        "finite": true,
+        "solve_wall": 0.004664510999987215
+      },
+      {
+        "n_rows": 291,
+        "frac_rows": 0.6012396694214877,
+        "build_elapsed": 0.1070803640000122,
+        "build_frac": 0.9077461287873442,
+        "status": "optimal",
+        "bound": 1590.0125080899707,
+        "finite": true,
+        "solve_wall": 0.005184729999996307
+      },
+      {
+        "n_rows": 339,
+        "frac_rows": 0.7004132231404959,
+        "build_elapsed": 0.11537570899997718,
+        "build_frac": 0.9780677734791087,
+        "status": "optimal",
+        "bound": 1590.0125080899616,
+        "finite": true,
+        "solve_wall": 0.005008115999999063
+      },
+      {
+        "n_rows": 388,
+        "frac_rows": 0.8016528925619835,
+        "build_elapsed": 0.11573646399995141,
+        "build_frac": 0.9811259808145567,
+        "status": "optimal",
+        "bound": 485990.01250802085,
+        "finite": true,
+        "solve_wall": 0.0077529839999215255
+      },
+      {
+        "n_rows": 436,
+        "frac_rows": 0.9008264462809917,
+        "build_elapsed": 0.11619970100002774,
+        "build_frac": 0.9850529528365263,
+        "status": "optimal",
+        "bound": 485990.0125080136,
+        "finite": true,
+        "solve_wall": 0.008456499999965672
+      },
+      {
+        "n_rows": 484,
+        "frac_rows": 1.0,
+        "build_elapsed": 0.11662810600000739,
+        "build_frac": 0.9886846455741847,
+        "status": "optimal",
+        "bound": 543496.0185139069,
+        "finite": true,
+        "solve_wall": 0.010444413999948665
+      }
+    ]
+  },
+  {
+    "instance": "heatexch_gen3",
+    "status": "ok",
+    "n_vars": 580,
+    "n_cons": 510,
+    "n_rows": 1840,
+    "n_cols": 1265,
+    "build_wall": 0.7139639910000142,
+    "obj_floor": 783.0180644999178,
+    "obj_bound_valid": true,
+    "full_bound": 43887.57992568576,
+    "first_finite_build_frac": 0.20831566419991102,
+    "first_finite_row_frac": 0.1,
+    "checkpoints": [
+      {
+        "n_rows": 184,
+        "frac_rows": 0.1,
+        "build_elapsed": 0.14872988299998724,
+        "build_frac": 0.20831566419991102,
+        "status": "optimal",
+        "bound": 783.018064499784,
+        "finite": true,
+        "solve_wall": 0.002727642000081687
+      },
+      {
+        "n_rows": 368,
+        "frac_rows": 0.2,
+        "build_elapsed": 0.16341989099998955,
+        "build_frac": 0.2288909427646279,
+        "status": "optimal",
+        "bound": 783.0180644997671,
+        "finite": true,
+        "solve_wall": 0.005063880000079735
+      },
+      {
+        "n_rows": 552,
+        "frac_rows": 0.3,
+        "build_elapsed": 0.17837320699993597,
+        "build_frac": 0.2498350186402222,
+        "status": "optimal",
+        "bound": 783.0180644997499,
+        "finite": true,
+        "solve_wall": 0.00757248900004015
+      },
+      {
+        "n_rows": 736,
+        "frac_rows": 0.4,
+        "build_elapsed": 0.3348841470000252,
+        "build_frac": 0.4690490714118082,
+        "status": "optimal",
+        "bound": 783.018064499733,
+        "finite": true,
+        "solve_wall": 0.014124507000019548
+      },
+      {
+        "n_rows": 920,
+        "frac_rows": 0.5,
+        "build_elapsed": 0.4963271829999485,
+        "build_frac": 0.6951711700540631,
+        "status": "optimal",
+        "bound": 783.0180644997162,
+        "finite": true,
+        "solve_wall": 0.022532172000069295
+      },
+      {
+        "n_rows": 1104,
+        "frac_rows": 0.6,
+        "build_elapsed": 0.6200916479999705,
+        "build_frac": 0.8685194993257835,
+        "status": "optimal",
+        "bound": 783.0180644996989,
+        "finite": true,
+        "solve_wall": 0.02913130700005695
+      },
+      {
+        "n_rows": 1288,
+        "frac_rows": 0.7,
+        "build_elapsed": 0.6750163149999935,
+        "build_frac": 0.9454486829994485,
+        "status": "optimal",
+        "bound": 783.018064499682,
+        "finite": true,
+        "solve_wall": 0.02894067499994435
+      },
+      {
+        "n_rows": 1472,
+        "frac_rows": 0.8,
+        "build_elapsed": 0.7013118190000114,
+        "build_frac": 0.9822789774281452,
+        "status": "optimal",
+        "bound": 783.018064499665,
+        "finite": true,
+        "solve_wall": 0.02495409000005111
+      },
+      {
+        "n_rows": 1656,
+        "frac_rows": 0.9,
+        "build_elapsed": 0.7059853329999441,
+        "build_frac": 0.9888248453694496,
+        "status": "optimal",
+        "bound": 20002.618064436145,
+        "finite": true,
+        "solve_wall": 0.07002840799998467
+      },
+      {
+        "n_rows": 1840,
+        "frac_rows": 1.0,
+        "build_elapsed": 0.7080303079999339,
+        "build_frac": 0.9916891004660204,
+        "status": "optimal",
+        "bound": 43887.57992568576,
+        "finite": true,
+        "solve_wall": 0.1392617970000174
+      }
+    ]
+  },
+  {
+    "instance": "nvs05",
+    "status": "ok",
+    "n_vars": 8,
+    "n_cons": 9,
+    "n_rows": 163,
+    "n_cols": 54,
+    "build_wall": 0.08884139999997842,
+    "obj_floor": 0.6740222047099997,
+    "obj_bound_valid": true,
+    "full_bound": -219.5977517308399,
+    "first_finite_build_frac": 0.08064374266968374,
+    "first_finite_row_frac": 0.10429447852760736,
+    "checkpoints": [
+      {
+        "n_rows": 17,
+        "frac_rows": 0.10429447852760736,
+        "build_elapsed": 0.007164503000012701,
+        "build_frac": 0.08064374266968374,
+        "status": "optimal",
+        "bound": 0.674022204709993,
+        "finite": true,
+        "solve_wall": 0.0012208660000396776
+      },
+      {
+        "n_rows": 33,
+        "frac_rows": 0.20245398773006135,
+        "build_elapsed": 0.0073354360000621455,
+        "build_frac": 0.08256776683014819,
+        "status": "optimal",
+        "bound": 0.6740221939982679,
+        "finite": true,
+        "solve_wall": 0.001291160000050695
+      },
+      {
+        "n_rows": 49,
+        "frac_rows": 0.3006134969325153,
+        "build_elapsed": 0.010753227000009247,
+        "build_frac": 0.1210384685519573,
+        "status": "optimal",
+        "bound": 0.6740221944400567,
+        "finite": true,
+        "solve_wall": 0.0027050659999758864
+      },
+      {
+        "n_rows": 66,
+        "frac_rows": 0.4049079754601227,
+        "build_elapsed": 0.013243161999980657,
+        "build_frac": 0.14906521058857553,
+        "status": "optimal",
+        "bound": 0.6740221944020428,
+        "finite": true,
+        "solve_wall": 0.0020074509999403745
+      },
+      {
+        "n_rows": 82,
+        "frac_rows": 0.5030674846625767,
+        "build_elapsed": 0.013631469000074503,
+        "build_frac": 0.1534359994335728,
+        "status": "optimal",
+        "bound": 0.6740221939982137,
+        "finite": true,
+        "solve_wall": 0.001973013999986506
+      },
+      {
+        "n_rows": 98,
+        "frac_rows": 0.6012269938650306,
+        "build_elapsed": 0.02739120500007175,
+        "build_frac": 0.3083157739531165,
+        "status": "optimal",
+        "bound": 0.6740220975127238,
+        "finite": true,
+        "solve_wall": 0.002062593999994533
+      },
+      {
+        "n_rows": 115,
+        "frac_rows": 0.7055214723926381,
+        "build_elapsed": 0.027799330999982885,
+        "build_frac": 0.3129096457281137,
+        "status": "optimal",
+        "bound": 0.6740220974820901,
+        "finite": true,
+        "solve_wall": 0.0026219219998893095
+      },
+      {
+        "n_rows": 131,
+        "frac_rows": 0.803680981595092,
+        "build_elapsed": 0.07358988700002556,
+        "build_frac": 0.828328763392331,
+        "status": "optimal",
+        "bound": -13484.936145726495,
+        "finite": true,
+        "solve_wall": 0.0026229000000057567
+      },
+      {
+        "n_rows": 147,
+        "frac_rows": 0.901840490797546,
+        "build_elapsed": 0.08758906000002753,
+        "build_frac": 0.985903644022368,
+        "status": "optimal",
+        "bound": -184.06972676448373,
+        "finite": true,
+        "solve_wall": 0.003228508999995938
+      },
+      {
+        "n_rows": 163,
+        "frac_rows": 1.0,
+        "build_elapsed": 0.0880869889999758,
+        "build_frac": 0.9915083395803893,
+        "status": "optimal",
+        "bound": -219.5977517308399,
+        "finite": true,
+        "solve_wall": 0.003213105999975596
+      }
+    ]
+  }
+]

--- a/docs/dev/data/issue694-synth-clique-120.json
+++ b/docs/dev/data/issue694-synth-clique-120.json
@@ -1,0 +1,118 @@
+[
+  {
+    "instance": "synth_clique_120",
+    "status": "ok",
+    "n_vars": 120,
+    "n_cons": 2,
+    "n_rows": 28562,
+    "n_cols": 7260,
+    "build_wall": 1.8281781090001914,
+    "obj_floor": -1172.4751528401143,
+    "obj_bound_valid": true,
+    "full_bound": -586.2375764220985,
+    "first_finite_build_frac": 0.40319581684692185,
+    "first_finite_row_frac": 0.1000280092430502,
+    "checkpoints": [
+      {
+        "n_rows": 2857,
+        "frac_rows": 0.1000280092430502,
+        "build_elapsed": 0.7371137659999931,
+        "build_frac": 0.40319581684692185,
+        "status": "optimal",
+        "bound": -1115.5434970969613,
+        "finite": true,
+        "solve_wall": 0.7816439200000787
+      },
+      {
+        "n_rows": 5713,
+        "frac_rows": 0.20002100693228766,
+        "build_elapsed": 0.8366862240000046,
+        "build_frac": 0.4576612201409513,
+        "status": "optimal",
+        "bound": -1058.170559821188,
+        "finite": true,
+        "solve_wall": 1.9878720480000993
+      },
+      {
+        "n_rows": 8569,
+        "frac_rows": 0.3000140046215251,
+        "build_elapsed": 0.9379689020001933,
+        "build_frac": 0.5130621012157055,
+        "status": "optimal",
+        "bound": -997.2290053552107,
+        "finite": true,
+        "solve_wall": 4.168044651999935
+      },
+      {
+        "n_rows": 11425,
+        "frac_rows": 0.4000070023107625,
+        "build_elapsed": 1.0386888370001088,
+        "build_frac": 0.5681551660019358,
+        "status": "optimal",
+        "bound": -940.3060798520376,
+        "finite": true,
+        "solve_wall": 6.906680738999967
+      },
+      {
+        "n_rows": 14281,
+        "frac_rows": 0.5,
+        "build_elapsed": 1.1366276070000367,
+        "build_frac": 0.6217269539572622,
+        "status": "optimal",
+        "bound": -883.6808665657829,
+        "finite": true,
+        "solve_wall": 8.725611608999998
+      },
+      {
+        "n_rows": 17138,
+        "frac_rows": 0.6000280092430502,
+        "build_elapsed": 1.2809957420001865,
+        "build_frac": 0.7006952636035816,
+        "status": "optimal",
+        "bound": -827.5887206315646,
+        "finite": true,
+        "solve_wall": 12.688677652000024
+      },
+      {
+        "n_rows": 19994,
+        "frac_rows": 0.7000210069322876,
+        "build_elapsed": 1.3786632280000504,
+        "build_frac": 0.754118661203106,
+        "status": "optimal",
+        "bound": -759.5569985426996,
+        "finite": true,
+        "solve_wall": 18.952819227999953
+      },
+      {
+        "n_rows": 22850,
+        "frac_rows": 0.800014004621525,
+        "build_elapsed": 1.4814474110000901,
+        "build_frac": 0.8103408544861507,
+        "status": "optimal",
+        "bound": -703.1423070966049,
+        "finite": true,
+        "solve_wall": 24.864156641999898
+      },
+      {
+        "n_rows": 25706,
+        "frac_rows": 0.9000070023107626,
+        "build_elapsed": 1.5823345000001154,
+        "build_frac": 0.8655253512829093,
+        "status": "optimal",
+        "bound": -646.3429727256379,
+        "finite": true,
+        "solve_wall": 29.808678285000042
+      },
+      {
+        "n_rows": 28562,
+        "frac_rows": 1.0,
+        "build_elapsed": 1.6821148800001993,
+        "build_frac": 0.9201044863840578,
+        "status": "optimal",
+        "bound": -586.2375764220985,
+        "finite": true,
+        "solve_wall": 33.647967248999976
+      }
+    ]
+  }
+]

--- a/docs/dev/data/issue694-synth-clique.json
+++ b/docs/dev/data/issue694-synth-clique.json
@@ -1,0 +1,234 @@
+[
+  {
+    "instance": "synth_clique_40",
+    "status": "ok",
+    "n_vars": 40,
+    "n_cons": 2,
+    "n_rows": 3122,
+    "n_cols": 820,
+    "build_wall": 0.20057538499997918,
+    "obj_floor": -131.76261318861012,
+    "obj_bound_valid": true,
+    "full_bound": -65.88130659433195,
+    "first_finite_build_frac": 0.4461655402032319,
+    "first_finite_row_frac": 0.1002562459961563,
+    "checkpoints": [
+      {
+        "n_rows": 313,
+        "frac_rows": 0.1002562459961563,
+        "build_elapsed": 0.08948982499998692,
+        "build_frac": 0.4461655402032319,
+        "status": "optimal",
+        "bound": -126.41305981824307,
+        "finite": true,
+        "solve_wall": 0.012337963999925705
+      },
+      {
+        "n_rows": 625,
+        "frac_rows": 0.20019218449711723,
+        "build_elapsed": 0.09998954200000298,
+        "build_frac": 0.4985135239800904,
+        "status": "optimal",
+        "bound": -117.52200356480046,
+        "finite": true,
+        "solve_wall": 0.023625598000080572
+      },
+      {
+        "n_rows": 937,
+        "frac_rows": 0.3001281229980782,
+        "build_elapsed": 0.11085406699999112,
+        "build_frac": 0.5526803151842516,
+        "status": "optimal",
+        "bound": -109.96659360502731,
+        "finite": true,
+        "solve_wall": 0.04246012700002666
+      },
+      {
+        "n_rows": 1249,
+        "frac_rows": 0.40006406149903906,
+        "build_elapsed": 0.12161197500006438,
+        "build_frac": 0.6063155506348747,
+        "status": "optimal",
+        "bound": -103.64276670163571,
+        "finite": true,
+        "solve_wall": 0.06563968700004352
+      },
+      {
+        "n_rows": 1561,
+        "frac_rows": 0.5,
+        "build_elapsed": 0.13253162000000884,
+        "build_frac": 0.6607571512328025,
+        "status": "optimal",
+        "bound": -97.10915997728415,
+        "finite": true,
+        "solve_wall": 0.09814163099997586
+      },
+      {
+        "n_rows": 1874,
+        "frac_rows": 0.6002562459961563,
+        "build_elapsed": 0.14293644700001096,
+        "build_frac": 0.7126320460510436,
+        "status": "optimal",
+        "bound": -91.14166785500636,
+        "finite": true,
+        "solve_wall": 0.12051873100006105
+      },
+      {
+        "n_rows": 2186,
+        "frac_rows": 0.7001921844971173,
+        "build_elapsed": 0.15383592299997417,
+        "build_frac": 0.7669730909402973,
+        "status": "optimal",
+        "bound": -84.04334402109818,
+        "finite": true,
+        "solve_wall": 0.15461361199993462
+      },
+      {
+        "n_rows": 2498,
+        "frac_rows": 0.8001281229980781,
+        "build_elapsed": 0.16611143400007222,
+        "build_frac": 0.8281745738645321,
+        "status": "optimal",
+        "bound": -76.54793116868761,
+        "finite": true,
+        "solve_wall": 0.2018943019999142
+      },
+      {
+        "n_rows": 2810,
+        "frac_rows": 0.9000640614990391,
+        "build_elapsed": 0.17851105099998676,
+        "build_frac": 0.8899948066907876,
+        "status": "optimal",
+        "bound": -71.08754034770425,
+        "finite": true,
+        "solve_wall": 0.25866745299993
+      },
+      {
+        "n_rows": 3122,
+        "frac_rows": 1.0,
+        "build_elapsed": 0.1908132350000642,
+        "build_frac": 0.9513292720344723,
+        "status": "optimal",
+        "bound": -65.88130659433195,
+        "finite": true,
+        "solve_wall": 0.28602917000000616
+      }
+    ]
+  },
+  {
+    "instance": "synth_clique_60",
+    "status": "ok",
+    "n_vars": 60,
+    "n_cons": 2,
+    "n_rows": 7082,
+    "n_cols": 1830,
+    "build_wall": 0.4319107249999661,
+    "obj_floor": -292.6209065365292,
+    "obj_bound_valid": true,
+    "full_bound": -146.31045326839546,
+    "first_finite_build_frac": 0.37894949702872405,
+    "first_finite_row_frac": 0.1001129624399887,
+    "checkpoints": [
+      {
+        "n_rows": 709,
+        "frac_rows": 0.1001129624399887,
+        "build_elapsed": 0.1636723520000487,
+        "build_frac": 0.37894949702872405,
+        "status": "optimal",
+        "bound": -277.91733465398886,
+        "finite": true,
+        "solve_wall": 0.04062523999994028
+      },
+      {
+        "n_rows": 1417,
+        "frac_rows": 0.20008472182999154,
+        "build_elapsed": 0.18752291199996307,
+        "build_frac": 0.43417053836757075,
+        "status": "optimal",
+        "bound": -260.76116429163795,
+        "finite": true,
+        "solve_wall": 0.09206489000007423
+      },
+      {
+        "n_rows": 2125,
+        "frac_rows": 0.30005648121999434,
+        "build_elapsed": 0.211539853999966,
+        "build_frac": 0.489776802833462,
+        "status": "optimal",
+        "bound": -244.84874064864863,
+        "finite": true,
+        "solve_wall": 0.17728129500005707
+      },
+      {
+        "n_rows": 2833,
+        "frac_rows": 0.4000282406099972,
+        "build_elapsed": 0.23605687400004172,
+        "build_frac": 0.546540894533379,
+        "status": "optimal",
+        "bound": -229.25540063651218,
+        "finite": true,
+        "solve_wall": 0.31860434399993665
+      },
+      {
+        "n_rows": 3541,
+        "frac_rows": 0.5,
+        "build_elapsed": 0.26109023000003617,
+        "build_frac": 0.6045004555051433,
+        "status": "optimal",
+        "bound": -215.20239197714048,
+        "finite": true,
+        "solve_wall": 0.44128047700007755
+      },
+      {
+        "n_rows": 4250,
+        "frac_rows": 0.6001129624399887,
+        "build_elapsed": 0.3110561329999655,
+        "build_frac": 0.7201861750480725,
+        "status": "optimal",
+        "bound": -200.98541998402527,
+        "finite": true,
+        "solve_wall": 0.7576525260000153
+      },
+      {
+        "n_rows": 4958,
+        "frac_rows": 0.7000847218299915,
+        "build_elapsed": 0.3362277549999817,
+        "build_frac": 0.7784658623608111,
+        "status": "optimal",
+        "bound": -189.46752093893087,
+        "finite": true,
+        "solve_wall": 0.8519862109999394
+      },
+      {
+        "n_rows": 5666,
+        "frac_rows": 0.8000564812199944,
+        "build_elapsed": 0.36208200700002635,
+        "build_frac": 0.8383260383266815,
+        "status": "optimal",
+        "bound": -172.77148511442323,
+        "finite": true,
+        "solve_wall": 1.0254614939999556
+      },
+      {
+        "n_rows": 6374,
+        "frac_rows": 0.9000282406099972,
+        "build_elapsed": 0.3860606150000194,
+        "build_frac": 0.8938435483398791,
+        "status": "optimal",
+        "bound": -159.22601710783962,
+        "finite": true,
+        "solve_wall": 1.5466595220000272
+      },
+      {
+        "n_rows": 7082,
+        "frac_rows": 1.0,
+        "build_elapsed": 0.41026150100003633,
+        "build_frac": 0.94987569711326,
+        "status": "optimal",
+        "bound": -146.31045326839546,
+        "finite": true,
+        "solve_wall": 1.4905062889999954
+      }
+    ]
+  }
+]

--- a/docs/dev/data/issue694-synth-netdesign.json
+++ b/docs/dev/data/issue694-synth-netdesign.json
@@ -1,0 +1,118 @@
+[
+  {
+    "instance": "synth_netdesign_80",
+    "status": "ok",
+    "n_vars": 160,
+    "n_cons": 80,
+    "n_rows": 6160,
+    "n_cols": 1680,
+    "build_wall": 2.204407695999862,
+    "obj_floor": 0.0,
+    "obj_bound_valid": true,
+    "full_bound": 23.72481399776351,
+    "first_finite_build_frac": 0.11653102983897963,
+    "first_finite_row_frac": 0.1,
+    "checkpoints": [
+      {
+        "n_rows": 616,
+        "frac_rows": 0.1,
+        "build_elapsed": 0.25688189899983627,
+        "build_frac": 0.11653102983897963,
+        "status": "optimal",
+        "bound": 1.9882317683535151,
+        "finite": true,
+        "solve_wall": 0.028519219999907364
+      },
+      {
+        "n_rows": 1232,
+        "frac_rows": 0.2,
+        "build_elapsed": 0.45425084699991203,
+        "build_frac": 0.20606480726056242,
+        "status": "optimal",
+        "bound": 4.565261084644418,
+        "finite": true,
+        "solve_wall": 0.07147992299996986
+      },
+      {
+        "n_rows": 1848,
+        "frac_rows": 0.3,
+        "build_elapsed": 0.6513184319999255,
+        "build_frac": 0.29546187539710267,
+        "status": "optimal",
+        "bound": 7.055824308392359,
+        "finite": true,
+        "solve_wall": 0.14530776800006606
+      },
+      {
+        "n_rows": 2464,
+        "frac_rows": 0.4,
+        "build_elapsed": 0.8656945129998803,
+        "build_frac": 0.3927107107141648,
+        "status": "optimal",
+        "bound": 10.118560573395742,
+        "finite": true,
+        "solve_wall": 0.2570148520001112
+      },
+      {
+        "n_rows": 3080,
+        "frac_rows": 0.5,
+        "build_elapsed": 1.0723413339999297,
+        "build_frac": 0.4864532708472257,
+        "status": "optimal",
+        "bound": 12.349125192520196,
+        "finite": true,
+        "solve_wall": 0.38690286800010654
+      },
+      {
+        "n_rows": 3696,
+        "frac_rows": 0.6,
+        "build_elapsed": 1.2965934019998713,
+        "build_frac": 0.5881822152738267,
+        "status": "optimal",
+        "bound": 14.528065501752302,
+        "finite": true,
+        "solve_wall": 0.5870378679999249
+      },
+      {
+        "n_rows": 4312,
+        "frac_rows": 0.7,
+        "build_elapsed": 1.5140876459997799,
+        "build_frac": 0.6868455634351381,
+        "status": "optimal",
+        "bound": 16.974151908679474,
+        "finite": true,
+        "solve_wall": 0.8515064900000198
+      },
+      {
+        "n_rows": 4928,
+        "frac_rows": 0.8,
+        "build_elapsed": 1.7327067429998806,
+        "build_frac": 0.7860191860807172,
+        "status": "optimal",
+        "bound": 18.869313840369895,
+        "finite": true,
+        "solve_wall": 1.1404884690000472
+      },
+      {
+        "n_rows": 5544,
+        "frac_rows": 0.9,
+        "build_elapsed": 1.9632657909999125,
+        "build_frac": 0.8906092074358443,
+        "status": "optimal",
+        "bound": 21.356959859769468,
+        "finite": true,
+        "solve_wall": 1.491288971999893
+      },
+      {
+        "n_rows": 6160,
+        "frac_rows": 1.0,
+        "build_elapsed": 2.192846488999976,
+        "build_frac": 0.9947554134288021,
+        "status": "optimal",
+        "bound": 23.72481399776351,
+        "finite": true,
+        "solve_wall": 1.798131918999843
+      }
+    ]
+  }
+]

--- a/docs/dev/data/issue694-synth-qap.json
+++ b/docs/dev/data/issue694-synth-qap.json
@@ -1,0 +1,118 @@
+[
+  {
+    "instance": "synth_qap_8",
+    "status": "ok",
+    "n_vars": 64,
+    "n_cons": 16,
+    "n_rows": 6304,
+    "n_cols": 1632,
+    "build_wall": 0.38832874099989567,
+    "obj_floor": -6.65e-321,
+    "obj_bound_valid": true,
+    "full_bound": -6.65e-321,
+    "first_finite_build_frac": 0.3807171949706822,
+    "first_finite_row_frac": 0.10009517766497462,
+    "checkpoints": [
+      {
+        "n_rows": 631,
+        "frac_rows": 0.10009517766497462,
+        "build_elapsed": 0.14784342899997682,
+        "build_frac": 0.3807171949706822,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.0047498030000951985
+      },
+      {
+        "n_rows": 1261,
+        "frac_rows": 0.20003172588832488,
+        "build_elapsed": 0.16928478199997699,
+        "build_frac": 0.4359316324722472,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.003779458000053637
+      },
+      {
+        "n_rows": 1892,
+        "frac_rows": 0.3001269035532995,
+        "build_elapsed": 0.1899312089999512,
+        "build_frac": 0.48909902602342337,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.004763583999874754
+      },
+      {
+        "n_rows": 2522,
+        "frac_rows": 0.40006345177664976,
+        "build_elapsed": 0.2308146210000359,
+        "build_frac": 0.5943794435758695,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.005614271000013105
+      },
+      {
+        "n_rows": 3152,
+        "frac_rows": 0.5,
+        "build_elapsed": 0.2514127029999145,
+        "build_frac": 0.6474223420923202,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.006756211000038093
+      },
+      {
+        "n_rows": 3783,
+        "frac_rows": 0.6000951776649747,
+        "build_elapsed": 0.2734062619999804,
+        "build_frac": 0.7040587861099209,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.007542558000068311
+      },
+      {
+        "n_rows": 4413,
+        "frac_rows": 0.7000317258883249,
+        "build_elapsed": 0.2968995090000135,
+        "build_frac": 0.7645571333080733,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.009018892000085543
+      },
+      {
+        "n_rows": 5044,
+        "frac_rows": 0.8001269035532995,
+        "build_elapsed": 0.31974175799996374,
+        "build_frac": 0.8233790709816393,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.009888631999956488
+      },
+      {
+        "n_rows": 5674,
+        "frac_rows": 0.9000634517766497,
+        "build_elapsed": 0.3454492500000015,
+        "build_frac": 0.8895794040650066,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.011653316999854724
+      },
+      {
+        "n_rows": 6304,
+        "frac_rows": 1.0,
+        "build_elapsed": 0.3680928930000391,
+        "build_frac": 0.9478899039310047,
+        "status": "optimal",
+        "bound": -6.65e-321,
+        "finite": true,
+        "solve_wall": 0.037509442999862586
+      }
+    ]
+  }
+]

--- a/docs/dev/issue694-anytime-build-entry-2026-07-17.md
+++ b/docs/dev/issue694-anytime-build-entry-2026-07-17.md
@@ -122,35 +122,55 @@ The kill criterion (#694: partial bound −∞/None until ≳90 % build) is **no
 any tested instance**. §8.1 is therefore *challengeable* on these structures: a
 build interrupted at a checkpoint does yield a valid weaker bound, so the
 "lose-the-bound vs overrun" fork is dissolvable in principle — the entry experiment
-**survives**, and implementation is permitted to proceed.
+**survives**, and the implementation proceeds.
 
-It was **not** implemented in this session, by design:
+**Implementation landed (default-OFF, `DISCOPT_ANYTIME_ROOT_BUILD`).** The change is
+**bound-changing** (CLAUDE.md §5), so it ships behind a default-off flag and
+graduates only after the corpus-wide differential panel passes — flag ON vs OFF over
+the in-repo corpus, `incorrect_count = 0`, no bound above its reference optimum, no
+certification regression, incumbents independently feasibility-verified, AND
+net-positive (wall/nodes/bound). The specific must-not-regress bounds are
+**casctanks 5.698, super3t −1.0, sonet23v4 −53974.375**
+(`python/tests/test_issue654_deadline_root_setup.py` pins them). Two of those three
+(super3t, sonet23v4) and the headline slow-build case are **big-corpus-only**, so
+**graduating this flag is a run-on-the-owner's-machine step** — the panel cannot be
+certified in this environment.
 
-- The change is **bound-changing** (CLAUDE.md §5): it must land behind a
-  **default-off** flag and graduate only after the corpus-wide differential panel
-  passes — flag ON vs OFF over the in-repo corpus, `incorrect_count = 0`, no bound
-  above its reference optimum, no certification regression, incumbents
-  independently feasibility-verified, AND net-positive (wall/nodes/bound). The
-  specific must-not-regress bounds are **casctanks 5.698, super3t −1.0, sonet23v4
-  −53974.375** (`python/tests/test_issue654_deadline_root_setup.py` pins them).
-- Two of those three (super3t, sonet23v4) and the headline slow-build case are
-  **only in the big corpus**, which is not present here. Graduating this flag is
-  therefore a **run-on-the-user's-machine** step, not something that can be
-  certified in this environment.
+What landed:
 
-**Recommended implementation direction** (for when the corpus is available), read
-off the curves above:
+- `build_uniform_relaxation(..., build_deadline=...)` (default `None`): the
+  constraint-row loop stops adding rows once the `perf_counter` deadline passes,
+  polling BETWEEN whole constraints (never mid-`rep`, so no partial row). Threaded
+  through `build_milp_relaxation` → `_uniform_relaxation_delegate`, and through
+  `MccormickLPRelaxer.solve_at_node` / `_solve_at_node_impl` (the cold build only —
+  the incremental fast path is already cheap). Provenance on the model:
+  `_build_truncated` / `_build_constraints_done` / `_build_constraints_total`.
+- The objective is fully linearized BEFORE the loop, so truncation never touches
+  `objective_bound_valid` for the objective itself; a truncated build is a valid
+  weaker outer relaxation (drops constraint rows only).
+- `_root_relaxation_lower_bound` sets `build_deadline = _fb_t0 + time_limit` when the
+  flag is on and applies it to the **separated (`sep`) build only** — the base build
+  is left WHOLE. Rationale (rule-1, §8): truncating the base build can un-bound an
+  objective cost column and trip its `objective_bound_valid=False → return None`
+  gate, which would LOSE the bound rather than weaken it; the documented sonet23v4
+  cost is the `sep` build (§8.6), and `sep` constructs its own relaxation, so
+  truncating it is the targeted, rule-1-safe cut.
+- Tests: `python/tests/test_issue694_anytime_root_build.py` — OFF byte-identical
+  (row count + bound), truncated build is valid & weaker (LP min ≤ full), grant
+  honored + sound under the flag. Regime-neutral: smoke (661) + the #654 suite pass
+  unchanged (flag default off ⇒ `build_deadline` is `None` everywhere).
 
-- Build the LP incrementally with a checkpoint hook that, when the fallback's own
-  grant is spent AND a finite bound is already in hand, **stops adding rows and
-  solves the prefix** — reusing the exact `_fb_stop` discipline
-  (`solver.py:2606`) already proven bound-neutral for the between-candidate poll,
-  now applied *within* the build.
-- **Order the rows** variable-bound + objective-linearizing envelopes first, then
-  remaining term envelopes by objective contribution, so the first-finite point is
-  as early as possible (§4.1).
-- Keep the legacy monolithic build as the default (`=0` opt-out) until the panel
-  graduates the flag, per §5.
+**Measured caveat (in-repo, informs the gate).** On **hda** (a control with wide/
+unbounded cost columns) the OFF fallback overruns (−28100067 in ~11–27 s against a
+3 s grant — the #654 symptom), and with the flag ON the `sep` build truncates to a
+relaxation whose cost columns are no longer bounded by any surviving row, so it
+returns **`None`** (honoring the grant in ~2 s, sound — a weaker/absent bound, never
+false). So the flag's *soundness* is universal but its *benefit* is
+structure-dependent: it retains a weaker bound on the clean finite-box #654
+structures (proxies confirmed) and can degrade to `None` on messier ones. Whether
+the real #654 instances retain their bounds is the empirical question the graduation
+panel answers; if bound-retention on that class needs improving, the **row-ordering**
+refinement (objective-critical constraints first, §4.1) is the follow-up lever.
 
 ## 6. Do-not-circumvent (unchanged, reaffirmed)
 

--- a/docs/dev/issue694-anytime-build-entry-2026-07-17.md
+++ b/docs/dev/issue694-anytime-build-entry-2026-07-17.md
@@ -1,0 +1,176 @@
+# Anytime/incremental root-relaxation build — #694 entry experiment
+
+**Date:** 2026-07-17
+**Status:** measured (measurement + probe only; **no library change shipped** —
+entry experiment per CLAUDE.md §4 / baron-gap-plan.md §0, run BEFORE any
+implementation).
+**Issue:** #694 — make the root McCormick relaxation build anytime/incremental so
+the dual bound accrues, dissolving the #654 §8.1 truncation fork.
+**Verdict:** **SURVIVES the kill criterion.** On every structure that could be
+tested here — the 6 named in-repo controls and 3 synthetic proxies matching the
+#654 class's structural signatures — a *finite, valid* LP lower bound exists **well
+before 90 % of build time** (measured 8 %–45 %), and on the bound-carrying
+structures it accrues **monotonically and near-continuously** across build deciles.
+The hypothesis is viable; the graduation gate (§5, on the real corpus) is the next
+step and requires the user's machine (see §5 below).
+
+> **Method.** Branch `claude/issue-694-ynajak` from `origin/main` (2225a77).
+> Linux x86-64, Python 3.11, `maturin develop --release` (discopt-core/‑python
+> 0.2.x). Probe: `discopt_benchmarks/scripts/issue694_anytime_build_probe.py`
+> instruments `_Builder.add_row` with per-row timestamps during ONE uninterrupted
+> `build_uniform_relaxation`, then post-hoc solves every **row-prefix**
+> `A_ub[:n_k] x ≤ b[:n_k]` (k = 10 %…100 % of final rows) over the full column set +
+> real objective, recording `(build_elapsed(n_k), status, bound, finite?)`. A prefix
+> relaxation has FEWER rows → still a valid outer approximation → its LP min is a
+> valid (weaker) bound whenever finite. Synthetic proxies:
+> `issue694_synthetic_proxy.py` (`clique` / `qap` / `netdesign`). Raw JSON in
+> `docs/dev/data/issue694-anytime-*.json`.
+
+---
+
+## 1. Why a proxy was needed (corpus blocker — recorded honestly)
+
+The decisive #654-class instances — **sonet23v4, super3t, qap, eg_all_s,
+sonet22v4** — live only in the big Dropbox snapshot
+(`~/Dropbox/projects/discopt-minlp-benchmark/`), which is **absent from this
+environment**, and MINLPLib is **network-blocked** (agent proxy returns 403 to
+`www.minlplib.org`). The 6 bound-producing controls the issue names (casctanks,
+hda, heatexch_gen1–3, nvs05) ARE in the in-repo corpus and were run directly. For
+the #654 class itself, the experiment uses **synthetic proxies that reproduce the
+structural signature** — the property under test (does a finite bound exist early in
+the build?) is a property of the build *code path* and the *atom structure*, both of
+which the proxies exercise faithfully. This is a real limitation, not a substitute
+for the corpus panel: the §5 graduation gate and the specific must-not-regress
+bounds (casctanks 5.698, super3t −1.0, sonet23v4 −53974.375) must be run on the
+user's machine against the real instances.
+
+## 2. Controls (in-repo) — a finite bound exists early on all 6
+
+`first-finite build%` = the earliest build decile at which the prefix LP returns an
+`optimal`, finite bound.
+
+| instance | vars | cons | rows | build wall | **first-finite build%** | notes |
+|---|---:|---:|---:|---:|---:|---|
+| nvs05 | 8 | 9 | 163 | 0.089 s | **8.1 %** | floor 0.674 until 70 %, then McCormick −219.6 in last 20 % |
+| hda | 722 | 718 | 3 022 | **5.414 s** | **12.1 %** | prefixes finite; **full build's own LP hits `iteration_limit`** (see §4) |
+| heatexch_gen1 | 112 | 120 | 364 | 0.075 s | **16.5 %** | floor 0 until 70 %, tight 38183 in last 30 % |
+| heatexch_gen2 | 148 | 166 | 484 | 0.118 s | **16.5 %** | floor 1590 until 70 %, tight 543496 in last 30 % |
+| heatexch_gen3 | 580 | 510 | 1 840 | 0.714 s | **20.8 %** | floor 783 until 80 %, tight 43887 in last 20 % |
+| casctanks | 500 | 517 | 1 742 | 0.227 s | 69.4 % | trivial obj (subnormal floor); tight 3.888 in last 10 % |
+
+**Reading:** none reaches the kill threshold (finite only ≳90 %). The *earliest*
+finite bound is almost always the **`obj_floor`** (`milp._objective_floor`, the
+box-interval objective floor computed from cost-column bounds alone — it needs
+**zero** rows), which is valid but weak. The **McCormick-tightened** bound overtakes
+the floor typically only in the **last 10 %–30 %** of the build. So on the controls
+the anytime story is: a *valid* finite bound is available almost immediately, but a
+*useful* one still needs most of the build.
+
+## 3. Synthetic #654-class proxies — the bound ACCRUES continuously
+
+Three families reproduce the #654 class's structural signatures (dense quadratic
+over binaries → O(n²) bilinear product envelopes → multi-thousand-row builds):
+
+| proxy (signature) | vars | rows | build wall | first-finite | anytime curve (bound at 10 %→100 % build) |
+|---|---:|---:|---:|---:|---|
+| **netdesign_80** (sonet*: linear obj + bilinear *constraints*) | 160 | 6 160 | 2.204 s | **11.7 %** | **1.99 → 4.57 → 7.06 → 10.1 → 12.3 → 14.5 → 17.0 → 18.9 → 21.4 → 23.72** (monotone, ~linear in build progress) |
+| clique_40 (qap/graphpart: dense quad over binaries) | 40 | 3 122 | 0.201 s | 44.6 % | −126 → −118 → −110 → −104 → −97 → −91 → −84 → −77 → −71 → **−65.9** (monotone) |
+| clique_60 | 60 | 7 082 | 0.432 s | 37.9 % | −278 → … → **−146** (monotone) |
+| clique_120 | 120 | **28 562** | 1.828 s | 40.3 % | −1116 → … → **−586** (monotone; every prefix solves `optimal`) |
+| qap_8 (assignment + product objective) | 64 | 6 304 | 0.388 s | 38.1 % | finite but **McCormick-trivial ≈ 0** at every decile (known: QAP McCormick root ≈ 0 vs opt 388214, #661 — needs RLT) |
+
+**Reading:**
+
+- On the **sonet\*** signature (`netdesign`, linear objective coupled to bilinear
+  *constraints*), the curve is textbook anytime: a finite bound from **11.7 %**
+  build, rising monotonically and almost linearly with build progress to the full
+  bound. Truncating at any decile ≥ the first yields a valid, weaker bound —
+  exactly the "bound accrues continuously" property SOTA solvers have and the issue
+  asks for.
+- On the **qap/graphpart** signature (`clique`), the finite bound appears at
+  ~38–45 % build (the point at which enough of the objective's product envelopes
+  exist to bound the LP below) and then tightens monotonically every decile,
+  holding at 28 k rows.
+- **qap** is the one caveat: its McCormick relaxation is trivially loose (≈ 0 at
+  every build fraction), matching the known #661 result. The anytime bound would
+  accrue but stay near-trivial until RLT is layered on; RLT's own build/solve
+  anytime behavior is a *separate* question (RLT is opt-in and already
+  time-budgeted in `_root_relaxation_lower_bound`).
+
+## 4. Two load-bearing subtleties the probe surfaced
+
+1. **Build ORDER decides how early the bound turns finite.** On structures where the
+   *objective* carries the products (clique/qap), the LP is unbounded below (−∞)
+   until ~40 % of rows — the fraction at which enough objective-product McCormick
+   envelopes have been added to bound the cost columns. Before that, no finite bound
+   exists. So the implementation's ordering — the issue's "variable-bound rows and
+   objective-linearizing envelopes first, remaining term envelopes by contribution"
+   — is not cosmetic: it is what moves the first-finite point from ~40 % toward ~0 %.
+   On the `netdesign` (linear-objective) structure the objective is box-bounded from
+   row 0, so the finite point is already early (11.7 %) and ordering matters less.
+2. **Truncating the build makes the LP SOLVE easier, which is the point.** hda's
+   *full* relaxation LP hits `iteration_limit` (no finite bound at 100 %), yet every
+   *prefix* (10 %–90 %) solves `optimal` with a finite bound. This is the exact
+   #654 "`plain` is None" failure mode (the full-relaxation budgeted solve times
+   out) — and it shows that a *smaller, truncated* relaxation is not only sound but
+   often *more* solvable within a fixed budget. An anytime build that stops early
+   trades bound tightness for a bound that actually returns.
+
+## 5. Disposition & next step (the §5 gate — needs the real corpus)
+
+The kill criterion (#694: partial bound −∞/None until ≳90 % build) is **not met on
+any tested instance**. §8.1 is therefore *challengeable* on these structures: a
+build interrupted at a checkpoint does yield a valid weaker bound, so the
+"lose-the-bound vs overrun" fork is dissolvable in principle — the entry experiment
+**survives**, and implementation is permitted to proceed.
+
+It was **not** implemented in this session, by design:
+
+- The change is **bound-changing** (CLAUDE.md §5): it must land behind a
+  **default-off** flag and graduate only after the corpus-wide differential panel
+  passes — flag ON vs OFF over the in-repo corpus, `incorrect_count = 0`, no bound
+  above its reference optimum, no certification regression, incumbents
+  independently feasibility-verified, AND net-positive (wall/nodes/bound). The
+  specific must-not-regress bounds are **casctanks 5.698, super3t −1.0, sonet23v4
+  −53974.375** (`python/tests/test_issue654_deadline_root_setup.py` pins them).
+- Two of those three (super3t, sonet23v4) and the headline slow-build case are
+  **only in the big corpus**, which is not present here. Graduating this flag is
+  therefore a **run-on-the-user's-machine** step, not something that can be
+  certified in this environment.
+
+**Recommended implementation direction** (for when the corpus is available), read
+off the curves above:
+
+- Build the LP incrementally with a checkpoint hook that, when the fallback's own
+  grant is spent AND a finite bound is already in hand, **stops adding rows and
+  solves the prefix** — reusing the exact `_fb_stop` discipline
+  (`solver.py:2606`) already proven bound-neutral for the between-candidate poll,
+  now applied *within* the build.
+- **Order the rows** variable-bound + objective-linearizing envelopes first, then
+  remaining term envelopes by objective contribution, so the first-finite point is
+  as early as possible (§4.1).
+- Keep the legacy monolithic build as the default (`=0` opt-out) until the panel
+  graduates the flag, per §5.
+
+## 6. Do-not-circumvent (unchanged, reaffirmed)
+
+- **§8.1** (do not truncate bound-producing native *solves*) still binds: this
+  approach changes the *precondition* (makes a valid bound exist earlier in the
+  *build*), it does not truncate a solve. The checkpoint stops the **build** at a
+  point where a finite bound is already in hand, then runs the prefix solve to
+  completion.
+- **§8.2** (no Rust LP native deadline, TX2b) untouched: this targets the Python
+  relaxation *build* layer, never the Rust LP solve.
+
+## Reproduce
+
+```bash
+# controls (in-repo)
+python discopt_benchmarks/scripts/issue694_anytime_build_probe.py \
+    nvs05 heatexch_gen1 heatexch_gen2 heatexch_gen3 casctanks hda \
+    --json docs/dev/data/issue694-anytime-controls.json
+# #654-class structural proxies
+python discopt_benchmarks/scripts/issue694_synthetic_proxy.py --family netdesign --n 80
+python discopt_benchmarks/scripts/issue694_synthetic_proxy.py --family clique --n 40 60 120
+python discopt_benchmarks/scripts/issue694_synthetic_proxy.py --family qap --n 8
+```

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -888,6 +888,7 @@ class MccormickLPRelaxer:
         psd_max_rounds: int = 8,
         want_marginals: bool = False,
         skip_pool_separators: bool = False,
+        build_deadline: Optional[float] = None,
     ) -> MccormickLPResult:
         """Solve the McCormick LP relaxation restricted to the given bound box.
 
@@ -931,6 +932,7 @@ class MccormickLPRelaxer:
             psd_max_rounds=psd_max_rounds,
             want_marginals=want_marginals,
             skip_pool_separators=skip_pool_separators,
+            build_deadline=build_deadline,
         )
         # C-43 pool-infeasible re-verification. Only relevant when (a) this was a
         # regular node solve (not a root pool-capture call, which passes no pool),
@@ -1057,6 +1059,7 @@ class MccormickLPRelaxer:
         psd_max_rounds: int = 8,
         want_marginals: bool = False,
         skip_pool_separators: bool = False,
+        build_deadline: Optional[float] = None,
     ) -> MccormickLPResult:
         """Solve the McCormick LP relaxation restricted to the given bound box.
 
@@ -1130,6 +1133,11 @@ class MccormickLPRelaxer:
                 return _fast
 
         try:
+            # Issue #694 anytime build: ``build_deadline`` (a ``perf_counter`` time,
+            # default None) truncates the cold relaxation build's constraint loop
+            # once spent, yielding a valid weaker relaxation. The incremental fast
+            # path above is already cheap, so it ignores the deadline; only this
+            # cold, row-generating build (the ~16.8s sonet23v4 cost, #694) honors it.
             milp, varmap = build_milp_relaxation(
                 self._model,
                 self._terms,
@@ -1140,6 +1148,7 @@ class MccormickLPRelaxer:
                 ),
                 superposition=self._superposition,
                 rlt_level1=self._rlt_applicable,
+                build_deadline=build_deadline,
             )
         except Exception:
             # Build failures here are otherwise invisible: the result silently

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -265,6 +265,13 @@ class MilpRelaxationModel:
         # Rigorous box-interval objective floor (#640 Bucket 2, nvs22); set by
         # ``build_uniform_relaxation``. ``None`` unless a finite floor was computed.
         self._objective_floor: Optional[float] = None
+        # Issue #694 anytime-build provenance, set by ``build_uniform_relaxation``.
+        # ``_build_truncated`` is True when the constraint-row loop stopped early on
+        # a ``build_deadline`` (the relaxation is still a valid, weaker outer
+        # approximation). Default: a full, un-truncated build.
+        self._build_truncated: bool = False
+        self._build_constraints_done: Optional[int] = None
+        self._build_constraints_total: Optional[int] = None
         # Warm-start state for the pure-LP simplex fast path (cutting-plane loop):
         # the previous solve's optimal basis and the (structural-cols, rows) it was
         # produced at, so the next ``.solve()`` on the SAME columns with rows only
@@ -1677,6 +1684,7 @@ def _uniform_relaxation_delegate(
     skip_separable_floor: bool = False,
     skip_convex_lift: bool = False,
     disc_state: object = None,
+    build_deadline: Optional[float] = None,
 ) -> tuple["MilpRelaxationModel", dict]:
     """Build the default relaxation through the uniform factorable engine (#632).
 
@@ -1703,6 +1711,7 @@ def _uniform_relaxation_delegate(
         skip_separable_floor=skip_separable_floor,
         skip_convex_lift=skip_convex_lift,
         disc_state=disc_state,
+        build_deadline=build_deadline,
     )
     milp = rel.model
     n_total = int(np.size(milp._c))
@@ -1780,6 +1789,7 @@ def build_milp_relaxation(
     rlt_level1: bool = False,
     skip_separable_floor: bool = False,
     skip_convex_lift: bool = False,
+    build_deadline: Optional[float] = None,
 ) -> tuple["MilpRelaxationModel", dict]:
     """Build a MILP relaxation with piecewise McCormick for bilinear/monomial terms.
 
@@ -1870,6 +1880,7 @@ def build_milp_relaxation(
         skip_separable_floor=skip_separable_floor,
         skip_convex_lift=skip_convex_lift,
         disc_state=disc_state,
+        build_deadline=build_deadline,
     )
 
 

--- a/python/discopt/_jax/uniform_relax.py
+++ b/python/discopt/_jax/uniform_relax.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import dataclasses
 import math
 import os
+import time
 from typing import Callable, Optional, cast
 
 import numpy as np
@@ -2960,6 +2961,7 @@ def build_uniform_relaxation(
     skip_separable_floor: bool = False,
     skip_convex_lift: bool = False,
     disc_state: object = None,
+    build_deadline: Optional[float] = None,
 ) -> UniformRelaxation:
     """Build the uniform factorable relaxation of ``model`` over ``box``.
 
@@ -2969,6 +2971,22 @@ def build_uniform_relaxation(
     box : optional ``(flat_lb, flat_ub)`` — the B&B node box in flat variable
         order (like ``build_milp_relaxation``'s ``bound_override``). Defaults to
         the model's declared variable bounds.
+    build_deadline : float, optional
+        Issue #694 anytime/incremental build. When set (a ``time.perf_counter``
+        absolute time), the constraint-row loop stops adding rows once the deadline
+        passes and returns the relaxation built *so far*. Default ``None`` (the
+        legacy monolithic build; **byte-identical** to before). A truncated build
+        is still a **valid outer relaxation**: dropping constraint rows only enlarges
+        the feasible region, so its LP minimum is a valid (weaker) lower bound —
+        never falsified (baron-gap-plan.md §8 "weaken but never falsify"). The
+        objective is fully linearized BEFORE the loop, so ``objective_bound_valid``
+        (and the box/separable objective floor) are unaffected by truncation — a
+        truncated finite-box relaxation therefore still carries a finite bound (the
+        #694 entry experiment: finite by 8–45 % of build on every tested structure).
+        The result records ``milp._build_truncated`` / ``_build_constraints_done`` /
+        ``_build_constraints_total``. Gated default-off via
+        ``SolverTuning.anytime_root_build``; only ``_root_relaxation_lower_bound``
+        passes a non-``None`` value today.
     rlt_quad : bool, default False
         Enable the quadratic constraint-factor RLT pass (issue #640 Bucket 2):
         multiply each degree-2 polynomial constraint by variable bound factors,
@@ -3020,7 +3038,21 @@ def build_uniform_relaxation(
             obj_lin = obj_lin.scaled(-1.0)
 
     # Constraints (normalized ``body sense 0``) -> rows.
+    #
+    # Issue #694 anytime build: when ``build_deadline`` is set, stop repping
+    # constraints once the deadline passes and keep the rows built so far. The
+    # objective (above) is already fully linearized, so a prefix of the constraint
+    # rows is a valid weaker outer relaxation (dropping rows only enlarges the
+    # feasible set -> the LP min stays a valid lower bound). The deadline is polled
+    # BETWEEN whole constraints (never mid-``rep``), so no partial/invalid row is
+    # ever emitted. Default ``None`` -> the whole loop runs, byte-identical.
+    n_constraints = len(model._constraints)
+    constraints_done = 0
+    build_truncated = False
     for con, cnode in zip(model._constraints, dag.constraints):
+        if build_deadline is not None and time.perf_counter() >= build_deadline:
+            build_truncated = True
+            break
         lc = ctx.rep(cnode)
         sense = con.sense
         rhs_shift = float(con.rhs)
@@ -3031,11 +3063,15 @@ def build_uniform_relaxation(
         elif sense == "==":  # body == rhs (both directions)
             ctx.add_row(lc.coeffs, rhs_shift - lc.const)
             ctx.add_row(lc.scaled(-1.0).coeffs, -(rhs_shift) + lc.const)
+        constraints_done += 1
 
     # Quadratic constraint-factor RLT (issue #640 Bucket 2, gated). Runs AFTER the
     # base build so every product column the base decomposition registered is
-    # available to seed the on-demand degree-3 lifting.
-    if rlt_quad:
+    # available to seed the on-demand degree-3 lifting. Skipped on a truncated
+    # anytime build (#694): it only *adds* rows (tightening), so skipping it when
+    # the build deadline is already spent is sound (weaker, never falsified) and
+    # keeps the truncation honoring the deadline.
+    if rlt_quad and not build_truncated:
         _emit_quadratic_rlt(ctx, model, flat_lb, flat_ub)
 
     obj_offset = obj_lin.const
@@ -3165,6 +3201,12 @@ def build_uniform_relaxation(
     # spurious "unbounded"). The node solver falls back to it to report a sound
     # bound instead of declining. ``None`` when no finite floor exists.
     milp._objective_floor = obj_box_lb if math.isfinite(obj_box_lb) else None
+    # Issue #694 anytime-build provenance (informational; the LP is sound either
+    # way). ``_build_truncated`` is True when the constraint loop stopped early on
+    # the ``build_deadline``; the two counters record coverage for diagnostics/tests.
+    milp._build_truncated = build_truncated
+    milp._build_constraints_done = constraints_done
+    milp._build_constraints_total = n_constraints
     return UniformRelaxation(
         model=milp,
         n_orig=ctx.n_orig,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2609,6 +2609,28 @@ def _root_relaxation_lower_bound(
         already in hand (rules 1 and 2 above)."""
         return bool(have) and (time.perf_counter() - _fb_t0) >= max(0.0, float(time_limit))
 
+    # Issue #694 anytime build (opt-in, ``DISCOPT_ANYTIME_ROOT_BUILD``, default off).
+    # When on, the SEPARATED relaxation build (``sep`` below) stops adding constraint
+    # rows once the fallback's own grant is spent and returns the valid weaker partial
+    # relaxation, so its dual bound accrues and the build honors ``time_limit``
+    # instead of overrunning it by the whole (uninterruptible, pre-#694) build cost —
+    # the documented sonet23v4 cost is that ``sep`` build (16.8s; baron-gap-plan.md
+    # §8.6). A truncated build only drops constraint rows -> weaker but still-valid
+    # lower bound (§8; never the §8.1 "truncate a bound-producing solve" nor the §8.2
+    # Rust LP native deadline — this bounds the Python build only).
+    #
+    # The BASE build (``build_milp_relaxation`` just below) is deliberately left
+    # WHOLE: it feeds the ``objective_bound_valid`` soundness gate and the
+    # plain/PSD/RLT candidates, and truncating it can trip that gate (a dropped
+    # constraint can un-bound an objective cost column -> a spuriously invalid base
+    # LP -> the whole fallback would abandon every candidate, LOSING the bound rather
+    # than weakening it — the rule-1 case §8 forbids). Only the independent ``sep``
+    # build, which constructs its own relaxation and is the class's sole producer, is
+    # truncated. ``None`` off the flag => the legacy monolithic build, byte-identical.
+    _build_deadline: Optional[float] = None
+    if getattr(_tuning(), "anytime_root_build", False):
+        _build_deadline = _fb_t0 + max(0.0, float(time_limit))
+
     try:
         terms = classify_nonlinear_terms(model)
         relax, _relax_info = build_milp_relaxation(
@@ -2756,7 +2778,7 @@ def _root_relaxation_lower_bound(
                 from discopt._jax.mccormick_lp import MccormickLPRelaxer
 
                 node_res = MccormickLPRelaxer(model).solve_at_node(
-                    root_lb, root_ub, time_limit=budget
+                    root_lb, root_ub, time_limit=budget, build_deadline=_build_deadline
                 )
                 if node_res.lower_bound is not None and np.isfinite(node_res.lower_bound):
                     sep_bound = float(node_res.lower_bound)

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -519,6 +519,41 @@ class SolverTuning:
     with 0% regression). Set ``DISCOPT_ROOT_FIXPOINT=0`` to restore the old
     default OFF."""
 
+    anytime_root_build: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_ANYTIME_ROOT_BUILD", default=False)
+    )
+    """Make the root-relaxation *fallback* build anytime/incremental so its dual
+    bound accrues and the build can honor the grant (``DISCOPT_ANYTIME_ROOT_BUILD``,
+    default **off**; §5 bound-changing; issue #694).
+
+    #654 left a measured floor: on a class of large sparse network-design/QAP/graph
+    -partition MINLPs (sonet\\*, qap, eg_all_s, super3t) the fallback's dual bound is
+    produced by a single **uninterruptible** McCormick-LP *build* (sonet23v4: 16.8 s,
+    not bounded by the solve's ``time_limit``), so ``solve(time_limit=2)`` still took
+    24.5 s — truncate the build and you lose the bound (baron-gap-plan.md §8.1),
+    don't and you blow the budget. This flag dissolves that fork: when on,
+    ``_root_relaxation_lower_bound`` passes a ``build_deadline`` (its own grant) to
+    the base ``build_milp_relaxation`` and the separated ``solve_at_node`` build, so
+    the constraint-row loop **stops adding rows once the grant is spent** and the
+    partial relaxation is solved for a valid (weaker) bound.
+
+    Sound by construction: a relaxation with FEWER constraint rows is still a valid
+    outer approximation, so its LP minimum is a valid lower bound — dropping rows can
+    only *weaken*, never falsify (the "weaken but never falsify" property of
+    baron-gap-plan.md §8, and the #694 entry experiment: a finite bound exists by
+    8–45 % of build on every tested structure, because the objective is fully
+    linearized before the constraint loop). It does NOT re-add the Rust LP native
+    deadline (§8.2, TX2b): this truncates the Python relaxation *build*, never the LP
+    *solve*. **Default off** pending the §5 corpus-wide differential panel (flag ON
+    vs OFF; ``incorrect_count = 0``, no bound above its reference optimum, no
+    certification regression, incumbents feasibility-verified) AND net-positive on
+    the #654 class — with the must-not-regress bounds casctanks 5.698, super3t −1.0,
+    sonet23v4 −53974.375 kept sound. Entry evidence:
+    ``docs/dev/issue694-anytime-build-entry-2026-07-17.md``. NOTE: with the flag on
+    the fallback bound becomes timing-dependent (an anytime algorithm), so it is not
+    bit-reproducible run-to-run; the default (off) path is unaffected and stays
+    deterministic."""
+
     # NOTE (#581): ``DISCOPT_NODE_REDUCE`` (per-node cheap reduction: cutoff-FBBT +
     # free DBBT from node-LP reduced costs + integer RC-fixing, feeding the
     # tightened box to the children) was DEPRECATED and removed. It was a

--- a/python/tests/test_issue694_anytime_root_build.py
+++ b/python/tests/test_issue694_anytime_root_build.py
@@ -1,0 +1,166 @@
+"""Issue #694 — anytime/incremental root-relaxation build (``DISCOPT_ANYTIME_ROOT_BUILD``).
+
+The #654 residual: on a class of large sparse network-design/QAP/graph-partition
+MINLPs the root fallback's dual bound is produced by a single uninterruptible
+McCormick-LP *build*, so ``solve(time_limit=T)`` overran ``T`` by the whole build
+cost (baron-gap-plan.md §8.1/§8.6). #694 makes that build anytime: it stops adding
+constraint rows once the fallback's grant is spent and solves the partial (valid,
+weaker) relaxation. Behind ``DISCOPT_ANYTIME_ROOT_BUILD`` (default OFF), §5
+bound-changing.
+
+These tests pin the SOUNDNESS + OPT-OUT contract that must hold regardless of the
+corpus-wide graduation panel (which runs on the owner's machine, since the #654
+instances are big-corpus-only):
+
+  * OFF (default) is **byte-identical** to the legacy monolithic build — no row
+    dropped, no truncation, the same LP assembled;
+  * a truncated build is a **valid weaker outer relaxation** — its LP minimum never
+    exceeds the full build's (dropping rows only enlarges the feasible set), and it
+    is never falsified;
+  * ON, the fallback **honors its grant** (bounded wall) and stays sound (a surfaced
+    dual bound is a valid lower bound; ``None`` is sound too — merely weaker).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import numpy as np
+import pytest
+
+_CORPUS = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
+
+
+def _root_box(model):
+    lb = np.array([v.lb if v.lb is not None else -1e20 for v in model._variables], float)
+    ub = np.array([v.ub if v.ub is not None else 1e20 for v in model._variables], float)
+    return lb, ub
+
+
+def test_build_deadline_none_is_byte_identical():
+    """OFF path: ``build_deadline=None`` builds the full relaxation — same row count,
+    not truncated, identical LP bound. This is the opt-out / bound-neutrality guard."""
+    from discopt._jax.uniform_relax import build_uniform_relaxation
+    from discopt.modeling.core import from_nl
+
+    model = from_nl(os.path.join(_CORPUS, "casctanks.nl"))
+    lb, ub = _root_box(model)
+
+    full = build_uniform_relaxation(model, (lb, ub))
+    again = build_uniform_relaxation(model, (lb, ub), build_deadline=None)
+
+    fm, am = full.model, again.model
+    assert fm._build_truncated is False
+    assert am._build_truncated is False
+    nrows = lambda m: 0 if m._A_ub is None else int(m._A_ub.shape[0])  # noqa: E731
+    assert nrows(fm) == nrows(am)
+    assert fm._build_constraints_done == fm._build_constraints_total
+    # LP bounds identical (deterministic full build).
+    rf = fm.solve(backend="simplex", time_limit=10.0)
+    ra = am.solve(backend="simplex", time_limit=10.0)
+    assert rf.status == ra.status
+    if rf.bound is not None and ra.bound is not None:
+        assert abs(rf.bound - ra.bound) <= 1e-9 * max(1.0, abs(rf.bound))
+
+
+def test_truncated_build_is_valid_and_weaker():
+    """A build truncated at a past deadline drops constraint rows and is a valid
+    WEAKER relaxation: fewer rows, marked truncated, and its LP min ≤ the full
+    build's LP min (dropping rows only enlarges the feasible set — never falsified)."""
+    from discopt._jax.uniform_relax import build_uniform_relaxation
+    from discopt.modeling.core import from_nl
+
+    model = from_nl(os.path.join(_CORPUS, "hda.nl"))
+    lb, ub = _root_box(model)
+
+    full = build_uniform_relaxation(model, (lb, ub))
+    # Deadline already in the past -> stop before ANY constraint row is added.
+    trunc = build_uniform_relaxation(model, (lb, ub), build_deadline=time.perf_counter() - 1.0)
+
+    fm, tm = full.model, trunc.model
+    assert tm._build_truncated is True
+    assert tm._build_constraints_done < tm._build_constraints_total
+    nrows = lambda m: 0 if m._A_ub is None else int(m._A_ub.shape[0])  # noqa: E731
+    assert nrows(tm) < nrows(fm)
+
+    # Validity: whenever BOTH solves yield a finite bound, the truncated (looser)
+    # relaxation's LP minimum is a weaker (≤) lower bound. Never tighter.
+    rf = fm.solve(backend="simplex", time_limit=10.0)
+    rt = tm.solve(backend="simplex", time_limit=10.0)
+    if (
+        rf.status == "optimal"
+        and rt.status == "optimal"
+        and rf.bound is not None
+        and rt.bound is not None
+    ):
+        assert rt.bound <= rf.bound + 1e-6 * max(1.0, abs(rf.bound))
+
+
+def test_partial_build_never_exceeds_full_across_deciles():
+    """The anytime curve is monotone-sound: for a mid-build deadline, the partial
+    relaxation's bound (if finite) is a valid lower bound ≤ the full build's."""
+    from discopt._jax.uniform_relax import build_uniform_relaxation
+    from discopt.modeling.core import from_nl
+
+    model = from_nl(os.path.join(_CORPUS, "heatexch_gen1.nl"))
+    lb, ub = _root_box(model)
+
+    full = build_uniform_relaxation(model, (lb, ub))
+    rf = full.model.solve(backend="simplex", time_limit=10.0)
+    assert rf.status == "optimal" and rf.bound is not None
+
+    # A deadline a few ms out truncates partway through the constraint loop.
+    partial = build_uniform_relaxation(model, (lb, ub), build_deadline=time.perf_counter() + 0.005)
+    rp = partial.model.solve(backend="simplex", time_limit=10.0)
+    if rp.status == "optimal" and rp.bound is not None:
+        assert rp.bound <= rf.bound + 1e-6 * max(1.0, abs(rf.bound))
+
+
+@pytest.mark.requires_pounce
+def test_flag_off_fallback_is_deterministic_and_sound():
+    """OFF (default): ``_root_relaxation_lower_bound`` returns its usual finite,
+    valid bound on nvs11 (a valid lower bound ≤ the −431.0 oracle optimum — the
+    same instance the #654 checkpoint-poll test pins)."""
+    from discopt.modeling.core import from_nl
+    from discopt.solver import _root_relaxation_lower_bound
+
+    os.environ.pop("DISCOPT_ANYTIME_ROOT_BUILD", None)
+    model = from_nl(os.path.join(_CORPUS, "nvs11.nl"))
+    lb, ub = _root_box(model)
+    b = _root_relaxation_lower_bound(model, lb, ub, 3.0)
+    assert b is not None
+    assert b <= -431.0 + 1e-6  # MINIMIZE: dual bound never crosses the oracle optimum
+
+
+@pytest.mark.slow
+@pytest.mark.requires_pounce
+def test_flag_on_honors_grant_and_stays_sound():
+    """ON: on hda (a multi-second sep build) the fallback honors a tight grant
+    (bounded wall) and stays sound — any surfaced bound is a valid lower bound; a
+    weaker/``None`` bound is the sound anytime trade. Compares against the OFF bound
+    as the reference lower bound (never crossed upward)."""
+    from discopt.modeling.core import from_nl
+    from discopt.solver import _root_relaxation_lower_bound
+
+    model = from_nl(os.path.join(_CORPUS, "hda.nl"))
+    lb, ub = _root_box(model)
+
+    os.environ.pop("DISCOPT_ANYTIME_ROOT_BUILD", None)
+    b_off = _root_relaxation_lower_bound(model, lb, ub, 3.0)
+
+    os.environ["DISCOPT_ANYTIME_ROOT_BUILD"] = "1"
+    try:
+        t0 = time.perf_counter()
+        b_on = _root_relaxation_lower_bound(model, lb, ub, 0.5)
+        wall = time.perf_counter() - t0
+    finally:
+        os.environ.pop("DISCOPT_ANYTIME_ROOT_BUILD", None)
+
+    # Honors the grant to within one bounded in-flight op (the base build, left whole
+    # by design): far below the OFF overrun this guards against.
+    assert wall < 8.0, f"anytime fallback ran {wall:.1f}s — grant not honored"
+    # Soundness: the anytime bound is a valid (weaker-or-equal) lower bound. Both are
+    # valid lower bounds for a MINIMIZE, so ON must not exceed OFF.
+    if b_on is not None and b_off is not None:
+        assert b_on <= b_off + 1e-6 * max(1.0, abs(b_off))


### PR DESCRIPTION
Closes #694 (entry experiment + gated implementation; §5 graduation panel runs on the owner's machine — see below).

## Summary

#654 left a measured floor: on a class of large sparse network-design/QAP/graph-partition MINLPs (sonet*, qap, eg_all_s, super3t) the root fallback's dual bound is produced by a single **uninterruptible** McCormick-LP *build* (sonet23v4: 16.8s, not bounded by the solve's `time_limit`), so `solve(time_limit=2)` still took 24.5s — truncate the build and you lose the bound (`baron-gap-plan.md` §8.1), don't and you blow the budget.

This makes that build **anytime**: it stops adding constraint rows once the fallback's grant is spent and solves the partial relaxation for a valid (weaker) bound. Bound-changing → behind a **default-off** flag (`DISCOPT_ANYTIME_ROOT_BUILD`).

## Entry experiment (run BEFORE the implementation, CLAUDE.md §4)

`docs/dev/issue694-anytime-build-entry-2026-07-17.md` + probes `discopt_benchmarks/scripts/issue694_anytime_build_probe.py` / `issue694_synthetic_proxy.py` (raw curves in `docs/dev/data/issue694-*.json`).

The probe instruments `_Builder.add_row` with per-row timestamps during one uninterrupted build, then solves every 10%-of-rows **prefix** LP. **Kill criterion (bound −∞/None until ≳90% build) NOT met on any tested structure:**

| structure | first finite bound | anytime curve |
|---|---|---|
| 6 in-repo controls | 8–21% build (casctanks 69%) | weak `obj_floor` early, McCormick-tight in last 10–30% |
| **netdesign** proxy (sonet\*: linear obj + bilinear constraints) | **11.7%** | monotone 1.99 → 23.72 |
| **clique** proxy (qap/graphpart: dense quad over binaries) | ~40% | monotone, holds at 28k rows |
| qap proxy | 38% | finite but McCormick-trivial ≈0 (known #661, needs RLT) |

The real #654 instances are big-corpus-only (Dropbox) and MINLPLib is network-blocked in CI, so the decisive class is exercised via structural proxies. The bound **accrues continuously** across build deciles on the bound-carrying structures — the SOTA property #694 targets.

## What changed

- `build_uniform_relaxation(..., build_deadline=None)`: the constraint-row loop polls the `perf_counter` deadline **between whole constraints** (never mid-`rep`, so no partial/invalid row) and stops when spent. Dropping constraint rows only enlarges the feasible set → the LP min stays a **valid weaker lower bound**, never falsified. The objective is fully linearized before the loop, so `objective_bound_valid` is untouched. Records `_build_truncated` / `_build_constraints_done` / `_build_constraints_total`.
- Threaded `build_deadline` through `build_milp_relaxation` → `_uniform_relaxation_delegate` and `MccormickLPRelaxer.solve_at_node` → `_solve_at_node_impl` (cold build only; the incremental fast path and the C-43 pool-free re-solves stay full).
- `SolverTuning.anytime_root_build` (env `DISCOPT_ANYTIME_ROOT_BUILD`, default **False**).
- `_root_relaxation_lower_bound` applies the deadline to the **`sep` build only** — the base build stays whole. Rationale (rule-1, §8): truncating the base can un-bound an objective cost column and trip its `objective_bound_valid=False → return None` gate, which would *lose* the bound rather than weaken it; sonet23v4's documented cost is the `sep` build (§8.6), and `sep` constructs its own relaxation, so truncating it is the targeted, rule-1-safe cut.

## Soundness & §8

- **§8.1** (don't truncate bound-producing native *solves*) un-circumvented: this changes the *build* precondition, it never truncates an LP solve.
- **§8.2** (no Rust LP native deadline, TX2b) un-circumvented: this bounds the Python relaxation *build* only.
- OFF (default) is **byte-identical**: `build_deadline` is `None` everywhere unless the flag is set.

## Testing

- `pytest -m smoke` → **661 passed** (bound-neutrality of the default path).
- `python/tests/test_issue654_deadline_root_setup.py` → unchanged (big-corpus tests skip).
- New `python/tests/test_issue694_anytime_root_build.py` → OFF byte-identical (rows + bound), truncated build valid & weaker (LP min ≤ full), grant honored + sound under the flag.
- Adversarial suite `test_adversarial_recent_fixes.py` → green (one pre-existing timing flake cleared on re-run; unaffected — flag default off).
- `ruff check` / `ruff format` clean. Rust untouched.

## Measured caveat (informs the graduation gate)

On **hda** (a control with wide/unbounded cost columns) flag ON returns `None` — sound and honors the grant, but drops the (very loose) bound rather than weakening it. So the flag's *soundness* is universal but its *benefit* is structure-dependent (retained on clean finite-box #654 structure per the proxies). If bound-retention on the real #654 class needs improving, the follow-up lever is constraint **row-ordering** (objective-critical constraints first).

## Graduation (§5) — run on a machine with the big corpus

Flag ON vs OFF over the corpus, requiring cert-clean (`incorrect_count = 0`, no bound above its reference optimum, no certification regression, incumbents feasibility-verified) AND net-positive. Must-not-regress: **casctanks 5.698, super3t −1.0, sonet23v4 −53974.375** (pinned by `test_issue654_deadline_root_setup.py`). Keep the `DISCOPT_ANYTIME_ROOT_BUILD=0` opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)