### PR TITLE
fix(#781): root-cut quality gate + model-row safety margin (clay regression)

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -10977,7 +10977,13 @@ def _solve_nlp_bb(
                         _rc_body = _term if _rc_body is None else _rc_body + _term
                     if _rc_body is None:
                         continue
-                    _rc_body = _rc_body + (-float(_rc_r))
+                    # Model-row safety margin: GMI cuts are TIGHT at integer
+                    # points (measured slack ~5e-10 at a verified optimum), so
+                    # an unrelaxed row could reject a tolerance-feasible
+                    # incumbent at acceptance time. Relaxing by 1e-7·scale is
+                    # far below the bound signal but above FP noise.
+                    _rc_rhs = float(_rc_r) + 1e-7 * (1.0 + abs(float(_rc_r)))
+                    _rc_body = _rc_body + (-_rc_rhs)
                     model._constraints.append(_RCConstraint(_rc_body, "<=", 0.0, None))
                     _root_cut_count += 1
                 _root_cut_bound = _rc.lp_bound

--- a/python/discopt/solvers/_root_cuts.py
+++ b/python/discopt/solvers/_root_cuts.py
@@ -456,6 +456,7 @@ def generate_root_cuts(
     obj, x, duals, h = oa_converge()
     if x is None:
         return RootCutResult()
+    b0 = obj  # OA-only root LP bound (pre-cut baseline for the quality gate)
 
     applied: list = []
     productive = 0
@@ -507,6 +508,18 @@ def generate_root_cuts(
         obj = new_obj
         if not chosen:
             break
+
+    # Quality gate: keep the stage's output only when the cutting loop actually
+    # MOVED the root LP bound past the OA-only baseline. On instances where the
+    # OA outer approximation is structurally weak (measured: clay0303hfsg's
+    # root LP bound is 0.0 vs opt 26669 — trivial), the cuts cannot help the
+    # bound and their per-node row cost is pure regression; skipping them makes
+    # the flag a no-op there (trivially sound).
+    if obj is None or b0 is None:
+        return RootCutResult(rounds_run=rounds, productive_rounds=productive)
+    gain = (b0 - obj) if root.sense_max else (obj - b0)
+    if gain <= 1e-6 * max(1.0, abs(b0)):
+        return RootCutResult(rounds_run=rounds, productive_rounds=productive)
 
     # Keep only the cuts binding at the final LP optimum: they carry the final
     # bound; slack cuts only bloat every node NLP. (Validity is unaffected —


### PR DESCRIPTION
## Summary

Fixes the one real per-instance regression the first #781 graduation-panel run surfaced (and that the net-positive tally under-counted — `obj=None` pairs weren't scored as "worse"): **clay0303hfsg** went feasible → no-incumbent at the 20 s budget with `DISCOPT_NLPBB_ROOT_CUTS=1`.

**Diagnosis (measured):** the cuts there are *valid* (worst violation 5e-10 at the independently-verified optimal incumbent) but *useless* — clay's OA root LP bound is **0.0 vs opt 26669** (structurally weak outer approximation), so the stage paid 22 extra rows of per-node cost plus its stage budget for zero bound gain.

## Fixes

1. **Quality gate** in `generate_root_cuts`: the stage's output is kept only when the cutting loop actually moved the root LP bound past the OA-only baseline B0 (relative 1e-6). Where the OA is structurally weak the flag becomes a no-op — trivially sound (skipping only forgoes an optional tightening).
2. **Model-row safety margin**: cuts appended as constraints get their rhs relaxed by `1e-7·(1+|rhs|)`. GMI cuts are tight at integer points; an unrelaxed row could reject a tolerance-feasible incumbent at acceptance time. Far below the bound signal, above FP noise.

## Measured after the fix (flag ON)

| instance | result |
|---|---|
| clay0303hfsg (60 s) | optimal 26669.1095, 443 nodes, certified — **identical to OFF** |
| syn30m (60 s) | **optimal 138.1596, 107 nodes, certified** (OFF: 1567 nodes, uncertified) — improvement kept |
| rsyn0805m (30 s) | bound 1575.2, obj 1210.2 — improvement kept |

## Tests run

- `python/tests/test_nlpbb_root_cuts_781.py` → 6 passed
- `pytest -m smoke` → 831 passed, 1 skipped, 2 xpassed
- `ruff` clean; no Rust touched; flag still default-OFF

The graduation-panel re-run with the gated version is in progress; the default-ON flip PR follows only if it passes both bars again.

Contributes to #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
