### PR TITLE
bench(#844): P2(a'') round-loop entry experiment — KILLED before implementation

### DIFF
--- a/discopt_benchmarks/scripts/presolve_roundloop_census.py
+++ b/discopt_benchmarks/scripts/presolve_roundloop_census.py
@@ -1,0 +1,207 @@
+"""Census: what a substitution<->bound-tightening round loop could reach (#844).
+
+This is the **entry experiment** for coupling `substitute_variables` to the existing
+FBBT (CLAUDE.md §4: run the falsifying experiment on real corpus instances *before*
+writing the implementation).
+
+## The mechanism under test
+
+SCIP's presolve alternates handlers across rounds: propagate bounds, fix variables
+whose domain collapsed, aggregate, propagate again. We already have both halves —
+`substitute_variables` (#844/#888) and `fbbt_fixed_point` — but they never run against
+each other. This measures the ceiling of coupling them.
+
+## What is measured, per instance
+
+1. `substitute(4)` to its own fixpoint — the shipped behaviour.
+2. `fbbt_fixed_point` on the *reduced* model, read to a fixed point.
+3. How many **continuous** blocks that were not already points have collapsed to a
+   point, at four widths: exactly 0, <=1e-12, <=1e-9, <=1e-6.
+
+Step 3 is the only thing a sound round loop may act on. Note the constraint this
+operates under: `presolve/orchestrator.rs:132-147` deliberately does **not** write
+FBBT-tightened bounds back into the returned model, for stated correctness reasons
+(an inactive bound flipped active changes LP duals; a cutoff-derived tightening can
+manufacture a false infeasibility on re-solve). A round loop must therefore use the
+tightened box *only* to detect exact domain collapse and fix, never to install general
+tightened bounds. The width histogram says whether that restriction costs anything.
+
+## Executed-assertion discipline
+
+Prints the number of instances examined and exits non-zero at zero (§6). Every
+instance runs in its own subprocess so one pathological FBBT cannot stall the census,
+and a crash is recorded as data rather than swallowed (§7).
+
+Wall times here are NOT timing claims — the census runs unshielded against other load.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "discopt_benchmarks"))
+
+from utils.corpus import corpus_is_synced, nl_dir  # noqa: E402
+
+SEED = int(os.environ.get("CENSUS_SEED", "20260727"))
+N = int(os.environ.get("CENSUS_N", "300"))
+FBBT_MS = int(os.environ.get("CENSUS_FBBT_MS", "20000"))
+CHILD_TIMEOUT_S = float(os.environ.get("CENSUS_CHILD_TIMEOUT", "180"))
+
+CHILD = r"""
+import json, sys, time
+import numpy as np
+import discopt, discopt.modeling as dm
+from discopt._rust import model_to_repr
+
+path, fbbt_ms, repo = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+# CLAUDE.md §8: assert WHICH code is loaded, and a marker unique to the version.
+assert discopt.__file__.startswith(repo), discopt.__file__
+import discopt._rust as R
+assert hasattr(R, "SubstitutionChain"), "marker absent"
+
+t0 = time.time()
+m = dm.from_nl(path)
+rep = model_to_repr(m, getattr(m, "_builder", None))
+n0 = rep.n_vars
+red, chain = rep.substitute(4)
+t_sub = time.time() - t0
+
+types = red.var_types()
+lo0 = np.array([red.var_lb(i)[0] for i in range(red.n_var_blocks)], dtype=float)
+hi0 = np.array([red.var_ub(i)[0] for i in range(red.n_var_blocks)], dtype=float)
+
+t1 = time.time()
+_out, st = red.presolve(passes=["fbbt_fixed_point"], max_iterations=1, time_limit_ms=fbbt_ms)
+t_fbbt = time.time() - t1
+lo1 = np.asarray(st["bounds_lo"], dtype=float)
+hi1 = np.asarray(st["bounds_hi"], dtype=float)
+assert lo1.shape == lo0.shape, (lo1.shape, lo0.shape)
+
+cont = np.array([t == "continuous" for t in types])
+was_point = (hi0 - lo0) == 0.0
+w = hi1 - lo1
+fin = np.isfinite(w)
+base = cont & ~was_point & fin
+out = {
+    "n_vars": int(n0),
+    "n_after_subst": int(red.n_vars),
+    "blocks": int(red.n_var_blocks),
+    "subst_sweeps": int(chain.n_sweeps),
+    "collapse_exact": int(np.sum(base & (w == 0.0))),
+    "collapse_1e12": int(np.sum(base & (w > 0.0) & (w <= 1e-12))),
+    "collapse_1e9": int(np.sum(base & (w > 0.0) & (w <= 1e-9))),
+    "collapse_1e6": int(np.sum(base & (w > 0.0) & (w <= 1e-6))),
+    "bounds_tightened": int(np.sum(fin & ((lo1 > lo0 + 1e-12) | (hi1 < hi0 - 1e-12)))),
+    "fbbt_terminated_by": str(st["terminated_by"]),
+    "t_subst": t_sub,
+    "t_fbbt": t_fbbt,
+}
+print("JSONRESULT " + json.dumps(out))
+"""
+
+
+def run_one(path: Path) -> dict:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO / "python")
+    try:
+        p = subprocess.run(
+            [sys.executable, "-u", "-c", CHILD, str(path), str(FBBT_MS), str(REPO)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=CHILD_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return {"status": "TIMEOUT"}
+    for line in p.stdout.splitlines():
+        if line.startswith("JSONRESULT "):
+            d = json.loads(line[len("JSONRESULT ") :])
+            d["status"] = "ok"
+            return d
+    return {"status": "CRASH", "stderr": p.stderr.strip()[-400:]}
+
+
+def main() -> int:
+    d = nl_dir()
+    if d is None:
+        print("FATAL: corpus did not resolve", file=sys.stderr)
+        return 2
+    if corpus_is_synced():
+        print(f"WARNING: corpus resolves into a synced folder ({d})", flush=True)
+    names = sorted(p.stem for p in d.glob("*.nl"))
+    print(f"population: {len(names)} .nl instances at {d}", flush=True)
+    sample = random.Random(SEED).sample(names, min(N, len(names)))
+    print(f"sample: {len(sample)} instances, seed {SEED}", flush=True)
+
+    results: dict[str, dict] = {}
+    for i, name in enumerate(sample, 1):
+        t0 = time.time()
+        r = run_one(d / f"{name}.nl")
+        results[name] = r
+        if r["status"] == "ok":
+            print(
+                f"[{i:3d}/{len(sample)}] {name:32s} vars {r['n_vars']:7d}->{r['n_after_subst']:7d} "
+                f"exact={r['collapse_exact']:5d} le1e-9={r['collapse_1e9']:4d} "
+                f"tight={r['bounds_tightened']:6d} {time.time() - t0:6.1f}s",
+                flush=True,
+            )
+        else:
+            print(f"[{i:3d}/{len(sample)}] {name:32s} {r['status']}", flush=True)
+
+    out_path = REPO / "presolve_roundloop_census.json"
+    with open(out_path, "w") as fh:
+        json.dump(results, fh, indent=1)
+    print(f"\nwrote {out_path}")
+
+    ok = [r for r in results.values() if r["status"] == "ok"]
+    print(f"\nINSTANCES EXAMINED: {len(ok)} (of {len(sample)} sampled)")
+    if not ok:
+        print("CENSUS EXECUTED NOTHING")
+        return 2
+
+    def pct(pred) -> tuple[int, float]:
+        n = sum(1 for r in ok if pred(r))
+        return n, 100.0 * n / len(ok)
+
+    subst = lambda r: r["n_after_subst"] < r["n_vars"]  # noqa: E731
+    coll = lambda r: r["collapse_exact"] > 0  # noqa: E731
+
+    for label, pred in (
+        ("substitution reduces (shipped)", subst),
+        ("FBBT tightens any bound", lambda r: r["bounds_tightened"] > 0),
+        (">=1 EXACT new point-collapse", coll),
+        (">=1 collapse within 1e-12", lambda r: r["collapse_exact"] + r["collapse_1e12"] > 0),
+        (">=1 collapse within 1e-9", lambda r: r["collapse_exact"] + r["collapse_1e9"] > 0),
+        (">=1 collapse within 1e-6", lambda r: r["collapse_exact"] + r["collapse_1e6"] > 0),
+        ("CEILING: subst OR exact collapse", lambda r: subst(r) or coll(r)),
+    ):
+        n, p = pct(pred)
+        print(f"  {label:36s} {n:4d}/{len(ok)}  {p:5.1f}%")
+
+    n_ceiling, p_ceiling = pct(lambda r: subst(r) or coll(r))
+    n_sub, p_sub = pct(subst)
+    print(
+        f"\n  collapse but NOT already reduced: "
+        f"{sum(1 for r in ok if coll(r) and not subst(r))} instances "
+        f"(the only ones a round loop can newly touch)"
+    )
+    print(f"  total blocks collapsed exactly: {sum(r['collapse_exact'] for r in ok)}")
+    print(f"  total blocks collapsed >0 and <=1e-6: {sum(r['collapse_1e6'] for r in ok)}")
+    print(
+        f"\nKILL CRITERION: coupled loop must raise 'any reduction' to >= 45.0%. "
+        f"Shipped = {p_sub:.1f}%, CEILING = {p_ceiling:.1f}%."
+    )
+    print("VERDICT:", "PROCEED" if p_ceiling >= 45.0 else "STOP — ceiling below the bar")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/dev/sota-parity-analysis-2026-07-27.md
+++ b/docs/dev/sota-parity-analysis-2026-07-27.md
@@ -245,6 +245,71 @@ stats) for whatever remains after (a) and (b).
 > recovered point against the pristine model. Bound-changing ⇒ full §5 differential
 > panel before any default.
 
+> **P2(a″) entry-experiment result (2026-07-27, iteration 4, Contributes to #844).
+> Coupling substitution to bound tightening: KILLED before implementation.**
+> Harness: `discopt_benchmarks/scripts/presolve_roundloop_census.py` (seed 20260727,
+> 300 instances drawn from the 1,610-instance mirrored corpus, 297 examined).
+>
+> The hypothesis after #888 was that the residual gap (866 vars vs SCIP's 566 on
+> `watercontamination0202`; 30–36 % of the corpus touched vs SCIP's 52.9 %) is caused by
+> `substitute_to_fixpoint` sweeping substitution against *itself* and never against
+> bound propagation — i.e. that a SCIP-style round loop (substitute → tighten → fix on
+> `lo == hi` → substitute) would close it. **Both halves are falsified by measurement.**
+>
+> 1. **The corpus ceiling is 34.7 %, against a pre-registered 45 % bar.** The metric
+>    "fraction of instances with any variable-count reduction" is *order-independent*
+>    for this loop: when substitution eliminates nothing the reduced model **is** the
+>    pristine model (`substitute.rs:393` returns `model.clone()`; asserted empirically
+>    on 6 instances), so FBBT-first and FBBT-second give the same answer. The ceiling is
+>    therefore exactly `{substitution reduces} ∪ {FBBT collapses ≥1 block}` =
+>    **103/297 = 34.7 %**, versus 90/297 = 30.3 % shipped. Only **13 instances**
+>    (`blend480/531`, `kport40`, `mpbp_04/07/09/21/31`, `pooling_adhya4pq`, `ramsey`,
+>    `st_bpv1`, `waterund01/14`) are ones a round loop could newly touch. Giving every
+>    ambiguous case the benefit of the doubt — the 5 instances whose FBBT hit the time
+>    budget while showing zero, plus the 3 that did not complete — the strict upper
+>    bound is **37.0 %**, still 8 points below the bar.
+> 2. **On `watercontamination0202` the loop terminates at 866 vars, unchanged.** After
+>    `substitute(4)` (106,711 → 866 in 0.076 s), `fbbt_fixed_point` on the reduced model
+>    tightens **859 of 866** bounds in 0.178 s and collapses **zero** of them to a
+>    point — zero continuous, zero integer, zero binary. No fixing is available, so the
+>    next substitution round has nothing new and the loop stops. The second kill clause
+>    ("must beat 866") is unreachable for this mechanism.
+>
+> **What the same measurement establishes positively**, and should be read before the
+> next iteration is scoped:
+>
+> * **A fixing tolerance is not needed, and must not be used.** Across the sample,
+>   9,349 blocks collapse at width **exactly 0.0**; only **18** land in `(0, 1e-6]`.
+>   Fixing on exact `lo == hi` therefore costs essentially nothing and *cuts nothing* —
+>   which matters because a tolerant fixing is a feasible-set reduction and a wrong one
+>   is a false certificate, not a rounding error. This also keeps the mechanism inside
+>   the constraint recorded at `orchestrator.rs:132-147`, where writing general
+>   FBBT-tightened bounds back into the returned model was deliberately rejected.
+> * **Order matters for the reduction *magnitude*, opposite to intuition.** On
+>   `watercontamination0202`, FBBT on the *pristine* model collapses **99,821 of
+>   106,711** variables outright (106,704 bounds tightened) — SCIP's 38,396 `FixedVars`
+>   are reproducible by our own FBBT. But it leaves ~6,890 variables, far *worse* than
+>   substitution-first's 866. Substitution subsumes those fixings; that is why the
+>   post-substitution collapse count is zero, and it is evidence the shipped order is
+>   the right one.
+> * **The real gap on that instance is FBBT throughput, not FBBT strength.** That
+>   pristine-model FBBT run took **≈216 s** (measured under load, so an upper estimate)
+>   against SCIP's **0.19 s for its entire 6-round presolve** — three orders of
+>   magnitude. Corpus-wide the pass is cheap (median 0.002 s, p90 0.79 s) but its tail
+>   is not: 7 of 297 instances exhausted a 20 s budget, 5 of them producing no
+>   tightening at all.
+> * **The mechanism is not worthless — it is mis-targeted.** It is worth 118 new
+>   fixings on `gastrans582_cold13` (112 continuous + 6 binary) and 5 on `gastrans040`,
+>   which is precisely the nonlinear-equality-dense family where substitution stalls at
+>   1.60×/1.37×. If it is ever built, `gastrans*` — not `watercontamination0202` —
+>   is the class to gate it on.
+>
+> **Retraction (§11).** The claim published in the #888 review thread — that the
+> 866-vs-566 residual "is" propagation-driven fixing and that coupling FBBT would close
+> it — is withdrawn. Our FBBT finds nothing to fix on the reduced model. Whatever
+> produces SCIP's extra ~300 variables of reduction there, it is not domain collapse
+> reachable from our post-substitution model.
+
 **Evidence it is required:** the G-B table — six instances at "no incumbent in 60 s" vs
 SCIP ≤ 18.7 s, all with `=opt=` oracles. Evidence of tractability: plunging's measured
 17× quality jump on the same class (#880); `ball_mk2_30`'s node loop reaches bound −26.9


### PR DESCRIPTION
## What this is

The **entry experiment** for coupling `substitute_variables` (#888) to the existing
`fbbt_fixed_point` in a SCIP-style presolve round loop, plus the falsification record it
produced. No solver code changed — the experiment killed the mechanism before the
implementation was written, which is what CLAUDE.md §4 asks for.

## Kill criterion (pre-registered, before any measurement was run)

> On a 300-instance census with seed 20260727 over the mirrored corpus (resolved via
> `discopt_benchmarks/utils/corpus.py`, never a hardcoded path), if the coupled loop does
> not raise "any reduction" from ~35.7 % to **at least 45 %**, **or** does not beat
> **866 vars** on `watercontamination0202`, STOP and report the measurement. Do not try a
> third variant.

## Outcome: both clauses fail

Harness: `discopt_benchmarks/scripts/presolve_roundloop_census.py`. 300 sampled, **297
examined** (3 did not complete: `unitcommit_200_100_2_mod_7`, `telecomsp_nor_sun`,
`acopf_case6515rte_qcqp` — recorded as data, not swallowed).

| measurement | value |
|---|---|
| substitution reduces (shipped) | 90/297 = **30.3 %** |
| FBBT tightens any bound | 196/297 = 66.0 % |
| ≥1 exact new point-collapse | 41/297 = 13.8 % |
| **CEILING: subst ∪ exact collapse** | 103/297 = **34.7 %** |
| strict upper bound (every ambiguous + incomplete case counted as a win) | 111/300 = **37.0 %** |
| **bar** | **45.0 %** |

Only **13 instances** are ones a round loop could newly touch: `blend480`, `blend531`,
`kport40`, `mpbp_04/07/09/21/31`, `pooling_adhya4pq`, `ramsey`, `st_bpv1`,
`waterund01`, `waterund14`.

**Clause 2, `watercontamination0202`:** after `substitute(4)` (106,711 → 866 vars,
0.076 s), `fbbt_fixed_point` on the reduced model tightens **859 of 866** bounds in
0.178 s and collapses **zero** to a point — zero continuous, zero integer, zero binary.
No fixing is available, so the next substitution round has nothing new and the loop
terminates at 866.

### Why the ceiling is order-independent

The natural objection is that the loop should run FBBT *first*. It makes no difference to
this metric: when substitution eliminates nothing it returns `model.clone()`
(`substitute.rs:393`), so on exactly the instances that decide the fraction — the ones
substitution does not touch — the reduced model **is** the pristine model and both orders
give the same FBBT answer. Asserted empirically as well as read from source (6 identity
checks, bounds compared block by block).

## What the same run establishes positively

* **A fixing tolerance is unnecessary and must not be used.** 9,349 blocks collapse at
  width **exactly 0.0**; only **18** land in `(0, 1e-6]`. Fixing on exact `lo == hi`
  costs essentially nothing and cuts nothing — which matters, because a tolerant fixing
  is a feasible-set reduction and a wrong one is a false certificate, not a rounding
  error. It also stays inside the constraint at `orchestrator.rs:132-147`, where writing
  general FBBT-tightened bounds back into the returned model was deliberately rejected.
* **Order matters for reduction *magnitude*, opposite to intuition.** FBBT on the
  *pristine* `watercontamination0202` collapses **99,821 of 106,711** variables
  (106,704 bounds tightened) — SCIP's 38,396 `FixedVars` are reproducible by our own
  FBBT — but leaves ~6,890 variables, far worse than substitution-first's 866.
  Substitution subsumes those fixings. The shipped order is the right one.
* **The gap on that instance is FBBT throughput, not FBBT strength.** That pristine run
  took ≈216 s (measured under load, so an upper estimate) against SCIP's 0.19 s for its
  entire 6-round presolve. Corpus-wide the pass is cheap (median 0.002 s, p90 0.79 s) but
  its tail is not: 7 of 297 exhausted a 20 s budget, 5 producing no tightening at all.
* **The mechanism is mis-targeted, not worthless.** It is worth 118 new fixings on
  `gastrans582_cold13` (112 continuous + 6 binary) and 5 on `gastrans040` — precisely the
  nonlinear-equality-dense family where substitution stalls at 1.60×/1.37×. If it is ever
  built, `gastrans*` is the class to gate it on, not `watercontamination0202`.

## Retraction (CLAUDE.md §11)

The claim made in the #888 review thread — that the 866-vs-566 residual **is**
propagation-driven fixing, and that coupling FBBT would close it — is **withdrawn**. Our
FBBT finds nothing to fix on the reduced model. Whatever produces SCIP's extra ~300
variables of reduction there, it is not domain collapse reachable from our
post-substitution model.

## Discrepancy to note

This census puts shipped substitution at **30.3 %** where an independent run reported
**35.7 %**. Same seed and same 1,610-instance population, but a different sampling
implementation draws a different subset; neither number is near the 45 % bar, so the
verdict does not turn on it.

## Verification

* `ruff check` + `ruff format` — clean.
* `pytest -m smoke` — **850 passed, 1 skipped, 2 xpassed, 8000 deselected** (130.7 s).
* No Rust, solver, or presolve code touched — one new measurement script and one plan-doc
  amendment. `cargo test` not required.
* The census prints `INSTANCES EXAMINED` and exits non-zero at zero (§6); each instance
  runs in its own subprocess so one pathological FBBT cannot stall the run, and crashes
  are recorded rather than swallowed (§7).
* Wall times in the census are explicitly **not** timing claims — it ran unshielded.

Contributes to #844
