### PR TITLE
fix(correctness): #750 lower cardinality atoms nested inside &/| in GDP reformulation

### DIFF
--- a/python/discopt/_jax/gdp_reformulate.py
+++ b/python/discopt/_jax/gdp_reformulate.py
@@ -1544,6 +1544,20 @@ def _to_nnf(expr: LogicalExpression) -> LogicalExpression:
                     LogicalAnd(LogicalNot(inner.left), inner.right),
                 )
             )
+        elif isinstance(inner, LogicalAtLeast):
+            # ~(sum >= k)  ≡  sum <= k-1  ≡  atmost(k-1, ops)
+            return LogicalAtMost(inner.k - 1, inner.operands)
+        elif isinstance(inner, LogicalAtMost):
+            # ~(sum <= k)  ≡  sum >= k+1  ≡  atleast(k+1, ops)
+            return LogicalAtLeast(inner.k + 1, inner.operands)
+        elif isinstance(inner, LogicalExactly):
+            # ~(sum == k)  ≡  sum <= k-1  |  sum >= k+1
+            return _to_nnf(
+                LogicalOr(
+                    LogicalAtMost(inner.k - 1, inner.operands),
+                    LogicalAtLeast(inner.k + 1, inner.operands),
+                )
+            )
         else:
             return expr
     elif isinstance(expr, LogicalAnd):
@@ -1611,7 +1625,20 @@ def _nnf_to_cnf_clauses(expr: LogicalExpression, model: Model, add_aux_binary) -
         right_lit = _tseitin_var(expr.right, model, add_aux_binary)
         return [left_lit + right_lit]
 
-    return []
+    # Cardinality atom nested inside a boolean combination: introduce a
+    # Tseitin auxiliary constrained to imply the atom, then emit the
+    # single-literal clause forcing that auxiliary true. Silently returning
+    # [] here would widen the feasible set (issue #750).
+    elif isinstance(expr, (LogicalAtLeast, LogicalAtMost, LogicalExactly)):
+        return [_tseitin_var(expr, model, add_aux_binary)]
+
+    # No expression should reach here in NNF. Refuse loudly rather than
+    # silently dropping the constraint and widening the feasible set.
+    raise NotImplementedError(
+        f"Cannot linearize logical sub-expression of type "
+        f"{type(expr).__name__!r} during GDP reformulation; refusing to "
+        f"silently drop it (would widen the feasible set). See issue #750."
+    )
 
 
 def _tseitin_var(expr: LogicalExpression, model: Model, add_aux_binary) -> list[tuple]:
@@ -1626,8 +1653,15 @@ def _tseitin_var(expr: LogicalExpression, model: Model, add_aux_binary) -> list[
     if isinstance(expr, LogicalNot) and isinstance(expr.operand, BooleanVar):
         return [(_get_binary_var(expr.operand), False)]
 
-    # Create auxiliary binary: aux <-> expr
+    # Create auxiliary binary: aux -> expr
     aux = add_aux_binary("_tseitin")
+
+    # Cardinality atom: emit the big-M implication aux -> (cardinality)
+    # directly; it has no CNF-clause representation.
+    if isinstance(expr, (LogicalAtLeast, LogicalAtMost, LogicalExactly)):
+        for cons in _cardinality_implication_constraints(aux, expr):
+            model._constraints.append(cons)
+        return [(aux, True)]
 
     # Get the sub-clauses for expr
     sub_clauses = _nnf_to_cnf_clauses(expr, model, add_aux_binary)
@@ -1646,6 +1680,48 @@ def _tseitin_var(expr: LogicalExpression, model: Model, add_aux_binary) -> list[
     #   building, the above is sufficient for correctness.
 
     return [(aux, True)]
+
+
+def _cardinality_implication_constraints(aux, expr: LogicalExpression) -> list[Constraint]:
+    """Build linear constraints encoding ``aux -> <cardinality atom>``.
+
+    Used when a ``LogicalAtLeast`` / ``LogicalAtMost`` / ``LogicalExactly``
+    atom appears nested inside a boolean combination and is lowered via a
+    Tseitin auxiliary ``aux``. Only the forward implication is needed: the
+    auxiliary occurs positively in exactly one clause, so it is existentially
+    chosen, and ``aux -> atom`` is sufficient for soundness (see issue #750).
+
+    Big-M form (``n`` = number of operands, ``s`` = sum of operand binaries):
+      atleast(k):  s >= k*aux           (aux=0 => trivially true)
+      atmost(k):   s <= n - (n-k)*aux   (aux=0 => s <= n, trivially true)
+      exactly(k):  both of the above.
+    """
+    operands = expr.operands
+    n = len(operands)
+    var_sum = _wrap(0.0)
+    for op in operands:
+        var_sum = var_sum + _get_binary_var(op)
+
+    constraints: list[Constraint] = []
+    if isinstance(expr, (LogicalAtLeast, LogicalExactly)):
+        # s - k*aux >= 0
+        constraints.append(
+            Constraint(
+                body=var_sum - _wrap(float(expr.k)) * aux,
+                sense=">=",
+                rhs=0.0,
+            )
+        )
+    if isinstance(expr, (LogicalAtMost, LogicalExactly)):
+        # s + (n-k)*aux - n <= 0
+        constraints.append(
+            Constraint(
+                body=var_sum + _wrap(float(n - expr.k)) * aux - _wrap(float(n)),
+                sense="<=",
+                rhs=0.0,
+            )
+        )
+    return constraints
 
 
 def _clause_to_constraint(clause: list[tuple], name: str | None = None) -> Constraint:

--- a/python/discopt/_jax/gdp_reformulate.py
+++ b/python/discopt/_jax/gdp_reformulate.py
@@ -1682,7 +1682,9 @@ def _tseitin_var(expr: LogicalExpression, model: Model, add_aux_binary) -> list[
     return [(aux, True)]
 
 
-def _cardinality_implication_constraints(aux, expr: LogicalExpression) -> list[Constraint]:
+def _cardinality_implication_constraints(
+    aux, expr: "LogicalAtLeast | LogicalAtMost | LogicalExactly"
+) -> list[Constraint]:
     """Build linear constraints encoding ``aux -> <cardinality atom>``.
 
     Used when a ``LogicalAtLeast`` / ``LogicalAtMost`` / ``LogicalExactly``

--- a/python/tests/test_gdp.py
+++ b/python/tests/test_gdp.py
@@ -1119,6 +1119,72 @@ class TestLogicalConstraints:
         y_sum = sum(result.x["y"])
         assert y_sum == pytest.approx(2.0, abs=1e-4)
 
+    # ── #750: cardinality atoms nested inside boolean combinations ──
+    #
+    # Before the fix, `_nnf_to_cnf_clauses` returned [] for a nested
+    # LogicalAtLeast/AtMost/Exactly, silently dropping it and widening the
+    # feasible set (A=1,B=0,C=0 wrongly satisfied `A & atleast(1,B,C)`).
+
+    @staticmethod
+    def _nested_reform_feasible(builder, va, vb, vc):
+        """Is the assignment (A,B,C) feasible after GDP reformulation?"""
+        m = dm.Model("nested_card")
+        a, b, c = m.boolean("A"), m.boolean("B"), m.boolean("C")
+        builder(m, a, b, c)
+        for var, val in ((a, va), (b, vb), (c, vc)):
+            m.logical(var if val == 1 else ~var)
+        m.minimize(a.variable * 0)
+        return m.solve(time_limit=30).status == "optimal"
+
+    def _assert_matches_truth(self, builder, truth):
+        for va in (0, 1):
+            for vb in (0, 1):
+                for vc in (0, 1):
+                    got = self._nested_reform_feasible(builder, va, vb, vc)
+                    want = truth(va, vb, vc)
+                    assert got == want, (
+                        f"A={va} B={vb} C={vc}: reformulated feasible={got}, expected={want}"
+                    )
+
+    def test_nested_atleast_in_and_not_dropped(self):
+        """#750: `A & atleast(1,B,C)` must reject A=1,B=0,C=0."""
+        self._assert_matches_truth(
+            lambda m, a, b, c: m.logical(a & dm.atleast(1, b, c)),
+            lambda a, b, c: a == 1 and (b + c) >= 1,
+        )
+
+    def test_nested_atleast_in_or_not_dropped(self):
+        self._assert_matches_truth(
+            lambda m, a, b, c: m.logical(a | dm.atleast(2, b, c)),
+            lambda a, b, c: a == 1 or (b + c) >= 2,
+        )
+
+    def test_nested_atmost_in_or_not_dropped(self):
+        self._assert_matches_truth(
+            lambda m, a, b, c: m.logical(a | dm.atmost(1, b, c)),
+            lambda a, b, c: a == 1 or (b + c) <= 1,
+        )
+
+    def test_nested_exactly_in_and_not_dropped(self):
+        self._assert_matches_truth(
+            lambda m, a, b, c: m.logical(a & dm.exactly(2, b, c)),
+            lambda a, b, c: a == 1 and (b + c) == 2,
+        )
+
+    def test_nested_negated_atleast_not_dropped(self):
+        """~atleast(1,B,C) nested must lower to atmost(0,B,C), not vanish."""
+        self._assert_matches_truth(
+            lambda m, a, b, c: m.logical(~dm.atleast(1, b, c) | a),
+            lambda a, b, c: (not ((b + c) >= 1)) or a == 1,
+        )
+
+    def test_nested_negated_exactly_not_dropped(self):
+        """~exactly(1,B,C) nested must lower to atmost(0)|atleast(2)."""
+        self._assert_matches_truth(
+            lambda m, a, b, c: m.logical(~dm.exactly(1, b, c) & a),
+            lambda a, b, c: ((b + c) != 1) and a == 1,
+        )
+
     def test_logical_equivalent_to_solve(self):
         """Y[0].equivalent_to(Y[1]) forces Y[0] == Y[1]."""
         m = dm.Model("test_equiv")


### PR DESCRIPTION
## Summary

`reformulate_gdp` silently dropped `LogicalAtLeast` / `LogicalAtMost` / `LogicalExactly` atoms when they appeared **nested inside** a boolean combination (`&` / `|`): `_nnf_to_cnf_clauses` returned `[]` for the cardinality atom and `_to_nnf` passed it through untouched, so the constraint vanished with no error. The reformulated feasible set became a strict superset of the user's model (e.g. `A=1,B=0,C=0` wrongly satisfied `A & atleast(1,B,C)`) — the same silent-widening defect class as #745. Closes #750.

Changes to `python/discopt/_jax/gdp_reformulate.py`:
- `_to_nnf` now pushes negation into cardinality atoms via De Morgan-style complements (`~atleast(k)→atmost(k-1)`, `~atmost(k)→atleast(k+1)`, `~exactly(k)→atmost(k-1)|atleast(k+1)`) instead of leaving `~atom` for the clause converter to drop.
- `_nnf_to_cnf_clauses` and `_tseitin_var` lower a nested cardinality atom via a Tseitin auxiliary constrained by the forward implication `aux → atom` (new `_cardinality_implication_constraints` big-M helper). Forward-only is sound because the auxiliary occurs positively in exactly one clause and is existentially chosen.
- The silent `return []` fallthrough is replaced with a loud `NotImplementedError`, so no logical sub-expression is ever dropped without a diagnostic again.

## Correctness

The fix **narrows** the reformulated feasible set back to the user's model — it removes previously-admitted infeasible points, and the six new enumeration tests confirm the reformulated feasible set exactly equals each formula's truth table over all `A,B,C` assignments. Top-level cardinality lowering is unchanged. The new `aux → atom` implication is a standard sound big-M encoding (`aux=0` leaves the atom unconstrained; `aux=1` enforces it), and `aux` is forced true wherever the atom must hold. No validation, fallback, or guard was weakened — the previously-silent drop is now a loud refusal.

- [x] Cannot produce a false certificate (narrows an over-wide feasible set; no bound/relaxation math touched)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke python/tests/` → 671 passed, 12 skipped
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 9 passed, 1 failed (`test_large_dense_jacobian_no_crash` — load-induced timeout under the serial slow suite; passes in isolation in 29.6s, unrelated to this change)
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)
- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest python/tests/test_gdp.py` → 109 passed

## Regression test

Six enumeration tests added in `python/tests/test_gdp.py::TestLogicalConstraints`, covering atleast/atmost/exactly nested in `&` and `|`, plus negated-atleast and negated-exactly. Each asserts the reformulated feasible set matches the formula's truth over all `A,B,C` assignments. All six **fail on the pre-fix tree** (silent drop admits the violating assignment) and **pass after**.

- [x] Added a regression test that fails before / passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxQZVfF6VSZfa2wFwtN3LX)_