### PR TITLE
feat(#282): iterate root OBBT to convergence over the McCormick LP (QCQP root bound)

### DIFF
--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -1842,6 +1842,7 @@ def obbt_tighten_root(
     prefer_pounce: bool = False,
     cascade_aux: bool = False,
     top_k: Optional[int] = None,
+    min_improvement: Optional[float] = None,
 ) -> RootObbtResult:
     """Structural root OBBT over the LP-form McCormick relaxation.
 
@@ -1903,6 +1904,21 @@ def obbt_tighten_root(
         original columns (T2.5). This bounds the per-sweep probe count so per-node
         OBBT stays affordable on large spatial models; soundness of each surviving
         tightening is unchanged. ``None`` keeps the all-columns behavior.
+    min_improvement : float, optional
+        Convergence early-stop for the iterate-to-fixpoint OBBT loop (#282). On a
+        wide-box dense QCQP, tightening ``x_i`` shrinks the McCormick envelopes,
+        which enables tightening ``x_j`` — so the root bound only converges after
+        *many* sweeps (nvs24: ~30 sweeps drive the box ``[0,200]^10 -> ~[0,24]^10``
+        and the McCormick LP bound ``-782k -> -14k``; the ``rounds=3`` default
+        stops at ``-394k``). Raising ``rounds`` alone lets the existing
+        ``sweep_tight == 0`` fixpoint break run to convergence, but on other
+        instances the tail sweeps can shave only a sliver each; ``min_improvement``
+        caps that cost by stopping once a sweep's *relative box-width reduction*
+        (summed over finite-width original columns) falls below this threshold.
+        Purely an additional early termination — ``None`` (default) preserves the
+        legacy behavior byte-for-byte (only the ``sweep_tight == 0`` break and the
+        ``rounds`` cap terminate the loop). Never affects the soundness of any
+        individual tightening (each is still NS-safe); only *when* the loop stops.
     """
     from discopt.modeling.core import VarType
 
@@ -1923,6 +1939,12 @@ def obbt_tighten_root(
     total_tight = 0
     total_lp_time = 0.0
     n_rounds = 0
+
+    def _finite_box_width() -> float:
+        """Total width over finite-width original columns (min-improvement metric)."""
+        w = ub[:n_orig] - lb[:n_orig]
+        w = w[np.isfinite(w)]
+        return float(w.sum()) if w.size else 0.0
 
     # Bootstrap: if the box is not fully finite, derive finite bounds for the
     # open variables before the round loop, which otherwise bails immediately on
@@ -2010,6 +2032,9 @@ def obbt_tighten_root(
             # whatever tightening prior rounds achieved) if any bound is open.
             if not (np.all(np.isfinite(lb)) and np.all(np.isfinite(ub))):
                 break
+            # Box width at the start of this sweep, for the #282 min-improvement
+            # convergence early-stop (measured only when the caller opts in).
+            _width_before = _finite_box_width() if min_improvement is not None else 0.0
             try:
                 milp, varmap = build_milp_relaxation(
                     relaxer._model,
@@ -2143,6 +2168,14 @@ def obbt_tighten_root(
             total_tight += sweep_tight
             if sweep_tight == 0:
                 break
+            # #282 convergence early-stop: once a sweep shrinks the box by less
+            # than ``min_improvement`` (relative, over finite-width columns) the
+            # remaining tail is not worth its 2n projection LPs. Purely bounds
+            # cost — every tightening already applied stays; only the loop stops.
+            if min_improvement is not None and _width_before > 0.0:
+                _rel = (_width_before - _finite_box_width()) / _width_before
+                if _rel < min_improvement:
+                    break
     except Exception:
         # Never let bound tightening crash or corrupt the solve.
         return RootObbtResult(lb, ub, total_tight, n_rounds, total_lp_time)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -406,6 +406,40 @@ def _obbt_topk_enabled() -> bool:
     return os.environ.get("DISCOPT_OBBT_TOPK", "").strip().lower() in ("1", "true", "yes", "on")
 
 
+# #282 iterate-root-OBBT-to-convergence (flag-gated, default OFF). The root OBBT
+# over the McCormick LP already iterates and rebuilds the envelope on the
+# tightened box each sweep (``obbt_tighten_root``), but at the default
+# ``rounds=3`` cap it stops FAR short of the fixpoint on a wide-box dense QCQP:
+# on nvs24 (dense 10-var integer QCQP, opt -1033.2) three sweeps leave the root
+# McCormick LP bound at ~-3.9e5 (the "stuck -4e5"), whereas iterating to the
+# natural ``sweep_tight == 0`` fixpoint (~33 sweeps) drives the box
+# ``[0,200]^10 -> ~[0,24]^10`` and the bound to ~-1.4e4 — a ~54x root-bound
+# tightening with discopt's own machinery, closing most of the root-relaxation
+# gap to SCIP. (The residual to a term-wise dense-tangent McCormick prototype's
+# -6.7e3 is envelope tangent density, orthogonal to OBBT — not addressed here.)
+# The lever is bounded LP work that scales with sweeps, so it is default-OFF and
+# only engaged, when the flag is on, for the structural class that pays: quadratic
+# (QCQP / bilinear-or-square) models with a wide box. Each individual tightening
+# is still the NS-safe clamp used by the ``rounds=3`` path — soundness unchanged;
+# only the number of sweeps grows. ``min_improvement`` caps the tail cost.
+_OBBT_ITERATE_ROUNDS = 50
+_OBBT_ITERATE_MIN_IMPROVEMENT = 1e-3
+# Only widen the sweep budget when the box is actually wide enough that the
+# envelope is loose and iterating pays; a narrow box reaches its fixpoint in a
+# sweep or two and the ``rounds=3`` cap already suffices.
+_OBBT_ITERATE_MIN_BOX_WIDTH = 10.0
+
+
+def _obbt_iterate_root_enabled() -> bool:
+    """Whether the #282 iterate-root-OBBT-to-convergence lever is on (default OFF)."""
+    return os.environ.get("DISCOPT_OBBT_ITERATE", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def _root_lp_probe_tight_enabled() -> bool:
     """Whether the #282 tightened-box root LP probe is on (env flag, default OFF).
 
@@ -5353,14 +5387,46 @@ def solve_model(
             from discopt._jax.obbt import obbt_tighten_root
 
             _obbt_budget = min(min(max(time_limit * 0.1, 2.0), 15.0), _remaining_budget())
+
+            # #282 iterate-to-convergence lever (default OFF). The ``rounds=3`` cap
+            # stops the root OBBT far short of the fixpoint on a wide-box dense
+            # QCQP, where the McCormick envelope is loose and each sweep's box
+            # shrink unlocks the next. When the flag is on AND the model is
+            # quadratically structured (bilinear or square terms) with a wide box,
+            # raise the sweep cap and let the existing fixpoint / min-improvement
+            # break run to convergence. General structural gate — no problem-name
+            # keying; each tightening is still the NS-safe clamp (soundness
+            # unchanged). OFF path is byte-identical (``rounds=3``, no early-stop).
+            _obbt_rounds = 3
+            _obbt_min_impr: Optional[float] = None
+            if _obbt_iterate_root_enabled():
+                try:
+                    from discopt._jax.term_classifier import (
+                        classify_nonlinear_terms as _cnt_it,
+                    )
+
+                    _ot_it = _cnt_it(model)
+                    _is_quadratic = bool(_ot_it.bilinear) or any(
+                        int(p) == 2 for _, p in _ot_it.monomial
+                    )
+                except Exception:
+                    _is_quadratic = False
+                _fin_w = ub - lb
+                _fin_w = _fin_w[np.isfinite(_fin_w)]
+                _wide_box = bool(_fin_w.size) and float(_fin_w.max()) > _OBBT_ITERATE_MIN_BOX_WIDTH
+                if _is_quadratic and _wide_box:
+                    _obbt_rounds = _OBBT_ITERATE_ROUNDS
+                    _obbt_min_impr = _OBBT_ITERATE_MIN_IMPROVEMENT
+
             _obbt_res = obbt_tighten_root(
                 model,
                 lb,
                 ub,
-                rounds=3,
+                rounds=_obbt_rounds,
                 deadline=time.perf_counter() + _obbt_budget,
                 superposition=(relaxation_arithmetic == "superposition"),
                 prefer_pounce=nlp_solver == "pounce",
+                min_improvement=_obbt_min_impr,
             )
             if _obbt_res.infeasible:
                 wall_time = time.perf_counter() - t_start

--- a/python/tests/test_obbt_iterate_root.py
+++ b/python/tests/test_obbt_iterate_root.py
@@ -1,0 +1,204 @@
+"""#282 — iterate root OBBT to convergence over the McCormick LP (QCQP root bound).
+
+The root OBBT over the McCormick LP (``obbt_tighten_root``) already iterates and
+rebuilds the envelope on the tightened box each sweep, but the default ``rounds=3``
+cap stops far short of the fixpoint on a *wide-box dense QCQP*: tightening ``x_i``
+shrinks the McCormick envelopes, which unlocks tightening ``x_j``, so the root
+bound only converges after many sweeps. The ``DISCOPT_OBBT_ITERATE`` lever
+(default OFF) raises that cap for the quadratic/wide-box structural class and adds
+a ``min_improvement`` convergence early-stop.
+
+These tests lock the two properties that make the lever a *win* and *safe*:
+
+  1. **Iterated >> one-pass (and default) on QCQP** — on a vendored dense integer
+     QCQP whose McCormick envelope needs >3 sweeps to converge, the iterated root
+     bound is dramatically tighter than a single OBBT pass and meaningfully
+     tighter than the ``rounds=3`` default.
+  2. **Sound** — differential (the iterated bound is a *valid* lower bound: it
+     never exceeds the true box optimum and is never looser than the one-pass
+     bound) plus feasible-point sampling (no feasible point of the original model,
+     in particular the global optimum, is cut by the tightened box).
+  3. **OFF path is inert** — ``min_improvement=None`` reproduces the legacy loop
+     bit-for-bit, and the solve-path flag helper defaults OFF.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+import pytest
+from discopt._jax.mccormick_lp import MccormickLPRelaxer, build_milp_relaxation
+from discopt._jax.obbt import obbt_tighten_root
+from discopt.modeling.core import Model
+from discopt.solvers import SolveStatus
+from discopt.solvers.lp_backend import get_exact_dual_lp_solver, get_exact_lp_solver
+
+pytestmark = pytest.mark.filterwarnings("ignore::RuntimeWarning")
+
+
+# --- Vendored dense integer QCQP -------------------------------------------
+# Minimize -sum_{i<j} x_i x_j  s.t.  sum_i x_i^2 <= 400,  x in [0, UB]^N integer.
+# The single sum-of-squares coupling over a very wide box makes the McCormick
+# envelope catastrophically loose, so OBBT needs ~5 sweeps to reach the fixpoint
+# (the rounds=3 default stops short). Brute-force global optimum: x = 8 (all),
+# sum sq = 6*64 = 384 <= 400, objective = -C(6,2)*64 = -960.
+_N = 6
+_UB = 2000
+_SS_CAP = 400
+_TRUE_OPT = -960.0
+
+
+def _qcqp() -> Model:
+    m = Model("iterate_root_qcqp")
+    x = m.integer("x", _N, lb=0, ub=_UB)
+    obj = 0
+    for i in range(_N):
+        for j in range(i + 1, _N):
+            obj = obj - x[i] * x[j]
+    m.minimize(obj)
+    ss = 0
+    for i in range(_N):
+        ss = ss + x[i] * x[i]
+    m.subject_to(ss <= _SS_CAP)
+    return m
+
+
+def _flat_bounds(model: Model):
+    lbs, ubs = [], []
+    for v in model._variables:
+        lbs.append(v.lb.flatten())
+        ubs.append(v.ub.flatten())
+    return np.concatenate(lbs).astype(float), np.concatenate(ubs).astype(float)
+
+
+def _mccormick_root_bound(model: Model, lb: np.ndarray, ub: np.ndarray):
+    """McCormick LP dual bound over the box ``[lb, ub]`` (discopt machinery)."""
+    relaxer = MccormickLPRelaxer(model, build_incremental=False)
+    milp, _ = build_milp_relaxation(
+        relaxer._model, relaxer._terms, relaxer._disc, bound_override=(lb, ub)
+    )
+    _lp = get_exact_dual_lp_solver() or get_exact_lp_solver()
+    res = _lp(
+        c=np.asarray(milp._c, dtype=float),
+        A_ub=milp._A_ub,
+        b_ub=milp._b_ub,
+        bounds=list(milp._bounds),
+        time_limit=5.0,
+    )
+    if res.status != SolveStatus.OPTIMAL:
+        return None
+    return float(res.objective) + float(milp._obj_offset)
+
+
+_ONE_PASS = dict(rounds=1, min_improvement=None)
+_DEFAULT = dict(rounds=3, min_improvement=None)
+_ITERATE = dict(rounds=50, min_improvement=1e-3)
+
+
+def _obbt_box(model, lb, ub, **kw):
+    import time as _t
+
+    r = obbt_tighten_root(model, lb.copy(), ub.copy(), deadline=_t.perf_counter() + 90.0, **kw)
+    return r
+
+
+@pytest.mark.correctness
+def test_iterated_root_bound_much_tighter_than_one_pass_and_default():
+    """Iterating to convergence dwarfs one-pass and beats the rounds=3 default."""
+    m = _qcqp()
+    lb0, ub0 = _flat_bounds(m)
+
+    r_one = _obbt_box(m, lb0, ub0, **_ONE_PASS)
+    b_one = _mccormick_root_bound(m, r_one.lb, r_one.ub)
+    r_def = _obbt_box(m, lb0, ub0, **_DEFAULT)
+    b_def = _mccormick_root_bound(m, r_def.lb, r_def.ub)
+    r_it = _obbt_box(m, lb0, ub0, **_ITERATE)
+    b_it = _mccormick_root_bound(m, r_it.lb, r_it.ub)
+
+    assert b_one is not None and b_def is not None and b_it is not None
+    # Iterating needs strictly more than 3 sweeps to reach the fixpoint here.
+    assert r_it.n_rounds > 3
+    # Iterated bound is a large multiple tighter than a single OBBT pass.
+    assert b_it > b_one * 0.2  # e.g. -2.5e3 vs -9.4e5  => >100x tighter
+    assert (b_one / b_it) > 20.0
+    # And meaningfully tighter than the rounds=3 default (this is what the flag buys).
+    assert b_it > b_def + 1e-6
+    assert (b_def / b_it) > 1.3
+
+
+@pytest.mark.correctness
+def test_iterated_root_bound_is_sound():
+    """Differential + feasible-point soundness of the iterated tightening."""
+    m = _qcqp()
+    lb0, ub0 = _flat_bounds(m)
+
+    r_one = _obbt_box(m, lb0, ub0, **_ONE_PASS)
+    b_one = _mccormick_root_bound(m, r_one.lb, r_one.ub)
+    r_it = _obbt_box(m, lb0, ub0, **_ITERATE)
+    b_it = _mccormick_root_bound(m, r_it.lb, r_it.ub)
+
+    # Differential: the iterated bound is a valid dual (lower) bound — never looser
+    # than one-pass, and never above the true box optimum (a bound that crossed the
+    # optimum would be a false certificate).
+    assert b_it >= b_one - 1e-6
+    assert b_it <= _TRUE_OPT + 1e-4
+
+    # The tightened box must be a subset of the input box (OBBT only shrinks).
+    assert np.all(r_it.lb >= lb0 - 1e-9)
+    assert np.all(r_it.ub <= ub0 + 1e-9)
+
+    # Feasible-point sampling: no feasible integer point of the original model may
+    # be cut by the tightened box. Enumerate the (tiny) feasible region sum sq<=400
+    # with each coordinate in [0, 20] (20 = floor(sqrt(400))), plus the global
+    # optimum, and assert every one lies inside the iterated box.
+    lo, hi = r_it.lb, r_it.ub
+    opt = np.full(_N, 8.0)
+    assert np.all(opt >= lo - 1e-9) and np.all(opt <= hi + 1e-9)
+
+    rng = np.random.default_rng(0)
+    checked = 0
+    for _ in range(4000):
+        pt = rng.integers(0, 21, size=_N).astype(float)
+        if float(np.sum(pt * pt)) > _SS_CAP:
+            continue
+        checked += 1
+        assert np.all(pt >= lo - 1e-9), (pt, lo)
+        assert np.all(pt <= hi + 1e-9), (pt, hi)
+    assert checked > 50  # sampled a non-trivial number of genuine feasible points
+
+
+@pytest.mark.correctness
+def test_min_improvement_none_is_inert():
+    """``min_improvement=None`` reproduces the legacy loop bit-for-bit (OFF path)."""
+    m = _qcqp()
+    lb0, ub0 = _flat_bounds(m)
+    for rounds in (1, 3, 7):
+        a = obbt_tighten_root(m, lb0.copy(), ub0.copy(), rounds=rounds)
+        b = obbt_tighten_root(m, lb0.copy(), ub0.copy(), rounds=rounds, min_improvement=None)
+        assert np.array_equal(a.lb, b.lb)
+        assert np.array_equal(a.ub, b.ub)
+        assert a.n_rounds == b.n_rounds
+        assert a.n_tightened == b.n_tightened
+
+
+def test_solver_flag_defaults_off():
+    """The solve-path lever helper is OFF unless explicitly enabled."""
+    from discopt.solver import _obbt_iterate_root_enabled
+
+    saved = os.environ.pop("DISCOPT_OBBT_ITERATE", None)
+    try:
+        assert _obbt_iterate_root_enabled() is False
+        for on in ("1", "true", "yes", "on", "ON"):
+            os.environ["DISCOPT_OBBT_ITERATE"] = on
+            assert _obbt_iterate_root_enabled() is True
+        for off in ("0", "false", "", "no"):
+            os.environ["DISCOPT_OBBT_ITERATE"] = off
+            assert _obbt_iterate_root_enabled() is False
+    finally:
+        os.environ.pop("DISCOPT_OBBT_ITERATE", None)
+        if saved is not None:
+            os.environ["DISCOPT_OBBT_ITERATE"] = saved


### PR DESCRIPTION
## Summary

Iterate the root OBBT over the McCormick LP **to convergence** on wide-box dense QCQP, closing most of the root-relaxation gap to SCIP. Flag-gated (`DISCOPT_OBBT_ITERATE`), **default OFF**, **NOT graduated**.

### Root cause (diagnosed, confirmed by measurement)

`obbt_tighten_root` *already* iterates and rebuilds the McCormick LP relaxation on the tightened box each sweep — the machinery was there. The bug was the **round cap of 3**: on a wide-box dense QCQP, tightening `x_i` shrinks the McCormick envelopes, which unlocks tightening `x_j`, so the root bound only converges after ~30 sweeps. Three sweeps stop far short.

Measured on nvs24 (dense 10-var integer QCQP, opt −1033.2), McCormick LP root bound with discopt's own machinery:

| box | McCormick LP root bound | box ub_mean | vs raw |
|---|---|---|---|
| raw (no OBBT) | −782,506 | 200.0 | 1x |
| **OFF** (rounds=3, current default) | **−394,504** | 141.2 | 2.0x |
| **ON** (rounds=50 + min-improvement) | **−14,443** | 24.2 (33 sweeps) | **54.2x** |

ON is **27x tighter than the rounds=3 default** and 54x tighter than raw. Added cost: ~1.7s of bounded LP work.

The prior entry experiment's −6.7e3 (a term-wise **dense-tangent** McCormick prototype) is **not** reached: discopt's static square (`x**2`) envelope uses only endpoint tangents + secant (~2x looser than a 25-tangent envelope). That residual is McCormick **tangent density**, orthogonal to OBBT, and is not touched here — reported honestly rather than shipping a weaker McCormick.

**carton7** is honestly **not-helped**: it has unbounded continuous columns, so the finite-box guard makes the round loop a no-op — ON and OFF are identical, exactly as predicted.

## Changes

- **`_jax/obbt.py`** — add optional `min_improvement` convergence early-stop to `obbt_tighten_root`. `None` (default) preserves the legacy loop **byte-for-byte** (only `sweep_tight==0` and the `rounds` cap terminate). Never affects the soundness of any individual tightening; only *when* the loop stops.
- **`solver.py`** — `DISCOPT_OBBT_ITERATE` flag (default OFF). When on **AND** the model is quadratically structured (bilinear or square terms) **AND** the box is wide, raise the root sweep cap 3→50 and enable the min-improvement early-stop. General structural gate — **no problem-name keying**. Each tightening is still the NS-safe clamp used by the `rounds=3` path (soundness unchanged). **OFF path is byte-identical** (`rounds=3`, `min_improvement=None`).

## Soundness (the hard gate)

- Every tightening reuses the existing Neumaier–Shcherbina safe-LP-lower-bound clamp + row equilibration; iterating only applies more *sound* tightenings (each round intersects a valid outer-approximation bound). No new tightening math.
- **Regression test** (`test_obbt_iterate_root.py`): vendored dense integer QCQP needing >3 sweeps. Asserts iterated bound >20x tighter than one-pass and >1.3x tighter than the rounds=3 default; **differential** (iterated bound never above the true box optimum, never looser than one-pass); **feasible-point sampling** (no feasible integer point, incl. the global optimum, cut by the tightened box); `min_improvement=None` inert; flag defaults OFF.
- **Panel** — flag ON vs OFF over 35 quadratic local-corpus instances (n≤40): `incorrect_count=0`, `oracle_violations=0`, no certification regression. (Neutral on these — they already solve to optimality OFF; the wide-box non-converging family that benefits, e.g. nvs24, is not in the local n≤40 corpus.)

## Why default-OFF / not graduated

End-to-end, the reported dual bound benefits when the node engine keeps the McCormick relaxer (nvs24 at TL=15: OFF −5045 → ON −1505), but nvs24's alphaBB node-bound path — governed by the separate `DISCOPT_ROOT_LP_PROBE_TIGHT` #282 lever — makes the reported bound time-limit-dependent. That node-engine concern is out of scope (branching/node-bounding is separate). The **in-scope deliverable** — the iterated McCormick LP root-box tightening — is deterministic and sound. Left OFF for the CLAUDE.md §5 Regime-2 panel to graduate.

## Verification run

- `pytest -m smoke` — 666 passed, 1 skipped.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed (carton7 sound).
- `pytest python/tests/test_obbt_iterate_root.py` — 4 passed.
- `ruff check` + `ruff format --check` — clean. No Rust touched (cargo N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
