### PR TITLE
feat(#814): graduate DISCOPT_ROOT_BUILD_DEADLINE to default-ON (#832)

### DIFF
--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -856,11 +856,11 @@ class SolverTuning:
     deterministic."""
 
     root_build_deadline: bool = field(
-        default_factory=lambda: _env_flag("DISCOPT_ROOT_BUILD_DEADLINE", default=False)
+        default_factory=lambda: _env_flag("DISCOPT_ROOT_BUILD_DEADLINE", default=True)
     )
     """Deadline the **base** root-relaxation ``build_milp_relaxation``
-    (``DISCOPT_ROOT_BUILD_DEADLINE``, default **off**; §5 bound-changing; issues
-    #832/#814).
+    (``DISCOPT_ROOT_BUILD_DEADLINE``, default **ON** — GRADUATED per §5, set ``=0`` to
+    opt out; §5 bound-changing; issues #832/#814).
 
     The #694 ``anytime_root_build`` flag truncates the *separated* build but its
     companion base build was deliberately left WHOLE — so on large ill-conditioned
@@ -880,11 +880,16 @@ class SolverTuning:
     yields a valid weaker bound in ~budget instead of ``None`` after 5x the grant.
 
     Bound-**changing** (a truncated base build can weaken a bound or drop it to
-    ``None``), so it is default off pending the §5 corpus-wide differential panel
-    (flag ON vs OFF; ``incorrect_count = 0``, no bound above its reference optimum,
-    no certification regression, must-not-regress #654-class bounds kept sound). Like
-    #694, with the flag on the fallback bound becomes timing-dependent, so it is not
-    bit-reproducible run-to-run; the default (off) path stays deterministic."""
+    ``None``). GRADUATED default-ON per §5 (one passing graduation-gate run suffices):
+    the ``graduation_gate.py --flags root_build_deadline`` panel (held-out N=40 seed 0
+    + cert panel) returned **eligible** — soundness ok (0 violations, no bound above
+    its reference optimum), cert-neutral (certified objective + optimal-status
+    enforced), net-positive (benefit 23% / regression 8.6%, and 2 of the 3
+    "regressions" are node-count-only labels on large wall wins: sonet24v5 33.6→14.5s,
+    sonet25v6 38.2→19.5s). Set ``DISCOPT_ROOT_BUILD_DEADLINE=0`` to restore the legacy
+    whole-base-build path. Like #694, with the deadline active the fallback bound
+    becomes timing-dependent (an anytime algorithm), so it is not bit-reproducible
+    run-to-run; the ``=0`` opt-out path stays deterministic."""
 
     # NOTE (#581): ``DISCOPT_NODE_REDUCE`` (per-node cheap reduction: cutoff-FBBT +
     # free DBBT from node-LP reduced costs + integer RC-fixing, feeding the

--- a/python/tests/test_832_root_build_deadline.py
+++ b/python/tests/test_832_root_build_deadline.py
@@ -64,27 +64,37 @@ def test_832_flag_on_bounds_gastrans_fallback(monkeypatch):
 
 @pytest.mark.slow
 @pytest.mark.skipif(not _GAS.exists(), reason="gastrans582_mild11.nl (benchmark corpus) absent")
-def test_832_flag_off_still_overruns_gastrans(monkeypatch):
-    """Flag OFF (default): the base build is left whole, so gastrans582 still
-    overruns — proving the default path is genuinely untouched (and that the flag,
-    not some unrelated change, is what bounds it)."""
+def test_832_default_bounds_gastrans_fallback(monkeypatch):
+    """GRADUATED (#832): with the env UNSET (the new default-ON), the gastrans582
+    fallback is bounded to ~grant — the fix is now the default path."""
     monkeypatch.delenv("DISCOPT_ROOT_BUILD_DEADLINE", raising=False)
+    _val, dt = _fallback(_GAS, budget=3.0)
+    assert dt < 6.0, f"#832: default (graduated ON) fallback took {dt:.1f}s, not bounded"
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not _GAS.exists(), reason="gastrans582_mild11.nl (benchmark corpus) absent")
+def test_832_opt_out_restores_overrun(monkeypatch):
+    """Opt-out (``=0``): the legacy whole-base-build path is preserved — gastrans582
+    overruns again — proving the graduation kept the opt-out and the old behavior."""
+    monkeypatch.setenv("DISCOPT_ROOT_BUILD_DEADLINE", "0")
     _val_off, dt_off = _fallback(_GAS, budget=3.0)
     assert dt_off > 8.0, (
-        f"#832: flag-OFF fallback took only {dt_off:.1f}s — expected the ~15s default "
-        "overrun; the default path may have changed"
+        f"#832: opt-out (=0) fallback took only {dt_off:.1f}s — the legacy overrun path "
+        "should be restored by =0"
     )
 
 
 @pytest.mark.parametrize("inst", ["syn05hfsg", "casctanks", "nvs11"])
 def test_832_flag_byte_identical_on_normal_instance(monkeypatch, inst):
-    """Soundness: on an instance whose base build finishes before the deadline, flag
-    ON and OFF produce the IDENTICAL bound — the deadline only ever affects a build
-    that would otherwise overrun, never the default result."""
+    """Soundness: on an instance whose base build finishes before the deadline, the
+    graduated-ON default and the ``=0`` opt-out produce the IDENTICAL bound — the
+    deadline only ever affects a build that would otherwise overrun, never the
+    default result."""
     p = _INREPO / f"{inst}.nl"
     if not p.exists():
         pytest.skip(f"{inst}.nl absent")
-    monkeypatch.delenv("DISCOPT_ROOT_BUILD_DEADLINE", raising=False)
+    monkeypatch.setenv("DISCOPT_ROOT_BUILD_DEADLINE", "0")
     val_off, _ = _fallback(p)
     monkeypatch.setenv("DISCOPT_ROOT_BUILD_DEADLINE", "1")
     val_on, _ = _fallback(p)


### PR DESCRIPTION
Graduates the #832 base root-build deadline to **default-ON** after its §5 graduation gate passed.

## Gate evidence
`graduation_gate.py --flags root_build_deadline --n 40 --seed 0` → **eligible=YES**: `soundness_ok=True` (0 violations, no bound above reference optimum), `cert_neutral=True` (0 cert violations, certified objective + optimal-status enforced), benefit **23%**, regression 8.6% (2 of the 3 are node-count-only labels on large wall wins — sonet24v5 33.6→14.5s, sonet25v6 38.2→19.5s). Report: `reports/graduation_gate_2026-07-21T14-32-47.{json,md}`.

## Change
- `solver_tuning.py`: `root_build_deadline` default `False`→`True` (keeps the `=0` opt-out + the legacy whole-base-build path).
- Resolves the **#814-a gastrans window on the default path**: the root fallback honors its grant (gastrans582_mild11 15.5s→3.6s) without opting in.
- Tests updated for the new default (default bounds gastrans; `=0` restores the legacy overrun; byte-identical `=0` vs `=1` on normal instances).

## Verification
- 6/6 `test_832_root_build_deadline.py` pass; default confirmed ON; ruff clean.

`Contributes to #814` — the emfl050-b window remains, tracked upstream as pounce#254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
