### PR TITLE
fix(#810): iterative _expression_degree — no RecursionError on deep expressions

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1693,36 +1693,56 @@ def _require_no_shape(shape, ctor: str) -> None:
 _INF_DEGREE = float("inf")
 
 
-def _expression_degree(e) -> float:
-    """Polynomial degree of ``e`` in the decision variables; ``inf`` for anything that
-    is not a polynomial (transcendental, variable power, variable denominator, opaque)."""
-    if isinstance(e, (int, float)):
-        return 0
-    if isinstance(e, Constant):
+def _degree_child_nodes(e) -> tuple:
+    """The sub-expressions whose polynomial degree ``e``'s degree depends on.
+
+    Deliberately narrow: a ``**`` reads its RHS as a *constant exponent* (not a
+    degree), and non-``neg`` unary / opaque nodes short-circuit to ``inf`` without
+    inspecting children, so those children are not returned.
+    """
+    if isinstance(e, IndexExpression):
+        return (e.base,)
+    if isinstance(e, SumExpression):
+        return (e.operand,)
+    if isinstance(e, SumOverExpression):
+        return tuple(e.terms)
+    if isinstance(e, UnaryOp):
+        return (e.operand,) if e.op == "neg" else ()
+    if isinstance(e, MatMulExpression):
+        return (e.left, e.right)
+    if isinstance(e, BinaryOp):
+        return (e.left,) if e.op == "**" else (e.left, e.right)
+    return ()  # leaves (int/float/Constant/Variable) and opaque (FunctionCall/...)
+
+
+def _degree_combine(e, child_degs: list[float]) -> float:
+    """Degree of ``e`` from its children's degrees (aligned with
+    :func:`_degree_child_nodes`). Mirrors the original per-node rules exactly."""
+    if isinstance(e, (int, float, Constant)):
         return 0
     if isinstance(e, Variable):
         return 1
     if isinstance(e, IndexExpression):
-        return _expression_degree(e.base)
+        return child_degs[0]
     if isinstance(e, SumExpression):
-        return _expression_degree(e.operand)
+        return child_degs[0]
     if isinstance(e, SumOverExpression):
-        return max((_expression_degree(t) for t in e.terms), default=0)
+        return max(child_degs, default=0)
     if isinstance(e, UnaryOp):
-        return _expression_degree(e.operand) if e.op == "neg" else _INF_DEGREE
+        return child_degs[0] if e.op == "neg" else _INF_DEGREE
     if isinstance(e, (FunctionCall, CustomCall)):
         return _INF_DEGREE
     if isinstance(e, MatMulExpression):
-        return _expression_degree(e.left) + _expression_degree(e.right)
+        return child_degs[0] + child_degs[1]
     if isinstance(e, BinaryOp):
-        left, right = _expression_degree(e.left), _expression_degree(e.right)
         if e.op in ("+", "-"):
-            return max(left, right)
+            return max(child_degs[0], child_degs[1])
         if e.op == "*":
-            return left + right
+            return child_degs[0] + child_degs[1]
         if e.op == "/":
-            return left if right == 0 else _INF_DEGREE
+            return child_degs[0] if child_degs[1] == 0 else _INF_DEGREE
         if e.op == "**":
+            left = child_degs[0]
             k = (
                 e.right.value
                 if isinstance(e.right, Constant)
@@ -1738,6 +1758,32 @@ def _expression_degree(e) -> float:
                 return _INF_DEGREE
         return _INF_DEGREE
     return _INF_DEGREE  # unknown node -> treat as nonlinear (guard runs; safe direction)
+
+
+def _expression_degree(root) -> float:
+    """Polynomial degree of ``root`` in the decision variables; ``inf`` for anything
+    that is not a polynomial (transcendental, variable power, variable denominator,
+    opaque).
+
+    Iterative post-order over the expression DAG with memoization by node identity,
+    so a deeply nested expression (e.g. a long left-associated sum) never overflows
+    the Python recursion stack, and shared sub-expressions are walked once (#810).
+    """
+    memo: dict[int, float] = {}
+    stack = [root]
+    while stack:
+        e = stack[-1]
+        if id(e) in memo:
+            stack.pop()
+            continue
+        kids = _degree_child_nodes(e)
+        pending = [c for c in kids if id(c) not in memo]
+        if pending:
+            stack.extend(pending)  # compute children first (no recursion)
+            continue
+        memo[id(e)] = _degree_combine(e, [memo[id(c)] for c in kids])
+        stack.pop()
+    return memo[id(root)]
 
 
 def _is_fast_linear_quadratic_family(model) -> bool:

--- a/python/tests/test_fast_path.py
+++ b/python/tests/test_fast_path.py
@@ -320,3 +320,52 @@ class TestFastPathEquivalence:
         for p in SUPPLY:
             used = sum(vals[(p, k)] for k in DEMAND)
             assert used <= SUPPLY[p] + 1e-5
+
+
+class TestExpressionDegreeDeepRecursion:
+    """Regression for #810: `_expression_degree` (the fast-family guard) must not
+    overflow the Python recursion stack on deeply nested expressions — a long
+    left-associated sum used to crash `solve()` with `RecursionError`.
+    """
+
+    def test_degree_matches_on_small_expressions(self):
+        from discopt.modeling.core import _expression_degree
+
+        m = dm.Model("deg")
+        x = [m.continuous(f"x{i}", lb=0, ub=1) for i in range(3)]
+        assert _expression_degree(x[0] + x[1] + x[2]) == 1
+        assert _expression_degree(x[0] * x[1]) == 2
+        assert _expression_degree(x[0] ** 3) == 3
+        assert _expression_degree(x[0] * x[1] * x[2]) == 3
+        assert _expression_degree(dm.sqrt(x[0])) == float("inf")  # transcendental
+
+    def test_deep_left_associated_sum_no_recursionerror(self):
+        import functools
+        import operator
+
+        from discopt.modeling.core import _expression_degree
+
+        m = dm.Model("deep")
+        # Depth well past CPython's ~1000-frame default recursion limit.
+        terms = [m.continuous(f"y{i}", lb=0, ub=1) for i in range(6000)]
+        expr = functools.reduce(operator.add, terms)  # ((((y0+y1)+y2)+...)
+        assert _expression_degree(expr) == 1  # linear, and no RecursionError
+
+    def test_solve_with_deep_sum_does_not_crash(self):
+        # A model with a deep left-associated sum in both the objective AND a
+        # constraint body must solve, not raise RecursionError from the
+        # incumbent-verification degree guard (which runs over `self._constraints`
+        # -- exactly the path that crashed on autocorr_bern* in the benchmark, #810).
+        m = dm.Model("deepsolve")
+        n = 3000
+        x = [m.continuous(f"x{i}", lb=0, ub=1) for i in range(n)]
+        obj = x[0]
+        deep = x[0]
+        for i in range(1, n):
+            obj = obj + (i % 3) * x[i]  # deep left-associated chain
+            deep = deep + x[i]
+        m.minimize(obj)
+        m.subject_to(deep >= 1.0)  # deep-sum constraint body triggers the guard
+        r = m.solve(time_limit=30, gap_tolerance=1e-4)
+        assert r.status in ("optimal", "feasible")
+        assert r.objective is not None


### PR DESCRIPTION
## Fix #810 — `solve()` crashed with `RecursionError` on deeply-nested expressions

`Model.solve()` raised an unhandled `RecursionError` on valid models whose expression tree is deeply nested (e.g. a long left-associated sum). The crash was in `_expression_degree`, a purely recursive expression-tree walker with no depth guard, reached on the **default** solve path via the incumbent-verification gate (`_is_fast_linear_quadratic_family`) — so any sufficiently deep model crashed the solver. It's a robustness bug (hard crash on a valid model), not a correctness bug.

Surfaced by the small+medium MINLPLib benchmark: `autocorr_bern35-09` and `autocorr_bern20-15` reported `error` at 0.0 s.

### Fix
Rewrote `_expression_degree` as an **iterative post-order over the expression DAG with memoization by node identity** (split into `_degree_child_nodes` + `_degree_combine`, combine semantics identical to the original per-node rules). Deep nesting now grows a heap list, not the Python call stack, and shared sub-expressions are walked once. The `**` RHS is read as a constant exponent (not a degree child), matching the original.

### Verification
- The two previously-erroring instances now solve to a **sound** feasible incumbent: `autocorr_bern20-15` obj −5952 ≥ opt −5960; `autocorr_bern35-09` obj −5092 ≥ opt −5108; dual bounds below the optimum (no crossing).
- **Regression tests** (`test_fast_path.py::TestExpressionDegreeDeepRecursion`): degrees match on small expressions; `_expression_degree` on a 6000-deep sum returns 1 with no `RecursionError` (crashes pre-fix); `solve()` with a deep sum in the objective **and** a constraint body returns normally.
- `test_fast_path.py` + `test_lazy_jax_linear_path.py` (**34 passed** — the JAX-free fast-path classification is unchanged), `pytest -m smoke` (**831 passed**), ruff + format + mypy clean.

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
