### PR TITLE
chore: post-release bump to 0.7.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "discopt"
-version = "0.7.0"
+version = "0.7.1.dev0"
 description = "Hybrid MINLP solver combining Rust and JAX"
 requires-python = ">=3.10"
 authors = [{name = "John Kitchin"}]

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -25,7 +25,7 @@ solvers
     NLP solver backends: POUNCE (pure-Rust Ipopt port), pure-JAX IPM (vmap batch), cyipopt (Ipopt).
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1.dev0"
 
 # Allow external distributions (e.g. the ``discopt-aggregation`` plugin) to
 # contribute submodules under the ``discopt`` namespace from a separate location


### PR DESCRIPTION
## Summary

Post-release version bump per RELEASE.md §12, following the **v0.7.0** release ([PyPI](https://pypi.org/project/discopt/0.7.0/), [GitHub Release](https://github.com/jkitchin/discopt/releases/tag/v0.7.0)).

- `pyproject.toml` + `python/discopt/__init__.py`: `0.7.0` → **`0.7.1.dev0`**, so commits landing on `main` after the tag aren't stamped with the released version.
- `CITATION.cff` intentionally **stays at `0.7.0`** (tracks the released version; Zenodo derives from the git tag).
- No CHANGELOG change needed — the fresh `## [Unreleased]` header and `v0.7.0...HEAD` compare footnote were already added during the v0.7.0 prep.

Verified: `python -c "import discopt; print(discopt.__version__)"` → `0.7.1.dev0`. pre-commit (ruff / ruff-format / mypy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
