### PR TITLE
fix(correctness): #907 a sub-ulp bound crossing must not fathom a live node

### DIFF
--- a/crates/discopt-core/src/bnb/in_tree_presolve.rs
+++ b/crates/discopt-core/src/bnb/in_tree_presolve.rs
@@ -25,7 +25,9 @@
 //! `depth_stride = 0` disables the pass.
 
 use crate::expr::ModelRepr;
-use crate::presolve::fbbt::{fbbt_with_cutoff, Interval};
+use crate::presolve::fbbt::{
+    any_empty_beyond, fbbt_with_cutoff, repair_subtol_crossings, Interval, FEAS_TOL,
+};
 use crate::presolve::probing::probe_node_bounds;
 
 /// Options controlling persistent in-tree bound tightening.
@@ -70,6 +72,11 @@ pub struct InTreeDelta {
     pub bounds_tightened: u32,
     /// True if the kernel detected infeasibility (empty interval).
     pub infeasible: bool,
+    /// How many sub-`FEAS_TOL` bound crossings were repaired (#907).
+    ///
+    /// Surfaced rather than absorbed: a rising count is a numerical smell, and
+    /// before #907 each of these events could have fathomed a live node.
+    pub subtol_repaired: usize,
     /// True iff the schedule actually ran the pass at this node.
     pub ran: bool,
 }
@@ -99,27 +106,49 @@ pub fn run_in_tree_presolve(
             ub: node_ub.to_vec(),
             bounds_tightened: 0,
             infeasible: false,
+            subtol_repaired: 0,
             ran: false,
         };
     }
+
+    // #907. Sanitize the INCOMING node box before anything reads it. A caller
+    // upstream (or an earlier `in_tree_presolve` on a parent node) may hand us a
+    // box already inverted by rounding noise; patching that straight onto
+    // `VarInfo` would seed FBBT from an inverted domain and manufacture the very
+    // emptiness we are trying not to over-read.
+    let mut node_box: Vec<Interval> = (0..node_lb.len())
+        .map(|i| Interval::new(node_lb[i], node_ub[i]))
+        .collect();
+    let mut subtol_repaired = repair_subtol_crossings(&mut node_box, FEAS_TOL);
 
     // Patch the model's variable bounds with the node-local bounds.
     // We clone only the lightweight `variables` Vec, not the arena.
     let mut patched = model.clone();
     for (i, vinfo) in patched.variables.iter_mut().enumerate() {
         if !vinfo.lb.is_empty() {
-            vinfo.lb[0] = node_lb[i];
+            vinfo.lb[0] = node_box[i].lo;
         }
         if !vinfo.ub.is_empty() {
-            vinfo.ub[0] = node_ub[i];
+            vinfo.ub[0] = node_box[i].hi;
         }
     }
 
-    let bounds: Vec<Interval> = fbbt_with_cutoff(&patched, opts.max_iter, opts.tol, incumbent);
-    let mut infeasible = bounds.iter().any(|iv| iv.is_empty());
+    // #907. `infeasible` is consumed by the B&B loop as a RIGOROUS FATHOM — the
+    // subtree is pruned outright — so it must never be set by floating-point
+    // noise. Repair sub-`FEAS_TOL` crossings, then conclude infeasibility only
+    // beyond the tolerance, exactly as `fbbt`, `fbbt_fp` and `probing` do.
+    //
+    // Loosening a fathom is the SOUND direction: the node is explored rather
+    // than discarded. Genuine detections are unaffected — corpus instrumentation
+    // found every real fathom carried either the `[inf, -inf]` empty sentinel or
+    // a crossing of exactly 1.0 (binary domain wipeout), 6+ orders above
+    // `FEAS_TOL`.
+    let mut bounds: Vec<Interval> = fbbt_with_cutoff(&patched, opts.max_iter, opts.tol, incumbent);
+    subtol_repaired += repair_subtol_crossings(&mut bounds, FEAS_TOL);
+    let mut infeasible = any_empty_beyond(&bounds, FEAS_TOL);
 
-    let mut new_lb = node_lb.to_vec();
-    let mut new_ub = node_ub.to_vec();
+    let mut new_lb: Vec<f64> = node_box.iter().map(|b| b.lo).collect();
+    let mut new_ub: Vec<f64> = node_box.iter().map(|b| b.hi).collect();
     let mut tightened = 0u32;
     if !infeasible {
         for i in 0..bounds.len() {
@@ -174,11 +203,34 @@ pub fn run_in_tree_presolve(
         }
     }
 
+    // #907. Final sanitation at the single exit. The probing branch above gates
+    // its own emptiness test on `opts.tol` (a different, smaller tolerance), so it
+    // can fold back a box that is inverted by a sub-`FEAS_TOL` amount WITHOUT
+    // setting `infeasible`. Returning that inverted box would push `lo > hi` onto
+    // an LP column bound downstream, reproducing the false infeasibility one layer
+    // down — declining to *declare* emptiness is not enough on its own.
+    let mut out: Vec<Interval> = (0..new_lb.len())
+        .map(|i| Interval::new(new_lb[i], new_ub[i]))
+        .collect();
+    subtol_repaired += repair_subtol_crossings(&mut out, FEAS_TOL);
+    if !infeasible && any_empty_beyond(&out, FEAS_TOL) {
+        infeasible = true;
+    }
+    for (i, b) in out.iter().enumerate() {
+        new_lb[i] = b.lo;
+        new_ub[i] = b.hi;
+    }
+    debug_assert!(
+        infeasible || new_lb.iter().zip(&new_ub).all(|(l, u)| l <= u),
+        "#907: in_tree_presolve returned an inverted box without declaring infeasible"
+    );
+
     InTreeDelta {
         lb: new_lb,
         ub: new_ub,
         bounds_tightened: tightened,
         infeasible,
+        subtol_repaired,
         ran: true,
     }
 }
@@ -435,5 +487,103 @@ mod tests {
         assert!(delta.ran);
         assert!(!delta.infeasible);
         assert!((delta.ub[1] - 2.0).abs() <= 1e-6);
+    }
+
+    // ── #907: a sub-FEAS_TOL crossing must not FATHOM a node ─────────────
+    //
+    // `InTreeDelta::infeasible` is consumed by the B&B loop as a *rigorous
+    // fathom*: the subtree is pruned outright. Setting it from a crossing of
+    // 8.5e-14 discards a region that may contain feasible points, violating the
+    // zero-slack `incorrect_count <= 0` gate with no flag set.
+
+    /// A node box inverted by rounding noise must be explored, not fathomed,
+    /// and must not be returned inverted.
+    #[test]
+    fn subtol_inverted_node_box_is_not_fathomed() {
+        let model = x_plus_y_le_5();
+        let opts = InTreePresolveOptions {
+            depth_stride: 1,
+            max_iter: 16,
+            tol: 1e-9,
+            probing: false,
+            probe_max_vars: 0,
+        };
+        // x fixed at 2.5 by two derivations disagreeing in the last ulps.
+        let lo = [2.5, 0.0];
+        let hi = [2.5 - 1e-14, 10.0];
+        let d = run_in_tree_presolve(&model, &lo, &hi, 0, None, &opts);
+
+        assert!(d.ran);
+        assert!(
+            !d.infeasible,
+            "a 1e-14 crossing fathomed a live node — #907 regressed"
+        );
+        assert_eq!(d.subtol_repaired, 1);
+        // The returned box must be well-formed: an inverted interval reaching an
+        // LP column bound reproduces the false infeasibility one layer down.
+        for i in 0..d.lb.len() {
+            assert!(
+                d.lb[i] <= d.ub[i],
+                "returned an inverted box at var{i}: [{}, {}]",
+                d.lb[i],
+                d.ub[i]
+            );
+        }
+        // Repair widens to contain both endpoints, so the feasible point x=2.5
+        // survives.
+        assert!(d.lb[0] <= 2.5 && 2.5 <= d.ub[0]);
+    }
+
+    /// ANTI-PERMISSIVENESS CONTROL: a genuinely empty node box must STILL
+    /// fathom. Without this the change is a tolerance-tweak, not a fix.
+    #[test]
+    fn genuine_empty_node_box_still_fathoms() {
+        let model = x_plus_y_le_5();
+        let opts = InTreePresolveOptions {
+            depth_stride: 1,
+            max_iter: 16,
+            tol: 1e-9,
+            probing: false,
+            probe_max_vars: 0,
+        };
+        // x >= 10 AND y >= 10 with x + y <= 5 — infeasible by 15, not by noise.
+        let d = run_in_tree_presolve(&model, &[10.0, 10.0], &[10.0, 10.0], 0, None, &opts);
+        assert!(d.ran);
+        assert!(d.infeasible, "a genuine infeasibility stopped fathoming");
+        assert_eq!(d.subtol_repaired, 0);
+    }
+
+    /// The repair must never cut a point the caller's box contained: sweep a
+    /// feasible point through many noise-inverted boxes and assert containment
+    /// survives. Prints nothing, but the assertion count is the point (§6).
+    #[test]
+    fn repair_never_cuts_a_contained_feasible_point() {
+        let model = x_plus_y_le_5();
+        let opts = InTreePresolveOptions {
+            depth_stride: 1,
+            max_iter: 16,
+            tol: 1e-9,
+            probing: false,
+            probe_max_vars: 0,
+        };
+        let mut checked = 0usize;
+        for k in 0..40 {
+            let v = 0.1 * k as f64; // feasible x value in [0, 3.9]
+            for eps in [1e-16, 1e-14, 1e-12, 1e-9, 1e-7] {
+                let d = run_in_tree_presolve(&model, &[v, 0.0], &[v - eps, 10.0], 0, None, &opts);
+                assert!(!d.infeasible, "fathomed a live node at eps={eps}");
+                assert!(
+                    d.lb[0] <= v && v <= d.ub[0],
+                    "repair cut x={v} at eps={eps}: [{}, {}]",
+                    d.lb[0],
+                    d.ub[0]
+                );
+                checked += 1;
+            }
+        }
+        assert_eq!(
+            checked, 200,
+            "probe did not execute the comparisons it claims"
+        );
     }
 }

--- a/crates/discopt-core/src/bnb/in_tree_presolve.rs
+++ b/crates/discopt-core/src/bnb/in_tree_presolve.rs
@@ -196,9 +196,13 @@ pub fn run_in_tree_presolve(
                     new_ub[i] = iv.hi;
                     tightened += 1;
                 }
-                if new_lb[i] > new_ub[i] + opts.tol {
-                    infeasible = true;
-                }
+                // #907. NO infeasibility verdict here. This loop used to test
+                // `new_lb[i] > new_ub[i] + opts.tol`, but `opts.tol` is the FBBT
+                // *convergence* tolerance — independently settable and smaller
+                // than `FEAS_TOL` in practice — so a crossing in
+                // `(opts.tol, FEAS_TOL]` set the rigorous-fathom flag on exactly
+                // the noise this fix exists to tolerate. The single exit below
+                // repairs and then decides, at `FEAS_TOL`, for every path.
             }
         }
     }
@@ -584,6 +588,69 @@ mod tests {
         assert_eq!(
             checked, 200,
             "probe did not execute the comparisons it claims"
+        );
+    }
+
+    /// #907, probing path enabled: a node box inverted by sub-`FEAS_TOL` noise
+    /// must not be fathomed, and must not come back inverted or with the point
+    /// cut. Runs with `opts.tol` two orders BELOW `FEAS_TOL` so the two
+    /// tolerances are distinguishable.
+    ///
+    /// SCOPE, stated honestly: this covers the incoming-box sanitation on the
+    /// probing path (it fails on pre-#907 `main`). It does NOT isolate the
+    /// fold-back verdict that used to read `new_lb[i] > new_ub[i] + opts.tol` —
+    /// reverting that one line alone leaves this test green, because reaching it
+    /// requires `probe_node_bounds` to itself return an interval inverted by
+    /// `(opts.tol, FEAS_TOL]`, which no toy model here produces. That line is
+    /// changed on consistency grounds — `opts.tol` is a convergence tolerance and
+    /// must not gate an infeasibility verdict — and is UNCOVERED by a
+    /// fail-before test.
+    #[test]
+    fn probing_path_does_not_fathom_subtol_inverted_box() {
+        let model = x_plus_y_le_5();
+        let opts = InTreePresolveOptions {
+            depth_stride: 1,
+            max_iter: 16,
+            tol: 1e-8, // << FEAS_TOL (1e-6): the window the old test fathomed in
+            probing: true,
+            probe_max_vars: 8,
+        };
+        let mut checked = 0usize;
+        for eps in [1e-7, 5e-7, 9e-7] {
+            // Crossing strictly inside (opts.tol, FEAS_TOL] — noise, not a proof.
+            let d = run_in_tree_presolve(&model, &[2.5, 0.0], &[2.5 - eps, 10.0], 0, None, &opts);
+            assert!(d.ran);
+            assert!(
+                !d.infeasible,
+                "probing path fathomed a live node at a {eps:e} crossing (< FEAS_TOL)"
+            );
+            assert!(d.lb[0] <= d.ub[0], "probing path returned an inverted box");
+            assert!(d.lb[0] <= 2.5 && 2.5 <= d.ub[0], "probing path cut x=2.5");
+            checked += 1;
+        }
+        assert_eq!(
+            checked, 3,
+            "probe did not execute the comparisons it claims"
+        );
+    }
+
+    /// ANTI-PERMISSIVENESS CONTROL for the probing path: a genuine infeasibility
+    /// must still fathom with probing on and a small `opts.tol`.
+    #[test]
+    fn probing_path_still_fathoms_genuine_infeasibility() {
+        let model = x_plus_y_le_5();
+        let opts = InTreePresolveOptions {
+            depth_stride: 1,
+            max_iter: 16,
+            tol: 1e-8,
+            probing: true,
+            probe_max_vars: 8,
+        };
+        let d = run_in_tree_presolve(&model, &[10.0, 10.0], &[10.0, 10.0], 0, None, &opts);
+        assert!(d.ran);
+        assert!(
+            d.infeasible,
+            "probing path stopped fathoming a real infeasibility"
         );
     }
 }

--- a/crates/discopt-core/src/presolve/fbbt.rs
+++ b/crates/discopt-core/src/presolve/fbbt.rs
@@ -67,22 +67,44 @@ impl Interval {
         self.hi - self.lo
     }
 
