### PR TITLE
exp(E1): template-refresh parity — PASS (100% templatable, 0 ulp)

### DIFF
--- a/discopt_benchmarks/scripts/e1_refresh.py
+++ b/discopt_benchmarks/scripts/e1_refresh.py
@@ -1,0 +1,197 @@
+"""E1 independent refresh reference (numpy, no JAX).
+
+Pure closed-form ``refresh(box) -> row coefficients`` reimplementations of the
+box-parametric envelope families the uniform relaxation emits. These are written
+FROM THE ENVELOPE MATH (McCormick 1976 inequalities; secant/tangent line
+constructions), NOT by copying the builder's dict-assembly, so that comparing their
+output to the production rows is a genuine parity test: a wrong formula fails the
+ulp bar. The Rust port (P1) is out of scope; E1 only establishes the mapping exists
+and is exact.
+
+Refresh inputs are the STATIC template (column identity, the atom stencil f/f' which
+close over only atom identity / fixed exponent — never the box) plus the node
+interval bounds produced by the interval/FBBT pass (``lo, hi`` for a 1-D atom; the
+four factor endpoints for a product). Output is the list of ``(coeffs, rhs)`` rows
+meaning ``sum_j coeffs[j]*col_j <= rhs`` — the exact contract of the builder.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+Row = tuple[dict[int, float], float]
+
+_BIG = 1e19
+_MIN_WIDTH = 1e-12
+
+
+def _finite(*vals: float) -> bool:
+    return all(math.isfinite(v) and abs(v) < _BIG for v in vals)
+
+
+def _scaled_into(coeffs: dict[int, float], src: dict[int, float], s: float) -> None:
+    """Accumulate ``s * src`` into ``coeffs`` (mirrors LinForm.scaled + fold)."""
+    for j, c in src.items():
+        cs = c * s
+        coeffs[j] = coeffs.get(j, 0.0) + cs
+
+
+def refresh_mccormick(
+    w: int,
+    a_coeffs: dict[int, float],
+    a_const: float,
+    b_coeffs: dict[int, float],
+    b_const: float,
+    a_lo: float,
+    a_hi: float,
+    b_lo: float,
+    b_hi: float,
+) -> list[Row]:
+    """Four McCormick rows for ``w = A*B`` over ``A in [a_lo,a_hi]``, ``B in [b_lo,b_hi]``.
+
+    The valid inequalities (McCormick 1976), each touching the bilinear graph:
+        w >= a_lo*B + b_lo*A - a_lo*b_lo     w >= a_hi*B + b_hi*A - a_hi*b_hi   (under)
+        w <= a_hi*B + b_lo*A - a_hi*b_lo     w <= a_lo*B + b_hi*A - a_lo*b_hi   (over)
+    Written here as ``E = coef_a*A + coef_b*B + cc`` then converted to a ``<= 0``
+    row: ``(-sign)*w + sign*E <= 0`` with sign=+1 for under, -1 for over.
+    """
+    rows: list[Row] = []
+    # (a_endpoint, b_endpoint, sign): coef_a = b_endpoint, coef_b = a_endpoint,
+    # cc = -a_endpoint*b_endpoint.
+    for a_pt, b_pt, sign in (
+        (a_lo, b_lo, +1.0),
+        (a_hi, b_hi, +1.0),
+        (a_hi, b_lo, -1.0),
+        (a_lo, b_hi, -1.0),
+    ):
+        coef_a = b_pt
+        coef_b = a_pt
+        cc = -a_pt * b_pt
+        if not _finite(coef_a, coef_b, cc):
+            continue
+        coeffs: dict[int, float] = {w: -sign}
+        _scaled_into(coeffs, a_coeffs, sign * coef_a)
+        _scaled_into(coeffs, b_coeffs, sign * coef_b)
+        rhs = -sign * (cc + coef_a * a_const + coef_b * b_const)
+        rows.append(({j: c for j, c in coeffs.items() if c != 0.0}, rhs))
+    return rows
+
+
+def _secant_row(
+    w: int,
+    lt_coeffs: dict[int, float],
+    lt_const: float,
+    lo: float,
+    hi: float,
+    f: Callable[[float], float],
+    sign: float,
+) -> Row | None:
+    """``sign*w <= sign*chord(t)`` — the secant of ``f`` between the endpoint images."""
+    if not _finite(lo, hi) or (hi - lo) < _MIN_WIDTH:
+        return None
+    flo, fhi = float(f(lo)), float(f(hi))
+    if not _finite(flo, fhi):
+        return None
+    slope = (fhi - flo) / (hi - lo)
+    a = flo - slope * lo
+    coeffs: dict[int, float] = {w: sign}
+    _scaled_into(coeffs, lt_coeffs, -sign * slope)
+    return ({j: c for j, c in coeffs.items() if c != 0.0}, sign * (a + slope * lt_const))
+
+
+def _tangent_row(
+    w: int,
+    lt_coeffs: dict[int, float],
+    lt_const: float,
+    t0: float,
+    f: Callable[[float], float],
+    fp: Callable[[float], float],
+    sign: float,
+) -> Row | None:
+    """``sign*w >= sign*tangent(t)`` at ``t0`` — a supporting line of ``f``."""
+    try:
+        g, gp = float(f(t0)), float(fp(t0))
+    except (ValueError, ArithmeticError):
+        return None
+    if not _finite(g, gp):
+        return None
+    intercept = g - gp * t0
+    coeffs: dict[int, float] = {w: -sign}
+    _scaled_into(coeffs, lt_coeffs, sign * gp)
+    return (
+        {j: c for j, c in coeffs.items() if c != 0.0},
+        -sign * intercept - sign * gp * lt_const,
+    )
+
+
+def refresh_univariate(
+    w: int,
+    lt_coeffs: dict[int, float],
+    lt_const: float,
+    lo: float,
+    hi: float,
+    f: Callable[[float], float],
+    fp: Callable[[float], float],
+    curv: str | None,
+) -> list[Row]:
+    """Secant + three tangents of ``w = f(t)`` over ``t in [lo,hi]`` (convex/concave).
+
+    Reproduces ``_emit_1d``: convex -> ``w <= secant`` and ``w >= tangent`` at
+    (lo, mid, hi); concave -> the mirror. ``curv is None`` -> no rows (aux floor).
+    """
+    if curv is None or not _finite(lo, hi) or (hi - lo) < _MIN_WIDTH:
+        return []
+    # Mirror _emit_1d: the endpoint eval gates the ENTIRE envelope (secant AND
+    # tangents) — a raise / non-finite there emits zero rows, not just no secant.
+    try:
+        flo, fhi = float(f(lo)), float(f(hi))
+    except (ValueError, ArithmeticError):
+        return []
+    if not _finite(flo, fhi):
+        return []
+    sign = +1.0 if curv == "convex" else -1.0
+    mid = 0.5 * (lo + hi)
+    rows: list[Row] = []
+    sec = _secant_row(w, lt_coeffs, lt_const, lo, hi, f, sign)
+    if sec is not None:
+        rows.append(sec)
+    for t0 in (lo, mid, hi):
+        tan = _tangent_row(w, lt_coeffs, lt_const, t0, f, fp, sign)
+        if tan is not None:
+            rows.append(tan)
+    return rows
+
+
+def refresh_obj_floor(
+    obj_coeffs: dict[int, float],
+    obj_const: float,
+    sep_lb: float,
+) -> list[Row]:
+    """The separable objective-floor cut ``obj_lin >= sep_lb`` as a ``<= 0`` row.
+
+    Coefficients are box-independent (the negated objective's variable part); only
+    the RHS moves with the box, through ``sep_lb`` — a separable interval lower
+    bound of the objective over the box (closed-form per term, no JAX). Here
+    ``sep_lb`` is the interval/FBBT-layer input, exactly as the McCormick endpoints
+    are; refresh reassembles the row.
+    """
+    coeffs = {j: -c for j, c in obj_coeffs.items()}
+    return [({j: c for j, c in coeffs.items() if c != 0.0}, obj_const - sep_lb)]
+
+
+def refresh_secant_only(
+    w: int,
+    lt_coeffs: dict[int, float],
+    lt_const: float,
+    lo: float,
+    hi: float,
+    f: Callable[[float], float],
+    sign: float,
+) -> list[Row]:
+    """Single secant row (abs over-side, odd-power hull secant)."""
+    sec = _secant_row(w, lt_coeffs, lt_const, lo, hi, f, sign)
+    return [] if sec is None else [sec]

--- a/discopt_benchmarks/scripts/e1_row_family_census.py
+++ b/discopt_benchmarks/scripts/e1_row_family_census.py
@@ -1,0 +1,162 @@
+"""E1 row-family census (docs/dev/scip-parity-kernel-plan.md §3 E1).
+
+Instrument the uniform relaxation builder so every emitted relaxation row of every
+vendored instance is attributed to the *builder function that emitted it* — the
+generating envelope family (McCormick bilinear, univariate secant/tangent, power
+envelope, linear passthrough, exact linking equality, RLT, ...). Attribution is by
+call-stack inspection: the innermost frame inside ``uniform_relax.py`` that called
+``add_row`` IS the family, read live from ``__name__``/``f_lineno`` — nothing is
+transcribed from a constant table, so the census reflects the code as it runs.
+
+Output: per-family row counts summed over the corpus, the templatable fraction, and
+the kill-criterion verdict input (% of panel rows in closed-form box-parametric
+families). A run that attributes zero rows exits non-zero (loud failure).
+
+Usage:  python discopt_benchmarks/scripts/e1_row_family_census.py
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from pathlib import Path
+
+import discopt.modeling as dm
+import numpy as np
+from discopt._jax import uniform_relax as ur
+from discopt._jax.model_utils import flat_variable_bounds
+
+NL_DIR = Path(__file__).resolve().parents[2] / "python" / "tests" / "data" / "minlplib_nl"
+
+# Human-readable family label per emitting builder frame. The KEYS are read from
+# the live call stack (frame __name__); this dict only *names* them for the report,
+# it does not decide attribution. A frame not listed is reported under its raw
+# function name so no row is silently bucketed.
+FAMILY_LABEL: dict[str, str] = {
+    "_emit_mccormick": "mccormick_bilinear",
+    "_secant_row": "univariate_secant",
+    "_tangent_row": "univariate_tangent",
+    "_emit_secant_only": "univariate_secant",
+    "_emit_1d": "univariate_1d_floor",
+    "_build_abs": "abs",
+    "_emit_lse": "logsumexp",
+    "_emit_norm": "norm",
+    "_emit_odd_power_hull": "odd_power_hull",
+    "_emit_engine_equality": "exact_linking_equality",
+    "_emit_scaled_equality": "exact_linking_equality",
+    "_emit_relent": "relative_entropy",
+    "_emit_logspace_band": "logspace_band",
+    "_build_multivar": "multivar_intrinsic",
+    "_emit_quadratic_rlt": "rlt_quad",
+    "_emit_piecewise_1d": "piecewise_1d",
+    "_try_convex_lift": "convex_lift_decision",
+    "_rep_impl": "node_rep",
+    "build_uniform_relaxation": "linear_passthrough",
+}
+
+# Families whose rows are reproducible by an analyze-phase template + a closed-form
+# refresh(lb, ub) (a few flops, no JAX) — the E1 hypothesis. Two sub-kinds, both
+# proven exact (0 ulp) by the parity harness e1_template_refresh.py:
+#   * box-parametric — coeffs/rhs move with the box (McCormick, secant/tangent, the
+#     objective separable-floor cut's rhs);
+#   * box-invariant  — coeffs are structural, independent of the box (linear
+#     passthrough; every exact affine link: scaled/engine equalities, the convex-lift
+#     `w == dec` link, and the log-space `s == Σ aᵢ zᵢ` link).
+TEMPLATABLE: set[str] = {
+    "mccormick_bilinear",
+    "univariate_secant",
+    "univariate_tangent",
+    "abs",
+    "odd_power_hull",
+    "exact_linking_equality",
+    "linear_passthrough",
+    # box-invariant exact affine links (verified box-independent coeffs):
+    "convex_lift_decision",
+    "logspace_band",
+}
+
+_UR_FILE = Path(ur.__file__).resolve()
+
+
+def _attribute_frame() -> tuple[str, int]:
+    """Innermost ``uniform_relax.py`` frame above ``add_row`` — (funcname, lineno)."""
+    f = sys._getframe(2)  # 0=_attribute_frame, 1=patched add_row, 2=caller
+    while f is not None:
+        code = f.f_code
+        if Path(code.co_filename).resolve() == _UR_FILE and code.co_name != "add_row":
+            return code.co_name, f.f_lineno
+        f = f.f_back
+    return "<unknown>", -1
+
+
+def census_instance(stem: str) -> Counter | None:
+    """Row-family counts for one instance at its root box. None if load fails."""
+    try:
+        model = dm.from_nl(str(NL_DIR / f"{stem}.nl"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"  LOAD-FAIL {stem}: {type(exc).__name__}: {exc}")
+        return None
+
+    counts: Counter = Counter()
+    orig_add_row = ur._Builder.add_row
+
+    def patched(self, coeffs, rhs):
+        name, _ = _attribute_frame()
+        counts[FAMILY_LABEL.get(name, name)] += 1
+        return orig_add_row(self, coeffs, rhs)
+
+    ur._Builder.add_row = patched  # type: ignore[method-assign]
+    try:
+        lb, ub = flat_variable_bounds(model)
+        ur.build_uniform_relaxation(model, (np.asarray(lb), np.asarray(ub)))
+    except Exception as exc:  # noqa: BLE001
+        print(f"  BUILD-FAIL {stem}: {type(exc).__name__}: {exc}")
+        return None
+    finally:
+        ur._Builder.add_row = orig_add_row  # type: ignore[method-assign]
+    return counts
+
+
+def main() -> int:
+    stems = sorted(p.stem for p in NL_DIR.glob("*.nl"))
+    print(f"E1 row-family census over {len(stems)} vendored .nl instances\n")
+
+    total: Counter = Counter()
+    ok = 0
+    failed: list[str] = []
+    for stem in stems:
+        c = census_instance(stem)
+        if c is None:
+            failed.append(stem)
+            continue
+        ok += 1
+        total += c
+
+    total_rows = sum(total.values())
+    if total_rows == 0:
+        print("FATAL: attributed 0 rows across the corpus", file=sys.stderr)
+        return 2
+
+    templatable_rows = sum(n for fam, n in total.items() if fam in TEMPLATABLE)
+    print(
+        f"\nInstances built: {ok}/{len(stems)}"
+        + (f"  (failed: {', '.join(failed)})" if failed else "")
+    )
+    print(f"Total rows attributed: {total_rows}\n")
+    print(f"{'family':<26}{'rows':>10}{'% total':>10}{'templatable':>13}")
+    print("-" * 59)
+    for fam, n in sorted(total.items(), key=lambda kv: -kv[1]):
+        mark = "yes" if fam in TEMPLATABLE else "NO"
+        print(f"{fam:<26}{n:>10}{100.0 * n / total_rows:>9.2f}%{mark:>13}")
+    print("-" * 59)
+    pct = 100.0 * templatable_rows / total_rows
+    print(f"{'TEMPLATABLE TOTAL':<26}{templatable_rows:>10}{pct:>9.2f}%")
+    print(
+        f"\nKill criterion: >=90% templatable to PASS. Measured: {pct:.2f}% -> "
+        + ("PASS" if pct >= 90.0 else "FAIL")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/discopt_benchmarks/scripts/e1_template_refresh.py
+++ b/discopt_benchmarks/scripts/e1_template_refresh.py
@@ -1,0 +1,356 @@
+"""E1 template-refresh parity harness (docs/dev/scip-parity-kernel-plan.md §3 E1).
+
+For every vendored instance, at the root box AND >=3 perturbed child boxes, build the
+uniform relaxation the normal way and reproduce every box-parametric envelope row via
+the independent numpy refresh (``e1_refresh``). Compare coefficient-by-coefficient and
+report the max ULP deviation per family; ``<=1 ulp`` is the bar. Box-invariant families
+(linear passthrough, exact links) are verified to carry ZERO box dependence.
+
+Mechanism: monkeypatch the three box-parametric emitters
+(``_emit_mccormick``, ``_emit_1d``, ``_emit_secant_only``) to capture the static
+template + FBBT node bounds they receive and the rows they emit, then refresh from the
+same inputs and diff in place — no cross-box row matching needed. Every other emitted
+row is a box-invariant family; its coefficients are checked for box-independence by
+skeleton-keyed comparison across boxes.
+
+Usage:  python discopt_benchmarks/scripts/e1_template_refresh.py
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+import zlib
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import discopt.modeling as dm
+import numpy as np
+from discopt._jax import uniform_relax as ur
+from discopt._jax.milp_relaxation import _flat_variable_types
+from discopt._jax.model_utils import flat_variable_bounds
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import e1_refresh as ref  # noqa: E402
+
+NL_DIR = Path(__file__).resolve().parents[2] / "python" / "tests" / "data" / "minlplib_nl"
+
+_BIG = 1e19
+
+
+# --------------------------------------------------------------------------- #
+# ULP distance (monotone-ordering of IEEE-754 doubles)
+# --------------------------------------------------------------------------- #
+def _ordered(x: float) -> int:
+    b = struct.unpack("<q", struct.pack("<d", float(x)))[0]
+    return b if b >= 0 else 0x8000000000000000 - b
+
+
+def ulp_diff(a: float, b: float) -> int:
+    if a == b:
+        return 0
+    return abs(_ordered(a) - _ordered(b))
+
+
+def _row_finite_ok(coeffs: dict, rhs: float) -> bool:
+    """Mirror _Builder.add_row's drop rule (non-finite payload -> row skipped)."""
+    import math
+
+    if not math.isfinite(rhs) or abs(rhs) >= _BIG:
+        return False
+    return all(math.isfinite(c) and abs(c) < _BIG for c in coeffs.values())
+
+
+def _norm(coeffs: dict) -> dict:
+    return {int(j): float(c) for j, c in coeffs.items() if c != 0.0}
+
+
+# --------------------------------------------------------------------------- #
+# Per-run capture state
+# --------------------------------------------------------------------------- #
+class Capture:
+    def __init__(self) -> None:
+        # family -> list of (expected_rows, refreshed_rows)
+        self.param: dict[str, list[tuple[list, list]]] = defaultdict(list)
+        # box-invariant rows emitted this build (coeffs, rhs), skeleton-keyed
+        self.invariant: list[tuple[dict, float]] = []
+        self._depth = 0  # >0 while inside a wrapped box-parametric emitter
+
+
+def _install(cap: Capture):
+    """Monkeypatch the emitters + add_row; return an uninstall callable."""
+    orig_mcc = ur._emit_mccormick
+    orig_1d = ur._emit_1d
+    orig_sec = ur._emit_secant_only
+    orig_add = ur._Builder.add_row
+
+    def add_row(self, coeffs, rhs):
+        # A box-parametric emitter's rows are captured by its own wrapper below;
+        # everything emitted OUTSIDE one is box-invariant EXCEPT the inline
+        # objective separable-floor cut (build_uniform_relaxation, box-dependent
+        # RHS via the `sep_lb` local), which is box-parametric — refresh it here.
+        if cap._depth == 0 and _row_finite_ok(coeffs, rhs):
+            caller = sys._getframe(1)
+            loc = caller.f_locals
+            if (
+                caller.f_code.co_name == "build_uniform_relaxation"
+                and loc.get("sep_lb") is not None
+                and "obj_lin" in loc
+            ):
+                obj_lin = loc["obj_lin"]
+                expected = [(_norm(coeffs), float(rhs))]
+                refreshed = [
+                    (_norm(c), float(r))
+                    for c, r in ref.refresh_obj_floor(
+                        dict(obj_lin.coeffs), float(obj_lin.const), float(loc["sep_lb"])
+                    )
+                    if _row_finite_ok(c, r)
+                ]
+                cap.param["objective_floor"].append((expected, refreshed))
+            else:
+                cap.invariant.append((_norm(coeffs), float(rhs)))
+        return orig_add(self, coeffs, rhs)
+
+    def emit_mccormick(ctx, w, la, ba, lb_, bb):
+        a_lo, a_hi = ba
+        b_lo, b_hi = bb
+        tmpl = (w, dict(la.coeffs), float(la.const), dict(lb_.coeffs), float(lb_.const))
+        before = len(ctx.rows)
+        cap._depth += 1
+        try:
+            orig_mcc(ctx, w, la, ba, lb_, bb)
+        finally:
+            cap._depth -= 1
+        expected = [(_norm(c), float(r)) for c, r in ctx.rows[before:]]
+        refreshed = [
+            (_norm(c), float(r))
+            for c, r in ref.refresh_mccormick(
+                tmpl[0], tmpl[1], tmpl[2], tmpl[3], tmpl[4], a_lo, a_hi, b_lo, b_hi
+            )
+            if _row_finite_ok(c, r)
+        ]
+        cap.param["mccormick_bilinear"].append((expected, refreshed))
+
+    def emit_1d(ctx, w, lt, lo, hi, f, fp, curv):
+        tmpl = (w, dict(lt.coeffs), float(lt.const))
+        before = len(ctx.rows)
+        cap._depth += 1
+        try:
+            out = orig_1d(ctx, w, lt, lo, hi, f, fp, curv)
+        finally:
+            cap._depth -= 1
+        expected = [(_norm(c), float(r)) for c, r in ctx.rows[before:]]
+        refreshed = [
+            (_norm(c), float(r))
+            for c, r in ref.refresh_univariate(tmpl[0], tmpl[1], tmpl[2], lo, hi, f, fp, curv)
+            if _row_finite_ok(c, r)
+        ]
+        # Attribute secant vs tangent for a finer census: the first row is the
+        # secant, the rest tangents (matches _emit_1d's emission order).
+        cap.param["univariate_secant_tangent"].append((expected, refreshed))
+        return out
+
+    def emit_secant_only(ctx, w, lt, lo, hi, f, sign):
+        tmpl = (w, dict(lt.coeffs), float(lt.const))
+        before = len(ctx.rows)
+        cap._depth += 1
+        try:
+            out = orig_sec(ctx, w, lt, lo, hi, f, sign)
+        finally:
+            cap._depth -= 1
+        expected = [(_norm(c), float(r)) for c, r in ctx.rows[before:]]
+        refreshed = [
+            (_norm(c), float(r))
+            for c, r in ref.refresh_secant_only(tmpl[0], tmpl[1], tmpl[2], lo, hi, f, sign)
+            if _row_finite_ok(c, r)
+        ]
+        cap.param["secant_only"].append((expected, refreshed))
+        return out
+
+    ur._emit_mccormick = emit_mccormick
+    ur._emit_1d = emit_1d
+    ur._emit_secant_only = emit_secant_only
+    ur._Builder.add_row = add_row
+
+    def uninstall():
+        ur._emit_mccormick = orig_mcc
+        ur._emit_1d = orig_1d
+        ur._emit_secant_only = orig_sec
+        ur._Builder.add_row = orig_add
+
+    return uninstall
+
+
+# --------------------------------------------------------------------------- #
+# Box construction: root + perturbed children
+# --------------------------------------------------------------------------- #
+def _child_boxes(lb, ub, vtypes, n_shrink=3, seed=0):
+    """Root-excluded perturbed boxes: n_shrink random inward shrinks + 1 int-pin."""
+    lb = np.asarray(lb, dtype=np.float64)
+    ub = np.asarray(ub, dtype=np.float64)
+    boxes: list[tuple[str, np.ndarray, np.ndarray]] = []
+    for s in range(n_shrink):
+        rng = np.random.default_rng(seed * 100 + s)
+        nlb, nub = lb.copy(), ub.copy()
+        for i in range(len(lb)):
+            w = ub[i] - lb[i]
+            if not np.isfinite(w) or w <= 0:
+                continue
+            fl, fu = rng.uniform(0.1, 0.5), rng.uniform(0.1, 0.5)
+            nlb[i] = lb[i] + fl * w
+            nub[i] = ub[i] - fu * w
+            if nub[i] < nlb[i]:
+                nlb[i] = nub[i] = 0.5 * (lb[i] + ub[i])
+        boxes.append((f"shrink{s}", nlb, nub))
+    # One box with an integer/binary variable pinned to a lattice point.
+    int_idx = [
+        i
+        for i, t in enumerate(vtypes)
+        if str(t).split(".")[-1].lower() in ("integer", "binary")
+        and np.isfinite(lb[i])
+        and np.isfinite(ub[i])
+        and ub[i] > lb[i]
+    ]
+    if int_idx:
+        i = int_idx[0]
+        nlb, nub = lb.copy(), ub.copy()
+        v = float(np.floor(0.5 * (lb[i] + ub[i])))
+        v = min(max(v, lb[i]), ub[i])
+        nlb[i] = nub[i] = v
+        boxes.append((f"intpin[x{i}={v:g}]", nlb, nub))
+    return boxes
+
+
+def _build_capture(model, box):
+    cap = Capture()
+    uninstall = _install(cap)
+    try:
+        ur.build_uniform_relaxation(model, (np.asarray(box[0]), np.asarray(box[1])))
+    finally:
+        uninstall()
+    return cap
+
+
+# --------------------------------------------------------------------------- #
+# Parity evaluation
+# --------------------------------------------------------------------------- #
+def _cmp_param(cap: Capture, agg: dict):
+    """Accumulate per-family (comparisons, max_ulp, count_mismatch)."""
+    for fam, groups in cap.param.items():
+        st = agg.setdefault(fam, {"cmp": 0, "max_ulp": 0, "count_mismatch": 0, "groups": 0})
+        for expected, refreshed in groups:
+            st["groups"] += 1
+            if len(expected) != len(refreshed):
+                st["count_mismatch"] += 1
+                continue
+            for (ec, er), (rc, rr) in zip(expected, refreshed, strict=True):
+                cols = set(ec) | set(rc)
+                st["cmp"] += 1
+                d = ulp_diff(er, rr)
+                for j in cols:
+                    d = max(d, ulp_diff(ec.get(j, 0.0), rc.get(j, 0.0)))
+                st["max_ulp"] = max(st["max_ulp"], d)
+
+
+def main() -> int:
+    stems = sorted(p.stem for p in NL_DIR.glob("*.nl"))
+    print(f"E1 template-refresh parity over {len(stems)} vendored .nl instances")
+    print("Boxes per instance: root + 3 random shrink + 1 integer-pin (when available)\n")
+
+    agg: dict[str, dict] = {}
+    inv_stats = {"instances": 0, "coeff_box_dependent": 0, "churn_only": 0}
+    n_boxes = 0
+    n_inst = 0
+    failed: list[str] = []
+
+    for stem in stems:
+        try:
+            model = dm.from_nl(str(NL_DIR / f"{stem}.nl"))
+            lb, ub = flat_variable_bounds(model)
+            vtypes = _flat_variable_types(model)
+        except Exception as exc:  # noqa: BLE001
+            failed.append(f"{stem}({type(exc).__name__})")
+            continue
+        boxes = [("root", np.asarray(lb, float), np.asarray(ub, float))]
+        # Deterministic per-instance seed (builtin hash is per-process salted).
+        boxes += _child_boxes(lb, ub, vtypes, seed=zlib.crc32(stem.encode()) & 0xFFFF)
+
+        inv_by_box: list[Counter] = []
+        try:
+            for _name, blb, bub in boxes:
+                cap = _build_capture(model, (blb, bub))
+                _cmp_param(cap, agg)
+                inv_by_box.append(Counter((tuple(sorted(c.items())), r) for c, r in cap.invariant))
+                n_boxes += 1
+        except Exception as exc:  # noqa: BLE001
+            failed.append(f"{stem}(build:{type(exc).__name__}:{exc})")
+            continue
+        n_inst += 1
+
+        # Box-invariance of the invariant families. Compare each child box's
+        # invariant-row multiset against root. A row present in root but not the
+        # child (or vice-versa) is either (a) analyze-phase lift churn — a whole
+        # row added/removed, its column skeleton on only ONE side of the diff — or
+        # (b) a genuine coefficient box-dependence — the SAME column skeleton on
+        # BOTH sides with differing (coeffs, rhs). Only (b) fails templatability.
+        # The +/- pair of a churned exact link lands wholly on one side, so it is
+        # correctly read as churn, not a coeff change.
+        inv_stats["instances"] += 1
+        root_c = inv_by_box[0]
+        box_dep = False
+        churn = False
+        for bc in inv_by_box[1:]:
+            only_root = root_c - bc
+            only_box = bc - root_c
+            if not only_root and not only_box:
+                continue
+            rs = {tuple(j for j, _ in items) for (items, _r), _n in only_root.items()}
+            bs = {tuple(j for j, _ in items) for (items, _r), _n in only_box.items()}
+            if rs & bs:
+                box_dep = True
+            else:
+                churn = True
+        if box_dep:
+            inv_stats["coeff_box_dependent"] += 1
+        elif churn:
+            inv_stats["churn_only"] += 1
+
+    # ----- report ---------------------------------------------------------- #
+    print(f"Instances parity-checked: {n_inst}/{len(stems)}   boxes built: {n_boxes}")
+    if failed:
+        print(f"Failed: {', '.join(failed)}")
+    print()
+    total_cmp = sum(s["cmp"] for s in agg.values())
+    if total_cmp == 0:
+        print("FATAL: 0 coefficient comparisons executed", file=sys.stderr)
+        return 2
+    print(
+        f"{'box-parametric family':<28}{'groups':>9}{'coef cmps':>11}{'cnt-mism':>10}{'max ulp':>9}"
+    )
+    print("-" * 67)
+    overall_max = 0
+    overall_mism = 0
+    for fam, s in sorted(agg.items()):
+        print(f"{fam:<28}{s['groups']:>9}{s['cmp']:>11}{s['count_mismatch']:>10}{s['max_ulp']:>9}")
+        overall_max = max(overall_max, s["max_ulp"])
+        overall_mism += s["count_mismatch"]
+    print("-" * 67)
+    print(f"{'TOTAL':<28}{'':>9}{total_cmp:>11}{overall_mism:>10}{overall_max:>9}")
+    print(
+        f"\nBox-invariant families over {inv_stats['instances']} instances: "
+        f"coeff box-dependent = {inv_stats['coeff_box_dependent']}, "
+        f"lift-churn only (coeffs invariant) = {inv_stats['churn_only']}"
+    )
+
+    ok = overall_max <= 1 and overall_mism == 0 and inv_stats["coeff_box_dependent"] == 0
+    print("\nParity bar: max ulp <= 1, no count mismatch, no box-dependent invariant coeff.")
+    box_dep = inv_stats["coeff_box_dependent"]
+    print(
+        f"Result: {'PASS' if ok else 'FAIL'} (max ulp={overall_max}, "
+        f"count-mismatch={overall_mism}, invariant-coeff-box-dep={box_dep})"
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## E1 entry experiment: template-refresh parity

**Verdict: PASS** (kill criterion: <90% of panel rows templatable → FAIL; measured **100%**, and every implemented box-parametric family is exact to 0 ulp).

E1 (`docs/dev/scip-parity-kernel-plan.md` §3) is the go/no-go for P1: it must show that every relaxation row the uniform builder emits is reproducible by an analyze-phase **template** + a closed-form **refresh(box)** (a few flops, no JAX) — the precondition for moving the per-node loop into the compiled kernel.

No production code is touched. Three harnesses land under `discopt_benchmarks/scripts/`; `pytest -m smoke` is green (844 passed, 1 skipped, 2 xpassed) — unaffected, as expected.

### 1. Row-family census (`e1_row_family_census.py`)
Every emitted row is attributed to the **builder frame that emitted it**, read live from the call stack (`__name__`/`f_lineno`) — nothing transcribed. Over all **66/66** vendored `.nl` instances, **20,587** rows at the root box:

| family | rows | % total | templatable |
|---|---|---|---|
| mccormick_bilinear | 6927 | 33.65% | yes (box-parametric) |
| linear_passthrough | 6034 | 29.31% | yes (box-invariant) |
| univariate_tangent | 5215 | 25.33% | yes (box-parametric) |
| univariate_secant | 1739 | 8.45% | yes (box-parametric) |
| convex_lift_decision | 566 | 2.75% | yes (box-invariant link) |
| logspace_band | 106 | 0.51% | yes (box-invariant link) |
| **TEMPLATABLE TOTAL** | **20587** | **100.00%** | |

Two families the census first flagged non-templatable (`convex_lift_decision`, `logspace_band`) turned out to emit **only box-invariant exact affine links** (`w == dec`; `s == Σ aᵢ zᵢ`) — their *direct* rows have structural, box-independent coefficients (the OA tangents of the convex-lift are added lazily by the separation loop and are not base rows, so they do not appear here). Reclassified as templatable and proven so by harness (3).

Note: this is the **default (ungated) build**. Gated paths (RLT-quad, piecewise partition, finite-domain trig tables, LSE/norm atoms) do not fire on the panel and would need their own templates in P1/P2 — scoped, not silently included.

### 2. Independent refresh (`e1_refresh.py`)
Pure-numpy `refresh(box) → row coefficients` for the box-parametric families, written **from the envelope math** (McCormick 1976 inequalities; secant/tangent line constructions), not copied from the builder's dict-assembly — so a wrong formula fails the ulp bar. Refresh inputs are the static template (column identity + the atom stencil f/f′, which close over only atom identity/fixed exponent, never the box) plus the node interval bounds from the interval/FBBT pass.

### 3. Parity harness (`e1_template_refresh.py`)
Each instance is built the normal way and via templates+refresh at **root + 3 seeded random shrink boxes (10–50% inward per side) + 1 integer-pin box** = **326 boxes**. Every box-parametric row is reproduced and diffed coefficient-by-coefficient (ULP via IEEE-754 monotone ordering); the diff is in-place per emitter call, so no cross-box row matching is needed.

| box-parametric family | groups | coef cmps | count-mism | max ulp |
|---|---|---|---|---|
| mccormick_bilinear | 14885 | 34823 | 0 | 0 |
| objective_floor | 23 | 23 | 0 | 0 |
| univariate_secant_tangent | 13722 | 34978 | 0 | 0 |
| **TOTAL** | | **69824** | **0** | **0** |

Box-invariant families over 66 instances: **coeff box-dependent = 0**; lift-churn only (whole rows add/remove as curvature certifies across boxes, coefficients invariant) = 13.

### Falsification recorded against the plan
The plan's §2 template list ("McCormick bilinear, univariate secant/tangent, OA tangent stencils") is **incomplete** in one measured respect: the objective **separable-floor cut** (`obj_lin >= sep_lb`, emitted inline in `build_uniform_relaxation`) is a genuine box-parametric row — box-independent coefficients but a box-dependent RHS through `sep_lb`, a separable interval objective bound. The harness detected it (4 instances) as a box-dependent "invariant" row; it is now attributed and refreshed as its own `objective_floor` family (`sep_lb` treated as an interval/FBBT-layer input, exactly as McCormick endpoints are). P1's ProblemData/refresh must carry it, or the kernel's LP bound will differ from the legacy path on those objectives.

### What this means for P1
The mapping "box → relaxation rows" is fully closed-form on the certifying panel; the Rust refresh is a mechanical port of `e1_refresh.py`'s arithmetic. FBBT (node interval bounds) and the separable objective floor are the two per-box inputs refresh consumes, both already present in the Rust presolve layer.

Contributes to the P1 SCIP-parity kernel track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
