### PR TITLE
feat(#196): SOS1 continuous-selector spatial branching (default-off flag)

### DIFF
--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -310,7 +310,11 @@ impl TreeManager {
                 continue;
             }
             let gwidth = self.global_ub[idx] - self.global_lb[idx];
-            if !(gwidth > 1e-15) {
+            // A non-positive (or NaN) global width is not branchable; a NaN falls
+            // through here and is filtered by the ``rel_width.is_finite()`` check
+            // below. (Written as ``<=`` rather than ``!(.. > ..)`` for clippy's
+            // ``neg_cmp_op_on_partial_ord``.)
+            if gwidth <= 1e-15 {
                 continue;
             }
             let rel_width = (ub[idx] - lb[idx]) / gwidth;

--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -179,6 +179,15 @@ pub struct TreeManager {
     /// variables against the box-shrink responsiveness ranking. Does not affect
     /// any branching or bounding decision.
     branch_var_counts: Vec<usize>,
+    /// Flat columns of *continuous SOS1 selectors* (issue #196): variables in a
+    /// one-of-N selection row `Σ s_i = 1` with each `s_i ≤` a binary indicator and
+    /// each `s_i` in a nonlinear product term. On a multi-line box the selectors
+    /// stay spread and pin the McCormick bound near 0; branching one spatially (at
+    /// the box midpoint) before the aux-binary MILP is drilled concentrates the
+    /// selection and lifts the node bound. Empty unless registered via
+    /// [`Self::set_sos1_selector_cols`] (gated by `DISCOPT_SOS1_SELECTOR_BRANCH`),
+    /// so this is inert by default and the legacy branch path is byte-identical.
+    sos1_selector_cols: Vec<usize>,
 }
 
 impl TreeManager {
@@ -221,6 +230,7 @@ impl TreeManager {
             bound_unresolved: false,
             unresolved_floor: f64::INFINITY,
             branch_var_counts: vec![0; n_vars],
+            sos1_selector_cols: Vec::new(),
         }
     }
 
@@ -263,6 +273,56 @@ impl TreeManager {
                 self.branch_deprioritized[c] = true;
             }
         }
+    }
+
+    /// Register continuous SOS1-selector columns (issue #196). Out-of-range
+    /// indices are ignored. Empty (the default) disables the selector spatial
+    /// branch entirely, keeping the legacy branch path byte-identical.
+    pub fn set_sos1_selector_cols(&mut self, cols: &[usize]) {
+        self.sos1_selector_cols = cols
+            .iter()
+            .copied()
+            .filter(|&c| c < self.global_lb.len())
+            .collect();
+    }
+
+    /// Pick a continuous SOS1 selector to branch spatially at this node, or
+    /// `None` when none is registered or none is still wide enough to split
+    /// (issue #196). Selects the registered selector with the largest relative
+    /// remaining width (current / root), skipping any below `SOS1_MIN_REL_WIDTH`
+    /// — the same completeness floor the general spatial brancher uses, so the
+    /// midpoint split (which halves the selector width each level) disables this
+    /// hint after finitely many splits and the standard selector then resumes.
+    /// The returned decision branches at the box midpoint, so
+    /// [`create_children_spatial`] partitions `[lb, ub]` into `[lb, mid]` and
+    /// `[mid, ub]` — a sound cover of the parent regardless of the LP point.
+    fn select_sos1_spatial(&self, node_id: NodeId) -> Option<BranchDecision> {
+        const SOS1_MIN_REL_WIDTH: f64 = 1e-6;
+        if self.sos1_selector_cols.is_empty() {
+            return None;
+        }
+        let node = self.pool.get(node_id);
+        let (lb, ub) = (&node.lb, &node.ub);
+        let mut best_idx: Option<usize> = None;
+        let mut best_width = SOS1_MIN_REL_WIDTH;
+        for &idx in &self.sos1_selector_cols {
+            if idx >= lb.len() {
+                continue;
+            }
+            let gwidth = self.global_ub[idx] - self.global_lb[idx];
+            if !(gwidth > 1e-15) {
+                continue;
+            }
+            let rel_width = (ub[idx] - lb[idx]) / gwidth;
+            if rel_width.is_finite() && rel_width > best_width {
+                best_width = rel_width;
+                best_idx = Some(idx);
+            }
+        }
+        best_idx.map(|idx| BranchDecision {
+            var_index: idx,
+            branch_point: 0.5 * (lb[idx] + ub[idx]),
+        })
     }
 
     /// Allocate a fresh NodeId.
