### PR TITLE
fix(#707,#732): resolve the two ex1252 graduation blockers (reform-build hang + short-budget dual collapse)

### DIFF
--- a/discopt_benchmarks/scripts/ex1252_stage5_differential.py
+++ b/discopt_benchmarks/scripts/ex1252_stage5_differential.py
@@ -83,7 +83,10 @@ def _fmt(x, w=10, p=2):
 
 def main() -> int:
     print(f"#732 Stage-5 differential (ON vs OFF, {_TL}s, this container)\n")
-    hdr = f"{'instance':10s} {'arm':3s} {'status':12s} {'dual':>11s} {'incumbent':>13s} {'nodes':>6s} {'cert':>5s}"
+    hdr = (
+        f"{'instance':10s} {'arm':3s} {'status':12s} {'dual':>11s} "
+        f"{'incumbent':>13s} {'nodes':>6s} {'cert':>5s}"
+    )
     print(hdr)
     print("-" * len(hdr))
     violations: list[str] = []
@@ -98,18 +101,21 @@ def main() -> int:
         for arm, res in (("OFF", off), ("ON", on)):
             print(
                 f"{name:10s} {arm:3s} {res['status'][:12]:12s} "
-                f"{_fmt(res['bound'],11,2)} {_fmt(res['obj'],13,4)} "
+                f"{_fmt(res['bound'], 11, 2)} {_fmt(res['obj'], 13, 4)} "
                 f"{str(res['nodes']):>6s} {str(res['cert']):>5s}"
             )
         # --- soundness (hard) ---
-        for arm, res in (("OFF", off), ("ON", res if False else on)):
+        for arm, res in (("OFF", off), ("ON", on)):
             b = res["bound"]
-            if b is not None and opt is not None:
-                # minimize: dual bound must not exceed the optimum.
-                if b > opt + _ABS + 1e-4 * abs(opt):
-                    violations.append(f"{name} {arm}: dual {b:.4f} > optimum {opt:.4f}")
-            if b is not None and res["obj"] is not None and b > res["obj"] + _ABS + 1e-4 * abs(res["obj"]):
-                violations.append(f"{name} {arm}: dual {b:.4f} > incumbent {res['obj']:.4f}")
+            if b is None:
+                continue
+            # minimize: dual bound must not exceed the optimum...
+            if opt is not None and b > opt + _ABS + 1e-4 * abs(opt):
+                violations.append(f"{name} {arm}: dual {b:.4f} > optimum {opt:.4f}")
+            # ...nor its own incumbent.
+            o = res["obj"]
+            if o is not None and b > o + _ABS + 1e-4 * abs(o):
+                violations.append(f"{name} {arm}: dual {b:.4f} > incumbent {o:.4f}")
         # --- cert regression (hard) ---
         if off.get("cert") and not on.get("cert"):
             violations.append(f"{name}: ON lost the certificate OFF held")

--- a/discopt_benchmarks/scripts/ex1252_stage5_differential.py
+++ b/discopt_benchmarks/scripts/ex1252_stage5_differential.py
@@ -1,0 +1,144 @@
+"""#732 Stage-5 graduation differential: reform-firing subset, ON vs OFF at 60s.
+
+Re-runs the 9-instance ON-vs-OFF differential the Stage-5 panel used, after the
+blocker-a (nvs09 reform-build blowup guard) and blocker-b (budget-aware adoption)
+fixes. Judged WITHIN this container (which is slower than the committed baseline),
+per the plan: compare ON vs OFF arms of the same run, not against committed walls.
+
+ON arm = the full flag stack: integer-multilinear reform + coupling RLT +
+disjunctive config bound + narrow-box branch (rider). OFF arm = all unset.
+
+Gates:
+  * cert-clean (hard): no dual bound above its reference optimum; ON never loses a
+    certificate OFF held; bound <= incumbent internally.
+  * net-positive: ON dual/incumbent broadly >= OFF, no regressions.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO / "python"))
+
+import discopt.modeling as dm  # noqa: E402
+
+_DATA = _REPO / "python" / "tests" / "data"
+_FLAGS = [
+    "DISCOPT_INTEGER_MULTILINEAR_REFORM",
+    "DISCOPT_MULTILINEAR_COUPLING_RLT",
+    "DISCOPT_DISJUNCTIVE_CONFIG_BOUND",
+    "DISCOPT_NARROW_BOX_BRANCH",
+]
+
+# (name, subdir, reference optimum or None if oracle not in-repo)
+_INSTANCES = [
+    ("nvs01", "minlplib_nl", 12.46966882156821),
+    ("nvs05", "minlplib_nl", 5.470934108225147),
+    ("nvs09", "minlplib_nl", -43.134336918035316),
+    ("nvs16", "minlplib", 0.703125),
+    ("nvs22", "minlplib", 6.05822),
+    ("st_e36", "minlplib_nl", -246.00000000000003),
+    ("st_e40", "minlplib", None),
+    ("ex1252", "minlplib", 128893.741),
+    ("ex1252a", "minlplib", None),
+]
+
+_TL = 60
+_ABS = 1e-4  # absolute soundness slack
+
+
+def _solve(path: str, arm: str):
+    for k in _FLAGS:
+        os.environ.pop(k, None)
+    if arm == "ON":
+        for k in _FLAGS:
+            os.environ[k] = "1"
+    try:
+        m = dm.from_nl(path)
+        t0 = time.perf_counter()
+        r = m.solve(time_limit=_TL)
+        dt = time.perf_counter() - t0
+    finally:
+        for k in _FLAGS:
+            os.environ.pop(k, None)
+    return {
+        "wall": dt,
+        "status": str(getattr(r, "status", None)),
+        "obj": getattr(r, "objective", None),
+        "bound": getattr(r, "bound", None),
+        "nodes": getattr(r, "node_count", None),
+        "cert": getattr(r, "gap_certified", None),
+    }
+
+
+def _fmt(x, w=10, p=2):
+    if x is None:
+        return " " * (w - 4) + "None"
+    return f"{x:{w}.{p}f}"
+
+
+def main() -> int:
+    print(f"#732 Stage-5 differential (ON vs OFF, {_TL}s, this container)\n")
+    hdr = f"{'instance':10s} {'arm':3s} {'status':12s} {'dual':>11s} {'incumbent':>13s} {'nodes':>6s} {'cert':>5s}"
+    print(hdr)
+    print("-" * len(hdr))
+    violations: list[str] = []
+    net: list[str] = []
+    for name, sub, opt in _INSTANCES:
+        path = str(_DATA / sub / f"{name}.nl")
+        if not Path(path).exists():
+            print(f"{name:10s} MISSING")
+            continue
+        off = _solve(path, "OFF")
+        on = _solve(path, "ON")
+        for arm, res in (("OFF", off), ("ON", on)):
+            print(
+                f"{name:10s} {arm:3s} {res['status'][:12]:12s} "
+                f"{_fmt(res['bound'],11,2)} {_fmt(res['obj'],13,4)} "
+                f"{str(res['nodes']):>6s} {str(res['cert']):>5s}"
+            )
+        # --- soundness (hard) ---
+        for arm, res in (("OFF", off), ("ON", res if False else on)):
+            b = res["bound"]
+            if b is not None and opt is not None:
+                # minimize: dual bound must not exceed the optimum.
+                if b > opt + _ABS + 1e-4 * abs(opt):
+                    violations.append(f"{name} {arm}: dual {b:.4f} > optimum {opt:.4f}")
+            if b is not None and res["obj"] is not None and b > res["obj"] + _ABS + 1e-4 * abs(res["obj"]):
+                violations.append(f"{name} {arm}: dual {b:.4f} > incumbent {res['obj']:.4f}")
+        # --- cert regression (hard) ---
+        if off.get("cert") and not on.get("cert"):
+            violations.append(f"{name}: ON lost the certificate OFF held")
+        # --- net-positive signal ---
+        ob, nb = off["bound"], on["bound"]
+        if ob is not None and nb is not None:
+            if nb > ob + 1e-6:
+                net.append(f"{name}: dual {ob:.3g} -> {nb:.3g} (ON better)")
+            elif nb < ob - 1e-6:
+                net.append(f"{name}: dual {ob:.3g} -> {nb:.3g} (ON WORSE)")
+        oo, no = off["obj"], on["obj"]
+        if oo is not None and no is not None and no < oo - 1e-6:
+            net.append(f"{name}: incumbent {oo:.6g} -> {no:.6g} (ON better)")
+        print("-" * len(hdr))
+
+    print("\n=== SOUNDNESS (hard gate) ===")
+    if violations:
+        for v in violations:
+            print("  VIOLATION:", v)
+    else:
+        print("  clean: no dual above optimum/incumbent, no certificate regression")
+    print("\n=== NET-POSITIVE signal ===")
+    if net:
+        for n in net:
+            print("  ", n)
+    else:
+        print("  (no ON/OFF dual or incumbent differences)")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/dev/ex1252-certification-plan.md
+++ b/docs/dev/ex1252-certification-plan.md
@@ -294,6 +294,93 @@ root-phase stall, (b) the short-budget dual cost of reform+RLT on the
 ex1252 class (candidate fix: budget-aware reform adoption). Re-run this panel
 after those land.
 
+### Stage 5 — blockers resolved *(2026-07-18, second pass)*
+
+Both graduation blockers were root-caused and fixed; the panel was re-run.
+
+**Blocker (a) — nvs09 "root-phase stall" was a reform-build monomial blowup.**
+The stall is not in the LP/search but in the reformulation *build*: nvs09's
+objective carries a **10-factor** integer-multilinear product (`[3,9]` each →
+`4^10 ≈ 1.05M` distributed binary monomials), each ≥2-bit one minting an AND aux,
+so `_try_expand_multilinear` explodes for minutes before the post-build column
+guard can reject it (faulthandler lands in `and_product`). **Fix:** an early
+estimate of the distributed monomial count (`∏_i(1+nbits_i)`, from the factor
+ranges alone, no columns minted) aborts the whole pass once the cumulative
+estimate exceeds `max(5000, 12·n_orig)` — caught by `expand_integer_products`'
+existing `except → return model`, so a blown-up reform degrades to exactly the
+flag-off model (bound-neutral: any reform that trips this would be rejected by
+the post-build/adoption guards anyway; the cap sits ~46× above the largest
+observed legitimate reform, ex1252 cum-est 108, and ~280× below the nvs09
+blowup). **Measured:** nvs09 flag-ON now certifies optimal in ~11 s / 5 nodes
+(`gap_certified=True`), was hanging > 150 s. ex1252/ex1252a/nvs05 reform to
+byte-identical column counts. Pinned by
+`test_integer_multilinear_reform.py::{test_wide_multilinear_reform_guard_degrades_instead_of_hanging,
+test_nvs09_reform_on_certifies_and_terminates}`.
+
+**Blocker (b) — the short-budget dual cost is now avoided by budget-aware
+adoption.** On the gated-configuration class the reform's payoff is the
+disjunctive config-bound floor / deep spatial recursion, which only engages at a
+generous budget (the disjunctive pass engages at `min(0.25·time_limit,150) ≥ 45`
+s, i.e. `time_limit ≥ 180` s). Below that the exact-linearization is pure
+per-node-LP cost: measured on this container, ex1252@60 s flag-ON collapsed the
+tree dual **9273 → 0** and lost the incumbent, vs the flag-off spatial path's
+9273. **Fix:** a non-pure-MILP reform that carries configuration indicators is
+adopted only when the budget affords the payoff pass; below that it keeps the
+flag-off path. A non-config reform (nvs05: payoff is the direct node-LP
+tightening, +0.19 dual at equal nodes @60 s) and pure-MILP reforms are
+unaffected. **Measured after:** ex1252@60 s flag-ON is byte-identical to flag-off
+(dual 9273, 31 nodes); ex1252@200 s still adopts and lifts (dual 31459, incumbent
+134471). Pinned by
+`test_integer_multilinear_reform.py::test_ex1252_short_budget_declines_reform_no_regression`
+(deterministic node-limited byte-identity). A hygiene rider silences the spurious
+`milp_simplex` divide overflow on the ill-conditioned reform boxes (bound-neutral
+`errstate`, finishing Stage 1's robust-node-LP mandate).
+
+**Re-run differential (ON vs OFF, 60 s, this container —
+`discopt_benchmarks/scripts/ex1252_stage5_differential.py`):**
+
+| instance | OFF dual / incumbent | ON dual / incumbent | note |
+|---|---|---|---|
+| nvs01, nvs16, nvs22, st_e36, st_e40 | (optimal, certified) | identical | byte-identical, guards reject the reform |
+| **nvs09** | optimal −43.13 / 5 nodes / **cert** | identical, **cert** | **blocker (a) fixed** — ON now certifies (was hanging, uncertified) |
+| **ex1252** | 9273 / 204321 | **identical (9273 / 204321)** | **blocker (b) fixed** — the 9273 → 0 collapse is gone; reform declined below its payoff budget |
+| nvs05 | 3.81 / 8.732 | identical | the Stage-5 "3.62 → 3.81 win" was **wall-clock-limit noise**; both arms reach 3.81 here |
+| ex1252a | 14086 / 177861 | 14086 / **183660** | dual identical; ON incumbent slightly worse — a *sound* primal wobble from the **narrow-box-branch rider** (the reform is declined at 60 s, so this is the only ON/OFF delta) |
+
+**Soundness: clean** — no dual above its optimum, no `bound > incumbent`, no
+certificate regression, on any arm. The two Stage-5 regressions (nvs09 cert loss,
+ex1252 dual collapse) are **both eliminated**.
+
+**Generous-budget check (200 s, config instances):** the reform stack is
+**net-negative on this container** — ex1252 OFF **46875** vs ON **31458**; ex1252a
+OFF **46368** vs ON **38746** (ON incumbent also worse, 147745 vs 131564). Root
+cause (logged): the disjunctive pass engages correctly (reported dual *equals* its
+floor, no wiring bug) but is **leaf-throughput-limited on this slow container** —
+only **29 leaf solves in its 50 s budget** → floor 31458, versus the baseline's
+48–120 leaves → 37945–63080. Meanwhile the **flag-off spatial path has become
+strong** (46875 @ 200 s, climbing — vs the plan's earlier "OFF ≈ 0 @ 600 s", a
+different/older tree), so the pass's 50 s tax + the reform's heavier per-node LPs
+are not repaid here. **This falsifies "the reform pays off at generous budgets"
+_on this container_** (Dev-Philosophy #4 — measurement recorded); whether it still
+holds on the faster baseline machine (where the pass reaches 120 leaves) is
+untested here.
+
+**Verdict (`DISCOPT_CUT_INHERIT` discipline): flags stay default-OFF, measurement
+recorded.** The two graduation *blockers are resolved* — the stack is now **safe**
+(no reform-build hang, no certificate loss, no short-budget dual collapse) and
+sound throughout — but it is **not net-positive on this container**: neutral at
+the 60 s fair budget (the reform is correctly inert on the config class below its
+180 s adoption budget) and net-negative at 200 s (container-limited pass
+throughput + a strong OFF path). This is a strict improvement over the prior
+verdict (which had *active* regressions), and the flag is now safe to opt into,
+but it does not clear the net-positive bar. Re-running on a baseline-speed panel
+(where the disjunctive pass reaches its 48–120-leaf regime) is the remaining
+graduation question; the blocker fixes ship regardless as a default-OFF increment.
+**All three fixes are sound and kept: the monomial-blowup guard (a real hang +
+certificate fix, valuable independent of graduation), the budget-aware adoption
+gate (prevents the measured 60 s collapse; unchanged at ≥ 180 s), and the
+`milp_simplex` errstate hygiene (bound-neutral).**
+
 ### Stage 5-original — graduation (CLAUDE.md §5)
 Class detector: `has_integer_multilinear_reformulation_work(model)` (the #707
 trigger) — i.e. the gated-configuration class, *not* an ex1252 special case.

--- a/python/discopt/_jax/integer_product_reform.py
+++ b/python/discopt/_jax/integer_product_reform.py
@@ -141,6 +141,22 @@ class _Expander:
         #   _bigm_cache: (e._index, other._index, other_elem) -> big-M product aux
         self._and_cache: dict[tuple, Variable] = {}
         self._bigm_cache: dict[tuple, Variable] = {}
+        # Early monomial-blowup guard (#707/#732 blocker a). A multilinear product
+        # distributes into ``prod_i (1 + nbits_i)`` binary monomials, each >=2-bit
+        # one minting an AND aux + big-M columns. On wide-multiplicity products this
+        # explodes the *build* long before the post-build column guard in
+        # ``expand_integer_products`` can reject it — nvs09 (10 factors x [3,9] ->
+        # 4^10 ~ 1.4M monomials) hangs the reformulation for minutes. We accumulate a
+        # cheap per-term estimate (from the factor ranges alone, no columns minted)
+        # and abort the whole pass once it exceeds ``_ml_monomial_cap``. Any reform
+        # that trips this would be rejected by the post-build/adoption guards anyway
+        # (the multilinear aux columns alone, <= the estimate, already blow the
+        # ``max(1000, 6*n_orig)`` cap), so the abort yields exactly the flag-OFF model
+        # — bound-neutral by construction. The floor sits ~46x above the largest
+        # observed legitimate reform (ex1252 cum-est 108) and ~280x below the nvs09
+        # blowup, so it never fires on an adoptable reform.
+        self._ml_est_columns = 0
+        self._ml_monomial_cap = max(5000, 12 * len(model._variables))
         # Configuration metadata for the disjunctive config bound (#732 Stage 2).
         # Collected on the multilinear path only: the flat indices of the
         # integer factors of every exact-linearized product, split into
@@ -532,6 +548,23 @@ def _try_expand_multilinear(node: BinaryOp, exp: _Expander) -> Optional[Expressi
     # Guard BEFORE creating any expansion column so a bailed term is a true no-op.
     if len(cont_factors) > 1 or not int_refs:
         return None
+
+    # Early monomial-blowup guard (#707/#732 blocker a) — estimate the distributed
+    # monomial count from the factor ranges *before* minting any expansion column,
+    # and abort the whole pass once the cumulative estimate exceeds the cap (see
+    # ``_Expander.__init__``). ``expand_integer_products`` catches the raise and
+    # returns the original model, so a blown-up reform degrades to exactly the
+    # flag-OFF path instead of hanging (nvs09).
+    _est = 1
+    for _v, _el, _lo, _hi in int_refs:
+        _est *= 1 + max(1, math.ceil(math.log2(_hi - _lo + 1)))
+    exp._ml_est_columns += _est
+    if exp._ml_est_columns > exp._ml_monomial_cap:
+        raise ValueError(
+            "integer-multilinear reform monomial estimate "
+            f"{exp._ml_est_columns} exceeds cap {exp._ml_monomial_cap}"
+        )
+
     int_factors = [exp.expansion(v, el, lo, hi) for (v, el, lo, hi) in int_refs]
 
     # #732 Stage 2: record the configuration structure of this product (pure

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5017,6 +5017,26 @@ def solve_model(
                     # with the flag off — never a regression.
                     _iml_n1 = sum(v.size for v in _iml._variables)
                     _iml_adopt = _iml_pure_milp or _iml_n1 <= 4 * max(_iml_n0, 16)
+                    # Budget-aware adoption for the disjunctive-eligible spatial-path
+                    # reform (#732 blocker b). On the gated-configuration class
+                    # (ex1252: the reform records configuration indicators, and its
+                    # payoff is the disjunctive config-bound floor / deep spatial
+                    # recursion) the exact-linearization only pays for its heavier
+                    # per-node LPs once that payoff mechanism can engage — which needs
+                    # a generous budget (the disjunctive pass engages at
+                    # ``min(0.25*time_limit, 150) >= 45`` s, i.e. ``time_limit >=
+                    # 180`` s). Below that the reform is pure cost: measured on
+                    # ex1252@60 s the reformed tree dual collapses 9273 -> 0 (heavier
+                    # LPs halve node throughput and the floor pass is skipped) and the
+                    # incumbent is lost, versus the flag-off spatial path's 9273. So on
+                    # the config class, keep the flag-off path until the budget affords
+                    # the payoff. A non-config reform (nvs05: payoff is the direct
+                    # node-LP tightening, +0.19 dual at equal nodes @60 s) and a
+                    # pure-MILP reform (MILP-engine route, cheap+exact) are unaffected.
+                    if _iml_adopt and not _iml_pure_milp:
+                        _iml_config = getattr(_iml, "_ipx_config_indicators", None) or ()
+                        if _iml_config and min(0.25 * float(time_limit), 150.0) < 45.0:
+                            _iml_adopt = False
                     if _iml_adopt:
                         _did_multilinear_reform = True
                         model = _iml

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -245,9 +245,18 @@ def _fbbt_eq_bounds(
         minrest = sum_min[rows] - np.where(min_inf, 0.0, min_term)
         maxrest = sum_max[rows] - np.where(max_inf, 0.0, max_term)
         # z_j = (b_i - rest)/a_ij; the rest-interval endpoints give z_j's bounds.
-        lo_cand = np.where(pos, (b_r - maxrest) / vals, (b_r - minrest) / vals)
+        # The quotient is computed densely over every stored coefficient, so on the
+        # ill-conditioned narrow/RLT boxes this runs on (coefficient spreads of ~1e26
+        # over ~1e-300 denormals — the same class as milp_relaxation.py's Stage-1B
+        # guard, #732) a handful of entries overflow to inf / divide by a denormal /
+        # go nan. Those results are rigorously discarded below by the ``*_valid`` mask
+        # AND the ``np.isfinite`` filter, so the transient inf/nan never reaches a
+        # bound — suppress the spurious RuntimeWarnings without changing any value
+        # (bound-neutral by construction; the arithmetic is byte-identical).
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            lo_cand = np.where(pos, (b_r - maxrest) / vals, (b_r - minrest) / vals)
+            hi_cand = np.where(pos, (b_r - minrest) / vals, (b_r - maxrest) / vals)
         lo_valid = np.where(pos, maxrest_finite, minrest_finite)
-        hi_cand = np.where(pos, (b_r - minrest) / vals, (b_r - maxrest) / vals)
         hi_valid = np.where(pos, minrest_finite, maxrest_finite)
 
         new_lo = np.full(lb.shape[0], -np.inf)

--- a/python/tests/test_integer_multilinear_reform.py
+++ b/python/tests/test_integer_multilinear_reform.py
@@ -20,6 +20,7 @@ import os
 os.environ["JAX_PLATFORMS"] = "cpu"
 os.environ["JAX_ENABLE_X64"] = "1"
 
+import time
 from pathlib import Path
 
 import discopt.modeling as dm
@@ -235,6 +236,81 @@ def test_flag_with_unextendable_seed_does_not_crash():
         os.environ.pop("DISCOPT_INTEGER_MULTILINEAR_REFORM", None)
     # Solve still completes soundly (seed simply dropped).
     assert res.objective is None or res.objective >= -1.0 - 1e-4
+
+
+@pytest.mark.correctness
+def test_wide_multilinear_reform_guard_degrades_instead_of_hanging():
+    """Monomial-blowup guard (#707/#732 blocker a). A product of many integer
+    factors distributes into ``prod_i (1 + nbits_i)`` binary monomials — a
+    12-factor ``[0,7]`` product is ``4**12 ~ 16.7M`` — each minting an AND aux.
+    Before the guard this explodes the *reform build* (nvs09, a 10-factor real
+    instance, hung the pass for minutes before the post-build column guard could
+    reject it). The early estimate must abort the pass and return the ORIGINAL
+    model (exactly the flag-off path), fast — and must NOT fire on a legitimate
+    small reform.
+
+    General/class test (Dev-Philosophy #2): the synthetic wide product stands in
+    for the nvs09 structure, so this pins the mechanism with no corpus dependency
+    and no multi-minute runtime.
+    """
+    m = dm.Model("wide")
+    factors = [m.integer(f"a{i}", lb=0, ub=7) for i in range(12)]
+    prod = factors[0]
+    for f in factors[1:]:
+        prod = prod * f
+    m.minimize(-prod)
+    assert has_integer_multilinear_reformulation_work(m)
+
+    t0 = time.perf_counter()
+    r = reformulate_integer_multilinear(m)
+    dt = time.perf_counter() - t0
+    # Degrades to the flag-off model (guard aborted the pass)...
+    assert r is m, "blown-up reform must return the original model, not a partial build"
+    # ...and does so from the range estimate alone — no ~16M-monomial build.
+    assert dt < 5.0, f"reform guard took {dt:.1f}s — it should abort on the estimate, not build"
+
+    # Inertness: a legitimate small product (4 factors [0,3] -> 3**4 = 81 monomials,
+    # well under the cap) must still reform, so the guard never over-triggers.
+    m2 = dm.Model("small")
+    g = [m2.integer(f"b{i}", lb=0, ub=3) for i in range(4)]
+    p2 = g[0]
+    for f in g[1:]:
+        p2 = p2 * f
+    m2.subject_to(g[0] + g[1] + g[2] + g[3] <= 6)
+    m2.minimize(-p2)
+    assert reformulate_integer_multilinear(m2) is not m2, "guard falsely aborted a small reform"
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+def test_nvs09_reform_on_certifies_and_terminates():
+    """nvs09 end-to-end with the flag ON (#732 graduation blocker a). Its objective
+    carries a 10-factor integer-multilinear product ([3,9] each -> ``4**10 ~ 1.05M``
+    monomials) that hung the reform build for minutes and left the instance
+    uncertified. With the blowup guard the reform degrades to the (fast, certifying)
+    flag-off path: the solve must terminate well within the budget and certify the
+    known optimum, sound throughout. Fails-before: without the guard this test times
+    out in the reform build."""
+    nvs09_path = Path(__file__).parent / "data" / "minlplib_nl" / "nvs09.nl"
+    if not nvs09_path.exists():
+        pytest.skip("nvs09.nl not present in this corpus")
+    nvs09_opt = -43.134336
+    os.environ["DISCOPT_INTEGER_MULTILINEAR_REFORM"] = "1"
+    try:
+        m = dm.from_nl(str(nvs09_path))
+        t0 = time.perf_counter()
+        res = m.solve(time_limit=60)
+        dt = time.perf_counter() - t0
+    finally:
+        os.environ.pop("DISCOPT_INTEGER_MULTILINEAR_REFORM", None)
+    # Terminates fast (the reform no longer hangs) — generous margin for CI load.
+    assert dt < 55.0, f"nvs09 reform-on took {dt:.1f}s — the build guard should keep it fast"
+    # Sound and certifies the known optimum.
+    if res.bound is not None and math.isfinite(res.bound):
+        assert res.bound <= nvs09_opt + 1e-2, f"nvs09 UNSOUND bound {res.bound}"
+    assert res.objective is not None and res.objective <= nvs09_opt + 1e-2, (
+        f"nvs09 incumbent {res.objective} did not reach the optimum {nvs09_opt}"
+    )
 
 
 @pytest.mark.slow

--- a/python/tests/test_integer_multilinear_reform.py
+++ b/python/tests/test_integer_multilinear_reform.py
@@ -195,13 +195,26 @@ def test_ex1252_multilinear_reform_sound_and_lifts_bound():
     optimum) and lifts well past the structural 5134 floor that the term-wise
     trilinear McCormick envelope plateaus at. Certification of the full instance
     additionally needs the residual continuous-cubic barrier to close (spatial
-    branching); here we lock soundness + the bound lift, which is the #707 gain."""
-    os.environ["DISCOPT_INTEGER_MULTILINEAR_REFORM"] = "1"
+    branching); here we lock soundness + the bound lift, which is the #707 gain.
+
+    Budget-aware adoption (#732 blocker b): on the gated-configuration class the
+    reform is only adopted once the budget affords its payoff (``time_limit >=
+    180`` s); below that the flag-on solve is byte-identical to flag-off (a
+    separate assertion in the graduation panel). So this exercises an adopting
+    budget (200 s) with the full graduation stack."""
+    keys = [
+        "DISCOPT_INTEGER_MULTILINEAR_REFORM",
+        "DISCOPT_MULTILINEAR_COUPLING_RLT",
+        "DISCOPT_DISJUNCTIVE_CONFIG_BOUND",
+    ]
+    for k in keys:
+        os.environ[k] = "1"
     try:
         m = dm.from_nl(str(_DATA / "ex1252.nl"))
-        res = m.solve(time_limit=60)
+        res = m.solve(time_limit=200)
     finally:
-        os.environ.pop("DISCOPT_INTEGER_MULTILINEAR_REFORM", None)
+        for k in keys:
+            os.environ.pop(k, None)
     assert res.bound is not None and math.isfinite(res.bound)
     # Sound: a valid dual bound never exceeds the true optimum.
     assert res.bound <= _EX1252_OPT + 1e-2, (
@@ -213,6 +226,50 @@ def test_ex1252_multilinear_reform_sound_and_lifts_bound():
     # The tightening: the bound clears the 5134 floor the term-wise envelope stalls at.
     assert res.bound > 5134.5, (
         f"ex1252 multilinear-reform bound {res.bound} did not lift past the 5134 floor"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+def test_ex1252_short_budget_declines_reform_no_regression():
+    """Budget-aware adoption (#732 blocker b). On the gated-configuration class the
+    reform's payoff (the disjunctive floor / deep spatial recursion) cannot engage
+    at a short budget, so the exact-linearization is pure per-node-LP cost there:
+    measured, ex1252@60 s flag-on collapsed the tree dual 9273 -> 0 and lost the
+    incumbent. The gate declines adoption below the payoff budget, so a short-budget
+    flag-on solve is byte-identical to flag-off. Fails-before: without the gate the
+    flag-on arm adopts the heavier reformed model and diverges (different relaxation
+    -> different bound and search).
+
+    A node limit (not a wall limit) makes the comparison deterministic; the 120 s
+    budget stays below the 180 s adoption threshold so the reform is declined."""
+
+    def _solve(flag_on):
+        keys = [
+            "DISCOPT_INTEGER_MULTILINEAR_REFORM",
+            "DISCOPT_MULTILINEAR_COUPLING_RLT",
+            "DISCOPT_DISJUNCTIVE_CONFIG_BOUND",
+        ]
+        for k in keys:
+            os.environ.pop(k, None)
+        if flag_on:
+            for k in keys:
+                os.environ[k] = "1"
+        try:
+            return dm.from_nl(str(_DATA / "ex1252.nl")).solve(time_limit=120, max_nodes=5)
+        finally:
+            for k in keys:
+                os.environ.pop(k, None)
+
+    off, on = _solve(False), _solve(True)
+    # Reform declined at this budget -> identical model -> identical node-limited
+    # search: same bound and same node count, deterministically.
+    assert off.bound is not None and on.bound is not None
+    assert abs(on.bound - off.bound) <= 1e-6, (
+        f"short-budget flag-on dual {on.bound} != flag-off {off.bound} — reform not declined"
+    )
+    assert on.node_count == off.node_count, (
+        f"short-budget flag-on nodes {on.node_count} != flag-off {off.node_count}"
     )
 
 


### PR DESCRIPTION
## Summary

Resolves the two graduation blockers the #732 Stage-5 panel recorded, so the gated-configuration reform stack is now **safe** (no hang, no certificate loss, no short-budget dual collapse) even though it still does not graduate.

- **Blocker (a) — nvs09 "root-phase stall" was a reform-build monomial blowup (a #707 defect).** nvs09's objective carries a **10-factor** integer-multilinear product (`[3,9]` each → `4^10 ≈ 1.05M` distributed monomials), each ≥2-bit one minting an AND aux, so `_try_expand_multilinear` explodes for minutes *before* the post-build column guard can reject it (faulthandler lands in `and_product`). An early estimate of the distributed monomial count (`∏(1+nbits_i)`, from factor ranges alone, no columns minted) aborts the pass once the cumulative estimate exceeds `max(5000, 12·n_orig)` — caught by the existing `except → return model`, so a blown-up reform degrades to exactly the flag-off model. **nvs09 flag-ON now certifies optimal in ~11 s / 5 nodes (`gap_certified=True`), was hanging > 150 s.**
- **Blocker (b) — short-budget dual collapse, fixed by budget-aware adoption.** On the gated-configuration class the reform's payoff (the disjunctive config-bound floor) only engages at a generous budget (`min(0.25·time_limit,150) ≥ 45` s → `time_limit ≥ 180` s); below that it is pure per-node-LP cost — ex1252@60 s flag-ON collapsed the tree dual **9273 → 0** and lost the incumbent. A non-pure-MILP reform carrying configuration indicators is now adopted only when the budget affords the payoff pass. **ex1252@60 s flag-ON is now byte-identical to flag-off (dual 9273, 31 nodes); ex1252@200 s still adopts (dual 31459).** Non-config reforms (nvs05) and pure-MILP reforms are unaffected.
- **Hygiene rider:** silence the spurious `milp_simplex` divide overflow on the ill-conditioned reform boxes (bound-neutral `errstate`; the inf/nan candidates were already discarded by the `_valid`/`isfinite` filters).

Every change lives inside the default-OFF reform flag stack (or is bound-neutral), so the default solver path is unchanged. **Contributes to #732** (default-OFF increment — the stack does not graduate; see below). Blocker (a) fixes a #707-origin defect.

## Correctness

- [x] Cannot produce a false certificate — blocker (a)/(b) fixes only *decline* work (yielding the flag-off model); the hygiene fix is bound-neutral. The Stage-5 differential is soundness-clean on all 9 instances (no dual above optimum, no `bound > incumbent`, no certificate regression).
- [x] No validation, fallback, or safety guard was weakened.

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **827 passed, 14 skipped, 2 xpassed** (identical to baseline)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **9 passed, 1 environmental timeout** (`test_large_dense_jacobian_no_crash` passes standalone in 35 s; this container is slow, and the diff cannot slow that path)
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)
- [x] `ruff check` / `ruff format --check` → clean

## Regression test

- [x] Added, fail-before / pass-after:
  - `test_wide_multilinear_reform_guard_degrades_instead_of_hanging` — a synthetic 12-factor blowup degrades to the original model in < 5 s (class-level, no corpus dependency).
  - `test_nvs09_reform_on_certifies_and_terminates` — nvs09 flag-ON certifies within budget (fails-before: times out in the reform build).
  - `test_ex1252_short_budget_declines_reform_no_regression` — short-budget flag-on is byte-identical to flag-off under a deterministic node limit (fails-before: adopted reform diverges).
  - The ex1252 reform-lift test moved to a 200 s adopting budget.

## Bound-changing / performance change?

- [x] Default-OFF flag stack: `DISCOPT_INTEGER_MULTILINEAR_REFORM` / `_MULTILINEAR_COUPLING_RLT` / `_DISJUNCTIVE_CONFIG_BOUND` (+ `_NARROW_BOX_BRANCH` rider) — flag-OFF path unchanged.
- [x] Not graduating — default-off only. Per `DISCOPT_CUT_INHERIT`: sound throughout and the two active regressions are eliminated, but **not net-positive on this container** — neutral at the 60 s fair budget (reform correctly inert below its 180 s adoption budget) and net-negative at 200 s (the disjunctive pass is leaf-throughput-limited here — 29 leaves/50 s → floor 31458 vs the baseline's 48–120 leaves → 37945–63080 — while the improved flag-off spatial path reaches 46875@200 s). This *falsifies* "the reform pays off at generous budgets" **on this container** (Dev-Philosophy #4, recorded in `docs/dev/ex1252-certification-plan.md`); untested on the faster baseline machine.
- Measurement: full detail in the plan doc's "Stage 5 — blockers resolved" section; harness added at `discopt_benchmarks/scripts/ex1252_stage5_differential.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rpcgUfAR9RoPr7Td2MonA

---
_Generated by [Claude Code](https://claude.ai/code/session_012rpcgUfAR9RoPr7Td2MonA)_