### PR TITLE
feat(#707): flow-aware integer-multilinear envelope (DISCOPT_INTEGER_MULTILINEAR_REFORM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ The release procedure that produces these entries is documented in
 
 ### Added
 
+- **Flow-aware integer-multilinear envelope** (`feat`, #707, default-off behind
+  `DISCOPT_INTEGER_MULTILINEAR_REFORM`). Generalizes the integer-*bilinear* exact
+  reformulation to products of ≥3 variable factors where every factor but at most
+  one is integer- or binary-valued (declared or *implied*) — e.g. ex1252's
+  objective `(6329.03 + 1800·x15)·x0·x3·x18` with integer flow factors
+  `x0,x3 ∈ {0..3}` and a 0/1 indicator `x18`. Each integer factor is
+  binary-expanded (`x = lo + Σ 2ᵏ eₖ`), the product distributed into binary
+  monomials (`e² = e`), and each monomial lifted to its **exact** hull: an n-ary
+  AND (`z ≤ eᵢ`, `z ≥ Σ eᵢ − (n−1)`, `z` binary) for the pure-integer part plus one
+  big-M product for the lone continuous factor. The rewrite is a value-preserving
+  algebraic identity (verified to ~1e-9 over sampled points), so it can only
+  tighten — never invalidate — the dual bound; it replaces the loose term-wise
+  trilinear McCormick envelope over the continuous box with the per-integer-level
+  exact envelope. Unlike the bilinear pass (adopted only when it yields a pure
+  MILP), this pass is **kept on the spatial B&B path** when residual *continuous*
+  nonlinearity remains, since the integer-term tightening is a strict gain there.
+  On ex1252 this lifts the global dual bound off its structural **5134** floor
+  (the plateau the term-wise envelope and SOS1-selector branching both stall at)
+  to ~32k in 45 s and climbing; the structure is general (present in 8 of the 81
+  in-repo MINLPLib instances: ex1252/ex1252a, nvs01/05/16/22, st_e36/e40). The
+  flag is default-off pending the CLAUDE.md §5 differential-panel graduation; the
+  default (flag-off) path is byte-identical (the bilinear reform and its blowup
+  guard are untouched). Full end-to-end certification of ex1252 additionally
+  requires closing a *separate* residual barrier — the continuous cubic cost rows
+  `x15 = f(x6, x12)` — which spatial branching, not this envelope, must tighten;
+  recorded in the issue.
+
 - **GP-structured MINLP: y-space node relaxations + integer branch-and-bound**
   (`feat`, #116). A MINLP whose *continuous relaxation* is a geometric program
   (posynomial objective, `posynomial ≤ monomial` / `monomial == monomial`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,20 @@ The release procedure that produces these entries is documented in
   On ex1252 this lifts the global dual bound off its structural **5134** floor
   (the plateau the term-wise envelope and SOS1-selector branching both stall at)
   to ~32k in 45 s and climbing; the structure is general (present in 8 of the 81
-  in-repo MINLPLib instances: ex1252/ex1252a, nvs01/05/16/22, st_e36/e40). The
-  flag is default-off pending the CLAUDE.md §5 differential-panel graduation; the
-  default (flag-off) path is byte-identical (the bilinear reform and its blowup
-  guard are untouched). Full end-to-end certification of ex1252 additionally
-  requires closing a *separate* residual barrier — the continuous cubic cost rows
-  `x15 = f(x6, x12)` — which spatial branching, not this envelope, must tighten;
-  recorded in the issue.
+  in-repo MINLPLib instances: ex1252/ex1252a, nvs01/05/16/22, st_e36/e40). A
+  spatial-path **blowup guard** keeps a non-pure-MILP reform only when the column
+  count stays within a modest factor of the original, so an already-tractable
+  instance the spatial solve certifies fast (nvs01: 3 → ~200 columns) is left on
+  its original path rather than regressed. Differential panel over the eight
+  in-repo integer-multilinear instances (flag off vs on): **cert-clean** (every
+  bound ≤ its reference optimum, every incumbent feasible, both regimes) and
+  **net non-negative** (large gain on ex1252/ex1252a, neutral elsewhere). The flag
+  is default-off pending a corpus-wide §5 graduation; the default (flag-off) path
+  is byte-identical (the bilinear reform and its blowup guard are untouched — the
+  new aux-sharing cache is scoped to the multilinear path). Full end-to-end
+  certification of ex1252 additionally requires closing a *separate* residual
+  barrier — the continuous cubic cost rows `x15 = f(x6, x12)` — which spatial
+  branching, not this envelope, must tighten; recorded in the issue.
 
 - **GP-structured MINLP: y-space node relaxations + integer branch-and-bound**
   (`feat`, #116). A MINLP whose *continuous relaxation* is a geometric program

--- a/discopt_benchmarks/scripts/ex1252_cutoff_obbt_falsification.py
+++ b/discopt_benchmarks/scripts/ex1252_cutoff_obbt_falsification.py
@@ -1,0 +1,102 @@
+"""Reproduction: issue #707 falsification — "cutoff-driven range reduction
+certifies the ex1252 class" (see docs/dev/performance-plan.md §6).
+
+The #707 flow-aware integer-multilinear envelope lifts ex1252's dual bound off its
+5134 floor but does not certify it (~48k vs opt 128893.74). This probe tests
+whether the *incumbent objective cutoff* is the missing lever: it hands OBBT the
+known optimum as a cutoff and measures whether it shrinks the wide continuous
+flows x6/x12 and lifts the dual — at the root, on a line-selected box, under
+continuous subdivision, and with the integer flow factors fixed.
+
+Result: the cutoff is inert at every level (the relaxation is ~10x looser than the
+cutoff, so it never binds). The bottleneck is the continuous-cubic relaxation
+strength, not range reduction. Run:
+
+    python -m discopt_benchmarks.scripts.ex1252_cutoff_obbt_falsification
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ.setdefault("DISCOPT_INCREMENTAL_MC", "0")  # cold build per call (no patch-state artifact)
+
+import discopt.modeling as dm
+from discopt._jax.integer_product_reform import reformulate_integer_multilinear
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.obbt import obbt_tighten_root
+
+OPT = 128893.74
+# line-1 selected, lines 2&3 off (indicators, selectors, matching binaries)
+LINE1 = {18: 1, 36: 1, 21: 1, 19: 0, 20: 0, 37: 0, 38: 0, 22: 0, 23: 0}
+
+
+def _nl_path() -> Path:
+    here = Path(__file__).resolve()
+    for base in here.parents:
+        cand = base / "python" / "tests" / "data" / "minlplib" / "ex1252.nl"
+        if cand.exists():
+            return cand
+    raise FileNotFoundError("ex1252.nl not found under any parent's python/tests/data/minlplib")
+
+
+def _bound(r, lb, ub):
+    res = MccormickLPRelaxer(r).solve_at_node(lb, ub)
+    return res.lower_bound if res.status == "optimal" else None
+
+
+def main() -> None:
+    r = reformulate_integer_multilinear(dm.from_nl(str(_nl_path())))
+    lb, ub = flat_variable_bounds(r)
+
+    # (1) root box
+    print(f"root, OBBT no-cutoff : {_root_obbt_bound(r, lb, ub, None):.1f}")
+    print(f"root, OBBT cutoff=opt: {_root_obbt_bound(r, lb, ub, OPT):.1f}  (cutoff inert)")
+
+    # (2) line-1 selected box
+    lb1, ub1 = lb.copy(), ub.copy()
+    for i, v in LINE1.items():
+        lb1[i] = ub1[i] = float(v)
+    nc = obbt_tighten_root(r, lb1.copy(), ub1.copy(), rounds=5, time_limit_per_lp=0.3)
+    cc = obbt_tighten_root(r, lb1.copy(), ub1.copy(), rounds=5, time_limit_per_lp=0.3,
+                           incumbent_cutoff=OPT)
+    print(f"\nline-1 box: x6 [{nc.lb[6]:.0f},{nc.ub[6]:.0f}] x12 [{nc.lb[12]:.1f},{nc.ub[12]:.1f}]")
+    print(f"line-1, OBBT no-cutoff : {_bound(r, nc.lb, nc.ub):.1f}")
+    print(f"line-1, OBBT cutoff=opt: {_bound(r, cc.lb, cc.ub):.1f}  (identical -> cutoff inert)")
+
+    # (3) subdivide continuous x12 (fresh cold relaxers) — bound does not move
+    lb2, ub2 = nc.lb.copy(), nc.ub.copy()
+    mid = 0.5 * (lb2[12] + ub2[12])
+    lo, hi = lb2.copy(), ub2.copy(); hi[12] = mid
+    print(f"\nx12 lower half: {_bound(r, lo, hi):.1f}")
+    lo, hi = lb2.copy(), ub2.copy(); lo[12] = mid
+    print(f"x12 upper half: {_bound(r, lo, hi):.1f}  (subdividing flows does not tighten)")
+
+    # (4) fix the integer flow factors: the loosest node is the binding one
+    print("\nfixing integer (x0,x3) on the line-1 box:")
+    best = float("inf")
+    for x0 in (1, 2, 3):
+        for x3 in (1, 2, 3):
+            lo, hi = nc.lb.copy(), nc.ub.copy()
+            lo[0] = hi[0] = x0; lo[3] = hi[3] = x3
+            lo[24] = hi[24] = x0 & 1; lo[25] = hi[25] = (x0 >> 1) & 1
+            lo[30] = hi[30] = x3 & 1; lo[31] = hi[31] = (x3 >> 1) & 1
+            b = _bound(r, lo, hi)
+            tag = f"{b:.0f}" if b is not None else "infeas"
+            print(f"    x0={x0} x3={x3}: {tag}")
+            if b is not None:
+                best = min(best, b)
+    print(f"min over integer (x0,x3) = {best:.0f}  vs opt {OPT}  (~10x loose -> relaxation is the wall)")
+
+
+def _root_obbt_bound(r, lb, ub, cutoff):
+    res = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3,
+                            incumbent_cutoff=cutoff)
+    return _bound(r, res.lb, res.ub)
+
+
+if __name__ == "__main__":
+    main()

--- a/discopt_benchmarks/scripts/ex1252_cutoff_obbt_falsification.py
+++ b/discopt_benchmarks/scripts/ex1252_cutoff_obbt_falsification.py
@@ -14,6 +14,7 @@ strength, not range reduction. Run:
 
     python -m discopt_benchmarks.scripts.ex1252_cutoff_obbt_falsification
 """
+
 from __future__ import annotations
 
 import os
@@ -21,7 +22,9 @@ from pathlib import Path
 
 os.environ.setdefault("JAX_PLATFORMS", "cpu")
 os.environ.setdefault("JAX_ENABLE_X64", "1")
-os.environ.setdefault("DISCOPT_INCREMENTAL_MC", "0")  # cold build per call (no patch-state artifact)
+os.environ.setdefault(
+    "DISCOPT_INCREMENTAL_MC", "0"
+)  # cold build per call (no patch-state artifact)
 
 import discopt.modeling as dm
 from discopt._jax.integer_product_reform import reformulate_integer_multilinear
@@ -61,8 +64,9 @@ def main() -> None:
     for i, v in LINE1.items():
         lb1[i] = ub1[i] = float(v)
     nc = obbt_tighten_root(r, lb1.copy(), ub1.copy(), rounds=5, time_limit_per_lp=0.3)
-    cc = obbt_tighten_root(r, lb1.copy(), ub1.copy(), rounds=5, time_limit_per_lp=0.3,
-                           incumbent_cutoff=OPT)
+    cc = obbt_tighten_root(
+        r, lb1.copy(), ub1.copy(), rounds=5, time_limit_per_lp=0.3, incumbent_cutoff=OPT
+    )
     print(f"\nline-1 box: x6 [{nc.lb[6]:.0f},{nc.ub[6]:.0f}] x12 [{nc.lb[12]:.1f},{nc.ub[12]:.1f}]")
     print(f"line-1, OBBT no-cutoff : {_bound(r, nc.lb, nc.ub):.1f}")
     print(f"line-1, OBBT cutoff=opt: {_bound(r, cc.lb, cc.ub):.1f}  (identical -> cutoff inert)")
@@ -70,9 +74,11 @@ def main() -> None:
     # (3) subdivide continuous x12 (fresh cold relaxers) — bound does not move
     lb2, ub2 = nc.lb.copy(), nc.ub.copy()
     mid = 0.5 * (lb2[12] + ub2[12])
-    lo, hi = lb2.copy(), ub2.copy(); hi[12] = mid
+    lo, hi = lb2.copy(), ub2.copy()
+    hi[12] = mid
     print(f"\nx12 lower half: {_bound(r, lo, hi):.1f}")
-    lo, hi = lb2.copy(), ub2.copy(); lo[12] = mid
+    lo, hi = lb2.copy(), ub2.copy()
+    lo[12] = mid
     print(f"x12 upper half: {_bound(r, lo, hi):.1f}  (subdividing flows does not tighten)")
 
     # (4) fix the integer flow factors: the loosest node is the binding one
@@ -81,20 +87,26 @@ def main() -> None:
     for x0 in (1, 2, 3):
         for x3 in (1, 2, 3):
             lo, hi = nc.lb.copy(), nc.ub.copy()
-            lo[0] = hi[0] = x0; lo[3] = hi[3] = x3
-            lo[24] = hi[24] = x0 & 1; lo[25] = hi[25] = (x0 >> 1) & 1
-            lo[30] = hi[30] = x3 & 1; lo[31] = hi[31] = (x3 >> 1) & 1
+            lo[0] = hi[0] = x0
+            lo[3] = hi[3] = x3
+            lo[24] = hi[24] = x0 & 1
+            lo[25] = hi[25] = (x0 >> 1) & 1
+            lo[30] = hi[30] = x3 & 1
+            lo[31] = hi[31] = (x3 >> 1) & 1
             b = _bound(r, lo, hi)
             tag = f"{b:.0f}" if b is not None else "infeas"
             print(f"    x0={x0} x3={x3}: {tag}")
             if b is not None:
                 best = min(best, b)
-    print(f"min over integer (x0,x3) = {best:.0f}  vs opt {OPT}  (~10x loose -> relaxation is the wall)")
+    print(
+        f"min over integer (x0,x3) = {best:.0f}  vs opt {OPT}  (~10x loose: relaxation is the wall)"
+    )
 
 
 def _root_obbt_bound(r, lb, ub, cutoff):
-    res = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3,
-                            incumbent_cutoff=cutoff)
+    res = obbt_tighten_root(
+        r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3, incumbent_cutoff=cutoff
+    )
     return _bound(r, res.lb, res.ub)
 
 

--- a/docs/design/relaxation-catalog.md
+++ b/docs/design/relaxation-catalog.md
@@ -214,6 +214,18 @@ functions that already had relaxations + IR support are writable from native Pyt
   factors fall back to recursive McCormick; `edge-concave` underestimators (Tardella; an
   alternative tighter family for some structures) are not generated; and the cuts are added
   densely rather than separated on demand (a cut-on-violation loop would scale to higher n).
+- **Integer-multilinear exact envelope (issue #707, `DISCOPT_INTEGER_MULTILINEAR_REFORM`,
+  default off).** The continuous multilinear hull above is still loose when the factors are
+  *integer/binary-valued* (declared or implied): the exact continuous hull over the box
+  `[0,3]²×[0,1]` need not be tight at the integer lattice. For a product of ≥3 factors where
+  every factor but at most one is integer/binary, `integer_product_reform.py` binary-expands
+  each integer factor and lifts the resulting binary monomials to their exact hull (n-ary
+  AND + one big-M product for the lone continuous factor) — the per-integer-level envelope,
+  a value-preserving algebraic identity. This generalizes the integer-*bilinear* pass to the
+  trilinear/multilinear case (ex1252's `(c+1800·x15)·x0·x3·x18` objective, lifting its dual
+  bound off the 5134 floor). Unlike the bilinear pass it is retained on the spatial path when
+  residual *continuous* nonlinearity remains. Bound-changing → default-off pending the §5
+  differential panel.
 - **α-BB now wired in (resolved sub-item):** auto-dispatched as a fallback and selectable
   via `arithmetic="alphabb"`, with a rigorous interval-Hessian α.
 - **No automatic relaxation tightening loop:** `obbt.py` and nonlinear bound tightening

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -515,6 +515,44 @@ panel green for 3 consecutive nightlies before default-on.
 > open, and it is open on a hard-bound, not an engine, gap. Reproduction:
 > `discopt_benchmarks/scripts/joint_correlation_moment_probe.py`.
 
+> **Falsified (2026-07-18, issue #707 — "cutoff-driven range reduction certifies
+> the ex1252 class").** #707 shipped the flow-aware integer-multilinear envelope
+> (`DISCOPT_INTEGER_MULTILINEAR_REFORM`), which lifts ex1252's dual bound off its
+> structural 5134 floor by exact-linearizing the objective's integer-multilinear
+> terms `(c+1800·x15)·x0·x3·x18`. That closes the barrier the issue *diagnosed*,
+> but does not certify ex1252 — the reformed dual climbs only to ~48k (opt
+> 128893.74). The natural next hypothesis was that discopt's dual lags because it
+> never gets an incumbent early, so cutoff-driven OBBT/DBBT never fires; the entry
+> experiment fed the **known optimum in as an objective cutoff** and ran root OBBT
+> before writing any code:
+>
+> | box | OBBT no-cutoff | OBBT + cutoff=opt | note |
+> |---|---|---|---|
+> | root (all indicators free) | 0.0 | **0.0** | obj relaxes to 0 → cutoff never binds |
+> | line-1 selected (x18=1) | 12658 | **12658** | identical; cutoff still slack (12658 ≪ 128893) |
+> | + subdivide continuous x12 | 12658 | 12658 | branching the flows does not move it |
+> | + fix integer x0=2,x3=1 (loosest node) | 12658 | 12658 | vs true ≈128893 → **~10× loose** |
+>
+> **The cutoff is inert at every level**: the relaxation is so loose (12658 on the
+> binding node) that `obj ≤ 128893` is trivially satisfied, so it propagates
+> nothing — range reduction / incumbent cutoff is **not** the lever. **Root
+> cause:** the continuous cost rows `x15 = a·x6³ + b·x6²·x12 + c·x12²·x6`
+> (`x6∈[0,2950]`, `x12∈[0,350]`) are relaxed term-wise, and the `w=x6²` lift secant
+> alone spans `w∈[0,8.7M]` — enormously loose, feeding every downstream term. Even
+> with the line selected *and* the integer flow factors fixed, the McCormick
+> relaxation of the cubic gives 12658 vs a true value ~10× higher; subdividing the
+> continuous flows does not tighten it. SCIP's dual reaches 128438 (0.35% gap) at
+> 120 s — its cubic relaxation + cuts are ~10× tighter on exactly this block; and
+> **SCIP itself does not certify ex1252 in 120 s**, so this is a SOTA-frontier
+> bound gap, not an engine/throughput fix. Re-scope (issue #721): the lever is a
+> **stronger relaxation of the wide-range cubic block** — auto piecewise-McCormick
+> on wide monomial factors (the `x6²` secant first), edge-concave/vertex-polyhedral
+> envelopes extended to cubic (non-quadratic) blocks (catalog §7's open item), and
+> RLT tying the cubic equality to the bound/bilinear rows — *not* cutoff/OBBT
+> orchestration, which only compounds once the relaxation is strong enough to make
+> the cutoff bind. Reproduction:
+> `discopt_benchmarks/scripts/ex1252_cutoff_obbt_falsification.py`.
+
 ## 7. Sequencing & rationale (revised by the measurement)
 
 ```

--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -259,10 +259,10 @@ class _Expander:
         # z - e_i <= 0  (each factor upper-bounds the product)
         for b in bits:
             ac.append(Constraint(BinaryOp("-", z, b), "<=", 0.0))
-        # z - sum_i e_i + (n-1) >= 0
-        s: Optional[Expression] = None
-        for b in bits:
-            s = b if s is None else BinaryOp("+", s, b)
+        # z - sum_i e_i + (n-1) >= 0  (bits is non-empty: n >= 2 at every call site)
+        s: Expression = bits[0]
+        for b in bits[1:]:
+            s = BinaryOp("+", s, b)
         body = BinaryOp("+", BinaryOp("-", z, s), Constant(float(n - 1)))
         ac.append(Constraint(body, ">=", 0.0))
         self._and_cache[key] = z
@@ -442,8 +442,10 @@ def _try_expand_multilinear(node: BinaryOp, exp: _Expander) -> Optional[Expressi
             if lo != 0.0:
                 newpoly[key] = newpoly.get(key, 0.0) + coef * float(lo)
             for ck, ek in bits:
-                nk = key if any(b is ek for b in key) else tuple(
-                    sorted((*key, ek), key=lambda b: b._index)
+                nk = (
+                    key
+                    if any(b is ek for b in key)
+                    else tuple(sorted((*key, ek), key=lambda b: b._index))
                 )
                 newpoly[nk] = newpoly.get(nk, 0.0) + coef * float(ck)
         poly = newpoly
@@ -454,9 +456,10 @@ def _try_expand_multilinear(node: BinaryOp, exp: _Expander) -> Optional[Expressi
         c = const * coef
         if c == 0.0:
             continue
-        # Lift the pure-binary monomial ``prod(key)`` to a single 0/1 quantity.
+        # Lift the pure-binary monomial ``prod(key)`` to a single 0/1 quantity — the
+        # bit itself, or a binary AND aux; both are ``Variable`` (needed by big-M).
         if len(key) == 0:
-            mono: Optional[Expression] = None  # empty product == 1
+            mono: Optional[Variable] = None  # empty product == 1
         elif len(key) == 1:
             mono = key[0]
         else:
@@ -613,9 +616,7 @@ def _has_int_multilinear(expr: Expression, implied) -> bool:
                 n_cont = len(refs) - n_int
                 if n_int >= 1 and n_cont <= 1:
                     return True
-        return _has_int_multilinear(expr.left, implied) or _has_int_multilinear(
-            expr.right, implied
-        )
+        return _has_int_multilinear(expr.left, implied) or _has_int_multilinear(expr.right, implied)
     c = getattr(expr, "operand", None)
     if isinstance(c, Expression) and _has_int_multilinear(c, implied):
         return True
@@ -692,9 +693,7 @@ def _participation(model: Model, implied) -> dict:
     return counts
 
 
-def expand_integer_products(
-    model: Model, implied=frozenset(), multilinear: bool = False
-) -> Model:
+def expand_integer_products(model: Model, implied=frozenset(), multilinear: bool = False) -> Model:
     """Return a model equivalent to *model* with integer-factor bilinear products
     binary-expanded + big-M-linearized to their exact (pure-MILP) form. ``implied``
     is an optional set of ``(var._index, elem)`` treated as integer-valued in

--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -109,9 +109,12 @@ class _Expander:
     """Creates and caches the binary expansion of integer factor variables and
     accumulates the linking ``x_i == lo + sum 2^k e_k`` constraints."""
 
-    def __init__(self, model: Model, implied=frozenset(), participation=None):
+    def __init__(self, model: Model, implied=frozenset(), participation=None, multilinear=False):
         self.model = model
         self.implied = implied
+        # When True, also exact-linearize integer-multilinear products (>=3 factors,
+        # <=1 continuous) — issue #707. Left off for the pure-bilinear entry points.
+        self.multilinear = multilinear
         # (var._index, elem) -> number of bilinear products the factor appears in;
         # the more-shared factor is expanded so its bits are reused (fewer vars).
         self.participation = participation or {}
@@ -131,6 +134,12 @@ class _Expander:
         # Cleared if an aux column cannot be described (defensive): then the whole
         # spec is discarded and no warm start is mapped rather than one misaligned.
         self.spec_ok = True
+        # Caches for the multilinear path (issue #707) so a binary monomial shared
+        # across several product terms is lifted once: key -> aux Variable.
+        #   _and_cache: tuple(sorted bit _index) -> binary AND aux
+        #   _bigm_cache: (e._index, other._index, other_elem) -> big-M product aux
+        self._and_cache: dict[tuple, Variable] = {}
+        self._bigm_cache: dict[tuple, Variable] = {}
 
     def expansion(self, var: Variable, elem: int, lo: int, hi: int):
         key = (var._index, elem)
@@ -178,6 +187,15 @@ class _Expander:
         # meaningless, not just at true infinity.
         if not (abs(lo_o) <= _BIGM_BOUND_CAP and abs(hi_o) <= _BIGM_BOUND_CAP):
             raise ValueError("cannot big-M-linearize a product with an unbounded factor")
+        # Reuse an identical ``e * other`` product if one was already lifted (the
+        # multilinear expansion can request the same AND-aux times continuous
+        # factor across several monomials). Keyed on the scalar refs. Scoped to the
+        # multilinear path so the pure-bilinear reform stays byte-identical (its
+        # blowup-guard threshold depends on the exact aux count — issue #707).
+        _oref = _scalar_var_ref(other) if self.multilinear else None
+        _ckey = (e._index, _oref[0]._index, _oref[1]) if _oref is not None else None
+        if _ckey is not None and _ckey in self._bigm_cache:
+            return self._bigm_cache[_ckey]
         v = Variable(
             f"_ipx_v{self._counter}",
             VarType.CONTINUOUS,
@@ -212,7 +230,43 @@ class _Expander:
         # v - other - hi_o*e + hi_o >= 0   (i.e. v >= other - hi_o*(1-e))
         body_l = BinaryOp("-", BinaryOp("-", v, other), BinaryOp("*", Constant(hi_o), e))
         ac.append(Constraint(BinaryOp("+", body_l, Constant(hi_o)), ">=", 0.0))
+        if _ckey is not None:
+            self._bigm_cache[_ckey] = v
         return v
+
+    def and_product(self, bits: "list[Variable]") -> Variable:
+        """Return a **binary** aux ``z = prod_i e_i`` for a set of binary variables
+        ``e_i`` via the exact multilinear-AND hull
+
+            z <= e_i  (each i),   z >= sum_i e_i - (n-1),   z in {0,1}.
+
+        At ``e_i in {0,1}`` these force ``z = 1`` iff every ``e_i = 1`` — the exact
+        (integral) convex hull of the binary product, tighter than a term-wise
+        McCormick envelope. Shared monomials are lifted once (``_and_cache``)."""
+        key = tuple(sorted(b._index for b in bits))
+        cached = self._and_cache.get(key)
+        if cached is not None:
+            return cached
+        n = len(bits)
+        z = Variable(f"_ipx_z{self._counter}", VarType.BINARY, (), 0.0, 1.0, self.model)
+        self._counter += 1
+        self.model._variables.append(z)
+        # z is exactly the product of its binary inputs, so it reconstructs from a
+        # point over the originals once its inputs are reconstructed. Record the
+        # AND spec (evaluated after every input bit, which are appended earlier).
+        self.aux_spec.append(("and", (z._index, 0), [(b._index, 0) for b in bits]))
+        ac = self.aux_constraints
+        # z - e_i <= 0  (each factor upper-bounds the product)
+        for b in bits:
+            ac.append(Constraint(BinaryOp("-", z, b), "<=", 0.0))
+        # z - sum_i e_i + (n-1) >= 0
+        s: Optional[Expression] = None
+        for b in bits:
+            s = b if s is None else BinaryOp("+", s, b)
+        body = BinaryOp("+", BinaryOp("-", z, s), Constant(float(n - 1)))
+        ac.append(Constraint(body, ">=", 0.0))
+        self._and_cache[key] = z
+        return z
 
 
 def _expand_product(
@@ -322,6 +376,107 @@ def _try_expand_mul(node: BinaryOp, model: Model, exp: _Expander) -> Optional[Ex
     return expanded
 
 
+def _classify_multilinear_factors(node: BinaryOp, exp: _Expander):
+    """Split a product *node* into ``(const, int_refs, cont_factors)`` where
+    ``int_refs`` is a list of ``(var, elem, lo, hi)`` integer variable factors (with
+    multiplicity, one per occurrence) and ``cont_factors`` is a list of
+    ``(scalar_expr, lo, hi)`` for the continuous variable factors. **No expansion
+    columns are created** — this is a pure inspection so a term that fails the
+    reformability guard leaves the model untouched. Returns ``None`` when a factor
+    is not a scalar variable / constant, or there are fewer than three variable
+    factors (the bilinear/square cases are handled elsewhere)."""
+    factors = _collect_mul_factors(node)
+    const = 1.0
+    var_refs: list[tuple[Expression, Variable, int]] = []
+    for f in factors:
+        if isinstance(f, Constant):
+            const *= float(f.value)
+            continue
+        ref = _scalar_var_ref(f)
+        if ref is None:
+            return None  # a non-scalar / non-constant factor — leave to McCormick
+        var_refs.append((f, ref[0], ref[1]))
+    if len(var_refs) < 3:
+        return None
+    int_refs: list[tuple[Variable, int, int, int]] = []
+    cont_factors: list[tuple[Expression, float, float]] = []
+    for e, v, el in var_refs:
+        rng = _int_factor_range(v, el, exp.implied)
+        if rng is not None:
+            int_refs.append((v, el, rng[0], rng[1]))
+        else:
+            lo = float(np.asarray(v.lb).flat[el])
+            hi = float(np.asarray(v.ub).flat[el])
+            cont_factors.append((e, lo, hi))
+    return const, int_refs, cont_factors
+
+
+def _try_expand_multilinear(node: BinaryOp, exp: _Expander) -> Optional[Expression]:
+    """Exactly linearize an *integer-multilinear* product (>=3 variable factors,
+    every factor but at most one integer/binary-valued). Binary-expand each integer
+    factor, distribute the product into binary monomials (using ``e^2 = e``), lift
+    each monomial to its exact hull (an ``and_product`` aux, or the bit itself for a
+    single-bit monomial), and — for the lone continuous factor, if any —
+    big-M-lift ``continuous * monomial``. Returns a purely linear expression, or
+    ``None`` when the term is not of this class (e.g. two continuous factors → a
+    genuine continuous nonlinearity left to McCormick)."""
+    split = _classify_multilinear_factors(node, exp)
+    if split is None:
+        return None
+    const, int_refs, cont_factors = split
+    # At most one continuous factor (to the first power): two distinct or a repeated
+    # continuous factor is a genuine continuous bilinear/square — not exact-linear.
+    # Guard BEFORE creating any expansion column so a bailed term is a true no-op.
+    if len(cont_factors) > 1 or not int_refs:
+        return None
+    int_factors = [exp.expansion(v, el, lo, hi) for (v, el, lo, hi) in int_refs]
+
+    # Distribute the product of the integer factors into monomials over the binary
+    # bits. ``poly`` maps a tuple of distinct bit Variables (sorted by index) to its
+    # integer coefficient; ``e^2 = e`` collapses repeated bits (repeated integer
+    # factor) via the ``any(b is ek ...)`` idempotence check.
+    poly: dict[tuple, float] = {(): 1.0}
+    for lo, bits in int_factors:
+        newpoly: dict[tuple, float] = {}
+        for key, coef in poly.items():
+            if lo != 0.0:
+                newpoly[key] = newpoly.get(key, 0.0) + coef * float(lo)
+            for ck, ek in bits:
+                nk = key if any(b is ek for b in key) else tuple(
+                    sorted((*key, ek), key=lambda b: b._index)
+                )
+                newpoly[nk] = newpoly.get(nk, 0.0) + coef * float(ck)
+        poly = newpoly
+
+    cont = cont_factors[0] if cont_factors else None
+    out: Optional[Expression] = None
+    for key, coef in poly.items():
+        c = const * coef
+        if c == 0.0:
+            continue
+        # Lift the pure-binary monomial ``prod(key)`` to a single 0/1 quantity.
+        if len(key) == 0:
+            mono: Optional[Expression] = None  # empty product == 1
+        elif len(key) == 1:
+            mono = key[0]
+        else:
+            mono = exp.and_product(list(key))
+        if cont is not None:
+            cexpr, clo, chi = cont
+            if mono is None:
+                term_expr: Expression = cexpr  # 1 * continuous
+            else:
+                term_expr = exp.bigm_product(mono, cexpr, clo, chi)  # continuous * 0/1
+        else:
+            if mono is None:
+                out = Constant(c) if out is None else BinaryOp("+", out, Constant(c))
+                continue
+            term_expr = mono
+        term = term_expr if c == 1.0 else BinaryOp("*", Constant(c), term_expr)
+        out = term if out is None else BinaryOp("+", out, term)
+    return out if out is not None else Constant(0.0)
+
+
 def _rewrite(expr: Expression, model: Model, exp: _Expander) -> Expression:
     """Recursively rewrite integer-factor bilinear products in *expr*."""
     if isinstance(expr, BinaryOp):
@@ -330,6 +485,10 @@ def _rewrite(expr: Expression, model: Model, exp: _Expander) -> Expression:
             if sq is not None:
                 return sq
         if expr.op == "*":
+            if exp.multilinear:
+                ml = _try_expand_multilinear(expr, exp)
+                if ml is not None:
+                    return ml
             replaced = _try_expand_mul(expr, model, exp)
             if replaced is not None:
                 return replaced
@@ -436,18 +595,64 @@ def _has_int_square(expr: Expression, implied) -> bool:
     return False
 
 
-def has_integer_product_work(model: Model, implied=frozenset()) -> bool:
+def _has_int_multilinear(expr: Expression, implied) -> bool:
+    """True if *expr* contains an *integer-multilinear* product this pass can
+    exactly linearize: a ``*`` term with >=3 scalar-variable factors, at least one
+    integer-valued (declared or *implied*) and at most one continuous factor. (Two
+    continuous factors is a genuine continuous nonlinearity; fewer than three
+    variable factors is the bilinear/square case handled separately.)"""
+    if isinstance(expr, BinaryOp):
+        if expr.op == "*":
+            refs = [
+                _scalar_var_ref(f)
+                for f in _collect_mul_factors(expr)
+                if not isinstance(f, Constant)
+            ]
+            if len(refs) >= 3 and all(r is not None for r in refs):
+                n_int = sum(1 for (vi, eli) in refs if _int_factor_range(vi, eli, implied))  # type: ignore[misc]
+                n_cont = len(refs) - n_int
+                if n_int >= 1 and n_cont <= 1:
+                    return True
+        return _has_int_multilinear(expr.left, implied) or _has_int_multilinear(
+            expr.right, implied
+        )
+    c = getattr(expr, "operand", None)
+    if isinstance(c, Expression) and _has_int_multilinear(c, implied):
+        return True
+    for attr in ("args", "terms"):
+        seq = getattr(expr, attr, None)
+        if isinstance(seq, (list, tuple)):
+            if any(isinstance(x, Expression) and _has_int_multilinear(x, implied) for x in seq):
+                return True
+    return False
+
+
+def has_integer_product_work(model: Model, implied=frozenset(), multilinear: bool = False) -> bool:
     """True if any constraint/objective has an integer-factor bilinear product or
-    integer square (integer or *implied*-integer factor) this pass can linearize."""
+    integer square (integer or *implied*-integer factor) this pass can linearize.
+    When *multilinear* is set, also detect integer-multilinear products (issue
+    #707)."""
     try:
         for body in _bodies(model):
             found = []
             _for_each_int_bilinear(body, implied, lambda ints: found.append(True))
             if found or _has_int_square(body, implied):
                 return True
+            if multilinear and _has_int_multilinear(body, implied):
+                return True
     except Exception:
         return False
     return False
+
+
+def has_integer_multilinear_work(model: Model, implied=frozenset()) -> bool:
+    """True if any constraint/objective has an integer-*multilinear* product
+    (>=3 factors, <=1 continuous, >=1 integer/implied-integer) — the class the
+    ``DISCOPT_INTEGER_MULTILINEAR_REFORM`` pass linearizes (issue #707)."""
+    try:
+        return any(_has_int_multilinear(body, implied) for body in _bodies(model))
+    except Exception:
+        return False
 
 
 def has_nonconvex_integer_bilinear(model: Model) -> bool:
@@ -487,21 +692,30 @@ def _participation(model: Model, implied) -> dict:
     return counts
 
 
-def expand_integer_products(model: Model, implied=frozenset()) -> Model:
+def expand_integer_products(
+    model: Model, implied=frozenset(), multilinear: bool = False
+) -> Model:
     """Return a model equivalent to *model* with integer-factor bilinear products
     binary-expanded + big-M-linearized to their exact (pure-MILP) form. ``implied``
     is an optional set of ``(var._index, elem)`` treated as integer-valued in
-    addition to declared integers. Returns *model* unchanged when no such product
-    exists or on any unexpected error (never regresses)."""
+    addition to declared integers. When *multilinear* is set, also exact-linearize
+    integer-multilinear products (>=3 factors, <=1 continuous — issue #707).
+    Returns *model* unchanged when no such product exists or on any unexpected error
+    (never regresses)."""
     try:
-        if not has_integer_product_work(model, implied):
+        if not has_integer_product_work(model, implied, multilinear=multilinear):
             return model
         new_model = Model(model.name)
         new_model._variables = list(model._variables)
         new_model._parameters = list(model._parameters)
         new_model._rebuild_name_index()  # keep the name cache in sync (M7)
         new_model._objective = model._objective
-        exp = _Expander(new_model, implied=implied, participation=_participation(model, implied))
+        exp = _Expander(
+            new_model,
+            implied=implied,
+            participation=_participation(model, implied),
+            multilinear=multilinear,
+        )
 
         rebuilt: list[Constraint] = []
         for c in model._constraints:
@@ -563,6 +777,9 @@ def _attach_warm_start_spec(model: Model, new_model: Model, exp: "_Expander") ->
             if entry[0] == "bit":
                 _, src, k, lo, nbits = entry
                 translated.append(("bit", _flat(src), k, lo, nbits))
+            elif entry[0] == "and":
+                _, z_key, in_keys = entry
+                translated.append(("and", _flat(z_key), [_flat(kk) for kk in in_keys]))
             else:  # "prod"
                 _, e_key, o_key = entry
                 translated.append(("prod", _flat(e_key), _flat(o_key)))
@@ -606,6 +823,12 @@ def extend_initial_point(reformed: Model, x0) -> Optional[np.ndarray]:
             if abs(n - nr) > 1e-6 or nr < 0 or nr > (1 << nbits) - 1:
                 return None
             out.append(float((nr >> k) & 1))
+        elif entry[0] == "and":  # z = prod of already-reconstructed input bits
+            _, _zi, in_idxs = entry
+            prod = 1.0
+            for ii in in_idxs:
+                prod *= float(out[ii])
+            out.append(prod)
         else:  # "prod": v = e * other, both already reconstructed above
             _, ei, oi = entry
             out.append(float(out[ei] * out[oi]))
@@ -634,5 +857,32 @@ def reformulate_integer_bilinear(model: Model) -> Model:
 
         implied = frozenset(detect_implied_integers(model))
         return expand_integer_products(model, implied)
+    except Exception:
+        return model
+
+
+def has_integer_multilinear_reformulation_work(model: Model) -> bool:
+    """True if the model has an integer-*multilinear* product (>=3 factors, <=1
+    continuous, >=1 declared/implied-integer) that the ``#707`` pass linearizes."""
+    try:
+        from .implied_integer import detect_implied_integers
+
+        implied = frozenset(detect_implied_integers(model))
+        return has_integer_multilinear_work(model, implied)
+    except Exception:
+        return False
+
+
+def reformulate_integer_multilinear(model: Model) -> Model:
+    """End-to-end pass (issue #707): detect implied-integer factors, then exactly
+    linearize every integer-factor bilinear **and** integer-multilinear product
+    (>=3 factors, <=1 continuous). A no-op (returns *model*) when nothing applies.
+    Gated by ``DISCOPT_INTEGER_MULTILINEAR_REFORM``; the caller decides whether the
+    result is adopted (pure-MILP → MILP engine, else kept on the spatial path)."""
+    try:
+        from .implied_integer import detect_implied_integers
+
+        implied = frozenset(detect_implied_integers(model))
+        return expand_integer_products(model, implied, multilinear=True)
     except Exception:
         return model

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4510,7 +4510,7 @@ def solve_model(
         # to certify do we clear and fall back to spatial B&B (see the convex
         # fast-path block below).
 
-    # --- Integer-multilinear exact reformulation (issue #707, DISCOPT_INTEGER_MULTILINEAR_REFORM) ---
+    # --- Integer-multilinear exact reformulation (#707, DISCOPT_INTEGER_MULTILINEAR_REFORM) ---
     # A generalization of the integer-bilinear pass below to products of >=3
     # variable factors where every factor but at most one is integer/binary-valued
     # (declared or implied), e.g. ex1252's objective ``(c + 1800*x15)*x0*x3*x18``
@@ -4527,6 +4527,8 @@ def solve_model(
         if _tuning().integer_multilinear_reform:
             from discopt._jax.integer_product_reform import (
                 extend_initial_point as _iml_extend,
+            )
+            from discopt._jax.integer_product_reform import (
                 has_integer_multilinear_reformulation_work,
                 reformulate_integer_multilinear,
             )

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4532,12 +4532,12 @@ def solve_model(
             )
 
             if has_integer_multilinear_reformulation_work(model):
+                _iml_n0 = sum(v.size for v in model._variables)
                 _iml = reformulate_integer_multilinear(model)
                 if _iml is not model:
                     from discopt._jax.problem_classifier import ProblemClass, classify_problem
                     from discopt._jax.term_classifier import classify_nonlinear_terms
 
-                    _did_multilinear_reform = True
                     # Does the reform eliminate *all* nonlinearity (pure MILP)? Then
                     # route to the MILP engine as the bilinear pass does; otherwise
                     # keep the reformed model on the spatial B&B path (still tighter).
@@ -4552,22 +4552,37 @@ def solve_model(
                         or _iml_nl.ratio_of_products
                         or _iml_nl.general_nl
                     )
-                    model = _iml
-                    model._convexity_classification_cache = None
-                    clear_declared_box_cache(model)
-                    model._convexity_time_budget = _convexity_time_budget
-                    model._solve_deadline = _solve_t0 + float(time_limit)
-                    if _iml_pure_milp and classify_problem(_iml) == ProblemClass.MILP:
-                        presolve = False
-                        if nlp_solver == "pounce" and not _p3_force_cut_path_enabled():
-                            nlp_solver = "simplex"
-                    # Extend a user warm start over the appended aux columns so the
-                    # (longer) reformed vector is not silently dropped. Purely primal:
-                    # the driver re-validates it, so it never affects the dual bound.
-                    if initial_point is not None:
-                        _iml_x0 = _iml_extend(model, initial_point)
-                        if _iml_x0 is not None:
-                            initial_point = _iml_x0
+                    # Blowup guard for the *spatial-path* case. The big-M/AND auxes
+                    # only pay off when they tighten a *binding* dual bound (ex1252:
+                    # the objective barrier); on an already-tractable instance they
+                    # merely balloon the per-node LP and slow convergence (nvs01: a
+                    # 3-var instance the spatial solve certifies fast blows up to
+                    # ~200 columns and *regresses*). So keep a non-pure-MILP reform
+                    # only when the column count stays within a modest factor of the
+                    # original; a pure-MILP reform is always worth the MILP-engine
+                    # route. When rejected, leave the model untouched so the normal
+                    # path (incl. the bilinear reform below) runs exactly as it would
+                    # with the flag off — never a regression.
+                    _iml_n1 = sum(v.size for v in _iml._variables)
+                    _iml_adopt = _iml_pure_milp or _iml_n1 <= 4 * max(_iml_n0, 16)
+                    if _iml_adopt:
+                        _did_multilinear_reform = True
+                        model = _iml
+                        model._convexity_classification_cache = None
+                        clear_declared_box_cache(model)
+                        model._convexity_time_budget = _convexity_time_budget
+                        model._solve_deadline = _solve_t0 + float(time_limit)
+                        if _iml_pure_milp and classify_problem(_iml) == ProblemClass.MILP:
+                            presolve = False
+                            if nlp_solver == "pounce" and not _p3_force_cut_path_enabled():
+                                nlp_solver = "simplex"
+                        # Extend a user warm start over the appended aux columns so the
+                        # (longer) reformed vector is not silently dropped. Purely primal:
+                        # the driver re-validates it, so it never affects the dual bound.
+                        if initial_point is not None:
+                            _iml_x0 = _iml_extend(model, initial_point)
+                            if _iml_x0 is not None:
+                                initial_point = _iml_x0
     except Exception as _iml_exc:  # pragma: no cover - defensive
         logger.debug("integer-multilinear reformulation skipped: %s", _iml_exc)
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4579,10 +4579,11 @@ def solve_model(
                         # Extend a user warm start over the appended aux columns so the
                         # (longer) reformed vector is not silently dropped. Purely primal:
                         # the driver re-validates it, so it never affects the dual bound.
+                        # If it cannot be extended (e.g. an off-integer seed), drop it
+                        # entirely — a shorter vector against the grown model would crash
+                        # the downstream integrality check on the spatial path.
                         if initial_point is not None:
-                            _iml_x0 = _iml_extend(model, initial_point)
-                            if _iml_x0 is not None:
-                                initial_point = _iml_x0
+                            initial_point = _iml_extend(model, initial_point)
     except Exception as _iml_exc:  # pragma: no cover - defensive
         logger.debug("integer-multilinear reformulation skipped: %s", _iml_exc)
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4510,6 +4510,67 @@ def solve_model(
         # to certify do we clear and fall back to spatial B&B (see the convex
         # fast-path block below).
 
+    # --- Integer-multilinear exact reformulation (issue #707, DISCOPT_INTEGER_MULTILINEAR_REFORM) ---
+    # A generalization of the integer-bilinear pass below to products of >=3
+    # variable factors where every factor but at most one is integer/binary-valued
+    # (declared or implied), e.g. ex1252's objective ``(c + 1800*x15)*x0*x3*x18``
+    # with integer flow factors ``x0,x3 in {0..3}`` and a 0/1 indicator ``x18``.
+    # Binary-expanding the integer factors and lifting the resulting binary product
+    # to its exact hull (n-ary AND + one big-M product for the lone continuous
+    # factor) replaces the loose term-wise trilinear McCormick envelope over the
+    # continuous box with the per-integer-level exact envelope. Unlike the
+    # bilinear pass, the result is retained even when residual *continuous*
+    # nonlinearity remains (ex1252's continuous cubic cost rows) — the tightening
+    # of the integer-multilinear terms is a strict, sound gain on the spatial path.
+    _did_multilinear_reform = False
+    try:
+        if _tuning().integer_multilinear_reform:
+            from discopt._jax.integer_product_reform import (
+                extend_initial_point as _iml_extend,
+                has_integer_multilinear_reformulation_work,
+                reformulate_integer_multilinear,
+            )
+
+            if has_integer_multilinear_reformulation_work(model):
+                _iml = reformulate_integer_multilinear(model)
+                if _iml is not model:
+                    from discopt._jax.problem_classifier import ProblemClass, classify_problem
+                    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+                    _did_multilinear_reform = True
+                    # Does the reform eliminate *all* nonlinearity (pure MILP)? Then
+                    # route to the MILP engine as the bilinear pass does; otherwise
+                    # keep the reformed model on the spatial B&B path (still tighter).
+                    _iml_nl = classify_nonlinear_terms(_iml)
+                    _iml_pure_milp = not (
+                        _iml_nl.bilinear
+                        or _iml_nl.trilinear
+                        or _iml_nl.multilinear
+                        or _iml_nl.monomial
+                        or _iml_nl.fractional_power
+                        or _iml_nl.bilinear_with_fp
+                        or _iml_nl.ratio_of_products
+                        or _iml_nl.general_nl
+                    )
+                    model = _iml
+                    model._convexity_classification_cache = None
+                    clear_declared_box_cache(model)
+                    model._convexity_time_budget = _convexity_time_budget
+                    model._solve_deadline = _solve_t0 + float(time_limit)
+                    if _iml_pure_milp and classify_problem(_iml) == ProblemClass.MILP:
+                        presolve = False
+                        if nlp_solver == "pounce" and not _p3_force_cut_path_enabled():
+                            nlp_solver = "simplex"
+                    # Extend a user warm start over the appended aux columns so the
+                    # (longer) reformed vector is not silently dropped. Purely primal:
+                    # the driver re-validates it, so it never affects the dual bound.
+                    if initial_point is not None:
+                        _iml_x0 = _iml_extend(model, initial_point)
+                        if _iml_x0 is not None:
+                            initial_point = _iml_x0
+    except Exception as _iml_exc:  # pragma: no cover - defensive
+        logger.debug("integer-multilinear reformulation skipped: %s", _iml_exc)
+
     # --- Integer-bilinear exact reformulation ---
     # When a bilinear term ``x_i*x_j`` has an integer (declared or implied)
     # factor, binary-expand it and big-M-linearize the resulting binary*var
@@ -4535,7 +4596,7 @@ def solve_model(
         # the MIQP-batch certification path). This witness is far cheaper than a
         # full convexity classification (~6s on ex1263), so the common path and
         # the reformulated path both stay fast.
-        if has_nonconvex_integer_bilinear(model):
+        if not _did_multilinear_reform and has_nonconvex_integer_bilinear(model):
             _ipx = reformulate_integer_bilinear(model)
             # Adopt the reformulation ONLY when it eliminates *all* nonlinearity,
             # i.e. yields an equivalent pure MILP. If other nonlinear terms remain

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -173,6 +173,31 @@ class SolverTuning:
     )
     """Trilinear RLT rows (``DISCOPT_TRILINEAR_RLT``, default on)."""
 
+    integer_multilinear_reform: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_INTEGER_MULTILINEAR_REFORM", default=False)
+    )
+    """Flow-aware exact linearization of *integer-multilinear* products — products
+    of >=3 variable factors where every factor but at most one is integer- or
+    binary-valued (declared or implied), e.g. ``(c + k*x_cont)*x_i*x_j*x_ind`` with
+    ``x_i,x_j`` integer flow factors and ``x_ind`` a 0/1 indicator
+    (``DISCOPT_INTEGER_MULTILINEAR_REFORM``, default **off**; issue #707).
+
+    Each integer factor is binary-expanded (``x = lo + sum 2^k e_k``) and the
+    resulting product of binaries is lifted to its **exact** hull — an n-ary AND
+    (``z <= e_i``, ``z >= sum e_i - (n-1)``, ``z`` binary) for the pure-integer
+    monomials, plus one big-M product (``v = e*x_cont``) for the single continuous
+    factor. The rewrite is a value-preserving algebraic identity; only the
+    *relaxation* changes (the loose term-wise trilinear McCormick envelope over the
+    continuous box is replaced by the per-integer-level exact envelope), so it is
+    sound and can only tighten the dual bound. Unlike the pure-bilinear integer
+    reform (which is adopted only when it yields a pure MILP), this pass is retained
+    on the spatial branch-and-bound path when residual *continuous* nonlinearity
+    remains — the tightening of the integer-multilinear terms is a strict gain there
+    (ex1252: lifts the SOS1-selector-branch dual bound off its 5134 floor).
+
+    Bound-changing (CLAUDE.md §5): default-off behind this flag until a corpus-wide
+    differential panel graduates it."""
+
     # --- McCormick separation toggles -----------------------------------------
     square_separate: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_SQUARE_SEPARATE", default=True)

--- a/python/tests/test_integer_multilinear_reform.py
+++ b/python/tests/test_integer_multilinear_reform.py
@@ -205,6 +205,28 @@ def test_ex1252_multilinear_reform_sound_and_lifts_bound():
     )
 
 
+@pytest.mark.correctness
+def test_flag_with_unextendable_seed_does_not_crash():
+    """A user warm start that cannot be extended across the big-M lift (e.g. an
+    off-integer value on an expanded factor) must be dropped, not left as a
+    length-mismatched vector against the grown model — which would crash the
+    downstream integrality check on the spatial path."""
+    m = dm.Model("tri")
+    a = m.integer("a", lb=0, ub=3)
+    b = m.integer("b", lb=0, ub=3)
+    c = m.integer("c", lb=0, ub=3)
+    m.subject_to(a + b + c <= 3)
+    m.minimize(-(a * b * c))
+    os.environ["DISCOPT_INTEGER_MULTILINEAR_REFORM"] = "1"
+    try:
+        # a=0.5 is fractional on an expanded integer factor → not extendable.
+        res = m.solve(time_limit=20, initial_solution={a: 0.5, b: 1.0, c: 1.0})
+    finally:
+        os.environ.pop("DISCOPT_INTEGER_MULTILINEAR_REFORM", None)
+    # Solve still completes soundly (seed simply dropped).
+    assert res.objective is None or res.objective >= -1.0 - 1e-4
+
+
 @pytest.mark.slow
 @pytest.mark.correctness
 def test_flag_does_not_regress_easy_instance():

--- a/python/tests/test_integer_multilinear_reform.py
+++ b/python/tests/test_integer_multilinear_reform.py
@@ -203,3 +203,27 @@ def test_ex1252_multilinear_reform_sound_and_lifts_bound():
     assert res.bound > 5134.5, (
         f"ex1252 multilinear-reform bound {res.bound} did not lift past the 5134 floor"
     )
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+def test_flag_does_not_regress_easy_instance():
+    """The spatial-path blowup guard must keep the flag from *regressing* an
+    already-tractable instance. ``nvs01`` (3 variables) certifies to 12.4697 on the
+    plain spatial path; its integer-multilinear reform balloons it to ~200 columns,
+    so the guard rejects the non-pure-MILP reform and leaves the original model —
+    the flag-on solve must reach the same optimum, not stall below it."""
+    nvs01_opt = 12.46966882
+    os.environ["DISCOPT_INTEGER_MULTILINEAR_REFORM"] = "1"
+    try:
+        m = dm.from_nl(str(_DATA / "nvs01.nl"))
+        res = m.solve(time_limit=30)
+    finally:
+        os.environ.pop("DISCOPT_INTEGER_MULTILINEAR_REFORM", None)
+    # Sound in any case.
+    if res.bound is not None and math.isfinite(res.bound):
+        assert res.bound <= nvs01_opt + 1e-2, f"nvs01 UNSOUND bound {res.bound}"
+    # No regression: the guard preserves the fast certification (bound reaches opt).
+    assert res.bound is not None and res.bound >= nvs01_opt - 1e-2, (
+        f"nvs01 regressed under the flag: bound {res.bound} < optimum {nvs01_opt}"
+    )

--- a/python/tests/test_integer_multilinear_reform.py
+++ b/python/tests/test_integer_multilinear_reform.py
@@ -1,0 +1,205 @@
+"""Regression tests for the flow-aware integer-multilinear reformulation
+(issue #707, ``DISCOPT_INTEGER_MULTILINEAR_REFORM``).
+
+The pass exact-linearizes products of >=3 variable factors where every factor
+but at most one is integer/binary-valued (declared or implied) — e.g. ex1252's
+objective ``(c + 1800*x15)*x0*x3*x18`` with integer flow factors ``x0,x3`` and a
+0/1 indicator ``x18``. Each integer factor is binary-expanded and the resulting
+binary product is lifted to its exact hull (an n-ary AND, plus one big-M product
+for the single continuous factor), replacing the loose term-wise trilinear
+McCormick envelope with the per-integer-level exact envelope.
+
+The invariant under test is **soundness**: the rewrite is an exact algebraic
+identity (value-preserving), so it can only tighten — never invalidate — the dual
+bound. A separate slow test locks that it lifts ex1252 off its 5134 floor.
+"""
+
+import math
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.integer_product_reform import (
+    extend_initial_point,
+    has_integer_multilinear_reformulation_work,
+    reformulate_integer_multilinear,
+)
+from discopt.modeling.core import BinaryOp, Constant, IndexExpression, UnaryOp, Variable
+
+_DATA = Path(__file__).parent / "data" / "minlplib"
+_EX1252_OPT = 128893.74
+
+
+def _flat_offsets(model):
+    off, o = {}, 0
+    for v in model._variables:
+        off[v._index] = o
+        o += v.size
+    return off, o
+
+
+def _eval(expr, x, off):
+    """Evaluate an expression DAG at a flat point ``x`` (offsets in ``off``)."""
+    if isinstance(expr, Constant):
+        return float(expr.value)
+    if isinstance(expr, Variable):
+        return float(x[off[expr._index]])
+    if isinstance(expr, IndexExpression):
+        v = getattr(expr, "variable", None) or getattr(expr, "var", None)
+        idx = getattr(expr, "index", 0)
+        return float(x[off[v._index] + (idx if isinstance(idx, int) else 0)])
+    if isinstance(expr, UnaryOp):
+        a = _eval(expr.operand, x, off)
+        return {"neg": lambda z: -z, "exp": math.exp, "log": math.log,
+                "sqrt": math.sqrt, "abs": abs}[expr.op](a)
+    if isinstance(expr, BinaryOp):
+        a, b = _eval(expr.left, x, off), _eval(expr.right, x, off)
+        if expr.op == "+":
+            return a + b
+        if expr.op == "-":
+            return a - b
+        if expr.op == "*":
+            return a * b
+        if expr.op == "/":
+            return a / b if b else math.inf
+        if expr.op == "**":
+            return a ** b
+        raise ValueError(f"unhandled op {expr.op}")
+    raise TypeError(type(expr))
+
+
+@pytest.mark.correctness
+def test_ex1252_multilinear_reform_is_value_preserving():
+    """The reform must be an **exact algebraic identity** on the objective: for any
+    point with integer flow factors and 0/1 indicators, the reformed objective
+    (aux columns reconstructed from the originals) equals the original objective.
+    This is the soundness bedrock — a mismatch would mean the rewrite changes the
+    problem, not just its relaxation."""
+    m = dm.from_nl(str(_DATA / "ex1252.nl"))
+    r = reformulate_integer_multilinear(m)
+    assert r is not m, "expected a rewritten model for ex1252"
+    o_off, _ = _flat_offsets(m)
+    r_off, _ = _flat_offsets(r)
+    rng = np.random.default_rng(0)
+    max_err = 0.0
+    for _ in range(500):
+        x = np.zeros(len(m._variables))
+        for i in range(6):  # x0..x5 integer flow factors in {0,1,2,3}
+            x[i] = rng.integers(0, 4)
+        for i in range(15, 18):  # x15..x17 continuous cost slopes
+            x[i] = rng.uniform(0, 80)
+        for i in range(18, 21):  # x18..x20 indicators in {0,1}
+            x[i] = rng.integers(0, 2)
+        xf = extend_initial_point(r, x)
+        assert xf is not None, "warm-start extension failed on an integer point"
+        vo = _eval(m._objective.expression, x, o_off)
+        vr = _eval(r._objective.expression, xf, r_off)
+        max_err = max(max_err, abs(vo - vr))
+    assert max_err < 1e-5, f"reform not value-preserving: max abs err {max_err}"
+
+
+@pytest.mark.correctness
+def test_ex1252_reform_eliminates_integer_multilinear_terms():
+    """After the reform, ex1252 carries no trilinear/multilinear product terms —
+    the integer-multilinear objective terms are gone. The residual nonlinearity is
+    the genuine *continuous* cubic cost rows, which the pass correctly leaves for
+    the spatial relaxation."""
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    m = dm.from_nl(str(_DATA / "ex1252.nl"))
+    assert has_integer_multilinear_reformulation_work(m)
+    r = reformulate_integer_multilinear(m)
+    nl = classify_nonlinear_terms(r)
+    assert not nl.trilinear, f"trilinear terms remain: {nl.trilinear}"
+    assert not nl.multilinear, f"multilinear terms remain: {nl.multilinear}"
+
+
+@pytest.mark.correctness
+def test_reform_noop_on_pure_continuous_product():
+    """A product with two continuous factors is a genuine continuous nonlinearity,
+    not exact-linearizable — the pass must be a no-op (returns the same model) so it
+    never bloats or perturbs models outside its class."""
+    m = dm.Model("cont")
+    x = m.continuous("x", lb=0.0, ub=5.0)
+    y = m.continuous("y", lb=0.0, ub=5.0)
+    z = m.continuous("z", lb=0.0, ub=5.0)
+    m.minimize(x * y * z)
+    assert not has_integer_multilinear_reformulation_work(m)
+    assert reformulate_integer_multilinear(m) is m
+
+
+@pytest.mark.correctness
+def test_reform_generic_integer_trilinear_is_exact_and_sound():
+    """General (non-ex1252) class check: a pure integer trilinear whose continuous
+    McCormick relaxation is loose. The reform is value-preserving and the model
+    solves to the true integer optimum, sound throughout.
+
+    ``max a*b*c`` s.t. ``a+b+c <= 3`` over ``a,b,c in {0,1,2,3}`` has integer
+    optimum ``1`` at ``(1,1,1)`` while the continuous hull reaches ``> 1`` — the
+    gap the exact reform closes."""
+    m = dm.Model("tri")
+    a = m.integer("a", lb=0, ub=3)
+    b = m.integer("b", lb=0, ub=3)
+    c = m.integer("c", lb=0, ub=3)
+    m.subject_to(a + b + c <= 3)
+    m.minimize(-(a * b * c))  # maximize a*b*c
+
+    assert has_integer_multilinear_reformulation_work(m)
+    r = reformulate_integer_multilinear(m)
+    assert r is not m
+
+    # Value-preserving on the product over the integer box.
+    o_off, _ = _flat_offsets(m)
+    r_off, _ = _flat_offsets(r)
+    for av in range(4):
+        for bv in range(4):
+            for cv in range(4):
+                x = np.array([av, bv, cv], dtype=float)
+                xf = extend_initial_point(r, x)
+                assert xf is not None
+                assert abs(_eval(m._objective.expression, x, o_off)
+                           - _eval(r._objective.expression, xf, r_off)) < 1e-9
+
+    os.environ["DISCOPT_INTEGER_MULTILINEAR_REFORM"] = "1"
+    try:
+        res = m.solve(time_limit=30)
+    finally:
+        os.environ.pop("DISCOPT_INTEGER_MULTILINEAR_REFORM", None)
+    assert res.objective is not None
+    assert res.objective >= -1.0 - 1e-4, f"incumbent {res.objective} below true optimum -1"
+    if res.bound is not None and math.isfinite(res.bound):
+        assert res.bound <= -1.0 + 1e-4, f"UNSOUND bound {res.bound} above true optimum -1"
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+def test_ex1252_multilinear_reform_sound_and_lifts_bound():
+    """End-to-end on ex1252: with the flag on, the dual bound is sound (<= the true
+    optimum) and lifts well past the structural 5134 floor that the term-wise
+    trilinear McCormick envelope plateaus at. Certification of the full instance
+    additionally needs the residual continuous-cubic barrier to close (spatial
+    branching); here we lock soundness + the bound lift, which is the #707 gain."""
+    os.environ["DISCOPT_INTEGER_MULTILINEAR_REFORM"] = "1"
+    try:
+        m = dm.from_nl(str(_DATA / "ex1252.nl"))
+        res = m.solve(time_limit=60)
+    finally:
+        os.environ.pop("DISCOPT_INTEGER_MULTILINEAR_REFORM", None)
+    assert res.bound is not None and math.isfinite(res.bound)
+    # Sound: a valid dual bound never exceeds the true optimum.
+    assert res.bound <= _EX1252_OPT + 1e-2, (
+        f"ex1252 multilinear-reform UNSOUND dual bound {res.bound} > optimum {_EX1252_OPT}"
+    )
+    # Any incumbent found is feasible (>= optimum for this minimize).
+    if res.objective is not None and math.isfinite(res.objective):
+        assert res.objective >= _EX1252_OPT - 1e-2
+    # The tightening: the bound clears the 5134 floor the term-wise envelope stalls at.
+    assert res.bound > 5134.5, (
+        f"ex1252 multilinear-reform bound {res.bound} did not lift past the 5134 floor"
+    )

--- a/python/tests/test_integer_multilinear_reform.py
+++ b/python/tests/test_integer_multilinear_reform.py
@@ -56,8 +56,13 @@ def _eval(expr, x, off):
         return float(x[off[v._index] + (idx if isinstance(idx, int) else 0)])
     if isinstance(expr, UnaryOp):
         a = _eval(expr.operand, x, off)
-        return {"neg": lambda z: -z, "exp": math.exp, "log": math.log,
-                "sqrt": math.sqrt, "abs": abs}[expr.op](a)
+        return {
+            "neg": lambda z: -z,
+            "exp": math.exp,
+            "log": math.log,
+            "sqrt": math.sqrt,
+            "abs": abs,
+        }[expr.op](a)
     if isinstance(expr, BinaryOp):
         a, b = _eval(expr.left, x, off), _eval(expr.right, x, off)
         if expr.op == "+":
@@ -69,7 +74,7 @@ def _eval(expr, x, off):
         if expr.op == "/":
             return a / b if b else math.inf
         if expr.op == "**":
-            return a ** b
+            return a**b
         raise ValueError(f"unhandled op {expr.op}")
     raise TypeError(type(expr))
 
@@ -163,8 +168,13 @@ def test_reform_generic_integer_trilinear_is_exact_and_sound():
                 x = np.array([av, bv, cv], dtype=float)
                 xf = extend_initial_point(r, x)
                 assert xf is not None
-                assert abs(_eval(m._objective.expression, x, o_off)
-                           - _eval(r._objective.expression, xf, r_off)) < 1e-9
+                assert (
+                    abs(
+                        _eval(m._objective.expression, x, o_off)
+                        - _eval(r._objective.expression, xf, r_off)
+                    )
+                    < 1e-9
+                )
 
     os.environ["DISCOPT_INTEGER_MULTILINEAR_REFORM"] = "1"
     try:


### PR DESCRIPTION
Closes #707. Follow-up: #721.

## What

Generalizes the integer-**bilinear** exact reformulation to products of ≥3 variable factors where every factor but at most one is integer/binary-valued (declared or implied) — e.g. ex1252's objective `(6329.03 + 1800·x15)·x0·x3·x18` with integer flow factors `x0,x3 ∈ {0..3}` and a 0/1 indicator `x18`.

Each integer factor is binary-expanded (`x = lo + Σ 2ᵏ eₖ`), the product distributed into binary monomials (`e² = e`), and each monomial lifted to its **exact** hull:
- an **n-ary AND** (`z ≤ eᵢ`, `z ≥ Σ eᵢ − (n−1)`, `z` binary) for the pure-integer part, plus
- one **big-M product** for the lone continuous factor.

This replaces the loose term-wise trilinear McCormick envelope over the continuous box with the **per-integer-level exact envelope**. The rewrite is a value-preserving algebraic identity, so it can only tighten — never invalidate — the dual bound.

Gated by `DISCOPT_INTEGER_MULTILINEAR_REFORM`, **default-off** (bound-changing → CLAUDE.md §5, pending a corpus-wide differential-panel graduation). The default (flag-off) path is **byte-identical**: the bilinear reform and its blowup guard are untouched, and the new aux-sharing cache is scoped to the multilinear path.

## Why it's safe on the spatial path

Unlike the bilinear pass (adopted only when it yields a pure MILP), this pass is kept on the spatial B&B path when residual *continuous* nonlinearity remains — but only when the reformed column count stays within a modest factor of the original (blowup guard). A bloated reform on an already-tractable instance is left on its original path, so the flag never regresses.

## Evidence

- **Soundness**: value-preservation is an exact algebraic identity (max abs err ~1e-9 over sampled points; unit-tested).
- **ex1252**: lifts the global dual bound off its structural **5134** floor (the plateau the term-wise envelope and SOS1-selector branching both stall at) toward the optimum.
- **General class**: the structure is present in **8 of the 81** in-repo MINLPLib instances (ex1252/ex1252a, nvs01/05/16/22, st_e36/e40).
- **Differential panel** (flag off vs on, all 8): **cert-clean** (every bound ≤ its reference optimum, every incumbent feasible) and **net non-negative** (large gain on ex1252/ex1252a, neutral elsewhere — the blowup guard prevents the initial nvs01/nvs22 regressions).

## Scope note (why #707 closes but ex1252 doesn't fully certify)

This resolves the barrier #707 **diagnosed** — the trilinear objective envelope. Full end-to-end certification of ex1252 requires closing a **separate** residual barrier — the continuous cubic cost rows `x15 = f(x6, x12)`. An entry experiment (recorded in `docs/dev/performance-plan.md` §6; reproduced by `discopt_benchmarks/scripts/ex1252_cutoff_obbt_falsification.py`) **falsifies** cutoff-driven range reduction as the lever and shows the bottleneck is continuous-cubic relaxation strength — a SOTA-frontier gap (SCIP itself does not certify ex1252 in 120s). That is tracked in **#721**.

## Tests run

- `pytest python/tests/test_integer_multilinear_reform.py -m correctness` — 5 fast + 2 slow pass (value-preservation, term-elimination, generic integer-trilinear class check, no-op / un-extendable-seed guards, ex1252 sound+lift, nvs01 no-regression).
- `pytest python/tests/test_integer_bilinear.py` — 16 pass (default path byte-identical).
- `pytest python/tests/test_bucket2_sound_bounds.py -m correctness` — pass (existing ex1252 soundness locks).
- `pytest -m smoke` — 664 passed, 0 failed (no default-path regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTJJxPj4W33LV8LdRyrhsV)_