### PR TITLE
fix(correctness): #740 gate heuristic incumbent injections through user callbacks

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2201,6 +2201,120 @@ def _invoke_pre_import_callbacks(
                 )
 
 
+def _screen_heuristic_incumbent(
+    *,
+    model,
+    tree,
+    t_start,
+    x,
+    obj,
+    int_offsets,
+    int_sizes,
+    lazy_constraints,
+    incumbent_callback,
+    _cut_pool,
+    tree_bound_valid=True,
+) -> bool:
+    """Screen ONE incumbent candidate through the user's callback gate (#740).
+
+    ``_invoke_pre_import_callbacks`` above screens batch-evaluated relaxation
+    solutions before they are imported — but incumbents also enter the spatial
+    search through single-point side channels (warm start, feasibility pump,
+    subnlp, diving, LNS, integer-box search, the completeness guard), which
+    used to call ``tree.inject_incumbent`` directly. Any of those could
+    (re-)introduce a point the user's ``incumbent_callback`` vetoed or whose
+    ``lazy_constraints`` cuts exclude it, and the solve then reported that
+    point as ``optimal``. This is the same gate, applied to a single candidate
+    at the injection funnel.
+
+    Returns True when the candidate may be handed to ``inject_incumbent``.
+    Candidates that cannot become the incumbent anyway — not integer-feasible,
+    or not strictly better than the current incumbent (``inject_incumbent``
+    enforces strict improvement) — pass through without invoking user code:
+    the callback contract is "called when a new incumbent is about to be
+    accepted". A candidate that reaches the callbacks more than once (e.g. a
+    batch NLP solution injected here and later re-screened by the batch gate)
+    may invoke them more than once; the callbacks must therefore be safe to
+    re-invoke on the same point, which the pre-existing batch gate already
+    required across iterations.
+
+    Cuts returned by ``lazy_constraints`` are added to ``_cut_pool`` (always
+    non-None when ``lazy_constraints`` is set — see the pool setup in
+    ``solve_model``) so they tighten subsequent relaxations, exactly as on the
+    batch path.
+    """
+    from discopt._jax.cutting_planes import LinearCut
+    from discopt.callbacks import CallbackContext, cut_result_to_dense
+
+    x = np.asarray(x, dtype=np.float64)
+    if not _is_integer_feasible_solution(x, int_offsets, int_sizes):
+        return True  # cannot become an incumbent; inject_incumbent re-verifies
+
+    incumbent_info = tree.incumbent()
+    inc_obj = None
+    if incumbent_info is not None:
+        _, inc_obj = incumbent_info
+        if inc_obj >= _SENTINEL_THRESHOLD:
+            inc_obj = None
+    if inc_obj is not None and obj >= inc_obj:
+        return True  # not strictly improving; inject_incumbent rejects it
+
+    stats = tree.stats()
+
+    from discopt.modeling.core import ObjectiveSense as _ObjectiveSense
+
+    _cb_is_max = model._objective is not None and model._objective.sense == _ObjectiveSense.MAXIMIZE
+    _cb_bound = _certified_callback_bound(
+        stats.get("global_lower_bound"), tree_bound_valid, _cb_is_max
+    )
+    ctx = CallbackContext(
+        node_count=stats["total_nodes"],
+        incumbent_obj=inc_obj,
+        best_bound=_cb_bound,
+        gap=(stats.get("gap") if _cb_bound is not None else None),
+        elapsed_time=time.perf_counter() - t_start,
+        x_relaxation=x.copy(),
+        # A heuristic candidate carries no node relaxation bound; its own
+        # (internal-sense) objective is the honest value for the inspected point.
+        node_bound=float(obj),
+    )
+
+    # Only the user callback may fail softly; acting on its verdict is our code
+    # and stays OUTSIDE the swallow (INT-1, #413 — same discipline as the batch
+    # gate above).
+    if lazy_constraints is not None:
+        try:
+            cuts = lazy_constraints(ctx, model)
+        except Exception as e:
+            logger.warning("Lazy constraint callback raised an exception: %s", e)
+            cuts = None
+        if cuts:
+            # The excluded point must never be accepted even if cut insertion
+            # below fails: on an exception the injection simply never happens
+            # (the funnel returns via the raised error, not True).
+            for cut in cuts:
+                coeffs, rhs, sense = cut_result_to_dense(cut, model)
+                _cut_pool.add(LinearCut(coeffs=coeffs, rhs=rhs, sense=sense))
+            logger.info(
+                "Lazy constraint callback cut off a heuristic incumbent candidate (%d cut(s))",
+                len(cuts),
+            )
+            return False
+
+    if incumbent_callback is not None:
+        solution = _unpack_solution(model, x)
+        try:
+            accept = incumbent_callback(ctx, model, solution)
+        except Exception as e:
+            logger.warning("Incumbent callback raised an exception: %s", e)
+            accept = None
+        if accept is False:
+            logger.info("Incumbent callback rejected a heuristic incumbent candidate")
+            return False
+
+    return True
+
+
 def _unpack_solution(model: Model, x_flat: np.ndarray):
     """Convert flat solution vector to {var_name: array} dict."""
     result = {}
