### PR TITLE
chore(deps): bump pounce-solver minimum to >=0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,10 @@ The release procedure that produces these entries is documented in
 
 ### Changed
 
+- **`pounce-solver` minimum raised to `>=0.9`** (`chore(deps)`). Bumps the core
+  dependency (and the back-compat `[pounce]` alias extra) from `>=0.8`; discopt's
+  usage is unaffected.
+
 - **OBBT-on-auxiliaries reverse-FBBT cascade graduated default-ON** (`perf`, #208).
   The root branch-and-reduce fixpoint now propagates OBBT-tightened auxiliary
   (product/ratio) column bounds back onto the original variables through the

--- a/docs/design/solver-review.md
+++ b/docs/design/solver-review.md
@@ -48,7 +48,7 @@ GAMS at once, built on machinery that already exists (the exporters).
 
 | Engine | Language | Role | Availability |
 |---|---|---|---|
-| **POUNCE** | Rust (Ipopt port) | All production LP/QP/NLP relaxation solves; node solves in the self-hosted B&B | **Core dep** (`pounce-solver>=0.3`, `pyproject.toml:31`) |
+| **POUNCE** | Rust (Ipopt port) | All production LP/QP/NLP relaxation solves; node solves in the self-hosted B&B | **Core dep** (`pounce-solver>=0.9`, `pyproject.toml:31`) |
 | **discopt B&B** | Rust tree + JAX McCormick/relaxations | Integer & spatial branch-and-bound, presolve/FBBT, OBBT, cuts (cover/clique/GMI/MIR), crossover | Core |
 | **HiGHS** | C++ (via `highspy`) | LP/MILP matrix solves; CI correctness oracle (QP/MIQP routing removed, #359) | Optional extra `highs` (`pyproject.toml:45`) |
 | **cyipopt / IPOPT** | C++ | NLP node/continuous solves | Optional extra `ipopt` (`pyproject.toml:44`) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jaxlib>=0.4",
     "numpy>=1.24",
     "scipy>=1.10",
-    "pounce-solver>=0.8",
+    "pounce-solver>=0.9",
 ]
 
 [project.urls]
@@ -40,7 +40,7 @@ Issues = "https://github.com/jkitchin/discopt/issues"
 [project.optional-dependencies]
 # POUNCE is now a core dependency (the default NLP/IPM engine); this extra is
 # kept as a no-op alias for back-compat with `pip install discopt[pounce]`.
-pounce = ["pounce-solver>=0.8"]
+pounce = ["pounce-solver>=0.9"]
 ipopt = ["cyipopt>=1.4"]
 cutest = ["pycutest>=1.8.0"]
 # GAMS solver link: the expert-level GAMS Python API (GMO/GEV). Ships with a


### PR DESCRIPTION
## Summary

Bumps the `pounce-solver` minimum from `>=0.8` to `>=0.9`.

- `pyproject.toml`: core dependency pin and the back-compat `[pounce]` alias extra both raised to `>=0.9`.
- `docs/design/solver-review.md`: synced the stale `pounce-solver>=0.3` reference (which cites `pyproject.toml:31`) to the current pin.
- `CHANGELOG.md`: recorded under **[Unreleased] → Changed**, matching the prior #633 bump entry.

pounce-solver 0.9.0 is published on PyPI (releases: 0.2.0 … 0.9.0). discopt's usage of pounce is unaffected by the bump.

## Verification

- `pyproject.toml` parses; the new pin is satisfied by the installed pounce-solver 0.9.0.
- A pounce-backed solve returns the correct optimum (`min (x-2)² on [0,5]` → `optimal`, `0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
