### PR TITLE
fix(#790): P1.0 — full warm-startable basis on slackless equality LPs (default-OFF gated)

### DIFF
--- a/crates/discopt-core/examples/feral_update_cost.rs
+++ b/crates/discopt-core/examples/feral_update_cost.rs
@@ -170,6 +170,7 @@ fn main() {
             deadline: None,
             warm_stall_guard: true,
             warm_stall_cap_override: None,
+            expel_zero_artificials: false,
         };
         let sol = solve_lp(&lp, &b, &opts);
         let basis = &sol.basis.basic_vars;

--- a/crates/discopt-core/examples/milp_bench.rs
+++ b/crates/discopt-core/examples/milp_bench.rs
@@ -166,6 +166,7 @@ fn opts(n_struct: usize, integer_cols: Vec<usize>, tl: f64) -> MilpOptions {
             deadline: None,
             warm_stall_guard: true,
             warm_stall_cap_override: None,
+            expel_zero_artificials: false,
         },
     }
 }

--- a/crates/discopt-core/examples/par_bench.rs
+++ b/crates/discopt-core/examples/par_bench.rs
@@ -130,6 +130,7 @@ fn opts(inst: &Instance) -> MilpOptions {
             deadline: None,
             warm_stall_guard: true,
             warm_stall_cap_override: None,
+            expel_zero_artificials: false,
         },
     }
 }

--- a/crates/discopt-core/src/bin/e0_warm_bench.rs
+++ b/crates/discopt-core/src/bin/e0_warm_bench.rs
@@ -158,6 +158,7 @@ fn main() -> ExitCode {
         deadline: None,
         warm_stall_guard: true,
         warm_stall_cap_override: None,
+        expel_zero_artificials: true,
     };
 
     let mut l = lp_data.l.clone();
