### PR TITLE
fix(correctness): #742 reset stale relaxation cache on parameter change

### DIFF
--- a/python/discopt/_jax/uniform_relax.py
+++ b/python/discopt/_jax/uniform_relax.py
@@ -508,6 +508,29 @@ def _get_analysis_cache(model: Model) -> _ModelAnalysisCache:
     return cache
 
 
+def clear_analysis_cache(model: Model) -> None:
+    """Drop the box-independent relaxation analysis cache pinned on ``model``.
+
+    The cache (canonical DAG, reconstructed exprs, DCP verdicts, compiled fns,
+    and interval enclosures in ``bounds_by_box``) is keyed by ``_analysis_token``
+    — ``(len(_variables), len(_constraints), id(_objective))`` — which guards
+    *structural* changes only and intentionally does NOT hash parameter *values*
+    (they can be large arrays; hashing them on the per-node cache lookup would be
+    a hot-path cost). Parameters are constant within a solve, so across the B&B
+    nodes of one solve the token is stable and the cache is correctly reused (the
+    intended win). But changing a :class:`~discopt.modeling.core.Parameter`'s
+    ``.value`` *between* solves — the supported use of parameters — leaves the
+    token unchanged while the cached interval bounds still embed the OLD value,
+    so the stale relaxation would be reused on the spatial B&B path and yield an
+    incorrect (unsound) bound on the re-solve (issue #742: NBI's per-weight
+    subproblems change the CHIM-target parameters between solves and stalled at
+    the dominated ``t = 0`` CHIM point). ``solve_model`` calls this at the start
+    of every solve, in lockstep with the convexity-classification reset, so each
+    solve rebuilds the analysis against the current parameter values.
+    """
+    model.__dict__.pop(_ANALYSIS_ATTR, None)
+
+
 def _node_support_cols(node: CNode) -> Optional[tuple[int, ...]]:
     """Original columns a node's interval enclosure can depend on.
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3803,6 +3803,17 @@ def solve_model(
     from discopt._jax.convexity.patterns import clear_declared_box_cache
 
     clear_declared_box_cache(model)
+    # The box-independent uniform-relaxation analysis (canonical DAG, DCP verdicts,
+    # interval enclosures) is pinned on the model and keyed by a structural token
+    # that does not hash parameter *values*. A parameter whose ``.value`` changed
+    # between solves leaves the token unchanged, so a stale relaxation embedding
+    # the OLD value would be reused on the spatial B&B path — an unsound bound on
+    # the re-solve (issue #742). Reset it here so each solve rebuilds against the
+    # current parameter values; within a solve it is still built once and reused
+    # across all B&B nodes.
+    from discopt._jax.uniform_relax import clear_analysis_cache
+
+    clear_analysis_cache(model)
     _convexity_time_budget = min(max(0.2 * float(time_limit), 0.5), 20.0)
     model._convexity_time_budget = _convexity_time_budget
     # #654: absolute solve deadline, anchored at ``_solve_t0`` (before all

--- a/python/tests/test_mo_nbi_param_cache_742.py
+++ b/python/tests/test_mo_nbi_param_cache_742.py
@@ -1,0 +1,105 @@
+"""Regression tests for issue #742 — NBI interior subproblems returned
+dominated (unmoved) CHIM points.
+
+Root cause: the box-independent uniform-relaxation analysis cache
+(``_uniform_relax_analysis``) is pinned on the model and keyed by a structural
+token — ``(len(_variables), len(_constraints), id(_objective))`` — that does
+**not** account for parameter *values*. NBI solves one max-``t`` subproblem per
+CHIM weight, changing the CHIM-target :class:`Parameter` values between solves
+while the model structure is fixed. The stale relaxation (embedding the previous
+weight's target) produced an incorrect dual bound on the spatial B&B path that
+fathomed the true Pareto point, so every interior subproblem terminated at the
+dominated ``t = 0`` CHIM start. ``solve_model`` now resets the analysis cache at
+the start of every solve, in lockstep with the convexity-classification reset.
+
+These tests are intentionally *fast* and unmarked-``slow`` so they run in the
+PR battery — the pre-existing on-front assertion in ``test_mo_nbi.py`` is
+``slow``/``integration`` marked, so no CI lane exercised it and the regression
+went unnoticed.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.mo import filter_nondominated, normal_boundary_intersection
+
+pytestmark = [pytest.mark.pr_correctness]
+
+
+def _on_qp_front(obj_pair, tol=5e-3):
+    """Analytic front residual of the bi-objective QP used below.
+
+    Minimizing ``f1 = x**2 + y**2`` and ``f2 = (x-2)**2 + (y-1)**2`` over the box
+    has Pareto set on the segment between the two minimizers; in objective space
+    the front satisfies ``sqrt(f1/5) + sqrt(f2/5) = 1``.
+    """
+    f1, f2 = float(obj_pair[0]), float(obj_pair[1])
+    return abs(np.sqrt(max(f1, 0.0) / 5.0) + np.sqrt(max(f2, 0.0) / 5.0) - 1.0) < tol
+
+
+def _build_biobj_qp():
+    m = dm.Model("biobj_qp_742")
+    x = m.continuous("x", lb=-5, ub=5)
+    y = m.continuous("y", lb=-5, ub=5)
+    f1 = x**2 + y**2
+    f2 = (x - 2) ** 2 + (y - 1) ** 2
+    return m, [f1, f2]
+
+
+def test_nbi_interior_points_on_front():
+    """Every NBI point — anchors *and* interior — lies on the analytic front.
+
+    Before the fix, the interior points equalled their (dominated) CHIM starts,
+    e.g. ``(3.75, 1.25)`` at ``f1 = 3.75`` where the true front has ``f2 ~= 0.09``.
+    """
+    m, objs = _build_biobj_qp()
+    front = normal_boundary_intersection(m, objs, n_points=5, filter=False)
+    assert front.n == 5
+    off = [tuple(map(float, p.objectives)) for p in front.points if not _on_qp_front(p.objectives)]
+    assert not off, f"NBI points off the analytic front (dominated CHIM starts): {off}"
+
+
+def test_nbi_returned_points_are_nondominated():
+    """The returned front must be mutually non-dominated (the dominated CHIM
+    interior points were mutually non-dominated, so this alone did not catch the
+    bug — kept as a companion invariant)."""
+    m, objs = _build_biobj_qp()
+    front = normal_boundary_intersection(m, objs, n_points=5)
+    assert filter_nondominated(front.objectives()).all()
+
+
+def test_resolve_after_parameter_change_is_sound():
+    """Direct root-cause probe: the NBI max-``t`` subproblem solved twice on one
+    model with only the CHIM-target parameters changed between solves.
+
+    The second solve (interior weight ``w = [0.5, 0.5]``) must reach the Pareto
+    point ``t = 0.25`` (objective ``(1.25, 1.25)``), not stall at the dominated
+    ``t = 0`` CHIM point ``(2.5, 2.5)`` from the stale relaxation of the first
+    (anchor) solve. This exercises the cache-reset path without the full sweep,
+    so it is both fast and specific to the reintroduction of the bug.
+    """
+    m, objs = _build_biobj_qp()
+    ideal = np.array([0.0, 0.0])
+    span = np.array([5.0, 5.0])
+    phi = np.array([[0.0, 1.0], [1.0, 0.0]])  # normalized anchors, min-form
+    n_hat = -phi.sum(axis=0)  # Das-Dennis quasi-normal
+
+    t = m.continuous("_mo_nbi_t", lb=-1e6, ub=1e6)
+    b = [m.parameter("_mo_nbi_b_0", value=0.0), m.parameter("_mo_nbi_b_1", value=0.0)]
+    for j in range(2):
+        g = (objs[j] - float(ideal[j])) / float(span[j])
+        m.subject_to(g - float(n_hat[j]) * t - b[j] == 0)
+    m.minimize(-t)
+
+    def solve_weight(w):
+        target = phi.T @ (w / w.sum())
+        b[0].value = np.asarray(float(target[0]))
+        b[1].value = np.asarray(float(target[1]))
+        return float(m.solve().x["_mo_nbi_t"])
+
+    # First: an anchor weight (populates the cache); its optimum is t = 0.
+    assert solve_weight(np.array([0.0, 1.0])) == pytest.approx(0.0, abs=1e-4)
+    # Second: an interior weight. With the stale cache this stalled at t = 0.
+    assert solve_weight(np.array([0.5, 0.5])) == pytest.approx(0.25, abs=2e-3)


### PR DESCRIPTION
## Summary

Closes #742.

`normal_boundary_intersection` returned dominated (unmoved) CHIM points for every interior weight — the max-`t` subproblem terminated at `t=0` without error, so the "front" interior was not Pareto-optimal.

**Root cause:** the box-independent uniform-relaxation analysis cache (`_uniform_relax_analysis`, pinned on the model) is keyed by a *structural* staleness token — `(len(_variables), len(_constraints), id(_objective))` — that does **not** account for parameter *values*. NBI solves one subproblem per CHIM weight, changing the CHIM-target `Parameter` values between solves while the model structure is fixed. The stale relaxation (embedding the previous weight's target in its `bounds_by_box` interval enclosures) produced an incorrect dual bound on the spatial B&B path that fathomed the true Pareto point, collapsing each interior subproblem onto the dominated `t=0` CHIM start. NNC was unaffected because its subproblems are convex and take the NLP fast path (no spatial relaxation).

This is a **general** re-solve-after-parameter-change soundness bug, not NBI-specific: any model re-solved on the spatial B&B path after mutating `Parameter.value` could reuse a stale relaxation.

**Fix:** `solve_model` now resets the analysis cache at the start of every solve, in lockstep with the existing convexity-classification reset, via a new `clear_analysis_cache` helper in `uniform_relax.py`.

## Correctness

The clear is a `dict.pop(..., None)` that is a **no-op on a fresh model**, so single-solve behavior — the standard benchmark panel — is byte-identical: `node_count` and certified `objective` unchanged. The change only affects the *stale-cache* re-solve path, whose prior behavior was unsound. Within a solve, parameters are constant, so the cache is still built once and reused across all B&B nodes (the intended win preserved). No validation, fallback, or safety guard was weakened — this *strengthens* soundness by rebuilding the relaxation against current parameter values.

- [x] Cannot produce a false certificate — the fix removes a source of unsound (stale) dual bounds; fresh single solves are byte-identical
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **664 passed, 13 skipped**
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **9 passed, 1 failed** — the failure is `test_large_dense_jacobian_no_crash`, whose assertion is a wall-clock deadline margin (`wall < budget + 40`); it **passes in isolation (24.9s)** and builds a fresh model with a single solve, which this change cannot affect (no-op on fresh models). Pre-existing timing flake under container CPU contention, not a regression.
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)
- [x] `ruff check` / `ruff format --check` → clean
- Also: full MO suite (`test_mo_*`) **43 passed**, including the previously-failing `test_mo_nbi.py::TestNBIConvex::test_front_on_analytic_curve`.

## Regression test

`python/tests/test_mo_nbi_param_cache_742.py`, marked `pr_correctness` so it runs on **every** PR — the pre-existing on-front assertion in `test_mo_nbi.py` is `slow`/`integration`, so no CI lane exercised it and the regression went unnoticed (the issue's own diagnosis).

- `test_nbi_interior_points_on_front` — asserts every NBI point (anchors *and* interior) lies on the analytic front.
- `test_resolve_after_parameter_change_is_sound` — direct root-cause probe: solves the max-`t` subproblem twice on one model with only the CHIM-target parameters changed; the interior weight must reach `t=0.25`, not stall at `t=0`.

Both **fail before** the change and **pass after** (verified by monkeypatch-reverting the clear: `2 failed, 1 passed` → `3 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFKTTAbP53Xs76gSDoBiaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFKTTAbP53Xs76gSDoBiaV)_