### PR TITLE
research(#661): qap Shor-SDP entry experiment — CONFIRMED (strong Shor, not plain)

### DIFF
--- a/discopt_benchmarks/results/issue661/qap_shor_plain.json
+++ b/discopt_benchmarks/results/issue661/qap_shor_plain.json
@@ -1,0 +1,16 @@
+{
+  "qap_meta": {
+    "n": 225,
+    "n_eq": 30,
+    "offset": 0.0,
+    "eig_min": -164905.19275524415,
+    "eig_max": 476723.64157340664
+  },
+  "runs": {
+    "shor_plain_SCS": {
+      "bound": -Infinity,
+      "status": "unbounded",
+      "time_s": 0.034559011459350586
+    }
+  }
+}

--- a/discopt_benchmarks/results/issue661/qap_shor_rlt1_gangster.json
+++ b/discopt_benchmarks/results/issue661/qap_shor_rlt1_gangster.json
@@ -1,0 +1,16 @@
+{
+  "qap_meta": {
+    "n": 225,
+    "n_eq": 30,
+    "offset": 0.0,
+    "eig_min": -164905.19275524415,
+    "eig_max": 476723.64157340664
+  },
+  "runs": {
+    "shor_rlt1_gangster_SCS": {
+      "bound": 377098.3849654485,
+      "status": "optimal",
+      "time_s": 86.32528829574585
+    }
+  }
+}

--- a/discopt_benchmarks/results/issue661/qap_shor_sdp_repro.py
+++ b/discopt_benchmarks/results/issue661/qap_shor_sdp_repro.py
@@ -1,0 +1,188 @@
+"""Issue #661 entry experiment: Shor SDP dual bound on qap.
+
+Measures whether the global semidefinite (Shor) relaxation produces a useful dual
+bound on qap, compared to McCormick (~0), RLT-1 (352891, LP), oracle dual (149106),
+and optimum (388214). LOCAL scratch script -- does not touch production solver code.
+"""
+
+import itertools
+import json
+import time
+import sys
+
+import numpy as np
+import cvxpy as cp
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/qap.nl"
+
+OPT = 388214.0
+BEST_DUAL = 149106.0
+MCCORMICK = 0.0
+RLT1_LP = 352890.9
+
+results = {"instance": "qap", "opt": OPT, "best_dual": BEST_DUAL,
+           "mccormick": MCCORMICK, "rlt1_lp_gauge": RLT1_LP, "runs": {}}
+
+
+def extract_qap():
+    """Load qap.nl and extract (Q, c_lin, offset, A_eq, b_eq, binary_vars)."""
+    import discopt.modeling as dm
+    from discopt._jax.milp_relaxation import build_milp_relaxation
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+    from discopt._jax.discretization import DiscretizationState
+    from discopt._jax.rlt import _reconstruct_quadratic_objective
+    from discopt._jax.obbt import _extract_linear_constraints
+    from discopt._jax.model_utils import binary_flat_cols
+
+    model = dm.from_nl(NL)
+    terms = classify_nonlinear_terms(model)
+    relax, info = build_milp_relaxation(model, terms, DiscretizationState())
+    n = len(model._variables)
+    recon = _reconstruct_quadratic_objective(relax, info, n)
+    assert recon is not None, "objective not a pure quadratic"
+    Q, c_lin, offset = recon
+    A_ub, b_ub, A_eq, b_eq, n2 = _extract_linear_constraints(model)
+    assert n2 == n
+    binary_vars = frozenset(binary_flat_cols(model))
+    A_eq = np.asarray(A_eq.todense()) if hasattr(A_eq, "todense") else np.asarray(A_eq)
+    b_eq = np.asarray(b_eq, dtype=float)
+    return Q, c_lin, offset, A_eq, b_eq, binary_vars, n
+
+
+def solve_shor(Q, c_lin, offset, A_eq, b_eq, n, *, add_rlt1=False, add_gangster=False,
+               solver="SCS", time_limit=600):
+    """Solve the Shor SDP relaxation of a binary QP.
+
+    min <Q,X> + c'x + offset
+    s.t.  [[1, x'],[x, X]] >= 0 (PSD),  diag(X)=x,  0<=x<=1,  A_eq x = b_eq
+    optional RLT-1:  A_eq_row . X[:,p] = b x_p    for each equality & var p
+    optional gangster: X_ij = 0 for mutually exclusive assignment pairs
+    """
+    x = cp.Variable(n)
+    X = cp.Variable((n, n), symmetric=True)
+    M = cp.bmat([[np.array([[1.0]]), cp.reshape(x, (1, n))],
+                 [cp.reshape(x, (n, 1)), X]])
+    cons = [M >> 0, cp.diag(X) == x, x >= 0, x <= 1, A_eq @ x == b_eq]
+
+    if add_rlt1:
+        # lifted equality: for each equality row a, (a . X[:,p]) = b_r * x_p
+        for r in range(A_eq.shape[0]):
+            a = A_eq[r]
+            cons.append(A_eq[r] @ X == b_eq[r] * x)
+        # McCormick / RLT bound-factor rows on X (redundant with PSD+diag partly,
+        # but cheap and tightening): 0 <= X_ij <= min(x_i,x_j), X_ij>=x_i+x_j-1
+        cons.append(X >= 0)
+        cons.append(X <= cp.reshape(x, (n, 1)) @ np.ones((1, n)))
+        cons.append(X <= np.ones((n, 1)) @ cp.reshape(x, (1, n)))
+
+    if add_gangster:
+        # exclusive pairs: two binaries both in an equality sum_k x_k = 1 -> X_ij=0
+        zero_pairs = set()
+        for r in range(A_eq.shape[0]):
+            supp = [k for k in range(n) if abs(A_eq[r, k] - 1.0) < 1e-9]
+            if abs(b_eq[r] - 1.0) < 1e-9 and all(abs(A_eq[r, k]) < 1e-9 or abs(A_eq[r, k] - 1.0) < 1e-9 for k in range(n)):
+                for i, j in itertools.combinations(supp, 2):
+                    zero_pairs.add((min(i, j), max(i, j)))
+        for (i, j) in zero_pairs:
+            cons.append(X[i, j] == 0)
+
+    obj = cp.Minimize(cp.trace(Q @ X) + c_lin @ x + offset)
+    prob = cp.Problem(obj, cons)
+    t0 = time.time()
+    kw = {"verbose": False}
+    if solver == "SCS":
+        kw.update(max_iters=20000, eps=1e-5, time_limit_secs=time_limit)
+    prob.solve(solver=getattr(cp, solver), **kw)
+    dt = time.time() - t0
+    return prob.value, prob.status, dt
+
+
+def brute_qap(F, D):
+    """Brute force Koopmans-Beckmann QAP min over permutations. Returns (opt, Q, n2)."""
+    n = F.shape[0]
+    best = np.inf
+    for perm in itertools.permutations(range(n)):
+        c = 0.0
+        for i in range(n):
+            for j in range(n):
+                c += F[i, j] * D[perm[i], perm[j]]
+        best = min(best, c)
+    return best
+
+
+def synthetic_experiment():
+    """Small n=4 Koopmans-Beckmann QAP: brute opt vs McCormick(0) vs Shor vs Shor+RLT1."""
+    rng = np.random.default_rng(0)
+    out = []
+    for n in (4, 5):
+        F = rng.integers(0, 10, size=(n, n)).astype(float)
+        np.fill_diagonal(F, 0)
+        D = rng.integers(0, 10, size=(n, n)).astype(float)
+        D = (D + D.T)
+        np.fill_diagonal(D, 0)
+        opt = brute_qap(F, D)
+        # variables x_{i,k} = facility i at location k, flat index i*n+k
+        N = n * n
+        Q = np.zeros((N, N))
+        for i in range(n):
+            for k in range(n):
+                for j in range(n):
+                    for l in range(n):
+                        Q[i * n + k, j * n + l] += F[i, j] * D[k, l]
+        Q = 0.5 * (Q + Q.T)
+        c_lin = np.zeros(N)
+        # assignment: each facility one loc, each loc one facility
+        rows = []
+        b = []
+        for i in range(n):
+            r = np.zeros(N); r[i * n:(i + 1) * n] = 1.0; rows.append(r); b.append(1.0)
+        for k in range(n):
+            r = np.zeros(N)
+            for i in range(n):
+                r[i * n + k] = 1.0
+            rows.append(r); b.append(1.0)
+        A_eq = np.array(rows); b_eq = np.array(b)
+        shor, st1, dt1 = solve_shor(Q, c_lin, 0.0, A_eq, b_eq, N, solver="CLARABEL")
+        shor_rlt, st2, dt2 = solve_shor(Q, c_lin, 0.0, A_eq, b_eq, N,
+                                        add_rlt1=True, add_gangster=True, solver="CLARABEL")
+        out.append({"n": n, "opt": float(opt), "mccormick": 0.0,
+                    "shor": float(shor), "shor_status": st1,
+                    "shor_rlt1_gangster": float(shor_rlt), "shor_rlt1_status": st2})
+        print(f"synthetic n={n}: opt={opt:.1f} McC=0 Shor={shor:.2f}({st1}) "
+              f"Shor+RLT1+gang={shor_rlt:.2f}({st2})")
+    return out
+
+
+if __name__ == "__main__":
+    print("=== synthetic small-QAP validation ===")
+    results["synthetic"] = synthetic_experiment()
+
+    print("\n=== real qap (n=15, 225 binaries) ===")
+    Q, c_lin, offset, A_eq, b_eq, binary_vars, n = extract_qap()
+    print(f"n={n}, A_eq {A_eq.shape}, offset={offset}, "
+          f"eig(Q) in [{np.linalg.eigvalsh(Q).min():.0f}, {np.linalg.eigvalsh(Q).max():.0f}]")
+    results["qap_meta"] = {"n": n, "n_eq": int(A_eq.shape[0]),
+                           "offset": float(offset),
+                           "eig_min": float(np.linalg.eigvalsh(Q).min()),
+                           "eig_max": float(np.linalg.eigvalsh(Q).max())}
+
+    for tag, kw in [("shor_plain", {}),
+                    ("shor_rlt1_gangster", {"add_rlt1": True, "add_gangster": True})]:
+        for solver in ("CLARABEL", "SCS"):
+            try:
+                print(f"solving qap {tag} with {solver} ...", flush=True)
+                val, st, dt = solve_shor(Q, c_lin, offset, A_eq, b_eq, n, solver=solver, **kw)
+                print(f"  {tag}/{solver}: bound={val} status={st} time={dt:.1f}s")
+                results["runs"][f"{tag}_{solver}"] = {
+                    "bound": (float(val) if val is not None else None),
+                    "status": st, "time_s": dt}
+                if st in ("optimal", "optimal_inaccurate") and val is not None:
+                    break  # got a usable value, don't need the other solver
+            except Exception as e:
+                print(f"  {tag}/{solver} FAILED: {e}")
+                results["runs"][f"{tag}_{solver}"] = {"error": str(e)}
+
+    print("\n=== SUMMARY ===")
+    print(json.dumps(results, indent=2))
+    with open(sys.argv[1] if len(sys.argv) > 1 else "qap_shor_results.json", "w") as f:
+        json.dump(results, f, indent=2)

--- a/discopt_benchmarks/results/issue661/qap_shor_sdp_summary_2026-07-17.json
+++ b/discopt_benchmarks/results/issue661/qap_shor_sdp_summary_2026-07-17.json
@@ -1,0 +1,56 @@
+{
+  "issue": 661,
+  "experiment": "qap Shor-SDP entry experiment (feasibility spike, local scratch, no production code changed)",
+  "date": "2026-07-17",
+  "instance": "qap.nl (Koopmans-Beckmann QAP, n=15, 225 binaries, 30 assignment equalities)",
+  "solver_env": "cvxpy 1.8.1; SCS 3.2.11; CLARABEL",
+  "reference": {
+    "optimum": 388214.0,
+    "published_best_dual": 149106.0,
+    "mccormick_lp_root_bound": 0.0,
+    "rlt1_lp_root_bound_gauge": 352890.9
+  },
+  "qap_meta": {
+    "n": 225,
+    "n_eq": 30,
+    "offset": 0.0,
+    "Q_sym_eig_min": -164905.0,
+    "Q_sym_eig_max": 476724.0,
+    "note": "eig of the symmetrized Q used here; issue quotes the raw-Q spectrum [-330k,+953k]"
+  },
+  "real_qap_runs": {
+    "shor_plain_SCS": {
+      "bound": null,
+      "status": "unbounded",
+      "note": "M>=0 + diag(X)=x + assignment-on-x ONLY (no upper bound on X): the indefinite objective is unbounded below over the PSD cone X>=xx'. Plain Shor as literally posed is useless on qap."
+    },
+    "shor_plain_CLARABEL": {
+      "bound": null,
+      "status": "did-not-finish-in-budget",
+      "time_s": ">300",
+      "note": "same unbounded model"
+    },
+    "shor_rlt1_gangster_SCS": {
+      "bound": 377098.38,
+      "status": "optimal",
+      "time_s": 86.3,
+      "eps": 1e-05,
+      "note": "Shor PSD + diag(X)=x + assignment-on-x + lifted-assignment RLT (A_eq . X = b . x) + McCormick box on X + gangster (X_ij=0 for same-row/col pairs). Sound: 377098 <= 388214 optimum. Approximate (first-order; not yet a rigorous certificate)."
+    },
+    "shor_rlt1_gangster_CLARABEL": {
+      "bound": 357858.09,
+      "status": "user_limit",
+      "time_s": 327.3,
+      "note": "interior-point cross-check; did NOT converge in budget (dense KKT over ~25k SDP-cone vars + ~150k linear rows). Iterate still climbing; confirms the same >350k ballpark. Interior-point is the wrong tool at this scale."
+    }
+  },
+  "synthetic_validation": [
+    {"n": 4, "opt": 490.0, "mccormick": 0.0, "shor_plain": -270.0, "shor_rlt1_gangster": 490.0,
+     "note": "Shor+RLT1+gangster hits the exact brute-force optimum; plain Shor is negative (worse than McCormick 0)."},
+    {"n": 5, "opt": 771.0, "mccormick": 0.0, "shor_plain": -668.24, "shor_rlt1_gangster": 771.0,
+     "note": "exact optimum recovered by Shor+RLT1+gangster"}
+  ],
+  "verdict": "CONFIRMED (with a formulation caveat): plain Shor is FALSIFIED (unbounded/negative), but Shor + lifted-assignment RLT + gangster (ZKRW-style) gives 377098 on qap in 86s with SCS -- above RLT-1's LP gauge (352891), far above the published dual (149106), 97.1% of the optimum, and sound. Kill threshold (>50000) cleared by ~7x.",
+  "tractability": "Tractable at qap scale with a FIRST-ORDER SDP solver (SCS, 86s for the root relaxation). Interior-point (Clarabel) does not finish in budget. Bound is approximate (first-order); a rigorous certificate needs safe dual post-processing (SDP analogue of the Neumaier-Shcherbina bound already used on the RLT-1 LP).",
+  "recommendation": "Conditional GO on relaxation strength; not plain Shor. (1) The useful bound needs lifted-assignment RLT rows + gangster (structure the RLT-1 LP path already builds), NOT plain Shor. (2) The SCS value is not yet a rigorous lower bound -- production integration must derive a safe dual bound from the SDP dual. (3) 86s/root is fine as a root cut but not per-node. (4) A first-order SDP solver is required; interior-point does not scale here. Suggested follow-up: optional root-only strong-Shor SDP bound behind a default-off flag, first-order solver + safe-dual post-process, joined by max with the existing McCormick/PSD/RLT-1 candidates."
+}

--- a/docs/dev/issue-661-qap-sdp-entry-experiment-2026-07-17.md
+++ b/docs/dev/issue-661-qap-sdp-entry-experiment-2026-07-17.md
@@ -1,0 +1,121 @@
+# Issue #661 — qap Shor-SDP entry experiment (2026-07-17)
+
+**Type:** entry experiment / feasibility spike (CLAUDE.md §4 — run the experiment
+*before* building). **No production solver code was changed.** All measurement is a
+local scratch script (`discopt_benchmarks/results/issue661/qap_shor_sdp_repro.py`)
+using `cvxpy 1.8.1` + `SCS 3.2.11` / `CLARABEL` on the extracted qap Q/constraints.
+
+## Hypothesis (H)
+
+The **Shor SDP** relaxation of qap gives a dual bound **much larger than the
+McCormick ~0** — ideally near the best-known dual 149106 — justifying the cost of
+integrating an SDP solve.
+
+## Evidence motivating it (measured, `docs/dev/sparse-milp-plan.md` §T9)
+
+- qap McCormick LP root bound = **~0** (indefinite `x'Qx`, x∈[0,1]).
+- Local (≤6-var) moment/PSD cuts are redundant with McCormick at the McCormick
+  vertex (0 of 223 pairwise minors violated) — only a **global** moment/PSD
+  constraint can bind. This is exactly the Shor SDP `M=[[1,xᵀ],[x,X]]⪰0`.
+- RLT-1 (LP, no SDP) already reaches **352890.9** (issue #661 / sparse-milp-plan
+  "RLT1" entry). So the entry-experiment question is specifically: **does the SDP
+  beat/complement RLT-1, and is it tractable at qap's n=15 (226×226 moment matrix)?**
+
+## Kill criterion (pre-registered)
+
+- **FALSIFIED** if the Shor bound is still ~0 / McCormick-level, **or** intractable
+  at qap scale (226-dim moment matrix) within minutes.
+- **CONFIRMED** if Shor (or Shor+RLT1) is substantially > 0 (say **> 50000**), sound
+  (`≤ 388214`).
+
+## Experiment
+
+Two relaxations were built and solved on both a brute-forceable synthetic
+Koopmans–Beckmann QAP (n=4, 5) and the real `qap.nl` (n=15, 225 binaries, 30
+assignment equalities):
+
+1. **Plain Shor** — `min ⟨Q,X⟩ s.t. M⪰0, diag(X)=x, x∈[0,1], A_eq x = b_eq`
+   (assignment on x only; the formulation named literally in the issue).
+2. **Strong Shor (ZKRW-style)** — plain Shor **plus** the lifted-assignment RLT rows
+   (`A_eq·X = b_eq·x`), the McCormick box on X (`0 ≤ X_ij ≤ min(x_i,x_j)`,
+   `X_ij ≥ x_i+x_j−1`), and the **gangster** constraints (`X_ij = 0` for two binaries
+   in the same assignment row/column — they cannot both be 1).
+
+Q, c, offset and A_eq/b_eq were extracted through the *existing* production helpers
+(`_reconstruct_quadratic_objective`, `_extract_linear_constraints`) so the model is
+identical to what the solver sees.
+
+## Results
+
+### Synthetic QAP (brute-force optimum available)
+
+| n | optimum | McCormick | plain Shor | strong Shor (RLT1+gangster) |
+|---|--------:|----------:|-----------:|----------------------------:|
+| 4 | 490     | 0         | **−270**   | **490.0** (exact)           |
+| 5 | 771     | 0         | **−668**   | **771.0** (exact)           |
+
+Plain Shor is **worse than McCormick** (negative). Strong Shor recovers the **exact
+optimum** — i.e. the SDP+gangster relaxation is tight on small QAPs, and the fix is
+general (not a qap special-case).
+
+### Real qap (n=15, 225 binaries)
+
+| relaxation | solver | bound | status | time |
+|---|---|---:|---|---:|
+| plain Shor | SCS | **unbounded (−∞)** | unbounded | 0 s |
+| plain Shor | Clarabel | — | did not finish | >300 s |
+| **strong Shor (RLT1+gangster)** | **SCS** | **377098** | optimal | **86 s** |
+| strong Shor (RLT1+gangster) | Clarabel | 357858 | user_limit (not converged) | 327 s |
+
+Reference ladder for qap: McCormick **~0** · published dual **149106** · RLT-1 LP
+**352891** · **strong-Shor SDP 377098** · optimum **388214**.
+
+- **Plain Shor is unbounded** on qap: with only PSD + diag + assignment-on-x, the
+  indefinite objective runs to −∞ over the cone `X ⪰ xxᵀ`. The bound comes entirely
+  from the McCormick box + lifted-assignment + gangster constraints.
+- **Strong Shor = 377098**, i.e. **97.1 % of the optimum**, above the RLT-1 LP gauge
+  (352891) and **~2.5× the published dual** (149106). Sound: `377098 ≤ 388214`.
+- **SCS (first-order) converges in 86 s**; interior-point (Clarabel) does not finish
+  (its 327 s iterate of 357858 is still climbing and confirms the same >350k
+  ballpark). First-order is the right tool at this scale.
+
+## Verdict — **CONFIRMED**, with a formulation caveat
+
+H is **confirmed for the strong (ZKRW-style) Shor SDP** — 377098 clears the >50000
+kill threshold by ~7× and is the tightest known root bound for qap — but **plain Shor
+as literally posed in the issue is FALSIFIED** (unbounded / negative; useless). The
+lever is the SDP *plus* the lifted-assignment RLT rows and gangster constraints, not
+the bare moment-matrix PSD.
+
+## Caveats (soundness & cost)
+
+- The SCS value is a **first-order approximate** optimum (eps=1e-5), **not yet a
+  rigorous lower bound**. It sat below the optimum in every run, but production use
+  must derive a **safe dual bound from the SDP dual** (the SDP analogue of the
+  Neumaier–Shcherbina safe bound already used on the RLT-1 LP, `obbt._ns_safe_lp_lower_bound`).
+- 86 s is fine for a **root** cut; it is **not** a per-node cost.
+- Interior-point SDP does **not** scale here — a first-order/ADMM SDP (SCS-class) is
+  required.
+
+## Go / no-go recommendation
+
+**Conditional GO** on relaxation strength, scoped narrowly:
+
+- Add an **optional, root-only, default-off** strong-Shor SDP bound (flag, §5
+  bound-changing), joined by `max` with the existing McCormick / PSD / RLT-1
+  candidates in `solver.py::_root_relaxation_lower_bound` — it can only raise the
+  bound.
+- **Solver:** a first-order SDP (SCS-class). **Constraints:** PSD moment matrix +
+  `diag(X)=x` + assignment + **lifted-assignment RLT** + McCormick box on X +
+  **gangster** (all derivable from structure the RLT-1 path already extracts; stated
+  generally per §2, keyed to set-partitioning equalities, not to "qap").
+- **Expected bound:** ~97 % of optimum on qap (377k), exact on small QAPs.
+- **Blocking requirement before default-on:** a rigorous safe-dual post-process on
+  the SDP dual (no first-order value surfaced as a bound without it), plus the §5
+  differential/feasible-point gates and the global50 `incorrect_count == 0` panel.
+
+## Reproduction
+
+`discopt_benchmarks/results/issue661/qap_shor_sdp_repro.py` (synthetic + real qap);
+raw numbers in `qap_shor_sdp_summary_2026-07-17.json`, `qap_shor_plain.json`,
+`qap_shor_rlt1_gangster.json` in the same directory.


### PR DESCRIPTION
## Summary

Entry experiment / feasibility spike for #661 (CLAUDE.md §4 — run the experiment
*before* building). Measures whether a global **Shor SDP** produces a useful dual
bound on qap before committing to integrate an SDP solver. **Docs + raw JSON + repro
script only — no production solver code touched.**

