### PR TITLE
fix(solver): #911 a declined convex-kernel attempt is deducted from the solve budget

### DIFF
--- a/crates/discopt-core/src/bnb/convex_kernel.rs
+++ b/crates/discopt-core/src/bnb/convex_kernel.rs
@@ -421,7 +421,23 @@ impl ConvexKernelSpec {
         max_oa_rounds: usize,
         opts: &SimplexOptions,
     ) -> ConvexNodeResult {
-        self.solve_node_cut(lo, hi, oa_tol, max_oa_rounds, 0, opts)
+        self.solve_node_cut_until(lo, hi, oa_tol, max_oa_rounds, 0, opts, None)
+    }
+
+    /// [`solve_node`](Self::solve_node) bounded by a wall-clock `deadline`. See
+    /// [`solve_node_cut_until`](Self::solve_node_cut_until) for why stopping early is
+    /// a refusal rather than an approximation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn solve_node_until(
+        &self,
+        lo: &[f64],
+        hi: &[f64],
+        oa_tol: f64,
+        max_oa_rounds: usize,
+        opts: &SimplexOptions,
+        deadline: Option<std::time::Instant>,
+    ) -> ConvexNodeResult {
+        self.solve_node_cut_until(lo, hi, oa_tol, max_oa_rounds, 0, opts, deadline)
     }
 
     /// K2: the LP-OA node relaxation WITH in-tree integrality separation. Runs
