### PR TITLE
feat(ci): track dependents and notify them on release (#414)

### DIFF
--- a/.github/dependent-ci-template.yml
+++ b/.github/dependent-ci-template.yml
@@ -1,0 +1,49 @@
+# Template: discopt integration CI for dependent packages (issue #414).
+#
+# Copy this file into a dependent repo as
+#   .github/workflows/discopt-integration.yml
+# so that repo's tests re-run against discopt whenever discopt publishes a
+# release. The discopt release pipeline sends a `repository_dispatch` event of
+# type `discopt-updated` (see .github/dependents.yml + notify-dependents.yml in
+# jkitchin/discopt); this workflow listens for it.
+#
+# Adjust the install/test steps to match the dependent's own layout.
+
+name: discopt integration
+
+on:
+  repository_dispatch:
+    types: [discopt-updated]
+  workflow_dispatch:
+  # Weekly fallback so drift is caught even if a dispatch is missed.
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  test:
+    name: Test against discopt @ main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Report what triggered this run
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "discopt release: ${{ github.event.client_payload.release_tag }}"
+          echo "Source run: ${{ github.event.client_payload.run_url }}"
+
+      - name: Install discopt (main) + this package
+        run: |
+          python -m pip install --upgrade pip
+          pip install "git+https://github.com/jkitchin/discopt.git@main"
+          pip install -e ".[dev]"
+
+      - name: Show installed discopt version
+        run: python -c "import discopt; print('discopt', discopt.__version__)"
+
+      - name: Run tests
+        run: pytest -q

--- a/.github/dependents.yml
+++ b/.github/dependents.yml
@@ -1,0 +1,57 @@
+# Registry of repositories that depend on discopt (issue #414).
+#
+# This is the machine-readable source of truth for "what depends on discopt".
+# The `notify-dependents` workflow (.github/workflows/notify-dependents.yml)
+# reads this file on every discopt release and, for each entry:
+#
+#   * dispatch: true  -> sends a `repository_dispatch` event so the dependent's
+#                        CI re-runs against the freshly released discopt and we
+#                        find out immediately if the release breaks a plugin.
+#   * notify:   true  -> opens a "review / update against discopt vX.Y.Z" issue
+#                        in the dependent repo so the update is tracked.
+#
+# The public entries below are also surfaced to humans in the README "Plugins"
+# table; private repos live here only (they are intentionally not listed in the
+# public README).
+#
+# Schema (per entry):
+#   repo        (required)  "owner/name" on GitHub.
+#   private     (optional, default false)  Informational; private repos need the
+#                                          dispatch token to be scoped to them.
+#   dispatch    (optional, default true)   Send repository_dispatch on release.
+#   notify      (optional, default true)   Open a review/update issue on release.
+#   event_type  (optional, default "discopt-updated")
+#                                          The repository_dispatch event type the
+#                                          dependent's workflow listens for.
+#   note        (optional)  Free-text description (unused by automation).
+
+dependents:
+  - repo: jkitchin/discopt-doe
+    private: false
+    dispatch: true
+    notify: true
+    note: Model-based design of experiments plugin.
+
+  - repo: jkitchin/discopt-aggregation
+    private: true
+    dispatch: true
+    notify: true
+    note: Variable aggregation (reduced-space presolve) plugin.
+
+  - repo: jkitchin/discopt-mkm
+    private: true
+    dispatch: true
+    notify: true
+    note: Microkinetic modeling plugin.
+
+  - repo: jkitchin/discopt-apps
+    private: false
+    dispatch: true
+    notify: true
+    note: Application builders (OPF, pooling).
+
+  - repo: jkitchin/discopt-course
+    private: false
+    dispatch: true
+    notify: true
+    note: Optimization course + interactive tutor CLI.

--- a/.github/scripts/notify_dependents.py
+++ b/.github/scripts/notify_dependents.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Fan out discopt release events to dependent repositories (issue #414).
+
+Reads the registry at ``.github/dependents.yml`` and, for each dependent:
+
+* sends a ``repository_dispatch`` event (so the dependent's CI re-runs against
+  the just-released discopt), and/or
+* opens a "review / update against discopt vX.Y.Z" tracking issue.
+
+Driven by ``.github/workflows/notify-dependents.yml``. The network-touching code
+is deliberately thin; the payload/manifest logic is pure and unit-tested in
+``python/tests/test_notify_dependents.py``.
+
+Environment variables:
+    GH_TOKEN        GitHub token with dispatch + issue write on the dependents.
+    RELEASE_TAG     Release tag (e.g. ``v1.2.3``); falls back to "unreleased".
+    RELEASE_URL     URL of the release (optional, embedded in the issue body).
+    SOURCE_REPO     ``owner/name`` of discopt (default ``jkitchin/discopt``).
+    RUN_URL         URL of the triggering Actions run (optional).
+    MANIFEST        Path to the registry (default ``.github/dependents.yml``).
+    DRY_RUN         "true" to log intended actions without calling the API.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+API_ROOT = "https://api.github.com"
+DEFAULT_EVENT_TYPE = "discopt-updated"
+DEFAULT_SOURCE_REPO = "jkitchin/discopt"
+
+
+@dataclass(frozen=True)
+class Dependent:
+    """One row of the dependents registry, with defaults applied."""
+
+    repo: str
+    private: bool = False
+    dispatch: bool = True
+    notify: bool = True
+    event_type: str = DEFAULT_EVENT_TYPE
+    note: str = ""
+
+
+def parse_manifest(text: str) -> list[Dependent]:
+    """Parse the dependents.yml contents into a list of ``Dependent``.
+
+    Raises ``ValueError`` on a malformed manifest so misconfiguration fails
+    loudly rather than silently skipping notifications.
+    """
+    data = yaml.safe_load(text) or {}
+    if not isinstance(data, dict) or "dependents" not in data:
+        raise ValueError("manifest must be a mapping with a 'dependents' key")
+    raw = data["dependents"] or []
+    if not isinstance(raw, list):
+        raise ValueError("'dependents' must be a list")
+
+    out: list[Dependent] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict) or "repo" not in entry:
+            raise ValueError(f"dependent #{i} is missing required 'repo' field")
+        repo = str(entry["repo"]).strip()
+        if repo.count("/") != 1 or repo.startswith("/") or repo.endswith("/"):
+            raise ValueError(f"dependent #{i} 'repo' must be 'owner/name', got {repo!r}")
+        out.append(
+            Dependent(
+                repo=repo,
+                private=bool(entry.get("private", False)),
+                dispatch=bool(entry.get("dispatch", True)),
+                notify=bool(entry.get("notify", True)),
+                event_type=str(entry.get("event_type", DEFAULT_EVENT_TYPE)),
+                note=str(entry.get("note", "")),
+            )
+        )
+    return out
+
+
+def dispatch_payload(
+    source_repo: str, release_tag: str, release_url: str, run_url: str
+) -> dict[str, Any]:
+    """Build the ``client_payload`` sent with a repository_dispatch event."""
+    return {
+        "source": source_repo,
+        "release_tag": release_tag,
+        "release_url": release_url,
+        "run_url": run_url,
+        "reason": "discopt release published",
+    }
+
+
+def issue_title(release_tag: str) -> str:
+    return f"Review / update against discopt {release_tag}"
+
+
+def issue_body(source_repo: str, release_tag: str, release_url: str, run_url: str) -> str:
+    lines = [
+        f"discopt **{release_tag}** was released. Please review this package for",
+        "compatibility and update pins / code as needed.",
+        "",
+        "This issue was opened automatically from the discopt release pipeline",
+        f"([{source_repo}](https://github.com/{source_repo}), issue #414).",
+        "",
+        "**Checklist**",
+        "- [ ] CI passes against the new discopt release",
+        "- [ ] Version pin updated if required",
+        "- [ ] Changelog / docs reviewed for breaking changes",
+    ]
+    if release_url:
+        lines += ["", f"Release notes: {release_url}"]
+    if run_url:
+        lines += [f"Triggering run: {run_url}"]
+    return "\n".join(lines)
+
+
+class GitHub:
+    """Minimal GitHub REST client over stdlib urllib."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def _request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+        url = f"{API_ROOT}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self._token}")
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("X-GitHub-Api-Version", "2022-11-28")
+        req.add_header("User-Agent", "discopt-notify-dependents")
+        with urllib.request.urlopen(req) as resp:  # noqa: S310 (fixed api.github.com host)
+            payload = resp.read()
+        return json.loads(payload) if payload else None
+
+    def send_dispatch(self, repo: str, event_type: str, client_payload: dict[str, Any]) -> None:
+        self._request(
+            "POST",
+            f"/repos/{repo}/dispatches",
+            {"event_type": event_type, "client_payload": client_payload},
+        )
+
+    def find_open_issue(self, repo: str, title: str) -> int | None:
+        """Return the number of an existing open issue with ``title``, else None."""
+        issues = self._request("GET", f"/repos/{repo}/issues?state=open&per_page=100") or []
+        for issue in issues:
+            # /issues also returns PRs; skip those and match the exact title.
+            if "pull_request" not in issue and issue.get("title") == title:
+                return int(issue["number"])
+        return None
+
+    def create_issue(self, repo: str, title: str, body: str) -> int:
+        created = self._request("POST", f"/repos/{repo}/issues", {"title": title, "body": body})
+        return int(created["number"])
+
+
+def _summary(line: str) -> None:
+    print(line)
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+
+def main() -> int:
+    manifest_path = Path(os.environ.get("MANIFEST", ".github/dependents.yml"))
+    release_tag = os.environ.get("RELEASE_TAG") or "unreleased"
+    release_url = os.environ.get("RELEASE_URL", "")
+    source_repo = os.environ.get("SOURCE_REPO") or DEFAULT_SOURCE_REPO
+    run_url = os.environ.get("RUN_URL", "")
+    dry_run = os.environ.get("DRY_RUN", "").lower() == "true"
+
+    dependents = parse_manifest(manifest_path.read_text(encoding="utf-8"))
+    active = [d for d in dependents if d.dispatch or d.notify]
+    if not active:
+        _summary("No dependents to notify.")
+        return 0
+
+    token = os.environ.get("GH_TOKEN", "")
+    if not token and not dry_run:
+        print(
+            "::error::GH_TOKEN is not set. Configure the DEPENDENTS_DISPATCH_TOKEN "
+            "secret (see docs/dev/dependents.md).",
+            file=sys.stderr,
+        )
+        return 1
+
+    gh = GitHub(token) if not dry_run else None
+    payload = dispatch_payload(source_repo, release_tag, release_url, run_url)
+    title = issue_title(release_tag)
+    body = issue_body(source_repo, release_tag, release_url, run_url)
+
+    failures = 0
+    _summary(f"### Notify dependents — discopt {release_tag}\n")
+    for dep in active:
+        actions: list[str] = []
+        if dep.dispatch:
+            try:
+                if dry_run:
+                    actions.append(f"would dispatch `{dep.event_type}`")
+                else:
+                    assert gh is not None
+                    gh.send_dispatch(dep.repo, dep.event_type, payload)
+                    actions.append(f"dispatched `{dep.event_type}`")
+            except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+                failures += 1
+                actions.append(f"dispatch FAILED ({exc})")
+                print(f"::warning title=dispatch failed::{dep.repo}: {exc}", file=sys.stderr)
+        if dep.notify:
+            try:
+                if dry_run:
+                    actions.append("would open review issue")
+                else:
+                    assert gh is not None
+                    existing = gh.find_open_issue(dep.repo, title)
+                    if existing is not None:
+                        actions.append(f"review issue exists (#{existing})")
+                    else:
+                        num = gh.create_issue(dep.repo, title, body)
+                        actions.append(f"opened review issue (#{num})")
+            except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+                failures += 1
+                actions.append(f"issue FAILED ({exc})")
+                print(f"::warning title=issue failed::{dep.repo}: {exc}", file=sys.stderr)
+        _summary(f"- **{dep.repo}**: {', '.join(actions)}")
+
+    if failures:
+        # Per-repo failures are warnings, not a hard job failure: one unreachable
+        # private repo must not red the release. Surface the count for visibility.
+        print(f"::warning::{failures} dependent notification(s) failed.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -1,0 +1,56 @@
+name: Notify dependents
+
+# Fan out discopt releases to dependent repositories (issue #414).
+#
+# On every published release this:
+#   * sends a `repository_dispatch` to each dependent so its CI re-runs against
+#     the new discopt (catching breakage), and
+#   * opens a "review / update" tracking issue in each dependent.
+#
+# The registry lives in .github/dependents.yml; the logic lives in
+# .github/scripts/notify_dependents.py. Cross-repo calls need a token beyond the
+# default GITHUB_TOKEN — configure the DEPENDENTS_DISPATCH_TOKEN secret as
+# described in docs/dev/dependents.md.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log intended actions without calling the GitHub API"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: notify-dependents-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Notify dependent repositories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: python -m pip install --quiet pyyaml
+
+      - name: Fan out to dependents
+        env:
+          GH_TOKEN: ${{ secrets.DEPENDENTS_DISPATCH_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          SOURCE_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # workflow_dispatch defaults to a dry run so it is safe to test by hand;
+          # a real release always runs live.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: python .github/scripts/notify_dependents.py

--- a/README.md
+++ b/README.md
@@ -265,6 +265,11 @@ pip install discopt-doe
 discopt doe --help          # the plugin's verbs are now under the `discopt` CLI
 ```
 
+Dependent packages are tracked in
+[`.github/dependents.yml`](.github/dependents.yml); each discopt release
+automatically re-runs their CI and opens a review issue so breakage surfaces
+early (see [docs/dev/dependents.md](docs/dev/dependents.md)).
+
 ## Command-Line Interface
 
 After installation, the `discopt` command is available on your PATH:

--- a/README.md
+++ b/README.md
@@ -270,6 +270,15 @@ Dependent packages are tracked in
 automatically re-runs their CI and opens a review issue so breakage surfaces
 early (see [docs/dev/dependents.md](docs/dev/dependents.md)).
 
+**Writing a plugin?** You can have discopt automatically exercise your package
+against every new core release. Ask to be added to
+[`.github/dependents.yml`](.github/dependents.yml), and copy
+[`.github/dependent-ci-template.yml`](.github/dependent-ci-template.yml) into
+your repo as `.github/workflows/discopt-integration.yml` — it listens for the
+`discopt-updated` dispatch and runs your tests against discopt `main` (with a
+weekly fallback), so you find out immediately if a discopt release breaks you.
+Details in [docs/dev/dependents.md](docs/dev/dependents.md).
+
 ## Command-Line Interface
 
 After installation, the `discopt` command is available on your PATH:

--- a/docs/dev/dependents.md
+++ b/docs/dev/dependents.md
@@ -1,0 +1,82 @@
+# Tracking dependent packages (issue #414)
+
+As application/teaching code moves out of the core into satellite packages
+(`discopt-doe`, `discopt-mkm`, `discopt-aggregation`, `discopt-apps`,
+`discopt-course`, …), we need to (1) keep a single source of truth for **what
+depends on discopt**, and (2) find out when a discopt change **breaks** one of
+those dependents. This page describes the mechanism.
+
+## Components
+
+| File | Role |
+|---|---|
+| [`.github/dependents.yml`](../../.github/dependents.yml) | Machine-readable registry of dependent repos (the source of truth, incl. private repos). |
+| [`.github/scripts/notify_dependents.py`](../../.github/scripts/notify_dependents.py) | Reads the registry and, per dependent, sends a `repository_dispatch` and/or opens a review issue. |
+| [`.github/workflows/notify-dependents.yml`](../../.github/workflows/notify-dependents.yml) | Runs the script on every published release (and manually, as a dry run). |
+| [`.github/dependent-ci-template.yml`](../../.github/dependent-ci-template.yml) | Template each dependent copies in to receive the dispatch and run its tests. |
+
+## How it works
+
+On a **published discopt release**, `notify-dependents.yml` runs the script,
+which for each entry in `dependents.yml`:
+
+- **`dispatch: true`** → sends a `repository_dispatch` event (type
+  `discopt-updated`) to the dependent. The dependent's
+  `discopt-integration.yml` workflow (from the template) catches it, installs
+  discopt from `main`, and runs the dependent's own test suite. Breakage shows
+  up in the dependent's Actions tab.
+- **`notify: true`** → opens a *"Review / update against discopt vX.Y.Z"* issue
+  in the dependent (deduplicated: it won't reopen one that already exists),
+  so the update is tracked.
+
+Releases (not every push) are the trigger, to keep per-push noise out of the
+dependents' issue trackers while still catching every shipped change.
+
+## One-time setup: the dispatch token
+
+The default `GITHUB_TOKEN` in Actions is scoped to the current repo and
+**cannot** dispatch to or open issues in other repos. You must provide a token
+with cross-repo access as the `DEPENDENTS_DISPATCH_TOKEN` secret on
+`jkitchin/discopt`.
+
+**Fine-grained personal access token (quickest):**
+
+1. GitHub → Settings → Developer settings → Fine-grained tokens → *Generate new
+   token*.
+2. Resource owner: `jkitchin`. Repository access: *Only select repositories* →
+   pick every repo listed in `dependents.yml` (public **and** private).
+3. Repository permissions:
+   - **Contents: Read and write** (required to send `repository_dispatch`).
+   - **Issues: Read and write** (required to open review issues).
+4. Copy the token, then add it at `jkitchin/discopt` → Settings → Secrets and
+   variables → Actions → *New repository secret* named
+   `DEPENDENTS_DISPATCH_TOKEN`.
+
+A GitHub App installed on the dependents is a cleaner long-term alternative
+(not tied to a personal account); the workflow only needs the resulting token
+in the same secret.
+
+If the secret is absent, a real release run fails loudly with a clear error
+rather than silently skipping dependents.
+
+## Adding / onboarding a dependent
+
+1. Add an entry to `.github/dependents.yml`:
+   ```yaml
+     - repo: jkitchin/discopt-newthing
+       private: false      # true if the repo is private
+       dispatch: true      # run its CI on discopt release
+       notify: true        # open a review issue on discopt release
+   ```
+2. If the token is a fine-grained PAT scoped to *selected* repos, add the new
+   repo to that token's repository access list.
+3. In the dependent repo, copy `.github/dependent-ci-template.yml` to
+   `.github/workflows/discopt-integration.yml` and adjust its install/test
+   steps to that package's layout.
+
+## Testing without a release
+
+Run the **Notify dependents** workflow manually
+(`Actions → Notify dependents → Run workflow`). It defaults to `dry_run: true`,
+which logs exactly what it *would* do (dispatch / open issue) per dependent in
+the run summary, without calling the write APIs.

--- a/docs/dev/dependents.md
+++ b/docs/dev/dependents.md
@@ -69,7 +69,16 @@ rather than silently skipping dependents.
        notify: true        # open a review issue on discopt release
    ```
 2. If the token is a fine-grained PAT scoped to *selected* repos, add the new
-   repo to that token's repository access list.
+   repo to that token's repository access list (edit the existing token in
+   place at GitHub → Settings → Developer settings → Fine-grained tokens — no
+   need to regenerate it or update the `DEPENDENTS_DISPATCH_TOKEN` secret; the
+   same token value keeps working). If you forget, only the new repo is skipped
+   (with a warning) on the next release; the others still notify.
+
+   > **Tip:** to skip this step forever, scope the token to *All repositories*
+   > instead of selected ones. Then any repo added to `dependents.yml` just
+   > works, at the cost of granting the token Contents + Issues write across all
+   > your repos rather than only the listed plugins.
 3. In the dependent repo, copy `.github/dependent-ci-template.yml` to
    `.github/workflows/discopt-integration.yml` and adjust its install/test
    steps to that package's layout.

--- a/python/tests/test_notify_dependents.py
+++ b/python/tests/test_notify_dependents.py
@@ -1,0 +1,100 @@
+"""Unit tests for the dependents notification script (issue #414).
+
+Covers the pure manifest/payload logic in ``.github/scripts/notify_dependents.py``
+and asserts it stays in sync with the checked-in ``.github/dependents.yml``.
+No network is touched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "notify_dependents.py"
+MANIFEST = REPO_ROOT / ".github" / "dependents.yml"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("notify_dependents", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclass introspection can resolve the module.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+nd = _load_module()
+
+
+def test_parse_manifest_applies_defaults():
+    deps = nd.parse_manifest(
+        """
+        dependents:
+          - repo: owner/only-repo
+          - repo: owner/full
+            private: true
+            dispatch: false
+            notify: false
+            event_type: custom-event
+        """
+    )
+    assert len(deps) == 2
+    d0, d1 = deps
+    assert d0.repo == "owner/only-repo"
+    assert d0.private is False
+    assert d0.dispatch is True and d0.notify is True
+    assert d0.event_type == nd.DEFAULT_EVENT_TYPE
+    assert d1.private is True
+    assert d1.dispatch is False and d1.notify is False
+    assert d1.event_type == "custom-event"
+
+
+def test_parse_manifest_empty_list():
+    assert nd.parse_manifest("dependents: []") == []
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "not_a_mapping",
+        "other_key: 1",  # missing 'dependents'
+        "dependents:\n  - private: true",  # missing 'repo'
+        "dependents:\n  - repo: no-slash",  # malformed repo
+        "dependents:\n  - repo: too/many/slashes",
+    ],
+)
+def test_parse_manifest_rejects_malformed(text):
+    with pytest.raises(ValueError):
+        nd.parse_manifest(text)
+
+
+def test_dispatch_payload_shape():
+    payload = nd.dispatch_payload("jkitchin/discopt", "v1.2.3", "https://rel", "https://run")
+    assert payload["source"] == "jkitchin/discopt"
+    assert payload["release_tag"] == "v1.2.3"
+    assert payload["release_url"] == "https://rel"
+    assert payload["run_url"] == "https://run"
+
+
+def test_issue_title_and_body():
+    assert nd.issue_title("v1.2.3") == "Review / update against discopt v1.2.3"
+    body = nd.issue_body("jkitchin/discopt", "v1.2.3", "https://rel", "https://run")
+    assert "v1.2.3" in body
+    assert "https://rel" in body
+    assert "https://run" in body
+    assert "#414" in body
+
+
+def test_checked_in_manifest_parses():
+    deps = nd.parse_manifest(MANIFEST.read_text(encoding="utf-8"))
+    assert deps, "dependents.yml should list at least one dependent"
+    repos = {d.repo for d in deps}
+    # The repos named in issue #414 must be tracked.
+    assert {"jkitchin/discopt-doe", "jkitchin/discopt-mkm", "jkitchin/discopt-aggregation"} <= repos
+    for d in deps:
+        assert d.repo.count("/") == 1


### PR DESCRIPTION
Add a mechanism to track packages that depend on discopt and exercise
them when discopt changes, so plugin breakage surfaces early.

- .github/dependents.yml: machine-readable registry of dependent repos
  (source of truth, includes private repos not listed in the README).
- .github/scripts/notify_dependents.py: on release, sends a
  repository_dispatch to each dependent (re-runs its CI against the new
  discopt) and opens a deduplicated "review / update" tracking issue.
- .github/workflows/notify-dependents.yml: runs the script on published
  releases; manual runs default to a dry run.
- .github/dependent-ci-template.yml: drop-in receiver workflow for
  dependent repos listening for the discopt-updated dispatch.
- docs/dev/dependents.md: mechanism + one-time DEPENDENTS_DISPATCH_TOKEN
  setup + onboarding steps.
- python/tests/test_notify_dependents.py: unit tests for manifest parsing,
  payload/issue building, and that the checked-in registry stays valid.
- README: point to the registry from the Plugins section.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EBCviS7nznvmtpLztiEXEa