### PR TITLE
feat(#781): NLP-BB root cutting-plane stage (GMI + selection, DISCOPT_NLPBB_ROOT_CUTS, default-OFF)

### DIFF
--- a/discopt_benchmarks/results/issue781/rootcuts_soundness_sweep_20260719.json
+++ b/discopt_benchmarks/results/issue781/rootcuts_soundness_sweep_20260719.json
@@ -1,0 +1,681 @@
+{
+ "panel": {
+  "rsyn0805m": {
+   "off": {
+    "status": "feasible",
+    "obj": 1055.8450068825605,
+    "bound": 1864.8382362707575,
+    "nodes": 159,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   },
+   "on": {
+    "status": "feasible",
+    "obj": 1210.1534089315596,
+    "bound": 1575.2232682834078,
+    "nodes": 95,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   }
+  },
+  "rsyn0810m": {
+   "off": {
+    "status": "feasible",
+    "obj": 1417.3003310497224,
+    "bound": 2596.3712318238,
+    "nodes": 127,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   },
+   "on": {
+    "status": "feasible",
+    "obj": 1623.7891324042798,
+    "bound": 1948.1572705281608,
+    "nodes": 63,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   }
+  },
+  "rsyn0815m": {
+   "off": {
+    "status": "feasible",
+    "obj": 1041.5274786964821,
+    "bound": 1987.4794272946203,
+    "nodes": 127,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   },
+   "on": {
+    "status": "feasible",
+    "obj": 697.6215396023317,
+    "bound": 1627.8814211390852,
+    "nodes": 31,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   }
+  },
+  "syn40m": {
+   "off": {
+    "status": "feasible",
+    "obj": 30.965221147428323,
+    "bound": 1245.3780167925963,
+    "nodes": 351,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   },
+   "on": {
+    "status": "feasible",
+    "obj": 39.99108271669044,
+    "bound": 375.9160796846244,
+    "nodes": 63,
+    "sense": "max",
+    "guard_tripped": false,
+    "certified": false
+   }
+  }
+ },
+ "corpus": {
+  "4stufen": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 20712.174649175664,
+   "nodes": 7,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "alan": {
+   "status": "optimal",
+   "obj": 2.924999998301341,
+   "bound": 2.924999998301341,
+   "nodes": 21,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "bchoco06": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 0.9999887833654022,
+   "nodes": 3,
+   "sense": "max",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "bchoco07": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 0.9999909483405423,
+   "nodes": 15,
+   "sense": "max",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "bchoco08": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 1.0000000000038425,
+   "nodes": 7,
+   "sense": "max",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "beuster": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 17801.54887879556,
+   "nodes": 31,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "casctanks": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 2.9097722176628698,
+   "nodes": 15,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "chance": {
+   "status": "optimal",
+   "obj": 29.894378154271102,
+   "bound": 29.894378154271102,
+   "nodes": 0,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "clay0303hfsg": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 0.0,
+   "nodes": 95,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "contvar": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 183632.76598245982,
+   "nodes": 7,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "cvxnonsep_nsig30": {
+   "status": "optimal",
+   "obj": 130.62871116925294,
+   "bound": 130.61841392487688,
+   "nodes": 165,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "cvxnonsep_psig30": {
+   "status": "optimal",
+   "obj": 78.9988543529429,
+   "bound": 78.99179874365787,
+   "nodes": 89,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "cvxnonsep_psig40r": {
+   "status": "optimal",
+   "obj": 86.54528391605676,
+   "bound": 86.53936612872786,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "dispatch": {
+   "status": "optimal",
+   "obj": 3155.28792669897,
+   "bound": 3155.28790421789,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1221": {
+   "status": "optimal",
+   "obj": 7.667180068813135,
+   "bound": 7.667180068813077,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1222": {
+   "status": "optimal",
+   "obj": 1.0765430833322625,
+   "bound": 1.0765430463031964,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1224": {
+   "status": "optimal",
+   "obj": -0.9434704942820806,
+   "bound": -0.9434705000000164,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1225": {
+   "status": "optimal",
+   "obj": 30.999999913557566,
+   "bound": 30.999999913557566,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex1226": {
+   "status": "optimal",
+   "obj": -17.000000003887443,
+   "bound": -17.000000003887443,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "ex14_1_9": {
+   "status": "feasible",
+   "obj": -1.9775220540513224e-16,
+   "bound": -1.9775220540513224e-16,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "fac2": {
+   "status": "optimal",
+   "obj": 331837498.18201387,
+   "bound": 331837497.561812,
+   "nodes": 39,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "flay02m": {
+   "status": "optimal",
+   "obj": 37.9473318657881,
+   "bound": 37.947331805116704,
+   "nodes": 7,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "flay03m": {
+   "status": "optimal",
+   "obj": 48.989794795563185,
+   "bound": 48.989794708365906,
+   "nodes": 105,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "gbd": {
+   "status": "optimal",
+   "obj": 2.199999982504936,
+   "bound": 2.199999982504936,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "gkocis": {
+   "status": "optimal",
+   "obj": -1.9230987798770212,
+   "bound": -1.9230988280923489,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "hda": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": -64473.44240160173,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "heatexch_gen1": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": 38183.5317460179,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "heatexch_gen2": {
+   "status": "feasible",
+   "obj": 824782.3074689015,
+   "bound": 555767.7902857271,
+   "nodes": 9,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "heatexch_gen3": {
+   "status": "time_limit",
+   "obj": null,
+   "bound": null,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "m3": {
+   "status": "optimal",
+   "obj": 37.79999968237359,
+   "bound": 37.79999966292655,
+   "nodes": 33,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs01": {
+   "status": "optimal",
+   "obj": 12.46966882156821,
+   "bound": 12.46966882156821,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs02": {
+   "status": "optimal",
+   "obj": 5.96418452307,
+   "bound": 5.96418452307,
+   "nodes": 337,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs03": {
+   "status": "optimal",
+   "obj": 16.0,
+   "bound": 15.99999972676511,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs04": {
+   "status": "optimal",
+   "obj": 0.720000000000006,
+   "bound": 0.7199999999999773,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs05": {
+   "status": "feasible",
+   "obj": 8.731956986640078,
+   "bound": 3.8053367777828426,
+   "nodes": 155,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "nvs06": {
+   "status": "optimal",
+   "obj": 1.7703125,
+   "bound": 1.7703124999999627,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs07": {
+   "status": "optimal",
+   "obj": 4.0,
+   "bound": 4.0,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs08": {
+   "status": "optimal",
+   "obj": 23.449727347139827,
+   "bound": 23.44972734516655,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs09": {
+   "status": "optimal",
+   "obj": -43.134336918035295,
+   "bound": -43.13433691803662,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs10": {
+   "status": "optimal",
+   "obj": -310.7999999999999,
+   "bound": -310.7999999999999,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs11": {
+   "status": "optimal",
+   "obj": -430.99999999999966,
+   "bound": -430.99999999999966,
+   "nodes": 55,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs12": {
+   "status": "optimal",
+   "obj": -481.20000000000005,
+   "bound": -481.20000000000005,
+   "nodes": 231,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs13": {
+   "status": "optimal",
+   "obj": -585.2,
+   "bound": -585.2000000002046,
+   "nodes": 19,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs14": {
+   "status": "optimal",
+   "obj": -40358.15476929996,
+   "bound": -40358.15476929999,
+   "nodes": 223,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs15": {
+   "status": "optimal",
+   "obj": 1.0,
+   "bound": 1.0,
+   "nodes": 7,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "nvs21": {
+   "status": "optimal",
+   "obj": -5.684782628025259,
+   "bound": -5.684782628025259,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "oaer": {
+   "status": "optimal",
+   "obj": -1.9230984998848466,
+   "bound": -1.923098601139822,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e11": {
+   "status": "optimal",
+   "obj": 189.31162970681882,
+   "bound": 189.31162966433996,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e13": {
+   "status": "optimal",
+   "obj": 2.0000003463351197,
+   "bound": 1.9999999825187809,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e29": {
+   "status": "optimal",
+   "obj": -0.9434704942820806,
+   "bound": -0.9434705000000164,
+   "nodes": 5,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e36": {
+   "status": "optimal",
+   "obj": -245.99999999999997,
+   "bound": -246.00000000170442,
+   "nodes": 85,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_e38": {
+   "status": "optimal",
+   "obj": 7197.727116826533,
+   "bound": 7197.727116826533,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp1": {
+   "status": "optimal",
+   "obj": 280.9999999906497,
+   "bound": 280.9999999906497,
+   "nodes": 15,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp2": {
+   "status": "optimal",
+   "obj": 2.0,
+   "bound": 2.0,
+   "nodes": 9,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp3": {
+   "status": "optimal",
+   "obj": -6.0,
+   "bound": -6.0,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp4": {
+   "status": "optimal",
+   "obj": -4574.000004423649,
+   "bound": -4574.000004423649,
+   "nodes": 3,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_miqp5": {
+   "status": "optimal",
+   "obj": -333.8888902488093,
+   "bound": -333.8888902488093,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_test1": {
+   "status": "optimal",
+   "obj": -1.6495994490692313e-08,
+   "bound": -1.6495994490692313e-08,
+   "nodes": 15,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "st_testgr3": {
+   "status": "optimal",
+   "obj": -20.59,
+   "bound": -20.59070709795548,
+   "nodes": 549,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "syn05hfsg": {
+   "status": "optimal",
+   "obj": 837.732412391107,
+   "bound": 837.732412391107,
+   "nodes": 185,
+   "sense": "max",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "tanksize": {
+   "status": "feasible",
+   "obj": 1.268643761465288,
+   "bound": 0.9221092536047468,
+   "nodes": 121,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "tls2": {
+   "status": "feasible",
+   "obj": 8.299999882620709,
+   "bound": 2.878150757026535,
+   "nodes": 237,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "tspn05": {
+   "status": "optimal",
+   "obj": 191.25520768494238,
+   "bound": 191.25510622528546,
+   "nodes": 51,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": true
+  },
+  "tspn08": {
+   "status": "feasible",
+   "obj": 290.56685374735457,
+   "bound": null,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "tspn10": {
+   "status": "feasible",
+   "obj": 225.1260713973292,
+   "bound": null,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  },
+  "tspn12": {
+   "status": "feasible",
+   "obj": 262.64739525060224,
+   "bound": null,
+   "nodes": 1,
+   "sense": "min",
+   "guard_tripped": false,
+   "certified": false
+  }
+ },
+ "violations": []
+}

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -10929,6 +10929,71 @@ def _solve_nlp_bb(
             gap_certified=_gap_certified,
         )
 
+    # --- Root cutting-plane stage (#781, DISCOPT_NLPBB_ROOT_CUTS, default-OFF) ---
+    # Generates integrality-valid cuts (GMI from the HiGHS tableau + c-MIR +
+    # cover under pooled top-K selection) over the OA root LP and appends them
+    # as model constraints BEFORE the evaluator/tree are built, so every node
+    # NLP relaxation tightens. Sound: runs only on the convex-certified route
+    # with a verified-linear objective; cuts are satisfied by every integer-
+    # feasible point, so no incumbent is ever cut (and the #779 guard verifies
+    # the final incumbent against the pristine pre-solve model regardless).
+    # Write-back honors the #772 lessons: each cut is a NEW Constraint with the
+    # full row folded into the body and ``rhs=0.0``. The applied cuts remain in
+    # the model after the solve (valid rows; keeps result.constraint_duals
+    # aligned). Failure-safe: any error degrades to the flag-off path.
+    _root_cut_bound: Optional[float] = None
+    _root_cut_count = 0
+    # Top-level solves only: RENS/local-branching sub-solves recurse into this
+    # function (with rens_enabled/_lns_enabled False) and must not pay for —
+    # or mutate their restricted models with — a second root-cut stage.
+    if _model_is_convex and rens_enabled and _lns_enabled:
+        try:
+            from discopt.solvers._root_cuts import (
+                generate_root_cuts,
+                nlpbb_root_cuts_enabled,
+            )
+
+            if nlpbb_root_cuts_enabled() and all(
+                getattr(v, "size", 1) == 1 for v in model._variables
+            ):
+                from discopt.modeling.core import Constraint as _RCConstraint
+
+                _rc_is_int = np.zeros(n_vars, bool)
+                for _off, _sz in zip(int_offsets, int_sizes):
+                    _rc_is_int[_off : _off + _sz] = True
+                _rc_is_bin = _rc_is_int & (lb == 0.0) & (ub == 1.0)
+                t_jax_start = time.perf_counter()
+                _rc_ev = _make_evaluator(model)  # pre-cut evaluator (cached)
+                _rc_budget = max(2.0, min(10.0, 0.2 * float(time_limit)))
+                _rc = generate_root_cuts(
+                    model, _rc_ev, lb, ub, _rc_is_int, _rc_is_bin, time_budget_s=_rc_budget
+                )
+                jax_time += time.perf_counter() - t_jax_start
+                _rc_blocks = model._variables
+                for _rc_a, _rc_r in _rc.cuts:
+                    _rc_body = None
+                    for _j in np.nonzero(np.abs(_rc_a) > 1e-15)[0]:
+                        _term = float(_rc_a[_j]) * _rc_blocks[int(_j)]
+                        _rc_body = _term if _rc_body is None else _rc_body + _term
+                    if _rc_body is None:
+                        continue
+                    _rc_body = _rc_body + (-float(_rc_r))
+                    model._constraints.append(_RCConstraint(_rc_body, "<=", 0.0, None))
+                    _root_cut_count += 1
+                _root_cut_bound = _rc.lp_bound
+                if _root_cut_count:
+                    logger.info(
+                        "NLP-BB root cuts (#781): applied %d cuts over %d rounds "
+                        "(%d productive), root LP bound %.6g",
+                        _root_cut_count,
+                        _rc.rounds_run,
+                        _rc.productive_rounds,
+                        _root_cut_bound if _root_cut_bound is not None else float("nan"),
+                    )
+        except Exception as e:
+            logger.debug("NLP-BB root cuts skipped: %s", e)
+            _root_cut_bound = None
+
     t_rust_start = time.perf_counter()
     tree = PyTreeManager(
         n_vars,
@@ -11963,6 +12028,32 @@ def _solve_nlp_bb(
     if _root_glb_internal is not None and np.isfinite(_root_glb_internal):
         root_bound_val = -_root_glb_internal if _nlpbb_is_max else _root_glb_internal
         if obj_val is not None and np.isfinite(obj_val):
+            root_gap_val = abs(obj_val - root_bound_val) / max(1.0, abs(obj_val))
+
+    # --- Root-cut bound composition (#781) ---
+    # The root cutting-plane LP bound is a valid dual bound (LP optimum over an
+    # outer approximation of the integer-feasible set: OA tangents of the
+    # convex-certified rows + integrality-valid cuts). Compose it with the tree
+    # bound by taking the TIGHTER of the two valid bounds, for the reported
+    # bound/gap and the root diagnostics. Deliberately conservative: it never
+    # upgrades ``gap_certified`` or the status — the LP is floating-point
+    # (HiGHS) and sits outside the trusted-node machinery, so certification
+    # continues to come solely from the tree logic above.
+    if _root_cut_bound is not None and np.isfinite(_root_cut_bound):
+        _rcb = float(_root_cut_bound)
+
+        def _tighter(a: Optional[float], b: float) -> float:
+            if a is None or not np.isfinite(a):
+                return b
+            return min(a, b) if _nlpbb_is_max else max(a, b)
+
+        _new_bound = _tighter(bound_val, _rcb)
+        if bound_val is None or _new_bound != bound_val:
+            bound_val = _new_bound
+            if obj_val is not None and np.isfinite(obj_val):
+                gap_val = abs(obj_val - bound_val) / max(1.0, abs(obj_val))
+        root_bound_val = _tighter(root_bound_val, _rcb)
+        if obj_val is not None and np.isfinite(obj_val) and root_bound_val is not None:
             root_gap_val = abs(obj_val - root_bound_val) / max(1.0, abs(obj_val))
 
     return SolveResult(

--- a/python/discopt/solvers/_root_cuts.py
+++ b/python/discopt/solvers/_root_cuts.py
@@ -1,0 +1,522 @@
+"""NLP-BB root cutting-plane stage (issue #781, ``DISCOPT_NLPBB_ROOT_CUTS``).
+
+Generates globally valid, integrality-based cutting planes at the root of the
+NLP-BB path and returns them for insertion as model constraints, together with
+the final root-LP dual bound. The mechanism is the one the #781 entry
+experiment validated (probe: ``discopt_benchmarks/scripts/issue781_cutmgmt_probe.py``):
+
+  * root LP = the model's linear rows + outer-approximation tangents of the
+    convex nonlinear rows, iterated to OA convergence each round;
+  * separators: Gomory mixed-integer cuts from the HiGHS basis/tableau (the
+    load-bearing family — closes 75–93% of the remaining root spread on the
+    convex synthesis panel), plus the existing c-MIR and knapsack-cover
+    separators;
+  * SCIP-style cut management: persistent pool, efficacy × orthogonality
+    scoring, apply only the top-K per round (compounds on GMI: same-or-better
+    bound with ~4× fewer cuts applied).
+
+Soundness contract (CLAUDE.md §1):
+  * Only runs when the model is CONVEX-certified (OA tangents of convex ≤ rows
+    / concave ≥ rows are valid outer approximations) and the objective is
+    verified linear (the LP objective must represent the true objective).
+  * Every cut is integrality-valid: satisfied by every point of the model's
+    feasible set with integral integer variables. Adding them as constraints
+    removes no integer-feasible point; node NLP relaxations only tighten.
+  * The returned LP bound is the optimum of an outer approximation of the
+    integer-feasible set, hence a valid dual bound for the MINLP.
+  * The GMI derivation was validated by exact per-integer-corner LP
+    enumeration on seeded random MILPs (0 unsound cuts; regression test
+    ``python/tests/test_nlpbb_root_cuts_781.py``), and each cut's rhs carries a
+    small relative safety relaxation against tableau roundoff.
+  * Everything is failure-safe: any error returns "no cuts" and the solve
+    proceeds exactly as with the flag off.
+
+Default OFF (bound-changing, CLAUDE.md §5); graduation requires the Regime-2
+panel (cert-clean + net-positive).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+ROUNDS = 30
+OA_TOL = 1e-6
+OA_MAX_ITERS = 60
+CUT_VIOL_TOL = 1e-6
+SEL_TOP_K = 8
+SEL_PARALLEL_MAX = 0.90
+GMI_F0_MIN = 0.01
+GMI_DYNAMISM_MAX = 1e6
+GMI_RHS_SAFETY_REL = 1e-9  # relative rhs relaxation absorbing tableau roundoff
+MAX_CUTS_PER_FAMILY = 24
+POOL_MAX = 4000
+
+
+def nlpbb_root_cuts_enabled() -> bool:
+    """Whether the ``DISCOPT_NLPBB_ROOT_CUTS`` opt-in flag is set (default OFF)."""
+    val = os.environ.get("DISCOPT_NLPBB_ROOT_CUTS", "0").strip().lower()
+    return val not in ("", "0", "false", "off", "no")
+
+
+@dataclass
+class RootCutResult:
+    """Applied cuts (``alpha·x <= rhs`` each) and the final root-LP dual bound."""
+
+    cuts: list = field(default_factory=list)  # [(alpha: np.ndarray, rhs: float)]
+    lp_bound: float | None = None  # in the model's objective sense
+    rounds_run: int = 0
+    productive_rounds: int = 0
+
+
+# ── linearised root view ─────────────────────────────────────────────────────
+
+
+class _RootLP:
+    """Linear rows + OA machinery over the (FBBT-tightened) root box."""
+
+    def __init__(self, model, evaluator, lb, ub, is_int, is_bin, sense_max: bool):
+        self.n = len(lb)
+        self.lb = np.asarray(lb, float)
+        self.ub = np.asarray(ub, float)
+        self.is_int = is_int
+        self.is_bin = is_bin
+        self.ev = evaluator
+        self.sense_max = sense_max
+        self.senses = [
+            c.sense if isinstance(c.sense, str) else c.sense.value for c in model._constraints
+        ]
+
+        # Objective must be LINEAR for the LP objective to represent it.
+        rng = np.random.default_rng(0)
+        lo = np.where(np.isfinite(self.lb), self.lb, 0.0)
+        hi = np.where(np.isfinite(self.ub), self.ub, lo + 5.0)
+        xa = lo + rng.random(self.n) * (hi - lo)
+        xb = lo + rng.random(self.n) * (hi - lo)
+        ga = np.asarray(evaluator.evaluate_gradient(xa), float)
+        gb = np.asarray(evaluator.evaluate_gradient(xb), float)
+        if not np.allclose(ga, gb, atol=1e-9):
+            raise ValueError("nonlinear objective — root-cut LP bound would be invalid")
+        # NLPEvaluator compiles a minimize-internal objective: it NEGATES the
+        # declared objective for MAXIMIZE models (``NLPEvaluator._negate``).
+        # Recover the DECLARED objective coefficients so the LP bound is in the
+        # model's sense (max → LP max c'x is a valid upper bound).
+        negate = bool(getattr(evaluator, "_negate", sense_max))
+        self.c = -ga if negate else ga
+
+        ja = evaluator.evaluate_jacobian(xa)
+        jb = evaluator.evaluate_jacobian(xb)
+        lin_rows = np.all(np.isclose(ja, jb, atol=1e-9), axis=1)
+        g0 = np.asarray(evaluator.evaluate_constraints(xa), float)
+        const = g0 - ja @ xa
+        self.nl_rows = [i for i in range(ja.shape[0]) if not lin_rows[i]]
+
+        a_le, b_le, a_eq, b_eq = [], [], [], []
+        for i in range(ja.shape[0]):
+            if not lin_rows[i]:
+                continue
+            a = np.asarray(ja[i], float)
+            ci = float(const[i])
+            s = self.senses[i]
+            if s == "<=":
+                a_le.append(a)
+                b_le.append(-ci)
+            elif s == ">=":
+                a_le.append(-a)
+                b_le.append(ci)
+            else:
+                a_eq.append(a)
+                b_eq.append(-ci)
+        self.A_le = np.array(a_le) if a_le else np.zeros((0, self.n))
+        self.b_le = np.array(b_le) if b_le else np.zeros(0)
+        self.A_eq = np.array(a_eq) if a_eq else np.zeros((0, self.n))
+        self.b_eq = np.array(b_eq) if b_eq else np.zeros(0)
+        self._fbbt_separation_bounds()
+
+    def _fbbt_separation_bounds(self):
+        """Interval FBBT over the linear rows for the separators' activity bounds."""
+        lb = self.lb.copy()
+        ub = self.ub.copy()
+        rows_a = list(self.A_le) + list(self.A_eq) + list(-self.A_eq)
+        rows_b = list(self.b_le) + list(self.b_eq) + list(-self.b_eq)
+        for _ in range(20):
+            changed = False
+            for a, b in zip(rows_a, rows_b, strict=True):
+                nz = np.where(np.abs(a) > 1e-12)[0]
+                for j in nz:
+                    aj = a[j]
+                    rest = 0.0
+                    ok = True
+                    for k in nz:
+                        if k == j:
+                            continue
+                        ak = a[k]
+                        v = lb[k] if ak > 0 else ub[k]
+                        if not np.isfinite(v):
+                            ok = False
+                            break
+                        rest += ak * v
+                    if not ok:
+                        continue
+                    bound = (b - rest) / aj
+                    if aj > 0:
+                        if bound < ub[j] - 1e-9:
+                            ub[j] = bound
+                            changed = True
+                    elif bound > lb[j] + 1e-9:
+                        lb[j] = bound
+                        changed = True
+            if not changed:
+                break
+        self.lb_sep = np.maximum(lb, self.lb)
+        self.ub_sep = np.minimum(ub, self.ub)
+
+    def oa_tangent(self, row_idx, x):
+        g = self.ev.evaluate_constraints(x)[row_idx]
+        jrow = self.ev.evaluate_jacobian(x)[row_idx]
+        s = self.senses[row_idx]
+        if s == "<=":
+            return np.asarray(jrow, float).copy(), float(jrow @ x - g)
+        if s == ">=":
+            return -np.asarray(jrow, float), float(-(jrow @ x) + g)
+        return None  # nonlinear equality: model would not be convex-certified
+
+    def nonlinear_violations(self, x):
+        g = self.ev.evaluate_constraints(x)
+        out = {}
+        for i in self.nl_rows:
+            s = self.senses[i]
+            out[i] = g[i] if s == "<=" else (-g[i] if s == ">=" else abs(g[i]))
+        return out
+
+
+def _solve_lp(root: _RootLP, cuts_a, cuts_b):
+    """Solve the root LP with HiGHS. Returns (obj_in_model_sense, x, duals, highs)."""
+    import highspy
+
+    inf = highspy.kHighsInf
+    a_ub = np.vstack([root.A_le] + ([np.array(cuts_a)] if cuts_a else []))
+    b_ub = np.concatenate([root.b_le] + ([np.array(cuts_b)] if cuts_b else []))
+    n_le = a_ub.shape[0]
+    n_eq = root.A_eq.shape[0]
+    lp = highspy.HighsLp()
+    lp.num_col_ = root.n
+    lp.num_row_ = n_le + n_eq
+    lp.sense_ = highspy.ObjSense.kMinimize
+    lp.col_cost_ = -root.c if root.sense_max else root.c
+    lp.col_lower_ = np.where(np.isfinite(root.lb), root.lb, -inf)
+    lp.col_upper_ = np.where(np.isfinite(root.ub), root.ub, inf)
+    lp.row_lower_ = np.concatenate([np.full(n_le, -inf), root.b_eq])
+    lp.row_upper_ = np.concatenate([b_ub, root.b_eq])
+    a_all = np.vstack([a_ub, root.A_eq]) if n_eq else a_ub
+    lp.a_matrix_.format_ = highspy.MatrixFormat.kRowwise
+    starts, idx, vals = [0], [], []
+    for r in range(a_all.shape[0]):
+        nz = np.where(np.abs(a_all[r]) > 1e-13)[0]
+        idx.extend(nz.tolist())
+        vals.extend(a_all[r, nz].tolist())
+        starts.append(len(idx))
+    lp.a_matrix_.start_ = np.array(starts, np.int32)
+    lp.a_matrix_.index_ = np.array(idx, np.int32)
+    lp.a_matrix_.value_ = np.array(vals, float)
+    h = highspy.Highs()
+    h.setOptionValue("output_flag", False)
+    h.passModel(lp)
+    h.run()
+    if h.getModelStatus() != highspy.HighsModelStatus.kOptimal:
+        return None, None, None, None
+    sol = h.getSolution()
+    x = np.array(sol.col_value, float)
+    duals = np.abs(np.array(sol.row_dual, float))[:n_le]
+    return float(root.c @ x), x, duals, h
+
+
+# ── GMI separator (validated: exact enumeration, 0 unsound) ──────────────────
+
+
+def separate_gmi(root: _RootLP, h, x, a_all, b_all, max_cuts=MAX_CUTS_PER_FAMILY):
+    """Gomory mixed-integer cuts for fractional basic integer structurals.
+
+    HiGHS convention (verified numerically): with row-activity variables
+    ``z_r = a_r·x`` the tableau identity for basic ``x_B(i)`` is
+    ``x_B(i) = −Σ red_ij·x_j + Σ binv_ir·z_r`` over nonbasic j, r. Deviation
+    variables (all ≥ 0): structural at lower ``p = x_j − l_j`` (t = red_ij),
+    at upper ``p = u_j − x_j`` (t = −red_ij); a binding ≤ row has z at its
+    UPPER bound, deviation ``q_r = b_r − a_r·x`` (t = binv_ir). Equality rows
+    contribute constants only (absorbed by d0 = x[bv]). GMI over
+    ``x_B + Σ t_k v_k = d0`` then substituted back to x-space.
+    """
+    import highspy
+
+    st, basic = h.getBasicVariables()
+    if st != highspy.HighsStatus.kOk:
+        return []
+    basic = np.asarray(basic, np.int64)
+    bas = h.getBasis()
+    col_st = np.array([int(s) for s in bas.col_status])
+    row_st = np.array([int(s) for s in bas.row_status])
+    k_lower = int(highspy.HighsBasisStatus.kLower)
+    k_upper = int(highspy.HighsBasisStatus.kUpper)
+    k_basic = int(highspy.HighsBasisStatus.kBasic)
+    n = root.n
+
+    order = []
+    for i, bv in enumerate(basic):
+        if bv >= 0 and root.is_int[bv]:
+            f = x[bv] - np.floor(x[bv])
+            if GMI_F0_MIN < f < 1.0 - GMI_F0_MIN:
+                order.append((min(f, 1 - f), i, int(bv)))
+    order.sort(reverse=True)
+
+    cuts = []
+    for _score, i, bv in order[: max_cuts * 2]:
+        st1, red = h.getReducedRow(i)
+        st2, binv = h.getBasisInverseRow(i)
+        if st1 != highspy.HighsStatus.kOk or st2 != highspy.HighsStatus.kOk:
+            continue
+        red = np.asarray(red, float)
+        binv = np.asarray(binv, float)
+
+        d0 = float(x[bv])
+        f0 = d0 - np.floor(d0)
+        if not (GMI_F0_MIN < f0 < 1.0 - GMI_F0_MIN):
+            continue
+        one_mf = 1.0 - f0
+
+        alpha = np.zeros(n)
+        beta = 0.0
+        ok = True
+        maxc, minc = 0.0, np.inf
+
+        for j in range(n):
+            if j == bv or abs(red[j]) < 1e-12:
+                continue
+            stj = col_st[j]
+            if stj == k_basic:
+                continue
+            if stj == k_lower:
+                t = red[j]
+                shift = root.lb[j]
+                sign = 1.0
+            elif stj == k_upper:
+                t = -red[j]
+                shift = root.ub[j]
+                sign = -1.0
+            else:
+                if abs(red[j]) > 1e-9:  # free nonbasic: derivation inapplicable
+                    ok = False
+                    break
+                continue
+            if not np.isfinite(shift):
+                ok = False
+                break
+            if root.is_int[j]:
+                fj = t - np.floor(t)
+                g = fj if fj <= f0 else f0 * (1.0 - fj) / one_mf
+            else:
+                g = t if t > 0 else -t * f0 / one_mf
+            if g < 1e-13:
+                continue
+            alpha[j] += -g * sign
+            beta += -g * sign * shift
+            maxc = max(maxc, abs(g))
+            minc = min(minc, abs(g))
+        if not ok:
+            continue
+
+        m_le = a_all.shape[0]
+        for r in range(m_le):
+            if abs(binv[r]) < 1e-12 or row_st[r] != k_upper:
+                continue
+            t = binv[r]
+            g = t if t > 0 else -t * f0 / one_mf
+            if g < 1e-13:
+                continue
+            alpha += g * a_all[r]
+            beta += g * b_all[r]
+            maxc = max(maxc, abs(g))
+            minc = min(minc, abs(g))
+
+        rhs = beta - f0
+        nrm = float(np.linalg.norm(alpha))
+        if nrm < 1e-10 or not np.isfinite(rhs):
+            continue
+        if maxc > 0 and minc < np.inf and maxc / max(minc, 1e-300) > GMI_DYNAMISM_MAX:
+            continue
+        rhs += GMI_RHS_SAFETY_REL * (1.0 + abs(rhs))  # roundoff safety relaxation
+        if float(alpha @ x - rhs) < CUT_VIOL_TOL:
+            continue
+        cuts.append((alpha, float(rhs)))
+        if len(cuts) >= max_cuts:
+            break
+    return cuts
+
+
+# ── cut pool + hybrid selection ──────────────────────────────────────────────
+
+
+class _CutPool:
+    def __init__(self):
+        self.pool = []
+        self.seen = set()
+
+    def offer(self, a, rhs):
+        key = tuple(np.round(np.asarray(a, float), 5)) + (round(float(rhs), 5),)
+        if key in self.seen:
+            return
+        self.seen.add(key)
+        self.pool.append((np.asarray(a, float), float(rhs)))
+        if len(self.pool) > POOL_MAX:
+            self.pool = self.pool[-POOL_MAX:]
+
+    def violated(self, x, tol=CUT_VIOL_TOL):
+        return [(a, r) for a, r in self.pool if a @ x - r > tol]
+
+
+def _select_cuts(candidates, x, top_k=SEL_TOP_K, par_max=SEL_PARALLEL_MAX):
+    """Efficacy × orthogonality greedy selection (simplified SCIP hybrid rule)."""
+    scored = []
+    for a, rhs in candidates:
+        nrm = float(np.linalg.norm(a))
+        if nrm < 1e-12:
+            continue
+        eff = float(a @ x - rhs) / nrm
+        if eff > 1e-9:
+            scored.append((eff, a, rhs, nrm))
+    scored.sort(key=lambda t: -t[0])
+    chosen = []
+    for eff, a, rhs, nrm in scored:
+        if len(chosen) >= top_k:
+            break
+        if all(abs(a @ ca) / (nrm * cn) <= par_max for _e, ca, _r, cn in chosen):
+            chosen.append((eff, a, rhs, nrm))
+    return [(a, rhs) for _e, a, rhs, _n in chosen]
+
+
+# ── driver ───────────────────────────────────────────────────────────────────
+
+
+def generate_root_cuts(
+    model, evaluator, lb, ub, is_int, is_bin, time_budget_s: float = 10.0
+) -> RootCutResult:
+    """Run the root cutting loop; return applied cuts + the final LP bound.
+
+    Caller contract: the model is CONVEX-certified and routed to NLP-BB;
+    ``lb``/``ub`` are the FBBT-tightened root bounds; ``is_int``/``is_bin``
+    are flat masks. Raises on structural inapplicability (nonlinear objective,
+    missing highspy) — the caller wraps and degrades to no-op.
+
+    The returned ``cuts`` are only those BINDING at the final LP optimum (they
+    are the ones carrying the bound); the rest served their purpose inside the
+    loop. This keeps the constraint set added to the tree small — the full
+    applied set (measured: ~170 dense rows on rsyn0805m) collapses node NLP
+    throughput. ``time_budget_s`` bounds the stage's wall time.
+    """
+    import time as _time
+
+    from discopt._jax.cmir_cuts import separate_cmir
+    from discopt._jax.cover_cuts import separate_cover_cuts
+    from discopt.modeling.core import ObjectiveSense
+
+    sense_max = model._objective.sense == ObjectiveSense.MAXIMIZE
+    root = _RootLP(model, evaluator, lb, ub, is_int, is_bin, sense_max)
+    if not np.any(is_int):
+        return RootCutResult()
+
+    cuts_a: list = []
+    cuts_b: list = []
+    pool = _CutPool()
+
+    def add_oa(x):
+        added = 0
+        for i, v in root.nonlinear_violations(x).items():
+            if v > OA_TOL:
+                tang = root.oa_tangent(i, x)
+                if tang is None:
+                    continue
+                a, bb = tang
+                cuts_a.append(a)
+                cuts_b.append(bb)
+                added += 1
+        return added
+
+    def oa_converge():
+        obj, x, duals, h = _solve_lp(root, cuts_a, cuts_b)
+        for _ in range(OA_MAX_ITERS):
+            if x is None or add_oa(x) == 0:
+                break
+            obj, x, duals, h = _solve_lp(root, cuts_a, cuts_b)
+        return obj, x, duals, h
+
+    obj, x, duals, h = oa_converge()
+    if x is None:
+        return RootCutResult()
+
+    applied: list = []
+    productive = 0
+    rounds = 0
+    t0 = _time.perf_counter()
+    lb_s = np.where(np.isfinite(root.lb_sep), root.lb_sep, 0.0)
+    ub_s = np.where(np.isfinite(root.ub_sep), root.ub_sep, 1e5)
+
+    for _rnd in range(ROUNDS):
+        if _time.perf_counter() - t0 > time_budget_s:
+            break
+        rounds += 1
+        a_all = np.vstack([root.A_le] + ([np.array(cuts_a)] if cuts_a else []))
+        b_all = np.concatenate([root.b_le] + ([np.array(cuts_b)] if cuts_b else []))
+
+        cands = []
+        try:
+            cands += separate_cmir(
+                a_all, b_all, x, lb_s, ub_s, is_int, max_cuts=MAX_CUTS_PER_FAMILY, duals=duals
+            )
+        except Exception as exc:  # pragma: no cover - separator robustness
+            logger.debug("root-cuts: c-MIR separation failed: %s", exc)
+        try:
+            for cover, rhs in separate_cover_cuts(a_all, b_all, x, is_bin, max_cuts=32):
+                a = np.zeros(root.n)
+                for j in cover:
+                    a[j] = 1.0
+                cands.append((a, float(rhs)))
+        except Exception as exc:  # pragma: no cover - separator robustness
+            logger.debug("root-cuts: cover separation failed: %s", exc)
+        if h is not None:
+            cands += separate_gmi(root, h, x, a_all, b_all)
+
+        for a, r in cands:
+            a = np.asarray(a, float)
+            if a @ x - float(r) > CUT_VIOL_TOL:
+                pool.offer(a, float(r))
+        chosen = _select_cuts(pool.violated(x), x)
+        if chosen:
+            productive += 1
+        for a, r in chosen:
+            cuts_a.append(a)
+            cuts_b.append(r)
+            applied.append((a, r))
+
+        new_obj, x, duals, h = oa_converge()
+        if x is None:
+            break
+        obj = new_obj
+        if not chosen:
+            break
+
+    # Keep only the cuts binding at the final LP optimum: they carry the final
+    # bound; slack cuts only bloat every node NLP. (Validity is unaffected —
+    # this merely drops rows.)
+    if x is not None and applied:
+        applied = [(a, r) for a, r in applied if abs(float(a @ x) - r) <= 1e-6 * (1.0 + abs(r))]
+
+    return RootCutResult(
+        cuts=applied,
+        lp_bound=obj,
+        rounds_run=rounds,
+        productive_rounds=productive,
+    )

--- a/python/tests/test_nlpbb_root_cuts_781.py
+++ b/python/tests/test_nlpbb_root_cuts_781.py
@@ -1,0 +1,202 @@
+"""Tests for the NLP-BB root cutting-plane stage (#781, DISCOPT_NLPBB_ROOT_CUTS).
+
+Soundness gates:
+  * the GMI separator is validated by EXACT enumeration: on seeded random
+    MILPs, every emitted cut must be violated at the LP vertex and satisfied
+    by every integer assignment's full continuous completion (LP certificate
+    per integer corner — no sampling gap);
+  * flag OFF is inert (no constraints added, no behavior change);
+  * flag ON preserves the optimum and never reports an unsound bound
+    (min: bound <= opt; max: bound >= opt), on both senses;
+  * the slow named regression runs the real convex-synthesis instance.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+from discopt import Model
+from discopt.solvers._root_cuts import (
+    _solve_lp,
+    generate_root_cuts,
+    nlpbb_root_cuts_enabled,
+    separate_gmi,
+)
+
+pytest.importorskip("highspy")
+
+BENCH_NL = Path(os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"))
+OPT_RSYN0805M = 1296.120603  # minlplib.solu (maximize)
+
+
+def _flag(monkeypatch, on: bool) -> None:
+    if on:
+        monkeypatch.setenv("DISCOPT_NLPBB_ROOT_CUTS", "1")
+    else:
+        monkeypatch.delenv("DISCOPT_NLPBB_ROOT_CUTS", raising=False)
+
+
+# ── GMI separator: exact validity by enumeration ─────────────────────────────
+
+
+def test_gmi_cuts_valid_by_exact_enumeration():
+    """Every GMI cut must keep every integer-feasible point (LP certificate per
+    integer corner). A single positive violation is an unsound cut."""
+    from scipy.optimize import linprog
+
+    rng = np.random.default_rng(7)
+    n_bad = 0
+    n_cuts = 0
+    for _trial in range(25):
+        n_int = int(rng.integers(2, 5))
+        n_cont = int(rng.integers(1, 4))
+        n = n_int + n_cont
+        m = int(rng.integers(2, 6))
+        a_mat = np.round(rng.normal(0, 2, size=(m, n)), 1)
+        lb = np.zeros(n)
+        ub = np.concatenate([rng.integers(1, 6, n_int).astype(float), rng.uniform(1, 8, n_cont)])
+        b = a_mat @ ((lb + ub) / 2) + rng.uniform(0.5, 3.0, m)
+        c = np.round(rng.normal(0, 1, n), 2)
+        is_int = np.array([True] * n_int + [False] * n_cont)
+
+        root = types.SimpleNamespace(
+            n=n,
+            lb=lb,
+            ub=ub,
+            is_int=is_int,
+            A_le=a_mat,
+            b_le=b,
+            A_eq=np.zeros((0, n)),
+            b_eq=np.zeros(0),
+            c=c,
+            sense_max=True,
+        )
+        _obj, x, _duals, h = _solve_lp(root, [], [])
+        if x is None:
+            continue
+        cuts = separate_gmi(root, h, x, a_mat, b, max_cuts=16)
+        n_cuts += len(cuts)
+        for alpha, rhs in cuts:
+            assert alpha @ x - rhs > 1e-7, "cut not violated at the LP vertex"
+            for combo in itertools.product(*[range(int(ub[j]) + 1) for j in range(n_int)]):
+                bounds = [(float(v), float(v)) for v in combo] + [
+                    (lb[j], ub[j]) for j in range(n_int, n)
+                ]
+                res = linprog(-alpha, A_ub=a_mat, b_ub=b, bounds=bounds, method="highs")
+                if not res.success:
+                    continue
+                if float(alpha @ res.x - rhs) > 1e-7:
+                    n_bad += 1
+    assert n_cuts > 0, "enumeration produced no cuts — test lost its teeth"
+    assert n_bad == 0, f"{n_bad} UNSOUND GMI cuts (integer-feasible points removed)"
+
+
+# ── synthetic convex MINLP fixtures (both senses) ────────────────────────────
+
+
+def _build_convex_minlp(sense: str) -> Model:
+    """Fixed-charge network + one convex quadratic row; linear objective.
+
+    Routes to NLP-BB when solved with ``nlp_bb=True`` (convex, integer vars).
+    """
+    m = Model(f"rc_{sense}")
+    f0 = m.continuous("f0", lb=0.0, ub=10.0)
+    f1 = m.continuous("f1", lb=0.0, ub=10.0)
+    y0 = m.binary("y0")
+    y1 = m.binary("y1")
+    m.subject_to(f0 - 8.0 * y0 <= 0.0)
+    m.subject_to(f1 - 8.0 * y1 <= 0.0)
+    m.subject_to(f0 + f1 >= 3.0)
+    m.subject_to(f0 * f0 + f1 * f1 <= 16.0)  # convex quadratic
+    expr = f0 + f1 - 2.5 * y0 - 2.5 * y1
+    if sense == "max":
+        m.maximize(expr)
+    else:
+        m.minimize(f0 + 2.0 * f1 + 2.5 * y0 + 2.5 * y1)
+    return m
+
+
+@pytest.mark.parametrize("sense", ["max", "min"])
+def test_flag_off_inert(monkeypatch, sense):
+    _flag(monkeypatch, False)
+    assert nlpbb_root_cuts_enabled() is False
+    m = _build_convex_minlp(sense)
+    n_before = len(m._constraints)
+    m.solve(time_limit=30, nlp_bb=True)
+    assert len(m._constraints) == n_before, "flag OFF must add no constraints"
+
+
+@pytest.mark.parametrize("sense", ["max", "min"])
+def test_flag_on_optimum_and_bound_sound(monkeypatch, sense):
+    _flag(monkeypatch, False)
+    base = _build_convex_minlp(sense).solve(time_limit=30, nlp_bb=True)
+    assert base.objective is not None
+
+    _flag(monkeypatch, True)
+    m = _build_convex_minlp(sense)
+    r = m.solve(time_limit=30, nlp_bb=True)
+    assert r.objective is not None
+    assert not getattr(r, "incumbent_verification_failed", False)
+    # optimum preserved (the cuts removed no integer-feasible point)
+    assert r.objective == pytest.approx(base.objective, abs=1e-4, rel=1e-4)
+    # reported dual bound is sound w.r.t. the known optimum (= base objective)
+    if r.bound is not None:
+        if sense == "max":
+            assert r.bound >= base.objective - 1e-4
+        else:
+            assert r.bound <= base.objective + 1e-4
+
+
+def test_generate_root_cuts_direct_sound(monkeypatch):
+    """Direct call: LP bound must be a valid dual bound (>= opt for max)."""
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+
+    _flag(monkeypatch, True)
+    m = _build_convex_minlp("max")
+    opt = m.solve(time_limit=30, nlp_bb=True).objective
+    assert opt is not None
+
+    m2 = _build_convex_minlp("max")
+    ev = NLPEvaluator(m2)
+    lb = np.array([0.0, 0.0, 0.0, 0.0])
+    ub = np.array([10.0, 10.0, 1.0, 1.0])
+    is_int = np.array([False, False, True, True])
+    res = generate_root_cuts(m2, ev, lb, ub, is_int, is_int.copy())
+    assert res.lp_bound is not None
+    assert res.lp_bound >= opt - 1e-6, (
+        f"root LP bound {res.lp_bound} below the optimum {opt} — unsound"
+    )
+    # every returned cut keeps the known optimum's integer corners: check the
+    # cuts at the optimal incumbent of the flag-off solve
+    r = _build_convex_minlp("max").solve(time_limit=30, nlp_bb=True)
+    x_opt = np.array([float(np.atleast_1d(r.x[nm])[0]) for nm in ("f0", "f1", "y0", "y1")])
+    for alpha, rhs in res.cuts:
+        assert float(alpha @ x_opt) <= rhs + 1e-6, "cut removes the optimal solution"
+
+
+# ── the real class (benchmark corpus; slow) ──────────────────────────────────
+
+
+@pytest.mark.slow
+def test_rsyn0805m_flag_on_sound_and_tighter(monkeypatch):
+    nl = BENCH_NL / "rsyn0805m.nl"
+    if not nl.exists():
+        pytest.skip("benchmark corpus not available")
+    import discopt.modeling as dm
+
+    _flag(monkeypatch, True)
+    r = dm.from_nl(str(nl)).solve(time_limit=30)
+    assert not getattr(r, "incumbent_verification_failed", False)
+    # soundness (maximize): incumbent never super-optimal, bound never below opt
+    if r.objective is not None:
+        assert r.objective <= OPT_RSYN0805M + 1e-3
+    assert r.bound is not None
+    assert r.bound >= OPT_RSYN0805M - 1e-3
+    # the composed bound is at most the root-cut LP bound (~1577.3 measured);
+    # flag-off tree bound at this budget is ~1768 — require a real improvement
+    assert r.bound <= 1650.0, f"root-cut bound composition ineffective: {r.bound}"


### PR DESCRIPTION
## Summary

In-solver build of the mechanism the #781 entry experiment validated (#782): a **root cutting-plane stage on the convex NLP-BB path** — OA root LP, **GMI cuts from the HiGHS basis/tableau** (the load-bearing family), c-MIR + knapsack cover, under pooled efficacy×orthogonality top-K selection. `DISCOPT_NLPBB_ROOT_CUTS`, **default-OFF** (bound-changing, CLAUDE.md §5).

## Mechanism (`python/discopt/solvers/_root_cuts.py`, wired in `_solve_nlp_bb`)

- Runs only on the **convex-certified** route with a **verified-linear objective** (gradient sampled at two points; the evaluator's minimize-internal negation for MAXIMIZE models is unfolded so the LP bound is in the declared sense — caught by the smoke A/B before it could ship as an unsound bound).
- Cuts **binding at the final LP optimum** are appended to the model as **new `Constraint` objects with the full row folded into the body and `rhs = 0.0`** (both #772 lessons applied), *before* the evaluator/tree are built — every node NLP relaxation tightens. The binding filter keeps the added set small (measured 171 → 23 rows on rsyn0805m; the unfiltered set collapsed node throughput).
- The final root-LP bound composes with the tree bound (tighter of two valid bounds) for the **reported** bound/gap only — it never upgrades `gap_certified` or status (the LP is floating-point and outside the trusted-node machinery).
- Top-level solves only (RENS/local-branching sub-solves skip the stage); stage wall budget `min(10 s, 20% of time_limit)`; failure-safe throughout (any error degrades to the flag-off path).

## Soundness

- **GMI validated by exact enumeration** (seeded random MILPs, per-integer-corner LP certificates): **0 unsound cuts** — shipped as a regression test. The HiGHS tableau convention (`x_B(i) = −Σ red_ij·x_j + Σ binv_ir·z_r`) was verified numerically; only ≤-rows nonbasic at kUpper contribute slack deviations; free nonbasics invalidate the row; f0 margins + dynamism cap + relative rhs safety relaxation.
- Cuts are integrality-valid — direct test asserts they hold at the flag-off optimum; the #779 pristine-model incumbent guard is active as defense-in-depth.
- **Flag-ON soundness sweep** (66 vendored instances, 20 s, `minlplib.solu` oracle, guard active): **0 violations** (`discopt_benchmarks/results/issue781/rootcuts_soundness_sweep_20260719.json`).

## Measured (30 s, MAXIMIZE panel, ON vs OFF — all sound: bounds ≥ opt, incumbents ≤ opt, guard untripped)

| instance | incumbent OFF → ON | dual bound OFF → ON | gap spread OFF → ON | opt |
|---|---|---|---|---|
| rsyn0805m | 1055.8 → **1210.2** | 1864.8 → **1575.2** | 712 → **365** | 1296.1 |
| rsyn0810m | 1417.3 → **1623.8** | 2596.4 → **1948.2** | 1179 → **324** | 1721.4 |
| rsyn0815m | 1041.5 → 697.6 † | 1987.5 → **1627.9** | — | 1269.9 |
| syn40m | 31.0 → **40.0** | 1245.4 → **375.9** | 1214 → **336** | 67.7 |

† 30 s anytime snapshot (31 nodes); the bound side is strictly better.

## Tests run

- `python/tests/test_nlpbb_root_cuts_781.py` → **6 fast + 1 slow passed** (GMI enumeration validity; flag-off inertness both senses; optimum + bound soundness both senses; direct-call bound soundness + cuts-hold-at-optimum; rsyn0805m named regression)
- `pytest -m smoke` → **831 passed, 1 skipped, 2 xpassed**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**
- `ruff check` / `ruff format` / pre-commit mypy clean. No Rust touched. Default path byte-identical (flag unset ⇒ the stage never runs).

## Disposition

Default stays **OFF** pending the Regime-2 graduation panel (cert-clean + net-positive, §1.5 nodes-to-close). The 30 s panel above is promising on both axes (bound *and* incumbent on 3/4) but is not the graduation measurement.

Contributes to #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
