### PR TITLE
feat(#280): one-hot swap reseed on the MILP fast path (default-off flag)

### DIFF
--- a/discopt_benchmarks/results/issue280/swap_reseed_panel_2026-07-17.json
+++ b/discopt_benchmarks/results/issue280/swap_reseed_panel_2026-07-17.json
@@ -1,0 +1,15 @@
+{
+  "issue": 280,
+  "flag": "DISCOPT_MILP_SWAP_RESEED",
+  "default": "off",
+  "date": "2026-07-17",
+  "note": "Starter differential panel (flag OFF vs ON) for the MILP-fast-path one-hot swap reseed. Single run/arm, TL=30s, contended box - directional evidence toward graduation, not the full corpus-wide gate. Full graduation to default-ON needs the corpus-wide graphpart panel + global50 cert-clean per CLAUDE.md §5.",
+  "time_limit_s": 30,
+  "rows": [
+    {"instance": "graphpart_2pm-0055-0055", "oracle": -20.0, "off_obj": -20.0, "off_bound": -20.0, "on_obj": -20.0, "on_bound": -20.0, "verdict": "tie (both optimal, certified)"},
+    {"instance": "graphpart_2pm-0077-0777", "oracle": -40.0, "off_obj": -34.0, "off_bound": -41.0, "on_obj": -36.0, "on_bound": -41.5, "verdict": "ON better primal"},
+    {"instance": "graphpart_2pm-0088-0888", "oracle": -55.0, "off_obj": -55.0, "off_bound": -56.0, "on_obj": -55.0, "on_bound": -56.0, "verdict": "tie (both optimal)"},
+    {"instance": "graphpart_2pm-0099-0999", "oracle": -64.0, "off_obj": -49.0, "off_bound": -74.5, "on_obj": -55.0, "on_bound": -74.0, "verdict": "ON better primal (+6)"}
+  ],
+  "summary": {"on_better_primal": 2, "tie": 2, "on_worse": 0, "unsound": 0, "soundness": "all bounds <= oracle, all incumbents >= oracle (min sense)"}
+}

--- a/discopt_benchmarks/scripts/issue280_swap_reseed_panel.py
+++ b/discopt_benchmarks/scripts/issue280_swap_reseed_panel.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import warnings
+
+sys.path.insert(0, "python")
+from discopt.modeling.core import from_nl
+
+NL = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+SOLU = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu")
+
+
+def oracle(name):
+    with open(SOLU) as f:
+        for line in f:
+            p = line.split()
+            if len(p) >= 3 and p[1] == name and p[0] in ("=opt=", "=best="):
+                return float(p[2])
+    return None
+
+
+insts = sys.argv[1].split(",")
+tl = float(sys.argv[2])
+_hdr_l = f"{'instance':24s} {'oracle':>9s}"
+_hdr_off = f"{'OFF obj':>8s} {'OFF bnd':>9s}"
+_hdr_on = f"{'ON obj':>8s} {'ON bnd':>9s}"
+print(f"{_hdr_l} | {_hdr_off} | {_hdr_on} | verdict")
+for name in insts:
+    opt = oracle(name)
+    row = []
+    for flag in ("0", "1"):
+        os.environ["DISCOPT_MILP_SWAP_RESEED"] = flag
+        m = from_nl(f"{NL}/{name}.nl")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            r = m.solve(time_limit=tl)
+        row.append((r.objective, r.bound))
+    (o0, b0), (o1, b1) = row
+    # soundness: for these min problems bound <= opt <= obj
+    snd = all(b is None or opt is None or b <= opt + 1e-4 for b in (b0, b1)) and all(
+        o is None or opt is None or o >= opt - 1e-4 for o in (o0, o1)
+    )
+    # primal verdict
+    if o0 is None or o1 is None:
+        v = "?"
+    elif o1 < o0 - 1e-6:
+        v = "ON BETTER primal"
+    elif o1 > o0 + 1e-6:
+        v = "ON WORSE primal"
+    else:
+        v = "tie primal"
+
+    def fo(x):
+        return f"{x:.2f}" if x is not None else "None"
+
+    mark = "" if snd else "  !!!UNSOUND"
+    left = f"{name:24s} {fo(opt):>9s}"
+    off = f"{fo(o0):>8s} {fo(b0):>9s}"
+    on = f"{fo(o1):>8s} {fo(b1):>9s}"
+    print(f"{left} | {off} | {on} | {v}{mark}")

--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -570,6 +570,10 @@ def _attach_warm_start_spec(model: Model, new_model: Model, exp: "_Expander") ->
         return
     setattr(new_model, "_ipx_aux_spec", translated)  # noqa: B010
     setattr(new_model, "_ipx_n_orig_flat", n_orig_flat)  # noqa: B010
+    # Stash the pre-lift model so a primal reseed (the #280 one-hot swap) can run
+    # assignment-aware moves over the ORIGINAL variables and map the result back
+    # through the spec above. Purely primal metadata; never a soundness lever.
+    setattr(new_model, "_ipx_source_model", model)  # noqa: B010
 
 
 def extend_initial_point(reformed: Model, x0) -> Optional[np.ndarray]:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -13998,6 +13998,56 @@ def _root_dive(
 _SIMPLEX_MILP_BUDGET_CAP_S = 10.0
 
 
+def _one_hot_swap_reseed(model: Model, x_lifted: np.ndarray, budget: float) -> Optional[np.ndarray]:
+    """A lifted-space seed built by improving *x_lifted* with an assignment-aware
+    swap over the ORIGINAL variables, or ``None`` when unavailable.
+
+    On set-partition / assignment-structured models (``sum_k x[i,k] == 1``) a
+    single bit flip always breaks a one-hot row, so the engine's generic
+    flip/dive heuristics make little headway and its incumbent stalls well above
+    the optimum while the dual bound is already tight (#280). The
+    feasibility-preserving move is a *swap*, which is only well defined on the
+    pre-lift model: permuting bits in the lifted space leaves the expansion /
+    big-M auxiliaries stale, i.e. genuinely infeasible. So swap over the
+    originals, then reconstruct the aux exactly (#689 / #696).
+
+    Purely primal and never a soundness lever — the result is only ever handed
+    back as an ``initial_incumbent``, which the Rust driver re-validates (bounds,
+    integrality, row feasibility) and re-scores from ``c``. A bad or worse point
+    is dropped by the engine, never trusted; the dual bound and the certificate
+    are untouched either way. Self-gates to a no-op (returns ``None``) when the
+    model was not lifted or carries no one-hot structure."""
+    src = getattr(model, "_ipx_source_model", None)
+    n0 = getattr(model, "_ipx_n_orig_flat", None)
+    if src is None or n0 is None or budget <= 0.2:
+        return None
+    # ``one_hot_swap_search`` scores with the model's own objective and accepts
+    # strict *decreases*, so it only searches in the improving direction on a
+    # minimize model. On a maximize model it would drive the wrong way and the
+    # engine would just discard the seed — skip rather than burn the budget.
+    from discopt.modeling.core import ObjectiveSense as _Sense
+
+    obj = getattr(src, "_objective", None)
+    if obj is None or obj.sense != _Sense.MINIMIZE:
+        return None
+    try:
+        from discopt._jax.integer_product_reform import extend_initial_point
+        from discopt._jax.primal_heuristics import one_hot_swap_search
+
+        sw = one_hot_swap_search(
+            src,
+            np.asarray(x_lifted[: int(n0)], dtype=np.float64),
+            time_budget=min(1.0, budget * 0.5),
+            deadline=time.perf_counter() + budget,
+        )
+        if sw is None:
+            return None
+        return extend_initial_point(model, sw[0])
+    except Exception as _exc:  # pragma: no cover - defensive
+        logger.debug("one-hot swap reseed skipped: %s", _exc)
+        return None
+
+
 def _solve_milp_simplex(
     model: Model,
     time_limit: float,
@@ -14180,6 +14230,26 @@ def _solve_milp_simplex(
             _seed2 = None
             if _xo1.size == n_orig:
                 _seed2 = np.ascontiguousarray(_xo1.astype(np.float64).ravel())
+            # #280: on assignment-structured models the stalled incumbent escapes
+            # only via a feasibility-preserving one-hot *swap* (a single bit flip
+            # breaks a one-hot row, so generic flip/dive heuristics stall). Improve
+            # the point with an assignment-aware swap over the ORIGINAL variables
+            # and reseed run 2 with it; fall back to the plain incumbent when the
+            # model was not lifted / has no one-hot structure. Purely primal — the
+            # driver re-validates and re-scores the seed, and the adoption gate
+            # below re-verifies the returned point via ``_point_feasible``, so a
+            # worse or invalid seed can only cost search, never the certificate.
+            # Default-OFF pending a graduation panel: sound, and the mechanism is
+            # verified (escapes a stalled assignment incumbent to the optimum in
+            # the reseed), but not yet shown net-positive vs the plain engine —
+            # the swap search costs a wall slice and can leave a marginally looser
+            # bound. Flag ON/OFF is the §5 differential-panel gate (issue #280).
+            if os.environ.get("DISCOPT_MILP_SWAP_RESEED", "0") == "1":
+                _swap_seed = _one_hot_swap_reseed(
+                    model, np.asarray(x_struct, dtype=np.float64), _reentry_remaining
+                )
+                if _swap_seed is not None and _swap_seed.size == n_orig:
+                    _seed2 = np.ascontiguousarray(_swap_seed.astype(np.float64).ravel())
             (
                 _status2,
                 _x2,

--- a/python/tests/test_issue_280_milp_reseed.py
+++ b/python/tests/test_issue_280_milp_reseed.py
@@ -1,0 +1,123 @@
+"""Regression tests for the #280 primal lever on the Rust MILP fast path.
+
+On set-partition / assignment-structured models (``sum_k x[i,k] == 1``) a single
+bit flip always breaks a one-hot row, so the engine's generic flip/dive
+heuristics stall well above the optimum while the dual bound is already tight
+(#280). The feasibility-preserving move is a *swap*, and it is only well defined
+on the pre-lift model: permuting bits in the integer-bilinear-lifted space leaves
+the expansion / big-M auxiliaries stale (genuinely infeasible).
+
+``_one_hot_swap_reseed`` runs the assignment-aware swap over the ORIGINAL
+variables and maps the improved point back through the lift's reconstruction spec
+(#689 / #696), producing a lifted-width seed for a re-entry of the MILP engine on
+an uncertified ``feasible``. It is purely primal: the seed is only ever handed to
+the Rust driver as an ``initial_incumbent`` (re-validated + re-scored there) and
+the re-entry adoption gate re-verifies the returned point, so a worse or invalid
+seed can only cost search, never the certificate.
+
+These tests are synthetic and corpus-free so they run in CI. They pin: the reform
+stashing the pre-lift model, the swap-reseed strictly improving a stalled
+assignment incumbent at the lifted width, and the no-op gating (maximize / not
+lifted / no budget) that keeps the move from firing where it does not apply.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.integer_product_reform import (
+    extend_initial_point,
+    reformulate_integer_bilinear,
+)
+from discopt._jax.nlp_evaluator import cached_evaluator
+from discopt._jax.primal_heuristics import _check_constraint_feasibility
+from discopt.solver import _one_hot_swap_reseed
+
+# A weighted K4 where the balanced split {0,1}|{2,3} costs 2 but {0,2}|{1,3} costs
+# 20 — one swap of nodes 1 and 2 turns the bad split optimal.
+_EDGES = [(0, 2, 10.0), (1, 3, 10.0), (0, 1, 1.0), (2, 3, 1.0), (0, 3, 1.0), (1, 2, 1.0)]
+
+
+def _partition_model(N, K, per, edges, *, maximize=False):
+    """min (or max) within-partition edge weight; each node in one partition,
+    balanced. Built the way the ``.nl`` reader encodes the real ``graphpart_*``
+    family: **scalar** decision columns declared ``INTEGER`` over ``[0, 1]`` (not
+    ``BINARY``) — ``_int_factor_range`` excludes declared binaries, so only this
+    shape exercises the integer-bilinear lift (#689)."""
+    m = dm.Model("gp")
+    x = [[m.integer(f"x_{i}_{k}", lb=0, ub=1) for k in range(K)] for i in range(N)]
+    for i in range(N):
+        m.subject_to(dm.sum(x[i][k] for k in range(K)) == 1, name=f"assign_{i}")
+    for k in range(K):
+        m.subject_to(dm.sum(x[i][k] for i in range(N)) == per, name=f"bal_{k}")
+    obj = dm.sum(w * dm.sum(x[i][k] * x[j][k] for k in range(K)) for (i, j, w) in edges)
+    m.maximize(obj) if maximize else m.minimize(obj)
+    return m, x
+
+
+def _flat_assignment(N, K, assign):
+    xf = np.zeros(N * K, dtype=np.float64)
+    for i, k in enumerate(assign):
+        xf[i * K + k] = 1.0
+    return xf
+
+
+@pytest.mark.smoke
+def test_reform_stashes_source_model():
+    """The lift must stash the pre-lift model so the swap can run over the
+    originals (the metadata ``_one_hot_swap_reseed`` depends on)."""
+    m, _ = _partition_model(4, 2, 2, _EDGES)
+    rm = reformulate_integer_bilinear(m)
+    assert len(rm._variables) > len(m._variables), "expected the reform to lift"
+    assert getattr(rm, "_ipx_source_model", None) is m
+    assert rm._ipx_n_orig_flat == sum(int(v.size) for v in m._variables)
+
+
+@pytest.mark.smoke
+def test_reseed_improves_stalled_assignment_incumbent():
+    """From the bad split (cost 20) the swap-reseed returns a lifted-width seed at
+    the optimum (cost 2), feasible on every lifted row."""
+    m, _ = _partition_model(4, 2, 2, _EDGES)
+    rm = reformulate_integer_bilinear(m)
+    ev = cached_evaluator(rm)
+
+    bad = extend_initial_point(rm, _flat_assignment(4, 2, [0, 1, 0, 1]))  # {0,2}|{1,3}
+    assert bad is not None
+    assert float(ev.evaluate_objective(bad)) == pytest.approx(20.0, abs=1e-9)
+
+    seed = _one_hot_swap_reseed(rm, bad, budget=2.0)
+    assert seed is not None, "swap-reseed should improve the stalled incumbent"
+    # Lifted width — matches the MILP driver's structural column count (n_orig),
+    # which is the guard the re-entry applies before handing it back.
+    assert seed.size == sum(int(v.size) for v in rm._variables)
+    assert float(ev.evaluate_objective(seed)) < 20.0 - 1e-9
+    assert float(ev.evaluate_objective(seed)) == pytest.approx(2.0, abs=1e-6)
+    # The reconstructed aux must satisfy the lifted rows (a wrong extension would
+    # hand the engine a genuinely infeasible seed).
+    assert _check_constraint_feasibility(ev, seed)
+
+
+@pytest.mark.smoke
+def test_reseed_gates_off_when_inapplicable():
+    """Self-gates to ``None`` where the move does not apply — never a guess."""
+    m, _ = _partition_model(4, 2, 2, _EDGES)
+    rm = reformulate_integer_bilinear(m)
+    bad = extend_initial_point(rm, _flat_assignment(4, 2, [0, 1, 0, 1]))
+
+    # No time to run the search.
+    assert _one_hot_swap_reseed(rm, bad, budget=0.1) is None
+
+    # A model that was never lifted carries no ``_ipx_source_model``.
+    bare = dm.Model("bare")
+    xb = bare.integer("x", lb=0, ub=1)
+    bare.minimize(xb)
+    assert _one_hot_swap_reseed(bare, np.zeros(1), budget=2.0) is None
+
+    # Maximize: the swap only searches the improving (decreasing) direction, so it
+    # would drive the wrong way — skip rather than hand back a worse seed.
+    mm, _ = _partition_model(4, 2, 2, _EDGES, maximize=True)
+    rmm = reformulate_integer_bilinear(mm)
+    bad_max = extend_initial_point(rmm, _flat_assignment(4, 2, [0, 0, 1, 1]))
+    assert bad_max is not None
+    assert _one_hot_swap_reseed(rmm, bad_max, budget=2.0) is None


### PR DESCRIPTION
## What this is

The **#280 primal lever**, carved out of #695 as a focused change. On
assignment-structured models (`sum_k x[i,k] == 1`) a single bit flip breaks a
one-hot row, so the engine's generic flip/dive heuristics stall well above the
optimum while the dual bound is already tight. The feasibility-preserving move
is a *swap*, well defined only on the pre-lift model.

`_one_hot_swap_reseed` runs an assignment-aware swap over the **original**
variables and maps the improved point back through the integer-bilinear lift's
exact reconstruction spec (`extend_initial_point`, #689/#696 — already on main),
producing a lifted-width seed for the #705 re-entry on an uncertified `feasible`.
The reform now also stashes `_ipx_source_model` so the swap can reach the
originals.

## Why #695 is closed in favor of this

#695 bundled three fixes; two landed while it sat stale:

| #695 piece | now on main via | status |
|---|---|---|
| #698 re-entry (spend leftover budget) | #705 | superseded |
| #689 warm-start lift across the reform | #696 | superseded (main's is newer) |
| **#280 one-hot-swap reseed** | — | **this PR** |

A straight rebase of #695 would re-apply its *older* #689/#698 drafts on top of
the better merged versions (a regression), which is why it's CONFLICTING at 48
commits behind. This PR ports only the still-unmerged piece, adapted to main's
#696 API.

## Soundness

Purely primal. The swap result is only ever handed to the Rust driver as an
`initial_incumbent` (re-validated for bounds/integrality/row feasibility and
re-scored from `c` there), and the re-entry adoption gate re-verifies the
returned point via `_point_feasible`. A worse or invalid seed can only cost
search — never the dual bound or the certificate. Verified: no bound crosses its
oracle on any tested instance; adversarial recent-fixes suite (false-certificate
hunt) 10 passed.

## Default OFF — "sound != helpful"

Behind `DISCOPT_MILP_SWAP_RESEED`, **default off**, per CLAUDE.md §5. The
mechanism is verified (traced escaping a stalled `-46` incumbent to the optimum
`-55` in the reseed), but it does not graduate default-on until a corpus-wide
differential panel proves it net-positive. Being honest: on `graphpart_2pm-0088`
alone it's *neutral* (the plain engine reaches the optimum in the same budget) —
one instance is not evidence.

**Starter panel** (flag OFF vs ON, TL=30 s, single run/arm, contended box —
directional; `discopt_benchmarks/results/issue280/swap_reseed_panel_2026-07-17.json`):

| instance | oracle | OFF obj | ON obj | verdict |
|---|---|---|---|---|
| graphpart_2pm-0055 | -20 | -20 | -20 | tie (both optimal) |
| graphpart_2pm-0077 | -40 | -34 | **-36** | ON better |
| graphpart_2pm-0088 | -55 | -55 | -55 | tie (both optimal) |
| graphpart_2pm-0099 | -64 | -49 | **-55** | ON better (+6) |

2/4 strictly better primal, 2/4 tie, **0 worse, 0 unsound**. Net-positive and
directional — full graduation needs the corpus-wide graphpart panel + global50
`incorrect_count==0`.

## Tests

`python/tests/test_issue_280_milp_reseed.py` (3, fail-before/pass-after): the
source-model stash, a strict `20 -> 2` improvement at lifted width with feasible
reconstructed aux, and maximize/unlifted/no-budget no-op gating.

- `pytest -m smoke` -> **666 passed, 1 skipped** (default-off neutral)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` -> **10 passed**
- `ruff check` / `ruff format --check` clean

Contributes to #280 (primal half; default-off pending graduation). Supersedes #695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
