### PR TITLE
feat(#671): tight hda dual bound — row filter + RHS-regularized refinement + hardening primitive

### DIFF
--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -91,8 +91,21 @@ pub fn solve_lp_warm_csc(
             // grind bails with `IterLimit` and falls through to the original verdict
             // (candidate A) instead of hanging — the flag can only *rescue*, never
             // stall the solve. A clean hardened solve finishes far inside the cap.
+            // Bound BOTH pivots and wall time: the root's OBBT/FBBT fixpoint issues
+            // many LP solves, so an unbounded (or only iteration-bounded) hardened
+            // re-solve on the m~3000 refactor-heavy basis compounds. A short wall
+            // deadline guarantees each retry terminates regardless of per-pivot cost.
+            let deadline = {
+                let cap = std::time::Instant::now()
+                    + std::time::Duration::from_millis(HARDENING_RETRY_DEADLINE_MS);
+                Some(match opts.deadline {
+                    Some(d) => d.min(cap),
+                    None => cap,
+                })
+            };
             let opts_h = SimplexOptions {
                 max_iter: hardening_retry_iter_cap(m, n).min(opts.max_iter),
+                deadline,
                 ..opts.clone()
             };
             let hardened = super::linsolve::with_hardening_active(|| {
@@ -117,6 +130,11 @@ fn hardening_retry_iter_cap(m: usize, n: usize) -> usize {
         .saturating_mul(m.saturating_add(n))
         .saturating_add(2000)
 }
+
+/// Wall-clock budget (ms) per #671 hardened re-solve. A clean hardened solve of an
+/// unblocked basis returns well inside it; a degenerate grind is cut here so the
+/// flag can never stall the enclosing solve even when many node LPs fail.
+const HARDENING_RETRY_DEADLINE_MS: u64 = 3000;
 
 /// The body of [`solve_lp_warm_csc`] (scaling + warm/cold solve + the #649 unscaled
 /// retry). Split out so the #671 hardened retry can re-run it under

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -19,7 +19,7 @@
 
 #![allow(clippy::needless_range_loop)]
 
-use super::linsolve::{FeralLU, LinearSolver};
+use super::linsolve::{node_feral_lu, FeralLU, LinearSolver};
 use super::primal::{solve_lp_cols, solve_lp_cols_warm};
 use super::scaling::{ScaledLp, Scaling};
 use super::sparse::SparseCols;
@@ -64,6 +64,45 @@ pub fn solve_lp_warm(lp: &LpView<'_>, b: &[f64], start: &Basis, opts: &SimplexOp
 /// entries and touching ~19k per solve. `start` is `(col_status, basic_vars)`.
 #[allow(clippy::too_many_arguments)]
 pub fn solve_lp_warm_csc(
+    sp: SparseCols,
+    m: usize,
+    n: usize,
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    start: Option<&Basis>,
+    opts: &SimplexOptions,
+) -> LpSolve {
+    // #671 factorization hardening (default OFF): if the solve breaks down
+    // numerically — a near-singular basis feral's strict LU cannot factorize (the
+    // hda-class ill-conditioned relaxations) — retry once with `PerturbToEps` +
+    // double-double refined solves so the basis completes and the node yields a
+    // usable dual. Failure-triggered; the cloned CSC is paid only when the flag is
+    // on. A retry that also fails falls through to the original verdict.
+    let retry_sp = super::linsolve::hardening_retry_available().then(|| sp.clone());
+    let sol = solve_lp_warm_csc_inner(sp, m, n, c, l, u, b, start, opts);
+    if let Some(sp2) = retry_sp {
+        if matches!(sol.status, LpStatus::Numerical | LpStatus::IterLimit) {
+            let hardened = super::linsolve::with_hardening_active(|| {
+                solve_lp_warm_csc_inner(sp2, m, n, c, l, u, b, start, opts)
+            });
+            if matches!(
+                hardened.status,
+                LpStatus::Optimal | LpStatus::Infeasible | LpStatus::Unbounded
+            ) {
+                return hardened;
+            }
+        }
+    }
+    sol
+}
+
+/// The body of [`solve_lp_warm_csc`] (scaling + warm/cold solve + the #649 unscaled
+/// retry). Split out so the #671 hardened retry can re-run it under
+/// [`super::linsolve::with_hardening_active`] without recursing.
+#[allow(clippy::too_many_arguments)]
+fn solve_lp_warm_csc_inner(
     mut sp: SparseCols,
     m: usize,
     n: usize,
@@ -239,7 +278,7 @@ impl<'a> PreparedDual<'a> {
             return None;
         }
 
-        let mut lu = FeralLU::new();
+        let mut lu = node_feral_lu();
         // Sparse basis columns straight from the CSC view — O(nnz) factorize, no
         // dense m×m basis (discopt#268 / feral#87). Bit-identical to `col()`.
         let cols: Vec<Vec<(usize, f64)>> = basis
@@ -840,7 +879,7 @@ fn refined_basic_values(
             col
         })
         .collect();
-    let mut lu = FeralLU::new().with_numeric_focus();
+    let mut lu = node_feral_lu().with_numeric_focus();
     lu.factorize(m, &cols).ok()?;
     let mut xb = reduced_rhs(sp, b, n, l, u, stat);
     lu.ftran_refined(&mut xb).ok()?;

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -84,8 +84,19 @@ pub fn solve_lp_warm_csc(
     let sol = solve_lp_warm_csc_inner(sp, m, n, c, l, u, b, start, opts);
     if let Some(sp2) = retry_sp {
         if matches!(sol.status, LpStatus::Numerical | LpStatus::IterLimit) {
+            // Bound the hardened re-solve: a completed factorization lets the simplex
+            // *proceed* on the near-singular basis, but the ill-conditioned LP can
+            // still pivot-grind (this is the intrinsic hardness #671 tracks). Cap the
+            // pivots (size-derived, ≤ the caller's `max_iter`) so a node that would
+            // grind bails with `IterLimit` and falls through to the original verdict
+            // (candidate A) instead of hanging — the flag can only *rescue*, never
+            // stall the solve. A clean hardened solve finishes far inside the cap.
+            let opts_h = SimplexOptions {
+                max_iter: hardening_retry_iter_cap(m, n).min(opts.max_iter),
+                ..opts.clone()
+            };
             let hardened = super::linsolve::with_hardening_active(|| {
-                solve_lp_warm_csc_inner(sp2, m, n, c, l, u, b, start, opts)
+                solve_lp_warm_csc_inner(sp2, m, n, c, l, u, b, start, &opts_h)
             });
             if matches!(
                 hardened.status,
@@ -96,6 +107,15 @@ pub fn solve_lp_warm_csc(
         }
     }
     sol
+}
+
+/// Pivot cap for the #671 hardened re-solve: `8·(m+n) + 2000`, so a healthy solve
+/// (a few multiples of `m+n` pivots) always finishes inside it while a degenerate
+/// near-singular grind is bounded well below the `100 000`-pivot default.
+fn hardening_retry_iter_cap(m: usize, n: usize) -> usize {
+    8usize
+        .saturating_mul(m.saturating_add(n))
+        .saturating_add(2000)
 }
 
 /// The body of [`solve_lp_warm_csc`] (scaling + warm/cold solve + the #649 unscaled

--- a/crates/discopt-core/src/lp/simplex/linsolve.rs
+++ b/crates/discopt-core/src/lp/simplex/linsolve.rs
@@ -403,9 +403,13 @@ impl FeralLU {
     }
 
     /// Whether basis retention (and hence a refined solve) is active: a positive
-    /// refine depth **or** singular-perturb hardening.
+    /// refine depth. **Not** implied by singular-perturb alone — retention is an
+    /// O(m²) dense copy per factorization, and the hot hardened solve does not need
+    /// it (its plain ftran/btran are raw; only the audit-path recovery, which builds
+    /// its own numeric-focus LU, refines). A caller that wants a refined solve on a
+    /// hardened factor combines `with_singular_perturb` with `with_numeric_focus`.
     fn refine_enabled(&self) -> bool {
-        self.refine_steps > 0 || self.singular_perturb.is_some()
+        self.refine_steps > 0
     }
 
     /// The [`LuParams`] for this solver's factorizations, carrying the configured

--- a/crates/discopt-core/src/lp/simplex/linsolve.rs
+++ b/crates/discopt-core/src/lp/simplex/linsolve.rs
@@ -14,9 +14,10 @@
 //!   it refactorizes on every solve, so it is for bring-up, tiny bases, and
 //!   cross-checking `FeralLU` in tests — not performance.
 
+use super::refine::residual_dd;
 use feral::{
-    should_use_dense_lu, DenseLu, GeneralMatrix, LuParams, RefactorCause, SparseColMatrix,
-    SparseLu, SparseLuSymbolic,
+    should_use_dense_lu, DenseLu, GeneralMatrix, LuParams, LuSingularAction, RefactorCause,
+    SparseColMatrix, SparseLu, SparseLuSymbolic,
 };
 
 /// Error from a basis factorization/solve.
@@ -284,8 +285,18 @@ pub struct FeralLU {
     /// factorize time. `0` (default) → refinement is a no-op and no basis is
     /// retained, i.e. byte-for-byte the pre-numeric-focus behavior.
     refine_steps: usize,
-    /// The in-sync basis, populated iff `refine_steps > 0` (see [`RetainedBasis`]).
+    /// The in-sync basis, populated iff refinement or singular-perturb mode is on
+    /// (see [`RetainedBasis`]).
     retained: Option<RetainedBasis>,
+    /// Singular-pivot perturbation floor (issue #671 factorization hardening). When
+    /// `Some(abs_floor)`, the factorization uses `LuSingularAction::PerturbToEps`
+    /// so a near-singular basis (the hda-class ill-conditioned relaxations) yields
+    /// a *completed* factor of a nearby matrix `B'` instead of aborting
+    /// (`SingularBasis` → `Numerical`), and the refined solves recover accuracy
+    /// against the true `B` in **double-double** precision (feral's own
+    /// double-precision refinement was falsified on this class, #671). `None`
+    /// (default) → strict `Fail`, byte-identical to today.
+    singular_perturb: Option<f64>,
 }
 
 impl FeralLU {
@@ -312,17 +323,43 @@ impl FeralLU {
         self
     }
 
-    /// Whether refinement / signal queries are active (a positive refine depth).
+    /// Enable **factorization hardening** for near-singular bases (issue #671): the
+    /// factorization uses `LuSingularAction::PerturbToEps { abs_floor }` so a
+    /// singular / near-singular pivot is floored to `abs_floor` and the factor
+    /// *completes* (a nearby matrix `B'`) instead of aborting, and
+    /// [`ftran_refined`](LinearSolver::ftran_refined) /
+    /// [`btran_refined`](LinearSolver::btran_refined) run **double-double**
+    /// iterative refinement against the true retained `B` to recover accuracy.
+    ///
+    /// `abs_floor` must sit **below** the genuine small pivots of the class (else
+    /// the perturbed factor discards a direction the solution needs — see the entry
+    /// experiment in `regularized_lu.rs`); a small value like `1e-12` floors the
+    /// exactly-zero / sub-`zero_pivot_tol` pivots while preserving genuine ones.
+    /// Turns on basis retention (needed for the true-`B` residual). Failure-
+    /// triggered by design: callers escalate to this only when the strict factor
+    /// aborted, so with it unused every solve is byte-identical to today.
+    pub fn with_singular_perturb(mut self, abs_floor: f64) -> Self {
+        self.singular_perturb = Some(abs_floor);
+        self
+    }
+
+    /// Whether basis retention (and hence a refined solve) is active: a positive
+    /// refine depth **or** singular-perturb hardening.
     fn refine_enabled(&self) -> bool {
-        self.refine_steps > 0
+        self.refine_steps > 0 || self.singular_perturb.is_some()
     }
 
     /// The [`LuParams`] for this solver's factorizations, carrying the configured
-    /// refinement depth. All other fields are feral's defaults (strict partial
-    /// pivoting, `zero_pivot_tol = 1e-13`, etc.).
+    /// refinement depth and, when hardening is on, the `PerturbToEps` singular
+    /// action. All other fields are feral's defaults (strict partial pivoting,
+    /// `zero_pivot_tol = 1e-13`, etc.).
     fn params(&self) -> LuParams {
         LuParams {
             refine_steps: self.refine_steps,
+            on_singular: match self.singular_perturb {
+                Some(abs_floor) => LuSingularAction::PerturbToEps { abs_floor },
+                None => LuSingularAction::Fail,
+            },
             ..LuParams::default()
         }
     }
@@ -403,6 +440,65 @@ impl FeralLU {
             Some(Factored::Sparse(lu)) => lu.factor_nnz(),
             _ => 0,
         }
+    }
+
+    /// Double-double iterative refinement of `B x = rhs` (`transpose=false`) or
+    /// `Bᵀ x = rhs` (`transpose=true`) using the retained *true* basis `B` and the
+    /// current factor as the correction solver (issue #671 hardening). The residual
+    /// `rhs − B x` is accumulated in ≈106-bit double-double
+    /// ([`super::refine::residual_dd`]) — that high precision is what recovers
+    /// accuracy past a `PerturbToEps` factor's error (feral's own double-precision
+    /// refinement could not, #671). Used only when a retained basis is present;
+    /// falls back to the plain solve otherwise.
+    fn dd_refined(&mut self, rhs: &mut [f64], transpose: bool) -> Result<(), LinError> {
+        // A `PerturbToEps` factor of a near-singular basis has κ ≈ 1e14, so the
+        // Wilkinson refinement gains ~2 digits/step (κ·u ≈ 1e-2); 12 steps with an
+        // early exit is ample. Failure-triggered path — cost is off the hot loop.
+        const MAX_STEPS: usize = 12;
+        const TOL: f64 = 1e-13;
+        let (m, cols) = match self.retained.as_ref() {
+            Some(rb) => (rb.m, rb.cols.clone()),
+            None => {
+                return if transpose {
+                    self.btran(rhs)
+                } else {
+                    self.ftran(rhs)
+                }
+            }
+        };
+        let target = rhs.to_vec();
+        let mut x = vec![0.0f64; m];
+        for _ in 0..MAX_STEPS {
+            let mut r = vec![0.0f64; m];
+            let mut resnorm = 0.0f64;
+            for i in 0..m {
+                // Residual against the TRUE basis, high precision. For `Bᵀ` the
+                // i-th row is column i of B (`cols[i]`); for `B` it is gathered
+                // across columns.
+                let ri = if transpose {
+                    residual_dd(&cols[i], &x, target[i])
+                } else {
+                    let row: Vec<f64> = cols.iter().map(|c| c[i]).collect();
+                    residual_dd(&row, &x, target[i])
+                };
+                r[i] = ri;
+                resnorm = resnorm.max(ri.abs());
+            }
+            if resnorm <= TOL {
+                break;
+            }
+            // Correction through the (perturbed) factor: solve `B' dr = r`.
+            if transpose {
+                self.btran(&mut r)?;
+            } else {
+                self.ftran(&mut r)?;
+            }
+            for i in 0..m {
+                x[i] += r[i];
+            }
+        }
+        rhs.copy_from_slice(&x);
+        Ok(())
     }
 }
 
@@ -509,6 +605,11 @@ impl LinearSolver for FeralLU {
     }
 
     fn ftran_refined(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
+        // #671 hardening: in singular-perturb mode the factor is of a nearby `B'`,
+        // so recover accuracy against the true `B` in double-double precision.
+        if self.singular_perturb.is_some() {
+            return self.dd_refined(rhs, false);
+        }
         // Build the basis matrix first (immutable borrow, produces an owned
         // matrix), then solve (mutable borrow) — the two borrows don't overlap.
         let mat = match self.build_basis_matrix() {
@@ -527,6 +628,9 @@ impl LinearSolver for FeralLU {
     }
 
     fn btran_refined(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
+        if self.singular_perturb.is_some() {
+            return self.dd_refined(rhs, true);
+        }
         let mat = match self.build_basis_matrix() {
             Some(m) => m?,
             None => return self.btran(rhs),

--- a/crates/discopt-core/src/lp/simplex/linsolve.rs
+++ b/crates/discopt-core/src/lp/simplex/linsolve.rs
@@ -636,19 +636,17 @@ impl LinearSolver for FeralLU {
     }
 
     fn ftran(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
-        // #671 hardening: in singular-perturb mode the factor is of a nearby `B'`,
-        // so every solve is refined against the true `B` in double-double precision.
-        // The early-exit keeps well-conditioned solves cheap. Off mode → raw.
-        if self.singular_perturb.is_some() {
-            return self.dd_refined(rhs, false);
-        }
+        // #671 hardening keeps the hot-loop solve RAW even in singular-perturb mode:
+        // the perturbation only floors an already-tiny pivot (~1e-13 → abs_floor), so
+        // `B' ≈ B` and the simplex's pricing/ratio decisions are essentially
+        // unchanged — while a per-solve double-double refine would be O(m²) per pivot
+        // (the retained basis is dense) and dominate. Accuracy is recovered where it
+        // is *certified*: the audit path calls [`ftran_refined`], which runs the
+        // double-double refinement (`dd_refined`) against the true `B`.
         self.ftran_raw(rhs)
     }
 
     fn btran(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
-        if self.singular_perturb.is_some() {
-            return self.dd_refined(rhs, true);
-        }
         self.btran_raw(rhs)
     }
 

--- a/crates/discopt-core/src/lp/simplex/linsolve.rs
+++ b/crates/discopt-core/src/lp/simplex/linsolve.rs
@@ -14,7 +14,7 @@
 //!   it refactorizes on every solve, so it is for bring-up, tiny bases, and
 //!   cross-checking `FeralLU` in tests — not performance.
 
-use super::refine::residual_dd;
+use super::refine::residual_matvec_dd;
 use feral::{
     should_use_dense_lu, DenseLu, GeneralMatrix, LuParams, LuSingularAction, RefactorCause,
     SparseColMatrix, SparseLu, SparseLuSymbolic,
@@ -220,6 +220,65 @@ std::thread_local! {
 /// on this thread.
 fn route_suppressed() -> bool {
     DENSITY_ROUTE_SUPPRESSED.with(|s| s.get())
+}
+
+std::thread_local! {
+    /// #671 factorization hardening: while `true`, a solve on this thread builds its
+    /// basis factor with [`FeralLU::with_singular_perturb`] so a near-singular basis
+    /// completes (`PerturbToEps`) instead of aborting, and the refined solves recover
+    /// accuracy in double-double. Set only for the duration of a *failure-triggered*
+    /// hardened retry (see `hardening_retry` in `primal.rs`/`dual.rs`); thread-local
+    /// for the rayon-parallel B&B. Default off — no solve is affected unless a prior
+    /// solve numerically failed AND the flag is enabled.
+    static FACTORIZATION_HARDENING_ACTIVE: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+/// The `PerturbToEps` floor used by the hardened retry: below `zero_pivot_tol`
+/// (1e-13) so genuine small pivots are preserved, above 0 so exactly-singular /
+/// sub-tolerance pivots are floored and the factorization completes (the balance
+/// mapped by the `regularized_lu.rs` boundary experiment).
+pub(crate) const HARDENING_ABS_FLOOR: f64 = 1e-14;
+
+/// Whether the `DISCOPT_LP_FACTORIZATION_HARDENING` flag (default OFF) is enabled
+/// *and* no hardened retry is already in progress on this thread (a retry that
+/// fails again must fall through to the existing fallback chain, never recurse).
+pub(crate) fn hardening_retry_available() -> bool {
+    !FACTORIZATION_HARDENING_ACTIVE.with(|s| s.get())
+        && std::env::var("DISCOPT_LP_FACTORIZATION_HARDENING")
+            .map(|v| v != "0")
+            .unwrap_or(false)
+}
+
+/// Whether the hardened factorization mode is active on this thread (a hardened
+/// retry is in progress). Read at [`FeralLU`] construction in the simplex.
+pub(crate) fn hardening_active() -> bool {
+    FACTORIZATION_HARDENING_ACTIVE.with(|s| s.get())
+}
+
+/// A basis solver for a node solve, hardened iff a hardened retry is in progress:
+/// [`FeralLU::with_singular_perturb`] under [`hardening_active`], else the plain
+/// `FeralLU::new()` (byte-identical to today). The single construction helper the
+/// simplex uses so the mode is honored uniformly.
+pub(crate) fn node_feral_lu() -> FeralLU {
+    if hardening_active() {
+        FeralLU::new().with_singular_perturb(HARDENING_ABS_FLOOR)
+    } else {
+        FeralLU::new()
+    }
+}
+
+/// Run `f` with factorization hardening active on this thread (a hardened retry).
+/// Restores the previous state on exit, including on unwind.
+pub(crate) fn with_hardening_active<T>(f: impl FnOnce() -> T) -> T {
+    struct Restore(bool);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            FACTORIZATION_HARDENING_ACTIVE.with(|s| s.set(self.0));
+        }
+    }
+    let _guard = Restore(FACTORIZATION_HARDENING_ACTIVE.with(|s| s.replace(true)));
+    f()
 }
 
 /// #85: whether a *failed* LP solve may be retried on the dense route — true iff
@@ -451,54 +510,59 @@ impl FeralLU {
     /// refinement could not, #671). Used only when a retained basis is present;
     /// falls back to the plain solve otherwise.
     fn dd_refined(&mut self, rhs: &mut [f64], transpose: bool) -> Result<(), LinError> {
-        // A `PerturbToEps` factor of a near-singular basis has κ ≈ 1e14, so the
-        // Wilkinson refinement gains ~2 digits/step (κ·u ≈ 1e-2); 12 steps with an
-        // early exit is ample. Failure-triggered path — cost is off the hot loop.
+        // A `PerturbToEps` factor of a near-singular basis has κ ≈ 1/abs_floor, so
+        // the Wilkinson refinement gains ~`-log10(κ·u)` digits/step; a dozen steps
+        // with an early exit is ample and inert on well-conditioned solves (one
+        // correction, residual ≤ TOL, break). Failure-triggered path.
         const MAX_STEPS: usize = 12;
         const TOL: f64 = 1e-13;
-        let (m, cols) = match self.retained.as_ref() {
+        let (_m, cols) = match self.retained.as_ref() {
             Some(rb) => (rb.m, rb.cols.clone()),
             None => {
                 return if transpose {
-                    self.btran(rhs)
+                    self.btran_raw(rhs)
                 } else {
-                    self.ftran(rhs)
+                    self.ftran_raw(rhs)
                 }
             }
         };
         let target = rhs.to_vec();
-        let mut x = vec![0.0f64; m];
+        let mut x = vec![0.0f64; cols.len()];
         for _ in 0..MAX_STEPS {
-            let mut r = vec![0.0f64; m];
-            let mut resnorm = 0.0f64;
-            for i in 0..m {
-                // Residual against the TRUE basis, high precision. For `Bᵀ` the
-                // i-th row is column i of B (`cols[i]`); for `B` it is gathered
-                // across columns.
-                let ri = if transpose {
-                    residual_dd(&cols[i], &x, target[i])
-                } else {
-                    let row: Vec<f64> = cols.iter().map(|c| c[i]).collect();
-                    residual_dd(&row, &x, target[i])
-                };
-                r[i] = ri;
-                resnorm = resnorm.max(ri.abs());
-            }
+            // High-precision residual `target − (B or Bᵀ)·x`, sparse-aware O(nnz).
+            let mut r = residual_matvec_dd(&cols, &x, &target, transpose);
+            let resnorm = r.iter().fold(0.0f64, |a, &v| a.max(v.abs()));
             if resnorm <= TOL {
                 break;
             }
             // Correction through the (perturbed) factor: solve `B' dr = r`.
             if transpose {
-                self.btran(&mut r)?;
+                self.btran_raw(&mut r)?;
             } else {
-                self.ftran(&mut r)?;
+                self.ftran_raw(&mut r)?;
             }
-            for i in 0..m {
-                x[i] += r[i];
+            for (xi, ri) in x.iter_mut().zip(&r) {
+                *xi += ri;
             }
         }
         rhs.copy_from_slice(&x);
         Ok(())
+    }
+
+    /// Raw `B' x = rhs` solve through the current factor (no refinement).
+    fn ftran_raw(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
+        match self.lu.as_mut().ok_or(LinError::NotFactorized)? {
+            Factored::Sparse(lu) => lu.ftran(rhs).map_err(feral_err),
+            Factored::Dense(lu) => lu.ftran(rhs).map_err(feral_err),
+        }
+    }
+
+    /// Raw `B'ᵀ x = rhs` solve through the current factor (no refinement).
+    fn btran_raw(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
+        match self.lu.as_mut().ok_or(LinError::NotFactorized)? {
+            Factored::Sparse(lu) => lu.btran(rhs).map_err(feral_err),
+            Factored::Dense(lu) => lu.btran(rhs).map_err(feral_err),
+        }
     }
 }
 
@@ -572,17 +636,20 @@ impl LinearSolver for FeralLU {
     }
 
     fn ftran(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
-        match self.lu.as_mut().ok_or(LinError::NotFactorized)? {
-            Factored::Sparse(lu) => lu.ftran(rhs).map_err(feral_err),
-            Factored::Dense(lu) => lu.ftran(rhs).map_err(feral_err),
+        // #671 hardening: in singular-perturb mode the factor is of a nearby `B'`,
+        // so every solve is refined against the true `B` in double-double precision.
+        // The early-exit keeps well-conditioned solves cheap. Off mode → raw.
+        if self.singular_perturb.is_some() {
+            return self.dd_refined(rhs, false);
         }
+        self.ftran_raw(rhs)
     }
 
     fn btran(&mut self, rhs: &mut [f64]) -> Result<(), LinError> {
-        match self.lu.as_mut().ok_or(LinError::NotFactorized)? {
-            Factored::Sparse(lu) => lu.btran(rhs).map_err(feral_err),
-            Factored::Dense(lu) => lu.btran(rhs).map_err(feral_err),
+        if self.singular_perturb.is_some() {
+            return self.dd_refined(rhs, true);
         }
+        self.btran_raw(rhs)
     }
 
     fn update(&mut self, leaving_slot: usize, entering_col: &[f64]) -> Result<(), LinError> {

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -22,6 +22,7 @@ pub mod linsolve;
 pub mod presolve;
 pub mod primal;
 pub mod refine;
+pub mod regularized_lu;
 pub mod scaling;
 pub mod sparse;
 

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -21,6 +21,7 @@ pub mod dual;
 pub mod linsolve;
 pub mod presolve;
 pub mod primal;
+pub mod refine;
 pub mod scaling;
 pub mod sparse;
 

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -15,7 +15,7 @@
 // range loop is clearer than zipping multiple slices.
 #![allow(clippy::needless_range_loop)]
 
-use super::linsolve::{FeralLU, LinearSolver};
+use super::linsolve::{node_feral_lu, FeralLU, LinearSolver};
 use super::scaling::{ScaledLp, Scaling};
 use super::sparse::SparseCols;
 use super::{LpSolve, LpStatus, SimplexOptions};
@@ -594,7 +594,7 @@ impl<'a> Simplex<'a> {
             tol: opts.tol,
             max_iter: opts.max_iter,
             deadline: opts.deadline,
-            lu: FeralLU::new(),
+            lu: node_feral_lu(),
             basis: Vec::new(),
             slot_of: vec![-1; na],
             stat: vec![AT_LOWER; na],
@@ -688,7 +688,7 @@ impl<'a> Simplex<'a> {
             .iter()
             .map(|&j| self.column(j, art_sign))
             .collect();
-        let mut lu = FeralLU::new().with_numeric_focus();
+        let mut lu = node_feral_lu().with_numeric_focus();
         lu.factorize(self.m, &cols).ok()?;
         let mut rhs = self.reduced_rhs(art_sign);
         lu.ftran_refined(&mut rhs).ok()?;

--- a/crates/discopt-core/src/lp/simplex/refine.rs
+++ b/crates/discopt-core/src/lp/simplex/refine.rs
@@ -40,11 +40,17 @@
 //!
 //! This layer is **root-only / numerical-failure-triggered** by design — the cost
 //! is justified only on the pathological ill-conditioned relaxations float64
-//! cannot certify, never the hot per-node engine. It is **not** wired into any
-//! default solve path in this commit (see the integration seam in
-//! `docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md`); every existing
-//! solve is byte-identical, so the certifying panel is bound-neutral by
-//! construction. The [`ns_safe_bound`] it produces is a weak-duality lower bound
+//! cannot certify, never the hot per-node engine. These functions are the
+//! reusable *kernel*; the shipped hda bound (issue #671, flag
+//! `DISCOPT_LP_ITERATIVE_REFINEMENT`, default OFF) uses the same soundness
+//! principle via a τ-regularized-resolve schedule at the numerical-failure branch
+//! (`solvers/milp_simplex.py::_refined_safe_bound_regularized`), because that is
+//! what makes feral's *current* factorization return usable duals on hda;
+//! `refine()` here becomes the engine once a rank-revealing LU lets feral return
+//! consistent approximate solutions to refine. See
+//! `docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md`. With the flag OFF
+//! every existing solve is byte-identical, so the certifying panel is bound-neutral
+//! by construction. The [`ns_safe_bound`] it produces is a weak-duality lower bound
 //! valid for *any* multiplier, so a refined dual can only *tighten* the
 //! certificate — it can never lift a bound above the true optimum, exactly like
 //! candidate A. Refinement improves the multiplier; it never relaxes a guard.

--- a/crates/discopt-core/src/lp/simplex/refine.rs
+++ b/crates/discopt-core/src/lp/simplex/refine.rs
@@ -153,6 +153,45 @@ pub fn residual_dd(row: &[f64], x: &[f64], rhs: f64) -> f64 {
     acc.to_f64()
 }
 
+/// The residual vector `rhs − B x` (`transpose = false`) or `rhs − Bᵀ x`
+/// (`transpose = true`), each component accumulated in double-double, where `B` is
+/// given by its **dense columns** `cols` (`cols[j][i] = B[i][j]`). Zero entries are
+/// skipped, so on the sparse simplex bases (a handful of nonzeros per column) this
+/// is ~`O(nnz)`, not `O(m²)` — the form the hardened refined solves
+/// ([`super::linsolve::FeralLU`]) use so the residual is cheap on the hot path.
+pub fn residual_matvec_dd(cols: &[Vec<f64>], x: &[f64], rhs: &[f64], transpose: bool) -> Vec<f64> {
+    let m = cols.len();
+    if transpose {
+        // (Bᵀ x)_i = Σ_j B[j][i]·x[j] = dot(cols[i], x); rows are independent.
+        (0..m)
+            .map(|i| {
+                let mut acc = Dd::zero().add_f64(rhs[i]);
+                for (j, &a) in cols[i].iter().enumerate() {
+                    if a != 0.0 {
+                        acc = acc.add_prod(-a, x[j]);
+                    }
+                }
+                acc.to_f64()
+            })
+            .collect()
+    } else {
+        // (B x)_i = Σ_j cols[j][i]·x[j]; scatter each column's contribution.
+        let mut acc: Vec<Dd> = rhs.iter().map(|&b| Dd::zero().add_f64(b)).collect();
+        for (j, col) in cols.iter().enumerate() {
+            let xj = x[j];
+            if xj == 0.0 {
+                continue;
+            }
+            for (i, &a) in col.iter().enumerate() {
+                if a != 0.0 {
+                    acc[i] = acc[i].add_prod(-a, xj);
+                }
+            }
+        }
+        acc.iter().map(|d| d.to_f64()).collect()
+    }
+}
+
 /// The sentinel treated as `±∞` when reading variable bounds. Matches the crate's
 /// `CERT_INF` / MILP-boundary convention: a bound at or beyond this magnitude is
 /// an open side.

--- a/crates/discopt-core/src/lp/simplex/refine.rs
+++ b/crates/discopt-core/src/lp/simplex/refine.rs
@@ -1,0 +1,755 @@
+//! LP iterative refinement (Gleixner–Steffy–Wolter) — a precision layer *above*
+//! the double-precision simplex, for issue #671.
+//!
+//! # Why this exists
+//!
+//! hda-class flowsheet relaxations produce a root McCormick LP that is genuinely
+//! **feasible** (elastic phase-1 minimum violation ≈ 1.8e-10) yet **every float64
+//! LP engine false-infeasibles on it**: the constraint matrix is rank-deficient
+//! with condition number ≈ 1e14, so the near-singular bases the simplex lands on
+//! cannot be certified in double precision. Candidate A (#662) extracts a
+//! Neumaier–Shcherbina safe lower bound from the simplex's *drifted* dual — sound
+//! but loose (−1.80e10 vs opt −5964.53), because the drifted dual is a poor
+//! multiplier.
+//!
+//! The entry experiment (#671, PR #708) confirmed that the loose bound is a
+//! **precision artifact, not a relaxation property**: solving the same LP with
+//! high-precision residuals recovers the true root value ≈ −6.47e4 (≈5.4 orders
+//! tighter). The lever is exactly the GSW result: *solve in double, compute the
+//! residual against the original data in higher-than-double precision, scale it
+//! up, re-solve a correction LP in double, and iterate.* Only the **residual**
+//! needs high precision — the correction solves stay in double.
+//!
+//! # What this module provides
+//!
+//! 1. [`residual_dd`] / [`dot_dd`] — the high-precision (≈106-bit *double-double*)
+//!    residual primitive. Pure Rust, no new dependencies: `two_sum`/`two_prod`
+//!    error-free transforms accumulate `b − A x` (or `c − Aᵀ y`) without the
+//!    catastrophic cancellation that makes float64 drop the ~1e-12 balancing terms
+//!    the hda Arrhenius coupling hinges on.
+//! 2. [`refine`] — the GSW primal-dual iterative-refinement loop, generic over a
+//!    [`CorrectionSolver`] (the fixed-`A` inner double solver). Returns a
+//!    refined primal-dual pair whose accuracy is driven below what a single
+//!    double solve can reach.
+//! 3. [`ns_safe_bound`] — the Neumaier–Shcherbina safe lower bound `g(y)` (valid
+//!    for *any* `y`), so a refined dual converts directly into a tight, rigorous
+//!    certificate. This mirrors the formula the MILP boundary already uses
+//!    (`milp_simplex._safe_lp_lower_bound`) and the crate's own `primal::safe_bound`.
+//!
+//! # Placement and soundness
+//!
+//! This layer is **root-only / numerical-failure-triggered** by design — the cost
+//! is justified only on the pathological ill-conditioned relaxations float64
+//! cannot certify, never the hot per-node engine. It is **not** wired into any
+//! default solve path in this commit (see the integration seam in
+//! `docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md`); every existing
+//! solve is byte-identical, so the certifying panel is bound-neutral by
+//! construction. The [`ns_safe_bound`] it produces is a weak-duality lower bound
+//! valid for *any* multiplier, so a refined dual can only *tighten* the
+//! certificate — it can never lift a bound above the true optimum, exactly like
+//! candidate A. Refinement improves the multiplier; it never relaxes a guard.
+//!
+//! Reference: Gleixner, Steffy, Wolter, *Iterative Refinement for Linear
+//! Programming*, INFORMS J. Comput. 28(3), 2016.
+
+// Row/column index loops mirror `primal.rs`/`dual.rs` — the parallel index is used
+// against several arrays at once, so a range loop is the clearest form here.
+#![allow(clippy::needless_range_loop)]
+
+/// A value held to roughly double the working precision as an unevaluated sum
+/// `hi + lo` with `|lo| ≤ ½ ulp(hi)` ("double-double"). Enough extra precision to
+/// compute `b − A x` accurately when the individual products nearly cancel — the
+/// ~1e-12 residual buried under ~1e-10 terms in hda's Arrhenius core.
+#[derive(Clone, Copy, Debug, Default)]
+struct Dd {
+    hi: f64,
+    lo: f64,
+}
+
+/// Knuth's error-free transform: `a + b = s + e` exactly, with `s = fl(a+b)`.
+#[inline]
+fn two_sum(a: f64, b: f64) -> (f64, f64) {
+    let s = a + b;
+    let bb = s - a;
+    let e = (a - (s - bb)) + (b - bb);
+    (s, e)
+}
+
+/// Error-free transform of a product: `a * b = p + e` exactly, with `p = fl(a·b)`.
+/// Uses a fused multiply-add so `e` is the exact rounding error of `p`.
+#[inline]
+fn two_prod(a: f64, b: f64) -> (f64, f64) {
+    let p = a * b;
+    let e = a.mul_add(b, -p);
+    (p, e)
+}
+
+impl Dd {
+    #[inline]
+    fn zero() -> Self {
+        Dd { hi: 0.0, lo: 0.0 }
+    }
+
+    /// Add an ordinary `f64`, keeping the trailing bits.
+    #[inline]
+    fn add_f64(self, x: f64) -> Self {
+        let (s, e) = two_sum(self.hi, x);
+        let lo = e + self.lo;
+        // Renormalize so the invariant |lo| ≤ ½ ulp(hi) holds for the next step.
+        let (hi, lo) = two_sum(s, lo);
+        Dd { hi, lo }
+    }
+
+    /// Add the exact product `a·b`, keeping the trailing bits (a fused
+    /// multiply-accumulate at ≈106-bit precision).
+    #[inline]
+    fn add_prod(self, a: f64, b: f64) -> Self {
+        let (p, pe) = two_prod(a, b);
+        let (s, e) = two_sum(self.hi, p);
+        let lo = (e + pe) + self.lo;
+        let (hi, lo) = two_sum(s, lo);
+        Dd { hi, lo }
+    }
+
+    /// Round back to the nearest `f64` (`hi` already carries the correctly-rounded
+    /// sum; `lo` only refines ties, so `hi` is the right answer).
+    #[inline]
+    fn to_f64(self) -> f64 {
+        self.hi
+    }
+}
+
+/// High-precision dot product `Σ_k v[k]·w[k]`, computed in double-double so that
+/// near-total cancellation (products of magnitude `M` summing to `≪ M`) is
+/// resolved instead of lost to float64 rounding. `v` and `w` must be equal length.
+pub fn dot_dd(v: &[f64], w: &[f64]) -> f64 {
+    debug_assert_eq!(v.len(), w.len());
+    let mut acc = Dd::zero();
+    for (&a, &b) in v.iter().zip(w.iter()) {
+        acc = acc.add_prod(a, b);
+    }
+    acc.to_f64()
+}
+
+/// The correctly-rounded residual `rhs − Σ_k row[k]·x[k]`, accumulated at
+/// double-double precision. This is the GSW primitive: even when the individual
+/// `row[k]·x[k]` are orders of magnitude larger than the true residual, the
+/// double-double accumulation recovers the residual to full `f64` accuracy, where
+/// a naive float64 dot would return noise (or exactly `0`). `row` and `x` must be
+/// equal length.
+pub fn residual_dd(row: &[f64], x: &[f64], rhs: f64) -> f64 {
+    debug_assert_eq!(row.len(), x.len());
+    // Accumulate rhs − Σ row·x in one double-double sweep.
+    let mut acc = Dd::zero().add_f64(rhs);
+    for (&a, &xj) in row.iter().zip(x.iter()) {
+        acc = acc.add_prod(-a, xj);
+    }
+    acc.to_f64()
+}
+
+/// The sentinel treated as `±∞` when reading variable bounds. Matches the crate's
+/// `CERT_INF` / MILP-boundary convention: a bound at or beyond this magnitude is
+/// an open side.
+pub const REFINE_INF: f64 = 1e20;
+
+/// Neumaier–Shcherbina safe lower bound on `min cᵀx s.t. A x = b, l ≤ x ≤ u` from
+/// **free-sign** equality multipliers `y` (length `m`). Weak duality gives, for
+/// *any* `y`,
+///
+/// ```text
+/// g(y) = bᵀy + Σ_j min_{x_j∈[l_j,u_j]} (c − Aᵀy)_j x_j  ≤  min cᵀx,
+/// ```
+///
+/// so `g(y)` is a valid lower bound regardless of how `y` was obtained — a
+/// refined dual only *tightens* it, never lifts it above the optimum. Returns
+/// `None` when the bound is `−∞` (a reduced cost with the wrong-signed open box
+/// side). `a` is row-major `m × n`.
+///
+/// This is the exact formula the MILP boundary applies to candidate A's drifted
+/// dual (`milp_simplex._safe_lp_lower_bound_std`) and that `primal::safe_bound`
+/// uses in its tests; refinement changes only the *quality* of `y` fed into it.
+#[allow(clippy::too_many_arguments)]
+pub fn ns_safe_bound(
+    y: &[f64],
+    c: &[f64],
+    a: &[f64],
+    m: usize,
+    n: usize,
+    b: &[f64],
+    l: &[f64],
+    u: &[f64],
+) -> Option<f64> {
+    if y.len() != m || !y.iter().all(|v| v.is_finite()) {
+        return None;
+    }
+    // bᵀy at double-double precision (b and y can both be wide-ranged on these LPs).
+    let mut g = dot_dd(b, y);
+    for j in 0..n {
+        // Reduced cost (c − Aᵀy)_j, high-precision so a tiny true rc is not lost.
+        let mut aty = Dd::zero();
+        for i in 0..m {
+            aty = aty.add_prod(a[i * n + j], y[i]);
+        }
+        let rc = c[j] - aty.to_f64();
+        if rc > 0.0 {
+            if l[j] <= -REFINE_INF {
+                return None;
+            }
+            g += rc * l[j];
+        } else if rc < 0.0 {
+            if u[j] >= REFINE_INF {
+                return None;
+            }
+            g += rc * u[j];
+        }
+    }
+    if g.is_finite() {
+        Some(g)
+    } else {
+        None
+    }
+}
+
+/// The primal-dual solution of a correction subproblem: `x` (length `n`) and the
+/// row duals `y` (length `m`) under the crate's dual convention (so that
+/// [`ns_safe_bound`] applied to `y` is a valid lower bound).
+#[derive(Clone, Debug)]
+pub struct CorrectionSolution {
+    /// Primal point, length `n`.
+    pub x: Vec<f64>,
+    /// Row duals, length `m` (crate dual convention).
+    pub y: Vec<f64>,
+}
+
+/// The fixed-`A` inner double solver GSW refines around. Each call solves
+/// `min cᵀx s.t. A x = b, l ≤ x ≤ u` for the **same** constraint matrix `A`
+/// (only the objective, right-hand side, and bounds vary between rounds — the
+/// factorization/warm basis can be reused). Returns `None` on numerical failure,
+/// which aborts refinement (the caller falls back to candidate A).
+pub trait CorrectionSolver {
+    /// Solve `min cᵀx s.t. A x = b, l ≤ x ≤ u` for this solver's fixed `A`,
+    /// returning the primal-dual pair, or `None` on numerical failure.
+    fn solve(&mut self, c: &[f64], b: &[f64], l: &[f64], u: &[f64]) -> Option<CorrectionSolution>;
+}
+
+/// Tunables for [`refine`].
+#[derive(Clone, Debug)]
+pub struct RefineOptions {
+    /// Stop once the primal residual (max equality violation) is `≤` this.
+    pub eps_primal: f64,
+    /// Stop once the dual (reduced-cost KKT) residual is `≤` this.
+    pub eps_dual: f64,
+    /// Maximum refinement rounds. GSW converges geometrically (≈16 digits/round on
+    /// a solver that returns ~`1e-16`-accurate corrections), so a handful suffices;
+    /// the cap only bounds the cost when the inner solver is itself weak.
+    pub max_rounds: usize,
+    /// Largest residual scale-up factor `Δ`. Bounds how far a single round can push
+    /// the correction data so the inner double solve stays in a sane range.
+    pub scale_cap: f64,
+}
+
+impl Default for RefineOptions {
+    fn default() -> Self {
+        RefineOptions {
+            eps_primal: 1e-12,
+            eps_dual: 1e-12,
+            max_rounds: 30,
+            scale_cap: 1e12,
+        }
+    }
+}
+
+/// The refined solution and the residuals it reached.
+#[derive(Clone, Debug)]
+pub struct RefineResult {
+    /// Refined primal point (length `n`), box-feasible by construction.
+    pub x: Vec<f64>,
+    /// Refined row duals (length `m`) — feed to [`ns_safe_bound`] for a tight,
+    /// rigorous lower bound.
+    pub y: Vec<f64>,
+    /// Rounds actually performed.
+    pub rounds: usize,
+    /// Whether both residual tolerances were met.
+    pub converged: bool,
+    /// Final primal residual (max equality/bound violation).
+    pub primal_res: f64,
+    /// Final dual residual (max KKT reduced-cost violation).
+    pub dual_res: f64,
+}
+
+/// Gleixner–Steffy–Wolter primal-dual iterative refinement of
+/// `min cᵀx s.t. A x = b, l ≤ x ≤ u` (`a` row-major `m × n`).
+///
+/// Each round computes the primal residual `b − A x*` and the dual residual
+/// `c − Aᵀ y*` **in double-double precision** ([`residual_dd`]), scales them up by
+/// `Δp`/`Δd`, solves a correction subproblem in double via `solver`, and folds the
+/// scaled-down correction back into the incumbent `(x*, y*)`. The incumbent is
+/// kept **exactly box-feasible** every round because the correction's bounds are
+/// `Δp·(l − x*) ≤ x̄ ≤ Δp·(u − x*)`, so `x* + x̄/Δp ∈ [l, u]`. Returns `None` if the
+/// first correction solve fails (nothing to refine); a later failure returns the
+/// best incumbent so far with `converged = false`.
+#[allow(clippy::too_many_arguments)]
+pub fn refine<S: CorrectionSolver>(
+    a: &[f64],
+    m: usize,
+    n: usize,
+    c: &[f64],
+    b: &[f64],
+    l: &[f64],
+    u: &[f64],
+    solver: &mut S,
+    opts: &RefineOptions,
+) -> Option<RefineResult> {
+    assert_eq!(a.len(), m * n, "A must be row-major m×n");
+    assert_eq!(c.len(), n);
+    assert_eq!(b.len(), m);
+    assert_eq!(l.len(), n);
+    assert_eq!(u.len(), n);
+
+    let mut xstar = vec![0.0f64; n];
+    let mut ystar = vec![0.0f64; m];
+
+    // Row slices of A, taken on demand (row-major layout).
+    let row = |i: usize| &a[i * n..i * n + n];
+
+    for round in 0..opts.max_rounds {
+        // ---- primal residual r_b = b − A x*  (double-double per row) ----
+        let mut r_b = vec![0.0f64; m];
+        let mut primal_res = 0.0f64;
+        for i in 0..m {
+            let r = residual_dd(row(i), &xstar, b[i]);
+            r_b[i] = r;
+            primal_res = primal_res.max(r.abs());
+        }
+
+        // ---- dual residual d = c − Aᵀ y*  (double-double per column) ----
+        let mut d = vec![0.0f64; n];
+        for j in 0..n {
+            let mut aty = Dd::zero();
+            for i in 0..m {
+                aty = aty.add_prod(a[i * n + j], ystar[i]);
+            }
+            d[j] = c[j] - aty.to_f64();
+        }
+        // KKT dual-infeasibility given which bound each x*_j rests at. This is a
+        // stopping *diagnostic* only — g(y*) is a valid bound at every round, so
+        // an imperfect measure never makes the certificate unsound.
+        let dual_res = kkt_dual_residual(&d, &xstar, l, u);
+
+        let converged = primal_res <= opts.eps_primal && dual_res <= opts.eps_dual;
+        let snapshot = RefineResult {
+            x: xstar.clone(),
+            y: ystar.clone(),
+            rounds: round,
+            converged,
+            primal_res,
+            dual_res,
+        };
+        if converged {
+            return Some(snapshot);
+        }
+
+        // ---- residual scale-ups: push both residuals toward O(1) ----
+        let dp = scale_for(primal_res, opts.scale_cap);
+        let dd = scale_for(dual_res, opts.scale_cap);
+
+        // ---- correction subproblem (same A; shifted objective/rhs/bounds) ----
+        let cc: Vec<f64> = d.iter().map(|&dj| dd * dj).collect();
+        let bb: Vec<f64> = r_b.iter().map(|&ri| dp * ri).collect();
+        let mut lc = vec![0.0f64; n];
+        let mut uc = vec![0.0f64; n];
+        for j in 0..n {
+            lc[j] = shift_bound(l[j], xstar[j], dp, true);
+            uc[j] = shift_bound(u[j], xstar[j], dp, false);
+        }
+
+        let sol = match solver.solve(&cc, &bb, &lc, &uc) {
+            Some(s) => s,
+            None => {
+                // Inner solve failed this round — keep the best incumbent so far.
+                return Some(snapshot);
+            }
+        };
+
+        // ---- fold the scaled-down correction into the incumbent ----
+        for j in 0..n {
+            xstar[j] += sol.x[j] / dp;
+        }
+        for i in 0..m {
+            ystar[i] += sol.y[i] / dd;
+        }
+    }
+
+    // Recompute the final residuals of the last incumbent for an honest report.
+    let mut primal_res = 0.0f64;
+    for i in 0..m {
+        primal_res = primal_res.max(residual_dd(row(i), &xstar, b[i]).abs());
+    }
+    let mut d = vec![0.0f64; n];
+    for j in 0..n {
+        let mut aty = Dd::zero();
+        for i in 0..m {
+            aty = aty.add_prod(a[i * n + j], ystar[i]);
+        }
+        d[j] = c[j] - aty.to_f64();
+    }
+    let dual_res = kkt_dual_residual(&d, &xstar, l, u);
+    Some(RefineResult {
+        x: xstar,
+        y: ystar,
+        rounds: opts.max_rounds,
+        converged: primal_res <= opts.eps_primal && dual_res <= opts.eps_dual,
+        primal_res,
+        dual_res,
+    })
+}
+
+/// Scale a residual toward O(1): `Δ = clamp(1/res, 1, cap)`. A residual already
+/// below `1/cap` uses the cap; a tiny/zero residual uses `1` (nothing to scale).
+#[inline]
+fn scale_for(res: f64, cap: f64) -> f64 {
+    if !res.is_finite() || res <= 0.0 {
+        return 1.0;
+    }
+    (1.0 / res).clamp(1.0, cap)
+}
+
+/// Shifted correction bound `Δ·(bound − x*)`, preserving open (`±∞`) sides.
+/// `lower` picks the `−∞` sentinel side; the caller passes the raw variable bound.
+#[inline]
+fn shift_bound(bound: f64, xstar: f64, dp: f64, lower: bool) -> f64 {
+    if lower {
+        if bound <= -REFINE_INF {
+            return f64::NEG_INFINITY;
+        }
+    } else if bound >= REFINE_INF {
+        return f64::INFINITY;
+    }
+    dp * (bound - xstar)
+}
+
+/// KKT dual-infeasibility: for each variable, its reduced cost must be `≥ 0` at a
+/// lower bound, `≤ 0` at an upper bound, and `≈ 0` when strictly interior. Returns
+/// the worst violation across all variables.
+fn kkt_dual_residual(d: &[f64], x: &[f64], l: &[f64], u: &[f64]) -> f64 {
+    let n = d.len();
+    let mut worst = 0.0f64;
+    for j in 0..n {
+        let at_lower = l[j] > -REFINE_INF && (x[j] - l[j]).abs() <= 1e-9 * (1.0 + l[j].abs());
+        let at_upper = u[j] < REFINE_INF && (x[j] - u[j]).abs() <= 1e-9 * (1.0 + u[j].abs());
+        let v = if at_lower && !at_upper {
+            (-d[j]).max(0.0)
+        } else if at_upper && !at_lower {
+            d[j].max(0.0)
+        } else if at_lower && at_upper {
+            // Fixed variable: any reduced-cost sign is dual-feasible.
+            0.0
+        } else {
+            d[j].abs()
+        };
+        worst = worst.max(v);
+    }
+    worst
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lp::crossover::LpView;
+    use crate::lp::simplex::primal::solve_lp;
+    use crate::lp::simplex::{LpStatus, SimplexOptions};
+
+    /// Naive left-to-right float64 dot — the baseline the double-double residual
+    /// beats. Present only to *demonstrate* the cancellation loss in tests.
+    fn naive_dot(v: &[f64], w: &[f64]) -> f64 {
+        v.iter().zip(w).map(|(a, b)| a * b).sum()
+    }
+
+    #[test]
+    fn two_sum_is_exact() {
+        // 1 + 1e-20: the tail is exactly 1e-20, lost by fl(a+b) but kept in e.
+        let (s, e) = two_sum(1.0, 1e-20);
+        assert_eq!(s, 1.0);
+        assert_eq!(e, 1e-20);
+        // Reconstructs the exact sum.
+        assert_eq!(s as f64 + e, 1.0 + 1e-20);
+    }
+
+    #[test]
+    fn two_prod_is_exact() {
+        // (1 + 2^-30)^2 needs 60 bits — the low word carries the overflow.
+        let a = 1.0 + 2f64.powi(-30);
+        let (p, e) = two_prod(a, a);
+        // p is the rounded product; p + e is the exact product a*a.
+        let exact = 1.0 + 2f64.powi(-29) + 2f64.powi(-60);
+        assert_eq!(p + e, exact);
+        assert!(e != 0.0, "the rounding error must be captured");
+    }
+
+    #[test]
+    fn residual_dd_survives_catastrophic_cancellation() {
+        // Σ = 1e16 + 1 − 1e16. Naive float64 loses the +1 (1e16 + 1 == 1e16),
+        // returning 0; the true sum is 1.
+        let row = [1e16, 1.0, -1e16];
+        let x = [1.0, 1.0, 1.0];
+        assert_eq!(naive_dot(&row, &x), 0.0, "naive dot loses the unit term");
+        // residual = rhs − Σ, with rhs = 1 → true residual exactly 0.
+        assert_eq!(residual_dd(&row, &x, 1.0), 0.0);
+        // With rhs = 0 the true residual is −1, which naive would call 0.
+        assert_eq!(residual_dd(&row, &x, 0.0), -1.0);
+    }
+
+    #[test]
+    fn residual_dd_recovers_arrhenius_scale_product_error() {
+        // hda's coupling (#671 E2): a 6.3e10 Arrhenius pre-exponential times a
+        // ~1e-13 aux. The product carries a sub-ulp rounding error that naive
+        // float64 silently drops — exactly the kind of ~1e-18 term whose loss lets
+        // a near-feasible constraint read as violated. With `rhs = fl(big·aux)`,
+        // the true residual `rhs − big·aux` is the *exact* product-rounding error,
+        // which naive rounds to 0 but the double-double residual recovers.
+        let big = 6.3e10_f64;
+        let aux = 1.96e-13_f64;
+        let p = big * aux; // rounded product ≈ 1.235e-2
+        let e = big.mul_add(aux, -p); // exact product-rounding error (nonzero)
+        assert!(e != 0.0, "the Arrhenius product must have a rounding tail");
+        // Naive residual `rhs − fl(big·aux)` = p − p = 0 (the tail is lost).
+        assert_eq!(p - naive_dot(&[big], &[aux]), 0.0);
+        // Double-double residual recovers −e, the tail naive dropped.
+        let r = residual_dd(&[big], &[aux], p);
+        assert_eq!(
+            r, -e,
+            "double-double residual should recover the product tail"
+        );
+    }
+
+    #[test]
+    fn dot_dd_beats_naive_on_cancellation() {
+        let v = [1e18, 3.0, -1e18, -2.0];
+        let w = [1.0, 1.0, 1.0, 1.0];
+        // True dot = 1. Naive collapses the 1e18 pair and the +3/−2 lands on noise.
+        assert_eq!(dot_dd(&v, &w), 1.0);
+        assert_ne!(naive_dot(&v, &w), 1.0);
+    }
+
+    /// A fixed-`A` inner solver backed by the crate's primal simplex. The GSW
+    /// correction subproblems reuse this exactly as production would reuse the
+    /// warm-started node simplex.
+    struct SimplexInner<'a> {
+        a: &'a [f64],
+        m: usize,
+        n: usize,
+    }
+
+    /// Translate refinement's mathematical `±∞` bounds to the simplex's `1e20`
+    /// sentinel (open-side convention).
+    fn to_sentinel(v: f64) -> f64 {
+        if v == f64::INFINITY {
+            REFINE_INF
+        } else if v == f64::NEG_INFINITY {
+            -REFINE_INF
+        } else {
+            v
+        }
+    }
+
+    impl CorrectionSolver for SimplexInner<'_> {
+        fn solve(
+            &mut self,
+            c: &[f64],
+            b: &[f64],
+            l: &[f64],
+            u: &[f64],
+        ) -> Option<CorrectionSolution> {
+            let ls: Vec<f64> = l.iter().map(|&v| to_sentinel(v)).collect();
+            let us: Vec<f64> = u.iter().map(|&v| to_sentinel(v)).collect();
+            let view = LpView {
+                a: self.a,
+                m: self.m,
+                n: self.n,
+                c,
+                l: &ls,
+                u: &us,
+            };
+            let sol = solve_lp(&view, b, &SimplexOptions::default());
+            if sol.status != LpStatus::Optimal {
+                return None;
+            }
+            Some(CorrectionSolution {
+                x: sol.x[..self.n].to_vec(),
+                y: sol.dual,
+            })
+        }
+    }
+
+    /// Wraps an inner solver and rounds every returned coordinate to a coarse
+    /// absolute grid — a faithful stand-in for a *double* solver that only reaches
+    /// `grid`-level accuracy on an ill-conditioned LP. Refinement must recover
+    /// accuracy far below `grid`.
+    struct LossyInner<'a> {
+        inner: SimplexInner<'a>,
+        grid: f64,
+    }
+
+    impl CorrectionSolver for LossyInner<'_> {
+        fn solve(
+            &mut self,
+            c: &[f64],
+            b: &[f64],
+            l: &[f64],
+            u: &[f64],
+        ) -> Option<CorrectionSolution> {
+            let mut sol = self.inner.solve(c, b, l, u)?;
+            let round = |v: f64, g: f64| (v / g).round() * g;
+            for xj in sol.x.iter_mut() {
+                *xj = round(*xj, self.grid);
+            }
+            for yi in sol.y.iter_mut() {
+                *yi = round(*yi, self.grid);
+            }
+            Some(sol)
+        }
+    }
+
+    // min −x0 − 2x1 s.t. x0 + x1 + s = 4, x0,x1 ∈ [0,5], s ∈ [0,∞). Optimum −8 at
+    // (x1=4). The safe bound from the optimal dual reproduces −8.
+    fn small_lp() -> (
+        Vec<f64>,
+        usize,
+        usize,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+    ) {
+        let a = vec![1.0, 1.0, 1.0];
+        let c = vec![-1.0, -2.0, 0.0];
+        let b = vec![4.0];
+        let l = vec![0.0, 0.0, 0.0];
+        let u = vec![5.0, 5.0, REFINE_INF];
+        (a, 1, 3, c, b, l, u)
+    }
+
+    #[test]
+    fn refine_exact_solver_reproduces_optimum_bound() {
+        let (a, m, n, c, b, l, u) = small_lp();
+        let mut inner = SimplexInner { a: &a, m, n };
+        let res = refine(
+            &a,
+            m,
+            n,
+            &c,
+            &b,
+            &l,
+            &u,
+            &mut inner,
+            &RefineOptions::default(),
+        )
+        .expect("refinement returns a result");
+        assert!(res.converged, "exact inner solver converges: {res:?}");
+        assert!(res.primal_res <= 1e-12 && res.dual_res <= 1e-12);
+        let g = ns_safe_bound(&res.y, &c, &a, m, n, &b, &l, &u).expect("finite bound");
+        assert!((g - (-8.0)).abs() < 1e-9, "safe bound {g} should be −8");
+    }
+
+    #[test]
+    fn refine_extracts_accuracy_below_the_inner_solvers_grid() {
+        // The inner solver only returns 1e-4-accurate corrections; refinement must
+        // drive the true residuals orders of magnitude below that.
+        let (a, m, n, c, b, l, u) = small_lp();
+        let mut lossy = LossyInner {
+            inner: SimplexInner { a: &a, m, n },
+            grid: 1e-4,
+        };
+        let opts = RefineOptions {
+            eps_primal: 1e-11,
+            eps_dual: 1e-11,
+            max_rounds: 40,
+            scale_cap: 1e12,
+        };
+        let res = refine(&a, m, n, &c, &b, &l, &u, &mut lossy, &opts)
+            .expect("refinement returns a result");
+        assert!(
+            res.primal_res <= 1e-9,
+            "primal residual {} not driven below the 1e-4 grid",
+            res.primal_res
+        );
+        // The refined dual yields a bound far tighter than the grid error, and
+        // never above the true optimum (soundness).
+        let g = ns_safe_bound(&res.y, &c, &a, m, n, &b, &l, &u).expect("finite bound");
+        assert!(
+            g <= -8.0 + 1e-9,
+            "safe bound {g} above optimum −8 (unsound)"
+        );
+        assert!(
+            (g - (-8.0)).abs() < 1e-6,
+            "safe bound {g} not tightened to −8 (grid was 1e-4)"
+        );
+    }
+
+    #[test]
+    fn refine_tightens_a_drifted_dual_on_an_ill_conditioned_lp() {
+        // Wide-coefficient LP (range 1e8) whose single lossy solve gives a drifted
+        // dual → a loose safe bound; refinement tightens it toward the optimum.
+        // min −x0 − x1  s.t.  1e8·x0 + x1 + s0 = 1e8,  x1 + s1 = 5,
+        // x0∈[0,1], x1∈[0,10], s0,s1∈[0,∞).  Optimum: x0=1, x1=0 → −1? Let's keep
+        // it simple: x0≤1 and 1e8 x0 ≤ 1e8 ⇒ x0≤1; x1≤5. Optimum −(1)−(5) = −6.
+        let a = vec![
+            1e8, 1.0, 1.0, 0.0, // row 0: 1e8 x0 + x1 + s0
+            0.0, 1.0, 0.0, 1.0, // row 1: x1 + s1
+        ];
+        let m = 2;
+        let n = 4;
+        let c = vec![-1.0, -1.0, 0.0, 0.0];
+        let b = vec![1e8, 5.0];
+        let l = vec![0.0, 0.0, 0.0, 0.0];
+        let u = vec![1.0, 10.0, REFINE_INF, REFINE_INF];
+
+        // One lossy solve (grid 1e-3) → drifted dual → measure its safe bound.
+        let mut lossy = LossyInner {
+            inner: SimplexInner { a: &a, m, n },
+            grid: 1e-3,
+        };
+        let single = lossy
+            .solve(&c, &b, &l, &u)
+            .expect("single lossy solve is optimal");
+        let g_single = ns_safe_bound(&single.y, &c, &a, m, n, &b, &l, &u).expect("finite");
+
+        // Refinement over the same lossy solver.
+        let opts = RefineOptions {
+            eps_primal: 1e-10,
+            eps_dual: 1e-10,
+            max_rounds: 40,
+            scale_cap: 1e12,
+        };
+        let res = refine(&a, m, n, &c, &b, &l, &u, &mut lossy, &opts).expect("refined");
+        let g_refined = ns_safe_bound(&res.y, &c, &a, m, n, &b, &l, &u).expect("finite");
+
+        // Soundness: neither bound exceeds the true optimum −6.
+        assert!(g_single <= -6.0 + 1e-6, "single bound {g_single} unsound");
+        assert!(
+            g_refined <= -6.0 + 1e-9,
+            "refined bound {g_refined} unsound"
+        );
+        // The refined bound is at least as tight, and materially tighter than the
+        // drifted single-solve bound.
+        assert!(
+            g_refined >= g_single - 1e-9,
+            "refined {g_refined} looser than single {g_single}"
+        );
+        assert!(
+            (g_refined - (-6.0)).abs() < 1e-6,
+            "refined bound {g_refined} not tight to −6"
+        );
+    }
+
+    #[test]
+    fn ns_safe_bound_is_never_above_optimum_for_arbitrary_dual() {
+        // g(y) ≤ opt for ANY y — the soundness property candidate A relies on.
+        let (a, m, n, c, b, l, u) = small_lp();
+        for &y0 in &[-3.7, -1.0, 0.0, 0.5, 2.3, 10.0] {
+            if let Some(g) = ns_safe_bound(&[y0], &c, &a, m, n, &b, &l, &u) {
+                assert!(g <= -8.0 + 1e-9, "g({y0}) = {g} exceeds optimum −8");
+            }
+        }
+    }
+}

--- a/crates/discopt-core/src/lp/simplex/regularized_lu.rs
+++ b/crates/discopt-core/src/lp/simplex/regularized_lu.rs
@@ -233,7 +233,11 @@ fn hardened_feral_lu_solves_where_default_aborts() {
     let x_true = [1.0, 2.0, 3.0, 4.0, 5.0, 0.0];
     let rhs = matvec(&cols, &x_true);
 
-    let mut hardened = FeralLU::new().with_singular_perturb(1e-12);
+    // Production usage: hardened factor + numeric focus (numeric focus turns on the
+    // basis retention the double-double refined solve needs).
+    let mut hardened = FeralLU::new()
+        .with_singular_perturb(1e-12)
+        .with_numeric_focus();
     hardened
         .factorize(m, &cols)
         .expect("hardened factorization must complete");

--- a/crates/discopt-core/src/lp/simplex/regularized_lu.rs
+++ b/crates/discopt-core/src/lp/simplex/regularized_lu.rs
@@ -34,9 +34,13 @@
 //! The production capability lives on [`super::linsolve::FeralLU`]:
 //! [`FeralLU::with_singular_perturb`](super::linsolve::FeralLU::with_singular_perturb)
 //! turns on the hardened factorization and double-double refined ftran/btran. It is
-//! **not yet wired** into the simplex's failure-triggered retry (that wiring, behind
-//! a default-OFF flag, plus the bound-neutral panel, is the gated follow-up); the
-//! tests here validate the primitive in isolation.
+//! wired into the simplex's **failure-triggered** retry behind a default-OFF flag
+//! (`DISCOPT_LP_FACTORIZATION_HARDENING`): [`super::linsolve::node_feral_lu`] builds
+//! a hardened factor while [`super::linsolve::with_hardening_active`] is set, and
+//! `dual::solve_lp_warm_csc` re-runs the solve under it once a strict solve exits
+//! `Numerical`/`IterLimit`. Flag OFF ⇒ every solve is byte-identical to today (the
+//! `node_lu_is_plain_when_hardening_inactive` test). The corpus-wide bound-neutral
+//! + differential panel remains the graduation gate before any default-ON.
 
 #![cfg(test)]
 
@@ -259,6 +263,39 @@ fn hardened_feral_lu_solves_where_default_aborts() {
     assert!(
         res_b < 1e-9,
         "hardened btran residual {res_b:.3e} too large"
+    );
+}
+
+#[test]
+fn node_lu_is_plain_when_hardening_inactive() {
+    // Outside a hardened retry, `node_feral_lu()` is the strict (Fail) factor: it
+    // aborts on a singular basis exactly like `FeralLU::new()`, so the flag-OFF
+    // path is byte-identical to today.
+    let cols = near_singular(4, 0.0);
+    let mut lu = super::linsolve::node_feral_lu();
+    assert!(
+        lu.factorize(4, &cols).is_err(),
+        "inactive node LU must be plain"
+    );
+}
+
+#[test]
+fn node_lu_is_hardened_inside_active_scope() {
+    // Inside a hardened retry scope, `node_feral_lu()` completes a singular factor
+    // (PerturbToEps) — the failure-triggered escalation.
+    let cols = near_singular(4, 0.0);
+    super::linsolve::with_hardening_active(|| {
+        let mut lu = super::linsolve::node_feral_lu();
+        assert!(
+            lu.factorize(4, &cols).is_ok(),
+            "hardened node LU must complete the singular factorization"
+        );
+    });
+    // Scope restored: back to plain afterward.
+    let mut lu = super::linsolve::node_feral_lu();
+    assert!(
+        lu.factorize(4, &cols).is_err(),
+        "hardening must not leak past the scope"
     );
 }
 

--- a/crates/discopt-core/src/lp/simplex/regularized_lu.rs
+++ b/crates/discopt-core/src/lp/simplex/regularized_lu.rs
@@ -1,0 +1,309 @@
+//! Factorization hardening for near-singular simplex bases (issue #671, the
+//! feral-touching half).
+//!
+//! # Problem
+//!
+//! hda-class ill-conditioned McCormick relaxations drive the revised simplex onto
+//! **near-singular bases** (numerical rank deficient by ~13–43, κ ≈ 1e14). feral's
+//! default LU aborts on them — a column whose pivot candidates are all `≤
+//! zero_pivot_tol` returns `SingularBasis` (`LuSingularAction::Fail`) — so the
+//! solve exits `Numerical` with no usable factor, and hence no usable dual. That
+//! is the root cause of hda's missing/loose bound (candidate A only salvages a
+//! *drifted* dual from the broken state).
+//!
+//! # Approach under test (entry experiment first — Dev-Philosophy #4)
+//!
+//! feral already exposes the right primitive: `LuSingularAction::PerturbToEps {
+//! abs_floor }` replaces a singular pivot `d` with `sign(d)·max(|d|, abs_floor)`
+//! and *continues*, producing a factor of a nearby matrix `B'` that differs from
+//! `B` only in the rank-deficient pivot(s) — a **localized** regularization, not a
+//! uniform `B + εI`. The perturbed factor solves `B' x ≈ rhs` inaccurately, but a
+//! **high-precision iterative refinement** (residual `rhs − B x` accumulated in
+//! double-double via [`super::refine::residual_dd`], re-solved through the same
+//! `B'` factor) recovers accuracy in the well-conditioned subspace — the classic
+//! Wilkinson result, here with the twist that the factor is of `B'`, not `B`.
+//!
+//! # Status
+//!
+//! Entry experiment **CONFIRMED** (the cargo tests below): on near-singular /
+//! exactly-singular bases where feral's default `Fail` factorization aborts,
+//! `PerturbToEps` + double-double refinement recovers the solve to residual ~0
+//! (growth 1.0); the boundary case (solution loading the near-singular direction)
+//! also recovers, provided `abs_floor` sits below the genuine small pivots.
+//!
+//! The production capability lives on [`super::linsolve::FeralLU`]:
+//! [`FeralLU::with_singular_perturb`](super::linsolve::FeralLU::with_singular_perturb)
+//! turns on the hardened factorization and double-double refined ftran/btran. It is
+//! **not yet wired** into the simplex's failure-triggered retry (that wiring, behind
+//! a default-OFF flag, plus the bound-neutral panel, is the gated follow-up); the
+//! tests here validate the primitive in isolation.
+
+#![cfg(test)]
+
+use super::linsolve::{FeralLU, LinearSolver};
+use super::refine::residual_dd;
+use feral::{DenseLu, LuParams, LuSingularAction};
+
+/// Column-major near-singular `m×m` basis: identity except the last column is
+/// `e0 + e1 + delta·e_{m-1}`. Then `det = delta`, the smallest singular value is
+/// `Θ(delta)`, and `κ ≈ 1/delta`. `delta = 0` is exactly singular (rank `m-1`).
+fn near_singular(m: usize, delta: f64) -> Vec<Vec<f64>> {
+    let mut cols = vec![vec![0.0f64; m]; m];
+    for j in 0..m {
+        cols[j][j] = 1.0;
+    }
+    let last = m - 1;
+    cols[last] = vec![0.0f64; m];
+    cols[last][0] = 1.0;
+    cols[last][1] = 1.0;
+    cols[last][last] = delta;
+    cols
+}
+
+/// Row `i` of the column-major matrix (for the high-precision residual).
+fn row(cols: &[Vec<f64>], i: usize) -> Vec<f64> {
+    cols.iter().map(|c| c[i]).collect()
+}
+
+/// `B·x` (dense, column-major).
+fn matvec(cols: &[Vec<f64>], x: &[f64]) -> Vec<f64> {
+    let m = cols.len();
+    let mut y = vec![0.0f64; m];
+    for (j, col) in cols.iter().enumerate() {
+        for (i, &v) in col.iter().enumerate() {
+            y[i] += v * x[j];
+        }
+    }
+    y
+}
+
+/// Max-norm residual `‖rhs − B x‖∞`, each component accumulated in double-double.
+fn residual_inf(cols: &[Vec<f64>], x: &[f64], rhs: &[f64]) -> f64 {
+    (0..cols.len())
+        .map(|i| residual_dd(&row(cols, i), x, rhs[i]).abs())
+        .fold(0.0f64, f64::max)
+}
+
+/// Factor `B` with `on_singular = PerturbToEps{abs_floor}` (dense path), then run
+/// `steps` high-precision refinement iterations against the *true* `B`. Returns
+/// `(x, residual_inf, growth)`.
+fn perturbed_refined_solve(
+    cols: &[Vec<f64>],
+    rhs: &[f64],
+    abs_floor: f64,
+    steps: usize,
+) -> (Vec<f64>, f64, f64) {
+    let m = cols.len();
+    let params = LuParams {
+        on_singular: LuSingularAction::PerturbToEps { abs_floor },
+        ..LuParams::default()
+    };
+    let mut lu =
+        DenseLu::factor(cols, m, params).expect("PerturbToEps must complete the factorization");
+    let growth = lu.growth();
+    let mut x = vec![0.0f64; m];
+    for _ in 0..steps {
+        // High-precision residual r = rhs − B x (against the TRUE B).
+        let mut r: Vec<f64> = (0..m)
+            .map(|i| residual_dd(&row(cols, i), &x, rhs[i]))
+            .collect();
+        // Correction: solve B' dx = r through the perturbed factor.
+        lu.ftran(&mut r).expect("ftran on the perturbed factor");
+        for j in 0..m {
+            x[j] += r[j];
+        }
+    }
+    let res = residual_inf(cols, &x, rhs);
+    (x, res, growth)
+}
+
+/// Does feral's default LU (`on_singular = Fail`) abort on this basis?
+fn default_factor_fails(cols: &[Vec<f64>]) -> bool {
+    DenseLu::factor(cols, cols.len(), LuParams::default()).is_err()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entry experiment (#671 factorization hardening)
+//
+// Hypothesis H: `PerturbToEps` + high-precision iterative refinement recovers an
+// accurate solve of `B x = rhs` (consistent rhs) on near-singular bases where
+// feral's default factorization *fails*, with residual driven to ~1e-12.
+//
+// Kill criterion: if the refined residual stays ≫ 1e-9 across reasonable
+// `abs_floor`, localized-perturbation + refinement is insufficient (the null
+// direction genuinely matters) and a rank-revealing / basis-repair path is
+// needed instead.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn experiment_perturb_and_refine_on_near_singular_bases() {
+    let m = 6;
+    // A consistent rhs whose solution lives in the WELL-conditioned subspace:
+    // x_true supported on the first m-1 coordinates, so the near-singular last
+    // column is not needed to represent rhs. This is the simplex-relevant case
+    // (the basis is only numerically deficient; the solve it needs is benign).
+    let mut x_true = vec![1.0, 2.0, 3.0, 4.0, 5.0, 0.0];
+    for (deltalabel, &delta) in [
+        ("exactly-singular", 0.0),
+        ("1e-14", 1e-14),
+        ("1e-11", 1e-11),
+    ]
+    .iter()
+    .map(|(l, d)| (l, d))
+    {
+        let cols = near_singular(m, delta);
+        let rhs = matvec(&cols, &x_true);
+        let default_fails = default_factor_fails(&cols);
+
+        // abs_floor sweep; a handful of refinement steps.
+        let mut best = f64::INFINITY;
+        let mut best_floor = 0.0;
+        let mut best_growth = 0.0;
+        for &floor in &[1e-12, 1e-10, 1e-8, 1e-6, 1e-4] {
+            let (_x, res, growth) = perturbed_refined_solve(&cols, &rhs, floor, 20);
+            if res < best {
+                best = res;
+                best_floor = floor;
+                best_growth = growth;
+            }
+        }
+        println!(
+            "[{deltalabel:>16}] default_fails={default_fails:<5}  \
+             best_refined_residual={best:.3e}  at abs_floor={best_floor:.0e}  growth={best_growth:.2e}"
+        );
+
+        // Core assertion of H: refinement drives the residual to high accuracy.
+        assert!(
+            best < 1e-9,
+            "[{deltalabel}] refined residual {best:.3e} did not reach 1e-9 — H falsified for this case"
+        );
+    }
+    // Keep x_true referenced (silences an unused-mut lint on some toolchains).
+    x_true[5] = 0.0;
+}
+
+#[test]
+fn experiment_boundary_solution_uses_near_singular_direction() {
+    // Adversarial: a NONSINGULAR but ill-conditioned basis (delta=1e-11, κ≈1e11)
+    // whose solution genuinely loads the near-singular direction (x_true[last]≠0,
+    // so rhs has a component only the tiny last pivot can represent). This maps
+    // where localized-perturb + refinement stops working: the correction step must
+    // resolve the 1/delta-amplified component through the *perturbed* factor.
+    let m = 6;
+    let delta = 1e-11;
+    let cols = near_singular(m, delta);
+    for &xlast in &[1.0f64, 100.0] {
+        let x_true = vec![1.0, 2.0, 3.0, 4.0, 5.0, xlast];
+        let rhs = matvec(&cols, &x_true);
+        // abs_floor should not exceed the true smallest pivot here, or the
+        // perturbed factor discards the direction the solution needs.
+        let mut best = f64::INFINITY;
+        let mut best_floor = 0.0;
+        for &floor in &[1e-14, 1e-13, 1e-12, 1e-10] {
+            let (_x, res, _g) = perturbed_refined_solve(&cols, &rhs, floor, 30);
+            if res < best {
+                best = res;
+                best_floor = floor;
+            }
+        }
+        println!(
+            "[boundary xlast={xlast:>5}] best_refined_residual={best:.3e} at abs_floor={best_floor:.0e}"
+        );
+        // Informational (no hard assert): documents the regime where abs_floor
+        // must sit below the true pivot for refinement to keep the direction.
+    }
+}
+
+#[test]
+fn hardened_feral_lu_solves_where_default_aborts() {
+    // The production capability end-to-end: `FeralLU::with_singular_perturb` must
+    // (1) factorize a basis whose default (strict) factorization aborts, and
+    // (2) its refined ftran/btran recover the true solve to high accuracy.
+    let m = 6;
+    let cols = near_singular(m, 0.0); // exactly singular → default aborts
+    assert!(
+        FeralLU::new().factorize(m, &cols).is_err(),
+        "default must abort"
+    );
+
+    let x_true = [1.0, 2.0, 3.0, 4.0, 5.0, 0.0];
+    let rhs = matvec(&cols, &x_true);
+
+    let mut hardened = FeralLU::new().with_singular_perturb(1e-12);
+    hardened
+        .factorize(m, &cols)
+        .expect("hardened factorization must complete");
+
+    // ftran: B x = rhs (refined against true B).
+    let mut xf = rhs.clone();
+    hardened.ftran_refined(&mut xf).expect("ftran_refined");
+    let res_f = residual_inf(&cols, &xf, &rhs);
+    assert!(
+        res_f < 1e-9,
+        "hardened ftran residual {res_f:.3e} too large"
+    );
+
+    // btran: Bᵀ y = e (a consistent rhs in the range of Bᵀ). Use Bᵀ·y_true.
+    let y_true = [0.5, -1.0, 2.0, 0.0, 1.5, 0.0];
+    let mut bt_rhs = vec![0.0f64; m];
+    for i in 0..m {
+        // (Bᵀ y_true)_i = Σ_j B_{ji} y_true_j = dot(cols[i], y_true)
+        bt_rhs[i] = cols[i].iter().zip(&y_true).map(|(a, b)| a * b).sum();
+    }
+    let mut yb = bt_rhs.clone();
+    hardened.btran_refined(&mut yb).expect("btran_refined");
+    // Residual ‖Bᵀ y − bt_rhs‖∞ (row i of Bᵀ is cols[i]).
+    let res_b = (0..m)
+        .map(|i| residual_dd(&cols[i], &yb, bt_rhs[i]).abs())
+        .fold(0.0f64, f64::max);
+    assert!(
+        res_b < 1e-9,
+        "hardened btran residual {res_b:.3e} too large"
+    );
+}
+
+#[test]
+fn hardened_mode_off_is_byte_identical_default() {
+    // Without `with_singular_perturb`, a well-conditioned basis solves identically
+    // whether or not the refined entry points exist (default path untouched).
+    let cols = vec![
+        vec![2.0, 1.0, 0.0],
+        vec![1.0, 2.0, 1.0],
+        vec![0.0, 1.0, 2.0],
+    ];
+    let m = 3;
+    let rhs = [1.0, 2.0, 3.0];
+    let mut plain = FeralLU::new();
+    plain.factorize(m, &cols).unwrap();
+    let mut xp = rhs;
+    plain.ftran(&mut xp).unwrap();
+
+    let mut refined = FeralLU::new();
+    refined.factorize(m, &cols).unwrap();
+    let mut xr = rhs;
+    refined.ftran_refined(&mut xr).unwrap(); // no perturb → feral default path
+    assert_eq!(
+        xp, xr,
+        "non-hardened refined solve must match the plain solve"
+    );
+}
+
+#[test]
+fn experiment_reproduces_default_failure_on_singular_basis() {
+    // The exactly-singular basis MUST fail feral's default factorization — this is
+    // the hda-class `Numerical` reproduction the hardening targets.
+    let cols = near_singular(6, 0.0);
+    assert!(
+        default_factor_fails(&cols),
+        "exactly-singular basis should abort feral's default (Fail) LU"
+    );
+    // And PerturbToEps must complete it (a factor exists to refine against).
+    let params = LuParams {
+        on_singular: LuSingularAction::PerturbToEps { abs_floor: 1e-8 },
+        ..LuParams::default()
+    };
+    assert!(
+        DenseLu::factor(&cols, 6, params).is_ok(),
+        "PerturbToEps must complete the singular factorization"
+    );
+}

--- a/discopt_benchmarks/results/issue671/inhouse_regularized.py
+++ b/discopt_benchmarks/results/issue671/inhouse_regularized.py
@@ -1,0 +1,91 @@
+"""Does the IN-HOUSE simplex (not HiGHS) recover a good dual on hda's root LP via
+tau-regularization? The issue forbids an external-solver rescue, so the good dual
+must come from feral. Plain solve reproduces the numerical false-fail; the
+tau-perturbed solves probe whether feral can certify the well-conditioned
+neighbour and hand back a dual tight enough for a rigorous NS bound."""
+
+from __future__ import annotations
+
+import math
+import os
+
+import numpy as np
+import scipy.sparse as sp
+
+from discopt._rust import solve_lp_warm_csc_py
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "rbe", os.path.join(HERE, "refined_bound_experiment.py")
+)
+rbe = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rbe)
+
+
+def load():
+    d = np.load(os.path.join(HERE, "hda_root_lp.npz"))
+    shape = tuple(int(x) for x in d["A_shape"])
+    A = sp.csr_matrix((d["A_data"], d["A_indices"], d["A_indptr"]), shape=shape)
+    return A, d["b_ub"], d["bounds"], d["c"]
+
+
+def solve_inhouse(A, b, bounds, c, tau):
+    """Standard form [A|I] x = b+tau, slacks in [0,inf). Returns (status, dual)."""
+    m, n = A.shape
+    A_std = sp.hstack([A, sp.identity(m, format="csc")], format="csc").tocsc()
+    lb = bounds[:, 0].astype(float)
+    ub = bounds[:, 1].astype(float)
+    lb = np.where(np.isfinite(lb), lb, -1e20)
+    ub = np.where(np.isfinite(ub), ub, 1e20)
+    lb_std = np.concatenate([lb, np.zeros(m)])
+    ub_std = np.concatenate([ub, np.full(m, 1e20)])
+    c_std = np.concatenate([c.astype(float), np.zeros(m)])
+    b_vec = (b + tau).astype(float)
+    status, x_full, obj, iters, cs, bv, dual, ray = solve_lp_warm_csc_py(
+        np.ascontiguousarray(c_std),
+        m,
+        n + m,
+        np.ascontiguousarray(A_std.indptr, dtype=np.int64),
+        np.ascontiguousarray(A_std.indices, dtype=np.int64),
+        np.ascontiguousarray(A_std.data, dtype=np.float64),
+        np.ascontiguousarray(b_vec),
+        np.ascontiguousarray(lb_std),
+        np.ascontiguousarray(ub_std),
+        None,
+        None,
+    )
+    return status, obj, np.asarray(dual) if dual is not None and len(dual) else None
+
+
+def main():
+    A, b, bounds, c = load()
+    m, n = A.shape
+    lb = np.where(np.isfinite(bounds[:, 0]), bounds[:, 0], -np.inf).astype(float)
+    ub = np.where(np.isfinite(bounds[:, 1]), bounds[:, 1], np.inf).astype(float)
+    lb, ub = rbe.fbbt_tighten(A.tocsc(), b, lb, ub)
+
+    print(f"hda root LP {m}x{n}; in-house feral simplex, standard form [A|I]")
+    print(f"{'tau':>10} {'status':>10} {'lp_obj':>16} {'g(y) sound LB':>18} {'finite':>7}")
+    best = -math.inf
+    for tau in [0.0, 1e-3, 3e-3, 5e-3, 1e-2, 2e-2, 3e-2, 5e-2, 1e-1, 2e-1]:
+        status, obj, dual = solve_inhouse(A, b, bounds, c, tau)
+        gstr, fin = "n/a", "-"
+        if dual is not None:
+            g, finite = rbe.ns_safe_bound(dual, A, b, c, lb, ub)
+            gstr = f"{g:.4f}" if math.isfinite(g) else "-inf"
+            fin = str(finite)
+            if finite:
+                best = max(best, g)
+        objs = f"{obj:.4f}" if obj is not None and math.isfinite(obj) else "n/a"
+        print(f"{tau:>10.0e} {status:>10} {objs:>16} {gstr:>18} {fin:>7}")
+    print(f"\nBEST in-house sound lower bound = {best:.4f}")
+    print(f"candidate A -1.80e10  |  true root LP ~ -6.468e4")
+    if math.isfinite(best):
+        print(f"SOUND (<= -6.468e4): {best <= -6.468e4 + 1e-3*6.468e4}")
+        print(f"TIGHT (>> -1.8e10):  {best > -1e6}")
+
+
+if __name__ == "__main__":
+    main()

--- a/discopt_benchmarks/results/issue671/refined_bound_experiment.py
+++ b/discopt_benchmarks/results/issue671/refined_bound_experiment.py
@@ -1,0 +1,253 @@
+"""Issue #671 — a RIGOROUS tight dual bound for hda's root McCormick LP.
+
+The entry experiment proved (E1/E2) that hda's float64 false-infeasible is a
+precision artifact and that the true root LP value is ~ -6.47e4 (candidate A's
+-1.80e10 is loose). This script closes the loop: it produces a *sound* (never
+above the true optimum) and *tight* dual bound on the real exported hda LP,
+without an exact-rational full solve and without a working factorization on the
+near-singular bases.
+
+Method (regularized dual + rigorous Neumaier-Shcherbina bound)
+--------------------------------------------------------------
+The Neumaier-Shcherbina safe bound
+
+    g(y) = b^T y + sum_j  min_{x_j in [l_j,u_j]}  (c - A^T y)_j x_j        (NS)
+
+is a valid lower bound on  min c^T x s.t. A x = b, l <= x <= u  for ANY y
+(weak duality). Its *soundness* does not depend on where y came from; only its
+*tightness* does. So:
+
+  1. Solve a tiny RHS-regularized system  min c^T x s.t. A x <= b + tau, bounds
+     in float64 (well-conditioned -> HiGHS returns a clean primal-dual), giving
+     a GOOD multiplier y = -(inequality marginals).
+  2. Evaluate g(y) against the ORIGINAL data (b, not b+tau) in high precision.
+
+g(y) is sound for every tau (NS holds for any y); a small tau makes y accurate
+so g(y) is tight. This is the practical GSW payoff: the correction/regularized
+solve only has to yield a good multiplier, and NS turns it into a rigorous
+certificate. Candidate A (#662) is the same NS bound applied to the *drifted*
+dual from the broken solve; here we feed it a good dual instead.
+
+We also run a GSW dual iterative-refinement loop (double-precision inner solves
+on tau-perturbed systems, high-precision residuals via math.fsum) to show the
+bound converges the same way the Rust `refine` kernel does, self-tuning tau.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import numpy as np
+import scipy.sparse as sp
+from scipy.optimize import linprog
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# True root LP-relaxation value (E1 converged); MINLP opt is -5964.534084.
+TRUE_ROOT_LP = -6.4675e4
+CAND_A = -1.80e10
+
+
+def load():
+    d = np.load(os.path.join(HERE, "hda_root_lp.npz"))
+    shape = tuple(int(x) for x in d["A_shape"])
+    A = sp.csr_matrix((d["A_data"], d["A_indices"], d["A_indptr"]), shape=shape)
+    return A, d["b_ub"], d["bounds"], d["c"]
+
+
+def _bnds(bounds):
+    return list(
+        zip(
+            np.where(np.isfinite(bounds[:, 0]), bounds[:, 0], -np.inf),
+            np.where(np.isfinite(bounds[:, 1]), bounds[:, 1], np.inf),
+        )
+    )
+
+
+def fbbt_tighten(A_csc, b, lb, ub, passes=3):
+    """Feasibility-based bound tightening for the <= system A x <= b: derive finite
+    bounds for open (+/-inf) sides from single constraint rows. Standard, rigorous
+    (every derived bound is implied by a constraint), and exactly what the real
+    solver's presolve does before it certifies -- the raw exported LP skips it,
+    which is why a basic variable with a ~0 reduced cost and a *raw* open side
+    otherwise sends the NS bound to -inf. Returns tightened (lb, ub) copies."""
+    Acsr = A_csc.tocsr()
+    lb = lb.copy()
+    ub = ub.copy()
+    m = Acsr.shape[0]
+    for _ in range(passes):
+        for i in range(m):
+            s, e = Acsr.indptr[i], Acsr.indptr[i + 1]
+            cols = Acsr.indices[s:e]
+            vals = Acsr.data[s:e]
+            # minsum_k a_ik x_k over the box (per-term min).
+            for jpos in range(len(cols)):
+                j = cols[jpos]
+                aij = float(vals[jpos])
+                if aij == 0.0:
+                    continue
+                # min of the other terms; bail to -inf if any is open on its min side.
+                minsum = 0.0
+                openp = False
+                for k in range(len(cols)):
+                    if k == jpos:
+                        continue
+                    a = float(vals[k])
+                    col = cols[k]
+                    if a > 0:
+                        if not np.isfinite(lb[col]):
+                            openp = True
+                            break
+                        minsum += a * lb[col]
+                    elif a < 0:
+                        if not np.isfinite(ub[col]):
+                            openp = True
+                            break
+                        minsum += a * ub[col]
+                if openp:
+                    continue
+                rhs = float(b[i]) - minsum  # a_ij x_j <= rhs
+                if aij > 0:
+                    newub = rhs / aij
+                    if newub < ub[j]:
+                        ub[j] = newub
+                else:
+                    newlb = rhs / aij
+                    if newlb > lb[j]:
+                        lb[j] = newlb
+    return lb, ub
+
+
+def ns_safe_bound(y, A_csc, b, c, lb, ub):
+    """Rigorous NS lower bound g(y) on min c^Tx s.t. Ax<=b, lb<=x<=ub, evaluated in
+    standard equality form A_std=[A|I] (slacks in [0,inf)). y are the <=-row
+    multipliers (length m), which MUST be <= 0 for dual feasibility; we clamp any
+    tiny wrong-signed (positive) noise to 0. Weak duality holds for every dual in
+    the feasible orthant, so clamping yields a different-but-still-valid multiplier
+    and g stays a rigorous lower bound. High-precision (math.fsum) reduced-cost dot
+    products so a tiny true reduced cost is not lost to float64 cancellation.
+    Returns (g, finite): finite=False only if a *structural* open box side has the
+    wrong reduced-cost sign."""
+    m, n = A_csc.shape
+    # Clamp <=-constraint multipliers to their dual-feasible sign (<= 0). Setting a
+    # multiplier to exactly 0 is always dual-feasible, so this is rigorous.
+    y = np.minimum(np.asarray(y, dtype=float), 0.0)
+    # b^T y (fsum for the wide-ranged b).
+    g_terms = [float(bi) * float(yi) for bi, yi in zip(b, y)]
+    # A^T y, column by column, in high precision.
+    Acsc = A_csc.tocsc()
+    aty = np.zeros(n)
+    for j in range(n):
+        s, e = Acsc.indptr[j], Acsc.indptr[j + 1]
+        rows = Acsc.indices[s:e]
+        vals = Acsc.data[s:e]
+        aty[j] = math.fsum(float(v) * float(y[r]) for v, r in zip(vals, rows))
+    # structural columns
+    finite = True
+    for j in range(n):
+        rc = float(c[j]) - aty[j]
+        if rc > 0.0:
+            if not np.isfinite(lb[j]):
+                finite = False
+                break
+            g_terms.append(rc * float(lb[j]))
+        elif rc < 0.0:
+            if not np.isfinite(ub[j]):
+                finite = False
+                break
+            g_terms.append(rc * float(ub[j]))
+    # slack columns j' with A-column e_i, c=0, box [0, inf): rc = -y_i.
+    if finite:
+        for i in range(m):
+            rc = -float(y[i])
+            if rc > 0.0:
+                g_terms.append(0.0)  # lb = 0
+            elif rc < 0.0:
+                finite = False  # ub = +inf -> -inf term
+                break
+    if not finite:
+        return -math.inf, False
+    g = math.fsum(g_terms)
+    # NS relative safety margin so the float64 evaluation cannot push g above opt.
+    margin = 1e-9 * (1.0 + abs(g) + math.fsum(abs(t) for t in g_terms))
+    return g - margin, True
+
+
+def regularized_dual_bound(A, b, bounds, c):
+    print("\n[R] regularized-dual + rigorous NS bound")
+    print(f"     candidate A (loose): {CAND_A:.3e}   true root LP ~ {TRUE_ROOT_LP:.3e}")
+    bnds = _bnds(bounds)
+    lb = bounds[:, 0].astype(float)
+    ub = bounds[:, 1].astype(float)
+    lb = np.where(np.isfinite(lb), lb, -np.inf)
+    ub = np.where(np.isfinite(ub), ub, np.inf)
+    lb, ub = fbbt_tighten(A.tocsc(), b, lb, ub)
+    print(f"     (after FBBT: lb=-inf {np.sum(~np.isfinite(lb))}, ub=+inf {np.sum(~np.isfinite(ub))})")
+    print(f"     {'tau':>10} {'lp_status':>10} {'lp_obj':>16} {'g(y) [sound LB]':>20} {'finite':>7}")
+    best = -math.inf
+    for tau in [1e-3, 1e-5, 1e-7, 1e-8, 1e-9, 1e-10]:
+        r = linprog(c, A_ub=A, b_ub=b + tau, bounds=bnds, method="highs")
+        if r.status != 0:
+            print(f"     {tau:>10.0e} {'fail(' + str(r.status) + ')':>10}")
+            continue
+        # equality multipliers y for A_std = [A|I]: the inequality-row marginals.
+        y = np.asarray(r.ineqlin.marginals, dtype=float)
+        g, finite = ns_safe_bound(y, A, b, c, lb, ub)
+        gstr = f"{g:.4f}" if math.isfinite(g) else "-inf"
+        print(f"     {tau:>10.0e} {'optimal':>10} {r.fun:>16.4f} {gstr:>20} {str(finite):>7}")
+        if finite:
+            best = max(best, g)
+    print(f"\n     BEST sound lower bound g(y) = {best:.4f}")
+    # Soundness + tightness verdicts.
+    sound = best <= TRUE_ROOT_LP + 1e-3 * abs(TRUE_ROOT_LP)
+    tight = best > CAND_A * 1e-4  # many orders above candidate A's -1.80e10
+    print(f"     SOUND  (g <= true root LP {TRUE_ROOT_LP:.3e}): {sound}")
+    print(f"     TIGHT  (>> candidate A {CAND_A:.3e}):         {tight}")
+    print(f"     gap-to-opt: candidate A {abs(CAND_A - (-5964.53)):.3e}  ->  "
+          f"g(y) {abs(best - (-5964.53)):.3e}")
+    return best
+
+
+def gsw_refine(A, b, bounds, c, rounds=6):
+    """GSW dual iterative refinement (the Rust `refine` kernel's Python twin):
+    self-tuning regularization. Each round solves a tau_k-perturbed system, folds
+    a high-precision-residual correction into the incumbent multiplier, and
+    reports the rigorous NS bound. tau_k shrinks geometrically as the residual
+    falls, so no hand-picked tau is needed."""
+    print("\n[G] GSW dual iterative refinement (self-tuning regularization)")
+    bnds = _bnds(bounds)
+    lb = bounds[:, 0].astype(float)
+    ub = bounds[:, 1].astype(float)
+    lb = np.where(np.isfinite(lb), lb, -np.inf)
+    ub = np.where(np.isfinite(ub), ub, np.inf)
+    lb, ub = fbbt_tighten(A.tocsc(), b, lb, ub)
+    tau = 1e-3
+    best = -math.inf
+    for k in range(rounds):
+        r = linprog(c, A_ub=A, b_ub=b + tau, bounds=bnds, method="highs")
+        if r.status != 0:
+            print(f"     round {k}: inner solve failed ({r.status}); stop")
+            break
+        y = np.asarray(r.ineqlin.marginals, dtype=float)
+        g, finite = ns_safe_bound(y, A, b, c, lb, ub)
+        gstr = f"{g:.4f}" if math.isfinite(g) else "-inf"
+        print(f"     round {k}: tau={tau:.0e}  g(y)={gstr:>16}  finite={finite}")
+        if finite:
+            best = max(best, g)
+        tau *= 0.05  # geometric shrink toward the float64 floor
+        if tau < 1e-11:
+            break
+    print(f"     GSW best sound lower bound = {best:.4f}")
+    return best
+
+
+def main():
+    A, b, bounds, c = load()
+    print(f"hda root LP: {A.shape[0]}x{A.shape[1]} nnz={A.nnz}")
+    regularized_dual_bound(A, b, bounds, c)
+    gsw_refine(A, b, bounds, c)
+
+
+if __name__ == "__main__":
+    main()

--- a/discopt_benchmarks/results/issue671/rowfilter_entry_experiment.py
+++ b/discopt_benchmarks/results/issue671/rowfilter_entry_experiment.py
@@ -1,0 +1,171 @@
+"""hda certification entry experiment: log-lift vs float64-intractable-row filter.
+
+Follow-up to the #671 tight-bound work. Goal: find the lever that lets hda's node
+LPs solve CLEANLY at tau=0 in the in-house simplex (the keystone for certifying
+hda: clean node LPs -> warm starts -> throughput -> branch-and-reduce can close
+the McCormick gap).
+
+Hypothesis H (log-lift): hda's ill-conditioned McCormick rows come from
+strictly-positive Arrhenius/monomial structure; replacing them with exact
+log-domain rows yields a well-conditioned LP solvable at tau=0 with bound
+>= -6.47e4.
+
+Kill criterion: coverage — if the wide rows are mostly NOT 2-term ratio form
+(rhs=0, opposite signs, both vars lb>0), the exact lift cannot absorb them.
+
+RESULT (2026-07-18):
+  * H's log-lift half is FALSIFIED ON COVERAGE: of 130 wide rows, only 4 are
+    exact-liftable 2-term ratio rows (50 of the 60 two-term rows have rhs!=0,
+    66 rows have 3 terms, 4 have 4; 60/154 touched columns have lb<=0).
+  * BUT the measurement found the far simpler sufficient lever: the 130 wide
+    rows contribute ZERO tightness at the root box. Dropping them (sound by
+    construction: fewer relaxation rows = superset = still a valid outer
+    approximation):
+      - coefficient spread 2.837e26 -> 3.5e11,
+      - HiGHS at tau=0: OPTIMAL, obj -64675.24919969549,
+      - in-house feral at tau=0: OPTIMAL, obj -64675.24919969546,
+      - Neumaier-Shcherbina safe bound from feral's own dual: -64675.2494
+        (rigorous, finite, sound: <= opt -5964.53),
+    i.e. exactly the tau-homotopy limit (-64675.25, E1) — no tightness lost —
+    and the false-infeasible is gone WITHOUT perturbation, sweep, hardening, or
+    external solver.
+
+CONFIRMED lever: a build-time "float64-intractable row" filter (skip emitting
+relaxation rows whose per-row coefficient spread exceeds what float64 can
+resolve at the LP feasibility tolerance). Sound by superset; tightness impact
+is instance-dependent and must be gated by the corpus differential panel
+(a wide row MAY carry tightness elsewhere). On hda it is a pure win: the rows
+poisoned every float64 engine and bought nothing.
+
+Reproduces: python rowfilter_entry_experiment.py   (needs discopt._rust built)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import numpy as np
+import scipy.sparse as sp
+from scipy.optimize import linprog
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Per-row classification thresholds (see doc: a principled production criterion
+# should be term-magnitude-based; the coefficient-ratio proxy suffices here).
+WIDE_RATIO = 1e6
+WIDE_ABS_HI = 1e8
+WIDE_ABS_LO = 1e-8
+
+
+def load():
+    d = np.load(os.path.join(HERE, "hda_root_lp.npz"))
+    shape = tuple(int(x) for x in d["A_shape"])
+    A = sp.csr_matrix((d["A_data"], d["A_indices"], d["A_indptr"]), shape=shape)
+    return A, d["b_ub"].astype(float), d["bounds"], d["c"].astype(float)
+
+
+def wide_rows(A):
+    out = []
+    for i in range(A.shape[0]):
+        s, e = A.indptr[i], A.indptr[i + 1]
+        if s == e:
+            continue
+        a = np.abs(A.data[s:e])
+        if a.max() / a.min() > WIDE_RATIO or a.max() > WIDE_ABS_HI or a.min() < WIDE_ABS_LO:
+            out.append(i)
+    return np.array(out, dtype=int)
+
+
+def coverage_audit(A, b, bounds, w):
+    """The log-lift coverage question (H's kill criterion)."""
+    lb = bounds[:, 0]
+    nnzs = np.diff(A.indptr)[w]
+    import collections
+
+    hist = dict(collections.Counter(nnzs.tolist()))
+    two = w[nnzs == 2]
+    liftable = rhs_nz = same_sign = blocked = 0
+    for i in two:
+        s, e = A.indptr[i], A.indptr[i + 1]
+        a = A.data[s:e]
+        cols = A.indices[s:e]
+        if abs(b[i]) > 0:
+            rhs_nz += 1
+        elif a[0] * a[1] >= 0:
+            same_sign += 1
+        elif all(lb[j] > 0 for j in cols):
+            liftable += 1
+        else:
+            blocked += 1
+    print(f"[coverage] wide rows {len(w)}; nnz hist {hist}")
+    print(
+        f"[coverage] 2-term: liftable {liftable}, rhs!=0 {rhs_nz}, "
+        f"same-sign {same_sign}, lb<=0-blocked {blocked}"
+    )
+    print(f"[coverage] VERDICT: exact log-lift covers {liftable}/{len(w)} wide rows -> "
+          f"{'FALSIFIED on coverage' if liftable < len(w) // 2 else 'viable'}")
+
+
+def drop_experiment(A, b, bounds, c):
+    """The row-filter measurement: drop wide rows, solve at tau=0, certify."""
+    w = wide_rows(A)
+    keep = np.setdiff1d(np.arange(A.shape[0]), w)
+    Ak = A[keep].tocsr()
+    bk = b[keep]
+    ad = np.abs(Ak.data)
+    print(f"[filter] dropped {len(w)} rows -> {Ak.shape[0]}; spread {ad.max()/ad.min():.3e}")
+
+    lb = np.where(np.isfinite(bounds[:, 0]), bounds[:, 0], -np.inf)
+    ub = np.where(np.isfinite(bounds[:, 1]), bounds[:, 1], np.inf)
+    r = linprog(c, A_ub=Ak, b_ub=bk, bounds=list(zip(lb, ub)), method="highs")
+    st = {0: "optimal", 2: "infeasible", 3: "unbounded", 4: "numerical"}.get(r.status, r.status)
+    print(f"[filter] HiGHS tau=0: {st} obj={r.fun}")
+
+    # In-house feral at tau=0, standard form [A|I].
+    from discopt._rust import solve_lp_warm_csc_py
+
+    mk, n = Ak.shape
+    A_std = sp.hstack([Ak, sp.identity(mk, format="csc")], format="csc").tocsc()
+    lbs = np.where(np.isfinite(bounds[:, 0]), bounds[:, 0], -1e20)
+    ubs = np.where(np.isfinite(bounds[:, 1]), bounds[:, 1], 1e20)
+    lb_std = np.concatenate([lbs, np.zeros(mk)])
+    ub_std = np.concatenate([ubs, np.full(mk, 1e20)])
+    c_std = np.concatenate([c, np.zeros(mk)])
+    status, _x, obj, _it, _cs, _bv, dual, _ray = solve_lp_warm_csc_py(
+        np.ascontiguousarray(c_std),
+        mk,
+        n + mk,
+        np.ascontiguousarray(A_std.indptr, dtype=np.int64),
+        np.ascontiguousarray(A_std.indices, dtype=np.int64),
+        np.ascontiguousarray(A_std.data, dtype=np.float64),
+        np.ascontiguousarray(bk),
+        np.ascontiguousarray(lb_std),
+        np.ascontiguousarray(ub_std),
+        None,
+        None,
+    )
+    print(f"[filter] in-house feral tau=0: {status} obj={obj}")
+
+    # Rigorous NS certificate from feral's own dual (FBBT-tightened boxes).
+    spec = importlib.util.spec_from_file_location(
+        "rbe", os.path.join(HERE, "refined_bound_experiment.py")
+    )
+    rbe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(rbe)
+    if dual is not None and len(dual):
+        lbf, ubf = rbe.fbbt_tighten(Ak.tocsc(), bk, lb.copy(), ub.copy())
+        g, finite = rbe.ns_safe_bound(np.asarray(dual), Ak, bk, c, lbf, ubf)
+        print(f"[filter] NS safe bound g(y) = {g:.4f} finite={finite} "
+              f"sound={g <= -5964.53}")
+
+
+def main():
+    A, b, bounds, c = load()
+    w = wide_rows(A)
+    coverage_audit(A, b, bounds, w)
+    drop_experiment(A, b, bounds, c)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/hda-certification-rowfilter-entry-2026-07-18.md
+++ b/docs/dev/hda-certification-rowfilter-entry-2026-07-18.md
@@ -82,6 +82,42 @@ wide row MAY carry tightness elsewhere in the corpus — so the flag ships
 the corpus differential panel (`incorrect_count = 0`, no bound above reference,
 net-positive).
 
+## Implementation (landed same day, default-OFF)
+
+Flag `DISCOPT_RELAX_ROW_FILTER` / `SolverTuning.relax_row_filter` (default OFF).
+`_filter_unresolvable_rows` at the tail of `build_milp_relaxation` — one site
+covering the root build **and** every per-node cold rebuild — drops rows whose
+nonzero |coefficients| exceed 1e8, fall below 1e-8, or span a ratio > 1e6 (the
+entry-experiment-validated criterion; absolute checks first so the ratio test is
+a multiply, no overflow). Container kind (CSR/dense) preserved; empty rows kept
+(a `0 ≤ b < 0` row is a rigorous infeasibility proof). Under the flag the
+incremental McCormick engine's row-for-row self-validation fails on models that
+actually filter rows → those solves take the trusted cold (filtered) build — a
+speed cost only; no-filter models are byte-identical either way.
+
+**End-to-end measurement** (`dm.from_nl("hda.nl").solve(time_limit=60)`,
+all other #671 flags OFF):
+
+| | bound | mechanism |
+|---|---|---|
+| filter OFF | −1.80e10 | candidate A (drifted dual of a failed LP) |
+| **filter ON** | **−64473.44** | **clean LP solves through the standard path** |
+
+The tight bound now arrives with *no* rescue stack — no τ-sweep, no NS-from-
+failure, no hardening. (−64473 is slightly tighter than the bare root LP's
+−64675: with clean LP solves, root OBBT/cut machinery does real work.)
+
+**Still open after this lever** (the measured next blockers, unchanged from the
+"revised path" below): the root consumes the whole 60 s budget (presolve ~10 s +
+FBBT + builds + now-working OBBT solves; `root_time ≈ wall`, 3 nodes) and no
+incumbent is found within it. The filter unblocks *clean LP solves*; root
+*throughput* and the incumbent are steps 2–3.
+
+Regression tests: `python/tests/test_relax_row_filter.py` (flag default-off;
+dense+sparse helper behavior incl. kind preservation and empty-row keep; no-op
+on well-conditioned matrices; slow: hda tight+sound end-to-end, alan/ex1221
+byte-identical ON vs OFF).
+
 ## Revised path to hda certification
 
 1. **Row filter** (this lever; small, well-scoped): default-OFF flag at row

--- a/docs/dev/hda-certification-rowfilter-entry-2026-07-18.md
+++ b/docs/dev/hda-certification-rowfilter-entry-2026-07-18.md
@@ -1,0 +1,107 @@
+# hda certification entry experiment — log-lift falsified on coverage; float64-intractable-row filter CONFIRMED
+
+Follow-up to the #671 tight-bound work (PR #746). Question: what lets hda's node
+LPs solve **cleanly at τ=0 in the in-house simplex** — the keystone for actually
+*certifying* hda (clean node LPs → warm starts → tree throughput → incumbent →
+branch-and-reduce closes the McCormick gap −6.47e4 → −5964.53)?
+
+Docs-only + reproducer; **no production solver code changed.** Reproducer:
+`discopt_benchmarks/results/issue671/rowfilter_entry_experiment.py`.
+
+## Hypothesis (H) and kill criterion
+
+**H (log-lift):** hda's ill-conditioned McCormick rows come from strictly-positive
+Arrhenius/monomial structure; replacing them with exact log-domain rows (the
+existing H-LOG machinery's transform) yields a well-conditioned LP solvable at
+τ=0 with bound ≥ −6.47e4.
+
+**Kill criterion:** coverage — the exact 2-term ratio lift (`a·x + b·w ≤ 0`,
+opposite signs, both vars `lb > 0` → unit-coefficient log row) must absorb the
+bulk of the wide rows, else the lift cannot de-condition the LP.
+
+## Measurement 1 — coverage audit: H is FALSIFIED
+
+Classifying the exported root LP's rows (per-row coefficient ratio > 1e6, or any
+|a| outside [1e-8, 1e8]) gives **130 wide rows** (of 3008; 4.3 %):
+
+| wide-row class | count | exact-liftable? |
+|---|---|---|
+| 2-term, rhs = 0, opposite signs, both lb > 0 | **4** | yes |
+| 2-term, rhs ≠ 0 | 50 | no (log of affine) |
+| 2-term, same-sign / lb ≤ 0 | 6 | no |
+| 3-term | 66 | no (log of sum) |
+| 4-term | 4 | no |
+
+**Exact log-lift covers 4/130.** 60 of the 154 wide-row columns have `lb ≤ 0`
+(precondition violation). H is falsified on coverage — a log-space rebuild would
+be a research project with most of the pathology untouched by the exact lift.
+
+## Measurement 2 — the pivot: the wide rows carry ZERO root tightness
+
+Dropping all 130 wide rows (**sound by construction**: fewer relaxation rows =
+superset = still a valid outer approximation — a relaxation-strength choice, not
+a soundness question; only *tightness* is at stake, and it is measured):
+
+| metric | with wide rows | without (130 dropped) |
+|---|---|---|
+| coefficient spread | 2.837e26 | **3.5e11** |
+| HiGHS at τ=0 | infeasible (false) | **optimal, −64675.24919969549** |
+| **in-house feral at τ=0** | `numerical` | **optimal, −64675.24919969546** |
+| NS safe bound (feral's own dual) | n/a (candidate A −1.80e10) | **−64675.2494, rigorous** |
+
+−64675.25 is *exactly* the τ-homotopy limit (E1, #708) — the tight root value —
+so the 130 rows bought **nothing** at the root box while making the LP
+float64-intractable for every engine. No perturbation, no τ-sweep, no
+factorization hardening, no external solver: the in-house simplex simply solves
+the filtered LP and its own dual certifies the tight bound.
+
+This also retro-explains the earlier findings: the τ-sweep (PR #746's working
+lever) succeeded because RHS regularization *loosened exactly these rows* past
+their float64-unresolvable balancing terms; factorization hardening failed
+because completing the factor still left the simplex pivoting on the degenerate
+geometry these rows create.
+
+## Confirmed lever — build-time float64-intractable-row filter
+
+Emit-time policy in the uniform factorable engine (`build_uniform_relaxation`,
+where every relaxation row is born): **skip emitting a row whose terms cannot be
+resolved in float64 at the LP feasibility tolerance.** The experiment's
+coefficient-ratio proxy (> 1e6, or |a| outside [1e-8, 1e8]) worked; the
+production criterion should be principled — per-row **term-magnitude spread over
+the box** (`max_j |a_ij|·max(|l_j|,|u_j|)` vs `min_j …`, and vs |b_i| + feasibility
+tolerance), which is what actually determines whether float64 can evaluate the
+row's satisfaction. Placement at emission means the rows never exist — root
+**and every node** (the per-node rebuild/tightening operates on the kept rows),
+so node LPs become warm-startable and the whole #671 rescue stack becomes a
+fallback rather than the path.
+
+Soundness: dropping a relaxation row can only *weaken*, never falsify (superset;
+the "weaken but never falsify" property). Tightness is instance-dependent — a
+wide row MAY carry tightness elsewhere in the corpus — so the flag ships
+**default-OFF** behind the §5 bound-changing regime and graduates only through
+the corpus differential panel (`incorrect_count = 0`, no bound above reference,
+net-positive).
+
+## Revised path to hda certification
+
+1. **Row filter** (this lever; small, well-scoped): default-OFF flag at row
+   emission → hda's root and node LPs solve cleanly at τ=0, NS-certified.
+2. **Incumbent:** with the root no longer consuming the whole budget, the
+   existing diving/multistart heuristics get their chance (13 binaries → 8192
+   configs; local NLPs likely land −5964.53 quickly). Measure before adding
+   anything new.
+3. **Branch-and-reduce** (existing machinery: `root_fixpoint`, OBBT-with-cutoff,
+   spatial branching) closes −6.47e4 → −5964.53 with clean, warm-started node
+   LPs. Node-count unknown; BARON/SCIP certify hda, so tractable in principle.
+4. **Gates:** each step behind its flag + the corpus panel (needs the full
+   MINLPLib corpus — not available in the dev container).
+
+Falsified en route (do not re-try): log-domain lift as the de-conditioning lever
+(4/130 coverage); dense→sparse Jacobian routing for root speed
+(`performance-plan.md` §10); factorization hardening as hda's bound rescue
+(PR #746 doc — kept as a validated primitive for less-degenerate instances).
+
+## Artifacts
+
+`discopt_benchmarks/results/issue671/rowfilter_entry_experiment.py` (reproduces
+all numbers above against the exported `hda_root_lp.npz`).

--- a/docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md
+++ b/docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md
@@ -156,14 +156,54 @@ whose node LPs solve cleanly never trigger it (test:
 - Candidate-A regression suite (`test_issue_517_*`, `test_issue362_*`) still green
   — the failure branch is unchanged with the flag OFF.
 
-### Remaining principled follow-up (not required for hda's bound)
+### Factorization hardening (the feral-touching half) — built, validated, wired; does NOT rescue hda's bound
 
-The GSW `refine` kernel would supersede the τ-sweep once feral gains a
-**rank-revealing / regularized LU** so its correction solves return consistent
-approximate solutions to refine (the τ-sweep is the pragmatic stand-in that works
-with feral's current factorization). An **exact-rational** solve of the small
-failing sub-block (E2 core was 2×3) remains the gold-standard feasibility
-certificate. Both are orthogonal to the now-delivered tight bound.
+The second half of the issue: make feral's LU survive the near-singular bases so a
+node LP can return `optimal` at τ=0. feral exposes `LuSingularAction::PerturbToEps
+{ abs_floor }`, which floors *only* the singular pivots (a localized regularization
+→ a nearby `B'`, not a uniform `B + εI`) and completes instead of aborting.
+
+**Primitive — CONFIRMED** (`crates/discopt-core/src/lp/simplex/regularized_lu.rs`,
+7 cargo tests). On near-singular / exactly-singular bases where feral's default
+`Fail` aborts, `PerturbToEps` + double-double refinement recovers the solve to
+residual ~0 (growth 1.0); the boundary case (solution loading the near-singular
+direction) recovers too, provided `abs_floor` sits below the genuine small pivots.
+The capability lives on `FeralLU::with_singular_perturb`; the double-double
+refinement (`dd_refined`, sparse-aware `residual_matvec_dd`) is what recovers
+accuracy past the perturbed factor's error (feral's own double-precision refine was
+falsified on this class).
+
+**Wiring — safe, default-OFF** (flag `DISCOPT_LP_FACTORIZATION_HARDENING`). Mirrors
+the #85 dense-retry: a thread-local `hardening_active()` makes `node_feral_lu()`
+build a hardened factor; `dual::solve_lp_warm_csc` re-runs the solve under
+`with_hardening_active` once a strict solve exits `Numerical`/`IterLimit`. The
+re-solve is bounded (`8·(m+n)+2000` pivots **and** a 3 s wall deadline) so it can
+only *rescue*, never stall. Flag OFF ⇒ byte-identical (measured: hda bound
+`−18016528426.5` unchanged; `node_lu_is_plain_when_hardening_inactive`).
+
+**Measured end-to-end on hda — the hardening does NOT rescue the bound.** With the
+flag ON, hda's reported bound stays at candidate A's `−1.80e10` (the hardened
+re-solve bails at its bound and falls through). The reason is decisive and worth
+recording (Dev-Philosophy #4): **`PerturbToEps` unblocks the *factorization*, but
+hda's McCormick LP is still too *degenerate to pivot* to optimality** — the simplex
+grinds the same near-singular vertex geometry a completed factor does not change.
+Contrast the **RHS regularization** lever (`DISCOPT_LP_ITERATIVE_REFINEMENT`, shipped
+above), which *does* give hda its tight `−6.45e4`: perturbing the RHS moves the
+optimum *off* the degenerate vertex, so the simplex reaches a clean optimum. So for
+**hda's bound, RHS regularization is the working lever**; factorization hardening is
+a correct, safe, validated primitive that may rescue *other*, less-degenerate
+numerical-failure instances (where a completed factor lets the simplex finish) but
+is not what hda needs. It stays default-OFF pending a corpus-wide panel that finds
+the instances it *does* help.
+
+### Remaining principled follow-up
+
+The GSW `refine` kernel would supersede the τ-sweep once feral gains a **true
+rank-revealing LU** *and* the degenerate-pivot problem above is addressed (a
+completed factor is necessary but not sufficient — hda shows the vertex geometry,
+not just the linear algebra, is the obstacle). An **exact-rational** solve of the
+small failing sub-block (E2 core was 2×3) remains the gold-standard feasibility
+certificate. Both are orthogonal to the delivered τ-regularized tight bound.
 
 ## Verification regime (Dev-Philosophy #5)
 

--- a/docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md
+++ b/docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md
@@ -1,0 +1,157 @@
+# Issue #671 — GSW LP iterative-refinement kernel (the precision layer above feral)
+
+Follow-up to the #671 entry experiment (`issue-671-hda-exact-lp-entry-experiment-2026-07-17.md`,
+PR #708), which **CONFIRMED** that hda's loose dual bound (−1.80e10, candidate A / #662)
+is a *precision artifact*, not a relaxation property: solving the same root
+McCormick LP with high-precision residuals recovers the true root value ≈ −6.47e4
+(≈5.4 orders tighter). The confirmed lever is **LP iterative refinement**
+(Gleixner–Steffy–Wolter 2016): solve in double, compute the residual against the
+original data in higher-than-double precision, scale it up, re-solve a correction
+LP in double, iterate.
+
+This doc records the **kernel** that lever needs, landed as a self-contained,
+cargo-tested Rust module, and the integration + factorization-hardening plan for
+turning it into hda's tight production bound.
+
+## What landed (this change)
+
+`crates/discopt-core/src/lp/simplex/refine.rs` — a precision layer *above* the
+double-precision simplex, with **no wiring into any default solve path** (so every
+existing solve is byte-identical and the certifying panel is bound-neutral by
+construction; see §"Verification regime"). Three pieces:
+
+1. **High-precision residual primitive** — `residual_dd` / `dot_dd`. Pure-Rust
+   *double-double* (≈106-bit) accumulation via the `two_sum`/`two_prod` error-free
+   transforms (the latter using a fused multiply-add). No new dependencies. This
+   is the GSW primitive: it computes `b − A x` (and `c − Aᵀ y`) to full float64
+   accuracy even when the individual products dwarf the true residual — the case
+   that makes a naive float64 dot return noise, or `0`.
+
+2. **GSW primal-dual refinement loop** — `refine(...)`, generic over a
+   `CorrectionSolver` (the fixed-`A` inner double solver — in production, the
+   warm-started node simplex). Each round:
+   - computes the primal residual `b − A x*` and dual residual `c − Aᵀ y*` in
+     double-double,
+   - scales each up toward O(1) (`Δp`, `Δd`),
+   - solves a correction subproblem with the **same `A`** and shifted
+     objective/rhs/bounds in double,
+   - folds the scaled-down correction back into the incumbent `(x*, y*)`.
+
+   The incumbent is kept **exactly box-feasible every round** because the
+   correction's bounds are `Δp·(l − x*) ≤ x̄ ≤ Δp·(u − x*)`, so
+   `x* + x̄/Δp ∈ [l, u]` identically. Convergence is geometric (≈16 digits/round
+   for a solver returning ≈1e-16-accurate corrections).
+
+3. **Neumaier–Shcherbina safe bound** — `ns_safe_bound(y, …)`, the same
+   weak-duality lower bound `g(y) = bᵀy + Σ_j min_{x_j∈box}(c − Aᵀy)_j x_j` the
+   MILP boundary already applies to candidate A's drifted dual
+   (`milp_simplex._safe_lp_lower_bound_std`) and that `primal::safe_bound` uses in
+   its tests. `g(y)` is valid for **any** `y`, so a refined dual can only *tighten*
+   the certificate — never lift a bound above the true optimum. Refinement improves
+   the multiplier fed into this function; it changes no guard, tolerance, or
+   fallback.
+
+### Why the precision has to live here, not inside feral
+
+feral's *existing* double-precision iterative refinement (`with_numeric_focus`)
+was already falsified on hda (issue body: "byte-identical, no effect — residual
+computed in double can't recover ~1e14 loss"). GSW is a **different layer**: the
+residual is computed against the original problem data at *higher-than-double*
+precision (`residual_dd`), then a **double** correction solve consumes it. Only the
+residual is high-precision. That is exactly what this module adds, and exactly what
+a feral-internal double-precision refine cannot.
+
+## Cargo-validated results (`cargo test -p discopt-core --lib refine`, 12 tests)
+
+| test | what it proves |
+|---|---|
+| `two_sum_is_exact`, `two_prod_is_exact` | the error-free transforms are exact (the precision floor of the whole layer) |
+| `residual_dd_survives_catastrophic_cancellation` | `1e16 + 1 − 1e16`: naive float64 → `0`, `residual_dd` → the exact `1` |
+| `residual_dd_recovers_arrhenius_scale_product_error` | at hda's `6.3e10 × 1.96e-13` Arrhenius magnitudes, `residual_dd` recovers the sub-ulp product tail naive drops to `0` |
+| `dot_dd_beats_naive_on_cancellation` | double-double dot resolves a cancellation naive gets wrong |
+| `refine_exact_solver_reproduces_optimum_bound` | the GSW loop + `ns_safe_bound` reproduce the true LP optimum |
+| `refine_extracts_accuracy_below_the_inner_solvers_grid` | given an inner solver capped at **1e-4** accuracy, refinement drives the true residual **< 1e-9** — the core GSW guarantee (accuracy past the inner solver's floor), the analogue of escaping HiGHS's ~1e-7 feasibility-tolerance floor on hda |
+| `refine_tightens_a_drifted_dual_on_an_ill_conditioned_lp` | on a 1e8-range LP, a single lossy solve gives a **drifted dual → loose** safe bound; refinement tightens it to the optimum (candidate A → tight, in miniature) |
+| `ns_safe_bound_is_never_above_optimum_for_arbitrary_dual` | soundness: `g(y) ≤ opt` for arbitrary `y` — the property candidate A relies on |
+
+Full suite green: `cargo test -p discopt-core --lib` → **470 passed**; `cargo
+clippy -p discopt-core --lib` clean.
+
+The `…grid` and `…drifted_dual` tests are the honest model of hda: the obstacle
+there is **not** float64 arithmetic cancellation in a single residual (hda's
+balancing terms are ~1e-11, only ~1 digit of cancellation) — it is a **fixed
+tolerance floor** (HiGHS's ~1e-7; feral's growth guards) that a single double
+solve cannot see under. GSW's scale-up-and-resolve is what escapes that floor, and
+that is precisely what these two tests exercise with a deliberately floor-limited
+inner solver.
+
+## Integration seam (follow-up, default-OFF, failure-triggered)
+
+The kernel is deliberately **unwired**. The production seam is a one-call-site
+change at the numerical-failure branch that already computes candidate A:
+
+- Rust: `dual.rs::solve_lp_warm_csc`, on `LpStatus::Numerical`, would build a
+  `CorrectionSolver` over the same CSC `A` (a thin adapter over the existing
+  warm-started simplex) and call `refine(...)`, then export the **refined** dual
+  in the existing `LpSolve::dual` field. No Python change is then required — the
+  boundary's existing `_safe_lp_lower_bound(dual, …)` (`milp_simplex.py:691`)
+  automatically tightens from the better dual.
+- Behind a new **default-OFF** flag `DISCOPT_LP_ITERATIVE_REFINEMENT` (a
+  `SolverTuning` field alongside `node_numerical_dual_bound`), **root-only /
+  numerical-failure-triggered** — never the hot per-node engine. Flag OFF ⇒ the
+  path is byte-identical to today.
+- Candidate A (#662) stays as the fallback: if refinement fails to converge (or
+  the inner solve fails), the drifted-dual NS bound is still emitted, so the seam
+  can only *improve* hda's bound, never lose it.
+
+### The remaining blocker (the harder, feral-touching half)
+
+Per the issue, GSW alone does **not** rescue hda without a **working factorization
+on near-singular bases**. hda's root LP defeats feral with an FT `Growth`
+*factorization failure* — the simplex cannot even return the inaccurate
+approximate solution GSW refines; it returns nothing. GSW's correction solves reuse
+the same `A`, so they hit the same near-singular bases. The correction *rhs/bounds*
+are better-scaled (residual scaled to O(1)), which helps conditioning, but the
+rank deficiency (~13–43) is scale-invariant, so a correction solve can still land
+on a singular basis. Closing #671 end-to-end therefore also needs one of:
+
+- **rank-revealing / regularized LU** (pivot to reveal the rank, regularize the
+  dependent rows), or
+- **basis management** that steers the simplex off the near-singular vertices, or
+- an **exact-rational** correction solve on the (small) failing sub-block only —
+  the E2 core was 2×3; a real exact-LP library (QSopt_ex / SoPlex-exact) is routine
+  at 3008×1140.
+
+This half is out of scope for this change (it modifies feral's hot factorization
+and needs its own bound-neutral panel). The kernel here is the prerequisite layer
+it plugs into.
+
+## Verification regime (unchanged from the issue; Dev-Philosophy #5)
+
+- **Bound-neutral by construction now:** the module is unwired, so `node_count` and
+  certified `objective` are exactly unchanged on every already-solving instance —
+  nothing calls it. `cargo test -p discopt-core` green (470).
+- **When wired (follow-up):** default-OFF flag; the certifying panel runs with the
+  flag OFF (byte-identical) and ON (fires only on numerical-failure nodes). The NS
+  bound is sound for any dual, and incumbents remain independently
+  feasibility-verified; `incorrect_count ≤ 0` with zero slack. Target acceptance:
+  hda reports a **tight** finite dual bound (materially closer to opt −5964.53 than
+  candidate A's −1.80e10, i.e. ≈ −6.47e4, the true root McCormick value), no panel
+  regression.
+
+## Scope honesty
+
+This tightens the **certificate**. It does **not** close hda's optimality gap: the
+residual between −6.47e4 and opt −5964.53 is the genuine McCormick relaxation gap
+at the root box (branch-and-reduce / a stronger relaxation — an orthogonal effort),
+not anything LP precision can touch.
+
+## References
+
+- #517 (first finite bound), #662 (candidate A, merged), #664 (superseded),
+  #708 (entry experiment, docs-only).
+- Gleixner, Steffy, Wolter, *Iterative Refinement for Linear Programming*,
+  INFORMS J. Comput. 28(3), 2016.
+- `crates/discopt-core/src/lp/simplex/refine.rs`,
+  `docs/dev/issue-671-hda-exact-lp-entry-experiment-2026-07-17.md`,
+  `docs/dev/hda-no-bound-simplex-robustness-2026-07-16.md`.

--- a/docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md
+++ b/docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md
@@ -15,10 +15,10 @@ turning it into hda's tight production bound.
 
 ## What landed (this change)
 
-`crates/discopt-core/src/lp/simplex/refine.rs` — a precision layer *above* the
-double-precision simplex, with **no wiring into any default solve path** (so every
-existing solve is byte-identical and the certifying panel is bound-neutral by
-construction; see §"Verification regime"). Three pieces:
+Two parts: the reusable **kernel** (`crates/discopt-core/src/lp/simplex/refine.rs`)
+and the **shipped hda bound** (the τ-regularized-resolve path wired into the
+numerical-failure branch behind a default-OFF flag — see "Integration" below). The
+kernel is a precision layer *above* the double-precision simplex. Three pieces:
 
 1. **High-precision residual primitive** — `residual_dd` / `dot_dd`. Pure-Rust
    *double-double* (≈106-bit) accumulation via the `two_sum`/`two_prod` error-free
@@ -85,59 +85,104 @@ solve cannot see under. GSW's scale-up-and-resolve is what escapes that floor, a
 that is precisely what these two tests exercise with a deliberately floor-limited
 inner solver.
 
-## Integration seam (follow-up, default-OFF, failure-triggered)
+## Integration (landed, default-OFF, failure-triggered) — hda resolved end-to-end
 
-The kernel is deliberately **unwired**. The production seam is a one-call-site
-change at the numerical-failure branch that already computes candidate A:
+The kernel is wired into the numerical-failure branch that already computes
+candidate A, behind a new **default-OFF** flag `DISCOPT_LP_ITERATIVE_REFINEMENT`
+(`SolverTuning.lp_iterative_refinement`).
 
-- Rust: `dual.rs::solve_lp_warm_csc`, on `LpStatus::Numerical`, would build a
-  `CorrectionSolver` over the same CSC `A` (a thin adapter over the existing
-  warm-started simplex) and call `refine(...)`, then export the **refined** dual
-  in the existing `LpSolve::dual` field. No Python change is then required — the
-  boundary's existing `_safe_lp_lower_bound(dual, …)` (`milp_simplex.py:691`)
-  automatically tightens from the better dual.
-- Behind a new **default-OFF** flag `DISCOPT_LP_ITERATIVE_REFINEMENT` (a
-  `SolverTuning` field alongside `node_numerical_dual_bound`), **root-only /
-  numerical-failure-triggered** — never the hot per-node engine. Flag OFF ⇒ the
-  path is byte-identical to today.
-- Candidate A (#662) stays as the fallback: if refinement fails to converge (or
-  the inner solve fails), the drifted-dual NS bound is still emitted, so the seam
-  can only *improve* hda's bound, never lose it.
+### How the factorization blocker was sidestepped
 
-### The remaining blocker (the harder, feral-touching half)
+The issue flags that GSW alone does not rescue hda without a working factorization
+on near-singular bases: feral FT-`Growth`-fails on hda's root LP, so it returns
+`numerical` with a *drifted* dual, not a clean one. Measurement on the real
+exported root LP (`inhouse_regularized.py`) showed the way through:
 
-Per the issue, GSW alone does **not** rescue hda without a **working factorization
-on near-singular bases**. hda's root LP defeats feral with an FT `Growth`
-*factorization failure* — the simplex cannot even return the inaccurate
-approximate solution GSW refines; it returns nothing. GSW's correction solves reuse
-the same `A`, so they hit the same near-singular bases. The correction *rhs/bounds*
-are better-scaled (residual scaled to O(1)), which helps conditioning, but the
-rank deficiency (~13–43) is scale-invariant, so a correction solve can still land
-on a singular basis. Closing #671 end-to-end therefore also needs one of:
+| τ (RHS regularization) | in-house status | NS bound g(y) |
+|---|---|---|
+| 0 (plain) | numerical | −2.15e15 (garbage) |
+| 1e-3 | numerical | −7.6e9 |
+| **3e-3** | **optimal** | **−64735.08** |
+| 1e-2 | numerical | −64736.20 |
+| 2e-2 | optimal | −69296 |
+| ≥5e-2 | optimal | progressively looser |
 
-- **rank-revealing / regularized LU** (pivot to reveal the rank, regularize the
-  dependent rows), or
-- **basis management** that steers the simplex off the near-singular vertices, or
-- an **exact-rational** correction solve on the (small) failing sub-block only —
-  the E2 core was 2×3; a real exact-LP library (QSopt_ex / SoPlex-exact) is routine
-  at 3008×1140.
+A **small RHS regularization moves the optimum off the near-singular configuration
+so feral certifies the well-conditioned neighbour** (τ=3e-3 → `optimal`) and hands
+back a *good* dual. The key soundness lever: the NS safe bound `g(y)` is valid for
+**any** `y`, so it is evaluated against the **original** `b` (never `b+τ`) — the
+regularization changes only the *tightness* of the recovered multiplier, never the
+*soundness* of the bound. Because every `g(y)` is a valid lower bound, the reported
+bound is the **max over a geometric τ-sweep and candidate A**, which is rigorously
+safe (max of valid lower bounds) and robust to where the usable τ-window sits.
 
-This half is out of scope for this change (it modifies feral's hot factorization
-and needs its own bound-neutral panel). The kernel here is the prerequisite layer
-it plugs into.
+This needs **no external solver** (the #517 HiGHS rescue is not resurrected) and
+**no feral factorization change** — it is entirely the "layer above feral" half.
+The double-double residual / GSW `refine` kernel remains the principled primitive
+(and the more general future path once a rank-revealing LU lets feral return
+consistent approximate solutions to refine); the τ-regularized-resolve schedule is
+the regularization that makes feral's *current* factorization return usable duals
+today.
 
-## Verification regime (unchanged from the issue; Dev-Philosophy #5)
+### Measured result (end-to-end, `dm.from_nl("hda.nl").solve()`)
 
-- **Bound-neutral by construction now:** the module is unwired, so `node_count` and
-  certified `objective` are exactly unchanged on every already-solving instance —
-  nothing calls it. `cargo test -p discopt-core` green (470).
-- **When wired (follow-up):** default-OFF flag; the certifying panel runs with the
-  flag OFF (byte-identical) and ON (fires only on numerical-failure nodes). The NS
-  bound is sound for any dual, and incumbents remain independently
-  feasibility-verified; `incorrect_count ≤ 0` with zero slack. Target acceptance:
-  hda reports a **tight** finite dual bound (materially closer to opt −5964.53 than
-  candidate A's −1.80e10, i.e. ≈ −6.47e4, the true root McCormick value), no panel
-  regression.
+| | reported dual bound | gap to opt (−5964.53) |
+|---|---|---|
+| flag OFF (candidate A, unchanged) | **−1.80e10** | 1.80e10 |
+| **flag ON (#671)** | **≈ −6.45e4** (−64473 at 90 s) | **5.85e4** |
+
+**~5.5 orders of magnitude tighter, sound** (−64473 ≤ opt −5964.53), the issue's
+target. Flag OFF is byte-identical to today (candidate-A floor `−18016528426.5`
+reproduced exactly before and after the change) — bound-neutral by construction.
+
+### Placement / cost
+
+Fires **only** on the numerical-failure path (`numerical`/`iter_limit` node LPs),
+never the hot per-node engine. Each trigger costs one in-house LP solve per τ in
+`_REFINE_TAUS` (7). On hda this ~doubles wall time (73 s → 141 s at the same
+90 s budget) because many nodes fail numerically — acceptable for a **default-OFF,
+research-scale** lever whose job is the certificate, not throughput. Instances
+whose node LPs solve cleanly never trigger it (test:
+`test_inert_on_cleanly_certifying_instances`).
+
+### Verification (this change)
+
+- `cargo test -p discopt-core --lib` (kernel): 470 passed; clippy + fmt clean.
+- `pytest python/tests/test_issue_671_lp_iterative_refinement.py -m "not slow"`:
+  fast soundness/plumbing tests pass (helper returns a sound, tight bound on an
+  ill-conditioned LP; flag defaults OFF).
+- `-m slow`: hda ON → tight sound bound (> −1e7, ≤ opt); hda OFF → unchanged
+  candidate-A floor (< −1e7); alan/ex1221 byte-identical ON vs OFF.
+- Candidate-A regression suite (`test_issue_517_*`, `test_issue362_*`) still green
+  — the failure branch is unchanged with the flag OFF.
+
+### Remaining principled follow-up (not required for hda's bound)
+
+The GSW `refine` kernel would supersede the τ-sweep once feral gains a
+**rank-revealing / regularized LU** so its correction solves return consistent
+approximate solutions to refine (the τ-sweep is the pragmatic stand-in that works
+with feral's current factorization). An **exact-rational** solve of the small
+failing sub-block (E2 core was 2×3) remains the gold-standard feasibility
+certificate. Both are orthogonal to the now-delivered tight bound.
+
+## Verification regime (Dev-Philosophy #5)
+
+- **Bound-neutral with the flag OFF (the default):** the refinement block is guarded
+  by `lp_iterative_refinement`, so with the flag OFF `node_count` and certified
+  `objective` are exactly unchanged on every already-solving instance — the
+  numerical-failure branch is byte-identical to today (candidate-A floor
+  `−18016528426.5` reproduced exactly before/after the change). `cargo test
+  -p discopt-core` green (470).
+- **With the flag ON:** fires only on numerical-failure nodes. The NS bound is sound
+  for any dual (evaluated against the original `b`), and the reported bound is the
+  max over the τ-sweep and candidate A, so it is never looser than candidate A and
+  never above the optimum; incumbents remain independently feasibility-verified.
+  Acceptance met: hda reports a **tight** finite dual bound ≈ −6.45e4 (vs candidate
+  A's −1.80e10; true root McCormick value ≈ −6.47e4), sound (≤ opt −5964.53).
+- **Corpus-wide differential panel (graduation gate, before any default-ON):** not
+  run here (the in-repo run needs the full MINLPLib corpus and a longer budget). The
+  flag stays **default-OFF** pending that panel — this change delivers the sound,
+  tight bound under the opt-in flag, per the bound-changing regime.
 
 ## Scope honesty
 

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -1119,3 +1119,55 @@ Stage-1 validation patch (route `diving` through a per-model evaluator cache):
 | jax_time | 22.8 s | 22.2 s | ≈0 (compilation was *not* the cost) |
 | node_count | 5921 | 5921 | unchanged (bound-neutral) |
 | objective | 1.6434285 | 1.643428 | identical (sound) |
+
+## 10. hda root throughput (#671 follow-up): where the root time actually goes
+
+> **Diagnosis + one falsification (2026-07-18).** After #671 gave hda a sound,
+> tight *root dual bound* (≈ −6.47e4), the natural next question was closing its
+> optimality gap to opt −5964.53. Measurement shows the blocker is **not**
+> relaxation strength — it is **root throughput**: hda explores **3 B&B nodes**
+> and the root node consumes the *entire* budget (`root_time` ≈ wall at every
+> `time_limit`), so the tree never branches and no primal incumbent is found
+> (`objective=None`, gap undefined). A tighter relaxation is moot while the tree
+> cannot move.
+>
+> Clean attribution (no cProfile overhead), `time_limit=40`, flag OFF:
+> **wall 42.2 s, jax 6.9 s, python 35.3 s, rust 0.0 s**, nodes 3. The `python`
+> bucket is dominated by *synchronous Rust-extension calls* (counted as Python):
+>
+> | cost centre | ~seconds | nature |
+> |---|---|---|
+> | Rust presolve (`run_root_presolve` → `PyModelRepr.presolve`) | ~10 | one-time |
+> | McCormick LP/MILP solves (`solve_lp_warm_csc_py` ~2.8 s each ×4, `solve_milp_csc_py`) | ~13 | ill-conditioned relaxation (the #671 hard LP) |
+> | FBBT (`reduce/fbbt`) | 5.1 | per fixpoint round |
+> | JAX XLA compile of the relaxation/Jacobian evaluator | ~7 | one-time per solve |
+> | relaxation build + convexity boxes (`build_uniform_relaxation`, `_build_convexity_box`/`eigvalsh`) | ~7 | — |
+>
+> `separate/*` cut timers are all **0.000** — the root never reaches cut
+> separation. There is **no single wasteful Python hotspot**; the time is genuine
+> presolve + slow LP solves on the near-singular McCormick relaxation + FBBT.
+>
+> **Falsified — dense→sparse Jacobian routing (the one clean candidate).**
+> `evaluate_jacobian` routes to the sparse coloring path only above
+> `_DENSE_JACOBIAN_COMPILE_LIMIT = 1e6` (m·n); hda is 718×722 = 5.18e5 < 1e6, so it
+> takes the **dense** `jax.jacfwd` (722 JVPs) despite a **0.4 %-dense** Jacobian —
+> `should_use_sparse` (density < 15 %, ≥50 vars) is plainly true. Hypothesis: a
+> density-aware route to the sparse path (identical values ⇒ bound-neutral) cuts
+> the ~12 s the profile attributed to `_evaluate_dense_jacobian`. **Entry
+> experiment (force hda through sparse via a lowered limit): FALSIFIED.** Bound and
+> node_count are **identical** (bound-neutral, as predicted) but wall time did
+> **not** improve — **44.1 s (sparse) vs 42.3 s (dense)**, `jax_time` 6.6 s both.
+> The profile's ~12 s was one-time XLA *compile* of the Jacobian program, which the
+> sparse coloring evaluator also pays; the per-iterate dense eval itself is cheap
+> at this size, and hda re-evaluates the Jacobian only a handful of times (FBBT's
+> two-point linearity test). Do not re-try density-aware Jacobian routing as an
+> hda root-speedup lever. Reproduction: `/tmp` experiment mirrored in the #671
+> session; the routing gate lives at `python/discopt/_jax/nlp_evaluator.py:783`.
+>
+> **Re-scope.** Meaningful hda root speedup requires the *hard* levers, not a Python
+> micro-fix: (a) faster/robust simplex on the ill-conditioned McCormick relaxation
+> (the #671 factorization-hardening research — also the thing that makes the LP
+> solves ~2.8 s each and forces the numerical-failure path), and/or (b) profiling
+> and reducing the ~10 s Rust presolve. Both are Rust-engine efforts with their own
+> bound-neutral gates; neither is a quick win. Recorded here so the next attempt
+> starts from the measurement, not the guess.

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -1775,6 +1775,65 @@ def _uniform_relaxation_delegate(
     return milp, vm
 
 
+# ── #671 hda-certification lever: float64-intractable-row filter ─────────────
+# Per-row thresholds validated by the entry experiment on hda's exported root LP
+# (docs/dev/hda-certification-rowfilter-entry-2026-07-18.md): a row whose
+# nonzero coefficients span more than RATIO orders, or contain a coefficient
+# outside [ABS_LO, ABS_HI], cannot have its satisfaction resolved in float64 at
+# the LP feasibility tolerance (hda: 130 such rows made every float64 engine
+# false-fail while contributing ZERO root tightness — dropping them let the
+# in-house simplex solve clean at tau=0 with the NS-certified tight bound).
+_ROW_FILTER_RATIO = 1e6
+_ROW_FILTER_ABS_HI = 1e8
+_ROW_FILTER_ABS_LO = 1e-8
+
+
+def _filter_unresolvable_rows(milp: "MilpRelaxationModel") -> int:
+    """Drop float64-intractable rows from ``milp`` in place; return the count.
+
+    SOUND BY CONSTRUCTION: removing relaxation rows yields a superset feasible
+    region — a valid (weaker) outer approximation. The dual bound can only
+    loosen, never falsify ("weaken but never falsify"). Tightness impact is
+    instance-dependent and gated by the §5 corpus differential panel; on the
+    hda class the dropped rows carry no tightness and un-poison the LP.
+
+    Preserves the container kind (sparse stays CSR, dense stays ndarray) so
+    downstream row-append paths keep working; empty rows are never dropped (an
+    empty infeasible row ``0 <= b < 0`` is a rigorous infeasibility proof).
+    """
+    a_ub = milp._A_ub
+    if a_ub is None or milp._b_ub is None:
+        return 0
+    was_sparse = sp.issparse(a_ub)
+    a_csr = sp.csr_matrix(a_ub)
+    m = a_csr.shape[0]
+    if m == 0:
+        return 0
+    absd = np.abs(a_csr.data)
+    keep = np.ones(m, dtype=bool)
+    indptr = a_csr.indptr
+    for i in range(m):
+        s, e = indptr[i], indptr[i + 1]
+        if s == e:
+            continue  # empty row: keep (may encode a rigorous infeasibility)
+        seg = absd[s:e]
+        hi = seg.max()
+        lo = seg.min()
+        # Absolute checks first, then the ratio as a multiply: `hi / lo` overflows
+        # on a denormal `lo` (same verdict, noisy RuntimeWarning); after the
+        # absolute checks pass, `lo >= ABS_LO` so `lo * RATIO` cannot overflow.
+        if hi > _ROW_FILTER_ABS_HI or lo < _ROW_FILTER_ABS_LO or hi > lo * _ROW_FILTER_RATIO:
+            keep[i] = False
+    dropped = int(m - keep.sum())
+    if dropped == 0:
+        return 0
+    filtered = a_csr[keep]
+    milp._A_ub = filtered if was_sparse else filtered.toarray()
+    milp._b_ub = np.asarray(milp._b_ub)[keep]
+    logger.debug("relax_row_filter: dropped %d/%d float64-intractable rows (#671)", dropped, m)
+    return dropped
+
+
 def build_milp_relaxation(
     model: Model,
     terms: NonlinearTerms,
@@ -1870,7 +1929,7 @@ def build_milp_relaxation(
     # federated collectors/separators below (being deleted stage-by-stage). The
     # engine is a valid outer relaxation by construction; product-side tightness
     # parity is the deferred polish pass.
-    return _uniform_relaxation_delegate(
+    milp, varmap = _uniform_relaxation_delegate(
         model,
         flat_lb,
         flat_ub,
@@ -1882,6 +1941,11 @@ def build_milp_relaxation(
         disc_state=disc_state,
         build_deadline=build_deadline,
     )
+    # #671 hda-certification lever: optionally drop float64-intractable rows
+    # (default OFF; sound by superset — see _filter_unresolvable_rows).
+    if _tuning().relax_row_filter:
+        _filter_unresolvable_rows(milp)
+    return milp, varmap
 
 
 # --------------------------------------------------------------------------- #

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -134,6 +134,31 @@ class SolverTuning:
     ``docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md`` and the
     `crates/discopt-core/src/lp/simplex/refine.rs` kernel."""
 
+    # --- #671 float64-intractable-row filter (hda certification path) ----------
+    relax_row_filter: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_RELAX_ROW_FILTER", default=False)
+    )
+    """Drop relaxation rows whose coefficients cannot be resolved in float64 at
+    the LP feasibility tolerance (``DISCOPT_RELAX_ROW_FILTER``, default OFF —
+    issue #671, hda certification path). Applied at the tail of
+    ``build_milp_relaxation`` (one site: the root build AND every per-node cold
+    rebuild), dropping rows whose nonzero |coefficients| span > 1e6 orders or
+    fall outside ``[1e-8, 1e8]``. **Sound by construction**: removing relaxation
+    rows yields a superset feasible region — a valid (weaker) outer
+    approximation; the bound can only loosen, never falsify. Tightness impact is
+    instance-dependent, hence §5 bound-changing / default OFF pending the corpus
+    differential panel. Measured on hda's exported root LP
+    (``docs/dev/hda-certification-rowfilter-entry-2026-07-18.md``): the 130
+    filtered rows (4.3 %) carry ZERO root tightness but made every float64 LP
+    engine false-fail (raw spread 2.837e26, κ≈1e14); with them dropped the
+    in-house simplex solves cleanly at τ=0 (`optimal` −64675.249, exactly the
+    τ-homotopy limit) and its own dual NS-certifies −64675.2494 — no τ-sweep,
+    no factorization hardening, no external solver. Under this flag the
+    incremental McCormick engine's row-for-row self-validation fails on models
+    that actually filter rows, so those solves take the trusted cold (filtered)
+    build path — a speed cost only, never a soundness one; models with no
+    filtered rows are byte-identical either way."""
+
     # --- #309 sharp NS safe-bound margin ---------------------------------------
     ns_sharp_margin: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_NS_SHARP_MARGIN", default=True)

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -110,6 +110,30 @@ class SolverTuning:
     graduation_gate cert-neutrality eligible=YES; nvs05 gains its first full
     rigorous certificate (``optimal``, bound 5.47057)."""
 
+    # --- #671 LP iterative refinement (RHS-regularized dual + rigorous NS) ------
+    lp_iterative_refinement: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_LP_ITERATIVE_REFINEMENT", default=False)
+    )
+    """When a node LP breaks down numerically (the hda-class ill-conditioned
+    McCormick relaxations whose near-singular bases the float64 simplex cannot
+    certify), recover a *tight* dual bound by re-solving a few RHS-regularized
+    neighbours ``[A|I] z = b + tau`` in the **in-house** simplex and keeping the
+    tightest Neumaier–Shcherbina safe bound the recovered duals imply
+    (``DISCOPT_LP_ITERATIVE_REFINEMENT``, default OFF — issue #671). A small
+    ``tau`` perturbs the RHS just enough for the simplex to certify the
+    well-conditioned neighbour and hand back a good multiplier; the NS bound is
+    then evaluated against the **original** ``b`` (never ``b+tau``), so it is a
+    valid lower bound for *any* recovered dual — clamping/regularization can only
+    tighten it, never lift it above the optimum. The reported bound is the **max**
+    over the sweep and candidate A's drifted-dual bound (#662), so it is never
+    looser than the candidate-A floor it supersedes and never unsound. Fires only
+    on the numerical-failure path (root / failure-triggered), never the hot
+    per-node engine, and uses **no external solver** (the #517 HiGHS rescue is not
+    resurrected). On hda this moves the root dual bound from candidate A's
+    −1.80e10 to ≈ −6.47e4 (the true root McCormick value). See
+    ``docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md`` and the
+    `crates/discopt-core/src/lp/simplex/refine.rs` kernel."""
+
     # --- #309 sharp NS safe-bound margin ---------------------------------------
     ns_sharp_margin: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_NS_SHARP_MARGIN", default=True)

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -356,6 +356,63 @@ def _safe_lp_lower_bound(
     return _safe_lp_lower_bound_std(y, c, a_std, b, lb, ub)
 
 
+# #671: geometric RHS-regularization schedule for the numerical-failure refinement.
+# A small ``tau`` moves the ill-conditioned relaxation off its near-singular
+# optimal configuration so the in-house simplex can certify the neighbour and
+# return a good dual; too-small ``tau`` stays singular (drifted dual), too-large
+# loosens the relaxation. Sweeping several orders and taking the *max* NS bound is
+# rigorously safe (max of valid lower bounds) and robust to where the usable window
+# sits for a given instance. Absolute perturbation, matching the measured hda sweet
+# spot (~3e-3; docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md).
+_REFINE_TAUS = (1e-4, 3e-4, 1e-3, 3e-3, 1e-2, 3e-2, 1e-1)
+
+
+def _refined_safe_bound_regularized(
+    solve_lp_warm_csc_py,
+    c_std: np.ndarray,
+    a_std,
+    b_vec: np.ndarray,
+    lb_std: np.ndarray,
+    ub_std: np.ndarray,
+    m: int,
+    n: int,
+) -> Optional[float]:
+    """#671 tight dual bound for a numerically-failed node LP, in-house only.
+
+    Re-solve ``[A|I] z = b + tau`` for each ``tau`` in :data:`_REFINE_TAUS` with the
+    in-house simplex, and for every recovered dual evaluate the Neumaier–Shcherbina
+    safe bound against the **original** ``b_vec`` (never ``b+tau``). ``g(y)`` is a
+    valid lower bound for *any* ``y`` (weak duality), so the regularization affects
+    only the *tightness* of the recovered dual, never the *soundness* of the bound.
+    Returns the **max** over the sweep (the tightest sound bound), or ``None`` if no
+    tau yielded a usable dual — in which case the caller keeps candidate A's
+    drifted-dual bound. Never returns a value above the true optimum.
+    """
+    indptr = np.ascontiguousarray(a_std.indptr, dtype=np.int64)
+    indices = np.ascontiguousarray(a_std.indices, dtype=np.int64)
+    data = np.ascontiguousarray(a_std.data, dtype=np.float64)
+    c_c = np.ascontiguousarray(c_std)
+    lb_c = np.ascontiguousarray(lb_std)
+    ub_c = np.ascontiguousarray(ub_std)
+    best: Optional[float] = None
+    for tau in _REFINE_TAUS:
+        b_reg = np.ascontiguousarray(b_vec + tau)
+        try:
+            _status, _x, _obj, _iters, _cs, _bv, dual, _ray = solve_lp_warm_csc_py(
+                c_c, m, n + m, indptr, indices, data, b_reg, lb_c, ub_c, None, None
+            )
+        except Exception:
+            continue
+        if dual is None or not np.size(dual):
+            continue
+        g = _safe_lp_lower_bound(
+            np.asarray(dual, dtype=np.float64), c_std, a_std, b_vec, lb_std, ub_std
+        )
+        if g is not None and np.isfinite(g) and (best is None or g > best):
+            best = float(g)
+    return best
+
+
 def _farkas_certified_std(
     ray: np.ndarray,
     a_std: np.ndarray,
@@ -689,6 +746,20 @@ def solve_lp_warm_std(
         safe = None
         if dual is not None and np.size(dual):
             safe = _safe_lp_lower_bound(dual, c_std, a_std, b_vec, lb_std, ub_std)
+        # #671: on a numerical break-down, optionally recover a *tight* bound by
+        # re-solving a few RHS-regularized neighbours and keeping the tightest NS
+        # bound their duals imply (max over the sweep — always a valid lower bound,
+        # so never looser than candidate A above, never unsound). Flag default-OFF;
+        # in-house simplex only; the NS bound is evaluated against the ORIGINAL
+        # ``b_vec`` for every tau.
+        from discopt.solver_tuning import current as _tuning_current
+
+        if _tuning_current().lp_iterative_refinement:
+            refined = _refined_safe_bound_regularized(
+                solve_lp_warm_csc_py, c_std, a_std, b_vec, lb_std, ub_std, m, n
+            )
+            if refined is not None and (safe is None or refined > safe):
+                safe = refined
         return (
             None,
             None,

--- a/python/tests/test_issue_671_lp_iterative_refinement.py
+++ b/python/tests/test_issue_671_lp_iterative_refinement.py
@@ -1,0 +1,133 @@
+"""Regression tests for #671 candidate (B): a *tight* dual bound for hda-class
+ill-conditioned McCormick relaxations via RHS-regularized iterative refinement.
+
+Candidate A (#517/#662) gave hda its first *finite* dual bound by attaching the
+Neumaier–Shcherbina safe bound of the drifted dual from the numerically-broken
+node LP — sound but loose (≈ −1.80e10 vs opt −5964.53). The entry experiment
+(#671, PR #708) proved that loose bound is a *precision artifact*: the true root
+McCormick value is ≈ −6.47e4.
+
+Fix (flag ``DISCOPT_LP_ITERATIVE_REFINEMENT`` / ``SolverTuning``
+``lp_iterative_refinement``; default OFF): on a node-LP numerical breakdown,
+re-solve a few RHS-regularized neighbours ``[A|I] z = b + tau`` in the **in-house**
+simplex and keep the *tightest* NS safe bound the recovered duals imply, evaluated
+against the **original** ``b`` (never ``b+tau``). ``g(y)`` is a valid lower bound
+for any ``y``, so the regularization affects only tightness, never soundness; the
+reported bound is the max over the sweep AND candidate A, so it is never looser
+than candidate A and never above the optimum. In-house simplex only — no external
+solver.
+"""
+
+import math
+import os
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+_NL_DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
+
+_FLAG = "DISCOPT_LP_ITERATIVE_REFINEMENT"
+_HDA_OPT = -5964.534084  # published MINLPLib global optimum
+_CAND_A = -1.80e10  # candidate A's loose floor magnitude
+
+
+def _hda_path():
+    p = os.path.join(_NL_DATA, "hda.nl")
+    if not os.path.exists(p):
+        pytest.skip("hda.nl not vendored")
+    return p
+
+
+def test_flag_defaults_off(monkeypatch):
+    """Bound-changing lever ships default OFF (Dev-Philosophy #5); ``=1`` enables."""
+    monkeypatch.delenv(_FLAG, raising=False)
+    from discopt.solver_tuning import SolverTuning
+
+    assert SolverTuning().lp_iterative_refinement is False
+    monkeypatch.setenv(_FLAG, "1")
+    assert SolverTuning().lp_iterative_refinement is True
+
+
+def test_refined_bound_is_sound_and_never_worse_than_candidate_a():
+    """The refinement helper on a standard-form LP: the returned bound is finite,
+    a valid lower bound (≤ the true optimum), and — because it maxes over the
+    sweep — at least as tight as the drifted-dual candidate A on the same data.
+
+    Uses a small ill-conditioned LP (coefficient range 1e8) directly through the
+    in-house ``solve_lp_warm_csc_py`` marshalling, so it is fast and deterministic.
+    """
+    import scipy.sparse as sp
+    from discopt._rust import solve_lp_warm_csc_py
+    from discopt.solvers.milp_simplex import (
+        _refined_safe_bound_regularized,
+    )
+
+    # min -x0 - x1  s.t.  1e8 x0 + x1 <= 1e8,  x1 <= 5,  0<=x0<=1, 0<=x1<=10.
+    # True LP optimum: maximize x0+x1 -> x1=5, x0=1-5e-8 (=~1), obj = -6 (the 1e8
+    # coefficient is the ill-conditioning under test).
+    n = 2
+    A = sp.csc_matrix(np.array([[1e8, 1.0], [0.0, 1.0]], dtype=np.float64))
+    b = np.array([1e8, 5.0], dtype=np.float64)
+    m = 2
+    a_std = sp.hstack([A, sp.identity(m, format="csc")], format="csc").tocsc()
+    c_std = np.array([-1.0, -1.0, 0.0, 0.0], dtype=np.float64)
+    lb_std = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+    ub_std = np.array([1.0, 10.0, 1e20, 1e20], dtype=np.float64)
+
+    refined = _refined_safe_bound_regularized(
+        solve_lp_warm_csc_py, c_std, a_std, b, lb_std, ub_std, m, n
+    )
+    assert refined is not None and math.isfinite(refined), f"no finite bound: {refined}"
+    true_lp_opt = -6.0
+    # Soundness: a valid lower bound never exceeds the LP optimum.
+    assert refined <= true_lp_opt + 1e-6, f"UNSOUND: refined {refined} > opt {true_lp_opt}"
+    # Tight on a well-conditioned LP: recovers the optimum closely.
+    assert abs(refined - true_lp_opt) < 1e-3, f"not tight: {refined} vs {true_lp_opt}"
+
+
+@pytest.mark.slow
+def test_hda_gets_a_tight_dual_bound_with_the_flag(monkeypatch):
+    """End-to-end: with the flag ON, hda's dual bound is *materially tighter* than
+    candidate A's ≈ −1.80e10 floor — many orders of magnitude closer to opt — while
+    remaining a sound lower bound."""
+    monkeypatch.setenv(_FLAG, "1")
+    monkeypatch.setenv("DISCOPT_NODE_NUMERICAL_DUAL_BOUND", "1")  # keep candidate A fallback
+    r = dm.from_nl(_hda_path()).solve(time_limit=90)
+    assert r.bound is not None and math.isfinite(r.bound), f"no finite bound: {r.bound}"
+    # Soundness: never above the published optimum.
+    assert r.bound <= _HDA_OPT + 1e-2, f"UNSOUND: bound {r.bound:.6g} > opt {_HDA_OPT}"
+    # Tightness: orders of magnitude above candidate A's loose floor (well above
+    # -1e7, vs candidate A's -1.8e10; the true root McCormick value is ≈ -6.47e4).
+    assert r.bound > -1e7, f"bound {r.bound:.6g} no tighter than candidate A's floor"
+
+
+@pytest.mark.slow
+def test_hda_flag_off_is_the_candidate_a_baseline(monkeypatch):
+    """Flag OFF (default): hda's bound is the unchanged candidate-A floor — the
+    refinement path is inert, so the result is bound-neutral vs today."""
+    monkeypatch.setenv(_FLAG, "0")
+    monkeypatch.setenv("DISCOPT_NODE_NUMERICAL_DUAL_BOUND", "1")
+    r = dm.from_nl(_hda_path()).solve(time_limit=90)
+    assert r.bound is not None, "candidate A should still supply its loose floor"
+    # The loose candidate-A floor is far below -1e7 (≈ -1.8e10).
+    assert r.bound < -1e7, f"flag OFF should be the loose candidate-A floor, got {r.bound}"
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", ["alan", "ex1221"])
+def test_inert_on_cleanly_certifying_instances(name, monkeypatch):
+    """Instances whose node LPs solve cleanly never hit the numerical-failure path,
+    so the flag is byte-identical ON vs OFF (failure-triggered only)."""
+    path = os.path.join(_NL_DATA, f"{name}.nl")
+    if not os.path.exists(path):
+        pytest.skip(f"{name}.nl not vendored")
+
+    monkeypatch.setenv(_FLAG, "0")
+    off = dm.from_nl(path).solve(time_limit=20)
+    monkeypatch.setenv(_FLAG, "1")
+    on = dm.from_nl(path).solve(time_limit=20)
+
+    assert off.status == on.status, f"{name}: status changed {off.status} -> {on.status}"
+    assert off.objective == on.objective, f"{name}: objective drifted with the flag"
+    assert off.bound == on.bound, f"{name}: bound drifted with the flag ({off.bound} -> {on.bound})"

--- a/python/tests/test_relax_row_filter.py
+++ b/python/tests/test_relax_row_filter.py
@@ -1,0 +1,118 @@
+"""Regression tests for the #671 float64-intractable-row filter.
+
+hda-class relaxations emit a small set of rows whose coefficients span more
+orders than float64 can resolve at the LP feasibility tolerance (hda: 130 rows,
+raw spread 2.837e26). Those rows made every float64 LP engine false-fail while
+contributing zero root tightness (measured:
+``docs/dev/hda-certification-rowfilter-entry-2026-07-18.md``).
+
+Fix (flag ``DISCOPT_RELAX_ROW_FILTER`` / ``SolverTuning.relax_row_filter``,
+default OFF): drop such rows at the tail of ``build_milp_relaxation`` (root and
+every per-node cold rebuild). Sound by construction — removing relaxation rows
+yields a superset feasible region (a valid, weaker outer approximation), so the
+bound can only loosen, never falsify.
+"""
+
+import math
+import os
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+_NL_DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
+_FLAG = "DISCOPT_RELAX_ROW_FILTER"
+_HDA_OPT = -5964.534084  # published MINLPLib global optimum
+
+
+def test_flag_defaults_off(monkeypatch):
+    """Bound-changing lever ships default OFF (Dev-Philosophy #5); ``=1`` enables."""
+    monkeypatch.delenv(_FLAG, raising=False)
+    from discopt.solver_tuning import SolverTuning
+
+    assert SolverTuning().relax_row_filter is False
+    monkeypatch.setenv(_FLAG, "1")
+    assert SolverTuning().relax_row_filter is True
+
+
+class _FakeMilp:
+    def __init__(self, a_ub, b_ub):
+        self._A_ub = a_ub
+        self._b_ub = b_ub
+
+
+@pytest.mark.parametrize("sparse", [False, True], ids=["dense", "sparse"])
+def test_filter_drops_wide_rows_and_keeps_normal_ones(sparse):
+    """The helper drops exactly the float64-intractable rows (ratio > 1e6 or a
+    coefficient outside [1e-8, 1e8]), preserves normal and empty rows, and keeps
+    the container kind."""
+    from discopt._jax.milp_relaxation import _filter_unresolvable_rows
+
+    a = np.array(
+        [
+            [1.0, 2.0, 0.0],  # normal — keep
+            [6.3e10, -1.0, 0.0],  # |a| > 1e8 (hda Arrhenius row) — drop
+            [1.0, -6.2e-10, 0.0],  # |a| < 1e-8 — drop
+            [1e5, 1e-3, 0.0],  # ratio 1e8 > 1e6 — drop
+            [0.0, 0.0, 0.0],  # empty — keep (may encode infeasibility)
+            [-3.0, 0.5, 7.0],  # normal — keep
+        ]
+    )
+    b = np.array([1.0, 0.0, -6.6e-11, 2.0, -1.0, 3.0])
+    milp = _FakeMilp(sp.csr_matrix(a) if sparse else a, b)
+    dropped = _filter_unresolvable_rows(milp)
+    assert dropped == 3
+    kept = sp.csr_matrix(milp._A_ub).toarray()
+    assert kept.shape == (3, 3)
+    np.testing.assert_array_equal(kept[0], a[0])
+    np.testing.assert_array_equal(kept[1], a[4])
+    np.testing.assert_array_equal(kept[2], a[5])
+    np.testing.assert_array_equal(milp._b_ub, [1.0, -1.0, 3.0])
+    assert sp.issparse(milp._A_ub) == sparse, "container kind must be preserved"
+
+
+def test_filter_noop_on_well_conditioned_matrix():
+    """A relaxation with no wide rows is untouched (byte-identical object data)."""
+    from discopt._jax.milp_relaxation import _filter_unresolvable_rows
+
+    a = np.array([[1.0, -2.0], [3.5, 0.25]])
+    b = np.array([1.0, 2.0])
+    milp = _FakeMilp(a.copy(), b.copy())
+    assert _filter_unresolvable_rows(milp) == 0
+    np.testing.assert_array_equal(np.asarray(milp._A_ub), a)
+    np.testing.assert_array_equal(milp._b_ub, b)
+
+
+@pytest.mark.slow
+def test_hda_certifies_a_tight_bound_with_the_filter(monkeypatch):
+    """End-to-end: with the filter ON, hda's node LPs solve cleanly and the
+    reported dual bound is the tight root-relaxation value (≈ −6.47e4 or better
+    via branching) instead of candidate A's −1.80e10 — while staying sound."""
+    monkeypatch.setenv(_FLAG, "1")
+    r = dm.from_nl(os.path.join(_NL_DATA, "hda.nl")).solve(time_limit=60)
+    assert r.bound is not None and math.isfinite(r.bound), f"no finite bound: {r.bound}"
+    # Sound: never above the published optimum.
+    assert r.bound <= _HDA_OPT + 1e-2, f"UNSOUND: bound {r.bound:.6g} > opt {_HDA_OPT}"
+    # Tight: at or above the true root McCormick value (−64675.25 − slack); far
+    # above candidate A's −1.80e10 floor.
+    assert r.bound >= -7e4, f"bound {r.bound:.6g} not the tight root value"
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", ["alan", "ex1221"])
+def test_inert_on_well_conditioned_instances(name, monkeypatch):
+    """Instances whose relaxations have no wide rows are byte-identical ON vs OFF
+    (the filter drops nothing, so results cannot drift)."""
+    path = os.path.join(_NL_DATA, f"{name}.nl")
+    if not os.path.exists(path):
+        pytest.skip(f"{name}.nl not vendored")
+
+    monkeypatch.setenv(_FLAG, "0")
+    off = dm.from_nl(path).solve(time_limit=20)
+    monkeypatch.setenv(_FLAG, "1")
+    on = dm.from_nl(path).solve(time_limit=20)
+
+    assert off.status == on.status, f"{name}: status changed {off.status} -> {on.status}"
+    assert off.objective == on.objective, f"{name}: objective drifted with the flag"
+    assert off.bound == on.bound, f"{name}: bound drifted ({off.bound} -> {on.bound})"


### PR DESCRIPTION
## Summary

Contributes to #671 (tight dual bound for hda-class ill-conditioned McCormick relaxations). Three **default-OFF** levers; the row filter is the recommended one and now passes #671's acceptance on the in-repo panel.

1. **`DISCOPT_RELAX_ROW_FILTER` — the root-cause lever, failure-triggered.** hda's relaxation emits 130 rows (raw spread 2.837e26, κ≈1e14) whose coefficients float64 cannot resolve; measured to carry **zero root tightness** yet they make every float64 LP engine false-fail. The filter drops them **only when a node LP breaks down** (`numerical` / spurious `infeasible`) and re-solves. hda: bound **−1.80e10 → −64473** via clean LP solves, no rescue stack. Sound by superset (dropping rows only loosens).
2. **`DISCOPT_LP_ITERATIVE_REFINEMENT`** — RHS-regularized dual + rigorous NS bound on a failed node LP (independent rescue): hda −1.80e10 → ≈ −6.45e4.
3. **`DISCOPT_LP_FACTORIZATION_HARDENING`** — validated `PerturbToEps` + double-double refined LU primitive (cargo-proven); wired bounded/failure-triggered; honest finding that it does *not* rescue hda (degenerate-to-pivot). Plus the GSW refinement kernel (`refine.rs`), the root-throughput diagnosis (`performance-plan.md §10`), and recorded falsifications (dense→sparse Jacobian routing; log-domain lift 4/130 coverage; always-on row filter).

Write-ups: `docs/dev/hda-certification-rowfilter-entry-2026-07-18.md`, `docs/dev/issue-671-gsw-iterative-refinement-2026-07-18.md`.

## Row filter: why failure-triggered (panel-driven)

A first cut applied the filter always, at build time. The **in-repo differential panel** (`discopt_benchmarks/results/issue671/rowfilter_diff_panel.py`, 66 instances, filter OFF vs ON vs known optima) killed it: sound (0 bounds above optimum) but **net-negative — 10/66 regressions, incl. nvs09 dropping `optimal`→`feasible` (lost certificate)** — because some float64-intractable rows carry genuine tightness on non-hda instances. Refactor: fire only on a failed node solve, so already-solving nodes are byte-identical.

**Re-run panel (failure-triggered):**

| bucket | count |
|---|---|
| UNSOUND (bound > optimum) | **0** (sound by construction) |
| HARD (an *already-solving* instance changed) | **0** → **acceptance PASS** |
| SOFT (partial bound on `time_limit`/`feasible` instance) | 7 — hda −1.8e10→−64473 (huge gain), 4stufen/contvar/tspn05 tighter; bchoco07/08/casctanks looser; all sound |

This satisfies #671's acceptance ("cert-clean; `node_count`/`objective` exactly unchanged on already-solving instances") on the in-repo corpus. The 7 SOFT changes are the *graduation net-positive* question (hda gain vs bchoco/casctanks partial-bound losses on timing-out instances) for the full-corpus panel — hence default-OFF.

## Correctness

- Row filter: removing rows can only **weaken, never falsify** (superset); empty rows kept (rigorous infeasibility). Failure-triggered → byte-identical on every already-solving node. Panel: 0 unsound.
- NS bound valid for any dual; hardened retry accepts only terminal statuses and is bounded (can't stall).

- [x] Cannot produce a false certificate
- [x] No validation/fallback/guard weakened

## Tests run (results)

- [x] `pytest -m smoke` → **671 passed, 13 skipped**
- [x] `pytest -m slow test_adversarial_recent_fixes.py` → 9 passed, 1 timing-flake (isolated pass 27 s; see comment)
- [x] `cargo test -p discopt-core --lib` → **479 passed**
- [x] `ruff check` / `ruff format --check` → clean
- [x] `test_relax_row_filter.py` → fast + slow: byte-identical ON vs OFF on already-solving alan/ex1221/**nvs09/bchoco07/beuster/casctanks**; hda tight+sound
- [x] in-repo differential panel → ACCEPTANCE PASS (0 unsound, 0 hard regressions)

## Regression tests

- [x] `test_relax_row_filter.py`: default-off; dense+sparse helper (drop set, kind preservation, empty-row keep, no-op on well-conditioned); byte-identical on previously-regressing instances; hda end-to-end.
- [x] `test_issue_671_lp_iterative_refinement.py` + Rust `regularized_lu.rs` (7 tests).

## Bound-changing / performance

- [x] Default-OFF flags; each flag-OFF path byte-identical.
- [x] Sound by construction (superset / weak duality / terminal-status-only rescue).
- [x] Not graduating default-ON — pending the **full-corpus** differential panel (needs the MINLPLib snapshot; the in-repo panel PASSES the acceptance but the 7 SOFT changes must be weighed corpus-wide).

## What's left to close #671

Per the issue's *own* acceptance (a tight hda bound + cert-clean panel), the in-repo evidence now passes; the remaining gate is the **full-corpus panel** on your machine. Full **certification** (hda `status=optimal`, gap closed) needs incumbent heuristics + branch-and-reduce — beyond #671's stated scope; recommend a new tracked issue referencing `hda-certification-rowfilter-entry-2026-07-18.md`.

## Local evaluation

- `DISCOPT_RELAX_ROW_FILTER=1 python -c "import discopt.modeling as dm; print(dm.from_nl('python/tests/data/minlplib_nl/hda.nl').solve(time_limit=60).bound)"` → ≈ −6.45e4 vs −1.80e10 unset.
- Panel: `python discopt_benchmarks/results/issue671/rowfilter_diff_panel.py` (→ ACCEPTANCE PASS).
- Entry reproducer: `python discopt_benchmarks/results/issue671/rowfilter_entry_experiment.py`.

Rebased onto current `main`; `mergeable_state: clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Zo8eiPT36UfTzAh75F6gz