### PR TITLE
docs(#861): mark the loop complete

### DIFF
--- a/docs/dev/issue-861-incremental-admission-plan.md
+++ b/docs/dev/issue-861-incremental-admission-plan.md
@@ -781,3 +781,5 @@ engine's interval propagation — where any divergence is a bound-neutrality
 violation — for no measured gain. Owner decision (2026-07-28): finish T6, close
 #861, and file a follow-up targeting the large-model tail where the cost model
 says admission actually pays (`hda`: 20.41 ms/node, 722 vars).
+
+RALPH-861-COMPLETE


### PR DESCRIPTION
Adds the loop's completion sentinel to the plan ledger.

#861 closed: admitted 31 → 36 of 81, all four DoD items met. Residual family-coverage work re-scoped to #896 with its entry experiment and kill criterion specified.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd