### PR TITLE
docs(#828): keep pounce UNBOUNDED-retry guard, record why (pounce#252)

### DIFF
--- a/python/discopt/solvers/nlp_pounce.py
+++ b/python/discopt/solvers/nlp_pounce.py
@@ -151,14 +151,25 @@ def solve_nlp(
     status_code = info.get("status", -100)
     status = _IPOPT_STATUS_MAP.get(status_code, SolveStatus.ERROR)
 
-    # pounce#248: POUNCE can spuriously report UNBOUNDED on a BOUNDED but ill-scaled
-    # problem (jit1: objective bounded below, every variable box-constrained, yet
-    # UNBOUNDED — while cyipopt solves the identical problem to OPTIMAL). A local NLP
-    # cannot prove GLOBAL unboundedness anyway, so an UNBOUNDED verdict here is
-    # untrustworthy. Retry once with the KKT-valid cyipopt backend and adopt its
-    # result ONLY if it converges to a definitive OPTIMAL — so a genuinely unbounded
-    # relaxation (where cyipopt also fails to converge) keeps POUNCE's verdict.
-    # Best-effort: a missing cyipopt install or any error falls through unchanged.
+    # POUNCE can report UNBOUNDED on a problem that in fact has a finite optimum,
+    # where a local NLP cannot legitimately prove GLOBAL unboundedness anyway — so an
+    # UNBOUNDED verdict here is untrustworthy. Retry once with the KKT-valid cyipopt
+    # backend and adopt its result ONLY if it converges to a definitive OPTIMAL, so a
+    # genuinely unbounded relaxation (where cyipopt also fails to converge) keeps
+    # POUNCE's verdict. Best-effort: a missing cyipopt install or any error falls
+    # through unchanged.
+    #
+    # DO NOT REMOVE this on the strength of pounce#248 alone. #248 ("Fix spurious
+    # UNBOUNDED on BOUNDED, ill-scaled NLPs", fixed 2026-07) resolves only the fully
+    # box-constrained root case: raw POUNCE now returns OPTIMAL on jit1's root
+    # continuous relaxation. But jit1's B&B NODE subproblems carry variables with
+    # ub=+inf (x12–x16, …), which are OUTSIDE #248's bounded class — and on current
+    # POUNCE (0.9.0) all 59 of jit1's node solves still return UNBOUNDED, so removing
+    # this retry regresses jit1 to status=unknown / no incumbent. Verified by removing
+    # it and re-solving: 59/59 UNBOUNDED, obj=None. The remaining case (UNBOUNDED on
+    # an unbounded-box subproblem that has a finite optimum) is tracked upstream as
+    # pounce#252 (#248 follow-up); this guard stays until that is fixed AND re-verified
+    # end-to-end on jit1.
     if status == SolveStatus.UNBOUNDED:
         try:
             from discopt.solvers.nlp_ipopt import solve_nlp as _solve_cyipopt


### PR DESCRIPTION
Comment-only change. Re-evaluating #828 against freshly-rebuilt **pounce 0.9.0**
(includes pounce#248): the #248 fix resolves only the **bounded** root case — raw
pounce now returns OPTIMAL on jit1's root continuous relaxation. But jit1's **B&B
node subproblems** carry `ub=+inf` variables (outside #248's bounded class), and
**all 59** of jit1's node solves still return spurious UNBOUNDED on current pounce.

Removing the discopt-side cyipopt-retry guard regresses jit1 to `status=unknown` /
no incumbent (verified: 59/59 UNBOUNDED, obj=None). So the guard is **load-bearing**,
not dead code — this rewrites its comment to say so (and to prevent a future reader
from removing it on the strength of #248 alone), and files the residual as
**pounce#252** (#248 follow-up).

No behavior change; the guard is unchanged. `Contributes to #828`.

## Verification
- jit1 solves optimal (173982.61, ~0.7s) with the guard; regresses to no incumbent without it.
- ruff/format/mypy clean (pre-commit passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
