### PR TITLE
fix(correctness): #910 the substitution postsolve guard was integrality-blind

### DIFF
--- a/python/discopt/solvers/_presolve_substitute.py
+++ b/python/discopt/solvers/_presolve_substitute.py
@@ -18,9 +18,10 @@ This module closes that loop:
 Soundness rules, in force regardless of what the reduced solve reports:
 
 - an incumbent that cannot be inverted, or whose lifted point is not feasible
-  for the **pristine** model (the #779 guard), is *discarded* — this function
-  returns ``None`` and the caller runs the ordinary path. A point that cannot
-  be verified is never reported;
+  for the **pristine** model (the #779 guard) — rows, variable bounds *and*
+  integrality (#910) — is *discarded*: this function returns ``None`` and the
+  caller runs the ordinary path. A point that cannot be verified is never
+  reported;
 - the reported objective is the one **recomputed on the pristine model** at the
   lifted point, not the reduced model's number, and the two must agree;
 - the dual bound is carried over unchanged, which is valid because the
@@ -50,6 +51,8 @@ logger = logging.getLogger(__name__)
 _OBJ_TOL = 1e-6
 #: Feasibility tolerance for the pristine-model check (matches the #779 guard).
 _FEAS_TOL = 1e-5
+#: Integrality tolerance for the lifted point (CLAUDE.md "Numerical tolerances").
+_INT_TOL = 1e-5
 
 #: Re-entrancy guard: the reduced solve must not substitute again.
 _state = threading.local()
@@ -186,12 +189,57 @@ def lift_result(
             max(con_viol, bnd_viol),
         )
         return None
+    bad_int = integrality_violation(model, x_full)
+    if bad_int is not None:
+        logger.warning(
+            "substitution postsolve: lifted point violates integrality on %s by %.3g; "
+            "discarding incumbent",
+            bad_int[0],
+            bad_int[1],
+        )
+        return None
 
     x_dict, _ = _unflatten(model, x_full)
     result.x = x_dict
     result.objective = float(obj_pristine)
     result._model = model
     return result
+
+
+def integrality_violation(model, x_full: np.ndarray) -> Optional[tuple[str, float]]:
+    """``(variable name, worst |x - round(x)|)`` for the first integral block the
+    lifted point does not satisfy, or ``None`` when every one of them does.
+
+    Issue #910. ``ModelRepr.evaluate_point`` — the Rust guard :func:`lift_result`
+    relies on — checks rows and variable bounds and **nothing else**. It is
+    integrality-blind, so a lifted point carrying a fractional value in an
+    integer variable passes both of the guard's other arms and is reported as
+    ``SolveResult(status='optimal')``. Today's substitution pass never eliminates
+    an integral block (``substitute.rs`` "Scope (v0)"), so the hole is not
+    reachable through *this* transform; it is reachable through any other repr
+    transform that reuses this postsolve entry, and the guard is the last check
+    before a point becomes the reported solution. Completing it here is
+    CLAUDE.md §3 (fix the guard, do not lean on an upstream invariant).
+
+    Kept as a numpy pass over the declared blocks rather than delegating to
+    :func:`discopt.validation.feasibility.verify_point`: that verifier builds a
+    JAX ``NLPEvaluator``, which is exactly the path the #779 comment in
+    :func:`lift_result` measured at >119 s on this pass's target models against
+    0.008 s for the Rust evaluator. O(n) integrality costs nothing and keeps
+    that margin intact.
+    """
+    from discopt.modeling.core import VarType
+
+    off = 0
+    for v in model._variables:
+        size = int(v.size)
+        if v.var_type in (VarType.INTEGER, VarType.BINARY):
+            vals = np.asarray(x_full[off : off + size], dtype=float)
+            dev = np.abs(vals - np.round(vals))
+            if dev.size and float(np.max(dev)) > _INT_TOL:
+                return v.name, float(np.max(dev))
+        off += size
+    return None
 
 
 def reduced_model_n_vars(reduced_model) -> int:

--- a/python/tests/test_presolve_substitute.py
+++ b/python/tests/test_presolve_substitute.py
@@ -156,3 +156,57 @@ def test_solve_path_flag_agrees_with_the_default_path():
     flat = [float(np.asarray(sub.x[f"x{i}"]).reshape(-1)[0]) for i in range(5)]
     _, con_viol, bnd_viol = rep.evaluate_point(flat)
     assert max(con_viol, bnd_viol) < 1e-6
+
+
+@pytest.mark.smoke
+def test_postsolve_guard_rejects_a_lifted_point_with_a_fractional_integer():
+    """Issue #910: the #779 guard was integrality-blind.
+
+    A lifted point whose *integral* survivor is fractional satisfies every row
+    and every variable bound of the pristine model, so both of the guard's
+    pre-#910 arms pass and the point is returned as
+    ``SolveResult(status='optimal')``. This test pins the fails-before evidence
+    (the Rust evaluator reports zero violation on exactly that point) and the
+    fix (``lift_result`` discards it).
+    """
+    from discopt.modeling.core import SolveResult, model_from_repr
+    from discopt.solvers._presolve_substitute import integrality_violation, lift_result
+
+    m = dm.Model("intguard")
+    m.continuous("x", lb=-100, ub=100)
+    m.integer("y", lb=0, ub=10)
+    xs, ys = m._variables
+    m.subject_to(xs - 2 * ys == 1)
+    m.minimize(xs)
+
+    pristine = _repr_of(m)
+    reduced_repr, chain = pristine.substitute(4)
+    assert chain.variables_eliminated == 1, "x must be the eliminated block"
+    reduced_model = model_from_repr(reduced_repr, "intguard_substituted")
+    assert [v.name for v in reduced_model._variables] == ["y"]
+
+    # y = 3.5 lifts to x = 2*3.5 + 1 = 8.0. Both coordinates are inside their
+    # pristine bounds and the only row was the (dropped) definition, so the Rust
+    # evaluator reports zero constraint and zero bound violation: the guard's two
+    # pre-#910 arms both PASS on a point that is not integer-feasible.
+    x_full = np.asarray(chain.postsolve([3.5]), dtype=float)
+    assert x_full == pytest.approx([8.0, 3.5])
+    _, con_viol, bnd_viol = pristine.evaluate_point(list(x_full))
+    assert max(con_viol, bnd_viol) <= 1e-12, "fails-before evidence: the old guard sees nothing"
+
+    # The new arm sees it, and names the variable and the deviation.
+    bad = integrality_violation(m, x_full)
+    assert bad is not None and bad[0] == "y"
+    assert bad[1] == pytest.approx(0.5)
+
+    result = SolveResult(status="optimal", objective=8.0, x={"y": np.asarray(3.5)})
+    assert lift_result(m, reduced_model, chain, pristine, result) is None, (
+        "a lifted point with a fractional integer must be discarded, not reported"
+    )
+
+    # And the guard does not fire on a genuinely integral point.
+    ok = SolveResult(status="optimal", objective=7.0, x={"y": np.asarray(3.0)})
+    lifted = lift_result(m, reduced_model, chain, pristine, ok)
+    assert lifted is not None
+    assert lifted.objective == pytest.approx(7.0)
+    assert integrality_violation(m, np.asarray([7.0, 3.0])) is None


### PR DESCRIPTION
`lift_result`'s #779 guard verifies the lifted point against the pristine model
through `ModelRepr.evaluate_point`, which checks constraint rows and variable
bounds and **nothing else**. It is integrality-blind, so a lifted point carrying
a fractional value in an integer variable passes both existing arms and is
returned as `SolveResult(status='optimal')`.

Measured, on the reproducer in this commit (model: min x s.t. x - 2y == 1,
x continuous in [-100,100], y integer in [0,10]; `substitute` eliminates x):
lifting y = 3.5 gives (x, y) = (8.0, 3.5); the Rust evaluator reports
con_viol = bnd_viol = 0, and before this change

    lift_result(...) -> ('optimal', 8.0, {'x': 8.0, 'y': 3.5})

After it, the guard names the variable and the deviation and discards the point:

    substitution postsolve: lifted point violates integrality on y by 0.5
    lift_result(...) -> None

The fix adds an `integrality_violation` arm alongside the row/bound arms, using
the 1e-5 integrality tolerance from conftest.py. It is an O(n) numpy pass over
the model's declared blocks rather than a call into
`validation.feasibility.verify_point`: that verifier builds a JAX
`NLPEvaluator`, which is the path the #779 comment measured at >119 s against
0.008 s for the Rust evaluator on this pass's target models, so delegating would
have thrown away the margin the guard was built on.

Today's substitution pass never eliminates an integral block (`substitute.rs`
"Scope (v0)"), so the hole is not reachable through this transform — but the
guard is the last check before a point becomes the reported answer, and it is
the reusable postsolve entry for any other repr transform. Fixed rather than
left leaning on an upstream invariant (CLAUDE.md §3).

No behavior change on the default path: `DISCOPT_PRESOLVE_SUBSTITUTE` remains
default-OFF and parked (its graduation is blocked on a predictor of when
substitution helps, per #910), and with the flag off `lift_result` is not
reached. The new arm can only reject a point, never accept one the old guard
rejected.

Tests: `test_postsolve_guard_rejects_a_lifted_point_with_a_fractional_integer`
(smoke) — verified failing before the source change and passing after, with the
pre-fix behavior captured above by driving `lift_result` directly, not just by
the import error.

Verification run: `pytest -m smoke` 901 passed / 1 skipped / 2 xpassed;
`pytest -m slow python/tests/test_adversarial_recent_fixes.py` 10 passed;
`pytest python/tests/test_presolve_substitute.py -m "not slow"` 7 passed; ruff
check + format clean. Rust untouched, so no cargo run.

Closes #910

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
