### PR TITLE
feat(#774): re-implement big-M coefficient tightening correctly (DISCOPT_COEF_TIGHTEN, default-OFF)

### DIFF
--- a/discopt_benchmarks/results/issue774/coef_tighten_soundness_sweep_20260719.json
+++ b/discopt_benchmarks/results/issue774/coef_tighten_soundness_sweep_20260719.json
@@ -1,0 +1,681 @@
+{
+ "panel": {
+  "rsyn0805m": {
+   "off": {
+    "status": "feasible",
+    "obj": 1055.8450068825605,
+    "bound": 1864.8382362707575,
+    "nodes": 159,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   },
+   "on": {
+    "status": "feasible",
+    "obj": 1105.6973877505081,
+    "bound": 1732.4325697124777,
+    "nodes": 191,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   }
+  },
+  "rsyn0810m": {
+   "off": {
+    "status": "feasible",
+    "obj": 1417.3003310497224,
+    "bound": 2533.7453636044916,
+    "nodes": 159,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   },
+   "on": {
+    "status": "feasible",
+    "obj": 1467.152711825676,
+    "bound": 2482.7946477166197,
+    "nodes": 127,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   }
+  },
+  "rsyn0815m": {
+   "off": {
+    "status": "feasible",
+    "obj": 1041.5274786964821,
+    "bound": 1987.4794272946203,
+    "nodes": 127,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   },
+   "on": {
+    "status": "feasible",
+    "obj": 1056.9194382270575,
+    "bound": 2201.0204439606696,
+    "nodes": 63,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   }
+  },
+  "syn40m": {
+   "off": {
+    "status": "feasible",
+    "obj": 30.965221147428323,
+    "bound": 1242.9493064124918,
+    "nodes": 383,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   },
+   "on": {
+    "status": "feasible",
+    "obj": -38.167335436361924,
+    "bound": 649.5219426809613,
+    "nodes": 191,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   }
+  }
+ },
+ "corpus": {
+  "4stufen": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 21475.147700500194,
+   "nodes": 31,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "alan": {
+   "status": "optimal",
+   "obj": 2.9249999982491564,
+   "bound": 2.9249999982491564,
+   "nodes": 17,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "bchoco06": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 0.9999775725261153,
+   "nodes": 3,
+   "sense": "max",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "bchoco07": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 0.9999909424986716,
+   "nodes": 15,
+   "sense": "max",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "bchoco08": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 1.0000000000038425,
+   "nodes": 7,
+   "sense": "max",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "beuster": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 6354.897306639267,
+   "nodes": 15,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "casctanks": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": -90.178623297559,
+   "nodes": 7,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "chance": {
+   "status": "optimal",
+   "obj": 29.894378154271102,
+   "bound": 29.894378154271102,
+   "nodes": 0,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "clay0303hfsg": {
+   "status": "feasible",
+   "obj": 26669.10955142754,
+   "bound": 19513.272337060724,
+   "nodes": 173,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "contvar": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 180782.85932835488,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "cvxnonsep_nsig30": {
+   "status": "optimal",
+   "obj": 130.62871116925294,
+   "bound": 130.61841392487688,
+   "nodes": 165,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "cvxnonsep_psig30": {
+   "status": "optimal",
+   "obj": 78.9988543529429,
+   "bound": 78.99179874365787,
+   "nodes": 89,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "cvxnonsep_psig40r": {
+   "status": "optimal",
+   "obj": 86.54527995164958,
+   "bound": 86.53873600363832,
+   "nodes": 95,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "dispatch": {
+   "status": "optimal",
+   "obj": 3155.28792669897,
+   "bound": 3155.28790421789,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1221": {
+   "status": "optimal",
+   "obj": 7.6671800686281255,
+   "bound": 7.6671800686281255,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1222": {
+   "status": "optimal",
+   "obj": 1.0765430833322625,
+   "bound": 1.0765430463031964,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1224": {
+   "status": "optimal",
+   "obj": -0.9434704942820806,
+   "bound": -0.9434705000000164,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1225": {
+   "status": "optimal",
+   "obj": 30.999999913557566,
+   "bound": 30.999999913557566,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1226": {
+   "status": "optimal",
+   "obj": -17.000000003887443,
+   "bound": -17.000000003887443,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex14_1_9": {
+   "status": "feasible",
+   "obj": -1.9775220540513224e-16,
+   "bound": -1.9775220540513224e-16,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "fac2": {
+   "status": "optimal",
+   "obj": 331837498.18201387,
+   "bound": 331837497.5618008,
+   "nodes": 25,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "flay02m": {
+   "status": "optimal",
+   "obj": 37.947331863834634,
+   "bound": 37.94733180456956,
+   "nodes": 7,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "flay03m": {
+   "status": "optimal",
+   "obj": 48.98979479383571,
+   "bound": 48.98979479322051,
+   "nodes": 111,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "gbd": {
+   "status": "optimal",
+   "obj": 2.1999999850603995,
+   "bound": 2.1999999850603995,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "gkocis": {
+   "status": "optimal",
+   "obj": -1.9230986523768174,
+   "bound": -1.9230988096417576,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "hda": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": -15208954203347.346,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "heatexch_gen1": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 40276.48124465793,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "heatexch_gen2": {
+   "status": "feasible",
+   "obj": 757844.9077777817,
+   "bound": 556990.0125079431,
+   "nodes": 7,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "heatexch_gen3": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": null,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "m3": {
+   "status": "optimal",
+   "obj": 37.799999669978845,
+   "bound": 37.79999951039202,
+   "nodes": 47,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs01": {
+   "status": "optimal",
+   "obj": 12.46966882156821,
+   "bound": 12.46966882156821,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs02": {
+   "status": "optimal",
+   "obj": 5.96418452307,
+   "bound": 5.96418452307,
+   "nodes": 337,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs03": {
+   "status": "optimal",
+   "obj": 16.0,
+   "bound": 15.99999972676511,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs04": {
+   "status": "optimal",
+   "obj": 0.720000000000006,
+   "bound": 0.7199999999999773,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs05": {
+   "status": "feasible",
+   "obj": 8.731956986640078,
+   "bound": 3.8053367777828426,
+   "nodes": 131,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "nvs06": {
+   "status": "optimal",
+   "obj": 1.7703125,
+   "bound": 1.7703124999999627,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs07": {
+   "status": "optimal",
+   "obj": 4.0,
+   "bound": 4.0,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs08": {
+   "status": "optimal",
+   "obj": 23.449727347139827,
+   "bound": 23.44972734516655,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs09": {
+   "status": "optimal",
+   "obj": -43.134336918035295,
+   "bound": -43.13433691803662,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs10": {
+   "status": "optimal",
+   "obj": -310.7999999999999,
+   "bound": -310.7999999999999,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs11": {
+   "status": "optimal",
+   "obj": -430.99999999999966,
+   "bound": -430.99999999999966,
+   "nodes": 55,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs12": {
+   "status": "optimal",
+   "obj": -481.20000000000005,
+   "bound": -481.20000000000005,
+   "nodes": 231,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs13": {
+   "status": "optimal",
+   "obj": -585.2,
+   "bound": -585.2000000002046,
+   "nodes": 19,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs14": {
+   "status": "optimal",
+   "obj": -40358.15476929996,
+   "bound": -40358.15476929999,
+   "nodes": 223,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs15": {
+   "status": "optimal",
+   "obj": 1.0,
+   "bound": 1.0,
+   "nodes": 7,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs21": {
+   "status": "optimal",
+   "obj": -5.684782628025259,
+   "bound": -5.684782628025259,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "oaer": {
+   "status": "optimal",
+   "obj": -1.9230984998848466,
+   "bound": -1.923098601139822,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e11": {
+   "status": "optimal",
+   "obj": 189.31162970681882,
+   "bound": 189.31162966433996,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e13": {
+   "status": "optimal",
+   "obj": 2.0000003463351197,
+   "bound": 1.9999999825187809,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e29": {
+   "status": "optimal",
+   "obj": -0.9434704942820806,
+   "bound": -0.9434705000000164,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e36": {
+   "status": "optimal",
+   "obj": -245.99999999999997,
+   "bound": -246.00000000170442,
+   "nodes": 85,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e38": {
+   "status": "optimal",
+   "obj": 7197.727116826533,
+   "bound": 7197.727116826533,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp1": {
+   "status": "optimal",
+   "obj": 280.9999999906497,
+   "bound": 280.9999999906497,
+   "nodes": 15,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp2": {
+   "status": "optimal",
+   "obj": 2.0,
+   "bound": 2.0,
+   "nodes": 9,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp3": {
+   "status": "optimal",
+   "obj": -6.0,
+   "bound": -6.0,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp4": {
+   "status": "optimal",
+   "obj": -4574.000002482959,
+   "bound": -4574.000002482959,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp5": {
+   "status": "optimal",
+   "obj": -333.8888902488093,
+   "bound": -333.8888902488093,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_test1": {
+   "status": "optimal",
+   "obj": -1.7279093690879156e-08,
+   "bound": -1.7279093690879156e-08,
+   "nodes": 15,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_testgr3": {
+   "status": "optimal",
+   "obj": -20.59,
+   "bound": -20.59070709795548,
+   "nodes": 549,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "syn05hfsg": {
+   "status": "optimal",
+   "obj": 837.732411648862,
+   "bound": 837.732411648862,
+   "nodes": 145,
+   "sense": "max",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "tanksize": {
+   "status": "feasible",
+   "obj": 1.268643761465288,
+   "bound": 0.9221092536047468,
+   "nodes": 121,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "tls2": {
+   "status": "feasible",
+   "obj": 5.299999998071545,
+   "bound": 4.308475192420458,
+   "nodes": 229,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "tspn05": {
+   "status": "optimal",
+   "obj": 191.25520768494238,
+   "bound": 191.25510622528546,
+   "nodes": 51,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "tspn08": {
+   "status": "feasible",
+   "obj": 290.56685374735457,
+   "bound": null,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "tspn10": {
+   "status": "feasible",
+   "obj": 225.1260713973292,
+   "bound": null,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "tspn12": {
+   "status": "feasible",
+   "obj": 262.64739525060224,
+   "bound": null,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  }
+ },
+ "violations": []
+}

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5285,6 +5285,30 @@ def solve_model(
         except Exception as e:
             logger.debug("Root presolve failed: %s", e)
 
+    # --- Activity-based big-M coefficient tightening (#282, opt-in) ---
+    # Shrinks big-M coefficients on binary-indicator rows toward the FBBT
+    # activity slack. Bound-changing (it strictly tightens the LP relaxation
+    # without removing any integer-feasible point), so it is gated behind
+    # ``DISCOPT_COEF_TIGHTEN`` (default OFF, CLAUDE.md §5). Runs once at the
+    # root here, before dispatch, so it benefits BOTH the NLP-BB and the
+    # spatial B&B paths. Rewrites the Python constraint DAG in place — the
+    # only place tightened coefficients reach the relaxation compiler. Skipped
+    # once the budget is blown (#654): declining it leaves the original,
+    # still-valid rows.
+    if presolve and not _deadline_exhausted():
+        try:
+            from discopt.solvers._root_presolve import (
+                coef_tighten_enabled,
+                tighten_bigm_coefficients,
+            )
+
+            if coef_tighten_enabled():
+                n_ct = tighten_bigm_coefficients(model)
+                if n_ct > 0:
+                    logger.info("Coefficient tightening: strengthened %d big-M rows", n_ct)
+        except Exception as e:
+            logger.debug("Coefficient tightening failed: %s", e)
+
     # --- Reverse-AD interval tightening (M9 of #51, opt-in) ---
     # Iterates Gauss-Seidel reverse-mode interval AD over every
     # constraint to a fixed point and writes back tighter scalar bounds.

--- a/python/discopt/solvers/_root_presolve.py
+++ b/python/discopt/solvers/_root_presolve.py
@@ -3,13 +3,25 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 import numpy as np
 
-from discopt.modeling.core import Model
+from discopt.modeling.core import Constraint, Model
 
 logger = logging.getLogger(__name__)
+
+
+def coef_tighten_enabled() -> bool:
+    """Whether ``DISCOPT_COEF_TIGHTEN`` opt-in flag is set (default OFF, #282).
+
+    Bound-changing presolve (CLAUDE.md §5): the strengthened LP relaxation is
+    only smaller than the original, never larger, so it is sound, but it stays
+    default-OFF until a corpus-wide differential panel graduates it.
+    """
+    val = os.environ.get("DISCOPT_COEF_TIGHTEN", "0").strip().lower()
+    return val not in ("", "0", "false", "off", "no")
 
 
 def _round_integral_bounds(
@@ -115,3 +127,325 @@ def tighten_root_bounds_with_fbbt(
 
     changed = bool(np.any(tightened_lb > orig_lb + tol) or np.any(tightened_ub < orig_ub - tol))
     return tightened_lb, tightened_ub, infeasible, changed
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Activity-based big-M coefficient tightening (issue #282, Stage 1)
+# ─────────────────────────────────────────────────────────────────────
+#
+# Standard MIP presolve (Savelsbergh 1994; Achterberg 2007): for a linear
+# row ``Σ_{j≠k} a_j x_j + a_k y ⋈ b`` with ``y ∈ {0,1}`` binary and the rest
+# of the activity bounded, the coefficient ``a_k`` can be shrunk toward the
+# activity slack without removing any *integer-feasible* point, while the LP
+# relaxation strictly tightens at fractional ``y``.
+#
+# Two cases, both derived for a normalised ``≤`` row (``≥`` rows are reflected):
+#
+#   Umax = max activity of the rest (Σ_{j≠k} a_j x_j) over the current box.
+#
+#   * ``a_k > 0``  (Savelsbergh):  slack = b − Umax. If ``0 < slack < a_k``,
+#     set ``a_k ← a_k − slack`` and ``b ← b − slack``. At y=0 the row becomes
+#     ``rest ≤ Umax`` (implied — no point removed); at y=1 it is unchanged.
+#   * ``a_k < 0``  (fixed-charge ``flow ≤ M·y`` ⇒ ``flow − M·y ≤ 0``, a_k=−M):
+#     set ``a_k ← b − Umax`` and keep ``b``, applied only when this raises
+#     ``a_k`` (reduces the big-M) and keeps it negative. At y=0 the row is
+#     unchanged; at y=1 both old and new rows are implied by ``rest ≤ Umax``
+#     (no point removed); at fractional y the RHS ``b + |a_k|·y`` shrinks.
+#
+# Feasible-set EQUIVALENCE (both directions — the #772 lesson):
+#   * no integer-feasible point removed: at y ∈ {0,1} the new row is implied by
+#     (old row + activity bounds), and the activity bounds hold at every point
+#     that is feasible in the original problem with integral binaries (FBBT /
+#     implied-bounds / probing inferences are valid exactly on that set);
+#   * no point admitted: for y ∈ [0, 1] the new row is pointwise at least as
+#     tight as the old one (a_k>0 case: the row shifts by ``slack·(1−y) ≥ 0``;
+#     a_k<0 case: the y-coefficient only increases), so the rewritten model's
+#     feasible set — even its continuous relaxation over the box — is a subset
+#     of the original's.
+#
+# The activity bound ``Umax`` uses FBBT-tightened bounds (valid over the whole
+# feasible region), so the strengthened row is globally valid and remains valid
+# at every descendant B&B node (child boxes are subsets of the root box). This
+# is exactly what SCIP's presolve does; on the #282 convex panel it is the
+# load-bearing root-gap lever (syn40m root excess +2608% → +1145%).
+#
+# ── #772 POST-MORTEM (why the #770 version produced a FALSE PRIMAL) ──────────
+# The #770 math above was valid, but the WRITE-BACK broke two model invariants:
+#
+#   1. ``Constraint.rhs`` is **always 0.0** in normalized form (documented on the
+#      dataclass; every comparison operator constructs ``rhs=0.0``). Consumers —
+#      ``NLPEvaluator``, the relaxation compilers, ``_infer_constraint_bounds``
+#      (which derives cl/cu from the *sense alone*) — therefore compile the body
+#      and test it against 0. #770 moved the Savelsbergh slack into ``con.rhs``
+#      (0 → −slack), which every consumer silently dropped: the rewritten row was
+#      read as ``body' ≤ 0`` instead of ``body' ≤ −slack`` — a RELAXATION by
+#      ``slack`` — admitting integer points infeasible in the original problem
+#      (rsyn0805m returned obj 1441.99 > opt 1296.12). The fix: fold the entire
+#      tightened row into the body (``body' = sgn·(a·x − rhs)``) and keep
+#      ``rhs = 0.0``.
+#   2. The evaluator cache (``evaluator_fingerprint``) is keyed on constraint
+#      *object identity*, so in-place mutation of ``con.body`` leaves previously
+#      compiled evaluators serving the un-tightened rows. The fix: REPLACE each
+#      rewritten ``Constraint`` with a new object, which invalidates the
+#      fingerprint and forces a consistent re-compile. (The #779 final-incumbent
+#      guard intentionally keeps its own pre-presolve snapshot reference.)
+#
+# NOTE ON LOCATION (why Python, not the Rust ``coefficient_strengthening`` pass):
+# the in-tree relaxation LP is compiled from the *Python* model DAG plus
+# separately-computed FBBT bound arrays. The Rust presolve orchestrator's
+# rewritten constraint bodies are never propagated back to that DAG
+# (``propagate_bounds_to_model`` copies bounds only), and the existing Rust
+# pass additionally (a) reads *declared* bounds — so it bails on the ``[0,∞)``
+# flows this family declares — and (b) skips negative (fixed-charge) binary
+# coefficients. Rewriting the Python model at the root is the only place the
+# tightened coefficients actually reach the relaxation.
+
+
+def _extract_row(model: Model, con, n: int):
+    """Return ``(coeffs, const)`` for a linear constraint body, or ``None``.
+
+    ``coeffs`` is a dense length-``n`` float vector over flat scalar-variable
+    slots; ``const`` is the free term. ``None`` when the body is non-linear or
+    otherwise not extractable — such rows are left untouched.
+    """
+    from discopt._jax.problem_classifier import (  # local import: heavy _jax dep
+        _extract_linear_coefficients,
+        _NotLinearError,
+    )
+
+    try:
+        coeffs, const = _extract_linear_coefficients(con.body, model, n)
+    except _NotLinearError:
+        return None
+    except Exception as exc:  # pragma: no cover - defensive; skip unparsable rows
+        logger.debug("coef-tighten: row extraction failed: %s", exc)
+        return None
+    return np.asarray(coeffs, dtype=np.float64), float(const)
+
+
+def _strong_block_bounds(model: Model, time_limit_ms: int) -> tuple[np.ndarray, np.ndarray] | None:
+    """Block-aligned tightened bounds from the root presolve orchestrator.
+
+    Runs FBBT + implied-bounds + probing + simplify (the full bound-tightening
+    orchestrator, but with the *variable-eliminating* passes disabled) so the
+    returned per-block arrays stay aligned 1:1 with ``model._variables`` — no
+    elimination/aggregation remaps the index space. Probing tightens the
+    binary-indicator flows far more than bare FBBT alone, and the extra activity
+    slack it exposes is what the coefficient tightening spends: on syn40m probing
+    takes the root excess to ~+1145% (vs bare FBBT's ~+2200%). Because probing
+    is the expensive part, this is called **once** per solve; the compounding
+    rounds reuse the cheap direct-FBBT binding.
+
+    The tightened bounds are read from the ``stats['fbbt']`` channel because the
+    returned repr's ``var_ub``/``var_lb`` are *not* updated by the orchestrator
+    (a known gap — ``propagate_bounds_to_model`` reads the same stale repr, so
+    the solver's own root FBBT tightening reaches only the tree, not this repr).
+    """
+    try:
+        from discopt._jax.presolve_pipeline import run_root_presolve
+        from discopt._rust import model_to_repr
+
+        repr0 = model_to_repr(model, getattr(model, "_builder", None))
+        _, stats = run_root_presolve(
+            repr0,
+            eliminate=False,
+            aggregate=False,
+            factorable_elim=False,
+            redundancy=False,
+            polynomial=False,
+            fbbt=True,
+            implied_bounds=True,
+            probing=True,
+            simplify=True,
+            max_iterations=8,
+            time_limit_ms=time_limit_ms,
+        )
+        fb = stats.get("fbbt")
+        if not fb:
+            return None
+        lbs = np.asarray(fb["lb"], dtype=np.float64)
+        ubs = np.asarray(fb["ub"], dtype=np.float64)
+    except Exception as exc:
+        logger.debug("coef-tighten: strong bound tightening unavailable: %s", exc)
+        return None
+    nblk = len(model._variables)
+    if lbs.size < nblk or ubs.size < nblk:
+        return None
+    return lbs[:nblk], ubs[:nblk]
+
+
+def _cheap_block_bounds(model: Model) -> tuple[np.ndarray, np.ndarray] | None:
+    """Block-aligned bounds from the bare FBBT binding (fast, no probing).
+
+    Used for the compounding rounds after the one-shot probing pass: once the
+    big-M coefficients have been shrunk, plain FBBT re-derives tighter flow
+    bounds from the strengthened rows, which unlocks a further round of
+    coefficient tightening — at negligible cost (~0.01–0.05 s vs probing's ~2–5 s).
+    """
+    try:
+        from discopt._rust import model_to_repr
+
+        repr_ = model_to_repr(model, getattr(model, "_builder", None))
+        lbs, ubs = repr_.fbbt(max_iter=20, tol=1e-9)
+    except Exception as exc:
+        logger.debug("coef-tighten: cheap FBBT unavailable: %s", exc)
+        return None
+    lbs = np.asarray(lbs, dtype=np.float64)
+    ubs = np.asarray(ubs, dtype=np.float64)
+    if lbs.size != len(model._variables) or ubs.size != len(model._variables):
+        return None
+    return lbs, ubs
+
+
+def _rebuild_linear_body(blocks, coeffs: np.ndarray, const: float):
+    """Rebuild ``Σ coeffs[j]·var_j (+const)`` as a modeling expression."""
+    body = None
+    nz = np.nonzero(np.abs(coeffs) > 1e-15)[0]
+    for j in nz:
+        term = float(coeffs[j]) * blocks[j]
+        body = term if body is None else body + term
+    if abs(const) > 1e-15:
+        body = float(const) if body is None else body + float(const)
+    if body is None:
+        body = 0.0
+    return body
+
+
+def tighten_bigm_coefficients(
+    model: Model,
+    *,
+    max_rounds: int = 6,
+    tol: float = 1e-7,
+    probe_time_ms: int = 5000,
+) -> int:
+    """Activity-based big-M coefficient tightening on ``model`` (issue #282).
+
+    Rewrites linear constraint rows that contain a binary variable, shrinking
+    the binary's coefficient toward the activity slack of the rest of the row
+    (both positive-coefficient Savelsbergh and negative-coefficient fixed-charge
+    cases). Iterates with FBBT bound tightening to a fixed point: each round's
+    tighter coefficients can tighten bounds, which enables further coefficient
+    tightening.
+
+    The transformation preserves the integer-feasible set EXACTLY — no feasible
+    point removed AND no infeasible point admitted (see the section comment for
+    the two-directional argument and the #772 post-mortem) — while the LP
+    relaxation only shrinks. Rewritten rows are REPLACED as new ``Constraint``
+    objects with the normalized ``rhs = 0.0`` invariant preserved. Returns the
+    total number of rows whose coefficients were tightened across all rounds
+    (0 when the flag is off or nothing tightens).
+
+    Scope (conservative, sound):
+      * only linear rows with an inequality sense and ≥1 binary,
+      * only rows whose non-binary worst-case activity is finite under the
+        current FBBT bounds (unbounded activity ⇒ skipped, not guessed),
+      * scalar (size-1) variable blocks only.
+    """
+    if not coef_tighten_enabled():
+        return 0
+
+    blocks = model._variables
+    # Only operate when every block is a scalar variable — the flat slot j then
+    # equals block j, so bounds/coeffs line up without per-element offsets.
+    if any(getattr(b, "size", 1) != 1 for b in blocks):
+        return 0
+    n = len(blocks)
+
+    def is_binary(i: int, lb: float, ub: float) -> bool:
+        # Match the DISCRETE types explicitly. (#770 tested ``"IN" in vtype`` —
+        # which also matches "contINuous", so a continuous variable whose FBBT
+        # bounds happen to be [0, 1] was treated as binary; the y∈{0,1}
+        # equivalence argument then removes its genuinely feasible fractional
+        # values. An integer variable with bounds [0, 1] IS binary-equivalent.)
+        vt = str(getattr(blocks[i], "vtype", getattr(blocks[i], "var_type", ""))).upper()
+        discrete = vt.endswith("BINARY") or vt.endswith("INTEGER")
+        return discrete and lb == 0.0 and ub == 1.0
+
+    total_changed = 0
+    for _round in range(max_rounds):
+        # One expensive probing pass for the first round (it exposes the most
+        # activity slack); cheap bare-FBBT for the compounding rounds.
+        fb = (
+            _strong_block_bounds(model, probe_time_ms)
+            if _round == 0
+            else _cheap_block_bounds(model)
+        )
+        if fb is None:
+            break
+        lb, ub = fb
+        round_changed = 0
+        for ci, con in enumerate(model._constraints):
+            sense = getattr(con, "sense", None)
+            if sense not in ("<=", ">="):
+                continue
+            row = _extract_row(model, con, n)
+            if row is None:
+                continue
+            coeffs, const = row
+            # Normalise to ``a·x ≤ rhs`` (fold const into rhs; reflect ≥).
+            a = coeffs.copy()
+            rhs = float(con.rhs) - const
+            sgn = 1.0
+            if sense == ">=":
+                a = -a
+                rhs = -rhs
+                sgn = -1.0
+            nz = [int(j) for j in np.nonzero(np.abs(a) > 1e-12)[0]]
+            bins = [j for j in nz if is_binary(j, lb[j], ub[j])]
+            if not bins:
+                continue
+            # Worst-case (max) activity of each term over the FBBT box.
+            term_max = {j: max(a[j] * lb[j], a[j] * ub[j]) for j in nz}
+            if not all(np.isfinite(v) for v in term_max.values()):
+                continue  # unbounded rest activity — cannot tighten yet
+            total_max = float(sum(term_max.values()))
+            row_changed = False
+            for k in bins:
+                ak = a[k]
+                u_rest = total_max - term_max[k]  # max activity of the rest (y_k excluded)
+                if ak > tol:
+                    slack = rhs - u_rest
+                    if slack > tol and slack + tol < ak:
+                        a[k] = ak - slack
+                        rhs -= slack
+                        row_changed = True
+                elif ak < -tol:
+                    new_ak = rhs - u_rest
+                    if new_ak > ak + tol and new_ak < -tol:
+                        a[k] = new_ak
+                        row_changed = True
+                else:
+                    continue
+                term_max[k] = max(a[k] * lb[k], a[k] * ub[k])
+                total_max = u_rest + term_max[k]
+            if not row_changed:
+                continue
+            # Reflect back to the original sense and REPLACE the constraint.
+            # Two hard requirements from the #772 post-mortem (see the section
+            # comment above):
+            #   1. fold the ENTIRE tightened row into the body and keep
+            #      ``rhs = 0.0`` — the normalized-form invariant every consumer
+            #      assumes (writing the slack into ``con.rhs`` is silently
+            #      dropped and RELAXES the row → false primal);
+            #   2. build a NEW Constraint object so the identity-keyed
+            #      evaluator-cache fingerprint changes and no stale compiled
+            #      evaluator keeps serving the old row.
+            # Normalized row is ``a·x ≤ rhs``; in original orientation the body
+            # is ``sgn·(a·x − rhs)`` compared against 0 with the original sense.
+            a_orig = a * sgn
+            new_const = -rhs * sgn
+            new_body = _rebuild_linear_body(blocks, a_orig, new_const)
+            model._constraints[ci] = Constraint(
+                new_body, con.sense, 0.0, getattr(con, "name", None)
+            )
+            round_changed += 1
+        total_changed += round_changed
+        if round_changed == 0:
+            break
+
+    if total_changed:
+        logger.info(
+            "Big-M coefficient tightening (DISCOPT_COEF_TIGHTEN): strengthened %d constraint rows",
+            total_changed,
+        )
+    return total_changed

--- a/python/tests/test_coef_tighten_774.py
+++ b/python/tests/test_coef_tighten_774.py
@@ -1,0 +1,393 @@
+"""Feasible-set equivalence gate for big-M coefficient tightening (#774, re-do of #770).
+
+The #770 implementation produced a FALSE PRIMAL (#772): its write-back moved the
+Savelsbergh slack into ``con.rhs``, violating the documented normalized-form
+invariant ``Constraint.rhs == 0.0``. Every consumer (``NLPEvaluator``, the
+relaxation compilers, ``_infer_constraint_bounds``) compiles the body and tests
+it against 0, so the rewritten row was silently RELAXED by the slack and the
+solver accepted integer points infeasible in the original problem.
+
+The #770 test suite checked feasible-set equivalence while *honoring* ``con.rhs``
+— mathematically true of the mutated model, but not what any consumer computes —
+so it passed on unsound code. This suite therefore reads rows exactly the way
+consumers do (``body ⋈ 0``) and enforces:
+
+  * the ``rhs == 0.0`` invariant survives the rewrite;
+  * feasible-set EQUIVALENCE in BOTH directions, proven per binary corner with
+    exact LPs (no sampling gaps): no integer-feasible point removed AND no
+    infeasible point admitted;
+  * the evaluator cache is invalidated by the rewrite (stale compiled
+    evaluators must not keep serving the un-tightened rows);
+  * a continuous variable with [0,1] bounds is NOT treated as binary (the
+    ``"IN" in "contINuous"`` misclassification latent in #770);
+  * end-to-end flag-ON regression on the real instance class: the reported
+    incumbent is feasible in the PRISTINE model and never super-optimal.
+
+Every test here fails against the reverted #770 implementation.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from discopt import Model
+from discopt.solvers._root_presolve import (
+    coef_tighten_enabled,
+    tighten_bigm_coefficients,
+)
+
+DATA_DIR = Path(__file__).parent / "data" / "minlplib_nl"
+BENCH_NL = Path(os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"))
+
+# minlplib.solu oracles (all maximize)
+OPT_SYN05HFSG = 837.7324009
+OPT_RSYN0805M = 1296.120603
+OPT_SYN40M = 67.71325586
+
+
+def _flag(monkeypatch, on: bool) -> None:
+    if on:
+        monkeypatch.setenv("DISCOPT_COEF_TIGHTEN", "1")
+    else:
+        monkeypatch.delenv("DISCOPT_COEF_TIGHTEN", raising=False)
+
+
+def _consumer_rows(model: Model):
+    """Rows exactly as solver consumers read them: ``coeffs·x + const ⋈ 0``.
+
+    ``NLPEvaluator`` compiles ``con.body`` and ``_infer_constraint_bounds``
+    derives cl/cu from the sense alone, so ``con.rhs`` is *never* consulted
+    downstream. Assert the normalized-form invariant instead of honoring a
+    nonzero rhs — a nonzero rhs IS the #772 bug.
+    """
+    from discopt._jax.problem_classifier import (
+        _extract_linear_coefficients,
+        _NotLinearError,
+    )
+
+    n = len(model._variables)
+    rows = []
+    for con in model._constraints:
+        assert con.rhs == 0.0, (
+            f"normalized-form invariant violated: con.rhs={con.rhs!r} (consumers "
+            "compile body vs 0 and silently drop rhs — the #772 false-primal bug)"
+        )
+        try:
+            coeffs, const = _extract_linear_coefficients(con.body, model, n)
+        except _NotLinearError:
+            continue
+        rows.append((np.asarray(coeffs, float), float(const), con.sense))
+    return rows
+
+
+def _feasible(rows, point: np.ndarray, tol: float = 1e-6) -> bool:
+    for coeffs, const, sense in rows:
+        act = float(coeffs @ point) + const
+        if sense == "<=" and act > tol:
+            return False
+        if sense == ">=" and act < -tol:
+            return False
+        if sense == "==" and abs(act) > tol:
+            return False
+    return True
+
+
+def _max_row_violation_lp(target_row, rows, bounds, fixed):
+    """Exact max of ``target_row`` violation subject to ``rows`` + box + fixations.
+
+    Returns the LP maximum of ``coeffs·x + const`` (sense ``<=``; callers
+    pre-orient) over the polytope defined by ``rows`` (consumer convention),
+    variable ``bounds``, and ``fixed`` (index -> value). ``None`` when the LP is
+    infeasible (that corner admits no point at all).
+    """
+    from scipy.optimize import linprog
+
+    t_coeffs, t_const, t_sense = target_row
+    obj = np.asarray(t_coeffs, float)
+    if t_sense == ">=":  # violation of a >= row is -(coeffs·x + const)
+        obj = -obj
+    a_ub, b_ub, a_eq, b_eq = [], [], [], []
+    for coeffs, const, sense in rows:
+        if sense == "<=":
+            a_ub.append(coeffs)
+            b_ub.append(-const)
+        elif sense == ">=":
+            a_ub.append(-coeffs)
+            b_ub.append(const)
+        else:
+            a_eq.append(coeffs)
+            b_eq.append(-const)
+    lp_bounds = list(bounds)
+    for j, v in fixed.items():
+        lp_bounds[j] = (v, v)
+    res = linprog(
+        -obj,  # maximize obj
+        A_ub=np.array(a_ub) if a_ub else None,
+        b_ub=np.array(b_ub) if b_ub else None,
+        A_eq=np.array(a_eq) if a_eq else None,
+        b_eq=np.array(b_eq) if b_eq else None,
+        bounds=lp_bounds,
+        method="highs",
+    )
+    if not res.success:
+        return None
+    val = float(obj @ res.x)
+    return val + (t_const if t_sense != ">=" else -t_const)
+
+
+def _assert_equivalent_at_integer_corners(orig: Model, tight: Model, tol: float = 1e-6):
+    """Exact bidirectional feasible-set equivalence, per binary corner.
+
+    For every assignment of the binaries:
+      * ADMIT direction: no point of the tightened polytope violates any
+        original row (feasible-in-tightened ⇒ feasible-in-original);
+      * REMOVE direction: no point of the original polytope violates any
+        tightened row (feasible-in-original ⇒ feasible-in-tightened).
+    LP maxima are exact — no sampling gap.
+    """
+    orig_rows = _consumer_rows(orig)
+    tight_rows = _consumer_rows(tight)
+    bounds = []
+    bins = []
+    for j, v in enumerate(orig._variables):
+        lb = float(getattr(v, "lb", 0.0))
+        ub = float(getattr(v, "ub", np.inf))
+        bounds.append((None if not np.isfinite(lb) else lb, None if not np.isfinite(ub) else ub))
+        vt = str(getattr(v, "vtype", getattr(v, "var_type", ""))).upper()
+        if vt.endswith("BINARY"):
+            bins.append(j)
+    assert bins, "test model must contain binaries"
+
+    for corner in itertools.product((0.0, 1.0), repeat=len(bins)):
+        fixed = dict(zip(bins, corner))
+        for row in orig_rows:
+            v = _max_row_violation_lp(row, tight_rows, bounds, fixed)
+            assert v is None or v <= tol, (
+                f"point ADMITTED at corner {corner}: original row violated by {v:.6g} "
+                "inside the tightened polytope (feasible set enlarged — the #772 bug class)"
+            )
+        for row in tight_rows:
+            v = _max_row_violation_lp(row, orig_rows, bounds, fixed)
+            assert v is None or v <= tol, (
+                f"feasible point REMOVED at corner {corner}: tightened row violated by "
+                f"{v:.6g} inside the original polytope (unsound tightening)"
+            )
+
+
+def _build_fixed_charge() -> Model:
+    """Small fixed-charge network with slack big-Ms in BOTH sign cases.
+
+    ``flow_i <= 5`` caps each flow while the big-M is 40 (8x slack) — the
+    ``a_k < 0`` fixed-charge case. The ``40·y0 + f0 + f1 <= 45`` row exercises
+    the positive-coefficient Savelsbergh case: FBBT caps the rest-activity at
+    10, so slack = 45 − 10 = 35 < a_k = 40 → a_k shrinks to 5.
+    """
+    m = Model("fc")
+    f0 = m.continuous("f0", lb=0.0, ub=float("inf"))
+    f1 = m.continuous("f1", lb=0.0, ub=float("inf"))
+    y0 = m.binary("y0")
+    y1 = m.binary("y1")
+    m.subject_to(f0 - 40.0 * y0 <= 0.0)  # fixed-charge (a_k < 0)
+    m.subject_to(f1 - 40.0 * y1 <= 0.0)
+    m.subject_to(f0 <= 5.0)  # capacity => FBBT ub(f)=5
+    m.subject_to(f1 <= 5.0)
+    m.subject_to(f0 + f1 >= 3.0)  # demand
+    m.subject_to(40.0 * y0 + f0 + f1 <= 45.0)  # Savelsbergh (a_k > 0)
+    m.maximize(f0 + f1 - 2.0 * y0 - 2.0 * y1)
+    return m
+
+
+# ── unit: flag gating and mechanism ──────────────────────────────────────────
+
+
+def test_flag_default_off(monkeypatch):
+    _flag(monkeypatch, False)
+    assert coef_tighten_enabled() is False
+    m = _build_fixed_charge()
+    cons_before = list(m._constraints)
+    assert tighten_bigm_coefficients(m) == 0
+    assert list(m._constraints) == cons_before  # same objects, untouched
+
+
+def test_fires_and_reduces_bigm(monkeypatch):
+    _flag(monkeypatch, True)
+    assert coef_tighten_enabled() is True
+    m = _build_fixed_charge()
+    n = tighten_bigm_coefficients(m)
+    assert n >= 2  # both fixed-charge rows tightened
+    for coeffs, _const, _sense in _consumer_rows(m):
+        assert np.max(np.abs(coeffs)) <= 6.0 + 1e-6, (
+            f"a slack big-M coefficient survived: {np.max(np.abs(coeffs))}"
+        )
+
+
+def test_unbounded_activity_row_skipped(monkeypatch):
+    """A row whose non-binary activity slack is zero is left untouched."""
+    _flag(monkeypatch, True)
+    m = Model("unb")
+    x = m.continuous("x", lb=0.0, ub=float("inf"))
+    y = m.binary("y")
+    m.subject_to(x - 40.0 * y <= 0.0)  # only bound on x is via this row
+    m.maximize(y)
+    # FBBT derives ub(x)=40 from the row itself => M == cap => nothing to do.
+    assert tighten_bigm_coefficients(m) == 0
+
+
+def test_continuous_unit_interval_var_is_not_binary(monkeypatch):
+    """The #770 classifier matched "IN" in "contINuous" — a continuous z∈[0,1]
+    was tightened as if it could only take values {0,1}, cutting its genuinely
+    feasible fractional range."""
+    _flag(monkeypatch, True)
+    m = Model("cont01")
+    x = m.continuous("x", lb=0.0, ub=float("inf"))
+    z = m.continuous("z", lb=0.0, ub=1.0)  # continuous, NOT a binary
+    m.subject_to(x - 40.0 * z <= 0.0)
+    m.subject_to(x <= 5.0)
+    m.maximize(x - z)
+    assert tighten_bigm_coefficients(m) == 0, (
+        "no binaries in the model — any rewrite treated a continuous [0,1] "
+        "variable as binary (unsound: removes fractional-z feasible points)"
+    )
+
+
+# ── the gate: exact bidirectional feasible-set equivalence ───────────────────
+
+
+def test_rhs_invariant_and_bidirectional_equivalence(monkeypatch):
+    orig = _build_fixed_charge()
+
+    _flag(monkeypatch, True)
+    tight = _build_fixed_charge()
+    assert tighten_bigm_coefficients(tight) >= 2
+    # _consumer_rows asserts the rhs==0 invariant on every constraint.
+    _assert_equivalent_at_integer_corners(orig, tight)
+
+
+def test_grid_equivalence_consumer_convention(monkeypatch):
+    """Redundant belt-and-braces sampling check at the consumer convention."""
+    orig = _build_fixed_charge()
+    orig_rows = _consumer_rows(orig)
+
+    _flag(monkeypatch, True)
+    tight = _build_fixed_charge()
+    assert tighten_bigm_coefficients(tight) >= 2
+    tight_rows = _consumer_rows(tight)
+
+    grid = np.linspace(0.0, 6.0, 13)  # spans past the ub=5 cap deliberately
+    removed = added = 0
+    for y0, y1 in itertools.product((0.0, 1.0), repeat=2):
+        for f0 in grid:
+            for f1 in grid:
+                pt = np.array([f0, f1, y0, y1], float)
+                fo = _feasible(orig_rows, pt)
+                ft = _feasible(tight_rows, pt)
+                removed += fo and not ft
+                added += ft and not fo
+    assert removed == 0, f"{removed} integer-feasible points removed (unsound)"
+    assert added == 0, f"{added} points newly admitted (the #772 bug class)"
+
+
+def test_evaluator_cache_invalidated(monkeypatch):
+    """Stale compiled evaluators must not survive the rewrite (identity-keyed
+    fingerprint): #770 mutated Constraint objects in place, so evaluators built
+    before the tightening kept serving the un-tightened rows."""
+    from discopt._jax.nlp_evaluator import cached_evaluator
+
+    _flag(monkeypatch, True)
+    m = _build_fixed_charge()
+    ev_pre = cached_evaluator(m)
+    assert tighten_bigm_coefficients(m) >= 2
+    ev_post = cached_evaluator(m)
+    assert ev_post is not ev_pre, "evaluator cache served a stale pre-tightening compile"
+
+    # And the post evaluator agrees with the consumer-convention rows.
+    rows = _consumer_rows(m)
+    pt = np.array([2.0, 3.0, 1.0, 1.0], float)
+    g = np.asarray(ev_post.evaluate_constraints(pt))
+    manual = np.array([float(c @ pt) + k for c, k, _s in rows])
+    np.testing.assert_allclose(g, manual, atol=1e-9)
+
+
+def test_optimum_unchanged(monkeypatch):
+    _flag(monkeypatch, False)
+    base = _build_fixed_charge().solve(time_limit=20, gap_tolerance=1e-6)
+
+    _flag(monkeypatch, True)
+    m = _build_fixed_charge()
+    assert tighten_bigm_coefficients(m) >= 2
+    _flag(monkeypatch, False)  # solve itself shouldn't re-tighten
+    tuned = m.solve(time_limit=20, gap_tolerance=1e-6)
+
+    assert base.objective is not None and tuned.objective is not None
+    assert tuned.objective == pytest.approx(base.objective, abs=1e-4, rel=1e-4)
+
+
+# ── real instance class (vendored corpus; CI-runnable) ───────────────────────
+
+
+def test_syn05hfsg_rhs_invariant_and_no_false_primal(monkeypatch):
+    """End-to-end flag-ON on the vendored process-synthesis instance: the
+    tightening fires, the rhs invariant holds, and the reported incumbent is
+    feasible in a PRISTINE model and never super-optimal (maximize)."""
+    import discopt.modeling as dm
+
+    nl = DATA_DIR / "syn05hfsg.nl"
+    _flag(monkeypatch, True)
+    m = dm.from_nl(str(nl))
+    n = tighten_bigm_coefficients(m)
+    assert n > 0, "tightening did not fire on the real fixed-charge class"
+    _consumer_rows(m)  # asserts rhs==0 on every row
+
+    r = dm.from_nl(str(nl)).solve(time_limit=60)
+    assert not getattr(r, "incumbent_verification_failed", False), (
+        "the #779 guard tripped — the solve produced a false primal"
+    )
+    assert r.objective is not None
+    assert r.objective <= OPT_SYN05HFSG + 1e-3, (
+        f"super-optimal incumbent {r.objective} > opt {OPT_SYN05HFSG} (false primal)"
+    )
+    # Independently verify the incumbent against a pristine parse.
+    from discopt._jax.nlp_evaluator import cached_evaluator
+    from discopt._jax.primal_heuristics import _check_constraint_feasibility
+
+    pm = dm.from_nl(str(nl))
+    flat = np.concatenate(
+        [np.atleast_1d(np.asarray(r.x[v.name], float)).ravel() for v in pm._variables]
+    )
+    assert _check_constraint_feasibility(cached_evaluator(pm), flat, tol=1e-4), (
+        "incumbent infeasible in the pristine original model (false primal)"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "name,opt",
+    [("rsyn0805m", OPT_RSYN0805M), ("syn40m", OPT_SYN40M)],
+)
+def test_772_named_regression(monkeypatch, name, opt):
+    """The exact #772 reproduction: flag-ON solve must return an incumbent that
+    is feasible in the pristine .nl model and not super-optimal."""
+    nl = BENCH_NL / f"{name}.nl"
+    if not nl.exists():
+        pytest.skip("benchmark corpus not available")
+    import discopt.modeling as dm
+    from discopt._jax.nlp_evaluator import cached_evaluator
+    from discopt._jax.primal_heuristics import _check_constraint_feasibility
+
+    _flag(monkeypatch, True)
+    r = dm.from_nl(str(nl)).solve(time_limit=60, verify_incumbent=False)
+    assert r.objective is not None
+    assert r.objective <= opt + 1e-3, (
+        f"super-optimal incumbent {r.objective} > opt {opt} (the #772 false primal)"
+    )
+    pm = dm.from_nl(str(nl))
+    flat = np.concatenate(
+        [np.atleast_1d(np.asarray(r.x[v.name], float)).ravel() for v in pm._variables]
+    )
+    assert _check_constraint_feasibility(cached_evaluator(pm), flat, tol=1e-4), (
+        "incumbent infeasible in the pristine original model (the #772 false primal)"
+    )


### PR DESCRIPTION
# feat(#774): re-implement big-M coefficient tightening correctly (`DISCOPT_COEF_TIGHTEN`, default-OFF)

Re-lands the #282 Stage-1 lever (activity-based big-M coefficient tightening) that was reverted in #773 after the #772 P0 false primal — with the actual root cause found by measurement, fixed, and gated by a test that fails against the old code.

## Root cause (measured — NOT the suspected `a_k<0` derivation error)

#774 hypothesized a sign/bound error in the fixed-charge case. Reproduction + row-level forensics on `rsyn0805m` falsified that: **the #770 math was valid in both sign cases; the write-back broke two model invariants.**

1. **`Constraint.rhs` must stay `0.0`** (documented normalized-form invariant on the dataclass; every comparison operator constructs `rhs=0.0`). #770 moved the Savelsbergh slack into `con.rhs` (0 → −slack). Every consumer — `NLPEvaluator`, the relaxation compilers, `_infer_constraint_bounds` (cl/cu from the *sense alone*) — compiles the body and tests it against 0, so the slack was silently dropped: the rewritten row was read as `body' ≤ 0` instead of `body' ≤ −slack`, a **relaxation** by the slack. The smoking gun: at the false incumbent, every violated row satisfies `new_body ≤ 0` (e.g. −34.04 ≤ 0) while the true tightened row requires `≤ −51.6` — and the violation of the *consistent* tightened row is invariant at y=1 (both sides shift by slack), so the point was infeasible in the correctly-read mutated model too. The false primal was purely the mixed read.
2. **Stale compiled evaluators**: the evaluator cache (`evaluator_fingerprint`) is keyed on constraint *object identity*; #770 mutated `con.body` in place, so evaluators compiled before the tightening kept serving un-tightened rows (verified: `cached_evaluator` returned the same object across the mutation).

Also fixed en route (latent, other direction): the #770 binary classifier tested `"IN" in vtype.upper()`, which matches `"contINuous"` — a continuous variable whose FBBT bounds happen to be `[0,1]` was tightened as if it could only take values {0,1}, removing genuinely feasible fractional points.

## The fix

- Fold the **entire tightened row into the body** (`body' = sgn·(a·x − rhs)`), keeping `rhs = 0.0` — consumers see either the old row or the new row, never a mixed relaxed one.
- **Replace** each rewritten `Constraint` with a new object — the identity-keyed fingerprint changes, forcing a consistent re-compile (the #779 guard intentionally keeps its own pre-presolve snapshot).
- Classifier matches only `BINARY` / `INTEGER`-with-`[0,1]`-bounds.
- Derivation + two-directional equivalence argument + full #772 post-mortem recorded in the module's section comment.

## The gate test (`python/tests/test_coef_tighten_774.py`) — why it catches what #770's couldn't

The #770 suite checked feasible-set equivalence while *honoring* `con.rhs` — mathematically true of the mutated model, but not what any consumer computes — so it passed on unsound code. The new suite reads rows **the way consumers do** (`body ⋈ 0`, asserting the `rhs == 0` invariant) and proves feasible-set equivalence **in BOTH directions with exact LPs per binary corner** (scipy/HiGHS; no sampling gap): no integer-feasible point removed AND no infeasible point admitted. Plus: evaluator-cache invalidation, continuous-[0,1] misclassification guard, flag-off inertness, optimum-unchanged differential, and end-to-end no-false-primal on vendored `syn05hfsg`.

**Fails-before/passes-after:** 6/9 fast tests fail against the reverted #770 implementation; all pass against this one. Slow named regressions (`rsyn0805m`, `syn40m` flag-ON, the exact #772 reproduction): incumbent verified feasible in the pristine `.nl` and not super-optimal — both pass.

(Interesting nuance: `syn05hfsg` never reproduced the false primal even on #770 — its rewrites are pure fixed-charge, which coincidentally left `rhs=0` consistent. The false primal needed the `a_k>0` Savelsbergh case, which fires on `rsyn*`/`syn40m`. That is why #770's vendored-corpus sweep missed it; the synthetic gate tests cover that case in CI.)

## Flag disposition

**Stays default-OFF.** #282 Stage 4 measured that the tightening alone certifies nothing new on the panel (sound ≠ helpful). This PR restores a *sound* opt-in lever for the root-cut work that compounds on it; graduation is a separate, later call per the CLAUDE.md §5 panel gate.

## Verification

- **#772 repro, fixed:** `rsyn0805m` flag-ON 60 s → **0 violations** vs pristine model, obj 1171.44 ≤ opt 1296.12, dual bound 1610.41 ≥ opt (sound, maximize). Was: infeasible incumbent, obj 1441.99 > opt.
- **Consumer-consistency probe:** fresh + cached evaluators on the mutated model now reject the #772 incumbent identically (violation 17.5625, matching the pre-mutation read); cache object correctly invalidated.
- `pytest -m smoke` → **831 passed, 1 skipped, 2 xpassed**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**
- `python/tests/test_coef_tighten_774.py` → **9 fast + 2 slow passed**
- **Flag-ON soundness sweep** (66 vendored instances, 20 s each, oracle = `minlplib.solu`, #779 guard active): **0 violations** — no bound past its oracle, no super-optimal incumbent, guard never tripped.
- **Convex-panel A/B** (`rsyn0805m/0810m/0815m/syn40m`, 30 s, ON vs OFF; maximize — lower dual bound = tighter; all four sound in both arms):

  | instance | dual bound OFF → ON | incumbent OFF → ON | nodes OFF → ON |
  |---|---|---|---|
  | rsyn0805m | 1864.8 → **1732.4** | 1055.8 → **1105.7** | 159 → 191 |
  | rsyn0810m | 2533.7 → **2482.8** | 1417.3 → **1467.2** | 159 → 127 |
  | rsyn0815m | 1987.5 → 2201.0 † | 1041.5 → **1056.9** | 127 → 63 |
  | syn40m | 1242.9 → **649.5** | 31.0 → −38.2 † | 383 → 191 |

  † anytime-snapshot effects, not soundness: rsyn0815m's ON arm processed half the nodes at 30 s so its frontier bound is behind (both arms' bounds are sound, ≥ opt); syn40m's ON incumbent is worse at 30 s but sound (≤ opt 67.7). The syn40m dual bound halving is the Stage-1 lever the SCIP attribution predicted. Consistent with the Stage-4 finding that the flag alone certifies nothing new — the default stays OFF.
- `ruff check` / `ruff format` clean; mypy pre-commit clean. **No Rust touched.** Default path untouched (flag-gated; OFF path byte-identical).

## Issue disposition

Completes item 1 of #774 (item 2, the final-incumbent verification guard, landed in #779). With this merged, **#774 can be closed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
