### PR TITLE
fix(correctness): #909 a non-zero Constraint.rhs is a public-API wrong answer — refuse it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,46 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **A non-zero `Constraint.rhs` was a silent wrong answer through the public API**
+  (`fix(correctness)`, #909). `Constraint` is exported in
+  `discopt.modeling.__all__`, and `m.subject_to(Constraint(w, ">=", 5.0))` solved
+  to `w = 0` while the equivalent `m.subject_to(w >= 5.0)` solved to `w = 5`. The
+  cause is a split in the tree over what an unnormalized row means: **26 modules
+  read `Constraint.body` and never read `.rhs`** — the entire relaxation/branching
+  stack, whose seam is `_jax/dag_compiler.compile_constraint` — while
+  `validation/feasibility` computes `signed = body - rhs`. The row was therefore
+  *solved* as `body sense 0` but *verified* as `body - rhs sense 0`, so the solver
+  returned a point its own verifier called feasible and the user called wrong.
+
+  The fix **refuses loudly** rather than teaching the solve path to honour `rhs`
+  (CLAUDE.md §3). Threading it through would mean correcting all 26 modules, each
+  of which encodes the `body sense 0` form structurally rather than
+  arithmetically, and a partial job is strictly *worse* than the status quo: today
+  the relaxation stack is uniformly rhs-blind, so its McCormick envelope relaxes
+  the same row the verifier checks; half-honoured, the envelope would be built for
+  a *different* row than the one verified — a soundness hazard replacing a
+  wrong-answer hazard. The refusal fires at `subject_to` (both the scalar and the
+  list arm, so the error lands on the offending line) and at `Model.validate` (so
+  a direct `_constraints.append` cannot slip past, since `solve` always
+  validates), and the message names both rewrites. Array `rhs` is tested with
+  `np.any`, not `float()`, which would raise a confusing `TypeError` on a vector
+  row.
+
+  Entry experiment (CLAUDE.md §4) established that refusing breaks nothing:
+  **66 models / 3,705 executed rhs comparisons / 0 violations**, with a planted
+  control arm proving the probe can see a non-zero `rhs`; a dynamic arm over the
+  suite found 58 non-zero constructions, **all from test fixtures — zero
+  production producers**.
+
+  `Model.validate` gains `for_solve=True`. Writers that represent a row faithfully
+  rather than solving it pass `False`: **`.nl`** (folds the constant into the
+  r-section bound) and **GAMS** (emits `rhs` verbatim) export such a row correctly
+  and must not be refused. **`.lp` and `.mps` keep the refusal** — and this
+  corrects issue #909's own text, which listed them as honouring `rhs`: measured,
+  both rebuild the right-hand side from the *body* alone, so `Constraint(w, ">=",
+  5.0)` emitted `c0: w >= 0` (LP) and an empty `RHS` section (MPS). For those two
+  the refusal converts a silently wrong export into a loud error.
+
 - **The convex kernel's `clay0303hfsg` "false optimum" was a false CERTIFICATE, not
   an invalid relaxation** (`fix(correctness)`, #879). #879 recorded three
   mutually-inconsistent `optimal` results on `clay0303hfsg` (28351.42 / 36397.83 /

--- a/discopt_benchmarks/scripts/card4c_rhs_entry.py
+++ b/discopt_benchmarks/scripts/card4c_rhs_entry.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Entry experiment for the ``Constraint.rhs`` silent-divergence defect (Card 4c
+Task 2's incidental finding, §6 2026-07-30).
+
+**Hypothesis under test (H-RHS).** A non-zero ``Constraint.rhs`` is *unreachable*
+through supported construction: every producer in the tree normalizes the offset
+into ``body`` and leaves ``rhs == 0.0``, exactly as ``Constraint``'s own docstring
+declares ("always 0.0 in normalized form").
+
+**Why it matters.** ``_jax/dag_compiler.compile_constraint`` compiles
+``constraint.body`` and discards ``rhs``; ``validation/feasibility`` honours it
+(``signed = body - rhs``). If H-RHS holds, the divergence is unreachable except by
+out-of-contract construction and the correct fix is a LOUD REFUSAL at the model
+boundary. If H-RHS is FALSIFIED — some supported path really does emit a non-zero
+``rhs`` — refusing would break working models and the solve path must honour
+``rhs`` instead.
+
+**Kill criterion.** One constraint with ``abs(rhs) > 0`` reached from a supported
+constructor (``.nl`` reader, GAMS parser, modeling DSL, or any internal
+reformulation running on those) falsifies H-RHS.
+
+Per CLAUDE.md §6 the probe prints an executed-comparison count and exits non-zero
+when it is zero. Per §7 no exception is swallowed: a load failure is reported and
+counted, never absorbed.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+import traceback
+
+# CLAUDE.md §8 — verify which code was actually loaded before measuring.
+import discopt
+import discopt.modeling.core as core
+from discopt.modeling import Constraint  # noqa: F401  (import-time contract check)
+
+MARKER = "always 0.0 in normalized form"
+
+
+def _assert_loaded_tree() -> None:
+    print(f"discopt.__file__      = {discopt.__file__}", flush=True)
+    print(f"core.__file__         = {core.__file__}", flush=True)
+    doc = core.Constraint.__doc__ or ""
+    print(f"marker {MARKER!r} present in Constraint.__doc__: {MARKER in doc}", flush=True)
+    if MARKER not in doc:
+        raise SystemExit(
+            "ABORT: the Constraint docstring marker is absent — this is not the tree "
+            "under test (CLAUDE.md §8)."
+        )
+
+
+def scan_model(model, label: str) -> tuple[int, list[str]]:
+    """Return (comparisons_executed, violations) for one model."""
+    n = 0
+    bad: list[str] = []
+    for i, c in enumerate(getattr(model, "_constraints", []) or []):
+        rhs = getattr(c, "rhs", None)
+        if rhs is None:
+            # Not a Constraint-shaped row (SOS/complementarity/logical). Counted so
+            # the total reflects rows examined, never silently skipped (§6).
+            n += 1
+            continue
+        n += 1
+        if float(rhs) != 0.0:
+            bad.append(f"{label}[{i}] name={getattr(c, 'name', None)!r} rhs={float(rhs)!r}")
+    return n, bad
+
+
+def main() -> int:
+    _assert_loaded_tree()
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo = os.path.dirname(os.path.dirname(here))
+    corpus = sorted(glob.glob(os.path.join(repo, "python", "tests", "data", "minlplib_nl", "*.nl")))
+    print(f"corpus instances found: {len(corpus)}", flush=True)
+    if not corpus:
+        raise SystemExit("ABORT: corpus empty — the probe would measure nothing (§6).")
+
+    total_rows = 0
+    total_models = 0
+    load_failures: list[str] = []
+    violations: list[str] = []
+
+    for path in corpus:
+        name = os.path.basename(path)
+        try:
+            m = core.from_nl(path)
+        except Exception as exc:  # noqa: BLE001 — reported, never swallowed (§7)
+            load_failures.append(f"{name}: {type(exc).__name__}: {exc}")
+            print(f"  LOAD-FAIL {name}: {type(exc).__name__}: {exc}", flush=True)
+            continue
+        total_models += 1
+        n, bad = scan_model(m, name)
+        total_rows += n
+        violations.extend(bad)
+        print(f"  {name:28s} rows={n:6d} nonzero_rhs={len(bad)}", flush=True)
+
+    # Control arm (§6 non-vacuity): the probe MUST be able to see a non-zero rhs.
+    ctl = core.Model("rhs_control")
+    w = ctl.continuous("w", lb=0.0, ub=10.0)
+    ctl.minimize(w)
+    ctl._constraints.append(core.Constraint(w, ">=", 5.0))
+    ctl_rows, ctl_bad = scan_model(ctl, "CONTROL")
+    total_rows += ctl_rows
+    print(f"\ncontrol arm: rows={ctl_rows} nonzero_rhs={len(ctl_bad)} -> {ctl_bad}", flush=True)
+    if len(ctl_bad) != 1:
+        raise SystemExit(
+            "ABORT: the control arm did not register its planted non-zero rhs — the "
+            "probe cannot detect what it claims to measure (CLAUDE.md §6)."
+        )
+
+    # Operator arm: the supported DSL must normalize.
+    op = core.Model("rhs_operator")
+    v = op.continuous("v", lb=0.0, ub=10.0)
+    op.minimize(v)
+    op.subject_to(v >= 5.0)
+    op_rows, op_bad = scan_model(op, "OPERATOR")
+    total_rows += op_rows
+    print(f"operator arm: rows={op_rows} nonzero_rhs={len(op_bad)}", flush=True)
+
+    print("\n" + "=" * 72, flush=True)
+    print(f"EXECUTED_RHS_COMPARISONS {total_rows}", flush=True)
+    print(f"MODELS_LOADED            {total_models}", flush=True)
+    print(f"LOAD_FAILURES            {len(load_failures)}", flush=True)
+    print(f"CORPUS_VIOLATIONS        {len(violations)}", flush=True)
+    for v_ in violations:
+        print(f"  VIOLATION {v_}", flush=True)
+    if load_failures:
+        print("\nload failures (reported, not swallowed):", flush=True)
+        for f in load_failures:
+            print(f"  {f}", flush=True)
+
+    if total_rows == 0:
+        print("VACUOUS: zero comparisons executed", flush=True)
+        return 2
+    if op_bad:
+        print("H-RHS FALSIFIED: the operator DSL itself leaves a non-zero rhs.", flush=True)
+        return 3
+    if violations:
+        print("H-RHS FALSIFIED: a supported corpus path emits a non-zero rhs.", flush=True)
+        return 3
+    print(
+        "H-RHS HOLDS on this population: no supported constructor emits a non-zero "
+        "rhs; the control arm proves the probe can see one.",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except Exception:  # noqa: BLE001 — crash loudly with the traceback (§7)
+        traceback.print_exc()
+        sys.exit(1)

--- a/python/discopt/export/gams.py
+++ b/python/discopt/export/gams.py
@@ -51,7 +51,14 @@ def to_gams(
     str or None
         The GAMS source if *path* is ``None``, otherwise ``None``.
     """
-    model.validate()
+    # ``for_solve=False``: like the ``.nl`` writer, this one *honours*
+    # ``Constraint.rhs`` — it emits it verbatim as the equation's right-hand side
+    # (``{body} =g= {c.rhs};``) — so a row the solve path refuses as
+    # unrepresentable (#909) still exports faithfully. Measured:
+    # ``Constraint(w, ">=", 5.0)`` emits ``c1.. w =g= 5.0;``.
+    # NOTE: the LP and MPS writers deliberately do *not* do this — see the comment
+    # on their ``model.validate()`` calls.
+    model.validate(for_solve=False)
     writer = _GamsWriter(model, model_type)
     text = writer.write()
     if path is not None:

--- a/python/discopt/export/lp.py
+++ b/python/discopt/export/lp.py
@@ -47,6 +47,13 @@ def to_lp(model: Model, path: str | Path | None = None) -> str | None:
     ValueError
         If the model contains nonlinear (non-quadratic) expressions.
     """
+    # Default ``for_solve=True`` is deliberate: unlike the ``.nl`` and GAMS
+    # writers, this one does *not* honour ``Constraint.rhs``. The row's right-hand
+    # side below is ``-const``, recovered from the *body* alone, so a non-zero
+    # ``rhs`` is silently dropped. Measured (#909): ``Constraint(w, ">=", 5.0)``
+    # emitted ``c0: w >= 0`` — a silently wrong model. Keeping the refusal turns
+    # that into a loud error; do not relax it without teaching the row builder
+    # below to fold ``con.rhs`` in.
     model.validate()
     flat_vars = flatten_variables(model)
     var_names = [name for name, _, _, _, _ in flat_vars]

--- a/python/discopt/export/mps.py
+++ b/python/discopt/export/mps.py
@@ -49,6 +49,13 @@ def to_mps(model: Model, path: str | Path | None = None) -> str | None:
     ValueError
         If the model contains nonlinear (non-quadratic) expressions.
     """
+    # Default ``for_solve=True`` is deliberate: unlike the ``.nl`` and GAMS
+    # writers, this one does *not* honour ``Constraint.rhs``. The RHS section below
+    # is built from ``-const``, recovered from the *body* alone, so a non-zero
+    # ``rhs`` is silently dropped. Measured (#909): ``Constraint(w, ">=", 5.0)``
+    # emitted an empty ``RHS`` section — a silently wrong model. Keeping the
+    # refusal turns that into a loud error; do not relax it without teaching the
+    # row builder below to fold ``con.rhs`` in.
     model.validate()
     flat_vars = flatten_variables(model)
     var_names = [name for name, _, _, _, _ in flat_vars]

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -67,7 +67,12 @@ def to_nl(
     str or None
         The .nl text if *path* is ``None``, otherwise ``None``.
     """
-    model.validate()
+    # ``for_solve=False``: this writer *honours* ``Constraint.rhs`` — it folds the
+    # body constant into the r-section row bound — so a row the solve path refuses
+    # as unrepresentable (#909) is still exported faithfully here. Refusing it
+    # would block a correct export over a defect that only affects solving.
+    # Measured: ``Constraint(w, ">=", 5.0)`` emits ``r`` entry ``2 5.0``.
+    model.validate(for_solve=False)
     writer = _NLWriter(model)
     text = writer.write()
     if path is not None:

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -1649,7 +1649,11 @@ class Constraint:
     sense : str
         One of ``"<="``, ``">="``, ``"=="``.
     rhs : float
-        Right-hand side value (always 0.0 in normalized form).
+        Right-hand side value (always 0.0 in normalized form). This is an
+        *enforced* contract, not just a convention: the solve path reads only
+        ``body``, so a non-zero ``rhs`` is refused by both ``subject_to`` and
+        ``Model.validate`` rather than silently ignored (#909). Build rows with
+        the comparison operators, which fold the offset into ``body`` for you.
     name : str or None
         Optional name for debugging and explanation.
     """
@@ -1677,6 +1681,71 @@ class Constraint:
             "almost always a mistake. Add it with m.subject_to(...); to test an "
             "expression's identity use 'is' or a set/dict keyed by the object."
         )
+
+
+def _reject_unnormalized_rhs(constraint: "Constraint", *, where: str, index: int = -1) -> None:
+    """Refuse a constraint whose ``rhs`` the solve path cannot represent.
+
+    :class:`Constraint` documents ``rhs`` as *always 0.0 in normalized form*, and
+    the comparison operators that build every constraint in the supported DSL fold
+    the offset into ``body``. Most of the tree honours that invariant by simply not
+    looking at ``rhs``: **26 modules read ``Constraint.body`` and never read
+    ``.rhs``**, among them the whole relaxation stack (``_jax/dag_compiler``,
+    ``relaxation_compiler``, ``milp_relaxation``, ``mccormick_subgradient``,
+    ``term_classifier``, ``nonlinear_bound_tightening``, ``dependent_vars``,
+    ``implied_integer``, the convexity certificate, ``bilevel/kkt``, Benders, RO).
+
+    A handful of *other* consumers do honour it — ``validation/feasibility``
+    (``signed = body - rhs``), the ``.nl`` and GAMS exporters,
+    ``problem_classifier``, ``_jax/obbt``, and the Rust ``ConstraintRepr`` (114
+    references across the presolve crate). (Issue #909 also listed the LP and MPS
+    exporters here; **measured, that is false** — both rebuild the row's
+    right-hand side from the *body* alone and silently drop a non-zero ``rhs``, so
+    they are corrupters, not honourers, and they keep this refusal. See the
+    comments on their ``model.validate()`` calls.) That split is the defect: a row
+    carrying a non-zero ``rhs`` is
+    *solved* as ``body sense 0`` but *verified* as ``body - rhs sense 0``, so the
+    solver returns a point the verifier considers feasible and the user considers
+    wrong. Measured on this tree: ``Constraint(w, ">=", 5.0)`` solves to ``w = 0``
+    while ``w >= 5.0`` solves to ``w = 5`` — a silent wrong answer, reachable
+    through the public API (``Constraint`` is in ``discopt.modeling.__all__``).
+
+    **Why refuse rather than teach the solve path to honour ``rhs``.** Threading it
+    through would mean correcting all 26 modules, each of which encodes the ``body
+    sense 0`` form structurally rather than arithmetically. A partial job is
+    strictly worse than the status quo: today the relaxation stack is uniformly
+    rhs-blind, so its McCormick envelope still relaxes the same row the verifier
+    checks; half-honoured, the envelope would be built for a *different* row than
+    the one being verified — a soundness hazard in place of a wrong-answer hazard.
+    Refusing keeps one invariant that all 26 modules already rely on, and it costs
+    the caller one obvious rewrite. CLAUDE.md §3: refuse loudly rather than ship a
+    silent approximation.
+
+    Raised from both doors — :meth:`Model.subject_to` (so the error lands on the
+    offending line) and :meth:`Model.validate` (so a direct
+    ``model._constraints.append`` cannot slip past; ``solve`` always validates).
+    """
+    rhs = getattr(constraint, "rhs", 0.0)
+    if rhs is None:
+        return
+    rhs_arr = np.asarray(rhs, dtype=np.float64)
+    if not np.any(rhs_arr != 0.0):
+        return
+    shown = float(rhs_arr.ravel()[0]) if rhs_arr.size else 0.0
+    label = getattr(constraint, "name", None)
+    if label is None:
+        label = f"_constraints[{index}]" if index >= 0 else "<unnamed>"
+    sense = getattr(constraint, "sense", "?")
+    raise ValueError(
+        f"Constraint '{label}' has a non-zero rhs ({rhs!r}), which the solve path "
+        f"cannot represent: Constraint is stored in normalized form 'body {sense} 0' "
+        f"and the relaxation/branching stack reads only 'body'. Solving it would "
+        f"silently ignore the rhs and return a point the feasibility verifier — "
+        f"which does honour rhs — reports as feasible. Build the row with the "
+        f"comparison operators, which normalize for you (e.g. 'body {sense} "
+        f"{shown!r}'), or subtract the offset yourself: "
+        f"Constraint(body - rhs, '{sense}', 0.0). Reached via {where}."
+    )
 
 
 @dataclass
@@ -2892,6 +2961,7 @@ class Model:
         ...              name="adjacent_limits")
         """
         if isinstance(constraint, Constraint):
+            _reject_unnormalized_rhs(constraint, where="subject_to")
             # M5: never let ``subject_to`` corrupt an earlier row or clobber a
             # name the caller set. The corruption case is *re-adding the same
             # object* (or one already carrying a different name): stamping
@@ -2936,6 +3006,7 @@ class Model:
                     f"Expected Constraint (from <=, >=, == on expressions), "
                     f"got {type(c)} at position {k}."
                 )
+            _reject_unnormalized_rhs(c, where="subject_to", index=k)
             # Copy-on-name here too (M5): never mutate the caller's list elements.
             self._constraints.append(_dc_replace(c, name=f"{name}_{k}" if name else None))
 
@@ -4556,9 +4627,22 @@ class Model:
                 f"'{self_name}'."
             )
 
-    def validate(self):
+    def validate(self, *, for_solve: bool = True):
         """
         Validate model consistency.
+
+        Parameters
+        ----------
+        for_solve
+            Also enforce the checks that only the *solve* path needs — currently
+            the normalized-``rhs`` rejection (see :func:`_reject_unnormalized_rhs`).
+            Consumers that represent a row faithfully rather than solving it pass
+            ``False``: the ``.nl`` writer honours ``Constraint.rhs`` (it folds the
+            body constant into the r-section row bound) and so does the GAMS writer
+            (it emits ``rhs`` verbatim), so a model they can export correctly must
+            not be refused just because the solver could not solve it. The LP and
+            MPS writers do **not** honour it — measured — and so keep the default.
+            Default ``True``, so ``solve`` and direct calls are unchanged.
 
         Raises
         ------
@@ -4588,7 +4672,14 @@ class Model:
         # ``constraint_duals`` for same-named indexed rows — is tracked as a
         # follow-up (#413, M5). Unnamed constraints (``name is None``) are exempt.
         con_names: set = set()
-        for c in self._constraints:
+        for ci, c in enumerate(self._constraints):
+            # A row the solve path cannot represent must never reach it. This is
+            # the collection-level enforcement of ``Constraint``'s normalized form:
+            # ``subject_to`` catches the public door, but constraints also arrive by
+            # direct ``_constraints.append`` and by internal rebuilds that propagate
+            # ``c.rhs`` verbatim, and ``solve`` always comes through here.
+            if for_solve and isinstance(c, Constraint):
+                _reject_unnormalized_rhs(c, where="Model.validate", index=ci)
             cname = getattr(c, "name", None)
             if cname is None:
                 continue

--- a/python/tests/test_constraint_rhs_refusal.py
+++ b/python/tests/test_constraint_rhs_refusal.py
@@ -1,0 +1,383 @@
+"""A ``Constraint`` with a non-zero ``rhs`` must be refused, never silently solved.
+
+The defect (plan §6, 2026-07-30, filed by Card 4c Task 2). :class:`Constraint`
+documents ``rhs`` as *always 0.0 in normalized form*, and the comparison operators
+that build every row in the supported DSL fold the offset into ``body``. But
+nothing enforced that, and the two halves of the stack disagree about what an
+unnormalized row means:
+
+* **26 modules read ``Constraint.body`` and never read ``.rhs``** — the whole
+  relaxation stack (``dag_compiler``, ``relaxation_compiler``, ``milp_relaxation``,
+  ``mccormick_subgradient``, ``term_classifier``, ``nonlinear_bound_tightening``,
+  ``dependent_vars``, ``implied_integer``, the convexity certificate, ``bilevel/kkt``,
+  Benders, RO). ``dag_compiler.compile_constraint`` is the seam: it compiles
+  ``constraint.body`` and drops ``rhs`` on the floor.
+* ``validation/feasibility`` (``signed = body - rhs``), the ``.nl`` and GAMS
+  exporters, ``problem_classifier``, ``_jax/obbt`` and the Rust ``ConstraintRepr``
+  (114 references in the presolve crate) all **do** honour it.
+
+  *Correction (CLAUDE.md §11).* Issue #909 and the first write-up of this file
+  both stated that "the exporters" honour ``rhs``, naming LP and MPS among them.
+  **Measured on this tree, that is false for LP and MPS** — both recover the row's
+  right-hand side from the *body* alone (``lp.py`` ``rows.append((..., -const))``,
+  ``mps.py`` likewise), so a non-zero ``rhs`` is silently dropped:
+  ``Constraint(w, ">=", 5.0)`` exported as ``c0: w >= 0`` in LP and as an empty
+  ``RHS`` section in MPS. Only ``.nl`` (r-section ``2 5.0``) and GAMS
+  (``c1.. w =g= 5.0;``) are faithful. The scoping below follows the measurement,
+  not the write-up: ``.nl`` and GAMS pass ``for_solve=False`` and export such a
+  row; LP and MPS keep the refusal, which converts a silently wrong export into a
+  loud error.
+
+So the row was *solved* as ``body sense 0`` and *verified* as ``body - rhs sense
+0``: ``Constraint(w, ">=", 5.0)`` solved to ``w = 0`` while the equivalent
+``w >= 5.0`` solved to ``w = 5``, and the verifier called the first one feasible.
+A silent wrong answer, and — contrary to the original write-up, which believed only
+the private ``_constraints.append`` path was affected — reachable straight through
+the **public API**: ``Constraint`` is exported in ``discopt.modeling.__all__`` and
+``m.subject_to(Constraint(w, ">=", 5.0))`` reproduced it exactly.
+
+Direction of the fix (CLAUDE.md §3). The model boundary **refuses loudly**; the
+solve path is not taught to honour ``rhs``. Threading ``rhs`` through would mean
+correcting all 26 modules, each of which encodes the ``body sense 0`` form
+structurally rather than arithmetically, and a partial job is strictly worse than
+the status quo: today the relaxation stack is uniformly rhs-blind, so its McCormick
+envelope still relaxes the same row the verifier checks; half-honoured, the envelope
+would be built for a *different* row than the one being verified — a soundness
+hazard in place of a wrong-answer hazard.
+
+This file tests **both directions** the finding named:
+
+1. the refusal fires, at both doors, for scalar and vector rows, named and unnamed
+   (``test_*_refused``);
+2. the normalized construction the DSL produces is untouched and still solves to the
+   right answer (``test_*_still_solves``) — the control that proves the guard is
+   discriminating rather than rejecting everything.
+
+3. the export scoping is right in *both* directions: the writers that honour
+   ``rhs`` still emit such a row, the writers that would corrupt it refuse
+   (``test_*_writers_*``).
+
+Per CLAUDE.md §6 every arm bumps a module counter and a module-scoped finalizer
+fails if this worker executed none. The finalizer deliberately does **not** assert
+per-arm totals — CI runs ``-n <workers> --dist loadgroup``, so each worker owns a
+separate copy of the counters and a zero there is a statement about the scheduler,
+not the code. The complete senses x doors claim is re-derived inside the single
+test :func:`test_every_door_refuses_the_full_matrix`, which is therefore always
+whole. (Verified by running this file under ``-n 4 --dist loadgroup``, not by
+reasoning about it — the sibling Card 4c guard failed in CI on exactly this.)
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt.modeling import Constraint, Model  # noqa: E402
+
+pytestmark = pytest.mark.smoke
+
+# Executed-assertion counters (CLAUDE.md §6). A guard test at the bottom fails if
+# any of them is still zero, so a collection error or an over-broad skip cannot
+# leave this file reporting "0 violations" and reading as a pass.
+COUNTS: dict[str, int] = {
+    "refused_subject_to": 0,
+    "refused_validate": 0,
+    "refused_solve": 0,
+    "normalized_solved": 0,
+    "public_api_reachable": 0,
+    "export_scoped": 0,
+}
+
+
+def _bump(key: str) -> None:
+    COUNTS[key] += 1
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# The refusal
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _scalar_model() -> tuple[Model, object]:
+    m = Model("rhs_scalar")
+    w = m.continuous("w", lb=0.0, ub=10.0)
+    m.minimize(w)
+    return m, w
+
+
+def _vector_model() -> tuple[Model, object]:
+    m = Model("rhs_vector")
+    x = m.continuous("x", shape=(3,), lb=-10.0, ub=10.0)
+    m.minimize(x[0])
+    return m, x
+
+
+@pytest.mark.parametrize("sense", ["<=", ">=", "=="])
+@pytest.mark.parametrize("rhs", [5.0, -5.0, 1e-9])
+def test_subject_to_refuses_nonzero_rhs(sense, rhs):
+    """The public door refuses, on the line that caused it."""
+    m, w = _scalar_model()
+    with pytest.raises(ValueError, match="non-zero rhs"):
+        m.subject_to(Constraint(w, sense, rhs))
+    # The refusal must not half-add the row.
+    assert m._constraints == []
+    _bump("refused_subject_to")
+
+
+def test_subject_to_list_refuses_nonzero_rhs():
+    """The list/iterable arm of ``subject_to`` is a second public door."""
+    m, w = _scalar_model()
+    with pytest.raises(ValueError, match="non-zero rhs"):
+        m.subject_to([w >= 1.0, Constraint(w, ">=", 5.0)], name="rows")
+    _bump("refused_subject_to")
+
+
+@pytest.mark.parametrize("sense", ["<=", ">=", "=="])
+def test_validate_refuses_privately_appended_nonzero_rhs(sense):
+    """``_constraints.append`` bypasses ``subject_to``; ``validate`` still catches it."""
+    m, w = _scalar_model()
+    m._constraints.append(Constraint(w, sense, 5.0, "wrow"))
+    with pytest.raises(ValueError, match="non-zero rhs"):
+        m.validate()
+    _bump("refused_validate")
+
+
+@pytest.mark.parametrize("sense", ["<=", ">="])
+def test_solve_refuses_privately_appended_nonzero_rhs(sense):
+    """``solve`` always validates, so the wrong answer is now unreachable.
+
+    Before the fix this returned ``optimal`` with ``w = 0`` for ``w >= 5``.
+    """
+    m, w = _scalar_model()
+    m._constraints.append(Constraint(w, sense, 5.0, "wrow"))
+    with pytest.raises(ValueError, match="non-zero rhs"):
+        m.solve(time_limit=30)
+    _bump("refused_solve")
+
+
+def test_vector_row_with_scalar_rhs_is_refused():
+    """A size-3 body against a scalar ``rhs`` — the shape the corpus fixtures use."""
+    m, x = _vector_model()
+    m._constraints.append(Constraint(x, "<=", 2.0, "xle2"))
+    with pytest.raises(ValueError, match="non-zero rhs"):
+        m.validate()
+    _bump("refused_validate")
+
+
+def test_vector_rhs_array_is_refused():
+    """An array ``rhs`` with any non-zero entry is refused.
+
+    ``np.any`` on the array, not ``float(rhs) != 0`` — the latter raises on a vector
+    and would have turned a silent wrong answer into a confusing TypeError.
+    """
+    m, x = _vector_model()
+    m._constraints.append(Constraint(x, "<=", np.array([0.0, 0.0, 3.0]), "xvec"))
+    with pytest.raises(ValueError, match="non-zero rhs"):
+        m.validate()
+    _bump("refused_validate")
+
+
+def test_refusal_message_is_actionable():
+    """The message must name the row, the value, and the rewrite."""
+    m, w = _scalar_model()
+    m._constraints.append(Constraint(w, ">=", 5.0, "wge5"))
+    with pytest.raises(ValueError) as exc:
+        m.validate()
+    text = str(exc.value)
+    for needle in ("wge5", "5.0", "Constraint(body - rhs", "Model.validate"):
+        assert needle in text, f"missing {needle!r} from refusal: {text}"
+    _bump("refused_validate")
+
+
+def test_unnamed_row_is_localised_by_index():
+    """An unnamed offender still identifies itself."""
+    m, w = _scalar_model()
+    m._constraints.append(w >= 1.0)  # normalized, fine
+    m._constraints.append(Constraint(w, ">=", 5.0))  # offender at index 1
+    with pytest.raises(ValueError, match=r"_constraints\[1\]"):
+        m.validate()
+    _bump("refused_validate")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# The control: normalized rows are untouched
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("build", "expected"),
+    [
+        (lambda m, w: m.subject_to(w >= 5.0), 5.0),
+        (lambda m, w: m.subject_to(Constraint(5.0 - w, "<=", 0.0)), 5.0),
+        (lambda m, w: m.subject_to(w >= 2.5), 2.5),
+    ],
+    ids=["operator_ge", "explicit_zero_rhs", "operator_ge_frac"],
+)
+def test_normalized_rows_still_solve(build, expected):
+    """The supported construction is unaffected and still gives the right answer.
+
+    Without this arm the refusal could be rejecting every constraint and the file
+    would still be green (CLAUDE.md §6 — the discriminator has to discriminate).
+    """
+    m, w = _scalar_model()
+    build(m, w)
+    r = m.solve(time_limit=60)
+    assert r.status == "optimal", r.status
+    assert r.objective == pytest.approx(expected, abs=1e-5)
+    _bump("normalized_solved")
+
+
+def test_operator_form_normalizes_rhs_to_zero():
+    """Why the invariant is cheap to keep: the DSL already folds the offset."""
+    m, w = _scalar_model()
+    m.subject_to(w >= 5.0)
+    (c,) = m._constraints
+    assert float(c.rhs) == 0.0
+    _bump("normalized_solved")
+
+
+def test_public_api_reach_is_real():
+    """``Constraint`` is public, so this was never only a private-attribute bug.
+
+    Recorded as its own assertion because the original write-up concluded "the
+    public path is correct" — it is not; ``subject_to`` accepted the object
+    verbatim.
+    """
+    import discopt.modeling as dm
+
+    assert "Constraint" in dm.__all__
+    assert dm.Constraint is Constraint
+    _bump("public_api_reachable")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Export scoping: refuse where the writer would corrupt, allow where it is faithful
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _model_with_unnormalized_row() -> Model:
+    """``w >= 5`` carried as a non-zero ``rhs`` — the row every arm below exports."""
+    m = Model("rhs_export")
+    w = m.continuous("w", lb=0.0, ub=10.0)
+    m.minimize(w)
+    m._constraints.append(Constraint(w, ">=", 5.0, "row"))
+    return m
+
+
+@pytest.mark.parametrize(
+    ("writer", "needle"),
+    [("to_nl", "5.0"), ("to_gams", "=g= 5.0")],
+)
+def test_faithful_writers_export_an_unnormalized_row(writer, needle):
+    """``.nl`` and GAMS honour ``rhs``, so refusing them would block a good export.
+
+    The needle is the *offset itself* appearing in the emitted text: this asserts the
+    writer round-tripped the 5.0, not merely that it declined to raise.
+    """
+    import discopt.export as ex
+
+    text = getattr(ex, writer)(_model_with_unnormalized_row())
+    assert needle in text, f"{writer} dropped the rhs: {text}"
+    _bump("export_scoped")
+
+
+@pytest.mark.parametrize("writer", ["to_lp", "to_mps"])
+def test_corrupting_writers_refuse_an_unnormalized_row(writer):
+    """LP and MPS rebuild the rhs from the body alone, so they must refuse.
+
+    Measured before the fix (CLAUDE.md §11 — this contradicts issue #909's text):
+    ``to_lp`` emitted ``c0: w >= 0`` and ``to_mps`` an empty ``RHS`` section for
+    this model. A loud refusal is strictly better than a silently wrong file.
+    """
+    import discopt.export as ex
+
+    with pytest.raises(ValueError, match="non-zero rhs"):
+        getattr(ex, writer)(_model_with_unnormalized_row())
+    _bump("export_scoped")
+
+
+def test_for_solve_false_does_not_disable_the_other_validate_checks():
+    """The export hatch must narrow to the rhs rule, not switch validation off.
+
+    Otherwise ``for_solve=False`` would be a hole: a missing objective, ``lb > ub``
+    and every other invariant would stop being enforced on the export path.
+    (Duplicate *constraint* names are deliberately not used here — those only warn,
+    per M5/#413.)
+    """
+    # Missing objective.
+    m = Model("no_obj")
+    m.continuous("w", lb=0.0, ub=10.0)
+    with pytest.raises(ValueError, match="No objective"):
+        m.validate(for_solve=False)
+    _bump("export_scoped")
+
+    # lb > ub.
+    m2 = Model("bad_bounds")
+    m2.minimize(m2.continuous("v", lb=5.0, ub=1.0))
+    with pytest.raises(ValueError, match="lb > ub"):
+        m2.validate(for_solve=False)
+    _bump("export_scoped")
+
+
+def test_every_door_refuses_the_full_matrix():
+    """The complete claim, re-derived inside ONE test so xdist cannot fragment it.
+
+    The module counters below live in a worker's own process; under CI's
+    ``-n <workers> --dist loadgroup`` the parametrised arms above scatter across
+    workers, so no single process sees the whole matrix and the finalizer can only
+    prove *this* worker did work. This test therefore re-derives the full
+    senses x doors claim itself and asserts the exact expected count — the
+    non-vacuous statement, independent of the scheduler. (The lesson is from the
+    sibling Card 4c guard, which asserted a cross-worker total and failed in CI on
+    a statement about the scheduler rather than about the code.)
+    """
+    doors = 0
+    for sense in ("<=", ">=", "=="):
+        for rhs in (5.0, -5.0, 1e-9):
+            # door 1: subject_to
+            m, w = _scalar_model()
+            with pytest.raises(ValueError, match="non-zero rhs"):
+                m.subject_to(Constraint(w, sense, rhs))
+            doors += 1
+            # door 2: validate, after a direct append
+            m, w = _scalar_model()
+            m._constraints.append(Constraint(w, sense, rhs, "r"))
+            with pytest.raises(ValueError, match="non-zero rhs"):
+                m.validate()
+            doors += 1
+    assert doors == 18, doors
+    _bump("refused_subject_to")
+    _bump("refused_validate")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Vacuity guard (CLAUDE.md §6)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _executed_assertion_counts():
+    """Fail at module teardown if any arm above executed zero times.
+
+    A module-scoped finalizer rather than a ``test_zzz_`` function on purpose:
+    ``pytest-randomly`` shuffles test order, so a last-in-file guard is only a
+    guard by luck. Teardown always runs last.
+
+    Scope of the claim, deliberately: this asserts only that **this worker**
+    executed real assertions. It cannot assert per-arm totals, because CI runs
+    ``-n <workers> --dist loadgroup`` and each worker owns a separate copy of
+    ``COUNTS`` — an arm that is zero here may simply have run elsewhere, which is a
+    statement about the scheduler, not about the code. The complete
+    senses x doors claim is re-derived inside
+    :func:`test_every_door_refuses_the_full_matrix`, which is one test and
+    therefore always whole.
+    """
+    yield
+    print("\nCard 4c / rhs-refusal executed counts (this worker):")
+    for key, n in COUNTS.items():
+        print(f"  {key:24s} {n}")
+    assert sum(COUNTS.values()) > 0, f"this worker executed no assertions: {COUNTS}"


### PR DESCRIPTION
Closes #909.

## The defect

`Constraint` is exported in `discopt.modeling.__all__`, so this is a silent wrong
answer through documented public API — not a private-attribute corner. Reproduced
on `main` before the fix:

```
m.subject_to(Constraint(w, ">=", 5.0))   ->  w = -5e-09    WRONG
m.subject_to(w >= 5.0)                   ->  w =  5.0      correct
```

The tree is **split** on whether `rhs` means anything. 26 modules read
`Constraint.body` and never read `.rhs` — the whole relaxation/branching stack,
whose seam is `_jax/dag_compiler.compile_constraint` (compiles `body`, drops
`rhs`). But `validation/feasibility` computes `signed = body - rhs`. The row is
therefore *solved* as `body sense 0` and *verified* as `body - rhs sense 0`: the
solver returns a point its own verifier calls feasible and the user calls wrong.

## Direction: refuse, don't teach the solve path to honour `rhs`

Threading `rhs` through means correcting all 26 modules, each of which encodes the
`body sense 0` form structurally rather than arithmetically. A partial job is
strictly **worse** than the status quo: today the relaxation stack is uniformly
rhs-blind, so its McCormick envelope relaxes the same row the verifier checks;
half-honoured, the envelope would be built for a *different* row than the one
verified — a soundness hazard replacing a wrong-answer hazard. CLAUDE.md §3.

`_reject_unnormalized_rhs` fires from `subject_to` (scalar and list arms, so the
error lands on the offending line) and from `Model.validate` (the collection-level
catch-all — direct `_constraints.append` and internal rebuilds that propagate
`c.rhs`; `solve` always validates). Array `rhs` is tested with `np.any`, not
`float()`, which would raise a confusing `TypeError` on a vector row.

## Entry experiment (CLAUDE.md §4)

**H-RHS**: a non-zero `rhs` is unreachable through supported construction. Kill
criterion: one such constraint from a supported constructor means refusing would
break working models and the solve path must honour `rhs` instead.

Re-run on this tree via `discopt_benchmarks/scripts/card4c_rhs_entry.py`:
**66 models, 3,705 executed rhs comparisons, 0 load failures, 0 violations**, with
a planted control arm registering its non-zero `rhs` — so the probe demonstrably
sees what it claims to measure. **H-RHS holds**; refusing breaks nothing.

## Export scoping — and a correction to the issue text (CLAUDE.md §11)

`Model.validate` gains `for_solve=True`; writers that represent a row faithfully
rather than solving it pass `False`.

Issue #909 states the exporters "all do honour `rhs`". I measured all four before
implementing, and **that is false for two of them**:

| writer | honours `rhs`? | emitted for `Constraint(w,">=",5.0)` | scoping |
|---|---|---|---|
| `.nl` | yes | r-section `2 5.0` | `for_solve=False` |
| GAMS | yes | `c1.. w =g= 5.0;` | `for_solve=False` |
| LP | **no** | `c0: w >= 0` | keeps refusing |
| MPS | **no** | empty `RHS` section | keeps refusing |

LP and MPS rebuild the right-hand side from the *body* alone, so for those two the
refusal converts a silently wrong export into a loud error. The earlier draft of
this fix scoped `for_solve=False` to `.nl` only, which would additionally have
blocked a faithful GAMS export. Each writer now carries a comment recording which
side of the split it is on and why.

## Verification

- **`python/tests/test_constraint_rhs_refusal.py` — 30 tests, both directions.**
  The refusal fires at every door (scalar/vector, named/unnamed, all three
  senses), **and** normalized rows still solve to the right answer — the control
  proving the guard discriminates rather than rejecting everything. Plus the
  export scoping in both directions, and a check that `for_solve=False` narrows to
  the rhs rule rather than switching validation off.
- **xdist-safety, verified not reasoned.** CI runs `-n <workers> --dist
  loadgroup`, where each worker owns its own module counters, so a cross-worker
  total asserts something about the scheduler rather than the code — the exact way
  the sibling Card 4c guard failed in CI. The full `senses x doors` claim is
  re-derived inside one test; confirmed by running the file under
  `-n 4 --dist loadgroup`.
- **CI's Python-fast lane, run locally with its exact command**: 7417 passed, 29
  skipped, 5 xfailed, 2 xpassed, **0 failed**. This is the lane that would expose
  any production path emitting a non-zero `rhs`; none does.
- `pytest python/tests -m smoke`: **900 passed**, 1 skipped, 2 xpassed, 0 failed.
- Adversarial suite (`pytest -m slow python/tests/test_adversarial_recent_fixes.py`):
  **10 passed**.
- `ruff check` / `ruff format --check`: clean. Pre-commit's pinned **mypy passed**.
  (A bare local `mypy` reports 6 errors in `nl.py`; I confirmed these are
  **pre-existing on `main`** — identical, line numbers shifted by this PR's
  comment — and are an artifact of local mypy 1.19.1 vs the CI pin. This change
  adds none.)
- Rust untouched, so no `cargo test`.

Bound-neutrality: the refusal is unreachable from any producer in the corpus or
the suite (measured above), so no bound can move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
