### PR TITLE
bench(#844): FP entry experiment — the LP pump exists; an upstream gate blocks it

### DIFF
--- a/discopt_benchmarks/scripts/issue844_fp_entry.py
+++ b/discopt_benchmarks/scripts/issue844_fp_entry.py
@@ -1,0 +1,380 @@
+"""#844 entry experiment for the LP-based feasibility pump — BEFORE any implementation.
+
+SCIP's own attribution on our gap instances names the constructor: ``gastrans040``'s
+incumbent comes from ``feaspump`` at node 1, ``gastrans582_cold13``'s from
+``pscostdiving`` at node 12 (``docs/dev/sota-parity-analysis-2026-07-27.md`` §G-G).
+This script answers the three questions that must be settled with a measurement on
+**real corpus instances** before writing a pump (CLAUDE.md §4, and the #727 RLT lesson:
+a mechanism validated on a synthetic proxy can be a no-op on the real class).
+
+Q1  What primal constructors does discopt have TODAY? Answered by reading source, not
+    by this script; the script records the one fact that decides reachability — the
+    scope gate of the engine that already hosts an LP-based objective pump
+    (``_jax/lp_spatial_bb.py``'s ``feasibility_pump``, Fischetti-Glover-Lodi).
+
+Q2  Is there a fractional LP solution to pump at all? A pump alternates between the
+    relaxation and a rounding; if the root McCormick LP never solves, the pump has
+    nothing to read and the gap is upstream of any primal work. Stage ``root``
+    reproduces the engine's own root sequence — ``classify_nonlinear_terms`` →
+    ``flat_variable_bounds`` → root OBBT when the box has an infinite endpoint →
+    ``_relax_bound`` — and reports whether a point came back and how many INTEGER
+    coordinates of it are fractional.
+
+Q3  What is today's primal gap and time-to-first-incumbent, so that "better" is a
+    number? Stage ``solve`` runs the DEFAULT path at two budgets and scores the
+    incumbent against ``minlplib.solu``.
+
+    Time-to-first-incumbent is bracketed by two budgets rather than instrumented with
+    an ``incumbent_callback``: passing one changes which engine runs. Read from source
+    this run — ``solver.py:570`` declines the native spatial kernel outright when
+    ``incumbent_callback is not None``. A callback-instrumented timing would therefore
+    be a measurement of a different code path than the default, which is the class of
+    error CLAUDE.md §8 is about.
+
+Corpus is resolved through ``discopt_benchmarks/utils/corpus.py`` (never a hardcoded
+Dropbox path). The panel is the vendored 50-instance BARON head-to-head list — the set
+the "40 jointly-proved slow-ratio" figure is computed over — plus the three §G-G
+targets.
+
+Executed-assertion discipline (CLAUDE.md §6): every probe increments a counter and the
+script exits non-zero when the count is zero, so a harness that traversed nothing can
+never read as a pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO / "discopt_benchmarks"))
+
+from utils.corpus import nl_dir, solu_path, warn_if_synced  # noqa: E402
+
+TARGETS = ["gastrans040", "gastrans582_cold13", "watercontamination0202"]
+PANEL_LIST = _REPO / "discopt_benchmarks" / "config" / "baron_global50.txt"
+
+# Root probe: the engine budgets its own root OBBT at a third of the remaining time
+# (lp_spatial_bb.py:501). Mirror that shape rather than inventing a schedule.
+ROOT_BUDGET_S = 120.0
+ROOT_CHILD_TIMEOUT_S = 400.0
+
+CHILD_ROOT = r'''
+import json, os, sys, time
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+import warnings; warnings.filterwarnings("ignore")
+
+import numpy as np
+import discopt
+
+# CLAUDE.md section 8: prove WHICH code is loaded before measuring anything with it.
+repo = sys.argv[3]
+assert discopt.__file__.startswith(repo), discopt.__file__
+from discopt._jax import lp_spatial_bb as LSB
+assert LSB.__file__.startswith(repo), LSB.__file__
+# Positive marker unique to the version under test: the LP objective pump this
+# experiment is about is a closure inside the engine, so assert its docstring text.
+_src = open(LSB.__file__).read()
+assert "Objective feasibility pump (Fischetti-Glover-Lodi)" in _src, "pump marker absent"
+assert hasattr(LSB, "_is_in_scope"), "marker absent: _is_in_scope"
+assert hasattr(LSB, "_relax_bound"), "marker absent: _relax_bound"
+
+import discopt.modeling as dm
+from discopt.modeling.core import ObjectiveSense, VarType
+from discopt._jax.model_utils import flat_variable_bounds
+from discopt._jax.term_classifier import classify_nonlinear_terms
+
+inst, budget = sys.argv[1], float(sys.argv[2])
+out = {"instance": inst, "asserts": 0}
+t0 = time.perf_counter()
+m = dm.from_nl(inst)
+out["t_load"] = time.perf_counter() - t0
+
+# SENSE READ PER MODEL. The .nl reader does not normalise to MINIMIZE.
+obj = m._objective
+out["sense"] = "min" if (obj is None or obj.sense == ObjectiveSense.MINIMIZE) else "max"
+n_int = sum(int(v.size) for v in m._variables
+            if v.var_type in (VarType.INTEGER, VarType.BINARY))
+n_all = sum(int(v.size) for v in m._variables)
+out["n_vars"] = n_all
+out["n_int"] = n_int
+out["n_cont"] = n_all - n_int
+out["n_cons"] = len(m._constraints)
+
+# Q1 reachability: does the engine that HOSTS the LP pump accept this model?
+out["in_scope_pure"] = bool(LSB._is_in_scope(m, mixed=False))
+out["in_scope_mixed"] = bool(LSB._is_in_scope(m, mixed=True))
+out["asserts"] += 2
+
+# Q2: the root McCormick LP the pump would read.
+lb, ub = flat_variable_bounds(m)
+lb = np.asarray(lb, dtype=float).copy()
+ub = np.asarray(ub, dtype=float).copy()
+is_int = LSB._integer_mask(m)
+out["inf_box"] = not (bool(np.all(np.isfinite(lb))) and bool(np.all(np.isfinite(ub))))
+
+t0 = time.perf_counter()
+terms = classify_nonlinear_terms(m)
+out["t_classify"] = time.perf_counter() - t0
+
+def probe(lo, hi, tag):
+    """One root-LP attempt. Returns the (bound, x) or None; records timing per tag."""
+    s = time.perf_counter()
+    try:
+        r = LSB._relax_bound(m, terms, lo, hi, deadline=time.perf_counter() + budget)
+    except BaseException as exc:
+        # Do NOT swallow (section 7): record the type and re-raise shape into the record.
+        out["root_error_" + tag] = type(exc).__name__ + ": " + str(exc)[:300]
+        out["t_relax_" + tag] = time.perf_counter() - s
+        return None
+    out["t_relax_" + tag] = time.perf_counter() - s
+    return r
+
+r = probe(lb, ub, "raw")
+out["root_lp_raw_ok"] = r is not None
+used = "raw"
+
+if r is None and out["inf_box"]:
+    # The engine runs root OBBT when the box has an infinite endpoint
+    # (lp_spatial_bb.py:492) precisely so the relaxation gets a valid bound.
+    s = time.perf_counter()
+    try:
+        from discopt._jax.obbt import obbt_tighten_root
+        rr = obbt_tighten_root(m, lb, ub, rounds=5,
+                               deadline=time.perf_counter() + budget / 3.0,
+                               time_limit_per_lp=0.5)
+        out["obbt_infeasible"] = bool(rr.infeasible)
+        if not rr.infeasible:
+            _rlb = np.asarray(rr.lb, dtype=float); _rub = np.asarray(rr.ub, dtype=float)
+            lb = np.maximum(lb, np.where(is_int, np.floor(_rlb + 1e-9), _rlb))
+            ub = np.minimum(ub, np.where(is_int, np.ceil(_rub - 1e-9), _rub))
+    except BaseException as exc:
+        out["obbt_error"] = type(exc).__name__ + ": " + str(exc)[:300]
+    out["t_obbt"] = time.perf_counter() - s
+    out["inf_box_after_obbt"] = not (bool(np.all(np.isfinite(lb)))
+                                     and bool(np.all(np.isfinite(ub))))
+    r = probe(lb, ub, "obbt")
+    used = "obbt"
+
+out["root_lp_ok"] = r is not None
+out["root_lp_path"] = used if r is not None else None
+out["asserts"] += 1
+
+if r is not None:
+    bound, x, _info = r
+    out["root_bound"] = None if bound is None else float(bound)
+    x = np.asarray(x, dtype=float)
+    n = int(lb.size)
+    xi = x[:n][is_int]
+    if xi.size:
+        frac = np.abs(xi - np.round(xi))
+        out["n_frac_int"] = int(np.count_nonzero(frac > 1e-6))
+        out["frac_int_fraction"] = float(np.count_nonzero(frac > 1e-6) / xi.size)
+        out["max_frac"] = float(frac.max())
+        out["asserts"] += 1
+    else:
+        out["n_frac_int"] = 0
+
+print("JSONRESULT " + json.dumps(out))
+'''
+
+CHILD_SOLVE = r"""
+import json, os, sys, time
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+import warnings; warnings.filterwarnings("ignore")
+
+import discopt
+repo = sys.argv[3]
+assert discopt.__file__.startswith(repo), discopt.__file__
+import discopt.modeling as dm
+from discopt.modeling.core import ObjectiveSense
+
+inst, tl = sys.argv[1], float(sys.argv[2])
+m = dm.from_nl(inst)
+obj = m._objective
+sense = "min" if (obj is None or obj.sense == ObjectiveSense.MINIMIZE) else "max"
+t0 = time.perf_counter()
+r = m.solve(time_limit=tl)
+wall = time.perf_counter() - t0
+print("JSONRESULT " + json.dumps({
+    "instance": inst, "sense": sense, "time_limit": tl, "wall": wall,
+    "status": str(r.status),
+    "objective": None if r.objective is None else float(r.objective),
+    "bound": None if r.bound is None else float(r.bound),
+    "gap_certified": bool(getattr(r, "gap_certified", False)),
+}))
+"""
+
+
+CHILD_ENGINE = r"""
+import json, os, sys, time
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+import warnings; warnings.filterwarnings("ignore")
+
+import discopt
+repo = sys.argv[3]
+assert discopt.__file__.startswith(repo), discopt.__file__
+import discopt.modeling as dm
+from discopt.modeling.core import ObjectiveSense
+from discopt._jax import lp_spatial_bb as LSB
+_src = open(LSB.__file__).read()
+assert "Objective feasibility pump (Fischetti-Glover-Lodi)" in _src, "pump marker absent"
+
+inst, tl = sys.argv[1], float(sys.argv[2])
+m = dm.from_nl(inst)
+obj = m._objective
+sense = "min" if (obj is None or obj.sense == ObjectiveSense.MINIMIZE) else "max"
+
+# Exactly the invocation the #844 fallback makes (modeling/core.py:4320-4326), except
+# mixed=True -- the one condition that currently declines these models by default.
+t0 = time.perf_counter()
+r = LSB.solve_lp_spatial_bb(m, time_limit=tl, use_obbt=False,
+                            require_incremental=True, mixed=True)
+wall = time.perf_counter() - t0
+out = {"instance": inst, "sense": sense, "time_limit": tl, "wall": wall}
+if r is None:
+    # require_incremental declined: the incremental McCormick structure did not build,
+    # which is ALSO the condition under which the pump itself is skipped (line 815).
+    out["engine_declined"] = True
+else:
+    out["engine_declined"] = False
+    out["status"] = str(r.status)
+    out["objective"] = None if r.objective is None else float(r.objective)
+    out["bound"] = None if r.bound is None else float(r.bound)
+    out["node_count"] = int(r.node_count)
+print("JSONRESULT " + json.dumps(out))
+"""
+
+
+def read_oracle() -> dict[str, tuple[str, float | None]]:
+    """``{name: (marker, value)}`` parsed from ``minlplib.solu`` IN THIS RUN."""
+    p = solu_path()
+    if p is None:
+        raise SystemExit("FATAL: no minlplib.solu under the resolved corpus root")
+    table: dict[str, tuple[str, float | None]] = {}
+    with open(p) as fh:
+        for line in fh:
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            marker, name = parts[0], parts[1]
+            val = float(parts[2]) if len(parts) > 2 else None
+            table[name] = (marker, val)
+    return table
+
+
+def panel() -> list[str]:
+    names = [ln.strip() for ln in PANEL_LIST.read_text().splitlines() if ln.strip()]
+    for t in TARGETS:
+        if t not in names:
+            names.append(t)
+    return names
+
+
+def run_child(src: str, inst_path: Path, arg: float, timeout: float) -> dict:
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        [sys.executable, "-u", "-c", src, str(inst_path), str(arg), str(_REPO)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    for line in proc.stdout.splitlines():
+        if line.startswith("JSONRESULT "):
+            return json.loads(line[len("JSONRESULT ") :])
+    return {
+        "child_failed": True,
+        "returncode": proc.returncode,
+        "stderr": proc.stderr[-800:],
+        "wall": time.perf_counter() - t0,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--stage", choices=("root", "solve", "engine"), required=True)
+    ap.add_argument("--budget", type=float, default=ROOT_BUDGET_S)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--only", default="", help="comma-separated instance subset")
+    args = ap.parse_args()
+
+    warn_if_synced("issue844_fp_entry")
+    nld = nl_dir()
+    if nld is None:
+        raise SystemExit("FATAL: no corpus (utils.corpus.nl_dir() is None)")
+
+    names = panel()
+    if args.only:
+        want = {s.strip() for s in args.only.split(",") if s.strip()}
+        names = [n for n in names if n in want]
+
+    oracle = read_oracle()
+    rows: list[dict] = []
+    executed = 0
+    missing: list[str] = []
+
+    for i, name in enumerate(names, 1):
+        p = nld / f"{name}.nl"
+        if not p.is_file():
+            missing.append(name)
+            print(f"[{i}/{len(names)}] {name}: NO .nl IN CORPUS", flush=True)
+            continue
+        src = {"root": CHILD_ROOT, "solve": CHILD_SOLVE, "engine": CHILD_ENGINE}[args.stage]
+        tmo = ROOT_CHILD_TIMEOUT_S if args.stage == "root" else args.budget * 3 + 240
+        try:
+            rec = run_child(src, p, args.budget, tmo)
+        except subprocess.TimeoutExpired:
+            rec = {"child_timeout": True}
+        rec["instance"] = name
+        mk, val = oracle.get(name, ("", None))
+        rec["oracle_marker"] = mk
+        rec["oracle"] = val
+        executed += int(rec.get("asserts", 0)) or (0 if rec.get("child_failed") else 1)
+        rows.append(rec)
+        if args.stage == "root":
+            print(
+                f"[{i}/{len(names)}] {name}: vars={rec.get('n_vars')} int={rec.get('n_int')} "
+                f"sense={rec.get('sense')} scope(pure/mixed)="
+                f"{rec.get('in_scope_pure')}/{rec.get('in_scope_mixed')} "
+                f"rootLP={rec.get('root_lp_ok')} via={rec.get('root_lp_path')} "
+                f"frac={rec.get('n_frac_int')}/{rec.get('n_int')} "
+                f"t_relax={rec.get('t_relax_raw')}",
+                flush=True,
+            )
+        elif args.stage == "engine":
+            print(
+                f"[{i}/{len(names)}] {name}: declined={rec.get('engine_declined')} "
+                f"status={rec.get('status')} obj={rec.get('objective')} "
+                f"bound={rec.get('bound')} nodes={rec.get('node_count')} "
+                f"wall={rec.get('wall')} oracle={val}",
+                flush=True,
+            )
+        else:
+            print(
+                f"[{i}/{len(names)}] {name}: status={rec.get('status')} "
+                f"obj={rec.get('objective')} bound={rec.get('bound')} "
+                f"wall={rec.get('wall')} oracle={val}",
+                flush=True,
+            )
+
+    Path(args.out).write_text(
+        json.dumps({"stage": args.stage, "budget": args.budget, "rows": rows}, indent=1)
+    )
+
+    print(f"\nINSTANCES EXAMINED: {len(rows)}  (missing .nl: {len(missing)})")
+    print(f"EXECUTED PROBES: {executed}")
+    if executed == 0:
+        print("FATAL: zero probes executed — this harness measured nothing.")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/dev/sota-parity-analysis-2026-07-27.md
+++ b/docs/dev/sota-parity-analysis-2026-07-27.md
@@ -202,6 +202,83 @@ variable bound by 1.60e-6 on the pristine model, bit-identical in both arms, whi
 panel's `FEAS_TOL = 1e-5` (`substitute_diff_panel.py:33`) hides — that tolerance is looser
 than the repo's abs=1e-6 and should be tightened.
 
+**G-G.2. ENTRY EXPERIMENT for the LP feasibility pump (2026-07-27) — the pump already
+exists; what blocks it is upstream of any pump.** Run before writing any code, per §4 and
+the #727 RLT lesson. Harness `discopt_benchmarks/scripts/issue844_fp_entry.py`, corpus
+resolved through `utils/corpus.py` (mirror, not synced), panel = vendored
+`config/baron_global50.txt` (50) + the three §G-G targets = **53 instances**, sense read
+per model (0 MAXIMIZE in this panel). 207 root probes + 106 solve probes + 35 engine
+probes executed; harness exits non-zero at zero.
+
+*Q1 — what exists.* Three FP-shaped constructors, read from source:
+
+| where | kind | reachable on the default nonconvex path? |
+|---|---|---|
+| `_jax/primal_heuristics.py:341` `feasibility_pump` | round → **pin** integers → re-solve continuous NLP, ≤5 rounds, random ±1 perturbation | **yes** — root, `solver.py:9926` and `:12903`. Not a projection pump: it never changes the relaxation objective, so on an all-integer model it degenerates to round-and-check (#844's own wording, confirmed) |
+| `solvers/oa.py:1920` `_run_feasibility_pump` | MindtPy-style L1/L2 projection, MILP master + NLP projection + no-good cuts | no — OA/GDP route (convex MINLP, highspy) |
+| `_jax/lp_spatial_bb.py:802` `feasibility_pump` (closure) | **the real thing**: Fischetti-Glover-Lodi objective pump over the McCormick LP, cycle-breaking perturbation, exact verification; called at the root (`:904`) and at every node (`:992`) | **no, on the target class** — see Q2 |
+
+So #844's ask ("LP-based feasibility pump … over a tightened McCormick relaxation") is
+**built**. The task is reachability, not construction.
+
+*Q2 — is there a fractional LP point to pump?* Yes, broadly. Root McCormick LP (engine's
+own sequence: `classify_nonlinear_terms` → `flat_variable_bounds` → root OBBT when the box
+has an infinite endpoint → `_relax_bound`) solves on **50/53** (45 raw, 5 after OBBT;
+median 0.25 s, p90 0.28 s, max 56.5 s), fails on 3 (`fac2`, `hda`, `st_miqp3`). Of the 50,
+**35 carry ≥1 fractional integer coordinate** and 15 come back already integral. So the
+answer is *not* "upstream of the LP" — except on two of the five instances that matter:
+
+* `watercontamination0202`: **0 of 7** integer coordinates fractional at the root
+  (max_frac 0.0). There is nothing to pump. FP is definitively not its mechanism.
+* `hda`: no root LP at all.
+* `gastrans040` **12/48** fractional (root LP 0.27 s), `gastrans582_cold13` **57/250**
+  (30.9 s), `casctanks` **33/40** — these three are genuinely pumpable.
+
+*Q3 — today's primal, so "better" is a number.* Default path, subprocess-isolated, two
+budgets to bracket time-to-first-incumbent (an `incumbent_callback` was **not** used: it
+disables the native spatial kernel outright at `solver.py:570`, so a callback-instrumented
+timing measures a different code path):
+
+| budget | incumbent | optimal | scored vs `=opt=` | false primals | mean gap | worst gap |
+|---|---|---|---|---|---|---|
+| 10 s | 46/53 | 44 | 45 | **0** | 0.0083 | 0.3735 |
+| 60 s | 48/53 | 47 | 47 | **0** | **0.0000** | **0.0000** |
+
+First incumbent ≤10 s on 46, in (10,60] on 2 (`clay0303hfsg`, `tls2`), **never** on 5:
+`casctanks`, `gastrans040`, `gastrans582_cold13`, `hda`, `watercontamination0202`. Where
+discopt produces an incumbent at all it is already at the reference optimum — the primal
+gap is not a quality problem on this panel, it is a **binary existence problem on 5
+instances**.
+
+*The finding that decides the next step.* The FGL pump's first statement is
+`if not _inc.ok: return None` (`lp_spatial_bb.py:815`) — it is skipped entirely when
+`IncrementalMcCormickLP` does not build. Measured over the 35 pumpable instances, invoking
+the host engine exactly as the #844 fallback does (`modeling/core.py:4320`:
+`use_obbt=False, require_incremental=True`) but with `mixed=True`:
+
+* **27 of 35 declined** — including all three pumpable no-incumbent targets
+  (`gastrans040`, `gastrans582_cold13`, `casctanks`).
+* 8 ran; all 8 found an incumbent, 0 false primals.
+
+The cause is **not** the budget, **not** the infinite box, and **not** the #860 scope gate.
+Building `IncrementalMcCormickLP` directly and reading `.ok` with debug logging on:
+`gastrans040` → `ValueError: column-count mismatch` in 0.07 s; `casctanks` / `tls2` /
+`tanksize` / `gastrans582_cold13` → `ValueError: bounds mismatch` in ≤0.36 s. These are the
+patcher's **own `_validate` self-check** (`incremental_mccormick.py:759,765`): the
+closed-form per-node patch does not reproduce the full build on this class, so the
+structure declines — and with it the cuts and the pump.
+
+Confirmed end-to-end: with `require_incremental=False` the engine runs the cold path (pump
+a no-op) and still returns nothing — `gastrans040` 19 nodes / 21 s / no incumbent,
+`casctanks` 3 nodes / bound 5.65 / no incumbent, `gastrans582_cold13` declines outright.
+
+**Consequence: do not implement a second feasibility pump.** A new pump would sit behind
+the identical `_inc.ok` gate and be a no-op on exactly the instances it was written for —
+the #727 RLT failure mode, predicted in advance this time. The measured blocker is the
+incremental McCormick patch/validate path, which is upstream of every LP-reading primal
+constructor (pump, diving, and the root cut rounds alike). Scoping decision required before
+any build.
+
 **G-F. `no_bound` family (8/62) — relaxation strength on family D** (tls2/tspn-class,
 `baron-gap-plan.md` G5): the dual bound never moves, so no budget helps. Distinct from
 G-B (those have vacuous-but-moving bounds); untouched by everything shipped this month.


### PR DESCRIPTION
## What this is

The **entry experiment** for #844's LP-based feasibility pump, run before writing any
implementation (CLAUDE.md §4, and the #727 RLT lesson: a mechanism validated on a
synthetic proxy can be a no-op on the real class). No solver code changes.

## Kill criterion, stated before the run

> If the entry experiment shows discopt already reaches a first incumbent at comparable
> quality on those instances, **or** has no usable fractional LP point to pump, STOP and
> report — do not implement FP on the assumption it must help.

**Outcome: stopped, on a third ground the criterion did not anticipate.** Clause 1 does
not fire for the target class (5 instances still get no incumbent at 60 s); clause 2 fires
on 2 of the 5 but not the other 3. What stops the work is that the pump #844 asks for is
already built and is blocked by a gate upstream of it.

## Method

`discopt_benchmarks/scripts/issue844_fp_entry.py`. Corpus resolved through
`discopt_benchmarks/utils/corpus.py` (mirror at `~/projects/discopt-minlp-benchmark`, not
synced, 1610 `.nl`) — no hardcoded Dropbox path. Panel = vendored
`config/baron_global50.txt` (50) + the three §G-G targets = **53 instances**. Objective
sense read per model (0 MAXIMIZE here). Every child asserts `discopt.__file__` under the
repo plus a positive marker unique to the version under test. Three stages, **348 probes
executed**; the harness prints the count and exits non-zero at zero.

## Q1 — what discopt already has (read from source)

| where | kind | on the default nonconvex path? |
|---|---|---|
| `_jax/primal_heuristics.py:341` | round → pin integers → re-solve continuous NLP, ≤5 rounds, random ±1 perturbation | **yes** (`solver.py:9926`, `:12903`). Not a projection pump — never changes the relaxation objective, so it degenerates to round-and-check on an all-integer model |
| `solvers/oa.py:1920` | MindtPy-style L1/L2 projection, MILP master + NLP projection + no-good cuts | no — OA/GDP route |
| `_jax/lp_spatial_bb.py:802` | **Fischetti-Glover-Lodi objective pump over the McCormick LP**, cycle-breaking, exact verification, root (`:904`) + every node (`:992`) | **no, on the target class** |

#844's ask — "LP-based feasibility pump … over a tightened McCormick relaxation" — is
built. This is a reachability problem, not a construction problem.

## Q2 — is there a fractional LP point to pump?

Root McCormick LP via the engine's own sequence. Solves on **50/53** (45 raw, 5 after root
OBBT; median 0.25 s, p90 0.28 s, max 56.5 s); fails on `fac2`, `hda`, `st_miqp3`. Of the
50, **35 carry ≥1 fractional integer coordinate**; 15 come back already integral.

Per target: `gastrans040` **12/48** fractional (0.27 s) · `gastrans582_cold13` **57/250**
(30.9 s) · `casctanks` **33/40** · `watercontamination0202` **0/7 — nothing to pump** ·
`hda` — no root LP at all.

## Q3 — today's primal, so "better" is a number

Default path, subprocess-isolated, two budgets bracketing time-to-first-incumbent. An
`incumbent_callback` was deliberately **not** used: it disables the native spatial kernel
outright (`solver.py:570`), so callback-instrumented timing measures a different code path.

| budget | incumbent | optimal | scored vs `=opt=` | false primals | mean gap | worst gap |
|---|---|---|---|---|---|---|
| 10 s | 46/53 | 44 | 45 | **0** | 0.0083 | 0.3735 |
| 60 s | 48/53 | 47 | 47 | **0** | **0.0000** | **0.0000** |

First incumbent ≤10 s on 46, in (10, 60] on 2 (`clay0303hfsg`, `tls2`), **never** on 5:
`casctanks`, `gastrans040`, `gastrans582_cold13`, `hda`, `watercontamination0202`. Where
discopt finds an incumbent at all it is already at the reference optimum — the panel has no
primal *quality* problem, it has a binary *existence* problem on 5 instances.

## The finding that decides the next step

The FGL pump's first statement is `if not _inc.ok: return None` (`lp_spatial_bb.py:815`) —
it is skipped whenever `IncrementalMcCormickLP` fails to build. Invoking the host engine
exactly as the #844 fallback does (`modeling/core.py:4320`, `use_obbt=False,
require_incremental=True`) but with `mixed=True`, over the 35 pumpable instances:

- **27 of 35 declined**, including all three pumpable no-incumbent targets.
- 8 ran; all 8 produced an incumbent, 0 false primals.

Cause is **not** budget, **not** the infinite box, **not** the #860 scope gate. Building
`IncrementalMcCormickLP` directly with debug logging: `gastrans040` →
`ValueError: column-count mismatch` (0.07 s); `casctanks` / `tls2` / `tanksize` /
`gastrans582_cold13` → `ValueError: bounds mismatch` (≤0.36 s). Both are the patcher's own
`_validate` self-check (`incremental_mccormick.py:759,765`): the closed-form per-node patch
does not reproduce the full build on this class, so the structure declines — taking the
cuts and the pump with it.

Confirmed end-to-end with `require_incremental=False` (engine runs, pump a no-op):
`gastrans040` 19 nodes / 21 s / no incumbent; `casctanks` 3 nodes / bound 5.65 / no
incumbent; `gastrans582_cold13` declines outright.

**A second pump would sit behind the identical gate and be a no-op on exactly the instances
it was written for.** The measured blocker is upstream of every LP-reading primal
constructor — pump, diving, and root cut rounds alike.

## Verification

- `ruff check` + `ruff format --check` clean before commit.
- `pytest -m smoke` → **850 passed, 1 skipped, 8000 deselected, 2 xpassed** in 108.80 s.
- No solver or Rust code touched; this PR is a harness plus the measurement record
  (§G-G.2 of the parity analysis).

Contributes to #844
