### PR TITLE
feat(presolve): #844 batch substitution-graph aggregator + postsolve chain (P2(a'))

### DIFF
--- a/crates/discopt-core/src/presolve/mod.rs
+++ b/crates/discopt-core/src/presolve/mod.rs
@@ -43,6 +43,7 @@ pub mod reduction_constraints;
 pub mod redundancy;
 pub mod scaling;
 pub mod simplify;
+pub mod substitute;
 pub mod symmetry;
 
 pub use aggregate::{
@@ -81,4 +82,8 @@ pub use reduction_constraints::{detect_reduction_constraints, ReductionStats};
 pub use redundancy::{detect_row_redundancy, RedundancyStats};
 pub use scaling::{compute_equilibration, ScalingFactors, ScalingStats};
 pub use simplify::{simplify, simplify_until, SimplifyResult};
+pub use substitute::{
+    postsolve_chain, postsolve_point, substitute_to_fixpoint, substitute_variables, SubstDef,
+    SubstitutionRecord, SubstitutionStats,
+};
 pub use symmetry::{detect_symmetries, Orbit, SymmetryStats};

--- a/crates/discopt-core/src/presolve/substitute.rs
+++ b/crates/discopt-core/src/presolve/substitute.rs
@@ -1,0 +1,1338 @@
+//! Batch substitution-graph aggregator — P2(a′) item (i) (issue #844).
+//!
+//! ## Why this exists
+//!
+//! [`super::aggregate::aggregate_variables`] and
+//! [`super::eliminate::eliminate_variables`] both require the eliminated
+//! variable to appear in **exactly one expression** (its defining equality and
+//! nowhere else), and both rescan every constraint per aggregation. The
+//! P2(a) entry experiment (`docs/dev/sota-parity-analysis-2026-07-27.md`)
+//! measured the consequences on `watercontamination0202` (106,711 vars,
+//! 106,201 linear equalities): 342 aggregations in 30 s (≈11/s, projecting
+//! ~2.6 h) for a 1.00× reduction, against SCIP's 189× in 0.19 s.
+//!
+//! This pass removes both limitations at once:
+//!
+//! 1. **Substitute-everywhere semantics.** An eliminated variable is rewritten
+//!    out of *every* expression it appears in — inequalities, nonlinear rows
+//!    and the objective included — not just its defining equality.
+//! 2. **One rewrite pass.** All definitions are resolved *first* (into affine
+//!    maps onto a surviving representative), then a single walk over the
+//!    expression DAG applies every substitution and the variable renumbering
+//!    together. Cost is O(nnz + nodes + eliminations·α) rather than
+//!    O(eliminations × rows).
+//!
+//! ## The transform
+//!
+//! Every `Eq` row with a linear (total-degree-1) body is resolved into
+//! *representative space* by the union-find below. A row that lands on
+//!
+//! ```text
+//!   one representative:   A·x_r == R          ⇒  x_r fixed to R/A
+//!   two representatives:  A·x_p + B·x_q == R  ⇒  x_p = (−B/A)·x_q + R/A
+//! ```
+//!
+//! contributes an elimination. The union-find carries an **affine potential**:
+//! each non-root block `i` stores `x_i = coeff_i · x_parent(i) + offset_i`, and
+//! `find` composes the maps along the path (with path compression). Chains of
+//! arbitrary depth therefore collapse to a *direct* definition on the class
+//! representative, which is why postsolve needs no topological ordering (see
+//! [`postsolve_point`]).
+//!
+//! A row whose variables all resolve to representatives that are already
+//! related — the **cycle** case — carries no new elimination: it is rejected
+//! and left in the model, where FBBT/redundancy can act on it. Rejecting
+//! rather than "simplifying" keeps this pass an exact reformulation.
+//!
+//! ## Exactness
+//!
+//! The transform is an equivalence, not a relaxation. For every eliminated
+//! block `e` with `x_e = c·x_s + o`:
+//!
+//! - the defining row is dropped, and it holds by construction at any point of
+//!   the reduced model lifted through the definition;
+//! - `x_e ∈ [l_e, u_e]` is an interval constraint on a *bijective* affine
+//!   image of `x_s`, so it transfers **exactly** onto `x_s`'s bounds
+//!   (`scale_interval` below). Nothing is dropped and nothing is relaxed.
+//!
+//! Consequently: #eliminated blocks == #dropped rows exactly (asserted), the
+//! objective value is preserved, and a feasible point of the reduced model
+//! lifts to a feasible point of the original.
+//!
+//! ## Numerical guards (why these thresholds)
+//!
+//! Substituting `x = m·y + q` multiplies every coefficient on `x` by `m` and
+//! injects `q` into every row's constant. Unchecked, a near-zero pivot turns a
+//! well-scaled model into an ill-conditioned one, so a candidate is rejected
+//! (the row is *kept* — nothing is lost but the reduction) when:
+//!
+//! - the pivot is below [`MIN_PIVOT_ABS`] in absolute value: at that magnitude
+//!   a coefficient is indistinguishable from a structural zero produced by
+//!   cancellation while resolving the row into representative space;
+//! - the pivot is below [`PIVOT_REL`] times the row's largest resolved
+//!   coefficient, which caps the per-step multiplier `|m|` at `1/PIVOT_REL`;
+//! - the *composed* multiplier or offset anywhere in the merged class would
+//!   exceed [`MAX_ABS_COEFF`] / [`MAX_ABS_OFFSET`]. Chains compose
+//!   multiplicatively, so a per-step cap alone does not bound a chain; the
+//!   union-find carries a per-class running maximum and a union is rejected
+//!   *before* it is applied when the merge would breach the cap.
+//!
+//! Both caps are on measurable quantities and every rejection is counted in
+//! [`SubstitutionStats`], so a disappointing reduction can be attributed
+//! rather than guessed at.
+//!
+//! ## Scope (v0)
+//!
+//! - Eliminated blocks must be **continuous**, **scalar** (`size == 1`) and
+//!   have exactly one `Variable` leaf in the arena. Integer/binary blocks are
+//!   never eliminated (substituting them out would move an integrality
+//!   requirement onto an affine image of another variable); they may serve as
+//!   *sources*, which is sound precisely because the eliminated variable is
+//!   continuous.
+//! - Only rows resolving to ≤ 2 representatives define a substitution.
+//!   General ≥3-variable Gaussian elimination is item (ii) of the P2(a′)
+//!   scope and is not done here.
+//! - Rows with more than [`MAX_ROW_TERMS`] linear monomials are skipped as
+//!   definition candidates (resolving them is quadratic in the term count and
+//!   they are never doubletons); they are of course still *rewritten*.
+//!
+//! ## Determinism
+//!
+//! Rows are processed in `model.constraints` order; ties in pivot choice break
+//! on the lower block index; eliminated blocks are emitted in ascending block
+//! order; `HashMap`s are only point-queried, never iterated on a result path.
+
+use std::collections::{HashMap, HashSet};
+
+use super::polynomial::try_polynomial;
+use crate::expr::{BinOp, ConstraintRepr, ConstraintSense, ExprArena, ExprId, ExprNode, ModelRepr};
+use crate::expr::{VarInfo, VarType};
+
+/// Smallest absolute pivot coefficient accepted for a substitution.
+pub const MIN_PIVOT_ABS: f64 = 1e-9;
+/// Smallest pivot accepted *relative* to the row's largest resolved
+/// coefficient. Caps the per-step substitution multiplier at `1 / PIVOT_REL`.
+pub const PIVOT_REL: f64 = 1e-6;
+/// Cap on the composed multiplier `|c|` of any eliminated block's definition.
+pub const MAX_ABS_COEFF: f64 = 1e6;
+/// Cap on the composed offset `|o|` of any eliminated block's definition.
+pub const MAX_ABS_OFFSET: f64 = 1e9;
+/// Maximum linear monomials in a row considered as a definition candidate.
+pub const MAX_ROW_TERMS: usize = 64;
+/// Relative slack when testing whether a transferred interval is empty or a
+/// fixed value violates its declared bounds.
+const FEAS_TOL: f64 = 1e-9;
+
+/// How an eliminated variable is recovered from the reduced solution.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SubstDef {
+    /// `x = value` — determined by a row that resolved to a single
+    /// representative (possibly after chain resolution).
+    Fixed(f64),
+    /// `x = coeff · x[source_block] + offset`, where `source_block` is a
+    /// **surviving** block index in the *input* model's numbering.
+    Affine {
+        /// Input-model block index of the surviving source variable.
+        source_block: usize,
+        /// Multiplier.
+        coeff: f64,
+        /// Additive offset.
+        offset: f64,
+    },
+}
+
+/// One recorded elimination, in input-model block numbering.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubstitutionRecord {
+    /// Block index of the eliminated variable in the *input* model.
+    pub eliminated_block: usize,
+    /// How to recover it.
+    pub def: SubstDef,
+}
+
+/// Statistics and the postsolve payload from one substitution run.
+#[derive(Debug, Clone, Default)]
+pub struct SubstitutionStats {
+    /// Number of variable blocks removed.
+    pub variables_eliminated: usize,
+    /// Number of equalities dropped. Always equals `variables_eliminated`.
+    pub equalities_dropped: usize,
+    /// Linear equality rows examined as definition candidates.
+    pub candidate_rows: usize,
+    /// Rows rejected because they resolved to 0 or >2 representatives.
+    pub cycles_rejected: usize,
+    /// Rows rejected by the pivot-magnitude guards.
+    pub pivots_rejected: usize,
+    /// Rows rejected because the merge would breach the coefficient/offset caps.
+    pub growth_rejected: usize,
+    /// Rows rejected because no resolved representative was eliminable.
+    pub ineligible_rejected: usize,
+    /// Set when a transferred interval is empty or a fixed value falls outside
+    /// its declared bounds. The model is returned **unchanged** in that case,
+    /// leaving the infeasibility for FBBT to report.
+    pub infeasible_detected: bool,
+    /// Set when the pass declined to apply an otherwise-computed reduction
+    /// (non-finite composed definition, broken invariant). Model unchanged.
+    pub aborted: Option<String>,
+    /// Recovery records, one per eliminated block, ascending by block index.
+    pub records: Vec<SubstitutionRecord>,
+    /// `old_block -> Some(new_block)` for survivors, `None` for eliminated.
+    pub block_map: Vec<Option<usize>>,
+}
+
+// ─────────────────────────────────────────────────────────────
+// Union-find over variable blocks with an affine potential
+// ─────────────────────────────────────────────────────────────
+
+/// `x_i = coeff[i] · x_parent[i] + offset[i]`; roots are their own parent with
+/// the identity map. `max_coeff`/`max_offset` are maintained **on roots only**
+/// and upper-bound `|c|`/`|o|` over every member of that root's class.
+struct AffineUf {
+    parent: Vec<usize>,
+    coeff: Vec<f64>,
+    offset: Vec<f64>,
+    max_coeff: Vec<f64>,
+    max_offset: Vec<f64>,
+    fixed: Vec<Option<f64>>,
+}
+
+impl AffineUf {
+    fn new(n: usize) -> Self {
+        Self {
+            parent: (0..n).collect(),
+            coeff: vec![1.0; n],
+            offset: vec![0.0; n],
+            max_coeff: vec![1.0; n],
+            max_offset: vec![0.0; n],
+            fixed: vec![None; n],
+        }
+    }
+
+    /// Resolve `i` to its representative, returning `(root, c, o)` with
+    /// `x_i = c · x_root + o`. Iterative — substitution chains reach 10^4 on
+    /// the target instances, so a recursive `find` would risk a stack overflow
+    /// — with path compression: after the call, every node on the path points
+    /// directly at the root carrying its composed map.
+    fn find(&mut self, i: usize) -> (usize, f64, f64) {
+        let mut path: Vec<usize> = Vec::new();
+        let mut cur = i;
+        while self.parent[cur] != cur {
+            path.push(cur);
+            cur = self.parent[cur];
+        }
+        let root = cur;
+        let mut c = 1.0f64;
+        let mut o = 0.0f64;
+        for &node in path.iter().rev() {
+            // x_node = coeff[node]·x_parent + offset[node]; the parent already
+            // composes to (c, o) against the root.
+            let nc = self.coeff[node] * c;
+            let no = self.coeff[node] * o + self.offset[node];
+            c = nc;
+            o = no;
+            self.parent[node] = root;
+            self.coeff[node] = nc;
+            self.offset[node] = no;
+        }
+        if i == root {
+            (root, 1.0, 0.0)
+        } else {
+            (root, self.coeff[i], self.offset[i])
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Public entry points
+// ─────────────────────────────────────────────────────────────
+
+/// Run the batch substitution aggregator once. Pure function.
+///
+/// Returns the reduced model and the stats/postsolve payload. When
+/// `infeasible_detected` or `aborted` is set the **input model is returned
+/// unchanged** with an empty record list, so the caller can always treat the
+/// result as a drop-in replacement.
+pub fn substitute_variables(model: &ModelRepr) -> (ModelRepr, SubstitutionStats) {
+    let n_blocks = model.variables.len();
+    let mut stats = SubstitutionStats {
+        block_map: (0..n_blocks).map(Some).collect(),
+        ..Default::default()
+    };
+
+    let (leaf_to_block, block_to_leaf, aliased) = scalar_leaf_maps(model);
+    if leaf_to_block.is_empty() {
+        return (model.clone(), stats);
+    }
+
+    let eliminable = |b: usize| -> bool {
+        model.variables[b].var_type == VarType::Continuous
+            && model.variables[b].size == 1
+            && !model.variables[b].lb.is_empty()
+            && !aliased.contains(&b)
+            && block_to_leaf.contains_key(&b)
+    };
+
+    let mut uf = AffineUf::new(n_blocks);
+    let mut consumed_rows: Vec<usize> = Vec::new();
+    let mut eliminated: HashSet<usize> = HashSet::new();
+
+    for (ci, c) in model.constraints.iter().enumerate() {
+        if c.sense != ConstraintSense::Eq {
+            continue;
+        }
+        let Some(row) = linear_row(model, c, &leaf_to_block) else {
+            continue;
+        };
+        stats.candidate_rows += 1;
+
+        // Resolve the row into representative space, folding already-fixed
+        // representatives into the constant.
+        let mut rterms: Vec<(usize, f64)> = Vec::with_capacity(2);
+        let mut lhs_const = row.constant;
+        let mut row_max = 0.0f64;
+        for &(b, cb) in &row.terms {
+            let (root, pc, po) = uf.find(b);
+            lhs_const += cb * po;
+            let a = cb * pc;
+            row_max = row_max.max(a.abs());
+            if let Some(v) = uf.fixed[root] {
+                lhs_const += a * v;
+            } else if let Some(slot) = rterms.iter_mut().find(|(r, _)| *r == root) {
+                slot.1 += a;
+            } else {
+                rterms.push((root, a));
+            }
+        }
+        let r = c.rhs - lhs_const;
+        if !r.is_finite() || !row_max.is_finite() {
+            stats.pivots_rejected += 1;
+            continue;
+        }
+        // A merged coefficient of *exactly* zero is a structural absence and is
+        // safe to drop; a near-zero one is a cancellation residual that must be
+        // kept so the relative pivot guard below can reject it.
+        rterms.retain(|(_, a)| *a != 0.0);
+
+        match rterms.len() {
+            // Constant relation: redundant or infeasible; either way the row
+            // stays and FBBT decides.
+            0 => stats.cycles_rejected += 1,
+            1 => {
+                let (root, a) = rterms[0];
+                if a.abs() < MIN_PIVOT_ABS || a.abs() < PIVOT_REL * row_max {
+                    stats.pivots_rejected += 1;
+                    continue;
+                }
+                let v = r / a;
+                if !v.is_finite() || v.abs() > MAX_ABS_OFFSET {
+                    stats.growth_rejected += 1;
+                    continue;
+                }
+                if !eliminable(root) || eliminated.contains(&root) {
+                    stats.ineligible_rejected += 1;
+                    continue;
+                }
+                uf.fixed[root] = Some(v);
+                eliminated.insert(root);
+                consumed_rows.push(ci);
+            }
+            2 => {
+                let (root_p, a) = rterms[0];
+                let (root_q, b) = rterms[1];
+                let p_ok = eliminable(root_p) && !eliminated.contains(&root_p);
+                let q_ok = eliminable(root_q) && !eliminated.contains(&root_q);
+                // Prefer eliminating the block with the larger coefficient
+                // (multiplier ≤ 1), subject to eligibility; ties on block index.
+                let pick_p = match (p_ok, q_ok) {
+                    (true, true) => match a.abs().partial_cmp(&b.abs()) {
+                        Some(std::cmp::Ordering::Greater) => true,
+                        Some(std::cmp::Ordering::Less) => false,
+                        _ => root_p < root_q,
+                    },
+                    (true, false) => true,
+                    (false, true) => false,
+                    (false, false) => {
+                        stats.ineligible_rejected += 1;
+                        continue;
+                    }
+                };
+                let (elim_root, pivot, keep_root, other) = if pick_p {
+                    (root_p, a, root_q, b)
+                } else {
+                    (root_q, b, root_p, a)
+                };
+                if pivot.abs() < MIN_PIVOT_ABS || pivot.abs() < PIVOT_REL * row_max {
+                    stats.pivots_rejected += 1;
+                    continue;
+                }
+                // x_elim_root = m·x_keep_root + q
+                let m = -other / pivot;
+                let q = r / pivot;
+                if !m.is_finite() || !q.is_finite() || m == 0.0 {
+                    stats.pivots_rejected += 1;
+                    continue;
+                }
+                let new_max_coeff = uf.max_coeff[elim_root] * m.abs();
+                let new_max_offset = uf.max_offset[elim_root] * m.abs() + q.abs();
+                if new_max_coeff > MAX_ABS_COEFF || new_max_offset > MAX_ABS_OFFSET {
+                    stats.growth_rejected += 1;
+                    continue;
+                }
+                uf.parent[elim_root] = keep_root;
+                uf.coeff[elim_root] = m;
+                uf.offset[elim_root] = q;
+                uf.max_coeff[keep_root] = uf.max_coeff[keep_root].max(new_max_coeff);
+                uf.max_offset[keep_root] = uf.max_offset[keep_root].max(new_max_offset);
+                eliminated.insert(elim_root);
+                consumed_rows.push(ci);
+            }
+            _ => stats.cycles_rejected += 1,
+        }
+    }
+
+    if eliminated.is_empty() {
+        return (model.clone(), stats);
+    }
+
+    // ── Resolve every eliminated block to a direct definition ──────────
+    let mut lb: Vec<f64> = Vec::with_capacity(n_blocks);
+    let mut ub: Vec<f64> = Vec::with_capacity(n_blocks);
+    for v in &model.variables {
+        if v.size == 1 && !v.lb.is_empty() && !v.ub.is_empty() {
+            lb.push(v.lb[0]);
+            ub.push(v.ub[0]);
+        } else {
+            lb.push(f64::NEG_INFINITY);
+            ub.push(f64::INFINITY);
+        }
+    }
+
+    let mut elim_sorted: Vec<usize> = eliminated.iter().copied().collect();
+    elim_sorted.sort_unstable();
+    let mut records: Vec<SubstitutionRecord> = Vec::with_capacity(elim_sorted.len());
+    for &e in &elim_sorted {
+        let (root, c, o) = uf.find(e);
+        let (elo, ehi) = (model.variables[e].lb[0], model.variables[e].ub[0]);
+        let def = if let Some(v) = uf.fixed[root] {
+            let val = c * v + o;
+            if !val.is_finite() {
+                return abort(model, stats, "non-finite fixed value");
+            }
+            let slack = FEAS_TOL * (1.0 + val.abs());
+            if val < elo - slack || val > ehi + slack {
+                stats.infeasible_detected = true;
+                return (model.clone(), stats);
+            }
+            SubstDef::Fixed(val)
+        } else {
+            if !c.is_finite() || !o.is_finite() || c == 0.0 {
+                return abort(model, stats, "non-finite affine definition");
+            }
+            // Transfer x_e ∈ [l_e, u_e] onto the source exactly:
+            //   x_root = (x_e − o) / c
+            let (tlo, thi) = scale_interval(1.0 / c, elo - o, ehi - o);
+            if tlo.is_nan() || thi.is_nan() {
+                return abort(model, stats, "non-finite transferred bound");
+            }
+            if tlo > lb[root] {
+                lb[root] = tlo;
+            }
+            if thi < ub[root] {
+                ub[root] = thi;
+            }
+            if lb[root] > ub[root] + FEAS_TOL * (1.0 + lb[root].abs()) {
+                stats.infeasible_detected = true;
+                return (model.clone(), stats);
+            }
+            SubstDef::Affine {
+                source_block: root,
+                coeff: c,
+                offset: o,
+            }
+        };
+        records.push(SubstitutionRecord {
+            eliminated_block: e,
+            def,
+        });
+    }
+
+    // A representative named as an Affine source must survive. Check, don't
+    // trust: a violation would make postsolve read an unassigned slot.
+    for rec in &records {
+        if let SubstDef::Affine { source_block, .. } = rec.def {
+            if eliminated.contains(&source_block) {
+                return abort(model, stats, "affine source was itself eliminated");
+            }
+        }
+    }
+
+    let mut block_map: Vec<Option<usize>> = Vec::with_capacity(n_blocks);
+    let mut next = 0usize;
+    for b in 0..n_blocks {
+        if eliminated.contains(&b) {
+            block_map.push(None);
+        } else {
+            block_map.push(Some(next));
+            next += 1;
+        }
+    }
+
+    let drop_rows: HashSet<usize> = consumed_rows.iter().copied().collect();
+    assert_eq!(
+        drop_rows.len(),
+        records.len(),
+        "substitution invariant: exactly one dropped equality per eliminated block"
+    );
+
+    let new_model = rewrite_model(
+        model,
+        &records,
+        &drop_rows,
+        &block_map,
+        &block_to_leaf,
+        &lb,
+        &ub,
+    );
+
+    stats.variables_eliminated = records.len();
+    stats.equalities_dropped = drop_rows.len();
+    stats.records = records;
+    stats.block_map = block_map;
+    (new_model, stats)
+}
+
+fn abort(
+    model: &ModelRepr,
+    mut stats: SubstitutionStats,
+    why: &str,
+) -> (ModelRepr, SubstitutionStats) {
+    stats.aborted = Some(why.to_string());
+    stats.variables_eliminated = 0;
+    stats.equalities_dropped = 0;
+    stats.records.clear();
+    stats.block_map = (0..model.variables.len()).map(Some).collect();
+    (model.clone(), stats)
+}
+
+/// Iterate [`substitute_variables`] until no further reduction, at most
+/// `max_sweeps` times.
+///
+/// Later sweeps find definitions the first cannot: a row with three variables
+/// two of which land in the same class resolves to a doubleton only after the
+/// first sweep's rewrite.
+///
+/// Returns `(models, chain)` where `chain[i]` is sweep `i`'s stats, `models[i]`
+/// is the model that sweep consumed, and `models[chain.len()]` is the final
+/// reduced model. [`postsolve_chain`] inverts the sweeps in reverse order.
+pub fn substitute_to_fixpoint(
+    model: &ModelRepr,
+    max_sweeps: usize,
+) -> (Vec<ModelRepr>, Vec<SubstitutionStats>) {
+    let mut models: Vec<ModelRepr> = vec![model.clone()];
+    let mut chain: Vec<SubstitutionStats> = Vec::new();
+    for _ in 0..max_sweeps {
+        let (next, st) = substitute_variables(models.last().expect("seeded above"));
+        if st.variables_eliminated == 0 {
+            break;
+        }
+        models.push(next);
+        chain.push(st);
+    }
+    (models, chain)
+}
+
+/// Lift a reduced-model point back to the original variable space.
+///
+/// `x_red` is a flat scalar vector over `reduced.n_vars`; the result is a flat
+/// vector over `original.n_vars`. Because every `Affine` source is a
+/// *surviving* block, one pass suffices — no topological ordering is needed.
+pub fn postsolve_point(
+    original: &ModelRepr,
+    reduced: &ModelRepr,
+    stats: &SubstitutionStats,
+    x_red: &[f64],
+) -> Result<Vec<f64>, String> {
+    if x_red.len() != reduced.n_vars {
+        return Err(format!(
+            "postsolve: point has {} entries, reduced model has {} scalar vars",
+            x_red.len(),
+            reduced.n_vars
+        ));
+    }
+    if stats.block_map.len() != original.variables.len() {
+        return Err("postsolve: block_map length does not match the original model".to_string());
+    }
+    let mut out = vec![f64::NAN; original.n_vars];
+    for (b, slot) in stats.block_map.iter().enumerate() {
+        let Some(nb) = slot else { continue };
+        let ov = &original.variables[b];
+        let nv = reduced
+            .variables
+            .get(*nb)
+            .ok_or_else(|| format!("postsolve: reduced block {nb} is out of range"))?;
+        if ov.size != nv.size {
+            return Err(format!(
+                "postsolve: block {b} changed size during substitution"
+            ));
+        }
+        out[ov.offset..ov.offset + ov.size].copy_from_slice(&x_red[nv.offset..nv.offset + nv.size]);
+    }
+    for rec in &stats.records {
+        let ov = &original.variables[rec.eliminated_block];
+        let v = match rec.def {
+            SubstDef::Fixed(v) => v,
+            SubstDef::Affine {
+                source_block,
+                coeff,
+                offset,
+            } => {
+                let s = out[original.variables[source_block].offset];
+                if s.is_nan() {
+                    return Err(format!(
+                        "postsolve: source block {source_block} was not recovered before use"
+                    ));
+                }
+                coeff * s + offset
+            }
+        };
+        out[ov.offset] = v;
+    }
+    if let Some(i) = out.iter().position(|v| v.is_nan()) {
+        return Err(format!("postsolve: scalar variable {i} was never assigned"));
+    }
+    Ok(out)
+}
+
+/// Invert a whole chain of sweeps produced by [`substitute_to_fixpoint`].
+///
+/// `models[i]` is the model that sweep `i` consumed; `models[chain.len()]` is
+/// the final reduced model. Sweeps are inverted in reverse order.
+pub fn postsolve_chain(
+    models: &[ModelRepr],
+    chain: &[SubstitutionStats],
+    x_red: &[f64],
+) -> Result<Vec<f64>, String> {
+    if models.len() != chain.len() + 1 {
+        return Err(format!(
+            "postsolve_chain: {} models for {} sweeps (expected {})",
+            models.len(),
+            chain.len(),
+            chain.len() + 1
+        ));
+    }
+    let mut x = x_red.to_vec();
+    for i in (0..chain.len()).rev() {
+        x = postsolve_point(&models[i], &models[i + 1], &chain[i], &x)?;
+    }
+    Ok(x)
+}
+
+// ─────────────────────────────────────────────────────────────
+// Row extraction
+// ─────────────────────────────────────────────────────────────
+
+struct LinearRow {
+    /// `(block_index, coefficient)` in polynomial order, distinct blocks.
+    terms: Vec<(usize, f64)>,
+    constant: f64,
+}
+
+/// Extract a linear row over scalar variable blocks, or `None`.
+fn linear_row(
+    model: &ModelRepr,
+    c: &ConstraintRepr,
+    leaf_to_block: &HashMap<ExprId, usize>,
+) -> Option<LinearRow> {
+    if !c.rhs.is_finite() {
+        return None;
+    }
+    let poly = try_polynomial(&model.arena, c.body)?;
+    if poly.max_total_degree() != 1 {
+        return None;
+    }
+    if poly.monomials.is_empty() || poly.monomials.len() > MAX_ROW_TERMS {
+        return None;
+    }
+    if !poly.constant.is_finite() {
+        return None;
+    }
+    let mut terms: Vec<(usize, f64)> = Vec::with_capacity(poly.monomials.len());
+    for m in &poly.monomials {
+        if m.factors.len() != 1 || m.factors[0].1 != 1 {
+            return None;
+        }
+        let block = *leaf_to_block.get(&m.factors[0].0)?;
+        if m.coeff == 0.0 || !m.coeff.is_finite() {
+            return None;
+        }
+        terms.push((block, m.coeff));
+    }
+    Some(LinearRow {
+        terms,
+        constant: poly.constant,
+    })
+}
+
+/// `(leaf -> block, block -> canonical leaf, aliased blocks)` for scalar
+/// variable blocks. A block with more than one `Variable` leaf is *aliased*:
+/// it is still renumbered, but never eliminated. Its canonical (lowest-id)
+/// leaf is retained so it can still serve as a substitution source.
+type LeafMaps = (
+    HashMap<ExprId, usize>,
+    HashMap<usize, ExprId>,
+    HashSet<usize>,
+);
+
+fn scalar_leaf_maps(model: &ModelRepr) -> LeafMaps {
+    let mut leaf_to_block: HashMap<ExprId, usize> = HashMap::new();
+    let mut block_to_leaf: HashMap<usize, ExprId> = HashMap::new();
+    let mut aliased: HashSet<usize> = HashSet::new();
+    for nid in 0..model.arena.len() {
+        let id = ExprId(nid);
+        if let ExprNode::Variable { index, size, .. } = model.arena.get(id) {
+            if *size != 1 || *index >= model.variables.len() || model.variables[*index].size != 1 {
+                continue;
+            }
+            leaf_to_block.insert(id, *index);
+            // Ascending scan ⇒ the first insert is the lowest node id.
+            if block_to_leaf.insert(*index, id).is_some() {
+                aliased.insert(*index);
+                // Restore the lowest-id canonical leaf.
+                block_to_leaf.insert(*index, first_leaf_of(model, *index));
+            }
+        }
+    }
+    (leaf_to_block, block_to_leaf, aliased)
+}
+
+fn first_leaf_of(model: &ModelRepr, block: usize) -> ExprId {
+    for nid in 0..model.arena.len() {
+        if let ExprNode::Variable { index, size, .. } = model.arena.get(ExprId(nid)) {
+            if *index == block && *size == 1 {
+                return ExprId(nid);
+            }
+        }
+    }
+    unreachable!("block {block} has at least one scalar leaf by construction")
+}
+
+// ─────────────────────────────────────────────────────────────
+// Single-pass rewrite
+// ─────────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn rewrite_model(
+    model: &ModelRepr,
+    records: &[SubstitutionRecord],
+    drop_rows: &HashSet<usize>,
+    block_map: &[Option<usize>],
+    block_to_leaf: &HashMap<usize, ExprId>,
+    lb: &[f64],
+    ub: &[f64],
+) -> ModelRepr {
+    let old = &model.arena;
+    let mut new = ExprArena::with_capacity(old.len());
+    let mut map: Vec<Option<ExprId>> = vec![None; old.len()];
+
+    // Pre-create the `Variable` nodes for surviving scalar blocks so that a
+    // substitution can reference its source regardless of node ordering.
+    let mut survivor_node: HashMap<usize, ExprId> = HashMap::new();
+    for (b, slot) in block_map.iter().enumerate() {
+        let Some(nb) = slot else { continue };
+        let Some(leaf) = block_to_leaf.get(&b) else {
+            continue;
+        };
+        if let ExprNode::Variable { name, shape, .. } = old.get(*leaf) {
+            let id = new.add(ExprNode::Variable {
+                name: name.clone(),
+                index: *nb,
+                size: 1,
+                shape: shape.clone(),
+            });
+            survivor_node.insert(b, id);
+            map[leaf.0] = Some(id);
+        }
+    }
+
+    // Build each eliminated block's replacement subtree exactly once. This is
+    // what makes the rewrite O(1) per elimination instead of O(rows).
+    let mut replacement: HashMap<usize, ExprId> = HashMap::new();
+    for rec in records {
+        let repl = match rec.def {
+            SubstDef::Fixed(v) => new.add(ExprNode::Constant(v)),
+            SubstDef::Affine {
+                source_block,
+                coeff,
+                offset,
+            } => {
+                let src = survivor_node[&source_block];
+                let mut t = if coeff == 1.0 {
+                    src
+                } else {
+                    let k = new.add(ExprNode::Constant(coeff));
+                    new.add(ExprNode::BinaryOp {
+                        op: BinOp::Mul,
+                        left: k,
+                        right: src,
+                    })
+                };
+                if offset != 0.0 {
+                    let k = new.add(ExprNode::Constant(offset));
+                    t = new.add(ExprNode::BinaryOp {
+                        op: BinOp::Add,
+                        left: t,
+                        right: k,
+                    });
+                }
+                t
+            }
+        };
+        replacement.insert(rec.eliminated_block, repl);
+        if let Some(leaf) = block_to_leaf.get(&rec.eliminated_block) {
+            map[leaf.0] = Some(repl);
+        }
+    }
+
+    let mut rewriter = Rewriter {
+        old,
+        new,
+        map,
+        block_map,
+        replacement: &replacement,
+    };
+
+    let objective = rewriter.rewrite(model.objective);
+    let mut constraints: Vec<ConstraintRepr> = Vec::with_capacity(model.constraints.len());
+    for (ci, c) in model.constraints.iter().enumerate() {
+        if drop_rows.contains(&ci) {
+            continue;
+        }
+        constraints.push(ConstraintRepr {
+            body: rewriter.rewrite(c.body),
+            sense: c.sense,
+            rhs: c.rhs,
+            name: c.name.clone(),
+        });
+    }
+
+    let mut variables: Vec<VarInfo> = Vec::with_capacity(model.variables.len());
+    let mut running = 0usize;
+    for (b, slot) in block_map.iter().enumerate() {
+        if slot.is_none() {
+            continue;
+        }
+        let mut v = model.variables[b].clone();
+        if v.size == 1 && !v.lb.is_empty() && !v.ub.is_empty() {
+            v.lb[0] = v.lb[0].max(lb[b]);
+            v.ub[0] = v.ub[0].min(ub[b]);
+        }
+        v.offset = running;
+        running += v.size;
+        variables.push(v);
+    }
+
+    ModelRepr {
+        arena: rewriter.new,
+        objective,
+        objective_sense: model.objective_sense,
+        constraints,
+        variables,
+        n_vars: running,
+    }
+}
+
+struct Rewriter<'a> {
+    old: &'a ExprArena,
+    new: ExprArena,
+    map: Vec<Option<ExprId>>,
+    block_map: &'a [Option<usize>],
+    replacement: &'a HashMap<usize, ExprId>,
+}
+
+impl Rewriter<'_> {
+    /// Iterative post-order rebuild of `root` into the new arena. Does not
+    /// assume children carry lower ids than their parents, memoises shared
+    /// subexpressions, and drops nodes unreachable from the roots.
+    fn rewrite(&mut self, root: ExprId) -> ExprId {
+        let mut stack: Vec<(ExprId, bool)> = vec![(root, false)];
+        while let Some((id, expanded)) = stack.pop() {
+            if self.map[id.0].is_some() {
+                continue;
+            }
+            if !expanded {
+                stack.push((id, true));
+                for ch in children(self.old.get(id)) {
+                    if self.map[ch.0].is_none() {
+                        stack.push((ch, false));
+                    }
+                }
+                continue;
+            }
+            let node = self.old.get(id);
+            let built = match node {
+                ExprNode::Variable {
+                    name,
+                    index,
+                    size,
+                    shape,
+                } => {
+                    if let Some(r) = self.replacement.get(index) {
+                        *r
+                    } else {
+                        let ni = self.block_map[*index]
+                            .expect("surviving variable must have a new block index");
+                        self.new.add(ExprNode::Variable {
+                            name: name.clone(),
+                            index: ni,
+                            size: *size,
+                            shape: shape.clone(),
+                        })
+                    }
+                }
+                ExprNode::Constant(v) => self.new.add(ExprNode::Constant(*v)),
+                ExprNode::ConstantArray(d, s) => {
+                    self.new.add(ExprNode::ConstantArray(d.clone(), s.clone()))
+                }
+                ExprNode::Parameter { name, value, shape } => self.new.add(ExprNode::Parameter {
+                    name: name.clone(),
+                    value: value.clone(),
+                    shape: shape.clone(),
+                }),
+                ExprNode::BinaryOp { op, left, right } => {
+                    let (l, r) = (self.map[left.0].unwrap(), self.map[right.0].unwrap());
+                    self.new.add(ExprNode::BinaryOp {
+                        op: *op,
+                        left: l,
+                        right: r,
+                    })
+                }
+                ExprNode::MatMul { left, right } => {
+                    let (l, r) = (self.map[left.0].unwrap(), self.map[right.0].unwrap());
+                    self.new.add(ExprNode::MatMul { left: l, right: r })
+                }
+                ExprNode::UnaryOp { op, operand } => {
+                    let o = self.map[operand.0].unwrap();
+                    self.new.add(ExprNode::UnaryOp {
+                        op: *op,
+                        operand: o,
+                    })
+                }
+                ExprNode::Sum { operand, axis } => {
+                    let o = self.map[operand.0].unwrap();
+                    self.new.add(ExprNode::Sum {
+                        operand: o,
+                        axis: *axis,
+                    })
+                }
+                ExprNode::FunctionCall { func, args } => {
+                    let a: Vec<ExprId> = args.iter().map(|x| self.map[x.0].unwrap()).collect();
+                    self.new.add(ExprNode::FunctionCall {
+                        func: *func,
+                        args: a,
+                    })
+                }
+                ExprNode::Index { base, index } => {
+                    let b = self.map[base.0].unwrap();
+                    self.new.add(ExprNode::Index {
+                        base: b,
+                        index: index.clone(),
+                    })
+                }
+                ExprNode::SumOver { terms } => {
+                    let t: Vec<ExprId> = terms.iter().map(|x| self.map[x.0].unwrap()).collect();
+                    self.new.add(ExprNode::SumOver { terms: t })
+                }
+            };
+            self.map[id.0] = Some(built);
+        }
+        self.map[root.0].expect("root must be rebuilt")
+    }
+}
+
+fn children(node: &ExprNode) -> Vec<ExprId> {
+    match node {
+        ExprNode::Constant(_)
+        | ExprNode::ConstantArray(_, _)
+        | ExprNode::Parameter { .. }
+        | ExprNode::Variable { .. } => Vec::new(),
+        ExprNode::BinaryOp { left, right, .. } | ExprNode::MatMul { left, right } => {
+            vec![*left, *right]
+        }
+        ExprNode::UnaryOp { operand, .. } | ExprNode::Sum { operand, .. } => vec![*operand],
+        ExprNode::FunctionCall { args, .. } => args.clone(),
+        ExprNode::Index { base, .. } => vec![*base],
+        ExprNode::SumOver { terms } => terms.clone(),
+    }
+}
+
+/// Scale `[lo, hi]` by `c`, preserving ordering.
+fn scale_interval(c: f64, lo: f64, hi: f64) -> (f64, f64) {
+    let a = c * lo;
+    let b = c * hi;
+    if a <= b {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expr::{ConstraintRepr, ObjectiveSense};
+
+    fn scalar_var(arena: &mut ExprArena, name: &str, idx: usize) -> ExprId {
+        arena.add(ExprNode::Variable {
+            name: name.to_string(),
+            index: idx,
+            size: 1,
+            shape: vec![],
+        })
+    }
+
+    fn vinfo(name: &str, lb: f64, ub: f64, ty: VarType) -> VarInfo {
+        VarInfo {
+            name: name.to_string(),
+            var_type: ty,
+            offset: 0,
+            size: 1,
+            shape: vec![],
+            lb: vec![lb],
+            ub: vec![ub],
+        }
+    }
+
+    /// Build `sum_i coeffs[i] * leaves[i]` as an arena expression.
+    fn lin(arena: &mut ExprArena, terms: &[(f64, ExprId)]) -> ExprId {
+        let mut acc: Option<ExprId> = None;
+        for (c, leaf) in terms {
+            let k = arena.add(ExprNode::Constant(*c));
+            let t = arena.add(ExprNode::BinaryOp {
+                op: BinOp::Mul,
+                left: k,
+                right: *leaf,
+            });
+            acc = Some(match acc {
+                None => t,
+                Some(a) => arena.add(ExprNode::BinaryOp {
+                    op: BinOp::Add,
+                    left: a,
+                    right: t,
+                }),
+            });
+        }
+        acc.expect("at least one term")
+    }
+
+    fn finalize(mut variables: Vec<VarInfo>) -> Vec<VarInfo> {
+        let mut off = 0;
+        for v in variables.iter_mut() {
+            v.offset = off;
+            off += v.size;
+        }
+        variables
+    }
+
+    /// x0 = 2·x1 + 1, x1 = 3·x2 + 2, x2 = 4·x3 + 3 — a chain of THREE
+    /// substitutions — plus one inequality and an objective in which every
+    /// chained variable also appears. `aggregate`/`eliminate` reject all three
+    /// definitions because each defined variable appears in more than one
+    /// expression; this pass must eliminate all three and collapse the chain
+    /// onto a single representative.
+    fn chain_model() -> ModelRepr {
+        let mut arena = ExprArena::new();
+        let x: Vec<ExprId> = (0..5)
+            .map(|i| scalar_var(&mut arena, &format!("x{i}"), i))
+            .collect();
+        let e0 = lin(&mut arena, &[(1.0, x[0]), (-2.0, x[1])]);
+        let e1 = lin(&mut arena, &[(1.0, x[1]), (-3.0, x[2])]);
+        let e2 = lin(&mut arena, &[(1.0, x[2]), (-4.0, x[3])]);
+        let ineq = lin(
+            &mut arena,
+            &[(1.0, x[0]), (1.0, x[1]), (1.0, x[2]), (1.0, x[3])],
+        );
+        let obj = lin(&mut arena, &[(1.0, x[0]), (1.0, x[4])]);
+        let variables = finalize(
+            (0..5)
+                .map(|i| vinfo(&format!("x{i}"), -1e3, 1e3, VarType::Continuous))
+                .collect(),
+        );
+        ModelRepr {
+            arena,
+            objective: obj,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![
+                ConstraintRepr {
+                    body: e0,
+                    sense: ConstraintSense::Eq,
+                    rhs: 1.0,
+                    name: None,
+                },
+                ConstraintRepr {
+                    body: e1,
+                    sense: ConstraintSense::Eq,
+                    rhs: 2.0,
+                    name: None,
+                },
+                ConstraintRepr {
+                    body: e2,
+                    sense: ConstraintSense::Eq,
+                    rhs: 3.0,
+                    name: None,
+                },
+                ConstraintRepr {
+                    body: ineq,
+                    sense: ConstraintSense::Le,
+                    rhs: 100.0,
+                    name: None,
+                },
+            ],
+            variables,
+            n_vars: 5,
+        }
+    }
+
+    #[test]
+    fn legacy_aggregate_cannot_touch_the_chain_model() {
+        // Fails-before evidence: the pre-existing pass eliminates nothing here,
+        // because every defined variable also appears in the inequality.
+        let m = chain_model();
+        let (out, stats) = super::super::aggregate::aggregate_variables(&m);
+        assert_eq!(stats.variables_aggregated, 0);
+        assert_eq!(out.variables.len(), 5);
+    }
+
+    #[test]
+    fn chain_of_three_substitutions_collapses_to_one_representative() {
+        let m = chain_model();
+        let (red, st) = substitute_variables(&m);
+        assert_eq!(st.variables_eliminated, 3, "x0, x1 and x2 are determined");
+        assert_eq!(st.equalities_dropped, 3);
+        assert_eq!(red.variables.len(), 2, "x3 and the unused x4 survive");
+        assert_eq!(red.constraints.len(), 1, "only the inequality remains");
+
+        // Every definition must name the SAME surviving representative — that
+        // is what "the chain collapsed" means, and it is why postsolve needs no
+        // topological order.
+        let sources: Vec<usize> = st
+            .records
+            .iter()
+            .map(|r| match r.def {
+                SubstDef::Affine { source_block, .. } => source_block,
+                SubstDef::Fixed(_) => usize::MAX,
+            })
+            .collect();
+        assert_eq!(sources.len(), 3);
+        assert!(
+            sources.iter().all(|s| *s == sources[0] && *s != usize::MAX),
+            "definitions must share one representative, got {sources:?}"
+        );
+    }
+
+    #[test]
+    fn postsolve_inverts_the_chain_exactly() {
+        let m = chain_model();
+        let (red, st) = substitute_variables(&m);
+        for t in [-3.5_f64, 0.0, 2.25, 7.0] {
+            let mut x_red = vec![0.0; red.n_vars];
+            for (i, v) in red.variables.iter().enumerate() {
+                x_red[v.offset] = t + i as f64 * 0.5;
+            }
+            let full = postsolve_point(&m, &red, &st, &x_red).expect("invertible");
+            assert_eq!(full.len(), m.n_vars);
+            // Every dropped equality must hold exactly at the lifted point.
+            for (k, c) in m.constraints.iter().enumerate() {
+                if c.sense != ConstraintSense::Eq {
+                    continue;
+                }
+                let r = m.evaluate_expr(c.body, &full) - c.rhs;
+                assert!(r.abs() < 1e-9, "row {k} residual {r} at t={t}");
+            }
+            // The objective and the surviving inequality body must agree.
+            let o_full = m.evaluate_objective(&full);
+            let o_red = red.evaluate_objective(&x_red);
+            assert!((o_full - o_red).abs() < 1e-9, "{o_full} vs {o_red}");
+            let b_full = m.evaluate_expr(m.constraints[3].body, &full);
+            let b_red = red.evaluate_expr(red.constraints[0].body, &x_red);
+            assert!((b_full - b_red).abs() < 1e-9, "{b_full} vs {b_red}");
+        }
+    }
+
+    #[test]
+    fn cycle_is_rejected_and_its_row_is_kept() {
+        // x0 − x1 = 0, x1 − x2 = 0, x2 − x0 = 0: the third row closes a cycle
+        // and defines nothing new. It must be rejected, not "simplified away".
+        let mut arena = ExprArena::new();
+        let x: Vec<ExprId> = (0..3)
+            .map(|i| scalar_var(&mut arena, &format!("x{i}"), i))
+            .collect();
+        let r0 = lin(&mut arena, &[(1.0, x[0]), (-1.0, x[1])]);
+        let r1 = lin(&mut arena, &[(1.0, x[1]), (-1.0, x[2])]);
+        let r2 = lin(&mut arena, &[(1.0, x[2]), (-1.0, x[0])]);
+        let obj = lin(&mut arena, &[(1.0, x[0])]);
+        let variables = finalize(
+            (0..3)
+                .map(|i| vinfo(&format!("x{i}"), -10.0, 10.0, VarType::Continuous))
+                .collect(),
+        );
+        let m = ModelRepr {
+            arena,
+            objective: obj,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: [r0, r1, r2]
+                .into_iter()
+                .map(|body| ConstraintRepr {
+                    body,
+                    sense: ConstraintSense::Eq,
+                    rhs: 0.0,
+                    name: None,
+                })
+                .collect(),
+            variables,
+            n_vars: 3,
+        };
+        let (red, st) = substitute_variables(&m);
+        assert_eq!(st.variables_eliminated, 2);
+        assert_eq!(st.cycles_rejected, 1, "the closing row must be rejected");
+        assert_eq!(red.variables.len(), 1);
+        assert_eq!(red.constraints.len(), 1, "the cycle row stays in the model");
+        // And it is still satisfied after the rewrite, for any survivor value.
+        let full = postsolve_point(&m, &red, &st, &[4.25]).unwrap();
+        assert_eq!(full, vec![4.25, 4.25, 4.25]);
+        let resid = red.evaluate_expr(red.constraints[0].body, &[4.25]);
+        assert!(resid.abs() < 1e-12, "kept cycle row residual {resid}");
+    }
+
+    #[test]
+    fn integer_blocks_are_never_eliminated_but_may_be_sources() {
+        // y integer, x continuous, x − 2·y = 1 ⇒ x must go, y must stay.
+        let mut arena = ExprArena::new();
+        let xv = scalar_var(&mut arena, "x", 0);
+        let yv = scalar_var(&mut arena, "y", 1);
+        let row = lin(&mut arena, &[(1.0, xv), (-2.0, yv)]);
+        let obj = lin(&mut arena, &[(1.0, xv)]);
+        let variables = finalize(vec![
+            vinfo("x", -100.0, 100.0, VarType::Continuous),
+            vinfo("y", 0.0, 10.0, VarType::Integer),
+        ]);
+        let m = ModelRepr {
+            arena,
+            objective: obj,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body: row,
+                sense: ConstraintSense::Eq,
+                rhs: 1.0,
+                name: None,
+            }],
+            variables,
+            n_vars: 2,
+        };
+        let (red, st) = substitute_variables(&m);
+        assert_eq!(st.variables_eliminated, 1);
+        assert_eq!(st.records[0].eliminated_block, 0, "the continuous x goes");
+        assert_eq!(red.variables.len(), 1);
+        assert_eq!(red.variables[0].var_type, VarType::Integer);
+        let full = postsolve_point(&m, &red, &st, &[3.0]).unwrap();
+        assert!(
+            (full[0] - 7.0).abs() < 1e-12,
+            "x = 2·3 + 1 = 7, got {full:?}"
+        );
+    }
+
+    #[test]
+    fn empty_transferred_interval_reports_infeasible_and_changes_nothing() {
+        // x ∈ [0, 1], y ∈ [5, 6], x − y = 0 has no solution.
+        let mut arena = ExprArena::new();
+        let xv = scalar_var(&mut arena, "x", 0);
+        let yv = scalar_var(&mut arena, "y", 1);
+        let row = lin(&mut arena, &[(1.0, xv), (-1.0, yv)]);
+        let obj = lin(&mut arena, &[(1.0, xv)]);
+        let variables = finalize(vec![
+            vinfo("x", 0.0, 1.0, VarType::Continuous),
+            vinfo("y", 5.0, 6.0, VarType::Continuous),
+        ]);
+        let m = ModelRepr {
+            arena,
+            objective: obj,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body: row,
+                sense: ConstraintSense::Eq,
+                rhs: 0.0,
+                name: None,
+            }],
+            variables,
+            n_vars: 2,
+        };
+        let (red, st) = substitute_variables(&m);
+        assert!(st.infeasible_detected);
+        assert_eq!(st.variables_eliminated, 0);
+        assert_eq!(red.variables.len(), 2, "model returned unchanged");
+        assert_eq!(red.constraints.len(), 1);
+    }
+
+    #[test]
+    fn tiny_pivot_is_rejected() {
+        // 1e-12·x + 1·y = 1: eliminating y is fine (pivot 1), but the row's
+        // pivot on x would be 1e-12 against a row max of 1. Force the bad
+        // choice by making y integer, so only x is eliminable.
+        let mut arena = ExprArena::new();
+        let xv = scalar_var(&mut arena, "x", 0);
+        let yv = scalar_var(&mut arena, "y", 1);
+        let row = lin(&mut arena, &[(1e-12, xv), (1.0, yv)]);
+        let obj = lin(&mut arena, &[(1.0, xv)]);
+        let variables = finalize(vec![
+            vinfo("x", -1e6, 1e6, VarType::Continuous),
+            vinfo("y", 0.0, 10.0, VarType::Integer),
+        ]);
+        let m = ModelRepr {
+            arena,
+            objective: obj,
+            objective_sense: ObjectiveSense::Minimize,
+            constraints: vec![ConstraintRepr {
+                body: row,
+                sense: ConstraintSense::Eq,
+                rhs: 1.0,
+                name: None,
+            }],
+            variables,
+            n_vars: 2,
+        };
+        let (red, st) = substitute_variables(&m);
+        assert_eq!(st.variables_eliminated, 0);
+        assert_eq!(st.pivots_rejected, 1);
+        assert_eq!(red.variables.len(), 2);
+    }
+
+    #[test]
+    fn fixpoint_sweeps_chain_and_postsolve_chain_inverts_them() {
+        let m = chain_model();
+        let (models, chain) = substitute_to_fixpoint(&m, 4);
+        assert_eq!(models.len(), chain.len() + 1);
+        assert!(!chain.is_empty());
+        let red = models.last().unwrap();
+        let x_red: Vec<f64> = (0..red.n_vars).map(|i| 1.5 + i as f64).collect();
+        let full = postsolve_chain(&models, &chain, &x_red).expect("invertible");
+        assert_eq!(full.len(), m.n_vars);
+        for c in m
+            .constraints
+            .iter()
+            .filter(|c| c.sense == ConstraintSense::Eq)
+        {
+            assert!((m.evaluate_expr(c.body, &full) - c.rhs).abs() < 1e-9);
+        }
+        assert!((m.evaluate_objective(&full) - red.evaluate_objective(&x_red)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn postsolve_rejects_a_mis_sized_point() {
+        let m = chain_model();
+        let (red, st) = substitute_variables(&m);
+        assert!(postsolve_point(&m, &red, &st, &[1.0]).is_err());
+    }
+}

--- a/crates/discopt-python/src/expr_bindings.rs
+++ b/crates/discopt-python/src/expr_bindings.rs
@@ -880,6 +880,182 @@ impl PyModelRepr {
             stats.into(),
         ))
     }
