### PR TITLE
feat(#774): re-implement big-M coefficient tightening (feasible-set-equivalent, DISCOPT_COEF_TIGHTEN, default-OFF)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5285,6 +5285,27 @@ def solve_model(
         except Exception as e:
             logger.debug("Root presolve failed: %s", e)
 
+    # --- Activity-based big-M coefficient tightening (#282/#774, opt-in) ---
+    # Shrinks big-M coefficients on binary-indicator rows toward the FBBT/probing
+    # activity slack. Feasible-set-equivalent (it strictly tightens the LP
+    # relaxation at fractional binaries without adding or removing any
+    # integer-feasible point), gated behind ``SolverTuning.coef_tighten`` /
+    # ``DISCOPT_COEF_TIGHTEN`` (default OFF, CLAUDE.md §5). Runs once at the root
+    # here, before dispatch, so it benefits BOTH the NLP-BB and the spatial B&B
+    # paths. Rewrites the Python constraint DAG in place in native normal form
+    # (constant in the body, rhs 0) — the #774 fix for the #770 false primal.
+    # Skipped once the budget is blown (#654): declining it leaves the original,
+    # still-valid rows.
+    if presolve and _tuning().coef_tighten and not _deadline_exhausted():
+        try:
+            from discopt.solvers._root_presolve import tighten_bigm_coefficients
+
+            n_ct = tighten_bigm_coefficients(model)
+            if n_ct > 0:
+                logger.info("Coefficient tightening: strengthened %d big-M rows", n_ct)
+        except Exception as e:
+            logger.debug("Coefficient tightening failed: %s", e)
+
     # --- Reverse-AD interval tightening (M9 of #51, opt-in) ---
     # Iterates Gauss-Seidel reverse-mode interval AD over every
     # constraint to a fixed point and writes back tighter scalar bounds.

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -511,6 +511,28 @@ class SolverTuning:
     everything else bound-neutral. A/B root values re-confirmed load-independent
     (``results/issue282/root_lp_probe_ab_reconfirm_*.json``)."""
 
+    coef_tighten: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_COEF_TIGHTEN", default=False)
+    )
+    """Activity-based big-M coefficient tightening at the root (issue #282/#774,
+    ``DISCOPT_COEF_TIGHTEN``, **default OFF**; §5 bound-changing, opt-in).
+
+    Rewrites each linear inequality carrying a binary indicator, shrinking the
+    binary's coefficient toward the FBBT/probing activity slack of the rest of the
+    row (Savelsbergh positive-coefficient + fixed-charge negative-coefficient
+    cases). Feasible-set-**equivalent** — no integer-feasible point is added or
+    removed — so the LP relaxation tightens at fractional binaries while every
+    integer corner is preserved. The rewrite is emitted in ``from_nl``'s native
+    normal form (constant in the body, ``con.rhs == 0``); the #770 revert (#773)
+    was a malformed write-back that split the constant across body and rhs and
+    admitted a false primal (rsyn0805m 1441.99 > =opt= 1296.12), re-derived and
+    fixed in #774.
+
+    Default OFF pending a net-positive graduation panel: #282 Stage 4 measured it
+    tightens the root (syn40m ~56% of the discopt→SCIP spread) but certifies
+    nothing extra on the panel, so it ships as a sound opt-in lever (HOLD, sound ≠
+    helpful — the DISCOPT_CUT_INHERIT lesson) rather than default-ON."""
+
     rlt1_root_bound: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_RLT1_ROOT_BOUND", default=False)
     )

--- a/python/discopt/solvers/_root_presolve.py
+++ b/python/discopt/solvers/_root_presolve.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 import numpy as np
@@ -115,3 +116,319 @@ def tighten_root_bounds_with_fbbt(
 
     changed = bool(np.any(tightened_lb > orig_lb + tol) or np.any(tightened_ub < orig_ub - tol))
     return tightened_lb, tightened_ub, infeasible, changed
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Activity-based big-M coefficient tightening (issue #282 / #774)
+# ─────────────────────────────────────────────────────────────────────
+#
+# Standard MIP presolve (Savelsbergh 1994; Achterberg 2007): for a linear
+# row ``Σ_{j≠k} a_j x_j + a_k y ⋈ b`` with ``y ∈ {0,1}`` binary and the rest
+# of the activity bounded, the binary coefficient ``a_k`` can be shrunk toward
+# the activity slack of the rest of the row **without changing the set of
+# integer-feasible points** — the LP relaxation strictly tightens at fractional
+# ``y`` while every integer corner is preserved exactly.
+#
+# Two cases, both derived for a normalised ``≤`` row (``≥`` rows are reflected):
+#
+#   u_rest = max activity of the rest (Σ_{j≠k} a_j x_j) over the current box.
+#
+#   * ``a_k > 0`` (Savelsbergh): slack = rhs − u_rest. If ``0 < slack < a_k``,
+#     set ``a_k ← a_k − slack`` and ``rhs ← rhs − slack``. At y=0 the row becomes
+#     ``rest ≤ u_rest`` (an implied, box-tight bound — equivalent, no point
+#     changed); at y=1 it is unchanged.
+#   * ``a_k < 0`` (fixed-charge ``flow − M·y ≤ b``, a_k = −M): set
+#     ``a_k ← rhs − u_rest`` and keep ``rhs``, applied only when this raises
+#     ``a_k`` (reduces the big-M) and keeps it negative. At y=0 the row is
+#     unchanged; at y=1 the new row is the implied ``rest ≤ u_rest`` and the old
+#     row ``rest ≤ rhs − a_k`` is *also* implied (the applied guard
+#     ``rhs − u_rest > a_k`` ⇔ ``u_rest < rhs − a_k``), so the two are equivalent.
+#
+# ``u_rest`` uses FBBT+probing bounds that are valid over the whole feasible
+# region (verified on rsyn0805m: the row whose declared box allowed rest≤7 has a
+# true feasible max of 5.755, exactly the probed u_rest). The strengthened row is
+# therefore valid over the root box and every descendant B&B node. Rows whose
+# rest activity is not finite under those bounds are SKIPPED (never guessed).
+#
+# ── #770/#774 ROOT CAUSE + THE FIX ────────────────────────────────────
+# The reverted #770 pass had SOUND math but an unsound **write-back**. It stored
+# ``con.body = rebuild(a', const)`` (constant left embedded in the body) AND
+# ``con.rhs = rhs_norm' + const`` (a now-nonzero rhs), splitting the constant
+# across body and rhs simultaneously. Every constraint ``from_nl`` produces keeps
+# the whole constant in the body with ``con.rhs == 0`` (verified: 214/214 rsyn0805m
+# inequality rows), so that split is a normal form the relaxation/feasibility
+# pipeline never sees natively — a downstream component reads only one of the two,
+# shifting the enforced row by ``const`` and admitting a false primal (rsyn0805m
+# reported 1441.99 > =opt= 1296.12, feasible in the mutated model but not the
+# original). This pass instead writes back in the native normal form: the entire
+# tightened constant goes into the body and ``con.rhs`` is set to 0, so the
+# rewritten row is byte-for-byte the shape ``from_nl`` emits. (The mislabel in the
+# original diagnosis — "fixed-charge sign error" — was wrong: fixed-charge only
+# changes ``a_k`` and never touches rhs; it was the Savelsbergh ``rhs -= slack``
+# path whose write-back split the constant.)
+
+
+def coef_tighten_enabled() -> bool:
+    """Whether ``DISCOPT_COEF_TIGHTEN`` opt-in flag is set (default OFF).
+
+    Bound-changing presolve (CLAUDE.md §5): the strengthened LP relaxation is
+    only smaller than the original and preserves the integer-feasible set
+    exactly, so it is sound, but it stays default-OFF until a corpus-wide
+    differential panel graduates it. The solver call site gates on the
+    :attr:`~discopt.solver_tuning.SolverTuning.coef_tighten` field; this env
+    helper is the standalone/legacy default for direct callers.
+    """
+    val = os.environ.get("DISCOPT_COEF_TIGHTEN", "0").strip().lower()
+    return val not in ("", "0", "false", "off", "no")
+
+
+def _extract_row(model: Model, con, n: int):
+    """Return ``(coeffs, const)`` for a linear constraint body, or ``None``.
+
+    ``coeffs`` is a dense length-``n`` float vector over flat scalar-variable
+    slots; ``const`` is the free term. ``None`` when the body is non-linear or
+    otherwise not extractable — such rows are left untouched.
+    """
+    from discopt._jax.problem_classifier import (  # local import: heavy _jax dep
+        _extract_linear_coefficients,
+        _NotLinearError,
+    )
+
+    try:
+        coeffs, const = _extract_linear_coefficients(con.body, model, n)
+    except _NotLinearError:
+        return None
+    except Exception as exc:  # pragma: no cover - defensive; skip unparsable rows
+        logger.debug("coef-tighten: row extraction failed: %s", exc)
+        return None
+    return np.asarray(coeffs, dtype=np.float64), float(const)
+
+
+def _strong_block_bounds(model: Model, time_limit_ms: int) -> tuple[np.ndarray, np.ndarray] | None:
+    """Block-aligned tightened bounds from the root presolve orchestrator.
+
+    Runs FBBT + implied-bounds + probing + simplify (the full bound-tightening
+    orchestrator, but with the *variable-eliminating* passes disabled) so the
+    returned per-block arrays stay aligned 1:1 with ``model._variables`` — no
+    elimination/aggregation remaps the index space. Probing tightens the
+    binary-indicator flows far more than bare FBBT alone; the extra activity
+    slack it exposes is what the coefficient tightening spends. Because probing
+    is the expensive part, this is called **once** per solve; the compounding
+    rounds reuse the cheap direct-FBBT binding.
+
+    The tightened bounds are read from the ``stats['fbbt']`` channel because the
+    returned repr's ``var_ub``/``var_lb`` are *not* updated by the orchestrator
+    (``propagate_bounds_to_model`` reads the same stale repr). All bounds
+    returned are valid over the feasible region.
+    """
+    try:
+        from discopt._jax.presolve_pipeline import run_root_presolve
+        from discopt._rust import model_to_repr
+
+        repr0 = model_to_repr(model, getattr(model, "_builder", None))
+        _, stats = run_root_presolve(
+            repr0,
+            eliminate=False,
+            aggregate=False,
+            factorable_elim=False,
+            redundancy=False,
+            polynomial=False,
+            fbbt=True,
+            implied_bounds=True,
+            probing=True,
+            simplify=True,
+            max_iterations=8,
+            time_limit_ms=time_limit_ms,
+        )
+        fb = stats.get("fbbt")
+        if not fb:
+            return None
+        lbs = np.asarray(fb["lb"], dtype=np.float64)
+        ubs = np.asarray(fb["ub"], dtype=np.float64)
+    except Exception as exc:
+        logger.debug("coef-tighten: strong bound tightening unavailable: %s", exc)
+        return None
+    nblk = len(model._variables)
+    if lbs.size < nblk or ubs.size < nblk:
+        return None
+    return lbs[:nblk], ubs[:nblk]
+
+
+def _cheap_block_bounds(model: Model) -> tuple[np.ndarray, np.ndarray] | None:
+    """Block-aligned bounds from the bare FBBT binding (fast, no probing).
+
+    Used for the compounding rounds after the one-shot probing pass: once the
+    big-M coefficients have been shrunk, plain FBBT re-derives tighter flow
+    bounds from the strengthened rows, unlocking a further round of tightening
+    at negligible cost. FBBT bounds are valid over the feasible region.
+    """
+    try:
+        from discopt._rust import model_to_repr
+
+        repr_ = model_to_repr(model, getattr(model, "_builder", None))
+        lbs, ubs = repr_.fbbt(max_iter=20, tol=1e-9)
+    except Exception as exc:
+        logger.debug("coef-tighten: cheap FBBT unavailable: %s", exc)
+        return None
+    lbs = np.asarray(lbs, dtype=np.float64)
+    ubs = np.asarray(ubs, dtype=np.float64)
+    if lbs.size != len(model._variables) or ubs.size != len(model._variables):
+        return None
+    return lbs, ubs
+
+
+def _is_binary_var(var, lb: float, ub: float) -> bool:
+    """Whether ``var`` takes only ``{0,1}`` under the box ``[lb, ub]``.
+
+    Binary-like ⟺ an *integer-typed* (``BINARY`` or ``INTEGER``) variable with a
+    ``[0, 1]`` box. A **continuous** ``[0, 1]`` variable must NOT qualify: the
+    coefficient tightening changes the row at fractional values, which preserves
+    the feasible set only when the variable is genuinely integral.
+
+    NB: a naive ``"IN" in str(vtype).upper()`` test is WRONG — ``"CONTINUOUS"``
+    contains ``"IN"``, so it would wrongly classify a continuous ``[0, 1]``
+    variable as binary (the latent unsoundness this guards, #774). Match the
+    type *name* against ``BINARY``/``INTEGER`` instead.
+    """
+    vt = getattr(var, "vtype", getattr(var, "var_type", ""))
+    name = str(getattr(vt, "name", vt)).upper()
+    is_integral = ("BINARY" in name) or ("INTEGER" in name)
+    return is_integral and lb == 0.0 and ub == 1.0
+
+
+def _rebuild_linear_body(blocks, coeffs: np.ndarray, const: float):
+    """Rebuild ``Σ coeffs[j]·var_j (+const)`` as a modeling expression."""
+    body = None
+    nz = np.nonzero(np.abs(coeffs) > 1e-15)[0]
+    for j in nz:
+        term = float(coeffs[j]) * blocks[j]
+        body = term if body is None else body + term
+    if abs(const) > 1e-15:
+        body = float(const) if body is None else body + float(const)
+    if body is None:
+        body = 0.0
+    return body
+
+
+def tighten_bigm_coefficients(
+    model: Model,
+    *,
+    max_rounds: int = 6,
+    tol: float = 1e-7,
+    probe_time_ms: int = 5000,
+) -> int:
+    """Activity-based big-M coefficient tightening on ``model`` (issue #282/#774).
+
+    Rewrites linear constraint rows that contain a binary variable, shrinking the
+    binary's coefficient toward the activity slack of the rest of the row (both
+    the positive-coefficient Savelsbergh case and the negative-coefficient
+    fixed-charge case). Iterates with FBBT bound tightening to a fixed point.
+
+    The transformation is **feasible-set-equivalent**: it changes no
+    integer-feasible point (it only shrinks the LP relaxation at fractional
+    binaries), so it is sound. It mutates ``model._constraints`` in place and
+    returns the number of rows rewritten across all rounds.
+
+    The rewritten rows are emitted in ``from_nl``'s native normal form (whole
+    constant in the body, ``con.rhs == 0``); see the module header for the
+    #770/#774 write-back root cause this avoids.
+
+    Scope (conservative, sound):
+      * only linear inequality rows with ≥1 binary,
+      * only rows whose non-binary worst-case activity is finite under the
+        current (valid) FBBT/probing bounds — unbounded activity ⇒ SKIPPED,
+      * scalar (size-1) variable blocks only.
+
+    Gating is the caller's responsibility (``SolverTuning.coef_tighten`` /
+    ``DISCOPT_COEF_TIGHTEN``); calling this directly always runs it.
+    """
+    blocks = model._variables
+    # Only operate when every block is a scalar variable — the flat slot j then
+    # equals block j, so bounds/coeffs line up without per-element offsets.
+    if any(getattr(b, "size", 1) != 1 for b in blocks):
+        return 0
+    n = len(blocks)
+
+    def is_binary(i: int, lb: float, ub: float) -> bool:
+        return _is_binary_var(blocks[i], lb, ub)
+
+    total_changed = 0
+    for _round in range(max_rounds):
+        # One expensive probing pass for the first round (it exposes the most
+        # activity slack); cheap bare-FBBT for the compounding rounds.
+        fb = (
+            _strong_block_bounds(model, probe_time_ms)
+            if _round == 0
+            else _cheap_block_bounds(model)
+        )
+        if fb is None:
+            break
+        lb, ub = fb
+        round_changed = 0
+        for con in model._constraints:
+            sense = getattr(con, "sense", None)
+            if sense not in ("<=", ">="):
+                continue
+            row = _extract_row(model, con, n)
+            if row is None:
+                continue
+            coeffs, const = row
+            # Normalise to ``a·x ≤ rhs`` (fold const into rhs; reflect ≥).
+            a = coeffs.copy()
+            rhs = float(con.rhs) - const
+            sgn = 1.0
+            if sense == ">=":
+                a = -a
+                rhs = -rhs
+                sgn = -1.0
+            nz = [int(j) for j in np.nonzero(np.abs(a) > 1e-12)[0]]
+            bins = [j for j in nz if is_binary(j, lb[j], ub[j])]
+            if not bins:
+                continue
+            # Worst-case (max) activity of each term over the FBBT box.
+            term_max = {j: max(a[j] * lb[j], a[j] * ub[j]) for j in nz}
+            if not all(np.isfinite(v) for v in term_max.values()):
+                continue  # unbounded rest activity — cannot tighten soundly
+            total_max = float(sum(term_max.values()))
+            row_changed = False
+            for k in bins:
+                ak = a[k]
+                u_rest = total_max - term_max[k]  # max activity of the rest (y_k excluded)
+                if ak > tol:
+                    slack = rhs - u_rest
+                    if slack > tol and slack + tol < ak:
+                        a[k] = ak - slack
+                        rhs -= slack
+                        row_changed = True
+                elif ak < -tol:
+                    new_ak = rhs - u_rest
+                    if new_ak > ak + tol and new_ak < -tol:
+                        a[k] = new_ak
+                        row_changed = True
+                else:
+                    continue
+                term_max[k] = max(a[k] * lb[k], a[k] * ub[k])
+                total_max = u_rest + term_max[k]
+            if not row_changed:
+                continue
+            # Write back in the NATIVE normal form (the #770/#774 fix): fold the
+            # entire constant into the body and set ``con.rhs`` to 0, so the row
+            # matches exactly the shape ``from_nl`` emits — never a body-constant
+            # coexisting with a nonzero rhs (the malformed split that admitted the
+            # #770 false primal). ``new_coeffs·x + new_const ⋈ 0`` reproduces the
+            # tightened normalised ``a·x ≤ rhs`` exactly under either sense.
+            new_coeffs = a * sgn
+            new_const = -sgn * rhs
+            con.body = _rebuild_linear_body(blocks, new_coeffs, new_const)
+            con.rhs = 0.0
+            round_changed += 1
+        total_changed += round_changed
+        if round_changed == 0:
+            break
+
+    if total_changed:
+        logger.info(
+            "Big-M coefficient tightening (DISCOPT_COEF_TIGHTEN): strengthened %d constraint rows",
+            total_changed,
+        )
+    return total_changed

--- a/python/tests/test_coef_tighten_equivalence_774.py
+++ b/python/tests/test_coef_tighten_equivalence_774.py
@@ -1,0 +1,254 @@
+"""Both-directions feasible-set-equivalence gate for big-M coefficient tightening (#774).
+
+The #770 gate only checked "no integer-feasible point REMOVED". The #772 false
+primal (rsyn0805m 1441.99 > =opt= 1296.12) proved that insufficient: a tightening
+that also ADMITS an infeasible point is equally unsound. This module adds the
+missing direction and pins the exact bug class down two ways.
+
+1. ``test_optimum_preserved`` — the both-directions gate *at the answer level*.
+   Solve each small vendored instance to optimality with the flag OFF and ON and
+   assert the certified optima are equal (feasible-set-equivalence ⟹ same optimum)
+   AND that the flag-ON incumbent is feasible in a freshly parsed ORIGINAL model.
+   A tightening that ADMITS an infeasible point moves the optimum (a false primal);
+   one that REMOVES a feasible point moves it the other way (a false bound). Either
+   fails this test. This is the direct regression guard for the #770/#772 defect.
+
+2. ``test_no_infeasible_admitted_lp`` — a fast, non-sampling structural guard on
+   the linear subsystem (where every coefficient change lives): for each binary
+   assignment, LP-certify over the DECLARED box that no point satisfying all
+   TIGHTENED linear rows violates any ORIGINAL linear row. Because the nonlinear
+   rows are byte-identical in both models and the declared box contains the whole
+   feasible region, this is an exact, rigorous certificate that the tightening can
+   never admit an infeasible (false-primal) point — the #772 direction the #770
+   test missed. It also catches the continuous-[0,1] misclassification class (a
+   continuous variable wrongly treated as a binary indicator).
+
+3. ``test_incumbent_feasible_in_fresh_original`` — end-to-end guard on the #282
+   false-primal instance rsyn0805m: the write-back representation bug is invisible
+   at the normalized-row level but corrupts the solve pipeline, so this exercises a
+   real solve and checks the incumbent against a fresh original model.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.modeling.core import Model
+from discopt.solvers._root_presolve import (
+    _extract_row,
+    _is_binary_var,
+    tighten_bigm_coefficients,
+)
+
+VENDORED = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
+
+# Small vendored instances whose big-M rows the pass rewrites and that solve to
+# optimality quickly (probed). ``opt`` is the minlplib.solu reference optimum.
+PRESERVE_INSTANCES = {
+    "gbd": 2.2000000000,
+    "gkocis": -1.9230987380,
+    "ex1221": 7.6671800690,
+    "st_test1": 0.0000000000,
+    "alan": 2.9250000000,
+}
+LP_ADMIT_INSTANCES = ["gbd", "gkocis", "flay02m", "syn05hfsg", "st_test1", "alan", "ex1221"]
+
+
+def _var_kind(v):
+    vt = getattr(v, "vtype", getattr(v, "var_type", ""))
+    name = str(getattr(vt, "name", vt)).upper()
+    return "int" if (("BINARY" in name) or ("INTEGER" in name)) else "cont"
+
+
+def _linear_rows(model, n):
+    """All linear inequality rows as normalized (a, b) for ``a·x <= b``."""
+    rows = []
+    for con in model._constraints:
+        sense = getattr(con, "sense", None)
+        if sense not in ("<=", ">="):
+            continue
+        r = _extract_row(model, con, n)
+        if r is None:
+            continue
+        coeffs, const = r
+        a = np.asarray(coeffs, float).copy()
+        b = float(con.rhs) - const
+        if sense == ">=":
+            a = -a
+            b = -b
+        rows.append((a, b))
+    return rows
+
+
+def test_continuous_unit_is_not_binary():
+    """A continuous [0,1] variable must NOT be classified as a binary indicator.
+
+    Regression for the latent unsoundness in the #770 pass: ``"IN" in vtype`` is
+    true for ``"CONTINUOUS"``, so a continuous [0,1] variable was treated as a
+    binary and its coefficient tightened — cutting its fractional feasible values.
+    """
+    m = Model("kinds")
+    b = m.binary("b")
+    z = m.continuous("z", lb=0.0, ub=1.0)
+    i01 = m.integer("i01", lb=0, ub=1)
+    i05 = m.integer("i05", lb=0, ub=5)
+    c = m.continuous("c", lb=0.0, ub=10.0)
+    assert _is_binary_var(b, 0.0, 1.0) is True
+    assert _is_binary_var(i01, 0.0, 1.0) is True  # integer with a [0,1] box is binary-like
+    assert _is_binary_var(z, 0.0, 1.0) is False  # the bug: continuous [0,1] is NOT binary
+    assert _is_binary_var(i05, 0.0, 5.0) is False  # integer but not [0,1]
+    assert _is_binary_var(c, 0.0, 10.0) is False
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("name", sorted(PRESERVE_INSTANCES))
+def test_optimum_preserved(name):
+    """Both directions, answer level: flag OFF vs ON certify the same optimum,
+    and the ON incumbent is feasible in a fresh ORIGINAL model."""
+    path = os.path.join(VENDORED, f"{name}.nl")
+    if not os.path.exists(path):
+        pytest.skip(f"{name} not vendored")
+    opt = PRESERVE_INSTANCES[name]
+
+    m_off = dm.from_nl(path)
+    res_off = m_off.solve(time_limit=60)
+
+    m_on = dm.from_nl(path)
+    nrw = tighten_bigm_coefficients(m_on)
+    res_on = m_on.solve(time_limit=60)
+
+    assert res_off.objective is not None and res_on.objective is not None
+    # 1. Both agree with the oracle optimum (neither admits nor removes a point
+    #    that would move the certified optimum).
+    assert res_off.objective == pytest.approx(opt, abs=1e-3, rel=1e-4), (
+        f"{name}: flag-OFF optimum {res_off.objective} != oracle {opt}"
+    )
+    assert res_on.objective == pytest.approx(opt, abs=1e-3, rel=1e-4), (
+        f"{name}: flag-ON optimum {res_on.objective} != oracle {opt} "
+        f"(tightening moved the optimum — not feasible-set-equivalent; {nrw} rows rewritten)"
+    )
+
+    # 2. The flag-ON incumbent is feasible in a freshly parsed ORIGINAL model.
+    m0 = dm.from_nl(path)
+    n = len(m0._variables)
+    names = [v.name for v in m0._variables]
+    sol = res_on.x if isinstance(getattr(res_on, "x", None), dict) else {}
+    if sol:
+        x = np.array([float(np.ravel(sol.get(nm, 0.0))[0]) for nm in names])
+        worst = max((float(a @ x) - b for a, b in _linear_rows(m0, n)), default=0.0)
+        assert worst <= 1e-4, f"{name}: ON incumbent violates original linear rows by {worst}"
+
+
+def _admit_violation(orig_rows, tight_rows, bin_idx, lb, ub, bin_values):
+    """LP-certify over the box: does any point satisfying all TIGHT rows violate
+    an ORIG row (with binaries fixed to ``bin_values``)? Returns (row, slack) or None."""
+    from scipy.optimize import linprog
+
+    n = len(lb)
+    bounds = [(float(lb[j]), None if not np.isfinite(ub[j]) else float(ub[j])) for j in range(n)]
+    bin_idx = np.asarray(bin_idx)
+    bvals = np.asarray(bin_values, float)
+
+    def reduce_rows(rows):
+        red = []
+        for a, b in rows:
+            a = np.asarray(a, float)
+            b_red = b - float(a[bin_idx] @ bvals)
+            a_free = a.copy()
+            a_free[bin_idx] = 0.0
+            red.append((a_free, b_red))
+        return red
+
+    tight_sys = reduce_rows(tight_rows)
+    orig_sys = reduce_rows(orig_rows)
+    A_ub = np.array([a for a, _ in tight_sys]) if tight_sys else None
+    b_ub = np.array([b for _, b in tight_sys]) if tight_sys else None
+    for a_obj, b_obj in orig_sys:
+        if np.allclose(a_obj, 0.0):
+            continue
+        res = linprog(-a_obj, A_ub=A_ub, b_ub=b_ub, bounds=bounds, method="highs")
+        if res.status == 3:  # unbounded ⇒ tight system does not imply this orig row
+            return (-1, float("inf"))
+        if res.status == 0 and (-res.fun - b_obj) > 1e-6:
+            return (-1, float(-res.fun - b_obj))
+    return None
+
+
+@pytest.mark.correctness
+@pytest.mark.parametrize("name", LP_ADMIT_INSTANCES)
+def test_no_infeasible_admitted_lp(name):
+    """Rigorous LP guard: the tightening admits no infeasible (false-primal) point."""
+    pytest.importorskip("scipy")
+    path = os.path.join(VENDORED, f"{name}.nl")
+    if not os.path.exists(path):
+        pytest.skip(f"{name} not vendored")
+
+    m_orig = dm.from_nl(path)
+    m_tight = dm.from_nl(path)
+    n = len(m_tight._variables)
+    if any(getattr(b, "size", 1) != 1 for b in m_tight._variables):
+        pytest.skip("non-scalar blocks")
+    if tighten_bigm_coefficients(m_tight) == 0:
+        pytest.skip(f"{name}: pass rewrote nothing")
+
+    orig_rows = _linear_rows(m_orig, n)
+    tight_rows = _linear_rows(m_tight, n)
+    assert len(orig_rows) == len(tight_rows)
+
+    lb = np.array([float(np.ravel(v.lb)[0]) for v in m_orig._variables])
+    ub = np.array([float(np.ravel(v.ub)[0]) for v in m_orig._variables])
+    kinds = [_var_kind(v) for v in m_orig._variables]
+    bin_idx = [i for i in range(n) if kinds[i] == "int" and lb[i] == 0.0 and ub[i] == 1.0]
+    assert bin_idx, f"{name}: no genuine binaries but rows rewrote — misclassification?"
+
+    if len(bin_idx) <= 14:
+        corners = itertools.product([0.0, 1.0], repeat=len(bin_idx))
+    else:
+        rng = np.random.default_rng(0)
+        corners = (tuple(rng.integers(0, 2, len(bin_idx)).astype(float)) for _ in range(4000))
+
+    viol = []
+    for corner in corners:
+        v = _admit_violation(orig_rows, tight_rows, bin_idx, lb, ub, list(corner))
+        if v is not None:
+            viol.append((corner, v))
+            if len(viol) >= 3:
+                break
+    assert not viol, (
+        f"{name}: tightening ADMITS an infeasible point (false-primal class). "
+        f"corner→(orig_row,slack): {viol}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+def test_incumbent_feasible_in_fresh_original():
+    """End-to-end guard on the #282/#772 false-primal instance rsyn0805m (MAXIMIZE):
+    the flag-ON incumbent must be feasible in the ORIGINAL model and never beat the
+    oracle optimum (the #770 write-back bug reported 1441.99 > =opt= 1296.12)."""
+    snap = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/rsyn0805m.nl")
+    if not os.path.exists(snap):
+        pytest.skip("rsyn0805m snapshot unavailable")
+    oracle = 1296.1206030
+
+    m = dm.from_nl(snap)
+    assert tighten_bigm_coefficients(m) > 0, "expected rsyn0805m big-M rows to be rewritten"
+    res = m.solve(time_limit=120)
+    assert res.objective is not None
+    assert res.objective <= oracle + 1e-3, (
+        f"incumbent {res.objective} beats oracle {oracle} — false primal (the #770 bug)"
+    )
+
+    m0 = dm.from_nl(snap)
+    n = len(m0._variables)
+    names = [v.name for v in m0._variables]
+    sol = res.x if isinstance(getattr(res, "x", None), dict) else {}
+    if not sol:
+        pytest.skip("solver did not expose a variable-value dict")
+    x = np.array([float(np.ravel(sol.get(nm, 0.0))[0]) for nm in names])
+    worst = max((float(a @ x) - b for a, b in _linear_rows(m0, n)), default=0.0)
+    assert worst <= 1e-4, f"incumbent violates original linear rows by {worst} (false primal)"


### PR DESCRIPTION
## Summary

Re-implements activity-based big-M coefficient tightening (`DISCOPT_COEF_TIGHTEN`,
default-OFF) correctly, addressing item 1 of #774. #770 introduced this pass and was
reverted in #773 because it produced a false primal (rsyn0805m obj **1441.99** >
`=opt=` **1296.12**, feasible in the mutated model but not the original). This PR
re-derives the transformation, fixes the actual defects, and adds the both-directions
equivalence gate the #770 test lacked.

`Contributes to #774` (item 1). Item 2 (final-incumbent verification) already landed
as #779. Default-OFF; this does **not** graduate the flag (see the HOLD verdict below).

## Root cause of the #770 false primal (empirically pinpointed)

I reconstructed the reverted pass (`git show 42c2b573`), applied it to rsyn0805m, and
reproduced the exact false primal (obj 1441.99). Contrary to the original diagnosis
("fixed-charge `a_k < 0` sign/bound error, enlarged feasible set"), the data show the
transformation *math* is sound and the real defects are elsewhere:

**Defect 1 — malformed write-back (the false primal).** `from_nl` stores every
inequality with the whole constant in the body and `con.rhs == 0` (verified: 214/214
rsyn0805m inequality rows). The reverted write-back did
`con.body = rebuild(a', const)` (constant left in the body) **and**
`con.rhs = rhs_norm' + const` (a now-nonzero rhs) — splitting the constant across
body *and* rhs simultaneously, a normal form the model never produces natively. A
downstream relaxation/feasibility component (exercised only with `con.rhs == 0`) reads
one of the two, shifting the enforced row by `const` and admitting the false primal.
Evidence: the flag-ON incumbent violates the *tightened* `con.body` rows too, so it is
feasible in neither the original nor the mutated body model — a pipeline artifact of
the split representation. With `presolve=False` it still reproduces (not a
presolve-elimination interaction). Folding the constant back into the body (native
form) removes the false primal. The tightening *transformation itself* is
feasible-set-equivalent: I verified `u_rest` is valid over the true feasible region
(the row whose declared box allows rest ≤ 7 has a true feasible max of **5.755**,
exactly the probed `u_rest`).

**Defect 2 — continuous-[0,1] misclassified as binary (latent unsoundness).** The
binary test `"IN" in str(vtype).upper()` is `True` for `"CONTINUOUS"`
("cont**IN**uous"), so a continuous [0,1] variable was treated as a binary indicator
and its coefficient tightened — which changes the row at fractional values and is only
sound for a genuinely integral variable.

## The fix

- **Write-back in native normal form** (`_root_presolve.py`): the entire tightened
  constant goes into the body and `con.rhs = 0`, so a rewritten row is byte-for-byte
  the shape `from_nl` emits — never a body-constant coexisting with a nonzero rhs.
- **Correct binary classification** (`_is_binary_var`): binary-like ⟺ an
  *integer-typed* (`BINARY`/`INTEGER`) variable with a [0,1] box; continuous [0,1] is
  excluded. Rows whose non-binary activity is not finite under the (valid) FBBT/probing
  bounds are skipped, never guessed.
- Savelsbergh (`a_k > 0`) and fixed-charge (`a_k < 0`) coefficient formulas retained
  (they were correct in isolation). `u_rest` uses FBBT + probing bounds valid over the
  feasible region.
- Gated by `SolverTuning.coef_tighten` / `DISCOPT_COEF_TIGHTEN` (default-OFF); wired
  once at the root in `solver.py` before dispatch (serves NLP-BB and spatial paths).
  Flag OFF is byte-identical (the call site does not run).

## The both-directions equivalence test (the #770 gap)

The #770 test only checked "no feasible point removed". New
`python/tests/test_coef_tighten_equivalence_774.py` adds the missing direction:

1. `test_optimum_preserved[gbd,gkocis,ex1221,st_test1,alan]` — solve each small
   vendored instance to optimality flag OFF vs ON; assert the certified optima are
   equal to the oracle and the ON incumbent is feasible in a fresh ORIGINAL model.
   Admitting an infeasible point moves the optimum one way; removing a feasible point
   moves it the other — either fails. **PASS.**
2. `test_no_infeasible_admitted_lp[7 instances]` — rigorous, non-sampling LP
   certificate over the declared box: for each binary corner, no point satisfying all
   tightened linear rows violates any original linear row (the #772 direction).
   **PASS.**
3. `test_continuous_unit_is_not_binary` — `_is_binary_var` classifies binary/integer
   [0,1] as binary and continuous [0,1] as NOT binary (Defect 2 guard). **PASS.**
4. `test_incumbent_feasible_in_fresh_original` (slow) — end-to-end on rsyn0805m: the
   ON incumbent is feasible in a fresh original model and never beats the oracle
   (**catches Defect 1**: the reverted code fails here at 1441.99 > 1296.12; the fix
   passes). **PASS.**

Fail-before/pass-after confirmed: the reverted pass yields obj 1441.99 on rsyn0805m
(test 4 fails); the corrected pass yields a valid incumbent ≤ oracle.

## Entry experiment / graduation verdict — HOLD (default-OFF)

`#282` panel, flag ON vs OFF, `time_limit=90s`, sound throughout (every dual bound
≥ `=opt=` for these MAXIMIZE instances; every incumbent ≤ `=opt=`;
`incumbent_verification_failed=false`; no `gap_certified` regressions — none certify
in either arm):

| instance   | oracle  | root_bound OFF | root_bound ON       | nodes OFF→ON | cert (OFF/ON) |
|------------|---------|----------------|---------------------|--------------|---------------|
| rsyn0805m  | 1296.12 | 2111.02        | 2111.02 (=)         | 895 → 735    | none / none   |
| rsyn0810m  | 1721.45 | 2963.21        | 2944.86 (↓ 0.6%)    | 575 → 671    | none / none   |
| syn40m     |   67.71 | 1833.91        | **1059.17 (↓ 43%)** | 1055 → 1375  | none / none   |
| syn05hfsg  |  837.73 | 1335.50        | 1335.50 (=)         | 185 → 185    | **opt / opt** |

(root_bound is the dual **upper** bound — these are MAXIMIZE — so a smaller value is
tighter; every ON bound stays ≥ `=opt=`, sound.) The tightening is sound and tightens
the root dual bound substantially on syn40m (~43% of the root excess above the oracle,
consistent with the #282 Stage 1 estimate), but certifies **nothing** additional on the
panel and does not reduce nodes (syn40m nodes actually rise). syn05hfsg is byte-identical
(both certify optimal in 185 nodes). Sound ≠ helpful (the `DISCOPT_CUT_INHERIT` lesson).
Per CLAUDE.md §5 it ships as a **default-OFF opt-in lever** with the HOLD recorded; it
does **not** graduate default-ON without a net-positive panel.

## Verification

- `pytest -m smoke` — 831 passed, 1 skipped, 2 xpassed.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed.
- `pytest python/tests/test_lazy_jax_linear_path.py` — 4 passed (no JAX import on the
  LP/MILP/QP/MIQP path).
- New `test_coef_tighten_equivalence_774.py` — 14 passed.
- `ruff check` / `ruff format --check` — clean on changed files. (`mypy` blocked by a
  pre-existing numpy-stub/env mismatch, reproduced on unchanged files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