@@ -5998,6 +6112,35 @@ def solve_model(
         tree.set_nonconvex(True)
     _gap_certified = True
 
+    # --- #740: single funnel for every non-batch incumbent injection ---
+    # All warm-start / heuristic / completeness-guard injections on this
+    # (spatial) path MUST go through this wrapper, never
+    # ``tree.inject_incumbent`` directly: the batch import gate
+    # (``_invoke_pre_import_callbacks``) only screens batch-evaluated nodes, so
+    # a side channel injecting directly would bypass the user's
+    # ``lazy_constraints`` / ``incumbent_callback`` contract and could report a
+    # vetoed / cut-off point as the final ``optimal`` incumbent. Reads
+    # ``_gap_certified`` at call time so the surfaced ``best_bound`` honors the
+    # A1 taint gate exactly like the batch path.
+    def _inject_incumbent(x_cand, obj_cand):
+        if (lazy_constraints is not None or incumbent_callback is not None) and (
+            not _screen_heuristic_incumbent(
+                model=model,
+                tree=tree,
+                t_start=t_start,
+                x=x_cand,
+                obj=obj_cand,
+                int_offsets=int_offsets,
+                int_sizes=int_sizes,
+                lazy_constraints=lazy_constraints,
+                incumbent_callback=incumbent_callback,
+                _cut_pool=_cut_pool,
+                tree_bound_valid=_gap_certified,
+            )
+        ):
+            return False
+        return tree.inject_incumbent(x_cand, obj_cand)
+
     # --- B2-FIX (task #89): per-node taint accounting for the reported dual bound.
     # A non-rigorous sentinel fathom (a node whose local NLP merely failed and that
     # was pruned with no infeasibility proof) rightly decertifies *optimality*
@@ -6761,7 +6904,7 @@ def solve_model(
                 evaluator, initial_point, cl_list, cu_list
             )
             if ws_con_feas:
-                tree.inject_incumbent(initial_point, ws_obj)
+                _inject_incumbent(initial_point, ws_obj)
                 logger.info("Warm-start incumbent injected: obj=%.6g", ws_obj)
             else:
                 logger.info(
@@ -6820,7 +6963,7 @@ def solve_model(
                 if _ir_sn is not None and (_ir_best is None or _ir_sn[1] < _ir_best[1]):
                     _ir_best = _ir_sn
             if _ir_best is not None:
-                tree.inject_incumbent(_ir_best[0], float(_ir_best[1]))
+                _inject_incumbent(_ir_best[0], float(_ir_best[1]))
                 logger.info("integer-ratio witness incumbent injected: obj=%.6g", _ir_best[1])
         except Exception:  # pragma: no cover - defensive (never blocks the solve)
             logger.debug("integer-ratio witness injection skipped", exc_info=True)
@@ -7617,7 +7760,7 @@ def solve_model(
             # bound (local minima can exceed the global optimum).  Reset ALL
             # non-sentinel nodes to -inf so only convex relaxation bounds are
             # used.  For integer-feasible nodes, inject the NLP solution as
-            # an incumbent candidate via tree.inject_incumbent() and let the
+            # an incumbent candidate via the _inject_incumbent funnel and let the
             # Rust tree continue spatial branching on continuous variables.
             if not _model_is_convex:
                 _nlp_obj_backup = result_lbs.copy()
@@ -7632,7 +7775,7 @@ def solve_model(
                             # objective improves on the current best.
                             nlp_obj = float(_nlp_obj_backup[i])
                             if np.isfinite(nlp_obj):
-                                tree.inject_incumbent(result_sols[i].copy(), nlp_obj)
+                                _inject_incumbent(result_sols[i].copy(), nlp_obj)
                         # Reset ALL nonconvex nodes to -inf; convex bounds
                         # computed below will provide valid lower bounds.
                         result_lbs[i] = -np.inf
@@ -8057,9 +8200,7 @@ def solve_model(
                     elif not _model_is_convex:
                         if _is_integer_feasible_solution(nlp_result.x, int_offsets, int_sizes):
                             if np.isfinite(nlp_obj) and nlp_obj < _SENTINEL_THRESHOLD:
-                                tree.inject_incumbent(
-                                    np.asarray(nlp_result.x).copy(), float(nlp_obj)
-                                )
+                                _inject_incumbent(np.asarray(nlp_result.x).copy(), float(nlp_obj))
                         nlp_lb = convex_lb if convex_lb > -np.inf else -np.inf
 
                     # Guard: NaN and +inf lower bounds corrupt the Rust B&B
@@ -8532,7 +8673,7 @@ def solve_model(
                             evaluator, fp_sol, cl_list, cu_list
                         )
                         if np.isfinite(fp_obj) and fp_obj < _SENTINEL_THRESHOLD and fp_feas:
-                            tree.inject_incumbent(fp_sol, fp_obj)
+                            _inject_incumbent(fp_sol, fp_obj)
                             logger.info("Feasibility pump found incumbent: obj=%.6g", fp_obj)
                 except Exception as e:
                     logger.debug("Feasibility pump failed: %s", e)
@@ -8604,7 +8745,7 @@ def solve_model(
                                     and fp_obj2 < _SENTINEL_THRESHOLD
                                     and fp_feas2
                                 ):
-                                    tree.inject_incumbent(fp_sol2, fp_obj2)
+                                    _inject_incumbent(fp_sol2, fp_obj2)
                                     logger.info(
                                         "NLP-relaxation feasibility pump found incumbent: obj=%.6g",
                                         fp_obj2,
@@ -8653,7 +8794,7 @@ def solve_model(
                         if ils is not None:
                             _x_ils, _obj_ils = ils
                             if np.isfinite(_obj_ils) and _obj_ils < _SENTINEL_THRESHOLD:
-                                tree.inject_incumbent(_x_ils.copy(), float(_obj_ils))
+                                _inject_incumbent(_x_ils.copy(), float(_obj_ils))
                                 logger.info(
                                     "Integer local search found incumbent: obj=%.6g",
                                     _obj_ils,
@@ -8695,7 +8836,7 @@ def solve_model(
                                 evaluator, _x_dv, cl_list, cu_list
                             )
                             if np.isfinite(_obj_dv) and _obj_dv < _SENTINEL_THRESHOLD and _dv_feas:
-                                tree.inject_incumbent(np.asarray(_x_dv).copy(), _obj_dv)
+                                _inject_incumbent(np.asarray(_x_dv).copy(), _obj_dv)
                                 logger.info("Fractional diving found incumbent: obj=%.6g", _obj_dv)
                     except Exception as e:
                         logger.debug("Fractional diving failed: %s", e)
@@ -8750,7 +8891,7 @@ def solve_model(
                             evaluator, _x_cms, cl_list, cu_list
                         )
                         if np.isfinite(_obj_cms) and _obj_cms < _SENTINEL_THRESHOLD and _cms_feas:
-                            tree.inject_incumbent(np.asarray(_x_cms).copy(), float(_obj_cms))
+                            _inject_incumbent(np.asarray(_x_cms).copy(), float(_obj_cms))
                             logger.info("Continuous multistart found incumbent: obj=%.6g", _obj_cms)
                 except Exception as e:
                     logger.debug("Continuous multistart failed: %s", e)
@@ -8811,7 +8952,7 @@ def solve_model(
                         _x_sn, _obj_sn = _sn
                         _subnlp_feasible += 1
                         if np.isfinite(_obj_sn) and _obj_sn < _SENTINEL_THRESHOLD:
-                            tree.inject_incumbent(_x_sn.copy(), float(_obj_sn))
+                            _inject_incumbent(_x_sn.copy(), float(_obj_sn))
                             _subnlp_incumbent_updates += 1
                             logger.info("SubNLP incumbent (gams seed): obj=%.6g", _obj_sn)
 
@@ -8853,7 +8994,7 @@ def solve_model(
                     _x_sn, _obj_sn = _sn
                     _subnlp_feasible += 1
                     if np.isfinite(_obj_sn) and _obj_sn < _SENTINEL_THRESHOLD:
-                        tree.inject_incumbent(_x_sn.copy(), float(_obj_sn))
+                        _inject_incumbent(_x_sn.copy(), float(_obj_sn))
                         _subnlp_incumbent_updates += 1
                         logger.info("SubNLP incumbent (seed): obj=%.6g", _obj_sn)
             else:
@@ -8910,7 +9051,7 @@ def solve_model(
                     _x_sn, _obj_sn = _sn
                     _subnlp_feasible += 1
                     if np.isfinite(_obj_sn) and _obj_sn < _SENTINEL_THRESHOLD:
-                        tree.inject_incumbent(_x_sn.copy(), float(_obj_sn))
+                        _inject_incumbent(_x_sn.copy(), float(_obj_sn))
                         _subnlp_incumbent_updates += 1
                         logger.info("SubNLP incumbent: obj=%.6g (iter=%d)", _obj_sn, iteration)
 
@@ -8976,7 +9117,7 @@ def solve_model(
             for _x_en, _obj_en in _enum_results:
                 _subnlp_feasible += 1
                 if np.isfinite(_obj_en) and _obj_en < _SENTINEL_THRESHOLD:
-                    tree.inject_incumbent(_x_en.copy(), float(_obj_en))
+                    _inject_incumbent(_x_en.copy(), float(_obj_en))
                     _subnlp_incumbent_updates += 1
                     logger.info("SubNLP enum incumbent: obj=%.6g", _obj_en)
             if _enum_had_inc:
@@ -9031,7 +9172,7 @@ def solve_model(
                     logger.debug("integer_box_search raised: %s", _e)
                     _bx = None
                 if _bx is not None and np.isfinite(_bx[1]) and _bx[1] < _inc_box[1] - 1e-9:
-                    tree.inject_incumbent(_bx[0].copy(), float(_bx[1]))
+                    _inject_incumbent(_bx[0].copy(), float(_bx[1]))
                     _subnlp_incumbent_updates += 1
                     _last_box_inc_obj = float(_bx[1])
                     logger.info("Box-search incumbent: obj=%.6g (iter=%d)", _bx[1], iteration)
@@ -9119,7 +9260,7 @@ def solve_model(
                                 evaluator, _x_dv, cl_list, cu_list
                             )
                             if np.isfinite(_obj_dv) and _obj_dv < _SENTINEL_THRESHOLD and _dv_feas:
-                                tree.inject_incumbent(np.asarray(_x_dv).copy(), _obj_dv)
+                                _inject_incumbent(np.asarray(_x_dv).copy(), _obj_dv)
                                 logger.info("LNS node-diving incumbent: obj=%.6g", _obj_dv)
                     except Exception as _e:
                         logger.debug("LNS node-diving failed: %s", _e)
@@ -9155,7 +9296,7 @@ def solve_model(
                                 evaluator, _x_ri, cl_list, cu_list
                             )
                             if np.isfinite(_obj_ri) and _obj_ri < _SENTINEL_THRESHOLD and _ri_feas:
-                                tree.inject_incumbent(np.asarray(_x_ri).copy(), _obj_ri)
+                                _inject_incumbent(np.asarray(_x_ri).copy(), _obj_ri)
                                 _rins_improved = _obj_ri < _rins_obj0 - 1e-9
                                 logger.info("LNS RINS incumbent: obj=%.6g", _obj_ri)
                     except Exception as _e:
@@ -9195,7 +9336,7 @@ def solve_model(
                                 evaluator, _x_sw, cl_list, cu_list
                             )
                             if np.isfinite(_obj_sw) and _obj_sw < _SENTINEL_THRESHOLD and _sw_feas:
-                                tree.inject_incumbent(np.asarray(_x_sw).copy(), _obj_sw)
+                                _inject_incumbent(np.asarray(_x_sw).copy(), _obj_sw)
                                 _swap_improved = _obj_sw < float(_lns_inc[1]) - 1e-9
                                 logger.info("LNS one-hot swap incumbent: obj=%.6g", _obj_sw)
                     except Exception as _e:
@@ -9244,7 +9385,7 @@ def solve_model(
                                 evaluator, _x_lb, cl_list, cu_list
                             )
                             if np.isfinite(_obj_lb) and _obj_lb < _SENTINEL_THRESHOLD and _lb_feas:
-                                tree.inject_incumbent(np.asarray(_x_lb).copy(), _obj_lb)
+                                _inject_incumbent(np.asarray(_x_lb).copy(), _obj_lb)
                                 _lb_improved = _obj_lb < _lb_obj0 - 1e-9
                                 logger.info(
                                     "LNS local-branching incumbent: obj=%.6g (k=%d)",
@@ -9302,9 +9443,10 @@ def solve_model(
         # its objective EVER being recorded. The tree then exhausts while missing
         # that point and falsely certifies a worse incumbent (nvs19: certified
         # -1098.0 with -1098.4 feasible). Inject every such verified point here,
-        # ungated: ``inject_incumbent`` accepts only a strictly-improving feasible
-        # point and never touches the dual bound, so this only ever tightens the
-        # incumbent — it cannot make the search unsound, only complete.
+        # gated only by the user-callback funnel (#740): ``inject_incumbent``
+        # accepts only a strictly-improving feasible point and never touches the
+        # dual bound, so this only ever tightens the incumbent — it cannot make
+        # the search unsound, only complete.
         if not _model_is_convex and int_offsets:
             _cl = [c[0] for c in constraint_bounds] if constraint_bounds else None
             _cu = [c[1] for c in constraint_bounds] if constraint_bounds else None
@@ -9321,7 +9463,7 @@ def solve_model(
                     continue
                 _obj_i = float(evaluator.evaluate_objective(xr))
                 if np.isfinite(_obj_i) and _obj_i < _SENTINEL_THRESHOLD:
-                    tree.inject_incumbent(xr, _obj_i)
+                    _inject_incumbent(xr, _obj_i)
 
         # Interactive debugger: steer point — relaxations solved, results not
         # yet imported. Safe-steer (inject incumbent / branch hint) applies here;
@@ -9363,7 +9505,7 @@ def solve_model(
         # Did the incumbent strictly improve this iteration, from ANY source?
         # proc_stats["incumbent_updates"] counts only incumbents found in the
         # batch evaluation — NOT the sub-NLP / binary-seed heuristics, which
-        # inject directly via tree.inject_incumbent. For small nonconvex MINLPs
+        # inject directly via the _inject_incumbent funnel. For small nonconvex MINLPs
         # the optimum is routinely found by those heuristics, so gating the
         # cutoff-tightening phases on the batch counter alone left the tightened
         # global box (and thus all pruning) on the table and the gap never

--- a/python/tests/test_callbacks.py
+++ b/python/tests/test_callbacks.py
@@ -412,6 +412,268 @@ class TestCallbacksWithMILP:
         assert len(node_calls) > 0
 
 
+def _spatial_mi_model():
+    """Nonconvex spatial MINLP from issue #740.
+
+    min x + y + 2*b  s.t.  x*y >= 1,  x + y <= 4 + b,  x,y in [0,4], b binary.
+    Unconstrained-by-callback optimum is b=0 (objective 2.0, at x=y=1); vetoing
+    or cutting off every b=0 incumbent makes the true optimum b=1 (objective
+    4.0). The bilinear ``x*y`` forces the spatial (nonconvex) B&B path, whose
+    primal heuristics (sub-NLP, feasibility pump, LNS, per-node NLP polish)
+    find the b=0 point through side channels that bypass the batch-import
+    callback gate — the #740 bug.
+    """
+    m = discopt.Model("spatial_mi")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=4.0)
+    b = m.binary("b")
+    m.subject_to(x * y >= 1.0)
+    m.subject_to(x + y <= 4.0 + b)
+    m.minimize(x + y + 2.0 * b)
+    return m, (x, y, b)
+
+
+@pytest.mark.slow
+@needs_rust
+@pytest.mark.integration
+class TestIssue740HeuristicInjectionGate:
+    """#740: incumbent_callback / lazy_constraints were bypassed by heuristic
+    incumbent injections on the spatial MINLP path. The batch-import gate
+    (``_invoke_pre_import_callbacks``) honored them, but incumbents entering via
+    ``tree.inject_incumbent`` side channels (warm start, sub-NLP, feasibility
+    pump, LNS, per-node NLP polish, completeness guard) never consulted the
+    callbacks, so a vetoed / cut-off point was returned as the final
+    ``optimal`` incumbent. The fix funnels every injection through
+    ``_screen_heuristic_incumbent``.
+    """
+
+    def test_incumbent_callback_veto_on_spatial_path(self):
+        """A vetoed point must never be the returned incumbent: rejecting all
+        b=0 solutions forces the b=1 optimum (objective 4.0). Pre-fix this
+        returned the vetoed b=0 point with objective 2.0."""
+        m, _vars = _spatial_mi_model()
+        vetoed = []
+
+        def inc_cb(ctx, model, sol):
+            if sol["b"] < 0.5:
+                vetoed.append(dict(sol))
+                return False
+            return True
+
+        res = m.solve(incumbent_callback=inc_cb, time_limit=60.0)
+        assert res.status in ("optimal", "feasible")
+        assert res.x is not None
+        assert round(float(np.ravel(res.x["b"])[0])) == 1, (
+            f"vetoed b=0 point returned as incumbent (objective {res.objective})"
+        )
+        assert res.objective == pytest.approx(4.0, rel=1e-3)
+        # The callback actually fired (the b=0 point WAS encountered and vetoed).
+        assert len(vetoed) > 0
+
+    def test_lazy_constraints_cut_on_spatial_path(self):
+        """A point excluded by a lazy cut must never be the returned incumbent:
+        cutting off b=0 relaxation points with a ``b >= 1`` cut forces the b=1
+        optimum (objective 4.0). Pre-fix this converged to the excluded b=0
+        point with objective 2.0."""
+        m, (_x, _y, b) = _spatial_mi_model()
+        cuts_fired = []
+
+        def lazy_cb(ctx, model):
+            # b is the third flat variable (index 2)
+            if ctx.x_relaxation[2] < 0.5:
+                cuts_fired.append(1)
+                return [CutResult(terms=[(b, 1.0)], sense=">=", rhs=1.0)]
+            return []
+
+        res = m.solve(lazy_constraints=lazy_cb, time_limit=60.0)
+        assert res.status in ("optimal", "feasible")
+        assert res.x is not None
+        assert round(float(np.ravel(res.x["b"])[0])) == 1, (
+            f"cut-off b=0 point returned as incumbent (objective {res.objective})"
+        )
+        assert res.objective == pytest.approx(4.0, rel=1e-3)
+        assert len(cuts_fired) > 0
+
+    def test_warm_start_incumbent_is_screened(self):
+        """The warm-start injection is a side channel too: an initial point the
+        incumbent callback vetoes must not survive as the final incumbent."""
+        m, (x, y, b) = _spatial_mi_model()
+
+        def reject_b0(ctx, model, sol):
+            return not sol["b"] < 0.5
+
+        # Feasible b=0 warm start (x=y=1): objective 2.0, vetoed by the callback.
+        res = m.solve(
+            incumbent_callback=reject_b0,
+            initial_solution={x: 1.0, y: 1.0, b: 0.0},
+            time_limit=60.0,
+        )
+        assert res.status in ("optimal", "feasible")
+        assert round(float(np.ravel(res.x["b"])[0])) == 1
+        assert res.objective == pytest.approx(4.0, rel=1e-3)
+
+
+class TestScreenHeuristicIncumbent:
+    """Unit tests for the #740 single-candidate callback gate."""
+
+    class _FakeTree:
+        def __init__(self, incumbent=None):
+            self._inc = incumbent
+
+        def incumbent(self):
+            return self._inc
+
+        def stats(self):
+            return {"total_nodes": 7, "global_lower_bound": 1.5, "gap": 0.5}
+
+    @staticmethod
+    def _model():
+        m = discopt.Model("gate_unit")
+        x = m.continuous("x", lb=0.0, ub=4.0)
+        b = m.binary("b")
+        m.minimize(x + b)
+        m.subject_to(x + b >= 0.5)
+        return m
+
+    def test_veto_blocks_candidate(self):
+        from discopt.solver import _screen_heuristic_incumbent
+
+        m = self._model()
+        seen = []
+
+        def veto(ctx, model, sol):
+            seen.append(sol)
+            return False
+
+        ok = _screen_heuristic_incumbent(
+            model=m,
+            tree=self._FakeTree(),
+            t_start=0.0,
+            x=np.array([1.0, 0.0]),
+            obj=1.0,
+            int_offsets=[1],
+            int_sizes=[1],
+            lazy_constraints=None,
+            incumbent_callback=veto,
+            _cut_pool=None,
+        )
+        assert ok is False
+        assert len(seen) == 1
+
+    def test_lazy_cut_blocks_candidate_and_pools_cut(self):
+        from discopt._jax.cutting_planes import CutPool
+        from discopt.solver import _screen_heuristic_incumbent
+
+        m = self._model()
+        b = m._variables[1]
+        pool = CutPool(max_cuts=10)
+
+        def lazy(ctx, model):
+            return [CutResult(terms=[(b, 1.0)], sense=">=", rhs=1.0)]
+
+        ok = _screen_heuristic_incumbent(
+            model=m,
+            tree=self._FakeTree(),
+            t_start=0.0,
+            x=np.array([1.0, 0.0]),
+            obj=1.0,
+            int_offsets=[1],
+            int_sizes=[1],
+            lazy_constraints=lazy,
+            incumbent_callback=None,
+            _cut_pool=pool,
+        )
+        assert ok is False
+        assert len(pool) == 1
+
+    def test_accepting_callback_passes_candidate(self):
+        from discopt.solver import _screen_heuristic_incumbent
+
+        m = self._model()
+        ok = _screen_heuristic_incumbent(
+            model=m,
+            tree=self._FakeTree(),
+            t_start=0.0,
+            x=np.array([1.0, 0.0]),
+            obj=1.0,
+            int_offsets=[1],
+            int_sizes=[1],
+            lazy_constraints=None,
+            incumbent_callback=lambda ctx, model, sol: True,
+            _cut_pool=None,
+        )
+        assert ok is True
+
+    def test_non_integer_candidate_skips_callbacks(self):
+        """A fractional candidate can never become the incumbent
+        (``inject_incumbent`` re-verifies), so user code must not see it."""
+        from discopt.solver import _screen_heuristic_incumbent
+
+        m = self._model()
+        calls = []
+        ok = _screen_heuristic_incumbent(
+            model=m,
+            tree=self._FakeTree(),
+            t_start=0.0,
+            x=np.array([1.0, 0.4]),
+            obj=1.4,
+            int_offsets=[1],
+            int_sizes=[1],
+            lazy_constraints=None,
+            incumbent_callback=lambda ctx, model, sol: calls.append(1) or False,
+            _cut_pool=None,
+        )
+        assert ok is True
+        assert not calls
+
+    def test_non_improving_candidate_skips_callbacks(self):
+        """The callback contract is "a new incumbent is about to be accepted":
+        a candidate that cannot strictly improve the incumbent is passed
+        through uninspected (``inject_incumbent`` rejects it)."""
+        from discopt.solver import _screen_heuristic_incumbent
+
+        m = self._model()
+        calls = []
+        ok = _screen_heuristic_incumbent(
+            model=m,
+            tree=self._FakeTree(incumbent=(np.array([1.0, 0.0]), 1.0)),
+            t_start=0.0,
+            x=np.array([2.0, 0.0]),
+            obj=2.0,
+            int_offsets=[1],
+            int_sizes=[1],
+            lazy_constraints=None,
+            incumbent_callback=lambda ctx, model, sol: calls.append(1) or False,
+            _cut_pool=None,
+        )
+        assert ok is True
+        assert not calls
+
+    def test_callback_exception_fails_soft(self):
+        """Only the user callback may fail softly (INT-1 discipline): an
+        exception is logged and the candidate proceeds."""
+        from discopt.solver import _screen_heuristic_incumbent
+
+        m = self._model()
+
+        def bad(ctx, model, sol):
+            raise RuntimeError("intentional")
+
+        ok = _screen_heuristic_incumbent(
+            model=m,
+            tree=self._FakeTree(),
+            t_start=0.0,
+            x=np.array([1.0, 0.0]),
+            obj=1.0,
+            int_offsets=[1],
+            int_sizes=[1],
+            lazy_constraints=None,
+            incumbent_callback=bad,
+            _cut_pool=None,
+        )
+        assert ok is True
+
+
 class TestCallbackContext:
     def test_construction(self):
         ctx = CallbackContext(


### PR DESCRIPTION
## Summary

Closes #740. On the spatial (nonconvex MINLP) B&B path, `incumbent_callback` vetoes and `lazy_constraints` cuts were honored only for batch-imported incumbents (`_invoke_pre_import_callbacks`). Incumbents entering through the ~19 side channels — warm start, per-node NLP polish, sub-NLP, feasibility pump (both variants), integer local search, fractional diving, continuous multistart, binary-seed enumeration, integer-box search, the four LNS neighbourhoods, and the completeness guard — called `tree.inject_incumbent` directly, so a vetoed or cut-off point could be (re-)introduced and reported as the final `optimal` incumbent. For `lazy_constraints` this is a soundness contract violation (the callback defines the true feasible set); for `incumbent_callback` it violates the documented "return False to reject" API.

Fix: every non-batch injection in `solve_model` now goes through a single `_inject_incumbent` funnel that screens the candidate with the new `_screen_heuristic_incumbent` gate (the single-point analogue of `_invoke_pre_import_callbacks`): lazy cuts are pooled and the point rejected; an incumbent-callback `False` rejects the point. Candidates that cannot become the incumbent anyway (fractional, or not strictly improving — `inject_incumbent` enforces strict improvement) skip user code, matching the "new incumbent about to be accepted" contract. The issue's repro now returns the callback-respecting optimum (b=1, objective 4.0) for both the veto and the lazy-cut variant; pre-fix both returned the excluded b=0 point (objective 2.0) as `optimal`.

The NLP-BB path already refuses these callbacks loudly (INT-1, #413) and is unchanged; MILP/MIQP dispatch is unchanged (silently ignoring these callbacks there is a pre-existing, separate gap — follow-up issue filed).

## Correctness

The gate only *rejects* incumbent candidates the user's callbacks exclude; it never touches the dual bound, never weakens a fathom, and never accepts a point `inject_incumbent` would have rejected. Cuts returned by `lazy_constraints` go to the same cut pool as on the batch path. Without callbacks the funnel short-circuits straight to `tree.inject_incumbent`, so the default path is a pass-through (bound-neutral). User-callback exceptions fail soft; acting on the verdict stays outside the swallow (same INT-1/#413 discipline as the batch gate).

- [x] Cannot produce a false certificate (or: N/A — no solver-math change)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 664 passed, 14 skipped
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 10 passed (one wall-clock flake on a cold first run — `test_large_dense_jacobian_no_crash` deadline margin — passed on re-run and in isolation)
- [x] `cargo test -p discopt-core` → N/A — no Rust touched
- [x] `ruff check` / `ruff format --check` clean (also `mypy python/discopt/solver.py` clean)

Also: callback/injection-adjacent files (`test_callbacks.py`, `test_c3_incumbent_rounding.py`, `test_issue_188_continuous_multistart.py`, `test_nonrigorous_fathom_decertifies_optimal.py`, `test_debug_bnb.py`, `test_debug_adversarial.py`, `test_c1_nlp_fathom_infeasible.py`, `test_batch_dispatch.py`) → 148 passed.

## Regression test

- [x] Added a regression test that fails before / passes after: `test_callbacks.py::TestIssue740HeuristicInjectionGate` — `test_incumbent_callback_veto_on_spatial_path`, `test_lazy_constraints_cut_on_spatial_path`, `test_warm_start_incumbent_is_screened` (all three fail pre-fix, returning the excluded b=0 point), plus six unit tests for the gate in `TestScreenHeuristicIncumbent` (veto, cut pooling, accept, fractional skip, non-improving skip, soft callback failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqpscMguajHrBcgSTYe7vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqpscMguajHrBcgSTYe7vN)_