### PR TITLE
fix(gams): #745 execute indexed param assignments; fold min/max in constant evaluator

### DIFF
--- a/python/discopt/modeling/gams_parser.py
+++ b/python/discopt/modeling/gams_parser.py
@@ -1255,10 +1255,85 @@ class _ModelBuilder:
             self.param_values[name] = dict(gt.data)
         # Process assignment statements for known params/scalars
         for pname, domain, dollar, expr in self.p.param_assigns:
-            if pname in self.scalar_values and not domain:
-                val = self._eval_const_expr(expr)
-                if val is not None:
-                    self.scalar_values[pname] = val
+            self._apply_param_assign(pname, domain, dollar, expr, {})
+
+    def _lookup_set_elements(self, name: str) -> list[str] | None:
+        """Resolve a set/alias name to its element list, or None if unknown."""
+        resolved = self.p.aliases.get(name, name)
+        if resolved in self.set_elements:
+            return self.set_elements[resolved]
+        for k, v in self.set_elements.items():
+            if k.lower() == resolved.lower():
+                return v
+        return None
+
+    def _apply_param_assign(self, pname: str, domain: list[str], dollar, expr, env: dict):
+        """Execute one parameter/scalar assignment statement.
+
+        Handles scalar targets (``s = expr``) and indexed targets
+        (``p(i) = expr``, ``p('a') = expr``), iterating free domain positions
+        over their set elements; loop indices arrive pre-bound in ``env``.
+        An assignment whose $-condition or right-hand side cannot be
+        evaluated raises :class:`GamsParseError` — silently dropping it
+        would build a wrong model with no diagnostic (#745).
+        """
+        import itertools
+
+        if not domain:
+            if dollar is not None:
+                cond = self._eval_dollar_cond(dollar, env)
+                if cond is None:
+                    raise GamsParseError(f"Cannot evaluate $-condition on assignment to '{pname}'")
+                if cond == 0.0:
+                    return
+            val = self._eval_const_expr_with_env(expr, env)
+            if val is None:
+                raise GamsParseError(
+                    f"Cannot evaluate right-hand side of assignment to '{pname}'; "
+                    f"refusing to silently drop the assignment"
+                )
+            if pname in self.scalar_values:
+                self.scalar_values[pname] = val
+                return
+            gp = self.p.parameters.get(pname)
+            if gp is not None and gp.domain:
+                raise GamsParseError(f"Assignment to indexed parameter '{pname}' without a domain")
+            # scalar (0-dim) parameter declared via Parameter
+            self.scalar_values[pname] = val
+            self.param_values[pname] = {("",): val}
+            return
+
+        # Indexed target: fix loop-bound positions, iterate free set positions,
+        # and treat non-set entries as concrete element labels (p('a') = ...).
+        index_sets: list[list[str]] = []
+        for d in domain:
+            if d in env:
+                index_sets.append([env[d]])
+            else:
+                elems = self._lookup_set_elements(d)
+                if elems is not None:
+                    index_sets.append(list(elems))
+                else:
+                    index_sets.append([d])
+        for combo in itertools.product(*index_sets):
+            local_env = dict(env)
+            for d, elem in zip(domain, combo):
+                local_env[d] = elem
+            if dollar is not None:
+                cond = self._eval_dollar_cond(dollar, local_env)
+                if cond is None:
+                    raise GamsParseError(f"Cannot evaluate $-condition on assignment to '{pname}'")
+                if cond == 0.0:
+                    continue
+            val = self._eval_const_expr_with_env(expr, local_env)
+            if val is None:
+                raise GamsParseError(
+                    f"Cannot evaluate right-hand side of assignment to "
+                    f"'{pname}({', '.join(combo)})'; refusing to silently drop "
+                    f"the assignment"
+                )
+            key: object = tuple(combo) if len(combo) > 1 else combo[0]
+            self.param_values.setdefault(pname, {})[key] = val
 
     def _execute_loops(self):
         """Execute loop/if statements, modifying scalars, params, and bounds."""
@@ -1310,14 +1385,7 @@ class _ModelBuilder:
 
         # Process any param assignments from the body
         for pname, domain, dollar, expr in body_parser.param_assigns:
-            val = self._eval_const_expr_with_env(expr, env)
-            if val is not None:
-                if pname in self.scalar_values and not domain:
-                    self.scalar_values[pname] = val
-                elif pname in self.param_values and domain:
-                    keys = [env.get(d, d) for d in domain]
-                    key = tuple(keys) if len(keys) > 1 else keys[0]
-                    self.param_values[pname][key] = val
+            self._apply_param_assign(pname, domain, dollar, expr, env)
 
         # Process any bound assignments from the body
         for b in body_parser.bounds:
@@ -1329,7 +1397,20 @@ class _ModelBuilder:
                 )
 
     def _eval_const_expr_with_env(self, expr, env: dict) -> float | None:
-        """Evaluate a constant expression with loop index substitution."""
+        """Evaluate a constant expression with loop-index substitution.
+
+        Returns None when the expression is not a compile-time constant
+        (e.g. it references a variable). Callers decide whether None is a
+        signal ("this is not constant", used when probing) or an error
+        (assignment statements refuse loudly rather than dropping, #745).
+        The ``env`` maps loop/domain index names to concrete set elements;
+        it is threaded through every recursion so compound expressions like
+        ``ord(i) * 10`` fold correctly inside loops and indexed assignments.
+        """
+        import itertools
+
+        if isinstance(expr, ExprNum):
+            return expr.value
         if isinstance(expr, ExprRef):
             if expr.name in env:
                 # Resolve to scalar value if it's a scalar ref
@@ -1352,7 +1433,7 @@ class _ModelBuilder:
                     if isinstance(idx, ExprRef) and idx.name in env:
                         indices.append(env[idx.name])
                     else:
-                        v = self._eval_const_expr(idx)
+                        v = self._eval_const_expr_with_env(idx, env)
                         if v is not None:
                             indices.append(str(int(v)) if v == int(v) else str(v))
                         else:
@@ -1364,25 +1445,15 @@ class _ModelBuilder:
                 tkey = tuple(indices)
                 if tkey in pdata:
                     return float(pdata[tkey])
+                # GAMS semantics: unset parameter entries read as 0
                 return 0.0
             return None
-        # Fall back to standard const eval
-        return self._eval_const_expr(expr)
-
-    def _eval_const_expr(self, expr) -> float | None:
-        """Evaluate a constant expression (no variables)."""
-        if isinstance(expr, ExprNum):
-            return expr.value
-        if isinstance(expr, ExprRef):
-            if expr.name in self.scalar_values:
-                return self.scalar_values[expr.name]
-            return None
         if isinstance(expr, ExprUnaryMinus):
-            v = self._eval_const_expr(expr.operand)
+            v = self._eval_const_expr_with_env(expr.operand, env)
             return -v if v is not None else None
         if isinstance(expr, ExprBinOp):
-            lv = self._eval_const_expr(expr.left)
-            rv = self._eval_const_expr(expr.right)
+            lv = self._eval_const_expr_with_env(expr.left, env)
+            rv = self._eval_const_expr_with_env(expr.right, env)
             if lv is None or rv is None:
                 return None
             if expr.op == "+":
@@ -1409,7 +1480,7 @@ class _ModelBuilder:
             if expr.op == "<>":
                 return 1.0 if lv != rv else 0.0
         if isinstance(expr, ExprFunc):
-            raw_args = [self._eval_const_expr(a) for a in expr.args]
+            raw_args = [self._eval_const_expr_with_env(a, env) for a in expr.args]
             if any(a is None for a in raw_args):
                 return None
             fargs: list[float] = [a for a in raw_args if a is not None]
@@ -1418,6 +1489,10 @@ class _ModelBuilder:
                 return math.exp(fargs[0])
             if fn == "log":
                 return math.log(fargs[0])
+            if fn == "log2":
+                return math.log2(fargs[0])
+            if fn == "log10":
+                return math.log10(fargs[0])
             if fn == "sqrt":
                 return math.sqrt(fargs[0])
             if fn == "sqr":
@@ -1430,10 +1505,90 @@ class _ModelBuilder:
                 return math.sin(fargs[0])
             if fn == "cos":
                 return math.cos(fargs[0])
+            if fn == "tan":
+                return math.tan(fargs[0])
+            if fn == "arcsin":
+                return math.asin(fargs[0])
+            if fn == "arccos":
+                return math.acos(fargs[0])
+            if fn == "arctan":
+                return math.atan(fargs[0])
+            if fn == "sinh":
+                return math.sinh(fargs[0])
+            if fn == "cosh":
+                return math.cosh(fargs[0])
+            if fn == "tanh":
+                return math.tanh(fargs[0])
+            # GAMS min/max take two or more arguments
+            if fn == "min":
+                return float(min(fargs))
+            if fn == "max":
+                return float(max(fargs))
+            if fn == "ceil":
+                return float(math.ceil(fargs[0]))
+            if fn == "floor":
+                return float(math.floor(fargs[0]))
+            if fn == "round":
+                ndigits = int(fargs[1]) if len(fargs) > 1 else 0
+                return float(round(fargs[0], ndigits))
+            if fn == "mod":
+                # GAMS mod(a, b) = a - b*trunc(a/b), which is fmod semantics
+                return float(math.fmod(fargs[0], fargs[1])) if fargs[1] != 0 else None
+            if fn == "sign":
+                return float((fargs[0] > 0) - (fargs[0] < 0))
+            if fn == "signpower":
+                a, p = fargs[0], fargs[1]
+                return float(math.copysign(abs(a) ** p, a)) if a != 0 else 0.0
+            if fn == "sigmoid":
+                return float(1.0 / (1.0 + math.exp(-fargs[0])))
+            # uniform/normal are nondeterministic and errorf's build-path
+            # mapping is unsettled — leave them unevaluable (None) so
+            # assignment sites refuse loudly instead of folding silently.
+            return None
+        if isinstance(expr, (ExprSum, ExprProd)):
+            is_sum = isinstance(expr, ExprSum)
+            index_sets = []
+            for iname in expr.index_names:
+                elems = self._lookup_set_elements(iname)
+                if elems is None:
+                    return None
+                index_sets.append(elems)
+            acc = 0.0 if is_sum else 1.0
+            for combo in itertools.product(*index_sets):
+                local_env = dict(env)
+                for iname, elem in zip(expr.index_names, combo):
+                    local_env[iname] = elem
+                if expr.dollar_cond is not None:
+                    cond = self._eval_dollar_cond(expr.dollar_cond, local_env)
+                    if cond is None:
+                        return None
+                    if cond == 0.0:
+                        continue
+                v = self._eval_const_expr_with_env(expr.body, local_env)
+                if v is None:
+                    return None
+                acc = acc + v if is_sum else acc * v
+            return acc
+        if isinstance(expr, ExprOrd):
+            sname = expr.set_name
+            if sname in env:
+                elem = env[sname]
+                elems = self._lookup_set_elements(sname)
+                if elems is not None and elem in elems:
+                    return float(elems.index(elem) + 1)
+                # Loop index named differently from its set: search all sets
+                for other in self.set_elements.values():
+                    if elem in other:
+                        return float(other.index(elem) + 1)
+            return None
         if isinstance(expr, ExprCard):
             elems = self.set_elements.get(expr.set_name, [])
             return float(len(elems))
         return None
+
+    def _eval_const_expr(self, expr) -> float | None:
+        """Evaluate a constant expression (no variables, no loop indices)."""
+        return self._eval_const_expr_with_env(expr, {})
 
     def _eval_dollar_cond(self, expr, env: dict) -> float | None:
         """Evaluate a dollar condition with loop index substitution.
@@ -1508,8 +1663,8 @@ class _ModelBuilder:
         if isinstance(expr, ExprCard):
             elems = self.set_elements.get(expr.set_name, [])
             return float(len(elems))
-        # Fallback to constant evaluation
-        return self._eval_const_expr(expr)
+        # Fallback to constant evaluation (keep the loop-index env)
+        return self._eval_const_expr_with_env(expr, env)
 
     def _create_variables(self, m):
         for name, gv in self.p.variables.items():
@@ -2151,10 +2306,18 @@ class _ModelBuilder:
                 if sn in self.set_elements:
                     index_sets.append(self.set_elements[sn])
                 else:
+                    matched = False
                     for k, v in self.set_elements.items():
                         if k.lower() == sn.lower():
                             index_sets.append(v)
+                            matched = True
                             break
+                    if not matched:
+                        # Concrete element label (e.g. ``x.l('a') = 1``):
+                        # treat as a literal single element, mirroring
+                        # _apply_bounds — previously this dimension was
+                        # dropped and idx[0] raised IndexError (#745).
+                        index_sets.append([sn])
             for combo in itertools.product(*index_sets):
                 if b.dollar_cond is not None:
                     env = dict(zip(b.domain, combo))

--- a/python/tests/test_gams.py
+++ b/python/tests/test_gams.py
@@ -405,6 +405,25 @@ class TestGamsLoopExecution:
         # Loop should set p(1)=10, p(2)=20, p(3)=30
         assert m._objective is not None
         assert len(m._constraints) == 3
+        # The loop-assigned values must actually reach the objective
+        # coefficients — asserting only the constraint count let all-zero
+        # coefficients go unnoticed (#745).
+        from discopt.modeling import core
+
+        consts = set()
+        stack = [m._objective.expression]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, core.Constant):
+                if node.value.ndim == 0:
+                    consts.add(float(node.value))
+            elif isinstance(node, core.BinaryOp):
+                stack.extend([node.left, node.right])
+            elif isinstance(node, core.UnaryOp):
+                stack.append(node.operand)
+            elif isinstance(node, core.IndexExpression):
+                stack.append(node.base)
+        assert {10.0, 20.0, 30.0} <= consts
 
 
 # ── Lag/lead tests ─────────────────────────────────────────────

--- a/python/tests/test_gams_parser_features.py
+++ b/python/tests/test_gams_parser_features.py
@@ -1,0 +1,221 @@
+"""
+Regression tests for GAMS parser silent-wrong-parse defects (#745).
+
+Covers:
+  1. Indexed parameter assignment statements (plain ``p(i) = expr`` and
+     inside ``loop(i, ...)``) must actually update the parameter store the
+     equation builder reads — previously they silently no-opped, leaving
+     all-zero coefficients.
+  2. Two-argument ``min``/``max`` in constant assignments must fold to the
+     correct value — previously the constant evaluator fell through and the
+     assignment was silently dropped (scalar kept its declared value).
+  3. Assignments the constant evaluator cannot fold must raise
+     ``GamsParseError`` loudly instead of silently building a wrong model.
+  4. A per-element level statement ``x.l('a') = 1.0`` must store the initial
+     value — previously it raised ``IndexError`` in ``_store_initial_value``.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    FunctionCall,
+    IndexExpression,
+    UnaryOp,
+)
+from discopt.modeling.gams_parser import GamsParseError, parse_gams
+
+pytestmark = pytest.mark.unit
+
+
+def _constants_in(expr) -> set[float]:
+    """Collect all scalar Constant values appearing in an expression DAG."""
+    out: set[float] = set()
+    stack = [expr]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, Constant):
+            if node.value.ndim == 0:
+                out.add(float(node.value))
+        elif isinstance(node, BinaryOp):
+            stack.extend([node.left, node.right])
+        elif isinstance(node, UnaryOp):
+            stack.append(node.operand)
+        elif isinstance(node, FunctionCall):
+            stack.extend(node.args)
+        elif isinstance(node, IndexExpression):
+            stack.append(node.base)
+    return out
+
+
+LOOP_PARAM_GMS = textwrap.dedent("""\
+    Sets i / 1*3 / ;
+    Parameter p(i) / 1 0, 2 0, 3 0 / ;
+
+    loop(i, p(i) = ord(i) * 10) ;
+
+    Positive Variables x(i) ;
+    Free Variable z ;
+
+    Equations obj_def, limit(i) ;
+    obj_def.. z =e= sum(i, p(i) * x(i)) ;
+    limit(i).. x(i) =l= 100 ;
+
+    Model ltest / all / ;
+    Solve ltest using LP minimizing z ;
+""")
+
+
+PLAIN_ASSIGN_GMS = textwrap.dedent("""\
+    Sets i / 1*3 / ;
+    Parameter p(i) ;
+    p(i) = 2 * ord(i) ;
+
+    Positive Variables x(i) ;
+    Free Variable z ;
+
+    Equations obj_def ;
+    obj_def.. z =e= sum(i, p(i) * x(i)) ;
+
+    Model ptest / all / ;
+    Solve ptest using LP minimizing z ;
+""")
+
+
+DOLLAR_ASSIGN_GMS = textwrap.dedent("""\
+    Sets i / 1*3 / ;
+    Parameter p(i) / 1 7, 2 7, 3 7 / ;
+    p(i)$(ord(i) > 1) = 100 ;
+
+    Positive Variables x(i) ;
+    Free Variable z ;
+
+    Equations obj_def ;
+    obj_def.. z =e= sum(i, p(i) * x(i)) ;
+
+    Model dtest / all / ;
+    Solve dtest using LP minimizing z ;
+""")
+
+
+MINMAX_GMS = textwrap.dedent("""\
+    Scalar s1 / 0 / ;
+    Scalar s2 / 0 / ;
+    Scalar s3 / 0 / ;
+    Scalar s4 / 0 / ;
+    s1 = 13 ;
+    s2 = min(13, 10) ;
+    s3 = min(s1, 10) ;
+    s4 = max(s1, 2) ;
+
+    Positive Variable x ;
+    Free Variable z ;
+
+    Equations obj_def ;
+    obj_def.. z =e= s2 * x + s3 * x + s4 * x ;
+
+    Model mtest / all / ;
+    Solve mtest using LP minimizing z ;
+""")
+
+
+class TestIndexedParamAssignment:
+    def test_loop_assignment_builds_parameter(self):
+        """loop(i, p(i) = ord(i)*10) must yield coefficients 10, 20, 30."""
+        m = parse_gams(LOOP_PARAM_GMS)
+        assert m._objective is not None
+        consts = _constants_in(m._objective.expression)
+        assert {10.0, 20.0, 30.0} <= consts, (
+            f"loop-assigned parameter values missing from objective: {consts}"
+        )
+
+    def test_plain_indexed_assignment_builds_parameter(self):
+        """Direct p(i) = 2*ord(i) must yield coefficients 2, 4, 6."""
+        m = parse_gams(PLAIN_ASSIGN_GMS)
+        assert m._objective is not None
+        consts = _constants_in(m._objective.expression)
+        assert {2.0, 4.0, 6.0} <= consts, (
+            f"assigned parameter values missing from objective: {consts}"
+        )
+
+    def test_dollar_conditioned_indexed_assignment(self):
+        """p(i)$(ord(i) > 1) = 100 must only overwrite elements 2 and 3."""
+        m = parse_gams(DOLLAR_ASSIGN_GMS)
+        assert m._objective is not None
+        consts = _constants_in(m._objective.expression)
+        assert {7.0, 100.0} <= consts, f"expected mixed 7/100 coefficients: {consts}"
+
+    def test_unevaluable_assignment_raises(self):
+        """An RHS the constant evaluator cannot fold must refuse loudly."""
+        src = textwrap.dedent("""\
+            Scalar s / 0 / ;
+            s = uniform(0, 1) ;
+            Free Variable z ;
+            Equations obj_def ;
+            obj_def.. z =e= s ;
+            Model utest / all / ;
+            Solve utest using LP minimizing z ;
+        """)
+        with pytest.raises(GamsParseError):
+            parse_gams(src)
+
+
+class TestScalarConstantFolding:
+    def test_scalar_constant_min_max_folding(self):
+        """min/max in constant assignments must fold, not zero out."""
+        m = parse_gams(MINMAX_GMS)
+        assert m._objective is not None
+        consts = _constants_in(m._objective.expression)
+        # s2 = min(13,10) = 10 ; s3 = min(s1,10) = 10 ; s4 = max(s1,2) = 13
+        assert 10.0 in consts, f"min() did not fold to 10: {consts}"
+        assert 13.0 in consts, f"max() did not fold to 13: {consts}"
+        assert 0.0 not in consts, f"min/max silently folded to 0: {consts}"
+
+    def test_scalar_sum_folding(self):
+        """sum(i, p(i)) in a constant assignment must fold with env."""
+        src = textwrap.dedent("""\
+            Sets i / 1*3 / ;
+            Parameter p(i) / 1 1, 2 2, 3 3 / ;
+            Scalar tot / 0 / ;
+            tot = sum(i, p(i)) ;
+
+            Positive Variable x ;
+            Free Variable z ;
+
+            Equations obj_def ;
+            obj_def.. z =e= tot * x ;
+
+            Model stest / all / ;
+            Solve stest using LP minimizing z ;
+        """)
+        m = parse_gams(src)
+        assert m._objective is not None
+        consts = _constants_in(m._objective.expression)
+        assert 6.0 in consts, f"sum() did not fold to 6: {consts}"
+
+
+class TestPerElementLevel:
+    def test_per_element_level_statement(self):
+        """x.l('a') = 1.0 must store an initial value, not raise IndexError."""
+        src = textwrap.dedent("""\
+            Sets i / a, b / ;
+            Positive Variables x(i) ;
+            Free Variable z ;
+
+            Equations obj_def ;
+            obj_def.. z =e= sum(i, x(i)) ;
+
+            x.l('a') = 1.0 ;
+
+            Model itest / all / ;
+            Solve itest using LP minimizing z ;
+        """)
+        m = parse_gams(src)
+        initial = getattr(m, "_gams_initial_values", None)
+        assert initial is not None
+        assert initial["x"][0] == 1.0
+        assert 1 not in initial["x"]