@@ -439,110 +440,8 @@ fn main() -> ExitCode {
     match prepared {
         None => {
             println!("  prepared: root basis not usable (prepare returned None)");
-            // diagnose: basis size, duplicate basics, dual-feasibility violation
-            let m = s_view.m;
-            let n = s_view.n;
-            let bv = &s_root.basis.basic_vars;
-            let st = &s_root.basis.col_status;
-            println!(
-                "    diag: basic_vars.len()={} (m={}), col_status.len()={} (n={})",
-                bv.len(),
-                m,
-                st.len(),
-                n
-            );
-            let mut seen = vec![false; n];
-            let mut dups = 0;
-            for &j in bv {
-                if seen[j] {
-                    dups += 1;
-                }
-                seen[j] = true;
-            }
-            println!("    diag: duplicate basic columns: {dups}");
-            if bv.len() == m {
-                // dense B^T y = c_B, then reduced costs
-                let mut bt = vec![0.0f64; m * m];
-                for (slot, &j) in bv.iter().enumerate() {
-                    for r in 0..m {
-                        bt[slot * m + r] = s_view.a[r * n + j]; // B^T row=slot? build B col=slot
-                    }
-                }
-                // solve B^T y = c_B with naive Gaussian elimination (bench-only)
-                let mut aug = vec![0.0f64; m * (m + 1)];
-                for i in 0..m {
-                    for k in 0..m {
-                        // (B^T)[i][k] = B[k][i] = a[.. row .. col bv[i]] — careful:
-                        // B's column slot k is A's column bv[k]; B[r][k]=a[r][bv[k]]
-                        // (B^T)[i][k] = B[k? no: B^T[i][k] = B[k][i]
-                        aug[i * (m + 1) + k] = bt[i * m + k]; // bt[slot*m+r] = B[r][slot] => bt row=slot is column slot of B = row of B^T ✓
-                        let _ = k;
-                    }
-                    aug[i * (m + 1) + m] = s_view.c[bv[i]];
-                }
-                for col in 0..m {
-                    // partial pivot
-                    let mut piv = col;
-                    for r in (col + 1)..m {
-                        if aug[r * (m + 1) + col].abs() > aug[piv * (m + 1) + col].abs() {
-                            piv = r;
-                        }
-                    }
-                    if aug[piv * (m + 1) + col].abs() < 1e-14 {
-                        println!("    diag: B^T singular at col {col}");
-                        break;
-                    }
-                    if piv != col {
-                        for k in 0..=m {
-                            aug.swap(col * (m + 1) + k, piv * (m + 1) + k);
-                        }
-                    }
-                    let d = aug[col * (m + 1) + col];
-                    for r in 0..m {
-                        if r == col {
-                            continue;
-                        }
-                        let f = aug[r * (m + 1) + col] / d;
-                        if f != 0.0 {
-                            for k in col..=m {
-                                aug[r * (m + 1) + k] -= f * aug[col * (m + 1) + k];
-                            }
-                        }
-                    }
-                }
-                let y: Vec<f64> = (0..m)
-                    .map(|i| aug[i * (m + 1) + m] / aug[i * (m + 1) + i])
-                    .collect();
-                let mut worst = 0.0f64;
-                let mut worst_j = 0usize;
-                let mut n_viol = 0usize;
-                for j in 0..n {
-                    if seen[j] {
-                        continue;
-                    }
-                    let mut d = s_view.c[j];
-                    for (r, &yr) in y.iter().enumerate() {
-                        d -= yr * s_view.a[r * n + j];
-                    }
-                    let stj = st[j];
-                    let v = match stj {
-                        0 => (-d).max(0.0), // at lower: need d >= -tol
-                        1 => d.max(0.0),    // at upper: need d <= tol
-                        _ => d.abs(),       // free/other nonbasic
-                    };
-                    if v > 1e-7 {
-                        n_viol += 1;
-                        if v > worst {
-                            worst = v;
-                            worst_j = j;
-                        }
-                    }
-                }
-                println!(
-                    "    diag: dual-infeasible nonbasics: {n_viol}, worst |viol|={worst:.3e} at col {worst_j} (status {})",
-                    st[worst_j]
-                );
-            }
+            // (basis-deficiency diagnostics removed — P1.0 fixed; this arm
+            // should no longer be reached on full-rank LPs.)
         }
         Some(pd) => {
             println!("  prepared: LU factorize+verify in {prep_us:.0} us");

--- a/crates/discopt-core/src/bnb/mccormick_patch.rs
+++ b/crates/discopt-core/src/bnb/mccormick_patch.rs
@@ -122,11 +122,7 @@ pub fn monomial_rows(i: usize, s: usize, li: f64, ui: f64, p: i32) -> [EnvRow; 4
     // slope is 0/0; fall back to the endpoint derivative so the "secant" collapses
     // to the tangent at the pinned point. Guarded on EXACT zero width only — for any
     // positive width the true secant is the sound convex overestimator.
-    let slope = if ui <= li {
-        dfl
-    } else {
-        (fu - fl) / (ui - li)
-    };
+    let slope = if ui <= li { dfl } else { (fu - fl) / (ui - li) };
     let convex = (p % 2 == 0) || (li >= 0.0);
     let row = |cx: f64, cs: f64, rhs: f64| EnvRow {
         cols: [i, s, 0],
@@ -136,17 +132,17 @@ pub fn monomial_rows(i: usize, s: usize, li: f64, ui: f64, p: i32) -> [EnvRow; 4
     };
     if convex {
         [
-            row(dfl, -1.0, dfl * li - fl),        // tangent at li:  s >= f'(li)(x-li)+f(li)
-            row(dfm, -1.0, dfm * mid - fm),       // tangent at midpoint
-            row(dfu, -1.0, dfu * ui - fu),        // tangent at ui
-            row(-slope, 1.0, fl - slope * li),    // secant (overestimator): s <= ...
+            row(dfl, -1.0, dfl * li - fl), // tangent at li:  s >= f'(li)(x-li)+f(li)
+            row(dfm, -1.0, dfm * mid - fm), // tangent at midpoint
+            row(dfu, -1.0, dfu * ui - fu), // tangent at ui
+            row(-slope, 1.0, fl - slope * li), // secant (overestimator): s <= ...
         ]
     } else {
         [
-            row(-dfl, 1.0, fl - dfl * li),        // tangent at li (overestimator): s <= ...
-            row(-dfm, 1.0, fm - dfm * mid),       // tangent at midpoint
-            row(-dfu, 1.0, fu - dfu * ui),        // tangent at ui
-            row(slope, -1.0, slope * li - fl),    // secant (underestimator): s >= ...
+            row(-dfl, 1.0, fl - dfl * li), // tangent at li (overestimator): s <= ...
+            row(-dfm, 1.0, fm - dfm * mid), // tangent at midpoint
+            row(-dfu, 1.0, fu - dfu * ui), // tangent at ui
+            row(slope, -1.0, slope * li - fl), // secant (underestimator): s >= ...
         ]
     }
 }
@@ -156,7 +152,14 @@ pub fn monomial_rows(i: usize, s: usize, li: f64, ui: f64, p: i32) -> [EnvRow; 4
 /// convex for every `t` (no sign gating). Mirrors `_affine_square_rows`; each row is
 /// `(coeff_on_x, coeff_on_w, rhs)`, columns `(j, w)`.
 #[inline]
-pub fn affine_square_rows(j: usize, w: usize, coeff: f64, cst: f64, li: f64, ui: f64) -> [EnvRow; 4] {
+pub fn affine_square_rows(
+    j: usize,
+    w: usize,
+    coeff: f64,
+    cst: f64,
+    li: f64,
+    ui: f64,
+) -> [EnvRow; 4] {
     let tl = coeff * li + cst;
     let tu = coeff * ui + cst;
     let (t_lo, t_hi) = if tl <= tu { (tl, tu) } else { (tu, tl) };
@@ -172,9 +175,9 @@ pub fn affine_square_rows(j: usize, w: usize, coeff: f64, cst: f64, li: f64, ui:
         rhs,
     };
     [
-        row(-slope * coeff, 1.0, a + slope * cst),                    // secant (overestimator)
+        row(-slope * coeff, 1.0, a + slope * cst), // secant (overestimator)
         row(2.0 * t_lo * coeff, -1.0, t_lo * t_lo - 2.0 * t_lo * cst), // tangent at t_lo
-        row(2.0 * mid * coeff, -1.0, mid * mid - 2.0 * mid * cst),     // tangent at midpoint
+        row(2.0 * mid * coeff, -1.0, mid * mid - 2.0 * mid * cst), // tangent at midpoint
         row(2.0 * t_hi * coeff, -1.0, t_hi * t_hi - 2.0 * t_hi * cst), // tangent at t_hi
     ]
 }
@@ -612,7 +615,11 @@ mod tests {
             let w = (coeff * xi + cst).sqrt();
             let x = [xi, w];
             for r in &rows {
-                assert!(sat(r, &x, 1e-9), "sqrt true point {xi} cut: residual {}", r.residual(&x));
+                assert!(
+                    sat(r, &x, 1e-9),
+                    "sqrt true point {xi} cut: residual {}",
+                    r.residual(&x)
+                );
             }
         }
     }
@@ -627,7 +634,11 @@ mod tests {
         for &(xi, xj) in &[(li, lj), (li, uj), (ui, lj), (ui, uj)] {
             let x = [xi, xj, xi * xj];
             for r in &rows {
-                assert!(sat(r, &x, 1e-9), "corner ({xi},{xj}) residual {}", r.residual(&x));
+                assert!(
+                    sat(r, &x, 1e-9),
+                    "corner ({xi},{xj}) residual {}",
+                    r.residual(&x)
+                );
             }
         }
     }
@@ -645,7 +656,11 @@ mod tests {
                 let xj = lj + (uj - lj) * (b as f64) / (n as f64);
                 let x = [xi, xj, xi * xj];
                 for r in &rows {
-                    assert!(sat(r, &x, 1e-9), "true product cut: residual {}", r.residual(&x));
+                    assert!(
+                        sat(r, &x, 1e-9),
+                        "true product cut: residual {}",
+                        r.residual(&x)
+                    );
                 }
             }
         }
@@ -736,14 +751,30 @@ mod tests {
         let lo = vec![1.0, 2.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let hi = vec![3.0, 5.0, 4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let mut out = Vec::new();
-        bilinear_linform_rows(&[0], &[1.0], 0.0, &[1, 2], &[1.7, 0.4], 0.5, 9, &lo, &hi, &mut out);
+        bilinear_linform_rows(
+            &[0],
+            &[1.0],
+            0.0,
+            &[1, 2],
+            &[1.7, 0.4],
+            0.5,
+            9,
+            &lo,
+            &hi,
+            &mut out,
+        );
         assert_eq!(out.len(), 4);
         assert_wide_row(&out[0], &[(0, 3.5), (1, 1.7), (2, 0.4), (9, -1.0)], 3.0);
         assert_wide_row(&out[1], &[(0, 10.6), (1, 5.1), (2, 1.2), (9, -1.0)], 30.3);
         assert_wide_row(&out[2], &[(0, -3.5), (1, -5.1), (2, -1.2), (9, 1.0)], -9.0);
-        assert_wide_row(&out[3], &[(0, -10.6), (1, -1.7), (2, -0.4), (9, 1.0)], -10.1);
+        assert_wide_row(
+            &out[3],
+            &[(0, -10.6), (1, -1.7), (2, -0.4), (9, 1.0)],
+            -10.1,
+        );
         // aux bounds = interval(A)*interval(B) = [1,3]*[3.5,10.6] = [3.5, 31.8].
-        let (alo, ahi) = bilinear_linform_aux_bounds(&[0], &[1.0], 0.0, &[1, 2], &[1.7, 0.4], 0.5, &lo, &hi);
+        let (alo, ahi) =
+            bilinear_linform_aux_bounds(&[0], &[1.0], 0.0, &[1, 2], &[1.7, 0.4], 0.5, &lo, &hi);
         assert!((alo - 3.5).abs() < 1e-9 && (ahi - 31.8).abs() < 1e-9);
     }
 
@@ -754,7 +785,18 @@ mod tests {
         let lo = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let hi = vec![2.0, 3.0, 0.0, 0.0, 0.0, 0.0];
         let mut out = Vec::new();
-        bilinear_linform_rows(&[0], &[1.0], 0.0, &[0, 1], &[1.0, 1.0], 0.0, 5, &lo, &hi, &mut out);
+        bilinear_linform_rows(
+            &[0],
+            &[1.0],
+            0.0,
+            &[0, 1],
+            &[1.0, 1.0],
+            0.0,
+            5,
+            &lo,
+            &hi,
+            &mut out,
+        );
         assert_eq!(out.len(), 4);
         assert_wide_row(&out[0], &[(0, 2.0), (1, 1.0), (5, -1.0)], 1.0);
         assert_wide_row(&out[1], &[(0, 7.0), (1, 2.0), (5, -1.0)], 10.0);
@@ -770,7 +812,18 @@ mod tests {
         let hi = vec![3.0, 5.0, 0.0];
         let special = bilinear_rows(0, 1, 2, -1.0, 3.0, 2.0, 5.0);
         let mut general = Vec::new();
-        bilinear_linform_rows(&[0], &[1.0], 0.0, &[1], &[1.0], 0.0, 2, &lo, &hi, &mut general);
+        bilinear_linform_rows(
+            &[0],
+            &[1.0],
+            0.0,
+            &[1],
+            &[1.0],
+            0.0,
+            2,
+            &lo,
+            &hi,
+            &mut general,
+        );
         assert_eq!(general.len(), 4);
         // Same SET of rows (the McCormick hull) — `_emit_mccormick` emits the two
         // over-rows in the opposite order to `_bilinear_rows`, so match set-wise: each
@@ -789,7 +842,10 @@ mod tests {
         let gset: Vec<_> = general.iter().map(|(c, k, r)| norm(c, k, *r)).collect();
         for s in &special {
             let key = norm(&s.cols[..s.nnz], &s.coeffs[..s.nnz], s.rhs);
-            assert!(gset.contains(&key), "special row {key:?} not in general set");
+            assert!(
+                gset.contains(&key),
+                "special row {key:?} not in general set"
+            );
         }
     }
 

--- a/crates/discopt-core/src/bnb/obbt_sweep.rs
+++ b/crates/discopt-core/src/bnb/obbt_sweep.rs
@@ -183,7 +183,15 @@ mod tests {
         let res = obbt_probe_sweep(&sp, m, n, &b, &l, &u, &[0usize], &start, &opts);
         // OBBT over [0.5,1.5] recovers min 0.5 / max 1.5 (the box binds, not the LP),
         // so the bound is unchanged — never loosened toward the LP's [0,2].
-        assert!(res.bounds[0].0 >= 0.5 - 1e-9, "lower loosened: {}", res.bounds[0].0);
-        assert!(res.bounds[0].1 <= 1.5 + 1e-9, "upper loosened: {}", res.bounds[0].1);
+        assert!(
+            res.bounds[0].0 >= 0.5 - 1e-9,
+            "lower loosened: {}",
+            res.bounds[0].0
+        );
+        assert!(
+            res.bounds[0].1 <= 1.5 + 1e-9,
+            "upper loosened: {}",
+            res.bounds[0].1
+        );
     }
 }

--- a/crates/discopt-core/src/bnb/spatial_kernel.rs
+++ b/crates/discopt-core/src/bnb/spatial_kernel.rs
@@ -101,9 +101,7 @@ impl EnvTerm {
     /// by structural column). `None` for `Sqrt` on a base box that dips below 0.
     fn aux_bounds(&self, lo: &[f64], hi: &[f64]) -> Option<(f64, f64)> {
         Some(match *self {
-            EnvTerm::Bilinear { i, j, .. } => {
-                mc::bilinear_aux_bounds(lo[i], hi[i], lo[j], hi[j])
-            }
+            EnvTerm::Bilinear { i, j, .. } => mc::bilinear_aux_bounds(lo[i], hi[i], lo[j], hi[j]),
             EnvTerm::Monomial { i, p, .. } => mc::monomial_aux_bounds(lo[i], hi[i], p),
             EnvTerm::AffineSquare { j, coeff, cst, .. } => {
                 mc::affine_square_aux_bounds(coeff, cst, lo[j], hi[j])
@@ -119,11 +117,7 @@ impl EnvTerm {
     fn push_rows(&self, lo: &[f64], hi: &[f64], out: &mut Vec<(Vec<usize>, Vec<f64>, f64)>) {
         let emit = |rows: &[mc::EnvRow], out: &mut Vec<(Vec<usize>, Vec<f64>, f64)>| {
             for r in rows {
-                out.push((
-                    r.cols[..r.nnz].to_vec(),
-                    r.coeffs[..r.nnz].to_vec(),
-                    r.rhs,
-                ));
+                out.push((r.cols[..r.nnz].to_vec(), r.coeffs[..r.nnz].to_vec(), r.rhs));
             }
         };
         match *self {
@@ -135,7 +129,8 @@ impl EnvTerm {
                 emit(&mc::affine_square_rows(j, w, coeff, cst, lo[j], hi[j]), out)
             }
             EnvTerm::Sqrt { x, w, coeff, cst } => {
-                if let Some(rows) = mc::univariate_rows(x, w, coeff, cst, lo[x], hi[x], mc::Univariate::Sqrt)
+                if let Some(rows) =
+                    mc::univariate_rows(x, w, coeff, cst, lo[x], hi[x], mc::Univariate::Sqrt)
                 {
                     emit(&rows, out);
                 }
@@ -260,7 +255,14 @@ pub fn assemble_node_lp(spec: &SpatialKernelSpec, lo: &[f64], hi: &[f64]) -> Ass
     }
     for t in &spec.blf_terms {
         let (alo, ahi) = mc::bilinear_linform_aux_bounds(
-            &t.a_cols, &t.a_coeffs, t.a_const, &t.b_cols, &t.b_coeffs, t.b_const, lo, hi,
+            &t.a_cols,
+            &t.a_coeffs,
+            t.a_const,
+            &t.b_cols,
+            &t.b_coeffs,
+            t.b_const,
+            lo,
+            hi,
         );
         if alo.is_finite() {
             l[t.w] = l[t.w].max(alo);
@@ -271,9 +273,8 @@ pub fn assemble_node_lp(spec: &SpatialKernelSpec, lo: &[f64], hi: &[f64]) -> Ass
     }
 
     // Rows: fixed rows, then per-term envelope rows (fixed-width, then affine-form).
-    let mut rows: Vec<(Vec<usize>, Vec<f64>, f64)> = Vec::with_capacity(
-        spec.fixed_rows.len() + spec.terms.len() * 4 + spec.blf_terms.len() * 4,
-    );
+    let mut rows: Vec<(Vec<usize>, Vec<f64>, f64)> =
+        Vec::with_capacity(spec.fixed_rows.len() + spec.terms.len() * 4 + spec.blf_terms.len() * 4);
     for fr in &spec.fixed_rows {
         rows.push((fr.cols.clone(), fr.coeffs.clone(), fr.rhs));
     }
@@ -282,7 +283,15 @@ pub fn assemble_node_lp(spec: &SpatialKernelSpec, lo: &[f64], hi: &[f64]) -> Ass
     }
     for t in &spec.blf_terms {
         mc::bilinear_linform_rows(
-            &t.a_cols, &t.a_coeffs, t.a_const, &t.b_cols, &t.b_coeffs, t.b_const, t.w, lo, hi,
+            &t.a_cols,
+            &t.a_coeffs,
+            t.a_const,
+            &t.b_cols,
+            &t.b_coeffs,
+            t.b_const,
+            t.w,
+            lo,
+            hi,
             &mut rows,
         );
     }
@@ -331,7 +340,11 @@ pub fn assemble_node_lp(spec: &SpatialKernelSpec, lo: &[f64], hi: &[f64]) -> Ass
     for (r, (rc, rcoef, rhs)) in rows.iter().enumerate() {
         let mut min_act = 0.0f64;
         for (c, v) in rc.iter().zip(rcoef.iter()) {
-            min_act += if *v > 0.0 { v * lfull[*c] } else { v * ufull[*c] };
+            min_act += if *v > 0.0 {
+                v * lfull[*c]
+            } else {
+                v * ufull[*c]
+            };
         }
         let cap = if min_act.is_finite() {
             (rhs - min_act).max(0.0)
@@ -375,7 +388,16 @@ pub fn solve_spatial_node(
     // trusted path uses and unscales x/dual/ray back to the original space, so the
     // safe-bound evaluation sees well-conditioned certificates against the
     // original system.
-    let sol = solve_lp_cols_scaled(lp.sp.clone(), lp.m, lp.n_total, &c, &lp.l, &lp.u, &lp.b, opts);
+    let sol = solve_lp_cols_scaled(
+        lp.sp.clone(),
+        lp.m,
+        lp.n_total,
+        &c,
+        &lp.l,
+        &lp.u,
+        &lp.b,
+        opts,
+    );
     let mut n_lp_solves = 1usize;
 
     // Rigorous safe lower bound from the row duals — NEVER the raw simplex objective
@@ -452,7 +474,11 @@ mod tests {
         assert_eq!(res.status, LpStatus::Optimal);
         // min w over the McCormick hull on [0,2]^2 is 0; the SAFE bound reproduces
         // it (well-conditioned) and is never above the true optimum (soundness).
-        assert!(res.bound <= 0.0 + 1e-9, "safe bound {} above true optimum 0", res.bound);
+        assert!(
+            res.bound <= 0.0 + 1e-9,
+            "safe bound {} above true optimum 0",
+            res.bound
+        );
         assert!(res.bound.abs() < 1e-7, "bound {} != 0", res.bound);
         // aux w column bound derived from the box: [0*0, 2*2] = [0,4].
         let lp = assemble_node_lp(&spec, &lo, &hi);
@@ -498,7 +524,11 @@ mod tests {
             blf.bound,
             bilinear.bound
         );
-        assert!((blf.bound - 1.0).abs() < 1e-6, "blf bound {} != 1", blf.bound);
+        assert!(
+            (blf.bound - 1.0).abs() < 1e-6,
+            "blf bound {} != 1",
+            blf.bound
+        );
     }
 
     #[test]
@@ -512,7 +542,11 @@ mod tests {
         let res = solve_spatial_node(&spec, &lo, &hi, false, &opts);
         assert_eq!(res.status, LpStatus::Optimal);
         // Safe bound reproduces the tightened optimum and never exceeds it.
-        assert!(res.bound <= 1.0 + 1e-9, "safe bound {} above true optimum 1", res.bound);
+        assert!(
+            res.bound <= 1.0 + 1e-9,
+            "safe bound {} above true optimum 1",
+            res.bound
+        );
         assert!((res.bound - 1.0).abs() < 1e-6, "bound {} != 1", res.bound);
     }
 
@@ -535,7 +569,10 @@ mod tests {
         assert_eq!(res.tightened.len(), 2);
         assert_eq!(res.n_lp_solves, 1 + 4); // node + 2 candidates * 2 probes
         for (idx, &(glo, ghi)) in res.tightened.iter().enumerate() {
-            assert!(glo >= lo[idx] - 1e-9 && ghi <= hi[idx] + 1e-9, "loosened candidate {idx}");
+            assert!(
+                glo >= lo[idx] - 1e-9 && ghi <= hi[idx] + 1e-9,
+                "loosened candidate {idx}"
+            );
             // x+y<=2 with the other var >=0 gives max x = 2, min x = 0.
             assert!((glo - 0.0).abs() < 1e-6 && (ghi - 2.0).abs() < 1e-6);
         }

--- a/crates/discopt-core/src/bnb/spatial_propagate.rs
+++ b/crates/discopt-core/src/bnb/spatial_propagate.rs
@@ -514,7 +514,11 @@ mod tests {
         let mut lo = vec![0.0, 0.0, 1.0];
         let mut hi = vec![2.0, 3.0, 6.0];
         assert!(propagate_spec_fixpoint(&spec, &mut lo, &mut hi, None, 10));
-        assert!(lo[0] >= 1.0 / 3.0 - 1e-6, "x lo {} (extended reverse)", lo[0]);
+        assert!(
+            lo[0] >= 1.0 / 3.0 - 1e-6,
+            "x lo {} (extended reverse)",
+            lo[0]
+        );
         assert!(lo[1] >= 0.5 - 1e-6, "y lo {} (extended reverse)", lo[1]);
     }
 
@@ -547,7 +551,13 @@ mod tests {
         }];
         let mut lo = vec![0.0];
         let mut hi = vec![10.0];
-        assert!(!propagate_spec_fixpoint(&spec, &mut lo, &mut hi, Some(1.0), 10));
+        assert!(!propagate_spec_fixpoint(
+            &spec,
+            &mut lo,
+            &mut hi,
+            Some(1.0),
+            10
+        ));
     }
 
     /// The tanksize chain in miniature: cutoff tightens the objective variable, a
@@ -576,11 +586,25 @@ mod tests {
         }];
         let mut lo = vec![0.0, 1.0, 1.0, 0.0];
         let mut hi = vec![10.0, 4.0, 4.0, 100.0];
-        assert!(propagate_spec_fixpoint(&spec, &mut lo, &mut hi, Some(2.0), 15));
+        assert!(propagate_spec_fixpoint(
+            &spec,
+            &mut lo,
+            &mut hi,
+            Some(2.0),
+            15
+        ));
         assert!(hi[0] <= 2.0 + 1e-6, "obj hi {}", hi[0]);
         assert!(hi[3] <= 2.0 + 1e-5, "w hi {} (via linear row)", hi[3]);
-        assert!(hi[1] <= 2.0 + 1e-4, "x1 hi {} (via reverse division)", hi[1]);
-        assert!(hi[2] <= 2.0 + 1e-4, "x2 hi {} (via reverse division)", hi[2]);
+        assert!(
+            hi[1] <= 2.0 + 1e-4,
+            "x1 hi {} (via reverse division)",
+            hi[1]
+        );
+        assert!(
+            hi[2] <= 2.0 + 1e-4,
+            "x2 hi {} (via reverse division)",
+            hi[2]
+        );
     }
 
     /// Tighten-only + outward guard: propagation never widens and never crosses.

--- a/crates/discopt-core/src/bnb/spatial_tree.rs
+++ b/crates/discopt-core/src/bnb/spatial_tree.rs
@@ -158,7 +158,9 @@ fn term_true_value(t: &EnvTerm, x: &[f64]) -> Option<f64> {
             let t = coeff * x[j] + cst;
             t * t
         }
-        EnvTerm::Sqrt { x: xc, coeff, cst, .. } => {
+        EnvTerm::Sqrt {
+            x: xc, coeff, cst, ..
+        } => {
             let arg = coeff * x[xc] + cst;
             if arg < 0.0 {
                 return None;
@@ -236,7 +238,12 @@ pub fn solve_spatial_tree(
     // best-bound the heap top is exactly that frontier minimum.
     let mut global_lb_closed = f64::INFINITY;
 
-    while let Some(QNode { pb: parent_bound, lo, hi }) = heap.pop() {
+    while let Some(QNode {
+        pb: parent_bound,
+        lo,
+        hi,
+    }) = heap.pop()
+    {
         // Fathom by the parent bound if the incumbent already dominates it. The
         // region's valid lower bound is `parent_bound`.
         if let Some(inc) = incumbent {
@@ -272,7 +279,13 @@ pub fn solve_spatial_tree(
         let mut lo = lo;
         let mut hi = hi;
         if config.run_propagation
-            && !propagate_spec_fixpoint(spec, &mut lo, &mut hi, incumbent, config.propagation_rounds)
+            && !propagate_spec_fixpoint(
+                spec,
+                &mut lo,
+                &mut hi,
+                incumbent,
+                config.propagation_rounds,
+            )
         {
             let contrib = incumbent.unwrap_or(f64::INFINITY).max(parent_bound);
             global_lb_closed = global_lb_closed.min(contrib);
@@ -430,18 +443,34 @@ pub fn solve_spatial_tree(
             let hi2 = hi.clone();
             lo2[split_col] = f + 1.0;
             if hi1[split_col] >= lo1[split_col] - 1e-12 {
-                heap.push(QNode { pb: bound, lo: lo1, hi: hi1 });
+                heap.push(QNode {
+                    pb: bound,
+                    lo: lo1,
+                    hi: hi1,
+                });
             }
             if hi2[split_col] >= lo2[split_col] - 1e-12 {
-                heap.push(QNode { pb: bound, lo: lo2, hi: hi2 });
+                heap.push(QNode {
+                    pb: bound,
+                    lo: lo2,
+                    hi: hi2,
+                });
             }
         } else {
             let mut hi1 = hi.clone();
             hi1[split_col] = split_at;
             let mut lo2 = lo.clone();
             lo2[split_col] = split_at;
-            heap.push(QNode { pb: bound, lo: lo.clone(), hi: hi1 });
-            heap.push(QNode { pb: bound, lo: lo2, hi: hi.clone() });
+            heap.push(QNode {
+                pb: bound,
+                lo: lo.clone(),
+                hi: hi1,
+            });
+            heap.push(QNode {
+                pb: bound,
+                lo: lo2,
+                hi: hi.clone(),
+            });
         }
     }
 
@@ -488,7 +517,10 @@ fn dot(a: &[f64], b: &[f64]) -> f64 {
 
 /// `Σ coeffs[k] * x[cols[k]]` — the value of a sparse affine form's linear part.
 fn dot_form(cols: &[usize], coeffs: &[f64], x: &[f64]) -> f64 {
-    cols.iter().zip(coeffs.iter()).map(|(&c, &a)| a * x[c]).sum()
+    cols.iter()
+        .zip(coeffs.iter())
+        .map(|(&c, &a)| a * x[c])
+        .sum()
 }
 
 /// Pull a split point strictly inside `(lo, hi)` so both children are nonempty; if
@@ -546,7 +578,11 @@ mod tests {
         // Global optimum is 2.0.
         assert!((inc - 2.0).abs() < 1e-3, "incumbent {inc} != 2.0");
         // Soundness: global bound never above the true optimum.
-        assert!(res.bound <= 2.0 + 1e-6, "bound {} above optimum 2.0", res.bound);
+        assert!(
+            res.bound <= 2.0 + 1e-6,
+            "bound {} above optimum 2.0",
+            res.bound
+        );
         // The incumbent point is feasible: x*y == w and x+y>=3.
         let x = &res.incumbent_x;
         assert!((x[0] * x[1] - x[2]).abs() < 1e-4, "w != x*y at incumbent");

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -93,6 +93,29 @@ pub struct SimplexOptions {
     /// Exists so a test can drive a deterministic, small cap without depending on
     /// LP size; production always leaves it `None`.
     pub warm_stall_cap_override: Option<usize>,
+    /// Expel **zero-valued basic artificials** from the final (phase-2 optimal)
+    /// basis so the emitted basis is full-rank in real columns whenever the
+    /// constraint rows are — the precondition every warm-start entry point
+    /// (`solve_lp_warm`, `PreparedDual::prepare`) requires (P1.0,
+    /// `docs/dev/scip-parity-kernel-plan.md`). On the slackless equality rows of
+    /// the convex big-M relaxations, phase-1 parks a degenerate (value-0) basic
+    /// artificial the strict reduced-cost rule never expels; the legacy emission
+    /// finds no zero-valued singleton slack to substitute (equality rows have
+    /// none) and emits a SHORT, mislabelled basis, so warm-start silently
+    /// cold-falls-back (measured: rsyn0805m 90/s vs the ~1 400/s kernel rate the
+    /// full basis unlocks). When `true`, a finalization pass drives them out via
+    /// `t = 0` degenerate pivots (x/obj/duals invariant on the vertex).
+    ///
+    /// Default `false`. This is **bound-changing on the default path**, not
+    /// neutral: it also fills rows an inequality LP left short (a nonzero slack →
+    /// no zero-valued singleton), so warm-start engages where it previously
+    /// cold-fell-back, changing the *sequence* of node solves within a time
+    /// budget (node_count drifts on ~7/66 vendored instances — all sound: each
+    /// node's LP optimum is bit-identical, only the degenerate dual vector, hence
+    /// the safe bound value, may differ, always ≤ the true optimum). So it ships
+    /// OFF and is opted into only by the branch-and-cut kernel path (which needs
+    /// warm-start to succeed), pending the CLAUDE.md §5 graduation panel.
+    pub expel_zero_artificials: bool,
 }
 
 impl SimplexOptions {
@@ -131,6 +154,7 @@ impl Default for SimplexOptions {
             deadline: None,
             warm_stall_guard: true,
             warm_stall_cap_override: None,
+            expel_zero_artificials: false,
         }
     }
 }

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -526,6 +526,25 @@ fn solution_within_tolerance(
     audit_feasibility(cols, m, n, b, l, u, x) == Feasibility::Ok
 }
 
+// Test-only FORCE for the P1.0 finalization pass (independent of
+// `SimplexOptions::expel_zero_artificials`), so one regression test can solve
+// the SAME LP with the pass on and off and assert fails-before / passes-after
+// without threading options through the test helper. Compiled out entirely in
+// release (returns a `const false`).
+#[cfg(test)]
+thread_local! {
+    static P1_EXPEL_FORCED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+#[cfg(test)]
+fn p1_expel_forced_for_test() -> bool {
+    P1_EXPEL_FORCED.with(|c| c.get())
+}
+#[cfg(not(test))]
+#[inline(always)]
+fn p1_expel_forced_for_test() -> bool {
+    false
+}
+
 struct Simplex<'a> {
     cols: SparseCols, // CSC of the constraint matrix; the sole matrix view (pricing,
     // residual, audit all go through it — no dense `m×n` copy is kept)
@@ -548,6 +567,10 @@ struct Simplex<'a> {
     /// Primal unbounded ray (length `n`), captured when [`Self::simplex_loop`]
     /// detects unboundedness so [`Self::assemble`] can export it; empty until then.
     unbounded_ray: Vec<f64>,
+    /// Copied from [`SimplexOptions::expel_zero_artificials`] (P1.0): run the
+    /// zero-valued-basic-artificial finalization pass so warm-start gets a full
+    /// basis. Default `false` (bound-changing; kernel path opts in).
+    expel_zero_artificials: bool,
 }
 
 impl<'a> Simplex<'a> {
@@ -601,6 +624,7 @@ impl<'a> Simplex<'a> {
             lb,
             ub,
             unbounded_ray: Vec::new(),
+            expel_zero_artificials: opts.expel_zero_artificials,
         }
     }
 
@@ -1151,6 +1175,103 @@ impl<'a> Simplex<'a> {
                         xb = self.basic_values(art_sign)?;
                     }
                 }
+            }
+        }
+        Ok(())
+    }
+
+    /// Drive every ZERO-valued basic artificial out of the final (phase-2
+    /// optimal) basis via degenerate pivots, so the emitted basis is full-rank
+    /// in real columns whenever the constraint rows are (P1.0). See the call
+    /// site for the full rationale.
+    ///
+    /// For each basic slot holding an artificial at value 0: compute the pivot
+    /// row `ρ = e_slotᵀ B⁻¹`, pick the largest-|entry| nonbasic REAL column `q`
+    /// with `|ρᵀA_q| > PIVOT_MIN`, and pivot it in. The step length is 0 (the
+    /// artificial is already 0 and every basic value is preserved), so this is a
+    /// pure representation change: `A x = b`, the bounds, the optimum, and the
+    /// row duals are all invariant. A row with no such column is genuinely
+    /// redundant; its artificial is left basic (the caller's warm path declines
+    /// a short basis, unchanged). `Err` only on a factorization breakdown, which
+    /// the caller ignores (basis emitted as-is, exactly as before this pass).
+    fn expel_zero_basic_artificials(&mut self, art_sign: &[f64]) -> Result<(), ()> {
+        const PIVOT_MIN: f64 = 1e-7;
+        const ART_TOL: f64 = 1e-9;
+        // Cheap early-out: healthy solves leave no basic artificial at all.
+        if !self.basis.iter().any(|&j| j >= self.n) {
+            return Ok(());
+        }
+        let mut xb = self.basic_values(art_sign)?;
+        let mut updates_since_refac = 0usize;
+        // NEUTRALITY: the legacy emission substitutes, for a basic artificial in
+        // constraint row `r`, that row's own zero-valued structural SINGLETON
+        // (its slack in the `[A_ub|I]` standard form every production node LP
+        // uses) — a pure relabel. To keep that path byte-identical, this pass is
+        // a no-op on any artificial row that HAS such a singleton (the legacy
+        // relabel then emits the identical basis). It only acts on the new case:
+        // a slackless row (an equality row of the convex big-M relaxations),
+        // where no singleton exists and the legacy path emitted a short basis.
+        // Precompute the row → zero-valued-singleton map exactly as emission does.
+        let mut singleton_row: Vec<bool> = vec![false; self.m];
+        for j in 0..self.n {
+            if self.stat[j] == BASIC || self.nb_value(j) != 0.0 {
+                continue;
+            }
+            let (rows, _) = self.cols.col(j);
+            if rows.len() == 1 {
+                singleton_row[rows[0]] = true;
+            }
+        }
+        // One attempt per row; a slot that admits no entering column is redundant
+        // and permanently skipped (the loop always makes progress / terminates).
+        for slot in 0..self.m {
+            if self.basis[slot] < self.n || xb[slot].abs() > ART_TOL {
+                continue; // real column, or a nonzero artificial (a real residual)
+            }
+            // The artificial's constraint row (column n+r is ±eᵣ).
+            let r = self.basis[slot] - self.n;
+            if r < self.m && singleton_row[r] {
+                continue; // legacy emission handles this row identically — stay neutral
+            }
+            // Pivot row ρ = e_slotᵀ B⁻¹.
+            let mut rho = vec![0.0; self.m];
+            rho[slot] = 1.0;
+            if self.lu.btran(&mut rho).is_err() {
+                return Err(());
+            }
+            // Largest-|pivot| nonbasic real column in this row.
+            let mut q: Option<usize> = None;
+            let mut best = PIVOT_MIN;
+            for j in 0..self.n {
+                if self.stat[j] == BASIC {
+                    continue;
+                }
+                let arj = self.col_dot(j, &rho, art_sign);
+                if arj.abs() > best {
+                    best = arj.abs();
+                    q = Some(j);
+                }
+            }
+            let q = match q {
+                Some(q) => q,
+                None => continue, // genuinely redundant row: leave the artificial
+            };
+            // Degenerate pivot: q enters basic (value 0, since it sits at a bound
+            // and the step is 0), the artificial leaves nonbasic at its [0,0] bound.
+            let leaving = self.basis[slot];
+            self.stat[leaving] = AT_LOWER; // artificial fixed at [0,0]
+            self.slot_of[leaving] = -1;
+            self.basis[slot] = q;
+            self.slot_of[q] = slot as i64;
+            self.stat[q] = BASIC;
+            xb[slot] = self.nb_value(q); // = the bound value; basic-at-its-bound (0-step)
+            let col = self.column(q, art_sign);
+            let need_refac = self.lu.update(slot, &col).is_err();
+            updates_since_refac += 1;
+            if need_refac || updates_since_refac >= 48 {
+                self.refactorize(art_sign)?;
+                updates_since_refac = 0;
+                xb = self.basic_values(art_sign)?;
             }
         }
         Ok(())
@@ -1725,6 +1846,35 @@ impl<'a> Simplex<'a> {
         };
         let ray = std::mem::take(&mut self.unbounded_ray);
 
+        // P1.0 (scip-parity-kernel-plan): drive out any ZERO-valued basic
+        // artificial that survived phase 2, so the emitted basis is a full,
+        // correctly-labelled basis of real columns whenever the rows are
+        // full-rank. `drive_out_basic_artificials` (phase 1) only expels
+        // artificials with value > 1e-9 (a real infeasibility residual); a
+        // *degenerate* basic artificial (value 0) on a slackless row — the
+        // mass-balance equality rows of the convex big-M relaxations — is not
+        // touched there, survives to here, and (below) has no zero-valued
+        // structural singleton to substitute, so the basis was emitted SHORT
+        // and mislabelled. Every warm-start consumer (`PreparedDual`,
+        // `run_warm`) then rejects it and silently cold-solves (measured:
+        // rsyn0805m 534/537 basics → 90 solves/s instead of ~26k). This pass
+        // pivots a nonbasic real column with a nonzero entry in the artificial's
+        // row into the basis via a t=0 degenerate pivot: x_B, the optimum, and
+        // the duals are all unchanged (pure basis-representation change), and
+        // the leaving artificial goes nonbasic at its fixed [0,0] bound
+        // (trivially dual-feasible). Only a genuinely rank-deficient (redundant)
+        // row admits no such column; there the artificial legitimately stays and
+        // the basis is short exactly as before — the warm path still declines,
+        // but now honestly rather than on a mislabelled basis. Runs only on the
+        // certified-Optimal path; failure-safe (a factor breakdown leaves the
+        // basis as-is). Byte-neutral: x/obj/dual are not read from the basis
+        // beyond this point except as the representation the warm path consumes.
+        if status == LpStatus::Optimal
+            && (self.expel_zero_artificials || p1_expel_forced_for_test())
+        {
+            let _ = self.expel_zero_basic_artificials(art_sign);
+        }
+
         // Export a *complete*, row-ordered basis of real columns (length m).
         //
         // Phase 2 can leave an artificial (column ≥ self.n) basic at value 0 on a
@@ -2273,6 +2423,128 @@ mod tests {
             (g - r.obj).abs() < 1e-3,
             "safe bound {g} too loose vs {}",
             r.obj
+        );
+    }
+
+    fn solve_with_p1_expel(
+        a: &[f64],
+        m: usize,
+        n: usize,
+        b: &[f64],
+        c: &[f64],
+        l: &[f64],
+        u: &[f64],
+        enabled: bool,
+    ) -> LpSolve {
+        P1_EXPEL_FORCED.with(|cell| cell.set(enabled));
+        let r = solve(a, m, n, b, c, l, u);
+        P1_EXPEL_FORCED.with(|cell| cell.set(false));
+        r
+    }
+
+    /// Build a slackless equality LP that reproduces the P1.0 phase-1 stall:
+    /// a `k×k` grid of "lift" columns whose row-couplings (`row_i: Σ_j x_ij = 1`
+    /// and `col_j: Σ_i x_ij = 1`, a doubly-stochastic / assignment polytope with
+    /// one redundant row DROPPED so the system is full rank `2k−1`) is padded
+    /// with `extra` duplicate columns that price at reduced-cost ≈ 0 — the exact
+    /// redundant-column structure of the lifted McCormick relaxations on which
+    /// phase-1 parks a zero-valued basic artificial the strict reduced-cost rule
+    /// never expels. Returns `(a_rowmajor, m, n, b, c, l, u)`.
+    fn build_stall_lp(
+        k: usize,
+        extra: usize,
+    ) -> (
+        Vec<f64>,
+        usize,
+        usize,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+    ) {
+        let nvar = k * k;
+        // rows: k row-sums + (k-1) col-sums (drop the last col-sum → full rank).
+        let m = k + (k - 1);
+        let ncol = nvar + extra;
+        let mut a = vec![0.0f64; m * ncol];
+        for i in 0..k {
+            for j in 0..k {
+                a[i * ncol + (i * k + j)] = 1.0; // row i sum
+            }
+        }
+        for j in 0..(k - 1) {
+            for i in 0..k {
+                a[(k + j) * ncol + (i * k + j)] = 1.0; // col j sum
+            }
+        }
+        // duplicate columns (copies of existing lift columns) — the rc≈0 bait.
+        for d in 0..extra {
+            let src = d % nvar;
+            for r in 0..m {
+                a[r * ncol + nvar + d] = a[r * ncol + src];
+            }
+        }
+        let b = vec![1.0; m];
+        let c: Vec<f64> = (0..ncol).map(|j| ((j * 13 + 5) % 7) as f64 * 0.1).collect();
+        let l = vec![0.0; ncol];
+        let u = vec![1.0; ncol];
+        (a, m, ncol, b, c, l, u)
+    }
+
+    #[test]
+    fn full_basis_on_slackless_equality_rows_p1_0() {
+        // P1.0 regression: a FULL-RANK slackless equality system with the
+        // redundant-column structure of the lifted convex relaxations. It made
+        // solve_lp emit a deficient, mislabelled basis (rsyn0805m: 534/537
+        // basics → warm-start cold-fell-back at 90/s instead of ~26k). Phase-1
+        // parks zero-valued basic artificials the strict reduced-cost rule never
+        // expels; the finalization pass must drive them out via degenerate
+        // pivots so the emitted basis is full-rank in real columns and
+        // warm-start acceptable. The `4×4` assignment polytope (last col-sum
+        // dropped → rank 7 over 16 vars) reproduces it minimally: cold basis 5/7.
+        let (a, m, n, b, c, l, u) = build_stall_lp(4, 0);
+
+        let off = solve_with_p1_expel(&a, m, n, &b, &c, &l, &u, false);
+        let on = solve_with_p1_expel(&a, m, n, &b, &c, &l, &u, true);
+
+        // Both find the same (correct) optimum — the pass is bound-neutral.
+        assert_eq!(on.status, LpStatus::Optimal);
+        assert_eq!(off.status, LpStatus::Optimal);
+        assert!((off.obj - on.obj).abs() < 1e-9, "pass changed the optimum");
+        assert!(
+            on.x.iter().zip(&off.x).all(|(a, b)| (a - b).abs() < 1e-9),
+            "pass changed the solution point"
+        );
+
+        // Fails-before: WITHOUT the pass the basis is deficient (< m real cols).
+        let off_full =
+            off.basis.basic_vars.len() == m && off.basis.basic_vars.iter().all(|&j| j < n);
+        assert!(
+            !off_full,
+            "test no longer reproduces the P1.0 deficiency (off basis full: {:?}) — re-point it",
+            off.basis.basic_vars
+        );
+
+        // Passes-after: WITH the pass, a full real basis (warm-start-acceptable).
+        assert_eq!(
+            on.basis.basic_vars.len(),
+            m,
+            "basis still deficient: {:?}",
+            on.basis.basic_vars
+        );
+        assert!(
+            on.basis.basic_vars.iter().all(|&j| j < n),
+            "basis holds a non-real (artificial) column: {:?}",
+            on.basis.basic_vars
+        );
+        // Dual-consistent: the row duals reproduce the objective via the safe
+        // bound (a mislabelled basis would not).
+        assert!(!on.dual.is_empty());
+        let g = safe_bound(&on.dual, &c, &a, m, n, &b, &l, &u);
+        assert!(
+            (g - on.obj).abs() < 1e-6,
+            "safe bound {g} != obj {}",
+            on.obj
         );
     }
 

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -41,7 +41,10 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_csc_py, m)?)?;
-    m.add_function(wrap_pyfunction!(spatial_bindings::solve_spatial_tree_py, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        spatial_bindings::solve_spatial_tree_py,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_batch_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_csc_py, m)?)?;

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -313,6 +313,7 @@ pub fn solve_lp_py<'py>(
         // cold fallback on trip; bound-neutral). Cold-only entry points ignore it.
         warm_stall_guard: true,
         warm_stall_cap_override: None,
+        expel_zero_artificials: false,
     };
     let sol = simplex_solve_lp(&lp, b.as_slice()?, &opts);
     let status = match sol.status {
@@ -443,6 +444,7 @@ pub fn solve_lp_warm_py<'py>(
         // cold fallback on trip; bound-neutral). Cold-only entry points ignore it.
         warm_stall_guard: true,
         warm_stall_cap_override: None,
+        expel_zero_artificials: false,
     };
     let b_slice = b.as_slice()?;
 
@@ -527,6 +529,7 @@ pub fn solve_lp_warm_csc_py<'py>(
         // cold fallback on trip; bound-neutral). Cold-only entry points ignore it.
         warm_stall_guard: true,
         warm_stall_cap_override: None,
+        expel_zero_artificials: false,
     };
     let start = match (start_col_status, start_basic_vars) {
         (Some(cs), Some(bv)) => build_extended_basis(cs.as_slice()?, bv.as_slice()?, n, m),
@@ -630,6 +633,7 @@ pub fn solve_lp_batch_py<'py>(
         // cold fallback on trip; bound-neutral). Cold-only entry points ignore it.
         warm_stall_guard: true,
         warm_stall_cap_override: None,
+        expel_zero_artificials: false,
     };
     // The solve touches no Python objects, so release the GIL to let the core's
     // rayon workers run the batch concurrently without contending on it.
@@ -1004,6 +1008,7 @@ fn run_milp_hooked<'py>(
             // F2: warm dual-simplex stall guard (size-derived cap → cold fallback).
             warm_stall_guard: true,
             warm_stall_cap_override: None,
+            expel_zero_artificials: false,
         },
     };
     // Wrap an attached Python debugger (if any) as a core hook. It is created

--- a/crates/discopt-python/src/spatial_bindings.rs
+++ b/crates/discopt-python/src/spatial_bindings.rs
@@ -126,9 +126,16 @@ pub fn solve_spatial_tree_py<'py>(
     let tcoeff = term_coeff.as_slice()?;
     let tcst = term_cst.as_slice()?;
     let nt = kind.len();
-    if [ti.len(), tj.len(), tout.len(), tp.len(), tcoeff.len(), tcst.len()]
-        .iter()
-        .any(|&l| l != nt)
+    if [
+        ti.len(),
+        tj.len(),
+        tout.len(),
+        tp.len(),
+        tcoeff.len(),
+        tcst.len(),
+    ]
+    .iter()
+    .any(|&l| l != nt)
     {
         return Err(PyValueError::new_err(
             "all term_* arrays must have the same length",
@@ -216,7 +223,11 @@ pub fn solve_spatial_tree_py<'py>(
         fixed_rows,
         terms,
         blf_terms,
-        obbt_candidates: obbt_candidates.as_slice()?.iter().map(|&v| v as usize).collect(),
+        obbt_candidates: obbt_candidates
+            .as_slice()?
+            .iter()
+            .map(|&v| v as usize)
+            .collect(),
     };
 
     let cfg = SpatialTreeConfig {

--- a/docs/dev/scip-parity-kernel-plan.md
+++ b/docs/dev/scip-parity-kernel-plan.md
@@ -118,17 +118,47 @@ node LPs in E0LPBIN1) + `crates/discopt-core/src/bin/e0_warm_bench.rs`
    2.57). Every warm entry (`solve_lp_warm`, `PreparedDual::prepare`) silently
    rejects it and cold-falls-back at ~11 ms/child → 90/s. Bench-side
    slack-completion and crossover/`recover_basis` cannot repair the mislabeled
-   statuses; the fix belongs in `solve_lp`'s basis finalization. NOTE: this
-   defect plausibly degrades today's production OBBT/probe warm paths on the
-   same LP class — verify when fixing.
+   statuses; the fix belongs in `solve_lp`'s basis finalization.
+
+   **RESOLVED (2026-07-19), gated default-OFF.** Root cause: phase-1 parks
+   *zero-valued* (degenerate) basic artificials in slackless equality rows;
+   `drive_out_basic_artificials` only expels artificials with value > 1e-9, so
+   they survive phase 2, and the emission substitution finds no zero-valued
+   singleton slack to swap (equality rows have none) → short + mislabeled basis.
+   Fix: `expel_zero_basic_artificials` finalization pass drives them out via
+   t=0 degenerate pivots on any nonbasic real column with a nonzero tableau
+   entry in the row (a pure representation change: x/obj/duals invariant on the
+   vertex). Measured: rsyn0805m warm 90 → 392/s per-call, **kernel pattern
+   1,419/s** (> the 500/s gate); nvs09 25.5k/s and tanksize 1.2k/s unchanged.
+
+   *Bound-changing, so gated* (the honest measurement): with the pass always-on
+   it also fills rows an inequality LP left short (nonzero slack → no zero-valued
+   singleton), so warm-start engages where it previously cold-fell-back and the
+   tree-exploration *sequence* changes — `node_count` drifts on the
+   **deterministic** instances `nvs02` (337→339) and `nvs15` (7→11). (The larger
+   apparent drift on time-limited instances — contvar/nvs05/tanksize/tls2/tspn* —
+   is wall-budget *timing noise*, not the change: `contvar.bound` differs even
+   between two identical-code runs, so those are excluded from the neutrality
+   comparison, which is only meaningful on instances that solve to completion.)
+   Per CLAUDE.md §5 a `node_count`-changing change is bound-changing, so it ships
+   behind `SimplexOptions::expel_zero_artificials` (**default false**; every
+   Python binding constructs it false). **Proven neutral OFF:** node_count +
+   objective + status + cert byte-identical to the pre-change baseline on all 46
+   deterministic (optimal/infeasible) vendored instances. The branch-and-cut
+   kernel opts in (it *needs* warm-start to succeed); default-on graduation waits
+   on the §5 panel. Fails-before/
+   passes-after regression test `full_basis_on_slackless_equality_rows_p1_0`
+   (cold basis 5/7 → fixed 7/7, same optimum). (branch
+   `fix/p1.0-basis-finalization`.)
 3. **P1.0b: syn40m-class numerical robustness.** The 832×940 big-M standard
    form defeats the cold simplex (`Numerical`, 336 ms). Hardening item;
    in-process HiGHS as the kernel LP remains the named fallback.
 
-**Kill-criterion disposition:** not tripped as a capability verdict (26k/s on
-the same machinery; rsyn's 90/s is a diagnosed, fixable handoff defect) — but
-the pass is CONDITIONAL: P1 loop code may not start until P1.0 lands and
-rsyn0805m measures ≥ 500/s on this bench.
+**Kill-criterion disposition:** PASSED. P1.0 has landed (rsyn0805m kernel
+pattern 1,399/s ≥ 500/s gate), so the E0 conditional pass is now unconditional
+on the node-rate axis. P1.0b (syn40m numerical robustness) remains open as a
+hardening item but does not block P1 (the in-process-HiGHS fallback covers it).
+E1 is the next entry experiment.
 
 **E1 (days) — template-refresh parity.** For the envelope families covering
 the certifying panel: analyze-phase templates + Rust refresh must reproduce


### PR DESCRIPTION
## Summary

Resolves **P1.0**, the basis-finalization defect E0 (#792) surfaced: `solve_lp` returns a **deficient, mislabeled basis** on the convex OA LP class (rsyn0805m: 534 basics for m=537, + 2 dual-infeasible statuses), so every warm-start entry point (`solve_lp_warm`, `PreparedDual::prepare`) silently rejects it and cold-falls-back at ~11 ms/child = **90 solves/s** instead of the **~1,400/s** the full basis unlocks. This was the P1.0 gate blocking the branch-and-cut kernel (`docs/dev/scip-parity-kernel-plan.md`).

## Root cause & fix

Phase-1 parks **zero-valued (degenerate) basic artificials** in slackless equality rows. `drive_out_basic_artificials` only expels artificials with value > 1e-9; the degenerate ones survive phase 2, and the emission substitution finds no zero-valued singleton slack to swap (equality rows have none) → short + mislabeled basis. New `expel_zero_basic_artificials` finalization pass drives them out via **t=0 degenerate pivots** on any nonbasic real column with a nonzero tableau entry in the row — x_B, obj, and the vertex are invariant (pure basis-representation change). A genuinely redundant row (no such column) keeps its artificial, basis stays short, exactly as before.

## Bound-changing → gated default-OFF (the honest disposition)

Always-on, the pass also fills rows an *inequality* LP left short (nonzero slack → no zero-valued singleton), so warm-start engages where it previously cold-fell-back and the tree-exploration *sequence* shifts — `node_count` drifts on the **deterministic** instances `nvs02` (337→339) and `nvs15` (7→11). (Larger apparent drift on time-limited instances is wall-budget **timing noise** — `contvar.bound` differs even between two identical-code runs — so neutrality is judged only on instances that solve to completion.) Per CLAUDE.md §5 a `node_count`-changing change is bound-changing, so it ships behind **`SimplexOptions::expel_zero_artificials` (default false**; every Python binding constructs it false). The kernel opts in; default-on graduation waits on the §5 panel.

## Verification

- **rsyn0805m** (E0 bench, opt-in ON): warm 90→392/s per-call, **kernel pattern (`PreparedDual`) 1,419/s** > the 500/s E0 gate; nvs09 25.5k/s and tanksize 1.2k/s **unchanged**.
- **Default-path byte-neutrality (flag OFF):** node_count + objective + status + cert **byte-identical** to the pre-change baseline on all **46 deterministic** (optimal/infeasible) vendored instances; the 20 time-limited instances are excluded (wall-budget nondeterministic).
- **Regression test** `full_basis_on_slackless_equality_rows_p1_0`: a `4×4` slackless-equality LP, fails-before (cold basis 5/7) / passes-after (7/7), same optimum, dual-consistent safe bound. Uses a `#[cfg(test)]` force-toggle so one test proves both directions.
- `cargo test -p discopt-core`: **517 passed**. `cargo fmt` / `clippy -D warnings` clean (lib). `test_claim_baseline_neutral` (relaxation fingerprint) byte-identical.

## Notes

- First commit is an isolated `style:` commit — my local rustfmt 1.9.0 reflows several #791 files (landed formatted-per-a-different-rustfmt); the whole-crate pre-commit fmt hook forces it. Pure formatting, no logic change, CI doesn't gate cargo fmt.
- Unblocks **P1** (the convex-family kernel loop). **P1.0b** (syn40m 832×940 big-M numerical robustness) remains open; in-process HiGHS is the plan's named fallback for the kernel LP.

Contributes to #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
