### PR TITLE
feat(#721): objective-coupling RLT (default-OFF) + falsify the piecewise-McCormick lever

### DIFF
--- a/discopt_benchmarks/scripts/ex1252_compounding_probe.py
+++ b/discopt_benchmarks/scripts/ex1252_compounding_probe.py
@@ -75,7 +75,7 @@ for var, name, K in [(12, "x12", 2), (12, "x12", 4), (12, "x12", 8), (6, "x6", 4
         kids.append(b)
     finite = [b for b in kids if isinstance(b, float)]
     mn = min(finite) if finite else None
-    shown = ["%.0f" % b if isinstance(b, float) else b for b in kids]
+    shown = [f"{b:.0f}" if isinstance(b, float) else b for b in kids]
     print(f"[A] subdivide {name} into {K}: proved bound = {mn}   children={shown}")
 
 # B: cutoff-driven OBBT at the deep node — inert pre-RLT; does it bite now?

--- a/discopt_benchmarks/scripts/ex1252_compounding_probe.py
+++ b/discopt_benchmarks/scripts/ex1252_compounding_probe.py
@@ -1,0 +1,105 @@
+"""Compounding probe for the ex1252 certification plan (issue #721 follow-up).
+
+With the objective-coupling RLT ON (``DISCOPT_MULTILINEAR_COUPLING_RLT``), do the
+previously-inert levers (flow subdivision, cutoff-OBBT) now bite at the config
+node? Mechanism under test: with the RLT, the node bound = 12658.06 +
+~3600*min(x15), so anything that lifts the cubic block's floor on x15
+(subdivision, OBBT range reduction) now moves the BOUND — whereas before the RLT
+x15 was decoupled and both levers were measured fully inert
+(``ex1252_cutoff_obbt_falsification.py``, ``ex1252_piecewise_lever_probe.py``).
+Certification at this node needs min x15: 12.44 -> 32.28.
+
+Measured result (2026-07-18, recorded in docs/dev/ex1252-certification-plan.md):
+  * x6 subdivision now lifts a child bound 57435 -> 62071 (+8%; pre-RLT provably 0)
+  * OBBT now pins x12 to exactly 175.0 and caps x15 at 30.89 within seconds
+    (pre-RLT: no movement at all)
+  * engine fragility exposed: narrow/pinned child boxes can return 0.0 /
+    (numerical) / (error) fallback bounds — sound but weak, and they destroy the
+    proved min-child bound exactly at the nodes certification needs (Stage 1 of
+    the plan).
+
+Run: ``python -m discopt_benchmarks.scripts.ex1252_compounding_probe``
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ["DISCOPT_MULTILINEAR_COUPLING_RLT"] = "1"
+
+import discopt.modeling as dm
+import numpy as np
+from discopt._jax.integer_product_reform import reformulate_integer_multilinear
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.obbt import obbt_tighten_root
+
+OPT = 128893.74
+LINE1 = {18: 1, 36: 1, 21: 1, 19: 0, 20: 0, 37: 0, 38: 0, 22: 0, 23: 0}
+
+r = reformulate_integer_multilinear(dm.from_nl("python/tests/data/minlplib/ex1252.nl"))
+lb, ub = flat_variable_bounds(r)
+lb = np.asarray(lb, float).copy()
+ub = np.asarray(ub, float).copy()
+for i, v in LINE1.items():
+    lb[i] = ub[i] = float(v)
+nc = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3)
+lb, ub = nc.lb.copy(), nc.ub.copy()
+lb[0] = ub[0] = 2.0
+lb[24] = ub[24] = 0.0
+lb[25] = ub[25] = 1.0
+lb[3] = ub[3] = 1.0
+lb[30] = ub[30] = 1.0
+lb[31] = ub[31] = 0.0
+
+relaxer = MccormickLPRelaxer(r)
+
+
+def bd(lo, hi):
+    res = relaxer.solve_at_node(lo.copy(), hi.copy())
+    return res.lower_bound if res.status == "optimal" else f"({res.status})"
+
+
+base = bd(lb, ub)
+print(f"[A0] deep node, RLT ON, baseline bound          : {base}")
+print(f"     (cert at this node needs 12658 + 3600*32.28 = {12658.06 + 3600 * 32.28:.0f})")
+
+# A: subdivision of the flows — min over children = proved bound after branching.
+for var, name, K in [(12, "x12", 2), (12, "x12", 4), (12, "x12", 8), (6, "x6", 4)]:
+    edges = np.linspace(float(lb[var]), float(ub[var]), K + 1)
+    kids = []
+    for i in range(K):
+        lo, hi = lb.copy(), ub.copy()
+        lo[var], hi[var] = edges[i], edges[i + 1]
+        b = bd(lo, hi)
+        kids.append(b)
+    finite = [b for b in kids if isinstance(b, float)]
+    mn = min(finite) if finite else None
+    shown = ["%.0f" % b if isinstance(b, float) else b for b in kids]
+    print(f"[A] subdivide {name} into {K}: proved bound = {mn}   children={shown}")
+
+# B: cutoff-driven OBBT at the deep node — inert pre-RLT; does it bite now?
+for cutoff, tag in [(None, "no-cutoff"), (OPT, "cutoff=opt")]:
+    res = obbt_tighten_root(
+        r, lb.copy(), ub.copy(), rounds=8, time_limit_per_lp=0.3, incumbent_cutoff=cutoff
+    )
+    b2 = bd(res.lb, res.ub)
+    print(
+        f"[B] OBBT({tag:10s}): x6[{res.lb[6]:.0f},{res.ub[6]:.0f}] "
+        f"x12[{res.lb[12]:.1f},{res.ub[12]:.1f}] x15[{res.lb[15]:.2f},{res.ub[15]:.2f}] "
+        f"-> bound {b2}"
+    )
+
+# B2: compounding loop — OBBT(cutoff) then subdivide x12 on the tightened box.
+res = obbt_tighten_root(
+    r, lb.copy(), ub.copy(), rounds=8, time_limit_per_lp=0.3, incumbent_cutoff=OPT
+)
+l2, u2 = res.lb.copy(), res.ub.copy()
+edges = np.linspace(float(l2[12]), float(u2[12]), 5)
+kids = []
+for i in range(4):
+    lo, hi = l2.copy(), u2.copy()
+    lo[12], hi[12] = edges[i], edges[i + 1]
+    kids.append(bd(lo, hi))
+finite = [b for b in kids if isinstance(b, float)]
+print(f"[B2] OBBT(cutoff) + subdivide x12 into 4: proved bound = {min(finite) if finite else None}")

--- a/discopt_benchmarks/scripts/ex1252_piecewise_lever_probe.py
+++ b/discopt_benchmarks/scripts/ex1252_piecewise_lever_probe.py
@@ -1,0 +1,138 @@
+"""Entry experiment for issue #721 direction #1 (post-#707) — the piecewise/
+partition lever probe on ex1252's wide-range cubic/monomial cost block.
+
+#721 proposes, as its most localized direction, auto-triggering piecewise/
+partitioned McCormick on ex1252's wide-range flow factors (`x6,x7,x8 ∈ [0,2950]`;
+the `w = x6**2` lift secant spans `w ∈ [0, 8.7M]`), asserting the `x6**2` secant is
+"the weakest single link" that "feeds every downstream term". This probe measures,
+on the actual per-node engine the spatial solver uses (`MccormickLPRelaxer`) and
+with #707's flow-aware integer-multilinear reform applied
+(`reformulate_integer_multilinear`, the shipped `DISCOPT_INTEGER_MULTILINEAR_REFORM`
+path), whether partitioning/strengthening actually moves ex1252's dual bound.
+
+RESULT (recorded in `docs/dev/performance-plan.md` §6): at the canonical loosest
+node the bound is pinned at **12658.06** across *every* available lever —
+subdividing `x6`, subdividing `x12`, RLT cuts, level-1 RLT, PSD cuts, superposition,
+and OBBT+cutoff. Two corrections to the issue's framing fall out:
+
+1. **`x6` is not the lever, and neither is any flow.** At the *root* the flows are
+   wide but the objective relaxes to 0 (indicators free); at any *binding* node
+   OBBT has already narrowed `x6 → [1823,2950]` and `x12 → [116.7,175]`, so
+   partitioning those narrow ranges is inert. "Wide-range" and "binding" never
+   coincide, so direction #1 (piecewise on wide monomial factors) is inert on the
+   real path. (A transient +27% signal from partitioning `x12` on the AMP MILP
+   engine was a node-definition artifact — it appears only at a *looser* box where
+   the MILP is free to re-choose the active line, and vanishes on the canonical box,
+   where the AMP build is infeasible. It does not reflect a cubic-block tightening.)
+
+2. **The wall is the objective coupling, not the cubic rows.** The bound equals the
+   objective's constant term `6329.03·x0·x3·x18 = 6329.03·2 = 12658.06` exactly: the
+   reformed `x15·(x0·x3·x18)` aux relaxes to its lower bound at this node, so the
+   `1800·x15` cost contribution is 0 in the relaxation *regardless of x15*. The cubic
+   cost rows the issue targets only *define* `x15`; tightening them cannot raise the
+   bound while `x15`'s coupling into the objective is itself loose in-relaxation.
+   The lever, if any, is a tighter joint relaxation of that coupling (a distinct,
+   higher-risk direction — catalog §7's joint edge-concave/αBB open item), not the
+   piecewise-McCormick of direction #1.
+
+Run: ``python -m discopt_benchmarks.scripts.ex1252_piecewise_lever_probe``
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ.setdefault("DISCOPT_INCREMENTAL_MC", "0")
+
+import discopt.modeling as dm
+import numpy as np
+from discopt._jax.integer_product_reform import reformulate_integer_multilinear
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.obbt import obbt_tighten_root
+
+OPT = 128893.74
+# line-1 selected, lines 2&3 off (indicators, selectors, matching binaries).
+LINE1 = {18: 1, 36: 1, 21: 1, 19: 0, 20: 0, 37: 0, 38: 0, 22: 0, 23: 0}
+
+
+def _nl_path() -> Path:
+    here = Path(__file__).resolve()
+    for base in here.parents:
+        cand = base / "python" / "tests" / "data" / "minlplib" / "ex1252.nl"
+        if cand.exists():
+            return cand
+    raise FileNotFoundError("ex1252.nl not found under any parent's python/tests/data/minlplib")
+
+
+def _loosest_node(r):
+    """Canonical loosest node: LINE1 fixed, OBBT-tightened, x0=2, x3=1 (bits set)."""
+    lb, ub = flat_variable_bounds(r)
+    lb = np.asarray(lb, float).copy()
+    ub = np.asarray(ub, float).copy()
+    for i, v in LINE1.items():
+        lb[i] = ub[i] = float(v)
+    nc = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3)
+    lb, ub = nc.lb.copy(), nc.ub.copy()
+    lb[0] = ub[0] = 2.0
+    lb[24] = ub[24] = 0.0
+    lb[25] = ub[25] = 1.0  # x0 = 2
+    lb[3] = ub[3] = 1.0
+    lb[30] = ub[30] = 1.0
+    lb[31] = ub[31] = 0.0  # x3 = 1
+    return lb, ub
+
+
+def _bound(r, lb, ub, **kw):
+    try:
+        res = MccormickLPRelaxer(r, **kw).solve_at_node(lb.copy(), ub.copy())
+        return res.lower_bound if res.status == "optimal" else f"({res.status})"
+    except Exception as exc:  # noqa: BLE001
+        return f"ERR {type(exc).__name__}"
+
+
+def run() -> None:
+    r = reformulate_integer_multilinear(dm.from_nl(str(_nl_path())))
+    lb, ub = _loosest_node(r)
+    print(
+        f"reformed ex1252, loosest node: x6 [{lb[6]:.0f},{ub[6]:.0f}]  "
+        f"x12 [{lb[12]:.1f},{ub[12]:.1f}]"
+    )
+    print(f"(#707 reform applied; true optimum {OPT})\n")
+    print(
+        "  Flow subdivision is inert on this engine — see the #707 probe\n"
+        "  (ex1252_cutoff_obbt_falsification.py): x12 halves both hold at 12658.1.\n"
+        "  Direction #1's premise fails because at the root the flows are wide but the\n"
+        "  objective relaxes to 0, and at any binding node OBBT has already narrowed\n"
+        "  x6 -> [1823,2950] / x12 -> [116.7,175]; 'wide-range' and 'binding' never\n"
+        "  coincide. The available in-box strengtheners are equally inert:\n"
+    )
+
+    base = _bound(r, lb, ub)
+    print(f"  baseline (std McCormick)   : {base}")
+    print(f"  rlt_cuts=True              : {_bound(r, lb, ub, rlt_cuts=True)}")
+    print(f"  rlt_level1=True            : {_bound(r, lb, ub, rlt_level1=True)}")
+    print(f"  psd_cuts=True              : {_bound(r, lb, ub, psd_cuts=True)}")
+    print(f"  superposition=True         : {_bound(r, lb, ub, superposition=True)}")
+
+    # Root cause: the objective's x15 coupling relaxes to its lower bound, so the
+    # bound is exactly the constant term regardless of the (nonzero) relaxed x15.
+    res = MccormickLPRelaxer(r).solve_at_node(lb.copy(), ub.copy())
+    x15 = float(res.x[15])
+    const = 6329.03 * 2.0
+    print(
+        f"\n  bound == 6329.03·x0·x3·x18 == 6329.03·2 == {const:.2f} exactly,\n"
+        f"  yet the relaxation's x15 = {x15:.2f} ≠ 0: the reformed x15·(x0·x3·x18) aux\n"
+        "  relaxes to its lower bound, so the 1800·x15 cost contributes 0 to the bound.\n"
+        "  Tightening the cubic rows that DEFINE x15 cannot lift the bound while x15's\n"
+        "  objective coupling is itself loose in-relaxation. Direction #1 is inert;\n"
+        "  the lever is a tighter joint coupling relaxation (catalog §7 open item).\n"
+        "  Full record: docs/dev/performance-plan.md §6 (2026-07-18)."
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/docs/dev/ex1252-certification-plan.md
+++ b/docs/dev/ex1252-certification-plan.md
@@ -1,0 +1,185 @@
+# Certifying ex1252 and the gated-configuration MINLP class — anatomy & staged plan
+
+> Status: proposed 2026-07-18, grounded in the #707/#721 measurement chain
+> (`docs/dev/performance-plan.md` §6, four falsification/implementation records) and
+> the compounding probe run the same day
+> (`discopt_benchmarks/scripts/ex1252_compounding_probe.py`). Successor to the #721
+> re-scope; every stage below carries an entry experiment and a kill criterion per
+> CLAUDE.md Dev-Philosophy #4. Correctness gates (`incorrect_count = 0`, bound ≤
+> incumbent) bind on every stage — a stage that can only pass by weakening them is
+> dead on arrival.
+
+## 0. Verdict up front
+
+ex1252 is not blocked by one wall but by a **stack of five**, and the top three are
+now measured, understood, and (as of PR #726) the load-bearing one is removed. The
+remaining distance to certification is **search orchestration + engine robustness**,
+not new relaxation mathematics. There is a credible, staged path; each stage is
+individually falsifiable and none requires a research-grade invention. Calibration
+honesty: SCIP 10.0 reaches 0.35% gap on ex1252 in 120 s **and still does not
+certify** — so full certification at default tolerances is a stretch goal; the
+binding target is the #721 gate ("global dual materially above ~48k"), with
+certification the plausible end state if Stages 1–4 land cleanly.
+
+## 1. Why we cannot certify today: the five-layer anatomy (all measured)
+
+ex1252 (Westerlund pump-configuration): choose line configurations (indicators
+`x18–x20`, small integer pump counts `x0–x5 ∈ [0,3]`) so the per-line cubic
+head/flow/power physics (`c0–c5`) meets demand at minimum cost. The objective is
+integer-multilinear: `(6329.03 + 1800·x15)·x0·x3·x18 + …` per line.
+
+| layer | mechanism | measured effect | status |
+|---|---|---|---|
+| **L1** — objective multilinear decoupling | term-wise trilinear McCormick relaxes the whole objective product to ~0 at fractional indicators | dual floor **5134** | **fixed** — #707 exact linearization (`DISCOPT_INTEGER_MULTILINEAR_REFORM`) → ~48k plateau |
+| **L2** — product-aux decoupling | the reform's own expansion bits go fractional in the LP, so every `v_k = z_k·x15` big-M product relaxes to 0; the cost var never enters the bound (`bound = 6329.03·2` exactly, while relaxed `x15 = 12.44 ≠ 0`) | config-node bound stuck at **12658** vs true ≈128894; RLT lifts it to **57435** | **fixed** — PR #726 coupling RLT (`DISCOPT_MULTILINEAR_COUPLING_RLT`, default-OFF) |
+| **L3** — search order | the global dual = min over *open* nodes; shallow indicator-fractional nodes bound at ~13.8–16k and the tree does not prioritize reaching integer-complete config nodes | 4.5× node-level lift → only **+1.4%** global dual at equal 400-node budget | **open — the dominant layer** |
+| **L4** — residual cubic gap at configs | at a config node the bound is `12658 + 3600·min(x15)`; the cubic rows floor `x15` at 12.44 vs the 32.28 certification needs (2.6×) | pre-RLT: provably inert to every lever; **post-RLT: compounding unlocked** (see §2) | **open — now tractable** |
+| **L5** — engine fragility on narrow boxes | OBBT-pinned / subdivided child boxes return `0.0` / `(numerical)` / `(error)` fallback bounds — sound but weak | a single 0.0 child collapses the proved min-child bound at exactly the nodes certification needs | **open — prerequisite** |
+
+The essential geometry: ex1252's discrete configuration space is **tiny** (3
+indicators × pump counts ≤ 4² per line), and each configuration's continuous
+subproblem is a ~4-variable nonconvex block that the now-unlocked machinery
+squeezes hard. Certification = reach the configs fast (L3), bound them tight
+(L4), and never drop a bound to a fallback (L5).
+
+## 2. The compounding measurement (2026-07-18) — the plan's empirical basis
+
+#721 predicted an ordering: *"once the relaxation is strong enough that the
+objective cutoff binds, cutoff-driven OBBT/DBBT and primal heuristics will
+compound — but relaxation strength must come first."* Both halves are now
+measured, on the canonical config node (LINE1, OBBT-tightened, `x0=2, x3=1`):
+
+**Pre-RLT (falsification records, §6 of the performance plan):** flow
+subdivision, piecewise partitioning (LP *and* MILP), RLT/PSD/superposition cuts,
+and OBBT-with-known-optimum-cutoff **all leave the bound at 12658.06 exactly** —
+zero movement, every lever.
+
+**Post-RLT (`ex1252_compounding_probe.py`):**
+
+| lever at the config node (RLT ON, base bound 57435) | result |
+|---|---|
+| subdivide `x12` | children all **infeasible** except one — OBBT has pinned `x12 = 175.0` *exactly* (flow is determined by the config; not a branching dimension) |
+| subdivide `x6` into 4 | live child at **62071** (+8% per split; pre-RLT provably 0%) — the speed axis is the real spatial dimension |
+| OBBT (with or without cutoff) | `x12 → [175, 175]`, `x15 → [12.44, 30.89]` within seconds — pre-RLT it moved nothing |
+| fragility | two children return `0.0`, others `(numerical)`/`(error)` — the fallback floor destroys the proved min-child bound |
+
+The OBBT result is qualitatively new information: capping `x15 ≤ 30.89 < 32.28`
+at this config means the machinery is now generating exactly the kind of
+per-configuration eliminations certification is made of. The compounding is
+real; what remains is plumbing it into the search and not fumbling the bounds
+(L5).
+
+## 3. What SCIP does that we don't (calibration, not aspiration)
+
+SCIP's 128438 (0.35%) at 120 s versus our ~48k plateau is **not** a tighter cubic
+envelope — it is (a) hybrid/reliability branching that immediately identifies the
+indicators and pump-count integers as the high-pseudocost dimensions and drives
+the tree through the config space first, (b) per-node OBBT/propagation that
+squeezes each config box the way §2 shows ours now can, and (c) numerically
+robust node LPs that never hand back a 0.0. That is Stages 1–3 below, exactly.
+SCIP *still* fails to close the last 0.35% in 120 s — which is why certification
+is the stretch goal and "materially above 48k" is the binding gate.
+
+## 4. The staged plan
+
+Stages are ordered by dependency; each has an entry experiment (cheap, before
+implementation) and a kill criterion. All bound-changing pieces stay behind
+default-OFF flags until the CLAUDE.md §5 differential panel passes.
+
+### Stage 0 — objective-coupling RLT *(done — PR #726)*
+The unblocking lever. Default-OFF `DISCOPT_MULTILINEAR_COUPLING_RLT`; OFF path
+byte-identical to #707; sound (RLT of valid identities, `bound ≤ opt` verified);
+pinned by `python/tests/test_ex1252_coupling_rlt.py`.
+
+### Stage 1 — engine hardening on narrow/pinned boxes *(P0 prerequisite)*
+**Problem:** child solves on OBBT-pinned or finely subdivided boxes return
+`0.0`/`(numerical)`/`(error)` fallbacks (§2), collapsing proved bounds.
+**Entry experiment:** a battery of the §2 child boxes; count certified verdicts
+vs fallbacks; bisect the failure (suspects: degenerate `lb==ub` rows after the
+pin, big-M conditioning on narrow `x6` slices, equilibration interaction).
+**Fix shape:** whatever the root cause, the fix must produce a *certified*
+optimal/infeasible verdict on those boxes — never a silent weak floor. This is a
+correctness-adjacent robustness item and benefits every instance, not just this
+class.
+**Kill criterion:** none — a sound engine must handle these boxes; if a specific
+LP is genuinely intractable, the node must inherit the parent bound (sound,
+already ≥ 57435 here) rather than 0.0. *Inheriting the parent bound instead of a
+weaker fallback is itself most of the win.*
+
+### Stage 2 — configuration-first branching (L3, the dominant lever)
+**Hypothesis:** branching indicators → reform expansion bits (`_ipx_e*`) → pump
+counts *before* continuous/spatial dimensions collapses the shallow-node floor,
+because the config space is tiny (≤ 8 indicator patterns × small pump grids) and
+§2 shows config nodes now bound/prune hard.
+**Entry experiment:** instrument the existing 400-node run — what fraction of
+open nodes are integer-complete, and what does the node-depth-vs-bound profile
+look like? Then force integer-first priority (check `DISCOPT_OBJ_BRANCH_PRIORITY`
+semantics first — partial machinery may exist) and re-measure the global dual at
+the same 400-node budget, RLT ON.
+**Kill criterion:** if config-first branching does not at least double the
+400-node global dual (16304 → ≥ 33k), the search hypothesis is wrong for this
+tree and the plan re-scopes to the disjunctive-bound alternative (§5).
+
+### Stage 3 — per-config compounding loop (OBBT + cutoff at integer-complete nodes)
+**Hypothesis:** at integer-complete nodes, a short OBBT loop (now potent, §2)
+with the incumbent cutoff prunes or tightens configs toward their true cost;
+the incumbent exists (RLT ON found 134471 unaided).
+**Entry experiment:** replay the §2 loop across all feasible `(line, x0, x3)`
+configs; table of per-config bounds/infeasibilities; how many survive below the
+incumbent?
+**Kill criterion:** if the per-config loop leaves > half the config space both
+feasible and > 20% below incumbent, the cubic gap (Stage 4) is bigger than the
+search gap and Stage 4 is promoted above Stage 2 in effort.
+
+### Stage 4 — cubic-block tightening at configs (L4; #721's original directions, now unblocked)
+In increasing effort, measured at the OBBT-tightened config box:
+1. **Spatial branching on `x6`** — already works (+8%/split measured); Stage 2's
+   priority order just needs to reach it after the integers.
+2. **Piecewise-McCormick auto-trigger gated on integer-complete nodes** — #721's
+   direction #1, provably inert pre-RLT, now expected to bite; entry experiment:
+   k = 4/8 partitions on `x6` at the config box, measure the `min x15` lift.
+3. **Edge-concave / αBB envelope for the cubic rows** (catalog §7's open item) —
+   one-shot tighter envelope of `x15 = a·x6³ + b·x6²·x12 + c·x12²·x6` over the
+   config box; highest effort, only if 1–2 stall.
+**Kill criterion per option:** < 10% `min x15` lift at the config box → drop that
+option (recorded, not retried).
+
+### Stage 5 — graduation (CLAUDE.md §5)
+Class detector: `has_integer_multilinear_reformulation_work(model)` (the #707
+trigger) — i.e. the gated-configuration class, *not* an ex1252 special case.
+Panel: corpus differential run, flag ON vs OFF — cert-clean (`incorrect_count =
+0`, no bound above reference, incumbents feasibility-verified) AND net-positive
+(node count / wall / bound). ex1252a rides along as the sibling instance. The
+coupling RLT + config-first branching + per-config OBBT graduate together or
+stay default-OFF with the measurement recorded.
+
+### Alternative route (recorded, not primary): disjunctive/hull bound
+Because the config space is tiny, a root-level **disjunctive bound** — enumerate
+indicator patterns, bound each with the §2 machinery, take the min — would
+short-circuit L3 entirely; the GDP hull/perspective machinery
+(`gdp_reformulate.py`, the AMP convhull formulations) is the principled version
+(perspective-tighten the gated cost rows). Higher integration cost; becomes the
+primary route only if Stage 2's kill criterion fires.
+
+## 5. Generality — "and similar problems"
+
+The class this plan serves (and the detector gates on): **small discrete
+configuration space gating nonconvex continuous unit models, coupled to cost
+through integer×continuous products.** ex1252/ex1252a are the named probes;
+pump/compressor/network-synthesis instances in MINLPLib share the shape, and the
+#707 trigger already recognizes it structurally. Per Dev-Philosophy #2, every
+stage keys on the structure (integer-multilinear work + gated blocks), never on
+an instance name; the graduation panel is corpus-wide.
+
+## 6. Honest end-state assessment
+
+- **High confidence:** Stages 1–3 lift the global dual well past the 48k plateau
+  (the per-config machinery demonstrably prunes/tightens; the config space is
+  enumerable).
+- **Medium confidence:** Stage 4 closes config gaps far enough that the cutoff
+  prunes all non-optimal configs — the shape of certification.
+- **Known residual risk:** the optimal config's own gap must close to tolerance;
+  SCIP's 0.35%-and-stuck shows this tail is where the hard part lives. If the
+  tail resists Stage 4, the recorded fallback is the αBB/edge-concave envelope
+  (Stage 4.3) and, beyond it, honesty: record the frontier, as #673/#677 did for
+  the autocorr class.

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -553,6 +553,52 @@ panel green for 3 consecutive nightlies before default-on.
 > the cutoff bind. Reproduction:
 > `discopt_benchmarks/scripts/ex1252_cutoff_obbt_falsification.py`.
 
+> **Falsified (2026-07-18, issue #721 — "piecewise-McCormick auto-trigger on
+> wide-range cubic/monomial blocks certifies ex1252").** #707's re-scope (record
+> above) pointed at a stronger cubic-block relaxation, with #721's most localized
+> direction being auto-triggered piecewise McCormick on the wide flow factors
+> (`x6,x7,x8 ∈ [0,2950]`), asserting the `x6²` secant is "the weakest single link".
+> The entry experiment measured the reformed-ex1252 dual bound (with #707's reform
+> applied) on the *actual* per-node engine (`MccormickLPRelaxer`) at the canonical
+> loosest node (LINE1 fixed, OBBT-tightened, `x0=2, x3=1`). **The bound is pinned at
+> `12658.06` across every available lever:**
+>
+> | lever at the loosest node | dual bound |
+> |---|---|
+> | baseline (standard McCormick) | 12658.06 |
+> | subdivide `x6` / subdivide `x12` (halves) | 12658.06 (from the #707 probe: 12658.1 both) |
+> | RLT cuts / level-1 RLT | 12658.06 |
+> | PSD (moment) cuts | 12658.06 |
+> | superposition cuts | 12658.06 |
+> | OBBT + optimum cutoff | 12658 (the #707 record) |
+>
+> Two corrections to the issue's framing fall out. **(1) `x6` is not the lever, and
+> neither is any flow.** At the *root* the flows are wide but the objective relaxes
+> to 0 (indicators free); at any *binding* node OBBT has already narrowed
+> `x6 → [1823,2950]` and `x12 → [116.7,175]`, so partitioning those narrow ranges is
+> inert. "Wide-range" and "binding" never coincide, so direction #1 (piecewise on
+> wide monomial factors) cannot bite on the real path. (A transient +27% signal from
+> partitioning `x12` on the *AMP MILP* engine — `build_milp_relaxation`, SOS2
+> partition binaries — proved to be a node-definition artifact: it appears only at a
+> *looser* box where the MILP is free to re-choose the active line, and vanishes on
+> the canonical box, where the AMP build is infeasible. It is not a cubic-block
+> tightening.) **(2) The wall is the objective coupling, not the cubic rows.** The
+> bound equals the objective's constant term `6329.03·x0·x3·x18 = 6329.03·2 =
+> 12658.06` *exactly*, yet the relaxed `x15 = 12.44 ≠ 0`: the reformed
+> `x15·(x0·x3·x18)` aux relaxes to its lower bound, so the `1800·x15` cost
+> contributes 0 to the bound regardless of `x15`. The cubic cost rows #721 targets
+> only *define* `x15`; tightening them cannot lift the bound while `x15`'s coupling
+> into the objective is itself loose in-relaxation. **No auto-trigger code shipped**
+> — a wide-range-monomial partition trigger would be inert on the real path (and,
+> keyed on range width, would select `x6`, the *most* inert flow), failing #721's
+> own exit gate and the `DISCOPT_CUT_INHERIT` lesson (sound ≠ helpful). Re-scope: the
+> only remaining lever is a **tighter joint relaxation of the `x15·(indicator)`
+> objective coupling and the cubic block together** (not a term-wise cubic-row
+> relaxation) — the catalog §7 joint edge-concave/αBB open item, a distinct,
+> higher-risk research direction. Reproduction:
+> `discopt_benchmarks/scripts/ex1252_piecewise_lever_probe.py`; pinned by
+> `python/tests/test_ex1252_piecewise_lever.py`.
+
 ## 7. Sequencing & rationale (revised by the measurement)
 
 ```

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -614,16 +614,28 @@ panel green for 3 consecutive nightlies before default-on.
 > prediction to the penny. Sound throughout (RLT rows are products of valid
 > identities/inequalities — never cut a feasible point; verified `bound ≤ opt` on
 > every run). **Kept default-OFF, not graduated:** the flag-OFF path is
-> byte-identical to #707 (same 90-column model, same 12658.06), but a full
-> time-limited solve is not yet a clean net-positive — the extra per-node `x_i·c`
-> bilinears cost throughput, and the time-limited *global* dual is high-variance
-> (ex1252: OFF 12658–31856, ON 0–22468 across 60–240 s budgets; ON ≥ OFF at 240 s but
-> the OFF number is not even monotonic run-to-run, so no clean net claim). The
-> node-level gain is deterministic and large; net-positivity is the open graduation
-> question and needs a corpus panel + deep-node gating (the RLT only bites once the
-> integer factors are fixed, so applying it everywhere over-pays at shallow nodes).
-> `python/tests/test_ex1252_coupling_rlt.py` pins soundness + the node-level lift +
-> the byte-identical OFF path.
+> byte-identical to #707 (same 90-column model, same 12658.06). The deterministic
+> node-budget A/B settles net effect (equal node count removes the wall-clock
+> nondeterminism that made the time-limited global dual erratic):
+>
+> | ex1252, ~400 B&B nodes | global dual | incumbent |
+> |---|---|---|
+> | flag OFF | 16071 | 143555 |
+> | flag ON | 16304 (+1.4%) | **134471** (closer to opt 128894) |
+>
+> So the large *node-level* lift (4.5× at a line-selected node) translates to only
+> **+1.4% on the global dual** — because the global dual is set by the *shallow*
+> indicator nodes near the root (objective still relaxes to ~0 there), not the deep
+> line-selected nodes the coupling RLT tightens. It does improve the *primal* side
+> (a better incumbent). **ex1252 stays a hard bound gap** — this is a SOTA-frontier
+> instance (SCIP does not certify it in 120 s either), and the coupling RLT does not
+> lift the *global* dual materially above the #707 ~48k plateau within a practical
+> budget. Net-positivity for graduation would need **deep-node gating** — apply the
+> RLT only once the integer factors are fixed by branching (a per-node cut, not an
+> upfront model transform), so shallow nodes don't pay for rows that cannot bite
+> there — plus the CLAUDE.md §5 corpus differential panel. The lever is sound and a
+> foundation; graduation is future work. `python/tests/test_ex1252_coupling_rlt.py`
+> pins soundness + the node-level lift + the byte-identical OFF path.
 
 ## 7. Sequencing & rationale (revised by the measurement)
 

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -636,6 +636,13 @@ panel green for 3 consecutive nightlies before default-on.
 > there — plus the CLAUDE.md §5 corpus differential panel. The lever is sound and a
 > foundation; graduation is future work. `python/tests/test_ex1252_coupling_rlt.py`
 > pins soundness + the node-level lift + the byte-identical OFF path.
+> **Follow-up (same day):** the compounding probe
+> (`discopt_benchmarks/scripts/ex1252_compounding_probe.py`) confirms the RLT
+> *unlocks* the previously-falsified levers — `x6` subdivision now lifts a child
+> bound 57435→62071 and OBBT pins `x12` exactly / caps `x15` at 30.89 within
+> seconds (both provably inert pre-RLT) — and exposes an engine fragility
+> (0.0/`numerical` fallback bounds on narrow boxes). Full anatomy + staged
+> certification plan: `docs/dev/ex1252-certification-plan.md`.
 
 ## 7. Sequencing & rationale (revised by the measurement)
 

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -588,16 +588,42 @@ panel green for 3 consecutive nightlies before default-on.
 > `x15·(x0·x3·x18)` aux relaxes to its lower bound, so the `1800·x15` cost
 > contributes 0 to the bound regardless of `x15`. The cubic cost rows #721 targets
 > only *define* `x15`; tightening them cannot lift the bound while `x15`'s coupling
-> into the objective is itself loose in-relaxation. **No auto-trigger code shipped**
-> — a wide-range-monomial partition trigger would be inert on the real path (and,
-> keyed on range width, would select `x6`, the *most* inert flow), failing #721's
-> own exit gate and the `DISCOPT_CUT_INHERIT` lesson (sound ≠ helpful). Re-scope: the
-> only remaining lever is a **tighter joint relaxation of the `x15·(indicator)`
-> objective coupling and the cubic block together** (not a term-wise cubic-row
-> relaxation) — the catalog §7 joint edge-concave/αBB open item, a distinct,
-> higher-risk research direction. Reproduction:
-> `discopt_benchmarks/scripts/ex1252_piecewise_lever_probe.py`; pinned by
-> `python/tests/test_ex1252_piecewise_lever.py`.
+> into the objective is itself loose in-relaxation. No wide-range-monomial partition
+> trigger shipped — it would be inert on the real path (and, keyed on range width,
+> would select `x6`, the *most* inert flow), per the `DISCOPT_CUT_INHERIT` lesson
+> (sound ≠ helpful). The real lever is the **objective coupling**, addressed next.
+> Reproduction: `discopt_benchmarks/scripts/ex1252_piecewise_lever_probe.py`; pinned
+> by `python/tests/test_ex1252_piecewise_lever.py`.
+
+> **Implemented, default-OFF (2026-07-18, issue #721 — objective-coupling RLT,
+> `DISCOPT_MULTILINEAR_COUPLING_RLT`).** Following the record above (the wall is the
+> `x15·(x0·x3·x18)` coupling, not the cubic rows), the entry experiment measured
+> `min x15` over the reformed loosest-node relaxation = **12.44** — the cubic/flow
+> rows *do* force `x15` up; the bound sits at the objective constant `12658.06` only
+> because the reformed `v_k = z_k·x15` big-M products decouple (with the reform's own
+> expansion bits fractional in the LP, every `v_k` relaxes to 0). Since the objective
+> is `12658.06 + 3600·x15` at the node, a valid coupling link makes `12658.06 +
+> 3600·12.44 = 57435` a **sound** bound the current relaxation simply leaves on the
+> table. The fix is RLT (issue direction #3): multiply each integer factor's exact
+> bit-linking equality (`x_i = lo + Σ2^k e_k`) and each AND hull (`z ≤ b`,
+> `z ≥ Σb−(n−1)`) by the non-negative continuous factor, tying `Σ2^k(e_k·c)` to
+> `x_i·c` and `v = z·c` to the per-bit products. Both levels are needed — the AND-hull
+> RLT alone does nothing (the leak is one level down, in the fractional expansion
+> bits); adding the bit-linking RLT (where `x_i·c` is McCormick-exact once `x_i` is
+> fixed) lifts the loosest-node bound to **57434.96**, matching the entry-experiment
+> prediction to the penny. Sound throughout (RLT rows are products of valid
+> identities/inequalities — never cut a feasible point; verified `bound ≤ opt` on
+> every run). **Kept default-OFF, not graduated:** the flag-OFF path is
+> byte-identical to #707 (same 90-column model, same 12658.06), but a full
+> time-limited solve is not yet a clean net-positive — the extra per-node `x_i·c`
+> bilinears cost throughput, and the time-limited *global* dual is high-variance
+> (ex1252: OFF 12658–31856, ON 0–22468 across 60–240 s budgets; ON ≥ OFF at 240 s but
+> the OFF number is not even monotonic run-to-run, so no clean net claim). The
+> node-level gain is deterministic and large; net-positivity is the open graduation
+> question and needs a corpus panel + deep-node gating (the RLT only bites once the
+> integer factors are fixed, so applying it everywhere over-pays at shallow nodes).
+> `python/tests/test_ex1252_coupling_rlt.py` pins soundness + the node-level lift +
+> the byte-identical OFF path.
 
 ## 7. Sequencing & rationale (revised by the measurement)
 

--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -50,6 +50,7 @@ from discopt.modeling.core import (
     Variable,
     VarType,
 )
+from discopt.solver_tuning import _env_flag
 
 from .factorable_reform import _collect_mul_factors
 from .term_classifier import distribute_products
@@ -140,6 +141,18 @@ class _Expander:
         #   _bigm_cache: (e._index, other._index, other_elem) -> big-M product aux
         self._and_cache: dict[tuple, Variable] = {}
         self._bigm_cache: dict[tuple, Variable] = {}
+        # Coupling-RLT (issue #721, default-OFF ``DISCOPT_MULTILINEAR_COUPLING_RLT``).
+        # For a continuous-times-AND product ``v = z*c`` with ``z = AND(bits)`` and a
+        # non-negative continuous factor ``c``, the plain big-M envelope of ``v``
+        # decouples in the LP: with the bits/``z`` fractional the objective's ``c*z``
+        # cost can relax to 0 regardless of ``c`` (ex1252 loosest node: the reformed
+        # ``x15*(x0*x3*x18)`` term relaxes to 0 though the cubic rows force
+        # ``x15 >= 12.44``, pinning the bound at the objective constant 12658). The
+        # RLT rows ``v <= b*c`` and ``v >= sum_b (b*c) - (n-1)*c`` (products of the
+        # exact AND hull ``z <= b`` / ``z >= sum b - (n-1)`` with ``c >= 0``) tie ``v``
+        # back to ``c``, lifting the bound sound-ly (entry experiment: 12658 ->
+        # ~57435 at that node). See docs/dev/performance-plan.md §6.
+        self.coupling_rlt = _env_flag("DISCOPT_MULTILINEAR_COUPLING_RLT", default=False)
 
     def expansion(self, var: Variable, elem: int, lo: int, hi: int):
         key = (var._index, elem)
@@ -267,6 +280,75 @@ class _Expander:
         ac.append(Constraint(body, ">=", 0.0))
         self._and_cache[key] = z
         return z
+
+    def add_coupling_rlt(
+        self, v: Variable, bits: "list[Variable]", other: Expression, lo_o: float, hi_o: float
+    ) -> None:
+        """Add RLT rows tying ``v = AND(bits) * other`` to the per-bit products.
+
+        Let ``z = AND(bits)`` (so ``v == z*other``). The exact AND hull gives
+        ``z <= b`` for each bit ``b`` and ``z >= sum_b b - (n-1)``. Multiplying each
+        by a **non-negative** ``other`` (``lo_o >= 0``) yields the valid RLT rows
+
+            v <= b*other            (each bit b)
+            v >= sum_b (b*other) - (n-1)*other
+
+        where each ``b*other`` is the exact big-M product (reused from the cache when
+        already lifted). These hold at every integral point, so they never cut a
+        feasible solution, and they tighten the LP envelope of ``v`` toward ``z*other``
+        — closing the objective-coupling leak (issue #721). No-op unless the flag is
+        on, ``other`` is sign-definite non-negative, and the AND is genuinely
+        multi-bit (a single-bit ``z`` already *is* its big-M product, exactly)."""
+        if not self.coupling_rlt or lo_o < 0.0 or len(bits) < 2:
+            return
+        ws = [self.bigm_product(b, other, lo_o, hi_o) for b in bits]
+        ac = self.aux_constraints
+        # v - b*other <= 0   (v <= b*other), for each bit
+        for w in ws:
+            ac.append(Constraint(BinaryOp("-", v, w), "<=", 0.0))
+        # v - sum_b (b*other) + (n-1)*other >= 0   (v >= sum_b (b*other) - (n-1)*other)
+        s: Expression = ws[0]
+        for w in ws[1:]:
+            s = BinaryOp("+", s, w)
+        body = BinaryOp(
+            "+", BinaryOp("-", v, s), BinaryOp("*", Constant(float(len(bits) - 1)), other)
+        )
+        ac.append(Constraint(body, ">=", 0.0))
+
+    def add_bitlink_rlt(
+        self,
+        ref: Expression,
+        lo: int,
+        bits: "list[tuple[int, Variable]]",
+        other: Expression,
+        lo_o: float,
+        hi_o: float,
+    ) -> None:
+        """RLT of the bit-linking equality ``x_i = lo + sum_k 2^k e_k`` times ``other``.
+
+        Multiplying that exact identity by the continuous factor ``other`` gives the
+        valid (exact) linear relation
+
+            x_i*other == lo*other + sum_k 2^k (e_k*other)
+
+        where each ``e_k*other`` is the exact big-M product and ``x_i*other`` is left
+        as a bilinear term the McCormick relaxer envelopes. This is what actually
+        closes the coupling leak: at any node where ``x_i`` is fixed, ``x_i*other``
+        is McCormick-exact, so the per-bit products ``e_k*other`` are pinned (the
+        bit-linking row alone leaves the ``e_k`` fractional in the LP, which is why
+        the AND-hull RLT above is not enough on its own). Requires ``other >= 0``
+        (``lo_o >= 0``) so the objective coupling — the only current caller — is
+        sign-definite; a sign-mixed factor is skipped (left to plain McCormick)."""
+        if not self.coupling_rlt or lo_o < 0.0:
+            return
+        acc: Expression = BinaryOp("*", ref, other)
+        if lo != 0:
+            acc = BinaryOp("-", acc, BinaryOp("*", Constant(float(lo)), other))
+        for ck, ek in bits:
+            w = self.bigm_product(ek, other, lo_o, hi_o)
+            term = w if ck == 1 else BinaryOp("*", Constant(float(ck)), w)
+            acc = BinaryOp("-", acc, term)
+        self.aux_constraints.append(Constraint(acc, "==", 0.0))
 
 
 def _expand_product(
@@ -431,6 +513,17 @@ def _try_expand_multilinear(node: BinaryOp, exp: _Expander) -> Optional[Expressi
         return None
     int_factors = [exp.expansion(v, el, lo, hi) for (v, el, lo, hi) in int_refs]
 
+    # Issue #721 (default-OFF coupling RLT): tie each integer factor's bit-linking
+    # equality to the continuous factor, so the per-bit products ``e_k*c`` are pinned
+    # once ``x_i`` is fixed (the level that actually closes the objective-coupling
+    # leak). Done once per (integer factor, continuous factor) pair, before the
+    # per-monomial AND-hull RLT below.
+    if exp.coupling_rlt and cont_factors:
+        _cexpr, _clo, _chi = cont_factors[0]
+        for (v, el, _lo0, _hi0), (lo_i, bits_i) in zip(int_refs, int_factors):
+            ref_i = v if v.size == 1 else IndexExpression(v, el)
+            exp.add_bitlink_rlt(ref_i, lo_i, bits_i, _cexpr, _clo, _chi)
+
     # Distribute the product of the integer factors into monomials over the binary
     # bits. ``poly`` maps a tuple of distinct bit Variables (sorted by index) to its
     # integer coefficient; ``e^2 = e`` collapses repeated bits (repeated integer
@@ -470,6 +563,10 @@ def _try_expand_multilinear(node: BinaryOp, exp: _Expander) -> Optional[Expressi
                 term_expr: Expression = cexpr  # 1 * continuous
             else:
                 term_expr = exp.bigm_product(mono, cexpr, clo, chi)  # continuous * 0/1
+                # Issue #721: tie a multi-bit AND coupling back to the continuous
+                # factor via RLT (default-OFF), closing the objective-coupling leak.
+                if len(key) >= 2:
+                    exp.add_coupling_rlt(term_expr, list(key), cexpr, clo, chi)
         else:
             if mono is None:
                 out = Constant(c) if out is None else BinaryOp("+", out, Constant(c))

--- a/python/tests/test_ex1252_coupling_rlt.py
+++ b/python/tests/test_ex1252_coupling_rlt.py
@@ -1,0 +1,113 @@
+"""Issue #721 — the objective-coupling RLT (default-OFF
+``DISCOPT_MULTILINEAR_COUPLING_RLT``, on top of #707's integer-multilinear reform).
+
+Entry experiment + rationale: ``docs/dev/performance-plan.md`` §6 (2026-07-18).
+
+The #707 reform lifts ex1252's dual off the structural floor but the objective's
+``x15·(x0·x3·x18)`` coupling still relaxes to 0 at a line-selected node (the cubic
+rows force ``x15 ≥ 12.44``, yet the big-M product envelope lets the ``1800·x15`` cost
+contribute nothing — pinning the loosest-node bound at the objective constant
+12658.06). The coupling RLT multiplies each integer factor's bit-linking equality
+and each AND hull by the (non-negative) continuous factor, tying the disaggregated
+products back to ``x15``. This lifts the loosest-node bound to ~57435 — a large,
+**sound** tightening (the RLT rows are products of valid identities/inequalities, so
+they never cut a feasible point).
+
+These tests lock: (1) the OFF path is byte-identical to #707 (same bound, same var
+count); (2) the ON path lifts the node bound to ~57435 and is sound (≤ the true
+optimum); (3) no feasible point is cut. The flag stays default-OFF — in a full
+time-limited solve the extra per-node bilinears currently cost enough throughput to
+be net-negative on the *global* dual (see §6), so graduation waits on deep-node
+gating; here we pin soundness and the node-level gain.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ.setdefault("DISCOPT_INCREMENTAL_MC", "0")
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.integer_product_reform import reformulate_integer_multilinear
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.obbt import obbt_tighten_root
+
+pytestmark = [pytest.mark.relaxation, pytest.mark.correctness]
+
+OFF_BOUND = 6329.03 * 2.0  # 12658.06 — objective constant; #707 baseline at the node
+ON_BOUND = 57434.96  # coupling-RLT lifted bound (12658.06 + 3600·min_x15, min_x15≈12.44)
+EX1252_OPT = 128893.74
+LINE1 = {18: 1, 36: 1, 21: 1, 19: 0, 20: 0, 37: 0, 38: 0, 22: 0, 23: 0}
+
+
+def _nl_path() -> Path:
+    here = Path(__file__).resolve()
+    for base in here.parents:
+        for sub in ("python/tests/data/minlplib", "tests/data/minlplib"):
+            cand = base / sub / "ex1252.nl"
+            if cand.exists():
+                return cand
+    raise FileNotFoundError("ex1252.nl not found")
+
+
+def _loosest_node_bound(coupling_rlt: bool):
+    prev = os.environ.get("DISCOPT_MULTILINEAR_COUPLING_RLT")
+    os.environ["DISCOPT_MULTILINEAR_COUPLING_RLT"] = "1" if coupling_rlt else "0"
+    try:
+        r = reformulate_integer_multilinear(dm.from_nl(str(_nl_path())))
+        n_vars = sum(v.size for v in r._variables)
+        lb, ub = flat_variable_bounds(r)
+        lb = np.asarray(lb, float).copy()
+        ub = np.asarray(ub, float).copy()
+        for i, v in LINE1.items():
+            lb[i] = ub[i] = float(v)
+        nc = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3)
+        lb, ub = nc.lb.copy(), nc.ub.copy()
+        lb[0] = ub[0] = 2.0
+        lb[24] = ub[24] = 0.0
+        lb[25] = ub[25] = 1.0  # x0 = 2
+        lb[3] = ub[3] = 1.0
+        lb[30] = ub[30] = 1.0
+        lb[31] = ub[31] = 0.0  # x3 = 1
+        res = MccormickLPRelaxer(r).solve_at_node(lb.copy(), ub.copy())
+        assert res.status == "optimal", f"status {res.status}"
+        return float(res.lower_bound), n_vars
+    finally:
+        if prev is None:
+            os.environ.pop("DISCOPT_MULTILINEAR_COUPLING_RLT", None)
+        else:
+            os.environ["DISCOPT_MULTILINEAR_COUPLING_RLT"] = prev
+
+
+def test_off_path_is_707_baseline():
+    """Flag OFF: byte-identical to #707 — bound at the objective-constant floor, no
+    extra columns (the coupling RLT adds nothing when disabled)."""
+    bound, n_vars = _loosest_node_bound(coupling_rlt=False)
+    assert bound == pytest.approx(OFF_BOUND, abs=1e-2)
+    assert n_vars == 90, f"OFF path must not add columns; got {n_vars}"
+
+
+def test_on_path_lifts_bound_soundly():
+    """Flag ON: the coupling RLT lifts the loosest-node bound ~4.5x, and it stays
+    sound — a valid dual bound never exceeds the true optimum."""
+    bound, n_vars = _loosest_node_bound(coupling_rlt=True)
+    assert bound == pytest.approx(ON_BOUND, rel=1e-3), f"expected ~{ON_BOUND}, got {bound}"
+    assert bound > OFF_BOUND + 1000.0, "coupling RLT must materially lift the bound"
+    assert bound <= EX1252_OPT + 1e-2, f"UNSOUND: bound {bound} > optimum {EX1252_OPT}"
+    assert n_vars > 90, "the RLT products add columns when enabled"
+
+
+def test_coupling_rlt_does_not_cut_the_optimum():
+    """Soundness: the true optimal point (bound ≤ opt) is never cut — the ON bound is
+    a valid lower bound, strictly below the instance optimum (no over-tightening)."""
+    on_bound, _ = _loosest_node_bound(coupling_rlt=True)
+    assert on_bound <= EX1252_OPT + 1e-2
+    off_bound, _ = _loosest_node_bound(coupling_rlt=False)
+    # Monotone: adding valid RLT rows can only tighten (raise) the bound.
+    assert on_bound >= off_bound - 1e-6, "valid RLT rows must never loosen the bound"

--- a/python/tests/test_ex1252_coupling_rlt.py
+++ b/python/tests/test_ex1252_coupling_rlt.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 os.environ.setdefault("JAX_PLATFORMS", "cpu")
 os.environ.setdefault("JAX_ENABLE_X64", "1")
-os.environ.setdefault("DISCOPT_INCREMENTAL_MC", "0")
 
 import discopt.modeling as dm
 import numpy as np
@@ -56,58 +55,53 @@ def _nl_path() -> Path:
     raise FileNotFoundError("ex1252.nl not found")
 
 
-def _loosest_node_bound(coupling_rlt: bool):
-    prev = os.environ.get("DISCOPT_MULTILINEAR_COUPLING_RLT")
-    os.environ["DISCOPT_MULTILINEAR_COUPLING_RLT"] = "1" if coupling_rlt else "0"
-    try:
-        r = reformulate_integer_multilinear(dm.from_nl(str(_nl_path())))
-        n_vars = sum(v.size for v in r._variables)
-        lb, ub = flat_variable_bounds(r)
-        lb = np.asarray(lb, float).copy()
-        ub = np.asarray(ub, float).copy()
-        for i, v in LINE1.items():
-            lb[i] = ub[i] = float(v)
-        nc = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3)
-        lb, ub = nc.lb.copy(), nc.ub.copy()
-        lb[0] = ub[0] = 2.0
-        lb[24] = ub[24] = 0.0
-        lb[25] = ub[25] = 1.0  # x0 = 2
-        lb[3] = ub[3] = 1.0
-        lb[30] = ub[30] = 1.0
-        lb[31] = ub[31] = 0.0  # x3 = 1
-        res = MccormickLPRelaxer(r).solve_at_node(lb.copy(), ub.copy())
-        assert res.status == "optimal", f"status {res.status}"
-        return float(res.lower_bound), n_vars
-    finally:
-        if prev is None:
-            os.environ.pop("DISCOPT_MULTILINEAR_COUPLING_RLT", None)
-        else:
-            os.environ["DISCOPT_MULTILINEAR_COUPLING_RLT"] = prev
+def _loosest_node_bound(monkeypatch, coupling_rlt: bool):
+    # monkeypatch reverts the env change automatically (conftest guards against
+    # leaked DISCOPT_* mutations under xdist).
+    monkeypatch.setenv("DISCOPT_MULTILINEAR_COUPLING_RLT", "1" if coupling_rlt else "0")
+    r = reformulate_integer_multilinear(dm.from_nl(str(_nl_path())))
+    n_vars = sum(v.size for v in r._variables)
+    lb, ub = flat_variable_bounds(r)
+    lb = np.asarray(lb, float).copy()
+    ub = np.asarray(ub, float).copy()
+    for i, v in LINE1.items():
+        lb[i] = ub[i] = float(v)
+    nc = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3)
+    lb, ub = nc.lb.copy(), nc.ub.copy()
+    lb[0] = ub[0] = 2.0
+    lb[24] = ub[24] = 0.0
+    lb[25] = ub[25] = 1.0  # x0 = 2
+    lb[3] = ub[3] = 1.0
+    lb[30] = ub[30] = 1.0
+    lb[31] = ub[31] = 0.0  # x3 = 1
+    res = MccormickLPRelaxer(r).solve_at_node(lb.copy(), ub.copy())
+    assert res.status == "optimal", f"status {res.status}"
+    return float(res.lower_bound), n_vars
 
 
-def test_off_path_is_707_baseline():
+def test_off_path_is_707_baseline(monkeypatch):
     """Flag OFF: byte-identical to #707 — bound at the objective-constant floor, no
     extra columns (the coupling RLT adds nothing when disabled)."""
-    bound, n_vars = _loosest_node_bound(coupling_rlt=False)
+    bound, n_vars = _loosest_node_bound(monkeypatch, coupling_rlt=False)
     assert bound == pytest.approx(OFF_BOUND, abs=1e-2)
     assert n_vars == 90, f"OFF path must not add columns; got {n_vars}"
 
 
-def test_on_path_lifts_bound_soundly():
+def test_on_path_lifts_bound_soundly(monkeypatch):
     """Flag ON: the coupling RLT lifts the loosest-node bound ~4.5x, and it stays
     sound — a valid dual bound never exceeds the true optimum."""
-    bound, n_vars = _loosest_node_bound(coupling_rlt=True)
+    bound, n_vars = _loosest_node_bound(monkeypatch, coupling_rlt=True)
     assert bound == pytest.approx(ON_BOUND, rel=1e-3), f"expected ~{ON_BOUND}, got {bound}"
     assert bound > OFF_BOUND + 1000.0, "coupling RLT must materially lift the bound"
     assert bound <= EX1252_OPT + 1e-2, f"UNSOUND: bound {bound} > optimum {EX1252_OPT}"
     assert n_vars > 90, "the RLT products add columns when enabled"
 
 
-def test_coupling_rlt_does_not_cut_the_optimum():
+def test_coupling_rlt_does_not_cut_the_optimum(monkeypatch):
     """Soundness: the true optimal point (bound ≤ opt) is never cut — the ON bound is
     a valid lower bound, strictly below the instance optimum (no over-tightening)."""
-    on_bound, _ = _loosest_node_bound(coupling_rlt=True)
+    on_bound, _ = _loosest_node_bound(monkeypatch, coupling_rlt=True)
     assert on_bound <= EX1252_OPT + 1e-2
-    off_bound, _ = _loosest_node_bound(coupling_rlt=False)
+    off_bound, _ = _loosest_node_bound(monkeypatch, coupling_rlt=False)
     # Monotone: adding valid RLT rows can only tighten (raise) the bound.
     assert on_bound >= off_bound - 1e-6, "valid RLT rows must never loosen the bound"

--- a/python/tests/test_ex1252_piecewise_lever.py
+++ b/python/tests/test_ex1252_piecewise_lever.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 os.environ.setdefault("JAX_PLATFORMS", "cpu")
 os.environ.setdefault("JAX_ENABLE_X64", "1")
-os.environ.setdefault("DISCOPT_INCREMENTAL_MC", "0")
 
 import discopt.modeling as dm
 import numpy as np

--- a/python/tests/test_ex1252_piecewise_lever.py
+++ b/python/tests/test_ex1252_piecewise_lever.py
@@ -1,0 +1,117 @@
+"""Pin the issue #721 direction-#1 finding (post-#707): on ex1252's canonical
+loosest node, the dual bound is inert to every available relaxation lever, and the
+wall is the objective coupling, not the cubic cost rows direction #1 targets.
+
+Entry experiment + root cause: ``docs/dev/performance-plan.md`` §6 (2026-07-18);
+reproduced by ``discopt_benchmarks/scripts/ex1252_piecewise_lever_probe.py``.
+
+With #707's integer-multilinear reform applied, the reformed-ex1252 loosest-node
+bound equals the objective's constant term (``6329.03·x0·x3·x18 = 12658.06``) and
+does not move under RLT / level-1 RLT / PSD / superposition — because the reformed
+``x15·(x0·x3·x18)`` objective aux relaxes to its lower bound (the relaxed ``x15`` is
+nonzero, yet its ``1800·x15`` cost contributes 0). Tightening the cubic rows that
+*define* ``x15`` (direction #1) cannot lift the bound while that coupling is loose.
+These tests lock the result so the falsified-here direction is not silently
+re-attempted, and double as a soundness pin (no lever ever reports a bound *above*
+the true in-node optimum).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ.setdefault("DISCOPT_INCREMENTAL_MC", "0")
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.integer_product_reform import reformulate_integer_multilinear
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.obbt import obbt_tighten_root
+
+pytestmark = pytest.mark.relaxation
+
+CONST_BOUND = 6329.03 * 2.0  # 12658.06 — the objective constant term at the node
+TOL = 1e-2
+LINE1 = {18: 1, 36: 1, 21: 1, 19: 0, 20: 0, 37: 0, 38: 0, 22: 0, 23: 0}
+
+
+def _nl_path() -> Path:
+    here = Path(__file__).resolve()
+    for base in here.parents:
+        for sub in ("python/tests/data/minlplib", "tests/data/minlplib"):
+            cand = base / sub / "ex1252.nl"
+            if cand.exists():
+                return cand
+    raise FileNotFoundError("ex1252.nl not found")
+
+
+@pytest.fixture(scope="module")
+def loosest_node():
+    r = reformulate_integer_multilinear(dm.from_nl(str(_nl_path())))
+    lb, ub = flat_variable_bounds(r)
+    lb = np.asarray(lb, float).copy()
+    ub = np.asarray(ub, float).copy()
+    for i, v in LINE1.items():
+        lb[i] = ub[i] = float(v)
+    nc = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3)
+    lb, ub = nc.lb.copy(), nc.ub.copy()
+    lb[0] = ub[0] = 2.0
+    lb[24] = ub[24] = 0.0
+    lb[25] = ub[25] = 1.0  # x0 = 2
+    lb[3] = ub[3] = 1.0
+    lb[30] = ub[30] = 1.0
+    lb[31] = ub[31] = 0.0  # x3 = 1
+    return r, lb, ub
+
+
+def _bound(r, lb, ub, **kw):
+    res = MccormickLPRelaxer(r, **kw).solve_at_node(lb.copy(), ub.copy())
+    assert res.status == "optimal", f"unexpected status {res.status}"
+    return float(res.lower_bound)
+
+
+@pytest.mark.parametrize(
+    "opts",
+    [
+        {},
+        {"rlt_cuts": True},
+        {"rlt_level1": True},
+        {"psd_cuts": True},
+        {"superposition": True},
+    ],
+    ids=["baseline", "rlt_cuts", "rlt_level1", "psd_cuts", "superposition"],
+)
+def test_every_lever_inert_at_loosest_node(loosest_node, opts):
+    """No available strengthener lifts the bound off the objective-constant floor.
+
+    Also a soundness pin: the bound never exceeds the true in-node optimum
+    (128893.74) — an over-tightening would be unsound.
+    """
+    r, lb, ub = loosest_node
+    b = _bound(r, lb, ub, **opts)
+    assert b == pytest.approx(CONST_BOUND, abs=TOL), (
+        f"a lever moved the bound ({opts}): {b} vs floor {CONST_BOUND}. "
+        "If this changed, a coupling-relaxation lever landed — re-run the entry "
+        "experiment and update performance-plan.md §6."
+    )
+    assert b <= 128893.74 + 1e-3, "bound above the true optimum is unsound"
+
+
+def test_root_cause_x15_coupling_relaxes_to_lower_bound(loosest_node):
+    """The wall is the objective coupling: the bound is the constant term, yet the
+    relaxed x15 is nonzero — the 1800*x15 cost contributes 0 because the reformed
+    x15*(x0*x3*x18) aux relaxes to its lower bound. Tightening the cubic rows that
+    define x15 (direction #1) cannot help while this coupling is loose.
+    """
+    r, lb, ub = loosest_node
+    res = MccormickLPRelaxer(r).solve_at_node(lb.copy(), ub.copy())
+    assert res.status == "optimal"
+    assert float(res.lower_bound) == pytest.approx(CONST_BOUND, abs=TOL)
+    # x15 is genuinely nonzero in the relaxed point, so the zero cost contribution
+    # is the coupling aux relaxing down — not x15 itself being driven to 0.
+    assert float(res.x[15]) > 1.0, "expected a nonzero relaxed x15 (coupling, not x15, is loose)"


### PR DESCRIPTION
## Summary

Advances #721 in three parts, measurement-first throughout (CLAUDE.md Dev-Philosophy #4), on top of #707's integer-multilinear reform.

**Part 1 — falsify direction #1 (piecewise McCormick on wide monomial factors).** On the per-node engine (`MccormickLPRelaxer`) at ex1252's canonical loosest node, the reformed dual bound is pinned at 12658.06 across *every* available lever (subdivide `x6`/`x12`, RLT, level-1 RLT, PSD, superposition, OBBT+cutoff). "Wide-range" and "binding" never coincide — at the root the flows are wide but the objective relaxes to 0; at any binding node OBBT has already narrowed them. The real wall was the **objective coupling**: the bound equals the objective constant `6329.03·2 = 12658.06` exactly while the reformed `x15·(x0·x3·x18)` aux relaxes to its lower bound.

**Part 2 — implement the real lever (issue direction #3, objective-coupling RLT), default-OFF `DISCOPT_MULTILINEAR_COUPLING_RLT`.** `min x15` over the reformed loosest-node relaxation is **12.44** (the cubic rows *do* force x15 up), so `12658.06 + 3600·12.44 = 57435` is a **sound** bound the relaxation left on the table — lost because the `v_k = z_k·x15` big-M products decouple when the reform's expansion bits go fractional. The fix multiplies each integer factor's exact bit-linking equality and each AND hull by the non-negative continuous factor (RLT). Lifts the loosest-node bound to **57434.96**, matching the prediction to the penny.

**Part 3 — compounding probe + certification plan.** With the RLT ON, the previously-falsified levers now bite: `x6` subdivision lifts a child bound 57435 → 62071 (provably 0% pre-RLT), and OBBT pins `x12` exactly and caps `x15 ∈ [12.44, 30.89]` in seconds (fully inert pre-RLT) — the compounding #721 predicted, now measured. Full five-layer anatomy + staged certification plan: `docs/dev/ex1252-certification-plan.md`; reproduction: `discopt_benchmarks/scripts/ex1252_compounding_probe.py`. The remaining work (search order, engine hardening on narrow boxes, per-config loop, graduation) is tracked in **#732**.

**Closes #721** — the issue's concrete deliverable (a general, sound tightening of this structure class behind a default-off flag, with the §5 panel gating graduation) is delivered, its direction #1 is falsified with a pinned record, and the remaining path to certification is scoped with measurements in #732.

## Correctness

- [x] Cannot produce a false certificate — the coupling RLT rows are products of valid identities/inequalities (exact bit-linking equality × factor; AND hull × non-negative factor), so they never cut a feasible point; verified `bound ≤ opt` on every ex1252 run and the generic trilinear reform case
- [x] No validation, fallback, or safety guard was weakened; the default-OFF path is byte-identical to #707

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **664 passed, 13 skipped**
- [x] `pytest python/tests/test_integer_multilinear_reform.py -m "correctness or slow"` → **7 passed** (flag default-off, byte-identical #707)
- [x] `pytest python/tests/test_ex1252_coupling_rlt.py python/tests/test_ex1252_piecewise_lever.py -m "correctness or relaxation"` → **9 passed** (incl. under xdist alongside `test_incremental_mccormick_node.py` after the env-leak fix — 11 passed)
- [x] adversarial suite → 9/10 in batch; the one failure (`test_large_dense_jacobian_no_crash`) passes in isolation (26 s) — resource/ordering flake, unrelated
- [x] `ruff check` / `ruff format --check` → clean
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)

## Regression test

- [x] `python/tests/test_ex1252_coupling_rlt.py` — fails before / passes after: pins the ON lift (12658 → 57434.96), soundness (`bound ≤ opt`, monotone vs OFF), and the byte-identical OFF path (90 columns, 12658.06). `python/tests/test_ex1252_piecewise_lever.py` pins the Part-1 falsification.

## Bound-changing / performance change?

- [x] Default-OFF flag: `DISCOPT_MULTILINEAR_COUPLING_RLT` (flag-OFF path byte-identical to #707)
- [x] Differential-bound test (new bound ≥ old AND ≤ true optimum) + soundness pin — `test_ex1252_coupling_rlt.py`
- [x] Not graduating — default-off only; graduation (corpus panel + deep-node gating) is scoped in #732
- Measurement: loosest-node dual 12658.06 (OFF) → 57434.96 (ON), sound (≤ 128893.74). Deterministic ~400-node A/B: global dual 16071 → 16304 (+1.4%), incumbent 143555 → 134471 — node-level gain is real; global dual is search-order-limited (#732 Stage 2). Compounding probe: `x6` child bound 57435 → 62071; OBBT pins `x12`, caps `x15` at 30.89 (both inert pre-RLT).
