### PR TITLE
feat(#843): QUBO/Ising local-search primal for chimera_k64ising (default-off)

### DIFF
--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -86,6 +86,129 @@ def _get_variable_bounds(model: Model) -> tuple[np.ndarray, np.ndarray]:
     return np.concatenate(lbs), np.concatenate(ubs)
 
 
+def is_qubo(model: Model) -> bool:
+    """True if *model* is an unconstrained binary quadratic program (QUBO).
+
+    That is: every variable is binary-valued (BINARY, or INTEGER with a [0, 1]
+    box), there are no constraints (general or fast), and the objective is at most
+    quadratic. This is the ``chimera_k64ising`` / Max-Cut structure (#843). Such a
+    model has no feasibility to satisfy — *any* binary point is feasible — so a
+    quadratic-form local search is a sound, purely-primal constructor.
+    """
+    if model._constraints or getattr(model, "_fast_constraints", None):
+        return False
+    if model._objective is None:
+        return False
+    for v in model._variables:
+        if v.var_type not in (VarType.BINARY, VarType.INTEGER):
+            return False
+        lo = np.asarray(v.lb, dtype=np.float64).ravel()
+        hi = np.asarray(v.ub, dtype=np.float64).ravel()
+        if not (np.all(lo == 0.0) and np.all(hi == 1.0)):
+            return False
+    return True
+
+
+def qubo_local_search(
+    model: Model,
+    *,
+    evaluator: Optional[NLPEvaluator] = None,
+    deadline: Optional[float] = None,
+    max_starts: int = 12,
+    iters_per_start: int = 4000,
+    tenure: int = 20,
+    seed: int = 0,
+) -> Optional[np.ndarray]:
+    """Greedy-1opt + tabu local search on a binary QUBO (#843).
+
+    Minimizes the evaluator's INTERNAL objective ``½xᵀHx + cᵀx`` over ``{0,1}ⁿ`` —
+    which is exactly the internal minimize form the solver uses (negated already for
+    a MAXIMIZE), so the caller can inject the returned binary point as ``x0`` /
+    incumbent and the reported objective sense is handled by the solver as usual.
+
+    The Hessian ``H`` is constant (quadratic objective), so each 1-flip's objective
+    delta is ``δ·g + ½·H_kk`` (δ = ±1) and the gradient updates incrementally
+    (``g += δ·H[:,k]``) — O(nnz) per flip. Tabu (with an aspiration override on a new
+    global best) escapes the shallow local optima plain greedy gets stuck in. Runs
+    from zeros / ones / stratified-random starts and returns the best binary point,
+    or ``None`` if the model is not a QUBO or no point improves on all-zeros.
+
+    Purely primal and sound: an unconstrained QUBO has no feasibility to violate, so
+    any binary point is a valid incumbent; the dual bound / certificate are untouched.
+    """
+    if not is_qubo(model):
+        return None
+    ev = evaluator if evaluator is not None else cached_evaluator(model)
+    n = ev.n_variables
+    if n == 0:
+        return None
+    z = np.zeros(n, dtype=np.float64)
+    # Build the (constant, quadratic) objective Hessian from the sparse structure +
+    # values, NOT the dense ``evaluate_hessian`` — the latter is a JAX dense n×n eval
+    # (~3.5s / 1192 vars) that would blow the heuristic's budget, while
+    # hessian_structure + evaluate_hessian_values is O(nnz) (~ms). hessian_structure is
+    # the lower triangle (Ipopt convention), so symmetrize L -> L + Lᵀ - diag(L).
+    try:
+        rows, cols = (np.asarray(a, dtype=np.int64) for a in ev.hessian_structure())
+        vals = np.asarray(
+            ev.evaluate_hessian_values(z, 1.0, np.zeros(ev.n_constraints)), dtype=np.float64
+        )
+        if rows.size != vals.size:
+            return None
+        H = np.zeros((n, n), dtype=np.float64)
+        H[rows, cols] = vals
+        H = H + H.T - np.diag(np.diag(H))
+    except Exception:  # noqa: BLE001 — fall back to the dense path if the sparse API is absent
+        H = np.asarray(ev.evaluate_hessian(z), dtype=np.float64)
+        if H.shape != (n, n):
+            return None
+    c = np.asarray(ev.evaluate_gradient(z), dtype=np.float64)
+    Hdiag = np.diag(H)
+
+    def one_pass(x0: np.ndarray, iters: int) -> tuple[np.ndarray, float]:
+        x = x0.astype(np.float64).copy()
+        g = H @ x + c
+        cur = 0.5 * x @ H @ x + c @ x
+        best, bestx = cur, x.copy()
+        tabu_until = np.full(n, -1, dtype=np.int64)
+        for it in range(iters):
+            delta = 1.0 - 2.0 * x
+            dobj = delta * g + 0.5 * Hdiag  # Δ internal objective per flip
+            allowed = np.where(tabu_until <= it, dobj, np.inf)
+            aspire = np.where(cur + dobj < best - 1e-9, dobj, np.inf)  # override tabu on new best
+            pick = np.minimum(allowed, aspire)
+            k = int(np.argmin(pick))
+            if not np.isfinite(pick[k]):
+                k = int(np.argmin(dobj))
+            d = delta[k]
+            x[k] = 1.0 - x[k]
+            cur += dobj[k]
+            g = g + d * H[:, k]
+            tabu_until[k] = it + tenure
+            if cur < best - 1e-9:
+                best, bestx = cur, x.copy()
+        return bestx, best
+
+    rng = np.random.default_rng(seed)
+    starts = [z, np.ones(n)]
+    starts += [(rng.random(n) > 0.5).astype(np.float64) for _ in range(max(0, max_starts - 2))]
+    best_x: Optional[np.ndarray] = None
+    best_internal = np.inf
+    for i, x0 in enumerate(starts):
+        # Always run the first (zeros) pass — the Hessian/gradient extraction above is a
+        # one-time JAX compile that can exceed a tight deadline, and returning a good
+        # incumbent matters more than never overrunning by one cheap local search.
+        if i > 0 and deadline is not None and time.perf_counter() >= deadline:
+            break
+        xb, ib = one_pass(x0, iters_per_start)
+        if ib < best_internal - 1e-9:
+            best_internal, best_x = ib, xb
+    # Only return a point that beats the trivial all-zeros incumbent (internal 0.0).
+    if best_x is None or best_internal >= -1e-9:
+        return None
+    return best_x
+
+
 def _generate_starts(
     lb: np.ndarray,
     ub: np.ndarray,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -431,6 +431,29 @@ def _trivial_primal_enabled() -> bool:
     )
 
 
+def _qubo_primal_enabled() -> bool:
+    """Whether the #843 QUBO local-search primal is on (env flag, **default OFF**
+    pending the §5 differential panel).
+
+    An unconstrained binary quadratic model (``chimera_k64ising``: 1192 binary vars,
+    0 constraints, indefinite MAXIMIZE Ising) returns NO incumbent — its dense
+    B&B never lands a good binary point, and the #827 trivial seed only gave the
+    useless all-zeros floor. When on, a greedy-1opt + tabu local search on the
+    quadratic form (``primal_heuristics.qubo_local_search``) constructs a real
+    feasible incumbent (chimera-01: 7.2 vs opt 24.3) and injects it as
+    ``initial_point``. Purely primal and sound: an unconstrained QUBO has no
+    feasibility to violate (any binary point is feasible), so the dual bound /
+    certificate are untouched. Gated to the QUBO structure via
+    ``primal_heuristics.is_qubo`` (so it never fires on the JAX-free LP/MILP cold
+    -start path, which is not a QUBO)."""
+    return os.environ.get("DISCOPT_QUBO_PRIMAL", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 # #282 iterate-root-OBBT-to-convergence (flag-gated, default OFF). The root OBBT
 # over the McCormick LP already iterates and rebuilds the envelope on the
 # tightened box each sweep (``obbt_tighten_root``), but at the default
@@ -6232,6 +6255,41 @@ def solve_model(
             f"and MIQCQP models only; "
             f"classified this model as {problem_class.value!r}."
         )
+
+    # #843: QUBO local-search primal. For an unconstrained binary quadratic model
+    # (chimera_k64ising), a greedy-1opt + tabu local search on the quadratic form lands
+    # a real feasible incumbent where the dense B&B and the #827 trivial seed find none
+    # (chimera-01: 7.2 vs opt 24.3). Runs before the generic trivial seed (more specific
+    # + far better for this structure) and ONLY when the model is a QUBO (all-binary, 0
+    # constraints, quadratic objective) — so it never touches the JAX-free LP/MILP
+    # cold-start path. Sound: any binary point is feasible (no constraints to violate),
+    # so it only ever seeds a valid incumbent; the dual bound / certificate are untouched.
+    if _qubo_primal_enabled() and initial_point is None:
+        # Detect the QUBO structure with a JAX-FREE check BEFORE importing the (JAX)
+        # heuristic — otherwise ``import primal_heuristics`` would pull JAX in on every
+        # LP/MILP solve and break the cold-start invariant (test_lazy_jax_linear_path).
+        _is_qubo_model = (
+            model._objective is not None
+            and not model._constraints
+            and not getattr(model, "_fast_constraints", None)
+            and bool(model._variables)
+            and all(
+                v.var_type in (VarType.BINARY, VarType.INTEGER)
+                and bool(np.all(np.asarray(v.lb, dtype=np.float64).ravel() == 0.0))
+                and bool(np.all(np.asarray(v.ub, dtype=np.float64).ravel() == 1.0))
+                for v in model._variables
+            )
+        )
+        if _is_qubo_model:
+            try:
+                from discopt._jax.primal_heuristics import qubo_local_search
+
+                _qubo_x = qubo_local_search(model, deadline=t_start + max(float(time_limit), 0.0))
+                if _qubo_x is not None:
+                    initial_point = _qubo_x
+                    logger.info("QUBO local-search primal seed as initial_point")
+            except Exception as _qubo_exc:  # noqa: BLE001 — best-effort primal seed
+                logger.debug("QUBO primal seed failed: %s", _qubo_exc)
 
     # #827: trivial-point primal seed. When no warm start is given, seed a feasible
     # OBVIOUS point (ball_mk2 — 30 integer vars in [-1,1] — has its optimum at the

--- a/python/tests/test_843_qubo_primal.py
+++ b/python/tests/test_843_qubo_primal.py
@@ -1,0 +1,102 @@
+"""#843: a real QUBO/Ising local-search primal for chimera_k64ising.
+
+chimera_k64ising is an unconstrained binary quadratic program (1192 binary vars, 0
+constraints, indefinite MAXIMIZE Ising) — discopt's dense B&B never lands a good
+binary point and the #827 trivial seed only gave the useless all-zeros floor (obj 0),
+so it returned NO incumbent. ``primal_heuristics.qubo_local_search`` (greedy-1opt +
+tabu on the quadratic form) constructs a real feasible incumbent, injected as
+``initial_point`` behind ``DISCOPT_QUBO_PRIMAL`` (default off).
+
+Sound by construction: an unconstrained QUBO has no feasibility to violate, so any
+binary point is a valid incumbent (a MAXIMIZE incumbent can never exceed the optimum).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.nlp_evaluator import NLPEvaluator
+from discopt._jax.primal_heuristics import is_qubo, qubo_local_search
+
+BENCH = Path(os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"))
+_CHIMERA = BENCH / "chimera_k64ising-01.nl"
+
+
+def _small_qubo(seed: int = 1, n: int = 12):
+    rng = np.random.default_rng(seed)
+    m = dm.Model("qubo")
+    x = [m.binary(f"x{i}") for i in range(n)]
+    expr = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            w = float(rng.integers(-3, 4))
+            if w:
+                expr = expr + w * x[i] * x[j]
+    m.maximize(expr)
+    return m
+
+
+def test_843_is_qubo_detection():
+    """``is_qubo`` accepts an unconstrained binary quadratic model and rejects
+    anything with constraints or non-binary variables."""
+    assert is_qubo(_small_qubo()) is True
+    # add a constraint -> not a QUBO
+    m = _small_qubo()
+    m.subject_to(sum(m._variables[0][()] for _ in range(1)) <= 5)  # any constraint
+    assert is_qubo(m) is False
+    # a continuous model -> not a QUBO
+    mc = dm.Model("c")
+    y = mc.continuous("y", lb=0.0, ub=1.0)
+    mc.maximize(y * y)
+    assert is_qubo(mc) is False
+
+
+def test_843_qubo_local_search_finds_optimum_small():
+    """On a small QUBO the local search reaches the brute-force optimum, and the value
+    is sound (a MAXIMIZE incumbent never exceeds the optimum)."""
+    m = _small_qubo(seed=2, n=12)
+    ev = NLPEvaluator(m)
+    x = qubo_local_search(m, evaluator=ev, deadline=None)
+    assert x is not None and np.all(np.isin(x, [0.0, 1.0]))
+    got = -float(ev.evaluate_objective(x))  # true = -internal (MAXIMIZE)
+    n = ev.n_variables
+    brute = max(
+        -float(ev.evaluate_objective(np.array([(k >> b) & 1 for b in range(n)], float)))
+        for k in range(1 << n)
+    )
+    assert abs(got - brute) < 1e-6, f"#843: local search {got} != optimum {brute}"
+
+
+def test_843_small_qubo_full_solve_seeds_incumbent(monkeypatch):
+    """End-to-end: with the flag on, the QUBO primal seeds the incumbent and the solve
+    certifies the optimum — soundly (obj <= optimum)."""
+    monkeypatch.setenv("DISCOPT_QUBO_PRIMAL", "1")
+    m = _small_qubo(seed=3, n=10)
+    ev = NLPEvaluator(m)
+    nn = ev.n_variables
+    brute = max(
+        -float(ev.evaluate_objective(np.array([(k >> b) & 1 for b in range(nn)], float)))
+        for k in range(1 << nn)
+    )
+    r = m.solve(time_limit=15)
+    assert r.objective is not None, "#843: QUBO primal produced no incumbent"
+    assert r.objective <= brute + 1e-4, f"#843: unsound incumbent {r.objective} > optimum {brute}"
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+@pytest.mark.skipif(not _CHIMERA.exists(), reason="chimera_k64ising-01.nl (corpus) absent")
+def test_843_qubo_primal_incumbent_on_chimera():
+    """chimera-01: the QUBO local search lands a real feasible incumbent (was NONE),
+    strictly better than the trivial obj-0 floor and sound (<= optimum 24.3)."""
+    m = dm.from_nl(str(_CHIMERA))
+    ev = NLPEvaluator(m)
+    x = qubo_local_search(m, evaluator=ev, deadline=None)
+    assert x is not None and np.all(np.isin(x, [0.0, 1.0]))
+    true_obj = -float(ev.evaluate_objective(x))
+    assert true_obj > 1.0, f"#843: chimera incumbent {true_obj} not better than the trivial floor"
+    assert true_obj <= 24.3 + 1e-3, f"#843: unsound chimera incumbent {true_obj} > optimum 24.3"


### PR DESCRIPTION
Builds the real Ising/QUBO primal #843 asked for. chimera_k64ising is an **unconstrained binary QUBO** (1192 binary vars, 0 constraints, indefinite MAXIMIZE Ising) that returned **no incumbent** — the dense B&B never lands a good binary point and the #827 trivial seed only gave the useless all-zeros floor.

## What
- **`primal_heuristics.qubo_local_search`** — greedy-1opt + tabu on the quadratic form. A 1-flip's Δ is `δ·g + ½·H_kk` with an O(nnz) incremental gradient update; tabu (aspiration override on a new global best) escapes the shallow local optima plain greedy sticks in. The constant Hessian is built from the **sparse** structure+values (O(nnz)), not the dense `evaluate_hessian` (a ~3.5s JAX dense n×n eval). Deadline-aware, multi-start, always runs the first pass.
- **Wired** into `solve_model` behind `DISCOPT_QUBO_PRIMAL` (default off), with a **JAX-free** inline QUBO structural gate so importing the JAX heuristic never touches the LP/MILP cold-start path.

## Soundness
An unconstrained QUBO has no feasibility to violate — any binary point is a valid incumbent (a MAXIMIZE incumbent can never exceed the optimum), so the dual bound / certificate are untouched. The entry experiment also **cleared a false alarm**: `evaluate_objective` returns the internal minimize-form (negated for MAXIMIZE); the `.nl` parser is correct.

## Verification
- small QUBO → finds the **brute-force optimum**; full solve → optimal + sound.
- **chimera-01 → incumbent 7.2** (was *none*), sound (≤ opt 24.3).
- **cold-start 4/4 pass** with `DISCOPT_QUBO_PRIMAL=1`; `pytest -m smoke` **831 passed**; ruff/mypy clean.

## Scope note
`Contributes to #843` (opt-in). The incumbent is modest — chimera is the D-Wave hard-Ising topology, designed to defeat local search (SCIP needs exact B&B, 18.7s). chimera's *full solve* remains slow (the orthogonal #845 throughput issue), so the incumbent aids pruning but doesn't make chimera fast. Graduating to default-on for the QUBO structure (low risk — it only fires on QUBOs) is a clean follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
