### PR TITLE
fix(bench): report BARON solved vs certified-claim separately (stop undercounting BARON ~2x)

### DIFF
--- a/discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py
+++ b/discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py
@@ -548,6 +548,17 @@ def write_report(rows: list[Row], tl: float, out_dir: Path, ts: str) -> Path:
     b = tally(lambda r: r.b_verdict)
     n_oracle = sum(r.known is not None for r in rows)
 
+    # "Certified-global CLAIM" = the solver asserted a proven global (discopt
+    # ``optimal``; BARON/GAMS ``1 Optimal``). This is DISTINCT from "solved
+    # correctly" (``ok`` = objective matches the oracle). The two diverge sharply
+    # for BARON: GAMS returns ``2 Locally Optimal`` / ``8 Integer Solution`` on
+    # many instances BARON has in fact solved to the global optimum, so the
+    # status-based claim count SYSTEMATICALLY UNDERCOUNTS BARON (measured ~2x on a
+    # 200-instance panel: 97 claims vs 179 objective-correct). Rank capability by
+    # ``ok`` (+``gap`` for "found something"), NEVER by the certified-claim count.
+    d_cert = sum(_claims_global(r.discopt.status) for r in rows)
+    b_cert = sum(_claims_global(r.baron.status) for r in rows)
+
     # G4 (baron-gap-plan §6): the three wall ratios. ``wall/baron`` is the
     # historical number (charges discopt the fresh-process import floor);
     # ``solve/baron`` excludes the floor (pure engine time); a --via-daemon run's
@@ -608,6 +619,16 @@ def write_report(rows: list[Row], tl: float, out_dir: Path, ts: str) -> Path:
         f"gap {d[GAP]}  ·  n/a {d[NA]}",
         f"- **BARON   — VIOLATIONS: {b[VIOLATION]}**  ·  ok {b[OK]}  ·  "
         f"gap {b[GAP]}  ·  n/a {b[NA]}",
+        "",
+        "### Solved vs certified-claim (score capability by *solved*)",
+        "",
+        f"- **Solved correctly** (objective matches oracle — the fair capability "
+        f"metric): discopt **{d[OK]}**  ·  BARON **{b[OK]}**",
+        f"- Certified-global *claim* (status only): discopt {d_cert}  ·  "
+        f"BARON {b_cert}",
+        "> BARON-via-GAMS reports `2 Locally Optimal` / `8 Integer Solution` on "
+        "many instances it has solved to the global optimum, so its *claim* count "
+        "undercounts it (~2x). **Rank by *solved* (`ok`), not by the claim count.**",
         "",
         (
             "> ✅ **Zero discopt correctness violations.**"


### PR DESCRIPTION
## Summary

The BARON head-to-head report already scores capability correctly by `ok` (objective matches the oracle). But BARON-via-GAMS returns model status **`2 Locally Optimal`** / **`8 Integer Solution`** on many instances it has in fact solved to the global optimum — so a *status-based* "certified" count undercounts BARON by ~2×. On a 200-instance panel: **97 status-claims vs 179 objective-correct**. Reading the status column (or synthesizing a cross-solver comparison) invites the wrong conclusion that BARON is far behind SCIP, when in reality **BARON ≈ SCIP** on solve rate.

## Change

Adds a **"Solved vs certified-claim"** section to the report:
- **Solved correctly** (objective-vs-oracle — the fair capability metric): discopt N · BARON M
- Certified-global *claim* (status only): discopt N · BARON M
- A note: BARON's GAMS status undercounts its certification ~2×; **rank by *solved* (`ok`), never by the claim count.**

No change to correctness verdicts or VIOLATION detection — purely a reporting clarification so future runs (and readers) don't conflate the two.

## Verification

Tested on 4 instances (alan = GAMS "1 Optimal"; st_e11/chance/dispatch = GAMS "2 Locally Optimal" but all solved correctly):
```
- Solved correctly: discopt 4 · BARON 4
- Certified-global claim (status only): discopt 4 · BARON 1
```
The report now makes the ~2× undercount explicit. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
