### PR TITLE
perf(relaxation): #861 anchor the probe and validation boxes to the real root box

### DIFF
--- a/discopt_benchmarks/data/local_oracle.json
+++ b/discopt_benchmarks/data/local_oracle.json
@@ -1,0 +1,106 @@
+{
+  "_README": [
+    "Reference optima for in-repo corpus instances that have NO entry in MINLPLib's",
+    "minlplib.solu snapshot (~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu).",
+    "",
+    "Only 2 of the 81 instances in python/tests/data/minlplib/ are missing from that",
+    "file: st_e17 and meanvar. Before this file existed, a probe that wanted to check",
+    "them had nothing to read -- and during issue #861 that led to an oracle value",
+    "being INVENTED for st_e17 (1.0), which produced a spurious 'false optimum /",
+    "bound above optimum' report against discopt's correct answer of 376.2919. The",
+    "fix is not to be more careful when typing numbers; it is to have the number on",
+    "disk with its provenance. Never hand-type a reference optimum.",
+    "",
+    "Each value below was established by running INDEPENDENT external global solvers",
+    "on the exact .nl file in this repository, not copied from a paper or a memory.",
+    "Reproduce with the commands in each entry's 'reproduce' field.",
+    "",
+    "Consumed by discopt_benchmarks/scripts/incremental_oracle_check.py, which merges",
+    "these entries with minlplib.solu (minlplib.solu wins on any overlap, so this file",
+    "can never override an upstream reference)."
+  ],
+  "instances": {
+    "st_e17": {
+      "value": 376.291905403861,
+      "marker": "opt",
+      "sense": "minimize",
+      "established": "2026-07-28",
+      "solvers": {
+        "scip": {
+          "version": "homebrew /opt/homebrew/bin/scip",
+          "objective": 376.291905403861,
+          "dual_bound": 376.291905403861,
+          "gap": 0.0,
+          "status": "optimal solution found",
+          "nodes": 1,
+          "solution": {"x0": 8.16961144386222, "x1": 7.56140716412845}
+        },
+        "baron": {
+          "version": "GAMS 53 Resources/baron",
+          "objective": 376.2919,
+          "model_status": "1 Optimal",
+          "solver_status": "1 Normal Completion",
+          "solution": {"x0": 8.17, "x1": 7.5607}
+        },
+        "couenne": {
+          "version": "/Applications/AMPL/couenne",
+          "status": "Optimal",
+          "cutoff": 376.28840798,
+          "lower_bound": 376.288,
+          "note": "looser default gap tolerance; consistent with SCIP/BARON"
+        }
+      },
+      "discopt": {
+        "objective": 376.2919323217,
+        "bound": 376.2918929614,
+        "status": "optimal",
+        "verdict": "CORRECT - agrees with SCIP/BARON to ~7 significant figures"
+      },
+      "reproduce": [
+        "scip -c \"read st_e17.nl optimize display solution quit\"",
+        "gams st_e17.gms  (NLP=baron, optcr=0, optca=0; model transcribed from the .nl:",
+        "  min 29.4*x0 + 18*x1  s.t.  6 - (x0 - 0.2458*sqr(x0)/x1) <= 0,",
+        "  x0 in [0, 115.8], x1 in [1e-5, 30])",
+        "couenne st_e17.nl"
+      ]
+    },
+    "meanvar": {
+      "value": 5.24339865067014,
+      "marker": "opt",
+      "sense": "minimize",
+      "established": "2026-07-28",
+      "solvers": {
+        "scip": {
+          "version": "homebrew /opt/homebrew/bin/scip",
+          "objective": 5.24339865067014,
+          "dual_bound": 5.24339865067014,
+          "gap": 0.0,
+          "status": "optimal solution found",
+          "nodes": 1
+        },
+        "couenne": {
+          "version": "/Applications/AMPL/couenne",
+          "status": "Optimal",
+          "lower_bound": 5.2434,
+          "upper_bound": 5.2434,
+          "gap": 0.0,
+          "nodes": 338
+        },
+        "baron": {
+          "status": "NOT RUN",
+          "why": "the GAMS BARON binary does not read .nl, and this model's objective is a dense 8-variable quadratic form; hand-transcribing it to GAMS is exactly the error class this file exists to prevent. Two independent global solvers (SCIP, Couenne) agree to 6 significant figures at a 0% gap, and the model is a convex mean-variance QP, where a local optimum is global."
+        }
+      },
+      "discopt": {
+        "objective": 5.2433990152,
+        "bound": 5.2433990152,
+        "status": "optimal",
+        "verdict": "CORRECT - agrees with SCIP/Couenne to ~7 significant figures (3.6e-7 absolute, 7e-8 relative)"
+      },
+      "reproduce": [
+        "scip -c \"read meanvar.nl optimize display solution quit\"",
+        "couenne meanvar.nl"
+      ]
+    }
+  }
+}

