### PR TITLE
docs(#861): T6 won't-fix decision, T7 close-out, and the measurements that stopped T5

### DIFF
--- a/discopt_benchmarks/results/issue861_admission_final_20260728.json
+++ b/discopt_benchmarks/results/issue861_admission_final_20260728.json
@@ -1,0 +1,798 @@
+{
+ "admitted": 36,
+ "declined": 45,
+ "instances": {
+  "alan": {
+   "n": 8,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.012
+  },
+  "carton7": {
+   "n": 328,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 528,
+   "n_bilinear": 200,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.155
+  },
+  "chance": {
+   "n": 4,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "dispatch": {
+   "n": 4,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 10,
+   "n_bilinear": 3,
+   "n_monomial": 3,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "ex1221": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1222": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1223a": {
+   "n": 7,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 13,
+   "n_bilinear": 0,
+   "n_monomial": 3,
+   "n_affine_square": 3,
+   "secs": 0.004
+  },
+  "ex1225": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1226": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex1233": {
+   "n": 52,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.01
+  },
+  "ex1252": {
+   "n": 39,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.007
+  },
+  "ex1252a": {
+   "n": 24,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.005
+  },
+  "ex1263": {
+   "n": 92,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 108,
+   "n_bilinear": 16,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.015
+  },
+  "ex1264": {
+   "n": 88,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 104,
+   "n_bilinear": 16,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.021
+  },
+  "ex1265": {
+   "n": 130,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 155,
+   "n_bilinear": 25,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.021
+  },
+  "ex1266": {
+   "n": 180,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 216,
+   "n_bilinear": 36,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.03
+  },
+  "ex8_1_1": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "ex8_5_4": {
+   "n": 5,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: monomial x_2^3: odd power on a root box spanning zero (the envelope switches between the 4-row secant/tangent hull and the 2-facet S-hull, which the fixed row pattern cannot express)",
+   "bucket": "odd power on straddling root",
+   "secs": 0.002
+  },
+  "fuel": {
+   "n": 15,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 21,
+   "n_bilinear": 0,
+   "n_monomial": 6,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "gbd": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 0,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "gear": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "gear2": {
+   "n": 28,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "gear3": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "gear4": {
+   "n": 6,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "hda": {
+   "n": 722,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.096
+  },
+  "kall_circles_c8a": {
+   "n": 22,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.013
+  },
+  "mathopt3": {
+   "n": 6,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.003
+  },
+  "mathopt5_2": {
+   "n": 1,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.002
+  },
+  "meanvar": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 36,
+   "n_bilinear": 21,
+   "n_monomial": 7,
+   "n_affine_square": 0,
+   "secs": 0.012
+  },
+  "meanvarx": {
+   "n": 35,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 63,
+   "n_bilinear": 21,
+   "n_monomial": 7,
+   "n_affine_square": 0,
+   "secs": 0.015
+  },
+  "nvs01": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.002
+  },
+  "nvs02": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 16,
+   "n_bilinear": 7,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.005
+  },
+  "nvs03": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 0,
+   "n_monomial": 1,
+   "n_affine_square": 2,
+   "secs": 0.003
+  },
+  "nvs04": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "nvs05": {
+   "n": 8,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.006
+  },
+  "nvs06": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "nvs07": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "nvs08": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "nvs10": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 1,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.003
+  },
+  "nvs11": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 9,
+   "n_bilinear": 3,
+   "n_monomial": 3,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "nvs12": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 14,
+   "n_bilinear": 6,
+   "n_monomial": 4,
+   "n_affine_square": 0,
+   "secs": 0.005
+  },
+  "nvs13": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 20,
+   "n_bilinear": 10,
+   "n_monomial": 5,
+   "n_affine_square": 0,
+   "secs": 0.008
+  },
+  "nvs14": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 16,
+   "n_bilinear": 7,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.004
+  },
+  "nvs15": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 8,
+   "n_bilinear": 2,
+   "n_monomial": 3,
+   "n_affine_square": 0,
+   "secs": 0.003
+  },
+  "nvs16": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "nvs17": {
+   "n": 7,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 35,
+   "n_bilinear": 21,
+   "n_monomial": 7,
+   "n_affine_square": 0,
+   "secs": 0.016
+  },
+  "nvs18": {
+   "n": 6,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 27,
+   "n_bilinear": 15,
+   "n_monomial": 6,
+   "n_affine_square": 0,
+   "secs": 0.011
+  },
+  "nvs19": {
+   "n": 8,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 44,
+   "n_bilinear": 28,
+   "n_monomial": 8,
+   "n_affine_square": 0,
+   "secs": 0.024
+  },
+  "nvs20": {
+   "n": 16,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.025
+  },
+  "nvs21": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "nvs22": {
+   "n": 8,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.006
+  },
+  "nvs23": {
+   "n": 9,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 54,
+   "n_bilinear": 36,
+   "n_monomial": 9,
+   "n_affine_square": 0,
+   "secs": 0.029
+  },
+  "nvs24": {
+   "n": 10,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 65,
+   "n_bilinear": 45,
+   "n_monomial": 10,
+   "n_affine_square": 0,
+   "secs": 0.039
+  },
+  "prob02": {
+   "n": 6,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 11,
+   "n_bilinear": 5,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.003
+  },
+  "prob03": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 3,
+   "n_bilinear": 1,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.001
+  },
+  "prob06": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 4,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "prob10": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 0,
+   "n_monomial": 0,
+   "n_affine_square": 2,
+   "secs": 0.003
+  },
+  "st_e01": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 3,
+   "n_bilinear": 1,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.001
+  },
+  "st_e02": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e03": {
+   "n": 10,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "st_e04": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.001
+  },
+  "st_e05": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e06": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e07": {
+   "n": 10,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e08": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 5,
+   "n_bilinear": 1,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "st_e09": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 3,
+   "n_bilinear": 1,
+   "n_monomial": 0,
+   "n_affine_square": 0,
+   "secs": 0.001
+  },
+  "st_e11": {
+   "n": 3,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e13": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 3,
+   "n_bilinear": 0,
+   "n_monomial": 1,
+   "n_affine_square": 0,
+   "secs": 0.001
+  },
+  "st_e15": {
+   "n": 5,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "st_e17": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: column-count mismatch",
+   "bucket": "column-count mismatch",
+   "secs": 0.001
+  },
+  "st_e18": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 4,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "st_e27": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 6,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "st_e31": {
+   "n": 112,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 120,
+   "n_bilinear": 6,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.017
+  },
+  "st_e35": {
+   "n": 32,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: relaxation has no valid bound / no rows",
+   "bucket": "no valid bound / no rows",
+   "secs": 0.009
+  },
+  "st_e36": {
+   "n": 2,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.964
+  },
+  "st_e38": {
+   "n": 4,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "st_e40": {
+   "n": 4,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.004
+  },
+  "st_ph10": {
+   "n": 2,
+   "finite_root": false,
+   "admitted": true,
+   "reason": null,
+   "bucket": "admitted",
+   "ncol": 4,
+   "n_bilinear": 0,
+   "n_monomial": 2,
+   "n_affine_square": 0,
+   "secs": 0.002
+  },
+  "syn05m": {
+   "n": 20,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.002
+  },
+  "trig": {
+   "n": 1,
+   "finite_root": true,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.001
+  },
+  "util": {
+   "n": 145,
+   "finite_root": false,
+   "admitted": false,
+   "reason": "ValueError: bounds mismatch",
+   "bucket": "bounds mismatch",
+   "secs": 0.009
+  }
+ }
+}

