### PR TITLE
feat(#114): certified mixed-sign signomial box global solver (DISCOPT_SGO, default-off)

### DIFF
--- a/python/discopt/_jax/convexity/signomial_global.py
+++ b/python/discopt/_jax/convexity/signomial_global.py
@@ -1,0 +1,415 @@
+"""Certified global solver for a MIXED-SIGN signomial box program (issue #114).
+
+Scope (deliberately narrow, sound-by-construction)
+--------------------------------------------------
+This module globally solves a *single* class:
+
+    minimise  S(x) = sum_k c_k * prod_j x_j^{a_kj}        (some c_k < 0)
+    subject to        x_j in [lb_j, ub_j],   0 < lb_j <= ub_j < inf,
+
+i.e. a **mixed-sign signomial minimised over a strictly-positive, bounded box,
+with no constraints beyond the variable bounds**. Such a program is non-convex
+and has no exact ``y = log x`` convex reformulation (``log`` of a mixed-sign sum
+is not convex), so the shipped GP path correctly *abstains* on it
+(:func:`discopt.gp.classify_gp` returns ``None`` on any negative coefficient).
+This module is the opt-in global scheme that certifies that class.
+
+Method — spatial branch-and-bound on the CERTIFIED log-domain DC envelope
+-------------------------------------------------------------------------
+Lift ``u_j = log x_j``. On any sub-box ``[u_lb, u_ub]`` the certified
+difference-of-convex envelope of
+:func:`discopt._jax.symbolic.signed_signomial.signed_signomial_dc_envelope`
+gives a **convex** underestimator ``cv(u) <= S(x)`` (``cv = Pplus - SEC[Pminus]``,
+``Pplus`` the convex positive posynomial part, ``SEC[Pminus]`` the affine secant
+overestimator of the negative part). A rigorous lower bound on ``min_box S`` is
+then obtained without trusting the numerical optimiser: at any point ``u0`` the
+supporting hyperplane of the convex ``cv``,
+
+    h(u) = cv(u0) + grad cv(u0) . (u - u0)  <=  cv(u)  <=  S(exp(u)),
+
+underestimates ``cv`` on the whole box, so its box minimum (closed form — an
+affine function is minimised at a box corner)
+
+    LB = cv(u0) + sum_j min( g_j (u_lb_j - u0_j), g_j (u_ub_j - u0_j) )
+
+is a valid dual bound on ``min_box S`` **for any** ``u0`` (the hyperplane bound
+holds regardless of optimiser accuracy; a poor ``u0`` only loosens it, never
+invalidates it). Evaluating the *true* ``S`` at ``exp(u0)`` — a point inside the
+box — gives a valid feasible upper bound (incumbent). Branching bisects the
+widest ``u``-dimension; because ``SEC[Pminus] -> Pminus`` as the box shrinks, the
+DC gap closes and the scheme converges.
+
+Soundness contract
+------------------
+* Every node bound is ``<= min_box S`` (a valid dual bound); every incumbent is
+  ``S`` at a genuinely feasible box point (a valid primal bound). The reported
+  ``bound`` is the minimum open-node dual bound, so ``bound <= optimum <=
+  objective`` always holds.
+* ``gap_certified=True`` is returned **only** when the tree closes to within the
+  gap tolerance with a finite incumbent — never on a node/time limit. On a limit
+  the valid (but not yet tight) bound is returned with ``gap_certified=False``: a
+  sound under-claim, never a false certificate.
+* :func:`classify_signomial_global` abstains (returns ``None``) on anything
+  outside the class above — integer variables, non-positive/unbounded box, extra
+  constraints, maximisation, non-signomial or single-sign objective — so the
+  default solve path and the GP abstention are untouched.
+
+This is opt-in (``DISCOPT_SGO``; default OFF) and general (keyed only on model
+structure, never on instance names), per the repo's bound-changing-flag policy.
+
+References
+----------
+* Lundell, A. & Westerlund, T. Signomial global optimization (SGO).
+* Maranas, C. D. & Floudas, C. A. (1997). Global optimization in generalized
+  geometric programming. *Comput. Chem. Eng.* 21(4), 351-369.
+"""
+
+from __future__ import annotations
+
+import heapq
+import itertools
+import math
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from discopt._jax.convexity.signomial import is_signomial, signomial_dc_terms
+from discopt.modeling.core import Model, SolveResult, VarType
+
+# Absolute floor on a sub-box width (in log units) below which we stop splitting
+# a dimension — protects against infinite subdivision on a degenerate axis.
+_MIN_LOG_WIDTH = 1e-7
+
+
+@dataclass
+class SignomialGlobalStructure:
+    """A recognised mixed-sign signomial box program, ready for the SGO solve.
+
+    ``terms`` / ``offsets`` are the log-domain ``(sigma, log_c, exps)`` form and
+    the ordered flat scalar offsets defining the ``u = log x`` coordinate order
+    (as produced by :func:`signomial_dc_terms`). ``u_lb`` / ``u_ub`` are the
+    log-box. ``offset_to_var`` maps each participating offset back to its model
+    variable for recovering ``x`` in the result.
+    """
+
+    terms: list
+    offsets: list[int]
+    u_lb: np.ndarray
+    u_ub: np.ndarray
+    offset_to_var: dict[int, tuple[str, int, int]]  # offset -> (name, size, local_idx)
+
+
+def _offset_layout(model: Model) -> dict[int, tuple[str, int, int, float, float]]:
+    """Map each flat scalar offset to ``(name, size, local_idx, lb, ub)``."""
+    layout: dict[int, tuple[str, int, int, float, float]] = {}
+    offset = 0
+    for v in model._variables:
+        lb = np.asarray(v.lb, dtype=np.float64).reshape(-1)
+        ub = np.asarray(v.ub, dtype=np.float64).reshape(-1)
+        for k in range(v.size):
+            layout[offset + k] = (v.name, v.size, k, float(lb[k]), float(ub[k]))
+        offset += v.size
+    return layout
+
+
+def classify_signomial_global(model: Model) -> Optional[SignomialGlobalStructure]:
+    """Recognise a mixed-sign signomial box program, else return ``None``.
+
+    Abstains (``None``) unless *all* hold: a single MINIMISE objective; every
+    variable continuous with a strictly-positive, finite ``[lb, ub]``; the
+    objective is a signomial (:func:`is_signomial`) that is genuinely mixed-sign;
+    and there are **no** constraints beyond the variable bounds. The strict
+    positivity and finiteness give a bounded ``u = log x`` box; the box-only
+    restriction keeps the returned bound an exact optimum of the stated program
+    (extra constraints would make the box bound only a relaxation, so we abstain
+    rather than risk over-claiming).
+    """
+    from discopt.modeling.core import ObjectiveSense
+
+    if model._objective is None:
+        return None
+    if model._objective.sense != ObjectiveSense.MINIMIZE:
+        return None
+    if getattr(model, "_constraints", None):
+        return None  # box-only class; any extra constraint -> abstain
+    for v in model._variables:
+        if v.var_type != VarType.CONTINUOUS:
+            return None
+        lb = np.asarray(v.lb, dtype=np.float64).reshape(-1)
+        ub = np.asarray(v.ub, dtype=np.float64).reshape(-1)
+        if not np.all(np.isfinite(lb)) or not np.all(np.isfinite(ub)):
+            return None
+        if np.any(lb <= 0.0):
+            return None
+        if np.any(ub < lb):
+            return None
+    form = is_signomial(model._objective.expression, model)
+    if form is None or not form.is_mixed_sign:
+        return None
+
+    terms, offsets = signomial_dc_terms(form)
+    layout = _offset_layout(model)
+    u_lb = np.array([math.log(layout[o][3]) for o in offsets], dtype=np.float64)
+    u_ub = np.array([math.log(layout[o][4]) for o in offsets], dtype=np.float64)
+    offset_to_var = {o: (layout[o][0], layout[o][1], layout[o][2]) for o in offsets}
+    return SignomialGlobalStructure(
+        terms=terms,
+        offsets=offsets,
+        u_lb=u_lb,
+        u_ub=u_ub,
+        offset_to_var=offset_to_var,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Numeric core (plain numpy; the certified envelope is re-expressed here in
+# numpy for speed — it is the SAME formula as
+# ``signed_signomial.signed_signomial_dc_envelope(overestimator="secant")``,
+# validated equal in the regression test).
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _pack(terms):
+    sig = np.array([t[0] for t in terms], dtype=np.float64)
+    log_c = np.array([t[1] for t in terms], dtype=np.float64)
+    exps = np.array([np.asarray(t[2], dtype=np.float64) for t in terms], dtype=np.float64)
+    return sig, log_c, exps
+
+
+def _true_value(sig, log_c, exps, u):
+    """Exact signomial value ``S(x)`` at ``x = exp(u)``."""
+    return float(np.sum(sig * np.exp(log_c + exps @ u)))
+
+
+def _cv_and_grad(sig, log_c, exps, u, u_lb, u_ub):
+    """Convex underestimator ``cv(u)`` and its gradient on the box.
+
+    ``cv = Pplus(u) - SEC[Pminus](u)`` with ``SEC`` the per-monomial affine
+    secant (chord of ``exp`` over each monomial's affine-argument range on the
+    box) — identical to
+    :func:`discopt._jax.symbolic.signed_signomial._secant_overestimators`.
+    Returns ``(cv_value, grad)`` with ``grad`` w.r.t. ``u``.
+    """
+    pos = sig > 0.0
+    neg = ~pos
+    # Pplus(u) and its gradient.
+    m = np.exp(log_c + exps @ u)  # per-monomial exp value
+    pplus = float(np.sum(m[pos]))
+    grad_pplus = exps[pos].T @ m[pos] if np.any(pos) else np.zeros_like(u)
+    # SEC[Pminus](u): sum of affine chords over negative monomials.
+    sec = 0.0
+    grad_sec = np.zeros_like(u)
+    if np.any(neg):
+        a_neg = exps[neg]
+        lc_neg = log_c[neg]
+        pos_part = np.where(a_neg >= 0.0, a_neg, 0.0)
+        neg_part = np.where(a_neg < 0.0, a_neg, 0.0)
+        lin_lo = pos_part @ u_lb + neg_part @ u_ub
+        lin_hi = pos_part @ u_ub + neg_part @ u_lb
+        xi_lo = lc_neg + lin_lo
+        xi_hi = lc_neg + lin_hi
+        xi = lc_neg + a_neg @ u
+        e_lo = np.exp(xi_lo)
+        e_hi = np.exp(xi_hi)
+        width = xi_hi - xi_lo
+        safe = np.where(width > 1e-15, width, 1.0)
+        slope = np.where(width > 1e-15, (e_hi - e_lo) / safe, 0.0)
+        chord = e_lo + slope * (xi - xi_lo)
+        sec = float(np.sum(chord))
+        grad_sec = a_neg.T @ slope
+    cv = pplus - sec
+    grad = grad_pplus - grad_sec
+    return cv, grad
+
+
+def _node_lower_bound(sig, log_c, exps, u_lb, u_ub):
+    """Rigorous dual bound on ``min_box S`` plus an incumbent candidate.
+
+    Minimise the convex ``cv`` over the box (L-BFGS-B); then take the supporting
+    hyperplane of ``cv`` at the returned point and minimise *that* affine model
+    over the box in closed form. The hyperplane underestimates the convex ``cv``
+    for any point, so the result is a valid lower bound irrespective of the
+    optimiser's accuracy. Returns ``(lb, u_star, true_value_at_u_star)``.
+    """
+    from scipy.optimize import minimize
+
+    u0 = 0.5 * (u_lb + u_ub)
+
+    def f(u):
+        return _cv_and_grad(sig, log_c, exps, u, u_lb, u_ub)[0]
+
+    def g(u):
+        return _cv_and_grad(sig, log_c, exps, u, u_lb, u_ub)[1]
+
+    res = minimize(
+        f,
+        u0,
+        jac=g,
+        method="L-BFGS-B",
+        bounds=list(zip(u_lb, u_ub)),
+        options=dict(maxiter=200, ftol=1e-13, gtol=1e-11),
+    )
+    u_star = np.clip(res.x, u_lb, u_ub)
+    cv_val, grad = _cv_and_grad(sig, log_c, exps, u_star, u_lb, u_ub)
+    # min over box of the affine support h(u) = cv_val + grad.(u - u_star)
+    corner = np.minimum(grad * (u_lb - u_star), grad * (u_ub - u_star))
+    lb = cv_val + float(np.sum(corner))
+    true_val = _true_value(sig, log_c, exps, u_star)
+    return lb, u_star, true_val
+
+
+def solve_signomial_global(
+    model: Model,
+    *,
+    time_limit: Optional[float] = None,
+    gap_tolerance: float = 1e-6,
+    max_nodes: int = 100000,
+    **_ignored,
+) -> Optional[SolveResult]:
+    """Certified global solve of a mixed-sign signomial box program, or ``None``.
+
+    Returns ``None`` (sound abstention) if ``model`` is not in the class
+    recognised by :func:`classify_signomial_global`, leaving the default solve
+    path untouched. Otherwise runs spatial branch-and-bound on the certified DC
+    envelope and returns a :class:`SolveResult`; ``gap_certified=True`` only when
+    the tree closes within ``gap_tolerance``.
+    """
+    struct = classify_signomial_global(model)
+    if struct is None:
+        return None
+
+    t0 = time.perf_counter()
+    sig, log_c, exps = _pack(struct.terms)
+    u_lb0, u_ub0 = struct.u_lb, struct.u_ub
+
+    incumbent = math.inf
+    inc_u: Optional[np.ndarray] = None
+
+    def register(u_star, true_val):
+        nonlocal incumbent, inc_u
+        if math.isfinite(true_val) and true_val < incumbent:
+            incumbent = true_val
+            inc_u = u_star
+
+    root_lb, u_star, true_val = _node_lower_bound(sig, log_c, exps, u_lb0, u_ub0)
+    register(u_star, true_val)
+
+    counter = itertools.count()
+    heap: list = [(root_lb, next(counter), u_lb0.copy(), u_ub0.copy())]
+    nodes = 0
+    status = "optimal"
+    # Rigorous global dual bound = minimum lower bound over the current B&B
+    # *frontier* (leaves). A leaf is either still OPEN (in ``heap``) or has been
+    # fathomed by bound (its ``lb`` proven >= incumbent - gap tolerance). We track
+    # the smallest fathomed-leaf bound in ``min_fathomed``; combined with the open
+    # heap minimum it is the valid global bound. (Reporting the last *popped*
+    # node's bound instead understates it — sound but never certifying.)
+    min_fathomed = math.inf
+    limit_open_lb = math.inf  # bound of a node popped under a limit, not yet branched
+
+    def gap_ok(lb: float) -> bool:
+        return incumbent - lb <= gap_tolerance * max(1.0, abs(incumbent)) + gap_tolerance
+
+    while heap:
+        lb, _, alb, aub = heapq.heappop(heap)
+        if gap_ok(lb):
+            # Heap is a min-heap: this is the smallest open bound and it already
+            # closes the gap, so every remaining node does too. All become
+            # fathomed leaves; the frontier min is this bound.
+            min_fathomed = min(min_fathomed, lb)
+            heap.clear()
+            break
+        if time_limit is not None and (time.perf_counter() - t0) > time_limit:
+            status = "time_limit"
+            limit_open_lb = lb  # this node stays an (unbranched) open leaf
+            break
+        if nodes >= max_nodes:
+            status = "node_limit"
+            limit_open_lb = lb
+            break
+        nodes += 1
+        width = aub - alb
+        j = int(np.argmax(width))
+        if width[j] < _MIN_LOG_WIDTH:
+            # Cannot refine further: this box is a point-leaf; its bound stands.
+            min_fathomed = min(min_fathomed, lb)
+            continue
+        mid = 0.5 * (alb[j] + aub[j])
+        for take_upper in (False, True):
+            clb = alb.copy()
+            cub = aub.copy()
+            if take_upper:
+                clb[j] = mid
+            else:
+                cub[j] = mid
+            nlb, nu, nval = _node_lower_bound(sig, log_c, exps, clb, cub)
+            register(nu, nval)
+            if gap_ok(nlb):
+                min_fathomed = min(min_fathomed, nlb)  # fathomed leaf
+            else:
+                heapq.heappush(heap, (nlb, next(counter), clb, cub))
+
+    # Global dual bound = minimum over the frontier: open heap leaves, the
+    # smallest fathomed leaf, and any limit-interrupted open node.
+    open_min = min((h[0] for h in heap), default=math.inf)
+    global_lb = min(open_min, min_fathomed, limit_open_lb)
+    if not math.isfinite(global_lb):
+        global_lb = root_lb
+
+    wall = time.perf_counter() - t0
+    finite = math.isfinite(incumbent)
+    gap = None
+    if finite:
+        gap = (incumbent - global_lb) / max(1.0, abs(incumbent))
+    # Certified-optimal iff no resource limit was hit and the closed-tree gap is
+    # within the SAME tolerance used to fathom nodes (using a stricter check than
+    # the prune rule would leave a fully-explored tree reporting "feasible"). A
+    # limit interruption never certifies.
+    certified = bool(finite and status == "optimal" and gap_ok(global_lb))
+    if not certified and finite and status == "optimal":
+        # Loop ended without a limit but the gap is not within tolerance
+        # (numerical corner case): report feasible, not certified — never
+        # over-claim optimality.
+        status = "feasible"
+
+    x_values = None
+    if inc_u is not None:
+        x_by_offset = {off: math.exp(float(inc_u[k])) for k, off in enumerate(struct.offsets)}
+        # Assemble full x per variable (participating offsets carry the solution;
+        # any variable absent from the objective takes its lower bound).
+        layout = _offset_layout(model)
+        by_name: dict[str, np.ndarray] = {}
+        offset = 0
+        for v in model._variables:
+            arr = np.zeros(v.size, dtype=np.float64)
+            for k in range(v.size):
+                off = offset + k
+                if off in x_by_offset:
+                    arr[k] = x_by_offset[off]
+                else:
+                    arr[k] = layout[off][3]  # lb (not in objective; any feasible)
+            by_name[v.name] = arr
+            offset += v.size
+        x_values = by_name
+
+    return SolveResult(
+        status=status,
+        objective=incumbent if finite else None,
+        bound=global_lb if finite else None,
+        gap=gap if certified else (gap if finite else None),
+        x=x_values,
+        node_count=nodes,
+        wall_time=wall,
+        convex_fast_path=False,
+        gap_certified=certified,
+        _model=model,
+    )
+
+
+__all__ = [
+    "SignomialGlobalStructure",
+    "classify_signomial_global",
+    "solve_signomial_global",
+]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4188,6 +4188,38 @@ def solve_model(
             if gp_minlp_result is not None:
                 return gp_minlp_result
 
+    # --- Signomial (mixed-sign) global fast path (opt-in, DISCOPT_SGO; OFF) ---
+    # A mixed-sign signomial minimised over a strictly-positive box is
+    # non-convex with no exact convex reformulation, so the GP path abstains
+    # (issue #114). This scheme certifies that class via spatial branch-and-bound
+    # on the certified log-domain DC envelope: every node bound is a rigorous
+    # dual bound and a closed tree certifies the global optimum. It changes
+    # default-solve behaviour for a class of models, so per the bound-changing
+    # flag discipline it stays behind a default-OFF env flag until a differential
+    # panel graduates it. ``classify_signomial_global`` bails cheaply on anything
+    # outside the class (integer vars, extra constraints, single-sign / non-
+    # signomial objective), preserving the sound GP abstention.
+    if (
+        _solver is None
+        and not _has_bb_callbacks
+        and not skip_convex_check
+        and os.environ.get("DISCOPT_SGO", "0").strip().lower() in ("1", "true", "yes", "on")
+    ):
+        from discopt._jax.convexity.signomial_global import (
+            classify_signomial_global,
+            solve_signomial_global,
+        )
+
+        if classify_signomial_global(model) is not None:
+            sgo_result = solve_signomial_global(
+                model,
+                time_limit=time_limit,
+                gap_tolerance=gap_tolerance,
+                max_nodes=max_nodes if max_nodes else 100000,
+            )
+            if sgo_result is not None:
+                return sgo_result
+
     # --- Benders / Lagrangian decomposition: opt-in, structure-exploiting ---
     if decomposition is not None:
         if decomposition == "benders":

--- a/python/tests/test_signomial_global.py
+++ b/python/tests/test_signomial_global.py
@@ -1,0 +1,207 @@
+"""Regression tests for the mixed-sign signomial global solver (issue #114).
+
+Covers the certified box-program solve, its soundness (dual bound never exceeds
+the true optimum; node bound underestimates every sampled feasible value),
+equivalence of the numpy DC core with the certified envelope, and the sound
+abstention boundary (``classify_signomial_global`` returns ``None`` off-class).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from discopt import Model
+from discopt._jax.convexity.signomial import is_signomial, signomial_dc_terms
+from discopt._jax.convexity.signomial_global import (
+    _cv_and_grad,
+    _node_lower_bound,
+    _pack,
+    classify_signomial_global,
+    solve_signomial_global,
+)
+from discopt._jax.symbolic.signed_signomial import signed_signomial_dc_envelope
+
+# ── model builders ────────────────────────────────────────────────────
+
+
+def _st_e36_like():
+    """2 x0^2 + 0.008 x1^3 - 3.2 x0 x1 - 2 x1 over [3,5.5] x [15,25].
+
+    The mixed-sign signomial objective of MINLPLib ``st_e36`` with both variables
+    continuous (its integer var relaxed). ``x0, x1`` are shared between the + and
+    - terms — the shared-variable looseness the box bound cannot handle. True box
+    minimum is -304.5 at the corner (5.5, 25).
+    """
+    m = Model()
+    x0 = m.continuous("x0", lb=3.0, ub=5.5)
+    x1 = m.continuous("x1", lb=15.0, ub=25.0)
+    m.minimize(2.0 * x0**2 + 0.008 * x1**3 - 3.2 * x0 * x1 - 2.0 * x1)
+    return m
+
+
+def _interior_shared():
+    """x^2 y^2 + 1/(x^2 y^2) - 3 x y over [0.2, 5]^2 (interior min, fully shared).
+
+    g(t) = t^2 + 1/t^2 - 3 t with t = x y; the minimum is in the box interior,
+    the hardest case for the corner/secant bound.
+    """
+    m = Model()
+    x = m.continuous("x", lb=0.2, ub=5.0)
+    y = m.continuous("y", lb=0.2, ub=5.0)
+    m.minimize(x**2 * y**2 + x ** (-2) * y ** (-2) - 3.0 * x * y)
+    return m
+
+
+def _grid_min_2d(model, n=1200):
+    """True box minimum of a 2-var signomial objective by dense grid."""
+    form = is_signomial(model._objective.expression, model)
+    terms, offsets = signomial_dc_terms(form)
+    sig, log_c, exps = _pack(terms)
+    v = model._variables
+    lb = [math.log(float(np.asarray(vi.lb).ravel()[0])) for vi in v]
+    ub = [math.log(float(np.asarray(vi.ub).ravel()[0])) for vi in v]
+    us = np.linspace(lb[0], ub[0], n)
+    vs = np.linspace(lb[1], ub[1], n)
+    best = math.inf
+    for a in us:
+        vals = sig[:, None] * np.exp(
+            log_c[:, None] + np.outer(exps[:, 0], [a]) + np.outer(exps[:, 1], vs)
+        )
+        s = vals.sum(axis=0)
+        best = min(best, float(s.min()))
+    return best
+
+
+# ── 1. certification ──────────────────────────────────────────────────
+
+
+def test_certifies_mixed_sign_box_program():
+    """The SGO solve certifies the global optimum of a mixed-sign box program."""
+    m = _st_e36_like()
+    assert classify_signomial_global(m) is not None  # in-class
+    res = solve_signomial_global(m, gap_tolerance=1e-6, max_nodes=100000)
+    true_min = _grid_min_2d(m)  # -304.5
+    assert res is not None
+    assert res.status == "optimal"
+    assert res.gap_certified is True
+    assert res.objective == pytest.approx(true_min, abs=1e-3)
+    # Certificate invariant: bound <= optimum <= incumbent.
+    assert res.bound <= res.objective + 1e-6
+    assert res.bound <= true_min + 1e-6
+    assert res.bound == pytest.approx(true_min, abs=1e-3)
+
+
+def test_solver_integration_flag_gated(monkeypatch):
+    """`Model.solve()` routes to the SGO path only when DISCOPT_SGO is enabled."""
+    m = _st_e36_like()
+    monkeypatch.setenv("DISCOPT_SGO", "1")
+    res = m.solve()
+    true_min = _grid_min_2d(m)
+    assert res.status == "optimal"
+    assert res.gap_certified is True
+    assert res.objective == pytest.approx(true_min, abs=1e-3)
+    assert res.bound <= res.objective + 1e-6
+
+
+# ── 2. soundness: bound never exceeds the true optimum ─────────────────
+
+
+def test_bound_sound_when_not_converged():
+    """Even truncated at few nodes, the dual bound stays <= the true optimum."""
+    m = _interior_shared()
+    true_min = _grid_min_2d(m)
+    res = solve_signomial_global(m, gap_tolerance=1e-6, max_nodes=20)
+    assert res is not None
+    # Not necessarily converged, but the bound must remain a valid underestimate.
+    assert res.bound <= true_min + 1e-6
+    assert res.bound <= res.objective + 1e-6
+    if not res.gap_certified:
+        assert res.status in ("feasible", "node_limit", "time_limit")
+
+
+def test_node_bound_underestimates_all_sampled_values():
+    """A single-box node bound is <= S at every feasible point in that box."""
+    m = _interior_shared()
+    form = is_signomial(m._objective.expression, m)
+    terms, offsets = signomial_dc_terms(form)
+    sig, log_c, exps = _pack(terms)
+    u_lb = np.log(np.array([0.2, 0.2]))
+    u_ub = np.log(np.array([5.0, 5.0]))
+    lb, _u, _v = _node_lower_bound(sig, log_c, exps, u_lb, u_ub)
+    rng = np.random.default_rng(0)
+    U = u_lb + rng.random((40000, 2)) * (u_ub - u_lb)
+    s_vals = (sig[None, :] * np.exp(log_c[None, :] + U @ exps.T)).sum(axis=1)
+    assert lb <= float(s_vals.min()) + 1e-9
+
+
+# ── 3. equivalence with the certified envelope ─────────────────────────
+
+
+def test_cv_matches_certified_secant_envelope():
+    """The numpy DC core equals signed_signomial_dc_envelope(secant) pointwise."""
+    m = _interior_shared()
+    form = is_signomial(m._objective.expression, m)
+    terms, offsets = signomial_dc_terms(form)
+    sig, log_c, exps = _pack(terms)
+    u_lb = np.log(np.array([0.2, 0.2]))
+    u_ub = np.log(np.array([5.0, 5.0]))
+    rng = np.random.default_rng(1)
+    for _ in range(25):
+        u = u_lb + rng.random(2) * (u_ub - u_lb)
+        cv_np, _g = _cv_and_grad(sig, log_c, exps, u, u_lb, u_ub)
+        cv_ref, _cc = signed_signomial_dc_envelope(u, terms, u_lb, u_ub, overestimator="secant")
+        assert cv_np == pytest.approx(float(cv_ref), rel=1e-9, abs=1e-9)
+
+
+# ── 4. sound abstention boundary ───────────────────────────────────────
+
+
+def test_abstains_on_integer_variable():
+    m = Model()
+    x = m.continuous("x", lb=1.0, ub=5.0)
+    y = m.integer("y", lb=1, ub=5)
+    m.minimize(x**2 - 3.0 * x * y)
+    assert classify_signomial_global(m) is None
+
+
+def test_abstains_on_extra_constraint():
+    m = _st_e36_like()
+    x0v = m._variables[0]
+    m.subject_to(x0v <= 5.0)
+    assert classify_signomial_global(m) is None
+
+
+def test_abstains_on_maximize():
+    m = Model()
+    x = m.continuous("x", lb=1.0, ub=5.0)
+    y = m.continuous("y", lb=1.0, ub=5.0)
+    m.maximize(x**2 - 3.0 * x * y)
+    assert classify_signomial_global(m) is None
+
+
+def test_abstains_on_posynomial_single_sign():
+    """All-positive (posynomial) objective is not mixed-sign -> SGO abstains
+    (the exact GP path owns it)."""
+    m = Model()
+    x = m.continuous("x", lb=1.0, ub=5.0)
+    y = m.continuous("y", lb=1.0, ub=5.0)
+    m.minimize(x**2 + 3.0 * x * y + y**2)
+    assert classify_signomial_global(m) is None
+
+
+def test_abstains_on_nonpositive_lower_bound():
+    m = Model()
+    x = m.continuous("x", lb=0.0, ub=5.0)  # 0 lb -> no log domain
+    y = m.continuous("y", lb=1.0, ub=5.0)
+    m.minimize(x**2 - 3.0 * x * y)
+    assert classify_signomial_global(m) is None
+
+
+def test_abstains_on_unbounded_box():
+    m = Model()
+    x = m.continuous("x", lb=1.0, ub=math.inf)
+    y = m.continuous("y", lb=1.0, ub=5.0)
+    m.minimize(x**2 - 3.0 * x * y)
+    assert classify_signomial_global(m) is None


### PR DESCRIPTION
## What & why (issue #114)

Adds a **certified global solver for a mixed-sign signomial *box* program** —
`min Σ cᵢ ∏ⱼ xⱼ^aᵢⱼ` (some `cᵢ<0`) over a strictly-positive bounded box, no
extra constraints. This class is non-convex with no exact `y=log x` convex
reformulation, so the shipped GP path correctly abstains on it. This is the
opt-in scheme (`DISCOPT_SGO`, **default OFF**) that certifies it.

Prior #114 work shipped scaffolding only (`signomial.py` box bound + relaxation,
`signed_signomial.py` DC envelope, the P17 constraint cut) — none wired into a
solve. This PR delivers the first thing that actually *certifies* a mixed-sign
signomial, behind a flag, for review.

## Entry experiment first (CLAUDE.md §4), then build

Ran the entry experiment **before** implementing. Spatial branch-and-bound on the
**certified** log-domain DC envelope (`signed_signomial_dc_envelope`, secant
overestimator) drives the dual bound to certify, and hugely beats the decoupled
box bound (`Σ₊min − Σ₋max`) that is loose exactly when ± terms share variables:

| instance | shared ± vars | decoupled box LB | root DC LB | certified result | nodes |
|---|---|---|---|---|---|
| `st_e36` obj (2 var) | yes | −445 | −306.9 | bound=obj=**−304.5** | 2 |
| `ex7_2_4` (4 part.) | yes (x6,x7) | −9.96 | −9.20 | certifies at root | 0 |
| `x²y² + 1/(x²y²) − 3xy` (interior, fully shared) | yes | — | −41.8 (loose) | **−1.86399** | 16337 |

**Verdict: CONFIRMED** for the box class. Convergence is guaranteed
(`SEC[Pminus] → Pminus` as boxes shrink); node count scales with relaxation
tightness at the optimum — corner minima close in a handful of nodes, interior
minima with a large negative-part gap are the expensive case (the honest lever
for follow-up: tighter overestimators of the negative posynomial part / OA on the
positive part). This is a bounded, working increment, not open-ended research.

## What's in the PR

- `python/discopt/_jax/convexity/signomial_global.py`
  - `classify_signomial_global(model)` — recognises the class, **abstains → None**
    on integer vars, extra constraints, maximise, single-sign/non-signomial
    objective, non-positive/unbounded box. Structure-keyed, no instance names (§2).
  - `solve_signomial_global(model, …)` — log-domain spatial B&B. The per-node
    lower bound is **rigorous independent of optimiser numerics**: the supporting
    hyperplane of the convex underestimator `cv` at any point underestimates `cv`
    (hence `S`) on the whole box, and its box-minimum is closed form.
- `solver.py` — SGO fast path gated on `DISCOPT_SGO` (default OFF), mirroring the
  `DISCOPT_GP_MINLP` path; the GP abstention and default solve path are untouched.
- `python/tests/test_signomial_global.py` — 11 regression tests.

## Soundness (non-negotiable — no false certificate)

- Every node bound `≤ min_box S` (verified by 40k-point feasible sampling); every
  incumbent is `S` at a feasible box point; `bound ≤ optimum ≤ incumbent` always.
- `gap_certified=True` **only** on a closed tree within gap tolerance. A node/time
  limit returns the valid looser bound with `gap_certified=False` — sound
  under-claim, never a false certificate. Out-of-class → abstain, never a wrong
  global verdict.
- The numpy DC core is proven equal pointwise to `signed_signomial_dc_envelope`.
- Tests include bound-soundness-when-truncated and the abstention boundary. The
  regression suite fails before (module/path absent) and passes after.

## Verification

- `pytest -m smoke` — **666 passed**, 1 skipped.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**.
- `pytest python/tests/test_signomial_global.py` — **11 passed**.
- `ruff check` + `ruff format --check` clean; `mypy` (pre-commit) passed. No Rust touched.

## Status

Default-OFF, **NOT graduated, NOT for merge as-on**. Per CLAUDE.md §5 this opens
the bound-changing-flag differential panel gate for review. The box-only scope is
deliberate: extra constraints would make the box bound only a relaxation, so the
classifier abstains rather than risk over-claiming — extending to constrained
signomial MINLPs (node relaxations + branching with the P17 constraint cut) is the
tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
