### PR TITLE
fix(correctness): #756 two false-infeasible certificates in GDPopt-LOA

### DIFF
--- a/python/discopt/solvers/gdpopt_loa.py
+++ b/python/discopt/solvers/gdpopt_loa.py
@@ -648,9 +648,7 @@ def _discrete_vars_all_binary(int_indices, lb, ub, tol: float = 1e-9) -> bool:
     The binary-only no-good cut (:func:`_add_no_good_cut`) is valid only in this
     case; otherwise the exact single-point exclusion is required (#756).
     """
-    return all(
-        abs(float(lb[i])) <= tol and abs(float(ub[i]) - 1.0) <= tol for i in int_indices
-    )
+    return all(abs(float(lb[i])) <= tol and abs(float(ub[i]) - 1.0) <= tol for i in int_indices)
 
 
 def _build_no_good_augmentation(no_good_configs, int_indices, lb, ub, n_base):

--- a/python/discopt/solvers/gdpopt_loa.py
+++ b/python/discopt/solvers/gdpopt_loa.py
@@ -163,9 +163,26 @@ def solve_gdpopt_loa(
     # break the loop soundly if the master re-proposes an unresolved config.
     unresolved_int_configs: set[tuple[int, ...]] = set()
 
+    # #756: integer configurations proven infeasible that must be excluded with an
+    # *exact* single-point no-good. The binary-only exclusion form (``_add_no_good_cut``)
+    # is only valid when every discrete variable is 0/1; for a general integer it also
+    # cuts off feasible configurations (a certified false infeasible). When any discrete
+    # variable is non-binary we exclude each proven-infeasible point exactly via
+    # auxiliary-binary "move away" disjunctions built in the master (see
+    # ``_build_no_good_augmentation``).
+    all_binary_discrete = _discrete_vars_all_binary(int_indices, lb, ub)
+    no_good_configs: list[tuple[int, ...]] = []
+
+    # #756: terminal state must distinguish a rigorous infeasibility proof from a
+    # limit exhaustion. A timeout / iteration-cap / non-infeasible master verdict is
+    # NOT an infeasibility proof and must never be certified as ``infeasible``.
+    timed_out = False
+    master_infeasible = False
+
     for iteration in range(max_iterations):
         elapsed = time.perf_counter() - t_start
         if elapsed >= time_limit:
+            timed_out = True
             break
 
         # a. Build and solve master MILP
@@ -185,11 +202,26 @@ def solve_gdpopt_loa(
             time_limit=time_limit - elapsed,
             gap_tolerance=gap_tolerance,
             milp_solver=milp_solver,
+            no_good_configs=no_good_configs,
+            int_indices=int_indices,
         )
 
         if master_result is None or master_result.x is None:
-            # Master infeasible → problem is infeasible
-            logger.info("LOA: Master MILP infeasible at iteration %d", iteration)
+            # #756: only a rigorous INFEASIBLE verdict is an infeasibility proof.
+            # A master that returns no solution under a time/iteration limit (or a
+            # backend error) has proved nothing — never certify it as infeasible.
+            from discopt.solvers import SolveStatus
+
+            if master_result is not None and master_result.status == SolveStatus.INFEASIBLE:
+                master_infeasible = True
+                logger.info("LOA: Master MILP proven infeasible at iteration %d", iteration)
+            else:
+                logger.info(
+                    "LOA: Master MILP returned no solution (status=%s) at iteration %d; "
+                    "not treating as an infeasibility proof",
+                    None if master_result is None else master_result.status,
+                    iteration,
+                )
             break
 
         x_master = master_result.x[:n_vars]
@@ -251,9 +283,15 @@ def solve_gdpopt_loa(
             )
 
             if rigorously_infeasible:
-                # Proven infeasible ⇒ the no-good cut is valid (and provides the
-                # anti-cycling exclusion). Certification is preserved.
-                _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars)
+                # Proven infeasible ⇒ exclude EXACTLY this integer configuration
+                # (anti-cycling + certification preserved). The binary-only cut is
+                # valid only when every discrete variable is 0/1; for general
+                # integers it also cuts feasible points (#756), so route those
+                # through the exact auxiliary-binary no-good built in the master.
+                if all_binary_discrete:
+                    _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars)
+                else:
+                    no_good_configs.append(_int_config_key(x_master, int_indices))
             else:
                 # Non-rigorous failure ⇒ do NOT exclude this configuration.
                 # Record it as unresolved (result not certified) and break
@@ -297,7 +335,9 @@ def solve_gdpopt_loa(
     has_unresolved = len(unresolved_int_configs) > 0
 
     if incumbent is not None:
-        certified = (gap <= gap_tolerance) and not has_unresolved
+        # #756: a timeout means optimality was never proved — report "feasible",
+        # never "optimal", even if the last computed gap happens to be small.
+        certified = (gap <= gap_tolerance) and not has_unresolved and not timed_out
         status = "optimal" if certified else "feasible"
         x_dict = _build_x_dict(incumbent, reformulated)
         return SolveResult(
@@ -323,13 +363,30 @@ def solve_gdpopt_loa(
             gap_certified=False,
         )
 
+    if master_infeasible:
+        # The only path to a certified infeasible: the master relaxation (linear
+        # rows + valid OA cuts + exact single-point no-good exclusions) was proved
+        # infeasible by the MILP backend.
+        return SolveResult(
+            status="infeasible",
+            objective=None,
+            bound=bound,
+            gap=None,
+            x={},
+            wall_time=wall_time,
+        )
+
+    # #756: no incumbent and no infeasibility proof — the loop stopped on the time
+    # limit, the iteration cap, or a non-infeasible master verdict. None of these
+    # prove infeasibility, so return an uncertified "unknown" result.
     return SolveResult(
-        status="infeasible",
+        status="unknown",
         objective=None,
         bound=bound,
         gap=None,
         x={},
         wall_time=wall_time,
+        gap_certified=False,
     )
 
 
@@ -560,7 +617,15 @@ def _int_config_key(x_master, int_indices) -> tuple[int, ...]:
 
 
 def _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars):
-    """Add an integer-exclusion (no-good) cut."""
+    """Add a binary integer-exclusion (no-good) cut.
+
+    Valid ONLY when every discrete variable is 0/1: the single inequality below
+    excludes exactly the incumbent 0/1 configuration and keeps all other 0/1
+    configurations feasible. For general integer variables this form is UNSOUND
+    (it also cuts feasible non-0/1 configurations — issue #756); those callers
+    must use :func:`_build_no_good_augmentation` instead. Callers gate on
+    :func:`_discrete_vars_all_binary`.
+    """
     # sum_{i: y_i*=1} (1 - y_i) + sum_{i: y_i*=0} y_i >= 1
     # Equivalently: -sum_{y_i*=1} y_i + sum_{y_i*=0} y_i >= 1 - count(y_i*=1)
     # As <= form: sum_{y_i*=1} y_i - sum_{y_i*=0} y_i <= count(y_i*=1) - 1
@@ -575,6 +640,73 @@ def _add_no_good_cut(x_master, int_indices, oa_A_rows, oa_b_rows, n_vars):
             coeffs[idx] = -1.0
     oa_A_rows.append(coeffs)
     oa_b_rows.append(float(count_ones - 1))
+
+
+def _discrete_vars_all_binary(int_indices, lb, ub, tol: float = 1e-9) -> bool:
+    """True iff every discrete variable is a 0/1 variable (bounds ``[0, 1]``).
+
+    The binary-only no-good cut (:func:`_add_no_good_cut`) is valid only in this
+    case; otherwise the exact single-point exclusion is required (#756).
+    """
+    return all(
+        abs(float(lb[i])) <= tol and abs(float(ub[i]) - 1.0) <= tol for i in int_indices
+    )
+
+
+def _build_no_good_augmentation(no_good_configs, int_indices, lb, ub, n_base):
+    """Exact single-point integer no-good exclusions via auxiliary binaries (#756).
+
+    Each recorded integer configuration ``v*`` is excluded with the disjunction
+    "at least one discrete variable moves strictly away from its value at ``v*``".
+    For each variable ``z_i`` with value ``v`` and bounds ``[l, u]`` we add, when a
+    move is possible, a binary indicator forcing a real step:
+
+    * down (``v > l``): ``z_i + (u - v + 1)·gamma <= u`` — ``gamma = 1`` forces
+      ``z_i <= v - 1``;
+    * up (``v < u``): ``-z_i + (v + 1 - l)·delta <= -l`` — ``delta = 1`` forces
+      ``z_i >= v + 1``;
+
+    plus an aggregate ``sum(indicators) >= 1`` (as ``-sum <= -1``). This removes
+    EXACTLY the point ``v*`` — every other integer combination can activate the
+    indicator for a coordinate in which it differs — so the exclusion is sound for
+    general integers, not only 0/1. If a configuration is pinned at its bounds in
+    every coordinate (no move possible), the empty aggregate row ``0 <= -1`` makes
+    the master infeasible, which is correct: ``v*`` was then the only integer point.
+
+    Returns ``(rows, rhs, n_aux)`` with each row already width ``n_base + n_aux``.
+    """
+    pending: list[tuple[dict[int, float], dict[int, float], float]] = []
+    n_aux = 0
+    for config in no_good_configs:
+        indicator_cols: list[int] = []
+        for idx, v in zip(int_indices, config):
+            lo = float(lb[idx])
+            hi = float(ub[idx])
+            vv = float(v)
+            if vv > lo + 0.5:  # a strictly-lower integer exists
+                col = n_aux
+                n_aux += 1
+                pending.append(({idx: 1.0}, {col: (hi - vv + 1.0)}, hi))
+                indicator_cols.append(col)
+            if vv < hi - 0.5:  # a strictly-higher integer exists
+                col = n_aux
+                n_aux += 1
+                pending.append(({idx: -1.0}, {col: (vv + 1.0 - lo)}, -lo))
+                indicator_cols.append(col)
+        pending.append(({}, {c: -1.0 for c in indicator_cols}, -1.0))
+
+    n_total = n_base + n_aux
+    rows: list[np.ndarray] = []
+    rhs: list[float] = []
+    for var_coeffs, aux_coeffs, r in pending:
+        row = np.zeros(n_total)
+        for idx, c in var_coeffs.items():
+            row[idx] = c
+        for col, c in aux_coeffs.items():
+            row[n_base + col] = c
+        rows.append(row)
+        rhs.append(float(r))
+    return rows, rhs, n_aux
 
 
 def _solve_master_milp(
@@ -593,6 +725,8 @@ def _solve_master_milp(
     time_limit,
     gap_tolerance,
     milp_solver="auto",
+    no_good_configs=None,
+    int_indices=None,
 ):
     """Build and solve the master MILP."""
     try:
@@ -646,6 +780,24 @@ def _solve_master_milp(
             A_eq_rows.append(row)
             b_eq_vals.append(linear_b_rows[i])
 
+    # #756: exact single-point integer no-good exclusions add auxiliary binary
+    # columns to the master. Pad the existing rows with zeros for those columns and
+    # append the exclusion rows (all <= form).
+    n_extra = 0
+    ng_rows: list[np.ndarray] = []
+    ng_rhs: list[float] = []
+    if no_good_configs:
+        if int_indices is None:
+            int_indices = [i for i in range(n_vars) if integrality[i]]
+        ng_rows, ng_rhs, n_extra = _build_no_good_augmentation(
+            no_good_configs, int_indices, lb, ub, n_master
+        )
+    if n_extra > 0:
+        A_ub_rows = [np.concatenate([r, np.zeros(n_extra)]) for r in A_ub_rows]
+        A_eq_rows = [np.concatenate([r, np.zeros(n_extra)]) for r in A_eq_rows]
+        A_ub_rows.extend(ng_rows)
+        b_ub_vals = list(b_ub_vals) + list(ng_rhs)
+
     # Build arrays
     A_ub = np.array(A_ub_rows) if A_ub_rows else None
     b_ub = np.array(b_ub_vals) if b_ub_vals else None
@@ -671,6 +823,12 @@ def _solve_master_milp(
     # Integrality
     int_vec = np.zeros(n_master, dtype=np.int32)
     int_vec[:n_vars] = integrality
+
+    # #756: extend objective / bounds / integrality for the no-good aux binaries.
+    if n_extra > 0:
+        c = np.concatenate([c, np.zeros(n_extra)])
+        bounds_list = bounds_list + [(0.0, 1.0)] * n_extra
+        int_vec = np.concatenate([int_vec, np.ones(n_extra, dtype=np.int32)])
 
     return solve_milp(
         c=c,

--- a/python/tests/test_gdpopt_loa_issue756.py
+++ b/python/tests/test_gdpopt_loa_issue756.py
@@ -1,0 +1,172 @@
+"""Regression tests for issue #756 — two false-infeasible certificates in GDPopt-LOA.
+
+Both defects produced ``status="infeasible"`` with ``gap_certified=True`` on *feasible*
+models (hard-gate territory per CLAUDE.md — same class as #739/#740):
+
+1. ``_add_no_good_cut`` used the binary-only exclusion form for general integer
+   variables; the cut for a proven-infeasible config also cut off feasible non-0/1
+   configurations, so LOA excluded everything and certified a false infeasible.
+2. Exiting the LOA loop on the time limit (or the iteration cap, or a non-infeasible
+   master verdict) fell through to a certified ``"infeasible"`` — a timeout is not an
+   infeasibility proof.
+
+These solve on the in-house simplex/POUNCE master, so no highspy is required.
+"""
+
+import itertools
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.solvers import gdpopt_loa as loa
+
+
+@pytest.mark.smoke
+class TestIssue756NoGoodSoundness:
+    def test_general_integer_no_good_cut_soundness(self):
+        """#756(1): y binary, z integer in [0, 3], y*z >= 2 — optimum 3 at (1, 2).
+
+        Fails before the fix: the binary-only no-good cut for config (0, 1) is
+        ``-y + z <= 0``, which also cuts the feasible optimum (1, 2); LOA excludes
+        every config and returns a certified false ``"infeasible"``.
+        """
+        m = dm.Model("loa_nogood_int")
+        y = m.binary("y")
+        z = m.integer("z", lb=0, ub=3)
+        m.subject_to(y * z >= 2)
+        m.minimize(y + z)
+        r = m.solve(time_limit=30, gdp_method="loa")
+        assert r.status in ("optimal", "feasible"), (
+            f"feasible model declared {r.status!r} (false infeasibility)"
+        )
+        assert r.objective == pytest.approx(3.0, abs=1e-5)
+
+    def test_general_integer_optimum_at_larger_value(self):
+        """A general-integer optimum away from 0/1: y*z >= 4, z in [0, 5] → (1, 4)."""
+        m = dm.Model("loa_nogood_int_large")
+        y = m.binary("y")
+        z = m.integer("z", lb=0, ub=5)
+        m.subject_to(y * z >= 4)
+        m.minimize(y + z)
+        r = m.solve(time_limit=30, gdp_method="loa")
+        assert r.status in ("optimal", "feasible")
+        assert r.objective == pytest.approx(5.0, abs=1e-5)
+        assert float(np.asarray(r.x["z"])) == pytest.approx(4.0, abs=1e-4)
+
+    def test_two_general_integers(self):
+        """Two general integers: a*b >= 6, a, b in [0, 4] → optimum 5."""
+        m = dm.Model("loa_two_int")
+        a = m.integer("a", lb=0, ub=4)
+        b = m.integer("b", lb=0, ub=4)
+        m.subject_to(a * b >= 6)
+        m.minimize(a + b)
+        r = m.solve(time_limit=30, gdp_method="loa")
+        assert r.status in ("optimal", "feasible")
+        assert r.objective == pytest.approx(5.0, abs=1e-5)
+
+    def test_genuinely_infeasible_general_integer_still_infeasible(self):
+        """The fix must not over-correct: a truly infeasible integer model stays
+        ``"infeasible"`` (max y*z = 3 < 100)."""
+        m = dm.Model("loa_int_infeasible")
+        y = m.binary("y")
+        z = m.integer("z", lb=0, ub=3)
+        m.subject_to(y * z >= 100)
+        m.minimize(y + z)
+        r = m.solve(time_limit=30, gdp_method="loa")
+        assert r.status == "infeasible"
+        assert r.objective is None
+
+
+@pytest.mark.unit
+class TestIssue756Augmentation:
+    def test_discrete_vars_all_binary(self):
+        lb = np.array([0.0, 0.0])
+        assert loa._discrete_vars_all_binary([0, 1], lb, np.array([1.0, 1.0]))
+        assert not loa._discrete_vars_all_binary([0, 1], lb, np.array([1.0, 3.0]))
+
+    def test_exact_exclusion_removes_only_target_point(self):
+        """The exact no-good excludes EXACTLY v* and keeps every other integer point.
+
+        Enumerate the box y in {0,1}, z in {0..3} against the augmented system
+        (variables + auxiliary binaries) after excluding (0, 1).
+        """
+        int_indices = [0, 1]
+        lb = np.array([0.0, 0.0])
+        ub = np.array([1.0, 3.0])
+        rows, rhs, n_aux = loa._build_no_good_augmentation([(0, 1)], int_indices, lb, ub, n_base=2)
+        A = np.array(rows)
+        b = np.array(rhs)
+
+        surviving = set()
+        for yv, zv in itertools.product([0, 1], [0, 1, 2, 3]):
+            for aux in itertools.product([0, 1], repeat=n_aux):
+                full = np.array([yv, zv, *aux], dtype=float)
+                if np.all(A @ full <= b + 1e-9):
+                    surviving.add((yv, zv))
+                    break
+
+        all_points = set(itertools.product([0, 1], [0, 1, 2, 3]))
+        assert (0, 1) not in surviving, "target point (0,1) must be excluded"
+        assert surviving == all_points - {(0, 1)}, "no other point may be cut"
+
+    def test_fully_pinned_config_makes_master_infeasible(self):
+        """A config pinned at its bounds in every coordinate yields the empty
+        aggregate row ``0 <= -1`` — correct, since v* was the only integer point."""
+        rows, rhs, n_aux = loa._build_no_good_augmentation(
+            [(2,)], [0], np.array([2.0]), np.array([2.0]), n_base=1
+        )
+        assert n_aux == 0
+        # one aggregate row, all-zero LHS with rhs -1  ->  0 <= -1 (infeasible)
+        assert len(rows) == 1
+        np.testing.assert_allclose(rows[0], [0.0])
+        assert rhs[0] == -1.0
+
+
+@pytest.mark.smoke
+class TestIssue756TimeLimit:
+    def test_time_limit_exhausted_is_not_infeasible(self):
+        """#756(2): a zero-iteration timeout must not certify infeasibility."""
+        m = dm.Model("loa_tl0")
+        x = m.continuous("x", lb=0, ub=10)
+        m.either_or([[x <= 3], [x >= 7]], name="choice")
+        m.minimize(x)
+        r = loa.solve_gdpopt_loa(m, time_limit=0.0)
+        assert r.status != "infeasible", (
+            "timeout with zero iterations must not certify infeasibility"
+        )
+        assert r.status == "unknown"
+        assert r.objective is None
+        assert r.gap_certified is False
+
+
+@pytest.mark.smoke
+class TestIssue756NoBinaryRegression:
+    """The all-binary path is unchanged: these must keep their prior behavior."""
+
+    def test_binary_no_good_cut_reaches_optimum(self):
+        m = dm.Model("loa_nogood_bin")
+        y1 = m.binary("y1")
+        y2 = m.binary("y2")
+        m.subject_to(y1 * y2 >= 1)
+        m.minimize(y1 + y2)
+        r = m.solve(time_limit=30, gdp_method="loa")
+        assert r.status in ("optimal", "feasible")
+        assert r.objective == pytest.approx(2.0, abs=1e-5)
+
+    def test_infeasible_by_master_still_infeasible(self):
+        m = dm.Model("loa_infeas")
+        x = m.continuous("x", lb=0, ub=10)
+        m.either_or([[x <= 3], [x >= 7]], name="choice")
+        m.subject_to(x >= 4)
+        m.subject_to(x <= 6)
+        m.minimize(x)
+        r = m.solve(time_limit=30, gdp_method="loa")
+        assert r.status == "infeasible"
+        assert r.objective is None
+
+    def test_add_no_good_cut_binary_form_unchanged(self):
+        A_rows: list = []
+        b_rows: list = []
+        loa._add_no_good_cut(np.array([1.0, 0.0]), [0, 1], A_rows, b_rows, 2)
+        np.testing.assert_allclose(A_rows[0], [1.0, -1.0])
+        assert b_rows[0] == 0.0


### PR DESCRIPTION
## Summary

Fixes both P0-class false-infeasible certificate defects in `solvers/gdpopt_loa.py` from #756. Both returned `status="infeasible"` with `gap_certified=True` on **feasible** models — hard-gate territory per CLAUDE.md (same class as #739/#740).

**1. No-good cut unsound for general integers.** `_add_no_good_cut` used the binary-only exclusion `sum_{v*≥0.5} v − sum_{v*<0.5} v ≤ count−1`, which is only valid for 0/1 variables. For config `(y=0, z=1)` it produced `−y+z ≤ 0`, cutting off the feasible optimum `(1,2)`; LOA excluded every config and certified a false infeasible on `min y+z s.t. y·z≥2`.
- The binary form is now used only when **every** discrete variable is 0/1 (`_discrete_vars_all_binary`).
- Otherwise each proven-infeasible point is excluded **exactly** via an auxiliary-binary "move strictly away" disjunction built in the master (`_build_no_good_augmentation`): per coordinate a down (`z ≤ v−1`) / up (`z ≥ v+1`) indicator forces a real ±1 step, aggregated by `sum(indicators) ≥ 1`. This removes only `v*` and keeps every other integer combination feasible — sound for general integers. `min y+z s.t. y·z≥2` now solves to the true optimum **3**.

**2. Time-limit exhaustion certified as infeasibility.** Exiting the loop on the time limit / iteration cap / a non-`INFEASIBLE` master verdict fell through to certified `"infeasible"`. The terminal state now certifies `"infeasible"` **only** on a rigorous master `INFEASIBLE` verdict; a limit returns uncertified `"unknown"` (`gap_certified=False`), and a timeout with an incumbent reports `"feasible"`, never `"optimal"`.

The all-binary master construction is byte-identical (aux columns are added only when non-binary integers are present), so existing LOA behavior (`test_infeasible_by_master`, `test_binary_no_good_cut_reaches_optimum`, the disjunction tests) is unchanged.

Closes #756.

## Correctness

The change only ever *removes* proven-infeasible integer points or *withholds* an unproven certificate — it never strengthens a bound or admits a new one. The exact no-good excludes exactly `v*` (verified by full enumeration in the test); the timeout path returns `"unknown"`, not a certificate. A certified `"infeasible"` is now reachable only from a rigorous master `INFEASIBLE` verdict, which is strictly stricter than the prior any-fallthrough behavior.

- [x] Cannot produce a false certificate — the two false-infeasible paths are removed; no bound/relaxation math changed
- [x] No validation, fallback, or safety guard was weakened to make a check pass — the fix tightens certification (adds `master_infeasible` gate) rather than loosening it

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **679 passed, 12 skipped** (3:34)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **9 passed, 1 failed** — the failure is `test_large_dense_jacobian_no_crash`, a wall-clock-margin assertion (#751-documented flake) on the big-M/spatial path (not LOA); **passes in isolation, 24.8s vs the 48s deadline**
- [x] `cargo test -p discopt-core` → N/A — no Rust touched
- [x] `ruff check` / `ruff format --check` clean; `mypy python/discopt/solvers/gdpopt_loa.py` → Success, no issues

GDP suite (`-k gdp or reformulate`): 165 passed / 19 skipped.

## Regression test

`python/tests/test_gdpopt_loa_issue756.py` (11 tests): the two bug probes (general-integer no-good soundness, timeout-not-infeasible), an enumeration proof that the exact exclusion cuts only `v*`, a genuine-infeasible guard against over-correction, and all-binary regression coverage.

- [x] Added a regression test that fails before / passes after — the 4 behavioral probes **fail on the pre-fix tree** (verified via `git stash`) and **pass after**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TeuL8Gg2tTC5ZMxDozGgZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015TeuL8Gg2tTC5ZMxDozGgZ)_