### PR TITLE
fix(correctness): #866 repr QP extractor dropped the quadratic term (false optimum)

### DIFF
--- a/python/discopt/_jax/problem_classifier.py
+++ b/python/discopt/_jax/problem_classifier.py
@@ -1060,6 +1060,50 @@ def _extract_qp_data_from_repr(model: Model) -> QPData:
     for j in range(n_orig):
         c_vec[j] = f_ej[j] - d - 0.5 * Q[j, j]
 
+    # --- Verify the probes actually recovered the objective (#866) ---
+    # Every formula above is an exact identity in real arithmetic but a difference
+    # of nearly-equal floats in practice: ``Q[j,j] = f(e_j) + f(-e_j) - 2d``
+    # cancels catastrophically once the constant term dwarfs the quadratic
+    # coefficient. On ``min (x - 1e10)**2`` (d = 1e20, ulp(1e20) ~ 16384) the unit
+    # probes lose the ``+1`` entirely and this returns **Q = 0** — the objective
+    # silently becomes linear. That produced a CERTIFIED optimum of -9e20 for a
+    # sum of squares (issue #866): a false optimum, the worst error class
+    # (CLAUDE.md §1), on the default path.
+    #
+    # So do not trust the probes: re-evaluate the recovered quadratic against the
+    # model's own objective at a few scale-aware points and raise if it disagrees.
+    # Raising hands the dispatcher on to the next extractor — the autodiff path
+    # recovers Q = 2, c = -2e10 exactly here — so a bad extraction degrades to a
+    # slower-but-correct one instead of a wrong answer.
+    # Probe near the box's own magnitude: a unit probe cannot expose the
+    # cancellation on a model whose interesting scale is 1e10.
+    _probe_scale = 1.0
+    for _v in getattr(model, "_variables", []):
+        for _b in (getattr(_v, "lb", None), getattr(_v, "ub", None)):
+            if _b is None:
+                continue
+            _arr = np.asarray(_b, dtype=np.float64).ravel()
+            _fin = _arr[np.isfinite(_arr)]
+            if _fin.size:
+                _probe_scale = max(_probe_scale, min(float(np.max(np.abs(_fin))), 1e12))
+    _rng = np.random.default_rng(0)
+    for _k in range(3):
+        _pt = (_rng.random(n_orig) * 2.0 - 1.0) * _probe_scale
+        _recovered = 0.5 * float(_pt @ Q @ _pt) + float(c_vec @ _pt) + d
+        # Reuse the SAME evaluator the probes above used, so the cross-check is
+        # always available. (An earlier draft reached for ``model._nl_repr``, which
+        # is absent for API-built models, and the check silently skipped itself —
+        # the very failure mode this guard exists to catch.)
+        _truth = float(repr_.evaluate_objective(_pt))
+        if not np.isfinite(_recovered) or not np.isfinite(_truth):
+            continue
+        if abs(_recovered - _truth) > 1e-6 * (1.0 + abs(_truth)):
+            raise _NotQuadraticError(
+                "repr probe extraction did not reproduce the objective "
+                f"(recovered {_recovered!r} vs true {_truth!r}); the probe "
+                "differences cancelled — falling through to a stabler extractor"
+            )
+
     # Extract constraints (same as LP)
     lp_data = _extract_lp_data_from_repr(model)
     n_slack = lp_data.c.shape[0] - n_orig