@@ -446,6 +506,32 @@ impl TreeManager {
                     // branch direction remains, the no-decision arm below
                     // fathoms it into `unresolved_floor` (#598).
                 }
+            }
+
+            // 2b. Continuous SOS1 selector spatial branch (issue #196,
+            // `DISCOPT_SOS1_SELECTOR_BRANCH`). A one-of-N selector row
+            // `Σ s_i = 1` (each `s_i ≤` a binary indicator, each in a product
+            // term) that is still spread across a multi-line box keeps that box's
+            // McCormick bound pinned near 0. Branching a selector spatially at the
+            // box midpoint concentrates the selection *before* the aux-binary MILP
+            // is drilled — measured on ex1252: an ambiguous box's bound
+            // 12658 → ~67–83k once one selector is pinned. Taking precedence over
+            // integer/pseudocost branching is order-only, so it can never affect a
+            // bound's validity; `create_children_spatial` partitions `[lb, ub]`
+            // into `[lb, mid]`/`[mid, ub]` (sound cover) and the midpoint halving
+            // + `SOS1_MIN_REL_WIDTH` floor bound the extra depth (complete). When
+            // no selector is registered (flag off / structure absent) this is a
+            // no-op and the legacy branch path below runs unchanged.
+            if let Some(sos1_decision) = self.select_sos1_spatial(result.node_id) {
+                let parent = self.pool.get(result.node_id).clone();
+                self.pool.get_mut(result.node_id).status = NodeStatus::Branched;
+                let (left, right) =
+                    create_children_spatial(&parent, &sos1_decision, || self.next_id());
+                self.pool.add(left);
+                self.pool.add(right);
+                stats.branched += 1;
+                self.record_branch_var(sos1_decision.var_index);
+                continue;
             }
 
             // 3. Branch: use hint if available, else pseudocost/most-fractional.

--- a/crates/discopt-python/src/bnb_bindings.rs
+++ b/crates/discopt-python/src/bnb_bindings.rs
@@ -393,6 +393,20 @@ impl PyTreeManager {
         Ok(())
     }
 
+    /// Register continuous SOS1-selector columns for spatial branch precedence
+    /// (issue #196, `DISCOPT_SOS1_SELECTOR_BRANCH`). Empty (the default) keeps the
+    /// legacy branch path byte-identical. Out-of-range indices are ignored.
+    fn set_sos1_selector_cols(&mut self, cols: PyReadonlyArray1<i64>) -> PyResult<()> {
+        let idx: Vec<usize> = cols
+            .as_slice()
+            .unwrap()
+            .iter()
+            .map(|&c| c as usize)
+            .collect();
+        self.inner.set_sos1_selector_cols(&idx);
+        Ok(())
+    }
+
     /// Score branching candidates for a solution vector.
     ///
     /// Returns (var_indices, frac_parts, obs_counts, scores) as four arrays.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -167,6 +167,150 @@ def _branch_priority_integer_vars(model: Model) -> frozenset[int]:
     return frozenset(priority)
 
 