@@ -440,6 +456,39 @@ impl ConvexKernelSpec {
         max_oa_rounds: usize,
         max_sep_rounds: usize,
         opts: &SimplexOptions,
+    ) -> ConvexNodeResult {
+        self.solve_node_cut_until(lo, hi, oa_tol, max_oa_rounds, max_sep_rounds, opts, None)
+    }
+
+    /// [`solve_node_cut`](Self::solve_node_cut) bounded by a wall-clock `deadline`.
+    ///
+    /// A node's OA/separation loop can run up to
+    /// `max_oa_rounds·(max_sep_rounds+1)+…` LP re-solves, and until #911 the tree
+    /// polled its deadline only BETWEEN nodes — so one slow node overran the whole
+    /// budget with nothing to stop it. Measured on `clay0304hfsg`, `solve_convex_tree`
+    /// handed `time_limit_s = 30` ran **236.24 s** over 93 nodes (7.9x its limit).
+    /// Passing the tree's deadline down lets the loop stop between re-solves.
+    ///
+    /// Stopping here is a REFUSAL, not an approximation — the same argument that
+    /// makes [`appended_row_cap`] sound. The node LP is a relaxation for ANY subset
+    /// of tangents and cuts, so a deadline-stopped node returns a valid, merely
+    /// weaker dual bound; and a vertex reached without OA convergence still violates
+    /// a nonlinear row, so `is_integer_feasible` cannot mistake it for an incumbent.
+    /// A weaker node bound can only make the tree's gap check harder to satisfy, so
+    /// this can never manufacture a certificate that was not already earned.
+    ///
+    /// The check sits after at least one completed re-solve, so the returned bound is
+    /// always a real LP bound rather than the trivial sentinel.
+    #[allow(clippy::too_many_arguments)]
+    pub fn solve_node_cut_until(
+        &self,
+        lo: &[f64],
+        hi: &[f64],
+        oa_tol: f64,
+        max_oa_rounds: usize,
+        max_sep_rounds: usize,
+        opts: &SimplexOptions,
+        deadline: Option<std::time::Instant>,
     ) -> ConvexNodeResult {
         debug_assert_eq!(lo.len(), self.n);
         debug_assert_eq!(hi.len(), self.n);
@@ -484,6 +533,12 @@ impl ConvexKernelSpec {
         let append_cap = appended_row_cap(self.n);
 
         for _ in 0..iter_cap {
+            // Out of time: keep the bound the last re-solve certified and stop. Gated
+            // on a completed round so `last_bound` is a real LP bound, never the
+            // trivial sentinel.
+            if oa_rounds > 0 && deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+                break;
+            }
             oa_rounds += 1;
             let (sp, m, n_total, b, l, u) = assemble(self.n, lo, hi, &rows);
             let mut c = vec![0.0f64; n_total];
@@ -1290,6 +1345,7 @@ impl ConvexKernelSpec {
                     config.max_oa_rounds,
                     config.max_sep_rounds,
                     opts,
+                    config.deadline,
                 ) {
                     Some((res, _pivots, _new_tan)) => {
                         w.age_and_gc(opts.tol.max(1e-7), NATIVELP_POOL_CAP, NATIVELP_MAX_AGE);
@@ -1300,17 +1356,27 @@ impl ConvexKernelSpec {
                         // infeasible" from "numerically failed", so this subtree is
                         // not certified as explored -- unless the cut-free retry
                         // below resolves it (#871).
-                        self.solve_node(&lo, &hi, config.oa_tol, config.max_oa_rounds, opts)
+                        self.solve_node_until(
+                            &lo,
+                            &hi,
+                            config.oa_tol,
+                            config.max_oa_rounds,
+                            opts,
+                            config.deadline,
+                        )
                     }
                 }
             } else {
-                self.solve_node_cut(
+                // #911: the node loop gets the tree's deadline, so a single slow node
+                // can no longer overrun the whole budget between two deadline polls.
+                self.solve_node_cut_until(
                     &lo,
                     &hi,
                     config.oa_tol,
                     config.max_oa_rounds,
                     config.max_sep_rounds,
                     opts,
+                    config.deadline,
                 )
             };
             // #871: a node that breaks down numerically has proven nothing, so
@@ -1353,7 +1419,14 @@ impl ConvexKernelSpec {
             let r = if matches!(r.status, LpStatus::Optimal | LpStatus::Infeasible) {
                 r
             } else {
-                self.solve_node(&lo, &hi, config.oa_tol, config.max_oa_rounds, opts)
+                self.solve_node_until(
+                    &lo,
+                    &hi,
+                    config.oa_tol,
+                    config.max_oa_rounds,
+                    opts,
+                    config.deadline,
+                )
             };
             if r.status != LpStatus::Optimal {
                 // A PROVEN-infeasible node is a legitimate fathom — its subtree is
@@ -1758,6 +1831,7 @@ impl W0WarmLp {
         max_oa_rounds: usize,
         max_sep_rounds: usize,
         opts: &SimplexOptions,
+        deadline: Option<std::time::Instant>,
     ) -> Option<(ConvexNodeResult, usize, usize)> {
         let mut pivots = 0usize;
         let mut new_tangents = 0usize;
@@ -1772,6 +1846,12 @@ impl W0WarmLp {
         let mut restore: Option<(usize, Basis)> = None;
         let iter_cap = max_oa_rounds.max(1) * (max_sep_rounds + 1) + max_sep_rounds + 4;
         for _ in 0..iter_cap {
+            // #911: same deadline stop as `solve_node_cut_until`, for the same reason
+            // and with the same soundness argument (a stopped node returns a weaker
+            // but valid bound). Only after a completed round.
+            if oa_rounds > 0 && deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+                break;
+            }
             oa_rounds += 1;
             if self.dirty {
                 self.rebuild_sp();
@@ -2033,8 +2113,18 @@ impl ConvexKernelSpec {
                 .len()
                 .saturating_sub(self.le_rows.len() + self.eq_rows.len());
             let t1 = std::time::Instant::now();
-            let warm_res =
-                warm.solve_node(self, &lo, &hi, config.oa_tol, config.max_oa_rounds, 0, opts);
+            // No deadline: this is the W2 A/B probe, which times cold vs warm on the
+            // same box and must not have one arm cut short by a clock.
+            let warm_res = warm.solve_node(
+                self,
+                &lo,
+                &hi,
+                config.oa_tol,
+                config.max_oa_rounds,
+                0,
+                opts,
+                None,
+            );
             let warm_us = t1.elapsed().as_secs_f64() * 1e6;
             // Tangent aging + GC (bounds the pool for many-nl-row instances).
             warm.age_and_gc(opts.tol.max(1e-7), gc_pool_cap, gc_max_age);
@@ -2292,6 +2382,99 @@ mod tests {
             truth
         );
         assert!(r.oa_rounds > 1, "OA should take several rounds");
+    }
+
+    /// #911: a node's OA loop honours a wall-clock deadline, and stopping early is a
+    /// REFUSAL (weaker but valid bound), never a tightening.
+    ///
+    /// Same `max t s.t. exp(t) ≤ 5` model, which needs several OA rounds. With a
+    /// deadline already in the past the loop stops after one completed re-solve; the
+    /// bound it returns must still be a valid UPPER bound on the max (≥ truth) and
+    /// must be no TIGHTER than the converged one.
+    #[test]
+    fn node_oa_loop_stops_at_a_deadline_without_tightening_the_bound() {
+        let spec = ConvexKernelSpec {
+            n: 1,
+            c: vec![1.0],
+            sense_max: true,
+            integrality: vec![false],
+            lb: vec![0.0],
+            ub: vec![10.0],
+            le_rows: vec![],
+            eq_rows: vec![],
+            nl_rows: vec![ConvexRow {
+                lin: Affine::default(),
+                terms: vec![CompositeTerm {
+                    coeff: 1.0,
+                    func: ConvexFunc::Exp,
+                    arg: Affine {
+                        cols: vec![0],
+                        coeffs: vec![1.0],
+                        cst: 0.0,
+                    },
+                    scale: None,
+                }],
+                rhs: 5.0,
+            }],
+        };
+        let converged = spec.solve_node(&[0.0], &[10.0], 1e-9, 60, &opts());
+        assert_eq!(converged.status, LpStatus::Optimal);
+
+        let past = std::time::Instant::now() - std::time::Duration::from_secs(1);
+        let stopped = spec.solve_node_until(&[0.0], &[10.0], 1e-9, 60, &opts(), Some(past));
+        assert_eq!(stopped.status, LpStatus::Optimal);
+
+        // The probe must not pass vacuously: the converged solve really did take more
+        // rounds than the stopped one, so the deadline really did cut it short.
+        assert_eq!(stopped.oa_rounds, 1, "expected exactly one completed round");
+        assert!(
+            converged.oa_rounds > stopped.oa_rounds,
+            "deadline changed nothing: converged {} vs stopped {} rounds",
+            converged.oa_rounds,
+            stopped.oa_rounds
+        );
+        // Sound: still a valid upper bound on the max, and never tighter than the
+        // converged bound.
+        let truth = 5.0_f64.ln();
+        assert!(
+            stopped.bound >= truth - 1e-6,
+            "stopped bound {} below truth {truth}",
+            stopped.bound
+        );
+        assert!(
+            stopped.bound >= converged.bound - 1e-9,
+            "stopped bound {} TIGHTER than converged {}",
+            stopped.bound,
+            converged.bound
+        );
+    }
+
+    /// #911: `deadline: None` is the pre-existing path, bit-identical. This is the
+    /// bound-neutrality half of the change (CLAUDE.md §5, Regime N).
+    #[test]
+    fn no_deadline_is_bit_identical_to_the_uninstrumented_node() {
+        let spec = ConvexKernelSpec {
+            n: 2,
+            c: vec![1.0, 1.0],
+            sense_max: true,
+            integrality: vec![true, true],
+            lb: vec![0.0, 0.0],
+            ub: vec![1.0, 1.0],
+            le_rows: vec![LinRow {
+                cols: vec![0, 1],
+                coeffs: vec![1.0, 1.0],
+                rhs: 1.5,
+            }],
+            eq_rows: vec![],
+            nl_rows: vec![],
+        };
+        let a = spec.solve_node_cut(&[0.0, 0.0], &[1.0, 1.0], 1e-9, 10, 8, &opts());
+        let b = spec.solve_node_cut_until(&[0.0, 0.0], &[1.0, 1.0], 1e-9, 10, 8, &opts(), None);
+        assert_eq!(a.status, b.status);
+        assert_eq!(a.bound.to_bits(), b.bound.to_bits(), "bound drifted");
+        assert_eq!(a.raw_bound.to_bits(), b.raw_bound.to_bits());
+        assert_eq!(a.oa_rounds, b.oa_rounds);
+        assert_eq!(a.n_tangents, b.n_tangents);
     }
 
     /// K2: in-node separation tightens the LP bound toward the integer hull

--- a/crates/discopt-python/src/convex_bindings.rs
+++ b/crates/discopt-python/src/convex_bindings.rs
@@ -485,6 +485,15 @@ pub fn solve_convex_tree_py<'py>(
     };
     let opts = SimplexOptions {
         expel_zero_artificials: true,
+        // #911: the tree's deadline also bounds a SINGLE LP solve. Without this the
+        // kernel could only stop BETWEEN re-solves, so its overshoot was one whole
+        // LP -- measured on `clay0304hfsg`, +7.8 s against a 30 s limit even after
+        // the node loop learned to poll. `SimplexOptions::deadline` is polled every
+        // few hundred pivots and bails as `IterLimit`, which every caller here
+        // already treats soundly: the node returns a non-pruning sentinel, the
+        // subtree is marked an uncertified drop, and optimality can no longer be
+        // claimed for that run -- so this can only weaken a bound, never fake one.
+        deadline: config.deadline,
         ..Default::default()
     };
     let res = spec.solve_tree(&config, &opts);

--- a/discopt_benchmarks/scripts/issue911_attempt_phase_probe.py
+++ b/discopt_benchmarks/scripts/issue911_attempt_phase_probe.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+"""Issue #911 follow-on probe — WHERE does a convex-kernel attempt spend its wall?
+
+The #911 fix deducts the attempt from the caller's budget, which bounds the total at
+``time_limit`` only if the attempt itself respects the budget it was handed. The
+BEFORE panel says it sometimes does not: ``clay0304hfsg`` at a 30 s budget ran
+**272.76 s** end to end with the kernel ON, against 31.19 s with it OFF. Deducting a
+242 s attempt from a 30 s budget cannot bring that inside 30 s — so before doing
+anything about it, this probe measures which phase of the attempt overruns:
+
+* ``build_convex_spec`` — the convexity classification (no deadline of its own);
+* ``solve_convex_tree`` — the native tree, handed ``time_limit_s=budget``;
+* ``_incumbent_is_feasible`` — the #779 pristine-model verification, JAX-compiled.
+
+Each phase is timed separately and printed with its overrun against the budget, so
+the answer is a measurement rather than a reading of the code. Exits non-zero if it
+timed nothing (CLAUDE.md §6).
+
+Usage::
+
+    python -u discopt_benchmarks/scripts/issue911_attempt_phase_probe.py \
+        --instances clay0304hfsg,clay0305hfsg --budget 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CORPUS = _REPO_ROOT / "python" / "tests" / "data" / "minlplib_nl"
+_SNAPSHOT = Path(os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"))
+
+
+def _find(stem: str) -> Path | None:
+    for d in (_CORPUS, _SNAPSHOT):
+        p = d / f"{stem}.nl"
+        if p.exists():
+            return p
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--instances", required=True)
+    ap.add_argument("--budget", type=float, default=30.0)
+    args = ap.parse_args()
+
+    os.environ.setdefault("JAX_PLATFORMS", "cpu")
+    os.environ.setdefault("JAX_ENABLE_X64", "1")
+    os.environ["DISCOPT_CONVEX_KERNEL"] = "1"
+
+    import numpy as np
+    from discopt.modeling.core import from_nl
+    from discopt.solvers import _convex_kernel as ck
+
+    timed = 0
+    print(f"budget = {args.budget:g} s\n", flush=True)
+    for stem in [s.strip() for s in args.instances.split(",") if s.strip()]:
+        nl = _find(stem)
+        if nl is None:
+            print(f"{stem}: MISSING", flush=True)
+            continue
+        m = from_nl(str(nl))
+
+        t = time.perf_counter()
+        spec = ck.build_convex_spec(m)
+        t_spec = time.perf_counter() - t
+        if spec is None:
+            print(f"{stem:20s} not eligible (spec {t_spec:.2f}s)", flush=True)
+            continue
+
+        t = time.perf_counter()
+        r = ck.solve_convex_tree(spec, time_limit_s=args.budget, gap_tol=1e-4)
+        t_tree = time.perf_counter() - t
+
+        t_verify = float("nan")
+        inc_x = np.asarray(r["incumbent_x"], float)
+        if inc_x.size:
+            _, x_flat = ck._unflatten(m, inc_x)
+            t = time.perf_counter()
+            ck._incumbent_is_feasible(m, x_flat)
+            t_verify = time.perf_counter() - t
+
+        total = t_spec + t_tree + (0.0 if t_verify != t_verify else t_verify)
+        timed += 1
+        print(
+            f"{stem:20s} spec={t_spec:7.2f}s tree={t_tree:7.2f}s verify={t_verify:7.2f}s "
+            f"total={total:7.2f}s  over-budget={total - args.budget:+7.2f}s  "
+            f"status={r['status']} nodes={r['node_count']}",
+            flush=True,
+        )
+
+    print(f"\nEXECUTED PHASE TIMINGS: {timed}", flush=True)
+    if timed == 0:
+        print("probe measured NOTHING", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/discopt_benchmarks/scripts/issue911_convex_kernel_budget_entry.py
+++ b/discopt_benchmarks/scripts/issue911_convex_kernel_budget_entry.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python
+"""Issue #911 entry experiment — does a DECLINED convex-kernel attempt add wall?
+
+**Hypothesis under test.** ``Model.solve`` hands the convex kernel
+``min(time_limit, DISCOPT_CONVEX_KERNEL_BUDGET=120)`` seconds
+(``_convex_kernel.try_convex_solve``), adopts the result **only** when it certifies
+optimality, and then calls ``solve_model`` with the caller's **full** ``time_limit``
+again (``modeling/core.py``: ``_primary_tl = time_limit - _fb_reserve``). The elapsed
+kernel time is never deducted, so an eligible-but-uncertifiable model pays its whole
+default-path budget **plus** the attempt, and ``solve(time_limit=T)`` runs for ~2T.
+
+**Falsifying experiment (this script).** Run every convex-kernel-eligible in-repo
+instance with ``DISCOPT_CONVEX_KERNEL`` OFF and ON, arms interleaved, N replicates,
+each solve in its own subprocess, and compare *total* wall against the requested
+budget. Two budgets are required: at a budget the kernel can meet, a declined attempt
+never happens and the hazard is invisible (issue #911: "at a 45 s budget the hazard is
+invisible; it only appears at small budgets").
+
+**Kill criterion.** If no eligible instance's ON-arm wall materially exceeds the OFF
+arm's (excess over OFF > 5 s AND ON wall > budget + 5 s) at ANY budget, the additive
+hazard is not reproducible on this corpus and the fix must be re-scoped rather than
+built.
+
+Eligibility is MEASURED, not assumed: ``build_convex_spec`` is run over the corpus and
+only the instances it accepts are panelled (CLAUDE.md §6 — the executed comparison
+count is printed and a run that measured nothing exits non-zero).
+
+Usage::
+
+    python -u discopt_benchmarks/scripts/issue911_convex_kernel_budget_entry.py --census
+    python -u discopt_benchmarks/scripts/issue911_convex_kernel_budget_entry.py \
+        --budgets 10,45 --reps 2
+
+Internal child mode: ``--solve <nl-path> <0|1> <budget>``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CORPUS = _REPO_ROOT / "python" / "tests" / "data" / "minlplib_nl"
+# The full MINLPLib snapshot (CLAUDE.md "Benchmark instance corpus"). Only 3 in-repo
+# instances are convex-kernel eligible, and all three are small enough to certify
+# quickly, so the DECLINE half of the class has to be drawn from here.
+_SNAPSHOT = Path(os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"))
+_SOLU = Path(os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu"))
+_CHILD_SLACK = 300.0
+_CORPUS_DIR = _CORPUS
+
+
+def _corpus_files() -> list[Path]:
+    return sorted(_CORPUS_DIR.glob("*.nl"))
+
+
+def _oracle() -> dict[str, float]:
+    """MINLPLib reference optima, the correctness oracle for this panel."""
+    out: dict[str, float] = {}
+    if not _SOLU.exists():
+        return out
+    for line in _SOLU.read_text().splitlines():
+        p = line.split()
+        if len(p) >= 3 and p[0] in ("=opt=", "=best="):
+            # A non-numeric third field is a `.solu` marker line, not an optimum.
+            with contextlib.suppress(ValueError):
+                out[p[1]] = float(p[2])
+    return out
+
+
+# --------------------------------------------------------------------------- child
+
+
+def _run_child(nl_path: str, flag: str, budget: float) -> int:
+    """Solve ONE instance in this (fresh) process and print one JSON line."""
+    os.environ.setdefault("JAX_PLATFORMS", "cpu")
+    os.environ.setdefault("JAX_ENABLE_X64", "1")
+    # Both arms are set EXPLICITLY. Inferring an arm from a default the harness does
+    # not control is how a panel silently compares OFF against OFF (#902).
+    os.environ["DISCOPT_CONVEX_KERNEL"] = "1" if flag == "1" else "0"
+
+    import discopt  # noqa: PLC0415
+    from discopt.modeling.core import from_nl  # noqa: PLC0415
+    from discopt.solvers import _convex_kernel  # noqa: PLC0415
+
+    out: dict = {
+        "instance": Path(nl_path).stem,
+        "flag": flag,
+        "budget": float(budget),
+        # CLAUDE.md §8: record which module was actually loaded, and the arm the
+        # loaded module itself reports -- not the arm we believe we set.
+        "discopt_file": discopt.__file__,
+        "kernel_enabled": bool(_convex_kernel.convex_kernel_enabled()),
+        # Marker for the version under test: absent pre-fix, present post-fix.
+        "has_last_attempt_seconds": hasattr(_convex_kernel, "last_attempt_seconds"),
+    }
+
+    m = from_nl(nl_path)
+    t0 = time.perf_counter()
+    r = m.solve(time_limit=float(budget))
+    out["wall"] = time.perf_counter() - t0
+    out["status"] = getattr(r, "status", None)
+    out["objective"] = getattr(r, "objective", None)
+    out["bound"] = getattr(r, "bound", None)
+    out["gap_certified"] = getattr(r, "gap_certified", None)
+    out["node_count"] = getattr(r, "node_count", None)
+    # Post-fix only: what the attempt actually cost, as the solver itself accounts it.
+    if out["has_last_attempt_seconds"]:
+        out["attempt_seconds"] = float(_convex_kernel.last_attempt_seconds())
+    print("RESULT " + json.dumps(out), flush=True)
+    return 0
+
+
+def _census(files: list[Path] | None = None) -> int:
+    """Print, for every corpus instance, whether build_convex_spec accepts it."""
+    os.environ.setdefault("JAX_PLATFORMS", "cpu")
+    os.environ.setdefault("JAX_ENABLE_X64", "1")
+    os.environ["DISCOPT_CONVEX_KERNEL"] = "1"
+    from discopt.modeling.core import from_nl  # noqa: PLC0415
+    from discopt.solvers._convex_kernel import build_convex_spec  # noqa: PLC0415
+
+    eligible: list[str] = []
+    examined = 0
+    for f in files if files is not None else _corpus_files():
+        examined += 1
+        t0 = time.perf_counter()
+        try:
+            spec = build_convex_spec(from_nl(str(f)))
+        except Exception as exc:  # noqa: BLE001 - reported, never swallowed silently
+            print(f"{f.stem:24s} ERROR {type(exc).__name__}: {exc}", flush=True)
+            continue
+        dt = time.perf_counter() - t0
+        if spec is not None:
+            eligible.append(f.stem)
+            print(f"{f.stem:24s} ELIGIBLE   spec_build={dt:.2f}s", flush=True)
+        else:
+            print(f"{f.stem:24s} declined   ({dt:.2f}s)", flush=True)
+    print(f"\nCENSUS examined={examined} eligible={len(eligible)}", flush=True)
+    print("ELIGIBLE " + json.dumps(eligible), flush=True)
+    if examined == 0:
+        print("CENSUS measured NOTHING", flush=True)
+        return 1
+    return 0
+
+
+# --------------------------------------------------------------------------- parent
+
+
+def _spawn(nl: Path, flag: str, budget: float) -> dict:
+    cmd = [
+        sys.executable,
+        "-u",
+        str(Path(__file__).resolve()),
+        "--solve",
+        str(nl),
+        flag,
+        str(budget),
+    ]
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        cmd, capture_output=True, text=True, timeout=budget + _CHILD_SLACK, check=False
+    )
+    outer = time.perf_counter() - t0
+    rec: dict = {
+        "instance": nl.stem,
+        "flag": flag,
+        "budget": budget,
+        "outer_wall": outer,
+        "rc": proc.returncode,
+    }
+    for line in proc.stdout.splitlines():
+        if line.startswith("RESULT "):
+            rec.update(json.loads(line[len("RESULT ") :]))
+    if "wall" not in rec:
+        rec["stderr_tail"] = proc.stderr[-1500:]
+    return rec
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--census", action="store_true")
+    ap.add_argument("--budgets", default="10,45")
+    ap.add_argument("--reps", type=int, default=2)
+    ap.add_argument("--instances", default="", help="comma-separated stems (default: census)")
+    ap.add_argument("--out", default="")
+    ap.add_argument(
+        "--snapshot", action="store_true", help="draw instances from the MINLPLib snapshot"
+    )
+    ap.add_argument("--glob", default="", help="census only snapshot stems matching these globs")
+    ap.add_argument("--solve", nargs=3, metavar=("NL", "FLAG", "BUDGET"))
+    args = ap.parse_args()
+
+    global _CORPUS_DIR
+    if args.snapshot:
+        _CORPUS_DIR = _SNAPSHOT
+
+    if args.solve:
+        return _run_child(args.solve[0], args.solve[1], float(args.solve[2]))
+    if args.census:
+        files = None
+        if args.glob:
+            files = sorted(
+                {f for pat in args.glob.split(",") for f in _CORPUS_DIR.glob(f"{pat.strip()}.nl")}
+            )
+        return _census(files)
+
+    if args.instances:
+        stems = [s.strip() for s in args.instances.split(",") if s.strip()]
+    else:
+        print("--instances is required (run --census first)", flush=True)
+        return 2
+    budgets = [float(b) for b in args.budgets.split(",")]
+
+    try:
+        load1 = os.getloadavg()[0]
+    except OSError:  # pragma: no cover - platform without getloadavg
+        load1 = float("nan")
+    print(f"LOAD at start: {load1:.2f} (1-min)", flush=True)
+
+    records: list[dict] = []
+    # Interleaved: OFF/ON adjacent within a rep, so a drift in machine load hits both
+    # arms alike (CLAUDE.md §9).
+    for rep in range(args.reps):
+        for budget in budgets:
+            for stem in stems:
+                nl = _CORPUS_DIR / f"{stem}.nl"
+                if not nl.exists():
+                    print(f"{stem}: MISSING {nl}", flush=True)
+                    continue
+                for flag in ("0", "1"):
+                    rec = _spawn(nl, flag, budget)
+                    rec["rep"] = rep
+                    records.append(rec)
+                    print(
+                        f"rep{rep} b={budget:g} {stem:22s} flag={flag} "
+                        f"wall={rec.get('wall', float('nan')):.2f} "
+                        f"status={rec.get('status')} "
+                        f"kernel_enabled={rec.get('kernel_enabled')}",
+                        flush=True,
+                    )
+
+    # ---- correctness ----------------------------------------------------------
+    # This fix only ever SHORTENS a budget, so it cannot make a result unsound -- but
+    # "cannot" is a claim, and CLAUDE.md §1 wants it checked rather than asserted.
+    oracle = _oracle()
+    checked = incorrect = 0
+    for r in records:
+        opt = oracle.get(r["instance"])
+        if opt is None or r.get("objective") is None:
+            continue
+        checked += 1
+        obj, bound = r["objective"], r.get("bound")
+        tol = 1e-2 * max(1.0, abs(opt))
+        # A CERTIFIED optimum must match the oracle; any dual bound must not sit on
+        # the wrong side of it. Sense is read off the reported bound/incumbent pair.
+        bad_obj = bool(r.get("gap_certified")) and abs(obj - opt) > tol
+        bad_bound = False
+        if bound is not None:
+            btol = 1e-4 * max(1.0, abs(opt))
+            bad_bound = (bound > opt + btol) if bound <= obj + tol else (bound < opt - btol)
+        if bad_obj or bad_bound:
+            incorrect += 1
+            print(
+                f"INCORRECT {r['instance']} flag={r['flag']} b={r['budget']:g} "
+                f"obj={obj} bound={bound} opt={opt} certified={r.get('gap_certified')}",
+                flush=True,
+            )
+    print(f"\nORACLE CHECK: checked={checked} incorrect={incorrect}", flush=True)
+
+    # ---- analysis -------------------------------------------------------------
+    comparisons = 0
+    hazards = 0
+    print("\n" + "=" * 92, flush=True)
+    print(
+        f"{'instance':22s} {'budget':>7s} {'OFF wall':>10s} {'ON wall':>10s} "
+        f"{'excess':>9s} {'over-budget':>12s}",
+        flush=True,
+    )
+    for budget in budgets:
+        for stem in stems:
+            off = [
+                r["wall"]
+                for r in records
+                if r["instance"] == stem
+                and r["flag"] == "0"
+                and r["budget"] == budget
+                and "wall" in r
+            ]
+            on = [
+                r["wall"]
+                for r in records
+                if r["instance"] == stem
+                and r["flag"] == "1"
+                and r["budget"] == budget
+                and "wall" in r
+            ]
+            if not off or not on:
+                continue
+            comparisons += 1
+            mo, mn = statistics.median(off), statistics.median(on)
+            sdo = statistics.stdev(off) if len(off) > 1 else float("nan")
+            sdn = statistics.stdev(on) if len(on) > 1 else float("nan")
+            excess = mn - mo
+            over = mn - budget
+            hazard = excess > 5.0 and over > 5.0
+            hazards += int(hazard)
+            print(
+                f"{stem:22s} {budget:7g} {mo:7.2f}±{sdo:4.2f} {mn:7.2f}±{sdn:4.2f} "
+                f"{excess:+9.2f} {over:+12.2f} {'HAZARD' if hazard else ''}",
+                flush=True,
+            )
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(records, indent=2))
+        print(f"\nwrote {args.out}", flush=True)
+
+    # CLAUDE.md §6: a probe that compared nothing is a failure, not a pass.
+    print(f"\nEXECUTED COMPARISONS: {comparisons}", flush=True)
+    if comparisons == 0:
+        print("VERDICT: measured NOTHING -- probe did not fire", flush=True)
+        return 1
+    if incorrect:
+        print(f"VERDICT: {incorrect} INCORRECT results -- hard gate failed", flush=True)
+        return 1
+    print(
+        f"VERDICT: {'HAZARD CONFIRMED' if hazards else 'hazard NOT reproduced'} "
+        f"({hazards}/{comparisons} instance-budget cells)",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -4162,11 +4162,37 @@ class Model:
         # model (#779); it returns None — falling through to the default path
         # below, untouched — for the flag-off case, any non-convex model, or an
         # unverifiable incumbent. Wrapped so a kernel error can never break solve.
+        #
+        # #911: a DECLINED attempt is no longer free. ``_ck_elapsed`` is the wall the
+        # attempt actually spent (spec build and the #779 feasibility verification
+        # included) and it is deducted from the budget handed to the default path
+        # below, so ``solve(time_limit=T)`` can no longer run for ~2T because a
+        # convex-eligible model failed to certify. Measured before the fix (medians,
+        # interleaved arms, 2 replicates): ``clay0304hfsg`` at a 10 s budget ran
+        # 22.01 s against an OFF arm of 10.55 s, and at a 30 s budget 269.17 s
+        # against 31.13 s. After: 12.94 s and 37.06 s.
+        #
+        # ``last_attempt_seconds()`` is EXACTLY 0.0 whenever DISCOPT_CONVEX_KERNEL is
+        # off (it is reset on entry and the clock starts after the flag check), so the
+        # default path subtracts a literal zero and every deadline below is unchanged.
+        _ck_elapsed = 0.0
         if not skip_convex_check:
+            _ck_res = None
             try:
-                from discopt.solvers._convex_kernel import try_convex_solve
+                from discopt.solvers._convex_kernel import (
+                    last_attempt_seconds,
+                    try_convex_solve,
+                )
 
-                _ck_res = try_convex_solve(self, time_limit=time_limit, gap_tolerance=gap_tolerance)
+                try:
+                    _ck_res = try_convex_solve(
+                        self, time_limit=time_limit, gap_tolerance=gap_tolerance
+                    )
+                finally:
+                    # In the ``finally`` so an attempt that raised part-way through
+                    # still has its consumed wall deducted -- the caller paid for it
+                    # either way.
+                    _ck_elapsed = last_attempt_seconds()
             except Exception:
                 _ck_res = None
             if _ck_res is not None:
@@ -4248,6 +4274,14 @@ class Model:
         # 0.3 s of a 40 s budget -- so they finish long before the reduced primary
         # budget binds, while the instances this targets (tln4/tln5) burn 100% of the
         # budget and still return nothing. Out-of-scope models keep the full budget.
+        #
+        # #911: everything from here on splits what is LEFT of the caller's budget
+        # after the convex-kernel attempt, not the budget as stated. The reserve is a
+        # fraction of the remainder for the same reason the primary is: 35% of a
+        # budget that has already been spent is not available to reserve. Flag-off
+        # gives ``_ck_elapsed == 0.0`` exactly, so ``_remaining_tl is time_limit``
+        # numerically and both figures below are unchanged.
+        _remaining_tl = max(0.0, time_limit - _ck_elapsed)
         _fb_reserve = 0.0
         if (
             _lp_spatial_fallback_enabled()
@@ -4270,7 +4304,7 @@ class Model:
                 # separate, panel-gated decision — hence the flag rather than the
                 # engine's own (already widened) gate.
                 if _is_in_scope(self, mixed=_lp_spatial_mixed_fallback_enabled()):
-                    _fb_reserve = 0.35 * time_limit
+                    _fb_reserve = 0.35 * _remaining_tl
                     # NOTE: scope is checked here, but whether the engine can actually
                     # build its incremental structure is only known once it runs (see
                     # ``require_incremental`` below). A model that is in scope yet
@@ -4281,7 +4315,11 @@ class Model:
                     # large factorable models, so the cheaper mistake is this one.
             except Exception:
                 _fb_reserve = 0.0
-        _primary_tl = time_limit - _fb_reserve
+        # ``max(0.0, ...)``: an attempt that consumed the whole budget leaves nothing,
+        # and ``solve_model`` handles a spent budget through its existing deadline
+        # short-circuit (a rigorous root-relaxation bound, never a certified claim)
+        # rather than by running an unbounded search.
+        _primary_tl = max(0.0, _remaining_tl - _fb_reserve)
 
         try:
             with deadline_scope(_primary_tl):

--- a/python/discopt/solvers/_convex_kernel.py
+++ b/python/discopt/solvers/_convex_kernel.py
@@ -85,6 +85,8 @@ value in ``python/tests/data/known_optima.toml``.
 from __future__ import annotations
 
 import os
+import threading
+import time
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -687,6 +689,35 @@ def solve_convex_tree(spec: dict, *, time_limit_s: Optional[float] = None, **cfg
     return result
 
 
+# Wall spent on the LAST convex-kernel attempt on this thread, whether or not the
+# attempt was adopted (#911). ``Model.solve`` deducts it from the budget it hands the
+# default path, so a DECLINED attempt can no longer make a ``time_limit=T`` solve run
+# for ~2T. Thread-local because ``Model.solve`` may run concurrently on several
+# threads and a process-global counter would let one solve deduct another's attempt.
+class _AttemptClock(threading.local):
+    def __init__(self) -> None:
+        self.seconds = 0.0
+
+
+_ATTEMPT = _AttemptClock()
+
+
+def last_attempt_seconds() -> float:
+    """Wall of the last convex-kernel attempt on this thread, in seconds.
+
+    **Exactly 0.0 when the flag is off**, which is load-bearing rather than cosmetic:
+    ``Model.solve`` subtracts this from the budget it passes to ``solve_model``, so a
+    nonzero reading on the default path would perturb every deadline-sensitive
+    decision in the solver. :func:`try_convex_solve` therefore resets it to 0.0 on
+    entry and starts the clock only *after* the flag check, so a flag-off solve
+    subtracts a literal zero and stays bit-identical.
+
+    A thread that has never run an attempt reads 0.0: ``threading.local`` re-runs a
+    subclass's ``__init__`` the first time the object is touched on each thread.
+    """
+    return float(_ATTEMPT.seconds)
+
+
 def try_convex_solve(
     model, *, time_limit: float = 3600.0, gap_tolerance: float = 1e-4
 ) -> Optional[SolveResult]:
@@ -698,19 +729,66 @@ def try_convex_solve(
     the incumbent is verified feasible against the pristine model (#779). Everything
     else — flag off, non-convex, not-certified-within-budget, no incumbent, or an
     unverifiable incumbent — returns ``None`` so the caller keeps the (always-correct)
-    default path with its full time budget. This bounds the kernel's cost on large
-    instances it cannot finish (tracked separately for SCIP-parity) and never
-    reports an unsound or uncertified result. Proven-infeasible roots are surfaced.
+    default path. Proven-infeasible roots are surfaced. Never reports an unsound or
+    uncertified result.
+
+    **Budget accounting (#911).** The attempt is bounded, but until this was fixed it
+    was *additive*: ``Model.solve`` afterwards called ``solve_model`` with the
+    caller's FULL ``time_limit``, so an eligible-but-uncertifiable model paid the
+    attempt on top of its whole default budget. Measured OFF-vs-ON, interleaved, 2
+    replicates (``issue911_convex_kernel_budget_entry.py``), medians:
+
+    ==================  ======  ==========  ==========  =========
+    instance            budget  OFF wall    ON before   ON after
+    ==================  ======  ==========  ==========  =========
+    clay0304hfsg          10 s   10.55 s     22.01 s     12.94 s
+    clay0305hfsg          10 s   11.89 s     23.88 s     12.89 s
+    clay0305hfsg          30 s   31.35 s     63.33 s     33.19 s
+    clay0304hfsg          30 s   31.13 s    269.17 s     37.06 s
+    ==================  ======  ==========  ==========  =========
+
+    :func:`last_attempt_seconds` publishes the attempt wall and ``Model.solve``
+    subtracts it. The spec build is inside the clock deliberately: it is the
+    convexity classification, and on the instances this hazard bites it is itself
+    ~1 s of wall. The ``clay0304hfsg`` 30 s cell needed a second fix as well — the
+    native tree polled its own deadline only *between* nodes (see
+    ``ConvexKernelSpec::solve_node_cut_until``); deduction alone would have moved it
+    from 269 s to ~237 s, still 7.9x the stated limit.
+
+    Every instance the kernel *certifies* is bit-unchanged by this: same objective and
+    same node count on all four certifying cells of the panel.
+
+    **Why the attempt is NOT capped to a fraction of the budget** (the first design,
+    falsified before it was built): the kernel needs the large majority of a tight
+    budget on exactly the instances where it wins. Measured here, ``clay0303hfsg``
+    certifies in ~8 s and turns a 10 s OFF-arm ``time_limit`` (no incumbent) into a
+    certified optimum; any fractional cap below ~0.8 of the budget gives that back.
+    The fraction was dropped rather than shipped as a dead knob.
     """
+    _ATTEMPT.seconds = 0.0
+    if not convex_kernel_enabled():
+        return None
+    # Clock starts HERE, after the flag check, so a flag-off solve reads exactly 0.0
+    # (see ``last_attempt_seconds``). The ``finally`` covers EVERY exit — including
+    # the decline paths below and an exception mid-attempt, which still consumed
+    # wall the caller has to pay for.
+    _attempt_t0 = time.perf_counter()
+    try:
+        return _attempt_convex_solve(model, time_limit=time_limit, gap_tolerance=gap_tolerance)
+    finally:
+        _ATTEMPT.seconds = time.perf_counter() - _attempt_t0
+
+
+def _attempt_convex_solve(
+    model, *, time_limit: float, gap_tolerance: float
+) -> Optional[SolveResult]:
+    """The attempt itself; :func:`try_convex_solve` wraps it to clock every exit."""
     import os
-    import time
 
     import numpy as np
 
     from discopt.modeling.core import SolveResult
 
-    if not convex_kernel_enabled():
-        return None
     spec = build_convex_spec(model)
     if spec is None:
         return None
@@ -731,8 +809,8 @@ def try_convex_solve(
     if r["status"] == "infeasible":
         return SolveResult(status="infeasible", bound=r["bound"], wall_time=wall, nlp_bb=False)
     # Use the kernel result ONLY when it CERTIFIED optimality within budget; any
-    # limit / feasible-only / no-incumbent outcome defers to the default path,
-    # which then gets the caller's full time budget.
+    # limit / feasible-only / no-incumbent outcome defers to the default path, which
+    # then gets the caller's budget MINUS what this attempt just spent (#911).
     if r["status"] != "optimal" or incumbent is None or inc_x.size == 0:
         return None
     status = "optimal"

--- a/python/tests/test_issue911_convex_kernel_budget.py
+++ b/python/tests/test_issue911_convex_kernel_budget.py
@@ -49,7 +49,20 @@ def _box_model():
     return m
 
 
-def _patched_solve(monkeypatch, *, kernel_on: bool, attempt_s: float):
+def _reserve_model():
+    """A model the #844 LP-spatial fallback is IN SCOPE for (pure-integer, minimize,
+    with an integer product), so ``Model.solve`` carves out its 35% reserve. #911
+    changed that reserve from 35% of the stated limit to 35% of what remains after
+    the kernel attempt; this model is how that path gets exercised."""
+    m = dm.Model()
+    x = m.integer("x", lb=0, ub=5)
+    y = m.integer("y", lb=0, ub=5)
+    m.constraint(dm.RangeSet(1), lambda _i: x * y >= 4.0, name="prod", fast=False)
+    m.minimize(x + y)
+    return m
+
+
+def _patched_solve(monkeypatch, *, kernel_on: bool, attempt_s: float, model_fn=None):
     """Solve ``_box_model()`` with a declining attempt of ``attempt_s`` seconds and
     return ``(time_limit the default path was handed, number of attempts made)``."""
     monkeypatch.setenv("DISCOPT_CONVEX_KERNEL", "1" if kernel_on else "0")
@@ -78,7 +91,7 @@ def _patched_solve(monkeypatch, *, kernel_on: bool, attempt_s: float):
 
     monkeypatch.setattr(_solver, "solve_model", _fake_solve_model)
 
-    _box_model().solve(time_limit=_TIME_LIMIT)
+    (model_fn or _box_model)().solve(time_limit=_TIME_LIMIT)
 
     # CLAUDE.md §6: a probe that never fired must not read as a pass.
     assert calls["solve_model"] == 1, "the default path was never reached"
@@ -113,6 +126,26 @@ def test_flag_off_deducts_exactly_zero(monkeypatch):
     assert _ck.last_attempt_seconds() == 0.0, (
         f"flag-off attempt clock is not literally 0.0: {_ck.last_attempt_seconds()!r}"
     )
+
+
+def test_flag_off_is_exact_on_the_fallback_reserve_path_too(monkeypatch):
+    """The #844 reserve now takes 35% of the REMAINING budget, not of the stated
+    limit. With the flag off the remainder IS the stated limit, so the primary budget
+    must come out bit-identical to the pre-#911 ``time_limit - 0.35*time_limit``."""
+    from discopt._jax.lp_spatial_bb import _is_in_scope
+    from discopt.modeling.core import _lp_spatial_fallback_enabled
+
+    # Non-vacuity: if the reserve is not actually carved out here, this test would
+    # silently be re-checking the box-only path (CLAUDE.md §6).
+    if not _lp_spatial_fallback_enabled() or not _is_in_scope(_reserve_model()):
+        pytest.skip("the #844 reserve does not apply to this model -- nothing to pin")
+
+    forwarded, attempts = _patched_solve(
+        monkeypatch, kernel_on=False, attempt_s=0.0, model_fn=_reserve_model
+    )
+    assert attempts == 0
+    expected = _TIME_LIMIT - 0.35 * _TIME_LIMIT
+    assert forwarded == expected, f"reserve arithmetic drifted: {forwarded!r} != {expected!r}"
 
 
 def test_attempt_clock_is_zero_before_any_attempt():

--- a/python/tests/test_issue911_convex_kernel_budget.py
+++ b/python/tests/test_issue911_convex_kernel_budget.py
@@ -1,0 +1,175 @@
+"""Issue #911 — a DECLINED convex-kernel attempt must be deducted from the budget.
+
+``Model.solve`` hands the convex kernel ``min(time_limit,
+DISCOPT_CONVEX_KERNEL_BUDGET)`` seconds, adopts the result ONLY when it certifies
+optimality, and then runs the default path. Before this fix the default path was
+handed the caller's **full** ``time_limit`` again, so an eligible-but-uncertifiable
+model paid the attempt on top of its whole budget: ``solve(time_limit=T)`` ran for
+~2T. Measured on ``clay0303hfsg`` at a 10 s budget, the replicate whose attempt did
+not certify ran **22.35 s** against an OFF arm of 10.88 s.
+
+The tests below pin, in order of what actually protects the contract:
+
+1. **the arithmetic** — a declined attempt of a known duration is subtracted from the
+   budget the default path receives (deterministic; no wall-clock threshold);
+2. **flag-off exactness** — with ``DISCOPT_CONVEX_KERNEL`` off the deduction is
+   *literally* ``0.0`` and the forwarded budget is bit-identical, so the default path
+   is untouched. This is asserted rather than assumed: a nonzero reading here would
+   perturb every deadline-sensitive decision in the solver;
+3. **end to end** — a real eligible instance under a budget the kernel provably
+   cannot meet stays inside its stated limit, and the test refuses to pass vacuously
+   (it asserts the attempt really ran and really declined).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import discopt.modeling as dm
+import pytest
+
+_ck = pytest.importorskip("discopt.solvers._convex_kernel")
+
+_DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
+
+# Long enough to dwarf the sub-millisecond noise of the surrounding bookkeeping, short
+# enough to keep the deterministic tests fast.
+_FAKE_ATTEMPT_S = 0.75
+_TIME_LIMIT = 20.0
+
+
+def _box_model():
+    """A model with no constraints: the #844 fallback reserve and the #772
+    verification snapshot both key off ``self._constraints``, so a box-only model
+    isolates the budget arithmetic under test from both."""
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    m.minimize(x)
+    return m
+
+
+def _patched_solve(monkeypatch, *, kernel_on: bool, attempt_s: float):
+    """Solve ``_box_model()`` with a declining attempt of ``attempt_s`` seconds and
+    return ``(time_limit the default path was handed, number of attempts made)``."""
+    monkeypatch.setenv("DISCOPT_CONVEX_KERNEL", "1" if kernel_on else "0")
+
+    calls = {"spec": 0, "solve_model": 0}
+
+    def _slow_decline(model):
+        # Stands in for a real ``build_convex_spec`` + kernel run that burns the
+        # budget and then declines. Declining through ``build_convex_spec`` exercises
+        # the real ``try_convex_solve`` clock rather than a stubbed one.
+        calls["spec"] += 1
+        time.sleep(attempt_s)
+        return None
+
+    monkeypatch.setattr(_ck, "build_convex_spec", _slow_decline)
+
+    import discopt.solver as _solver
+    from discopt.modeling.core import SolveResult
+
+    seen: dict[str, float] = {}
+
+    def _fake_solve_model(model, **kw):
+        calls["solve_model"] += 1
+        seen["time_limit"] = kw["time_limit"]
+        return SolveResult(status="optimal", objective=0.0, bound=0.0, gap=0.0)
+
+    monkeypatch.setattr(_solver, "solve_model", _fake_solve_model)
+
+    _box_model().solve(time_limit=_TIME_LIMIT)
+
+    # CLAUDE.md §6: a probe that never fired must not read as a pass.
+    assert calls["solve_model"] == 1, "the default path was never reached"
+    assert calls["spec"] == (1 if kernel_on else 0), (
+        f"expected {'an' if kernel_on else 'no'} attempt, got {calls['spec']}"
+    )
+    return seen["time_limit"], calls["spec"]
+
+
+def test_declined_attempt_is_deducted_from_the_default_path_budget(monkeypatch):
+    """The wall a declined attempt spent is gone from the caller's budget."""
+    forwarded, attempts = _patched_solve(monkeypatch, kernel_on=True, attempt_s=_FAKE_ATTEMPT_S)
+    assert attempts == 1
+    # Deducted, and not over-deducted: the attempt slept at least _FAKE_ATTEMPT_S, so
+    # the forwarded budget sits just below ``time_limit - _FAKE_ATTEMPT_S``.
+    assert forwarded <= _TIME_LIMIT - _FAKE_ATTEMPT_S, (
+        f"attempt of {_FAKE_ATTEMPT_S}s not deducted: default path got {forwarded}s "
+        f"of a {_TIME_LIMIT}s budget"
+    )
+    assert forwarded > _TIME_LIMIT - _FAKE_ATTEMPT_S - 1.0, (
+        f"over-deducted: default path got {forwarded}s"
+    )
+
+
+def test_flag_off_deducts_exactly_zero(monkeypatch):
+    """Flag-off must forward the caller's budget bit-identically."""
+    forwarded, attempts = _patched_solve(monkeypatch, kernel_on=False, attempt_s=_FAKE_ATTEMPT_S)
+    assert attempts == 0, "no attempt may be made with the flag off"
+    # Exact equality, deliberately: `==`, not `approx`. The deduction is subtracted
+    # from every downstream deadline, so "close to zero" is not the contract.
+    assert forwarded == _TIME_LIMIT, f"flag-off budget drifted: {forwarded!r} != {_TIME_LIMIT!r}"
+    assert _ck.last_attempt_seconds() == 0.0, (
+        f"flag-off attempt clock is not literally 0.0: {_ck.last_attempt_seconds()!r}"
+    )
+
+
+def test_attempt_clock_is_zero_before_any_attempt():
+    """A thread that has never run an attempt reads 0.0, not garbage."""
+    import threading
+
+    seen: list[float] = []
+    t = threading.Thread(target=lambda: seen.append(_ck.last_attempt_seconds()))
+    t.start()
+    t.join()
+    assert seen == [0.0]
+
+
+@pytest.mark.slow
+def test_real_instance_does_not_pay_a_second_full_budget(monkeypatch):
+    """End to end on a real eligible instance under a budget the kernel cannot meet.
+
+    ``clay0303hfsg`` is convex-kernel eligible and needs ~8 s to certify on this
+    corpus, so a 6 s budget makes the attempt decline. The assertion is the contract
+    this fix delivers -- *the default path does not get a second full budget* -- not
+    ``wall <= time_limit``: the attempt has its own granularity (the kernel polls its
+    deadline between LP re-solves, so it can overshoot by one re-solve), and folding
+    that into the threshold would make this test measure the LP layer instead.
+
+    Pre-fix the wall was ``attempt + budget + overhead``; post-fix it is
+    ``attempt + overhead``.
+    """
+    from discopt.modeling.core import from_nl
+
+    nl = os.path.join(_DATA, "clay0303hfsg.nl")
+    if not os.path.exists(nl):  # pragma: no cover - corpus always present in-repo
+        pytest.skip(f"missing corpus instance {nl}")
+    monkeypatch.setenv("DISCOPT_CONVEX_KERNEL", "1")
+    budget = 6.0
+
+    # Non-vacuity guard, checked FIRST: the attempt must really run and really
+    # decline at this budget, else the timing assertion below means nothing. A
+    # skip (not a pass) if it does not, so a vacuous run is visible in the report.
+    if _ck.try_convex_solve(from_nl(nl), time_limit=budget) is not None:
+        pytest.skip("kernel certified within the budget -- no declined attempt to test")
+    probe_attempt = _ck.last_attempt_seconds()
+    assert probe_attempt > 0.5 * budget, (
+        f"attempt consumed only {probe_attempt:.2f}s of a {budget}s budget -- it did "
+        f"not spend the budget, so this instance no longer exercises the hazard"
+    )
+
+    t0 = time.perf_counter()
+    from_nl(nl).solve(time_limit=budget)
+    wall = time.perf_counter() - t0
+    attempt = _ck.last_attempt_seconds()
+    assert attempt > 0.5 * budget, "the timed solve did not make a real attempt"
+
+    # 0.8, not 1.0: pre-fix the default path got the WHOLE budget on top of the
+    # attempt, so anything at or above `attempt + budget` is the old behaviour and
+    # the margin below it absorbs presolve/teardown overhead.
+    assert wall < attempt + 0.8 * budget, (
+        f"solve(time_limit={budget}) ran {wall:.2f}s with a {attempt:.2f}s convex-"
+        f"kernel attempt -- the default path was handed a second full budget "
+        f"instead of the {budget - attempt:.2f}s that remained"
+    )


### PR DESCRIPTION
fix(solver): #911 a declined convex-kernel attempt is deducted from the budget

`Model.solve` handed the convex kernel `min(time_limit,
DISCOPT_CONVEX_KERNEL_BUDGET)` seconds, adopted the result only when it certified
optimality, and then called `solve_model` with the caller's FULL `time_limit`
again. The attempt was never deducted, so an eligible-but-uncertifiable model paid
the attempt on top of its whole default budget.

ENTRY EXPERIMENT (issue911_convex_kernel_budget_entry.py; eligibility MEASURED via
build_convex_spec, arms interleaved, subprocess-isolated, 2 replicates, medians):
the hazard reproduced on 4 of 12 instance-budget cells. Only 3 of the 66 in-repo
instances are kernel-eligible and all three certify quickly, so the DECLINE half of
the class was drawn from the MINLPLib snapshot.

ATTRIBUTION (issue911_attempt_phase_probe.py): the `clay0304hfsg` 30 s cell was
269 s, far more than the ~2x the missing deduction explains. Timing the attempt by
phase showed `solve_convex_tree`, handed `time_limit_s = 30`, ran 236.24 s over 93
nodes -- the native tree polled its deadline only BETWEEN nodes, and one node's
OA/separation loop (up to `max_oa_rounds*(max_sep_rounds+1)+...` LP re-solves) has
nothing to stop it. Deduction alone would have left that cell at ~237 s.

FIX, two parts, same contract:

1. `_convex_kernel.last_attempt_seconds()` publishes the attempt wall (spec build
   and the #779 verification included) and `Model.solve` subtracts it. The
   subtraction happens in a `finally`, so an attempt that raises part-way still has
   its consumed wall deducted. The #844 fallback reserve is now 35% of what REMAINS
   rather than 35% of the stated limit, for the same reason.
2. `ConvexKernelSpec::solve_node_cut_until` / `solve_node_until` take the tree's
   deadline and stop the node's OA/separation loop between re-solves. Stopping is a
   REFUSAL, not an approximation -- the same argument that already makes
   `appended_row_cap` sound: the node LP is a relaxation for any subset of tangents,
   so a stopped node returns a valid, merely WEAKER dual bound, and a vertex reached
   without OA convergence still violates a nonlinear row, so `is_integer_feasible`
   cannot mistake it for an incumbent. A weaker node bound can only make the tree's
   gap check harder, so this cannot manufacture a certificate.

MEASURED, OFF vs ON, interleaved, 2 reps, medians (OFF arm is unaffected -- with
the flag off the kernel never runs -- and reproduced its BEFORE numbers to within
0.5 s, which is the machine-state control):

  instance       budget   OFF wall   ON before   ON after
  clay0304hfsg     10 s    11.01 s     22.01 s    13.11 s
  clay0305hfsg     10 s    10.58 s     23.88 s    12.90 s
  clay0305hfsg     30 s    30.68 s     63.33 s    33.13 s
  clay0304hfsg     30 s    31.19 s    269.17 s    33.09 s

Hazard cells 4/12 -> 0/12; the panel's own kill criterion reports "hazard NOT
reproduced". Oracle check: 30 results against minlplib.solu, 0 incorrect, on both
panels.

NOT REGRESSED. Every instance the kernel certifies is bit-unchanged: all 16
certifying ON-arm cells carry the identical objective AND identical node count as
before the change (clay0203hfsg 117, clay0303hfsg 141, cvxnonsep_normcon40r 77,
syn05hfsg 2), and no status changed anywhere on the ON arm. Flag-off deducts a literal `0.0`, asserted
with `==` rather than assumed.

NO RESIDUAL, after a retraction. This PR first shipped a 1.26x residual on
`clay0304hfsg`@30 (37.8 s), described as needing "a deadline inside the simplex
iteration loop, a separate change in the LP layer". That was wrong.
`SimplexOptions` has had a `deadline` field all along, polled every few hundred
pivots by the primal and dual loops; `solve_convex_tree_py` set `config.deadline`
but built its `SimplexOptions` with `..Default::default()`, so the kernel never
passed down the deadline it already had. One line. The tree now lands on its limit
at every budget -- clay0304hfsg 10 s -> 10.01 s, 30 s -> 30.00 s, 60 s -> 60.01 s
-- with node count unchanged at 93, so the bail truncates the in-flight LP rather
than altering the search. No follow-up issue is needed.

FALSIFIED, and NOT shipped: capping the attempt at a fraction of the budget. The
kernel needs the large majority of a tight budget on exactly the instances where it
wins -- `clay0303hfsg` certifies in ~8 s and turns a 10 s OFF-arm `time_limit` with
no incumbent into a certified 26669.1096 -- so any fractional cap below ~0.8 gives
that back. Dropped rather than shipped as a dead knob.

TESTS
- python/tests/test_issue911_convex_kernel_budget.py (new): the budget arithmetic
  (deterministic, no wall-clock threshold), flag-off exactness (`==`), a fresh
  thread reading 0.0, and an end-to-end check that the default path does not get a
  second full budget. All fail before this change and pass after.
- convex_kernel.rs: `node_oa_loop_stops_at_a_deadline_without_tightening_the_bound`
  (past deadline -> exactly one round, bound still >= truth and never tighter than
  the converged one, with a non-vacuity assert that the converged solve really took
  more rounds) and `no_deadline_is_bit_identical_to_the_uninstrumented_node`
  (bit-for-bit on `bound`/`raw_bound`/`oa_rounds`/`n_tangents`).

RUN: `pytest -m smoke` 904 passed, 1 skipped, 2 xpassed; `pytest -m slow
python/tests/test_adversarial_recent_fixes.py` 10 passed; `cargo test -p
discopt-core` 577+4+1 passed; convex-kernel-adjacent selection 78 passed, 1
skipped; ruff / ruff format / mypy / cargo fmt all passed via pre-commit.

THE ISSUE'S TWO OTHER OVERRUN OBSERVATIONS DO NOT REPRODUCE and need no follow-up.
#911 filed `heatexch_gen3` at 233 s under `time_limit=45` (5.2x) and `contvar` over
400 s. Re-measured on this tree: heatexch_gen3 46.7 s (1.0x, `time_limit`) and
contvar 47.2 s (1.0x, `feasible`). Neither is convex-kernel eligible
(`build_convex_spec` declines both), so neither was ever this code path; intervening
work closed them. Recording the retraction rather than filing a stale follow-up.

Closes #911

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BWf4gy9kxqZBRbFkQWhd
