### PR TITLE
fix(#822): make the incumbent-verification guard unconditional

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -3915,8 +3915,16 @@ class Model:
         # paths are JAX-free by design and do not run the nonlinear presolve mutation
         # this guard defends against, so building a JAX evaluator there would regress
         # their JAX-free cold start (``_is_fast_linear_quadratic_family`` is pure-Python).
+        #
+        # #822: the snapshot is NOT gated on ``verify_incumbent``. Returning an
+        # incumbent that is infeasible in the original model is the cardinal error
+        # (CLAUDE.md §1); a user flag must not be able to disable that soundness
+        # withhold. On a nonlinear solve the evaluator is already built during the
+        # solve, so ``cached_evaluator(self)`` here is a cache hit (~0 ms) — the
+        # verification is effectively free and now always runs. ``verify_incumbent``
+        # is retained for API compatibility but no longer suppresses the withhold.
         _verify_snap = None
-        if verify_incumbent and self._constraints and not _is_fast_linear_quadratic_family(self):
+        if self._constraints and not _is_fast_linear_quadratic_family(self):
             try:
                 from discopt._jax.nlp_evaluator import cached_evaluator
 

--- a/python/tests/test_incumbent_verification_guard_772.py
+++ b/python/tests/test_incumbent_verification_guard_772.py
@@ -91,9 +91,14 @@ def test_guard_withholds_injected_false_primal(monkeypatch):
     assert r.gap_certified is False
 
 
-def test_verify_incumbent_false_disables_guard(monkeypatch):
-    """``verify_incumbent=False`` restores the pre-guard behavior (the same injected
-    false primal passes through unflagged) — the opt-out works."""
+def test_verify_incumbent_false_still_withholds_false_primal(monkeypatch):
+    """#822: ``verify_incumbent=False`` no longer disables the soundness withhold.
+
+    Returning an incumbent infeasible in the ORIGINAL model is the cardinal error
+    (CLAUDE.md §1); a user flag must not be able to enable it. The verification is a
+    cache hit on a nonlinear solve (the evaluator is already built), so it is
+    effectively free and now always runs. (Previously the flag opted out of the
+    guard — a soundness hole: a false primal from any path would be returned.)"""
     m = dm.Model()
     x = m.continuous("x", lb=0.0, ub=10.0)
     y = m.continuous("y", lb=0.0, ub=10.0)
@@ -101,6 +106,7 @@ def test_verify_incumbent_false_disables_guard(monkeypatch):
     m.minimize(x + y)
 
     def _fake_solve_model(model, **kwargs):
+        # x=y=3 grossly violates x^2 + y^2 <= 1 (value 18) — a false primal.
         return SolveResult(
             status="optimal",
             objective=6.0,
@@ -112,5 +118,6 @@ def test_verify_incumbent_false_disables_guard(monkeypatch):
 
     monkeypatch.setattr(solver_mod, "solve_model", _fake_solve_model)
     r = m.solve(time_limit=5, verify_incumbent=False)
-    assert r.incumbent_verification_failed is False
-    assert r.x is not None  # not withheld — guard was off
+    assert r.incumbent_verification_failed is True  # guard fires even with the flag off
+    assert r.x is None  # withheld
+    assert r.objective is None


### PR DESCRIPTION
Closes #822.

## Problem

The #772 incumbent-verification guard withholds an incumbent that is infeasible in
the **original** model — the cardinal soundness invariant (CLAUDE.md §1). But it
was gated on the user flag `verify_incumbent` (default True): with
`verify_incumbent=False` the verification snapshot was never built, so **a false
primal from any path would be returned to the user**. A user flag must not be able
to enable the cardinal error.

Demonstrated pre-fix: `solve(verify_incumbent=False)` on a model whose incumbent
violates its nonlinear constraint returned the infeasible point (obj=2.0).

## Fix

Drop `verify_incumbent` from the snapshot-build condition — the verification always
runs on the nonlinear path. It's **effectively free** there: a nonlinear solve
already builds the evaluator, so `cached_evaluator(self)` in the guard is a **cache
hit (~0 ms, measured)**.

The **LP/MILP/QP/MIQP fast family stays skipped** — it's JAX-free by design and
**cannot produce a false primal** (exact solvers satisfy their linear/quadratic
rows by construction; no nonlinear presolve mutation). Skipping keeps its JAX-free
cold start and is sound. `verify_incumbent` is retained for API compatibility but
no longer suppresses the withhold.

## Verification

- **`test_verify_incumbent_false_still_withholds_false_primal`** (rewritten from the
  old test that codified the hole): **FAILS before, PASSES after** — with the flag
  off, an infeasible incumbent is now withheld (obj/x → None,
  `incumbent_verification_failed=True`).
- **No over-withholding**: 5 feasible-incumbent instances (ex4_1_1, ex8_1_1, nvs03,
  st_e05, gbd) still return their optima with `verify_incumbent=False`.
- #772/#779 guard suites: 11 passed. Smoke: 831 passed. mypy/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
