### PR TITLE
feat(bench): #823 GDPlib benchmark integration (Pyomo bridge + HiGHS/SCIP oracles)

### DIFF
--- a/discopt_benchmarks/README.md
+++ b/discopt_benchmarks/README.md
@@ -126,9 +126,11 @@ python -m benchmarks.gdplib_runner --max-variables 500 --output reports/gdplib.j
 ```
 
 The runner reformulates each GDP (`gdp.bigm` / `gdp.hull`) and solves it through the
-`discopt.pyomo` bridge, cross-checking the linear subset against HiGHS. See
+`discopt.pyomo` bridge, cross-checking every run against an independent oracle:
+**HiGHS** for the linear subset and **SCIP** (`pyscipopt`) for the nonlinear subset
+(used only when SCIP proves optimality). See
 [`docs/dev/gdplib-benchmarking.md`](../docs/dev/gdplib-benchmarking.md) for the full
-recipe, the model inventory, and the correctness strategy.
+recipe, the model inventory, the discopt-vs-SCIP results, and the correctness strategy.
 
 ## Phase Gate Criteria
 

--- a/discopt_benchmarks/README.md
+++ b/discopt_benchmarks/README.md
@@ -111,6 +111,25 @@ uncontrolled local Python environment for those solver-dependent examples.
 | `subsolver` | LP/NLP subsolver-only benchmarks     | varies    | 300s       |
 | `nightly`   | CI regression suite                  | ~100      | 1800s      |
 
+## GDPlib (Generalized Disjunctive Programming) benchmarks
+
+Benchmark discopt against the [SECQUOIA GDPlib](https://github.com/SECQUOIA/gdplib)
+corpus of Pyomo GDP models. Install the extra (GDPlib **from source** — the PyPI
+wheel omits data files), then use `benchmarks/gdplib_runner.py`:
+
+```bash
+pip install "discopt-benchmarks[gdplib]"      # pyomo + gdplib(source) + highspy
+
+python -m benchmarks.gdplib_runner --list                     # discovered models
+python -m benchmarks.gdplib_runner --models jobshop --methods bigm hull
+python -m benchmarks.gdplib_runner --max-variables 500 --output reports/gdplib.json
+```
+
+The runner reformulates each GDP (`gdp.bigm` / `gdp.hull`) and solves it through the
+`discopt.pyomo` bridge, cross-checking the linear subset against HiGHS. See
+[`docs/dev/gdplib-benchmarking.md`](../docs/dev/gdplib-benchmarking.md) for the full
+recipe, the model inventory, and the correctness strategy.
+
 ## Phase Gate Criteria
 
 Each phase has automated pass/fail criteria defined in `config/benchmarks.toml`.

--- a/discopt_benchmarks/benchmarks/gdplib_runner.py
+++ b/discopt_benchmarks/benchmarks/gdplib_runner.py
@@ -18,11 +18,13 @@ the MINLPLib and CUTEst runners.
 
 Correctness (the non-negotiable gate, per ``CLAUDE.md``): where an independent
 oracle exists we cross-check discopt's certified objective against it and count
-any disagreement as *incorrect*. Most GDPlib models are **nonlinear**, for which
-HiGHS is not a valid oracle; for those we fall back to (a) verified reference
-optima from :func:`reference_optima` and (b) a bigm-vs-hull self-consistency check.
-A discopt objective *strictly better* than a known optimum, or a dual bound on the
-wrong side of it, is a soundness violation and is surfaced loudly — never masked.
+any disagreement as *incorrect*. Oracles, most-trusted first: **HiGHS** for the
+linear (MILP) subset (exact); **SCIP** (``pyscipopt``) for the nonlinear subset,
+but only when SCIP proves global optimality; and a table of SCIP-certified
+:func:`reference_optima` as an offline fallback. A discopt objective *strictly
+better* than the oracle optimum (an infeasible incumbent / false primal), a
+claimed-optimal objective that disagrees, or a dual bound on the wrong side of the
+optimum, is a soundness violation and is surfaced loudly — never masked.
 
 Requirements (``pip install discopt-benchmarks[gdplib]``): ``pyomo`` and
 ``gdplib``. Install ``gdplib`` **from source** — the PyPI wheel omits the model
@@ -31,7 +33,9 @@ data files (``.dat`` / ``.xlsx`` / ``.txt``), so most builders raise
 
     pip install "gdplib @ git+https://github.com/SECQUOIA/gdplib.git"
 
-An independent oracle for the *linear* GDP subset needs ``highspy`` (``appsi_highs``).
+The oracles are optional: the linear subset needs ``highspy`` (``appsi_highs``);
+the nonlinear subset needs ``pyscipopt`` (bundles SCIP). Absent both, checks fall
+back to the :func:`reference_optima` table.
 """
 
 from __future__ import annotations
@@ -176,10 +180,24 @@ def reference_optima() -> dict[str, float]:
     GDPlib documentation). Used by :func:`assess_correctness` as the oracle for
     models HiGHS cannot check (nonlinear). Extend this as values are verified — a
     seed here is a *regression anchor*, not a target to tune toward.
+
+    All entries below were certified by **SCIP 10** (``gap = 0``) on the big-M
+    reformulation, and the optimum of a GDP is method-independent, so the same
+    value anchors both big-M and hull. Models where SCIP did *not* prove optimality
+    within its budget (methanol, batch_processing, gdp_col) are deliberately absent
+    — an unproven incumbent is not a certified optimum and must never seed an oracle.
     """
     return {
-        # jobshop: linear GDP, discopt bigm/hull both certify 11.0, HiGHS agrees.
+        # jobshop is also HiGHS-checkable (linear); the rest are nonlinear GDPs.
         "jobshop": 11.0,
+        "ex1_linan_2023": -0.9995999999999999,
+        "positioning": -8.064136166293226,
+        "small_batch": 167427.6515668371,
+        "cstr": 3.0543118059526293,
+        "spectralog": 12.089261322767793,
+        "syngas": 4669.0234827946,
+        "water_network": 348337.03671302047,
+        "modprodnet": 3592.924373781839,
     }
 
 
@@ -261,7 +279,7 @@ class ModelRun:
     is_linear: bool
     minimize: bool
     oracle_objective: float | None = None
-    oracle_source: str | None = None  # "highs" | "reference" | None
+    oracle_source: str | None = None  # "highs" | "scip" | "reference" | None
     # Soundness flags — any True is a hard failure (never mask these).
     false_optimum: bool = False  # certified optimal but disagrees with oracle
     bound_crosses: bool = False  # dual bound on the wrong side of the oracle
@@ -393,9 +411,17 @@ def _node_count(res) -> int:
 def _attach_oracle(run: ModelRun, spec: GDPModelSpec, method: str, time_limit: float) -> None:
     """Populate ``run.oracle_objective`` / ``oracle_source``.
 
-    Priority: (1) HiGHS for a linear reformulation (exact, independent); else
-    (2) a verified reference optimum keyed by model name. HiGHS is *only* sound on
-    a linear model, so it is never used on a nonlinear one.
+    Oracle priority, most-trusted first:
+
+    1. **HiGHS** on a *linear* reformulation — exact, independent, cheap. HiGHS
+       cannot handle a nonlinear model, so it is used only when ``is_linear``.
+    2. **SCIP** (a global MINLP solver, via ``pyscipopt``) — a valid oracle for the
+       nonlinear subset, but *only when it proves global optimality* (gap ≈ 0). An
+       unproven SCIP incumbent is a mere upper bound, never a certified optimum, so
+       it is discarded rather than used as the equality oracle.
+    3. **Verified reference optimum** keyed by model name (see
+       :func:`reference_optima`) — the SCIP-certified values, used offline / when
+       ``pyscipopt`` is absent.
     """
     if run.is_linear:
         obj = _solve_with_highs(spec, method, time_limit)
@@ -403,6 +429,11 @@ def _attach_oracle(run: ModelRun, spec: GDPModelSpec, method: str, time_limit: f
             run.oracle_objective = obj
             run.oracle_source = "highs"
             return
+    scip_obj = _solve_with_scip(spec, method, time_limit)
+    if scip_obj is not None:
+        run.oracle_objective = scip_obj
+        run.oracle_source = "scip"
+        return
     ref = reference_optima().get(spec.name)
     if ref is not None:
         run.oracle_objective = ref
@@ -422,6 +453,51 @@ def _solve_with_highs(spec: GDPModelSpec, method: str, time_limit: float) -> flo
         TransformationFactory(f"gdp.{method}").apply_to(m)
         solver.solve(m)
         return _objective_value(m)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _solve_with_scip(spec: GDPModelSpec, method: str, time_limit: float) -> float | None:
+    """Solve the reformulation with SCIP (``pyscipopt``) as a global oracle.
+
+    Returns SCIP's objective **only if SCIP proved global optimality** within
+    ``time_limit`` (status ``optimal`` and gap ≈ 0); otherwise ``None`` — an
+    unconverged SCIP run yields only an incumbent/bound, not a certified optimum.
+    The reformulated Pyomo model is handed to SCIP through the same AMPL ``.nl``
+    encoding the discopt bridge uses, so both solvers see identical input.
+    """
+    import os
+    import tempfile
+
+    from pyomo.core import TransformationFactory
+    from pyomo.repn.plugins.nl_writer import NLWriter
+
+    try:
+        import pyscipopt
+    except ImportError:
+        return None
+
+    try:
+        m = spec.builder()
+        TransformationFactory(f"gdp.{method}").apply_to(m)
+        with tempfile.TemporaryDirectory(prefix="gdplib_scip_") as d:
+            nl_path = os.path.join(d, "model.nl")
+            with open(nl_path, "w") as stream:
+                NLWriter().write(
+                    m,
+                    stream,
+                    linear_presolve=False,
+                    scale_model=False,
+                    skip_trivial_constraints=False,
+                )
+            sm = pyscipopt.Model()
+            sm.hideOutput()
+            sm.setParam("limits/time", float(time_limit))
+            sm.readProblem(nl_path)
+            sm.optimize()
+            if sm.getStatus() != "optimal" or abs(sm.getGap()) > 1e-6:
+                return None  # not certified -> not a usable equality oracle
+            return float(sm.getObjVal())
     except Exception:  # noqa: BLE001
         return None
 
@@ -510,7 +586,11 @@ def _print_run(run: ModelRun) -> None:
     if run.false_optimum or run.bound_crosses:
         flag = "  ✗ SOUNDNESS"
     elif run.oracle_source and r.is_solved:
-        flag = f"  ✓ vs {run.oracle_source}"
+        flag = f"  ✓ vs {run.oracle_source} ({run.oracle_objective:.6g})"
+    elif run.oracle_source and r.is_feasible:
+        # Feasible but not proven optimal: show the certified optimum + the gap
+        # to it, so a loose incumbent is visible (and its soundness is confirmed).
+        flag = f"  ~ {run.oracle_source} opt={run.oracle_objective:.6g}"
     line = (
         f"  {run.name:42s} {r.status.value:11s} obj={obj:>12s} "
         f"nodes={r.node_count:>7d} {r.wall_time:6.1f}s{flag}"

--- a/discopt_benchmarks/benchmarks/gdplib_runner.py
+++ b/discopt_benchmarks/benchmarks/gdplib_runner.py
@@ -1,0 +1,598 @@
+"""GDPlib benchmark runner (issue #823).
+
+Runs discopt against the SECQUOIA GDPlib corpus of Generalized Disjunctive
+Programming models (https://github.com/SECQUOIA/gdplib). GDPlib ships *Pyomo GDP*
+models (``Disjunct`` / ``Disjunction`` / ``LogicalConstraint``), which are not a
+file format discopt reads directly. The bridge is:
+
+    build_model()                    # gdplib -> Pyomo GDP model
+    TransformationFactory('gdp.bigm' | 'gdp.hull').apply_to(m)   # GDP -> MI(N)LP
+    SolverFactory('discopt').solve(m)                            # discopt.pyomo
+
+The Pyomo ``gdp.bigm`` / ``gdp.hull`` transformations lower the disjunctions to a
+standard mixed-integer (non)linear program, which the existing ``discopt.pyomo``
+plugin round-trips through a temporary ``.nl`` file and solves in-process. This
+runner automates that pipeline over the corpus and emits ``metrics.SolveResult``
+objects so GDPlib results flow through the same correctness/reporting pipeline as
+the MINLPLib and CUTEst runners.
+
+Correctness (the non-negotiable gate, per ``CLAUDE.md``): where an independent
+oracle exists we cross-check discopt's certified objective against it and count
+any disagreement as *incorrect*. Most GDPlib models are **nonlinear**, for which
+HiGHS is not a valid oracle; for those we fall back to (a) verified reference
+optima from :func:`reference_optima` and (b) a bigm-vs-hull self-consistency check.
+A discopt objective *strictly better* than a known optimum, or a dual bound on the
+wrong side of it, is a soundness violation and is surfaced loudly — never masked.
+
+Requirements (``pip install discopt-benchmarks[gdplib]``): ``pyomo`` and
+``gdplib``. Install ``gdplib`` **from source** — the PyPI wheel omits the model
+data files (``.dat`` / ``.xlsx`` / ``.txt``), so most builders raise
+``FileNotFoundError`` under it::
+
+    pip install "gdplib @ git+https://github.com/SECQUOIA/gdplib.git"
+
+An independent oracle for the *linear* GDP subset needs ``highspy`` (``appsi_highs``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import pkgutil
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from benchmarks.metrics import (
+    BenchmarkResults,
+    InstanceInfo,
+    SolveResult,
+    SolveStatus,
+    dual_bound_crosses_optimum,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# discopt status string -> benchmark SolveStatus.
+_STATUS_MAP = {
+    "optimal": SolveStatus.OPTIMAL,
+    "feasible": SolveStatus.FEASIBLE,
+    "infeasible": SolveStatus.INFEASIBLE,
+    "unbounded": SolveStatus.UNBOUNDED,
+    "time_limit": SolveStatus.TIME_LIMIT,
+    "maxtimelimit": SolveStatus.TIME_LIMIT,
+    "node_limit": SolveStatus.TIME_LIMIT,
+    "maxiterations": SolveStatus.TIME_LIMIT,
+    "error": SolveStatus.ERROR,
+}
+
+@dataclass
+class GDPModelSpec:
+    """A discovered GDPlib model: its name and zero-arg builder."""
+
+    name: str
+    builder: Callable[[], object]
+    module: str
+
+
+@dataclass
+class GDPLibSuiteConfig:
+    """Configuration for a GDPlib benchmark sweep."""
+
+    name: str = "gdplib"
+    description: str = ""
+    methods: tuple[str, ...] = ("bigm",)  # gdp reformulations to run
+    time_limit_seconds: float = 300.0
+    max_variables: int | None = None  # skip models whose reformulation exceeds
+    include: list[str] | None = None  # explicit model-name allowlist
+    exclude: list[str] = field(default_factory=list)
+    oracle: bool = True  # cross-check the linear subset against HiGHS
+
+
+def is_available() -> bool:
+    """True if Pyomo and GDPlib are both importable."""
+    try:
+        import gdplib  # noqa: F401
+        import pyomo  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def discover_models(
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> list[GDPModelSpec]:
+    """Enumerate discoverable GDPlib models as ``(name, builder)`` specs.
+
+    Walks the ``gdplib`` namespace and collects every zero-argument ``build_model``
+    (and, for the multi-model subpackages, every other ``build_*`` that takes no
+    required arguments). Submodules that fail to *import* — e.g. a data file the
+    PyPI wheel omitted, or a Pyomo-version incompatibility — are skipped silently
+    here (they surface as errors only if explicitly requested via ``include``).
+
+    No model is filtered by name: a builder that needs an external tool (ipopt /
+    GAMS) at build time is still listed, and :func:`solve_model` records its build
+    failure as an ``ERROR`` run rather than hiding it — honest reporting over a
+    hardcoded, environment-specific skip list.
+    """
+    import gdplib
+
+    exclude_set = set(exclude or [])
+    specs: list[GDPModelSpec] = []
+    seen: set[str] = set()
+    for mod_info in pkgutil.iter_modules(gdplib.__path__):
+        mod_name = mod_info.name
+        try:
+            sub = importlib.import_module(f"gdplib.{mod_name}")
+        except Exception:
+            continue
+        for attr in dir(sub):
+            if not attr.startswith("build"):
+                continue
+            fn = getattr(sub, attr)
+            if not callable(fn) or not _is_zero_arg(fn):
+                continue
+            # Prefer the short module name when the builder is the canonical
+            # ``build_model``; otherwise disambiguate as ``module.builder``.
+            name = mod_name if attr == "build_model" else f"{mod_name}.{attr}"
+            if name in seen:
+                continue
+            seen.add(name)
+            specs.append(GDPModelSpec(name=name, builder=fn, module=mod_name))
+
+    if include is not None:
+        want = set(include)
+        specs = [s for s in specs if s.name in want]
+    if exclude_set:
+        specs = [s for s in specs if s.name not in exclude_set]
+    return sorted(specs, key=lambda s: s.name)
+
+
+def _is_zero_arg(fn: Callable) -> bool:
+    """True if *fn* can be called with no arguments (all params have defaults)."""
+    import inspect
+
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return True  # builtins / C-callables: assume callable and let build fail
+    for p in sig.parameters.values():
+        if p.kind in (p.VAR_POSITIONAL, p.VAR_KEYWORD):
+            continue
+        if p.default is inspect.Parameter.empty:
+            return False
+    return True
+
+
+def reference_optima() -> dict[str, float]:
+    """Verified reference optima for GDPlib models, keyed by ``name/method``.
+
+    Seeded only with values independently confirmed in-repo (e.g. via the HiGHS
+    oracle on a linear model, or a value stable across bigm/hull and matching the
+    GDPlib documentation). Used by :func:`assess_correctness` as the oracle for
+    models HiGHS cannot check (nonlinear). Extend this as values are verified — a
+    seed here is a *regression anchor*, not a target to tune toward.
+    """
+    return {
+        # jobshop: linear GDP, discopt bigm/hull both certify 11.0, HiGHS agrees.
+        "jobshop": 11.0,
+    }
+
+
+def _classify(pyomo_model) -> tuple[InstanceInfo, bool]:
+    """Return ``(InstanceInfo, is_linear)`` for a *reformulated* Pyomo model.
+
+    ``is_linear`` drives oracle selection: HiGHS is a valid, exact oracle only for
+    a fully linear (MILP) reformulation.
+    """
+    import pyomo.environ as pyo
+    from pyomo.repn import generate_standard_repn
+
+    n_var = n_int = n_bin = n_cont = 0
+    for v in pyomo_model.component_data_objects(pyo.Var, active=True):
+        n_var += 1
+        if v.is_binary():
+            n_bin += 1
+        elif v.is_integer():
+            n_int += 1
+        else:
+            n_cont += 1
+
+    n_con = 0
+    n_nonlin = 0
+    is_linear = True
+    for c in pyomo_model.component_data_objects(pyo.Constraint, active=True):
+        n_con += 1
+        repn = generate_standard_repn(c.body, quadratic=True)
+        if not repn.is_linear():
+            n_nonlin += 1
+            is_linear = False
+    for obj in pyomo_model.component_data_objects(pyo.Objective, active=True):
+        if not generate_standard_repn(obj.expr, quadratic=True).is_linear():
+            is_linear = False
+        break
+
+    info = InstanceInfo(
+        name="",  # filled by caller (includes method suffix)
+        num_variables=n_var,
+        num_constraints=n_con,
+        num_integer_vars=n_int,
+        num_binary_vars=n_bin,
+        num_continuous_vars=n_cont,
+        num_nonlinear_constraints=n_nonlin,
+        problem_class="gdp-linear" if is_linear else "gdp-nonlinear",
+        is_convex=None,
+        source="gdplib",
+    )
+    return info, is_linear
+
+
+def _objective_value(pyomo_model) -> float | None:
+    import pyomo.environ as pyo
+    from pyomo.core.expr import value as pyo_value
+
+    for obj in pyomo_model.component_data_objects(pyo.Objective, active=True):
+        try:
+            return float(pyo_value(obj.expr))
+        except Exception:
+            return None
+    return None
+
+
+def _is_minimize(pyomo_model) -> bool:
+    import pyomo.environ as pyo
+
+    for obj in pyomo_model.component_data_objects(pyo.Objective, active=True):
+        return obj.sense == 1  # pyo.minimize
+    return True
+
+
+@dataclass
+class ModelRun:
+    """One (model, method) run: the discopt result plus oracle cross-check."""
+
+    name: str  # ``<model>/<method>``
+    info: InstanceInfo
+    discopt: SolveResult
+    is_linear: bool
+    minimize: bool
+    oracle_objective: float | None = None
+    oracle_source: str | None = None  # "highs" | "reference" | None
+    # Soundness flags — any True is a hard failure (never mask these).
+    false_optimum: bool = False  # certified optimal but disagrees with oracle
+    bound_crosses: bool = False  # dual bound on the wrong side of the oracle
+    note: str = ""
+
+
+def solve_model(
+    spec: GDPModelSpec,
+    method: str = "bigm",
+    time_limit: float = 300.0,
+    oracle: bool = True,
+    max_variables: int | None = None,
+) -> ModelRun:
+    """Build, reformulate, and solve one GDPlib model with discopt.
+
+    Returns a :class:`ModelRun`. Build/transform/solve failures are captured as an
+    ``ERROR`` result rather than raised, so a sweep is robust to one bad model.
+    """
+    import discopt.pyomo  # noqa: F401  registers SolverFactory('discopt')
+    import pyomo.environ as pyo
+    from pyomo.core import TransformationFactory
+
+    run_name = f"{spec.name}/{method}"
+
+    def _err(msg: str, info: InstanceInfo | None = None) -> ModelRun:
+        info = info or InstanceInfo(name=run_name, source="gdplib")
+        info.name = run_name
+        return ModelRun(
+            name=run_name,
+            info=info,
+            discopt=SolveResult(instance=run_name, solver="discopt", status=SolveStatus.ERROR),
+            is_linear=False,
+            minimize=True,
+            note=msg,
+        )
+
+    try:
+        model = spec.builder()
+    except Exception as exc:  # noqa: BLE001
+        return _err(f"build failed: {type(exc).__name__}: {exc}")
+    if model is None:
+        return _err("builder returned None")
+
+    try:
+        TransformationFactory(f"gdp.{method}").apply_to(model)
+    except Exception as exc:  # noqa: BLE001
+        return _err(f"gdp.{method} transform failed: {type(exc).__name__}: {exc}")
+
+    info, is_linear = _classify(model)
+    info.name = run_name
+    minimize = _is_minimize(model)
+    if max_variables is not None and info.num_variables > max_variables:
+        return ModelRun(
+            name=run_name,
+            info=info,
+            discopt=SolveResult(instance=run_name, solver="discopt", status=SolveStatus.UNKNOWN),
+            is_linear=is_linear,
+            minimize=minimize,
+            note=f"skipped: {info.num_variables} vars > max_variables={max_variables}",
+        )
+
+    t0 = time.time()
+    try:
+        res = pyo.SolverFactory("discopt").solve(model, options={"time_limit": time_limit})
+    except Exception as exc:  # noqa: BLE001
+        run = _err(f"discopt.solve failed: {type(exc).__name__}: {exc}", info)
+        run.discopt.wall_time = time.time() - t0
+        return run
+    wall = time.time() - t0
+
+    tc = str(res.solver.termination_condition).lower()
+    status = _STATUS_MAP.get(tc, SolveStatus.UNKNOWN)
+    objective = (
+        _objective_value(model)
+        if status
+        in (
+            SolveStatus.OPTIMAL,
+            SolveStatus.FEASIBLE,
+        )
+        else None
+    )
+    bound = _problem_bound(res, minimize)
+    nodes = _node_count(res)
+
+    discopt_result = SolveResult(
+        instance=run_name,
+        solver="discopt",
+        status=status,
+        objective=objective,
+        bound=bound,
+        wall_time=wall,
+        node_count=nodes,
+    )
+
+    run = ModelRun(
+        name=run_name,
+        info=info,
+        discopt=discopt_result,
+        is_linear=is_linear,
+        minimize=minimize,
+    )
+    if oracle:
+        _attach_oracle(run, spec, method, time_limit)
+    _assess(run)
+    return run
+
+
+def _problem_bound(res, minimize: bool) -> float | None:
+    prob = res.problem
+    # Pyomo stores the dual bound in the field opposite the incumbent's.
+    field_name = "upper_bound" if minimize else "lower_bound"
+    try:
+        val = getattr(prob[0] if hasattr(prob, "__getitem__") else prob, field_name, None)
+    except Exception:
+        val = None
+    try:
+        return float(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _node_count(res) -> int:
+    try:
+        return int(res.solver.statistics.branch_and_bound.number_of_nodes)
+    except Exception:
+        return 0
+
+
+def _attach_oracle(run: ModelRun, spec: GDPModelSpec, method: str, time_limit: float) -> None:
+    """Populate ``run.oracle_objective`` / ``oracle_source``.
+
+    Priority: (1) HiGHS for a linear reformulation (exact, independent); else
+    (2) a verified reference optimum keyed by model name. HiGHS is *only* sound on
+    a linear model, so it is never used on a nonlinear one.
+    """
+    if run.is_linear:
+        obj = _solve_with_highs(spec, method, time_limit)
+        if obj is not None:
+            run.oracle_objective = obj
+            run.oracle_source = "highs"
+            return
+    ref = reference_optima().get(spec.name)
+    if ref is not None:
+        run.oracle_objective = ref
+        run.oracle_source = "reference"
+
+
+def _solve_with_highs(spec: GDPModelSpec, method: str, time_limit: float) -> float | None:
+    """Solve the (linear) reformulation with HiGHS as an independent oracle."""
+    import pyomo.environ as pyo
+    from pyomo.core import TransformationFactory
+
+    try:
+        solver = pyo.SolverFactory("appsi_highs")
+        if not solver.available(exception_flag=False):
+            return None
+        m = spec.builder()
+        TransformationFactory(f"gdp.{method}").apply_to(m)
+        solver.solve(m)
+        return _objective_value(m)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _assess(run: ModelRun) -> None:
+    """Set the soundness flags on *run* by comparing discopt to its oracle.
+
+    Three independent checks (all must stay clean — see ``CLAUDE.md`` §1):
+
+    * **impossible incumbent** — *any* feasible incumbent (even one merely reported
+      ``FEASIBLE``, not ``OPTIMAL``) whose objective is *strictly better* than the
+      true optimum (lower for min, higher for max). No feasible point can beat the
+      optimum, so this means the incumbent violates a constraint — a false primal
+      (issue #815). This is the most dangerous flag and does not require an
+      ``OPTIMAL`` claim.
+    * **false optimum** — discopt reports ``OPTIMAL`` but its certified objective
+      disagrees with the oracle beyond tolerance (in either direction).
+    * **bound crossing** — discopt's dual bound sits on the far/wrong side of the
+      oracle optimum (would fathom the true optimum).
+    """
+    r = run.discopt
+    opt = run.oracle_objective
+    if opt is None:
+        return
+    abs_tol, rel_tol = 1e-4, 1e-3
+    tol = abs_tol + rel_tol * abs(opt)
+
+    if r.is_feasible and r.objective is not None:
+        beats_oracle = (
+            (run.minimize and r.objective < opt - tol)
+            or (not run.minimize and r.objective > opt + tol)
+        )
+        disagrees = abs(r.objective - opt) > tol
+        if beats_oracle:
+            # Impossible: no feasible point beats the optimum -> false primal.
+            run.false_optimum = True
+            run.note = (
+                f"IMPOSSIBLE INCUMBENT ({r.status.value}): discopt={r.objective:.8g} "
+                f"beats oracle={opt:.8g} [{run.oracle_source}] — incumbent is infeasible"
+            )
+        elif r.is_solved and disagrees:
+            # Claimed optimal but converged to a suboptimal (worse) objective.
+            run.false_optimum = True
+            run.note = (
+                f"INCORRECT (worse-than-oracle, claimed optimal): "
+                f"discopt={r.objective:.8g} oracle={opt:.8g} [{run.oracle_source}]"
+            )
+
+    if dual_bound_crosses_optimum(r.bound, opt, run.minimize, abs_tol, rel_tol):
+        run.bound_crosses = True
+        run.note = (f"{run.note} | BOUND CROSSES oracle {opt:.8g}").strip(" |")
+
+
+def run_suite(config: GDPLibSuiteConfig) -> tuple[BenchmarkResults, list[ModelRun]]:
+    """Run a full GDPlib sweep per *config*. Returns ``(BenchmarkResults, runs)``."""
+    if not is_available():
+        raise RuntimeError(
+            "GDPlib benchmark requires pyomo + gdplib: "
+            "pip install 'discopt-benchmarks[gdplib]' and install gdplib from source "
+            "(the PyPI wheel omits model data files)."
+        )
+    specs = discover_models(include=config.include, exclude=config.exclude)
+    results = BenchmarkResults(suite=config.name, timestamp=datetime.now().isoformat())
+    runs: list[ModelRun] = []
+    for spec in specs:
+        for method in config.methods:
+            run = solve_model(
+                spec,
+                method=method,
+                time_limit=config.time_limit_seconds,
+                oracle=config.oracle,
+                max_variables=config.max_variables,
+            )
+            results.instance_info[run.name] = run.info
+            results.add_result(run.discopt)
+            runs.append(run)
+            _print_run(run)
+    _print_summary(runs)
+    return results, runs
+
+
+def _print_run(run: ModelRun) -> None:
+    r = run.discopt
+    obj = f"{r.objective:.6g}" if r.objective is not None else "—"
+    flag = ""
+    if run.false_optimum or run.bound_crosses:
+        flag = "  ✗ SOUNDNESS"
+    elif run.oracle_source and r.is_solved:
+        flag = f"  ✓ vs {run.oracle_source}"
+    line = (
+        f"  {run.name:42s} {r.status.value:11s} obj={obj:>12s} "
+        f"nodes={r.node_count:>7d} {r.wall_time:6.1f}s{flag}"
+    )
+    print(line)
+    if run.note:
+        print(f"      · {run.note}")
+
+
+def _print_summary(runs: list[ModelRun]) -> None:
+    n = len(runs)
+    solved = sum(1 for r in runs if r.discopt.is_solved)
+    feasible = sum(1 for r in runs if r.discopt.is_feasible)
+    errored = sum(1 for r in runs if r.discopt.status == SolveStatus.ERROR)
+    checked = sum(1 for r in runs if r.oracle_objective is not None)
+    incorrect = sum(1 for r in runs if r.false_optimum)
+    bound_bad = sum(1 for r in runs if r.bound_crosses)
+    print("\n" + "=" * 68)
+    print(f"GDPlib sweep: {n} runs | solved={solved} feasible={feasible} error={errored}")
+    print(f"oracle-checked={checked} | INCORRECT={incorrect} | bound-crossings={bound_bad}")
+    if incorrect or bound_bad:
+        print("  ✗ SOUNDNESS VIOLATIONS — see flagged runs above (incorrect_count must be 0)")
+    else:
+        print("  ✓ no soundness violations among oracle-checked runs")
+    print("=" * 68)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Benchmark discopt on the GDPlib corpus.")
+    parser.add_argument(
+        "--models",
+        nargs="*",
+        default=None,
+        help="explicit model names (default: all discovered). e.g. jobshop cstr",
+    )
+    parser.add_argument("--exclude", nargs="*", default=None, help="model names to skip")
+    parser.add_argument(
+        "--methods",
+        nargs="+",
+        default=["bigm"],
+        choices=["bigm", "hull"],
+        help="GDP reformulation(s) to apply (default: bigm)",
+    )
+    parser.add_argument("--time-limit", type=float, default=300.0, help="per-solve seconds")
+    parser.add_argument("--max-variables", type=int, default=None, help="skip larger models")
+    parser.add_argument("--no-oracle", action="store_true", help="skip HiGHS/reference checks")
+    parser.add_argument("--list", action="store_true", help="list discovered models and exit")
+    parser.add_argument("--output", default=None, help="write BenchmarkResults JSON to this path")
+    args = parser.parse_args(argv)
+
+    if not is_available():
+        print(
+            "GDPlib benchmark unavailable: install pyomo + gdplib "
+            "(gdplib from source — the PyPI wheel omits data files)."
+        )
+        return 2
+
+    if args.list:
+        specs = discover_models(include=args.models, exclude=args.exclude)
+        print(f"{len(specs)} runnable GDPlib models:")
+        for s in specs:
+            print(f"  {s.name}")
+        return 0
+
+    config = GDPLibSuiteConfig(
+        methods=tuple(args.methods),
+        time_limit_seconds=args.time_limit,
+        max_variables=args.max_variables,
+        include=args.models,
+        exclude=args.exclude or [],
+        oracle=not args.no_oracle,
+    )
+    results, runs = run_suite(config)
+    if args.output:
+        from pathlib import Path
+
+        results.save(Path(args.output))
+        print(f"wrote results to {args.output}")
+    # Nonzero exit on any soundness violation so CI can gate on it.
+    violations = sum(1 for r in runs if r.false_optimum or r.bound_crosses)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/discopt_benchmarks/pyproject.toml
+++ b/discopt_benchmarks/pyproject.toml
@@ -24,6 +24,14 @@ dev = [
     "pytest-cov>=4.1",
     "mutmut>=2.4",              # Mutation testing
 ]
+gdplib = [
+    # GDPlib GDP benchmark corpus (issue #823). Install gdplib FROM SOURCE — the
+    # PyPI wheel omits the model data files, so most builders raise
+    # FileNotFoundError. highspy provides the independent oracle for linear models.
+    "pyomo>=6.7",
+    "gdplib @ git+https://github.com/SECQUOIA/gdplib.git",
+    "highspy>=1.7",
+]
 
 [project.scripts]
 discopt-bench = "run_benchmarks:main"

--- a/discopt_benchmarks/pyproject.toml
+++ b/discopt_benchmarks/pyproject.toml
@@ -27,10 +27,12 @@ dev = [
 gdplib = [
     # GDPlib GDP benchmark corpus (issue #823). Install gdplib FROM SOURCE — the
     # PyPI wheel omits the model data files, so most builders raise
-    # FileNotFoundError. highspy provides the independent oracle for linear models.
+    # FileNotFoundError. Oracles: highspy (HiGHS) verifies the linear subset,
+    # pyscipopt (bundles SCIP) the nonlinear subset. Both optional at runtime.
     "pyomo>=6.7",
     "gdplib @ git+https://github.com/SECQUOIA/gdplib.git",
     "highspy>=1.7",
+    "pyscipopt>=5.0",
 ]
 
 [project.scripts]

--- a/discopt_benchmarks/tests/test_gdplib.py
+++ b/discopt_benchmarks/tests/test_gdplib.py
@@ -33,6 +33,20 @@ def _has_highs() -> bool:
         return False
 
 
+def _has_scip() -> bool:
+    try:
+        import pyscipopt  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _spec(name):
+    (spec,) = gr.discover_models(include=[name])
+    return spec
+
+
 # ── discovery ──────────────────────────────────────────────────────────────
 
 
@@ -123,8 +137,50 @@ def test_max_variables_skips_large_models():
 
 
 def test_reference_optima_seed_is_sane():
+    import math
+
     ref = gr.reference_optima()
     assert ref.get("jobshop") == pytest.approx(11.0)
+    # SCIP-certified nonlinear seeds are present and finite.
+    for name in ("positioning", "cstr", "small_batch", "syngas", "water_network"):
+        assert name in ref
+        assert math.isfinite(ref[name])
+    assert ref["cstr"] == pytest.approx(3.0543118, abs=1e-4)
+    # Models SCIP did NOT prove within budget must not be seeded.
+    for unproven in ("methanol", "batch_processing", "gdp_col"):
+        assert unproven not in ref
+
+
+# ── SCIP oracle (nonlinear subset) ──────────────────────────────────────────
+
+
+@pytest.mark.skipif(not _has_scip(), reason="pyscipopt (SCIP) not installed")
+def test_scip_certifies_nonlinear_optimum():
+    """SCIP returns the certified optimum for a small nonlinear GDP (ex1_linan_2023)."""
+    obj = gr._solve_with_scip(_spec("ex1_linan_2023"), method="bigm", time_limit=60)
+    assert obj is not None
+    assert obj == pytest.approx(-0.9996, abs=1e-3)
+
+
+@pytest.mark.skipif(not _has_scip(), reason="pyscipopt (SCIP) not installed")
+def test_scip_declines_when_not_proven():
+    """A time budget too small to prove optimality yields no oracle value, not a guess."""
+    # 0s wall budget -> SCIP cannot certify -> None (never a bare incumbent).
+    obj = gr._solve_with_scip(_spec("cstr"), method="bigm", time_limit=0.0)
+    assert obj is None
+
+
+@pytest.mark.correctness
+@pytest.mark.slow
+@pytest.mark.skipif(not _has_scip(), reason="pyscipopt (SCIP) not installed")
+def test_scip_is_oracle_for_nonlinear_end_to_end():
+    """A nonlinear model gets a SCIP oracle, and discopt stays sound against it."""
+    run = gr.solve_model(_spec("ex1_linan_2023"), method="bigm", time_limit=60, oracle=True)
+    assert run.is_linear is False
+    assert run.oracle_source == "scip"
+    assert run.oracle_objective == pytest.approx(-0.9996, abs=1e-3)
+    assert run.false_optimum is False, run.note
+    assert run.bound_crosses is False, run.note
 
 
 # ── soundness assessment (solver-free, deterministic) ───────────────────────

--- a/discopt_benchmarks/tests/test_gdplib.py
+++ b/discopt_benchmarks/tests/test_gdplib.py
@@ -1,0 +1,202 @@
+"""Tests for the GDPlib benchmark integration (issue #823).
+
+The GDPlib corpus (https://github.com/SECQUOIA/gdplib) is an optional dependency,
+so every test skips cleanly when pyomo/gdplib are absent. The fast path exercises
+``jobshop`` — a small *linear* GDP whose big-M and hull reformulations both certify
+11.0, cross-checked against HiGHS (the independent oracle for linear models).
+
+Install to run these locally::
+
+    pip install pyomo highspy
+    pip install "gdplib @ git+https://github.com/SECQUOIA/gdplib.git"   # from source
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks import gdplib_runner as gr
+from benchmarks.metrics import InstanceInfo, SolveResult, SolveStatus
+
+pytestmark = pytest.mark.skipif(
+    not gr.is_available(),
+    reason="GDPlib benchmark requires pyomo + gdplib (install gdplib from source)",
+)
+
+
+def _has_highs() -> bool:
+    try:
+        import pyomo.environ as pyo
+
+        return bool(pyo.SolverFactory("appsi_highs").available(exception_flag=False))
+    except Exception:
+        return False
+
+
+# ── discovery ──────────────────────────────────────────────────────────────
+
+
+def test_discover_returns_specs():
+    specs = gr.discover_models()
+    names = {s.name for s in specs}
+    assert names, "expected at least one runnable GDPlib model"
+    # jobshop is the canonical small model and must always be discoverable.
+    assert "jobshop" in names
+    for s in specs:
+        assert callable(s.builder)
+
+
+def test_discover_include_filter():
+    specs = gr.discover_models(include=["jobshop"])
+    assert [s.name for s in specs] == ["jobshop"]
+
+
+def test_discover_exclude_filter():
+    all_names = {s.name for s in gr.discover_models()}
+    if "jobshop" not in all_names:
+        pytest.skip("jobshop not present")
+    filtered = {s.name for s in gr.discover_models(exclude=["jobshop"])}
+    assert "jobshop" not in filtered
+    assert filtered == all_names - {"jobshop"}
+
+
+def test_build_failure_captured_as_error():
+    """A builder that raises yields an ERROR run with a reason, not an exception."""
+
+    def _boom():
+        raise RuntimeError("needs GAMS on PATH")
+
+    spec = gr.GDPModelSpec(name="synthetic_bad", builder=_boom, module="synthetic")
+    run = gr.solve_model(spec, method="bigm", time_limit=5, oracle=False)
+    assert run.discopt.status == SolveStatus.ERROR
+    assert "build failed" in run.note
+    assert "needs GAMS" in run.note
+
+
+# ── the jobshop end-to-end path (linear GDP, HiGHS-checkable) ───────────────
+
+
+@pytest.mark.correctness
+def test_jobshop_bigm_optimal_and_correct():
+    """jobshop via big-M solves to the certified optimum 11.0 with no violation."""
+    (spec,) = gr.discover_models(include=["jobshop"])
+    run = gr.solve_model(spec, method="bigm", time_limit=120, oracle=True)
+
+    assert run.discopt.status == SolveStatus.OPTIMAL
+    assert run.discopt.objective == pytest.approx(11.0, abs=1e-2)
+    assert run.is_linear is True
+    # The non-negotiable gate: no false optimum, no bound crossing.
+    assert run.false_optimum is False, run.note
+    assert run.bound_crosses is False, run.note
+
+
+@pytest.mark.correctness
+def test_jobshop_hull_matches_bigm():
+    """big-M and hull reformulations must certify the same optimum (self-consistency)."""
+    (spec,) = gr.discover_models(include=["jobshop"])
+    r_bigm = gr.solve_model(spec, method="bigm", time_limit=120, oracle=False)
+    r_hull = gr.solve_model(spec, method="hull", time_limit=120, oracle=False)
+    assert r_bigm.discopt.objective == pytest.approx(11.0, abs=1e-2)
+    assert r_hull.discopt.objective == pytest.approx(11.0, abs=1e-2)
+    assert r_bigm.discopt.objective == pytest.approx(r_hull.discopt.objective, abs=1e-2)
+
+
+@pytest.mark.correctness
+@pytest.mark.skipif(not _has_highs(), reason="HiGHS (highspy) not installed")
+def test_jobshop_oracle_is_highs():
+    """For the linear jobshop model the oracle is HiGHS, and discopt agrees."""
+    (spec,) = gr.discover_models(include=["jobshop"])
+    run = gr.solve_model(spec, method="bigm", time_limit=120, oracle=True)
+    assert run.oracle_source == "highs"
+    assert run.oracle_objective == pytest.approx(11.0, abs=1e-2)
+
+
+# ── classification & robustness ─────────────────────────────────────────────
+
+
+def test_max_variables_skips_large_models():
+    """A tiny max_variables budget skips the solve without erroring."""
+    (spec,) = gr.discover_models(include=["jobshop"])
+    run = gr.solve_model(spec, method="bigm", time_limit=10, oracle=False, max_variables=1)
+    assert run.discopt.status == SolveStatus.UNKNOWN
+    assert "skipped" in run.note
+
+
+def test_reference_optima_seed_is_sane():
+    ref = gr.reference_optima()
+    assert ref.get("jobshop") == pytest.approx(11.0)
+
+
+# ── soundness assessment (solver-free, deterministic) ───────────────────────
+
+
+def _make_run(status, objective, *, minimize=True, oracle=10.0, bound=None):
+    r = SolveResult(
+        instance="x/bigm", solver="discopt", status=status, objective=objective, bound=bound
+    )
+    return gr.ModelRun(
+        name="x/bigm",
+        info=InstanceInfo(name="x/bigm", source="gdplib"),
+        discopt=r,
+        is_linear=True,
+        minimize=minimize,
+        oracle_objective=oracle,
+        oracle_source="reference",
+    )
+
+
+def test_assess_clean_when_matches_oracle():
+    run = _make_run(SolveStatus.OPTIMAL, 10.0)
+    gr._assess(run)
+    assert not run.false_optimum and not run.bound_crosses
+
+
+def test_assess_flags_impossible_feasible_incumbent_min():
+    """A merely-FEASIBLE incumbent below the true min optimum is a false primal."""
+    run = _make_run(SolveStatus.FEASIBLE, 9.0, minimize=True, oracle=10.0)
+    gr._assess(run)
+    assert run.false_optimum is True
+    assert "IMPOSSIBLE INCUMBENT" in run.note
+
+
+def test_assess_flags_impossible_feasible_incumbent_max():
+    """Symmetric max case: a feasible incumbent above the true max optimum."""
+    run = _make_run(SolveStatus.FEASIBLE, 11.0, minimize=False, oracle=10.0)
+    gr._assess(run)
+    assert run.false_optimum is True
+
+
+def test_assess_flags_optimal_disagreement():
+    """Claimed OPTIMAL but converged worse than the oracle -> false optimum."""
+    run = _make_run(SolveStatus.OPTIMAL, 12.0, minimize=True, oracle=10.0)
+    gr._assess(run)
+    assert run.false_optimum is True
+    assert "worse-than-oracle" in run.note
+
+
+def test_assess_feasible_worse_is_not_flagged():
+    """A FEASIBLE (unconverged) incumbent worse than the optimum is expected, not a bug."""
+    run = _make_run(SolveStatus.FEASIBLE, 12.0, minimize=True, oracle=10.0)
+    gr._assess(run)
+    assert run.false_optimum is False
+
+
+def test_assess_flags_bound_crossing_min():
+    """A min-sense dual bound above the optimum would fathom it -> crossing."""
+    run = _make_run(SolveStatus.TIME_LIMIT, None, minimize=True, oracle=10.0, bound=10.5)
+    gr._assess(run)
+    assert run.bound_crosses is True
+
+
+@pytest.mark.slow
+def test_run_suite_jobshop_only_no_violation():
+    """A one-model suite runs cleanly and reports zero soundness violations."""
+    config = gr.GDPLibSuiteConfig(
+        include=["jobshop"], methods=("bigm",), time_limit_seconds=120, oracle=True
+    )
+    results, runs = gr.run_suite(config)
+    assert len(runs) == 1
+    assert all(not r.false_optimum and not r.bound_crosses for r in runs)
+    # Results flow through the standard metrics pipeline.
+    assert "jobshop/bigm" in results.instance_info
+    assert results.get_results("discopt")

--- a/docs/dev/gdplib-benchmarking.md
+++ b/docs/dev/gdplib-benchmarking.md
@@ -1,0 +1,152 @@
+# Benchmarking discopt against GDPlib (issue #823)
+
+**Status:** implemented. Runner + tests + optional-dependency extra landed;
+`jobshop` verified end-to-end against the HiGHS oracle. This doc is the "figure out
+how" writeup requested in [#823](https://github.com/jkitchin/discopt/issues/823)
+(suggested by David Bernal Neira in [#819](https://github.com/jkitchin/discopt/issues/819)).
+
+## What GDPlib is
+
+[GDPlib](https://github.com/SECQUOIA/gdplib) (SECQUOIA) is an open library of
+**Generalized Disjunctive Programming** models — process-synthesis and design
+problems written in **Pyomo GDP** (`Disjunct` / `Disjunction` / `LogicalConstraint`
+/ Boolean vars). It is the GDP analogue of MINLPLib: an educational and
+benchmarking corpus. Most instances are nonlinear (reactor/column/network design);
+a handful are linear (jobshop, scheduling, capacity-expansion).
+
+## The bridge: how a GDPlib model reaches discopt
+
+GDPlib models are Python-built Pyomo objects, not a file format discopt reads. But
+discopt already ships a Pyomo solver plugin (`discopt.pyomo`, `pip install
+discopt[pyomo]`) that round-trips a Pyomo model through a temporary AMPL `.nl` file
+and solves it in-process. A Pyomo GDP model is not directly `.nl`-writable, so we
+first lower the disjunctions to a standard mixed-integer (non)linear program with
+Pyomo's built-in GDP transformations. The full path:
+
+```python
+import pyomo.environ as pyo
+from pyomo.core import TransformationFactory
+import discopt.pyomo                       # registers SolverFactory('discopt')
+from gdplib.jobshop import build_model
+
+m = build_model()                          # Pyomo GDP model
+TransformationFactory('gdp.bigm').apply_to(m)   # or 'gdp.hull'
+res = pyo.SolverFactory('discopt').solve(m, options={'time_limit': 300})
+print(res.solver.termination_condition, pyo.value(m.makespan))
+```
+
+`gdp.bigm` (big-M) and `gdp.hull` (convex-hull / perspective) are the two standard
+reformulations. Both round-trip cleanly through the bridge; on `jobshop` they
+certify the same optimum (11.0). discopt also has a *native* GDP modeling API
+(`either_or`, `make_disjunct`, `m.logical(...)`, see `python/tests/test_gdp.py`),
+but the Pyomo-reformulation path is what lets us benchmark the existing corpus
+without hand-porting 20+ models.
+
+## Installation caveats (learned the hard way)
+
+- **Install GDPlib from source, not PyPI.** The PyPI wheel omits the model data
+  files (`.dat`, `.xlsx`, `.txt`), so most builders raise `FileNotFoundError`. Use:
+  ```bash
+  pip install "gdplib @ git+https://github.com/SECQUOIA/gdplib.git"
+  ```
+  or `pip install discopt-benchmarks[gdplib]`, which pins the source install plus
+  `pyomo` and `highspy`.
+- **Some builders need an external solver at *build* time** (`mod_hens`, `kaibel`
+  call ipopt; `reverse_electrodialysis` calls GAMS). Without those tools the build
+  raises — the runner records this as an `ERROR` run rather than crashing the sweep.
+- A few `logical`-subpackage models depend on Pyomo APIs that drift across versions
+  (`BooleanVarData.set_binary_var`); pin a compatible Pyomo if you hit that.
+
+## The runner
+
+`discopt_benchmarks/benchmarks/gdplib_runner.py` automates the pipeline and emits
+`metrics.SolveResult` / `InstanceInfo` objects, so GDPlib results flow through the
+same correctness/reporting machinery as the MINLPLib and CUTEst runners.
+
+```bash
+cd discopt_benchmarks
+
+# list the models discovered in your install
+python -m benchmarks.gdplib_runner --list
+
+# solve one model with both reformulations, 60s each, cross-check vs HiGHS
+python -m benchmarks.gdplib_runner --models jobshop --methods bigm hull --time-limit 60
+
+# sweep the small models only, write results JSON
+python -m benchmarks.gdplib_runner --max-variables 500 --time-limit 120 --output reports/gdplib.json
+```
+
+The CLI exits nonzero if any run trips a soundness flag, so it can gate CI.
+
+## Correctness strategy (the non-negotiable part)
+
+Per `CLAUDE.md` §1 the product is the *certificate*, so a benchmark that only
+measures speed is not enough — every run is checked for soundness:
+
+- **Linear GDP models** → the reformulation is an MILP, and **HiGHS** (`appsi_highs`)
+  is used as an exact, independent oracle. discopt's certified objective must match.
+- **Nonlinear GDP models** → HiGHS is *not* a valid oracle. We fall back to (a) a
+  small table of verified reference optima (`reference_optima()`) and (b) a
+  bigm-vs-hull self-consistency check. Seeding a reference value requires
+  independent verification first (an external global solver, or agreement across
+  reformulations plus the GDPlib documentation) — never the solver-under-test alone.
+- Two flags are raised and surfaced loudly, never masked: a **false optimum**
+  (`OPTIMAL` but objective disagrees with the oracle) and a **bound crossing** (dual
+  bound on the wrong side of the oracle). Either is a hard failure — `incorrect_count`
+  must stay 0.
+
+An external global solver (BARON / SCIP / Couenne), where licensed/installed, is
+the natural oracle to add for the nonlinear subset; the runner's oracle hook is
+structured to accept one.
+
+## Model inventory (source install, this environment)
+
+Sizes are the *reformulated* (`gdp.bigm`) model; `class` is discopt-relevant
+(linear ⇒ HiGHS-checkable). `ERR` = build needs an external tool not present here.
+
+| model | vars | disj | class | notes |
+|---|---:|---:|---|---|
+| jobshop | 4 | 3 | linear | ✓ verified: bigm & hull = **11.0**, matches HiGHS |
+| ex1_linan_2023 | 2 | 2 | nonlinear | tiny but nonconvex |
+| positioning | 6 | 25 | nonlinear | nonconvex distance |
+| small_batch | 19 | 9 | nonlinear | |
+| cstr | 56 | 10 | nonlinear | |
+| spectralog | 68 | 30 | nonlinear | |
+| methanol | 247 | 4 | nonlinear | |
+| batch_processing | 270 | 9 | nonlinear | |
+| syngas | 321 | 23 | nonlinear | |
+| water_network | 335 | 5 | nonlinear | |
+| gdp_col | 412 | 15 | nonlinear | distillation column |
+| multiperiod_blending | 474 | 126 | nonlinear | |
+| modprodnet | 486 | 1 | nonlinear | + distributed/quarter variants |
+| med_term_purchasing | 949 | 72 | linear | HiGHS-checkable |
+| pandemic | 999 | 111 | nonlinear | |
+| hda | 1146 | 6 | nonlinear | |
+| disease_model | 1198 | 26 | linear | HiGHS-checkable |
+| grid | 12525 | 12500 | linear | large scheduling MILP |
+| biofuel | 36324 | 252 | nonlinear | large |
+| stranded_gas | 57618 | 96 | nonlinear | large |
+| kaibel, mod_hens | — | — | ERR | build needs ipopt |
+| reverse_electrodialysis | — | — | ERR | build needs GAMS |
+
+## Findings & limitations
+
+- **The bridge works and is sound where checkable.** `jobshop` solves to the
+  certified optimum via both reformulations and matches HiGHS exactly.
+- **Nonlinear GDPlib instances are genuinely hard for discopt today** and are good
+  stress material, not CI fodder: several hit the time limit and overrun it (the
+  known [#814](https://github.com/jkitchin/discopt/issues/814) time-limit-overrun
+  behavior — e.g. `small_batch` ran well past a 5 s budget). Use conservative limits
+  and expect `feasible`/`time_limit` rather than `optimal` on the nonlinear corpus.
+- **Only the linear subset gets an independent oracle here.** Verifying the
+  nonlinear subset needs a global MINLP solver; that's the main follow-up.
+
+## Suggested next steps
+
+1. Add a global-MINLP oracle (BARON/SCIP/Couenne) so the nonlinear subset gets
+   independent objective verification, then seed `reference_optima()` from it.
+2. Wire a curated `gdplib_small` suite into the nightly correctness lane (linear
+   models + short-limit nonlinear feasibility), gating on `incorrect_count == 0`.
+3. Optionally add a direct **Pyomo GDP → discopt native GDP** converter so discopt's
+   own disjunction/big-M/hull machinery is exercised instead of Pyomo's — a stronger
+   test of discopt's GDP path than the reformulate-then-solve route.

--- a/docs/dev/gdplib-benchmarking.md
+++ b/docs/dev/gdplib-benchmarking.md
@@ -81,23 +81,28 @@ The CLI exits nonzero if any run trips a soundness flag, so it can gate CI.
 ## Correctness strategy (the non-negotiable part)
 
 Per `CLAUDE.md` §1 the product is the *certificate*, so a benchmark that only
-measures speed is not enough — every run is checked for soundness:
+measures speed is not enough — every run is checked against an independent oracle,
+selected most-trusted-first:
 
-- **Linear GDP models** → the reformulation is an MILP, and **HiGHS** (`appsi_highs`)
-  is used as an exact, independent oracle. discopt's certified objective must match.
-- **Nonlinear GDP models** → HiGHS is *not* a valid oracle. We fall back to (a) a
-  small table of verified reference optima (`reference_optima()`) and (b) a
-  bigm-vs-hull self-consistency check. Seeding a reference value requires
-  independent verification first (an external global solver, or agreement across
-  reformulations plus the GDPlib documentation) — never the solver-under-test alone.
-- Two flags are raised and surfaced loudly, never masked: a **false optimum**
-  (`OPTIMAL` but objective disagrees with the oracle) and a **bound crossing** (dual
-  bound on the wrong side of the oracle). Either is a hard failure — `incorrect_count`
-  must stay 0.
+1. **HiGHS** (`appsi_highs`) on the **linear** subset — the reformulation is an MILP,
+   so HiGHS is an exact, independent oracle. discopt's certified objective must match.
+2. **SCIP** (`pyscipopt`, which bundles SCIP) on the **nonlinear** subset — a global
+   MINLP solver reading the *same* AMPL `.nl` discopt solves. SCIP's objective is
+   used **only when SCIP proves global optimality** (status `optimal`, gap ≈ 0); an
+   unconverged SCIP run yields an incumbent/bound, never a certified optimum, so it
+   is discarded rather than trusted.
+3. **`reference_optima()`** — the SCIP-certified values, baked in as regression
+   anchors and used offline / when `pyscipopt` is absent.
 
-An external global solver (BARON / SCIP / Couenne), where licensed/installed, is
-the natural oracle to add for the nonlinear subset; the runner's oracle hook is
-structured to accept one.
+Three flags are raised and surfaced loudly, never masked:
+- **impossible incumbent** — *any* feasible incumbent (even `FEASIBLE`, not
+  `OPTIMAL`) beating the oracle optimum: it violates a constraint (false primal, cf.
+  #815). The most dangerous case, and it does not require an `OPTIMAL` claim.
+- **false optimum** — `OPTIMAL` but the certified objective disagrees with the oracle.
+- **bound crossing** — the dual bound sits on the wrong side of the optimum.
+
+Any of these is a hard failure — `incorrect_count` must stay 0, and the CLI exits
+nonzero. BARON / Couenne could be added the same way SCIP was, behind the oracle hook.
 
 ## Model inventory (source install, this environment)
 
@@ -129,22 +134,50 @@ Sizes are the *reformulated* (`gdp.bigm`) model; `class` is discopt-relevant
 | kaibel, mod_hens | — | — | ERR | build needs ipopt |
 | reverse_electrodialysis | — | — | ERR | build needs GAMS |
 
+## discopt vs SCIP (12 small models, big-M, 60 s each)
+
+Both solvers read the **same** big-M `.nl`, so this is a fair head-to-head. SCIP 10
+(via `pyscipopt`) is the oracle; its proven optima seed `reference_optima()`.
+
+| model | discopt status | discopt obj | SCIP status | SCIP obj (opt) |
+|---|---|---:|---|---:|
+| jobshop | optimal | 11.0 | optimal | 11.0 |
+| ex1_linan_2023 | optimal | −0.9996 | optimal | −0.9996 |
+| positioning | feasible | 2570.62 | optimal | −8.06414 |
+| cstr | feasible | 4.06191 | optimal | 3.05431 |
+| small_batch | time_limit | — | optimal | 167427.65 |
+| spectralog | time_limit | — | optimal | 12.0893 |
+| syngas | time_limit | — | optimal | 4669.02 |
+| water_network | time_limit | — | optimal | 348337.04 |
+| modprodnet | time_limit | — | optimal | 3592.92 |
+| methanol | time_limit | — | timelimit | −1793.43 (gap ~130%) |
+| batch_processing | time_limit | — | timelimit | 679365 (gap 3%) |
+| gdp_col | time_limit | — | timelimit | 20355.1 (gap ~110%) |
+
+**SCIP: 9/12 proven optimal** (all ≤ 41 s). **discopt: 2/12 optimal, 2 loose-feasible,
+8 no incumbent.** The three SCIP left unproven are *not* seeded.
+
 ## Findings & limitations
 
-- **The bridge works and is sound where checkable.** `jobshop` solves to the
-  certified optimum via both reformulations and matches HiGHS exactly.
+- **Sound, but far slower/weaker than SCIP on this set.** Every discopt result is on
+  the correct side of SCIP's bound — where both prove optimality they agree to the
+  digit; discopt's feasible incumbents (positioning, cstr) sit *above* the min optimum
+  as a valid incumbent must. **Zero soundness violations.** This is the
+  certification-gap story, quantified.
 - **Nonlinear GDPlib instances are genuinely hard for discopt today** and are good
   stress material, not CI fodder: several hit the time limit and overrun it (the
   known [#814](https://github.com/jkitchin/discopt/issues/814) time-limit-overrun
-  behavior — e.g. `small_batch` ran well past a 5 s budget). Use conservative limits
-  and expect `feasible`/`time_limit` rather than `optimal` on the nonlinear corpus.
-- **Only the linear subset gets an independent oracle here.** Verifying the
-  nonlinear subset needs a global MINLP solver; that's the main follow-up.
+  behavior — e.g. `small_batch` ran well past a 5 s budget; SCIP by contrast stops
+  cleanly at its limit). Expect `feasible`/`time_limit`, not `optimal`, on the
+  nonlinear corpus.
+- **The oracle gap is now closed for the small nonlinear subset** via SCIP; the
+  larger models (biofuel, stranded_gas, grid) still need a longer SCIP budget to
+  certify.
 
 ## Suggested next steps
 
-1. Add a global-MINLP oracle (BARON/SCIP/Couenne) so the nonlinear subset gets
-   independent objective verification, then seed `reference_optima()` from it.
+1. Extend the SCIP-certified `reference_optima()` to the larger models with a longer
+   budget; optionally add BARON/Couenne behind the same oracle hook for redundancy.
 2. Wire a curated `gdplib_small` suite into the nightly correctness lane (linear
    models + short-limit nonlinear feasibility), gating on `incorrect_count == 0`.
 3. Optionally add a direct **Pyomo GDP → discopt native GDP** converter so discopt's


### PR DESCRIPTION
## Summary

Adds a way to benchmark/test discopt against the [SECQUOIA GDPlib](https://github.com/SECQUOIA/gdplib) corpus of Pyomo GDP models (issue #823, suggested by @bernalde in #819).

GDPlib ships **Pyomo GDP** models (`Disjunct`/`Disjunction`/`LogicalConstraint`), not a format discopt reads. The path — automated here — reuses discopt's **existing** `discopt.pyomo` bridge:

```
build_model() → TransformationFactory('gdp.bigm'|'gdp.hull').apply_to(m) → SolverFactory('discopt').solve(m)
```

**Scope note:** this PR touches only the benchmark harness + docs. **No change to the core solver** (`python/discopt/`, `crates/`) — it exercises discopt through the already-shipped Pyomo bridge.

What landed (all additive, 1152 insertions):
- `discopt_benchmarks/benchmarks/gdplib_runner.py` — discovers all zero-arg GDPlib builders (build failures reported as `ERROR` runs, no name-keyed skip list), reformulates + solves each through the bridge, and emits `metrics.SolveResult`/`InstanceInfo` so results flow through the existing pipeline. CLI: `--list`, `--models`, `--methods bigm hull`, `--time-limit`, `--max-variables`, `--output`; exits nonzero on any soundness flag.
- Independent-oracle cross-checks: **HiGHS** (`appsi_highs`) for the linear subset, **SCIP** (`pyscipopt`) for the nonlinear subset (used only when SCIP *proves* optimality), and a SCIP-certified `reference_optima()` table as offline fallback.
- `tests/test_gdplib.py` (19 tests, skip cleanly without pyomo/gdplib/highspy/pyscipopt), the `[gdplib]` optional-dependency extra, and `docs/dev/gdplib-benchmarking.md` (recipe, install caveats, model inventory, discopt-vs-SCIP results, correctness strategy).

Verified end-to-end: `jobshop` certifies **11.0** via both big-M and hull, matching HiGHS exactly; SCIP certifies 9/12 small nonlinear models and discopt stays sound against every one.

Contributes to #823 (follow-up discopt-performance work tracked on the issue).

## Correctness

- [x] Cannot produce a false certificate — **N/A, no solver-math change**. This is benchmark tooling + docs; it changes no bound, cut, relaxation, or solver path. If anything it *strengthens* correctness surveillance: the runner is itself a soundness gate (flags impossible incumbents / false optima / bound crossings against an independent oracle, `incorrect_count` must stay 0).
- [x] No validation, fallback, or safety guard was weakened.

## Tests run (state the result — numbers, not adjectives)

- [ ] `pytest -m smoke` → **N/A** — change is confined to `discopt_benchmarks/`; core smoke unaffected (3 pre-existing, unrelated `ModuleNotFoundError: discopt_benchmarks` collection errors in `test_perf_gate`/`test_overhead_330`/`test_nl_solvers_verdict` are a dev-layout quirk, not introduced here).
- [x] GDPlib suite → **19 passed** (`pytest discopt_benchmarks/tests/test_gdplib.py`), incl. SCIP/HiGHS oracle paths and the jobshop end-to-end solve.
- [x] `cargo test -p discopt-core` → **N/A** — no Rust touched.
- [x] `ruff check` / `ruff format --check` → clean (strict benchmarks profile: E,F,W,I,N,UP,B,A,C4,SIM,TCH).

## Regression test

- [x] `tests/test_gdplib.py` is the regression guard for this new module (19 tests): discovery, the jobshop bigm/hull end-to-end solve vs the HiGHS oracle, SCIP certifying/declining, the soundness-assessment logic (impossible-incumbent / false-optimum / bound-crossing), and the seed table. New feature module → covered by its own suite rather than a fail-before/pass-after on existing behavior.

## discopt vs SCIP (evidence, 12 small models, big-M, 60 s each)

Both solvers read the **same** big-M `.nl`. SCIP proves 9/12 global optima (≤ 41 s); discopt solves 2, is loose-feasible on 2, no incumbent on 8 — **zero soundness violations** (every discopt result on the correct side of SCIP's bound; where both prove optimality they agree to the digit). This quantifies the certification gap; full table in `docs/dev/gdplib-benchmarking.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Khryhjsy1WwCWnRNy1aXje)_