### PR TITLE
feat(#732): Stage 1 narrow-box branch-instead-of-taint + conditioning fix

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -378,7 +378,13 @@ class MilpRelaxationModel:
             if (
                 _nz.size
                 and np.isfinite(_nz).all()
-                and _nz.max() / _nz.min() > _RELAX_FALSE_INFEAS_TRIGGER
+                # Cross-multiplied form of ``max/min > TRIGGER``: identical boolean
+                # (``min > 0`` after the zero-filter), but on the ill-conditioned
+                # narrow/RLT boxes this guard exists for — coefficient spreads of
+                # ~1e26 over ~1e-300 denormals — the division overflows to ``inf``
+                # (a spurious RuntimeWarning), whereas ``TRIGGER * min`` cannot
+                # overflow (#732 Stage 1-B).
+                and _nz.max() > _RELAX_FALSE_INFEAS_TRIGGER * _nz.min()
             ):
                 c_s, A_s, b_s, bounds_s, col_scale = equilibrate_relaxation_lp(
                     self._c, self._A_ub, self._b_ub, self._bounds, self._integrality

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7093,6 +7093,52 @@ def solve_model(
     iteration = 0
     _deadline = t_start + time_limit
 
+    # --- #732 Stage 1-A: narrow-box branch-instead-of-taint --------------------
+    # (``DISCOPT_NARROW_BOX_BRANCH``, default OFF — bound-changing, awaits the §5
+    # graduation panel.) A nonconvex node whose relaxation LP fails numerically
+    # (the failure sentinel) is normally fathomed *non-rigorously*, which taints
+    # the tree's certified dual bound: its unproven subtree is dropped from the
+    # frontier, so the reported global bound is discarded (ex1252: the internal
+    # bound reaches the optimum yet the report collapses to ~0). When the flag is
+    # ON and the failed node's box is still spatially branchable, keep it OPEN
+    # instead — import ``-inf`` so the Rust child floor lifts it to the node's
+    # rigorous parent-inherited bound, and the brancher bisects it; its children
+    # re-solve on narrower, better-conditioned boxes (the probe shows the LP
+    # succeeds once the box shrinks). This reuses the sound "-inf stays open,
+    # floored at parent" mechanism the deadline path uses (#138).
+    #
+    # SOUNDNESS: convert ONLY a *branchable* node. An unbranchable node kept open
+    # would dead-end unbranched and could falsely certify (the #467 hazard), so a
+    # failed node below the spatial-branch width stays a (honest) sentinel fathom.
+    # The threshold is 2x the Rust brancher's ``SPATIAL_MIN_WIDTH`` (1e-6 relative),
+    # so a converted node is unambiguously above the width the brancher will split.
+    _narrow_box_branch = os.environ.get("DISCOPT_NARROW_BOX_BRANCH", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    _nbb_root_width = _root_ub_snapshot - _root_lb_snapshot
+    _nbb_int_mask = np.zeros(n_vars, dtype=bool)
+    for _off, _sz in zip(int_offsets, int_sizes):
+        _nbb_int_mask[int(_off) : int(_off) + int(_sz)] = True
+    _NBB_MIN_REL_WIDTH = 2e-6
+
+    def _nbb_is_branchable(_nlb, _nub) -> bool:
+        """Conservative: True iff some CONTINUOUS dimension is still wide enough for
+        the spatial brancher to split (relative width > 2x SPATIAL_MIN_WIDTH).
+        Integer-only branchability is deliberately excluded to stay conservative —
+        a false positive here risks a dead-end false certificate (#467)."""
+        _w = np.asarray(_nub, dtype=np.float64) - np.asarray(_nlb, dtype=np.float64)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            _rel = np.where(
+                (~_nbb_int_mask) & np.isfinite(_nbb_root_width) & (_nbb_root_width > 1e-15),
+                _w / _nbb_root_width,
+                0.0,
+            )
+        _rel = np.where(np.isfinite(_rel), _rel, 0.0)
+        return bool(np.any(_rel > _NBB_MIN_REL_WIDTH))
+
     # --- TX1: adaptive back-off for the strided in-tree node NLP -------------
     # DISCOPT_ADAPTIVE_NLP (default ON since G2, flag-graduation; =0 restores the
     # fixed stride). The strided node-NLP is
@@ -8423,6 +8469,17 @@ def solve_model(
         _taint_pop_lbs = None
         for i in range(n_batch):
             if result_lbs[i] >= _SENTINEL_THRESHOLD and not node_infeasible_mask[i]:
+                # #732 Stage 1-A: keep a branchable failed node OPEN (rigorous
+                # parent floor via the -inf import) instead of a taint-inducing
+                # non-rigorous fathom. Only when branchable — an unbranchable node
+                # kept open could dead-end unbranched and falsely certify (#467).
+                if _narrow_box_branch and _nbb_is_branchable(batch_lb[i], batch_ub[i]):
+                    result_lbs[i] = -np.inf
+                    result_feas[i] = False
+                    _lbc = np.clip(np.asarray(batch_lb[i], dtype=np.float64), -_SPC, _SPC)
+                    _ubc = np.clip(np.asarray(batch_ub[i], dtype=np.float64), -_SPC, _SPC)
+                    result_sols[i] = 0.5 * (_lbc + _ubc)
+                    continue
                 _nonrigorous_fathom = True
                 if _taint_pop_lbs is None:
                     _taint_pop_lbs = np.asarray(

--- a/python/tests/test_732_narrow_box_branch.py
+++ b/python/tests/test_732_narrow_box_branch.py
@@ -1,0 +1,96 @@
+"""#732 Stage 1 — narrow-box branch-instead-of-taint (``DISCOPT_NARROW_BOX_BRANCH``).
+
+A nonconvex node whose relaxation LP fails numerically on a narrow/pinned box is
+normally fathomed *non-rigorously*, which taints the tree's certified dual bound
+and forces it to be discarded (ex1252: the internal frontier reaches the optimum
+yet the reported bound collapses to ~0). With the flag ON, a *branchable* failed
+node is kept OPEN at its rigorous parent-inherited bound and bisected instead, so
+its children re-solve on narrower, better-conditioned boxes.
+
+Soundness is the point of the flag: it must never report a dual bound above the
+true optimum (a false certificate), and it must be byte-identical when OFF.
+"""
+
+from __future__ import annotations
+
+import os
+
+import discopt.modeling as dm
+import pytest
+
+_EX1252 = "python/tests/data/minlplib/ex1252.nl"
+_EX1252_OPT = 128893.741
+
+
+def _solve(nl_or_model, *, nbb: str, rlt: str = "0", time_limit: float = 60.0):
+    prev_nbb = os.environ.get("DISCOPT_NARROW_BOX_BRANCH")
+    prev_rlt = os.environ.get("DISCOPT_MULTILINEAR_COUPLING_RLT")
+    os.environ["DISCOPT_NARROW_BOX_BRANCH"] = nbb
+    os.environ["DISCOPT_MULTILINEAR_COUPLING_RLT"] = rlt
+    try:
+        model = dm.from_nl(nl_or_model) if isinstance(nl_or_model, str) else nl_or_model
+        return model.solve(time_limit=time_limit)
+    finally:
+        for k, v in (
+            ("DISCOPT_NARROW_BOX_BRANCH", prev_nbb),
+            ("DISCOPT_MULTILINEAR_COUPLING_RLT", prev_rlt),
+        ):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _tiny_nonconvex():
+    """A small well-conditioned nonconvex model with no narrow-box LP failures,
+    so the flag is inert on it (ON must equal OFF exactly)."""
+    m = dm.Model()
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    m.subject_to(x * y >= 1.0)
+    m.minimize(x * y + x * x + y * y)
+    return m
+
+
+def test_flag_off_and_on_byte_identical_on_clean_model():
+    """No narrow-box failure -> the flag changes nothing: same node_count and
+    objective ON vs OFF. Guards the OFF path's inertness."""
+    off = _solve(_tiny_nonconvex(), nbb="0", time_limit=30)
+    on = _solve(_tiny_nonconvex(), nbb="1", time_limit=30)
+    assert off.node_count == on.node_count
+    assert (off.objective is None) == (on.objective is None)
+    if off.objective is not None:
+        assert off.objective == pytest.approx(on.objective, abs=1e-6, rel=1e-6)
+    assert (off.bound is None) == (on.bound is None)
+    if off.bound is not None and on.bound is not None:
+        assert off.bound == pytest.approx(on.bound, abs=1e-6, rel=1e-6)
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not os.path.exists(_EX1252),
+    reason="ex1252.nl corpus file not present",
+)
+def test_ex1252_untaints_soundly():
+    """Before #732 Stage 1-A, ex1252 (coupling-RLT ON) reports a discarded ~0 dual
+    bound because narrow-box LP failures taint the tree. With the flag ON the bound
+    is a real, rigorous value again — and must remain SOUND (never above the true
+    optimum). This is the fails-before / passes-after regression."""
+    r = _solve(_EX1252, nbb="1", rlt="1", time_limit=90)
+    tol = 1e-3 * (1 + abs(_EX1252_OPT))
+
+    # Un-tainted: the reported dual bound is a real positive number, not the
+    # ~0 / discarded sentinel the taint path produced before the fix.
+    assert r.bound is not None, "flag ON must surface a rigorous dual bound"
+    assert r.bound > 1.0, f"bound {r.bound} still looks discarded (taint not removed)"
+
+    # SOUND (non-negotiable): the dual bound never exceeds the true optimum.
+    assert r.bound <= _EX1252_OPT + tol, (
+        f"FALSE CERTIFICATE: bound {r.bound} > oracle {_EX1252_OPT}"
+    )
+
+    # Any incumbent found is a genuine feasible point (>= the optimum).
+    if r.objective is not None:
+        assert r.objective >= _EX1252_OPT - tol, (
+            f"incumbent {r.objective} below oracle {_EX1252_OPT}"
+        )


### PR DESCRIPTION
## Summary

Contributes to #732 (Stage 1 — engine hardening on narrow/pinned boxes, the P0 prerequisite for certifying the gated-configuration MINLP class). Two changes, one default-OFF flag plus one bound-neutral conditioning fix, grounded in the entry-experiment measurements recorded on the issue.

### Root cause (measured, [#732 comment](https://github.com/jkitchin/discopt/issues/732#issuecomment-5011650386))
On ex1252 with coupling-RLT ON, the spatial tree **internally reaches the optimum** (`global_lower_bound = 134471.56`) but the **reported dual bound is discarded to ≈0** and the result is uncertified. Cause: a narrow/pinned-box node whose relaxation LP fails numerically (`(numerical)`/`(error)`) is assigned the failure sentinel (`≈1e30`) and flagged a **non-rigorous fathom**. The existing Rust `.max(parent)` child-bound floor (`tree_manager.rs:403`) cannot rescue it (`max(1e30, parent) = 1e30`), and one such fathom taints the whole tree → the proven bound is thrown away. So ex1252 is uncertified *precisely because of L5* — not a bound-value collapse (Rust floors that), but narrow-box LP failures poisoning certification.

### A — `DISCOPT_NARROW_BOX_BRANCH` (default OFF, bound-changing)
When a failed-LP node's box is still **spatially branchable**, keep it OPEN instead of sentinel-fathoming: import `-inf` so the Rust child floor lifts it to the node's rigorous parent-inherited bound, and let the brancher bisect it — children re-solve on narrower, better-conditioned boxes (the probe shows the LP succeeds once the box shrinks). Reuses the sound "-inf stays open, floored at parent" mechanism the deadline path already uses (#138).

**Soundness:** convert ONLY a branchable node (relative width > 2× the Rust brancher's `SPATIAL_MIN_WIDTH`). An unbranchable node kept open would dead-end unbranched and could falsely certify (the #467 hazard), so a failed node below the branch width stays a (honest) sentinel fathom.

### B — narrow-box conditioning overflow (bound-neutral, default behavior)
The false-infeasible re-verify's conditioning gate computed `max/min > TRIGGER`; on the ill-conditioned narrow/RLT boxes (coefficient spread ~1e26 over ~1e-300 denormals) the division overflows to `inf` (spurious `RuntimeWarning`). Rewritten as the algebraically identical `max > TRIGGER * min` (min > 0 after the zero-filter) — same boolean, no overflow.

## Correctness

- [x] Cannot produce a false certificate
- [x] No validation, fallback, or safety guard weakened
- B is byte-identical behavior (algebraic rewrite of the same predicate).
- A is default-OFF and, when ON, only ever keeps a *branchable* node open at a *rigorous parent bound* — it never drops or fabricates a bound.

## Tests run (results)

- [x] `pytest -m smoke` → **673 passed, 1 skipped**
- [x] `pytest -m slow test_adversarial_recent_fixes.py` → **10 passed**
- [x] `python/tests/test_732_narrow_box_branch.py` → **2 passed** (fast OFF==ON inertness; slow ex1252 un-taint + soundness)
- [x] `ruff check` / `ruff format --check` → clean
- No Rust touched → cargo not required.

### Flag-ON measurement (ex1252, coupling-RLT ON, TL=120 s)
| | reported bound | incumbent | sound? |
|---|---|---|---|
| OFF (= `main`) | ≈0 (discarded, uncertified) | 134471.56 (**4.3 % suboptimal**) | — |
| ON | **57055.52** (rigorous) | **128893.74 (= true optimum)** | ✅ bound ≤ oracle 128893.741 |

Un-taints the reported bound *and* finds the global optimum the OFF path was dropping. Still does not *certify* (bound 57055 vs incumbent 128893 — that gap is Stages 2–4).

### Soundness spot-check (in-repo corpus, flag ON, TL=8 s)
62/63 oracled instances sound. The 1 exception (`syn05hfsg`, bound > incumbent) is **byte-identical OFF vs ON** and `gap_certified=False` — the pre-existing #120 αBB-fallback bug, not caused or touched by this PR (tracked separately).

## Bound-changing / performance change?

- [x] `DISCOPT_NARROW_BOX_BRANCH` default-OFF; OFF path byte-identical (verified: ex1252 OFF bound/obj/node_count unchanged vs `main`; `test_flag_off_and_on_byte_identical_on_clean_model`).
- [x] **Not graduating** — default-off pending the CLAUDE.md §5 corpus-wide differential panel (the graduation gate). This PR lands the sound mechanism + measurement only.

Closes nothing — `Contributes to #732` (Stage 1 mechanism; graduation + Stages 2–4 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
