### PR TITLE
fix(#840): make fast=True indexed constraints visible to the NLPEvaluator + #772 guard

### DIFF
--- a/python/discopt/_jax/nlp_evaluator.py
+++ b/python/discopt/_jax/nlp_evaluator.py
@@ -164,6 +164,10 @@ def evaluator_fingerprint(model: Model) -> tuple:
     return (
         id(model._objective),
         tuple(id(c) for c in model._constraints),
+        # #840: fast-path constraints are part of the evaluator's constraint set, so
+        # they must be in the fingerprint — else a model that gains a fast family
+        # would reuse a stale evaluator built without it.
+        tuple(id(c) for c in getattr(model, "_fast_constraints", ())),
         tuple(id(v) for v in model._variables),
         tuple(id(p) for p in model._parameters),
         bool(getattr(model, "_gauss_newton_hessian", False)),
@@ -348,8 +352,16 @@ class NLPEvaluator:
         # bodies at call time. This lets DAEBuilder emit one big vector body
         # instead of thousands of scalar closures — the XLA trace shrinks from
         # O(nfe*ncp) scalar ops to O(1) bulk ops.
+        # #840: include fast-path single-variable-affine constraints (emitted to the
+        # Rust builder, stored in ``model._fast_constraints``, absent from
+        # ``_constraints``) so the evaluator's view — and hence
+        # ``_check_constraint_feasibility`` and the #772 incumbent guard — reflects the
+        # COMPLETE constraint set. Without them, a fast-indexed model looks
+        # unconstrained and any point (e.g. all-zeros on an assignment MILP) passes.
         self._source_constraints: list[Constraint] = [
-            c for c in model._constraints if isinstance(c, Constraint)
+            c
+            for c in (*model._constraints, *getattr(model, "_fast_constraints", ()))
+            if isinstance(c, Constraint)
         ]
         constraint_fns = [
             compile_constraint_params(c, model, self._param_index) for c in self._source_constraints

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2097,6 +2097,18 @@ class Model:
         # introduces a name also adds it here.
         self._names: set[str] = set()
         self._constraints: list[Constraint] = []
+        # #840: single-variable-affine constraint families emitted through the fast
+        # path (``constraint(fast=True)`` -> ``_try_fast_linear_family``) are NOT
+        # appended to ``_constraints`` because they are already emitted as sparse rows
+        # into the Rust builder (adding them there too would double-count them in the
+        # native solve). But the NLPEvaluator, ``_check_constraint_feasibility``, and
+        # the #772 incumbent-verification guard build their view of the model from the
+        # Constraint objects, so without this store they are BLIND to fast constraints
+        # (evaluate_constraints -> [], the guard accepts any point — the #840
+        # false-primal hole). We keep the generated Constraint objects here so those
+        # consumers see the COMPLETE constraint set, while the native solve keeps
+        # reading only the builder rows. Never fed to the builder/native path.
+        self._fast_constraints: list[Constraint] = []
         self._objective: Optional[Objective] = None
         # R4: names of lifted product-factor auxes whose interval spans 0, set by
         # the factorable reform under ``DISCOPT_LIFT_ZERO_SPANNING_FACTORS`` so the
@@ -2785,8 +2797,11 @@ class Model:
 
         members = {m: c for m, c in generated}
         if fast and self._try_fast_linear_family([c for _, c in generated], name):
-            # Rows were emitted into the Rust builder; keep the Constraint
-            # objects only for introspection (not in self._constraints).
+            # Rows were emitted into the Rust builder; keep the Constraint objects in
+            # ``_fast_constraints`` (NOT ``_constraints`` — that would double-count them
+            # in the native solve) so the NLPEvaluator / feasibility check / #772 guard
+            # see the complete constraint set (#840). Introspection view still returned.
+            self._fast_constraints.extend(c for _, c in generated)
             return IndexedConstraint(name, index_set, members, fast=True)
         for _, c in generated:
             self._constraints.append(c)

--- a/python/tests/test_840_fast_constraint_visibility.py
+++ b/python/tests/test_840_fast_constraint_visibility.py
@@ -1,0 +1,82 @@
+"""#840: fast=True indexed constraints must be visible to the NLPEvaluator, the
+feasibility check, and the #772 incumbent-verification guard.
+
+``m.constraint(set, rule, fast=True)`` emits single-variable-affine families as
+sparse rows straight into the Rust builder and does NOT append the Constraint
+objects to ``model._constraints`` (adding them there would double-count in the native
+solve). Before this fix that left the NLPEvaluator — and hence
+``_check_constraint_feasibility`` and the #772 guard, which verify incumbents through
+it — BLIND to those constraints: ``evaluate_constraints`` returned ``[]`` and any
+point was accepted. That is a soundness hole: an infeasible incumbent on a
+fast-indexed model would be certified (the #829 trivial-primal seed exposed it by
+injecting all-zeros on an assignment MILP → false optimum obj 0 vs the true 9).
+
+The fix tracks the fast families in ``model._fast_constraints`` and the NLPEvaluator
+includes them, so its constraint view is complete.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+from discopt._jax.nlp_evaluator import cached_evaluator
+from discopt._jax.primal_heuristics import _check_constraint_feasibility
+
+_WORKERS = ["w1", "w2", "w3"]
+_TASKS = ["a", "b", "c"]
+_ACOST = {(w, t): (i + 1) * (j + 1) for i, w in enumerate(_WORKERS) for j, t in enumerate(_TASKS)}
+
+
+def _assignment(fast: bool):
+    m = dm.Model("assign")
+    w = m.set("w", _WORKERS)
+    t = m.set("t", _TASKS)
+    assign = m.binary("assign", over=w * t)
+    m.minimize(dm.sum(_ACOST[(i, j)] * assign[i, j] for i in w for j in t))
+    m.constraint(w, lambda i: dm.sum(assign[i, j] for j in t) == 1, name="one_task", fast=fast)
+    m.constraint(t, lambda j: dm.sum(assign[i, j] for i in w) == 1, name="one_worker", fast=fast)
+    return m
+
+
+def _flat_n(m):
+    return sum(v.size for v in m._variables)
+
+
+def test_840_evaluator_sees_fast_constraints():
+    """The evaluator's constraint count for a fast=True model matches the fast=False
+    model (both 6) — the fast rows are no longer invisible."""
+    ev_fast = cached_evaluator(_assignment(fast=True))
+    ev_slow = cached_evaluator(_assignment(fast=False))
+    assert ev_fast.n_constraints == ev_slow.n_constraints == 6, (
+        f"#840: fast evaluator sees {ev_fast.n_constraints} constraints, "
+        f"slow sees {ev_slow.n_constraints} (want 6 each)"
+    )
+
+
+def test_840_feasibility_check_rejects_infeasible_on_fast_model():
+    """all-zeros violates every ``==1`` assignment row; the feasibility check (used by
+    the #772 guard AND the trivial-primal seed) must now reject it on the fast=True
+    model, not accept it as it did when the evaluator had no constraints."""
+    ev = cached_evaluator(_assignment(fast=True))
+    z = np.zeros(_flat_n(_assignment(fast=True)))
+    assert _check_constraint_feasibility(ev, z, tol=1e-6) is False, (
+        "#840: all-zeros wrongly accepted on a fast=True assignment model (guard blind spot)"
+    )
+    # a genuine permutation (w1->a, w2->b, w3->c) satisfies both families
+    idx = {(w, t): k for k, (w, t) in enumerate((w, t) for w in _WORKERS for t in _TASKS)}
+    perm = np.zeros(_flat_n(_assignment(fast=True)))
+    for w, t in zip(_WORKERS, _TASKS):
+        perm[idx[(w, t)]] = 1.0
+    assert _check_constraint_feasibility(ev, perm, tol=1e-6) is True, (
+        "#840: a valid permutation was rejected on the fast=True model"
+    )
+
+
+def test_840_fast_and_slow_solve_agree():
+    """End-to-end: the fast and slow formulations certify the SAME optimum (the true
+    assignment optimum, 10) — the fix does not perturb the correct solve, only makes
+    verification faithful."""
+    rf = _assignment(fast=True).solve()
+    rs = _assignment(fast=False).solve()
+    assert rf.objective == rs.objective, f"fast {rf.objective} != slow {rs.objective}"
+    assert abs(rf.objective - 10.0) < 1e-6, f"#840: optimum drifted to {rf.objective}"


### PR DESCRIPTION
Closes a **soundness hole** in the #772 incumbent-verification guard on fast-indexed models.

## The bug
`m.constraint(set, rule, fast=True)` emits single-variable-affine families as sparse rows straight into the Rust builder and does **not** append the `Constraint` objects to `model._constraints` (adding them there would double-count in the native solve). So the `NLPEvaluator`, `_check_constraint_feasibility`, and the **#772 guard** — which verify incumbents through the evaluator — saw **zero constraints** and accepted any point:

```
_assignment(fast=True):  evaluator n_constraints = 0   _check_constraint_feasibility(all-zeros) = True
_assignment(fast=False): evaluator n_constraints = 6   _check_constraint_feasibility(all-zeros) = False
```

Latent on default paths (the Rust solver is correct, so nothing feeds the guard a false primal), but the #829 trivial-primal seed exposed it — injecting all-zeros on a fast=True assignment MILP → **false optimum obj 0 vs the true 10** (this is what failed CI on PR #839).

## The fix
Track the generated `Constraint` objects in a new `model._fast_constraints` store and include them in the NLPEvaluator's source constraints (+ the `cached_evaluator` fingerprint). The native solve is unchanged (still reads only the builder rows → no double-count); the evaluator's view is now the **complete** constraint set.

## Verification
- fast evaluator now sees **6** constraints (was 0); `_check_constraint_feasibility` rejects all-zeros, accepts a valid permutation; fast/slow solves agree (optimum 10).
- `test_incumbent_verification_guard_772` + `test_indexed_correctness` + `test_fast_path` + `test_lazy_jax_linear_path` + new `test_840_*`: **50 passed**.
- `pytest -m smoke`: **831 passed**. JAX cold-start unaffected (evaluator built on demand). ruff/mypy clean.

`Contributes to #840` — the direct `add_linear_constraints` matrix API (also bypasses `_constraints`, but creates no `Constraint` objects) remains a noted residual. Unblocks the **soundness** half of the #827 trivial-primal graduation (the JAX cold-start wiring is separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
