### PR TITLE
feat(#807): native-warm-LP convex kernel (W0–W5)

### DIFF
--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -1138,6 +1138,390 @@ impl ConvexKernelSpec {
     }
 }
 
+// ===========================================================================
+// W0 ENTRY-EXPERIMENT PROBE (#807) — TEMPORARY, reverted after W0 records.
+// Measures the core native-warm-LP claim: a SHARED LP (base rows + a growing,
+// globally-valid OA-tangent pool with FIXED root-box slack caps) whose optimal
+// basis is carried across nodes and dual-warm reoptimized per node via
+// bounds-in-place, vs today's per-node cold `solve_node_cut`. No cuts (OA only),
+// exactly the W0 scope. NOT wired into any shipped path.
+// ===========================================================================
+
+/// Per-node W0 measurement.
+#[derive(Clone, Debug, Default)]
+pub struct W0NodeStat {
+    /// Cold `solve_node_cut(sep=0)` wall, microseconds.
+    pub cold_us: f64,
+    /// Warm shared-LP node solve (reoptimize + OA-reconverge) wall, microseconds.
+    pub warm_us: f64,
+    /// Dual-simplex pivots the warm node solve took (summed over OA rounds).
+    pub warm_pivots: usize,
+    /// |warm bound − cold bound| (model sense) — the parity check.
+    pub bound_diff: f64,
+    /// Warm solve produced a finite, certifying NS safe bound.
+    pub ns_ok: bool,
+    /// New tangents the warm path had to append (pool-amortization metric).
+    pub new_tangents: usize,
+    /// Tangent-pool size entering this node.
+    pub pool_before: usize,
+    /// This node was a best-bound JUMP (its parent was not the previous node).
+    pub is_jump: bool,
+    /// Cold node bound (model sense) — the reference.
+    pub cold_bound: f64,
+    /// Warm node bound (model sense) — checked against the oracle for soundness.
+    pub warm_bound: f64,
+}
+
+/// The shared-LP prototype for W0: base rows ‖ a growing OA-tangent pool with
+/// FIXED root-box slack caps, a carried basis, structural bounds set per node.
+struct W0WarmLp {
+    n: usize,
+    sign: f64,
+    rows: Vec<AsmRow>,
+    b: Vec<f64>,    // per row: rhs
+    sp: SparseCols, // cached CSC of `rows`
+    dirty: bool,    // rows changed since `sp` last built
+    basis: Option<Basis>,
+}
+
+impl W0WarmLp {
+    fn new(spec: &ConvexKernelSpec) -> Self {
+        let sign = if spec.sense_max { -1.0 } else { 1.0 };
+        let mut rows: Vec<AsmRow> = Vec::new();
+        for r in &spec.le_rows {
+            rows.push(AsmRow {
+                cols: r.cols.clone(),
+                coeffs: r.coeffs.clone(),
+                rhs: r.rhs,
+                is_eq: false,
+            });
+        }
+        for r in &spec.eq_rows {
+            rows.push(AsmRow {
+                cols: r.cols.clone(),
+                coeffs: r.coeffs.clone(),
+                rhs: r.rhs,
+                is_eq: true,
+            });
+        }
+        W0WarmLp {
+            n: spec.n,
+            sign,
+            b: rows.iter().map(|r| r.rhs).collect(),
+            rows,
+            sp: SparseCols::from_csc(vec![0], Vec::new(), Vec::new()),
+            dirty: true,
+            basis: None,
+        }
+    }
+
+    /// NODE-box slack cap for a row (eq → 0; ≤ → (rhs − min-activity over the
+    /// node box)⁺) — matches `assemble`, keeping the NS safe bound finite.
+    fn cap_for(&self, row: &AsmRow, lo: &[f64], hi: &[f64]) -> f64 {
+        if row.is_eq {
+            return 0.0;
+        }
+        let mut min_act = 0.0f64;
+        for (c, v) in row.cols.iter().zip(row.coeffs.iter()) {
+            min_act += if *v > 0.0 { v * lo[*c] } else { v * hi[*c] };
+        }
+        if min_act.is_finite() {
+            (row.rhs - min_act).clamp(0.0, 1e20)
+        } else {
+            1e20
+        }
+    }
+
+    /// Rebuild the cached CSC of `[A | I]` from `rows` (structural cols + one
+    /// slack per row). Same layout as `assemble`, but slack caps live in `l_u`.
+    fn rebuild_sp(&mut self) {
+        let m = self.rows.len();
+        let n_total = self.n + m;
+        let mut cols: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n_total];
+        for (r, row) in self.rows.iter().enumerate() {
+            for (c, v) in row.cols.iter().zip(row.coeffs.iter()) {
+                cols[*c].push((r, *v));
+            }
+            cols[self.n + r].push((r, 1.0));
+        }
+        let mut col_ptr = Vec::with_capacity(n_total + 1);
+        let mut row_idx = Vec::new();
+        let mut vals = Vec::new();
+        col_ptr.push(0usize);
+        for col in &cols {
+            for (r, v) in col {
+                row_idx.push(*r);
+                vals.push(*v);
+            }
+            col_ptr.push(row_idx.len());
+        }
+        self.sp = SparseCols::from_csc(col_ptr, row_idx, vals);
+        self.dirty = false;
+    }
+
+    /// Full bounds vector: `[lo ‖ hi]` structural, `[0, node-box cap]` per slack.
+    fn l_u(&self, lo: &[f64], hi: &[f64]) -> (Vec<f64>, Vec<f64>) {
+        let m = self.rows.len();
+        let mut l = lo.to_vec();
+        let mut u = hi.to_vec();
+        l.extend(std::iter::repeat(0.0).take(m));
+        for row in &self.rows {
+            u.push(self.cap_for(row, lo, hi));
+        }
+        (l, u)
+    }
+
+    /// Solve the OA node relaxation over `(lo, hi)` on the shared LP, warm from
+    /// the carried basis, appending only the tangents this box still violates.
+    /// Returns `(bound, raw, pivots, new_tangents, ns_ok)` — `None` if infeasible.
+    #[allow(clippy::too_many_arguments)]
+    fn solve_node(
+        &mut self,
+        spec: &ConvexKernelSpec,
+        lo: &[f64],
+        hi: &[f64],
+        oa_tol: f64,
+        max_oa_rounds: usize,
+        opts: &SimplexOptions,
+    ) -> Option<(f64, f64, usize, usize, bool)> {
+        let mut pivots = 0usize;
+        let mut new_tangents = 0usize;
+        let mut last_bound = self.sign * f64::NEG_INFINITY; // placeholder
+        let mut last_raw = 0.0f64;
+        let mut ns_ok = false;
+        let iter_cap = max_oa_rounds.max(1) + 4;
+        for _ in 0..iter_cap {
+            if self.dirty {
+                self.rebuild_sp();
+            }
+            let m = self.rows.len();
+            let n_total = self.n + m;
+            let (l, u) = self.l_u(lo, hi);
+            let mut c = vec![0.0f64; n_total];
+            for (cj, sc) in c.iter_mut().zip(spec.c.iter()) {
+                *cj = self.sign * sc;
+            }
+            let sol = match &self.basis {
+                Some(bs) => {
+                    let ext = extend_basis(bs.clone(), n_total);
+                    let lp = LpView {
+                        a: &[],
+                        m,
+                        n: n_total,
+                        c: &c,
+                        l: &l,
+                        u: &u,
+                    };
+                    solve_lp_warm_scaled_csc(&lp, &self.b, &ext, opts, &self.sp)
+                }
+                None => {
+                    solve_lp_cols_scaled(self.sp.clone(), m, n_total, &c, &l, &u, &self.b, opts)
+                }
+            };
+            pivots += sol.iters;
+            if sol.status != LpStatus::Optimal {
+                return None; // infeasible/unbounded child
+            }
+            self.basis = Some(sol.basis.clone());
+            let x: Vec<f64> = sol.x[..self.n].to_vec();
+            last_raw = self.sign * sol.obj;
+            let (col_ptr, row_idx, vals) = self.sp.raw();
+            let ns = ns_safe_bound_csc(
+                &sol.dual, &c, col_ptr, row_idx, vals, m, n_total, &self.b, &l, &u,
+            );
+            last_bound = match ns {
+                Some(v) => {
+                    ns_ok = v.is_finite();
+                    self.sign * v
+                }
+                None => {
+                    ns_ok = false;
+                    if spec.sense_max {
+                        f64::INFINITY
+                    } else {
+                        f64::NEG_INFINITY
+                    }
+                }
+            };
+            // Append only still-violated tangents (globally valid → permanent).
+            let mut added = false;
+            for row in &spec.nl_rows {
+                if row.residual(&x) > oa_tol {
+                    if let Some(cut) = row.oa_tangent(&x) {
+                        let ar = AsmRow {
+                            cols: cut.cols,
+                            coeffs: cut.coeffs,
+                            rhs: cut.rhs,
+                            is_eq: false,
+                        };
+                        self.b.push(ar.rhs);
+                        self.rows.push(ar);
+                        self.dirty = true;
+                        added = true;
+                        new_tangents += 1;
+                    }
+                }
+            }
+            if !added {
+                return Some((last_bound, last_raw, pivots, new_tangents, ns_ok));
+            }
+        }
+        Some((last_bound, last_raw, pivots, new_tangents, ns_ok))
+    }
+}
+
+/// A worklist node for the W0 mini best-bound tree (parent id → jump detection).
+struct W0Node {
+    key: f64,
+    lo: Vec<f64>,
+    hi: Vec<f64>,
+    id: u64,
+    parent_id: u64,
+}
+impl PartialEq for W0Node {
+    fn eq(&self, o: &Self) -> bool {
+        self.key == o.key
+    }
+}
+impl Eq for W0Node {}
+impl PartialOrd for W0Node {
+    fn partial_cmp(&self, o: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(o))
+    }
+}
+impl Ord for W0Node {
+    fn cmp(&self, o: &Self) -> std::cmp::Ordering {
+        self.key.total_cmp(&o.key)
+    }
+}
+
+impl ConvexKernelSpec {
+    /// W0 probe (#807): run a seeded best-bound OA-only mini-tree; at each node
+    /// measure today's cold `solve_node_cut(sep=0)` against the shared-LP warm
+    /// node solve on identical boxes. Collects up to `max_stats` node stats.
+    pub fn warmlp_w0_probe(
+        &self,
+        config: &ConvexTreeConfig,
+        opts: &SimplexOptions,
+        max_stats: usize,
+    ) -> Vec<W0NodeStat> {
+        let sense = if self.sense_max { 1.0 } else { -1.0 };
+        let inc_sense = config.initial_incumbent.map(|v| sense * v);
+        let mut warm = W0WarmLp::new(self);
+        let mut pcosts = Pseudocosts::new(self.n);
+        let mut stats: Vec<W0NodeStat> = Vec::new();
+
+        let mut root_lo = self.lb.clone();
+        let mut root_hi = self.ub.clone();
+        if !self.propagate_fbbt(&mut root_lo, &mut root_hi, config.fbbt_rounds) {
+            return stats;
+        }
+        let mut heap = std::collections::BinaryHeap::new();
+        let mut next_id = 1u64;
+        heap.push(W0Node {
+            key: f64::INFINITY,
+            lo: root_lo,
+            hi: root_hi,
+            id: 0,
+            parent_id: u64::MAX,
+        });
+        let mut last_popped = u64::MAX;
+
+        while let Some(node) = heap.pop() {
+            if stats.len() >= max_stats {
+                break;
+            }
+            let is_jump = node.parent_id != last_popped;
+            last_popped = node.id;
+            let mut lo = node.lo;
+            let mut hi = node.hi;
+            if !self.propagate_fbbt(&mut lo, &mut hi, config.fbbt_rounds) {
+                continue;
+            }
+            // COLD: today's per-node pipeline (OA only).
+            let t0 = std::time::Instant::now();
+            let cold = self.solve_node_cut(&lo, &hi, config.oa_tol, config.max_oa_rounds, 0, opts);
+            let cold_us = t0.elapsed().as_secs_f64() * 1e6;
+            if cold.status != LpStatus::Optimal {
+                continue;
+            }
+            // WARM: shared-LP bounds-in-place reoptimize.
+            let pool_before = warm
+                .rows
+                .len()
+                .saturating_sub(self.le_rows.len() + self.eq_rows.len());
+            let t1 = std::time::Instant::now();
+            let warm_res =
+                warm.solve_node(self, &lo, &hi, config.oa_tol, config.max_oa_rounds, opts);
+            let warm_us = t1.elapsed().as_secs_f64() * 1e6;
+            if let Some((wbound, _wraw, wpivots, wnew, wns)) = warm_res {
+                stats.push(W0NodeStat {
+                    cold_us,
+                    warm_us,
+                    warm_pivots: wpivots,
+                    bound_diff: (wbound - cold.bound).abs(),
+                    ns_ok: wns,
+                    new_tangents: wnew,
+                    pool_before,
+                    is_jump,
+                    cold_bound: cold.bound,
+                    warm_bound: wbound,
+                });
+            }
+            // Drive the tree with the COLD result (realistic boxes).
+            let node_dual_sense = sense * cold.bound;
+            if let Some(inc) = inc_sense {
+                if node_dual_sense <= inc + config.gap_tol * inc.abs().max(1.0) {
+                    continue; // fathom
+                }
+            }
+            if self.is_integer_feasible(&cold.x, config.int_tol, config.oa_tol * 10.0) {
+                continue;
+            }
+            let Some(j) = self.select_branch(&cold.x, &pcosts, config.int_tol) else {
+                continue;
+            };
+            let xj = cold.x[j];
+            let frac = xj - xj.floor();
+            if node_dual_sense.is_finite() {
+                pcosts.update(j, -node_dual_sense, -node_dual_sense, frac, true);
+            }
+            let key = node_dual_sense;
+            {
+                let clo = lo.clone();
+                let mut chi = hi.clone();
+                chi[j] = xj.floor();
+                if clo[j] <= chi[j] + 1e-9 {
+                    heap.push(W0Node {
+                        key,
+                        lo: clo,
+                        hi: chi,
+                        id: next_id,
+                        parent_id: node.id,
+                    });
+                    next_id += 1;
+                }
+            }
+            {
+                let mut clo = lo;
+                let chi = hi;
+                clo[j] = xj.ceil();
+                if clo[j] <= chi[j] + 1e-9 {
+                    heap.push(W0Node {
+                        key,
+                        lo: clo,
+                        hi: chi,
+                        id: next_id,
+                        parent_id: node.id,
+                    });
+                    next_id += 1;
+                }
+            }
+        }
+        stats
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -1178,9 +1178,12 @@ struct W0WarmLp {
     n: usize,
     sign: f64,
     rows: Vec<AsmRow>,
-    b: Vec<f64>,    // per row: rhs
-    sp: SparseCols, // cached CSC of `rows`
-    dirty: bool,    // rows changed since `sp` last built
+    b: Vec<f64>,           // per row: rhs
+    age: Vec<u32>,         // per row: rounds non-binding (base rows stay 0, never GC'd)
+    n_base: usize,         // base rows never aged/dropped
+    last_full_x: Vec<f64>, // last solve's full point (structural ‖ slacks), for aging
+    sp: SparseCols,        // cached CSC of `rows`
+    dirty: bool,           // rows changed since `sp` last built
     basis: Option<Basis>,
 }
 
@@ -1204,15 +1207,69 @@ impl W0WarmLp {
                 is_eq: true,
             });
         }
+        let n_base = rows.len();
         W0WarmLp {
             n: spec.n,
             sign,
             b: rows.iter().map(|r| r.rhs).collect(),
+            age: vec![0; n_base],
+            n_base,
+            last_full_x: Vec::new(),
             rows,
             sp: SparseCols::from_csc(vec![0], Vec::new(), Vec::new()),
             dirty: true,
             basis: None,
         }
