### PR TITLE
fix(#789): native spatial kernel — feature-safe routing + final-incumbent verification

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -487,6 +487,56 @@ def _native_spatial_kernel_enabled() -> bool:
     )
 
 
+def _native_kernel_feature_safe(
+    *,
+    mccormick_bounds,
+    initial_point,
+    lazy_constraints,
+    incumbent_callback,
+    node_callback,
+    kwargs,
+) -> bool:
+    """Whether the native spatial kernel may take over this solve (#789).
+
+    The kernel runs the ENTIRE spatial B&B inside ``discopt-core`` and so does
+    not exercise the Python-engine machinery layered on the interpreter loop:
+    node/incumbent/iteration callbacks, lazy-constraint injection, the solution
+    pool, warm-start incumbents, non-default McCormick bound modes, and any
+    per-solve ``tuning`` whose stats/behaviour a caller inspects. Those are real
+    contracts (encoded by the smoke suite), so when a solve REQUESTS one, we
+    decline here and route it to the trusted Python engine, taking the native
+    path only when the solve is feature-safe. This is the #789 "route
+    unsupported models to the Python engine" resolution — no test is weakened,
+    and the fast native path is still taken for the plain certified-optimal
+    solves it was graduated on (tanksize et al.).
+
+    Declining is always sound: it only ever *widens* which solves use the
+    already-trusted default path.
+    """
+    if incumbent_callback is not None or node_callback is not None:
+        return False
+    if kwargs.get("iteration_callback") is not None:
+        return False
+    if lazy_constraints:
+        return False
+    if initial_point is not None:
+        return False
+    # A non-default McCormick bound mode changes the relaxation the caller asked
+    # for; the kernel always builds its own McCormick relaxation, so honour the
+    # request by routing to the Python engine (e.g. ``mccormick_bounds="none"``).
+    if mccormick_bounds is not None and str(mccormick_bounds) != "auto":
+        return False
+    # Solution-pool collection is a Python-engine feature the kernel does not fill.
+    if kwargs.get("solution_pool") is not None or kwargs.get("solution_pool_capacity"):
+        return False
+    # An explicit per-solve tuning object may enable/disable levers whose
+    # solver_stats a caller inspects (e.g. cut-inherit pool stats); the kernel
+    # emits none of those, so route explicit-tuning solves to the Python engine.
+    if kwargs.get("tuning") is not None:
+        return False
+    return True
+
+
 def _root_lp_probe_tight_enabled() -> bool:
     """Whether the #282 tightened-box root LP probe is on (**GRADUATED default-ON**).
 
@@ -867,6 +917,40 @@ def _try_native_spatial_kernel(
         x_flat = np.asarray(seed_point, dtype=np.float64)[:n_vars]
     else:
         return None  # no usable incumbent point -> Python path (never fabricate one)
+
+    # #789: rigorously verify the FINAL reported incumbent against the ORIGINAL
+    # model before returning it as a certified optimum. The kernel solves a
+    # McCormick relaxation with its own integrality handling; on some models
+    # (e.g. a bilinear coupled to a binary in a way the kernel's rounding does
+    # not reproduce exactly) its tree incumbent is infeasible in the original —
+    # a false primal the #779 final-incumbent guard would catch and withhold,
+    # turning a solvable model into a null result. Verifying here instead means
+    # the kernel *declines* such a model (returns None), so the trusted Python
+    # engine solves it and reports the true optimum. Sound and conservative:
+    # declining only ever widens use of the already-trusted default path, and
+    # the kernel is still taken on every model whose incumbent verifies (the
+    # tanksize-class it was graduated on). ``x_flat`` is original-variable order
+    # (``n_vars`` slots) — the same layout ``_native_kernel_verify_point`` reads.
+    _ok, _model_obj = _native_kernel_verify_point(model, x_flat[:n_orig])
+    if not _ok:
+        logger.debug(
+            "native spatial kernel: final incumbent failed original-model "
+            "verification (obj=%.6g) — routing to the Python engine (#789)",
+            obj_val,
+        )
+        return None
+    # Prefer the independently-recomputed true objective (exact model units) over
+    # the kernel's mapped relaxation reading when they agree within tolerance; a
+    # gross disagreement is itself a decline signal.
+    if _model_obj is not None and abs(_model_obj - obj_val) > 1e-4 * (1.0 + abs(obj_val)):
+        logger.debug(
+            "native spatial kernel: reported obj %.6g disagrees with verified "
+            "obj %.6g — routing to the Python engine (#789)",
+            obj_val,
+            _model_obj,
+        )
+        return None
+
     x_dict = _unpack_solution(model, x_flat)
     wall_time = time.perf_counter() - t_start
     gap_val = abs(obj_val - bound_val) / (abs(obj_val) + 1e-10)
@@ -6579,9 +6663,22 @@ def solve_model(
     # returns None with no import/side effect, so the default path below is byte-for-byte
     # unchanged; when ON it only takes over on a fully-certified native solve, else falls
     # through to the trusted Python search.
-    _native_result: Optional[SolveResult] = _try_native_spatial_kernel(
-        model, lb, ub, n_vars, gap_tolerance, max_nodes, t_start, rust_time, jax_time
-    )
+    # #789: only take the native path when the solve is feature-safe — it does
+    # not exercise the Python-engine contracts (callbacks, lazy constraints,
+    # solution pool, warm-start, non-default McCormick modes, explicit tuning),
+    # so a solve requesting any of those is routed to the trusted Python engine.
+    _native_result: Optional[SolveResult] = None
+    if _native_kernel_feature_safe(
+        mccormick_bounds=mccormick_bounds,
+        initial_point=initial_point,
+        lazy_constraints=lazy_constraints,
+        incumbent_callback=incumbent_callback,
+        node_callback=node_callback,
+        kwargs=kwargs,
+    ):
+        _native_result = _try_native_spatial_kernel(
+            model, lb, ub, n_vars, gap_tolerance, max_nodes, t_start, rust_time, jax_time
+        )
     if _native_result is not None:
         return _native_result
 

--- a/python/tests/test_spatial_native_kernel.py
+++ b/python/tests/test_spatial_native_kernel.py
@@ -317,3 +317,82 @@ def test_unbounded_relaxation_declines():
 
     spec = build_spatial_kernel_spec(from_nl(nl))
     assert spec is None
+
+
+# ── #789: native-kernel feature-safety routing + final-incumbent verification ──
+
+
+def _bilinear_binary_minlp():
+    """Nonconvex bilinear MINLP with a binary (the model on which the kernel's
+    tree incumbent is a false primal — the #789 verification case)."""
+    m = Model("bb_mi")
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=4.0)
+    b = m.binary("b")
+    m.subject_to(x * y >= 1.0)
+    m.subject_to(x + y <= 4.0 + b)
+    m.minimize(x + y + 2.0 * b)
+    return m
+
+
+def _with_kernel_on(monkeypatch):
+    monkeypatch.setenv("DISCOPT_NATIVE_SPATIAL_KERNEL", "1")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"incumbent_callback": (lambda ctx, model, sol: None)},
+        {"node_callback": (lambda ctx, model: None)},
+        {"lazy_constraints": (lambda ctx, model, sol: [])},
+        {"mccormick_bounds": "none"},
+        {"use_learned_relaxations": True},
+    ],
+)
+def test_kernel_feature_safe_declines_return_correct_optimum(monkeypatch, kwargs):
+    """#789: with the kernel ON, a solve requesting a Python-engine feature the
+    kernel does not honour must route to the Python engine and still certify the
+    true optimum (obj 2.0) — never a withheld/None result."""
+    _with_kernel_on(monkeypatch)
+    m = _bilinear_binary_minlp()
+    res = m.solve(time_limit=120.0, **kwargs)
+    assert res.status in ("optimal", "feasible"), res.status
+    assert res.objective == pytest.approx(2.0, abs=1e-4), res.objective
+
+
+def test_kernel_feature_safe_predicate_units():
+    """The predicate declines each unsupported-feature request and accepts a
+    plain solve."""
+    from discopt.solver import _native_kernel_feature_safe as safe
+
+    base = dict(
+        mccormick_bounds="auto",
+        initial_point=None,
+        lazy_constraints=None,
+        incumbent_callback=None,
+        node_callback=None,
+        kwargs={},
+    )
+    assert safe(**base) is True
+    assert safe(**{**base, "incumbent_callback": lambda *a: None}) is False
+    assert safe(**{**base, "node_callback": lambda *a: None}) is False
+    assert safe(**{**base, "lazy_constraints": lambda *a: []}) is False
+    assert safe(**{**base, "initial_point": np.zeros(3)}) is False
+    assert safe(**{**base, "mccormick_bounds": "none"}) is False
+    assert safe(**{**base, "kwargs": {"iteration_callback": lambda *a: None}}) is False
+    assert safe(**{**base, "kwargs": {"solution_pool": []}}) is False
+    assert safe(**{**base, "kwargs": {"tuning": object()}}) is False
+
+
+def test_kernel_verifies_final_incumbent_and_declines_false_primal(monkeypatch):
+    """#789: on a covered model where the kernel's tree incumbent is INFEASIBLE
+    in the original (a false primal), the kernel must verify its own final
+    incumbent and decline (route to the Python engine), so the reported result
+    is the true optimum — not the #779-withheld None. A plain (feature-safe)
+    solve exercises the verification path directly."""
+    _with_kernel_on(monkeypatch)
+    m = _bilinear_binary_minlp()
+    res = m.solve(time_limit=120.0)
+    assert res.objective is not None, "withheld/None: false primal escaped kernel verification"
+    assert res.objective == pytest.approx(2.0, abs=1e-4), res.objective
+    assert not getattr(res, "incumbent_verification_failed", False)


