### PR TITLE
fix(correctness): LP presolve fabricated bounds from the INF sentinel

### DIFF
--- a/crates/discopt-core/src/lp/simplex/presolve.rs
+++ b/crates/discopt-core/src/lp/simplex/presolve.rs
@@ -135,6 +135,31 @@ pub fn tighten_bounds_csc(
     }
 }
 
+/// A column's contribution `a_ij * x_j` over `[lo_j, hi_j]`, as
+/// `(cmin, cmin_is_infinite, cmax, cmax_is_infinite)`.
+///
+/// The infinity flags are derived from the **bounds**, never from the products.
+/// `INF` is a sentinel (1e20), not a true infinity, so `a_ij * hi_j` for an
+/// unbounded column is an ordinary finite number whenever `|a_ij| < 1` — e.g.
+/// `-0.5 * 1e20 = -5e19`, which fails a `<= -INF` test and is therefore booked as
+/// a *finite* activity. That is unsound twice over: the row's activity range is no
+/// longer recognised as unbounded, and the huge magnitude then annihilates every
+/// smaller term in the running sum (`ulp(5e19) = 8192`), so the residual
+/// `sum - term` comes back as `0.0` instead of its true value. On gear4's node LP
+/// that fabricated the tightening `x >= 35.2244` on a column whose optimal value is
+/// `0`, cutting the optimum out of the box and turning a `0.0` LP optimum into a
+/// certified-`optimal` `184279.32`.
+#[inline]
+fn contrib(aij: f64, lo_j: f64, hi_j: f64) -> (f64, bool, f64, bool) {
+    let lo_inf = lo_j <= -INF;
+    let hi_inf = hi_j >= INF;
+    if aij > 0.0 {
+        (aij * lo_j, lo_inf, aij * hi_j, hi_inf)
+    } else {
+        (aij * hi_j, hi_inf, aij * lo_j, lo_inf)
+    }
+}
+
 /// One FBBT round over a single row, given its nonzeros `(col, coeff)`. Mutates
 /// `lo`/`hi` in place; returns `Some(changed)` or `None` if the box was proven empty.
 /// Matrix-representation-independent — the dense and CSC entries differ ONLY in how
