### PR TITLE
perf(#814): restrict quadratic_curvature eigvalsh to Q's support (gastrans582 root build >75s→24.6s)

### DIFF
--- a/python/discopt/_jax/convexity/patterns.py
+++ b/python/discopt/_jax/convexity/patterns.py
@@ -668,6 +668,18 @@ def quadratic_curvature(expr: Expression, model: Model) -> Optional[Curvature]:
     Q, _c, _const = data
     if np.allclose(Q, 0.0, atol=1e-10):
         return Curvature.AFFINE
+    # #814: `_quadratic_data` returns Q as a full n_total x n_total dense matrix,
+    # so a quadratic that involves only a few variables (e.g. one gas-pipe flow
+    # term in gastrans582's 2186-var model) still triggers an O(n_total^3)
+    # eigvalsh — which grinds the root relaxation build for 75s+ before B&B even
+    # starts. Restrict the eigenproblem to the nonzero SUPPORT of Q: the omitted
+    # rows/cols are all-zero, contributing exactly-zero eigenvalues that can never
+    # flip the CONVEX (min >= 0) or CONCAVE (max <= 0) sign tests below, so the
+    # classification is identical while the eigvalsh cost drops to the support
+    # dimension (a handful of vars).
+    support = np.nonzero(np.any(np.abs(Q) > 1e-12, axis=0))[0]
+    if 0 < support.size < Q.shape[0]:
+        Q = Q[np.ix_(support, support)]
     eigvals = np.linalg.eigvalsh(Q)
     if float(np.min(eigvals)) >= -1e-10:
         return Curvature.CONVEX

--- a/python/tests/test_814_quadratic_curvature_support.py
+++ b/python/tests/test_814_quadratic_curvature_support.py
@@ -1,0 +1,56 @@
+"""#814: `quadratic_curvature` restricts `eigvalsh` to the nonzero SUPPORT of Q.
+
+`_quadratic_data` returns Q as a full ``n_total x n_total`` dense matrix, so a
+quadratic that touches only a few variables inside a large model previously
+triggered an O(n_total^3) ``eigvalsh`` — which ground the root relaxation build
+for 75s+ on gastrans582 (2186 vars) before B&B ever started. The fix restricts the
+eigenproblem to the nonzero support; the omitted rows/cols contribute exactly-zero
+eigenvalues that cannot flip the CONVEX (min >= 0) / CONCAVE (max <= 0) sign tests,
+so the classification is identical.
+
+These tests pin the classification correctness on small-support-in-large-space
+quadratics (the case that exercises the support-restriction branch).
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+from discopt._jax.convexity import Curvature
+from discopt._jax.convexity import patterns as pat
+
+
+def _big_model_with_extra_vars(n_extra: int = 60):
+    """A model with n_extra continuous vars so the full Q is (n_extra+3)-dim while
+    any quadratic below touches only x/y/z — support strictly smaller than Q."""
+    m = dm.Model("q814")
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-2.0, ub=2.0)
+    z = m.continuous("z", lb=-2.0, ub=2.0)
+    for i in range(n_extra):
+        m.continuous(f"w{i}", lb=-1.0, ub=1.0)
+    return m, x, y, z
+
+
+def test_814_convex_quadratic_small_support_in_large_model():
+    m, x, y, z = _big_model_with_extra_vars()
+    # touches only x, y (support 2) inside a 63-var model
+    assert pat.quadratic_curvature(x * x + 2.0 * (y * y), m) == Curvature.CONVEX
+
+
+def test_814_concave_quadratic_small_support_in_large_model():
+    m, x, y, z = _big_model_with_extra_vars()
+    assert pat.quadratic_curvature(-(x * x) - 3.0 * (z * z), m) == Curvature.CONCAVE
+
+
+def test_814_indefinite_quadratic_small_support_in_large_model():
+    m, x, y, z = _big_model_with_extra_vars()
+    # x^2 - y^2 is indefinite -> UNKNOWN (both signs present in the support)
+    assert pat.quadratic_curvature(x * x - y * y, m) == Curvature.UNKNOWN
+
+
+def test_814_affine_and_full_support_unchanged():
+    m, x, y, z = _big_model_with_extra_vars(n_extra=0)
+    # 3-var model, quadratic over all 3 (support == full): must still classify
+    assert pat.quadratic_curvature(x * x + y * y + z * z, m) == Curvature.CONVEX
+    # a purely linear expr is AFFINE (Q == 0)
+    assert pat.quadratic_curvature(2.0 * x + y, m) == Curvature.AFFINE


### PR DESCRIPTION
Contributes to #814 (the discopt-side `gastrans582` overrun sub-cause).

## Root cause

`gastrans582_mild11` (2186 vars, 909 nl-cons) **hard-killed at 75s+ with 0 nodes** —
it never reached B&B. `faulthandler` pinned it in the **root relaxation build's
convexity classification**:

```
solve_model → _root_relaxation_lower_bound → build_uniform_relaxation
  → _try_convex_lift → quadratic_curvature → numpy eigvalsh
```

`_quadratic_data` returns Q as a **full n_total × n_total dense matrix**, so a
quadratic touching only a few variables (one gas-pipe flow term) still triggered an
**O(2186³) `eigvalsh`** — per expression, with no deadline check.

## Fix

Restrict the eigenproblem to the **nonzero support** of Q. The omitted rows/cols
are all-zero → contribute exactly-zero eigenvalues → can never flip the CONVEX
(`min ≥ 0`) / CONCAVE (`max ≤ 0`) sign tests. So the classification is **identical**
while `eigvalsh` drops from O(n_total³) to O(support³).

## Bound-neutral (verified)

Differential check over 10 instances (3..7455 nodes + a time_limit case) is
**byte-identical** in (status, objective, bound, node_count) with and without the
change. Classification-identical by construction. Convexity suites (107 tests) green.

## Measured

`gastrans582_mild11` root build no longer hard-kills: **>75s → ~24.6s**.

## Scope — one sub-cause down, one to go

This removes the **eigvalsh** sub-cause. A **second** remains: the root LP
relaxation solve (`milp_simplex`) still overruns its ~1s budget on the large LP, so
the instance is now ~5× over the limit instead of 15×+. That residual (the simplex
not honoring `time_limit` tightly) is a separate follow-up on #814.

## Tests

`python/tests/test_814_quadratic_curvature_support.py`: convex/concave/indefinite
quadratics with small support in a large model classify correctly (exercises the
support-restriction branch); full-support + affine unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
