### PR TITLE
fix(correctness): #248 restore nvs16 garbage-bound guard in uniform relaxer

### DIFF
--- a/python/discopt/_jax/uniform_relax.py
+++ b/python/discopt/_jax/uniform_relax.py
@@ -410,6 +410,14 @@ _EMPTY_BOX = np.empty(0, dtype=np.float64)
 _BOUNDS_CACHE_CAP = 500_000
 # Cap on the per-node proven/abstained curvature-box lists (drop-oldest).
 _CERT_LIST_CAP = 8
+# #248: magnitude past which the objective's box-interval floor is treated as
+# garbage — the factorable-reform signature where a wide-boxed monomial-lift
+# auxiliary (e.g. nvs16's ``_fr_aux == x1**6`` over [0, 6.4e13]) with a negative
+# objective coefficient sinks the LP objective bound to a garbage-but-sound value
+# (~-5e11) that anchors the tree and never certifies. The LP bound is refused so
+# the solver falls back to the rigorous alphaBB/interval bound. Matches the
+# relaxation's 1e10 aux-bound cap (milp_relaxation._RELAX_NUMERIC_CAP).
+_OBJ_BOX_FLOOR_GARBAGE_CAP = 1e10
 
 
 class _TracedEvalFn:
@@ -3155,6 +3163,19 @@ def build_uniform_relaxation(
         else:
             obj_box_lb += contrib
     if not math.isfinite(obj_box_lb):
+        obj_bound_valid = False
+    # #248: when the objective's box-interval floor is garbage-wide, the LP
+    # objective bound is untrustworthy and must be refused so the solver falls
+    # back to the rigorous alphaBB/interval bound. This is the factorable-reform
+    # signature: a monomial-lift auxiliary (e.g. nvs16's x1**6 over [0, 6.4e13])
+    # carries a wide box AND a negative objective coefficient, so the loose
+    # McCormick rows let the LP drive it to that box edge and sink the objective
+    # to a garbage-but-sound bound (~-5e11 vs true 0.703) that anchors the tree
+    # and never certifies. The aux is IN the rows (not omitted), so the freed-
+    # column check above doesn't catch it — the box-floor magnitude does.
+    # Refusing only ever tightens (falls back to a rigorous bound), never loosens
+    # below truth, so a rare false refusal costs nodes, not soundness.
+    elif obj_box_lb < -_OBJ_BOX_FLOOR_GARBAGE_CAP:
         obj_bound_valid = False
 
     # ── Separable objective lower bound (issue #640 Bucket 1 — federation-parity) ──

--- a/python/tests/test_bucket2_sound_bounds.py
+++ b/python/tests/test_bucket2_sound_bounds.py
@@ -159,19 +159,23 @@ def test_nvs16_produces_sound_finite_bound():
 
 @pytest.mark.correctness
 def test_nvs16_full_solve_does_not_anchor_on_garbage_bound():
-    """#248: the live solve factorable-reforms nvs16 into aux vars including
-    ``_fr_aux == x1**6``, whose defining equality the relaxer cannot linearize
-    (x1**6 over [0,200] spans [0, 6.4e13], past the monomial magnitude cap) and
-    therefore DROPS. Dropping the sole constraint on a wide-boxed aux variable
-    that the objective depends on frees it, and minimizing drove the dual bound to
-    a garbage **-5.08e11** (~100% gap, never certifies) — even though the
-    objective is a sum of squares trivially ``>= 0``.
+    """#248: the live solve factorable-reforms nvs16 into monomial-lift aux vars
+    including ``_fr_aux == x1**6``, whose box spans [0, 6.4e13] (past the 1e10
+    aux-bound cap). The uniform relaxer DOES represent these auxes as rows, but the
+    McCormick under-estimators over such wide boxes are so loose that — with the
+    aux carrying a NEGATIVE objective coefficient — the LP drives it to its box
+    edge and sinks the objective bound to a garbage **-5e11** (~100% gap, never
+    certifies), even though the objective is a sum of squares trivially ``>= 0``.
 
-    The relaxer now detects that the omitted constraint frees an objective-linked,
-    otherwise-unconstrained, wide-boxed variable, marks the objective bound
-    invalid, and falls back to the rigorous alphaBB / prereform-interval bound.
-    The raw-model root-bound test above never caught this because it does not run
-    the factorable reform — the bug only appears in the full solve pipeline."""
+    The relaxer now detects that the objective's box-interval floor is garbage-wide
+    (``obj_box_lb < -1e10``), marks the objective bound invalid, and falls back to
+    the rigorous alphaBB / prereform-interval bound. Note this is NOT the freed-
+    column case (the aux IS in the constraint rows) — the box-floor magnitude is
+    the signal. The raw-model root-bound test above never caught this because it
+    does not run the factorable reform — the bug only appears in the full solve
+    pipeline. Regressed silently at #632 (d897f033, uniform-relax cutover) which
+    dropped the original milp_relaxation ``_omitted_obj_linked`` guard; the
+    correctness marker is excluded from the PR-fast CI lane, so CI never caught it."""
     m = dm.from_nl(str(_DATA / "nvs16.nl"))
     r = m.solve(time_limit=20)
     assert r.objective is not None and abs(r.objective - 0.703125) < 1e-3


### PR DESCRIPTION
## Problem

`nvs16` (MINLPLib) solved to the correct optimum **0.703125** but returned a dual
bound of **-5e11** — a ~100% gap that never certifies — even though its objective
is a sum of squares trivially `>= 0`. This is a correctness-adjacent quality
regression: the tree anchors on a garbage-but-sound bound.

### Root cause

The factorable reform lifts `x1**6` into a monomial-aux over `[0, 6.4e13]` (past
the `1e10` aux-bound cap). The uniform relaxer (`build_uniform_relaxation`) *does*
represent that aux as McCormick rows, but over such a wide box the under-estimators
are so loose that — with the aux carrying a **negative objective coefficient** —
the LP drives it to its box edge and sinks the objective bound to -5e11.

The original guard for this (#248, `_omitted_obj_linked` in `milp_relaxation.py`,
commit `8e052079`) keyed on a *freed column* (dropped constraint frees an
objective-linked wide-boxed var). That framing was silently dropped in the **#632**
uniform-relax cutover (`d897f033`) and never re-added. In the uniform engine the
aux is **not** freed — it is in the rows — so the freed-column check does not port.

### Fix

The general signal is the objective's box-interval floor itself: when
`obj_box_lb < -1e10` the LP objective bound is untrustworthy, so
`objective_bound_valid` is set `False` and the solver falls back to the rigorous
alphaBB / prereform-interval bound. **Refusing only ever tightens toward a
rigorous bound, never loosens below truth** — a rare false refusal costs nodes,
not soundness. `nvs16` now returns bound **0.703125** (= optimum).

The regression went uncaught for a full release cycle because the `correctness`
pytest marker is **excluded from the PR-fast CI lane** (see note below).

## Verification

- `test_nvs16_full_solve_does_not_anchor_on_garbage_bound` (correctness): **FAILED before, PASSES after** — the regression test.
- bucket2 sound-bounds suite: **20 passed, 2 xfailed**
- smoke suite: **831 passed, 2 xpassed**
- full `correctness` marker sweep: **428 passed, 7 skipped, 4 xfailed, 0 failures** — no certified instance regressed (no over-refusal).

## Follow-up (not in this PR)

The `correctness` marker is not gated in the PR-fast CI lane
(`-m "not slow and not correctness and ..."`), which is why this regressed
silently at #632. Worth a separate issue to add a nightly/gate correctness lane.

Closes #248 (the specific nvs16 garbage-bound regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
