### PR TITLE
fix(correctness): #815 withhold infeasible NLP iterate in the continuous path

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -11539,6 +11539,39 @@ def _solve_continuous(
     _c_bound = obj_val if status == "optimal" else None
     _c_gap = _optimal_relative_gap(obj_val) if status == "optimal" and obj_val is not None else None
 
+    # #815: this single-NLP path reports the solver's returned point as the
+    # incumbent. A local NLP that stalls at the time/iteration limit — or, on a
+    # problem with unbounded variables, one that terminates at a non-KKT point —
+    # can hand back an INFEASIBLE iterate (emfl050_3_3/emfl100_3_3: the NLP stalls
+    # at an all-10 point violating the distance-defining equalities by ~9.5, and
+    # this path would otherwise report it as objective=594). Reporting that point
+    # as an incumbent is a false primal. Verify feasibility HERE, at the source,
+    # with the SAME loose check the final incumbent-verification guard (#772) uses
+    # (abs tol 1e-3 — it can only flag a gross violation, never a point feasible
+    # within the solver's own tolerance), and withhold an infeasible point so a
+    # bogus incumbent never propagates. This only ever removes a bad incumbent;
+    # the path carries no valid dual bound when it is not "optimal", so refusing
+    # here can never loosen a bound below truth (soundness is untouched).
+    if x_dict is not None and nlp_result.x is not None:
+        from discopt._jax.primal_heuristics import (
+            _check_constraint_feasibility as _cc_feas_verify,
+        )
+
+        if not _cc_feas_verify(evaluator, np.asarray(nlp_result.x, dtype=np.float64), tol=1e-3):
+            logger.warning(
+                "continuous NLP returned an infeasible point (status=%s, obj=%s); "
+                "withholding the incumbent — no feasible solution was found.",
+                status,
+                obj_val,
+            )
+            obj_val = None
+            x_dict = None
+            _c_bound = None
+            _c_gap = None
+            # An unverified point can never be reported as a proven optimum.
+            if status == "optimal":
+                status = "unknown"
+
     return SolveResult(
         status=status,
         objective=obj_val,

--- a/python/tests/test_815_continuous_false_primal.py
+++ b/python/tests/test_815_continuous_false_primal.py
@@ -1,0 +1,124 @@
+"""Regression tests for #815: the pure-continuous single-NLP path must not report
+an infeasible NLP iterate as an incumbent (a false primal).
+
+``_solve_continuous`` (``solver.py``) solves a pure-continuous model with one
+local NLP solve (no B&B tree). A local NLP that stalls at the time/iteration
+limit — or, on a model with unbounded variables, terminates at a non-KKT point —
+can hand back an INFEASIBLE point with a finite objective. Before the fix the
+path reported that point as ``objective``/``x`` (emfl050_3_3: an all-10 iterate
+violating the distance-defining equalities by ~9.5, reported as objective=594),
+and only the final incumbent-verification guard (#772) caught it downstream.
+
+The fix verifies feasibility AT THE SOURCE — with the same loose 1e-3 check the
+#772 guard uses — and withholds an infeasible point there, so the bogus incumbent
+never propagates.
+
+The unit tests drive ``_solve_continuous`` directly with a monkeypatched NLP
+backend (deterministic, CI-safe, no benchmark corpus needed); the slow test is
+the real-instance guard when the MINLPLib corpus is present.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import discopt.modeling as dm
+import discopt.solver as solver_mod
+import discopt.solvers.nlp_ipopt as _nlp_ipopt
+import discopt.solvers.nlp_pounce as _nlp_pounce
+import numpy as np
+import pytest
+from discopt.solvers.nlp_ipopt import NLPResult, SolveStatus
+
+
+def _patch_nlp(monkeypatch, x_value: float, status: SolveStatus, objective: float):
+    """Force both NLP backends to return a fixed point/status/objective."""
+
+    def _fake_solve(evaluator, x0, *args, **kwargs):
+        n = int(np.asarray(x0).size)
+        return NLPResult(
+            status=status,
+            x=np.full(n, x_value, dtype=np.float64),
+            objective=objective,
+            multipliers=None,
+            bound_multipliers_lower=None,
+            bound_multipliers_upper=None,
+            iterations=1,
+            wall_time=0.01,
+        )
+
+    monkeypatch.setattr(_nlp_pounce, "solve_nlp", _fake_solve)
+    monkeypatch.setattr(_nlp_ipopt, "solve_nlp", _fake_solve)
+
+
+def _nonlinear_continuous_model() -> dm.Model:
+    """A pure-continuous, nonlinear, FEASIBLE model (optimum at x=1)."""
+    m = dm.Model("fp815")
+    m.continuous("x", lb=0.0, ub=2.0)
+    m.minimize(m._variables[0])
+    m.subject_to(m._variables[0] ** 2 == 1.0)
+    return m
+
+
+@pytest.mark.correctness
+def test_815_solve_continuous_withholds_infeasible_incumbent(monkeypatch):
+    """A stalled NLP returning an INFEASIBLE point (x=2 violates x**2==1 by 3)
+    must NOT be reported as an incumbent — objective/x are withheld at the source.
+    Before the fix this returned objective=2.0 with an infeasible x."""
+    _patch_nlp(monkeypatch, x_value=2.0, status=SolveStatus.TIME_LIMIT, objective=2.0)
+    m = _nonlinear_continuous_model()
+    r = solver_mod._solve_continuous(m, 5.0, None, time.perf_counter(), nlp_solver="pounce")
+    assert r.objective is None, f"#815: infeasible incumbent reported: obj={r.objective}"
+    assert r.x is None, "#815: infeasible incumbent point reported"
+
+
+@pytest.mark.correctness
+def test_815_solve_continuous_keeps_feasible_incumbent(monkeypatch):
+    """Positive control: a FEASIBLE returned point (x=1 satisfies x**2==1) must be
+    kept — the feasibility gate must not over-withhold genuine incumbents."""
+    _patch_nlp(monkeypatch, x_value=1.0, status=SolveStatus.OPTIMAL, objective=1.0)
+    m = _nonlinear_continuous_model()
+    r = solver_mod._solve_continuous(m, 5.0, None, time.perf_counter(), nlp_solver="pounce")
+    assert r.objective is not None and abs(r.objective - 1.0) < 1e-6, (
+        f"#815 over-withholding: a feasible incumbent was dropped (obj={r.objective})"
+    )
+    assert r.x is not None
+
+
+# --- Real-instance guard (needs the MINLPLib benchmark corpus) ---------------
+
+_EMFL = Path(
+    os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/emfl050_3_3.nl")
+)
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+@pytest.mark.skipif(not _EMFL.exists(), reason="emfl050_3_3.nl (benchmark corpus) absent")
+def test_815_emfl_no_false_primal():
+    """The real repro: emfl050_3_3's stalled NLP must not surface the ~594 false
+    primal, and the #772 guard must never have to fire (the source withholds)."""
+    model = dm.from_nl(str(_EMFL))
+    result = model.solve(time_limit=5)
+    assert not getattr(result, "incumbent_verification_failed", False), (
+        "#815: the #772 guard had to catch a false primal the source should have withheld."
+    )
+    assert result.objective is None or abs(result.objective - 594.0) > 1.0, (
+        f"#815 garbage incumbent 594 returned: {result.objective}"
+    )
+    if result.objective is not None and result.x is not None:
+        from discopt._jax.nlp_evaluator import cached_evaluator
+        from discopt._jax.primal_heuristics import _check_constraint_feasibility
+
+        ev = cached_evaluator(model)
+        flat = np.concatenate(
+            [
+                np.atleast_1d(np.asarray(result.x[v.name], dtype=np.float64)).ravel()
+                for v in model._variables
+            ]
+        )
+        assert _check_constraint_feasibility(ev, flat, tol=1e-3), (
+            "#815: reported incumbent is infeasible in the original model"
+        )


### PR DESCRIPTION
Fixes #815.

## Root cause

`_solve_continuous` — the pure-continuous single-NLP path (one local NLP solve,
no B&B tree) — reported the NLP solver's returned point as the incumbent **with no
feasibility check**. A local NLP that stalls at the time/iteration limit (or, on a
model with unbounded variables, terminates at a non-KKT point) can hand back an
**infeasible point with a finite objective**. On `emfl050_3_3`/`emfl100_3_3` the
NLP stalls at an all-10 iterate violating the distance-defining equalities by ~9.5
and reported it as `objective=594`; only the final #772 guard caught it downstream
— a false primal, contained but real (the fuzz-sweep discovery behind #815).

Tracing established the producer was **not** the tree, any heuristic inject, or a
presolve mutation — it was `_solve_continuous` reporting a non-converged NLP
iterate verbatim.

## Fix

Verify feasibility **at the source**, using the **same loose 1e-3 check the #772
guard uses** (it can only flag a gross violation, never a point feasible within
the solver's own tolerance), and withhold an infeasible point there —
`objective`/`x` → `None`, and a non-optimal-but-infeasible `optimal` downgraded to
`unknown`.

- **Sound**: only ever removes a bad incumbent. This path carries no valid dual
  bound when it is not `optimal`, so refusing here can never loosen a bound below
  truth.
- **Narrow**: the corpus-wide second-pass scan (265 heuristic-heavy instances)
  found guard-caught false primals **only** on the `emfl*` family.
- **No over-withholding**: 11 pure-continuous instances re-checked still return
  their correct optima (`ex4_1_1` −7.4873, `ex8_1_1` −2.0218, …); a positive-control
  test asserts feasible points are kept.

The #772 guard remains as defense-in-depth; it just no longer has to fire on this
class.

## Tests (`python/tests/test_815_continuous_false_primal.py`)

- **`test_815_solve_continuous_withholds_infeasible_incumbent`** (`correctness`,
  CI-safe): monkeypatches the NLP backend to return an infeasible point and drives
  `_solve_continuous` directly. **FAILS before** (returns `obj=2.0` with infeasible
  `x`), **passes after**. No benchmark corpus needed, so it runs in the
  fast-correctness CI lane (#813).
- **`test_815_solve_continuous_keeps_feasible_incumbent`** (`correctness`): positive
  control — a feasible point is kept.
- **`test_815_emfl_no_false_primal`** (`slow`, `skipif` corpus absent): the real repro.

## Verification

- new tests: FAIL before, PASS after
- `emfl050`/`emfl100`: no FALSE PRIMAL, clean `time_limit obj=None` (guard never fires)
- bucket2 sound bounds: 3 passed (nvs16 unaffected) · #772/#779 guard suites: 11 passed
- adversarial recent-fixes: 10 passed · smoke: 831 passed, 2 xpassed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
