### PR TITLE
feat(#732): Stages 1+2+4 — ex1252 certified dual 0 → 74915 (58% of optimum) behind default-OFF flags

### DIFF
--- a/discopt_benchmarks/scripts/ex1252_compounding_probe.py
+++ b/discopt_benchmarks/scripts/ex1252_compounding_probe.py
@@ -10,13 +10,15 @@ x15 was decoupled and both levers were measured fully inert
 Certification at this node needs min x15: 12.44 -> 32.28.
 
 Measured result (2026-07-18, recorded in docs/dev/ex1252-certification-plan.md):
-  * x6 subdivision now lifts a child bound 57435 -> 62071 (+8%; pre-RLT provably 0)
-  * OBBT now pins x12 to exactly 175.0 and caps x15 at 30.89 within seconds
-    (pre-RLT: no movement at all)
-  * engine fragility exposed: narrow/pinned child boxes can return 0.0 /
-    (numerical) / (error) fallback bounds — sound but weak, and they destroy the
-    proved min-child bound exactly at the nodes certification needs (Stage 1 of
-    the plan).
+  * x6 subdivision now lifts child bounds 57435 -> 62071/66932/92706 (monotone
+    in x6; pre-RLT provably 0 movement) — proved 4-way min-child bound 62071.
+  * OBBT now pins x12 to exactly 175.0, caps x15 at 30.89 within seconds, and at
+    rounds=8 proves the whole config box EMPTY (``infeasible=True`` — the config
+    is pruned outright). Pre-RLT: no movement at all.
+  * The first run of this probe also exposed the Stage-1 engine fragility (child
+    bounds collapsing to a 0.0 floor via a directional-widening bug in the
+    conditioning clamp; crossed boxes crashing to ``error``) — both fixed, see
+    the plan doc's Stage 1 record and ``python/tests/test_narrow_box_bounds.py``.
 
 Run: ``python -m discopt_benchmarks.scripts.ex1252_compounding_probe``
 """
@@ -79,27 +81,35 @@ for var, name, K in [(12, "x12", 2), (12, "x12", 4), (12, "x12", 8), (6, "x6", 4
     print(f"[A] subdivide {name} into {K}: proved bound = {mn}   children={shown}")
 
 # B: cutoff-driven OBBT at the deep node — inert pre-RLT; does it bite now?
+# NOTE (#732 Stage 1): with more rounds OBBT's tightening can CROSS a bound —
+# that is a proof the config box is EMPTY, flagged via ``res.infeasible`` (the
+# solver's call sites prune on it; a crossed box handed onward now yields the
+# correct ``infeasible`` verdict from solve_at_node rather than a build crash).
 for cutoff, tag in [(None, "no-cutoff"), (OPT, "cutoff=opt")]:
     res = obbt_tighten_root(
         r, lb.copy(), ub.copy(), rounds=8, time_limit_per_lp=0.3, incumbent_cutoff=cutoff
     )
-    b2 = bd(res.lb, res.ub)
+    b2 = "CONFIG PRUNED (box empty)" if res.infeasible else bd(res.lb, res.ub)
     print(
         f"[B] OBBT({tag:10s}): x6[{res.lb[6]:.0f},{res.ub[6]:.0f}] "
         f"x12[{res.lb[12]:.1f},{res.ub[12]:.1f}] x15[{res.lb[15]:.2f},{res.ub[15]:.2f}] "
-        f"-> bound {b2}"
+        f"infeasible={res.infeasible} -> {b2}"
     )
 
 # B2: compounding loop — OBBT(cutoff) then subdivide x12 on the tightened box.
 res = obbt_tighten_root(
     r, lb.copy(), ub.copy(), rounds=8, time_limit_per_lp=0.3, incumbent_cutoff=OPT
 )
-l2, u2 = res.lb.copy(), res.ub.copy()
-edges = np.linspace(float(l2[12]), float(u2[12]), 5)
-kids = []
-for i in range(4):
-    lo, hi = l2.copy(), u2.copy()
-    lo[12], hi[12] = edges[i], edges[i + 1]
-    kids.append(bd(lo, hi))
-finite = [b for b in kids if isinstance(b, float)]
-print(f"[B2] OBBT(cutoff) + subdivide x12 into 4: proved bound = {min(finite) if finite else None}")
+if res.infeasible:
+    print("[B2] OBBT(cutoff) proves the config box empty — node pruned outright.")
+else:
+    l2, u2 = res.lb.copy(), res.ub.copy()
+    edges = np.linspace(float(l2[12]), float(u2[12]), 5)
+    kids = []
+    for i in range(4):
+        lo, hi = l2.copy(), u2.copy()
+        lo[12], hi[12] = edges[i], edges[i + 1]
+        kids.append(bd(lo, hi))
+    finite = [b for b in kids if isinstance(b, float)]
+    mn = min(finite) if finite else None
+    print(f"[B2] OBBT(cutoff) + subdivide x12 into 4: proved bound = {mn}")

--- a/discopt_benchmarks/scripts/ex1252_pump_recursion_probe.py
+++ b/discopt_benchmarks/scripts/ex1252_pump_recursion_probe.py
@@ -1,0 +1,86 @@
+"""#732 Stage 2 deliverable-2 entry experiment: pump-count zero-dichotomy recursion.
+
+Multi-line configs bound at ~0 because free pump counts let each line's cost
+coupling sit at its x_i=0 corner. Split every active-line pump var into {0} vs
+[1,3] (a partition of the implied-integer domain): with lb >= 1 the bit-link RLT
+McCormick chains get real lower corners, and the x=0 children degenerate toward
+the (already strongly bounded) fewer-line configs. Measure min over the 16
+children of config (1,1,0) — the proved recursed bound for that config.
+
+MEASURED (2026-07-18, recorded in docs/dev/ex1252-certification-plan.md Stage 2):
+  * 12/16 children PRUNE (LP-infeasible) — the dichotomy eliminates hard;
+  * 2 children are `numerical` (x0=x3=0 with line 1 on: genuinely infeasible by
+    the head equation x18 = 0.0025*x9*x3, but the ill-conditioned LP cannot
+    Farkas-certify it and OBBT rounds=8 does not cross — the SAME contradiction
+    is provable by interval FBBT alone, so the disjunctive pass must run a
+    per-box FBBT step (Rust binding: `tighten_var_bounds` + `fbbt`/
+    `fbbt_with_cutoff`) before the LP;
+  * 2 children bound: (1+,1+,0,1+) = 62027 and (1+,1+,1+,1+) = 6814 — the
+    all-pumps-on child needs one more value-split level (x in {1},{2},{3}) to
+    climb, since lb=1 corners keep the multilinear chain near its constant.
+"""
+
+import os
+
+os.environ["DISCOPT_MULTILINEAR_COUPLING_RLT"] = "1"
+
+import itertools
+
+import discopt.modeling as dm
+import numpy as np
+from discopt._jax.integer_product_reform import reformulate_integer_multilinear
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.obbt import obbt_tighten_root
+
+INCUMBENT = 134471.56
+
+r = reformulate_integer_multilinear(dm.from_nl("python/tests/data/minlplib/ex1252.nl"))
+lb0, ub0 = flat_variable_bounds(r)
+lb0 = np.asarray(lb0, float).copy()
+ub0 = np.asarray(ub0, float).copy()
+
+# Config (1,1,0): lines 1,2 on; line 3 off. Pump vars: line1 (x0 par, x3 ser),
+# line2 (x1 par, x4 ser). Line-3 vars pinned 0 by gating.
+for ind, sel, v in ((18, 36, 1.0), (19, 37, 1.0), (20, 38, 0.0)):
+    lb0[ind] = ub0[ind] = v
+    lb0[sel] = ub0[sel] = v
+
+PUMPS = [0, 3, 1, 4]  # x0, x3 (line 1), x1, x4 (line 2)
+
+
+def child_bound(dichotomy):
+    lb, ub = lb0.copy(), ub0.copy()
+    for var, hi_side in zip(PUMPS, dichotomy, strict=True):
+        if hi_side:
+            lb[var] = max(lb[var], 1.0)
+        else:
+            ub[var] = min(ub[var], 0.0)
+    res = obbt_tighten_root(
+        r, lb.copy(), ub.copy(), rounds=3, time_limit_per_lp=0.2, incumbent_cutoff=INCUMBENT
+    )
+    if res.infeasible:
+        return "OBBT-pruned", None
+    node = MccormickLPRelaxer(r).solve_at_node(res.lb.copy(), res.ub.copy())
+    if node.status == "infeasible":
+        return "LP-infeasible", None
+    if node.status != "optimal":
+        return node.status, None
+    return "optimal", float(node.lower_bound)
+
+
+alive, statuses = [], {}
+for dich in itertools.product((0, 1), repeat=4):
+    st, b = child_bound(dich)
+    statuses[dich] = (st, b)
+    tag = f"{b:.0f}" if b is not None else st
+    print(f"  (x0,x3,x1,x4) {'/'.join('0' if d == 0 else '1+' for d in dich):11s}: {tag}")
+    if b is not None:
+        alive.append(b)
+
+print(
+    f"\nconfig (1,1,0) recursed bound = min over children = {min(alive):.1f}"
+    if alive
+    else "all children pruned!"
+)
+print("(pre-recursion config bound: ~0; single-line configs: 71644-115466)")

--- a/discopt_benchmarks/scripts/ex1252_stage2_branching_probe.py
+++ b/discopt_benchmarks/scripts/ex1252_stage2_branching_probe.py
@@ -1,0 +1,115 @@
+"""#732 Stage 2 entry experiments: configuration-first branching on ex1252.
+
+Three experiments, run 2026-07-18 (reform + coupling RLT ON throughout); results
+recorded in ``docs/dev/ex1252-certification-plan.md`` Stage 2.
+
+A. **Instrument the 400-node tree** (branch-count sink): the tree spends its
+   branching on the reform's *continuous* big-M product auxes (``_ipx_v*`` — top
+   column 29 branchings) whose subdivision provably cannot pin the coupling,
+   while the priority set (``DISCOPT_OBJ_BRANCH_PRIORITY``) contains only 6 vars
+   post-reform and the top priority var got 4 branchings. The ``_ipx_e``
+   expansion bits — whose fractionality is the L2 leak — appear only in linear
+   big-M rows, invisible to the nonlinear-term-keyed priority detector.
+
+B. **All-binaries priority (monkeypatch)**: forcing every binary into the
+   priority set FAILED the kill criterion — 400-node global dual 12658 (< the
+   16304 baseline, << the 33k gate), incumbent worse. Root cause: the priority
+   hint is *fractionality-gated*, and the node LP vertex often has integral
+   binaries while the coupling stays loose through the v-auxes — no fractional
+   signal, no hint, and the standard selector branches the useless v columns.
+   Hint-based configuration-first branching is falsified for this tree.
+
+C. **Disjunctive route (the plan's recorded alternative)**: enumerate the 2^3
+   line-indicator patterns (every feasible point has integral indicators — they
+   are equality-pinned to binaries), OBBT each config box, take the min of
+   per-config bounds as a valid root bound. Measured:
+
+     lines (0,0,1): 90592  (PRUNED outright under the incumbent cutoff)
+     lines (0,1,1): 59806
+     lines (1,0,0): 38524
+     lines (1,0,1)/(1,1,0)/(1,1,1): ~0   <-- the residual wall
+     (0,0,0): infeasible; (0,1,0): numerical
+
+   Single-line configs certify far above the tree's 16.3k global dual; the
+   multi-line configs re-create the L2 decoupling one level down: their coupling
+   runs through the pump-count integer-BILINEAR products (``x9*x3 = 400*x18``
+   etc.), which the reform expands on its *bilinear* path — initially not
+   covered by the #721 coupling RLT. Extending the bit-link RLT to that path
+   (Stage 2 deliverable 1, same flag) amplifies the per-config bounds to
+   (0,0,1) 115466 / (0,1,1) 90429 / (1,0,0) 71644 — the numbers this script now
+   reproduces — leaving only the multi-line configs weak (pump-count recursion,
+   deliverable 2).
+
+Run: ``python -m discopt_benchmarks.scripts.ex1252_stage2_branching_probe``
+(runs experiment C, the cheap decisive one; A/B need a full 400-node solve).
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+
+os.environ["DISCOPT_MULTILINEAR_COUPLING_RLT"] = "1"
+
+import discopt.modeling as dm
+import numpy as np
+from discopt._jax.integer_product_reform import reformulate_integer_multilinear
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.obbt import obbt_tighten_root
+
+OPT = 128893.74
+INCUMBENT = 134471.56  # found by discopt itself (RLT ON) — a legitimate cutoff
+
+
+def _nl_path():
+    from pathlib import Path
+
+    here = Path(__file__).resolve()
+    for base in here.parents:
+        cand = base / "python" / "tests" / "data" / "minlplib" / "ex1252.nl"
+        if cand.exists():
+            return cand
+    raise FileNotFoundError("ex1252.nl not found")
+
+
+def run() -> None:
+    r = reformulate_integer_multilinear(dm.from_nl(str(_nl_path())))
+    lb0, ub0 = flat_variable_bounds(r)
+    lb0 = np.asarray(lb0, float).copy()
+    ub0 = np.asarray(ub0, float).copy()
+
+    def config_bound(pattern, cutoff):
+        lb, ub = lb0.copy(), ub0.copy()
+        for (ind, sel), v in zip(((18, 36), (19, 37), (20, 38)), pattern, strict=True):
+            lb[ind] = ub[ind] = float(v)
+            lb[sel] = ub[sel] = float(v)
+        res = obbt_tighten_root(
+            r, lb.copy(), ub.copy(), rounds=6, time_limit_per_lp=0.3, incumbent_cutoff=cutoff
+        )
+        if res.infeasible:
+            return "OBBT-pruned", None
+        node = MccormickLPRelaxer(r).solve_at_node(res.lb.copy(), res.ub.copy())
+        if node.status == "infeasible":
+            return "LP-infeasible", None
+        if node.status != "optimal":
+            return node.status, None
+        return "optimal", float(node.lower_bound)
+
+    for cutoff, tag in [(None, "no cutoff"), (INCUMBENT, f"cutoff={INCUMBENT:.0f}")]:
+        print(f"\n=== per-config bounds ({tag}) ===")
+        alive = []
+        for pattern in itertools.product((0, 1), repeat=3):
+            st, b = config_bound(pattern, cutoff)
+            print(f"  lines {pattern}: {st:14s} bound={b}")
+            if b is not None:
+                alive.append(b)
+        if alive:
+            print(
+                f"  DISJUNCTIVE ROOT BOUND = min over configs = {min(alive):.1f} "
+                f"(tree global dual at 400 nodes: 16304; opt {OPT})"
+            )
+
+
+if __name__ == "__main__":
+    run()

--- a/docs/dev/ex1252-certification-plan.md
+++ b/docs/dev/ex1252-certification-plan.md
@@ -225,16 +225,34 @@ incumbent?
 feasible and > 20% below incumbent, the cubic gap (Stage 4) is bigger than the
 search gap and Stage 4 is promoted above Stage 2 in effort.
 
-### Stage 4 — cubic-block tightening at configs (L4; #721's original directions, now unblocked)
+### Stage 4 — cubic-block tightening at configs *(option 1 DONE 2026-07-18 — the
+plateau breaks; #721's acceptance bar exceeded)*
 In increasing effort, measured at the OBBT-tightened config box:
-1. **Spatial branching on `x6`** — already works (+8%/split measured); Stage 2's
-   priority order just needs to reach it after the integers.
+1. **Spatial bisection of the cubic block at count-complete leaves — DONE.**
+   Kill bar (≥ 10% leaf lift) was already met by the Stage-1 battery (config-box
+   x6 children: parent 65654 → min-child 73848, +12.5%). Implemented inside the
+   disjunctive pass: once a leaf has no configuration count left to peel,
+   bisect the **widest-relative continuous nonlinear participant** (structural:
+   nonlinear-term participants minus counts/indicators — the x6-class), capped
+   at `max_spatial_depth` bisections per path. **Measured:** the standalone pass
+   goes 37945 (48 leaves — byte-identical to Stage 2, spatial only engages
+   deeper) → **63080 at 120 leaves** (129 s, no incumbent, no tree) — through
+   the ~48k plateau, i.e. **the original #721 acceptance criterion ("global
+   dual climbs materially above ~48k") is formally exceeded**. Wiring budget
+   raised to `min(25% of time_limit, 150 s)` with a deadline-governed leaf
+   budget (the module's 48-leaf default was capping the in-solve pass at the
+   shallow regime). **End-to-end: the reported global dual on a 600 s solve goes
+   0.0 (flag OFF) → 74915 (flag ON)** — 58% of the optimum, with a better
+   incumbent as well (131124 vs 134471); the in-solve pass beats the standalone
+   63080 because the root box is presolve/FBBT-tightened before it runs. Session
+   trajectory of the certified dual: 5134 (pre-#707) → ~16k (#707) → 42725 →
+   **74915**. Pinned by `test_ex1252_spatial_recursion_clears_721_bar` (≥ 48k).
 2. **Piecewise-McCormick auto-trigger gated on integer-complete nodes** — #721's
-   direction #1, provably inert pre-RLT, now expected to bite; entry experiment:
-   k = 4/8 partitions on `x6` at the config box, measure the `min x15` lift.
+   direction #1; held in reserve — option 1 did not stall, so per the plan's
+   ordering this stays unbuilt until the spatial lever plateaus (record the
+   measurement then).
 3. **Edge-concave / αBB envelope for the cubic rows** (catalog §7's open item) —
-   one-shot tighter envelope of `x15 = a·x6³ + b·x6²·x12 + c·x12²·x6` over the
-   config box; highest effort, only if 1–2 stall.
+   highest effort, only if 1–2 stall.
 **Kill criterion per option:** < 10% `min x15` lift at the config box → drop that
 option (recorded, not retried).
 

--- a/docs/dev/ex1252-certification-plan.md
+++ b/docs/dev/ex1252-certification-plan.md
@@ -91,20 +91,34 @@ The unblocking lever. Default-OFF `DISCOPT_MULTILINEAR_COUPLING_RLT`; OFF path
 byte-identical to #707; sound (RLT of valid identities, `bound ≤ opt` verified);
 pinned by `python/tests/test_ex1252_coupling_rlt.py`.
 
-### Stage 1 — engine hardening on narrow/pinned boxes *(P0 prerequisite)*
-**Problem:** child solves on OBBT-pinned or finely subdivided boxes return
+### Stage 1 — engine hardening on narrow/pinned boxes *(DONE 2026-07-18)*
+**Problem:** child solves on OBBT-pinned or finely subdivided boxes returned
 `0.0`/`(numerical)`/`(error)` fallbacks (§2), collapsing proved bounds.
-**Entry experiment:** a battery of the §2 child boxes; count certified verdicts
-vs fallbacks; bisect the failure (suspects: degenerate `lb==ub` rows after the
-pin, big-M conditioning on narrow `x6` slices, equilibration interaction).
-**Fix shape:** whatever the root cause, the fix must produce a *certified*
-optimal/infeasible verdict on those boxes — never a silent weak floor. This is a
-correctness-adjacent robustness item and benefits every instance, not just this
-class.
-**Kill criterion:** none — a sound engine must handle these boxes; if a specific
-LP is genuinely intractable, the node must inherit the parent bound (sound,
-already ≥ 57435 here) rather than 0.0. *Inheriting the parent bound instead of a
-weaker fallback is itself most of the win.*
+**Root causes found (bisect: deterministic, order-independent — not warm/pool
+state):**
+1. *Directional-widening bug in the conditioning clamp* (`solve_at_node` +
+   `sanitize_relaxation_for_conditioning`): a bound crossing the 1e10 numeric cap
+   was mapped to ±inf **by sign**, so a large-*positive lower* bound became
+   `+inf` — a pinned `[+inf, +inf)` box, not the documented widening. The ex1252
+   `x6³` monomial aux (lb 1.9e10 on high-speed sub-boxes) hit exactly this; the
+   simplex reported the nonsense LP `unbounded` and the objective-floor fallback
+   collapsed the child bound to 0.0. **Fixed**: a crossing bound now always
+   widens outward (lo → −inf, hi → +inf); the ±sentinel cases the clamp was
+   written for behave identically.
+2. *Crossed (empty) boxes crashed the build* into a diagnostic-free `error`:
+   OBBT correctly flags a crossed tightening as `infeasible=True` (a proof the
+   box is empty — at this config it fires at rounds=8, pruning the whole config
+   outright), but a crossed box handed to `solve_at_node` crashed
+   (`Interval lo > hi`). **Fixed**: `solve_at_node` now answers a genuinely
+   crossed box with the definitionally correct `infeasible`, and repairs
+   hair-crossings (float round-off) by widening — which can never false-prune.
+
+**Measured after the fix** (same battery): children 2/3 go `0.0 → 66932 / 92706`
+(certified, monotone in `x6`; proved 4-way min-child bound 62071 vs 0.0 before),
+and the OBBT-crossed box returns `infeasible` (correct prune) instead of `error`.
+Both LP relaxations only widen or prune-on-empty, so the change is sound by
+construction; `python/tests/test_narrow_box_bounds.py` pins fails-before/
+passes-after (4 tests, incl. the false-prune guard for hair-crossings).
 
 ### Stage 2 — configuration-first branching (L3, the dominant lever)
 **Hypothesis:** branching indicators → reform expansion bits (`_ipx_e*`) → pump

--- a/docs/dev/ex1252-certification-plan.md
+++ b/docs/dev/ex1252-certification-plan.md
@@ -172,11 +172,30 @@ counts *before* continuous/spatial dimensions collapses the shallow-node floor.
    test pins moved to the feasible line-1-only config; (b) the raw-node simplex
    cannot Farkas-certify that emptiness (ill-conditioning) — an engine-hardening
    item to fold into Stage 1's scope if it recurs on feasible boxes.
-2. A root **disjunctive-bound pass** over the indicator patterns (class-gated,
-   default-OFF): global dual = max(root bound, min over configs of the per-config
-   OBBT+LP bound), recursing one level (pump counts) on configs that stay weak.
-   With deliverable 1's amplification, the surviving weak set is exactly the
-   multi-line configs — the recursion targets their pump-count integers.
+2. *(DONE 2026-07-18)* The root **disjunctive-bound pass**
+   (`discopt/_jax/disjunctive_config_bound.py`, flag
+   `DISCOPT_DISJUNCTIVE_CONFIG_BOUND`, default-OFF): enumerate the reform's
+   indicator patterns, bound each configuration box by **FBBT → OBBT → LP**
+   (the per-box FBBT closes the `numerical` leaves in ~4 ms), best-first
+   **unit-peel** the weakest leaf on the configuration count variables, under a
+   leaf/wall budget. Anytime-valid: children inherit the parent bound until
+   certified, so min-over-leaves is valid at any cutoff. Wired via the
+   integer-ratio-partitioner precedent: the floor is stashed on the model and
+   `MccormickLPRelaxer.solve_at_node` max-combines it into every optimal node
+   bound (a root-box bound is valid on every sub-box), flowing through the
+   tree's existing plumbing with no new threading. **Measured:** standalone
+   root pass (48 leaves, no incumbent, no tree) certifies **37945** — the
+   re-scoped Stage-2 gate (≥ 33k) passes; end-to-end at equal solve settings
+   (85 nodes, 240 s) the reported global dual goes **0.0 → 42725** with the
+   same incumbent (134471). Two operational findings: (a) *incumbent-cutoff
+   OBBT inside the pass is net-negative* — it degrades LP conditioning enough
+   that leaves stay uncertified and the min collapses to the inherited floor
+   (160-leaf run returned exactly the floor) — so the wiring runs the pass
+   cutoff-free; (b) the surviving weak leaves are the deep all-pumps-on chains,
+   whose climb is bounded by the per-leaf LP tightness (Stage 4's cubic
+   levers pick up from here). Tests:
+   `python/tests/test_disjunctive_config_bound.py` (decline, anytime validity,
+   the ≥ 33k gate, and the relaxer floor plumbing).
    *Recursion entry experiment (2026-07-18,
    `ex1252_pump_recursion_probe.py`, config (1,1,0), zero-dichotomies `{0}` vs
    `[1,3]` on the 4 active pump vars):* **12/16 children prune** (LP-infeasible)

--- a/docs/dev/ex1252-certification-plan.md
+++ b/docs/dev/ex1252-certification-plan.md
@@ -120,19 +120,66 @@ Both LP relaxations only widen or prune-on-empty, so the change is sound by
 construction; `python/tests/test_narrow_box_bounds.py` pins fails-before/
 passes-after (4 tests, incl. the false-prune guard for hair-crossings).
 
-### Stage 2 — configuration-first branching (L3, the dominant lever)
+### Stage 2 — configuration-first branching *(entry experiments run 2026-07-18 —
+kill criterion FIRED for the hint route; re-scoped to the disjunctive route)*
 **Hypothesis:** branching indicators → reform expansion bits (`_ipx_e*`) → pump
-counts *before* continuous/spatial dimensions collapses the shallow-node floor,
-because the config space is tiny (≤ 8 indicator patterns × small pump grids) and
-§2 shows config nodes now bound/prune hard.
-**Entry experiment:** instrument the existing 400-node run — what fraction of
-open nodes are integer-complete, and what does the node-depth-vs-bound profile
-look like? Then force integer-first priority (check `DISCOPT_OBJ_BRANCH_PRIORITY`
-semantics first — partial machinery may exist) and re-measure the global dual at
-the same 400-node budget, RLT ON.
-**Kill criterion:** if config-first branching does not at least double the
-400-node global dual (16304 → ≥ 33k), the search hypothesis is wrong for this
-tree and the plan re-scopes to the disjunctive-bound alternative (§5).
+counts *before* continuous/spatial dimensions collapses the shallow-node floor.
+**Measured** (`ex1252_stage2_branching_probe.py`, reform + RLT ON):
+- *Experiment A (instrumented 400-node tree):* the tree spends its branching on
+  the reform's **continuous** big-M product auxes (`_ipx_v*`, top column 29
+  branchings) whose subdivision provably cannot pin the coupling; the existing
+  `DISCOPT_OBJ_BRANCH_PRIORITY` set contains only 6 vars post-reform (its
+  detector keys on nonlinear-term participation, and the `_ipx_e` bits — the L2
+  leak drivers — appear only in *linear* big-M rows, invisible to it).
+- *Experiment B (all-binaries priority, monkeypatch):* **kill criterion fired**
+  — 400-node global dual 12658 (below the 16304 baseline, far below the 33k
+  gate), incumbent worse. Root cause: the priority hint is *fractionality-gated*
+  and the node LP vertex often has **integral binaries while the coupling stays
+  loose through the v-auxes** — no fractional signal, no hint, and the standard
+  selector keeps branching the useless v columns. Hint-based config-first
+  branching is falsified for this tree (the mechanism cannot express "branch a
+  config dichotomy regardless of fractionality").
+- *Experiment C (disjunctive route — the recorded alternative, now primary):*
+  enumerate the 2³ line patterns, OBBT each, min over configs = valid root bound:
+
+  | config | bound |
+  |---|---|
+  | (0,0,1) | 90592 — **pruned outright** under the incumbent cutoff |
+  | (0,1,1) | 59806 |
+  | (1,0,0) | 38524 |
+  | (1,0,1), (1,1,0), (1,1,1) | ~0 — the residual wall |
+  | (0,0,0) | infeasible; (0,1,0): numerical |
+
+  Single-line configs certify far above the tree's 16.3k; the multi-line configs
+  re-create the L2 decoupling **one level down**: their coupling runs through the
+  pump-count integer-**bilinear** products (`x9·x3 = 400·x18` …), which the
+  reform expands on its *bilinear* path — **not covered by the #721 coupling RLT**
+  (it keys on ≥3-factor multilinear products with a continuous factor).
+
+**Re-scoped Stage 2 deliverables (in order):**
+1. *(DONE 2026-07-18)* Extend the bit-linking coupling RLT to the
+   **integer-bilinear** expansion path (`_try_expand_mul`) — same identity, same
+   default-OFF flag. Measured per-config amplification (OBBT'd config boxes,
+   with the incumbent cutoff): (0,0,1) 90592 → **115466** (and pruned outright
+   under the cutoff), (0,1,1) 59806 → **90429**, (1,0,0) 38524 → **71644**; the
+   line-1-only config node lifts 12658 → **65654** (5.2×). Multi-line configs
+   stay ~0 — correctly: their pump-count integers are free, so the coupling
+   grounds out at a genuinely loose McCormick; they need one recursion level
+   (deliverable 2). Two side-findings: (a) the extension tightened the *old*
+   test anchor (LINE1 + `x0=2, x3=1`) enough to expose that the config is
+   **genuinely infeasible** (OBBT rounds=8 proves the box empty; the raw node LP
+   now goes `numerical`-inconclusive rather than bounding a vacuous 57435) — the
+   test pins moved to the feasible line-1-only config; (b) the raw-node simplex
+   cannot Farkas-certify that emptiness (ill-conditioning) — an engine-hardening
+   item to fold into Stage 1's scope if it recurs on feasible boxes.
+2. A root **disjunctive-bound pass** over the indicator patterns (class-gated,
+   default-OFF): global dual = max(root bound, min over configs of the per-config
+   OBBT+LP bound), recursing one level (pump counts) on configs that stay weak.
+   With deliverable 1's amplification, the surviving weak set is exactly the
+   multi-line configs — the recursion targets their pump-count integers.
+3. Only then revisit in-tree branching (the correct mechanism is dichotomy
+   branching on config variables regardless of fractionality — a tree-side
+   change, larger scope).
 
 ### Stage 3 — per-config compounding loop (OBBT + cutoff at integer-complete nodes)
 **Hypothesis:** at integer-complete nodes, a short OBBT loop (now potent, §2)

--- a/docs/dev/ex1252-certification-plan.md
+++ b/docs/dev/ex1252-certification-plan.md
@@ -256,7 +256,45 @@ In increasing effort, measured at the OBBT-tightened config box:
 **Kill criterion per option:** < 10% `min x15` lift at the config box → drop that
 option (recorded, not retried).
 
-### Stage 5 — graduation (CLAUDE.md §5)
+### Stage 5 — graduation panel *(RUN 2026-07-18 — verdict: NOT eligible; flags
+stay default-OFF, measurement recorded)*
+
+**Instruments:** `check_cert_neutrality` OFF (environment sanity) and ON (the
+flag stack: reform + coupling RLT + disjunctive bound) over the 49-instance cert
+panel, plus a 9-instance ON-vs-OFF differential on the reform-firing subset
+(nvs01/05/09/16/22, st_e36/e40, ex1252, ex1252a) at the 60 s fair budget.
+
+**Findings:**
+1. *Environmental noise:* clay0303hfsg / st_e38 / tls2 violate the committed
+   baseline **in the OFF arm too** (this container is slower than the baseline
+   machine) — not flag-attributable.
+2. *nvs09 loses its certificate ON* (optimal in 9 s OFF → 0 nodes, wall overrun
+   ON). **Attributed to the pre-existing #707 reform flag**: reform-only
+   reproduces it identically (78 s, 0 nodes) with none of this branch's code —
+   a root-phase stall on the reformed nvs09 needing its own diagnosis.
+3. *Short-budget dual regression on the flagship:* at 60 s, reform+RLT costs
+   ex1252's tree bound (14347 → ~0; bigger LPs → fewer nodes at equal time)
+   while improving the primal side (incumbent 204321 → 134471). The stack pays
+   off only at generous budgets (600 s: 0 → 74915).
+4. *Two defects the panel caught were fixed on the spot:* the pass's leaf
+   solves carried no time limit (nvs09 ON overran a 60 s budget to 115 s; with
+   the fix, nvs09@300 s **certifies optimal with the full stack ON**, 103 s),
+   and the pass now engages only when its budget is ≥ 45 s (below that the
+   stack's pass is byte-identical to OFF — the 60 s panel behavior is restored
+   to reform+RLT-only).
+5. *Genuine wins where structure fires:* nvs05 bound 3.81 → 4.10 (equal
+   nodes); ex1252 primal 204321 → 134471; ex1252 dual 0 → 74915 at 600 s;
+   6 of 9 firing instances byte-identical (guards reject the reform).
+
+**Verdict (per the `DISCOPT_CUT_INHERIT` discipline):** sound throughout (no
+bound ever crossed its reference; every violation is environmental or
+pre-existing-#707), but **not net-positive at the fair budget** — the flags stay
+default-OFF. Graduation blockers, in order: (a) the pre-existing #707 nvs09
+root-phase stall, (b) the short-budget dual cost of reform+RLT on the
+ex1252 class (candidate fix: budget-aware reform adoption). Re-run this panel
+after those land.
+
+### Stage 5-original — graduation (CLAUDE.md §5)
 Class detector: `has_integer_multilinear_reformulation_work(model)` (the #707
 trigger) — i.e. the gated-configuration class, *not* an ex1252 special case.
 Panel: corpus differential run, flag ON vs OFF — cert-clean (`incorrect_count =

--- a/docs/dev/ex1252-certification-plan.md
+++ b/docs/dev/ex1252-certification-plan.md
@@ -177,6 +177,20 @@ counts *before* continuous/spatial dimensions collapses the shallow-node floor.
    OBBT+LP bound), recursing one level (pump counts) on configs that stay weak.
    With deliverable 1's amplification, the surviving weak set is exactly the
    multi-line configs — the recursion targets their pump-count integers.
+   *Recursion entry experiment (2026-07-18,
+   `ex1252_pump_recursion_probe.py`, config (1,1,0), zero-dichotomies `{0}` vs
+   `[1,3]` on the 4 active pump vars):* **12/16 children prune** (LP-infeasible)
+   — the dichotomy eliminates hard; 2 children bound (62027 and 6814 — the
+   all-pumps-on child needs one value-split level `{1},{2},{3}` to climb); 2
+   children are `numerical` — genuinely infeasible (head equation
+   `x18 = 0.0025·x9·x3` with both line-1 pumps zero) but the ill-conditioned LP
+   cannot Farkas-certify it and OBBT does not cross. **The same contradiction is
+   provable by interval FBBT alone**, so the pass must run a per-box FBBT step
+   before the LP — the Rust binding exposes exactly this
+   (`tighten_var_bounds` + `fbbt`/`fbbt_with_cutoff`). Implementation shape:
+   per config box, FBBT → OBBT(cutoff) → LP; prune on any of the three; recurse
+   zero-dichotomies then value-splits on the weakest surviving child, under a
+   node/LP budget; return max(root bound, min over leaves).
 3. Only then revisit in-tree branching (the correct mechanism is dichotomy
    branching on config variables regardless of fractionality — a tree-side
    change, larger scope).

--- a/python/discopt/_jax/disjunctive_config_bound.py
+++ b/python/discopt/_jax/disjunctive_config_bound.py
@@ -1,0 +1,293 @@
+"""Disjunctive configuration bound for gated-configuration MINLPs (#732 Stage 2).
+
+For models whose objective couples through integer-multilinear products (the #707
+reform class), the tree's global dual is dominated by shallow nodes where the
+configuration selectors are fractional and every cost coupling relaxes to ~0
+(the L3 wall of ``docs/dev/ex1252-certification-plan.md``). But the configuration
+space itself is tiny: the reform records which integer factors gate the products
+(``model._ipx_config_indicators`` — range-{0,1} selectors — and
+``model._ipx_config_counts`` — small-range counts, e.g. pump multiplicities).
+
+This pass computes a valid global lower bound by **partitioning on the
+configuration variables** instead of relaxing across them:
+
+1. Enumerate the ``2^k`` indicator patterns (every feasible point has integral
+   indicators; the patterns partition the box).
+2. Per configuration box: interval **FBBT** (fresh Rust repr per box — proves the
+   degenerate patterns crossed/empty in milliseconds, which the ill-conditioned
+   LP cannot Farkas-certify), then budgeted **OBBT** with the incumbent cutoff,
+   then the node **LP** bound.
+3. **Unit-peel** the weakest surviving leaf on a configuration count variable
+   (``{lo}`` vs ``[lo+1, ub]`` — a partition of the integer domain, the same
+   implied-integrality trust the #707 reform itself relies on), best-first,
+   under a leaf/wall budget.
+
+Anytime-valid by construction: every child inherits its parent's bound until its
+own is certified, so ``min over leaves`` is a valid lower bound at any budget
+cutoff; leaves pruned infeasible contribute nothing and leaves pruned by the
+incumbent cutoff contribute their certified bound. Soundness: FBBT/OBBT/LP are
+each sound per box, the indicator patterns partition the box exactly, and the
+unit-peel partitions the integer domain of a reform-expanded (declared or
+implied integer) variable.
+
+Entry experiments (recorded in the plan doc): per-config bounds 71644–115466 on
+the single-line ex1252 patterns (one pruned outright by the incumbent cutoff),
+12/16 pump-dichotomy children of a multi-line pattern pruned, and the FBBT step
+closing the ``numerical`` leaves that poisoned the min.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from itertools import product as _iproduct
+from typing import Optional
+
+import numpy as np
+
+from discopt.modeling.core import Model
+
+logger = logging.getLogger(__name__)
+
+# A leaf whose certified LP bound sits within this of the incumbent is pruned by
+# the cutoff (mirrors the solver's absolute gap tolerance).
+_CUTOFF_EPS = 1e-6
+# FBBT iteration cap per box (the per-box repr build + sweep measures ~4 ms).
+_FBBT_MAX_ITER = 20
+_FBBT_TOL = 1e-9
+
+
+@dataclass
+class DisjunctiveConfigResult:
+    """Outcome of the disjunctive configuration pass.
+
+    ``bound`` is a valid global lower bound for the model over the input box, or
+    ``None`` when the pass declined / could not certify anything above ``-inf``.
+    ``infeasible`` is True only when EVERY configuration pattern was pruned
+    infeasible — a rigorous proof the input box contains no feasible point.
+    """
+
+    bound: Optional[float] = None
+    infeasible: bool = False
+    n_processed: int = 0
+    n_pruned_infeasible: int = 0
+    n_pruned_cutoff: int = 0
+    n_leaves: int = 0
+    wall: float = 0.0
+
+
+@dataclass
+class _Leaf:
+    lb: np.ndarray
+    ub: np.ndarray
+    bound: float  # inherited from the parent until certified — always valid
+    certified: bool = False
+    attempts: int = 0
+    depth: int = 0
+    terminal: bool = False  # no splittable variable remains / budget-terminal
+    key: tuple = field(default_factory=tuple)
+
+
+def _box_fbbt(model: Model, lb: np.ndarray, ub: np.ndarray):
+    """Interval FBBT restricted to ``[lb, ub]`` via a fresh Rust repr.
+
+    Returns ``(tight_lb, tight_ub, crossed)``; on any failure returns the input
+    box with ``crossed=False`` (abstaining is sound — FBBT is a tightener).
+    """
+    try:
+        from discopt._rust import model_to_repr
+
+        rep = model_to_repr(model, getattr(model, "_builder", None))
+        off = 0
+        for bi, v in enumerate(model._variables):
+            rep.tighten_var_bounds(bi, list(lb[off : off + v.size]), list(ub[off : off + v.size]))
+            off += v.size
+        fl, fu = rep.fbbt(max_iter=_FBBT_MAX_ITER, tol=_FBBT_TOL)
+        tl = np.concatenate([np.atleast_1d(np.asarray(b, dtype=np.float64)) for b in fl])
+        tu = np.concatenate([np.atleast_1d(np.asarray(b, dtype=np.float64)) for b in fu])
+        if tl.shape != lb.shape:
+            return lb, ub, False
+        # Intersect defensively (FBBT starts from the written box, so this is a
+        # no-op unless the binding returned something unexpected).
+        tl = np.maximum(tl, lb)
+        tu = np.minimum(tu, ub)
+        crossed = bool(np.any(tl > tu + 1e-9))
+        return tl, tu, crossed
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("disjunctive pass: per-box FBBT abstained: %s", exc)
+        return lb, ub, False
+
+
+def _split_var(leaf: _Leaf, count_flats: list[int]) -> Optional[int]:
+    """First configuration count variable with integer width >= 1 in the leaf box."""
+    for j in count_flats:
+        lo = np.ceil(leaf.lb[j] - 1e-9)
+        hi = np.floor(leaf.ub[j] + 1e-9)
+        if hi - lo >= 1.0:
+            return j
+    return None
+
+
+def compute_disjunctive_config_bound(
+    model: Model,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    *,
+    incumbent: Optional[float] = None,
+    deadline: Optional[float] = None,
+    max_leaf_solves: int = 48,
+    max_indicators: int = 4,
+    obbt_rounds: int = 3,
+    obbt_lp_time: float = 0.2,
+    root_floor: float = -np.inf,
+) -> DisjunctiveConfigResult:
+    """Compute the disjunctive configuration bound over ``[lb, ub]``.
+
+    ``root_floor`` is the caller's existing valid bound for the box (used as the
+    inherited bound of unprocessed leaves, keeping the pass anytime-valid).
+    Declines (``bound=None``) when the model carries no configuration metadata,
+    the indicator count exceeds ``max_indicators``, or nothing above ``-inf``
+    could be certified within budget.
+    """
+    t0 = time.perf_counter()
+    res = DisjunctiveConfigResult()
+
+    indicators = sorted(getattr(model, "_ipx_config_indicators", None) or ())
+    count_flats = sorted(getattr(model, "_ipx_config_counts", None) or ())
+    lb = np.asarray(lb, dtype=np.float64).copy()
+    ub = np.asarray(ub, dtype=np.float64).copy()
+    # Only indicators still free in this box need enumeration.
+    free_ind = [j for j in indicators if ub[j] - lb[j] > 0.5]
+    if not indicators or len(free_ind) > max_indicators:
+        return res
+
+    from discopt._jax.mccormick_lp import MccormickLPRelaxer
+    from discopt._jax.obbt import obbt_tighten_root
+
+    relaxer = MccormickLPRelaxer(model)
+
+    leaves: list[_Leaf] = []
+    for pattern in _iproduct((0.0, 1.0), repeat=len(free_ind)):
+        clb, cub = lb.copy(), ub.copy()
+        for j, v in zip(free_ind, pattern, strict=True):
+            clb[j] = cub[j] = v
+        leaves.append(_Leaf(clb, cub, root_floor, key=pattern))
+    terminal_bounds: list[float] = []
+
+    def _out_of_budget() -> bool:
+        if res.n_processed >= max_leaf_solves:
+            return True
+        return deadline is not None and time.perf_counter() >= deadline
+
+    def _process(leaf: _Leaf) -> Optional[_Leaf]:
+        """FBBT -> OBBT(cutoff) -> LP on the leaf. Returns the surviving leaf
+        (certified or not), or ``None`` when pruned (stats updated)."""
+        res.n_processed += 1
+        tl, tu, crossed = _box_fbbt(model, leaf.lb, leaf.ub)
+        if crossed:
+            res.n_pruned_infeasible += 1
+            return None
+        leaf.lb, leaf.ub = tl, tu
+        try:
+            ob = obbt_tighten_root(
+                model,
+                leaf.lb.copy(),
+                leaf.ub.copy(),
+                rounds=obbt_rounds,
+                time_limit_per_lp=obbt_lp_time,
+                incumbent_cutoff=incumbent,
+                deadline=deadline,
+            )
+            if ob.infeasible:
+                res.n_pruned_infeasible += 1
+                return None
+            leaf.lb, leaf.ub = ob.lb.copy(), ob.ub.copy()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("disjunctive pass: OBBT abstained: %s", exc)
+        node = relaxer.solve_at_node(leaf.lb.copy(), leaf.ub.copy())
+        if node.status == "infeasible":
+            res.n_pruned_infeasible += 1
+            return None
+        leaf.attempts += 1
+        if node.status == "optimal" and node.lower_bound is not None:
+            b = float(node.lower_bound)
+            leaf.bound = max(leaf.bound, b)
+            leaf.certified = True
+            if incumbent is not None and b >= incumbent - _CUTOFF_EPS:
+                # The leaf holds nothing better than the incumbent: its box
+                # contributes at least b to the min — terminal, kept as a bound.
+                res.n_pruned_cutoff += 1
+                terminal_bounds.append(b)
+                return None
+        return leaf
+
+    # Pass 1: process every indicator pattern once.
+    survivors: list[_Leaf] = []
+    for leaf in leaves:
+        if _out_of_budget():
+            survivors.append(leaf)  # unprocessed: keeps its inherited bound
+            continue
+        kept = _process(leaf)
+        if kept is not None:
+            survivors.append(kept)
+
+    if not survivors and not terminal_bounds:
+        # Every configuration pattern pruned infeasible: the box is empty.
+        res.infeasible = res.n_pruned_cutoff == 0
+        res.bound = incumbent if res.n_pruned_cutoff else None
+        res.n_leaves = 0
+        res.wall = time.perf_counter() - t0
+        return res
+
+    # Pass 2: best-first unit-peeling — always work the weakest leaf, because the
+    # result is min over leaves and only lifting the min helps.
+    while not _out_of_budget():
+        survivors.sort(key=lambda le: (le.terminal, le.certified, le.bound))
+        leaf = survivors[0]
+        if leaf.terminal:
+            break  # weakest leaf can no longer improve
+        if leaf.certified or leaf.attempts > 0:
+            j = _split_var(leaf, count_flats)
+            if j is None:
+                leaf.terminal = True
+                continue
+            lo = float(np.ceil(leaf.lb[j] - 1e-9))
+            left = _Leaf(leaf.lb.copy(), leaf.ub.copy(), leaf.bound, depth=leaf.depth + 1)
+            left.ub[j] = lo
+            left.lb[j] = min(left.lb[j], lo)
+            right = _Leaf(leaf.lb.copy(), leaf.ub.copy(), leaf.bound, depth=leaf.depth + 1)
+            right.lb[j] = lo + 1.0
+            survivors.remove(leaf)
+            for child in (left, right):
+                if _out_of_budget():
+                    survivors.append(child)  # inherited bound keeps validity
+                    continue
+                kept = _process(child)
+                if kept is not None:
+                    survivors.append(kept)
+            if not survivors and not terminal_bounds:
+                res.infeasible = res.n_pruned_cutoff == 0
+                res.bound = incumbent if res.n_pruned_cutoff else None
+                res.n_leaves = 0
+                res.wall = time.perf_counter() - t0
+                return res
+        else:
+            kept = _process(leaf)
+            if kept is None:
+                survivors.remove(leaf)
+                if not survivors and not terminal_bounds:
+                    res.infeasible = res.n_pruned_cutoff == 0
+                    res.bound = incumbent if res.n_pruned_cutoff else None
+                    res.n_leaves = 0
+                    res.wall = time.perf_counter() - t0
+                    return res
+
+    all_bounds = [le.bound for le in survivors] + terminal_bounds
+    res.n_leaves = len(survivors)
+    res.wall = time.perf_counter() - t0
+    if not all_bounds:
+        return res
+    best = float(min(all_bounds))
+    res.bound = best if np.isfinite(best) else None
+    return res

--- a/python/discopt/_jax/disjunctive_config_bound.py
+++ b/python/discopt/_jax/disjunctive_config_bound.py
@@ -253,7 +253,10 @@ def compute_disjunctive_config_bound(
             leaf.lb, leaf.ub = ob.lb.copy(), ob.ub.copy()
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("disjunctive pass: OBBT abstained: %s", exc)
-        node = relaxer.solve_at_node(leaf.lb.copy(), leaf.ub.copy())
+        _tl = None
+        if deadline is not None:
+            _tl = max(deadline - time.perf_counter(), 1.0)
+        node = relaxer.solve_at_node(leaf.lb.copy(), leaf.ub.copy(), time_limit=_tl)
         if node.status == "infeasible":
             res.n_pruned_infeasible += 1
             return None

--- a/python/discopt/_jax/disjunctive_config_bound.py
+++ b/python/discopt/_jax/disjunctive_config_bound.py
@@ -85,6 +85,7 @@ class _Leaf:
     certified: bool = False
     attempts: int = 0
     depth: int = 0
+    spatial_depth: int = 0  # number of continuous bisections on this path
     terminal: bool = False  # no splittable variable remains / budget-terminal
     key: tuple = field(default_factory=tuple)
 
@@ -119,14 +120,39 @@ def _box_fbbt(model: Model, lb: np.ndarray, ub: np.ndarray):
         return lb, ub, False
 
 
-def _split_var(leaf: _Leaf, count_flats: list[int]) -> Optional[int]:
-    """First configuration count variable with integer width >= 1 in the leaf box."""
+def _split_var(
+    leaf: _Leaf,
+    count_flats: list[int],
+    cont_flats: list[int],
+    root_width: np.ndarray,
+    max_spatial_depth: int,
+) -> Optional[tuple[str, int]]:
+    """Next split for the leaf: a count unit-peel, else a continuous bisection.
+
+    Count variables first (fixing the configuration is what couples the cost
+    terms); once none has integer width left, fall to spatial bisection of the
+    widest-relative continuous nonlinear participant (#732 Stage 4 — the cubic
+    block's x6-class variables; measured +12.5% min-child per split at the
+    config box), capped at ``max_spatial_depth`` bisections per path.
+    """
     for j in count_flats:
         lo = np.ceil(leaf.lb[j] - 1e-9)
         hi = np.floor(leaf.ub[j] + 1e-9)
         if hi - lo >= 1.0:
-            return j
-    return None
+            return ("count", j)
+    if leaf.spatial_depth >= max_spatial_depth:
+        return None
+    best_j, best_rel = None, 0.05  # ignore near-pinned variables
+    for j in cont_flats:
+        w = float(leaf.ub[j] - leaf.lb[j])
+        rw = float(root_width[j])
+        if rw > 0.0 and np.isfinite(rw):
+            rel = w / rw
+            if rel > best_rel:
+                best_rel, best_j = rel, j
+    if best_j is None:
+        return None
+    return ("cont", best_j)
 
 
 def compute_disjunctive_config_bound(
@@ -141,6 +167,7 @@ def compute_disjunctive_config_bound(
     obbt_rounds: int = 3,
     obbt_lp_time: float = 0.2,
     root_floor: float = -np.inf,
+    max_spatial_depth: int = 6,
 ) -> DisjunctiveConfigResult:
     """Compute the disjunctive configuration bound over ``[lb, ub]``.
 
@@ -164,6 +191,27 @@ def compute_disjunctive_config_bound(
 
     from discopt._jax.mccormick_lp import MccormickLPRelaxer
     from discopt._jax.obbt import obbt_tighten_root
+
+    # #732 Stage 4: continuous bisection candidates — nonlinear-term participants
+    # that are neither configuration counts nor indicators (the cubic block's
+    # x6-class variables on ex1252). Structural, never name-keyed.
+    cont_flats: list[int] = []
+    try:
+        from discopt._jax.term_classifier import classify_nonlinear_terms
+
+        _terms = classify_nonlinear_terms(model)
+        _part: set[int] = set()
+        for _grp in (_terms.bilinear, _terms.trilinear, _terms.multilinear):
+            for _t in _grp or []:
+                _part.update(int(_x) for _x in _t)
+        for _t in _terms.monomial or []:
+            _part.add(int(_t[0]))
+        cont_flats = sorted(_part - set(count_flats) - set(indicators))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("disjunctive pass: continuous candidates skipped: %s", exc)
+    root_width = np.where(
+        np.isfinite(ub - lb), ub - lb, np.inf
+    )  # spatial ranking is relative to the root width
 
     relaxer = MccormickLPRelaxer(model)
 
@@ -248,16 +296,27 @@ def compute_disjunctive_config_bound(
         if leaf.terminal:
             break  # weakest leaf can no longer improve
         if leaf.certified or leaf.attempts > 0:
-            j = _split_var(leaf, count_flats)
-            if j is None:
+            split = _split_var(leaf, count_flats, cont_flats, root_width, max_spatial_depth)
+            if split is None:
                 leaf.terminal = True
                 continue
-            lo = float(np.ceil(leaf.lb[j] - 1e-9))
-            left = _Leaf(leaf.lb.copy(), leaf.ub.copy(), leaf.bound, depth=leaf.depth + 1)
-            left.ub[j] = lo
-            left.lb[j] = min(left.lb[j], lo)
-            right = _Leaf(leaf.lb.copy(), leaf.ub.copy(), leaf.bound, depth=leaf.depth + 1)
-            right.lb[j] = lo + 1.0
+            kind, j = split
+            sd = leaf.spatial_depth + (1 if kind == "cont" else 0)
+            left = _Leaf(
+                leaf.lb.copy(), leaf.ub.copy(), leaf.bound, depth=leaf.depth + 1, spatial_depth=sd
+            )
+            right = _Leaf(
+                leaf.lb.copy(), leaf.ub.copy(), leaf.bound, depth=leaf.depth + 1, spatial_depth=sd
+            )
+            if kind == "count":
+                lo = float(np.ceil(leaf.lb[j] - 1e-9))
+                left.ub[j] = lo
+                left.lb[j] = min(left.lb[j], lo)
+                right.lb[j] = lo + 1.0
+            else:  # continuous bisection at the midpoint (#732 Stage 4)
+                mid = 0.5 * (float(leaf.lb[j]) + float(leaf.ub[j]))
+                left.ub[j] = mid
+                right.lb[j] = mid
             survivors.remove(leaf)
             for child in (left, right):
                 if _out_of_budget():

--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -53,7 +53,7 @@ from discopt.modeling.core import (
 from discopt.solver_tuning import _env_flag
 
 from .factorable_reform import _collect_mul_factors
-from .term_classifier import distribute_products
+from .term_classifier import _compute_var_offset, distribute_products
 
 # Skip an integer factor whose range needs more than this many bits — the
 # expansion adds one binary and one aux product per bit, so a huge range would
@@ -141,6 +141,15 @@ class _Expander:
         #   _bigm_cache: (e._index, other._index, other_elem) -> big-M product aux
         self._and_cache: dict[tuple, Variable] = {}
         self._bigm_cache: dict[tuple, Variable] = {}
+        # Configuration metadata for the disjunctive config bound (#732 Stage 2).
+        # Collected on the multilinear path only: the flat indices of the
+        # integer factors of every exact-linearized product, split into
+        # *indicator-like* factors (range {0,1} — the configuration selectors)
+        # and *count-like* factors (range span >= 2 — e.g. pump counts). Pure
+        # metadata: never enters a bound or feasibility test here; the
+        # disjunctive pass uses it to enumerate/peel configuration boxes.
+        self.config_indicator_flats: set[int] = set()
+        self.config_count_flats: set[int] = set()
         # Coupling-RLT (issue #721, default-OFF ``DISCOPT_MULTILINEAR_COUPLING_RLT``).
         # For a continuous-times-AND product ``v = z*c`` with ``z = AND(bits)`` and a
         # non-negative continuous factor ``c``, the plain big-M envelope of ``v``
@@ -525,6 +534,15 @@ def _try_expand_multilinear(node: BinaryOp, exp: _Expander) -> Optional[Expressi
         return None
     int_factors = [exp.expansion(v, el, lo, hi) for (v, el, lo, hi) in int_refs]
 
+    # #732 Stage 2: record the configuration structure of this product (pure
+    # metadata for the disjunctive config bound — never enters a bound here).
+    for v, el, lo_i, hi_i in int_refs:
+        flat = _compute_var_offset(v, exp.model) + el
+        if lo_i == 0 and hi_i == 1:
+            exp.config_indicator_flats.add(flat)
+        elif hi_i - lo_i >= 2:
+            exp.config_count_flats.add(flat)
+
     # Issue #721 (default-OFF coupling RLT): tie each integer factor's bit-linking
     # equality to the continuous factor, so the per-bit products ``e_k*c`` are pinned
     # once ``x_i`` is fixed (the level that actually closes the objective-coupling
@@ -854,6 +872,12 @@ def expand_integer_products(model: Model, implied=frozenset(), multilinear: bool
             return model
         new_model._constraints = rebuilt + exp.aux_constraints
         _attach_warm_start_spec(model, new_model, exp)
+        # #732 Stage 2: configuration metadata for the disjunctive config bound
+        # (flat indices over the ORIGINAL columns — the aux block is a suffix, so
+        # original offsets are unchanged by the reform). Empty sets when the
+        # model has no multilinear configuration structure.
+        new_model._ipx_config_indicators = frozenset(exp.config_indicator_flats)
+        new_model._ipx_config_counts = frozenset(exp.config_count_flats)
         return new_model
     except Exception:
         return model

--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -453,6 +453,18 @@ def _try_expand_mul(node: BinaryOp, model: Model, exp: _Expander) -> Optional[Ex
     lo_o = float(np.asarray(vo.lb).flat[elo])
     hi_o = float(np.asarray(vo.ub).flat[elo])
     expanded = _expand_product(base_lo, bits, other_e, lo_o, hi_o, exp)
+    # #732 Stage 2: the integer-BILINEAR expansion has the same L2 decoupling as
+    # the multilinear one — with the bits fractional in the LP, every
+    # ``v_k = e_k·other`` big-M product can relax to 0 (ex1252 multi-line
+    # configs: the pump-count couplings ``x9·x3 = 400·x18`` all collapse,
+    # pinning those config bounds at ~0). Tie the bit-linking equality to the
+    # other factor exactly as ``_try_expand_multilinear`` does. Multilinear-path
+    # only (its ``_bigm_cache`` reuses the products just created — no new
+    # columns; the pure-bilinear entry stays byte-identical), same default-OFF
+    # flag (``DISCOPT_MULTILINEAR_COUPLING_RLT``).
+    if exp.multilinear and exp.coupling_rlt:
+        ref_i = vi if vi.size == 1 else IndexExpression(vi, eli)
+        exp.add_bitlink_rlt(ref_i, base_lo, bits, other_e, lo_o, hi_o)
     if const != 1.0:
         expanded = BinaryOp("*", Constant(const), expanded)
     return expanded

--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -875,9 +875,10 @@ def expand_integer_products(model: Model, implied=frozenset(), multilinear: bool
         # #732 Stage 2: configuration metadata for the disjunctive config bound
         # (flat indices over the ORIGINAL columns — the aux block is a suffix, so
         # original offsets are unchanged by the reform). Empty sets when the
-        # model has no multilinear configuration structure.
-        new_model._ipx_config_indicators = frozenset(exp.config_indicator_flats)
-        new_model._ipx_config_counts = frozenset(exp.config_count_flats)
+        # model has no multilinear configuration structure. Dynamic attributes
+        # (like the warm-start spec) — read back via ``getattr``.
+        setattr(new_model, "_ipx_config_indicators", frozenset(exp.config_indicator_flats))
+        setattr(new_model, "_ipx_config_counts", frozenset(exp.config_count_flats))
         return new_model
     except Exception:
         return model

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -433,6 +433,15 @@ class MccormickLPRelaxer:
         # ratio-of-integer-products structure; ``solve_at_node`` then max-combines
         # the partitioner's sound node bound with the LP bound.
         self._integer_ratio_partitioner = None
+        # Disjunctive configuration floor (#732 Stage 2, flag-gated default-OFF):
+        # stashed on the model by the solver's root disjunctive-config pass. A
+        # valid lower bound over the ROOT box is valid over every node's sub-box,
+        # so ``solve_at_node`` max-combines it into every optimal node bound —
+        # the same plumbing precedent as the integer-ratio partitioner.
+        _dcf = getattr(model, "_disjunctive_config_floor", None)
+        self._disjunctive_floor: Optional[float] = (
+            float(_dcf) if _dcf is not None and np.isfinite(_dcf) else None
+        )
         # Pre-compute which original columns are integer/binary so that
         # integrality is preserved (only aux columns get relaxed).
         flags: list[int] = []
@@ -1036,7 +1045,23 @@ class MccormickLPRelaxer:
                 # infeasible → the *default-path* separators tightened the loose base
                 # to empty, a rigorous fathom, since every separated cut is valid).
                 res = pool_free
-        return self._apply_integer_ratio_partition(res, node_lb, node_ub, out_cuts)
+        res = self._apply_integer_ratio_partition(res, node_lb, node_ub, out_cuts)
+        # #732 Stage 2 (flag-gated default-OFF at wiring time): floor every
+        # optimal node bound at the root disjunctive-configuration bound. The
+        # floor is a valid lower bound over the ROOT box, hence over every
+        # node's sub-box; raising an optimal node bound to it is sound and
+        # flows through the tree's existing bound plumbing. Every other verdict
+        # passes through untouched.
+        if (
+            self._disjunctive_floor is not None
+            and out_cuts is None
+            and res.status == "optimal"
+            and res.lower_bound is not None
+            and np.isfinite(res.lower_bound)
+            and res.lower_bound < self._disjunctive_floor
+        ):
+            res = dataclasses.replace(res, lower_bound=float(self._disjunctive_floor))
+        return res
 
     def set_integer_ratio_partitioner(self, partitioner) -> None:
         """Attach an :class:`~discopt._jax.integer_ratio.IntegerRatioPartitioner`.

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -228,6 +228,14 @@ def _append_relax_rows(milp, A_rows, b_rows) -> None:
 # the deadline from receiving a zero/negative budget the backend would reject).
 _SOLVE_DEADLINE_FLOOR_S = 0.05
 
+# Empty-box guard tolerance (#732 Stage 1): a node box whose lower bound crosses
+# its upper bound by more than this (relative to the bound magnitude) is a
+# genuinely empty box — ``solve_at_node`` answers ``infeasible`` (the
+# definitionally correct verdict) instead of crashing the relaxation build. A
+# crossing within the tolerance is treated as float round-off and repaired by
+# widening to the enclosing box (sound — widening only enlarges the relaxation).
+_EMPTY_BOX_TOL = 1e-6
+
 # Cap on constraints probed per node by the (opt-in, default-OFF) G-convexity
 # separator (#181) — bounds the per-node interval-Hessian certification cost.
 _GCONV_MAX_CONSTRAINTS = 16
@@ -926,6 +934,26 @@ class MccormickLPRelaxer:
 
         See :meth:`_solve_at_node_impl` for the full parameter contract.
         """
+        # Empty-box guard (#732 Stage 1). A node whose box is crossed (lb > ub)
+        # contains no point at all, so ``infeasible`` is the definitionally
+        # correct verdict for the box given — previously the crossed box crashed
+        # the relaxation build (``Interval lo > hi``) into a diagnostic-free
+        # ``status="error"``, losing the prune that a sound tightener (OBBT
+        # returning ``infeasible=True``) had already earned. Two tiers so a
+        # hair-crossing from float round-off can never trigger a false prune:
+        # a crossing beyond the conservative tolerance is a genuinely empty box
+        # (the observed case is a binary crossed by a full unit); a crossing
+        # within it is repaired by WIDENING to the enclosing box — widening only
+        # enlarges the relaxed feasible set, so the bound stays valid.
+        node_lb = np.asarray(node_lb, dtype=np.float64)
+        node_ub = np.asarray(node_ub, dtype=np.float64)
+        _cross = node_lb - node_ub
+        if np.any(_cross > _EMPTY_BOX_TOL * np.maximum(1.0, np.abs(node_ub))):
+            return MccormickLPResult(status="infeasible")
+        if np.any(_cross > 0.0):
+            _lo = np.minimum(node_lb, node_ub)
+            _hi = np.maximum(node_lb, node_ub)
+            node_lb, node_ub = _lo, _hi
         res = self._solve_at_node_impl(
             node_lb,
             node_ub,
@@ -1232,11 +1260,22 @@ class MccormickLPRelaxer:
         # and routes genuine unbounded variables through the simplex's correct
         # free-variable handling. Mirrors the root path's
         # ``sanitize_relaxation_for_conditioning``.
+        #
+        # The widening must be DIRECTIONAL (#732 Stage 1): a crossing lower bound
+        # always drops to -inf and a crossing upper bound always rises to +inf.
+        # The old sign-based mapping sent a large-*positive* lower bound to +inf
+        # (and a large-negative upper bound to -inf), i.e. it PINNED the box to
+        # [+inf, +inf) instead of widening it — a nonsense LP the simplex reports
+        # as spuriously "unbounded", which the objective-floor fallback then turns
+        # into a uselessly weak node bound (ex1252 config children: the x6^3
+        # monomial aux has lb 1.9e10 >= the 1e10 cap on high-speed sub-boxes,
+        # collapsing the child bound from ~62k to the 0.0 floor). Sentinel cases
+        # (lo <= -cap / hi >= +cap) behave identically under both mappings.
         _cap = _RELAX_NUMERIC_CAP
         milp._bounds = [
             (
-                lo if abs(lo) < _cap else (-np.inf if lo < 0 else np.inf),
-                hi if abs(hi) < _cap else (np.inf if hi > 0 else -np.inf),
+                lo if abs(lo) < _cap else -np.inf,
+                hi if abs(hi) < _cap else np.inf,
             )
             for (lo, hi) in milp._bounds
         ]

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -687,10 +687,15 @@ def sanitize_relaxation_for_conditioning(
         A = None
         b = None
 
+    # Directional widening (#732 Stage 1): a crossing lower bound always drops to
+    # -inf and a crossing upper bound always rises to +inf. The old sign-based
+    # mapping pinned a large-positive lower bound to +inf (a [+inf, +inf) box —
+    # not a widening), which is how the docstring's "widening" contract was
+    # silently violated; see the solve_at_node clamp for the measured failure.
     bounds = [
         (
-            lo if abs(lo) < cap else (-np.inf if lo < 0 else np.inf),
-            hi if abs(hi) < cap else (np.inf if hi > 0 else -np.inf),
+            lo if abs(lo) < cap else -np.inf,
+            hi if abs(hi) < cap else np.inf,
         )
         for (lo, hi) in model._bounds
     ]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4827,6 +4827,51 @@ def solve_model(
                             presolve = False
                             if nlp_solver == "pounce" and not _p3_force_cut_path_enabled():
                                 nlp_solver = "simplex"
+                        elif _tuning().disjunctive_config_bound:
+                            # #732 Stage 2 (default-OFF): root disjunctive
+                            # configuration bound for the spatial-path case.
+                            # Enumerate the reform's configuration-indicator
+                            # patterns, bound each config box (FBBT->OBBT->LP,
+                            # unit-peeling), and stash min-over-leaves as a
+                            # global-dual floor. The floor is a valid lower
+                            # bound over the ROOT box, hence over every node's
+                            # sub-box — ``MccormickLPRelaxer.solve_at_node``
+                            # max-combines it into every node bound (the
+                            # integer-ratio-partitioner precedent), so it flows
+                            # through the tree's existing bound plumbing with
+                            # no new threading. Budgeted to a fraction of the
+                            # solve's wall budget; a declined/failed pass
+                            # stashes nothing and the solve is unchanged.
+                            try:
+                                from discopt._jax.disjunctive_config_bound import (
+                                    compute_disjunctive_config_bound,
+                                )
+                                from discopt._jax.model_utils import (
+                                    flat_variable_bounds as _dcb_flat,
+                                )
+
+                                _dcb_budget = min(0.25 * float(time_limit), 60.0)
+                                _dcb_lb, _dcb_ub = _dcb_flat(model)
+                                _dcb = compute_disjunctive_config_bound(
+                                    model,
+                                    np.asarray(_dcb_lb, dtype=np.float64),
+                                    np.asarray(_dcb_ub, dtype=np.float64),
+                                    deadline=time.perf_counter() + _dcb_budget,
+                                )
+                                if _dcb.bound is not None and np.isfinite(_dcb.bound):
+                                    model._disjunctive_config_floor = float(_dcb.bound)
+                                    logger.info(
+                                        "disjunctive config bound: floor %.6g "
+                                        "(%d leaf solves, %d infeasible, %.1fs)",
+                                        _dcb.bound,
+                                        _dcb.n_processed,
+                                        _dcb.n_pruned_infeasible,
+                                        _dcb.wall,
+                                    )
+                            except Exception as _dcb_exc:  # pragma: no cover
+                                logger.debug(
+                                    "disjunctive config bound skipped: %s", _dcb_exc
+                                )
                         # Extend a user warm start over the appended aux columns so the
                         # (longer) reformed vector is not silently dropped. Purely primal:
                         # the driver re-validates it, so it never affects the dual bound.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4850,13 +4850,19 @@ def solve_model(
                                     flat_variable_bounds as _dcb_flat,
                                 )
 
-                                _dcb_budget = min(0.25 * float(time_limit), 60.0)
+                                _dcb_budget = min(0.25 * float(time_limit), 150.0)
                                 _dcb_lb, _dcb_ub = _dcb_flat(model)
                                 _dcb = compute_disjunctive_config_bound(
                                     model,
                                     np.asarray(_dcb_lb, dtype=np.float64),
                                     np.asarray(_dcb_ub, dtype=np.float64),
                                     deadline=time.perf_counter() + _dcb_budget,
+                                    # The wall deadline governs in-solve; the leaf
+                                    # cap is a runaway backstop only (the module
+                                    # default of 48 would stop a 150 s budget at
+                                    # ~50 s, pinning the floor at the shallow
+                                    # 42.7k instead of the deep-regime 63k).
+                                    max_leaf_solves=1000,
                                 )
                                 if _dcb.bound is not None and np.isfinite(_dcb.bound):
                                     model._disjunctive_config_floor = float(_dcb.bound)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4842,6 +4842,9 @@ def solve_model(
                             # no new threading. Budgeted to a fraction of the
                             # solve's wall budget; a declined/failed pass
                             # stashes nothing and the solve is unchanged.
+                            class _DcbSkip(Exception):
+                                pass
+
                             try:
                                 from discopt._jax.disjunctive_config_bound import (
                                     compute_disjunctive_config_bound,
@@ -4850,7 +4853,16 @@ def solve_model(
                                     flat_variable_bounds as _dcb_flat,
                                 )
 
+                                # Engagement gate (#732 Stage-5 panel): at short
+                                # budgets the pass cannot reach its productive
+                                # regime and only eats the root phase (60 s panel:
+                                # ex1252 bound 14347 -> 0.0, nvs09 loses its
+                                # certificate). Engage only when the solve budget
+                                # affords a >= 45 s pass; below that the stack is
+                                # byte-identical to flag-OFF.
                                 _dcb_budget = min(0.25 * float(time_limit), 150.0)
+                                if _dcb_budget < 45.0:
+                                    raise _DcbSkip()
                                 _dcb_lb, _dcb_ub = _dcb_flat(model)
                                 _dcb = compute_disjunctive_config_bound(
                                     model,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4869,9 +4869,7 @@ def solve_model(
                                         _dcb.wall,
                                     )
                             except Exception as _dcb_exc:  # pragma: no cover
-                                logger.debug(
-                                    "disjunctive config bound skipped: %s", _dcb_exc
-                                )
+                                logger.debug("disjunctive config bound skipped: %s", _dcb_exc)
                         # Extend a user warm start over the appended aux columns so the
                         # (longer) reformed vector is not silently dropped. Purely primal:
                         # the driver re-validates it, so it never affects the dual bound.

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -594,9 +594,11 @@ class SolverTuning:
     leaves — a valid bound by partition (anytime-valid: unprocessed leaves
     inherit the caller's existing root bound). Measured (ex1252, plan doc Stage
     2): the standalone root pass certifies 37945 at a 48-leaf budget (tree at
-    400 nodes: 16304), and end-to-end at equal solve settings the reported
-    global dual goes 0.0 -> 42725. Default-OFF pending the CLAUDE.md §5 corpus
-    differential panel."""
+    400 nodes: 16304) and 63080 at 120 leaves once the Stage-4 spatial bisection
+    engages (through the ~48k plateau — the #721 acceptance bar); end-to-end
+    the reported global dual goes 0.0 -> 42725 (240 s solve) and 0.0 -> 74915
+    (600 s solve, deadline-governed leaf budget). Default-OFF pending the
+    CLAUDE.md §5 corpus differential panel."""
 
     obj_branch_priority: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_OBJ_BRANCH_PRIORITY", default=True)

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -581,6 +581,23 @@ class SolverTuning:
     sub-NLP-verified and re-verified by ``inject_incumbent``); it never touches the
     dual bound or the certificate (heuristic-policy regime, CLAUDE.md §5)."""
 
+    disjunctive_config_bound: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_DISJUNCTIVE_CONFIG_BOUND", default=False)
+    )
+    """Root disjunctive configuration bound for the gated-configuration class
+    (``DISCOPT_DISJUNCTIVE_CONFIG_BOUND``, default **OFF**; #732 Stage 2).
+
+    When the integer-multilinear reform (#707) applies, enumerate the reform's
+    configuration-indicator patterns at the root, bound each configuration box by
+    FBBT -> OBBT -> LP with best-first unit-peeling on the configuration count
+    variables, and floor every optimal node bound at the min over configuration
+    leaves — a valid bound by partition (anytime-valid: unprocessed leaves
+    inherit the caller's existing root bound). Measured (ex1252, plan doc Stage
+    2): the standalone root pass certifies 37945 at a 48-leaf budget (tree at
+    400 nodes: 16304), and end-to-end at equal solve settings the reported
+    global dual goes 0.0 -> 42725. Default-OFF pending the CLAUDE.md §5 corpus
+    differential panel."""
+
     obj_branch_priority: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_OBJ_BRANCH_PRIORITY", default=True)
     )

--- a/python/tests/test_disjunctive_config_bound.py
+++ b/python/tests/test_disjunctive_config_bound.py
@@ -85,6 +85,33 @@ def test_anytime_validity_tiny_budget(monkeypatch):
 
 
 @pytest.mark.slow
+def test_ex1252_spatial_recursion_clears_721_bar(monkeypatch):
+    """#732 Stage 4: with continuous bisection at count-complete leaves, the pass
+    breaks the ~48k plateau — the original #721 acceptance bar ("global dual
+    climbs materially above ~48k") — with no incumbent and no tree.
+
+    Measured 63080 at a 120-leaf budget (48-leaf behavior is byte-identical to
+    Stage 2: counts are still splittable there, so the spatial extension only
+    engages deeper).
+    """
+    r = _reformed(monkeypatch)
+    lb, ub = flat_variable_bounds(r)
+    res = compute_disjunctive_config_bound(
+        r,
+        np.asarray(lb),
+        np.asarray(ub),
+        max_leaf_solves=120,
+        deadline=time.perf_counter() + 240.0,
+    )
+    assert res.bound is not None
+    assert res.bound <= EX1252_OPT + 1e-2, f"UNSOUND: {res.bound} > optimum {EX1252_OPT}"
+    assert res.bound >= 48000.0, (
+        f"spatial recursion bound {res.bound} fell below the #721 bar (48k) — "
+        "re-run the plan-doc Stage-4 measurement before shipping a change here"
+    )
+
+
+@pytest.mark.slow
 def test_ex1252_pass_clears_stage2_gate(monkeypatch):
     """The full-budget root pass certifies a sound bound above the Stage-2 bar.
 

--- a/python/tests/test_disjunctive_config_bound.py
+++ b/python/tests/test_disjunctive_config_bound.py
@@ -1,0 +1,138 @@
+"""#732 Stage 2 — the root disjunctive configuration bound
+(``DISCOPT_DISJUNCTIVE_CONFIG_BOUND``, default-OFF).
+
+Plan + entry experiments: ``docs/dev/ex1252-certification-plan.md`` Stage 2.
+
+The pass partitions on the reform's configuration variables instead of relaxing
+across them: enumerate the indicator patterns, bound each configuration box by
+FBBT → OBBT → LP, unit-peel the weakest leaf on the count variables, and return
+the min over leaves — a valid global lower bound by partition, anytime-valid
+because children inherit their parent's bound until certified.
+
+Measured (recorded in the plan doc): standalone root pass on ex1252 certifies
+~37.9k at a 48-leaf budget (tree at 400 nodes: 16.3k); wired end-to-end at equal
+solve settings the reported dual goes 0.0 → 42725. These tests pin the decline
+path, soundness + the Stage-2 gate (≥ 33k), anytime validity, and the relaxer's
+floor plumbing; the OFF path is untouched (attribute absent → no combine).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.disjunctive_config_bound import compute_disjunctive_config_bound
+from discopt._jax.integer_product_reform import reformulate_integer_multilinear
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.model_utils import flat_variable_bounds
+
+pytestmark = [pytest.mark.relaxation, pytest.mark.correctness]
+
+EX1252_OPT = 128893.74
+STAGE2_GATE = 33000.0  # the plan's Stage-2 kill-criterion bar (2x the 16304 tree dual)
+
+
+def _nl_path() -> Path:
+    here = Path(__file__).resolve()
+    for base in here.parents:
+        for sub in ("python/tests/data/minlplib", "tests/data/minlplib"):
+            cand = base / sub / "ex1252.nl"
+            if cand.exists():
+                return cand
+    raise FileNotFoundError("ex1252.nl not found")
+
+
+def _reformed(monkeypatch):
+    monkeypatch.setenv("DISCOPT_MULTILINEAR_COUPLING_RLT", "1")
+    return reformulate_integer_multilinear(dm.from_nl(str(_nl_path())))
+
+
+def test_declines_without_config_metadata():
+    """A model with no reform configuration metadata: the pass declines cleanly."""
+    m = dm.Model("plain")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    m.minimize(x)
+    lb, ub = flat_variable_bounds(m)
+    res = compute_disjunctive_config_bound(m, np.asarray(lb), np.asarray(ub))
+    assert res.bound is None
+    assert not res.infeasible
+    assert res.n_processed == 0
+
+
+def test_anytime_validity_tiny_budget(monkeypatch):
+    """With a tiny budget the pass must stay sound: any returned bound respects
+    the caller's root floor (leaves only ever inherit it or improve on it) and
+    never exceeds the true optimum."""
+    r = _reformed(monkeypatch)
+    lb, ub = flat_variable_bounds(r)
+    res = compute_disjunctive_config_bound(
+        r,
+        np.asarray(lb),
+        np.asarray(ub),
+        root_floor=5134.0,  # the pre-#707 structural floor — a known-valid bound
+        max_leaf_solves=4,
+    )
+    if res.bound is not None:
+        assert res.bound >= 5134.0 - 1e-6, "leaves may only inherit or improve the floor"
+        assert res.bound <= EX1252_OPT + 1e-2, "bound above the optimum is unsound"
+
+
+@pytest.mark.slow
+def test_ex1252_pass_clears_stage2_gate(monkeypatch):
+    """The full-budget root pass certifies a sound bound above the Stage-2 bar.
+
+    This is the re-scoped Stage-2 acceptance: the branching route failed the
+    >= 33k gate (12658); the disjunctive pass clears it with no incumbent and no
+    tree (measured ~37.9k at this budget).
+    """
+    r = _reformed(monkeypatch)
+    lb, ub = flat_variable_bounds(r)
+    res = compute_disjunctive_config_bound(
+        r,
+        np.asarray(lb),
+        np.asarray(ub),
+        max_leaf_solves=48,
+        deadline=time.perf_counter() + 180.0,
+    )
+    assert res.bound is not None, "the pass must certify a bound on the config class"
+    assert res.bound <= EX1252_OPT + 1e-2, f"UNSOUND: {res.bound} > optimum {EX1252_OPT}"
+    assert res.bound >= STAGE2_GATE, (
+        f"pass bound {res.bound} fell below the Stage-2 gate {STAGE2_GATE} — "
+        "re-run the plan-doc entry experiments before shipping a change here"
+    )
+
+
+def test_relaxer_floors_node_bounds_at_disjunctive_floor(monkeypatch):
+    """The solver stashes the pass result on the model; the relaxer must floor
+    every optimal node bound at it (valid: a root-box bound is valid on every
+    sub-box). With the attribute absent, behavior is untouched."""
+    r = _reformed(monkeypatch)
+    lb, ub = flat_variable_bounds(r)
+    lb = np.asarray(lb, float).copy()
+    ub = np.asarray(ub, float).copy()
+    for ind, sel, v in ((18, 36, 1.0), (19, 37, 0.0), (20, 38, 0.0)):
+        lb[ind] = ub[ind] = v
+        lb[sel] = ub[sel] = v
+
+    base = MccormickLPRelaxer(r).solve_at_node(lb.copy(), ub.copy())
+    assert base.status == "optimal"
+
+    # A floor between the raw node bound and the (known-valid) pass bound: the
+    # combine must lift the node exactly to it.
+    floor = float(base.lower_bound) + 1000.0
+    r._disjunctive_config_floor = floor
+    try:
+        lifted = MccormickLPRelaxer(r).solve_at_node(lb.copy(), ub.copy())
+    finally:
+        del r._disjunctive_config_floor
+    assert lifted.status == "optimal"
+    assert lifted.lower_bound == pytest.approx(floor), (
+        f"expected the node bound floored at {floor}, got {lifted.lower_bound}"
+    )

--- a/python/tests/test_ex1252_coupling_rlt.py
+++ b/python/tests/test_ex1252_coupling_rlt.py
@@ -9,13 +9,15 @@ rows force ``x15 ≥ 12.44``, yet the big-M product envelope lets the ``1800·x1
 contribute nothing — pinning the loosest-node bound at the objective constant
 12658.06). The coupling RLT multiplies each integer factor's bit-linking equality
 and each AND hull by the (non-negative) continuous factor, tying the disaggregated
-products back to ``x15``. This lifts the loosest-node bound to ~57435 — a large,
-**sound** tightening (the RLT rows are products of valid identities/inequalities, so
-they never cut a feasible point).
+products back to ``x15``; the #732 Stage-2 extension applies the same bit-link RLT
+to the integer-BILINEAR expansion path (the pump-count couplings). Together they
+lift the line-1-only config-node bound 12658 -> ~65654 (~5.2x) — a large, **sound**
+tightening (the RLT rows are products of valid identities/inequalities, so they
+never cut a feasible point).
 
 These tests lock: (1) the OFF path is byte-identical to #707 (same bound, same var
-count); (2) the ON path lifts the node bound to ~57435 and is sound (≤ the true
-optimum); (3) no feasible point is cut. The flag stays default-OFF — in a full
+count); (2) the ON path lifts the config-node bound to ~65654 and is sound (≤ the
+true optimum); (3) no feasible point is cut. The flag stays default-OFF — in a full
 time-limited solve the extra per-node bilinears currently cost enough throughput to
 be net-negative on the *global* dual (see §6), so graduation waits on deep-node
 gating; here we pin soundness and the node-level gain.
@@ -39,10 +41,14 @@ from discopt._jax.obbt import obbt_tighten_root
 
 pytestmark = [pytest.mark.relaxation, pytest.mark.correctness]
 
-OFF_BOUND = 6329.03 * 2.0  # 12658.06 — objective constant; #707 baseline at the node
-ON_BOUND = 57434.96  # coupling-RLT lifted bound (12658.06 + 3600·min_x15, min_x15≈12.44)
+OFF_BOUND = 6329.03 * 2.0  # 12658.06 — objective constant; #707 baseline at the config
+ON_BOUND = 65653.83  # coupling-RLT (multilinear + bilinear bit-link) lifted bound
 EX1252_OPT = 128893.74
-LINE1 = {18: 1, 36: 1, 21: 1, 19: 0, 20: 0, 37: 0, 38: 0, 22: 0, 23: 0}
+# Feasible line-1-only configuration: indicators + their equality-pinned binaries.
+# (The original anchor — LINE1 + x0=2, x3=1 — is a config OBBT proves EMPTY at
+# rounds=8; the #732 Stage-2 bilinear RLT tightens its raw node to correctly
+# expose that infeasibility, so pins live on this feasible config instead.)
+CONFIG_100 = ((18, 36, 1.0), (19, 37, 0.0), (20, 38, 0.0))
 
 
 def _nl_path() -> Path:
@@ -55,7 +61,7 @@ def _nl_path() -> Path:
     raise FileNotFoundError("ex1252.nl not found")
 
 
-def _loosest_node_bound(monkeypatch, coupling_rlt: bool):
+def _config_node_bound(monkeypatch, coupling_rlt: bool):
     # monkeypatch reverts the env change automatically (conftest guards against
     # leaked DISCOPT_* mutations under xdist).
     monkeypatch.setenv("DISCOPT_MULTILINEAR_COUPLING_RLT", "1" if coupling_rlt else "0")
@@ -64,17 +70,12 @@ def _loosest_node_bound(monkeypatch, coupling_rlt: bool):
     lb, ub = flat_variable_bounds(r)
     lb = np.asarray(lb, float).copy()
     ub = np.asarray(ub, float).copy()
-    for i, v in LINE1.items():
-        lb[i] = ub[i] = float(v)
+    for ind, sel, v in CONFIG_100:
+        lb[ind] = ub[ind] = v
+        lb[sel] = ub[sel] = v
     nc = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3)
-    lb, ub = nc.lb.copy(), nc.ub.copy()
-    lb[0] = ub[0] = 2.0
-    lb[24] = ub[24] = 0.0
-    lb[25] = ub[25] = 1.0  # x0 = 2
-    lb[3] = ub[3] = 1.0
-    lb[30] = ub[30] = 1.0
-    lb[31] = ub[31] = 0.0  # x3 = 1
-    res = MccormickLPRelaxer(r).solve_at_node(lb.copy(), ub.copy())
+    assert not nc.infeasible, "the line-1-only config is feasible"
+    res = MccormickLPRelaxer(r).solve_at_node(nc.lb.copy(), nc.ub.copy())
     assert res.status == "optimal", f"status {res.status}"
     return float(res.lower_bound), n_vars
 
@@ -82,15 +83,16 @@ def _loosest_node_bound(monkeypatch, coupling_rlt: bool):
 def test_off_path_is_707_baseline(monkeypatch):
     """Flag OFF: byte-identical to #707 — bound at the objective-constant floor, no
     extra columns (the coupling RLT adds nothing when disabled)."""
-    bound, n_vars = _loosest_node_bound(monkeypatch, coupling_rlt=False)
+    bound, n_vars = _config_node_bound(monkeypatch, coupling_rlt=False)
     assert bound == pytest.approx(OFF_BOUND, abs=1e-2)
     assert n_vars == 90, f"OFF path must not add columns; got {n_vars}"
 
 
 def test_on_path_lifts_bound_soundly(monkeypatch):
-    """Flag ON: the coupling RLT lifts the loosest-node bound ~4.5x, and it stays
-    sound — a valid dual bound never exceeds the true optimum."""
-    bound, n_vars = _loosest_node_bound(monkeypatch, coupling_rlt=True)
+    """Flag ON: the coupling RLT (multilinear + #732 Stage-2 bilinear bit-link)
+    lifts the config-node bound ~5.2x, and it stays sound — a valid dual bound
+    never exceeds the true optimum."""
+    bound, n_vars = _config_node_bound(monkeypatch, coupling_rlt=True)
     assert bound == pytest.approx(ON_BOUND, rel=1e-3), f"expected ~{ON_BOUND}, got {bound}"
     assert bound > OFF_BOUND + 1000.0, "coupling RLT must materially lift the bound"
     assert bound <= EX1252_OPT + 1e-2, f"UNSOUND: bound {bound} > optimum {EX1252_OPT}"
@@ -100,8 +102,8 @@ def test_on_path_lifts_bound_soundly(monkeypatch):
 def test_coupling_rlt_does_not_cut_the_optimum(monkeypatch):
     """Soundness: the true optimal point (bound ≤ opt) is never cut — the ON bound is
     a valid lower bound, strictly below the instance optimum (no over-tightening)."""
-    on_bound, _ = _loosest_node_bound(monkeypatch, coupling_rlt=True)
+    on_bound, _ = _config_node_bound(monkeypatch, coupling_rlt=True)
     assert on_bound <= EX1252_OPT + 1e-2
-    off_bound, _ = _loosest_node_bound(monkeypatch, coupling_rlt=False)
+    off_bound, _ = _config_node_bound(monkeypatch, coupling_rlt=False)
     # Monotone: adding valid RLT rows can only tighten (raise) the bound.
     assert on_bound >= off_bound - 1e-6, "valid RLT rows must never loosen the bound"

--- a/python/tests/test_narrow_box_bounds.py
+++ b/python/tests/test_narrow_box_bounds.py
@@ -1,0 +1,183 @@
+"""#732 Stage 1 — engine hardening on narrow/pinned/crossed node boxes.
+
+Root causes found and fixed (record: ``docs/dev/ex1252-certification-plan.md``
+Stage 1; entry experiment: ``discopt_benchmarks/scripts/ex1252_compounding_probe.py``):
+
+1. **Directional-widening bug in the conditioning clamp** (``solve_at_node`` and
+   ``sanitize_relaxation_for_conditioning``): a bound crossing the numeric cap was
+   mapped to ±inf *by sign*, so a large-**positive lower** bound became ``+inf`` —
+   a pinned ``[+inf, +inf)`` box, not a widening. On ex1252 config children the
+   ``x6**3`` monomial aux (lb ≥ 1.9e10 ≥ the 1e10 cap on high-speed sub-boxes) hit
+   exactly this; the simplex reported the nonsense LP ``unbounded`` and the
+   objective-floor fallback collapsed the child bound to 0.0. The fix widens
+   directionally (crossing lo → −inf, crossing hi → +inf) — identical on the
+   ±sentinel cases the clamp was written for, and a true widening otherwise.
+
+2. **Crossed (empty) node boxes crashed the build** into a diagnostic-free
+   ``status="error"``: a sound tightener (OBBT returns ``infeasible=True`` when its
+   tightening crosses bounds) hands back a provably empty box; callers that pass it
+   to ``solve_at_node`` should get the definitionally correct ``infeasible`` — an
+   empty box contains no point. Hair-crossings (float round-off) are instead
+   repaired by widening to the enclosing box, which can never produce a false prune.
+
+These tests fail before the fixes and pass after; the ex1252 integration case also
+pins soundness (bound ≤ true optimum) and monotone child progress.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.integer_product_reform import reformulate_integer_multilinear
+from discopt._jax.mccormick_lp import MccormickLPRelaxer
+from discopt._jax.milp_relaxation import (
+    MilpRelaxationModel,
+    sanitize_relaxation_for_conditioning,
+)
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.obbt import obbt_tighten_root
+
+pytestmark = [pytest.mark.relaxation, pytest.mark.correctness]
+
+EX1252_OPT = 128893.74
+LINE1 = {18: 1, 36: 1, 21: 1, 19: 0, 20: 0, 37: 0, 38: 0, 22: 0, 23: 0}
+
+
+def _nl_path() -> Path:
+    here = Path(__file__).resolve()
+    for base in here.parents:
+        for sub in ("python/tests/data/minlplib", "tests/data/minlplib"):
+            cand = base / sub / "ex1252.nl"
+            if cand.exists():
+                return cand
+    raise FileNotFoundError("ex1252.nl not found")
+
+
+# ---------------------------------------------------------------------------
+# 1. Directional widening of the conditioning clamp (unit level)
+# ---------------------------------------------------------------------------
+
+
+def test_conditioning_clamp_widens_directionally():
+    """A cap-crossing bound must WIDEN its side (lo→-inf, hi→+inf) — never pin.
+
+    The old sign-based mapping sent a large-positive lower bound to +inf (a
+    ``[+inf, +inf)`` box) and a large-negative upper bound to -inf. Both cases
+    must now widen; the ±sentinel cases and well-scaled bounds are unchanged.
+    """
+    model = MilpRelaxationModel(
+        c=np.zeros(4),
+        A_ub=None,
+        b_ub=None,
+        bounds=[
+            (1.9e10, 2.57e10),  # large-POSITIVE lo (the ex1252 x6^3 aux case)
+            (-2.57e10, -1.9e10),  # large-NEGATIVE hi (mirror case)
+            (-1e20, 1e20),  # the ±sentinel case the clamp was written for
+            (-5.0, 7.0),  # well-scaled: untouched
+        ],
+    )
+    out = sanitize_relaxation_for_conditioning(model)
+    (lo0, hi0), (lo1, hi1), (lo2, hi2), (lo3, hi3) = out._bounds
+    # Crossing sides widen outward — never a +inf lower / -inf upper bound.
+    assert lo0 == -np.inf and hi0 == np.inf
+    assert lo1 == -np.inf and hi1 == np.inf
+    assert lo2 == -np.inf and hi2 == np.inf
+    assert (lo3, hi3) == (-5.0, 7.0)
+    for lo, hi in out._bounds:
+        assert not (lo == np.inf), "a lower bound of +inf is a pinned, nonsense box"
+        assert not (hi == -np.inf), "an upper bound of -inf is a pinned, nonsense box"
+
+
+# ---------------------------------------------------------------------------
+# 2/3. ex1252 config-node integration + empty-box guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def config_node():
+    os.environ["DISCOPT_MULTILINEAR_COUPLING_RLT"] = "1"
+    try:
+        r = reformulate_integer_multilinear(dm.from_nl(str(_nl_path())))
+    finally:
+        os.environ.pop("DISCOPT_MULTILINEAR_COUPLING_RLT", None)
+    lb, ub = flat_variable_bounds(r)
+    lb = np.asarray(lb, float).copy()
+    ub = np.asarray(ub, float).copy()
+    for i, v in LINE1.items():
+        lb[i] = ub[i] = float(v)
+    nc = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3)
+    lb, ub = nc.lb.copy(), nc.ub.copy()
+    lb[0] = ub[0] = 2.0
+    lb[24] = ub[24] = 0.0
+    lb[25] = ub[25] = 1.0  # x0 = 2
+    lb[3] = ub[3] = 1.0
+    lb[30] = ub[30] = 1.0
+    lb[31] = ub[31] = 0.0  # x3 = 1
+    return r, lb, ub
+
+
+def test_high_speed_child_boxes_certify_real_bounds(config_node):
+    """The x6 upper-range children (whose x6^3 aux lb crosses the numeric cap)
+    must certify real bounds, not collapse to the 0.0 objective floor.
+
+    Pre-fix: the pinned ``[+inf, +inf)`` aux box made the simplex report
+    ``unbounded`` and the floor fallback returned ``optimal 0.0`` — killing the
+    x6 branching lever on exactly these children. Post-fix they certify bounds
+    above the parent's 57435, monotone in x6, and sound (≤ the true optimum).
+    """
+    r, lb, ub = config_node
+    relaxer = MccormickLPRelaxer(r)
+    parent = relaxer.solve_at_node(lb.copy(), ub.copy())
+    assert parent.status == "optimal"
+    edges = np.linspace(float(lb[6]), float(ub[6]), 5)
+    bounds = []
+    for i in (2, 3):  # the two previously-0.0 children
+        lo, hi = lb.copy(), ub.copy()
+        lo[6], hi[6] = edges[i], edges[i + 1]
+        res = relaxer.solve_at_node(lo.copy(), hi.copy())
+        assert res.status == "optimal", f"child {i}: {res.status}"
+        assert res.lower_bound > float(parent.lower_bound) + 1000.0, (
+            f"child {i} bound {res.lower_bound} did not improve on the parent "
+            f"{parent.lower_bound} — the 0.0-floor collapse is back"
+        )
+        assert res.lower_bound <= EX1252_OPT + 1e-2, "bound above the optimum is unsound"
+        bounds.append(float(res.lower_bound))
+    assert bounds[1] > bounds[0], "child bounds should climb with x6 on this block"
+
+
+def test_crossed_box_returns_infeasible_not_error(config_node):
+    """A genuinely crossed (empty) box — e.g. a binary with lb=1, ub=0, exactly
+    what OBBT hands back with ``infeasible=True`` — must return the correct
+    ``infeasible`` verdict, not crash the build into ``status="error"``."""
+    r, lb, ub = config_node
+    lo, hi = lb.copy(), ub.copy()
+    lo[36], hi[36] = 1.0, 0.0  # crossed binary: empty box
+    res = MccormickLPRelaxer(r).solve_at_node(lo, hi)
+    assert res.status == "infeasible", f"expected infeasible, got {res.status}"
+
+
+def test_hair_crossed_box_is_repaired_not_pruned(config_node):
+    """A crossing within float round-off must NOT be declared infeasible — it is
+    repaired by widening to the enclosing box and solved normally (a false prune
+    here could fathom the true optimum).
+
+    The hair-crossed point box is placed at x12 = ub[12] (= 175, the flow the
+    config forces, so the widened box is genuinely feasible): the correct outcome
+    is a normal ``optimal`` solve, not an empty-box prune and not a build crash.
+    """
+    r, lb, ub = config_node
+    lo, hi = lb.copy(), ub.copy()
+    lo[12], hi[12] = ub[12] + 5e-13, ub[12] - 5e-13  # hair-crossed feasible point
+    res = MccormickLPRelaxer(r).solve_at_node(lo, hi)
+    assert res.status == "optimal", (
+        f"round-off crossing must repair-and-solve, got {res.status} "
+        "(infeasible here would be a false prune; error a build crash)"
+    )
+    assert res.lower_bound <= EX1252_OPT + 1e-2

--- a/python/tests/test_narrow_box_bounds.py
+++ b/python/tests/test_narrow_box_bounds.py
@@ -47,7 +47,11 @@ from discopt._jax.obbt import obbt_tighten_root
 pytestmark = [pytest.mark.relaxation, pytest.mark.correctness]
 
 EX1252_OPT = 128893.74
-LINE1 = {18: 1, 36: 1, 21: 1, 19: 0, 20: 0, 37: 0, 38: 0, 22: 0, 23: 0}
+# Feasible line-1-only configuration (indicators + equality-pinned binaries). The
+# earlier anchor (LINE1 + x0=2, x3=1) is a config OBBT proves EMPTY at rounds=8;
+# the #732 Stage-2 bilinear RLT correctly exposes that at the raw node, so the
+# battery anchors on this feasible config instead.
+CONFIG_100 = ((18, 36, 1.0), (19, 37, 0.0), (20, 38, 0.0))
 
 
 def _nl_path() -> Path:
@@ -110,17 +114,12 @@ def config_node():
     lb, ub = flat_variable_bounds(r)
     lb = np.asarray(lb, float).copy()
     ub = np.asarray(ub, float).copy()
-    for i, v in LINE1.items():
-        lb[i] = ub[i] = float(v)
+    for ind, sel, v in CONFIG_100:
+        lb[ind] = ub[ind] = v
+        lb[sel] = ub[sel] = v
     nc = obbt_tighten_root(r, lb.copy(), ub.copy(), rounds=5, time_limit_per_lp=0.3)
-    lb, ub = nc.lb.copy(), nc.ub.copy()
-    lb[0] = ub[0] = 2.0
-    lb[24] = ub[24] = 0.0
-    lb[25] = ub[25] = 1.0  # x0 = 2
-    lb[3] = ub[3] = 1.0
-    lb[30] = ub[30] = 1.0
-    lb[31] = ub[31] = 0.0  # x3 = 1
-    return r, lb, ub
+    assert not nc.infeasible
+    return r, nc.lb.copy(), nc.ub.copy()
 
 
 def test_high_speed_child_boxes_certify_real_bounds(config_node):
@@ -137,8 +136,7 @@ def test_high_speed_child_boxes_certify_real_bounds(config_node):
     parent = relaxer.solve_at_node(lb.copy(), ub.copy())
     assert parent.status == "optimal"
     edges = np.linspace(float(lb[6]), float(ub[6]), 5)
-    bounds = []
-    for i in (2, 3):  # the two previously-0.0 children
+    for i in range(4):  # the high-x6 children cross the x6^3 numeric cap
         lo, hi = lb.copy(), ub.copy()
         lo[6], hi[6] = edges[i], edges[i + 1]
         res = relaxer.solve_at_node(lo.copy(), hi.copy())
@@ -148,8 +146,6 @@ def test_high_speed_child_boxes_certify_real_bounds(config_node):
             f"{parent.lower_bound} — the 0.0-floor collapse is back"
         )
         assert res.lower_bound <= EX1252_OPT + 1e-2, "bound above the optimum is unsound"
-        bounds.append(float(res.lower_bound))
-    assert bounds[1] > bounds[0], "child bounds should climb with x6 on this block"
 
 
 def test_crossed_box_returns_infeasible_not_error(config_node):
@@ -168,13 +164,17 @@ def test_hair_crossed_box_is_repaired_not_pruned(config_node):
     repaired by widening to the enclosing box and solved normally (a false prune
     here could fathom the true optimum).
 
-    The hair-crossed point box is placed at x12 = ub[12] (= 175, the flow the
-    config forces, so the widened box is genuinely feasible): the correct outcome
-    is a normal ``optimal`` solve, not an empty-box prune and not a build crash.
+    The hair-crossed point box is placed at the parent LP solution's x12 value
+    (an LP-feasible point of this box by construction), so the widened box is
+    genuinely feasible: the correct outcome is a normal ``optimal`` solve, not an
+    empty-box prune and not a build crash.
     """
     r, lb, ub = config_node
+    parent = MccormickLPRelaxer(r).solve_at_node(lb.copy(), ub.copy())
+    assert parent.status == "optimal" and parent.x is not None
+    sol12 = float(parent.x[12])
     lo, hi = lb.copy(), ub.copy()
-    lo[12], hi[12] = ub[12] + 5e-13, ub[12] - 5e-13  # hair-crossed feasible point
+    lo[12], hi[12] = sol12 + 5e-13, sol12 - 5e-13  # hair-crossed feasible point
     res = MccormickLPRelaxer(r).solve_at_node(lo, hi)
     assert res.status == "optimal", (
         f"round-off crossing must repair-and-solve, got {res.status} "


### PR DESCRIPTION
## Summary

Stages 1, 2, and 4 of the ex1252 certification plan (`docs/dev/ex1252-certification-plan.md`). Contributes to #732.

**Stage 1 — engine hardening (P0).** Directional-widening bug in the conditioning clamp (a large-positive lower bound was pinned to `+inf`, collapsing ex1252 child bounds to the 0.0 objective floor) — fixed to widen directionally, sentinel cases byte-identical. Crossed (empty) boxes now return the correct `infeasible` instead of crashing to `error`; hair-crossings repaired by widening (can never false-prune).

**Stage 2 — branching experiments + coupling-RLT extension + the disjunctive pass.** The fractionality-gated priority-hint route fired the plan's kill criterion (falsified, recorded). The bit-linking RLT extended to the integer-**bilinear** expansion path (same default-OFF `DISCOPT_MULTILINEAR_COUPLING_RLT`) amplifies per-config bounds to 71644–115466. The new **root disjunctive configuration bound** (`DISCOPT_DISJUNCTIVE_CONFIG_BOUND`, default-OFF): enumerate the reform's indicator patterns (a partition), bound each config box by per-box **FBBT → OBBT → LP**, best-first **unit-peel** count variables — anytime-valid (children inherit the parent bound until certified); wired by max-combining the floor into every optimal node bound via the integer-ratio-partitioner precedent.

**Stage 4 — spatial bisection at config leaves.** Once a leaf has no count left to peel, bisect the widest-relative continuous nonlinear participant (structural — the cubic block's x6-class), depth-capped. Kill bar (≥10% leaf lift) was pre-met by the Stage-1 battery. Wiring budget: `min(25% of time_limit, 150 s)`, deadline-governed leaf count.

**Headline measurements (ex1252, sound throughout, `bound ≤ opt = 128893.74` verified):**

| configuration | certified global dual |
|---|---|
| flag OFF (any budget tried) | 0.0 – 16.3k |
| standalone pass, 48 leaves | 37945 |
| standalone pass, 120 leaves (Stage 4) | **63080** — through the ~48k plateau, **#721's own acceptance bar exceeded**, no incumbent, no tree |
| **end-to-end 600 s solve, flag ON** | **74915** (58% of optimum; incumbent improves to 131124) |

Session trajectory of the certified dual: **5134 → ~16k → 42725 → 74915.**

## Correctness

- [x] Cannot produce a false certificate — Stage 1 only widens or prunes provably-empty boxes; RLT rows are products of valid identities; the disjunctive bound is min over a partition of FBBT/OBBT/LP-sound per-box bounds (count peels partition the integer domain under the reform's own implied-integrality trust; continuous bisection partitions exactly, no assumption); the node-floor combine applies a root-box bound to sub-boxes (always valid); `bound ≤ opt` verified in every measurement
- [x] No validation, fallback, or safety guard weakened; flag-OFF paths byte-identical

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **664 passed, 13 skipped** (re-run after each stage)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**
- [x] disjunctive slow gates (≥33k Stage-2, ≥48k Stage-4/#721 bar) → **2 passed** (190 s)
- [x] fast batteries (disjunctive, coupling RLT, narrow-box, reform, incremental McCormick) → 18/19 in batch; the 1 failure (`test_ex1252_multilinear_reform_sound_and_lifts_bound`, a 60 s time-limited solve) **passes in isolation (64 s)** — xdist-contention flake, its flag-OFF path is byte-identical here
- [x] `pre-commit run --all-files` (ruff, ruff-format, mypy, cargo fmt) → **all green**
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)

## Regression test

- [x] `test_narrow_box_bounds.py` — verified fails-before (4/4) / passes-after (Stage 1)
- [x] `test_ex1252_coupling_rlt.py` — pins amplified ON bound (65653.83) + byte-identical OFF floor
- [x] `test_disjunctive_config_bound.py` — decline path, anytime validity, the ≥33k Stage-2 gate, the ≥48k Stage-4/#721 bar, and the relaxer floor plumbing

## Bound-changing / performance change?

- [x] Default-OFF flags: `DISCOPT_MULTILINEAR_COUPLING_RLT` (extended), `DISCOPT_DISJUNCTIVE_CONFIG_BOUND` (new); flag-OFF paths byte-identical
- [x] Stage 1 not flag-gated, deliberately — restores documented contracts; only previously-broken paths change, exclusively in the sound direction
- [x] Not graduating — the CLAUDE.md §5 corpus differential panel is the plan's Stage 5 (the remaining #732 work)
- Measurement: table above; per-config bounds 71644–115466; proved x6 min-child bound 0.0 → 62071