--- a/discopt_benchmarks/results/issue861_admission_t4_20260728.json
+++ b/discopt_benchmarks/results/issue861_admission_t4_20260728.json
@@ -1,0 +1,798 @@
+{
+ "admitted": 36,
+ "declined": 45,
+ "instances": {
+  "alan": {
+   "n": 8,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.012
+  },
+  "carton7": {
+   "n": 328,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 528,
+   "n_bilinear": 200,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.156
+  },
+  "chance": {
+   "n": 4,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "dispatch": {
+   "n": 4,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 10,
+   "n_bilinear": 3,
+   "n_monomial": 3,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "ex1221": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1222": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1223a": {
+   "n": 7,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 13,
+   "n_bilinear": 0,
+   "n_monomial": 3,
+   "n_affine_square": 3,
+   "secs": 0.004
+  },
+  "ex1225": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1226": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1233": {
+   "n": 52,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.009
+  },
+  "ex1252": {
+   "n": 39,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.006
+  },
+  "ex1252a": {
+   "n": 24,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.005
+  },
+  "ex1263": {
+   "n": 92,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 108,
+   "n_bilinear": 16,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.016
+  },
+  "ex1264": {
+   "n": 88,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 104,
+   "n_bilinear": 16,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.021
+  },
+  "ex1265": {
+   "n": 130,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 155,
+   "n_bilinear": 25,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.022
+  },
+  "ex1266": {
+   "n": 180,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 216,
+   "n_bilinear": 36,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.029
+  },
+  "ex8_1_1": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex8_5_4": {
+   "n": 5,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: monomial x_2^3: odd power on a root box spanning zero (the envelope switches between the 4-row secant/tangent hull and the 2-facet S-hull, which the fixed row pattern cannot express)",
+   "bucket": "odd power on straddling root",
+   "secs": 0.002
+  },
+  "fuel": {
+   "n": 15,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 21,
+   "n_bilinear": 0,
+   "n_monomial": 6,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "gbd": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 0,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "gear": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "gear2": {
+   "n": 28,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "gear3": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "gear4": {
+   "n": 6,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "hda": {
+   "n": 722,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.096
+  },
+  "kall_circles_c8a": {
+   "n": 22,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.014
+  },
+  "mathopt3": {
+   "n": 6,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.004
+  },
+  "mathopt5_2": {
+   "n": 1,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.002
+  },
+  "meanvar": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 36,
+   "n_bilinear": 21,
+   "n_monomial": 7,
+   "n_affine_square": 0,
+   "secs": 0.012
+  },
+  "meanvarx": {
+   "n": 35,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 63,
+   "n_bilinear": 21,
+   "n_monomial": 7,
+   "n_affine_square": 0,
+   "secs": 0.014
+  },
+  "nvs01": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.002
+  },
+  "nvs02": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 16,
+   "n_bilinear": 7,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "nvs03": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 0,
+   "n_monomial": 1,
+   "n_affine_square": 2,
+   "secs": 0.002
+  },
+  "nvs04": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "nvs05": {
+   "n": 8,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.006
+  },
+  "nvs06": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "nvs07": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "nvs08": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "nvs10": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 1,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "nvs11": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 9,
+   "n_bilinear": 3,
+   "n_monomial": 3,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "nvs12": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 14,
+   "n_bilinear": 6,
+   "n_monomial": 4,
+   "n_affine_square": 0,
+   "secs": 0.005
+  },
+  "nvs13": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 20,
+   "n_bilinear": 10,
+   "n_monomial": 5,
+   "n_affine_square": 0,
+   "secs": 0.008
+  },
+  "nvs14": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 16,
+   "n_bilinear": 7,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.005
+  },
+  "nvs15": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 8,
+   "n_bilinear": 2,
+   "n_monomial": 3,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "nvs16": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "nvs17": {
+   "n": 7,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 35,
+   "n_bilinear": 21,
+   "n_monomial": 7,
+   "n_affine_square": 0,
+   "secs": 0.016
+  },
+  "nvs18": {
+   "n": 6,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 27,
+   "n_bilinear": 15,
+   "n_monomial": 6,
+   "n_affine_square": 0,
+   "secs": 0.011
+  },
+  "nvs19": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 44,
+   "n_bilinear": 28,
+   "n_monomial": 8,
+   "n_affine_square": 0,
+   "secs": 0.024
+  },
+  "nvs20": {
+   "n": 16,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.024
+  },
+  "nvs21": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "nvs22": {
+   "n": 8,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.006
+  },
+  "nvs23": {
+   "n": 9,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 54,
+   "n_bilinear": 36,
+   "n_monomial": 9,
+   "n_affine_square": 0,
+   "secs": 0.029
+  },
+  "nvs24": {
+   "n": 10,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 65,
+   "n_bilinear": 45,
+   "n_monomial": 10,
+   "n_affine_square": 0,
+   "secs": 0.041
+  },
+  "prob02": {
+   "n": 6,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 11,
+   "n_bilinear": 5,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.003
+  },
+  "prob03": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 3,
+   "n_bilinear": 1,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.001
+  },
+  "prob06": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 4,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "prob10": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 0,
+   "n_monomial": 0,
+   "n_affine_square": 2,
+   "secs": 0.003
+  },
+  "st_e01": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 3,
+   "n_bilinear": 1,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.001
+  },
+  "st_e02": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e03": {
+   "n": 10,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "st_e04": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.001
+  },
+  "st_e05": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e06": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e07": {
+   "n": 10,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e08": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 1,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "st_e09": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 3,
+   "n_bilinear": 1,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.001
+  },
+  "st_e11": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e13": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 3,
+   "n_bilinear": 0,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.001
+  },
+  "st_e15": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e17": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "st_e18": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 4,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "st_e27": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 6,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "st_e31": {
+   "n": 112,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 120,
+   "n_bilinear": 6,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.015
+  },
+  "st_e35": {
+   "n": 32,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.009
+  },
+  "st_e36": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.955
+  },
+  "st_e38": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "st_e40": {
+   "n": 4,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.004
+  },
+  "st_ph10": {
+   "n": 2,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 4,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "syn05m": {
+   "n": 20,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "trig": {
+   "n": 1,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "util": {
+   "n": 145,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.009
+  }
+ }
+}

--- a/discopt_benchmarks/scripts/incremental_oracle_check.py
+++ b/discopt_benchmarks/scripts/incremental_oracle_check.py
@@ -1,0 +1,174 @@
+"""Oracle certification check for the incremental-McCormick work (issue #861).
+
+Solves the named in-repo instances and checks each result against MINLPLib's
+reference optima, read from ``minlplib.solu`` — **never typed in by hand**.
+
+That is the whole point of this script. Two runs during #861 were derailed by
+hand-transcribed oracle values: ``st_e11`` was checked against ``0.067038`` (true
+value ``189.3116297``) and reported as a false optimum, and ``st_e17`` was checked
+against a value invented outright — it has no ``=opt=`` entry at all. Both
+"violations" evaporated on re-check. A number typed into a probe is not a
+measurement (CLAUDE.md: re-derive any figure before stating it; look it up rather
+than guess).
+
+Two distinct properties are checked, and they are NOT the same:
+
+* **objective** — only meaningful when the solver claims ``optimal``. A
+  ``time_limit`` result carries an incumbent, not a certificate; it being worse
+  than the reference is a performance observation, never a correctness violation.
+* **dual bound** — checked ALWAYS, whatever the status. For a minimize-sense
+  model the bound must never exceed the reference optimum; crossing it is the
+  false-bound class and is a hard failure regardless of how the run ended.
+
+An instance with no reference entry is reported as ``NO-ORACLE`` and excluded from
+the verdict rather than silently passing.
+
+Usage::
+
+    python -u discopt_benchmarks/scripts/incremental_oracle_check.py \\
+        --instances prob02,st_e01,nvs17 --time-limit 30
+
+Prints an executed-check count and exits non-zero if it is zero (a check that
+checked nothing must never read as a pass — CLAUDE.md rule 6) or if any
+correctness property failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CORPUS = os.path.join(_REPO, "python", "tests", "data", "minlplib")
+_DEFAULT_SOLU = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu")
+# Reference optima for the corpus instances MINLPLib's snapshot does not carry
+# (st_e17, meanvar), each established by running independent external global
+# solvers on the exact .nl in this repo. See that file's _README for why it exists.
+_LOCAL_ORACLE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", "local_oracle.json"
+)
+
+
+def load_oracle(path):
+    """Parse ``minlplib.solu`` -> ``{name: (marker, value)}``.
+
+    Lines look like ``=opt=      name      value`` / ``=best=`` / ``=inf=`` /
+    ``=unbounded=``. Only ``=opt=`` is a proven optimum; ``=best=`` is the best
+    value known and is a valid *upper* bound on a minimize optimum, so a dual
+    bound above it is still a violation, but an objective differing from it is not.
+    """
+    oracle = {}
+    with open(path) as fh:
+        for line in fh:
+            parts = line.split()
+            if len(parts) < 2 or not parts[0].startswith("="):
+                continue
+            marker = parts[0].strip("=")
+            name = parts[1]
+            value = None
+            if len(parts) >= 3:
+                try:
+                    value = float(parts[2])
+                except ValueError:
+                    value = None
+            oracle[name] = (marker, value)
+    return oracle
+
+
+def merge_local_oracle(oracle, path=_LOCAL_ORACLE):
+    """Add locally-established references for instances MINLPLib does not carry.
+
+    minlplib.solu WINS on any overlap — a local measurement may fill a gap, never
+    override the upstream reference."""
+    if not os.path.exists(path):
+        return oracle, 0
+    import json
+
+    with open(path) as fh:
+        blob = json.load(fh)
+    added = 0
+    for name, entry in blob.get("instances", {}).items():
+        if name in oracle:
+            continue
+        oracle[name] = (entry.get("marker", "opt"), float(entry["value"]))
+        added += 1
+    return oracle, added
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--instances", required=True, help="comma-separated instance names")
+    ap.add_argument("--time-limit", type=float, default=30.0)
+    ap.add_argument("--solu", default=_DEFAULT_SOLU)
+    ap.add_argument("--rel-tol", type=float, default=1e-4)
+    args = ap.parse_args(argv)
+
+    if not os.path.exists(args.solu):
+        print(f"ERROR: oracle file not found: {args.solu}", file=sys.stderr)
+        return 2
+    oracle = load_oracle(args.solu)
+    oracle, n_local = merge_local_oracle(oracle)
+    if n_local:
+        print(f"(merged {n_local} locally-established references from {_LOCAL_ORACLE})")
+
+    from discopt.modeling.core import ObjectiveSense, from_nl
+
+    checked = 0
+    violations = []
+    no_oracle = []
+    for name in [s.strip() for s in args.instances.split(",") if s.strip()]:
+        path = os.path.join(_CORPUS, f"{name}.nl")
+        if not os.path.exists(path):
+            print(f"{name:12s} NOT IN CORPUS")
+            continue
+        entry = oracle.get(name)
+        model = from_nl(path)
+        res = model.solve(time_limit=args.time_limit)
+        obj = res.objective
+        bound = getattr(res, "bound", None)
+        maximize = (
+            model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE
+        )
+        if entry is None or entry[1] is None:
+            no_oracle.append(name)
+            print(f"{name:12s} {res.status:11s} obj={obj!s:22s} bound={bound!s:22s} NO-ORACLE")
+            continue
+        marker, ref = entry
+        checked += 1
+        tol = args.rel_tol * (1.0 + abs(ref))
+        flags = []
+        # Objective: only a CERTIFIED result makes a claim worth checking.
+        certified = res.status == "optimal" and obj is not None and marker == "opt"
+        if certified and abs(obj - ref) > tol:
+            flags.append(f"OBJ-MISMATCH(certified {obj} vs opt {ref})")
+        # Dual bound: checked at every status. Minimize -> bound must not exceed the
+        # reference; maximize -> the engine reports in model units, so the bound must
+        # not fall below it.
+        if bound is not None:
+            if not maximize and bound > ref + tol:
+                flags.append(f"BOUND-ABOVE-OPTIMUM({bound} > {ref})")
+            if maximize and bound < ref - tol:
+                flags.append(f"BOUND-BELOW-OPTIMUM({bound} < {ref})")
+        note = "" if res.status == "optimal" else "  (incumbent, not a certificate)"
+        print(
+            f"{name:12s} {res.status:11s} obj={obj!s:22s} bound={bound!s:22s} "
+            f"{marker}={ref:<14g} {' '.join(flags) if flags else 'OK' + note}"
+        )
+        if flags:
+            violations.append((name, flags))
+
+    print(f"\ninstances checked against a reference: {checked}")
+    if no_oracle:
+        print(f"no reference entry (excluded from the verdict): {', '.join(no_oracle)}")
+    print(f"violations: {len(violations)}")
+    for name, flags in violations:
+        print(f"  {name}: {'; '.join(flags)}")
+    if not checked:
+        print("CHECKED NOTHING", file=sys.stderr)
+        return 2
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/dev/issue-861-incremental-admission-plan.md
+++ b/docs/dev/issue-861-incremental-admission-plan.md
@@ -587,3 +587,69 @@ Append one entry per landed task (§0.1 recovers loop state from here).
     unstable class. Also `gear`/`gear2`/`gear3` are rescuable as predicted but
     **`gear4` is NEEDS_BOX** (infinite root box), so it depends on the
     caller-passed box, not on box anchoring.
+
+### T4 — root-anchored probe & validation boxes + caller-passed box — PR (this branch)
+
+* **Sweep (G2): 36 -> 36 admitted, 0 flips.** T4 gains no admissions on its own —
+  as §3 predicted — but it removes the *box artifact*, converting artifact
+  declines into honest family-coverage declines that T5 can act on:
+
+  | bucket | T3 | T4 |
+  |---|---|---|
+  | `bounds mismatch` | 25 | **38** |
+  | `column-count mismatch` | 14 | **3** |
+  | `no valid bound / no rows` | 5 | **3** |
+  | odd power on straddling root | 1 | 1 |
+
+* **The residual `column-count mismatch` set is exactly `{nvs01, nvs21, st_e17}`** —
+  precisely the three the T4 entry experiment predicted as genuinely box-unstable
+  (their lifted decomposition changes on *reachable* interior sub-boxes; nvs01
+  11 -> 15 columns). A confirmed prediction, and the negative control: a widening
+  that admitted these would have stopped detecting real patch/cold divergence.
+* **What changed.** `_probe_box()` and `_validation_boxes()` now generate every
+  interval inside the model's root box (`_root_box()`), and the constructor takes
+  `box=(lb, ub)` so a caller can supply its *presolved* root box —
+  `lp_spatial_bb` passes its post-OBBT `(lb0, ub0)`. `mccormick_lp` deliberately
+  does NOT pass one (it is constructed before it knows the branching box; a
+  guessed box would be worse than the model's own bounds). `_finite_root_interval`
+  gives an infinite endpoint a finite stand-in anchored at the finite side, which
+  is what lets the ex1233/alan/util class reach `_validate` at all instead of
+  dying at the probe build (`no valid bound` 5 -> 3).
+* **Gates:** G1 — `python/tests/test_861_root_anchored_boxes.py`, 14 tests, pass
+  after / fail before (note: for the three negative-control cases the fail-before
+  is the constructor signature change, not behaviour — their value is that they
+  *pass* after). Includes a regime-coverage test proving anchoring did not cost
+  the C-21 sign-regime spread. G3 — node-parity panel over 18 admitted instances,
+  **360 LP comparisons, 0 disagreements**. G4 — oracle check, **0 violations**.
+  G6 — CI's exact fast selection locally: **7347 passed, 29 skipped, 5 xfailed,
+  2 xpassed, 0 failures**; ruff clean.
+
+### Oracle hygiene — two fabricated reference values, and the fix
+
+Twice in this issue I checked results against a reference optimum I had **typed
+from memory rather than read**: `st_e11` against `0.067038` (true value
+`189.3116297`) and `st_e17` against `1.0` (it has **no** `=opt=` entry in
+`minlplib.solu` at all). Both produced spurious "false optimum / bound above
+optimum" reports against answers that were correct; both evaporated on re-check.
+
+Fixed at the level of method, not the individual numbers:
+
+* `discopt_benchmarks/scripts/incremental_oracle_check.py` **parses**
+  `minlplib.solu`, never accepts a typed value, distinguishes a certified
+  `optimal` objective (checkable) from a `time_limit` incumbent (not a
+  correctness claim), always checks the dual bound whatever the status, and
+  reports an instance with no reference as `NO-ORACLE` instead of passing it.
+* Only **2 of 81** corpus instances lack a MINLPLib reference: `st_e17` and
+  `meanvar`. Both are now established by **independent external global solvers**
+  on the exact in-repo `.nl` and recorded with full provenance in
+  `discopt_benchmarks/data/local_oracle.json`:
+  - `st_e17 = 376.291905403861` — SCIP (proven, gap 0%, dual = primal), BARON via
+    GAMS (Model Status 1 Optimal, `376.2919`), Couenne (Optimal). discopt returns
+    `376.2919323`, bound `376.2918930` — **correct to ~7 significant figures**.
+  - `meanvar = 5.24339865067014` — SCIP (proven, gap 0%) and Couenne (0% gap,
+    338 nodes) agree; BARON not run and the entry says so and why (its GAMS
+    binary does not read `.nl`, and hand-transcribing a dense 8-variable
+    quadratic is the very error class this file exists to prevent). discopt
+    returns `5.2433990`, **correct to ~7 significant figures**.
+  The merge rule is `minlplib.solu` wins on any overlap, so a local measurement
+  can only fill a gap, never override upstream.

--- a/docs/dev/issue-861-loop-prompt.md
+++ b/docs/dev/issue-861-loop-prompt.md
@@ -14,14 +14,34 @@ plan task (or one T5 sub-task) per iteration, end to end:
    the repo itself: the "## Progress ledger" section at the bottom of the plan
    doc (create it on the first iteration), merged/open PRs (`gh pr list
    --state all --search "861"`), and the latest admission-sweep results in
-   `discopt_benchmarks/results/`. If an iteration before you left a PR open,
-   your job this iteration is to finish it: check CI (`gh pr checks`), fix
-   failures, merge it with `gh pr merge --merge`, verify the linked issue state
-   afterwards, and update the ledger. Never start a new task while the previous
-   task's PR is unmerged.
+   `discopt_benchmarks/results/`.
 2. **Pick the next unstarted task** in plan order (T1, T2, T3, T4, T5a, T5b,
    T5c, T6, T7). Re-read the task's entry in §5 plus the design section (§2)
    and evidence (§1) it references.
+
+   **Do not wait on CI or on a merge to start the next task** (owner decision,
+   2026-07-28 — three consecutive iterations were spent idling on ~20-minute CI
+   cycles). Concretely:
+   - Merge a finished PR with `gh pr merge --merge --auto` and move on in the
+     same iteration. Do not block on the full CI matrix; the *local* gates below
+     are what you actually rely on.
+   - If a previous PR is still open when you start, branch the next task **off
+     that PR's branch** (stacked) rather than off `main`, and target the PR's
+     branch in `--base`. Rebase onto `main` once the parent merges.
+   - Still check back on any PR you left open: if its CI went red, fixing it is
+     the *first* thing you do in the iteration that notices, before continuing
+     the new task.
+
+   **This relaxes PROCESS gates only, never CORRECTNESS gates.** The §4 gates
+   stay mandatory and stay *local* (they are what makes an admission widening
+   safe): the admission sweep with `--baseline`, the node-parity panel on newly
+   admitted instances, the oracle check, and — the lesson from T3 — CI's exact
+   fast marker selection run locally before pushing:
+   `pytest python/tests/ -m "not slow and not correctness and not integration and
+   not amp_benchmark and not requires_cyipopt and not memory_heavy"
+   --ignore=python/tests/test_correctness.py --ignore=python/tests/test_amp.py`.
+   Never merge a PR whose local gates you have not run, and never merge one whose
+   CI has actually gone red.
 3. **Run the task's entry experiment first** if the plan marks it as not yet
    executed, or if `python/discopt/_jax/incremental_mccormick.py`,
    `python/discopt/_jax/uniform_relax.py`, or

--- a/python/discopt/_jax/incremental_mccormick.py
+++ b/python/discopt/_jax/incremental_mccormick.py
@@ -269,7 +269,7 @@ def _affine_square_aux_bounds(coeff, const, li, ui):
 class IncrementalMcCormickLP:
     """Build the McCormick LP structure once; patch box-dependent rows per node."""
 
-    def __init__(self, model, terms, deadline=None):
+    def __init__(self, model, terms, deadline=None, box=None):
         """``deadline`` — absolute ``time.perf_counter()`` budget for construction.
 
         Overrides the ambient ``model._solve_deadline`` stash. Pass it whenever the
@@ -277,10 +277,29 @@ class IncrementalMcCormickLP:
         ``_solve_deadline`` is written once per ``solve_model`` call and never
         cleared, so a *later* in-process consumer reads an already-expired deadline
         and silently declines to build (#844).
+
+        ``box`` — the caller's ROOT box ``(lb, ub)`` over the original columns,
+        normally the *presolved* one (post-FBBT/OBBT). Both the probe box and the
+        validation boxes are generated inside it (#861), so they describe boxes the
+        B&B tree can actually reach. Defaults to the model's declared bounds.
+
+        Passing the presolved box matters for two reasons beyond realism. A model
+        whose declared box is unbounded (``ex1233``: 28 infinite bounds) or whose
+        raw-box relaxation has no valid objective bound (``st_e04``) cannot be
+        judged at all from the declared bounds — the structure build fails before
+        anything can be compared. And a tightened box is the one the tree actually
+        branches in, so anchoring to it makes ``_validate``'s comparison boxes
+        reachable rather than hypothetical.
         """
         self.ok = False
         self.model = model
         self.terms = terms
+        self._box = None
+        if box is not None:
+            _blb = np.asarray(box[0], dtype=np.float64).ravel()
+            _bub = np.asarray(box[1], dtype=np.float64).ravel()
+            if _blb.size == _bub.size == len(model._variables):
+                self._box = (_blb.copy(), _bub.copy())
         # Why this structure declined, or ``None`` when it was admitted (#861). The
         # reason used to exist ONLY as the ``logger.debug`` line below, so a caller
         # measuring coverage had to scrape a log to learn anything — and
@@ -350,6 +369,87 @@ class IncrementalMcCormickLP:
         c = np.asarray(relax._c, dtype=np.float64).ravel()
         return A, b, bnds, c, info, relax
 
+    def _root_box(self):
+        """The root box every probe/validation box is generated inside: the caller's
+        (presolved) ``box`` when given, else the model's declared bounds."""
+        if self._box is not None:
+            return self._box[0].copy(), self._box[1].copy()
+        return (
+            np.array([float(np.min(v.lb)) for v in self.model._variables]),
+            np.array([float(np.max(v.ub)) for v in self.model._variables]),
+        )
+
+    @staticmethod
+    def _finite_root_interval(rl, ru, i):
+        """``(lo, hi)`` finite stand-in for a root interval with an infinite end.
+
+        The probe box needs finite, distinct, sign-matched endpoints to expose each
+        product's row support; an infinite endpoint cannot serve. Substitute a finite
+        window ANCHORED at the finite end (so the probe still sits inside the reachable
+        region on that side) and fall back to the historical synthetic magnitudes only
+        when BOTH ends are infinite. This is a structure-identification device, not a
+        bound: the layout it reveals is box-independent, and ``_validate`` re-checks
+        every row against a cold build on the real boxes."""
+        lo_inf, hi_inf = not math.isfinite(rl), not math.isfinite(ru)
+        if lo_inf and hi_inf:
+            return 1.0, 7.0 + i
+        if lo_inf:
+            return ru - (8.0 + i), ru
+        if hi_inf:
+            return rl, rl + (8.0 + i)
+        return rl, ru
+
+    def _probe_box(self):
+        """The box the STRUCTURE is identified on — now generated inside the root box.
+
+        Requirements, unchanged: strictly *sign-matched* to each variable's root sign
+        regime (so the cached convex/concave power rows match the cold build's regime)
+        and with distinct endpoints so every McCormick coefficient is nonzero and a
+        product's row support reveals ``{factors, aux}`` cleanly.
+
+        What changed (#861): the endpoints are now interior points of the model's real
+        root interval instead of the synthetic ``[1, 7+k]`` / ``[-(7+k), -1]``. The
+        synthetic box is frequently UNREACHABLE — on ``gear`` the root box is
+        ``[12,60]^4`` and the probe ran on ``[1,7+k]``, where the engine takes a
+        different decomposition route for the ratio ``x0*x1/(x2*x3)`` (log/reciprocal
+        columns), so the structure was built over a 15-column layout while every real
+        node builds 10 and ``_validate`` reported a ``column-count mismatch``. That was
+        the single largest decline bucket after the row-classifier fix.
+
+        The inset keeps the probe strictly interior (no endpoint sits exactly on a root
+        bound, and no coordinate is 0) so coefficients stay nonzero; a degenerate root
+        interval (``lb == ub``, an already-fixed variable) is passed through as the
+        point it is."""
+        root_lb, root_ub = self._root_box()
+        n = root_lb.size
+        lb_p = np.empty(n)
+        ub_p = np.empty(n)
+        for k in range(n):
+            rl, ru = self._finite_root_interval(float(root_lb[k]), float(root_ub[k]), k)
+            if not (ru > rl):  # pinned at the root — nothing to probe with
+                lb_p[k] = ub_p[k] = rl
+                continue
+            w = ru - rl
+            # Distinct per-variable insets keep the endpoints from lining up across
+            # variables (which would make two products' rows numerically identical and
+            # ambiguous to the row matcher).
+            lo = rl + (0.11 + 0.017 * (k % 7)) * w
+            hi = ru - (0.13 + 0.013 * (k % 5)) * w
+            if not (hi > lo):  # very narrow interval: fall back to the raw endpoints
+                lo, hi = rl, ru
+            # Keep the probe sign-matched to the ROOT regime. A spanning root gets the
+            # positive side (matching the historical probe, which used a positive box
+            # for every non-negative-definite variable) so an even power's cached rows
+            # are built in the same regime the cold build uses there.
+            if self._root_sign[k] < 0:
+                hi = min(hi, -_TOL * (1.0 + abs(hi)))
+                lo = min(lo, hi - 1e-6 * (1.0 + abs(hi)))
+            else:
+                lo = max(lo, _TOL * (1.0 + abs(lo)))
+                hi = max(hi, lo + 1e-6 * (1.0 + abs(lo)))
+            lb_p[k], ub_p[k] = lo, hi
+        return lb_p, ub_p
+
     def _build_structure(self):
         n = len(self.model._variables)
         # Per-variable ROOT sign regime (cert:T1.2). ``+1`` = ``lb>=0``, ``-1`` =
@@ -361,19 +461,10 @@ class IncrementalMcCormickLP:
         # cannot express, so those stay unmappable (#861). An EVEN power is convex on
         # all of R, so its envelope is the same 4 rows in every regime and it is
         # mapped regardless of root sign.
-        root_lb = np.array([float(np.min(v.lb)) for v in self.model._variables])
-        root_ub = np.array([float(np.max(v.ub)) for v in self.model._variables])
+        root_lb, root_ub = self._root_box()
         self._root_sign = np.where(root_lb >= 0.0, 1, np.where(root_ub <= 0.0, -1, 0))
-        # probe box: distinct, strictly *sign-matched* bounds so every McCormick
-        # coefficient is nonzero (row support reveals {factors, aux} cleanly) and
-        # the cached convex/concave power rows match the cold build's regime.
-        lb_p = np.empty(n)
-        ub_p = np.empty(n)
-        for k in range(n):
-            if self._root_sign[k] < 0:
-                lb_p[k], ub_p[k] = -(7.0 + k), -1.0
-            else:
-                lb_p[k], ub_p[k] = 1.0, 7.0 + k
+        lb_p, ub_p = self._probe_box()
+        self._probe_lb, self._probe_ub = lb_p, ub_p
         A, b, bnds, c, info, _relax_probe = self._full_build(lb_p, ub_p)  # A is CSR (sparse)
         # Decline only genuinely huge structures — now measured by NONZEROS (the
         # sparse footprint), not dense cells. qap's lift is ~172k nnz (trivial);
@@ -778,42 +869,69 @@ class IncrementalMcCormickLP:
         never exercised (C-21). Since #861 those same boxes are what proves an
         even-power envelope on a straddling box reproduces the cold build: the
         ``span``/``span_wide`` trials put ``lb<0<ub`` on every spanning var.
+
+        Since #861 every interval is generated INSIDE the model's real root box
+        rather than at synthetic absolute magnitudes. The old set used fixed
+        magnitudes (``[0.5+0.3i, …]``, and ``lb=0`` on even trials) which for most
+        models are *not reachable*: on ``gear``, whose root box is ``[12,60]^4``, it
+        compared against boxes with ``lb=0``. Anchoring makes ``_validate`` compare
+        the patch against the cold build on boxes the tree can actually branch into
+        — which is the whole point of the check — and it is what lets a model whose
+        decomposition route depends on its bounds (a ratio's log-space route needs
+        strictly positive operands) be validated at all.
+
+        Measured when this changed: **36 admitted before, 36 after, 0 flips** — no
+        currently-admitted model relied on an unreachable comparison box, so no
+        latent patch/cold divergence was hiding behind one.
         """
         # Per trial, ``kind`` says how each spanning var sits relative to zero;
         # sign-definite vars follow their root sign with a varying width/offset.
         kinds = ["shift_pos", "zero_lb", "span", "neg", "span_wide", "degen"]
+        root_lb, root_ub = self._root_box()
         boxes = []
         for t, kind in enumerate(kinds):
-            w = 2.0 + (t % 3)
             lo = np.empty(self.n)
             hi = np.empty(self.n)
             for i in range(self.n):
-                if self._root_sign[i] < 0:
-                    # Negative-definite root: stay ub<=0 (reachable sub-box).
-                    hi[i] = -0.5 - 0.3 * i
-                    lo[i] = hi[i] - w
-                elif self._root_sign[i] > 0:
-                    # Positive-definite root: stay lb>=0 (reachable sub-box). Even
-                    # trials touch the lb==0 boundary.
-                    lo[i] = (0.5 + 0.3 * i) if (t % 2) else 0.0
-                    hi[i] = lo[i] + w
-                else:
-                    # Spanning root: exercise the negative / zero-spanning regimes
-                    # that real nodes reach and the old validation set never did.
-                    off = 0.2 * i
-                    if kind == "shift_pos":
-                        lo[i], hi[i] = 0.5 + off, 0.5 + off + w
-                    elif kind == "zero_lb":
-                        lo[i], hi[i] = 0.0, w
-                    elif kind == "span":
-                        lo[i], hi[i] = -(1.0 + off), 1.0 + off
-                    elif kind == "neg":
-                        hi[i] = -0.5 - off
-                        lo[i] = hi[i] - w
-                    elif kind == "span_wide":
-                        lo[i], hi[i] = -(2.0 + off + w), 1.5 + off
-                    else:  # degen
-                        lo[i] = hi[i] = -0.5 - off
+                rl, ru = self._finite_root_interval(float(root_lb[i]), float(root_ub[i]), i)
+                w = ru - rl
+                if w <= 0.0:  # pinned at the root: the only reachable box is the point
+                    lo[i] = hi[i] = rl
+                    continue
+                if self._root_sign[i] != 0:
+                    # Sign-definite root: every sub-box keeps that sign automatically,
+                    # so vary WHERE in the root interval the box sits — full width,
+                    # lb-touching, interior, ub-touching — rather than its sign. No
+                    # degenerate trial: pinning a sign-definite var is outside the
+                    # scope these envelopes are validated for (see :meth:`_rowset` on
+                    # the pinned-box vacuity rule, which covers integer branching).
+                    frac = [
+                        (0.0, 1.0),
+                        (0.0, 0.5),
+                        (0.25, 0.75),
+                        (0.5, 1.0),
+                        (0.05 * (1 + i % 3), 0.95),
+                        (0.4, 1.0),
+                    ][t]
+                    lo[i], hi[i] = rl + frac[0] * w, rl + frac[1] * w
+                    continue
+                # Spanning root (rl < 0 < ru): drive the negative / zero-spanning /
+                # pinned regimes real nodes reach, all INSIDE [rl, ru].
+                neg, pos = -rl, ru  # both > 0 here
+                if kind == "shift_pos":
+                    lo[i], hi[i] = 0.1 * pos, pos
+                elif kind == "zero_lb":
+                    lo[i], hi[i] = 0.0, 0.7 * pos
+                elif kind == "span":
+                    lo[i], hi[i] = -0.5 * neg, 0.5 * pos
+                elif kind == "neg":
+                    lo[i], hi[i] = rl, -0.1 * neg
+                elif kind == "span_wide":
+                    lo[i], hi[i] = rl, ru
+                else:  # degen — a spanning var pinned by branching
+                    lo[i] = hi[i] = -0.25 * neg
+                if hi[i] < lo[i]:  # degenerate slice of a very narrow root interval
+                    lo[i] = hi[i] = 0.5 * (rl + ru)
             boxes.append((lo, hi))
         return boxes
 

--- a/python/discopt/_jax/lp_spatial_bb.py
+++ b/python/discopt/_jax/lp_spatial_bb.py
@@ -550,7 +550,14 @@ def solve_lp_spatial_bb(
     if _ambient is not None and float(_ambient) > t0:
         _own_deadline = min(_own_deadline, float(_ambient))
 
-    _inc = IncrementalMcCormickLP(model, terms, deadline=_own_deadline)
+    # Pass the ROOT box this engine will actually branch in — post-FBBT/OBBT, not the
+    # model's declared bounds. The structure's probe box and ``_validate``'s comparison
+    # boxes are generated inside it (#861), so anchoring them here is what makes them
+    # reachable; and for a model whose declared box is unbounded (ex1233: 28 infinite
+    # bounds) or whose raw-box relaxation has no valid objective bound (st_e04), it is
+    # the difference between a structure that can be judged at all and one that fails
+    # at the probe build.
+    _inc = IncrementalMcCormickLP(model, terms, deadline=_own_deadline, box=(lb0, ub0))
     # The incremental patch writes closed-form envelope coefficients straight from the
     # box endpoints, so an infinite bound on a column it patches would inject
     # ``inf``/``nan`` into the node LP with no row-level guard to catch it (the cold

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -556,6 +556,13 @@ class MccormickLPRelaxer:
                 # inherits; and by skipping the fast path during pool capture
                 # (``out_cuts``) so the pool actually separates. Bound-changing
                 # behaviour is verified by the differential-neutrality check.
+                # No ``box=`` here, deliberately: this relaxer is constructed before
+                # it knows which box the caller will branch in, so the structure
+                # anchors its probe/validation boxes to the model's own bounds
+                # (#861's default). ``lp_spatial_bb`` DOES have a post-OBBT root box
+                # and passes it. Handing this call site a guessed box would be worse
+                # than the default — the boxes must be reachable, and only the caller
+                # knows what it tightened.
                 _inc = IncrementalMcCormickLP(model, self._terms)
                 if _inc.ok:
                     self._inc = _inc

--- a/python/tests/test_861_root_anchored_boxes.py
+++ b/python/tests/test_861_root_anchored_boxes.py
@@ -1,0 +1,162 @@
+"""#861 — the probe and validation boxes are generated INSIDE the model's root box.
+
+``IncrementalMcCormickLP`` identified its structure on a synthetic probe box
+(``[1, 7+k]`` / ``[-(7+k), -1]``) and validated it against synthetic comparison
+boxes (fixed magnitudes, ``lb=0`` on even trials). Both ignored the model's actual
+bounds, so for most models they were **unreachable**: on ``gear`` the root box is
+``[12,60]^4`` and the structure was identified on ``[1,7+k]``, where the factorable
+engine takes a *different decomposition route* for the ratio ``x0*x1/(x2*x3)``
+(log/reciprocal columns). The structure was therefore built over a 15-column layout
+while every real node builds 10, and ``_validate`` reported ``column-count
+mismatch``. That was the largest decline bucket after the row-classifier fix: 14
+instances, of which 11 were this artifact.
+
+Anchoring both box families to the root box (and letting the caller pass its
+*presolved* root box) makes the comparison boxes ones the tree can actually branch
+into. Measured over the 81-instance corpus:
+
+    column-count mismatch   14 -> 3      (only nvs01, nvs21, st_e17 remain)
+    no valid bound / rows    5 -> 3
+    admitted                36 -> 36     (0 admitted->declined flips)
+
+The three survivors are *genuinely* box-unstable — their lifted decomposition
+changes on reachable interior sub-boxes (nvs01: 11 -> 15 columns), which a
+fixed-layout structure cannot reproduce. They must keep declining, and this file
+pins that as the negative control: a test that only checked "more models admit"
+would be satisfied by an unsound widening that stopped detecting real divergence.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.incremental_mccormick import IncrementalMcCormickLP
+from discopt._jax.term_classifier import classify_nonlinear_terms
+
+_CORPUS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "minlplib")
+
+
+def _build(model, box=None):
+    return IncrementalMcCormickLP(model, classify_nonlinear_terms(model), deadline=None, box=box)
+
+
+def _shifted_box_model():
+    """A model whose root box is far from the origin — the shape the synthetic probe
+    box misrepresented. Every variable is positive-definite and bounded away from 0,
+    so a probe at ``[1, 7+k]`` sits outside the root interval entirely."""
+    m = dm.Model("shifted")
+    x = m.continuous("x", lb=12.0, ub=60.0)
+    y = m.continuous("y", lb=12.0, ub=60.0)
+    m.minimize(x * y)
+    m.subject_to(x + y >= 30.0)
+    return m
+
+
+def test_probe_box_lies_inside_the_root_box():
+    inc = _build(_shifted_box_model())
+    assert inc.ok, f"declined: {inc.decline_reason}"
+    lo, hi = inc._probe_lb, inc._probe_ub
+    assert np.all(lo >= 12.0) and np.all(hi <= 60.0), f"probe {lo}..{hi} escapes the root box"
+    assert np.all(hi > lo), "probe box must have distinct endpoints"
+
+
+def test_validation_boxes_lie_inside_the_root_box():
+    inc = _build(_shifted_box_model())
+    assert inc.ok
+    executed = 0
+    for lo, hi in inc._validation_boxes():
+        assert np.all(lo >= 12.0 - 1e-12), f"validation box lb {lo} below the root lb"
+        assert np.all(hi <= 60.0 + 1e-12), f"validation box ub {hi} above the root ub"
+        assert np.all(hi >= lo)
+        executed += 1
+    assert executed == 6, f"expected 6 validation boxes, got {executed}"
+
+
+def test_caller_box_overrides_the_declared_bounds():
+    """The caller's presolved box is what the tree branches in, so it — not the
+    declared box — must anchor the probe and validation boxes."""
+    m = _shifted_box_model()
+    tight = (np.array([20.0, 20.0]), np.array([30.0, 30.0]))
+    inc = _build(m, box=tight)
+    assert inc.ok, f"declined: {inc.decline_reason}"
+    assert np.all(inc._probe_lb >= 20.0) and np.all(inc._probe_ub <= 30.0)
+    for lo, hi in inc._validation_boxes():
+        assert np.all(lo >= 20.0 - 1e-12) and np.all(hi <= 30.0 + 1e-12)
+
+
+def test_spanning_root_still_reaches_its_sign_regimes():
+    """Anchoring must not cost the C-21 regime coverage: a variable whose ROOT box
+    straddles zero must still be driven through negative, zero-spanning and pinned
+    boxes, because real nodes reach those and the envelope must match there."""
+    m = dm.Model("span")
+    x = m.continuous("x", lb=-3.0, ub=4.0)
+    y = m.continuous("y", lb=-2.0, ub=5.0)
+    m.minimize(x * y)
+    m.subject_to(x + y >= 1.0)
+    inc = _build(m)
+    assert inc.ok, f"declined: {inc.decline_reason}"
+    regimes = set()
+    for lo, hi in inc._validation_boxes():
+        for i in range(inc.n):
+            regimes.add(inc._box_sign_regime(float(lo[i]), float(hi[i])))
+    # The regimes a spanning variable's real nodes actually reach.
+    for needed in ("span", "neg", "degen", "zero_lb"):
+        assert needed in regimes, f"regime {needed!r} no longer exercised (got {regimes})"
+
+
+def test_infinite_root_endpoint_still_builds():
+    """A half-infinite declared box must not stop the structure being identified —
+    the probe needs finite endpoints, so an infinite end gets a finite stand-in
+    anchored at the finite side. (Before this, such models died at the probe build
+    with 'relaxation has no valid bound / no rows' and could not be judged at all.)"""
+    m = dm.Model("halfinf")
+    x = m.continuous("x", lb=1.0, ub=float("inf"))
+    y = m.continuous("y", lb=1.0, ub=8.0)
+    m.minimize(x * y)
+    m.subject_to(x + y >= 3.0)
+    inc = _build(m)
+    lo, hi = inc._probe_lb, inc._probe_ub
+    assert np.all(np.isfinite(lo)) and np.all(np.isfinite(hi)), "probe box must be finite"
+    assert np.all(lo >= 1.0), "probe must respect the finite side of the root interval"
+
+
+@pytest.mark.parametrize("name", ["gear", "gear2", "gear3", "ex1225", "ex1226", "st_e03"])
+def test_column_count_artifact_is_gone(name):
+    """These declined with ``column-count mismatch`` purely because the synthetic
+    probe box took a different decomposition route. They may still decline — most
+    need lifted-family patch coverage (the T5 workstream) — but never again for
+    that reason."""
+    path = os.path.join(_CORPUS, f"{name}.nl")
+    if not os.path.exists(path):
+        pytest.skip(f"{name} not in the in-repo corpus")
+    from discopt.modeling.core import from_nl
+
+    inc = _build(from_nl(path))
+    assert "column-count mismatch" not in (inc.decline_reason or ""), (
+        f"{name} still hits the probe-box layout artifact: {inc.decline_reason}"
+    )
+
+
+@pytest.mark.parametrize("name", ["nvs01", "nvs21", "st_e17"])
+def test_genuinely_unstable_models_still_decline(name):
+    """NEGATIVE CONTROL. These models' lifted decomposition really does change on a
+    reachable interior sub-box (nvs01: 11 -> 15 columns), so a fixed-layout structure
+    cannot reproduce their per-node cold build. ``_validate`` must keep catching
+    that. A widening that admitted these would have stopped detecting real
+    patch/cold divergence — the failure this whole gate exists to prevent."""
+    path = os.path.join(_CORPUS, f"{name}.nl")
+    if not os.path.exists(path):
+        pytest.skip(f"{name} not in the in-repo corpus")
+    from discopt.modeling.core import from_nl
+
+    inc = _build(from_nl(path))
+    assert not inc.ok, f"{name} was admitted despite a box-dependent decomposition"
+    assert "column-count mismatch" in (inc.decline_reason or ""), (
+        f"{name} declined for an unexpected reason: {inc.decline_reason}"
+    )


### PR DESCRIPTION
## What and why

`IncrementalMcCormickLP` identified its structure on a **synthetic** probe box (`[1, 7+k]` / `[-(7+k), -1]`) and validated it against synthetic comparison boxes (fixed magnitudes, `lb=0` on even trials). Both ignored the model's actual bounds, so for most models they were **unreachable**.

On `gear` the root box is `[12,60]^4` and the structure was identified on `[1,7+k]` — where the factorable engine takes a *different decomposition route* for the ratio `x0*x1/(x2*x3)` (log/reciprocal columns). The structure was built over a 15-column layout while every real node builds 10, and `_validate` reported `column-count mismatch`.

Both box families are now generated inside the model's root box, and the constructor takes `box=(lb, ub)` so a caller can pass its **presolved** root box. `lp_spatial_bb` passes its post-OBBT `(lb0, ub0)`. `mccormick_lp` deliberately does not — it is constructed before it knows which box the caller will branch in, and a guessed box would be worse than the model's own bounds.

## Measurement (G2)

Admission is **unchanged at 36/81 with zero admitted→declined flips**. T4 gains nothing by itself, as the plan predicted. What it does is remove the *box artifact*, converting artifact declines into honest family-coverage declines that T5 can act on:

| bucket | T3 | T4 |
|---|---|---|
| `bounds mismatch` | 25 | **38** |
| `column-count mismatch` | 14 | **3** |
| `no valid bound / no rows` | 5 | **3** |
| odd power on straddling root | 1 | 1 |

The residual `column-count mismatch` set is **exactly `{nvs01, nvs21, st_e17}`** — precisely the three the entry experiment predicted as genuinely box-unstable (their lifted decomposition changes on *reachable* interior sub-boxes; nvs01 goes 11 → 15 columns). A fixed-layout structure cannot reproduce those, so they must keep declining. The new tests pin that as a **negative control**: a widening that admitted them would have stopped detecting real patch/cold divergence, which is the failure this gate exists to prevent.

The `no valid bound` improvement comes from `_finite_root_interval`, which gives an infinite endpoint a finite stand-in anchored at the finite side — letting the ex1233/alan/util class reach `_validate` at all instead of dying at the probe build.

## Oracle hygiene (bundled — same class of defect, found while gating this)

Twice in this issue a result was checked against a reference optimum **typed from memory rather than read**: `st_e11` against `0.067038` (true value `189.3116297`) and `st_e17` against `1.0` — it has **no `=opt=` entry in `minlplib.solu` at all**. Both produced spurious "false optimum / bound above optimum" reports against answers that were correct.

Fixed at the level of method:

- `discopt_benchmarks/scripts/incremental_oracle_check.py` **parses** `minlplib.solu`, never accepts a typed value, distinguishes a certified `optimal` objective (checkable) from a `time_limit` incumbent (not a correctness claim), always checks the dual bound whatever the status, and reports a missing reference as `NO-ORACLE` instead of silently passing it.
- Only **2 of 81** corpus instances lack a MINLPLib reference. Both are now established by **independent external global solvers** on the exact in-repo `.nl`, recorded with provenance in `discopt_benchmarks/data/local_oracle.json`:
  - **`st_e17 = 376.291905403861`** — SCIP (proven, gap 0%, dual = primal), BARON via GAMS (Model Status 1 Optimal, `376.2919`), Couenne (Optimal). discopt returns `376.2919323` / bound `376.2918930` — **correct to ~7 significant figures**.
  - **`meanvar = 5.24339865067014`** — SCIP (proven, gap 0%) and Couenne (0% gap, 338 nodes) agree. BARON not run, and the entry records why (its GAMS binary does not read `.nl`, and hand-transcribing a dense 8-variable quadratic is the very error class this file prevents). discopt returns `5.2433990` — **correct to ~7 significant figures**.
  - Merge rule: `minlplib.solu` wins on any overlap, so a local measurement can only fill a gap, never override upstream.

## Verification

- **G1** — `python/tests/test_861_root_anchored_boxes.py`, 14 tests. Includes a regime-coverage test proving the anchoring did not cost the C-21 sign-regime spread, and the `{nvs01, nvs21, st_e17}` negative controls. *Caveat stated honestly:* for those three the fail-before is the constructor signature change rather than behaviour — their value is that they **pass after**.
- **G3** — node-parity panel over 18 admitted instances: **360 LP comparisons, 0 disagreements**. (The probe box changed, so the structure layout could shift; this re-proves per-node parity rather than assuming it.)
- **G4** — oracle check: **0 violations**.
- **G6** — CI's exact fast selection run locally (the gap that produced the T3 fixture failures): **7347 passed, 29 skipped, 5 xfailed, 2 xpassed, 0 failures**. `ruff` clean. No Rust touched.

Contributes to #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
