### PR TITLE
perf(obbt): #208 graduate reverse-FBBT aux cascade default-ON (budgeted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@ The release procedure that produces these entries is documented in
   `DISCOPT_CONTINUOUS_MULTISTART=0` / `SolverTuning.continuous_multistart=False`
   restores the prior behavior.
 
+### Changed
+
+- **OBBT-on-auxiliaries reverse-FBBT cascade graduated default-ON** (`perf`, #208).
+  The root branch-and-reduce fixpoint now propagates OBBT-tightened auxiliary
+  (product/ratio) column bounds back onto the original variables through the
+  nonlinear term definitions — the hyperbolic/root bounds the linear McCormick rows
+  cannot express (`w=a·b ⟹ a∈[w]/[b]`, `w=aᵖ ⟹` p-th-root box, plus the
+  trilinear/multilinear and ratio-of-products generalizations). The extra aux
+  min/max LPs are budgeted to the reverse-FBBT-*reachable* columns
+  (`obbt.cascade_reachable_aux`), which is bound-neutral vs a blanket cascade but
+  drops ~87% of the aux probes, and the cascade runs root-only (no per-node cost).
+  Graduation gate (`design/ab_cascade_aux.py`, 65-instance corpus, fair 30 s
+  budget): cert-clean — 0 differential soundness violations, 0 optimum mismatches,
+  0 cert regressions, +1 cert gain (`tls2` F→T) — and net-positive with 0
+  regression: node-neutral on the convergent integer-heavy majority (converged-only
+  2228 vs 2228) and helpful on the continuous spatial-branch class (`tspn08/10/12`
+  prune to 1 node, `heatexch_gen3` 208→31 s wall; all-instances node_count −2.5%).
+  An earlier too-tight 8 s A/B had read as net-negative; that was time-limited noise
+  (`fac2`/`cvxnonsep_nsig30` converge bit-identically at a fair budget).
+  `DISCOPT_OBBT_CASCADE_AUX=0` restores the prior default-OFF behavior.
+
 ## [0.6.0] - 2026-07-12
 
 ### Removed

--- a/design/ab_cascade_aux.py
+++ b/design/ab_cascade_aux.py
@@ -1,10 +1,13 @@
 """#208 A/B panel: OBBT aux-cascade OFF vs ON over the vendored corpus.
 
 The reverse-FBBT aux cascade (``obbt_tighten_root(cascade_aux=True)``) is sound by
-construction but ships default-OFF because it was measured *not* net-positive on
-the integer-heavy corpus. This harness drives it through the *real* solve path via
-the ``DISCOPT_OBBT_CASCADE_AUX`` env gate (default ``0``) and reports the flag ON
-vs OFF differential the issue's acceptance criteria ask for:
+construction and, with the reverse-FBBT-reachable candidate budget, **graduated
+default-ON** (``DISCOPT_OBBT_CASCADE_AUX``, default ``1``, ``=0`` to opt out): this
+harness at a fair 30 s budget returned cert-clean and net-positive with 0
+regression (see #208). Run it at the too-tight 8 s budget (``AB_TL=8``) to
+reproduce the earlier time-limited-noise verdict. It drives the flag through the
+*real* solve path via the ``DISCOPT_OBBT_CASCADE_AUX`` env gate and reports the
+flag ON vs OFF differential the issue's acceptance criteria ask for:
 
   * **net-positive?** total node_count / wall, and per-instance node deltas;
   * **cert-clean?** ON vs the trusted OFF path (CLAUDE.md §5 bound-changing

--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -1888,10 +1888,15 @@ def obbt_tighten_root(
         **budgeted** (:func:`cascade_reachable_aux`): only aux columns whose
         reverse-FBBT can reach an original variable at the current box are probed,
         which is bound-neutral vs probing every aux column but drops ~87% of the
-        aux LPs on the vendored corpus. **Opt-in (default off):** it is sound on the
-        corpus (every optimum preserved) and shrinks the root box on the continuous
-        spatial-branch instances that spatial branching bottlenecks; graduation to
-        default-on is gated on a net-positive A/B (see ``design/ab_cascade_aux.py``).
+        aux LPs on the vendored corpus. **Graduated default-ON** on the real solve
+        path (``DISCOPT_OBBT_CASCADE_AUX``, default ``1``, ``=0`` to opt out) per
+        #208: the graduation gate (``design/ab_cascade_aux.py``, 65-instance corpus
+        at a fair 30 s budget) returned cert-clean (0 differential soundness
+        violations, 0 optimum mismatches, 0 cert regressions, +1 gain: tls2 F→T) and
+        net-positive with 0 regression — node-neutral on the convergent integer-heavy
+        majority and helpful on the continuous spatial-branch class (tspn08/10/12 →
+        1 node, heatexch_gen3 208→31 s wall). ``cascade_aux=False`` here is only the
+        *function* default; the solve path passes the env-resolved value.
     top_k : int, optional
         Forwarded to :func:`run_obbt_on_relaxation` — probe only the ``top_k``
         highest ``width × |reduced cost|`` variables per sweep instead of all

--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -1884,13 +1884,14 @@ def obbt_tighten_root(
         hyperbolic/root bounds the linear McCormick rows cannot express, and is
         sound by construction (an OBBT aux bound is valid over the relaxation
         polytope, which outer-approximates the MINLP feasible set, and reverse
-        FBBT only removes term-infeasible points). **Opt-in (default off):** on
-        the vendored corpus it is sound (every optimum preserved) and measurably
-        shrinks the root box on several instances (e.g. nvs11/12/13: box
-        log-volume −4 nats), but it did **not** yield a net node-count / wall
-        reduction and slightly regressed one instance (nvs13 39→53 nodes), so it
-        does not meet #208's "the extra OBBT cost must pay for itself" bar yet. It
-        is kept available behind this flag for a future targeted-budget A/B.
+        FBBT only removes term-infeasible points). The extra aux min/max LPs are
+        **budgeted** (:func:`cascade_reachable_aux`): only aux columns whose
+        reverse-FBBT can reach an original variable at the current box are probed,
+        which is bound-neutral vs probing every aux column but drops ~87% of the
+        aux LPs on the vendored corpus. **Opt-in (default off):** it is sound on the
+        corpus (every optimum preserved) and shrinks the root box on the continuous
+        spatial-branch instances that spatial branching bottlenecks; graduation to
+        default-on is gated on a net-positive A/B (see ``design/ab_cascade_aux.py``).
     top_k : int, optional
         Forwarded to :func:`run_obbt_on_relaxation` — probe only the ``top_k``
         highest ``width × |reduced cost|`` variables per sweep instead of all
@@ -2062,9 +2063,18 @@ def obbt_tighten_root(
 
             # Include the aux columns as OBBT candidates (and request the full
             # column vector) when cascading, so their tightening is captured and
-            # carried instead of discarded.
+            # carried instead of discarded. Budget the extra probes (#208): only the
+            # aux columns whose reverse-FBBT can actually reach an original variable
+            # at the current box are candidates — probing the rest spends min/max LPs
+            # whose tightening can never cascade (bound-neutral to skip, ~87% of aux
+            # probes on the vendored corpus), which is what made the blanket cascade
+            # net-negative on integer-heavy instances.
             n_total = len(milp._bounds)
-            obbt_candidates = list(range(n_total)) if cascade_aux else None
+            if cascade_aux:
+                reach = cascade_reachable_aux(varmap, lb, ub, n_orig, n_total, eps=eps)
+                obbt_candidates = list(range(n_orig)) + reach
+            else:
+                obbt_candidates = None
             res = run_obbt_on_relaxation(
                 milp,
                 relaxer._n_orig,
@@ -2077,8 +2087,8 @@ def obbt_tighten_root(
                 prefer_pounce=prefer_pounce,
                 full_result=cascade_aux,
                 # T2.5: probe only the top-k width×|RC| candidates when requested.
-                # Not combined with the aux-cascade candidate set (all columns) —
-                # cascade is a diagnostic path with its own full-column contract.
+                # Not combined with the aux-cascade candidate set (originals + the
+                # reachable aux subset) — cascade has its own full-column contract.
                 top_k=None if cascade_aux else top_k,
             )
             total_lp_time += res.total_lp_time
@@ -2160,6 +2170,96 @@ def _interval_prod(intervals: list[tuple[float, float]]) -> Optional[tuple[float
             return None
         lo, hi = _interval_mul(lo, hi, a, b)
     return lo, hi
+
+
+def cascade_reachable_aux(
+    varmap: dict,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    n_orig: int,
+    n_total: int,
+    *,
+    eps: float = 1e-7,
+) -> list[int]:
+    """Aux columns whose :func:`reverse_fbbt_from_aux` *could* tighten an original.
+
+    The #208 aux cascade only ever shrinks the original box through
+    :func:`reverse_fbbt_from_aux` — carrying an aux bound back through the *linear*
+    McCormick rows is self-implied (the Part-1 no-op finding). So OBBT-probing an
+    aux column whose reverse-FBBT step is structurally incapable of reaching an
+    original variable (a bilinear/product partner interval that straddles zero, a
+    ratio divisor that straddles zero, …) spends min/max LPs whose result can never
+    cascade — pure wasted cost. On the vendored corpus that waste is ~87% of the aux
+    probes and is exactly what made the blanket cascade net-negative on
+    integer-heavy instances (extra LPs cost more than they save when nothing
+    cascades). Restricting the aux candidate set to this reachable subset is
+    **bound-neutral** vs probing all aux columns: every column that reverse-FBBT
+    could tighten from is retained (the predicate below is a *superset* of the
+    reverse-FBBT deduction guards — it only ever over-includes, never under-includes),
+    so the propagated original box is identical while the LP count drops sharply.
+
+    The predicate is evaluated at the *current* box, so an aux that only becomes
+    reachable after a partner's interval turns sign-definite in a later round
+    re-enters the candidate set on that round (obbt_tighten_root recomputes it per
+    sweep). Returns the sorted aux column indices (all ``>= n_orig``).
+    """
+
+    def _excl0(a: float, b: float) -> bool:
+        # Interval [a, b] excludes zero (strictly, to a tolerance).
+        return a > eps or b < -eps
+
+    def _prod_excl0(cols) -> bool:
+        # Interval product ``∏ [lb[c], ub[c]]`` excludes zero iff every factor does.
+        return all(_excl0(float(lb[c]), float(ub[c])) for c in cols)
+
+    reachable: set[int] = set()
+
+    def _is_aux(cw) -> bool:
+        return isinstance(cw, (int, np.integer)) and n_orig <= int(cw) < n_total
+
+    for (i, j), cw in varmap.get("bilinear", {}).items():
+        if not _is_aux(cw):
+            continue
+        # a = w / b needs 0 ∉ [b]; b = w / a needs 0 ∉ [a].
+        if (0 <= i < n_orig and _excl0(float(lb[j]), float(ub[j]))) or (
+            0 <= j < n_orig and _excl0(float(lb[i]), float(ub[i]))
+        ):
+            reachable.add(int(cw))
+
+    for (i, p), cw in varmap.get("monomial", {}).items():
+        # a**p (p>=2) always yields a p-th-root box on the original — no divisor.
+        if _is_aux(cw) and 0 <= i < n_orig and p >= 2:
+            reachable.add(int(cw))
+
+    for mapname in ("trilinear", "multilinear"):
+        for cols, cw in varmap.get(mapname, {}).items():
+            if not _is_aux(cw):
+                continue
+            cols = tuple(int(c) for c in cols)
+            for t, ct in enumerate(cols):
+                if 0 <= ct < n_orig and _prod_excl0([cols[s] for s in range(len(cols)) if s != t]):
+                    reachable.add(int(cw))
+                    break
+
+    for (num, den), cw in varmap.get("ratio", {}).items():
+        if not _is_aux(cw) or not num or not den:
+            continue
+        num = tuple(int(c) for c in num)
+        den = tuple(int(c) for c in den)
+        hit = False
+        for t, ca in enumerate(num):
+            if 0 <= ca < n_orig and _prod_excl0([num[s] for s in range(len(num)) if s != t]):
+                hit = True
+                break
+        if not hit:
+            for t, cb in enumerate(den):
+                if 0 <= cb < n_orig and _prod_excl0([den[s] for s in range(len(den)) if s != t]):
+                    hit = True
+                    break
+        if hit:
+            reachable.add(int(cw))
+
+    return sorted(reachable)
 
 
 def reverse_fbbt_from_aux(

--- a/python/discopt/_jax/root_reduce.py
+++ b/python/discopt/_jax/root_reduce.py
@@ -371,17 +371,26 @@ def _stage_obbt(
     Delegates to :func:`obbt_tighten_root`, which already runs a ≤``rounds`` internal
     reduce↔rebuild fixpoint, DBBT-first (one objective LP → reduced costs tighten all
     vars) then OBBT (2n min/max probes), all through the NS-safe vertex clamp. It is
-    tighten-only and returns the input box on any failure. ``cascade_aux`` stays off
-    by default (measured-dead on the integer-heavy corpus, §4/§14); it is exposed
-    behind ``DISCOPT_OBBT_CASCADE_AUX`` (default ``0``) purely so the #208 A/B panel
-    can drive the reverse-FBBT cascade through the real solve path without changing
-    the default behavior."""
+    tighten-only and returns the input box on any failure. ``cascade_aux`` (the #208
+    reverse-FBBT aux cascade) is ``DISCOPT_OBBT_CASCADE_AUX``, default **ON**
+    (GRADUATED per #208 under the one-successful-graduation-gate-run policy —
+    CLAUDE.md §5). The graduation gate (``design/ab_cascade_aux.py``, 65-instance
+    corpus at a fair 30 s budget) returned cert-clean (0 differential soundness
+    violations, 0 optimum mismatches, 0 cert regressions, +1 cert gain: tls2 F→T)
+    and net-positive with 0 regression: node-neutral on the convergent integer-heavy
+    majority (converged-only 2228 vs 2228) and helpful on the continuous
+    spatial-branch class (tspn08/10/12 prune to 1 node, heatexch_gen3 208→31 s wall),
+    all-instances node_count −2.5 %. The candidate set is budgeted to the
+    reverse-FBBT-reachable aux columns (:func:`obbt.cascade_reachable_aux`), so the
+    extra probes are ~87 % fewer than a blanket cascade and it runs root-only (no
+    per-node cost). Set ``DISCOPT_OBBT_CASCADE_AUX=0`` to restore the old default
+    OFF."""
     try:
         from discopt._jax.obbt import obbt_tighten_root
     except Exception:
         return lb, ub, False, 0
 
-    cascade_aux = os.environ.get("DISCOPT_OBBT_CASCADE_AUX", "0") != "0"
+    cascade_aux = os.environ.get("DISCOPT_OBBT_CASCADE_AUX", "1") != "0"
     try:
         res = obbt_tighten_root(
             model,

--- a/python/tests/test_obbt.py
+++ b/python/tests/test_obbt.py
@@ -861,6 +861,122 @@ class TestReverseFbbtFromAux:
 
 
 # ─────────────────────────────────────────────────────────────
+# #208 aux-cascade budget: only probe reverse-FBBT-reachable aux columns
+# ─────────────────────────────────────────────────────────────
+
+
+class TestCascadeReachableAux:
+    """`cascade_reachable_aux` selects exactly the aux columns whose reverse-FBBT
+    could tighten an original — a *superset* of the reverse-FBBT deduction guards,
+    so restricting the OBBT aux candidate set to it is bound-neutral (#208)."""
+
+    def test_bilinear_reachable_when_partner_sign_definite(self):
+        from discopt._jax.obbt import cascade_reachable_aux
+
+        # w = x*y, x in [0,10] straddles 0, y in [2,4] excludes 0. b=w/a needs
+        # 0 ∉ [x] (fails) but a=w/b needs 0 ∉ [y] (holds) -> aux reachable.
+        lb = np.array([0.0, 2.0])
+        ub = np.array([10.0, 4.0])
+        varmap = {"bilinear": {(0, 1): 2}}
+        assert cascade_reachable_aux(varmap, lb, ub, n_orig=2, n_total=3) == [2]
+
+    def test_bilinear_unreachable_when_both_straddle_zero(self):
+        from discopt._jax.obbt import cascade_reachable_aux
+
+        # Both partners straddle 0 -> neither division is defined -> not reachable.
+        lb = np.array([-5.0, -3.0])
+        ub = np.array([5.0, 3.0])
+        varmap = {"bilinear": {(0, 1): 2}}
+        assert cascade_reachable_aux(varmap, lb, ub, n_orig=2, n_total=3) == []
+
+    def test_monomial_always_reachable(self):
+        from discopt._jax.obbt import cascade_reachable_aux
+
+        # A p>=2 monomial deduces a root box with no divisor -> always reachable,
+        # even when the base straddles zero.
+        lb = np.array([-5.0])
+        ub = np.array([5.0])
+        varmap = {"monomial": {(0, 2): 1}}
+        assert cascade_reachable_aux(varmap, lb, ub, n_orig=1, n_total=2) == [1]
+
+    def test_ratio_reachable_only_when_a_factor_is_sign_definite(self):
+        from discopt._jax.obbt import cascade_reachable_aux
+
+        # w = x/y. Denominator y in [2,4] excludes 0 -> numerator factor x is
+        # reachable (x = w*y). Both original.
+        lb = np.array([0.0, 2.0])
+        ub = np.array([10.0, 4.0])
+        varmap = {"ratio": {((0,), (1,)): 2}}
+        assert cascade_reachable_aux(varmap, lb, ub, n_orig=2, n_total=3) == [2]
+
+    def test_reachable_set_is_bound_neutral_on_the_corpus_shape(self):
+        # The predicate must never *under*-include: any aux from which
+        # reverse_fbbt_from_aux actually tightens an original MUST be reachable.
+        # Cross-check on a randomized varmap of every term family.
+        from discopt._jax.obbt import cascade_reachable_aux, reverse_fbbt_from_aux
+
+        rng = np.random.default_rng(7)
+        for _ in range(300):
+            n_orig = 3
+            lb = np.array([rng.uniform(-3, 1) for _ in range(n_orig)])
+            ub = np.array([lb[k] + rng.uniform(0.5, 4) for k in range(n_orig)])
+            cw = n_orig  # single aux column
+            n_total = n_orig + 1
+            kind = rng.integers(0, 4)
+            if kind == 0:
+                varmap = {"bilinear": {(0, 1): cw}}
+            elif kind == 1:
+                varmap = {"monomial": {(0, int(rng.integers(2, 4))): cw}}
+            elif kind == 2:
+                varmap = {"trilinear": {(0, 1, 2): cw}}
+            else:
+                varmap = {"ratio": {((0,), (1,)): cw}}
+            wl, wu = sorted(rng.uniform(-10, 10, size=2))
+            aux_lb = np.append(np.zeros(n_orig), wl)
+            aux_ub = np.append(np.zeros(n_orig), wu)
+            reach = set(cascade_reachable_aux(varmap, lb, ub, n_orig, n_total))
+            tl, tu = lb.copy(), ub.copy()
+            n = reverse_fbbt_from_aux(tl, tu, aux_lb, aux_ub, varmap)
+            if n > 0:  # reverse-FBBT tightened -> the aux MUST have been reachable
+                assert cw in reach, (varmap, lb.tolist(), ub.tolist(), wl, wu)
+
+    def test_targeted_candidate_set_matches_full_on_original_box(self):
+        # End-to-end bound-neutrality: obbt_tighten_root(cascade_aux=True) with the
+        # budgeted candidate set must return the SAME original box as it would with
+        # every aux column probed. We assert the shipped (budgeted) path equals a
+        # patched full-probe path on a mixed bilinear+monomial model.
+        import discopt._jax.obbt as obbt_mod
+
+        m = Model("mix")
+        m.continuous("x", lb=0.5, ub=4.0)
+        m.continuous("y", lb=1.0, ub=3.0)
+        x, y = m._variables[0], m._variables[1]
+        m.minimize(x + y)
+        m.subject_to(x * y >= 3.0)
+        m.subject_to(x * x <= 9.0)
+        lb = np.array([0.5, 1.0])
+        ub = np.array([4.0, 3.0])
+
+        budgeted = obbt_tighten_root(m, lb.copy(), ub.copy(), cascade_aux=True)
+
+        # Force the full-probe behavior by making the reachability predicate return
+        # every aux column, then confirm the propagated original box is identical.
+        orig = obbt_mod.cascade_reachable_aux
+
+        def _all_aux(varmap, lo, hi, n_orig, n_total, eps=1e-7):
+            return list(range(n_orig, n_total))
+
+        obbt_mod.cascade_reachable_aux = _all_aux
+        try:
+            full = obbt_tighten_root(m, lb.copy(), ub.copy(), cascade_aux=True)
+        finally:
+            obbt_mod.cascade_reachable_aux = orig
+
+        assert np.allclose(budgeted.lb, full.lb, atol=1e-9)
+        assert np.allclose(budgeted.ub, full.ub, atol=1e-9)
+
+
+# ─────────────────────────────────────────────────────────────
 # C-15: run_obbt must clamp the raw LP vertex to the NS-safe bound
 # ─────────────────────────────────────────────────────────────
 

--- a/python/tests/test_obbt.py
+++ b/python/tests/test_obbt.py
@@ -976,6 +976,47 @@ class TestCascadeReachableAux:
         assert np.allclose(budgeted.ub, full.ub, atol=1e-9)
 
 
+class TestCascadeAuxGraduatedDefault:
+    """#208 graduation: the reverse-FBBT aux cascade is default-ON on the real
+    solve path (`DISCOPT_OBBT_CASCADE_AUX`, default `1`), with `=0` as the opt-out.
+    Guards the flipped default so a future edit can't silently un-graduate it."""
+
+    def _stub_model(self):
+        m = Model("bil")
+        m.continuous("x", lb=0.5, ub=4.0)
+        m.continuous("y", lb=0.5, ub=4.0)
+        x, y = m._variables[0], m._variables[1]
+        m.minimize(x + y)
+        m.subject_to(x * y >= 4.0)
+        return m
+
+    def test_default_on_and_optout_off(self, monkeypatch):
+        import discopt._jax.obbt as obbt_mod
+        from discopt._jax.obbt import RootObbtResult
+        from discopt._jax.root_reduce import _stage_obbt
+
+        captured = {}
+
+        def _spy(model, lb, ub, **kw):
+            captured["cascade_aux"] = kw.get("cascade_aux")
+            return RootObbtResult(lb, ub, 0, 0, 0.0)
+
+        monkeypatch.setattr(obbt_mod, "obbt_tighten_root", _spy)
+        m = self._stub_model()
+        lb, ub = np.array([0.5, 0.5]), np.array([4.0, 4.0])
+        kw = dict(rounds=1, deadline=None, prefer_pounce=False, superposition=False)
+
+        # Default (env unset) -> cascade ON (the graduated default).
+        monkeypatch.delenv("DISCOPT_OBBT_CASCADE_AUX", raising=False)
+        _stage_obbt(m, lb.copy(), ub.copy(), None, **kw)
+        assert captured["cascade_aux"] is True
+
+        # Explicit opt-out -> OFF (legacy path preserved).
+        monkeypatch.setenv("DISCOPT_OBBT_CASCADE_AUX", "0")
+        _stage_obbt(m, lb.copy(), ub.copy(), None, **kw)
+        assert captured["cascade_aux"] is False
+
+
 # ─────────────────────────────────────────────────────────────
 # C-15: run_obbt must clamp the raw LP vertex to the NS-safe bound
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Resolves #208 — the OBBT-on-auxiliaries node-count reducer. The reverse-FBBT aux cascade is **budgeted** to the columns it can actually use and **graduated default-ON**, closing the acceptance criteria.

The cascade propagates OBBT-tightened auxiliary (product/ratio) column bounds back onto the original variables through the nonlinear term definitions — the hyperbolic/root bounds the linear McCormick rows can't express (`w=a·b ⟹ a∈[w]/[b]`, `w=aᵖ ⟹` p-th-root box, plus trilinear/multilinear and ratio-of-products). It runs **root-only** inside the already-default-ON root branch-and-reduce fixpoint, so there is **no per-node cost**.

## Two commits

**1. Budget the cascade** (`cascade_reachable_aux`)
The cascade only shrinks the original box through `reverse_fbbt_from_aux`, so probing an aux column whose reverse-FBBT can't reach an original (partner/divisor straddles zero) is pure wasted LP cost. `obbt_tighten_root(cascade_aux=True)` now probes `originals + reachable_aux` — **bound-neutral** vs a blanket cascade (the predicate is a superset of the deduction guards) but **~87% fewer aux LPs** (6078→797 candidates), which removes the pathological root-OBBT blowup (`tspn12` 55s→9s).

**2. Graduate default-ON**
Flip `DISCOPT_OBBT_CASCADE_AUX` default `0`→`1` (`=0` opts out, legacy path intact), mirroring the #581 `root_fixpoint` graduation pattern.

## Graduation gate (CLAUDE.md §5 — one passing run, both bars)

`design/ab_cascade_aux.py`, 65-instance corpus, **fair 30 s budget**:

| metric | OFF | ON | delta |
|---|---|---|---|
| converged-only node_count (n=45, both cert=T) | 2228 | 2228 | **+0 (0.0%)** |
| all-instances node_count | 3096 | 3018 | **−78 (−2.5%)** |
| differential soundness violations | — | — | **0** |
| optimum mismatches | — | — | **0** |
| cert gains / regressions | — | — | **+1 / 0** (`tls2` F→T) |

- ✅ **cert-clean**: 0 soundness violations, 0 optimum drift, 0 cert regressions, +1 gain.
- ✅ **net-positive, 0 regression**: node-neutral on the convergent integer-heavy majority; genuinely helpful on the continuous spatial-branch class — `tspn08/10/12` prune to **1 node**, `heatexch_gen3` **208→31 s** wall.

**Why the earlier "net-negative" verdict was wrong:** it came from a too-tight 8 s A/B where most instances time out and node count is a stopwatch reading. At a fair budget the "regressions" vanish — `fac2` (41=41) and `cvxnonsep_nsig30` (171=171) converge bit-identically; `casctanks` doesn't converge either way, so its 8 s cert flip was noise.

## Testing

- `pytest python/tests/test_obbt.py` — **60 passed** (7 new: reachability, end-to-end bound-neutrality vs full-probe, and the graduated-default + `=0` opt-out regression test).
- `pytest -m smoke` — **661 passed / 14 skipped** (with default-ON).
- Node-count-comparison suites (`test_tx1_adaptive_nlp`, `test_debug_bnb`, `test_binary_nl_parsing`, `test_callbacks`, `test_debug_rust_milp`) — green.
- End-to-end: `nvs01` solves in **3 nodes** by default vs 5 with `=0`, same certified optimum `12.46967`.
- `ruff check` / `ruff format` clean.

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)