--- a/docs/dev/issue-861-incremental-admission-plan.md
+++ b/docs/dev/issue-861-incremental-admission-plan.md
@@ -653,3 +653,64 @@ Fixed at the level of method, not the individual numbers:
     returns `5.2433990`, **correct to ~7 significant figures**.
   The merge rule is `minlplib.solu` wins on any overlap, so a local measurement
   can only fill a gap, never override upstream.
+
+---
+
+## §7 addendum — T5's premise is falsified by measurement (2026-07-28)
+
+Three measurements taken as T5a's entry experiment, together, invalidate the T5
+design and its staging. Recorded per CLAUDE.md §4 (the measurement wins) before
+any T5 code was written.
+
+**1. The staging is backwards — the bounds tape is a PREREQUISITE, not a follow-on.**
+Classifying all 457 product specs in the `bounds mismatch` bucket by what their
+operand forms reference:
+
+    BARE_BILINEAR 179    ORIG_FORM 27    AUX 251   (55% reference an AUX column)
+
+Only **6** instances (`alan`, `kall_circles_c8a`, `st_e05`, `st_e07`, `st_e11`,
+`util`) have products over original columns only, which is all T5a-as-scoped can
+patch. The other **24** reference aux columns whose bounds are themselves
+box-dependent and produced upstream by the engine — so they need the ordered
+bounds tape (planned as T5c, *last*). T5a → T5b → T5c cannot be executed in that
+order.
+
+**2. The instances T5 would admit are the ones where patching saves least.**
+Per-node cold-build cost over the corpus:
+
+    ADMITTED (fast path today)   n=36  median 0.20 ms  p90 1.10 ms  max 9.42 ms
+    DECLINED (T5 would admit)    n=45  median 0.20 ms  p90 1.14 ms  max 20.41 ms
+
+Only **5 of 45** declined instances have a cold build above 1 ms: `hda`
+(20.41 ms, 722 vars), `ex1233`, `kall_circles_c8a`, `nvs20`, `util`. For the
+other 40 the per-node build being replaced costs ~0.2 ms.
+
+**3. Admission delivers no measurable end-to-end speedup on that class.**
+Interleaved A/B (never sequential), 3 repeats, `DISCOPT_INCREMENTAL_MC` 1 vs 0,
+load checked before and after (load average 2.6 → 4.9):
+
+    prob02  0.38±0.04 / 0.37±0.01 = 0.96x     nvs01   1.05±0.15 / 1.04±0.20 = 0.99x
+    st_e01  0.50±0.01 / 0.48±0.01 = 0.96x     ex1225  1.09±0.30 / 1.07±0.36 = 0.98x
+    st_e09  0.56±0.01 / 0.58±0.03 = 1.03x     gear    0.54±0.07 / 0.55±0.01 = 1.02x
+
+`prob02`/`st_e01`/`st_e09` are ADMITTED (so ON exercises the fast path, OFF the
+cold one); `nvs01`/`ex1225`/`gear` are DECLINED and therefore run the cold path
+either way — they are the **noise-floor control**, and the admitted instances are
+indistinguishable from it. Validity checked (CLAUDE.md rule 8): the native #764
+kernel returns `None` for all six, so they genuinely run the Python path and the
+env var genuinely toggles it. (`st_e13` IS handled natively and was excluded.)
+
+**Conclusion.** T5 as designed is the largest and riskiest task in this plan — it
+reimplements the engine's interval propagation as a replayable tape, where any
+divergence is a bound-neutrality violation — and measurement says it would buy
+~1.00x on 40 of the 45 instances it targets. That is the `DISCOPT_CUT_INHERIT`
+shape exactly: sound is not the same as helpful, and a cert-clean but
+neutral change does not earn its risk.
+
+Where admission *should* pay is the large-model tail — `hda` above all (20.41 ms
+per node, 722 variables) — and `hda` sits in the AUX-tape class. So the honest
+re-scope is to target the tape at the families the large instances actually need,
+or to drop the tape in favour of a hybrid that calls the engine's own bound
+propagation (parity by construction rather than by reimplementation), and to stop
+treating raw admission count as the objective. **Not started pending an owner
+decision on which of those to pursue.**

