### PR TITLE
fix(correctness): #757 correct inverted discriminant in fractional-epigraph positive-denominator branch

### DIFF
--- a/python/discopt/_jax/convexity/patterns.py
+++ b/python/discopt/_jax/convexity/patterns.py
@@ -266,9 +266,9 @@ def _box_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
         lb = np.asarray(v.lb, dtype=np.float64).ravel()
         ub = np.asarray(v.ub, dtype=np.float64).ravel()
         if lb.size == 1 and v.size != 1:
-            lb = np.full(v.size, float(lb), dtype=np.float64)
+            lb = np.full(v.size, float(lb.item()), dtype=np.float64)
         if ub.size == 1 and v.size != 1:
-            ub = np.full(v.size, float(ub), dtype=np.float64)
+            ub = np.full(v.size, float(ub.item()), dtype=np.float64)
         los.append(lb)
         his.append(ub)
     if not los:
@@ -1087,8 +1087,13 @@ def classify_fractional_epigraph_constraint(
             # coeff(x) * y + r(x) <= 0 with coeff < 0 ⇒ y >= r(x) / (-coeff).
             return curvature_numerator >= -1e-10
         if coeff_lo > 1e-10:
-            # coeff(x) * y + r(x) <= 0 with coeff > 0 ⇒ y <= -r(x) / coeff.
-            return curvature_numerator <= 1e-10
+            # coeff(x) * y + r(x) <= 0 with coeff > 0 ⇒ y <= -r(x) / coeff, a
+            # hypograph { y <= -q(x)/L(x) }; it is convex iff -q/L is concave,
+            # i.e. q/L is convex over the positive denominator L>0. That is the
+            # SAME discriminant as the coeff_hi<0 branch: a e^2 - b d e + c d^2
+            # >= 0. (The earlier `<= 1e-10` inverted this, classifying the
+            # nonconvex hypograph of a convex ratio as convex — see #757.)
+            return curvature_numerator >= -1e-10
 
     return None
 

--- a/python/tests/test_convexity_wide_box.py
+++ b/python/tests/test_convexity_wide_box.py
@@ -139,6 +139,44 @@ class TestWideBoxStructuralRecognizers:
         m.subject_to((x + 1.0) * (-y) + x * x - 10.0 <= 0)
         assert classify_constraint(m._constraints[0], m) is False
 
+    def test_fractional_epigraph_positive_denominator_hypograph_is_nonconvex(self):
+        """Regression for #757: the ``coeff_lo > 0`` (positive-denominator)
+        branch inverted the discriminant test.
+
+        ``(x+2)*y - x**2 <= 0`` with ``x in [0,1]`` rearranges to
+        ``y <= x**2/(x+2)``. The ratio ``x**2/(x+2)`` is strictly *convex*
+        on the box (positive denominator, discriminant
+        ``a*e^2 - b*d*e + c*d^2 = (-1)*4 = -4 < 0`` for the epigraph
+        orientation), so its *hypograph* — this feasible set — is NONconvex:
+        ``(0,0)`` and ``(1, 1/3)`` are feasible but their midpoint is not.
+        The classifier must return False. Before the fix it returned True
+        because the branch compared ``<= 1e-10`` instead of ``>= -1e-10``.
+
+        Both pre-existing fractional-epigraph tests use the ``(...)*(-y)``
+        form, which routes through the ``coeff_hi < 0`` branch; this is the
+        first coverage of the positive-denominator branch.
+        """
+        m = Model("frac_epi_pos_denom_nonconvex")
+        x = m.continuous("x", lb=0.0, ub=1.0)
+        y = m.continuous("y", lb=-10.0, ub=10.0)
+        m.subject_to((x + 2.0) * y - x * x <= 0)
+        assert classify_constraint(m._constraints[0], m) is False
+
+    def test_fractional_epigraph_positive_denominator_convex_hypograph(self):
+        """Sound direction of the ``coeff_lo > 0`` branch (#757).
+
+        ``(x+2)*y + x**2 + 1 <= 0`` rearranges to ``y <= -(x**2+1)/(x+2)``.
+        The ratio ``(x**2+1)/(x+2)`` is convex on the box (discriminant
+        ``a*e^2 - b*d*e + c*d^2 = 1*4 + 1*1 = 5 >= 0``), so its negation is
+        concave and the hypograph is genuinely convex. The classifier must
+        return True; the inverted comparison lost this valid tightening.
+        """
+        m = Model("frac_epi_pos_denom_convex")
+        x = m.continuous("x", lb=0.0, ub=1.0)
+        y = m.continuous("y", lb=-10.0, ub=10.0)
+        m.subject_to((x + 2.0) * y + x * x + 1.0 <= 0)
+        assert classify_constraint(m._constraints[0], m) is True
+
     def test_exp_perspective_with_mismatched_denominator_is_unknown(self):
         """Negative case for the perspective-of-exp recogniser.
 


### PR DESCRIPTION
## Summary

`_jax/convexity/patterns.py::classify_fractional_epigraph_constraint`'s `coeff_lo > 0` (positive-denominator) branch compared the Schur-complement discriminant with the **wrong sign** (`curvature_numerator <= 1e-10`), inverting the correct `coeff_hi < 0` branch. A provably nonconvex fractional-epigraph feasible set was therefore classified **convex**, and `is_constraint_convex` in `rules.py` trusts that verdict for convexity-based dispatch/bounding.

Deriving the second derivative of the ratio `q(x)/L(x)` with `L(x)=αx+β` gives `r'' = 2(a·β² − b·α·β + c·α²)/L³`. With a **positive** denominator `L>0` this is `≥0` iff `a·e² − b·d·e + c·d² ≥ 0` — *identical* to the `coeff_hi < 0` branch. The `coeff_lo > 0` branch is corrected to `curvature_numerator >= -1e-10`, mirroring it.

Also fixed a latent NumPy 2 bug the issue noted in `_box_bounds`: `float()` on a 1-element array raises under NumPy 2; the scalar-bound broadcast branch now uses `.item()`.

Closes #757.

## Correctness

The old code returned `True` (convex) for a nonconvex set — `(x+2)*y − x² ≤ 0`, i.e. `y ≤ x²/(x+2)`, whose feasible region is the hypograph of a strictly convex ratio (`(0,0)` and `(1, 1/3)` feasible, midpoint not). That verdict is trusted by convex dispatch/bounding, so it could seed a false certificate. The fix tightens classification toward soundness (the ratio is convex iff the discriminant is non-negative); the symmetric genuinely-convex case (`(x+2)*y + x² + 1 ≤ 0`) now correctly returns `True`, recovering a valid tightening the inverted test had dropped. No validation, fallback, or safety guard was weakened.

- [x] Cannot produce a false certificate — removes a source of one
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 671 passed, 12 skipped
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 9 passed; `test_large_dense_jacobian_no_crash` overran its wall-clock deadline once when run concurrently with the smoke suite, and passes in isolation (35s). It is a 1100-variable no-crash/deadline probe — unreachable by this change, which only affects the 2-scalar-variable fractional-epigraph classifier.
- [x] `cargo test -p discopt-core` → N/A — no Rust touched
- [x] `ruff check` / `ruff format --check` clean
- Additionally: all 27 tests in `test_convexity_wide_box.py` and 698 convexity-related tests pass.

## Regression test

Both pre-existing fractional-epigraph tests use the `(...)*(-y)` form, which only routes through the `coeff_hi < 0` branch — the buggy positive-denominator branch had no coverage. Added two tests in `test_convexity_wide_box.py` giving the first coverage of that branch:
- `test_fractional_epigraph_positive_denominator_hypograph_is_nonconvex` — the issue's nonconvex reproduction, must return `False`.
- `test_fractional_epigraph_positive_denominator_convex_hypograph` — the symmetric convex case, must return `True`.

- [x] Added a regression test that fails before / passes after — confirmed via `git stash`: both fail on unfixed code, pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)