## Hypothesis

The Shor SDP relaxation of qap gives a dual bound **much larger than McCormick ~0**,
justifying SDP integration.

## Kill criterion (pre-registered)

FALSIFIED if the bound is still ~0 / McCormick-level, or intractable at qap's n=15
(226-dim moment matrix) in minutes. CONFIRMED if substantially > 0 (>50000) and sound
(≤ 388214).

## Result — CONFIRMED (with a formulation caveat)

qap.nl (n=15, 225 binaries, 30 assignment equalities), via cvxpy + SCS/Clarabel:

| relaxation | bound | status | time |
|---|---:|---|---:|
| McCormick LP (ref) | ~0 | — | — |
| published best dual (ref) | 149106 | — | — |
| RLT-1 LP gauge (ref, already landed) | 352891 | — | — |
| **plain Shor** (M⪰0, diag(X)=x, x∈[0,1]) | **unbounded −∞** | unbounded | 0 s |
| **strong Shor** (+ lifted-assignment RLT + McCormick box on X + gangster) | **377098** | optimal (SCS) | **86 s** |
| optimum (ref) | 388214 | — | — |

- **Plain Shor is FALSIFIED** — unbounded on qap (indefinite objective runs off the
  cone `X⪰xxᵀ`); on synthetic n=4/5 it is even *negative* (worse than McCormick 0).