+
+    /// Run the batch substitution-graph aggregator (issue #844, P2(a′)).
+    ///
+    /// Returns `(reduced_repr, chain)`. `chain` is a [`PySubstitutionChain`]
+    /// that owns every intermediate model and knows how to lift a reduced
+    /// point back to the original variable space via `chain.postsolve(x)`.
+    ///
+    /// Refuses (returns the model unchanged, `chain.n_sweeps == 0`, with
+    /// `chain.refused` set) when the model carries complementarity relations:
+    /// those reference variable indices outside `ModelRepr`, which this pass
+    /// renumbers.
+    #[pyo3(signature = (max_sweeps=4))]
+    fn substitute(&self, max_sweeps: usize) -> PyResult<(PyModelRepr, PySubstitutionChain)> {
+        use discopt_core::presolve::substitute_to_fixpoint;
+
+        if !self.complementarities.is_empty() {
+            return Ok((
+                PyModelRepr {
+                    inner: self.inner.clone(),
+                    complementarities: self.complementarities.clone(),
+                },
+                PySubstitutionChain {
+                    models: vec![self.inner.clone()],
+                    chain: Vec::new(),
+                    refused: Some("model carries complementarity relations".to_string()),
+                },
+            ));
+        }
+
+        let (models, chain) = substitute_to_fixpoint(&self.inner, max_sweeps);
+        let reduced = models.last().expect("seeded with the input model").clone();
+        Ok((
+            PyModelRepr {
+                inner: reduced,
+                complementarities: Vec::new(),
+            },
+            PySubstitutionChain {
+                models,
+                chain,
+                refused: None,
+            },
+        ))
+    }
+
+    /// Evaluate the objective and the maximum constraint/bound violation of a
+    /// flat scalar point against **this** model. Used to feasibility-verify a
+    /// postsolved incumbent against the pristine model.
+    ///
+    /// Returns `(objective, max_constraint_violation, max_bound_violation)`.
+    fn evaluate_point(&self, x: Vec<f64>) -> PyResult<(f64, f64, f64)> {
+        use discopt_core::expr::ConstraintSense;
+        if x.len() != self.inner.n_vars {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "point has {} entries, model has {} scalar vars",
+                x.len(),
+                self.inner.n_vars
+            )));
+        }
+        let obj = self.inner.evaluate_objective(&x);
+        let mut max_con = 0.0f64;
+        for c in &self.inner.constraints {
+            let v = self.inner.evaluate_expr(c.body, &x);
+            let viol = match c.sense {
+                ConstraintSense::Eq => (v - c.rhs).abs(),
+                ConstraintSense::Le => (v - c.rhs).max(0.0),
+                ConstraintSense::Ge => (c.rhs - v).max(0.0),
+            };
+            if viol.is_nan() {
+                return Ok((obj, f64::NAN, f64::NAN));
+            }
+            max_con = max_con.max(viol);
+        }
+        let mut max_bnd = 0.0f64;
+        for v in &self.inner.variables {
+            for k in 0..v.size {
+                let xi = x[v.offset + k];
+                let lo = *v.lb.get(k).unwrap_or(&f64::NEG_INFINITY);
+                let hi = *v.ub.get(k).unwrap_or(&f64::INFINITY);
+                max_bnd = max_bnd.max((lo - xi).max(0.0)).max((xi - hi).max(0.0));
+            }
+        }
+        Ok((obj, max_con, max_bnd))
+    }
+}
+
+/// Postsolve payload for [`PyModelRepr::substitute`].
+///
+/// Owns every intermediate model produced by the substitution sweeps so that a
+/// reduced-space point can be lifted back to the original variable space
+/// without the caller having to keep them alive or re-derive the mapping.
+#[pyclass(name = "SubstitutionChain")]
+pub struct PySubstitutionChain {
+    models: Vec<ModelRepr>,
+    chain: Vec<discopt_core::presolve::SubstitutionStats>,
+    refused: Option<String>,
+}
+
+#[pymethods]
+impl PySubstitutionChain {
+    /// Number of substitution sweeps applied.
+    #[getter]
+    fn n_sweeps(&self) -> usize {
+        self.chain.len()
+    }
+
+    /// Why the pass declined to run at all, if it did.
+    #[getter]
+    fn refused(&self) -> Option<String> {
+        self.refused.clone()
+    }
+
+    /// Total variable blocks eliminated across all sweeps.
+    #[getter]
+    fn variables_eliminated(&self) -> usize {
+        self.chain.iter().map(|s| s.variables_eliminated).sum()
+    }
+
+    /// Per-sweep counter dicts, oldest first.
+    fn sweep_stats(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let out = pyo3::types::PyList::empty(py);
+        for st in &self.chain {
+            let d = PyDict::new(py);
+            d.set_item("variables_eliminated", st.variables_eliminated)?;
+            d.set_item("equalities_dropped", st.equalities_dropped)?;
+            d.set_item("candidate_rows", st.candidate_rows)?;
+            d.set_item("cycles_rejected", st.cycles_rejected)?;
+            d.set_item("pivots_rejected", st.pivots_rejected)?;
+            d.set_item("growth_rejected", st.growth_rejected)?;
+            d.set_item("ineligible_rejected", st.ineligible_rejected)?;
+            d.set_item("infeasible_detected", st.infeasible_detected)?;
+            d.set_item("aborted", st.aborted.clone())?;
+            out.append(d)?;
+        }
+        Ok(out.into_any().unbind())
+    }
+
+    /// Definition records for sweep `i`, as
+    /// `{"eliminated_block", "kind", ...}` dicts.
+    fn records(&self, py: Python<'_>, sweep: usize) -> PyResult<PyObject> {
+        let st = self
+            .chain
+            .get(sweep)
+            .ok_or_else(|| pyo3::exceptions::PyIndexError::new_err(format!("no sweep {sweep}")))?;
+        let out = pyo3::types::PyList::empty(py);
+        for r in &st.records {
+            let rd = PyDict::new(py);
+            rd.set_item("eliminated_block", r.eliminated_block)?;
+            match r.def {
+                discopt_core::presolve::SubstDef::Fixed(v) => {
+                    rd.set_item("kind", "fixed")?;
+                    rd.set_item("value", v)?;
+                }
+                discopt_core::presolve::SubstDef::Affine {
+                    source_block,
+                    coeff,
+                    offset,
+                } => {
+                    rd.set_item("kind", "affine")?;
+                    rd.set_item("source_block", source_block)?;
+                    rd.set_item("coeff", coeff)?;
+                    rd.set_item("offset", offset)?;
+                }
+            }
+            out.append(rd)?;
+        }
+        Ok(out.into_any().unbind())
+    }
+
+    /// Lift a reduced-space flat point back to the original variable space.
+    ///
+    /// Raises `ValueError` when the point cannot be inverted — a solution that
+    /// cannot be recovered must be discarded, never reported.
+    fn postsolve(&self, x: Vec<f64>) -> PyResult<Vec<f64>> {
+        discopt_core::presolve::postsolve_chain(&self.models, &self.chain, &x)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -30,6 +30,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<batch::PyBatchDispatcher>()?;
     m.add_class::<bnb_bindings::PyTreeManager>()?;
     m.add_class::<expr_bindings::PyModelRepr>()?;
+    m.add_class::<expr_bindings::PySubstitutionChain>()?;
     m.add_class::<expr_bindings::PyModelBuilder>()?;
     m.add_function(wrap_pyfunction!(expr_bindings::model_to_repr, m)?)?;
     m.add_function(wrap_pyfunction!(nl_bindings::parse_nl_file, m)?)?;

--- a/discopt_benchmarks/scripts/presolve_substitute_probe.py
+++ b/discopt_benchmarks/scripts/presolve_substitute_probe.py
@@ -1,0 +1,108 @@
+"""P2(a') step-1 probe: batch substitution-graph aggregator, reduction + wall.
+
+Kill criterion, stated BEFORE the run (issue #844 / P2(a')):
+    the aggregator must reach >= 50x variable reduction on
+    watercontamination0202 within 5 s of substitution wall time.
+
+Also runs an equivalence probe on every instance: sample points inside the
+REDUCED box, lift them through the postsolve chain, and require that the
+pristine model agrees with the reduced model on (objective, max constraint
+violation, max bound violation). Any disagreement above tolerance is a
+soundness failure of the transform.
+
+Executed-assertion discipline: prints the number of comparisons actually made
+and exits non-zero when it is zero.
+"""
+
+import sys
+import time
+
+import numpy as np
+from discopt._rust import parse_nl_file
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"
+DEFAULT = ["gastrans040", "gastrans582_cold13", "watercontamination0202"]
+N_SAMPLES = 5
+EQ_TOL = 1e-6
+
+CHECKS = 0
+FAILURES = []
+
+
+def sample_point(rep, rng):
+    """Uniform sample inside the model box, clipped to a finite window."""
+    lo = np.concatenate([np.asarray(rep.var_lb(i), dtype=float) for i in range(rep.n_var_blocks)])
+    hi = np.concatenate([np.asarray(rep.var_ub(i), dtype=float) for i in range(rep.n_var_blocks)])
+    lo = np.where(np.isfinite(lo), lo, -10.0)
+    hi = np.where(np.isfinite(hi), hi, 10.0)
+    hi = np.maximum(hi, lo)
+    return lo + rng.random(lo.shape) * (hi - lo)
+
+
+def equivalence_probe(pristine, reduced, chain, rng):
+    global CHECKS
+    for _ in range(N_SAMPLES):
+        x_red = sample_point(reduced, rng)
+        x_full = np.asarray(chain.postsolve(list(x_red)), dtype=float)
+        o_r, c_r, b_r = reduced.evaluate_point(list(x_red))
+        o_p, c_p, b_p = pristine.evaluate_point(list(x_full))
+        CHECKS += 3
+        scale = 1.0 + abs(o_r)
+        if not np.isfinite(o_p) or abs(o_p - o_r) > EQ_TOL * scale:
+            FAILURES.append(f"objective {o_p!r} != {o_r!r}")
+        if abs(c_p - c_r) > EQ_TOL * (1.0 + abs(c_r)):
+            FAILURES.append(f"constraint violation {c_p!r} != {c_r!r}")
+        if b_p > b_r + EQ_TOL * (1.0 + abs(b_r)):
+            FAILURES.append(f"bound violation {b_p!r} > {b_r!r}")
+
+
+def run_one(inst, rng):
+    path = f"{NL}/{inst}.nl"
+    pristine = parse_nl_file(path)
+    v0, c0 = pristine.n_vars, pristine.n_constraints
+    t0 = time.perf_counter()
+    reduced, chain = pristine.substitute(4)
+    dt = time.perf_counter() - t0
+    v1, c1 = reduced.n_vars, reduced.n_constraints
+    ratio = (v0 / v1) if v1 else float("inf")
+    print(
+        f"{inst:24s} {v0:>7d}->{v1:<7d}v  {c0:>7d}->{c1:<7d}c  "
+        f"{dt:7.3f}s  {ratio:8.2f}x  sweeps={chain.n_sweeps}",
+        flush=True,
+    )
+    for i, st in enumerate(chain.sweep_stats()):
+        print(
+            f"    sweep{i}: elim={st['variables_eliminated']} "
+            f"cand={st['candidate_rows']} cycle={st['cycles_rejected']} "
+            f"pivot={st['pivots_rejected']} growth={st['growth_rejected']} "
+            f"inelig={st['ineligible_rejected']} "
+            f"infeas={st['infeasible_detected']} abort={st['aborted']}",
+            flush=True,
+        )
+    equivalence_probe(pristine, reduced, chain, rng)
+    return inst, v0, v1, ratio, dt
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(20260727)
+    rows = [run_one(i, rng) for i in (sys.argv[1:] or DEFAULT)]
+
+    print(f"\nequivalence comparisons executed: {CHECKS}")
+    if CHECKS == 0:
+        print("PROBE EXECUTED NOTHING")
+        sys.exit(2)
+    if FAILURES:
+        print(f"EQUIVALENCE FAILURES: {len(FAILURES)}")
+        for f in FAILURES[:20]:
+            print("   ", f)
+        sys.exit(1)
+    print("equivalence: all comparisons passed")
+
+    water = [r for r in rows if r[0] == "watercontamination0202"]
+    if water:
+        _, v0, v1, ratio, dt = water[0]
+        ok = ratio >= 50.0 and dt <= 5.0
+        print(
+            f"\nKILL CRITERION (>=50x within 5s on watercontamination0202): "
+            f"{ratio:.2f}x in {dt:.3f}s -> {'PASS' if ok else 'FAIL'}"
+        )

--- a/discopt_benchmarks/scripts/substitute_diff_panel.py
+++ b/discopt_benchmarks/scripts/substitute_diff_panel.py
@@ -1,0 +1,230 @@
+"""CLAUDE.md §5 differential panel for DISCOPT_PRESOLVE_SUBSTITUTE (issue #844).
+
+Runs both arms (flag OFF, flag ON) over the 66 vendored `.nl` instances in
+`python/tests/data/minlplib_nl/` and checks the cert-clean bars:
+
+  * no dual bound crossing the `=opt=` oracle (sense-aware: MINIMIZE bounds must
+    not exceed the optimum, MAXIMIZE bounds must not fall below it);
+  * no false primal;
+  * no certification regression (`gap_certified` True in OFF, False in ON);
+  * no lost incumbent (an objective in OFF but none in ON);
+  * every incumbent independently feasibility-verified against the PRISTINE
+    model via the Rust `evaluate_point` on the un-presolved `ModelRepr`.
+
+Each instance runs in a subprocess so a crash or a hang in one arm cannot
+poison the panel. Oracle values are read from `minlplib.solu` IN THIS SCRIPT
+and the objective sense is read from each model.
+
+Executed-assertion discipline: prints the number of comparisons made and exits
+non-zero when it is zero.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CORPUS = REPO / "python" / "tests" / "data" / "minlplib_nl"
+SOLU = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu"
+TIME_LIMIT = float(os.environ.get("PANEL_TIME_LIMIT", "20"))
+FEAS_TOL = 1e-5
+
+CHILD = r"""
+import json, os, sys, time
+import numpy as np
+import discopt.modeling as dm
+from discopt._rust import model_to_repr
+
+path, tl = sys.argv[1], float(sys.argv[2])
+out = {"instance": os.path.basename(path)[:-3],
+       "flag": os.environ.get("DISCOPT_PRESOLVE_SUBSTITUTE", "0")}
+m = dm.from_nl(path)
+pristine = model_to_repr(m, getattr(m, "_builder", None))
+out["sense"] = pristine.objective_sense
+out["n_vars"] = pristine.n_vars
+t0 = time.perf_counter()
+r = m.solve(time_limit=tl)
+out["wall"] = time.perf_counter() - t0
+out["status"] = r.status
+out["objective"] = None if r.objective is None else float(r.objective)
+out["bound"] = None if r.bound is None else float(r.bound)
+out["gap_certified"] = bool(getattr(r, "gap_certified", False))
+out["node_count"] = int(getattr(r, "node_count", 0) or 0)
+
+# Independent feasibility verification of the reported incumbent against the
+# PRISTINE (un-presolved) model, using the Rust evaluator rather than whatever
+# the solve path used.
+out["verified"] = None
+if isinstance(r.x, dict):
+    flat = []
+    ok = True
+    for v in m._variables:
+        if v.name not in r.x:
+            ok = False
+            break
+        flat.extend(np.asarray(r.x[v.name], dtype=float).reshape(-1).tolist())
+    if ok and len(flat) == pristine.n_vars:
+        obj, con, bnd = pristine.evaluate_point(flat)
+        out["verified"] = {"objective": obj, "con_viol": con, "bnd_viol": bnd}
+print("JSONRESULT " + json.dumps(out))
+"""
+
+
+def read_oracle():
+    table = {}
+    with open(SOLU) as fh:
+        for line in fh:
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            table[parts[1]] = (parts[0], float(parts[2]) if len(parts) > 2 else None)
+    return table
+
+
+def run(path, flag):
+    env = dict(os.environ)
+    env["DISCOPT_PRESOLVE_SUBSTITUTE"] = "1" if flag else "0"
+    env["PYTHONPATH"] = str(REPO / "python")
+    try:
+        p = subprocess.run(
+            [sys.executable, "-u", "-c", CHILD, str(path), str(TIME_LIMIT)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=TIME_LIMIT * 10 + 300,
+        )
+    except subprocess.TimeoutExpired:
+        return {"instance": path.stem, "flag": "1" if flag else "0", "status": "HARD_TIMEOUT"}
+    for line in p.stdout.splitlines():
+        if line.startswith("JSONRESULT "):
+            return json.loads(line[len("JSONRESULT ") :])
+    return {
+        "instance": path.stem,
+        "flag": "1" if flag else "0",
+        "status": "CRASH",
+        "stderr": p.stderr[-600:],
+    }
+
+
+def main():
+    oracle = read_oracle()
+    instances = sorted(CORPUS.glob("*.nl"))
+    print(f"panel: {len(instances)} instances, {TIME_LIMIT}s each, two arms", flush=True)
+
+    checks = 0
+    problems = []
+    results = {}
+    for i, path in enumerate(instances, 1):
+        row = {}
+        for flag in (False, True):
+            t0 = time.time()
+            row["on" if flag else "off"] = run(path, flag)
+            print(
+                f"[{i:3d}/{len(instances)}] {path.stem:28s} "
+                f"{'ON ' if flag else 'OFF'} {time.time() - t0:6.1f}s "
+                f"{row['on' if flag else 'off'].get('status')}",
+                flush=True,
+            )
+        results[path.stem] = row
+        off, on = row["off"], row["on"]
+        marker, opt = oracle.get(path.stem, (None, None))
+
+        for arm_name, arm in (("off", off), ("on", on)):
+            if arm.get("status") in ("CRASH", "HARD_TIMEOUT"):
+                problems.append((path.stem, arm_name, "run failed", arm.get("status"), None))
+                continue
+            sense = arm.get("sense")
+            # Bound vs oracle.
+            if marker == "=opt=" and opt is not None and arm.get("bound") is not None:
+                checks += 1
+                tol = 1e-6 * (1.0 + abs(opt))
+                if sense == "minimize" and arm["bound"] > opt + tol:
+                    problems.append((path.stem, arm_name, "bound above optimum", arm["bound"], opt))
+                if sense == "maximize" and arm["bound"] < opt - tol:
+                    problems.append((path.stem, arm_name, "bound below optimum", arm["bound"], opt))
+            # False primal.
+            if marker == "=opt=" and opt is not None and arm.get("objective") is not None:
+                checks += 1
+                tol = 1e-4 * (1.0 + abs(opt))
+                if sense == "minimize" and arm["objective"] < opt - tol:
+                    problems.append((path.stem, arm_name, "false primal", arm["objective"], opt))
+                if sense == "maximize" and arm["objective"] > opt + tol:
+                    problems.append((path.stem, arm_name, "false primal", arm["objective"], opt))
+            # Independent feasibility of the reported incumbent.
+            if arm.get("objective") is not None:
+                checks += 1
+                v = arm.get("verified")
+                if v is None:
+                    problems.append((path.stem, arm_name, "incumbent unverifiable", None, None))
+                elif max(v["con_viol"], v["bnd_viol"]) > FEAS_TOL:
+                    problems.append(
+                        (
+                            path.stem,
+                            arm_name,
+                            "incumbent infeasible on pristine model",
+                            max(v["con_viol"], v["bnd_viol"]),
+                            FEAS_TOL,
+                        )
+                    )
+                elif abs(v["objective"] - arm["objective"]) > 1e-4 * (1 + abs(arm["objective"])):
+                    problems.append(
+                        (
+                            path.stem,
+                            arm_name,
+                            "reported objective != pristine objective",
+                            arm["objective"],
+                            v["objective"],
+                        )
+                    )
+
+        # Differential checks: ON must not lose anything OFF had.
+        if off.get("status") not in ("CRASH", "HARD_TIMEOUT") and on.get("status") not in (
+            "CRASH",
+            "HARD_TIMEOUT",
+        ):
+            checks += 2
+            if off.get("gap_certified") and not on.get("gap_certified"):
+                problems.append((path.stem, "diff", "certification regression", True, False))
+            if off.get("objective") is not None and on.get("objective") is None:
+                problems.append((path.stem, "diff", "lost incumbent", off["objective"], None))
+
+    out_path = REPO / "substitute_diff_panel.json"
+    with open(out_path, "w") as fh:
+        json.dump(results, fh, indent=2)
+    print(f"\nwrote {out_path}")
+
+    print(f"\ncomparisons executed: {checks}")
+    if checks == 0:
+        print("PANEL EXECUTED NOTHING")
+        return 2
+    if problems:
+        print(f"CERT-CLEAN FAILURES: {len(problems)}")
+        for p in problems:
+            print("   ", p)
+        return 1
+    print(
+        "cert-clean: 0 bound crossings, 0 false primals, 0 cert regressions, "
+        "0 lost incumbents, all incumbents verified on the pristine model"
+    )
+
+    # Net-positive summary (informational; the gate above is soundness).
+    gained = [
+        k
+        for k, v in results.items()
+        if v["off"].get("objective") is None and v["on"].get("objective") is not None
+    ]
+    cert_gained = [
+        k
+        for k, v in results.items()
+        if not v["off"].get("gap_certified") and v["on"].get("gap_certified")
+    ]
+    print(f"incumbents gained by ON: {len(gained)} {gained}")
+    print(f"certifications gained by ON: {len(cert_gained)} {cert_gained}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/discopt_benchmarks/scripts/substitute_targets_e2e.py
+++ b/discopt_benchmarks/scripts/substitute_targets_e2e.py
@@ -1,0 +1,152 @@
+"""P2(a') end-to-end on the three G-G targets, flag ON vs OFF (issue #844).
+
+Reports for each instance and arm: vars/constraints before and after
+substitution, substitution wall, solve status/objective/bound/wall, and
+soundness against the `=opt=` oracle read from minlplib.solu IN THIS SCRIPT.
+
+The objective SENSE is read from the model, so a MAXIMIZE instance is not
+reported as a violation just because the minimize convention was assumed.
+
+Executed-assertion discipline: prints the number of oracle comparisons made and
+exits non-zero when it is zero.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"
+SOLU = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu"
+TARGETS = ["watercontamination0202", "gastrans582_cold13", "gastrans040"]
+TIME_LIMIT = float(os.environ.get("E2E_TIME_LIMIT", "60"))
+
+CHILD = r"""
+import json, os, sys, time
+import discopt.modeling as dm
+from discopt._rust import model_to_repr
+
+inst, tl = sys.argv[1], float(sys.argv[2])
+path = f"{NL}/" + inst + ".nl"
+out = {"instance": inst, "flag": os.environ.get("DISCOPT_PRESOLVE_SUBSTITUTE", "0")}
+m = dm.from_nl(path)
+rep = model_to_repr(m, getattr(m, "_builder", None))
+out["vars_before"] = rep.n_vars
+out["cons_before"] = rep.n_constraints
+out["sense"] = rep.objective_sense
+t0 = time.perf_counter()
+red, chain = rep.substitute(4)
+out["subst_wall"] = time.perf_counter() - t0
+out["vars_after"] = red.n_vars
+out["cons_after"] = red.n_constraints
+t0 = time.perf_counter()
+r = m.solve(time_limit=tl)
+out["solve_wall"] = time.perf_counter() - t0
+out["status"] = r.status
+out["objective"] = None if r.objective is None else float(r.objective)
+out["bound"] = None if r.bound is None else float(r.bound)
+out["gap_certified"] = bool(getattr(r, "gap_certified", False))
+print("JSONRESULT " + json.dumps(out))
+""".replace("{NL}", NL)
+
+
+def read_oracle():
+    """`{name: (marker, value)}` parsed from minlplib.solu in this run."""
+    table = {}
+    with open(SOLU) as fh:
+        for line in fh:
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            marker, name = parts[0], parts[1]
+            val = float(parts[2]) if len(parts) > 2 else None
+            table[name] = (marker, val)
+    return table
+
+
+def run(inst, flag):
+    env = dict(os.environ)
+    env["DISCOPT_PRESOLVE_SUBSTITUTE"] = "1" if flag else "0"
+    env["PYTHONPATH"] = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    env["PYTHONPATH"] = os.path.join(env["PYTHONPATH"], "python")
+    p = subprocess.run(
+        [sys.executable, "-u", "-c", CHILD, inst, str(TIME_LIMIT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=TIME_LIMIT * 8 + 600,
+    )
+    for line in p.stdout.splitlines():
+        if line.startswith("JSONRESULT "):
+            return json.loads(line[len("JSONRESULT ") :])
+    print(f"  !! no result for {inst} flag={flag}\n{p.stdout[-2000:]}\n{p.stderr[-2000:]}")
+    return None
+
+
+if __name__ == "__main__":
+    oracle = read_oracle()
+    checks = 0
+    violations = []
+    rows = []
+    for inst in TARGETS:
+        for flag in (False, True):
+            t0 = time.time()
+            res = run(inst, flag)
+            print(
+                f"[{time.strftime('%H:%M:%S')}] {inst} flag={int(flag)} "
+                f"done in {time.time() - t0:.1f}s",
+                flush=True,
+            )
+            if res is None:
+                continue
+            marker, opt = oracle.get(inst, (None, None))
+            res["oracle_marker"], res["oracle"] = marker, opt
+            # Soundness: for MINIMIZE the dual bound must not exceed the optimum;
+            # for MAXIMIZE the dual bound must not fall below it.
+            if marker == "=opt=" and opt is not None and res["bound"] is not None:
+                checks += 1
+                tol = 1e-6 * (1.0 + abs(opt))
+                if res["sense"] == "minimize" and res["bound"] > opt + tol:
+                    violations.append((inst, flag, "bound above optimum", res["bound"], opt))
+                if res["sense"] == "maximize" and res["bound"] < opt - tol:
+                    violations.append((inst, flag, "bound below optimum", res["bound"], opt))
+            if marker == "=opt=" and opt is not None and res["objective"] is not None:
+                checks += 1
+                tol = 1e-4 * (1.0 + abs(opt))
+                if res["sense"] == "minimize" and res["objective"] < opt - tol:
+                    violations.append((inst, flag, "false primal", res["objective"], opt))
+                if res["sense"] == "maximize" and res["objective"] > opt + tol:
+                    violations.append((inst, flag, "false primal", res["objective"], opt))
+            rows.append(res)
+            print("   " + json.dumps(res), flush=True)
+
+    print("\n=== END-TO-END TABLE ===")
+    hdr = (
+        f"{'instance':24s} {'flag':4s} {'vars':>16s} {'cons':>16s} {'sub_s':>7s} "
+        f"{'status':12s} {'objective':>14s} {'bound':>14s} {'wall_s':>7s}"
+    )
+    print(hdr)
+    for r in rows:
+        obj_s = "-" if r["objective"] is None else format(r["objective"], ".6g")
+        bnd_s = "-" if r["bound"] is None else format(r["bound"], ".6g")
+        print(
+            f"{r['instance']:24s} {r['flag']:4s} "
+            f"{r['vars_before']:>7d}->{r['vars_after']:<8d} "
+            f"{r['cons_before']:>7d}->{r['cons_after']:<8d} "
+            f"{r['subst_wall']:7.3f} {r['status']:12s} "
+            f"{obj_s:>14s} {bnd_s:>14s} {r['solve_wall']:7.2f}"
+        )
+    with open("substitute_targets_e2e.json", "w") as fh:
+        json.dump(rows, fh, indent=2)
+
+    print(f"\noracle comparisons executed: {checks}")
+    if checks == 0:
+        print("PROBE EXECUTED NOTHING")
+        sys.exit(2)
+    if violations:
+        print(f"SOUNDNESS VIOLATIONS: {len(violations)}")
+        for v in violations:
+            print("   ", v)
+        sys.exit(1)
+    print("soundness: no violations against the =opt= oracle")

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -5282,6 +5282,73 @@ def _rebalance_deep_sum(expr: "Expression") -> "Expression":
     return terms[0]
 
 
+def model_from_repr(rep, name: str) -> Model:
+    """Build a Python :class:`Model` from a Rust ``ModelRepr``.
+
+    Shared by :func:`from_nl` (whose ``rep`` comes from the ``.nl`` parser) and
+    by the presolve substitution entry (#844), whose ``rep`` is a *reduced*
+    model produced by ``ModelRepr.substitute``. Variables are created in block
+    order, so the resulting model's flat variable vector is index-compatible
+    with ``rep``'s.
+
+    Complementarity relations are **not** reconstructed here — they live
+    outside ``ModelRepr`` and are threaded separately by :func:`from_nl`.
+    """
+    from discopt._jax.nl_reconstruction import reconstruct_dag
+
+    m = Model(name)
+
+    var_types = rep.var_types()
+    var_names = rep.var_names()
+    var_shapes = rep.var_shapes()
+    for i in range(len(var_names)):
+        vt = var_types[i]
+        vname = var_names[i]
+        lb_vals = rep.var_lb(i)
+        ub_vals = rep.var_ub(i)
+        shape_list = var_shapes[i]
+        shape = tuple(shape_list) if shape_list else ()
+        lb = np.array(lb_vals).reshape(shape) if shape else float(lb_vals[0])
+        ub = np.array(ub_vals).reshape(shape) if shape else float(ub_vals[0])
+
+        if vt == "continuous":
+            m.continuous(vname, shape=shape, lb=lb, ub=ub)
+        elif vt == "binary":
+            var = m.binary(vname, shape=shape)
+            # Preserve the parsed bounds (X-3 / M2 / INT-2): `Model.binary` hardcodes
+            # ``[0, 1]``, so a bound-narrowed or fixed binary (e.g. ``lb == ub == 1``,
+            # routine Pyomo/presolve output) would silently un-fix, giving the wrong
+            # optimum on the round-trip. Clamp the parsed bounds into ``[0, 1]`` (a
+            # binary column is 0/1 by definition) and stamp them onto the variable.
+            var.lb = np.broadcast_to(np.clip(np.asarray(lb, dtype=np.float64), 0.0, 1.0), shape)
+            var.ub = np.broadcast_to(np.clip(np.asarray(ub, dtype=np.float64), 0.0, 1.0), shape)
+        elif vt == "integer":
+            m.integer(vname, shape=shape, lb=lb, ub=ub)
+
+    objective_expr, constraint_tuples = reconstruct_dag(rep, m._variables)
+
+    # #654: rebalance pathologically deep ``+`` chains (flat sums parsed as depth-N
+    # left chains) so downstream recursive tree-walks don't overflow the stack.
+    # A no-op below _SUM_REBALANCE_DEPTH, so ordinary models are byte-identical.
+    obj_expr: Expression = _rebalance_deep_sum(objective_expr)
+
+    if rep.objective_sense == "minimize":
+        m.minimize(obj_expr)
+    else:
+        m.maximize(obj_expr)
+
+    for body, sense, rhs in constraint_tuples:
+        body_expr: Expression = _rebalance_deep_sum(body)
+        if sense == "<=":
+            m.subject_to(body_expr <= rhs)
+        elif sense == ">=":
+            m.subject_to(body_expr >= rhs)
+        elif sense == "==":
+            m.subject_to(body_expr == rhs)
+
+    return m
+
+
 def from_nl(path: str) -> Model:
     """
     Import a model from AMPL .nl format.
@@ -5305,71 +5372,15 @@ def from_nl(path: str) -> Model:
     >>> model = dm.from_nl("problem.nl")
     >>> result = model.solve()
     """
-    from discopt._jax.nl_reconstruction import (
-        reconstruct_complementarities,
-        reconstruct_dag,
-    )
+    import os
+
+    from discopt._jax.nl_reconstruction import reconstruct_complementarities
     from discopt._rust import parse_nl_file
 
     nl_repr = parse_nl_file(path)
 
-    # Build a Python Model from the parsed representation
-    import os
-
     model_name = os.path.splitext(os.path.basename(path))[0]
-    m = Model(model_name)
-
-    # Create variables matching the .nl file
-    var_types = nl_repr.var_types()
-    var_names = nl_repr.var_names()
-    var_shapes = nl_repr.var_shapes()
-    for i in range(len(var_names)):
-        vt = var_types[i]
-        name = var_names[i]
-        lb_vals = nl_repr.var_lb(i)
-        ub_vals = nl_repr.var_ub(i)
-        shape_list = var_shapes[i]
-        shape = tuple(shape_list) if shape_list else ()
-        lb = np.array(lb_vals).reshape(shape) if shape else float(lb_vals[0])
-        ub = np.array(ub_vals).reshape(shape) if shape else float(ub_vals[0])
-
-        if vt == "continuous":
-            m.continuous(name, shape=shape, lb=lb, ub=ub)
-        elif vt == "binary":
-            var = m.binary(name, shape=shape)
-            # Preserve the parsed bounds (X-3 / M2 / INT-2): `Model.binary` hardcodes
-            # ``[0, 1]``, so a bound-narrowed or fixed binary (e.g. ``lb == ub == 1``,
-            # routine Pyomo/presolve output) would silently un-fix, giving the wrong
-            # optimum on the round-trip. Clamp the parsed bounds into ``[0, 1]`` (a
-            # binary column is 0/1 by definition) and stamp them onto the variable.
-            var.lb = np.broadcast_to(np.clip(np.asarray(lb, dtype=np.float64), 0.0, 1.0), shape)
-            var.ub = np.broadcast_to(np.clip(np.asarray(ub, dtype=np.float64), 0.0, 1.0), shape)
-        elif vt == "integer":
-            m.integer(name, shape=shape, lb=lb, ub=ub)
-
-    # Reconstruct the expression DAG from the Rust arena
-    objective_expr, constraint_tuples = reconstruct_dag(nl_repr, m._variables)
-
-    # #654: rebalance pathologically deep ``+`` chains (flat sums parsed as depth-N
-    # left chains) so downstream recursive tree-walks don't overflow the stack.
-    # A no-op below _SUM_REBALANCE_DEPTH, so ordinary models are byte-identical.
-    obj_expr: Expression = _rebalance_deep_sum(objective_expr)
-
-    # Set the objective with the reconstructed expression
-    if nl_repr.objective_sense == "minimize":
-        m.minimize(obj_expr)
-    else:
-        m.maximize(obj_expr)
-
-    # Add constraints from the reconstructed DAG
-    for body, sense, rhs in constraint_tuples:
-        body_expr: Expression = _rebalance_deep_sum(body)
-        if sense == "<=":
-            m.subject_to(body_expr <= rhs)
-        elif sense == ">=":
-            m.subject_to(body_expr >= rhs)
-        elif sense == "==":
-            m.subject_to(body_expr == rhs)
+    m = model_from_repr(nl_repr, model_name)
 
     # Complementarity (type-5) rows: lower each ``body ⊥ x`` relation through the
     # exact GDP disjunction machinery instead of adding it as an ordinary

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4684,7 +4684,7 @@ def solve_model(
     if _sub is not None:
         import inspect as _inspect
 
-        _reduced_model, _sub_chain, _sub_pristine = _sub
+        _reduced_model, _sub_chain, _sub_pristine, _sub_prep_s = _sub
         _frame = _inspect.currentframe()
         if _frame is None:  # pragma: no cover - no Python frame introspection
             raise RuntimeError(
@@ -4696,6 +4696,9 @@ def solve_model(
         _fwd = {k: _lv[k] for k in _names if k != "model"}
         if _kwname:
             _fwd.update(_lv[_kwname])
+        # Charge the reduction's own wall time against the caller's budget so
+        # ``solve(time_limit=N)`` still tracks N end to end.
+        _fwd["time_limit"] = max(1.0, float(time_limit) - _sub_prep_s)
         with _sub_scope():
             _sub_result = solve_model(_reduced_model, **_fwd)
         _lifted: Optional[SolveResult] = _sub_lift_result(

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4648,6 +4648,66 @@ def solve_model(
     if _root_cut_max < 1:
         raise ValueError(f"root_cut_max must be >= 1, got {_root_cut_max}")
 
+    # --- Presolve substitution entry (#844, P2(a′), opt-in) ---------------
+    # Solve a REDUCED model in which every variable determined by a linear
+    # equality has been substituted out of every row and the objective, then
+    # lift the incumbent back through the postsolve chain and verify it against
+    # the PRISTINE model (#779). Bound-changing in the sense of CLAUDE.md §5
+    # (it rewrites the model the relaxation is built from), so it is gated
+    # behind ``DISCOPT_PRESOLVE_SUBSTITUTE``, default OFF. Declined whenever a
+    # caller-supplied object is expressed in the ORIGINAL variable space —
+    # a warm-start point, a callback, lazy constraints or a decomposition
+    # structure — because handing those to the reduced model would silently
+    # misinterpret them.
+    try:
+        from discopt.solvers._presolve_substitute import (
+            build_reduced as _sub_build_reduced,
+        )
+        from discopt.solvers._presolve_substitute import (
+            lift_result as _sub_lift_result,
+        )
+        from discopt.solvers._presolve_substitute import (
+            reduced_solve_scope as _sub_scope,
+        )
+
+        _sub_blocked = (
+            initial_point is not None
+            or lazy_constraints is not None
+            or incumbent_callback is not None
+            or node_callback is not None
+            or decomposition_structure is not None
+        )
+        _sub = None if _sub_blocked else _sub_build_reduced(model)
+    except Exception as _sub_exc:  # pragma: no cover - capability probe
+        logger.debug("substitution presolve entry unavailable: %s", _sub_exc)
+        _sub = None
+    if _sub is not None:
+        import inspect as _inspect
+
+        _reduced_model, _sub_chain, _sub_pristine = _sub
+        _frame = _inspect.currentframe()
+        if _frame is None:  # pragma: no cover - no Python frame introspection
+            raise RuntimeError(
+                "DISCOPT_PRESOLVE_SUBSTITUTE needs frame introspection to forward "
+                "solve arguments to the reduced solve; this interpreter does not "
+                "provide it. Unset the flag to use the default path."
+            )
+        _names, _, _kwname, _lv = _inspect.getargvalues(_frame)
+        _fwd = {k: _lv[k] for k in _names if k != "model"}
+        if _kwname:
+            _fwd.update(_lv[_kwname])
+        with _sub_scope():
+            _sub_result = solve_model(_reduced_model, **_fwd)
+        _lifted: Optional[SolveResult] = _sub_lift_result(
+            model, _reduced_model, _sub_chain, _sub_pristine, _sub_result
+        )
+        if _lifted is not None:
+            return _lifted
+        logger.warning(
+            "substitution presolve: result could not be lifted and verified; "
+            "re-solving the original model"
+        )
+
     # Anchor the whole-solve clock HERE, before any reformulation / presolve /
     # relaxation-build work — not at the B&B loop entry below. Preprocessing
     # (root presolve, OBBT, relaxation build) can take tens of seconds on large

--- a/python/discopt/solvers/_presolve_substitute.py
+++ b/python/discopt/solvers/_presolve_substitute.py
@@ -1,0 +1,200 @@
+"""Solve-path entry for the batch substitution aggregator (issue #844, P2(a′)).
+
+The Rust pass ``ModelRepr.substitute`` rewrites a variable determined by a
+linear equality out of *every* expression it appears in and drops the defining
+row (see ``crates/discopt-core/src/presolve/substitute.rs``). Until this module
+existed the reduced model was computed and then discarded — the solve path
+consumed only the tightened *bounds*
+(``presolve_pipeline.propagate_bounds_to_model``).
+
+This module closes that loop:
+
+1. build the pristine ``ModelRepr``;
+2. substitute to a fixed point;
+3. reconstruct a Python ``Model`` from the reduced repr and solve **that**;
+4. lift the incumbent back through the postsolve chain and report it in the
+   ORIGINAL variables.
+
+Soundness rules, in force regardless of what the reduced solve reports:
+
+- an incumbent that cannot be inverted, or whose lifted point is not feasible
+  for the **pristine** model (the #779 guard), is *discarded* — this function
+  returns ``None`` and the caller runs the ordinary path. A point that cannot
+  be verified is never reported;
+- the reported objective is the one **recomputed on the pristine model** at the
+  lifted point, not the reduced model's number, and the two must agree;
+- the dual bound is carried over unchanged, which is valid because the
+  substitution is an exact reformulation (equal feasible sets under the affine
+  bijection, equal objective), not a relaxation.
+
+Gated by ``DISCOPT_PRESOLVE_SUBSTITUTE``, default **OFF** (CLAUDE.md §5:
+bound-changing work ships behind a flag until a differential panel passes).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import TYPE_CHECKING, Any, Optional
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from discopt.modeling.core import SolveResult
+
+logger = logging.getLogger(__name__)
+
+#: Objective agreement tolerance between the reduced and pristine evaluations.
+_OBJ_TOL = 1e-6
+#: Feasibility tolerance for the pristine-model check (matches the #779 guard).
+_FEAS_TOL = 1e-5
+
+#: Re-entrancy guard: the reduced solve must not substitute again.
+_state = threading.local()
+
+
+def substitution_enabled() -> bool:
+    """True when ``DISCOPT_PRESOLVE_SUBSTITUTE`` is set to a truthy value."""
+    return os.environ.get("DISCOPT_PRESOLVE_SUBSTITUTE", "0").strip().lower() not in (
+        "",
+        "0",
+        "false",
+        "off",
+        "no",
+    )
+
+
+def _in_reduced_solve() -> bool:
+    return bool(getattr(_state, "active", False))
+
+
+def build_reduced(model) -> Optional[tuple[Any, Any, Any]]:
+    """``(reduced_model, chain, pristine_repr)`` or ``None`` if not applicable.
+
+    ``None`` means "nothing to gain / not safe here": the flag is off, the Rust
+    repr could not be built, the model carries complementarity relations, or no
+    variable was eliminated.
+    """
+    if not substitution_enabled() or _in_reduced_solve():
+        return None
+    try:
+        from discopt._rust import model_to_repr
+        from discopt.modeling.core import model_from_repr
+    except Exception as exc:  # pragma: no cover - import-time capability probe
+        logger.debug("substitution presolve unavailable: %s", exc)
+        return None
+
+    pristine = model_to_repr(model, getattr(model, "_builder", None))
+    reduced_repr, chain = pristine.substitute(4)
+    if chain.refused is not None:
+        logger.info("substitution presolve declined: %s", chain.refused)
+        return None
+    if chain.variables_eliminated == 0:
+        return None
+    reduced_model = model_from_repr(reduced_repr, f"{model.name}_substituted")
+    logger.info(
+        "substitution presolve: %d -> %d vars, %d -> %d constraints (%d sweeps)",
+        pristine.n_vars,
+        reduced_repr.n_vars,
+        pristine.n_constraints,
+        reduced_repr.n_constraints,
+        chain.n_sweeps,
+    )
+    return reduced_model, chain, pristine
+
+
+def _flat_point(model, x_dict) -> Optional[np.ndarray]:
+    """Flatten a ``SolveResult.x`` dict into the model's variable order."""
+    if not isinstance(x_dict, dict):
+        return None
+    flat: list[float] = []
+    for v in model._variables:
+        if v.name not in x_dict:
+            return None
+        flat.extend(np.asarray(x_dict[v.name], dtype=float).reshape(-1).tolist())
+    return np.asarray(flat, dtype=float)
+
+
+def lift_result(
+    model, reduced_model, chain, pristine_repr, result: Optional[SolveResult]
+) -> Optional[SolveResult]:
+    """Map a reduced-space :class:`SolveResult` back to the original variables.
+
+    Returns ``None`` when the result cannot be lifted **and verified**, in which
+    case the caller must fall back to the ordinary solve path.
+    """
+    from discopt.solvers._convex_kernel import _incumbent_is_feasible, _unflatten
+
+    if result is None:
+        return None
+
+    # A status with no incumbent still carries a valid dual bound for the
+    # ORIGINAL problem (the transform is an equivalence), so it can be reported
+    # as-is once we know there is nothing to invert.
+    if result.objective is None or result.x is None:
+        return result
+
+    x_red = _flat_point(reduced_model, result.x)
+    if x_red is None or x_red.size != reduced_model_n_vars(reduced_model):
+        logger.warning("substitution postsolve: reduced point unusable; discarding incumbent")
+        return None
+    try:
+        x_full = np.asarray(chain.postsolve(x_red.tolist()), dtype=float)
+    except Exception as exc:
+        logger.warning("substitution postsolve failed (%s); discarding incumbent", exc)
+        return None
+    if x_full.size != pristine_repr.n_vars or not np.all(np.isfinite(x_full)):
+        logger.warning("substitution postsolve produced a bad point; discarding incumbent")
+        return None
+
+    # #779 guard: the lifted point must be feasible for the PRISTINE model.
+    if not _incumbent_is_feasible(model, x_full, tol=_FEAS_TOL):
+        logger.warning(
+            "substitution postsolve: lifted incumbent is infeasible for the "
+            "pristine model; discarding it and falling back"
+        )
+        return None
+
+    obj_pristine, con_viol, bnd_viol = pristine_repr.evaluate_point(x_full.tolist())
+    if not np.isfinite(obj_pristine):
+        logger.warning("substitution postsolve: non-finite pristine objective; discarding")
+        return None
+    if abs(obj_pristine - float(result.objective)) > _OBJ_TOL * (1.0 + abs(obj_pristine)):
+        logger.warning(
+            "substitution postsolve: objective mismatch (pristine %.12g vs reduced "
+            "%.12g); discarding incumbent",
+            obj_pristine,
+            result.objective,
+        )
+        return None
+    if max(con_viol, bnd_viol) > _FEAS_TOL:
+        logger.warning(
+            "substitution postsolve: pristine violation %.3g exceeds tolerance; discarding",
+            max(con_viol, bnd_viol),
+        )
+        return None
+
+    x_dict, _ = _unflatten(model, x_full)
+    result.x = x_dict
+    result.objective = float(obj_pristine)
+    result._model = model
+    return result
+
+
+def reduced_model_n_vars(reduced_model) -> int:
+    """Total scalar variable count of a Python model."""
+    return int(sum(int(v.size) for v in reduced_model._variables))
+
+
+class reduced_solve_scope:  # noqa: N801 - context manager, lowercase by convention here
+    """Marks the nested solve so it does not substitute recursively."""
+
+    def __enter__(self):
+        self._prev = getattr(_state, "active", False)
+        _state.active = True
+        return self
+
+    def __exit__(self, *exc):
+        _state.active = self._prev
+        return False

--- a/python/discopt/solvers/_presolve_substitute.py
+++ b/python/discopt/solvers/_presolve_substitute.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -69,12 +70,14 @@ def _in_reduced_solve() -> bool:
     return bool(getattr(_state, "active", False))
 
 
-def build_reduced(model) -> Optional[tuple[Any, Any, Any]]:
-    """``(reduced_model, chain, pristine_repr)`` or ``None`` if not applicable.
+def build_reduced(model) -> Optional[tuple[Any, Any, Any, float]]:
+    """``(reduced_model, chain, pristine_repr, elapsed_s)`` or ``None``.
 
     ``None`` means "nothing to gain / not safe here": the flag is off, the Rust
     repr could not be built, the model carries complementarity relations, or no
-    variable was eliminated.
+    variable was eliminated. ``elapsed_s`` is the wall time this preparation
+    consumed, so the caller can charge it against the solve's ``time_limit``
+    rather than handing the reduced solve a fresh full budget.
     """
     if not substitution_enabled() or _in_reduced_solve():
         return None
@@ -85,6 +88,7 @@ def build_reduced(model) -> Optional[tuple[Any, Any, Any]]:
         logger.debug("substitution presolve unavailable: %s", exc)
         return None
 
+    t0 = time.perf_counter()
     pristine = model_to_repr(model, getattr(model, "_builder", None))
     reduced_repr, chain = pristine.substitute(4)
     if chain.refused is not None:
@@ -93,15 +97,17 @@ def build_reduced(model) -> Optional[tuple[Any, Any, Any]]:
     if chain.variables_eliminated == 0:
         return None
     reduced_model = model_from_repr(reduced_repr, f"{model.name}_substituted")
+    elapsed = time.perf_counter() - t0
     logger.info(
-        "substitution presolve: %d -> %d vars, %d -> %d constraints (%d sweeps)",
+        "substitution presolve: %d -> %d vars, %d -> %d constraints (%d sweeps, %.3fs)",
         pristine.n_vars,
         reduced_repr.n_vars,
         pristine.n_constraints,
         reduced_repr.n_constraints,
         chain.n_sweeps,
+        elapsed,
     )
-    return reduced_model, chain, pristine
+    return reduced_model, chain, pristine, elapsed
 
 
 def _flat_point(model, x_dict) -> Optional[np.ndarray]:
@@ -124,7 +130,7 @@ def lift_result(
     Returns ``None`` when the result cannot be lifted **and verified**, in which
     case the caller must fall back to the ordinary solve path.
     """
-    from discopt.solvers._convex_kernel import _incumbent_is_feasible, _unflatten
+    from discopt.solvers._convex_kernel import _unflatten
 
     if result is None:
         return None
@@ -149,13 +155,19 @@ def lift_result(
         return None
 
     # #779 guard: the lifted point must be feasible for the PRISTINE model.
-    if not _incumbent_is_feasible(model, x_full, tol=_FEAS_TOL):
-        logger.warning(
-            "substitution postsolve: lifted incumbent is infeasible for the "
-            "pristine model; discarding it and falling back"
-        )
-        return None
-
+    #
+    # The check runs through the Rust evaluator on ``pristine_repr`` — the
+    # un-presolved ``ModelRepr`` built from this very model — rather than
+    # ``_convex_kernel._incumbent_is_feasible``, which builds a JAX
+    # ``NLPEvaluator``. Two reasons, in order:
+    #   1. it is *stronger*: it checks variable bounds as well as constraints,
+    #      and bounds are exactly what a substitution transfers;
+    #   2. the JAX path does not scale to the models this pass targets. On
+    #      watercontamination0202 (106,711 vars / 107,209 rows) the Rust check
+    #      is 0.008 s while the JAX path had not returned after 119 s
+    #      (measured, same point, same process) — verification alone would have
+    #      consumed several times the solve budget the reduction is meant to
+    #      save.
     obj_pristine, con_viol, bnd_viol = pristine_repr.evaluate_point(x_full.tolist())
     if not np.isfinite(obj_pristine):
         logger.warning("substitution postsolve: non-finite pristine objective; discarding")

--- a/python/tests/test_presolve_substitute.py
+++ b/python/tests/test_presolve_substitute.py
@@ -1,0 +1,158 @@
+"""Regression tests for the batch substitution aggregator (#844, P2(a′)).
+
+Covers the three properties the Rust pass has to guarantee end to end:
+
+1. **substitute-everywhere** — a variable defined by a linear equality is
+   rewritten out of every row *and* the objective, which is exactly what the
+   pre-existing ``aggregate``/``eliminate`` passes cannot do (they require the
+   eliminated variable to appear in a single expression). ``test_legacy_*``
+   pins that pre-existing limitation so the difference is measured, not
+   asserted;
+2. **postsolve inverts exactly** — including a chain of ≥3 substitutions and a
+   rejected cycle;
+3. **the solve path agrees** — ``DISCOPT_PRESOLVE_SUBSTITUTE=1`` returns the
+   same optimum, in the ORIGINAL variables, as the default path.
+"""
+
+import os
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._rust import model_to_repr
+
+
+def _repr_of(model):
+    return model_to_repr(model, getattr(model, "_builder", None))
+
+
+def _chain_model():
+    """x0 = 2·x1 + 1, x1 = 3·x2 + 2, x2 = 4·x3 + 3 (a depth-3 chain), plus an
+    inequality and an objective in which every chained variable appears."""
+    m = dm.Model("chain")
+    x = [m.continuous(f"x{i}", lb=-1e3, ub=1e3) for i in range(5)]
+    m.subject_to(x[0] - 2 * x[1] == 1)
+    m.subject_to(x[1] - 3 * x[2] == 2)
+    m.subject_to(x[2] - 4 * x[3] == 3)
+    m.subject_to(x[0] + x[1] + x[2] + x[3] <= 100)
+    m.minimize(x[0] + x[4])
+    return m
+
+
+@pytest.mark.smoke
+def test_legacy_aggregate_pass_cannot_reduce_the_chain_model():
+    """Fails-before evidence: the pre-existing passes eliminate nothing here."""
+    rep = _repr_of(_chain_model())
+    reduced, _ = rep.presolve(
+        passes=["eliminate", "aggregate", "factorable_elim"],
+        max_iterations=8,
+        time_limit_ms=5000,
+    )
+    assert reduced.n_vars == rep.n_vars == 5
+
+
+@pytest.mark.smoke
+def test_chain_of_three_substitutions_is_eliminated_and_inverted():
+    m = _chain_model()
+    rep = _repr_of(m)
+    reduced, chain = rep.substitute(4)
+
+    assert chain.variables_eliminated == 3
+    assert reduced.n_vars == 2, "x3 and the unused x4 survive"
+    assert reduced.n_constraints == 1, "only the inequality remains"
+
+    # Every definition names the SAME surviving representative: the chain
+    # collapsed, which is why postsolve needs no topological ordering.
+    recs = chain.records(0)
+    sources = {r["source_block"] for r in recs if r["kind"] == "affine"}
+    assert len(sources) == 1, f"expected one representative, got {sources}"
+
+    checked = 0
+    for t in (-3.5, 0.0, 2.25, 7.0):
+        x_red = [t + 0.5 * i for i in range(reduced.n_vars)]
+        x_full = np.asarray(chain.postsolve(x_red), float)
+        assert x_full.shape == (rep.n_vars,)
+        obj_r, _, _ = reduced.evaluate_point(x_red)
+        obj_p, con_p, _ = rep.evaluate_point(list(x_full))
+        # The three dropped equalities are the ONLY equalities in the model, so
+        # a zero constraint violation on the pristine model at the lifted point
+        # is exactly the statement that postsolve inverted them.
+        assert con_p == pytest.approx(0.0, abs=1e-9), f"dropped rows violated at t={t}"
+        assert obj_p == pytest.approx(obj_r, abs=1e-9)
+        checked += 1
+    assert checked == 4
+
+
+@pytest.mark.smoke
+def test_cycle_is_rejected_and_its_row_is_kept():
+    m = dm.Model("cycle")
+    x = [m.continuous(f"x{i}", lb=-10, ub=10) for i in range(3)]
+    m.subject_to(x[0] - x[1] == 0)
+    m.subject_to(x[1] - x[2] == 0)
+    m.subject_to(x[2] - x[0] == 0)  # closes the cycle: defines nothing new
+    m.minimize(x[0])
+
+    rep = _repr_of(m)
+    reduced, chain = rep.substitute(4)
+    stats = chain.sweep_stats()[0]
+
+    assert chain.variables_eliminated == 2
+    assert stats["cycles_rejected"] == 1
+    assert reduced.n_vars == 1
+    assert reduced.n_constraints == 1, "the cycle row stays in the model"
+    assert chain.postsolve([4.25]) == pytest.approx([4.25, 4.25, 4.25])
+
+
+@pytest.mark.smoke
+def test_infeasible_transfer_is_reported_and_the_model_is_unchanged():
+    m = dm.Model("infeas")
+    a = m.continuous("a", lb=0.0, ub=1.0)
+    b = m.continuous("b", lb=5.0, ub=6.0)
+    m.subject_to(a - b == 0)
+    m.minimize(a)
+
+    rep = _repr_of(m)
+    reduced, chain = rep.substitute(4)
+    assert chain.variables_eliminated == 0
+    assert reduced.n_vars == rep.n_vars
+    assert reduced.n_constraints == rep.n_constraints
+
+
+@pytest.mark.smoke
+def test_integer_source_is_kept_and_continuous_target_is_eliminated():
+    m = dm.Model("intsrc")
+    x = m.continuous("x", lb=-100, ub=100)
+    y = m.integer("y", lb=0, ub=10)
+    m.subject_to(x - 2 * y == 1)
+    m.minimize(x)
+
+    rep = _repr_of(m)
+    reduced, chain = rep.substitute(4)
+    assert chain.variables_eliminated == 1
+    assert reduced.var_types() == ["integer"]
+    assert chain.postsolve([3.0]) == pytest.approx([7.0, 3.0])
+
+
+@pytest.mark.smoke
+def test_solve_path_flag_agrees_with_the_default_path():
+    """The reduced solve must return the same optimum, in original variables."""
+    prev = os.environ.get("DISCOPT_PRESOLVE_SUBSTITUTE")
+    try:
+        os.environ["DISCOPT_PRESOLVE_SUBSTITUTE"] = "0"
+        base = _chain_model().solve(time_limit=30)
+        os.environ["DISCOPT_PRESOLVE_SUBSTITUTE"] = "1"
+        sub = _chain_model().solve(time_limit=30)
+    finally:
+        if prev is None:
+            os.environ.pop("DISCOPT_PRESOLVE_SUBSTITUTE", None)
+        else:
+            os.environ["DISCOPT_PRESOLVE_SUBSTITUTE"] = prev
+
+    assert sub.status == base.status
+    assert sub.objective == pytest.approx(base.objective, rel=1e-6, abs=1e-6)
+    # Reported in the ORIGINAL variables, and feasible for the pristine model.
+    assert set(sub.x) == {"x0", "x1", "x2", "x3", "x4"}
+    rep = _repr_of(_chain_model())
+    flat = [float(np.asarray(sub.x[f"x{i}"]).reshape(-1)[0]) for i in range(5)]
+    _, con_viol, bnd_viol = rep.evaluate_point(flat)
+    assert max(con_viol, bnd_viol) < 1e-6


### PR DESCRIPTION
## What

P2(a') items (i) and (iii) from `docs/dev/sota-parity-analysis-2026-07-27.md`: a
**batch substitution-graph aggregator** with **substitute-everywhere** semantics
and a **postsolve chain**, plus an opt-in solve-path entry that consumes the
reduced model.

New: `crates/discopt-core/src/presolve/substitute.rs`.

Every `Eq` row with a linear body is resolved into *representative space* by a
union-find over variable blocks carrying an **affine potential** (`x_i =
coeff_i * x_parent(i) + offset_i`, composed with path compression). A row landing
on one representative fixes it; a row landing on two eliminates one in favour of
the other. All definitions are resolved **first**, then a **single** post-order
walk over the expression DAG applies every substitution and the variable
renumbering together.

This removes both limitations the P2(a) entry experiment measured:

| limitation of `aggregate`/`eliminate` | here |
|---|---|
| eliminated variable must appear in **exactly one expression** | substituted out of **every** row, nonlinear body and the objective |
| rescans all rows per aggregation (measured ~11 aggregations/s on `watercontamination0202`, projecting ~2.6 h) | O(nnz + nodes + eliminations) with one rewrite pass |

Because every substitution replaces one variable leaf by an affine image of one
other variable, **no fill-in is created** - each row's term count is unchanged.

## Kill criterion (stated before the run, per CLAUDE.md section 4)

> the batch aggregator must reach **>=50x reduction on `watercontamination0202`
> within 5 s**, else stop and report the achieved number and the structural
> reason.

**Verdict: PASS - 123.22x in 0.075 s.**

| instance | discopt before (P2(a) entry) | **this PR** | SCIP reference |
|---|---|---|---|
| `watercontamination0202` | 106,711 -> 106,711 (1.00x), 60 s | **106,711 -> 866 (123.2x), 0.075 s** | 106,711 -> 566 (189x), 0.19 s |
| `gastrans582_cold13` | 2,186 -> 2,025 (1.08x), 60 s | **2,186 -> 1,368 (1.60x), 0.004 s** | 2,186 -> 598 (3.7x), 5.4 s |
| `gastrans040` | 279 -> 269 (1.04x), 1.6 s | **279 -> 204 (1.37x), 0.001 s** | 279 -> 80 (3.5x), 0.06 s |

The substitution wall is 2.5x faster than SCIP's whole presolve on
`watercontamination0202` at 65% of its reduction. The residual gap is
*attributed* by the pass's own counters, not guessed: 609 + 356 rows rejected as
cycles across the two sweeps, and **zero** rejected by the pivot or growth
guards. The `gastrans*` gap is a different mechanism - those models are
nonlinear-equality-heavy (45 nonlinear equalities on `gastrans040`), which no
linear substitution can touch; that is item (ii) of the P2(a') scope (>=3-variable
Gaussian elimination) and is **not** in this PR.

## Exactness

The transform is an **equivalence**, not a relaxation:

* the defining row is dropped and holds by construction at any lifted point;
* `x_e` in `[l_e, u_e]` is an interval constraint on a *bijective* affine image of
  the source, so it transfers **exactly** onto the source's bounds - nothing is
  dropped, nothing is relaxed;
* `#eliminated blocks == #dropped rows` is asserted in the pass.

Numerical guards, all on measured quantities, all counted in
`SubstitutionStats` so a disappointing reduction can be *attributed*:

* pivot below `MIN_PIVOT_ABS = 1e-9` (indistinguishable from a cancellation zero);
* pivot below `PIVOT_REL = 1e-6` times the row's largest resolved coefficient
  (caps the per-step multiplier at 1e6);
* prospective composed `|coeff|`/`|offset|` anywhere in the **merged class**
  exceeding `MAX_ABS_COEFF = 1e6` / `MAX_ABS_OFFSET = 1e9` - chains compose
  multiplicatively, so a per-step cap alone does not bound a chain; the
  union-find carries a per-class running maximum and rejects the union *before*
  applying it.

A rejected candidate leaves its row in the model: the reduction is smaller, the
model is still correct. An empty transferred interval or an out-of-box fixed
value sets `infeasible_detected` and returns the model **unchanged** (declaring
infeasibility is FBBT's job).

Scope of v0: only **continuous, scalar, non-aliased** blocks are eliminated;
integer/binary blocks are never eliminated but may serve as sources (sound
precisely because the eliminated variable is continuous).

## Postsolve

`SubstitutionChain` owns every intermediate model and inverts the sweeps in
reverse. Because chains collapse onto a **single representative**, each sweep's
inversion is one pass with no topological ordering. A point that cannot be
inverted raises rather than returning something plausible.

The solve-path entry (`DISCOPT_PRESOLVE_SUBSTITUTE`, **default OFF**) solves the
reduced model, lifts the incumbent, and **verifies it against the pristine
model** (the #779 guard) before reporting; the reported objective is the one
recomputed on the pristine model. Anything that cannot be inverted **and**
verified is discarded and the original model is re-solved. The entry declines
whenever a caller-supplied object lives in the original variable space
(warm-start point, callbacks, lazy constraints, decomposition structure) or the
model carries complementarity relations (those reference variable indices outside
`ModelRepr`, which this pass renumbers). The reduction's own wall time is charged
against the caller's `time_limit`.

The pristine check uses the **Rust** `ModelRepr.evaluate_point`, not the JAX
`NLPEvaluator`: it is strictly stronger (it checks variable bounds too, and
bounds are exactly what a substitution transfers) and it scales - 0.008 s vs
"had not returned after 119 s" on `watercontamination0202`, measured on the same
point in the same process.

## Verification

### Gates

| gate | result |
|---|---|
| `cargo test -p discopt-core` | **565 + 4 + 1 passed, 0 failed** |
| `cargo fmt --check` | clean |
| `cargo clippy -p discopt-core -p discopt-python --all-targets` | no new findings on the touched files (pre-existing warnings elsewhere unchanged) |
| `ruff check` / `ruff format --check` / `mypy python/discopt/` | clean |
| `pytest -m smoke` | **850 passed, 1 skipped, 2 xpassed** (131 s) |
| `pytest -m slow python/tests/test_adversarial_recent_fixes.py` | **10 passed** (154 s) |

### Regression tests (fail before, pass after)

`crates/discopt-core/src/presolve/substitute.rs` (9 tests) and
`python/tests/test_presolve_substitute.py` (6 tests). Both suites pin the
*fails-before* half explicitly: `legacy_aggregate_cannot_touch_the_chain_model`
/ `test_legacy_aggregate_pass_cannot_reduce_the_chain_model` assert that
`eliminate`+`aggregate`+`factorable_elim` eliminate **0** variables on the model
this pass reduces from 5 to 2, because every defined variable also appears in an
inequality.

Covered: a **chain of three** substitutions (`x0 = 2*x1 + 1`, `x1 = 3*x2 + 2`,
`x2 = 4*x3 + 3`) collapsing onto **one** representative and inverting exactly at
four sampled points; **cycle rejection** (`x0-x1=0`, `x1-x2=0`, `x2-x0=0` -> two
eliminations, `cycles_rejected == 1`, the closing row **kept**); an integer
source with a continuous target; an empty transferred interval reporting
`infeasible_detected` and returning the model unchanged; tiny-pivot rejection;
the fixpoint/`postsolve_chain` round trip; and a mis-sized postsolve point being
rejected.

### Equivalence probe on the target instances

`discopt_benchmarks/scripts/presolve_substitute_probe.py`: samples points inside
the REDUCED box, lifts them, and requires the pristine model to agree with the
reduced model on objective, max constraint violation and max bound violation.
**45 comparisons executed, all passed** on the three targets.

### End to end, three targets, 60 s, flag ON vs OFF

| instance | flag | vars | cons | subst s | status | objective | bound | wall s |
|---|---|---|---|---|---|---|---|---|
| `watercontamination0202` | OFF | 106711 -> 866 | 107209 -> 1364 | 0.076 | time_limit | **-** | 2.73e-12 | 76.41 |
| `watercontamination0202` | **ON** | 106711 -> 866 | 107209 -> 1364 | 0.083 | **feasible** | **3190.45** | **60.33** | 61.25 |
| `gastrans582_cold13` | OFF | 2186 -> 1368 | 3732 -> 2914 | 0.003 | time_limit | - | 0 | 77.70 |
| `gastrans582_cold13` | ON | 2186 -> 1368 | 3732 -> 2914 | 0.004 | time_limit | - | 0 | 90.55 |
| `gastrans040` | OFF | 279 -> 204 | 553 -> 478 | 0.000 | time_limit | - | 0 | 63.77 |
| `gastrans040` | ON | 279 -> 204 | 553 -> 478 | 0.000 | time_limit | - | 0 | 63.46 |

7 oracle comparisons executed, **no violations against the `=opt=` oracle**
(sense read from each model, oracle read from `minlplib.solu` in the script).

`watercontamination0202` moves from **no incumbent in 60 s** to a **verified
incumbent** (checked against the pristine model before reporting) and its dual
bound from 2.7e-12 to **60.33**. The incumbent's quality is poor - primal gap
2449% against the optimum 125.1956 - so this does **not** meet P2's <=10% quality
bar; it removes the "no incumbent" symptom and the primal constructors named in
#844 are still needed. The `gastrans*` pair is unchanged, as expected from a
1.4-1.6x reduction on nonlinear-dominated models.

### CLAUDE.md section 5 differential panel, both arms, 66 vendored instances (20 s each)

`discopt_benchmarks/scripts/substitute_diff_panel.py`, one subprocess per
instance per arm, ON immediately after OFF so both see the same machine state.

**442 comparisons executed. cert-clean: 0 bound crossings, 0 false primals,
0 certification regressions, 0 lost incumbents, every incumbent independently
feasibility-verified against the pristine `ModelRepr`.** A follow-up sweep
widened the bound check from `=opt=` to the `=opt=`-or-`=best=` primal reference
(219 further comparisons): **no bound exceeds its primal reference in either
arm**.

**Net-positive: NO.** Certified 48/66 in both arms; incumbents 54/66 in both
arms; 0 incumbents and 0 certifications gained; median node and wall delta 0.
Only **13 of 66** vendored instances contain anything to substitute at all
(largest `syn05hfsg` 42 -> 17, 2.47x), so the corpus mostly cannot exercise the
pass. Among those 13 the effect is mixed and worth stating plainly:

| instance | nodes OFF -> ON | bound OFF -> ON |
|---|---|---|
| `syn05hfsg` | 185 -> **89** | 837.732 -> 837.732 (same certified optimum) |
| `st_e11` | 27 -> **5** | 189.312 -> 189.312 (same certified optimum) |
| `4stufen` | 31 -> **3** | 21372 -> **100992** (still under the 112657 best dual) |
| `beuster` | 15 -> **3** | 6355 -> **6458** |
| `hda` | 3 -> 3 | -64473 -> **-1.56e8** (a *weaker*, still-sound bound) |

Per CLAUDE.md section 5 this is cert-clean but **not** net-positive on the
in-repo corpus, so the flag **stays default-OFF** in this PR. Graduating it needs
a corpus that contains the structure it targets (large linear-equality-dense
models like `watercontamination0202`), plus a fix for the `hda` bound
regression.

## Falsifications recorded

* The P2(a) entry experiment's structural census concluded that the doubleton /
  singleton class covers "92% of SCIP's reduction". Counting only *plain*
  doubletons predicts ~11.8x on `watercontamination0202`
  (106,711 - 97,655 = 9,056 survivors). The measured 123.2x is an order of
  magnitude better, because resolving each row into *representative space* first
  turns many >=3-variable rows into doubletons once two of their variables have
  already merged into one class. The chain-folding step, not the doubleton
  count, is what produces the reduction.
* `_convex_kernel._incumbent_is_feasible` (the JAX-evaluator form of the #779
  guard) is unusable at this scale: >119 s on `watercontamination0202` against
  0.008 s for the Rust evaluator. Any future large-model incumbent guard should
  use the Rust path.

Contributes to #844.
