### PR TITLE
fix(correctness): #739 abs() misclassified as linear — false optimal via LP fast path

### DIFF
--- a/crates/discopt-core/src/expr.rs
+++ b/crates/discopt-core/src/expr.rs
@@ -959,11 +959,15 @@ impl ExprArena {
             ExprNode::UnaryOp { op, operand } => match op {
                 UnOp::Neg => self.max_degree(*operand),
                 UnOp::Abs => {
-                    // abs is not polynomial in general, but for structure
-                    // detection we treat abs(linear) as degree 1.
-                    let d = self.max_degree(*operand);
-                    if d <= 1 {
-                        d
+                    // abs(constant) is a constant, but abs of anything
+                    // variable-dependent is piecewise and NOT polynomial:
+                    // classifying abs(linear) as degree 1 routed |x| models
+                    // onto the LP fast path, whose extractors bake in one
+                    // side's slope and certify a false optimum / drop the
+                    // constraint (issue #739). FunctionCall(Abs) below already
+                    // returns usize::MAX for the same reason.
+                    if self.max_degree(*operand) == 0 {
+                        0
                     } else {
                         usize::MAX
                     }
@@ -1775,6 +1779,59 @@ mod tests {
         });
         assert!(!arena.is_linear(exp_x));
         assert!(!arena.is_quadratic(exp_x));
+    }
+
+    #[test]
+    fn test_abs_of_variable_is_not_linear_or_quadratic() {
+        // Issue #739: abs(linear) is piecewise linear, NOT linear. Classifying
+        // it as degree 1 sent |x| models down the LP fast path, which baked in
+        // one side's slope (false optimal certificate / dropped constraint).
+        let mut arena = ExprArena::new();
+        let x0 = arena.add(ExprNode::Variable {
+            name: "x".into(),
+            index: 0,
+            size: 1,
+            shape: vec![],
+        });
+        let abs_x = arena.add(ExprNode::UnaryOp {
+            op: UnOp::Abs,
+            operand: x0,
+        });
+        assert!(!arena.is_linear(abs_x));
+        assert!(!arena.is_quadratic(abs_x));
+
+        // abs buried in an otherwise-linear sum still poisons the degree.
+        let c3 = arena.add(ExprNode::Constant(3.0));
+        let sum = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Add,
+            left: abs_x,
+            right: c3,
+        });
+        assert!(!arena.is_linear(sum));
+        assert!(!arena.is_quadratic(sum));
+    }
+
+    #[test]
+    fn test_abs_of_constant_is_constant_degree() {
+        // abs of a genuine constant folds to degree 0: x + |c| must stay linear.
+        let mut arena = ExprArena::new();
+        let c = arena.add(ExprNode::Constant(-3.0));
+        let abs_c = arena.add(ExprNode::UnaryOp {
+            op: UnOp::Abs,
+            operand: c,
+        });
+        let x0 = arena.add(ExprNode::Variable {
+            name: "x".into(),
+            index: 0,
+            size: 1,
+            shape: vec![],
+        });
+        let sum = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Add,
+            left: x0,
+            right: abs_c,
+        });
+        assert!(arena.is_linear(sum));
     }
 
     #[test]