+def _sos1_selector_vars(model: Model) -> frozenset[int]:
+    """Continuous SOS1-selector flat indices (issue #196).
+
+    A "selector" is a *continuous* variable ``s`` that simultaneously
+    (a) sits in a one-of-N **selection row** ``Σ_i s_i = k`` (``k ≠ 0``, an affine
+    equality with ≥ 2 continuous members — a convex-combination/selection row, not
+    a defining equality ``s = f(·)`` which is nonlinear and so never reduces to an
+    affine row), (b) is upper-bounded by a 0/1 **indicator** via ``s ≤ y`` (``y``
+    binary, or a ``[0, 1]``-bounded continuous indicator such as ex1252's
+    ``x18 = x36``), and (c) appears in a nonlinear product term.
+
+    On a box where several lines are simultaneously "on", such selectors stay
+    spread (``s_i`` fractional) and the McCormick relaxation of the gated products
+    relaxes to 0, so the node bound is pinned near 0 until the selection is
+    concentrated. Branching one selector spatially forces a single product
+    positive (measured on ex1252: an ambiguous box's bound 12658 → ~67–83k once a
+    selector is pinned).
+
+    Like :func:`_branch_priority_integer_vars`, this is **branching-order metadata
+    only** — it never enters a bound or feasibility test, so it cannot affect
+    soundness. Returns an empty set when the structure is absent.
+    """
+    from discopt._jax.term_classifier import _get_flat_index, classify_nonlinear_terms
+    from discopt.modeling.core import (
+        BinaryOp,
+        Constant,
+        IndexExpression,
+        UnaryOp,
+        Variable,
+    )
+
+    n = sum(v.size for v in model._variables)
+    is_int = [False] * n
+    lb = np.full(n, -np.inf)
+    ub = np.full(n, np.inf)
+    fi = 0
+    for v in model._variables:
+        flag = v.var_type in (VarType.BINARY, VarType.INTEGER)
+        vlb = np.asarray(v.lb).reshape(-1)
+        vub = np.asarray(v.ub).reshape(-1)
+        for k in range(v.size):
+            if fi < n:
+                is_int[fi] = flag
+                lb[fi] = float(vlb[k]) if vlb.size == v.size else float(vlb.reshape(-1)[0])
+                ub[fi] = float(vub[k]) if vub.size == v.size else float(vub.reshape(-1)[0])
+            fi += 1
+
+    # Variables in a nonlinear term (objective or constraint).
+    terms = classify_nonlinear_terms(model)
+    nl: set[int] = set()
+    for group in (terms.bilinear, terms.trilinear, terms.multilinear):
+        for term in group or []:
+            nl.update(int(x) for x in term)
+    for term in terms.monomial or []:
+        nl.add(int(term[0]))
+
+    def _is_indicator(j: int) -> bool:
+        # A 0/1 gate: an integer/binary column, or a continuous column pinned to
+        # ``[0, 1]`` (ex1252's ``x18`` is continuous but ``= x36`` binary).
+        return is_int[j] or (0.0 <= lb[j] and ub[j] <= 1.0 + 1e-9)
+
+    def _affine(expr: Any, s: float = 1.0):
+        if isinstance(expr, Constant):
+            return ({}, s * float(expr.value))
+        if isinstance(expr, (Variable, IndexExpression)):
+            flat = _get_flat_index(expr, model)
+            if flat is None:
+                return None
+            return ({int(flat): s}, 0.0)
+        if isinstance(expr, UnaryOp) and expr.op == "neg":
+            return _affine(expr.operand, -s)
+        if isinstance(expr, BinaryOp):
+            if expr.op in ("+", "-"):
+                left = _affine(expr.left, s)
+                right = _affine(expr.right, s if expr.op == "+" else -s)
+                if left is None or right is None:
+                    return None
+                d = dict(left[0])
+                for k, val in right[0].items():
+                    d[k] = d.get(k, 0.0) + val
+                return (d, left[1] + right[1])
+            if expr.op == "*":
+                if isinstance(expr.left, Constant):
+                    return _affine(expr.right, s * float(expr.left.value))
+                if isinstance(expr.right, Constant):
+                    return _affine(expr.left, s * float(expr.right.value))
+        return None
+
+    # Pass 1: collect candidate selectors from every affine selection row
+    # ``Σ s_i = k`` (k != 0, >= 2 continuous members).
+    candidates: set[int] = set()
+    for c in model._constraints:
+        if getattr(c, "sense", None) != "==":
+            continue
+        reduced = _affine(c.body)
+        if reduced is None:
+            continue
+        coeffs, const = reduced
+        members = [(k, v) for k, v in coeffs.items() if abs(v) > 1e-12]
+        if len(members) < 2 or abs(const) < 1e-12:
+            continue
+        if any(is_int[k] for k, _ in members):
+            continue  # a genuine convex-combination row is all-continuous
+        for k, _ in members:
+            candidates.add(k)
+
+    if not candidates:
+        return frozenset()
+
+    # Pass 2: keep a candidate ``s`` only if it is upper-coupled to a 0/1
+    # indicator ``y`` by an inequality ``s - y (<=) 0`` where the pair is tied to
+    # the nonlinear core — either the indicator ``y`` gates a product (``y`` is a
+    # nonlinear-term factor, as ex1252's ``x18`` in ``x0*x3*x18``) or the selector
+    # ``s`` is itself a factor. Concentrating ``s`` then tightens that product's
+    # McCormick envelope, which is the whole point.
+    selectors: set[int] = set()
+    for c in model._constraints:
+        if getattr(c, "sense", None) not in ("<=", ">="):
+            continue
+        reduced = _affine(c.body)
+        if reduced is None:
+            continue
+        coeffs, const = reduced
+        nz = [(k, v) for k, v in coeffs.items() if abs(v) > 1e-12]
+        if len(nz) != 2 or abs(const) > 1e-9:
+            continue
+        (i, ci), (j, cj) = nz
+        # Orient to ``s - y (<=) 0``: for '<=', selector has the + coeff; for '>=',
+        # the - coeff. Only the sign pattern (opposite signs) matters here.
+        if ci * cj >= 0:
+            continue
+        sense = c.sense
+        s_col, y_col = (i, j) if (ci > 0) == (sense == "<=") else (j, i)
+        if (
+            s_col in candidates
+            and not is_int[s_col]
+            and _is_indicator(y_col)
+            and (y_col in nl or s_col in nl)
+        ):
+            selectors.add(s_col)
+
+    return frozenset(selectors)
+
+
 def _select_priority_branch_var(
     solution: np.ndarray,
     node_lb: np.ndarray,
@@ -5635,6 +5779,25 @@ def solve_model(
                             )
                     except Exception as _dep_exc:  # pragma: no cover - defensive
                         logger.debug("branch-deprioritization wiring skipped: %s", _dep_exc)
+                    # SOS1 selector spatial branch (issue #196,
+                    # ``DISCOPT_SOS1_SELECTOR_BRANCH``, default off). Register the
+                    # continuous one-of-N selectors so the Rust tree branches one
+                    # spatially before drilling the aux-binary MILP, un-pinning a
+                    # multi-line box's bound off 0. Order-only metadata (soundness
+                    # unaffected); empty list when the flag is off or the structure
+                    # is absent, leaving the branch path byte-identical.
+                    if _tuning().sos1_selector_branch:
+                        try:
+                            _sos1_cols = sorted(_sos1_selector_vars(model))
+                            if _sos1_cols:
+                                tree.set_sos1_selector_cols(np.asarray(_sos1_cols, dtype=np.int64))
+                                logger.info(
+                                    "SOS1 selector spatial branching: %d selector(s) %s",
+                                    len(_sos1_cols),
+                                    _sos1_cols,
+                                )
+                        except Exception as _sos1_exc:  # pragma: no cover - defensive
+                            logger.debug("SOS1 selector wiring skipped: %s", _sos1_exc)
                     # Root probe: keep the LP relaxer only if it actually yields
                     # a valid objective bound (or a rigorous infeasibility proof)
                     # at the root box. When the objective is not LP-linearizable

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -498,6 +498,26 @@ class SolverTuning:
     oracle-cross 0, cert-loss 0; both-certified nodes 1092 -> 1054). Set
     ``DISCOPT_OBJ_BRANCH_PRIORITY=0`` to restore the old default."""
 
+    sos1_selector_branch: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_SOS1_SELECTOR_BRANCH", default=False)
+    )
+    """Spatially branch continuous SOS1 selectors before drilling aux-binaries
+    (``DISCOPT_SOS1_SELECTOR_BRANCH``, default OFF; issue #196).
+
+    A continuous one-of-N selector ``s`` (member of a selection row ``Σ s_i = 1``,
+    upper-coupled to a 0/1 indicator by ``s ≤ y``, and in a nonlinear product term)
+    that stays spread across a multi-line box keeps the McCormick bound of the
+    gated products pinned near 0. When on, :func:`_sos1_selector_vars` detects such
+    selectors and the Rust tree branches one spatially (box-midpoint) with
+    precedence, concentrating the selection so a single product is forced positive
+    (ex1252: an ambiguous box's bound 12658 → ~67–83k once a selector is pinned).
+
+    Branch-ORDER metadata only (never a bound/feasibility input), so it cannot
+    change a bound's validity — the midpoint split is a sound cover and its
+    width-halving keeps the search complete. Default OFF pending a corpus
+    differential panel (CLAUDE.md §5, ``incorrect_count = 0`` + net-positive)
+    before any graduation."""
+
     lp_warmstart: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_LP_WARMSTART", default=True)
     )

--- a/python/tests/test_sos1_selector_branch.py
+++ b/python/tests/test_sos1_selector_branch.py
@@ -1,0 +1,109 @@
+"""SOS1 continuous-selector spatial branching (issue #196).
+
+``ex1252``'s global dual bound is pinned at 0 because its objective is a sum of
+products gated by line indicators ``x18/x19/x20``; on a box where several lines
+are simultaneously "on" the *continuous* selectors ``x21+x22+x23 = 1`` (each
+``x21 <= x18`` ...) stay spread and the McCormick relaxation drives every product
+to 0. Branching a selector spatially concentrates the selection so a single
+product is forced positive (measured: an ambiguous box's bound 12658 -> ~67-83k
+once one selector is pinned).
+
+The mechanism is gated behind ``DISCOPT_SOS1_SELECTOR_BRANCH`` (default OFF) and
+is **branch-ORDER metadata only** — it never enters a bound or feasibility test,
+so these tests lock (a) that the detector finds exactly the selectors, (b) that
+it does not fire on unrelated structure, and (c) that enabling it keeps every
+reported bound *sound* (<= the known optimum). Soundness is the invariant; the
+bound-lift is measured in the issue, not asserted as a brittle threshold here.
+"""
+
+import math
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+_EX1252_OPT = 128893.74
+
+
+@pytest.mark.correctness
+def test_ex1252_sos1_selector_detection():
+    """The detector identifies exactly ex1252's continuous selectors
+    ``x21/x22/x23`` — the members of the selection row ``x21+x22+x23=1``, each
+    upper-coupled to a ``[0,1]`` indicator (``x21<=x18`` ...) whose indicator gates
+    an objective product. Branch-ORDER metadata only, so this guards the
+    heuristic, not soundness."""
+    from discopt.solver import _sos1_selector_vars
+
+    nl = _DATA / "ex1252.nl"
+    assert nl.exists(), f"missing {nl}"
+    m = dm.from_nl(str(nl))
+    sel = _sos1_selector_vars(m)
+    assert sorted(sel) == [21, 22, 23], f"expected selectors {{21,22,23}}, got {sorted(sel)}"
+
+
+@pytest.mark.correctness
+def test_sos1_selector_no_false_positive_plain_bilinear():
+    """A plain bilinear model with no one-of-N selection row yields no selectors:
+    the detector must not fire on generic products."""
+    from discopt.solver import _sos1_selector_vars
+
+    m = dm.Model("plain_bilinear")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    y = m.continuous("y", lb=0.0, ub=1.0)
+    m.minimize(x * y)
+    m.subject_to(x + y >= 0.5)  # inequality, not a ``= const`` selection row
+    assert _sos1_selector_vars(m) == frozenset()
+
+
+@pytest.mark.correctness
+def test_sos1_selector_no_false_positive_linear_selection():
+    """A one-of-N ``= 1`` selection row whose members are NOT coupled to a
+    product-gating indicator (a purely linear assignment) yields no selectors:
+    concentrating them would not tighten any nonlinear relaxation."""
+    from discopt.solver import _sos1_selector_vars
+
+    m = dm.Model("linear_selection")
+    s1 = m.continuous("s1", lb=0.0, ub=1.0)
+    s2 = m.continuous("s2", lb=0.0, ub=1.0)
+    m.minimize(s1 + 2.0 * s2)  # linear objective — no product gated by an indicator
+    m.subject_to(s1 + s2 == 1.0)
+    assert _sos1_selector_vars(m) == frozenset()
+
+
+@pytest.mark.correctness
+def test_ex1252_sos1_selector_branch_is_sound():
+    """Enabling the selector spatial branch keeps every reported bound sound:
+    the dual bound never exceeds the true optimum and a certified gap never
+    certifies a bound above it. Order-only metadata cannot loosen a bound, so the
+    lock is that the *lifted* bound is still valid."""
+    monkey = os.environ.get("DISCOPT_SOS1_SELECTOR_BRANCH")
+    os.environ["DISCOPT_SOS1_SELECTOR_BRANCH"] = "1"
+    try:
+        nl = _DATA / "ex1252.nl"
+        assert nl.exists(), f"missing {nl}"
+        m = dm.from_nl(str(nl))
+        r = m.solve(time_limit=20.0)
+        # Dual bound must be a valid lower bound: <= the true optimum, always.
+        if r.bound is not None and math.isfinite(r.bound):
+            assert r.bound <= _EX1252_OPT + 1e-3, (
+                f"ex1252 SOS1-branch UNSOUND dual bound {r.bound} > optimum {_EX1252_OPT}"
+            )
+        # Any incumbent found must be feasible (>= optimum for this minimize).
+        if r.objective is not None and math.isfinite(r.objective):
+            assert r.objective >= _EX1252_OPT - 1e-3, (
+                f"ex1252 SOS1-branch incumbent {r.objective} below optimum {_EX1252_OPT}"
+            )
+        # A certified gap must bracket the optimum soundly.
+        if r.gap_certified and r.bound is not None and r.objective is not None:
+            assert r.bound <= r.objective + 1e-3
+    finally:
+        if monkey is None:
+            os.environ.pop("DISCOPT_SOS1_SELECTOR_BRANCH", None)
+        else:
+            os.environ["DISCOPT_SOS1_SELECTOR_BRANCH"] = monkey


### PR DESCRIPTION
## Summary

Follow-up to #196. `ex1252`'s global dual bound is pinned at **0**: its objective is a sum of products gated by line indicators `x18/x19/x20`, and on a box where several lines are simultaneously "on" the continuous selectors `x21+x22+x23=1` (each `x21≤x18` …) stay spread, so the McCormick relaxation drives every gated product to 0. Branching an integer indicator does not resolve this — an indicator can be 1 while the selector routes flow elsewhere.

This PR adds, behind **`DISCOPT_SOS1_SELECTOR_BRANCH` (default OFF)**, spatial branching on the continuous SOS1 selectors, which lifts the bound off its structural 0 for the first time on this instance (**0 → 5134.47**, sound).

## Entry experiment (run before implementing, per CLAUDE.md §4)

Fixing an *indicator* alone does not close the ambiguous multi-line boxes. Fixing a *selector* does:

| box | bound (selectors free) | + `x21=1` | + `x23=1` |
|---|---|---|---|
| `(1,1,1)` all lines | 12658 | **83462** | **67719** |
| `(1,0,1)` lines 1+3 | 12658 | **83462** | 67719 (root jumps immediately) |

So concentrating a selector converts an intractable ambiguous box into single-selection sub-boxes with bounds ≥ 67k. Mechanism confirmed before writing the feature.

## What changed

- **`_sos1_selector_vars(model)`** (`python/discopt/solver.py`) — detects continuous one-of-N selectors *generally*: members of an affine selection row `Σ sᵢ = k` (k≠0, ≥2 continuous members), each upper-coupled to a 0/1 indicator by `s ≤ y` where the indicator gates a product. Returns exactly `{x21,x22,x23}` on `ex1252`; no false positives on plain bilinears or linear selections.
- **`TreeManager::select_sos1_spatial` + `set_sos1_selector_cols`** (`crates/discopt-core/.../tree_manager.rs`, PyO3 binding in `bnb_bindings.rs`) — branches the widest registered selector spatially at the box midpoint, taking precedence over integer/pseudocost branching so the selection concentrates before the aux-binary MILP is drilled.
- **`DISCOPT_SOS1_SELECTOR_BRANCH`** flag in `solver_tuning.py` (default OFF), wired in `solve_model` alongside the existing branch-priority setup.

## Soundness (CLAUDE.md §5)

Branch-**order** metadata only — it never enters a bound or feasibility test, so it cannot change a bound's validity. `create_children_spatial` partitions `[lb,ub]` into `[lb,mid]`/`[mid,ub]` (a sound cover regardless of the LP point); the new block only ever *adds* a branch, never fathoms; midpoint-halving + a `SOS1_MIN_REL_WIDTH` floor keep the search complete. With the flag off (or the structure absent) the selector list is empty and the branch path is **byte-identical** to before.

## Measured result on `ex1252` (flag ON)

| | status | dual bound | incumbent | nodes |
|---|---|---|---|---|
| OFF (baseline) | feasible | ≈0 | 128893.74 | 97 (60 s) |
| ON, 60 s | feasible | **5134.47** | 134471.6 | 73 |
| ON, 240 s | feasible | 5134.47 | 134471.6 | 581 |

The bound lifts off 0 (sound: 5134 ≪ opt 128893.74) and then plateaus — the residual gap is a slack trilinear McCormick envelope, tracked as follow-up (see #196 for the full diagnosis). This PR is the first mechanism to move the bound at all.

## Why default-OFF

Sound and helpful on `ex1252`, but not yet corpus-validated. Per §5 it stays default-off pending a differential panel (`incorrect_count=0` + net-positive) before any graduation; the flag is the opt-in.

## Verification

- `cargo test -p discopt-core bnb::` — **95 passed**.
- `pytest -m smoke` — **661 passed, 0 failed** (default-OFF path unchanged).
- New `python/tests/test_sos1_selector_branch.py` — detection + two no-false-positive + a soundness solve, all pass.
- The one adversarial-suite red (`test_large_dense_jacobian_no_crash`, a large-model deadline assert) was a CPU-contention overrun; it passes cleanly in isolation (28 s < 48 s) and is untouched by this default-off branching change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2Wdhrcp997U9PaJzBiq7w)_