--- a/docs/dev/issue-861-incremental-admission-plan.md
+++ b/docs/dev/issue-861-incremental-admission-plan.md
@@ -714,3 +714,70 @@ or to drop the tape in favour of a hybrid that calls the engine's own bound
 propagation (parity by construction rather than by reimplementation), and to stop
 treating raw admission count as the objective. **Not started pending an owner
 decision on which of those to pursue.**
+
+### T6 — odd power on a straddling root box: WON'T-FIX (measured)
+
+Entry probe (fresh, this session): row count the COLD build emits for ``s = x**p``
+over a straddling box vs sign-definite ones, read off the lifted matrix:
+
+    p=2  straddling -> 4 rows    positive -> 4    negative -> 4
+    p=3  straddling -> 2 rows    positive -> 4    negative -> 4
+    p=4  straddling -> 4 rows    positive -> 4    negative -> 4
+    p=5  straddling -> 2 rows    positive -> 4    negative -> 4
+
+D6's condition was "0 rows (curvature abstains) => drop the gate". The answer is
+**2 rows**, not 0: the cold build emits a genuinely different row FAMILY there
+(the 2-facet S-hull), so the D6 escape does not apply and the sub-item closes as
+**won't-fix**, exactly as the issue's DoD item 3 permits.
+
+Not claimed impossible — claimed disproportionate. The 4-row reserved pattern
+*could* in principle carry 2 real facets plus 2 vacuous rows (``_rowset`` drops
+vacuous rows, the mechanism #873 introduced for pinned boxes). What makes it not
+worth building is the facets themselves: an S-hull facet is the tangent drawn
+from the opposite endpoint, whose tangency point is the root of a degree-``p``
+equation — closed-form only for small ``p``, a numerical solve in general, and
+each one must reproduce the engine's emission bit-for-bit or the structure is not
+bound-neutral. That is real machinery for a class with exactly **one** consumer in
+the corpus (``ex8_5_4``), which the fast path already serves correctly via the
+cold build.
+
+Already pinned in-repo by
+``test_861_monomial_span_zero.py::test_odd_power_monomial_still_declines_on_a_root_box_spanning_zero``
+plus the row-count table in that file's docstring, so the decision is verifiable
+rather than asserted.
+
+---
+
+## T7 — close-out (2026-07-28)
+
+**Final sweep, original baseline -> now:** admitted **31 -> 36** of 81, declined
+50 -> 45. Newly admitted: `prob02`, `prob03`, `st_e01`, `st_e08`, `st_e09`. Zero
+admitted->declined flips at any step.
+
+| bucket | baseline | final | what happened |
+|---|---|---|---|
+| `bounds mismatch` | 24 | 38 | grew *by design* — instances moved here from the two artifact buckets, now declining for an honest, attributable reason (an unpatched lifted family) instead of a box artifact |
+| `column-count mismatch` | 14 | **3** | artifact removed; the 3 survivors (`nvs01`, `nvs21`, `st_e17`) are genuinely box-unstable and must decline |
+| `envelope row count != 4` | 6 | **0** | eliminated — the misclassification is fixed |
+| `no valid bound / no rows` | 5 | **3** | infinite-root instances now reach `_validate` instead of dying at the probe build |
+| odd power on straddling root | 1 | 1 | won't-fix, measured (T6) |
+
+**Issue DoD status.** (1) Triage the two dominant buckets — **done**, with a
+verdict per bucket and the finding that `bounds mismatch` was *not* an
+over-strict comparison but genuine missing coverage. (2) Fix or correctly narrow
+the comparison so admission rises, bound-neutrality clean — **done**: +5
+admitted, both artifact buckets collapsed, and every gate clean at every step
+(360-comparison parity panel with a firing control, 0 oracle violations, 0
+flips). (3) Odd power — **decided** (won't-fix, T6, measured). (4) Before/after
+sweep over the same corpus — **done**, committed as JSON at each step.
+
+**Not done, and why:** T5's family-coverage work (the patch tape). Its premise is
+falsified by measurement — see the §7 addendum above: the staging is backwards
+(the tape is a prerequisite, not a follow-on), the instances it targets are the
+ones where patching saves least (median cold build 0.20 ms; only 5 of 45 exceed
+1 ms), and admission delivers **0.96–1.03x end-to-end** on that class, inside the
+noise floor set by declined-instance controls. Building it would reimplement the
+engine's interval propagation — where any divergence is a bound-neutrality
+violation — for no measured gain. Owner decision (2026-07-28): finish T6, close
+#861, and file a follow-up targeting the large-model tail where the cost model
+says admission actually pays (`hda`: 20.41 ms/node, 722 vars).


### PR DESCRIPTION
Closes #861.

Documentation and measurement only — no source changes. The code work for #861 landed in #893, #894 and #895; this PR records the T6 decision, the T7 close-out, and the measurements that stopped T5.

## Final result

**Admitted 31 → 36 of 81**, zero admitted→declined flips at any step.

| bucket | baseline | final | what happened |
|---|---|---|---|
| `bounds mismatch` | 24 | 38 | grew **by design** — instances moved here from the two artifact buckets and now decline for an honest, attributable reason (an unpatched lifted family) rather than a box artifact |
| `column-count mismatch` | 14 | **3** | artifact removed; the survivors (`nvs01`, `nvs21`, `st_e17`) are genuinely box-unstable and must decline |
| `envelope row count != 4` | 6 | **0** | eliminated — the misclassification is fixed |
| `no valid bound / no rows` | 5 | **3** | infinite-root instances now reach `_validate` instead of dying at the probe build |
| odd power on straddling root | 1 | 1 | won't-fix, measured |

## T6 — odd power on a straddling root: won't-fix, measured

The plan's escape condition was "cold build emits 0 rows there ⇒ drop the gate". Probed:

```
p=2  straddling -> 4 rows    p=3  straddling -> 2 rows
p=4  straddling -> 4 rows    p=5  straddling -> 2 rows   (sign-definite: 4 everywhere)
```

It emits **2** rows — a genuinely different row family (the 2-facet S-hull) — so the escape does not apply. Not claimed impossible, claimed disproportionate: an S-hull facet is the tangent from the opposite endpoint, whose tangency point is the root of a degree-`p` equation, and each must reproduce the engine bit-for-bit or the structure is not bound-neutral. One corpus consumer (`ex8_5_4`), already served correctly by the cold build. The issue's DoD explicitly permits this outcome, and the behaviour is already pinned by an existing test.

## T5 — stopped, premise falsified before any code was written

Three entry measurements (full detail in the plan's §7 addendum, and in #896):

1. **Staging is backwards.** 251 of 457 product specs (55%) reference an AUX column, so the bounds tape — planned *last* — is a prerequisite for 24 of 30 instances.
2. **Targets are where patching saves least.** Declined set median cold build **0.20 ms**; only **5 of 45** exceed 1 ms.
3. **Admission buys ~nothing end-to-end there.** Interleaved A/B, 3 repeats, load-gated: **0.96–1.03x**, indistinguishable from the noise floor set by declined-instance controls that run the cold path either way. Validity checked — the native #764 kernel declines all six, so they genuinely exercise the Python incremental path.

Building the tape means reimplementing the engine's interval propagation, where any divergence is a bound-neutrality violation, for a measured ~1.00x on 40 of 45 targets. That is the `DISCOPT_CUT_INHERIT` shape. Re-scoped to the large-model tail in **#896**, gated on a measured win on `hda` (20.41 ms/node, 722 vars) rather than on admission count.

## Verification

- Final admission sweep vs the committed baseline: 31 → 36, **0 regressions**.
- `incremental_oracle_check.py`: 11 instances, **0 violations** — including `st_e17` and `meanvar` against the references this work established with SCIP/BARON/Couenne.
- CI's exact fast marker selection run locally.

## Issue DoD

1. Triage the two dominant buckets — **done**, with a verdict per bucket, including the finding that `bounds mismatch` was *not* an over-strict comparison but genuine missing coverage (correcting the issue's own hypothesis (b)).
2. Fix or narrow the comparison so admission rises, bound-neutrality clean — **done**: +5 admitted, both artifact buckets collapsed, every gate clean at every step.
3. Odd power: implement or explicitly close won't-fix with `ex8_5_4` named — **done** (won't-fix, measured).
4. Before/after sweep over the same 81 instances — **done**, committed as JSON at each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