--- a/python/tests/test_866_qp_extraction_false_optimum.py
+++ b/python/tests/test_866_qp_extraction_false_optimum.py
@@ -1,0 +1,95 @@
+"""#866: the repr QP extractor dropped the quadratic term at large coefficient scale.
+
+`_extract_qp_data_from_repr` recovers the objective by unit probes::
+
+    d = f(0);   Q[j,j] = f(e_j) + f(-e_j) - 2d;   c_j = f(e_j) - d - 0.5*Q[j,j]
+
+Each identity is exact in real arithmetic and a difference of nearly-equal floats
+in practice. On ``min (x - 1e10)**2`` the constant term is 1e20, whose ulp is
+~16384, so the ``+1`` from ``x**2`` is lost in rounding and the extractor returns
+**Q = 0** — the objective silently becomes linear.
+
+Measured before the fix::
+
+    min (x - 1e10)**2  s.t.  x in [1, 1e11]
+      -> status=optimal, objective=-8.9999989761e+20, gap_certified=True
+      -> returned x = 5.0e10, whose TRUE objective is 1.6e21
+      -> true optimum is 0.0 at x = 1e10
+
+A **certified negative objective for a sum of squares** (CLAUDE.md §1), on the
+default path. At wider boxes the same corruption instead produced ``unbounded``.
+
+The fix does not try to make the cancelling probes accurate — it checks them. The
+recovered ``(Q, c, d)`` is re-evaluated against the model's own objective at
+box-scale points, and a disagreement raises so the dispatcher falls through to the
+autodiff extractor, which recovers ``Q=2, c=-2e10`` exactly here. A bad extraction
+now degrades to a slower-but-correct one instead of a wrong answer.
+
+Residual (documented, not a regression): the reported objective can still be off by
+about one ulp of the constant term (±16384 against 1e20) because the *expanded*
+quadratic form cancels in float64. The returned point is correct — its true
+objective is ~1e-11 — so this is report-level noise at 1.6e-16 relative, not a
+dropped term.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt._jax.problem_classifier import extract_qp_data  # noqa: E402
+
+
+def _model(ub: float):
+    """``min (x - 1e10)**2`` on ``[1, ub]`` — convex, true optimum 0.0 at x=1e10."""
+    m = dm.Model("shifted_square")
+    x = m.continuous("x", lb=1.0, ub=ub)
+    m.minimize((x - 1e10) ** 2)
+    return m, x
+
+
+def test_extraction_recovers_the_quadratic_term():
+    """The dispatched extractor must not lose ``x**2``. Pre-fix this returned
+    ``Q=[0.]`` and a linear objective."""
+    data = extract_qp_data(_model(1e11)[0])
+    q = float(np.asarray(data.Q).ravel()[0])
+    c = float(np.asarray(data.c).ravel()[0])
+    assert q == pytest.approx(2.0, rel=1e-9), f"quadratic term dropped: Q={q}"
+    assert c == pytest.approx(-2e10, rel=1e-9), f"linear term corrupted: c={c}"
+
+
+@pytest.mark.parametrize("ub", [2e10, 1e11, 1e12, 1e14, 1e16, 1e18, 1e19])
+def test_no_false_optimum_and_no_false_unbounded(ub):
+    """Across the scale sweep: never ``unbounded`` (the model is bounded and
+    feasible), and never a grossly negative objective for a sum of squares."""
+    m, _x = _model(ub)
+    r = m.solve(time_limit=30)
+    assert r.status != "unbounded", (
+        f"ub={ub:.0e}: FALSE UNBOUNDED on a bounded, feasible model (true optimum 0.0)"
+    )
+    if r.objective is not None:
+        # A square is >= 0. Allow ulp-of-1e20 noise from the expanded QP form, but
+        # nothing on the scale of the pre-fix -9e20.
+        assert r.objective > -1e6, f"ub={ub:.0e}: certified {r.objective!r} for a sum of squares"
+
+
+@pytest.mark.parametrize("ub", [2e10, 1e11, 1e12, 1e16, 1e19])
+def test_returned_point_is_the_true_minimizer(ub):
+    """The strongest check, and the one the pre-fix solver failed hardest: the
+    returned point must actually minimize the true objective. Pre-fix it returned
+    x=5e10 (true objective 1.6e21) for ub=1e11."""
+    m, x = _model(ub)
+    r = m.solve(time_limit=30)
+    if r.objective is None:
+        pytest.skip("no incumbent returned")
+    x_val = float(np.asarray(r.value(x)).ravel()[0])
+    true_obj = (x_val - 1e10) ** 2
+    assert true_obj < 1.0, (
+        f"ub={ub:.0e}: returned x={x_val!r} has true objective {true_obj!r}, "
+        "not the minimizer (true optimum 0.0 at x=1e10)"
+    )


### PR DESCRIPTION
Closes #866 — which turned out to be far worse than filed.

## The bug

`_extract_qp_data_from_repr` recovers the objective by **unit probes**:

```
d = f(0);   Q[j,j] = f(e_j) + f(-e_j) - 2d;   c_j = f(e_j) - d - 0.5*Q[j,j]
```

Exact in real arithmetic; a difference of nearly-equal floats in practice. On `min (x-1e10)**2` the constant is `1e20`, whose **ulp is ~16384**, so the `+1` contributed by `x²` vanishes in rounding and the extractor returns **`Q = 0`** — the objective silently becomes linear.

**On the default path, no flags:**

```
min (x - 1e10)**2   s.t.  x in [1, 1e11]

status=optimal   objective=-8.9999989761e+20   gap_certified=True
returned x = 5.0e10,  whose TRUE objective is 1.6e21
true optimum is 0.0 at x = 1e10
```

A **certified negative objective for a sum of squares** (CLAUDE.md §1). The reported value is exactly `-2e10*x + 1e20` — the objective with `x²` deleted. At wider boxes (≥1e16) the same corruption instead produced `unbounded` on a bounded feasible model, which is the symptom originally filed.

The three extractors disagreed, and the broken one wins dispatch:

| extractor | Q | c | |
|---|---|---|---|
| `_extract_qp_data_from_repr` | **[0.]** | −1.9999998e10 | ← used |
| `extract_qp_data_algebraic` | raises `_NotQuadraticError` | | bails on `x**2` |
| `_extract_qp_data_autodiff` | **[2.]** | **[−2e10]** | ← correct |

## Fix

Don't try to make cancelling probes accurate — **check them**. The recovered `(Q, c, d)` is re-evaluated against the model's own objective at box-scale points; a disagreement raises so the dispatcher falls through to the autodiff extractor. A bad extraction degrades to a slower-but-correct one instead of a wrong answer.

**After:** extraction recovers `Q=2, c=-2e10`; every box in the sweep returns `optimal` (no `unbounded`), and every returned point is the true minimizer `x≈1e10` with true objective `1e-11..1e-8` — versus `x=5e10` / `1.6e21` before.

## Documented residual

The reported objective can still be off by ~one ulp of the constant (±16384 against 1e20) because the **expanded** quadratic form cancels in float64. The returned point is correct, so this is report-level noise at 1.6e-16 relative — not a dropped term.

## Verification

- **13 new tests, 10 of which fail before the fix**
- QP/classifier suites — 169 passed
- `pytest -m smoke` — **831 passed**, 1 skipped, 2 xpassed
- ruff + format + mypy clean

One process note: the guard's first draft reached for `model._nl_repr`, absent for API-built models, so it **silently skipped itself** — the exact failure mode it exists to catch. It now reuses the same `repr_` the probes use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