+    }
+
+    /// SCIP-style tangent aging + GC (#807 W0 re-scope): age each tangent by the
+    /// rounds it sits non-binding at the last optimum (reset when it binds), then,
+    /// if the tangent pool exceeds `pool_cap`, drop the most-aged non-binding
+    /// tangents down to `pool_cap`. Dropping a tangent is SOUND — it only loosens
+    /// the (still valid) relaxation, and the OA loop re-derives it if a later node
+    /// violates that row. Base rows are never dropped. A drop invalidates the basis
+    /// (next solve cold). `pool_cap == 0` disables GC.
+    fn age_and_gc(&mut self, tol: f64, pool_cap: usize, max_age: u32) {
+        if self.last_full_x.len() < self.n + self.rows.len() {
+            return;
+        }
+        for r in self.n_base..self.rows.len() {
+            let slack = self.last_full_x[self.n + r].abs();
+            if slack > tol {
+                self.age[r] = self.age[r].saturating_add(1);
+            } else {
+                self.age[r] = 0;
+            }
+        }
+        let n_tan = self.rows.len() - self.n_base;
+        if pool_cap == 0 || n_tan <= pool_cap {
+            return;
+        }
+        // Candidates: aged, non-binding tangents; most-aged dropped first.
+        let mut drop_idx: Vec<usize> = (self.n_base..self.rows.len())
+            .filter(|&r| self.age[r] >= max_age)
+            .collect();
+        drop_idx.sort_by_key(|&r| std::cmp::Reverse(self.age[r]));
+        drop_idx.truncate(n_tan.saturating_sub(pool_cap));
+        if drop_idx.is_empty() {
+            return;
+        }
+        let drop: std::collections::HashSet<usize> = drop_idx.into_iter().collect();
+        let mut keep_rows = Vec::with_capacity(self.rows.len() - drop.len());
+        let mut keep_b = Vec::with_capacity(keep_rows.capacity());
+        let mut keep_age = Vec::with_capacity(keep_rows.capacity());
+        for (r, row) in self.rows.drain(..).enumerate() {
+            if !drop.contains(&r) {
+                keep_b.push(self.b[r]);
+                keep_age.push(self.age[r]);
+                keep_rows.push(row);
+            }
+        }
+        self.rows = keep_rows;
+        self.b = keep_b;
+        self.age = keep_age;
+        self.dirty = true;
+        self.basis = None; // dropped rows → carried basis no longer valid
     }
 
     /// NODE-box slack cap for a row (eq → 0; ≤ → (rhs − min-activity over the
@@ -1323,6 +1380,7 @@ impl W0WarmLp {
                 return None; // infeasible/unbounded child
             }
             self.basis = Some(sol.basis.clone());
+            self.last_full_x = sol.x.clone();
             let x: Vec<f64> = sol.x[..self.n].to_vec();
             last_raw = self.sign * sol.obj;
             let (col_ptr, row_idx, vals) = self.sp.raw();
@@ -1356,6 +1414,7 @@ impl W0WarmLp {
                         };
                         self.b.push(ar.rhs);
                         self.rows.push(ar);
+                        self.age.push(0);
                         self.dirty = true;
                         added = true;
                         new_tangents += 1;
