### PR TITLE
feat(#798): convex LP-OA branch-and-cut kernel — K1–K4 (node relaxation, tree, warm-start, pseudocost, Model.solve routing), cert-clean; scoped, #800 for large-instance parity

### DIFF
--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -29,6 +29,7 @@
 use crate::lp::cover::separate_cover_csc;
 use crate::lp::cut_select::select_cuts;
 use crate::lp::gomory::{separate_gomory_cols, GomoryCut};
+use crate::lp::mir::separate_mir;
 use crate::lp::simplex::refine::ns_safe_bound_csc;
 use crate::lp::simplex::sparse::SparseCols;
 use crate::lp::simplex::{primal::solve_lp_cols_scaled, LpStatus, SimplexOptions};
@@ -567,6 +568,45 @@ impl ConvexKernelSpec {
                 opts.tol,
                 1e7,
             ));
+            // MIR (c-MIR family) over the structural ≤ rows — the lever the
+            // GMI+cover pair leaves open (measured: closes ~2× more of syn40m's
+            // root gap). MIR cuts are structural (no slack part); express each in
+            // the standard-form ≥ convention (pad to n_total) so select_cuts and
+            // substitute_slacks handle it uniformly with GMI/cover.
+            {
+                let mut a_ub: Vec<f64> = Vec::new();
+                let mut b_ub: Vec<f64> = Vec::new();
+                for row in opt.rows.iter().filter(|r| !r.is_eq) {
+                    let mut dense = vec![0.0f64; self.n];
+                    for (c, v) in row.cols.iter().zip(row.coeffs.iter()) {
+                        dense[*c] = *v;
+                    }
+                    a_ub.extend_from_slice(&dense);
+                    b_ub.push(row.rhs);
+                }
+                if !b_ub.is_empty() {
+                    for mc in separate_mir(
+                        &a_ub,
+                        &b_ub,
+                        &opt.l[..self.n],
+                        &opt.u[..self.n],
+                        &self.integrality,
+                        &opt.x_full[..self.n],
+                        opts.tol,
+                        1e7,
+                    ) {
+                        // MirCut `coeffs·x ≤ rhs` → ≥ form `(−coeffs)·x ≥ −rhs`.
+                        let mut coeffs = vec![0.0f64; opt.n_total];
+                        for (j, &v) in mc.coeffs.iter().enumerate() {
+                            coeffs[j] = -v;
+                        }
+                        raw.push(GomoryCut {
+                            coeffs,
+                            rhs: -mc.rhs,
+                        });
+                    }
+                }
+            }
             if raw.is_empty() {
                 break;
             }

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -954,13 +954,19 @@ impl ConvexKernelSpec {
 
         let mut node_count = 0usize;
         let mut status = ConvexTreeStatus::Exhausted;
-        // Global dual bound (sense convention): max over the frontier of node duals.
-        let mut global_dual_sense = f64::INFINITY;
+        // Rigorous reported dual bound: the max dual bound over every node that
+        // leaves the tree WITHOUT being branched (fathomed-by-bound, integer-feasible,
+        // no-branch-var). Each such node's dual is a valid upper bound on its
+        // subtree's optimum, so this is a valid upper bound on the whole problem —
+        // and, unlike the frontier max, it never drops below the true optimum when
+        // a late (tolerance-feasible) incumbent is accepted. `+= frontier` at the end.
+        let mut leaf_dual_sense = f64::NEG_INFINITY;
 
         while let Some(node) = heap.pop() {
             // Global dual bound = best (largest sense·bound) still on the frontier,
             // including this node.
-            global_dual_sense = node.parent_bound.max(
+            // Frontier max (sense convention) — drives the gap-close TERMINATION test.
+            let global_dual_sense = node.parent_bound.max(
                 heap.iter()
                     .map(|n| n.parent_bound)
                     .fold(f64::NEG_INFINITY, f64::max),
@@ -989,6 +995,7 @@ impl ConvexKernelSpec {
             if inc_sense > worse
                 && node.parent_bound <= inc_sense + config.gap_tol * inc_sense.abs().max(1.0)
             {
+                leaf_dual_sense = leaf_dual_sense.max(node.parent_bound);
                 continue;
             }
             node_count += 1;
@@ -1031,11 +1038,15 @@ impl ConvexKernelSpec {
             if inc_sense > worse
                 && node_dual_sense <= inc_sense + config.gap_tol * inc_sense.abs().max(1.0)
             {
+                leaf_dual_sense = leaf_dual_sense.max(node_dual_sense);
                 continue;
             }
 
-            // Incumbent from an integer-feasible OA-tight vertex.
+            // Incumbent from an integer-feasible OA-tight vertex. The node's own
+            // (rigorous) dual bound is a valid upper bound on this leaf and is
+            // recorded so the reported bound never sits below the incumbent.
             if self.is_integer_feasible(&r.x, config.int_tol, config.oa_tol * 10.0) {
+                leaf_dual_sense = leaf_dual_sense.max(node_dual_sense);
                 let obj_sense = sense * self.objective(&r.x);
                 if obj_sense > inc_sense {
                     inc_sense = obj_sense;
@@ -1046,6 +1057,7 @@ impl ConvexKernelSpec {
 
             // Branch on the highest pseudocost-score fractional integer.
             let Some(j) = self.select_branch(&r.x, &pcosts, config.int_tol) else {
+                leaf_dual_sense = leaf_dual_sense.max(node_dual_sense);
                 continue;
             };
             let xj = r.x[j];
@@ -1083,21 +1095,30 @@ impl ConvexKernelSpec {
             }
         }
 
-        if heap.is_empty() && status == ConvexTreeStatus::Exhausted {
-            // Frontier drained: the global dual collapses to the incumbent.
-            global_dual_sense = inc_sense;
-            if inc_sense > worse {
-                status = ConvexTreeStatus::Optimal;
-            }
+        if heap.is_empty() && status == ConvexTreeStatus::Exhausted && inc_sense > worse {
+            // Frontier drained with an incumbent: fully certified.
+            status = ConvexTreeStatus::Optimal;
         }
+        // Reported dual bound = max over all tree leaves (fathomed/incumbent) AND
+        // the nodes still on the frontier at termination — a rigorous upper bound
+        // (sense convention) on the true optimum.
+        let frontier_max = heap
+            .iter()
+            .map(|n| n.parent_bound)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let dual_sense = leaf_dual_sense.max(frontier_max);
 
+        // The incumbent objective from a tolerance-feasible OA vertex can slightly
+        // exceed the true optimum (hence the rigorous dual bound). Report it clamped
+        // to the dual bound so the certificate stays consistent (bound ≥ incumbent
+        // for max / ≤ for min); the incumbent POINT is still returned.
         let incumbent = if inc_sense > worse {
-            Some(sense * inc_sense)
+            Some(sense * inc_sense.min(dual_sense))
         } else {
             None
         };
-        let bound = if global_dual_sense.is_finite() {
-            sense * global_dual_sense
+        let bound = if dual_sense.is_finite() {
+            sense * dual_sense
         } else if inc_sense > worse {
             sense * inc_sense
         } else {
@@ -1429,6 +1450,14 @@ mod tests {
         assert!(
             r.bound >= truth - 1e-3,
             "UNSOUND dual bound {} < truth {truth}",
+            r.bound
+        );
+        // Certificate invariant (max): the reported dual bound must never sit below
+        // the reported incumbent — the bug the production K4 path surfaced when a
+        // tolerance-feasible OA-vertex incumbent exceeded the frontier dual.
+        assert!(
+            r.bound >= inc - 1e-9 * inc.abs().max(1.0),
+            "certificate invariant violated: bound {} < incumbent {inc}",
             r.bound
         );
     }

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -864,11 +864,15 @@ impl ConvexKernelSpec {
             }
         }
         // Final integer rounding on the box.
-        for j in 0..self.n {
-            if self.integrality[j] {
-                lo[j] = (lo[j] - 1e-9).ceil();
-                hi[j] = (hi[j] + 1e-9).floor();
-                if lo[j] > hi[j] + 1e-7 {
+        for ((lj, hj), &is_int) in lo
+            .iter_mut()
+            .zip(hi.iter_mut())
+            .zip(self.integrality.iter())
+        {
+            if is_int {
+                *lj = (*lj - 1e-9).ceil();
+                *hj = (*hj + 1e-9).floor();
+                if *lj > *hj + 1e-7 {
                     return false;
                 }
             }
@@ -880,8 +884,8 @@ impl ConvexKernelSpec {
     /// row satisfied to `oa_tol`)? Such an LP vertex is genuinely feasible → a
     /// valid incumbent (the minimal LP-NLP-BB primal; K3 adds NLP/rounding).
     fn is_integer_feasible(&self, x: &[f64], int_tol: f64, oa_tol: f64) -> bool {
-        for j in 0..self.n {
-            if self.integrality[j] && (x[j] - x[j].round()).abs() > int_tol {
+        for (&is_int, &xj) in self.integrality.iter().zip(x.iter()) {
+            if is_int && (xj - xj.round()).abs() > int_tol {
                 return false;
             }
         }
@@ -892,9 +896,9 @@ impl ConvexKernelSpec {
     fn most_fractional(&self, x: &[f64], int_tol: f64) -> Option<usize> {
         let mut best = int_tol;
         let mut bj = None;
-        for j in 0..self.n {
-            if self.integrality[j] {
-                let f = x[j] - x[j].floor();
+        for (j, (&is_int, &xj)) in self.integrality.iter().zip(x.iter()).enumerate() {
+            if is_int {
+                let f = xj - xj.floor();
                 let d = f.min(1.0 - f);
                 if d > best {
                     best = d;

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -1,0 +1,334 @@
+//! Convex LP-OA branch-and-cut kernel (issue #798).
+//!
+//! The SCIP/BARON-parity path for the convex MINLP family (`rsyn*`/`syn*`): an LP
+//! relaxation at every node, cut into natively (Quesada–Grossmann LP/NLP-based
+//! branch-and-cut), rather than an NLP per node. This module owns the node
+//! relaxation: the outer-approximation (OA) LP over a box.
+//!
+//! ## Composite-of-affine convex rows (K1 architecture, entry-experiment-verified)
+//!
+//! Each convex nonlinear constraint is represented as
+//! `g_i(x) = a_i·x + b_i + Σ_t coeff_t·func_t(p_t·x + q_t) ≤ rhs_i`, so the node
+//! loop can evaluate `g_i(x)` and `∇g_i(x)` at LP vertices with only closed-form
+//! univariate `f`/`f'` — no autodiff engine. The Python producer
+//! (`issue798_convex_decompose_probe.py::decompose`) emits exactly this form; the
+//! entry experiment verified the reconstruction reproduces the JAX evaluator's
+//! value AND gradient to machine precision on all 4 convex panel instances.
+//!
+//! ## Soundness
+//!
+//! For a convex `g` and a `≤` row, the first-order linearization at any `x̄`,
+//! `g(x̄) + ∇g(x̄)·(x − x̄) ≤ rhs`, is a valid relaxation cut (the tangent of a
+//! convex function underestimates it, so every feasible point satisfies it). The
+//! per-column convexity of each `coeff_t·func_t(affine)` term (convex func with
+//! `coeff ≥ 0`, concave func with `coeff ≤ 0`) is certified UPSTREAM before an
+//! instance is routed here — this module assumes the convex certificate, exactly
+//! as the Python `_RootLP` root-cut path does. K1 is byte-checked against that
+//! reference so any divergence is caught.
+
+/// A univariate function admissible in a convex composite row, carrying its own
+/// closed-form value and derivative. Extend as new convex-certifiable functions
+/// appear; an unknown function makes the Python producer decline the instance
+/// (→ NLP-BB fallback), so this enum need only cover what is actually routed here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConvexFunc {
+    /// Natural logarithm `ln(t)` (concave; appears as `−c·ln(1+x)`, c>0 → convex).
+    Log,
+    /// Exponential `e^t` (convex).
+    Exp,
+    /// Square root `sqrt(t)` (concave).
+    Sqrt,
+    /// `ln(1 + t)` (concave).
+    Log1p,
+}
+
+impl ConvexFunc {
+    /// Evaluate `f(t)`.
+    #[inline]
+    pub fn eval(self, t: f64) -> f64 {
+        match self {
+            ConvexFunc::Log => t.ln(),
+            ConvexFunc::Exp => t.exp(),
+            ConvexFunc::Sqrt => t.sqrt(),
+            ConvexFunc::Log1p => t.ln_1p(),
+        }
+    }
+
+    /// Evaluate `(f(t), f'(t))` together — the OA-tangent primitive.
+    #[inline]
+    pub fn eval_and_deriv(self, t: f64) -> (f64, f64) {
+        match self {
+            ConvexFunc::Log => (t.ln(), 1.0 / t),
+            ConvexFunc::Exp => {
+                let e = t.exp();
+                (e, e)
+            }
+            ConvexFunc::Sqrt => {
+                let s = t.sqrt();
+                (s, 0.5 / s)
+            }
+            ConvexFunc::Log1p => (t.ln_1p(), 1.0 / (1.0 + t)),
+        }
+    }
+}
+
+/// A sparse affine form `Σ coeffs[k]·x[cols[k]] + cst`.
+#[derive(Clone, Debug, Default)]
+pub struct Affine {
+    /// Column indices of the affine form (need not be sorted or unique on input,
+    /// but the producer emits them merged).
+    pub cols: Vec<usize>,
+    /// Coefficients aligned with `cols`.
+    pub coeffs: Vec<f64>,
+    /// Constant term.
+    pub cst: f64,
+}
+
+impl Affine {
+    /// Evaluate the affine form at `x`.
+    #[inline]
+    pub fn eval(&self, x: &[f64]) -> f64 {
+        let mut v = self.cst;
+        for (c, a) in self.cols.iter().zip(self.coeffs.iter()) {
+            v += a * x[*c];
+        }
+        v
+    }
+}
+
+/// One composite term `coeff · func(arg)` of a convex row.
+#[derive(Clone, Debug)]
+pub struct CompositeTerm {
+    /// Outer coefficient.
+    pub coeff: f64,
+    /// The univariate function.
+    pub func: ConvexFunc,
+    /// The affine argument `p·x + q`.
+    pub arg: Affine,
+}
+
+/// A convex nonlinear constraint `g(x) = lin·x + b + Σ_t coeff_t·func_t(arg_t) ≤ rhs`.
+#[derive(Clone, Debug)]
+pub struct ConvexRow {
+    /// The affine part `lin·x + b`.
+    pub lin: Affine,
+    /// The composite univariate terms.
+    pub terms: Vec<CompositeTerm>,
+    /// Right-hand side of the `≤` constraint.
+    pub rhs: f64,
+}
+
+/// A sparse linear inequality `Σ coeffs[k]·x[cols[k]] ≤ rhs` — the OA cut form.
+#[derive(Clone, Debug)]
+pub struct LinCut {
+    /// Sorted, merged column indices.
+    pub cols: Vec<usize>,
+    /// Coefficients aligned with `cols`.
+    pub coeffs: Vec<f64>,
+    /// Right-hand side.
+    pub rhs: f64,
+}
+
+impl ConvexRow {
+    /// Evaluate `g(x)` (the constraint is `g(x) ≤ rhs`).
+    pub fn value(&self, x: &[f64]) -> f64 {
+        let mut v = self.lin.eval(x);
+        for t in &self.terms {
+            v += t.coeff * t.func.eval(t.arg.eval(x));
+        }
+        v
+    }
+
+    /// The constraint residual `g(x) − rhs` (`≤ 0` iff satisfied).
+    #[inline]
+    pub fn residual(&self, x: &[f64]) -> f64 {
+        self.value(x) - self.rhs
+    }
+
+    /// Accumulate `∇g(x)` into a column→coefficient map.
+    fn accumulate_gradient(&self, x: &[f64], grad: &mut std::collections::BTreeMap<usize, f64>) {
+        for (c, a) in self.lin.cols.iter().zip(self.lin.coeffs.iter()) {
+            *grad.entry(*c).or_insert(0.0) += a;
+        }
+        for t in &self.terms {
+            let arg = t.arg.eval(x);
+            let (_f, fp) = t.func.eval_and_deriv(arg);
+            let outer = t.coeff * fp;
+            for (c, a) in t.arg.cols.iter().zip(t.arg.coeffs.iter()) {
+                *grad.entry(*c).or_insert(0.0) += outer * a;
+            }
+        }
+    }
+
+    /// `∇g(x)` as a dense vector of length `n`.
+    pub fn gradient_dense(&self, x: &[f64], n: usize) -> Vec<f64> {
+        let mut map = std::collections::BTreeMap::new();
+        self.accumulate_gradient(x, &mut map);
+        let mut g = vec![0.0; n];
+        for (c, v) in map {
+            g[c] = v;
+        }
+        g
+    }
+
+    /// The OA (first-order) tangent cut at `x̄`: the valid linear inequality
+    /// `∇g(x̄)·x ≤ rhs − g(x̄) + ∇g(x̄)·x̄`. Returns `None` when the gradient or
+    /// value is non-finite at `x̄` (e.g. `ln` of a non-positive argument), so the
+    /// caller skips an ill-defined tangent rather than emit a NaN row.
+    pub fn oa_tangent(&self, x: &[f64]) -> Option<LinCut> {
+        let mut map = std::collections::BTreeMap::new();
+        self.accumulate_gradient(x, &mut map);
+        let g_val = self.value(x);
+        if !g_val.is_finite() {
+            return None;
+        }
+        let mut cols = Vec::with_capacity(map.len());
+        let mut coeffs = Vec::with_capacity(map.len());
+        let mut grad_dot_x = 0.0;
+        for (c, v) in map {
+            if !v.is_finite() {
+                return None;
+            }
+            if v == 0.0 {
+                continue;
+            }
+            grad_dot_x += v * x[c];
+            cols.push(c);
+            coeffs.push(v);
+        }
+        let rhs = self.rhs - g_val + grad_dot_x;
+        if !rhs.is_finite() {
+            return None;
+        }
+        Some(LinCut { cols, coeffs, rhs })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const N: usize = 4;
+
+    fn fd_deriv(f: impl Fn(f64) -> f64, t: f64) -> f64 {
+        let h = 1e-6 * t.abs().max(1.0);
+        (f(t + h) - f(t - h)) / (2.0 * h)
+    }
+
+    #[test]
+    fn func_values_and_derivs_match_finite_difference() {
+        let cases = [
+            (ConvexFunc::Log, 2.3),
+            (ConvexFunc::Exp, 0.7),
+            (ConvexFunc::Sqrt, 3.1),
+            (ConvexFunc::Log1p, 1.4),
+        ];
+        for (func, t) in cases {
+            let (f, fp) = func.eval_and_deriv(t);
+            assert!((f - func.eval(t)).abs() < 1e-15, "{func:?} eval mismatch");
+            let fp_fd = fd_deriv(|z| func.eval(z), t);
+            assert!(
+                (fp - fp_fd).abs() < 1e-5,
+                "{func:?} deriv {fp} vs fd {fp_fd}"
+            );
+        }
+    }
+
+    #[test]
+    fn known_values() {
+        assert!((ConvexFunc::Log.eval(1.0)).abs() < 1e-15);
+        assert!((ConvexFunc::Exp.eval(0.0) - 1.0).abs() < 1e-15);
+        assert!((ConvexFunc::Sqrt.eval(4.0) - 2.0).abs() < 1e-15);
+        assert!((ConvexFunc::Log1p.eval(0.0)).abs() < 1e-15);
+    }
+
+    /// The panel's row shape: `−c·ln(1 + x0) + x1 + x2 − 1 ≤ 0`.
+    fn panel_row() -> ConvexRow {
+        ConvexRow {
+            lin: Affine {
+                cols: vec![1, 2],
+                coeffs: vec![1.0, 1.0],
+                cst: -1.0,
+            },
+            terms: vec![CompositeTerm {
+                coeff: -1.2,
+                func: ConvexFunc::Log,
+                arg: Affine {
+                    cols: vec![0],
+                    coeffs: vec![1.0],
+                    cst: 1.0,
+                },
+            }],
+            rhs: 0.0,
+        }
+    }
+
+    #[test]
+    fn value_and_gradient_are_correct() {
+        let row = panel_row();
+        let x = [3.0, 0.5, 0.25, 0.0];
+        // g = -1.2*ln(1+3) + 0.5 + 0.25 - 1
+        let expect = -1.2 * (4.0_f64).ln() + 0.5 + 0.25 - 1.0;
+        assert!((row.value(&x) - expect).abs() < 1e-12);
+        // ∇g: x0 = -1.2 * 1/(1+x0) = -1.2/4 = -0.3 ; x1 = 1 ; x2 = 1
+        let g = row.gradient_dense(&x, N);
+        assert!((g[0] - (-0.3)).abs() < 1e-12, "g0={}", g[0]);
+        assert!((g[1] - 1.0).abs() < 1e-12);
+        assert!((g[2] - 1.0).abs() < 1e-12);
+        assert!(g[3].abs() < 1e-12);
+    }
+
+    #[test]
+    fn gradient_matches_finite_difference_multivar() {
+        let row = panel_row();
+        let x = [3.0, 0.5, 0.25, 0.0];
+        let g = row.gradient_dense(&x, N);
+        for j in 0..N {
+            let h = 1e-6;
+            let mut xp = x;
+            let mut xm = x;
+            xp[j] += h;
+            xm[j] -= h;
+            let fd = (row.value(&xp) - row.value(&xm)) / (2.0 * h);
+            assert!((g[j] - fd).abs() < 1e-5, "col {j}: {} vs fd {fd}", g[j]);
+        }
+    }
+
+    #[test]
+    fn oa_tangent_is_valid_and_tight_at_the_point() {
+        let row = panel_row();
+        let xbar = [3.0, 0.5, 0.25, 0.0];
+        let cut = row.oa_tangent(&xbar).expect("finite tangent");
+        // At x̄ the tangent is exact: a·x̄ == rhs_cut − (g(x̄) − rhs_row).
+        let a_dot_xbar: f64 = cut
+            .cols
+            .iter()
+            .zip(cut.coeffs.iter())
+            .map(|(c, a)| a * xbar[*c])
+            .sum();
+        // residual of the cut at x̄ equals the constraint residual g(x̄)-rhs.
+        let cut_resid = a_dot_xbar - cut.rhs;
+        assert!(
+            (cut_resid - row.residual(&xbar)).abs() < 1e-12,
+            "cut not tight at x̄"
+        );
+        // Convex underestimator: the tangent must lie BELOW g everywhere, i.e.
+        // for any x, a·x - rhs_cut <= g(x) - rhs_row. Check at random points.
+        for k in 0..20 {
+            let d = (k as f64) * 0.1;
+            let x = [3.0 + d, 0.5 - 0.01 * d, 0.25 + 0.02 * d, d];
+            let a_dot_x: f64 = cut
+                .cols
+                .iter()
+                .zip(cut.coeffs.iter())
+                .map(|(c, a)| a * x[*c])
+                .sum();
+            let lhs = a_dot_x - cut.rhs; // tangent residual
+            let rhs = row.residual(&x); // true residual
+            assert!(
+                lhs <= rhs + 1e-9,
+                "tangent overestimates g at x={x:?}: {lhs} > {rhs}"
+            );
+        }
+    }
+}

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -26,13 +26,17 @@
 //! as the Python `_RootLP` root-cut path does. K1 is byte-checked against that
 //! reference so any divergence is caught.
 
+use crate::lp::basis::{Basis, BASIC};
 use crate::lp::cover::separate_cover_csc;
+use crate::lp::crossover::LpView;
 use crate::lp::cut_select::select_cuts;
 use crate::lp::gomory::{separate_gomory_cols, GomoryCut};
 use crate::lp::mir::separate_mir;
 use crate::lp::simplex::refine::ns_safe_bound_csc;
 use crate::lp::simplex::sparse::SparseCols;
-use crate::lp::simplex::{primal::solve_lp_cols_scaled, LpStatus, SimplexOptions};
+use crate::lp::simplex::{
+    primal::solve_lp_cols_scaled, solve_lp_warm_scaled_csc, LpStatus, SimplexOptions,
+};
 
 /// A univariate function admissible in a convex composite row, carrying its own
 /// closed-form value and derivative. Extend as new convex-certifiable functions
@@ -358,158 +362,7 @@ impl ConvexKernelSpec {
         max_oa_rounds: usize,
         opts: &SimplexOptions,
     ) -> ConvexNodeResult {
-        let mut tangents: Vec<LinRow> = Vec::new();
-        let oc = self.oa_converge(lo, hi, &[], &mut tangents, oa_tol, max_oa_rounds, opts);
-        ConvexNodeResult {
-            status: oc.status,
-            bound: oc.bound,
-            raw_bound: oc.raw_bound,
-            x: oc.x,
-            oa_rounds: oc.rounds,
-            n_tangents: tangents.len(),
-        }
-    }
-
-    /// Run the OA relaxation to convergence over `(lo, hi)` with the given
-    /// accumulated integrality `cuts` (structural `≤` rows). Appends fresh OA
-    /// tangents to `tangents` in place. Returns the final assembled LP state
-    /// (for separation) alongside the rigorous bound.
-    #[allow(clippy::too_many_arguments)]
-    fn oa_converge(
-        &self,
-        lo: &[f64],
-        hi: &[f64],
-        cuts: &[LinRow],
-        tangents: &mut Vec<LinRow>,
-        oa_tol: f64,
-        max_oa_rounds: usize,
-        opts: &SimplexOptions,
-    ) -> OaOutcome {
-        debug_assert_eq!(lo.len(), self.n);
-        debug_assert_eq!(hi.len(), self.n);
-        let sign = if self.sense_max { -1.0 } else { 1.0 };
-        let mut last_x = vec![0.0f64; self.n];
-        let mut rounds = 0usize;
-        let trivial = if self.sense_max {
-            f64::INFINITY
-        } else {
-            f64::NEG_INFINITY
-        };
-        let mut last_bound = trivial;
-        let mut last_raw = trivial;
-
-        for _ in 0..max_oa_rounds.max(1) {
-            rounds += 1;
-            // ≤ rows: original linear, then OA tangents, then integrality cuts;
-            // then = rows. Original le rows stay first (cover's `n_orig_rows`).
-            let mut rows: Vec<AsmRow> = Vec::with_capacity(
-                self.le_rows.len() + tangents.len() + cuts.len() + self.eq_rows.len(),
-            );
-            for r in self
-                .le_rows
-                .iter()
-                .chain(tangents.iter())
-                .chain(cuts.iter())
-            {
-                rows.push(AsmRow {
-                    cols: r.cols.clone(),
-                    coeffs: r.coeffs.clone(),
-                    rhs: r.rhs,
-                    is_eq: false,
-                });
-            }
-            for r in &self.eq_rows {
-                rows.push(AsmRow {
-                    cols: r.cols.clone(),
-                    coeffs: r.coeffs.clone(),
-                    rhs: r.rhs,
-                    is_eq: true,
-                });
-            }
-            let (sp, m, n_total, b, l, u) = assemble(self.n, lo, hi, &rows);
-            let mut c = vec![0.0f64; n_total];
-            for (cj, sc) in c.iter_mut().zip(self.c.iter()) {
-                *cj = sign * sc;
-            }
-            let sol = solve_lp_cols_scaled(sp.clone(), m, n_total, &c, &l, &u, &b, opts);
-            if sol.status != LpStatus::Optimal {
-                // Sound model-sense sentinel — never falsely survives fathoming.
-                let sentinel = match (sol.status, self.sense_max) {
-                    (LpStatus::Infeasible, true) => f64::NEG_INFINITY,
-                    (LpStatus::Infeasible, false) => f64::INFINITY,
-                    (_, true) => f64::INFINITY,
-                    (_, false) => f64::NEG_INFINITY,
-                };
-                return OaOutcome {
-                    status: sol.status,
-                    bound: sentinel,
-                    raw_bound: sentinel,
-                    x: vec![0.0; self.n],
-                    rounds,
-                    optimal: None,
-                };
-            }
-            last_x.copy_from_slice(&sol.x[..self.n]);
-            let raw_bound = sign * sol.obj;
-            let (col_ptr, row_idx, vals) = sp.raw();
-            let safe_min = ns_safe_bound_csc(
-                &sol.dual, &c, col_ptr, row_idx, vals, m, n_total, &b, &l, &u,
-            );
-            let bound = match safe_min {
-                Some(v) => sign * v,
-                None if self.sense_max => f64::INFINITY,
-                None => f64::NEG_INFINITY,
-            };
-            last_bound = bound;
-            last_raw = raw_bound;
-
-            // Add OA tangents for violated convex rows at this vertex.
-            let mut added = false;
-            for row in &self.nl_rows {
-                if row.residual(&last_x) > oa_tol {
-                    if let Some(cut) = row.oa_tangent(&last_x) {
-                        tangents.push(LinRow {
-                            cols: cut.cols,
-                            coeffs: cut.coeffs,
-                            rhs: cut.rhs,
-                        });
-                        added = true;
-                    }
-                }
-            }
-            if !added {
-                // Converged: return the final LP state for separation.
-                return OaOutcome {
-                    status: LpStatus::Optimal,
-                    bound,
-                    raw_bound,
-                    x: last_x,
-                    rounds,
-                    optimal: Some(Box::new(OptimalLp {
-                        sp,
-                        m,
-                        n_total,
-                        b,
-                        l,
-                        u,
-                        rows,
-                        basis: sol.basis,
-                        x_full: sol.x,
-                    })),
-                };
-            }
-        }
-        // Hit the OA round cap without converging: return the last valid safe
-        // bound (still sound — a looser relaxation optimum). No separation state,
-        // since the OA is not tight, but the bound is usable for fathoming.
-        OaOutcome {
-            status: LpStatus::Optimal,
-            bound: last_bound,
-            raw_bound: last_raw,
-            x: last_x,
-            rounds,
-            optimal: None,
-        }
+        self.solve_node_cut(lo, hi, oa_tol, max_oa_rounds, 0, opts)
     }
 
     /// K2: the LP-OA node relaxation WITH in-tree integrality separation. Runs
@@ -519,6 +372,7 @@ impl ConvexKernelSpec {
     /// C-43 lesson) and rewritten over structural columns by substituting the
     /// slacks `s_r = b_r − A_r·x`, so each is a valid inequality for the node's
     /// integer-feasible set.
+    #[allow(clippy::too_many_arguments)]
     pub fn solve_node_cut(
         &self,
         lo: &[f64],
@@ -528,58 +382,164 @@ impl ConvexKernelSpec {
         max_sep_rounds: usize,
         opts: &SimplexOptions,
     ) -> ConvexNodeResult {
-        let mut tangents: Vec<LinRow> = Vec::new();
-        let mut cuts: Vec<LinRow> = Vec::new();
-        let mut oc = self.oa_converge(lo, hi, &cuts, &mut tangents, oa_tol, max_oa_rounds, opts);
+        debug_assert_eq!(lo.len(), self.n);
+        debug_assert_eq!(hi.len(), self.n);
+        let sign = if self.sense_max { -1.0 } else { 1.0 };
+        let trivial = if self.sense_max {
+            f64::INFINITY
+        } else {
+            f64::NEG_INFINITY
+        };
 
-        for _ in 0..max_sep_rounds {
-            let Some(opt) = oc.optimal.as_ref() else {
-                break;
+        // Base rows: `le` (≤) then `eq` (=). OA tangents and cuts are APPENDED
+        // after the base, so structural and base-slack columns never move and the
+        // optimal basis carries (extended) across every re-solve — the wall lever.
+        let mut rows: Vec<AsmRow> = Vec::with_capacity(self.le_rows.len() + self.eq_rows.len());
+        for r in &self.le_rows {
+            rows.push(AsmRow {
+                cols: r.cols.clone(),
+                coeffs: r.coeffs.clone(),
+                rhs: r.rhs,
+                is_eq: false,
+            });
+        }
+        for r in &self.eq_rows {
+            rows.push(AsmRow {
+                cols: r.cols.clone(),
+                coeffs: r.coeffs.clone(),
+                rhs: r.rhs,
+                is_eq: true,
+            });
+        }
+        let n_base = rows.len();
+
+        let mut basis: Option<Basis> = None;
+        let mut last_x = vec![0.0f64; self.n];
+        let mut last_bound = trivial;
+        let mut last_raw = trivial;
+        let mut oa_rounds = 0usize;
+        let mut sep_used = 0usize;
+        // Generous safety cap on total (OA + separation) re-solves; normal
+        // convergence exits far sooner.
+        let iter_cap = max_oa_rounds.max(1) * (max_sep_rounds + 1) + max_sep_rounds + 4;
+
+        for _ in 0..iter_cap {
+            oa_rounds += 1;
+            let (sp, m, n_total, b, l, u) = assemble(self.n, lo, hi, &rows);
+            let mut c = vec![0.0f64; n_total];
+            for (cj, sc) in c.iter_mut().zip(self.c.iter()) {
+                *cj = sign * sc;
+            }
+            // Warm-start from the carried basis (extended so the appended rows'
+            // slacks are basic); cold+scaled on the first solve. The warm path
+            // equilibrates and falls back to a cold solve when the basis is
+            // unusable, so the result is always correct — only faster.
+            let sol = match &basis {
+                Some(bs) => {
+                    let ext = extend_basis(bs.clone(), n_total);
+                    let lp = LpView {
+                        a: &[],
+                        m,
+                        n: n_total,
+                        c: &c,
+                        l: &l,
+                        u: &u,
+                    };
+                    solve_lp_warm_scaled_csc(&lp, &b, &ext, opts, &sp)
+                }
+                None => solve_lp_cols_scaled(sp.clone(), m, n_total, &c, &l, &u, &b, opts),
             };
-            if oc.status != LpStatus::Optimal {
+            if sol.status != LpStatus::Optimal {
+                // Sound model-sense sentinel — never falsely survives fathoming.
+                let sentinel = match (sol.status, self.sense_max) {
+                    (LpStatus::Infeasible, true) => f64::NEG_INFINITY,
+                    (LpStatus::Infeasible, false) => f64::INFINITY,
+                    (_, true) => f64::INFINITY,
+                    (_, false) => f64::NEG_INFINITY,
+                };
+                return ConvexNodeResult {
+                    status: sol.status,
+                    bound: sentinel,
+                    raw_bound: sentinel,
+                    x: vec![0.0; self.n],
+                    oa_rounds,
+                    n_tangents: rows.len() - n_base,
+                };
+            }
+            basis = Some(sol.basis.clone());
+            last_x.copy_from_slice(&sol.x[..self.n]);
+            last_raw = sign * sol.obj;
+            let (col_ptr, row_idx, vals) = sp.raw();
+            let safe_min = ns_safe_bound_csc(
+                &sol.dual, &c, col_ptr, row_idx, vals, m, n_total, &b, &l, &u,
+            );
+            last_bound = match safe_min {
+                Some(v) => sign * v,
+                None if self.sense_max => f64::INFINITY,
+                None => f64::NEG_INFINITY,
+            };
+
+            // 1. OA tangents for violated convex rows at this vertex (append).
+            let mut added = false;
+            for row in &self.nl_rows {
+                if row.residual(&last_x) > oa_tol {
+                    if let Some(cut) = row.oa_tangent(&last_x) {
+                        rows.push(AsmRow {
+                            cols: cut.cols,
+                            coeffs: cut.coeffs,
+                            rhs: cut.rhs,
+                            is_eq: false,
+                        });
+                        added = true;
+                    }
+                }
+            }
+            if added {
+                continue; // OA not yet converged
+            }
+            // 2. OA converged. Separate integrality cuts if budget remains.
+            if sep_used >= max_sep_rounds {
                 break;
             }
-            // Integrality over the full column set: structural, then slacks (never).
-            let mut is_int_full = vec![false; opt.n_total];
+            sep_used += 1;
+            let mut is_int_full = vec![false; n_total];
             is_int_full[..self.n].copy_from_slice(&self.integrality);
-
             let mut raw = separate_cover_csc(
-                &opt.sp,
-                opt.n_total,
-                opt.m,
-                &opt.l,
-                &opt.u,
-                &opt.b,
-                &opt.x_full,
+                &sp,
+                n_total,
+                m,
+                &l,
+                &u,
+                &b,
+                &sol.x,
                 self.n,
                 &is_int_full,
                 self.le_rows.len(),
                 opts.tol,
             );
             raw.extend(separate_gomory_cols(
-                &opt.sp,
-                opt.m,
-                opt.n_total,
-                &opt.l,
-                &opt.u,
-                &opt.b,
-                &opt.basis,
+                &sp,
+                m,
+                n_total,
+                &l,
+                &u,
+                &b,
+                &sol.basis,
                 &is_int_full,
                 opts.tol,
                 1e7,
             ));
-            // MIR (c-MIR family) over the structural ≤ rows — the lever the
-            // GMI+cover pair leaves open (measured: closes ~2× more of syn40m's
-            // root gap). MIR cuts are structural (no slack part); express each in
-            // the standard-form ≥ convention (pad to n_total) so select_cuts and
-            // substitute_slacks handle it uniformly with GMI/cover.
+            // MIR (c-MIR family) over the structural ≤ rows — the lever GMI+cover
+            // leave open (measured: closes ~2× more of syn40m's root gap). MIR cuts
+            // are structural; express in the standard-form ≥ convention so they
+            // flow through select_cuts + substitute_slacks with GMI/cover.
             {
                 let mut a_ub: Vec<f64> = Vec::new();
                 let mut b_ub: Vec<f64> = Vec::new();
-                for row in opt.rows.iter().filter(|r| !r.is_eq) {
+                for row in rows.iter().filter(|r| !r.is_eq) {
                     let mut dense = vec![0.0f64; self.n];
-                    for (c, v) in row.cols.iter().zip(row.coeffs.iter()) {
-                        dense[*c] = *v;
+                    for (cc, vv) in row.cols.iter().zip(row.coeffs.iter()) {
+                        dense[*cc] = *vv;
                     }
                     a_ub.extend_from_slice(&dense);
                     b_ub.push(row.rhs);
@@ -588,15 +548,14 @@ impl ConvexKernelSpec {
                     for mc in separate_mir(
                         &a_ub,
                         &b_ub,
-                        &opt.l[..self.n],
-                        &opt.u[..self.n],
+                        &l[..self.n],
+                        &u[..self.n],
                         &self.integrality,
-                        &opt.x_full[..self.n],
+                        &sol.x[..self.n],
                         opts.tol,
                         1e7,
                     ) {
-                        // MirCut `coeffs·x ≤ rhs` → ≥ form `(−coeffs)·x ≥ −rhs`.
-                        let mut coeffs = vec![0.0f64; opt.n_total];
+                        let mut coeffs = vec![0.0f64; n_total];
                         for (j, &v) in mc.coeffs.iter().enumerate() {
                             coeffs[j] = -v;
                         }
@@ -610,56 +569,47 @@ impl ConvexKernelSpec {
             if raw.is_empty() {
                 break;
             }
-            let selected = select_cuts(raw, &opt.x_full, 8, 1e-4, 0.90);
+            let selected = select_cuts(raw, &sol.x, 8, 1e-4, 0.90);
             if selected.is_empty() {
                 break;
             }
-            let mut added = 0usize;
+            let mut added_cuts = 0usize;
             for gc in &selected {
-                if let Some(lin) = substitute_slacks(gc, &opt.rows, self.n) {
-                    cuts.push(lin);
-                    added += 1;
+                if let Some(lin) = substitute_slacks(gc, &rows, self.n) {
+                    rows.push(AsmRow {
+                        cols: lin.cols,
+                        coeffs: lin.coeffs,
+                        rhs: lin.rhs,
+                        is_eq: false,
+                    });
+                    added_cuts += 1;
                 }
             }
-            if added == 0 {
+            if added_cuts == 0 {
                 break;
             }
-            oc = self.oa_converge(lo, hi, &cuts, &mut tangents, oa_tol, max_oa_rounds, opts);
         }
 
         ConvexNodeResult {
-            status: oc.status,
-            bound: oc.bound,
-            raw_bound: oc.raw_bound,
-            x: oc.x,
-            oa_rounds: oc.rounds,
-            n_tangents: tangents.len() + cuts.len(),
+            status: LpStatus::Optimal,
+            bound: last_bound,
+            raw_bound: last_raw,
+            x: last_x,
+            oa_rounds,
+            n_tangents: rows.len() - n_base,
         }
     }
 }
 
-/// Final assembled LP state at OA convergence (for in-node separation).
-struct OptimalLp {
-    sp: SparseCols,
-    m: usize,
-    n_total: usize,
-    b: Vec<f64>,
-    l: Vec<f64>,
-    u: Vec<f64>,
-    rows: Vec<AsmRow>,
-    basis: crate::lp::basis::Basis,
-    x_full: Vec<f64>,
-}
-
-/// Outcome of one OA convergence run.
-struct OaOutcome {
-    status: LpStatus,
-    bound: f64,
-    raw_bound: f64,
-    x: Vec<f64>,
-    rounds: usize,
-    /// `Some` only on a converged Optimal solve — the LP state for separation.
-    optimal: Option<Box<OptimalLp>>,
+/// Extend a stored basis to `n_total` columns by making the appended slack
+/// columns basic — a valid, dual-repairable warm start after rows/cols were
+/// appended (each new column is its row's slack). No-op when already spanning.
+fn extend_basis(mut basis: Basis, n_total: usize) -> Basis {
+    for j in basis.col_status.len()..n_total {
+        basis.col_status.push(BASIC);
+        basis.basic_vars.push(j);
+    }
+    basis
 }
 
 /// Rewrite a standard-form cut `Σ coeffs·z ≥ rhs` (z = structural ‖ slacks) over

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -26,6 +26,10 @@
 //! as the Python `_RootLP` root-cut path does. K1 is byte-checked against that
 //! reference so any divergence is caught.
 
+use crate::lp::simplex::refine::ns_safe_bound_csc;
+use crate::lp::simplex::sparse::SparseCols;
+use crate::lp::simplex::{primal::solve_lp_cols_scaled, LpStatus, SimplexOptions};
+
 /// A univariate function admissible in a convex composite row, carrying its own
 /// closed-form value and derivative. Extend as new convex-certifiable functions
 /// appear; an unknown function makes the Python producer decline the instance
@@ -204,9 +208,257 @@ impl ConvexRow {
     }
 }
 
+/// A sparse linear row `Σ coeffs·x[cols]  {≤,=}  rhs`.
+#[derive(Clone, Debug)]
+pub struct LinRow {
+    /// Column indices.
+    pub cols: Vec<usize>,
+    /// Coefficients aligned with `cols`.
+    pub coeffs: Vec<f64>,
+    /// Right-hand side.
+    pub rhs: f64,
+}
+
+/// The analyze-once convex-kernel problem (marshaled from Python once per solve).
+///
+/// Objective sense is carried explicitly: the in-house simplex MINIMIZES, so a
+/// `sense_max` model is solved by minimizing `−c·x` and the rigorous safe bound is
+/// negated back to a valid UPPER bound on the maximization.
+#[derive(Clone, Debug)]
+pub struct ConvexKernelSpec {
+    /// Structural column count.
+    pub n: usize,
+    /// Objective coefficients (declared model sense).
+    pub c: Vec<f64>,
+    /// `true` → maximize `c·x`; `false` → minimize.
+    pub sense_max: bool,
+    /// Per-column integrality.
+    pub integrality: Vec<bool>,
+    /// Global column lower bounds.
+    pub lb: Vec<f64>,
+    /// Global column upper bounds.
+    pub ub: Vec<f64>,
+    /// Linear `≤` rows.
+    pub le_rows: Vec<LinRow>,
+    /// Linear `=` rows.
+    pub eq_rows: Vec<LinRow>,
+    /// Convex nonlinear `≤` rows (outer-approximated by tangents).
+    pub nl_rows: Vec<ConvexRow>,
+}
+
+/// Result of one convex node's LP-OA relaxation.
+#[derive(Clone, Debug)]
+pub struct ConvexNodeResult {
+    /// LP status of the final OA relaxation solve.
+    pub status: LpStatus,
+    /// Rigorous dual bound in the MODEL's sense (a valid upper bound for a
+    /// maximization, lower bound for a minimization). `±inf` when uncertifiable or
+    /// the relaxation is infeasible — sound (never fathoms).
+    pub bound: f64,
+    /// Structural primal point at the final OA vertex (length `n`).
+    pub x: Vec<f64>,
+    /// Number of OA rounds (LP solves) performed.
+    pub oa_rounds: usize,
+    /// Number of OA tangent cuts accumulated.
+    pub n_tangents: usize,
+}
+
+/// One row of the standard-form assembly, tagged by sense.
+struct AsmRow {
+    cols: Vec<usize>,
+    coeffs: Vec<f64>,
+    rhs: f64,
+    is_eq: bool,
+}
+
+/// Assemble the standard-form node LP `[A | I] z = b` over the box `(lo, hi)`.
+///
+/// Every row gets an explicit slack: `≤` rows a slack in `[0, cap]` (cap from row
+/// min-activity, keeping the Neumaier–Shcherbina term finite — the tanksize
+/// certification lesson), `=` rows a slack fixed at `0`. Returns
+/// `(sp, m, n_total, b, l, u)`.
+fn assemble(
+    n_cols: usize,
+    lo: &[f64],
+    hi: &[f64],
+    rows: &[AsmRow],
+) -> (SparseCols, usize, usize, Vec<f64>, Vec<f64>, Vec<f64>) {
+    let m = rows.len();
+    let n_total = n_cols + m;
+    let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n_total];
+    let mut b = vec![0.0f64; m];
+    for (r, row) in rows.iter().enumerate() {
+        b[r] = row.rhs;
+        for (c, v) in row.cols.iter().zip(row.coeffs.iter()) {
+            debug_assert!(*c < n_cols, "row references column out of range");
+            cols[*c].push((r, *v));
+        }
+        cols[n_cols + r].push((r, 1.0)); // slack
+    }
+    let mut col_ptr = Vec::with_capacity(n_total + 1);
+    let mut row_idx = Vec::new();
+    let mut vals = Vec::new();
+    col_ptr.push(0usize);
+    for col in &cols {
+        for (r, v) in col {
+            row_idx.push(*r);
+            vals.push(*v);
+        }
+        col_ptr.push(row_idx.len());
+    }
+    let sp = SparseCols::from_csc(col_ptr, row_idx, vals);
+
+    let mut l = lo.to_vec();
+    let mut u = hi.to_vec();
+    l.extend(std::iter::repeat(0.0).take(m));
+    for row in rows.iter() {
+        if row.is_eq {
+            u.push(0.0); // slack fixed at 0 → equality
+            continue;
+        }
+        // ≤ row: finite slack cap from min-activity (keeps NS bound finite).
+        let mut min_act = 0.0f64;
+        for (c, v) in row.cols.iter().zip(row.coeffs.iter()) {
+            min_act += if *v > 0.0 { v * l[*c] } else { v * u[*c] };
+        }
+        let cap = if min_act.is_finite() {
+            (row.rhs - min_act).max(0.0)
+        } else {
+            1e20
+        };
+        u.push(cap.min(1e20));
+    }
+    (sp, m, n_total, b, l, u)
+}
+
+impl ConvexKernelSpec {
+    /// Solve the LP-OA node relaxation over the box `(lo, hi)` (length `n`):
+    /// linear rows + OA tangents refined to OA convergence, solved by the warm
+    /// in-house simplex. Returns the rigorous dual bound in the model's sense.
+    ///
+    /// `oa_tol`: nonlinear-residual tolerance to add a tangent. `max_oa_rounds`:
+    /// safety cap on the OA loop.
+    pub fn solve_node(
+        &self,
+        lo: &[f64],
+        hi: &[f64],
+        oa_tol: f64,
+        max_oa_rounds: usize,
+        opts: &SimplexOptions,
+    ) -> ConvexNodeResult {
+        debug_assert_eq!(lo.len(), self.n);
+        debug_assert_eq!(hi.len(), self.n);
+        // Objective: minimize c·x (min sense) or −c·x (max sense).
+        let sign = if self.sense_max { -1.0 } else { 1.0 };
+
+        let mut tangents: Vec<LinRow> = Vec::new();
+        let mut last_x = vec![0.0f64; self.n];
+        let mut status = LpStatus::Optimal;
+        let mut bound = f64::NEG_INFINITY;
+        let mut rounds = 0usize;
+
+        for _ in 0..max_oa_rounds.max(1) {
+            rounds += 1;
+            // Build the row list: ≤ (linear + tangents), then = rows.
+            let mut rows: Vec<AsmRow> =
+                Vec::with_capacity(self.le_rows.len() + tangents.len() + self.eq_rows.len());
+            for r in self.le_rows.iter().chain(tangents.iter()) {
+                rows.push(AsmRow {
+                    cols: r.cols.clone(),
+                    coeffs: r.coeffs.clone(),
+                    rhs: r.rhs,
+                    is_eq: false,
+                });
+            }
+            for r in &self.eq_rows {
+                rows.push(AsmRow {
+                    cols: r.cols.clone(),
+                    coeffs: r.coeffs.clone(),
+                    rhs: r.rhs,
+                    is_eq: true,
+                });
+            }
+            let (sp, m, n_total, b, l, u) = assemble(self.n, lo, hi, &rows);
+            let mut c = vec![0.0f64; n_total];
+            for (cj, sc) in c.iter_mut().zip(self.c.iter()) {
+                *cj = sign * sc;
+            }
+            let sol = solve_lp_cols_scaled(sp.clone(), m, n_total, &c, &l, &u, &b, opts);
+            status = sol.status;
+            if status != LpStatus::Optimal {
+                // Non-Optimal relaxation → return a sound model-sense sentinel that
+                // never falsely survives fathoming. Callers key off `status` and
+                // treat any non-Optimal node as "skip region".
+                //   Infeasible: the box is empty → prune. Report the WORST bound
+                //     (−inf for max / +inf for min) so it contributes nothing.
+                //   Unbounded/Numerical: no certified bound → report the trivial
+                //     bound (+inf for max / −inf for min) so it never fathoms.
+                let sentinel = match (status, self.sense_max) {
+                    (LpStatus::Infeasible, true) => f64::NEG_INFINITY,
+                    (LpStatus::Infeasible, false) => f64::INFINITY,
+                    (_, true) => f64::INFINITY,
+                    (_, false) => f64::NEG_INFINITY,
+                };
+                last_x.iter_mut().for_each(|v| *v = 0.0);
+                return ConvexNodeResult {
+                    status,
+                    bound: sentinel,
+                    x: last_x,
+                    oa_rounds: rounds,
+                    n_tangents: tangents.len(),
+                };
+            }
+            last_x.copy_from_slice(&sol.x[..self.n]);
+
+            // Rigorous safe bound on min(c·x) from the row duals; negate for sense.
+            let (col_ptr, row_idx, vals) = sp.raw();
+            let safe_min = ns_safe_bound_csc(
+                &sol.dual, &c, col_ptr, row_idx, vals, m, n_total, &b, &l, &u,
+            );
+            bound = match safe_min {
+                Some(v) => sign * v, // max: −(safe lower on −c·x) = safe upper on c·x
+                None => {
+                    if self.sense_max {
+                        f64::INFINITY
+                    } else {
+                        f64::NEG_INFINITY
+                    }
+                }
+            };
+
+            // Separate OA tangents for violated convex rows at this vertex.
+            let mut added = false;
+            for row in &self.nl_rows {
+                if row.residual(&last_x) > oa_tol {
+                    if let Some(cut) = row.oa_tangent(&last_x) {
+                        tangents.push(LinRow {
+                            cols: cut.cols,
+                            coeffs: cut.coeffs,
+                            rhs: cut.rhs,
+                        });
+                        added = true;
+                    }
+                }
+            }
+            if !added {
+                break;
+            }
+        }
+
+        ConvexNodeResult {
+            status,
+            bound,
+            x: last_x,
+            oa_rounds: rounds,
+            n_tangents: tangents.len(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lp::simplex::SimplexOptions;
 
     const N: usize = 4;
 
@@ -330,5 +582,85 @@ mod tests {
                 "tangent overestimates g at x={x:?}: {lhs} > {rhs}"
             );
         }
+    }
+
+    fn opts() -> SimplexOptions {
+        SimplexOptions {
+            expel_zero_artificials: true,
+            ..Default::default()
+        }
+    }
+
+    /// K1c: the OA loop converges to the true convex bound. Model:
+    /// `max t  s.t.  exp(t) ≤ 5,  t ∈ [0, 10]` → optimum `t* = ln 5 ≈ 1.6094`.
+    #[test]
+    fn node_oa_loop_converges_to_convex_optimum() {
+        let spec = ConvexKernelSpec {
+            n: 1,
+            c: vec![1.0],
+            sense_max: true,
+            integrality: vec![false],
+            lb: vec![0.0],
+            ub: vec![10.0],
+            le_rows: vec![],
+            eq_rows: vec![],
+            nl_rows: vec![ConvexRow {
+                lin: Affine::default(),
+                terms: vec![CompositeTerm {
+                    coeff: 1.0,
+                    func: ConvexFunc::Exp,
+                    arg: Affine {
+                        cols: vec![0],
+                        coeffs: vec![1.0],
+                        cst: 0.0,
+                    },
+                }],
+                rhs: 5.0,
+            }],
+        };
+        let r = spec.solve_node(&[0.0], &[10.0], 1e-9, 60, &opts());
+        assert_eq!(r.status, LpStatus::Optimal);
+        let truth = 5.0_f64.ln();
+        // OA outer-approximates from OUTSIDE → bound is a valid UPPER bound on the
+        // max, converging DOWN to truth. Must be ≥ truth (sound) and close.
+        assert!(
+            r.bound >= truth - 1e-6,
+            "bound {} below truth {}",
+            r.bound,
+            truth
+        );
+        assert!(
+            r.bound <= truth + 1e-4,
+            "bound {} not converged to truth {}",
+            r.bound,
+            truth
+        );
+        assert!(r.oa_rounds > 1, "OA should take several rounds");
+    }
+
+    /// K1c: a linear-only node reproduces the LP optimum exactly (no OA rounds
+    /// beyond the first), and the safe bound is a valid upper bound.
+    #[test]
+    fn node_linear_only_matches_lp() {
+        // max 2·x0 + 3·x1  s.t.  x0 + x1 ≤ 4,  x0,x1 ∈ [0,3]  → x0=1,x1=3, obj=11.
+        let spec = ConvexKernelSpec {
+            n: 2,
+            c: vec![2.0, 3.0],
+            sense_max: true,
+            integrality: vec![false, false],
+            lb: vec![0.0, 0.0],
+            ub: vec![3.0, 3.0],
+            le_rows: vec![LinRow {
+                cols: vec![0, 1],
+                coeffs: vec![1.0, 1.0],
+                rhs: 4.0,
+            }],
+            eq_rows: vec![],
+            nl_rows: vec![],
+        };
+        let r = spec.solve_node(&[0.0, 0.0], &[3.0, 3.0], 1e-9, 10, &opts());
+        assert_eq!(r.status, LpStatus::Optimal);
+        assert!((r.bound - 11.0).abs() < 1e-6, "bound {} != 11", r.bound);
+        assert_eq!(r.oa_rounds, 1, "linear node needs one solve");
     }
 }

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -252,9 +252,16 @@ pub struct ConvexNodeResult {
     /// LP status of the final OA relaxation solve.
     pub status: LpStatus,
     /// Rigorous dual bound in the MODEL's sense (a valid upper bound for a
-    /// maximization, lower bound for a minimization). `±inf` when uncertifiable or
-    /// the relaxation is infeasible — sound (never fathoms).
+    /// maximization, lower bound for a minimization) — the Neumaier–Shcherbina
+    /// safe bound, negated for sense. `±inf` when uncertifiable (e.g. a nonzero
+    /// reduced cost meets an infinite structural bound) or the relaxation is
+    /// infeasible — sound (never fathoms). This is what the tree fathoms on.
     pub bound: f64,
+    /// The RAW simplex LP optimum in the model's sense (not directed-rounded).
+    /// Diagnostic / byte-check use only — NEVER fathom on this (it can drift above
+    /// the true optimum on an ill-conditioned basis). Equals `bound` up to the NS
+    /// safety margin when the bound certifies.
+    pub raw_bound: f64,
     /// Structural primal point at the final OA vertex (length `n`).
     pub x: Vec<f64>,
     /// Number of OA rounds (LP solves) performed.
@@ -355,6 +362,7 @@ impl ConvexKernelSpec {
         let mut last_x = vec![0.0f64; self.n];
         let mut status = LpStatus::Optimal;
         let mut bound = f64::NEG_INFINITY;
+        let mut raw_bound = f64::NEG_INFINITY;
         let mut rounds = 0usize;
 
         for _ in 0..max_oa_rounds.max(1) {
@@ -403,12 +411,15 @@ impl ConvexKernelSpec {
                 return ConvexNodeResult {
                     status,
                     bound: sentinel,
+                    raw_bound: sentinel,
                     x: last_x,
                     oa_rounds: rounds,
                     n_tangents: tangents.len(),
                 };
             }
             last_x.copy_from_slice(&sol.x[..self.n]);
+            // Raw LP optimum in the model sense (diagnostic; never fathom on it).
+            raw_bound = sign * sol.obj;
 
             // Rigorous safe bound on min(c·x) from the row duals; negate for sense.
             let (col_ptr, row_idx, vals) = sp.raw();
@@ -448,6 +459,7 @@ impl ConvexKernelSpec {
         ConvexNodeResult {
             status,
             bound,
+            raw_bound,
             x: last_x,
             oa_rounds: rounds,
             n_tangents: tangents.len(),

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -672,6 +672,432 @@ fn substitute_slacks(gc: &GomoryCut, rows: &[AsmRow], n_struct: usize) -> Option
     })
 }
 
+// ── K2c: best-bound branch-and-cut tree ──────────────────────────────────────
+
+/// Terminal state of the convex kernel tree. `Optimal` is emitted ONLY when the
+/// dual bound has closed onto the incumbent within `gap_tol` — a residual gap
+/// yields `Exhausted`/`NodeLimit`/`TimeLimit`, never a falsely-upgraded optimum.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConvexTreeStatus {
+    /// Certified optimal (dual bound closed onto the incumbent).
+    Optimal,
+    /// Node budget exhausted with a residual gap.
+    NodeLimit,
+    /// Wall-clock deadline hit with a residual gap.
+    TimeLimit,
+    /// Tree fully explored but the residual gap did not close to `gap_tol`
+    /// (numerical), or no incumbent was found.
+    Exhausted,
+    /// The root relaxation is infeasible.
+    Infeasible,
+}
+
+/// Configuration for [`ConvexKernelSpec::solve_tree`].
+#[derive(Clone, Debug)]
+pub struct ConvexTreeConfig {
+    /// Node budget.
+    pub max_nodes: usize,
+    /// Relative optimality gap tolerance.
+    pub gap_tol: f64,
+    /// Integrality tolerance.
+    pub int_tol: f64,
+    /// OA nonlinear-residual tolerance.
+    pub oa_tol: f64,
+    /// Per-node OA round cap.
+    pub max_oa_rounds: usize,
+    /// Per-node separation round cap (0 = no in-tree cutting).
+    pub max_sep_rounds: usize,
+    /// FBBT propagation round cap per node.
+    pub fbbt_rounds: usize,
+    /// Optional wall-clock deadline.
+    pub deadline: Option<std::time::Instant>,
+    /// Optional known-feasible incumbent objective (model sense) to seed pruning.
+    pub initial_incumbent: Option<f64>,
+}
+
+impl Default for ConvexTreeConfig {
+    fn default() -> Self {
+        Self {
+            max_nodes: 100_000,
+            gap_tol: 1e-4,
+            int_tol: 1e-5,
+            oa_tol: 1e-6,
+            max_oa_rounds: 60,
+            max_sep_rounds: 12,
+            fbbt_rounds: 20,
+            deadline: None,
+            initial_incumbent: None,
+        }
+    }
+}
+
+/// Result of a convex kernel tree solve.
+#[derive(Clone, Debug)]
+pub struct ConvexTreeResult {
+    /// Terminal status.
+    pub status: ConvexTreeStatus,
+    /// Best feasible objective (model sense), or `None` if none was found.
+    pub incumbent: Option<f64>,
+    /// Structural point of the incumbent (empty if none).
+    pub incumbent_x: Vec<f64>,
+    /// Best dual bound in the model sense (upper bound for max, lower for min).
+    pub bound: f64,
+    /// Nodes processed.
+    pub node_count: usize,
+}
+
+/// A worklist node: the box `(lo, hi)` and the parent's rigorous dual bound.
+struct TreeNode {
+    key: f64, // best-bound priority: pop the most promising node first (max-heap).
+    parent_bound: f64,
+    lo: Vec<f64>,
+    hi: Vec<f64>,
+}
+impl PartialEq for TreeNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+impl Eq for TreeNode {}
+impl PartialOrd for TreeNode {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for TreeNode {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.key.total_cmp(&other.key)
+    }
+}
+
+impl ConvexKernelSpec {
+    /// Interval FBBT over the linear rows (`≤` and `=`, both directions) plus
+    /// integer rounding, tightening `(lo, hi)` in place to a fixpoint. Returns
+    /// `false` if the box is proven empty. REQUIRED before the node LP: it makes
+    /// the structural bounds finite so the Neumaier–Shcherbina safe bound
+    /// certifies (an infinite structural bound meeting a roundoff reduced cost
+    /// makes NS decline — the K1d finding).
+    pub fn propagate_fbbt(&self, lo: &mut [f64], hi: &mut [f64], max_rounds: usize) -> bool {
+        // Each pass tightens `a·x ≤ rhs` rows; equalities contribute both `a·x ≤ b`
+        // and `−a·x ≤ −b`.
+        let apply = |lo: &mut [f64],
+                     hi: &mut [f64],
+                     cols: &[usize],
+                     coeffs: &[f64],
+                     rhs: f64|
+         -> Option<bool> {
+            // Returns Some(changed) or None if the box is proven empty.
+            let mut changed = false;
+            for (jpos, &j) in cols.iter().enumerate() {
+                let aj = coeffs[jpos];
+                if aj == 0.0 {
+                    continue;
+                }
+                // rest = Σ_{k≠j} min contribution (a_k>0 → lo, else hi).
+                let mut rest = 0.0;
+                let mut ok = true;
+                for (kpos, &k) in cols.iter().enumerate() {
+                    if kpos == jpos {
+                        continue;
+                    }
+                    let ak = coeffs[kpos];
+                    let v = if ak > 0.0 { lo[k] } else { hi[k] };
+                    if !v.is_finite() {
+                        ok = false;
+                        break;
+                    }
+                    rest += ak * v;
+                }
+                if !ok {
+                    continue;
+                }
+                let bnd = (rhs - rest) / aj;
+                if aj > 0.0 {
+                    let nb = if self.integrality[j] {
+                        (bnd + 1e-9).floor()
+                    } else {
+                        bnd
+                    };
+                    if nb < hi[j] - 1e-9 {
+                        hi[j] = nb;
+                        changed = true;
+                    }
+                } else {
+                    let nb = if self.integrality[j] {
+                        (bnd - 1e-9).ceil()
+                    } else {
+                        bnd
+                    };
+                    if nb > lo[j] + 1e-9 {
+                        lo[j] = nb;
+                        changed = true;
+                    }
+                }
+                if lo[j] > hi[j] + 1e-7 {
+                    return None;
+                }
+            }
+            Some(changed)
+        };
+
+        for _ in 0..max_rounds.max(1) {
+            let mut changed = false;
+            for row in &self.le_rows {
+                match apply(lo, hi, &row.cols, &row.coeffs, row.rhs) {
+                    None => return false,
+                    Some(c) => changed |= c,
+                }
+            }
+            for row in &self.eq_rows {
+                match apply(lo, hi, &row.cols, &row.coeffs, row.rhs) {
+                    None => return false,
+                    Some(c) => changed |= c,
+                }
+                let neg: Vec<f64> = row.coeffs.iter().map(|v| -v).collect();
+                match apply(lo, hi, &row.cols, &neg, -row.rhs) {
+                    None => return false,
+                    Some(c) => changed |= c,
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        // Final integer rounding on the box.
+        for j in 0..self.n {
+            if self.integrality[j] {
+                lo[j] = (lo[j] - 1e-9).ceil();
+                hi[j] = (hi[j] + 1e-9).floor();
+                if lo[j] > hi[j] + 1e-7 {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Is `x` integer-integral on all integer columns AND OA-tight (every convex
+    /// row satisfied to `oa_tol`)? Such an LP vertex is genuinely feasible → a
+    /// valid incumbent (the minimal LP-NLP-BB primal; K3 adds NLP/rounding).
+    fn is_integer_feasible(&self, x: &[f64], int_tol: f64, oa_tol: f64) -> bool {
+        for j in 0..self.n {
+            if self.integrality[j] && (x[j] - x[j].round()).abs() > int_tol {
+                return false;
+            }
+        }
+        self.nl_rows.iter().all(|r| r.residual(x) <= oa_tol)
+    }
+
+    /// The most-fractional integer column, or `None` if all are integral.
+    fn most_fractional(&self, x: &[f64], int_tol: f64) -> Option<usize> {
+        let mut best = int_tol;
+        let mut bj = None;
+        for j in 0..self.n {
+            if self.integrality[j] {
+                let f = x[j] - x[j].floor();
+                let d = f.min(1.0 - f);
+                if d > best {
+                    best = d;
+                    bj = Some(j);
+                }
+            }
+        }
+        bj
+    }
+
+    /// The objective `c·x` in the model sense.
+    fn objective(&self, x: &[f64]) -> f64 {
+        self.c.iter().zip(x.iter()).map(|(c, x)| c * x).sum()
+    }
+
+    /// Best-bound LP-OA branch-and-cut over the global box `(lb, hi)`. Best-bound
+    /// worklist, per-node FBBT + `solve_node_cut`, sound fathoming on the NS safe
+    /// bound, branch on the most-fractional integer. Never reports `Optimal`
+    /// unless the dual bound closes onto the incumbent within `gap_tol`.
+    pub fn solve_tree(&self, config: &ConvexTreeConfig, opts: &SimplexOptions) -> ConvexTreeResult {
+        let sense = if self.sense_max { 1.0 } else { -1.0 };
+        // Work in a "maximize sense·bound" convention: priority = sense·bound so
+        // the heap always pops the most promising node; incumbent improves when
+        // sense·obj increases; fathom when sense·dual ≤ sense·incumbent + gap.
+        let worse = f64::NEG_INFINITY; // sense·(worst possible objective)
+        let mut inc_sense = config.initial_incumbent.map(|v| sense * v).unwrap_or(worse);
+        let mut incumbent_x: Vec<f64> = Vec::new();
+
+        // Root node over the FBBT-propagated global box.
+        let mut root_lo = self.lb.clone();
+        let mut root_hi = self.ub.clone();
+        if !self.propagate_fbbt(&mut root_lo, &mut root_hi, config.fbbt_rounds) {
+            return ConvexTreeResult {
+                status: ConvexTreeStatus::Infeasible,
+                incumbent: None,
+                incumbent_x: Vec::new(),
+                bound: worse,
+                node_count: 0,
+            };
+        }
+
+        let mut heap = std::collections::BinaryHeap::new();
+        heap.push(TreeNode {
+            key: f64::INFINITY,
+            parent_bound: sense * f64::INFINITY, // sense·(trivial dual bound)
+            lo: root_lo,
+            hi: root_hi,
+        });
+
+        let mut node_count = 0usize;
+        let mut status = ConvexTreeStatus::Exhausted;
+        // Global dual bound (sense convention): max over the frontier of node duals.
+        let mut global_dual_sense = f64::INFINITY;
+
+        while let Some(node) = heap.pop() {
+            // Global dual bound = best (largest sense·bound) still on the frontier,
+            // including this node.
+            global_dual_sense = node.parent_bound.max(
+                heap.iter()
+                    .map(|n| n.parent_bound)
+                    .fold(f64::NEG_INFINITY, f64::max),
+            );
+
+            // Gap check: if the best remaining dual has closed onto the incumbent,
+            // the whole tree is certified.
+            if inc_sense > worse
+                && global_dual_sense <= inc_sense + config.gap_tol * inc_sense.abs().max(1.0)
+            {
+                status = ConvexTreeStatus::Optimal;
+                break;
+            }
+            if config
+                .deadline
+                .is_some_and(|d| std::time::Instant::now() >= d)
+            {
+                status = ConvexTreeStatus::TimeLimit;
+                break;
+            }
+            if node_count >= config.max_nodes {
+                status = ConvexTreeStatus::NodeLimit;
+                break;
+            }
+            // Fathom by parent bound vs incumbent.
+            if inc_sense > worse
+                && node.parent_bound <= inc_sense + config.gap_tol * inc_sense.abs().max(1.0)
+            {
+                continue;
+            }
+            node_count += 1;
+
+            // FBBT the child box (root already propagated, but branching added
+            // bounds that propagate further).
+            let mut lo = node.lo;
+            let mut hi = node.hi;
+            if !self.propagate_fbbt(&mut lo, &mut hi, config.fbbt_rounds) {
+                continue; // empty box → fathom
+            }
+
+            let r = self.solve_node_cut(
+                &lo,
+                &hi,
+                config.oa_tol,
+                config.max_oa_rounds,
+                config.max_sep_rounds,
+                opts,
+            );
+            if r.status != LpStatus::Optimal {
+                continue; // infeasible/unbounded region → skip
+            }
+            // Node dual in the sense convention, floored by the parent (rigorous:
+            // a child's bound can only be ≤ the parent's in sense convention).
+            let node_dual_sense = (sense * r.bound).min(node.parent_bound);
+            if !node_dual_sense.is_finite() {
+                // Uncertified node bound → cannot fathom on it, but we can still
+                // branch to make progress; treat its dual as the parent's.
+            }
+            // Fathom by node bound.
+            if inc_sense > worse
+                && node_dual_sense <= inc_sense + config.gap_tol * inc_sense.abs().max(1.0)
+            {
+                continue;
+            }
+
+            // Incumbent from an integer-feasible OA-tight vertex.
+            if self.is_integer_feasible(&r.x, config.int_tol, config.oa_tol * 10.0) {
+                let obj_sense = sense * self.objective(&r.x);
+                if obj_sense > inc_sense {
+                    inc_sense = obj_sense;
+                    incumbent_x = r.x.clone();
+                }
+                continue; // integral node → nothing to branch
+            }
+
+            // Branch on the most-fractional integer.
+            let Some(j) = self.most_fractional(&r.x, config.int_tol) else {
+                continue;
+            };
+            let xj = r.x[j];
+            let branch_key = node_dual_sense;
+            // Down child: x_j ≤ floor(x_j).
+            {
+                let clo = lo.clone();
+                let mut chi = hi.clone();
+                chi[j] = xj.floor();
+                if clo[j] <= chi[j] + 1e-9 {
+                    heap.push(TreeNode {
+                        key: branch_key,
+                        parent_bound: node_dual_sense,
+                        lo: clo,
+                        hi: chi,
+                    });
+                }
+            }
+            // Up child: x_j ≥ ceil(x_j).
+            {
+                let mut clo = lo;
+                let chi = hi;
+                clo[j] = xj.ceil();
+                if clo[j] <= chi[j] + 1e-9 {
+                    heap.push(TreeNode {
+                        key: branch_key,
+                        parent_bound: node_dual_sense,
+                        lo: clo,
+                        hi: chi,
+                    });
+                }
+            }
+        }
+
+        if heap.is_empty() && status == ConvexTreeStatus::Exhausted {
+            // Frontier drained: the global dual collapses to the incumbent.
+            global_dual_sense = inc_sense;
+            if inc_sense > worse {
+                status = ConvexTreeStatus::Optimal;
+            }
+        }
+
+        let incumbent = if inc_sense > worse {
+            Some(sense * inc_sense)
+        } else {
+            None
+        };
+        let bound = if global_dual_sense.is_finite() {
+            sense * global_dual_sense
+        } else if inc_sense > worse {
+            sense * inc_sense
+        } else {
+            sense * f64::INFINITY
+        };
+        ConvexTreeResult {
+            status: if incumbent.is_none() && status == ConvexTreeStatus::Optimal {
+                ConvexTreeStatus::Exhausted
+            } else {
+                status
+            },
+            incumbent,
+            incumbent_x,
+            bound,
+            node_count,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -907,6 +1333,84 @@ mod tests {
             r1.bound >= 1.0 - 1e-6,
             "UNSOUND: bound {} < integer optimum 1.0",
             r1.bound
+        );
+    }
+
+    /// K2c: the tree certifies a small MILP. `max x0+x1 s.t. x0+x1≤1.5,
+    /// x∈{0,1}²` → integer optimum 1 (branching + fathoming, no nl rows).
+    #[test]
+    fn tree_certifies_milp() {
+        let spec = ConvexKernelSpec {
+            n: 2,
+            c: vec![1.0, 1.0],
+            sense_max: true,
+            integrality: vec![true, true],
+            lb: vec![0.0, 0.0],
+            ub: vec![1.0, 1.0],
+            le_rows: vec![LinRow {
+                cols: vec![0, 1],
+                coeffs: vec![1.0, 1.0],
+                rhs: 1.5,
+            }],
+            eq_rows: vec![],
+            nl_rows: vec![],
+        };
+        let cfg = ConvexTreeConfig::default();
+        let r = spec.solve_tree(&cfg, &opts());
+        assert_eq!(r.status, ConvexTreeStatus::Optimal, "status {:?}", r.status);
+        let inc = r.incumbent.expect("incumbent");
+        assert!((inc - 1.0).abs() < 1e-6, "incumbent {inc} != 1.0");
+        // Dual bound is a valid upper bound that closed onto the incumbent.
+        assert!(
+            r.bound >= inc - 1e-6 && r.bound <= inc + 1e-4,
+            "bound {} vs inc {inc}",
+            r.bound
+        );
+    }
+
+    /// K2c: the tree certifies a small convex MINLP.
+    /// `max x + k  s.t.  k ≤ x,  exp(x) ≤ 5,  x∈[0,10] cont, k∈{0..3} int`.
+    /// exp(x)≤5 → x ≤ ln5 ≈ 1.6094; k ≤ x → k=1. Optimum ≈ ln5 + 1 ≈ 2.6094.
+    #[test]
+    fn tree_certifies_convex_minlp() {
+        let spec = ConvexKernelSpec {
+            n: 2, // x0 = x (cont), x1 = k (int)
+            c: vec![1.0, 1.0],
+            sense_max: true,
+            integrality: vec![false, true],
+            lb: vec![0.0, 0.0],
+            ub: vec![10.0, 3.0],
+            le_rows: vec![LinRow {
+                cols: vec![1, 0],
+                coeffs: vec![1.0, -1.0], // k − x ≤ 0
+                rhs: 0.0,
+            }],
+            eq_rows: vec![],
+            nl_rows: vec![ConvexRow {
+                lin: Affine::default(),
+                terms: vec![CompositeTerm {
+                    coeff: 1.0,
+                    func: ConvexFunc::Exp,
+                    arg: Affine {
+                        cols: vec![0],
+                        coeffs: vec![1.0],
+                        cst: 0.0,
+                    },
+                }],
+                rhs: 5.0,
+            }],
+        };
+        let cfg = ConvexTreeConfig::default();
+        let r = spec.solve_tree(&cfg, &opts());
+        assert_eq!(r.status, ConvexTreeStatus::Optimal, "status {:?}", r.status);
+        let inc = r.incumbent.expect("incumbent");
+        let truth = 5.0_f64.ln() + 1.0;
+        assert!((inc - truth).abs() < 1e-3, "incumbent {inc} != {truth}");
+        // Sound: the dual bound never below the true optimum (it's an UPPER bound).
+        assert!(
+            r.bound >= truth - 1e-3,
+            "UNSOUND dual bound {} < truth {truth}",
+            r.bound
         );
     }
 

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -26,6 +26,7 @@
 //! as the Python `_RootLP` root-cut path does. K1 is byte-checked against that
 //! reference so any divergence is caught.
 
+use crate::bnb::branching::Pseudocosts;
 use crate::lp::basis::{Basis, BASIC};
 use crate::lp::cover::separate_cover_csc;
 use crate::lp::crossover::LpView;
@@ -736,12 +737,15 @@ pub struct ConvexTreeResult {
     pub node_count: usize,
 }
 
-/// A worklist node: the box `(lo, hi)` and the parent's rigorous dual bound.
+/// A worklist node: the box `(lo, hi)`, the parent's rigorous dual bound, and the
+/// branching that created it — `(var, frac_at_parent, is_down)` — used to update
+/// pseudocosts once this node's own bound is known.
 struct TreeNode {
     key: f64, // best-bound priority: pop the most promising node first (max-heap).
     parent_bound: f64,
     lo: Vec<f64>,
     hi: Vec<f64>,
+    branch: Option<(usize, f64, bool)>,
 }
 impl PartialEq for TreeNode {
     fn eq(&self, other: &Self) -> bool {
@@ -882,17 +886,22 @@ impl ConvexKernelSpec {
         self.nl_rows.iter().all(|r| r.residual(x) <= oa_tol)
     }
 
-    /// The most-fractional integer column, or `None` if all are integral.
-    fn most_fractional(&self, x: &[f64], int_tol: f64) -> Option<usize> {
-        let mut best = int_tol;
+    /// The fractional integer column with the highest pseudocost score (SCIP
+    /// product rule); falls back toward most-fractional for unobserved variables
+    /// (their default pseudocost makes the score track fractionality). `None` if
+    /// all integers are integral.
+    fn select_branch(&self, x: &[f64], pcosts: &Pseudocosts, int_tol: f64) -> Option<usize> {
+        let mut best = f64::NEG_INFINITY;
         let mut bj = None;
         for (j, (&is_int, &xj)) in self.integrality.iter().zip(x.iter()).enumerate() {
             if is_int {
                 let f = xj - xj.floor();
-                let d = f.min(1.0 - f);
-                if d > best {
-                    best = d;
-                    bj = Some(j);
+                if f.min(1.0 - f) > int_tol {
+                    let s = pcosts.score(j, f);
+                    if s > best {
+                        best = s;
+                        bj = Some(j);
+                    }
                 }
             }
         }
@@ -916,6 +925,10 @@ impl ConvexKernelSpec {
         let worse = f64::NEG_INFINITY; // sense·(worst possible objective)
         let mut inc_sense = config.initial_incumbent.map(|v| sense * v).unwrap_or(worse);
         let mut incumbent_x: Vec<f64> = Vec::new();
+        // Pseudocost branching (SCIP product rule) — far fewer nodes than
+        // most-fractional. Costs are learned in the tree's own "maximize sense·bound"
+        // convention negated to a minimize (lower-bound-rising) convention.
+        let mut pcosts = Pseudocosts::new(self.n);
 
         // Root node over the FBBT-propagated global box.
         let mut root_lo = self.lb.clone();
@@ -936,6 +949,7 @@ impl ConvexKernelSpec {
             parent_bound: sense * f64::INFINITY, // sense·(trivial dual bound)
             lo: root_lo,
             hi: root_hi,
+            branch: None,
         });
 
         let mut node_count = 0usize;
@@ -1005,6 +1019,14 @@ impl ConvexKernelSpec {
                 // Uncertified node bound → cannot fathom on it, but we can still
                 // branch to make progress; treat its dual as the parent's.
             }
+            // Learn a pseudocost from the branch that created this node. In the
+            // minimize (lower-bound-rising) convention the bound is −sense·dual, so
+            // the gain of tightening = node.parent_bound − node_dual_sense ≥ 0.
+            if let Some((var, frac, is_down)) = node.branch {
+                if node_dual_sense.is_finite() && node.parent_bound.is_finite() {
+                    pcosts.update(var, -node.parent_bound, -node_dual_sense, frac, is_down);
+                }
+            }
             // Fathom by node bound.
             if inc_sense > worse
                 && node_dual_sense <= inc_sense + config.gap_tol * inc_sense.abs().max(1.0)
@@ -1022,11 +1044,12 @@ impl ConvexKernelSpec {
                 continue; // integral node → nothing to branch
             }
 
-            // Branch on the most-fractional integer.
-            let Some(j) = self.most_fractional(&r.x, config.int_tol) else {
+            // Branch on the highest pseudocost-score fractional integer.
+            let Some(j) = self.select_branch(&r.x, &pcosts, config.int_tol) else {
                 continue;
             };
             let xj = r.x[j];
+            let frac = xj - xj.floor();
             let branch_key = node_dual_sense;
             // Down child: x_j ≤ floor(x_j).
             {
@@ -1039,6 +1062,7 @@ impl ConvexKernelSpec {
                         parent_bound: node_dual_sense,
                         lo: clo,
                         hi: chi,
+                        branch: Some((j, frac, true)),
                     });
                 }
             }
@@ -1053,6 +1077,7 @@ impl ConvexKernelSpec {
                         parent_bound: node_dual_sense,
                         lo: clo,
                         hi: chi,
+                        branch: Some((j, frac, false)),
                     });
                 }
             }

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -26,6 +26,9 @@
 //! as the Python `_RootLP` root-cut path does. K1 is byte-checked against that
 //! reference so any divergence is caught.
 
+use crate::lp::cover::separate_cover_csc;
+use crate::lp::cut_select::select_cuts;
+use crate::lp::gomory::{separate_gomory_cols, GomoryCut};
 use crate::lp::simplex::refine::ns_safe_bound_csc;
 use crate::lp::simplex::sparse::SparseCols;
 use crate::lp::simplex::{primal::solve_lp_cols_scaled, LpStatus, SimplexOptions};
@@ -344,7 +347,8 @@ impl ConvexKernelSpec {
     /// in-house simplex. Returns the rigorous dual bound in the model's sense.
     ///
     /// `oa_tol`: nonlinear-residual tolerance to add a tangent. `max_oa_rounds`:
-    /// safety cap on the OA loop.
+    /// safety cap on the OA loop. This is the K1 (OA-only) node relaxation — no
+    /// integrality separation. See [`solve_node_cut`](Self::solve_node_cut) for K2.
     pub fn solve_node(
         &self,
         lo: &[f64],
@@ -353,24 +357,59 @@ impl ConvexKernelSpec {
         max_oa_rounds: usize,
         opts: &SimplexOptions,
     ) -> ConvexNodeResult {
+        let mut tangents: Vec<LinRow> = Vec::new();
+        let oc = self.oa_converge(lo, hi, &[], &mut tangents, oa_tol, max_oa_rounds, opts);
+        ConvexNodeResult {
+            status: oc.status,
+            bound: oc.bound,
+            raw_bound: oc.raw_bound,
+            x: oc.x,
+            oa_rounds: oc.rounds,
+            n_tangents: tangents.len(),
+        }
+    }
+
+    /// Run the OA relaxation to convergence over `(lo, hi)` with the given
+    /// accumulated integrality `cuts` (structural `≤` rows). Appends fresh OA
+    /// tangents to `tangents` in place. Returns the final assembled LP state
+    /// (for separation) alongside the rigorous bound.
+    #[allow(clippy::too_many_arguments)]
+    fn oa_converge(
+        &self,
+        lo: &[f64],
+        hi: &[f64],
+        cuts: &[LinRow],
+        tangents: &mut Vec<LinRow>,
+        oa_tol: f64,
+        max_oa_rounds: usize,
+        opts: &SimplexOptions,
+    ) -> OaOutcome {
         debug_assert_eq!(lo.len(), self.n);
         debug_assert_eq!(hi.len(), self.n);
-        // Objective: minimize c·x (min sense) or −c·x (max sense).
         let sign = if self.sense_max { -1.0 } else { 1.0 };
-
-        let mut tangents: Vec<LinRow> = Vec::new();
         let mut last_x = vec![0.0f64; self.n];
-        let mut status = LpStatus::Optimal;
-        let mut bound = f64::NEG_INFINITY;
-        let mut raw_bound = f64::NEG_INFINITY;
         let mut rounds = 0usize;
+        let trivial = if self.sense_max {
+            f64::INFINITY
+        } else {
+            f64::NEG_INFINITY
+        };
+        let mut last_bound = trivial;
+        let mut last_raw = trivial;
 
         for _ in 0..max_oa_rounds.max(1) {
             rounds += 1;
-            // Build the row list: ≤ (linear + tangents), then = rows.
-            let mut rows: Vec<AsmRow> =
-                Vec::with_capacity(self.le_rows.len() + tangents.len() + self.eq_rows.len());
-            for r in self.le_rows.iter().chain(tangents.iter()) {
+            // ≤ rows: original linear, then OA tangents, then integrality cuts;
+            // then = rows. Original le rows stay first (cover's `n_orig_rows`).
+            let mut rows: Vec<AsmRow> = Vec::with_capacity(
+                self.le_rows.len() + tangents.len() + cuts.len() + self.eq_rows.len(),
+            );
+            for r in self
+                .le_rows
+                .iter()
+                .chain(tangents.iter())
+                .chain(cuts.iter())
+            {
                 rows.push(AsmRow {
                     cols: r.cols.clone(),
                     coeffs: r.coeffs.clone(),
@@ -392,52 +431,38 @@ impl ConvexKernelSpec {
                 *cj = sign * sc;
             }
             let sol = solve_lp_cols_scaled(sp.clone(), m, n_total, &c, &l, &u, &b, opts);
-            status = sol.status;
-            if status != LpStatus::Optimal {
-                // Non-Optimal relaxation → return a sound model-sense sentinel that
-                // never falsely survives fathoming. Callers key off `status` and
-                // treat any non-Optimal node as "skip region".
-                //   Infeasible: the box is empty → prune. Report the WORST bound
-                //     (−inf for max / +inf for min) so it contributes nothing.
-                //   Unbounded/Numerical: no certified bound → report the trivial
-                //     bound (+inf for max / −inf for min) so it never fathoms.
-                let sentinel = match (status, self.sense_max) {
+            if sol.status != LpStatus::Optimal {
+                // Sound model-sense sentinel — never falsely survives fathoming.
+                let sentinel = match (sol.status, self.sense_max) {
                     (LpStatus::Infeasible, true) => f64::NEG_INFINITY,
                     (LpStatus::Infeasible, false) => f64::INFINITY,
                     (_, true) => f64::INFINITY,
                     (_, false) => f64::NEG_INFINITY,
                 };
-                last_x.iter_mut().for_each(|v| *v = 0.0);
-                return ConvexNodeResult {
-                    status,
+                return OaOutcome {
+                    status: sol.status,
                     bound: sentinel,
                     raw_bound: sentinel,
-                    x: last_x,
-                    oa_rounds: rounds,
-                    n_tangents: tangents.len(),
+                    x: vec![0.0; self.n],
+                    rounds,
+                    optimal: None,
                 };
             }
             last_x.copy_from_slice(&sol.x[..self.n]);
-            // Raw LP optimum in the model sense (diagnostic; never fathom on it).
-            raw_bound = sign * sol.obj;
-
-            // Rigorous safe bound on min(c·x) from the row duals; negate for sense.
+            let raw_bound = sign * sol.obj;
             let (col_ptr, row_idx, vals) = sp.raw();
             let safe_min = ns_safe_bound_csc(
                 &sol.dual, &c, col_ptr, row_idx, vals, m, n_total, &b, &l, &u,
             );
-            bound = match safe_min {
-                Some(v) => sign * v, // max: −(safe lower on −c·x) = safe upper on c·x
-                None => {
-                    if self.sense_max {
-                        f64::INFINITY
-                    } else {
-                        f64::NEG_INFINITY
-                    }
-                }
+            let bound = match safe_min {
+                Some(v) => sign * v,
+                None if self.sense_max => f64::INFINITY,
+                None => f64::NEG_INFINITY,
             };
+            last_bound = bound;
+            last_raw = raw_bound;
 
-            // Separate OA tangents for violated convex rows at this vertex.
+            // Add OA tangents for violated convex rows at this vertex.
             let mut added = false;
             for row in &self.nl_rows {
                 if row.residual(&last_x) > oa_tol {
@@ -452,19 +477,199 @@ impl ConvexKernelSpec {
                 }
             }
             if !added {
+                // Converged: return the final LP state for separation.
+                return OaOutcome {
+                    status: LpStatus::Optimal,
+                    bound,
+                    raw_bound,
+                    x: last_x,
+                    rounds,
+                    optimal: Some(Box::new(OptimalLp {
+                        sp,
+                        m,
+                        n_total,
+                        b,
+                        l,
+                        u,
+                        rows,
+                        basis: sol.basis,
+                        x_full: sol.x,
+                    })),
+                };
+            }
+        }
+        // Hit the OA round cap without converging: return the last valid safe
+        // bound (still sound — a looser relaxation optimum). No separation state,
+        // since the OA is not tight, but the bound is usable for fathoming.
+        OaOutcome {
+            status: LpStatus::Optimal,
+            bound: last_bound,
+            raw_bound: last_raw,
+            x: last_x,
+            rounds,
+            optimal: None,
+        }
+    }
+
+    /// K2: the LP-OA node relaxation WITH in-tree integrality separation. Runs
+    /// OA to convergence, then separates GMI + knapsack-cover cuts into the node
+    /// LP under efficacy×orthogonality selection, re-converging OA, up to
+    /// `max_sep_rounds`. Cuts are node-local (never shared across siblings — the
+    /// C-43 lesson) and rewritten over structural columns by substituting the
+    /// slacks `s_r = b_r − A_r·x`, so each is a valid inequality for the node's
+    /// integer-feasible set.
+    pub fn solve_node_cut(
+        &self,
+        lo: &[f64],
+        hi: &[f64],
+        oa_tol: f64,
+        max_oa_rounds: usize,
+        max_sep_rounds: usize,
+        opts: &SimplexOptions,
+    ) -> ConvexNodeResult {
+        let mut tangents: Vec<LinRow> = Vec::new();
+        let mut cuts: Vec<LinRow> = Vec::new();
+        let mut oc = self.oa_converge(lo, hi, &cuts, &mut tangents, oa_tol, max_oa_rounds, opts);
+
+        for _ in 0..max_sep_rounds {
+            let Some(opt) = oc.optimal.as_ref() else {
+                break;
+            };
+            if oc.status != LpStatus::Optimal {
                 break;
             }
+            // Integrality over the full column set: structural, then slacks (never).
+            let mut is_int_full = vec![false; opt.n_total];
+            is_int_full[..self.n].copy_from_slice(&self.integrality);
+
+            let mut raw = separate_cover_csc(
+                &opt.sp,
+                opt.n_total,
+                opt.m,
+                &opt.l,
+                &opt.u,
+                &opt.b,
+                &opt.x_full,
+                self.n,
+                &is_int_full,
+                self.le_rows.len(),
+                opts.tol,
+            );
+            raw.extend(separate_gomory_cols(
+                &opt.sp,
+                opt.m,
+                opt.n_total,
+                &opt.l,
+                &opt.u,
+                &opt.b,
+                &opt.basis,
+                &is_int_full,
+                opts.tol,
+                1e7,
+            ));
+            if raw.is_empty() {
+                break;
+            }
+            let selected = select_cuts(raw, &opt.x_full, 8, 1e-4, 0.90);
+            if selected.is_empty() {
+                break;
+            }
+            let mut added = 0usize;
+            for gc in &selected {
+                if let Some(lin) = substitute_slacks(gc, &opt.rows, self.n) {
+                    cuts.push(lin);
+                    added += 1;
+                }
+            }
+            if added == 0 {
+                break;
+            }
+            oc = self.oa_converge(lo, hi, &cuts, &mut tangents, oa_tol, max_oa_rounds, opts);
         }
 
         ConvexNodeResult {
-            status,
-            bound,
-            raw_bound,
-            x: last_x,
-            oa_rounds: rounds,
-            n_tangents: tangents.len(),
+            status: oc.status,
+            bound: oc.bound,
+            raw_bound: oc.raw_bound,
+            x: oc.x,
+            oa_rounds: oc.rounds,
+            n_tangents: tangents.len() + cuts.len(),
         }
     }
+}
+
+/// Final assembled LP state at OA convergence (for in-node separation).
+struct OptimalLp {
+    sp: SparseCols,
+    m: usize,
+    n_total: usize,
+    b: Vec<f64>,
+    l: Vec<f64>,
+    u: Vec<f64>,
+    rows: Vec<AsmRow>,
+    basis: crate::lp::basis::Basis,
+    x_full: Vec<f64>,
+}
+
+/// Outcome of one OA convergence run.
+struct OaOutcome {
+    status: LpStatus,
+    bound: f64,
+    raw_bound: f64,
+    x: Vec<f64>,
+    rounds: usize,
+    /// `Some` only on a converged Optimal solve — the LP state for separation.
+    optimal: Option<Box<OptimalLp>>,
+}
+
+/// Rewrite a standard-form cut `Σ coeffs·z ≥ rhs` (z = structural ‖ slacks) over
+/// structural columns only, by substituting `s_r = b_r − A_r·x` for each row's
+/// slack, then flip to `≤` form for a [`LinRow`]. Returns `None` if the resulting
+/// row is empty or non-finite. Sound: `s_r = b_r − A_r·x` is an identity on the
+/// feasible region, so the substituted structural cut holds for every
+/// integer-feasible `x` the original cut was valid for.
+fn substitute_slacks(gc: &GomoryCut, rows: &[AsmRow], n_struct: usize) -> Option<LinRow> {
+    use std::collections::BTreeMap;
+    let mut acc: BTreeMap<usize, f64> = BTreeMap::new();
+    // Structural part (≥ form).
+    for (j, &v) in gc.coeffs.iter().take(n_struct).enumerate() {
+        if v != 0.0 {
+            *acc.entry(j).or_insert(0.0) += v;
+        }
+    }
+    let mut rhs_ge = gc.rhs;
+    // Slack part: column n_struct + r corresponds to rows[r].
+    for (r, row) in rows.iter().enumerate() {
+        let cs = gc.coeffs.get(n_struct + r).copied().unwrap_or(0.0);
+        if cs == 0.0 {
+            continue;
+        }
+        rhs_ge -= cs * row.rhs;
+        for (c, v) in row.cols.iter().zip(row.coeffs.iter()) {
+            *acc.entry(*c).or_insert(0.0) -= cs * v;
+        }
+    }
+    // acc·x ≥ rhs_ge  →  (−acc)·x ≤ −rhs_ge.
+    let mut cols = Vec::with_capacity(acc.len());
+    let mut coeffs = Vec::with_capacity(acc.len());
+    for (c, v) in acc {
+        if v == 0.0 || !v.is_finite() {
+            if !v.is_finite() {
+                return None;
+            }
+            continue;
+        }
+        cols.push(c);
+        coeffs.push(-v);
+    }
+    if cols.is_empty() || !rhs_ge.is_finite() {
+        return None;
+    }
+    Some(LinRow {
+        cols,
+        coeffs,
+        rhs: -rhs_ge,
+    })
 }
 
 #[cfg(test)]
@@ -648,6 +853,61 @@ mod tests {
             truth
         );
         assert!(r.oa_rounds > 1, "OA should take several rounds");
+    }
+
+    /// K2: in-node separation tightens the LP bound toward the integer hull
+    /// WITHOUT cutting any integer-feasible point.
+    ///
+    /// `max x0+x1  s.t.  x0+x1 ≤ 1.5,  x0,x1 ∈ {0,1}`. LP relaxation optimum 1.5;
+    /// integer optimum 1. `{x0,x1}` is a knapsack cover (1+1 > 1.5) → the cover
+    /// cut `x0+x1 ≤ 1` closes the LP to exactly the integer hull.
+    #[test]
+    fn node_separation_tightens_to_integer_hull_soundly() {
+        let spec = ConvexKernelSpec {
+            n: 2,
+            c: vec![1.0, 1.0],
+            sense_max: true,
+            integrality: vec![true, true],
+            lb: vec![0.0, 0.0],
+            ub: vec![1.0, 1.0],
+            le_rows: vec![LinRow {
+                cols: vec![0, 1],
+                coeffs: vec![1.0, 1.0],
+                rhs: 1.5,
+            }],
+            eq_rows: vec![],
+            nl_rows: vec![],
+        };
+        // K1 (no separation): the LP relaxation bound is 1.5.
+        let r0 = spec.solve_node(&[0.0, 0.0], &[1.0, 1.0], 1e-9, 10, &opts());
+        assert_eq!(r0.status, LpStatus::Optimal);
+        assert!(
+            (r0.bound - 1.5).abs() < 1e-6,
+            "no-sep bound {} != 1.5",
+            r0.bound
+        );
+        // K2 (with separation): the cover cut closes it to the integer hull, 1.0.
+        let r1 = spec.solve_node_cut(&[0.0, 0.0], &[1.0, 1.0], 1e-9, 10, 8, &opts());
+        assert_eq!(r1.status, LpStatus::Optimal);
+        // Strictly tighter than the un-cut relaxation ...
+        assert!(
+            r1.bound < 1.5 - 1e-6,
+            "separation did not tighten: {}",
+            r1.bound
+        );
+        // ... reaches the integer hull ...
+        assert!(
+            r1.bound <= 1.0 + 1e-6,
+            "bound {} did not reach hull 1.0",
+            r1.bound
+        );
+        // ... and is SOUND: never below the true integer optimum (a cut that
+        // removed an integer-feasible point would push the bound under 1.0).
+        assert!(
+            r1.bound >= 1.0 - 1e-6,
+            "UNSOUND: bound {} < integer optimum 1.0",
+            r1.bound
+        );
     }
 
     /// K1c: a linear-only node reproduces the LP optimum exactly (no OA rounds

--- a/crates/discopt-core/src/bnb/mod.rs
+++ b/crates/discopt-core/src/bnb/mod.rs
@@ -1,6 +1,7 @@
 //! Branch-and-Bound engine — node pool, branching, pruning.
 
 pub mod branching;
+pub mod convex_kernel;
 pub mod in_tree_presolve;
 pub mod mccormick_patch;
 pub mod milp_driver;

--- a/crates/discopt-python/src/convex_bindings.rs
+++ b/crates/discopt-python/src/convex_bindings.rs
@@ -1,8 +1,9 @@
-//! PyO3 binding for the convex LP-OA branch-and-cut kernel node relaxation
-//! (`discopt_core::bnb::convex_kernel`, issue #798 / K1). The Python producer
+//! PyO3 bindings for the convex LP-OA branch-and-cut kernel
+//! (`discopt_core::bnb::convex_kernel`, issue #798). The Python producer
 //! decomposes each convex nonlinear row into composite-of-affine form once and
-//! hands the flat arrays over; Rust builds a `ConvexKernelSpec` and solves the
-//! LP-OA node relaxation over a box (K1d byte-check gate against `_RootLP`).
+//! hands the flat arrays over; Rust builds a `ConvexKernelSpec` and either solves
+//! one node relaxation (`solve_convex_node_py`, the K1 byte-check) or runs the
+//! whole best-bound branch-and-cut tree (`solve_convex_tree_py`, K2+).
 //!
 //! ## Marshaling schema (all int arrays are i64, float arrays f64)
 //!
@@ -22,13 +23,15 @@
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 
 use discopt_core::bnb::convex_kernel::{
-    Affine, CompositeTerm, ConvexFunc, ConvexKernelSpec, ConvexRow, LinRow,
+    Affine, CompositeTerm, ConvexFunc, ConvexKernelSpec, ConvexRow, ConvexTreeConfig,
+    ConvexTreeStatus, LinRow,
 };
 use discopt_core::lp::simplex::{LpStatus, SimplexOptions};
 use numpy::{PyArray1, PyReadonlyArray1};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use std::time::{Duration, Instant};
 
 fn func_from_code(code: i64) -> PyResult<ConvexFunc> {
     Ok(match code {
@@ -78,11 +81,142 @@ fn build_lin_rows(ptr: &[i64], cols: &[i64], coeffs: &[f64], rhs: &[f64]) -> PyR
     Ok(out)
 }
 
-/// Solve one convex LP-OA node relaxation over the box `(lo, hi)`.
+/// The full flat-array bundle (all the marshaled arrays) shared by both bindings.
+struct SpecArrays<'py> {
+    n: usize,
+    sense_max: bool,
+    c: PyReadonlyArray1<'py, f64>,
+    integrality: PyReadonlyArray1<'py, i64>,
+    lo: PyReadonlyArray1<'py, f64>,
+    hi: PyReadonlyArray1<'py, f64>,
+    le_row_ptr: PyReadonlyArray1<'py, i64>,
+    le_cols: PyReadonlyArray1<'py, i64>,
+    le_coeffs: PyReadonlyArray1<'py, f64>,
+    le_rhs: PyReadonlyArray1<'py, f64>,
+    eq_row_ptr: PyReadonlyArray1<'py, i64>,
+    eq_cols: PyReadonlyArray1<'py, i64>,
+    eq_coeffs: PyReadonlyArray1<'py, f64>,
+    eq_rhs: PyReadonlyArray1<'py, f64>,
+    nl_rhs: PyReadonlyArray1<'py, f64>,
+    nl_lin_const: PyReadonlyArray1<'py, f64>,
+    nl_lin_ptr: PyReadonlyArray1<'py, i64>,
+    nl_lin_cols: PyReadonlyArray1<'py, i64>,
+    nl_lin_coeffs: PyReadonlyArray1<'py, f64>,
+    nl_term_ptr: PyReadonlyArray1<'py, i64>,
+    term_coeff: PyReadonlyArray1<'py, f64>,
+    term_func: PyReadonlyArray1<'py, i64>,
+    term_arg_const: PyReadonlyArray1<'py, f64>,
+    term_arg_ptr: PyReadonlyArray1<'py, i64>,
+    term_arg_cols: PyReadonlyArray1<'py, i64>,
+    term_arg_coeffs: PyReadonlyArray1<'py, f64>,
+}
+
+impl SpecArrays<'_> {
+    /// Validate and build the `ConvexKernelSpec` (`lb/ub` from `lo/hi`).
+    fn build(&self) -> PyResult<ConvexKernelSpec> {
+        let c = self.c.as_slice()?;
+        let integrality = self.integrality.as_slice()?;
+        let lo = self.lo.as_slice()?;
+        let hi = self.hi.as_slice()?;
+        let n = self.n;
+        if c.len() != n || integrality.len() != n || lo.len() != n || hi.len() != n {
+            return Err(PyValueError::new_err(
+                "c / integrality / lo / hi must all have length n",
+            ));
+        }
+        let le_rows = build_lin_rows(
+            self.le_row_ptr.as_slice()?,
+            self.le_cols.as_slice()?,
+            self.le_coeffs.as_slice()?,
+            self.le_rhs.as_slice()?,
+        )?;
+        let eq_rows = build_lin_rows(
+            self.eq_row_ptr.as_slice()?,
+            self.eq_cols.as_slice()?,
+            self.eq_coeffs.as_slice()?,
+            self.eq_rhs.as_slice()?,
+        )?;
+
+        let nl_rhs = self.nl_rhs.as_slice()?;
+        let nl_lin_const = self.nl_lin_const.as_slice()?;
+        let nl_lin_ptr = self.nl_lin_ptr.as_slice()?;
+        let nl_lin_cols = self.nl_lin_cols.as_slice()?;
+        let nl_lin_coeffs = self.nl_lin_coeffs.as_slice()?;
+        let nl_term_ptr = self.nl_term_ptr.as_slice()?;
+        let term_coeff = self.term_coeff.as_slice()?;
+        let term_func = self.term_func.as_slice()?;
+        let term_arg_const = self.term_arg_const.as_slice()?;
+        let term_arg_ptr = self.term_arg_ptr.as_slice()?;
+        let term_arg_cols = self.term_arg_cols.as_slice()?;
+        let term_arg_coeffs = self.term_arg_coeffs.as_slice()?;
+        let n_nl = nl_rhs.len();
+        if nl_lin_const.len() != n_nl
+            || nl_lin_ptr.len() != n_nl + 1
+            || nl_term_ptr.len() != n_nl + 1
+        {
+            return Err(PyValueError::new_err(
+                "nl per-row arrays must have length n_nl (ptrs n_nl+1)",
+            ));
+        }
+        let mut nl_rows = Vec::with_capacity(n_nl);
+        for i in 0..n_nl {
+            let (lc, lk) = csr_row(nl_lin_ptr, nl_lin_cols, nl_lin_coeffs, i)?;
+            let lin = Affine {
+                cols: lc,
+                coeffs: lk,
+                cst: nl_lin_const[i],
+            };
+            let (ts, te) = (nl_term_ptr[i] as usize, nl_term_ptr[i + 1] as usize);
+            if ts > te || te > term_coeff.len() {
+                return Err(PyValueError::new_err("nl_term_ptr out of range"));
+            }
+            let mut terms = Vec::with_capacity(te - ts);
+            for t in ts..te {
+                let (ac, ak) = csr_row(term_arg_ptr, term_arg_cols, term_arg_coeffs, t)?;
+                terms.push(CompositeTerm {
+                    coeff: term_coeff[t],
+                    func: func_from_code(term_func[t])?,
+                    arg: Affine {
+                        cols: ac,
+                        coeffs: ak,
+                        cst: term_arg_const[t],
+                    },
+                });
+            }
+            nl_rows.push(ConvexRow {
+                lin,
+                terms,
+                rhs: nl_rhs[i],
+            });
+        }
+        Ok(ConvexKernelSpec {
+            n,
+            c: c.to_vec(),
+            sense_max: self.sense_max,
+            integrality: integrality.iter().map(|&v| v != 0).collect(),
+            lb: lo.to_vec(),
+            ub: hi.to_vec(),
+            le_rows,
+            eq_rows,
+            nl_rows,
+        })
+    }
+}
+
+fn lp_status_str(s: LpStatus) -> &'static str {
+    match s {
+        LpStatus::Optimal => "optimal",
+        LpStatus::Infeasible => "infeasible",
+        LpStatus::Unbounded => "unbounded",
+        LpStatus::IterLimit => "iter_limit",
+        LpStatus::Numerical => "numerical",
+    }
+}
+
+/// Solve one convex LP-OA node relaxation over the box `(lo, hi)` (K1 byte-check).
 ///
-/// Returns a dict: `status` ("optimal"|"infeasible"|"unbounded"|"iter_limit"|
-/// "numerical"), `bound` (rigorous dual bound in the model's sense), `x`
-/// (structural primal, length `n`), `oa_rounds`, `n_tangents`.
+/// Returns `{status, bound (NS safe), raw_bound (LP optimum), x, oa_rounds,
+/// n_tangents}`.
 #[pyfunction]
 #[pyo3(signature = (
     n, c, integrality, lo, hi, sense_max,
@@ -90,7 +224,7 @@ fn build_lin_rows(ptr: &[i64], cols: &[i64], coeffs: &[f64], rhs: &[f64]) -> PyR
     eq_row_ptr, eq_cols, eq_coeffs, eq_rhs,
     nl_rhs, nl_lin_const, nl_lin_ptr, nl_lin_cols, nl_lin_coeffs, nl_term_ptr,
     term_coeff, term_func, term_arg_const, term_arg_ptr, term_arg_cols, term_arg_coeffs,
-    oa_tol=1e-6, max_oa_rounds=60, expel_zero_artificials=true,
+    oa_tol=1e-6, max_oa_rounds=60, max_sep_rounds=0, expel_zero_artificials=true,
 ))]
 pub fn solve_convex_node_py<'py>(
     py: Python<'py>,
@@ -122,114 +256,167 @@ pub fn solve_convex_node_py<'py>(
     term_arg_coeffs: PyReadonlyArray1<'py, f64>,
     oa_tol: f64,
     max_oa_rounds: usize,
+    max_sep_rounds: usize,
     expel_zero_artificials: bool,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let c = c.as_slice()?;
-    let integrality = integrality.as_slice()?;
-    let lo = lo.as_slice()?;
-    let hi = hi.as_slice()?;
-    if c.len() != n || integrality.len() != n || lo.len() != n || hi.len() != n {
-        return Err(PyValueError::new_err(
-            "c / integrality / lo / hi must all have length n",
-        ));
-    }
-
-    let le_rows = build_lin_rows(
-        le_row_ptr.as_slice()?,
-        le_cols.as_slice()?,
-        le_coeffs.as_slice()?,
-        le_rhs.as_slice()?,
-    )?;
-    let eq_rows = build_lin_rows(
-        eq_row_ptr.as_slice()?,
-        eq_cols.as_slice()?,
-        eq_coeffs.as_slice()?,
-        eq_rhs.as_slice()?,
-    )?;
-
-    // Nonlinear rows.
-    let nl_rhs = nl_rhs.as_slice()?;
-    let nl_lin_const = nl_lin_const.as_slice()?;
-    let nl_lin_ptr = nl_lin_ptr.as_slice()?;
-    let nl_lin_cols = nl_lin_cols.as_slice()?;
-    let nl_lin_coeffs = nl_lin_coeffs.as_slice()?;
-    let nl_term_ptr = nl_term_ptr.as_slice()?;
-    let term_coeff = term_coeff.as_slice()?;
-    let term_func = term_func.as_slice()?;
-    let term_arg_const = term_arg_const.as_slice()?;
-    let term_arg_ptr = term_arg_ptr.as_slice()?;
-    let term_arg_cols = term_arg_cols.as_slice()?;
-    let term_arg_coeffs = term_arg_coeffs.as_slice()?;
-    let n_nl = nl_rhs.len();
-    if nl_lin_const.len() != n_nl || nl_lin_ptr.len() != n_nl + 1 || nl_term_ptr.len() != n_nl + 1 {
-        return Err(PyValueError::new_err(
-            "nl per-row arrays must have length n_nl (ptrs n_nl+1)",
-        ));
-    }
-
-    let mut nl_rows = Vec::with_capacity(n_nl);
-    for i in 0..n_nl {
-        let (lc, lk) = csr_row(nl_lin_ptr, nl_lin_cols, nl_lin_coeffs, i)?;
-        let lin = Affine {
-            cols: lc,
-            coeffs: lk,
-            cst: nl_lin_const[i],
-        };
-        let (ts, te) = (nl_term_ptr[i] as usize, nl_term_ptr[i + 1] as usize);
-        if ts > te || te > term_coeff.len() {
-            return Err(PyValueError::new_err("nl_term_ptr out of range"));
-        }
-        let mut terms = Vec::with_capacity(te - ts);
-        for t in ts..te {
-            let (ac, ak) = csr_row(term_arg_ptr, term_arg_cols, term_arg_coeffs, t)?;
-            terms.push(CompositeTerm {
-                coeff: term_coeff[t],
-                func: func_from_code(term_func[t])?,
-                arg: Affine {
-                    cols: ac,
-                    coeffs: ak,
-                    cst: term_arg_const[t],
-                },
-            });
-        }
-        nl_rows.push(ConvexRow {
-            lin,
-            terms,
-            rhs: nl_rhs[i],
-        });
-    }
-
-    let spec = ConvexKernelSpec {
+    let arrays = SpecArrays {
         n,
-        c: c.to_vec(),
         sense_max,
-        integrality: integrality.iter().map(|&v| v != 0).collect(),
-        lb: lo.to_vec(),
-        ub: hi.to_vec(),
-        le_rows,
-        eq_rows,
-        nl_rows,
+        c,
+        integrality,
+        lo,
+        hi,
+        le_row_ptr,
+        le_cols,
+        le_coeffs,
+        le_rhs,
+        eq_row_ptr,
+        eq_cols,
+        eq_coeffs,
+        eq_rhs,
+        nl_rhs,
+        nl_lin_const,
+        nl_lin_ptr,
+        nl_lin_cols,
+        nl_lin_coeffs,
+        nl_term_ptr,
+        term_coeff,
+        term_func,
+        term_arg_const,
+        term_arg_ptr,
+        term_arg_cols,
+        term_arg_coeffs,
     };
-
+    let spec = arrays.build()?;
+    let lo = arrays.lo.as_slice()?;
+    let hi = arrays.hi.as_slice()?;
     let opts = SimplexOptions {
         expel_zero_artificials,
         ..Default::default()
     };
-    let res = spec.solve_node(lo, hi, oa_tol, max_oa_rounds, &opts);
-
-    let status = match res.status {
-        LpStatus::Optimal => "optimal",
-        LpStatus::Infeasible => "infeasible",
-        LpStatus::Unbounded => "unbounded",
-        LpStatus::IterLimit => "iter_limit",
-        LpStatus::Numerical => "numerical",
+    let res = if max_sep_rounds > 0 {
+        spec.solve_node_cut(lo, hi, oa_tol, max_oa_rounds, max_sep_rounds, &opts)
+    } else {
+        spec.solve_node(lo, hi, oa_tol, max_oa_rounds, &opts)
     };
     let out = PyDict::new(py);
-    out.set_item("status", status)?;
+    out.set_item("status", lp_status_str(res.status))?;
     out.set_item("bound", res.bound)?;
     out.set_item("raw_bound", res.raw_bound)?;
     out.set_item("x", PyArray1::from_slice(py, &res.x))?;
     out.set_item("oa_rounds", res.oa_rounds)?;
     out.set_item("n_tangents", res.n_tangents)?;
+    Ok(out)
+}
+
+/// Run the full convex LP-OA branch-and-cut tree (K2). Returns
+/// `{status, incumbent, incumbent_x, bound, node_count}`.
+#[pyfunction]
+#[pyo3(signature = (
+    n, c, integrality, lo, hi, sense_max,
+    le_row_ptr, le_cols, le_coeffs, le_rhs,
+    eq_row_ptr, eq_cols, eq_coeffs, eq_rhs,
+    nl_rhs, nl_lin_const, nl_lin_ptr, nl_lin_cols, nl_lin_coeffs, nl_term_ptr,
+    term_coeff, term_func, term_arg_const, term_arg_ptr, term_arg_cols, term_arg_coeffs,
+    max_nodes=100_000, gap_tol=1e-4, int_tol=1e-5, oa_tol=1e-6,
+    max_oa_rounds=60, max_sep_rounds=12, fbbt_rounds=20,
+    initial_incumbent=None, time_limit_s=None,
+))]
+pub fn solve_convex_tree_py<'py>(
+    py: Python<'py>,
+    n: usize,
+    c: PyReadonlyArray1<'py, f64>,
+    integrality: PyReadonlyArray1<'py, i64>,
+    lo: PyReadonlyArray1<'py, f64>,
+    hi: PyReadonlyArray1<'py, f64>,
+    sense_max: bool,
+    le_row_ptr: PyReadonlyArray1<'py, i64>,
+    le_cols: PyReadonlyArray1<'py, i64>,
+    le_coeffs: PyReadonlyArray1<'py, f64>,
+    le_rhs: PyReadonlyArray1<'py, f64>,
+    eq_row_ptr: PyReadonlyArray1<'py, i64>,
+    eq_cols: PyReadonlyArray1<'py, i64>,
+    eq_coeffs: PyReadonlyArray1<'py, f64>,
+    eq_rhs: PyReadonlyArray1<'py, f64>,
+    nl_rhs: PyReadonlyArray1<'py, f64>,
+    nl_lin_const: PyReadonlyArray1<'py, f64>,
+    nl_lin_ptr: PyReadonlyArray1<'py, i64>,
+    nl_lin_cols: PyReadonlyArray1<'py, i64>,
+    nl_lin_coeffs: PyReadonlyArray1<'py, f64>,
+    nl_term_ptr: PyReadonlyArray1<'py, i64>,
+    term_coeff: PyReadonlyArray1<'py, f64>,
+    term_func: PyReadonlyArray1<'py, i64>,
+    term_arg_const: PyReadonlyArray1<'py, f64>,
+    term_arg_ptr: PyReadonlyArray1<'py, i64>,
+    term_arg_cols: PyReadonlyArray1<'py, i64>,
+    term_arg_coeffs: PyReadonlyArray1<'py, f64>,
+    max_nodes: usize,
+    gap_tol: f64,
+    int_tol: f64,
+    oa_tol: f64,
+    max_oa_rounds: usize,
+    max_sep_rounds: usize,
+    fbbt_rounds: usize,
+    initial_incumbent: Option<f64>,
+    time_limit_s: Option<f64>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let arrays = SpecArrays {
+        n,
+        sense_max,
+        c,
+        integrality,
+        lo,
+        hi,
+        le_row_ptr,
+        le_cols,
+        le_coeffs,
+        le_rhs,
+        eq_row_ptr,
+        eq_cols,
+        eq_coeffs,
+        eq_rhs,
+        nl_rhs,
+        nl_lin_const,
+        nl_lin_ptr,
+        nl_lin_cols,
+        nl_lin_coeffs,
+        nl_term_ptr,
+        term_coeff,
+        term_func,
+        term_arg_const,
+        term_arg_ptr,
+        term_arg_cols,
+        term_arg_coeffs,
+    };
+    let spec = arrays.build()?;
+    let config = ConvexTreeConfig {
+        max_nodes,
+        gap_tol,
+        int_tol,
+        oa_tol,
+        max_oa_rounds,
+        max_sep_rounds,
+        fbbt_rounds,
+        deadline: time_limit_s.map(|s| Instant::now() + Duration::from_secs_f64(s.max(0.0))),
+        initial_incumbent,
+    };
+    let opts = SimplexOptions {
+        expel_zero_artificials: true,
+        ..Default::default()
+    };
+    let res = spec.solve_tree(&config, &opts);
+    let status = match res.status {
+        ConvexTreeStatus::Optimal => "optimal",
+        ConvexTreeStatus::NodeLimit => "node_limit",
+        ConvexTreeStatus::TimeLimit => "time_limit",
+        ConvexTreeStatus::Exhausted => "exhausted",
+        ConvexTreeStatus::Infeasible => "infeasible",
+    };
+    let out = PyDict::new(py);
+    out.set_item("status", status)?;
+    out.set_item("incumbent", res.incumbent)?;
+    out.set_item("incumbent_x", PyArray1::from_slice(py, &res.incumbent_x))?;
+    out.set_item("bound", res.bound)?;
+    out.set_item("node_count", res.node_count)?;
     Ok(out)
 }

--- a/crates/discopt-python/src/convex_bindings.rs
+++ b/crates/discopt-python/src/convex_bindings.rs
@@ -1,0 +1,235 @@
+//! PyO3 binding for the convex LP-OA branch-and-cut kernel node relaxation
+//! (`discopt_core::bnb::convex_kernel`, issue #798 / K1). The Python producer
+//! decomposes each convex nonlinear row into composite-of-affine form once and
+//! hands the flat arrays over; Rust builds a `ConvexKernelSpec` and solves the
+//! LP-OA node relaxation over a box (K1d byte-check gate against `_RootLP`).
+//!
+//! ## Marshaling schema (all int arrays are i64, float arrays f64)
+//!
+//! Structural: `n`, `c` (len n), `integrality` (len n), `lo`, `hi` (len n),
+//! `sense_max` (bool).
+//!
+//! Linear `≤` rows, CSR: `le_row_ptr` (len n_le+1) into `le_cols`/`le_coeffs`,
+//! `le_rhs` (len n_le). Linear `=` rows likewise via `eq_*`.
+//!
+//! Convex nonlinear `≤` rows (`g = lin + Σ coeff·func(arg) ≤ rhs`):
+//! * per row (len n_nl): `nl_rhs`, `nl_lin_const`, `nl_lin_ptr` (len n_nl+1) into
+//!   `nl_lin_cols`/`nl_lin_coeffs`, and `nl_term_ptr` (len n_nl+1) into the term
+//!   arrays.
+//! * per term (len n_terms): `term_coeff`, `term_func` (0=Log,1=Exp,2=Sqrt,
+//!   3=Log1p), `term_arg_const`, `term_arg_ptr` (len n_terms+1) into
+//!   `term_arg_cols`/`term_arg_coeffs`.
+#![allow(clippy::too_many_arguments, clippy::type_complexity)]
+
+use discopt_core::bnb::convex_kernel::{
+    Affine, CompositeTerm, ConvexFunc, ConvexKernelSpec, ConvexRow, LinRow,
+};
+use discopt_core::lp::simplex::{LpStatus, SimplexOptions};
+use numpy::{PyArray1, PyReadonlyArray1};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+fn func_from_code(code: i64) -> PyResult<ConvexFunc> {
+    Ok(match code {
+        0 => ConvexFunc::Log,
+        1 => ConvexFunc::Exp,
+        2 => ConvexFunc::Sqrt,
+        3 => ConvexFunc::Log1p,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "unknown term_func code {other} (0=Log,1=Exp,2=Sqrt,3=Log1p)"
+            )))
+        }
+    })
+}
+
+/// Build a CSR row's `(cols, coeffs)` slice, validating pointer ranges.
+fn csr_row(
+    ptr: &[i64],
+    cols: &[i64],
+    coeffs: &[f64],
+    r: usize,
+) -> PyResult<(Vec<usize>, Vec<f64>)> {
+    let s = ptr[r] as usize;
+    let e = ptr[r + 1] as usize;
+    if s > e || e > cols.len() || e > coeffs.len() {
+        return Err(PyValueError::new_err("CSR pointer out of range"));
+    }
+    Ok((
+        cols[s..e].iter().map(|&v| v as usize).collect(),
+        coeffs[s..e].to_vec(),
+    ))
+}
+
+fn build_lin_rows(ptr: &[i64], cols: &[i64], coeffs: &[f64], rhs: &[f64]) -> PyResult<Vec<LinRow>> {
+    if ptr.len() != rhs.len() + 1 {
+        return Err(PyValueError::new_err("row_ptr must have length n_rows+1"));
+    }
+    let mut out = Vec::with_capacity(rhs.len());
+    for r in 0..rhs.len() {
+        let (c, k) = csr_row(ptr, cols, coeffs, r)?;
+        out.push(LinRow {
+            cols: c,
+            coeffs: k,
+            rhs: rhs[r],
+        });
+    }
+    Ok(out)
+}
+
+/// Solve one convex LP-OA node relaxation over the box `(lo, hi)`.
+///
+/// Returns a dict: `status` ("optimal"|"infeasible"|"unbounded"|"iter_limit"|
+/// "numerical"), `bound` (rigorous dual bound in the model's sense), `x`
+/// (structural primal, length `n`), `oa_rounds`, `n_tangents`.
+#[pyfunction]
+#[pyo3(signature = (
+    n, c, integrality, lo, hi, sense_max,
+    le_row_ptr, le_cols, le_coeffs, le_rhs,
+    eq_row_ptr, eq_cols, eq_coeffs, eq_rhs,
+    nl_rhs, nl_lin_const, nl_lin_ptr, nl_lin_cols, nl_lin_coeffs, nl_term_ptr,
+    term_coeff, term_func, term_arg_const, term_arg_ptr, term_arg_cols, term_arg_coeffs,
+    oa_tol=1e-6, max_oa_rounds=60, expel_zero_artificials=true,
+))]
+pub fn solve_convex_node_py<'py>(
+    py: Python<'py>,
+    n: usize,
+    c: PyReadonlyArray1<'py, f64>,
+    integrality: PyReadonlyArray1<'py, i64>,
+    lo: PyReadonlyArray1<'py, f64>,
+    hi: PyReadonlyArray1<'py, f64>,
+    sense_max: bool,
+    le_row_ptr: PyReadonlyArray1<'py, i64>,
+    le_cols: PyReadonlyArray1<'py, i64>,
+    le_coeffs: PyReadonlyArray1<'py, f64>,
+    le_rhs: PyReadonlyArray1<'py, f64>,
+    eq_row_ptr: PyReadonlyArray1<'py, i64>,
+    eq_cols: PyReadonlyArray1<'py, i64>,
+    eq_coeffs: PyReadonlyArray1<'py, f64>,
+    eq_rhs: PyReadonlyArray1<'py, f64>,
+    nl_rhs: PyReadonlyArray1<'py, f64>,
+    nl_lin_const: PyReadonlyArray1<'py, f64>,
+    nl_lin_ptr: PyReadonlyArray1<'py, i64>,
+    nl_lin_cols: PyReadonlyArray1<'py, i64>,
+    nl_lin_coeffs: PyReadonlyArray1<'py, f64>,
+    nl_term_ptr: PyReadonlyArray1<'py, i64>,
+    term_coeff: PyReadonlyArray1<'py, f64>,
+    term_func: PyReadonlyArray1<'py, i64>,
+    term_arg_const: PyReadonlyArray1<'py, f64>,
+    term_arg_ptr: PyReadonlyArray1<'py, i64>,
+    term_arg_cols: PyReadonlyArray1<'py, i64>,
+    term_arg_coeffs: PyReadonlyArray1<'py, f64>,
+    oa_tol: f64,
+    max_oa_rounds: usize,
+    expel_zero_artificials: bool,
+) -> PyResult<Bound<'py, PyDict>> {
+    let c = c.as_slice()?;
+    let integrality = integrality.as_slice()?;
+    let lo = lo.as_slice()?;
+    let hi = hi.as_slice()?;
+    if c.len() != n || integrality.len() != n || lo.len() != n || hi.len() != n {
+        return Err(PyValueError::new_err(
+            "c / integrality / lo / hi must all have length n",
+        ));
+    }
+
+    let le_rows = build_lin_rows(
+        le_row_ptr.as_slice()?,
+        le_cols.as_slice()?,
+        le_coeffs.as_slice()?,
+        le_rhs.as_slice()?,
+    )?;
+    let eq_rows = build_lin_rows(
+        eq_row_ptr.as_slice()?,
+        eq_cols.as_slice()?,
+        eq_coeffs.as_slice()?,
+        eq_rhs.as_slice()?,
+    )?;
+
+    // Nonlinear rows.
+    let nl_rhs = nl_rhs.as_slice()?;
+    let nl_lin_const = nl_lin_const.as_slice()?;
+    let nl_lin_ptr = nl_lin_ptr.as_slice()?;
+    let nl_lin_cols = nl_lin_cols.as_slice()?;
+    let nl_lin_coeffs = nl_lin_coeffs.as_slice()?;
+    let nl_term_ptr = nl_term_ptr.as_slice()?;
+    let term_coeff = term_coeff.as_slice()?;
+    let term_func = term_func.as_slice()?;
+    let term_arg_const = term_arg_const.as_slice()?;
+    let term_arg_ptr = term_arg_ptr.as_slice()?;
+    let term_arg_cols = term_arg_cols.as_slice()?;
+    let term_arg_coeffs = term_arg_coeffs.as_slice()?;
+    let n_nl = nl_rhs.len();
+    if nl_lin_const.len() != n_nl || nl_lin_ptr.len() != n_nl + 1 || nl_term_ptr.len() != n_nl + 1 {
+        return Err(PyValueError::new_err(
+            "nl per-row arrays must have length n_nl (ptrs n_nl+1)",
+        ));
+    }
+
+    let mut nl_rows = Vec::with_capacity(n_nl);
+    for i in 0..n_nl {
+        let (lc, lk) = csr_row(nl_lin_ptr, nl_lin_cols, nl_lin_coeffs, i)?;
+        let lin = Affine {
+            cols: lc,
+            coeffs: lk,
+            cst: nl_lin_const[i],
+        };
+        let (ts, te) = (nl_term_ptr[i] as usize, nl_term_ptr[i + 1] as usize);
+        if ts > te || te > term_coeff.len() {
+            return Err(PyValueError::new_err("nl_term_ptr out of range"));
+        }
+        let mut terms = Vec::with_capacity(te - ts);
+        for t in ts..te {
+            let (ac, ak) = csr_row(term_arg_ptr, term_arg_cols, term_arg_coeffs, t)?;
+            terms.push(CompositeTerm {
+                coeff: term_coeff[t],
+                func: func_from_code(term_func[t])?,
+                arg: Affine {
+                    cols: ac,
+                    coeffs: ak,
+                    cst: term_arg_const[t],
+                },
+            });
+        }
+        nl_rows.push(ConvexRow {
+            lin,
+            terms,
+            rhs: nl_rhs[i],
+        });
+    }
+
+    let spec = ConvexKernelSpec {
+        n,
+        c: c.to_vec(),
+        sense_max,
+        integrality: integrality.iter().map(|&v| v != 0).collect(),
+        lb: lo.to_vec(),
+        ub: hi.to_vec(),
+        le_rows,
+        eq_rows,
+        nl_rows,
+    };
+
+    let opts = SimplexOptions {
+        expel_zero_artificials,
+        ..Default::default()
+    };
+    let res = spec.solve_node(lo, hi, oa_tol, max_oa_rounds, &opts);
+
+    let status = match res.status {
+        LpStatus::Optimal => "optimal",
+        LpStatus::Infeasible => "infeasible",
+        LpStatus::Unbounded => "unbounded",
+        LpStatus::IterLimit => "iter_limit",
+        LpStatus::Numerical => "numerical",
+    };
+    let out = PyDict::new(py);
+    out.set_item("status", status)?;
+    out.set_item("bound", res.bound)?;
+    out.set_item("raw_bound", res.raw_bound)?;
+    out.set_item("x", PyArray1::from_slice(py, &res.x))?;
+    out.set_item("oa_rounds", res.oa_rounds)?;
+    out.set_item("n_tangents", res.n_tangents)?;
+    Ok(out)
+}

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -43,6 +43,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_csc_py, m)?)?;
     m.add_function(wrap_pyfunction!(convex_bindings::solve_convex_node_py, m)?)?;
+    m.add_function(wrap_pyfunction!(convex_bindings::solve_convex_tree_py, m)?)?;
     m.add_function(wrap_pyfunction!(
         spatial_bindings::solve_spatial_tree_py,
         m

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -10,6 +10,7 @@ use pyo3::prelude::*;
 
 mod batch;
 mod bnb_bindings;
+mod convex_bindings;
 mod decomp_bindings;
 mod expr_bindings;
 mod lp_bindings;
@@ -41,6 +42,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_warm_csc_py, m)?)?;
+    m.add_function(wrap_pyfunction!(convex_bindings::solve_convex_node_py, m)?)?;
     m.add_function(wrap_pyfunction!(
         spatial_bindings::solve_spatial_tree_py,
         m

--- a/discopt_benchmarks/pyproject.toml
+++ b/discopt_benchmarks/pyproject.toml
@@ -87,6 +87,7 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "C4", "SIM", "TCH"]
 # Stage 0/2 probes it extends.
 "scripts/issue781_cutmgmt_probe.py" = ["N803", "N806", "C408", "B905"]
 "scripts/issue786_intree_value_probe.py" = ["N803", "N806", "C408", "B905"]
+"scripts/issue786_lpoa_bandc_prototype.py" = ["N803", "N806", "C408", "B905"]
 
 [tool.coverage.run]
 source = ["benchmarks", "utils"]

--- a/discopt_benchmarks/results/issue786/lpoa_bandc_ablation_20260719T212513.json
+++ b/discopt_benchmarks/results/issue786/lpoa_bandc_ablation_20260719T212513.json
@@ -1,0 +1,37 @@
+{
+ "rsyn0805m": {
+  "opt": 1296.120603,
+  "cut_nodes": 67,
+  "cut_status": "feasible",
+  "nocut_nodes": 1188,
+  "nocut_status": "feasible",
+  "node_reduction": 17.73134328358209
+ },
+ "rsyn0810m": {
+  "opt": 1721.447711,
+  "cut_nodes": 60,
+  "cut_status": "feasible",
+  "nocut_nodes": 956,
+  "nocut_status": "feasible",
+  "node_reduction": 15.933333333333334
+ },
+ "rsyn0815m": {
+  "opt": 1269.925649,
+  "cut_nodes": 46,
+  "cut_status": "feasible",
+  "nocut_nodes": 835,
+  "nocut_status": "feasible",
+  "node_reduction": 18.152173913043477
+ },
+ "syn40m": {
+  "opt": 67.71325586,
+  "cut_nodes": 55,
+  "cut_status": "feasible",
+  "nocut_nodes": 816,
+  "nocut_status": "feasible",
+  "node_reduction": 14.836363636363636
+ },
+ "_summary": {
+  "median_reduction": 17.73134328358209
+ }
+}

--- a/discopt_benchmarks/scripts/issue786_lpoa_bandc_prototype.py
+++ b/discopt_benchmarks/scripts/issue786_lpoa_bandc_prototype.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python
+"""Issue #786 / #790-P1 — SCIP-aligned LP-OA branch-and-cut PROTOTYPE (convex family).
+
+The #786 entry experiment proved in-tree cutting is a real lever. This prototype
+tests the SOTA-aligned ARCHITECTURE that delivers it — the one SCIP/BARON use and
+the one the NLP-per-node path cannot: an **LP relaxation at every node, cut into
+natively**, not an NLP per node with cuts bolted on.
+
+Per node (all reusing the validated #781/#786 machinery):
+  * relaxation = linear rows + OA tangents of the convex nonlinear rows over the
+    node box, refined to OA convergence;
+  * separate GMI (tableau) + c-MIR + cover into the node LP under pooled top-K
+    selection — cheap because the relaxation is an LP;
+  * the LP optimum is the node dual bound (sound: LP ⊇ the integer-feasible set);
+  * an integer-integral, OA-tight LP vertex is a genuine feasible point -> an
+    incumbent (the LP-NLP-BB primal, minimal form: no separate NLP solve needed
+    when the vertex is already tight);
+  * branch on the most-fractional integer into two covering child boxes.
+
+Best-bound worklist; fathom by bound. Reports nodes-to-certify and wall, next to
+the current NLP-BB path (`model.solve`) on the same instances — the decision on
+whether to build the Rust LP-OA kernel (#790 P1) rests on this.
+
+Soundness: every node bound is an LP relaxation optimum over an outer
+approximation of the node's integer-feasible set (OA tangents + integrality-valid
+cuts), hence a valid dual bound; the accepted incumbent is integer-integral AND
+OA-tight (nonlinear residual <= tol), i.e. genuinely feasible, so its objective
+is a valid primal bound. Cuts are re-separated fresh per node over that node's
+box — never shared across siblings (the C-43 lesson) — so no node-scoping bug is
+possible.
+
+THROWAWAY prototype — no shipped solver code.
+"""
+
+from __future__ import annotations
+
+import heapq
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from discopt._jax.cmir_cuts import separate_cmir  # noqa: E402
+from discopt._jax.cover_cuts import separate_cover_cuts  # noqa: E402
+from issue781_cutmgmt_probe import (  # noqa: E402
+    PANEL,
+    CutPool,
+    RootModel,
+    select_cuts,
+    separate_gmi,
+    solve_lp_highs,
+)
+from issue786_intree_value_probe import child_fbbt  # noqa: E402
+
+OA_TOL = 1e-6
+CUT_VIOL_TOL = 1e-6
+INT_TOL = 1e-6
+SEP_ROUNDS = 12
+GAP_TOL = 1e-4
+MAX_NODES = 20000
+NODE_TIME = 60.0
+
+
+def node_relax(rm, lo, hi, lb_s, ub_s, separate=True):
+    """LP-OA relaxation over [lo,hi] with in-tree separation. Returns (bound, x)
+    in the LP's maximize-c'x internal sense; (None, None) if infeasible."""
+    saved = (rm.lb, rm.ub)
+    rm.lb, rm.ub = lo, hi
+    try:
+        ca, cb = [], []
+        pool = CutPool()
+
+        def oa():
+            obj, x, duals, h, _n = solve_lp_highs(rm, ca, cb)
+            for _ in range(60):
+                if x is None:
+                    break
+                added = 0
+                for i, v in rm.nonlinear_violation(x).items():
+                    if v > OA_TOL:
+                        t = rm.oa_tangent(i, x)
+                        if t is not None:
+                            ca.append(t[0])
+                            cb.append(t[1])
+                            added += 1
+                if not added:
+                    break
+                obj, x, duals, h, _n = solve_lp_highs(rm, ca, cb)
+            return obj, x, duals, h
+
+        obj, x, duals, h = oa()
+        if x is None:
+            return None, None
+        if separate:
+            for _ in range(SEP_ROUNDS):
+                a_all = np.vstack([rm.A_le] + ([np.array(ca)] if ca else []))
+                b_all = np.concatenate([rm.b_le] + ([np.array(cb)] if cb else []))
+                cands = list(
+                    separate_cmir(a_all, b_all, x, lb_s, ub_s, rm.is_int, max_cuts=24, duals=duals)
+                )
+                for cover, rhs in separate_cover_cuts(a_all, b_all, x, rm.is_bin, max_cuts=32):
+                    arr = np.zeros(rm.n)
+                    arr[list(cover)] = 1.0
+                    cands.append((arr, float(rhs)))
+                if h is not None:
+                    cands += separate_gmi(rm, h, x, a_all, b_all, rm.A_eq.shape[0])
+                for arr, r in cands:
+                    arr = np.asarray(arr, float)
+                    if arr @ x - float(r) > CUT_VIOL_TOL:
+                        pool.offer(arr, float(r))
+                chosen = select_cuts(pool.violated(x), x)
+                if not chosen:
+                    break
+                for arr, r in chosen:
+                    ca.append(arr)
+                    cb.append(r)
+                obj, x, duals, h = oa()
+                if x is None:
+                    return None, None
+        return obj, x
+    finally:
+        rm.lb, rm.ub = saved
+
+
+def integer_and_tight(rm, x):
+    """Is x integer-integral on all int vars AND OA-tight (feasible)?"""
+    for j in range(rm.n):
+        if rm.is_int[j] and abs(x[j] - round(x[j])) > INT_TOL:
+            return False
+    return all(v <= 1e-5 for v in rm.nonlinear_violation(x).values())
+
+
+def most_fractional(rm, x):
+    best, bj = INT_TOL, None
+    for j in range(rm.n):
+        if rm.is_int[j]:
+            f = abs(x[j] - round(x[j]))
+            if min(f, 1 - f) > best:
+                best, bj = min(f, 1 - f), j
+    return bj
+
+
+def solve_lpoa_bandc(rm, opt, seed_incumbent=None, separate=True):
+    """Best-bound LP-OA branch-and-cut. Returns dict with status/bound/incumbent/nodes.
+
+    ``seed_incumbent``: start the search with a known feasible objective (e.g. the
+    oracle optimum) so the measurement isolates the DUAL side — nodes-to-certify,
+    which in-tree cutting drives — from the primal (a separate, solvable concern:
+    SCIP uses rounding/diving/RENS to find incumbents, out of scope for this
+    architecture probe). With the optimum seeded, nodes-to-certify = how many
+    nodes the LP-OA B&C tree needs to PROVE optimality. ``separate=False`` runs
+    the same tree WITHOUT in-tree cutting (OA-only node bounds) — the ablation
+    that isolates the cutting's contribution to the tree size."""
+    lb_s = np.where(np.isfinite(rm.lb_sep), rm.lb_sep, 0.0)
+    ub_s = np.where(np.isfinite(np.minimum(rm.ub, rm.ub_sep)), np.minimum(rm.ub, rm.ub_sep), 1e5)
+    # maximize: LP bound is an UPPER bound; incumbent is a LOWER bound.
+    incumbent = -np.inf if seed_incumbent is None else float(seed_incumbent)
+    first_inc_node = None
+    # heap of (-upper_bound, tie, lo, hi): pop the node with the LARGEST upper
+    # bound first (best-bound for maximize).
+    tie = 0
+    root_b, root_x = node_relax(rm, rm.lb.copy(), rm.ub.copy(), lb_s, ub_s, separate)
+    if root_x is None:
+        return dict(status="infeasible", nodes=0)
+    heap = [(-root_b, tie, rm.lb.copy(), rm.ub.copy(), root_b, root_x)]
+    nodes = 0
+    t0 = time.time()
+    global_ub = root_b
+    while heap:
+        if nodes >= MAX_NODES or time.time() - t0 > NODE_TIME:
+            break
+        neg_pb, _, lo, hi, nb, nx = heapq.heappop(heap)
+        pb = -neg_pb
+        # global upper bound = max pb over frontier (heap top) — but we popped it;
+        # recompute from remaining frontier + this node.
+        global_ub = max([pb] + [-h[0] for h in heap]) if heap else pb
+        if pb <= incumbent + GAP_TOL * max(1.0, abs(incumbent)):
+            continue  # fathom: cannot beat incumbent
+        nodes += 1
+        # (nb, nx) are this node's relaxation from when it was created; re-use.
+        x = nx
+        if integer_and_tight(rm, x):
+            if nb > incumbent:
+                incumbent = nb
+                if first_inc_node is None:
+                    first_inc_node = nodes
+            continue
+        j = most_fractional(rm, x)
+        if j is None:
+            continue
+        for lo2, hi2 in (
+            (lo.copy(), _seti(hi, j, np.floor(x[j]))),
+            (_seti(lo, j, np.ceil(x[j])), hi.copy()),
+        ):
+            lo2, hi2 = child_fbbt(rm, lo2, hi2)
+            if np.any(lo2 > hi2 + 1e-9):
+                continue
+            cb2, cx2 = node_relax(rm, lo2, hi2, lb_s, ub_s, separate)
+            if cx2 is None:
+                continue
+            cb2 = min(cb2, pb)  # child bound inherits parent (tighter of the two)
+            if cb2 <= incumbent + GAP_TOL * max(1.0, abs(incumbent)):
+                continue
+            tie += 1
+            heapq.heappush(heap, (-cb2, tie, lo2, hi2, cb2, cx2))
+    wall = time.time() - t0
+    # final global upper bound
+    global_ub = max([incumbent] + [-h[0] for h in heap]) if heap else incumbent
+    gap = abs(global_ub - incumbent) / max(1.0, abs(incumbent)) if incumbent > -np.inf else None
+    certified = incumbent > -np.inf and gap is not None and gap <= GAP_TOL
+    return dict(
+        status="optimal" if certified else ("feasible" if incumbent > -np.inf else "no_inc"),
+        bound=global_ub,
+        incumbent=None if incumbent == -np.inf else incumbent,
+        nodes=nodes,
+        wall=wall,
+        first_inc_node=first_inc_node,
+        gap=gap,
+    )
+
+
+def _seti(arr, j, v):
+    a = arr.copy()
+    a[j] = v
+    return a
+
+
+def main():
+    import discopt.modeling as dm
+
+    snap = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/")
+    report = {}
+    for name, info in PANEL.items():
+        opt = info["opt"]
+        print(f"\n===== {name} opt={opt} =====", flush=True)
+        # LP-OA branch-and-cut prototype
+        rm = RootModel(name)
+        r = solve_lpoa_bandc(rm, opt)
+        print(
+            f"  LP-OA B&C: {r['status']} inc={r.get('incumbent')} bound={r.get('bound'):.3f} "
+            f"nodes={r['nodes']} wall={r['wall']:.1f}s gap={r.get('gap')}",
+            flush=True,
+        )
+        # NLP-BB baseline (current path) for comparison, same wall budget
+        os.environ["DISCOPT_NLPBB_ROOT_CUTS"] = "0"
+        t0 = time.time()
+        rb = dm.from_nl(snap + name + ".nl").solve(time_limit=NODE_TIME)
+        nlp = dict(
+            status=str(rb.status),
+            obj=rb.objective,
+            bound=rb.bound,
+            nodes=rb.node_count,
+            wall=time.time() - t0,
+            cert=bool(rb.gap_certified),
+        )
+        print(
+            f"  NLP-BB    : {nlp['status']} obj={nlp['obj']} bound={nlp['bound']} "
+            f"nodes={nlp['nodes']} wall={nlp['wall']:.1f}s cert={nlp['cert']}",
+            flush=True,
+        )
+        report[name] = dict(opt=opt, lpoa=r, nlpbb=nlp)
+    print("\n===== VERDICT (#786 / #790-P1: does LP-OA B&C beat NLP-BB?) =====")
+    lpoa_cert = sum(1 for r in report.values() if r["lpoa"].get("status") == "optimal")
+    nlp_cert = sum(1 for r in report.values() if r["nlpbb"].get("cert"))
+    print(f"  certified: LP-OA B&C {lpoa_cert}/{len(report)}  vs  NLP-BB {nlp_cert}/{len(report)}")
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    here = os.path.dirname(os.path.abspath(__file__))
+    outdir = os.path.normpath(os.path.join(here, "..", "results", "issue786"))
+    os.makedirs(outdir, exist_ok=True)
+    outp = f"{outdir}/lpoa_bandc_prototype_{stamp}.json"
+    with open(outp, "w") as f:
+        json.dump(report, f, indent=1, default=float)
+    print(f"  wrote {outp}")
+
+
+if __name__ == "__main__":
+    main()

--- a/discopt_benchmarks/scripts/issue798_convex_decompose_probe.py
+++ b/discopt_benchmarks/scripts/issue798_convex_decompose_probe.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+"""Issue #798 / K1 — analyze-once convex-row decomposition probe + producer.
+
+The convex LP-OA kernel needs Rust to evaluate g_i(x) and ∇g_i(x) at LP vertices
+discovered *during* the node loop. Rather than a full autodiff engine in Rust, K1
+marshals each convex nonlinear row as a **composite-of-affine** descriptor:
+
+    g_i(x) = a_i·x + b_i + Σ_t coeff_t · func_t( p_t·x + q_t )   ≤ rhs_i
+
+so Rust needs only closed-form univariate f/f' per MathFunc. This is the
+OA-canonical convex class SCIP linearizes this way. A row that does NOT decompose
+into this form (bilinear-in-a-convex-row, non-affine function argument, …) means
+the instance is out of scope → the analyze-once step returns None and the caller
+keeps the NLP-BB path (the sound, honest boundary, exactly like spatial_producer).
+
+THIS SCRIPT IS THE ENTRY EXPERIMENT for that architecture (CLAUDE.md §4): it
+decomposes every nonlinear row of the convex panel and VERIFIES the reconstruction
+reproduces the JAX evaluator's value AND gradient at random points to <=1e-8. If
+any row fails to decompose or the reconstruction disagrees, Architecture B is
+falsified for that instance and we learn the real structure before building Rust.
+
+Its `decompose_row` / `build_convex_spec` are the reusable producer (not throwaway):
+they emit the flat-array marshaling K1's PyO3 binding consumes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from discopt.modeling.core import (  # noqa: E402
+    BinaryOp,
+    Constant,
+    FunctionCall,
+    IndexExpression,
+    UnaryOp,
+    Variable,
+)
+from issue781_cutmgmt_probe import PANEL, RootModel  # noqa: E402
+
+# Closed-form derivatives for the univariate funcs the convex class uses. Extend
+# as new convex-certifiable funcs appear; an unknown func → row is unsupported.
+_FUNC = {
+    "log": (np.log, lambda t: 1.0 / t),
+    "exp": (np.exp, np.exp),
+    "sqrt": (np.sqrt, lambda t: 0.5 / np.sqrt(t)),
+    "log1p": (np.log1p, lambda t: 1.0 / (1.0 + t)),
+}
+
+
+class NotComposite(Exception):
+    """Row is not a composite-of-affine convex row (→ instance out of scope)."""
+
+
+def _flat_offsets(model) -> dict[int, int]:
+    """Map variable._index → starting flat column offset."""
+    off, cur = {}, 0
+    for v in model._variables:
+        off[v._index] = cur
+        cur += v.size
+    return off
+
+
+def _col_of(node, offsets: dict[int, int]) -> int:
+    """Flat column index of a scalar Variable or IndexExpression leaf."""
+    if isinstance(node, Variable):
+        if node.size != 1:
+            raise NotComposite("array variable used as scalar")
+        return offsets[node._index]
+    if isinstance(node, IndexExpression) and isinstance(node.base, Variable):
+        base = node.base
+        idx = node.index
+        if isinstance(idx, tuple):
+            flat = int(np.ravel_multi_index(idx, base.shape))
+        else:
+            flat = int(idx)
+        return offsets[base._index] + flat
+    raise NotComposite("non-variable leaf")
+
+
+class Decomp:
+    """Sum of an affine form (coeffs, const) and composite-univariate terms."""
+
+    __slots__ = ("aff", "const", "terms")
+
+    def __init__(self):
+        self.aff: dict[int, float] = {}
+        self.const: float = 0.0
+        self.terms: list[dict] = []  # {coeff, func, arg_aff: dict, arg_const}
+
+    def scale(self, k: float) -> Decomp:
+        self.const *= k
+        for c in list(self.aff):
+            self.aff[c] *= k
+        for t in self.terms:
+            t["coeff"] *= k
+        return self
+
+    def add(self, other: Decomp) -> Decomp:
+        self.const += other.const
+        for c, v in other.aff.items():
+            self.aff[c] = self.aff.get(c, 0.0) + v
+        self.terms.extend(other.terms)
+        return self
+
+
+def _as_const(node):
+    if isinstance(node, Constant) and node.value.ndim == 0:
+        return float(node.value)
+    return None
+
+
+def decompose(node, offsets) -> Decomp:
+    """Decompose an expression into affine + composite-univariate terms."""
+    d = Decomp()
+    c = _as_const(node)
+    if c is not None:
+        d.const = c
+        return d
+    if isinstance(node, (Variable, IndexExpression)):
+        d.aff[_col_of(node, offsets)] = 1.0
+        return d
+    if isinstance(node, UnaryOp):
+        if node.op == "neg":
+            return decompose(node.operand, offsets).scale(-1.0)
+        raise NotComposite(f"unary {node.op}")
+    if isinstance(node, BinaryOp):
+        if node.op == "+":
+            return decompose(node.left, offsets).add(decompose(node.right, offsets))
+        if node.op == "-":
+            return decompose(node.left, offsets).add(decompose(node.right, offsets).scale(-1.0))
+        if node.op == "*":
+            lc, rc = _as_const(node.left), _as_const(node.right)
+            if lc is not None:
+                return decompose(node.right, offsets).scale(lc)
+            if rc is not None:
+                return decompose(node.left, offsets).scale(rc)
+            raise NotComposite("bilinear product (non-constant × non-constant)")
+        if node.op == "/":
+            rc = _as_const(node.right)
+            if rc is not None and rc != 0.0:
+                return decompose(node.left, offsets).scale(1.0 / rc)
+            raise NotComposite("division by non-constant")
+        raise NotComposite(f"binary {node.op}")
+    if isinstance(node, FunctionCall):
+        if node.func_name not in _FUNC:
+            raise NotComposite(f"unsupported func {node.func_name}")
+        if len(node.args) != 1:
+            raise NotComposite(f"multi-arg func {node.func_name}")
+        arg = decompose(node.args[0], offsets)
+        if arg.terms:
+            raise NotComposite("non-affine function argument")
+        d.terms.append(
+            {"coeff": 1.0, "func": node.func_name, "arg_aff": arg.aff, "arg_const": arg.const}
+        )
+        return d
+    raise NotComposite(f"node {type(node).__name__}")
+
+
+def eval_decomp(d: Decomp, x: np.ndarray) -> float:
+    v = d.const + sum(co * x[c] for c, co in d.aff.items())
+    for t in d.terms:
+        arg = t["arg_const"] + sum(co * x[c] for c, co in t["arg_aff"].items())
+        v += t["coeff"] * _FUNC[t["func"]][0](arg)
+    return float(v)
+
+
+def grad_decomp(d: Decomp, x: np.ndarray, n: int) -> np.ndarray:
+    g = np.zeros(n)
+    for c, co in d.aff.items():
+        g[c] += co
+    for t in d.terms:
+        arg = t["arg_const"] + sum(co * x[c] for c, co in t["arg_aff"].items())
+        fp = _FUNC[t["func"]][1](arg)
+        for c, co in t["arg_aff"].items():
+            g[c] += t["coeff"] * fp * co
+    return g
+
+
+def constraint_expr(model, row_idx):
+    """The residual expression g(x) for constraint `row_idx` (form g(x) <= 0)."""
+    con = model._constraints[row_idx]
+    # discopt constraints expose the body via .expr; residual repr is `(body) <= 0`.
+    for attr in ("expr", "body", "lhs"):
+        e = getattr(con, attr, None)
+        if e is not None:
+            return e
+    raise NotComposite("cannot locate constraint expression")
+
+
+def main():
+    rng = np.random.default_rng(1)
+    all_ok = True
+    for name in PANEL:
+        rm = RootModel(name)
+        offsets = _flat_offsets(rm.model)
+        lo = np.where(np.isfinite(rm.lb), rm.lb, 0.0)
+        hi = np.where(np.isfinite(rm.ub), rm.ub, lo + 5.0)
+        n_ok, n_fail = 0, 0
+        max_gerr = max_verr = 0.0
+        fails = []
+        for i in rm.nl_rows:
+            try:
+                d = decompose(constraint_expr(rm.model, i), offsets)
+            except NotComposite as ex:
+                n_fail += 1
+                fails.append((i, str(ex)))
+                continue
+            # verify value + gradient vs JAX at random interior points
+            ok = True
+            for _ in range(5):
+                x = lo + rng.random(rm.n) * (hi - lo)
+                g_jax = float(rm.ev.evaluate_constraints(x)[i])
+                v = eval_decomp(d, x)
+                # jacobian row from JAX
+                jr = np.asarray(rm.ev.evaluate_jacobian(x)[i], float)
+                gr = grad_decomp(d, x, rm.n)
+                verr = abs(v - g_jax)
+                gerr = float(np.max(np.abs(jr - gr)))
+                max_verr = max(max_verr, verr)
+                max_gerr = max(max_gerr, gerr)
+                if verr > 1e-7 or gerr > 1e-7:
+                    ok = False
+            if ok:
+                n_ok += 1
+            else:
+                n_fail += 1
+                fails.append((i, f"recon mismatch verr={max_verr:.2e} gerr={max_gerr:.2e}"))
+        status = "OK" if n_fail == 0 else "FAIL"
+        print(
+            f"{name}: {status}  rows={len(rm.nl_rows)} decomposed={n_ok} failed={n_fail} "
+            f"max_verr={max_verr:.2e} max_gerr={max_gerr:.2e}",
+            flush=True,
+        )
+        for i, why in fails[:5]:
+            print(f"    row {i}: {why}", flush=True)
+        all_ok = all_ok and n_fail == 0
+    print(f"\nVERDICT (Architecture B composite-of-affine): {'GO' if all_ok else 'FALSIFIED'}")
+    return all_ok
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/discopt_benchmarks/scripts/issue798_convex_family_certclean.py
+++ b/discopt_benchmarks/scripts/issue798_convex_family_certclean.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+"""Issue #798 / K4 — cert-clean sweep over the convex rsyn/syn family (snapshot).
+
+Routes each instance through the soundness gate + try_convex_solve and checks the
+dual bound never sits below the MINLPLib oracle optimum (soundDual) and the
+certified objective matches it (no false optimal). Unverifiable incumbents fall
+back (sound). Graduation evidence beyond the 4-instance panel + in-repo corpus.
+"""
+
+import os
+import time
+
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+os.environ["DISCOPT_CONVEX_KERNEL"] = "1"
+import discopt.modeling as dm
+from discopt.solvers._convex_kernel import build_convex_spec, try_convex_solve
+
+snap = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/")
+solu = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu")
+oracle = {}
+for L in open(solu):
+    p = L.split()
+    if len(p) >= 3 and p[0] in ("=opt=", "=best="):
+        try:
+            oracle[p[1]] = float(p[2])
+        except ValueError:
+            pass
+cand = [
+    "rsyn0805m",
+    "rsyn0810m",
+    "rsyn0815m",
+    "rsyn0820m",
+    "rsyn0830m",
+    "syn05m",
+    "syn10m",
+    "syn20m",
+    "syn40m",
+    "syn15m",
+]
+routed = incorrect = 0
+for name in cand:
+    f = snap + name + ".nl"
+    if not os.path.exists(f):
+        print(name, "missing", flush=True)
+        continue
+    m = dm.from_nl(f)
+    if build_convex_spec(m) is None:
+        print(f"{name:10s} declined", flush=True)
+        continue
+    routed += 1
+    opt = oracle.get(name)
+    t = time.perf_counter()
+    r = try_convex_solve(m, time_limit=45)
+    dt = time.perf_counter() - t
+    if r is None:
+        print(f"{name:10s} fallback(unverified)", flush=True)
+        continue
+    bad = (
+        r.status == "optimal"
+        and opt is not None
+        and abs(r.objective - opt) > 1e-2 * max(1, abs(opt))
+    )
+    sound = opt is None or r.bound >= opt - 1e-4 * max(1, abs(opt))
+    if bad or not sound:
+        incorrect += 1
+    print(
+        f"{name:10s} {r.status:9s} obj={r.objective:.3f} bound={r.bound:.3f} opt={opt} {dt:.1f}s soundDual={sound} falseOpt={bad}",
+        flush=True,
+    )
+print(
+    f"\nCONVEX-FAMILY cert-clean: routed={routed} incorrect={incorrect}  {'PASS' if incorrect == 0 else 'FAIL'}",
+    flush=True,
+)

--- a/discopt_benchmarks/scripts/issue798_k1_bytecheck.py
+++ b/discopt_benchmarks/scripts/issue798_k1_bytecheck.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+"""Issue #798 / K1d — byte-check the Rust convex LP-OA node relaxation vs Python.
+
+The K1 GATE: on the convex panel, the Rust `solve_convex_node_py` node bound must
+match the Python reference LP-OA node relaxation to <=1e-6 over (a) the root box
+and (b) perturbed child boxes. The reference is the throwaway prototype's
+`node_relax(rm, lo, hi, ..., separate=False)` — the OA-converged LP over the box
+with NO separation (the exact relaxation K1 reproduces before K2 adds cuts).
+
+The producer `build_convex_arrays(rm, lo, hi)` marshals a RootModel + the
+composite-of-affine decomposition (issue798_convex_decompose_probe.decompose) into
+the flat arrays the PyO3 binding consumes — it is the reusable analyze-once
+producer, not throwaway.
+
+Soundness note: Python's bound is the raw HiGHS LP optimum (max c·x, a valid upper
+bound). Rust's bound is the Neumaier-Shcherbina SAFE bound (<= the true LP optimum,
+rounded down for verified soundness), so Rust <= Python is EXPECTED; the gate
+checks |Rust - Python| <= tol, i.e. the safe margin is within tolerance AND Rust
+never exceeds Python (which would be an unsound over-estimate).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import discopt._rust as _rust  # noqa: E402
+from issue781_cutmgmt_probe import PANEL, RootModel  # noqa: E402
+from issue786_lpoa_bandc_prototype import node_relax  # noqa: E402
+from issue798_convex_decompose_probe import (  # noqa: E402
+    _flat_offsets,
+    constraint_expr,
+    decompose,
+)
+
+_FUNC_CODE = {"log": 0, "exp": 1, "sqrt": 2, "log1p": 3}
+GATE_TOL = 1e-6
+
+
+def _csr_from_dense(a: np.ndarray, thresh: float = 1e-13):
+    ptr, cols, vals = [0], [], []
+    for r in range(a.shape[0]):
+        nz = np.where(np.abs(a[r]) > thresh)[0]
+        cols.extend(nz.tolist())
+        vals.extend(a[r, nz].tolist())
+        ptr.append(len(cols))
+    return (
+        np.asarray(ptr, np.int64),
+        np.asarray(cols, np.int64),
+        np.asarray(vals, float),
+    )
+
+
+def _affine_csr(items):
+    """(sorted cols, coeffs) from a {col: coeff} dict."""
+    cols = sorted(items)
+    return (
+        np.asarray(cols, np.int64),
+        np.asarray([items[c] for c in cols], float),
+    )
+
+
+def build_convex_arrays(rm: RootModel, lo: np.ndarray, hi: np.ndarray) -> dict:
+    """Marshal a RootModel node relaxation into the PyO3 flat-array schema."""
+    offsets = _flat_offsets(rm.model)
+
+    le_row_ptr, le_cols, le_coeffs = _csr_from_dense(rm.A_le)
+    le_rhs = np.asarray(rm.b_le, float)
+    eq_row_ptr, eq_cols, eq_coeffs = _csr_from_dense(rm.A_eq)
+    eq_rhs = np.asarray(rm.b_eq, float)
+
+    nl_rhs, nl_lin_const = [], []
+    nl_lin_ptr, nl_lin_cols, nl_lin_coeffs = [0], [], []
+    nl_term_ptr = [0]
+    term_coeff, term_func, term_arg_const = [], [], []
+    term_arg_ptr, term_arg_cols, term_arg_coeffs = [0], [], []
+
+    for i in rm.nl_rows:
+        d = decompose(constraint_expr(rm.model, i), offsets)  # g_i(x); constraint g_i <= 0
+        lc, lk = _affine_csr(d.aff)
+        nl_lin_cols.extend(lc.tolist())
+        nl_lin_coeffs.extend(lk.tolist())
+        nl_lin_ptr.append(len(nl_lin_cols))
+        nl_lin_const.append(d.const)
+        nl_rhs.append(0.0)
+        for t in d.terms:
+            term_coeff.append(t["coeff"])
+            term_func.append(_FUNC_CODE[t["func"]])
+            term_arg_const.append(t["arg_const"])
+            ac, ak = _affine_csr(t["arg_aff"])
+            term_arg_cols.extend(ac.tolist())
+            term_arg_coeffs.extend(ak.tolist())
+            term_arg_ptr.append(len(term_arg_cols))
+        nl_term_ptr.append(len(term_coeff))
+
+    return dict(
+        n=rm.n,
+        c=np.asarray(rm.c, float),
+        integrality=np.asarray(rm.is_int, np.int64),
+        lo=np.asarray(lo, float),
+        hi=np.asarray(hi, float),
+        sense_max=True,
+        le_row_ptr=le_row_ptr,
+        le_cols=le_cols,
+        le_coeffs=le_coeffs,
+        le_rhs=le_rhs,
+        eq_row_ptr=eq_row_ptr,
+        eq_cols=eq_cols,
+        eq_coeffs=eq_coeffs,
+        eq_rhs=eq_rhs,
+        nl_rhs=np.asarray(nl_rhs, float),
+        nl_lin_const=np.asarray(nl_lin_const, float),
+        nl_lin_ptr=np.asarray(nl_lin_ptr, np.int64),
+        nl_lin_cols=np.asarray(nl_lin_cols, np.int64),
+        nl_lin_coeffs=np.asarray(nl_lin_coeffs, float),
+        nl_term_ptr=np.asarray(nl_term_ptr, np.int64),
+        term_coeff=np.asarray(term_coeff, float),
+        term_func=np.asarray(term_func, np.int64),
+        term_arg_const=np.asarray(term_arg_const, float),
+        term_arg_ptr=np.asarray(term_arg_ptr, np.int64),
+        term_arg_cols=np.asarray(term_arg_cols, np.int64),
+        term_arg_coeffs=np.asarray(term_arg_coeffs, float),
+    )
+
+
+def rust_node_bound(rm: RootModel, lo: np.ndarray, hi: np.ndarray) -> dict:
+    arrays = build_convex_arrays(rm, lo, hi)
+    return _rust.solve_convex_node_py(**arrays, oa_tol=1e-6, max_oa_rounds=60)
+
+
+def python_node_bound(rm: RootModel, lo: np.ndarray, hi: np.ndarray):
+    lb_s = np.where(np.isfinite(rm.lb_sep), rm.lb_sep, 0.0)
+    ub_s = np.where(np.isfinite(np.minimum(rm.ub, rm.ub_sep)), np.minimum(rm.ub, rm.ub_sep), 1e5)
+    return node_relax(rm, lo.copy(), hi.copy(), lb_s, ub_s, separate=False)
+
+
+def perturbed_boxes(rm: RootModel, k: int = 3):
+    """A few child boxes: fix the first k binaries to 0 then to 1."""
+    boxes = []
+    bins = [j for j in range(rm.n) if rm.is_bin[j]][:k]
+    for j in bins:
+        for val in (0.0, 1.0):
+            lo, hi = rm.lb.copy(), rm.ub.copy()
+            lo[j] = hi[j] = val
+            boxes.append((f"x{j}={int(val)}", lo, hi))
+    return boxes
+
+
+def main() -> bool:
+    all_ok = True
+    for name in PANEL:
+        rm = RootModel(name)
+        cases = [("root", rm.lb.copy(), rm.ub.copy())] + perturbed_boxes(rm)
+        worst = 0.0
+        worst_case = ""
+        n_checked = 0
+        n_certified = 0  # boxes where the NS safe bound is finite (tree-fathomable)
+        unsound = False
+        for label, lo, hi in cases:
+            pb = python_node_bound(rm, lo, hi)
+            py_bound = pb[0] if pb is not None else None
+            rr = rust_node_bound(rm, lo, hi)
+            rs_status, rs_raw, rs_safe = rr["status"], rr["raw_bound"], rr["bound"]
+            if py_bound is None:
+                # Python relaxation infeasible/None → Rust must not be Optimal-finite.
+                if rs_status == "optimal" and np.isfinite(rs_raw):
+                    print(f"  {name}/{label}: PY None but RUST optimal {rs_raw:.6f}  MISMATCH")
+                    all_ok = False
+                continue
+            if rs_status != "optimal":
+                print(f"  {name}/{label}: PY {py_bound:.6f} but RUST {rs_status}  MISMATCH")
+                all_ok = False
+                continue
+            n_checked += 1
+            # PRIMARY GATE: the relaxation optimum must match (raw LP vs raw HiGHS).
+            gap = abs(rs_raw - py_bound)
+            if gap > worst:
+                worst, worst_case = gap, label
+            # SAFE-BOUND soundness: when it certifies (finite), it must be a valid
+            # upper bound (≤ python raw + tol); an over-estimate would be unsound.
+            if np.isfinite(rs_safe):
+                n_certified += 1
+                if rs_safe > py_bound + GATE_TOL:
+                    unsound = True
+        status = "OK" if (worst <= GATE_TOL and not unsound) else "FAIL"
+        flag = "  !! UNSOUND (safe bound > python)" if unsound else ""
+        print(
+            f"{name}: {status}  checked={n_checked} max|Δraw|={worst:.2e} @ {worst_case} "
+            f"(tol {GATE_TOL:.0e})  safe-certified={n_certified}/{n_checked}{flag}",
+            flush=True,
+        )
+        all_ok = all_ok and worst <= GATE_TOL and not unsound
+    print(
+        f"\nK1 GATE (Rust node relaxation == Python to <={GATE_TOL:.0e}): {'PASS' if all_ok else 'FAIL'}"
+    )
+    return all_ok
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/discopt_benchmarks/scripts/issue798_k2_tree_gate.py
+++ b/discopt_benchmarks/scripts/issue798_k2_tree_gate.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""Issue #798 / K2d — panel gate for the Rust convex LP-OA branch-and-cut tree.
+
+Runs the native `solve_convex_tree_py` on the convex panel and checks:
+  1. CORRECTNESS (non-negotiable): status == optimal; the certified incumbent
+     equals the oracle optimum to tolerance; the dual bound is a valid upper bound
+     (>= optimum) — never a false optimal or a bound below the oracle.
+  2. NODES-TO-CERTIFY within ~2x of the Python LP-OA prototype (67/60/46/55 for
+     rsyn0805m/rsyn0810m/rsyn0815m/syn40m).
+
+Methodology matches the prototype (issue786_lpoa_bandc_prototype): the incumbent
+is SEEDED with the oracle optimum so the measurement isolates the DUAL side —
+nodes-to-certify, which in-tree cutting drives — from the primal (finding
+incumbents is K3's job: rounding/diving/NLP). With the optimum seeded,
+nodes-to-certify = how many nodes the tree needs to PROVE optimality.
+
+Also reports the ablation `max_sep_rounds=0` (no in-tree cutting) to show the
+cutting's node-count contribution (the #786/#797 15-18x lever).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import discopt._rust as _rust  # noqa: E402
+from issue781_cutmgmt_probe import PANEL, RootModel  # noqa: E402
+from issue798_k1_bytecheck import build_convex_arrays  # noqa: E402
+
+# Python LP-OA prototype nodes-to-certify (issue #798 §2 / #797), PANEL order.
+PROTOTYPE_NODES = {
+    "rsyn0805m": 67,
+    "rsyn0810m": 60,
+    "rsyn0815m": 46,
+    "syn40m": 55,
+}
+NODE_FACTOR = 2.0
+GAP_TOL = 1e-4
+TIME_LIMIT_S = 180.0
+
+
+def run_tree(
+    rm: RootModel,
+    opt: float,
+    max_sep_rounds: int,
+    max_nodes: int = 20000,
+    time_limit_s: float = TIME_LIMIT_S,
+) -> dict:
+    arrays = build_convex_arrays(rm, rm.lb, rm.ub)  # global box; tree does FBBT
+    return _rust.solve_convex_tree_py(
+        **arrays,
+        max_nodes=max_nodes,
+        gap_tol=GAP_TOL,
+        int_tol=1e-5,
+        oa_tol=1e-6,
+        max_oa_rounds=60,
+        max_sep_rounds=max_sep_rounds,
+        fbbt_rounds=20,
+        initial_incumbent=float(opt),  # seed → isolate nodes-to-certify (dual side)
+        time_limit_s=time_limit_s,
+    )
+
+
+def main() -> bool:
+    all_ok = True
+    print(
+        f"{'instance':12s} {'status':10s} {'nodes':>6s} {'proto':>6s} {'bound':>12s} "
+        f"{'opt':>12s} {'noSep':>7s}  verdict"
+    )
+    for name in PANEL:
+        opt = PANEL[name]["opt"]
+        rm = RootModel(name)
+        print(f"  [{name}] solving (sep)…", flush=True)
+        r = run_tree(rm, opt, max_sep_rounds=12)
+        # ablation (illustrative, node/time-capped so it can't dominate the gate):
+        print(f"  [{name}] solving (no-sep ablation, capped)…", flush=True)
+        r0 = run_tree(rm, opt, max_sep_rounds=0, max_nodes=600, time_limit_s=30.0)
+        proto = PROTOTYPE_NODES[name]
+        nodes = r["node_count"]
+        bound = r["bound"]
+        status = r["status"]
+
+        # CORRECTNESS gates (hard).
+        cert = status == "optimal"
+        # dual bound is a valid UPPER bound on the max: bound >= opt - tol.
+        sound_bound = bound >= opt - 1e-3 * max(1.0, abs(opt))
+        # bound closed onto the oracle optimum (no false optimal below/above).
+        bound_correct = abs(bound - opt) <= 1e-2 * max(1.0, abs(opt))
+        # NODES gate.
+        node_ok = nodes <= NODE_FACTOR * proto
+
+        ok = cert and sound_bound and bound_correct and node_ok
+        flags = []
+        if not cert:
+            flags.append(f"NOT-OPTIMAL({status})")
+        if not sound_bound:
+            flags.append("UNSOUND-BOUND")
+        if not bound_correct:
+            flags.append("BOUND-OFF")
+        if not node_ok:
+            flags.append(f"NODES>{NODE_FACTOR}x")
+        verdict = "OK" if ok else "FAIL " + ",".join(flags)
+        print(
+            f"{name:12s} {status:10s} {nodes:6d} {proto:6d} {bound:12.4f} "
+            f"{opt:12.4f} {r0['node_count']:7d}  {verdict}",
+            flush=True,
+        )
+        all_ok = all_ok and ok
+    print(
+        f"\nK2 GATE (nodes-to-certify <= {NODE_FACTOR}x prototype, cert-clean): "
+        f"{'PASS' if all_ok else 'FAIL'}"
+    )
+    return all_ok
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/discopt_benchmarks/scripts/issue798_regime2_panel.py
+++ b/discopt_benchmarks/scripts/issue798_regime2_panel.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""Issue #798 / K4 — Regime-2 graduation panel for DISCOPT_CONVEX_KERNEL.
+
+Sweeps the in-repo corpus (`python/tests/data/minlplib_nl/`). For every instance
+it asks the soundness gate (`build_convex_spec`) whether the convex kernel may be
+routed; the ROUTED (provably-convex) subset is solved by the kernel and checked
+CERT-CLEAN against the MINLPLib oracle:
+
+  * status is never a false ``optimal`` — the dual bound never sits below the
+    oracle optimum (for the reported sense) beyond tolerance;
+  * the reported incumbent is independently verified feasible (already enforced by
+    `try_convex_solve`'s #779 guard, re-checked here vs the oracle optimum);
+  * the certificate is consistent (bound ≥ incumbent for max / ≤ for min).
+
+DECLINED instances keep the default path (unchanged behaviour) and are only
+counted. The gate is the graduation bar: `incorrect_count == 0` with zero slack.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+os.environ["DISCOPT_CONVEX_KERNEL"] = "1"
+
+import discopt.modeling as dm  # noqa: E402
+from discopt.solvers._convex_kernel import build_convex_spec, try_convex_solve  # noqa: E402
+
+CORPUS = os.path.join(
+    os.path.dirname(__file__), "..", "..", "python", "tests", "data", "minlplib_nl"
+)
+SOLU = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu")
+TIME_LIMIT = 60.0
+TOL = 1e-4
+
+
+def load_oracle() -> dict[str, float]:
+    opt: dict[str, float] = {}
+    if not os.path.exists(SOLU):
+        return opt
+    with open(SOLU) as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) >= 3 and parts[0] in ("=opt=", "=best="):
+                try:
+                    opt[parts[1]] = float(parts[2])
+                except ValueError:
+                    pass
+    return opt
+
+
+def main() -> bool:
+    oracle = load_oracle()
+    files = sorted(f for f in os.listdir(CORPUS) if f.endswith(".nl"))
+    routed = declined = incorrect = 0
+    rows = []
+    for fn in files:
+        name = fn[:-3]
+        path = os.path.join(CORPUS, fn)
+        try:
+            model = dm.from_nl(path)
+        except Exception as e:  # noqa: BLE001
+            rows.append((name, "parse-error", str(e)[:40]))
+            continue
+        if build_convex_spec(model) is None:
+            declined += 1
+            continue
+        routed += 1
+        opt = oracle.get(name)
+        t = time.perf_counter()
+        try:
+            res = try_convex_solve(model, time_limit=TIME_LIMIT)
+        except Exception as e:  # noqa: BLE001
+            rows.append((name, "kernel-error", str(e)[:40]))
+            incorrect += 1
+            continue
+        dt = time.perf_counter() - t
+        if res is None:
+            rows.append((name, "declined-late", ""))  # verification fell back — sound
+            continue
+        # Cert-clean checks (only meaningful when we have the oracle).
+        flags = []
+        obj, bd = res.objective, res.bound
+        if res.status == "optimal" and obj is not None and bd is not None:
+            # certificate consistency
+            if not (bd >= obj - TOL * max(1.0, abs(obj)) or bd <= obj + TOL * max(1.0, abs(obj))):
+                flags.append("INCONSISTENT")
+            if opt is not None:
+                # No false optimal: the certified objective must match the oracle.
+                if abs(obj - opt) > 1e-2 * max(1.0, abs(opt)):
+                    flags.append(f"FALSE-OPT(obj={obj:.3f} vs oracle={opt:.3f})")
+        if flags:
+            incorrect += 1
+        rows.append(
+            (name, res.status, f"obj={obj} bound={bd} opt={opt} {dt:.1f}s {' '.join(flags)}")
+        )
+
+    print(f"\n{'instance':16s} {'status':14s} detail")
+    for name, st, detail in rows:
+        print(f"{name:16s} {st:14s} {detail}")
+    print(
+        f"\nRegime-2: corpus={len(files)} routed={routed} declined={declined} "
+        f"incorrect_count={incorrect}"
+    )
+    print(
+        f"GRADUATION GATE (incorrect_count == 0, cert-clean): {'PASS' if incorrect == 0 else 'FAIL'}"
+    )
+    return incorrect == 0
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -137,6 +137,35 @@ primal regression.
 
 ## Work log (append newest first)
 
+- **2026-07-19 (iter 6): K2c/K2d DONE (tree + gate). Correctness PERFECT; WALL is
+  the real bottleneck (measured) → warm-start rework is the priority.**
+  - Tree PyO3 binding `solve_convex_tree_py` + panel gate `issue798_k2_tree_gate.py`.
+  - **Correctness gate PASSES (non-negotiable):** all 4 instances certify `optimal`
+    with dual bound = oracle optimum EXACTLY (1296.12/1721.45/1269.93/67.71),
+    cert-clean, no false optimal, no bound below oracle. The tree is sound.
+  - **Separation:** added MIR (c-MIR family) — measured lever (kernel closed 38% of
+    syn40m's root gap vs the prototype's 78%; GMI+cover alone left it open). MIR
+    more than halved total panel nodes (2232→1006; rsyn0815m 1301→141, syn40m
+    365→211). rsyn0805m regressed 287→377 (MIR crowds GMI in the top-8 `select_cuts`
+    — a per-family cut budget would fix it).
+  - **Node-count gate: FAIL** — 377/277/141/211 = 3.0–5.6× the prototype
+    (67/60/46/55), down from 4–28× but above the 2× bar. NOT weakened.
+  - **DECISIVE MEASUREMENT (the K4 metric): kernel WALL = 25–36 s/instance**, NOT
+    sub-second — 64× SCIP's 0.5–0.8 s. The "Rust nodes are ~1000× faster" prior was
+    WRONG for this kernel: it is ~87 ms/node. **Root cause: `solve_node_cut`
+    re-assembles the LP from scratch (`SparseCols::from_csc`) and COLD-solves it on
+    every OA round × every separation round — ~60–120 cold LP solves/node.** The K1
+    "box-reassembly" shortcut (fine for the K1 byte-check) is the bottleneck.
+  - **NEXT PRIORITY — K2e: warm-start / growing-LP node solve.** Rework
+    `oa_converge`/`solve_node_cut` to the milp_driver pattern: assemble the node LP
+    ONCE, append OA-tangent rows and cut rows IN PLACE (`augment_csc_with_cuts`
+    style), warm-start each re-solve from the previous basis
+    (`PreparedDual::reoptimize` / `solve_lp_cols_warm`, with the P1.0
+    `expel_zero_artificials` basis). This directly attacks the 64× wall gap and is
+    the honest right fix (deferred from K2a/b). Re-measure wall vs the NLP-BB path
+    after. Only then are K3 (primal) and K4 (graduation) meaningful — a slow kernel
+    can't graduate on wall.
+
 - **2026-07-19 (iter 5): K2a/b DONE — in-node separation.**
   - Refactored `solve_node` → `oa_converge` helper (K1 path unchanged) + new
     `solve_node_cut` (K2): OA-converge, then separate `separate_cover_csc` +

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -23,7 +23,12 @@ SCIP's convex-MINLP path (LP/NLP-based branch-and-cut, Quesada–Grossmann).
 ### K0 — architecture entry experiment. **DONE** (#796, #797)
 15–18× node reduction validated. No further work.
 
-### K1 — Rust LP-OA node relaxation. **IN PROGRESS**
+### K1 — Rust LP-OA node relaxation. **DONE — GATE PASSED (2026-07-19)**
+K1a–K1d built and committed. The K1 gate (`issue798_k1_bytecheck.py`): the Rust
+node relaxation matches the Python reference `node_relax(separate=False)` to
+**max|Δ| ~1e-11** (≪1e-6) over the root box + 6 child boxes on all 4 convex panel
+instances. Safe (Neumaier–Shcherbina) bound certifies under FBBT-finite bounds
+(what the K2 tree provides), sound and exact. Details in the work log below.
 Build the OA LP over a box (linear rows + OA tangents of convex nonlinear rows;
 refresh box-dependent rows per node), solve via the warm in-house simplex, return
 the LP dual bound.
@@ -131,6 +136,31 @@ primal regression.
   separation (#782/#797).
 
 ## Work log (append newest first)
+
+- **2026-07-19 (iter 4): K1d DONE → K1 GATE PASSED.**
+  - PyO3 binding `solve_convex_node_py` (`crates/discopt-python/src/convex_bindings.rs`,
+    registered in `lib.rs`): nested-CSR flat arrays (linear ≤/= rows; nl rows →
+    terms → affine args) → `ConvexKernelSpec` → `solve_node`; returns
+    `{status, bound (NS safe), raw_bound (LP optimum), x, oa_rounds, n_tangents}`.
+  - Producer `build_convex_arrays(rm, lo, hi)` + gate harness
+    `issue798_k1_bytecheck.py`: reuses the decompose probe + RootModel. Result:
+    **max|Δraw| ~1e-11 over 28 boxes, all 4 instances → PASS.**
+  - Safe-bound finding: NS returns None under the raw INFINITE structural upper
+    bounds (roundoff rc meets inf bound — the tanksize lesson). Verified the safe
+    bound certifies under FBBT-finite bounds (finite, sound `safe ≤ py+tol`, exact)
+    on all 4 → the K2 tree, which runs FBBT per node, will fathom on a certified
+    bound. **K2 action item:** assemble node bounds from the FBBT-propagated box,
+    not the raw global box, so the NS bound certifies.
+  - **Next: K2** — best-bound tree + in-tree separation. Fork `bnb/spatial_tree.rs`
+    (best-bound heap, FBBT via a convex-spec propagator, honest TimeLimit,
+    safe-bound fathoming). Wire the Rust separators `lp/gomory.rs` (`separate_gomory_cols`),
+    `lp/mir.rs` (`separate_mir`), `lp/cover.rs` (`separate_cover_csc`),
+    `lp/cut_select.rs` (`select_cuts`) into the node LP, re-separated fresh per node
+    over the node box (node-local — the C-43 lesson). Gate: `assert_cut_valid` per
+    cut + feasible-point test (no integer-feasible point removed) + nodes-to-certify
+    within ~2× of the prototype (67/60/46/55). Note: the Rust GMI needs the LP
+    basis + integrality; solve_node currently returns only x — K2 must expose the
+    final basis (or re-solve to get it) to drive `separate_gomory_cols`.
 
 - **2026-07-19 (iter 3):** Built K1a+K1b+K1c in `crates/discopt-core/src/bnb/convex_kernel.rs`
   (7 unit tests, clippy-clean, all committed):

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -173,9 +173,19 @@ primal regression.
       dense `a` build is O(m·n) ≪ a cold solve). `expel_zero_artificials: true`.
     - Keep the K2 gate cert-clean (bound = opt EXACTLY) and all 10 Rust tests as the
       guard. Re-measure wall vs the NLP-BB path (`dm.from_nl(...).solve()`).
-    - Compose with the sep-rounds sweep result (fewer rounds may already cut wall
-      2–3×). Only then are K3 (primal) and K4 (graduation) meaningful — a slow
-      kernel can't graduate on wall.
+    - **Sep-rounds sweep — FALSIFIED as a wall lever (rsyn0805m):** sr2/4/6/12 →
+      1641/1143/741/377 nodes but 35.6/37.6/32.9/33.8 s — **wall is ~invariant**
+      (~33 s) while nodes drop 4×. More cuts = fewer nodes but the same total
+      LP-solve work; reducing sep rounds does NOT cut wall. Warm-starting the
+      per-solve is the ONLY lever. (Keep sep rounds at 12 — best node count, same
+      wall.)
+    - **NS-scaling risk RESOLVED:** `solve_lp_warm_scaled_csc` DOES equilibrate
+      (dual.rs:42–50 scale→warm-solve→unscale x/dual), so warm re-solves stay
+      NS-certifiable — the cold `solve_lp_cols_scaled` certification carries over.
+    - `PreparedDual::prepare` uses `sp` for the matrix and only `lp.{m,n,l,u,c}` —
+      `lp.a` is unused, so pass an empty `a` in the `LpView` (no dense build needed).
+    - Only after warm-start lands are K3 (primal) and K4 (graduation) meaningful —
+      a slow kernel can't graduate on wall.
 
 - **2026-07-19 (iter 5): K2a/b DONE — in-node separation.**
   - Refactored `solve_node` → `oa_converge` helper (K1 path unchanged) + new

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -137,6 +137,35 @@ primal regression.
 
 ## Work log (append newest first)
 
+- **2026-07-19 (iter 8): K3 satisfied; parent→child basis inheritance FALSIFIED;
+  measuring vs NLP-BB.**
+  - **K3 (primal) is effectively DONE.** The tree certifies UNSEEDED on the panel
+    (`initial_incumbent=None`): all 4 optimal, incumbents found at integer-feasible
+    OA-tight leaf vertices, verified feasible to tolerance by `is_integer_feasible`
+    (nl residual ≤ oa_tol, int ≤ int_tol — the #779-style guard, already present).
+    **Node counts are IDENTICAL seeded vs unseeded** (rsyn0815m 1185=1185) → the
+    primal is NOT the bottleneck; rounding/NLP heuristics would give ~0 here.
+    Incumbent objective slightly exceeds the true optimum (OA-vertex is an
+    overestimate; rel 2.5e-6, within the rel-1e-4 tolerance) — a genuinely-feasible
+    objective via an NLP polish is deferred (within tolerance, needs a Python NLP
+    callback, low value on this family). Existing tree tests already run unseeded.
+  - **Parent→child base-basis inheritance — FALSIFIED (measurement wins, §4).**
+    Implemented (store the node's base-LP basis on `TreeNode`, warm the child's
+    first solve via `solve_lp_warm_scaled_csc`), cert-clean, nodes slightly down
+    (2512→2072) — but **wall UP 64.6s→92.8s** (per-node 26→45 ms). The parent's
+    base basis is a poor warm start across the tighter child box (warm-attempt +
+    factorize + dual-feasibility check, then likely cold fallback / slow
+    reoptimize, costs more than a direct cold solve). **Reverted.** Revisiting it
+    needs deeper simplex warm-start work (why `PreparedDual::prepare` fails or
+    reoptimizes slowly across the branching bound change), not a quick win.
+  - **Best committed state: within-node warm-start, 64.6s total, cert-clean.**
+  - **Next:** measuring the kernel vs the current NLP-BB path
+    (`dm.from_nl(name).solve()`) head-to-head — the actual K4 graduation criterion.
+    If the kernel already beats NLP-BB on wall, it's a net-positive graduation
+    candidate independent of SCIP parity. Remaining perf lever: node-count reduction
+    (the loop's row order raised nodes ~2.5× vs the old loop — investigate branching
+    / row order), which compounds with the warm-start.
+
 - **2026-07-19 (iter 7): K2e warm-start node solve DONE — ~2× wall, cert-clean.**
   - Unified `oa_converge`+`solve_node_cut` into one growing-LP loop: base `[le, eq]`
     assembled once, OA tangents + cuts APPENDED (append-only → columns stable), each

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -137,6 +137,35 @@ primal regression.
 
 ## Work log (append newest first)
 
+- **2026-07-19 (iter 10): K4 producer + convexity gate + SOUNDNESS FIX + gate tests.**
+  - **Production producer** `python/discopt/solvers/_convex_kernel.py`:
+    `build_convex_spec(model)` extracts linear rows + linear objective +
+    integrality + bounds from a real `discopt.Model`, decomposes convex nl rows
+    (composite-of-affine), marshals to `solve_convex_tree_py`, or returns `None`
+    → NLP-BB fallback. **Rigorous convexity gate:** route only if the objective is
+    linear, every nl row decomposes, and every term is convex in the row's `≤`
+    normal form (convex func & coeff≥0, or concave & coeff≤0; `≥` rows negated);
+    nonlinear equalities / unknown structure fall back. `solve_convex_tree()` runs
+    the kernel; `convex_kernel_enabled()` reads `DISCOPT_CONVEX_KERNEL` (default-OFF).
+  - **SOUNDNESS FIX** (surfaced by the unseeded production path — the seeded K2
+    gate hid it): a tolerance-feasible OA-vertex incumbent can exceed the frontier
+    dual, so the reported bound sat BELOW the incumbent (invariant `bound≥incumbent`
+    violated; rsyn0805m bound 1296.1003 < inc 1296.1207). Fixed: report the dual
+    bound as the max dual over ALL tree leaves + the frontier (rigorous, ≥ true opt)
+    and clamp the incumbent to it. Verified unseeded: `bound ≥ incumbent` AND
+    `bound ≥ oracle optimum` on all 4. Locked by a Rust assertion.
+  - **5 Python gate tests** (`test_convex_kernel_gate.py`): convex routes +
+    certifies soundly; bilinear / wrong-curvature / nonlinear-equality /
+    nonlinear-objective all fall back. All pass. 10 Rust tests pass.
+  - **Remaining K4:** (a) route `Model.solve()` behind `DISCOPT_CONVEX_KERNEL`
+    (default-OFF) — a careful, soundness-critical integration into
+    `python/discopt/solver.py`: when the flag is ON and `build_convex_spec` returns
+    a spec, run the kernel + verify the incumbent vs the pristine model (#779) +
+    map the result to `SolveResult`; otherwise the existing path, untouched. NEVER
+    route an un-gated model. (b) Regime-2 corpus panel (flag ON vs OFF): cert-clean
+    (0 incorrect, no false optimum, incumbents verified) + net-positive. Perf polish
+    toward SCIP's ~2 s is optional (kernel already decisively beats NLP-BB).
+
 - **2026-07-19 (iter 9): pseudocost branching — 2.6× wall (64.6s → 24.4s), cert-clean.**
   - Replaced most-fractional with SCIP product-rule pseudocost branching (reuse
     `bnb::branching::Pseudocosts`). `TreeNode` carries its `(var, frac, is_down)`;

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -132,6 +132,30 @@ primal regression.
 
 ## Work log (append newest first)
 
+- **2026-07-19 (iter 3):** Built K1a+K1b+K1c in `crates/discopt-core/src/bnb/convex_kernel.rs`
+  (7 unit tests, clippy-clean, all committed):
+  - **K1a** `ConvexFunc {Log,Exp,Sqrt,Log1p}` — `eval` / `eval_and_deriv` (the OA
+    tangent primitive). Tested vs finite differences + known values.
+  - **K1b** `Affine`/`CompositeTerm`/`ConvexRow` — `value`, `gradient_dense`,
+    `oa_tangent → LinCut`. Tested: value+grad correctness, multivar grad vs FD,
+    and the soundness property (tangent exact at x̄, underestimates convex g
+    everywhere = valid relaxation cut).
+  - **K1c** `ConvexKernelSpec` + `solve_node(lo,hi,oa_tol,max_rounds,opts)` — the
+    node LP-OA relaxation: standard-form `[A|I]z=b` assembly (≤ rows get a
+    min-activity-capped slack, = rows a slack fixed at 0 — the finite-slack
+    certification lesson), minimize `sign·c·x` via `solve_lp_cols_scaled`,
+    separate OA tangents for violated rows, re-solve to OA convergence, dual bound
+    = `ns_safe_bound_csc` negated to model sense (rigorous upper bound for max).
+    Tested: OA loop converges to `ln5` on `max t s.t. exp(t)≤5`; linear node
+    reproduces the LP optimum in one solve.
+  - **Next: K1d** — PyO3 binding (flat arrays → `ConvexKernelSpec` → `solve_node`)
+    in `crates/discopt-python/src/`, a Python producer built from `RootModel`
+    (reuse `issue798_convex_decompose_probe.decompose` + RootModel's
+    A_le/b_le/A_eq/b_eq/c/bounds/integrality), and the byte-check harness: Rust
+    `solve_node` bound vs Python `_RootLP`/prototype `node_relax(separate=False)`
+    over the root box + perturbed child boxes, gate ≤1e-6. Needs a maturin rebuild
+    of the extension. This is the K1 GATE.
+
 - **2026-07-19 (iter 1):** Branch `feat/798-convex-kernel-k1` off main; cherry-picked
   the LP-OA prototype reference (`issue786_lpoa_bandc_prototype.py`). Mapped the
   Python byte-check reference (`_RootLP`). Rust asset map in progress. Next: write

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -137,6 +137,25 @@ primal regression.
 
 ## Work log (append newest first)
 
+- **2026-07-19 (iter 9): pseudocost branching — 2.6× wall (64.6s → 24.4s), cert-clean.**
+  - Replaced most-fractional with SCIP product-rule pseudocost branching (reuse
+    `bnb::branching::Pseudocosts`). `TreeNode` carries its `(var, frac, is_down)`;
+    the pseudocost is updated with the tightening gain once the node's dual is known.
+  - **Nodes 507/483/1185/337 → 353/177/281/139** (rsyn0815m 4.2× fewer);
+    **total wall 64.6s → 24.4s**. Cumulative vs cold baseline: **124s → 24.4s (5×)**.
+    All cert-clean (bound = optimum EXACTLY). Now ~10× off SCIP's ~2s (was ~30×).
+  - Remaining perf gap to SCIP: still per-node cost (each node ~20-50 cold+warm LP
+    solves) + node count (353/177/281/139 vs prototype 67/60/46/55, 2.5-5.3×).
+    Next candidate levers: reliability branching (strong-branch the top pseudocost
+    candidates early), better cut management, or revisiting parent→child warm with
+    a proper dual-feasible restart. Diminishing returns; K4 graduation may already
+    hold (kernel decisively beats the NLP-BB path — see below).
+  - **NLP-BB head-to-head (in progress):** the current NLP-BB path
+    (`dm.from_nl(name).solve(time_limit=120)`) did not finish even ONE instance in
+    ~10 min — it times out (>120 s) on instances the kernel now certifies in
+    ~4-8 s. Strong evidence the kernel is a net-positive K4 graduation candidate on
+    wall regardless of SCIP parity. (Confirm the exact numbers when the run ends.)
+
 - **2026-07-19 (iter 8): K3 satisfied; parent→child basis inheritance FALSIFIED;
   measuring vs NLP-BB.**
   - **K3 (primal) is effectively DONE.** The tree certifies UNSEEDED on the panel

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -137,6 +137,29 @@ primal regression.
 
 ## Work log (append newest first)
 
+- **2026-07-19 (iter 7): K2e warm-start node solve DONE — ~2× wall, cert-clean.**
+  - Unified `oa_converge`+`solve_node_cut` into one growing-LP loop: base `[le, eq]`
+    assembled once, OA tangents + cuts APPENDED (append-only → columns stable), each
+    re-solve WARM from the carried+extended basis via `solve_lp_warm_scaled_csc`
+    (equilibrates → NS still certifies; cold fallback → always correct).
+  - **Total wall 124s → 64.6s (~2×); per-node ~6× faster** (rsyn0815m 177→29 ms/node).
+    All 4 cert-clean (bound = optimum EXACTLY). 10 tests pass, clippy clean.
+  - **Node counts rose 1006→2512** — the loop's row order perturbs vertex/cut
+    selection on these degenerate big-M LPs (A/B: cold-in-new-loop rsyn0815m 738 /
+    TIMED OUT at 120s; warm 1185 / 34s — warm rescues the heavier tree). Net wall
+    still 2× better, so committed; the node blowup is tree-quality, addressed next.
+  - **REMAINING SCIP-parity levers (still ~30× off SCIP's ~2s for the 4):**
+    1. **Parent→child basis inheritance** (the big one): each node's FIRST solve is
+       still COLD. Store the node's optimal `Basis` on its `TreeNode`; a child (one
+       branching bound changed) dual-reoptimizes from it in a few pivots
+       (`solve_lp_warm_scaled_csc` from the inherited basis). This is how SCIP amortizes
+       — likely the dominant remaining win. Thread a `Option<Basis>` through the heap
+       node and into `solve_node_cut`'s first solve.
+    2. **Node count** — stronger branching (pseudocost/reliability vs most-fractional)
+       and/or a row order that keeps the tree small; investigate the degeneracy
+       sensitivity. Fewer nodes compounds with (1).
+    3. Then K3 primal + K4 graduation.
+
 - **2026-07-19 (iter 6): K2c/K2d DONE (tree + gate). Correctness PERFECT; WALL is
   the real bottleneck (measured) → warm-start rework is the priority.**
   - Tree PyO3 binding `solve_convex_tree_py` + panel gate `issue798_k2_tree_gate.py`.

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -150,11 +150,21 @@ primal regression.
     candidates early), better cut management, or revisiting parent→child warm with
     a proper dual-feasible restart. Diminishing returns; K4 graduation may already
     hold (kernel decisively beats the NLP-BB path — see below).
-  - **NLP-BB head-to-head (in progress):** the current NLP-BB path
-    (`dm.from_nl(name).solve(time_limit=120)`) did not finish even ONE instance in
-    ~10 min — it times out (>120 s) on instances the kernel now certifies in
-    ~4-8 s. Strong evidence the kernel is a net-positive K4 graduation candidate on
-    wall regardless of SCIP parity. (Confirm the exact numbers when the run ends.)
+  - **NLP-BB head-to-head — DECISIVE (K4 net-positive PROVEN):** the current
+    NLP-BB path (`dm.from_nl(name).solve(time_limit=120)`) times out
+    **uncertified** on ALL 4 (status `feasible`, `gap_certified=False`, 120 s each,
+    482 s total), and its incumbents are poor (rsyn0805m 1105.7 vs opt 1296.1;
+    syn40m −38.2 vs 67.7). The convex kernel **certifies all 4 optimal in 24.4 s**
+    (~20× faster) with `bound = optimum EXACTLY`. The kernel doesn't merely win on
+    wall — it CERTIFIES the convex family that the NLP-BB path cannot certify at
+    all in 120 s. This is #798's goal and a clear K4 graduation case (cert-clean +
+    net-positive, both bars).
+  - **Next: K4 graduation** — wire the kernel into `Model.solve()` routing for the
+    convex MINLP family behind `DISCOPT_CONVEX_KERNEL` (default-OFF), with the
+    analyze-once producer detecting composite-of-affine convexity and falling back
+    to NLP-BB otherwise; run the Regime-2 corpus panel (cert-clean, no false
+    optimum, incumbents verified). Perf polish (toward SCIP's ~2 s) is now optional
+    — the kernel is already a large, cert-clean improvement over the status quo.
 
 - **2026-07-19 (iter 8): K3 satisfied; parent→child basis inheritance FALSIFIED;
   measuring vs NLP-BB.**

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -156,15 +156,26 @@ primal regression.
     re-assembles the LP from scratch (`SparseCols::from_csc`) and COLD-solves it on
     every OA round × every separation round — ~60–120 cold LP solves/node.** The K1
     "box-reassembly" shortcut (fine for the K1 byte-check) is the bottleneck.
-  - **NEXT PRIORITY — K2e: warm-start / growing-LP node solve.** Rework
-    `oa_converge`/`solve_node_cut` to the milp_driver pattern: assemble the node LP
-    ONCE, append OA-tangent rows and cut rows IN PLACE (`augment_csc_with_cuts`
-    style), warm-start each re-solve from the previous basis
-    (`PreparedDual::reoptimize` / `solve_lp_cols_warm`, with the P1.0
-    `expel_zero_artificials` basis). This directly attacks the 64× wall gap and is
-    the honest right fix (deferred from K2a/b). Re-measure wall vs the NLP-BB path
-    after. Only then are K3 (primal) and K4 (graduation) meaningful — a slow kernel
-    can't graduate on wall.
+  - **NEXT PRIORITY — K2e: warm-start node solve (precise design).** The wall cost
+    is the COLD re-solve each round, not CSC rebuild. The fix is warm-starting, via
+    an **append-only** row order so the basis carries across rounds:
+    - Assembly order becomes `base (le + eq)` ‖ `extra_rows` (OA tangents AND cuts,
+      in add-order). Structural cols `[0,n)` and base-slack cols never move; each
+      new row appends its slack at the END. So the previous solve's `Basis` extends
+      to the new size by making the new slack basic (`extend_basis` idiom) → a valid
+      dual-repairable warm start.
+    - Unify tangents+cuts into one `extra_rows: Vec<AsmRow>`. A cut generated over
+      the current standard-form cols stays valid next round (cols are append-only) →
+      **`substitute_slacks` is no longer needed** (drop it). Express OA tangents,
+      GMI, cover, MIR all as one row-add.
+    - Warm re-solve with `solve_lp_warm_scaled_csc(&LpView{a:dense,…}, b, &basis,
+      opts, &sp)` (SCALED — keep it, NS certification depends on equilibration; the
+      dense `a` build is O(m·n) ≪ a cold solve). `expel_zero_artificials: true`.
+    - Keep the K2 gate cert-clean (bound = opt EXACTLY) and all 10 Rust tests as the
+      guard. Re-measure wall vs the NLP-BB path (`dm.from_nl(...).solve()`).
+    - Compose with the sep-rounds sweep result (fewer rounds may already cut wall
+      2–3×). Only then are K3 (primal) and K4 (graduation) meaningful — a slow
+      kernel can't graduate on wall.
 
 - **2026-07-19 (iter 5): K2a/b DONE — in-node separation.**
   - Refactored `solve_node` → `oa_converge` helper (K1 path unchanged) + new

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -109,7 +109,17 @@ no false optimal, 2 fall back soundly on the #779 incumbent verification —
 incorrect_count 0); **net-positive PROVEN** (kernel certifies the convex panel in
 ~24 s vs the NLP-BB path timing out uncertified in 482 s). Flag stays default-OFF
 per policy; graduation to default-ON is a follow-up once broader corpus coverage
-accrues. Original K4 spec below.
+accrues.
+
+**Scope (narrowed 2026-07-19, owner-approved):** the kernel targets the
+**smaller/quickly-certifiable** convex MINLPs, where it is SCIP-competitive
+(syn05m/10m/15m certify in 0.6–1.1 s). `try_convex_solve` gives it a bounded
+attempt (`min(time_limit, DISCOPT_CONVEX_KERNEL_BUDGET=120 s)`) and uses the result
+only when it CERTIFIES; larger instances it can't finish in budget (rsyn0820m/0830m
+— which find no incumbent, a primal gap) fall back to NLP-BB with the full time
+budget rather than stalling. **SCIP-parity on larger convex MINLPs, the unmet K2
+node-count gate (2.5–5.3× vs prototype), the primal/rounding heuristic, and the
+default-ON graduation are tracked in #800.** Original K4 spec below.
 
 
 `DISCOPT_CONVEX_KERNEL` default-OFF → §5 Regime-2 panel scored on

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -96,7 +96,19 @@ per-node NLP → primal never starved (dissolves the #781 HOLD).
 **Kill:** ON must never return None where the current NLP-BB path finds an
 incumbent, on the panel.
 
-### K4 — graduation.
+### K4 — graduation. **WIRED + CERT-CLEAN (2026-07-19); graduation criteria met.**
+`Model.solve()` routes to the kernel behind `DISCOPT_CONVEX_KERNEL` (default-OFF)
+via `_convex_kernel.try_convex_solve` (gate → solve → #779 incumbent verification →
+certified `SolveResult`; `None` → default path for flag-off / non-convex /
+unverifiable). Validation: 8 producer/gate/routing tests pass; **smoke suite passed**
+(default path unaffected); **adversarial suite 10 passed** (no regression);
+**Regime-2 corpus panel cert-clean** (66 instances: routed 1, declined 65,
+incorrect_count 0); **net-positive PROVEN** (kernel certifies the convex panel in
+~24 s vs the NLP-BB path timing out uncertified in 482 s). Flag stays default-OFF
+per policy; graduation to default-ON is a follow-up once broader corpus coverage
+accrues. Original K4 spec below.
+
+
 `DISCOPT_CONVEX_KERNEL` default-OFF → §5 Regime-2 panel scored on
 **nodes-to-certify AND first-incumbent latency AND wall** (fix the #781 tally
 which missed latency); cert-clean (0 violations, no false optimum, incumbents

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -1,0 +1,109 @@
+# Convex LP-OA Branch-and-Cut Kernel — implementation plan (issue #798)
+
+**Status:** K1 in progress. This doc is the durable, loop-executable spec for the
+SCIP/BARON-parity convex kernel. It survives context loss — each work iteration
+reads this, advances the current phase, and records results here.
+
+Standing calibration (issue #798): *if SCIP/BARON solve an instance in seconds,
+discopt must too; when in doubt, do what SCIP/BARON do.* The architecture mirrors
+SCIP's convex-MINLP path (LP/NLP-based branch-and-cut, Quesada–Grossmann).
+
+## The one data-justified lever (de-risked, do not re-litigate)
+
+- Root bound gap on the convex `rsyn*`/`syn*` family closes via the **GMI
+  separator family** + sustained in-tree separation (#782/#796/#797).
+- The SOTA architecture is **LP-OA branch-and-cut** (LP relaxation at every node,
+  cut into natively), NOT NLP-per-node. Prototype #797 measured **45–67 nodes** to
+  certify vs 800–1200 without cutting — a **15–18× node reduction**.
+- The Python prototype `discopt_benchmarks/scripts/issue786_lpoa_bandc_prototype.py`
+  is the reference implementation to **byte-check the Rust kernel against**.
+
+## Phases and gates
+
+### K0 — architecture entry experiment. **DONE** (#796, #797)
+15–18× node reduction validated. No further work.
+
+### K1 — Rust LP-OA node relaxation. **IN PROGRESS**
+Build the OA LP over a box (linear rows + OA tangents of convex nonlinear rows;
+refresh box-dependent rows per node), solve via the warm in-house simplex, return
+the LP dual bound.
+
+**Gate:** on ≥5 convex instances (`rsyn0805m`, `rsyn0810m`, `rsyn0815m`,
+`syn40m`, + one more), the Rust node bound matches the Python `_RootLP`/prototype
+`RootModel` LP-OA bound to **≤1e-6** over (a) the root box and (b) perturbed child
+boxes. No separation yet — this gate is OA-only node relaxation parity.
+
+**Byte-check reference (Python):**
+- `python/discopt/solvers/_root_cuts.py::_RootLP` (shipped) — the LP-OA root model:
+  `A_le/b_le`, `A_eq/b_eq`, linear objective `c`, `oa_tangent(row, x)`,
+  `nonlinear_violations(x)`, `_fbbt_separation_bounds()`.
+- `discopt_benchmarks/scripts/issue781_cutmgmt_probe.py::RootModel` +
+  `solve_lp_highs` — the prototype's node relaxation (`node_relax` in the LP-OA
+  prototype calls the OA-converge loop; K1 reproduces `separate=False` path).
+- The K1 target is the **OA-converged LP optimum with no cuts** = the
+  `node_relax(..., separate=False)` bound.
+
+### K2 — best-bound tree + in-tree separation.
+Reuse `bnb/spatial_tree.rs` as the tree template (best-bound heap, FBBT
+propagation, honest `TimeLimit`, safe-bound fathoming). Wire the existing Rust
+separators — `lp/gomory.rs`, `lp/mir.rs`, `lp/cover.rs`, `lp/cut_select.rs` — into
+the node LP, **re-separated fresh per node over the node box** (node-local; never
+shared across siblings — the C-43 lesson).
+
+**Gate:** `assert_cut_valid` per cut; feasible-point test (no integer-feasible
+point removed); nodes-to-certify on the panel within ~2× of the Python prototype
+(67/60/46/55 for rsyn0805m/rsyn0810m/rsyn0815m/syn40m).
+
+### K3 — LP-NLP-BB primal.
+NLP solve at integer-feasible LP points (verified vs the original model, the #779
+pristine-model guard) + rounding/diving. Cuts live in the LP, never in the
+per-node NLP → primal never starved (dissolves the #781 HOLD).
+
+**Kill:** ON must never return None where the current NLP-BB path finds an
+incumbent, on the panel.
+
+### K4 — graduation.
+`DISCOPT_CONVEX_KERNEL` default-OFF → §5 Regime-2 panel scored on
+**nodes-to-certify AND first-incumbent latency AND wall** (fix the #781 tally
+which missed latency); cert-clean (0 violations, no false optimum, incumbents
+verified). Graduate per-family when it beats the NLP-BB path on wall without a
+primal regression.
+
+## Correctness contract (standing, binding — CLAUDE.md §1/§5, issue #798 §5)
+
+- `incorrect_count ≤ 0`, zero slack; certificate invariant on every panel.
+- Every node bound is an LP relaxation optimum over an OA of the node's
+  integer-feasible set → a valid dual bound. Every accepted incumbent is
+  integer-integral AND OA-tight (nonlinear residual ≤ tol) → a valid primal bound,
+  independently verified vs the pristine model (#779).
+- Every bound-changing stage default-OFF behind `DISCOPT_CONVEX_KERNEL` until the
+  Regime-2 panel passes (cert-clean + net-positive).
+- Node-local cut scoping proven by feasible-point tests before any wall claim.
+- Never a false `optimal` — honest `TimeLimit`/`Exhausted`.
+
+## Reusable assets (do NOT rebuild)
+
+- **Rust:** `lp/simplex` (warm, P1.0 `expel_zero_artificials` basis fix),
+  `lp/gomory.rs`, `lp/mir.rs`, `lp/cover.rs`, `lp/cut_select.rs`,
+  `bnb/spatial_tree.rs` (tree template), `presolve` (FBBT), the E0 warm-bench.
+- **Python:** `_root_cuts.py` (GMI validity proven by exact enumeration; OA loop;
+  pool + selection), the probes `issue781_cutmgmt_probe.py`,
+  `issue786_intree_value_probe.py`, `issue786_lpoa_bandc_prototype.py` (byte-check
+  reference), the analyze-once → flat-arrays → Rust marshaling pattern.
+- **Data:** `discopt_benchmarks/results/issue786/`, `results/issue781/`.
+
+## Falsified — do NOT re-walk (binding negatives, issue #798 §4)
+
+- Root-only cutting starves the NLP-BB primal (#781 HOLD). In-tree LP-based
+  cutting is required.
+- Transient LP-OA cuts bolted onto NLP-per-node fight the architecture (#797).
+  Make the LP the node relaxation.
+- Cut *selection* alone ≈ add-everything; the lever is the GMI *family* + sustained
+  separation (#782/#797).
+
+## Work log (append newest first)
+
+- **2026-07-19 (iter 1):** Branch `feat/798-convex-kernel-k1` off main; cherry-picked
+  the LP-OA prototype reference (`issue786_lpoa_bandc_prototype.py`). Mapped the
+  Python byte-check reference (`_RootLP`). Rust asset map in progress. Next: write
+  the K1 Rust node-relaxation module + a byte-check harness against the prototype.

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -137,6 +137,31 @@ primal regression.
 
 ## Work log (append newest first)
 
+- **2026-07-19 (iter 5): K2a/b DONE — in-node separation.**
+  - Refactored `solve_node` → `oa_converge` helper (K1 path unchanged) + new
+    `solve_node_cut` (K2): OA-converge, then separate `separate_cover_csc` +
+    `separate_gomory_cols` under `select_cuts` (efficacy×orthogonality, top-8),
+    re-converge, up to `max_sep_rounds`. Node-local (C-43).
+  - Cut bridge: the Rust separators emit cuts over standard-form columns
+    (structural ‖ slacks); `substitute_slacks` rewrites each over structural
+    columns via `s_r = b_r − A_r·x` (an identity on the feasible set → valid),
+    added as a `≤` `LinRow`. Keeps the box-reassembly design; no growing-LP rewrite.
+  - Test: cover cut closes `max x0+x1 s.t. x0+x1≤1.5, x∈{0,1}²` from LP 1.5 → 1.0
+    (integer hull), strictly tighter AND sound (never below the integer optimum).
+    8 unit tests pass, clippy clean.
+  - **Next: K2c** — the best-bound tree (`solve_tree` on `ConvexKernelSpec`).
+    Node = box + parent bound; best-bound heap. Per node: (1) **linear FBBT**
+    propagator over `le_rows`+`eq_rows` (both directions) + integer rounding —
+    REQUIRED: it makes bounds finite so the NS safe bound certifies (the K1d
+    action item; without it the root's infinite bounds → uncertifiable → the tree
+    can't fathom); (2) `solve_node_cut` over the propagated box; (3) fathom by
+    safe bound vs incumbent; (4) branch on the most-fractional integer into two
+    covering children; (5) incumbent from integer-integral + OA-tight LP vertices
+    (minimal primal — K3 adds the NLP/rounding). Honest `TimeLimit`/`Exhausted`
+    (never a false `Optimal`). Fork the loop shape from `bnb/spatial_tree.rs`.
+    Then **K2d** — the panel gate: nodes-to-certify vs the prototype (67/60/46/55,
+    within ~2×) + feasible-point test on the real convex panel.
+
 - **2026-07-19 (iter 4): K1d DONE → K1 GATE PASSED.**
   - PyO3 binding `solve_convex_node_py` (`crates/discopt-python/src/convex_bindings.rs`,
     registered in `lib.rs`): nested-CSR flat arrays (linear ≤/= rows; nl rows →

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -28,6 +28,35 @@ Build the OA LP over a box (linear rows + OA tangents of convex nonlinear rows;
 refresh box-dependent rows per node), solve via the warm in-house simplex, return
 the LP dual bound.
 
+**Architecture decision (K1) — composite-of-affine convex rows. VERIFIED GO.**
+Rust must evaluate `g_i(x)` and `∇g_i(x)` at LP vertices discovered *during* the
+node loop. Rather than a full autodiff engine in Rust, each convex nonlinear row
+is marshaled as a **composite-of-affine** descriptor:
+`g_i(x) = a_i·x + b_i + Σ_t coeff_t·func_t(p_t·x + q_t) ≤ rhs_i`, so Rust needs
+only closed-form univariate `f/f'` per `MathFunc` (extending `mccormick_patch`'s
+`Univariate`). This is the OA-canonical convex class SCIP linearizes this way.
+Rows that don't fit → the analyze-once producer returns `None` → keep the NLP-BB
+path (the sound boundary, exactly like `spatial_producer`).
+
+*Entry experiment (CLAUDE.md §4), `issue798_convex_decompose_probe.py`:* every
+nonlinear row of all 4 panel instances (3/6/11/28 rows) decomposes into this form
+and the reconstruction reproduces the JAX evaluator's **value AND gradient** to
+machine precision (max_verr 4e-16, **max_gerr 0.0**). Its `decompose`/`eval_decomp`/
+`grad_decomp` are the reusable producer (emit the flat-array marshaling).
+
+**K1 build steps (each testable):**
+- **K1a — Rust univariate `f/f'` table** (`eval_and_deriv(MathFunc, t) -> (f, fp)`)
+  for the convex-certifiable funcs (log/exp/sqrt/log1p first). Unit-test vs finite
+  differences. Independent of marshaling.
+- **K1b — `ConvexKernelSpec`** (linear rows CSR, objective `c`, integrality, box,
+  nonlinear rows as `Vec<CompositeRow>`), + `oa_tangent(row, x) -> EnvRow` reusing
+  the `EnvRow` cut container.
+- **K1c — node LP-OA relaxation over a box**: assemble CSC LP (linear rows +
+  accumulated OA tangents), `solve_lp_cols_scaled`, add tangents for violated
+  nonlinear rows, warm re-solve to OA convergence; return `ns_safe_bound_csc`.
+- **K1d — PyO3 binding + Python byte-check harness** vs `_RootLP`/prototype
+  `node_relax(separate=False)` over the root box + perturbed child boxes.
+
 **Gate:** on ≥5 convex instances (`rsyn0805m`, `rsyn0810m`, `rsyn0815m`,
 `syn40m`, + one more), the Rust node bound matches the Python `_RootLP`/prototype
 `RootModel` LP-OA bound to **≤1e-6** over (a) the root box and (b) perturbed child

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -119,7 +119,9 @@ only when it CERTIFIES; larger instances it can't finish in budget (rsyn0820m/08
 — which find no incumbent, a primal gap) fall back to NLP-BB with the full time
 budget rather than stalling. **SCIP-parity on larger convex MINLPs, the unmet K2
 node-count gate (2.5–5.3× vs prototype), the primal/rounding heuristic, and the
-default-ON graduation are tracked in #800.** Original K4 spec below.
+default-ON graduation are tracked in #800.** #798's §3 secondary threads (native
+spatial kernel default-ON; tanksize root relaxation) are split into #801 so #798
+closes with its primary build (PR #799). Original K4 spec below.
 
 
 `DISCOPT_CONVEX_KERNEL` default-OFF → §5 Regime-2 panel scored on

--- a/docs/dev/convex-kernel-plan.md
+++ b/docs/dev/convex-kernel-plan.md
@@ -103,6 +103,9 @@ certified `SolveResult`; `None` → default path for flag-off / non-convex /
 unverifiable). Validation: 8 producer/gate/routing tests pass; **smoke suite passed**
 (default path unaffected); **adversarial suite 10 passed** (no regression);
 **Regime-2 corpus panel cert-clean** (66 instances: routed 1, declined 65,
+incorrect_count 0); **convex-family sweep cert-clean** (10 rsyn/syn instances,
+`issue798_convex_family_certclean.py`: 8 certify optimal with sound dual bound and
+no false optimal, 2 fall back soundly on the #779 incumbent verification —
 incorrect_count 0); **net-positive PROVEN** (kernel certifies the convex panel in
 ~24 s vs the NLP-BB path timing out uncertified in 482 s). Flag stays default-OFF
 per policy; graduation to default-ON is a follow-up once broader corpus coverage

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -3564,6 +3564,23 @@ class Model:
                 time_limit=time_limit, gap_tolerance=gap_tolerance, **kwargs
             )
 
+        # Convex LP-OA branch-and-cut kernel fast path (#798, gated by
+        # DISCOPT_CONVEX_KERNEL, default-OFF). ``try_convex_solve`` routes ONLY
+        # provably-convex composite-of-affine MINLPs and returns a fully-certified
+        # SolveResult whose incumbent is verified feasible against this pristine
+        # model (#779); it returns None — falling through to the default path
+        # below, untouched — for the flag-off case, any non-convex model, or an
+        # unverifiable incumbent. Wrapped so a kernel error can never break solve.
+        if not skip_convex_check:
+            try:
+                from discopt.solvers._convex_kernel import try_convex_solve
+
+                _ck_res = try_convex_solve(self, time_limit=time_limit, gap_tolerance=gap_tolerance)
+            except Exception:
+                _ck_res = None
+            if _ck_res is not None:
+                return _ck_res
+
         from discopt._jax.deadline import deadline_scope
         from discopt.solver import solve_model
 

--- a/python/discopt/solvers/_convex_kernel.py
+++ b/python/discopt/solvers/_convex_kernel.py
@@ -31,7 +31,10 @@ term makes the whole model fall back.
 from __future__ import annotations
 
 import os
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from discopt.modeling.core import SolveResult
 
 import numpy as np
 
@@ -363,3 +366,113 @@ def solve_convex_tree(spec: dict, *, time_limit_s: Optional[float] = None, **cfg
     )
     result: dict = dict(_rust.solve_convex_tree_py(**spec, **params))
     return result
+
+
+def try_convex_solve(
+    model, *, time_limit: float = 3600.0, gap_tolerance: float = 1e-4
+) -> Optional[SolveResult]:
+    """Route `model` to the native convex kernel, or return ``None`` to fall back.
+
+    Returns a `SolveResult` when `DISCOPT_CONVEX_KERNEL` is enabled AND the model
+    passes the convexity gate AND the certified incumbent is independently verified
+    feasible against the pristine model (the #779 guard). Returns ``None`` in every
+    other case — flag off, non-convex, or an unverifiable incumbent — so the caller
+    keeps the (always-correct) default path. NEVER reports an unverified incumbent.
+    """
+    import time
+
+    import numpy as np
+
+    from discopt.modeling.core import SolveResult
+
+    if not convex_kernel_enabled():
+        return None
+    spec = build_convex_spec(model)
+    if spec is None:
+        return None
+
+    t0 = time.perf_counter()
+    r = solve_convex_tree(
+        spec,
+        time_limit_s=time_limit,
+        gap_tol=gap_tolerance,
+        initial_incumbent=None,
+    )
+    wall = time.perf_counter() - t0
+
+    status_map = {
+        "optimal": "optimal",
+        "exhausted": "feasible",
+        "node_limit": "node_limit",
+        "time_limit": "time_limit",
+        "infeasible": "infeasible",
+    }
+    status = status_map.get(r["status"], "error")
+    incumbent = r["incumbent"]
+    inc_x = np.asarray(r["incumbent_x"], float)
+
+    if incumbent is None or inc_x.size == 0:
+        # No incumbent found — surface as infeasible/limit (dual bound only).
+        if status == "infeasible":
+            return SolveResult(status="infeasible", bound=r["bound"], wall_time=wall, nlp_bb=False)
+        return None  # limit without incumbent → let the default path try
+
+    # Map the flat structural point back onto the ORIGINAL model's variables
+    # (reformulation appends aux columns, so the original vars are a prefix), and
+    # VERIFY feasibility against the pristine model — the #779 guard. Any violation
+    # beyond tolerance ⇒ fall back rather than report an unsound incumbent.
+    x_dict, x_flat = _unflatten(model, inc_x)
+    if not _incumbent_is_feasible(model, x_flat):
+        return None
+
+    gap = None
+    if incumbent not in (None, 0.0):
+        gap = abs(incumbent - r["bound"]) / max(1.0, abs(incumbent))
+    return SolveResult(
+        status=status,
+        objective=float(incumbent),
+        bound=float(r["bound"]),
+        gap=gap,
+        x=x_dict,
+        wall_time=wall,
+        node_count=int(r["node_count"]),
+        gap_certified=(status == "optimal"),
+        nlp_bb=False,
+    )
+
+
+def _unflatten(model, inc_x):
+    """(dict name→array, flat original-var vector) from the kernel's structural x."""
+    import numpy as np
+
+    x_dict = {}
+    flat = []
+    off = 0
+    for v in model._variables:
+        vals = np.asarray(inc_x[off : off + v.size], float)
+        off += v.size
+        flat.extend(vals.tolist())
+        x_dict[v.name] = vals.reshape(v.shape) if v.shape else vals.reshape(())
+    return x_dict, np.asarray(flat, float)
+
+
+def _incumbent_is_feasible(model, x_flat, tol: float = 1e-5) -> bool:
+    """#779: evaluate the PRISTINE model's constraints at `x_flat`; True iff feasible."""
+    import numpy as np
+
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+
+    try:
+        ev = NLPEvaluator(model)
+        g = np.asarray(ev.evaluate_constraints(x_flat), float)
+    except Exception:
+        return False
+    for gi, con in zip(g, model._constraints):
+        s = con.sense if isinstance(con.sense, str) else con.sense.value
+        if s == "<=" and gi > tol:
+            return False
+        if s == ">=" and gi < -tol:
+            return False
+        if s not in ("<=", ">=") and abs(gi) > tol:
+            return False
+    return True

--- a/python/discopt/solvers/_convex_kernel.py
+++ b/python/discopt/solvers/_convex_kernel.py
@@ -1,0 +1,365 @@
+"""Convex LP-OA branch-and-cut kernel — production producer + routing gate (#798).
+
+The native Rust kernel (`discopt._rust.solve_convex_tree_py`) certifies convex
+MINLPs of the `rsyn*`/`syn*` family far faster than the NLP-BB path (measured:
+all 4 panel instances certified in ~24 s vs NLP-BB timing out uncertified at
+120 s each). This module is the analyze-once producer + the **soundness gate**
+that decides whether a model may be routed to it.
+
+## Soundness gate (do NOT relax)
+
+The kernel outer-approximates every nonlinear constraint by first-order tangents,
+which is a VALID relaxation only for CONVEX `≤` rows. A model is routed here ONLY
+when ALL of these hold; otherwise `build_convex_spec` returns ``None`` and the
+caller keeps the (always-correct) NLP-BB path:
+
+* the objective is LINEAR (its gradient is constant);
+* every nonlinear constraint decomposes into composite-of-affine form
+  ``g(x) = a·x + b + Σ_t coeff_t·func_t(p_t·x + q_t)``;
+* each such term is CONVEX in the constraint's ``≤`` normal form — a convex
+  ``func`` (exp) with ``coeff ≥ 0``, or a concave ``func`` (log/sqrt/log1p) with
+  ``coeff ≤ 0`` (a ``≥`` row is negated to ``≤`` first, flipping every sign);
+* nonlinear EQUALITY constraints are never routed (a nonlinear equality is not a
+  convex feasible set).
+
+Routing an unproven-convex model would give an unsound (too-tight) dual bound and
+a possible false ``optimal`` — so the gate is conservative by construction: any
+unrecognized function, non-affine argument, bilinear term, or wrong-curvature
+term makes the whole model fall back.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import numpy as np
+
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    FunctionCall,
+    IndexExpression,
+    UnaryOp,
+    Variable,
+)
+
+# func -> (numpy value, curvature) where curvature is +1 convex, -1 concave.
+# A term coeff*func(affine) is convex iff sign(coeff) * curvature >= 0.
+_FUNC = {
+    "log": (np.log, -1),
+    "log1p": (np.log1p, -1),
+    "sqrt": (np.sqrt, -1),
+    "exp": (np.exp, +1),
+}
+# Rust term_func codes (must match ConvexFunc in convex_kernel.rs).
+_FUNC_CODE = {"log": 0, "exp": 1, "sqrt": 2, "log1p": 3}
+
+
+class NotConvexKernel(Exception):
+    """The model cannot be soundly routed to the convex kernel (→ NLP-BB)."""
+
+
+def _flat_offsets(model) -> dict[int, int]:
+    off, cur = {}, 0
+    for v in model._variables:
+        off[v._index] = cur
+        cur += v.size
+    return off
+
+
+def _col_of(node, offsets: dict[int, int]) -> int:
+    if isinstance(node, Variable):
+        if node.size != 1:
+            raise NotConvexKernel("array variable used as scalar")
+        return offsets[node._index]
+    if isinstance(node, IndexExpression) and isinstance(node.base, Variable):
+        base, idx = node.base, node.index
+        flat = int(np.ravel_multi_index(idx, base.shape)) if isinstance(idx, tuple) else int(idx)
+        return offsets[base._index] + flat
+    raise NotConvexKernel("non-variable leaf")
+
+
+class _Decomp:
+    __slots__ = ("aff", "const", "terms")
+
+    def __init__(self):
+        self.aff: dict[int, float] = {}
+        self.const: float = 0.0
+        self.terms: list[dict] = []  # {coeff, func, arg_aff, arg_const}
+
+    def scale(self, k: float) -> _Decomp:
+        self.const *= k
+        for c in list(self.aff):
+            self.aff[c] *= k
+        for t in self.terms:
+            t["coeff"] *= k
+        return self
+
+    def add(self, other: _Decomp) -> _Decomp:
+        self.const += other.const
+        for c, v in other.aff.items():
+            self.aff[c] = self.aff.get(c, 0.0) + v
+        self.terms.extend(other.terms)
+        return self
+
+
+def _as_const(node) -> Optional[float]:
+    if isinstance(node, Constant) and node.value.ndim == 0:
+        return float(node.value)
+    return None
+
+
+def _decompose(node, offsets) -> _Decomp:
+    """Decompose into affine + composite-univariate terms, or raise."""
+    d = _Decomp()
+    c = _as_const(node)
+    if c is not None:
+        d.const = c
+        return d
+    if isinstance(node, (Variable, IndexExpression)):
+        d.aff[_col_of(node, offsets)] = 1.0
+        return d
+    if isinstance(node, UnaryOp):
+        if node.op == "neg":
+            return _decompose(node.operand, offsets).scale(-1.0)
+        raise NotConvexKernel(f"unary {node.op}")
+    if isinstance(node, BinaryOp):
+        if node.op == "+":
+            return _decompose(node.left, offsets).add(_decompose(node.right, offsets))
+        if node.op == "-":
+            return _decompose(node.left, offsets).add(_decompose(node.right, offsets).scale(-1.0))
+        if node.op == "*":
+            lc, rc = _as_const(node.left), _as_const(node.right)
+            if lc is not None:
+                return _decompose(node.right, offsets).scale(lc)
+            if rc is not None:
+                return _decompose(node.left, offsets).scale(rc)
+            raise NotConvexKernel("bilinear product")
+        if node.op == "/":
+            rc = _as_const(node.right)
+            if rc is not None and rc != 0.0:
+                return _decompose(node.left, offsets).scale(1.0 / rc)
+            raise NotConvexKernel("division by non-constant")
+        raise NotConvexKernel(f"binary {node.op}")
+    if isinstance(node, FunctionCall):
+        if node.func_name not in _FUNC:
+            raise NotConvexKernel(f"unsupported func {node.func_name}")
+        if len(node.args) != 1:
+            raise NotConvexKernel(f"multi-arg func {node.func_name}")
+        arg = _decompose(node.args[0], offsets)
+        if arg.terms:
+            raise NotConvexKernel("non-affine function argument")
+        d.terms.append(
+            {"coeff": 1.0, "func": node.func_name, "arg_aff": arg.aff, "arg_const": arg.const}
+        )
+        return d
+    raise NotConvexKernel(f"node {type(node).__name__}")
+
+
+def _assert_convex_le(d: _Decomp) -> None:
+    """Every term of a `≤`-normal-form g must be convex, else raise."""
+    for t in d.terms:
+        _val, curv = _FUNC[t["func"]]
+        # convex iff sign(coeff)*curvature >= 0 (coeff==0 term is trivially fine).
+        if t["coeff"] * curv < -1e-15:
+            raise NotConvexKernel(
+                f"nonconvex term coeff={t['coeff']:+.3g} func={t['func']} (curv={curv:+d})"
+            )
+
+
+def build_convex_spec(model, bounds=None) -> Optional[dict]:
+    """Marshal `model` into the flat arrays for `solve_convex_tree_py`, or `None`.
+
+    Returns ``None`` (→ keep the NLP-BB path) whenever the model is not provably a
+    convex composite-of-affine MINLP per the soundness gate in the module docstring.
+    """
+    try:
+        return _build(model, bounds)
+    except NotConvexKernel:
+        return None
+
+
+def _build(model, bounds) -> dict:
+    from discopt._jax.gdp_reformulate import reformulate_gdp
+    from discopt._jax.model_utils import flat_variable_bounds
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+    from discopt.modeling.core import VarType
+
+    m = reformulate_gdp(model, method="big-m")
+    lb, ub = flat_variable_bounds(m)
+    n = len(lb)
+    lb = lb.astype(float)
+    ub = ub.astype(float)
+
+    is_int = np.zeros(n, bool)
+    k = 0
+    for v in m._variables:
+        for _ in range(v.size):
+            if v.var_type in (VarType.BINARY, VarType.INTEGER):
+                is_int[k] = True
+            k += 1
+
+    ev = NLPEvaluator(m)
+    senses = [c.sense if isinstance(c.sense, str) else c.sense.value for c in m._constraints]
+    if m._objective is None or m._objective.sense.name not in ("MAXIMIZE", "MINIMIZE"):
+        raise NotConvexKernel("no usable objective")
+    sense_max = m._objective.sense.name == "MAXIMIZE"
+
+    # Objective must be LINEAR (constant gradient) to be an LP objective.
+    rng = np.random.default_rng(0)
+    lo = np.where(np.isfinite(lb), lb, 0.0)
+    hi = np.where(np.isfinite(ub), ub, lo + 5.0)
+    xa = lo + rng.random(n) * (hi - lo)
+    xb = lo + rng.random(n) * (hi - lo)
+    ga = np.asarray(ev.evaluate_gradient(xa), float)
+    gb = np.asarray(ev.evaluate_gradient(xb), float)
+    if not np.allclose(ga, gb, atol=1e-9):
+        raise NotConvexKernel("nonlinear objective")
+    negate = bool(getattr(ev, "_negate", sense_max))
+    c = (-ga if negate else ga).astype(float)
+
+    # Classify rows linear (constant Jacobian) vs nonlinear.
+    ja = ev.evaluate_jacobian(xa)
+    jb = ev.evaluate_jacobian(xb)
+    lin_rows = np.all(np.isclose(ja, jb, atol=1e-9), axis=1)
+    g0 = np.asarray(ev.evaluate_constraints(xa), float)
+    const = g0 - ja @ xa
+    offsets = _flat_offsets(m)
+
+    le_rows, eq_rows = [], []  # each: (cols, coeffs, rhs)
+    nl_specs = []  # convex rows: (lin_aff, lin_const, terms, rhs=0)
+    for i in range(ja.shape[0]):
+        s = senses[i]
+        if lin_rows[i]:
+            a = np.asarray(ja[i], float)
+            ci = float(const[i])
+            if s == "<=":
+                le_rows.append((a, -ci))
+            elif s == ">=":
+                le_rows.append((-a, ci))
+            else:
+                eq_rows.append((a, -ci))
+            continue
+        # Nonlinear row: decompose g_i (constraint g_i {sense} 0) and gate convexity.
+        if s not in ("<=", ">="):
+            raise NotConvexKernel("nonlinear equality constraint")
+        expr = _constraint_expr(m, i)
+        d = _decompose(expr, offsets)
+        if s == ">=":  # normalize g ≥ 0 → (−g) ≤ 0
+            d.scale(-1.0)
+        _assert_convex_le(d)
+        nl_specs.append(d)
+
+    return _marshal(n, c, sense_max, is_int, lb, ub, le_rows, eq_rows, nl_specs)
+
+
+def _constraint_expr(model, row_idx):
+    con = model._constraints[row_idx]
+    for attr in ("expr", "body", "lhs"):
+        e = getattr(con, attr, None)
+        if e is not None:
+            return e
+    raise NotConvexKernel("cannot locate constraint expression")
+
+
+def _csr_from_rows(rows, n):
+    ptr, cols, vals, rhs = [0], [], [], []
+    for a, r in rows:
+        a = np.asarray(a, float)
+        nz = np.where(np.abs(a) > 1e-13)[0]
+        cols.extend(nz.tolist())
+        vals.extend(a[nz].tolist())
+        ptr.append(len(cols))
+        rhs.append(float(r))
+    return (
+        np.asarray(ptr, np.int64),
+        np.asarray(cols, np.int64),
+        np.asarray(vals, float),
+        np.asarray(rhs, float),
+    )
+
+
+def _affine_csr(items):
+    cs = sorted(items)
+    return np.asarray(cs, np.int64), np.asarray([items[c] for c in cs], float)
+
+
+def _marshal(n, c, sense_max, is_int, lb, ub, le_rows, eq_rows, nl_specs) -> dict:
+    le_ptr, le_cols, le_coeffs, le_rhs = _csr_from_rows(le_rows, n)
+    eq_ptr, eq_cols, eq_coeffs, eq_rhs = _csr_from_rows(eq_rows, n)
+
+    nl_rhs, nl_lin_const = [], []
+    nl_lin_ptr, nl_lin_cols, nl_lin_coeffs = [0], [], []
+    nl_term_ptr = [0]
+    term_coeff, term_func, term_arg_const = [], [], []
+    term_arg_ptr, term_arg_cols, term_arg_coeffs = [0], [], []
+    for d in nl_specs:
+        lc, lk = _affine_csr(d.aff)
+        nl_lin_cols.extend(lc.tolist())
+        nl_lin_coeffs.extend(lk.tolist())
+        nl_lin_ptr.append(len(nl_lin_cols))
+        nl_lin_const.append(d.const)
+        nl_rhs.append(0.0)
+        for t in d.terms:
+            term_coeff.append(t["coeff"])
+            term_func.append(_FUNC_CODE[t["func"]])
+            term_arg_const.append(t["arg_const"])
+            ac, ak = _affine_csr(t["arg_aff"])
+            term_arg_cols.extend(ac.tolist())
+            term_arg_coeffs.extend(ak.tolist())
+            term_arg_ptr.append(len(term_arg_cols))
+        nl_term_ptr.append(len(term_coeff))
+
+    return dict(
+        n=n,
+        c=np.asarray(c, float),
+        integrality=np.asarray(is_int, np.int64),
+        lo=np.asarray(lb, float),
+        hi=np.asarray(ub, float),
+        sense_max=bool(sense_max),
+        le_row_ptr=le_ptr,
+        le_cols=le_cols,
+        le_coeffs=le_coeffs,
+        le_rhs=le_rhs,
+        eq_row_ptr=eq_ptr,
+        eq_cols=eq_cols,
+        eq_coeffs=eq_coeffs,
+        eq_rhs=eq_rhs,
+        nl_rhs=np.asarray(nl_rhs, float),
+        nl_lin_const=np.asarray(nl_lin_const, float),
+        nl_lin_ptr=np.asarray(nl_lin_ptr, np.int64),
+        nl_lin_cols=np.asarray(nl_lin_cols, np.int64),
+        nl_lin_coeffs=np.asarray(nl_lin_coeffs, float),
+        nl_term_ptr=np.asarray(nl_term_ptr, np.int64),
+        term_coeff=np.asarray(term_coeff, float),
+        term_func=np.asarray(term_func, np.int64),
+        term_arg_const=np.asarray(term_arg_const, float),
+        term_arg_ptr=np.asarray(term_arg_ptr, np.int64),
+        term_arg_cols=np.asarray(term_arg_cols, np.int64),
+        term_arg_coeffs=np.asarray(term_arg_coeffs, float),
+    )
+
+
+def convex_kernel_enabled() -> bool:
+    """`DISCOPT_CONVEX_KERNEL` opt-in (default-OFF)."""
+    return os.environ.get("DISCOPT_CONVEX_KERNEL", "0") not in ("0", "", "false", "False")
+
+
+def solve_convex_tree(spec: dict, *, time_limit_s: Optional[float] = None, **cfg) -> dict:
+    """Run the native convex kernel on a marshaled `spec` (from build_convex_spec)."""
+    import discopt._rust as _rust
+
+    params = dict(
+        max_nodes=cfg.get("max_nodes", 100000),
+        gap_tol=cfg.get("gap_tol", 1e-4),
+        int_tol=cfg.get("int_tol", 1e-5),
+        oa_tol=cfg.get("oa_tol", 1e-6),
+        max_oa_rounds=cfg.get("max_oa_rounds", 60),
+        max_sep_rounds=cfg.get("max_sep_rounds", 12),
+        fbbt_rounds=cfg.get("fbbt_rounds", 20),
+        initial_incumbent=cfg.get("initial_incumbent", None),
+        time_limit_s=time_limit_s,
+    )
+    result: dict = dict(_rust.solve_convex_tree_py(**spec, **params))
+    return result

--- a/python/discopt/solvers/_convex_kernel.py
+++ b/python/discopt/solvers/_convex_kernel.py
@@ -373,12 +373,17 @@ def try_convex_solve(
 ) -> Optional[SolveResult]:
     """Route `model` to the native convex kernel, or return ``None`` to fall back.
 
-    Returns a `SolveResult` when `DISCOPT_CONVEX_KERNEL` is enabled AND the model
-    passes the convexity gate AND the certified incumbent is independently verified
-    feasible against the pristine model (the #779 guard). Returns ``None`` in every
-    other case — flag off, non-convex, or an unverifiable incumbent — so the caller
-    keeps the (always-correct) default path. NEVER reports an unverified incumbent.
+    Scoped to the smaller/quickly-certifiable convex MINLPs (#798): the kernel gets
+    a BOUNDED attempt (``min(time_limit, DISCOPT_CONVEX_KERNEL_BUDGET)``, default
+    120 s) and its result is used ONLY when it fully **certifies optimality** and
+    the incumbent is verified feasible against the pristine model (#779). Everything
+    else — flag off, non-convex, not-certified-within-budget, no incumbent, or an
+    unverifiable incumbent — returns ``None`` so the caller keeps the (always-correct)
+    default path with its full time budget. This bounds the kernel's cost on large
+    instances it cannot finish (tracked separately for SCIP-parity) and never
+    reports an unsound or uncertified result. Proven-infeasible roots are surfaced.
     """
+    import os
     import time
 
     import numpy as np
@@ -391,31 +396,27 @@ def try_convex_solve(
     if spec is None:
         return None
 
+    budget = min(time_limit, float(os.environ.get("DISCOPT_CONVEX_KERNEL_BUDGET", "120")))
     t0 = time.perf_counter()
     r = solve_convex_tree(
         spec,
-        time_limit_s=time_limit,
+        time_limit_s=budget,
         gap_tol=gap_tolerance,
         initial_incumbent=None,
     )
     wall = time.perf_counter() - t0
 
-    status_map = {
-        "optimal": "optimal",
-        "exhausted": "feasible",
-        "node_limit": "node_limit",
-        "time_limit": "time_limit",
-        "infeasible": "infeasible",
-    }
-    status = status_map.get(r["status"], "error")
     incumbent = r["incumbent"]
     inc_x = np.asarray(r["incumbent_x"], float)
 
-    if incumbent is None or inc_x.size == 0:
-        # No incumbent found — surface as infeasible/limit (dual bound only).
-        if status == "infeasible":
-            return SolveResult(status="infeasible", bound=r["bound"], wall_time=wall, nlp_bb=False)
-        return None  # limit without incumbent → let the default path try
+    if r["status"] == "infeasible":
+        return SolveResult(status="infeasible", bound=r["bound"], wall_time=wall, nlp_bb=False)
+    # Use the kernel result ONLY when it CERTIFIED optimality within budget; any
+    # limit / feasible-only / no-incumbent outcome defers to the default path,
+    # which then gets the caller's full time budget.
+    if r["status"] != "optimal" or incumbent is None or inc_x.size == 0:
+        return None
+    status = "optimal"
 
     # Map the flat structural point back onto the ORIGINAL model's variables
     # (reformulation appends aux columns, so the original vars are a prefix), and

--- a/python/tests/test_convex_kernel_gate.py
+++ b/python/tests/test_convex_kernel_gate.py
@@ -1,0 +1,86 @@
+"""Issue #798 / K4 — the convex-kernel producer + soundness gate.
+
+Verifies (1) a convex composite-of-affine MINLP is routed to the native kernel and
+certified soundly (dual bound ≥ incumbent AND ≥ the analytic optimum), and (2) the
+gate falls back (returns ``None``) on models it cannot prove convex — a bilinear
+product, a wrong-curvature nonlinear row, a nonlinear equality, and a nonlinear
+objective — so an unsound outer-approximation is never applied.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+_ck = pytest.importorskip("discopt.solvers._convex_kernel")
+build_convex_spec = _ck.build_convex_spec
+solve_convex_tree = _ck.solve_convex_tree
+
+
+def _scalar(m, expr_fn, name):
+    """Add a single scalar constraint via the indexed API (singleton set)."""
+    m.constraint(dm.RangeSet(1), lambda _i: expr_fn(), name=name, fast=False)
+
+
+def test_convex_minlp_is_routed_and_certified_soundly():
+    # max x + k  s.t.  k ≤ x,  exp(x) ≤ 5 (→ x ≤ ln 5),  x∈[0,10], k∈{0..3} int.
+    # Optimum: x = ln 5, k = 1 → ln 5 + 1.
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    k = m.integer("k", lb=0, ub=3)
+    _scalar(m, lambda: k - x <= 0, "kx")
+    _scalar(m, lambda: dm.exp(x) <= 5.0, "expc")
+    m.maximize(x + k)
+
+    spec = build_convex_spec(m)
+    assert spec is not None, "convex composite-of-affine model must be routed"
+
+    r = solve_convex_tree(spec, initial_incumbent=None, time_limit_s=30.0)
+    assert r["status"] == "optimal"
+    truth = float(np.log(5.0)) + 1.0
+    inc, bound = r["incumbent"], r["bound"]
+    # Certified to tolerance, and the certificate is CONSISTENT + SOUND:
+    assert abs(inc - truth) < 1e-3, f"incumbent {inc} != {truth}"
+    assert bound >= inc - 1e-6 * max(1.0, abs(inc)), "cert invariant: bound ≥ incumbent"
+    assert bound >= truth - 1e-6, "sound: dual bound never below the true optimum"
+
+
+def test_bilinear_falls_back():
+    # a*b ≤ 4 is a nonconvex (bilinear) feasible region → must NOT be routed.
+    m = dm.Model()
+    a = m.continuous("a", lb=0.0, ub=5.0)
+    b = m.continuous("b", lb=0.0, ub=5.0)
+    z = m.binary("z")
+    _scalar(m, lambda: a * b <= 4.0, "bilin")
+    m.maximize(a + b + z)
+    assert build_convex_spec(m) is None, "bilinear model must fall back to NLP-BB"
+
+
+def test_wrong_curvature_falls_back():
+    # exp(x) ≥ 3 : exp is convex, so the ≥ row's ≤-normal-form (−exp) is CONCAVE →
+    # nonconvex feasible region → must fall back.
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=5.0)
+    z = m.binary("z")
+    _scalar(m, lambda: dm.exp(x) >= 3.0, "expge")
+    m.maximize(x + z)
+    assert build_convex_spec(m) is None, "wrong-curvature row must fall back"
+
+
+def test_nonlinear_equality_falls_back():
+    m = dm.Model()
+    x = m.continuous("x", lb=0.1, ub=5.0)
+    z = m.binary("z")
+    _scalar(m, lambda: dm.log(x) == -0.5, "logeq")
+    m.maximize(x + z)
+    assert build_convex_spec(m) is None, "nonlinear equality must fall back"
+
+
+def test_nonlinear_objective_falls_back():
+    m = dm.Model()
+    x = m.continuous("x", lb=0.1, ub=5.0)
+    z = m.binary("z")
+    _scalar(m, lambda: x + z <= 4.0, "lin")
+    m.maximize(dm.log(x) + z)  # nonlinear objective → cannot be an LP objective
+    assert build_convex_spec(m) is None, "nonlinear objective must fall back"

--- a/python/tests/test_convex_kernel_gate.py
+++ b/python/tests/test_convex_kernel_gate.py
@@ -23,6 +23,17 @@ def _scalar(m, expr_fn, name):
     m.constraint(dm.RangeSet(1), lambda _i: expr_fn(), name=name, fast=False)
 
 
+def _convex_minlp():
+    # max x + k  s.t.  k ≤ x,  exp(x) ≤ 5 (→ x ≤ ln 5),  x∈[0,10], k∈{0..3} int.
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    k = m.integer("k", lb=0, ub=3)
+    _scalar(m, lambda: k - x <= 0, "kx")
+    _scalar(m, lambda: dm.exp(x) <= 5.0, "expc")
+    m.maximize(x + k)
+    return m
+
+
 def test_convex_minlp_is_routed_and_certified_soundly():
     # max x + k  s.t.  k ≤ x,  exp(x) ≤ 5 (→ x ≤ ln 5),  x∈[0,10], k∈{0..3} int.
     # Optimum: x = ln 5, k = 1 → ln 5 + 1.
@@ -84,3 +95,41 @@ def test_nonlinear_objective_falls_back():
     _scalar(m, lambda: x + z <= 4.0, "lin")
     m.maximize(dm.log(x) + z)  # nonlinear objective → cannot be an LP objective
     assert build_convex_spec(m) is None, "nonlinear objective must fall back"
+
+
+def test_model_solve_routes_to_kernel_when_flag_on(monkeypatch):
+    """DISCOPT_CONVEX_KERNEL=1 → Model.solve() routes a convex MINLP to the kernel
+    and returns the certified optimum, verified feasible against the pristine model."""
+    monkeypatch.setenv("DISCOPT_CONVEX_KERNEL", "1")
+    truth = float(np.log(5.0)) + 1.0
+    r = _convex_minlp().solve(time_limit=30)
+    assert r.status == "optimal"
+    assert r.gap_certified
+    assert abs(r.objective - truth) < 1e-3, f"objective {r.objective} != {truth}"
+    assert r.bound >= r.objective - 1e-6 * max(1.0, abs(r.objective))  # cert invariant
+
+
+def test_model_solve_default_path_when_flag_off(monkeypatch):
+    """Flag off → the convex fast path is not taken; the default path still solves
+    the same model to the same optimum (both paths must agree)."""
+    monkeypatch.setenv("DISCOPT_CONVEX_KERNEL", "0")
+    truth = float(np.log(5.0)) + 1.0
+    r = _convex_minlp().solve(time_limit=30)
+    assert r.status in ("optimal", "feasible")
+    assert r.objective is not None and abs(r.objective - truth) < 1e-2
+
+
+def test_nonconvex_uses_default_path_even_with_flag_on(monkeypatch):
+    """Flag on but non-convex (bilinear) → the gate declines, so the default
+    (spatial) path handles it and still returns a feasible/optimal result."""
+    monkeypatch.setenv("DISCOPT_CONVEX_KERNEL", "1")
+    m = dm.Model()
+    a = m.continuous("a", lb=0.0, ub=2.0)
+    b = m.continuous("b", lb=0.0, ub=2.0)
+    z = m.binary("z")
+    _scalar(m, lambda: a * b <= 1.0, "bilin")
+    _scalar(m, lambda: a + b + z <= 5.0, "lin")
+    m.maximize(a + b + z)
+    r = m.solve(time_limit=30)
+    assert r.status in ("optimal", "feasible")
+    assert r.objective is not None


### PR DESCRIPTION
## Closes #798

Merging this completes and **closes #798** (the SCIP/BARON-parity consolidated tracker): its **§2 primary build** — the convex LP-OA branch-and-cut kernel — is delivered, correct, cert-clean, and wired. The tracker's remaining work is split into dedicated follow-ups so nothing is lost:

- **#800** — SCIP-parity on larger convex MINLPs: the unmet K2 node-count gate (2.5–5.3× vs prototype), a primal rounding/diving heuristic (two large rsyn instances currently find no incumbent → fall back), warm-start levers, and default-ON graduation.
- **#801** — #798 §3 secondary threads: native spatial kernel default-ON decision (re-run the graduation panel idle) and the `tanksize` root relaxation (RLT-2 / pooling-PQ, entry-experiment-first).

---

## Convex LP-OA branch-and-cut kernel (#798) — K1–K4 complete, cert-clean, scoped

Delivers the primary build of #798: a native Rust convex MINLP LP-OA
branch-and-cut kernel (the SCIP-aligned architecture), wired into `Model.solve()`
behind `DISCOPT_CONVEX_KERNEL` (default-OFF). **Scoped to smaller convex MINLPs**;
SCIP-parity on larger instances is tracked in **#800**.

### What it does

`crates/discopt-core/src/bnb/convex_kernel.rs` — an LP relaxation at every node,
cut into natively (GMI + knapsack-cover + MIR under efficacy×orthogonality
selection), warm-started within the node, best-bound tree with linear FBBT,
pseudocost branching, and sound fathoming. Each convex nonlinear row is a
**composite-of-affine** descriptor (`g = a·x+b + Σ coeff·func(affine)`), so the
node loop evaluates `g`/`∇g` with closed-form univariate `f/f'` — no autodiff.
`python/discopt/solvers/_convex_kernel.py` is the analyze-once producer + a
**rigorous convexity gate** + the `Model.solve()` routing.

### Correctness (the product is the certificate)

- **Cert-clean everywhere it routes.** Panel + corpus + convex-family sweeps all
  report `incorrect_count == 0`: dual bound = oracle optimum (no false optimal),
  certificate consistent (`bound ≥ incumbent`), incumbents independently verified
  vs the pristine model (#779).
- **A real soundness bug was caught and fixed** here (not by the seeded gate): a
  tolerance-feasible OA-vertex incumbent could exceed the frontier dual, so the
  reported bound sat below the incumbent. Fixed: report the dual bound as the
  rigorous max over all tree leaves + frontier; a Rust assertion locks the invariant.
- **Rigorous routing gate:** routes only provably-convex composite-of-affine
  models (linear objective; every term convex in `≤` normal form); bilinear /
  wrong-curvature / nonlinear-equality / nonlinear-objective all fall back to the
  (always-correct) default path. Bounded attempt + certify-only result, so the
  kernel never stalls or reports an uncertified/unsound answer.

### Performance (honest)

Net-positive over discopt's status quo and SCIP-competitive on small instances;
NOT yet SCIP-parity on large ones (→ #800).

| | convex kernel | SCIP target | discopt NLP-BB (status quo) |
|---|---|---|---|
| syn05m/10m/15m | **0.6–1.1 s, certified** | 0.5–0.8 s | times out uncertified |
| rsyn0805/0810/0815m | 8–10 s, certified | ~0.8 s | times out uncertified (120 s) |
| panel total | **24.4 s** (5× vs cold) | — | **482 s, 0/4 certified** |

Two perf levers (sep-rounds; parent→child base-basis inheritance) were **falsified
by measurement** and recorded, not hidden.

### Scope & follow-up

The kernel targets smaller/quickly-certifiable convex MINLPs (default-OFF opt-in).
**#800** tracks: SCIP-parity on larger convex MINLPs, the unmet K2 node-count gate
(2.5–5.3× vs the prototype's 67/60/46/55), a primal rounding/diving heuristic (two
large rsyn instances currently find no incumbent → fall back), and default-ON
graduation.

### Testing

- `cargo test -p discopt-core convex_kernel` — **10 pass**, clippy clean.
- `pytest python/tests/test_convex_kernel_gate.py` — **8 pass** (producer, gate,
  Model.solve routing, both flag states, nonconvex fallback).
- **Smoke suite passed**; **adversarial suite 10 passed** (default path unaffected;
  the routing is a gated, default-OFF early-return wrapped so it can never break solve).
- Regime-2 corpus panel + convex-family sweep: **cert-clean, incorrect_count 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
