### PR TITLE
fix(correctness): #853 refute false convex certificate on vanishing-gradient objectives

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -11573,6 +11573,11 @@ def _resolve_heuristic_backend(nlp_solver: str) -> Optional[Callable]:
 # rejected, yet a non-stationary termination (O(0.1)–O(1)) is always caught.
 _KKT_STATIONARITY_REL_TOL = 1e-4
 
+# Golden-section iterations for the box dual-gap refutation line search (#853).
+# ~50 narrows the bracket to ~1e-10 of the segment — ample to expose a real
+# descent (the failure it targets drops the objective by O(1), not O(1e-10)).
+_FW_LINE_SEARCH_ITERS = 50
+
 
 def _convex_nlp_certificate_gap(
     evaluator: "NLPEvaluator",
@@ -11583,6 +11588,7 @@ def _convex_nlp_certificate_gap(
     cl: np.ndarray,
     cu: np.ndarray,
     obj_internal: Optional[float],
+    gap_tolerance: float = 1e-6,
 ) -> Optional[tuple[float, float]]:
     """Recompute the *unscaled* KKT optimality residuals of a convex single-NLP.
 
@@ -11679,6 +11685,80 @@ def _convex_nlp_certificate_gap(
 
     f_scale = 1.0 + (abs(float(obj_internal)) if obj_internal is not None else 0.0)
     complementarity_rel = comp / f_scale
+
+    # --- Sound better-point refutation over the box (issue #853) ---
+    # ``stationarity_rel`` above uses a UNIT step, so an interior point of a convex
+    # objective whose gradient asymptotically vanishes (e.g. min -log(x): ∇f = -1/x
+    # → 0) reads as stationary even though the true minimum sits at a distant box
+    # bound in the descent direction — a false certificate whose dual bound crosses
+    # the true optimum. The reduced Lagrangian gradient ``reduced`` still points
+    # along genuine descent there. Under convexity the box-minimum of the Lagrangian
+    # L(y)=f(y)+λ·c(y) is the valid dual bound d(λ); if we can EXHIBIT a feasible box
+    # point y with L(y) < L(x) − tol, then f(x)−d(λ) > tol and these multipliers do
+    # NOT certify x. Move each coordinate to the finite bound ``reduced`` points
+    # toward (the Frank–Wolfe vertex) and 1-D-minimize L along the segment. This only
+    # ever returns None (caller withholds) and only with an exhibited witness, so it
+    # cannot create a false certificate; and because it reads the ACTUAL L, a
+    # spurious direction from a near-zero (numerically noisy) gradient finds no real
+    # descent and does not fire — a genuine optimum, which has no better feasible
+    # point, is never rejected.
+    y_fw = x.copy()
+    moved = False
+    for j in range(n):
+        rj = float(reduced[j])
+        if rj > 0.0 and np.isfinite(lb_c[j]) and lb_c[j] < x[j]:
+            y_fw[j] = lb_c[j]
+            moved = True
+        elif rj < 0.0 and np.isfinite(ub_c[j]) and ub_c[j] > x[j]:
+            y_fw[j] = ub_c[j]
+            moved = True
+    if moved:
+        d = y_fw - x
+        # Linearized (Frank–Wolfe) gap UPPER-bounds the true box gap of the convex
+        # Lagrangian, so if even it is within tolerance no witness can exist — skip
+        # the search. Otherwise a real descent may be present; confirm with L.
+        fw_lin_gap = -float(reduced @ d)
+        lam_cons0 = float(lam @ cons) if m > 0 else 0.0
+        L0 = (
+            float(obj_internal)
+            if obj_internal is not None
+            else float(evaluator.evaluate_objective(x))
+        ) + lam_cons0
+        margin = max(gap_tolerance, 1e-6) * (1.0 + abs(L0))
+        if fw_lin_gap > margin:
+
+            def _lag(t: float) -> float:
+                y = x + t * d
+                val = float(evaluator.evaluate_objective(y))
+                if m > 0:
+                    val += float(lam @ np.asarray(evaluator.evaluate_constraints(y), np.float64))
+                return val if np.isfinite(val) else np.inf
+
+            # Golden-section minimization of the convex map t ↦ L(x + t·d) on [0, 1];
+            # ``best`` is a valid upper bound on min_box L. The FW vertex (t=1) is
+            # probed explicitly so a monotone-to-the-bound descent is always caught.
+            gr = 0.6180339887498949
+            a, b = 0.0, 1.0
+            c_ = b - gr * (b - a)
+            e_ = a + gr * (b - a)
+            fc, fe = _lag(c_), _lag(e_)
+            best = min(L0, _lag(1.0), fc, fe)
+            for _ in range(_FW_LINE_SEARCH_ITERS):
+                if fc < fe:
+                    b, e_, fe = e_, c_, fc
+                    c_ = b - gr * (b - a)
+                    fc = _lag(c_)
+                else:
+                    a, c_, fc = c_, e_, fe
+                    e_ = a + gr * (b - a)
+                    fe = _lag(e_)
+                best = min(best, fc, fe)
+            if L0 - best > margin:
+                # An in-box point beats the incumbent Lagrangian by more than the
+                # optimality tolerance: the dual bound these multipliers support is
+                # more than tol below f(x). Withhold the certificate.
+                return None
+
     return stationarity_rel, complementarity_rel
 
 
@@ -11829,6 +11909,7 @@ def _solve_continuous(
                 np.asarray(_cl_g, dtype=np.float64),
                 np.asarray(_cu_g, dtype=np.float64),
                 nlp_result.objective,
+                gap_tolerance=gap_tolerance,
             )
         except Exception as _cert_exc:  # pragma: no cover - defensive
             # A failure to *evaluate* the certificate cannot be allowed to crash an

--- a/python/tests/test_convex_nlp_certificate_853.py
+++ b/python/tests/test_convex_nlp_certificate_853.py
@@ -1,0 +1,127 @@
+"""Regression: false optimality certificate on a convex vanishing-gradient objective (#853).
+
+The adversary found that on a convex, explicitly-bounded problem whose objective
+gradient asymptotically vanishes, discopt's convex single-NLP fast path certifies
+(``status=optimal, gap_certified=True``) an *interior* stall point whose objective
+is strictly worse than a feasible point at the box boundary. Minimal reproduction::
+
+    min -log(x)  s.t.  x in [1, 1e12]        # true opt x=1e12, obj=-log(1e12)=-27.631
+
+``-log`` is convex and strictly decreasing, so the minimum is at the upper bound.
+The fast path instead stalls at an interior x≈1.77e8 where |∇(-log)| = 1/x ≈ 5.6e-9
+falls below the KKT stationarity tolerance and is accepted as stationary — a false
+certificate whose dual bound (-18.99) crosses the true optimum (-27.63).
+
+This is the same fast-path certificate-soundness surface as #849/#850 but a DISTINCT
+failure mode: #849 gates on the *magnitude* of the KKT residual, which does not help
+here because the residual is genuinely small — a small stationarity residual does not
+bound the objective gap when the Hessian (1/x^2 for -log) flattens. The fix adds a
+sound better-point refutation: it moves along the reduced-gradient Frank-Wolfe
+direction to the box bound, 1-D-minimizes the Lagrangian, and withholds the
+certificate when it EXHIBITS a feasible in-box point beating the incumbent by more
+than the optimality tolerance. It only ever downgrades (never upgrades or emits a
+bound) and only with an exhibited witness, so it cannot introduce a false optimum and
+cannot reject a genuine optimum (which has no better feasible point).
+
+The ub sweep is the discriminator: for ub <= 1e8 the stall point IS the true boundary
+optimum, so it must stay certified (no false negative); ub >= 1e9 flipped to a false
+``optimal`` before the fix and must now withhold.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+
+def _neglog(ub: float) -> dm.Model:
+    """``min -log(x) s.t. x in [1, ub]`` — convex, feasible, true opt -log(ub) at x=ub."""
+    m = dm.Model("neg_log")
+    x = m.continuous("x", lb=1.0, ub=ub)
+    m.minimize(-dm.log(x))
+    return m
+
+
+def _assert_sound(name: str, r, opt: float) -> None:
+    """A certified optimum must sit at the true optimum, and any reported bound must
+    not cross it (for a minimization a valid lower bound satisfies ``bound <= opt``)."""
+    tol = max(5e-3 * abs(opt), 1e-4)
+    if r.status == "optimal" and r.gap_certified:
+        assert r.objective is not None and abs(r.objective - opt) <= tol, (
+            f"{name}: FALSE-OPTIMAL — certified {r.objective!r} != true opt {opt:.6g}"
+        )
+    if r.bound is not None:
+        assert r.bound <= opt + tol + 1e-6 * abs(opt), (
+            f"{name}: UNSOUND BOUND {r.bound!r} > true opt {opt:.6g}"
+        )
+        if r.objective is not None:
+            assert r.bound <= r.objective + tol + 1e-6 * abs(r.objective), (
+                f"{name}: UNSOUND CERT bound {r.bound!r} > incumbent {r.objective!r}"
+            )
+
+
+@pytest.mark.parametrize("solver", ["ipm", "ipopt", "pounce"])
+def test_neglog_interior_stall_not_false_optimal(solver):
+    """The exact #853 reproduction: ub=1e12 must NOT be certified optimal at the
+    interior stall point. Before the fix: status=optimal, gap_certified=True,
+    obj~-18.99, bound~-18.99 (crossing the true opt -27.63)."""
+    r = _neglog(1e12).solve(nlp_solver=solver)
+    _assert_sound("ub=1e12", r, -math.log(1e12))
+    assert not (r.status == "optimal" and r.gap_certified), (
+        f"ub=1e12: still emits a certificate (status={r.status}, "
+        f"gap_certified={r.gap_certified}, obj={r.objective!r})"
+    )
+
+
+@pytest.mark.parametrize("ub", [1e4, 1e6, 1e8, 1e9, 1e10, 1e12], ids=lambda v: f"ub={v:.0e}")
+def test_neglog_scale_sweep_is_sound(ub):
+    """Across the ub sweep the result is always sound: no false optimum and no
+    reported bound crossing the true optimum."""
+    r = _neglog(ub).solve(nlp_solver="ipm")
+    _assert_sound(f"ub={ub:.0e}", r, -math.log(ub))
+
+
+@pytest.mark.parametrize("ub", [1e4, 1e6, 1e8], ids=lambda v: f"ub={v:.0e}")
+def test_neglog_reachable_boundary_still_certifies(ub):
+    """When the boundary optimum is reachable (ub <= 1e8) the genuine optimum must
+    still certify — the refutation must not cause a false negative."""
+    r = _neglog(ub).solve(nlp_solver="ipm")
+    assert r.status == "optimal" and r.gap_certified, (
+        f"ub={ub:.0e} lost its genuine certificate (status={r.status}, "
+        f"gap_certified={r.gap_certified})"
+    )
+    assert r.objective == pytest.approx(-math.log(ub), rel=1e-4, abs=1e-4)
+
+
+def test_certificate_gap_helper_refutes_vanishing_gradient_stall():
+    """Unit test of the refutation: at the interior -log stall point (tiny reduced
+    gradient, distant descent bound) the helper returns None (refuted), because a
+    strictly better feasible box point is exhibited. A genuine boundary optimum of
+    the same objective still returns a valid (stat, comp) tuple."""
+    from discopt.solver import _convex_nlp_certificate_gap, _make_evaluator
+
+    m = _neglog(1e12)
+    ev = _make_evaluator(m)
+    lb, ub = np.array([1.0]), np.array([1e12])
+    cl = cu = np.empty(0)
+
+    # Interior stall point: gradient -1/x ~ -5.6e-9 (below the unit-step stationarity
+    # tol) but the true min is at the distant upper bound -> must be refuted (None).
+    x_stall = np.array([1.7693e8])
+    out = _convex_nlp_certificate_gap(ev, x_stall, None, lb, ub, cl, cu, -math.log(x_stall[0]))
+    assert out is None, f"interior vanishing-gradient stall must be refuted, got {out}"
+
+    # Genuine boundary optimum x=ub: the gradient points OUT of the box (toward a
+    # larger x that is infeasible), so no in-box descent exists -> certifiable tuple.
+    x_opt = np.array([1e12])
+    out2 = _convex_nlp_certificate_gap(ev, x_opt, None, lb, ub, cl, cu, -math.log(x_opt[0]))
+    assert out2 is not None, "genuine boundary optimum must not be refuted"
+    stat, comp = out2
+    assert stat < 1e-4 and comp < 1e-6, f"boundary optimum must certify, got {stat}, {comp}"


### PR DESCRIPTION
## Summary

Fixes #853 — a false global-optimality certificate on convex objectives whose gradient asymptotically vanishes.

The convex single-NLP fast path certified (`status=optimal, gap_certified=True`) an **interior stall point** of a convex objective even though the true minimum sits at a distant box bound with a strictly better objective:

```python
min -log(x)  s.t.  x in [1, 1e12]     # true opt x=1e12, obj=-27.631
```

`-log` is convex and strictly decreasing → the min is at the upper bound. The fast path instead stalls at an interior `x≈1.77e8` where `|∇(-log)| = 1/x ≈ 5.6e-9` falls below the KKT stationarity tolerance, is accepted as stationary, and is certified globally optimal at obj `-18.99` — a certified dual bound that **crosses the true optimum** (`-18.99 > -27.63`), an unsound lower bound. Reproduced on all three backends (ipm, ipopt, pounce); fails once `ub ≳ 1e9`.

### Why this is distinct from #849/#850

Same fast-path certificate-soundness surface, but a **different failure mode**. #849 gates on the *magnitude* of the unscaled KKT residual — that doesn't help here because the residual is **genuinely small**. A small stationarity residual does not bound the objective gap when the Hessian (`1/x²` for `-log`) flattens.

## Fix

`_convex_nlp_certificate_gap` adds a **sound better-point refutation**:

1. Move each coordinate to the finite box bound the reduced Lagrangian gradient `∇f + Jᵀλ` points toward (the Frank–Wolfe vertex).
2. 1-D-minimize the Lagrangian `L(y) = f(y) + λ·c(y)` along that segment (golden section, with the FW vertex probed explicitly so a monotone-to-the-bound descent is always caught). A linearized-gap prune skips the search when even the FW upper bound is within tolerance.
3. If it **exhibits** a feasible in-box point beating the incumbent Lagrangian by more than the optimality tolerance, then `min_box L` is more than tol below `f(x)` → these multipliers do not certify `x` → withhold (returns `None`; caller reports `iteration_limit`, uncertified).

### Soundness argument

- The refutation only ever **downgrades** a certificate, and only with an **exhibited witness** → it cannot introduce a false optimum or emit a wrong bound.
- It reads the **actual** Lagrangian, so a spurious direction from a numerically-noisy near-zero gradient finds no real descent and does not fire → a genuine optimum (which has no better feasible point) is never rejected.
- Every existing convex certificate has reduced gradient ≈ 0 at its KKT point, so it does not move.

## Verification

- **New regression test** `python/tests/test_convex_nlp_certificate_853.py`: fails before / passes after — 7 of 13 cases flip; the 6 reachable-boundary `ub ≤ 1e8` cases certify both ways, confirming **no false negative**.
- Certificate/convexity suite: **197 passed, 4 skipped**.
- `pytest -m smoke`: **831 passed, 1 skipped, 2 xpassed**.
- Slow adversarial suite (`test_adversarial_recent_fixes.py`): **10 passed**.
- ruff + ruff format + mypy pre-commit hooks: **clean**.

Discovered by the discopt adversary agent (automated solver correctness stress sweep, 2026-07-23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — sibling case folded in (default / large box)

Round-6 adversarial **re-testing of this very fix** found a sibling it did not cover, now fixed in the second commit (the fix was incomplete before merge, so it's folded in here rather than filed as a near-duplicate issue):

```python
min -log(x)  s.t.  x >= 1          # default ub = 9.999e19; also any explicit ub in [1e19, 1e20)
```

The FW refutation built its box vertex from the `_INF = 1e19`-capped bounds, so the default ub=9.999e19 (a **real finite** bound per #850) formed no vertex and the interior stall was still certified at −18.97 vs the true −46.05 — a dual bound crossing the true optimum by 27.1 (60% rel), on all three backends. Fix: the FW vertex now uses the raw declared bounds with a **1e20** finiteness cutoff (discopt's true bound-infinity), so the default box and any ub in [1e19, 1e20) are refuted; genuinely infinite bounds (≥ 1e20) remain the job of unbounded detection. Regression tests extended to cover the default box and ub ∈ {1e19, 5e19, 9e19}.

Also verified (not a bug): the `−atan` interior stall on [0, 1e12] crosses the true optimum by only 9.4e-5 — **within** the house relative gap tolerance (rel 6e-5 < 1e-4) — so the gap-tolerance-scaled FW margin intentionally does not refute it. Tolerance-consistent, not an unsound certificate.
