### PR TITLE
fix(#828): retry cyipopt on spurious pounce UNBOUNDED (jit1 unknown → optimal)

### DIFF
--- a/python/discopt/solvers/nlp_pounce.py
+++ b/python/discopt/solvers/nlp_pounce.py
@@ -151,6 +151,27 @@ def solve_nlp(
     status_code = info.get("status", -100)
     status = _IPOPT_STATUS_MAP.get(status_code, SolveStatus.ERROR)
 
+    # pounce#248: POUNCE can spuriously report UNBOUNDED on a BOUNDED but ill-scaled
+    # problem (jit1: objective bounded below, every variable box-constrained, yet
+    # UNBOUNDED — while cyipopt solves the identical problem to OPTIMAL). A local NLP
+    # cannot prove GLOBAL unboundedness anyway, so an UNBOUNDED verdict here is
+    # untrustworthy. Retry once with the KKT-valid cyipopt backend and adopt its
+    # result ONLY if it converges to a definitive OPTIMAL — so a genuinely unbounded
+    # relaxation (where cyipopt also fails to converge) keeps POUNCE's verdict.
+    # Best-effort: a missing cyipopt install or any error falls through unchanged.
+    if status == SolveStatus.UNBOUNDED:
+        try:
+            from discopt.solvers.nlp_ipopt import solve_nlp as _solve_cyipopt
+
+            _retry = _solve_cyipopt(
+                evaluator, x0, constraint_bounds=constraint_bounds, options=options
+            )
+            if _retry.status == SolveStatus.OPTIMAL:
+                _logger.debug("pounce UNBOUNDED overturned by cyipopt (OPTIMAL); adopting")
+                return _retry
+        except Exception as _retry_exc:  # noqa: BLE001 — fallback is best-effort
+            _logger.debug("cyipopt UNBOUNDED-retry skipped: %s", _retry_exc)
+
     multipliers = info.get("mult_g", None)
     if multipliers is not None and len(multipliers) == 0:
         multipliers = None

--- a/python/tests/test_828_pounce_unbounded_fallback.py
+++ b/python/tests/test_828_pounce_unbounded_fallback.py
@@ -1,0 +1,62 @@
+"""#828: a spurious POUNCE UNBOUNDED status is overturned by a cyipopt retry.
+
+jit1 is a convex reciprocal MINLP (objective ``Σ cᵢ/xᵢ`` for x>0 plus a badly
+scaled linear tail, coefficients spanning ~10 to ~1e7). POUNCE returns a *spurious*
+UNBOUNDED on its bounded continuous relaxation (pounce#248) — cyipopt solves the
+identical problem to OPTIMAL. Because the node relaxations "fail", the NLP-BB
+fathoms them non-rigorously and reports ``status=unknown`` with no incumbent, while
+SCIP solves jit1 in <0.1s.
+
+`nlp_pounce.solve_nlp` now retries once with the KKT-valid cyipopt backend when
+POUNCE reports UNBOUNDED and adopts cyipopt's result only if it converges to
+OPTIMAL — so jit1 solves on the default path, while a genuinely unbounded
+relaxation (where cyipopt also fails to converge) keeps POUNCE's verdict.
+
+Needs the benchmark corpus AND cyipopt (the fallback backend).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.nlp_evaluator import cached_evaluator
+from discopt.solvers.nlp_backend import available_backends
+
+BENCH = Path(os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"))
+_JIT1 = BENCH / "jit1.nl"
+_HAS_CYIPOPT = "cyipopt" in available_backends()
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+@pytest.mark.skipif(not _JIT1.exists(), reason="jit1.nl (benchmark corpus) absent")
+@pytest.mark.skipif(not _HAS_CYIPOPT, reason="cyipopt backend absent (fallback unavailable)")
+def test_828_jit1_solves_on_default_path():
+    """jit1 solves to its optimum on the DEFAULT (pounce) path — the UNBOUNDED
+    retry overturns pounce's spurious status. Before the fix it returned
+    status='unknown' with no incumbent."""
+    model = dm.from_nl(str(_JIT1))
+    r = model.solve(time_limit=10)
+    assert r.objective is not None, "#828: jit1 returned no incumbent (unknown) on the default path"
+    # oracle optimum 173983.33 (SCIP)
+    assert abs(r.objective - 173983.33) < 5.0, (
+        f"#828: jit1 objective {r.objective} != optimum 173983.33"
+    )
+    # and the incumbent is genuinely feasible (never a false primal)
+    if r.x is not None:
+        from discopt._jax.primal_heuristics import _check_constraint_feasibility
+
+        ev = cached_evaluator(model)
+        flat = np.concatenate(
+            [
+                np.atleast_1d(np.asarray(r.x[v.name], dtype=np.float64)).ravel()
+                for v in model._variables
+            ]
+        )
+        assert _check_constraint_feasibility(ev, flat, tol=1e-3), (
+            "#828: reported incumbent is infeasible in the original model"
+        )


### PR DESCRIPTION
Contributes to #828 (discopt-side robustness; upstream root cause = pounce#248).

## Root cause

jit1 returned `status=unknown` with no incumbent on the default path, while SCIP
solves it in <0.1s. It is a fully-supported convex reciprocal MINLP (objective
`Σ cᵢ/xᵢ` for x>0 plus a badly scaled linear tail, coefficients spanning ~10 to
~1e7). **POUNCE reports a spurious UNBOUNDED** on its bounded continuous relaxation:

```
pounce : status=UNBOUNDED  obj=173345.39   (even with EVERY var clamped to ±100)
ipopt  : status=OPTIMAL    obj=173345.38   (same point, correct status)
```

A box-bounded feasible region cannot be unbounded, so the status is spurious. The
NLP-BB then fathoms those nodes non-rigorously → `unknown`. Filed upstream as
**pounce#248**.

## Fix

`nlp_pounce.solve_nlp` retries once with the KKT-valid **cyipopt** backend when
POUNCE reports UNBOUNDED, adopting cyipopt's result **only** if it converges to a
definitive `OPTIMAL`. Rationale: a local NLP cannot prove *global* unboundedness,
so an UNBOUNDED verdict is untrustworthy; a genuinely unbounded relaxation (where
cyipopt also fails) keeps POUNCE's verdict. Best-effort — a missing cyipopt install
or any error falls through unchanged. The retry fires **only on UNBOUNDED** (rare;
bounded nodes never trigger it), so normal solves are unaffected.

## Measured

`jit1` on the **default path** now solves to **optimal 173982.61** (oracle
173983.33) — was `unknown`.

## Verification

- `test_828_jit1_solves_on_default_path` (slow, corpus + cyipopt gated): jit1
  solves to the optimum; incumbent feasibility-verified. (No incumbent before.)
- No regression: 7 instances (incl. himmel16 / ex14 unbounded-relaxation cases)
  unchanged; smoke **831 passed**. mypy/ruff clean.

## Note

The fallback needs cyipopt installed; without it the retry is a graceful no-op
(jit1 stays `unknown`) until the upstream pounce#248 fix lands. The real fix is
upstream — this is a sound robustness net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