--- a/python/tests/test_issue_739_abs_linearity_misclassification.py
+++ b/python/tests/test_issue_739_abs_linearity_misclassification.py
@@ -1,0 +1,117 @@
+"""Regression tests for issue #739 — abs() models misclassified as LP.
+
+``ExprArena::max_degree`` treated ``UnOp::Abs`` of a linear operand as degree 1
+("abs(linear) as degree 1" for structure detection), so ``|x|`` objectives and
+constraints classified as LP. The LP fast path's extractors then probed the model
+pointwise (unit-vector / Jacobian samples), which cannot distinguish a piecewise
+linear function from a linear one: they baked in one side's slope, turning
+``min |x|`` into ``min x`` (false optimal certificate) and ``|x| <= c`` into
+``x <= c`` (constraint silently dropped, violated at the returned point).
+
+The fix makes ``UnOp::Abs`` of anything variable-dependent non-polynomial
+(``usize::MAX``), matching the existing ``FunctionCall(Abs)`` handling, so such
+models classify NLP/MINLP and route to the spatial B&B whose piecewise
+relaxation certifies them exactly.
+
+Each solve assertion below FAILS on pre-fix ``main`` (status='optimal' with
+objective -1.0 / -2.0) and passes after the fix.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.modeling.core import Model
+
+# ── classification: abs must never classify as LP/QP ─────────────────────────
+
+
+@pytest.mark.smoke
+def test_abs_objective_not_classified_lp():
+    from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+    m = Model("absmin")
+    x = m.continuous("x", lb=-1.0, ub=2.0)
+    m.minimize(abs(x))
+    assert classify_problem(m) == ProblemClass.NLP
+
+
+@pytest.mark.smoke
+def test_abs_constraint_not_classified_lp():
+    from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+    m = Model("abscon")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    m.subject_to(abs(x) <= 0.5)
+    m.minimize(x)
+    assert classify_problem(m) == ProblemClass.NLP
+
+
+@pytest.mark.smoke
+def test_abs_nested_in_linear_sum_not_classified_lp_or_qp():
+    """abs buried in an otherwise linear/quadratic body still poisons the degree."""
+    from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+    m = Model("absnested")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    m.subject_to(2.0 * y + abs(x - 1.0) <= 1.5)
+    m.minimize(x + y)
+    assert classify_problem(m) == ProblemClass.NLP
+
+
+@pytest.mark.smoke
+def test_abs_objective_rust_repr_not_linear():
+    """Probe the Rust fix directly: |x| is neither linear nor quadratic."""
+    model_to_repr = pytest.importorskip("discopt._rust").model_to_repr
+
+    m = Model("absrepr")
+    x = m.continuous("x", lb=-1.0, ub=2.0)
+    m.minimize(abs(x))
+    repr_ = model_to_repr(m, None)
+    assert not repr_.is_objective_linear()
+    assert not repr_.is_objective_quadratic()
+
+
+@pytest.mark.smoke
+def test_plain_linear_model_still_classified_lp():
+    """Control: the abs refusal must not over-reach onto genuinely linear models."""
+    from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+    m = Model("lin")
+    x = m.continuous("x", lb=-1.0, ub=2.0)
+    m.subject_to(x >= -0.5)
+    m.minimize(2.0 * x + 1.0)
+    assert classify_problem(m) == ProblemClass.LP
+
+
+# ── end-to-end: the false-optimal repros from the issue ──────────────────────
+
+
+@pytest.mark.smoke
+def test_abs_objective_solves_to_true_optimum():
+    """min |x| over [-1, 2]: true optimum 0 at x=0 (pre-fix: -1.0 at x=-1)."""
+    m = Model("absmin")
+    x = m.continuous("x", lb=-1.0, ub=2.0)
+    m.minimize(abs(x))
+    res = m.solve(time_limit=30.0)
+    assert res.status == "optimal"
+    assert abs(res.objective - 0.0) < 1e-5, f"got {res.objective}, want 0.0"
+    xv = float(np.asarray(res.x["x"]).reshape(()))
+    # The reported objective must match the model at the returned point.
+    assert abs(abs(xv) - res.objective) < 1e-5
+
+
+@pytest.mark.smoke
+def test_abs_constraint_not_dropped():
+    """min x s.t. |x| <= 0.5 over [-2, 2]: true optimum -0.5 (pre-fix: -2.0,
+    with the constraint violated at the returned point)."""
+    m = Model("abscon")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    m.subject_to(abs(x) <= 0.5)
+    m.minimize(x)
+    res = m.solve(time_limit=30.0)
+    assert res.status == "optimal"
+    xv = float(np.asarray(res.x["x"]).reshape(()))
+    assert abs(xv) <= 0.5 + 1e-5, f"|x| <= 0.5 violated at returned point x={xv}"
+    assert abs(res.objective - (-0.5)) < 1e-4, f"got {res.objective}, want -0.5"


### PR DESCRIPTION
## Summary

Closes #739. `min |x|` over a box straddling the kink returned a false optimal certificate (`objective=-1.0` at `x=-1` instead of `0.0` at `x=0`), and an `|x| <= c` constraint was silently dropped (violated at the returned point). Root cause: `ExprArena::max_degree` in `crates/discopt-core/src/expr.rs` deliberately treated `UnOp::Abs` of a linear operand as degree 1 ("for structure detection"), so `is_objective_linear()` / `is_constraint_linear()` returned true, `classify_problem` said LP, and the LP fast path's pointwise extractors (unit-vector / Jacobian probes, which cannot distinguish piecewise linear from linear) baked in one side's slope.

The fix makes `UnOp::Abs` of anything variable-dependent non-polynomial (`usize::MAX`), with `abs(constant)` staying degree 0 — matching the existing `FunctionCall(Abs)` handling. `max_degree` is the single choke point for all classification paths (expression API, fast-builder API, `.nl` parser), so this fixes the class, not the named instances; `min`/`max`/norms already returned non-polynomial. Such models now classify NLP/MINLP and route to the spatial B&B, whose exact piecewise relaxation certifies them (both repros now certify their true optima 0.0 / -0.5). The only other in-crate `is_linear` consumer (OBBT's row gate) also required abs to be non-linear for soundness; its own coefficient extractor already refused `UnOp::Abs`.

## Correctness

Classification-only change in the strictly conservative direction: a class of piecewise-linear models previously (unsoundly) sent to LP/QP fast paths now goes to the sound spatial B&B. No relaxation, bound, or cut math changed. A control test confirms genuinely linear models still classify LP.

- [x] Cannot produce a false certificate (or: N/A — no solver-math change)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 671 passed, 13 skipped
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 10 passed
- [x] `cargo test -p discopt-core` → 468 passed (incl. 2 new unit tests)
- [x] `ruff check` / `ruff format --check` clean; `cargo fmt --check` clean

## Regression test

- [x] Added a regression test that fails before / passes after (or: N/A — docs/refactor only)

`python/tests/test_issue_739_abs_linearity_misclassification.py` (7 tests: classification for abs objective / constraint / nested body, direct Rust-repr probe, LP control, and both end-to-end repros from the issue) — verified red on pre-fix build via stash/rebuild/re-run, green after. Rust side: `test_abs_of_variable_is_not_linear_or_quadratic`, `test_abs_of_constant_is_constant_degree` in `expr.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FhAz2Ure3TfDnXCtk7ocP

---
_Generated by [Claude Code](https://claude.ai/code/session_017FhAz2Ure3TfDnXCtk7ocP)_