-    /// Whether the interval is empty (lo > hi).
-    pub fn is_empty(&self) -> bool {
+    /// Whether the interval is *formally* inverted (`lo > hi`), with **zero**
+    /// tolerance.
+    ///
+    /// This is a syntactic predicate, **not** a feasibility verdict. Do not use
+    /// it to conclude that a constraint, a node, or a presolve sweep is
+    /// infeasible — use [`is_empty_beyond`] for that. It is deliberately *not*
+    /// named `is_empty` (#907): under that name it read as a legitimate
+    /// emptiness test and was used to fathom B&B nodes and abort presolve
+    /// sweeps, so a crossing of 8.5e-14 discarded a live region.
+    ///
+    /// Legitimate uses are guards where either answer is sound — early-returning
+    /// an already-degenerate interval unchanged, or filtering it out of a
+    /// candidate list.
+    pub fn is_formally_inverted(&self) -> bool {
         self.lo > self.hi
     }
 
     /// Whether the interval is empty by more than a feasibility tolerance,
     /// i.e. `lo - hi > tol`.
     ///
-    /// Use this (not [`is_empty`]) when deciding that a *constraint* is
-    /// genuinely infeasible. Approximate reformulations — notably the GDP
-    /// hull perspective form `y * f(v / y)` with a clamp `y + eps` — leave
-    /// eps-scale (~1e-8) residuals at integer faces. A strict `lo > hi`
-    /// check mistakes that numerical noise for infeasibility and can fix a
-    /// disjunction's selector incorrectly, producing an unsound bound. A
-    /// tolerance-aware check declares infeasibility only when the violation
-    /// exceeds the feasibility tolerance.
+    /// **This is the only predicate that may be used to conclude
+    /// infeasibility.** Approximate reformulations — notably the GDP hull
+    /// perspective form `y * f(v / y)` with a clamp `y + eps` — leave eps-scale
+    /// (~1e-8) residuals at integer faces. A strict `lo > hi` check mistakes
+    /// that numerical noise for infeasibility and can fix a disjunction's
+    /// selector incorrectly, producing an unsound bound. A tolerance-aware check
+    /// declares infeasibility only when the violation exceeds the feasibility
+    /// tolerance.
+    ///
+    /// The threshold is measured, not assumed. Instrumenting both acting sites
+    /// over the in-repo corpus (10,105 predicate evaluations, #907 experiment A)
+    /// found the crossing-magnitude distribution degenerate at two points:
+    /// rounding noise at 1e-14 absolute / 1e-16 relative, and genuine
+    /// infeasibility at exactly 1.0 (binary domain wipeout, `[1.0, 0.0]`) plus
+    /// the explicit `[inf, -inf]` sentinel of [`Interval::empty`]. `FEAS_TOL`
+    /// sits ~7 orders above the largest noise crossing and ~6 orders below the
+    /// smallest genuine one, and nothing was observed in between. Note the
+    /// genuine population is unsampled in `(FEAS_TOL, 1.0)`.
     pub fn is_empty_beyond(&self, tol: f64) -> bool {
         self.lo - self.hi > tol
     }
@@ -90,6 +112,35 @@ impl Interval {
     /// Whether `x` is contained in the interval.
     pub fn contains(&self, x: f64) -> bool {
         x >= self.lo && x <= self.hi
+    }
+
+    /// Repair a sub-tolerance inversion in place, returning `true` if it did.
+    ///
+    /// A crossing of `lo - hi` in `(0, tol]` is two derivations of the same
+    /// quantity disagreeing in their last ulps, not an infeasibility. Widen to
+    /// `[min(lo, hi), max(lo, hi)]` — the smallest interval containing **both**
+    /// endpoints, so whichever derivation was the sound one keeps its endpoint
+    /// and no feasible point is cut.
+    ///
+    /// Widening (not snapping to a midpoint) is the whole point: a midpoint
+    /// collapse is *tighter* than at least one sound endpoint and could cut the
+    /// optimum. A crossing beyond `tol`, and the explicit `[inf, -inf]` empty
+    /// sentinel, are left untouched — they are real verdicts.
+    ///
+    /// Repairing is the necessary second half of the #907 fix. Declining to
+    /// *declare* emptiness is not enough if an inverted interval still escapes
+    /// to a consumer: `lo > hi` on an LP column bound reproduces the same false
+    /// infeasibility one layer down.
+    pub fn repair_if_subtol_inverted(&mut self, tol: f64) -> bool {
+        let cross = self.lo - self.hi;
+        if cross > 0.0 && cross <= tol {
+            let (lo, hi) = (self.lo.min(self.hi), self.lo.max(self.hi));
+            self.lo = lo;
+            self.hi = hi;
+            true
+        } else {
+            false
+        }
     }
 
     /// Intersect two intervals.
@@ -139,6 +190,28 @@ pub fn interval_mul(a: &Interval, b: &Interval) -> Interval {
     let p3 = prod(a.hi, b.lo);
     let p4 = prod(a.hi, b.hi);
     Interval::new(p1.min(p2).min(p3).min(p4), p1.max(p2).max(p3).max(p4))
+}
+
+/// Whether any interval in `bounds` is empty by more than `tol`.
+///
+/// The single sanctioned way for a caller to conclude "this box is infeasible".
+/// See [`Interval::is_empty_beyond`] for why the strict `lo > hi` form is not.
+pub fn any_empty_beyond(bounds: &[Interval], tol: f64) -> bool {
+    bounds.iter().any(|b| b.is_empty_beyond(tol))
+}
+
+/// Repair every sub-`tol` inversion in `bounds` in place; returns how many.
+///
+/// Pair this with [`any_empty_beyond`] at any site that acts on an emptiness
+/// verdict: repair first so no inverted interval escapes to a consumer, then
+/// test. A non-zero return is a numerical smell worth surfacing — it means some
+/// pass produced a formally-empty interval that was pure floating-point noise —
+/// so callers thread the count out rather than absorbing it silently.
+pub fn repair_subtol_crossings(bounds: &mut [Interval], tol: f64) -> usize {
+    bounds
+        .iter_mut()
+        .map(|b| usize::from(b.repair_if_subtol_inverted(tol)))
+        .sum()
 }
 
 /// `[a,b] / [c,d]` with division-by-zero handling.
@@ -192,8 +265,12 @@ pub fn interval_pow(base: &Interval, exp: &Interval) -> Interval {
         }
     }
     // General case: base must be non-negative for real-valued power.
+    // Formal inversion (#907): this clamps the base to its non-negative part and
+    // asks whether anything survived. Returning `entire()` is the maximally
+    // conservative answer, so either verdict is sound; no infeasibility is
+    // concluded.
     let b = Interval::new(base.lo.max(0.0), base.hi.max(0.0));
-    if b.is_empty() || b.hi < 0.0 {
+    if b.is_formally_inverted() || b.hi < 0.0 {
         return Interval::entire();
     }
     let vals = [
@@ -593,8 +670,14 @@ pub fn backward_propagate(
     var_bounds: &mut [Interval],
 ) {
     // Intersect the output bound with the forward-propagated bound.
+    //
+    // Formal inversion is the right test here (#907): bailing out declines to
+    // *tighten*, which is the conservative direction — it can only leave the box
+    // looser, never cut a feasible point. It is also the guard that stops a
+    // noise-inverted interval being written into `var_bounds` and surfacing as a
+    // spurious emptiness verdict upstream. No infeasibility is concluded.
     let tightened = output_bound.intersect(&node_bounds[id.0]);
-    if tightened.is_empty() {
+    if tightened.is_formally_inverted() {
         return;
     }
 
@@ -1075,7 +1158,10 @@ pub(crate) const INTEGRALITY_SNAP_TOL: f64 = FEAS_TOL;
 /// unchanged; a value squeezed to neither 0 nor 1 (for a binary) yields an
 /// empty interval — a genuine integer infeasibility the caller detects.
 pub(crate) fn snap_integral_interval(iv: Interval) -> Interval {
-    if iv.is_empty() {
+    // Formal inversion (#907): an already-degenerate interval is returned
+    // unchanged rather than fed to `ceil`/`floor`. Pass-through concludes
+    // nothing; the caller still applies its own tolerance-aware verdict.
+    if iv.is_formally_inverted() {
         return iv;
     }
     Interval::new(
@@ -1633,7 +1719,7 @@ mod tests {
     #[test]
     fn test_interval_empty() {
         let a = Interval::empty();
-        assert!(a.is_empty());
+        assert!(a.is_formally_inverted());
         assert!(!a.contains(0.0));
     }
 
@@ -1667,7 +1753,7 @@ mod tests {
         let a = Interval::new(1.0, 3.0);
         let b = Interval::new(5.0, 7.0);
         let r = a.intersect(&b);
-        assert!(r.is_empty());
+        assert!(r.is_formally_inverted());
     }
 
     // -- Forward propagation tests --
@@ -2204,7 +2290,10 @@ mod tests {
         let model = make_linear_model();
         let bounds = fbbt_with_cutoff(&model, 10, 1e-8, Some(-1.0));
         for b in &bounds {
-            assert!(b.is_empty(), "Expected infeasible (empty bounds)");
+            assert!(
+                b.is_formally_inverted(),
+                "Expected infeasible (empty bounds)"
+            );
         }
     }
 
@@ -2413,16 +2502,86 @@ mod tests {
         // An eps-scale inverted interval is empty in the strict sense but
         // feasible within tolerance — it must not be treated as infeasible.
         let eps = Interval::new(1.0, 1.0 - 1e-9);
-        assert!(eps.is_empty());
+        assert!(eps.is_formally_inverted());
         assert!(!eps.is_empty_beyond(FEAS_TOL));
 
         // A genuinely inverted interval is empty beyond tolerance.
         let real = Interval::new(1.0, 0.9);
-        assert!(real.is_empty());
+        assert!(real.is_formally_inverted());
         assert!(real.is_empty_beyond(FEAS_TOL));
 
         // The canonical empty interval is empty beyond any finite tolerance.
         assert!(Interval::empty().is_empty_beyond(FEAS_TOL));
+    }
+
+    // -- sub-tolerance crossing repair (issue #907) --
+
+    #[test]
+    fn test_repair_widens_subtol_crossing_without_cutting_either_endpoint() {
+        // The exact crossing measured on `heatexch_gen3` var4 on the default
+        // path: two derivations of the same fixed value disagreeing by 8.5e-14.
+        let mut iv = Interval::new(226.7, 226.699_999_999_999_9);
+        assert!(iv.is_formally_inverted());
+        assert!(iv.repair_if_subtol_inverted(FEAS_TOL));
+
+        // Repair must WIDEN to contain both endpoints. A midpoint collapse
+        // would be tighter than one sound endpoint and could cut the optimum.
+        assert!(!iv.is_formally_inverted());
+        assert!(iv.contains(226.7), "repair cut the upper derivation");
+        assert!(
+            iv.contains(226.699_999_999_999_9),
+            "repair cut the lower one"
+        );
+        assert_eq!(iv.lo, 226.699_999_999_999_9);
+        assert_eq!(iv.hi, 226.7);
+    }
+
+    /// ANTI-PERMISSIVENESS CONTROL. Repair must not launder a real infeasibility
+    /// into a feasible box. Without this the fix would be the tolerance-tweak
+    /// CLAUDE.md §3 forbids rather than a correctness fix.
+    #[test]
+    fn test_repair_leaves_genuine_and_sentinel_emptiness_alone() {
+        // A crossing beyond FEAS_TOL is a real verdict — untouched.
+        let mut real = Interval::new(1.0, 0.9);
+        assert!(!real.repair_if_subtol_inverted(FEAS_TOL));
+        assert!(real.is_empty_beyond(FEAS_TOL));
+
+        // The exact genuine population observed at the in-tree site: a binary
+        // whose domain was wiped out, `[1.0, 0.0]`, crossing exactly 1.0.
+        let mut binary = Interval::new(1.0, 0.0);
+        assert!(!binary.repair_if_subtol_inverted(FEAS_TOL));
+        assert!(binary.is_empty_beyond(FEAS_TOL));
+
+        // The explicit `[inf, -inf]` sentinel survives any finite tolerance.
+        let mut sentinel = Interval::empty();
+        assert!(!sentinel.repair_if_subtol_inverted(FEAS_TOL));
+        assert!(sentinel.is_empty_beyond(FEAS_TOL));
+
+        // A well-formed interval is not disturbed.
+        let mut ok = Interval::new(0.0, 1.0);
+        assert!(!ok.repair_if_subtol_inverted(FEAS_TOL));
+        assert_eq!((ok.lo, ok.hi), (0.0, 1.0));
+    }
+
+    #[test]
+    fn test_slice_helpers_count_and_verdict() {
+        let mut bounds = vec![
+            Interval::new(0.0, 1.0),                     // fine
+            Interval::new(226.7, 226.699_999_999_999_9), // noise
+            Interval::new(5.0, 5.0 - 1e-12),             // noise
+        ];
+        // Verdict BEFORE repair: no genuine emptiness present.
+        assert!(!any_empty_beyond(&bounds, FEAS_TOL));
+        assert_eq!(repair_subtol_crossings(&mut bounds, FEAS_TOL), 2);
+        assert!(bounds.iter().all(|b| !b.is_formally_inverted()));
+        // Idempotent: a second pass repairs nothing.
+        assert_eq!(repair_subtol_crossings(&mut bounds, FEAS_TOL), 0);
+
+        // ANTI-PERMISSIVENESS: a genuine crossing still reports empty, and
+        // repair declines to touch it.
+        bounds.push(Interval::new(1.0, 0.0));
+        assert_eq!(repair_subtol_crossings(&mut bounds, FEAS_TOL), 0);
+        assert!(any_empty_beyond(&bounds, FEAS_TOL));
     }
 
     /// Build a one-variable model `x` fixed to `[0, 0]` with a single `x >= rhs`
@@ -2482,7 +2641,7 @@ mod tests {
         let model = make_eps_violated_model(0.5);
         let bounds = fbbt(&model, 5, 1e-8);
         assert!(
-            bounds.iter().all(|b| b.is_empty()),
+            bounds.iter().all(|b| b.is_formally_inverted()),
             "a violation beyond the feasibility tolerance must be infeasible"
         );
     }
@@ -2551,7 +2710,7 @@ mod tests {
         // Then b ≥ x/10 ≥ 0.3, and since b ∈ {0,1}, b must be 1.
         let model = make_indicator_model(3.0, 10.0, 10.0);
         let bounds = fbbt(&model, 8, 1e-9);
-        assert!(!bounds.iter().any(|b| b.is_empty()));
+        assert!(!bounds.iter().any(|b| b.is_formally_inverted()));
         assert!(
             (bounds[1].lo - 1.0).abs() < 1e-9 && (bounds[1].hi - 1.0).abs() < 1e-9,
             "binary should be inferred = 1, got {:?}",
@@ -2567,7 +2726,7 @@ mod tests {
         model.variables[1].lb = vec![0.0];
         model.variables[1].ub = vec![0.0]; // b = 0
         let bounds = fbbt(&model, 8, 1e-9);
-        assert!(!bounds.iter().any(|b| b.is_empty()));
+        assert!(!bounds.iter().any(|b| b.is_formally_inverted()));
         assert!(
             bounds[0].hi <= 1e-6,
             "deactivated guard should force x ≤ 0, got {:?}",
@@ -2596,7 +2755,7 @@ mod tests {
         };
         let bounds = fbbt(&model, 8, 1e-9);
         assert!(
-            bounds.iter().any(|b| b.is_empty()),
+            bounds.iter().any(|b| b.is_formally_inverted()),
             "a binary squeezed to neither 0 nor 1 must be infeasible, got {:?}",
             bounds
         );
@@ -2647,7 +2806,7 @@ mod tests {
         // would wrongly eliminate the b = 0 disjunct and yield an unsound bound.
         let model = make_indicator_model(0.0, 0.0, 1e-9);
         let bounds = fbbt(&model, 8, 1e-9);
-        assert!(!bounds.iter().any(|b| b.is_empty()));
+        assert!(!bounds.iter().any(|b| b.is_formally_inverted()));
         assert!(
             bounds[1].lo <= 1e-9 && bounds[1].hi >= 1.0 - 1e-9,
             "eps residual must leave the binary free, got {:?}",
@@ -2768,7 +2927,7 @@ mod tests {
         // C-31 FIXED: a feasible model must NOT be reported infeasible.
         // "FBBT never reports feasible as infeasible."
         assert!(
-            !bounds.iter().any(|b| b.is_empty()),
+            !bounds.iter().any(|b| b.is_formally_inverted()),
             "C-31: feasible model x=[5, 0..3] must not be declared infeasible, \
              got {:?}",
             bounds

--- a/crates/discopt-core/src/presolve/fbbt_fp.rs
+++ b/crates/discopt-core/src/presolve/fbbt_fp.rs
@@ -455,7 +455,7 @@ mod tests {
         let mut bounds = vec![Interval::new(0.5, 10.0)];
         let stats = fbbt_fixed_point(&model, &mut bounds, FbbtFpOptions::default());
         assert!(stats.infeasible);
-        assert!(bounds[0].is_empty());
+        assert!(bounds[0].is_formally_inverted());
     }
 
     // cert:C-20 regression: the watch-list engine declared infeasibility with a
@@ -490,7 +490,7 @@ mod tests {
         // Main engine tolerates it (bounds not collapsed to empty).
         let main_bounds = crate::presolve::fbbt::fbbt(&eps_residual_equality_model(eps), 100, 1e-9);
         assert!(
-            !main_bounds.iter().any(|b| b.is_empty()),
+            !main_bounds.iter().any(|b| b.is_formally_inverted()),
             "main engine (reference) should treat the eps residual as feasible"
         );
 
@@ -506,7 +506,7 @@ mod tests {
             !stats.infeasible,
             "C-20: eps-residual equality falsely reported infeasible by the watch-list engine"
         );
-        assert!(!bounds.iter().any(|b| b.is_empty()));
+        assert!(!bounds.iter().any(|b| b.is_formally_inverted()));
     }
 
     #[test]

--- a/crates/discopt-core/src/presolve/obbt.rs
+++ b/crates/discopt-core/src/presolve/obbt.rs
@@ -238,7 +238,10 @@ pub fn obbt_candidates(var_bounds: &[Interval], min_width: f64) -> Vec<usize> {
         .iter()
         .enumerate()
         .filter(|(_, b)| {
-            !b.is_empty() && b.width() > min_width && b.lo.is_finite() && b.hi.is_finite()
+            !b.is_formally_inverted()
+                && b.width() > min_width
+                && b.lo.is_finite()
+                && b.hi.is_finite()
         })
         .map(|(i, _)| i)
         .collect()

--- a/crates/discopt-core/src/presolve/orchestrator.rs
+++ b/crates/discopt-core/src/presolve/orchestrator.rs
@@ -6,7 +6,11 @@
 //!
 //! Termination conditions, in order of priority:
 //!
-//! 1. A pass detected infeasibility (any bound's `is_empty()`).
+//! 1. A pass detected infeasibility — some bound is empty by more than
+//!    `FEAS_TOL` (`Interval::is_empty_beyond`). A *sub*-tolerance crossing is
+//!    rounding noise, is repaired in place, and does NOT stop the loop; the
+//!    strict `lo > hi` test that used to be here aborted the sweep spuriously
+//!    on the default path (#907).
 //! 2. The configured time budget was exhausted.
 //! 3. The configured work-unit budget was exhausted.
 //! 4. `max_iterations` sweeps completed.
@@ -22,6 +26,7 @@
 use std::time::Instant;
 
 use super::delta::{PresolveDelta, TerminationReason};
+use super::fbbt::{any_empty_beyond, repair_subtol_crossings, FEAS_TOL};
 use super::pass::{PassCategory, PresolveContext, PresolvePass};
 
 /// Tunables for one orchestrator run.
@@ -64,6 +69,13 @@ pub struct PresolveResult {
     pub iterations: u32,
     /// Why the loop stopped.
     pub terminated_by: TerminationReason,
+    /// How many sub-`FEAS_TOL` bound crossings were repaired during the run.
+    ///
+    /// Non-zero means some pass produced a formally-inverted interval that was
+    /// pure floating-point noise. Before #907 the same event aborted the whole
+    /// presolve as `Infeasible`; it is surfaced rather than silently absorbed so
+    /// that a *rising* count is visible as the numerical smell it is.
+    pub subtol_crossings_repaired: usize,
 }
 
 /// Run the fixed-point loop on `model` with the given options.
@@ -80,6 +92,7 @@ pub fn run(model: crate::expr::ModelRepr, mut opts: OrchestratorOptions) -> Pres
     let mut deltas: Vec<PresolveDelta> = Vec::new();
     let mut terminated_by = TerminationReason::IterationCap;
     let mut last_iter: u32 = 0;
+    let mut subtol_crossings_repaired: usize = 0;
 
     'outer: for sweep in 0..opts.max_iterations {
         ctx.iter = sweep;
@@ -106,7 +119,21 @@ pub fn run(model: crate::expr::ModelRepr, mut opts: OrchestratorOptions) -> Pres
                 ctx.resync_bounds_after_rewrite();
             }
 
-            if any_empty(&ctx.bounds) {
+            // #907. A bound crossing below `FEAS_TOL` is floating-point noise,
+            // not an infeasibility: two derivations of the same quantity
+            // disagreeing in their last ulps. Repair it — so no inverted
+            // interval escapes to a consumer — and keep going. Declare
+            // `Infeasible` only on a crossing that exceeds the feasibility
+            // tolerance, which is what `fbbt`, `fbbt_fp` and `probing` have
+            // always done.
+            //
+            // Measured on the in-repo corpus: the strict `lo > hi` test that
+            // used to be here aborted the sweep on `heatexch_gen3` at 8.5e-14
+            // with NO flag set, killing its presolve after 1 sweep instead of
+            // 16 — and it fired on zero instances with a crossing above
+            // `FEAS_TOL`. Every abort it produced corpus-wide was spurious.
+            subtol_crossings_repaired += repair_subtol_crossings(&mut ctx.bounds, FEAS_TOL);
+            if any_empty_beyond(&ctx.bounds, FEAS_TOL) {
                 deltas.push(delta);
                 terminated_by = TerminationReason::Infeasible;
                 break 'outer;
@@ -152,11 +179,8 @@ pub fn run(model: crate::expr::ModelRepr, mut opts: OrchestratorOptions) -> Pres
         deltas,
         iterations: last_iter,
         terminated_by,
+        subtol_crossings_repaired,
     }
-}
-
-fn any_empty(bounds: &[super::fbbt::Interval]) -> bool {
-    bounds.iter().any(|b| b.is_empty())
 }
 
 #[cfg(test)]
@@ -189,6 +213,69 @@ mod tests {
             }],
             n_vars: 1,
         }
+    }
+
+    // ── #907: a sub-FEAS_TOL crossing must not abort the presolve sweep ──
+    //
+    // The orchestrator's emptiness test used to be a strict `lo > hi`, while
+    // `fbbt`, `fbbt_fp` and `probing` all gate on `is_empty_beyond(FEAS_TOL)`.
+    // Measured on the in-repo corpus, that strict test aborted the sweep on
+    // `heatexch_gen3` at 8.5e-14 on the DEFAULT path — killing its presolve
+    // after 1 sweep instead of 16 — and fired on zero instances with a crossing
+    // above FEAS_TOL. Every abort it produced corpus-wide was spurious.
+
+    /// A pass that stamps a fixed interval onto variable 0, once.
+    struct StampPass {
+        iv: super::super::fbbt::Interval,
+        done: bool,
+    }
+
+    impl PresolvePass for StampPass {
+        fn name(&self) -> &'static str {
+            "stamp"
+        }
+        fn category(&self) -> PassCategory {
+            PassCategory::BoundsOnly
+        }
+        fn run(&mut self, ctx: &mut PresolveContext) -> PresolveDelta {
+            let mut d = PresolveDelta::empty(self.name(), ctx.iter);
+            if !self.done {
+                ctx.bounds[0] = self.iv;
+                self.done = true;
+                d.bounds_tightened = 1;
+            }
+            d
+        }
+    }
+
+    #[test]
+    fn subtol_crossing_does_not_abort_sweep_and_box_is_repaired() {
+        // The exact `heatexch_gen3` var4 crossing, on the default path.
+        let iv = super::super::fbbt::Interval::new(226.7, 226.699_999_999_999_9);
+        let opts = OrchestratorOptions::with_passes(vec![Box::new(StampPass { iv, done: false })]);
+        let result = run(trivial_model(), opts);
+
+        assert_ne!(
+            result.terminated_by,
+            TerminationReason::Infeasible,
+            "a 8.5e-14 crossing aborted the presolve — #907 regressed"
+        );
+        assert_eq!(result.subtol_crossings_repaired, 1);
+        // The returned box must not be inverted: declining to DECLARE emptiness
+        // is not enough if an inverted interval still reaches a consumer.
+        assert!(!result.bounds[0].is_formally_inverted());
+        assert!(result.bounds[0].contains(226.7));
+        assert!(result.bounds[0].contains(226.699_999_999_999_9));
+    }
+
+    /// ANTI-PERMISSIVENESS CONTROL: a crossing beyond FEAS_TOL must still abort.
+    #[test]
+    fn genuine_crossing_still_aborts_sweep() {
+        let iv = super::super::fbbt::Interval::new(1.0, 0.0); // crossing 1.0
+        let opts = OrchestratorOptions::with_passes(vec![Box::new(StampPass { iv, done: false })]);
+        let result = run(trivial_model(), opts);
+        assert_eq!(result.terminated_by, TerminationReason::Infeasible);
+        assert_eq!(result.subtol_crossings_repaired, 0);
     }
 
     #[test]

--- a/crates/discopt-python/src/expr_bindings.rs
+++ b/crates/discopt-python/src/expr_bindings.rs
@@ -606,6 +606,7 @@ impl PyModelRepr {
     /// Returns a dict with keys:
     /// - `lb`, `ub`: numpy arrays of post-tightening per-variable bounds.
     /// - `bounds_tightened`: int — number of half-bounds that tightened.
+    /// - `subtol_repaired`: int — sub-`FEAS_TOL` bound crossings repaired (#907).
     /// - `infeasible`: bool — `True` if the kernel detected emptiness.
     /// - `ran`: bool — `True` if the schedule actually fired at this depth.
     #[pyo3(signature = (
@@ -666,6 +667,9 @@ impl PyModelRepr {
         )?;
         out.set_item("bounds_tightened", delta.bounds_tightened)?;
         out.set_item("infeasible", delta.infeasible)?;
+        // #907: surfaced, not absorbed — a rising count is a numerical smell,
+        // and each of these events could previously have fathomed a live node.
+        out.set_item("subtol_repaired", delta.subtol_repaired)?;
         out.set_item("ran", delta.ran)?;
         Ok(out.into_any().unbind())
     }
@@ -824,6 +828,10 @@ impl PyModelRepr {
         // Build stats dict.
         let stats = PyDict::new(py);
         stats.set_item("terminated_by", format!("{:?}", result.terminated_by))?;
+        stats.set_item(
+            "subtol_crossings_repaired",
+            result.subtol_crossings_repaired,
+        )?;
         stats.set_item("iterations", result.iterations)?;
         let lbs: Vec<f64> = result.bounds.iter().map(|b| b.lo).collect();
         let ubs: Vec<f64> = result.bounds.iter().map(|b| b.hi).collect();

--- a/python/discopt/_jax/presolve_pipeline.py
+++ b/python/discopt/_jax/presolve_pipeline.py
@@ -154,6 +154,10 @@ def run_root_presolve(
         "iterations": raw["iterations"],
         "terminated_by": raw["terminated_by"],
         "deltas": list(raw["deltas"]),
+        # #907: sub-FEAS_TOL bound crossings repaired rather than mistaken for
+        # infeasibility. Surfaced, not absorbed — a rising count is a numerical
+        # smell, and before #907 each such event aborted the whole presolve.
+        "subtol_crossings_repaired": raw.get("subtol_crossings_repaired", 0),
     }
 
     # Synthesize legacy per-pass dicts from the delta log for backward


### PR DESCRIPTION
## What this fixes

`presolve::orchestrator::any_empty` and `bnb::in_tree_presolve` tested emptiness with `Interval::is_empty()` — strict `lo > hi`, **zero tolerance** — while `fbbt.rs`, `fbbt_fp.rs` and `probing.rs` all gate on `is_empty_beyond(FEAS_TOL)`. The two outliers were precisely the two that **act** on the verdict: the orchestrator aborts the presolve sweep, and the in-tree kernel sets `infeasible`, which `solver.py:9048` consumes under the literal comment `# Rigorous fathom` and prunes the subtree.

Default path. No flag required.

## Evidence

Independently reproduced on `main` (the issue's own probe depends on branch-only infrastructure that does not exist here, so these are fresh probes against `main`'s API):

| | |
|---|---|
| `heatexch_gen3`, no flags | root presolve `Infeasible` at a crossing of **8.53e-14**, `var4 = [226.7, 226.6999999999999]` |
| cost | presolve dies after **1 sweep instead of 16**; `probing` never runs |
| pass isolation | box is clean through `implied_bounds` (16 sweeps); adding `fbbt` flips it to `Infeasible` at iteration 1 — FBBT *manufactures* the crossing from a valid box |
| corpus | 66 instances, **12,006 executed bound comparisons**: 1 spurious abort, **0 genuine crossings above FEAS_TOL anywhere** |

## The threshold is measured, not assumed

The whole fix rests on FEAS_TOL sitting in a clean gap between noise and real infeasibility. That was tested *before* implementing, with a kill criterion ("no clean gap → the tolerance gate is wrong, stop"). Instrumented build, verdict logic byte-identical, **10,105 predicate evaluations**:

```
ORCH   ABSOLUTE  1e-14 | ###        (3 crossings, all heatexch_gen3)
       RELATIVE  1e-16 | ###
ITP    ABSOLUTE  1e+0  | ##########  (10 finite, all [1.0, 0.0] binary wipeout)
       + 124,346 explicit [inf,-inf] Interval::empty() sentinels
```

The distribution is **degenerate at two points**: noise at 1e-14 abs / 1e-16 rel, genuine at exactly 1.0. **Gap 1.2e13.** FEAS_TOL sits ~7 orders above the largest noise crossing and ~6 below the smallest genuine one, with nothing in between. This also explains *mechanically* why real fathoms survive: 124,346 of them carry the `[inf,-inf]` sentinel, and `inf > tol` for any finite tolerance.

## The fix

1. **Class fix.** `Interval::is_empty()` → `is_formally_inverted()`; `is_empty_beyond(tol)` documented as the only predicate that may conclude infeasibility. The compiler then enumerates every site — and caught one (`backward_propagate`) that my manual enumeration had misclassified as a `Vec` check. Benign guards keep the formal predicate with a note on why either answer is sound there.
2. **Gate both acting sites** on `any_empty_beyond(_, FEAS_TOL)`.
3. **Repair in place** to `[min(lo,hi), max(lo,hi)]` — the smallest interval containing both endpoints, so whichever derivation was sound keeps its endpoint and nothing feasible is cut. A midpoint collapse would be *tighter* than a sound endpoint and could cut the optimum. Necessary second half: declining to *declare* emptiness is not enough if an inverted interval still reaches an LP column bound. The in-tree kernel also sanitizes its incoming node box, and the **single exit** is now the only place any path decides infeasibility.

**Third hole, both directions (2nd commit).** The probing fold-back decided infeasibility with `new_lb[i] > new_ub[i] + opts.tol`. `opts.tol` is the FBBT *convergence* tolerance — smaller than `FEAS_TOL` in practice (1e-8 vs 1e-6) — so a crossing in `(opts.tol, FEAS_TOL]` still set the fathom flag on the opt-in path. The first commit closed only the *returned-inverted-box* direction; exit sanitation only ever ADDS `infeasible` and cannot clear a flag probing already set. The verdict is now removed from the fold-back loop entirely.

Counters are surfaced through PyO3 and `run_root_presolve`, not absorbed. No flag — gating a false-fathom fix default-OFF would ship the defect.

## Verification

Loosening a fathom is the sound direction (the node is explored, not discarded), so **3 of the 8 new Rust tests are anti-permissiveness controls** asserting a crossing beyond FEAS_TOL still aborts / still fathoms and that repair declines to touch a genuine or sentinel emptiness. Fail-before/pass-after confirmed by reverting only the behaviour with the tests in place: the 3 behavioural tests fail, the controls correctly still pass.

- **B — no valid point cut**: **2,155 executed oracle assertions** over the 19 in-repo `.sol` oracles, on node boxes deliberately inverted by 1e-16..1e-7 straddling the oracle coordinate — the exact shape that used to fathom. **0 fathomed, 0 points cut.**
- **D — bound neutrality**: 5,036 branch-simulated node evaluations; fathom set **node-for-node identical** to the pre-fix baseline on all **63 comparable** instances. 3 (`contvar`, `hda`, `heatexch_gen3`) are budget-dependent (`TimeBudget`) and excluded as non-comparable rather than counted as passes.
- **E — `heatexch_gen3`**: `Infeasible`@1 sweep → completes; 3 crossings repaired; 0 inverted intervals returned.
- **F — termination**: max root iterations 16 (the cap); the widening repair causes no fixed-point oscillation.
- `cargo test -p discopt-core` **575 passed** (+10) · `pytest -m smoke` **850 passed, 1 skipped, 2 xpassed** · adversarial **10 passed** · ruff / cargo fmt / clippy clean on touched files.

## Limits, stated rather than papered over

- The genuine population is **unsampled in (FEAS_TOL, 1.0)** — every finite genuine crossing observed came from one mechanism at exactly 1.0. The 13-order margin is real for the mechanisms this corpus exercises; it is not a proof that nothing can land near 1e-6.
- The **ORCH site has zero genuine crossings of any kind**, so its threshold is transferred from the ITP measurement by the assumption that it is the same `Interval` arithmetic. That is an extrapolation.
- The probing fold-back line is changed on **consistency grounds and is UNCOVERED by a fail-before test**: reverting that one line alone leaves the new probing tests green, because reaching it needs `probe_node_bounds` to return an interval inverted by `(opts.tol, FEAS_TOL]`, which no toy model here produces. The test's doc comment says so at the site.
- The **in-tree fathom is latent** on this corpus: a pre-fix differential build flipped **0 of 705** fathoms. This PR fixes a *live presolve regression* and closes a *latent* false-fathom hazard — it does not claim to fix an observed wrong answer.

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd

