### PR TITLE
fix(correctness): #748 route MILP/MIQP with callbacks to spatial B&B

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2100,10 +2100,24 @@ def _invoke_pre_import_callbacks(
        an incumbent). The cuts will tighten subsequent relaxations.
     2. Call ``incumbent_callback``. If it returns False, mark the node as
        infeasible.
+
+    Returns the number of nodes rejected (by a lazy cut or an incumbent-callback
+    ``False``). A rejection sentinels a node whose relaxation is genuinely
+    FEASIBLE, so it is a *non-rigorous* fathom (issue #748): the removed region
+    is not proven to contain no acceptable point — the callback merely excluded
+    the specific integer point found. The caller must therefore flag
+    ``_nonrigorous_fathom`` so a tree that later exhausts with no accepted
+    incumbent reports ``unknown`` (feasibility undetermined) rather than falsely
+    certifying ``infeasible``. Without this, a pure-MILP whose LP-relaxation root
+    is already integer-optimal but callback-rejected (nothing left to branch)
+    certified a FALSE infeasibility (CLAUDE.md §1). This runs AFTER the batch's
+    own non-rigorous-sentinel sweep, so the caller must account for these
+    rejections separately.
     """
     from discopt._jax.cutting_planes import LinearCut
     from discopt.callbacks import CallbackContext, cut_result_to_dense
 
+    n_rejected = 0
     incumbent_info = tree.incumbent()
     inc_obj = None
     if incumbent_info is not None:
@@ -2173,6 +2187,7 @@ def _invoke_pre_import_callbacks(
                 # fail, the point the cuts exclude must never be accepted as an
                 # incumbent. This assignment precedes any fallible cut math.
                 result_lbs[i] = _INFEASIBILITY_SENTINEL
+                n_rejected += 1
                 for cut in cuts:
                     coeffs, rhs, sense = cut_result_to_dense(cut, model)
                     _cut_pool.add(LinearCut(coeffs=coeffs, rhs=rhs, sense=sense))
@@ -2195,10 +2210,13 @@ def _invoke_pre_import_callbacks(
                 accept = None
             if accept is False:
                 result_lbs[i] = _INFEASIBILITY_SENTINEL
+                n_rejected += 1
                 logger.info(
                     "Incumbent callback rejected solution at node %d",
                     int(result_ids[i]),
                 )
+
+    return n_rejected
 
 
 def _screen_heuristic_incumbent(
@@ -5467,53 +5485,73 @@ def solve_model(
             else:
                 return _solve_qp(model, t_start, prefer_pounce=nlp_solver == "pounce")
         elif problem_class == ProblemClass.MILP:
-            # Warm-started-simplex engine (nlp_solver="simplex"): the whole MILP
-            # B&B runs in Rust with dual-warm-started simplex node solves. Opt-in;
-            # falls through to the default path if unavailable.
-            if nlp_solver == "simplex":
-                if lagrangian_bound:
-                    logger.warning(
-                        "lagrangian_bound is ignored with nlp_solver='simplex' (the "
-                        "monolithic Rust MILP engine has no per-node hook); use the "
-                        "default nlp_solver='pounce' MILP path to enable it."
+            # #748: the specialized MILP engines (``_solve_milp_simplex`` /
+            # ``_solve_milp_bb``) do not receive or consult ``lazy_constraints``
+            # / ``incumbent_callback``, so a callback-rejected or cut-off
+            # integer-feasible point would be silently accepted as the incumbent
+            # — a soundness bug for lazy constraints (the callback defines the
+            # true feasible set) and an API-contract violation for an incumbent
+            # rejection. When either callback is present, do NOT dispatch to the
+            # specialized engine: fall through (no return) to the spatial
+            # McCormick Branch-and-Bound path below, which honors both callbacks
+            # (#740) — the same fall-through the nonconvex-MIQP branch and the
+            # NLP-BB auto-select already take. Trades the specialized engine's
+            # speed for correctness (CLAUDE.md §1). This mirrors the #740 fix on
+            # the spatial path.
+            if lazy_constraints is None and incumbent_callback is None:
+                # Warm-started-simplex engine (nlp_solver="simplex"): the whole MILP
+                # B&B runs in Rust with dual-warm-started simplex node solves. Opt-in;
+                # falls through to the default path if unavailable.
+                if nlp_solver == "simplex":
+                    if lagrangian_bound:
+                        logger.warning(
+                            "lagrangian_bound is ignored with nlp_solver='simplex' (the "
+                            "monolithic Rust MILP engine has no per-node hook); use the "
+                            "default nlp_solver='pounce' MILP path to enable it."
+                        )
+                    _simplex_res = _solve_milp_simplex(
+                        model,
+                        time_limit,
+                        gap_tolerance,
+                        max_nodes,
+                        t_start,
+                        initial_point=initial_point,
                     )
-                _simplex_res = _solve_milp_simplex(
+                    if _simplex_res is not None:
+                        return _simplex_res
+                # POUNCE-only mode (nlp_solver="pounce", the universal default)
+                # routes to the self-hosted B&B and bypasses HiGHS entirely. An
+                # interior-point method is the wrong tool for the *linear* node LPs
+                # (no warm-start across branches, interior smearing, no basis), so
+                # the per-node engine defaults to the exact-vertex warm-started
+                # **simplex** (node_engine="simplex"); it degrades to the POUNCE IPM
+                # node path inside _solve_milp_bb if the simplex binding is absent.
+                # The B&B itself is sound, runs the continuous-repair root dive for
+                # an early incumbent, recovers stalled nodes, and reduced-cost-fixes.
+                _pounce_only = nlp_solver == "pounce"
+                return _solve_milp_bb(
                     model,
                     time_limit,
                     gap_tolerance,
+                    batch_size,
+                    strategy,
                     max_nodes,
                     t_start,
-                    initial_point=initial_point,
+                    prefer_pounce=_pounce_only,
+                    # Node LP relaxations are linear — always solve them with the
+                    # structured engine (exact-vertex Rust simplex, degrading to
+                    # POUNCE), regardless of nlp_solver. nlp_solver governs only the
+                    # NLP subproblem solver. The JAX LP-IPM node path was retired (#370).
+                    node_engine="simplex",
+                    lagrangian_bound=lagrangian_bound,
+                    lagrangian_frequency=lagrangian_frequency,
                 )
-                if _simplex_res is not None:
-                    return _simplex_res
-            # POUNCE-only mode (nlp_solver="pounce", the universal default)
-            # routes to the self-hosted B&B and bypasses HiGHS entirely. An
-            # interior-point method is the wrong tool for the *linear* node LPs
-            # (no warm-start across branches, interior smearing, no basis), so
-            # the per-node engine defaults to the exact-vertex warm-started
-            # **simplex** (node_engine="simplex"); it degrades to the POUNCE IPM
-            # node path inside _solve_milp_bb if the simplex binding is absent.
-            # The B&B itself is sound, runs the continuous-repair root dive for
-            # an early incumbent, recovers stalled nodes, and reduced-cost-fixes.
-            _pounce_only = nlp_solver == "pounce"
-            return _solve_milp_bb(
-                model,
-                time_limit,
-                gap_tolerance,
-                batch_size,
-                strategy,
-                max_nodes,
-                t_start,
-                prefer_pounce=_pounce_only,
-                # Node LP relaxations are linear — always solve them with the
-                # structured engine (exact-vertex Rust simplex, degrading to
-                # POUNCE), regardless of nlp_solver. nlp_solver governs only the
-                # NLP subproblem solver. The JAX LP-IPM node path was retired (#370).
-                node_engine="simplex",
-                lagrangian_bound=lagrangian_bound,
-                lagrangian_frequency=lagrangian_frequency,
+            logger.info(
+                "MILP with a lazy_constraints/incumbent_callback — routing to spatial "
+                "Branch-and-Bound (the specialized MILP engine cannot honor these "
+                "callbacks; #748)"
             )
+            # Fall through to the spatial/McCormick path below.
         elif problem_class == ProblemClass.MIQP:
             # A convex MIQP may use the convex MIQP B&B; a NONCONVEX one must
             # NOT. `_solve_miqp_bb` assumes a convex node QP (a convex relaxation
@@ -5534,25 +5572,41 @@ def solve_model(
                 _root_constraint_mask,
             ) = _classify_model_convexity(model, failure_label="MIQP convexity detection failed")
             if _root_convexity_known and _root_is_convex:
-                # Convex MIQP via discopt's own self-hosted B&B (POUNCE node QP
-                # relaxations) — HiGHS-free by design (issue #359 / pure-Rust
-                # goal). The convex node QP is solved to global optimality, so the
-                # B&B bound is valid.
-                return _solve_miqp_bb(
-                    model,
-                    time_limit,
-                    gap_tolerance,
-                    batch_size,
-                    strategy,
-                    max_nodes,
-                    t_start,
-                    prefer_pounce=True,
+                # #748: the convex MIQP B&B (``_solve_miqp_bb``) does not receive
+                # or consult ``lazy_constraints`` / ``incumbent_callback``, so a
+                # callback-rejected or cut-off integer point would be silently
+                # accepted (soundness bug for lazy constraints; API violation for
+                # incumbent rejection). When either callback is present, fall
+                # through (no return) to the spatial McCormick Branch-and-Bound
+                # path below, which honors both (#740) — same as the nonconvex
+                # MIQP branch. Trades speed for correctness (CLAUDE.md §1).
+                if lazy_constraints is None and incumbent_callback is None:
+                    # Convex MIQP via discopt's own self-hosted B&B (POUNCE node QP
+                    # relaxations) — HiGHS-free by design (issue #359 / pure-Rust
+                    # goal). The convex node QP is solved to global optimality, so the
+                    # B&B bound is valid.
+                    return _solve_miqp_bb(
+                        model,
+                        time_limit,
+                        gap_tolerance,
+                        batch_size,
+                        strategy,
+                        max_nodes,
+                        t_start,
+                        prefer_pounce=True,
+                    )
+                logger.info(
+                    "Convex MIQP with a lazy_constraints/incumbent_callback — routing "
+                    "to spatial Branch-and-Bound (the convex MIQP engine cannot honor "
+                    "these callbacks; #748)"
                 )
-            logger.info(
-                "Nonconvex MIQP detected — routing to spatial Branch-and-Bound "
-                "(convex MIQP solvers would certify a local stationary point)"
-            )
-            # Fall through to the spatial/McCormick path below.
+                # Fall through to the spatial/McCormick path below.
+            else:
+                logger.info(
+                    "Nonconvex MIQP detected — routing to spatial Branch-and-Bound "
+                    "(convex MIQP solvers would certify a local stationary point)"
+                )
+                # Fall through to the spatial/McCormick path below.
 
     # --- Materialize builder-resident linear constraint rows (issue #681) ---
     # The fast-construction API (``add_linear_constraints`` / the
@@ -9367,7 +9421,7 @@ def solve_model(
 
         # --- User callbacks: lazy constraints and incumbent filtering ---
         if lazy_constraints is not None or incumbent_callback is not None:
-            _invoke_pre_import_callbacks(
+            _n_cb_rejected = _invoke_pre_import_callbacks(
                 model=model,
                 tree=tree,
                 t_start=t_start,
@@ -9384,6 +9438,20 @@ def solve_model(
                 _cut_pool=_cut_pool,
                 tree_bound_valid=_gap_certified,
             )
+            # #748: a callback rejection sentinels a FEASIBLE node without proving
+            # its region empty of acceptable points — a non-rigorous fathom. It is
+            # applied here, AFTER the batch's own non-rigorous-sentinel sweep
+            # (which cannot see these late sentinels), so record it now. This
+            # prevents a tree that later drains with no accepted incumbent from
+            # falsely certifying "infeasible": the terminal logic routes a
+            # non-rigorous exhaustion to "unknown" (feasibility undetermined)
+            # instead (the tight-integer-root pure-MILP case where the callback
+            # rejects the LP-optimal root and nothing remains to branch). It does
+            # NOT touch _taint_floor_internal, so a solve that DOES find an
+            # accepted incumbent and closes its frontier gap still certifies as
+            # before — only the no-incumbent false-infeasible is corrected.
+            if _n_cb_rejected:
+                _nonrigorous_fathom = True
 
         # Convex-objective node bound (applied at the single point every node's
         # bound funnels through, so it covers all upstream paths). When the

--- a/python/tests/test_callbacks.py
+++ b/python/tests/test_callbacks.py
@@ -826,3 +826,168 @@ class TestCallbackBoundSoundness:
                 assert b <= res.bound + 1e-4, (
                     f"callback best_bound {b} over-reports the final certified bound {res.bound}"
                 )
+
+
+# ── #748: MILP / convex-MIQP classifier dispatch honors callbacks ──
+
+
+def _pure_milp_748():
+    """Pure MILP (no exp() forcing) classified ``ProblemClass.MILP``.
+
+    min x + 10*y   s.t.  3*x + 2*y >= 5,   x,y integer in [0,3].
+
+    The LP relaxation root is fractional (x=5/3, y=0) so B&B branches and the
+    UNIQUE integer optimum is x=2, y=0 (obj 2.0). A callback that rejects x>=2
+    must drive the solve to the acceptable optimum x=1, y=1 (obj 11.0).
+
+    Pre-#748 this model routed to ``_solve_milp_bb`` (or ``_solve_milp_simplex``),
+    which never consulted the callback and returned the vetoed x=2 point as
+    ``optimal`` — the silent-drop bug. After the fix it falls through to the
+    spatial B&B, which honors the callback.
+    """
+    m = discopt.Model("milp748")
+    x = m.integer("x", lb=0, ub=3)
+    y = m.integer("y", lb=0, ub=3)
+    m.minimize(x + 10 * y)
+    m.subject_to(3 * x + 2 * y >= 5, name="c")
+    return m, x, y
+
+
+def _convex_miqp_748():
+    """Convex MIQP (no exp() forcing) classified ``ProblemClass.MIQP``.
+
+    min (x - 2.2)**2 + 3*y   s.t.  x + y >= 1,   x integer in [0,3], y binary.
+
+    Convex quadratic objective, fractional QP root (x=2.2) so B&B branches; the
+    UNIQUE integer optimum is x=2, y=0 (obj 0.04). A callback rejecting exactly
+    x==2 drives the solve to the acceptable optimum x=3, y=0 (obj 0.64) — which
+    is the QP-integer-optimum of the x>=3 branch, so the convex spatial B&B
+    reaches it.
+
+    Pre-#748 this routed to ``_solve_miqp_bb`` (convex MIQP B&B) which never
+    consulted the callback and returned the vetoed x=2 point as ``optimal``.
+    """
+    m = discopt.Model("miqp748")
+    x = m.integer("x", lb=0, ub=3)
+    y = m.binary("y")
+    m.minimize((x - 2.2) ** 2 + 3 * y)
+    m.subject_to(x + y >= 1, name="c")
+    return m, x, y
+
+
+@pytest.mark.slow
+@needs_rust
+@pytest.mark.integration
+class TestIssue748MilpMiqpCallbackDispatch:
+    """#748: the problem-classifier dispatch routed a MILP / convex-MIQP model
+    with ``incumbent_callback`` / ``lazy_constraints`` to specialized engines
+    (``_solve_milp_simplex`` / ``_solve_milp_bb`` / ``_solve_miqp_bb``) that never
+    received or consulted the callbacks — the rejection/cut was dropped SILENTLY
+    and the vetoed/cut-off point was returned as ``optimal`` (a soundness bug for
+    lazy constraints; an API violation for incumbent rejection). The fix routes
+    these models to the spatial B&B (which honors both callbacks, #740) when a
+    callback is present. These use PURE MILP / convex MIQP models (NO ``exp()``)
+    so they exercise the newly-fixed dispatch; the pre-existing tests all add an
+    ``exp()`` term to force MINLP classification and dodge this path.
+    """
+
+    @staticmethod
+    def _x(sol):
+        return round(float(np.ravel(sol["x"])[0]))
+
+    def test_milp_incumbent_callback_honored(self):
+        """Pure MILP + rejecting incumbent_callback: the vetoed x>=2 optimum
+        (returned by the MILP engine pre-fix) must NOT be the incumbent."""
+        m, _x, _y = _pure_milp_748()
+
+        def reject_x_ge_2(ctx, model, sol):
+            return float(np.ravel(sol["x"])[0]) <= 1.5
+
+        res = m.solve(incumbent_callback=reject_x_ge_2, time_limit=60)
+        assert res.status in ("optimal", "feasible")
+        assert res.x is not None
+        xv = round(float(np.ravel(res.x["x"])[0]))
+        assert xv <= 1, f"vetoed x={xv} (>=2) returned as incumbent (obj {res.objective})"
+        assert res.objective == pytest.approx(11.0, rel=1e-3)
+
+    def test_milp_lazy_constraint_honored(self):
+        """Pure MILP + lazy cut x<=1: the cut-off x>=2 optimum must NOT be the
+        returned incumbent."""
+        m, x, _y = _pure_milp_748()
+
+        def lazy_cut(ctx, model):
+            if round(float(ctx.x_relaxation[0])) >= 2:
+                return [CutResult(terms=[(x, 1.0)], sense="<=", rhs=1.0)]
+            return []
+
+        res = m.solve(lazy_constraints=lazy_cut, time_limit=60)
+        assert res.status in ("optimal", "feasible")
+        assert res.x is not None
+        xv = round(float(np.ravel(res.x["x"])[0]))
+        assert xv <= 1, f"cut-off x={xv} (>=2) returned as incumbent (obj {res.objective})"
+        assert res.objective == pytest.approx(11.0, rel=1e-3)
+
+    def test_convex_miqp_incumbent_callback_honored(self):
+        """Convex MIQP + rejecting incumbent_callback: the vetoed x==2 optimum
+        (returned by the convex MIQP engine pre-fix) must NOT be the incumbent;
+        the solve must reach the acceptable x=3 optimum instead."""
+        m, _x, _y = _convex_miqp_748()
+
+        def reject_x_eq_2(ctx, model, sol):
+            return self._x(sol) != 2
+
+        res = m.solve(incumbent_callback=reject_x_eq_2, time_limit=60)
+        assert res.status in ("optimal", "feasible")
+        assert res.x is not None
+        xv = round(float(np.ravel(res.x["x"])[0]))
+        assert xv != 2, f"vetoed x=2 returned as incumbent (obj {res.objective})"
+        assert res.objective == pytest.approx(0.64, rel=1e-3)
+
+    def test_milp_no_callback_unchanged(self):
+        """Sanity: a pure MILP WITHOUT callbacks still solves to its true
+        optimum (the specialized engine path is unchanged)."""
+        m, _x, _y = _pure_milp_748()
+        res = m.solve(time_limit=60)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(2.0, rel=1e-3)
+        assert round(float(np.ravel(res.x["x"])[0])) == 2
+
+    def test_convex_miqp_no_callback_unchanged(self):
+        """Sanity: a convex MIQP WITHOUT callbacks still solves to its true
+        optimum (the convex MIQP engine path is unchanged)."""
+        m, _x, _y = _convex_miqp_748()
+        res = m.solve(time_limit=60)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(0.04, abs=1e-3)
+        assert round(float(np.ravel(res.x["x"])[0])) == 2
+
+    def test_reproduction_sketch_never_returns_vetoed_point(self):
+        """The issue's exact reproduction sketch (a tight-integer-root MILP whose
+        LP relaxation is already integer-optimal). Pre-fix it silently returned
+        the vetoed x=1 point certified ``optimal``. After the fix the vetoed
+        point is never returned: because the rejected root leaves nothing to
+        branch, the spatial B&B reports an honest UNCERTIFIED result
+        (feasibility undetermined) rather than either the vetoed point OR a
+        certified-false ``infeasible`` — the callback rejection is a non-rigorous
+        fathom, so certification is withheld (#748 / CLAUDE.md §1)."""
+        m = discopt.Model("milp748_sketch")
+        x = m.binary("x")
+        y = m.binary("y")
+        m.minimize(x + 2 * y)
+        m.subject_to(x + y >= 1)
+
+        res = m.solve(
+            incumbent_callback=lambda ctx, model, sol: float(sol["x"]) < 0.5,
+            time_limit=30,
+        )
+        # The vetoed x=1 point must never be returned as the incumbent.
+        if res.x is not None:
+            assert round(float(np.ravel(res.x["x"])[0])) == 0, (
+                f"vetoed x=1 point returned as incumbent (status {res.status})"
+            )
+        # And a feasible model must never be CERTIFIED infeasible (a false
+        # certificate is the worst-class error; the pre-backstop code returned
+        # exactly this).
+        assert not (res.status == "infeasible" and res.gap_certified), (
+            "feasible model falsely certified infeasible"
+        )


### PR DESCRIPTION
## Summary

Closes #748.

A model classified as **MILP** or **convex MIQP** with `incumbent_callback` or `lazy_constraints` attached was routed by the problem-classifier dispatch in `solve_model` to the specialized engines (`_solve_milp_simplex` / `_solve_milp_bb` / `_solve_miqp_bb`), none of which receive or consult these callbacks. The callbacks were dropped **silently** — the returned incumbent could be a point the user's callback vetoed or whose lazy cuts exclude it, yet reported `optimal`. For `lazy_constraints` this is a soundness bug (the callback defines the true feasible set); for `incumbent_callback` it violates the documented "return `False` to reject" API.

The fix follows Option 2 from the issue (the precedent the NLP-BB auto-select and nonconvex-MIQP branch already use): when either callback is present, the MILP / convex-MIQP dispatch **falls through** (no return) to the spatial McCormick Branch-and-Bound path, which honors both callbacks (#740). This trades the specialized engine's speed for correctness (CLAUDE.md §1) only when a callback is actually attached; callback-free solves are byte-unchanged.

A companion guard on the spatial path: `_invoke_pre_import_callbacks` now returns the number of callback-rejected nodes, and the batch loop sets `_nonrigorous_fathom = True` when any rejection occurs. A callback rejection sentinels a *feasible* node without proving its region empty, so a tree that then exhausts with no accepted incumbent (e.g. a tight-integer-root MILP whose LP-optimal root is rejected with nothing left to branch) now reports `unknown` instead of a **false `infeasible`** certificate.

## Correctness

- [x] Cannot produce a false certificate (or: N/A — no solver-math change) — the change removes two silent-wrong-answer paths and adds a guard against a false `infeasible`; the fall-through target (spatial B&B) already enforces both callbacks soundly (#740).
- [x] No validation, fallback, or safety guard was weakened to make a check pass

The `_nonrigorous_fathom` addition only affects certification when either (a) an incumbent is found but `_gap_certified` is already `False` (the conservative taint-recovery block, which still requires a rigorous converged bound to upgrade), or (b) no incumbent is found (routes a non-rigorous exhaustion to `unknown`). A normally-certified incumbent solve is unaffected.

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 671 passed, 13 skipped, 0 failed (183s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 9 passed; `test_large_dense_jacobian_no_crash` flaked once on a deadline overrun under back-to-back load (8s solve budget + 40s margin) and **passes in isolation** (24s). That model has no callbacks and is not MILP/MIQP-classified, so this change cannot affect it.
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)
- [x] `ruff check` / `ruff format --check` clean

Also: full `test_callbacks.py` → 45 passed; classification/dispatch/convexity tests → 44 passed.

## Regression test

Added `TestIssue748MilpMiqpCallbackDispatch` (6 tests) in `python/tests/test_callbacks.py`, using **pure MILP / convex-MIQP models with no `exp()` forcing** so they exercise the newly-fixed classifier dispatch (existing callback tests add an `exp()` term to force MINLP classification and dodge this path):

- `test_milp_incumbent_callback_honored`, `test_milp_lazy_constraint_honored`, `test_convex_miqp_incumbent_callback_honored`, `test_reproduction_sketch_never_returns_vetoed_point` — **fail before / pass after** (verified by stashing the `solver.py` change: 4 failed, 2 passed).
- `test_milp_no_callback_unchanged`, `test_convex_miqp_no_callback_unchanged` — pass before and after (no behavior change without callbacks).

- [x] Added a regression test that fails before / passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012vgFGKsSH1t7G6ZBrngroX)_