- **Strong Shor (ZKRW-style) is CONFIRMED** — 377098 = **97.1 % of the optimum**,
  above the RLT-1 LP gauge and ~2.5× the published dual, sound. On synthetic n=4/5 it
  recovers the **exact** brute-force optimum, so the fix is general, not a qap
  special-case.
- **Tractable only with a first-order SDP solver** (SCS, 86 s). Interior-point
  (Clarabel) does not converge in budget.

## Go / no-go

**Conditional GO** on strength: an optional, **root-only, default-off** strong-Shor
SDP bound joined by `max` with the existing McCormick/PSD/RLT-1 candidates.
**Blocking before default-on:** the SCS value is a first-order *approximate* optimum,
not a rigorous certificate — production must derive a **safe dual bound from the SDP
dual** (the SDP analogue of the NS-safe LP bound), then pass the §5 differential /
feasible-point gates + global50 `incorrect_count == 0`.

## What was run

Local scratch only (`discopt_benchmarks/results/issue661/qap_shor_sdp_repro.py`);
synthetic QAP validation (n=4,5) + real qap. No pytest/cargo suites relevant (docs +
data only; no code paths changed). Full writeup:
`docs/dev/issue-661-qap-sdp-entry-experiment-2026-07-17.md`.

Leaving for review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
