### PR TITLE
perf(#723): cache reconstructed relaxation/derivative jit functions (kill identical-shape recompiles)

### DIFF
--- a/python/discopt/_jax/nlp_evaluator.py
+++ b/python/discopt/_jax/nlp_evaluator.py
@@ -170,6 +170,21 @@ def evaluator_fingerprint(model: Model) -> tuple:
     )
 
 
+# Number of distinct-fingerprint evaluators kept per model. A single slot was
+# enough for the plain B&B loop (one structural fingerprint for the whole solve),
+# but the primal heuristics *temporarily* add a structural row (the RENS /
+# local-branching sub-solves append a Hamming-distance / restriction constraint,
+# solve, then remove it) and then re-solve the *base* model. That oscillation —
+# base → base+cut → base → base+cut' → … — thrashes a one-slot cache: every return
+# to the base model evicts and rebuilds the base evaluator (measured on
+# clay0303hfsg: the base evaluator rebuilt 3× per solve, #723). A small LRU keyed
+# on :func:`evaluator_fingerprint` keeps the base entry resident across the
+# interleaved sub-solve fingerprints so it is built once, while each genuinely
+# different sub-solve model still gets its own (correct) evaluator. Bounded so a
+# long run of ever-distinct sub-solve cuts cannot grow the cache without limit.
+_EVALUATOR_CACHE_MAXSIZE = 8
+
+
 def cached_evaluator(model: Model) -> "NLPEvaluator":
     """Return a per-model cached ``NLPEvaluator``, reusing its compiled JAX
     callables across repeated constructions as long as the model's *structure* is
@@ -184,15 +199,31 @@ def cached_evaluator(model: Model) -> "NLPEvaluator":
     fresh ``NLPEvaluator(model)`` per call (e.g. the diving heuristic, ~110×/solve
     on gear4) re-paid that construction cost on every call. Keyed on
     :func:`evaluator_fingerprint`, so a structurally different model rebuilds.
+
+    The cache holds up to :data:`_EVALUATOR_CACHE_MAXSIZE` distinct-fingerprint
+    evaluators (LRU) rather than a single slot, so a heuristic that temporarily
+    mutates the model's structure (RENS / local-branching adding then removing a
+    cut) does not evict — and force a rebuild of — the base-model evaluator each
+    time the search returns to it (#723). Each fingerprint maps to the identical
+    evaluator the one-slot cache would have built, so this is bound-neutral: it
+    only avoids rebuilding evaluators that were previously discarded.
     """
+    from collections import OrderedDict
+
     fp = evaluator_fingerprint(model)
-    cached = getattr(model, "_nlp_evaluator_cache", None)
-    if cached is not None:
-        ev, cached_fp = cached
-        if cached_fp == fp:
-            return ev
+    cache: "OrderedDict[tuple, NLPEvaluator] | None" = getattr(model, "_nlp_evaluator_cache", None)
+    if cache is None:
+        cache = OrderedDict()
+        model._nlp_evaluator_cache = cache  # type: ignore[attr-defined]
+    ev = cache.get(fp)
+    if ev is not None:
+        cache.move_to_end(fp)  # mark most-recently-used
+        return ev
     ev = NLPEvaluator(model, gauss_newton=bool(getattr(model, "_gauss_newton_hessian", False)))
-    model._nlp_evaluator_cache = (ev, fp)  # type: ignore[attr-defined]
+    cache[fp] = ev
+    cache.move_to_end(fp)
+    while len(cache) > _EVALUATOR_CACHE_MAXSIZE:
+        cache.popitem(last=False)  # evict least-recently-used
     return ev
 
 

--- a/python/tests/test_cached_evaluator.py
+++ b/python/tests/test_cached_evaluator.py
@@ -68,3 +68,44 @@ def test_make_evaluator_shares_the_cache():
     ev_main = S._make_evaluator(m)
     ev_heur = cached_evaluator(m)
     assert ev_main is ev_heur, "_make_evaluator and cached_evaluator must share one cache"
+
+
+def test_lru_keeps_base_evaluator_across_transient_row():
+    """#723: a heuristic that *temporarily* appends a structural row (the RENS /
+    local-branching sub-solve adds a Hamming/restriction cut, solves, then removes
+    it) must not evict the base-model evaluator.
+
+    With the previous one-slot cache the return to the base structure rebuilt the
+    base evaluator every time — measured on clay0303hfsg as 3 wasted base rebuilds
+    / ~8 redundant XLA compiles per solve. The LRU must return the *same* base
+    object after the interleaved variant.
+    """
+    m = _model()
+    ev_base = cached_evaluator(m)
+    fp_base = evaluator_fingerprint(m)
+
+    # Sub-solve appends a transient structural row -> new fingerprint, new evaluator.
+    m._constraints.append(m._variables[0] >= 0.5)
+    assert evaluator_fingerprint(m) != fp_base
+    ev_variant = cached_evaluator(m)
+    assert ev_variant is not ev_base
+
+    # Sub-solve finishes and restores the base structure.
+    m._constraints.pop()
+    assert evaluator_fingerprint(m) == fp_base
+    ev_base_again = cached_evaluator(m)
+    assert ev_base_again is ev_base, "base evaluator must survive interleaved variant (no rebuild)"
+
+
+def test_cache_is_bounded_by_maxsize():
+    """The LRU must not grow without bound when a solve emits an unbounded stream
+    of ever-distinct transient sub-solve cuts."""
+    from discopt._jax.nlp_evaluator import _EVALUATOR_CACHE_MAXSIZE
+
+    m = _model()
+    cached_evaluator(m)  # base entry
+    for k in range(_EVALUATOR_CACHE_MAXSIZE + 5):
+        m._constraints.append(m._variables[0] >= 0.1 * (k + 1))
+        cached_evaluator(m)  # distinct fingerprint each iteration
+        m._constraints.pop()
+    assert len(m._nlp_evaluator_cache) <= _EVALUATOR_CACHE_MAXSIZE