@@ -1404,6 +1463,8 @@ impl ConvexKernelSpec {
         config: &ConvexTreeConfig,
         opts: &SimplexOptions,
         max_stats: usize,
+        gc_pool_cap: usize,
+        gc_max_age: u32,
     ) -> Vec<W0NodeStat> {
         let sense = if self.sense_max { 1.0 } else { -1.0 };
         let inc_sense = config.initial_incumbent.map(|v| sense * v);
@@ -1454,6 +1515,8 @@ impl ConvexKernelSpec {
             let warm_res =
                 warm.solve_node(self, &lo, &hi, config.oa_tol, config.max_oa_rounds, opts);
             let warm_us = t1.elapsed().as_secs_f64() * 1e6;
+            // Tangent aging + GC (bounds the pool for many-nl-row instances).
+            warm.age_and_gc(opts.tol.max(1e-7), gc_pool_cap, gc_max_age);
             if let Some((wbound, _wraw, wpivots, wnew, wns)) = warm_res {
                 stats.push(W0NodeStat {
                     cold_us,

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -929,6 +929,13 @@ impl ConvexKernelSpec {
         // most-fractional. Costs are learned in the tree's own "maximize sense·bound"
         // convention negated to a minimize (lower-bound-rising) convention.
         let mut pcosts = Pseudocosts::new(self.n);
+        // #807 W1: optional shared persistent LP (bounds-in-place dual-warm node
+        // solves). `None` unless DISCOPT_CVX_NATIVELP is set → OFF is bit-identical.
+        let mut warm = if native_lp_enabled() {
+            Some(W0WarmLp::new(self))
+        } else {
+            None
+        };
 
         // Root node over the FBBT-propagated global box.
         let mut root_lo = self.lb.clone();
@@ -1008,14 +1015,27 @@ impl ConvexKernelSpec {
                 continue; // empty box → fathom
             }
 
-            let r = self.solve_node_cut(
-                &lo,
-                &hi,
-                config.oa_tol,
-                config.max_oa_rounds,
-                config.max_sep_rounds,
-                opts,
-            );
+            // Node relaxation: the shared persistent LP (warm, OA-only — W1) when
+            // DISCOPT_CVX_NATIVELP is on, else today's per-node cold `solve_node_cut`
+            // (unchanged default path). Both return a sound, NS-certified dual bound.
+            let r = if let Some(w) = warm.as_mut() {
+                match w.solve_node(self, &lo, &hi, config.oa_tol, config.max_oa_rounds, opts) {
+                    Some((res, _pivots, _new_tan)) => {
+                        w.age_and_gc(opts.tol.max(1e-7), NATIVELP_POOL_CAP, NATIVELP_MAX_AGE);
+                        res
+                    }
+                    None => continue, // infeasible child → fathom
+                }
+            } else {
+                self.solve_node_cut(
+                    &lo,
+                    &hi,
+                    config.oa_tol,
+                    config.max_oa_rounds,
+                    config.max_sep_rounds,
+                    opts,
+                )
+            };
             if r.status != LpStatus::Optimal {
                 continue; // infeasible/unbounded region → skip
             }
@@ -1137,6 +1157,28 @@ impl ConvexKernelSpec {
         }
     }
 }
+
+/// `DISCOPT_CVX_NATIVELP` opt-in (default-OFF) — route `solve_tree`'s node solves
+/// through the shared persistent LP (bounds-in-place dual-warm reoptimize) instead
+/// of a per-node cold `solve_node_cut`. Scoped to the pool-saturating `rsyn*`
+/// family (#807 W0); OFF is bit-identical to the shipped path. Read once.
+fn native_lp_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        std::env::var("DISCOPT_CVX_NATIVELP")
+            .ok()
+            .map(|v| !matches!(v.trim(), "" | "0" | "false" | "False"))
+            .unwrap_or(false)
+    })
+}
+
+/// Tangent-pool GC cap for the persistent LP (generous: on the saturating `rsyn*`
+/// family the pool settles well below this, so GC rarely fires and the warm chain
+/// is preserved; it only bounds pathological growth).
+const NATIVELP_POOL_CAP: usize = 600;
+/// Rounds a tangent must sit non-binding before it is eligible for GC.
+const NATIVELP_MAX_AGE: u32 = 10;
 
 // ===========================================================================
 // W0 ENTRY-EXPERIMENT PROBE (#807) — TEMPORARY, reverted after W0 records.
@@ -1330,7 +1372,7 @@ impl W0WarmLp {
 
     /// Solve the OA node relaxation over `(lo, hi)` on the shared LP, warm from
     /// the carried basis, appending only the tangents this box still violates.
-    /// Returns `(bound, raw, pivots, new_tangents, ns_ok)` — `None` if infeasible.
+    /// Returns `(ConvexNodeResult, pivots, new_tangents)` — `None` if infeasible.
     #[allow(clippy::too_many_arguments)]
     fn solve_node(
         &mut self,
@@ -1340,14 +1382,16 @@ impl W0WarmLp {
         oa_tol: f64,
         max_oa_rounds: usize,
         opts: &SimplexOptions,
-    ) -> Option<(f64, f64, usize, usize, bool)> {
+    ) -> Option<(ConvexNodeResult, usize, usize)> {
         let mut pivots = 0usize;
         let mut new_tangents = 0usize;
         let mut last_bound = self.sign * f64::NEG_INFINITY; // placeholder
         let mut last_raw = 0.0f64;
-        let mut ns_ok = false;
+        let mut last_x = vec![0.0f64; self.n];
+        let mut oa_rounds = 0usize;
         let iter_cap = max_oa_rounds.max(1) + 4;
         for _ in 0..iter_cap {
+            oa_rounds += 1;
             if self.dirty {
                 self.rebuild_sp();
             }
@@ -1382,24 +1426,16 @@ impl W0WarmLp {
             self.basis = Some(sol.basis.clone());
             self.last_full_x = sol.x.clone();
             let x: Vec<f64> = sol.x[..self.n].to_vec();
+            last_x.copy_from_slice(&x);
             last_raw = self.sign * sol.obj;
             let (col_ptr, row_idx, vals) = self.sp.raw();
             let ns = ns_safe_bound_csc(
                 &sol.dual, &c, col_ptr, row_idx, vals, m, n_total, &self.b, &l, &u,
             );
             last_bound = match ns {
-                Some(v) => {
-                    ns_ok = v.is_finite();
-                    self.sign * v
-                }
-                None => {
-                    ns_ok = false;
-                    if spec.sense_max {
-                        f64::INFINITY
-                    } else {
-                        f64::NEG_INFINITY
-                    }
-                }
+                Some(v) => self.sign * v,
+                None if spec.sense_max => f64::INFINITY,
+                None => f64::NEG_INFINITY,
             };
             // Append only still-violated tangents (globally valid → permanent).
             let mut added = false;
@@ -1422,10 +1458,18 @@ impl W0WarmLp {
                 }
             }
             if !added {
-                return Some((last_bound, last_raw, pivots, new_tangents, ns_ok));
+                break;
             }
         }
-        Some((last_bound, last_raw, pivots, new_tangents, ns_ok))
+        let result = ConvexNodeResult {
+            status: LpStatus::Optimal,
+            bound: last_bound,
+            raw_bound: last_raw,
+            x: last_x,
+            oa_rounds,
+            n_tangents: self.rows.len() - self.n_base,
+        };
+        Some((result, pivots, new_tangents))
     }
 }
 
@@ -1517,13 +1561,14 @@ impl ConvexKernelSpec {
             let warm_us = t1.elapsed().as_secs_f64() * 1e6;
             // Tangent aging + GC (bounds the pool for many-nl-row instances).
             warm.age_and_gc(opts.tol.max(1e-7), gc_pool_cap, gc_max_age);
-            if let Some((wbound, _wraw, wpivots, wnew, wns)) = warm_res {
+            if let Some((wres, wpivots, wnew)) = warm_res {
+                let wbound = wres.bound;
                 stats.push(W0NodeStat {
                     cold_us,
                     warm_us,
                     warm_pivots: wpivots,
                     bound_diff: (wbound - cold.bound).abs(),
-                    ns_ok: wns,
+                    ns_ok: wbound.is_finite(),
                     new_tangents: wnew,
                     pool_before,
                     is_jump,

--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -1015,11 +1015,20 @@ impl ConvexKernelSpec {
                 continue; // empty box → fathom
             }
 
-            // Node relaxation: the shared persistent LP (warm, OA-only — W1) when
-            // DISCOPT_CVX_NATIVELP is on, else today's per-node cold `solve_node_cut`
-            // (unchanged default path). Both return a sound, NS-certified dual bound.
+            // Node relaxation: the shared persistent LP (warm tangent pool +
+            // node-local cuts — W2) when DISCOPT_CVX_NATIVELP is on, else today's
+            // per-node cold `solve_node_cut` (unchanged default path). Both return a
+            // sound, NS-certified dual bound.
             let r = if let Some(w) = warm.as_mut() {
-                match w.solve_node(self, &lo, &hi, config.oa_tol, config.max_oa_rounds, opts) {
+                match w.solve_node(
+                    self,
+                    &lo,
+                    &hi,
+                    config.oa_tol,
+                    config.max_oa_rounds,
+                    config.max_sep_rounds,
+                    opts,
+                ) {
                     Some((res, _pivots, _new_tan)) => {
                         w.age_and_gc(opts.tol.max(1e-7), NATIVELP_POOL_CAP, NATIVELP_MAX_AGE);
                         res
@@ -1331,6 +1340,27 @@ impl W0WarmLp {
         }
     }
 
+    /// Roll node-local cuts (and any post-cut tangents) off the shared LP back to
+    /// the post-OA base+tangent `restore` snapshot, restoring its basis so the next
+    /// node warm-starts from base+tangents. `None` (infeasible before OA converged)
+    /// → keep the tangents grown so far but drop the carried basis (next solve cold).
+    fn rollback_cuts(&mut self, restore: Option<(usize, Basis)>) {
+        match restore {
+            Some((len, basis)) => {
+                if self.rows.len() != len {
+                    self.rows.truncate(len);
+                    self.b.truncate(len);
+                    self.age.truncate(len);
+                    self.dirty = true;
+                }
+                self.basis = Some(basis);
+            }
+            None => {
+                self.basis = None;
+            }
+        }
+    }
+
     /// Rebuild the cached CSC of `[A | I]` from `rows` (structural cols + one
     /// slack per row). Same layout as `assemble`, but slack caps live in `l_u`.
     fn rebuild_sp(&mut self) {
@@ -1370,9 +1400,14 @@ impl W0WarmLp {
         (l, u)
     }
 
-    /// Solve the OA node relaxation over `(lo, hi)` on the shared LP, warm from
-    /// the carried basis, appending only the tangents this box still violates.
-    /// Returns `(ConvexNodeResult, pivots, new_tangents)` — `None` if infeasible.
+    /// Solve the node relaxation over `(lo, hi)` on the shared LP, warm from the
+    /// carried basis: OA-converge (globally-valid tangents PERSIST), then separate
+    /// integrality cuts up to `max_sep_rounds` — but the cuts are **NODE-LOCAL**:
+    /// after the node they are ROLLED BACK to the post-OA base+tangent snapshot, so
+    /// no cut ever persists into another node (C-43 by construction, exactly like
+    /// the shipped `solve_node_cut`). Only the tangent pool carries the warmth
+    /// across nodes. Returns `(ConvexNodeResult, pivots, new_tangents)` — `None`
+    /// if infeasible.
     #[allow(clippy::too_many_arguments)]
     fn solve_node(
         &mut self,
@@ -1381,6 +1416,7 @@ impl W0WarmLp {
         hi: &[f64],
         oa_tol: f64,
         max_oa_rounds: usize,
+        max_sep_rounds: usize,
         opts: &SimplexOptions,
     ) -> Option<(ConvexNodeResult, usize, usize)> {
         let mut pivots = 0usize;
@@ -1389,7 +1425,12 @@ impl W0WarmLp {
         let mut last_raw = 0.0f64;
         let mut last_x = vec![0.0f64; self.n];
         let mut oa_rounds = 0usize;
-        let iter_cap = max_oa_rounds.max(1) + 4;
+        let mut sep_used = 0usize;
+        // Snapshot of the base+tangent state (row count + optimal basis) taken at
+        // first OA convergence — the point rolled back to after this node so cuts
+        // (and any post-cut tangents) never leak into the next node.
+        let mut restore: Option<(usize, Basis)> = None;
+        let iter_cap = max_oa_rounds.max(1) * (max_sep_rounds + 1) + max_sep_rounds + 4;
         for _ in 0..iter_cap {
             oa_rounds += 1;
             if self.dirty {
@@ -1421,6 +1462,7 @@ impl W0WarmLp {
             };
             pivots += sol.iters;
             if sol.status != LpStatus::Optimal {
+                self.rollback_cuts(restore); // clean base+tangent state for the next node
                 return None; // infeasible/unbounded child
             }
             self.basis = Some(sol.basis.clone());
@@ -1437,19 +1479,18 @@ impl W0WarmLp {
                 None if spec.sense_max => f64::INFINITY,
                 None => f64::NEG_INFINITY,
             };
-            // Append only still-violated tangents (globally valid → permanent).
+            // 1. OA tangents for still-violated convex rows (globally valid → persist).
             let mut added = false;
             for row in &spec.nl_rows {
                 if row.residual(&x) > oa_tol {
                     if let Some(cut) = row.oa_tangent(&x) {
-                        let ar = AsmRow {
+                        self.b.push(cut.rhs);
+                        self.rows.push(AsmRow {
                             cols: cut.cols,
                             coeffs: cut.coeffs,
                             rhs: cut.rhs,
                             is_eq: false,
-                        };
-                        self.b.push(ar.rhs);
-                        self.rows.push(ar);
+                        });
                         self.age.push(0);
                         self.dirty = true;
                         added = true;
@@ -1457,7 +1498,101 @@ impl W0WarmLp {
                     }
                 }
             }
-            if !added {
+            if added {
+                continue; // OA not yet converged
+            }
+            // OA converged: snapshot the base+tangent restore point once.
+            if restore.is_none() {
+                restore = Some((self.rows.len(), sol.basis.clone()));
+            }
+            // 2. Separate NODE-LOCAL integrality cuts if the budget remains.
+            if sep_used >= max_sep_rounds {
+                break;
+            }
+            sep_used += 1;
+            let mut is_int_full = vec![false; n_total];
+            is_int_full[..self.n].copy_from_slice(&spec.integrality);
+            let mut raw = separate_cover_csc(
+                &self.sp,
+                n_total,
+                m,
+                &l,
+                &u,
+                &self.b,
+                &sol.x,
+                self.n,
+                &is_int_full,
+                spec.le_rows.len(),
+                opts.tol,
+            );
+            raw.extend(separate_gomory_cols(
+                &self.sp,
+                m,
+                n_total,
+                &l,
+                &u,
+                &self.b,
+                &sol.basis,
+                &is_int_full,
+                opts.tol,
+                1e7,
+            ));
+            {
+                let mut a_ub: Vec<f64> = Vec::new();
+                let mut b_ub: Vec<f64> = Vec::new();
+                for row in self.rows.iter().filter(|r| !r.is_eq) {
+                    let mut dense = vec![0.0f64; self.n];
+                    for (cc, vv) in row.cols.iter().zip(row.coeffs.iter()) {
+                        dense[*cc] = *vv;
+                    }
+                    a_ub.extend_from_slice(&dense);
+                    b_ub.push(row.rhs);
+                }
+                if !b_ub.is_empty() {
+                    for mc in separate_mir(
+                        &a_ub,
+                        &b_ub,
+                        &l[..self.n],
+                        &u[..self.n],
+                        &spec.integrality,
+                        &sol.x[..self.n],
+                        opts.tol,
+                        1e7,
+                    ) {
+                        let mut coeffs = vec![0.0f64; n_total];
+                        for (j, &v) in mc.coeffs.iter().enumerate() {
+                            coeffs[j] = -v;
+                        }
+                        raw.push(GomoryCut {
+                            coeffs,
+                            rhs: -mc.rhs,
+                        });
+                    }
+                }
+            }
+            if raw.is_empty() {
+                break;
+            }
+            let selected = select_cuts(raw, &sol.x, 8, 1e-4, 0.90);
+            if selected.is_empty() {
+                break;
+            }
+            let mut added_cuts = 0usize;
+            for gc in &selected {
+                if let Some(lin) = substitute_slacks(gc, &self.rows, self.n) {
+                    self.b.push(lin.rhs);
+                    self.rows.push(AsmRow {
+                        cols: lin.cols,
+                        coeffs: lin.coeffs,
+                        rhs: lin.rhs,
+                        is_eq: false,
+                    });
+                    self.age.push(0);
+                    self.dirty = true;
+                    added_cuts += 1;
+                }
+            }
+            if added_cuts == 0 {
                 break;
             }
         }
@@ -1467,8 +1602,10 @@ impl W0WarmLp {
             raw_bound: last_raw,
             x: last_x,
             oa_rounds,
-            n_tangents: self.rows.len() - self.n_base,
+            n_tangents: 0,
         };
+        // Roll the node-local cuts back off the shared LP; tangents persist.
+        self.rollback_cuts(restore);
         Some((result, pivots, new_tangents))
     }
 }
@@ -1557,7 +1694,7 @@ impl ConvexKernelSpec {
                 .saturating_sub(self.le_rows.len() + self.eq_rows.len());
             let t1 = std::time::Instant::now();
             let warm_res =
-                warm.solve_node(self, &lo, &hi, config.oa_tol, config.max_oa_rounds, opts);
+                warm.solve_node(self, &lo, &hi, config.oa_tol, config.max_oa_rounds, 0, opts);
             let warm_us = t1.elapsed().as_secs_f64() * 1e6;
             // Tangent aging + GC (bounds the pool for many-nl-row instances).
             warm.age_and_gc(opts.tol.max(1e-7), gc_pool_cap, gc_max_age);

--- a/crates/discopt-python/src/convex_bindings.rs
+++ b/crates/discopt-python/src/convex_bindings.rs
@@ -420,3 +420,129 @@ pub fn solve_convex_tree_py<'py>(
     out.set_item("node_count", res.node_count)?;
     Ok(out)
 }
+
+/// W0 entry-experiment probe (#807, TEMPORARY). Runs the seeded best-bound
+/// OA-only mini-tree and returns per-node cold-vs-warm measurements as parallel
+/// arrays: `{cold_us, warm_us, warm_pivots, bound_diff, ns_ok, new_tangents,
+/// pool_before, is_jump}`. Reverted after W0 records its GO/KILL.
+#[pyfunction]
+#[pyo3(signature = (
+    n, c, integrality, lo, hi, sense_max,
+    le_row_ptr, le_cols, le_coeffs, le_rhs,
+    eq_row_ptr, eq_cols, eq_coeffs, eq_rhs,
+    nl_rhs, nl_lin_const, nl_lin_ptr, nl_lin_cols, nl_lin_coeffs, nl_term_ptr,
+    term_coeff, term_func, term_arg_const, term_arg_ptr, term_arg_cols, term_arg_coeffs,
+    max_stats=25, gap_tol=1e-4, int_tol=1e-5, oa_tol=1e-6,
+    max_oa_rounds=60, fbbt_rounds=20, initial_incumbent=None,
+))]
+#[allow(clippy::too_many_arguments)]
+pub fn convex_warmlp_probe_py<'py>(
+    py: Python<'py>,
+    n: usize,
+    c: PyReadonlyArray1<'py, f64>,
+    integrality: PyReadonlyArray1<'py, i64>,
+    lo: PyReadonlyArray1<'py, f64>,
+    hi: PyReadonlyArray1<'py, f64>,
+    sense_max: bool,
+    le_row_ptr: PyReadonlyArray1<'py, i64>,
+    le_cols: PyReadonlyArray1<'py, i64>,
+    le_coeffs: PyReadonlyArray1<'py, f64>,
+    le_rhs: PyReadonlyArray1<'py, f64>,
+    eq_row_ptr: PyReadonlyArray1<'py, i64>,
+    eq_cols: PyReadonlyArray1<'py, i64>,
+    eq_coeffs: PyReadonlyArray1<'py, f64>,
+    eq_rhs: PyReadonlyArray1<'py, f64>,
+    nl_rhs: PyReadonlyArray1<'py, f64>,
+    nl_lin_const: PyReadonlyArray1<'py, f64>,
+    nl_lin_ptr: PyReadonlyArray1<'py, i64>,
+    nl_lin_cols: PyReadonlyArray1<'py, i64>,
+    nl_lin_coeffs: PyReadonlyArray1<'py, f64>,
+    nl_term_ptr: PyReadonlyArray1<'py, i64>,
+    term_coeff: PyReadonlyArray1<'py, f64>,
+    term_func: PyReadonlyArray1<'py, i64>,
+    term_arg_const: PyReadonlyArray1<'py, f64>,
+    term_arg_ptr: PyReadonlyArray1<'py, i64>,
+    term_arg_cols: PyReadonlyArray1<'py, i64>,
+    term_arg_coeffs: PyReadonlyArray1<'py, f64>,
+    max_stats: usize,
+    gap_tol: f64,
+    int_tol: f64,
+    oa_tol: f64,
+    max_oa_rounds: usize,
+    fbbt_rounds: usize,
+    initial_incumbent: Option<f64>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let arrays = SpecArrays {
+        n,
+        sense_max,
+        c,
+        integrality,
+        lo,
+        hi,
+        le_row_ptr,
+        le_cols,
+        le_coeffs,
+        le_rhs,
+        eq_row_ptr,
+        eq_cols,
+        eq_coeffs,
+        eq_rhs,
+        nl_rhs,
+        nl_lin_const,
+        nl_lin_ptr,
+        nl_lin_cols,
+        nl_lin_coeffs,
+        nl_term_ptr,
+        term_coeff,
+        term_func,
+        term_arg_const,
+        term_arg_ptr,
+        term_arg_cols,
+        term_arg_coeffs,
+    };
+    let spec = arrays.build()?;
+    let config = ConvexTreeConfig {
+        max_nodes: 100_000,
+        gap_tol,
+        int_tol,
+        oa_tol,
+        max_oa_rounds,
+        max_sep_rounds: 0,
+        fbbt_rounds,
+        deadline: None,
+        initial_incumbent,
+    };
+    let opts = SimplexOptions {
+        expel_zero_artificials: true,
+        ..Default::default()
+    };
+    let stats = spec.warmlp_w0_probe(&config, &opts, max_stats);
+    let cold: Vec<f64> = stats.iter().map(|s| s.cold_us).collect();
+    let warm: Vec<f64> = stats.iter().map(|s| s.warm_us).collect();
+    let pivots: Vec<f64> = stats.iter().map(|s| s.warm_pivots as f64).collect();
+    let bound_diff: Vec<f64> = stats.iter().map(|s| s.bound_diff).collect();
+    let ns_ok: Vec<f64> = stats
+        .iter()
+        .map(|s| if s.ns_ok { 1.0 } else { 0.0 })
+        .collect();
+    let new_tan: Vec<f64> = stats.iter().map(|s| s.new_tangents as f64).collect();
+    let pool: Vec<f64> = stats.iter().map(|s| s.pool_before as f64).collect();
+    let jump: Vec<f64> = stats
+        .iter()
+        .map(|s| if s.is_jump { 1.0 } else { 0.0 })
+        .collect();
+    let cold_bound: Vec<f64> = stats.iter().map(|s| s.cold_bound).collect();
+    let warm_bound: Vec<f64> = stats.iter().map(|s| s.warm_bound).collect();
+    let out = PyDict::new(py);
+    out.set_item("cold_bound", PyArray1::from_slice(py, &cold_bound))?;
+    out.set_item("warm_bound", PyArray1::from_slice(py, &warm_bound))?;
+    out.set_item("cold_us", PyArray1::from_slice(py, &cold))?;
+    out.set_item("warm_us", PyArray1::from_slice(py, &warm))?;
+    out.set_item("warm_pivots", PyArray1::from_slice(py, &pivots))?;
+    out.set_item("bound_diff", PyArray1::from_slice(py, &bound_diff))?;
+    out.set_item("ns_ok", PyArray1::from_slice(py, &ns_ok))?;
+    out.set_item("new_tangents", PyArray1::from_slice(py, &new_tan))?;
+    out.set_item("pool_before", PyArray1::from_slice(py, &pool))?;
+    out.set_item("is_jump", PyArray1::from_slice(py, &jump))?;
+    Ok(out)
+}

--- a/crates/discopt-python/src/convex_bindings.rs
+++ b/crates/discopt-python/src/convex_bindings.rs
@@ -434,6 +434,7 @@ pub fn solve_convex_tree_py<'py>(
     term_coeff, term_func, term_arg_const, term_arg_ptr, term_arg_cols, term_arg_coeffs,
     max_stats=25, gap_tol=1e-4, int_tol=1e-5, oa_tol=1e-6,
     max_oa_rounds=60, fbbt_rounds=20, initial_incumbent=None,
+    gc_pool_cap=0, gc_max_age=5,
 ))]
 #[allow(clippy::too_many_arguments)]
 pub fn convex_warmlp_probe_py<'py>(
@@ -471,6 +472,8 @@ pub fn convex_warmlp_probe_py<'py>(
     max_oa_rounds: usize,
     fbbt_rounds: usize,
     initial_incumbent: Option<f64>,
+    gc_pool_cap: usize,
+    gc_max_age: u32,
 ) -> PyResult<Bound<'py, PyDict>> {
     let arrays = SpecArrays {
         n,
@@ -516,7 +519,7 @@ pub fn convex_warmlp_probe_py<'py>(
         expel_zero_artificials: true,
         ..Default::default()
     };
-    let stats = spec.warmlp_w0_probe(&config, &opts, max_stats);
+    let stats = spec.warmlp_w0_probe(&config, &opts, max_stats, gc_pool_cap, gc_max_age);
     let cold: Vec<f64> = stats.iter().map(|s| s.cold_us).collect();
     let warm: Vec<f64> = stats.iter().map(|s| s.warm_us).collect();
     let pivots: Vec<f64> = stats.iter().map(|s| s.warm_pivots as f64).collect();

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -45,6 +45,10 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(convex_bindings::solve_convex_node_py, m)?)?;
     m.add_function(wrap_pyfunction!(convex_bindings::solve_convex_tree_py, m)?)?;
     m.add_function(wrap_pyfunction!(
+        convex_bindings::convex_warmlp_probe_py,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
         spatial_bindings::solve_spatial_tree_py,
         m
     )?)?;

--- a/discopt_benchmarks/scripts/issue807_w0_probe.py
+++ b/discopt_benchmarks/scripts/issue807_w0_probe.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+"""Issue #807 / W0 entry experiment — in-place dual reoptimize vs cold node solve.
+
+Measures the core native-warm-LP claim on REAL panel instances (rsyn0815m =
+heaviest per-node, syn40m = most nl rows) BEFORE any architecture is built: a
+SHARED LP (base rows + a growing, globally-valid OA-tangent pool with FIXED
+root-box slack caps, carried basis) dual-warm reoptimized per node via
+bounds-in-place, vs today's per-node cold `solve_node_cut(sep=0)`. Boxes come from
+a seeded best-bound OA-only mini-tree (realistic node boxes incl. best-bound
+jumps). Both paths OA-only (W0 scope; cuts are W2).
+
+GO/KILL (W0, BLOCKING for #807):
+  KILL if — warm not >=2x faster than cold on the MEDIAN child, OR any
+  |warm_bound - cold_bound| > 1e-6 (parity), OR any warm solve fails NS
+  certification. A kill falsifies #807 at the architecture level.
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import discopt._rust as _rust  # noqa: E402
+from issue781_cutmgmt_probe import PANEL, RootModel  # noqa: E402
+from issue798_k1_bytecheck import build_convex_arrays  # noqa: E402
+
+INSTANCES = ["rsyn0815m", "syn40m"]
+MAX_STATS = 120
+# Warm and cold OA-converge to DIFFERENT (both valid) tangent sets, so they agree
+# only to OA tolerance, not bit-exactly. The real invariants are (i) soundness:
+# every warm bound is a valid dual bound (>= oracle optimum), and (ii) parity to
+# OA tolerance. A separate oa_tol=1e-9 run confirms the residual gap is OA slack.
+SOUND_TOL = 1e-4      # warm bound may not sit below oracle by more than this (rel)
+OA_PARITY_TOL = 1e-4  # warm vs cold agree to OA tolerance (both converged to 1e-6)
+
+
+def pctl(xs, q):
+    if not xs:
+        return float("nan")
+    xs = sorted(xs)
+    i = min(len(xs) - 1, int(q * (len(xs) - 1) + 0.5))
+    return xs[i]
+
+
+def run(name: str, oa_tol: float = 1e-6) -> dict:
+    opt = PANEL[name]["opt"]
+    rm = RootModel(name)
+    arrays = build_convex_arrays(rm, rm.lb, rm.ub)
+    r = _rust.convex_warmlp_probe_py(
+        **arrays, max_stats=MAX_STATS, gap_tol=1e-4, int_tol=1e-5, oa_tol=oa_tol,
+        max_oa_rounds=60, fbbt_rounds=20, initial_incumbent=float(opt),
+    )
+    cold = list(r["cold_us"])
+    warm = list(r["warm_us"])
+    piv = list(r["warm_pivots"])
+    bdiff = list(r["bound_diff"])
+    ns = list(r["ns_ok"])
+    newt = list(r["new_tangents"])
+    pool = list(r["pool_before"])
+    jump = list(r["is_jump"])
+    cb = list(r["cold_bound"])
+    wb = list(r["warm_bound"])
+    nstat = len(cold)
+
+    # Node 0 is the root (both cold; warm builds the pool) — exclude from the
+    # steady-state warm-vs-cold ratio, but keep it in parity/NS checks.
+    idx = list(range(1, nstat))
+    ratios = [cold[i] / warm[i] for i in idx if warm[i] > 0]
+    med_ratio = statistics.median(ratios) if ratios else float("nan")
+    # Amortized regime: second half of nodes (pool closer to saturated).
+    amort = idx[len(idx) // 2:]
+    amort_ratios = [cold[i] / warm[i] for i in amort if warm[i] > 0]
+    amort_ratio = statistics.median(amort_ratios) if amort_ratios else float("nan")
+    med_cold = statistics.median([cold[i] for i in idx]) if idx else float("nan")
+    med_warm = statistics.median([warm[i] for i in idx]) if idx else float("nan")
+    max_bdiff = max(bdiff) if bdiff else 0.0
+    all_ns = all(v == 1.0 for v in ns)
+    # Soundness: for a MAX problem the dual bound is an UPPER bound, so a valid
+    # bound is >= opt; for MIN it is a LOWER bound, <= opt. Check the warm bound
+    # never violates the oracle by more than the OA/rounding tolerance, on the
+    # SAME side the cold bound sits (cold is the trusted reference).
+    scale = max(1.0, abs(opt))
+    is_max = cb[0] >= opt - OA_PARITY_TOL * scale  # cold is an upper bound → max
+    if is_max:
+        worst_warm = min(wb)  # closest to / below opt
+        sound_margin = (worst_warm - opt) / scale  # want >= -SOUND_TOL
+    else:
+        worst_warm = max(wb)
+        sound_margin = (opt - worst_warm) / scale
+    sound = sound_margin >= -SOUND_TOL
+    jumps = [i for i in idx if jump[i] == 1.0]
+    adj = [i for i in idx if jump[i] == 0.0]
+    jump_piv = statistics.median([piv[i] for i in jumps]) if jumps else float("nan")
+    adj_piv = statistics.median([piv[i] for i in adj]) if adj else float("nan")
+
+    print(f"\n=== {name}: {nstat} nodes, tangent pool {pool[0]:.0f}→{pool[-1]:.0f} ===")
+    print(f"{'node':>4} {'jump':>4} {'cold_us':>9} {'warm_us':>9} {'ratio':>6} "
+          f"{'pivots':>6} {'newtan':>6} {'bdiff':>10} {'ns':>3}")
+    for i in range(nstat):
+        rt = cold[i] / warm[i] if warm[i] > 0 else float("nan")
+        print(f"{i:>4} {int(jump[i]):>4} {cold[i]:>9.1f} {warm[i]:>9.1f} {rt:>6.2f} "
+              f"{int(piv[i]):>6} {int(newt[i]):>6} {bdiff[i]:>10.2e} {int(ns[i]):>3}")
+    print(f"  cold={med_cold:.0f}us warm={med_warm:.0f}us  ALL-NODE RATIO={med_ratio:.2f}x  "
+          f"AMORTIZED(2nd half)={amort_ratio:.2f}x  p90={pctl(ratios, 0.9):.2f}x")
+    print(f"  new tangents: total={sum(newt):.0f}, after node 10={sum(newt[10:]):.0f} "
+          f"(pool amortization; final pool {pool[-1]:.0f})")
+    print(f"  jump pivots(med)={jump_piv:.0f} vs adjacent={adj_piv:.0f}  "
+          f"(jumps={len(jumps)}/{len(idx)})")
+    print(f"  PARITY max|Δbound|={max_bdiff:.2e} (OA-slack)  NS all-certify={all_ns}  "
+          f"SOUND margin={sound_margin:+.2e} (>= -{SOUND_TOL:.0e} → {sound})")
+
+    return dict(name=name, med_ratio=med_ratio, amort_ratio=amort_ratio,
+                max_bdiff=max_bdiff, all_ns=all_ns, sound=sound)
+
+
+def main() -> bool:
+    print("########## oa_tol=1e-6 (production) ##########")
+    results = [run(n, oa_tol=1e-6) for n in INSTANCES]
+    print("\n########## oa_tol=1e-9 (parity diagnostic — gap should shrink) ##########")
+    tight = [run(n, oa_tol=1e-9) for n in INSTANCES]
+
+    print("\n================ W0 VERDICT ================")
+    print("Speed: warm dual-reoptimize vs cold node solve. Kill if amortized "
+          "median <2x.\nParity: warm/cold agree to OA tolerance (both valid dual "
+          "bounds); the\n1e-9 run below confirms the residual gap is OA slack, not "
+          "a mechanism error.\nSoundness (the real invariant): every warm bound is "
+          "a valid dual bound vs oracle.")
+    ok = True
+    for r, t in zip(results, tight):
+        speed_ok = r["amort_ratio"] >= 2.0
+        ns_ok = r["all_ns"]
+        sound_ok = r["sound"]
+        # Parity shrinks when OA is tightened → confirms OA-slack (not a bug).
+        oa_slack_confirmed = t["max_bdiff"] <= r["max_bdiff"] * 1.5
+        good = speed_ok and ns_ok and sound_ok and oa_slack_confirmed
+        ok = ok and good
+        print(f"{r['name']:10s} amortized={r['amort_ratio']:.2f}x (>=2 {speed_ok})  "
+              f"NS={ns_ok}  SOUND={sound_ok}  "
+              f"parity 1e-6→1e-9: {r['max_bdiff']:.1e}→{t['max_bdiff']:.1e} "
+              f"(OA-slack {oa_slack_confirmed})  => {'GO' if good else 'KILL'}")
+    print(f"\nW0 {'GO — build W1' if ok else 'KILL — #807 architecture falsified'}")
+    return ok
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/discopt_benchmarks/scripts/issue807_w0_probe.py
+++ b/discopt_benchmarks/scripts/issue807_w0_probe.py
@@ -48,13 +48,14 @@ def pctl(xs, q):
     return xs[i]
 
 
-def run(name: str, oa_tol: float = 1e-6) -> dict:
+def run(name: str, oa_tol: float = 1e-6, gc_pool_cap: int = 0) -> dict:
     opt = PANEL[name]["opt"]
     rm = RootModel(name)
     arrays = build_convex_arrays(rm, rm.lb, rm.ub)
     r = _rust.convex_warmlp_probe_py(
         **arrays, max_stats=MAX_STATS, gap_tol=1e-4, int_tol=1e-5, oa_tol=oa_tol,
         max_oa_rounds=60, fbbt_rounds=20, initial_incumbent=float(opt),
+        gc_pool_cap=gc_pool_cap, gc_max_age=5,
     )
     cold = list(r["cold_us"])
     warm = list(r["warm_us"])
@@ -119,32 +120,36 @@ def run(name: str, oa_tol: float = 1e-6) -> dict:
                 max_bdiff=max_bdiff, all_ns=all_ns, sound=sound)
 
 
-def main() -> bool:
-    print("########## oa_tol=1e-6 (production) ##########")
-    results = [run(n, oa_tol=1e-6) for n in INSTANCES]
-    print("\n########## oa_tol=1e-9 (parity diagnostic — gap should shrink) ##########")
-    tight = [run(n, oa_tol=1e-9) for n in INSTANCES]
+GC_CAP = 150  # tangent-pool cap (W0 re-scope: bound the pool for many-nl-row cases)
 
-    print("\n================ W0 VERDICT ================")
-    print("Speed: warm dual-reoptimize vs cold node solve. Kill if amortized "
-          "median <2x.\nParity: warm/cold agree to OA tolerance (both valid dual "
-          "bounds); the\n1e-9 run below confirms the residual gap is OA slack, not "
-          "a mechanism error.\nSoundness (the real invariant): every warm bound is "
-          "a valid dual bound vs oracle.")
+
+def main() -> bool:
+    print("########## oa_tol=1e-6, GC OFF (baseline, permanent pool) ##########")
+    base = [run(n, oa_tol=1e-6, gc_pool_cap=0) for n in INSTANCES]
+    print(f"\n########## oa_tol=1e-6, GC ON (tangent pool cap={GC_CAP}) ##########")
+    gc = [run(n, oa_tol=1e-6, gc_pool_cap=GC_CAP) for n in INSTANCES]
+    print("\n########## oa_tol=1e-9, GC ON (parity diagnostic) ##########")
+    tight = [run(n, oa_tol=1e-9, gc_pool_cap=GC_CAP) for n in INSTANCES]
+
+    print("\n================ W0 VERDICT (with tangent-GC) ================")
+    print("GC bounds the pool so the warm advantage survives on many-nl-row "
+          "instances.\nSpeed: amortized warm-vs-cold >=2x. Soundness: every warm "
+          "bound valid vs oracle.\nParity: OA-tolerance slack (1e-9 run collapses "
+          "it), not a mechanism error.")
     ok = True
-    for r, t in zip(results, tight):
-        speed_ok = r["amort_ratio"] >= 2.0
-        ns_ok = r["all_ns"]
-        sound_ok = r["sound"]
-        # Parity shrinks when OA is tightened → confirms OA-slack (not a bug).
-        oa_slack_confirmed = t["max_bdiff"] <= r["max_bdiff"] * 1.5
+    for b, g, t in zip(base, gc, tight):
+        speed_ok = g["amort_ratio"] >= 2.0
+        ns_ok = g["all_ns"]
+        sound_ok = g["sound"]
+        oa_slack_confirmed = t["max_bdiff"] <= g["max_bdiff"] * 1.5
         good = speed_ok and ns_ok and sound_ok and oa_slack_confirmed
         ok = ok and good
-        print(f"{r['name']:10s} amortized={r['amort_ratio']:.2f}x (>=2 {speed_ok})  "
-              f"NS={ns_ok}  SOUND={sound_ok}  "
-              f"parity 1e-6→1e-9: {r['max_bdiff']:.1e}→{t['max_bdiff']:.1e} "
-              f"(OA-slack {oa_slack_confirmed})  => {'GO' if good else 'KILL'}")
-    print(f"\nW0 {'GO — build W1' if ok else 'KILL — #807 architecture falsified'}")
+        print(f"{g['name']:10s} amortized: GC-off={b['amort_ratio']:.2f}x → "
+              f"GC-on={g['amort_ratio']:.2f}x (>=2 {speed_ok})  NS={ns_ok}  "
+              f"SOUND={sound_ok}  parity 1e-6→1e-9: {g['max_bdiff']:.1e}→"
+              f"{t['max_bdiff']:.1e} (OA-slack {oa_slack_confirmed})  "
+              f"=> {'GO' if good else 'KILL'}")
+    print(f"\nW0 {'GO — build W1' if ok else 'KILL/RE-SCOPE — see per-instance'}")
     return ok
 
 

--- a/discopt_benchmarks/scripts/issue807_w1_bytecheck.py
+++ b/discopt_benchmarks/scripts/issue807_w1_bytecheck.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""Issue #807 / W1 gate — persistent-LP tree integration (OA-only), rsyn* subset.
+
+Runs the seeded best-bound tree OA-only (max_sep_rounds=0) with DISCOPT_CVX_NATIVELP
+OFF (today's per-node cold solve_node_cut) vs ON (the shared persistent LP,
+bounds-in-place dual-warm) on the scoped rsyn* family, and checks:
+  1. CERT-CLEAN under the flag (the integration is sound): status honest, dual
+     bound is a valid bound vs the oracle, never a false optimal.
+  2. WALL: the ON path is faster at the same setting (W0 measured >=2x per node;
+     it should show as less wall for a comparable tree).
+
+Search-order regime (flavor ii): the warm path lands on different LP vertices, so
+node_count may differ; the guard is cert-clean, not node parity. syn40m is OUT OF
+SCOPE (#807 W0: OA-round-bound) — not run here.
+
+Flag is process-global (read once), so ON/OFF run in separate subprocesses.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+
+RSYN = ["rsyn0805m", "rsyn0810m", "rsyn0815m"]  # config-B prototyped subset
+MAX_NODES = 600  # representative of the cut-driven tree size (W2); OA-only bloats beyond
+TIME_LIMIT = 120.0
+
+
+def run_child() -> None:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import discopt._rust as _rust  # noqa: E402
+    from issue781_cutmgmt_probe import PANEL, RootModel  # noqa: E402
+    from issue798_k1_bytecheck import build_convex_arrays  # noqa: E402
+
+    flag = os.environ.get("DISCOPT_CVX_NATIVELP", "0")
+    print(f"# DISCOPT_CVX_NATIVELP={flag}  (OA-only, seeded)")
+    print(f"{'instance':12s} {'status':10s} {'nodes':>7s} {'wall_s':>8s} "
+          f"{'bound':>12s} {'opt':>12s}  cert")
+    tw = 0.0
+    bad = 0
+    for name in RSYN:
+        opt = PANEL[name]["opt"]
+        rm = RootModel(name)
+        arrays = build_convex_arrays(rm, rm.lb, rm.ub)
+        t = time.perf_counter()
+        r = _rust.solve_convex_tree_py(
+            **arrays, max_nodes=MAX_NODES, gap_tol=1e-4, int_tol=1e-5, oa_tol=1e-6,
+            max_oa_rounds=60, max_sep_rounds=0, fbbt_rounds=20,
+            initial_incumbent=float(opt), time_limit_s=TIME_LIMIT,
+        )
+        dt = time.perf_counter() - t
+        tw += dt
+        bound = r["bound"]
+        status = r["status"]
+        # Sound: dual bound never below the oracle optimum (upper bound for max).
+        sound = bound >= opt - 1e-3 * max(1.0, abs(opt))
+        # If it certified, the bound must have closed onto the oracle.
+        closed = status != "optimal" or abs(bound - opt) <= 1e-2 * max(1.0, abs(opt))
+        cert = sound and closed
+        bad += 0 if cert else 1
+        print(f"{name:12s} {status:10s} {r['node_count']:7d} {dt:8.2f} "
+              f"{bound:12.4f} {opt:12.4f}  {cert}", flush=True)
+    print(f"TOTAL wall={tw:.1f}s  cert-clean={'YES' if bad == 0 else 'NO(' + str(bad) + ')'}",
+          flush=True)
+
+
+def main() -> bool:
+    if os.environ.get("_W1_CHILD") == "1":
+        run_child()
+        return True
+    import subprocess
+
+    outs = {}
+    for flag in ("0", "1"):
+        env = dict(os.environ, DISCOPT_CVX_NATIVELP=flag, _W1_CHILD="1")
+        print(f"\n===== DISCOPT_CVX_NATIVELP={flag} =====", flush=True)
+        p = subprocess.run([sys.executable, os.path.abspath(__file__)], env=env,
+                           capture_output=True, text=True)
+        print(p.stdout, end="")
+        if p.returncode != 0:
+            print(p.stderr[-2000:])
+        outs[flag] = p.stdout
+
+    def parse(out):
+        wall = None
+        cert = None
+        for line in out.splitlines():
+            if line.startswith("TOTAL"):
+                wall = float(line.split("wall=")[1].split("s")[0])
+                cert = "cert-clean=YES" in line
+        return wall, cert
+
+    w_off, c_off = parse(outs["0"])
+    w_on, c_on = parse(outs["1"])
+    print("\n================ W1 GATE ================")
+    speedup = (w_off / w_on) if (w_on and w_off) else float("nan")
+    ok = bool(c_off) and bool(c_on) and (w_on is not None and w_off is not None and w_on <= w_off)
+    print(f"cert-clean: OFF={c_off} ON={c_on}")
+    print(f"wall: OFF={w_off}s  ON={w_on}s  speedup={speedup:.2f}x  (ON must be cert-clean AND <= OFF)")
+    print(f"\nW1 {'PASS' if ok else 'REVIEW'}")
+    return ok
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/discopt_benchmarks/scripts/issue807_w2_gate.py
+++ b/discopt_benchmarks/scripts/issue807_w2_gate.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""Issue #807 / W2 gate — box-tagged cuts in the persistent LP, seeded rsyn* panel.
+
+Runs the seeded best-bound branch-and-cut tree (max_sep_rounds=12) with
+DISCOPT_CVX_NATIVELP ON (shared persistent LP + box-tagged integrality cuts) vs
+OFF (today's per-node cold solve_node_cut = the config-B baseline) on the scoped
+rsyn* family, and checks:
+  1. CERT-CLEAN (SOUNDNESS — the make-or-break): status optimal, dual bound = the
+     MINLPLib oracle optimum exactly, bound >= oracle (never a false optimal / a
+     bound below the oracle). A box-tagged cut must never remove the optimum.
+  2. NODE BLOWUP GUARD: nodes <= 1.5x the config-B anchor (353/177/281 -> 530/266/422).
+  3. WALL: seeded panel <= 12s (>=2x vs the 24s config-B anchor).
+
+Search-order regime (flavor ii): the warm path lands on different vertices, so
+node_count may differ; the guard is cert-clean + the blowup bar. syn40m is OUT OF
+SCOPE (#807 W0). Flag is process-global, so ON/OFF run in separate subprocesses.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+
+RSYN = ["rsyn0805m", "rsyn0810m", "rsyn0815m"]
+ANCHOR = {"rsyn0805m": 353, "rsyn0810m": 177, "rsyn0815m": 281}  # config-B seeded nodes
+BLOWUP = 1.5
+WALL_BAR = 12.0
+
+
+def run_child() -> None:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import discopt._rust as _rust  # noqa: E402
+    from issue781_cutmgmt_probe import PANEL, RootModel  # noqa: E402
+    from issue798_k1_bytecheck import build_convex_arrays  # noqa: E402
+
+    flag = os.environ.get("DISCOPT_CVX_NATIVELP", "0")
+    print(f"# DISCOPT_CVX_NATIVELP={flag}  (cuts on, seeded)")
+    print(f"{'instance':12s} {'status':10s} {'nodes':>6s} {'anch':>6s} {'cap':>6s} "
+          f"{'wall_s':>7s} {'bound':>12s} {'opt':>12s}  cert node_ok")
+    tw = 0.0
+    bad = 0
+    node_bad = 0
+    for name in RSYN:
+        opt = PANEL[name]["opt"]
+        rm = RootModel(name)
+        arrays = build_convex_arrays(rm, rm.lb, rm.ub)
+        t = time.perf_counter()
+        r = _rust.solve_convex_tree_py(
+            **arrays, max_nodes=20000, gap_tol=1e-4, int_tol=1e-5, oa_tol=1e-6,
+            max_oa_rounds=60, max_sep_rounds=12, fbbt_rounds=20,
+            initial_incumbent=float(opt), time_limit_s=180.0,
+        )
+        dt = time.perf_counter() - t
+        tw += dt
+        bound = r["bound"]
+        nodes = r["node_count"]
+        status = r["status"]
+        sound = bound >= opt - 1e-3 * max(1.0, abs(opt))
+        closed = abs(bound - opt) <= 1e-2 * max(1.0, abs(opt))
+        cert = status == "optimal" and sound and closed
+        cap = int(BLOWUP * ANCHOR[name])
+        node_ok = nodes <= cap
+        bad += 0 if cert else 1
+        node_bad += 0 if node_ok else 1
+        print(f"{name:12s} {status:10s} {nodes:6d} {ANCHOR[name]:6d} {cap:6d} "
+              f"{dt:7.2f} {bound:12.4f} {opt:12.4f}  {cert}  {node_ok}", flush=True)
+    print(f"TOTAL wall={tw:.1f}s  cert-clean={'YES' if bad == 0 else 'NO(' + str(bad) + ')'}  "
+          f"nodes_ok={'YES' if node_bad == 0 else 'NO(' + str(node_bad) + ')'}", flush=True)
+
+
+def parse(out):
+    wall = cert = nodes_ok = None
+    for line in out.splitlines():
+        if line.startswith("TOTAL"):
+            wall = float(line.split("wall=")[1].split("s")[0])
+            cert = "cert-clean=YES" in line
+            nodes_ok = "nodes_ok=YES" in line
+    return wall, cert, nodes_ok
+
+
+def main() -> bool:
+    if os.environ.get("_W2_CHILD") == "1":
+        run_child()
+        return True
+    import subprocess
+
+    outs = {}
+    for flag in ("0", "1"):
+        env = dict(os.environ, DISCOPT_CVX_NATIVELP=flag, _W2_CHILD="1")
+        print(f"\n===== DISCOPT_CVX_NATIVELP={flag} =====", flush=True)
+        p = subprocess.run([sys.executable, os.path.abspath(__file__)], env=env,
+                           capture_output=True, text=True)
+        print(p.stdout, end="")
+        if p.returncode != 0:
+            print(p.stderr[-3000:])
+        outs[flag] = p.stdout
+
+    w_off, c_off, _ = parse(outs["0"])
+    w_on, c_on, n_on = parse(outs["1"])
+    print("\n================ W2 GATE ================")
+    speedup = (w_off / w_on) if (w_on and w_off) else float("nan")
+    ok = bool(c_on) and bool(n_on) and (w_on is not None and w_on <= WALL_BAR)
+    print(f"cert-clean: OFF={c_off} ON={c_on} (ON is the soundness gate)")
+    print(f"nodes within 1.5x anchor: ON={n_on}")
+    print(f"wall: OFF={w_off}s  ON={w_on}s  speedup={speedup:.2f}x  (ON bar <= {WALL_BAR}s)")
+    print(f"\nW2 {'PASS' if ok else 'FAIL/REVIEW'}")
+    return ok
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/discopt_benchmarks/scripts/issue807_w2_production.py
+++ b/discopt_benchmarks/scripts/issue807_w2_production.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""Issue #807 / W2 — production (UNSEEDED) panel net, the real #807 target metric.
+
+Runs the full scoped rsyn* production panel UNSEEDED (no oracle incumbent — the
+kernel must find its own) with cuts on, DISCOPT_CVX_NATIVELP ON (persistent tangent
+pool + node-local cuts) vs OFF (today's per-node cold solve_node_cut), and reports
+wall + cert-clean. This is the config-A target the seeded W2 gate only proxied.
+
+Cert-clean: dual bound >= oracle optimum (valid upper bound for max), and if
+optimal, closed onto it. Flag is process-global → ON/OFF in separate subprocesses.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ["DISCOPT_COEF_TIGHTEN"] = "1"
+
+RSYN = ["rsyn0805m", "rsyn0810m", "rsyn0815m", "rsyn0820m", "rsyn0830m"]
+SNAP = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/")
+SOLU = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu")
+
+
+def load_oracle():
+    o = {}
+    for line in open(SOLU):
+        p = line.split()
+        if len(p) >= 3 and p[0] in ("=opt=", "=best="):
+            try:
+                o[p[1]] = float(p[2])
+            except ValueError:
+                pass
+    return o
+
+
+def run_child() -> None:
+    import discopt.modeling as dm  # noqa: E402
+    from discopt.solvers._convex_kernel import build_convex_spec, solve_convex_tree  # noqa: E402
+
+    oracle = load_oracle()
+    flag = os.environ.get("DISCOPT_CVX_NATIVELP", "0")
+    print(f"# DISCOPT_CVX_NATIVELP={flag}  (production / unseeded, cuts on)")
+    print(f"{'instance':12s} {'status':10s} {'nodes':>7s} {'wall_s':>8s} "
+          f"{'bound':>12s} {'opt':>12s}  cert")
+    tw = 0.0
+    bad = 0
+    for name in RSYN:
+        f = SNAP + name + ".nl"
+        m = dm.from_nl(f)
+        spec = build_convex_spec(m)
+        if spec is None:
+            print(f"{name:12s} declined")
+            continue
+        opt = oracle.get(name)
+        t = time.perf_counter()
+        r = solve_convex_tree(spec, time_limit_s=180.0, initial_incumbent=None)
+        dt = time.perf_counter() - t
+        tw += dt
+        bound = float(r["bound"])
+        status = r["status"]
+        sound = opt is None or bound >= opt - 1e-3 * max(1.0, abs(opt))
+        closed = status != "optimal" or opt is None or abs(bound - opt) <= 1e-2 * max(1.0, abs(opt))
+        cert = sound and closed
+        bad += 0 if cert else 1
+        os_ = "None" if opt is None else f"{opt:12.4f}"
+        print(f"{name:12s} {status:10s} {r['node_count']:7d} {dt:8.2f} "
+              f"{bound:12.4f} {os_:>12s}  {cert}", flush=True)
+    print(f"TOTAL wall={tw:.1f}s  cert-clean={'YES' if bad == 0 else 'NO(' + str(bad) + ')'}",
+          flush=True)
+
+
+def parse(out):
+    w = c = None
+    for line in out.splitlines():
+        if line.startswith("TOTAL"):
+            w = float(line.split("wall=")[1].split("s")[0])
+            c = "cert-clean=YES" in line
+    return w, c
+
+
+def main() -> bool:
+    if os.environ.get("_W2P_CHILD") == "1":
+        run_child()
+        return True
+    import subprocess
+
+    outs = {}
+    for flag in ("0", "1"):
+        env = dict(os.environ, DISCOPT_CVX_NATIVELP=flag, _W2P_CHILD="1")
+        print(f"\n===== DISCOPT_CVX_NATIVELP={flag} =====", flush=True)
+        p = subprocess.run([sys.executable, os.path.abspath(__file__)], env=env,
+                           capture_output=True, text=True)
+        print(p.stdout, end="")
+        if p.returncode != 0:
+            print(p.stderr[-3000:])
+        outs[flag] = p.stdout
+
+    w_off, c_off = parse(outs["0"])
+    w_on, c_on = parse(outs["1"])
+    print("\n================ W2 PRODUCTION NET ================")
+    su = (w_off / w_on) if (w_on and w_off) else float("nan")
+    print(f"cert-clean: OFF={c_off} ON={c_on}")
+    print(f"wall: OFF={w_off}s  ON={w_on}s  speedup={su:.2f}x")
+    print(f"\nNet: ON is {'FASTER' if (w_on and w_off and w_on < w_off) else 'NOT faster'} "
+          f"and {'cert-clean' if c_on else 'NOT cert-clean'}")
+    return bool(c_on)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/docs/dev/native-warmlp-plan.md
+++ b/docs/dev/native-warmlp-plan.md
@@ -379,4 +379,45 @@ regression ⇒ revert, record, done. Search-order regime (flavor ii).
 
 ## 8. Work log (append newest first)
 
-*(empty — W0 not started)*
+- **2026-07-20 (#807 W0): primitive VALIDATED + SOUND, but the permanent-tangent-
+  pool amortization FALSIFIED on syn40m → SURFACED for re-scope.**
+  Probe: `crates/discopt-core/src/bnb/convex_kernel.rs` (`W0WarmLp` + a shared-LP
+  best-bound OA-only mini-tree, temporary) + PyO3 `convex_warmlp_probe_py` +
+  `discopt_benchmarks/scripts/issue807_w0_probe.py`. Seeded config-B, 120 nodes,
+  cold `solve_node_cut(sep=0)` vs shared-LP warm dual-reoptimize on identical
+  boxes. NODE-box slack caps (a W0 correction to §3.2's fixed-root-caps: raw-box
+  caps hit the K1d infinite-bound NS failure; node-box caps certify AND stay warm,
+  since a slack cap change is just another bound the dual path reoptimizes).
+  - **VALIDATED — the core primitive works.** rsyn0815m **9.90× amortized**
+    (2nd-half median; pool saturates → most nodes need 0 new tangents → the whole
+    node is one warm solve). Adjacent-node warm pivots median **1–2**, jump-node
+    **13** (best-bound jumps cost more, as expected — the W3 lever).
+  - **SOUND — the real invariant holds.** Every warm bound is a valid dual bound
+    vs the oracle (worst-case sound margin **+0.34 / +1.85**, never below opt);
+    **NS certifies on every node**. The warm/cold parity gap (≤2.7e-4 at
+    oa_tol=1e-6) is pure **OA-tolerance slack**, confirmed: tightening oa_tol to
+    1e-9 collapses it to **1.7e-7 / 1.3e-7**. Warm and cold OA-converge to
+    different-but-both-valid tangent sets; there is no mechanism error. (The plan's
+    ≤1e-6 W0 parity threshold was mis-specified — the right checks are soundness +
+    OA-tolerance agreement, both PASS.)
+  - **FALSIFIED — permanent-pool amortization for many-nl-row instances.**
+    **syn40m 1.01× amortized (KILL vs the ≥2× bar).** Its tangent pool **never
+    saturates**: 0→817 rows over 120 nodes (~6–7 NEW tangents *every* node, 625 of
+    830 added after node 10). §3.1's "0–2 new tangents/node once the pool warms"
+    does not hold — syn40m's many nonlinear rows need fresh linearization points in
+    every branched region, so the permanent pool bloats the LP (each warm solve
+    over 800+ rows costs as much as a cold solve over the node's own ~few tangents),
+    erasing the warm-start win. The per-SOLVE warm advantage is still real (adjacent
+    pivots 2); it's the pool GROWTH that kills the net.
+  - **This is a re-scope, not a clean GO or whole-issue KILL.** The primitive +
+    soundness are proven; only the "permanent tangent pool" *design choice* (§3.1)
+    is falsified, and only for the many-nl-row class. Identified fix: **tangent-pool
+    GC/aging** (cap the pool, drop stale tangents, re-derive on demand — SCIP ages
+    cuts exactly so; §3.4 already contemplates GC for cuts, just not tangents).
+    Applying it now would improvise past a stated kill criterion, so per the loop
+    protocol this is **surfaced to the owner** with the options: (a) add tangent-GC
+    to the architecture and re-run W0 (likely rescues syn40m — the primitive is
+    sound and fast per-solve); (b) scope #807 to the pool-saturating (`rsyn*`)
+    family; (c) treat as a whole-issue kill. **Recommendation: (a).** Probe + this
+    record committed; draft PR opened; kernel shipped paths untouched (probe is a
+    separate binding, not wired into `solve_tree`).

--- a/docs/dev/native-warmlp-plan.md
+++ b/docs/dev/native-warmlp-plan.md
@@ -395,6 +395,40 @@ regression ⇒ revert, record, done. Search-order regime (flavor ii).
 
 ## 8. Work log (append newest first)
 
+- **2026-07-20 (#807 W2 PRODUCTION NET — DEFINITIVE): native-warm-LP is SOUND but a
+  3× REGRESSION on the certifying panel → #807 premise falsified; recommend close on
+  the W1 scoped finding.** Ran the real #807 target — the config-A UNSEEDED rsyn*
+  production panel (incl. the big rsyn0820m/0830m), cuts on, flag ON vs OFF
+  (`issue807_w2_production.py`):
+  - OFF (shipped path): **148.7 s, all 5 certify** (rsyn0805m/0810m/0815m
+    7.9/8.1/6.3 s, rsyn0820m 77 s, rsyn0830m 49 s), cert-clean.
+  - ON (native-warm-LP): **434.9 s (3× SLOWER)**, cert-clean but **rsyn0820m and
+    rsyn0830m REGRESS from certified to TIME_LIMIT** (180 s each, unfinished);
+    rsyn0815m blows up 237→1235 nodes / 6.3→62 s. Only rsyn0810m improved.
+  - **DEFINITIVE: the per-node warm advantage does NOT net out on the full
+    cut-driven certifying tree — it is a large regression.** Root cause is
+    fundamental and matches every prior signal: over the hundreds–thousands of nodes
+    a certifying tree needs (rsyn0820m ~1800), the PERSISTENT tangent pool bloats, so
+    every warm solve runs over a huge accumulated-tangent LP — SLOWER than the
+    baseline's small fresh per-node LP; per-node cost is dominated by cut separation
+    (identical ON/OFF), which the warm-LP cannot accelerate; and search-order
+    variance blows up node counts. The tangent-pool warmth that gave W0's 8–10× /
+    W1's 4× in low-node micro-regimes is a LIABILITY at scale (the same bloat that
+    put syn40m out of scope — now hitting rsyn* on the real tree).
+  - **The #800→#801→#807 arc resolves.** #800: node-count levers (row-order, strong
+    branching) all falsified. #801: named per-node throughput ("native warm LPs +
+    RCRR") as BARON's edge. #807: built native warm LPs — the per-node throughput is
+    REAL (W0/W1) but does NOT translate to a panel wall win on the certifying tree
+    (W2). No incremental lever over this per-node-reassembly-or-persistent kernel
+    delivers SCIP-parity; the gap is more fundamental (SCIP's LP kernel, presolve,
+    and integrated cut/bound management beyond these levers).
+  - **RECOMMENDATION: close #807 on the W1 scoped finding.** Deliverables: the
+    native-warm-LP node solve is built, SOUND, and cert-clean behind
+    `DISCOPT_CVX_NATIVELP` (default-OFF, flag-OFF bit-identical); W0/W1 prove the
+    per-node warm primitive (8–10× / 4×); W2 proves — with a durable measurement —
+    that it does not net out on the certifying panel (3× regression). Keep the flag
+    default-OFF. **SURFACED to the owner.**
+
 - **2026-07-20 (#807 W2 v2): NODE-LOCAL cuts — SOUND ✓ but wall net-negative on the
   seeded panel (tangent-pool bloat) → SURFACED.** Owner-chosen re-scope after the
   box-tagged failure. Design: persist ONLY the globally-valid tangent pool (warm

--- a/docs/dev/native-warmlp-plan.md
+++ b/docs/dev/native-warmlp-plan.md
@@ -395,6 +395,18 @@ regression ⇒ revert, record, done. Search-order regime (flavor ii).
 
 ## 8. Work log (append newest first)
 
+- **2026-07-20 (#807 W2 GC-cap sweep — owner-requested; does NOT rescue).** Swept
+  the tangent-pool GC cap (`DISCOPT_CVX_POOLCAP`) on the seeded rsyn* subset, flag-ON:
+  **600→26.2 s, 200→23.4 s, 100→23.8 s, 50→22.5 s** (all sound). Tightening the cap
+  helps ~15% (bloat vs churn trade bottoms out near cap 50–200) but the **best
+  (22.5 s) still loses to OFF's 19.9 s** — and this is only the SMALL seeded rsyn;
+  the big rsyn0820m/0830m (1800-node trees, where the production regression caused
+  timeouts) would churn re-deriving tangents under a tight cap, not improve.
+  **Confirmed: GC tuning does not rescue the regression** — the bloat/cut-domination
+  is fundamental to the persistent-warm-LP approach on the certifying tree. Knob
+  reverted (default-off path isn't graduating). Recommendation stands: close #807 on
+  the W1 scoped finding.
+
 - **2026-07-20 (#807 W2 PRODUCTION NET — DEFINITIVE): native-warm-LP is SOUND but a
   3× REGRESSION on the certifying panel → #807 premise falsified; recommend close on
   the W1 scoped finding.** Ran the real #807 target — the config-A UNSEEDED rsyn*

--- a/docs/dev/native-warmlp-plan.md
+++ b/docs/dev/native-warmlp-plan.md
@@ -1,8 +1,20 @@
 # Native-Warm-LP Convex Kernel — implementation plan (issue #807)
 
-**Status:** not started. This is the durable, loop-executable spec for the #807
-rewrite: one persistent LP, bounds modified in place across the whole tree,
+**Status:** W0 DONE — **GO, scoped to the pool-saturating `rsyn*` family**
+(owner-approved 2026-07-20). W1 next. This is the durable, loop-executable spec for
+the #807 rewrite: one persistent LP, bounds modified in place across the whole tree,
 dual-warm reoptimized per node — the SCIP/BARON per-node-throughput architecture.
+
+**SCOPE (W0 finding, owner-approved).** The native-warm-LP kernel targets the
+**`rsyn*` family** (rsyn0805m/0810m/0815m/0820m/0830m), where W0 measured **8–10×**
+warm-vs-cold per node and where the #800 panel-wall gap actually lives (rsyn0820m
+80 s / rsyn0830m 50 s dominate config-A's 174 s). **`syn40m` is OUT OF SCOPE**: W0
+proved it is *OA-round-bound* (~7 new tangents/node, derived by cold AND warm alike),
+so the first-solve warm advantage is a small fraction of its node cost — a
+relaxation-quality limit no warm-LP or tangent-GC strategy can move (measured:
+1.00×→1.25× with GC). syn40m (and any OA-round-bound instance) **routes to the
+existing cold `solve_node_cut` path**; syn05–20m are ≤0.6 s and irrelevant either
+way. All #807 gates below are scored on the **`rsyn*` subset**.
 It survives context loss: each work iteration reads this doc in full, takes the
 first unfinished task, runs its entry experiment BEFORE implementing (CLAUDE.md
 §4), honors the kill criterion, and records measured results in the work log
@@ -230,7 +242,11 @@ dead flags), record the falsification, commit+push, STOP and surface. Any
 correctness regression (a bound above its reference, a false optimal, an
 unverified incumbent, cert-fail) → STOP immediately and surface.
 
-### W0 — entry experiment: in-place dual reoptimize on the real instance. **BLOCKING.**
+### W0 — entry experiment: in-place dual reoptimize on the real instance. **DONE — GO (scoped to `rsyn*`).**
+*Result (2026-07-20, work log):* the primitive is validated + sound + cert-clean;
+warm-vs-cold **8–10×** on rsyn0815m (pool saturates). syn40m is OA-round-bound
+(1.0–1.25×) → out of scope (routes to cold). Owner approved scoping #807 to `rsyn*`.
+Original spec below.
 - **Goal.** Validate the core claim — same-LP bound-change dual reoptimize is
   much cheaper than today's per-node cold pipeline — on a REAL panel instance
   before any architecture is built.

--- a/docs/dev/native-warmlp-plan.md
+++ b/docs/dev/native-warmlp-plan.md
@@ -1,0 +1,382 @@
+# Native-Warm-LP Convex Kernel — implementation plan (issue #807)
+
+**Status:** not started. This is the durable, loop-executable spec for the #807
+rewrite: one persistent LP, bounds modified in place across the whole tree,
+dual-warm reoptimized per node — the SCIP/BARON per-node-throughput architecture.
+It survives context loss: each work iteration reads this doc in full, takes the
+first unfinished task, runs its entry experiment BEFORE implementing (CLAUDE.md
+§4), honors the kill criterion, and records measured results in the work log
+(newest first). It is self-contained: every anchor number a task needs is in §2.
+
+**Provenance (do not re-derive).** #800 closed on its scoped win (the convex
+panel certifies cert-clean within the 120 s production budget; net-positive vs
+NLP-BB) after falsifying all three of its per-node/search levers by entry
+experiment — T1 row-order, T2 reliability branching, T3 warm-child restart
+(records: PR #805, `docs/dev/convex-kernel-plan.md` work log, 2026-07-20
+entries). #801 closed pinning BARON's edge on this class as *"native warm LPs +
+reduced-cost range reduction — the only deficit is per-node throughput."* #807 is
+the intersection of those two findings: the throughput gap is architectural, and
+this plan is the architecture.
+
+## 1. Why the current kernel cannot be warm (binding — the T3 finding)
+
+The shipped kernel (`crates/discopt-core/src/bnb/convex_kernel.rs::solve_node_cut`)
+**re-assembles and cold-solves the node LP from scratch at every node** (and
+rebuilds the CSC every OA/separation round via `assemble`). T3 proved cross-node
+warm starts cannot be bolted onto this design:
+
+- the parent's *cut-converged* optimal basis lives on a **different, larger LP**
+  (its tangent/cut set) than the child's base-only first solve — dimensions and
+  meaning don't match;
+- the parent's *base-only* basis (right dimensions) is **neither dual-feasible
+  for the child nor bound-neutral**: warming from it drifted `node_count`
+  950→1120 (+18%, different degenerate vertex — the T1 degeneracy lesson) AND
+  raised wall +12% (prepare + dual-feasibility check + frequent cold fallback
+  cost more than the cold solve). Reproduces iter-8's negative via the dual path.
+
+**The enabling fact for the fix** (verified in `lp/simplex/dual.rs`,
+`PreparedDual` doc, lines ~276–280): dual feasibility of a basis depends on the
+objective, the basis, the matrix, and *which bound each nonbasic sits at* — **not
+on the bound values**. Therefore, in a **shared** LP (same rows, columns,
+objective), any node's optimal basis is a dual-feasible warm start for **any**
+other node's box: a node differs from its neighbor only in the `l`/`u` vectors,
+and `PreparedDual::reoptimize(l, u, b, opts)` takes fresh bounds per call. T3
+failed because the LP was *not* shared. Sharing the LP is the whole architecture.
+
+## 2. Anchors (pinned by #800 T0 — cite these, do not re-measure as baselines)
+
+Scripts: config A = `discopt_benchmarks/scripts/issue800_t0_baseline.py`
+(production/unseeded, budget 120 s); config B =
+`discopt_benchmarks/scripts/issue798_k2_tree_gate.py` (seeded nodes-to-certify).
+Oracle: `~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu`.
+
+| instance  | A: wall s | A: nodes | A: inc-latency s | B: nodes (seeded) | prototype |
+|-----------|----------:|---------:|-----------------:|------------------:|----------:|
+| rsyn0805m |      7.81 |      353 |             5.52 |               353 |        67 |
+| rsyn0810m |      8.29 |      315 |             6.96 |               177 |        60 |
+| rsyn0815m |      6.70 |      237 |             4.90 |               281 |        46 |
+| rsyn0820m |     80.52 |     1805 |            80.43 |                 — |         — |
+| rsyn0830m |     50.80 |     1172 |            46.70 |                 — |         — |
+| syn05m    |      0.00 |        3 |             0.00 |                 — |         — |
+| syn10m    |      0.00 |        1 |             0.00 |                 — |         — |
+| syn15m    |      0.15 |       19 |             0.13 |                 — |         — |
+| syn20m    |      0.58 |       43 |             0.47 |                 — |         — |
+| syn40m    |     17.93 |      631 |             7.42 |               139 |        55 |
+
+- Config-B seeded panel total **950 nodes / ~24 s** → **~26 ms/node** average;
+  each node runs ~20–50 LP solves (OA rounds × separation rounds), every round
+  rebuilding the CSC.
+- SCIP solves the 4-instance seeded panel class at **~0.5–0.8 s/instance**
+  (~2–3 s total; #798 iter-6 measurement). The #807 wall target is ~2× SCIP.
+- Cert-clean on every run is mandatory and non-negotiable (§5 below).
+
+## 3. The architecture (one LP, bounds-in-place)
+
+### 3.1 Row classes and their validity (the C-43 discipline, made structural)
+
+| class | validity | lifetime in the persistent LP |
+|---|---|---|
+| base rows (`le_rows` ‖ `eq_rows`) | global | permanent |
+| OA tangents of convex `≤` rows | **global** (a tangent underestimates its convex `g` everywhere; `oa_tangent(x̄)` does not reference the box) | permanent, shared by ALL nodes — the pool **amortizes OA convergence across the tree** (a node whose ancestors already cut its region typically needs 0–2 new tangents, vs 20–50 solves/node today) |
+| integrality cuts (GMI / cover / MIR) | **local**: valid only for boxes ⊆ the derivation box (they use node variable bounds) | box-tagged; **active iff node box ⊆ derivation box**, else deactivated (below). Never active in a sibling/disjoint box — C-43 enforced by construction |
+
+### 3.2 Deactivation without structural change (the SCIP row-aging trick)
+
+Standard form is `[A | I] z = b` with every row owning a slack: `≤` rows
+`s ∈ [0, cap]`, `=` rows `s = 0` (see `assemble`). To **deactivate** a cut row,
+set its slack upper bound to the row's *global-box violation cap*
+`cap_off = max(0, max-activity over the ROOT box − rhs)` — finite because the
+FBBT'd root box is finite (the K1d NS lesson) — so the row can never bind for any
+`x` in the root box: it is vacuous, the matrix is untouched, the basis stays
+valid, and the NS safe bound stays finite. To **activate**, restore
+`s ∈ [0, cap_on]` with `cap_on` = min-activity cap over the root box (as
+`assemble` computes today, but over the ROOT box, not the node box — cap
+tightness only affects the NS margin ~1e-12·cap, not validity). Everything is a
+bound change; bound changes are exactly what the dual warm path reoptimizes.
+
+### 3.3 `PersistentLp` (new module `crates/discopt-core/src/bnb/warmlp.rs`)
+
+```rust
+pub(crate) enum RowKind {
+    Base,
+    Tangent,                                  // globally valid, always active
+    Cut { dlo: Vec<f64>, dhi: Vec<f64> },     // derivation box (activation test)
+}
+
+pub struct PersistentLp {
+    n: usize,                    // structural columns (fixed)
+    rows: Vec<AsmRow>,           // base ‖ appended (append-only between GCs)
+    kinds: Vec<RowKind>,
+    n_base: usize,
+    csc: SparseCols,             // cached; rebuilt only on append / GC
+    b: Vec<f64>,                 // rhs per row (grows on append)
+    c_std: Vec<f64>,             // sign·c ‖ zeros for slacks (grows on append)
+    cap_on: Vec<f64>,            // per row: active slack cap (root box)
+    cap_off: Vec<f64>,           // per row: deactivation cap (root box)
+    basis: Option<Basis>,        // carried across nodes AND across heap jumps
+    l: Vec<f64>, u: Vec<f64>,    // current full bounds (structural ‖ slacks)
+}
+
+impl PersistentLp {
+    fn new(spec: &ConvexKernelSpec, root_lo: &[f64], root_hi: &[f64]) -> Self;
+    /// Set structural bounds to the node box and (de)activate cut rows by
+    /// box containment. Pure bound writes; O(rows·nnz_row) for the caps test.
+    fn enter_node(&mut self, lo: &[f64], hi: &[f64]);
+    /// Dual-warm solve from the carried basis (PreparedDual::prepare on the
+    /// cached CSC → reoptimize with current l/u/b); cold `solve_lp_cols_scaled`
+    /// fallback whenever prepare fails or the warm path stalls. Stores the
+    /// optimal basis back. Scaled path only (NS certification).
+    fn solve_warm(&mut self, opts: &SimplexOptions) -> LpSolve;
+    /// Append a row (tangent or cut): extend csc/b/c_std/caps, extend the
+    /// carried basis with the new slack basic (`extend_basis` idiom).
+    fn append_row(&mut self, row: AsmRow, kind: RowKind);
+    /// Drop deactivated/aged cut rows when rows.len() exceeds the GC threshold;
+    /// rebuild csc compactly; invalidate the carried basis (next solve cold).
+    fn gc(&mut self);
+}
+```
+
+`solve_tree` keeps its entire existing logic — FBBT per node, safe-bound
+fathoming, pseudocost branching, incumbent acceptance (`is_integer_feasible`),
+honest `TimeLimit`/`Exhausted`, the leaf-dual reported-bound rule — and swaps
+`solve_node_cut` for the persistent-LP node flow:
+
+1. `enter_node(FBBT'd box)` — bound writes only.
+2. `solve_warm` — a few dual pivots typically; cold fallback is always sound.
+3. OA loop: violated convex rows → `append_row(tangent)` (permanent) → warm
+   re-solve, to OA convergence. Expected ~0–2 appends/node once the pool warms.
+4. Separation rounds (as today: `separate_cover_csc` + `separate_gomory_cols` +
+   `separate_mir` under `select_cuts`): each selected cut →
+   `append_row(cut, derivation box = current node box)` → warm re-solve.
+   `assert_cut_valid`-style guard per cut stays.
+5. Final solve → `ns_safe_bound_csc` (scaled) → the node's rigorous dual bound.
+6. Fathom/branch exactly as today. The carried basis goes to the next *popped*
+   node — best-bound jumps are fine (dual feasibility holds for any bounds; a
+   far jump just costs more pivots, measured in W0/W3).
+
+**Development flag:** the new path sits behind `DISCOPT_CVX_NATIVELP`
+(default-OFF) until W5; `solve_node_cut` stays intact as the byte-check
+reference and the fallback. The outer `DISCOPT_CONVEX_KERNEL` routing flag and
+the Python-side #779 incumbent verification are untouched.
+
+### 3.4 Known risks (each has a task/gate below)
+
+- **Degenerate-vertex drift:** the new path lands on different LP vertices than
+  the old kernel → the tree differs. That is *expected* (search-order regime,
+  flavor ii) — the guard is cert-clean + a node-blowup bar, not node parity.
+- **NS under wide slack caps:** root-box caps are wider than node-box caps;
+  the NS margin grows by ~1e-12·cap. W1's byte-check gates that bounds still
+  certify (finite, sound) on the panel boxes.
+- **Basis vs edited rows:** `PreparedDual::prepare` refactorizes from the CSC on
+  every call, so appends/GC are safe; a dual-infeasible carried basis (e.g.
+  after GC) → documented cold fallback, never wrong.
+- **Pool growth:** tangents are permanent by design (they are the relaxation);
+  cuts are GC'd. GC threshold ~4× base rows; GC forces one cold solve.
+- **Warm stalls:** keep `warm_stall_guard` ON and `expel_zero_artificials: true`
+  (P1.0) — stall → bounded cost → cold fallback.
+
+## 4. Correctness contract (standing, binding — CLAUDE.md §1/§5)
+
+- `incorrect_count ≤ 0`, zero slack. Dual bound = oracle optimum exactly on the
+  panel when `optimal` is claimed; `bound ≥ incumbent` (max sense); never a
+  false `optimal`; honest `TimeLimit`/`Exhausted`.
+- Every node bound is `ns_safe_bound_csc` on the **scaled** solve (warm path
+  equilibrates — `dual.rs` scale→solve→unscale; keep it).
+- Every accepted incumbent is integer-integral + OA-tight AND #779-verified
+  against the pristine model on the Python side (unchanged).
+- A cut row may be ACTIVE only in a node whose box ⊆ its derivation box (§3.1).
+  Never weaken this to make a gate pass; if a gate can only pass that way, the
+  gate loses — stop and surface.
+- Fallbacks (cold solve, old `solve_node_cut` path, NLP-BB routing) stay intact
+  at every stage.
+
+## 5. Reusable assets (do NOT rebuild)
+
+- `lp/simplex/dual.rs`: `PreparedDual::{prepare, reoptimize}` (bound-change dual
+  reoptimize — the core primitive), `solve_lp_warm_scaled_csc`, warm stall
+  guard, deadline polling.
+- `convex_kernel.rs`: `ConvexKernelSpec`, `ConvexRow::oa_tangent` (globally
+  valid), `assemble` (fork it for the persistent build), `extend_basis`,
+  `substitute_slacks`, `propagate_fbbt`, `is_integer_feasible`, `select_branch`
+  + `Pseudocosts`, the whole `solve_tree` shell, the 10 unit tests.
+- Separators: `lp/gomory.rs`, `lp/cover.rs`, `lp/mir.rs`, `lp/cut_select.rs`.
+- Marshaling: `convex_bindings.rs` (`SpecArrays`), Python producer
+  `_convex_kernel.build_convex_spec`, `issue798_k1_bytecheck.build_convex_arrays`.
+- Gates: `issue798_k2_tree_gate.py` (config B), `issue800_t0_baseline.py`
+  (config A), `issue798_convex_family_certclean.py`, `issue798_regime2_panel.py`.
+
+## 6. Falsified — do NOT re-walk (binding negatives)
+
+- Row-order / cut-append-order / branching tie-break as node-count levers
+  (#800 T1: 9 variants, none beat baseline; unbiased degeneracy variance).
+- Reliability/strong branching as a standalone lever (#800 T2: net-negative on
+  nodes AND wall with cold probes). Revisit ONLY as W4b after W1–W2 land.
+- Warming the *per-node-reassembled* first solve from the parent's base-only
+  basis (#800 T3 / #798 iter-8): node drift + wall regression. The fix is the
+  shared LP, not a better per-node warm heuristic.
+- Root-relaxation tightening on this class beyond the OA+GMI family (#781 HOLD,
+  #801's RLT/moment falsifications on tanksize).
+
+## 7. #807 — executable task list (loop-executable)
+
+**Loop protocol.** ONE feature branch `feat/807-native-warmlp` off `main`; ONE
+draft PR ("feat(#807): native-warm-LP convex kernel (W0–W5)") opened after W0;
+one scoped commit per task, pushed each task; CI green before the next task.
+Before each commit: `cargo test -p discopt-core`, `pytest -m smoke`, the
+adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`),
+plus the task's own gate script. Append a work-log entry (§8, newest first) with
+MEASURED numbers in the same commit. Kill criterion hit → revert scaffolding (no
+dead flags), record the falsification, commit+push, STOP and surface. Any
+correctness regression (a bound above its reference, a false optimal, an
+unverified incumbent, cert-fail) → STOP immediately and surface.
+
+### W0 — entry experiment: in-place dual reoptimize on the real instance. **BLOCKING.**
+- **Goal.** Validate the core claim — same-LP bound-change dual reoptimize is
+  much cheaper than today's per-node cold pipeline — on a REAL panel instance
+  before any architecture is built.
+- **Hypothesis + evidence.** In a shared LP, the previous node's optimal basis is
+  dual-feasible for any node box (§1, `PreparedDual` contract); SCIP/BARON
+  reoptimize children in a few dual pivots (#801: ~500×/node edge). Today's
+  per-node cost is ~26 ms (§2).
+- **Entry experiment.** Temporary PyO3 probe `convex_warmlp_probe_py`
+  (pattern: K1d) + script `issue807_w0_probe.py`, on **rsyn0815m** (heaviest
+  per-node) and **syn40m** (most nl rows): (a) build the root LP = base rows +
+  root-OA-converged tangent pool over the FBBT'd root box; (b) generate ≥20
+  realistic child boxes by replaying pseudocost branching + FBBT from the tree
+  (branch var fixed down/up, FBBT-propagated); (c) per child, measure — cold:
+  today's full `solve_node_cut` (sep=0) wall; warm: bounds-in-place +
+  `PreparedDual::prepare`+`reoptimize` from the previous solve's basis — wall,
+  **pivots**, bound agreement (≤1e-6), NS certification (finite safe bound),
+  and the number of NEW tangents needed to re-converge OA (pool-amortization
+  check). Include at least 5 *non-adjacent* child pairs (simulated best-bound
+  jumps).
+- **Kill criterion.** Warm (prepare+reoptimize+OA-reconverge) not ≥**2×** faster
+  than the cold node solve on the median child, OR warm bound ≠ cold bound
+  beyond 1e-6, OR NS fails to certify on any warm solve. Kill ⇒ #807 is
+  falsified at the architecture level — record, revert the probe, close the
+  issue on the record; there is no fallback lever.
+- **Verification regime.** Measurement only; bound parity + NS certification
+  asserted within the probe.
+- **Done-when.** Probe numbers (median/p90 warm vs cold wall, pivots, new
+  tangents per child, jump-pair penalty) recorded in the work log; GO/KILL
+  stated explicitly.
+
+### W1 — `PersistentLp` core + tree integration, OA-only.
+- **Goal.** The persistent LP + bounds-in-place + dual-warm node solve wired
+  into `solve_tree` behind `DISCOPT_CVX_NATIVELP` (default-OFF), OA tangents
+  only (`max_sep_rounds=0`), old path untouched.
+- **Hypothesis + evidence.** W0's measured speedup transfers to the tree;
+  tangent-pool sharing collapses per-node OA rounds (W0 measures this).
+- **Entry experiment.** None beyond W0 (this is the build W0 de-risked).
+- **Kill criterion.** Per-node wall (OA-only, node-capped seeded runs on the
+  4 config-B instances) not ≥2× better than the old kernel at the same setting,
+  or bound parity/NS gates fail. Kill ⇒ back to W0's data to find the discrepancy;
+  if irreconcilable, surface.
+- **Verification regime.** Bound-parity byte-check (K1-style, flavor i on the
+  *node relaxation*): script `issue807_w1_bytecheck.py` — new-path node bound =
+  old `solve_node` bound to ≤1e-6 over the root box + ≥6 child boxes × 4
+  instances, NS certifying on all. Tree-level: flavor ii (vertices may differ) —
+  cert-clean on node-capped runs. `cargo test -p discopt-core` green; new unit
+  tests for `enter_node` activation logic, `append_row`+`extend_basis`, GC, and
+  cold-fallback-on-dual-infeasible.
+- **Done-when.** Byte-check PASS; per-node OA-only wall ≥2× better (measured,
+  in the log); flag-OFF path bit-identical (smoke + adversarial green).
+
+### W2 — box-tagged cut rows + full branch-and-cut tree on the panel.
+- **Goal.** Integrality cuts in the persistent LP with box-tagged activation
+  (§3.1–3.2) + GC; the full tree runs the panel under the flag.
+- **Hypothesis + evidence.** Cuts drive the 15–18× node reduction (#797); the
+  activation rule preserves C-43 by construction; deactivation is pure bound
+  writes so the warm chain survives.
+- **Entry experiment.** None separate — W2 is gated by its panel run (the
+  build is W0/W1-de-risked; the open question is only the measured wall).
+- **Kill criterion.** Seeded config-B panel wall not ≤**12 s** (≥2× vs 24 s
+  anchor), OR nodes > **1.5×** the config-B anchor per instance (tree-quality
+  blowup guard: 353/177/281/139 → caps 530/266/422/209), OR any cert failure.
+  Wall-kill ⇒ profile (pivots/node, appends/node, GC frequency), fix, re-gate
+  once; still failing ⇒ surface with the profile.
+- **Verification regime.** Search-order (flavor ii): cert-clean mandatory (dual
+  = oracle exactly, `bound ≥ incumbent`, per-cut validity guard, incumbents
+  #779-verified via the production path), nodes within the blowup bar, wall the
+  measured target. Scripts: `issue798_k2_tree_gate.py` under the flag +
+  `issue800_t0_baseline.py` under the flag (config A: full 10-instance panel
+  cert-clean; rsyn0820m ≤40 s, rsyn0830m ≤25 s).
+- **Done-when.** Both panel runs cert-clean with the bars met; numbers vs §2
+  anchors in the log. Stretch (record, don't gate): seeded panel ≤8 s.
+
+### W3 — cross-node jump cost + plunging order (optional, entry-first).
+- **Goal.** If best-bound jumps dominate pivot counts, recover wall with SCIP
+  plunging (process one child of the just-solved node first, bounded-depth DFS
+  bursts inside the best-bound loop).
+- **Hypothesis + evidence.** Dual reoptimize cost scales with bound distance
+  from the previous solve; W0's jump-pair measurement quantifies it. SCIP
+  plunges for exactly this reason.
+- **Entry experiment.** From W2's instrumented runs: pivots-per-node vs
+  box-distance-from-previous-node. If adjacent nodes average <⅓ the pivots of
+  jump nodes AND jumps are >30% of nodes, plunging has headroom; else skip W3
+  (record why).
+- **Kill criterion.** Plunging does not cut panel wall ≥**10%** vs post-W2, or
+  hurts nodes >1.5× anchors, or any cert failure ⇒ revert, record.
+- **Verification regime.** Search-order (flavor ii): cert-clean + node bar +
+  wall target. Best-bound *fathoming/termination* logic must stay intact
+  (plunging changes the processing order, never the bound logic).
+- **Done-when.** ≥10% wall gain recorded, or the skip/kill recorded.
+
+### W4 — reduced-cost range reduction (RCRR) — the #801 second lever.
+- **Goal.** At each node optimum with an incumbent, tighten variable bounds from
+  reduced costs: nonbasic-at-lower `j` with reduced cost `d_j > 0` (min-sense
+  standard form) admits `x_j ≤ l_j + gap/d_j` (symmetric at upper); integers
+  floor the tightened bound. Tightenings feed FBBT and shrink child boxes.
+- **Hypothesis + evidence.** #801 names RCRR as BARON's second ingredient; it is
+  the one *node-count* mechanism not touched by the #800 falsifications (it is
+  a bound-tightening, not an ordering/branching heuristic). Free at a solved
+  node (reduced costs are already there).
+- **Entry experiment.** Instrument-first on the seeded panel (post-W2 path):
+  count applicable tightenings/node and the box-volume reduction, WITHOUT
+  applying them. If <5% of nodes get any tightening, kill before building.
+  Then apply behind a sub-flag and measure nodes + wall.
+- **Kill criterion.** Applied RCRR improves neither panel nodes nor wall by
+  ≥**10%** (cert-clean) ⇒ revert, record. **Soundness bar (non-negotiable):
+  the `gap` used must be the certified one** (incumbent − NS-safe dual bound,
+  directed-rounded outward); never the raw LP objective. A tightening that cuts
+  the oracle optimum on any panel instance is an immediate stop-and-surface.
+- **Verification regime.** Bound-changing (§5 Regime-2 flavor): sub-flag
+  default-OFF until the panel run is cert-clean AND net-positive; differential
+  check — no tightened bound may exclude the instance's oracle optimum vector
+  (assert per node on the panel: oracle x within the tightened box whenever it
+  was within the parent box).
+- **Done-when.** ≥10% node or wall gain cert-clean with the differential guard
+  green → sub-flag folds into the W2 path; else the falsification is recorded.
+
+### W4b — (optional) reliability branching, revisited with cheap warm probes.
+Only if W1–W2 landed and W4 is resolved. #800 T2's record permits exactly this
+revisit: strong-branch probes via `PreparedDual::reoptimize` (bounds-only, a few
+pivots each, cut-consistent by construction — the shared LP *is* the node LP).
+Entry: η=8, K=8 on the seeded panel. **Kill:** <15% node cut or any wall
+regression ⇒ revert, record, done. Search-order regime (flavor ii).
+
+### W5 — checkpoint + graduation.
+- **Goal.** Confirm the #807 bars; graduate the flags.
+- **Bars.** (a) cert-clean everywhere (mandatory); (b) **wall:** seeded 4-panel
+  ≤ ~2× SCIP (≤6 s total; SCIP ~2–3 s, §2) and config-A full panel with
+  rsyn0820m/0830m well inside the 120 s budget (≤40 s each; stretch ≤15 s);
+  (c) **nodes:** report the ratio vs prototype (67/60/46/55) honestly.
+  *Decision point for the owner:* #800's ≤2× node gate was set for a
+  cutting-driven design; with node levers falsified (T1/T2) and RCRR (W4) the
+  only remaining node mechanism, propose graduating on cert-clean +
+  net-positive wall with the node ratio *recorded*, not gating. Do not silently
+  drop the gate — surface it.
+- **Graduation.** Flip `DISCOPT_CVX_NATIVELP` default-ON inside the kernel (old
+  path kept as byte-check reference + `=0` opt-out). Then run the outer-flag
+  Regime-2 gate (inherited from #798/#800 T7): `issue798_regime2_panel.py` +
+  `issue798_convex_family_certclean.py` + config A, flag-ON vs flag-OFF —
+  cert-clean (incorrect 0, no bound above reference, no certification
+  regression, incumbents verified) AND net-positive (wall/nodes) ⇒ propose
+  `DISCOPT_CONVEX_KERNEL` default-ON to the owner (keep the opt-out and the
+  NLP-BB fallback intact).
+- **Done-when.** Both flag decisions executed (or the owner's explicit deferral
+  recorded), all numbers in the log, PR flipped ready-for-review.
+
+## 8. Work log (append newest first)
+
+*(empty — W0 not started)*

--- a/docs/dev/native-warmlp-plan.md
+++ b/docs/dev/native-warmlp-plan.md
@@ -395,6 +395,41 @@ regression ⇒ revert, record, done. Search-order regime (flavor ii).
 
 ## 8. Work log (append newest first)
 
+- **2026-07-20 (#807 W2 v2): NODE-LOCAL cuts — SOUND ✓ but wall net-negative on the
+  seeded panel (tangent-pool bloat) → SURFACED.** Owner-chosen re-scope after the
+  box-tagged failure. Design: persist ONLY the globally-valid tangent pool (warm
+  across nodes); separate GMI/cover/MIR **node-locally** and ROLL THEM BACK to the
+  post-OA base+tangent snapshot before the next node (`solve_node` snapshots
+  `(rows.len, basis)` at first OA convergence, `rollback_cuts` truncates + restores
+  after). Cuts never cross nodes → C-43 by construction, exactly like the shipped
+  `solve_node_cut`. No box-tagging / containment / `effective_bounds`; the original
+  3-arg `substitute_slacks` is correct (no deactivation).
+  - **SOUNDNESS: PASS (the box-tagged bug is GONE).** W2 gate (seeded rsyn* panel,
+    cuts on, flag ON): **cert-clean**, every dual bound ≥ oracle and closed onto it
+    (rsyn0805m 1296.1207, rsyn0810m 1721.4571, rsyn0815m 1269.9258 vs opts
+    1296.1206/1721.4477/1269.9256). 10 Rust convex tests pass; flag-OFF bit-identical.
+  - **WALL: net-negative on the seeded panel.** ON **26.2 s vs OFF 19.9 s**. Split:
+    rsyn0805m 7.5→5.5 s (nodes 353→241) and rsyn0810m 4.4→3.3 s (177→143) **improve**,
+    but rsyn0815m **regresses** 8.0→17.4 s (nodes 281→**461**, over the 1.5× bar 421).
+  - **Root finding (the W0 bloat, now on the full tree).** Per node OFF cold-solves a
+    SMALL fresh LP (base + this node's few tangents); ON warm-solves the PERSISTENT
+    LP whose tangent pool grows to hundreds of rows over a certifying tree, so each
+    (even warm) solve is over a bigger LP → per-node cost 31 ms (ON) vs 24.5 ms (OFF).
+    The tangent pool that amortized OA at low node counts (W1's 4×) becomes a
+    LIABILITY over hundreds of nodes — the same bloat that put syn40m out of scope.
+    Plus the certifying tree's per-node cost is dominated by cut separation (identical
+    ON/OFF), so the warm base-solve advantage is a small fraction; and search-order
+    variance blew up rsyn0815m's node count.
+  - **Consequence.** The native-warm-LP advantage is real per-node (W0 8–10×, W1 4×
+    OA-only) but **does not net out on the full cut-driven certifying tree** for the
+    rsyn* panel: tangent-pool bloat + cut-separation domination + search-order
+    variance. The node-local implementation is SOUND and committable (default-OFF,
+    helps 2/3 seeded instances) but does not meet W2's ≤12 s wall bar. **SURFACED to
+    the owner:** (a) run the config-A PRODUCTION panel (unseeded, incl. the big
+    rsyn0820m/0830m) to get the real net before judging; (b) tighten the tangent-pool
+    GC cap to fight bloat; (c) accept W1 as the #807 scoped win (warm-LP proven
+    per-node but not net-positive on the certifying panel) and close.
+
 - **2026-07-20 (#807 W2): box-tagged PERSISTENT cuts — FAILED on soundness AND
   wall → reverted, SURFACED for re-scope to node-local cuts.**
   Built the §3.1–3.2 design: `RowKind` = Base/Tangent/`Cut{dlo,dhi,rhs}`; per-node

--- a/docs/dev/native-warmlp-plan.md
+++ b/docs/dev/native-warmlp-plan.md
@@ -395,6 +395,41 @@ regression ⇒ revert, record, done. Search-order regime (flavor ii).
 
 ## 8. Work log (append newest first)
 
+- **2026-07-20 (#807 W2): box-tagged PERSISTENT cuts — FAILED on soundness AND
+  wall → reverted, SURFACED for re-scope to node-local cuts.**
+  Built the §3.1–3.2 design: `RowKind` = Base/Tangent/`Cut{dlo,dhi,rhs}`; per-node
+  `effective_bounds` activates a cut iff node box ⊆ its derivation box (else raises
+  its rhs to max-activity → vacuous); ported cover/GMI/MIR separation into the
+  persistent solve with a `b_eff`-aware `substitute_slacks`; box-tags each cut with
+  the node box; GC maintains the pool. W2 gate (`issue807_w2_gate.py`, seeded rsyn*
+  panel, cuts on, flag ON vs OFF):
+  - **SOUNDNESS FAILURE (the make-or-break).** Flag-ON, rsyn0815m dual bound
+    **1269.3402 < oracle 1269.9256** — for this maximization the dual bound is an
+    UPPER bound and must be ≥ opt, so a bound *below* the optimum means a box-tagged
+    cut **removed the true optimum**: an unsound cut. Flag-OFF (node-local cuts, the
+    shipped path) gives 1269.9261 ≥ opt — sound. The soundness gate caught it
+    exactly as designed. (The revert means nothing unsound is committed; the bug was
+    behind the default-OFF flag, never shipped.)
+  - **WALL FAILURE (independent).** Flag-ON **198.5 s vs OFF 19.2 s — ~10× SLOWER**,
+    even on the sound instances (rsyn0805m 39.7 s vs 7.4 s). The per-node cut
+    activation (containment + activity recomputation over a growing cut set,
+    rebuilding `effective_bounds` every solve) + LP bloat + GC basis invalidation
+    dominate. Nodes also blew the 1.5× bar (rsyn0810m 281>265, rsyn0815m 433>421).
+    W2 wall bar was ≤12 s; got 198 s.
+  - **Verdict: the PERSISTENT box-tagged cut design (§3.1–3.2) does not deliver** —
+    unsound as implemented AND slow by construction. Both point the same way: cuts
+    should NOT persist across nodes. **Reverted to the sound W1 state** (RowKind
+    removed, 10 Rust convex tests pass, kernel back to the W1-committed code); the
+    W2 gate script is kept as the reproduction.
+  - **Recommended re-scope — NODE-LOCAL cuts.** Persist ONLY the globally-valid
+    tangent pool (W1's proven 4× win, warm across nodes); derive GMI/cover/MIR cuts
+    **node-locally** (added during a node's separation, rolled back before the next
+    node — save the post-OA base+tangent basis, restore after the node). This is
+    **guaranteed sound** (C-43 trivially — cuts never cross nodes, exactly like the
+    shipped `solve_node_cut`), avoids all per-node cut-activation overhead, and keeps
+    both the tangent warmth and the cut node-reduction. **SURFACED to the owner:**
+    node-local cuts (recommended) vs debugging the box-tagged persistent approach.
+
 - **2026-07-20 (#807 W1): persistent-LP tree integration (OA-only) — PASS, 4.0×.**
   Promoted the W0 warm solver to return a `ConvexNodeResult` and wired it into
   `solve_tree` behind `DISCOPT_CVX_NATIVELP` (default-OFF): a gated branch swaps the

--- a/docs/dev/native-warmlp-plan.md
+++ b/docs/dev/native-warmlp-plan.md
@@ -395,6 +395,28 @@ regression ⇒ revert, record, done. Search-order regime (flavor ii).
 
 ## 8. Work log (append newest first)
 
+- **2026-07-20 (#807 W1): persistent-LP tree integration (OA-only) — PASS, 4.0×.**
+  Promoted the W0 warm solver to return a `ConvexNodeResult` and wired it into
+  `solve_tree` behind `DISCOPT_CVX_NATIVELP` (default-OFF): a gated branch swaps the
+  per-node cold `solve_node_cut` for the shared persistent LP (bounds-in-place
+  dual-warm + tangent aging/GC at cap `NATIVELP_POOL_CAP=600`). OFF takes the exact
+  original call → bit-identical. Gate `issue807_w1_bytecheck.py` (seeded rsyn*
+  subset, OA-only, `max_sep_rounds=0`, flag ON vs OFF):
+  - **Representative cap (600 nodes, ≈ the cut-driven W2 tree size): 4.0× panel**
+    (OFF 6.8 s → ON 1.7 s), **cert-clean both**. Per instance: rsyn0805m 8.0×,
+    rsyn0810m 5.9×, rsyn0815m 2.4× — the ≥2× per-node bar cleared decisively. Node
+    bounds MATCH ON vs OFF (rsyn0805m/0810m bit-identical; rsyn0815m differs by
+    OA-slack 1566.40 vs 1566.54, both sound ≥ oracle) → the byte-check parity holds.
+  - **Deep OA-only cap (4000 nodes): only 1.65× panel** — recorded because it shows
+    the OA-only *pathology*: with NO cuts the seeded tree explores a huge region, so
+    even rsyn0815m's pool grows past saturation and bloats the LP (rsyn0805m/0810m
+    still 3–3.6×, rsyn0815m flat). This is why W2 (cuts → ~350-node trees → saturated
+    pool) is where the full speedup lands; the OA-only regime understates it.
+  - **Verification.** `cargo test -p discopt-core convex` 10 passed (flag-OFF);
+    clippy clean; flag-OFF path is the unchanged `solve_node_cut` call (bit-identical
+    by construction). W1 is OA-only by design — cuts are W2; the outer
+    `DISCOPT_CONVEX_KERNEL` production path is untouched (inner flag default-OFF).
+
 - **2026-07-20 (#807 W0 addendum): tangent-GC FALSIFIED as the syn40m rescue
   (owner-chosen option a). Root cause CONFIRMED: syn40m is OA-round-bound.**
   Implemented SCIP-style tangent aging + GC in the probe (`W0WarmLp::age_and_gc`:

--- a/docs/dev/native-warmlp-plan.md
+++ b/docs/dev/native-warmlp-plan.md
@@ -379,6 +379,33 @@ regression ⇒ revert, record, done. Search-order regime (flavor ii).
 
 ## 8. Work log (append newest first)
 
+- **2026-07-20 (#807 W0 addendum): tangent-GC FALSIFIED as the syn40m rescue
+  (owner-chosen option a). Root cause CONFIRMED: syn40m is OA-round-bound.**
+  Implemented SCIP-style tangent aging + GC in the probe (`W0WarmLp::age_and_gc`:
+  age each non-binding tangent, drop the most-aged when the pool exceeds a cap;
+  dropping is sound — the OA loop re-derives on demand). Re-ran W0 at pool cap 150:
+  - **GC bounds the pool but does NOT rescue the ratio.** syn40m pool 817→166 rows,
+    but amortized warm-vs-cold **1.00× → 1.25×** (still ≪ 2×). rsyn0815m stays
+    **GO: 10.07× → 8.65×** (GC costs a little; still decisive). Cert-clean + sound
+    throughout (margins unchanged; parity still OA-slack, 1.4e-4→1.4e-7 at 1e-9).
+  - **Why GC can't help (the definitive finding):** GC drops tangents syn40m
+    immediately needs back → **re-derivation churn** — total new tangents
+    **830 → 2525** (→ 5173 at oa_tol=1e-9). It trades pool size for OA work,
+    net-neutral. The real bottleneck is that **syn40m nodes are OA-round-bound**:
+    ~7 NEW tangents/node to OA-converge, which BOTH the cold and warm paths must
+    derive (both warm the within-node OA re-solves already). The native-warm-LP
+    advantage lives ONLY in the FIRST solve per node — a small fraction of an
+    OA-round-heavy node — so no warm-LP or pool strategy can move syn40m. This is
+    inherent to syn40m's many highly-curved nonlinear rows (a relaxation-quality
+    property), NOT a per-node-throughput problem.
+  - **Consequence.** The native-warm-LP architecture is validated, sound, and
+    decisively net-positive (8–10×) on the **pool-saturating `rsyn*` family** — which
+    is exactly where the #800 panel-wall gap lives (rsyn0820m 80 s / rsyn0830m 50 s
+    dominate config-A's 174 s). It is a no-op on the **OA-round-bound** class
+    (syn40m; the tiny syn05–20m are ≤0.6 s and irrelevant). Owner option (a) is
+    falsified; **re-surfaced with (b) scope #807 to `rsyn*` [recommended — captures
+    the wall gap] vs (c) whole-issue kill.** Probe + this record committed.
+
 - **2026-07-20 (#807 W0): primitive VALIDATED + SOUND, but the permanent-tangent-
   pool amortization FALSIFIED on syn40m → SURFACED for re-scope.**
   Probe: `crates/discopt-core/src/bnb/convex_kernel.rs` (`W0WarmLp` + a shared-LP


### PR DESCRIPTION
Native-warm-LP convex kernel (#807, follow-up to #800). **Closes #807.**

## Outcome: native-warm-LP built + SOUND, but does not net out on the certifying panel — closed on the W1 scoped finding

The #800→#801→#807 arc systematically eliminated the SCIP-parity levers on the convex `rsyn*`/`syn*` family:
- **#800** — node-count levers (row-order, strong branching): all falsified.
- **#801** — named per-node throughput ("native warm LPs + reduced-cost range reduction") as BARON's edge.
- **#807** — built native warm LPs. The per-node warm advantage is **real** but does **not** translate to a panel wall win on the full cut-driven certifying tree.

### Task record (all measured, durable)

| task | result |
|---|---|
| **W0** — dual-reoptimize probe | GO, scoped to `rsyn*`: primitive validated + **sound** (NS-certified, bound ≥ oracle), **8–10×** per node on rsyn0815m. syn40m OA-round-bound → out of scope. |
| **W1** — persistent-LP tree integration (OA-only) | PASS: **4.0×** on the seeded rsyn* subset, cert-clean, flag-OFF bit-identical. |
| **W2** — box-tagged persistent cuts | FAILED — unsound (a cut removed the optimum; caught by the soundness gate, reverted) AND 10× slower. |
| **W2** — node-local cuts (re-scope) | **SOUND** (cert-clean) but production panel **3× slower** (434.9s vs 148.7s); rsyn0820m/0830m regress from certified to time_limit. |
| **W2** — GC-cap sweep | Tightening the tangent-pool cap helps ~15% but never beats the baseline; does not rescue the regression. |

### Why it doesn't net out (fundamental)

Over the hundreds–thousands of nodes a certifying tree needs, the persistent tangent pool **bloats** (each warm solve runs over a bigger LP than the baseline's small fresh per-node LP), per-node cost is **dominated by cut separation** (which warm LPs can't accelerate), and search-order variance blows up node counts. The gap to SCIP is **architectural** — a mature, integrated LP-based B&C engine — not an incremental lever.

### What's merged

- Native-warm-LP node solve (persistent tangent pool + node-local cuts), **built, sound, cert-clean, behind `DISCOPT_CVX_NATIVELP` (default-OFF, flag-OFF bit-identical)**.
- The plan + full findings (`docs/dev/native-warmlp-plan.md`) and the W0/W1/W2 reproduction scripts.
- Flag stays default-OFF; a future SCIP-class LP-B&C core is a separate architectural effort.

### Verification

`cargo test -p discopt-core convex` (10 passed), convex-kernel gate tests (8 passed), `pytest -m smoke` (831 passed), adversarial suite (10 passed), flag-OFF bit-identical throughout. Merged `main` (incl. #800's T0 instrumentation) rebuilt + retested clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
