### PR TITLE
feat(diag): #861 store the incremental-McCormick decline reason + admission sweep meter

### DIFF
--- a/discopt_benchmarks/results/issue861_admission_baseline_20260728.json
+++ b/discopt_benchmarks/results/issue861_admission_baseline_20260728.json
@@ -1,0 +1,778 @@
+{
+ "admitted": 31,
+ "declined": 50,
+ "instances": {
+  "alan": {
+   "n": 8,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.011
+  },
+  "carton7": {
+   "n": 328,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 528,
+   "n_bilinear": 200,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.15
+  },
+  "chance": {
+   "n": 4,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "dispatch": {
+   "n": 4,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 10,
+   "n_bilinear": 3,
+   "n_monomial": 3,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "ex1221": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1222": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1223a": {
+   "n": 7,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 13,
+   "n_bilinear": 0,
+   "n_monomial": 3,
+   "n_affine_square": 3,
+   "secs": 0.004
+  },
+  "ex1225": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "ex1226": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "ex1233": {
+   "n": 52,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.008
+  },
+  "ex1252": {
+   "n": 39,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.006
+  },
+  "ex1252a": {
+   "n": 24,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.005
+  },
+  "ex1263": {
+   "n": 92,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 108,
+   "n_bilinear": 16,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.013
+  },
+  "ex1264": {
+   "n": 88,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 104,
+   "n_bilinear": 16,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.013
+  },
+  "ex1265": {
+   "n": 130,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 155,
+   "n_bilinear": 25,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.027
+  },
+  "ex1266": {
+   "n": 180,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 216,
+   "n_bilinear": 36,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.027
+  },
+  "ex8_1_1": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex8_5_4": {
+   "n": 5,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: monomial x_2^3: odd power on a root box spanning zero (the envelope switches between the 4-row secant/tangent hull and the 2-facet S-hull, which the fixed row pattern cannot express)",
+   "bucket": "odd power on straddling root",
+   "secs": 0.002
+  },
+  "fuel": {
+   "n": 15,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 21,
+   "n_bilinear": 0,
+   "n_monomial": 6,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "gbd": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 0,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "gear": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "gear2": {
+   "n": 28,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.002
+  },
+  "gear3": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "gear4": {
+   "n": 6,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "hda": {
+   "n": 722,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.092
+  },
+  "kall_circles_c8a": {
+   "n": 22,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.013
+  },
+  "mathopt3": {
+   "n": 6,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.003
+  },
+  "mathopt5_2": {
+   "n": 1,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.002
+  },
+  "meanvar": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 36,
+   "n_bilinear": 21,
+   "n_monomial": 7,
+   "n_affine_square": 0,
+   "secs": 0.012
+  },
+  "meanvarx": {
+   "n": 35,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 63,
+   "n_bilinear": 21,
+   "n_monomial": 7,
+   "n_affine_square": 0,
+   "secs": 0.014
+  },
+  "nvs01": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "nvs02": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 16,
+   "n_bilinear": 7,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "nvs03": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 0,
+   "n_monomial": 1,
+   "n_affine_square": 2,
+   "secs": 0.002
+  },
+  "nvs04": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "nvs05": {
+   "n": 8,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.006
+  },
+  "nvs06": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.002
+  },
+  "nvs07": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "nvs08": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "nvs10": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 1,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "nvs11": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 9,
+   "n_bilinear": 3,
+   "n_monomial": 3,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "nvs12": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 14,
+   "n_bilinear": 6,
+   "n_monomial": 4,
+   "n_affine_square": 0,
+   "secs": 0.005
+  },
+  "nvs13": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 20,
+   "n_bilinear": 10,
+   "n_monomial": 5,
+   "n_affine_square": 0,
+   "secs": 0.007
+  },
+  "nvs14": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 16,
+   "n_bilinear": 7,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "nvs15": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 8,
+   "n_bilinear": 2,
+   "n_monomial": 3,
+   "n_affine_square": 0,
+   "secs": 0.003
+  },
+  "nvs16": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "nvs17": {
+   "n": 7,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 35,
+   "n_bilinear": 21,
+   "n_monomial": 7,
+   "n_affine_square": 0,
+   "secs": 0.016
+  },
+  "nvs18": {
+   "n": 6,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 27,
+   "n_bilinear": 15,
+   "n_monomial": 6,
+   "n_affine_square": 0,
+   "secs": 0.011
+  },
+  "nvs19": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 44,
+   "n_bilinear": 28,
+   "n_monomial": 8,
+   "n_affine_square": 0,
+   "secs": 0.021
+  },
+  "nvs20": {
+   "n": 16,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.014
+  },
+  "nvs21": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "nvs22": {
+   "n": 8,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.005
+  },
+  "nvs23": {
+   "n": 9,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 54,
+   "n_bilinear": 36,
+   "n_monomial": 9,
+   "n_affine_square": 0,
+   "secs": 0.04
+  },
+  "nvs24": {
+   "n": 10,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 65,
+   "n_bilinear": 45,
+   "n_monomial": 10,
+   "n_affine_square": 0,
+   "secs": 0.039
+  },
+  "prob02": {
+   "n": 6,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bilinear (0,1) -> 5 rows, expected 4",
+   "bucket": "envelope row count != 4",
+   "secs": 0.001
+  },
+  "prob03": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bilinear (0,1) -> 5 rows, expected 4",
+   "bucket": "envelope row count != 4",
+   "secs": 0.0
+  },
+  "prob06": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 4,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "prob10": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 0,
+   "n_monomial": 0,
+   "n_affine_square": 2,
+   "secs": 0.003
+  },
+  "st_e01": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bilinear (0,1) -> 5 rows, expected 4",
+   "bucket": "envelope row count != 4",
+   "secs": 0.0
+  },
+  "st_e02": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e03": {
+   "n": 10,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "st_e04": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.001
+  },
+  "st_e05": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e06": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e07": {
+   "n": 10,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e08": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bilinear (0,1) -> 5 rows, expected 4",
+   "bucket": "envelope row count != 4",
+   "secs": 0.0
+  },
+  "st_e09": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bilinear (0,1) -> 5 rows, expected 4",
+   "bucket": "envelope row count != 4",
+   "secs": 0.0
+  },
+  "st_e11": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bilinear (0,1) -> 6 rows, expected 4",
+   "bucket": "envelope row count != 4",
+   "secs": 0.0
+  },
+  "st_e13": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 3,
+   "n_bilinear": 0,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "st_e15": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e17": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "st_e18": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 4,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "st_e27": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 6,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "st_e31": {
+   "n": 112,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 120,
+   "n_bilinear": 6,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.014
+  },
+  "st_e35": {
+   "n": 32,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.009
+  },
+  "st_e36": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.964
+  },
+  "st_e38": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "st_e40": {
+   "n": 4,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.004
+  },
+  "st_ph10": {
+   "n": 2,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 4,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "syn05m": {
+   "n": 20,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "trig": {
+   "n": 1,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "util": {
+   "n": 145,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.008
+  }
+ }
+}

--- a/discopt_benchmarks/scripts/incremental_admission_sweep.py
+++ b/discopt_benchmarks/scripts/incremental_admission_sweep.py
@@ -1,0 +1,190 @@
+"""Incremental-McCormick admission sweep (issue #861).
+
+Builds :class:`IncrementalMcCormickLP` over the in-repo MINLPLib corpus exactly
+as the default relaxer does and reports, per instance, whether the structure was
+ADMITTED (``ok=True`` -> the ~30x-faster patched node path serves it) or DECLINED
+(``ok=False`` -> every node falls back to the trusted cold build), with the
+stored ``decline_reason``.
+
+This is the progress meter for #861: every task's PR quotes a before/after run.
+The admitted count must be monotone non-decreasing, and an instance that was
+admitted before must never become declined (see the plan doc's §0.5 — such a flip
+is either a bug in the change or a real patch/cold divergence the old synthetic
+validation boxes never exercised; investigate, never paper over).
+
+Declining is always SOUND — the caller falls back to the per-node cold build — so
+this script measures *coverage and speed*, never correctness. Bound-neutrality is
+gated separately by ``IncrementalMcCormickLP._validate`` and by the panels in §4
+of ``docs/dev/issue-861-incremental-admission-plan.md``.
+
+Usage::
+
+    python -u discopt_benchmarks/scripts/incremental_admission_sweep.py \\
+        --out discopt_benchmarks/results/issue861_admission_<stamp>.json
+    # compare against a previous run (fails on any admitted->declined flip):
+    python -u ... --out new.json --baseline old.json
+
+Exits non-zero when no instance was measured (a sweep that measures nothing must
+never read as a pass — CLAUDE.md rule 6), when the corpus directory is missing,
+or when ``--baseline`` shows a regression.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+import time
+from collections import Counter
+
+import numpy as np
+
+# The in-repo MINLPLib corpus (81 instances) the issue's sweep is defined over.
+DEFAULT_CORPUS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "python",
+    "tests",
+    "data",
+    "minlplib",
+)
+
+
+def bucket(reason: str | None) -> str:
+    """Coarse decline bucket, matching the issue's triage table."""
+    if not reason:
+        return "admitted"
+    for needle, label in (
+        ("bounds mismatch", "bounds mismatch"),
+        ("column-count mismatch", "column-count mismatch"),
+        ("rows, expected 4", "envelope row count != 4"),
+        ("no valid bound", "no valid bound / no rows"),
+        ("odd power on a root box spanning zero", "odd power on straddling root"),
+        ("row-set mismatch", "row-set mismatch"),
+        ("objective offset is box-dependent", "box-dependent objective offset"),
+        ("exceeds budget", "structure too large"),
+        ("deadline", "deadline spent"),
+    ):
+        if needle in reason:
+            return label
+    return reason.split(":")[0].strip() or "other"
+
+
+def measure(path: str) -> dict:
+    """Build the structure for one instance; return its result row."""
+    from discopt._jax.incremental_mccormick import IncrementalMcCormickLP
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+    from discopt.modeling.core import from_nl
+
+    t0 = time.perf_counter()
+    row: dict = {}
+    # NOTE: no blanket try/except around the measurement itself — an instrument
+    # that swallows exceptions turns "this path is broken" into "this path is
+    # fine" (CLAUDE.md rule 7). Only the *model load* is guarded, and it records
+    # the failure explicitly rather than silently counting as a decline.
+    try:
+        model = from_nl(path)
+    except Exception as exc:  # corpus/parse problem — report, don't hide
+        return {
+            "admitted": False,
+            "load_error": f"{type(exc).__name__}: {exc}",
+            "reason": None,
+            "bucket": "load error",
+            "secs": round(time.perf_counter() - t0, 3),
+        }
+    lb = np.array([float(np.min(v.lb)) for v in model._variables])
+    ub = np.array([float(np.max(v.ub)) for v in model._variables])
+    row["n"] = int(lb.size)
+    row["finite_root"] = bool(np.all(np.isfinite(lb)) and np.all(np.isfinite(ub)))
+    terms = classify_nonlinear_terms(model)
+    # deadline=None: measure structural admission, never a budget artifact (#844).
+    inc = IncrementalMcCormickLP(model, terms, deadline=None)
+    row["admitted"] = bool(inc.ok)
+    row["reason"] = inc.decline_reason
+    row["bucket"] = bucket(inc.decline_reason)
+    if inc.ok:
+        row["ncol"] = int(inc.ncol)
+        row["n_bilinear"] = len(inc.bilinear)
+        row["n_monomial"] = len(inc.monomial)
+        row["n_affine_square"] = len(inc.affine_square)
+    row["secs"] = round(time.perf_counter() - t0, 3)
+    return row
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--corpus", default=DEFAULT_CORPUS, help="directory of .nl instances")
+    ap.add_argument("--out", default=None, help="write results JSON here")
+    ap.add_argument("--baseline", default=None, help="compare against a previous run's JSON")
+    ap.add_argument("--only", default=None, help="comma-separated instance names (debug)")
+    args = ap.parse_args(argv)
+
+    paths = sorted(glob.glob(os.path.join(args.corpus, "*.nl")))
+    if args.only:
+        want = {s.strip() for s in args.only.split(",") if s.strip()}
+        paths = [p for p in paths if os.path.basename(p)[:-3] in want]
+    if not paths:
+        print(f"ERROR: no .nl instances under {args.corpus}", file=sys.stderr)
+        return 2
+
+    results: dict[str, dict] = {}
+    print(f"sweeping {len(paths)} instances from {args.corpus}", flush=True)
+    for k, path in enumerate(paths, 1):
+        name = os.path.basename(path)[:-3]
+        row = measure(path)
+        results[name] = row
+        tag = "ADMIT  " if row["admitted"] else "DECLINE"
+        note = "" if row["admitted"] else f"  {row['bucket']}"
+        print(f"[{k:3d}/{len(paths)}] {name:24s} {tag} ({row['secs']:6.2f}s){note}", flush=True)
+
+    admitted = sum(1 for r in results.values() if r["admitted"])
+    declined = len(results) - admitted
+    print(f"\n=== admitted {admitted}/{len(results)}   declined {declined} ===")
+    hist = Counter(r["bucket"] for r in results.values() if not r["admitted"])
+    for label, count in hist.most_common():
+        names = sorted(n for n, r in results.items() if not r["admitted"] and r["bucket"] == label)
+        print(f"  {count:3d}  {label:32s} {', '.join(names[:8])}{' …' if len(names) > 8 else ''}")
+
+    if args.out:
+        os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+        with open(args.out, "w") as fh:
+            json.dump(
+                {"admitted": admitted, "declined": declined, "instances": results}, fh, indent=1
+            )
+        print(f"\nwrote {args.out}")
+
+    status = 0
+    if args.baseline:
+        with open(args.baseline) as fh:
+            base = json.load(fh)
+        base_inst = base.get("instances", base)
+        regressed = sorted(
+            n
+            for n, r in base_inst.items()
+            if r.get("admitted") and not results.get(n, {}).get("admitted", False)
+        )
+        gained = sorted(
+            n
+            for n, r in results.items()
+            if r["admitted"] and not base_inst.get(n, {}).get("admitted", False)
+        )
+        print(f"\nvs baseline {args.baseline}: {base.get('admitted', '?')} -> {admitted} admitted")
+        if gained:
+            print(f"  NEWLY ADMITTED ({len(gained)}): {', '.join(gained)}")
+        if regressed:
+            print(f"  REGRESSED ({len(regressed)}): {', '.join(regressed)}")
+            for n in regressed:
+                print(f"    {n}: {results.get(n, {}).get('reason')}")
+            status = 1
+
+    # Executed-measurement count: a sweep that measured nothing must not read as
+    # a pass (CLAUDE.md rule 6).
+    print(f"\nexecuted structure builds: {len(results)}")
+    if not results:
+        return 2
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/dev/issue-861-incremental-admission-plan.md
+++ b/docs/dev/issue-861-incremental-admission-plan.md
@@ -1,0 +1,479 @@
+# Issue #861 — Incremental McCormick admission plan (loop-executable)
+
+**Target issue:** #861 *“Incremental McCormick declines 50/81 instances: 38 are
+`_validate` patch/cold mismatches.”*
+**Plan date / HEAD:** 2026-07-28, `bdc104bb` (post-#764 native-kernel graduation,
+post-#873 even-power admission).
+**All evidence in §1 was re-measured at this HEAD** with instrumented probes; the
+issue’s 31/50 split and its 24/14/6/5/1 bucket counts reproduce exactly.
+
+**Why this still matters post-#764:** `IncrementalMcCormickLP` is not only the
+opt-in `lp_spatial` engine’s fast path. It is built by the **default**
+`MccormickLPRelaxer` (`mccormick_lp.py:535-563`, `DISCOPT_INCREMENTAL_MC` default
+ON) and serves `_try_incremental_node` in the main Python B&B — the path every
+solve takes when the native Rust kernel (#764) declines a model or the solve is
+feature-unsafe (`solver.py:_native_kernel_feature_safe`). The native producer
+(`spatial_producer.py`) covers an even narrower family set than the Python
+incremental path, so the 50 declined instances are running the ~30× slower
+per-node cold build in *both* engines today.
+
+---
+
+## §0 Loop protocol (binding)
+
+1. Work the §5 task list top to bottom, one task per iteration. Each task lands
+   as its own scoped PR from a feature branch (`perf/861-<task>` /
+   `fix/861-<task>`); never commit to `main`. Title names the issue
+   (`Contributes to #861`; only the final task uses `Closes #861`).
+2. **Entry experiment before implementation** (CLAUDE.md §4). Each task lists its
+   entry probe and kill criterion. The §1 probes already run count as executed
+   entry experiments where noted; re-run a probe only if the tree has drifted
+   under the relevant files since this plan’s HEAD.
+3. **Never weaken `_validate`.** Every change either (a) makes the *boxes* it
+   compares on realistic (reachable from the true root box), (b) makes the
+   *classification* of rows correct, or (c) makes the *patch* reproduce the cold
+   build on more families. The comparison itself (`bounds` allclose 1e-6,
+   `_rowset` exact-polytope identity, box-independent objective offset) stays
+   byte-identical. A task that can only pass by loosening a tolerance or
+   dropping a comparison is dead — stop and record it in §7.
+4. Every probe/panel script prints an executed-assertion count and exits
+   non-zero when it is zero (CLAUDE.md rule 6). No bare `except` in instruments.
+5. After every task: run the §4/G2 sweep and paste the admitted/declined table
+   into the PR. Admissions must be ≥ the previous task’s count, and **no
+   previously-admitted instance may become declined** — if one does, that is
+   either a bug in your change or a genuine divergence the old synthetic boxes
+   missed; investigate and record before proceeding, never paper over.
+6. Record falsified hypotheses in §7 as you go (house style:
+   `docs/dev/performance-plan.md` §6). Update the issue with a short comment per
+   landed task.
+
+---
+
+## §1 Measured root causes (evidence, this session)
+
+Baseline sweep at HEAD over the 81-instance corpus
+`python/tests/data/minlplib/*.nl`, constructing `IncrementalMcCormickLP(model,
+classify_nonlinear_terms(model), deadline=None)` and capturing the DEBUG decline
+log: **31 admitted, 50 declined** — `bounds mismatch` 24, `column-count
+mismatch` 14, `rows, expected 4` 6, `no valid bound / no rows` 5, odd-power 1.
+Identical to the issue’s table.
+
+### Bucket A — `bounds mismatch` (24): NOT an over-strict comparison; genuinely unpatched lifted families
+
+`_validate` fails at `bounds mismatch` (`incremental_mccormick.py:764`) because
+the mismatching **aux columns belong to lifted families the patch never
+updates** — their `base_bounds` keep probe-box values while the cold build
+recomputes them per box. Attribution of the first-failing columns (probe:
+patched-vs-cold aux bounds on validation box 0, attributed via the
+`UniformRelaxation` maps/specs):
+
+| instance | offending aux family | measured example (patched vs cold) |
+|---|---|---|
+| ex1222 | `univariate_atom_specs` (`exp`, x0, coeff 1.0, const −0.2) | (2.2255, 897.85) vs (0.8187, 6.0496) |
+| trig, mathopt3, syn05m | `univ_atom` `sin`/`cos` | sin: (−1,1) vs (0.4794, 1) |
+| alan, nvs07, st_e05, st_e07, st_e40, util, kall_circles… | `bilinear_linform_specs` (products of *linear forms*, `_emit_mccormick`) | alan col 8: (4, 873) vs (−4, 44) |
+| st_e02, st_e15, ex1221, nvs20, nvs04, kall_circles_c8a | **power of a multi-var LinForm** or **fractional power** — coverage kind `power`, absent from `monomial_map`/`affine_square_map` | st_e02: (4, 225) vs (≈0, 16) = `(x0+x1)^2`; ex1221/st_e15: `x^1.5` |
+| ex1252, ex1252a, mathopt3 | `trilinear_map` (+ blf) | ex1252 col 41: (1, 1750) vs (0, 8) |
+| chance | a `univariate_call` atom not exported in any spec (cold aux lower −inf) | (4.6465, 41.81) vs (−inf, 9.293) |
+
+Key structural fact (read `uniform_relax._emit_1d`, line ~1220): **every 1-D
+atom** — power (any real exponent), exp, log, sqrt, sin, cos, … — of a LinForm
+`t` emits *exactly* secant + 3 tangents (4 rows, support = form vars ∪ {aux})
+when its curvature verdict on `[lo,hi]` is definite, and **0 rows** when the
+verdict abstains (`curv is None`), the box is degenerate (`< _MIN_WIDTH`), or an
+endpoint is non-finite; individual tangents are silently skipped on non-finite
+`f`/`f'`. Products of LinForms (`_emit_mccormick`) emit the 4 McCormick rows over
+the forms’ interval images. So the entire bucket reduces to **two generic
+closed-form recipes plus a bounds tape** (§2/D5) — not 24 bespoke fixes.
+
+### Bucket B — `column-count mismatch` (14): synthetic probe/validation boxes are unreachable, and the engine’s *decomposition* is box-dependent
+
+The probe box (`incremental_mccormick.py:354-360`: `[1, 7+k]` sign-matched) and
+the validation boxes (`_validation_boxes`, lines 672-724: absolute magnitudes,
+`lo=0.0` on even trials for positive vars) **ignore the model’s real root box
+entirely**. Measured on `gear` (root box `[12,60]^4`, strictly positive):
+
+* probe box `[1,7+k]` build: **15 columns** — the ratio `i1·i2/(i3·i4)` is
+  lifted through `log(x_i)` columns (bounds `(0, ln 7)`…), reciprocal columns
+  (`(1/9, 1)`), and a sum-of-logs column (the strictly-positive log-space route,
+  `uniform_relax.py` ~1801/2232);
+* validation box 0 (drives positive vars to `lo=0.0`, **unreachable** from
+  `lb=12`): **10 columns** — log route unavailable, reciprocal bounds
+  `(−inf, inf)` → `column-count mismatch`.
+
+Same mechanism on ex1225/ex1226 (probe 14/13 vs box0 11/10) and hda (1145 vs
+1082). The five `no valid bound / no rows` instances (Bucket D) are the same
+defect at a different exit: the *synthetic* box makes the relaxation invalid
+(`nvs06`, root `[1,200]^2` — validation `lo=0` ⇒ unbounded reciprocal ⇒
+`_objective_bound_valid=False`), or the *raw* root box is itself invalid
+pre-presolve (`st_e04`: cold build on the true root has
+`_objective_bound_valid=False`; ex1233 has 28 infinite root bounds).
+
+**Falsification measured this session (binding):** root-anchoring alone does
+*not* make every layout stable. Building the cold relaxation on 6 *reachable*
+sub-boxes of the true root box: `gear`/`ex1225`/`ex1226` are stable on all
+non-degenerate sub-boxes (unstable only when every var is pinned — a folding
+regime `_validate` never tests for sign-definite vars, cf. the #873 pinned-box
+vacuity precedent); but **nvs01 and st_e35 flip decomposition on interior
+reachable boxes** (root has `lb=0` columns; strictly-positive interior sub-boxes
+*gain* the log-route columns: nvs01 11→15, st_e35 69→87). Those models’ per-node
+cold builds genuinely change column layout across the tree; a fixed-layout
+incremental structure cannot be bound-neutral against them. They must keep
+declining (honestly) unless a route-pinning build option is added — an explicit
+non-goal here (§6).
+
+### Bucket C — `bilinear (i,j) → 5 or 6 rows, expected 4` (6): support-based row classification counts lifted *model constraints* as envelope rows
+
+`_build_structure` classifies a row as a product’s envelope iff its support ⊆
+`{i, j, aux}` (`incremental_mccormick.py:426-428`). A model constraint such as
+`x0·x1 ≥ 60` is lifted to the single-column row `{aux: −1} ≤ −60` — support ⊆
+`{i,j,aux}` — so prob02’s bilinears count 5 rows and the whole structure
+declines. Measured extra rows: prob02 `{6:−1} ≤ −60`, st_e01 `{2:1} ≤ 4`,
+st_e08 `{2:−16} ≤ −1`, st_e09 `{0:2, 1:2, 2:4}`, st_e11 two rows also touching a
+second aux. These extra rows are **box-independent** (they are model rows) and
+belong with the fixed rows.
+
+**Fix confirmed by entry experiment:** selecting the 4 envelope rows by *numeric
+match* against the closed-form `_bilinear_rows` evaluated on the probe box
+(coefficients + rhs, atol 1e-9) uniquely identifies them in all 6 instances, and
+a hand-driven `_patch`+`_validate` over all 6 validation boxes then **passes
+cleanly for st_e01, st_e09, prob02, prob03**. st_e08/st_e11 pass the row stage
+and move to Bucket A (their monomial/other aux weren’t patched in the manual
+harness; st_e08’s monomials are patched by the real code). The same
+support-⊆-based classification is used by the **native producer**
+(`spatial_producer.py`, “a row is a term’s envelope iff its support is contained
+in …”) — audit it for the same defect (T3).
+
+### Bucket D — `relaxation has no valid bound / no rows` (5)
+
+See Bucket B: synthetic-box artifact (nvs06, st_e35, ex1233 via infinite raw
+root) or genuinely-invalid raw root box that the real solve only fixes via
+FBBT/OBBT before building (st_e04). The constructor never receives the
+presolved box: `lp_spatial_bb.py:553` builds `IncrementalMcCormickLP(model,
+terms, deadline=…)` *after* computing OBBT-tightened `lb0/ub0` but doesn’t pass
+them; `mccormick_lp.py:559` likewise. (`spatial_producer.build_spatial_kernel_spec`
+already grew a `bounds=` parameter for exactly this reason — tanksize.)
+
+### Ergonomics blocker (from the issue, confirmed)
+
+The decline reason exists only as a `logger.debug` line
+(`incremental_mccormick.py:297-300`); nothing is stored on the object. The
+baseline sweep had to scrape the log.
+
+---
+
+## §2 Design
+
+**D1 — `decline_reason` attribute.** In `__init__`, initialize
+`self.decline_reason: str | None = None`; in the `except` set it to
+`f"{type(exc).__name__}: {exc}"` (keep the debug log). Also set a reason at the
+two early-return declines (expired deadline; `lp_spatial`’s
+`box_is_patchable` flip happens at the caller — leave that to the caller’s log).
+
+**D2 — Admission sweep as an in-repo meter.**
+`discopt_benchmarks/scripts/incremental_admission_sweep.py`: iterate
+`python/tests/data/minlplib/*.nl` (81 instances), build the structure exactly as
+the default relaxer does (optionally with the root box argument from D4), print
+one line per instance (`ADMIT`/`DECLINE reason`), write JSON, print the bucket
+histogram, exit non-zero on zero instances. This is the meter every task’s PR
+must quote (before/after).
+
+**D3 — Numeric envelope-row classifier.** In `_build_structure`, for each
+registered product/monomial/affine-square (and each family added by D5): among
+candidate rows (support ⊆ term cols), select rows by numeric equality
+(atol 1e-9 on each coefficient and rhs) with the closed-form envelope evaluated
+**on the probe box**. Exactly one candidate must match each expected row
+(ambiguity ⇒ decline, as today). Non-matching candidate rows are left as fixed
+rows. Mirror the audit onto `spatial_producer._classify` (same defect class); if
+confirmed there, fix it the same way in a separate commit of the same PR with
+its own regression test (a prob02-like model through
+`build_spatial_kernel_spec`).
+
+**D4 — Root-anchored probe & validation boxes; caller-passed box.**
+* Constructor grows `box: tuple[np.ndarray, np.ndarray] | None = None` —
+  the *finite, presolved* root box. Call sites: `lp_spatial_bb.py:553` passes
+  the post-OBBT `(lb0, ub0)`; `mccormick_lp.py:559` passes the flat root bounds
+  it already has (post-presolve at that layer). Default `None` keeps reading
+  `model._variables` (back-compat).
+* Probe box: for each var, distinct interior endpoints of the ROOT interval,
+  strictly sign-matched, avoiding zero endpoints (support detection needs every
+  McCormick coefficient nonzero): e.g. `lo_i = rlb + (0.11 + 0.017·(i mod 7))·w`,
+  `hi_i = rub − (0.13 + 0.013·(i mod 5))·w`, clamped to keep `lo < hi`; for an
+  infinite endpoint keep today’s synthetic magnitude on that side; a root-pinned
+  var (`w=0`) keeps its point (its envelope rows will be degenerate — if
+  `_index_of` then misses a pattern entry the structure declines as today, and
+  the instance is recorded; do not special-case).
+* Validation boxes: keep the six C-21 regime kinds and the spanning-var
+  span/neg/zero_lb/degen coverage, but generate every interval **inside the root
+  interval**, scaled by root width (spanning root vars have `rlb<0<rub`, so all
+  sign regimes remain reachable; sign-definite vars get full-width,
+  lb-touching, interior-shifted, and ub-touching sub-boxes — *no* degenerate
+  trials for sign-definite vars, exactly today’s scope, per the #873 pinned-box
+  vacuity precedent).
+* The `_box_sign_regime` bookkeeping and `_validated_regimes` stay; assert in
+  the new unit test that the generated set still covers
+  `{pos, span, neg, degen, zero_lb}` regimes for a model with spanning vars
+  (`zero_lb` only when the root box actually contains 0 as a lower bound —
+  reachability wins over regime nostalgia; record coverage actually achieved).
+
+**D5 — Generic patch tape (the coverage extension).** Replace the three
+hand-maintained families with a *tape* exported by the uniform engine and
+replayed by `_patch`:
+
+* **Export (uniform_relax, export-only — zero behavior change to the build):**
+  extend `UniformRelaxation` with an `envelope_tape` describing, for every
+  box-dependent envelope emitted: `("oneD", fname_or_("pow", p), linform
+  (dict col→coeff, const), aux, reserved_row_count=4)` and `("prod", linformA,
+  linformB, aux)` — generalizing today’s `univariate_atom_specs` /
+  `bilinear_linform_specs` / `affine_square_map` to *all* `_emit_1d` and
+  `_emit_mccormick` sites — plus, for **every** aux column, a `bounds_recipe`
+  in topological order: either `("interval_oneD", fname/p, linform)`,
+  `("interval_prod", linformA, linformB)`, or `("linform", linform)` for
+  linear-definitional aux, recording exactly the computation `ctx.bounds`
+  performs (reuse the same `Interval` ops — the #873 parity lesson:
+  reproduce the engine’s enclosure, including its outward rounding and
+  non-finite handling; *never* substitute a tighter closed form).
+* **Consume (incremental_mccormick):** `_build_structure` maps each tape entry’s
+  rows by the D3 numeric matcher, using the *same* `f/f'/curvature` table as the
+  engine (import it from `uniform_relax` — do not re-derive derivatives).
+  `_patch` replays, per node box: aux bounds from the recipes (in tape order,
+  so a form over aux columns reads already-updated bounds), then envelope rows:
+  when the curvature verdict on this box is definite → write secant + 3
+  tangents (skipping a tangent exactly when the engine would, writing a
+  vacuous `0 ≤ 0` row in its slot); when the verdict abstains / box degenerate /
+  non-finite → write 4 vacuous rows (matches the cold build’s **no rows**, and
+  `_rowset`’s vacuity filter drops them on comparison — mechanism already in
+  place from #873).
+* **Reserved rows:** an atom can emit 0 rows on the probe box but 4 on a node
+  box (sin/cos with indefinite curvature at the probe box; odd power on a
+  straddling box). For any tape atom whose probe-box emission is < 4 rows,
+  **append** 4 reserved rows to `base_A` (explicit entries on form vars ∪ aux,
+  initialized vacuous). `_rowset` filtering makes the comparison exact either
+  way; LP shape stays fixed across nodes (basis reuse unaffected in
+  correctness; a few extra vacuous rows are cheap).
+* **Families in scope for this plan:** `prod` (bilinear + all linform
+  products), `oneD` powers (integer, fractional on domain-valid boxes,
+  multi-var forms — subsumes monomial + affine-square), `oneD` intrinsics
+  (exp, log, sqrt, sin, cos — whatever the engine’s 1-D table holds),
+  linear-definitional aux bounds. **Out of scope** (structure declines, exactly
+  as today, now for an honest reason): trilinear/multilinear lifts, ratio
+  log-space *band rows* (`_emit_logspace_band`) if they prove box-dependent
+  beyond the tape shapes, composite specs, trig-square selector tables. Measure
+  what remains (T7) before deciding any follow-up.
+* The old `bilinear`/`monomial`/`affine_square` public attributes stay populated
+  (consumers: `lp_spatial` info map, C-44 column identities, cut inheritance).
+
+**D6 — Odd power on a straddling root box (`ex8_5_4`).** With D5’s reserved
+rows + abstain-→-vacuous mechanism, the odd-power gate
+(`incremental_mccormick.py:437-442`) can be dropped *iff* the engine’s cold
+emission for odd `p` on a straddling box is “curvature abstains → 0 rows”
+(then the patch writes 4 vacuous rows and stays bound-neutral, merely inheriting
+the cold build’s loose interval floor there). Entry probe: build gear-style cold
+relaxations of `x^3` over `[-1,2]` and check emitted rows for the monomial aux.
+If the cold build instead emits a genuine 2-facet S-hull (different row family),
+keep the decline for odd-`p`-straddling and close that sub-item as won’t-fix
+with `ex8_5_4` named (the issue explicitly allows this).
+
+**D7 — Bound-neutrality panels (§4)** are the graduation gate; no new env flag
+is added. The admission widening is inherently gated per-model by `_validate`
+(build-time, zero-risk fallback), which is this subsystem’s designed gate;
+`DISCOPT_INCREMENTAL_MC=0` remains the global opt-out.
+
+---
+
+## §3 Expected per-instance outcomes (testable predictions)
+
+* **T3 alone (+4):** st_e01, st_e09, prob02, prob03 admit. st_e08, st_e11 move
+  to Bucket A.
+* **T4 alone:** nvs06 admits only if its families are covered (needs T5) — but
+  its failure moves from `no valid bound` to an attributable mismatch; st_e04 /
+  ex1233 / nvs05(∞ root) become buildable via the passed presolved box (their
+  final admission still needs T5). No previously-admitted instance may regress.
+* **T4+T5 (bulk):** expected admissions include ex1221, ex1222, st_e02, st_e05,
+  st_e06, st_e07, st_e15, st_e36, st_e40, nvs04, nvs07, nvs08, nvs16, nvs20,
+  trig, syn05m, util, alan, chance, kall_circles_c8a, gear, gear2, gear3,
+  gear4(∞ root → box pass), ex1225, ex1226, st_e17, st_e08, st_e11, mathopt5_2,
+  nvs06, st_e04 — i.e. every decliner whose census is within
+  {blf, power-of-form, univ_atom, linear-def}. **Expected to remain declined
+  (honest):** nvs01, nvs05, nvs22, st_e03, st_e38, st_e35, hda (trilinear /
+  ratio-route instability / multilinear), ex1252, ex1252a, mathopt3
+  (trilinear), ex8_5_4 (pending T6), ex1233 (32 blf but check trilinear-free —
+  may admit). Quantitative goal: **≥ 55/81 admitted** (from 31). Report the
+  full final table regardless; if the goal is missed, the per-instance reasons
+  (now stored, D1) say exactly which family/route each residual needs — record,
+  don’t stretch.
+
+---
+
+## §4 Verification gates (every task PR states which it ran, with numbers)
+
+* **G1 — Regression tests.** Each task adds tests that fail before / pass after
+  (pytest, `python/tests/test_incremental_*`): the prob02 lifted-model-row
+  classifier case; a root-anchored-boxes case (gear admits; a synthetic
+  nvs01-like route-flip model still declines); per-family patch parity tests in
+  the style of `test_monomial_aux_bounds_match_interval_pow` (patch vs engine
+  interval/emitter parity across sign regimes, incl. non-finite boxes).
+* **G2 — Admission sweep** (D2 script): before/after table per PR; monotone
+  non-decreasing; no admitted→declined flips (see §0.5).
+* **G3 — Per-node LP-value parity (the direct bound-neutrality gate).** New
+  panel script: for every **newly admitted** instance, sample ≥ 20 reachable
+  sub-boxes of the true root box (branching-style splits incl. integer pins and
+  sign-regime diversity), solve the patched LP and the cold-build LP, assert
+  bound equality to 1e-9·(1+|bound|), assert identical
+  infeasibility verdicts; print executed-comparison count. Zero violations
+  required. (This is the per-node analogue of `_validate`, on real instances
+  and realistic boxes rather than the 6 synthetic regimes.)
+* **G4 — End-to-end certifying panel.** Full `solve()` over the 81-instance
+  corpus with the change vs. `DISCOPT_INCREMENTAL_MC=0`, oracle =
+  `minlplib.solu` (`~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu`):
+  `incorrect_count = 0`, no dual bound crossing its reference optimum, no
+  `gap_certified=True` instance regressing to uncertified, objective drift
+  within tolerance (abs 1e-6 / rel 1e-4). On the 31 previously-admitted
+  instances: node_count and certified objective **exactly unchanged**
+  (bound-neutral regime, CLAUDE.md §5).
+* **G5 — Net-positive measurement (CLAUDE.md §5 bar 2).** On ≥ 5 newly-admitted
+  instances: wall time and node throughput, incremental ON vs OFF, interleaved
+  A/B with load gate (`uptime`), ≥ 3 repeats, report mean ± sd
+  (CLAUDE.md rules 9–10). The expectation is the measured ~30× per-node speedup
+  class; if a newly-admitted instance is *slower* ON (tape overhead), find out
+  why before shipping the family.
+* **G6 — Suites.** `pytest -m smoke`, adversarial suite
+  (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`); Rust
+  untouched by this plan (no `cargo test` needed unless T3’s
+  `spatial_producer` audit leads into `crates/` — it shouldn’t).
+
+---
+
+## §5 Task list
+
+**T1 — `decline_reason` + sweep meter (D1 + D2).** Small PR. Includes the D2
+script + a unit test that a declined structure carries a non-None reason and an
+admitted one carries None. *Entry experiment:* none needed (mechanical).
+*Done:* sweep runs at HEAD reproducing 31/50 with stored reasons (no log
+scraping).
+
+**T2 — Baseline lock-in.** Commit the sweep’s JSON baseline (31/50 table) under
+`discopt_benchmarks/results/` via the D2 script so later diffs are one command.
+(May be folded into T1’s PR.)
+
+**T3 — Numeric envelope-row classifier (D3) + native-producer audit.**
+*Entry experiment (already executed, §1-C):* numeric matching uniquely
+identifies the 4 envelope rows and full validation passes on
+st_e01/st_e09/prob02/prob03. *Kill criterion:* ambiguous numeric match (two
+candidate rows equal within atol) on any corpus instance ⇒ keep decline for
+that term, log reason. *Done:* +4 admissions; st_e08/st_e11 reasons now
+`bounds mismatch`; prob02-class regression test; `spatial_producer` audited
+(and fixed if affected, with its own test). *Gates:* G1, G2, G4 (31 admitted
+unchanged), G6.
+
+**T4 — Root-anchored probe/validation boxes + `box=` parameter (D4).**
+*Entry experiment (already executed, §1-B):* gear-class layouts are stable on
+reachable non-degenerate sub-boxes; nvs01/st_e35 flip on reachable boxes (they
+must still decline — this is the task’s negative control). *Kill criterion:*
+any previously-admitted instance regresses under root-anchored boxes and
+investigation shows the *boxes* (not a real divergence) are at fault ⇒ fix box
+generation, do not exempt the instance. *Done:* probe/validation boxes are
+sub-boxes of the (possibly caller-passed) root box wherever it is finite; both
+call sites pass their presolved boxes; regime-coverage unit test; st_e04/ex1233
+reach `_validate` instead of dying at the probe build. *Gates:* G1, G2, G4, G6.
+
+**T5 — Generic patch tape (D5), landed family-by-family in three PRs:**
+* **T5a `prod` generalization** (linform × linform products; subsumes bare
+  bilinear): expected admissions among {st_e05, st_e07, st_e40, util, nvs07,
+  alan(box), st_e11, kall_circles… partial}.
+* **T5b `oneD` generalization** (powers of forms incl. fractional; exp/log/
+  sqrt/sin/cos via the engine’s own f/f′/curvature table; reserved rows +
+  abstain→vacuous): expected admissions among {st_e02, st_e15, ex1221, ex1222,
+  nvs04, nvs08, nvs16, nvs20, trig, syn05m, st_e36, st_e06, mathopt5_2,
+  st_e08}.
+* **T5c bounds tape for linear-definitional aux + full-aux coverage check**
+  (gear’s log/reciprocal/sum columns; assert at build time that *every* aux
+  column has a recipe, else decline with reason `uncovered aux <family>`):
+  expected admissions among {gear, gear2, gear3, gear4, ex1225, ex1226,
+  st_e17, nvs06, chance, ex1233}.
+
+*Entry experiment per sub-task:* before implementing, write the parity probe
+(patch recipe vs cold engine on 200 random finite/sign-diverse boxes for that
+family; plus non-finite-endpoint cases for T5b) and run it against a prototype
+of the closed form; the #873 methodology (exact-rational or high-precision
+check on a sample, executed-assertion counts, a deliberately-broken control
+that must fire). *Kill criterion:* any family whose cold emission is not
+reproducible from the tape shapes (e.g. box-dependent facet count beyond the
+reserved 4, engine-internal state leaking into rows) ⇒ that family stays
+unpatched and its models keep declining with a stored reason; record in §7.
+*Gates per sub-task:* G1, G2, G3 (newly admitted), G4, G6; G5 after T5c.
+
+**T6 — Odd power on straddling root (D6).** *Entry probe:* what does the cold
+build emit for `x^3` on `[-1, 2]`? 0 rows (abstain) ⇒ drop the gate, admit
+`ex8_5_4` under T5b mechanics, add the regression test. S-hull rows ⇒ won’t-fix:
+comment on the issue naming `ex8_5_4` as the sole consumer, keep the gate,
+done. Either outcome closes issue-DoD item 3.
+
+**T7 — Close-out.** Final sweep table (before: 31/50 with buckets; after:
+measured), G3/G4/G5 numbers, per-instance residual reasons for everything still
+declined, retract/confirm the §3 predictions explicitly, update
+`docs/dev/performance-plan.md` §6 with any falsifications from §7, and comment
+on #861 with the summary ending in an explicit **“issue can be closed: yes/no
+(+ exactly what remains)”** per CLAUDE.md. `Closes #861` only if DoD items 1–4
+are all met (they are, if T3–T6 landed: buckets triaged with per-bucket
+verdicts (§1), comparison fixed/narrowed with panels clean, odd-power decided,
+before/after sweep reported).
+
+---
+
+## §6 Non-goals (do not drift into these)
+
+* The `ball_mk2_30` primal gap — #862’s workstream (issue correction 1).
+* Route-pinning the uniform engine’s decomposition (would admit
+  nvs01/st_e35/hda-class) — file a follow-up **only** in T7 and **only with**
+  the measured residual table as its evidence; do not build it here.
+* Extending the native Rust kernel’s family coverage (#764 follow-ups) — except
+  the T3 classifier audit, which is a correctness/coverage defect shared by
+  construction.
+* Any tightening of aux bounds beyond the engine’s own enclosure (explicitly
+  forbidden — bound-neutrality is the product; see `_monomial_aux_bounds`’s
+  docstring contract).
+
+## §7 Falsification log (append as you go)
+
+* *(this session)* “The `_validate` mismatches are an over-strict comparison
+  (issue hypothesis b).” — **Partially falsified.** Bucket A is genuine missing
+  patch coverage (correctly declined today); only Buckets B/D stem from
+  unrealistic comparison *boxes*, and Bucket C from misclassification.
+* *(this session)* “Root-anchored validation boxes suffice for the
+  `column-count` bucket.” — **Falsified** for nvs01/st_e35 (decomposition
+  flips on *reachable* interior boxes: 11→15 / 69→87 columns). Root-anchoring
+  is necessary, not sufficient; those instances stay declined pending a
+  route-pinning decision (out of scope).
+
+---
+
+## Progress ledger
+
+Append one entry per landed task (§0.1 recovers loop state from here).
+
+### T1 + T2 — `decline_reason` + admission sweep meter + baseline — PR #893
+
+* **Landed:** `python/discopt/_jax/incremental_mccormick.py` stores
+  `decline_reason` (set on the exception path *and* on both non-raising
+  deadline guards, which were the paths most likely to read as “no reason”);
+  new meter `discopt_benchmarks/scripts/incremental_admission_sweep.py`;
+  baseline `discopt_benchmarks/results/issue861_admission_baseline_20260728.json`.
+* **Sweep (G2), at `bdc104bb` + this change:** **admitted 31/81, declined 50** —
+  `bounds mismatch` 24, `column-count mismatch` 14, `envelope row count != 4` 6,
+  `no valid bound / no rows` 5, `odd power on straddling root` 1. Reproduces the
+  issue’s table exactly, now from the stored attribute rather than a scraped
+  DEBUG log. This JSON is the baseline every later task diffs against
+  (`--baseline`, which exits non-zero on any admitted→declined flip).
+* **Gates:** G1 — `python/tests/test_861_decline_reason.py`, 10 tests;
+  verified **3 fail before / all pass after** (`AttributeError: … has no
+  attribute 'decline_reason'`), plus the bucket-mapping contract pinned against
+  the exact messages the code raises. G2 — baseline established (no prior run to
+  regress against). G6 — `pytest -m smoke` 850 passed / 1 skipped / 2 xpassed;
+  adversarial suite 10 passed; incremental-McCormick files 160 passed;
+  `ruff check` + `ruff format` clean. (`mypy` reports one error inside numpy’s
+  own stubs — verified **pre-existing on clean `main`**, unrelated.)
+* **Behaviour change:** none in the solve path. The attribute is diagnostic; no
+  code branches on it, and admission is byte-identical (31/81 before and after).
+* **Next:** T3 (numeric envelope-row classifier + `spatial_producer` audit).
+  Its entry experiment is already executed (§1-C).

--- a/docs/dev/issue-861-loop-prompt.md
+++ b/docs/dev/issue-861-loop-prompt.md
@@ -1,0 +1,74 @@
+You are implementing GitHub issue #861 for the discopt repo, working from the
+evidence-based plan in `docs/dev/issue-861-incremental-admission-plan.md`. Read
+that plan file COMPLETELY before doing anything else — its §0 protocol is
+binding, its §1 evidence is already measured (do not re-derive it unless the
+tree has drifted under the cited files), and its §5 task list (T1–T7) is your
+work queue. Also read `CLAUDE.md` and honor it fully (especially §§1–11:
+correctness before performance, entry experiments before implementation,
+executed-assertion counts, no swallowed exceptions in instruments).
+
+Each invocation of this prompt is ONE iteration of a loop. Do exactly one
+plan task (or one T5 sub-task) per iteration, end to end:
+
+1. **Recover state.** Determine which plan tasks are already done by looking at
+   the repo itself: the "## Progress ledger" section at the bottom of the plan
+   doc (create it on the first iteration), merged/open PRs (`gh pr list
+   --state all --search "861"`), and the latest admission-sweep results in
+   `discopt_benchmarks/results/`. If an iteration before you left a PR open,
+   your job this iteration is to finish it: check CI (`gh pr checks`), fix
+   failures, merge it with `gh pr merge --merge`, verify the linked issue state
+   afterwards, and update the ledger. Never start a new task while the previous
+   task's PR is unmerged.
+2. **Pick the next unstarted task** in plan order (T1, T2, T3, T4, T5a, T5b,
+   T5c, T6, T7). Re-read the task's entry in §5 plus the design section (§2)
+   and evidence (§1) it references.
+3. **Run the task's entry experiment first** if the plan marks it as not yet
+   executed, or if `python/discopt/_jax/incremental_mccormick.py`,
+   `python/discopt/_jax/uniform_relax.py`, or
+   `python/discopt/_jax/spatial_producer.py` changed since the plan's HEAD
+   (`bdc104bb`). If the experiment falsifies the task's premise, STOP the task,
+   record the falsification in plan §7 and the ledger, comment on issue #861,
+   and end the iteration — do not implement against a falsified premise.
+4. **Implement on a feature branch** (`git checkout -b <type>/861-<task> main`
+   after `git pull`), with the regression tests the task's G1 gate names
+   (fail-before/pass-after). NEVER commit to main, never use --no-verify,
+   never weaken `_validate`'s comparisons or any other gate to make something
+   pass — if a task can only pass that way, it is dead; record why and stop.
+5. **Run the task's verification gates** exactly as §4 specifies (sweep
+   before/after table, LP-value parity panel, certifying panel, pytest smoke +
+   adversarial suite as applicable) and paste the numbers — not adjectives —
+   into the PR description (write PR/issue bodies to a file and use
+   --body-file; never inline --body). The admission count must be monotone
+   non-decreasing and no previously-admitted instance may flip to declined
+   (plan §0.5 tells you what to do if one does).
+6. **Open the PR** (`Contributes to #861`; only T7 uses `Closes #861`), then
+   merge it yourself once CI is green (`gh pr merge --merge`). If CI cannot go
+   green this iteration, leave the PR open with a comment describing exactly
+   what remains, update the ledger, and end the iteration.
+7. **Close the loop for the iteration:** append to the plan doc's Progress
+   ledger (task id, PR number, sweep numbers, gates run, anything falsified)
+   in the SAME PR as the task when possible, and post a short comment on
+   issue #861 summarizing the landed task and the current admitted/declined
+   count.
+
+Rules of engagement:
+- Prefer finishing over documenting: if you notice three artifacts and no code
+  change in your session, stop analyzing and build (CLAUDE.md working-on-an-
+  issue §6).
+- Scope discipline: plan §6 non-goals are hard fences. The ball_mk2_30 primal
+  gap, engine route-pinning, and native-kernel family extensions are OFF
+  limits (except the T3 spatial_producer classifier audit).
+- Measurement discipline: every probe/panel prints an executed-assertion count
+  and exits non-zero when zero; timing claims need interleaved A/B, a load
+  check, and a spread; long jobs print incremental progress and are run with
+  `python -u`.
+- If a measurement contradicts the plan, THE MEASUREMENT WINS: record the
+  falsification in plan §7, re-scope the task in the plan (edit it in the same
+  PR), and continue with the corrected scope.
+
+Termination: after T7's PR is merged and issue #861 has the close-out comment
+(explicit "issue can be closed: yes/no + what remains"), verify the issue's
+final state matches that verdict, write the line `RALPH-861-COMPLETE` as the
+last line of the plan doc's Progress ledger, and output `RALPH-861-COMPLETE`
+as the final line of your reply. If the ledger already contains
+`RALPH-861-COMPLETE` when you start, do nothing and output it again.

--- a/python/discopt/_jax/incremental_mccormick.py
+++ b/python/discopt/_jax/incremental_mccormick.py
@@ -275,6 +275,14 @@ class IncrementalMcCormickLP:
         self.ok = False
         self.model = model
         self.terms = terms
+        # Why this structure declined, or ``None`` when it was admitted (#861). The
+        # reason used to exist ONLY as the ``logger.debug`` line below, so a caller
+        # measuring coverage had to scrape a log to learn anything — and
+        # ``getattr(inc, "reason", None)`` returning ``None`` for a missing attribute
+        # reads as "declined for no reason", which cost a wrong triage pass. Storing
+        # it makes the decline reason a first-class, measurable property; nothing in
+        # the solve path branches on it (it is diagnostic only).
+        self.decline_reason: str | None = None
         self._validated_regimes = frozenset()  # sign regimes _validate exercised
         self._deadline = (
             deadline if deadline is not None else getattr(model, "_solve_deadline", None)
@@ -285,6 +293,7 @@ class IncrementalMcCormickLP:
         # use the trusted per-node cold build. No-op when budget remains (the common
         # case) or when no deadline was stashed (construction outside a solve).
         if self._deadline is not None and time.perf_counter() > self._deadline:
+            self.decline_reason = "deadline already spent before construction"
             return
         try:
             self._build_structure()
@@ -295,6 +304,7 @@ class IncrementalMcCormickLP:
             # feasibility pump. A silently-declined structure is exactly how #844's
             # overshoot hid for two rounds of measurement, so record why.
             self.ok = False
+            self.decline_reason = f"{type(exc).__name__}: {exc}"
             logger.debug(
                 "IncrementalMcCormickLP declined to build: %s: %s", type(exc).__name__, exc
             )
@@ -746,6 +756,7 @@ class IncrementalMcCormickLP:
         for lb, ub in rng_boxes:
             if _deadline is not None and time.perf_counter() > _deadline:
                 self.ok = False
+                self.decline_reason = "deadline spent during validation"
                 return
             for i in range(self.n):
                 regimes.add(self._box_sign_regime(float(lb[i]), float(ub[i])))

--- a/python/tests/test_861_decline_reason.py
+++ b/python/tests/test_861_decline_reason.py
@@ -1,0 +1,117 @@
+"""#861 — a declined incremental structure records WHY, as an attribute.
+
+``IncrementalMcCormickLP`` recorded its decline reason only via ``logger.debug``.
+Nothing was stored on the object, so a caller measuring coverage had to scrape a
+log, and ``getattr(inc, "reason", None)`` returned ``None`` because the attribute
+did not exist — which reads as "declined for no reason" and cost a wrong triage
+pass while the issue was being written.
+
+The reason is diagnostic ONLY: nothing in the solve path branches on it, and
+declining stays exactly as sound as before (the caller falls back to the trusted
+per-node cold build). What it buys is a measurable meter — the admission sweep
+(``discopt_benchmarks/scripts/incremental_admission_sweep.py``) reads this
+attribute instead of a DEBUG log to attribute the corpus's declines to buckets.
+
+Pinned here: an ADMITTED structure carries ``None``; a DECLINED one carries a
+non-empty ``"<ExcType>: <message>"``; and the two non-exception declines (the
+#654/#844 deadline guards, which return early without raising) carry a reason
+too — those were the paths most likely to look like "no reason at all".
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import time
+
+import discopt.modeling as dm
+import pytest
+from discopt._jax.incremental_mccormick import IncrementalMcCormickLP
+from discopt._jax.term_classifier import classify_nonlinear_terms
+
+
+def _admitting_model():
+    """Small all-integer QCQP (bilinear + affine squares) — in the fast-path scope."""
+    m = dm.Model("iqcqp")
+    x = m.integer("x", lb=0, ub=5)
+    y = m.integer("y", lb=0, ub=5)
+    m.minimize((x - 3) ** 2 + (y - 2) ** 2 + x * y)
+    m.subject_to(x + y >= 3)
+    return m
+
+
+def _declining_model():
+    """An ODD power on a root box that spans zero — declined by design (the envelope
+    switches between the 4-row secant/tangent hull and the 2-facet S-hull, which the
+    fixed sparsity pattern cannot express). Chosen because its decline is a *stable*
+    property of the mathematics, not of the current validation-box set."""
+    m = dm.Model("odd_span")
+    x = m.continuous("x", lb=-2.0, ub=3.0)  # straddles zero
+    y = m.continuous("y", lb=0.5, ub=4.0)
+    m.minimize(x**3 + y)
+    m.subject_to(x + y >= 1)
+    return m
+
+
+def _build(model):
+    return IncrementalMcCormickLP(model, classify_nonlinear_terms(model), deadline=None)
+
+
+def test_admitted_structure_has_no_decline_reason():
+    inc = _build(_admitting_model())
+    assert inc.ok, "expected the integer QCQP to be admitted by the fast path"
+    assert inc.decline_reason is None
+
+
+def test_declined_structure_records_the_reason():
+    inc = _build(_declining_model())
+    assert not inc.ok, "expected an odd power on a straddling root box to decline"
+    # The attribute exists, is non-empty, and names both the exception type and the
+    # cause — enough for the sweep to bucket it without reading a log.
+    assert isinstance(inc.decline_reason, str) and inc.decline_reason
+    assert "ValueError" in inc.decline_reason
+    assert "odd power on a root box spanning zero" in inc.decline_reason
+
+
+def test_deadline_declines_carry_a_reason():
+    """The two non-exception declines (#654/#844 budget guards) return early rather
+    than raising, so they are the paths most at risk of reading as "no reason"."""
+    model = _admitting_model()
+    terms = classify_nonlinear_terms(model)
+    # Deadline already in the past when the constructor is entered.
+    inc = IncrementalMcCormickLP(model, terms, deadline=time.perf_counter() - 1.0)
+    assert not inc.ok
+    assert inc.decline_reason is not None
+    assert "deadline" in inc.decline_reason.lower()
+
+
+@pytest.mark.parametrize(
+    "reason,expected",
+    [
+        (None, "admitted"),
+        ("ValueError: bounds mismatch", "bounds mismatch"),
+        ("ValueError: column-count mismatch", "column-count mismatch"),
+        ("ValueError: bilinear (0,1) -> 5 rows, expected 4", "envelope row count != 4"),
+        ("ValueError: relaxation has no valid bound / no rows", "no valid bound / no rows"),
+        (
+            "ValueError: monomial x_2^3: odd power on a root box spanning zero (…)",
+            "odd power on straddling root",
+        ),
+        ("deadline spent during validation", "deadline spent"),
+    ],
+)
+def test_sweep_bucketing_of_reasons(reason, expected):
+    """The sweep's bucket mapping is part of the meter's contract: a renamed error
+    message that silently falls into "other" would make a coverage change look like
+    a bucket shift. Pin the mapping against the exact messages the code raises."""
+    import importlib.util
+
+    here = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    path = os.path.join(here, "discopt_benchmarks", "scripts", "incremental_admission_sweep.py")
+    spec = importlib.util.spec_from_file_location("_admission_sweep", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert mod.bucket(reason) == expected


### PR DESCRIPTION
## What and why

`IncrementalMcCormickLP` recorded **why** it declined only via `logger.debug`. Nothing was stored on the object, so measuring coverage meant scraping a log — and `getattr(inc, "reason", None)` returned `None` because the attribute did not exist, which reads as "declined for no reason". The issue names this as the ergonomics blocker for the rest of the work; it cost a wrong triage pass while the issue was being written.

This PR is task T1+T2 of the #861 plan: make the decline reason a first-class property, and stand up the meter the remaining tasks are measured with.

## Changes

- **`decline_reason` attribute** (`python/discopt/_jax/incremental_mccormick.py`) — set on the exception path and on **both non-raising deadline guards** (#654 pre-construction, #844 mid-validation). Those two were the paths most likely to look like no reason at all, since they return early rather than raising. Diagnostic only: nothing in the solve path branches on it, declining stays exactly as sound as before (the caller falls back to the trusted per-node cold build), and admission is byte-identical (31/81 before and after).
- **Admission sweep meter** — `discopt_benchmarks/scripts/incremental_admission_sweep.py`. Builds the structure over the 81-instance in-repo corpus exactly as the default relaxer does, prints per-instance ADMIT/DECLINE with the stored reason, writes JSON, prints the bucket histogram, and exits non-zero when it measured nothing. `--baseline old.json` exits non-zero on any admitted→declined flip.
- **Committed baseline** — `discopt_benchmarks/results/issue861_admission_baseline_20260728.json`.
- **Plan doc** — `docs/dev/issue-861-incremental-admission-plan.md`: per-bucket root causes measured this session, the design, per-task entry experiments and kill criteria, verification gates, and a falsification log. Plus the loop prompt that executes it.

## Measurement (G2)

At `bdc104bb` + this change, over `python/tests/data/minlplib/*.nl`:

```
=== admitted 31/81   declined 50 ===
   24  bounds mismatch                  alan, chance, ex1221, ex1222, ex1252, ex1252a, ex8_1_1, kall_circles_c8a …
   14  column-count mismatch            ex1225, ex1226, gear, gear2, gear3, gear4, hda, nvs01 …
    6  envelope row count != 4          prob02, prob03, st_e01, st_e08, st_e09, st_e11
    5  no valid bound / no rows         ex1233, mathopt5_2, nvs06, st_e04, st_e35
    1  odd power on straddling root     ex8_5_4

executed structure builds: 81
```

Reproduces the issue's triage table exactly, now from the stored attribute rather than a scraped DEBUG log.

## Verification

- **G1** — `python/tests/test_861_decline_reason.py`, 10 tests. Verified **fail-before/pass-after**: with the source change stashed, 3 fail with `AttributeError: 'IncrementalMcCormickLP' object has no attribute 'decline_reason'`; all 10 pass with it. The bucket mapping is pinned against the exact messages the code raises, so a renamed error can't silently fall into "other" and make a coverage change look like a bucket shift.
- **G6** — `pytest -m smoke`: 850 passed, 1 skipped, 2 xpassed. Adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`): 10 passed. Incremental-McCormick test files: 160 passed. `ruff check` + `ruff format` clean. No Rust touched.
- `mypy` reports one error inside numpy's own stubs (`Type statement is only supported in Python 3.12 and greater`) — verified **pre-existing on clean `main`**, unrelated to this change.

## Scope

No behaviour change in the solve path. The admission widening itself is T3–T6.

Contributes to #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