### PR DESCRIPTION
## Summary

Fixes a single-slot evaluator-cache **thrash** that forced redundant reconstruction
(and identical-shape XLA recompilation) of the expensive relaxation/derivative
`jit` functions (`_fused_fc`, `fn`, `batch_jvp`, `batch_hvp`, `concat_constraints`)
on solves that run RENS / local-branching sub-solves.

`cached_evaluator(model)` kept **one** evaluator slot keyed on the model's
structural fingerprint. The primal heuristics *temporarily* append a structural
row (RENS / local-branching add a Hamming-distance / restriction cut, solve the
sub-MINLP, then remove it) and then the search returns to the base model. That
oscillation — `base -> base+cut -> base -> base+cut' -> ...` — evicts and
**rebuilds the base-model evaluator every time** the search comes back to it. Each
rebuild re-traces the DAG and re-emits the (identical-shape) `jit` functions.

The fix replaces the one-slot cache with a small **LRU keyed on the structural
fingerprint** (`_EVALUATOR_CACHE_MAXSIZE = 8`), so the base entry stays resident
across the interleaved sub-solve fingerprints and is built **once**, while each
genuinely-different sub-solve model still gets its own (correct) evaluator. The
cache is bounded so an unbounded stream of distinct sub-solve cuts cannot grow it.

## Measured entry experiment (the reconstruction is real, and it is cache thrash)

Instrumenting `NLPEvaluator` construction + `cached_evaluator` hit/miss on
**clay0303hfsg** (TL=60): **one** model object, but the fingerprint oscillates
between the base model (150 constraints) and transient 151-constraint variants
(the extra row is a local-branching Hamming cut, `Sum[21 terms] - 2 <= 0`, a fresh
object each incumbent). The single-slot cache misses on every return to the base
model, so the **base evaluator is rebuilt 3x per solve** (6 evaluator builds total).

## Measured effect (clay0303hfsg, TL=60, back-to-back A/B same machine)

| metric | origin/main | this PR |
|---|---|---|
| node_count | 443 | **443** (identical) |
| objective | 26669.10955143198 | **26669.10955143198** (identical) |
| evaluator builds | 6 | **4** |
| XLA compiles | 30 | **22** |

**Honest magnitude.** The task's older estimate (~15 s / ~21 identical-shape
compiles ~ ~21 s of wall, assuming ~1 s CC5 compiles) does **not** hold in current
`main`: on clay the 30 compiles total **0.78 s** (~0.026 s each -- these are
*cheap* compiles, not the ~1 s relaxation compiles), and total evaluator
construction is **0.66 s**, of which the savable base rebuilds are **~0.5 s**.
Prior work (#724 + the existing fingerprint cache, and the collapse of the old
gear4 5921-node CC1 case -- gear4 now solves in 0.66 s / 3 nodes) already removed
the large cost. So this is a **small, provably bound-neutral compile-count
reduction** (~8 fewer XLA compiles + 2 fewer evaluator builds on clay), **neutral
everywhere else** (the plain B&B loop has a single fingerprint -> single build,
unchanged). It is the safe win the task asked for, not a 15 s win.

## Bound-neutrality (CLAUDE.md section 5, bound-neutral regime)

The LRU returns, for any fingerprint, the **identical** evaluator the one-slot
cache would have built for that fingerprint; it only avoids rebuilding evaluators
that were previously discarded. The evaluator is stateless in the evaluation point
and reads bounds/parameters live (the property the existing cache already relies
on), so reuse across bound changes and sub-solve re-entry is exact.

Verified by a back-to-back A/B (origin/main vs this PR, same machine):
`node_count` **and** certified `objective` are **bitwise-identical** on the slow
panel (clay0303hfsg, nvs05, fac2, ex1224, st_e29, st_e36) and on a broader
25-instance certifying subset (st_miqp1-5, bchoco06/07, nvs01/03/06/11/12/13,
ex1221/1222/1224, st_e11/e29/e36, gbd, alan, flay02m, syn05hfsg, tls2).

## Tests

- New regression tests in `python/tests/test_cached_evaluator.py`:
  `test_lru_keeps_base_evaluator_across_transient_row` (fails on `main` -- the base
  evaluator is a *different object* after an interleaved transient row) and
  `test_cache_is_bounded_by_maxsize`.
- `pytest -m smoke` -- 666 passed, 1 skipped.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` -- 10 passed.
- `ruff check` / `ruff format --check` clean on the changed files; `mypy` introduces
  no new errors (the pre-existing numpy-stub toolchain error is identical on `main`).
- No Rust touched (pure-Python one-file change), so `cargo test` not required.

Generated with [Claude Code](https://claude.com/claude-code)
