### PR TITLE
fix(#862): plunge in the #844 fallback — tln6 +326.8% -> +5.9%, tln4 exact

### DIFF
--- a/python/discopt/_jax/lp_spatial_bb.py
+++ b/python/discopt/_jax/lp_spatial_bb.py
@@ -78,6 +78,70 @@ _PROD_TOL = 1e-5
 # branched any further is exactly one the leaf test counts as collapsed.
 _MIN_BRANCH_WIDTH = 1e-9
 
+# #862: how deep a single plunge may run before the search returns to best-first.
+# A plunge trades bound quality for depth in order to reach an EXACT LEAF, which is
+# the only place this engine's node loop can produce an incumbent (a fully-fixed box
+# determines every nonlinear term). Best-first on tln6/nvs17 reaches depth 32 with
+# ``fully_fixed = 0`` -- no exact leaf in 2000+ nodes -- so no incumbent ever arrives
+# from the loop and the primal is left entirely to the rounding heuristics, which on
+# this family are reading a relaxation that is ~250x loose (2562/2562 roundings
+# infeasible; see docs/dev/lp-node-primal-quality.md).
+_PLUNGE_MAX_DEPTH = 64
+
+# Relative gap below which plunging STOPS. A plunge is a primal device: it buys depth
+# (hence exact leaves, hence incumbents) at the cost of dual progress. Once the gap is
+# nearly closed the remaining work is proving the bound, which is exactly what
+# best-first does and what a plunge starves. Measured on the in-repo corpus: without
+# this guard ``gear2`` -- whose best-first incumbent is 1.4e-06 against an optimum of
+# 0.0, i.e. already converged -- lost ``status=optimal`` entirely, the one
+# certification regression in the panel. With it, gear2 is untouched and every gain
+# (tln6 +132.7% -> +7.8%, nvs19, nvs23, ex1265) is kept: those all sit at gaps of
+# tens of percent when the plunge decision is made.
+_PLUNGE_MIN_GAP = 1e-2
+
+
+def _plunge_enabled(*, require_incremental: bool = False) -> bool:
+    """#862: depth-first plunging in the node loop.
+
+    **Default: ON for the #844 no-incumbent fallback, OFF for the general engine.**
+
+    The scoping is the point, not a compromise. The fallback exists *only* to find a
+    primal on a model the default path left with no incumbent — it is invoked with
+    ``require_incremental=True`` and its output is an incumbent, never a certificate.
+    There, trading dual progress for depth is the whole job. The general engine, by
+    contrast, is asked to *prove* optimality, and plunging costs it: on ``gear2``
+    best-first certifies in 657 nodes / 7.2 s while an unconditional plunge needs 6017
+    nodes / 61.3 s for the same answer, which shows up as a certification regression at
+    a 20 s panel budget. Enabling it everywhere would buy #862's incumbents at the
+    price of a §5 cert-clean violation; enabling it where it belongs buys them for free.
+
+    Measured on the in-repo corpus at 20 s (engine-direct, 58 in-scope), plunge ON vs
+    OFF *everywhere*: 0 oracle crossings, incumbents 46 -> 49 (``ex1252a``, ``ex1263``,
+    ``nvs24`` gained, none lost), quality better=7 worse=2, wall +7.0% — and exactly
+    one certification regression, ``gear2``. Restricting the default to the fallback
+    keeps the primal gains on the path #862 is about and leaves ``gear2``'s path
+    bit-identical.
+
+    ``DISCOPT_LP_SPATIAL_PLUNGE=1`` forces it on everywhere (the measurement above);
+    ``=0`` forces it off everywhere, fallback included.
+
+    Node ORDER cannot change the set of nodes explored, so plunging cannot make a
+    bound unsound *by itself* -- but the in-loop global lower bound used to be read
+    off the popped node, which is the frontier minimum only under best-first. That
+    read is generalized to a true minimum over all live nodes (see ``glb`` below), so
+    the two orders share one sound accounting rather than plunging relying on the
+    best-first assumption. With this flag off the generalized form is bit-identical to
+    the old one, which is what keeps the default path bound-neutral.
+
+    Opt in with ``DISCOPT_LP_SPATIAL_PLUNGE=1``.
+    """
+    import os as _os
+
+    _raw = _os.environ.get("DISCOPT_LP_SPATIAL_PLUNGE")
+    if _raw is not None:
+        return _raw not in ("0", "", "false", "False")
+    return bool(require_incremental)
+
 
 class LpSpatialResult(NamedTuple):
     status: str  # "optimal" | "feasible" | "infeasible" | "time_limit"
@@ -790,13 +854,19 @@ def solve_lp_spatial_bb(
         if cand is not None and cand[0] < inc_val:
             inc_val, inc_x = cand[0], cand[1].copy()
 
-    def child(lb, ub, parent_basis, parent_cuts, rounds, parent_bound):
+    def child(lb, ub, parent_basis, parent_cuts, rounds, parent_bound, collect=None):
         """Solve a child node (inheriting parent cuts, separating ``rounds`` more);
         push if promising. Returns its bound (or None).
 
         ``parent_bound`` is a valid lower bound for this child (its box is contained
         in the parent's), and is what gets recorded if the child's own relaxation
         cannot be resolved -- see below.
+
+        ``collect`` (#862) receives the surviving node instead of the global heap, so
+        the caller can decide between plunging into it and returning it to the
+        best-first frontier. It changes only WHERE a live node is parked, never
+        whether it stays live: ``_route`` below places every collected node in exactly
+        one of the two containers, and both are counted by ``glb``.
         """
         nonlocal counter, unresolved_lb
         if np.any(lb > ub + 1e-9):
@@ -805,8 +875,12 @@ def solve_lp_spatial_bb(
             lb, ub, parent_basis, parent_cuts, rounds
         )
         if b_ is not None and b_ < inc_val - 1e-9:
-            heapq.heappush(heap, (b_, counter, lb, ub, x_, basis_, cuts_, info_))
+            _node = (b_, counter, lb, ub, x_, basis_, cuts_, info_)
             counter += 1
+            if collect is None:
+                heapq.heappush(heap, _node)
+            else:
+                collect.append(_node)
         elif b_ is None and verdict != "fathom":
             # The child's relaxation gave no certified verdict, so its subtree is NOT
             # ruled out. Dropping it silently (the pre-#844 behaviour) removes live
@@ -835,18 +909,72 @@ def solve_lp_spatial_bb(
     # declared only when that closes the gap to the verified incumbent.
     unresolved_lb = float("inf")
 
+    # #862 plunging: a LIFO of nodes to descend into depth-first. Empty (and every
+    # branch below routes straight to ``heap``) unless the flag is on, so the default
+    # path keeps pure best-first.
+    plunge: list = []
+    plunge_depth = 0
+    _plunge_on = _plunge_enabled(require_incremental=require_incremental)
+
+    def _route(kids, node_bound):
+        """Send the most promising child down the plunge, the rest to the frontier.
+
+        "Most promising" is the smallest bound, i.e. the child best-first would have
+        chosen next anyway -- so a plunge is best-first *committed to for a while*
+        rather than a different search. Every child lands in exactly one container, so
+        the live-node set is identical to what pure best-first would hold; only the
+        ORDER of exploration differs.
+
+        Plunging stops once the gap is nearly closed (``_PLUNGE_MIN_GAP``): past that
+        point the work left is proving the bound, and depth-first starves exactly the
+        dual progress that does it. With no incumbent yet the gap is infinite, so the
+        search plunges freely -- which is when it is most needed, since the node loop
+        has no other way to reach an exact leaf.
+        """
+        if not kids:
+            return
+        kids.sort(key=lambda k: k[0])
+        for k in kids[1:]:
+            heapq.heappush(heap, k)
+        _gap_now = (
+            float("inf") if inc_x is None else abs(inc_val - node_bound) / (1.0 + abs(inc_val))
+        )
+        if plunge_depth < _PLUNGE_MAX_DEPTH and _gap_now > _PLUNGE_MIN_GAP:
+            plunge.append(kids[0])
+        else:
+            heapq.heappush(heap, kids[0])
+
     status = "infeasible"
-    while heap:
+    while heap or plunge:
         if (time.perf_counter() - t0) >= time_limit or nodes >= max_nodes:
             status = "time_limit"
             break
-        bound, _, lb, ub, x, basis, ncuts, ninfo = heapq.heappop(heap)
+        if plunge:
+            bound, _, lb, ub, x, basis, ncuts, ninfo = plunge.pop()
+            plunge_depth += 1
+        else:
+            bound, _, lb, ub, x, basis, ncuts, ninfo = heapq.heappop(heap)
+            plunge_depth = 0
         nodes += 1
-        # Global lower bound = smallest frontier bound (this popped node, best-first)
-        # capped by any unresolved-node floor. Fathoming/gap tests use this, never the
-        # popped node's bound alone, so an unresolved node below the incumbent keeps
-        # the gap open instead of yielding a false optimality proof.
+        # Global lower bound: the minimum over ALL live nodes -- this popped one, the
+        # best-first frontier, and anything parked on the plunge stack -- capped by the
+        # unresolved-node floor. Fathoming/gap tests use this, never the popped node's
+        # bound alone, so an unresolved node below the incumbent keeps the gap open
+        # instead of yielding a false optimality proof.
+        #
+        # The frontier/plunge terms are what make plunging sound. Under pure best-first
+        # the popped node IS the frontier minimum, so ``min(bound, unresolved_lb)`` was
+        # correct; a plunge pops a node that may be far from minimal, and reading the
+        # bound off it would report a global lower bound HIGHER than the truth -- which
+        # closes the gap early and certifies optimality over space still on the heap
+        # (CLAUDE.md §1). With the flag off ``plunge`` is empty and ``heap[0][0] >=
+        # bound`` by the heap invariant, so this expression is bit-identical to the old
+        # one and the default path stays bound-neutral.
         glb = min(bound, unresolved_lb)
+        if heap:
+            glb = min(glb, heap[0][0])
+        for _p in plunge:
+            glb = min(glb, _p[0])
         if bound >= inc_val - 1e-9 * (1 + abs(inc_val)):
             continue
         if inc_x is not None and abs(inc_val - glb) <= gap_tolerance * (1 + abs(inc_val)):
@@ -872,10 +1000,13 @@ def solve_lp_spatial_bb(
         if bi is not None:
             fd = x[bi] - np.floor(x[bi])
             fu = np.ceil(x[bi]) - x[bi]
-            bd = child(lb, _set(ub, bi, np.floor(x[bi])), basis, ncuts, _rounds, bound)
-            bu = child(_set(lb, bi, np.ceil(x[bi])), ub, basis, ncuts, _rounds, bound)
+            _kids: Optional[list] = [] if _plunge_on else None
+            bd = child(lb, _set(ub, bi, np.floor(x[bi])), basis, ncuts, _rounds, bound, _kids)
+            bu = child(_set(lb, bi, np.ceil(x[bi])), ub, basis, ncuts, _rounds, bound, _kids)
             _update_pc(bi, "d", bound, bd, fd)
             _update_pc(bi, "u", bound, bu, fu)
+            if _kids is not None:
+                _route(_kids, bound)
             continue
         # Integral assignment: spatial-bisect the worst-violated product variable.
         # ``_worst_product_var`` can only see products present in ``info``; once a
@@ -901,16 +1032,22 @@ def solve_lp_spatial_bb(
             # Integer domain split: [lb, mid] and [mid+1, ub] partition the integers
             # in the box exactly, so no integer point is lost.
             mid = np.floor((lb[bv] + ub[bv]) / 2)
-            child(lb, _set(ub, bv, mid), basis, ncuts, _rounds, bound)
-            child(_set(lb, bv, mid + 1.0), ub, basis, ncuts, _rounds, bound)
+            _kids = [] if _plunge_on else None
+            child(lb, _set(ub, bv, mid), basis, ncuts, _rounds, bound, _kids)
+            child(_set(lb, bv, mid + 1.0), ub, basis, ncuts, _rounds, bound, _kids)
+            if _kids is not None:
+                _route(_kids, bound)
         else:
             # Continuous bisection: the children SHARE the midpoint, so their union is
             # the parent box and no feasible point can fall between them. (The integer
             # split above can use disjoint halves only because there is nothing between
             # ``mid`` and ``mid+1``.)
             mid = 0.5 * (lb[bv] + ub[bv])
-            child(lb, _set(ub, bv, mid), basis, ncuts, _rounds, bound)
-            child(_set(lb, bv, mid), ub, basis, ncuts, _rounds, bound)
+            _kids = [] if _plunge_on else None
+            child(lb, _set(ub, bv, mid), basis, ncuts, _rounds, bound, _kids)
+            child(_set(lb, bv, mid), ub, basis, ncuts, _rounds, bound, _kids)
+            if _kids is not None:
+                _route(_kids, bound)
     else:
         # Heap exhausted. Optimal only if the unresolved-node floor does not sit below
         # the incumbent (else there is space the engine could not rule out -> feasible
@@ -929,7 +1066,8 @@ def solve_lp_spatial_bb(
         else:
             status = "infeasible"
 
-    gbound = min([h[0] for h in heap], default=float("inf"))
+    # Every live node counts, on the frontier OR parked mid-plunge (#862).
+    gbound = min([h[0] for h in heap] + [p[0] for p in plunge], default=float("inf"))
     gbound = min(gbound, unresolved_lb)
     if inc_x is not None:
         gbound = min(gbound, inc_val)

--- a/python/tests/test_862_plunge.py
+++ b/python/tests/test_862_plunge.py
@@ -1,0 +1,195 @@
+"""#862: depth-first plunging gives the node loop a primal source.
+
+The LP-per-node engine can only produce an incumbent from the node loop at an **exact
+leaf** (a fully-fixed box, where every nonlinear term is determined). Best-first never
+reaches one on the `tln`/`nvs` family — depth 32 with ``fully_fixed = 0`` in 2000+
+nodes — so the primal was left entirely to rounding heuristics reading a relaxation
+that is ~250x loose (2562/2562 roundings infeasible; see
+``docs/dev/lp-node-primal-quality.md``). Plunging commits to one child depth-first
+until an exact leaf, a fathom, or ``_PLUNGE_MAX_DEPTH``.
+
+Measured on #862's own metric — the #844 fallback panel, 60 s, oracles from
+``minlplib.solu``:
+
+======  ==============  ==============  =========
+inst    before          after           optimum
+======  ==============  ==============  =========
+tln4    9.3  (+12.0%)   **8.3 (exact)** 8.3
+tln5    32.2 (+212.6%)  10.8 (+4.9%)    10.3
+tln6    65.3 (+326.8%)  16.2 (+5.9%)    15.3
+======  ==============  ==============  =========
+
+worst gap 0.7657 -> 0.0556, mean 0.5178 -> 0.0340; panel reports 0 cert regressions,
+0 unsound, 0 false primals, 0 overshoots.
+
+**Default: ON for the fallback, OFF for the general engine.** The fallback exists only
+to find a primal (``require_incremental=True``, output is an incumbent, never a
+certificate), so trading dual progress for depth is its whole job. The general engine
+is asked to *prove* optimality and plunging costs it: ``gear2`` certifies in 657 nodes
+/ 7.2 s best-first versus 6017 nodes / 61.3 s plunging (same answer, both ~0), which
+at a 20 s budget reads as a certification regression. Scoping the default keeps the
+gains where they belong and leaves the proving path bit-identical.
+
+These tests pin the **soundness invariant and the wiring**, never wall-clock or node
+counts: at a *time* limit those are not reproducible — two runs of the identical
+configuration over the 58-instance in-repo corpus produced 23 differences, including
+``gear4``'s objective moving 31.5 -> 17.5, so a node-count assertion here would be a
+flake generator.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.lp_spatial_bb import (
+    _PLUNGE_MAX_DEPTH,
+    _plunge_enabled,
+    solve_lp_spatial_bb,
+)
+
+# --------------------------------------------------------------------------- #
+# Wiring: where the default is on, and how the env var overrides it
+# --------------------------------------------------------------------------- #
+
+
+def test_default_is_on_for_the_fallback_and_off_for_the_engine(monkeypatch):
+    monkeypatch.delenv("DISCOPT_LP_SPATIAL_PLUNGE", raising=False)
+    assert _plunge_enabled(require_incremental=True) is True, (
+        "the #844 fallback's job is a primal; plunging must be on there by default"
+    )
+    assert _plunge_enabled(require_incremental=False) is False, (
+        "the general engine must prove optimality; plunging must be off there by default"
+    )
+    assert _plunge_enabled() is False, "the bare default must be the conservative one"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("1", True), ("true", True), ("0", False), ("false", False), ("", False)],
+)
+def test_env_var_forces_both_ways_including_the_fallback(monkeypatch, raw, expected):
+    """An explicit setting overrides the per-path default in BOTH directions.
+
+    ``=0`` must switch the fallback off too, otherwise there is no way to reproduce
+    the pre-#862 behaviour for a bisect.
+    """
+    monkeypatch.setenv("DISCOPT_LP_SPATIAL_PLUNGE", raw)
+    assert _plunge_enabled(require_incremental=True) is expected
+    assert _plunge_enabled(require_incremental=False) is expected
+
+
+def test_plunge_depth_cap_is_finite():
+    assert 0 < _PLUNGE_MAX_DEPTH < 10_000
+
+
+# --------------------------------------------------------------------------- #
+# Soundness: the generalized global lower bound
+# --------------------------------------------------------------------------- #
+
+
+def _integer_product_model(n=6, ub=4):
+    """Pure-integer product model: in scope, needs branching, has a known optimum.
+
+    ``min sum_i (x_i * x_{i+1}) - 3*sum_i x_i`` over ``[0, ub]^n`` with a knapsack row.
+    The exact optimum is found by brute force below, so the certificate can be checked
+    against ground truth rather than against the engine's own opinion.
+    """
+    m = dm.Model(f"prod{n}")
+    xs = [m.integer(f"x{i}", lb=0, ub=ub) for i in range(n)]
+    obj = sum(xs[i] * xs[i + 1] for i in range(n - 1)) - 3 * sum(xs)
+    m.minimize(obj)
+    m.subject_to(sum(xs) <= 2 * ub)
+    m.subject_to(sum(xs) >= 2)
+    return m
+
+
+def _brute_force(n=6, ub=4):
+    import itertools
+
+    best = float("inf")
+    for pt in itertools.product(range(ub + 1), repeat=n):
+        s = sum(pt)
+        if not (2 <= s <= 2 * ub):
+            continue
+        val = sum(pt[i] * pt[i + 1] for i in range(n - 1)) - 3 * s
+        best = min(best, val)
+    return best
+
+
+@pytest.mark.parametrize("plunge", ["0", "1"])
+def test_bound_never_crosses_the_true_optimum(monkeypatch, plunge):
+    """The core §1 invariant, under both node orders, against a brute-forced optimum.
+
+    Plunging pops a node that is NOT the frontier minimum. The in-loop global lower
+    bound used to be read off the popped node, which is only the minimum under
+    best-first; reading it that way while plunging would report a bound ABOVE the truth
+    and could certify optimality over space still on the heap. This is the test that
+    would catch that.
+    """
+    monkeypatch.setenv("DISCOPT_LP_SPATIAL_PLUNGE", plunge)
+    n, ub = 6, 4
+    true_opt = _brute_force(n, ub)
+    r = solve_lp_spatial_bb(_integer_product_model(n, ub), time_limit=30, gap_tolerance=1e-6)
+    assert r is not None, "model should be in scope"
+    checks = 0
+    if r.bound is not None and np.isfinite(r.bound):
+        checks += 1
+        assert r.bound <= true_opt + 1e-6 * (1 + abs(true_opt)), (
+            f"plunge={plunge}: dual bound {r.bound!r} exceeds the true optimum "
+            f"{true_opt!r} — the global lower bound is being read off a non-minimal node"
+        )
+    if r.objective is not None and np.isfinite(r.objective):
+        checks += 1
+        assert r.objective >= true_opt - 1e-6 * (1 + abs(true_opt)), (
+            f"plunge={plunge}: objective {r.objective!r} is BELOW the true optimum "
+            f"{true_opt!r} — a false primal"
+        )
+    if r.status == "optimal":
+        checks += 1
+        assert r.objective == pytest.approx(true_opt, rel=1e-6, abs=1e-6), (
+            f"plunge={plunge}: certified optimal at {r.objective!r}, true optimum is {true_opt!r}"
+        )
+    assert checks >= 1, f"plunge={plunge}: no assertion fired — the probe is vacuous"
+
+
+def test_plunging_actually_changes_the_search(monkeypatch):
+    """Guard against the flag being an accidental no-op.
+
+    Without this, every other test here could pass while plunging never engaged. Uses
+    ``nvs17`` — the instance the #862 diagnosis is built on — under a fixed **node**
+    budget rather than a time limit, so the comparison is reproducible: at a *time*
+    limit two runs of the identical configuration differ (23 differences over the
+    58-instance corpus), which would make this a flake.
+
+    A synthetic product model was tried first and solved at the root in 1 node, so
+    plunging never fired and this assertion caught it — which is the point of having it.
+    """
+    from discopt.modeling.core import from_nl
+
+    nl = pathlib.Path(__file__).parent / "data" / "minlplib" / "nvs17.nl"
+    assert nl.exists(), f"missing fixture {nl}"
+    seen = {}
+    for flag in ("0", "1"):
+        monkeypatch.setenv("DISCOPT_LP_SPATIAL_PLUNGE", flag)
+        r = solve_lp_spatial_bb(
+            from_nl(str(nl)), time_limit=300, max_nodes=300, gap_tolerance=1e-12
+        )
+        assert r is not None, "nvs17 should be in scope"
+        seen[flag] = (
+            r.node_count,
+            None if r.bound is None else round(float(r.bound), 6),
+            None if r.objective is None else round(float(r.objective), 6),
+        )
+    assert seen["0"] != seen["1"], (
+        f"plunge on and off produced identical search state {seen} at a fixed node "
+        "budget — the flag is a no-op and the rest of this file proves nothing"
+    )
+    # And the plunge arm must not be unsound on this instance (oracle -1100.4).
+    for flag, (_nodes, bound, obj) in seen.items():
+        if bound is not None:
+            assert bound <= -1100.4 + 1e-4, f"plunge={flag}: bound {bound} above the optimum"
+        if obj is not None:
+            assert obj >= -1100.4 - 1e-4, f"plunge={flag}: objective {obj} below the optimum"


### PR DESCRIPTION
## What

Adds depth-first **plunging** to the LP-per-node engine's node loop, default-ON for the #844 no-incumbent fallback. **Closes #862.**

## The result, on #862's own metric

The #844 fallback panel at 60 s, oracles from `minlplib.solu` — the exact command `docs/dev/lp-node-primal-quality.md` §6 names as the next step:

| instance | issue's value | now | optimum |
|---|---|---|---|
| `tln4` | 9.3 (+12.0%) | **8.3 — exact** | 8.3 |
| `tln5` | 32.2 (**+212.6%**) | **10.8 (+4.9%)** | 10.3 |
| `tln6` | 65.3 (**+326.8%**) | **16.2 (+5.9%)** | 15.3 |

worst gap **0.7657 → 0.0556**, mean **0.5178 → 0.0340**. Panel: `gains=3 lost_incumbents=0 cert_regressions=0 overshoots=0 unsound=0 false_primals=0`, `GATE OK / QUALITY CLEAN / PANEL OK` all True.

## Why plunging, and why it works

The engine can only produce an incumbent from its node loop at an **exact leaf** — a fully-fixed box, where every nonlinear term is determined. Best-first never reaches one on this family: depth 32 with `fully_fixed = 0` in 2000+ nodes. So the primal was left entirely to rounding heuristics reading a McCormick relaxation that is **~250× loose** (root −278209 vs true −1100.4 on `nvs17`), which is why 2562/2562 roundings were infeasible.

That is why #862's two earlier levers failed, and why a third rounding tweak would have failed too. The plan doc's standing conclusion named plunging as one of the two productive directions; this is that.

## Soundness — the one substantive change beyond node order

The in-loop global lower bound was read off the **popped** node, which is the frontier minimum *only under best-first*. A plunge pops a node that may be far from minimal, so reading the bound there would report a global lower bound **higher than the truth**, close the gap early, and certify optimality over space still on the heap — CLAUDE.md §1's worst class.

It is now a true minimum over **all** live nodes: the popped node, `heap[0][0]`, and every node parked on the plunge stack. With plunging off, `plunge` is empty and `heap[0][0] >= bound` by the heap invariant, so the expression is **bit-identical** to the old one. The final reported bound likewise now scans the plunge stack as well as the heap.

## Default scoping — ON for the fallback, OFF for the engine

This is scoping, not a compromise. The fallback exists *only* to find a primal (`require_incremental=True`; its output is an incumbent, never a certificate), so trading dual progress for depth is its whole job. The general engine is asked to **prove** optimality and plunging costs it:

| `gear2` | nodes | wall | result |
|---|---|---|---|
| best-first | 657 | **7.2 s** | `optimal` |
| plunging | 6017 | **61.3 s** | `optimal` (same answer, both ≈ 0) |

At a 20 s budget that reads as a certification regression. Enabling plunging everywhere would buy #862's incumbents at the price of a §5 cert-clean violation; enabling it where it belongs buys them for free. `DISCOPT_LP_SPATIAL_PLUNGE=1`/`=0` forces it on/off everywhere.

**Engine-direct corpus differential** at 20 s (58 in-scope), plunge ON vs OFF *everywhere*, recorded for completeness: 0 oracle crossings, incumbents 46 → 49 (`ex1252a`, `ex1263`, `nvs24` gained, none lost), quality better=7 worse=2, wall +7.0%, and exactly one certification regression — `gear2`. That measurement is what motivated the scoping.

## Bound-neutrality of the general path, with a control

Default vs plunge-off over the 58 instances showed **23 differences** (node counts and last-ulp bounds). Running the **identical configuration twice** showed the **same 23** — including `gear4`'s objective moving 31.5 → 17.5 between two runs of the same code. So the drift is wall-clock nondeterminism at a 20 s budget, not a code effect.

Stating that plainly because it cuts both ways: it also means the 58-instance quality table above is noise-contaminated and is **not** what this change rests on. What it rests on is the fallback panel (an effect far larger than the noise, with `tln4` reaching the exact optimum) and `gear2`'s slowdown, measured directly at 20 / 60 / 120 s.

## Tests

`python/tests/test_862_plunge.py` — 10 tests pinning the **soundness invariant and the wiring**, never wall-clock or node counts (at a time limit those are not reproducible, per the control above):

- the dual bound is checked against a **brute-forced** optimum under **both** node orders — the test that would catch the non-minimal-pop bound bug;
- the default is ON for `require_incremental=True` and OFF otherwise, and the env var overrides both ways (`=0` must switch the fallback off too, or there is no way to bisect);
- a **firing guard**: plunge on vs off must differ at a fixed *node* budget on `nvs17`, or the flag is a no-op and the file proves nothing. That guard earned its place — the first synthetic model solved at the root in 1 node so plunging never fired, and the guard caught it.

| check | result |
|---|---|
| `pytest -m smoke` | **844 passed**, 1 skipped, 2 xpassed |
| `pytest -m slow test_adversarial_recent_fixes.py` | 10 passed |
| `test_862_plunge` + `test_844_lp_spatial_fallback` + `test_lp_spatial_bb` | all passed |
| `ruff check` / `ruff format --check` / `mypy` | clean |
| Rust | not touched |

## Follow-up, not in scope

The plan doc's other productive direction — **tightening the relaxation** (cuts/RLT) — is untouched and remains the deeper fix; plunging works around a loose relaxation rather than fixing it. The residual gaps (`tln5` +4.9%, `tln6` +5.9%) are where that would show up.
