### PR TITLE
fix(correctness): #908 incumbent verifiers accepted points violating a row

### DIFF
--- a/python/discopt/_jax/nlp_evaluator.py
+++ b/python/discopt/_jax/nlp_evaluator.py
@@ -1205,6 +1205,37 @@ class NLPEvaluator:
         """Total number of constraints."""
         return self._n_constraints
 
+    def constraint_row_map(self) -> list[tuple[int, int, "Constraint"]]:
+        """The authoritative row→``Constraint`` map: ``(start, stop, constraint)``
+        per source constraint, where ``evaluate_constraints(x)[start:stop]`` are
+        exactly that constraint's flat rows.
+
+        This exists because the mapping is genuinely non-trivial in two ways that
+        callers repeatedly got wrong (#908):
+
+        1. A constraint body may be **array-valued** — ``x <= 1`` on a 3-vector is
+           ONE :class:`Constraint` object and THREE rows. Walking
+           ``model._constraints`` with one index per object desynchronises from
+           the row stream on the first vector constraint and every check after it
+           reads the wrong row. Measured: that made both incumbent verifiers
+           vouch for a point violating a row by 5.0.
+        2. The row set is ``model._constraints`` **plus**
+           ``model._builder_linear_constraints()`` (#840). A caller reading only
+           ``_constraints`` both misses the builder rows entirely and mis-indexes
+           the ones it does read.
+
+        Consume this rather than re-deriving the correspondence: it is built from
+        the same ``_source_constraints`` / ``_constraint_flat_sizes`` the compiled
+        concatenation uses, so the two cannot drift.
+        """
+        out: list[tuple[int, int, Constraint]] = []
+        start = 0
+        for con, size in zip(self._source_constraints, self._constraint_flat_sizes):
+            stop = start + int(size)
+            out.append((start, stop, con))
+            start = stop
+        return out
+
     @property
     def variable_bounds(self) -> tuple[np.ndarray, np.ndarray]:
         """Returns (lb, ub) arrays of shape (n,) for all variables."""

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -743,94 +743,24 @@ def _native_kernel_verify_point(model, x_flat):
     point's TRUE objective in model units, or ``(False, None)``.
 
     Soundness (#764 Task 1): this gates whether a value may seed the native kernel's
-    incumbent cutoff. An unverified seed would poison every downstream certificate, so
-    the contract is strict — it returns ``True`` ONLY when the model evaluator
-    successfully evaluated every constraint AND the objective and every residual is
-    within the repo tolerances (bounds/constraints abs=1e-6 + rel=1e-4, integrality
-    1e-5). Any evaluator failure, shape mismatch, or non-finite value yields
-    ``(False, None)`` — never an optimistic pass. The objective returned is recomputed
-    from the original variables (independent of the kernel's McCormick aux columns), so
-    it is the genuinely-attained value, not an optimistic relaxation reading."""
-    from discopt.modeling.core import Constraint, ObjectiveSense, VarType
+    incumbent cutoff. An unverified seed would poison every downstream certificate.
 
-    abs_tol, rel_tol, int_tol = 1e-6, 1e-4, 1e-5
-    x_flat = np.asarray(x_flat, dtype=np.float64)
-    if not np.all(np.isfinite(x_flat)):
+    #908: the row walk this used to carry advanced one index per ``Constraint`` object
+    while the evaluator emits one row per FLAT element, so any vector constraint
+    desynchronised the two streams and the check read the wrong row — measured wrongly
+    accepting 4 of 5 constructed-infeasible points, including one violating a row by
+    5.0. It also never examined builder-resident linear rows and ignored
+    ``Constraint.rhs``. The logic now lives in ONE place,
+    :func:`discopt.validation.feasibility.verify_point`, which enumerates rows from the
+    evaluator's own row map so the misalignment class is structurally impossible.
+    """
+    from discopt.validation.feasibility import verify_point
+
+    res = verify_point(model, x_flat, with_objective=True)
+    if not res.ok:
+        logger.debug("native seed verification declined: %s", res.reason)
         return False, None
-
-    # Variable bounds + integrality against the ORIGINAL declared model. Bounds use the
-    # repo's COMBINED tolerance (abs=1e-6 + rel=1e-4 * |bound|): a local NLP returns a
-    # bound-active variable a few ULPs off its bound, and on a large-magnitude bound
-    # (tanksize x41 lb=536) a 4e-6 absolute slack is 8e-9 relative — inside the regime
-    # the whole solver (and its trusted incumbents) operate in. This is the same
-    # abs+rel tolerance the constraint residual check below uses.
-    off = 0
-    for v in model._variables:
-        size = int(getattr(v, "size", 1))
-        vals = x_flat[off : off + size]
-        if vals.shape[0] != size:
-            return False, None
-        lb_flat = np.asarray(v.lb, dtype=np.float64).flatten()
-        ub_flat = np.asarray(v.ub, dtype=np.float64).flatten()
-        lb_tol = abs_tol + rel_tol * np.abs(lb_flat)
-        ub_tol = abs_tol + rel_tol * np.abs(ub_flat)
-        if np.any(vals < lb_flat - lb_tol) or np.any(vals > ub_flat + ub_tol):
-            return False, None
-        if v.var_type in (VarType.INTEGER, VarType.BINARY):
-            if np.any(np.abs(vals - np.round(vals)) > int_tol):
-                return False, None
-        off += size
-
-    try:
-        # ``cached_evaluator``, not ``NLPEvaluator(model)``: this is called once per
-        # seed candidate (and once more on the final incumbent), and constructing an
-        # evaluator re-traces and re-compiles the model's JAX constraint/objective/
-        # Jacobian callables every time. Profiling #902 measured 697 traces / 8.5 s
-        # inside a 12 s seed phase on nvs19 — the same defect ``cached_evaluator`` was
-        # introduced to fix for the diving heuristic. The cache is keyed on the model's
-        # structural fingerprint and reads bounds/parameters live, so a cached
-        # evaluator computes byte-identical residuals: this changes only the cost of
-        # the verification, never its verdict.
-        from discopt._jax.nlp_evaluator import cached_evaluator
-
-        evaluator = cached_evaluator(model)
-        if evaluator.n_constraints > 0:
-            cons = np.asarray(evaluator.evaluate_constraints(x_flat), dtype=np.float64)
-            idx = 0
-            for c in model._constraints:
-                if not isinstance(c, Constraint):
-                    continue
-                if idx >= cons.shape[0]:
-                    return False, None  # evaluator produced fewer rows than constraints
-                val = float(cons[idx])
-                if not math.isfinite(val):
-                    return False, None
-                tol = abs_tol + rel_tol * abs(val)
-                if c.sense == "<=":
-                    if val > tol:
-                        return False, None
-                elif c.sense == ">=":
-                    if val < -tol:
-                        return False, None
-                elif c.sense == "==":
-                    if abs(val) > tol:
-                        return False, None
-                else:
-                    return False, None  # unknown sense -> refuse to vouch for the point
-                idx += 1
-        obj_min = float(evaluator.evaluate_objective(x_flat))
-    except Exception as exc:  # evaluator could not vouch -> NOT verified
-        logger.debug("native seed verification skipped (evaluator error): %s", exc)
-        return False, None
-    if not math.isfinite(obj_min):
-        return False, None
-    # ``evaluate_objective`` negates the body for a MAXIMIZE model (it minimizes the
-    # negation); undo that so the returned value is the objective in model units.
-    if model._objective.sense == ObjectiveSense.MAXIMIZE:
-        model_obj = -obj_min
-    else:
-        model_obj = obj_min
-    return True, float(model_obj)
+    return True, res.objective
 
 
 # Cap on the number of FREE integers (span > 0.5 in the presolved box) the seed

--- a/python/discopt/solvers/_convex_kernel.py
+++ b/python/discopt/solvers/_convex_kernel.py
@@ -777,22 +777,19 @@ def _unflatten(model, inc_x):
 
 
 def _incumbent_is_feasible(model, x_flat, tol: float = 1e-5) -> bool:
-    """#779: evaluate the PRISTINE model's constraints at `x_flat`; True iff feasible."""
-    import numpy as np
+    """#779: evaluate the PRISTINE model's constraints at `x_flat`; True iff feasible.
 
-    from discopt._jax.nlp_evaluator import NLPEvaluator
+    #908: this used to ``zip(g, model._constraints)`` — pairing per-ROW evaluator
+    values against per-CONSTRAINT-OBJECT entries. On any vector constraint the two
+    desynchronise (and ``zip`` silently truncates to the shorter), so it vouched for
+    points violating a row outright; it also checked neither variable bounds nor
+    integrality. It now delegates to the single verifier, which enumerates rows from
+    the evaluator's own row map.
 
-    try:
-        ev = NLPEvaluator(model)
-        g = np.asarray(ev.evaluate_constraints(x_flat), float)
-    except Exception:
-        return False
-    for gi, con in zip(g, model._constraints):
-        s = con.sense if isinstance(con.sense, str) else con.sense.value
-        if s == "<=" and gi > tol:
-            return False
-        if s == ">=" and gi < -tol:
-            return False
-        if s not in ("<=", ">=") and abs(gi) > tol:
-            return False
-    return True
+    ``tol`` is accepted for call-compatibility and ignored: the verifier keys its
+    tolerance on each row's own scale rather than on a flat constant, which is what
+    fixes the scale-blindness in both directions.
+    """
+    from discopt.validation.feasibility import verify_point
+
+    return bool(verify_point(model, x_flat).ok)

--- a/python/discopt/validation/feasibility.py
+++ b/python/discopt/validation/feasibility.py
@@ -1,0 +1,272 @@
+"""The single incumbent-feasibility verifier (#908).
+
+Every solver path that promotes a point to an incumbent — the native kernel's
+cutoff seed, the convex kernel's incumbent guard — must agree on what "feasible"
+means, and must be right. Before this module there were two independent
+implementations and both were wrong in the *wrongly-accept* direction.
+
+What went wrong, and why the fix is shaped this way
+---------------------------------------------------
+
+Both verifiers advanced **one row index per** :class:`~discopt.modeling.core.Constraint`
+**object** while :class:`~discopt._jax.nlp_evaluator.NLPEvaluator` emits **one row
+per flat element**. A constraint body may be array-valued — ``x <= 1`` on a
+3-vector is one ``Constraint`` and three rows — so on any model with a vector
+constraint the two streams desynchronise and every check from that point on reads
+the wrong row. Measured on a purpose-built corpus: a point violating row 2 of a
+size-3 vector constraint **by 5.0** was reported feasible by both verifiers, and
+4 of 5 constructed-infeasible points were wrongly accepted.
+
+The fix is not to patch the arithmetic. Rows are enumerated from
+:meth:`NLPEvaluator.constraint_row_map`, the evaluator's own map, so the
+misalignment class is **structurally impossible**: the same
+``_source_constraints`` / ``_constraint_flat_sizes`` that build the compiled
+concatenation also drive the verification, and they cannot drift.
+
+That row map also closes a second hole for free. The evaluator's row set is
+``model._constraints`` **plus** ``model._builder_linear_constraints()`` (#840);
+a verifier reading only ``_constraints`` never examined the builder-resident
+linear rows at all — so a model built through ``add_linear_constraints`` or the
+``constraint(fast=True)`` path had those rows silently unchecked.
+
+Tolerance
+---------
+
+The old form was ``abs_tol + rel_tol * |residual|``, which is self-referential:
+it scales with the *residual* rather than with the *row*. On an equality row it
+collapses to a flat ``1e-6`` no matter whether the row's natural magnitude is 1
+or 10,782, so the ``rel_tol`` term is arithmetically dead and the check is
+scale-blind. Measured consequence in the other direction: ``nvs22``'s incumbent
+was rejected at a *relative* residual of 8.1e-9 (absolute 1.71e-5 against a row
+value of 2121.64).
+
+This module keys the tolerance on the **row's** scale::
+
+    violation_i <= abs_tol * max(1, |rhs_i|, max_j |J_ij| * max(1, |x_j|))
+
+Two properties of that form are load-bearing and easy to get wrong:
+
+* The relative coefficient is ``abs_tol`` (1e-6), **not** the repo's ``rel_tol``
+  (1e-4). Using ``rel_tol`` would loosen every unit-scale row 100x.
+* The Jacobian term is a *row-scale estimate*, not a slack. Dropping it makes the
+  test **stricter**, never looser — which is why the fallback below is sound.
+
+``test_vector_constraint_corpus.py`` carries a control for each naive widening of
+this form, showing that each one accepts a bad point this form rejects.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+#: Absolute feasibility tolerance, and the *relative* coefficient in the
+#: scale-keyed form above. Deliberately not ``rel_tol`` — see the module note.
+ABS_TOL = 1e-6
+#: Integrality tolerance for INTEGER/BINARY variables.
+INT_TOL = 1e-5
+#: Legacy relative coefficient, used ONLY for the variable-bound test, where it
+#: is keyed on the bound (a genuine scale) rather than on the residual.
+BOUND_REL_TOL = 1e-4
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    """Outcome of a feasibility verification.
+
+    ``objective`` is the point's TRUE objective in model units (MAXIMIZE
+    un-negated), or ``None`` when it was not requested or could not be computed.
+    ``reason`` names the first failing check — for logs, never for control flow.
+    """
+
+    ok: bool
+    objective: Optional[float] = None
+    reason: str = ""
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+def _sense_str(con) -> Optional[str]:
+    """``Constraint.sense`` is a ``str`` on some paths and an enum on others."""
+    s = con.sense
+    if not isinstance(s, str):
+        s = getattr(s, "value", None)
+    return s if s in ("<=", ">=", "==") else None
+
+
+def _row_violation(val: float, sense: str) -> float:
+    """Signed violation of ``body <sense> 0``, ``<= 0`` meaning satisfied."""
+    if sense == "<=":
+        return val
+    if sense == ">=":
+        return -val
+    return abs(val)
+
+
+def check_variable_bounds(model, x_flat: np.ndarray) -> VerifyResult:
+    """Variable bounds + integrality against the ORIGINAL declared model.
+
+    Bounds use ``abs_tol + rel_tol * |bound|``. Unlike the old *constraint*
+    tolerance this is keyed on the bound — a real scale — not on the residual, so
+    it is not self-referential: a local NLP returns a bound-active variable a few
+    ULPs off its bound, and on a large-magnitude bound (``tanksize`` x41 lb=536) a
+    4e-6 absolute slack is 8e-9 relative, inside the regime the whole solver
+    operates in.
+    """
+    from discopt.modeling.core import VarType
+
+    off = 0
+    for v in model._variables:
+        size = int(getattr(v, "size", 1))
+        vals = x_flat[off : off + size]
+        if vals.shape[0] != size:
+            return VerifyResult(False, None, f"length mismatch at variable {v.name!r}")
+        lb_flat = np.asarray(v.lb, dtype=np.float64).flatten()
+        ub_flat = np.asarray(v.ub, dtype=np.float64).flatten()
+        lb_tol = ABS_TOL + BOUND_REL_TOL * np.abs(lb_flat)
+        ub_tol = ABS_TOL + BOUND_REL_TOL * np.abs(ub_flat)
+        if np.any(vals < lb_flat - lb_tol) or np.any(vals > ub_flat + ub_tol):
+            return VerifyResult(False, None, f"variable {v.name!r} out of bounds")
+        if v.var_type in (VarType.INTEGER, VarType.BINARY):
+            if np.any(np.abs(vals - np.round(vals)) > INT_TOL):
+                return VerifyResult(False, None, f"variable {v.name!r} not integral")
+        off += size
+    return VerifyResult(True)
+
+
+def _row_scales(evaluator, x_flat: np.ndarray, rows: np.ndarray) -> Optional[np.ndarray]:
+    """``max_j |J_ij| * max(1, |x_j|)`` for the given row indices, or ``None``.
+
+    ``None`` means the Jacobian was unavailable, and the caller must then fall
+    back to the Jacobian-free bound — which is STRICTER, so the fallback can only
+    reject a point the full form would have accepted. It can never accept one the
+    full form would reject.
+    """
+    try:
+        J = np.asarray(evaluator.evaluate_jacobian(x_flat), dtype=np.float64)
+    except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+        logger.debug("feasibility: Jacobian unavailable, using the stricter bound: %s", exc)
+        return None
+    if J.ndim != 2 or J.shape[0] <= int(rows.max()):
+        logger.debug("feasibility: Jacobian shape %s cannot cover rows; stricter bound", J.shape)
+        return None
+    xw = np.maximum(1.0, np.abs(np.asarray(x_flat, dtype=np.float64)))
+    sub = np.abs(J[rows, :]) * xw[None, :]
+    if not np.all(np.isfinite(sub)):
+        logger.debug("feasibility: non-finite Jacobian entry; stricter bound")
+        return None
+    return np.asarray(sub.max(axis=1), dtype=np.float64)
+
+
+def check_constraints(model, x_flat: np.ndarray, evaluator=None) -> VerifyResult:
+    """Every constraint row, enumerated from the evaluator's own row map."""
+    if evaluator is None:
+        from discopt._jax.nlp_evaluator import cached_evaluator
+
+        evaluator = cached_evaluator(model)
+
+    if evaluator.n_constraints <= 0:
+        return VerifyResult(True)
+
+    g = np.asarray(evaluator.evaluate_constraints(x_flat), dtype=np.float64)
+    row_map = evaluator.constraint_row_map()
+    n_rows = row_map[-1][1] if row_map else 0
+    if g.shape[0] < n_rows:
+        # The evaluator produced fewer rows than its own map claims. Refuse to
+        # vouch rather than check a prefix.
+        return VerifyResult(
+            False, None, f"evaluator produced {g.shape[0]} rows, map wants {n_rows}"
+        )
+
+    # Pass 1 — residuals under the Jacobian-FREE (stricter) bound. Rows that
+    # clear this also clear the scale-aware bound, which is never smaller, so the
+    # Jacobian is computed only when some row is actually near or over the line.
+    viol = np.zeros(n_rows, dtype=np.float64)
+    anchor = np.ones(n_rows, dtype=np.float64)
+    for start, stop, con in row_map:
+        sense = _sense_str(con)
+        if sense is None:
+            return VerifyResult(False, None, f"unknown constraint sense {con.sense!r}")
+        # Honour Constraint.rhs. Bodies built through the operator API are
+        # normalised to rhs == 0, but the field is settable and the evaluator
+        # compiles the BODY ONLY, so `body <sense> rhs` must be re-centred here.
+        rhs = float(getattr(con, "rhs", 0.0) or 0.0)
+        for i in range(start, stop):
+            val = float(g[i]) - rhs
+            if not math.isfinite(val):
+                return VerifyResult(False, None, f"non-finite residual in row {i}")
+            viol[i] = _row_violation(val, sense)
+            anchor[i] = max(1.0, abs(rhs))
+
+    suspect = np.nonzero(viol > ABS_TOL * anchor)[0]
+    if suspect.size == 0:
+        return VerifyResult(True)
+
+    # Pass 2 — only the suspect rows get the full scale-keyed bound.
+    scales = _row_scales(evaluator, x_flat, suspect)
+    if scales is None:
+        worst = int(suspect[int(np.argmax(viol[suspect]))])
+        return VerifyResult(False, None, f"row {worst} violated by {viol[worst]:.3e}")
+    allowed = ABS_TOL * np.maximum(anchor[suspect], scales)
+    over = viol[suspect] > allowed
+    if np.any(over):
+        k = int(np.argmax(np.where(over, viol[suspect] - allowed, -np.inf)))
+        w = int(suspect[k])
+        return VerifyResult(
+            False, None, f"row {w} violated by {viol[w]:.3e} (allowed {allowed[k]:.3e})"
+        )
+    return VerifyResult(True)
+
+
+def verify_point(
+    model,
+    x_flat,
+    *,
+    with_objective: bool = False,
+) -> VerifyResult:
+    """Verify ``x_flat`` is feasible for ``model``; optionally return its objective.
+
+    The contract is strict, because callers use this to decide whether a value may
+    seed an incumbent cutoff and an unverified seed poisons every downstream
+    certificate: this returns ``ok=True`` ONLY when the evaluator successfully
+    evaluated every constraint row and every residual, bound and integrality
+    condition is within tolerance. Any evaluator failure, shape mismatch or
+    non-finite value yields ``ok=False`` — never an optimistic pass.
+    """
+    from discopt.modeling.core import ObjectiveSense
+
+    x_flat = np.asarray(x_flat, dtype=np.float64)
+    if x_flat.ndim != 1 or not np.all(np.isfinite(x_flat)):
+        return VerifyResult(False, None, "point is not a finite 1-D vector")
+
+    res = check_variable_bounds(model, x_flat)
+    if not res.ok:
+        return res
+
+    try:
+        from discopt._jax.nlp_evaluator import cached_evaluator
+
+        evaluator = cached_evaluator(model)
+        res = check_constraints(model, x_flat, evaluator=evaluator)
+        if not res.ok:
+            return res
+        if not with_objective:
+            return VerifyResult(True)
+        obj_min = float(evaluator.evaluate_objective(x_flat))
+    except Exception as exc:  # noqa: BLE001 - the evaluator could not vouch
+        logger.debug("feasibility verification declined (evaluator error): %s", exc)
+        return VerifyResult(False, None, f"evaluator error: {exc}")
+
+    if not math.isfinite(obj_min):
+        return VerifyResult(False, None, "non-finite objective")
+    # ``evaluate_objective`` minimises the negation for a MAXIMIZE model; undo
+    # that so the returned value is the objective in model units.
+    model_obj = -obj_min if model._objective.sense == ObjectiveSense.MAXIMIZE else obj_min
+    return VerifyResult(True, float(model_obj))

--- a/python/tests/test_vector_constraint_corpus.py
+++ b/python/tests/test_vector_constraint_corpus.py
@@ -1,0 +1,330 @@
+"""#908 — the incumbent verifiers must not vouch for points that violate a row.
+
+Coverage note worth knowing before trusting any correctness benchmark here:
+**every row in the in-repo ``.nl`` corpus is scalar**, so ``from_nl`` models cannot
+exercise this class at all. A correctness sweep over the ``.nl`` corpus alone is
+structurally blind to it. This corpus is therefore built through the modelling
+API, which is where array-valued constraint bodies come from (``x <= 1`` on a
+3-vector is ONE ``Constraint`` and THREE evaluator rows).
+
+The pre-fix row loop is transcribed verbatim below as :func:`_pre908_verify` and
+run against the same cases, so "it wrongly accepted these" is *reproduced* here
+rather than argued from a commit message.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt import Model
+from discopt._jax.nlp_evaluator import NLPEvaluator
+from discopt.solver import _native_kernel_verify_point
+from discopt.solvers._convex_kernel import _incumbent_is_feasible
+from discopt.validation.feasibility import ABS_TOL, verify_point
+
+pytestmark = pytest.mark.smoke
+
+
+# --------------------------------------------------------------------------
+# The pre-fix implementation, transcribed verbatim.
+# --------------------------------------------------------------------------
+def _pre908_verify(model, x_flat) -> bool:
+    """The row loop as it stood before #908: ONE index per ``Constraint`` object.
+
+    Kept so the wrong-accept result is reproducible rather than asserted. Do not
+    "fix" this — its wrongness is the point of the test.
+    """
+    from discopt.modeling.core import Constraint
+
+    abs_tol, rel_tol = 1e-6, 1e-4
+    ev = NLPEvaluator(model)
+    if ev.n_constraints <= 0:
+        return True
+    cons = np.asarray(ev.evaluate_constraints(x_flat), dtype=np.float64)
+    idx = 0
+    for c in model._constraints:
+        if not isinstance(c, Constraint):
+            continue
+        if idx >= cons.shape[0]:
+            return False
+        val = float(cons[idx])
+        tol = abs_tol + rel_tol * abs(val)
+        if c.sense == "<=":
+            if val > tol:
+                return False
+        elif c.sense == ">=":
+            if val < -tol:
+                return False
+        elif c.sense == "==":
+            if abs(val) > tol:
+                return False
+        else:
+            return False
+        idx += 1
+    return True
+
+
+def _vector_le():
+    m = Model("vec_le")
+    x = m.continuous("x", shape=(3,), lb=0.0, ub=10.0)
+    m.subject_to(x <= 1.0)
+    m.minimize(x[0])
+    return m, np.array([0.5, 0.5, 6.0])
+
+
+def _vector_eq():
+    m = Model("vec_eq")
+    x = m.continuous("x", shape=(3,), lb=-10.0, ub=10.0)
+    m.subject_to(x == 0.0)
+    m.minimize(x[0])
+    return m, np.array([0.0, 3.0, 0.0])
+
+
+def _vector_then_scalar():
+    m = Model("vec_then_scalar")
+    x = m.continuous("x", shape=(3,), lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.subject_to(x <= 5.0)
+    m.subject_to(y <= 1.0)
+    m.minimize(y)
+    return m, np.array([0.0, 0.0, 0.0, 9.0])
+
+
+def _two_vectors():
+    m = Model("two_vec")
+    x = m.continuous("x", shape=(2,), lb=0.0, ub=10.0)
+    y = m.continuous("y", shape=(2,), lb=0.0, ub=10.0)
+    m.subject_to(x <= 1.0)
+    m.subject_to(y <= 1.0)
+    m.minimize(x[0])
+    return m, np.array([0.0, 0.0, 0.0, 7.0])
+
+
+BAD_CASES = [
+    pytest.param(_vector_le, id="vector_le_row2_violated_by_5"),
+    pytest.param(_vector_eq, id="vector_eq_row1_violated_by_3"),
+    pytest.param(_vector_then_scalar, id="scalar_row_shifted_by_vector"),
+    pytest.param(_two_vectors, id="two_vector_constraints"),
+]
+
+
+def _assert_point_is_in_bounds(model, pt):
+    """The bad point must be in-bounds, so the ROW check is provably the only
+    thing that can reject it. Without this the test could pass for the wrong
+    reason (rejected on bounds, row misalignment untouched)."""
+    off = 0
+    for v in model._variables:
+        size = int(getattr(v, "size", 1))
+        vals = pt[off : off + size]
+        lb = np.asarray(v.lb, float).flatten()
+        ub = np.asarray(v.ub, float).flatten()
+        assert np.all(vals >= lb - 1e-9) and np.all(vals <= ub + 1e-9), (
+            "point is out of bounds — the row check is not the discriminator here"
+        )
+        off += size
+
+
+@pytest.mark.parametrize("build", BAD_CASES)
+def test_infeasible_vector_point_is_rejected_by_all_entry_points(build):
+    model, pt = build()
+    _assert_point_is_in_bounds(model, pt)
+
+    ok_native, obj = _native_kernel_verify_point(model, pt)
+    assert ok_native is False, "native kernel vouched for a point violating a row"
+    assert obj is None
+    assert _incumbent_is_feasible(model, pt) is False
+    assert verify_point(model, pt).ok is False
+
+
+@pytest.mark.parametrize("build", BAD_CASES)
+def test_pre908_row_loop_wrongly_accepted_these(build):
+    """The discriminator: the pre-fix loop ACCEPTS every one of these.
+
+    If this ever starts failing, the corpus has stopped exercising the
+    misalignment and the tests above are no longer evidence of anything.
+    """
+    model, pt = build()
+    assert _pre908_verify(model, pt) is True, (
+        "the pre-fix loop rejected this point, so the case no longer discriminates"
+    )
+
+
+def test_scalar_control_is_rejected_by_old_and_new():
+    """Control: with only scalar rows the two streams agree, so the OLD loop must
+    reject too. This is what shows the corpus measures ALIGNMENT rather than the
+    new verifier simply failing everything."""
+    m = Model("scalar_ctl")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    m.subject_to(x <= 1.0)
+    m.minimize(x)
+    pt = np.array([7.0])
+    assert _pre908_verify(m, pt) is False
+    assert verify_point(m, pt).ok is False
+
+
+def test_feasible_vector_point_is_still_accepted():
+    """Control in the other direction: a genuinely feasible vector point must be
+    ACCEPTED by all three entry points, so the fix cannot be 'reject everything'."""
+    m = Model("vec_ok")
+    x = m.continuous("x", shape=(3,), lb=0.0, ub=10.0)
+    m.subject_to(x <= 5.0)
+    m.minimize(x[0])
+    pt = np.array([1.0, 2.0, 3.0])
+    ok, obj = _native_kernel_verify_point(m, pt)
+    assert ok is True
+    assert obj == pytest.approx(1.0)
+    assert _incumbent_is_feasible(m, pt) is True
+    assert verify_point(m, pt).ok is True
+
+
+def test_maximize_objective_is_returned_in_model_units():
+    m = Model("vec_max")
+    x = m.continuous("x", shape=(2,), lb=0.0, ub=10.0)
+    m.subject_to(x <= 5.0)
+    m.maximize(x[0] + x[1])
+    ok, obj = _native_kernel_verify_point(m, np.array([2.0, 3.0]))
+    assert ok is True
+    assert obj == pytest.approx(5.0), "MAXIMIZE objective was not un-negated"
+
+
+def test_builder_resident_linear_rows_are_examined():
+    """#840 rows live in the builder, not ``model._constraints``. The evaluator
+    includes them; a verifier walking ``_constraints`` never saw them at all."""
+    m = Model("builder_rows")
+    x = m.continuous("x", shape=(3,), lb=0.0, ub=10.0)
+    A = np.eye(3)
+    m.add_linear_constraints(A, x, "<=", np.array([1.0, 1.0, 1.0]), name="cap")
+    m.minimize(x[0])
+
+    assert len(m._constraints) == 0, "precondition: these rows are builder-resident"
+    assert len(m._builder_linear_constraints()) == 3
+
+    pt = np.array([0.0, 0.0, 8.0])  # violates row 2 by 7
+    _assert_point_is_in_bounds(m, pt)
+    assert _pre908_verify(m, pt) is True, "precondition: the old loop could not see these"
+    assert verify_point(m, pt).ok is False
+    assert _native_kernel_verify_point(m, pt)[0] is False
+    assert _incumbent_is_feasible(m, pt) is False
+
+
+def test_row_map_covers_every_evaluator_row_exactly_once():
+    """Structural invariant: the map partitions ``[0, n_constraints)``. This is
+    what makes the misalignment class impossible rather than merely fixed."""
+    m = Model("cover")
+    x = m.continuous("x", shape=(3,), lb=0.0, ub=10.0)
+    y = m.continuous("y", lb=0.0, ub=10.0)
+    m.subject_to(x <= 5.0)
+    m.subject_to(y <= 1.0)
+    m.add_linear_constraints(np.ones((1, 3)), x, "<=", np.array([9.0]), name="tot")
+    m.minimize(y)
+
+    ev = NLPEvaluator(m)
+    rows = ev.constraint_row_map()
+    covered = []
+    for start, stop, _ in rows:
+        covered.extend(range(start, stop))
+    assert covered == list(range(ev.n_constraints)), "row map does not partition the rows"
+    assert ev.n_constraints == 5  # 3 vector + 1 scalar + 1 builder
+
+
+# --------------------------------------------------------------------------
+# Tolerance: keyed on the ROW's scale, and not one notch looser.
+# --------------------------------------------------------------------------
+def test_large_scale_row_is_not_rejected_for_a_tiny_relative_residual():
+    """The nvs22 direction: an absolute residual of 1.7e-5 against a row whose
+    natural magnitude is ~2100 is a RELATIVE 8e-9 and must be accepted. The old
+    flat 1e-6 rejected it."""
+    m = Model("big_scale")
+    x = m.continuous("x", lb=0.0, ub=1e4)
+    m.subject_to(2121.64 * x == 2121.64)
+    m.minimize(x)
+    # Perturb so the row residual is ~1.7e-5 in absolute terms.
+    pt = np.array([1.0 + 8.1e-9])
+    ev = NLPEvaluator(m)
+    resid = abs(float(np.asarray(ev.evaluate_constraints(pt))[0]))
+    assert 1e-6 < resid < 1e-3, f"case does not exercise the regime (resid={resid:.3e})"
+    assert verify_point(m, pt).ok is True, "scale-blind rejection of a valid incumbent"
+
+
+def test_unit_scale_row_is_still_held_to_the_absolute_tolerance():
+    """Anti-permissiveness: scale-keying must not loosen a unit-scale row."""
+    m = Model("unit_scale")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    m.subject_to(x == 1.0)
+    m.minimize(x)
+    assert verify_point(m, np.array([1.0 + 1e-9])).ok is True
+    assert verify_point(m, np.array([1.0 + 1e-3])).ok is False
+
+
+# Each entry is a NAIVE WIDENING of
+#     violation <= abs_tol * max(1, |rhs|, max_j |J_ij| * max(1,|x_j|))
+# together with a (violation, scale) pair it accepts and the chosen form rejects.
+# The direction matters: every one of these is LOOSER, and three of them are
+# looser in a way that grows with the violation itself.
+NAIVE_WIDENINGS = [
+    pytest.param(
+        lambda viol, scale, val: viol <= 1e-4 * max(1.0, scale),
+        1e-5,
+        1.0,
+        1e-5,
+        id="rel_tol_coefficient_instead_of_abs_tol__100x_looser",
+    ),
+    pytest.param(
+        lambda viol, scale, val: viol <= ABS_TOL + 1e-4 * abs(val),
+        1e-2,
+        1.0,
+        1e3,
+        id="self_referential_old_form__grows_with_the_residual",
+    ),
+    pytest.param(
+        lambda viol, scale, val: viol <= ABS_TOL * max(1.0, abs(val)),
+        1e-2,
+        1.0,
+        1e5,
+        id="anchored_on_row_VALUE__tolerance_grows_with_violation",
+    ),
+    pytest.param(
+        lambda viol, scale, val: viol <= ABS_TOL * max(1.0, 1000.0 * scale),
+        1e-4,
+        1.0,
+        1e-4,
+        id="sum_j_instead_of_max_j__scales_with_row_density",
+    ),
+]
+
+
+@pytest.mark.parametrize("widened,viol,scale,val", NAIVE_WIDENINGS)
+def test_naive_tolerance_widenings_accept_what_the_chosen_form_rejects(widened, viol, scale, val):
+    chosen = viol <= ABS_TOL * max(1.0, scale)
+    assert chosen is False, "case does not exercise the chosen form's boundary"
+    assert widened(viol, scale, val) is True, (
+        "this widening was supposed to be looser; the control no longer discriminates"
+    )
+
+
+def test_constraint_rhs_is_honoured():
+    """``Constraint.rhs`` must re-centre the row, not be ignored.
+
+    The evaluator compiles the **body only**. Bodies built through the operator
+    API normalise to ``rhs == 0`` (``x <= 10`` becomes body ``x - 10``, rhs 0), so
+    no production path in this tree is currently known to set a non-zero ``rhs``
+    — this guards a *latent* inconsistency rather than reproducing an observed
+    production failure. It is written on the ``>=`` side because that is the
+    direction in which ignoring ``rhs`` WRONGLY ACCEPTS: comparing the raw body
+    against 0 tests ``x >= 0``, which admits a point that violates ``x >= 2``.
+    """
+    from discopt.modeling.core import Constraint
+
+    m = Model("rhs")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    m.subject_to(x >= 0.0)
+    m.minimize(x)
+    # body is exactly `x`, so the stored constraint reads `x >= 2`.
+    m._constraints[0] = Constraint(body=x, sense=">=", rhs=2.0, name="floor")
+
+    ev = NLPEvaluator(m)
+    assert float(np.asarray(ev.evaluate_constraints(np.array([1.0])))[0]) == pytest.approx(1.0), (
+        "precondition: the evaluator returns the RAW body, un-centred by rhs"
+    )
+    assert verify_point(m, np.array([3.0])).ok is True, "rhs=2 should admit x=3"
+    assert verify_point(m, np.array([1.0])).ok is False, "rhs ignored: x=1 violates x>=2"


### PR DESCRIPTION
## What this fixes

Both incumbent feasibility verifiers advanced **one row index per `Constraint` object** while `NLPEvaluator` emits **one row per flat element**. A constraint body may be array-valued — `x <= 1` on a 3-vector is one `Constraint` and three rows — so on any model with a vector constraint the two streams desynchronise and every check from that point on reads the wrong row.

## Evidence (entry experiment, run before implementing)

The issue's own repro artifacts don't exist on `main` (both are branch-only), so this is a fresh probe against `main`'s API, with an explicit kill criterion.

| | pre-fix | post-fix |
|---|---|---|
| infeasible points wrongly accepted by `_native_kernel_verify_point` | **4/5** | 0/5 |
| infeasible points wrongly accepted by `_incumbent_is_feasible` | **4/5** | 0/5 |

A point violating **row 2 of a size-3 vector constraint by 5.0** was reported feasible by both.

The corpus is built so the result can't be an artefact: every bad point is **asserted in-bounds first**, so the row check is provably the only thing that could reject it; a **scalar control** is rejected by both old and new, so the corpus measures *alignment* rather than blanket failure; and a **feasible control** is accepted, so the fix isn't "reject everything."

Three further defects in the same code, all wrongly-accept:
- **builder-resident linear rows (#840) were never examined** — the evaluator's row set is `_constraints` **plus** `_builder_linear_constraints()`, so a verifier reading only `_constraints` both missed those rows *and* mis-indexed the rest;
- `Constraint.rhs` was ignored (the evaluator compiles the **body only**);
- `_incumbent_is_feasible` checked neither bounds nor integrality, and its `zip(g, model._constraints)` silently truncated to the shorter stream.

## The fix

**One** verifier — `discopt.validation.feasibility.verify_point` — enumerating rows from the evaluator's own map (`NLPEvaluator.constraint_row_map`, new, built from the same `_source_constraints` / `_constraint_flat_sizes` that drive the compiled concatenation). The misalignment class becomes **structurally impossible** rather than patched: the two cannot drift. Both call sites delegate; the duplicated row loops are deleted.

**Tolerance.** The old `abs_tol + rel_tol * |residual|` is self-referential — it scales with the *residual*, not the *row* — so on an equality row it collapses to a flat `1e-6` whether the row's natural magnitude is 1 or 10,782, and the `rel_tol` term is arithmetically dead. Now keyed on the row:

```
violation_i <= abs_tol * max(1, |rhs_i|, max_j |J_ij| * max(1, |x_j|))
```

The relative coefficient is `abs_tol` (1e-6), **not** `rel_tol` (1e-4), which would loosen every unit-scale row 100×. Four naive widenings each have a control test showing they accept a bad point this form rejects. The Jacobian is computed **only** for rows already exceeding the Jacobian-free bound; if unavailable, the fallback *is* that stricter bound — so it can only reject a point the full form would accept, never the reverse.

## Verification

- **Fail-before/pass-after**: with only the two consumers reverted and the new tests in place, **5 tests fail** (4 vector cases + builder rows); the 15 controls and pre-fix-transcription tests correctly still pass.
- **No-regression sweep**: 114 executed old-vs-new comparisons over the 19 in-repo `.sol` oracles plus perturbations — **True → False = 0** (no valid incumbent lost). 7 False → True, every one a large-scale row at **8e-9 … 1e-6 relative** residual (e.g. `clay0303hfsg`: violation 4.32e-6 against row scale 536). Scale-blindness fixed, not points laundered.
- **Coverage caveat, measured**: the sweep confirms **0 of 66** in-repo `.nl` instances has a non-scalar row. The `.nl` corpus is structurally **blind** to this defect class — which is why the regression corpus is built through the modelling API, and why a correctness benchmark over `.nl` alone would have reported everything green.
- `pytest -m smoke` **870 passed** (was 850; +20 new), 1 skipped, 2 xpassed · adversarial **10 passed** · ruff + ruff format + mypy clean. No Rust touched.

## Stated rather than implied

`Constraint.rhs`: no production path in this tree is currently known to set a non-zero value (the operator API normalises it to 0), so that test guards a **latent** inconsistency rather than reproducing an observed failure. It's written on the `>=` side because that's the direction in which ignoring `rhs` wrongly *accepts*. My first draft of that test asserted the wrong thing — `x <= 10` normalises to body `x - 10`, so `rhs=2` meant `x <= 12` — and the verifier was right; the test was wrong.

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