### PR DESCRIPTION
## Summary

Closes #745. Fixes two silent-wrong-parse defects in `discopt.modeling.gams_parser` (plus the related minor `IndexError`):

1. **Indexed parameter assignments now execute.** A shared `_apply_param_assign` handles both top-level `p(i) = expr` (previously dropped entirely — `_resolve_parameters` only processed scalar targets) and loop-body assignments, iterating free domain positions over set elements, binding loop indices, and honoring `$`-conditions. The constant evaluator is unified into one env-aware recursion, so compound expressions like `ord(i) * 10` fold correctly inside loops (previously the env was lost at the first binop and the assignment silently no-opped, leaving all-zero coefficients).
2. **`min`/`max` fold in constant assignments** (n-ary, per GAMS semantics), along with the other deterministic intrinsics the parser already accepted (`log2`, `log10`, `tan`, arc-trig, hyperbolics, `ceil`, `floor`, `round`, `mod`, `sign`, `signpower`, `sigmoid`) and `sum`/`prod` folding with the env.
3. **Loud refusal replaces silent wrongness**: an assignment whose RHS or `$`-condition cannot be evaluated (e.g. `uniform(0,1)`) now raises `GamsParseError` instead of silently building a model with stale/zero coefficients (CLAUDE.md §3 — no silent approximations).
4. **`x.l('a') = 1.0` stores the initial value** instead of raising `IndexError` in `_store_initial_value`, via the same literal-element fallback `_apply_bounds` already used (X-2, #413).

## Correctness

- [x] Cannot produce a false certificate (or: N/A — no solver-math change) — parser-only change; no bound, cut, or relaxation math touched. The change makes parsed models *match their GAMS source* (correct coefficients) or refuse loudly; it cannot loosen a bound.
- [x] No validation, fallback, or safety guard was weakened to make a check pass — the change adds a refusal (unevaluable assignments now raise instead of silently no-opping).

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 614 passed, 52 failed, 27 skipped. The 52 failures are container-environment (missing `pounce` NLP backend etc.): rerunning **exactly those 52 tests with the pre-fix parser produces an identical failure list** (diff: IDENTICAL). None of the failing files exercise the GAMS parser.
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 8 passed, 2 failed (`test_oa_maximize_synthetic_concave`, `test_large_dense_jacobian_no_crash`); both use `.nl`/programmatic models (no GAMS parser) and fail identically with the pre-fix parser (missing `pounce`).
- [x] `pytest python/tests/test_gams.py python/tests/test_gams_parser_features.py python/tests/test_gams_link.py python/tests/test_modeling_tail_m4_m8.py` → 119 passed, 2 skipped, 5 failed — the 5 are the known `pounce`-dependent solve tests, identical without the fix.
- [x] `cargo test -p discopt-core` → N/A — no Rust touched.
- [x] `ruff check` / `ruff format --check` clean (ruff 0.14.6) on all touched files.

## Regression test

- [x] Added `python/tests/test_gams_parser_features.py` (7 tests): `test_loop_assignment_builds_parameter`, `test_plain_indexed_assignment_builds_parameter`, `test_dollar_conditioned_indexed_assignment`, `test_unevaluable_assignment_raises`, `test_scalar_constant_min_max_folding`, `test_scalar_sum_folding`, `test_per_element_level_statement` — **all 7 fail on the base commit and pass with the fix** (verified by stashing the parser change). Also strengthened the fixture test #745 called out (`test_loop_sets_param_values`) to assert the loop-assigned coefficients 10/20/30 actually reach the objective, not just the constraint count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkgFcZfHvy9cabcgoBEnMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkgFcZfHvy9cabcgoBEnMT)_