### PR TITLE
docs(#323): lock two-axis solver API contract (docstring + dev doc)

### DIFF
--- a/docs/dev/mip-nlp-upstream-readiness.md
+++ b/docs/dev/mip-nlp-upstream-readiness.md
@@ -24,7 +24,7 @@ before opening the final upstream PR from `bernalde:feature/mip-nlp-solver` to
 
 | Issue | Scope | Integration PR | Status |
 | --- | --- | --- | --- |
-| #111 | Route `solver="mip-nlp"` to OA/ECP and establish the two-axis API | #122 | Merged into `feature/mip-nlp-solver` |
+| #111 | Route `solver="mip-nlp"` to OA/ECP and establish the two-axis API (contract locked by #323; see `solve-routing.md` §4) | #122 | Merged into `feature/mip-nlp-solver` |
 | #112 | OA/ECP parity baselines against MindtPy-style fixtures | #123 | Merged into `feature/mip-nlp-solver` |
 | #113 | Initialization strategies: `rNLP`, `initial_binary`, `max_binary` | #124 | Merged into `feature/mip-nlp-solver` |
 | #114 | OA robustness: slack, no-good cuts, feasibility norms, cycling | #125 | Merged into `feature/mip-nlp-solver` |

--- a/docs/dev/solve-routing.md
+++ b/docs/dev/solve-routing.md
@@ -36,10 +36,11 @@ solve_model(...)                                          [solver.py:2017]
   │     solver="bb"       ──► force B&B (skip GP auto fast-paths)
   │     solver=None       ──► fall through
   │
-  ├─ GDP INTERCEPT (model has disjunctions / logic)
-  │     gdp_method="oa"    ──► Outer Approximation (solve_oa)
-  │     gdp_method="loa"   ──► LOA decomposition
+  ├─ GDP INTERCEPT (model has disjunctions / logic)          [two-axis contract → §4]
+  │     gdp_method="oa"    ──► Outer Approximation (solve_oa) (deprecated → mip-nlp/oa)
+  │     gdp_method="loa"   ──► LOA decomposition   (native disjunctive axis)
   │     gdp_method="big-m"/"hull" ──► reformulate_gdp → standard MINLP (continue)
+  │     NB: native gdp_method (loa) + solver="mip-nlp" ──► ValueError (contradictory; §4)
   │
   ├─ PRE-DISPATCH REWRITES  (sequential; each may replace `model`)
   │     1. factorable_reformulate   (clear sign-definite denominators / lift factorable terms)
@@ -214,3 +215,49 @@ while True:
 > (clay0204m 43%→12%) but cannot escape far basins (syn40m) — there the heuristics
 > return worse points than the B&B's own node incumbent, so the residual gap is a
 > global-*search* problem, not a primal one. See `performance-plan.md`.
+
+---
+
+## 4. Two-axis solver API contract (locked, #323)
+
+The solver API has **two orthogonal axes**. They answer different questions and
+must never be aliased together. This contract was agreed while reviewing #319/#320
+and locked by #323 so later work does not drift; the enforcement below ships and is
+tested — do not weaken it without re-litigating the contract.
+
+**Axis 1 — `gdp_method`: *how a disjunctive model is handled.*** Either reformulate
+the disjunctions into an algebraic MIP/MINLP, or solve the disjunctive form
+*natively* via a logic-based method.
+
+| `gdp_method` | Meaning | Kind |
+|---|---|---|
+| `big-m`, `hull`, `mbigm`, `auto` | reformulate disjunctions → algebraic MIP/MINLP | reformulation |
+| `loa` | logic-based OA, solved natively on the disjunctive form (`solve_gdpopt_loa`) | native disjunctive |
+| `oa` | *deprecated* — was "OA solver + big-M reform"; now warns and reforms as `big-m` | deprecated |
+| `gloa` | *reserved* — global logic-based OA, native axis; not yet implemented | reserved (native) |
+
+**Axis 2 — `solver` / `mip_nlp_method`: *how the resulting algebraic MIP/MINLP is
+solved.*** With `solver="mip-nlp"`, `mip_nlp_method` selects the decomposition
+algorithm: `oa`, `ecp`, `fp`, `goa`, `lp_nlp_bb` (implemented); `roa` (reserved).
+
+### The two locked rules
+
+1. **Native-disjunctive `gdp_method` + `solver="mip-nlp"` raises.** Requesting a
+   native `gdp_method` (`loa`) together with `solver="mip-nlp"` is contradictory —
+   one says "solve the disjunctions natively," the other says "reformulate to
+   algebraic and decompose." This raises a clear `ValueError` rather than silently
+   reformulating away the native request.
+   Enforced: `solver.py` (`native_gdp_methods = {"loa"}` guard, ~line 3819).
+   Test: `test_mip_nlp_rejects_native_gdp_solver_method` (`python/tests/test_mip_nlp.py`).
+
+2. **`goa` ≠ `gloa`; they must stay distinct and must not be aliased.** `goa` is a
+   `mip_nlp_method` (generalized/global OA over the *algebraic* MINLP). `gloa`
+   (global *logic-based* OA) belongs on the *native* `gdp_method` axis and is
+   reserved — requesting it as a `mip_nlp_method` raises and points the caller at
+   `goa` (algebraic) vs the `gdp_method` axis (logic-based).
+   Enforced: `mip_nlp.py` `_normalize_method` (~line 638).
+   Test: `test_mip_nlp_method_gloa_is_reserved_for_gdp_axis` (`python/tests/test_mip_nlp.py`).
+
+Line anchors are approximate — grep the named guards/tests if they drift. The
+umbrella "establish the two-axis API" work is tracked in
+`mip-nlp-upstream-readiness.md` (issue #111).

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3411,8 +3411,29 @@ def solve_model(
         a valid lower bound on the box minimum, so it could certify a wrong
         optimum. Selecting it now raises ``ValueError``.)
     gdp_method : str, default "big-m"
-        Reformulation method for disjunctive constraints:
-        ``"big-m"`` (default) or ``"hull"`` (convex hull).
+        How a disjunctive (GDP) model is handled — the first of the two
+        orthogonal solver axes (see the second, ``solver``/``mip_nlp_method``,
+        below). Either *reformulate* the disjunctions into an algebraic
+        MIP/MINLP or solve the disjunctive form *natively* via a logic-based
+        method:
+
+        - ``"big-m"`` (default), ``"hull"`` (convex hull), ``"mbigm"``,
+          ``"auto"`` — reformulate disjunctions into a standard algebraic
+          MIP/MINLP, then dispatch normally.
+        - ``"loa"`` — *native* logic-based Outer Approximation on the
+          disjunctive form (dispatches to :func:`solve_gdpopt_loa`), not a
+          reformulation.
+        - ``"oa"`` — *deprecated*; historically "OA solver + big-M reform".
+          Now emits a ``DeprecationWarning`` and reformulates as ``"big-m"``.
+          Use ``solver="mip-nlp", mip_nlp_method="oa"`` for algebraic OA.
+
+        The two axes are orthogonal and are not aliased: a *native*
+        ``gdp_method`` (``"loa"``) combined with ``solver="mip-nlp"`` is
+        contradictory (one asks to solve the disjunctions natively, the other
+        to reformulate and decompose) and raises ``ValueError``. Likewise
+        ``"gloa"`` (global logic-based OA) is reserved for this native axis and
+        is distinct from the algebraic ``mip_nlp_method="goa"``. See
+        ``docs/dev/solve-routing.md`` §4 for the locked contract (#323).
     solver : str or None, default None
         Optional global-solver selector. Use ``"amp"`` to dispatch to
         Adaptive Multivariate Partitioning instead of branch-and-bound.


### PR DESCRIPTION
## Summary

Closes #323.

#323 is a contract-locking issue, not a feature: it exists so the two-axis solver API decisions agreed while reviewing #319/#320 aren't lost. The **code enforcement already ships and is tested** on `main` — this PR writes the contract down where contributors will find it so later work doesn't drift.

The two axes:
- **`gdp_method`** — *how a disjunctive model is handled*: reformulate disjunctions into an algebraic MIP/MINLP (`big-m`/`hull`/`mbigm`/`auto`) **or** solve natively via logic-based methods (`loa`; `gloa` reserved).
- **`solver`/`mip_nlp_method`** — *how the resulting algebraic MIP/MINLP is solved*: `oa`/`ecp`/`fp`/`goa`/`lp_nlp_bb` (`roa` reserved).

Changes (docs + docstring only):
- **`docs/dev/solve-routing.md`**: new §4 documenting the two orthogonal axes and the two locked rules — (1) a native-disjunctive `gdp_method` (`loa`) + `solver="mip-nlp"` raises `ValueError`, and (2) `goa` (mip_nlp_method) ≠ `gloa` (reserved native logic-based) — each with its guard location and regression-test name. Trunk GDP-intercept box annotated to point at §4.
- **`python/discopt/solver.py`**: expanded the `gdp_method` docstring (previously only `big-m`/`hull`) to reflect the two-axis model: reformulation methods, native `loa`, deprecated `oa`, and the reserved `gloa` vs algebraic `goa` distinction.
- **`docs/dev/mip-nlp-upstream-readiness.md`**: cross-linked the #111 row ("establish the two-axis API") to §4.

### Acceptance criteria (#323)

- [x] `solve_model` raises when a native-disjunctive `gdp_method` is combined with `solver="mip-nlp"`, with a regression test — already shipped: guard `solver.py` `native_gdp_methods = {"loa"}` (~L3819), test `test_mip_nlp_rejects_native_gdp_solver_method`. Now documented.
- [x] `goa` (mip_nlp_method) and `gloa` (native logic-based) reserved distinct, with each axis documented — already shipped: guard `mip_nlp.py` `_normalize_method` (~L638), test `test_mip_nlp_method_gloa_is_reserved_for_gdp_axis`. Now documented.
- [x] Docstrings for `solver`, `mip_nlp_method`, and `gdp_method` reflect the two-axis model — `solver`/`mip_nlp_method` were already thorough; this PR closes the remaining `gdp_method` docstring gap.

## Correctness

- [x] Cannot produce a false certificate (N/A — no solver-math change; docs + docstring only, no executable code paths touched)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

Docs/docstring-only change; no logic touched. The remote session has no Python deps installed (numpy absent), so the suite couldn't be exercised here. Verified instead:
- `python -m py_compile python/discopt/solver.py python/discopt/solvers/mip_nlp.py` → OK
- AST check: `solve_model` docstring parses and contains the two-axis contract text.

The two guarding tests referenced by the contract (`test_mip_nlp_rejects_native_gdp_solver_method`, `test_mip_nlp_method_gloa_is_reserved_for_gdp_axis`) already exist and are unchanged by this PR.

## Regression test

- [x] N/A — docs/docstring only. The behavior this contract documents is already covered by the two existing tests named above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gx8xS5csGAQK2u4T7BXaNv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gx8xS5csGAQK2u4T7BXaNv)_