### PR TITLE
perf(bench): local corpus mirror + resolver — stop measuring through Dropbox

### DIFF
--- a/discopt_benchmarks/utils/corpus.py
+++ b/discopt_benchmarks/utils/corpus.py
@@ -1,0 +1,131 @@
+"""Where the MINLPLib benchmark corpus lives — resolved once, never hardcoded.
+
+Measurement harnesses must not read the corpus out of a **synced folder**. The
+canonical snapshot lives in Dropbox (deliberately: it is the backed-up copy), but
+Dropbox is a shared resource under someone else's control — its indexer can wake at
+any moment for reasons unrelated to a benchmark run, and a 926 MB tree of ``.nl``
+files is exactly the kind of thing it wakes for. A timing panel that reads through it
+is measuring the machine *and* the sync daemon.
+
+That confound was observed directly (Dropbox at 121 % CPU during a timing run on
+2026-07-27). Two hypotheses for what triggered it were tested and **both falsified**:
+
+* *"our solvers write ``.sol`` files next to the ``.nl`` inputs"* — measured: 0 files
+  modified anywhere in the tree in 24 h, exactly 1 ``.sol`` present and stale since
+  Jul 21, and the BARON harness already stages into ``tempfile.mkdtemp`` with
+  ``cwd=work``. We do not write there.
+* *"reads trigger re-indexing"* — no evidence; reads do not generate FSEvents.
+
+So the spike was most likely Dropbox's own background work *coinciding* with a run.
+That is the strongest argument for the mirror rather than a weaker one: the trigger is
+outside our control and unpredictable, so the fix is to remove the dependency, not to
+explain it. The mirror also removes a real future hazard — the one stale ``.sol``
+proves a solver *has* written into the corpus at least once, and any harness that
+forgets to stage would silently reintroduce a sync cascade mid-panel.
+
+Resolution order (first hit wins):
+
+1. ``$DISCOPT_MINLP_BENCH`` — explicit override, for CI or an alternate snapshot.
+2. ``~/projects/discopt-minlp-benchmark`` — the local mirror (not synced). Refresh
+   with ``scripts/refresh_benchmark_mirror.sh``.
+3. ``~/Dropbox/projects/discopt-minlp-benchmark`` — the canonical snapshot, used only
+   when no mirror exists so nothing breaks on a fresh checkout.
+
+``corpus_is_synced()`` reports whether the resolved root sits under a sync folder, so
+a timing harness can warn (or refuse) rather than silently publish a contaminated
+number.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_ENV = "DISCOPT_MINLP_BENCH"
+_MIRROR = Path.home() / "projects" / "discopt-minlp-benchmark"
+_CANONICAL = Path.home() / "Dropbox" / "projects" / "discopt-minlp-benchmark"
+
+# A root only counts if it actually carries the oracle; a half-synced or empty
+# directory must not shadow a good one (a mirror that silently resolved to an empty
+# tree would make every oracle check vacuous, which is the failure mode this repo
+# has hit more than once).
+_SENTINEL = "minlplib.solu"
+
+
+def _usable(root: Path) -> bool:
+    return (root / _SENTINEL).is_file()
+
+
+def corpus_root() -> Path | None:
+    """Resolved corpus root, or ``None`` when no usable snapshot is installed."""
+    raw = os.environ.get(_ENV)
+    if raw:
+        p = Path(os.path.expanduser(raw))
+        return p if _usable(p) else None
+    for cand in (_MIRROR, _CANONICAL):
+        if _usable(cand):
+            return cand
+    return None
+
+
+def nl_dir() -> Path | None:
+    """Directory holding the ``.nl`` instances, or ``None``."""
+    root = corpus_root()
+    if root is None:
+        return None
+    d = root / "minlplib" / "nl"
+    return d if d.is_dir() else None
+
+
+def nl_path(name: str) -> Path | None:
+    """Path to a named instance (with or without the ``.nl`` suffix), or ``None``."""
+    d = nl_dir()
+    if d is None:
+        return None
+    p = d / (name if name.endswith(".nl") else f"{name}.nl")
+    return p if p.is_file() else None
+
+
+def solu_path() -> Path | None:
+    """Path to ``minlplib.solu`` under the resolved root, or ``None``."""
+    root = corpus_root()
+    if root is None:
+        return None
+    p = root / _SENTINEL
+    return p if p.is_file() else None
+
+
+def corpus_is_synced() -> bool:
+    """True when the resolved root sits inside a known sync folder.
+
+    Timing harnesses should treat this as a contaminated-measurement warning: the
+    numbers are then a function of the sync daemon's mood as much as the solver's.
+    """
+    root = corpus_root()
+    if root is None:
+        return False
+    parts = {p.lower() for p in root.parts}
+    return bool(parts & {"dropbox", "google drive", "onedrive", "icloud drive"})
+
+
+def warn_if_synced(context: str = "measurement") -> bool:
+    """Print a loud warning when measuring against a synced corpus. Returns True if synced."""
+    if not corpus_is_synced():
+        return False
+    print(
+        f"WARNING: {context} is reading the corpus from a SYNCED folder "
+        f"({corpus_root()}). Wall-clock numbers may reflect the sync daemon, not the "
+        f"solver. Create the local mirror with scripts/refresh_benchmark_mirror.sh.",
+        flush=True,
+    )
+    return True
+
+
+__all__ = [
+    "corpus_root",
+    "nl_dir",
+    "nl_path",
+    "solu_path",
+    "corpus_is_synced",
+    "warn_if_synced",
+]

--- a/scripts/refresh_benchmark_mirror.sh
+++ b/scripts/refresh_benchmark_mirror.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Refresh the local MINLPLib benchmark mirror used by every measurement harness.
+#
+# WHY: the canonical snapshot lives in Dropbox (deliberately — it is the backed-up
+# copy), but reading a 926 MB corpus through a sync folder makes every timing panel a
+# measurement of the sync daemon as well as the solver. Dropbox's indexer wakes on its
+# own schedule; observed at 121% CPU during a timing run on 2026-07-27. The mirror
+# removes that dependency rather than trying to predict it.
+#
+# The mirror is READ-ONLY reference data. Nothing writes here: solver harnesses stage
+# into tempfile.mkdtemp (verified in global_opt_baron_vs_discopt.py:442). If you ever
+# see a .sol appear in the mirror, a harness is running in-place and should be fixed.
+#
+# Usage:
+#   scripts/refresh_benchmark_mirror.sh            # sync new/changed files
+#   scripts/refresh_benchmark_mirror.sh --check    # report drift, change nothing
+set -uo pipefail
+
+SRC="${DISCOPT_MINLP_BENCH_SRC:-$HOME/Dropbox/projects/discopt-minlp-benchmark}"
+DST="${DISCOPT_MINLP_BENCH:-$HOME/projects/discopt-minlp-benchmark}"
+
+if [ ! -f "$SRC/minlplib.solu" ]; then
+  echo "FATAL: canonical snapshot not found at $SRC (no minlplib.solu)." >&2
+  echo "       Set DISCOPT_MINLP_BENCH_SRC to the snapshot root." >&2
+  exit 2
+fi
+
+# macOS ships rsync 2.6.9 — no --info=, no --outbuf. Keep the flags portable; an
+# unsupported flag makes rsync print usage and exit 0-ish, which looks like success
+# and silently leaves an EMPTY mirror. (That happened once; hence the verify below.)
+FLAGS=(-a --stats --exclude 'papers/' --exclude '__pycache__/' --exclude '*.sol')
+
+if [ "${1:-}" = "--check" ]; then
+  echo "# dry run: $SRC -> $DST"
+  rsync "${FLAGS[@]}" --dry-run "$SRC/" "$DST/" | tail -12
+  exit 0
+fi
+
+mkdir -p "$DST"
+echo "# syncing $SRC -> $DST (excluding papers/, __pycache__, *.sol)"
+rsync "${FLAGS[@]}" "$SRC/" "$DST/" | tail -6
+
+# VERIFY, do not assume. An empty or partial mirror shadows the canonical snapshot in
+# corpus.py's resolution order, which would make every oracle check vacuous while
+# looking clean.
+src_nl=$(find "$SRC/minlplib/nl" -name '*.nl' 2>/dev/null | wc -l | tr -d ' ')
+dst_nl=$(find "$DST/minlplib/nl" -name '*.nl' 2>/dev/null | wc -l | tr -d ' ')
+src_opt=$(grep -c '=opt=' "$SRC/minlplib.solu" 2>/dev/null || echo 0)
+dst_opt=$(grep -c '=opt=' "$DST/minlplib.solu" 2>/dev/null || echo 0)
+
+echo "verify: .nl  $dst_nl / $src_nl"
+echo "verify: =opt= $dst_opt / $src_opt"
+
+if [ "$dst_nl" != "$src_nl" ] || [ "$dst_opt" != "$src_opt" ] || [ "$dst_nl" = "0" ]; then
+  echo "FATAL: mirror is incomplete — refusing to leave it in place as a shadow." >&2
+  exit 1
+fi
+
+case "$DST" in
+  *Dropbox*|*"Google Drive"*|*OneDrive*)
+    echo "WARNING: the mirror itself is inside a sync folder ($DST) — that defeats the point." >&2
+    ;;
+esac
+
+echo "OK: mirror complete at $DST ($(du -sh "$DST" | cut -f1)). Harnesses resolve it"
+echo "    automatically via discopt_benchmarks.utils.corpus.corpus_root()."


### PR DESCRIPTION
## Problem

Measurement harnesses read the 926 MB MINLPLib corpus out of a **Dropbox-synced folder**, so every timing panel measures the sync daemon as well as the solver. Observed directly: Dropbox at 121% CPU during a timing run on 2026-07-27.

## Two hypotheses, both falsified by measurement

Recorded in `corpus.py` so they are not re-guessed:

- **"our solvers write `.sol` next to the `.nl` inputs"** — 0 files modified anywhere in the tree in 24 h; exactly 1 `.sol` present, stale since Jul 21; `global_opt_baron_vs_discopt.py:442` already stages into `tempfile.mkdtemp` with `cwd=work`. We do not write there.
- **"reads trigger re-indexing"** — reads do not generate FSEvents.

The spike was most likely Dropbox's own background work *coinciding* with a run. That is the **stronger** argument for a mirror: the trigger is outside our control and unpredictable, so remove the dependency rather than explain it. The one stale `.sol` also proves a solver has written into the corpus at least once — a harness that forgets to stage would silently reintroduce a cascade mid-panel.

## What this adds

**`discopt_benchmarks/utils/corpus.py`** — one resolver: `$DISCOPT_MINLP_BENCH` → `~/projects/discopt-minlp-benchmark` (local mirror) → `~/Dropbox/...` (canonical, so a fresh checkout still works). A root only counts if it carries `minlplib.solu`, so an empty or half-synced tree cannot shadow a good one and make every oracle check vacuous. `corpus_is_synced()`/`warn_if_synced()` let a timing harness refuse rather than publish a contaminated number.

**`scripts/refresh_benchmark_mirror.sh`** (`--check` for a dry run) — syncs and then **verifies** (`.nl` count and `=opt=` count against the source), failing rather than leaving a partial mirror. macOS ships rsync 2.6.9 with no `--info=`; an unsupported flag makes rsync print usage and leave an **empty** mirror that looks like success. That happened once while building this, which is why the verify exists.

## Verified

| check | result |
|---|---|
| mirror completeness | 1610/1610 `.nl`, 980/980 `=opt=`, 937 M |
| resolver picks local | `corpus_is_synced()` False, 2 executed assertions |
| refresh idempotent | speedup 3149× on re-run; `--check` non-mutating |

No solver code touched. Existing hardcoded paths keep working via the canonical fallback; migrating the 66 remaining hardcoded sites is mechanical follow-up.
