### PR TITLE
feat(#827): graduate DISCOPT_TRIVIAL_PRIMAL to default-ON (#829)

### DIFF
--- a/discopt_benchmarks/scripts/generality_sweep.py
+++ b/discopt_benchmarks/scripts/generality_sweep.py
@@ -177,6 +177,18 @@ ARMS: dict[str, dict] = {
     # or trips the ``_objective_bound_valid`` gate to None — so it can change (weaken)
     # a fallback bound: ``bound_changing``. No cheap static proxy — the overrun is a
     # runtime build-cost property (like lu_density_route / node_numerical_dual_bound).
+    # Trivial-point primal seed (#827/#829): at the root, evaluate a handful of
+    # obvious candidate points (origin-in-box, box-center, all-lb, all-ub), verify
+    # each against the TRUE constraints, and inject the best verified-feasible one as
+    # a warm-start incumbent when none exists yet. Primal-only and soundness-safe (a
+    # verified-feasible point can never falsify a bound), but it seeds an incumbent
+    # that enables pruning -> node_count changes -> ``bound_changing`` regime. No
+    # static structure proxy (whether a trivial point is feasible is a runtime fact).
+    "trivial_primal": {
+        "env": {"DISCOPT_TRIVIAL_PRIMAL": "1"},
+        "struct_attr": None,
+        "regime": "bound_changing",
+    },
     "root_build_deadline": {
         "env": {"DISCOPT_ROOT_BUILD_DEADLINE": "1"},
         "struct_attr": None,
@@ -200,6 +212,8 @@ GRADUATION_ARMS = (
     "node_numerical_dual_bound",
     # #832/#814 base root-build deadline, wired 2026-07-21
     "root_build_deadline",
+    # #827/#829 trivial-point primal seed, wired 2026-07-21
+    "trivial_primal",
 )
 
 # correctness tolerance (matches conftest abs=1e-6, rel=1e-4)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -410,24 +410,32 @@ def _obbt_topk_enabled() -> bool:
 
 
 def _trivial_primal_enabled() -> bool:
-    """Whether the #827 trivial-point primal seed is on (env flag, **default OFF**
-    pending the §5 differential panel).
+    """Whether the #827 trivial-point primal seed is on (env flag, **default ON** —
+    GRADUATED per §5; set ``DISCOPT_TRIVIAL_PRIMAL=0`` (or ``false``/``no``/``off``)
+    to opt out).
 
     Some models' feasible regions include an OBVIOUS point that the primal
     heuristics never sample: ``ball_mk2_30``'s optimum is the origin (the single
     ball constraint holds at 0), and ``chimera_k64ising-*`` has zero nonlinear
     constraints so any box point is feasible — yet both return NO incumbent while
-    SCIP solves them instantly. When ON, the root evaluates a handful of trivial
+    SCIP solves them instantly. When on, the root evaluates a handful of trivial
     candidates (origin projected into the box, box-center, all-lb, all-ub), verifies
     each against the true constraints, and injects the best VERIFIED-feasible one.
     Primal-only: it only ever seeds a feasible incumbent (and only when none exists
     yet), so the dual bound / certificate are untouched. Gated to pure-continuous
-    models (a trivial point need not be integer-feasible)."""
-    return os.environ.get("DISCOPT_TRIVIAL_PRIMAL", "").strip().lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
+    models (a trivial point need not be integer-feasible).
+
+    Graduated default-ON per §5 (one passing graduation-gate run suffices): the
+    ``graduation_gate.py --flags trivial_primal`` panel (held-out N=40 seed 0 + cert
+    panel) returned **eligible** — soundness ok (0 violations; a verified-feasible
+    seed can never falsify a bound), cert-neutral (certified objective +
+    optimal-status enforced), net-positive (benefit 45% / regression 7%). Set
+    ``DISCOPT_TRIVIAL_PRIMAL=0`` to restore the legacy no-seed behavior."""
+    return os.environ.get("DISCOPT_TRIVIAL_PRIMAL", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
     )
 
 

--- a/python/tests/test_827_trivial_primal.py
+++ b/python/tests/test_827_trivial_primal.py
@@ -7,11 +7,13 @@ origin (any x_i = +/-1 makes the sum strictly positive), so the origin is the
 unique feasible point and the optimum (obj 0). discopt's B&B never samples it and
 returns NO incumbent; SCIP solves it in 0.02s.
 
-With `DISCOPT_TRIVIAL_PRIMAL=1`, `solve_model` seeds a trivial feasible point
+With the trivial-primal seed on, `solve_model` seeds a trivial feasible point
 (origin / box-center / bound corners) as the `initial_point`, which the sub-solver
 re-verifies (constraint AND integer feasibility) and injects as an incumbent.
 
-Default OFF pending the §5 panel; flag-OFF behavior is unchanged. Corpus-gated.
+GRADUATED default-ON per §5 (gate: benefit 45% / regression 7%, soundness ok,
+cert-neutral); `DISCOPT_TRIVIAL_PRIMAL=0` restores the legacy no-seed behavior.
+Corpus-gated.
 """
 
 from __future__ import annotations
@@ -44,7 +46,8 @@ def _solve(inst: str, flag: str, tl: float):
     reason="ball_mk2_30.nl (benchmark corpus) absent",
 )
 def test_827_trivial_seed_finds_ball_mk2_incumbent():
-    """flag OFF finds NO incumbent; flag ON finds the origin (the optimum, obj 0)."""
+    """opt-out (=0) finds NO incumbent; seed on (=1) finds the origin (the optimum,
+    obj 0)."""
     off = _solve("ball_mk2_30", "0", 8.0)
     on = _solve("ball_mk2_30", "1", 8.0)
     assert off.objective is None, (
@@ -52,6 +55,26 @@ def test_827_trivial_seed_finds_ball_mk2_incumbent():
     )
     assert on.objective is not None and abs(on.objective) < 1e-4, (
         f"#827: trivial seed failed to find the ball_mk2 optimum 0.0 (got {on.objective})"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+@pytest.mark.skipif(
+    not (BENCH / "ball_mk2_30.nl").exists(),
+    reason="ball_mk2_30.nl (benchmark corpus) absent",
+)
+def test_827_graduated_default_finds_ball_mk2_incumbent():
+    """GRADUATED (#829): with the env UNSET (the new default-ON), ball_mk2_30 finds
+    its incumbent — the seed is now the default path, not opt-in."""
+    prev = os.environ.pop("DISCOPT_TRIVIAL_PRIMAL", None)
+    try:
+        r = dm.from_nl(str(BENCH / "ball_mk2_30.nl")).solve(time_limit=8.0)
+    finally:
+        if prev is not None:
+            os.environ["DISCOPT_TRIVIAL_PRIMAL"] = prev
+    assert r.objective is not None and abs(r.objective) < 1e-4, (
+        f"#829: graduated default failed to find the ball_mk2 optimum 0.0 (got {r.objective})"
     )
 
 


### PR DESCRIPTION
Graduates the #829 trivial-point primal seed to **default-ON** after its §5 graduation gate passed.

## Gate evidence
`graduation_gate.py --flags trivial_primal --n 40 --seed 0` → **eligible=YES**: `soundness_ok=True` (0 violations — a verified-feasible seed can never falsify a bound), `cert_neutral=True` (0 cert violations), benefit **45%**, regression 7%. Report: `reports/graduation_gate_2026-07-21T18-30-00.{json,md}`.

## Change
- `solver.py`: `_trivial_primal_enabled()` default off→on (set `DISCOPT_TRIVIAL_PRIMAL=0` to opt out).
- Resolves **#827 families D+C on the default path**: ball_mk2_30 (no incumbent → optimal 0.0) and chimera_k64ising (no incumbent → feasible) now surface an incumbent without opting in.
- `generality_sweep.py`: registers the `trivial_primal` gate arm.
- Tests: opt-out (`=0`) still finds no ball_mk2 incumbent; the graduated default (unset) now does; control unchanged; chimera sound.

## Verification
- 4/4 `test_827_trivial_primal.py` pass; default confirmed ON, `=0` opt-out confirmed OFF; ruff clean.

`Contributes to #827` — the chimera incumbent *quality* (a real Ising primal) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
