### PR TITLE
fix(robustness): cut-free retry recovers a numerically-failed node LP — clay0303hfsg certifies

### DIFF
--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -1298,9 +1298,9 @@ impl ConvexKernelSpec {
                     None => {
                         // Warm solve gave up: it does not distinguish "proven
                         // infeasible" from "numerically failed", so this subtree is
-                        // not certified as explored.
-                        uncertified_drop = true;
-                        continue;
+                        // not certified as explored -- unless the cut-free retry
+                        // below resolves it (#871).
+                        self.solve_node(&lo, &hi, config.oa_tol, config.max_oa_rounds, opts)
                     }
                 }
             } else {
@@ -1312,6 +1312,48 @@ impl ConvexKernelSpec {
                     config.max_sep_rounds,
                     opts,
                 )
+            };
+            // #871: a node that breaks down numerically has proven nothing, so
+            // poisoning the certificate is correct -- but premature. The breakdown is
+            // caused by the separated pool itself: on clay0303hfsg one node reached
+            // 307 OA rounds / 2042 tangents with coefficient dynamism 7.3e8 before the
+            // factorization failed. Re-solving the SAME box with `solve_node` (K1,
+            // OA-only, no integrality separation) is a *different, weaker* relaxation:
+            // every cut dropped can only enlarge the feasible region, so its optimum
+            // stays a valid bound in the sense convention -- weaker, never tighter,
+            // which is the sound direction. Only if that also fails is the subtree
+            // genuinely unexplored.
+            //
+            // This is #871 step 2's retry-with-fewer-cuts. It is NOT a tolerance tweak:
+            // no threshold moves and nothing is relaxed. The thing to avoid is lowering
+            // `max_sep_rounds` globally, which would cost separation everywhere it is
+            // net-positive.
+            // #871: a node that breaks down numerically has proven nothing, so
+            // poisoning the certificate is correct -- but premature. The breakdown is
+            // caused by the separated pool itself: on clay0303hfsg one node reached
+            // 307 OA rounds / 2042 tangents with coefficient dynamism 7.3e8 before the
+            // factorization failed. Re-solving the SAME box with `solve_node` (K1,
+            // OA-only, no integrality separation) is a *different, weaker* relaxation:
+            // every cut dropped can only enlarge the feasible region, so its optimum
+            // stays a valid bound in the sense convention -- weaker, never tighter,
+            // which is the sound direction. Only if that also fails is the subtree
+            // genuinely unexplored.
+            //
+            // This is #871 step 2's retry-with-fewer-cuts. It is NOT a tolerance tweak:
+            // no threshold moves and nothing is relaxed. The thing to avoid is lowering
+            // `max_sep_rounds` globally, which would cost separation everywhere it is
+            // net-positive.
+            //
+            // Deliberately scoped to the non-`Optimal` exit. The sibling symptom -- an
+            // `Optimal` LP whose Neumaier-Shcherbina bound is `-inf` -- was also tried
+            // here and MEASURED to be a no-op: `cvxnonsep_psig40r` returns
+            // `exhausted`/`-inf` at node 1 both with and without that retry, because
+            // its NS decline is not caused by the separated pool. Unmeasured code does
+            // not ship; that face of #871 stays open.
+            let r = if matches!(r.status, LpStatus::Optimal | LpStatus::Infeasible) {
+                r
+            } else {
+                self.solve_node(&lo, &hi, config.oa_tol, config.max_oa_rounds, opts)
             };
             if r.status != LpStatus::Optimal {
                 // A PROVEN-infeasible node is a legitimate fathom — its subtree is

--- a/python/tests/test_871_cut_free_retry.py
+++ b/python/tests/test_871_cut_free_retry.py
@@ -1,0 +1,155 @@
+"""#871: a numerically-failed node LP is retried without cuts before poisoning the certificate.
+
+The convex tree only upgrades ``Exhausted -> Optimal`` when every node is accounted
+for (``!uncertified_drop``). A node LP exiting ``numerical`` proves nothing, so
+poisoning is correct — but premature. The breakdown is caused by the separated pool
+itself: on ``clay0303hfsg`` one node reached 307 OA rounds / 2042 tangents with
+coefficient dynamism ``7.3e8`` before the factorization failed.
+
+Re-solving that box with ``solve_node`` (K1: OA-only, no integrality separation) is a
+*different, weaker* relaxation — every cut dropped can only enlarge the feasible
+region — so its optimum stays a valid bound in the sense convention. Weaker, never
+tighter, which is the sound direction. That is #871 step 2's retry-with-fewer-cuts,
+and it is not a tolerance tweak: no threshold moves and nothing is relaxed.
+
+Measured, ``DISCOPT_CONVEX_KERNEL=1``, oracle from ``minlplib.solu``:
+
+==================  =====================================  =====================================
+instance            before                                 after
+==================  =====================================  =====================================
+clay0303hfsg        ``exhausted``, bound 26668.921579      **``optimal``, 26669.109557**
+syn05m              optimal 837.7324009                    unchanged
+syn05hfsg           optimal 837.7324009                    unchanged
+rsyn0805m04hfsg     optimal 7174.220058                    unchanged
+rsyn0810m04hfsg     optimal 6581.935607                    unchanged
+cvxnonsep_psig40r   ``exhausted``/``-inf`` at node 1       unchanged (see below)
+==================  =====================================  =====================================
+
+**#871 is not fully closed by this.** Its title symptom — an LP that exits ``Optimal``
+while its Neumaier–Shcherbina safe bound is ``-inf`` — is a *different* face, and
+``cvxnonsep_psig40r`` still shows it at node 1. Retrying that case without cuts was
+implemented, measured to be a **no-op** there (its NS decline is not caused by the
+separated pool), and removed rather than shipped unmeasured.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+from discopt.modeling.core import ObjectiveSense  # noqa: E402
+
+_DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
+
+
+def _known_optimum(name: str) -> float:
+    """Read the optimum from the shared registry — never a transcribed literal."""
+    from _optima import known_optimum
+
+    return float(known_optimum(name))
+
+
+@pytest.fixture
+def kernel_on(monkeypatch):
+    monkeypatch.setenv("DISCOPT_CONVEX_KERNEL", "1")
+
+
+@pytest.mark.correctness
+@pytest.mark.timeout(600)
+def test_clay0303hfsg_certifies_after_the_cut_free_retry(kernel_on):
+    """The instance #871 blocks now certifies, and the certified value is correct.
+
+    Fail-before / pass-after: with the retry removed this returns ``exhausted`` with
+    bound 26668.921579 (measured), so the ``optimal`` assertion is what the change
+    buys. Not marked ``slow`` — every CI lane excludes ``slow`` (``ci.yml`` 178 / 262 /
+    388), and a guard that cannot run is documentation. It carries an explicit
+    ``timeout(600)`` because the solve is ~7 s locally but far slower on CI runners.
+    """
+    from discopt.solvers._convex_kernel import build_convex_spec, solve_convex_tree
+
+    opt = _known_optimum("clay0303hfsg")
+    m = dm.from_nl(os.path.join(_DATA, "clay0303hfsg.nl"))
+    assert m._objective.sense == ObjectiveSense.MINIMIZE, "sense assumed below"
+    spec = build_convex_spec(m)
+    assert spec is not None, "clay0303hfsg must be kernel-eligible"
+
+    r = solve_convex_tree(spec, initial_incumbent=None, time_limit_s=300.0)
+    inc, bound, status = r["incumbent"], r["bound"], r["status"]
+    tol = 1e-4 * max(1.0, abs(opt))
+
+    checks = 0
+    assert status == "optimal", f"clay0303hfsg did not certify (status={status})"
+    checks += 1
+    # MINIMIZE: the dual bound is a LOWER bound, so `bound > opt` is the unsound side.
+    assert bound is not None and bound <= opt + tol, f"UNSOUND bound {bound} > {opt}"
+    checks += 1
+    assert inc is not None and abs(inc - opt) < tol, (
+        f"CERTIFIED objective {inc} != known optimum {opt} — a false certificate"
+    )
+    checks += 1
+    assert bound <= inc + tol, "certificate invariant: bound <= incumbent (min sense)"
+    checks += 1
+    assert checks == 4, "soundness assertions did not all execute"
+
+
+@pytest.mark.correctness
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize(
+    "name",
+    ["syn05m", "syn05hfsg", "clay0303hfsg"],
+)
+def test_kernel_certificates_stay_correct(kernel_on, name):
+    """No instance that already certified may regress, and none may certify wrongly.
+
+    Reads the objective SENSE from the model rather than assuming MINIMIZE: `syn*` are
+    MAXIMIZE, where a valid dual bound is an UPPER bound and the incumbent lies BELOW
+    the optimum. Applying the minimize direction to them reports perfectly sound
+    results as violations — a mistake made once already while measuring this issue.
+
+    Instances outside ``known_optima.toml`` or outside the vendored corpus SKIP rather
+    than assert: the registry is the only ground truth CI has, and asserting against a
+    transcribed literal is exactly how a wrong oracle gets published. The `syn*`
+    non-regression is covered by the measurement in this module's docstring and by
+    ``test_convex_kernel_perspective_865``.
+    """
+    from discopt.solvers._convex_kernel import build_convex_spec, solve_convex_tree
+
+    path = os.path.join(_DATA, f"{name}.nl")
+    if not os.path.exists(path):
+        pytest.skip(f"{name}.nl not vendored")
+    try:
+        opt = _known_optimum(name)
+    except KeyError:
+        # The registry is the only ground truth available in CI (minlplib.solu is not
+        # vendored). Skipping is honest; asserting against a transcribed literal is how
+        # a wrong oracle gets published, which happened once already on this issue.
+        pytest.skip(f"no recorded optimum for {name} in known_optima.toml")
+    m = dm.from_nl(path)
+    maximize = m._objective.sense == ObjectiveSense.MAXIMIZE
+    spec = build_convex_spec(m)
+    assert spec is not None, f"{name} must be kernel-eligible"
+
+    r = solve_convex_tree(spec, initial_incumbent=None, time_limit_s=300.0)
+    inc, bound, status = r["incumbent"], r["bound"], r["status"]
+    tol = 1e-4 * (1.0 + abs(opt))
+
+    checks = 0
+    if bound is not None and abs(bound) != float("inf"):
+        bad = (bound < opt - tol) if maximize else (bound > opt + tol)
+        assert not bad, f"{name}: UNSOUND bound {bound} vs optimum {opt} (max={maximize})"
+        checks += 1
+    if inc is not None:
+        bad = (inc > opt + tol) if maximize else (inc < opt - tol)
+        assert not bad, f"{name}: incumbent {inc} beyond optimum {opt} (max={maximize})"
+        checks += 1
+    if status == "optimal":
+        assert inc is not None and abs(inc - opt) < tol, (
+            f"{name}: CERTIFIED {inc} != optimum {opt} — a false certificate"
+        )
+        checks += 1
+    assert checks >= 2, f"{name}: only {checks} assertions fired — probe is vacuous"


### PR DESCRIPTION
> **Framing corrected on review.** This is a **robustness / capability** change, not a
> correctness fix, and the original `fix(#871)` title implied otherwise.
>
> #871's title symptom — the Neumaier–Shcherbina safe bound going `-inf` — is **not a
> bug**. `ns_safe_bound`'s contract is `g(y) = bᵀy + Σ_j min_{x_j∈[l_j,u_j]} (c − Aᵀy)_j x_j`,
> valid for *any* `y`; a column with `u_j = +∞` and a negative reduced cost makes that
> term genuinely `-∞`, and the function documents exactly that ("Returns `None` when the
> bound is `−∞` — a reduced cost with the wrong-signed open box side"). It is a rigorous
> bound correctly declining to certify, not a degradation.
>
> The genuine correctness bug in #871 was the silently-discarded subtree, already fixed
> by `1df5f71a` and shipped in #870. #871's own body states current behaviour is sound:
> "No false certificate, no default-path change."
>
> What this PR fixes is real but different: node LPs that break down numerically
> **because of cuts this kernel generated itself** (307 OA rounds / 2042 tangents,
> dynamism `7.3e8`). Recovering from that soundly converts *sound-but-uncertifiable*
> into *certified*. No unsoundness is being repaired.

## What

`clay0303hfsg` was **sound but uncertifiable**: `status="exhausted"`, incumbent `26669.109572` (the known optimum to 7 figures), bound `26668.921579`, relative gap **7.0e-06**. It now **certifies**.

The tree upgrades `Exhausted → Optimal` only when every node is accounted for (`!uncertified_drop`), and a node LP exiting `numerical` proves nothing — so poisoning the certificate is correct, but premature.

The breakdown is caused by the separated pool itself: #879 measured one node reaching **307 OA rounds / 2042 tangents** with coefficient dynamism `7.3e8` before the factorization failed. Re-solving that same box with `solve_node` — the **existing** K1 entry point (OA-only, no integrality separation) — is a *different, weaker* relaxation of the same box. Every cut dropped can only enlarge the feasible region, so its optimum remains a valid bound in the sense convention: weaker, never tighter, which is the sound direction. Only if the retry also fails is the subtree genuinely unexplored.

This is **#871 step 2's retry-with-fewer-cuts**, as the issue itself describes it.

## Why this is not a tolerance tweak

No threshold moves, nothing is relaxed, and no bound-producing solve is truncated (§8.1 — *the overruns ARE the dual bound*). The alternative the issue explicitly warns against — lowering `max_sep_rounds` globally — is **not** taken, so separation keeps working everywhere it is net-positive.

## Measured

`DISCOPT_CONVEX_KERNEL=1`. The oracle comes from `minlplib.solu` and the objective **sense** from the model, both read in the measuring script rather than transcribed. **15 soundness assertions, 0 unsound.**

| instance | sense | before | after |
|---|---|---|---|
| `clay0303hfsg` | MIN | `exhausted`, bound 26668.921579 | **`optimal` 26669.109557** (opt 26669.10957) |
| `syn05m` | MAX | optimal 837.7324009 | unchanged |
| `syn05hfsg` | MAX | optimal 837.7324009 | unchanged |
| `rsyn0805m04hfsg` | MAX | optimal 7174.220058 | unchanged |
| `rsyn0810m04hfsg` | MAX | optimal 6581.935607 | unchanged |
| `cvxnonsep_psig40r` | MIN | `exhausted`/`-inf` at node 1 | unchanged |

## What this does NOT do — #871 stays open

The issue's **title** symptom is a different face: an LP that exits `Optimal` while its Neumaier–Shcherbina safe bound is `-inf`. `cvxnonsep_psig40r` still shows it at node 1.

I implemented the retry for that case too and **measured it to be a no-op there** — its NS decline is not caused by the separated pool — so it was **removed rather than shipped unmeasured**. That face stays open, and the reasoning is recorded in the code comment so it is not re-attempted blind.

Hence `Contributes to`, not `Closes`.

## Tests

`python/tests/test_871_cut_free_retry.py`:

- the `clay0303hfsg` guard asserts the **certified** objective against the shared registry, never a transcribed literal;
- **`correctness`-marked without `slow`** — every CI lane excludes `slow` (`ci.yml` 178 / 262 / 388), so a slow guard would not run — with an explicit `timeout(600)`, because the solve is ~7 s locally and far slower on CI runners;
- the companion reads the objective **sense from the model** rather than assuming MINIMIZE (`syn*` are MAXIMIZE, where the minimize direction reports sound results as violations — a mistake I made once while measuring this issue), and **skips** instances outside `known_optima.toml` rather than asserting against a literal.

Fails-before / passes-after verified by stashing the Rust change: the certification assertion fails with `status=exhausted`, then passes.

| check | result |
|---|---|
| `cargo test -p discopt-core` | **556 passed**, 0 failed |
| `cargo fmt --check` / `clippy` | clean |
| `pytest -m smoke` | **844 passed**, 1 skipped, 2 xpassed |
| `pytest -m "correctness and not slow"` | **292 passed**, 3 skipped, 4 xfailed |
| `pytest -m slow test_adversarial_recent_fixes.py` | 10 passed |

Contributes to #871