@@ -154,38 +179,41 @@ fn fbbt_row(
     let mut sum_max_finite = 0.0;
     let mut n_min_inf = 0usize;
     let mut n_max_inf = 0usize;
+    // Largest magnitude entering the running sums. Floating-point accumulation
+    // error is ~eps * max_term, and each residual below is formed by SUBTRACTING
+    // one term from that sum, so this sets the absolute error scale of every
+    // derived bound. See `res_err`.
+    let mut max_abs_term = b_i.abs();
     for &(j, aij) in row_nz {
         if aij == 0.0 {
             continue;
         }
-        let (cmin, cmax) = if aij > 0.0 {
-            (aij * lo[j], aij * hi[j])
-        } else {
-            (aij * hi[j], aij * lo[j])
-        };
-        if cmin <= -INF {
+        let (cmin, cmin_inf, cmax, cmax_inf) = contrib(aij, lo[j], hi[j]);
+        if cmin_inf {
             n_min_inf += 1;
         } else {
             sum_min_finite += cmin;
+            max_abs_term = max_abs_term.max(cmin.abs());
         }
-        if cmax >= INF {
+        if cmax_inf {
             n_max_inf += 1;
         } else {
             sum_max_finite += cmax;
+            max_abs_term = max_abs_term.max(cmax.abs());
         }
     }
+    // Error budget for `sum - term`. A residual is only meaningful to within the
+    // rounding error already baked into the sum; widening each derived bound by
+    // this keeps the contraction sound when a legitimately large (but finite)
+    // bound swamps the smaller terms. Negligible in the normal case: for terms of
+    // order 1e3 this is ~2e-13.
+    let res_err = 8.0 * f64::EPSILON * max_abs_term;
 
     for &(k, aik) in row_nz {
         if aik == 0.0 {
             continue;
         }
-        let (ck_min, ck_max) = if aik > 0.0 {
-            (aik * lo[k], aik * hi[k])
-        } else {
-            (aik * hi[k], aik * lo[k])
-        };
-        let k_min_inf = ck_min <= -INF;
-        let k_max_inf = ck_max >= INF;
+        let (ck_min, k_min_inf, ck_max, k_max_inf) = contrib(aik, lo[k], hi[k]);
 
         let res_min_finite = n_min_inf - (k_min_inf as usize) == 0;
         let res_max_finite = n_max_inf - (k_max_inf as usize) == 0;
@@ -193,12 +221,12 @@ fn fbbt_row(
         let mut term_ub = INF;
         if res_min_finite {
             let res_min = sum_min_finite - if k_min_inf { 0.0 } else { ck_min };
-            term_ub = b_i - res_min;
+            term_ub = b_i - res_min + res_err;
         }
         let mut term_lb = -INF;
         if res_max_finite {
             let res_max = sum_max_finite - if k_max_inf { 0.0 } else { ck_max };
-            term_lb = b_i - res_max;
+            term_lb = b_i - res_max - res_err;
         }
 
         let (mut new_lo, mut new_hi) = if aik > 0.0 {

--- a/python/tests/test_lp_presolve_infinite_bound.py
+++ b/python/tests/test_lp_presolve_infinite_bound.py
@@ -1,0 +1,125 @@
+"""LP presolve FBBT must not fabricate bounds from the ``INF`` sentinel.
+
+``crates/discopt-core/src/lp/simplex/presolve.rs`` propagates row activity with
+"infinity bookkeeping". It used to decide whether a column's contribution
+``a_ij * x_j`` was unbounded by testing the **product** against the sentinel
+``INF = 1e20``. That is wrong whenever ``|a_ij| < 1``: an unbounded column
+contributes ``-0.5 * 1e20 = -5e19``, which fails a ``<= -INF`` test and is booked
+as a *finite* activity. Two things then go wrong at once:
+
+1. the row's activity range is no longer recognised as unbounded, so the pass
+   derives bounds it has no right to derive; and
+2. the huge magnitude annihilates every smaller term in the running sum
+   (``ulp(5e19) == 8192``), so the residual ``sum_min_finite - ck_min`` evaluates
+   to ``0.0`` instead of its true value.
+
+On the minimal LP below that fabricated the tightening ``x0 >= 35.2244`` for a
+column whose optimal value is ``0`` — cutting the optimum out of the box. Because
+presolve is *dimension-preserving* and has no postsolve, the B&B then solved the
+mutilated box and reported ``OPTIMAL`` at a value far above the true optimum: a
+false dual bound, which is the one class of defect this project treats as
+unconditionally fatal (see CLAUDE.md §1).
+
+The LP here is the shrunk core of ``gear4``'s equilibrated root relaxation, where
+this surfaced as a certified ``optimal`` of ``184279.32`` against a true optimum of
+``1.643428474``. ``presolve.rs``'s own module docstring promises the pass "never
+cuts a feasible (let alone optimal) solution"; these tests hold it to that.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt.solvers.milp_simplex import solve_milp  # noqa: E402
+
+# The shrunk gear4 core: 1 row, 2 columns. x1 alone satisfies the row (at its
+# upper bound 1600 the row activity is -3051 <= -17.6), so x0 = 0 is feasible and
+# optimal at objective 0.
+_C = np.array([4096.0, 0.0])
+_A = np.array([[-0.5, -1.9073486328125]])
+_B = np.array([-17.612222262299806])
+_LO = np.array([0.0, 2.5599999999999965])
+_HI_FINITE = 1600.0000000000016
+
+
+def _solve(hi0: float) -> tuple[str, float | None]:
+    bounds = [(_LO[0], hi0), (_LO[1], _HI_FINITE)]
+    r = solve_milp(c=_C, A_ub=_A, b_ub=_B, bounds=bounds, integrality=None)
+    obj = None if r.objective is None else float(r.objective)
+    return str(r.status), obj
+
+
+@pytest.mark.parametrize(
+    "hi0",
+    [np.inf, 1e20, 1e21, 1e25, 1e19, 1e15, 1e8],
+    ids=["inf", "sentinel_1e20", "1e21", "1e25", "1e19", "1e15", "1e8"],
+)
+def test_unbounded_column_does_not_fabricate_a_bound(hi0):
+    """The optimum is 0.0 whatever the (large or infinite) upper bound on x0.
+
+    ``1e20`` is the Rust sentinel itself and ``inf``/``1e21``/``1e25`` all exceed
+    it, so every one of these is an "unbounded above" column. Pre-fix, exactly the
+    cases at or above the sentinel returned 144279.32 with status OPTIMAL; the
+    sub-sentinel ones were already correct and guard against over-correction.
+    """
+    status, obj = _solve(hi0)
+    assert obj is not None, f"no objective returned for x0 ub={hi0}"
+    assert "OPTIMAL" in status.upper(), f"unexpected status {status} for x0 ub={hi0}"
+    assert obj == pytest.approx(0.0, abs=1e-6), (
+        f"x0 ub={hi0}: LP optimum is 0.0 (x0=0, x1=1600 is feasible) but the solver "
+        f"reported {obj!r} — presolve fabricated a lower bound on x0 and cut the optimum"
+    )
+
+
+def test_presolve_never_exceeds_an_independently_verified_optimum():
+    """Differential fuzz against HiGHS over LPs with sentinel/infinite bounds.
+
+    Guards the general class rather than the one shrunk instance: a *claimed*
+    ``OPTIMAL`` may never sit above the true minimum. Counts its comparisons so a
+    silently vacuous run (every LP infeasible/unbounded, or scipy missing) fails
+    instead of passing green.
+    """
+    linprog = pytest.importorskip("scipy.optimize").linprog
+    rng = np.random.default_rng(20260726)
+    compared = 0
+    violations = []
+
+    for _ in range(300):
+        n = int(rng.integers(2, 6))
+        m = int(rng.integers(1, 5))
+        # Coefficients below 1 in magnitude are what turn the sentinel into a
+        # finite product; keep them in the mix deliberately.
+        A = np.round(rng.uniform(-2.0, 2.0, size=(m, n)) * 2) / 2.0
+        b = np.round(rng.uniform(-20.0, 5.0, size=m), 6)
+        c = rng.integers(0, 4097, size=n).astype(float)
+        bounds = []
+        for _j in range(n):
+            lo = float(rng.choice([0.0, rng.uniform(0.0, 5.0)]))
+            hi = float(rng.choice([np.inf, 1e20, 1e21, rng.uniform(lo + 1.0, 2000.0)]))
+            bounds.append((lo, hi))
+
+        h = linprog(c, A_ub=A, b_ub=b, bounds=bounds, method="highs")
+        if not h.success:
+            continue
+        r = solve_milp(c=c, A_ub=A, b_ub=b, bounds=bounds, integrality=None)
+        if r.objective is None or "OPTIMAL" not in str(r.status).upper():
+            continue
+        compared += 1
+        obj = float(r.objective)
+        truth = float(h.fun)
+        if obj > truth + 1e-6 * (1.0 + abs(truth)):
+            violations.append((obj, truth, c.tolist(), A.tolist(), b.tolist(), bounds))
+
+    assert compared >= 50, (
+        f"only {compared} LPs were actually compared — the fuzz is vacuous and would "
+        "pass without testing anything"
+    )
+    assert not violations, (
+        f"{len(violations)} of {compared} LPs reported OPTIMAL above the true minimum; "
+        f"first: solver={violations[0][0]!r} vs highs={violations[0][1]!r}"
+    )


### PR DESCRIPTION
## The defect

`crates/discopt-core/src/lp/simplex/presolve.rs` decides whether a column's contribution to a row is unbounded by testing the **product** `a_ij * x_j` against the sentinel `INF = 1e20`:

```rust
let (cmin, cmax) = if aij > 0.0 { (aij*lo[j], aij*hi[j]) } else { (aij*hi[j], aij*lo[j]) };
if cmin <= -INF { n_min_inf += 1; } else { sum_min_finite += cmin; }
```

`INF` is a **sentinel, not a true infinity**. For `|a_ij| < 1` an unbounded column contributes an ordinary finite number — `-0.5 * 1e20 = -5e19` — which fails the `<= -INF` test and is booked as a *finite* activity. Two things then go wrong at once:

1. the row's activity range is no longer recognised as unbounded, so the pass derives bounds it has no right to derive; and
2. the huge magnitude annihilates every smaller term in the running sum (`ulp(5e19) = 8192`), so the residual `sum_min_finite - ck_min` evaluates to exactly `0.0` instead of its true value.

The result is an **invalid tightening**. Presolve is dimension-preserving with no postsolve, so the mutilated box goes straight to the B&B tree and the node LPs, and the search reports `OPTIMAL` on a box the optimum has been removed from — a false dual bound. The module's own docstring promises the pass "never cuts a feasible (let alone optimal) solution"; it did.

## Minimal reproducer

```
min 4096·x0    s.t.  -0.5·x0 - 1.9073486328125·x1 <= -17.612222262299806
                     x0 in [0, inf),  x1 in [2.56, 1600.0]
```

`x1 = 1600` satisfies the row on its own (activity −3051 ≤ −17.6), so **`x0 = 0` is feasible and optimal at objective 0**. HiGHS agrees. Pre-fix, presolve fabricates `x0 >= 35.2244` and the solver returns `OPTIMAL` at `144279.32` — and `4096 × 35.2244 = 144279.32` exactly.

The threshold is precisely the sentinel: `x0` upper bound of `1e19` is correct, while `1e20`, `1e21`, `1e25` and `inf` are all wrong.

## How it was found, and how the layer was identified

`gear4` returned `status=optimal objective=bound=184279.32477 gap_certified=True` against a true optimum of `1.643428474` (this repo's own `test_gear4_false_infeasible.py`, and `minlplib.solu`).

The layer was pinned by a **box-monotonicity** check that needs no oracle: a valid relaxation bound is antitone in the box, so capping an infinite endpoint (which *shrinks* the box) cannot lower the bound. On gear4 the raw box gave `184279.32` and a box capped at `1e6` — a strict subset — gave `0.0`. Enlarging the box raised the minimum, which is impossible.

That pointed at the relaxation, but the relaxation was exonerated: `A`, `b`, `c`, `obj_offset` and the objective floor are **byte-identical** between the two builds; only two column bounds differ. Handing the identical LP to scipy/HiGHS returned `0.0` while the in-house path returned `184279.32`. Equilibration was also exonerated (scipy returns `0.0` on both the scaled and unscaled systems). Shrinking the equilibrated LP greedily while the discrepancy persisted reduced 44×16 to the 1×2 case above.

## Fix

Infinity is now decided on the **bounds** (`lo <= -INF` / `hi >= INF`) in a shared `contrib()` helper used by both the activity-sum loop and the per-column loop.

Additionally, each derived bound is widened by an explicit rounding-error budget `8 * eps * max_abs_term`, so that a legitimately large but *finite* bound swamping the smaller terms cannot reproduce the same false tightening by cancellation. For terms of order `1e3` that is ~`2e-13` — no practical loss of propagation.

## This is a general defect, not a gear4 quirk

In the differential fuzz added here, **11 of 174** random LPs with unbounded columns (6.3%) returned a claimed-`OPTIMAL` objective above the true minimum before this change; **0 of 174** after.

Box monotonicity over the in-repo corpus went from **1 violation in 17 comparisons** to **0 in 18**.

## Corpus differential (79 instances, `time_limit=20`, oracle = `minlplib.solu`)

Both arms were run with the extension rebuilt and a marker assertion proving which build was loaded (`144279.32` for unfixed, `0.0` for fixed) before either panel started.

| | main | this PR |
|---|---|---|
| oracle crossings | 0 | **0** |
| `gap_certified` | 62 | **62** — 0 regressions, 0 newly certified |
| objective drifts | — | **0** |
| bound drifts | — | **0** |
| status changes | — | **0** |
| node-count changes | — | 11 (both directions: `nvs14` 223→129, `ex1263` 7455→10005) |
| total wall | 356.4 s | 350.7 s (−1.6%, noise) |

Exactly the expected shape for a soundness fix: identical answers, a slightly different search once the invalid tightenings stop firing.

**Honest blast radius.** `gear4` through the *default* `solve()` path is byte-identical on both arms (`1.6434284641`, 3 nodes, certified) and no in-repo instance crossed its oracle on either arm. Surfacing this required either the relaxation-level entry (`build_milp_relaxation(...).solve()`) or the mixed-scope LP engine. It also explains why the finite-root-box guard in `lp_spatial_bb` was **load-bearing rather than conservative**: it was masking this defect for the pure-integer engine, which is why removing it in #874 produced a certified `optimal` at `184279.32`.

## Tests

`python/tests/test_lp_presolve_infinite_bound.py`:

- the shrunk LP across a bound ladder — `inf`, `1e20`, `1e21`, `1e25`, plus sub-sentinel `1e19`/`1e15`/`1e8` as over-correction guards;
- a HiGHS differential fuzz over LPs with sentinel/infinite bounds, with a **comparison counter** (`assert compared >= 50`) so a vacuous run fails instead of passing green.

**Fails-before / passes-after verified by rebuilding the extension with the fix reverted**: 5 failed / 3 passed before, 8 passed after.

## Verification

| check | result |
|---|---|
| `cargo test -p discopt-core` | **537 passed**, 0 failed (+ 4 presolve-determinism, 1 doc-test) |
| `pytest python/tests/ -m smoke` | **832 passed**, 1 skipped, 2 xpassed |
| `pytest -m slow test_adversarial_recent_fixes.py` | **10 passed** |
| `ruff check` / `ruff format --check` | clean |
| `cargo fmt --check` / `cargo clippy` | clean |

Contributes to #874's blocker (that PR's false certificate on `gear4` is this bug, surfaced by widening the engine's scope).
