### PR TITLE
research(#704): H2 entry experiment — improver-LNS contingent is abstract-cost, not wall time (CONFIRMED)

### DIFF
--- a/discopt_benchmarks/results/issue704/h2_walltime_2026-07-17.json
+++ b/discopt_benchmarks/results/issue704/h2_walltime_2026-07-17.json
@@ -1,0 +1,524 @@
+[
+  {
+    "instance": "rsyn0805m",
+    "oracle": 1296.120603,
+    "status": "feasible",
+    "objective": 1116.458325165389,
+    "bound": 1640.3418265241712,
+    "nodes": 351,
+    "wall_s": 61.39784108300228,
+    "time_limit": 60.0,
+    "first_incumbent": {
+      "t": 7.582744209008524,
+      "node": 3,
+      "obj": -1025.8450264708492
+    },
+    "improver_total_wall_s": 39.12943328998517,
+    "improver_frac_of_budget": 0.6521572214997529,
+    "by_role": {
+      "rins": {
+        "n_calls": 12,
+        "total_wall_s": 18.865852707007434,
+        "mean_s": 1.5721543922506196,
+        "max_s": 3.182799292000709,
+        "min_s": 0.6759761669964064,
+        "charged_each": 5.0,
+        "charged_total": 60.0
+      },
+      "lbranch": {
+        "n_calls": 5,
+        "total_wall_s": 20.26358058297774,
+        "mean_s": 4.052716116595548,
+        "max_s": 4.436451207991922,
+        "min_s": 3.6306983339891303,
+        "charged_each": 10.0,
+        "charged_total": 50.0
+      }
+    },
+    "calls": [
+      {
+        "role": "rins",
+        "t_rel": 7.712660582998069,
+        "dur": 0.7650461250159424,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 8.712663042009808,
+        "dur": 0.723464790993603,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 9.993715457996586,
+        "dur": 0.6759761669964064,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 10.669739708013367,
+        "dur": 3.6306983339891303,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 15.500389791995985,
+        "dur": 2.2544103330001235,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 17.75490762499976,
+        "dur": 3.8000034170108847,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 22.7634287920082,
+        "dur": 2.325945332995616,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 26.333569208014524,
+        "dur": 0.7656170419941191,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 27.099307666998357,
+        "dur": 3.9659769159916323,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 32.41068495801301,
+        "dur": 2.5238144589820877,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 36.16507504199399,
+        "dur": 0.7730755410157144,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 38.301471874990966,
+        "dur": 0.9627734580135439,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 40.75119595800061,
+        "dur": 1.1818611249909736,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 41.93317737500183,
+        "dur": 4.430450707994169,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 47.974636958009796,
+        "dur": 3.182799292000709,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 51.15765791700687,
+        "dur": 4.436451207991922,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 57.299490542005515,
+        "dur": 2.7310690410085954,
+        "improved": true
+      }
+    ]
+  },
+  {
+    "instance": "rsyn0810m",
+    "oracle": 1721.447711,
+    "status": "feasible",
+    "objective": 1548.6431867057615,
+    "bound": 2486.3685843313865,
+    "nodes": 191,
+    "wall_s": 62.05811012498452,
+    "time_limit": 60.0,
+    "first_incumbent": {
+      "t": 11.136768708005548,
+      "node": 3,
+      "obj": -1387.3003750648554
+    },
+    "improver_total_wall_s": 41.608730209001806,
+    "improver_frac_of_budget": 0.6934788368166968,
+    "by_role": {
+      "rins": {
+        "n_calls": 8,
+        "total_wall_s": 20.710297001030995,
+        "mean_s": 2.5887871251288743,
+        "max_s": 5.055744666984538,
+        "min_s": 0.971526833018288,
+        "charged_each": 5.0,
+        "charged_total": 40.0
+      },
+      "lbranch": {
+        "n_calls": 5,
+        "total_wall_s": 20.89843320797081,
+        "mean_s": 4.179686641594162,
+        "max_s": 4.713356374995783,
+        "min_s": 3.0604420420131646,
+        "charged_each": 10.0,
+        "charged_total": 50.0
+      }
+    },
+    "calls": [
+      {
+        "role": "rins",
+        "t_rel": 11.34691875000135,
+        "dur": 1.4390987500082701,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 13.183599165990017,
+        "dur": 1.3602347090200055,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 15.495066957984818,
+        "dur": 1.3471542920160573,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 16.842282583005726,
+        "dur": 4.713356374995783,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 23.322346583008766,
+        "dur": 3.7149648329941556,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 27.03742737500579,
+        "dur": 4.022730540978955,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 32.38206254100078,
+        "dur": 3.0047033749870025,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 36.632944249984575,
+        "dur": 0.971526833018288,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 37.60457683299319,
+        "dur": 4.47497279199888,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 43.91825108299963,
+        "dur": 5.055744666984538,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 48.97423575000721,
+        "dur": 4.626931457984028,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 55.16803308299859,
+        "dur": 3.816869542002678,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 58.985079165984644,
+        "dur": 3.0604420420131646,
+        "improved": false
+      }
+    ]
+  },
+  {
+    "instance": "syn30hfsg",
+    "oracle": 138.1596024,
+    "status": "feasible",
+    "objective": 138.1596289302158,
+    "bound": 1375.049838217518,
+    "nodes": 373,
+    "wall_s": 62.27830891602207,
+    "time_limit": 60.0,
+    "first_incumbent": {
+      "t": 11.380660333990818,
+      "node": 3,
+      "obj": -122.02648477973716
+    },
+    "improver_total_wall_s": 12.544156998977996,
+    "improver_frac_of_budget": 0.20906928331629995,
+    "by_role": {
+      "rins": {
+        "n_calls": 13,
+        "total_wall_s": 2.3429785829794127,
+        "mean_s": 0.18022912176764713,
+        "max_s": 0.2897118330001831,
+        "min_s": 0.06825504198786803,
+        "charged_each": 5.0,
+        "charged_total": 65.0
+      },
+      "lbranch": {
+        "n_calls": 4,
+        "total_wall_s": 10.201178415998584,
+        "mean_s": 2.550294603999646,
+        "max_s": 2.7243797080009244,
+        "min_s": 2.3926558750099503,
+        "charged_each": 10.0,
+        "charged_total": 40.0
+      }
+    },
+    "calls": [
+      {
+        "role": "rins",
+        "t_rel": 11.853265125013422,
+        "dur": 0.07065929099917412,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 12.631291583005805,
+        "dur": 0.06825504198786803,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 12.700528750021476,
+        "dur": 2.7243797080009244,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 17.28474520801683,
+        "dur": 0.27428225000039674,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 17.55910004102043,
+        "dur": 2.5187126669916324,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 27.186993375013117,
+        "dur": 0.2598059579904657,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 27.446921875001863,
+        "dur": 2.5654301659960765,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 34.84562737500528,
+        "dur": 0.12747658300213516,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 38.484864958008984,
+        "dur": 0.14179516700096428,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 41.71927066601347,
+        "dur": 0.12864108398207463,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 43.8638372910209,
+        "dur": 0.12946358398767188,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 46.04913845800911,
+        "dur": 0.13849741700687446,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 46.187686958000995,
+        "dur": 2.3926558750099503,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 51.08304670799407,
+        "dur": 0.2897118330001831,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 53.87788470799569,
+        "dur": 0.1991475830145646,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 56.757225625013234,
+        "dur": 0.2671156660071574,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 59.5154525830003,
+        "dur": 0.24812712499988265,
+        "improved": true
+      }
+    ]
+  },
+  {
+    "instance": "syn40hfsg",
+    "oracle": 67.71325586,
+    "status": "feasible",
+    "objective": 64.44554961700268,
+    "bound": 1659.2292023560494,
+    "nodes": 347,
+    "wall_s": 64.77365287501016,
+    "time_limit": 60.0,
+    "first_incumbent": {
+      "t": 17.627572500001406,
+      "node": 3,
+      "obj": -61.19706863066675
+    },
+    "improver_total_wall_s": 11.861149624019163,
+    "improver_frac_of_budget": 0.19768582706698604,
+    "by_role": {
+      "rins": {
+        "n_calls": 11,
+        "total_wall_s": 1.3272279990487732,
+        "mean_s": 0.12065709082261575,
+        "max_s": 0.19694295802037232,
+        "min_s": 0.08237895800266415,
+        "charged_each": 5.0,
+        "charged_total": 55.0
+      },
+      "lbranch": {
+        "n_calls": 3,
+        "total_wall_s": 10.53392162497039,
+        "mean_s": 3.5113072083234633,
+        "max_s": 3.7957514580048155,
+        "min_s": 3.347137666976778,
+        "charged_each": 10.0,
+        "charged_total": 30.0
+      }
+    },
+    "calls": [
+      {
+        "role": "rins",
+        "t_rel": 18.36080954200588,
+        "dur": 0.14998308301437646,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 19.61974208301399,
+        "dur": 0.12464445899240673,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 21.916603917023167,
+        "dur": 0.12338929099496454,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 24.247333417006303,
+        "dur": 0.19694295802037232,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 24.444344667019323,
+        "dur": 3.7957514580048155,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 30.9275099170045,
+        "dur": 0.1509421250084415,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 31.078524458018364,
+        "dur": 3.391032499988796,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 37.14276200000313,
+        "dur": 0.12258312501944602,
+        "improved": true
+      },
+      {
+        "role": "lbranch",
+        "t_rel": 37.26540595802362,
+        "dur": 3.347137666976778,
+        "improved": false
+      },
+      {
+        "role": "rins",
+        "t_rel": 42.84840266700485,
+        "dur": 0.11704325000755489,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 45.10053075000178,
+        "dur": 0.08884241699706763,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 50.60622900002636,
+        "dur": 0.0866903749993071,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 53.823067125020316,
+        "dur": 0.08378795799217187,
+        "improved": true
+      },
+      {
+        "role": "rins",
+        "t_rel": 56.9266499170044,
+        "dur": 0.08237895800266415,
+        "improved": true
+      }
+    ]
+  }
+]

--- a/docs/dev/issue-704-h2-improver-walltime-2026-07-17.md
+++ b/docs/dev/issue-704-h2-improver-walltime-2026-07-17.md
@@ -1,0 +1,170 @@
+# Issue #704 — H2 entry experiment: improver-LNS contingent is denominated in abstract cost, not wall time
+
+**Date:** 2026-07-17
+**Issue:** [#704](https://github.com/jkitchin/discopt/issues/704) (split from #282 round 2, `docs/dev/issue-282-syn-rsyn-diagnosis-2026-07-17.md` §R2-7)
+**Regime:** entry experiment only — measure-only, no production/solver code changed.
+**Verdict:** **H2 CONFIRMED.**
+
+## Hypothesis (H2)
+
+`_improver_allowed` on the NLP-BB path (`python/discopt/solver.py`, the second copy at
+~10005–10705; the same closure exists on the McCormick path at ~6245–8605) charges *fixed
+abstract cost units* against a node-proportional contingent and **never measures wall time**:
+
+```python
+_HEUR_COST = {"rins": 5.0, "lbranch": 10.0}
+...
+def _improver_allowed(cost: float) -> bool:
+    if not _heur_budget_on or tree.incumbent() is None:
+        return True                                   # (gap 2) ungated pre-incumbent
+    _nodes = float(tree.stats().get("total_nodes", 0))
+    _weight = _HEUR_SUCCESS_GAIN * (_heur_state["found"] + 1) / (_heur_state["calls"] + 1)
+    _contingent = _HEUR_BUDGET_OFFSET + _HEUR_BUDGET_QUOT * _nodes * _weight
+    return (_heur_state["cost"] + cost) <= _contingent
+```
+
+Two structural gaps claimed:
+
+1. **No wall clock.** A `rins` call is charged 5.0 and a `local_branching` call 10.0
+   regardless of whether it took 50 ms or 6 s. On syn/rsyn a single `local_branching` call is
+   multiple seconds, so a handful of improver calls burns a large slice of a 60 s budget
+   before a node-count-proportional contingent can throttle them.
+2. **Bypassed before the first incumbent** (`tree.incumbent() is None → return True`).
+
+## Kill criterion (stated before running)
+
+H2 is **FALSIFIED** if any of: improver calls are uniformly short (≪ 1 s); OR total improver
+wall time is a small fraction of the budget; OR the abstract cost already tracks wall time
+proportionally (i.e. wall-seconds-per-charged-unit is roughly constant across families).
+H2 is **CONFIRMED** if a single call is multiple seconds AND improvers consume a large slice
+of the budget while the fixed abstract contingent stays unthrottled.
+
+## Method
+
+Measure-only. A local scratch harness (`scratchpad/h2_probe.py`, not committed) monkeypatches
+`discopt._jax.primal_heuristics.rins` / `.local_branching` with timing wrappers (the solver
+imports them at call time inside the node loop, so the module-attribute swap is picked up) and
+uses a `node_callback` to timestamp the first incumbent. Instances loaded with `dm.from_nl`
+from `~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/`, oracle from `minlplib.solu`,
+`time_limit=60`, default (auto → NLP-BB) path. A separate `cProfile` run corroborates the
+issue's original methodology. Raw data: `discopt_benchmarks/results/issue704/h2_walltime_2026-07-17.json`.
+
+**Load caveat (#702).** Wall-clock numbers are soft under contention. These ran on a 14-core
+box at load ≈ 3.3–3.7 with one concurrent CPU-bound `python` process (another agent). The
+*direction and magnitude* of the finding (multi-second calls, 20–69 % of budget, 21× spread
+in cost-per-unit) is far larger than plausible load noise, but the exact seconds are not
+reproducible to the decimal. Single run per instance, no variance estimate.
+
+## Results (time_limit = 60 s)
+
+### Per-call wall time vs charged abstract cost
+
+| instance | role | calls | total wall | mean / call | max / call | charged/call | wall ÷ charged (s per unit) |
+|---|---|---|---|---|---|---|---|
+| rsyn0805m | rins    | 12 | 18.87 s | 1.57 s | 3.18 s | 5.0 | **0.314** |
+| rsyn0805m | lbranch |  5 | 20.26 s | 4.05 s | 4.44 s | 10.0 | 0.405 |
+| rsyn0810m | rins    |  8 | 20.71 s | 2.59 s | 5.06 s | 5.0 | **0.518** |
+| rsyn0810m | lbranch |  5 | 20.90 s | 4.18 s | 4.71 s | 10.0 | 0.418 |
+| syn30hfsg | rins    | 13 |  2.34 s | 0.18 s | 0.29 s | 5.0 | **0.036** |
+| syn30hfsg | lbranch |  4 | 10.20 s | 2.55 s | 2.72 s | 10.0 | 0.255 |
+| syn40hfsg | rins    | 11 |  1.33 s | 0.12 s | 0.20 s | 5.0 | **0.024** |
+| syn40hfsg | lbranch |  3 | 10.53 s | 3.51 s | 3.80 s | 10.0 | 0.351 |
+
+The **cost-per-unit for `rins` varies 21×** (0.024 → 0.518 s/unit) across families while the
+charged cost is a fixed 5.0 every time. `local_branching` is **2.5–4.7 s per call** on every
+family — never anywhere near "cheap" — yet is charged a flat 10.0. If the abstract
+denomination were a decent wall-time proxy, the last column would be roughly constant; it is
+not. The relative weighting is also wrong on some families: `rins` is charged half of
+`lbranch` (5 vs 10), but on `syn40hfsg` a `rins` call (0.12 s) is ~3 % of a `lbranch` call
+(3.51 s), not half.
+
+### Total improver wall time within the 60 s budget
+
+| instance | improver total wall | % of 60 s budget | nodes | obj (oracle) | dual bound |
+|---|---|---|---|---|---|
+| rsyn0805m | **39.13 s** | **65.2 %** | 351 | 1116.5 (1296.1) | 1640.3 |
+| rsyn0810m | **41.61 s** | **69.3 %** | 191 | 1548.6 (1721.4) | 2486.4 |
+| syn30hfsg | 12.54 s | 20.9 % | 373 | 138.16 (138.16) | 1375.0 |
+| syn40hfsg | 11.86 s | 19.8 % | 347 |  64.45 (67.71) | 1659.2 |
+
+On the convex `rsyn` half the improvers eat **~two-thirds of the entire budget**. On the
+`hfsg` pair — where the incumbent is already at/near the oracle (nothing left for improvers to
+find) — they still burn ~20 %, dominated by `local_branching` (2.5–3.5 s/call). The contingent
+never sees any of this: it is counting 5s and 10s.
+
+### Ungated window (budget elapsed before the first incumbent)
+
+| instance | first incumbent at | at node |
+|---|---|---|
+| rsyn0805m |  7.58 s | 3 |
+| rsyn0810m | 11.14 s | 3 |
+| syn30hfsg | 11.38 s | 3 |
+| syn40hfsg | 17.63 s | 3 |
+
+Reproduces the issue's "first incumbent ≈ 8.5 s on rsyn0805m" (measured 7.6 s).
+
+### cProfile corroboration (rsyn0805m, 60 s — reproduces the issue's cited datum)
+
+```
+ncalls  tottime  cumtime  percall  function
+     3    0.001   18.932    6.311  primal_heuristics.py:1610(local_branching)
+     6    0.001   16.195    2.699  primal_heuristics.py:1338(rins)
+```
+
+The issue cited `rsyn0805m/60 s: 3 calls / 18.3 s` for `local_branching`; cProfile gives
+3 calls / **18.93 s**, **6.31 s per call**. (Profiler overhead lowers node throughput, so the
+profiled run reaches fewer improver windows than the direct-timer run — 3 vs 5 `lbranch`
+calls — and inflates per-call time; the direct-timer table above is the faithful, lower
+measurement.)
+
+## Verdict: **H2 CONFIRMED**
+
+Against the kill criterion:
+
+- Calls are **not** uniformly short: `local_branching` is 2.5–4.7 s per call on every family
+  and `rins` reaches 5.06 s on rsyn0810m. ✗ (not falsified)
+- Improver wall is **not** a small fraction: 65–69 % of budget on rsyn, ~20 % on syn. ✗
+- The abstract cost does **not** track wall time: cost-per-unit for a single role spans 21×
+  while the charged cost is a fixed constant. ✗
+
+All three falsification routes fail; both confirmation conditions hold. **Gap (1) is decisively
+confirmed** — the contingent's denomination is decoupled from real wall cost, so it cannot
+self-calibrate to families where a sub-MIP is seconds long.
+
+**Honest scoping of gap (2).** The pre-incumbent bypass (`tree.incumbent() is None → return
+True`) is real in the shared closure, but on the **NLP-BB path** the RINS / local-branching
+block is already nested under `if _lns_inc is not None` (`solver.py:10589`), so those two
+improvers cannot fire before the first incumbent regardless of the gate. The bypass therefore
+does **not** open an extra improver window for RINS/lbranch on this path (it matters for the
+McCormick-path `enumerate` heuristic at ~8279, not exercised here). The dominant, measured
+defect is unambiguously gap (1). A time-denominated redesign should still gate the
+pre-first-incumbent window for the improvers that *can* fire there, but the entry data does not
+show gap (2) as an independent cost on the syn/rsyn NLP-BB runs.
+
+## Proposed fix (design only — do NOT implement here; needs the Regime-2 panel gate)
+
+Denominate the contingent in **measured wall seconds** against a fraction of remaining wall
+budget, keeping the existing success-weighting so improvers that stop paying off still shut
+down (SCIP `heur_subnlp` is time-aware in this spirit). Sketch, behind a flag, default-OFF:
+
+- Time each improver call (`t = perf_counter()` around the `rins` / `local_branching` call)
+  and charge the **measured seconds** to `_heur_state["cost"]` instead of `_HEUR_COST[...]`.
+- Express the contingent as a fraction of *remaining* budget, e.g.
+  `contingent = HEUR_TIME_FRAC * max(0, deadline - now) * _weight` with the same
+  `3·(found+1)/(calls+1)` success weight, so a family whose sub-MIPs cost seconds is throttled
+  by the same rule that lets a family with 50 ms sub-MIPs run many calls.
+- Also gate the pre-first-incumbent window for any improver that can fire there (close gap 2
+  for the McCormick `enumerate` path), so early cheap-looking abstract costs don't front-load.
+
+Soundness is not at risk either way: B&B stays exhaustive, so a throttled improver costs nodes,
+never a wrong optimum. Graduation must clear the CLAUDE.md Regime-2 panel gate (flag
+default-OFF; `incorrect_count = 0`; no bound above oracle; no `gap_certified=True` → uncertified
+regression; incumbents independently feasibility-verified; net-positive corpus-wide), and must
+be A/B'd on the families that motivated the governor (#347 `clay*`, #321) so the fix does not
+re-break the instances the improvers were built for. Per §R2-7, none of this moves a default
+until that gate passes.
+
+## Artifacts
+
+- Raw JSON: `discopt_benchmarks/results/issue704/h2_walltime_2026-07-17.json`
+- Harness (not committed): `scratchpad/h2_probe.py`, `scratchpad/h2_cprofile.py`


### PR DESCRIPTION
## Summary

Docs-only entry experiment for #704 (H2). **No production/solver code touched** — this is the
measure-first step CLAUDE.md §4 and the issue both require before any build. Adds a diagnosis
doc and the raw measurement JSON.

**Verdict: H2 CONFIRMED.** The improver-LNS contingent (`_improver_allowed`, `_HEUR_COST =
{"rins": 5.0, "lbranch": 10.0}`) charges fixed abstract cost units that are decoupled from real
wall time, so it cannot self-calibrate to families where a sub-MIP is seconds long.

## Method

Measure-only monkeypatch of `discopt._jax.primal_heuristics.rins` / `.local_branching` (timing
wrappers) plus a `node_callback` to timestamp the first incumbent; syn/rsyn panel at
`time_limit=60` on the default auto→NLP-BB path. cProfile corroboration of the issue's cited
datum. Harness not committed. Load caveat per #702: 14-core box at load ≈ 3.3–3.7 with one
concurrent CPU-bound process; single run per instance; the effect size dwarfs plausible load
noise but exact seconds are soft.

## Key numbers (60 s)

| instance | rins mean/max (charged 5.0) | lbranch mean/max (charged 10.0) | improver % of budget | first inc. |
|---|---|---|---|---|
| rsyn0805m | 1.57 / 3.18 s | 4.05 / 4.44 s | **65.2 %** | 7.6 s |
| rsyn0810m | 2.59 / 5.06 s | 4.18 / 4.71 s | **69.3 %** | 11.1 s |
| syn30hfsg | 0.18 / 0.29 s | 2.55 / 2.72 s | 20.9 % | 11.4 s |
| syn40hfsg | 0.12 / 0.20 s | 3.51 / 3.80 s | 19.8 % | 17.6 s |

- **Cost-per-charged-unit for `rins` varies 21×** (0.024 → 0.518 s/unit) while the charge is a
  fixed 5.0 — the abstract denomination is not a wall-time proxy.
- `local_branching` is 2.5–4.7 s per call on every family (never cheap), charged a flat 10.0.
- cProfile reproduces the issue's cited datum: `rsyn0805m` `local_branching` 3 calls / 18.93 s
  / 6.31 s per call (issue cited 3 calls / 18.3 s).

Gap (2) (pre-incumbent bypass) scoped honestly: on the NLP-BB path the RINS/lbranch block is
already nested behind an incumbent check, so the bypass adds no window there; gap (1) is the
dominant, measured defect.

## Not in this PR

No fix. A time-denominated contingent (charge measured seconds vs a fraction of remaining
budget) is proposed in the doc **design-only, behind a flag default-OFF**, to be A/B'd on the
#347/#321 families and graduated only through the CLAUDE.md Regime-2 panel gate. Left for
review; do not merge as a behavior change.

## Verification

Docs + data only; no code paths exercised. `pre-commit` ran clean (nothing to lint — no
`.py`/`.rs` changed).

Doc: `docs/dev/issue-704-h2-improver-walltime-2026-07-17.md`
Data: `discopt_benchmarks/results/issue704/h2_walltime_2026-07-17.json`

Entry-experiment step of #704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
