### PR TITLE
fix(#828): remove jit1 cyipopt workaround + fix Ipopt code-3 mis-map (pounce#258)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           uv pip install maturin
           uv pip install \
             jax jaxlib numpy scipy highspy cyipopt openpyxl scikit-learn pyyaml \
-            pounce-solver \
+            "pounce-solver @ git+https://github.com/jkitchin/pounce.git@main#subdirectory=python" \
             pytest pytest-timeout pytest-xdist
           maturin develop
       - name: Run pytest (PR-fast, parallel)
@@ -241,7 +241,7 @@ jobs:
           uv pip install maturin
           uv pip install \
             jax jaxlib numpy scipy highspy cyipopt openpyxl scikit-learn pyyaml \
-            pounce-solver \
+            "pounce-solver @ git+https://github.com/jkitchin/pounce.git@main#subdirectory=python" \
             pytest pytest-timeout pytest-xdist
           maturin develop
       - name: Run pytest (fast correctness, serial)
@@ -302,7 +302,7 @@ jobs:
           uv pip install maturin
           uv pip install \
             jax jaxlib numpy scipy highspy openpyxl scikit-learn pyyaml \
-            pounce-solver \
+            "pounce-solver @ git+https://github.com/jkitchin/pounce.git@main#subdirectory=python" \
             pytest pytest-timeout pytest-xdist
           maturin develop
       - name: Run pytest (claim-boundary, serial)
@@ -372,7 +372,7 @@ jobs:
           uv pip install maturin
           uv pip install \
             jax jaxlib numpy scipy highspy cyipopt openpyxl scikit-learn pyyaml \
-            pounce-solver \
+            "pounce-solver @ git+https://github.com/jkitchin/pounce.git@main#subdirectory=python" \
             sympy pyomo litellm equinox optax onnx onnxruntime xgboost lightgbm \
             pytest pytest-timeout pytest-xdist pytest-cov
           maturin develop

--- a/.github/workflows/graduation-gate.yml
+++ b/.github/workflows/graduation-gate.yml
@@ -40,7 +40,7 @@ jobs:
           source .venv/bin/activate
           pip install maturin
           pip install numpy scipy "jax[cpu]" pytest pytest-timeout
-          pip install pounce-solver || echo "pounce-solver unavailable; cert panel may skip nonlinear instances"
+          pip install "pounce-solver @ git+https://github.com/jkitchin/pounce.git@main#subdirectory=python" || echo "pounce-solver unavailable; cert panel may skip nonlinear instances"
           maturin develop --release
       - name: Run the graduation gate CI subset (cert-neutrality + incorrect_count)
         run: |

--- a/python/discopt/solvers/nlp_ipopt.py
+++ b/python/discopt/solvers/nlp_ipopt.py
@@ -33,7 +33,15 @@ _IPOPT_STATUS_MAP: dict[int, SolveStatus] = {
     0: SolveStatus.OPTIMAL,  # Solve_Succeeded
     1: SolveStatus.OPTIMAL,  # Solved_To_Acceptable_Level
     2: SolveStatus.ERROR,  # Infeasible_Problem_Detected (local only)
-    3: SolveStatus.UNBOUNDED,  # Search_Direction_Becomes_Too_Small
+    # Ipopt code 3 = Search_Direction_Becomes_Too_Small: the IPM stalled on a tiny
+    # step, typically AT/near a local solution it cannot certify to tolerance — NOT
+    # unboundedness (that is code 4, Diverging_Iterates). Mapping it to UNBOUNDED made
+    # a converged-but-uncertified node look like an unbounded relaxation, which a local
+    # NLP can never prove; on jit1's B&B nodes this produced a false UNBOUNDED cascade
+    # (pounce#257/#258) that forced a cyipopt-retry workaround. Treat it as a
+    # non-converged limit — the B&B handles it soundly (non-pruning, uncertified),
+    # never as a false unbounded verdict.
+    3: SolveStatus.ITERATION_LIMIT,  # Search_Direction_Becomes_Too_Small (stalled, not unbounded)
     4: SolveStatus.ERROR,  # Diverging_Iterates
     5: SolveStatus.ERROR,  # User_Requested_Stop
     6: SolveStatus.ERROR,  # Feasible_Point_Found (not optimal)

--- a/python/discopt/solvers/nlp_pounce.py
+++ b/python/discopt/solvers/nlp_pounce.py
@@ -151,37 +151,14 @@ def solve_nlp(
     status_code = info.get("status", -100)
     status = _IPOPT_STATUS_MAP.get(status_code, SolveStatus.ERROR)
 
-    # POUNCE can report UNBOUNDED on a problem that in fact has a finite optimum,
-    # where a local NLP cannot legitimately prove GLOBAL unboundedness anyway — so an
-    # UNBOUNDED verdict here is untrustworthy. Retry once with the KKT-valid cyipopt
-    # backend and adopt its result ONLY if it converges to a definitive OPTIMAL, so a
-    # genuinely unbounded relaxation (where cyipopt also fails to converge) keeps
-    # POUNCE's verdict. Best-effort: a missing cyipopt install or any error falls
-    # through unchanged.
-    #
-    # DO NOT REMOVE this on the strength of pounce#248 alone. #248 ("Fix spurious
-    # UNBOUNDED on BOUNDED, ill-scaled NLPs", fixed 2026-07) resolves only the fully
-    # box-constrained root case: raw POUNCE now returns OPTIMAL on jit1's root
-    # continuous relaxation. But jit1's B&B NODE subproblems carry variables with
-    # ub=+inf (x12–x16, …), which are OUTSIDE #248's bounded class — and on current
-    # POUNCE (0.9.0) all 59 of jit1's node solves still return UNBOUNDED, so removing
-    # this retry regresses jit1 to status=unknown / no incumbent. Verified by removing
-    # it and re-solving: 59/59 UNBOUNDED, obj=None. The remaining case (UNBOUNDED on
-    # an unbounded-box subproblem that has a finite optimum) is tracked upstream as
-    # pounce#252 (#248 follow-up); this guard stays until that is fixed AND re-verified
-    # end-to-end on jit1.
-    if status == SolveStatus.UNBOUNDED:
-        try:
-            from discopt.solvers.nlp_ipopt import solve_nlp as _solve_cyipopt
-
-            _retry = _solve_cyipopt(
-                evaluator, x0, constraint_bounds=constraint_bounds, options=options
-            )
-            if _retry.status == SolveStatus.OPTIMAL:
-                _logger.debug("pounce UNBOUNDED overturned by cyipopt (OPTIMAL); adopting")
-                return _retry
-        except Exception as _retry_exc:  # noqa: BLE001 — fallback is best-effort
-            _logger.debug("cyipopt UNBOUNDED-retry skipped: %s", _retry_exc)
+    # (The interim cyipopt-retry-on-UNBOUNDED guard was removed once pounce#258 fixed
+    # the actual root cause. jit1's B&B nodes converged to the node optimum and then
+    # returned Ipopt status 3 "Search_Direction_Becomes_Too_Small", which this file's
+    # _IPOPT_STATUS_MAP mis-mapped to UNBOUNDED — the false verdict the guard papered
+    # over. pounce#258 makes the strict certificate reachable under strong objective
+    # scaling, and the code-3 mis-map is fixed in nlp_ipopt._IPOPT_STATUS_MAP. Verified
+    # post-#258: jit1's 26 node solves all return OPTIMAL, jit1 solves to 173982.61 on
+    # pure POUNCE with no retry.)
 
     multipliers = info.get("mult_g", None)
     if multipliers is not None and len(multipliers) == 0:

--- a/python/tests/test_828_pounce_unbounded_fallback.py
+++ b/python/tests/test_828_pounce_unbounded_fallback.py
@@ -1,18 +1,23 @@
-"""#828: a spurious POUNCE UNBOUNDED status is overturned by a cyipopt retry.
+"""#828: jit1 solves on the default POUNCE path (pounce#258 fixed the root cause).
 
 jit1 is a convex reciprocal MINLP (objective ``Σ cᵢ/xᵢ`` for x>0 plus a badly
-scaled linear tail, coefficients spanning ~10 to ~1e7). POUNCE returns a *spurious*
-UNBOUNDED on its bounded continuous relaxation (pounce#248) — cyipopt solves the
-identical problem to OPTIMAL. Because the node relaxations "fail", the NLP-BB
-fathoms them non-rigorously and reports ``status=unknown`` with no incumbent, while
-SCIP solves jit1 in <0.1s.
+scaled linear tail, coefficients spanning ~10 to ~1e7). Its B&B node NLPs converge
+to the node optimum and then returned Ipopt status 3
+(``Search_Direction_Becomes_Too_Small``) because, under strong objective scaling, the
+strict termination certificate was unreachable — and discopt's ``_IPOPT_STATUS_MAP``
+mis-mapped status 3 onto ``UNBOUNDED``. The NLP-BB then fathomed those nodes
+non-rigorously and reported ``status=unknown`` with no incumbent, while SCIP solves
+jit1 in <0.1s.
 
-`nlp_pounce.solve_nlp` now retries once with the KKT-valid cyipopt backend when
-POUNCE reports UNBOUNDED and adopts cyipopt's result only if it converges to
-OPTIMAL — so jit1 solves on the default path, while a genuinely unbounded
-relaxation (where cyipopt also fails to converge) keeps POUNCE's verdict.
+Fixed end-to-end by:
+  * **pounce#258** — makes the strict certificate reachable under objective scaling,
+    so raw POUNCE returns OPTIMAL (not status 3) on jit1's nodes; and
+  * discopt — ``_IPOPT_STATUS_MAP`` maps status 3 to ``ITERATION_LIMIT`` (a stalled
+    limit), never ``UNBOUNDED`` (a local NLP cannot prove global unboundedness).
 
-Needs the benchmark corpus AND cyipopt (the fallback backend).
+The interim cyipopt-retry-on-UNBOUNDED workaround (#834/#836) is therefore removed —
+jit1 now solves on the pure POUNCE path with no retry and no cyipopt dependency.
+Needs only the benchmark corpus.
 """
 
 from __future__ import annotations
@@ -24,20 +29,17 @@ import discopt.modeling as dm
 import numpy as np
 import pytest
 from discopt._jax.nlp_evaluator import cached_evaluator
-from discopt.solvers.nlp_backend import available_backends
 
 BENCH = Path(os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"))
 _JIT1 = BENCH / "jit1.nl"
-_HAS_CYIPOPT = "cyipopt" in available_backends()
 
 
 @pytest.mark.slow
 @pytest.mark.correctness
 @pytest.mark.skipif(not _JIT1.exists(), reason="jit1.nl (benchmark corpus) absent")
-@pytest.mark.skipif(not _HAS_CYIPOPT, reason="cyipopt backend absent (fallback unavailable)")
 def test_828_jit1_solves_on_default_path():
-    """jit1 solves to its optimum on the DEFAULT (pounce) path — the UNBOUNDED
-    retry overturns pounce's spurious status. Before the fix it returned
+    """jit1 solves to its optimum on the DEFAULT (pure POUNCE) path — pounce#258 plus
+    the status-3 remap remove the false-UNBOUNDED cascade. Before the fix it returned
     status='unknown' with no incumbent."""
     model = dm.from_nl(str(_JIT1))
     r = model.solve(time_limit=10)
@@ -60,3 +62,41 @@ def test_828_jit1_solves_on_default_path():
         assert _check_constraint_feasibility(ev, flat, tol=1e-3), (
             "#828: reported incumbent is infeasible in the original model"
         )
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+@pytest.mark.skipif(not _JIT1.exists(), reason="jit1.nl (benchmark corpus) absent")
+def test_828_jit1_nodes_no_longer_spurious_unbounded():
+    """Pins the mechanism: with the (removed) cyipopt retry unavailable, raw POUNCE
+    must NOT return UNBOUNDED on jit1's node NLPs (pre-#258 it was 59/59 UNBOUNDED)."""
+    import discopt.solvers.nlp_ipopt as NI
+    import discopt.solvers.nlp_pounce as NP
+    from discopt.solvers import SolveStatus
+
+    # make any latent cyipopt retry a no-op so RAW POUNCE verdicts surface
+    _orig_ip = NI.solve_nlp
+    NI.solve_nlp = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("retry disabled for test"))
+    _orig = NP.solve_nlp
+    counts = {"unbounded": 0, "total": 0}
+
+    def _wrap(*a, **k):
+        r = _orig(*a, **k)
+        counts["total"] += 1
+        if r.status == SolveStatus.UNBOUNDED:
+            counts["unbounded"] += 1
+        return r
+
+    NP.solve_nlp = _wrap
+    try:
+        r = dm.from_nl(str(_JIT1)).solve(time_limit=10)
+    finally:
+        NP.solve_nlp = _orig
+        NI.solve_nlp = _orig_ip
+    assert counts["unbounded"] == 0, (
+        f"#828/pounce#258: {counts['unbounded']}/{counts['total']} jit1 node NLPs returned "
+        "spurious UNBOUNDED on raw POUNCE"
+    )
+    assert r.objective is not None and abs(r.objective - 173983.33) < 5.0, (
+        f"#828: jit1 did not solve on pure POUNCE (obj={r.objective})"
+    )

--- a/python/tests/test_perf_723_convexity_dedup.py
+++ b/python/tests/test_perf_723_convexity_dedup.py
@@ -62,7 +62,11 @@ def test_convexity_dedup_on_nlp_bb_path(monkeypatch):
     # count is platform-FP-dependent for this nonconvex instance (39 local vs 41
     # CI), so here we only assert it did not blow up.
     assert res.node_count < 100
-    assert res.objective == pytest.approx(331837498.18201387, rel=1e-9)
+    # Optimum pinned to the solver's actual tolerance (abs=1e-6, rel=1e-4), not a
+    # spurious 1e-9: pounce#258 (refuse a certificate masked by extreme objective
+    # scale, continue to the true minimum) legitimately shifted the last digits on
+    # this ~3.3e8-scale nonconvex objective (331837498.18 -> 331837497.84, ~1e-9 rel).
+    assert res.objective == pytest.approx(331837498.18201387, rel=1e-6)
     # Pre-#723 this was 4; the dedup brings it to 2 (one per solve_model entry).
     assert calls["n"] <= 2, f"convexity classified {calls['n']}x (expected <= 2)"
 


### PR DESCRIPTION
Closes the discopt side of the pounce#257→#258 loop.

## Root cause (from pounce#258)
jit1's B&B node NLPs converge to the node optimum, then return Ipopt status **3** (`Search_Direction_Becomes_Too_Small`) because the strict termination certificate was unreachable under strong objective scaling. discopt's `_IPOPT_STATUS_MAP` **mis-mapped code 3 → `UNBOUNDED`** — but a local NLP can never prove *global* unboundedness (that's code 4, `Diverging_Iterates`). That false-UNBOUNDED cascade is what the #834/#836 cyipopt-retry workaround papered over.

pounce#258 makes the certificate reachable (raw pounce now returns OPTIMAL), so both the workaround and the mis-map can go.

## Changes
- **`nlp_ipopt.py`**: code 3 → `ITERATION_LIMIT` (stalled/uncertified, handled soundly by the B&B), never `UNBOUNDED`.
- **`nlp_pounce.py`**: remove the dead cyipopt-retry-on-UNBOUNDED guard.
- **`test_828`**: jit1 solves on the pure POUNCE path (obj 173982.61, **0/26** node solves UNBOUNDED), no cyipopt; a second test pins 0 spurious-UNBOUNDED nodes.
- **`test_perf_723`**: relax the objective pin `1e-9→1e-6` (solver tolerance) — pounce#258 legitimately shifted the last digits on this ~3.3e8 nonconvex objective (…498.18 → …497.84).
- **CI (`ci.yml`, `graduation-gate.yml`)**: install pounce from **git `@main`** (which has #242–#258) instead of the stale **PyPI 0.8.0** that predates every recent fix.

## ⚠️ Dependency note
PyPI's latest `pounce-solver` is **0.8.0** — the 0.9.x with #258 was never published. This PR bridges CI via a git install ("use local pounce for now"). The runtime pin `pounce-solver>=0.8` in `pyproject.toml` is **unchanged**, so end-users on PyPI still get 0.8.0 (where jit1 would regress). Follow-up (owner): publish pounce 0.9.x, then bump the pin to `>=0.9.x` and drop the git install.

## Verification
- jit1 solves on pure pounce, 0 retries; `pytest -m smoke` **831 passed**; targeted nlp/pounce/status suites **915 passed**; ruff/mypy clean. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
