### PR TITLE
perf(#390): vectorize JAX fuzz loops in the slowest PR-fast soundness tests

### DIFF
--- a/python/tests/test_g_convex_inject.py
+++ b/python/tests/test_g_convex_inject.py
@@ -12,6 +12,7 @@ thing off by default.
 from __future__ import annotations
 
 import discopt.modeling as dm
+import jax
 import jax.numpy as jnp
 import numpy as np
 from discopt._jax.convexity.g_convex_inject import (
@@ -31,17 +32,25 @@ def _cut_bodies(m):
 
 
 def _feasible_never_removed(m, body_expr, cut_fns, *, box_lb, box_ub, seed=0, n=60000):
-    """No point feasible for ``body_expr ≤ 0`` violates any injected cut."""
+    """No point feasible for ``body_expr ≤ 0`` violates any injected cut.
+
+    The fuzz is fully vectorized: the ``n`` sample points are drawn as one
+    ``(n, d)`` block and every compiled body/cut is evaluated with ``jax.vmap``
+    in a single dispatch. ``rng.uniform`` fills the block row-major from the
+    same bit stream, so these are the *identical* points the old per-point loop
+    drew — same samples, same tolerance, same soundness assertion, ~1000× fewer
+    JAX dispatches.
+    """
     fbody = compile_expression(body_expr, m)
     rng = np.random.default_rng(seed)
-    checked = 0
+    x = rng.uniform(box_lb, box_ub, size=(n, len(box_lb)))
+    feasible = np.asarray(jax.vmap(fbody)(jnp.asarray(x))) <= 0.0  # feasible for the original
+    checked = int(feasible.sum())
     worst = -np.inf
-    for _ in range(n):
-        x = rng.uniform(box_lb, box_ub)
-        if float(fbody(jnp.asarray(x))) <= 0.0:  # feasible for the original
-            checked += 1
-            for fc in cut_fns:
-                worst = max(worst, float(fc(jnp.asarray(x))))  # cut body ≤ 0 form
+    if checked:
+        xf = jnp.asarray(x[feasible])
+        for fc in cut_fns:
+            worst = max(worst, float(jnp.max(jax.vmap(fc)(xf))))  # cut body ≤ 0 form
     assert worst <= 1e-7, f"injected cut removed a feasible point (residual={worst})"
     return checked
 
@@ -81,12 +90,12 @@ class TestInjectorSoundness:
         fbody = compile_expression(body, m)
         cut_fns = _cut_bodies(m)
         rng = np.random.default_rng(3)
-        separated = 0
-        for _ in range(40000):
-            x = rng.uniform([1.4, 1.6], [1.5, 1.7])
-            if float(fbody(jnp.asarray(x))) > 0.0:  # infeasible for original
-                if max(float(fc(jnp.asarray(x))) for fc in cut_fns) > 1e-7:
-                    separated += 1
+        x = rng.uniform([1.4, 1.6], [1.5, 1.7], size=(40000, 2))
+        infeasible = np.asarray(jax.vmap(fbody)(jnp.asarray(x))) > 0.0  # infeasible for original
+        cut_max = np.full(x.shape[0], -np.inf)  # max cut residual per point
+        for fc in cut_fns:
+            cut_max = np.maximum(cut_max, np.asarray(jax.vmap(fc)(jnp.asarray(x))))
+        separated = int(np.count_nonzero(infeasible & (cut_max > 1e-7)))
         assert separated > 0, "cuts are valid but vacuous — they separate nothing"
 
     def test_ge_constraint_g_concave_body(self):

--- a/python/tests/test_g_signomial_products.py
+++ b/python/tests/test_g_signomial_products.py
@@ -13,6 +13,8 @@ products/ratios that are neither convex nor concave.
 
 from __future__ import annotations
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 from discopt._jax.convexity.g_products_ratios import (
@@ -45,37 +47,46 @@ class TestSignomialSecantOverestimator:
     ub = np.array([1.0, 1.0])
 
     def test_secant_envelope_is_valid(self):
+        # Vectorized over the 2000-point fuzz: the signomial value and the DC
+        # envelope are ``jax.vmap``'d across the whole sample block in one
+        # dispatch each. ``rng.uniform`` fills the block row-major, so these are
+        # the identical points the per-point loop drew — same validity assertion.
         rng = np.random.default_rng(1)
-        for _ in range(2000):
-            u = rng.uniform(self.lb, self.ub)
-            sv = _s(u, self.terms)
-            cv, cc = (
-                float(v)
-                for v in signed_signomial_dc_envelope(
-                    u, self.terms, self.lb, self.ub, overestimator="secant"
+        u = jnp.asarray(rng.uniform(self.lb, self.ub, size=(2000, self.lb.shape[0])))
+        pp, pm = jax.vmap(lambda uu: _posynomial_parts(uu, self.terms))(u)
+        sv = np.asarray(pp - pm)
+        cv, cc = (
+            np.asarray(v)
+            for v in jax.vmap(
+                lambda uu: signed_signomial_dc_envelope(
+                    uu, self.terms, self.lb, self.ub, overestimator="secant"
                 )
-            )
-            assert cv - 1e-9 <= sv <= cc + 1e-9
+            )(u)
+        )
+        assert np.all(cv - 1e-9 <= sv) and np.all(sv <= cc + 1e-9)
 
     def test_secant_never_looser_than_corner(self):
         rng = np.random.default_rng(2)
-        for _ in range(2000):
-            u = rng.uniform(self.lb, self.ub)
-            cvc, ccc = (
-                float(v)
-                for v in signed_signomial_dc_envelope(
-                    u, self.terms, self.lb, self.ub, overestimator="corner"
+        u = jnp.asarray(rng.uniform(self.lb, self.ub, size=(2000, self.lb.shape[0])))
+        cvc, ccc = (
+            np.asarray(v)
+            for v in jax.vmap(
+                lambda uu: signed_signomial_dc_envelope(
+                    uu, self.terms, self.lb, self.ub, overestimator="corner"
                 )
-            )
-            cvs, ccs = (
-                float(v)
-                for v in signed_signomial_dc_envelope(
-                    u, self.terms, self.lb, self.ub, overestimator="secant"
+            )(u)
+        )
+        cvs, ccs = (
+            np.asarray(v)
+            for v in jax.vmap(
+                lambda uu: signed_signomial_dc_envelope(
+                    uu, self.terms, self.lb, self.ub, overestimator="secant"
                 )
-            )
-            # secant tightens: cc no larger, cv no smaller
-            assert ccs <= ccc + 1e-9
-            assert cvs >= cvc - 1e-9
+            )(u)
+        )
+        # secant tightens: cc no larger, cv no smaller
+        assert np.all(ccs <= ccc + 1e-9)
+        assert np.all(cvs >= cvc - 1e-9)
 
     def test_single_monomial_strictly_tighter_interior(self):
         terms = [(1.0, 0.0, np.array([1.0]))]  # exp(u)

--- a/python/tests/test_mccormick_subgradient.py
+++ b/python/tests/test_mccormick_subgradient.py
@@ -30,30 +30,34 @@ RNG = np.random.default_rng(0)
 
 
 def _sound(model, lb, ub, f_true, n_samples=300):
+    # Vectorized fuzz: the underestimator ``u`` (and its gradient) are the only
+    # JAX-dispatched work, so they are evaluated over the whole sample block with
+    # ``jax.vmap`` in one shot instead of one dispatch per point. Draw order is
+    # preserved bit-for-bit (P first, then the 120 (a, b) chord pairs interleaved
+    # via a (120, 2, n) block), so the shared module RNG stays in sync for the
+    # rest of the file and these are the identical samples the old loop tested.
     R = build_reduced_relaxation(model, lb, ub)
     u = R.obj_under
     n = R.n
     P = lb + RNG.random((n_samples, n)) * (ub - lb)
+    uP = np.asarray(jax.vmap(u)(jnp.asarray(P)))
+    fP = np.array([float(f_true(x)) for x in P])  # f_true is cheap numpy, kept per-row
     # validity: u(x) <= f(x)
-    for x in P:
-        assert float(u(jnp.asarray(x))) <= float(f_true(x)) + 1e-6 * (abs(float(f_true(x))) + 1)
-    # convexity + subgradient validity
-    gu = jax.grad(lambda z: u(z))
-    for _ in range(120):
-        a = lb + RNG.random(n) * (ub - lb)
-        b = lb + RNG.random(n) * (ub - lb)
-        mid = 0.5 * (a + b)
-        assert (
-            float(u(jnp.asarray(mid)))
-            <= 0.5 * (float(u(jnp.asarray(a))) + float(u(jnp.asarray(b)))) + 1e-6
-        )
-        u_a = float(u(jnp.asarray(a)))
-        g = np.asarray(gu(jnp.asarray(a)))
-        assert float(u(jnp.asarray(b))) >= u_a + g @ (b - a) - 1e-6 * (abs(u_a) + 1)
+    assert np.all(uP <= fP + 1e-6 * (np.abs(fP) + 1))
+    # convexity + subgradient validity over 120 random chords
+    ab = RNG.random((120, 2, n))
+    a = lb + ab[:, 0, :] * (ub - lb)
+    b = lb + ab[:, 1, :] * (ub - lb)
+    mid = 0.5 * (a + b)
+    u_a = np.asarray(jax.vmap(u)(jnp.asarray(a)))
+    u_b = np.asarray(jax.vmap(u)(jnp.asarray(b)))
+    u_mid = np.asarray(jax.vmap(u)(jnp.asarray(mid)))
+    g = np.asarray(jax.vmap(jax.grad(lambda z: u(z)))(jnp.asarray(a)))
+    assert np.all(u_mid <= 0.5 * (u_a + u_b) + 1e-6)  # midpoint convexity
+    # first-order (subgradient) inequality: u(b) >= u(a) + g(a) . (b - a)
+    assert np.all(u_b >= u_a + np.einsum("ij,ij->i", g, b - a) - 1e-6 * (np.abs(u_a) + 1))
     # bound validity: min cv <= min f (sampled)
-    min_u = min(float(u(jnp.asarray(x))) for x in P)
-    min_f = min(float(f_true(x)) for x in P)
-    assert min_u <= min_f + 1e-6 * (abs(min_f) + 1)
+    assert uP.min() <= fP.min() + 1e-6 * (abs(fP.min()) + 1)
 
 
 def test_bilinear_envelope_not_collapse():


### PR DESCRIPTION
Closes #390.

## Problem

The `Python fast (3.12, ubuntu)` CI job is the run critical path. Measuring the last several `main`-branch CI runs, its `pytest` step averaged **~12.9 min** and drove nearly the entire whole-run wall clock (other jobs finish in <6 min). The `--durations=20` table from run `29612467531` (main) pinned the offenders: a handful of relaxation **soundness / false-optimal** tests dominated the tail.

## Root cause

The three biggest contributors were slow because of the **test harness**, not solver math: each evaluated a JAX-compiled function **one scalar point at a time inside a Python `for` loop** — thousands of individual JAX dispatches:

- `test_g_convex_inject.py` — 60k / 40k-point feasibility fuzzes, one `float(fbody(jnp.asarray(x)))` per point
- `test_mccormick_subgradient.py` — the `_sound` helper's 300-point validity loop + 120-iteration convexity/subgradient loop (`jax.grad` re-traced per point)
- `test_g_signomial_products.py` — two `range(2000)` envelope-evaluation loops

## Change

Replace the per-point loops with a single `jax.vmap` dispatch over the whole `(N, d)` sample block. **This is behavior-neutral — no soundness check is weakened** (CLAUDE.md §1):

- Sample points are drawn as one row-major `(N, d)` block, which is bit-identical to the old sequential `rng.uniform` draws. The mccormick chord pairs use a `(120, 2, n)` block to preserve interleaved `a`/`b` draw order, keeping the shared module RNG in sync for downstream tests in the file.
- `f_true` (cheap numpy) stays per-row; only the JAX-dispatched `u` / `grad` / envelope work is vectorized.
- Same points, same tolerances, same assertions (`np.all` over the batch).

## Verification

- **Faithfulness:** `vmap(u)`, `vmap(jax.grad(u))`, and the signomial `vmap` envelopes (corner + secant) are **bit-identical** to the pointwise evaluations — max abs diff `0.0`. Batched `rng.uniform` points and the `(120,2,n)` chord order were confirmed equal to the sequential draws.
- **Non-vacuous:** a negative control injecting an unsound cut (`x+y-3.05 ≤ 0`, which removes feasible points) still fails the vectorized `_feasible_never_removed` fuzz (residual `0.094` flagged) — the fast assertion still catches soundness violations.
- **Suite unchanged:** `pytest python/tests/test_g_convex_inject.py python/tests/test_mccormick_subgradient.py python/tests/test_g_signomial_products.py` → **35 passed** before and after.
- **Lint:** `ruff==0.14.6` `check` + `format --check` clean on all three files.

## Measurement

Local wall (single-core, `-n0`) for the three files:

| | Before | After |
|---|---|---|
| `test_g_convex_inject.py` | ~190 s | ~1 s |
| `test_mccormick_subgradient.py` | ~62 s | ~5 s |
| `test_g_signomial_products.py` | ~29 s | ~1.5 s |
| **Combined (35 tests)** | **284.7 s** | **~6–10 s** |

Removes ~275 s of the ~700 s `Python fast` CPU-time tail from a pure test-harness change.

## Not included (follow-up)

The remaining tail is genuinely solve-bound and left for a separate verify-then-trim pass: `test_c40_util_false_optimal.py` (`solve(time_limit=60)`), `test_bilevel_phase3.py` (`time_limit=90/150`), `test_issue694_anytime_root_build.py` (timeout is the thing under test), and `test_rlt_root_bound.py` (n=6 QAP build). Trimming those requires confirming each regression still fires at a shorter limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSZwAfJDdeGNGTt7x11PcN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSZwAfJDdeGNGTt7x11PcN)_