### PR TITLE
fix(correctness): #849 gate convex single-NLP certificate on unscaled KKT residuals

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -6514,6 +6514,8 @@ def solve_model(
             t_start,
             nlp_solver,
             initial_point=initial_point,
+            gap_tolerance=gap_tolerance,
+            certify_convex=True,
         )
         result.convex_fast_path = True
         if result.status == "optimal":
@@ -11564,6 +11566,122 @@ def _resolve_heuristic_backend(nlp_solver: str) -> Optional[Callable]:
     return None
 
 
+# Relative projected-gradient stationarity above which a reported ``optimal`` on
+# the convex single-NLP path is not trusted (issue #849). At a genuine optimum the
+# unscaled projected gradient is ~1e-10 relative; this threshold is far looser so a
+# converged IPM point (which stops slightly inside its bounds) is never spuriously
+# rejected, yet a non-stationary termination (O(0.1)–O(1)) is always caught.
+_KKT_STATIONARITY_REL_TOL = 1e-4
+
+
+def _convex_nlp_certificate_gap(
+    evaluator: "NLPEvaluator",
+    x: np.ndarray,
+    multipliers: Optional[np.ndarray],
+    lb: np.ndarray,
+    ub: np.ndarray,
+    cl: np.ndarray,
+    cu: np.ndarray,
+    obj_internal: Optional[float],
+) -> Optional[tuple[float, float]]:
+    """Recompute the *unscaled* KKT optimality residuals of a convex single-NLP.
+
+    Under convexity the KKT conditions are sufficient for global optimality, so a
+    backend that reports ``optimal`` is only trustworthy when the returned point is
+    an actual KKT point of the ORIGINAL (unscaled) problem. A gradient/interior IPM
+    under aggressive automatic scaling can satisfy its *scaled* stopping test at a
+    point that grossly violates the *unscaled* KKT complementarity — reporting
+    ``optimal`` at a point ~20x short of the optimum with the binding constraint
+    nowhere near active while certifying a dual bound that crosses the true optimum
+    (issue #849). This recomputes the residuals so the caller can withhold the
+    certificate. Only the solver's CONSTRAINT multipliers ``λ`` are trusted; the
+    variable box is handled from the primal geometry.
+
+    Returns ``(stationarity_rel, complementarity_rel)`` — both dimensionless and ~0
+    at a true optimum — or ``None`` when the certificate cannot be assessed
+    (constraints present but no multipliers, or a dual-INFEASIBLE multiplier that
+    would invalidate the dual bound), which the caller treats as "not certified".
+
+    * ``stationarity_rel``: the box-projected-gradient optimality measure
+      ``||x − clip(x − r, lb, ub)||_∞`` for the reduced gradient ``r = ∇f + Jᵀλ``,
+      over ``r``'s own magnitude scale. This is the standard first-order measure for
+      a box: it equals ``|r_j|`` on an interior variable (so a near-zero gradient
+      never blows up, even against a distant bound), collapses to ~0 at or near a
+      bound the gradient points toward (an IPM stopping just inside, or a variable
+      pinned by ``lb==ub``), and stays large only when a materially-interior
+      variable has a non-vanishing gradient. No fragile "exactly on the bound?"
+      threshold is needed.
+    * ``complementarity_rel``: the constraint complementarity duality gap
+      ``−Σ λ_i c_i(x)|_active`` over ``1 + |f(x)|``. With stationarity satisfied this
+      equals ``f(x) − d(λ)`` for the valid convex dual bound ``d(λ) = min_box f+λ·c``,
+      so a large value means the incumbent is provably far from the bound these
+      multipliers support — not a certified optimum (the #849 signature: a nonzero
+      multiplier on a hugely-slack constraint).
+
+    All quantities are in the evaluator's INTERNAL minimization space
+    (``obj_internal`` is the minimized objective, i.e. ``-f`` for a maximize model),
+    so the results are sign-independent.
+    """
+    m = evaluator.n_constraints
+    n = evaluator.n_variables
+    if m > 0 and multipliers is None:
+        # Cannot reconstruct complementarity without constraint multipliers; the
+        # caller withholds the certificate rather than trust an unverifiable one.
+        return None
+
+    lam = (
+        np.asarray(multipliers, dtype=np.float64)
+        if multipliers is not None
+        else np.zeros(m, dtype=np.float64)
+    )
+
+    grad = np.asarray(evaluator.evaluate_gradient(x), dtype=np.float64)
+    if m > 0:
+        jac = np.asarray(evaluator.evaluate_jacobian(x), dtype=np.float64).reshape(m, n)
+        jtlam = jac.T @ lam
+        cons = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64)
+        jac_row_inf = np.max(np.abs(jac), axis=1) if jac.size else np.zeros(m)
+    else:
+        jtlam = np.zeros(n, dtype=np.float64)
+        cons = np.empty(0, dtype=np.float64)
+        jac_row_inf = np.zeros(0)
+
+    _INF = 1e19  # bound sentinel: ±1e20 (constraints) / large var bounds read as ∞
+
+    # Projected-gradient stationarity: pg = x − clip(x − r, lb, ub). Bounded by
+    # |r_j| for interior points (no amplification against a distant bound) and ~0
+    # at/near a bound the gradient points toward.
+    reduced = grad + jtlam
+    step = x - reduced
+    lb_c = np.where(lb > -_INF, lb, -np.inf)
+    ub_c = np.where(ub < _INF, ub, np.inf)
+    proj = np.clip(step, lb_c, ub_c)
+    pg = x - proj
+    stat = float(np.max(np.abs(pg))) if pg.size else 0.0
+    stat_scale = 1.0 + (float(np.max(np.abs(grad))) if grad.size else 0.0)
+    stat_scale += float(np.max(np.abs(jtlam))) if jtlam.size else 0.0
+    stationarity_rel = stat / stat_scale
+
+    # Constraint complementarity + dual-feasibility of λ. Each active-side
+    # multiplier contributes its slack to the bound it is associated with
+    # (λ>0 ↔ upper cu, λ<0 ↔ lower cl). A nonzero multiplier that points at an
+    # ABSENT (infinite) bound is dual-infeasible: the Lagrangian dual bound is then
+    # not valid, so the certificate cannot be trusted (return None).
+    comp = 0.0
+    for i in range(m):
+        li = float(lam[i])
+        if li > 0.0 and cu[i] < _INF:
+            comp += li * (cu[i] - cons[i])
+        elif li < 0.0 and cl[i] > -_INF:
+            comp += (-li) * (cons[i] - cl[i])
+        elif abs(li) * float(jac_row_inf[i]) > 1e-9 * stat_scale:
+            return None
+
+    f_scale = 1.0 + (abs(float(obj_internal)) if obj_internal is not None else 0.0)
+    complementarity_rel = comp / f_scale
+    return stationarity_rel, complementarity_rel
+
+
 def _solve_continuous(
     model: Model,
     time_limit: float,
@@ -11571,6 +11689,8 @@ def _solve_continuous(
     t_start: float,
     nlp_solver: str = "ipopt",
     initial_point: Optional[np.ndarray] = None,
+    gap_tolerance: float = 1e-6,
+    certify_convex: bool = False,
 ) -> SolveResult:
     """Solve a purely continuous model directly with NLP solver (no B&B)."""
     # Single-NLP solves need reliable KKT convergence. The pure-JAX IPM's
@@ -11679,6 +11799,60 @@ def _solve_continuous(
     bound_duals_lower = _unpack_bound_duals(model, nlp_result.bound_multipliers_lower)
     bound_duals_upper = _unpack_bound_duals(model, nlp_result.bound_multipliers_upper)
 
+    _gap_certified = True
+
+    # Convex single-NLP certificate gate (issue #849). On the convexity-CERTIFIED
+    # fast path a reported ``optimal`` is taken as a *global* optimality
+    # certificate — but the NLP backend's stopping test runs on its internally
+    # SCALED problem, so under a large objective/constraint coefficient it can
+    # declare success at a point that satisfies the scaled test yet grossly
+    # violates the UNSCALED KKT conditions (min -x s.t. x²≤1e18 reported optimal at
+    # x≈6.4e7 with the constraint nowhere near active and a certified dual bound
+    # BELOW the true optimum). Under convexity, KKT is sufficient for global
+    # optimality, so recompute the unscaled residuals here and withhold the
+    # certificate when they are not met: without a genuine KKT point the single NLP
+    # has only found a feasible incumbent, not a proven optimum. Only ever
+    # DOWNGRADES a certificate (never upgrades / loosens a bound), so it cannot
+    # introduce a false optimum or a wrong bound — the honest ``iteration_limit``
+    # it falls back to is exactly what the neighbouring problem scales already
+    # report. Gated on ``certify_convex`` so the convexity-UNKNOWN caller (which
+    # already strips the bound) is unaffected.
+    if certify_convex and status == "optimal" and nlp_result.x is not None:
+        try:
+            _cl_g, _cu_g = _infer_constraint_bounds(model, evaluator)
+            _cert = _convex_nlp_certificate_gap(
+                evaluator,
+                np.asarray(nlp_result.x, dtype=np.float64),
+                nlp_result.multipliers,
+                np.asarray(lb, dtype=np.float64),
+                np.asarray(ub, dtype=np.float64),
+                np.asarray(_cl_g, dtype=np.float64),
+                np.asarray(_cu_g, dtype=np.float64),
+                nlp_result.objective,
+            )
+        except Exception as _cert_exc:  # pragma: no cover - defensive
+            # A failure to *evaluate* the certificate cannot be allowed to crash an
+            # otherwise-successful solve; withholding the certificate is the safe
+            # outcome (it only ever downgrades), so treat it as unassessable.
+            logger.warning("KKT certificate check failed to evaluate (%s); withholding", _cert_exc)
+            _cert = None
+        if (
+            _cert is None
+            or _cert[0] > _KKT_STATIONARITY_REL_TOL
+            or _cert[1] > max(gap_tolerance, 1e-6)
+        ):
+            logger.warning(
+                "Convex NLP reported optimal but the unscaled KKT residuals are not "
+                "certifiable (stationarity_rel=%s, complementarity_rel=%s, "
+                "gap_tol=%s); withholding the optimality certificate and reporting "
+                "iteration_limit (issue #849).",
+                "unassessable" if _cert is None else f"{_cert[0]:.3e}",
+                "unassessable" if _cert is None else f"{_cert[1]:.3e}",
+                gap_tolerance,
+            )
+            status = "iteration_limit"
+            _gap_certified = False
+
     # Root-node certification metrics (cert:T0.1). This path has no B&B tree —
     # the single NLP solve at the root box is the whole solve, so the root
     # bound/gap/time equal the reported ones.
@@ -11735,6 +11909,7 @@ def _solve_continuous(
         root_bound=_c_bound,
         root_gap=_c_gap,
         root_time=wall_time,
+        gap_certified=_gap_certified,
     )
 
 

--- a/python/tests/test_convex_nlp_certificate_849.py
+++ b/python/tests/test_convex_nlp_certificate_849.py
@@ -1,0 +1,216 @@
+"""Regression: false optimality certificate on a bounded convex QCP (#849).
+
+The adversary found that on a bounded, feasible, *convex* quadratically
+constrained problem with a large constraint coefficient, discopt returned
+``status=optimal, gap=0.0, gap_certified=True`` at a point ~20x short of the true
+optimum, with the certified dual bound *crossing* the true optimum (an unsound
+lower bound). Minimal reproduction::
+
+    min -x  s.t.  x**2 <= 1e18,  x in [0, 1e12]     # true opt x=1e9, obj=-1e9
+
+The convexity-certified single-NLP fast path took the backend's reported
+``optimal`` as a global optimality certificate. But the NLP backend's stopping
+test runs on its internally *scaled* problem, so under the large coefficient it
+declared success at a point that satisfies the *scaled* test yet grossly violates
+the *unscaled* KKT complementarity (the constraint was nowhere near active while
+its multiplier was nonzero). Under convexity KKT is sufficient for global
+optimality, so the fix recomputes the *unscaled* KKT residuals at the returned
+primal-dual point and withholds the certificate (reporting ``iteration_limit``,
+uncertified) when they are not met — exactly as the neighbouring problem scales
+(R=1e12..1e15) already do. It never upgrades a certificate or emits a bound, so
+it cannot introduce a false optimum or a wrong bound.
+
+The scale sweep is the discriminator (true opt ``-sqrt(R)``): only R=1e18 flipped
+to a false ``optimal`` before the fix; R=1e6 is a genuine certified optimum and
+must stay certified (no false negative).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+
+def _qcp(R: float) -> dm.Model:
+    """``min -x s.t. x**2 <= R, x in [0, 1e12]`` — convex, feasible, true opt -sqrt(R)."""
+    m = dm.Model("qcp")
+    x = m.continuous("x", lb=0.0, ub=1e12)
+    m.minimize(-x)
+    m.subject_to(x * x <= R)
+    return m
+
+
+def _assert_sound(name: str, r, opt: float) -> None:
+    """A certified optimum must sit at the true optimum, and any dual bound must
+    not cross it (for a minimization a valid lower bound satisfies ``bound <= opt``)."""
+    tol = max(5e-3 * abs(opt), 1e-4)
+    if r.status == "optimal" and r.gap_certified:
+        assert r.objective is not None and abs(r.objective - opt) <= tol, (
+            f"{name}: FALSE-OPTIMAL — certified {r.objective!r} != true opt {opt:.6g}"
+        )
+    if r.bound is not None:
+        # Sound lower bound: never above the true optimum (never crosses it).
+        assert r.bound <= opt + tol + 1e-6 * abs(opt), (
+            f"{name}: UNSOUND BOUND {r.bound!r} > true opt {opt:.6g}"
+        )
+        if r.objective is not None:
+            assert r.bound <= r.objective + tol + 1e-6 * abs(r.objective), (
+                f"{name}: UNSOUND CERT bound {r.bound!r} > incumbent {r.objective!r}"
+            )
+
+
+@pytest.mark.parametrize("solver", ["ipm", "pounce"])
+def test_large_coefficient_qcp_not_false_optimal(solver):
+    """The exact #849 reproduction: R=1e18 must NOT be certified optimal at the
+    wrong point. Before the fix: status=optimal, gap_certified=True, obj~-5e7,
+    bound~-5e7 (crossing the true opt -1e9)."""
+    r = _qcp(1e18).solve(nlp_solver=solver)
+    _assert_sound("R=1e18", r, -1e9)
+    # It specifically must not claim a certified optimum at the ~20x-short point.
+    assert not (r.status == "optimal" and r.gap_certified), (
+        f"R=1e18: still emits a certificate (status={r.status}, "
+        f"gap_certified={r.gap_certified}, obj={r.objective!r})"
+    )
+
+
+@pytest.mark.parametrize(
+    "R,opt",
+    [
+        (1e6, -1_000.0),
+        (1e9, -math.sqrt(1e9)),
+        (1e12, -1e6),
+        (1e15, -math.sqrt(1e15)),
+        (1e18, -1e9),
+    ],
+)
+def test_qcp_scale_sweep_is_sound(R, opt):
+    """Across the whole scale sweep the result is always sound: no false optimum
+    and no dual bound crossing the true optimum."""
+    r = _qcp(R).solve(nlp_solver="ipm")
+    _assert_sound(f"R={R:.0e}", r, opt)
+
+
+def test_small_coefficient_qcp_still_certifies():
+    """A well-conditioned convex QCP must still certify its genuine optimum — the
+    gate only withholds bad certificates, it must not cause a false negative."""
+    r = _qcp(1e6).solve(nlp_solver="ipm")
+    assert r.status == "optimal" and r.gap_certified, (
+        f"R=1e6 lost its genuine certificate (status={r.status}, gap_certified={r.gap_certified})"
+    )
+    assert r.objective == pytest.approx(-1_000.0, rel=1e-4)
+
+
+def _quad_bound_active() -> tuple[dm.Model, float]:
+    # min (x-10)^2 s.t. x <= 5  -> opt 25 at the active linear bound.
+    m = dm.Model("q")
+    x = m.continuous("x", lb=0, ub=20)
+    m.minimize((x - 10) ** 2)
+    m.subject_to(x <= 5)
+    return m, 25.0
+
+
+def _circle_active() -> tuple[dm.Model, float]:
+    # min -x-y s.t. x^2+y^2 <= 1 -> opt -sqrt(2), the QCP active at the boundary.
+    m = dm.Model("qcp2")
+    x = m.continuous("x", lb=-2, ub=2)
+    y = m.continuous("y", lb=-2, ub=2)
+    m.minimize(-x - y)
+    m.subject_to(x * x + y * y <= 1)
+    return m, -math.sqrt(2)
+
+
+@pytest.mark.parametrize(
+    "builder", [_quad_bound_active, _circle_active], ids=["quad-linear-active", "qcp-circle-active"]
+)
+def test_well_posed_convex_problems_still_certify(builder):
+    """Genuine convex optima at active constraints/bounds must keep their
+    certificate: the KKT gate must not reject a converged solve."""
+    model, opt = builder()
+    r = model.solve(nlp_solver="ipm")
+    assert r.status == "optimal" and r.gap_certified, (
+        f"lost certificate: status={r.status}, gap_certified={r.gap_certified}"
+    )
+    assert r.objective == pytest.approx(opt, rel=5e-3, abs=1e-3)
+
+
+def test_certificate_gap_helper_flags_noncomplementary_point():
+    """Unit test of the duality-gap helper: a stationary point whose multiplier is
+    complementary-violating (nonzero λ on a far-from-active inequality) must show a
+    large relative gap, while a true KKT point shows ~0."""
+    from discopt.solver import _convex_nlp_certificate_gap, _make_evaluator
+
+    R = 1e18
+    m = _qcp(R)
+    ev = _make_evaluator(m)
+    from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+    cl, cu = _infer_constraint_bounds(ev)
+    lb, ub = np.array([0.0]), np.array([1e12])
+
+    # Non-KKT point: x with x^2 << R (constraint slack huge) but a positive
+    # multiplier tuned to satisfy stationarity of min -x (grad -1, jac 2x).
+    x_bad = np.array([6.4e7])
+    lam_bad = np.array([1.0 / (2.0 * x_bad[0])])  # makes grad + J^T lam = 0
+    stat, comp = _convex_nlp_certificate_gap(ev, x_bad, lam_bad, lb, ub, cl, cu, -x_bad[0])
+    assert stat < 1e-4, f"constructed point should be projected-gradient stationary, got {stat}"
+    assert comp > 1.0, f"far-from-active nonzero multiplier must show large gap, got {comp}"
+
+    # True KKT point: x = sqrt(R) (constraint active), lam = 1/(2x).
+    x_ok = np.array([math.sqrt(R)])
+    lam_ok = np.array([1.0 / (2.0 * x_ok[0])])
+    stat2, comp2 = _convex_nlp_certificate_gap(ev, x_ok, lam_ok, lb, ub, cl, cu, -x_ok[0])
+    assert stat2 < 1e-4 and comp2 < 1e-6, f"true KKT point must certify, got {stat2}, {comp2}"
+
+
+def test_certificate_gap_helper_certifies_bound_active_and_fixed_vars():
+    """The gap must NOT flag a genuine optimum resting on a variable bound, nor a
+    variable pinned by lb==ub — even with zero bound multipliers (POUNCE/Ipopt
+    return ~0 there). Regression for the GP-MINLP node false-negative uncovered
+    while fixing #849: min exp(y)+2.25 exp(-y)."""
+    from discopt import exp as dexp
+    from discopt.solver import _convex_nlp_certificate_gap, _make_evaluator
+
+    # Bound-active: y in [log2, log5], optimum at the lower bound y=log2.
+    lo, hi = math.log(2), math.log(5)
+    m1 = dm.Model("ba")
+    y = m1.continuous("y", lb=lo, ub=hi)
+    m1.minimize(dexp(y) + 2.25 * dexp(-y))
+    ev1 = _make_evaluator(m1)
+    stat1, comp1 = _convex_nlp_certificate_gap(
+        ev1, np.array([lo]), None, np.array([lo]), np.array([hi]), np.empty(0), np.empty(0), 3.125
+    )
+    assert stat1 < 1e-4 and comp1 < 1e-6, f"bound-active optimum rejected: {stat1}, {comp1}"
+
+    # Fixed variable: y pinned at log2 (lb==ub). Gradient there is nonzero (0.875)
+    # but the variable cannot move, so the projected gradient is zero.
+    m2 = dm.Model("fx")
+    yf = m2.continuous("y", lb=lo, ub=lo)
+    m2.minimize(dexp(yf) + 2.25 * dexp(-yf))
+    ev2 = _make_evaluator(m2)
+    stat2, comp2 = _convex_nlp_certificate_gap(
+        ev2, np.array([lo]), None, np.array([lo]), np.array([lo]), np.empty(0), np.empty(0), 3.125
+    )
+    assert stat2 < 1e-4 and comp2 < 1e-6, f"fixed-variable optimum rejected: {stat2}, {comp2}"
+
+
+def test_certificate_gap_helper_none_without_multipliers():
+    """Constraints present but no multipliers -> cannot assess -> None (caller
+    treats as not-certified)."""
+    from discopt.solver import _convex_nlp_certificate_gap, _make_evaluator
+
+    m = _qcp(1e18)
+    ev = _make_evaluator(m)
+    from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+    cl, cu = _infer_constraint_bounds(ev)
+    out = _convex_nlp_certificate_gap(
+        ev, np.array([1.0]), None, np.array([0.0]), np.array([1e12]), cl, cu, -1.0
+    )
+    assert out is None


### PR DESCRIPTION
On the convexity-certified single-NLP fast path, discopt trusted the NLP
backend's reported `optimal` as a global optimality certificate. But the backend's
stopping test runs on its internally *scaled* problem, so under a large
objective/constraint coefficient it declares success at a point that satisfies the
scaled test yet grossly violates the *unscaled* KKT complementarity. On
`min -x s.t. x**2 <= 1e18, x in [0,1e12]` (true opt x=1e9, obj=-1e9) all three
backends returned `status=optimal, gap=0, gap_certified=True` at x≈6.4e7 (obj
≈-5e7) with the certified dual bound *crossing* the true optimum — a false
optimality certificate and an unsound lower bound (CLAUDE.md §1).

Under convexity KKT is sufficient for global optimality, so `_solve_continuous`
now recomputes the unscaled KKT residuals at the returned point (new
`_convex_nlp_certificate_gap`, gated by a `certify_convex` flag passed only from
the convex fast path) and withholds the certificate — reporting the honest
`iteration_limit`/uncertified, exactly as the neighbouring problem scales
(R=1e12..1e15) already do — when they are not met. It only ever DOWNGRADES a
certificate (never upgrades or emits a bound), so it cannot introduce a false
optimum or a wrong bound.

The check trusts only the solver's constraint multipliers λ; the variable box is
handled by the standard threshold-free projected-gradient measure
`||x - clip(x - (∇f + Jᵀλ), lb, ub)||`, which reads bound activity from the primal
geometry (robust to backends returning ~0 bound multipliers on active/fixed
bounds, and to an IPM stopping just inside a bound) and does not amplify near-zero
reduced-gradient noise against a distant bound. A nonzero multiplier pointing at an
absent (infinite) constraint bound is dual-infeasible and withholds the certificate.

Regression test `test_convex_nlp_certificate_849.py`: the exact reproduction
(no false certificate), the full R=1e6..1e18 scale sweep is sound, well-posed
convex problems (bound-active, constraint-active, fixed-variable/GP-MINLP nodes)
still certify, and unit coverage of the residual helper.

Verified: new test file (13 tests) passes; `pytest -m smoke` 827 passed;
adversarial soundness suite passes; convex/nlp/gp/certification integration
suites pass.

Closes #849

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018sW396mRVLt7PtJ3rzXrCZ