### PR DESCRIPTION
## Summary

The native Rust spatial kernel (#764/#791) short-circuits the Python B&B engine, so with `DISCOPT_NATIVE_SPATIAL_KERNEL` forced ON it failed **20 of the `-m smoke` tests** — the machinery the kernel bypasses (callbacks, RENS/SubNLP, pools, warm-start, non-default McCormick modes, lazy constraints, deadline, batching). Per CLAUDE.md the gate may not be greened by editing those tests; they encode real contracts. This makes the **driver honor them** — the #789 "route unsupported models to the Python engine" resolution.

## Two complementary guards (both in `python/discopt/solver.py`)

1. **Feature-safety predicate** (`_native_kernel_feature_safe`) gating the hand-off: decline (→ Python engine) when the solve requests a contract the kernel doesn't reproduce — node/incumbent/iteration callbacks, lazy constraints, warm-start `initial_point`, non-default `mccormick_bounds` (e.g. `"none"`), solution pool, or an explicit per-solve `tuning`. **Cleared 9/20.**

2. **Final-incumbent verification** (in `_try_native_spatial_kernel`): before returning `"optimal"`, rigorously verify the kernel's **own final incumbent** against the **original** model (the existing `_native_kernel_verify_point`) and decline if it's infeasible or its objective disagrees. On some covered models (a bilinear coupled to a binary the kernel's rounding doesn't reproduce exactly) the tree incumbent was a **false primal** — caught only by the #779 `Model.solve` guard, which withheld it and turned a *solvable* model into a null result. Verifying at the kernel boundary makes it **decline** those (→ Python engine → true optimum). **Cleared the remaining 11** (rens/subnlp/ipopt-node/batched/learned/lp-spatial/deadline/abs/debug).

Both guards only ever **widen** use of the already-trusted default path — sound and conservative. The kernel is still taken on every feature-safe model whose incumbent verifies (the tanksize class it graduated on).

## Verification

- `pytest -m smoke`, **flag ON**: **831 passed, 0 failed** (was 807 / 20 failed) — the #789 acceptance gate.
- `pytest -m smoke`, **flag OFF (default)**: 831 passed — default path untouched (guards inert when off / feature-safe).
- New regression tests (`test_spatial_native_kernel.py`): **20 passed** — per-feature decline routing, predicate units, and the false-primal verification decline.
- `pytest -m slow test_adversarial_recent_fixes.py`: 9 passed; `hda` passes standalone (47 s) — its full-suite failure was time-limited-instance flake, not this change (entirely flag-ON-gated).
- `ruff check` / `format` clean. **No Rust touched.**

## Disposition

Second prerequisite for the #764 default-ON graduation of the native kernel (first being the graduation panel). With smoke green under the flag, the native kernel can be considered for default-ON in a follow-up.

Contributes to #789 / #764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
