### PR TITLE
bench(#844): P2(a) presolve-parity entry experiment — NEW-ALGORITHM verdict

### DIFF
--- a/discopt_benchmarks/scripts/presolve_reduction_census.py
+++ b/discopt_benchmarks/scripts/presolve_reduction_census.py
@@ -1,0 +1,105 @@
+"""Structural census of SCIP's reduction on the G-G instances.
+
+For each instance: classify every EQUALITY constraint by arity (# distinct
+scalar-var leaves in a linear body): 1-var (singleton pin -> eliminate.rs),
+2-var (affine substitution -> aggregate.rs), >=3-var linear, nonlinear.
+
+This tells us what fraction of SCIP's var reduction is reachable by discopt's
+existing eliminate/aggregate transforms vs. requires new algorithm (>=3-var
+Gaussian pivoting / doubleton chains where target appears in many rows).
+
+Executed-count discipline: prints total examined + each bucket; fails at zero.
+"""
+
+import sys
+import time
+
+import discopt.modeling as dm
+from discopt._jax.problem_classifier import (
+    _extract_linear_coefficients_sparse,
+    _NotLinearError,
+)
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"
+
+
+def census(inst):
+    path = f"{NL}/{inst}.nl"
+    print(f"\n{'=' * 78}\nCENSUS: {inst}\n{'=' * 78}")
+    t0 = time.time()
+    model = dm.from_nl(path)
+    print(f"from_nl in {time.time() - t0:.2f}s")
+    n = sum(v.size for v in model._variables)
+    ncons = len(model._constraints)
+    nvars = len(model._variables)
+    print(f"vars(blocks)={nvars} flat={n} cons={ncons}")
+
+    n_eq = 0
+    n_ineq = 0
+    eq_1var = 0
+    eq_2var = 0
+    eq_3plus = 0
+    eq_nonlinear = 0
+    examined = 0
+    # Track, for 2-var eqs, how often each variable appears (to detect whether
+    # aggregate's "target appears in exactly one eq" precondition holds, i.e.
+    # doubleton chains where a var appears in many rows).
+    from collections import Counter
+
+    var_eq_degree = Counter()  # flat var index -> # of 2-var-or-less eqs touching it
+
+    t0 = time.time()
+    for con in model._constraints:
+        examined += 1
+        sense = getattr(con, "sense", None)
+        if sense == "==":
+            n_eq += 1
+        else:
+            n_ineq += 1
+            continue
+        try:
+            terms, _const = _extract_linear_coefficients_sparse(con.body, model, n)
+        except _NotLinearError:
+            eq_nonlinear += 1
+            continue
+        except Exception:
+            eq_nonlinear += 1
+            continue
+        nz = [i for i, c in terms.items() if abs(c) > 1e-12]
+        k = len(nz)
+        if k <= 1:
+            eq_1var += 1
+            for i in nz:
+                var_eq_degree[i] += 1
+        elif k == 2:
+            eq_2var += 1
+            for i in nz:
+                var_eq_degree[i] += 1
+        else:
+            eq_3plus += 1
+    dt = time.time() - t0
+    print(f"scanned {examined} constraints in {dt:.2f}s")
+    assert examined > 0, "CENSUS EXAMINED ZERO CONSTRAINTS"
+    print(f"  equalities:          {n_eq}")
+    print(f"  inequalities:        {n_ineq}")
+    print(f"  eq 1-var (singleton, eliminate.rs): {eq_1var}")
+    print(f"  eq 2-var (doubleton, aggregate.rs): {eq_2var}")
+    print(f"  eq >=3-var linear (needs Gaussian): {eq_3plus}")
+    print(f"  eq nonlinear:                       {eq_nonlinear}")
+    # How many 2-var/1-var eqs have BOTH endpoints appearing in exactly one such eq?
+    # (aggregate precondition: target var appears in exactly one expression total).
+    solo = sum(1 for _i, d in var_eq_degree.items() if d == 1)
+    multi = sum(1 for _i, d in var_eq_degree.items() if d > 1)
+    print(f"  vars touching exactly one (1-or-2)-var eq: {solo}")
+    print(f"  vars touching >1 such eq (chains):         {multi}")
+    reducible_est = eq_1var + eq_2var
+    print(
+        f"  ESTIMATE reducible-by-existing-transforms (1var+2var eq): {reducible_est} "
+        f"= {100.0 * reducible_est / max(n_eq, 1):.1f}% of equalities"
+    )
+
+
+if __name__ == "__main__":
+    which = sys.argv[1:] if len(sys.argv) > 1 else ["gastrans040", "gastrans582_cold13"]
+    for inst in which:
+        census(inst)

--- a/discopt_benchmarks/scripts/presolve_reduction_entry.py
+++ b/discopt_benchmarks/scripts/presolve_reduction_entry.py
@@ -1,0 +1,78 @@
+"""P2(a) entry experiment: measure discopt's existing presolve reduction on
+the three G-G instances, per-pass, vars/cons before->after with wall time.
+
+Run with `python -u` for unbuffered output. Tight per-pass caps so aggregate's
+O(n^2) loop returns its achieved-under-budget reduction rather than hanging.
+Executed-count discipline: a pass that reduces nothing prints REDUCES-NOTHING.
+"""
+
+import sys
+import time
+
+from discopt._rust import parse_nl_file
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"
+INSTANCES = ["gastrans040", "gastrans582_cold13", "watercontamination0202"]
+
+# Reduction-relevant passes (change var/constraint COUNT), measured alone.
+SINGLE_PASSES = ["eliminate", "aggregate", "factorable_elim"]
+# Full reducer set to a fixed point (what a real presolve would chain).
+FULL_SET = ["eliminate", "aggregate", "factorable_elim", "simplify", "fbbt"]
+
+PASS_CAP_MS = 30000  # per single-pass budget
+FULL_CAP_MS = 60000  # full-set budget
+
+
+def counts(r):
+    return r.n_vars, r.n_var_blocks, r.n_constraints
+
+
+def presolve(r, passes, cap_ms):
+    t0 = time.time()
+    new_r, stats = r.presolve(
+        passes=passes,
+        max_iterations=32,
+        time_limit_ms=cap_ms,
+        work_unit_budget=0,
+        fbbt_max_iter=20,
+        fbbt_tol=1e-8,
+        reduced_cost_info=None,
+    )
+    return new_r, stats, time.time() - t0
+
+
+def run_one(inst):
+    path = f"{NL}/{inst}.nl"
+    print(f"\n{'=' * 78}\nINSTANCE: {inst}\n{'=' * 78}", flush=True)
+    v0, b0, c0 = counts(parse_nl_file(path))
+    print(f"baseline  vars={v0}  cons={c0}", flush=True)
+
+    for pname in SINGLE_PASSES:
+        r = parse_nl_file(path)
+        vb, bb, cb = counts(r)
+        new_r, stats, dt = presolve(r, [pname], PASS_CAP_MS)
+        v1, b1, c1 = counts(new_r)
+        dv, dc = vb - v1, cb - c1
+        ratio = (vb / v1) if v1 else float("inf")
+        tag = "REDUCES-NOTHING" if (dv == 0 and dc == 0) else f"-{dv}v -{dc}c ({ratio:.2f}x)"
+        print(
+            f"  {pname:16s} {vb:>7d}->{v1:<7d}v {cb:>7d}->{c1:<7d}c "
+            f"{dt:6.2f}s term={stats['terminated_by']} it={stats['iterations']}  {tag}",
+            flush=True,
+        )
+
+    r = parse_nl_file(path)
+    vb, bb, cb = counts(r)
+    new_r, stats, dt = presolve(r, FULL_SET, FULL_CAP_MS)
+    v1, b1, c1 = counts(new_r)
+    ratio = (vb / v1) if v1 else float("inf")
+    print(
+        f"  FULL_SET         {vb:>7d}->{v1:<7d}v {cb:>7d}->{c1:<7d}c "
+        f"{dt:6.2f}s term={stats['terminated_by']} it={stats['iterations']}  ({ratio:.2f}x)",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    for inst in sys.argv[1:] or INSTANCES:
+        run_one(inst)

--- a/docs/dev/sota-parity-analysis-2026-07-27.md
+++ b/docs/dev/sota-parity-analysis-2026-07-27.md
@@ -196,6 +196,55 @@ likely a one-line gate, blocked on reproducing the #843 discrepancy. **(c) genui
 primal constructors** (LP feasibility pump, pscost diving — both named by SCIP's own
 stats) for whatever remains after (a) and (b).
 
+> **P2(a) entry-experiment result (2026-07-27, iteration 2, Contributes to #844).**
+> The wiring hypothesis above — *"the first question is wiring, not new algorithms"* —
+> is **FALSIFIED**. Existing passes invoked directly on the instances (scripts
+> `discopt_benchmarks/scripts/presolve_reduction_{entry,census}.py`) achieve, best
+> case across `{eliminate, aggregate, factorable_elim, simplify, fbbt}`:
+>
+> | instance | discopt achieved (wall/term) | SCIP reference |
+> |---|---|---|
+> | `gastrans040` | 279 → 269 vars (**1.04×**), 1.6 s NoProgress | 279 → 80 (**3.5×**), 0.06 s |
+> | `gastrans582_cold13` | 2,186 → 2,025 vars (**1.08×**), 60 s TimeBudget | 2,186 → 598 (**3.7×**), 5.4 s |
+> | `watercontamination0202` | 106,711 → 106,711 vars (**1.00×**) FULL_SET / 106,369 (aggregate-alone, **342 vars in 30 s**) | 106,711 → 566 (**189×**), 0.19 s |
+>
+> Two independent root causes, **both new-algorithm, not wiring**:
+> 1. **No general affine substitution.** `eliminate`/`aggregate`/`factorable_elim`
+>    each require the eliminated variable to appear in *exactly one expression*
+>    (its defining equality, nowhere else). SCIP substitutes a doubleton-defined
+>    variable *out of every row and the objective* it appears in. On `gastrans040`
+>    the census finds 105 doubleton equalities but `aggregate` fires on only 10 —
+>    the rest define variables that also appear in inequalities, so the precondition
+>    rejects them. This is the binding limit where time is *not* the constraint
+>    (`gastrans040` finished with NoProgress at 1.04×).
+> 2. **Superlinear implementation.** `aggregate_variables_until` rescans every
+>    constraint per aggregation (O(applications × rows)); measured ≈11 aggregations/s
+>    on `watercontamination0202` (342 in 30 s), projecting **~2.6 h** for the full
+>    reduction SCIP does in 0.19 s. In `FULL_SET` the slow `eliminate` pass starves
+>    `aggregate` of the shared budget → 1.00× (0 vars) in 60 s.
+>
+> Plus a **plumbing** gap that blocks *using* any reduction even if achieved: the
+> reduced `ModelRepr` is discarded on the solve path (`propagate_bounds_to_model`
+> copies bounds only; `solver.py:6043` never consumes the aggregated model), and
+> **no postsolve is chained** — `AggregationRecord` is recorded but never inverted
+> (`orchestrator.rs:140`, `aggregate.rs:79`: *"does not currently chain post-solve
+> recovery"*), so solutions cannot be reported/verified in original variables.
+>
+> **Structural census (`watercontamination0202`):** 106,201 equalities (0 nonlinear),
+> = 15,834 singleton + 81,821 doubleton + 8,546 ≥3-var linear. **92 % of the reduction
+> is plain 1-or-2-var equality aggregation** — so the *transform class* SCIP uses is
+> not exotic, but discopt has no scalable, substitute-everywhere implementation of it,
+> and 8 % (8,546 rows) additionally needs ≥3-var Gaussian elimination that no pass has.
+>
+> **Kill verdict: NEW-ALGORITHM. STOP — do not build a new presolver in this
+> iteration.** Scope for a follow-up (P2(a′)): (i) a batch substitution-graph
+> aggregator (union-find over doubleton/singleton equalities, one rewrite pass,
+> substitute-everywhere semantics) replacing the O(n²) rescan; (ii) ≥3-var free-column
+> Gaussian elimination; (iii) a reduced-model solve entry + postsolve chain that
+> inverts `AggregationRecord`/`factorable_elim` records and feasibility-verifies the
+> recovered point against the pristine model. Bound-changing ⇒ full §5 differential
+> panel before any default.
+
 **Evidence it is required:** the G-B table — six instances at "no incumbent in 60 s" vs
 SCIP ≤ 18.7 s, all with `=opt=` oracles. Evidence of tractability: plunging's measured
 17× quality jump on the same class (#880); `ball_mk2_30`'s node loop reaches bound −26.9


### PR DESCRIPTION
## P2(a) presolve-parity entry experiment (iteration 2)

Executes the entry experiment from `docs/dev/sota-parity-analysis-2026-07-27.md`
§G-G / P2(a): does discopt's existing Rust presolve reach SCIP-class model
reduction on the three no-incumbent instances, and is it a **wiring** or a
**new-algorithm** problem?

**This PR ships measurement + a scoping amendment only — no solver behavior
changes.** The entry-experiment kill criterion fired NEW-ALGORITHM, so per
CLAUDE.md §4 / the plan's own gate I did **not** start building a new presolver.

### Verdict: NEW-ALGORITHM (wiring hypothesis FALSIFIED)

Existing passes invoked directly on the instances (fresh parse each), best case
across `{eliminate, aggregate, factorable_elim, simplify, fbbt}`:

| instance | discopt achieved | SCIP reference |
|---|---|---|
| `gastrans040` | 279 → 269 vars (**1.04×**), NoProgress | 279 → 80 (**3.5×**), 0.06 s |
| `gastrans582_cold13` | 2,186 → 2,025 vars (**1.08×**), 60 s TimeBudget | 2,186 → 598 (**3.7×**), 5.4 s |
| `watercontamination0202` | 106,711 → 106,711 (**1.00×**) FULL_SET; aggregate-alone 342 vars in 30 s | 106,711 → 566 (**189×**), 0.19 s |

The kill criterion (< 10× reduction on watercontamination) is met decisively
(~1.00×). Root causes, both new-algorithm:

1. **No general affine substitution.** `eliminate`/`aggregate`/`factorable_elim`
   all require the eliminated variable to appear in *exactly one expression*.
   SCIP substitutes a doubleton-defined variable out of *every* row + objective.
   On `gastrans040` the census finds 105 doubleton equalities but `aggregate`
   fires on only 10 (the rest also appear in inequalities) — and it finishes with
   NoProgress at 1.04×, so time is *not* the binding constraint there.
2. **Superlinear implementation.** `aggregate_variables_until` rescans every
   constraint per aggregation; ≈11 aggregations/s on watercontamination
   (342 in 30 s) projects **~2.6 h** for the full reduction SCIP does in 0.19 s.

Plus a **plumbing** gap that blocks *using* any reduction: the reduced
`ModelRepr` is discarded on the solve path (`propagate_bounds_to_model` copies
bounds only; `solver.py:6043`), and **no postsolve is chained** —
`AggregationRecord` is recorded but never inverted (`orchestrator.rs:140`,
`aggregate.rs:79`).

### Structural census (`watercontamination0202`)

106,201 equalities (0 nonlinear) = 15,834 singleton + 81,821 doubleton + 8,546
≥3-var linear. **92 % of the reduction is plain 1-or-2-var equality aggregation**
— the transform class is not exotic, but discopt has no scalable
substitute-everywhere implementation, and 8 % needs ≥3-var Gaussian elimination
no pass has.

### Scope handed to follow-up (P2(a′))

(i) batch substitution-graph aggregator (union-find, one rewrite, substitute
everywhere) replacing the O(n²) rescan; (ii) ≥3-var free-column Gaussian
elimination; (iii) reduced-model solve entry + postsolve chain inverting the
aggregation records and feasibility-verifying against the pristine model.
Bound-changing ⇒ full §5 differential panel before any default.

### What changed here

- `docs/dev/sota-parity-analysis-2026-07-27.md` — dated P2(a) entry-experiment
  result block recording the falsification and the follow-up scope.
- `discopt_benchmarks/scripts/presolve_reduction_entry.py` — per-pass reduction
  measurement (reproduces the table).
- `discopt_benchmarks/scripts/presolve_reduction_census.py` — equality-arity
  structural census (reproduces the 92 % figure).

### Verification

- `pytest -m smoke` — see PR checks.
- No Rust or solver code touched (docs + measurement scripts only), so behavior
  is unchanged by construction.
- Instances read from the local MINLPLib snapshot; oracle senses/optima read from
  `minlplib.solu` / `scip_join.csv` in the measuring run (all minimize; water opt
  125.196, both gastrans 0).

Contributes to #844. References #875's G-G finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
